### PR TITLE
Zero out complex-typed fields in RowContainer::freeVariableWidthFields

### DIFF
--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -277,7 +277,7 @@ char* RowContainer::newRow() {
 char* RowContainer::initializeRow(char* row, bool reuse) {
   if (reuse) {
     auto rows = folly::Range<char**>(&row, 1);
-    freeVariableWidthFields(rows, true);
+    freeVariableWidthFields(rows);
     freeAggregates(rows);
   } else if (rowSizeOffset_ != 0 && checkFree_) {
     // zero out string views so that clear() will not hit uninited data. The
@@ -353,9 +353,7 @@ int32_t RowContainer::findRows(folly::Range<char**> rows, char** result) {
   return numRows;
 }
 
-void RowContainer::freeVariableWidthFields(
-    folly::Range<char**> rows,
-    bool resetFields) {
+void RowContainer::freeVariableWidthFields(folly::Range<char**> rows) {
   for (auto i = 0; i < types_.size(); ++i) {
     switch (typeKinds_[i]) {
       case TypeKind::VARCHAR:
@@ -370,9 +368,7 @@ void RowContainer::freeVariableWidthFields(
             if (!view.isInline()) {
               stringAllocator_->free(
                   HashStringAllocator::headerOf(view.data()));
-              if (checkFree_ || resetFields) {
-                valueAt<StringView>(row, column.offset()) = StringView();
-              }
+              valueAt<StringView>(row, column.offset()) = StringView();
             }
           }
         }

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -1098,8 +1098,11 @@ class RowContainer {
       int32_t rightOffset,
       CompareFlags flags = CompareFlags());
 
-  // Free any variable-width fields associated with the 'rows'.
-  void freeVariableWidthFields(folly::Range<char**> rows);
+  // Free any variable-width fields associated with the 'rows'. If 'resetFields'
+  // is set to true, zero out complex-typed field in 'rows'.
+  void freeVariableWidthFields(
+      folly::Range<char**> rows,
+      bool resetFields = false);
 
   // Free any aggregates associated with the 'rows'.
   void freeAggregates(folly::Range<char**> rows);

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -1098,11 +1098,9 @@ class RowContainer {
       int32_t rightOffset,
       CompareFlags flags = CompareFlags());
 
-  // Free any variable-width fields associated with the 'rows'. If 'resetFields'
-  // is set to true, zero out complex-typed field in 'rows'.
-  void freeVariableWidthFields(
-      folly::Range<char**> rows,
-      bool resetFields = false);
+  // Free any variable-width fields associated with the 'rows' and zero out
+  // complex-typed field in 'rows'.
+  void freeVariableWidthFields(folly::Range<char**> rows);
 
   // Free any aggregates associated with the 'rows'.
   void freeAggregates(folly::Range<char**> rows);

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -1549,26 +1549,40 @@ TEST_F(RowContainerTest, toString) {
       "{3, winter, 12, 123.00299835205078, null}");
 }
 
-TEST_F(RowContainerTest, initializeRowForReuseStringView) {
-  std::vector<TypePtr> keyTypes = {BIGINT(), VARCHAR()};
-  auto rowContainer = std::make_unique<RowContainer>(keyTypes, pool_.get());
-
+TEST_F(RowContainerTest, initializeRowForReuseComplexTypes) {
   auto intVector = makeFlatVector<int64_t>({10, 20});
-  auto strVector = makeFlatVector<std::string>(
-      {"non-inline string", "another non-inline string"});
+  auto strVector = makeFlatVector<std::string>({"non-inline string"});
+  auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4, 5}});
+  auto mapVector = makeMapVector<int64_t, int64_t>({{{4, 41}}});
+  auto rowVector = makeRowVector({strVector, arrayVector, mapVector});
 
   DecodedVector decodedInt(*intVector);
+  std::vector<TypePtr> keyTypes = {
+      intVector->type(),
+      strVector->type(),
+      arrayVector->type(),
+      mapVector->type(),
+      rowVector->type()};
+  auto rowContainer = std::make_unique<RowContainer>(keyTypes, pool_.get());
+
   DecodedVector decodedString(*strVector);
+  DecodedVector decodedArray(*arrayVector);
+  DecodedVector decodedMap(*mapVector);
+  DecodedVector decodedRow(*rowVector);
 
   auto row = rowContainer->newRow();
-  // store both fields
+  // Store all fields.
   rowContainer->store(decodedInt, 0, row, 0);
   rowContainer->store(decodedString, 0, row, 1);
+  rowContainer->store(decodedArray, 0, row, 2);
+  rowContainer->store(decodedMap, 0, row, 3);
+  rowContainer->store(decodedRow, 0, row, 4);
 
-  // initializeRow for reuse, and don't store to the varchar field
+  // initializeRow() for reuse, and don't store to the complex-typed fields.
   rowContainer->initializeRow(row, true);
-  rowContainer->store(decodedInt, 0, row, 0);
+  rowContainer->store(decodedInt, 1, row, 0);
 
-  // initializeRow for reuse again, should not double free the varchar field
+  // initializeRow() for reuse again, this should not double free the
+  // complex-typed fields.
   rowContainer->initializeRow(row, true);
 }


### PR DESCRIPTION
An attempt to fix https://github.com/facebookincubator/velox/issues/7298:
1. Add test for repetitive call to `RowContainer::initializeRow(row, reuse = true)` with no write to complex-typed field of `row` in-between.
2. Make `RowContainer::freeVariableWidthFields` zero out non-inline-VARCHAR, ROW, ARRAY and MAP fields.