### PR TITLE
Hive sort writer memory reclaim code refactor and some fixes

### DIFF
--- a/velox/common/file/File.cpp
+++ b/velox/common/file/File.cpp
@@ -258,9 +258,10 @@ void LocalWriteFile::append(std::string_view data) {
   VELOX_CHECK_EQ(
       bytes_written,
       data.size(),
-      "fwrite failure in LocalWriteFile::append, {} vs {}.",
+      "fwrite failure in LocalWriteFile::append, {} vs {}: {}",
       bytes_written,
-      data.size());
+      data.size(),
+      folly::errnoStr(errno));
 }
 
 void LocalWriteFile::flush() {

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -266,15 +266,6 @@ class QueryConfig {
   static constexpr const char* kJoinSpillPartitionBits =
       "join_spiller_partition_bits";
 
-  static constexpr const char* kAggregationSpillPartitionBits =
-      "aggregation_spiller_partition_bits";
-
-  /// If true and spilling has been triggered during the input processing, the
-  /// spiller will spill all the remaining in-memory state to disk before output
-  /// processing. This is to simplify the aggregation query OOM prevention in
-  /// output processing stage.
-  static constexpr const char* kAggregationSpillAll = "aggregation_spill_all";
-
   static constexpr const char* kMinSpillableReservationPct =
       "min_spillable_reservation_pct";
 
@@ -552,22 +543,6 @@ class QueryConfig {
     constexpr uint8_t kMaxBits = 3;
     return std::min(
         kMaxBits, get<uint8_t>(kJoinSpillPartitionBits, kDefaultBits));
-  }
-
-  /// Returns the number of bits used to calculate the spilling partition
-  /// number for hash join. The number of spilling partitions will be power of
-  /// two.
-  ///
-  /// NOTE: as for now, we only support up to 8-way spill partitioning.
-  uint8_t aggregationSpillPartitionBits() const {
-    constexpr uint8_t kDefaultBits = 0;
-    constexpr uint8_t kMaxBits = 3;
-    return std::min(
-        kMaxBits, get<uint8_t>(kAggregationSpillPartitionBits, kDefaultBits));
-  }
-
-  bool aggregationSpillAll() const {
-    return get<bool>(kAggregationSpillAll, true);
   }
 
   uint64_t writerFlushThresholdBytes() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -223,12 +223,6 @@ Spilling
      - integer
      - 0
      - Maximum amount of memory in bytes that a final aggregation can use before spilling. 0 means unlimited.
-   * - aggregation_spill_all
-     - boolean
-     - false
-     - If true and spilling has been triggered during the input processing, the spiller will spill all the remaining
-       in-memory state to disk before output processing. This is to simplify the aggregation query OOM prevention in
-       output processing stage.
    * - join_spill_memory_threshold
      - integer
      - 0
@@ -294,12 +288,7 @@ Spilling
      - integer
      - 2
      - The number of bits (N) used to calculate the spilling partition number for hash join and RowNumber: 2 ^ N. At the moment the maximum
-       value is 3, meaning we only support up to 8-way spill partitioning.
-   * - aggregation_spiller_partition_bits
-     - integer
-     - 0
-     - The number of bits (N) used to calculate the spilling partition number for hash aggregation: 2 ^ N. At the moment the
-       maximum value is 3, meaning we only support up to 8-way spill partitioning.
+       value is 3, meaning we only support up to 8-way spill partitioning.ing.
    * - testing.spill_pct
      - integer
      - 0

--- a/velox/dwio/common/SortingWriter.h
+++ b/velox/dwio/common/SortingWriter.h
@@ -64,12 +64,17 @@ class SortingWriter : public Writer {
     const bool canReclaim_;
   };
 
+  bool canReclaim() const;
+
+  uint64_t reclaim(uint64_t targetBytes, memory::MemoryReclaimer::Stats& stats);
+
   // Sets the sort writer as closed on close or abort. The function returns true
   // if this sort writer has already been closed.
   bool setClose();
 
   const std::unique_ptr<Writer> outputWriter_;
   memory::MemoryPool* const sortPool_;
+  const bool canReclaim_;
   bool closed_{false};
   std::unique_ptr<exec::SortBuffer> sortBuffer_;
 };

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -500,18 +500,6 @@ class HashTable : public BaseHashTable {
     setHashMode(mode, numNew);
   }
 
-  void testingStoreRowPointer(uint64_t index, uint64_t hash, char* row) {
-    storeRowPointer(index, hash, row);
-  }
-
-  auto testingLoadTags(uint64_t bucketOffset) {
-    return loadTags(bucketOffset);
-  }
-
-  auto testingGetRow(uint64_t bucketOffset, uint64_t slotIndex) {
-    return row(bucketOffset, slotIndex);
-  }
-
   auto& testingOtherTables() const {
     return otherTables_;
   }

--- a/velox/exec/tests/AggregateSpillBenchmarkBase.cpp
+++ b/velox/exec/tests/AggregateSpillBenchmarkBase.cpp
@@ -61,7 +61,7 @@ void AggregateSpillBenchmarkBase::writeSpillData() {
   }
 
   std::vector<char*> rows;
-  rows.reserve(numRows);
+  rows.resize(numRows);
   for (int i = 0; i < numRows; ++i) {
     rows[i] = rowContainer_->newRow();
   }

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -827,31 +827,6 @@ TEST_P(HashTableTest, offsetOverflowLoadTags) {
   }
 }
 
-TEST_P(HashTableTest, offsetOverflowStoreRowPointer) {
-  std::vector<std::unique_ptr<VectorHasher>> hashers;
-  hashers.push_back(std::make_unique<VectorHasher>(TINYINT(), 0));
-  auto table = HashTable<false>::createForJoin(
-      std::move(hashers),
-      {} /*dependentTypes=*/,
-      true,
-      false,
-      1'000,
-      pool_.get());
-  table->testingSetHashMode(
-      BaseHashTable::HashMode::kNormalizedKey, 700'000'000);
-  // Set greater than INT_MAX bucketOffset.
-  uint64_t bucketOffset = 2'848'622'336;
-  // Setting random value and hash value.
-  uint8_t value = 10;
-  uint64_t hash = 168'520'4148'842'825'593;
-  table->testingStoreRowPointer(bucketOffset, hash, (char*)&value);
-  auto expectedTag = BaseHashTable::hashTag(hash);
-  auto actualTagSimdBatch = table->testingLoadTags(bucketOffset);
-  ASSERT_EQ(expectedTag, actualTagSimdBatch.get(0));
-  auto slotIndex = bucketOffset & (sizeof(BaseHashTable::TagVector) - 1);
-  ASSERT_EQ(value, *(uint8_t*)table->testingGetRow(bucketOffset, slotIndex));
-}
-
 DEBUG_ONLY_TEST_P(HashTableTest, failureInCreateRowPartitions) {
   // This tests an issue in parallelJoinBuild where an exception in
   // createRowPartitions could lead to concurrency issues in async table


### PR DESCRIPTION
- Hive sort writer code refactor to move memory reclaim processing
   control into sort writer to ease the output buffer size control logic
- Improve local data sink error log
- Fix a bug in spiller aggregation input benchmark
- Remove some deprecated code