### PR TITLE
Fix ColumnReader

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -24,7 +24,6 @@
 namespace facebook::velox::dwrf {
 
 using dwio::common::ColumnSelector;
-using dwio::common::ExecutorBarrier;
 using dwio::common::FileFormat;
 using dwio::common::InputStream;
 using dwio::common::ReaderOptions;
@@ -35,10 +34,7 @@ DwrfRowReader::DwrfRowReader(
     const RowReaderOptions& opts)
     : StripeReaderBase(reader),
       options_(opts),
-      executorBarrier_{
-          options_.getDecodingExecutor() ? std::make_unique<ExecutorBarrier>(
-                                               options_.getDecodingExecutor())
-                                         : nullptr},
+      executor_{options_.getDecodingExecutor()},
       columnSelector_{std::make_shared<ColumnSelector>(
           ColumnSelector::apply(opts.getSelector(), reader->getSchema()))} {
   auto& footer = getReader().getFooter();
@@ -265,9 +261,6 @@ void DwrfRowReader::readNext(
         mutation == nullptr,
         "Mutation pushdown is only supported in selective reader");
     columnReader_->next(rowsToRead, result);
-    if (executorBarrier_) {
-      executorBarrier_->waitAll();
-    }
     auto reportDecodingTimeMsMetric = options_.getDecodingTimeMsCallback();
     if (reportDecodingTimeMsMetric) {
       auto decodingTime = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -521,7 +514,7 @@ DwrfRowReader::FetchResult DwrfRowReader::fetch(uint32_t stripeIndex) {
         fileType,
         stripeStreams,
         streamLabels,
-        executorBarrier_.get(),
+        executor_.get(),
         flatMapContext);
   }
   DWIO_ENSURE(

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -16,8 +16,8 @@
 
 #pragma once
 
+#include "folly/Executor.h"
 #include "folly/synchronization/Baton.h"
-#include "velox/dwio/common/ExecutorBarrier.h"
 #include "velox/dwio/common/ReaderFactory.h"
 #include "velox/dwio/dwrf/reader/SelectiveDwrfReader.h"
 
@@ -146,7 +146,7 @@ class DwrfRowReader : public StrideIndexProvider,
   uint64_t strideIndex_;
   std::shared_ptr<StripeDictionaryCache> stripeDictionaryCache_;
   dwio::common::RowReaderOptions options_;
-  std::unique_ptr<dwio::common::ExecutorBarrier> executorBarrier_;
+  std::shared_ptr<folly::Executor> executor_;
 
   struct PrefetchedStripeState {
     bool preloaded;


### PR DESCRIPTION
Summary:
D50459051 (https://github.com/facebookincubator/velox/pull/7151) and D50472518 (https://github.com/facebookincubator/velox/pull/7155) broke the reader for cases where children vectors had different types than the ones that would be read.

Undoing those changes and parallelizing at that level.

Differential Revision: D51088935


