### PR TITLE
Fix edge case for from_unixtime(double)

### DIFF
--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -60,6 +60,11 @@ FOLLY_ALWAYS_INLINE std::optional<Timestamp> fromUnixtime(double unixtime) {
 
   auto seconds = std::floor(unixtime);
   auto milliseconds = std::llround((unixtime - seconds) * kMillisInSecond);
+  VELOX_CHECK_LE(milliseconds, kMillisInSecond);
+  if (milliseconds == kMillisInSecond) {
+    ++seconds;
+    milliseconds = 0;
+  }
   return Timestamp(seconds, milliseconds * kNanosecondsInMillisecond);
 }
 

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -3685,7 +3685,11 @@ TEST_F(DateTimeFunctionsTest, fromUnixtimeDouble) {
        1623748303.123,
        1623748304.009,
        1623748304.001,
-       1623748304.999});
+       1623748304.999,
+       1623748304.001290,
+       1623748304.001890,
+       1623748304.999390,
+       1623748304.999590});
   auto actual =
       evaluate("cast(from_unixtime(c0) as varchar)", makeRowVector({input}));
   auto expected = makeFlatVector<StringView>({
@@ -3697,6 +3701,10 @@ TEST_F(DateTimeFunctionsTest, fromUnixtimeDouble) {
       "2021-06-15T09:11:44.009",
       "2021-06-15T09:11:44.001",
       "2021-06-15T09:11:44.999",
+      "2021-06-15T09:11:44.001",
+      "2021-06-15T09:11:44.002",
+      "2021-06-15T09:11:44.999",
+      "2021-06-15T09:11:45.000",
   });
   assertEqualVectors(expected, actual);
 }

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -76,11 +76,9 @@ struct Timestamp {
 
   Timestamp(int64_t seconds, uint64_t nanos)
       : seconds_(seconds), nanos_(nanos) {
-    VELOX_USER_DCHECK_GE(
-        seconds, kMinSeconds, "Timestamp seconds out of range");
-    VELOX_USER_DCHECK_LE(
-        seconds, kMaxSeconds, "Timestamp seconds out of range");
-    VELOX_USER_DCHECK_LE(nanos, kMaxNanos, "Timestamp nanos out of range");
+    VELOX_USER_CHECK_GE(seconds, kMinSeconds, "Timestamp seconds out of range");
+    VELOX_USER_CHECK_LE(seconds, kMaxSeconds, "Timestamp seconds out of range");
+    VELOX_USER_CHECK_LE(nanos, kMaxNanos, "Timestamp nanos out of range");
   }
 
   // Returns the current unix timestamp (ms precision).


### PR DESCRIPTION
To solve https://github.com/facebookincubator/velox/issues/5595, https://github.com/facebookincubator/velox/pull/7047 was introduced, 
but it didn't handle the case when millisecond is rounding to 1000

Also change the DCHECKs to regular checks to prevent invalid data penetrate 