### PR TITLE
Adopt spill-friendly order of input columns in Window operator

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -2075,6 +2075,10 @@ class WindowNode : public PlanNode {
     return outputType_;
   }
 
+  const RowTypePtr& inputType() const {
+    return sources_[0]->outputType();
+  }
+
   const std::vector<FieldAccessTypedExprPtr>& partitionKeys() const {
     return partitionKeys_;
   }

--- a/velox/exec/SortWindowBuild.cpp
+++ b/velox/exec/SortWindowBuild.cpp
@@ -31,8 +31,8 @@ SortWindowBuild::SortWindowBuild(
 }
 
 void SortWindowBuild::addInput(RowVectorPtr input) {
-  for (auto col = 0; col < input->childrenSize(); ++col) {
-    decodedInputVectors_[col].decode(*input->childAt(col));
+  for (auto i = 0; i < inputChannels_.size(); ++i) {
+    decodedInputVectors_[i].decode(*input->childAt(inputChannels_[i]));
   }
 
   // Add all the rows into the RowContainer.

--- a/velox/exec/StreamingWindowBuild.cpp
+++ b/velox/exec/StreamingWindowBuild.cpp
@@ -30,8 +30,8 @@ void StreamingWindowBuild::buildNextPartition() {
 }
 
 void StreamingWindowBuild::addInput(RowVectorPtr input) {
-  for (auto col = 0; col < input->childrenSize(); ++col) {
-    decodedInputVectors_[col].decode(*input->childAt(col));
+  for (auto i = 0; i < inputChannels_.size(); ++i) {
+    decodedInputVectors_[i].decode(*input->childAt(inputChannels_[i]));
   }
 
   for (auto row = 0; row < input->size(); ++row) {

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -31,7 +31,7 @@ Window::Window(
           operatorId,
           windowNode->id(),
           "Window"),
-      numInputColumns_(windowNode->sources()[0]->outputType()->size()),
+      numInputColumns_(windowNode->inputType()->size()),
       windowNode_(windowNode),
       currentPartition_(nullptr),
       stringAllocator_(pool()) {
@@ -501,14 +501,8 @@ RowVectorPtr Window::getOutput() {
   }
 
   auto numOutputRows = std::min(numRowsPerOutput_, numRowsLeft);
-  auto result = std::dynamic_pointer_cast<RowVector>(
-      BaseVector::create(outputType_, numOutputRows, operatorCtx_->pool()));
-
-  for (int i = numInputColumns_; i < outputType_->size(); i++) {
-    auto output = BaseVector::create(
-        outputType_->childAt(i), numOutputRows, operatorCtx_->pool());
-    result->childAt(i) = output;
-  }
+  auto result = BaseVector::create<RowVector>(
+      outputType_, numOutputRows, operatorCtx_->pool());
 
   // Compute the output values of window functions.
   auto numResultRows = callApplyLoop(numOutputRows, result);

--- a/velox/exec/WindowBuild.cpp
+++ b/velox/exec/WindowBuild.cpp
@@ -21,47 +21,83 @@
 namespace facebook::velox::exec {
 
 namespace {
-void initKeyInfo(
-    const RowTypePtr& type,
-    const std::vector<core::FieldAccessTypedExprPtr>& keys,
-    const std::vector<core::SortOrder>& orders,
-    std::vector<std::pair<column_index_t, core::SortOrder>>& keyInfo) {
-  const core::SortOrder defaultPartitionSortOrder(true, true);
+std::vector<column_index_t> reorderInputChannels(
+    const RowTypePtr& inputType,
+    const std::vector<core::FieldAccessTypedExprPtr>& partitionKeys,
+    const std::vector<core::FieldAccessTypedExprPtr>& sortingKeys) {
+  const auto size = inputType->size();
 
-  keyInfo.reserve(keys.size());
-  for (auto i = 0; i < keys.size(); ++i) {
-    auto channel = exprToChannel(keys[i].get(), type);
-    VELOX_CHECK(
-        channel != kConstantChannel,
-        "Window doesn't allow constant partition or sort keys");
-    if (i < orders.size()) {
-      keyInfo.push_back(std::make_pair(channel, orders[i]));
-    } else {
-      keyInfo.push_back(std::make_pair(channel, defaultPartitionSortOrder));
+  std::vector<column_index_t> channels;
+  channels.reserve(size);
+
+  std::unordered_set<std::string> keyNames;
+
+  for (const auto& key : partitionKeys) {
+    channels.push_back(exprToChannel(key.get(), inputType));
+    keyNames.insert(key->name());
+  }
+
+  for (const auto& key : sortingKeys) {
+    channels.push_back(exprToChannel(key.get(), inputType));
+    keyNames.insert(key->name());
+  }
+
+  for (auto i = 0; i < size; ++i) {
+    if (keyNames.count(inputType->nameOf(i)) == 0) {
+      channels.push_back(i);
     }
   }
+
+  return channels;
+}
+
+RowTypePtr reorderInputType(
+    const RowTypePtr& inputType,
+    const std::vector<column_index_t>& channels) {
+  const auto size = inputType->size();
+
+  VELOX_CHECK_EQ(size, channels.size());
+
+  std::vector<std::string> names;
+  names.reserve(size);
+
+  std::vector<TypePtr> types;
+  types.reserve(size);
+
+  for (auto channel : channels) {
+    names.push_back(inputType->nameOf(channel));
+    types.push_back(inputType->childAt(channel));
+  }
+
+  return ROW(std::move(names), std::move(types));
 }
 }; // namespace
 
 WindowBuild::WindowBuild(
     const std::shared_ptr<const core::WindowNode>& windowNode,
     velox::memory::MemoryPool* pool)
-    : numInputColumns_(windowNode->sources()[0]->outputType()->size()),
-      data_(std::make_unique<RowContainer>(
-          windowNode->sources()[0]->outputType()->children(),
-          pool)),
-      decodedInputVectors_(windowNode->sources()[0]->outputType()->size()) {
-  auto inputType = windowNode->sources()[0]->outputType();
-  for (int i = 0; i < inputType->children().size(); i++) {
-    inputColumns_.push_back(data_->columnAt(i));
+    : inputChannels_{reorderInputChannels(
+          windowNode->inputType(),
+          windowNode->partitionKeys(),
+          windowNode->sortingKeys())},
+      inputType_{reorderInputType(windowNode->inputType(), inputChannels_)},
+      data_(std::make_unique<RowContainer>(inputType_->children(), pool)),
+      decodedInputVectors_(inputType_->size()) {
+  for (int i = 0; i < windowNode->inputType()->size(); i++) {
+    const auto index =
+        inputType_->getChildIdx(windowNode->inputType()->nameOf(i));
+    inputColumns_.emplace_back(data_->columnAt(index));
   }
 
-  initKeyInfo(inputType, windowNode->partitionKeys(), {}, partitionKeyInfo_);
-  initKeyInfo(
-      inputType,
-      windowNode->sortingKeys(),
-      windowNode->sortingOrders(),
-      sortKeyInfo_);
+  const auto numPartitionKeys = windowNode->partitionKeys().size();
+  for (auto i = 0; i < numPartitionKeys; ++i) {
+    partitionKeyInfo_.push_back(std::make_pair(i, core::SortOrder{true, true}));
+  }
+
+  for (auto i = 0; i < windowNode->sortingKeys().size(); ++i) {
+    sortKeyInfo_.push_back(
+        std::make_pair(numPartitionKeys + i, windowNode->sortingOrders()[i]));
+  }
 }
 
 bool WindowBuild::compareRowsWithKeys(

--- a/velox/exec/WindowBuild.h
+++ b/velox/exec/WindowBuild.h
@@ -82,7 +82,11 @@ class WindowBuild {
   std::vector<std::pair<column_index_t, core::SortOrder>> partitionKeyInfo_;
   std::vector<std::pair<column_index_t, core::SortOrder>> sortKeyInfo_;
 
-  const vector_size_t numInputColumns_;
+  // Input columns in the order of: partition keys, sorting keys, the rest.
+  const std::vector<column_index_t> inputChannels_;
+
+  // Input column types in 'inputChannels_' order.
+  const RowTypePtr inputType_;
 
   // The RowContainer holds all the input rows in WindowBuild.
   std::unique_ptr<RowContainer> data_;

--- a/velox/functions/lib/window/tests/WindowTestBase.cpp
+++ b/velox/functions/lib/window/tests/WindowTestBase.cpp
@@ -158,12 +158,16 @@ void WindowTestBase::testWindowFunction(
   std::mt19937 gen(rd());
   std::uniform_int_distribution<int> dis(0, 1);
 
+  int n = 0;
   for (const auto& overClause : overClauses) {
-    WindowTestBase::QueryInfo queryInfo;
     for (const auto& frameClause : frameClauses) {
+      ++n;
+
       auto resolvedWindowStyle = windowStyle == WindowStyle::kRandom
           ? static_cast<int>(dis(gen))
           : static_cast<int>(windowStyle);
+
+      WindowTestBase::QueryInfo queryInfo;
       if (resolvedWindowStyle == static_cast<int>(WindowStyle::kSort)) {
         queryInfo = buildWindowQuery(input, function, overClause, frameClause);
       } else {
@@ -171,7 +175,7 @@ void WindowTestBase::testWindowFunction(
             buildStreamingWindowQuery(input, function, overClause, frameClause);
       }
 
-      SCOPED_TRACE(queryInfo.functionSql);
+      SCOPED_TRACE(fmt::format("Query #{}: {}", n, queryInfo.functionSql));
       assertQuery(queryInfo.planNode, queryInfo.querySql);
     }
   }


### PR DESCRIPTION
To add spilling support, it is convenient to store columns in the order of
partition keys, followed by sorting keys, followed by the rest of the input
columns.

This column order allows to sort and spill accumulated inputs, then merge-sort the
data back and produce the output.

Similar to #7144