### PR TITLE
No semicolon after namespace in files inc velox/vector/tests/SelectivityVectorTest.cpp

### DIFF
--- a/velox/vector/tests/SelectivityVectorTest.cpp
+++ b/velox/vector/tests/SelectivityVectorTest.cpp
@@ -98,7 +98,7 @@ void setValid_normal(bool setToValue) {
   }
 }
 
-}; // namespace
+} // namespace
 
 TEST(SelectivityVectorTest, setValid_true_normal) {
   setValid_normal(true);


### PR DESCRIPTION
Summary:
Auto-generated with
```
fbgs "}; // namespace" -l | sort -u | sed 's/fbsource.//' | xargs -n 50 sed -i 's_}; // namespace_} // namespace_'
```

 - If you approve of this diff, please use the "Accept & Ship" button :-)

(40 files modified.)

Reviewed By: meyering

Differential Revision: D51031629


