### PR TITLE
Return null when offset is null for lead/lag

### DIFF
--- a/velox/docs/functions/presto/window.rst
+++ b/velox/docs/functions/presto/window.rst
@@ -130,19 +130,33 @@ Returns the value at the specified offset from the beginning of the window. Offs
 can be any scalar expression. If the offset is null or greater than the number of values in the window, null is
 returned. It is an error for the offset to be zero or negative.
 
-.. function:: lag(x[, offset [, default_value]]) -> [same as input]
+.. function:: lag(x[, offset[, default_value]] [IGNORE NULLS]) -> [same as input]
 
-Returns the value at ``offset`` rows before the current row in the partition. If
-there is no such row, the ``default_value`` is returned, or if it is not
-specified ``null`` is returned. Offsets start at ``0``, which is the current
-row. The default ``offset`` is ``1``.
+Returns the value at ``offset`` rows before the current row in the window partition.
+Offsets start at ``0``, which is the current row. The default ``offset`` is ``1``.
+The offset can be any scalar expression. If the offset is ``null``, ``null`` is
+returned. If the offset refers to a row that is not within the partition, the
+``default_value`` is returned, or if ``default_value`` is not specified ``null``
+is returned.
 
-.. function:: lead(x[, offset [, default_value]]) -> [same as input]
+An optional ``IGNORE NULLS`` suffix can be specified after all the params, if
+``IGNORE NULLS`` is specified, ``null`` values are ignored during offset counting.
+If not enough non-null values are found during offset counting, ``default_value``
+is returned.
 
-Returns the value at ``offset`` rows after the current row in the partition. If
-there is no such row, the ``default_value`` is returned, or if it is not
-specified ``null`` is returned. Offsets start at ``0``, which is the current
-row. The default ``offset`` is ``1``.
+.. function:: lead(x[, offset[, default_value]] [IGNORE NULLS]) -> [same as input]
+
+Returns the value at ``offset`` rows after the current row in the window partition.
+Offsets start at ``0``, which is the current row. The default ``offset`` is ``1``.
+The offset can be any scalar expression. If the offset is ``null``, ``null`` is
+returned. If the offset refers to a row that is not within the partition, the
+``default_value`` is returned, or if ``default_value`` is not specified ``null``
+is returned.
+
+An optional ``IGNORE NULLS`` suffix can be specified after all the params, if
+``IGNORE NULLS`` is specified, ``null`` values are ignored during offset counting.
+If not enough non-null values are found during offset counting, ``default_value``
+is returned.
 
 Aggregate functions
 ___________________

--- a/velox/docs/functions/presto/window.rst
+++ b/velox/docs/functions/presto/window.rst
@@ -116,6 +116,12 @@ within the window partition.
 Value functions
 _______________
 
+Value functions provide an option to specify how null values should be treated when evaluating the
+function. Nulls can either be ignored (``IGNORE NULLS``) or respected (``RESPECT NULLS``). By default,
+null values are respected. If ``IGNORE NULLS`` is specified, all rows where the value expression is
+null are excluded from the calculation. If ``IGNORE NULLS`` is specified and the value expression is
+null for all rows, the ``default_value`` is returned, or if it is not specified, ``null`` is returned.
+
 .. function:: first_value(x) -> [same as input]
 
 Returns the first value of the window.
@@ -130,31 +136,29 @@ Returns the value at the specified offset from the beginning of the window. Offs
 can be any scalar expression. If the offset is null or greater than the number of values in the window, null is
 returned. It is an error for the offset to be zero or negative.
 
-.. function:: lag(x[, offset[, default_value]] [IGNORE NULLS]) -> [same as input]
+.. function:: lag(x[, offset[, default_value]]) -> [same as input]
 
 Returns the value at ``offset`` rows before the current row in the window partition.
 Offsets start at ``0``, which is the current row. The default ``offset`` is ``1``.
-The offset can be any scalar expression. If the offset is ``null``, ``null`` is
+The offset can be a constant value or a column reference. If the offset is ``null``, ``null`` is
 returned. If the offset refers to a row that is not within the partition, the
 ``default_value`` is returned, or if ``default_value`` is not specified ``null``
 is returned.
 
-An optional ``IGNORE NULLS`` suffix can be specified after all the params, if
-``IGNORE NULLS`` is specified, ``null`` values are ignored during offset counting.
+If ``IGNORE NULLS`` is specified, ``null`` values are ignored during offset counting.
 If not enough non-null values are found during offset counting, ``default_value``
 is returned.
 
-.. function:: lead(x[, offset[, default_value]] [IGNORE NULLS]) -> [same as input]
+.. function:: lead(x[, offset[, default_value]]) -> [same as input]
 
 Returns the value at ``offset`` rows after the current row in the window partition.
 Offsets start at ``0``, which is the current row. The default ``offset`` is ``1``.
-The offset can be any scalar expression. If the offset is ``null``, ``null`` is
+The offset can be a constant value or a column reference. If the offset is ``null``, ``null`` is
 returned. If the offset refers to a row that is not within the partition, the
 ``default_value`` is returned, or if ``default_value`` is not specified ``null``
 is returned.
 
-An optional ``IGNORE NULLS`` suffix can be specified after all the params, if
-``IGNORE NULLS`` is specified, ``null`` values are ignored during offset counting.
+If ``IGNORE NULLS`` is specified, ``null`` values are ignored during offset counting.
 If not enough non-null values are found during offset counting, ``default_value``
 is returned.
 

--- a/velox/functions/prestosql/window/LeadLag.cpp
+++ b/velox/functions/prestosql/window/LeadLag.cpp
@@ -87,6 +87,15 @@ class LeadLagFunction : public exec::WindowFunction {
   }
 
  private:
+  // Lead/Lag return default value (using kDefaultValueRow) if offsets for
+  // target rowNumbers are outside the partition. If offset is null, then the
+  // functions return null (using kNullRow) .
+  //
+  // kDefaultValueRow needs to be a negative number so that
+  // WindowPartition::extractColumn calls skip this row. It is set to -2 to
+  // distinguish it from kNullRow which is -1.
+  static constexpr vector_size_t kDefaultValueRow = -2;
+
   void initializeOffset(const std::vector<exec::WindowFunctionArg>& args) {
     if (args.size() == 1) {
       constantOffset_ = 1;
@@ -130,15 +139,16 @@ class LeadLagFunction : public exec::WindowFunction {
   void setRowNumbersForConstantOffset(vector_size_t offset);
 
   void setRowNumbersForConstantOffset() {
+    // Set row number to kNullRow for NULL offset.
     if (isConstantOffsetNull_) {
       std::fill(rowNumbers_.begin(), rowNumbers_.end(), kNullRow);
       return;
     }
 
     auto constantOffsetValue = constantOffset_.value();
-    // Set row number to kNullRow for out of range offset.
+    // Set row number to kDefaultValueRow for out of range offset.
     if (constantOffsetValue > partition_->numRows()) {
-      std::fill(rowNumbers_.begin(), rowNumbers_.end(), kNullRow);
+      std::fill(rowNumbers_.begin(), rowNumbers_.end(), kDefaultValueRow);
       return;
     }
 
@@ -154,14 +164,15 @@ class LeadLagFunction : public exec::WindowFunction {
     const auto maxRowNumber = partition_->numRows() - 1;
     auto* rawNulls = nulls_->as<uint64_t>();
     for (auto i = 0; i < numRows; ++i) {
+      // Set row number to kNullRow for NULL offset.
       if (offsets_->isNullAt(i)) {
         rowNumbers_[i] = kNullRow;
       } else {
         auto offset = offsets_->valueAt(i);
         VELOX_USER_CHECK_GE(offset, 0, "Offset must be at least 0");
-        // Set rowNumber to kNullRow for out of range offset.
+        // Set rowNumber to kDefaultValueRow for out of range offset.
         if (offset > partition_->numRows()) {
-          rowNumbers_[i] = kNullRow;
+          rowNumbers_[i] = kDefaultValueRow;
           continue;
         }
 
@@ -170,8 +181,9 @@ class LeadLagFunction : public exec::WindowFunction {
             rowNumbers_[i] = rowNumberIgnoreNull(
                 rawNulls, offset, partitionOffset_ + i - 1, -1, -1);
           } else {
+            // Set rowNumber to kDefaultValueRow for out of range offset.
             auto rowNumber = partitionOffset_ + i - offset;
-            rowNumbers_[i] = rowNumber >= 0 ? rowNumber : kNullRow;
+            rowNumbers_[i] = rowNumber >= 0 ? rowNumber : kDefaultValueRow;
           }
         } else {
           if constexpr (ignoreNulls) {
@@ -182,8 +194,10 @@ class LeadLagFunction : public exec::WindowFunction {
                 partition_->numRows(),
                 1);
           } else {
+            // Set rowNumber to kDefaultValueRow for out of range offset.
             auto rowNumber = partitionOffset_ + i + offset;
-            rowNumbers_[i] = rowNumber <= maxRowNumber ? rowNumber : kNullRow;
+            rowNumbers_[i] =
+                rowNumber <= maxRowNumber ? rowNumber : kDefaultValueRow;
           }
         }
       }
@@ -206,20 +220,20 @@ class LeadLagFunction : public exec::WindowFunction {
       }
     }
 
-    return kNullRow;
+    return kDefaultValueRow;
   }
 
   void setDefaultValue(const VectorPtr& result, int32_t resultOffset) {
+    // Default value is not specified, just return.
     if (!constantDefaultValue_ && !defaultValueIndex_) {
       return;
     }
 
     // Copy default values into 'result' for rows with invalid offsets or empty
     // frames.
-
     if (constantDefaultValue_) {
       for (auto i = 0; i < rowNumbers_.size(); ++i) {
-        if (rowNumbers_[i] == kNullRow) {
+        if (rowNumbers_[i] == kDefaultValueRow) {
           result->copy(constantDefaultValue_.get(), resultOffset + i, 0, 1);
         }
       }
@@ -227,7 +241,7 @@ class LeadLagFunction : public exec::WindowFunction {
       std::vector<vector_size_t> defaultValueRowNumbers;
       defaultValueRowNumbers.reserve(rowNumbers_.size());
       for (auto i = 0; i < rowNumbers_.size(); ++i) {
-        if (rowNumbers_[i] == kNullRow) {
+        if (rowNumbers_[i] == kDefaultValueRow) {
           defaultValueRowNumbers.push_back(partitionOffset_ + i);
         }
       }
@@ -281,7 +295,7 @@ class LeadLagFunction : public exec::WindowFunction {
   // Reusable vector of offsets if these are not constant.
   FlatVectorPtr<int64_t> offsets_;
 
-  // Reusable vector of default values if these are not cosntant.
+  // Reusable vector of default values if these are not constant.
   VectorPtr defaultValues_;
 
   // Null positions buffer to use for ignoreNulls.
@@ -302,13 +316,14 @@ class LeadLagFunction : public exec::WindowFunction {
 template <>
 void LeadLagFunction<true>::setRowNumbersForConstantOffset(
     vector_size_t offset) {
-  // Figure out how many rows at the start should be NULL.
+  // Figure out how many rows at the start is out of range.
   vector_size_t nullCnt = 0;
   if (offset > partitionOffset_) {
     nullCnt =
         std::min<vector_size_t>(offset - partitionOffset_, rowNumbers_.size());
     if (nullCnt) {
-      std::fill(rowNumbers_.begin(), rowNumbers_.begin() + nullCnt, kNullRow);
+      std::fill(
+          rowNumbers_.begin(), rowNumbers_.begin() + nullCnt, kDefaultValueRow);
     }
   }
 
@@ -330,14 +345,15 @@ void LeadLagFunction<true>::setRowNumbersForConstantOffset(
 template <>
 void LeadLagFunction<false>::setRowNumbersForConstantOffset(
     vector_size_t offset) {
-  // Figure out how many rows at the end should be NULL.
+  // Figure out how many rows at the end is out of range.
   vector_size_t nonNullCnt = std::max<vector_size_t>(
       0,
       std::min<vector_size_t>(
           rowNumbers_.size(),
           partition_->numRows() - partitionOffset_ - offset));
   if (nonNullCnt < rowNumbers_.size()) {
-    std::fill(rowNumbers_.begin() + nonNullCnt, rowNumbers_.end(), kNullRow);
+    std::fill(
+        rowNumbers_.begin() + nonNullCnt, rowNumbers_.end(), kDefaultValueRow);
   }
 
   // Populate sequential values for non-NULL rows.


### PR DESCRIPTION
This is to match Presto's behavior for offset null scenario. Before this commit, Lead/Lag use kNullRow to describe both out of range and null offset scenario, in this commit we introduced another constant: kDefaultValueRow: we use kNullRow if offset is null, otherwise use kDefaultValueRow. We only copy default value from input vector for rows marked as kDefaultValueRow.

Fixes #6413

cc @mbasmanova @aditi-pandit 