### PR TITLE
Fix try_cast to stop processing rows with errors

### DIFF
--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -538,14 +538,22 @@ void CastExpr::applyCastPrimitives(
     if (queryConfig.adjustTimestampToTimezone()) {
       auto sessionTzName = queryConfig.sessionTimezone();
       if (!sessionTzName.empty()) {
+        // When context.throwOnError is false, some rows will be marked as
+        // 'failed'. These rows should not be processed further. 'remainingRows'
+        // will contain a subset of 'rows' that have passed all the checks (e.g.
+        // keys are not nulls and number of keys and values is the same).
+        exec::LocalSelectivityVector remainingRows(context, rows);
+        context.deselectErrors(*remainingRows);
+
         // locate_zone throws runtime_error if the timezone couldn't be found
         // (so we're safe to dereference the pointer).
         auto* timeZone = date::locate_zone(sessionTzName);
         auto rawTimestamps = resultFlatVector->mutableRawValues();
 
-        applyToSelectedNoThrowLocal(context, rows, result, [&](int row) {
-          rawTimestamps[row].toGMT(*timeZone);
-        });
+        applyToSelectedNoThrowLocal(
+            context, *remainingRows, result, [&](int row) {
+              rawTimestamps[row].toGMT(*timeZone);
+            });
       }
     }
   }


### PR DESCRIPTION
try_cast(varchar as timestamp) used to process all rows including the ones that
already generated errors. Rows with errors have undefined values in the result
vector, hence, processing these may result in new failures or even crashes.

Fixes #7350