### PR TITLE
Fix distinct aggregations with global grouping sets over empty input

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -603,6 +603,8 @@ bool GroupingSet::getGlobalAggregationOutput(
 bool GroupingSet::getDefaultGlobalGroupingSetOutput(
     RowContainerIterator& iterator,
     RowVectorPtr& result) {
+  VELOX_CHECK(hasDefaultGlobalGroupingSetOutput());
+
   if (iterator.allocationIndex != 0) {
     return false;
   }
@@ -718,9 +720,7 @@ bool GroupingSet::getOutput(
     return getGlobalAggregationOutput(iterator, result);
   }
 
-  bool defaultGlobalGroupingSetOutput = noMoreInput_ && numInputRows_ == 0 &&
-      !globalGroupingSets_.empty() && (isRawInput_ || isPartial_);
-  if (defaultGlobalGroupingSetOutput) {
+  if (hasDefaultGlobalGroupingSetOutput()) {
     return getDefaultGlobalGroupingSetOutput(iterator, result);
   }
 

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -414,6 +414,14 @@ RowVectorPtr HashAggregation::getOutput() {
     if (!newDistincts_) {
       if (noMoreInput_) {
         finished_ = true;
+        if (auto numRows = groupingSet_->numDefaultGlobalGroupingSetRows()) {
+          prepareOutput(numRows.value());
+          if (groupingSet_->getDefaultGlobalGroupingSetOutput(
+                  resultIterator_, output_)) {
+            numOutputRows_ += output_->size();
+            return output_;
+          }
+        }
       }
       return nullptr;
     }


### PR DESCRIPTION
HashAggregation without aggregates are used for removing duplicates of grouping keys. If there are no input rows, such
aggregation returns empty results.

However, if used with global grouping sets and no input rows, the expected result is still a row per global grouping set with just the groupId key value.

Before this change, no result rows were returned in that case.