### PR TITLE
Avoid caching filter result in FilterProject::filterEvalCtx_ when enable_expression_evaluation_cache is false

### DIFF
--- a/velox/exec/OperatorUtils.h
+++ b/velox/exec/OperatorUtils.h
@@ -31,8 +31,8 @@ void deselectRowsWithNulls(
 // Reusable memory needed for processing filter results.
 struct FilterEvalCtx {
   DecodedVector decodedResult;
-  BufferPtr selectedIndices;
-  BufferPtr selectedBits;
+  BufferPtr selectedIndices = nullptr;
+  BufferPtr selectedBits = nullptr;
 
   // Make sure selectedBits has enough capacity to hold 'size' bits and return
   // raw pointer to the underlying buffer.
@@ -45,6 +45,12 @@ struct FilterEvalCtx {
   vector_size_t* FOLLY_NONNULL getRawSelectedIndices(
       vector_size_t size,
       memory::MemoryPool* FOLLY_NONNULL pool);
+
+  void reset() {
+    decodedResult.reset(0);
+    selectedIndices = nullptr;
+    selectedBits = nullptr;
+  }
 };
 
 // Convert the results of filter evaluation as a vector of booleans into indices

--- a/velox/exec/tests/utils/OperatorTestBase.h
+++ b/velox/exec/tests/utils/OperatorTestBase.h
@@ -89,6 +89,12 @@ class OperatorTestBase : public testing::Test,
   }
 
   std::shared_ptr<Task> assertQuery(
+      const CursorParameters& params,
+      const RowVectorPtr& expectedResults) {
+    return test::assertQuery(params, {expectedResults});
+  }
+
+  std::shared_ptr<Task> assertQuery(
       const core::PlanNodePtr& plan,
       const std::string& duckDbSql) {
     return test::assertQuery(plan, duckDbSql, duckDbQueryRunner_);

--- a/velox/vector/DecodedVector.cpp
+++ b/velox/vector/DecodedVector.cpp
@@ -105,8 +105,12 @@ void DecodedVector::makeIndices(
 
 void DecodedVector::reset(vector_size_t size) {
   if (!indicesNotCopied()) {
+    copiedIndices_.resize(size);
     // Init with default value to avoid invalid indices for unselected rows)
     std::fill(copiedIndices_.begin(), copiedIndices_.end(), 0);
+  }
+  if (!nullsNotCopied()) {
+    copiedNulls_.resize(bits::nwords(size));
   }
   size_ = size;
   indices_ = nullptr;

--- a/velox/vector/DecodedVector.h
+++ b/velox/vector/DecodedVector.h
@@ -292,6 +292,10 @@ class DecodedVector {
   /// Pre-allocated vector of 0, 1, 2,..
   static const std::vector<vector_size_t>& consecutiveIndices();
 
+  /// Resets all internal states of the DecodedVector and set its size to
+  /// `size`.
+  void reset(vector_size_t size);
+
  private:
   DecodedVector(
       const BaseVector& vector,
@@ -344,8 +348,6 @@ class DecodedVector {
   void setBaseDataForConstant(
       const BaseVector& vector,
       const SelectivityVector* rows);
-
-  void reset(vector_size_t size);
 
   // If `rows` is null applies the `func` to all rows in [0, size_)
   // otherwise, applies it to selected rows only.


### PR DESCRIPTION
Summary:
When the query config enable_expression_evaluation_cache is false, avoid caching
filter result in FilterProject::filterEvalCtx_ by resetting it after it is used. This diff also
updates FilterProjectTest to run unit tests with enable_expression_evaluation_cache
being both true and false to ensure correctness.

Differential Revision: D51092512


