### PR TITLE
Reuse aggregation input vectors in sorted aggregations

### DIFF
--- a/velox/exec/SortedAggregations.h
+++ b/velox/exec/SortedAggregations.h
@@ -85,9 +85,10 @@ class SortedAggregations {
       std::vector<char*>& groupRows,
       const SortingSpec& sortingSpec);
 
-  std::vector<VectorPtr> extractSingleGroup(
+  vector_size_t extractSingleGroup(
       std::vector<char*>& groupRows,
-      const AggregateInfo& aggregate);
+      const AggregateInfo& aggregate,
+      std::vector<VectorPtr>& inputVectors);
 
   struct Hash {
     static uint64_t hashSortOrder(const core::SortOrder& sortOrder) {


### PR DESCRIPTION
Profile for sorted aggregations shows 30% of the cpu time spent in creating
vectors and another 30% in destructing vectors. Rearrange the code to reuse the
vectors.