### PR TITLE
Fix the RuntimeStatWriterScopeGuard

### DIFF
--- a/velox/common/base/RuntimeMetrics.cpp
+++ b/velox/common/base/RuntimeMetrics.cpp
@@ -68,14 +68,13 @@ void setThreadLocalRunTimeStatWriter(BaseRuntimeStatWriter* writer) {
   localRuntimeStatWriter = writer;
 }
 
-BaseRuntimeStatWriter* getThreadLocalRunTimeStatWriter() {
-  return localRuntimeStatWriter;
-}
-
 void addThreadLocalRuntimeStat(
     const std::string& name,
     const RuntimeCounter& value) {
-  if (localRuntimeStatWriter) {
+  if (localRuntimeStatWriter == nullptr) {
+    LOG(ERROR) << "Add runtime stats " << name << ":" << value.value
+               << " when localRuntimeStatWriter is null";
+  } else {
     localRuntimeStatWriter->addRuntimeStat(name, value);
   }
 }

--- a/velox/common/base/RuntimeMetrics.h
+++ b/velox/common/base/RuntimeMetrics.h
@@ -85,9 +85,6 @@ class BaseRuntimeStatWriter {
 void setThreadLocalRunTimeStatWriter(
     BaseRuntimeStatWriter* FOLLY_NULLABLE writer);
 
-/// Retrives the current runtime stats writer.
-BaseRuntimeStatWriter* FOLLY_NULLABLE getThreadLocalRunTimeStatWriter();
-
 /// Writes runtime counter to the current Operator running on that thread.
 void addThreadLocalRuntimeStat(
     const std::string& name,
@@ -96,18 +93,13 @@ void addThreadLocalRuntimeStat(
 /// Scope guard to conveniently set and revert back the current stat writer.
 class RuntimeStatWriterScopeGuard {
  public:
-  explicit RuntimeStatWriterScopeGuard(
-      BaseRuntimeStatWriter* FOLLY_NULLABLE writer)
-      : prevWriter_(getThreadLocalRunTimeStatWriter()) {
+  RuntimeStatWriterScopeGuard(BaseRuntimeStatWriter* FOLLY_NULLABLE writer) {
     setThreadLocalRunTimeStatWriter(writer);
   }
 
   ~RuntimeStatWriterScopeGuard() {
-    setThreadLocalRunTimeStatWriter(prevWriter_);
+    setThreadLocalRunTimeStatWriter(nullptr);
   }
-
- private:
-  BaseRuntimeStatWriter* const FOLLY_NULLABLE prevWriter_;
 };
 
 } // namespace facebook::velox


### PR DESCRIPTION
The prevWriter_ in RuntimeStatWriterScopeGuard would always be nullptr. 
Remove it to eliminate confusion.

Also add check and log to detect potential misusage of addThreadLocalRuntimeStat.