### PR TITLE
Add termination time to TaskStats

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1697,6 +1697,11 @@ ContinueFuture Task::terminate(TaskState terminalState) {
     if (taskStats_.executionEndTimeMs == 0) {
       taskStats_.executionEndTimeMs = getCurrentTimeMs();
     }
+    if (taskStats_.terminationTimeMs == 0) {
+      // In case terminate gets called multiple times somehow,
+      // this represents the first time.
+      taskStats_.terminationTimeMs = getCurrentTimeMs();
+    }
     if (not isRunningLocked()) {
       return makeFinishFutureLocked("Task::terminate");
     }
@@ -1942,6 +1947,14 @@ uint64_t Task::timeSinceEndMs() const {
     return 0UL;
   }
   return getCurrentTimeMs() - taskStats_.executionEndTimeMs;
+}
+
+uint64_t Task::timeSinceTerminationMs() const {
+  std::lock_guard<std::mutex> l(mutex_);
+  if (taskStats_.terminationTimeMs == 0UL) {
+    return 0UL;
+  }
+  return getCurrentTimeMs() - taskStats_.terminationTimeMs;
 }
 
 void Task::onTaskCompletion() {

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -266,6 +266,10 @@ class Task : public std::enable_shared_from_this<Task> {
   /// Returns time (ms) since the task execution ended or zero, if not finished.
   uint64_t timeSinceEndMs() const;
 
+  /// Returns time (ms) since the task was terminated or zero, if not terminated
+  /// yet.
+  uint64_t timeSinceTerminationMs() const;
+
   /// Returns the total number of drivers in the output pipeline, e.g. the
   /// pipeline that produces the results.
   uint32_t numOutputDrivers() const {

--- a/velox/exec/TaskStats.h
+++ b/velox/exec/TaskStats.h
@@ -73,6 +73,11 @@ struct TaskStats {
   /// and results have been consumed.
   uint64_t endTimeMs{0};
 
+  /// Epoch time (ms) when the task was terminated, i.e. its terminal state
+  /// has been set, whether by finishing successfully or with an error, or
+  /// being cancelled or aborted.
+  uint64_t terminationTimeMs{0};
+
   /// Total number of drivers.
   uint64_t numTotalDrivers{0};
   /// The number of completed drivers (which slots are null in Task 'drivers_'


### PR DESCRIPTION
Summary:
Like the title says, store termination time, separately from execution end time, in the TaskStats.

The reason for needing termination time comes from Presto.  They currently use execution end time to determine when a task was last used and clean up the Task once it's terminated and after some threshold of time after the end time.  If a task has partitioned output, that output may not be fully consumed until some time after the execution end time.  Termination time is guaranteed to be after the partitioned output has been consumed (assuming the query is running successfully), and so it's a better reflection of how long ago the task was used.

Today we see that for some queries, the execution end time is long before the termination time, and so Presto will delete the task as soon as it's terminated.  This leads to issues with in flight status checks Presto makes against the Worker.

Differential Revision: D51140307


