### PR TITLE
Fix a race condition in memory pool reclaim

### DIFF
--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -729,7 +729,6 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimToOrderBy) {
 }
 
 TEST_F(SharedArbitrationTest, reclaimFromCompletedOrderBy) {
-  GTEST_SKIP() << "https://github.com/facebookincubator/velox/issues/7154";
   const int numVectors = 2;
   std::vector<RowVectorPtr> vectors;
   for (int i = 0; i < numVectors; ++i) {
@@ -1201,7 +1200,6 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimToAggregation) {
 }
 
 TEST_F(SharedArbitrationTest, reclaimFromCompletedAggregation) {
-  GTEST_SKIP() << "https://github.com/facebookincubator/velox/issues/7154";
   const int numVectors = 2;
   std::vector<RowVectorPtr> vectors;
   for (int i = 0; i < numVectors; ++i) {


### PR DESCRIPTION
MemoryReclaimer::reclaim doesn't hold the reader lock when visit the child
memory pool which can cause race condition if there is a concurrent update
to the child memory pool. This race caused reclaimFromCompletedAggregation
and reclaimFromCompletedOrderBy test flakiness.
This PR fix the issue by holding a reader lock while accessing the child memory
pools and verified with the previous flaky tests with 1000 runs in clion and meta
internal.