### PR TITLE
Avoid reading index stream before loading

### DIFF
--- a/velox/dwio/common/BufferedInput.cpp
+++ b/velox/dwio/common/BufferedInput.cpp
@@ -97,7 +97,13 @@ std::unique_ptr<SeekableInputStream> BufferedInput::enqueue(
       // Save "i", the position in which this region was enqueued. This will
       // help faster lookup using enqueuedToBufferOffset_ later.
       [region, this, i = regions_.size() - 1]() {
-        return readInternal(region.offset, region.length, i);
+        auto result = readInternal(region.offset, region.length, i);
+        VELOX_CHECK(
+            std::get<1>(result) != MAX_UINT64,
+            "Fail to read region offset={} length={}",
+            region.offset,
+            region.length);
+        return result;
       });
 }
 

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
@@ -65,8 +65,6 @@ SelectiveStringDictionaryColumnReader::SelectiveStringDictionaryColumnReader(
       params.streamLabels().label(),
       false);
   if (inDictStream) {
-    formatData_->as<DwrfData>().ensureRowGroupIndex();
-
     inDictionaryReader_ =
         createBooleanRleDecoder(std::move(inDictStream), encodingKey);
 


### PR DESCRIPTION
Summary:
In `SelectiveStringDictionaryColumnReader`, we read the row group index
stream in constructor by mistake.  This caused failed reading when
`BufferedInput` is used (`CachedBufferedInput` would work but performance is
suboptimal).  The row group index is already ensured to be loaded in
`SelectiveStringDictionaryColumnReader::ensureInitialized` which is the right
time for it to happen (after loading).

Differential Revision: D50658787


