### PR TITLE
Fix CPU regression

### DIFF
--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -1905,16 +1905,21 @@ void StructColumnReader::next(
     result = std::move(rowResult);
   }
 
-  for (uint64_t i = 0; i < children_.size(); ++i) {
-    auto& reader = children_[i];
-    if (reader) {
-      if (executor_) {
+  if (executor_) {
+    for (uint64_t i = 0; i < children_.size(); ++i) {
+      auto& reader = children_[i];
+      if (reader) {
         executor_->add(
             [&reader,
              numValues,
              child = &(*childrenVectorsPtr)[i],
              nullsPtr]() { reader->next(numValues, *child, nullsPtr); });
-      } else {
+      }
+    }
+  } else {
+    for (uint64_t i = 0; i < children_.size(); ++i) {
+      auto& reader = children_[i];
+      if (reader) {
         reader->next(numValues, (*childrenVectorsPtr)[i], nullsPtr);
       }
     }


### PR DESCRIPTION
Summary:
A CPU regression in `facebook::velox::dwrf::DwrfRowReader::readNext` was flagged (as regressing 30%) with the introduction of parallel decoding. Even when we're not using parallel decoding. It looks quite impossible for me by the way, but maybe a mess with the branch prediction could cause it.

The only thing that I can think of is that we check for the existence of the executor inside a loop. I assumed that the branch prediction would take care of it, since it will be always true or false. But maybe it isn't. Let's move it outside the loop and see what happens.

Differential Revision: D51037397


