### PR TITLE
Fix CompactRowSerializer handling of split rows

### DIFF
--- a/velox/serializers/tests/CMakeLists.txt
+++ b/velox/serializers/tests/CMakeLists.txt
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 add_executable(
-  velox_presto_serializer_test
+  velox_serializer_test
   PrestoOutputStreamListenerTest.cpp PrestoSerializerTest.cpp
   UnsafeRowSerializerTest.cpp CompactRowSerializerTest.cpp)
 
-add_test(velox_presto_serializer_test velox_presto_serializer_test)
+add_test(velox_serializer_test velox_serializer_test)
 
 target_link_libraries(
-  velox_presto_serializer_test
+  velox_serializer_test
   velox_presto_serializer
   velox_vector_test_lib
   velox_vector_fuzzer


### PR DESCRIPTION
Summary:
Applying the fix on
https://github.com/facebookincubator/velox/pull/7468 to CompactRow since it was
forked off of UnsafeRowSerializer.

Differential Revision: D51128086


