### PR TITLE
Control Prefetching

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -251,6 +251,9 @@ CoalescedLoad::~CoalescedLoad() {
 bool CoalescedLoad::loadOrFuture(folly::SemiFuture<bool>* wait) {
   {
     std::lock_guard<std::mutex> l(mutex_);
+    if (wait == nullptr && state_ == State::kPlanned && !mayPrefetchLocked()) {
+      return true;
+    }
     if (state_ == State::kCancelled || state_ == State::kLoaded) {
       return true;
     }
@@ -746,6 +749,21 @@ CacheStats AsyncDataCache::refreshStats() const {
     stats.ssdStats = std::make_shared<SsdCacheStats>(ssdCache_->stats());
   }
   return stats;
+}
+
+bool AsyncDataCache::mayPrefetch(memory::MachinePageCount numPages) {
+  const auto cachePages = cachedPages_;
+  const auto maxPages =
+      memory::AllocationTraits::numPages(allocator_->capacity());
+  const auto allocatedPages = allocator_->numAllocated();
+  if (numPages < maxPages - allocatedPages) {
+    // There is free space for the read-ahead.
+    return true;
+  }
+  auto prefetchPages = prefetchPages_;
+  // Return true if the planned prefetch plus other prefetches are under half
+  // the cache.
+  return numPages + prefetchPages < cachePages / 2;
 }
 
 void AsyncDataCache::clear() {

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -441,6 +441,14 @@ class CoalescedLoad {
   }
 
  protected:
+  // Return false if a prefetch should not be started because of low
+  // memory or too many already outstanding prefetches. If this
+  // returns false, a call to loadOrFuture(nullptr) returns without
+  // changing the state of 'this'.
+  virtual bool mayPrefetchLocked() {
+    return true;
+  }
+
   // Makes entries for 'keys_' and loads their content. Elements of
   // 'keys_' that are already loaded or loading are expected to be left
   // out. The returned pins are expected to be exclusive with data
@@ -763,6 +771,10 @@ class AsyncDataCache : public memory::Cache {
   tsan_atomic<int32_t>& numSkippedSaves() {
     return numSkippedSaves_;
   }
+
+  /// Returns true if it is reasonable to prefetch 'numPages' more of prefetched
+  /// data.
+  bool mayPrefetch(memory::MachinePageCount numPages);
 
  private:
   static constexpr int32_t kNumShards = 4; // Must be power of 2.

--- a/velox/dwio/common/CachedBufferedInput.cpp
+++ b/velox/dwio/common/CachedBufferedInput.cpp
@@ -86,20 +86,7 @@ bool CachedBufferedInput::shouldPreload(int32_t numPages) {
                     memory::AllocationTraits::kPageSize) /
         memory::AllocationTraits::kPageSize;
   }
-  auto cachePages = cache_->incrementCachedPages(0);
-  auto allocator = cache_->allocator();
-  auto maxPages = memory::AllocationTraits::numPages(allocator->capacity());
-  auto allocatedPages = allocator->numAllocated();
-  if (numPages < maxPages - allocatedPages) {
-    // There is free space for the read-ahead.
-    return true;
-  }
-  auto prefetchPages = cache_->incrementPrefetchPages(0);
-  if (numPages + prefetchPages < cachePages / 2) {
-    // The planned prefetch plus other prefetches are under half the cache.
-    return true;
-  }
-  return false;
+  return cache_->mayPrefetch(numPages);
 }
 
 namespace {
@@ -219,6 +206,11 @@ void CachedBufferedInput::makeLoads(
   }
   bool isSsd = !requests[0]->ssdPin.empty();
   int32_t maxDistance = isSsd ? 20000 : options_.maxCoalesceDistance();
+  // If reading densely accessed, coalesce into large for best throughput, if
+  // for sparse, coalesce to quantum to reduce overread. Not all sparse access
+  // is correlated.
+  const auto maxCoalesceBytes =
+      prefetch ? options_.maxCoalesceBytes() : options_.loadQuantum();
   std::sort(
       requests.begin(),
       requests.end(),
@@ -248,7 +240,7 @@ void CachedBufferedInput::makeLoads(
         return size;
       },
       [&](int32_t index) {
-        if (coalescedBytes > options_.maxCoalesceBytes()) {
+        if (coalescedBytes > maxCoalesceBytes) {
           coalescedBytes = 0;
           return kNoCoalesce;
         }
@@ -314,6 +306,10 @@ class DwioCoalescedLoadBase : public cache::CoalescedLoad {
 
   int64_t size() const override {
     return size_;
+  }
+
+  bool mayPrefetchLocked() override {
+    return cache_.mayPrefetch(memory::AllocationTraits::numPages(size()));
   }
 
   std::string toString() const override {
@@ -404,7 +400,7 @@ class DwioCoalescedLoad : public DwioCoalescedLoadBase {
     auto stats = cache::readPins(
         pins,
         maxCoalesceDistance_,
-        1000,
+        1000, // Limit coalesce by size, not count.
         [&](int32_t i) { return pins[i].entry()->offset(); },
         [&](const std::vector<CachePin>& /*pins*/,
             int32_t /*begin*/,


### PR DESCRIPTION
Pre-opening files and loading metadata is generally useful to parallelize off the Driver control path. This is a latency dominated activity.  Loading large numbers of columns is not as clearly desirable since this can increase memory pressure by a multiple of the hot columns in a stripe, up to hundreds of MB per driver in the worst case.  So, add a hook that will decide whether there is space for prefetch right before allocating the memory for the cache or other buffers where the prefetch will go.

Adjust CachedBufferedInput coalescing to cut by size and not number of streams. There can be hundreds of small densely accessed streams that should coalesce. Also, for infrequently loaded data, lower the max coalesce because infrequent loads may not be correlated. These come from conditionals more than from top level conjuncts.