### PR TITLE
Introduce VeloxPersistentUserError exception and VELOX_USER_ABORT macros

### DIFF
--- a/velox/common/base/Exceptions.cpp
+++ b/velox/common/base/Exceptions.cpp
@@ -22,6 +22,7 @@ namespace detail {
 
 DEFINE_CHECK_FAIL_TEMPLATES(::facebook::velox::VeloxRuntimeError);
 DEFINE_CHECK_FAIL_TEMPLATES(::facebook::velox::VeloxUserError);
+DEFINE_CHECK_FAIL_TEMPLATES(::facebook::velox::VeloxPersistentUserError);
 
 } // namespace detail
 } // namespace velox

--- a/velox/common/base/VeloxException.cpp
+++ b/velox/common/base/VeloxException.cpp
@@ -78,22 +78,27 @@ VeloxException::VeloxException(
     std::string_view errorCode,
     bool isRetriable,
     Type exceptionType,
-    std::string_view exceptionName)
-    : VeloxException(State::make(exceptionType, [&](auto& state) {
-        state.exceptionType = exceptionType;
-        state.exceptionName = exceptionName;
-        state.file = file;
-        state.line = line;
-        state.function = function;
-        state.failingExpression = failingExpression;
-        state.message = message;
-        state.errorSource = errorSource;
-        state.errorCode = errorCode;
-        state.context = getExceptionContext().message(exceptionType);
-        state.topLevelContext =
-            getTopLevelExceptionContextString(exceptionType, state.context);
-        state.isRetriable = isRetriable;
-      })) {}
+    std::string_view exceptionName,
+    bool suppressedByTry)
+    : VeloxException(
+          State::make(
+              exceptionType,
+              [&](auto& state) {
+                state.exceptionType = exceptionType;
+                state.exceptionName = exceptionName;
+                state.file = file;
+                state.line = line;
+                state.function = function;
+                state.failingExpression = failingExpression;
+                state.message = message;
+                state.errorSource = errorSource;
+                state.errorCode = errorCode;
+                state.context = getExceptionContext().message(exceptionType);
+                state.topLevelContext = getTopLevelExceptionContextString(
+                    exceptionType, state.context);
+                state.isRetriable = isRetriable;
+              }),
+          suppressedByTry) {}
 
 VeloxException::VeloxException(
     const std::exception_ptr& e,
@@ -102,23 +107,26 @@ VeloxException::VeloxException(
     std::string_view errorCode,
     bool isRetriable,
     Type exceptionType,
-    std::string_view exceptionName)
-    : VeloxException(State::make([&](auto& state) {
-        state.exceptionType = exceptionType;
-        state.exceptionName = exceptionName;
-        state.file = "UNKNOWN";
-        state.line = 0;
-        state.function = "";
-        state.failingExpression = "";
-        state.message = message;
-        state.errorSource = errorSource;
-        state.errorCode = errorCode;
-        state.context = getExceptionContext().message(exceptionType);
-        state.topLevelContext =
-            getTopLevelExceptionContextString(exceptionType, state.context);
-        state.isRetriable = isRetriable;
-        state.wrappedException = e;
-      })) {}
+    std::string_view exceptionName,
+    bool suppressedByTry)
+    : VeloxException(
+          State::make([&](auto& state) {
+            state.exceptionType = exceptionType;
+            state.exceptionName = exceptionName;
+            state.file = "UNKNOWN";
+            state.line = 0;
+            state.function = "";
+            state.failingExpression = "";
+            state.message = message;
+            state.errorSource = errorSource;
+            state.errorCode = errorCode;
+            state.context = getExceptionContext().message(exceptionType);
+            state.topLevelContext =
+                getTopLevelExceptionContextString(exceptionType, state.context);
+            state.isRetriable = isRetriable;
+            state.wrappedException = e;
+          }),
+          suppressedByTry) {}
 
 namespace {
 

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -174,7 +174,7 @@ void CastExpr::applyToSelectedNoThrowLocal(
       try {
         func(row);
       } catch (const VeloxException& e) {
-        if (!e.isUserError()) {
+        if (!e.suppressedByTry()) {
           throw;
         }
         // Avoid double throwing.
@@ -506,7 +506,7 @@ void CastExpr::applyCastPrimitives(
             row, context, inputSimpleVector, resultFlatVector);
 
       } catch (const VeloxException& ue) {
-        if (!ue.isUserError()) {
+        if (!ue.suppressedByTry()) {
           throw;
         }
         setError(row, ue.message());
@@ -521,7 +521,7 @@ void CastExpr::applyCastPrimitives(
         applyCastKernel<ToKind, FromKind, true /*truncate*/>(
             row, context, inputSimpleVector, resultFlatVector);
       } catch (const VeloxException& ue) {
-        if (!ue.isUserError()) {
+        if (!ue.suppressedByTry()) {
           throw;
         }
         setError(row, ue.message());

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -53,7 +53,7 @@ VectorPtr CastExpr::castFromDate(
           std::memcpy(writer.data(), output.data(), output.size());
           writer.finalize();
         } catch (const VeloxException& ue) {
-          if (!ue.isUserError()) {
+          if (!ue.suppressedByTry()) {
             throw;
           }
           VELOX_USER_FAIL(

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -104,11 +104,12 @@ class EvalCtx {
       try {
         func(row);
       } catch (const VeloxException& e) {
-        if (!e.isUserError()) {
+        if (!e.suppressedByTry()) {
           throw;
         }
         // Avoid double throwing.
         setVeloxExceptionError(row, std::current_exception());
+
       } catch (const std::exception& e) {
         setError(row, std::current_exception());
       }

--- a/velox/expression/tests/EvalCtxTest.cpp
+++ b/velox/expression/tests/EvalCtxTest.cpp
@@ -221,3 +221,23 @@ TEST_F(EvalCtxTest, localSingleRow) {
     }
   }
 }
+
+TEST_F(EvalCtxTest, applyToSelectedNoThrow) {
+  EvalCtx context(&execCtx_);
+  *context.mutableThrowOnError() = true;
+  EXPECT_THROW(
+      (context.applyToSelectedNoThrow(
+          SelectivityVector(10), [&](auto row) { VELOX_USER_FAIL("fail"); })),
+      VeloxUserError);
+  *context.mutableThrowOnError() = false;
+  EXPECT_NO_THROW((context.applyToSelectedNoThrow(
+      SelectivityVector(10), [&](auto row) { VELOX_USER_FAIL("fail"); })));
+  EXPECT_THROW(
+      (context.applyToSelectedNoThrow(
+          SelectivityVector(10), [&](auto row) { VELOX_USER_ABORT("fail"); })),
+      VeloxPersistentUserError);
+  EXPECT_THROW(
+      (context.applyToSelectedNoThrow(
+          SelectivityVector(10), [&](auto row) { VELOX_FAIL("fail"); })),
+      VeloxRuntimeError);
+}

--- a/velox/functions/prestosql/types/JsonType.cpp
+++ b/velox/functions/prestosql/types/JsonType.cpp
@@ -772,7 +772,7 @@ void castFromJson(
         try {
           castFromJsonTyped<kind>(object, writer.current());
         } catch (const VeloxException& ve) {
-          if (!ve.isUserError()) {
+          if (!ve.suppressedByTry()) {
             throw;
           }
           writer.commitNull();


### PR DESCRIPTION
Summary:
Not all user errors should be suppressed by try expression, some errors are not Velox runtime errors
but are not meant to  be suppressed by try expression.

Right now we do not have a way to express them this PR add VeloxPersistentUserError which
represent such errors. and VELOX_USER_ABORT.. that can be used to throw them.

Differential Revision: D50661338


