### PR TITLE
Fix runtime stats reporting when memory arbitration is triggered

### DIFF
--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -610,6 +610,7 @@ uint64_t Operator::MemoryReclaimer::reclaim(
     return 0;
   }
 
+  RuntimeStatWriterScopeGuard opStatsGuard(op_);
   op_->reclaim(targetBytes, stats);
   return pool->shrink(targetBytes);
 }

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -332,6 +332,7 @@ uint64_t TableWriter::ConnectorReclaimer::reclaim(
         << ", memory usage: " << succinctBytes(pool->currentBytes());
     return 0;
   }
+  RuntimeStatWriterScopeGuard opStatsGuard(op_);
   return memory::MemoryReclaimer::reclaim(pool, targetBytes, stats);
 }
 


### PR DESCRIPTION
When one operator(eg A)'s memory reaches limit, it triggers memory 
arbitration which calls into other operator(eg B)'s reclaim method. 
The reclaim method then would update runtimeStats which would be 
counted on Operator A instead of B.

This PR fixes such result by changing RuntimeStatWriterScopeGuard  
to point to the right operator.