### PR TITLE
Fail if compare null for complex type in contains

### DIFF
--- a/velox/docs/functions/presto/array.rst
+++ b/velox/docs/functions/presto/array.rst
@@ -218,6 +218,12 @@ Array Functions
 .. function:: contains(x, element) -> boolean
 
     Returns true if the array ``x`` contains the ``element``.
+    When 'element' is of complex type, throws if 'x' or 'element' contains nested nulls
+    and these need to be compared to produce a result. ::
+
+    SELECT contains(ARRAY[ARRAY[1, 3]], ARRAY[2, null]); -- false.
+    SELECT contains(ARRAY[ARRAY[2, 3]], ARRAY[2, null]); -- failed: contains does not support arrays with elements that are null or contain null
+    SELECT contains(ARRAY[ARRAY[2, null]], ARRAY[2, 1]); -- failed: contains does not support arrays with elements that are null or contain null
 
 .. function:: element_at(array(E), index) -> E
 


### PR DESCRIPTION
In Presto, `contains` is applied to arrays of complex types with nested
nulls may or may not fail depending on whether need to compare
the nulls or not.

```SQL
presto> select contains(col0, col1) from (values (array[array[1, 3]], 
array[2, null])) as tbl(col0, col1);
 _col0
-------
 false
(1 row)

presto> select contains(col0, col1) from (values (array[array[2, 3]], 
array[2, null])) as tbl(col0, col1);
Query 20231027_015548_00004_whazu failed: contains does not
support arrays with elements that are null or contain null

presto> select contains(col0, col1) from (values (array[array[2, null]],
array[2, 3])) as tbl(col0, col1);
Query 20231027_015600_00005_whazu failed: contains does not
support arrays with elements that are null or contain null

presto> select contains(col0, col1) from (values (array[array[1, null]],
array[2, 3])) as tbl(col0, col1);
 _col0
-------
 false
(1 row)
```

This PR check the equal result and `setError` if compare
the nested nulls of complex type.