### PR TITLE
Add VectorMaker::nestedArrayVectorFromJson helper method

### DIFF
--- a/velox/functions/prestosql/tests/ArrayAllMatchTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayAllMatchTest.cpp
@@ -92,21 +92,11 @@ TEST_F(ArrayAllMatchTest, basic) {
 }
 
 TEST_F(ArrayAllMatchTest, complexTypes) {
-  auto baseVector = makeArrayVector<int64_t>({
-      {1, 2, 3},
-      {2, 2},
-      {3, 3},
-      {4, 4},
-      {5, 5},
-      {},
+  auto arrayOfArrays = makeNestedArrayVectorFromJson<int32_t>({
+      "[[1, 2, 3]]",
+      "[[2, 2], [3, 3], [4, 4], [5, 5]]",
+      "[[]]",
   });
-  // Create an array of array vector using above base vector using offsets.
-  // [
-  //  [[1, 2, 3]],
-  //  [[2, 2], [3, 3], [4, 4], [5, 5]],
-  //  [[]]
-  // ]
-  auto arrayOfArrays = makeArrayVector({0, 1, 5}, baseVector);
   std::vector<std::optional<bool>> expectedResult{
       true,
       true,
@@ -114,14 +104,12 @@ TEST_F(ArrayAllMatchTest, complexTypes) {
   };
   testAllMatchExpr(expectedResult, "cardinality(x) > 0", arrayOfArrays);
 
-  // Create an array of array vector using above base vector using offsets.
-  // [
-  //  [[1, 2, 3]],  cardinalities is 3
-  //  [[2, 2], [3, 3], [4, 4], [5, 5]], all cardinalities is 2
-  //  [[]],
-  //  null
-  // ]
-  arrayOfArrays = makeArrayVector({0, 1, 5, 6}, baseVector, {3});
+  arrayOfArrays = makeNestedArrayVectorFromJson<int32_t>({
+      "[[1, 2, 3]]",
+      "[[2, 2], [3, 3], [4, 4], [5, 5]]",
+      "[[]]",
+      "null",
+  });
   expectedResult = {true, false, false, std::nullopt};
   testAllMatchExpr(expectedResult, "cardinality(x) > 2", arrayOfArrays);
 }

--- a/velox/functions/prestosql/tests/ArrayAnyMatchTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayAnyMatchTest.cpp
@@ -90,21 +90,11 @@ TEST_F(ArrayAnyMatchTest, basic) {
 }
 
 TEST_F(ArrayAnyMatchTest, complexTypes) {
-  auto baseVector = makeArrayVector<int64_t>({
-      {1, 2, 3},
-      {2, 2},
-      {3, 3},
-      {4, 4},
-      {5, 5},
-      {},
+  auto arrayOfArrays = makeNestedArrayVectorFromJson<int32_t>({
+      "[[1, 2, 3]]",
+      "[[2, 2], [3, 3], [4, 4], [5, 5]]",
+      "[[]]",
   });
-  // Create an array of array vector using above base vector using offsets.
-  // [
-  //  [[1, 2, 3]],
-  //  [[2, 2], [3, 3], [4, 4], [5, 5]],
-  //  [[]]
-  // ]
-  auto arrayOfArrays = makeArrayVector({0, 1, 5}, baseVector);
   std::vector<std::optional<bool>> expectedResult{
       true,
       true,
@@ -112,14 +102,12 @@ TEST_F(ArrayAnyMatchTest, complexTypes) {
   };
   testAnyMatchExpr(expectedResult, "cardinality(x) > 0", arrayOfArrays);
 
-  // Create an array of array vector using above base vector using offsets.
-  // [
-  //  [[1, 2, 3]],  cardinalities is 3
-  //  [[2, 2], [3, 3], [4, 4], [5, 5]], all cardinalities is 2
-  //  [[]],
-  //  null
-  // ]
-  arrayOfArrays = makeArrayVector({0, 1, 5, 6}, baseVector, {3});
+  arrayOfArrays = makeNestedArrayVectorFromJson<int32_t>({
+      "[[1, 2, 3]]",
+      "[[2, 2], [3, 3], [4, 4], [5, 5]]",
+      "[[]]",
+      "null",
+  });
   expectedResult = {
       true,
       false,

--- a/velox/functions/prestosql/tests/ArrayNoneMatchTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayNoneMatchTest.cpp
@@ -91,32 +91,20 @@ TEST_F(ArrayNoneMatchTest, basic) {
 }
 
 TEST_F(ArrayNoneMatchTest, complexTypes) {
-  auto baseVector = makeArrayVector<int64_t>({
-      {1, 2, 3},
-      {2, 2},
-      {3, 3},
-      {4, 4},
-      {5, 5},
-      {},
+  auto arrayOfArrays = makeNestedArrayVectorFromJson<int32_t>({
+      "[[1, 2, 3]]",
+      "[[2, 2], [3, 3], [4, 4], [5, 5]]",
+      "[[]]",
   });
-  // Create an array of array vector using above base vector using offsets.
-  // [
-  //  [[1, 2, 3]],
-  //  [[2, 2], [3, 3], [4, 4], [5, 5]],
-  //  [[]]
-  // ]
-  auto arrayOfArrays = makeArrayVector({0, 1, 5}, baseVector);
   std::vector<std::optional<bool>> expectedResult{false, false, true};
   testNoneMatchExpr(expectedResult, "cardinality(x) > 0", arrayOfArrays);
 
-  // Create an array of array vector using above base vector using offsets.
-  // [
-  //  [[1, 2, 3]],  cardinalities is 3
-  //  [[2, 2], [3, 3], [4, 4], [5, 5]], all cardinalities is 2
-  //  [[]],
-  //  null
-  // ]
-  arrayOfArrays = makeArrayVector({0, 1, 5, 6}, baseVector, {3});
+  arrayOfArrays = makeNestedArrayVectorFromJson<int32_t>({
+      "[[1, 2, 3]]",
+      "[[2, 2], [3, 3], [4, 4], [5, 5]]",
+      "[[]]",
+      "null",
+  });
   expectedResult = {false, true, true, std::nullopt};
   testNoneMatchExpr(expectedResult, "cardinality(x) > 2", arrayOfArrays);
 }

--- a/velox/vector/tests/utils/VectorMaker.h
+++ b/velox/vector/tests/utils/VectorMaker.h
@@ -588,21 +588,62 @@ class VectorMaker {
         arrays.push_back(std::nullopt);
         continue;
       }
-
       std::vector<std::optional<T>> elements;
-      for (const auto& element : arrayObject) {
-        if (element.isNull()) {
-          // Null element.
-          elements.push_back(std::nullopt);
-        } else {
-          elements.push_back(detail::jsonValue<T>(element));
-        }
-      }
-
+      appendElementsFromJsonArray(arrayObject, elements);
       arrays.push_back(elements);
     }
-
     return arrayVectorNullable<T>(arrays, arrayType);
+  }
+
+  /// Creates an ArrayVector from a list of JSON arrays of arrays.
+  ///
+  /// JSON array of arrays can represent a null array, an empty array or array
+  /// with null elements.
+  ///
+  /// Examples:
+  /// [[1, 2], [2, 3, 4], [null, 7]]
+  /// [[1, 3, 7, 9], []]
+  /// [] - empty array of arrays
+  /// null - null array of arrays
+  /// [null] - array of null array
+  /// [[]]
+  ///
+  /// @tparam T Type of array elements.
+  /// @param jsonArrays A list of JSON arrays. JSON array cannot be an empty
+  /// string.
+  template <typename T>
+  ArrayVectorPtr nestedArrayVectorFromJson(
+      const std::vector<std::string>& jsonArrays,
+      const TypePtr& arrayType = ARRAY(CppToType<T>::create())) {
+    std::vector<std::optional<std::vector<std::optional<T>>>> baseVector;
+    std::vector<vector_size_t> offsets;
+    std::vector<vector_size_t> nulls;
+    const std::vector<std::optional<T>> empty;
+    int offset = 0;
+    for (auto i = 0; i < jsonArrays.size(); i++) {
+      const auto& jsonArray = jsonArrays.at(i);
+      VELOX_CHECK(!jsonArray.empty());
+      const folly::dynamic arraysObject = folly::parseJson(jsonArray);
+      offsets.push_back(offset);
+      if (arraysObject.isNull()) {
+        // Null array.
+        nulls.push_back(i);
+        continue;
+      }
+      for (const auto& nestedArray : arraysObject) {
+        if (nestedArray.isNull()) {
+          // Null nested array
+          baseVector.push_back(std::nullopt);
+        } else {
+          std::vector<std::optional<T>> elements;
+          appendElementsFromJsonArray(nestedArray, elements);
+          baseVector.push_back(elements);
+        }
+      }
+      offset += arraysObject.size();
+    }
+    auto baseArrayVector = arrayVectorNullable<T>(baseVector, arrayType);
+    return arrayVector(offsets, baseArrayVector, nulls);
   }
 
   ArrayVectorPtr allNullArrayVector(
@@ -758,7 +799,8 @@ class VectorMaker {
   ///
   /// @tparam K Type of map keys. Must be an integer: int8_t, int16_t,
   /// int32_t, int64_t.
-  /// @tparam V Type of map value. Can be an integer or a floating point number.
+  /// @tparam V Type of map value. Can be an integer or a floating point
+  /// number.
   /// @param jsonMaps A list of JSON maps. JSON map cannot be an empty
   /// string.
   template <typename K, typename V>
@@ -847,9 +889,9 @@ class VectorMaker {
     return flatVector;
   }
 
-  /// Create an ArrayVector from a vector of offsets and a base element vector.
-  /// The size of the arrays is computed from the difference of offsets.
-  /// An optional vector of nulls can be passed to specify null rows.
+  /// Create an ArrayVector from a vector of offsets and a base element
+  /// vector. The size of the arrays is computed from the difference of
+  /// offsets. An optional vector of nulls can be passed to specify null rows.
   /// The offset for a null value must match previous offset
   /// i.e size computed should be zero.
   /// E.g arrayVector({0, 2 ,2}, elements, {1}) creates an array vector
@@ -881,6 +923,19 @@ class VectorMaker {
       BufferPtr* nulls,
       BufferPtr* offsets,
       BufferPtr* sizes);
+
+  template <typename T>
+  void appendElementsFromJsonArray(
+      const folly::dynamic& arrayObject,
+      std::vector<std::optional<T>>& elements) {
+    for (const auto& element : arrayObject) {
+      if (element.isNull()) {
+        elements.push_back(std::nullopt);
+      } else {
+        elements.push_back(detail::jsonValue<T>(element));
+      }
+    }
+  }
 
   memory::MemoryPool* pool_;
 };

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -459,6 +459,20 @@ class VectorTestBase {
         size, sizeAt, valueAt, isNullAt, valueIsNullAt, arrayType);
   }
 
+  /// Similar to makeArrayVectorFromJson. Creates an ArrayVector from list of
+  /// JSON arrays of arrays.
+  /// @tparam T Type of array elements. Must be an integer: int8_t, int16_t,
+  /// int32_t, int64_t.
+  /// @param jsonArrays A list of JSON arrays. JSON array cannot be an empty
+  /// string.
+  /// @param arrayType type of array elements.
+  template <typename T>
+  ArrayVectorPtr makeNestedArrayVectorFromJson(
+      const std::vector<std::string>& jsonArrays,
+      const TypePtr& arrayType = ARRAY(CppToType<T>::create())) {
+    return vectorMaker_.nestedArrayVectorFromJson<T>(jsonArrays, arrayType);
+  }
+
   template <typename T>
   ArrayVectorPtr makeArrayVector(
       vector_size_t size,


### PR DESCRIPTION
Add a helper method to create an array-of-arrays vectors from JSON.

Fixes #6896
