### PR TITLE
Benchmark group-by with 2 string keys

### DIFF
--- a/velox/functions/prestosql/aggregates/benchmarks/TwoStringKeys.cpp
+++ b/velox/functions/prestosql/aggregates/benchmarks/TwoStringKeys.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <string>
+
+#include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/tests/utils/Cursor.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+DEFINE_int64(fuzzer_seed, 99887766, "Seed for random input dataset generator");
+
+using namespace facebook::velox;
+using namespace facebook::velox::connector::hive;
+using namespace facebook::velox::exec::test;
+
+static constexpr int32_t kNumVectors = 7'000;
+static constexpr int32_t kRowsPerVector = 4'000;
+
+namespace {
+
+// Compare performance of sum(x) with equivalent reduce_agg(x,..).
+class TwoStringKeysBenchmark : public HiveConnectorTestBase {
+ public:
+  explicit TwoStringKeysBenchmark() {
+    OperatorTestBase::SetUpTestCase();
+    HiveConnectorTestBase::SetUp();
+
+    inputType_ = ROW({
+        {"k1", VARCHAR()},
+        {"k2", VARCHAR()},
+        {"n", SMALLINT()},
+    });
+
+    VectorFuzzer::Options opts;
+    opts.vectorSize = kRowsPerVector;
+    opts.nullRatio = 0.0;
+    opts.stringLength = 32;
+    VectorFuzzer fuzzer(opts, pool(), FLAGS_fuzzer_seed);
+
+    std::vector<RowVectorPtr> vectors;
+    for (auto i = 0; i < kNumVectors; ++i) {
+      vectors.emplace_back(fuzzer.fuzzInputFlatRow(inputType_));
+    }
+
+    filePath_ = TempFilePath::create();
+    writeToFile(filePath_->path, vectors);
+  }
+
+  ~TwoStringKeysBenchmark() override {
+    HiveConnectorTestBase::TearDown();
+  }
+
+  void TestBody() override {}
+
+  void verify() {
+    auto plan = PlanBuilder()
+                    .tableScan(inputType_)
+                    .singleAggregation({"k1", "k2"}, {"sum(n)"})
+                    .planFragment();
+
+    auto task = makeTask(plan);
+
+    vector_size_t numResultRows = 0;
+    while (auto result = task->next()) {
+      numResultRows += result->size();
+    }
+
+    LOG(ERROR) << exec::printPlanWithStats(
+        *plan.planNode, task->taskStats(), true);
+  }
+
+  void run() {
+    folly::BenchmarkSuspender suspender;
+
+    auto plan = PlanBuilder()
+                    .tableScan(inputType_)
+                    .singleAggregation({"k1", "k2"}, {"sum(n)"})
+                    .planFragment();
+
+    auto task = makeTask(plan);
+
+    suspender.dismiss();
+
+    vector_size_t numResultRows = 0;
+    while (auto result = task->next()) {
+      numResultRows += result->size();
+    }
+
+    LOG(ERROR) << exec::printPlanWithStats(
+        *plan.planNode, task->taskStats(), true);
+
+    folly::doNotOptimizeAway(numResultRows);
+  }
+
+ private:
+  std::shared_ptr<exec::Task> makeTask(core::PlanFragment plan) {
+    auto task = exec::Task::create(
+        "t",
+        std::move(plan),
+        0,
+        std::make_shared<core::QueryCtx>(executor_.get()));
+
+    task->addSplit("0", exec::Split(makeHiveConnectorSplit(filePath_->path)));
+    task->noMoreSplits("0");
+    return task;
+  }
+
+  RowTypePtr inputType_;
+  std::shared_ptr<TempFilePath> filePath_;
+};
+
+std::unique_ptr<TwoStringKeysBenchmark> benchmark;
+
+BENCHMARK(two_string_keys) {
+  benchmark->run();
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+
+  benchmark = std::make_unique<TwoStringKeysBenchmark>();
+  benchmark->verify();
+//   folly::runBenchmarks();
+  benchmark.reset();
+  return 0;
+}


### PR DESCRIPTION
Summary:
```
 -- Aggregation[SINGLE [k1, k2] a0 := sum(ROW["n"])] -> k1:VARCHAR, k2:VARCHAR, a0:BIGINT
   Output: 28000000 rows (4.06GB, 27344 batches), Cpu time: 13.78s, Blocked wall time: 0ns, Peak memory: 3.30GB, Memory allocations: 109413, Threads: 1
      dataSourceLazyCpuNanos       sum: 7.28s, count: 14005, min: 46.11us, max: 9.54ms
      dataSourceLazyWallNanos      sum: 7.66s, count: 1, min: 7.66s, max: 7.66s
      distinctKey0                 sum: 30001, count: 1, min: 30001, max: 30001
      distinctKey1                 sum: 30001, count: 1, min: 30001, max: 30001
      hashtable.capacity           sum: 33554432, count: 1, min: 33554432, max: 33554432
      hashtable.numDistinct        sum: 28000000, count: 1, min: 28000000, max: 28000000
      hashtable.numRehashes        sum: 12, count: 1, min: 12, max: 12
      hashtable.numTombstones      sum: 0, count: 1, min: 0, max: 0
      loadedToValueHook            sum: 28000000, count: 2801, min: 4000, max: 10000
      queuedWallNanos              sum: 966.00us, count: 1, min: 966.00us, max: 966.00us
      runningAddInputWallNanos     sum: 11.63s, count: 1, min: 11.63s, max: 11.63s
      runningFinishWallNanos       sum: 0ns, count: 1, min: 0ns, max: 0ns
      runningGetOutputWallNanos    sum: 2.14s, count: 1, min: 2.14s, max: 2.14s
  -- TableScan[table: hive_table] -> k1:VARCHAR, k2:VARCHAR, n:SMALLINT
     Input: 28000000 rows (0B, 2801 batches), Output: 28000000 rows (0B, 2801 batches), Cpu time: 7.32s, Blocked wall time: 0ns, Peak memory: 3.64MB, Memory allocations: 84197, Threads: 1, Splits: 1
        dataSourceWallNanos              sum: 61.35ms, count: 1, min: 61.35ms, max: 61.35ms
        flattenStringDictionaryValues    sum: 0, count: 1, min: 0, max: 0
        ioWaitNanos                      sum: 719.63ms, count: 1, min: 719.63ms, max: 719.63ms
        localReadBytes                   sum: 0B, count: 1, min: 0B, max: 0B
        numLocalRead                     sum: 0, count: 1, min: 0, max: 0
        numPrefetch                      sum: 40, count: 1, min: 40, max: 40
        numRamRead                       sum: 23, count: 1, min: 23, max: 23
        numStorageRead                   sum: 146, count: 1, min: 146, max: 146
        overreadBytes                    sum: 0B, count: 1, min: 0B, max: 0B
        prefetchBytes                    sum: 684.96MB, count: 1, min: 684.96MB, max: 684.96MB
        queryThreadIoLatency             sum: 116, count: 1, min: 116, max: 116
        ramReadBytes                     sum: 403.04KB, count: 1, min: 403.04KB, max: 403.04KB
        runningAddInputWallNanos         sum: 0ns, count: 1, min: 0ns, max: 0ns
        runningFinishWallNanos           sum: 1.28us, count: 1, min: 1.28us, max: 1.28us
        runningGetOutputWallNanos        sum: 7.72s, count: 1, min: 7.72s, max: 7.72s
        skippedSplitBytes                sum: 0B, count: 1, min: 0B, max: 0B
        skippedSplits                    sum: 0, count: 1, min: 0, max: 0
        skippedStrides                   sum: 0, count: 1, min: 0, max: 0
        storageReadBytes                 sum: 1.44GB, count: 1, min: 1.44GB, max: 1.44GB
        totalScanTime                    sum: 0ns, count: 1, min: 0ns, max: 0ns
```


```
$ lscpu
Architecture:            x86_64
  CPU op-mode(s):        32-bit, 64-bit
  Address sizes:         46 bits physical, 48 bits virtual
  Byte Order:            Little Endian
CPU(s):                  56
  On-line CPU(s) list:   0-55
Vendor ID:               GenuineIntel
  Model name:            Intel(R) Xeon(R) CPU E5-2680 v4 @ 2.40GHz
    CPU family:          6
    Model:               79
    Thread(s) per core:  2
    Core(s) per socket:  14
    Socket(s):           2
    Stepping:            1
    Frequency boost:     enabled
    CPU max MHz:         2401.0000
    CPU min MHz:         1200.0000
    BogoMIPS:            4788.54
    Flags:               fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts
                          rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt tsc_
                         deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb cat_l3 cdp_l3 invpcid_single pti intel_ppin ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid ep
                         t_ad fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm cqm rdt_a rdseed adx smap intel_pt xsaveopt cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local dtherm ida arat pln pts
Virtualization features:
  Virtualization:        VT-x
Caches (sum of all):
  L1d:                   896 KiB (28 instances)
  L1i:                   896 KiB (28 instances)
  L2:                    7 MiB (28 instances)
  L3:                    70 MiB (2 instances)
NUMA:
  NUMA node(s):          2
  NUMA node0 CPU(s):     0-13,28-41
  NUMA node1 CPU(s):     14-27,42-55
Vulnerabilities:
  Itlb multihit:         KVM: Mitigation: VMX disabled
  L1tf:                  Mitigation; PTE Inversion; VMX conditional cache flushes, SMT vulnerable
  Mds:                   Vulnerable: Clear CPU buffers attempted, no microcode; SMT vulnerable
  Meltdown:              Mitigation; PTI
  Spec store bypass:     Vulnerable
  Spectre v1:            Mitigation; usercopy/swapgs barriers and __user pointer sanitization
  Spectre v2:            Mitigation; Full generic retpoline, IBPB conditional, IBRS_FW, STIBP conditional, RSB filling
  Srbds:                 Not affected
  Tsx async abort:       Vulnerable: Clear CPU buffers attempted, no microcode; SMT vulnerable
```

Differential Revision: D50837090


