### PR TITLE
Prevent crashes in Timestamp::toGMT

### DIFF
--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -47,10 +47,16 @@ Timestamp Timestamp::now() {
 void Timestamp::toGMT(const date::time_zone& zone) {
   // Magic number -2^39 + 24*3600. This number and any number lower than that
   // will cause time_zone::to_sys() to SIGABRT. We don't want that to happen.
-  if (seconds_ <= (-1096193779200l + 86400l)) {
-    VELOX_UNSUPPORTED(
-        "Timestamp out of bound for time zone adjustment {} seconds", seconds_);
-  }
+  VELOX_USER_CHECK_GT(
+      seconds_,
+      -1096193779200l + 86400l,
+      "Timestamp seconds out of range for time zone adjustment");
+
+  VELOX_USER_CHECK_LE(
+      seconds_,
+      kMaxSeconds,
+      "Timestamp seconds out of range for time zone adjustment");
+
   date::local_time<std::chrono::seconds> localTime{
       std::chrono::seconds(seconds_)};
   std::chrono::time_point<std::chrono::system_clock, std::chrono::seconds>


### PR DESCRIPTION
Check seconds in Timestamp::toGMT to avoid crashes when seconds are too large.

See #7350