### PR TITLE
Fix segfault on TPCH benchmark shutdown

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -270,7 +270,9 @@ class TpchBenchmark {
   }
 
   void shutdown() {
-    cache_->shutdown();
+    if (cache_) {
+      cache_->shutdown();
+    }
   }
 
   std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>> run(


### PR DESCRIPTION
shutdown() calls cache_->shutdown() unconditionally; however, if ssd_cache_gb was not provided, the cache is not initialised and the null pointer dereference causes a segfault. 

Check cache_ is initialised  before interacting with it, as is done everywhere else in the module.