### PR TITLE
Disabling spilling for aggrs with distinct and sorting.

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -227,6 +227,21 @@ void addSortingKeys(
 }
 } // namespace
 
+bool AggregationNode::canSpill(const QueryConfig& queryConfig) const {
+  // TODO: add spilling for aggregations with sorting or with distinct later:
+  // https://github.com/facebookincubator/velox/issues/7454
+  // https://github.com/facebookincubator/velox/issues/7455
+  for (const auto& aggregate : aggregates_) {
+    if (aggregate.distinct || !aggregate.sortingKeys.empty()) {
+      return false;
+    }
+  }
+  // TODO: add spilling for pre-grouped aggregation later:
+  // https://github.com/facebookincubator/velox/issues/3264
+  return (isFinal() || isSingle()) && preGroupedKeys().empty() &&
+      queryConfig.aggregationSpillEnabled();
+}
+
 void AggregationNode::addDetails(std::stringstream& stream) const {
   stream << stepName(step_) << " ";
 

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -597,12 +597,7 @@ class AggregationNode : public PlanNode {
     return "Aggregation";
   }
 
-  bool canSpill(const QueryConfig& queryConfig) const override {
-    // TODO: add spilling for pre-grouped aggregation later:
-    // https://github.com/facebookincubator/velox/issues/3264
-    return (isFinal() || isSingle()) && preGroupedKeys().empty() &&
-        queryConfig.aggregationSpillEnabled();
-  }
+  bool canSpill(const QueryConfig& queryConfig) const override;
 
   bool isFinal() const {
     return step_ == Step::kFinal;


### PR DESCRIPTION
Summary:
Disabling spilling for aggregations with distinct and sorting,
because these aren't supported yet.

Differential Revision: D51091567


