### PR TITLE
Remove the `re2:re2` alias

### DIFF
--- a/CMake/resolve_dependency_modules/re2.cmake
+++ b/CMake/resolve_dependency_modules/re2.cmake
@@ -44,7 +44,6 @@ endif()
 
 set(re2_LIBRARIES ${re2_BINARY_DIR}/libre2.a)
 set(re2_INCLUDE_DIRS ${re2_SOURCE_DIR})
-add_library(re2::re2 ALIAS re2)
 
 set(RE2_ROOT ${re2_BINARY_DIR})
 set(re2_ROOT ${re2_BINARY_DIR})


### PR DESCRIPTION
CMake complained that `re2:re2` was already defined. The exact error was:

```
[cmake] -- Setting re2 source to AUTO
[cmake] -- Could NOT find re2 (missing: re2_lib re2_include) 
[cmake] -- Building re2 from source
[cmake] CMake Error at /Users/r_rahman/vcpkg/scripts/buildsystems/vcpkg.cmake:639 (_add_library):
[cmake]   _add_library cannot create ALIAS target "re2::re2" because another target
[cmake]   with the same name already exists.
[cmake] Call Stack (most recent call first):
[cmake]   build/_deps/velox-src/CMake/resolve_dependency_modules/re2.cmake:47 (add_library)
[cmake]   build/_deps/velox-src/CMake/ResolveDependency.cmake:43 (include)
[cmake]   build/_deps/velox-src/CMake/ResolveDependency.cmake:75 (build_dependency)
[cmake]   build/_deps/velox-src/CMakeLists.txt:428 (resolve_dependency)
```

Without the `add_library(re2::re2 ALIAS re2)`, the build succeeded.