### PR TITLE
Use huge pages for containers only

### DIFF
--- a/velox/common/memory/Allocation.cpp
+++ b/velox/common/memory/Allocation.cpp
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-#include "velox/common/memory/Allocation.h"
-
 #include "velox/common/memory/Memory.h"
+#include "velox/common/memory/MemoryAllocator.h"
 
 namespace facebook::velox::memory {
 
@@ -98,6 +97,7 @@ void ContiguousAllocation::grow(MachinePageCount increment) {
 void ContiguousAllocation::clear() {
   pool_ = nullptr;
   set(nullptr, 0);
+  isHugePages_ = false;
 }
 
 MachinePageCount ContiguousAllocation::numPages() const {
@@ -114,6 +114,17 @@ std::optional<folly::Range<char*>> ContiguousAllocation::hugePageRange() const {
   }
   return folly::Range<char*>(
       reinterpret_cast<char*>(roundedBegin), roundedEnd - roundedBegin);
+}
+void ContiguousAllocation::useHugePages() {
+  if (!isHugePages_) {
+    MemoryAllocator::useHugePages(*this, true);
+  }
+}
+
+void ContiguousAllocation::revertHugePages() {
+  if (isHugePages_) {
+    MemoryAllocator::useHugePages(*this, false);
+  }
 }
 
 std::string ContiguousAllocation::toString() const {

--- a/velox/common/memory/Allocation.h
+++ b/velox/common/memory/Allocation.h
@@ -207,6 +207,7 @@ class ContiguousAllocation {
     pool_ = other.pool_;
     data_ = other.data_;
     size_ = other.size_;
+    isHugePages_ = other.isHugePages_;
     maxSize_ = other.maxSize_;
     other.clear();
     sanityCheck();
@@ -217,6 +218,7 @@ class ContiguousAllocation {
     pool_ = other.pool_;
     data_ = other.data_;
     size_ = other.size_;
+    isHugePages_ = other.isHugePages_;
     maxSize_ = other.maxSize_;
     other.clear();
     sanityCheck();
@@ -275,6 +277,17 @@ class ContiguousAllocation {
     return maxSize_;
   }
 
+  /// Requests huge pages if size is large enough.
+  void useHugePages();
+
+  /// Changes the backing memory to regular pages if huge pages are being used.
+  /// Called before unmapping.
+  void revertHugePages();
+
+  bool isHugePages() const {
+    return isHugePages_;
+  }
+
   std::string toString() const;
 
  private:
@@ -291,5 +304,11 @@ class ContiguousAllocation {
 
   // Offset of first byte after the mmap of 'data'.
   uint64_t maxSize_{0};
+
+  // True if huge pages madvise should be turned off before unmap.
+  bool isHugePages_{false};
+
+  friend class MemoryAllocator;
+  friend class MmapAllocator;
 };
 } // namespace facebook::velox::memory

--- a/velox/common/memory/AllocationPool.cpp
+++ b/velox/common/memory/AllocationPool.cpp
@@ -19,6 +19,8 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/memory/MemoryAllocator.h"
 
+DECLARE_bool(velox_memory_use_hugepages_for_containers);
+
 namespace facebook::velox::memory {
 
 folly::Range<char*> AllocationPool::rangeAt(int32_t index) const {
@@ -120,7 +122,9 @@ void AllocationPool::newRunImpl(MachinePageCount numPages) {
         AllocationTraits::numPagesInHugePage();
     pool_->allocateContiguous(
         pagesToAlloc, largeAlloc, AllocationTraits::numPages(nextSize));
-
+    if (FLAGS_velox_memory_use_hugepages_for_containers) {
+      largeAlloc.useHugePages();
+    }
     auto range = largeAlloc.hugePageRange().value();
     startOfRun_ = range.data();
     bytesInRun_ = range.size();

--- a/velox/common/memory/MemoryAllocator.cpp
+++ b/velox/common/memory/MemoryAllocator.cpp
@@ -327,13 +327,9 @@ std::string Stats::toString() const {
   return out.str();
 }
 
-void MemoryAllocator::useHugePages(
-    const ContiguousAllocation& data,
-    bool enable) {
+// static
+void MemoryAllocator::useHugePages(ContiguousAllocation& data, bool enable) {
 #ifdef linux
-  if (!FLAGS_velox_memory_use_hugepages) {
-    return;
-  }
   auto maybeRange = data.hugePageRange();
   if (!maybeRange.has_value()) {
     return;
@@ -342,6 +338,7 @@ void MemoryAllocator::useHugePages(
       maybeRange.value().data(),
       maybeRange.value().size(),
       enable ? MADV_HUGEPAGE : MADV_NOHUGEPAGE);
+  data.isHugePages_ = enable;
   if (rc != 0) {
     VELOX_MEM_LOG(WARNING) << "madvise hugepage errno="
                            << folly ::errnoStr(errno);

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -387,6 +387,10 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
     isPersistentFailureInjection_ = false;
   }
 
+  /// If 'data' is sufficiently large, enables/disables adaptive  huge pages for
+  /// the address range. Sets 'isHugePages_' in 'data'.
+  static void useHugePages(ContiguousAllocation& data, bool enable);
+
  protected:
   explicit MemoryAllocator() = default;
 
@@ -456,10 +460,6 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
     }
     return true;
   }
-
-  // If 'data' is sufficiently large, enables/disables adaptive  huge pages for
-  // the address raneg.
-  void useHugePages(const ContiguousAllocation& data, bool enable);
 
   // The machine page counts corresponding to different sizes in order
   // of increasing size.

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -25,6 +25,8 @@
 
 using facebook::velox::common::testutil::TestValue;
 
+DECLARE_bool(velox_memory_use_hugepages_for_containers);
+
 namespace facebook::velox::exec {
 // static
 std::string BaseHashTable::modeString(HashMode mode) {
@@ -695,6 +697,9 @@ void HashTable<ignoreNullKeys>::allocateTables(uint64_t size) {
   const auto numPages =
       memory::AllocationTraits::numPages(size * tableSlotSize());
   rows_->pool()->allocateContiguous(numPages, tableAllocation_);
+  if (FLAGS_velox_memory_use_hugepages_for_containers) {
+    tableAllocation_.useHugePages();
+  }
   table_ = tableAllocation_.data<char*>();
   memset(table_, 0, capacity_ * sizeof(char*));
 }
@@ -1230,6 +1235,9 @@ void HashTable<ignoreNullKeys>::setHashMode(HashMode mode, int32_t numNew) {
     const auto bytes = capacity_ * tableSlotSize();
     const auto numPages = memory::AllocationTraits::numPages(bytes);
     rows_->pool()->allocateContiguous(numPages, tableAllocation_);
+    if (FLAGS_velox_memory_use_hugepages_for_containers) {
+      tableAllocation_.useHugePages();
+    }
     table_ = tableAllocation_.data<char*>();
     memset(table_, 0, bytes);
     hashMode_ = HashMode::kArray;

--- a/velox/flag_definitions/flags.cpp
+++ b/velox/flag_definitions/flags.cpp
@@ -104,4 +104,12 @@ DEFINE_bool(
     "If true, suppress the verbose error message in memory capacity exceeded "
     "exception. This is only used by test to control the test error output size");
 
-DEFINE_bool(velox_memory_use_hugepages, true, "Use explicit huge pages");
+DEFINE_bool(
+    velox_memory_use_hugepages_for_containers,
+    true,
+    "Use explicit huge pages for large containers only");
+
+DEFINE_bool(
+    velox_memory_use_hugepages,
+    false,
+    "Use explicit huge pages for all allocations that are large enough");


### PR DESCRIPTION
If huge pages are used for all allocations that contain an aligned 2 MB range, the system time for rewiring the memory may become prohibitive.  We therefore use huge pages only for large long-lived containers that are accessed at random, that is AllocationPool and hash table arrays.

Adds a flag to ContiguousAllocation to indicate if huge pages are used.