### PR TITLE
Fix pushdown overflow in sum(bigint) Spark aggregate function

### DIFF
--- a/velox/dwio/common/SelectiveIntegerColumnReader.h
+++ b/velox/dwio/common/SelectiveIntegerColumnReader.h
@@ -179,7 +179,13 @@ void SelectiveIntegerColumnReader::processValueHook(
       readHelper<Reader, velox::common::AlwaysTrue, isDense>(
           &alwaysTrue(),
           rows,
-          ExtractToHook<aggregate::SumHook<int64_t, int64_t>>(hook));
+          ExtractToHook<aggregate::SumHook<int64_t, int64_t, false>>(hook));
+      break;
+    case aggregate::AggregationHook::kSumBigintToBigintOverflow:
+      readHelper<Reader, velox::common::AlwaysTrue, isDense>(
+          &alwaysTrue(),
+          rows,
+          ExtractToHook<aggregate::SumHook<int64_t, int64_t, true>>(hook));
       break;
     case aggregate::AggregationHook::kBigintMax:
       readHelper<Reader, velox::common::AlwaysTrue, isDense>(

--- a/velox/functions/lib/aggregates/SumAggregateBase.h
+++ b/velox/functions/lib/aggregates/SumAggregateBase.h
@@ -133,7 +133,7 @@ class SumAggregateBase
 
     if (mayPushdown && arg->isLazy()) {
       BaseAggregate::template pushdown<
-          facebook::velox::aggregate::SumHook<TValue, TData>>(
+          facebook::velox::aggregate::SumHook<TValue, TData, Overflow>>(
           groups, rows, arg);
       return;
     }

--- a/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
@@ -34,5 +34,9 @@ TEST_F(SumAggregationTest, overflow) {
   SumTestBase::testAggregateOverflow<int64_t, int64_t, int64_t>("spark_sum");
 }
 
+TEST_F(SumAggregationTest, hookLimits) {
+  testHookLimits<int64_t, int64_t, true>();
+}
+
 } // namespace
 } // namespace facebook::velox::functions::aggregate::sparksql::test


### PR DESCRIPTION
Fixes #7297

Support for allowing sum(bigint) overflow in Spark aggregate function was added in issue #7211. However, the part of aggregation pushdown was missing. This patch now adds support to allow overflow for the Spark sum(bigint) aggregate function during aggregation pushdown.