### PR TITLE
Refactor TimestampToStringOptions to support TIME data

### DIFF
--- a/velox/functions/lib/TimeUtils.h
+++ b/velox/functions/lib/TimeUtils.h
@@ -52,7 +52,7 @@ std::tm getDateTime(Timestamp timestamp, const date::time_zone* timeZone) {
   int64_t seconds = getSeconds(timestamp, timeZone);
   std::tm dateTime;
   VELOX_USER_CHECK(
-      epochToUtc(seconds, dateTime),
+      Timestamp::epochToUtc(seconds, dateTime),
       "Timestamp is too large: {} seconds since epoch",
       seconds);
   return dateTime;
@@ -64,7 +64,9 @@ std::tm getDateTime(int32_t days) {
   int64_t seconds = days * kSecondsInDay;
   std::tm dateTime;
   VELOX_USER_CHECK(
-      epochToUtc(seconds, dateTime), "Date is too large: {} days", days);
+      Timestamp::epochToUtc(seconds, dateTime),
+      "Date is too large: {} days",
+      days);
   return dateTime;
 }
 

--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -400,7 +400,7 @@ struct Converter<TypeKind::VARCHAR, void, TRUNCATE> {
 
   static std::string cast(const Timestamp& val) {
     TimestampToStringOptions options;
-    options.precision = TimestampToStringOptions::kMilliseconds;
+    options.precision = TimestampToStringOptions::Precision::kMilliseconds;
     return val.toString(options);
   }
 

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -15,7 +15,6 @@
  */
 #include "velox/type/Timestamp.h"
 #include <chrono>
-#include "velox/common/base/Exceptions.h"
 #include "velox/external/date/tz.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
@@ -172,9 +171,25 @@ void appendSmallInt(int n, std::string& out) {
   out.append(intToStr[n], 2);
 }
 
+std::string::size_type getCapacity(const TimestampToStringOptions& options) {
+  auto precisionWidth = static_cast<int8_t>(options.precision);
+  switch (options.mode) {
+    case TimestampToStringOptions::Mode::kDateOnly:
+      // yyyy-mm-dd
+      return 10;
+    case TimestampToStringOptions::Mode::kTimeOnly:
+      // hh:mm:ss.precision
+      return 9 + precisionWidth;
+    case TimestampToStringOptions::Mode::kFull:
+      return 26 + precisionWidth;
+    default:
+      VELOX_UNREACHABLE();
+  }
+}
+
 } // namespace
 
-bool epochToUtc(int64_t epoch, std::tm& tm) {
+bool Timestamp::epochToUtc(int64_t epoch, std::tm& tm) {
   constexpr int kSecondsPerHour = 3600;
   constexpr int kSecondsPerDay = 24 * kSecondsPerHour;
   constexpr int kDaysPerYear = 365;
@@ -219,39 +234,45 @@ bool epochToUtc(int64_t epoch, std::tm& tm) {
   return true;
 }
 
-std::string tmToString(
+std::string Timestamp::tmToString(
     const std::tm& tmValue,
-    int nanos,
+    uint64_t nanos,
     const TimestampToStringOptions& options) {
   VELOX_DCHECK_GE(nanos, 0);
   VELOX_DCHECK_LT(nanos, 1'000'000'000);
-  int width = options.precision;
+  auto precisionWidth = static_cast<int8_t>(options.precision);
   std::string out;
-  out.reserve(options.dateOnly ? 10 : 26 + width);
-  int n = kTmYearBase + tmValue.tm_year;
-  bool negative = n < 0;
-  if (negative) {
-    out += '-';
-    n = -n;
-  }
-  while (n > 0) {
-    out += '0' + n % 10;
-    n /= 10;
-  }
-  if (options.zeroPaddingYear && out.size() < negative + 4) {
-    while (out.size() < negative + 4) {
-      out += '0';
+  out.reserve(getCapacity(options));
+
+  if (options.mode != TimestampToStringOptions::Mode::kTimeOnly) {
+    int n = kTmYearBase + tmValue.tm_year;
+    bool negative = n < 0;
+    if (negative) {
+      out += '-';
+      n = -n;
     }
+    while (n > 0) {
+      out += '0' + n % 10;
+      n /= 10;
+    }
+    auto zeroPaddingYearSize = negative + 4;
+    if (options.zeroPaddingYear && out.size() < zeroPaddingYearSize) {
+      while (out.size() < zeroPaddingYearSize) {
+        out += '0';
+      }
+    }
+    std::reverse(out.begin() + negative, out.end());
+    out += '-';
+    appendSmallInt(1 + tmValue.tm_mon, out);
+    out += '-';
+    appendSmallInt(tmValue.tm_mday, out);
+    if (options.mode == TimestampToStringOptions::Mode::kDateOnly) {
+      return out;
+    }
+
+    out += options.dateTimeSeparator;
   }
-  std::reverse(out.begin() + negative, out.end());
-  out += '-';
-  appendSmallInt(1 + tmValue.tm_mon, out);
-  out += '-';
-  appendSmallInt(tmValue.tm_mday, out);
-  if (options.dateOnly) {
-    return out;
-  }
-  out += options.dateTimeSeparator;
+
   appendSmallInt(tmValue.tm_hour, out);
   out += ':';
   appendSmallInt(tmValue.tm_min, out);
@@ -259,14 +280,14 @@ std::string tmToString(
   appendSmallInt(tmValue.tm_sec, out);
   out += '.';
   int offset = out.size();
-  if (options.precision == TimestampToStringOptions::kMilliseconds) {
+  if (options.precision == TimestampToStringOptions::Precision::kMilliseconds) {
     nanos /= 1'000'000;
   }
   while (nanos > 0) {
     out += '0' + nanos % 10;
     nanos /= 10;
   }
-  while (out.size() - offset < width) {
+  while (out.size() - offset < precisionWidth) {
     out += '0';
   }
   std::reverse(out.begin() + offset, out.end());

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -1018,10 +1018,12 @@ std::string DateType::toString(int32_t days) const {
   int64_t daySeconds = days * (int64_t)(86400);
   std::tm tmValue;
   VELOX_CHECK(
-      epochToUtc(daySeconds, tmValue), "Can't convert days to dates: {}", days);
+      Timestamp::epochToUtc(daySeconds, tmValue),
+      "Can't convert days to dates: {}",
+      days);
   TimestampToStringOptions options;
-  options.dateOnly = true;
-  return tmToString(tmValue, 0, options);
+  options.mode = TimestampToStringOptions::Mode::kDateOnly;
+  return Timestamp::tmToString(tmValue, 0, options);
 }
 
 int32_t DateType::toDays(folly::StringPiece in) const {


### PR DESCRIPTION
Refactor `TimestampToStringOptions` to support time type data:

- Add TimestampToStringOptions::kTimeOnly enum for processing TIME data.
- Adapt Timestamp::tmToString to handle TIME data.