### PR TITLE
Add AggregationBenchmarkBuilder

### DIFF
--- a/velox/benchmarks/AggregationBenchmarkBuilder.cpp
+++ b/velox/benchmarks/AggregationBenchmarkBuilder.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/benchmarks/AggregationBenchmarkBuilder.h"
+
+#include <folly/Benchmark.h>
+#include <string>
+
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+namespace facebook::velox {
+
+namespace {
+
+core::PlanNodePtr getAggregationPlan(
+    PlanType planType,
+    const std::vector<RowVectorPtr>& input,
+    const AggregationPair& aggregationPair,
+    memory::MemoryPool* pool) {
+  auto plan = exec::test::PlanBuilder(pool).values(input);
+  switch (planType) {
+    case kSingle:
+      plan.singleAggregation(
+          aggregationPair.groupingKeys, aggregationPair.aggregations);
+      break;
+    case kPartialFinal:
+      plan.partialAggregation(
+              aggregationPair.groupingKeys, aggregationPair.aggregations)
+          .finalAggregation();
+      break;
+    case kPartialIntermediateFinal:
+      plan.partialAggregation(
+              aggregationPair.groupingKeys, aggregationPair.aggregations)
+          .intermediateAggregation()
+          .finalAggregation();
+      break;
+    default:
+      VELOX_UNREACHABLE("Not a valid plan type.");
+  }
+  return plan.planNode();
+}
+
+} // namespace
+
+void AggregationBenchmarkBuilder::ensureInputVectors() {
+  for (auto& [_, benchmarkSet] : benchmarkSets_) {
+    VectorFuzzer fuzzer(benchmarkSet.fuzzerOptions_, pool_.get());
+    benchmarkSet.inputRowVectors_.insert(
+        benchmarkSet.inputRowVectors_.end(),
+        benchmarkSet.iterations_,
+        std::dynamic_pointer_cast<RowVector>(
+            fuzzer.fuzzFlat(benchmarkSet.inputType_)));
+  }
+}
+
+void AggregationBenchmarkBuilder::registerBenchmarks() {
+  ensureInputVectors();
+
+  for (auto& [setName, benchmarkSet] : benchmarkSets_) {
+    for (auto& [aggregationPairName, aggregationPair] :
+         benchmarkSet.aggregations_) {
+      auto name = fmt::format("{}##{}", setName, aggregationPairName);
+      auto& inputVectors = benchmarkSet.inputRowVectors_;
+      auto planType = benchmarkSet.planType_;
+      auto& aggregationPairLocal = aggregationPair;
+
+      folly::addBenchmark(
+          __FILE__,
+          name,
+          [this, &inputVectors, &aggregationPairLocal, planType]() {
+            int cnt = 0;
+            folly::BenchmarkSuspender suspender;
+
+            auto plan = getAggregationPlan(
+                planType, inputVectors, aggregationPairLocal, pool_.get());
+
+            std::shared_ptr<folly::Executor> executor{
+                std::make_shared<folly::CPUThreadPoolExecutor>(
+                    std::thread::hardware_concurrency())};
+            auto task = exec::Task::create(
+                "aggregation benchmark task",
+                core::PlanFragment{
+                    plan, core::ExecutionStrategy::kUngrouped, 1, {}},
+                0,
+                std::make_shared<core::QueryCtx>(executor.get()));
+
+            suspender.dismiss();
+
+            auto result = task->next();
+            while (result != nullptr) {
+              cnt += result->size();
+              result = task->next();
+            }
+            folly::doNotOptimizeAway(cnt);
+            return 1;
+          });
+    }
+    BENCHMARK_DRAW_LINE();
+    BENCHMARK_DRAW_LINE();
+  }
+}
+
+} // namespace facebook::velox

--- a/velox/benchmarks/AggregationBenchmarkBuilder.h
+++ b/velox/benchmarks/AggregationBenchmarkBuilder.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/Task.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+namespace facebook::velox {
+
+enum PlanType { kSingle, kPartialFinal, kPartialIntermediateFinal };
+
+struct AggregationPair {
+  std::vector<std::string> groupingKeys;
+  std::vector<std::string> aggregations;
+};
+
+struct AggregationBenchmarkSet {
+  explicit AggregationBenchmarkSet(const TypePtr& inputType)
+      : inputType_{inputType} {}
+
+  AggregationBenchmarkSet& addAggregations(
+      const std::string& name,
+      const std::vector<std::string>& groupingKeys,
+      const std::vector<std::string>& aggregations) {
+    aggregations_.push_back({name, {groupingKeys, aggregations}});
+    return *this;
+  }
+
+  AggregationBenchmarkSet& withFuzzerOptions(
+      const VectorFuzzer::Options& options) {
+    fuzzerOptions_ = options;
+    return *this;
+  }
+
+  AggregationBenchmarkSet& withIterations(int iterations) {
+    iterations_ = iterations;
+    return *this;
+  }
+
+  AggregationBenchmarkSet& withPlanType(PlanType planType) {
+    planType_ = planType;
+    return *this;
+  }
+
+  std::vector<std::pair<std::string, AggregationPair>> aggregations_;
+
+  // The input that will be used for for benchmarking aggregations. If not set,
+  // a flat input vector is fuzzed using fuzzerOptions_.
+  std::vector<RowVectorPtr> inputRowVectors_;
+
+  // The type of the input that will be used for all the aggregations
+  // benchmarked.
+  TypePtr inputType_;
+
+  // User can provide fuzzer options for the input row vector used for this
+  // benchmark. Note that the fuzzer will be used to generate a flat input row
+  // vector if inputRowVector_ is nullptr.
+  VectorFuzzer::Options fuzzerOptions_{.vectorSize = 10000, .nullRatio = 0};
+
+  // Number of times to run each benchmark.
+  int iterations_ = 1000;
+
+  PlanType planType_ = PlanType::kSingle;
+};
+
+class AggregationBenchmarkBuilder {
+ public:
+  explicit AggregationBenchmarkBuilder() {}
+
+  // Register all the benchmarks, so that they would run when
+  // folly::runBenchmarks() is called.
+  void registerBenchmarks();
+
+  AggregationBenchmarkSet& addBenchmarkSet(
+      const std::string& name,
+      const TypePtr& inputType) {
+    VELOX_CHECK(!benchmarkSets_.count(name));
+    benchmarkSets_.emplace(name, AggregationBenchmarkSet(inputType));
+    return benchmarkSets_.at(name);
+  }
+
+ private:
+  void ensureInputVectors();
+
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+
+  std::map<std::string, AggregationBenchmarkSet> benchmarkSets_;
+};
+
+} // namespace facebook::velox

--- a/velox/benchmarks/CMakeLists.txt
+++ b/velox/benchmarks/CMakeLists.txt
@@ -33,6 +33,11 @@ target_link_libraries(velox_benchmark_builder ${velox_benchmark_deps})
 # This is a workaround for the use of VectorTestBase.h which includes gtest.h
 target_link_libraries(velox_benchmark_builder gtest)
 
+add_library(velox_aggregation_benchmark_builder AggregationBenchmarkBuilder.cpp)
+target_link_libraries(
+  velox_aggregation_benchmark_builder velox_exec velox_exec_test_lib
+  velox_vector_fuzzer ${FOLLY_BENCHMARK})
+
 if(${VELOX_ENABLE_BENCHMARKS})
   add_subdirectory(tpch)
 endif()

--- a/velox/functions/prestosql/benchmarks/AverageAggregateBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/AverageAggregateBenchmark.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include "velox/benchmarks/AggregationBenchmarkBuilder.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+  aggregate::prestosql::registerAllAggregateFunctions();
+
+  AggregationBenchmarkBuilder benchmarkBuilder;
+  auto inputType = ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), DOUBLE()});
+
+  benchmarkBuilder.addBenchmarkSet("avg_single", inputType)
+      .addAggregations("integer", {"c0"}, {"avg(c1)"})
+      .addAggregations("double", {"c0"}, {"avg(c2)"})
+      .withPlanType(kSingle)
+      .withIterations(10);
+
+  benchmarkBuilder.addBenchmarkSet("avg_partial_final", inputType)
+      .addAggregations("integer", {"c0"}, {"avg(c1)"})
+      .addAggregations("double", {"c0"}, {"avg(c2)"})
+      .withPlanType(kPartialFinal)
+      .withIterations(10);
+
+  benchmarkBuilder.addBenchmarkSet("avg_partial_intermediate_final", inputType)
+      .addAggregations("integer", {"c0"}, {"avg(c1)"})
+      .addAggregations("double", {"c0"}, {"avg(c2)"})
+      .withPlanType(kPartialIntermediateFinal)
+      .withIterations(10);
+
+  benchmarkBuilder.registerBenchmarks();
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -176,3 +176,8 @@ add_executable(velox_functions_prestosql_benchmarks_map_subscript
                MapSubscriptCachingBenchmark.cpp)
 target_link_libraries(velox_functions_prestosql_benchmarks_map_subscript
                       ${BENCHMARK_DEPENDENCIES})
+
+add_executable(velox_functions_prestosql_benchmarks_avg
+               AverageAggregateBenchmark.cpp)
+target_link_libraries(velox_functions_prestosql_benchmarks_avg velox_aggregates
+                      velox_aggregation_benchmark_builder ${FOLLY_BENCHMARK})


### PR DESCRIPTION
Summary:
Add AggregationBenchmarkBuilder to allow easy creation of benchmark for
aggregation functions. AggregationBenchmarkBuilder currently allows three
plan types: single aggregation, partial + final aggregation, and partial +
intermediate + final aggregation. Input is read from ValuesNode.

Differential Revision: D50765523


