### PR TITLE
Merge small batches of data into larger vectors in Exchange

### DIFF
--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -66,11 +66,20 @@ class ExchangeClient {
   // runtime metric named ExchangeClient::kBackgroundCpuTimeMs.
   folly::F14FastMap<std::string, RuntimeMetric> stats() const;
 
-  std::shared_ptr<ExchangeQueue> queue() const {
+  const std::shared_ptr<ExchangeQueue>& queue() const {
     return queue_;
   }
 
-  std::unique_ptr<SerializedPage> next(bool* atEnd, ContinueFuture* future);
+  /// Returns up to 'maxBytes' pages of data, but no less than one.
+  ///
+  /// If no data is available returns empty list and sets 'atEnd' to true if no
+  /// more data is expected. If data is still expected, sets 'atEnd' to false
+  /// and sets 'future' to a Future that will comlete when data arrives.
+  ///
+  /// The data may be compressed, in which case 'maxBytes' applies to compressed
+  /// size.
+  std::vector<std::unique_ptr<SerializedPage>>
+  next(uint32_t maxBytes, bool* atEnd, ContinueFuture* future);
 
   std::string toString() const;
 

--- a/velox/exec/ExchangeQueue.cpp
+++ b/velox/exec/ExchangeQueue.cpp
@@ -91,7 +91,8 @@ void ExchangeQueue::enqueueLocked(
   }
 }
 
-std::unique_ptr<SerializedPage> ExchangeQueue::dequeueLocked(
+std::vector<std::unique_ptr<SerializedPage>> ExchangeQueue::dequeueLocked(
+    uint32_t maxBytes,
     bool* atEnd,
     ContinueFuture* future) {
   VELOX_CHECK(future);
@@ -99,21 +100,33 @@ std::unique_ptr<SerializedPage> ExchangeQueue::dequeueLocked(
     *atEnd = true;
     VELOX_FAIL(error_);
   }
-  if (queue_.empty()) {
-    if (atEnd_) {
-      *atEnd = true;
-    } else {
-      promises_.emplace_back("ExchangeQueue::dequeue");
-      *future = promises_.back().getSemiFuture();
-      *atEnd = false;
-    }
-    return nullptr;
-  }
-  auto page = std::move(queue_.front());
-  queue_.pop_front();
+
   *atEnd = false;
-  totalBytes_ -= page->size();
-  return page;
+
+  std::vector<std::unique_ptr<SerializedPage>> pages;
+  uint32_t pageBytes = 0;
+  for (;;) {
+    if (queue_.empty()) {
+      if (atEnd_) {
+        *atEnd = true;
+      } else {
+        promises_.emplace_back("ExchangeQueue::dequeue");
+        *future = promises_.back().getSemiFuture();
+      }
+      return pages;
+    }
+
+    if (pageBytes > 0 && pageBytes + queue_.front()->size() > maxBytes) {
+      return pages;
+    }
+
+    pages.emplace_back(std::move(queue_.front()));
+    queue_.pop_front();
+    pageBytes += pages.back()->size();
+    totalBytes_ -= pages.back()->size();
+  }
+
+  VELOX_UNREACHABLE();
 }
 
 void ExchangeQueue::setError(const std::string& error) {

--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -47,6 +47,8 @@ void PlanNodeStats::addTotals(const OperatorStats& stats) {
   cpuWallTiming.add(stats.getOutputTiming);
   cpuWallTiming.add(stats.finishTiming);
 
+  backgroundTiming.add(stats.backgroundTiming);
+
   blockedWallNanos += stats.blockedWallNanos;
 
   peakMemoryBytes += stats.memoryStats.peakTotalMemoryReservation;

--- a/velox/exec/PlanNodeStats.h
+++ b/velox/exec/PlanNodeStats.h
@@ -78,6 +78,11 @@ struct PlanNodeStats {
   /// up.
   CpuWallTiming cpuWallTiming;
 
+  /// Sum of CPU, scheduled and wall times spent on background activities
+  /// (activities that are not running on driver threads) for all corresponding
+  /// operators.
+  CpuWallTiming backgroundTiming;
+
   /// Sum of blocked wall time for all corresponding operators.
   uint64_t blockedWallNanos{0};
 

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -54,14 +54,12 @@ class ExchangeClientTest : public testing::Test,
 
   std::shared_ptr<Task> makeTask(
       const std::string& taskId,
-      const core::PlanNodePtr& planNode,
-      int destination) {
+      const core::PlanNodePtr& planNode) {
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
         memory::defaultMemoryManager().addRootPool(queryCtx->queryId()));
-    core::PlanFragment planFragment{planNode};
     return Task::create(
-        taskId, std::move(planFragment), destination, std::move(queryCtx));
+        taskId, core::PlanFragment{planNode}, 0, std::move(queryCtx));
   }
 
   int32_t enqueue(
@@ -81,9 +79,38 @@ class ExchangeClientTest : public testing::Test,
     for (auto i = 0; i < numPages; ++i) {
       bool atEnd;
       ContinueFuture future;
-      auto page = client.next(&atEnd, &future);
-      ASSERT_TRUE(page != nullptr);
+      auto pages = client.next(1, &atEnd, &future);
+      ASSERT_EQ(1, pages.size());
     }
+  }
+
+  static void addSources(ExchangeQueue& queue, int32_t numSources) {
+    {
+      std::lock_guard<std::mutex> l(queue.mutex());
+      for (auto i = 0; i < numSources; ++i) {
+        queue.addSourceLocked();
+      }
+    }
+    queue.noMoreSources();
+  }
+
+  static void enqueue(
+      ExchangeQueue& queue,
+      std::unique_ptr<SerializedPage> page) {
+    std::vector<ContinuePromise> promises;
+    {
+      std::lock_guard<std::mutex> l(queue.mutex());
+      queue.enqueueLocked(std::move(page), promises);
+    }
+    for (auto& promise : promises) {
+      promise.setValue();
+    }
+  }
+
+  static std::unique_ptr<SerializedPage> makePage(uint64_t size) {
+    auto ioBuf = folly::IOBuf::create(size);
+    ioBuf->append(size);
+    return std::make_unique<SerializedPage>(std::move(ioBuf));
   }
 
   std::shared_ptr<OutputBufferManager> bufferManager_;
@@ -120,7 +147,7 @@ TEST_F(ExchangeClientTest, stats) {
                   .partitionedOutput({"c0"}, 100)
                   .planNode();
   auto taskId = "local://t1";
-  auto task = makeTask(taskId, plan, 17);
+  auto task = makeTask(taskId, plan);
 
   bufferManager_->initializeTask(
       task, core::PartitionedOutputNode::Kind::kPartitioned, 100, 16);
@@ -170,7 +197,7 @@ TEST_F(ExchangeClientTest, flowControl) {
   std::vector<std::shared_ptr<Task>> tasks;
   for (auto i = 0; i < 10; ++i) {
     auto taskId = fmt::format("local://t{}", i);
-    auto task = makeTask(taskId, plan, 17);
+    auto task = makeTask(taskId, plan);
 
     bufferManager_->initializeTask(
         task, core::PartitionedOutputNode::Kind::kPartitioned, 100, 16);
@@ -195,6 +222,46 @@ TEST_F(ExchangeClientTest, flowControl) {
     task->requestCancel();
     bufferManager_->removeTask(task->taskId());
   }
+}
+
+TEST_F(ExchangeClientTest, multiPageFetch) {
+  ExchangeClient client("test", 17, pool(), 1 << 20);
+
+  bool atEnd;
+  ContinueFuture future;
+  auto pages = client.next(1, &atEnd, &future);
+  ASSERT_EQ(0, pages.size());
+  ASSERT_FALSE(atEnd);
+
+  const auto& queue = client.queue();
+  addSources(*queue, 1);
+
+  for (auto i = 0; i < 10; ++i) {
+    enqueue(*queue, makePage(1'000 + i));
+  }
+
+  // Fetch one page.
+  pages = client.next(1, &atEnd, &future);
+  ASSERT_EQ(1, pages.size());
+  ASSERT_FALSE(atEnd);
+
+  // Fetch multiple pages. Each page is slightly larger than 1K bytes, hence,
+  // only 4 pages fit.
+  pages = client.next(5'000, &atEnd, &future);
+  ASSERT_EQ(4, pages.size());
+  ASSERT_FALSE(atEnd);
+
+  // Fetch the rest of the pages.
+  pages = client.next(10'000, &atEnd, &future);
+  ASSERT_EQ(5, pages.size());
+  ASSERT_FALSE(atEnd);
+
+  // Signal no-more-data.
+  enqueue(*queue, nullptr);
+
+  pages = client.next(10'000, &atEnd, &future);
+  ASSERT_EQ(0, pages.size());
+  ASSERT_TRUE(atEnd);
 }
 
 } // namespace

--- a/velox/exec/tests/OutputBufferManagerTest.cpp
+++ b/velox/exec/tests/OutputBufferManagerTest.cpp
@@ -998,7 +998,8 @@ TEST_F(OutputBufferManagerTest, errorInQueue) {
   std::lock_guard<std::mutex> l(queue->mutex());
   ContinueFuture future;
   bool atEnd = false;
-  VELOX_ASSERT_THROW(queue->dequeueLocked(&atEnd, &future), "Forced failure");
+  VELOX_ASSERT_THROW(
+      queue->dequeueLocked(1, &atEnd, &future), "Forced failure");
 }
 
 TEST_F(OutputBufferManagerTest, setQueueErrorWithPendingPages) {
@@ -1024,7 +1025,8 @@ TEST_F(OutputBufferManagerTest, setQueueErrorWithPendingPages) {
   std::lock_guard<std::mutex> l(queue->mutex());
   ContinueFuture future;
   bool atEnd = false;
-  VELOX_ASSERT_THROW(queue->dequeueLocked(&atEnd, &future), "Forced failure");
+  VELOX_ASSERT_THROW(
+      queue->dequeueLocked(1, &atEnd, &future), "Forced failure");
 }
 
 TEST_F(OutputBufferManagerTest, getDataOnFailedTask) {

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -57,6 +57,11 @@ AssertQueryBuilder& AssertQueryBuilder::maxDrivers(int32_t maxDrivers) {
   return *this;
 }
 
+AssertQueryBuilder& AssertQueryBuilder::destination(int32_t destination) {
+  params_.destination = destination;
+  return *this;
+}
+
 AssertQueryBuilder& AssertQueryBuilder::config(
     const std::string& key,
     const std::string& value) {

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -35,6 +35,10 @@ class AssertQueryBuilder {
   /// Change requested number of drivers. Default is 1.
   AssertQueryBuilder& maxDrivers(int32_t maxDrivers);
 
+  /// Change task's 'destination', the partition number assigned to the task.
+  /// Default is 0.
+  AssertQueryBuilder& destination(int32_t destination);
+
   /// Set configuration property. May be called multiple times to set multiple
   /// properties.
   AssertQueryBuilder& config(const std::string& key, const std::string& value);

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -107,6 +107,10 @@ class VectorSerde {
       RowVectorPtr* result,
       vector_size_t resultOffset,
       const Options* options = nullptr) {
+    if (resultOffset == 0) {
+      deserialize(source, pool, type, result, options);
+      return;
+    }
     VELOX_UNSUPPORTED();
   }
 };


### PR DESCRIPTION
There is significant overhead to processing short vectors. When small amount of
data is partitioned many ways, Exchange may receive lots of tiny batches of
rows and produce short vectors slowing down further processing. Add logic to
merge small batches into larger ones. Aim to produce batches
of 'preferred_output_batch_bytes' size.