### PR TITLE
Fix TSAN race if testing with DWRF parallel decoding

### DIFF
--- a/velox/dwio/common/encryption/TestProvider.h
+++ b/velox/dwio/common/encryption/TestProvider.h
@@ -58,7 +58,7 @@ class TestEncryption {
 
  private:
   std::string key_;
-  mutable size_t count_;
+  mutable std::atomic<size_t> count_;
 };
 
 class TestEncrypter : public TestEncryption, public Encrypter {


### PR DESCRIPTION
Summary: While testing `E2EEncryptionTest.EncryptRoot` on TSAN mode using DWRF parallel decoding (for this diff: D50481013) I found this to be a problem if not atomic. Making it atomic.

Differential Revision: D50676930


