### PR TITLE
Document CallTypedExpr and CastTypedExpr

### DIFF
--- a/velox/core/tests/TypedExprSerdeTest.cpp
+++ b/velox/core/tests/TypedExprSerdeTest.cpp
@@ -113,19 +113,11 @@ TEST_F(TypedExprSerDeTest, call) {
 
 TEST_F(TypedExprSerDeTest, cast) {
   auto expression = std::make_shared<CastTypedExpr>(
-      BIGINT(),
-      std::vector<TypedExprPtr>{
-          std::make_shared<FieldAccessTypedExpr>(VARCHAR(), "a"),
-      },
-      false);
+      BIGINT(), std::make_shared<FieldAccessTypedExpr>(VARCHAR(), "a"), false);
   testSerde(expression);
 
   expression = std::make_shared<CastTypedExpr>(
-      VARCHAR(),
-      std::vector<TypedExprPtr>{
-          std::make_shared<FieldAccessTypedExpr>(BIGINT(), "a"),
-      },
-      true);
+      VARCHAR(), std::make_shared<FieldAccessTypedExpr>(BIGINT(), "a"), true);
   testSerde(expression);
 }
 

--- a/velox/expression/RegisterSpecialForm.h
+++ b/velox/expression/RegisterSpecialForm.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/velox/expression/benchmarks/CastBenchmark.cpp
+++ b/velox/expression/benchmarks/CastBenchmark.cpp
@@ -30,12 +30,12 @@ class CastBenchmark : public functions::test::FunctionBenchmarkBase {
   size_t doRun(const TypePtr& inputType, const TypePtr& outputType) {
     folly::BenchmarkSuspender suspender;
     std::string colName = "c0";
-    std::vector<facebook::velox::core::TypedExprPtr> inputs{
+    auto castInput =
         std::make_shared<facebook::velox::core::FieldAccessTypedExpr>(
-            inputType, colName)};
+            inputType, colName);
     std::vector<facebook::velox::core::TypedExprPtr> expr{
         std::make_shared<facebook::velox::core::CastTypedExpr>(
-            outputType, inputs, false)};
+            outputType, castInput, false)};
     exec::ExprSet exprSet(expr, &execCtx_);
 
     facebook::velox::VectorFuzzer fuzzer({}, pool());

--- a/velox/functions/prestosql/tests/CastBaseTest.h
+++ b/velox/functions/prestosql/tests/CastBaseTest.h
@@ -44,7 +44,7 @@ class CastBaseTest : public FunctionBaseTest {
     core::TypedExprPtr inputField =
         std::make_shared<const core::FieldAccessTypedExpr>(fromType, "c0");
     return std::make_shared<const core::CastTypedExpr>(
-        toType, std::vector<core::TypedExprPtr>{inputField}, isTryCast);
+        toType, inputField, isTryCast);
   }
 
   // Evaluate cast(fromType as toType) and return the result vector.
@@ -88,7 +88,7 @@ class CastBaseTest : public FunctionBaseTest {
         std::vector<core::TypedExprPtr>{inputField},
         "testing_dictionary");
     return std::make_shared<const core::CastTypedExpr>(
-        toType, std::vector<core::TypedExprPtr>{callExpr}, isTryCast);
+        toType, callExpr, isTryCast);
   }
 
   // Evaluate cast(testing_dictionary(fromType) as toType) and verify the result

--- a/velox/parse/Expressions.cpp
+++ b/velox/parse/Expressions.cpp
@@ -49,8 +49,8 @@ TypePtr resolveTypeImpl(
 namespace {
 std::shared_ptr<const core::CastTypedExpr> makeTypedCast(
     const TypePtr& type,
-    const std::vector<TypedExprPtr>& inputs) {
-  return std::make_shared<const core::CastTypedExpr>(type, inputs, false);
+    const TypedExprPtr& input) {
+  return std::make_shared<const core::CastTypedExpr>(type, input, false);
 }
 
 std::vector<TypePtr> implicitCastTargets(const TypePtr& type) {
@@ -100,7 +100,7 @@ std::vector<TypedExprPtr> genImplicitCasts(const TypedExprPtr& typedExpr) {
   std::vector<TypedExprPtr> implicitCasts;
   implicitCasts.reserve(targetTypes.size());
   for (auto targetType : targetTypes) {
-    implicitCasts.emplace_back(makeTypedCast(targetType, {typedExpr}));
+    implicitCasts.emplace_back(makeTypedCast(targetType, typedExpr));
   }
   return implicitCasts;
 }


### PR DESCRIPTION
Add documentation to CallTypedExpr and CastTypedExpr. Clarify that CallTypedExpr
can be used for both functions and special forms. Explain the difference
between functions and special forms.

Add CallTypedExpr's constructor that takes a single input. Add a check to
existing constructor to verify that there is exactly one input. Add
CallTypedExprPtr typedef.