### PR TITLE
Allow overflow in sum(bigint) Spark aggregate function

### DIFF
--- a/velox/docs/functions/spark/aggregate.rst
+++ b/velox/docs/functions/spark/aggregate.rst
@@ -69,16 +69,59 @@ General Aggregate Functions
 
     Returns the last non-null value of `x`.
 
-.. spark:function:: max_by(x, y) -> x
+.. spark:function:: max_by(x, y) -> [same as x]
 
     Returns the value of `x` associated with the maximum value of `y`.
     Note: Spark provides a non-strictly comparator which is greater than or equals to.
-    Eg. SELECT max_by(x, y) FROM VALUES (('a', 10)), (('b', 50)), (('c', 50)) AS tab(x, y);
-        > c
 
-.. spark:function:: min_by(x, y) -> x
+    Example::
+
+        SELECT max_by(x, y)
+        FROM (
+            VALUES
+                ('a', 10),
+                ('b', 50),
+                ('c', 50)
+        ) AS t(x, y);
+
+    Returns c
+
+.. spark:function:: min_by(x, y) -> [same as x]
 
     Returns the value of `x` associated with the minimum value of `y`.
     Note: Spark provides a non-strictly comparator which is less than or equals to.
-    Eg. SELECT min_by(x, y) FROM VALUES (('a', 10)), (('b', 10)), (('c', 50)) AS tab(x, y);
-        > b
+
+    Example::
+
+        SELECT min_by(x, y)
+        FROM (
+            VALUES
+                ('a', 10),
+                ('b', 10),
+                ('c', 50)
+        ) AS t(x, y);
+
+    Returns b
+
+.. spark:function:: sum(x) -> bigint|double|real
+
+    Returns the sum of `x`.
+
+    Supported types are TINYINT, SMALLINT, INTEGER, BIGINT, REAL and DOUBLE.
+
+    When x is of type DOUBLE, the result type is DOUBLE.
+    When x is of type REAL, the result type is REAL.
+    For all other input types, the result type is BIGINT.
+
+    Note: When the sum of BIGINT values exceeds its limit, it cycles to the overflowed value rather than raising an error.
+
+    Example::
+
+        SELECT SUM(x)
+        FROM (
+            VALUES
+                (9223372036854775807L),
+                (1L)
+        ) AS t(x);
+
+    Returns -9223372036854775808

--- a/velox/functions/lib/aggregates/SumAggregateBase.h
+++ b/velox/functions/lib/aggregates/SumAggregateBase.h
@@ -26,7 +26,7 @@ template <
     typename TInput,
     typename TAccumulator,
     typename ResultType,
-    bool Overflow = false>
+    bool Overflow>
 class SumAggregateBase
     : public SimpleNumericAggregate<TInput, TAccumulator, ResultType> {
   using BaseAggregate =

--- a/velox/functions/lib/aggregates/SumAggregateBase.h
+++ b/velox/functions/lib/aggregates/SumAggregateBase.h
@@ -22,7 +22,11 @@
 
 namespace facebook::velox::functions::aggregate {
 
-template <typename TInput, typename TAccumulator, typename ResultType>
+template <
+    typename TInput,
+    typename TAccumulator,
+    typename ResultType,
+    bool Overflow = false>
 class SumAggregateBase
     : public SimpleNumericAggregate<TInput, TAccumulator, ResultType> {
   using BaseAggregate =
@@ -150,6 +154,7 @@ class SumAggregateBase
   template <typename TData>
   static void updateSingleValue(TData& result, TData value) {
     if constexpr (
+        (std::is_same_v<TData, int64_t> && Overflow) ||
         std::is_same_v<TData, double> || std::is_same_v<TData, float>) {
       result += value;
     } else {
@@ -160,6 +165,7 @@ class SumAggregateBase
   template <typename TData>
   static void updateDuplicateValues(TData& result, TData value, int n) {
     if constexpr (
+        (std::is_same_v<TData, int64_t> && Overflow) ||
         std::is_same_v<TData, double> || std::is_same_v<TData, float>) {
       result += n * value;
     } else {

--- a/velox/functions/lib/aggregates/tests/SumTestBase.h
+++ b/velox/functions/lib/aggregates/tests/SumTestBase.h
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/AggregationHook.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+
+namespace facebook::velox::functions::aggregate::test {
+
+class SumTestBase : public AggregationTestBase {
+ protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+    allowInputShuffle();
+  }
+
+  template <
+      typename InputType,
+      typename ResultType,
+      typename IntermediateType = ResultType>
+  void testAggregateOverflow(
+      const std::string& function,
+      bool expectOverflow = false,
+      const TypePtr& type = CppToType<InputType>::create());
+};
+
+template <typename ResultType>
+void verifyAggregates(
+    const std::vector<std::pair<core::PlanNodePtr, ResultType>>& aggsToTest,
+    bool expectOverflow) {
+  for (const auto& [agg, expectedResult] : aggsToTest) {
+    if (expectOverflow) {
+      VELOX_ASSERT_THROW(
+          facebook::velox::exec::test::readSingleValue(agg), "overflow");
+    } else {
+      auto result = facebook::velox::exec::test::readSingleValue(agg);
+      if constexpr (std::is_same_v<ResultType, float>) {
+        ASSERT_FLOAT_EQ(
+            result.template value<TypeKind::REAL>(), expectedResult);
+      } else if constexpr (std::is_same_v<ResultType, double>) {
+        ASSERT_FLOAT_EQ(
+            result.template value<TypeKind::DOUBLE>(), expectedResult);
+      } else {
+        ASSERT_EQ(result, expectedResult);
+      }
+    }
+  }
+}
+
+template <typename InputType, typename ResultType, typename IntermediateType>
+#if defined(__has_feature)
+#if __has_feature(__address_sanitizer__)
+__attribute__((no_sanitize("integer")))
+#endif
+#endif
+void SumTestBase::testAggregateOverflow(
+    const std::string& function,
+    bool expectOverflow,
+    const TypePtr& type) {
+  const InputType maxLimit = std::numeric_limits<InputType>::max();
+  const InputType overflow = InputType(1);
+  const InputType zero = InputType(0);
+
+  // Intermediate type size is always >= result type size. Hence, use
+  // intermediate type to calculate the expected output.
+  IntermediateType limitResult = IntermediateType(maxLimit);
+  IntermediateType overflowResult = IntermediateType(overflow);
+
+  // Single max limit value. 0's to induce dummy calculations.
+  auto limitVector =
+      makeRowVector({makeFlatVector<InputType>({maxLimit, zero, zero}, type)});
+
+  // Test code path for single values with possible overflow hit in add.
+  auto overflowFlatVector =
+      makeRowVector({makeFlatVector<InputType>({maxLimit, overflow}, type)});
+  IntermediateType expectedFlatSum = limitResult + overflowResult;
+
+  // Test code path for duplicate values with possible overflow hit in
+  // multiply.
+  auto overflowConstantVector =
+      makeRowVector({makeConstant<InputType>(maxLimit / 3, 4, type)});
+  IntermediateType expectedConstantSum = (limitResult / 3) * 4;
+
+  // Test code path for duplicate values with possible overflow hit in add.
+  auto overflowHybridVector = {limitVector, overflowConstantVector};
+  IntermediateType expectedHybridSum = limitResult + expectedConstantSum;
+
+  // Vector with element pairs of a partial aggregate node, expected result.
+  std::vector<std::pair<core::PlanNodePtr, IntermediateType>> partialAggsToTest;
+  // Partial Aggregation (raw input in - partial result out).
+  partialAggsToTest.push_back(
+      {facebook::velox::exec::test::PlanBuilder()
+           .values({overflowFlatVector})
+           .partialAggregation({}, {fmt::format("{}(c0)", function)})
+           .planNode(),
+       expectedFlatSum});
+  partialAggsToTest.push_back(
+      {facebook::velox::exec::test::PlanBuilder()
+           .values({overflowConstantVector})
+           .partialAggregation({}, {fmt::format("{}(c0)", function)})
+           .planNode(),
+       expectedConstantSum});
+  partialAggsToTest.push_back(
+      {facebook::velox::exec::test::PlanBuilder()
+           .values(overflowHybridVector)
+           .partialAggregation({}, {fmt::format("{}(c0)", function)})
+           .planNode(),
+       expectedHybridSum});
+
+  // Vector with element pairs of a full aggregate node, expected result.
+  std::vector<std::pair<core::PlanNodePtr, ResultType>> aggsToTest;
+  // Single Aggregation (raw input in - final result out).
+  aggsToTest.push_back(
+      {facebook::velox::exec::test::PlanBuilder()
+           .values({overflowFlatVector})
+           .singleAggregation({}, {fmt::format("{}(c0)", function)})
+           .planNode(),
+       expectedFlatSum});
+  aggsToTest.push_back(
+      {facebook::velox::exec::test::PlanBuilder()
+           .values({overflowConstantVector})
+           .singleAggregation({}, {fmt::format("{}(c0)", function)})
+           .planNode(),
+       expectedConstantSum});
+  aggsToTest.push_back(
+      {facebook::velox::exec::test::PlanBuilder()
+           .values(overflowHybridVector)
+           .singleAggregation({}, {fmt::format("{}(c0)", function)})
+           .planNode(),
+       expectedHybridSum});
+  // Final Aggregation (partial result in - final result out):
+  // To make sure that the overflow occurs in the final aggregation step, we
+  // create 2 plan fragments and plugging their partially aggregated
+  // output into a final aggregate plan node. Each of those input fragments
+  // only have a single input value under the max limit which when added in
+  // the final step causes a potential overflow.
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  aggsToTest.push_back(
+      {facebook::velox::exec::test::PlanBuilder(planNodeIdGenerator)
+           .localPartition(
+               {},
+               {facebook::velox::exec::test::PlanBuilder(planNodeIdGenerator)
+                    .values({limitVector})
+                    .partialAggregation({}, {fmt::format("{}(c0)", function)})
+                    .planNode(),
+                facebook::velox::exec::test::PlanBuilder(planNodeIdGenerator)
+                    .values({limitVector})
+                    .partialAggregation({}, {fmt::format("{}(c0)", function)})
+                    .planNode()})
+           .finalAggregation()
+           .planNode(),
+       limitResult + limitResult});
+
+  // Verify all partial aggregates.
+  verifyAggregates<IntermediateType>(partialAggsToTest, expectOverflow);
+  // Verify all aggregates.
+  verifyAggregates<ResultType>(aggsToTest, expectOverflow);
+}
+
+} // namespace facebook::velox::functions::aggregate::test

--- a/velox/functions/prestosql/aggregates/SumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/SumAggregate.cpp
@@ -20,6 +20,8 @@ using namespace facebook::velox::functions::aggregate;
 
 namespace facebook::velox::aggregate::prestosql {
 namespace {
+template <typename TInput, typename TAccumulator, typename ResultType>
+using SumAggregate = SumAggregateBase<TInput, TAccumulator, ResultType, false>;
 
 template <template <typename U, typename V, typename W> class T>
 exec::AggregateRegistrationResult registerSum(const std::string& name) {
@@ -110,7 +112,7 @@ exec::AggregateRegistrationResult registerSum(const std::string& name) {
 } // namespace
 
 void registerSumAggregate(const std::string& prefix) {
-  registerSum<SumAggregateBase>(prefix + kSum);
+  registerSum<SumAggregate>(prefix + kSum);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/tests/SumTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SumTest.cpp
@@ -18,7 +18,7 @@
 #include "velox/exec/AggregationHook.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
-#include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+#include "velox/functions/lib/aggregates/tests/SumTestBase.h"
 
 using facebook::velox::exec::test::PlanBuilder;
 using namespace facebook::velox::exec::test;
@@ -28,152 +28,19 @@ namespace facebook::velox::aggregate::test {
 
 namespace {
 
-class SumTest : public AggregationTestBase {
- protected:
-  void SetUp() override {
-    AggregationTestBase::SetUp();
-    allowInputShuffle();
-  }
-
+class SumTest : public SumTestBase {
+ public:
   template <
       typename InputType,
       typename ResultType,
       typename IntermediateType = ResultType>
   void testAggregateOverflow(
       bool expectOverflow = false,
-      const TypePtr& type = CppToType<InputType>::create());
-};
-
-template <typename ResultType>
-void verifyAggregates(
-    const std::vector<std::pair<core::PlanNodePtr, ResultType>>& aggsToTest,
-    bool expectOverflow) {
-  for (const auto& [agg, expectedResult] : aggsToTest) {
-    if (expectOverflow) {
-      VELOX_ASSERT_THROW(readSingleValue(agg), "overflow");
-    } else {
-      auto result = readSingleValue(agg);
-      if constexpr (std::is_same_v<ResultType, float>) {
-        ASSERT_FLOAT_EQ(
-            result.template value<TypeKind::REAL>(), expectedResult);
-      } else if constexpr (std::is_same_v<ResultType, double>) {
-        ASSERT_FLOAT_EQ(
-            result.template value<TypeKind::DOUBLE>(), expectedResult);
-      } else {
-        ASSERT_EQ(result, expectedResult);
-      }
-    }
+      const TypePtr& type = CppToType<InputType>::create()) {
+    SumTestBase::testAggregateOverflow<InputType, ResultType, IntermediateType>(
+        "sum", expectOverflow, type);
   }
-}
-
-template <typename InputType, typename ResultType, typename IntermediateType>
-#if defined(__has_feature)
-#if __has_feature(__address_sanitizer__)
-__attribute__((no_sanitize("integer")))
-#endif
-#endif
-void SumTest::testAggregateOverflow(
-    bool expectOverflow,
-    const TypePtr& type) {
-  const InputType maxLimit = std::numeric_limits<InputType>::max();
-  const InputType overflow = InputType(1);
-  const InputType zero = InputType(0);
-
-  // Intermediate type size is always >= result type size. Hence, use
-  // intermediate type to calculate the expected output.
-  IntermediateType limitResult = IntermediateType(maxLimit);
-  IntermediateType overflowResult = IntermediateType(overflow);
-
-  // Single max limit value. 0's to induce dummy calculations.
-  auto limitVector =
-      makeRowVector({makeFlatVector<InputType>({maxLimit, zero, zero}, type)});
-
-  // Test code path for single values with possible overflow hit in add.
-  auto overflowFlatVector =
-      makeRowVector({makeFlatVector<InputType>({maxLimit, overflow}, type)});
-  IntermediateType expectedFlatSum = limitResult + overflowResult;
-
-  // Test code path for duplicate values with possible overflow hit in
-  // multiply.
-  auto overflowConstantVector =
-      makeRowVector({makeConstant<InputType>(maxLimit / 3, 4, type)});
-  IntermediateType expectedConstantSum = (limitResult / 3) * 4;
-
-  // Test code path for duplicate values with possible overflow hit in add.
-  auto overflowHybridVector = {limitVector, overflowConstantVector};
-  IntermediateType expectedHybridSum = limitResult + expectedConstantSum;
-
-  // Vector with element pairs of a partial aggregate node, expected result.
-  std::vector<std::pair<core::PlanNodePtr, IntermediateType>> partialAggsToTest;
-  // Partial Aggregation (raw input in - partial result out).
-  partialAggsToTest.push_back(
-      {PlanBuilder()
-           .values({overflowFlatVector})
-           .partialAggregation({}, {"sum(c0)"})
-           .planNode(),
-       expectedFlatSum});
-  partialAggsToTest.push_back(
-      {PlanBuilder()
-           .values({overflowConstantVector})
-           .partialAggregation({}, {"sum(c0)"})
-           .planNode(),
-       expectedConstantSum});
-  partialAggsToTest.push_back(
-      {PlanBuilder()
-           .values(overflowHybridVector)
-           .partialAggregation({}, {"sum(c0)"})
-           .planNode(),
-       expectedHybridSum});
-
-  // Vector with element pairs of a full aggregate node, expected result.
-  std::vector<std::pair<core::PlanNodePtr, ResultType>> aggsToTest;
-  // Single Aggregation (raw input in - final result out).
-  aggsToTest.push_back(
-      {PlanBuilder()
-           .values({overflowFlatVector})
-           .singleAggregation({}, {"sum(c0)"})
-           .planNode(),
-       expectedFlatSum});
-  aggsToTest.push_back(
-      {PlanBuilder()
-           .values({overflowConstantVector})
-           .singleAggregation({}, {"sum(c0)"})
-           .planNode(),
-       expectedConstantSum});
-  aggsToTest.push_back(
-      {PlanBuilder()
-           .values(overflowHybridVector)
-           .singleAggregation({}, {"sum(c0)"})
-           .planNode(),
-       expectedHybridSum});
-  // Final Aggregation (partial result in - final result out):
-  // To make sure that the overflow occurs in the final aggregation step, we
-  // create 2 plan fragments and plugging their partially aggregated
-  // output into a final aggregate plan node. Each of those input fragments
-  // only have a single input value under the max limit which when added in
-  // the final step causes a potential overflow.
-  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
-  aggsToTest.push_back(
-      {PlanBuilder(planNodeIdGenerator)
-           .localPartition(
-               {},
-               {PlanBuilder(planNodeIdGenerator)
-                    .values({limitVector})
-                    .partialAggregation({}, {"sum(c0)"})
-                    .planNode(),
-                PlanBuilder(planNodeIdGenerator)
-                    .values({limitVector})
-                    .partialAggregation({}, {"sum(c0)"})
-                    .planNode()})
-           .finalAggregation()
-           .planNode(),
-       limitResult + limitResult});
-
-  // Verify all partial aggregates.
-  verifyAggregates<IntermediateType>(partialAggsToTest, expectOverflow);
-  // Verify all aggregates.
-  verifyAggregates<ResultType>(aggsToTest, expectOverflow);
-}
+};
 
 TEST_F(SumTest, sumTinyint) {
   auto rowType = ROW({"c0", "c1"}, {BIGINT(), TINYINT()});

--- a/velox/functions/sparksql/aggregates/SumAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/SumAggregate.cpp
@@ -19,6 +19,11 @@ using namespace facebook::velox::functions::aggregate;
 
 namespace facebook::velox::functions::aggregate::sparksql {
 
+namespace {
+template <typename TInput, typename TAccumulator, typename ResultType>
+using SumAggregate = SumAggregateBase<TInput, TAccumulator, ResultType, true>;
+}
+
 void registerSum(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
@@ -54,37 +59,37 @@ void registerSum(const std::string& name) {
         auto inputType = argTypes[0];
         switch (inputType->kind()) {
           case TypeKind::TINYINT:
-            return std::make_unique<SumAggregateBase<int8_t, int64_t, int64_t>>(
+            return std::make_unique<SumAggregate<int8_t, int64_t, int64_t>>(
                 BIGINT());
           case TypeKind::SMALLINT:
-            return std::make_unique<
-                SumAggregateBase<int16_t, int64_t, int64_t>>(BIGINT());
+            return std::make_unique<SumAggregate<int16_t, int64_t, int64_t>>(
+                BIGINT());
           case TypeKind::INTEGER:
-            return std::make_unique<
-                SumAggregateBase<int32_t, int64_t, int64_t>>(BIGINT());
+            return std::make_unique<SumAggregate<int32_t, int64_t, int64_t>>(
+                BIGINT());
           case TypeKind::BIGINT: {
             if (inputType->isShortDecimal()) {
               VELOX_NYI();
             }
-            return std::make_unique<
-                SumAggregateBase<int64_t, int64_t, int64_t>>(BIGINT());
+            return std::make_unique<SumAggregate<int64_t, int64_t, int64_t>>(
+                BIGINT());
           }
           case TypeKind::HUGEINT: {
             VELOX_NYI();
           }
           case TypeKind::REAL:
             if (resultType->kind() == TypeKind::REAL) {
-              return std::make_unique<SumAggregateBase<float, double, float>>(
+              return std::make_unique<SumAggregate<float, double, float>>(
                   resultType);
             }
-            return std::make_unique<SumAggregateBase<float, double, double>>(
+            return std::make_unique<SumAggregate<float, double, double>>(
                 DOUBLE());
           case TypeKind::DOUBLE:
             if (resultType->kind() == TypeKind::REAL) {
-              return std::make_unique<SumAggregateBase<double, double, float>>(
+              return std::make_unique<SumAggregate<double, double, float>>(
                   resultType);
             }
-            return std::make_unique<SumAggregateBase<double, double, double>>(
+            return std::make_unique<SumAggregate<double, double, double>>(
                 DOUBLE());
           default:
             VELOX_CHECK(

--- a/velox/functions/sparksql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/aggregates/tests/CMakeLists.txt
@@ -20,7 +20,8 @@ add_executable(
   LastAggregateTest.cpp
   AverageAggregationTest.cpp
   Main.cpp
-  MinMaxByAggregationTest.cpp)
+  MinMaxByAggregationTest.cpp
+  SumAggregationTest.cpp)
 
 add_test(velox_functions_spark_aggregates_test
          velox_functions_spark_aggregates_test)

--- a/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/lib/aggregates/tests/SumTestBase.h"
+#include "velox/functions/sparksql/aggregates/Register.h"
+
+using namespace facebook::velox::functions::aggregate::test;
+
+namespace facebook::velox::functions::aggregate::sparksql::test {
+
+namespace {
+class SumAggregationTest : public SumTestBase {
+ protected:
+  void SetUp() override {
+    SumTestBase::SetUp();
+    registerAggregateFunctions("spark_");
+  }
+};
+
+TEST_F(SumAggregationTest, overflow) {
+  SumTestBase::testAggregateOverflow<int64_t, int64_t, int64_t>("spark_sum");
+}
+
+} // namespace
+} // namespace facebook::velox::functions::aggregate::sparksql::test


### PR DESCRIPTION
In sparksql, when the sum of bigint values exceeds its limit, it cycles to the overflowed value rather than raising an error. However, the current sum aggregation of sparksql is using the same implementation from prestosql, and it throws an error on overflow.

This PR align the function overflow behavior with spark and added UT. The test class to test aggregation overflow is moved from velox/functions/prestosql/aggregates/tests/SumTest.cpp into velox/functions/lib/aggregates/tests/SumTestBase.cpp.

Example of the overflow behavior:
```
SELECT SUM(x) FROM (VALUES (9223372036854775807L), (1L)) AS tab(x);
> -9223372036854775808
```