### PR TITLE
Disable spilling in bucket sort writer

### DIFF
--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -595,7 +595,8 @@ HiveDataSink::maybeCreateBucketSortWriter(
       sortPool,
       &nonReclaimableSection_,
       &numSpillRuns_,
-      spillConfig_);
+      // TODO: enable spillling on sort buffer write later.
+      nullptr);
   return std::make_unique<dwio::common::SortingWriter>(
       std::move(writer), std::move(sortBuffer));
 }

--- a/velox/dwio/common/SortingWriter.cpp
+++ b/velox/dwio/common/SortingWriter.cpp
@@ -39,6 +39,8 @@ void SortingWriter::close() {
     output = sortBuffer_->getOutput();
   }
   outputWriter_->close();
+
+  sortBuffer_->pool()->release();
 }
 
 void SortingWriter::abort() {

--- a/velox/exec/SortBuffer.h
+++ b/velox/exec/SortBuffer.h
@@ -58,6 +58,10 @@ class SortBuffer {
   /// the rows from 'data_'.
   void spill(int64_t targetRows, int64_t targetBytes);
 
+  memory::MemoryPool* pool() const {
+    return pool_;
+  }
+
   /// Returns the spiller stats including total bytes and rows spilled so far.
   std::optional<SpillStats> spilledStats() const {
     if (spiller_ == nullptr) {


### PR DESCRIPTION
Disable spilling in bucket sort writer and turn it on after we have e2e
support.
Add unit test to verify spilling is not enabled.