### PR TITLE
Optimize element_at for maps with complex type keys

### DIFF
--- a/velox/functions/lib/SubscriptUtil.h
+++ b/velox/functions/lib/SubscriptUtil.h
@@ -101,7 +101,7 @@ class LookupTable : public LookupTableBase {
 
 class MapSubscript {
  public:
-  explicit MapSubscript(bool allowCaching) : allowcaching_(allowCaching) {}
+  explicit MapSubscript(bool allowCaching) : allowCaching_(allowCaching) {}
 
   VectorPtr applyMap(
       const SelectivityVector& rows,
@@ -109,7 +109,7 @@ class MapSubscript {
       exec::EvalCtx& context) const;
 
   bool cachingEnabled() const {
-    return allowcaching_;
+    return allowCaching_;
   }
 
   auto& lookupTable() const {
@@ -122,14 +122,14 @@ class MapSubscript {
 
  private:
   bool shouldTriggerCaching(const VectorPtr& mapArg) const {
-    if (!allowcaching_) {
+    if (!allowCaching_) {
       return false;
     }
 
     if (!mapArg->type()->childAt(0)->isPrimitiveType() &&
         !!mapArg->type()->childAt(0)->isBoolean()) {
       // Disable caching if the key type is not primitive or is boolean.
-      allowcaching_ = false;
+      allowCaching_ = false;
       return false;
     }
 
@@ -143,7 +143,7 @@ class MapSubscript {
     }
 
     // Disable caching forever.
-    allowcaching_ = false;
+    allowCaching_ = false;
     lookupTable_.reset();
     firstSeenMap_.reset();
     return false;
@@ -151,7 +151,7 @@ class MapSubscript {
 
   // When true the function is allowed to cache a materialized version of the
   // processed map.
-  mutable bool allowcaching_;
+  mutable bool allowCaching_;
 
   // This is used to check if the same base map is being passed over and over
   // in the function. A shared_ptr is used to guarantee that if the map is
@@ -181,8 +181,8 @@ template <
     bool indexStartsAtOne>
 class SubscriptImpl : public exec::Subscript {
  public:
-  explicit SubscriptImpl(bool allowcaching)
-      : mapSubscript_(MapSubscript(allowcaching)) {}
+  explicit SubscriptImpl(bool allowCaching)
+      : mapSubscript_(MapSubscript(allowCaching)) {}
 
   void apply(
       const SelectivityVector& rows,


### PR DESCRIPTION
Implementation of element_at(map, search) uses linear search to find matching
entry. This is slow when maps are large (100s of entries). This optimization
sorts map keys and uses binary search producing 4x speedup on a real-world
workload. The optimization applies only if there is a single map (constant or
dictionary encoded) since in this case the cost of sorting the map amortizes 
across many searches.

There is a standard query optimization technique that generates element_at 
over a single map.

A simple join with a small lookup table u:

```
SELECT * FROM t, u WHERE t.id = u.id
```

Can be written as 

```
SELECT
   element_at(
      (SELECT map_agg(u.id) FROM u), t.id
   ) 
FROM t
```

This ensures that records from u will be collected into a single map and
broadcasted to all workers to be "joined" with t. The original join query may
run as partitioned join (if optimizer is not smart enough) and be very slow.