### PR TITLE
Fix CAST to/from complex types with nested JSON

### DIFF
--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -79,20 +79,7 @@ class CastExpr : public SpecialForm {
             nullOnFailure ? kTryCast.data() : kCast.data(),
             false /* supportsFlatNoNullsFastPath */,
             trackCpuUsage),
-        nullOnFailure_(nullOnFailure) {
-    auto fromType = inputs_[0]->type();
-    castFromOperator_ = getCustomTypeCastOperator(fromType->toString());
-    if (castFromOperator_ && !castFromOperator_->isSupportedToType(type)) {
-      VELOX_USER_FAIL(
-          "Cannot cast {} to {}.", fromType->toString(), type->toString());
-    }
-
-    castToOperator_ = getCustomTypeCastOperator(type->toString());
-    if (castToOperator_ && !castToOperator_->isSupportedFromType(fromType)) {
-      VELOX_USER_FAIL(
-          "Cannot cast {} to {}.", fromType->toString(), type->toString());
-    }
-  }
+        nullOnFailure_(nullOnFailure) {}
 
   void evalSpecialForm(
       const SelectivityVector& rows,
@@ -280,13 +267,10 @@ class CastExpr : public SpecialForm {
     return nullOnFailure() && inTopLevel;
   }
 
-  // Custom cast operator for the from-type. Nullptr if the type is native or
-  // doesn't support cast-from.
-  CastOperatorPtr castFromOperator_;
+  CastOperatorPtr getCastOperator(const TypePtr& type);
 
-  // Custom cast operator for the to-type. Nullptr if the type is native or
-  // doesn't support cast-to.
-  CastOperatorPtr castToOperator_;
+  // Custom cast operators for to and from top-level as well as nested types.
+  folly::F14FastMap<std::string, CastOperatorPtr> castOperators_;
 
   bool nullOnFailure_;
 

--- a/velox/functions/prestosql/tests/JsonCastTest.cpp
+++ b/velox/functions/prestosql/tests/JsonCastTest.cpp
@@ -321,6 +321,26 @@ TEST_F(JsonCastTest, fromUnknown) {
   evaluateAndVerify(UNKNOWN(), JSON(), makeRowVector({input}), expected);
 }
 
+TEST_F(JsonCastTest, toArrayOfJson) {
+  auto arrays = makeArrayVectorFromJson<int64_t>({
+      "[1, 2, 3]",
+      "[4, 5]",
+      "[6, 7, 8]",
+  });
+
+  auto from = makeArrayVector({0, 2}, arrays);
+
+  auto to = makeArrayVector<JsonNativeType>(
+      {
+          {"[1,2,3]", "[4,5]"},
+          {"[6,7,8]"},
+      },
+      JSON());
+
+  testCast(ARRAY(ARRAY(BIGINT())), ARRAY(JSON()), from, to);
+  testCast(ARRAY(JSON()), ARRAY(ARRAY(BIGINT())), to, from);
+}
+
 TEST_F(JsonCastTest, fromArray) {
   TwoDimVector<StringView> array{
       {"red"_sv, "blue"_sv}, {std::nullopt, std::nullopt, "purple"_sv}, {}};


### PR DESCRIPTION
Cast expression didn't support casting to or from arrays, maps or structs with
JSON types nested inside, e.g. CAST(x AS ARRAY(JSON)).

Fixes #7255