### PR TITLE
Fix from_utf8 handling of invalid UTF-8 codepoint

### DIFF
--- a/velox/docs/functions/presto/string.rst
+++ b/velox/docs/functions/presto/string.rst
@@ -40,15 +40,19 @@ String Functions
 .. function:: from_utf8(binary) -> varchar
 
     Decodes a UTF-8 encoded string from ``binary``. Invalid UTF-8 sequences
-    are replaced with the Unicode replacement character ``U+FFFD``.
+    are replaced with the Unicode replacement character ``U+FFFD``. Each
+    invalid UTF-8 codepoint, including those of multi-byte long, is replaced
+    with one replacement character.
 
 .. function:: from_utf8(binary, replace) -> varchar
     :noindex:
 
     Decodes a UTF-8 encoded string from ``binary``. Invalid UTF-8 sequences are
-    replaced with `replace`. The `replace` argument can be either Unicode code
-    point (bigint), a single character or empty string. When `replace` is an
-    empty string invalid characters are removed.
+    replaced with `replace`. Each invalid UTF-8 codepoint, including those of
+    multi-byte long, is replaced with one replacement character. The `replace`
+    argument can be either Unicode code point (bigint), a single character or
+    empty string. When `replace` is an empty string invalid characters are
+    removed.
 
 .. function:: length(string) -> bigint
 
@@ -181,7 +185,7 @@ String Functions
     ``instance`` must be a positive number.
     Positions start with ``1``. If not found, ``0`` is returned.
     It takes into account overlapping strings when counting occurrences. ::
-        
+
         SELECT strrpos('aaa', 'aa', 2); -- 1
 
 .. function:: substr(string, start) -> varchar

--- a/velox/functions/prestosql/Utf8Utils.h
+++ b/velox/functions/prestosql/Utf8Utils.h
@@ -20,11 +20,24 @@
 namespace facebook::velox::functions {
 
 /// This function is not part of the original utf8proc.
-/// Tries to get the length of UTF-8 encoded code point.  A
+/// Tries to get the length of UTF-8 encoded code point. A
 /// positive return value means the UTF-8 sequence is valid, and
-/// the result is the length of the code point.  A negative return value means
+/// the result is the length of the code point. A negative return value means
 /// the UTF-8 sequence at the position is invalid, and the length of the invalid
-/// sequence is the absolute value of the result.
+/// sequence is the absolute value of the result. A byte sequence is recognized
+/// as an invalid UTF-8 code point of length N in either of the folllowing
+/// situations:
+///   1. The first byte is a continuation byte or indicates the length of the
+///      code point is greater than 6. N is 1 in this situation.
+///   2. The first byte indicates a length of M > N, but there are only N-1
+///      bytes left afterwards in the buffer of the given `size`.
+///   3. The first byte indicates a length of M > N, but only the subsequent
+///      N-1 bytes are continuation bytes.
+///   4. The first byte indicates a length of N, but the code point is
+///      overlong-encoded, a surrogate character not allowed in UTF-8, or above
+///      the Unicode upper bound 0x10FFFF.
+///   5. The first byte indicates a length of N > 4. Code points of more
+///      than 4 bytes are no longer allowed per RFC3629.
 ///
 /// @param input Pointer to the first byte of the code point. Must not be null.
 /// @param size Number of available bytes. Must be greater than zero.


### PR DESCRIPTION
Summary:
For in invalid codepoint of multiple-byte long, e.g., 0xFB 0xB7 0x8E 0xB6 0xBE,
from_utf8() used to recognizie it as multiple invalid codepoint of one byte each.
On the other hand, Presto recognize it as one codepoint. This makes the result
of from_utf8() different between Velox and Presto because Presto replaces the
invalid sequence with one 0xFFFD while Velox replaces it with five. This diff
makes from_utf8() follow Presto behavior.

Differential Revision: D51050645


