### PR TITLE
Back out "Support order-able and comparable variables In the simple function interface."

### DIFF
--- a/velox/core/tests/TypeAnalysisTest.cpp
+++ b/velox/core/tests/TypeAnalysisTest.cpp
@@ -17,7 +17,6 @@
 #include <gtest/gtest.h>
 
 #include "velox/core/SimpleFunctionMetadata.h"
-#include "velox/expression/FunctionSignature.h"
 #include "velox/type/Type.h"
 
 // Test for simple function type analysis.
@@ -71,11 +70,10 @@ class TypeAnalysisTest : public testing::Test {
   }
 
   template <typename... Args>
-  void testVariables(
-      const folly::F14FastMap<std::string, exec::SignatureVariable>& expected) {
+  void testVariables(const std::set<std::string>& expected) {
     TypeAnalysisResults results;
     (TypeAnalysis<Args>().run(results), ...);
-    ASSERT_EQ(expected, results.variablesInformation);
+    ASSERT_EQ(expected, results.variables);
   }
 
   template <typename... Args>
@@ -101,11 +99,6 @@ TEST_F(TypeAnalysisTest, hasGeneric) {
 
   testHasGeneric<Map<Array<Any>, Array<int32_t>>>(true);
   testHasGeneric<Map<Array<Generic<T1>>, Array<int32_t>>>(true);
-  testHasGeneric<Map<Array<Generic<T1, true, true>>, Array<int32_t>>>(true);
-  testHasGeneric<Map<Array<Generic<T1, true, false>>, Array<int32_t>>>(true);
-  testHasGeneric<Map<Array<Comparable<T1>>, Array<int32_t>>>(true);
-  testHasGeneric<Map<Array<Orderable<T1>>, Array<int32_t>>>(true);
-
   testHasGeneric<Map<Array<int32_t>, Any>>(true);
   testHasGeneric<Variadic<Any>>(true);
   testHasGeneric<Any>(true);
@@ -137,9 +130,6 @@ TEST_F(TypeAnalysisTest, hasVariadicOfGeneric) {
   testHasVariadicOfGeneric<Any, Variadic<int32_t>>(false);
 
   testHasVariadicOfGeneric<Variadic<Any>>(true);
-  testHasVariadicOfGeneric<Variadic<Comparable<T2>>>(true);
-  testHasVariadicOfGeneric<Variadic<Generic<T2, true, false>>>(true);
-
   testHasVariadicOfGeneric<Variadic<Any>, int32_t>(true);
   testHasVariadicOfGeneric<int32_t, Variadic<Array<Any>>>(true);
   testHasVariadicOfGeneric<int32_t, Variadic<Map<int64_t, Array<Generic<T1>>>>>(
@@ -153,9 +143,6 @@ TEST_F(TypeAnalysisTest, countConcrete) {
   testCountConcrete<int32_t, int32_t, double>(3);
   testCountConcrete<Any>(0);
   testCountConcrete<Generic<T1>>(0);
-  testCountConcrete<Generic<T1, true, false>>(0);
-  testCountConcrete<Orderable<T1>>(0);
-
   testCountConcrete<Variadic<Any>>(0);
   testCountConcrete<Variadic<int32_t>>(1);
   testCountConcrete<Variadic<Array<Any>>>(1);
@@ -192,21 +179,8 @@ TEST_F(TypeAnalysisTest, testStringType) {
       "integer",
       "bigint",
       "map(array(integer), __user_T2)",
-
   });
 
-  testStringType<int32_t, int64_t, Map<Array<int32_t>, Orderable<T2>>>({
-      "integer",
-      "bigint",
-      "map(array(integer), __user_T2)",
-
-  });
-  testStringType<int32_t, int64_t, Map<Array<int32_t>, Comparable<T2>>>({
-      "integer",
-      "bigint",
-      "map(array(integer), __user_T2)",
-
-  });
   testStringType<Array<int32_t>>({"array(integer)"});
   testStringType<Map<int64_t, double>>({"map(bigint, double)"});
   testStringType<Row<Any, double, Generic<T1>>>(
@@ -217,66 +191,11 @@ TEST_F(TypeAnalysisTest, testVariables) {
   testVariables<int32_t>({});
   testVariables<Array<int32_t>>({});
   testVariables<Any>({});
-
-  testVariables<Generic<T1>>(
-      {{"__user_T1",
-        exec::SignatureVariable(
-            "__user_T1",
-            std::nullopt,
-            exec::ParameterType::kTypeParameter,
-            false,
-            false,
-            false)}});
-
-  testVariables<Orderable<T1>>(
-      {{"__user_T1",
-        exec::SignatureVariable(
-            "__user_T1",
-            std::nullopt,
-            exec::ParameterType::kTypeParameter,
-            false,
-            true /*orderableTypesOnly*/,
-            true)}});
-
-  testVariables<Generic<T1, true, true>>(
-      {{"__user_T1",
-        exec::SignatureVariable(
-            "__user_T1",
-            std::nullopt,
-            exec::ParameterType::kTypeParameter,
-            false,
-            true /*orderableTypesOnly*/,
-            true /*comparableTypesOnly*/)}});
-
-  testVariables<Comparable<T1>>(
-      {{"__user_T1",
-        exec::SignatureVariable(
-            "__user_T1",
-            std::nullopt,
-            exec::ParameterType::kTypeParameter,
-            false,
-            false /*orderableTypesOnly*/,
-            true /*comparableTypesOnly*/)}});
-
+  testVariables<Generic<T1>>({"__user_T1"});
   testVariables<Map<Any, int32_t>>({});
   testVariables<Variadic<int32_t>>({});
-  testVariables<int32_t, Generic<T5>, Map<Array<int32_t>, Orderable<T2>>>(
-      {{"__user_T5",
-        exec::SignatureVariable(
-            "__user_T5",
-            std::nullopt,
-            exec::ParameterType::kTypeParameter,
-            false,
-            false /*orderableTypesOnly*/,
-            false /*comparableTypesOnly*/)},
-       {"__user_T2",
-        exec::SignatureVariable(
-            "__user_T2",
-            std::nullopt,
-            exec::ParameterType::kTypeParameter,
-            false,
-            true /*orderableTypesOnly*/,
-            true /*comparableTypesOnly*/)}});
+  testVariables<int32_t, Generic<T5>, Map<Array<int32_t>, Generic<T2>>>(
+      {"__user_T2", "__user_T5"});
 }
 
 TEST_F(TypeAnalysisTest, testRank) {
@@ -291,15 +210,12 @@ TEST_F(TypeAnalysisTest, testRank) {
   testRank<Any>(3);
   testRank<Array<int32_t>, Any, Variadic<int32_t>>(3);
   testRank<Array<int32_t>, Generic<T2>>(3);
-  testRank<Array<int32_t>, Comparable<T2>>(3);
-
   testRank<Array<Any>, Generic<T2>>(3);
   testRank<Array<Any>, int32_t>(3);
   testRank<Array<int32_t>, Any, Any>(3);
 
   testRank<Variadic<Any>>(4);
   testRank<Array<int32_t>, Any, Variadic<Array<Any>>>(4);
-  testRank<Array<int32_t>, Any, Variadic<Array<Generic<T2, true, true>>>>(4);
 }
 
 TEST_F(TypeAnalysisTest, testPriority) {

--- a/velox/exec/tests/FunctionResolutionTest.cpp
+++ b/velox/exec/tests/FunctionResolutionTest.cpp
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-#include <optional>
-
-#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/expression/SimpleFunctionRegistry.h"
 #include "velox/functions/Udf.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
@@ -319,119 +316,5 @@ TEST_F(FunctionResolutionTest, resolveCustomTypeTimestampWithTimeZone) {
       exec::simpleFunctions().resolveFunction("f_timestampzone", {})->type();
   EXPECT_EQ(type->toString(), TIMESTAMP_WITH_TIME_ZONE()->toString());
 }
-
-// A function that takes TInput and returns int, TInput determined at
-// registration.
-template <typename T>
-struct SingleInputFunc {
-  VELOX_DEFINE_FUNCTION_TYPES(T);
-  template <typename TInput>
-  void call(int64_t& out, const TInput&) {
-    out = 1;
-  }
-};
-
-// A function that takes two inputs of types TInput1, TInput2 and return int,
-// input types determined at registration.
-template <typename T>
-struct TwoInputFunc {
-  VELOX_DEFINE_FUNCTION_TYPES(T);
-  template <typename TInput1, typename TInput2>
-  void call(int64_t& out, const TInput1&, const TInput2&) {
-    out = 1;
-  }
-};
-
-TEST_F(FunctionResolutionTest, constrainedGenerics) {
-  registerFunction<SingleInputFunc, int64_t, Orderable<T1>>({"orderable"});
-  registerFunction<SingleInputFunc, int64_t, Comparable<T1>>({"comparable"});
-  registerFunction<SingleInputFunc, int64_t, Generic<T1>>({"generic"});
-
-  auto& registry = exec::simpleFunctions();
-
-  auto testSingleInput = [&](const auto& inputType) {
-    // Test orderable.
-    {
-      auto resolved = registry.resolveFunction("orderable", {inputType});
-      if (inputType->isOrderable()) {
-        EXPECT_EQ(TypeKind::BIGINT, resolved->type()->kind());
-      } else {
-        EXPECT_EQ(std::nullopt, resolved);
-      }
-    }
-
-    // Test comparable.
-    {
-      auto resolved = registry.resolveFunction("comparable", {inputType});
-
-      if (inputType->isComparable()) {
-        EXPECT_EQ(TypeKind::BIGINT, resolved->type()->kind());
-      } else {
-        EXPECT_EQ(std::nullopt, resolved);
-      }
-    }
-
-    // Test generic.
-    EXPECT_EQ(
-        TypeKind::BIGINT,
-        registry.resolveFunction("generic", {inputType})->type()->kind());
-  };
-
-  auto functionType = std::make_shared<FunctionType>(
-      std::vector<TypePtr>{BIGINT(), VARCHAR()}, BOOLEAN());
-
-  testSingleInput(INTEGER());
-  testSingleInput(functionType);
-  testSingleInput(ARRAY(INTEGER()));
-  testSingleInput(MAP(INTEGER(), INTEGER()));
-  testSingleInput(ROW({INTEGER(), MAP(INTEGER(), INTEGER())}));
-  testSingleInput(ARRAY(ARRAY(INTEGER())));
-
-  // Make sure we can't assign different properties to the same variable.
-  VELOX_ASSERT_THROW(
-      (registerFunction<TwoInputFunc, int64_t, Generic<T1>, Comparable<T1>>(
-          {"generic"})),
-      "Cant assign different properties to the same variable __user_T1");
-  VELOX_ASSERT_THROW(
-      (registerFunction<TwoInputFunc, int64_t, Orderable<T1>, Comparable<T1>>(
-          {"generic"})),
-      "Cant assign different properties to the same variable __user_T1");
-
-  // Expect two args to be the same and comprable.
-  registerFunction<TwoInputFunc, int64_t, Comparable<T1>, Comparable<T1>>(
-      {"same_comparable"});
-
-  EXPECT_EQ(
-      TypeKind::BIGINT,
-      registry.resolveFunction("same_comparable", {BIGINT(), BIGINT()})
-          ->type()
-          ->kind());
-
-  EXPECT_EQ(
-      std::nullopt,
-      registry.resolveFunction(
-          "same_comparable",
-          {MAP(INTEGER(), functionType), MAP(INTEGER(), functionType)}));
-  EXPECT_EQ(
-      std::nullopt,
-      registry.resolveFunction("same_comparable", {BIGINT(), DOUBLE()}));
-
-  // Orderable nested in array.
-  registerFunction<SingleInputFunc, int64_t, Array<Orderable<T1>>>(
-      {"nested_orderable"});
-
-  EXPECT_EQ(
-      std::nullopt,
-      registry.resolveFunction(
-          "nested_orderable", {ARRAY(MAP(BIGINT(), BIGINT()))}));
-  EXPECT_EQ(
-      std::nullopt, registry.resolveFunction("nested_orderable", {INTEGER()}));
-  EXPECT_EQ(
-      TypeKind::BIGINT,
-      registry.resolveFunction("nested_orderable", {ARRAY(INTEGER())})
-          ->type()
-          ->kind());
-}
-
 } // namespace
 } // namespace facebook::velox::exec

--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -1004,8 +1004,8 @@ struct HasGeneric {
   }
 };
 
-template <typename T, bool comparable, bool orderable>
-struct HasGeneric<Generic<T, comparable, orderable>> {
+template <typename T>
+struct HasGeneric<Generic<T>> {
   static constexpr bool value() {
     return true;
   }

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -274,11 +274,6 @@ class FunctionSignatureBuilder {
     return *this;
   }
 
-  FunctionSignatureBuilder& variable(const SignatureVariable& variable) {
-    addVariable(variables_, variable);
-    return *this;
-  }
-
   FunctionSignatureBuilder& knownTypeVariable(const std::string& name);
 
   /// Orderable implies comparable, this method would enable

--- a/velox/expression/UdfTypeResolver.h
+++ b/velox/expression/UdfTypeResolver.h
@@ -143,8 +143,8 @@ struct resolver<Variadic<T>> {
   // Variadic cannot be used as an out_type
 };
 
-template <typename T, bool comparable, bool orderable>
-struct resolver<Generic<T, comparable, orderable>> {
+template <typename T>
+struct resolver<Generic<T>> {
   using in_type = GenericView;
   using null_free_in_type = in_type;
   using out_type = GenericWriter;

--- a/velox/expression/VectorReaders.h
+++ b/velox/expression/VectorReaders.h
@@ -632,18 +632,16 @@ struct VectorReader<Variadic<T>> {
   std::vector<std::unique_ptr<VectorReader<T>>> childReaders_;
 };
 
-template <typename T, bool comparable, bool orderable>
-struct VectorReader<Generic<T, comparable, orderable>> {
+template <typename T>
+struct VectorReader<Generic<T>> {
   using exec_in_t = GenericView;
   using exec_null_free_in_t = exec_in_t;
 
   explicit VectorReader(const DecodedVector* decoded) : decoded_(*decoded) {}
 
-  explicit VectorReader(
-      const VectorReader<Generic<T, comparable, orderable>>&) = delete;
+  explicit VectorReader(const VectorReader<Generic<T>>&) = delete;
 
-  VectorReader<Generic<T, comparable, orderable>>& operator=(
-      const VectorReader<Generic<T, comparable, orderable>>&) = delete;
+  VectorReader<Generic<T>>& operator=(const VectorReader<Generic<T>>&) = delete;
 
   bool isSet(vector_size_t offset) const {
     return !decoded_.isNullAt(offset);

--- a/velox/expression/VectorWriters.h
+++ b/velox/expression/VectorWriters.h
@@ -487,14 +487,12 @@ struct VectorWriter<std::shared_ptr<T>> : public VectorWriterBase {
   vector_t* vector_;
 };
 
-template <typename T, bool comparable, bool orderable>
-struct VectorWriter<Generic<T, comparable, orderable>>
-    : public VectorWriterBase {
+template <typename T>
+struct VectorWriter<Generic<T>> : public VectorWriterBase {
   using exec_out_t = GenericWriter;
   using vector_t = BaseVector;
 
-  VectorWriter<Generic<T, comparable, orderable>>()
-      : writer_{castWriter_, castType_, offset_} {}
+  VectorWriter<Generic<T>>() : writer_{castWriter_, castType_, offset_} {}
 
   void setOffset(vector_size_t offset) override {
     offset_ = offset;

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1743,20 +1743,12 @@ using T8 = TypeVariable<8>;
 
 struct AnyType {};
 
-template <typename T = AnyType, bool comparable = false, bool orderable = false>
+template <typename T = AnyType>
 struct Generic {
   Generic() = delete;
-  static_assert(!(orderable && !comparable), "Orderable implies comparable.");
 };
 
 using Any = Generic<>;
-
-template <typename T>
-using Comparable = Generic<T, true, false>;
-
-// Orderable implies comparable.
-template <typename T>
-using Orderable = Generic<T, true, true>;
 
 template <typename>
 struct isVariadicType : public std::false_type {};
@@ -1767,9 +1759,8 @@ struct isVariadicType<Variadic<T>> : public std::true_type {};
 template <typename>
 struct isGenericType : public std::false_type {};
 
-template <typename T, bool comparable, bool orderable>
-struct isGenericType<Generic<T, comparable, orderable>>
-    : public std::true_type {};
+template <typename T>
+struct isGenericType<Generic<T>> : public std::true_type {};
 
 template <typename>
 struct isOpaqueType : public std::false_type {};
@@ -1922,8 +1913,8 @@ struct SimpleTypeTrait<IntervalYearMonth> : public SimpleTypeTrait<int32_t> {
   static constexpr const char* name = "INTERVAL YEAR TO MONTH";
 };
 
-template <typename T, bool comparable, bool orderable>
-struct SimpleTypeTrait<Generic<T, comparable, orderable>> {
+template <typename T>
+struct SimpleTypeTrait<Generic<T>> {
   static constexpr TypeKind typeKind = TypeKind::UNKNOWN;
   static constexpr bool isPrimitiveType = false;
   static constexpr bool isFixedWidth = false;


### PR DESCRIPTION
Summary:
Original commit changeset: a05c73ee0121

Original Phabricator Diff: D50568822

Reviewed By: kagamiori

Differential Revision: D50758626


