### PR TITLE
Handle allocations that exceed PageRun limits

### DIFF
--- a/velox/common/memory/Allocation.cpp
+++ b/velox/common/memory/Allocation.cpp
@@ -30,12 +30,17 @@ Allocation::~Allocation() {
   }
 }
 
-void Allocation::append(uint8_t* address, int32_t numPages) {
+void Allocation::append(uint8_t* address, uint32_t numPages) {
   numPages_ += numPages;
   VELOX_CHECK(
       runs_.empty() || address != runs_.back().data(),
       "Appending a duplicate address into a PageRun");
-  runs_.emplace_back(address, numPages);
+  while (numPages > 0) {
+    auto numPagesInRun = std::min(numPages, PageRun::kMaxPagesInRun);
+    runs_.emplace_back(address, numPagesInRun);
+    address += AllocationTraits::pageBytes(numPagesInRun);
+    numPages -= numPagesInRun;
+  }
 }
 void Allocation::appendMove(Allocation& other) {
   for (auto& run : other.runs_) {

--- a/velox/common/memory/Allocation.cpp
+++ b/velox/common/memory/Allocation.cpp
@@ -36,7 +36,7 @@ void Allocation::append(uint8_t* address, uint32_t numPages) {
       runs_.empty() || address != runs_.back().data(),
       "Appending a duplicate address into a PageRun");
   while (numPages > 0) {
-    auto numPagesInRun = std::min(numPages, PageRun::kMaxPagesInRun);
+    const auto numPagesInRun = std::min(numPages, PageRun::kMaxPagesInRun);
     runs_.emplace_back(address, numPagesInRun);
     address += AllocationTraits::pageBytes(numPagesInRun);
     numPages -= numPagesInRun;

--- a/velox/common/memory/Allocation.h
+++ b/velox/common/memory/Allocation.h
@@ -193,6 +193,7 @@ class Allocation {
   VELOX_FRIEND_TEST(MemoryAllocatorTest, allocationClass2);
   VELOX_FRIEND_TEST(AllocationTest, append);
   VELOX_FRIEND_TEST(AllocationTest, appendMove);
+  VELOX_FRIEND_TEST(AllocationTest, multiplePageRuns);
 };
 
 /// Represents a run of contiguous pages that do not belong to any size class.

--- a/velox/common/memory/Allocation.h
+++ b/velox/common/memory/Allocation.h
@@ -171,7 +171,7 @@ class Allocation {
     VELOX_CHECK(numPages_ != 0 || pool_ == nullptr);
   }
 
-  void append(uint8_t* address, int32_t numPages);
+  void append(uint8_t* address, uint32_t numPages);
 
   void clear() {
     runs_.clear();

--- a/velox/common/memory/MallocAllocator.cpp
+++ b/velox/common/memory/MallocAllocator.cpp
@@ -225,11 +225,12 @@ int64_t MallocAllocator::freeNonContiguous(Allocation& allocation) {
     while (i + 1 < allocation.numRuns()) {
       Allocation::PageRun nextRun = allocation.runAt(i + 1);
       void* nextPtr = nextRun.data();
-      if (mallocs_.count(nextPtr) != 0) {
+      if (static_cast<char*>(nextPtr) - static_cast<char*>(ptr) !=
+          AllocationTraits::pageBytes(numFreed)) {
         break;
       }
       numFreed += nextRun.numPages();
-      i++;
+      ++i;
     }
     {
       std::lock_guard<std::mutex> l(mallocsMutex_);

--- a/velox/common/memory/MallocAllocator.cpp
+++ b/velox/common/memory/MallocAllocator.cpp
@@ -221,6 +221,16 @@ int64_t MallocAllocator::freeNonContiguous(Allocation& allocation) {
     Allocation::PageRun run = allocation.runAt(i);
     numFreed += run.numPages();
     void* ptr = run.data();
+    // Check if ptr was split into multiple PageRuns.
+    while (i + 1 < allocation.numRuns()) {
+      Allocation::PageRun nextRun = allocation.runAt(i + 1);
+      void* nextPtr = nextRun.data();
+      if (mallocs_.count(nextPtr) != 0) {
+        break;
+      }
+      numFreed += nextRun.numPages();
+      i++;
+    }
     {
       std::lock_guard<std::mutex> l(mallocsMutex_);
       const auto ret = mallocs_.erase(ptr);

--- a/velox/common/memory/MallocAllocator.cpp
+++ b/velox/common/memory/MallocAllocator.cpp
@@ -225,6 +225,8 @@ int64_t MallocAllocator::freeNonContiguous(Allocation& allocation) {
     while (i + 1 < allocation.numRuns()) {
       Allocation::PageRun nextRun = allocation.runAt(i + 1);
       void* nextPtr = nextRun.data();
+      // NOTE: std::malloc will not return two allocated buffers which are
+      // contiguous in memory space.
       if (static_cast<char*>(nextPtr) - static_cast<char*>(ptr) !=
           AllocationTraits::pageBytes(numFreed)) {
         break;

--- a/velox/common/memory/MemoryAllocator.cpp
+++ b/velox/common/memory/MemoryAllocator.cpp
@@ -95,14 +95,6 @@ MemoryAllocator::SizeMix MemoryAllocator::allocationSize(
       ++numUnits;
       needed -= size;
     }
-    if (FOLLY_UNLIKELY(numUnits * size > Allocation::PageRun::kMaxPagesInRun)) {
-      VELOX_MEM_ALLOC_ERROR(fmt::format(
-          "Too many pages {} to allocate, the number of units {} at size class of {} exceeds the PageRun limit {}",
-          numPages,
-          numUnits,
-          size,
-          Allocation::PageRun::kMaxPagesInRun));
-    }
     mix.sizeCounts[mix.numSizes] = numUnits;
     pagesToAlloc += numUnits * size;
     mix.sizeIndices[mix.numSizes++] = sizeIndex;

--- a/velox/common/memory/tests/AllocationTest.cpp
+++ b/velox/common/memory/tests/AllocationTest.cpp
@@ -94,13 +94,13 @@ TEST_F(AllocationTest, multiplePageRuns) {
   ASSERT_EQ(allocation.numRuns(), 2);
 
   uint8_t* const secondBufAddr = reinterpret_cast<uint8_t*>(
-      startBufAddrValue + allocation.numPages() * AllocationTraits::kPageSize);
+      startBufAddrValue + AllocationTraits::pageBytes(allocation.numPages()));
   allocation.append(secondBufAddr, Allocation::PageRun::kMaxPagesInRun - 100);
   ASSERT_EQ(allocation.numPages(), Allocation::PageRun::kMaxPagesInRun * 2);
   ASSERT_EQ(allocation.numRuns(), 3);
 
   uint8_t* const thirdBufAddr = reinterpret_cast<uint8_t*>(
-      firstBufAddr + 2 * allocation.numPages() * AllocationTraits::kPageSize);
+      firstBufAddr + 2 * AllocationTraits::pageBytes(allocation.numPages()));
   allocation.append(thirdBufAddr, Allocation::PageRun::kMaxPagesInRun * 2);
   ASSERT_EQ(allocation.numPages(), Allocation::PageRun::kMaxPagesInRun * 4);
   ASSERT_EQ(allocation.numRuns(), 5);

--- a/velox/common/memory/tests/AllocationTest.cpp
+++ b/velox/common/memory/tests/AllocationTest.cpp
@@ -85,4 +85,26 @@ TEST_F(AllocationTest, appendMove) {
   allocation.clear();
 }
 
+TEST_F(AllocationTest, multiplePageRuns) {
+  Allocation allocation;
+  const uint64_t startBufAddrValue = 4096;
+  uint8_t* const firstBufAddr = reinterpret_cast<uint8_t*>(startBufAddrValue);
+  allocation.append(firstBufAddr, Allocation::PageRun::kMaxPagesInRun + 100);
+  ASSERT_EQ(allocation.numPages(), Allocation::PageRun::kMaxPagesInRun + 100);
+  ASSERT_EQ(allocation.numRuns(), 2);
+
+  uint8_t* const secondBufAddr = reinterpret_cast<uint8_t*>(
+      startBufAddrValue + allocation.numPages() * AllocationTraits::kPageSize);
+  allocation.append(secondBufAddr, Allocation::PageRun::kMaxPagesInRun - 100);
+  ASSERT_EQ(allocation.numPages(), Allocation::PageRun::kMaxPagesInRun * 2);
+  ASSERT_EQ(allocation.numRuns(), 3);
+
+  uint8_t* const thirdBufAddr = reinterpret_cast<uint8_t*>(
+      firstBufAddr + 2 * allocation.numPages() * AllocationTraits::kPageSize);
+  allocation.append(thirdBufAddr, Allocation::PageRun::kMaxPagesInRun * 2);
+  ASSERT_EQ(allocation.numPages(), Allocation::PageRun::kMaxPagesInRun * 4);
+  ASSERT_EQ(allocation.numRuns(), 5);
+  allocation.clear();
+}
+
 } // namespace facebook::velox::memory

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -1304,14 +1304,13 @@ TEST_P(MemoryAllocatorTest, StlMemoryAllocator) {
   }
 }
 
-TEST_P(MemoryAllocatorTest, badNonContiguousAllocation) {
+TEST_P(MemoryAllocatorTest, nonContiguousAllocationBounds) {
   // Set the num of pages to allocate exceeds one PageRun limit.
   constexpr MachinePageCount kNumPages =
       Allocation::PageRun::kMaxPagesInRun + 1;
   std::unique_ptr<Allocation> allocation(new Allocation());
-  ASSERT_THROW(
-      instance_->allocateNonContiguous(kNumPages, *allocation),
-      VeloxRuntimeError);
+  ASSERT_TRUE(instance_->allocateNonContiguous(kNumPages, *allocation));
+  instance_->freeNonContiguous(*allocation);
   ASSERT_TRUE(instance_->allocateNonContiguous(kNumPages - 1, *allocation));
   instance_->freeNonContiguous(*allocation);
 }

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -1784,9 +1784,9 @@ TEST_P(MemoryPoolTest, contiguousAllocateGrowExceedMemoryPoolLimit) {
   ASSERT_EQ(allocation.numPages(), kMaxNumPages / 2);
 }
 
-TEST_P(MemoryPoolTest, badNonContiguousAllocation) {
+TEST_P(MemoryPoolTest, nonContiguousAllocationBounds) {
   auto manager = getMemoryManager();
-  auto pool = manager->addLeafPool("badNonContiguousAllocation");
+  auto pool = manager->addLeafPool("nonContiguousAllocationBounds");
   Allocation allocation;
   // Bad zero page allocation size.
   ASSERT_THROW(pool->allocateNonContiguous(0, allocation), VeloxRuntimeError);
@@ -1794,8 +1794,9 @@ TEST_P(MemoryPoolTest, badNonContiguousAllocation) {
   // Set the num of pages to allocate exceeds one PageRun limit.
   constexpr MachinePageCount kNumPages =
       Allocation::PageRun::kMaxPagesInRun + 1;
-  ASSERT_THROW(
-      pool->allocateNonContiguous(kNumPages, allocation), VeloxRuntimeError);
+  pool->allocateNonContiguous(kNumPages, allocation);
+  ASSERT_GE(allocation.numPages(), kNumPages);
+  pool->freeNonContiguous(allocation);
   pool->allocateNonContiguous(kNumPages - 1, allocation);
   ASSERT_GE(allocation.numPages(), kNumPages - 1);
   pool->freeNonContiguous(allocation);


### PR DESCRIPTION
Fix issue with TPC-DS Q43 SF-10K error in HashTable
"Too many pages 109870 to allocate, the number of units 429 at size class of 256 exceeds the PageRun limit 65535"
Resolves https://github.com/prestodb/presto/issues/21292