### PR TITLE
Polish memory pool abort error message

### DIFF
--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -3162,7 +3162,7 @@ TEST_P(MemoryPoolTest, maybeReserveFailWithAbort) {
   ASSERT_TRUE(child->aborted());
   ASSERT_TRUE(root->aborted());
   VELOX_ASSERT_THROW(
-      child->maybeReserve(2 * kMaxSize), "This memory pool has been aborted.");
+      child->maybeReserve(2 * kMaxSize), "Manual MemoryPool Abortion");
 }
 
 // Model implementation of a GrowCallback.
@@ -3313,7 +3313,9 @@ TEST_P(MemoryPoolTest, abortAPI) {
       }
       ASSERT_TRUE(rootPool->aborted());
       {
-        abortPool(rootPool.get());
+        VELOX_ASSERT_THROW(
+            abortPool(rootPool.get()),
+            "Trying to set another abort error on an already aborted pool.");
         ASSERT_TRUE(rootPool->aborted());
       }
       ASSERT_TRUE(rootPool->aborted());
@@ -3375,7 +3377,9 @@ TEST_P(MemoryPoolTest, abortAPI) {
           "aggregateAbortAPI", MemoryReclaimer::create());
       ASSERT_TRUE(aggregatePool->aborted());
       {
-        abortPool(aggregatePool.get());
+        VELOX_ASSERT_THROW(
+            abortPool(aggregatePool.get()),
+            "Trying to set another abort error on an already aborted pool.");
         ASSERT_TRUE(aggregatePool->aborted());
         ASSERT_TRUE(leafPool->aborted());
         ASSERT_TRUE(rootPool->aborted());
@@ -3384,7 +3388,9 @@ TEST_P(MemoryPoolTest, abortAPI) {
       ASSERT_TRUE(leafPool->aborted());
       ASSERT_TRUE(rootPool->aborted());
       {
-        abortPool(rootPool.get());
+        VELOX_ASSERT_THROW(
+            abortPool(rootPool.get()),
+            "Trying to set another abort error on an already aborted pool.");
         ASSERT_TRUE(aggregatePool->aborted());
         ASSERT_TRUE(leafPool->aborted());
         ASSERT_TRUE(rootPool->aborted());

--- a/velox/exec/SharedArbitrator.cpp
+++ b/velox/exec/SharedArbitrator.cpp
@@ -273,8 +273,13 @@ bool SharedArbitrator::handleOOM(
                          << " to free up memory for requestor "
                          << requestor->name();
   try {
-    VELOX_MEM_POOL_ABORTED(
-        memoryPoolAbortMessage(victim, requestor, targetBytes));
+    if (victim == requestor) {
+      VELOX_MEM_POOL_CAP_EXCEEDED(
+          memoryPoolAbortMessage(victim, requestor, targetBytes));
+    } else {
+      VELOX_MEM_POOL_ABORTED(
+          memoryPoolAbortMessage(victim, requestor, targetBytes));
+    }
   } catch (VeloxRuntimeError& e) {
     abort(victim, std::current_exception());
   }


### PR DESCRIPTION
We have see memory pool aborted error which is a memory pool abort error when we actually run into memory reclaim error. This PR improves this
1. if the aborted memory pool is the same as the failed reclaim memory pool, a memory pool exceeded error is thrown
2. storing memory abort error with all error details in memory pool and rethrow when second time checking, to make sure there is no information loss at the client side for the final error message