### PR TITLE
Add spill support for hive sort writer

### DIFF
--- a/velox/common/config/SpillConfig.cpp
+++ b/velox/common/config/SpillConfig.cpp
@@ -28,6 +28,7 @@ SpillConfig::SpillConfig(
     uint8_t _startPartitionBit,
     uint8_t _joinPartitionBits,
     int32_t _maxSpillLevel,
+    uint64_t _writerFlushThresholdSize,
     int32_t _testSpillPct,
     const std::string& _compressionKind)
     : filePath(_filePath),
@@ -42,6 +43,7 @@ SpillConfig::SpillConfig(
       startPartitionBit(_startPartitionBit),
       joinPartitionBits(_joinPartitionBits),
       maxSpillLevel(_maxSpillLevel),
+      writerFlushThresholdSize(_writerFlushThresholdSize),
       testSpillPct(_testSpillPct),
       compressionKind(common::stringToCompressionKind(_compressionKind)) {
   VELOX_USER_CHECK_GE(

--- a/velox/common/config/SpillConfig.h
+++ b/velox/common/config/SpillConfig.h
@@ -34,6 +34,7 @@ struct SpillConfig {
       uint8_t _startPartitionBit,
       uint8_t _joinPartitionBits,
       int32_t _maxSpillLevel,
+      uint64_t _writerFlushThresholdSize,
       int32_t _testSpillPct,
       const std::string& _compressionKind);
 
@@ -91,6 +92,10 @@ struct SpillConfig {
   /// is no limit and then some extreme large query might run out of spilling
   /// partition bits at the end.
   int32_t maxSpillLevel;
+
+  /// Minimum memory footprint size required to reclaim memory from a file
+  /// writer by flushing its buffered data to disk.
+  uint64_t writerFlushThresholdSize;
 
   /// Percentage of input batches to be spilled for testing. 0 means no
   /// spilling for test.

--- a/velox/common/testutil/tests/SpillConfigTest.cpp
+++ b/velox/common/testutil/tests/SpillConfigTest.cpp
@@ -37,6 +37,7 @@ TEST(SpillConfig, spillLevel) {
       kNumPartitionsBits,
       0,
       0,
+      0,
       "none");
   struct {
     uint8_t bitOffset;
@@ -120,6 +121,7 @@ TEST(SpillConfig, spillLevelLimit) {
         testData.numBits,
         testData.maxSpillLevel,
         0,
+        0,
         "none");
 
     ASSERT_EQ(
@@ -160,6 +162,7 @@ TEST(SpillConfig, spillableReservationPercentages) {
           nullptr,
           testData.minPct,
           testData.growthPct,
+          0,
           0,
           0,
           0,

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -166,10 +166,6 @@ int32_t HiveConfig::numCacheFileHandles(const Config* config) {
   return config->get<int32_t>(kNumCacheFileHandles, 20'000);
 }
 
-uint64_t HiveConfig::fileWriterFlushThresholdBytes(const Config* config) {
-  return config->get<int32_t>(kFileWriterFlushThresholdBytes, 96L << 20);
-}
-
 uint64_t HiveConfig::getOrcWriterMaxStripeSize(
     const Config* connectorQueryCtxConfig,
     const Config* connectorPropertiesConfig) {

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -107,12 +107,6 @@ class HiveConfig {
   /// Maximum number of entries in the file handle cache.
   static constexpr const char* kNumCacheFileHandles = "num_cached_file_handles";
 
-  /// The memory arbitrator might flush a file write to reclaim used memory if
-  /// its buffered data size is no less than this minimum threshold. The
-  /// buffered data size is measured by a file writer's memory footprint.
-  static constexpr const char* kFileWriterFlushThresholdBytes =
-      "file_writer_flush_threshold_bytes";
-
   // TODO: Refactor and merge config and session property.
   static constexpr const char* kOrcWriterMaxStripeSize =
       "orc_optimized_writer_max_stripe_size";

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -20,17 +20,19 @@
 #include "velox/common/testutil/TestValue.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HivePartitionFunction.h"
-#include "velox/connectors/hive/TableHandle.h"
 #include "velox/core/ITypedExpr.h"
 #include "velox/dwio/common/SortingWriter.h"
-#include "velox/exec/OperatorUtils.h"
 #include "velox/exec/SortBuffer.h"
+
+#include "velox/connectors/hive/TableHandle.h"
+#include "velox/exec/OperatorUtils.h"
 
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
 using facebook::velox::common::testutil::TestValue;
+
 namespace facebook::velox::connector::hive {
 
 namespace {
@@ -116,23 +118,17 @@ std::string computeBucketedFileName(
 
 std::shared_ptr<memory::MemoryPool> createSinkPool(
     const std::shared_ptr<memory::MemoryPool>& writerPool) {
-  auto sinkPool =
-      writerPool->addLeafChild(fmt::format("{}.sink", writerPool->name()));
-  if (writerPool->reclaimer() != nullptr) {
-    sinkPool->setReclaimer(exec::MemoryReclaimer::create());
-  }
-  return sinkPool;
+  return writerPool->addLeafChild(fmt::format("{}.sink", writerPool->name()));
 }
 
 std::shared_ptr<memory::MemoryPool> createSortPool(
     const std::shared_ptr<memory::MemoryPool>& writerPool) {
-  auto sortPool =
-      writerPool->addLeafChild(fmt::format("{}.sort", writerPool->name()));
-  if (writerPool->reclaimer() != nullptr) {
-    sortPool->setReclaimer(exec::MemoryReclaimer::create());
-  }
-  return sortPool;
+  return writerPool->addLeafChild(fmt::format("{}.sort", writerPool->name()));
 }
+
+#define WRITER_NON_RECLAIMABLE_SECTION_GUARD(index)     \
+  exec::NonReclaimableSectionGuard nonReclaimableGuard( \
+      writerInfo_[(index)]->nonReclaimableSectionHolder.get())
 } // namespace
 
 const HiveWriterId& HiveWriterId::unpartitionedId() {
@@ -142,13 +138,12 @@ const HiveWriterId& HiveWriterId::unpartitionedId() {
 
 std::string HiveWriterId::toString() const {
   if (!partitionId.has_value()) {
-    return "UNPARTITIONED";
+    return "unpart";
   }
   if (bucketId.has_value()) {
-    return fmt::format(
-        "PARTITIONED[{}.{}]", partitionId.value(), bucketId.value());
+    return fmt::format("part[{}.{}]", partitionId.value(), bucketId.value());
   }
-  return fmt::format("PARTITIONED[{}]", partitionId.value());
+  return fmt::format("part[{}]", partitionId.value());
 }
 
 const std::string LocationHandle::tableTypeName(
@@ -356,7 +351,7 @@ HiveDataSink::HiveDataSink(
 
 bool HiveDataSink::canReclaim() const {
   // Currently, we only support memory reclaim on dwrf file writer.
-  return (spillConfig_ != nullptr) && !sortWrite() &&
+  return (spillConfig_ != nullptr) &&
       (insertTableHandle_->tableStorageFormat() ==
        dwio::common::FileFormat::DWRF);
 }
@@ -380,8 +375,8 @@ void HiveDataSink::appendData(RowVectorPtr input) {
     input->childAt(i)->loadedVector();
   }
 
-  // All inputs belong to a single non-bucketed partition. The partition id must
-  // be zero.
+  // All inputs belong to a single non-bucketed partition. The partition id
+  // must be zero.
   if (!isBucketed() && partitionIdGenerator_->numPartitions() == 1) {
     const auto index = ensureWriter(HiveWriterId{0});
     write(index, input);
@@ -404,6 +399,7 @@ void HiveDataSink::appendData(RowVectorPtr input) {
 }
 
 void HiveDataSink::write(size_t index, const VectorPtr& input) {
+  WRITER_NON_RECLAIMABLE_SECTION_GUARD(index);
   writers_[index]->write(input);
   writerInfo_[index]->numWrittenRows += input->size();
 }
@@ -433,15 +429,20 @@ int32_t HiveDataSink::numWrittenFiles() const {
 std::shared_ptr<memory::MemoryPool> HiveDataSink::createWriterPool(
     const HiveWriterId& writerId) {
   auto* connectorPool = connectorQueryCtx_->connectorMemoryPool();
-  auto writerPool = connectorPool->addAggregateChild(
+  return connectorPool->addAggregateChild(
       fmt::format("{}.{}", connectorPool->name(), writerId.toString()));
-  if (connectorPool->reclaimer() != nullptr) {
-    writerPool->setReclaimer(WriterReclaimer::create(
-        canReclaim(),
-        HiveConfig::fileWriterFlushThresholdBytes(
-            connectorQueryCtx_->config())));
+}
+
+void HiveDataSink::setMemoryReclaimers(HiveWriterInfo* writerInfo) {
+  auto* connectorPool = connectorQueryCtx_->connectorMemoryPool();
+  if (connectorPool->reclaimer() == nullptr) {
+    return;
   }
-  return writerPool;
+  writerInfo->writerPool->setReclaimer(
+      WriterReclaimer::create(this, writerInfo));
+  writerInfo->sinkPool->setReclaimer(exec::MemoryReclaimer::create());
+  // NOTE: we set the memory reclaimer for sort pool when we construct the sort
+  // writer.
 }
 
 std::vector<std::string> HiveDataSink::close(bool success) {
@@ -500,13 +501,15 @@ void HiveDataSink::closeInternal(bool abort) {
 
   if (!abort) {
     closed_ = true;
-    for (const auto& writer : writers_) {
-      writer->close();
+    for (int i = 0; i < writers_.size(); ++i) {
+      WRITER_NON_RECLAIMABLE_SECTION_GUARD(i);
+      writers_[i]->close();
     }
   } else {
     aborted_ = true;
-    for (const auto& writer : writers_) {
-      writer->abort();
+    for (int i = 0; i < writers_.size(); ++i) {
+      WRITER_NON_RECLAIMABLE_SECTION_GUARD(i);
+      writers_[i]->abort();
     }
   }
 }
@@ -548,6 +551,7 @@ uint32_t HiveDataSink::appendWriter(const HiveWriterId& id) {
       std::move(writerPool),
       std::move(sinkPool),
       std::move(sortPool)));
+  setMemoryReclaimers(writerInfo_.back().get());
 
   dwio::common::WriterOptions options;
   options.schema = inputType_;
@@ -556,12 +560,17 @@ uint32_t HiveDataSink::appendWriter(const HiveWriterId& id) {
   if (canReclaim()) {
     options.spillConfig = spillConfig_;
   }
+  options.nonReclaimableSection =
+      writerInfo_.back()->nonReclaimableSectionHolder.get();
   options.maxStripeSize = std::optional(HiveConfig::getOrcWriterMaxStripeSize(
       connectorQueryCtx_->config(), connectorProperties_.get()));
   options.maxDictionaryMemory =
       std::optional(HiveConfig::getOrcWriterMaxDictionaryMemory(
           connectorQueryCtx_->config(), connectorProperties_.get()));
   ioStats_.emplace_back(std::make_shared<io::IoStatistics>());
+
+  // Prevents the memory allocation during the writer creation.
+  WRITER_NON_RECLAIMABLE_SECTION_GUARD(writerInfo_.size() - 1);
   auto writer = writerFactory_->createWriter(
       dwio::common::FileSink::create(
           writePath,
@@ -594,12 +603,12 @@ HiveDataSink::maybeCreateBucketSortWriter(
       inputType_,
       sortColumnIndices_,
       sortCompareFlags_,
-      1000, // todo batch size
+      // TODO: set batch size based on the query configs.
+      1000,
       sortPool,
-      &nonReclaimableSection_,
+      writerInfo_.back()->nonReclaimableSectionHolder.get(),
       &numSpillRuns_,
-      // TODO: enable spillling on sort buffer write later.
-      nullptr);
+      spillConfig_);
   return std::make_unique<dwio::common::SortingWriter>(
       std::move(writer), std::move(sortBuffer));
 }
@@ -666,9 +675,9 @@ std::pair<std::string, std::string> HiveDataSink::getWriterFileNames(
     targetFileName = computeBucketedFileName(
         connectorQueryCtx_->queryId(), bucketId.value());
   } else {
-    // targetFileName includes planNodeId and Uuid. As a result, different table
-    // writers run by the same task driver or the same table writer run in
-    // different task tries would have different targetFileNames.
+    // targetFileName includes planNodeId and Uuid. As a result, different
+    // table writers run by the same task driver or the same table writer
+    // run in different task tries would have different targetFileNames.
     targetFileName = fmt::format(
         "{}_{}_{}_{}",
         connectorQueryCtx_->taskId(),
@@ -798,21 +807,18 @@ LocationHandlePtr LocationHandle::create(const folly::dynamic& obj) {
 }
 
 std::unique_ptr<memory::MemoryReclaimer> HiveDataSink::WriterReclaimer::create(
-    bool canReclaim,
-    uint64_t flushThresholdBytes) {
+    HiveDataSink* dataSink,
+    HiveWriterInfo* writerInfo) {
   return std::unique_ptr<memory::MemoryReclaimer>(
-      new HiveDataSink::WriterReclaimer(canReclaim, flushThresholdBytes));
+      new HiveDataSink::WriterReclaimer(dataSink, writerInfo));
 }
 
 bool HiveDataSink::WriterReclaimer::reclaimableBytes(
     const memory::MemoryPool& pool,
     uint64_t& reclaimableBytes) const {
-  VELOX_CHECK_EQ(pool.kind(), memory::MemoryPool::Kind::kAggregate);
+  VELOX_CHECK_EQ(pool.name(), writerInfo_->writerPool->name());
   reclaimableBytes = 0;
-  if (!canReclaim_) {
-    return false;
-  }
-  if (pool.currentBytes() < flushThresholdBytes_) {
+  if (!dataSink_->canReclaim()) {
     return false;
   }
   return exec::MemoryReclaimer::reclaimableBytes(pool, reclaimableBytes);
@@ -822,23 +828,23 @@ uint64_t HiveDataSink::WriterReclaimer::reclaim(
     memory::MemoryPool* pool,
     uint64_t targetBytes,
     memory::MemoryReclaimer::Stats& stats) {
-  VELOX_CHECK_EQ(pool->kind(), memory::MemoryPool::Kind::kAggregate);
-  if (!canReclaim_) {
+  VELOX_CHECK_EQ(pool->name(), writerInfo_->writerPool->name());
+  if (!dataSink_->canReclaim()) {
+    return 0;
+  }
+
+  if (*writerInfo_->nonReclaimableSectionHolder.get()) {
+    LOG(WARNING) << "Can't reclaim from hive writer pool " << pool->name()
+                 << " which is under non-reclaimable section, "
+                 << " used memory: " << succinctBytes(pool->currentBytes())
+                 << ", reserved memory: "
+                 << succinctBytes(pool->reservedBytes());
+    ++stats.numNonReclaimableAttempts;
     return 0;
   }
 
   const uint64_t memoryUsageBeforeReclaim = pool->currentBytes();
   const std::string memoryUsageTreeBeforeReclaim = pool->treeMemoryUsage();
-  if (memoryUsageBeforeReclaim < flushThresholdBytes_) {
-    LOG(WARNING)
-        << "Can't reclaim memory from writer pool " << pool->name()
-        << " which doesn't have sufficient memory to flush, writer memory usage: "
-        << succinctBytes(memoryUsageBeforeReclaim)
-        << ", writer flush threshold: " << succinctBytes(flushThresholdBytes_);
-    ++stats.numNonReclaimableAttempts;
-    return 0;
-  }
-
   const auto reclaimedBytes =
       exec::MemoryReclaimer::reclaim(pool, targetBytes, stats);
   const uint64_t memoryUsageAfterReclaim = pool->currentBytes();

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -281,6 +281,11 @@ class QueryConfig {
   static constexpr const char* kSpillableReservationGrowthPct =
       "spillable_reservation_growth_pct";
 
+  /// Minimum memory footprint size required to reclaim memory from a file
+  /// writer by flushing its buffered data to disk.
+  static constexpr const char* kWriterFlushThresholdBytes =
+      "writer_flush_threshold_bytes";
+
   /// If true, array_agg() aggregation function will ignore nulls in the input.
   static constexpr const char* kPrestoArrayAggIgnoreNulls =
       "presto.array_agg.ignore_nulls";
@@ -563,6 +568,10 @@ class QueryConfig {
 
   bool aggregationSpillAll() const {
     return get<bool>(kAggregationSpillAll, true);
+  }
+
+  uint64_t writerFlushThresholdBytes() const {
+    return get<uint64_t>(kWriterFlushThresholdBytes, 96L << 20);
   }
 
   uint64_t maxSpillFileSize() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -237,6 +237,10 @@ Spilling
      - integer
      - 0
      - Maximum amount of memory in bytes that an order by can use before spilling. 0 means unlimited.
+   * - writer_flush_threshold_bytes
+     - integer
+     - 96MB
+     - Minimum memory footprint size required to reclaim memory from a file writer by flushing its buffered data to disk.
    * - min_spillable_reservation_pct
      - integer
      - 5
@@ -382,10 +386,6 @@ Hive Connector
      - integer
      - 128MB
      - Maximum distance in bytes between chunks to be fetched that may be coalesced into a single request.
-   * - file_writer_flush_threshold_bytes
-     - integer
-     - 96MB
-     - Minimum memory footprint size required to reclaim memory from a file writer by flushing its buffered data to disk.
 
 ``Amazon S3 Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -550,6 +550,7 @@ struct WriterOptions {
   TypePtr schema;
   velox::memory::MemoryPool* memoryPool;
   const velox::common::SpillConfig* spillConfig{nullptr};
+  tsan_atomic<bool>* nonReclaimableSection{nullptr};
   std::optional<velox::common::CompressionKind> compressionKind;
   std::optional<uint64_t> maxStripeSize{std::nullopt};
   std::optional<uint64_t> maxDictionaryMemory{std::nullopt};

--- a/velox/dwio/common/SortingWriter.cpp
+++ b/velox/dwio/common/SortingWriter.cpp
@@ -21,31 +21,90 @@ namespace facebook::velox::dwio::common {
 SortingWriter::SortingWriter(
     std::unique_ptr<Writer> writer,
     std::unique_ptr<exec::SortBuffer> sortBuffer)
-    : outputWriter_(std::move(writer)), sortBuffer_(std::move(sortBuffer)) {}
+    : outputWriter_(std::move(writer)),
+      sortPool_(sortBuffer->pool()),
+      sortBuffer_(std::move(sortBuffer)) {
+  if (sortPool_->parent()->reclaimer() != nullptr) {
+    sortPool_->setReclaimer(MemoryReclaimer::create(this));
+  }
+}
 
 void SortingWriter::write(const VectorPtr& data) {
   sortBuffer_->addInput(data);
 }
 
 void SortingWriter::flush() {
-  // TODO: add to support flush by disk spilling.
+  outputWriter_->flush();
 }
 
 void SortingWriter::close() {
+  if (setClose()) {
+    return;
+  }
+
   sortBuffer_->noMoreInput();
   RowVectorPtr output = sortBuffer_->getOutput();
   while (output != nullptr) {
     outputWriter_->write(output);
     output = sortBuffer_->getOutput();
   }
+  sortBuffer_.reset();
+  sortPool_->release();
   outputWriter_->close();
-
-  sortBuffer_->pool()->release();
 }
 
 void SortingWriter::abort() {
+  if (setClose()) {
+    return;
+  }
   sortBuffer_.reset();
+  sortPool_->release();
   outputWriter_->abort();
 }
 
+bool SortingWriter::setClose() {
+  const bool closed = closed_;
+  closed_ = true;
+  return closed;
+}
+
+std::unique_ptr<memory::MemoryReclaimer> SortingWriter::MemoryReclaimer::create(
+    SortingWriter* writer) {
+  return std::unique_ptr<memory::MemoryReclaimer>(new MemoryReclaimer(writer));
+}
+
+bool SortingWriter::MemoryReclaimer::reclaimableBytes(
+    const memory::MemoryPool& pool,
+    uint64_t& reclaimableBytes) const {
+  VELOX_CHECK_EQ(pool.name(), writer_->sortPool_->name());
+
+  reclaimableBytes = 0;
+  if (!canReclaim_) {
+    return false;
+  }
+  reclaimableBytes = pool.currentBytes();
+  return true;
+}
+
+uint64_t SortingWriter::MemoryReclaimer::reclaim(
+    memory::MemoryPool* pool,
+    uint64_t targetBytes,
+    memory::MemoryReclaimer::Stats& stats) {
+  VELOX_CHECK_EQ(pool->name(), writer_->sortPool_->name());
+
+  if (!canReclaim_) {
+    return 0;
+  }
+
+  if (writer_->closed_) {
+    LOG(WARNING) << "Can't reclaim from a closed or aborted hive sort writer: "
+                 << pool->name();
+    ++stats.numNonReclaimableAttempts;
+    return 0;
+  }
+
+  writer_->sortBuffer_->spill(0, 0);
+  pool->release();
+  return pool->shrink(targetBytes);
+}
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/dwrf/test/E2EWriterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTest.cpp
@@ -242,7 +242,8 @@ class E2EWriterTest : public testing::Test {
 
   static common::SpillConfig getSpillConfig(
       int32_t minSpillableReservationPct,
-      int32_t spillableReservationGrowthPct) {
+      int32_t spillableReservationGrowthPct,
+      uint64_t writerFlushThresholdSize = 0) {
     return common::SpillConfig(
         "fakeSpillConfig",
         0,
@@ -254,6 +255,7 @@ class E2EWriterTest : public testing::Test {
         0,
         0,
         0,
+        writerFlushThresholdSize,
         0,
         "none");
   }
@@ -1530,6 +1532,28 @@ TEST_F(E2EWriterTest, fuzzFlatmap) {
   }
 }
 
+TEST_F(E2EWriterTest, memoryConfigError) {
+  const auto type = ROW(
+      {{"int_val", INTEGER()},
+       {"string_val", VARCHAR()},
+       {"binary_val", VARBINARY()}});
+
+  dwrf::WriterOptions options;
+  options.schema = type;
+  const common::SpillConfig spillConfig = getSpillConfig(10, 20);
+  options.spillConfig = &spillConfig;
+  auto writerPool = memory::defaultMemoryManager().addRootPool(
+      "memoryReclaim", 1L << 30, exec::MemoryReclaimer::create());
+  auto dwrfPool = writerPool->addAggregateChild("writer");
+  auto sinkPool =
+      writerPool->addLeafChild("sink", true, exec::MemoryReclaimer::create());
+  auto sink = std::make_unique<MemorySink>(
+      200 * 1024 * 1024, FileSink::Options{.pool = sinkPool.get()});
+  VELOX_ASSERT_THROW(
+      std::make_unique<dwrf::Writer>(std::move(sink), options, dwrfPool),
+      "nonReclaimableSection_ must be set if writer memory reclaim is enabled");
+}
+
 DEBUG_ONLY_TEST_F(E2EWriterTest, memoryReclaimOnWrite) {
   const auto type = ROW(
       {{"int_val", INTEGER()},
@@ -1555,9 +1579,11 @@ DEBUG_ONLY_TEST_F(E2EWriterTest, memoryReclaimOnWrite) {
     config->set<uint64_t>(dwrf::Config::STRIPE_SIZE, 1L << 30);
     config->set<uint64_t>(dwrf::Config::MAX_DICTIONARY_SIZE, 1L << 30);
 
+    tsan_atomic<bool> nonReclaimableSection{false};
     dwrf::WriterOptions options;
     options.schema = type;
     options.config = std::move(config);
+    options.nonReclaimableSection = &nonReclaimableSection;
     if (enableReclaim) {
       options.spillConfig = &spillConfig;
     }
@@ -1612,8 +1638,14 @@ DEBUG_ONLY_TEST_F(E2EWriterTest, memoryReclaimOnWrite) {
       ASSERT_EQ(writerPool->capacity(), oldCapacity);
     }
 
-    for (size_t i = 0; i < vectors.size(); ++i) {
-      writer->write(vectors[i]);
+    // Expect a throw if we don't set the non-reclaimable section.
+    VELOX_ASSERT_THROW(writer->write(vectors[0]), "");
+    {
+      exec::NonReclaimableSectionGuard nonReclaimableGuard(
+          &nonReclaimableSection);
+      for (size_t i = 0; i < vectors.size(); ++i) {
+        writer->write(vectors[i]);
+      }
     }
     if (!enableReclaim) {
       ASSERT_FALSE(reservationCalled);
@@ -1661,6 +1693,8 @@ DEBUG_ONLY_TEST_F(E2EWriterTest, memoryReclaimOnFlush) {
     dwrf::WriterOptions options;
     options.schema = type;
     options.config = std::move(config);
+    tsan_atomic<bool> nonReclaimableSection{false};
+    options.nonReclaimableSection = &nonReclaimableSection;
     if (enableReclaim) {
       options.spillConfig = &spillConfig;
     }
@@ -1703,11 +1737,14 @@ DEBUG_ONLY_TEST_F(E2EWriterTest, memoryReclaimOnFlush) {
           ASSERT_FALSE(writer->testingNonReclaimableSection());
         }));
 
-    for (size_t i = 0; i < vectors.size(); ++i) {
-      writer->write(vectors[i]);
+    {
+      exec::NonReclaimableSectionGuard nonReclaimableGuard(
+          &nonReclaimableSection);
+      for (size_t i = 0; i < vectors.size(); ++i) {
+        writer->write(vectors[i]);
+      }
+      writer->flush();
     }
-
-    writer->flush();
     ASSERT_EQ(reservationCalled, enableReclaim);
     writer->close();
   }
@@ -1760,6 +1797,8 @@ TEST_F(E2EWriterTest, memoryReclaimAfterClose) {
     dwrf::WriterOptions options;
     options.schema = type;
     options.config = std::move(config);
+    tsan_atomic<bool> nonReclaimableSection{false};
+    options.nonReclaimableSection = &nonReclaimableSection;
     if (testData.canReclaim) {
       options.spillConfig = &spillConfig;
     }
@@ -1777,8 +1816,12 @@ TEST_F(E2EWriterTest, memoryReclaimAfterClose) {
 
     writer->flush();
 
-    for (size_t i = 0; i < vectors.size(); ++i) {
-      writer->write(vectors[i]);
+    {
+      exec::NonReclaimableSectionGuard nonReclaimableGuard(
+          &nonReclaimableSection);
+      for (size_t i = 0; i < vectors.size(); ++i) {
+        writer->write(vectors[i]);
+      }
     }
 
     if (testData.abort) {
@@ -1829,6 +1872,8 @@ DEBUG_ONLY_TEST_F(E2EWriterTest, memoryReclaimDuringInit) {
     dwrf::WriterOptions options;
     options.schema = type;
     options.config = std::move(config);
+    tsan_atomic<bool> nonReclaimableSection{false};
+    options.nonReclaimableSection = &nonReclaimableSection;
     if (reclaimable) {
       options.spillConfig = &spillConfig;
     }
@@ -1860,14 +1905,91 @@ DEBUG_ONLY_TEST_F(E2EWriterTest, memoryReclaimDuringInit) {
         }));
 
     std::unique_ptr<dwrf::Writer> writer;
-    std::thread writerThread([&]() {
-      writer =
-          std::make_unique<dwrf::Writer>(std::move(sink), options, dwrfPool);
-    });
+    {
+      exec::NonReclaimableSectionGuard nonReclaimableGuard(
+          &nonReclaimableSection);
+      std::thread writerThread([&]() {
+        writer =
+            std::make_unique<dwrf::Writer>(std::move(sink), options, dwrfPool);
+      });
 
-    writerThread.join();
+      writerThread.join();
+    }
     ASSERT_TRUE(writer != nullptr);
     ASSERT_EQ(writer->canReclaim(), reclaimable);
+    writer->close();
+  }
+}
+
+TEST_F(E2EWriterTest, memoryReclaimThreshold) {
+  const auto type = ROW(
+      {{"int_val", INTEGER()},
+       {"string_val", VARCHAR()},
+       {"binary_val", VARBINARY()}});
+
+  VectorFuzzer fuzzer(
+      {
+          .vectorSize = 1000,
+          .stringLength = 1'000,
+          .stringVariableLength = false,
+      },
+      leafPool_.get());
+  std::vector<VectorPtr> vectors;
+  for (int i = 0; i < 10; ++i) {
+    vectors.push_back(fuzzer.fuzzInputRow(type));
+  }
+  const std::vector<uint64_t> writerFlushThresholdSizes = {0, 1L << 30};
+  for (uint64_t writerFlushThresholdSize : writerFlushThresholdSizes) {
+    SCOPED_TRACE(fmt::format(
+        "writerFlushThresholdSize {}",
+        succinctBytes(writerFlushThresholdSize)));
+
+    const common::SpillConfig spillConfig =
+        getSpillConfig(10, 20, writerFlushThresholdSize);
+    auto config = std::make_shared<dwrf::Config>();
+    config->set<uint64_t>(dwrf::Config::STRIPE_SIZE, 1L << 30);
+    config->set<uint64_t>(dwrf::Config::MAX_DICTIONARY_SIZE, 1L << 30);
+
+    dwrf::WriterOptions options;
+    options.schema = type;
+    options.config = std::move(config);
+    tsan_atomic<bool> nonReclaimableSection{false};
+    options.nonReclaimableSection = &nonReclaimableSection;
+    options.spillConfig = &spillConfig;
+
+    auto writerPool = memory::defaultMemoryManager().addRootPool(
+        "memoryReclaimThreshold", 1L << 30, exec::MemoryReclaimer::create());
+    auto dwrfPool = writerPool->addAggregateChild("writer");
+    auto sinkPool =
+        writerPool->addLeafChild("sink", true, exec::MemoryReclaimer::create());
+    auto sink = std::make_unique<MemorySink>(
+        200 * 1024 * 1024, FileSink::Options{.pool = sinkPool.get()});
+
+    auto writer =
+        std::make_unique<dwrf::Writer>(std::move(sink), options, dwrfPool);
+
+    {
+      exec::NonReclaimableSectionGuard nonReclaimableGuard(
+          &nonReclaimableSection);
+      for (size_t i = 0; i < vectors.size(); ++i) {
+        writer->write(vectors[i]);
+      }
+    }
+
+    uint64_t reclaimableBytes{0};
+    memory::MemoryReclaimer::Stats stats;
+    if (writerFlushThresholdSize == 0) {
+      ASSERT_TRUE(writerPool->reclaimer()->reclaimableBytes(
+          *writerPool, reclaimableBytes));
+      ASSERT_GT(reclaimableBytes, 0);
+      ASSERT_GT(writerPool->reclaim(1L << 30, stats), 0);
+    } else {
+      ASSERT_FALSE(writerPool->reclaimer()->reclaimableBytes(
+          *writerPool, reclaimableBytes));
+      ASSERT_EQ(reclaimableBytes, 0);
+      ASSERT_EQ(writerPool->reclaim(1L << 30, stats), 0);
+    }
+    writer->flush();
     writer->close();
   }
 }

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -56,6 +56,9 @@ dwio::common::StripeProgress getStripeProgress(const WriterContext& context) {
 
 #define CHECK_NOT_CLOSED() \
   VELOX_CHECK(!closed_, "{} not allowed on a closed writer", __FUNCTION__);
+
+#define NON_RECLAIMABLE_SECTION_CHECK() \
+  VELOX_CHECK(nonReclaimableSection_ == nullptr || *nonReclaimableSection_);
 } // namespace
 
 Writer::Writer(
@@ -64,9 +67,11 @@ Writer::Writer(
     std::shared_ptr<memory::MemoryPool> pool)
     : writerBase_(std::make_unique<WriterBase>(std::move(sink))),
       schema_{dwio::common::TypeWithId::create(options.schema)},
-      spillConfig_{options.spillConfig} {
-  // Prevent the memory reclaim during writer initialization.
-  exec::NonReclaimableSectionGuard guard(&nonReclaimableSection_);
+      spillConfig_{options.spillConfig},
+      nonReclaimableSection_(options.nonReclaimableSection) {
+  VELOX_CHECK(
+      spillConfig_ == nullptr || nonReclaimableSection_ != nullptr,
+      "nonReclaimableSection_ must be set if writer memory reclaim is enabled");
   auto handler =
       (options.encryptionSpec ? encryption::EncryptionHandler::create(
                                     schema_,
@@ -140,7 +145,7 @@ void Writer::setMemoryReclaimers(
 
 void Writer::write(const VectorPtr& input) {
   CHECK_NOT_CLOSED();
-  exec::NonReclaimableSectionGuard reclaimGuard(&nonReclaimableSection_);
+  NON_RECLAIMABLE_SECTION_CHECK();
 
   auto& context = writerBase_->getContext();
   // Calculate length increment based on linear projection of micro batch size.
@@ -224,12 +229,12 @@ void Writer::ensureWriteFits(size_t appendBytes, size_t appendRows) {
 
   // Allows the memory arbitrator to reclaim memory from this file writer if the
   // memory reservation below has triggered memory arbitration.
-  exec::ReclaimableSectionGuard reclaimGuard(&nonReclaimableSection_);
+  exec::ReclaimableSectionGuard reclaimGuard(nonReclaimableSection_);
 
   const size_t estimatedAppendMemoryBytes =
       std::max(appendBytes, context.estimateNextWriteSize(appendRows));
   const double estimatedMemoryGrowthRatio =
-      estimatedAppendMemoryBytes / totalMemoryUsage;
+      (double)estimatedAppendMemoryBytes / totalMemoryUsage;
   if (!maybeReserveMemory(
           MemoryUsageCategory::GENERAL, estimatedMemoryGrowthRatio)) {
     return;
@@ -256,7 +261,7 @@ void Writer::ensureStripeFlushFits() {
 
   // Allows the memory arbitrator to reclaim memory from this file writer if the
   // memory reservation below has triggered memory arbitration.
-  exec::ReclaimableSectionGuard reclaimGuard(&nonReclaimableSection_);
+  exec::ReclaimableSectionGuard reclaimGuard(nonReclaimableSection_);
 
   auto& context = getContext();
   const size_t estimateFlushMemoryBytes =
@@ -271,7 +276,7 @@ void Writer::ensureStripeFlushFits() {
         .maybeReserve(outputMemoryToReserve);
   } else {
     const double estimatedMemoryGrowthRatio =
-        estimateFlushMemoryBytes / outputMemoryUsage;
+        (double)estimateFlushMemoryBytes / outputMemoryUsage;
     maybeReserveMemory(
         MemoryUsageCategory::OUTPUT_STREAM, estimatedMemoryGrowthRatio);
   }
@@ -280,7 +285,7 @@ void Writer::ensureStripeFlushFits() {
 bool Writer::maybeReserveMemory(
     MemoryUsageCategory memoryUsageCategory,
     double estimatedMemoryGrowthRatio) {
-  VELOX_CHECK(!nonReclaimableSection_);
+  VELOX_CHECK(!*nonReclaimableSection_);
   VELOX_CHECK(canReclaim());
   auto& context = getContext();
   auto& pool = context.getMemoryPool(memoryUsageCategory);
@@ -565,6 +570,7 @@ void Writer::flushStripe(bool close) {
 }
 
 void Writer::flushInternal(bool close) {
+  TestValue::adjust("facebook::velox::dwrf::Writer::flushInternal", this);
   auto exitGuard = folly::makeGuard([this]() { releaseMemory(); });
 
   auto& context = writerBase_->getContext();
@@ -676,14 +682,11 @@ void Writer::flushInternal(bool close) {
 
 void Writer::flush() {
   CHECK_NOT_CLOSED();
-  TestValue::adjust("facebook::velox::dwrf::Writer::flush", this);
-  exec::NonReclaimableSectionGuard reclaimGuard(&nonReclaimableSection_);
   flushInternal(false);
 }
 
 void Writer::close() {
   RETURN_IF_CLOSED();
-  exec::NonReclaimableSectionGuard reclaimGuard(&nonReclaimableSection_);
   auto exitGuard = folly::makeGuard([this]() {
     flushPolicy_->onClose();
     closed_ = true;
@@ -694,7 +697,6 @@ void Writer::close() {
 
 void Writer::abort() {
   RETURN_IF_CLOSED();
-  exec::NonReclaimableSectionGuard reclaimGuard(&nonReclaimableSection_);
   auto exitGuard = folly::makeGuard([this]() { closed_ = true; });
   // NOTE: we need to reset column writer as all its dependent objects (e.g.
   // writer context) will be reset by writer base abort.
@@ -711,11 +713,15 @@ std::unique_ptr<memory::MemoryReclaimer> Writer::MemoryReclaimer::create(
 bool Writer::MemoryReclaimer::reclaimableBytes(
     const memory::MemoryPool& /*unused*/,
     uint64_t& reclaimableBytes) const {
+  reclaimableBytes = 0;
   if (!writer_->canReclaim()) {
-    reclaimableBytes = 0;
     return false;
   }
-  reclaimableBytes = writer_->getContext().getTotalMemoryUsage();
+  const uint64_t memoryUsage = writer_->getContext().getTotalMemoryUsage();
+  if (memoryUsage < writer_->spillConfig_->writerFlushThresholdSize) {
+    return false;
+  }
+  reclaimableBytes = memoryUsage;
   return true;
 }
 
@@ -727,7 +733,7 @@ uint64_t Writer::MemoryReclaimer::reclaim(
     return 0;
   }
 
-  if (writer_->nonReclaimableSection_) {
+  if (*writer_->nonReclaimableSection_) {
     LOG(WARNING)
         << "Can't reclaim from dwrf writer which is under non-reclaimable section: "
         << pool->name();
@@ -740,7 +746,17 @@ uint64_t Writer::MemoryReclaimer::reclaim(
     ++stats.numNonReclaimableAttempts;
     return 0;
   }
-  writer_->flush();
+  const uint64_t memoryUsage = writer_->getContext().getTotalMemoryUsage();
+  if (memoryUsage < writer_->spillConfig_->writerFlushThresholdSize) {
+    LOG(WARNING)
+        << "Can't reclaim memory from dwrf writer pool " << pool->name()
+        << " which doesn't have sufficient memory to flush, writer memory usage: "
+        << succinctBytes(memoryUsage) << ", writer flush memory threshold: "
+        << succinctBytes(writer_->spillConfig_->writerFlushThresholdSize);
+    ++stats.numNonReclaimableAttempts;
+    return 0;
+  }
+  writer_->flushInternal(false);
   return pool->shrink(targetBytes);
 }
 
@@ -767,6 +783,7 @@ dwrf::WriterOptions getDwrfOptions(const dwio::common::WriterOptions& options) {
   dwrfOptions.schema = options.schema;
   dwrfOptions.memoryPool = options.memoryPool;
   dwrfOptions.spillConfig = options.spillConfig;
+  dwrfOptions.nonReclaimableSection = options.nonReclaimableSection;
   return dwrfOptions;
 }
 

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -143,6 +143,7 @@ std::optional<common::SpillConfig> DriverCtx::makeSpillConfig(
       queryConfig.spillStartPartitionBit(),
       queryConfig.joinSpillPartitionBits(),
       queryConfig.maxSpillLevel(),
+      queryConfig.writerFlushThresholdBytes(),
       queryConfig.testingSpillPct(),
       queryConfig.spillCompressionKind());
 }

--- a/velox/exec/SharedArbitrator.cpp
+++ b/velox/exec/SharedArbitrator.cpp
@@ -408,7 +408,7 @@ uint64_t SharedArbitrator::reclaim(
       }
     } catch (const std::exception& e) {
       VELOX_MEM_LOG(ERROR) << "Failed to reclaim from memory pool "
-                           << pool->name() << ", aborting it!";
+                           << pool->name() << ", aborting it: " << e.what();
       abort(pool, std::current_exception());
       // Free up all the free capacity from the aborted pool as the associated
       // query has failed at this point.

--- a/velox/exec/SortBuffer.h
+++ b/velox/exec/SortBuffer.h
@@ -52,6 +52,11 @@ class SortBuffer {
   /// Returns the sorted output rows in batch.
   RowVectorPtr getOutput();
 
+  /// Indicates if this sort buffer can spill or not.
+  bool canSpill() const {
+    return spillConfig_ != nullptr;
+  }
+
   /// Invoked to spill from 'data_' to disk with specified targets.
   ///
   /// NOTE: if either 'targetRows' or 'targetBytes' is zero, then we spill all

--- a/velox/exec/tests/SharedArbitratorTest.cpp
+++ b/velox/exec/tests/SharedArbitratorTest.cpp
@@ -2413,7 +2413,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, tableWriteSpillUseMoreMemory) {
   setupMemory(memoryCapacity);
   // Create a large number of vectors to trigger writer spill.
   fuzzerOpts_.vectorSize = 1000;
-  fuzzerOpts_.stringLength = 1024;
+  fuzzerOpts_.stringLength = 2048;
   fuzzerOpts_.stringVariableLength = false;
   VectorFuzzer fuzzer(fuzzerOpts_, pool());
   std::vector<RowVectorPtr> vectors;
@@ -2433,7 +2433,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, tableWriteSpillUseMoreMemory) {
   void* allocatedBuffer;
   TestAllocation injectedWriterAllocation;
   SCOPED_TESTVALUE_SET(
-      "facebook::velox::dwrf::Writer::flush",
+      "facebook::velox::dwrf::Writer::flushInternal",
       std::function<void(dwrf::Writer*)>(([&](dwrf::Writer* writer) {
         ASSERT_TRUE(underMemoryArbitration());
         injectedFakeAllocation.free();
@@ -2472,9 +2472,8 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, tableWriteSpillUseMoreMemory) {
           .config(core::QueryConfig::kSpillEnabled, "true")
           .config(core::QueryConfig::kWriterSpillEnabled, "true")
           // Set 0 file writer flush threshold to always trigger flush in test.
-          .connectorConfig(
-              kHiveConnectorId,
-              connector::hive::HiveConfig::kFileWriterFlushThresholdBytes,
+          .config(
+              core::QueryConfig::kWriterFlushThresholdBytes,
               folly::to<std::string>(0))
           // Set stripe size to extreme large to avoid writer internal triggered
           // flush.
@@ -2568,9 +2567,8 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, tableWriteReclaimOnClose) {
       .config(core::QueryConfig::kSpillEnabled, "true")
       .config(core::QueryConfig::kWriterSpillEnabled, "true")
       // Set 0 file writer flush threshold to always trigger flush in test.
-      .connectorConfig(
-          kHiveConnectorId,
-          connector::hive::HiveConfig::kFileWriterFlushThresholdBytes,
+      .config(
+          core::QueryConfig::kWriterFlushThresholdBytes,
           folly::to<std::string>(0))
       // Set stripe size to extreme large to avoid writer internal triggered
       // flush.
@@ -2634,9 +2632,8 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, tableFileWriteError) {
           .config(core::QueryConfig::kWriterSpillEnabled, "true")
           // Set 0 file writer flush threshold to always reclaim memory from
           // file writer.
-          .connectorConfig(
-              kHiveConnectorId,
-              connector::hive::HiveConfig::kFileWriterFlushThresholdBytes,
+          .config(
+              core::QueryConfig::kWriterFlushThresholdBytes,
               folly::to<std::string>(0))
           // Set stripe size to extreme large to avoid writer internal triggered
           // flush.
@@ -2655,7 +2652,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, tableFileWriteError) {
   waitForAllTasksToBeDeleted();
 }
 
-DEBUG_ONLY_TEST_F(SharedArbitrationTest, arbitrationFromTableWriter) {
+DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimFromTableWriter) {
   VectorFuzzer::Options options;
   const int batchSize = 1'000;
   options.vectorSize = batchSize;
@@ -2730,9 +2727,8 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, arbitrationFromTableWriter) {
             core::QueryConfig::kWriterSpillEnabled,
             writerSpillEnabled ? "true" : "false")
         // Set 0 file writer flush threshold to always trigger flush in test.
-        .connectorConfig(
-            kHiveConnectorId,
-            connector::hive::HiveConfig::kFileWriterFlushThresholdBytes,
+        .config(
+            core::QueryConfig::kWriterFlushThresholdBytes,
             folly::to<std::string>(0))
         .plan(std::move(writerPlan))
         .assertResults(fmt::format("SELECT {}", numRows));
@@ -2740,6 +2736,106 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, arbitrationFromTableWriter) {
     ASSERT_EQ(arbitrator_->stats().numFailures, writerSpillEnabled ? 0 : 1);
     ASSERT_EQ(arbitrator_->stats().numNonReclaimableAttempts, 0);
     waitForAllTasksToBeDeleted(3'000'000);
+  }
+}
+
+DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimFromSortTableWriter) {
+  VectorFuzzer::Options options;
+  const int batchSize = 1'000;
+  options.vectorSize = batchSize;
+  options.stringVariableLength = false;
+  options.stringLength = 1'000;
+  VectorFuzzer fuzzer(options, pool());
+  const int numBatches = 20;
+  std::vector<RowVectorPtr> vectors;
+  int numRows{0};
+  const auto partitionKeyVector = makeFlatVector<int32_t>(
+      batchSize, [&](vector_size_t /*unused*/) { return 0; });
+  for (int i = 0; i < numBatches; ++i) {
+    numRows += batchSize;
+    vectors.push_back(fuzzer.fuzzInputRow(rowType_));
+    vectors.back()->childAt(0) = partitionKeyVector;
+  }
+  createDuckDbTable(vectors);
+
+  for (bool writerSpillEnabled : {false, true}) {
+    SCOPED_TRACE(fmt::format("writerSpillEnabled: {}", writerSpillEnabled));
+
+    setupMemory(kMemoryCapacity, 0);
+
+    std::shared_ptr<core::QueryCtx> queryCtx = newQueryCtx(kMemoryCapacity);
+    ASSERT_EQ(queryCtx->pool()->capacity(), 0);
+
+    const auto spillStats = globalSpillStats();
+
+    std::atomic<int> numInputs{0};
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Driver::runInternal::addInput",
+        std::function<void(Operator*)>(([&](Operator* op) {
+          if (op->operatorType() != "TableWrite") {
+            return;
+          }
+          // We reclaim memory from table writer connector memory pool which
+          // connects to the memory pools inside the hive connector.
+          ASSERT_FALSE(op->canReclaim());
+          if (++numInputs != numBatches) {
+            return;
+          }
+
+          const auto fakeAllocationSize =
+              arbitrator_->stats().maxCapacityBytes -
+              op->pool()->parent()->reservedBytes();
+          if (writerSpillEnabled) {
+            auto* buffer = op->pool()->allocate(fakeAllocationSize);
+            op->pool()->free(buffer, fakeAllocationSize);
+          } else {
+            VELOX_ASSERT_THROW(
+                op->pool()->allocate(fakeAllocationSize),
+                "Exceeded memory pool");
+          }
+        })));
+
+    auto spillDirectory = exec::test::TempDirectoryPath::create();
+    auto outputDirectory = TempDirectoryPath::create();
+    auto writerPlan =
+        PlanBuilder()
+            .values(vectors)
+            .tableWrite(outputDirectory->path, {"c0"}, 4, {"c1"}, {"c2"})
+            .project({TableWriteTraits::rowCountColumnName()})
+            .singleAggregation(
+                {},
+                {fmt::format(
+                    "sum({})", TableWriteTraits::rowCountColumnName())})
+            .planNode();
+
+    AssertQueryBuilder(duckDbQueryRunner_)
+        .queryCtx(queryCtx)
+        .maxDrivers(1)
+        .spillDirectory(spillDirectory->path)
+        .config(
+            core::QueryConfig::kSpillEnabled,
+            writerSpillEnabled ? "true" : "false")
+        .config(
+            core::QueryConfig::kWriterSpillEnabled,
+            writerSpillEnabled ? "true" : "false")
+        // Set 0 file writer flush threshold to always trigger flush in test.
+        .config(
+            core::QueryConfig::kWriterFlushThresholdBytes,
+            folly::to<std::string>(0))
+        .plan(std::move(writerPlan))
+        .assertResults(fmt::format("SELECT {}", numRows));
+
+    ASSERT_EQ(arbitrator_->stats().numFailures, writerSpillEnabled ? 0 : 1);
+    ASSERT_EQ(arbitrator_->stats().numNonReclaimableAttempts, 0);
+    waitForAllTasksToBeDeleted(3'000'000);
+    const auto updatedSpillStats = globalSpillStats();
+    if (writerSpillEnabled) {
+      ASSERT_GT(updatedSpillStats.spilledBytes, spillStats.spilledBytes);
+      ASSERT_GT(
+          updatedSpillStats.spilledPartitions, spillStats.spilledPartitions);
+    } else {
+      ASSERT_EQ(updatedSpillStats, spillStats);
+    }
   }
 }
 
@@ -2814,10 +2910,8 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, writerFlushThreshold) {
         .spillDirectory(spillDirectory->path)
         .config(core::QueryConfig::kSpillEnabled, "true")
         .config(core::QueryConfig::kWriterSpillEnabled, "true")
-        // Set 0 file writer flush threshold to always trigger flush in test.
-        .connectorConfig(
-            kHiveConnectorId,
-            connector::hive::HiveConfig::kFileWriterFlushThresholdBytes,
+        .config(
+            core::QueryConfig::kWriterFlushThresholdBytes,
             folly::to<std::string>(writerFlushThreshold))
         .plan(std::move(writerPlan))
         .assertResults(fmt::format("SELECT {}", numRows));
@@ -2831,9 +2925,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, writerFlushThreshold) {
   }
 }
 
-DEBUG_ONLY_TEST_F(
-    SharedArbitrationTest,
-    arbitrationFromNonReclaimableFileWriter) {
+DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimFromNonReclaimableTableWriter) {
   VectorFuzzer::Options options;
   const int batchSize = 1'000;
   options.vectorSize = batchSize;
@@ -2857,23 +2949,17 @@ DEBUG_ONLY_TEST_F(
 
   std::atomic<bool> injectFakeAllocationOnce{true};
   SCOPED_TESTVALUE_SET(
-      "facebook::velox::memory::MemoryPoolImpl::reserveThreadSafe",
-      std::function<void(MemoryPool*)>(([&](MemoryPool* pool) {
-        const std::string re(".*general");
-        if (!RE2::FullMatch(pool->name(), re)) {
-          return;
-        }
-        const int writerMemoryUsage = 4L << 20;
-        if (pool->parent()->reservedBytes() < writerMemoryUsage) {
-          return;
-        }
+      "facebook::velox::dwrf::Writer::write",
+      std::function<void(dwrf::Writer*)>(([&](dwrf::Writer* writer) {
         if (!injectFakeAllocationOnce.exchange(false)) {
           return;
         }
-        const auto fakeAllocationSize = arbitrator_->stats().maxCapacityBytes -
-            pool->parent()->reservedBytes();
+        auto& pool = writer->getContext().getMemoryPool(
+            dwrf::MemoryUsageCategory::GENERAL);
+        const auto fakeAllocationSize =
+            arbitrator_->stats().maxCapacityBytes - pool.reservedBytes();
         VELOX_ASSERT_THROW(
-            pool->allocate(fakeAllocationSize), "Exceeded memory pool");
+            pool.allocate(fakeAllocationSize), "Exceeded memory pool");
       })));
 
   auto outputDirectory = TempDirectoryPath::create();
@@ -2887,15 +2973,17 @@ DEBUG_ONLY_TEST_F(
               {fmt::format("sum({})", TableWriteTraits::rowCountColumnName())})
           .planNode();
 
+  const auto spillDirectory = exec::test::TempDirectoryPath::create();
   AssertQueryBuilder(duckDbQueryRunner_)
       .queryCtx(queryCtx)
       .maxDrivers(1)
+      .spillDirectory(spillDirectory->path)
+      .config(core::QueryConfig::kSpillEnabled, "true")
       .config(core::QueryConfig::kWriterSpillEnabled, "true")
       // Set file writer flush threshold of zero to always trigger flush in
       // test.
-      .connectorConfig(
-          kHiveConnectorId,
-          connector::hive::HiveConfig::kFileWriterFlushThresholdBytes,
+      .config(
+          core::QueryConfig::kWriterFlushThresholdBytes,
           folly::to<std::string>(0))
       // Set large stripe and dictionary size thresholds to avoid writer
       // internal stripe flush.
@@ -2911,7 +2999,7 @@ DEBUG_ONLY_TEST_F(
       .assertResults(fmt::format("SELECT {}", numRows));
 
   ASSERT_EQ(arbitrator_->stats().numFailures, 1);
-  ASSERT_EQ(arbitrator_->stats().numNonReclaimableAttempts, 0);
+  ASSERT_EQ(arbitrator_->stats().numNonReclaimableAttempts, 1);
 }
 
 DEBUG_ONLY_TEST_F(
@@ -2985,9 +3073,8 @@ DEBUG_ONLY_TEST_F(
       .config(core::QueryConfig::kSpillEnabled, "true")
       .config(core::QueryConfig::kWriterSpillEnabled, "true")
       // Set 0 file writer flush threshold to always trigger flush in test.
-      .connectorConfig(
-          kHiveConnectorId,
-          connector::hive::HiveConfig::kFileWriterFlushThresholdBytes,
+      .config(
+          core::QueryConfig::kWriterFlushThresholdBytes,
           folly::to<std::string>(0))
       // Set large stripe and dictionary size thresholds to avoid writer
       // internal stripe flush.
@@ -3005,6 +3092,97 @@ DEBUG_ONLY_TEST_F(
   ASSERT_EQ(arbitrator_->stats().numNonReclaimableAttempts, 0);
   ASSERT_EQ(arbitrator_->stats().numFailures, 0);
   ASSERT_GT(arbitrator_->stats().numReclaimedBytes, 0);
+}
+
+DEBUG_ONLY_TEST_F(
+    SharedArbitrationTest,
+    reclaimFromNonReclaimableSortTableWriter) {
+  VectorFuzzer::Options options;
+  const int batchSize = 1'000;
+  options.vectorSize = batchSize;
+  options.stringVariableLength = false;
+  options.stringLength = 1'000;
+  VectorFuzzer fuzzer(options, pool());
+  const int numBatches = 20;
+  std::vector<RowVectorPtr> vectors;
+  int numRows{0};
+  const auto partitionKeyVector = makeFlatVector<int32_t>(
+      batchSize, [&](vector_size_t /*unused*/) { return 0; });
+  for (int i = 0; i < numBatches; ++i) {
+    numRows += batchSize;
+    vectors.push_back(fuzzer.fuzzInputRow(rowType_));
+    vectors.back()->childAt(0) = partitionKeyVector;
+  }
+
+  createDuckDbTable(vectors);
+
+  setupMemory(kMemoryCapacity, 0);
+
+  std::shared_ptr<core::QueryCtx> queryCtx = newQueryCtx(kMemoryCapacity);
+  ASSERT_EQ(queryCtx->pool()->capacity(), 0);
+
+  std::atomic<bool> injectFakeAllocationOnce{true};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::memory::MemoryPoolImpl::reserveThreadSafe",
+      std::function<void(MemoryPool*)>(([&](MemoryPool* pool) {
+        const std::string re(".*sort");
+        if (!RE2::FullMatch(pool->name(), re)) {
+          return;
+        }
+        const int writerMemoryUsage = 4L << 20;
+        if (pool->parent()->reservedBytes() < writerMemoryUsage) {
+          return;
+        }
+        if (!injectFakeAllocationOnce.exchange(false)) {
+          return;
+        }
+        const auto fakeAllocationSize = arbitrator_->stats().maxCapacityBytes -
+            pool->parent()->reservedBytes();
+        VELOX_ASSERT_THROW(
+            pool->allocate(fakeAllocationSize), "Exceeded memory pool");
+      })));
+
+  auto outputDirectory = TempDirectoryPath::create();
+  auto writerPlan =
+      PlanBuilder()
+          .values(vectors)
+          .tableWrite(outputDirectory->path, {"c0"}, 4, {"c1"}, {"c2"})
+          .project({TableWriteTraits::rowCountColumnName()})
+          .singleAggregation(
+              {},
+              {fmt::format("sum({})", TableWriteTraits::rowCountColumnName())})
+          .planNode();
+
+  const auto spillStats = globalSpillStats();
+  const auto spillDirectory = exec::test::TempDirectoryPath::create();
+  AssertQueryBuilder(duckDbQueryRunner_)
+      .queryCtx(queryCtx)
+      .maxDrivers(1)
+      .spillDirectory(spillDirectory->path)
+      .config(core::QueryConfig::kSpillEnabled, "true")
+      .config(core::QueryConfig::kWriterSpillEnabled, "true")
+      // Set file writer flush threshold of zero to always trigger flush in
+      // test.
+      .config(
+          core::QueryConfig::kWriterFlushThresholdBytes,
+          folly::to<std::string>(0))
+      // Set large stripe and dictionary size thresholds to avoid writer
+      // internal stripe flush.
+      .connectorConfig(
+          kHiveConnectorId,
+          connector::hive::HiveConfig::kOrcWriterMaxStripeSize,
+          "1GB")
+      .connectorConfig(
+          kHiveConnectorId,
+          connector::hive::HiveConfig::kOrcWriterMaxDictionaryMemory,
+          "1GB")
+      .plan(std::move(writerPlan))
+      .assertResults(fmt::format("SELECT {}", numRows));
+
+  ASSERT_EQ(arbitrator_->stats().numFailures, 1);
+  ASSERT_EQ(arbitrator_->stats().numNonReclaimableAttempts, 1);
+  const auto updatedSpillStats = globalSpillStats();
+  ASSERT_EQ(updatedSpillStats, spillStats);
 }
 
 // This test is to reproduce a race condition that memory arbitrator tries to

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -44,7 +44,7 @@ class SortBufferTest : public OperatorTestBase {
 
   common::SpillConfig getSpillConfig(const std::string& spillFilePath) const {
     return common::SpillConfig(
-        spillFilePath, 0, 0, 0, executor_.get(), 5, 10, 0, 0, 0, 0, "none");
+        spillFilePath, 0, 0, 0, executor_.get(), 5, 10, 0, 0, 0, 0, 0, "none");
   }
 
   const RowTypePtr inputType_ = ROW(
@@ -289,6 +289,7 @@ TEST_F(SortBufferTest, batchOutput) {
         0,
         0,
         0,
+        0,
         100, //  testSpillPct
         "none");
     auto sortBuffer = std::make_unique<SortBuffer>(
@@ -301,6 +302,7 @@ TEST_F(SortBufferTest, batchOutput) {
         &numSpillRuns_,
         testData.triggerSpill ? &spillConfig : nullptr,
         0);
+    ASSERT_EQ(sortBuffer->canSpill(), testData.triggerSpill);
 
     const std::shared_ptr<memory::MemoryPool> fuzzerPool =
         memory::addDefaultLeafMemoryPool("VectorFuzzer");
@@ -379,6 +381,7 @@ TEST_F(SortBufferTest, spill) {
         executor_.get(),
         100,
         spillableReservationGrowthPct,
+        0,
         0,
         0,
         0,

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -64,6 +64,30 @@ template <TypeKind FromKind, TypeKind ToKind>
 typename TypeTraits<ToKind>::NativeType cast(const variant& v) {
   return util::Converter<ToKind, void, false>::cast(v.value<FromKind>());
 }
+
+std::shared_ptr<HiveBucketProperty> buildHiveBucketProperty(
+    const RowTypePtr rowType,
+    int32_t bucketCount,
+    const std::vector<std::string>& bucketColumns,
+    const std::vector<std::string>& sortByColumns) {
+  std::vector<TypePtr> bucketTypes;
+  bucketTypes.reserve(bucketColumns.size());
+  for (const auto& bucketColumn : bucketColumns) {
+    bucketTypes.push_back(rowType->childAt(rowType->getChildIdx(bucketColumn)));
+  }
+  std::vector<std::shared_ptr<const HiveSortingColumn>> sortedBy;
+  sortedBy.reserve(sortByColumns.size());
+  for (const auto& sortByColumn : sortByColumns) {
+    sortedBy.push_back(std::make_shared<const HiveSortingColumn>(
+        sortByColumn, core::SortOrder{false, false}));
+  }
+  return std::make_shared<HiveBucketProperty>(
+      HiveBucketProperty::Kind::kHiveCompatible,
+      bucketCount,
+      bucketColumns,
+      bucketTypes,
+      sortedBy);
+}
 } // namespace
 
 PlanBuilder& PlanBuilder::tableScan(
@@ -306,14 +330,57 @@ PlanBuilder& PlanBuilder::tableWrite(
     const std::string& outputDirectoryPath,
     const dwio::common::FileFormat fileFormat,
     const std::vector<std::string>& aggregates) {
+  return tableWrite(outputDirectoryPath, {}, 0, {}, {}, fileFormat, aggregates);
+}
+
+PlanBuilder& PlanBuilder::tableWrite(
+    const std::string& outputDirectoryPath,
+    const std::vector<std::string>& partitionBy,
+    const dwio::common::FileFormat fileFormat,
+    const std::vector<std::string>& aggregates) {
+  return tableWrite(
+      outputDirectoryPath, partitionBy, 0, {}, {}, fileFormat, aggregates);
+}
+
+PlanBuilder& PlanBuilder::tableWrite(
+    const std::string& outputDirectoryPath,
+    const std::vector<std::string>& partitionBy,
+    int32_t bucketCount,
+    const std::vector<std::string>& bucketedBy,
+    const dwio::common::FileFormat fileFormat,
+    const std::vector<std::string>& aggregates) {
+  return tableWrite(
+      outputDirectoryPath,
+      partitionBy,
+      bucketCount,
+      bucketedBy,
+      {},
+      fileFormat,
+      aggregates);
+}
+
+PlanBuilder& PlanBuilder::tableWrite(
+    const std::string& outputDirectoryPath,
+    const std::vector<std::string>& partitionBy,
+    int32_t bucketCount,
+    const std::vector<std::string>& bucketedBy,
+    const std::vector<std::string>& sortBy,
+    const dwio::common::FileFormat fileFormat,
+    const std::vector<std::string>& aggregates) {
   auto rowType = planNode_->outputType();
 
   std::vector<std::shared_ptr<const connector::hive::HiveColumnHandle>>
       columnHandles;
   for (auto i = 0; i < rowType->size(); ++i) {
+    const auto column = rowType->nameOf(i);
+    const bool isPartitionKey =
+        std::find(partitionBy.begin(), partitionBy.end(), column) !=
+        partitionBy.end();
     columnHandles.push_back(std::make_shared<connector::hive::HiveColumnHandle>(
-        rowType->nameOf(i),
-        connector::hive::HiveColumnHandle::ColumnType::kRegular,
+        column,
+        isPartitionKey
+            ? connector::hive::HiveColumnHandle::ColumnType::kPartitionKey
+            : connector::hive::HiveColumnHandle::ColumnType::kRegular,
         rowType->childAt(i),
         rowType->childAt(i)));
   }
@@ -322,11 +389,16 @@ PlanBuilder& PlanBuilder::tableWrite(
       outputDirectoryPath,
       outputDirectoryPath,
       connector::hive::LocationHandle::TableType::kNew);
+  std::shared_ptr<HiveBucketProperty> bucketProperty;
+  if (!partitionBy.empty() && bucketCount != 0) {
+    bucketProperty =
+        buildHiveBucketProperty(rowType, bucketCount, bucketedBy, sortBy);
+  }
   auto hiveHandle = std::make_shared<connector::hive::HiveInsertTableHandle>(
       columnHandles,
       locationHandle,
       fileFormat,
-      nullptr, // bucketProperty,
+      bucketProperty,
       common::CompressionKind_NONE);
 
   auto insertHandle =

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -266,6 +266,61 @@ class PlanBuilder {
           dwio::common::FileFormat::DWRF,
       const std::vector<std::string>& aggregates = {});
 
+  /// Adds a TableWriteNode to write all input columns into a partitioned Hive
+  /// table without compression.
+  ///
+  /// @param outputDirectoryPath Path to a directory to write data to.
+  /// @param partitionBy Specifies the partition key columns.
+  /// @param fileFormat File format to use for the written data.
+  /// @param aggregates Aggregations for column statistics collection during
+  /// write.
+  PlanBuilder& tableWrite(
+      const std::string& outputDirectoryPath,
+      const std::vector<std::string>& partitionBy,
+      const dwio::common::FileFormat fileFormat =
+          dwio::common::FileFormat::DWRF,
+      const std::vector<std::string>& aggregates = {});
+
+  /// Adds a TableWriteNode to write all input columns into a non-sorted
+  /// bucketed Hive table without compression.
+  ///
+  /// @param outputDirectoryPath Path to a directory to write data to.
+  /// @param partitionBy Specifies the partition key columns.
+  /// @param bucketCount Specifies the bucket count.
+  /// @param bucketedBy Specifies the bucket by columns.
+  /// @param fileFormat File format to use for the written data.
+  /// @param aggregates Aggregations for column statistics collection during
+  /// write.
+  PlanBuilder& tableWrite(
+      const std::string& outputDirectoryPath,
+      const std::vector<std::string>& partitionBy,
+      int32_t bucketCount,
+      const std::vector<std::string>& bucketedBy,
+      const dwio::common::FileFormat fileFormat =
+          dwio::common::FileFormat::DWRF,
+      const std::vector<std::string>& aggregates = {});
+
+  /// Adds a TableWriteNode to write all input columns into a sorted bucket Hive
+  /// table without compression.
+  ///
+  /// @param outputDirectoryPath Path to a directory to write data to.
+  /// @param partitionBy Specifies the partition key columns.
+  /// @param bucketCount Specifies the bucket count.
+  /// @param bucketedBy Specifies the bucket by columns.
+  /// @param sortBy Specifies the sort by columns.
+  /// @param fileFormat File format to use for the written data.
+  /// @param aggregates Aggregations for column statistics collection during
+  /// write.
+  PlanBuilder& tableWrite(
+      const std::string& outputDirectoryPath,
+      const std::vector<std::string>& partitionBy,
+      int32_t bucketCount,
+      const std::vector<std::string>& bucketedBy,
+      const std::vector<std::string>& sortBy,
+      const dwio::common::FileFormat fileFormat =
+          dwio::common::FileFormat::DWRF,
+      const std::vector<std::string>& aggregates = {});
+
   /// Add a TableWriteMergeNode.
   PlanBuilder& tableWriteMerge(
       const std::shared_ptr<core::AggregationNode>& aggregationNode = nullptr);


### PR DESCRIPTION
Add initial spilling support for hive sort writer:
- Turn on spill in sort buffer if the associated writer has enabled spilling to allow
   spilling in sort buffer
- Move non-reclaimable section control from dwrf writer into hive data sink to 
   protect all the file writer operations by default which apply for different file formats.
- Move the minimum writer flush size protection from hive writer to dwrf writer so
   as to allow spill on hive sort writer which doesn't have such limit. We also move the
   config from hive config to query config and make it part of spill config to consolidate
   memory reclaim related configs in one place.
- Extend PlanBuilder::tableWrite to create write plan node with basic partition, bucket
   and bucket sort support.
- Some code refactor in hive data sink and dwrf writer as part of this support.

