### PR TITLE
Faster StringView hash

### DIFF
--- a/velox/common/base/BitUtil.cpp
+++ b/velox/common/base/BitUtil.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/Exceptions.h"
+#include "velox/common/base/SimdUtil.h"
 #include "velox/common/process/ProcessBase.h"
 
 namespace facebook::velox::bits {
@@ -158,4 +159,49 @@ void scatterBits(
 #endif
 }
 
+uint64_t hashBytes(uint64_t seed, const char* data, size_t size) {
+  auto begin = reinterpret_cast<const uint8_t*>(data);
+  const uint64_t kMul = 0x9ddfea08eb382d69ULL;
+  if (size < 8) {
+    auto word = loadPartialWord(begin, size);
+    uint64_t crc = simd::crc32U64(seed, word);
+    uint64_t crc2 = simd::crc32U64(seed, word >> 32);
+    return crc | (crc2 << 32);
+  }
+  uint64_t a0 = seed;
+  uint64_t a1 = seed << 32;
+  uint64_t a2 = seed >> 16;
+  int32_t toGo = size;
+  auto words = reinterpret_cast<const uint64_t*>(data);
+  while (toGo >= 24) {
+    a0 = simd::crc32U64(a0, words[0]);
+    a1 = simd::crc32U64(a1, words[1]);
+    a2 = simd::crc32U64(a2, words[2]);
+    words += 3;
+    toGo -= 24;
+  }
+  if (toGo > 16) {
+    a0 = simd::crc32U64(a0, words[0]);
+    a1 = simd::crc32U64(a1, words[1]);
+    a2 = simd::crc32U64(
+        a2,
+        loadPartialWord(
+            reinterpret_cast<const uint8_t*>(words + 2), toGo - 16));
+  } else if (toGo > 8) {
+    a0 = simd::crc32U64(a0, words[0]);
+    a1 = simd::crc32U64(
+        a1,
+        toGo == 16
+            ? words[1]
+            : loadPartialWord(
+                  reinterpret_cast<const uint8_t*>(words + 1), toGo - 8));
+  } else if (toGo > 0) {
+    a0 = simd::crc32U64(
+        a0,
+        toGo == 8
+            ? words[0]
+            : loadPartialWord(reinterpret_cast<const uint8_t*>(words), toGo));
+  }
+  return a0 ^ ((a1 * kMul)) ^ (a2 * kMul);
+}
 } // namespace facebook::velox::bits

--- a/velox/common/base/BitUtil.h
+++ b/velox/common/base/BitUtil.h
@@ -784,24 +784,7 @@ inline uint64_t loadPartialWord(const uint8_t* data, int32_t size) {
   return result;
 }
 
-inline size_t hashBytes(size_t seed, const char* data, size_t size) {
-  auto begin = reinterpret_cast<const uint8_t*>(data);
-  if (size < 8) {
-    return hashMix(seed, loadPartialWord(begin, size));
-  }
-  auto result = seed;
-  auto end = begin + size;
-  while (begin + 8 <= end) {
-    result = hashMix(result, *reinterpret_cast<const uint64_t*>(begin));
-    begin += 8;
-  }
-  if (end != begin) {
-    // Accesses the last 64 bits. Some bytes may get processed twice but the
-    // access is safe.
-    result = hashMix(result, *reinterpret_cast<const uint64_t*>(end - 8));
-  }
-  return result;
-}
+uint64_t hashBytes(uint64_t seed, const char* data, size_t size);
 
 namespace detail {
 // Returns at least 'numBits' bits of data starting at bit 'bitOffset'

--- a/velox/type/StringView.h
+++ b/velox/type/StringView.h
@@ -296,8 +296,7 @@ namespace folly {
 template <>
 struct hasher<::facebook::velox::StringView> {
   size_t operator()(const ::facebook::velox::StringView view) const {
-    return hash::SpookyHashV2::Hash64(view.data(), view.size(), 0);
-    // return facebook::velox::bits::hashBytes(1, view.data(), view.size());
+    return facebook::velox::bits::hashBytes(1, view.data(), view.size());
   }
 };
 

--- a/velox/type/tests/CMakeLists.txt
+++ b/velox/type/tests/CMakeLists.txt
@@ -29,7 +29,7 @@ add_test(velox_type_test velox_type_test)
 target_link_libraries(
   velox_type_test
   velox_type
-  velox_serialization
+  velox_common_base
   velox_external_date
   Folly::folly
   gtest

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -84,18 +84,9 @@ std::unique_ptr<SimpleVector<uint64_t>> FlatVector<T>::hashAll() const {
   auto hashData = hashBuffer->asMutable<uint64_t>();
 
   if (rawValues_ != nullptr) { // non all-null case
-    if constexpr (std::is_same_v<T, StringView>) {
-      folly::hasher<folly::StringPiece> stringHasher;
-      for (size_t i = 0; i < BaseVector::length_; ++i) {
-        auto view = valueAt(i);
-        folly::StringPiece piece(view.data(), view.size());
-        hashData[i] = stringHasher(piece);
-      }
-    } else {
-      folly::hasher<T> hasher;
-      for (size_t i = 0; i < BaseVector::length_; ++i) {
-        hashData[i] = hasher(valueAtFast(i));
-      }
+    folly::hasher<T> hasher;
+    for (size_t i = 0; i < BaseVector::length_; ++i) {
+      hashData[i] = hasher(valueAtFast(i));
     }
   }
 


### PR DESCRIPTION
Replaces folly spookyHash with a combination of CRC32 intrinnsics. Most X86 implementations can run 3 data independent CRC32 instructions at a time.  The loop hashes a string with a stride of 24 bytes. The CRCs for 0, 3, 6 and 1, 4, 7,... and 2, 5, 8,... are mixed at the end. The folly CRC calculator works in a similar way but only produces 32 bits of output. Here we have 64 independently mixed bits for strings of 8 or more bytes.

Note that AMD may benefit from a different intrinsic.

With a test like

select substr(l_comment, 10), l_comment, count(*) from lineitem_10 group by 1, 2 order by 3 desc limit 10;

We get a wall time drop from 101s to 74s with 200M rows.

See #7251