### PR TITLE
Report cache state when failing allocation after evict

### DIFF
--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -510,6 +510,10 @@ struct CacheStats {
   // lifetime for entries in cache.
   int64_t sumEvictScore{0};
 
+  // Total size of shared/exclusive pinned entries.
+  int64_t sharedPinnedBytes{0};
+  int64_t exclusivePinnedBytes{0};
+
   std::shared_ptr<SsdCacheStats> ssdStats = nullptr;
 
   std::string toString() const;

--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -789,6 +789,8 @@ TEST_F(AsyncDataCacheTest, cacheStats) {
   stats.numEntries = 100;
   stats.numExclusive = 20;
   stats.numShared = 30;
+  stats.sharedPinnedBytes = 10 << 20;
+  stats.exclusivePinnedBytes = 10 << 20;
   stats.numEmptyEntries = 20;
   stats.numPrefetch = 30;
   stats.prefetchBytes = 100;
@@ -803,7 +805,8 @@ TEST_F(AsyncDataCacheTest, cacheStats) {
   ASSERT_EQ(
       stats.toString(),
       "Cache size: 2.56KB tinySize: 257B large size: 2.31KB\n"
-      "Cache entries: 100 read pins: 30 write pins: 20 num write wait: 244 empty entries: 20\n"
+      "Cache entries: 100 read pins: 30 write pins: 20 pinned shared: 10.00MB pinned exclusive: 10.00MB\n"
+      " num write wait: 244 empty entries: 20\n"
       "Cache access miss: 2041 hit: 46 hit bytes: 1.34KB eviction: 463 eviction checks: 348\n"
       "Prefetch entries: 30 bytes: 100B\n"
       "Alloc Megaclocks 0");
@@ -815,7 +818,8 @@ TEST_F(AsyncDataCacheTest, cacheStats) {
       cache_->toString(),
       "AsyncDataCache:\n"
       "Cache size: 0B tinySize: 0B large size: 0B\n"
-      "Cache entries: 0 read pins: 0 write pins: 0 num write wait: 0 empty entries: 0\n"
+      "Cache entries: 0 read pins: 0 write pins: 0 pinned shared: 0B pinned exclusive: 0B\n"
+      " num write wait: 0 empty entries: 0\n"
       "Cache access miss: 0 hit: 0 hit bytes: 0B eviction: 0 eviction checks: 0\n"
       "Prefetch entries: 0 bytes: 0B\n"
       "Alloc Megaclocks 0\n"

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -161,6 +161,17 @@ class Cache {
   virtual MemoryAllocator* allocator() const = 0;
 };
 
+/// Sets a thread level failure message describing cache state. Used
+/// for example to expose why space could not be freed from
+/// cache. This is defined here with the abstract Cache base class
+/// and not the cache implementation because allocator cannot depend
+/// on cache.
+void setCacheFailureMessage(std::string message);
+
+/// Returns and clears a thread local message set with
+/// setCacheFailuremessage().
+std::string getAndClearCacheFailureMessage();
+
 /// This class provides interface for the actual memory allocations from memory
 /// pool. It allocates runs of machine pages from predefined size classes, and
 /// supports both contiguous and non-contiguous memory allocations. An
@@ -386,6 +397,11 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
     injectedFailure_ = InjectedFailure::kNone;
     isPersistentFailureInjection_ = false;
   }
+
+  /// Returns extra information after returning false from any of the allocate
+  /// functions. The error message is scoped to the most recent call on the
+  /// thread. The message is cleared after return.
+  std::string getAndClearFailureMessage();
 
  protected:
   explicit MemoryAllocator() = default;

--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -515,7 +515,11 @@ void MemoryPoolImpl::allocateNonContiguous(
           minSizeClass)) {
     VELOX_CHECK(out.empty());
     VELOX_MEM_ALLOC_ERROR(fmt::format(
-        "{} failed with {} pages from {}", __FUNCTION__, numPages, toString()));
+        "{} failed with {} pages from {} {}",
+        __FUNCTION__,
+        numPages,
+        toString(),
+        allocator_->getAndClearFailureMessage()));
   }
   DEBUG_RECORD_ALLOC(out);
   VELOX_CHECK(!out.empty());
@@ -563,7 +567,11 @@ void MemoryPoolImpl::allocateContiguous(
           maxPages)) {
     VELOX_CHECK(out.empty());
     VELOX_MEM_ALLOC_ERROR(fmt::format(
-        "{} failed with {} pages from {}", __FUNCTION__, numPages, toString()));
+        "{} failed with {} pages from {} {}",
+        __FUNCTION__,
+        numPages,
+        toString(),
+        allocator_->getAndClearFailureMessage()));
   }
   DEBUG_RECORD_ALLOC(out);
   VELOX_CHECK(!out.empty());
@@ -592,10 +600,11 @@ void MemoryPoolImpl::growContiguous(
             }
           })) {
     VELOX_MEM_ALLOC_ERROR(fmt::format(
-        "{} failed with {} pages from {}",
+        "{} failed with {} pages from {} {}",
         __FUNCTION__,
         increment,
-        toString()));
+        toString(),
+        allocator_->getAndClearFailureMessage()));
   }
   if (FOLLY_UNLIKELY(debugEnabled_)) {
     recordGrowDbg(allocation.data(), allocation.size());


### PR DESCRIPTION
Queries are sometimes killed by spurious allocation failures due to failing to evict cache fast enough. This tags the failure message wit the cache state. This allows distinguishing between not evicting fast enough and not having anything to evict. This adds a counter of pinned bytes. A failure to evict can result from too many pins. A large table scan can pind ~200MB per thread.