### PR TITLE
Simplify the hash aggregation spill processing

### DIFF
--- a/velox/common/config/SpillConfig.cpp
+++ b/velox/common/config/SpillConfig.cpp
@@ -27,8 +27,6 @@ SpillConfig::SpillConfig(
     int32_t _spillableReservationGrowthPct,
     uint8_t _startPartitionBit,
     uint8_t _joinPartitionBits,
-    uint8_t _aggregationPartitionBits,
-    bool _aggregationSpillAll,
     int32_t _maxSpillLevel,
     int32_t _testSpillPct,
     const std::string& _compressionKind)
@@ -43,8 +41,6 @@ SpillConfig::SpillConfig(
       spillableReservationGrowthPct(_spillableReservationGrowthPct),
       startPartitionBit(_startPartitionBit),
       joinPartitionBits(_joinPartitionBits),
-      aggregationPartitionBits(_aggregationPartitionBits),
-      aggregationSpillAll(_aggregationSpillAll),
       maxSpillLevel(_maxSpillLevel),
       testSpillPct(_testSpillPct),
       compressionKind(common::stringToCompressionKind(_compressionKind)) {

--- a/velox/common/config/SpillConfig.h
+++ b/velox/common/config/SpillConfig.h
@@ -33,8 +33,6 @@ struct SpillConfig {
       int32_t _spillableReservationGrowthPct,
       uint8_t _startPartitionBit,
       uint8_t _joinPartitionBits,
-      uint8_t _aggregationPartitionBits,
-      bool _aggregationSpillAll,
       int32_t _maxSpillLevel,
       int32_t _testSpillPct,
       const std::string& _compressionKind);
@@ -86,16 +84,6 @@ struct SpillConfig {
   /// Used to calculate the spill hash partition number for hash join with
   /// 'startPartitionBit'.
   uint8_t joinPartitionBits;
-
-  /// Used to calculate the spill hash partition number for aggregation with
-  /// 'startPartitionBit'.
-  uint8_t aggregationPartitionBits;
-
-  /// If true and spilling has been triggered during the input processing, the
-  /// spiller will spill all the remaining in-memory state to disk before output
-  /// processing. This is to simplify the aggregation query OOM prevention in
-  /// output processing stage.
-  bool aggregationSpillAll;
 
   /// The max allowed spilling level with zero being the initial spilling
   /// level. This only applies for hash build spilling which needs recursive

--- a/velox/common/testutil/tests/SpillConfigTest.cpp
+++ b/velox/common/testutil/tests/SpillConfigTest.cpp
@@ -36,8 +36,6 @@ TEST(SpillConfig, spillLevel) {
       kInitialBitOffset,
       kNumPartitionsBits,
       0,
-      false,
-      0,
       0,
       "none");
   struct {
@@ -120,8 +118,6 @@ TEST(SpillConfig, spillLevelLimit) {
         0,
         testData.startBitOffset,
         testData.numBits,
-        0,
-        false,
         testData.maxSpillLevel,
         0,
         "none");
@@ -166,8 +162,6 @@ TEST(SpillConfig, spillableReservationPercentages) {
           testData.growthPct,
           0,
           0,
-          0,
-          false,
           0,
           0,
           "none");

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -69,20 +69,7 @@ class HiveDataSinkTest : public exec::test::HiveConnectorTestBase {
         "planNodeId.HiveDataSinkTest",
         0);
     spillConfig_ = std::make_unique<SpillConfig>(
-        "HiveDataSinkTest",
-        0,
-        0,
-        0,
-        nullptr,
-        10,
-        20,
-        0,
-        0,
-        0,
-        false,
-        0,
-        0,
-        "none");
+        "HiveDataSinkTest", 0, 0, 0, nullptr, 10, 20, 0, 0, 0, 0, "none");
 
     auto hiveConnector =
         connector::getConnectorFactory(

--- a/velox/dwio/dwrf/test/E2EWriterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTest.cpp
@@ -254,8 +254,6 @@ class E2EWriterTest : public testing::Test {
         0,
         0,
         0,
-        false,
-        0,
         0,
         "none");
   }

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -142,8 +142,6 @@ std::optional<common::SpillConfig> DriverCtx::makeSpillConfig(
       queryConfig.spillableReservationGrowthPct(),
       queryConfig.spillStartPartitionBit(),
       queryConfig.joinSpillPartitionBits(),
-      queryConfig.aggregationSpillPartitionBits(),
-      queryConfig.aggregationSpillAll(),
       queryConfig.maxSpillLevel(),
       queryConfig.testingSpillPct(),
       queryConfig.spillCompressionKind());

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -223,9 +223,7 @@ void GroupingSet::noMoreInput() {
   // Spill the remaining in-memory state to disk if spilling has been triggered
   // on this grouping set. This is to simplify query OOM prevention when
   // producing output as we don't support to spill during that stage as for now.
-  // We will remove this limitation after we support spilling during the middle
-  // of output processing later.
-  if (hasSpilled() && spillConfig_->aggregationSpillAll) {
+  if (hasSpilled()) {
     spill(0, 0);
   }
 
@@ -729,6 +727,7 @@ bool GroupingSet::getOutput(
   if (hasSpilled()) {
     return getOutputWithSpill(maxOutputRows, maxOutputBytes, result);
   }
+  VELOX_CHECK(!isDistinct());
 
   // @lint-ignore CLANGTIDY
   char* groups[maxOutputRows];
@@ -753,7 +752,7 @@ void GroupingSet::extractGroups(
   if (groups.empty()) {
     return;
   }
-  RowContainer& rows = table_ ? *table_->rows() : *nonSpilledRowContainer_;
+  RowContainer& rows = *table_->rows();
   auto totalKeys = rows.keyTypes().size();
   for (int32_t i = 0; i < totalKeys; ++i) {
     auto keyVector = result->childAt(i);
@@ -848,23 +847,13 @@ void GroupingSet::ensureInputFits(const RowVectorPtr& input) {
   if (spillConfig_->testSpillPct > 0 &&
       (folly::hasher<uint64_t>()(++spillTestCounter_)) % 100 <=
           spillConfig_->testSpillPct) {
-    const auto rowsToSpill = std::max<int64_t>(1, numDistinct / 10);
-    spill(
-        numDistinct - rowsToSpill,
-        outOfLineBytes - (rowsToSpill * outOfLineBytesPerRow));
+    spill(0, 0);
     return;
   }
 
   const auto currentUsage = pool_.currentBytes();
   if (spillMemoryThreshold_ != 0 && currentUsage > spillMemoryThreshold_) {
-    const int64_t bytesToSpill =
-        currentUsage * spillConfig_->spillableReservationGrowthPct / 100;
-    auto rowsToSpill = std::max<int64_t>(
-        1, bytesToSpill / (rows->fixedRowSize() + outOfLineBytesPerRow));
-    spill(
-        std::max<int64_t>(0, numDistinct - rowsToSpill),
-        std::max<int64_t>(
-            0, outOfLineBytes - (rowsToSpill * outOfLineBytesPerRow)));
+    spill(0, 0);
     return;
   }
 
@@ -916,10 +905,7 @@ void GroupingSet::ensureInputFits(const RowVectorPtr& input) {
   // the operator memory pool.
   const auto rowsToSpill = std::max<int64_t>(
       1, targetIncrementBytes / (rows->fixedRowSize() + outOfLineBytesPerRow));
-  spill(
-      std::max<int64_t>(0, numDistinct - rowsToSpill),
-      std::max<int64_t>(
-          0, outOfLineBytes - (rowsToSpill * outOfLineBytesPerRow)));
+  spill(0, 0);
 }
 
 void GroupingSet::ensureOutputFits() {
@@ -973,10 +959,6 @@ void GroupingSet::spill(int64_t targetRows, int64_t targetBytes) {
         rows,
         [&](folly::Range<char**> rows) { table_->erase(rows); },
         ROW(std::move(names), std::move(types)),
-        HashBitRange(
-            spillConfig_->startPartitionBit,
-            spillConfig_->startPartitionBit +
-                spillConfig_->aggregationPartitionBits),
         rows->keyTypes().size(),
         std::vector<CompareFlags>(),
         spillConfig_->filePath,
@@ -1031,7 +1013,10 @@ bool GroupingSet::getOutputWithSpill(
     int32_t maxOutputRows,
     int32_t maxOutputBytes,
     const RowVectorPtr& result) {
-  if (outputPartition_ == -1) {
+  if (merge_ == nullptr) {
+    VELOX_CHECK_NULL(mergeRows_);
+    VELOX_CHECK(mergeArgs_.empty());
+
     mergeArgs_.resize(1);
     std::vector<TypePtr> keyTypes;
     for (auto& hasher : table_->hashers()) {
@@ -1052,95 +1037,53 @@ bool GroupingSet::getOutputWithSpill(
 
     initializeAggregates(aggregates_, *mergeRows_, false);
 
-    // Take ownership of the rows and free the hash table. The table will not be
-    // needed for producing spill output.
-    nonSpilledRowContainer_ = table_->moveRows();
-    table_.reset();
-    outputPartition_ = 0;
-    nonSpilledRows_ = spiller_->finishSpill();
-  }
+    VELOX_CHECK_EQ(table_->rows()->numRows(), 0);
+    const auto nonSpillRows = spiller_->finishSpill();
+    VELOX_CHECK(nonSpillRows.empty());
 
-  // NOTE: we don't expect non-spilled rows if spilling is triggered during the
-  // aggregation output processing.
-  if (spiller_->type() == Spiller::Type::kAggregateOutput) {
-    VELOX_CHECK_EQ(nonSpilledRows_.value().size(), 0);
+    merge_ = spiller_->startMerge(0);
   }
+  VELOX_CHECK_EQ(spiller_->state().maxPartitions(), 1);
+  VELOX_CHECK_NOT_NULL(merge_);
 
-  if (nonSpilledRowIndex_ < nonSpilledRows_.value().size()) {
-    const int32_t numGroups =
-        numNonSpilledGroupsToExtract(maxOutputRows, maxOutputBytes);
-    extractGroups(
-        folly::Range<char**>(
-            nonSpilledRows_.value().data() + nonSpilledRowIndex_, numGroups),
-        result);
-    nonSpilledRowIndex_ += numGroups;
-    return true;
-  }
-
-  while (outputPartition_ < spiller_->state().maxPartitions()) {
-    if (merge_ == nullptr) {
-      merge_ = spiller_->startMerge(outputPartition_);
-    }
-    // NOTE: 'merge_' might be nullptr if 'outputPartition_' is empty.
-    if (merge_ == nullptr ||
-        !mergeNext(maxOutputRows, maxOutputBytes, result)) {
-      ++outputPartition_;
-      merge_ = nullptr;
-      continue;
-    }
-    return true;
-  }
-  return false;
-}
-
-size_t GroupingSet::numNonSpilledGroupsToExtract(
-    int32_t maxOutputRows,
-    int32_t maxOutputBytes) const {
-  const size_t maxNumGroups = std::min<vector_size_t>(
-      maxOutputRows, nonSpilledRows_.value().size() - nonSpilledRowIndex_);
-  size_t totalBytes{0};
-  size_t nextRow = nonSpilledRowIndex_;
-  size_t numGroups{0};
-  for (; numGroups < maxNumGroups; ++numGroups, ++nextRow) {
-    const auto rowSize =
-        nonSpilledRowContainer_->rowSize(nonSpilledRows_.value()[nextRow]);
-    if (numGroups > 0 && (totalBytes + rowSize) >= maxOutputBytes) {
-      break;
-    }
-    totalBytes += rowSize;
-  }
-  return numGroups;
+  return mergeNext(maxOutputRows, maxOutputBytes, result);
 }
 
 bool GroupingSet::mergeNext(
     int32_t maxOutputRows,
     int32_t maxOutputBytes,
     const RowVectorPtr& result) {
+  VELOX_CHECK(!isDistinct());
+
+  // True if 'merge_' indicates that the next key is the same as the current
+  // one.
+  bool nextKeyIsEqual{false};
   for (;;) {
     auto next = merge_->nextWithEquals();
-    if (!next.first) {
+    if (next.first == nullptr) {
       extractSpillResult(result);
       return result->size() > 0;
     }
-    if (!nextKeyIsEqual_) {
+    if (!nextKeyIsEqual) {
       mergeState_ = mergeRows_->newRow();
       initializeRow(*next.first, mergeState_);
     }
     updateRow(*next.first, mergeState_);
-    nextKeyIsEqual_ = next.second;
+    nextKeyIsEqual = next.second;
     next.first->pop();
-    if (!nextKeyIsEqual_ &&
+    if (!nextKeyIsEqual &&
         ((mergeRows_->numRows() >= maxOutputRows) ||
          (mergeRows_->allocatedBytes() >= maxOutputBytes))) {
       extractSpillResult(result);
       return true;
     }
   }
+  VELOX_UNREACHABLE();
 }
 
-void GroupingSet::initializeRow(SpillMergeStream& keys, char* row) {
+void GroupingSet::initializeRow(SpillMergeStream& stream, char* row) {
   for (auto i = 0; i < keyChannels_.size(); ++i) {
-    mergeRows_->store(keys.decoded(i), keys.currentIndex(), mergeState_, i);
+    mergeRows_->store(stream.decoded(i), stream.currentIndex(), mergeState_, i);
   }
   vector_size_t zero = 0;
   for (auto& aggregate : aggregates_) {
@@ -1302,13 +1245,4 @@ void GroupingSet::toIntermediate(
   // aggregaiton function instances won't be reused after it returns.
   tempVectors_.clear();
 }
-
-std::optional<int64_t> GroupingSet::estimateRowSize() const {
-  const RowContainer* rows =
-      table_ ? table_->rows() : nonSpilledRowContainer_.get();
-  return rows && rows->estimateRowSize() >= 0
-      ? std::optional<int64_t>(rows->estimateRowSize())
-      : std::nullopt;
-};
-
 } // namespace facebook::velox::exec

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -135,14 +135,15 @@ class GroupingSet {
   /// single input row. Passes grouping keys through.
   void toIntermediate(const RowVectorPtr& input, RowVectorPtr& result);
 
-  /// Returns an estimate of the average row size.
-  std::optional<int64_t> estimateRowSize() const;
-
   memory::MemoryPool& testingPool() const {
     return pool_;
   }
 
  private:
+  bool isDistinct() const {
+    return aggregates_.empty();
+  }
+
   void addInputForActiveRows(const RowVectorPtr& input, bool mayPushdown);
 
   void addRemainingInput();
@@ -200,7 +201,7 @@ class GroupingSet {
       const RowVectorPtr& result);
 
   // Initializes a new row in 'mergeRows' with the keys from the
-  // current element from 'keys'. Accumulators are left in the initial
+  // current element from 'stream'. Accumulators are left in the initial
   // state with no data accumulated. This is called each time a new
   // key is received from a merge of spilled data. After this
   // updateRow() is called on the same element and on every subsequent
@@ -209,7 +210,7 @@ class GroupingSet {
   // accumulated and we have a new key, we produce the output and
   // clear 'mergeRows_' with extractSpillResult() and only then do
   // initializeRow().
-  void initializeRow(SpillMergeStream& keys, char* row);
+  void initializeRow(SpillMergeStream& stream, char* row);
 
   // Updates the accumulators in 'row' with the intermediate type data from
   // 'keys'. This is called for each row received from a merge of spilled data.
@@ -225,14 +226,6 @@ class GroupingSet {
   // 'excludeToIntermediate' is true, skip the functions that support
   // 'toIntermediate'.
   std::vector<Accumulator> accumulators(bool excludeToIntermediate);
-
-  // Calculates the number of groups to extract from 'rowsWhileReadingSpill_'
-  // container with rows starting at 'nonSpilledIndex_' in 'nonSpilledRows_'.
-  // 'maxOutputRows' and 'maxOutputBytes' specifies the max number of groups and
-  // bytes to extract.
-  size_t numNonSpilledGroupsToExtract(
-      int32_t maxOutputRows,
-      int32_t maxOutputBytes) const;
 
   bool getDefaultGlobalGroupingSetOutput(
       RowContainerIterator& iterator,
@@ -316,9 +309,6 @@ class GroupingSet {
   // The row with the current merge state, allocated from 'mergeRow_'.
   char* mergeState_ = nullptr;
 
-  // The currently running spill partition in producing spilled output.
-  int32_t outputPartition_{-1};
-
   // Intermediate vector for passing arguments to aggregate in merging spill.
   std::vector<VectorPtr> mergeArgs_;
 
@@ -326,23 +316,8 @@ class GroupingSet {
   // to merge.
   SelectivityVector mergeSelection_;
 
-  // True if 'merge_' indicates that the next key is the same as the current
-  // one.
-  bool nextKeyIsEqual_{false};
-
-  // The set of rows that are outside of the spillable hash number ranges. Used
-  // when producing output.
-  std::optional<Spiller::SpillRows> nonSpilledRows_;
-
-  // Index of first in 'nonSpilledRows_' that has not been added to output.
-  size_t nonSpilledRowIndex_{0};
-
   // Pool of the OperatorCtx. Used for spilling.
   memory::MemoryPool& pool_;
-
-  // The RowContainer of 'table_' is moved here before freeing 'table_' when
-  // starting to read spill output.
-  std::unique_ptr<RowContainer> nonSpilledRowContainer_;
 
   // Counts input batches and triggers spilling if folly hash of this % 100 <=
   // 'spillConfig_->testSpillPct'.

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -94,12 +94,12 @@ HashAggregation::HashAggregation(
       isDistinct_(!isGlobal_ && aggregationNode->aggregates().empty()),
       maxExtendedPartialAggregationMemoryUsage_(
           driverCtx->queryConfig().maxExtendedPartialAggregationMemoryUsage()),
-      maxPartialAggregationMemoryUsage_(
-          driverCtx->queryConfig().maxPartialAggregationMemoryUsage()),
       abandonPartialAggregationMinRows_(
           driverCtx->queryConfig().abandonPartialAggregationMinRows()),
       abandonPartialAggregationMinPct_(
-          driverCtx->queryConfig().abandonPartialAggregationMinPct()) {}
+          driverCtx->queryConfig().abandonPartialAggregationMinPct()),
+      maxPartialAggregationMemoryUsage_(
+          driverCtx->queryConfig().maxPartialAggregationMemoryUsage()) {}
 
 void HashAggregation::initialize() {
   Operator::initialize();
@@ -479,11 +479,13 @@ void HashAggregation::reclaim(
   if (noMoreInput_) {
     if (groupingSet_->hasSpilled()) {
       LOG(WARNING)
-          << "Can't reclaim from aggregation operator which has spilled and is under output processing, pool["
-          << pool()->toString()
-          << ", usage: " << succinctBytes(pool()->currentBytes()) << "]";
+          << "Can't reclaim from aggregation operator which has spilled and is under output processing, pool "
+          << pool()->name()
+          << ", memory usage: " << succinctBytes(pool()->currentBytes())
+          << ", reservation: " << succinctBytes(pool()->reservedBytes());
       return;
     }
+
     // Spill all the rows starting from the next output row pointed by
     // 'resultIterator_'.
     groupingSet_->spill(resultIterator_);

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -72,6 +72,8 @@ class HashAggregation : public Operator {
   // 'abandonPartialAggregationMinPct_' % of rows are unique.
   bool abandonPartialAggregationEarly(int64_t numOutput) const;
 
+  RowVectorPtr getDistinctOutput();
+
   // Invoked to record the spilling stats in operator stats after processing all
   // the inputs.
   void recordSpillStats();
@@ -82,6 +84,12 @@ class HashAggregation : public Operator {
   const bool isGlobal_;
   const bool isDistinct_;
   const int64_t maxExtendedPartialAggregationMemoryUsage_;
+  // Minimum number of rows to see before deciding to give up on partial
+  // aggregation.
+  const int32_t abandonPartialAggregationMinRows_;
+  // Min unique rows pct for partial aggregation. If more than this many rows
+  // are unique, the partial aggregation is not worthwhile.
+  const int32_t abandonPartialAggregationMinPct_;
 
   int64_t maxPartialAggregationMemoryUsage_;
   std::unique_ptr<GroupingSet> groupingSet_;
@@ -91,14 +99,6 @@ class HashAggregation : public Operator {
   bool finished_ = false;
   // True if partial aggregation has been found to be non-reducing.
   bool abandonedPartialAggregation_{false};
-
-  // Minimum number of rows to see before deciding to give up on partial
-  // aggregation.
-  const int32_t abandonPartialAggregationMinRows_;
-
-  // Min unique rows pct for partial aggregation. If more than this many rows
-  // are unique, the partial aggregation is not worthwhile.
-  const int32_t abandonPartialAggregationMinPct_;
 
   RowContainerIterator resultIterator_;
   bool pushdownChecked_ = false;

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -63,7 +63,10 @@ Spiller::Spiller(
           compressionKind,
           pool,
           executor) {
-  VELOX_CHECK_EQ(type_, Type::kOrderBy);
+  VELOX_CHECK(
+      type_ == Type::kOrderBy || type_ == Type::kAggregateInput,
+      "Unexpected spiller type: {}",
+      type_);
 }
 
 Spiller::Spiller(
@@ -164,7 +167,8 @@ Spiller::Spiller(
   VELOX_CHECK_EQ(container_ == nullptr, type_ == Type::kHashJoinProbe);
   // kOrderBy spiller type must only have one partition.
   VELOX_CHECK(
-      (type_ != Type::kOrderBy && type_ != Type::kAggregateOutput) ||
+      (type_ != Type::kOrderBy && type_ != Type::kAggregateInput &&
+       type_ != Type::kAggregateOutput) ||
       (state_.maxPartitions() == 1));
   spillRuns_.reserve(state_.maxPartitions());
   for (int i = 0; i < state_.maxPartitions(); ++i) {
@@ -679,9 +683,7 @@ void Spiller::fillSpillRuns(
     constexpr int32_t kHashBatchSize = 4096;
     std::vector<uint64_t> hashes(kHashBatchSize);
     std::vector<char*> rows(kHashBatchSize);
-    VELOX_CHECK((type_ != Type::kOrderBy) || bits_.numPartitions() == 1);
-    const bool isSinglePartition =
-        (type_ == Type::kOrderBy || bits_.numPartitions() == 1);
+    const bool isSinglePartition = bits_.numPartitions() == 1;
     for (;;) {
       auto numRows = container_->listRows(
           &iterator, rows.size(), RowContainer::kUnlimited, rows.data());

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -44,7 +44,7 @@ class Spiller {
   using SpillRows = std::vector<char*, memory::StlAllocator<char*>>;
 
   // The constructor without specifying hash bits which will only use one
-  // partition by default. It is only used by SortBuffer spiller type for now.
+  // partition by default.
   Spiller(
       Type type,
       RowContainer* container,

--- a/velox/exec/tests/SharedArbitratorTest.cpp
+++ b/velox/exec/tests/SharedArbitratorTest.cpp
@@ -801,7 +801,6 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimFromAggregation) {
               .spillDirectory(spillDirectory->path)
               .config(core::QueryConfig::kSpillEnabled, "true")
               .config(core::QueryConfig::kAggregationSpillEnabled, "true")
-              .config(core::QueryConfig::kAggregationSpillPartitionBits, "2")
               .queryCtx(aggregationQueryCtx)
               .plan(PlanBuilder()
                         .values(vectors)
@@ -902,7 +901,6 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimFromAggregationOnNoMoreInput) {
               .spillDirectory(spillDirectory->path)
               .config(core::QueryConfig::kSpillEnabled, "true")
               .config(core::QueryConfig::kAggregationSpillEnabled, "true")
-              .config(core::QueryConfig::kAggregationSpillPartitionBits, "2")
               .queryCtx(aggregationQueryCtx)
               .maxDrivers(1)
               .plan(PlanBuilder()
@@ -1009,7 +1007,6 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimFromAggregationDuringOutput) {
               .spillDirectory(spillDirectory->path)
               .config(core::QueryConfig::kSpillEnabled, "true")
               .config(core::QueryConfig::kAggregationSpillEnabled, "true")
-              .config(core::QueryConfig::kAggregationSpillPartitionBits, "2")
               .config(
                   core::QueryConfig::kPreferredOutputBatchRows,
                   std::to_string(numRows / 10))

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -44,20 +44,7 @@ class SortBufferTest : public OperatorTestBase {
 
   common::SpillConfig getSpillConfig(const std::string& spillFilePath) const {
     return common::SpillConfig(
-        spillFilePath,
-        0,
-        0,
-        0,
-        executor_.get(),
-        5,
-        10,
-        0,
-        0,
-        0,
-        false,
-        0,
-        0,
-        "none");
+        spillFilePath, 0, 0, 0, executor_.get(), 5, 10, 0, 0, 0, 0, "none");
   }
 
   const RowTypePtr inputType_ = ROW(
@@ -302,8 +289,6 @@ TEST_F(SortBufferTest, batchOutput) {
         0,
         0,
         0,
-        false,
-        0,
         100, //  testSpillPct
         "none");
     auto sortBuffer = std::make_unique<SortBuffer>(
@@ -396,8 +381,6 @@ TEST_F(SortBufferTest, spill) {
         spillableReservationGrowthPct,
         0,
         0,
-        0,
-        false,
         0,
         0,
         "none");


### PR DESCRIPTION
Simplify the hash aggregation spill processing by removing the
fine-grained partition control logic in grouping set:
- Always create aggregation spiller with single partition
- Always spill all the rows from spiller no matter it is triggered by memory arbitration,
   threshold or test injection
- Simplify the corresponding un-spilling code path.

The final or single aggregation is multi-threaded executed on a worker which means
that each aggregate operator runs a subset of data so that fine-grained partitioning
inside an operator is not that necessary.

The followup is to remove the corresponding query configs and simplification inside
the spiller.