### PR TITLE
fast path for storing a string into HashStringAllocator

### DIFF
--- a/velox/common/memory/CompactDoubleList.h
+++ b/velox/common/memory/CompactDoubleList.h
@@ -64,6 +64,14 @@ class CompactDoubleList {
     return loadPointer(previousLow_, previousHigh_);
   }
 
+  // Updates the next pointer to be 'next' and sets 'next's previous pointer to
+  // 'this'. The use case is taking the head of a free list block without a full
+  // remove of block plus reinsert of the remainder of the block.
+  void updateNext(CompactDoubleList* next) {
+    setNext(next);
+    next->setPrevious(this);
+  }
+
  private:
   static constexpr uint8_t kPointerSignificantBits = 48;
 

--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -518,6 +518,78 @@ void HashStringAllocator::ensureAvailable(int32_t bytes, Position& position) {
   position = finishWrite(stream, 0).first;
 }
 
+inline bool HashStringAllocator::storeStringFast(
+    const char* bytes,
+    int32_t numBytes,
+    char* destination) {
+  auto roundedBytes = std::max(numBytes, kMinAlloc);
+  Header* header = nullptr;
+  if (free_[kNumFreeLists - 1].empty()) {
+    if (roundedBytes >= kMaxAlloc) {
+      return false;
+    }
+    auto index = freeListIndex(roundedBytes);
+    auto available = bits::findFirstBit(freeNonEmpty_, index, kNumFreeLists);
+    if (available < 0) {
+      return false;
+    }
+    header = allocateFromFreeList(roundedBytes, true, true, available);
+    VELOX_CHECK_NOT_NULL(header);
+  } else {
+    auto& freeList = free_[kNumFreeLists - 1];
+    header = headerOf(freeList.next());
+    auto size = header->size();
+    if (roundedBytes > size) {
+      return false;
+    }
+    const auto spaceTaken = roundedBytes + sizeof(Header);
+    if (size - spaceTaken > kMaxAlloc) {
+      // The entry after allocation stays in the largest free list.
+      // The size at the end of the block is changed in place.
+      reinterpret_cast<int32_t*>(header->end())[-1] -= spaceTaken;
+      auto freeHeader = new (header->begin() + roundedBytes)
+          Header(header->size() - spaceTaken);
+      freeHeader->setFree();
+      header->clearFree();
+      memcpy(freeHeader->begin(), header->begin(), sizeof(CompactDoubleList));
+      freeList.updateNext(
+          reinterpret_cast<CompactDoubleList*>(freeHeader->begin()));
+      header->setSize(roundedBytes);
+      freeBytes_ -= spaceTaken;
+      cumulativeBytes_ += roundedBytes;
+    } else {
+      header =
+          allocateFromFreeList(roundedBytes, true, true, kNumFreeLists - 1);
+      if (!header) {
+        return false;
+      }
+    }
+  }
+  simd::memcpy(header->begin(), bytes, numBytes);
+  *reinterpret_cast<StringView*>(destination) =
+      StringView(reinterpret_cast<char*>(header->begin()), numBytes);
+  return true;
+}
+
+void HashStringAllocator::copyMultipartNoInline(
+    char* FOLLY_NONNULL group,
+    int32_t offset) {
+  auto string = reinterpret_cast<StringView*>(group + offset);
+  const auto numBytes = string->size();
+  if (storeStringFast(string->data(), numBytes, group + offset)) {
+    return;
+  }
+  // Write the string as non-contiguous chunks.
+  ByteStream stream(this, false, false);
+  auto position = newWrite(stream, numBytes);
+  stream.appendStringPiece(folly::StringPiece(string->data(), numBytes));
+  finishWrite(stream, 0);
+
+  // The stringView has a pointer to the first byte and the total
+  // size. Read with contiguousString().
+  *string = StringView(reinterpret_cast<char*>(position.position), numBytes);
+}
+
 std::string HashStringAllocator::toString() const {
   std::ostringstream out;
 
@@ -649,33 +721,4 @@ void HashStringAllocator::checkEmpty() const {
   VELOX_CHECK_EQ(0, checkConsistency());
 }
 
-void HashStringAllocator::copy(char* FOLLY_NONNULL group, int32_t offset) {
-  StringView* string = reinterpret_cast<StringView*>(group + offset);
-  if (string->isInline()) {
-    return;
-  }
-  auto data = pool_.allocateFixed(string->size());
-  memcpy(data, string->data(), string->size());
-  *string = StringView(data, string->size());
-}
-
-void HashStringAllocator::copyMultipart(
-    char* FOLLY_NONNULL group,
-    int32_t offset) {
-  auto string = reinterpret_cast<StringView*>(group + offset);
-  if (string->isInline()) {
-    return;
-  }
-  auto numBytes = string->size();
-
-  // Write the string as non-contiguous chunks.
-  ByteStream stream(this, false, false);
-  auto position = newWrite(stream, numBytes);
-  stream.appendStringPiece(folly::StringPiece(string->data(), numBytes));
-  finishWrite(stream, 0);
-
-  // The stringView has a pointer to the first byte and the total
-  // size. Read with contiguousString().
-  *string = StringView(reinterpret_cast<char*>(position.position), numBytes);
-}
 } // namespace facebook::velox

--- a/velox/common/memory/HashStringAllocator.h
+++ b/velox/common/memory/HashStringAllocator.h
@@ -181,7 +181,15 @@ class HashStringAllocator : public StreamArena {
 
   // Copies a StringView at 'offset' in 'group' to storage owned by
   // the hash table. Updates the StringView.
-  void copy(char* FOLLY_NONNULL group, int32_t offset);
+  void copy(char* FOLLY_NONNULL group, int32_t offset) {
+    StringView* string = reinterpret_cast<StringView*>(group + offset);
+    if (string->isInline()) {
+      return;
+    }
+    auto data = pool_.allocateFixed(string->size());
+    memcpy(data, string->data(), string->size());
+    *string = StringView(data, string->size());
+  }
 
   // Copies a StringView at 'offset' in 'group' to storage owned by
   // 'this'. Updates the StringView. A large string may be copied into
@@ -191,7 +199,13 @@ class HashStringAllocator : public StreamArena {
   // data. StringViews written by this are to be read with
   // contiguousString(). This is nearly always zero copy but will
   // accommodate the odd extra large string.
-  void copyMultipart(char* FOLLY_NONNULL group, int32_t offset);
+  void copyMultipart(char* FOLLY_NONNULL group, int32_t offset) {
+    auto string = reinterpret_cast<StringView*>(group + offset);
+    if (string->isInline()) {
+      return;
+    }
+    copyMultipartNoInline(group, offset);
+  }
 
   // Returns a contiguous view on 'view', where 'view' comes from
   // copyMultipart(). Uses 'storage' to own a possible temporary
@@ -368,6 +382,11 @@ class HashStringAllocator : public StreamArena {
   // 'header's memory to free list. Does nothing if the resulting
   // blocks would be below minimum size.
   void freeRestOfBlock(Header* FOLLY_NONNULL header, int32_t keepBytes);
+
+  void copyMultipartNoInline(char* FOLLY_NONNULL group, int32_t offset);
+  // Fast path for storing a string as a single part. Returns true if succeeded,
+  // has no effect if returns false.
+  bool storeStringFast(const char* bytes, int32_t size, char* destination);
 
   // Returns the free list index for 'size'.
   int32_t freeListIndex(int size);

--- a/velox/functions/prestosql/aggregates/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/benchmarks/CMakeLists.txt
@@ -27,6 +27,22 @@ target_link_libraries(
   ${FOLLY_BENCHMARK}
   gflags::gflags)
 
+add_executable(velox_aggregates_string_keys_bm TwoStringKeys.cpp)
+
+target_link_libraries(
+  velox_aggregates_string_keys_bm
+  velox_aggregates
+  velox_hive_connector
+  velox_functions_lib
+  velox_exec_test_lib
+  velox_functions_prestosql
+  velox_dwio_common_exception
+  velox_vector_fuzzer
+  velox_vector_test_lib
+  Folly::folly
+  ${FOLLY_BENCHMARK}
+  gflags::gflags)
+
 add_executable(velox_aggregates_reduce_agg_bm SimpleAggregates.cpp)
 
 target_link_libraries(

--- a/velox/functions/prestosql/aggregates/benchmarks/TwoStringKeys.cpp
+++ b/velox/functions/prestosql/aggregates/benchmarks/TwoStringKeys.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <string>
+
+#include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/tests/utils/Cursor.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+DEFINE_int64(fuzzer_seed, 99887766, "Seed for random input dataset generator");
+
+using namespace facebook::velox;
+using namespace facebook::velox::connector::hive;
+using namespace facebook::velox::exec::test;
+
+static constexpr int32_t kNumVectors = 7'000;
+static constexpr int32_t kRowsPerVector = 4'000;
+
+namespace {
+
+// Compare performance of sum(x) with equivalent reduce_agg(x,..).
+class TwoStringKeysBenchmark : public HiveConnectorTestBase {
+ public:
+  explicit TwoStringKeysBenchmark() {
+    OperatorTestBase::SetUpTestCase();
+    HiveConnectorTestBase::SetUp();
+
+    inputType_ = ROW({
+        {"k1", VARCHAR()},
+        {"k2", VARCHAR()},
+        {"n", SMALLINT()},
+    });
+
+    VectorFuzzer::Options opts;
+    opts.vectorSize = kRowsPerVector;
+    opts.nullRatio = 0.0;
+    opts.stringLength = 32;
+    VectorFuzzer fuzzer(opts, pool(), FLAGS_fuzzer_seed);
+
+    std::vector<RowVectorPtr> vectors;
+    for (auto i = 0; i < kNumVectors; ++i) {
+      vectors.emplace_back(fuzzer.fuzzInputFlatRow(inputType_));
+    }
+
+    filePath_ = TempFilePath::create();
+    writeToFile(filePath_->path, vectors);
+  }
+
+  ~TwoStringKeysBenchmark() override {
+    HiveConnectorTestBase::TearDown();
+  }
+
+  void TestBody() override {}
+
+  void verify() {
+    auto plan = PlanBuilder()
+                    .tableScan(inputType_)
+                    .singleAggregation({"k1", "k2"}, {"sum(n)"})
+                    .planFragment();
+
+    auto task = makeTask(plan);
+
+    vector_size_t numResultRows = 0;
+    while (auto result = task->next()) {
+      numResultRows += result->size();
+    }
+
+    LOG(ERROR) << exec::printPlanWithStats(
+        *plan.planNode, task->taskStats(), true);
+  }
+
+  void run() {
+    folly::BenchmarkSuspender suspender;
+
+    auto plan = PlanBuilder()
+                    .tableScan(inputType_)
+                    .singleAggregation({"k1", "k2"}, {"sum(n)"})
+                    .planFragment();
+
+    auto task = makeTask(plan);
+
+    suspender.dismiss();
+
+    vector_size_t numResultRows = 0;
+    while (auto result = task->next()) {
+      numResultRows += result->size();
+    }
+
+    LOG(ERROR) << exec::printPlanWithStats(
+        *plan.planNode, task->taskStats(), true);
+
+    folly::doNotOptimizeAway(numResultRows);
+  }
+
+ private:
+  std::shared_ptr<exec::Task> makeTask(core::PlanFragment plan) {
+    auto task = exec::Task::create(
+        "t",
+        std::move(plan),
+        0,
+        std::make_shared<core::QueryCtx>(executor_.get()));
+
+    task->addSplit("0", exec::Split(makeHiveConnectorSplit(filePath_->path)));
+    task->noMoreSplits("0");
+    return task;
+  }
+
+  RowTypePtr inputType_;
+  std::shared_ptr<TempFilePath> filePath_;
+};
+
+std::unique_ptr<TwoStringKeysBenchmark> benchmark;
+
+BENCHMARK(two_string_keys) {
+  benchmark->run();
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+
+  benchmark = std::make_unique<TwoStringKeysBenchmark>();
+  benchmark->verify();
+  folly::runBenchmarks();
+  benchmark.reset();
+  return 0;
+}


### PR DESCRIPTION
Making a stream and appending a string and finishing a write to HashStringAllocator takes a long time.  The common use case is an append where there is one free list item that spans the rest of the last arena of the HSA. This makes a fast path for allocating the head of this fre block without first unhooking it from the free list and then putting the tail back there.

Using a test with all unique strings as in

select l_orderkey, l_comment, substr(l_comment, 6), count(*) from lineitem group by 1, 2, 3 order by 1 limit 1;