### PR TITLE
Fix empty aggregation spill check failure

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1038,7 +1038,9 @@ bool GroupingSet::getOutputWithSpill(
     merge_ = spiller_->startMerge();
   }
   VELOX_CHECK_EQ(spiller_->state().maxPartitions(), 1);
-  VELOX_CHECK_NOT_NULL(merge_);
+  if (merge_ == nullptr) {
+    return false;
+  }
   return mergeNext(maxOutputRows, maxOutputBytes, result);
 }
 
@@ -1058,6 +1060,7 @@ bool GroupingSet::mergeNextWithAggregates(
     int32_t maxOutputBytes,
     const RowVectorPtr& result) {
   VELOX_CHECK(!isDistinct());
+  VELOX_CHECK_NOT_NULL(merge_);
 
   // True if 'merge_' indicates that the next key is the same as the current
   // one.
@@ -1088,6 +1091,7 @@ bool GroupingSet::mergeNextWithAggregates(
 bool GroupingSet::mergeNextWithoutAggregates(
     int32_t maxOutputRows,
     const RowVectorPtr& result) {
+  VELOX_CHECK_NOT_NULL(merge_);
   VELOX_CHECK(isDistinct());
 
   // We are looping over sorted rows produced by tree-of-losers. We logically

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -516,6 +516,10 @@ void HashAggregation::reclaim(
   VELOX_CHECK(canReclaim());
   VELOX_CHECK(!nonReclaimableSection_);
 
+  if (groupingSet_ == nullptr) {
+    return;
+  }
+
   updateEstimatedOutputRowSize();
 
   if (noMoreInput_) {


### PR DESCRIPTION
The spilling can be triggered during aggregation output processing stage.
If it happens that all the output have been produced and before we finish the
operator, the output spilling will be triggered but nothing will be spilled. This
triggers a check failure in un-spill path which expect spill data if the spiller has
been triggered.
This PR remove this check and adds unit test to reproduce this. Note it is not
easy to detect if a hash aggregation operator has produced all the output or not
from row container iterator. 
