### PR TITLE
Fail if compare null for complex type in array_sort

### DIFF
--- a/velox/docs/functions/presto/array.rst
+++ b/velox/docs/functions/presto/array.rst
@@ -148,19 +148,24 @@ Array Functions
 
     Returns an array which has the sorted order of the input array x. E must be
     an orderable type. Null elements will be placed at the end of the returned array.
-    Throws if compare nested null elements of complex type. ::
+    May throw if E is and ARRAY or ROW type and input values contain nested nulls.
+    Throws if deciding the order of elements would require comparing nested null values. ::
 
         SELECT array_sort(ARRAY [1, 2, 3]); -- [1, 2, 3]
         SELECT array_sort(ARRAY [3, 2, 1]); -- [1, 2, 3]
         SELECT array_sort(ARRAY [2, 1, NULL]; -- [1, 2, NULL]
         SELECT array_sort(ARRAY [NULL, 1, NULL]); -- [1, NULL, NULL]
         SELECT array_sort(ARRAY [NULL, 2, 1]); -- [1, 2, NULL]
+        SELECT array_sort(ARRAY [ARRAY [1, 2], ARRAY [2, null]]); -- [[1, 2], [2, null]]
+        SELECT array_sort(ARRAY [ARRAY [1, 2], ARRAY [1, null]]); -- failed: array_sort contains nested nulls not supported for comparison
 
 .. function:: array_sort(array(T), function(T,U)) -> array(T)
 
     Returns the array sorted by values computed using specified lambda in ascending
     order. U must be an orderable type. Null elements will be placed at the end of
-    the returned array. Throws if compare nested null elements of complex type. ::
+    the returned array. May throw if E is and ARRAY or ROW type and input values contain
+    nested nulls. Throws if deciding the order of elements would require comparing nested
+    null values. ::
 
         SELECT array_sort(ARRAY ['cat', 'leopard', 'mouse'], x -> length(x)); -- ['cat', 'mouse', 'leopard']
 
@@ -168,19 +173,24 @@ Array Functions
 
     Returns the array sorted in the descending order. E must be an orderable type.
     Null elements will be placed at the end of the returned array.
-    Throws if compare nested null elements of complex type. ::
+    May throw if E is and ARRAY or ROW type and input values contain nested nulls.
+    Throws if deciding the order of elements would require comparing nested null values. ::
 
         SELECT array_sort_desc(ARRAY [1, 2, 3]); -- [3, 2, 1]
         SELECT array_sort_desc(ARRAY [3, 2, 1]); -- [3, 2, 1]
         SELECT array_sort_desc(ARRAY [2, 1, NULL]; -- [2, 1, NULL]
         SELECT array_sort_desc(ARRAY [NULL, 1, NULL]); -- [1, NULL, NULL]
         SELECT array_sort_desc(ARRAY [NULL, 2, 1]); -- [2, 1, NULL]
+        SELECT array_sort(ARRAY [ARRAY [1, 2], ARRAY [2, null]]); -- [[1, 2], [2, null]]
+        SELECT array_sort(ARRAY [ARRAY [1, 2], ARRAY [1, null]]); -- failed: array_sort contains nested nulls not supported for comparison
 
 .. function:: array_sort_desc(array(T), function(T,U)) -> array(T)
 
     Returns the array sorted by values computed using specified lambda in descending
     order. U must be an orderable type. Null elements will be placed at the end of
-    the returned array. Throws if compare nested null elements of complex type. ::
+    the returned array. May throw if E is and ARRAY or ROW type and input values contain
+    nested nulls. Throws if deciding the order of elements would require comparing nested
+    null values. ::
 
         SELECT array_sort_desc(ARRAY ['cat', 'leopard', 'mouse'], x -> length(x)); -- ['leopard', 'mouse', 'cat']
 

--- a/velox/docs/functions/presto/array.rst
+++ b/velox/docs/functions/presto/array.rst
@@ -147,7 +147,8 @@ Array Functions
 .. function:: array_sort(array(E)) -> array(E)
 
     Returns an array which has the sorted order of the input array x. E must be
-    an orderable type. Null elements will be placed at the end of the returned array.::
+    an orderable type. Null elements will be placed at the end of the returned array.
+    Throws if compare nested null elements of complex type. ::
 
         SELECT array_sort(ARRAY [1, 2, 3]); -- [1, 2, 3]
         SELECT array_sort(ARRAY [3, 2, 1]); -- [1, 2, 3]
@@ -159,14 +160,15 @@ Array Functions
 
     Returns the array sorted by values computed using specified lambda in ascending
     order. U must be an orderable type. Null elements will be placed at the end of
-    the returned array. ::
+    the returned array. Throws if compare nested null elements of complex type. ::
 
         SELECT array_sort(ARRAY ['cat', 'leopard', 'mouse'], x -> length(x)); -- ['cat', 'mouse', 'leopard']
 
 .. function:: array_sort_desc(array(E)) -> array(E)
 
     Returns the array sorted in the descending order. E must be an orderable type.
-    Null elements will be placed at the end of the returned array.::
+    Null elements will be placed at the end of the returned array.
+    Throws if compare nested null elements of complex type. ::
 
         SELECT array_sort_desc(ARRAY [1, 2, 3]); -- [3, 2, 1]
         SELECT array_sort_desc(ARRAY [3, 2, 1]); -- [3, 2, 1]
@@ -178,7 +180,7 @@ Array Functions
 
     Returns the array sorted by values computed using specified lambda in descending
     order. U must be an orderable type. Null elements will be placed at the end of
-    the returned array. ::
+    the returned array. Throws if compare nested null elements of complex type. ::
 
         SELECT array_sort_desc(ARRAY ['cat', 'leopard', 'mouse'], x -> length(x)); -- ['leopard', 'mouse', 'cat']
 

--- a/velox/functions/prestosql/ArraySort.cpp
+++ b/velox/functions/prestosql/ArraySort.cpp
@@ -61,6 +61,10 @@ BufferPtr sortElements(
         rawIndices + offset,
         rawIndices + offset + size,
         [&](vector_size_t& a, vector_size_t& b) {
+          if (a == b) {
+            return false;
+          }
+
           bool aNull = decodedElements->isNullAt(a);
           bool bNull = decodedElements->isNullAt(b);
           if (aNull) {

--- a/velox/functions/prestosql/ArraySort.cpp
+++ b/velox/functions/prestosql/ArraySort.cpp
@@ -31,7 +31,8 @@ BufferPtr sortElements(
     const ArrayVector& inputArray,
     const BaseVector& inputElements,
     bool ascending,
-    exec::EvalCtx& context) {
+    exec::EvalCtx& context,
+    bool throwOnNestedNull) {
   const SelectivityVector inputElementRows =
       toElementRows(inputElements.size(), rows, &inputArray);
   exec::LocalDecodedVector decodedElements(
@@ -42,7 +43,11 @@ BufferPtr sortElements(
   BufferPtr indices = allocateIndices(inputElements.size(), context.pool());
   vector_size_t* rawIndices = indices->asMutable<vector_size_t>();
 
-  const CompareFlags flags{.nullsFirst = false, .ascending = ascending};
+  CompareFlags flags{.nullsFirst = false, .ascending = ascending};
+  if (throwOnNestedNull) {
+    flags.nullHandlingMode = CompareFlags::NullHandlingMode::StopAtNull;
+  }
+
   auto decodedIndices = decodedElements->indices();
 
   rows.applyToSelected([&](vector_size_t row) {
@@ -64,11 +69,16 @@ BufferPtr sortElements(
           if (bNull) {
             return true;
           }
-          return baseElementsVector->compare(
-                     baseElementsVector,
-                     decodedIndices[a],
-                     decodedIndices[b],
-                     flags) < 0;
+
+          std::optional<int32_t> result = baseElementsVector->compare(
+              baseElementsVector, decodedIndices[a], decodedIndices[b], flags);
+
+          VELOX_USER_CHECK(
+              result.has_value(),
+              "{} comparison not supported for values that contain nulls",
+              mapTypeKindToName(baseElementsVector->typeKind()));
+
+          return result.value() < 0;
         });
   });
 
@@ -80,10 +90,11 @@ void applyComplexType(
     ArrayVector* inputArray,
     bool ascending,
     exec::EvalCtx& context,
-    VectorPtr& resultElements) {
+    VectorPtr& resultElements,
+    bool throwOnNestedNull) {
   auto inputElements = inputArray->elements();
-  auto indices =
-      sortElements(rows, *inputArray, *inputElements, ascending, context);
+  auto indices = sortElements(
+      rows, *inputArray, *inputElements, ascending, context, throwOnNestedNull);
   resultElements = BaseVector::transpose(indices, std::move(inputElements));
 }
 
@@ -193,7 +204,8 @@ class ArraySortFunction : public exec::VectorFunction {
   /// and 'offsets' vectors that control where output arrays start and end
   /// remain the same in the output ArrayVector.
 
-  explicit ArraySortFunction(bool ascending) : ascending_{ascending} {}
+  explicit ArraySortFunction(bool ascending, bool throwOnNestedNull)
+      : ascending_{ascending}, throwOnNestedNull_(throwOnNestedNull) {}
 
   // Execute function.
   void apply(
@@ -244,7 +256,13 @@ class ArraySortFunction : public exec::VectorFunction {
           resultElements);
 
     } else {
-      applyComplexType(rows, inputArray, ascending_, context, resultElements);
+      applyComplexType(
+          rows,
+          inputArray,
+          ascending_,
+          context,
+          resultElements,
+          throwOnNestedNull_);
     }
 
     return std::make_shared<ArrayVector>(
@@ -259,11 +277,13 @@ class ArraySortFunction : public exec::VectorFunction {
   }
 
   const bool ascending_;
+  const bool throwOnNestedNull_;
 };
 
 class ArraySortLambdaFunction : public exec::VectorFunction {
  public:
-  explicit ArraySortLambdaFunction(bool ascending) : ascending_{ascending} {}
+  explicit ArraySortLambdaFunction(bool ascending, bool throwOnNestedNull)
+      : ascending_{ascending}, throwOnNestedNull_(throwOnNestedNull) {}
 
   void apply(
       const SelectivityVector& rows,
@@ -309,8 +329,13 @@ class ArraySortLambdaFunction : public exec::VectorFunction {
     }
 
     // Sort 'newElements'.
-    auto indices =
-        sortElements(rows, *flatArray, *newElements, ascending_, context);
+    auto indices = sortElements(
+        rows,
+        *flatArray,
+        *newElements,
+        ascending_,
+        context,
+        throwOnNestedNull_);
     auto sortedElements = BaseVector::wrapInDictionary(
         nullptr, indices, newNumElements, flatArray->elements());
 
@@ -330,42 +355,51 @@ class ArraySortLambdaFunction : public exec::VectorFunction {
 
  private:
   const bool ascending_;
+  const bool throwOnNestedNull_;
 };
 
 // Create function template based on type.
 template <TypeKind kind>
 std::shared_ptr<exec::VectorFunction> createTyped(
     const std::vector<exec::VectorFunctionArg>& inputArgs,
-    bool ascending) {
+    bool ascending,
+    bool throwOnNestedNull = true) {
   VELOX_CHECK_EQ(inputArgs.size(), 1);
-  return std::make_shared<ArraySortFunction<kind>>(ascending);
+  return std::make_shared<ArraySortFunction<kind>>(
+      ascending, throwOnNestedNull);
 }
 
 // Create function.
 std::shared_ptr<exec::VectorFunction> create(
     const std::vector<exec::VectorFunctionArg>& inputArgs,
-    bool ascending) {
+    bool ascending,
+    bool throwOnNestedNull = true) {
   if (inputArgs.size() == 2) {
-    return std::make_shared<ArraySortLambdaFunction>(ascending);
+    return std::make_shared<ArraySortLambdaFunction>(
+        ascending, throwOnNestedNull);
   }
 
   auto elementType = inputArgs.front().type->childAt(0);
   return VELOX_DYNAMIC_TYPE_DISPATCH(
-      createTyped, elementType->kind(), inputArgs, ascending);
+      createTyped,
+      elementType->kind(),
+      inputArgs,
+      ascending,
+      throwOnNestedNull);
 }
 
 std::shared_ptr<exec::VectorFunction> createAsc(
     const std::string& /* name */,
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& /*config*/) {
-  return create(inputArgs, true);
+  return create(inputArgs, true, true);
 }
 
 std::shared_ptr<exec::VectorFunction> createDesc(
     const std::string& /* name */,
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& /*config*/) {
-  return create(inputArgs, false);
+  return create(inputArgs, false, true);
 }
 
 // Define function signature.
@@ -411,6 +445,13 @@ internalCanonicalizeSignatures() {
           .argumentType("array(T)")
           .build()};
   return signatures;
+}
+
+std::shared_ptr<exec::VectorFunction> createAscNoThrowOnNestedNull(
+    const std::string& /* name */,
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    const core::QueryConfig& /*config*/) {
+  return create(inputArgs, true, false);
 }
 
 core::CallTypedExprPtr asArraySortCall(
@@ -487,6 +528,6 @@ VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
 VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
     udf_$internal$canonicalize,
     internalCanonicalizeSignatures(),
-    createAsc);
+    createAscNoThrowOnNestedNull);
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/aggregates/tests/ArrayAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ArrayAggTest.cpp
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/dwio/common/tests/utils/BatchMaker.h"
+
 #include "velox/exec/tests/SimpleAggregateFunctionsRegistration.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
-#include "velox/exec/tests/utils/Cursor.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
@@ -36,9 +35,9 @@ class ArrayAggTest : public AggregationTestBase {
     registerSimpleArrayAggAggregate("simple_array_agg");
   }
 
-  RowVectorPtr fuzzFlatBatch(const RowTypePtr& rowType) {
+  RowVectorPtr fuzzFlat(const RowTypePtr& rowType, size_t size) {
     VectorFuzzer::Options options;
-    options.vectorSize = 1'00;
+    options.vectorSize = size;
     VectorFuzzer fuzzer(options, pool());
     return fuzzer.fuzzInputFlatRow(rowType);
   }
@@ -62,7 +61,7 @@ TEST_F(ArrayAggTest, groupBy) {
     // elements with, for key k, batch[k[, batch[k + 10], ... batch[k +
     // 90], repeated 10 times.
     batches.push_back(
-        fuzzFlatBatch(ROW({"c0", "a"}, {INTEGER(), ARRAY(VARCHAR())})));
+        fuzzFlat(ROW({"c0", "a"}, {INTEGER(), ARRAY(VARCHAR())}), 100));
     // We divide the rows into 10 groups.
     auto keys = batches[0]->childAt(0)->as<FlatVector<int32_t>>();
     auto values = batches[0]->childAt(1)->as<ArrayVector>();


### PR DESCRIPTION
In Presto, `array_sort` applied to arrays of complex types with nested
nulls may or may not fail depending on whether the sorting logic
needs to compare the nulls to decide the order. 

```SQL
presto> SELECT array_sort(col0) FROM ( VALUES (array [array [1, 2, 3, 4],
array [2, null, 3]])) AS t(col0);
            _col0
------------------------------
 [[1, 2, 3, 4], [2, null, 3]]

presto> SELECT array_sort(col0) FROM ( VALUES (array [array [1, 2, 3, 4], 
array [1, null, 3]])) AS t(col0);

Query 20230925_113531_00074_6r5h7 failed: 
Array contains elements not supported for comparison
```

This PR checks for contains-nulls only during complex type
comparison (Presto's implementation). Add a throwOnNestedNullCompare
flag to distinguish the normal `array_sort[_desc]` function and
the internal canonicalize function `$internal$canonicalize` introduced in #6928,
which would use `NoStop` null-handling mode to compare and not throw.

Resolve https://github.com/facebookincubator/velox/issues/6713