### PR TITLE
Avoid server crash caused by catching data sink abort error

### DIFF
--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -17,19 +17,20 @@
 #include "velox/connectors/hive/HiveDataSink.h"
 
 #include "velox/common/base/Fs.h"
+#include "velox/common/testutil/TestValue.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HivePartitionFunction.h"
+#include "velox/connectors/hive/TableHandle.h"
 #include "velox/core/ITypedExpr.h"
 #include "velox/dwio/common/SortingWriter.h"
-#include "velox/exec/SortBuffer.h"
-
-#include "velox/connectors/hive/TableHandle.h"
 #include "velox/exec/OperatorUtils.h"
+#include "velox/exec/SortBuffer.h"
 
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
+using facebook::velox::common::testutil::TestValue;
 namespace facebook::velox::connector::hive {
 
 namespace {
@@ -444,6 +445,8 @@ std::shared_ptr<memory::MemoryPool> HiveDataSink::createWriterPool(
 }
 
 std::vector<std::string> HiveDataSink::close(bool success) {
+  TestValue::adjust(
+      "facebook::velox::connector::hive::HiveDataSink::close", this);
   closeInternal(!success);
   if (!success) {
     VELOX_CHECK(aborted_);

--- a/velox/dwio/dwrf/writer/WriterSink.h
+++ b/velox/dwio/dwrf/writer/WriterSink.h
@@ -54,7 +54,8 @@ class WriterSink {
 
   ~WriterSink() {
     if (!buffers_.empty() || size_ != 0) {
-      LOG(WARNING) << "Unflushed data in writer sink!";
+      LOG(WARNING) << "Unflushed data in writer sink: " << succinctBytes(size_)
+                   << ", " << buffers_.size() << " buffers";
     }
   }
 

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -95,7 +95,12 @@ void TableWriter::abortDataSink() {
   VELOX_CHECK(!closed_);
   auto abortGuard = folly::makeGuard([this]() { closed_ = true; });
   if (dataSink_ != nullptr) {
-    dataSink_->close(false);
+    try {
+      dataSink_->close(false);
+    } catch (const std::exception& e) {
+      LOG(WARNING) << "Failed to abort data sink from table writer: "
+                   << toString() << ", error: " << e.what();
+    }
   }
 }
 


### PR DESCRIPTION
In Meta internal test, table writer failed with remote storage write failure.
Table writer close in this case will abort the data sink underneath which 
tries to close file sink. The file sink close to remote storage will also fail
as the file handle has already run into error. The file sink close error will
throw which cause crash as the table writer close is called from CancelGuard
destructor in driver framework. Throw in object destructor will cause
program crash.
The fix is to catch the abort data sink error with a warning log as the table
writer has already failed. We can just skip the data sink error. Unit test is added
to reproduce and verify the fix.