### PR TITLE
Rename skip(int64_t) to SkipInt64

### DIFF
--- a/velox/dwio/common/CacheInputStream.cpp
+++ b/velox/dwio/common/CacheInputStream.cpp
@@ -105,7 +105,7 @@ void CacheInputStream::BackUp(int32_t count) {
   position_ -= unsignedCount;
 }
 
-bool CacheInputStream::skip(int64_t count) {
+bool CacheInputStream::SkipInt64(int64_t count) {
   if (count < 0) {
     return false;
   }

--- a/velox/dwio/common/CacheInputStream.h
+++ b/velox/dwio/common/CacheInputStream.h
@@ -42,7 +42,7 @@ class CacheInputStream : public SeekableInputStream {
 
   bool Next(const void** data, int* size) override;
   void BackUp(int count) override;
-  bool skip(int64_t count) override;
+  bool SkipInt64(int64_t count) override;
   google::protobuf::int64 ByteCount() const override;
   void seekToPosition(PositionProvider& position) override;
   std::string getName() const override;

--- a/velox/dwio/common/SeekableInputStream.cpp
+++ b/velox/dwio/common/SeekableInputStream.cpp
@@ -147,7 +147,7 @@ void SeekableArrayInputStream::BackUp(int32_t count) {
   }
 }
 
-bool SeekableArrayInputStream::skip(int64_t count) {
+bool SeekableArrayInputStream::SkipInt64(int64_t count) {
   loadIfAvailable();
 
   if (count >= 0) {
@@ -230,7 +230,7 @@ void SeekableFileInputStream::BackUp(int32_t signedCount) {
   position -= pushBack;
 }
 
-bool SeekableFileInputStream::skip(int64_t signedCount) {
+bool SeekableFileInputStream::SkipInt64(int64_t signedCount) {
   if (signedCount < 0) {
     return false;
   }

--- a/velox/dwio/common/SeekableInputStream.h
+++ b/velox/dwio/common/SeekableInputStream.h
@@ -57,10 +57,10 @@ class SeekableInputStream : public google::protobuf::io::ZeroCopyInputStream {
   // ORC/DWRF stream address.
   virtual size_t positionSize() = 0;
 
-  virtual bool skip(int64_t count) = 0;
+  virtual bool SkipInt64(int64_t count) = 0;
 
   bool Skip(int32_t count) final override {
-    return skip(count);
+    return SkipInt64(count);
   }
 
   void readFully(char* buffer, size_t bufferSize);
@@ -102,7 +102,7 @@ class SeekableArrayInputStream : public SeekableInputStream {
   ~SeekableArrayInputStream() override = default;
   virtual bool Next(const void** data, int32_t* size) override;
   virtual void BackUp(int32_t count) override;
-  virtual bool skip(int64_t count) override;
+  virtual bool SkipInt64(int64_t count) override;
   virtual google::protobuf::int64 ByteCount() const override;
   virtual void seekToPosition(PositionProvider& position) override;
   virtual std::string getName() const override;
@@ -136,7 +136,7 @@ class SeekableFileInputStream : public SeekableInputStream {
 
   virtual bool Next(const void** data, int32_t* size) override;
   virtual void BackUp(int32_t count) override;
-  virtual bool skip(int64_t count) override;
+  virtual bool SkipInt64(int64_t count) override;
   virtual google::protobuf::int64 ByteCount() const override;
   virtual void seekToPosition(PositionProvider& position) override;
   virtual std::string getName() const override;

--- a/velox/dwio/common/compression/PagedInputStream.cpp
+++ b/velox/dwio/common/compression/PagedInputStream.cpp
@@ -258,7 +258,7 @@ bool PagedInputStream::skipAllPending() {
   return true;
 }
 
-bool PagedInputStream::skip(int64_t count) {
+bool PagedInputStream::SkipInt64(int64_t count) {
   VELOX_CHECK_GE(count, 0);
   pendingSkip_ += count;
   // We never use the return value of this function so this is OK.

--- a/velox/dwio/common/compression/PagedInputStream.h
+++ b/velox/dwio/common/compression/PagedInputStream.h
@@ -54,7 +54,7 @@ class PagedInputStream : public dwio::common::SeekableInputStream {
   void BackUp(int32_t count) override;
 
   // NOTE: This always returns true.
-  bool skip(int64_t count) override;
+  bool SkipInt64(int64_t count) override;
 
   google::protobuf::int64 ByteCount() const override {
     return bytesReturned_ + pendingSkip_;

--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -1666,7 +1666,7 @@ uint64_t StringDirectColumnReader::skip(uint64_t numValues) {
     totalBytes += computeSize(buffer.data(), nullptr, step);
     done += step;
   }
-  blobStream->skip(static_cast<int64_t>(totalBytes));
+  blobStream->SkipInt64(static_cast<int64_t>(totalBytes));
   return numValues;
 }
 

--- a/velox/dwio/dwrf/test/TestDecompression.cpp
+++ b/velox/dwio/dwrf/test/TestDecompression.cpp
@@ -1015,7 +1015,7 @@ class TestingSeekableInputStream : public SeekableInputStream {
     position_ -= count;
   }
 
-  bool skip(int64_t count) override {
+  bool SkipInt64(int64_t count) override {
     VELOX_CHECK_LE(count + position_, length_);
     position_ += count;
     return true;


### PR DESCRIPTION
Summary:
Addressing open source comment that I neglected in the below diff. I think the reasoning for the comment is sound.

https://github.com/facebookincubator/velox/pull/7178?fbclid=IwAR3OMRtLS6ugbMDbuNE4yPJHMEpfnmlppdPMJ5HHblF0_A0mLk-apHcBtrs#discussion_r1367994787

Reviewed By: Yuhta

Differential Revision: D50667115


