### PR TITLE
Add TIME/TIME WITH TIME ZONE type

### DIFF
--- a/velox/docs/functions/presto/datetime.rst
+++ b/velox/docs/functions/presto/datetime.rst
@@ -88,6 +88,10 @@ Date and Time Functions
 
     Returns the current date.
 
+.. function:: current_time() -> time with time zone
+
+    Returns the current time as of the start of the query.
+
 .. function:: date(x) -> date
 
     This is an alias for ``CAST(x AS date)``.

--- a/velox/expression/fuzzer/ExpressionFuzzer.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzer.cpp
@@ -444,6 +444,7 @@ bool isSupportedSignature(
       useTypeName(signature, "short_decimal") ||
       useTypeName(signature, "decimal") ||
       useTypeName(signature, "timestamp with time zone") ||
+      useTypeName(signature, "time with time zone") ||
       useTypeName(signature, "interval day to second") ||
       (enableComplexType && useTypeName(signature, "unknown")));
 }

--- a/velox/expression/tests/CustomTypeTest.cpp
+++ b/velox/expression/tests/CustomTypeTest.cpp
@@ -215,6 +215,7 @@ TEST_F(CustomTypeTest, getCustomTypeNames) {
           "JSON",
           "HYPERLOGLOG",
           "TIMESTAMP WITH TIME ZONE",
+          "TIME WITH TIME ZONE",
           "UUID",
       }),
       names);
@@ -228,6 +229,7 @@ TEST_F(CustomTypeTest, getCustomTypeNames) {
           "JSON",
           "HYPERLOGLOG",
           "TIMESTAMP WITH TIME ZONE",
+          "TIME WITH TIME ZONE",
           "UUID",
           "FANCY_INT",
       }),

--- a/velox/functions/prestosql/Comparisons.h
+++ b/velox/functions/prestosql/Comparisons.h
@@ -18,6 +18,7 @@
 #include "velox/common/base/CompareFlags.h"
 #include "velox/functions/Macros.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneUtil.h"
 
 namespace facebook::velox::functions {
 

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -19,7 +19,10 @@
 #include "velox/functions/lib/DateTimeFormatter.h"
 #include "velox/functions/lib/TimeUtils.h"
 #include "velox/functions/prestosql/DateTimeImpl.h"
+#include "velox/functions/prestosql/types/TimeWithTimeZoneType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneUtil.h"
+#include "velox/type/TimeUtil.h"
 #include "velox/type/TimestampConversion.h"
 #include "velox/type/Type.h"
 #include "velox/type/tz/TimeZoneMap.h"
@@ -1510,6 +1513,35 @@ struct CurrentDateFunction {
             localTimepoint(std::chrono::milliseconds(now.toMillis()));
     result = std::chrono::floor<date::days>((localTimepoint).time_since_epoch())
                  .count();
+  }
+};
+
+template <typename T>
+struct CurrentTimeFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  const date::time_zone* timeZone_ = nullptr;
+  std::optional<int64_t> sessionTzID_;
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config) {
+    timeZone_ = getTimeZoneFromConfig(config);
+
+    if (timeZone_ != nullptr) {
+      sessionTzID_ = util::getTimeZoneID(timeZone_->name());
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE void call(out_type<TimeWithTimezone>& result) {
+    // Get UTC millis
+    auto utcMillis = getCurrentTimeMs();
+    if (timeZone_ != nullptr) {
+      utcMillis = velox::TimeUtil::toTimezone(utcMillis, *timeZone_);
+    }
+
+    int16_t timezoneId = sessionTzID_.value_or(0);
+    result = pack(velox::TimeUtil::getMillisOfDay(utcMillis), timezoneId);
   }
 };
 

--- a/velox/functions/prestosql/FromUnixTime.cpp
+++ b/velox/functions/prestosql/FromUnixTime.cpp
@@ -16,6 +16,7 @@
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneUtil.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox::functions {

--- a/velox/functions/prestosql/aggregates/PrestoHasher.cpp
+++ b/velox/functions/prestosql/aggregates/PrestoHasher.cpp
@@ -22,6 +22,7 @@
 
 #include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneUtil.h"
 
 namespace facebook::velox::aggregate {
 

--- a/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneUtil.h"
 
 using namespace facebook::velox::exec::test;
 using namespace facebook::velox::functions::aggregate::test;

--- a/velox/functions/prestosql/aggregates/tests/PrestoHasherTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/PrestoHasherTest.cpp
@@ -18,6 +18,7 @@
 
 #include "velox/functions/prestosql/aggregates/PrestoHasher.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneUtil.h"
 #include "velox/type/tz/TimeZoneMap.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -200,6 +200,8 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerFunction<FromIso8601Timestamp, TimestampWithTimezone, Varchar>(
       {prefix + "from_iso8601_timestamp"});
   registerFunction<CurrentDateFunction, Date>({prefix + "current_date"});
+  registerFunction<CurrentTimeFunction, TimeWithTimezone>(
+      {prefix + "current_time"});
 
   registerFunction<ToISO8601Function, Varchar, Date>({prefix + "to_iso8601"});
   registerFunction<ToISO8601Function, Varchar, Timestamp>(
@@ -217,6 +219,7 @@ void registerSimpleFunctions(const std::string& prefix) {
 
 void registerDateTimeFunctions(const std::string& prefix) {
   registerTimestampWithTimeZoneType();
+  registerTimeWithTimeZoneType();
 
   registerSimpleFunctions(prefix);
   VELOX_REGISTER_VECTOR_FUNCTION(udf_from_unixtime, prefix + "from_unixtime");

--- a/velox/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
+++ b/velox/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/functions/prestosql/tests/CastBaseTest.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneUtil.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox {

--- a/velox/functions/prestosql/types/CMakeLists.txt
+++ b/velox/functions/prestosql/types/CMakeLists.txt
@@ -11,8 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(velox_presto_types HyperLogLogType.cpp JsonType.cpp
-                               TimestampWithTimeZoneType.cpp UuidType.cpp)
+add_library(
+  velox_presto_types
+  HyperLogLogType.cpp JsonType.cpp TimeWithTimeZoneType.cpp
+  TimestampWithTimeZoneType.cpp TimestampWithTimeZoneUtil.h UuidType.cpp)
 
 target_link_libraries(
   velox_presto_types velox_memory velox_expression velox_functions_util

--- a/velox/functions/prestosql/types/TimeWithTimeZoneType.cpp
+++ b/velox/functions/prestosql/types/TimeWithTimeZoneType.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/types/TimeWithTimeZoneType.h"
+
+namespace facebook::velox {
+
+void registerTimeWithTimeZoneType() {
+  registerCustomType(
+      "time with time zone",
+      std::make_unique<const TimeWithTimeZoneTypeFactories>());
+}
+
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/TimeWithTimeZoneType.h
+++ b/velox/functions/prestosql/types/TimeWithTimeZoneType.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/type/SimpleFunctionApi.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox {
+
+/// Represents time with time zone as a number of milliseconds since epoch
+/// and time zone ID.
+class TimeWithTimeZoneType : public BigintType {
+  TimeWithTimeZoneType() = default;
+
+ public:
+  static const std::shared_ptr<const TimeWithTimeZoneType>& get() {
+    static const std::shared_ptr<const TimeWithTimeZoneType> instance =
+        std::shared_ptr<TimeWithTimeZoneType>(new TimeWithTimeZoneType());
+
+    return instance;
+  }
+
+  bool equivalent(const Type& other) const override {
+    // Pointer comparison works since this type is a singleton.
+    return this == &other;
+  }
+
+  const char* name() const override {
+    return "TIME WITH TIME ZONE";
+  }
+
+  const std::vector<TypeParameter>& parameters() const override {
+    static const std::vector<TypeParameter> kEmpty = {};
+    return kEmpty;
+  }
+
+  std::string toString() const override {
+    return name();
+  }
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = "Type";
+    obj["type"] = name();
+    return obj;
+  }
+};
+
+inline bool isTimeWithTimeZoneType(const TypePtr& type) {
+  // Pointer comparison works since this type is a singleton.
+  return TimeWithTimeZoneType::get() == type;
+}
+
+inline std::shared_ptr<const TimeWithTimeZoneType> TIME_WITH_TIME_ZONE() {
+  return TimeWithTimeZoneType::get();
+}
+
+// Type used for function registration.
+struct TimeWithTimezoneT {
+  using type = int64_t;
+  static constexpr const char* typeName = "time with time zone";
+};
+
+using TimeWithTimezone = CustomType<TimeWithTimezoneT>;
+
+class TimeWithTimeZoneTypeFactories : public CustomTypeFactories {
+ public:
+  TypePtr getType() const override {
+    return TIME_WITH_TIME_ZONE();
+  }
+
+  // Type casting from and to TimeWithTimezone is not supported yet.
+  exec::CastOperatorPtr getCastOperator() const override {
+    VELOX_NYI(
+        "Casting of {} is not implemented yet.",
+        TIME_WITH_TIME_ZONE()->toString());
+  }
+};
+
+void registerTimeWithTimeZoneType();
+
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.cpp
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.cpp
@@ -16,6 +16,7 @@
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/expression/StringWriter.h"
 #include "velox/functions/lib/DateTimeFormatter.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneUtil.h"
 #include "velox/type/Timestamp.h"
 #include "velox/type/TimestampConversion.h"
 #include "velox/type/tz/TimeZoneMap.h"

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
@@ -124,25 +124,4 @@ class TimestampWithTimeZoneTypeFactories : public CustomTypeFactories {
 };
 
 void registerTimestampWithTimeZoneType();
-
-using TimeZoneKey = int16_t;
-
-constexpr int32_t kTimezoneMask = 0xFFF;
-constexpr int32_t kMillisShift = 12;
-
-inline int64_t unpackMillisUtc(int64_t dateTimeWithTimeZone) {
-  return dateTimeWithTimeZone >> kMillisShift;
-}
-
-inline TimeZoneKey unpackZoneKeyId(int64_t dateTimeWithTimeZone) {
-  return dateTimeWithTimeZone & kTimezoneMask;
-}
-
-inline int64_t pack(int64_t millisUtc, int16_t timeZoneKey) {
-  return (millisUtc << kMillisShift) | (timeZoneKey & kTimezoneMask);
-}
-
-inline Timestamp unpackTimestampUtc(int64_t dateTimeWithTimeZone) {
-  return Timestamp::fromMillis(unpackMillisUtc(dateTimeWithTimeZone));
-}
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneUtil.h
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneUtil.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/type/Timestamp.h"
+
+namespace facebook::velox {
+using TimeZoneKey = int16_t;
+
+constexpr int32_t kTimezoneMask = 0xFFF;
+constexpr int32_t kMillisShift = 12;
+
+inline int64_t unpackMillisUtc(int64_t dateTimeWithTimeZone) {
+  return dateTimeWithTimeZone >> kMillisShift;
+}
+
+inline TimeZoneKey unpackZoneKeyId(int64_t dateTimeWithTimeZone) {
+  return dateTimeWithTimeZone & kTimezoneMask;
+}
+
+inline int64_t pack(int64_t millisUtc, int16_t timeZoneKey) {
+  return (millisUtc << kMillisShift) | (timeZoneKey & kTimezoneMask);
+}
+
+inline Timestamp unpackTimestampUtc(int64_t dateTimeWithTimeZone) {
+  return Timestamp::fromMillis(unpackMillisUtc(dateTimeWithTimeZone));
+}
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/types/tests/CMakeLists.txt
@@ -14,8 +14,13 @@
 
 add_executable(
   velox_presto_types_test
-  HyperLogLogTypeTest.cpp JsonTypeTest.cpp TimestampWithTimeZoneTypeTest.cpp
-  TypeTestBase.cpp UuidTypeTest.cpp)
+  HyperLogLogTypeTest.cpp
+  JsonTypeTest.cpp
+  TimestampWithTimeZoneTypeTest.cpp
+  TimestampWithTimeZoneUtilTest.cpp
+  TimeWithTimeZoneTypeTest.cpp
+  TypeTestBase.cpp
+  UuidTypeTest.cpp)
 
 add_test(velox_presto_types_test velox_presto_types_test)
 

--- a/velox/functions/prestosql/types/tests/TimeWithTimeZoneTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/TimeWithTimeZoneTypeTest.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/types/TimeWithTimeZoneType.h"
+#include "velox/functions/prestosql/types/tests/TypeTestBase.h"
+
+namespace facebook::velox::test {
+
+class TimeWithTimeZoneTypeTest : public testing::Test, public TypeTestBase {
+ public:
+  TimeWithTimeZoneTypeTest() {
+    registerTimeWithTimeZoneType();
+  }
+};
+
+TEST_F(TimeWithTimeZoneTypeTest, basic) {
+  ASSERT_EQ(TIME_WITH_TIME_ZONE()->name(), "TIME WITH TIME ZONE");
+  ASSERT_EQ(TIME_WITH_TIME_ZONE()->kindName(), "BIGINT");
+  ASSERT_TRUE(TIME_WITH_TIME_ZONE()->parameters().empty());
+  ASSERT_EQ(TIME_WITH_TIME_ZONE()->toString(), "TIME WITH TIME ZONE");
+
+  ASSERT_TRUE(hasType("TIME WITH TIME ZONE"));
+  ASSERT_EQ(*getType("TIME WITH TIME ZONE", {}), *TIME_WITH_TIME_ZONE());
+}
+
+TEST_F(TimeWithTimeZoneTypeTest, serde) {
+  testTypeSerde(TIME_WITH_TIME_ZONE());
+}
+} // namespace facebook::velox::test

--- a/velox/functions/prestosql/types/tests/TimestampWithTimeZoneTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/TimestampWithTimeZoneTypeTest.cpp
@@ -40,29 +40,4 @@ TEST_F(TimestampWithTimeZoneTypeTest, basic) {
 TEST_F(TimestampWithTimeZoneTypeTest, serde) {
   testTypeSerde(TIMESTAMP_WITH_TIME_ZONE());
 }
-
-TEST_F(TimestampWithTimeZoneTypeTest, pack) {
-  std::mt19937 randGen(std::random_device{}());
-  // 0xFFF8000000000000 and 0x7FFFFFFFFFFFF are hexadecimal numbers
-  // that represent the minimum and maximum values that the
-  // TimestampWithTimeZoneType type can represent, respectively.
-  std::uniform_int_distribution<int64_t> millisUtcDis(
-      0xFFF8000000000000L, 0x7FFFFFFFFFFFF);
-
-  // 2233 represents the maximum value of timeZoneKey,
-  // see tzDB in TimeZoneDatabase.cpp
-  std::uniform_int_distribution<int16_t> timeZoneKeyDis(0, 2233);
-
-  for (int64_t i = 0; i < 10'000; ++i) {
-    auto millisUtc = millisUtcDis(randGen);
-    auto timeZoneKey = timeZoneKeyDis(randGen);
-    SCOPED_TRACE(
-        fmt::format("millisUtc={}, timeZoneKey={}", millisUtc, timeZoneKey));
-
-    auto packedTimeMillis = pack(millisUtc, timeZoneKey);
-    ASSERT_EQ(unpackMillisUtc(packedTimeMillis), millisUtc);
-    ASSERT_EQ(unpackZoneKeyId(packedTimeMillis), timeZoneKey);
-  }
-}
-
 } // namespace facebook::velox::test

--- a/velox/functions/prestosql/types/tests/TimestampWithTimeZoneUtilTest.cpp
+++ b/velox/functions/prestosql/types/tests/TimestampWithTimeZoneUtilTest.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <random>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneUtil.h"
+
+namespace facebook::velox::test {
+TEST(TimestampWithTimeZoneUtilTest, pack) {
+  std::mt19937 randGen(std::random_device{}());
+  // 0xFFF8000000000000 and 0x7FFFFFFFFFFFF are hexadecimal numbers
+  // that represent the minimum and maximum values that the
+  // TimestampWithTimeZoneType type can represent, respectively.
+  std::uniform_int_distribution<int64_t> millisUtcDis(
+      0xFFF8000000000000L, 0x7FFFFFFFFFFFF);
+
+  // 2233 represents the maximum value of timeZoneKey,
+  // see tzDB in TimeZoneDatabase.cpp
+  std::uniform_int_distribution<int16_t> timeZoneKeyDis(0, 2233);
+
+  for (int64_t i = 0; i < 10'000; ++i) {
+    auto millisUtc = millisUtcDis(randGen);
+    auto timeZoneKey = timeZoneKeyDis(randGen);
+    SCOPED_TRACE(
+        fmt::format("millisUtc={}, timeZoneKey={}", millisUtc, timeZoneKey));
+
+    auto packedTimeMillis = pack(millisUtc, timeZoneKey);
+    ASSERT_EQ(unpackMillisUtc(packedTimeMillis), millisUtc);
+    ASSERT_EQ(unpackZoneKeyId(packedTimeMillis), timeZoneKey);
+  }
+}
+} // namespace facebook::velox::test

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -21,6 +21,7 @@
 #include "velox/common/memory/ByteStream.h"
 #include "velox/common/time/Timer.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneUtil.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 

--- a/velox/type/CMakeLists.txt
+++ b/velox/type/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(
   StringView.cpp
   StringView.h
   Subfield.cpp
+  TimeUtil.h
   Timestamp.cpp
   TimestampConversion.cpp
   Tokenizer.cpp

--- a/velox/type/TimeUtil.h
+++ b/velox/type/TimeUtil.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <type_traits>
+
+#include "velox/external/date/tz.h"
+#include "velox/type/tz/TimeZoneMap.h"
+
+namespace facebook::velox {
+
+/// A static class that holds helper functions for TIME type.
+class TimeUtil {
+ public:
+  static constexpr int64_t kMillisecondsInSecond = 1'000;
+  // 24 * 60 * 60 * 1000
+  static constexpr int64_t kMillisecondPerDay = 86400000LL;
+
+  // Get the number of milliseconds in a day from a given milliseconds
+  // millis – the milliseconds from 1970-01-01T00:00:00Z
+  // Returns the amount of milliseconds in a day.
+  inline static int64_t getMillisOfDay(int64_t millis) {
+    if (millis >= 0) {
+      return millis % kMillisecondPerDay;
+    } else {
+      return kMillisecondPerDay - 1 + ((millis + 1) % kMillisecondPerDay);
+    }
+  }
+
+  // Convert UTC milliseconds to milliseconds in corresponding time zone
+  inline static int64_t toTimezone(
+      int64_t millis,
+      const date::time_zone& zone) {
+    auto timePoint = std::chrono::
+        time_point<std::chrono::system_clock, std::chrono::milliseconds>(
+            std::chrono::milliseconds(millis));
+
+    auto epoch = zone.to_local(timePoint).time_since_epoch();
+    return std::chrono::duration_cast<std::chrono::milliseconds>(epoch).count();
+  }
+
+  // Assuming tzID is in [1, 1680] range.
+  // tzID - PrestoDB time zone ID.
+  inline static int64_t getPrestoTZOffsetInMillis(int16_t tzID) {
+    // PrestoDb time zone ids require some custom code.
+    // Mapping is 1-based and covers [-14:00, +14:00] range without 00:00.
+    return ((tzID <= 840) ? (tzID - 841) : (tzID - 840)) * 60 *
+        kMillisecondsInSecond;
+  }
+
+  inline static int64_t toGMT(int64_t millis, int16_t tzID) {
+    if (tzID == 0) {
+      // No conversion required for time zone id 0, as it is '+00:00'.
+      return millis;
+    } else if (tzID <= 1680) {
+      return millis - getPrestoTZOffsetInMillis(tzID);
+    } else {
+      // Other ids go this path.
+      return toGMT(millis, *date::locate_zone(util::getTimeZoneName(tzID)));
+    }
+  }
+
+  inline static int64_t toGMT(int64_t millis, const date::time_zone& zone) {
+    date::local_time<std::chrono::milliseconds> localTime{
+        std::chrono::milliseconds(millis)};
+    std::chrono::
+        time_point<std::chrono::system_clock, std::chrono::milliseconds>
+            sysTime;
+    try {
+      sysTime = zone.to_sys(localTime);
+    } catch (const date::ambiguous_local_time& error) {
+      sysTime = zone.to_sys(localTime, date::choose::earliest);
+    } catch (const date::nonexistent_local_time& error) {
+      // If the time does not exist, fail the conversion.
+      VELOX_USER_FAIL(error.what());
+    }
+    return sysTime.time_since_epoch().count();
+  }
+
+}; // TimeUtil
+} // namespace facebook::velox

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -35,6 +35,7 @@
 #include "velox/common/serialization/Serializable.h"
 #include "velox/type/HugeInt.h"
 #include "velox/type/StringView.h"
+#include "velox/type/TimeUtil.h"
 #include "velox/type/Timestamp.h"
 #include "velox/type/Tree.h"
 
@@ -550,6 +551,8 @@ class Type : public Tree<const TypePtr>, public velox::ISerializable {
   bool isIntervalDayTime() const;
 
   bool isDate() const;
+
+  bool isTimeMillis() const;
 
   bool containsUnknown() const;
 
@@ -1310,6 +1313,57 @@ FOLLY_ALWAYS_INLINE bool isDateName(const std::string& name) {
 FOLLY_ALWAYS_INLINE bool Type::isDate() const {
   // The pointers can be compared since DATE is a singleton.
   return this == DATE().get();
+}
+
+/// A TimeMillis is stored as milliseconds from midnight on 1970-01-01T00:00:00
+/// in the time zone of the session. When performing calculations on a time
+/// the client's time zone must be taken into account.
+class TimeMillisType : public BigintType {
+ private:
+  TimeMillisType() = default;
+
+ public:
+  static const std::shared_ptr<const TimeMillisType>& get() {
+    static const std::shared_ptr<const TimeMillisType> kType{
+        new TimeMillisType()};
+    return kType;
+  }
+
+  const char* name() const override {
+    return "TIME_MILLIS";
+  }
+
+  bool equivalent(const Type& other) const override {
+    return this == &other;
+  }
+
+  std::string toString() const override {
+    return name();
+  }
+
+  /// Convert millis to string representation according to timeZone
+  static std::string valueToString(
+      int64_t millis,
+      const date::time_zone* timeZone = nullptr);
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = "TimeMillisType";
+    obj["type"] = name();
+    return obj;
+  }
+
+  static TypePtr deserialize(const folly::dynamic& /*obj*/) {
+    return TimeMillisType::get();
+  }
+};
+
+FOLLY_ALWAYS_INLINE std::shared_ptr<const TimeMillisType> TIME_MILLIS() {
+  return TimeMillisType::get();
+}
+
+FOLLY_ALWAYS_INLINE bool Type::isTimeMillis() const {
+  return this == TIME_MILLIS().get();
 }
 
 /// Used as T for SimpleVector subclasses that wrap another vector when

--- a/velox/vector/tests/VectorSaverTest.cpp
+++ b/velox/vector/tests/VectorSaverTest.cpp
@@ -21,6 +21,7 @@
 #include "velox/exec/tests/utils/TempFilePath.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
 #include "velox/functions/prestosql/types/JsonType.h"
+#include "velox/functions/prestosql/types/TimeWithTimeZoneType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
@@ -37,6 +38,7 @@ class VectorSaverTest : public testing::Test, public VectorTestBase {
     registerJsonType();
     registerHyperLogLogType();
     registerTimestampWithTimeZoneType();
+    registerTimeWithTimeZoneType();
   }
 
   void SetUp() override {
@@ -265,6 +267,7 @@ TEST_F(VectorSaverTest, types) {
   testTypeRoundTrip(JSON());
   testTypeRoundTrip(HYPERLOGLOG());
   testTypeRoundTrip(TIMESTAMP_WITH_TIME_ZONE());
+  testTypeRoundTrip(TIME_WITH_TIME_ZONE());
 }
 
 TEST_F(VectorSaverTest, selectivityVector) {


### PR DESCRIPTION
Add support TIME/TIME WITH TIME ZONE type in velox. Design documentation can be found [here](https://docs.google.com/document/d/1RmMR7EtbGljNXeix51Ek_YebKAFC4doCOpkuQbV0758/edit). The discussion can be found [here](https://github.com/facebookincubator/velox/discussions/6792). This PR is the first task to implement TIME/TIME WITH TIME ZONE type. All tasks can be found [here](https://github.com/facebookincubator/velox/discussions/6792#discussioncomment-7353882).



Resolves https://github.com/facebookincubator/velox/issues/6603