### PR TITLE
Add Spark cast expr based on cast hooks

### DIFF
--- a/velox/benchmarks/basic/CastBenchmark.cpp
+++ b/velox/benchmarks/basic/CastBenchmark.cpp
@@ -120,6 +120,8 @@ int main(int argc, char** argv) {
           "cast_large_double_to_standard_notation",
           "cast(large_double as varchar)")
       .addExpression("cast_timestamp", "cast (timestamp as varchar)")
+      .addExpression("cast_real_as_int", "cast (small_real as integer)")
+      .addExpression("cast_decimal_as_bigint", "cast (short_decimal as bigint)")
       .withIterations(100)
       .disableTesting();
 

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -511,10 +511,12 @@ class QueryConfig {
     return get<bool>(kCastMatchStructByName, false);
   }
 
+  // TODO: to be removed.
   bool isCastToIntByTruncate() const {
     return get<bool>(kCastToIntByTruncate, false);
   }
 
+  // TODO: to be removed.
   bool isIso8601() const {
     return get<bool>(kCastStringToDateIsIso8601, true);
   }

--- a/velox/core/tests/QueryConfigTest.cpp
+++ b/velox/core/tests/QueryConfigTest.cpp
@@ -36,7 +36,6 @@ TEST_F(QueryConfigTest, emptyConfig) {
   ASSERT_FALSE(config.codegenEnabled());
   ASSERT_EQ(config.codegenConfigurationFilePath(), "");
   ASSERT_FALSE(config.isLegacyCast());
-  ASSERT_FALSE(config.isCastToIntByTruncate());
 }
 
 TEST_F(QueryConfigTest, setConfig) {
@@ -51,7 +50,6 @@ TEST_F(QueryConfigTest, setConfig) {
   ASSERT_TRUE(config.codegenEnabled());
   ASSERT_EQ(config.codegenConfigurationFilePath(), path);
   ASSERT_TRUE(config.isLegacyCast());
-  ASSERT_FALSE(config.isCastToIntByTruncate());
 }
 
 TEST_F(QueryConfigTest, memConfig) {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -160,25 +160,6 @@ Expression Evaluation Configuration
      - bool
      - false
      - This flag makes the Row conversion to by applied in a way that the casting row field are matched by name instead of position.
-   * - cast_to_int_by_truncate
-     - bool
-     - false
-     - This flags forces the cast from float/double/decimal/string to integer to be performed by truncating the decimal part instead of rounding.
-   * - cast_string_to_date_is_iso_8601
-     - bool
-     - true
-     - If set, cast from string to date allows only ISO 8601 formatted strings: ``[+-](YYYY-MM-DD)``.
-       Otherwise, allows all patterns supported by Spark:
-         * ``[+-]yyyy*``
-         * ``[+-]yyyy*-[m]m``
-         * ``[+-]yyyy*-[m]m-[d]d``
-         * ``[+-]yyyy*-[m]m-[d]d *``
-         * ``[+-]yyyy*-[m]m-[d]dT*``
-       The asterisk ``*`` in ``yyyy*`` stands for any numbers.
-       For the last two patterns, the trailing ``*`` can represent none or any sequence of characters, e.g:
-         * "1970-01-01 123"
-         * "1970-01-01 (BC)"
-       Regardless of this setting's value, leading spaces will be trimmed.
 
 Memory Management
 -----------------

--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -269,10 +269,6 @@ From strings
 Casting a string to an integral type is allowed if the string represents an
 integral number within the range of the result type. By default, casting from
 strings that represent floating-point numbers is not allowed.
-
-If cast_to_int_by_truncate is set to true, and the string represents a floating-point number,
-the decimal part will be truncated for casting to an integer.
-
 Casting from invalid input values throws.
 
 Valid examples
@@ -283,34 +279,7 @@ Valid examples
   SELECT cast('+1' as tinyint); -- 1
   SELECT cast('-1' as tinyint); -- -1
 
-Valid examples if cast_to_int_by_truncate=true
-
-::
-
-  SELECT cast('12345.67' as bigint); -- 12345
-  SELECT cast('1.2' as tinyint); -- 1
-  SELECT cast('-1.8' as tinyint); -- -1
-  SELECT cast('+1' as tinyint); -- 1
-  SELECT cast('1.' as tinyint); -- 1
-  SELECT cast('-1' as tinyint); -- -1
-  SELECT cast('-1.' as tinyint); -- -1
-  SELECT cast('0.' as tinyint); -- 0
-  SELECT cast('.' as tinyint); -- 0
-  SELECT cast('-.' as tinyint); -- 0
-
 Invalid examples
-
-::
-
-  SELECT cast('1234567' as tinyint); -- Out of range
-  SELECT cast('1a' as tinyint); -- Invalid argument
-  SELECT cast('' as tinyint); -- Invalid argument
-  SELECT cast('1,234,567' as bigint); -- Invalid argument
-  SELECT cast('1'234'567' as bigint); -- Invalid argument
-  SELECT cast('nan' as bigint); -- Invalid argument
-  SELECT cast('infinity' as bigint); -- Invalid argument
-
-Invalid examples if cast_to_int_by_truncate=false
 
 ::
 
@@ -327,14 +296,13 @@ Invalid examples if cast_to_int_by_truncate=false
 From decimal
 ^^^^^^^^^^^^
 
-By default, the decimal part is rounded. If cast_to_int_by_truncate is enabled, the decimal part will be truncated for casting to an integer.
+The decimal part is rounded.
 
 Valid examples
 
 ::
 
-  SELECT cast(2.56 decimal(6, 2) as integer); -- 2 /* cast_to_int_by_truncate enabled */
-  SELECT cast(2.56 decimal(6, 2) as integer); -- 3 /* cast_to_int_by_truncate disabled */
+  SELECT cast(2.56 decimal(6, 2) as integer); -- 3
   SELECT cast(3.46 decimal(6, 2) as integer); -- 3
 
 Invalid examples
@@ -684,36 +652,15 @@ Cast to Date
 From strings
 ^^^^^^^^^^^^
 
-By default, only ISO 8601 strings are supported: `[+-]YYYY-MM-DD`.
-
-If cast_string_to_date_is_iso_8601 is set to false, all Spark supported patterns are allowed.
-See the documentation for cast_string_to_date_is_iso_8601 in :ref:`Expression Evaluation Configuration<expression-evaluation-conf>`
-for the full list of supported patterns.
-
-Casting from invalid input values throws.
+Only ISO 8601 strings are supported: `[+-]YYYY-MM-DD`. Casting from invalid input values throws.
 
 Valid examples
 
-**cast_string_to_date_is_iso_8601=true**
-
 ::
 
   SELECT cast('1970-01-01' as date); -- 1970-01-01
-
-**cast_string_to_date_is_iso_8601=false**
-
-::
-
-  SELECT cast('1970' as date); -- 1970-01-01
-  SELECT cast('1970-01' as date); -- 1970-01-01
-  SELECT cast('1970-01-01' as date); -- 1970-01-01
-  SELECT cast('1970-01-01T123' as date); -- 1970-01-01
-  SELECT cast('1970-01-01 ' as date); -- 1970-01-01
-  SELECT cast('1970-01-01 (BC)' as date); -- 1970-01-01
 
 Invalid examples
-
-**cast_string_to_date_is_iso_8601=true**
 
 ::
 
@@ -725,14 +672,6 @@ Invalid examples
   SELECT cast('2012/10/23' as date); -- Invalid argument
   SELECT cast('2012.10.23' as date); -- Invalid argument
   SELECT cast('2012-10-23 ' as date); -- Invalid argument
-
-**cast_string_to_date_is_iso_8601=false**
-
-::
-
-  SELECT cast('2012-Oct-23' as date); -- Invalid argument
-  SELECT cast('2012/10/23' as date); -- Invalid argument
-  SELECT cast('2012.10.23' as date); -- Invalid argument
 
 From TIMESTAMP
 ^^^^^^^^^^^^^^

--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -1,0 +1,164 @@
+====================
+Conversion Functions
+====================
+
+Cast to Integral Types
+----------------------
+
+Integral types include bigint, integer, smallint, and tinyint.
+
+From integral types
+^^^^^^^^^^^^^^^^^^^
+
+Casting one integral type to another is allowed. When the input value exceeds the range of result type,
+a value of the result type is created forcedly with the input value.
+
+Valid examples:
+
+::
+
+  SELECT cast(1234567 as bigint); -- 1234567
+  SELECT cast(12 as tinyint); -- 12
+  SELECT cast(1234 as tinyint); -- -46
+  SELECT cast(1234567 as smallint); -- -10617
+
+From floating-point types
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Casting from floating-point input to an integral type truncates the input value.
+It is allowed when the truncated result exceeds the range of result type.
+
+Valid examples
+
+::
+
+  SELECT cast(12345.12 as bigint); -- 12345
+  SELECT cast(12345.67 as bigint); -- 12345
+  SELECT cast(127.1 as tinyint); -- 127
+  SELECT cast(127.8 as tinyint); -- 127
+  SELECT cast(1234567.89 as smallint); -- -10617
+  SELECT cast(cast('inf' as double) as bigint); -- 9223372036854775807
+  SELECT cast(cast('nan' as double) as integer); -- 0
+  SELECT cast(cast('nan' as double) as smallint); -- 0
+  SELECT cast(cast('nan' as double) as tinyint); -- 0
+  SELECT cast(cast('nan' as double) as bigint); -- 0
+
+From strings
+^^^^^^^^^^^^
+
+Casting a string to an integral type is allowed if the string represents a number within the range of result type.
+Casting from strings that represent floating-point numbers truncates the decimal part of the input value.
+Casting from invalid input values throws.
+
+Valid examples
+
+::
+
+  SELECT cast('12345' as bigint); -- 12345
+  SELECT cast('+1' as tinyint); -- 1
+  SELECT cast('-1' as tinyint); -- -1
+  SELECT cast('12345.67' as bigint); -- 12345
+  SELECT cast('1.2' as tinyint); -- 1
+  SELECT cast('-1.8' as tinyint); -- -1
+  SELECT cast('+1' as tinyint); -- 1
+  SELECT cast('1.' as tinyint); -- 1
+  SELECT cast('-1' as tinyint); -- -1
+  SELECT cast('-1.' as tinyint); -- -1
+  SELECT cast('0.' as tinyint); -- 0
+  SELECT cast('.' as tinyint); -- 0
+  SELECT cast('-.' as tinyint); -- 0
+
+Invalid examples
+
+::
+
+  SELECT cast('1234567' as tinyint); -- Out of range
+  SELECT cast('1a' as tinyint); -- Invalid argument
+  SELECT cast('' as tinyint); -- Invalid argument
+  SELECT cast('1,234,567' as bigint); -- Invalid argument
+  SELECT cast('1'234'567' as bigint); -- Invalid argument
+  SELECT cast('nan' as bigint); -- Invalid argument
+  SELECT cast('infinity' as bigint); -- Invalid argument
+
+From decimal
+^^^^^^^^^^^^
+
+The decimal part will be truncated for casting to an integer.
+It is allowed when the truncated result exceeds the range of result type.
+
+Valid examples
+
+::
+
+  SELECT cast(cast(2.56 as DECIMAL(6, 2)) as bigint); -- 2
+  SELECT cast(cast(3.46 as DECIMAL(6, 2)) as bigint); -- 3
+  SELECT cast(cast(5500.0 as DECIMAL(5, 1)) as tinyint); -- 124
+  SELECT cast(cast(2147483648.90 as DECIMAL(12, 2)) as tinyint); -- 0
+  SELECT cast(cast(2147483648.90 as DECIMAL(12, 2)) as integer); -- -2147483648
+  SELECT cast(cast(2147483648.90 as DECIMAL(12, 2)) as bigint); -- 2147483648
+
+Cast to String
+--------------
+
+From TIMESTAMP
+^^^^^^^^^^^^^^
+
+Casting a timestamp to a string returns ISO 8601 format with space as separator between date and time,
+and the year part is padded with zeros to 4 characters.
+The conversion precision is microsecond, and trailing zeros are not appended.
+When the year exceeds 9999, a positive sign is added.
+
+Valid examples
+
+::
+
+  SELECT cast(cast('1970-01-01 00:00:00' as timestamp) as string); -- '1970-01-01 00:00:00'
+  SELECT cast(cast('2000-01-01 12:21:56.129' as timestamp) as string); -- '2000-01-01 12:21:56.129'
+  SELECT cast(cast('2000-01-01 12:21:56.100000' as timestamp) as string); -- '2000-01-01 12:21:56.1'
+  SELECT cast(cast('2000-01-01 12:21:56.129900' as timestamp) as string); -- '2000-01-01 12:21:56.1299'
+  SELECT cast(cast('10000-02-01 16:00:00.000' as timestamp) as string); -- '+10000-02-01 16:00:00'
+  SELECT cast(cast('0384-01-01 08:00:00.000' as timestamp) as string); -- '0384-01-01 08:00:00'
+  SELECT cast(cast('-0010-02-01 10:00:00.000' as timestamp) as string); -- '-0010-02-01 10:00:00'
+
+Cast to Date
+------------
+
+From strings
+^^^^^^^^^^^^
+
+All Spark supported patterns are allowed:
+  
+  * ``[+-](YYYY-MM-DD)``
+  * ``[+-]yyyy*``
+  * ``[+-]yyyy*-[m]m``
+  * ``[+-]yyyy*-[m]m-[d]d``
+  * ``[+-]yyyy*-[m]m-[d]d *``
+  * ``[+-]yyyy*-[m]m-[d]dT*``
+
+The asterisk ``*`` in ``yyyy*`` stands for any numbers.
+For the last two patterns, the trailing ``*`` can represent none or any sequence of characters, e.g:
+  
+  * "1970-01-01 123"
+  * "1970-01-01 (BC)"
+  
+All leading and trailing UTF8 white-spaces will be trimmed before cast.
+Casting from invalid input values throws.
+
+Valid examples
+
+::
+
+  SELECT cast('1970' as date); -- 1970-01-01
+  SELECT cast('1970-01' as date); -- 1970-01-01
+  SELECT cast('1970-01-01' as date); -- 1970-01-01
+  SELECT cast('1970-01-01T123' as date); -- 1970-01-01
+  SELECT cast('1970-01-01 ' as date); -- 1970-01-01
+  SELECT cast('1970-01-01 (BC)' as date); -- 1970-01-01
+
+Invalid examples
+
+::
+
+  SELECT cast('2012-Oct-23' as date); -- Invalid argument
+  SELECT cast('2012/10/23' as date); -- Invalid argument
+  SELECT cast('2012.10.23' as date); -- Invalid argument

--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(
   velox_expression
   BooleanMix.cpp
   CastExpr.cpp
+  PrestoCastHooks.cpp
   CoalesceExpr.cpp
   ConjunctExpr.cpp
   ConstantExpr.cpp

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -198,16 +198,29 @@ void CastExpr::applyCastKernel(
   try {
     auto inputRowValue = input->valueAt(row);
 
+    if constexpr (
+        FromKind == TypeKind::TIMESTAMP &&
+        (ToKind == TypeKind::VARCHAR || ToKind == TypeKind::VARBINARY)) {
+      auto writer = exec::StringWriter<>(result, row);
+      hooks_->castTimestampToString(inputRowValue, writer);
+      return;
+    }
+
     // Optimize empty input strings casting by avoiding throwing exceptions.
     if constexpr (
         FromKind == TypeKind::VARCHAR || FromKind == TypeKind::VARBINARY) {
       if constexpr (
           TypeTraits<ToKind>::isPrimitiveType &&
           TypeTraits<ToKind>::isFixedWidth) {
+        inputRowValue = hooks_->removeWhiteSpaces(inputRowValue);
         if (inputRowValue.size() == 0) {
           setError("Empty string");
           return;
         }
+      }
+      if constexpr (ToKind == TypeKind::TIMESTAMP) {
+        result->set(row, hooks_->castStringToTimestamp(inputRowValue));
+        return;
       }
     }
 
@@ -329,37 +342,39 @@ VectorPtr CastExpr::applyDecimalToIntegralCast(
   const auto precisionScale = getDecimalPrecisionScale(*fromType);
   const auto simpleInput = input.as<SimpleVector<FromNativeType>>();
   const auto scaleFactor = DecimalUtil::kPowersOfTen[precisionScale.second];
-  const auto castToIntByTruncate =
-      context.execCtx()->queryCtx()->queryConfig().isCastToIntByTruncate();
-  applyToSelectedNoThrowLocal(context, rows, result, [&](int row) {
-    auto value = simpleInput->valueAt(row);
-    auto integralPart = value / scaleFactor;
-    if (!castToIntByTruncate) {
+  if (hooks_->truncate()) {
+    applyToSelectedNoThrowLocal(context, rows, result, [&](vector_size_t row) {
+      resultBuffer[row] =
+          static_cast<To>(simpleInput->valueAt(row) / scaleFactor);
+    });
+  } else {
+    applyToSelectedNoThrowLocal(context, rows, result, [&](vector_size_t row) {
+      auto value = simpleInput->valueAt(row);
+      auto integralPart = value / scaleFactor;
       auto fractionPart = value % scaleFactor;
       auto sign = value >= 0 ? 1 : -1;
       bool needsRoundUp =
           (scaleFactor != 1) && (sign * fractionPart >= (scaleFactor >> 1));
       integralPart += needsRoundUp ? sign : 0;
-    }
-
-    if (integralPart > std::numeric_limits<To>::max() ||
-        integralPart < std::numeric_limits<To>::min()) {
-      if (setNullInResultAtError()) {
-        result->setNull(row, true);
-      } else {
-        context.setVeloxExceptionError(
-            row,
-            makeBadCastException(
-                result->type(),
-                input,
-                row,
-                makeErrorMessage(input, row, toType) + "Out of bounds."));
+      if (integralPart > std::numeric_limits<To>::max() ||
+          integralPart < std::numeric_limits<To>::min()) {
+        if (setNullInResultAtError()) {
+          result->setNull(row, true);
+        } else {
+          context.setVeloxExceptionError(
+              row,
+              makeBadCastException(
+                  result->type(),
+                  input,
+                  row,
+                  makeErrorMessage(input, row, toType) + "Out of bounds."));
+        }
+        return;
       }
-      return;
-    }
 
-    resultBuffer[row] = static_cast<To>(integralPart);
-  });
+      resultBuffer[row] = static_cast<To>(integralPart);
+    });
+  }
   return result;
 }
 
@@ -489,11 +504,10 @@ void CastExpr::applyCastPrimitives(
   auto* resultFlatVector = result->as<FlatVector<To>>();
   auto* inputSimpleVector = input.as<SimpleVector<From>>();
 
-  const auto& queryConfig = context.execCtx()->queryCtx()->queryConfig();
   auto& resultType = resultFlatVector->type();
 
-  if (!queryConfig.isCastToIntByTruncate()) {
-    if (!queryConfig.isLegacyCast()) {
+  if (!hooks_->truncate()) {
+    if (!hooks_->legacy()) {
       applyToSelectedNoThrowLocal(context, rows, result, [&](int row) {
         applyCastKernel<ToKind, FromKind, false /*truncate*/, false /*legacy*/>(
             row, context, inputSimpleVector, resultFlatVector);
@@ -505,7 +519,7 @@ void CastExpr::applyCastPrimitives(
       });
     }
   } else {
-    if (!queryConfig.isLegacyCast()) {
+    if (!hooks_->legacy()) {
       applyToSelectedNoThrowLocal(context, rows, result, [&](int row) {
         applyCastKernel<ToKind, FromKind, true /*truncate*/, false /*legacy*/>(
             row, context, inputSimpleVector, resultFlatVector);
@@ -521,6 +535,7 @@ void CastExpr::applyCastPrimitives(
   // If we're converting to a TIMESTAMP, check if we need to adjust the
   // current GMT timezone to the user provided session timezone.
   if constexpr (ToKind == TypeKind::TIMESTAMP) {
+    const auto& queryConfig = context.execCtx()->queryCtx()->queryConfig();
     // If user explicitly asked us to adjust the timezone.
     if (queryConfig.adjustTimestampToTimezone()) {
       auto sessionTzName = queryConfig.sessionTimezone();

--- a/velox/expression/CastHooks.h
+++ b/velox/expression/CastHooks.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/expression/StringWriter.h"
+#include "velox/type/Timestamp.h"
+
+namespace facebook::velox::exec {
+
+/// This class provides cast hooks to allow different behaviors of CastExpr and
+/// SparkCastExpr. The main purpose is crate customized cast implementation by
+/// taking full usage of existing cast expression.
+class CastHooks {
+ public:
+  virtual ~CastHooks() = default;
+
+  virtual Timestamp castStringToTimestamp(const StringView& view) const = 0;
+
+  virtual int32_t castStringToDate(const StringView& dateString) const = 0;
+
+  // Cast from timestamp to string and write the result to string writer.
+  virtual void castTimestampToString(
+      const Timestamp& timestamp,
+      StringWriter<false>& out) const = 0;
+
+  // Returns whether legacy cast semantics are enabled.
+  virtual bool legacy() const = 0;
+
+  // Trims all leading and trailing UTF8 whitespaces.
+  virtual StringView removeWhiteSpaces(const StringView& view) const = 0;
+
+  // Returns whether to cast to int by truncate.
+  virtual bool truncate() const = 0;
+};
+} // namespace facebook::velox::exec

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -396,11 +396,12 @@ ExprPtr compileRewrittenExpression(
     if (FOLLY_UNLIKELY(*resultType == *compiledInputs[0]->type())) {
       result = compiledInputs[0];
     } else {
-      result = std::make_shared<CastExpr>(
+      result = getSpecialForm(
+          config,
+          cast->nullOnFailure() ? "try_cast" : "cast",
           resultType,
-          std::move(compiledInputs[0]),
-          trackCpuUsage,
-          cast->nullOnFailure());
+          std::move(compiledInputs),
+          trackCpuUsage);
     }
   } else if (auto call = dynamic_cast<const core::CallTypedExpr*>(expr.get())) {
     if (auto specialForm = getSpecialForm(

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/PrestoCastHooks.h"
+
+namespace facebook::velox::exec {
+
+Timestamp PrestoCastHooks::castStringToTimestamp(const StringView& view) const {
+  return util::fromTimestampString(view.data(), view.size());
+}
+
+int32_t PrestoCastHooks::castStringToDate(const StringView& dateString) const {
+  // Cast from string to date allows only ISO 8601 formatted strings:
+  // [+-](YYYY-MM-DD).
+  return util::castFromDateString(dateString, true /*isIso8601*/);
+}
+
+void PrestoCastHooks::castTimestampToString(
+    const Timestamp& timestamp,
+    StringWriter<false>& out) const {
+  out.copy_from(
+      legacyCast_
+          ? util::Converter<TypeKind::VARCHAR, void, false, true>::cast(
+                timestamp)
+          : util::Converter<TypeKind::VARCHAR, void, false, false>::cast(
+                timestamp));
+  out.finalize();
+}
+
+bool PrestoCastHooks::legacy() const {
+  return legacyCast_;
+}
+
+StringView PrestoCastHooks::removeWhiteSpaces(const StringView& view) const {
+  return view;
+}
+
+bool PrestoCastHooks::truncate() const {
+  return false;
+}
+} // namespace facebook::velox::exec

--- a/velox/expression/PrestoCastHooks.h
+++ b/velox/expression/PrestoCastHooks.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/expression/CastHooks.h"
+#include "velox/expression/EvalCtx.h"
+
+namespace facebook::velox::exec {
+
+// This class provides cast hooks following Presto semantics.
+class PrestoCastHooks : public CastHooks {
+ public:
+  PrestoCastHooks(const core::QueryConfig& config)
+      : CastHooks(), legacyCast_(config.isLegacyCast()) {}
+
+  // Uses the default implementation of 'castFromDateString'.
+  Timestamp castStringToTimestamp(const StringView& view) const override;
+
+  // Uses standard cast mode to cast from string to date.
+  int32_t castStringToDate(const StringView& dateString) const override;
+
+  // Applies different cast options according to 'isLegacyCast' config.
+  void castTimestampToString(
+      const Timestamp& timestamp,
+      StringWriter<false>& out) const override;
+
+  // Follows 'isLegacyCast' config.
+  bool legacy() const override;
+
+  // Returns the input as is.
+  StringView removeWhiteSpaces(const StringView& view) const override;
+
+  // Returns false.
+  bool truncate() const override;
+
+ private:
+  const bool legacyCast_;
+};
+} // namespace facebook::velox::exec

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -29,20 +29,6 @@
 using namespace facebook::velox;
 namespace facebook::velox::test {
 namespace {
-
-constexpr float kInf = std::numeric_limits<float>::infinity();
-constexpr float kNan = std::numeric_limits<float>::quiet_NaN();
-
-namespace {
-auto createCopy(const VectorPtr& input) {
-  VectorPtr result;
-  SelectivityVector rows(input->size());
-  BaseVector::ensureWritable(rows, input->type(), input->pool(), result);
-  result->copy(input.get(), rows, nullptr);
-  return result;
-}
-} // namespace
-
 class CastExprTest : public functions::test::CastBaseTest {
  protected:
   CastExprTest() {
@@ -55,12 +41,6 @@ class CastExprTest : public functions::test::CastBaseTest {
   void setLegacyCast(bool value) {
     queryCtx_->testingOverrideConfigUnsafe({
         {core::QueryConfig::kLegacyCast, std::to_string(value)},
-    });
-  }
-
-  void setCastIntByTruncate(bool value) {
-    queryCtx_->testingOverrideConfigUnsafe({
-        {core::QueryConfig::kCastToIntByTruncate, std::to_string(value)},
     });
   }
 
@@ -77,89 +57,9 @@ class CastExprTest : public functions::test::CastBaseTest {
     });
   }
 
-  void setCastStringToDateIsIso8601(bool value) {
-    queryCtx_->testingOverrideConfigUnsafe({
-        {core::QueryConfig::kCastStringToDateIsIso8601, std::to_string(value)},
-    });
-  }
-
   std::shared_ptr<core::ConstantTypedExpr> makeConstantNullExpr(TypeKind kind) {
     return std::make_shared<core::ConstantTypedExpr>(
         createType(kind, {}), variant(kind));
-  }
-
-  std::shared_ptr<core::CastTypedExpr> makeCastExpr(
-      const core::TypedExprPtr& input,
-      const TypePtr& toType,
-      bool nullOnFailure) {
-    std::vector<core::TypedExprPtr> inputs = {input};
-    return std::make_shared<core::CastTypedExpr>(toType, inputs, nullOnFailure);
-  }
-
-  void testComplexCast(
-      const std::string& fromExpression,
-      const VectorPtr& data,
-      const VectorPtr& expected,
-      bool nullOnFailure = false) {
-    auto rowVector = makeRowVector({data});
-    auto rowType = asRowType(rowVector->type());
-    auto castExpr = makeCastExpr(
-        makeTypedExpr(fromExpression, rowType),
-        expected->type(),
-        nullOnFailure);
-    exec::ExprSet exprSet({castExpr}, &execCtx_);
-    auto copy = createCopy(data);
-    const auto size = data->size();
-    SelectivityVector rows(size);
-    std::vector<VectorPtr> result(1);
-    {
-      exec::EvalCtx evalCtx(&execCtx_, &exprSet, rowVector.get());
-      exprSet.eval(rows, evalCtx, result);
-
-      assertEqualVectors(expected, result[0]);
-
-      // Make sure the input vector does not change.
-      assertEqualVectors(data, copy);
-    }
-
-    // Test constant input.
-    {
-      // Use last element for constant.
-      const auto index = size - 1;
-      auto constantData = BaseVector::wrapInConstant(size, index, data);
-      auto constantRow = makeRowVector({constantData});
-      auto localCopy = createCopy(constantRow);
-      exec::EvalCtx evalCtx(&execCtx_, &exprSet, constantRow.get());
-      exprSet.eval(rows, evalCtx, result);
-
-      // Make sure the input vector does not change.
-      assertEqualVectors(constantRow, localCopy);
-      assertEqualVectors(data, copy);
-
-      assertEqualVectors(
-          BaseVector::wrapInConstant(size, index, expected), result[0]);
-    }
-
-    // Test dictionary input. It is not sufficient to wrap input in a dictionary
-    // as it will be peeled off before calling "cast". Apply
-    // testing_dictionary function to input to ensure that "cast" receives
-    // dictionary input.
-    {
-      auto dictionaryCastExpr = makeCastExpr(
-          makeTypedExpr(
-              fmt::format("testing_dictionary({})", fromExpression), rowType),
-          expected->type(),
-          nullOnFailure);
-      exec::ExprSet dictionaryExprSet({dictionaryCastExpr}, &execCtx_);
-      exec::EvalCtx evalCtx(&execCtx_, &dictionaryExprSet, rowVector.get());
-      dictionaryExprSet.eval(rows, evalCtx, result);
-
-      // Make sure the input vector does not change.
-      assertEqualVectors(data, copy);
-
-      auto indices = functions::test::makeIndicesInReverse(size, pool());
-      assertEqualVectors(wrapInDictionary(indices, size, expected), result[0]);
-    }
   }
 
   template <typename T>
@@ -280,7 +180,6 @@ class CastExprTest : public functions::test::CastBaseTest {
 
   template <typename T>
   void testDecimalToIntegralCasts() {
-    setCastIntByTruncate(false);
     auto shortFlat = makeNullableFlatVector<int64_t>(
         {-300,
          -260,
@@ -338,41 +237,6 @@ class CastExprTest : public functions::test::CastBaseTest {
              55,
              55 /* 55.49 rounds to 55*/,
              56 /* 55.99 rounds to 56*/,
-             69,
-             72,
-             std::nullopt}));
-
-    setCastIntByTruncate(true);
-    testComplexCast(
-        "c0",
-        shortFlat,
-        makeNullableFlatVector<T>(
-            {-3,
-             -2 /*-2.6 truncated to -2*/,
-             -2 /*-2.3 truncated to -2*/,
-             -2,
-             -1,
-             0,
-             55,
-             57 /*57.49 truncated to 57*/,
-             57 /*57.55 truncated to 57*/,
-             69,
-             72,
-             std::nullopt}));
-
-    testComplexCast(
-        "c0",
-        longFlat,
-        makeNullableFlatVector<T>(
-            {-3,
-             -2 /*-2.55 truncated to -2*/,
-             -2 /*-2.45 truncated to -2*/,
-             -2,
-             -1,
-             0,
-             55,
-             55 /* 55.49 truncated to 55*/,
-             55 /* 55.99 truncated to 55*/,
              69,
              72,
              std::nullopt}));
@@ -695,9 +559,6 @@ TEST_F(CastExprTest, stringToTimestamp) {
       std::nullopt,
   };
   testCast<std::string, Timestamp>("timestamp", input, expected);
-
-  setCastIntByTruncate(true);
-  testCast<std::string, Timestamp>("timestamp", input, expected);
 }
 
 TEST_F(CastExprTest, timestampToString) {
@@ -873,115 +734,89 @@ TEST_F(CastExprTest, timestampAdjustToTimezoneInvalid) {
 }
 
 TEST_F(CastExprTest, date) {
-  for (bool isIso8601 : {true, false}) {
-    setCastStringToDateIsIso8601(isIso8601);
-    testCast<std::string, int32_t>(
-        "date",
-        {"1970-01-01",
-         "2020-01-01",
-         "2135-11-09",
-         "1969-12-27",
-         "1812-04-15",
-         "1920-01-02",
-         "12345-12-18",
-         "1970-1-2",
-         "1970-01-2",
-         "1970-1-02",
-         "+1970-01-02",
-         "-1-1-1",
-         " 1970-01-01",
-         std::nullopt},
-        {0,
-         18262,
-         60577,
-         -5,
-         -57604,
-         -18262,
-         3789742,
-         1,
-         1,
-         1,
-         1,
-         -719893,
-         0,
-         std::nullopt},
-        VARCHAR(),
-        DATE());
-  }
-
-  setCastStringToDateIsIso8601(false);
   testCast<std::string, int32_t>(
       "date",
-      {"12345",
-       "2015",
-       "2015-03",
-       "2015-03-18T",
-       "2015-03-18T123123",
-       "2015-03-18 123142",
-       "2015-03-18 (BC)"},
-      {3789391, 16436, 16495, 16512, 16512, 16512, 16512},
+      {"1970-01-01",
+       "2020-01-01",
+       "2135-11-09",
+       "1969-12-27",
+       "1812-04-15",
+       "1920-01-02",
+       "12345-12-18",
+       "1970-1-2",
+       "1970-01-2",
+       "1970-1-02",
+       "+1970-01-02",
+       "-1-1-1",
+       " 1970-01-01",
+       std::nullopt},
+      {0,
+       18262,
+       60577,
+       -5,
+       -57604,
+       -18262,
+       3789742,
+       1,
+       1,
+       1,
+       1,
+       -719893,
+       0,
+       std::nullopt},
       VARCHAR(),
       DATE());
 }
 
 TEST_F(CastExprTest, invalidDate) {
-  for (bool isIso8601 : {true, false}) {
-    setCastStringToDateIsIso8601(isIso8601);
+  testInvalidCast<int8_t>(
+      "date", {12}, "Cast from TINYINT to DATE is not supported", TINYINT());
+  testInvalidCast<int16_t>(
+      "date",
+      {1234},
+      "Cast from SMALLINT to DATE is not supported",
+      SMALLINT());
+  testInvalidCast<int32_t>(
+      "date", {1234}, "Cast from INTEGER to DATE is not supported", INTEGER());
+  testInvalidCast<int64_t>(
+      "date", {1234}, "Cast from BIGINT to DATE is not supported", BIGINT());
 
-    testInvalidCast<int8_t>(
-        "date", {12}, "Cast from TINYINT to DATE is not supported", TINYINT());
-    testInvalidCast<int16_t>(
-        "date",
-        {1234},
-        "Cast from SMALLINT to DATE is not supported",
-        SMALLINT());
-    testInvalidCast<int32_t>(
-        "date",
-        {1234},
-        "Cast from INTEGER to DATE is not supported",
-        INTEGER());
-    testInvalidCast<int64_t>(
-        "date", {1234}, "Cast from BIGINT to DATE is not supported", BIGINT());
+  testInvalidCast<float>(
+      "date", {12.99}, "Cast from REAL to DATE is not supported", REAL());
+  testInvalidCast<double>(
+      "date", {12.99}, "Cast from DOUBLE to DATE is not supported", DOUBLE());
 
-    testInvalidCast<float>(
-        "date", {12.99}, "Cast from REAL to DATE is not supported", REAL());
-    testInvalidCast<double>(
-        "date", {12.99}, "Cast from DOUBLE to DATE is not supported", DOUBLE());
-
-    // Parsing ill-formated dates.
-    testInvalidCast<std::string>(
-        "date",
-        {"2012-Oct-23"},
-        "Unable to parse date value: \"2012-Oct-23\"",
-        VARCHAR());
-    testInvalidCast<std::string>(
-        "date",
-        {"2015-03-18X"},
-        "Unable to parse date value: \"2015-03-18X\"",
-        VARCHAR());
-    testInvalidCast<std::string>(
-        "date",
-        {"2015/03/18"},
-        "Unable to parse date value: \"2015/03/18\"",
-        VARCHAR());
-    testInvalidCast<std::string>(
-        "date",
-        {"2015.03.18"},
-        "Unable to parse date value: \"2015.03.18\"",
-        VARCHAR());
-    testInvalidCast<std::string>(
-        "date",
-        {"20150318"},
-        "Unable to parse date value: \"20150318\"",
-        VARCHAR());
-    testInvalidCast<std::string>(
-        "date",
-        {"2015-031-8"},
-        "Unable to parse date value: \"2015-031-8\"",
-        VARCHAR());
-  }
-
-  setCastStringToDateIsIso8601(true);
+  // Parsing ill-formated dates.
+  testInvalidCast<std::string>(
+      "date",
+      {"2012-Oct-23"},
+      "Unable to parse date value: \"2012-Oct-23\"",
+      VARCHAR());
+  testInvalidCast<std::string>(
+      "date",
+      {"2015-03-18X"},
+      "Unable to parse date value: \"2015-03-18X\"",
+      VARCHAR());
+  testInvalidCast<std::string>(
+      "date",
+      {"2015/03/18"},
+      "Unable to parse date value: \"2015/03/18\"",
+      VARCHAR());
+  testInvalidCast<std::string>(
+      "date",
+      {"2015.03.18"},
+      "Unable to parse date value: \"2015.03.18\"",
+      VARCHAR());
+  testInvalidCast<std::string>(
+      "date",
+      {"20150318"},
+      "Unable to parse date value: \"20150318\"",
+      VARCHAR());
+  testInvalidCast<std::string>(
+      "date",
+      {"2015-031-8"},
+      "Unable to parse date value: \"2015-031-8\"",
+      VARCHAR());
   testInvalidCast<std::string>(
       "date", {"12345"}, "Unable to parse date value: \"12345\"", VARCHAR());
   testInvalidCast<std::string>(
@@ -1022,7 +857,6 @@ TEST_F(CastExprTest, invalidDate) {
 }
 
 TEST_F(CastExprTest, primitiveInvalidCornerCases) {
-  setCastIntByTruncate(false);
   // To integer.
   {
     // Overflow.
@@ -1132,67 +966,9 @@ TEST_F(CastExprTest, primitiveInvalidCornerCases) {
         {"tru"},
         "Non-whitespace character found after end of conversion");
   }
-
-  setCastIntByTruncate(true);
-  // To integer.
-  {
-    // Invalid strings.
-    testInvalidCast<std::string>(
-        "tinyint", {"1234567"}, "Value is too large for type");
-    testInvalidCast<std::string>(
-        "tinyint", {"1a"}, "Encountered a non-digit character");
-    testInvalidCast<std::string>("tinyint", {""}, "Empty string");
-    testInvalidCast<std::string>(
-        "integer", {"1'234'567"}, "Encountered a non-digit character");
-    testInvalidCast<std::string>(
-        "integer", {"1,234,567"}, "Encountered a non-digit character");
-    testInvalidCast<std::string>(
-        "bigint", {"infinity"}, "Encountered a non-digit character");
-    testInvalidCast<std::string>(
-        "bigint", {"nan"}, "Encountered a non-digit character");
-  }
-
-  // To floating-point.
-  {
-    // Invalid strings.
-    testInvalidCast<std::string>(
-        "real",
-        {"1.2a"},
-        "Non-whitespace character found after end of conversion");
-    testInvalidCast<std::string>(
-        "real",
-        {"1.2.3"},
-        "Non-whitespace character found after end of conversion");
-  }
-
-  // To boolean.
-  {
-    testInvalidCast<std::string>(
-        "boolean",
-        {"1.7E308"},
-        "Non-whitespace character found after end of conversion");
-    testInvalidCast<std::string>(
-        "boolean",
-        {"nan"},
-        "Non-whitespace character found after end of conversion");
-    testInvalidCast<std::string>(
-        "boolean", {"infinity"}, "Invalid value for bool");
-    testInvalidCast<std::string>(
-        "boolean", {"12"}, "Integer overflow when parsing bool");
-    testInvalidCast<std::string>("boolean", {"-1"}, "Invalid value for bool");
-    testInvalidCast<std::string>(
-        "boolean",
-        {"tr"},
-        "Non-whitespace character found after end of conversion");
-    testInvalidCast<std::string>(
-        "boolean",
-        {"tru"},
-        "Non-whitespace character found after end of conversion");
-  }
 }
 
 TEST_F(CastExprTest, primitiveValidCornerCases) {
-  setCastIntByTruncate(false);
   // To integer.
   {
     testCast<double, int8_t>("tinyint", {127.1}, {127});
@@ -1242,111 +1018,13 @@ TEST_F(CastExprTest, primitiveValidCornerCases) {
     testCast<float, std::string>("varchar", {kInf}, {"Infinity"});
     testCast<float, std::string>("varchar", {kNan}, {"NaN"});
   }
-
-  setCastIntByTruncate(true);
-  // To integer.
-  {
-    // Valid strings.
-    testCast<std::string, int8_t>("tinyint", {"1.2"}, {1});
-    testCast<std::string, int8_t>("tinyint", {"1.23444"}, {1});
-    testCast<std::string, int8_t>("tinyint", {".2355"}, {0});
-    testCast<std::string, int8_t>("tinyint", {"-1.8"}, {-1});
-    testCast<std::string, int8_t>("tinyint", {"+1"}, {1});
-    testCast<std::string, int8_t>("tinyint", {"1."}, {1});
-    testCast<std::string, int8_t>("tinyint", {"-1"}, {-1});
-    testCast<std::string, int8_t>("tinyint", {"-1."}, {-1});
-    testCast<std::string, int8_t>("tinyint", {"0."}, {0});
-    testCast<std::string, int8_t>("tinyint", {"."}, {0});
-    testCast<std::string, int8_t>("tinyint", {"-."}, {0});
-
-    testCast<int32_t, int8_t>("tinyint", {1234567}, {-121});
-    testCast<int32_t, int8_t>("tinyint", {-1234567}, {121});
-    testCast<double, int8_t>("tinyint", {12345.67}, {57});
-    testCast<double, int8_t>("tinyint", {-12345.67}, {-57});
-    testCast<double, int8_t>("tinyint", {127.1}, {127});
-    testCast<float, int64_t>("bigint", {kInf}, {9223372036854775807});
-    testCast<float, int64_t>("bigint", {kNan}, {0});
-    testCast<float, int32_t>("integer", {kNan}, {0});
-    testCast<float, int16_t>("smallint", {kNan}, {0});
-    testCast<float, int8_t>("tinyint", {kNan}, {0});
-
-    testCast<double, int64_t>("bigint", {12345.12}, {12345});
-    testCast<double, int64_t>("bigint", {12345.67}, {12345});
-  }
-
-  // To floating-point.
-  {
-    testCast<double, float>("real", {1.7E308}, {kInf});
-
-    testCast<std::string, float>("real", {"1.7E308"}, {kInf});
-    testCast<std::string, float>("real", {"1."}, {1.0});
-    testCast<std::string, float>("real", {"1"}, {1});
-    testCast<std::string, float>("real", {"infinity"}, {kInf});
-    testCast<std::string, float>("real", {"-infinity"}, {-kInf});
-    testCast<std::string, float>("real", {"nan"}, {kNan});
-    testCast<std::string, float>("real", {"InfiNiTy"}, {kInf});
-    testCast<std::string, float>("real", {"-InfiNiTy"}, {-kInf});
-    testCast<std::string, float>("real", {"nAn"}, {kNan});
-  }
-
-  // To boolean.
-  {
-    testCast<int8_t, bool>("boolean", {1}, {true});
-    testCast<int8_t, bool>("boolean", {0}, {false});
-    testCast<int8_t, bool>("boolean", {12}, {true});
-    testCast<int8_t, bool>("boolean", {-1}, {true});
-    testCast<double, bool>("boolean", {1.0}, {true});
-    testCast<double, bool>("boolean", {1.1}, {true});
-    testCast<double, bool>("boolean", {0.1}, {true});
-    testCast<double, bool>("boolean", {-0.1}, {true});
-    testCast<double, bool>("boolean", {-1.0}, {true});
-    testCast<float, bool>("boolean", {kNan}, {false});
-    testCast<float, bool>("boolean", {kInf}, {true});
-    testCast<double, bool>("boolean", {0.0000000000001}, {true});
-
-    testCast<std::string, bool>("boolean", {"1"}, {true});
-    testCast<std::string, bool>("boolean", {"0"}, {false});
-    testCast<std::string, bool>("boolean", {"t"}, {true});
-    testCast<std::string, bool>("boolean", {"true"}, {true});
-  }
-
-  // To string.
-  {
-    testCast<float, std::string>("varchar", {kInf}, {"Infinity"});
-    testCast<float, std::string>("varchar", {kNan}, {"NaN"});
-  }
 }
 
 TEST_F(CastExprTest, truncateVsRound) {
-  // Testing truncate vs round cast from double to int.
-  setCastIntByTruncate(true);
-  testCast<double, int>(
-      "int", {1.888, 2.5, 3.6, 100.44, -100.101}, {1, 2, 3, 100, -100});
-  testCast<double, int8_t>(
-      "tinyint",
-      {1,
-       256,
-       257,
-       2147483646,
-       2147483647,
-       2147483648,
-       -2147483646,
-       -2147483647,
-       -2147483648,
-       -2147483649},
-      {1, 0, 1, -2, -1, -1, 2, 1, 0, 0});
-
-  setCastIntByTruncate(false);
+  // Testing round cast from double to int.
   testCast<double, int>(
       "int", {1.888, 2.5, 3.6, 100.44, -100.101}, {2, 3, 4, 100, -100});
-
   testCast<int8_t, int32_t>("int", {111, 2, 3, 10, -10}, {111, 2, 3, 10, -10});
-
-  setCastIntByTruncate(true);
-  testCast<int32_t, int8_t>(
-      "tinyint", {1111111, 2, 3, 1000, -100101}, {71, 2, 3, -24, -5});
-
-  setCastIntByTruncate(false);
   testCast<int32_t, int8_t>("tinyint", {2, 3}, {2, 3});
   testInvalidCast<int32_t>(
       "tinyint",
@@ -1376,51 +1054,6 @@ TEST_F(CastExprTest, errorHandling) {
       "tinyint",
       {"1abc", "2", "3", "100", std::nullopt},
       {std::nullopt, 2, 3, 100, std::nullopt});
-
-  setCastIntByTruncate(true);
-  testTryCast<std::string, int8_t>(
-      "tinyint",
-      {"-",
-       "-0",
-       " @w 123",
-       "123 ",
-       "  122",
-       "",
-       "-12-3",
-       "1234",
-       "-129",
-       "1.1.1",
-       "1..",
-       "1.abc",
-       "..",
-       "-..",
-       "125.5",
-       "127",
-       "-128"},
-      {std::nullopt,
-       0,
-       std::nullopt,
-       std::nullopt,
-       std::nullopt,
-       std::nullopt,
-       std::nullopt,
-       std::nullopt,
-       std::nullopt,
-       std::nullopt,
-       std::nullopt,
-       std::nullopt,
-       std::nullopt,
-       std::nullopt,
-       125,
-       127,
-       -128});
-
-  testTryCast<double, int>(
-      "integer",
-      {1e12, 2.5, 3.6, 100.44, -100.101},
-      {std::numeric_limits<int32_t>::max(), 2, 3, 100, -100});
-
-  setCastIntByTruncate(false);
   testCast<double, int>(
       "int", {1.888, 2.5, 3.6, 100.44, -100.101}, {2, 3, 4, 100, -100});
 

--- a/velox/functions/lib/string/StringImpl.h
+++ b/velox/functions/lib/string/StringImpl.h
@@ -493,8 +493,15 @@ template <
 FOLLY_ALWAYS_INLINE void trimUnicodeWhiteSpace(
     TOutString& output,
     const TInString& input) {
+  auto emtpyOutput = [&]() {
+    if constexpr (std::is_same_v<TOutString, StringView>) {
+      output = StringView("");
+    } else {
+      output.setEmpty();
+    }
+  };
   if (input.empty()) {
-    output.setEmpty();
+    emtpyOutput;
     return;
   }
 
@@ -513,7 +520,7 @@ FOLLY_ALWAYS_INLINE void trimUnicodeWhiteSpace(
     }
 
     if (curStartPos >= input.size()) {
-      output.setEmpty();
+      emtpyOutput;
       return;
     }
   }
@@ -535,12 +542,17 @@ FOLLY_ALWAYS_INLINE void trimUnicodeWhiteSpace(
     }
 
     if (endIndex < startIndex) {
-      output.setEmpty();
+      emtpyOutput;
       return;
     }
   }
 
-  output.setNoCopy(StringView(stringStart, endIndex - startIndex + 1));
+  auto view = StringView(stringStart, endIndex - startIndex + 1);
+  if constexpr (std::is_same_v<TOutString, StringView>) {
+    output = view;
+  } else {
+    output.setNoCopy(view);
+  }
 }
 
 template <bool ascii, typename TOutString, typename TInString>

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -41,6 +41,7 @@
 #include "velox/functions/sparksql/UnscaledValueFunction.h"
 #include "velox/functions/sparksql/specialforms/DecimalRound.h"
 #include "velox/functions/sparksql/specialforms/MakeDecimal.h"
+#include "velox/functions/sparksql/specialforms/SparkCastExpr.h"
 
 namespace facebook::velox::functions {
 extern void registerElementAtFunction(
@@ -89,6 +90,10 @@ void registerAllSpecialFormGeneralFunctions() {
   exec::registerFunctionCallToSpecialForm(
       DecimalRoundCallToSpecialForm::kRoundDecimal,
       std::make_unique<DecimalRoundCallToSpecialForm>());
+  registerFunctionCallToSpecialForm(
+      "cast", std::make_unique<SparkCastCallToSpecialForm>());
+  registerFunctionCallToSpecialForm(
+      "try_cast", std::make_unique<SparkTryCastCallToSpecialForm>());
 }
 
 namespace {

--- a/velox/functions/sparksql/specialforms/CMakeLists.txt
+++ b/velox/functions/sparksql/specialforms/CMakeLists.txt
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_functions_spark_specialforms DecimalRound.cpp MakeDecimal.cpp)
+add_library(
+  velox_functions_spark_specialforms DecimalRound.cpp MakeDecimal.cpp
+                                     SparkCastExpr.cpp SparkCastHooks.cpp)
 
 target_link_libraries(velox_functions_spark_specialforms fmt::fmt
                       velox_expression)

--- a/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
@@ -1,0 +1,57 @@
+
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/sparksql/specialforms/SparkCastExpr.h"
+
+namespace facebook::velox::functions::sparksql {
+
+exec::ExprPtr SparkCastCallToSpecialForm::constructSpecialForm(
+    const TypePtr& type,
+    std::vector<exec::ExprPtr>&& compiledChildren,
+    bool trackCpuUsage,
+    const core::QueryConfig& /*config*/) {
+  VELOX_CHECK_EQ(
+      compiledChildren.size(),
+      1,
+      "CAST statements expect exactly 1 argument, received {}.",
+      compiledChildren.size());
+  return std::make_shared<SparkCastExpr>(
+      type,
+      std::move(compiledChildren[0]),
+      trackCpuUsage,
+      false,
+      std::make_shared<SparkCastHooks>());
+}
+
+exec::ExprPtr SparkTryCastCallToSpecialForm::constructSpecialForm(
+    const TypePtr& type,
+    std::vector<exec::ExprPtr>&& compiledChildren,
+    bool trackCpuUsage,
+    const core::QueryConfig& /*config*/) {
+  VELOX_CHECK_EQ(
+      compiledChildren.size(),
+      1,
+      "TRY CAST statements expect exactly 1 argument, received {}.",
+      compiledChildren.size());
+  return std::make_shared<SparkCastExpr>(
+      type,
+      std::move(compiledChildren[0]),
+      trackCpuUsage,
+      true,
+      std::make_shared<SparkCastHooks>());
+}
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/SparkCastExpr.h
+++ b/velox/functions/sparksql/specialforms/SparkCastExpr.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/expression/CastExpr.h"
+#include "velox/functions/sparksql/specialforms/SparkCastHooks.h"
+
+namespace facebook::velox::functions::sparksql {
+
+class SparkCastExpr : public exec::CastExpr {
+ public:
+  /// @param type The target type of the cast expression
+  /// @param expr The expression to cast
+  /// @param trackCpuUsage Whether to track CPU usage
+  SparkCastExpr(
+      TypePtr type,
+      exec::ExprPtr&& expr,
+      bool trackCpuUsage,
+      bool nullOnFailure,
+      std::shared_ptr<SparkCastHooks> hooks)
+      : exec::CastExpr(
+            type,
+            std::move(expr),
+            trackCpuUsage,
+            nullOnFailure,
+            hooks) {}
+};
+
+class SparkCastCallToSpecialForm : public exec::CastCallToSpecialForm {
+ public:
+  exec::ExprPtr constructSpecialForm(
+      const TypePtr& type,
+      std::vector<exec::ExprPtr>&& compiledChildren,
+      bool trackCpuUsage,
+      const core::QueryConfig& config) override;
+};
+
+class SparkTryCastCallToSpecialForm : public exec::TryCastCallToSpecialForm {
+ public:
+  exec::ExprPtr constructSpecialForm(
+      const TypePtr& type,
+      std::vector<exec::ExprPtr>&& compiledChildren,
+      bool trackCpuUsage,
+      const core::QueryConfig& config) override;
+};
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/sparksql/specialforms/SparkCastHooks.h"
+#include "velox/functions/lib/string/StringImpl.h"
+
+namespace facebook::velox::functions::sparksql {
+
+Timestamp SparkCastHooks::castStringToTimestamp(const StringView& view) const {
+  return util::fromTimestampString(view.data(), view.size());
+}
+
+int32_t SparkCastHooks::castStringToDate(const StringView& dateString) const {
+  // Allows all patterns supported by Spark:
+  // `[+-]yyyy*`
+  // `[+-]yyyy*-[m]m`
+  // `[+-]yyyy*-[m]m-[d]d`
+  // `[+-]yyyy*-[m]m-[d]d *`
+  // `[+-]yyyy*-[m]m-[d]dT*`
+  // The asterisk `*` in `yyyy*` stands for any numbers.
+  // For the last two patterns, the trailing `*` can represent none or any
+  // sequence of characters, e.g:
+  //   "1970-01-01 123"
+  //   "1970-01-01 (BC)"
+  return util::castFromDateString(
+      removeWhiteSpaces(dateString), false /*isIso8601*/);
+}
+
+void SparkCastHooks::castTimestampToString(
+    const Timestamp& timestamp,
+    exec::StringWriter<false>& out) const {
+  static constexpr TimestampToStringOptions options = {
+      .precision = TimestampToStringOptions::Precision::kMicroseconds,
+      .leadingPositiveSign = true,
+      .skipTrailingZeros = true,
+      .zeroPaddingYear = true,
+      .dateTimeSeparator = ' ',
+  };
+  out.copy_from(timestamp.toString(options));
+  out.finalize();
+}
+
+bool SparkCastHooks::legacy() const {
+  return false;
+}
+
+StringView SparkCastHooks::removeWhiteSpaces(const StringView& view) const {
+  StringView output;
+  stringImpl::trimUnicodeWhiteSpace<true, true, StringView, StringView>(
+      output, view);
+  return output;
+}
+
+bool SparkCastHooks::truncate() const {
+  return true;
+}
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/expression/CastHooks.h"
+
+namespace facebook::velox::functions::sparksql {
+
+// This class provides cast hooks following Spark semantics.
+class SparkCastHooks : public exec::CastHooks {
+ public:
+  // TODO: Spark hook allows more string patterns than Presto.
+  Timestamp castStringToTimestamp(const StringView& view) const override;
+
+  /// 1) Removes all leading and trailing UTF8 white-spaces before cast. 2) Uses
+  /// non-standard cast mode to cast from string to date.
+  int32_t castStringToDate(const StringView& dateString) const override;
+
+  /// 1) Does not follow 'isLegacyCast' config. 2) The conversion precision is
+  /// microsecond. 3) Does not append trailing zeros. 4) Adds a positive sign at
+  /// first if the year exceeds 9999.
+  void castTimestampToString(
+      const Timestamp& timestamp,
+      exec::StringWriter<false>& out) const override;
+
+  // Returns false.
+  bool legacy() const override;
+
+  /// When casting from string to integral, floating-point, decimal, date, and
+  /// timestamp types, Spark hook trims all leading and trailing UTF8
+  /// whitespaces before cast.
+  StringView removeWhiteSpaces(const StringView& view) const override;
+
+  // Returns true.
+  bool truncate() const override;
+};
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(
   RegexFunctionsTest.cpp
   SizeTest.cpp
   SortArrayTest.cpp
+  SparkCastExprTest.cpp
   SplitFunctionsTest.cpp
   StringTest.cpp
   StringToMapTest.cpp

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -1,0 +1,526 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/tests/CastBaseTest.h"
+#include "velox/functions/sparksql/Register.h"
+
+using namespace facebook::velox;
+namespace facebook::velox::test {
+namespace {
+
+class SparkCastExprTest : public functions::test::CastBaseTest {
+ protected:
+  static void SetUpTestCase() {
+    functions::sparksql::registerFunctions("");
+  }
+
+  template <typename T>
+  void testDecimalToIntegralCasts() {
+    auto shortFlat = makeNullableFlatVector<int64_t>(
+        {-300,
+         -260,
+         -230,
+         -200,
+         -100,
+         0,
+         5500,
+         5749,
+         5755,
+         6900,
+         7200,
+         std::nullopt},
+        DECIMAL(6, 2));
+    testComplexCast(
+        "c0",
+        shortFlat,
+        makeNullableFlatVector<T>(
+            {-3,
+             -2 /*-2.6 truncated to -2*/,
+             -2 /*-2.3 truncated to -2*/,
+             -2,
+             -1,
+             0,
+             55,
+             57 /*57.49 truncated to 57*/,
+             57 /*57.55 truncated to 57*/,
+             69,
+             72,
+             std::nullopt}));
+    auto longFlat = makeNullableFlatVector<int128_t>(
+        {-30'000'000'000,
+         -25'500'000'000,
+         -24'500'000'000,
+         -20'000'000'000,
+         -10'000'000'000,
+         0,
+         550'000'000'000,
+         554'900'000'000,
+         559'900'000'000,
+         690'000'000'000,
+         720'000'000'000,
+         std::nullopt},
+        DECIMAL(20, 10));
+    testComplexCast(
+        "c0",
+        longFlat,
+        makeNullableFlatVector<T>(
+            {-3,
+             -2 /*-2.55 truncated to -2*/,
+             -2 /*-2.45 truncated to -2*/,
+             -2,
+             -1,
+             0,
+             55,
+             55 /* 55.49 truncated to 55*/,
+             55 /* 55.99 truncated to 55*/,
+             69,
+             72,
+             std::nullopt}));
+  }
+};
+
+TEST_F(SparkCastExprTest, date) {
+  testCast<std::string, int32_t>(
+      "date",
+      {"1970-01-01",
+       "2020-01-01",
+       "2135-11-09",
+       "1969-12-27",
+       "1812-04-15",
+       "1920-01-02",
+       "12345-12-18",
+       "1970-1-2",
+       "1970-01-2",
+       "1970-1-02",
+       "+1970-01-02",
+       "-1-1-1",
+       " 1970-01-01",
+       std::nullopt},
+      {0,
+       18262,
+       60577,
+       -5,
+       -57604,
+       -18262,
+       3789742,
+       1,
+       1,
+       1,
+       1,
+       -719893,
+       0,
+       std::nullopt},
+      VARCHAR(),
+      DATE());
+  testCast<std::string, int32_t>(
+      "date",
+      {"12345",
+       "2015",
+       "2015-03",
+       "2015-03-18T",
+       "2015-03-18T123123",
+       "2015-03-18 123142",
+       "2015-03-18 (BC)"},
+      {3789391, 16436, 16495, 16512, 16512, 16512, 16512},
+      VARCHAR(),
+      DATE());
+}
+
+TEST_F(SparkCastExprTest, decimalToIntegral) {
+  testDecimalToIntegralCasts<int64_t>();
+  testDecimalToIntegralCasts<int32_t>();
+  testDecimalToIntegralCasts<int16_t>();
+  testDecimalToIntegralCasts<int8_t>();
+}
+
+TEST_F(SparkCastExprTest, invalidDate) {
+  testInvalidCast<int8_t>(
+      "date", {12}, "Cast from TINYINT to DATE is not supported", TINYINT());
+  testInvalidCast<int16_t>(
+      "date",
+      {1234},
+      "Cast from SMALLINT to DATE is not supported",
+      SMALLINT());
+  testInvalidCast<int32_t>(
+      "date", {1234}, "Cast from INTEGER to DATE is not supported", INTEGER());
+  testInvalidCast<int64_t>(
+      "date", {1234}, "Cast from BIGINT to DATE is not supported", BIGINT());
+
+  testInvalidCast<float>(
+      "date", {12.99}, "Cast from REAL to DATE is not supported", REAL());
+  testInvalidCast<double>(
+      "date", {12.99}, "Cast from DOUBLE to DATE is not supported", DOUBLE());
+
+  // Parsing ill-formated dates.
+  testInvalidCast<std::string>(
+      "date",
+      {"2012-Oct-23"},
+      "Unable to parse date value: \"2012-Oct-23\"",
+      VARCHAR());
+  testInvalidCast<std::string>(
+      "date",
+      {"2015-03-18X"},
+      "Unable to parse date value: \"2015-03-18X\"",
+      VARCHAR());
+  testInvalidCast<std::string>(
+      "date",
+      {"2015/03/18"},
+      "Unable to parse date value: \"2015/03/18\"",
+      VARCHAR());
+  testInvalidCast<std::string>(
+      "date",
+      {"2015.03.18"},
+      "Unable to parse date value: \"2015.03.18\"",
+      VARCHAR());
+  testInvalidCast<std::string>(
+      "date",
+      {"20150318"},
+      "Unable to parse date value: \"20150318\"",
+      VARCHAR());
+  testInvalidCast<std::string>(
+      "date",
+      {"2015-031-8"},
+      "Unable to parse date value: \"2015-031-8\"",
+      VARCHAR());
+}
+
+TEST_F(SparkCastExprTest, stringToTimestamp) {
+  std::vector<std::optional<std::string>> input{
+      "1970-01-01",
+      "2000-01-01",
+      "1970-01-01 00:00:00",
+      "2000-01-01 12:21:56",
+      "1970-01-01 00:00:00-02:00",
+      std::nullopt,
+      "2015-03-18T12:03:17",
+      "2015-03-18 12:03:17Z",
+      "2015-03-18T12:03:17Z",
+      "2015-03-18 12:03:17.123",
+      "2015-03-18T12:03:17.123",
+      "2015-03-18T12:03:17.456Z",
+      "2015-03-18 12:03:17.456Z",
+  };
+  std::vector<std::optional<Timestamp>> expected{
+      Timestamp(0, 0),
+      Timestamp(946684800, 0),
+      Timestamp(0, 0),
+      Timestamp(946729316, 0),
+      Timestamp(7200, 0),
+      std::nullopt,
+      Timestamp(1426680197, 0),
+      Timestamp(1426680197, 0),
+      Timestamp(1426680197, 0),
+      Timestamp(1426680197, 123000000),
+      Timestamp(1426680197, 123000000),
+      Timestamp(1426680197, 456000000),
+      Timestamp(1426680197, 456000000),
+  };
+  testCast<std::string, Timestamp>("timestamp", input, expected);
+}
+
+TEST_F(SparkCastExprTest, primitiveInvalidCornerCases) {
+  // To integer.
+  {
+    // Invalid strings.
+    testInvalidCast<std::string>(
+        "tinyint", {"1234567"}, "Value is too large for type");
+    testInvalidCast<std::string>(
+        "tinyint", {"1a"}, "Encountered a non-digit character");
+    testInvalidCast<std::string>("tinyint", {""}, "Empty string");
+    testInvalidCast<std::string>(
+        "integer", {"1'234'567"}, "Encountered a non-digit character");
+    testInvalidCast<std::string>(
+        "integer", {"1,234,567"}, "Encountered a non-digit character");
+    testInvalidCast<std::string>(
+        "bigint", {"infinity"}, "Encountered a non-digit character");
+    testInvalidCast<std::string>(
+        "bigint", {"nan"}, "Encountered a non-digit character");
+  }
+
+  // To floating-point.
+  {
+    // Invalid strings.
+    testInvalidCast<std::string>(
+        "real",
+        {"1.2a"},
+        "Non-whitespace character found after end of conversion");
+    testInvalidCast<std::string>(
+        "real",
+        {"1.2.3"},
+        "Non-whitespace character found after end of conversion");
+  }
+
+  // To boolean.
+  {
+    testInvalidCast<std::string>(
+        "boolean",
+        {"1.7E308"},
+        "Non-whitespace character found after end of conversion");
+    testInvalidCast<std::string>(
+        "boolean",
+        {"nan"},
+        "Non-whitespace character found after end of conversion");
+    testInvalidCast<std::string>(
+        "boolean", {"infinity"}, "Invalid value for bool");
+    testInvalidCast<std::string>(
+        "boolean", {"12"}, "Integer overflow when parsing bool");
+    testInvalidCast<std::string>("boolean", {"-1"}, "Invalid value for bool");
+    testInvalidCast<std::string>(
+        "boolean",
+        {"tr"},
+        "Non-whitespace character found after end of conversion");
+    testInvalidCast<std::string>(
+        "boolean",
+        {"tru"},
+        "Non-whitespace character found after end of conversion");
+  }
+}
+
+TEST_F(SparkCastExprTest, primitiveValidCornerCases) {
+  // To integer.
+  {
+    // Valid strings.
+    testCast<std::string, int8_t>("tinyint", {"1.2"}, {1});
+    testCast<std::string, int8_t>("tinyint", {"1.23444"}, {1});
+    testCast<std::string, int8_t>("tinyint", {".2355"}, {0});
+    testCast<std::string, int8_t>("tinyint", {"-1.8"}, {-1});
+    testCast<std::string, int8_t>("tinyint", {"+1"}, {1});
+    testCast<std::string, int8_t>("tinyint", {"1."}, {1});
+    testCast<std::string, int8_t>("tinyint", {"-1"}, {-1});
+    testCast<std::string, int8_t>("tinyint", {"-1."}, {-1});
+    testCast<std::string, int8_t>("tinyint", {"0."}, {0});
+    testCast<std::string, int8_t>("tinyint", {"."}, {0});
+    testCast<std::string, int8_t>("tinyint", {"-."}, {0});
+
+    testCast<int32_t, int8_t>("tinyint", {1234567}, {-121});
+    testCast<int32_t, int8_t>("tinyint", {-1234567}, {121});
+    testCast<double, int8_t>("tinyint", {12345.67}, {57});
+    testCast<double, int8_t>("tinyint", {-12345.67}, {-57});
+    testCast<double, int8_t>("tinyint", {127.1}, {127});
+    testCast<float, int64_t>("bigint", {kInf}, {9223372036854775807});
+    testCast<float, int64_t>("bigint", {kNan}, {0});
+    testCast<float, int32_t>("integer", {kNan}, {0});
+    testCast<float, int16_t>("smallint", {kNan}, {0});
+    testCast<float, int8_t>("tinyint", {kNan}, {0});
+
+    testCast<double, int64_t>("bigint", {12345.12}, {12345});
+    testCast<double, int64_t>("bigint", {12345.67}, {12345});
+  }
+
+  // To floating-point.
+  {
+    testCast<double, float>("real", {1.7E308}, {kInf});
+
+    testCast<std::string, float>("real", {"1.7E308"}, {kInf});
+    testCast<std::string, float>("real", {"1."}, {1.0});
+    testCast<std::string, float>("real", {"1"}, {1});
+    testCast<std::string, float>("real", {"infinity"}, {kInf});
+    testCast<std::string, float>("real", {"-infinity"}, {-kInf});
+    testCast<std::string, float>("real", {"nan"}, {kNan});
+    testCast<std::string, float>("real", {"InfiNiTy"}, {kInf});
+    testCast<std::string, float>("real", {"-InfiNiTy"}, {-kInf});
+    testCast<std::string, float>("real", {"nAn"}, {kNan});
+  }
+
+  // To boolean.
+  {
+    testCast<int8_t, bool>("boolean", {1}, {true});
+    testCast<int8_t, bool>("boolean", {0}, {false});
+    testCast<int8_t, bool>("boolean", {12}, {true});
+    testCast<int8_t, bool>("boolean", {-1}, {true});
+    testCast<double, bool>("boolean", {1.0}, {true});
+    testCast<double, bool>("boolean", {1.1}, {true});
+    testCast<double, bool>("boolean", {0.1}, {true});
+    testCast<double, bool>("boolean", {-0.1}, {true});
+    testCast<double, bool>("boolean", {-1.0}, {true});
+    testCast<float, bool>("boolean", {kNan}, {false});
+    testCast<float, bool>("boolean", {kInf}, {true});
+    testCast<double, bool>("boolean", {0.0000000000001}, {true});
+
+    testCast<std::string, bool>("boolean", {"1"}, {true});
+    testCast<std::string, bool>("boolean", {"0"}, {false});
+    testCast<std::string, bool>("boolean", {"t"}, {true});
+    testCast<std::string, bool>("boolean", {"true"}, {true});
+  }
+
+  // To string.
+  {
+    testCast<float, std::string>("varchar", {kInf}, {"Infinity"});
+    testCast<float, std::string>("varchar", {kNan}, {"NaN"});
+  }
+}
+
+TEST_F(SparkCastExprTest, truncate) {
+  // Testing truncate cast from double to int.
+  testCast<int32_t, int8_t>(
+      "tinyint", {1111111, 2, 3, 1000, -100101}, {71, 2, 3, -24, -5});
+}
+
+TEST_F(SparkCastExprTest, errorHandling) {
+  testTryCast<std::string, int8_t>(
+      "tinyint",
+      {"-",
+       "-0",
+       " @w 123",
+       "123 ",
+       "  122",
+       "",
+       "-12-3",
+       "1234",
+       "-129",
+       "1.1.1",
+       "1..",
+       "1.abc",
+       "..",
+       "-..",
+       "125.5",
+       "127",
+       "-128"},
+      {std::nullopt,
+       0,
+       std::nullopt,
+       123,
+       122,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       125,
+       127,
+       -128});
+
+  testTryCast<double, int>(
+      "integer",
+      {1e12, 2.5, 3.6, 100.44, -100.101},
+      {std::numeric_limits<int32_t>::max(), 2, 3, 100, -100});
+}
+
+TEST_F(SparkCastExprTest, overflow) {
+  testCast<int16_t, int8_t>("tinyint", {456}, {-56});
+  testCast<int32_t, int8_t>("tinyint", {266}, {10});
+  testCast<int64_t, int8_t>("tinyint", {1234}, {-46});
+  testCast<int64_t, int16_t>("smallint", {1234567}, {-10617});
+  testCast<double, int8_t>("tinyint", {127.8}, {127});
+  testCast<double, int8_t>("tinyint", {129.9}, {-127});
+  testCast<double, int16_t>("smallint", {1234567.89}, {-10617});
+  testCast<double, int64_t>(
+      "bigint", {std::numeric_limits<double>::max()}, {9223372036854775807});
+  testCast<double, int64_t>(
+      "bigint", {std::numeric_limits<double>::quiet_NaN()}, {0});
+  auto shortFlat = makeNullableFlatVector<int64_t>(
+      {-3000,
+       -2600,
+       -2300,
+       -2000,
+       -1000,
+       0,
+       55000,
+       57490,
+       5755,
+       6900,
+       7200,
+       std::nullopt},
+      DECIMAL(5, 1));
+  testComplexCast(
+      "c0",
+      shortFlat,
+      makeNullableFlatVector<int8_t>(
+          {-44, -4, 26, 56, -100, 0, 124, 117, 63, -78, -48, std::nullopt}));
+  testComplexCast(
+      "c0",
+      makeNullableFlatVector<int64_t>({214748364890}, DECIMAL(12, 2)),
+      makeNullableFlatVector<int8_t>({0}));
+  testComplexCast(
+      "c0",
+      makeNullableFlatVector<int64_t>({214748364890}, DECIMAL(12, 2)),
+      makeNullableFlatVector<int32_t>({-2147483648}));
+  testComplexCast(
+      "c0",
+      makeNullableFlatVector<int64_t>({214748364890}, DECIMAL(12, 2)),
+      makeNullableFlatVector<int64_t>({2147483648}));
+}
+
+TEST_F(SparkCastExprTest, timestampToString) {
+  testCast<Timestamp, std::string>(
+      "string",
+      {
+          Timestamp(-946684800, 0),
+          Timestamp(-7266, 0),
+          Timestamp(0, 0),
+          Timestamp(946684800, 0),
+          Timestamp(9466848000, 0),
+          Timestamp(94668480000, 0),
+          Timestamp(946729316, 0),
+          Timestamp(946729316, 123),
+          Timestamp(946729316, 100000000),
+          Timestamp(946729316, 129900000),
+          Timestamp(946729316, 123456789),
+
+          Timestamp(7266, 0),
+          Timestamp(-50049331200, 0),
+          Timestamp(253405036800, 0),
+          Timestamp(-62480037600, 0),
+          std::nullopt,
+      },
+      {
+          "1940-01-02 00:00:00",
+          "1969-12-31 21:58:54",
+          "1970-01-01 00:00:00",
+          "2000-01-01 00:00:00",
+          "2269-12-29 00:00:00",
+          "4969-12-04 00:00:00",
+          "2000-01-01 12:21:56",
+          "2000-01-01 12:21:56",
+          "2000-01-01 12:21:56.1",
+          "2000-01-01 12:21:56.1299",
+          "2000-01-01 12:21:56.123456",
+          "1970-01-01 02:01:06",
+          "0384-01-01 08:00:00",
+          "+10000-02-01 16:00:00",
+          "-0010-02-01 10:00:00",
+          std::nullopt,
+      });
+}
+
+TEST_F(SparkCastExprTest, fromString) {
+  testCast<std::string, int8_t>(
+      "tinyint", {"\n\f\r\t\n\u001F 123\u000B\u001C\u001D\u001E"}, {123});
+  testCast<std::string, int32_t>(
+      "integer", {"\n\f\r\t\n\u001F 123\u000B\u001C\u001D\u001E"}, {123});
+  testCast<std::string, int64_t>(
+      "bigint", {"\n\f\r\t\n\u001F 123\u000B\u001C\u001D\u001E"}, {123});
+  testCast<std::string, int32_t>(
+      "date",
+      {"\n\f\r\t\n\u001F 2015-03-18T\u000B\u001C\u001D\u001E"},
+      {16512},
+      VARCHAR(),
+      DATE());
+  testCast<std::string, float>(
+      "real", {"\n\f\r\t\n\u001F 123.0\u000B\u001C\u001D\u001E"}, {123.0});
+  testCast<std::string, double>(
+      "double", {"\n\f\r\t\n\u001F 123.0\u000B\u001C\u001D\u001E"}, {123.0});
+  testCast<std::string, Timestamp>(
+      "timestamp",
+      {"\n\f\r\t\n\u001F 2000-01-01 12:21:56\u000B\u001C\u001D\u001E"},
+      {Timestamp(946729316, 0)});
+}
+} // namespace
+} // namespace facebook::velox::test


### PR DESCRIPTION
There are several corner cases of semantic differences on cast between Presto 
and Spark. According to the implementation of
`registerFunctionCallToSpecialForm`, a previously registered special form can be 
overriden by one registered after it and of the same name.This PR implements 
SparkCastExpr, which is registered as special form, and can be customized with 
the help of cast hooks compatible with Spark's semantics. Below hooks are added 
to solve several semantic differences.
- castStringToTimestamp
- castStringToDate
- castTimestampToString
- legacy
- removeWhiteSpaces
- truncate

Two configurations `kCastToIntByTruncate` and `kCastStringToDateIsIso8601` are 
replaced by cast hooks. These configurations are no longer used and will be removed 
by subsequent PRs.

https://github.com/facebookincubator/velox/issues/4876
Fixes https://github.com/facebookincubator/velox/issues/8121.