### PR TITLE
Avoid program crash by catching BufferedWriter error with abort support

### DIFF
--- a/velox/dwio/dwrf/utils/BufferedWriter.h
+++ b/velox/dwio/dwrf/utils/BufferedWriter.h
@@ -83,6 +83,14 @@ class BufferedWriter {
     flush();
   }
 
+  /// Invoked to abort this buffered write on error. It closes the buffered
+  /// writer without flushing pending buffers.
+  void abort() {
+    VELOX_CHECK(!closed_);
+    pos_ = 0;
+    closed_ = true;
+  }
+
   std::string toString() const {
     return fmt::format(
         "BufferedWriter[pos[{}] capacity[{}] closed[{}]]",

--- a/velox/dwio/dwrf/utils/test/BufferedWriterTest.cpp
+++ b/velox/dwio/dwrf/utils/test/BufferedWriterTest.cpp
@@ -218,16 +218,47 @@ TEST_P(BufferedWriterTest, closeTest) {
     writer = std::make_unique<BufferedWriter<char, WriteFn>>(
         *pool_, bufferSize, writeFn);
   } else {
-    writer = std::make_unique<BufferedWriter<char, WriteFn>>(
-        *pool_, bufferSize, writeFn);
+    writer = std::make_unique<BufferedWriter<char, WriteFn>>(*buffer, writeFn);
   }
   writer->add('a');
   ASSERT_EQ(
       writer->toString(),
       "BufferedWriter[pos[1] capacity[1024] closed[false]]");
   writer->close();
+  ASSERT_EQ(flushCount, 1);
   // Verify all the calls on a closed object throw.
   VELOX_ASSERT_THROW(writer->close(), "");
+  VELOX_ASSERT_THROW(writer->abort(), "");
+  VELOX_ASSERT_THROW(writer->add('a'), "");
+  VELOX_ASSERT_THROW(writer->flush(), "");
+}
+
+TEST_P(BufferedWriterTest, abortTest) {
+  const int bufferSize = 1024;
+  std::unique_ptr<dwio::common::DataBuffer<char>> buffer;
+  if (!usePool_) {
+    buffer =
+        std::make_unique<dwio::common::DataBuffer<char>>(*pool_, bufferSize);
+  }
+  size_t flushCount{0};
+  auto writeFn = [&](char* buf, size_t size) { flushCount += size; };
+  std::unique_ptr<BufferedWriter<char, WriteFn>> writer;
+  if (usePool_) {
+    writer = std::make_unique<BufferedWriter<char, WriteFn>>(
+        *pool_, bufferSize, writeFn);
+  } else {
+    writer = std::make_unique<BufferedWriter<char, WriteFn>>(*buffer, writeFn);
+  }
+  writer->add('a');
+  ASSERT_EQ(
+      writer->toString(),
+      "BufferedWriter[pos[1] capacity[1024] closed[false]]");
+  writer->abort();
+  // Verify nothing has been flushed on abort.
+  ASSERT_EQ(flushCount, 0);
+  // Verify all the calls on an abort object throw.
+  VELOX_ASSERT_THROW(writer->close(), "");
+  VELOX_ASSERT_THROW(writer->abort(), "");
   VELOX_ASSERT_THROW(writer->add('a'), "");
   VELOX_ASSERT_THROW(writer->flush(), "");
 }


### PR DESCRIPTION
BufferedWriter destructor checks if there is no pending buffer or not.
It throws if there is pending buffers as it will cause silent data corruption on write.
However throws in object destructor will crash the program. This change fixes
the issue by adding abort method to BufferedWriter and try catch any errors
during BufferedWriter processing.