### PR TITLE
Optimize map_filter and filter Presto functions

### DIFF
--- a/velox/functions/prestosql/FilterFunctions.cpp
+++ b/velox/functions/prestosql/FilterFunctions.cpp
@@ -34,17 +34,6 @@ class FilterFunctionBase : public exec::VectorFunction {
   }
 
  protected:
-  static void appendToIndicesBuffer(
-      BufferPtr* buffer,
-      memory::MemoryPool* pool,
-      vector_size_t data) {
-    if (!*buffer) {
-      *buffer = AlignedBuffer::allocate<decltype(data)>(100, pool);
-      (*buffer)->setSize(0);
-    }
-    AlignedBuffer::appendTo(buffer, &data, 1);
-  }
-
   // Applies filter functions to elements of maps or arrays and returns the
   // number of elements that passed the filters. Stores the number of elements
   // in each array or map that passed the filter in resultSizes. Stores the
@@ -60,18 +49,24 @@ class FilterFunctionBase : public exec::VectorFunction {
       BufferPtr& resultOffsets,
       BufferPtr& resultSizes,
       BufferPtr& selectedIndices) {
-    auto inputOffsets = input->rawOffsets();
-    auto inputSizes = input->rawSizes();
+    const auto* inputOffsets = input->rawOffsets();
+    const auto* inputSizes = input->rawSizes();
 
     auto* pool = context.pool();
     resultSizes = allocateSizes(rows.end(), pool);
     resultOffsets = allocateOffsets(rows.end(), pool);
-    auto rawResultSizes = resultSizes->asMutable<vector_size_t>();
-    auto rawResultOffsets = resultOffsets->asMutable<vector_size_t>();
-    auto numElements = lambdaArgs[0]->size();
+    auto* rawResultSizes = resultSizes->asMutable<vector_size_t>();
+    auto* rawResultOffsets = resultOffsets->asMutable<vector_size_t>();
 
-    auto elementToTopLevelRows = getElementToTopLevelRows(
-        numElements, rows, input.get(), context.pool());
+    const auto numElements = lambdaArgs[0]->size();
+
+    selectedIndices = allocateIndices(numElements, pool);
+    auto* rawSelectedIndices = selectedIndices->asMutable<vector_size_t>();
+
+    vector_size_t numSelected = 0;
+
+    auto elementToTopLevelRows =
+        getElementToTopLevelRows(numElements, rows, input.get(), pool);
 
     exec::LocalDecodedVector bitsDecoder(context);
     auto iter = lambdas->asUnchecked<FunctionVector>()->iterator(&rows);
@@ -97,21 +92,21 @@ class FilterFunctionBase : public exec::VectorFunction {
         }
         auto size = inputSizes[row];
         auto offset = inputOffsets[row];
-        rawResultOffsets[row] = selectedIndices
-            ? selectedIndices->size() / sizeof(vector_size_t)
-            : 0;
+        rawResultOffsets[row] = numSelected;
         for (auto i = 0; i < size; ++i) {
           if (!bitsDecoder.get()->isNullAt(offset + i) &&
               bitsDecoder.get()->valueAt<bool>(offset + i)) {
             ++rawResultSizes[row];
-            appendToIndicesBuffer(&selectedIndices, pool, offset + i);
+            rawSelectedIndices[numSelected] = offset + i;
+            ++numSelected;
           }
         }
       });
     }
 
-    return selectedIndices ? selectedIndices->size() / sizeof(vector_size_t)
-                           : 0;
+    selectedIndices->setSize(numSelected * sizeof(vector_size_t));
+
+    return numSelected;
   }
 };
 


### PR DESCRIPTION
map_filter and filter functions used to resize selectedIndices buffer to add one
index for each element that passed the filter. This is slow. Allocate the
buffer up front instead and resize at the end when it is known how many
elements passed the filter.