### PR TITLE
Fix tsan data race in flaky AllTableWriterTest.directReadWrite

### DIFF
--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -303,9 +303,8 @@ void SelectiveStructColumnReaderBase::getValues(
     RowSet rows,
     VectorPtr* result) {
   VELOX_CHECK(!scanSpec_->children().empty());
-  VELOX_CHECK(
-      *result != nullptr,
-      "SelectiveStructColumnReaderBase expects a non-null result");
+  VELOX_CHECK_NOT_NULL(
+      *result, "SelectiveStructColumnReaderBase expects a non-null result");
   VELOX_CHECK(
       result->get()->type()->isRow(),
       "Struct reader expects a result of type ROW.");

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -70,7 +70,7 @@ void BaseVector::ensureNullsCapacity(
     bool setNotNull) {
   auto fill = setNotNull ? bits::kNotNull : bits::kNull;
   // Ensure the size of nulls_ is always at least as large as length_.
-  auto size = std::max(minimumSize, length_);
+  auto size = std::max<vector_size_t>(minimumSize, length_);
   if (nulls_ && !nulls_->isView() && nulls_->unique()) {
     if (nulls_->capacity() < bits::nbytes(size)) {
       AlignedBuffer::reallocate<bool>(&nulls_, size, fill);
@@ -90,7 +90,7 @@ void BaseVector::ensureNullsCapacity(
       memcpy(
           newNulls->asMutable<char>(),
           nulls_->as<char>(),
-          byteSize<bool>(std::min(length_, size)));
+          byteSize<bool>(std::min<vector_size_t>(length_, size)));
     }
     nulls_ = std::move(newNulls);
     rawNulls_ = nulls_->as<uint64_t>();
@@ -427,8 +427,8 @@ void BaseVector::clearNulls(const SelectivityVector& nonNullRows) {
   bits::orBits(
       rawNulls,
       nonNullRows.asRange().bits(),
-      std::min(length_, nonNullRows.begin()),
-      std::min(length_, nonNullRows.end()));
+      std::min<vector_size_t>(length_, nonNullRows.begin()),
+      std::min<vector_size_t>(length_, nonNullRows.end()));
   nullCount_ = std::nullopt;
 }
 

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -886,7 +886,7 @@ class BaseVector {
   // Caches raw pointer to 'nulls->as<uint64_t>().
   const uint64_t* rawNulls_ = nullptr;
   velox::memory::MemoryPool* pool_;
-  vector_size_t length_ = 0;
+  tsan_atomic<vector_size_t> length_{0};
 
   /**
    * Holds the number of nulls in the vector. If the number of nulls

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -1269,8 +1269,8 @@ void RowVector::appendNulls(vector_size_t numberOfRows) {
   if (numberOfRows == 0) {
     return;
   }
-  auto newSize = numberOfRows + BaseVector::length_;
-  auto oldSize = BaseVector::length_;
+  const vector_size_t newSize = numberOfRows + BaseVector::length_;
+  const vector_size_t oldSize = BaseVector::length_;
   BaseVector::resize(newSize, false);
   bits::fillBits(mutableRawNulls(), oldSize, newSize, bits::kNull);
 }

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -375,7 +375,8 @@ class ConstantVector final : public SimpleVector<T> {
 
     isNull_ = valueVector_->isNullAt(index_);
     BaseVector::distinctValueCount_ = isNull_ ? 0 : 1;
-    BaseVector::nullCount_ = isNull_ ? BaseVector::length_ : 0;
+    const vector_size_t vectorSize = BaseVector::length_;
+    BaseVector::nullCount_ = isNull_ ? vectorSize : 0;
     if (valueVector_->isScalar()) {
       auto simple = valueVector_->loadedVector()->as<SimpleVector<T>>();
       isNull_ = simple->isNullAt(index_);

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -410,7 +410,7 @@ VectorPtr FlatVector<T>::slice(vector_size_t offset, vector_size_t length)
 
 template <typename T>
 void FlatVector<T>::resize(vector_size_t newSize, bool setNotNull) {
-  auto previousSize = BaseVector::length_;
+  const vector_size_t previousSize = BaseVector::length_;
   if (newSize == previousSize) {
     return;
   }
@@ -522,11 +522,11 @@ void FlatVector<T>::resizeValues(
       auto len = std::min(values_->size(), newValues->size());
       memcpy(dst, src, len);
     } else {
-      auto previousSize = BaseVector::length_;
-      auto rawOldValues = newValues->asMutable<T>();
-      auto rawNewValues = newValues->asMutable<T>();
-      auto len = std::min<vector_size_t>(newSize, previousSize);
-      for (vector_size_t row = 0; row < len; row++) {
+      const vector_size_t previousSize = BaseVector::length_;
+      auto* rawOldValues = newValues->asMutable<T>();
+      auto* rawNewValues = newValues->asMutable<T>();
+      const auto len = std::min<vector_size_t>(newSize, previousSize);
+      for (vector_size_t row = 0; row < len; ++row) {
         rawNewValues[row] = rawOldValues[row];
       }
     }

--- a/velox/vector/LazyVector.h
+++ b/velox/vector/LazyVector.h
@@ -290,7 +290,7 @@ class LazyVector : public BaseVector {
   std::unique_ptr<VectorLoader> loader_;
 
   // True if all values are loaded.
-  mutable bool allLoaded_ = false;
+  mutable tsan_atomic<bool> allLoaded_{false};
   // Vector to hold loaded values. This may be present before load for
   // reuse. If loading is with ValueHook, this will not be created.
   mutable VectorPtr vector_;


### PR DESCRIPTION
In partitioned table write, table scan and table writer are in different pipelines.
The tsan test mode detects race condition on access to the output vector reused
by the table scan. The table scan reuse write to fields of the vector which were
previously read by the table write. This is expected and not a real data race and
table scan reuse code will check if the buffer is unique.
This PR fixes this by marking the fields detected by tsan as tsan_atomic so as to
de-flake the test case.
