### PR TITLE
Add binary lpad and rpad Presto functions

### DIFF
--- a/velox/docs/functions/presto/binary.rst
+++ b/velox/docs/functions/presto/binary.rst
@@ -75,10 +75,30 @@ Binary Functions
 
     Returns the length of ``binary`` in bytes.
 
+.. function:: lpad(binary, size, padbinary) -> varbinary
+    :noindex:
+    
+    Left pads ``binary`` to ``size`` bytes with ``padbinary``.
+    If ``size`` is less than the length of ``binary``, the result is
+    truncated to ``size`` characters. ``size`` must not be negative
+    and ``padbinary`` must be non-empty. ``size`` has a maximum value of 1 MiB.
+    In the case of ``size`` being smaller than the length of ``binary``, 
+    ``binary`` will be truncated from the right to fit the ``size``.
+
 .. function:: md5(binary) -> varbinary
 
     Computes the md5 hash of ``binary``.
 
+.. function:: rpad(binary, size, padbinary) -> varbinary
+    :noindex:
+
+    Right pads ``binary`` to ``size`` bytes with ``padbinary``.
+    If ``size`` is less than the length of ``binary``, the result is
+    truncated to ``size`` characters. ``size`` must not be negative
+    and ``padbinary`` must be non-empty. ``size`` has a maximum value of 1 MiB.
+    In the case of ``size`` being smaller than the length of ``binary``, 
+    ``binary`` will be truncated from the right to fit the ``size``.
+    
 .. function:: sha1(binary) -> varbinary
 
     Computes the SHA-1 hash of ``binary``.

--- a/velox/functions/prestosql/BinaryFunctions.h
+++ b/velox/functions/prestosql/BinaryFunctions.h
@@ -25,6 +25,7 @@
 #include "velox/external/md5/md5.h"
 #include "velox/functions/Udf.h"
 #include "velox/functions/lib/ToHex.h"
+#include "velox/functions/lib/string/StringImpl.h"
 
 namespace facebook::velox::functions {
 
@@ -435,5 +436,32 @@ struct FromIEEE754Bits32 {
     result = folly::Endian::big(result);
   }
 };
+
+/// lpad(binary, size, padbinary) -> varbinary
+///     Left pads input to size characters with padding.  If size is
+///     less than the length of input, the result is truncated to size
+///     characters.  size must not be negative and padding must be non-empty.
+/// rpad(binary, size, padbinary) -> varbinary
+///     Right pads input to size characters with padding.  If size is
+///     less than the length of input, the result is truncated to size
+///     characters.  size must not be negative and padding must be non-empty.
+template <typename T, bool lpad>
+struct PadFunctionVarbinaryBase {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Varbinary>& result,
+      const arg_type<Varbinary>& binary,
+      const arg_type<int64_t>& size,
+      const arg_type<Varbinary>& padbinary) {
+    stringImpl::pad<lpad, false /*isAscii*/>(result, binary, size, padbinary);
+  }
+};
+
+template <typename T>
+struct LPadVarbinaryFunction : public PadFunctionVarbinaryBase<T, true> {};
+
+template <typename T>
+struct RPadVarbinaryFunction : public PadFunctionVarbinaryBase<T, false> {};
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/BinaryFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/BinaryFunctionsRegistration.cpp
@@ -68,6 +68,18 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "to_ieee754_32"});
   registerFunction<FromIEEE754Bits32, float, Varbinary>(
       {prefix + "from_ieee754_32"});
+  registerFunction<
+      LPadVarbinaryFunction,
+      Varbinary,
+      Varbinary,
+      int64_t,
+      Varbinary>({prefix + "lpad"});
+  registerFunction<
+      RPadVarbinaryFunction,
+      Varbinary,
+      Varbinary,
+      int64_t,
+      Varbinary>({prefix + "rpad"});
 }
 } // namespace
 

--- a/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
@@ -747,4 +747,67 @@ TEST_F(BinaryFunctionsTest, fromIEEE754Bits32) {
       fromIEEE754Bits32(hexToDec("0000000000000001")),
       "Input floating-point value must be exactly 4 bytes long");
 }
+
+TEST_F(BinaryFunctionsTest, rpad) {
+  const auto rpad = [&](std::optional<StringView> arg,
+                        std::optional<int32_t> size,
+                        std::optional<StringView> key) {
+    return evaluateOnce<std::string, StringView, int32_t, StringView>(
+        "rpad(c0, c1, c2)",
+        {VARBINARY(), INTEGER(), VARBINARY()},
+        {arg},
+        {size},
+        {key});
+  };
+  EXPECT_EQ(rpad("1234", 14, "45"), ("12344545454545"));
+  EXPECT_EQ(
+      rpad("123456789012", 24, "4444555566667777"),
+      ("123456789012444455556666"));
+  EXPECT_EQ(
+      rpad("1234567890", 30, "44445555666677778888"),
+      ("123456789044445555666677778888"));
+  EXPECT_EQ(rpad("1234", 15, "45"), ("123445454545454"));
+  EXPECT_EQ(rpad("1234", 14, "4524"), ("12344524452445"));
+  EXPECT_EQ(rpad("1234", 6, "4524"), ("123445"));
+  EXPECT_EQ(rpad("23", 0, "4524"), (""));
+  EXPECT_EQ(rpad("∆", 2, "˚"), ("∆˚"));
+  EXPECT_EQ(rpad("©", 4, "£"), ("©£££"));
+  EXPECT_EQ(rpad("1234", 2, "4524"), ("12"));
+  EXPECT_EQ(rpad(std::nullopt, 0, std::nullopt), std::nullopt);
+  VELOX_ASSERT_USER_THROW(
+      rpad("2312", -1, "4524"), "pad size must be in the range [0..1048576)");
+  VELOX_ASSERT_USER_THROW(rpad("2312", 1, ""), "padString must not be empty");
+}
+
+TEST_F(BinaryFunctionsTest, lpad) {
+  const auto lpad = [&](std::optional<StringView> arg,
+                        std::optional<int32_t> size,
+                        std::optional<StringView> key) {
+    return evaluateOnce<std::string, StringView, int32_t, StringView>(
+        "lpad(c0, c1, c2)",
+        {VARBINARY(), INTEGER(), VARBINARY()},
+        {arg},
+        {size},
+        {key});
+  };
+  EXPECT_EQ(lpad("1234", 14, "45"), ("45454545451234"));
+  EXPECT_EQ(lpad("1234", 15, "45"), ("454545454541234"));
+  EXPECT_EQ(
+      lpad("123456789012", 24, "4444555566667777"),
+      ("444455556666123456789012"));
+  EXPECT_EQ(
+      lpad("1234567890", 30, "44445555666677778888"),
+      ("444455556666777788881234567890"));
+  EXPECT_EQ(lpad("∆", 2, "˚"), ("˚∆"));
+  EXPECT_EQ(lpad("©", 4, "£"), ("£££©"));
+  EXPECT_EQ(lpad("1234", 14, "4524"), ("45244524451234"));
+  EXPECT_EQ(lpad("1234", 6, "4524"), ("451234"));
+  EXPECT_EQ(lpad("1234", 0, "4524"), (""));
+  EXPECT_EQ(lpad("1234", 2, "4524"), ("12"));
+  EXPECT_EQ(lpad(std::nullopt, 0, std::nullopt), std::nullopt);
+  VELOX_ASSERT_USER_THROW(
+      lpad("2312", -1, "4524"), "pad size must be in the range [0..1048576)");
+  VELOX_ASSERT_USER_THROW(lpad("2312", 1, ""), "padString must not be empty");
+}
+
 } // namespace


### PR DESCRIPTION
Adds binary lpad and rpad functions and associated unit tests.

Resolves issue #7328 