### PR TITLE
Optimize dictionary memoization in favor of memory

### DIFF
--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -3804,7 +3804,7 @@ TEST_F(HashJoinTest, memory) {
   params.queryCtx = std::make_shared<core::QueryCtx>(driverExecutor_.get());
   auto [taskCursor, rows] = readCursor(params, [](Task*) {});
   EXPECT_GT(3'500, params.queryCtx->pool()->stats().numAllocs);
-  EXPECT_GT(7'500'000, params.queryCtx->pool()->stats().cumulativeBytes);
+  EXPECT_GT(18'000'000, params.queryCtx->pool()->stats().cumulativeBytes);
 }
 
 TEST_F(HashJoinTest, lazyVectors) {

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1142,81 +1142,96 @@ void Expr::evalWithNulls(
   evalAll(rows, context, result);
 }
 
+// Optimization that attempts to cache results for inputs that are dictionary
+// encoded and use the same base vector between subsequent input batches. Since
+// this hold onto a reference to the base vector and the cached results, it can
+// be memory intensive. Therefore in order to reduce this consumption and ensure
+// it is only employed for cases where it can be useful, it only starts caching
+// result after it encounters the same base at least twice.
 void Expr::evalWithMemo(
     const SelectivityVector& rows,
     EvalCtx& context,
     VectorPtr& result) {
   VectorPtr base;
   distinctFields_[0]->evalSpecialForm(rows, context, base);
-  ++numCachableInput_;
-  if (baseDictionary_ == base) {
-    ++numCacheableRepeats_;
-    if (cachedDictionaryIndices_) {
-      LocalSelectivityVector cachedHolder(context, rows);
-      auto cached = cachedHolder.get();
-      VELOX_DCHECK(cached != nullptr);
-      cached->intersect(*cachedDictionaryIndices_);
-      if (cached->hasSelections()) {
-        context.ensureWritable(rows, type(), result);
-        result->copy(dictionaryCache_.get(), *cached, nullptr);
-      }
-    }
-    LocalSelectivityVector uncachedHolder(context, rows);
-    auto uncached = uncachedHolder.get();
-    VELOX_DCHECK(uncached != nullptr);
-    if (cachedDictionaryIndices_) {
-      uncached->deselect(*cachedDictionaryIndices_);
-    }
-    if (uncached->hasSelections()) {
-      // Fix finalSelection at "rows" if uncached rows is a strict subset to
-      // avoid losing values not in uncached rows that were copied earlier into
-      // "result" from the cached rows.
-      ScopedFinalSelectionSetter scopedFinalSelectionSetter(
-          context, &rows, uncached->countSelected() < rows.countSelected());
 
-      evalWithNulls(*uncached, context, result);
-      context.deselectErrors(*uncached);
-      context.exprSet()->addToMemo(this);
-      auto newCacheSize = uncached->end();
-
-      // dictionaryCache_ is valid only for cachedDictionaryIndices_. Hence, a
-      // safe call to BaseVector::ensureWritable must include all the rows not
-      // covered by cachedDictionaryIndices_. If BaseVector::ensureWritable is
-      // called only for a subset of rows not covered by
-      // cachedDictionaryIndices_, it will attempt to copy rows that are not
-      // valid leading to a crash.
-      LocalSelectivityVector allUncached(context, dictionaryCache_->size());
-      allUncached.get()->setAll();
-      allUncached.get()->deselect(*cachedDictionaryIndices_);
-      context.ensureWritable(*allUncached.get(), type(), dictionaryCache_);
-
-      if (cachedDictionaryIndices_->size() < newCacheSize) {
-        cachedDictionaryIndices_->resize(newCacheSize, false);
-      }
-
-      cachedDictionaryIndices_->select(*uncached);
-
-      // Resize the dictionaryCache_ to accommodate all the necessary rows.
-      if (dictionaryCache_->size() < uncached->end()) {
-        dictionaryCache_->resize(uncached->end());
-      }
-      dictionaryCache_->copy(result.get(), *uncached, nullptr);
-    }
-    context.releaseVector(base);
+  if (base.get() != baseOfDictionaryRawPtr_ ||
+      baseOfDictionaryWeakPtr_.expired()) {
+    baseOfDictionaryRepeats_ = 0;
+    baseOfDictionaryWeakPtr_ = base;
+    baseOfDictionaryRawPtr_ = base.get();
+    context.releaseVector(baseOfDictionary_);
+    context.releaseVector(dictionaryCache_);
+    evalWithNulls(rows, context, result);
     return;
   }
-  context.releaseVector(baseDictionary_);
-  baseDictionary_ = base;
-  evalWithNulls(rows, context, result);
+  ++baseOfDictionaryRepeats_;
 
-  context.releaseVector(dictionaryCache_);
-  dictionaryCache_ = result;
-  if (!cachedDictionaryIndices_) {
-    cachedDictionaryIndices_ =
-        context.execCtx()->getSelectivityVector(rows.end());
+  if (baseOfDictionaryRepeats_ == 1) {
+    evalWithNulls(rows, context, result);
+    baseOfDictionary_ = base;
+    dictionaryCache_ = result;
+    if (!cachedDictionaryIndices_) {
+      cachedDictionaryIndices_ =
+          context.execCtx()->getSelectivityVector(rows.end());
+    }
+    *cachedDictionaryIndices_ = rows;
+    context.deselectErrors(*cachedDictionaryIndices_);
+    return;
   }
-  *cachedDictionaryIndices_ = rows;
-  context.deselectErrors(*cachedDictionaryIndices_);
+
+  if (cachedDictionaryIndices_) {
+    LocalSelectivityVector cachedHolder(context, rows);
+    auto cached = cachedHolder.get();
+    VELOX_DCHECK(cached != nullptr);
+    cached->intersect(*cachedDictionaryIndices_);
+    if (cached->hasSelections()) {
+      context.ensureWritable(rows, type(), result);
+      result->copy(dictionaryCache_.get(), *cached, nullptr);
+    }
+  }
+  LocalSelectivityVector uncachedHolder(context, rows);
+  auto uncached = uncachedHolder.get();
+  VELOX_DCHECK(uncached != nullptr);
+  if (cachedDictionaryIndices_) {
+    uncached->deselect(*cachedDictionaryIndices_);
+  }
+  if (uncached->hasSelections()) {
+    // Fix finalSelection at "rows" if uncached rows is a strict subset to
+    // avoid losing values not in uncached rows that were copied earlier into
+    // "result" from the cached rows.
+    ScopedFinalSelectionSetter scopedFinalSelectionSetter(
+        context, &rows, uncached->countSelected() < rows.countSelected());
+
+    evalWithNulls(*uncached, context, result);
+    context.deselectErrors(*uncached);
+    context.exprSet()->addToMemo(this);
+    auto newCacheSize = uncached->end();
+
+    // dictionaryCache_ is valid only for cachedDictionaryIndices_. Hence, a
+    // safe call to BaseVector::ensureWritable must include all the rows not
+    // covered by cachedDictionaryIndices_. If BaseVector::ensureWritable is
+    // called only for a subset of rows not covered by
+    // cachedDictionaryIndices_, it will attempt to copy rows that are not
+    // valid leading to a crash.
+    LocalSelectivityVector allUncached(context, dictionaryCache_->size());
+    allUncached.get()->setAll();
+    allUncached.get()->deselect(*cachedDictionaryIndices_);
+    context.ensureWritable(*allUncached.get(), type(), dictionaryCache_);
+
+    if (cachedDictionaryIndices_->size() < newCacheSize) {
+      cachedDictionaryIndices_->resize(newCacheSize, false);
+    }
+
+    cachedDictionaryIndices_->select(*uncached);
+
+    // Resize the dictionaryCache_ to accommodate all the necessary rows.
+    if (dictionaryCache_->size() < uncached->end()) {
+      dictionaryCache_->resize(uncached->end());
+    }
+    dictionaryCache_->copy(result.get(), *uncached, nullptr);
+  }
+  context.releaseVector(base);
 }
 
 void Expr::setAllNulls(

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -159,14 +159,18 @@ class ExprTest : public testing::Test, public VectorTestBase {
   std::pair<VectorPtr, std::unordered_map<std::string, exec::ExprStats>>
   evaluateWithStats(const std::string& expression, const RowVectorPtr& input) {
     auto exprSet = compileExpression(expression, asRowType(input->type()));
+    return evaluateWithStats(exprSet.get(), input);
+  }
 
+  std::pair<VectorPtr, std::unordered_map<std::string, exec::ExprStats>>
+  evaluateWithStats(exec::ExprSet* exprSetPtr, const RowVectorPtr& input) {
     SelectivityVector rows(input->size());
     std::vector<VectorPtr> results(1);
 
-    exec::EvalCtx context(execCtx_.get(), exprSet.get(), input.get());
-    exprSet->eval(rows, context, results);
+    exec::EvalCtx context(execCtx_.get(), exprSetPtr, input.get());
+    exprSetPtr->eval(rows, context, results);
 
-    return {results[0], exprSet->stats()};
+    return {results[0], exprSetPtr->stats()};
   }
 
   template <
@@ -2062,7 +2066,10 @@ TEST_P(ParameterizedExprTest, rewriteInputs) {
   }
 }
 
-TEST_P(ParameterizedExprTest, memo) {
+TEST_F(ExprTest, memo) {
+  // Verify that dictionary memoization
+  // 1. correctly evaluates the unevaluated rows on subsequent runs
+  // 2. Only caches results if it encounters the same base twice
   auto base = makeArrayVector<int64_t>(
       1'000,
       [](auto row) { return row % 5 + 1; },
@@ -2074,24 +2081,55 @@ TEST_P(ParameterizedExprTest, memo) {
   auto rowType = ROW({"c0"}, {base->type()});
   auto exprSet = compileExpression("c0[1] = 1", rowType);
 
-  auto result = evaluate(
+  auto [result, stats] = evaluateWithStats(
       exprSet.get(), makeRowVector({wrapInDictionary(evenIndices, 100, base)}));
   auto expectedResult = makeFlatVector<bool>(
       100, [](auto row) { return (8 + row * 2) % 3 == 1; });
   assertEqualVectors(expectedResult, result);
+  VELOX_CHECK_EQ(stats["eq"].numProcessedRows, 100);
+  VELOX_CHECK(base.unique());
 
-  result = evaluate(
+  // After this results would be cached
+  std::tie(result, stats) = evaluateWithStats(
+      exprSet.get(), makeRowVector({wrapInDictionary(evenIndices, 100, base)}));
+  assertEqualVectors(expectedResult, result);
+  VELOX_CHECK_EQ(stats["eq"].numProcessedRows, 200);
+  VELOX_CHECK(!base.unique());
+
+  // Unevaluated rows are processed
+  std::tie(result, stats) = evaluateWithStats(
       exprSet.get(), makeRowVector({wrapInDictionary(oddIndices, 100, base)}));
   expectedResult = makeFlatVector<bool>(
       100, [](auto row) { return (9 + row * 2) % 3 == 1; });
   assertEqualVectors(expectedResult, result);
+  VELOX_CHECK_EQ(stats["eq"].numProcessedRows, 300);
+  VELOX_CHECK(!base.unique());
 
   auto everyFifth = makeIndices(100, [](auto row) { return row * 5; });
-  result = evaluate(
+  std::tie(result, stats) = evaluateWithStats(
       exprSet.get(), makeRowVector({wrapInDictionary(everyFifth, 100, base)}));
   expectedResult =
       makeFlatVector<bool>(100, [](auto row) { return (row * 5) % 3 == 1; });
   assertEqualVectors(expectedResult, result);
+  VELOX_CHECK_EQ(
+      stats["eq"].numProcessedRows,
+      360,
+      "Fewer rows expected as memoization should have kicked in.");
+  VELOX_CHECK(!base.unique());
+
+  // Create a new base
+  base = makeArrayVector<int64_t>(
+      1'000,
+      [](auto row) { return row % 5 + 1; },
+      [](auto row, auto index) { return (row % 3) + index; });
+
+  std::tie(result, stats) = evaluateWithStats(
+      exprSet.get(), makeRowVector({wrapInDictionary(oddIndices, 100, base)}));
+  expectedResult = makeFlatVector<bool>(
+      100, [](auto row) { return (9 + row * 2) % 3 == 1; });
+  assertEqualVectors(expectedResult, result);
+  VELOX_CHECK_EQ(stats["eq"].numProcessedRows, 460);
+  VELOX_CHECK(base.unique());
 }
 
 // This test triggers the situation when peelEncodings() produces an empty


### PR DESCRIPTION
We recently noticed that this optimization in expression evaluation
eagerly holds onto the base of the dictionary vector and the cached
results in anticipation that the next input vector might have the
same base. This additional memory can be held up unnecessarily in
cases where the input cannot take advantage of it. Therefore, with
this change we ensure that we only cache results if we encounter
the same base at least twice. Additionally, a strong reference to
the base is only held once results are cached. This is to ensure
that the vector held is not modified and re-used in-place.

Test Plan:
Modified additional unit testing.
A unit test in HashJoinTest was modified as it relied heavily of
memoization for saving memory but after this change the first
iteration for memoization is skipped so memory usage increases.
For reference, the cumulativeBytes without this change is 7'500'000,
memory with it is 16'777'216 and finally memory used if
memoization is completely turned off is 99'614'720