### PR TITLE
Add antlr4-runtime-cpp installation in setup scripts

### DIFF
--- a/scripts/setup-centos8.sh
+++ b/scripts/setup-centos8.sh
@@ -44,6 +44,9 @@ dnf_install curl-devel c-ares-devel
 
 dnf_install conda
 
+# Required for Antlr4
+dnf install -y libuuid-devel
+
 # Activate gcc9; enable errors on unset variables afterwards.
 source /opt/rh/gcc-toolset-9/enable || exit 1
 set -u
@@ -84,6 +87,15 @@ wait  # For cmake and source downloads to complete.
   cd boost
   ./bootstrap.sh --prefix=/usr/local
   ./b2 "-j$(nproc)" -d0 install threading=multi
+)
+
+(
+  wget https://www.antlr.org/download/antlr4-cpp-runtime-4.9.3-source.zip &&
+  mkdir antlr4-cpp-runtime-4.9.3-source &&
+  cd antlr4-cpp-runtime-4.9.3-source &&
+  unzip ../antlr4-cpp-runtime-4.9.3-source.zip &&
+  cmake_install_deps antlr4 -DBUILD_SHARED_LIBS=ON
+  ldconfig
 )
 
 cmake_install_deps gflags -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DBUILD_gflags_LIB=ON -DLIB_SUFFIX=64 -DCMAKE_INSTALL_PREFIX:PATH=/usr

--- a/scripts/setup-circleci.sh
+++ b/scripts/setup-circleci.sh
@@ -41,6 +41,9 @@ dnf_install autoconf automake libtool bison flex python3 libsodium-devel
 
 dnf_install conda
 
+# Required for Antlr4
+dnf install -y libuuid-devel
+
 # install sphinx for doc gen
 pip3 install sphinx sphinx-tabs breathe sphinx_rtd_theme
 
@@ -105,6 +108,15 @@ cp -a hadoop /usr/local/
   ./configure --prefix=/usr
   make "-j${NPROC}"
   make install
+  ldconfig
+)
+
+(
+  wget https://www.antlr.org/download/antlr4-cpp-runtime-4.9.3-source.zip &&
+  mkdir antlr4-cpp-runtime-4.9.3-source &&
+  cd antlr4-cpp-runtime-4.9.3-source &&
+  unzip ../antlr4-cpp-runtime-4.9.3-source.zip &&
+  cmake_install antlr4 -DBUILD_SHARED_LIBS=ON
   ldconfig
 )
 

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -113,6 +113,12 @@ function install_re2 {
   cmake_install -DRE2_BUILD_TESTING=OFF
 }
 
+function install_antlr {
+  github_checkout antlr/antlr4 "4.9.3"
+  cd runtime/Cpp
+  cmake_install -DBUILD_TESTS=OFF
+}
+
 function install_velox_deps {
   if [ "${INSTALL_PREREQUISITES:-Y}" == "Y" ]; then
     run_and_time install_build_prerequisites
@@ -121,6 +127,8 @@ function install_velox_deps {
   run_and_time install_fmt
   run_and_time install_double_conversion
   run_and_time install_re2
+  run_and_time install_antlr
+
 }
 
 (return 2> /dev/null) && return # If script was sourced, don't run commands.

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -117,6 +117,18 @@ function install_conda {
   bash Miniconda3-latest-Linux-x86_64.sh -b -p $MINICONDA_PATH
 }
 
+function install_antlr4 {
+    cd "${DEPENDENCY_DIR}"
+      if [ -d "antlr4-cpp-runtime-4.9.3-source" ]; then
+        rm -rf antlr4-cpp-runtime-4.9.3-source
+      fi
+    wget https://www.antlr.org/download/antlr4-cpp-runtime-4.9.3-source.zip -O antlr4-cpp-runtime-4.9.3-source.zip
+    mkdir antlr4-cpp-runtime-4.9.3-source && cd antlr4-cpp-runtime-4.9.3-source
+    unzip ../antlr4-cpp-runtime-4.9.3-source.zip
+    mkdir build && mkdir run && cd build
+    cmake .. && make "-j${NPROC}" install
+}
+
 function install_velox_deps {
   run_and_time install_fmt
   run_and_time install_folly
@@ -124,6 +136,7 @@ function install_velox_deps {
   run_and_time install_wangle
   run_and_time install_fbthrift
   run_and_time install_conda
+  run_and_time install_antlr4
 }
 
 (return 2> /dev/null) && return # If script was sourced, don't run commands.


### PR DESCRIPTION
As discussed in #7417 PrestoDB has a parseTypeSignature API, 
which can parse a type string to a Velox type. However, we do
not have this kind of API in Velox. To add this parser, we need
to have antlr4-cpp-runtime first. Use the same way in PrestoDB
to add antlr4 through setup scripts, such as `function install_antlr4`
in https://github.com/prestodb/presto/blob/master/presto-native-execution/scripts/setup-ubuntu.sh#L48