### PR TITLE
Fix data race in cache stats access

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -671,8 +671,8 @@ bool AsyncDataCache::makeSpace(
       sizeMultiplier *= 2;
     }
   }
-  memory::setCacheFailureMessage(
-      fmt::format("After failing to evict from cache state: {}", toString()));
+  memory::setCacheFailureMessage(fmt::format(
+      "After failing to evict from cache state: {}", toString(false)));
   return false;
 }
 
@@ -756,16 +756,18 @@ void AsyncDataCache::clear() {
   }
 }
 
-std::string AsyncDataCache::toString() const {
+std::string AsyncDataCache::toString(bool details) const {
   auto stats = refreshStats();
   std::stringstream out;
   out << "AsyncDataCache:\n"
       << stats.toString() << "\n"
       << "Allocated pages: " << allocator_->numAllocated()
       << " cached pages: " << cachedPages_ << "\n";
-  out << "Backing: " << allocator_->toString();
-  if (ssdCache_) {
-    out << "\nSSD: " << ssdCache_->toString();
+  if (details) {
+    out << "Backing: " << allocator_->toString();
+    if (ssdCache_) {
+      out << "\nSSD: " << ssdCache_->toString();
+    }
   }
   return out.str();
 }

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -696,7 +696,9 @@ class AsyncDataCache : public memory::Cache {
 
   CacheStats refreshStats() const;
 
-  std::string toString() const;
+  /// If 'details' is true, returns the stats of the backing memory allocator
+  /// and ssd cache. Otherwise, only returns the cache stats.
+  std::string toString(bool details = true) const;
 
   memory::MachinePageCount incrementCachedPages(int64_t pages) {
     // The counter is unsigned and the increment is signed.

--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -814,8 +814,7 @@ TEST_F(AsyncDataCacheTest, cacheStats) {
   constexpr uint64_t kRamBytes = 32 << 20;
   constexpr uint64_t kSsdBytes = 512UL << 20;
   initializeCache(kRamBytes, kSsdBytes);
-  ASSERT_EQ(
-      cache_->toString(),
+  const std::string expectedDetailedCacheOutput =
       "AsyncDataCache:\n"
       "Cache size: 0B tinySize: 0B large size: 0B\n"
       "Cache entries: 0 read pins: 0 write pins: 0 pinned shared: 0B pinned exclusive: 0B\n"
@@ -836,5 +835,17 @@ TEST_F(AsyncDataCacheTest, cacheStats) {
       "[size 256: 0(0MB) allocated 0 mapped]\n"
       "]\n"
       "SSD: Ssd cache IO: Write 0MB read 0MB Size 0GB Occupied 0GB0K entries.\n"
-      "GroupStats: <dummy FileGroupStats>");
+      "GroupStats: <dummy FileGroupStats>";
+  ASSERT_EQ(cache_->toString(), expectedDetailedCacheOutput);
+  ASSERT_EQ(cache_->toString(true), expectedDetailedCacheOutput);
+  const std::string expectedShortCacheOutput =
+      "AsyncDataCache:\n"
+      "Cache size: 0B tinySize: 0B large size: 0B\n"
+      "Cache entries: 0 read pins: 0 write pins: 0 pinned shared: 0B pinned exclusive: 0B\n"
+      " num write wait: 0 empty entries: 0\n"
+      "Cache access miss: 0 hit: 0 hit bytes: 0B eviction: 0 eviction checks: 0\n"
+      "Prefetch entries: 0 bytes: 0B\n"
+      "Alloc Megaclocks 0\n"
+      "Allocated pages: 0 cached pages: 0\n";
+  ASSERT_EQ(cache_->toString(false), expectedShortCacheOutput);
 }

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -275,7 +275,7 @@ class MmapAllocator : public MemoryAllocator {
     const int32_t pageBitmapSize_;
 
     // Serializes access to all data members and private methods.
-    std::mutex mutex_;
+    mutable std::mutex mutex_;
 
     // Start of address range.
     uint8_t* address_;


### PR DESCRIPTION
Fix a data race when log size class stats from memory allocator which is
detected by tsan test mode after we include cache error stats in memory
allocation failure. We don't hold the lock to access size class internal stats.
Also this PR removing the backing memory and ssd cache stats from cache
error log which is not that useful for in-memory allocation failure debugging
to reduce the log volume.