### PR TITLE
Add kAggregateOutput spiller in AggregateSpillBenchmark

### DIFF
--- a/velox/exec/tests/AggregateSpillBenchmarkBase.cpp
+++ b/velox/exec/tests/AggregateSpillBenchmarkBase.cpp
@@ -31,7 +31,7 @@ std::unique_ptr<RowContainer> makeRowContainer(
     const std::vector<TypePtr>& keyTypes,
     const std::vector<TypePtr>& dependentTypes,
     std::shared_ptr<velox::memory::MemoryPool>& pool) {
-  auto container = std::make_unique<RowContainer>(
+  return std::make_unique<RowContainer>(
       keyTypes,
       true, // nullableKeys
       std::vector<Accumulator>{},
@@ -41,7 +41,6 @@ std::unique_ptr<RowContainer> makeRowContainer(
       false, // hasProbedFlag
       false, // hasNormalizedKey
       pool.get());
-  return container;
 }
 
 std::unique_ptr<RowContainer> setupSpillContainer(

--- a/velox/exec/tests/AggregateSpillBenchmarkBase.cpp
+++ b/velox/exec/tests/AggregateSpillBenchmarkBase.cpp
@@ -26,32 +26,79 @@ using namespace facebook::velox::exec;
 
 namespace facebook::velox::exec::test {
 
+namespace {
+std::unique_ptr<RowContainer> makeRowContainer(
+    const std::vector<TypePtr>& keyTypes,
+    const std::vector<TypePtr>& dependentTypes,
+    std::shared_ptr<velox::memory::MemoryPool>& pool) {
+  auto container = std::make_unique<RowContainer>(
+      keyTypes,
+      true, // nullableKeys
+      std::vector<Accumulator>{},
+      dependentTypes,
+      false, // hasNext
+      false, // isJoinBuild
+      false, // hasProbedFlag
+      false, // hasNormalizedKey
+      pool.get());
+  return container;
+}
+
+std::unique_ptr<RowContainer> setupSpillContainer(
+    const RowTypePtr& rowType,
+    uint32_t numKeys,
+    std::shared_ptr<velox::memory::MemoryPool>& pool) {
+  const auto& childTypes = rowType->children();
+  std::vector<TypePtr> keys(childTypes.begin(), childTypes.begin() + numKeys);
+  std::vector<TypePtr> dependents;
+  if (numKeys < childTypes.size()) {
+    dependents.insert(
+        dependents.end(), childTypes.begin() + numKeys, childTypes.end());
+  }
+  return makeRowContainer(keys, dependents, pool);
+}
+} // namespace
+
 void AggregateSpillBenchmarkBase::setUp() {
   SpillerBenchmarkBase::setUp();
 
-  rowContainer_ =
-      setupSpillContainer(rowType_, FLAGS_spiller_benchmark_num_key_columns);
-  spiller_ = std::make_unique<Spiller>(
-      exec::Spiller::Type::kAggregateInput,
-      rowContainer_.get(),
-      [&](folly::Range<char**> rows) { rowContainer_->eraseRows(rows); },
-      rowType_,
-      HashBitRange{29, 29},
-      rowContainer_->keyTypes().size(),
-      std::vector<CompareFlags>{},
-      fmt::format("{}/{}", spillDir_, FLAGS_spiller_benchmark_name),
-      FLAGS_spiller_benchmark_max_spill_file_size,
-      FLAGS_spiller_benchmark_write_buffer_size,
-      FLAGS_spiller_benchmark_min_spill_run_size,
-      stringToCompressionKind(FLAGS_spiller_benchmark_compression_kind),
-      memory::spillMemoryPool(),
-      executor_.get());
+  spillerPool_ = rootPool_->addLeafChild("spillerPool");
+  rowContainer_ = setupSpillContainer(
+      rowType_, FLAGS_spiller_benchmark_num_key_columns, pool_);
   writeSpillData();
+  spiller_ = makeSpiller();
 }
 
 void AggregateSpillBenchmarkBase::run() {
   MicrosecondTimer timer(&executionTimeUs_);
-  spiller_->spill(0, 0);
+  if (spillerType_ == Spiller::Type::kAggregateInput) {
+    spiller_->spill(0, 0);
+  } else {
+    spiller_->spill(RowContainerIterator{});
+  }
+}
+
+void AggregateSpillBenchmarkBase::printStats() const {
+  LOG(INFO) << "======Aggregate " << Spiller::typeName(spillerType_)
+            << " spilling statistics======";
+  LOG(INFO) << "total execution time: " << succinctMicros(executionTimeUs_);
+  LOG(INFO) << numInputVectors_ << " vectors each with " << inputVectorSize_
+            << " rows have been processed";
+  const auto memStats = spillerPool_->stats();
+  LOG(INFO) << "peak memory usage[" << succinctBytes(memStats.peakBytes)
+            << "] cumulative memory usage["
+            << succinctBytes(memStats.cumulativeBytes) << "]";
+  LOG(INFO) << spiller_->stats().toString();
+  // List files under file path.
+  SpillPartitionSet partitionSet;
+  spiller_->finishSpill(partitionSet);
+  VELOX_CHECK_EQ(partitionSet.size(), 1);
+  const auto files = fs_->list(spillDir_);
+  for (const auto& file : files) {
+    auto rfile = fs_->openFileForRead(file);
+    LOG(INFO) << "spilled file " << file << " size "
+              << succinctBytes(rfile->size());
+  }
 }
 
 void AggregateSpillBenchmarkBase::writeSpillData() {
@@ -78,32 +125,34 @@ void AggregateSpillBenchmarkBase::writeSpillData() {
   }
 }
 
-std::unique_ptr<RowContainer> AggregateSpillBenchmarkBase::makeRowContainer(
-    const std::vector<TypePtr>& keyTypes,
-    const std::vector<TypePtr>& dependentTypes) const {
-  auto container = std::make_unique<RowContainer>(
-      keyTypes,
-      true, // nullableKeys
-      std::vector<Accumulator>{},
-      dependentTypes,
-      false, // hasNext
-      false, // isJoinBuild
-      false, // hasProbedFlag
-      false, // hasNormalizedKey
-      pool_.get());
-  return container;
-}
-
-std::unique_ptr<RowContainer> AggregateSpillBenchmarkBase::setupSpillContainer(
-    const RowTypePtr& rowType,
-    uint32_t numKeys) const {
-  const auto& childTypes = rowType->children();
-  std::vector<TypePtr> keys(childTypes.begin(), childTypes.begin() + numKeys);
-  std::vector<TypePtr> dependents;
-  if (numKeys < childTypes.size()) {
-    dependents.insert(
-        dependents.end(), childTypes.begin() + numKeys, childTypes.end());
+std::unique_ptr<Spiller> AggregateSpillBenchmarkBase::makeSpiller() const {
+  if (spillerType_ == Spiller::Type::kAggregateInput) {
+    return std::make_unique<Spiller>(
+        spillerType_,
+        rowContainer_.get(),
+        [&](folly::Range<char**> rows) { rowContainer_->eraseRows(rows); },
+        rowType_,
+        HashBitRange{29, 29},
+        rowContainer_->keyTypes().size(),
+        std::vector<CompareFlags>{},
+        spillDir_,
+        FLAGS_spiller_benchmark_max_spill_file_size,
+        FLAGS_spiller_benchmark_write_buffer_size,
+        FLAGS_spiller_benchmark_min_spill_run_size,
+        stringToCompressionKind(FLAGS_spiller_benchmark_compression_kind),
+        spillerPool_.get(),
+        executor_.get());
+  } else {
+    return std::make_unique<Spiller>(
+        spillerType_,
+        rowContainer_.get(),
+        [&](folly::Range<char**> rows) { rowContainer_->eraseRows(rows); },
+        rowType_,
+        spillDir_,
+        FLAGS_spiller_benchmark_write_buffer_size,
+        stringToCompressionKind(FLAGS_spiller_benchmark_compression_kind),
+        spillerPool_.get(),
+        executor_.get());
   }
-  return makeRowContainer(keys, dependents);
 }
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/AggregateSpillBenchmarkBase.h
+++ b/velox/exec/tests/AggregateSpillBenchmarkBase.h
@@ -34,7 +34,7 @@ class AggregateSpillBenchmarkBase : public SpillerBenchmarkBase {
   void writeSpillData();
   std::unique_ptr<Spiller> makeSpiller() const;
 
-  Spiller::Type spillerType_;
+  const Spiller::Type spillerType_;
   std::unique_ptr<RowContainer> rowContainer_;
   std::shared_ptr<velox::memory::MemoryPool> spillerPool_;
 };

--- a/velox/exec/tests/AggregateSpillBenchmarkBase.h
+++ b/velox/exec/tests/AggregateSpillBenchmarkBase.h
@@ -19,7 +19,8 @@
 namespace facebook::velox::exec::test {
 class AggregateSpillBenchmarkBase : public SpillerBenchmarkBase {
  public:
-  AggregateSpillBenchmarkBase() = default;
+  explicit AggregateSpillBenchmarkBase(Spiller::Type spillerType)
+      : spillerType_(spillerType){};
 
   /// Sets up the test.
   void setUp() override;
@@ -27,15 +28,14 @@ class AggregateSpillBenchmarkBase : public SpillerBenchmarkBase {
   /// Runs the test.
   void run() override;
 
- private:
-  std::unique_ptr<RowContainer> makeRowContainer(
-      const std::vector<TypePtr>& keyTypes,
-      const std::vector<TypePtr>& dependentTypes) const;
-  std::unique_ptr<RowContainer> setupSpillContainer(
-      const RowTypePtr& rowType,
-      uint32_t numKeys) const;
-  void writeSpillData();
+  void printStats() const override;
 
+ private:
+  void writeSpillData();
+  std::unique_ptr<Spiller> makeSpiller() const;
+
+  Spiller::Type spillerType_;
   std::unique_ptr<RowContainer> rowContainer_;
+  std::shared_ptr<velox::memory::MemoryPool> spillerPool_;
 };
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/SpillerAggregateBenchmarkTest.cpp
+++ b/velox/exec/tests/SpillerAggregateBenchmarkTest.cpp
@@ -26,13 +26,24 @@ int main(int argc, char* argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   serializer::presto::PrestoVectorSerde::registerVectorSerde();
   filesystems::registerLocalFileSystem();
-  for (const auto type :
-       {Spiller::Type::kAggregateInput, Spiller::Type::kAggregateOutput}) {
-    auto test = std::make_unique<exec::test::AggregateSpillBenchmarkBase>(type);
-    test->setUp();
-    test->run();
-    test->printStats();
-    test->cleanup();
+
+  auto spillerTypeName = FLAGS_spiller_benchmark_spiller_type;
+  Spiller::Type spillerType;
+  if (spillerTypeName == Spiller::typeName(Spiller::Type::kAggregateInput)) {
+    spillerType = Spiller::Type::kAggregateInput;
+  } else if (
+      spillerTypeName == Spiller::typeName(Spiller::Type::kAggregateOutput)) {
+    spillerType = Spiller::Type::kAggregateOutput;
+  } else {
+    VELOX_UNSUPPORTED(
+        "Not support {} spiller type in Aggregate spiller benchmark",
+        spillerTypeName);
   }
+  auto test = std::make_unique<test::AggregateSpillBenchmarkBase>(spillerType);
+  test->setUp();
+  test->run();
+  test->printStats();
+  test->cleanup();
+
   return 0;
 }

--- a/velox/exec/tests/SpillerAggregateBenchmarkTest.cpp
+++ b/velox/exec/tests/SpillerAggregateBenchmarkTest.cpp
@@ -20,15 +20,19 @@
 #include <gflags/gflags.h>
 
 using namespace facebook::velox;
+using namespace facebook::velox::exec;
 
 int main(int argc, char* argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   serializer::presto::PrestoVectorSerde::registerVectorSerde();
   filesystems::registerLocalFileSystem();
-  auto test = std::make_unique<exec::test::AggregateSpillBenchmarkBase>();
-  test->setUp();
-  test->run();
-  test->printStats();
-  test->cleanup();
+  for (const auto type :
+       {Spiller::Type::kAggregateInput, Spiller::Type::kAggregateOutput}) {
+    auto test = std::make_unique<exec::test::AggregateSpillBenchmarkBase>(type);
+    test->setUp();
+    test->run();
+    test->printStats();
+    test->cleanup();
+  }
   return 0;
 }

--- a/velox/exec/tests/SpillerAggregateBenchmarkTest.cpp
+++ b/velox/exec/tests/SpillerAggregateBenchmarkTest.cpp
@@ -28,6 +28,11 @@ int main(int argc, char* argv[]) {
   filesystems::registerLocalFileSystem();
 
   auto spillerTypeName = FLAGS_spiller_benchmark_spiller_type;
+  std::transform(
+      spillerTypeName.begin(),
+      spillerTypeName.end(),
+      spillerTypeName.begin(),
+      [](unsigned char c) { return std::toupper(c); });
   Spiller::Type spillerType;
   if (spillerTypeName == Spiller::typeName(Spiller::Type::kAggregateInput)) {
     spillerType = Spiller::Type::kAggregateInput;
@@ -36,7 +41,7 @@ int main(int argc, char* argv[]) {
     spillerType = Spiller::Type::kAggregateOutput;
   } else {
     VELOX_UNSUPPORTED(
-        "Not support {} spiller type in Aggregate spiller benchmark",
+        "The spiller type {} is not one of [AGGREGATE_INPUT, AGGREGATE_OUTPUT], the aggregate spiller dose not support it.",
         spillerTypeName);
   }
   auto test = std::make_unique<test::AggregateSpillBenchmarkBase>(spillerType);

--- a/velox/exec/tests/SpillerBenchmarkBase.cpp
+++ b/velox/exec/tests/SpillerBenchmarkBase.cpp
@@ -43,7 +43,7 @@ DEFINE_string(
 DEFINE_string(
     spiller_benchmark_spiller_type,
     "AGGREGATE_INPUT",
-    "The spiller type name, must be in all uppercase");
+    "The spiller type name.");
 DEFINE_uint32(
     spiller_benchmark_num_spill_vectors,
     10'000,

--- a/velox/exec/tests/SpillerBenchmarkBase.cpp
+++ b/velox/exec/tests/SpillerBenchmarkBase.cpp
@@ -40,6 +40,10 @@ DEFINE_string(
     spiller_benchmark_compression_kind,
     "none",
     "The compression kind to compress spill rows before write to disk");
+DEFINE_string(
+    spiller_benchmark_spiller_type,
+    "AGGREGATE_INPUT",
+    "The spiller type name, must be in all uppercase");
 DEFINE_uint32(
     spiller_benchmark_num_spill_vectors,
     10'000,

--- a/velox/exec/tests/SpillerBenchmarkBase.h
+++ b/velox/exec/tests/SpillerBenchmarkBase.h
@@ -27,6 +27,7 @@
 DECLARE_string(spiller_benchmark_compression_kind);
 DECLARE_string(spiller_benchmark_name);
 DECLARE_string(spiller_benchmark_path);
+DECLARE_string(spiller_benchmark_spiller_type);
 DECLARE_uint32(spiller_benchmark_num_key_columns);
 DECLARE_uint32(spiller_benchmark_num_spill_vectors);
 DECLARE_uint32(spiller_benchmark_spill_executor_size);


### PR DESCRIPTION
This PR does the following things,
- Add a `kAggregateOutput` spiller in AggregateSpillBenchmark.
- Use a spiller-type flag to control the actual spiller used in AggregateSpillBenchmark.