### PR TITLE
Add id to SpillMergeStream

### DIFF
--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -242,6 +242,12 @@ class RowContainerSpillMergeStream : public SpillMergeStream {
     }
   }
 
+  uint32_t id() const override {
+    // Returns the max uint32_t as the special id for in-memory spill merge
+    // stream.
+    return std::numeric_limits<uint32_t>::max();
+  }
+
  private:
   int32_t numSortingKeys() const override {
     return numSortingKeys_;

--- a/velox/exec/tests/HashJoinBridgeTest.cpp
+++ b/velox/exec/tests/HashJoinBridgeTest.cpp
@@ -94,10 +94,12 @@ class HashJoinBridgeTest : public testing::Test,
   }
 
   SpillFiles makeFakeSpillFiles(int32_t numFiles) {
+    static uint32_t fakeFileId{0};
     SpillFiles files;
     files.reserve(numFiles);
     for (int32_t i = 0; i < numFiles; ++i) {
       files.push_back(std::make_unique<SpillFile>(
+          fakeFileId++,
           rowType_,
           1,
           std::vector<CompareFlags>({}),

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -304,6 +304,14 @@ class SpillTest : public ::testing::TestWithParam<common::CompressionKind>,
         prevGStats.spillSortTimeUs + stats.spillSortTimeUs,
         newGStats.spillSortTimeUs);
 
+    // Verifies the spill file id
+    for (auto& partitionNum : state_->spilledPartitionSet()) {
+      const auto spilledFileIds = state_->testingSpilledFileIds(partitionNum);
+      uint32_t expectedFileId{0};
+      for (auto spilledFileId : spilledFileIds) {
+        ASSERT_EQ(spilledFileId, expectedFileId++);
+      }
+    }
     std::vector<std::string> spilledFiles = state_->testingSpilledFilePaths();
     std::unordered_set<std::string> spilledFileSet(
         spilledFiles.begin(), spilledFiles.end());


### PR DESCRIPTION
The id to SpillMergeStream to help order the spilled file from a given
spill partition. The spilled file id starts from zero of the first spilled file.
The in-memory spill stream has a special max uint32_t value. This
helps identify the first spilled file used in un-spilling merge path for
special handling such as distinct aggregation used to tell if a output
group is distinct or not. 