### PR TITLE
Add support for legacy cast

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -94,6 +94,8 @@ class QueryConfig {
 
   /// Flags used to configure the CAST operator:
 
+  static constexpr const char* kLegacyCast = "legacy_cast";
+
   /// This flag makes the Row conversion to by applied in a way that the casting
   /// row field are matched by name instead of position.
   static constexpr const char* kCastMatchStructByName =
@@ -439,6 +441,10 @@ class QueryConfig {
 
   bool adaptiveFilterReorderingEnabled() const {
     return get<bool>(kAdaptiveFilterReorderingEnabled, true);
+  }
+
+  bool isLegacyCast() const {
+    return get<bool>(kLegacyCast, false);
   }
 
   bool isMatchStructByName() const {

--- a/velox/core/tests/QueryConfigTest.cpp
+++ b/velox/core/tests/QueryConfigTest.cpp
@@ -28,6 +28,7 @@ TEST(TestQueryConfig, emptyConfig) {
 
   ASSERT_FALSE(config.codegenEnabled());
   ASSERT_EQ(config.codegenConfigurationFilePath(), "");
+  ASSERT_FALSE(config.isLegacyCast());
   ASSERT_FALSE(config.isCastToIntByTruncate());
 }
 
@@ -35,12 +36,14 @@ TEST(TestQueryConfig, setConfig) {
   std::string path = "/tmp/CodeGenConfig";
   std::unordered_map<std::string, std::string> configData(
       {{QueryConfig::kCodegenEnabled, "true"},
-       {QueryConfig::kCodegenConfigurationFilePath, path}});
+       {QueryConfig::kCodegenConfigurationFilePath, path},
+       {QueryConfig::kLegacyCast, "true"}});
   auto queryCtx = std::make_shared<QueryCtx>(nullptr, std::move(configData));
   const QueryConfig& config = queryCtx->queryConfig();
 
   ASSERT_TRUE(config.codegenEnabled());
   ASSERT_EQ(config.codegenConfigurationFilePath(), path);
+  ASSERT_TRUE(config.isLegacyCast());
   ASSERT_FALSE(config.isCastToIntByTruncate());
 }
 

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -60,11 +60,6 @@ core::TypedExprPtr parseExpr(
   return core::Expressions::inferTypes(untyped, rowType, pool);
 }
 
-template <TypeKind FromKind, TypeKind ToKind>
-typename TypeTraits<ToKind>::NativeType cast(const variant& v) {
-  return util::Converter<ToKind, void, false>::cast(v.value<FromKind>());
-}
-
 std::shared_ptr<HiveBucketProperty> buildHiveBucketProperty(
     const RowTypePtr rowType,
     int32_t bucketCount,

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -192,43 +192,57 @@ void CastExpr::applyToSelectedNoThrowLocal(
 /// @param row The index of the current row
 /// @param input The input vector (of type FromKind)
 /// @param result The output vector (of type ToKind)
-template <TypeKind ToKind, TypeKind FromKind, bool Truncate>
+template <TypeKind ToKind, TypeKind FromKind, bool Truncate, bool LegacyCast>
 void CastExpr::applyCastKernel(
     vector_size_t row,
     EvalCtx& context,
     const SimpleVector<typename TypeTraits<FromKind>::NativeType>* input,
     FlatVector<typename TypeTraits<ToKind>::NativeType>* result) {
-  auto inputRowValue = input->valueAt(row);
+  auto setError = [&](const std::string& details) {
+    if (setNullInResultAtError()) {
+      result->setNull(row, true);
+    } else {
+      context.setVeloxExceptionError(
+          row, makeBadCastException(result->type(), *input, row, details));
+    }
+  };
 
-  // Optimize empty input strings casting by avoiding throwing exceptions.
-  if constexpr (
-      FromKind == TypeKind::VARCHAR || FromKind == TypeKind::VARBINARY) {
+  try {
+    auto inputRowValue = input->valueAt(row);
+
+    // Optimize empty input strings casting by avoiding throwing exceptions.
     if constexpr (
-        TypeTraits<ToKind>::isPrimitiveType &&
-        TypeTraits<ToKind>::isFixedWidth) {
-      if (inputRowValue.size() == 0) {
-        if (setNullInResultAtError()) {
-          result->setNull(row, true);
-        } else {
-          context.setVeloxExceptionError(
-              row,
-              makeBadCastException(
-                  result->type(), *input, row, "Empty string"));
+        FromKind == TypeKind::VARCHAR || FromKind == TypeKind::VARBINARY) {
+      if constexpr (
+          TypeTraits<ToKind>::isPrimitiveType &&
+          TypeTraits<ToKind>::isFixedWidth) {
+        if (inputRowValue.size() == 0) {
+          setError("Empty string");
+          return;
         }
-        return;
       }
     }
-  }
 
-  auto output = util::Converter<ToKind, void, Truncate>::cast(inputRowValue);
+    auto output = util::Converter<ToKind, void, Truncate, LegacyCast>::cast(
+        inputRowValue);
 
-  if constexpr (ToKind == TypeKind::VARCHAR || ToKind == TypeKind::VARBINARY) {
-    // Write the result output to the output vector
-    auto writer = exec::StringWriter<>(result, row);
-    writer.copy_from(output);
-    writer.finalize();
-  } else {
-    result->set(row, output);
+    if constexpr (
+        ToKind == TypeKind::VARCHAR || ToKind == TypeKind::VARBINARY) {
+      // Write the result output to the output vector
+      auto writer = exec::StringWriter<>(result, row);
+      writer.copy_from(output);
+      writer.finalize();
+    } else {
+      result->set(row, output);
+    }
+
+  } catch (const VeloxException& ue) {
+    if (!ue.isUserError()) {
+      throw;
+    }
+    setError(ue.message());
+  } catch (const std::exception& e) {
+    setError(e.what());
   }
 }
 
@@ -304,8 +318,8 @@ VectorPtr CastExpr::applyDecimalToFloatCast(
   const auto simpleInput = input.as<SimpleVector<FromNativeType>>();
   const auto scaleFactor = DecimalUtil::kPowersOfTen[precisionScale.second];
   applyToSelectedNoThrowLocal(context, rows, result, [&](int row) {
-    auto output =
-        util::Converter<ToKind, void, false>::cast(simpleInput->valueAt(row));
+    auto output = util::Converter<ToKind, void, false, false>::cast(
+        simpleInput->valueAt(row));
     resultBuffer[row] = output / scaleFactor;
   });
   return result;
@@ -490,45 +504,30 @@ void CastExpr::applyCastPrimitives(
   const auto& queryConfig = context.execCtx()->queryCtx()->queryConfig();
   auto& resultType = resultFlatVector->type();
 
-  auto setError = [&](vector_size_t row, const std::string& details) {
-    if (setNullInResultAtError()) {
-      result->setNull(row, true);
-    } else {
-      context.setVeloxExceptionError(
-          row, makeBadCastException(resultType, input, row, details));
-    }
-  };
-
   if (!queryConfig.isCastToIntByTruncate()) {
-    applyToSelectedNoThrowLocal(context, rows, result, [&](int row) {
-      try {
-        applyCastKernel<ToKind, FromKind, false /*truncate*/>(
+    if (!queryConfig.isLegacyCast()) {
+      applyToSelectedNoThrowLocal(context, rows, result, [&](int row) {
+        applyCastKernel<ToKind, FromKind, false /*truncate*/, false /*legacy*/>(
             row, context, inputSimpleVector, resultFlatVector);
-
-      } catch (const VeloxException& ue) {
-        if (!ue.isUserError()) {
-          throw;
-        }
-        setError(row, ue.message());
-      } catch (const std::exception& e) {
-        setError(row, e.what());
-      }
-    });
-
+      });
+    } else {
+      applyToSelectedNoThrowLocal(context, rows, result, [&](int row) {
+        applyCastKernel<ToKind, FromKind, false /*truncate*/, true /*legacy*/>(
+            row, context, inputSimpleVector, resultFlatVector);
+      });
+    }
   } else {
-    applyToSelectedNoThrowLocal(context, rows, result, [&](int row) {
-      try {
-        applyCastKernel<ToKind, FromKind, true /*truncate*/>(
+    if (!queryConfig.isLegacyCast()) {
+      applyToSelectedNoThrowLocal(context, rows, result, [&](int row) {
+        applyCastKernel<ToKind, FromKind, true /*truncate*/, false /*legacy*/>(
             row, context, inputSimpleVector, resultFlatVector);
-      } catch (const VeloxException& ue) {
-        if (!ue.isUserError()) {
-          throw;
-        }
-        setError(row, ue.message());
-      } catch (const std::exception& e) {
-        setError(row, e.what());
-      }
-    });
+      });
+    } else {
+      applyToSelectedNoThrowLocal(context, rows, result, [&](int row) {
+        applyCastKernel<ToKind, FromKind, true /*truncate*/, true /*legacy*/>(
+            row, context, inputSimpleVector, resultFlatVector);
+      });
+    }
   }
 
   // If we're converting to a TIMESTAMP, check if we need to adjust the

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -162,7 +162,7 @@ class CastExpr : public SpecialForm {
   /// @param row The index of the current row
   /// @param input The input vector (of type FromKind)
   /// @param result The output vector (of type ToKind)
-  template <TypeKind ToKind, TypeKind FromKind, bool Truncate>
+  template <TypeKind ToKind, TypeKind FromKind, bool Truncate, bool LegacyCast>
   void applyCastKernel(
       vector_size_t row,
       EvalCtx& context,

--- a/velox/functions/prestosql/ArrayFunctions.h
+++ b/velox/functions/prestosql/ArrayFunctions.h
@@ -160,7 +160,8 @@ struct ArrayJoinFunction {
 
   template <typename C>
   void writeValue(out_type<velox::Varchar>& result, const C& value) {
-    result += util::Converter<TypeKind::VARCHAR, void, false>::cast(value);
+    result +=
+        util::Converter<TypeKind::VARCHAR, void, false, false>::cast(value);
   }
 
   template <typename C>


### PR DESCRIPTION
Add support for legacy cast, for backward capability of CAST
expression behavior and adoption of new CAST behaviors. Add
a QueryConfig legacy_cast with default value false, which
translates to one more template parameter of struct Converter.

Refactor CastExpr::applyCastKernel and CastExpr::applyCastPrimitives
to avoid duplicate code.

This change only adds a QueryConfig and should make no behavior change
to the CAST expr. Note that any caller that uses the QueryConfig legacy_cast
with default value false will automatically pick up all the upcoming behavior
changes we will add and gated by this QueryConfig.