### PR TITLE
Optimize remaining filter evaluation

### DIFF
--- a/velox/expression/ConjunctExpr.h
+++ b/velox/expression/ConjunctExpr.h
@@ -82,6 +82,10 @@ class ConjunctExpr : public SpecialForm {
       FlatVector<bool>* result,
       SelectivityVector* activeRows);
 
+  bool evaluatesArgumentsOnNonIncreasingSelection() const override {
+    return isAnd_;
+  }
+
   // true if conjunction (and), false if disjunction (or).
   const bool isAnd_;
 

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -831,9 +831,12 @@ void Expr::eval(
     for (auto* field : distinctFields_) {
       context.ensureFieldLoaded(field->index(context), rows);
     }
-  } else if (!propagatesNulls_) {
-    // Load multiply-referenced fields at common parent expr with "rows".
-    // Delay loading fields that are not in multiplyReferencedFields_.
+  } else if (
+      !propagatesNulls_ && !evaluatesArgumentsOnNonIncreasingSelection()) {
+    // Load multiply-referenced fields at common parent expr with "rows".  Delay
+    // loading fields that are not in multiplyReferencedFields_.  In case
+    // evaluatesArgumentsOnNonIncreasingSelection() is true, this is delayed
+    // until we process the inputs of ConjunctExpr.
     for (const auto& field : multiplyReferencedFields_) {
       context.ensureFieldLoaded(field->index(context), rows);
     }

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -549,6 +549,16 @@ class Expr {
   // referenced fields.
   virtual void computeDistinctFields();
 
+  // True if this is a spcial form where the next argument will always be
+  // evaluated on a subset of the rows for which the previous one was evaluated.
+  // This is true of AND and no other at this time.  This implies that lazies
+  // can be loaded on first use and not before starting evaluating the form.
+  // This is so because a subsequent use will never access rows that were not in
+  // scope for the previous one.
+  virtual bool evaluatesArgumentsOnNonIncreasingSelection() const {
+    return false;
+  }
+
   const TypePtr type_;
   const std::vector<std::shared_ptr<Expr>> inputs_;
   const std::string name_;

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -4256,7 +4256,7 @@ TEST_P(ParameterizedExprTest, lazyHandlingByDereference) {
   // Ensure FieldReference handles an input which has an encoding over a lazy
   // vector. Trying to access the inner flat vector of an input in the form
   // Row(Dict(Lazy(Row(Flat)))) will ensure an intermediate FieldReference
-  // expression in the tree recieves an input of the form Dict(Lazy(Row(Flat))).
+  // expression in the tree receives an input of the form Dict(Lazy(Row(Flat))).
   auto base = makeRowVector(
       {makeNullableFlatVector<int32_t>({1, std::nullopt, 3, 4, 5})});
   VectorPtr col1 = std::make_shared<LazyVector>(
@@ -4406,6 +4406,102 @@ TEST_P(ParameterizedExprTest, coalesceRowInputTypesAreTheSame) {
         "plus");
 
     ASSERT_NO_THROW(compileExpression(plus));
+  }
+}
+
+TEST_P(ParameterizedExprTest, evaluatesArgumentsOnNonIncreasingSelection) {
+  auto makeLazy = [&](const auto& base, const auto& check) {
+    return std::make_shared<LazyVector>(
+        execCtx_->pool(),
+        base->type(),
+        base->size(),
+        std::make_unique<test::SimpleVectorLoader>([&](auto rows) {
+          check(rows);
+          return base;
+        }));
+  };
+  constexpr int kSize = 300;
+  auto c0 = makeFlatVector<int64_t>(kSize, folly::identity);
+
+  {
+    SCOPED_TRACE("No eager loading for AND clauses");
+    auto input = makeRowVector({
+        c0,
+        makeLazy(
+            c0,
+            [](auto& rows) {
+              // Only the rows passing c0 % 2 == 0 should be loaded.
+              VELOX_CHECK_EQ(rows.size(), (kSize + 1) / 2);
+              for (auto i : rows) {
+                VELOX_CHECK(i % 2 == 0);
+              }
+            }),
+    });
+    auto actual =
+        evaluate("c0 % 2 == 0 and c1 % 3 == 0 and c1 % 5 == 0", input);
+    auto expected =
+        makeFlatVector<bool>(kSize, [](auto i) { return i % 30 == 0; });
+    assertEqualVectors(expected, actual);
+  }
+
+  {
+    SCOPED_TRACE("IF inside AND");
+    auto input = makeRowVector({
+        c0,
+        makeLazy(
+            c0,
+            [](auto& rows) {
+              // Only the rows passing c0 % 2 == 0 should be loaded.
+              VELOX_CHECK_EQ(rows.size(), (kSize + 1) / 2);
+              for (auto i : rows) {
+                VELOX_CHECK(i % 2 == 0);
+              }
+            }),
+    });
+    auto actual =
+        evaluate("c0 % 2 == 0 and if (c0 % 3 == 0, c1, -1 * c1) >= 0", input);
+    auto expected =
+        makeFlatVector<bool>(kSize, [](auto i) { return i % 6 == 0; });
+    assertEqualVectors(expected, actual);
+  }
+
+  {
+    SCOPED_TRACE("AND inside IF");
+    auto input = makeRowVector({
+        c0,
+        makeLazy(
+            c0,
+            [&](auto& rows) {
+              // All rows should be loaded.
+              VELOX_CHECK_EQ(rows.size(), kSize);
+            }),
+    });
+    auto actual = evaluate(
+        "if (c0 % 2 == 0, c1 % 3 == 0 and c1 % 5 == 0, c1 % 7 == 0 and c1 % 11 == 0)",
+        input);
+    auto expected = makeFlatVector<bool>(kSize, [](auto i) {
+      return (i % 2 == 0 && i % 15 == 0) || (i % 2 != 0 && i % 77 == 0);
+    });
+    assertEqualVectors(expected, actual);
+  }
+
+  {
+    SCOPED_TRACE("Shared subexp");
+    auto c1 = makeFlatVector<int64_t>({0, 0});
+    auto c2 = makeFlatVector<int64_t>({1, 1});
+    auto input = makeRowVector({
+        makeNullableFlatVector<int64_t>({0, std::nullopt}),
+        makeLazy(
+            c1,
+            [&](auto& rows) {
+              // All rows should be loaded.
+              VELOX_CHECK_EQ(rows.size(), 2);
+            }),
+        c2,
+    });
+    auto actual =
+        evaluate("(c0 <> if (c1 < c2, 1, 0)) is null and c1 < c2", input);
+    assertEqualVectors(makeFlatVector<bool>({false, true}), actual);
   }
 }
 


### PR DESCRIPTION
Summary:
Currently when we have a remaining filter separated by ANDs and same field is multi-referenced from different clauses, we eagerly materialize that field.  If there is a very selective condition in the AND clauses, we lose the opportunity to avoid reading unneeded rows using that condition on the mutli-referenced field.

Since AND always reduces the selectivity, there is no need to eagerly evaluate the multi-referenced fields.  It gives 2.6x performance gain in some queries by evaluating the field lazily.

Differential Revision: D51039406


