### PR TITLE
Ensure RowVector::resize also resizes the children.

### DIFF
--- a/velox/expression/VectorWriters.h
+++ b/velox/expression/VectorWriters.h
@@ -277,8 +277,10 @@ struct VectorWriter<Row<T...>> : public VectorWriterBase {
 
   void ensureSize(size_t size) override {
     if (size > rowVector_->size()) {
+      // Note order is important here, we resize children first to ensure
+      // data_ is cached and are not reset when rowVector resizes them.
+      resizeVectorWriters<0>(size);
       rowVector_->resize(size, /*setNotNull*/ false);
-      resizeVectorWriters<0>(rowVector_->size());
     }
   }
 
@@ -534,14 +536,7 @@ struct VectorWriter<Generic<T, comparable, orderable>>
       castWriter_->ensureSize(size);
     } else {
       if (vector_->size() < size) {
-        if (vector_->typeKind() == TypeKind::ROW) {
-          // Avoid calling resize on all children by adding top level nulls
-          // only.
-          vector_->asUnchecked<RowVector>()->appendNulls(
-              size - vector_->size());
-        } else {
-          vector_->resize(size, false);
-        }
+        vector_->resize(size, false);
       }
     }
   }
@@ -715,10 +710,10 @@ struct VectorWriter<DynamicRow, void> : public VectorWriterBase {
 
   void ensureSize(size_t size) override {
     if (size > rowVector_->size()) {
-      rowVector_->resize(size, /*setNotNull*/ false);
       for (int i = 0; i < writer_.childrenCount_; ++i) {
         writer_.childrenWriters_[i]->ensureSize(size);
       }
+      rowVector_->resize(size, /*setNotNull*/ false);
     }
   }
 

--- a/velox/functions/lib/aggregates/MinMaxByAggregatesBase.h
+++ b/velox/functions/lib/aggregates/MinMaxByAggregatesBase.h
@@ -23,17 +23,6 @@
 
 namespace facebook::velox::functions::aggregate {
 
-namespace {
-inline void resizeRowVectorAndChildren(
-    RowVector& rowVector,
-    vector_size_t size) {
-  rowVector.resize(size);
-  for (auto& child : rowVector.children()) {
-    child->resize(size);
-  }
-}
-} // namespace
-
 template <typename T>
 constexpr bool isNumeric() {
   return std::is_same_v<T, bool> || std::is_same_v<T, int8_t> ||
@@ -245,10 +234,10 @@ class MinMaxByAggregateBase : public exec::Aggregate {
   void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     auto rowVector = (*result)->as<RowVector>();
+    rowVector->resize(numGroups);
+
     auto valueVector = rowVector->childAt(0);
     auto comparisonVector = rowVector->childAt(1);
-
-    resizeRowVectorAndChildren(*rowVector, numGroups);
     uint64_t* rawNulls = getRawNulls(rowVector);
 
     T* rawValues = nullptr;

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -668,11 +668,11 @@ class MinMaxByNAggregate : public exec::Aggregate {
   void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     auto rowVector = (*result)->as<RowVector>();
+    rowVector->resize(numGroups);
+
     auto nVector = rowVector->childAt(0);
     auto comparisonArray = rowVector->childAt(1)->as<ArrayVector>();
     auto valueArray = rowVector->childAt(2)->as<ArrayVector>();
-
-    resizeRowVectorAndChildren(*rowVector, numGroups);
 
     auto* rawNs = nVector->as<FlatVector<int64_t>>()->mutableRawValues();
 

--- a/velox/functions/prestosql/tests/MapFromEntriesTest.cpp
+++ b/velox/functions/prestosql/tests/MapFromEntriesTest.cpp
@@ -295,6 +295,8 @@ TEST_F(MapFromEntriesTest, arrayOfDictionaryRowOfNulls) {
   RowVectorPtr rowVector =
       makeRowVector({makeFlatVector<int32_t>(0), makeFlatVector<int32_t>(0)});
   rowVector->resize(4);
+  rowVector->childAt(0)->resize(0);
+  rowVector->childAt(1)->resize(0);
   for (int i = 0; i < rowVector->size(); i++) {
     rowVector->setNull(i, true);
   }
@@ -330,7 +332,8 @@ TEST_F(MapFromEntriesTest, arrayOfConstantRowOfNulls) {
       makeRowVector({makeFlatVector<int32_t>(0), makeFlatVector<int32_t>(0)});
   rowVector->resize(1);
   rowVector->setNull(0, true);
-
+  rowVector->childAt(0)->resize(0);
+  rowVector->childAt(1)->resize(0);
   EXPECT_EQ(rowVector->childAt(0)->size(), 0);
   EXPECT_EQ(rowVector->childAt(1)->size(), 0);
 

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -643,6 +643,28 @@ void RowVector::unsafeResize(vector_size_t newSize, bool setNotNull) {
   BaseVector::resize(newSize, setNotNull);
 }
 
+void RowVector::resize(vector_size_t newSize, bool setNotNull) {
+  auto oldSize = length_;
+  BaseVector::resize(newSize, setNotNull);
+
+  // Resize all the children.
+  for (auto& child : children_) {
+    if (child) {
+      if (child->isLazy()) {
+        VELOX_FAIL("Resize on a lazy vector is not allowed");
+      }
+
+      // If we are just reducing the size of the vector, its safe
+      // to skip uniqueness check since effectively we are just changing
+      // the length.
+      if (newSize > oldSize) {
+        VELOX_CHECK(child.unique(), "Resizing shared child vector");
+        child->resize(newSize, setNotNull);
+      }
+    }
+  }
+}
+
 void ArrayVectorBase::checkRanges() const {
   std::unordered_map<vector_size_t, vector_size_t> seenElements;
   seenElements.reserve(size());

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -209,6 +209,12 @@ class RowVector : public BaseVector {
   /// until the few places that require it are migrated over.
   void unsafeResize(vector_size_t newSize, bool setNotNull = true);
 
+  /// Resizes the parent row container and also recursively resizes the
+  /// children. Note that this function will throw if the children are not
+  /// uniquely referenced by the parent when increasing the size.
+  /// Note : If the child is null, then it will stay null after the resize.
+  void resize(vector_size_t newSize, bool setNotNull = true) override;
+
  private:
   vector_size_t childSize() const {
     bool allConstant = false;

--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -948,14 +948,7 @@ VectorPtr VectorLoaderWrap::makeEncodingPreservedCopy(
   if (decoded.isConstantMapping() || decoded.isIdentityMapping()) {
     VectorPtr result;
     BaseVector::ensureWritable(rows, vector_->type(), vector_->pool(), result);
-    if (result->typeKind() == TypeKind::ROW) {
-      // Avoid calling resize on all children by adding top level nulls only.
-      // We know from the check above that result is unique and isNullsWritable.
-      result->asUnchecked<RowVector>()->appendNulls(
-          vectorSize - result->size());
-    } else {
-      result->resize(vectorSize);
-    }
+    result->resize(vectorSize);
     result->copy(vector_.get(), rows, nullptr);
     return result;
   }


### PR DESCRIPTION
Summary:
This is the final change to enable resizing row vectors and their children. Previously we added,

1. Row vector validation ( D50244089) (To ensure Rows are well formed via the validate api).
2. Row vector unsafe resize api (D50577808) (To migrate over the few places which cannot use the newer api for performance or other reasons).

With this diff we make RowVector::resize recursively resize all the children along with the container. We also check to ensure that the children are uniquely referenced if the size is being increased.

This change also reverts:
1. D50205657
2. D50328306

Original commit changeset: bfe158c2d460

Original Phabricator Diff: D49547057

Differential Revision: D49611624


