### PR TITLE
Null fixes on Arrow bridge

### DIFF
--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -107,10 +107,7 @@ class ArrowBridgeArrayExportTest : public testing::Test {
     EXPECT_EQ(nullptr, arrowArray.dictionary);
     EXPECT_NE(nullptr, arrowArray.release);
 
-    bool isNullLayout = validateNulls(inputData, arrowArray);
-    if (isNullLayout) {
-      return;
-    }
+    validateNulls(inputData, arrowArray);
 
     // Validate array contents.
     if constexpr (isString) {
@@ -185,32 +182,24 @@ class ArrowBridgeArrayExportTest : public testing::Test {
 
   // Validate nulls and returns whether this array uses Arrow's Null Layout.
   template <typename T>
-  bool validateNulls(
+  void validateNulls(
       const std::vector<std::optional<T>>& inputData,
       const ArrowArray& arrowArray) {
     size_t nullCount =
         std::count(inputData.begin(), inputData.end(), std::nullopt);
-    if (arrowArray.null_count != -1) {
-      EXPECT_EQ(nullCount, arrowArray.null_count);
-    }
-
-    // If every element is null, check if it's using arrow's Null Layout.
-    if (!inputData.empty() && (nullCount == inputData.size())) {
-      // TODO: FlatVectors containing only null values are not generating Null
-      // Layout today. Need to fix that before uncommenting these checks.
-      // EXPECT_EQ(arrowArray.buffers, nullptr);
-      // EXPECT_EQ(arrowArray.children, nullptr);
-      // EXPECT_EQ(arrowArray.n_buffers, 0);
-      // EXPECT_EQ(arrowArray.n_children, 0);
-      return true;
-    }
+    EXPECT_EQ(arrowArray.null_count, nullCount);
 
     if (arrowArray.null_count == 0) {
       EXPECT_EQ(arrowArray.buffers[0], nullptr);
     } else {
       EXPECT_NE(arrowArray.buffers[0], nullptr);
+      EXPECT_EQ(
+          arrowArray.null_count,
+          bits::countNulls(
+              static_cast<const uint64_t*>(arrowArray.buffers[0]),
+              0,
+              inputData.size()));
     }
-    return false;
   }
 
   template <typename T>


### PR DESCRIPTION
Summary:
Ensure null_count is always set, add support for null constants, and
enhance tests to check the bitmap values match null_count.

Differential Revision: D50997553


