### PR TITLE
Add spill support to Window operator

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -2055,6 +2055,14 @@ class WindowNode : public PlanNode {
     return outputType_;
   }
 
+  bool canSpill(const QueryConfig& queryConfig) const override {
+    // No partitioning keys means the whole input is one big partition. In this
+    // case, spilling is not helpful because we need to have a full partition in
+    // memory to produce results.
+    return !partitionKeys_.empty() && !inputsSorted_ &&
+        queryConfig.windowSpillEnabled();
+  }
+
   const RowTypePtr& inputType() const {
     return sources_[0]->outputType();
   }

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -197,6 +197,9 @@ class QueryConfig {
   /// OrderBy spilling flag, only applies if "spill_enabled" flag is set.
   static constexpr const char* kOrderBySpillEnabled = "order_by_spill_enabled";
 
+  /// Window spilling flag, only applies if "spill_enabled" flag is set.
+  static constexpr const char* kWindowSpillEnabled = "window_spill_enabled";
+
   /// If true, the memory arbitrator will reclaim memory from table writer by
   /// flushing its buffered data to disk.
   static constexpr const char* kWriterSpillEnabled = "writer_spill_enabled";
@@ -489,6 +492,12 @@ class QueryConfig {
   /// spillEnabled()!
   bool orderBySpillEnabled() const {
     return get<bool>(kOrderBySpillEnabled, true);
+  }
+
+  /// Returns true if spilling is enabled for Window operator. Must also
+  /// check the spillEnabled()!
+  bool windowSpillEnabled() const {
+    return get<bool>(kWindowSpillEnabled, true);
   }
 
   /// Returns 'is writer spilling enabled' flag. Must also check the

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -194,17 +194,18 @@ Spilling
      - boolean
      - true
      - When `spill_enabled` is true, determines whether HashAggregation operator can spill to disk under memory pressure.
-       memory limits for the query.
    * - join_spill_enabled
      - boolean
      - true
      - When `spill_enabled` is true, determines whether HashBuild and HashProbe operators can spill to disk under memory pressure.
-       limits for the query.
    * - order_by_spill_enabled
      - boolean
      - true
      - When `spill_enabled` is true, determines whether OrderBy operator can spill to disk under memory pressure.
-       limits for the query.
+   * - window_spill_enabled
+     - boolean
+     - true
+     - When `spill_enabled` is true, determines whether Window operator can spill to disk under memory pressure.
    * - row_number_spill_enabled
      - boolean
      - true

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -71,27 +71,6 @@ void populateAggregateInputs(
   }
 }
 
-void verifyIntermediateInputs(
-    const std::string& name,
-    const std::vector<TypePtr>& types) {
-  VELOX_USER_CHECK_GE(
-      types.size(),
-      1,
-      "Intermediate aggregates must have at least one argument: {}",
-      name);
-  VELOX_USER_CHECK_NE(
-      types[0]->kind(),
-      TypeKind::FUNCTION,
-      "First argument of an intermediate aggregate cannot be a lambda: {}",
-      name);
-  for (auto i = 1; i < types.size(); ++i) {
-    VELOX_USER_CHECK_EQ(
-        types[i]->kind(),
-        TypeKind::FUNCTION,
-        "Non-first argument of an intermediate aggregate must be a lambda: {}",
-        name);
-  }
-}
 } // namespace
 
 HashAggregation::HashAggregation(

--- a/velox/exec/StreamingWindowBuild.cpp
+++ b/velox/exec/StreamingWindowBuild.cpp
@@ -20,8 +20,10 @@ namespace facebook::velox::exec {
 
 StreamingWindowBuild::StreamingWindowBuild(
     const std::shared_ptr<const core::WindowNode>& windowNode,
-    velox::memory::MemoryPool* pool)
-    : WindowBuild(windowNode, pool) {}
+    velox::memory::MemoryPool* pool,
+    const common::SpillConfig* spillConfig,
+    tsan_atomic<bool>* nonReclaimableSection)
+    : WindowBuild(windowNode, pool, spillConfig, nonReclaimableSection) {}
 
 void StreamingWindowBuild::buildNextPartition() {
   partitionStartRows_.push_back(sortedRows_.size());

--- a/velox/exec/StreamingWindowBuild.h
+++ b/velox/exec/StreamingWindowBuild.h
@@ -28,9 +28,19 @@ class StreamingWindowBuild : public WindowBuild {
  public:
   StreamingWindowBuild(
       const std::shared_ptr<const core::WindowNode>& windowNode,
-      velox::memory::MemoryPool* pool);
+      velox::memory::MemoryPool* pool,
+      const common::SpillConfig* spillConfig,
+      tsan_atomic<bool>* nonReclaimableSection);
 
   void addInput(RowVectorPtr input) override;
+
+  void spill() override {
+    VELOX_UNREACHABLE();
+  }
+
+  std::optional<SpillStats> spilledStats() const override {
+    return std::nullopt;
+  }
 
   void noMoreInput() override;
 

--- a/velox/exec/Window.h
+++ b/velox/exec/Window.h
@@ -64,6 +64,9 @@ class Window : public Operator {
     return noMoreInput_ && numRows_ == numProcessedRows_;
   }
 
+  void reclaim(uint64_t targetBytes, memory::MemoryReclaimer::Stats& stats)
+      override;
+
  private:
   // Used for k preceding/following frames. Index is the column index if k is a
   // column. value is used to read column values from the column index when k
@@ -171,6 +174,7 @@ class Window : public Operator {
   // WindowFunction is the base API implemented by all the window functions.
   // The functions are ordered by their positions in the output columns.
   std::vector<std::unique_ptr<exec::WindowFunction>> windowFunctions_;
+
   // Vector of WindowFrames corresponding to each windowFunction above.
   // It represents the frame spec for the function computation.
   std::vector<WindowFrame> windowFrames_;


### PR DESCRIPTION
Window operator accumulates all input into a RowContainer. After adding all
input, it sorts the data by partition and sorting keys, splits into partitions,
computes window functions and produces results.

A streaming version of the operator accumulates only one partition at a time
(give and take a few extra rows from the next partition).

When asked to spill, non-streaming Window operator sorts accumulated input rows by
partition and sorting keys, spills all of them, clears the RowContainer, and continues 
to accumulate future input into freed up container.

After receiving (and spilling) all input, Window operator sort-merges
spilled data and generates output. Since at this point all data is sorted by
partition and sorting keys, the operator produces data in streaming fashion.

Spilling is enabled by default. It can be disabled by setting
window_number_spill_enabled configuration property to false.

Spilling after noMoreInput() is not supported yet.

Spilling for streaming Window operator is not supported.