### PR TITLE
Do nont buffer output from fragments with a partial limit

### DIFF
--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -112,7 +112,8 @@ BlockingReason Destination::flush(
 PartitionedOutput::PartitionedOutput(
     int32_t operatorId,
     DriverCtx* ctx,
-    const std::shared_ptr<const core::PartitionedOutputNode>& planNode)
+    const std::shared_ptr<const core::PartitionedOutputNode>& planNode,
+    bool noBufferSingleDestination)
     : Operator(
           ctx,
           planNode->outputType(),
@@ -138,7 +139,11 @@ PartitionedOutput::PartitionedOutput(
       bufferReleaseFn_([task = operatorCtx_->task()]() {}),
       maxBufferedBytes_(ctx->task->queryCtx()
                             ->queryConfig()
-                            .maxPartitionedOutputBufferSize()) {
+                            .maxPartitionedOutputBufferSize()),
+      noBufferSingleDestination_(noBufferSingleDestination) {
+  VELOX_CHECK(
+      !noBufferSingleDestination || numDestinations_ == 1,
+      "noBufferSingleDestination is only allowed  for single destination output");
   if (!planNode->isPartitioned()) {
     VELOX_USER_CHECK_EQ(numDestinations_, 1);
   }
@@ -342,13 +347,14 @@ RowVectorPtr PartitionedOutput::getOutput() {
     }
   } while (workLeft);
 
-  if (blockedDestination) {
+  if (blockedDestination || (noBufferSingleDestination_ && !noMoreInput_)) {
     // If we are going off-thread, we may as well make the output in
     // progress for other destinations available, unless it is too
     // small to be worth transfer.
     for (auto& destination : destinations_) {
       if (destination.get() == blockedDestination ||
-          destination->serializedBytes() < kMinDestinationSize) {
+          (destination->serializedBytes() < kMinDestinationSize &&
+           !noBufferSingleDestination_)) {
         continue;
       }
       destination->flush(*bufferManager, bufferReleaseFn_, nullptr);

--- a/velox/exec/PartitionedOutput.h
+++ b/velox/exec/PartitionedOutput.h
@@ -142,10 +142,15 @@ class PartitionedOutput : public Operator {
   // network MTU of 64K.
   static constexpr uint64_t kMinDestinationSize = 60 * 1024;
 
+  /// Constructs PartitionedOutput. 'noBufferSingleDestination' enables a mode
+  /// where all input is passed directly to a single consumer. This
+  /// optimizes operation upstream of a final limit node so that the
+  /// limit is filled as soon as possible.
   PartitionedOutput(
       int32_t operatorId,
       DriverCtx* ctx,
-      const std::shared_ptr<const core::PartitionedOutputNode>& planNode);
+      const std::shared_ptr<const core::PartitionedOutputNode>& planNode,
+      bool noBufferSingleDestination = false);
 
   void addInput(RowVectorPtr input) override;
 
@@ -215,6 +220,10 @@ class PartitionedOutput : public Operator {
   SelectivityVector nullRows_;
   std::vector<uint32_t> partitions_;
   std::vector<DecodedVector> decodedVectors_;
+
+  // True if this is upstream of final limit and should therefore send data as
+  // soon as it is available, without buffering.
+  const bool noBufferSingleDestination_;
 };
 
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -1837,5 +1837,38 @@ TEST_F(MultiFragmentTest, earlyTaskFailure) {
         << partialSortTask->taskId();
   }
 }
+
+TEST_F(MultiFragmentTest, partialLimit) {
+  std::vector<RowVectorPtr> singleRows;
+  for (auto i = 0; i < 100; ++i) {
+    singleRows.push_back(makeRowVector({makeFlatVector<int32_t>({1})}));
+  }
+  auto leafTaskId = makeTaskId("leaf", 0);
+  core::PlanNodePtr leafPlan;
+
+  leafPlan = PlanBuilder()
+                 .values(singleRows)
+                 .limit(0, 10000, true)
+                 .partitionedOutput({}, 1)
+                 .planNode();
+
+  auto leafTask = makeTask(leafTaskId, leafPlan, 0);
+  leafTask->start(1);
+
+  auto rootPlan = PlanBuilder()
+                      .exchange(leafPlan->outputType())
+                      .limit(0, 100000, false)
+                      .planNode();
+
+  auto rootTask = AssertQueryBuilder(rootPlan)
+                      .split(remoteSplit(leafTaskId))
+                      .assertResults(singleRows);
+
+  auto stats = rootTask->taskStats();
+  // We check that the PartitionedOutput does not merge the input vectors before
+  // sending.
+  EXPECT_EQ(100, stats.pipelineStats[0].operatorStats[1].inputVectors);
+}
+
 } // namespace
 } // namespace facebook::velox::exec


### PR DESCRIPTION
Fragments with selective filters belo a partial limit may reach the final limit in the next fragment late if they buffer their output. Therefore, when a fragment has a partial limit before its partitioned output, the partitioned output must send its input a soon as it arrives. In this way, the final limit in the next fragment will reach its count as soon as possible and will terminate its input fragment.