### PR TITLE
Memory arbitration related code refactor

### DIFF
--- a/velox/common/memory/CMakeLists.txt
+++ b/velox/common/memory/CMakeLists.txt
@@ -28,7 +28,6 @@ add_library(
   MemoryPool.cpp
   MmapAllocator.cpp
   MmapArena.cpp
-  SharedArbitrator.cpp
   StreamArena.cpp)
 
 target_link_libraries(

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -74,26 +74,28 @@ class MemoryArbitrator {
   using Factory = std::function<std::unique_ptr<MemoryArbitrator>(
       const MemoryArbitrator::Config& config)>;
 
-  /// Register factory for a specific 'kind' of memory arbitrator
+  /// Registers factory for a specific 'kind' of memory arbitrator
   /// MemoryArbitrator::Create looks up the registry to find the factory to
   /// create arbitrator instance based on the kind specified in arbitrator
   /// config.
   ///
   /// NOTE: we only allow the same 'kind' of memory arbitrator to be registered
-  /// once. The function throws an error if 'kind' is already registered.
-  static void registerFactory(const std::string& kind, Factory factory);
+  /// once. The function returns false if 'kind' is already registered.
+  static bool registerFactory(const std::string& kind, Factory factory);
 
-  /// Unregister the registered factory for a specifc kind.
+  /// Unregisters the registered factory for a specifc kind.
   ///
   /// NOTE: the function throws if the specified arbitrator 'kind' is not
   /// registered.
   static void unregisterFactory(const std::string& kind);
 
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
   /// Register all the supported memory arbitrator kinds.
-  static void registerAllFactories();
+  static void registerAllFactories() {}
 
   /// Unregister all the supported memory arbitrator kinds.
-  static void unregisterAllFactories();
+  static void unregisterAllFactories() {}
+#endif
 
   /// Invoked by the memory manager to create an instance of memory arbitrator
   /// based on the kind specified in 'config'. The arbitrator kind must be
@@ -345,4 +347,12 @@ MemoryArbitrationContext* memoryArbitrationContext();
 
 /// Returns true if the running thread is under memory arbitration or not.
 bool underMemoryArbitration();
+
+#define VELOX_REGISTER_MEMORY_ARBITRATION_FACTORY(kind, factory)  \
+  namespace {                                                     \
+  static bool FB_ANONYMOUS_VARIABLE(g_MemoryArbitrationFactory) = \
+      facebook::velox::memory::MemoryArbitrator::registerFactory( \
+          kind,                                                   \
+          (factory));                                             \
+  }
 } // namespace facebook::velox::memory

--- a/velox/common/memory/tests/CMakeLists.txt
+++ b/velox/common/memory/tests/CMakeLists.txt
@@ -25,7 +25,6 @@ add_executable(
   MemoryManagerTest.cpp
   MemoryPoolTest.cpp
   MockSharedArbitratorTest.cpp
-  SharedArbitratorTest.cpp
   StreamArenaTest.cpp)
 
 target_link_libraries(

--- a/velox/common/memory/tests/MemoryArbitratorTest.cpp
+++ b/velox/common/memory/tests/MemoryArbitratorTest.cpp
@@ -22,7 +22,6 @@
 #include "velox/common/memory/MallocAllocator.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/common/memory/MemoryArbitrator.h"
-#include "velox/common/memory/SharedArbitrator.h"
 
 using namespace ::testing;
 
@@ -98,7 +97,6 @@ TEST_F(MemoryArbitrationTest, queryMemoryCapacity) {
   }
   {
     // Reserved memory is enforced when SharedMemoryArbitrator is used.
-    SharedArbitrator::registerFactory();
     auto allocator = std::make_shared<MallocAllocator>(8L << 20);
     MemoryManager manager{
         {.capacity = (int64_t)allocator->capacity(),
@@ -114,7 +112,6 @@ TEST_F(MemoryArbitrationTest, queryMemoryCapacity) {
         "Exceeded memory pool cap of 4.00MB");
     ASSERT_NO_THROW(buffer = leafPool->allocate(4L << 20));
     leafPool->free(buffer, 4L << 20);
-    SharedArbitrator::unregisterFactory();
   }
 }
 
@@ -218,9 +215,7 @@ class MemoryArbitratorFactoryTest : public testing::Test {
 };
 
 TEST_F(MemoryArbitratorFactoryTest, register) {
-  VELOX_ASSERT_THROW(
-      MemoryArbitrator::registerFactory(kind_, factory_),
-      "Arbitrator factory for kind USER already registered");
+  ASSERT_FALSE(MemoryArbitrator::registerFactory(kind_, factory_));
 }
 
 TEST_F(MemoryArbitratorFactoryTest, create) {

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -40,10 +40,6 @@ MemoryManager& toMemoryManager(MemoryManager& manager) {
 
 class MemoryManagerTest : public testing::Test {
  protected:
-  static void SetUpTestCase() {
-    MemoryArbitrator::registerAllFactories();
-  }
-
   inline static const std::string arbitratorKind_{"SHARED"};
 };
 

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -73,7 +73,6 @@ class MemoryPoolTest : public testing::TestWithParam<TestParam> {
  protected:
   static constexpr uint64_t kDefaultCapacity = 8 * GB; // 8GB
   static void SetUpTestCase() {
-    MemoryArbitrator::registerAllFactories();
     FLAGS_velox_memory_leak_check_enabled = true;
     TestValue::enable();
   }

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -24,8 +24,8 @@
 #include "velox/common/memory/MallocAllocator.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/common/memory/MemoryArbitrator.h"
-#include "velox/common/memory/SharedArbitrator.h"
 #include "velox/common/testutil/TestValue.h"
+#include "velox/exec/SharedArbitrator.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 
@@ -383,7 +383,6 @@ MockTask::~MockTask() {
 class MockSharedArbitrationTest : public testing::Test {
  protected:
   static void SetUpTestCase() {
-    SharedArbitrator::registerFactory();
     FLAGS_velox_memory_leak_check_enabled = true;
     TestValue::enable();
   }

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -217,7 +217,8 @@ Spilling
    * - writer_spill_enabled
      - boolean
      - true
-     - When `writer_spill_enabled` is true, determines whether TableWriter operator can spill to disk under memory pressure.
+     - When `writer_spill_enabled` is true, determines whether TableWriter operator can flush the buffered data to disk
+       under memory pressure.
    * - aggregation_spill_memory_threshold
      - integer
      - 0
@@ -225,7 +226,9 @@ Spilling
    * - aggregation_spill_all
      - boolean
      - false
-     - If true and spilling has been triggered during the input processing, the spiller will spill all the remaining in-memory state to disk before output processing. This is to simplify the aggregation query OOM prevention in output processing stage.
+     - If true and spilling has been triggered during the input processing, the spiller will spill all the remaining
+       in-memory state to disk before output processing. This is to simplify the aggregation query OOM prevention in
+       output processing stage.
    * - join_spill_memory_threshold
      - integer
      - 0

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -59,6 +59,7 @@ add_library(
   ProbeOperatorState.cpp
   RowContainer.cpp
   RowNumber.cpp
+  SharedArbitrator.cpp
   SortBuffer.cpp
   SortedAggregations.cpp
   SortWindowBuild.cpp

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -465,18 +465,7 @@ void HashAggregation::reclaim(
     uint64_t targetBytes,
     memory::MemoryReclaimer::Stats& stats) {
   VELOX_CHECK(canReclaim());
-
-  // NOTE: an aggregation operator is reclaimable if it hasn't started output
-  // processing and is not under non-reclaimable execution section.
-  if (nonReclaimableSection_) {
-    // TODO: reduce the log frequency if it is too verbose.
-    ++stats.numNonReclaimableAttempts;
-    LOG(WARNING)
-        << "Can't reclaim from aggregation operator which is under non-reclaimable section, pool["
-        << pool()->toString()
-        << ", usage: " << succinctBytes(pool()->currentBytes()) << "]";
-    return;
-  }
+  VELOX_CHECK(!nonReclaimableSection_);
 
   if (noMoreInput_) {
     if (groupingSet_->hasSpilled()) {

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -1109,6 +1109,7 @@ void HashBuild::reclaim(
   VELOX_CHECK(canReclaim());
   auto* driver = operatorCtx_->driver();
   VELOX_CHECK_NOT_NULL(driver);
+  VELOX_CHECK(!nonReclaimableSection_);
 
   TestValue::adjust("facebook::velox::exec::HashBuild::reclaim", this);
 

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -80,17 +80,19 @@ void OrderBy::reclaim(
     uint64_t targetBytes,
     memory::MemoryReclaimer::Stats& stats) {
   VELOX_CHECK(canReclaim());
+  VELOX_CHECK(!nonReclaimableSection_);
   auto* driver = operatorCtx_->driver();
 
   // NOTE: an order by operator is reclaimable if it hasn't started output
   // processing and is not under non-reclaimable execution section.
-  if (noMoreInput_ || nonReclaimableSection_) {
+  if (noMoreInput_) {
     // TODO: reduce the log frequency if it is too verbose.
     ++stats.numNonReclaimableAttempts;
-    LOG(WARNING) << "Can't reclaim from order by operator, noMoreInput_["
-                 << noMoreInput_ << "], nonReclaimableSection_["
-                 << nonReclaimableSection_ << "], pool[" << pool()->name()
-                 << ", usage: " << succinctBytes(pool()->currentBytes()) << "]";
+    LOG(WARNING)
+        << "Can't reclaim from order by operator which has started producing output: "
+        << pool()->name()
+        << ", usage: " << succinctBytes(pool()->currentBytes())
+        << ", reservation: " << succinctBytes(pool()->reservedBytes());
     return;
   }
 

--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -359,6 +359,9 @@ void RowNumber::setNumRows(char* partition, int64_t numRows) {
 void RowNumber::reclaim(
     uint64_t /*targetBytes*/,
     memory::MemoryReclaimer::Stats& stats) {
+  VELOX_CHECK(canReclaim());
+  VELOX_CHECK(!nonReclaimableSection_);
+
   if (table_ == nullptr || table_->numDistinct() == 0) {
     // Nothing to spill.
     return;
@@ -366,11 +369,6 @@ void RowNumber::reclaim(
 
   if (hashTableSpiller_) {
     // Already spilled.
-    return;
-  }
-
-  if (nonReclaimableSection_) {
-    ++stats.numNonReclaimableAttempts;
     return;
   }
 

--- a/velox/exec/SharedArbitrator.cpp
+++ b/velox/exec/SharedArbitrator.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "velox/common/memory/SharedArbitrator.h"
+#include "velox/exec/SharedArbitrator.h"
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/testutil/TestValue.h"
@@ -22,7 +22,7 @@
 
 using facebook::velox::common::testutil::TestValue;
 
-namespace facebook::velox::memory {
+namespace facebook::velox::exec {
 
 namespace {
 
@@ -58,6 +58,10 @@ std::string memoryPoolAbortMessage(
   return out.str();
 }
 
+std::unique_ptr<MemoryArbitrator> createSharedArbitrator(
+    const MemoryArbitrator::Config& config) {
+  return std::make_unique<SharedArbitrator>(config);
+}
 } // namespace
 
 SharedArbitrator::SharedArbitrator(const MemoryArbitrator::Config& config)
@@ -586,14 +590,6 @@ std::string SharedArbitrator::kind() const {
   return kind_;
 }
 
-void SharedArbitrator::registerFactory() {
-  MemoryArbitrator::registerFactory(
-      kind_, [](const MemoryArbitrator::Config& config) {
-        return std::make_unique<SharedArbitrator>(config);
-      });
-}
+VELOX_REGISTER_MEMORY_ARBITRATION_FACTORY("SHARED", createSharedArbitrator);
 
-void SharedArbitrator::unregisterFactory() {
-  MemoryArbitrator::unregisterFactory(kind_);
-}
-} // namespace facebook::velox::memory
+} // namespace facebook::velox::exec

--- a/velox/exec/SharedArbitrator.h
+++ b/velox/exec/SharedArbitrator.h
@@ -21,7 +21,9 @@
 #include "velox/common/future/VeloxPromise.h"
 #include "velox/common/memory/Memory.h"
 
-namespace facebook::velox::memory {
+using namespace facebook::velox::memory;
+
+namespace facebook::velox::exec {
 
 /// Used to achieve dynamic memory sharing among running queries. When a
 /// memory pool exceeds its current memory capacity, the arbitrator tries to
@@ -31,12 +33,8 @@ namespace facebook::velox::memory {
 /// aborting a query. For Prestissimo-on-Spark, we can configure it to
 /// reclaim from a running query through techniques such as disk-spilling,
 /// partial aggregation or persistent shuffle data flushes.
-class SharedArbitrator : public MemoryArbitrator {
+class SharedArbitrator : public memory::MemoryArbitrator {
  public:
-  static void registerFactory();
-
-  static void unregisterFactory();
-
   explicit SharedArbitrator(const Config& config);
 
   ~SharedArbitrator() override;
@@ -202,4 +200,4 @@ class SharedArbitrator : public MemoryArbitrator {
   tsan_atomic<uint64_t> reclaimTimeUs_{0};
   tsan_atomic<uint64_t> numNonReclaimableAttempts_{0};
 };
-} // namespace facebook::velox::memory
+} // namespace facebook::velox::exec

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -63,6 +63,7 @@ add_executable(
   RowContainerTest.cpp
   RowNumberTest.cpp
   MarkDistinctTest.cpp
+  SharedArbitratorTest.cpp
   SpillTest.cpp
   SpillOperatorGroupTest.cpp
   SpillerTest.cpp

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -5287,17 +5287,14 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringAllocation) {
     ASSERT_EQ(reclaimable, enableSpilling);
     if (enableSpilling) {
       ASSERT_GE(reclaimableBytes, 0);
-      op->reclaim(
-          folly::Random::oneIn(2) ? 0 : folly::Random::rand32(),
-          reclaimerStats_);
     } else {
-      VELOX_ASSERT_THROW(
-          op->reclaim(
-              folly::Random::oneIn(2) ? 0 : folly::Random::rand32(),
-              reclaimerStats_),
-          "");
       ASSERT_EQ(reclaimableBytes, 0);
     }
+    VELOX_ASSERT_THROW(
+        op->reclaim(
+            folly::Random::oneIn(2) ? 0 : folly::Random::rand32(),
+            reclaimerStats_),
+        "");
 
     driverWait.notify();
     Task::resume(task);
@@ -5305,7 +5302,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringAllocation) {
 
     taskThread.join();
   }
-  ASSERT_EQ(reclaimerStats_, memory::MemoryReclaimer::Stats{1});
+  ASSERT_EQ(reclaimerStats_, memory::MemoryReclaimer::Stats{0});
 }
 
 DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringOutputProcessing) {

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -939,17 +939,11 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringAllocation) {
       ASSERT_EQ(reclaimableBytes, 0);
     }
 
-    if (enableSpilling) {
-      op->reclaim(
-          folly::Random::oneIn(2) ? 0 : folly::Random::rand32(rng_),
-          reclaimerStats_);
-    } else {
-      VELOX_ASSERT_THROW(
-          op->reclaim(
-              folly::Random::oneIn(2) ? 0 : folly::Random::rand32(rng_),
-              reclaimerStats_),
-          "");
-    }
+    VELOX_ASSERT_THROW(
+        op->reclaim(
+            folly::Random::oneIn(2) ? 0 : folly::Random::rand32(rng_),
+            reclaimerStats_),
+        "");
 
     driverWait.notify();
     Task::resume(task);
@@ -961,7 +955,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringAllocation) {
     ASSERT_EQ(stats[0].operatorStats[1].spilledPartitions, 0);
     OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
   }
-  ASSERT_EQ(reclaimerStats_, memory::MemoryReclaimer::Stats{1});
+  ASSERT_EQ(reclaimerStats_, memory::MemoryReclaimer::Stats{0});
 }
 
 DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringOutputProcessing) {

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -129,7 +129,7 @@ class AssertQueryBuilder {
 
   /// Run the query and collect all results into a single vector. Throws if
   /// query returns empty result.
-  RowVectorPtr copyResults(memory::MemoryPool* FOLLY_NONNULL pool);
+  RowVectorPtr copyResults(memory::MemoryPool* pool);
 
  private:
   std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>>

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -53,7 +53,6 @@ OperatorTestBase::~OperatorTestBase() {
 
 void OperatorTestBase::SetUpTestCase() {
   FLAGS_velox_enable_memory_usage_track_in_default_memory_pool = true;
-  memory::MemoryArbitrator::registerAllFactories();
   functions::prestosql::registerAllScalarFunctions();
   aggregate::prestosql::registerAllAggregateFunctions();
   TestValue::enable();
@@ -61,7 +60,6 @@ void OperatorTestBase::SetUpTestCase() {
 
 void OperatorTestBase::TearDownTestCase() {
   waitForAllTasksToBeDeleted();
-  memory::MemoryArbitrator::unregisterAllFactories();
 }
 
 void OperatorTestBase::SetUp() {


### PR DESCRIPTION
- Move SharedArbitrator and its test from memory namespace to exec
   namespace
- Add macro to handle memory arbitrator registration
- Move non-reclaimable section check from each individual spillable operator
  to Operator::reclaim()