### PR TITLE
Add a lightweight http client

### DIFF
--- a/CMake/resolve_dependency_modules/cpr.cmake
+++ b/CMake/resolve_dependency_modules/cpr.cmake
@@ -27,6 +27,7 @@ FetchContent_Declare(
   cpr
   URL ${VELOX_CPR_SOURCE_URL}
   URL_HASH ${VELOX_CPR_BUILD_SHA256_CHECKSUM}
-  PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/cpr/cpr-libcurl-compatible.patch)
+  PATCH_COMMAND git apply
+                ${CMAKE_CURRENT_LIST_DIR}/cpr/cpr-libcurl-compatible.patch)
 set(BUILD_SHARED_LIBS OFF)
 FetchContent_MakeAvailable(cpr)

--- a/CMake/resolve_dependency_modules/cpr.cmake
+++ b/CMake/resolve_dependency_modules/cpr.cmake
@@ -1,0 +1,31 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+include_guard(GLOBAL)
+
+set(VELOX_CPR_VERSION 1.10.5)
+set(VELOX_CPR_BUILD_SHA256_CHECKSUM
+    c8590568996cea918d7cf7ec6845d954b9b95ab2c4980b365f582a665dea08d8)
+set(VELOX_CPR_SOURCE_URL
+    "https://github.com/libcpr/cpr/archive/refs/tags/${VELOX_CPR_VERSION}.tar.gz"
+)
+
+resolve_dependency_url(CPR)
+
+message(STATUS "Building cpr from source")
+FetchContent_Declare(
+  cpr
+  URL ${VELOX_CPR_SOURCE_URL}
+  URL_HASH ${VELOX_CPR_BUILD_SHA256_CHECKSUM})
+
+FetchContent_MakeAvailable(cpr)

--- a/CMake/resolve_dependency_modules/cpr.cmake
+++ b/CMake/resolve_dependency_modules/cpr.cmake
@@ -30,4 +30,5 @@ FetchContent_Declare(
   PATCH_COMMAND git apply
                 ${CMAKE_CURRENT_LIST_DIR}/cpr/cpr-libcurl-compatible.patch)
 set(BUILD_SHARED_LIBS OFF)
+set(CPR_USE_SYSTEM_CURL ON)
 FetchContent_MakeAvailable(cpr)

--- a/CMake/resolve_dependency_modules/cpr.cmake
+++ b/CMake/resolve_dependency_modules/cpr.cmake
@@ -26,7 +26,7 @@ message(STATUS "Building cpr from source")
 FetchContent_Declare(
   cpr
   URL ${VELOX_CPR_SOURCE_URL}
-  URL_HASH ${VELOX_CPR_BUILD_SHA256_CHECKSUM})
+  URL_HASH ${VELOX_CPR_BUILD_SHA256_CHECKSUM}
+  PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/cpr/cpr-libcurl-compatible.patch)
 set(BUILD_SHARED_LIBS OFF)
-set(CPR_USE_SYSTEM_CURL ON)
 FetchContent_MakeAvailable(cpr)

--- a/CMake/resolve_dependency_modules/cpr.cmake
+++ b/CMake/resolve_dependency_modules/cpr.cmake
@@ -27,5 +27,6 @@ FetchContent_Declare(
   cpr
   URL ${VELOX_CPR_SOURCE_URL}
   URL_HASH ${VELOX_CPR_BUILD_SHA256_CHECKSUM})
-
+set(BUILD_SHARED_LIBS OFF)
+set(CPR_USE_SYSTEM_CURL ON)
 FetchContent_MakeAvailable(cpr)

--- a/CMake/resolve_dependency_modules/cpr/cpr-libcurl-compatible.patch
+++ b/CMake/resolve_dependency_modules/cpr/cpr-libcurl-compatible.patch
@@ -1,0 +1,26 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This can be removed once we upgrade to curl >= 7.68.0
+--- a/include/cpr/util.h
++++ b/include/cpr/util.h
+@@ -23,7 +23,7 @@ size_t writeUserFunction(char* ptr, size_t size, size_t nmemb, const WriteCallba
+ template <typename T = ProgressCallback>
+ int progressUserFunction(const T* progress, cpr_pf_arg_t dltotal, cpr_pf_arg_t dlnow, cpr_pf_arg_t ultotal, cpr_pf_arg_t ulnow) {
+     const int cancel_retval{1};
+-    static_assert(cancel_retval != CURL_PROGRESSFUNC_CONTINUE);
++    static_assert(cancel_retval != 0x10000001);
+     return (*progress)(dltotal, dlnow, ultotal, ulnow) ? 0 : cancel_retval;
+ }
+ int debugUserFunction(CURL* handle, curl_infotype type, char* data, size_t size, const DebugCallback* debug);

--- a/CMake/resolve_dependency_modules/cpr/cpr-libcurl-compatible.patch
+++ b/CMake/resolve_dependency_modules/cpr/cpr-libcurl-compatible.patch
@@ -13,8 +13,6 @@
 # limitations under the License.
 #
 # This can be removed once we upgrade to curl >= 7.68.0
-diff --git a/cpr/multiperform.cpp b/cpr/multiperform.cpp
-index e9e3f00..f6c7847 100644
 --- a/cpr/multiperform.cpp
 +++ b/cpr/multiperform.cpp
 @@ -97,9 +97,9 @@ void MultiPerform::DoMultiPerform() {
@@ -29,8 +27,7 @@ index e9e3f00..f6c7847 100644
                  break;
              }
          }
-diff --git a/include/cpr/util.h b/include/cpr/util.h
-index d851e23..b491eab 100644
+
 --- a/include/cpr/util.h
 +++ b/include/cpr/util.h
 @@ -23,7 +23,7 @@ size_t writeUserFunction(char* ptr, size_t size, size_t nmemb, const WriteCallba

--- a/CMake/resolve_dependency_modules/cpr/cpr-libcurl-compatible.patch
+++ b/CMake/resolve_dependency_modules/cpr/cpr-libcurl-compatible.patch
@@ -13,6 +13,24 @@
 # limitations under the License.
 #
 # This can be removed once we upgrade to curl >= 7.68.0
+diff --git a/cpr/multiperform.cpp b/cpr/multiperform.cpp
+index e9e3f00..f6c7847 100644
+--- a/cpr/multiperform.cpp
++++ b/cpr/multiperform.cpp
+@@ -97,9 +97,9 @@ void MultiPerform::DoMultiPerform() {
+
+         if (still_running) {
+             const int timeout_ms{250};
+-            error_code = curl_multi_poll(multicurl_->handle, nullptr, 0, timeout_ms, nullptr);
++            error_code = curl_multi_wait(multicurl_->handle, nullptr, 0, timeout_ms, nullptr);
+             if (error_code) {
+-                std::cerr << "curl_multi_poll() failed, code " << static_cast<int>(error_code) << std::endl;
++                std::cerr << "curl_multi_wait() failed, code " << static_cast<int>(error_code) << std::endl;
+                 break;
+             }
+         }
+diff --git a/include/cpr/util.h b/include/cpr/util.h
+index d851e23..b491eab 100644
 --- a/include/cpr/util.h
 +++ b/include/cpr/util.h
 @@ -23,7 +23,7 @@ size_t writeUserFunction(char* ptr, size_t size, size_t nmemb, const WriteCallba

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -526,6 +526,11 @@ endif()
 set(xsimd_SOURCE BUNDLED)
 resolve_dependency(xsimd)
 
+if(VELOX_BUILD_TESTING)
+  set(cpr_SOURCE BUNDLED)
+  resolve_dependency(cpr)
+endif()
+
 include(CTest) # include after project() but before add_subdirectory()
 
 include_directories(.)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,6 +436,9 @@ endif()
 set_source(simdjson)
 resolve_dependency(simdjson 3.1.5)
 
+set_source(cpr)
+resolve_dependency(cpr)
+
 # Locate or build folly.
 add_compile_definitions(FOLLY_HAVE_INT128_T=1)
 set_source(folly)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,9 +436,6 @@ endif()
 set_source(simdjson)
 resolve_dependency(simdjson 3.1.5)
 
-set_source(cpr)
-resolve_dependency(cpr)
-
 # Locate or build folly.
 add_compile_definitions(FOLLY_HAVE_INT128_T=1)
 set_source(folly)

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -282,6 +282,9 @@ target_link_libraries(
   velox_spiller_aggregate_benchmark velox_exec velox_exec_test_lib
   velox_spiller_aggregate_benchmark_base)
 
+set(cpr_SOURCE BUNDLED)
+resolve_dependency(cpr)
+
 add_executable(cpr_http_client_test CprHttpClientTest.cpp)
 add_test(
   NAME cpr_http_client_test

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -287,5 +287,4 @@ add_test(
   NAME cpr_http_client_test
   COMMAND cpr_http_client_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(cpr_http_client_test cpr::cpr Folly::folly gtest
-                      gtest_main)
+target_link_libraries(cpr_http_client_test cpr::cpr gtest gtest_main)

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -281,3 +281,11 @@ add_executable(velox_spiller_aggregate_benchmark
 target_link_libraries(
   velox_spiller_aggregate_benchmark velox_exec velox_exec_test_lib
   velox_spiller_aggregate_benchmark_base)
+
+add_executable(cpr_http_client_test CprHttpClientTest.cpp)
+add_test(
+  NAME cpr_http_client_test
+  COMMAND cpr_http_client_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(cpr_http_client_test cpr::cpr Folly::folly gtest
+                      gtest_main)

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -282,9 +282,6 @@ target_link_libraries(
   velox_spiller_aggregate_benchmark velox_exec velox_exec_test_lib
   velox_spiller_aggregate_benchmark_base)
 
-set(cpr_SOURCE BUNDLED)
-resolve_dependency(cpr)
-
 add_executable(cpr_http_client_test CprHttpClientTest.cpp)
 add_test(
   NAME cpr_http_client_test

--- a/velox/exec/tests/CprHttpClientTest.cpp
+++ b/velox/exec/tests/CprHttpClientTest.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "folly/json.h"
+#include "velox/common/base/VeloxException.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+#include <cpr/cpr.h>
+#include <map>
+#include <string>
+#include <thread>
+
+class CprHttpClientTest : public testing::Test {};
+
+TEST_F(CprHttpClientTest, basic) {
+  auto response = cpr::Get(
+      cpr::Url{"https://facebookincubator.github.io/velox/"},
+      cpr::Timeout{std::chrono::seconds{3}});
+  ASSERT_EQ(response.status_code, 200);
+  ASSERT_FALSE(response.text.empty());
+
+  response = cpr::Get(cpr::Url{"null"});
+  ASSERT_NE(response.status_code, 200);
+  ASSERT_TRUE(response.text.empty());
+
+  response = cpr::Post(
+      cpr::Url{"https://facebookincubator.github.io/velox/"},
+      cpr::Body{"select * from nation limit 1"},
+      cpr::Header({{"Content-Type", "text/plain"}}));
+  ASSERT_EQ(response.status_code, 405);
+  ASSERT_FALSE(response.text.empty());
+
+  response = cpr::Post(
+      cpr::Url{"null"},
+      cpr::Body{"select * from nation limit 1"},
+      cpr::Header({{"Content-Type", "text/plain"}}));
+  ASSERT_NE(response.status_code, 200);
+  ASSERT_TRUE(response.text.empty());
+}

--- a/velox/exec/tests/CprHttpClientTest.cpp
+++ b/velox/exec/tests/CprHttpClientTest.cpp
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-#include "folly/json.h"
-#include "velox/common/base/VeloxException.h"
 #include "velox/common/base/tests/GTestUtils.h"
 
 #include <cpr/cpr.h>
 #include <map>
-#include <string>
-#include <thread>
 
 class CprHttpClientTest : public testing::Test {};
 

--- a/velox/exec/tests/CprHttpClientTest.cpp
+++ b/velox/exec/tests/CprHttpClientTest.cpp
@@ -21,7 +21,10 @@
 
 class CprHttpClientTest : public testing::Test {};
 
-TEST_F(CprHttpClientTest, basic) {
+// This test requires open access to internet and most places test runners might
+// be closed off from the general internet. And this test case is just an
+// illustration of how to use cpr, so disable it by default.
+TEST_F(CprHttpClientTest, DISABLED_basic) {
   auto response = cpr::Get(
       cpr::Url{"https://facebookincubator.github.io/velox/"},
       cpr::Timeout{std::chrono::seconds{3}});


### PR DESCRIPTION
The `libcpr/cpr` is a simple wrapper around `libcurl`.
It supports `fetch_content` and is easy to integrate into 
Velox so it perfectly matches Velox's hermetic building philosophy.
See https://velox-lib.io/blog/velox-build-experience

This is the first step to add PrestoQueryRunner in Velox.