### PR TITLE
Back out "Optimize remaining filter evaluation"

### DIFF
--- a/velox/expression/ConjunctExpr.h
+++ b/velox/expression/ConjunctExpr.h
@@ -82,10 +82,6 @@ class ConjunctExpr : public SpecialForm {
       FlatVector<bool>* result,
       SelectivityVector* activeRows);
 
-  bool evaluatesArgumentsOnNonIncreasingSelection() const override {
-    return isAnd_;
-  }
-
   // true if conjunction (and), false if disjunction (or).
   const bool isAnd_;
 

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -831,8 +831,7 @@ void Expr::eval(
     for (auto* field : distinctFields_) {
       context.ensureFieldLoaded(field->index(context), rows);
     }
-  } else if (
-      !propagatesNulls_ && !evaluatesArgumentsOnNonIncreasingSelection()) {
+  } else if (!propagatesNulls_) {
     // Load multiply-referenced fields at common parent expr with "rows".
     // Delay loading fields that are not in multiplyReferencedFields_.
     for (const auto& field : multiplyReferencedFields_) {

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -549,16 +549,6 @@ class Expr {
   // referenced fields.
   virtual void computeDistinctFields();
 
-  // True if this is a spcial form where the next argument will always be
-  // evaluated on a subset of the rows for which the previous one was evaluated.
-  // This is true of AND and no other at this time.  This implies that lazies
-  // can be loaded on first use and not before starting evaluating the form.
-  // This is so because a subsequent use will never access rows that were not in
-  // scope for the previous one.
-  virtual bool evaluatesArgumentsOnNonIncreasingSelection() const {
-    return false;
-  }
-
   const TypePtr type_;
   const std::vector<std::shared_ptr<Expr>> inputs_;
   const std::string name_;

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -4256,7 +4256,7 @@ TEST_P(ParameterizedExprTest, lazyHandlingByDereference) {
   // Ensure FieldReference handles an input which has an encoding over a lazy
   // vector. Trying to access the inner flat vector of an input in the form
   // Row(Dict(Lazy(Row(Flat)))) will ensure an intermediate FieldReference
-  // expression in the tree receives an input of the form Dict(Lazy(Row(Flat))).
+  // expression in the tree recieves an input of the form Dict(Lazy(Row(Flat))).
   auto base = makeRowVector(
       {makeNullableFlatVector<int32_t>({1, std::nullopt, 3, 4, 5})});
   VectorPtr col1 = std::make_shared<LazyVector>(
@@ -4406,80 +4406,6 @@ TEST_P(ParameterizedExprTest, coalesceRowInputTypesAreTheSame) {
         "plus");
 
     ASSERT_NO_THROW(compileExpression(plus));
-  }
-}
-
-TEST_P(ParameterizedExprTest, evaluatesArgumentsOnNonIncreasingSelection) {
-  auto makeLazy = [&](const auto& base, const auto& check) {
-    return std::make_shared<LazyVector>(
-        execCtx_->pool(),
-        base->type(),
-        base->size(),
-        std::make_unique<test::SimpleVectorLoader>([&](auto rows) {
-          check(rows);
-          return base;
-        }));
-  };
-  constexpr int kSize = 300;
-  auto c0 = makeFlatVector<int64_t>(kSize, folly::identity);
-  {
-    SCOPED_TRACE("No eager loading for AND clauses");
-    auto input = makeRowVector({
-        c0,
-        makeLazy(
-            c0,
-            [](auto& rows) {
-              // Only the rows passing c0 % 2 == 0 should be loaded.
-              VELOX_CHECK_EQ(rows.size(), (kSize + 1) / 2);
-              for (auto i : rows) {
-                VELOX_CHECK(i % 2 == 0);
-              }
-            }),
-    });
-    auto actual =
-        evaluate("c0 % 2 == 0 and c1 % 3 == 0 and c1 % 5 == 0", input);
-    auto expected =
-        makeFlatVector<bool>(kSize, [](auto i) { return i % 30 == 0; });
-    assertEqualVectors(expected, actual);
-  }
-  {
-    SCOPED_TRACE("IF inside AND");
-    auto input = makeRowVector({
-        c0,
-        makeLazy(
-            c0,
-            [](auto& rows) {
-              // Only the rows passing c0 % 2 == 0 should be loaded.
-              VELOX_CHECK_EQ(rows.size(), (kSize + 1) / 2);
-              for (auto i : rows) {
-                VELOX_CHECK(i % 2 == 0);
-              }
-            }),
-    });
-    auto actual =
-        evaluate("c0 % 2 == 0 and if (c0 % 3 == 0, c1, -1 * c1) >= 0", input);
-    auto expected =
-        makeFlatVector<bool>(kSize, [](auto i) { return i % 6 == 0; });
-    assertEqualVectors(expected, actual);
-  }
-  {
-    SCOPED_TRACE("AND inside IF");
-    auto input = makeRowVector({
-        c0,
-        makeLazy(
-            c0,
-            [&](auto& rows) {
-              // All rows should be loaded.
-              VELOX_CHECK_EQ(rows.size(), kSize);
-            }),
-    });
-    auto actual = evaluate(
-        "if (c0 % 2 == 0, c1 % 3 == 0 and c1 % 5 == 0, c1 % 7 == 0 and c1 % 11 == 0)",
-        input);
-    auto expected = makeFlatVector<bool>(kSize, [](auto i) {
-      return (i % 2 == 0 && i % 15 == 0) || (i % 2 != 0 && i % 77 == 0);
-    });
-    assertEqualVectors(expected, actual);
   }
 }
 


### PR DESCRIPTION
Summary:
Original commit changeset: af24a4b1b9eb


The PR  https://github.com/facebookincubator/velox/pull/7260 introduce a bug in loading rows details in
 https://github.com/facebookincubator/velox/issues/7401
Some rows are not loaded when the vector is first loaded but they should

Original Phabricator Diff: D50700083

Differential Revision: D51004757


