### PR TITLE
Fix crash in StreamingAggregation::close()

### DIFF
--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -130,7 +130,9 @@ void StreamingAggregation::initialize() {
 }
 
 void StreamingAggregation::close() {
-  rows_->clear();
+  if (rows_ != nullptr) {
+    rows_->clear();
+  }
   Operator::close();
 }
 


### PR DESCRIPTION
StreamingAggregation::close() may be called without calling StreamingAggregation::initialize(), 
hence, rows_ may be null. 