### PR TITLE
Restrict input to orderable types in min/max/min_by/max_by

### DIFF
--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -91,6 +91,7 @@ General Aggregate Functions
 .. function:: max_by(x, y) -> [same as x]
 
     Returns the value of ``x`` associated with the maximum value of ``y`` over all input values.
+    ``y`` must be an orderable type.
 
 .. function:: max_by(x, y, n) -> array([same as x])
     :noindex:
@@ -100,6 +101,7 @@ General Aggregate Functions
 .. function:: min_by(x, y) -> [same as x]
 
     Returns the value of ``x`` associated with the minimum value of ``y`` over all input values.
+    ``y`` must be an orderable type.
 
 .. function:: min_by(x, y, n) -> array([same as x])
     :noindex:
@@ -110,6 +112,7 @@ General Aggregate Functions
 
     Returns the maximum value of all input values.
     ``x`` must not contain nulls when it is complex type.
+    ``x`` must be an orderable type.
 
 .. function:: max(x, n) -> array<[same as x]>
     :noindex:
@@ -121,6 +124,7 @@ General Aggregate Functions
 
     Returns the minimum value of all input values.
     ``x`` must not contain nulls when it is complex type.
+    ``x`` must be an orderable type.
 
 .. function:: min(x, n) -> array<[same as x]>
     :noindex:

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -907,7 +907,7 @@ template <
 exec::AggregateRegistrationResult registerMinMax(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   signatures.push_back(exec::AggregateFunctionSignatureBuilder()
-                           .typeVariable("T")
+                           .orderableTypeVariable("T")
                            .returnType("T")
                            .intermediateType("T")
                            .argumentType("T")

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -1107,7 +1107,7 @@ exec::AggregateRegistrationResult registerMinMaxBy(const std::string& name) {
   // V, C -> row(V, C) -> V.
   signatures.push_back(exec::AggregateFunctionSignatureBuilder()
                            .typeVariable("V")
-                           .typeVariable("C")
+                           .orderableTypeVariable("C")
                            .returnType("V")
                            .intermediateType("row(V,C)")
                            .argumentType("V")


### PR DESCRIPTION
In Presto, input to `min/max/min_by/max_by` is restricted to
orderable types. For example, MAP type is not orderable.

This PR uses the orderableTypeVariable to apply the restriction
to the input argument of `min/max/min_by/max_by`. 

Resolve https://github.com/facebookincubator/velox/issues/6718