### PR TITLE
Add spilling support for distinct aggregation

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -598,12 +598,10 @@ class AggregationNode : public PlanNode {
   }
 
   bool canSpill(const QueryConfig& queryConfig) const override {
-    // NOTE: as for now, we don't allow spilling for distinct aggregation
-    // (https://github.com/facebookincubator/velox/issues/3263) and pre-grouped
-    // aggregation (https://github.com/facebookincubator/velox/issues/3264). We
-    // will add support later to re-enable.
-    return (isFinal() || isSingle()) && !(aggregates().empty()) &&
-        preGroupedKeys().empty() && queryConfig.aggregationSpillEnabled();
+    // TODO: add spilling for pre-grouped aggregation later:
+    // https://github.com/facebookincubator/velox/issues/3264
+    return (isFinal() || isSingle()) && preGroupedKeys().empty() &&
+        queryConfig.aggregationSpillEnabled();
   }
 
   bool isFinal() const {

--- a/velox/core/tests/PlanFragmentTest.cpp
+++ b/velox/core/tests/PlanFragmentTest.cpp
@@ -154,7 +154,7 @@ TEST_F(PlanFragmentTest, aggregationCanSpill) {
   } testSettings[] = {
       {AggregationNode::Step::kSingle, false, true, false, false, false},
       {AggregationNode::Step::kSingle, true, false, false, false, false},
-      {AggregationNode::Step::kSingle, true, true, true, false, false},
+      {AggregationNode::Step::kSingle, true, true, true, false, true},
       {AggregationNode::Step::kSingle, true, true, false, true, false},
       {AggregationNode::Step::kSingle, true, true, false, false, true},
       {AggregationNode::Step::kIntermediate, false, true, false, false, false},
@@ -167,11 +167,11 @@ TEST_F(PlanFragmentTest, aggregationCanSpill) {
       {AggregationNode::Step::kPartial, true, true, true, false, false},
       {AggregationNode::Step::kPartial, true, true, false, true, false},
       {AggregationNode::Step::kPartial, true, true, false, false, false},
-      {AggregationNode::Step::kSingle, false, true, false, false, false},
-      {AggregationNode::Step::kSingle, true, false, false, false, false},
-      {AggregationNode::Step::kSingle, true, true, true, false, false},
-      {AggregationNode::Step::kSingle, true, true, false, true, false},
-      {AggregationNode::Step::kSingle, true, true, false, false, true}};
+      {AggregationNode::Step::kFinal, false, true, false, false, false},
+      {AggregationNode::Step::kFinal, true, false, false, false, false},
+      {AggregationNode::Step::kFinal, true, true, true, false, true},
+      {AggregationNode::Step::kFinal, true, true, false, true, false},
+      {AggregationNode::Step::kFinal, true, true, false, false, true}};
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -784,7 +784,7 @@ void GroupingSet::extractGroups(
   }
 }
 
-void GroupingSet::resetPartial() {
+void GroupingSet::resetTable() {
   if (table_ != nullptr) {
     table_->clear();
   }
@@ -940,9 +940,10 @@ void GroupingSet::spill(int64_t targetRows, int64_t targetBytes) {
   // NOTE: if the disk spilling is triggered by the memory arbitrator, then it
   // is possible that the grouping set hasn't processed any input data yet.
   // Correspondingly, 'table_' will not be initialized at that point.
-  if (table_ == nullptr) {
+  if (table_ == nullptr || table_->numDistinct() == 0) {
     return;
   }
+
   if (!hasSpilled()) {
     auto rows = table_->rows();
     auto types = rows->keyTypes();
@@ -1017,25 +1018,27 @@ bool GroupingSet::getOutputWithSpill(
     VELOX_CHECK_NULL(mergeRows_);
     VELOX_CHECK(mergeArgs_.empty());
 
-    mergeArgs_.resize(1);
-    std::vector<TypePtr> keyTypes;
-    for (auto& hasher : table_->hashers()) {
-      keyTypes.push_back(hasher->type());
+    if (!isDistinct()) {
+      mergeArgs_.resize(1);
+      std::vector<TypePtr> keyTypes;
+      for (auto& hasher : table_->hashers()) {
+        keyTypes.push_back(hasher->type());
+      }
+
+      mergeRows_ = std::make_unique<RowContainer>(
+          keyTypes,
+          !ignoreNullKeys_,
+          accumulators(false),
+          std::vector<TypePtr>(),
+          false,
+          false,
+          false,
+          false,
+          &pool_,
+          table_->rows()->stringAllocatorShared());
+
+      initializeAggregates(aggregates_, *mergeRows_, false);
     }
-
-    mergeRows_ = std::make_unique<RowContainer>(
-        keyTypes,
-        !ignoreNullKeys_,
-        accumulators(false),
-        std::vector<TypePtr>(),
-        false,
-        false,
-        false,
-        false,
-        &pool_,
-        table_->rows()->stringAllocatorShared());
-
-    initializeAggregates(aggregates_, *mergeRows_, false);
 
     VELOX_CHECK_EQ(table_->rows()->numRows(), 0);
     const auto nonSpillRows = spiller_->finishSpill();
@@ -1050,6 +1053,17 @@ bool GroupingSet::getOutputWithSpill(
 }
 
 bool GroupingSet::mergeNext(
+    int32_t maxOutputRows,
+    int32_t maxOutputBytes,
+    const RowVectorPtr& result) {
+  if (isDistinct()) {
+    return mergeNextWithoutAggregates(maxOutputRows, result);
+  } else {
+    return mergeNextWithAggregates(maxOutputRows, maxOutputBytes, result);
+  }
+}
+
+bool GroupingSet::mergeNextWithAggregates(
     int32_t maxOutputRows,
     int32_t maxOutputBytes,
     const RowVectorPtr& result) {
@@ -1079,6 +1093,47 @@ bool GroupingSet::mergeNext(
     }
   }
   VELOX_UNREACHABLE();
+}
+
+bool GroupingSet::mergeNextWithoutAggregates(
+    int32_t maxOutputRows,
+    const RowVectorPtr& result) {
+  VELOX_CHECK(isDistinct());
+
+  // We are looping over sorted rows produced by tree-of-losers. We logically
+  // split the stream into runs of duplicate rows. As we process each run we
+  // track whether one of the values comes from stream 0, in which case we
+  // should not produce a result from that run. Otherwise, we produce a result
+  // at the end of the run (when we know for sure whether the run contains a row
+  // from stream 0 or not).
+  //
+  // NOTE: stream 0 contains rows which has already been output as distinct
+  // before we trigger spilling.
+  bool newDistinct{true};
+  int32_t numOutputRows{0};
+  while (numOutputRows < maxOutputRows) {
+    const auto next = merge_->nextWithEquals();
+    auto* stream = next.first;
+    if (stream == nullptr) {
+      break;
+    }
+    if (stream->id() == 0) {
+      newDistinct = false;
+    }
+    if (next.second) {
+      stream->pop();
+      continue;
+    }
+    if (newDistinct) {
+      // Yield result for new distinct.
+      result->copy(
+          &stream->current(), numOutputRows++, stream->currentIndex(), 1);
+    }
+    stream->pop();
+    newDistinct = true;
+  }
+  result->resize(numOutputRows);
+  return numOutputRows > 0;
 }
 
 void GroupingSet::initializeRow(SpillMergeStream& stream, char* row) {
@@ -1244,5 +1299,12 @@ void GroupingSet::toIntermediate(
   // of HashAggregation::getOutput(). When toIntermediate() is called, the
   // aggregaiton function instances won't be reused after it returns.
   tempVectors_.clear();
+}
+
+std::optional<int64_t> GroupingSet::estimateOutputRowSize() const {
+  if (table_ == nullptr) {
+    return std::nullopt;
+  }
+  return table_->rows()->estimateRowSize();
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -78,6 +78,8 @@ class HashAggregation : public Operator {
   // the inputs.
   void recordSpillStats();
 
+  void updateEstimatedOutputRowSize();
+
   std::shared_ptr<const core::AggregationNode> aggregationNode_;
 
   const bool isPartialOutput_;
@@ -93,6 +95,11 @@ class HashAggregation : public Operator {
 
   int64_t maxPartialAggregationMemoryUsage_;
   std::unique_ptr<GroupingSet> groupingSet_;
+
+  // Size of a single output row estimated using
+  // 'groupingSet_->estimateRowSize()'. If spilling, this value is set to max
+  // 'groupingSet_->estimateRowSize()' across all accumulated data set.
+  std::optional<int64_t> estimatedOutputRowSize_;
 
   bool partialFull_ = false;
   bool newDistincts_ = false;


### PR DESCRIPTION
Add spilling support for distinct aggregation:
(1) when spilling has triggered, the hash aggregation operator stops producing the
distinct output rows;
(2) the spilling write out all the rows in row container to disk;
(3) during the output stage, we leverage the stream id from the spill file to tell if the
spilled row is a new distinct or not. If a spilled row contains in the first merge stream,
then it is not a new distinct, otherwise it is a new distinct.