### PR TITLE
Use std::string_view as RowContainer's reference structure for complex types.

### DIFF
--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -135,20 +135,20 @@ RowContainer::RowContainer(
   // Compute the layout of the payload row.  The row has keys, null
   // flags, accumulators, dependent fields. All fields are fixed
   // width. If variable width data is referenced, this is done with
-  // StringView that inlines or points to the data.  The number of
-  // bytes used by each key is determined by keyTypes[i].  Null flags
-  // are one bit per field. If nullableKeys is true there is a null
-  // flag for each key. A null bit for each accumulator and dependent
-  // field follows.  If hasProbedFlag is true, there is an extra bit
-  // to track if the row has been selected by a hash join probe. This
-  // is followed by a free bit which is set if the row is in a free
-  // list. The accumulators come next, with size given by
-  // Aggregate::accumulatorFixedWidthSize(). Dependent fields follow.
-  // These are non-key columns for hash join or order by. If there are variable
-  // length columns or accumulators, i.e. ones that allocate extra space, this
-  // space is tracked by a uint32_t after the dependent columns. If this is a
-  // hash join build side, the pointer to the next row with the same key is
-  // after the optional row size.
+  // StringView(for VARCHAR) and std::string_view(ARRAY, MAP and ROW) that
+  // inlines or points to the data.  The number of bytes used by each key is
+  // determined by keyTypes[i].  Null flags are one bit per field. If
+  // nullableKeys is true there is a null flag for each key. A null bit for each
+  // accumulator and dependent field follows.  If hasProbedFlag is true, there
+  // is an extra bit to track if the row has been selected by a hash join probe.
+  // This is followed by a free bit which is set if the row is in a free list.
+  // The accumulators come next, with size given by
+  // Aggregate::accumulatorFixedWidthSize(). Dependent fields follow. These are
+  // non-key columns for hash join or order by. If there are variable length
+  // columns or accumulators, i.e. ones that allocate extra space, this space is
+  // tracked by a uint32_t after the dependent columns. If this is a hash join
+  // build side, the pointer to the next row with the same key is after the
+  // optional row size.
   //
   // In most cases, rows are prefixed with a normalized_key_t at index
   // -1, 8 bytes below the pointer. This space is reserved for a 64
@@ -357,22 +357,16 @@ void RowContainer::freeVariableWidthFields(folly::Range<char**> rows) {
   for (auto i = 0; i < types_.size(); ++i) {
     switch (typeKinds_[i]) {
       case TypeKind::VARCHAR:
-      case TypeKind::VARBINARY:
+      case TypeKind::VARBINARY: {
+        freeVariableWidthFieldsAtColumn<StringView>(i, rows);
+        break;
+      }
       case TypeKind::ROW:
       case TypeKind::ARRAY:
       case TypeKind::MAP: {
-        auto column = columnAt(i);
-        for (auto row : rows) {
-          if (!isNullAt(row, column.nullByte(), column.nullMask())) {
-            StringView view = valueAt<StringView>(row, column.offset());
-            if (!view.isInline()) {
-              stringAllocator_->free(
-                  HashStringAllocator::headerOf(view.data()));
-              valueAt<StringView>(row, column.offset()) = StringView();
-            }
-          }
-        }
-      } break;
+        freeVariableWidthFieldsAtColumn<std::string_view>(i, rows);
+        break;
+      }
       default:;
     }
   }
@@ -444,16 +438,9 @@ void RowContainer::prepareRead(
     const char* row,
     int32_t offset,
     ByteStream& stream) {
-  auto view = reinterpret_cast<const StringView*>(row + offset);
-  if (view->isInline()) {
-    stream.setRange(ByteRange{
-        const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(view->data())),
-        static_cast<int32_t>(view->size()),
-        0});
-    return;
-  }
+  const auto& view = reinterpret_cast<const std::string_view*>(row + offset);
   // We set 'stream' to range over the ranges that start at the Header
-  // immediately below the first character in the StringView.
+  // immediately below the first character in the std::string_view.
   HashStringAllocator::prepareRead(
       HashStringAllocator::headerOf(view->data()), stream);
 }
@@ -494,8 +481,8 @@ void RowContainer::storeComplexType(
   auto position = stringAllocator_->newWrite(stream);
   ContainerRowSerde::serialize(*decoded.base(), decoded.index(index), stream);
   stringAllocator_->finishWrite(stream, 0);
-  valueAt<StringView>(row, offset) =
-      StringView(reinterpret_cast<char*>(position.position), stream.size());
+  valueAt<std::string_view>(row, offset) = std::string_view(
+      reinterpret_cast<char*>(position.position), stream.size());
 }
 
 //   static

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -132,17 +132,17 @@ RowContainer::RowContainer(
       stringAllocator_(
           stringAllocator ? stringAllocator
                           : std::make_shared<HashStringAllocator>(pool)) {
-  // Compute the layout of the payload row.  The row has keys, null
-  // flags, accumulators, dependent fields. All fields are fixed
-  // width. If variable width data is referenced, this is done with
-  // StringView(for VARCHAR) and std::string_view(ARRAY, MAP and ROW) that
-  // inlines or points to the data.  The number of bytes used by each key is
-  // determined by keyTypes[i].  Null flags are one bit per field. If
-  // nullableKeys is true there is a null flag for each key. A null bit for each
-  // accumulator and dependent field follows.  If hasProbedFlag is true, there
-  // is an extra bit to track if the row has been selected by a hash join probe.
-  // This is followed by a free bit which is set if the row is in a free list.
-  // The accumulators come next, with size given by
+  // Compute the layout of the payload row.  The row has keys, null flags,
+  // accumulators, dependent fields. All fields are fixed width. If variable
+  // width data is referenced, this is done with StringView(for VARCHAR) and
+  // std::string_view(for ARRAY, MAP and ROW) pointing to the data (StringView
+  // might inline the data if it's sufficiently small). The number of bytes used
+  // by each key is determined by keyTypes[i]. Null flags are one bit per field.
+  // If nullableKeys is true there is a null flag for each key. A null bit for
+  // each accumulator and dependent field follows.  If hasProbedFlag is true,
+  // there is an extra bit to track if the row has been selected by a hash join
+  // probe. This is followed by a free bit which is set if the row is in a free
+  // list. The accumulators come next, with size given by
   // Aggregate::accumulatorFixedWidthSize(). Dependent fields follow. These are
   // non-key columns for hash join or order by. If there are variable length
   // columns or accumulators, i.e. ones that allocate extra space, this space is


### PR DESCRIPTION
This PR replaces `StringView` with `std::string_view` as `RowContainer`'s data structure to represent complex type data.

`RowContainer` uses `StringView` as the data structure to represent the reference to variable width data types: `VARCHAR` and complex types like `ARRAY`, `MAP` AND `ROW`. While it makes sense for `VARCHAR`, it does not fit so well with complex types:
- It might lead to confusion as `StringView` suggest a value of type VARCHAR, while for complex types, all they need to store is a pointer to data and size.
- The benefits of `StringView` do not apply to complex types:
    - `StringView` has 4-byte prefix for fast failing of comparison, which is not used for complex types.
    - `StringView` stores data inline for data with size <= 12 , but complex-typed data is bigger than this.
- Construction of `StringView` involves copying first 4 bytes to prefix, which is a waste for complex types.