### PR TITLE
Fix call to unsafeResize in StructColumnReader

### DIFF
--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -1864,7 +1864,7 @@ void StructColumnReader::next(
     DWIO_ENSURE_GE(childrenVectors.size(), children_.size());
 
     // Resize rowVector
-    rowVector->unsafeResize(numValues);
+    rowVector->unsafeResize(numValues, false);
   }
 
   BufferPtr nulls = readNulls(numValues, result, incomingNulls);


### PR DESCRIPTION
Summary:
Ensure call to unsafeResize sets new rows to false in StructColumnReader.
When adding unsafeRowApi (D50577808) I missed setting one call to false instead of the default true.

Reviewed By: Yuhta

Differential Revision: D51091937


