### PR TITLE
Add initializeFields to RowContainer.

### DIFF
--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -263,14 +263,13 @@ class RowContainer {
   /// Initialize row. 'reuse' specifies whether the 'row' is reused or not. If
   /// it is reused, it will free memory associated with the row elsewhere (such
   /// as in HashStringAllocator).
-  /// Note: Fields of the row is not zero-initialized. If the row contains
-  /// variable-width fields and the caller does not intend to write to those
-  /// fields(via store()), the caller should call 'initializeFields' to zero out
-  /// all the fields to prevent issues when freeing memory.
-  char* FOLLY_NONNULL initializeRow(char* FOLLY_NONNULL row, bool reuse);
+  /// Note: Fields of the row are not zero-initialized. If the row contains
+  /// variable-width fields, the caller must populate these fields by calling
+  /// 'store' or initialize them to zero by calling 'initializeFields'.
+  char* initializeRow(char* row, bool reuse);
 
   /// Zero out all the fields of the 'row'.
-  void initializeFields(char* FOLLY_NONNULL row) {
+  void initializeFields(char* row) {
     ::memset(row, 0, fixedRowSize_);
   }
 

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -1551,11 +1551,11 @@ TEST_F(RowContainerTest, toString) {
 
 TEST_F(RowContainerTest, partialWriteComplexTypedRow) {
   auto data = makeRowVector(
-      {makeFlatVector<int64_t>({10}),
+      {makeFlatVector<int64_t>(1, [](auto row) { return row; }),
        makeFlatVector<std::string>({"non-inline string"}),
        makeArrayVector<int64_t>({{1, 2, 3, 4, 5}}),
        makeMapVector<int64_t, int64_t>({{{4, 41}}}),
-       makeRowVector({makeFlatVector<int64_t>({10})})});
+       makeRowVector({makeFlatVector<std::string>({"non-inline string"})})});
 
   auto rowContainer = std::make_unique<RowContainer>(
       data->type()->asRow().children(), pool_.get());

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -1549,40 +1549,40 @@ TEST_F(RowContainerTest, toString) {
       "{3, winter, 12, 123.00299835205078, null}");
 }
 
-TEST_F(RowContainerTest, initializeRowForReuseComplexTypes) {
-  auto intVector = makeFlatVector<int64_t>({10, 20});
-  auto strVector = makeFlatVector<std::string>({"non-inline string"});
-  auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4, 5}});
-  auto mapVector = makeMapVector<int64_t, int64_t>({{{4, 41}}});
-  auto rowVector = makeRowVector({strVector, arrayVector, mapVector});
+TEST_F(RowContainerTest, partialWriteComplexTypedRow) {
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>({10}),
+       makeFlatVector<std::string>({"non-inline string"}),
+       makeArrayVector<int64_t>({{1, 2, 3, 4, 5}}),
+       makeMapVector<int64_t, int64_t>({{{4, 41}}}),
+       makeRowVector({makeFlatVector<int64_t>({10})})});
 
-  DecodedVector decodedInt(*intVector);
-  std::vector<TypePtr> keyTypes = {
-      intVector->type(),
-      strVector->type(),
-      arrayVector->type(),
-      mapVector->type(),
-      rowVector->type()};
-  auto rowContainer = std::make_unique<RowContainer>(keyTypes, pool_.get());
+  auto rowContainer = std::make_unique<RowContainer>(
+      data->type()->asRow().children(), pool_.get());
 
-  DecodedVector decodedString(*strVector);
-  DecodedVector decodedArray(*arrayVector);
-  DecodedVector decodedMap(*mapVector);
-  DecodedVector decodedRow(*rowVector);
+  std::vector<DecodedVector> decodedVectors;
+  for (auto& vectorPtr : data->children()) {
+    decodedVectors.emplace_back(*vectorPtr);
+  }
 
+  // No write at all.
   auto row = rowContainer->newRow();
-  // Store all fields.
-  rowContainer->store(decodedInt, 0, row, 0);
-  rowContainer->store(decodedString, 0, row, 1);
-  rowContainer->store(decodedArray, 0, row, 2);
-  rowContainer->store(decodedMap, 0, row, 3);
-  rowContainer->store(decodedRow, 0, row, 4);
+  rowContainer->initializeFields(row);
+  rowContainer->eraseRows(folly::Range<char**>(&row, 1));
 
-  // initializeRow() for reuse, and don't store to the complex-typed fields.
+  row = rowContainer->newRow();
+  rowContainer->initializeFields(row);
+  for (auto i = 0; i < decodedVectors.size(); ++i) {
+    rowContainer->store(decodedVectors[i], 0, row, i);
+  }
+  // Partial writes should not break initializeRow for reuse.
   rowContainer->initializeRow(row, true);
-  rowContainer->store(decodedInt, 1, row, 0);
+  rowContainer->initializeFields(row);
+  for (auto i = 0; i < 3; ++i) {
+    rowContainer->store(decodedVectors[i], 0, row, i);
+  }
+  rowContainer->initializeRow(row, true);
 
-  // initializeRow() for reuse again, this should not double free the
-  // complex-typed fields.
-  rowContainer->initializeRow(row, true);
+  rowContainer->initializeFields(row);
+  rowContainer->eraseRows(folly::Range<char**>(&row, 1));
 }


### PR DESCRIPTION
- Add `initializeFields` to `RowContainer` to zero out all the fields of the row.
- `initializeRow` no longer zero out variable-width fields for reuse. That means if the row contains variable-width fields and the caller does not intend to write to those fields(via `store()`), the caller should call `initializeFields` to zero out the fields to prevent issues when freeing memory.

Resolves https://github.com/facebookincubator/velox/issues/7380.