### PR TITLE
Fix metadata computation for shared lambda expressions

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -99,19 +99,6 @@ bool isMember(
   return std::find(fields.begin(), fields.end(), &field) != fields.end();
 }
 
-void mergeFields(
-    std::vector<FieldReference*>& distinctFields,
-    std::unordered_set<FieldReference*>& multiplyReferencedFields,
-    const std::vector<FieldReference*>& moreFields) {
-  for (auto* newField : moreFields) {
-    if (isMember(distinctFields, *newField)) {
-      multiplyReferencedFields.insert(newField);
-    } else {
-      distinctFields.emplace_back(newField);
-    }
-  }
-}
-
 // Returns true if input expression or any sub-expression is an IF, AND or OR.
 bool hasConditionals(Expr* expr) {
   if (expr->isConditional()) {
@@ -216,6 +203,26 @@ void Expr::clearMetaData() {
   sameAsParentDistinctFields_ = false;
 }
 
+void Expr::mergeFields(
+    std::vector<FieldReference*>& distinctFields,
+    std::unordered_set<FieldReference*>& multiplyReferencedFields,
+    const std::vector<FieldReference*>& moreFields) {
+  for (auto* newField : moreFields) {
+    if (isMember(distinctFields, *newField)) {
+      multiplyReferencedFields.insert(newField);
+    } else {
+      distinctFields.emplace_back(newField);
+    }
+  }
+}
+
+void Expr::computeDistinctFields() {
+  for (auto& input : inputs_) {
+    mergeFields(
+        distinctFields_, multiplyReferencedFields_, input->distinctFields_);
+  }
+}
+
 void Expr::computeMetadata() {
   if (metaDataComputed_) {
     return;
@@ -241,15 +248,7 @@ void Expr::computeMetadata() {
   }
 
   // (2) Compute distinctFields_ and multiplyReferencedFields_.
-  for (auto& input : inputs_) {
-    mergeFields(
-        distinctFields_, multiplyReferencedFields_, input->distinctFields_);
-  }
-
-  if (is<FieldReference>() && inputs_.empty()) {
-    distinctFields_.resize(1);
-    distinctFields_[0] = this->as<FieldReference>();
-  }
+  computeDistinctFields();
 
   // (3) Compute propagatesNulls_.
   // propagatesNulls_ is true iff a null in any of the columns this
@@ -1711,7 +1710,7 @@ ExprSet::ExprSet(
   exprs_ = compileExpressions(sources, execCtx, this, enableConstantFolding);
   std::vector<FieldReference*> allDistinctFields;
   for (auto& expr : exprs_) {
-    mergeFields(
+    Expr::mergeFields(
         distinctFields_, multiplyReferencedFields_, expr->distinctFields());
   }
 }

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -239,6 +239,13 @@ class Expr {
   // sameAsParentDistinctFields_.
   void computeMetadata();
 
+  // Utility function to add fields to both distinct and multiply referenced
+  // fields.
+  static void mergeFields(
+      std::vector<FieldReference*>& distinctFields,
+      std::unordered_set<FieldReference*>& multiplyReferencedFields,
+      const std::vector<FieldReference*>& fieldsToAdd);
+
   virtual void reset() {
     sharedSubexprResults_.clear();
   }
@@ -536,6 +543,11 @@ class Expr {
     return trackCpuUsage_ ? std::make_unique<CpuWallTimer>(stats_.timing)
                           : nullptr;
   }
+
+  // Should be called only after computeMetadata() has been called on 'inputs_'.
+  // Computes distinctFields for this expression. Also updates any multiply
+  // referenced fields.
+  virtual void computeDistinctFields();
 
   const TypePtr type_;
   const std::vector<std::shared_ptr<Expr>> inputs_;

--- a/velox/expression/FieldReference.cpp
+++ b/velox/expression/FieldReference.cpp
@@ -20,6 +20,16 @@
 
 namespace facebook::velox::exec {
 
+void FieldReference::computeDistinctFields() {
+  SpecialForm::computeDistinctFields();
+  if (inputs_.empty()) {
+    mergeFields(
+        distinctFields_,
+        multiplyReferencedFields_,
+        {this->as<FieldReference>()});
+  }
+}
+
 // Fast path to avoid copying result.  An alternative way to do this is to
 // ensure that children has null if parent has nulls on corresponding rows,
 // whenever the RowVector is constructed or mutated (eager propagation of

--- a/velox/expression/FieldReference.h
+++ b/velox/expression/FieldReference.h
@@ -79,6 +79,9 @@ class FieldReference : public SpecialForm {
   std::string toSql(
       std::vector<VectorPtr>* complexConstants = nullptr) const override;
 
+ protected:
+  void computeDistinctFields() override;
+
  private:
   void
   apply(const SelectivityVector& rows, EvalCtx& context, VectorPtr& result);

--- a/velox/expression/LambdaExpr.cpp
+++ b/velox/expression/LambdaExpr.cpp
@@ -132,6 +132,15 @@ class ExprCallable : public Callable {
 
 } // namespace
 
+void LambdaExpr::computeDistinctFields() {
+  SpecialForm::computeDistinctFields();
+  std::vector<FieldReference*> capturedFields;
+  for (auto& field : capture_) {
+    capturedFields.push_back(field.get());
+  }
+  mergeFields(distinctFields_, multiplyReferencedFields_, capturedFields);
+}
+
 std::string LambdaExpr::toString(bool recursive) const {
   if (!recursive) {
     return name_;

--- a/velox/expression/LambdaExpr.h
+++ b/velox/expression/LambdaExpr.h
@@ -42,11 +42,7 @@ class LambdaExpr : public SpecialForm {
             trackCpuUsage),
         signature_(std::move(signature)),
         body_(std::move(body)),
-        capture_(std::move(capture)) {
-    for (auto& field : capture_) {
-      distinctFields_.push_back(field.get());
-    }
-  }
+        capture_(std::move(capture)) {}
 
   bool isConstant() const override {
     return false;
@@ -61,6 +57,9 @@ class LambdaExpr : public SpecialForm {
       const SelectivityVector& rows,
       EvalCtx& context,
       VectorPtr& result) override;
+
+ protected:
+  void computeDistinctFields() override;
 
  private:
   /// Used to initialize captureChannels_ and typeWithCapture_ on first use.


### PR DESCRIPTION
Currently the distinct fields for lambda expression are updated only
during construction. However, this can be an issue if we want to
clear and recompute it which happens when the expression is marked
as a shared expression. This change fixes it by ensuring recomputing
correctly updates the distinct fields every time.

Test Plan:
Added unit test