### PR TITLE
Remove redundant WindowPartition::resetPartition method

### DIFF
--- a/velox/exec/SortWindowBuild.cpp
+++ b/velox/exec/SortWindowBuild.cpp
@@ -110,17 +110,14 @@ std::unique_ptr<WindowPartition> SortWindowBuild::nextPartition() {
       currentPartition_ <= partitionStartRows_.size() - 2,
       "All window partitions consumed");
 
-  auto windowPartition = std::make_unique<WindowPartition>(
-      data_.get(), inputColumns_, sortKeyInfo_);
   // There is partition data available now.
   auto partitionSize = partitionStartRows_[currentPartition_ + 1] -
       partitionStartRows_[currentPartition_];
   auto partition = folly::Range(
       sortedRows_.data() + partitionStartRows_[currentPartition_],
       partitionSize);
-  windowPartition->resetPartition(partition);
-
-  return windowPartition;
+  return std::make_unique<WindowPartition>(
+      data_.get(), partition, inputColumns_, sortKeyInfo_);
 }
 
 bool SortWindowBuild::hasNextPartition() {

--- a/velox/exec/StreamingWindowBuild.cpp
+++ b/velox/exec/StreamingWindowBuild.cpp
@@ -81,16 +81,14 @@ std::unique_ptr<WindowPartition> StreamingWindowBuild::nextPartition() {
     }
   }
 
-  auto windowPartition = std::make_unique<WindowPartition>(
-      data_.get(), inputColumns_, sortKeyInfo_);
   auto partitionSize = partitionStartRows_[currentPartition_ + 1] -
       partitionStartRows_[currentPartition_];
   auto partition = folly::Range(
       sortedRows_.data() + partitionStartRows_[currentPartition_],
       partitionSize);
-  windowPartition->resetPartition(partition);
 
-  return windowPartition;
+  return std::make_unique<WindowPartition>(
+      data_.get(), partition, inputColumns_, sortKeyInfo_);
 }
 
 bool StreamingWindowBuild::hasNextPartition() {

--- a/velox/exec/WindowPartition.cpp
+++ b/velox/exec/WindowPartition.cpp
@@ -19,13 +19,13 @@ namespace facebook::velox::exec {
 
 WindowPartition::WindowPartition(
     RowContainer* data,
+    const folly::Range<char**>& rows,
     const std::vector<exec::RowColumn>& columns,
     const std::vector<std::pair<column_index_t, core::SortOrder>>& sortKeyInfo)
-    : data_(data), columns_(columns), sortKeyInfo_(sortKeyInfo) {}
-
-void WindowPartition::resetPartition(const folly::Range<char**>& rows) {
-  partition_ = rows;
-}
+    : data_(data),
+      partition_(rows),
+      columns_(columns),
+      sortKeyInfo_(sortKeyInfo) {}
 
 void WindowPartition::extractColumn(
     int32_t columnIndex,


### PR DESCRIPTION
WindowPartition::resetPartition can be consolidated with the window constructor. We call resetPartition only once per WindowPartition now.