### PR TITLE
Fix flaky raceBetweenRaclaimAndJoinFinish

### DIFF
--- a/velox/exec/HashJoinBridge.cpp
+++ b/velox/exec/HashJoinBridge.cpp
@@ -14,18 +14,9 @@
  * limitations under the License.
  */
 
-#include <re2/re2.h>
-
 #include "velox/exec/HashJoinBridge.h"
 
 namespace facebook::velox::exec {
-namespace {
-bool isHashBuildMemoryPool(const memory::MemoryPool& pool) {
-  static const std::string re(".*HashBuild");
-  return RE2::FullMatch(pool.name(), re);
-}
-} // namespace
-
 void HashJoinBridge::start() {
   std::lock_guard<std::mutex> l(mutex_);
   started_ = true;
@@ -197,5 +188,9 @@ uint64_t HashJoinMemoryReclaimer::reclaim(
         return false;
       });
   return reclaimedBytes;
+}
+
+bool isHashBuildMemoryPool(const memory::MemoryPool& pool) {
+  return folly::StringPiece(pool.name()).endsWith("HashBuild");
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/HashJoinBridge.h
+++ b/velox/exec/HashJoinBridge.h
@@ -151,4 +151,8 @@ class HashJoinMemoryReclaimer final : public MemoryReclaimer {
  private:
   HashJoinMemoryReclaimer() : MemoryReclaimer() {}
 };
+
+/// Returns true if 'pool' is a hash build operator's memory pool. The check is
+/// currently based on the pool name.
+bool isHashBuildMemoryPool(const memory::MemoryPool& pool);
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/HashJoinBridgeTest.cpp
+++ b/velox/exec/tests/HashJoinBridgeTest.cpp
@@ -486,6 +486,33 @@ TEST_P(HashJoinBridgeTest, multiThreading) {
   }
 }
 
+TEST(HashJoinBridgeTest, isHashBuildMemoryPool) {
+  auto root =
+      memory::defaultMemoryManager().addRootPool("isHashBuildMemoryPool");
+  struct {
+    std::string poolName;
+    bool expectedHashBuildPool;
+
+    std::string debugString() const {
+      return fmt::format(
+          "poolName: {}, expectedHashBuildPool: {}",
+          poolName,
+          expectedHashBuildPool);
+    }
+  } testSettings[] = {
+      {"HashBuild", true},
+      {"HashBuildd", false},
+      {"hHashBuild", true},
+      {"hHashProbe", false},
+      {"HashProbe", false},
+      {"HashProbeh", false}};
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    const auto pool = root->addLeafChild(testData.poolName);
+    ASSERT_EQ(isHashBuildMemoryPool(*pool), testData.expectedHashBuildPool);
+  }
+}
+
 VELOX_INSTANTIATE_TEST_SUITE_P(
     HashJoinBridgeTest,
     HashJoinBridgeTest,


### PR DESCRIPTION
The flakiness is due to the fact that if the last hash build operator is the first
child build memory pool in its parent or not. The hash build pool's parent
memory pool has a customized memory reclaim which only reclaim from the
first encountered hash build memory pool as hash build operator do coordinated
memory reclaim. The child pool visit is based on the child memory pool list which
is fixed on creation. The flaky test is designed to let the last build operator to
finish (the driver is closed and removed from the task), and block the remaining
hash build operators and the do memory reclamation in expect to reproduce the
corner case that all the hash build operators are in wait for build state and the 
spiller are finalized. The test expect to see non-reclaimable counter to be set.

Given that if the last hash build is the first hash build pool in its parent pool's list,
then non-reclaimable counter  is zero, otherwise one.

This PR fixes this issue by checking whether the last build operator is the first hash
build pool and use the fact to check the test result. Run 100 times in clion and Meta
internal stress test.