### PR TITLE
Support order-able and comparable variables In the simple function interface.

### DIFF
--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -1004,8 +1004,8 @@ struct HasGeneric {
   }
 };
 
-template <typename T>
-struct HasGeneric<Generic<T>> {
+template <typename T, bool comparable, bool orderable>
+struct HasGeneric<Generic<T, comparable, orderable>> {
   static constexpr bool value() {
     return true;
   }

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -274,6 +274,11 @@ class FunctionSignatureBuilder {
     return *this;
   }
 
+  FunctionSignatureBuilder& variable(const SignatureVariable& variable) {
+    addVariable(variables_, variable);
+    return *this;
+  }
+
   FunctionSignatureBuilder& knownTypeVariable(const std::string& name);
 
   /// Orderable implies comparable, this method would enable

--- a/velox/expression/UdfTypeResolver.h
+++ b/velox/expression/UdfTypeResolver.h
@@ -143,8 +143,8 @@ struct resolver<Variadic<T>> {
   // Variadic cannot be used as an out_type
 };
 
-template <typename T>
-struct resolver<Generic<T>> {
+template <typename T, bool comparable, bool orderable>
+struct resolver<Generic<T, comparable, orderable>> {
   using in_type = GenericView;
   using null_free_in_type = in_type;
   using out_type = GenericWriter;

--- a/velox/expression/VectorReaders.h
+++ b/velox/expression/VectorReaders.h
@@ -632,16 +632,18 @@ struct VectorReader<Variadic<T>> {
   std::vector<std::unique_ptr<VectorReader<T>>> childReaders_;
 };
 
-template <typename T>
-struct VectorReader<Generic<T>> {
+template <typename T, bool comparable, bool orderable>
+struct VectorReader<Generic<T, comparable, orderable>> {
   using exec_in_t = GenericView;
   using exec_null_free_in_t = exec_in_t;
 
   explicit VectorReader(const DecodedVector* decoded) : decoded_(*decoded) {}
 
-  explicit VectorReader(const VectorReader<Generic<T>>&) = delete;
+  explicit VectorReader(
+      const VectorReader<Generic<T, comparable, orderable>>&) = delete;
 
-  VectorReader<Generic<T>>& operator=(const VectorReader<Generic<T>>&) = delete;
+  VectorReader<Generic<T, comparable, orderable>>& operator=(
+      const VectorReader<Generic<T, comparable, orderable>>&) = delete;
 
   bool isSet(vector_size_t offset) const {
     return !decoded_.isNullAt(offset);

--- a/velox/expression/VectorWriters.h
+++ b/velox/expression/VectorWriters.h
@@ -487,12 +487,14 @@ struct VectorWriter<std::shared_ptr<T>> : public VectorWriterBase {
   vector_t* vector_;
 };
 
-template <typename T>
-struct VectorWriter<Generic<T>> : public VectorWriterBase {
+template <typename T, bool comparable, bool orderable>
+struct VectorWriter<Generic<T, comparable, orderable>>
+    : public VectorWriterBase {
   using exec_out_t = GenericWriter;
   using vector_t = BaseVector;
 
-  VectorWriter<Generic<T>>() : writer_{castWriter_, castType_, offset_} {}
+  VectorWriter<Generic<T, comparable, orderable>>()
+      : writer_{castWriter_, castType_, offset_} {}
 
   void setOffset(vector_size_t offset) override {
     offset_ = offset;

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1743,12 +1743,20 @@ using T8 = TypeVariable<8>;
 
 struct AnyType {};
 
-template <typename T = AnyType>
+template <typename T = AnyType, bool comparable = false, bool orderable = false>
 struct Generic {
   Generic() = delete;
+  static_assert(!(orderable && !comparable), "Orderable implies comparable.");
 };
 
 using Any = Generic<>;
+
+template <typename T>
+using Comparable = Generic<T, true, false>;
+
+// Orderable implies comparable.
+template <typename T>
+using Orderable = Generic<T, true, true>;
 
 template <typename>
 struct isVariadicType : public std::false_type {};
@@ -1759,8 +1767,9 @@ struct isVariadicType<Variadic<T>> : public std::true_type {};
 template <typename>
 struct isGenericType : public std::false_type {};
 
-template <typename T>
-struct isGenericType<Generic<T>> : public std::true_type {};
+template <typename T, bool comparable, bool orderable>
+struct isGenericType<Generic<T, comparable, orderable>>
+    : public std::true_type {};
 
 template <typename>
 struct isOpaqueType : public std::false_type {};
@@ -1913,8 +1922,8 @@ struct SimpleTypeTrait<IntervalYearMonth> : public SimpleTypeTrait<int32_t> {
   static constexpr const char* name = "INTERVAL YEAR TO MONTH";
 };
 
-template <typename T>
-struct SimpleTypeTrait<Generic<T>> {
+template <typename T, bool comparable, bool orderable>
+struct SimpleTypeTrait<Generic<T, comparable, orderable>> {
   static constexpr TypeKind typeKind = TypeKind::UNKNOWN;
   static constexpr bool isPrimitiveType = false;
   static constexpr bool isFixedWidth = false;


### PR DESCRIPTION
Summary:
Before this diff, Generic<X> used to be translated to variables with the properties
only comparable and only order-able always being false.
this limitation is problematic for some functions like ArrayMax and Eq.

this diff allow expressions Orderable<Tx> and Comprable<Tx> in the simple function interface.t

Differential Revision: D50759990


