### PR TITLE
Remove fine-grained spill control logic

### DIFF
--- a/velox/common/file/File.cpp
+++ b/velox/common/file/File.cpp
@@ -233,8 +233,8 @@ LocalWriteFile::LocalWriteFile(
           path);
     }
   }
-  auto file = fopen(buf.get(), "ab");
-  VELOX_CHECK(
+  auto* file = fopen(buf.get(), "ab");
+  VELOX_CHECK_NOT_NULL(
       file,
       "fopen failure in LocalWriteFile constructor, {} {}.",
       path,

--- a/velox/dwio/common/SortingWriter.cpp
+++ b/velox/dwio/common/SortingWriter.cpp
@@ -91,7 +91,7 @@ uint64_t SortingWriter::reclaim(
   }
   VELOX_CHECK_NOT_NULL(sortBuffer_);
 
-  sortBuffer_->spill(0, 0);
+  sortBuffer_->spill();
   sortPool_->release();
   return sortPool_->shrink(targetBytes);
 }

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -104,14 +104,8 @@ class GroupingSet {
 
   const HashLookup& hashLookup() const;
 
-  /// Spills content until under 'targetRows' and under 'targetBytes'
-  /// of out of line data are left. If targetRows is 0, spills
-  /// everything and physically frees the data in the
-  /// 'table_->rows()'. This leaves 'table_' initialized and 'this'
-  /// ready to accumulate more input. This is called by ensureInputFits
-  /// or by external memory management. In the latter case, the Driver
-  /// of this will be in a paused state and off thread.
-  void spill(int64_t targetRows, int64_t targetBytes);
+  /// Spills all the rows in container.
+  void spill();
 
   /// Spills all the rows in container starting from the offset specified by
   /// 'rowIterator'.

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -544,7 +544,7 @@ void HashAggregation::reclaim(
   } else {
     // TODO: support fine-grain disk spilling based on 'targetBytes' after
     // having row container memory compaction support later.
-    groupingSet_->spill(0, targetBytes);
+    groupingSet_->spill();
   }
   VELOX_CHECK_EQ(groupingSet_->numRows(), 0);
   VELOX_CHECK_EQ(groupingSet_->numDistinct(), 0);

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -231,15 +231,11 @@ void HashBuild::setupSpiller(SpillPartition* spillPartition) {
   spiller_ = std::make_unique<Spiller>(
       Spiller::Type::kHashJoinBuild,
       table_->rows(),
-      [&](folly::Range<char**> rows) { table_->rows()->eraseRows(rows); },
       tableType_,
       std::move(hashBits),
-      keyChannels_.size(),
-      std::vector<CompareFlags>(),
       spillConfig.filePath,
       spillConfig.maxFileSize,
       spillConfig.writeBufferSize,
-      spillConfig.minSpillRunSize,
       spillConfig.compressionKind,
       memory::spillMemoryPool(),
       spillConfig.executor);
@@ -667,53 +663,22 @@ void HashBuild::runSpill(const std::vector<Operator*>& spillOperators) {
 
   uint64_t targetRows = 0;
   uint64_t targetBytes = 0;
-  std::vector<Spiller*> spillers;
-  spillers.reserve(spillOperators.size());
   for (auto& spillOp : spillOperators) {
     HashBuild* build = dynamic_cast<HashBuild*>(spillOp);
     VELOX_CHECK_NOT_NULL(build);
     ++build->numSpillRuns_;
-    spillers.push_back(build->spiller_.get());
     build->addAndClearSpillTarget(targetRows, targetBytes);
   }
   VELOX_CHECK_GT(targetRows, 0);
   VELOX_CHECK_GT(targetBytes, 0);
 
-  std::vector<Spiller::SpillableStats> spillableStats(
-      spiller_->hashBits().numPartitions());
-  for (auto* spiller : spillers) {
-    spiller->fillSpillRuns(spillableStats);
-  }
-
-  // Sort the partitions based on the amount of spillable data.
-  SpillPartitionNumSet partitionsToSpill;
-  std::vector<int32_t> partitionIndices(spillableStats.size());
-  std::iota(partitionIndices.begin(), partitionIndices.end(), 0);
-  std::sort(
-      partitionIndices.begin(),
-      partitionIndices.end(),
-      [&](int32_t lhs, int32_t rhs) {
-        return spillableStats[lhs].numBytes > spillableStats[rhs].numBytes;
-      });
-  int64_t numRows = 0;
-  int64_t numBytes = 0;
-  for (auto partitionNum : partitionIndices) {
-    if (spillableStats[partitionNum].numBytes == 0) {
-      break;
-    }
-    partitionsToSpill.insert(partitionNum);
-    numRows += spillableStats[partitionNum].numRows;
-    numBytes += spillableStats[partitionNum].numBytes;
-    if (numRows >= targetRows && numBytes >= targetBytes) {
-      break;
-    }
-  }
-  VELOX_CHECK(!partitionsToSpill.empty());
-
   // TODO: consider to offload the partition spill processing to an executor to
   // run in parallel.
-  for (auto* spiller : spillers) {
-    spiller->spill(partitionsToSpill);
+  for (auto& spillOp : spillOperators) {
+    HashBuild* build = dynamic_cast<HashBuild*>(spillOp);
+    build->spiller_->spill();
+    build->table_->clear();
+    build->pool()->release();
   }
 }
 
@@ -1152,9 +1117,6 @@ void HashBuild::reclaim(
     }
   }
 
-  std::vector<Spiller::SpillableStats> spillableStats;
-  spillableStats.reserve(spiller_->hashBits().numPartitions());
-
   struct SpillResult {
     const std::exception_ptr error{nullptr};
 
@@ -1166,12 +1128,10 @@ void HashBuild::reclaim(
   for (auto* op : operators) {
     HashBuild* buildOp = static_cast<HashBuild*>(op);
     ++buildOp->numSpillRuns_;
-    spillTasks.push_back(std::make_shared<AsyncSource<SpillResult>>(
-        [this, &spillableStats, buildOp]() {
+    spillTasks.push_back(
+        std::make_shared<AsyncSource<SpillResult>>([buildOp]() {
           try {
-            buildOp->spiller_->fillSpillRuns(spillableStats);
             buildOp->spiller_->spill();
-            VELOX_CHECK_EQ(buildOp->table_->numDistinct(), 0);
             buildOp->table_->clear();
             // Release the minimum reserved memory.
             buildOp->pool()->release();

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -257,7 +257,6 @@ void HashProbe::maybeSetupSpillInput(
       spillConfig.filePath,
       spillConfig.maxFileSize,
       spillConfig.writeBufferSize,
-      spillConfig.minSpillRunSize,
       spillConfig.compressionKind,
       memory::spillMemoryPool(),
       spillConfig.executor);

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -98,7 +98,7 @@ void OrderBy::reclaim(
 
   // TODO: support fine-grain disk spilling based on 'targetBytes' after having
   // row container memory compaction support later.
-  sortBuffer_->spill(0, targetBytes);
+  sortBuffer_->spill();
   // Release the minimum reserved memory.
   pool()->release();
 }

--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -389,17 +389,11 @@ void RowNumber::setupHashTableSpiller() {
   hashTableSpiller_ = std::make_unique<Spiller>(
       Spiller::Type::kHashJoinBuild,
       table_->rows(),
-      [&](folly::Range<char**> /*rows*/) {
-        // Do nothing. We spill hash table in full and clear it all at once.
-      },
       tableType,
       std::move(hashBits),
-      tableType->size() - 1,
-      std::vector<CompareFlags>(),
       spillConfig.filePath,
       spillConfig.maxFileSize,
       spillConfig.writeBufferSize,
-      spillConfig.minSpillRunSize,
       spillConfig.compressionKind,
       memory::spillMemoryPool(),
       spillConfig.executor);
@@ -417,7 +411,6 @@ void RowNumber::setupInputSpiller() {
       spillConfig.filePath,
       spillConfig.maxFileSize,
       spillConfig.writeBufferSize,
-      spillConfig.minSpillRunSize,
       spillConfig.compressionKind,
       memory::spillMemoryPool(),
       spillConfig.executor);
@@ -442,9 +435,6 @@ void RowNumber::spill() {
   setupHashTableSpiller();
   setupInputSpiller();
 
-  std::vector<Spiller::SpillableStats> spillableStats(
-      hashTableSpiller_->hashBits().numPartitions());
-  hashTableSpiller_->fillSpillRuns(spillableStats);
   hashTableSpiller_->spill();
   hashTableSpiller_->finishSpill(spillHashTablePartitionSet_);
 

--- a/velox/exec/SortBuffer.h
+++ b/velox/exec/SortBuffer.h
@@ -57,11 +57,8 @@ class SortBuffer {
     return spillConfig_ != nullptr;
   }
 
-  /// Invoked to spill from 'data_' to disk with specified targets.
-  ///
-  /// NOTE: if either 'targetRows' or 'targetBytes' is zero, then we spill all
-  /// the rows from 'data_'.
-  void spill(int64_t targetRows, int64_t targetBytes);
+  /// Invoked to spill all the rows from 'data_'.
+  void spill();
 
   memory::MemoryPool* pool() const {
     return pool_;

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -377,7 +377,6 @@ std::unique_ptr<TreeOfLosers<SpillMergeStream>> SpillState::startMerge(
       result.push_back(FileSpillMergeStream::create(std::move(file)));
     }
   }
-  VELOX_CHECK_EQ(!result.empty(), isPartitionSpilled(partition));
   if (extra != nullptr) {
     result.push_back(std::move(extra));
   }

--- a/velox/exec/tests/AggregateSpillBenchmarkBase.cpp
+++ b/velox/exec/tests/AggregateSpillBenchmarkBase.cpp
@@ -71,10 +71,11 @@ void AggregateSpillBenchmarkBase::setUp() {
 void AggregateSpillBenchmarkBase::run() {
   MicrosecondTimer timer(&executionTimeUs_);
   if (spillerType_ == Spiller::Type::kAggregateInput) {
-    spiller_->spill(0, 0);
+    spiller_->spill();
   } else {
     spiller_->spill(RowContainerIterator{});
   }
+  rowContainer_->clear();
 }
 
 void AggregateSpillBenchmarkBase::printStats() const {
@@ -129,15 +130,11 @@ std::unique_ptr<Spiller> AggregateSpillBenchmarkBase::makeSpiller() const {
     return std::make_unique<Spiller>(
         spillerType_,
         rowContainer_.get(),
-        [&](folly::Range<char**> rows) { rowContainer_->eraseRows(rows); },
         rowType_,
-        HashBitRange{29, 29},
         rowContainer_->keyTypes().size(),
         std::vector<CompareFlags>{},
         spillDir_,
-        FLAGS_spiller_benchmark_max_spill_file_size,
         FLAGS_spiller_benchmark_write_buffer_size,
-        FLAGS_spiller_benchmark_min_spill_run_size,
         stringToCompressionKind(FLAGS_spiller_benchmark_compression_kind),
         spillerPool_.get(),
         executor_.get());
@@ -145,7 +142,6 @@ std::unique_ptr<Spiller> AggregateSpillBenchmarkBase::makeSpiller() const {
     return std::make_unique<Spiller>(
         spillerType_,
         rowContainer_.get(),
-        [&](folly::Range<char**> rows) { rowContainer_->eraseRows(rows); },
         rowType_,
         spillDir_,
         FLAGS_spiller_benchmark_write_buffer_size,

--- a/velox/exec/tests/JoinSpillInputBenchmarkBase.cpp
+++ b/velox/exec/tests/JoinSpillInputBenchmarkBase.cpp
@@ -39,7 +39,6 @@ void JoinSpillInputBenchmarkBase::setUp() {
       fmt::format("{}/{}", spillDir_, FLAGS_spiller_benchmark_name),
       FLAGS_spiller_benchmark_max_spill_file_size,
       FLAGS_spiller_benchmark_write_buffer_size,
-      FLAGS_spiller_benchmark_min_spill_run_size,
       stringToCompressionKind(FLAGS_spiller_benchmark_compression_kind),
       memory::spillMemoryPool(),
       executor_.get());

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -201,8 +201,7 @@ class OrderByTest : public OperatorTestBase {
         EXPECT_LT(0, spilledStats(*task).spilledBytes);
         EXPECT_EQ(1, spilledStats(*task).spilledPartitions);
         EXPECT_LT(0, spilledStats(*task).spilledFiles);
-        // NOTE: the last input batch won't go spilling.
-        EXPECT_GT(inputRows, spilledStats(*task).spilledRows);
+        EXPECT_EQ(inputRows, spilledStats(*task).spilledRows);
         ASSERT_EQ(memory::spillMemoryPool()->stats().currentBytes, 0);
         if (memory::spillMemoryPool()->trackUsage()) {
           ASSERT_GT(memory::spillMemoryPool()->stats().peakBytes, 0);
@@ -481,11 +480,11 @@ TEST_F(OrderByTest, spill) {
       params, "SELECT * FROM tmp ORDER BY c0 ASC NULLS LAST", {0});
   auto stats = task->taskStats().pipelineStats[0].operatorStats[1];
   ASSERT_GT(stats.spilledRows, 0);
-  ASSERT_LT(stats.spilledRows, kNumBatches * kNumRows);
+  ASSERT_EQ(stats.spilledRows, kNumBatches * kNumRows);
   ASSERT_GT(stats.spilledBytes, 0);
   ASSERT_GT(stats.spilledInputBytes, 0);
   ASSERT_EQ(stats.spilledPartitions, 1);
-  ASSERT_EQ(stats.spilledFiles, 2);
+  ASSERT_EQ(stats.spilledFiles, 3);
   ASSERT_GT(stats.runtimeStats["spillRuns"].count, 0);
   ASSERT_GT(stats.runtimeStats["spillFillTime"].sum, 0);
   ASSERT_GT(stats.runtimeStats["spillSortTime"].sum, 0);

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -417,7 +417,7 @@ TEST_F(SortBufferTest, spill) {
     if (!testData.spillTriggered) {
       ASSERT_FALSE(spillStats.has_value());
       if (!testData.spillEnabled) {
-        VELOX_ASSERT_THROW(sortBuffer->spill(0, 0), "spill config is null");
+        VELOX_ASSERT_THROW(sortBuffer->spill(), "spill config is null");
       }
     } else {
       ASSERT_TRUE(spillStats.has_value());
@@ -428,7 +428,7 @@ TEST_F(SortBufferTest, spill) {
       // SortBuffer shall not respect maxFileSize. Total files should be num
       // addInput() calls minus one which is the first one that has nothing to
       // spill.
-      ASSERT_EQ(spillStats->spilledFiles, 2);
+      ASSERT_EQ(spillStats->spilledFiles, 3);
       sortBuffer.reset();
       ASSERT_EQ(memory::spillMemoryPool()->stats().currentBytes, 0);
       if (memory::spillMemoryPool()->trackUsage()) {
@@ -460,7 +460,7 @@ TEST_F(SortBufferTest, emptySpill) {
         &spillConfig,
         0);
 
-    sortBuffer->spill(0, 0);
+    sortBuffer->spill();
     if (hasPostSpillData) {
       VectorFuzzer fuzzer({.vectorSize = 1024}, fuzzerPool.get());
       sortBuffer->addInput(fuzzer.fuzzRow(inputType_));


### PR DESCRIPTION
Remove the fine-grained the spilling control inside the spill execution framework.
We now only provide two spill APIs (except vector spill API) used by memory reclaim:
spill() and spill(row container iterator). Both spill all the rows from the row container.
The latter will only spill rows starting from the specified the row container iterator.
Internally, they call into the same spill() function which takes an optional row container
iterator. The spiller will mark all the partitions as spilled, then collect the rows to spill
from all the partitions and then spill them all from the row container.
To reduce the single row erase cost as today, we do not erase row inside the spiller but
let the user clear the row container at once after the spill completes. The experiment
shows for row type (int key + string dependent), the row erase time can be reduced up
to 200 times:
```
number of rows     single row erase.   row container clear
2K                 152us               50us   
200K               27.63ms             216us
2M                 275.26ms            1.32ms
```