### PR TITLE
Add parseType API in DuckDB parser

### DIFF
--- a/velox/duckdb/conversion/DuckConversion.h
+++ b/velox/duckdb/conversion/DuckConversion.h
@@ -215,4 +215,52 @@ std::string makeCreateTableSql(
     const std::string& tableName,
     const RowType& rowType);
 
+/// Velox has a different declaration way of complex type with DuckDB, say
+/// 'row(bigint,double)' in Velox must be changed to
+/// 'struct(c0 bigint, c1 double)' to be parsed by the DuckDB parser.
+/// This method does this kind of transformation on a Velox-type JSON object
+/// making the output can be parsed by the DuckDB parser.
+/// For example, the following JSON string is a result columns return a
+/// PrestoQueryRunner, its velox type string is
+/// 'row(array(map(varchar,bigint)),array(array(bigint)))', it would be
+/// transformed to struct(s0 map(varchar,bigint)[],s1 bigint[][]).
+/// {
+///   "rawType":"row",
+///   "typeArguments":[
+///     {
+///       "rawType":"array",
+///       "typeArguments":[
+///         {
+///           "rawType":"map",
+///           "typeArguments":[
+///             {
+///               "rawType":"varchar",
+///               "typeArguments":[]
+///             },
+///             {
+///               "rawType":"bigint",
+///               "typeArguments":[]
+///             }
+///           ]
+///         }
+///       ]
+///     },
+///     {
+///       "rawType":"array",
+///       "typeArguments":[
+///         {
+///           "rawType":"array",
+///           "typeArguments":[
+///             {
+///               "rawType":"bigint",
+///               "typeArguments":[]
+///             }
+///           ]
+///         }
+///       ]
+///     }
+///   ]
+/// }
+std::string toDuckTypeString(const folly::dynamic& veloxTypeJsonObject);
+
 } // namespace facebook::velox::duckdb

--- a/velox/duckdb/conversion/DuckParser.cpp
+++ b/velox/duckdb/conversion/DuckParser.cpp
@@ -26,6 +26,7 @@ namespace facebook::velox::duckdb {
 using ::duckdb::BetweenExpression;
 using ::duckdb::CaseExpression;
 using ::duckdb::CastExpression;
+using ::duckdb::ColumnDefinition;
 using ::duckdb::ColumnRefExpression;
 using ::duckdb::ComparisonExpression;
 using ::duckdb::ConjunctionExpression;
@@ -33,6 +34,7 @@ using ::duckdb::ConstantExpression;
 using ::duckdb::ExpressionClass;
 using ::duckdb::ExpressionType;
 using ::duckdb::FunctionExpression;
+using ::duckdb::LogicalType;
 using ::duckdb::LogicalTypeId;
 using ::duckdb::LogicalTypeIdToString;
 using ::duckdb::OperatorExpression;
@@ -648,7 +650,21 @@ std::unique_ptr<::duckdb::ParsedExpression> parseSingleExpression(
       1, parsed.size(), "Expected exactly one expression: {}.", exprString);
   return std::move(parsed.front());
 }
+
+std::vector<::duckdb::LogicalType> ParseColumns(const std::string& columns) {
+  auto parsedColumns = Parser::ParseColumnList(columns);
+  std::vector<::duckdb::LogicalType> types;
+  types.reserve(columns.size());
+  for (const auto& column : parsedColumns) {
+    types.emplace_back(column.Type());
+  }
+  return types;
+}
 } // namespace
+
+TypePtr parseType(const std::string& typeString) {
+  return toVeloxType(ParseColumns(fmt::format("col {}", typeString)).front());
+}
 
 std::shared_ptr<const core::IExpr> parseExpr(
     const std::string& exprString,

--- a/velox/duckdb/conversion/DuckParser.h
+++ b/velox/duckdb/conversion/DuckParser.h
@@ -18,6 +18,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include "velox/type/Type.h"
 
 namespace facebook::velox::core {
 class IExpr;
@@ -44,6 +45,9 @@ struct ParseOptions {
 // are lower-cased, what prevents you to use functions and column names
 // containing upper case letters (e.g: "concatRow" will be parsed as
 // "concatrow").
+
+TypePtr parseType(const std::string& typeString);
+
 std::shared_ptr<const core::IExpr> parseExpr(
     const std::string& exprString,
     const ParseOptions& options);

--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -746,3 +746,25 @@ TEST(DuckParserTest, lambda) {
       parseExpr("filter(a, if (b > 0, x -> (x = 10), x -> (x = 20)))")
           ->toString());
 }
+
+TEST(DuckParserTest, type) {
+  EXPECT_EQ(SMALLINT(), parseType("smallint"));
+  EXPECT_EQ(INTEGER(), parseType("integer"));
+  EXPECT_EQ(BIGINT(), parseType("bigint"));
+  EXPECT_EQ(DOUBLE(), parseType("double"));
+  EXPECT_EQ(REAL(), parseType("float"));
+  EXPECT_EQ(BOOLEAN(), parseType("bool"));
+
+  EXPECT_NE(BIGINT(), parseType("integer"));
+  EXPECT_NE(BIGINT(), parseType("double"));
+  EXPECT_NE(BOOLEAN(), parseType("integer"));
+
+  EXPECT_TRUE(DECIMAL(32, 8)->equivalent(*parseType("decimal(32, 8)")));
+  EXPECT_TRUE(ARRAY(BIGINT())->equivalent(*parseType("bigint[]")));
+  EXPECT_TRUE(MAP(BIGINT(), ARRAY(ROW({VARCHAR(), DOUBLE()})))
+                  ->equivalent(*parseType(
+                      "map(bigint, struct(r0 varchar, r1 double)[])")));
+  EXPECT_TRUE(ROW({ARRAY(MAP(VARCHAR(), BIGINT())), ARRAY(ARRAY(BIGINT()))})
+                  ->equivalent(*parseType(
+                      "struct(s0 map(varchar,bigint)[],s1 bigint[][])")));
+}


### PR DESCRIPTION
In PrestoQueryRunner, it would use the result of the
SQL execution from the server side including the
columns and data to construct a Velox `RowVector`
to compare with Velox's result.  This PR is the step-2
of adding PrestoQeryRunner in Velox,
1. Add a type parser API in the DuckDB parser to
  parse the type string to Velox type.
2. Add a transform API to transform the JSON object
of the columns type info of the SQL execution result to a
type string that can be parsed by the DuckDB parser. 

