### PR TITLE
string_view for `typeToEncodingName()`

### DIFF
--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -99,7 +99,7 @@ bool isChecksumBitSet(int8_t codec) {
   return (codec & kCheckSumBitMask) == kCheckSumBitMask;
 }
 
-std::string typeToEncodingName(const TypePtr& type) {
+std::string_view typeToEncodingName(const TypePtr& type) {
   switch (type->kind()) {
     case TypeKind::BOOLEAN:
       return "BYTE_ARRAY";


### PR DESCRIPTION
Summary:
# Problem
This function is dealing with all string literals. We do not need to create `std::string` to access. Let's use `std::string_view`.

Differential Revision: D50978122


