### PR TITLE
Add primitive fast path for ArrayConcatFunction

### DIFF
--- a/velox/functions/prestosql/benchmarks/ArrayConcatBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayConcatBenchmark.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/type/Type.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/DecodedVector.h"
+
+using namespace facebook::velox;
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+
+  ExpressionBenchmarkBuilder benchmarkBuilder;
+  facebook::velox::functions::prestosql::registerAllScalarFunctions();
+
+  auto* pool = benchmarkBuilder.pool();
+  auto& vm = benchmarkBuilder.vectorMaker();
+
+  auto createSet =
+      [&](const TypePtr& elementType,
+          const std::vector<int>& containerLengths = {5, 10, 20, 40}) {
+        VectorFuzzer::Options options;
+        options.vectorSize = 1000;
+        options.complexElementsMaxSize = 1'000'000;
+        options.containerVariableLength = false;
+
+        for (auto length : containerLengths) {
+          options.containerLength = length;
+          options.stringLength = length;
+          VectorFuzzer fuzzer(options, pool);
+
+          std::vector<VectorPtr> columns;
+          for (int i = 0; i < 4; i++) {
+            columns.push_back(fuzzer.fuzz(ARRAY(elementType)));
+          }
+
+          benchmarkBuilder
+              .addBenchmarkSet(
+                  fmt::format(
+                      "array_concat_{}_{}",
+                      elementType->toString(),
+                      options.containerLength),
+                  vm.rowVector(columns))
+              .addExpression("2arg", "concat(c0, c1)")
+              .addExpression("3arg", "concat(c0, c1, c2)")
+              .addExpression("4arg", "concat(c0, c1, c2, c3)");
+        }
+      };
+
+  createSet(INTEGER());
+  createSet(VARCHAR());
+  createSet(BOOLEAN());
+
+  benchmarkBuilder.registerBenchmarks();
+
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/functions/prestosql/registration/ArrayConcatRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayConcatRegistration.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/Registerer.h"
+#include "velox/functions/prestosql/ArrayFunctions.h"
+
+namespace facebook::velox::functions {
+namespace {
+template <typename T>
+inline void registerArrayConcatFunctions(const std::string& prefix) {
+  registerFunction<
+      ParameterBinder<ArrayConcatFunction, T>,
+      Array<T>,
+      Array<T>,
+      T>({prefix + "concat"});
+  registerFunction<
+      ParameterBinder<ArrayConcatFunction, T>,
+      Array<T>,
+      T,
+      Array<T>>({prefix + "concat"});
+  registerFunction<
+      ParameterBinder<ArrayConcatFunction, T>,
+      Array<T>,
+      Variadic<Array<T>>>({prefix + "concat"});
+}
+} // namespace
+
+void registerArrayConcatFunctions(const std::string& prefix) {
+  registerArrayConcatFunctions<Generic<T1>>(prefix);
+  // Fast paths for primitives types.
+  registerArrayConcatFunctions<int8_t>(prefix);
+  registerArrayConcatFunctions<int16_t>(prefix);
+  registerArrayConcatFunctions<int32_t>(prefix);
+  registerArrayConcatFunctions<int64_t>(prefix);
+  registerArrayConcatFunctions<int128_t>(prefix);
+  registerArrayConcatFunctions<float>(prefix);
+  registerArrayConcatFunctions<double>(prefix);
+  registerArrayConcatFunctions<bool>(prefix);
+  registerArrayConcatFunctions<Varchar>(prefix);
+  registerArrayConcatFunctions<Timestamp>(prefix);
+  registerArrayConcatFunctions<Date>(prefix);
+}
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <string>
+
 #include "velox/functions/Registerer.h"
 #include "velox/functions/prestosql/ArrayConstructor.h"
 #include "velox/functions/prestosql/ArrayFunctions.h"
@@ -21,6 +23,8 @@
 #include "velox/functions/prestosql/WidthBucketArray.h"
 
 namespace facebook::velox::functions {
+extern void registerArrayConcatFunctions(const std::string& prefix);
+
 template <typename T>
 inline void registerArrayMinMaxFunctions(const std::string& prefix) {
   registerFunction<ArrayMinFunction, T, Array<T>>({prefix + "array_min"});
@@ -174,20 +178,8 @@ void registerArrayFunctions(const std::string& prefix) {
   registerFunction<ArrayAverageFunction, double, Array<double>>(
       {prefix + "array_average"});
 
-  registerFunction<
-      ArrayConcatFunction,
-      Array<Generic<T1>>,
-      Array<Generic<T1>>,
-      Generic<T1>>({prefix + "concat"});
-  registerFunction<
-      ArrayConcatFunction,
-      Array<Generic<T1>>,
-      Generic<T1>,
-      Array<Generic<T1>>>({prefix + "concat"});
-  registerFunction<
-      ArrayConcatFunction,
-      Array<Generic<T1>>,
-      Variadic<Array<Generic<T1>>>>({prefix + "concat"});
+  registerArrayConcatFunctions(prefix);
+
   registerFunction<
       ArrayFlattenFunction,
       Array<Generic<T1>>,

--- a/velox/functions/prestosql/registration/CMakeLists.txt
+++ b/velox/functions/prestosql/registration/CMakeLists.txt
@@ -27,7 +27,8 @@ add_library(
   StringFunctionsRegistration.cpp
   BitwiseFunctionsRegistration.cpp
   URLFunctionsRegistration.cpp
-  RegistrationFunctions.cpp)
+  RegistrationFunctions.cpp
+  ArrayConcatRegistration.cpp)
 
 # GCC 12 has a bug where it does not respect "pragma ignore" directives and ends
 # up failing compilation in an openssl header included by a hash-related


### PR DESCRIPTION
Summary:
Optimize  ArrayConcatFunction for primitives, similar to what we do for
registerArrayRemoveFunctions and registerArrayTrimFunctions.

Note: we can further optimize this by adding fast path for strings and
add a no copy version for that.
Note: there are also still several functions that uses add_items() and do
not have such fast path we shall optimize those also.

Follow up will address the points above.

before:
```
BUILD SUCCEEDED
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
array_concat_BOOLEAN_10##2arg                             723.07ms      1.38
array_concat_BOOLEAN_10##3arg                                1.14s   877.15m
array_concat_BOOLEAN_10##4arg                                1.57s   637.52m
array_concat_BOOLEAN_20##2arg                             775.91ms      1.29
array_concat_BOOLEAN_20##3arg                                1.17s   857.28m
array_concat_BOOLEAN_20##4arg                                1.55s   646.56m
array_concat_BOOLEAN_40##2arg                             778.07ms      1.29
array_concat_BOOLEAN_40##3arg                                1.16s   860.94m
array_concat_BOOLEAN_40##4arg                                1.57s   636.92m
array_concat_BOOLEAN_5##2arg                              726.71ms      1.38
array_concat_BOOLEAN_5##3arg                                 1.11s   904.61m
array_concat_BOOLEAN_5##4arg                                 1.55s   643.97m
array_concat_INTEGER_10##2arg                             689.14ms      1.45
array_concat_INTEGER_10##3arg                                1.01s   991.35m
array_concat_INTEGER_10##4arg                                1.40s   713.43m
array_concat_INTEGER_20##2arg                             681.24ms      1.47
array_concat_INTEGER_20##3arg                                1.03s   973.70m
array_concat_INTEGER_20##4arg                                1.35s   740.10m
array_concat_INTEGER_40##2arg                             666.57ms      1.50
array_concat_INTEGER_40##3arg                                1.04s   958.60m
array_concat_INTEGER_40##4arg                                1.37s   727.85m
array_concat_INTEGER_5##2arg                              652.99ms      1.53
array_concat_INTEGER_5##3arg                              985.63ms      1.01
array_concat_INTEGER_5##4arg                                 1.34s   745.48m
array_concat_VARCHAR_10##2arg                             679.71ms      1.47
array_concat_VARCHAR_10##3arg                                1.46s   683.21m
array_concat_VARCHAR_10##4arg                                2.09s   479.20m
array_concat_VARCHAR_20##2arg                                1.36s   733.91m
array_concat_VARCHAR_20##3arg                                1.85s   539.88m
array_concat_VARCHAR_20##4arg                                2.78s   359.50m
array_concat_VARCHAR_40##2arg                                1.23s   809.85m
array_concat_VARCHAR_40##3arg                                1.84s   542.69m
array_concat_VARCHAR_40##4arg                                2.45s   407.85m
array_concat_VARCHAR_5##2arg                                 1.53s   653.44m
array_concat_VARCHAR_5##3arg                                 2.06s   485.88m
array_concat_VARCHAR_5##4arg                                 2.81s   356.51m
```


after:�
```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
array_concat_BOOLEAN_10##2arg                             197.26ms      5.07
array_concat_BOOLEAN_10##3arg                             337.22ms      2.97
array_concat_BOOLEAN_10##4arg                             486.89ms      2.05
array_concat_BOOLEAN_20##2arg                             280.10ms      3.57
array_concat_BOOLEAN_20##3arg                             352.67ms      2.84
array_concat_BOOLEAN_20##4arg                             495.94ms      2.02
array_concat_BOOLEAN_40##2arg                             260.39ms      3.84
array_concat_BOOLEAN_40##3arg                             415.81ms      2.40
array_concat_BOOLEAN_40##4arg                             550.83ms      1.82
array_concat_BOOLEAN_5##2arg                              189.44ms      5.28
array_concat_BOOLEAN_5##3arg                              244.64ms      4.09
array_concat_BOOLEAN_5##4arg                              376.33ms      2.66
array_concat_INTEGER_10##2arg                              80.36ms     12.44
array_concat_INTEGER_10##3arg                             129.36ms      7.73
array_concat_INTEGER_10##4arg                             194.14ms      5.15
array_concat_INTEGER_20##2arg                             110.09ms      9.08
array_concat_INTEGER_20##3arg                             144.69ms      6.91
array_concat_INTEGER_20##4arg                             179.20ms      5.58
array_concat_INTEGER_40##2arg                              83.20ms     12.02
array_concat_INTEGER_40##3arg                             128.46ms      7.78
array_concat_INTEGER_40##4arg                             167.46ms      5.97
array_concat_INTEGER_5##2arg                               80.45ms     12.43
array_concat_INTEGER_5##3arg                              111.43ms      8.97
array_concat_INTEGER_5##4arg                              154.83ms      6.46
array_concat_VARCHAR_10##2arg                             401.57ms      2.49
array_concat_VARCHAR_10##3arg                             755.30ms      1.32
array_concat_VARCHAR_10##4arg                                1.03s   969.99m
array_concat_VARCHAR_20##2arg                             681.27ms      1.47
array_concat_VARCHAR_20##3arg                             959.15ms      1.04
array_concat_VARCHAR_20##4arg                                1.50s   665.93m
array_concat_VARCHAR_40##2arg                             660.68ms      1.51
array_concat_VARCHAR_40##3arg                             984.20ms      1.02
array_concat_VARCHAR_40##4arg                                1.35s   738.16m
array_concat_VARCHAR_5##2arg                              827.10ms      1.21
array_concat_VARCHAR_5##3arg                                 1.11s   903.32m
array_concat_VARCHAR_5##4arg                                 1.47s   682.15m
```

Differential Revision: D50948537


