### PR TITLE
Fix recursiveResizeChildren() in GroupingSet

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1136,9 +1136,8 @@ void recursiveResizeChildren(VectorPtr& vector, vector_size_t newSize) {
     for (auto& child : rowVector->children()) {
       recursiveResizeChildren(child, newSize);
     }
-  } else {
-    vector->resize(newSize);
   }
+  vector->resize(newSize);
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
GroupingSet::toIntermediate() calls recursiveResizeChildren() to resize
the result vector. When the result vector is a RowVecotr, however,
recursiveResizeChildren() doesn't resize the top-level vector. This can
cause the partial aggregation result being malformed when not all rows
are selected in GroupingSet::toIntermediate().

This diff fixes https://github.com/facebookincubator/velox/issues/7162, https://github.com/facebookincubator/velox/issues/7163, and https://github.com/facebookincubator/velox/issues/7202.

Reviewed By: kgpai

Differential Revision: D50617845


