### PR TITLE
Fix shared arbitrator registeration issue

### DIFF
--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -347,12 +347,4 @@ MemoryArbitrationContext* memoryArbitrationContext();
 
 /// Returns true if the running thread is under memory arbitration or not.
 bool underMemoryArbitration();
-
-#define VELOX_REGISTER_MEMORY_ARBITRATION_FACTORY(kind, factory)  \
-  namespace {                                                     \
-  static bool FB_ANONYMOUS_VARIABLE(g_MemoryArbitrationFactory) = \
-      facebook::velox::memory::MemoryArbitrator::registerFactory( \
-          kind,                                                   \
-          (factory));                                             \
-  }
 } // namespace facebook::velox::memory

--- a/velox/common/memory/tests/MemoryArbitratorTest.cpp
+++ b/velox/common/memory/tests/MemoryArbitratorTest.cpp
@@ -22,6 +22,7 @@
 #include "velox/common/memory/MallocAllocator.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/common/memory/MemoryArbitrator.h"
+#include "velox/exec/SharedArbitrator.h"
 
 using namespace ::testing;
 
@@ -97,6 +98,7 @@ TEST_F(MemoryArbitrationTest, queryMemoryCapacity) {
   }
   {
     // Reserved memory is enforced when SharedMemoryArbitrator is used.
+    exec::SharedArbitrator::registerFactory();
     auto allocator = std::make_shared<MallocAllocator>(8L << 20);
     MemoryManager manager{
         {.capacity = (int64_t)allocator->capacity(),
@@ -112,6 +114,7 @@ TEST_F(MemoryArbitrationTest, queryMemoryCapacity) {
         "Exceeded memory pool cap of 4.00MB");
     ASSERT_NO_THROW(buffer = leafPool->allocate(4L << 20));
     leafPool->free(buffer, 4L << 20);
+    exec::SharedArbitrator::unregisterFactory();
   }
 }
 

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -20,6 +20,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/MallocAllocator.h"
 #include "velox/common/memory/Memory.h"
+#include "velox/exec/SharedArbitrator.h"
 
 DECLARE_int32(velox_memory_num_shared_leaf_pools);
 DECLARE_bool(velox_enable_memory_usage_track_in_default_memory_pool);
@@ -40,6 +41,10 @@ MemoryManager& toMemoryManager(MemoryManager& manager) {
 
 class MemoryManagerTest : public testing::Test {
  protected:
+  static void SetUpTestCase() {
+    exec::SharedArbitrator::registerFactory();
+  }
+
   inline static const std::string arbitratorKind_{"SHARED"};
 };
 

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -24,6 +24,7 @@
 #include "velox/common/memory/Memory.h"
 #include "velox/common/memory/MmapAllocator.h"
 #include "velox/common/testutil/TestValue.h"
+#include "velox/exec/SharedArbitrator.h"
 
 DECLARE_bool(velox_memory_leak_check_enabled);
 DECLARE_bool(velox_memory_pool_debug_enabled);
@@ -73,6 +74,7 @@ class MemoryPoolTest : public testing::TestWithParam<TestParam> {
  protected:
   static constexpr uint64_t kDefaultCapacity = 8 * GB; // 8GB
   static void SetUpTestCase() {
+    exec::SharedArbitrator::registerFactory();
     FLAGS_velox_memory_leak_check_enabled = true;
     TestValue::enable();
   }

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -383,6 +383,7 @@ MockTask::~MockTask() {
 class MockSharedArbitrationTest : public testing::Test {
  protected:
   static void SetUpTestCase() {
+    exec::SharedArbitrator::registerFactory();
     FLAGS_velox_memory_leak_check_enabled = true;
     TestValue::enable();
   }

--- a/velox/exec/SharedArbitrator.cpp
+++ b/velox/exec/SharedArbitrator.cpp
@@ -57,11 +57,6 @@ std::string memoryPoolAbortMessage(
       << victim->treeMemoryUsage();
   return out.str();
 }
-
-std::unique_ptr<MemoryArbitrator> createSharedArbitrator(
-    const MemoryArbitrator::Config& config) {
-  return std::make_unique<SharedArbitrator>(config);
-}
 } // namespace
 
 SharedArbitrator::SharedArbitrator(const MemoryArbitrator::Config& config)
@@ -590,6 +585,14 @@ std::string SharedArbitrator::kind() const {
   return kind_;
 }
 
-VELOX_REGISTER_MEMORY_ARBITRATION_FACTORY("SHARED", createSharedArbitrator);
+void SharedArbitrator::registerFactory() {
+  MemoryArbitrator::registerFactory(
+      kind_, [](const MemoryArbitrator::Config& config) {
+        return std::make_unique<SharedArbitrator>(config);
+      });
+}
 
+void SharedArbitrator::unregisterFactory() {
+  MemoryArbitrator::unregisterFactory(kind_);
+}
 } // namespace facebook::velox::exec

--- a/velox/exec/SharedArbitrator.h
+++ b/velox/exec/SharedArbitrator.h
@@ -39,6 +39,10 @@ class SharedArbitrator : public memory::MemoryArbitrator {
 
   ~SharedArbitrator() override;
 
+  static void registerFactory();
+
+  static void unregisterFactory();
+
   void reserveMemory(MemoryPool* pool, uint64_t /*unused*/) final;
 
   void releaseMemory(MemoryPool* pool) final;

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -22,6 +22,7 @@
 #include "velox/dwio/common/FileSink.h"
 #include "velox/exec/Exchange.h"
 #include "velox/exec/OutputBufferManager.h"
+#include "velox/exec/SharedArbitrator.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
@@ -53,6 +54,7 @@ OperatorTestBase::~OperatorTestBase() {
 
 void OperatorTestBase::SetUpTestCase() {
   FLAGS_velox_enable_memory_usage_track_in_default_memory_pool = true;
+  exec::SharedArbitrator::registerFactory();
   functions::prestosql::registerAllScalarFunctions();
   aggregate::prestosql::registerAllAggregateFunctions();
   TestValue::enable();
@@ -60,6 +62,7 @@ void OperatorTestBase::SetUpTestCase() {
 
 void OperatorTestBase::TearDownTestCase() {
   waitForAllTasksToBeDeleted();
+  exec::SharedArbitrator::unregisterFactory();
 }
 
 void OperatorTestBase::SetUp() {


### PR DESCRIPTION
Revert the change use global variable to register memory arbitrator
and instead of explicitly registering the arbitrator factory in either test
or query system initialization code path.