### PR TITLE
Add exactSize flag to FlatVector::getRawStringBufferWithSpace API

### DIFF
--- a/velox/vector/FlatVector.cpp
+++ b/velox/vector/FlatVector.cpp
@@ -47,7 +47,9 @@ void FlatVector<bool>::set(vector_size_t idx, bool value) {
 }
 
 template <>
-Buffer* FlatVector<StringView>::getBufferWithSpace(int32_t size) {
+Buffer* FlatVector<StringView>::getBufferWithSpace(
+    int32_t size,
+    bool exactSize) {
   VELOX_DCHECK_GE(stringBuffers_.size(), stringBufferSet_.size());
 
   // Check if the last buffer is uniquely referenced and has enough space.
@@ -59,7 +61,7 @@ Buffer* FlatVector<StringView>::getBufferWithSpace(int32_t size) {
   }
 
   // Allocate a new buffer.
-  int32_t newSize = std::max(kInitialStringSize, size);
+  const int32_t newSize = exactSize ? size : std::max(kInitialStringSize, size);
   BufferPtr newBuffer = AlignedBuffer::allocate<char>(newSize, pool());
   newBuffer->setSize(0);
   addStringBuffer(newBuffer);
@@ -67,8 +69,10 @@ Buffer* FlatVector<StringView>::getBufferWithSpace(int32_t size) {
 }
 
 template <>
-char* FlatVector<StringView>::getRawStringBufferWithSpace(int32_t size) {
-  Buffer* buffer = getBufferWithSpace(size);
+char* FlatVector<StringView>::getRawStringBufferWithSpace(
+    int32_t size,
+    bool exactSize) {
+  Buffer* buffer = getBufferWithSpace(size, exactSize);
   char* rawBuffer = buffer->asMutable<char>() + buffer->size();
   buffer->setSize(buffer->size() + size);
   return rawBuffer;

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -443,7 +443,10 @@ class FlatVector final : public SimpleVector<T> {
   /// Buffer::setSize(n) to update the size of the buffer to include newly
   /// written content ('n' cannot exceed 'size', but can be less than 'size').
   /// The caller must ensure not to write more then 'size' bytes.
-  Buffer* getBufferWithSpace(int32_t /* size */) {
+  ///
+  /// If allocates new buffer and 'exactSize' is true, allocates 'size' bytes.
+  /// Otherwise, allocates at least kInitialStringSize bytes.
+  Buffer* getBufferWithSpace(int32_t /*size*/, bool exactSize = false) {
     return nullptr;
   }
 
@@ -456,7 +459,10 @@ class FlatVector final : public SimpleVector<T> {
   /// sets buffer size to 'size' and returns a pointer to the start of writable
   /// memory.
   /// The caller must ensure not to write more then 'size' bytes.
-  char* getRawStringBufferWithSpace(int32_t /* size */) {
+  ///
+  /// If allocates new buffer and 'exactSize' is true, allocates 'size' bytes.
+  /// Otherwise, allocates at least kInitialStringSize bytes.
+  char* getRawStringBufferWithSpace(int32_t /*size*/, bool exactSize = false) {
     return nullptr;
   }
 
@@ -545,10 +551,14 @@ void FlatVector<StringView>::validate(
     const VectorValidateOptions& options) const;
 
 template <>
-Buffer* FlatVector<StringView>::getBufferWithSpace(int32_t size);
+Buffer* FlatVector<StringView>::getBufferWithSpace(
+    int32_t size,
+    bool exactSize);
 
 template <>
-char* FlatVector<StringView>::getRawStringBufferWithSpace(int32_t size);
+char* FlatVector<StringView>::getRawStringBufferWithSpace(
+    int32_t size,
+    bool exactSize);
 
 template <>
 void FlatVector<StringView>::prepareForReuse();


### PR DESCRIPTION
FlatVector<StringView::getBufferWithSpace and getRawStringBufferWithSpace return
an existing buffer with enough free capacity or allocate new buffer. When
allocating new buffer these APIs allocate at least 32KB(kInitialStringSize). In
some cases, e.g. deserializing vectors from Presto's SerializedPage, we know
the maximum number of bytes needed. In these cases allocating more is
wasteful.

Add 'exactSize' boolean parameter to avoid allocating more than requested number
of bytes.