### PR TITLE
Skip spilling if all the partitions have been spilled

### DIFF
--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -633,6 +633,11 @@ bool HashBuild::requestSpill(RowVectorPtr& input) {
   VELOX_CHECK_GT(numSpillRows_, 0);
   VELOX_CHECK_GT(numSpillBytes_, 0);
 
+  // If all the partitions have been spilled, then nothing to spill.
+  if (spiller_->isAllSpilled()) {
+    return true;
+  }
+
   input_ = std::move(input);
   if (spillGroup_->requestSpill(*this, future_)) {
     VELOX_CHECK(future_.valid());


### PR DESCRIPTION
If memory arbitration has reclaimed memory from the hash build operator which
request memory reservation, and there is still lack of memory, then the hash build
operator will try spill. However, this is not required if the memory arbitration has enabled.
This can lead to a check failure in HashBuild::runSpill which expects not all the partitions
have been spilled.
This PR adds a check if all the partitions have been spilled when memory reservation
fails for a hash build operator, and skip spilling if all the partitions have been spilled.