### PR TITLE
Fix pyvelox signature check test for concat.

### DIFF
--- a/pyvelox/test/test_signatures.py
+++ b/pyvelox/test/test_signatures.py
@@ -41,9 +41,11 @@ class TestFunctionSignatures(unittest.TestCase):
         concat_signatures = presto_signatures["concat"]
         self.assertTrue(len(concat_signatures) > 0)
         # Array functions are registered first, then string functions.
+        concat_signatures.sort(key=lambda sig: sig.__str__())
         self.assertEqual(str(concat_signatures[0].return_type()), "array(__user_T1)")
         self.assertEqual(
-            str(concat_signatures[0]), "(array(__user_T1)...) -> array(__user_T1)"
+            str(concat_signatures[0]),
+            "(__user_T1,array(__user_T1)) -> array(__user_T1)",
         )
         self.assertEqual(str(concat_signatures[-1].return_type()), "varchar")
         self.assertEqual(str(concat_signatures[-1]), "(varchar,varchar...) -> varchar")


### PR DESCRIPTION
Ensure we sort the signatures and also take the newer signature added. 