### PR TITLE
Stop using ExchangeSource::supportsFlowControlV2

### DIFF
--- a/velox/exec/ExchangeClient.cpp
+++ b/velox/exec/ExchangeClient.cpp
@@ -133,48 +133,28 @@ std::unique_ptr<SerializedPage> ExchangeClient::next(
 void ExchangeClient::request(const RequestSpec& requestSpec) {
   auto& exec = folly::QueuedImmediateExecutor::instance();
   for (auto& source : requestSpec.sources) {
-    if (source->supportsFlowControlV2()) {
-      auto future =
-          source->request(requestSpec.maxBytes, kDefaultMaxWaitSeconds);
-      VELOX_CHECK(future.valid());
-      std::move(future)
-          .via(&exec)
-          .thenValue([this, requestSource = source](auto&& response) {
-            RequestSpec requestSpec;
-            {
-              std::lock_guard<std::mutex> l(queue_->mutex());
-              if (!response.atEnd) {
-                if (response.bytes > 0) {
-                  producingSources_.push(requestSource);
-                } else {
-                  emptySources_.push(requestSource);
-                }
+    auto future = source->request(requestSpec.maxBytes, kDefaultMaxWaitSeconds);
+    VELOX_CHECK(future.valid());
+    std::move(future)
+        .via(&exec)
+        .thenValue([this, requestSource = source](auto&& response) {
+          RequestSpec requestSpec;
+          {
+            std::lock_guard<std::mutex> l(queue_->mutex());
+            if (!response.atEnd) {
+              if (response.bytes > 0) {
+                producingSources_.push(requestSource);
+              } else {
+                emptySources_.push(requestSource);
               }
-              requestSpec = pickSourcesToRequestLocked();
             }
-            request(requestSpec);
-          })
-          .thenError(
-              folly::tag_t<std::exception>{},
-              [&](const std::exception& e) { queue_->setError(e.what()); });
-    } else {
-      auto future = source->request(requestSpec.maxBytes);
-      VELOX_CHECK(future.valid());
-      std::move(future)
-          .via(&exec)
-          .thenValue([this, requestSource = source](auto&& /*unused*/) {
-            RequestSpec requestSpec;
-            {
-              std::lock_guard<std::mutex> l(queue_->mutex());
-              emptySources_.push(requestSource);
-              requestSpec = pickSourcesToRequestLocked();
-            }
-            request(requestSpec);
-          })
-          .thenError(
-              folly::tag_t<std::exception>{},
-              [&](const std::exception& e) { queue_->setError(e.what()); });
-    }
+            requestSpec = pickSourcesToRequestLocked();
+          }
+          request(requestSpec);
+        })
+        .thenError(
+            folly::tag_t<std::exception>{},
+            [&](const std::exception& e) { queue_->setError(e.what()); });
   }
 }
 

--- a/velox/exec/ExchangeSource.h
+++ b/velox/exec/ExchangeSource.h
@@ -42,7 +42,7 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
   /// Temporary API to indicate whether 'request(maxBytes, maxWaitSeconds)' API
   /// is supported.
   virtual bool supportsFlowControlV2() const {
-    return false;
+    VELOX_UNREACHABLE();
   }
 
   /// Returns true if there is no request to the source pending or if

--- a/velox/exec/tests/utils/LocalExchangeSource.cpp
+++ b/velox/exec/tests/utils/LocalExchangeSource.cpp
@@ -29,10 +29,6 @@ class LocalExchangeSource : public exec::ExchangeSource {
       memory::MemoryPool* pool)
       : ExchangeSource(taskId, destination, queue, pool) {}
 
-  bool supportsFlowControlV2() const override {
-    return true;
-  }
-
   bool shouldRequestLocked() override {
     if (atEnd_) {
       return false;


### PR DESCRIPTION
All clients have migrated to the new API. 