### PR TITLE
Pass maxOutputRows limit to SortBuffer

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -171,6 +171,16 @@ bool HiveConfig::isFileHandleCacheEnabled(const Config* config) {
   return config->get<bool>(kEnableFileHandleCache, true);
 }
 
+// static.
+uint32_t HiveConfig::sortWriterMaxOutputRows(const Config* config) {
+  return config->get<int32_t>(kSortWriterMaxOutputRows, 1024);
+}
+
+// static.
+uint64_t HiveConfig::sortWriterMaxOutputBytes(const Config* config) {
+  return config->get<uint64_t>(kSortWriterMaxOutputBytes, 10UL << 20);
+}
+
 uint64_t HiveConfig::getOrcWriterMaxStripeSize(
     const Config* connectorQueryCtxConfig,
     const Config* connectorPropertiesConfig) {

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -122,6 +122,11 @@ class HiveConfig {
   static constexpr const char* kOrcWriterMaxDictionaryMemoryConfig =
       "hive.orc.writer.dictionary-max-memory";
 
+  static constexpr const char* kSortWriterMaxOutputRows =
+      "sort_writer_max_output_rows";
+  static constexpr const char* kSortWriterMaxOutputBytes =
+      "sort_writer_max_output_bytes";
+
   static InsertExistingPartitionsBehavior insertExistingPartitionsBehavior(
       const Config* config);
 
@@ -166,6 +171,10 @@ class HiveConfig {
   static bool isFileHandleCacheEnabled(const Config* config);
 
   static uint64_t fileWriterFlushThresholdBytes(const Config* config);
+
+  static uint32_t sortWriterMaxOutputRows(const Config* config);
+
+  static uint64_t sortWriterMaxOutputBytes(const Config* config);
 
   static uint64_t getOrcWriterMaxStripeSize(
       const Config* connectorQueryCtxConfig,

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -603,14 +603,15 @@ HiveDataSink::maybeCreateBucketSortWriter(
       inputType_,
       sortColumnIndices_,
       sortCompareFlags_,
-      // TODO: set batch size based on the query configs.
-      1000,
       sortPool,
       writerInfo_.back()->nonReclaimableSectionHolder.get(),
       &numSpillRuns_,
       spillConfig_);
   return std::make_unique<dwio::common::SortingWriter>(
-      std::move(writer), std::move(sortBuffer));
+      std::move(writer),
+      std::move(sortBuffer),
+      HiveConfig::sortWriterMaxOutputRows(connectorQueryCtx_->config()),
+      HiveConfig::sortWriterMaxOutputBytes(connectorQueryCtx_->config()));
 }
 
 void HiveDataSink::splitInputRowsAndEnsureWriters() {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -399,6 +399,14 @@ Hive Connector
      - true
      - Enables caching of file handles if true. Disables caching if false. File handle cache should be
        disabled if files are not immutable, i.e. file content may change while file path stays the same.
+   * - sort_writer_max_output_rows
+     - integer
+     - 1024
+     - Maximum number of rows for sort writer in one batch of output. This is to limit the memory usage of sort writer.
+   * - sort_writer_max_output_bytes
+     - integer
+     - 10MB
+     - Maximum bytes for sort writer in one batch of output. This is to limit the memory usage of sort writer.
 
 ``Amazon S3 Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/velox/dwio/common/SortingWriter.cpp
+++ b/velox/dwio/common/SortingWriter.cpp
@@ -20,11 +20,17 @@ namespace facebook::velox::dwio::common {
 
 SortingWriter::SortingWriter(
     std::unique_ptr<Writer> writer,
-    std::unique_ptr<exec::SortBuffer> sortBuffer)
+    std::unique_ptr<exec::SortBuffer> sortBuffer,
+    uint32_t maxOutputRowsConfig,
+    uint64_t maxOutputBytesConfig)
     : outputWriter_(std::move(writer)),
+      maxOutputRowsConfig_(maxOutputRowsConfig),
+      maxOutputBytesConfig_(maxOutputBytesConfig),
       sortPool_(sortBuffer->pool()),
       canReclaim_(sortBuffer->canSpill()),
       sortBuffer_(std::move(sortBuffer)) {
+  VELOX_CHECK_GT(maxOutputRowsConfig_, 0);
+  VELOX_CHECK_GT(maxOutputBytesConfig_, 0);
   if (sortPool_->parent()->reclaimer() != nullptr) {
     sortPool_->setReclaimer(MemoryReclaimer::create(this));
   }
@@ -45,10 +51,11 @@ void SortingWriter::close() {
   setState(State::kClosed);
 
   sortBuffer_->noMoreInput();
-  RowVectorPtr output = sortBuffer_->getOutput();
+  const auto maxOutputBatchRows = outputBatchRows();
+  RowVectorPtr output = sortBuffer_->getOutput(maxOutputBatchRows);
   while (output != nullptr) {
     outputWriter_->write(output);
-    output = sortBuffer_->getOutput();
+    output = sortBuffer_->getOutput(maxOutputBatchRows);
   }
   sortBuffer_.reset();
   sortPool_->release();
@@ -94,6 +101,16 @@ uint64_t SortingWriter::reclaim(
       stats);
 
   return reclaimBytes;
+}
+
+uint32_t SortingWriter::outputBatchRows() {
+  uint32_t estimatedMaxOutputRows = UINT_MAX;
+  if (sortBuffer_->estimateOutputRowSize().has_value() &&
+      sortBuffer_->estimateOutputRowSize().value() != 0) {
+    estimatedMaxOutputRows =
+        maxOutputBytesConfig_ / sortBuffer_->estimateOutputRowSize().value();
+  }
+  return std::min(estimatedMaxOutputRows, maxOutputRowsConfig_);
 }
 
 std::unique_ptr<memory::MemoryReclaimer> SortingWriter::MemoryReclaimer::create(

--- a/velox/dwio/common/SortingWriter.h
+++ b/velox/dwio/common/SortingWriter.h
@@ -27,7 +27,9 @@ class SortingWriter : public Writer {
  public:
   SortingWriter(
       std::unique_ptr<Writer> writer,
-      std::unique_ptr<exec::SortBuffer> sortBuffer);
+      std::unique_ptr<exec::SortBuffer> sortBuffer,
+      uint32_t maxOutputRowsConfig,
+      uint64_t maxOutputBytesConfig);
 
   void write(const VectorPtr& data) override;
 
@@ -68,7 +70,12 @@ class SortingWriter : public Writer {
 
   uint64_t reclaim(uint64_t targetBytes, memory::MemoryReclaimer::Stats& stats);
 
+  uint32_t outputBatchRows();
+
   const std::unique_ptr<Writer> outputWriter_;
+  const uint32_t maxOutputRowsConfig_;
+  const uint64_t maxOutputBytesConfig_;
+
   memory::MemoryPool* const sortPool_;
   const bool canReclaim_;
   std::unique_ptr<exec::SortBuffer> sortBuffer_;

--- a/velox/exec/OrderBy.h
+++ b/velox/exec/OrderBy.h
@@ -69,5 +69,6 @@ class OrderBy : public Operator {
 
   std::unique_ptr<SortBuffer> sortBuffer_;
   bool finished_ = false;
+  uint32_t maxOutputRows_;
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/SortBuffer.h
+++ b/velox/exec/SortBuffer.h
@@ -34,7 +34,6 @@ class SortBuffer {
       const RowTypePtr& input,
       const std::vector<column_index_t>& sortColumnIndices,
       const std::vector<CompareFlags>& sortCompareFlags,
-      uint32_t outputBatchSize,
       velox::memory::MemoryPool* pool,
       tsan_atomic<bool>* nonReclaimableSection,
       uint32_t* numSpillRuns,
@@ -50,7 +49,7 @@ class SortBuffer {
   void noMoreInput();
 
   /// Returns the sorted output rows in batch.
-  RowVectorPtr getOutput();
+  RowVectorPtr getOutput(uint32_t maxOutputRows);
 
   /// Indicates if this sort buffer can spill or not.
   bool canSpill() const {
@@ -72,18 +71,19 @@ class SortBuffer {
     return spiller_->stats();
   }
 
+  std::optional<uint64_t> estimateOutputRowSize() const;
+
  private:
   // Ensures there is sufficient memory reserved to process 'input'.
   void ensureInputFits(const VectorPtr& input);
+  void updateEstimatedOutputRowSize();
   // Invoked to initialize or reset the reusable output buffer to get output.
-  void prepareOutput();
+  void prepareOutput(uint32_t maxOutputRows);
   void getOutputWithoutSpill();
   void getOutputWithSpill();
 
   const RowTypePtr input_;
   const std::vector<CompareFlags> sortCompareFlags_;
-  // Maximum number of rows to return in one output batch.
-  const uint32_t outputBatchSize_;
   velox::memory::MemoryPool* const pool_;
   // The flag is passed from the associated operator such as OrderBy or
   // TableWriter to indicate if this sort buffer object is under non-reclaimable
@@ -125,6 +125,9 @@ class SortBuffer {
 
   // Reusable output vector.
   RowVectorPtr output_;
+  // Estimated size of a single output row by using the max
+  // 'data_->estimateRowSize()' across all accumulated data set.
+  std::optional<uint64_t> estimatedOutputRowSize_{};
   // The number of rows that has been returned.
   size_t numOutputRows_{0};
 };


### PR DESCRIPTION
Query can OOM during SortBuffer’s output processing stage. In some query,
output can generate ~1GB data with 1000 rows, which can be huge.

This change makes SortBuffer produce output based on maxOutputRows
to prevent SortBuffer’s output stage using too much memory.