### PR TITLE
Add codec options to parquet writer

### DIFF
--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -135,6 +135,7 @@ std::shared_ptr<WriterProperties> getArrowParquetWriterOptions(
   properties = properties->data_pagesize(options.dataPageSize);
   properties = properties->max_row_group_length(
       static_cast<int64_t>(flushPolicy->rowsInRowGroup()));
+  properties = properties->codec_options(options.codecOptions);
   return properties->build();
 }
 

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -23,9 +23,12 @@
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/Writer.h"
 #include "velox/dwio/common/WriterFactory.h"
+#include "velox/dwio/parquet/writer/arrow/util/Compression.h"
 #include "velox/vector/ComplexVector.h"
 
 namespace facebook::velox::parquet {
+
+using facebook::velox::parquet::arrow::util::CodecOptions;
 
 class ArrowDataBufferSink;
 
@@ -94,6 +97,7 @@ struct WriterOptions {
   // The default factory allows the writer to construct the default flush
   // policy with the configs in its ctor.
   std::function<std::unique_ptr<DefaultFlushPolicy>()> flushPolicyFactory;
+  std::shared_ptr<CodecOptions> codecOptions;
 };
 
 // Writes Velox vectors into  a DataSink using Arrow Parquet writer.


### PR DESCRIPTION
Velox have upgrade arrow to 14.0.0 which support CodecOptions. 
If we add CodecOptions to ::parquet::WriterOptions it will help to make more compression parameters (such as window_bits) customizable when creating the Codec for parquet writer. 