### PR TITLE
Fix flaky HashJoinTest test cases

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1448,6 +1448,7 @@ void HashProbe::abort() {
   output_.reset();
   nonSpillInputIndicesBuffer_.reset();
   spillInputIndicesBuffers_.clear();
+  spillInputReader_.reset();
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -644,7 +644,6 @@ class HashJoinBuilder {
         }
         verifyTaskSpilledRuntimeStats(*task, true);
       }
-      ASSERT_EQ(memory::spillMemoryPool()->stats().currentBytes, 0);
       if (statsPair.first.spilledBytes > 0 &&
           memory::spillMemoryPool()->trackUsage()) {
         ASSERT_GT(memory::spillMemoryPool()->stats().peakBytes, 0);
@@ -666,13 +665,12 @@ class HashJoinBuilder {
       ASSERT_EQ(statsPair.second.spilledFiles, 0);
       verifyTaskSpilledRuntimeStats(*task, false);
     }
-    ASSERT_EQ(memory::spillMemoryPool()->stats().currentBytes, 0);
     // Customized test verification.
     if (testVerifier_ != nullptr) {
       testVerifier_(task, injectSpill);
     }
-
     OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
+    ASSERT_EQ(memory::spillMemoryPool()->stats().currentBytes, 0);
   }
 
   VectorFuzzer::Options fuzzerOpts_;


### PR DESCRIPTION
Current hash probe un-spill path will hold buffer allocated from spill memory pool
on un-spill path which is freed until the hash probe destruction.
This PR fixes the following flaky tests by check spill memory usage after task has
been destroyed. Also add to reset spill reader in hash probe abort:

- HashJoinTest/MultiThreadedHashJoinTest.antiJoin
- MultiThreadedHashJoinTest.leftSemiJoinFilterWithEmptyBuild
- HashJoinTest.memoryUsage

The followup will switch to use operator memory pool for read which shouldn't use
the spill memory pool
