### PR TITLE
Use TypePtr in core/Expressions.h

### DIFF
--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -23,8 +23,7 @@ namespace facebook::velox::core {
 
 class InputTypedExpr : public ITypedExpr {
  public:
-  InputTypedExpr(std::shared_ptr<const Type> type)
-      : ITypedExpr{std::move(type)} {}
+  explicit InputTypedExpr(TypePtr type) : ITypedExpr{std::move(type)} {}
 
   bool operator==(const ITypedExpr& other) const final {
     const auto* casted = dynamic_cast<const InputTypedExpr*>(&other);
@@ -55,7 +54,7 @@ class ConstantTypedExpr : public ITypedExpr {
  public:
   // Creates constant expression. For complex types, only
   // variant::null() value is supported.
-  ConstantTypedExpr(std::shared_ptr<const Type> type, variant value)
+  ConstantTypedExpr(TypePtr type, variant value)
       : ITypedExpr{std::move(type)}, value_{std::move(value)} {}
 
   // Creates constant expression of scalar or complex type. The value comes from
@@ -87,7 +86,7 @@ class ConstantTypedExpr : public ITypedExpr {
     return valueVector_ != nullptr;
   }
 
-  // Returns scalar value as variant if hasValueVector() is false.
+  /// Returns scalar value as variant if hasValueVector() is false.
   const variant& value() const {
     return value_;
   }
@@ -164,7 +163,7 @@ class ConstantTypedExpr : public ITypedExpr {
 class CallTypedExpr : public ITypedExpr {
  public:
   CallTypedExpr(
-      std::shared_ptr<const Type> type,
+      TypePtr type,
       std::vector<TypedExprPtr> inputs,
       std::string funcName)
       : ITypedExpr{std::move(type), std::move(inputs)},
@@ -396,9 +395,7 @@ class DereferenceTypedExpr : public ITypedExpr {
 
 using DereferenceTypedExprPtr = std::shared_ptr<const DereferenceTypedExpr>;
 
-/*
- * Evaluates a list of expressions to produce a row.
- */
+/// Evaluates a list of expressions to produce a row.
 class ConcatTypedExpr : public ITypedExpr {
  public:
   ConcatTypedExpr(
@@ -453,10 +450,10 @@ class ConcatTypedExpr : public ITypedExpr {
   static TypedExprPtr create(const folly::dynamic& obj, void* context);
 
  private:
-  static std::shared_ptr<const Type> toType(
+  static TypePtr toType(
       const std::vector<std::string>& names,
       const std::vector<TypedExprPtr>& expressions) {
-    std::vector<std::shared_ptr<const Type>> children{};
+    std::vector<TypePtr> children{};
     std::vector<std::string> namesCopy{};
     for (size_t i = 0; i < names.size(); ++i) {
       namesCopy.push_back(names.at(i));
@@ -470,7 +467,7 @@ class LambdaTypedExpr : public ITypedExpr {
  public:
   LambdaTypedExpr(RowTypePtr signature, TypedExprPtr body)
       : ITypedExpr(std::make_shared<FunctionType>(
-            std::vector<std::shared_ptr<const Type>>(signature->children()),
+            std::vector<TypePtr>(signature->children()),
             body->type())),
         signature_(signature),
         body_(body) {}
@@ -530,7 +527,7 @@ using LambdaTypedExprPtr = std::shared_ptr<const LambdaTypedExpr>;
 class CastTypedExpr : public ITypedExpr {
  public:
   CastTypedExpr(
-      const std::shared_ptr<const Type>& type,
+      const TypePtr& type,
       const std::vector<TypedExprPtr>& inputs,
       bool nullOnFailure)
       : ITypedExpr{type, inputs}, nullOnFailure_(nullOnFailure) {}
@@ -580,8 +577,7 @@ class CastTypedExpr : public ITypedExpr {
   static TypedExprPtr create(const folly::dynamic& obj, void* context);
 
  private:
-  // This flag prevents throws and instead returns
-  // null on cast failure
+  // Suppress exception and return null on failure to cast.
   const bool nullOnFailure_;
 };
 

--- a/velox/core/ITypedExpr.h
+++ b/velox/core/ITypedExpr.h
@@ -24,16 +24,15 @@ class ITypedExpr;
 
 using TypedExprPtr = std::shared_ptr<const ITypedExpr>;
 
-/* a strongly-typed expression, such as literal, function call, etc... */
+/// Strongly-typed expression, e.g. literal, function call, etc.
 class ITypedExpr : public ISerializable {
  public:
-  explicit ITypedExpr(std::shared_ptr<const Type> type)
-      : type_{std::move(type)}, inputs_{} {}
+  explicit ITypedExpr(TypePtr type) : type_{std::move(type)}, inputs_{} {}
 
-  ITypedExpr(std::shared_ptr<const Type> type, std::vector<TypedExprPtr> inputs)
+  ITypedExpr(TypePtr type, std::vector<TypedExprPtr> inputs)
       : type_{std::move(type)}, inputs_{std::move(inputs)} {}
 
-  const std::shared_ptr<const Type>& type() const {
+  const TypePtr& type() const {
     return type_;
   }
 
@@ -44,12 +43,12 @@ class ITypedExpr : public ISerializable {
   }
 
   /// Returns a copy of this expression with input fields replaced according
-  /// to specified 'mapping'. Fields specified in the 'mapping are replaced
+  /// to specified 'mapping'. Fields specified in the 'mapping' are replaced
   /// by the corresponding expression in 'mapping'.
   /// Fields not present in 'mapping' are left unmodified.
   ///
   /// Used to bind inputs to lambda functions.
-  virtual std::shared_ptr<const ITypedExpr> rewriteInputNames(
+  virtual TypedExprPtr rewriteInputNames(
       const std::unordered_map<std::string, TypedExprPtr>& mapping) const = 0;
 
   virtual std::string toString() const = 0;
@@ -64,9 +63,9 @@ class ITypedExpr : public ISerializable {
     return hash;
   }
 
-  // Returns true if other is recursively equal to 'this'. We do not
-  // overload == because this is overloaded in a subclass for a
-  // different purpose.
+  /// Returns true if other is recursively equal to 'this'. We do not
+  /// overload == because this is overloaded in a subclass for a
+  /// different purpose.
   bool equals(const ITypedExpr& other) const {
     if (type_ != other.type_ || inputs_.size() != other.inputs_.size()) {
       return false;
@@ -104,8 +103,8 @@ class ITypedExpr : public ISerializable {
     return false;
   }
 
-  std::shared_ptr<const Type> type_;
-  std::vector<std::shared_ptr<const ITypedExpr>> inputs_;
+  TypePtr type_;
+  std::vector<TypedExprPtr> inputs_;
 };
 
 } // namespace facebook::velox::core


### PR DESCRIPTION
Refactor core/Expressions.h and core/ITypedExpr.h to use TypePtr instead of `std::shared_ptr<const Type>`.