### PR TITLE
Provide clear error message for unsupported datetime units

### DIFF
--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -646,7 +646,6 @@ inline std::optional<DateTimeUnit> fromDateTimeUnitString(
   if (unit == kYear) {
     return DateTimeUnit::kYear;
   }
-  // TODO Add support for "week".
   if (throwIfInvalid) {
     VELOX_UNSUPPORTED("Unsupported datetime unit: {}", unitString);
   }
@@ -1017,7 +1016,7 @@ struct DateDiffFunction : public TimestampWithTimezoneSupport<T> {
     }
   }
 
-  FOLLY_ALWAYS_INLINE bool call(
+  FOLLY_ALWAYS_INLINE void call(
       int64_t& result,
       const arg_type<Varchar>& unitString,
       const arg_type<Timestamp>& timestamp1,
@@ -1046,10 +1045,9 @@ struct DateDiffFunction : public TimestampWithTimezoneSupport<T> {
     } else {
       result = diffTimestamp(unit, timestamp1, timestamp2);
     }
-    return true;
   }
 
-  FOLLY_ALWAYS_INLINE bool call(
+  FOLLY_ALWAYS_INLINE void call(
       int64_t& result,
       const arg_type<Varchar>& unitString,
       const arg_type<Date>& date1,
@@ -1059,15 +1057,14 @@ struct DateDiffFunction : public TimestampWithTimezoneSupport<T> {
         : getDateUnit(unitString, true).value();
 
     result = diffDate(unit, date1, date2);
-    return true;
   }
 
-  FOLLY_ALWAYS_INLINE bool call(
+  FOLLY_ALWAYS_INLINE void call(
       int64_t& result,
       const arg_type<Varchar>& unitString,
       const arg_type<TimestampWithTimezone>& timestamp1,
       const arg_type<TimestampWithTimezone>& timestamp2) {
-    return call(
+    call(
         result,
         unitString,
         this->toTimestamp(timestamp1),

--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -174,8 +174,10 @@ FOLLY_ALWAYS_INLINE Timestamp addToTimestamp(
       outTimestamp = inTimestamp + std::chrono::milliseconds(value);
       break;
     }
+    case DateTimeUnit::kWeek:
+      VELOX_UNSUPPORTED("Unsupported datetime unit: week")
     default:
-      VELOX_UNREACHABLE();
+      VELOX_UNREACHABLE("Unsupported datetime unit");
   }
 
   Timestamp milliTimestamp =
@@ -195,7 +197,7 @@ FOLLY_ALWAYS_INLINE int64_t diffTimestamp(
     return 0;
   }
 
-  int8_t sign = fromTimestamp < toTimestamp ? 1 : -1;
+  const int8_t sign = fromTimestamp < toTimestamp ? 1 : -1;
 
   // fromTimepoint is less than or equal to toTimepoint
   const std::chrono::
@@ -238,6 +240,8 @@ FOLLY_ALWAYS_INLINE int64_t diffTimestamp(
           std::chrono::duration_cast<date::days>(toTimepoint - fromTimepoint)
               .count();
     }
+    case DateTimeUnit::kWeek:
+      VELOX_UNSUPPORTED("Unsupported datetime unit: week")
     default:
       break;
   }
@@ -267,9 +271,8 @@ FOLLY_ALWAYS_INLINE int64_t diffTimestamp(
   const uint8_t toLastYearMonthDay =
       static_cast<unsigned>(toCalLastYearMonthDay.day());
 
-  int64_t diff;
   if (unit == DateTimeUnit::kMonth || unit == DateTimeUnit::kQuarter) {
-    diff = (int(toCalDate.year()) - int(fromCalDate.year())) * 12 +
+    int64_t diff = (int(toCalDate.year()) - int(fromCalDate.year())) * 12 +
         int(toMonth) - int(fromMonth);
 
     if ((toDay != toLastYearMonthDay && fromDay > toDay) ||
@@ -282,7 +285,7 @@ FOLLY_ALWAYS_INLINE int64_t diffTimestamp(
   }
 
   if (unit == DateTimeUnit::kYear) {
-    diff = (toCalDate.year() - fromCalDate.year()).count();
+    int64_t diff = (toCalDate.year() - fromCalDate.year()).count();
 
     if (fromMonth > toMonth ||
         (fromMonth == toMonth && fromDay > toDay &&
@@ -294,7 +297,7 @@ FOLLY_ALWAYS_INLINE int64_t diffTimestamp(
     return sign * diff;
   }
 
-  VELOX_UNREACHABLE();
+  VELOX_UNREACHABLE("Unsupported datetime unit");
 }
 
 FOLLY_ALWAYS_INLINE

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -1703,7 +1703,11 @@ TEST_F(DateTimeFunctionsTest, dateAddTimestamp) {
   EXPECT_EQ(std::nullopt, dateAdd("month", std::nullopt, Timestamp(0, 0)));
 
   // Check invalid units
-  EXPECT_THROW(dateAdd("invalid_unit", 1, Timestamp(0, 0)), VeloxUserError);
+  auto ts = Timestamp(0, 0);
+  VELOX_ASSERT_THROW(
+      dateAdd("invalid_unit", 1, ts),
+      "Unsupported datetime unit: invalid_unit");
+  VELOX_ASSERT_THROW(dateAdd("week", 1, ts), "Unsupported datetime unit: week");
 
   // Simple tests
   EXPECT_EQ(
@@ -2145,9 +2149,12 @@ TEST_F(DateTimeFunctionsTest, dateDiffTimestamp) {
   EXPECT_EQ(std::nullopt, dateDiff("month", std::nullopt, Timestamp(0, 0)));
 
   // Check invalid units
-  EXPECT_THROW(
+  VELOX_ASSERT_THROW(
       dateDiff("invalid_unit", Timestamp(1, 0), Timestamp(0, 0)),
-      VeloxUserError);
+      "Unsupported datetime unit: invalid_unit");
+  VELOX_ASSERT_THROW(
+      dateDiff("week", Timestamp(1, 0), Timestamp(0, 0)),
+      "Unsupported datetime unit: week");
 
   // Simple tests
   EXPECT_EQ(
@@ -2444,8 +2451,10 @@ TEST_F(DateTimeFunctionsTest, parseDatetime) {
   EXPECT_EQ(std::nullopt, parseDatetime(std::nullopt, std::nullopt));
 
   // Ensure it throws.
-  EXPECT_THROW(parseDatetime("", ""), VeloxUserError);
-  EXPECT_THROW(parseDatetime("1234", "Y Y"), VeloxUserError);
+  VELOX_ASSERT_THROW(parseDatetime("", ""), "Invalid pattern specification");
+  VELOX_ASSERT_THROW(
+      parseDatetime("1234", "Y Y"),
+      "Invalid format: \"1234\" is malformed at \"\"");
 
   // Simple tests. More exhaustive tests are provided as part of Joda's
   // implementation.


### PR DESCRIPTION
date_diff('week',...) and date_add('week',...) used to throw empty error. 

Now these report "Datetime unit 'week' is not supported"