### PR TITLE
Fix map_entries to take min of Keys and Values for array elements vector.

### DIFF
--- a/velox/functions/prestosql/MapEntries.cpp
+++ b/velox/functions/prestosql/MapEntries.cpp
@@ -29,7 +29,6 @@ class MapEntriesFunction : public exec::VectorFunction {
       exec::EvalCtx& context,
       VectorPtr& result) const override {
     auto& arg = args[0];
-
     VectorPtr localResult;
 
     // Input can be constant or flat.
@@ -71,7 +70,7 @@ class MapEntriesFunction : public exec::VectorFunction {
         context.pool(),
         outputType->childAt(0),
         BufferPtr(nullptr),
-        inputMap->mapKeys()->size(),
+        std::min(inputMap->mapKeys()->size(), inputMap->mapValues()->size()),
         std::vector<VectorPtr>{inputMap->mapKeys(), inputMap->mapValues()});
 
     return std::make_shared<ArrayVector>(


### PR DESCRIPTION
Fix for #7318 .
Currently we take the mapKeys size as size of element vector, when we should do a min of both values and keys. 