### PR TITLE
Fix spill for TopNRowNumber

### DIFF
--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -524,6 +524,9 @@ void TopNRowNumber::setupNextOutput(
     }
     next->pop();
   }
+
+  // This partition is the last partition.
+  nextRowNumber_ = 0;
 }
 
 RowVectorPtr TopNRowNumber::getOutputFromSpill() {


### PR DESCRIPTION
Fix rowNumber < limit_ (1 vs. 1) failures in TopNRowNumber::getOutputFromSpill.

TopNRowNumber::setupNextOutput needs to reset nextRowNumber_ to zero if 
current partition is the last partition.