### PR TITLE
Fix: Override values with loaded vector when dictionary vector is loaded

### DIFF
--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -220,41 +220,6 @@ class ExprTest : public testing::Test, public VectorTestBase {
         valueType, std::move(value));
   }
 
-  // Create LazyVector that produces a flat vector and asserts that is is being
-  // loaded for a specific set of rows.
-  template <typename T>
-  std::shared_ptr<LazyVector> makeLazyFlatVector(
-      vector_size_t size,
-      std::function<T(vector_size_t /*row*/)> valueAt,
-      std::function<bool(vector_size_t /*row*/)> isNullAt,
-      vector_size_t expectedSize,
-      const std::function<vector_size_t(vector_size_t /*index*/)>&
-          expectedRowAt) {
-    return std::make_shared<LazyVector>(
-        execCtx_->pool(),
-        CppToType<T>::create(),
-        size,
-        std::make_unique<SimpleVectorLoader>([=](RowSet rows) {
-          VELOX_CHECK_EQ(rows.size(), expectedSize);
-          for (auto i = 0; i < rows.size(); i++) {
-            VELOX_CHECK_EQ(rows[i], expectedRowAt(i));
-          }
-          return makeFlatVector<T>(size, valueAt, isNullAt);
-        }));
-  }
-
-  VectorPtr wrapInLazyDictionary(VectorPtr vector) {
-    return std::make_shared<LazyVector>(
-        execCtx_->pool(),
-        vector->type(),
-        vector->size(),
-        std::make_unique<SimpleVectorLoader>([=](RowSet /*rows*/) {
-          auto indices =
-              makeIndices(vector->size(), [](auto row) { return row; });
-          return wrapInDictionary(indices, vector->size(), vector);
-        }));
-  }
-
   /// Remove ". Input data: .*" from the 'context'.
   std::string trimInputPath(const std::string& context) {
     auto pos = context.find(". Input data: ");

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -188,7 +188,6 @@ void registerArrayFunctions(const std::string& prefix) {
       ArrayConcatFunction,
       Array<Generic<T1>>,
       Variadic<Array<Generic<T1>>>>({prefix + "concat"});
-
   registerFunction<
       ArrayFlattenFunction,
       Array<Generic<T1>>,

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -15,10 +15,9 @@
  */
 #pragma once
 
+#include <folly/container/F14Map.h>
 #include <memory>
 #include <type_traits>
-
-#include <folly/container/F14Map.h>
 
 #include "velox/common/base/SimdUtil.h"
 #include "velox/vector/LazyVector.h"
@@ -159,6 +158,7 @@ class DictionaryVector : public SimpleVector<T> {
     rows.updateBounds();
 
     LazyVector::ensureLoadedRows(dictionaryValues_, rows);
+    dictionaryValues_ = BaseVector::loadedVectorShared(dictionaryValues_);
     setInternalState();
     return this;
   }

--- a/velox/vector/tests/DecodedVectorTest.cpp
+++ b/velox/vector/tests/DecodedVectorTest.cpp
@@ -602,7 +602,7 @@ TEST_F(DecodedVectorTest, dictionaryOverLazy) {
     checkUnloaded(decoded);
   }
   dictionaryVector->loadedVector();
-  EXPECT_TRUE(dictionaryVector->valueVector()->as<LazyVector>()->isLoaded());
+  EXPECT_TRUE(!dictionaryVector->valueVector()->isLazy());
   {
     SelectivityVector selection(dictionarySize);
     DecodedVector decoded(*dictionaryVector, selection, false);

--- a/velox/vector/tests/LazyVectorTest.cpp
+++ b/velox/vector/tests/LazyVectorTest.cpp
@@ -59,10 +59,7 @@ TEST_F(LazyVectorTest, lazyInDictionary) {
   rows.updateBounds();
   LazyVector::ensureLoadedRows(wrapped, rows);
   EXPECT_EQ(wrapped->encoding(), VectorEncoding::Simple::DICTIONARY);
-  EXPECT_EQ(wrapped->valueVector()->encoding(), VectorEncoding::Simple::LAZY);
-  EXPECT_EQ(
-      wrapped->valueVector()->loadedVector()->encoding(),
-      VectorEncoding::Simple::FLAT);
+  EXPECT_EQ(wrapped->valueVector()->encoding(), VectorEncoding::Simple::FLAT);
 
   EXPECT_EQ(loadedRows, (std::vector<vector_size_t>{0, 5}));
   assertCopyableVector(wrapped);


### PR DESCRIPTION
Summary:
This is not a sound but not complete fix for leaking lazy vectors .
This should fix https://github.com/facebookincubator/velox/issues/7009
and potentially reduce errors or fix:
https://github.com/facebookincubator/velox/issues/7331
and
https://github.com/facebookincubator/velox/issues/7330

A more comprehensive refactor is planned for a more sound approach.

Reviewed By: Yuhta

Differential Revision: D50936749


