### PR TITLE
Remove check for groupId if global GroupingSets are present

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -159,11 +159,6 @@ AggregationNode::AggregationNode(
         "GroupId key {} must have global grouping sets",
         groupId_.value()->name());
   }
-
-  if (!globalGroupingSets_.empty()) {
-    VELOX_USER_CHECK(
-        groupId_.has_value(), "Global grouping sets require GroupId key");
-  }
 }
 
 AggregationNode::AggregationNode(


### PR DESCRIPTION
Final aggregation nodes can have global grouping sets without groupId key. Remove the validation.