### PR TITLE
Move StreamingAggregation's initialization from ctor to initialize().

### DIFF
--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -32,28 +32,33 @@ StreamingAggregation::StreamingAggregation(
               ? "PartialAggregation"
               : "Aggregation"),
       outputBatchSize_{outputBatchRows()},
-      step_{aggregationNode->step()} {
-  auto numKeys = aggregationNode->groupingKeys().size();
+      aggregationNode_{aggregationNode},
+      step_{aggregationNode->step()} {}
+
+void StreamingAggregation::initialize() {
+  Operator::initialize();
+
+  auto numKeys = aggregationNode_->groupingKeys().size();
   decodedKeys_.resize(numKeys);
 
-  auto inputType = aggregationNode->sources()[0]->outputType();
+  auto inputType = aggregationNode_->sources()[0]->outputType();
 
   std::vector<TypePtr> groupingKeyTypes;
   groupingKeyTypes.reserve(numKeys);
 
   groupingKeys_.reserve(numKeys);
-  for (const auto& key : aggregationNode->groupingKeys()) {
+  for (const auto& key : aggregationNode_->groupingKeys()) {
     auto channel = exprToChannel(key.get(), inputType);
     groupingKeys_.push_back(channel);
     groupingKeyTypes.push_back(inputType->childAt(channel));
   }
 
-  auto numAggregates = aggregationNode->aggregates().size();
+  auto numAggregates = aggregationNode_->aggregates().size();
   aggregates_.reserve(numAggregates);
   std::vector<std::optional<column_index_t>> maskChannels;
   maskChannels.reserve(numAggregates);
   for (auto i = 0; i < numAggregates; i++) {
-    const auto& aggregate = aggregationNode->aggregates()[i];
+    const auto& aggregate = aggregationNode_->aggregates()[i];
 
     std::vector<column_index_t> channels;
     std::vector<VectorPtr> constants;
@@ -77,17 +82,17 @@ StreamingAggregation::StreamingAggregation(
     const auto& aggResultType = outputType_->childAt(numKeys + i);
     aggregates_.push_back(Aggregate::create(
         aggregate.call->name(),
-        isPartialOutput(aggregationNode->step())
+        isPartialOutput(aggregationNode_->step())
             ? core::AggregationNode::Step::kPartial
             : core::AggregationNode::Step::kSingle,
         aggregate.rawInputTypes,
         aggResultType,
-        driverCtx->queryConfig()));
+        operatorCtx_->driverCtx()->queryConfig()));
     args_.push_back(channels);
     constantArgs_.push_back(constants);
   }
 
-  if (aggregationNode->ignoreNullKeys()) {
+  if (aggregationNode_->ignoreNullKeys()) {
     VELOX_NYI("Streaming aggregation doesn't support ignoring null keys yet");
   }
 
@@ -101,7 +106,7 @@ StreamingAggregation::StreamingAggregation(
 
   rows_ = std::make_unique<RowContainer>(
       groupingKeyTypes,
-      !aggregationNode->ignoreNullKeys(),
+      !aggregationNode_->ignoreNullKeys(),
       accumulators,
       std::vector<TypePtr>{},
       false,
@@ -120,6 +125,8 @@ StreamingAggregation::StreamingAggregation(
         rowColumn.nullMask(),
         rows_->rowSizeOffset());
   }
+
+  aggregationNode_.reset();
 }
 
 void StreamingAggregation::close() {

--- a/velox/exec/StreamingAggregation.h
+++ b/velox/exec/StreamingAggregation.h
@@ -30,6 +30,8 @@ class StreamingAggregation : public Operator {
       DriverCtx* driverCtx,
       const std::shared_ptr<const core::AggregationNode>& aggregationNode);
 
+  void initialize() override;
+
   void addInput(RowVectorPtr input) override;
 
   RowVectorPtr getOutput() override;
@@ -70,6 +72,9 @@ class StreamingAggregation : public Operator {
 
   /// Maximum number of rows in the output batch.
   const uint32_t outputBatchSize_;
+
+  // Used at initialize() and gets reset() afterward.
+  std::shared_ptr<const core::AggregationNode> aggregationNode_;
 
   const core::AggregationNode::Step step_;
 

--- a/velox/exec/tests/StreamingAggregationTest.cpp
+++ b/velox/exec/tests/StreamingAggregationTest.cpp
@@ -52,6 +52,7 @@ class StreamingAggregationTest : public OperatorTestBase {
                          "max(c1)",
                          "sum(c1)",
                          "sumnonpod(1)",
+                         "sum(cast(NULL as INT))",
                          "approx_percentile(c1, 0.95)"})
                     .finalAggregation()
                     .planNode();
@@ -61,7 +62,7 @@ class StreamingAggregationTest : public OperatorTestBase {
             core::QueryConfig::kPreferredOutputBatchRows,
             std::to_string(outputBatchSize))
         .assertResults(
-            "SELECT c0, count(1), min(c1), max(c1), sum(c1), sum(1)"
+            "SELECT c0, count(1), min(c1), max(c1), sum(c1), sum(1), sum(cast(NULL as INT))"
             "     , approx_quantile(c1, 0.95) "
             "FROM tmp GROUP BY 1");
 


### PR DESCRIPTION
Part of https://github.com/facebookincubator/velox/issues/7233:
1. Extend `StreamingAggregationTest` to trigger memory pool allocation at `StreamingAggregation`'s initialization, so the driver can have a chance to detect if it's in operator ctor.
2. Move `StreamingAggregation`'s initialization from ctor to `initialize()`.