### PR TITLE
Fix data race between operator init and memory reclaim

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -450,8 +450,6 @@ StopReason Driver::runInternal(
     return stop;
   }
 
-  TestValue::adjust("facebook::velox::exec::Driver::runInternal", self.get());
-
   // Update the queued time after entering the Task to ensure the stats have not
   // been deleted.
   if (curOperatorId_ < operators_.size()) {
@@ -479,6 +477,8 @@ StopReason Driver::runInternal(
   try {
     // Invoked to initialize the operators once before driver starts execution.
     self->initializeOperators();
+
+    TestValue::adjust("facebook::velox::exec::Driver::runInternal", self.get());
 
     const int32_t numOperators = operators_.size();
     ContinueFuture future;

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -83,9 +83,7 @@ Operator::Operator(
           operatorId,
           driverCtx->pipelineId,
           std::move(planNodeId),
-          std::move(operatorType)}) {
-  maybeSetReclaimer();
-}
+          std::move(operatorType)}) {}
 
 void Operator::maybeSetReclaimer() {
   VELOX_CHECK_NULL(pool()->reclaimer());
@@ -139,7 +137,14 @@ std::unique_ptr<JoinBridge> Operator::joinBridgeFromPlanNode(
 
 void Operator::initialize() {
   VELOX_CHECK(!initialized_);
+  VELOX_CHECK_EQ(
+      pool()->currentBytes(),
+      0,
+      "Unexpected memory usage {} from pool {} before operator init",
+      succinctBytes(pool()->currentBytes()),
+      pool()->name());
   initialized_ = true;
+  maybeSetReclaimer();
 }
 
 // static


### PR DESCRIPTION
There is a data race between operator init and the async memory reclaim from
the memory arbitration. Once we setup the memory reclaimer during operator
construction, the memory arbitrator can start to reclaim memory from this operator
through the memory pool.
This data race is detected by a flaky test: SharedArbitrationTest.concurrentArbitration
under Meta internal tsan test mode.
The fix is to set memory reclaimer on operation initialization which is called once on
the first driver start execution. Currently, we require (with check in driver start code
path) all the operators to start memory pool allocation after initialized.
Passed 500 tsan test iterations with this fix.
