### PR TITLE
Fix from_unixtime when millisecond part is rounding to 1000

### DIFF
--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -405,6 +405,7 @@ TEST_F(DateTimeFunctionsTest, fromUnixtime) {
 
   EXPECT_EQ(Timestamp(0, 0), fromUnixtime(0));
   EXPECT_EQ(Timestamp(-1, 9000000), fromUnixtime(-0.991));
+  EXPECT_EQ(Timestamp(1, 0), fromUnixtime(1 - 1e-10));
   EXPECT_EQ(Timestamp(4000000000, 0), fromUnixtime(4000000000));
   EXPECT_EQ(
       Timestamp(9'223'372'036'854'775, 807'000'000), fromUnixtime(3.87111e+37));
@@ -3677,15 +3678,20 @@ TEST_F(DateTimeFunctionsTest, lastDayOfMonthTimestampWithTimezone) {
 }
 
 TEST_F(DateTimeFunctionsTest, fromUnixtimeDouble) {
-  auto input = makeFlatVector<double>(
-      {1623748302.,
-       1623748302.0,
-       1623748302.02,
-       1623748302.023,
-       1623748303.123,
-       1623748304.009,
-       1623748304.001,
-       1623748304.999});
+  auto input = makeFlatVector<double>({
+      1623748302.,
+      1623748302.0,
+      1623748302.02,
+      1623748302.023,
+      1623748303.123,
+      1623748304.009,
+      1623748304.001,
+      1623748304.999,
+      1623748304.001290,
+      1623748304.001890,
+      1623748304.999390,
+      1623748304.999590,
+  });
   auto actual =
       evaluate("cast(from_unixtime(c0) as varchar)", makeRowVector({input}));
   auto expected = makeFlatVector<StringView>({
@@ -3697,6 +3703,10 @@ TEST_F(DateTimeFunctionsTest, fromUnixtimeDouble) {
       "2021-06-15T09:11:44.009",
       "2021-06-15T09:11:44.001",
       "2021-06-15T09:11:44.999",
+      "2021-06-15T09:11:44.001",
+      "2021-06-15T09:11:44.002",
+      "2021-06-15T09:11:44.999",
+      "2021-06-15T09:11:45.000",
   });
   assertEqualVectors(expected, actual);
 }


### PR DESCRIPTION
Summary:
When this happens, we create an invalid `Timestamp` with invalid nano
part.

Differential Revision: D50740711


