### PR TITLE
Move HashAggregation's initialization routine from ctor to initialize().

### DIFF
--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -27,6 +27,8 @@ class HashAggregation : public Operator {
       DriverCtx* driverCtx,
       const std::shared_ptr<const core::AggregationNode>& aggregationNode);
 
+  void initialize() override;
+
   void addInput(RowVectorPtr input) override;
 
   RowVectorPtr getOutput() override;
@@ -73,6 +75,8 @@ class HashAggregation : public Operator {
   // Invoked to record the spilling stats in operator stats after processing all
   // the inputs.
   void recordSpillStats();
+
+  std::shared_ptr<const core::AggregationNode> aggregationNode_;
 
   const bool isPartialOutput_;
   const bool isGlobal_;

--- a/velox/exec/TableWriteMerge.cpp
+++ b/velox/exec/TableWriteMerge.cpp
@@ -64,6 +64,13 @@ TableWriteMerge::TableWriteMerge(
   }
 }
 
+void TableWriteMerge::initialize() {
+  Operator::initialize();
+  if (aggregation_ != nullptr) {
+    aggregation_->initialize();
+  }
+}
+
 void TableWriteMerge::addInput(RowVectorPtr input) {
   VELOX_CHECK(!noMoreInput_);
   VELOX_CHECK_GT(input->size(), 0);

--- a/velox/exec/TableWriteMerge.h
+++ b/velox/exec/TableWriteMerge.h
@@ -31,6 +31,8 @@ class TableWriteMerge : public Operator {
       const std::shared_ptr<const core::TableWriteMergeNode>&
           tableWriteMergeNode);
 
+  void initialize() override;
+
   BlockingReason isBlocked(ContinueFuture* /* future */) override {
     return BlockingReason::kNotBlocked;
   }

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -81,6 +81,9 @@ void TableWriter::initialize() {
   Operator::initialize();
   VELOX_CHECK_NULL(dataSink_);
   createDataSink();
+  if (aggregation_ != nullptr) {
+    aggregation_->initialize();
+  }
 }
 
 void TableWriter::createDataSink() {


### PR DESCRIPTION
Part of #7233.
HashAggregation can make potential memory pool allocation at `populateAggregateInputs`, which will fail the check #6409.
1. Add a test that triggers memory pool allocation at `populateAggregateInputs`.
2. Move HashAggregation's initialization routine from ctor to `initialize()`.

Also, initialize `TableWriter`/`TableWriteMerge`'s `aggregation_` if presents.