### PR TITLE
Move HashBuild::setupFilterForAntiJoins to initialize().

### DIFF
--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -61,6 +61,8 @@ class HashBuild final : public Operator {
       DriverCtx* FOLLY_NONNULL driverCtx,
       std::shared_ptr<const core::HashJoinNode> joinNode);
 
+  void initialize() override;
+
   void addInput(RowVectorPtr input) override;
 
   RowVectorPtr getOutput() override {
@@ -323,6 +325,9 @@ class HashBuild final : public Operator {
   std::vector<column_index_t> keyFilterChannels_;
   // Indices of dependent columns used by the filter in 'decoders_'.
   std::vector<column_index_t> dependentFilterChannels_;
+
+  // Maps from key channel in 'input_' to channel in key.
+  folly::F14FastMap<column_index_t, column_index_t> keyChannelMap_;
 };
 
 inline std::ostream& operator<<(std::ostream& os, HashBuild::State state) {

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -326,7 +326,7 @@ class HashBuild final : public Operator {
   // Indices of dependent columns used by the filter in 'decoders_'.
   std::vector<column_index_t> dependentFilterChannels_;
 
-  // Maps from key channel in 'input_' to channel in key.
+  // Maps key channel in 'input_' to channel in key.
   folly::F14FastMap<column_index_t, column_index_t> keyChannelMap_;
 };
 

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -455,7 +455,7 @@ class HashJoinBuilder {
       auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
       std::shared_ptr<const core::HashJoinNode> joinNode;
       auto planNode =
-          PlanBuilder(planNodeIdGenerator)
+          PlanBuilder(planNodeIdGenerator, &pool_)
               .values(
                   testData.probeParallelize ? probeVectors_ : allProbeVectors_,
                   testData.probeParallelize)
@@ -2191,6 +2191,10 @@ TEST_P(MultiThreadedHashJoinTest, antiJoin) {
       // should not evaluate filter on those rows and therefore should not
       // fail.
       "t1 / coalesce(u1, 0::integer) is not null",
+      // This filter triggers memory pool allocation at
+      // HashBuild::setupFilterForAntiJoins, which should not be invoked in
+      // operator's constructor.
+      "contains(array[1, 2, NULL], 1)",
   });
   for (const std::string& filter : filters) {
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())


### PR DESCRIPTION
Part of https://github.com/facebookincubator/velox/issues/7233:
1. Extend `HashJoinTest` to trigger memory pool allocation at `HashBuild::setupFilterForAntiJoins`, so the driver can have a chance to detect if it's in operator ctor.
2. Move HashBuild::setupFilterForAntiJoins to initialize().