### PR TITLE
Add extra checks in Spiller.

### DIFF
--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -836,7 +836,7 @@ std::string RowContainer::toString() const {
   }
 
   if (types_.size() > keyTypes_.size()) {
-    out << " Dependents: ";
+    out << ", Dependents: ";
     for (auto i = keyTypes_.size(); i < types_.size(); ++i) {
       if (i > keyTypes_.size()) {
         out << ", ";
@@ -846,10 +846,10 @@ std::string RowContainer::toString() const {
   }
 
   if (!accumulators_.empty()) {
-    out << " Num accumulators: " << accumulators_.size();
+    out << ", Num accumulators: " << accumulators_.size();
   }
 
-  out << " Num rows: " << numRows_;
+  out << ", Num rows: " << numRows_;
   return out.str();
 }
 


### PR DESCRIPTION
Summary:
We have a number of queries that are failing with "index < childrenSize_ (9 vs. 9) Trying to access non-existing child in RowVector" errors.
Stack trace shows it comes from Spiller.
Adding two new checks to collect more information on why and how this happens.

Differential Revision: D50896681


