### PR TITLE
Convert TIMESTAMP_WITH_TIME_ZONE to primitive type

### DIFF
--- a/velox/core/tests/ConstantTypedExprTest.cpp
+++ b/velox/core/tests/ConstantTypedExprTest.cpp
@@ -47,12 +47,8 @@ TEST(ConstantTypedExprTest, null) {
   EXPECT_FALSE(*makeNull(HYPERLOGLOG()) == *makeNull(VARBINARY()));
   EXPECT_FALSE(*makeNull(VARBINARY()) == *makeNull(HYPERLOGLOG()));
 
-  EXPECT_FALSE(
-      *makeNull(TIMESTAMP_WITH_TIME_ZONE()) ==
-      *makeNull(ROW({BIGINT(), SMALLINT()})));
-  EXPECT_FALSE(
-      *makeNull(ROW({BIGINT(), SMALLINT()})) ==
-      *makeNull(TIMESTAMP_WITH_TIME_ZONE()));
+  EXPECT_FALSE(*makeNull(TIMESTAMP_WITH_TIME_ZONE()) == *makeNull(BIGINT()));
+  EXPECT_FALSE(*makeNull(BIGINT()) == *makeNull(TIMESTAMP_WITH_TIME_ZONE()));
 
   EXPECT_TRUE(*makeNull(DOUBLE()) == *makeNull(DOUBLE()));
   EXPECT_TRUE(*makeNull(ARRAY(DOUBLE())) == *makeNull(ARRAY(DOUBLE())));

--- a/velox/functions/lib/RegistrationHelpers.h
+++ b/velox/functions/lib/RegistrationHelpers.h
@@ -63,8 +63,6 @@ void registerNonSimdizableScalar(const std::vector<std::string>& aliases) {
   registerFunction<T, TReturn, bool, bool>(aliases);
   registerFunction<T, TReturn, Timestamp, Timestamp>(aliases);
   registerFunction<T, TReturn, Date, Date>(aliases);
-  registerFunction<T, TReturn, TimestampWithTimezone, TimestampWithTimezone>(
-      aliases);
 }
 
 template <template <class> class T>

--- a/velox/functions/prestosql/Comparisons.h
+++ b/velox/functions/prestosql/Comparisons.h
@@ -30,17 +30,17 @@ struct TimestampWithTimezoneComparisonSupport {
   FOLLY_ALWAYS_INLINE
   int64_t toGMTMillis(
       const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
-    const int64_t milliseconds = *timestampWithTimezone.template at<0>();
-    const int16_t timezone = *timestampWithTimezone.template at<1>();
-    Timestamp inputTimeStamp = Timestamp::fromMillis(milliseconds);
+    auto inputTimeStamp = unpackTimestampUtc(timestampWithTimezone);
+    const auto timezone = unpackZoneKeyId(timestampWithTimezone);
     inputTimeStamp.toGMT(timezone);
+
     return inputTimeStamp.toMillis();
   }
 };
 
 } // namespace
 
-#define VELOX_GEN_BINARY_EXPR(Name, Expr, tsExpr, TResult)         \
+#define VELOX_GEN_BINARY_EXPR(Name, Expr, TResult)                 \
   template <typename T>                                            \
   struct Name : public TimestampWithTimezoneComparisonSupport<T> { \
     VELOX_DEFINE_FUNCTION_TYPES(T);                                \
@@ -49,37 +49,45 @@ struct TimestampWithTimezoneComparisonSupport {
     call(TResult& result, const TInput& lhs, const TInput& rhs) {  \
       result = (Expr);                                             \
     }                                                              \
-                                                                   \
-    FOLLY_ALWAYS_INLINE void call(                                 \
-        bool& result,                                              \
-        const arg_type<TimestampWithTimezone>& lhs,                \
-        const arg_type<TimestampWithTimezone>& rhs) {              \
-      result = (tsExpr);                                           \
-    }                                                              \
   };
 
-VELOX_GEN_BINARY_EXPR(
+#define VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(Name, tsExpr, TResult) \
+  template <typename T>                                                       \
+  struct Name##TimestampWithTimezone                                          \
+      : public TimestampWithTimezoneComparisonSupport<T> {                    \
+    VELOX_DEFINE_FUNCTION_TYPES(T);                                           \
+    FOLLY_ALWAYS_INLINE void call(                                            \
+        bool& result,                                                         \
+        const arg_type<TimestampWithTimezone>& lhs,                           \
+        const arg_type<TimestampWithTimezone>& rhs) {                         \
+      result = (tsExpr);                                                      \
+    }                                                                         \
+  };
+
+VELOX_GEN_BINARY_EXPR(LtFunction, lhs < rhs, bool);
+VELOX_GEN_BINARY_EXPR(GtFunction, lhs > rhs, bool);
+VELOX_GEN_BINARY_EXPR(LteFunction, lhs <= rhs, bool);
+VELOX_GEN_BINARY_EXPR(GteFunction, lhs >= rhs, bool);
+
+VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(
     LtFunction,
-    lhs < rhs,
     this->toGMTMillis(lhs) < this->toGMTMillis(rhs),
     bool);
-VELOX_GEN_BINARY_EXPR(
+VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(
     GtFunction,
-    lhs > rhs,
     this->toGMTMillis(lhs) > this->toGMTMillis(rhs),
     bool);
-VELOX_GEN_BINARY_EXPR(
+VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(
     LteFunction,
-    lhs <= rhs,
     this->toGMTMillis(lhs) <= this->toGMTMillis(rhs),
     bool);
-VELOX_GEN_BINARY_EXPR(
+VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(
     GteFunction,
-    lhs >= rhs,
     this->toGMTMillis(lhs) >= this->toGMTMillis(rhs),
     bool);
 
 #undef VELOX_GEN_BINARY_EXPR
+#undef VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE
 
 template <typename T>
 struct DistinctFromFunction {
@@ -104,21 +112,13 @@ struct DistinctFromFunction {
 };
 
 template <typename T>
-struct EqFunction : public TimestampWithTimezoneComparisonSupport<T> {
+struct EqFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   // Used for primitive inputs.
   template <typename TInput>
   void call(bool& out, const TInput& lhs, const TInput& rhs) {
     out = (lhs == rhs);
-  }
-
-  // For TimestampWithTimezone.
-  void call(
-      bool& result,
-      const arg_type<TimestampWithTimezone>& lhs,
-      const arg_type<TimestampWithTimezone>& rhs) {
-    result = this->toGMTMillis(lhs) == this->toGMTMillis(rhs);
   }
 
   // For arbitrary nested complex types. Can return null.
@@ -139,21 +139,26 @@ struct EqFunction : public TimestampWithTimezoneComparisonSupport<T> {
 };
 
 template <typename T>
-struct NeqFunction : public TimestampWithTimezoneComparisonSupport<T> {
+struct EqFunctionTimestampWithTimezone
+    : public TimestampWithTimezoneComparisonSupport<T> {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  void call(
+      bool& result,
+      const arg_type<TimestampWithTimezone>& lhs,
+      const arg_type<TimestampWithTimezone>& rhs) {
+    result = this->toGMTMillis(lhs) == this->toGMTMillis(rhs);
+  }
+};
+
+template <typename T>
+struct NeqFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   // Used for primitive inputs.
   template <typename TInput>
   void call(bool& out, const TInput& lhs, const TInput& rhs) {
     out = (lhs != rhs);
-  }
-
-  // For TimestampWithTimezone.
-  void call(
-      bool& result,
-      const arg_type<TimestampWithTimezone>& lhs,
-      const arg_type<TimestampWithTimezone>& rhs) {
-    result = this->toGMTMillis(lhs) != this->toGMTMillis(rhs);
   }
 
   // For arbitrary nested complex types. Can return null.
@@ -167,6 +172,19 @@ struct NeqFunction : public TimestampWithTimezoneComparisonSupport<T> {
     } else {
       return false;
     }
+  }
+};
+
+template <typename T>
+struct NeqFunctionTimestampWithTimezone
+    : public TimestampWithTimezoneComparisonSupport<T> {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  void call(
+      bool& result,
+      const arg_type<TimestampWithTimezone>& lhs,
+      const arg_type<TimestampWithTimezone>& rhs) {
+    result = this->toGMTMillis(lhs) != this->toGMTMillis(rhs);
   }
 };
 

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -40,7 +40,7 @@ struct ToUnixtimeFunction {
   FOLLY_ALWAYS_INLINE bool call(
       double& result,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
-    const auto milliseconds = *timestampWithTimezone.template at<0>();
+    const auto milliseconds = unpackMillisUtc(timestampWithTimezone);
     result = (double)milliseconds / kMillisecondsInSecond;
     return true;
   }
@@ -75,11 +75,9 @@ struct TimestampWithTimezoneSupport {
   Timestamp toTimestamp(
       const arg_type<TimestampWithTimezone>& timestampWithTimezone,
       bool asGMT = false) {
-    const auto milliseconds = *timestampWithTimezone.template at<0>();
-    auto tz = *timestampWithTimezone.template at<1>();
-    Timestamp timestamp = Timestamp::fromMillis(milliseconds);
+    auto timestamp = unpackTimestampUtc(timestampWithTimezone);
     if (!asGMT) {
-      timestamp.toTimezone(*timestampWithTimezone.template at<1>());
+      timestamp.toTimezone(unpackZoneKeyId(timestampWithTimezone));
     }
 
     return timestamp;
@@ -90,10 +88,9 @@ struct TimestampWithTimezoneSupport {
   int64_t getGMTOffsetSec(
       const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
     Timestamp inputTimeStamp = this->toTimestamp(timestampWithTimezone);
-
     // Create a copy of inputTimeStamp and convert it to GMT
     auto gmtTimeStamp = inputTimeStamp;
-    gmtTimeStamp.toGMT(*timestampWithTimezone.template at<1>());
+    gmtTimeStamp.toGMT(unpackZoneKeyId(timestampWithTimezone));
 
     // Get offset in seconds with GMT and convert to hour
     return (inputTimeStamp.getSeconds() - gmtTimeStamp.getSeconds());
@@ -908,11 +905,10 @@ struct DateTruncFunction : public TimestampWithTimezoneSupport<T> {
     }
 
     if (unit == DateTimeUnit::kSecond) {
-      auto utcTimestamp =
-          Timestamp::fromMillis(*timestampWithTimezone.template at<0>());
-      result.template get_writer_at<0>() = utcTimestamp.getSeconds() * 1000;
-      result.template get_writer_at<1>() =
-          *timestampWithTimezone.template at<1>();
+      auto utcTimestamp = unpackTimestampUtc(timestampWithTimezone);
+      result = pack(
+          utcTimestamp.getSeconds() * 1000,
+          unpackZoneKeyId(timestampWithTimezone));
       return;
     }
 
@@ -920,11 +916,9 @@ struct DateTruncFunction : public TimestampWithTimezoneSupport<T> {
     auto dateTime = getDateTime(timestamp, nullptr);
     adjustDateTime(dateTime, unit);
     timestamp = Timestamp::fromMillis(timegm(&dateTime) * 1000);
-    timestamp.toGMT(*timestampWithTimezone.template at<1>());
+    timestamp.toGMT(unpackZoneKeyId(timestampWithTimezone));
 
-    result.template get_writer_at<0>() = timestamp.toMillis();
-    result.template get_writer_at<1>() =
-        *timestampWithTimezone.template at<1>();
+    result = pack(timestamp.toMillis(), unpackZoneKeyId(timestampWithTimezone));
   }
 };
 
@@ -1009,9 +1003,9 @@ struct DateAddFunction : public TimestampWithTimezoneSupport<T> {
 
     auto finalTimeStamp = addToTimestamp(
         this->toTimestamp(timestampWithTimezone), unit, (int32_t)value);
-    finalTimeStamp.toGMT(*timestampWithTimezone.template at<1>());
-    result = std::make_tuple(
-        finalTimeStamp.toMillis(), *timestampWithTimezone.template at<1>());
+    auto tzID = unpackZoneKeyId(timestampWithTimezone);
+    finalTimeStamp.toGMT(tzID);
+    result = pack(finalTimeStamp.toMillis(), tzID);
 
     return true;
   }
@@ -1278,9 +1272,8 @@ struct FormatDateTimeFunction {
       const arg_type<Varchar>& formatString) {
     ensureFormatter(formatString);
 
-    const auto milliseconds = *timestampWithTimezone.template at<0>();
-    Timestamp timestamp = Timestamp::fromMillis(milliseconds);
-    int16_t timeZoneId = *timestampWithTimezone.template at<1>();
+    const auto timestamp = unpackTimestampUtc(timestampWithTimezone);
+    const auto timeZoneId = unpackZoneKeyId(timestampWithTimezone);
     auto* timezonePtr = date::locate_zone(util::getTimeZoneName(timeZoneId));
 
     auto maxResultSize = jodaDateTime_->maxResultSize(timezonePtr);
@@ -1345,7 +1338,7 @@ struct ParseDateTimeFunction {
         ? dateTimeResult.timezoneId
         : sessionTzID_.value_or(0);
     dateTimeResult.timestamp.toGMT(timezoneId);
-    result = std::make_tuple(dateTimeResult.timestamp.toMillis(), timezoneId);
+    result = pack(dateTimeResult.timestamp.toMillis(), timezoneId);
     return true;
   }
 };

--- a/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
@@ -375,17 +375,12 @@ TEST_F(ChecksumAggregateTest, globalAggregationNoData) {
 }
 
 TEST_F(ChecksumAggregateTest, timestampWithTimezone) {
-  auto timestamp =
-      makeFlatVector<int64_t>(5, [](auto row) { return 1639426440000; });
-  auto timezone = makeFlatVector<int16_t>(5, [](auto row) { return 0; });
-
-  auto timestampWithTzVector = std::make_shared<RowVector>(
-      pool_.get(),
-      TIMESTAMP_WITH_TIME_ZONE(),
-      BufferPtr(nullptr),
+  auto timestampWithTimezone = makeFlatVector<int64_t>(
       5,
-      std::vector<VectorPtr>{timestamp, timezone});
+      [](auto row) { return pack(1639426440000, 0); },
+      /* isNullAt */ nullptr,
+      TIMESTAMP_WITH_TIME_ZONE());
 
-  assertChecksum(timestampWithTzVector, "jwqENA0VLZY=");
+  assertChecksum(timestampWithTimezone, "jwqENA0VLZY=");
 }
 } // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
@@ -28,22 +28,52 @@ void registerComparisonFunctions(const std::string& prefix) {
   registerNonSimdizableScalar<EqFunction, bool>({prefix + "eq"});
   VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_eq, prefix + "eq");
   registerFunction<EqFunction, bool, Generic<T1>, Generic<T1>>({prefix + "eq"});
+  registerFunction<
+      EqFunctionTimestampWithTimezone,
+      bool,
+      TimestampWithTimezone,
+      TimestampWithTimezone>({prefix + "eq"});
 
   registerNonSimdizableScalar<NeqFunction, bool>({prefix + "neq"});
   VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_neq, prefix + "neq");
   registerFunction<NeqFunction, bool, Generic<T1>, Generic<T1>>(
       {prefix + "neq"});
+  registerFunction<
+      NeqFunctionTimestampWithTimezone,
+      bool,
+      TimestampWithTimezone,
+      TimestampWithTimezone>({prefix + "neq"});
 
   registerNonSimdizableScalar<LtFunction, bool>({prefix + "lt"});
+  registerFunction<
+      LtFunctionTimestampWithTimezone,
+      bool,
+      TimestampWithTimezone,
+      TimestampWithTimezone>({prefix + "lt"});
   VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_lt, prefix + "lt");
 
   registerNonSimdizableScalar<GtFunction, bool>({prefix + "gt"});
+  registerFunction<
+      GtFunctionTimestampWithTimezone,
+      bool,
+      TimestampWithTimezone,
+      TimestampWithTimezone>({prefix + "gt"});
   VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_gt, prefix + "gt");
 
   registerNonSimdizableScalar<LteFunction, bool>({prefix + "lte"});
+  registerFunction<
+      LteFunctionTimestampWithTimezone,
+      bool,
+      TimestampWithTimezone,
+      TimestampWithTimezone>({prefix + "lte"});
   VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_lte, prefix + "lte");
 
   registerNonSimdizableScalar<GteFunction, bool>({prefix + "gte"});
+  registerFunction<
+      GteFunctionTimestampWithTimezone,
+      bool,
+      TimestampWithTimezone,
+      TimestampWithTimezone>({prefix + "gte"});
   VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_gte, prefix + "gte");
 
   registerBinaryScalar<DistinctFromFunction, bool>({prefix + "distinct_from"});

--- a/velox/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
+++ b/velox/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
@@ -21,16 +21,17 @@ using namespace facebook::velox;
 
 class TimestampWithTimeZoneCastTest : public functions::test::CastBaseTest {
  public:
-  RowVectorPtr makeTimestampWithTimeZoneVector(
-      const VectorPtr& timestamps,
-      const VectorPtr& timezones) {
-    VELOX_CHECK_EQ(timestamps->size(), timezones->size());
-    return std::make_shared<RowVector>(
-        pool(),
-        TIMESTAMP_WITH_TIME_ZONE(),
+  VectorPtr makeTimestampWithTimeZoneVector(
+      vector_size_t size,
+      const std::function<int64_t(int32_t row)>& timestampAt,
+      const std::function<int16_t(int32_t row)>& timezoneAt) {
+    return makeFlatVector<int64_t>(
+        size,
+        [&](int32_t index) {
+          return pack(timestampAt(index), timezoneAt(index));
+        },
         nullptr,
-        timestamps->size(),
-        std::vector<VectorPtr>({timestamps, timezones}));
+        TIMESTAMP_WITH_TIME_ZONE());
   }
 
  protected:
@@ -51,20 +52,27 @@ class TimestampWithTimeZoneCastTest : public functions::test::CastBaseTest {
 TEST_F(TimestampWithTimeZoneCastTest, fromTimestamp) {
   const auto tsVector = makeNullableFlatVector<Timestamp>(
       {Timestamp(1996, 0), std::nullopt, Timestamp(19920, 0)});
+  auto timestamps =
+      std::vector<int64_t>{1996 * kMillisInSecond, 0, 19920 * kMillisInSecond};
+  auto timezones = std::vector<TimeZoneKey>{0, 0, 0};
   const auto expected = makeTimestampWithTimeZoneVector(
-      makeFlatVector<int64_t>(
-          {1996 * kMillisInSecond, 0, 19920 * kMillisInSecond}),
-      makeFlatVector<int16_t>({0, 0, 0}));
+      timestamps.size(),
+      [&](int32_t index) { return timestamps[index]; },
+      [&](int32_t index) { return timezones[index]; });
   expected->setNull(1, true);
 
   testCast(tsVector, expected);
 }
 
 TEST_F(TimestampWithTimeZoneCastTest, toTimestamp) {
+  auto timestamps =
+      std::vector<int64_t>{1996 * kMillisInSecond, 0, 19920 * kMillisInSecond};
+  auto timezones = std::vector<TimeZoneKey>{0, 0, 1825 /*America/Los_Angeles*/};
+
   const auto tsWithTZVector = makeTimestampWithTimeZoneVector(
-      makeFlatVector<int64_t>(
-          {1996 * kMillisInSecond, 0, 19920 * kMillisInSecond}),
-      makeFlatVector<int16_t>({0, 0, 1825 /*America/Los_Angeles*/}));
+      timestamps.size(),
+      [&](int32_t index) { return timestamps[index]; },
+      [&](int32_t index) { return timezones[index]; });
   tsWithTZVector->setNull(1, true);
 
   for (const char* timezone : {"America/Los_Angeles", "America/New_York"}) {

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
@@ -54,9 +54,8 @@ class TimestampWithTimeZoneCastOperator : public exec::CastOperator {
 
 /// Represents timestamp with time zone as a number of milliseconds since epoch
 /// and time zone ID.
-class TimestampWithTimeZoneType : public RowType {
-  TimestampWithTimeZoneType()
-      : RowType({"timestamp", "timezone"}, {BIGINT(), SMALLINT()}) {}
+class TimestampWithTimeZoneType : public BigintType {
+  TimestampWithTimeZoneType() = default;
 
  public:
   static const std::shared_ptr<const TimestampWithTimeZoneType>& get() {
@@ -105,7 +104,7 @@ TIMESTAMP_WITH_TIME_ZONE() {
 
 // Type used for function registration.
 struct TimestampWithTimezoneT {
-  using type = Row<int64_t, int16_t>;
+  using type = int64_t;
   static constexpr const char* typeName = "timestamp with time zone";
 };
 
@@ -125,4 +124,24 @@ class TimestampWithTimeZoneTypeFactories : public CustomTypeFactories {
 
 void registerTimestampWithTimeZoneType();
 
+using TimeZoneKey = int16_t;
+
+constexpr int32_t kTimezoneMask = 0xFFF;
+constexpr int32_t kMillisShift = 12;
+
+inline int64_t unpackMillisUtc(int64_t dateTimeWithTimeZone) {
+  return dateTimeWithTimeZone >> kMillisShift;
+}
+
+inline TimeZoneKey unpackZoneKeyId(int64_t dateTimeWithTimeZone) {
+  return dateTimeWithTimeZone & kTimezoneMask;
+}
+
+inline int64_t pack(int64_t millisUtc, int16_t timeZoneKey) {
+  return (millisUtc << kMillisShift) | (timeZoneKey & kTimezoneMask);
+}
+
+inline Timestamp unpackTimestampUtc(int64_t dateTimeWithTimeZone) {
+  return Timestamp::fromMillis(unpackMillisUtc(dateTimeWithTimeZone));
+}
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/tests/TimestampWithTimeZoneTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/TimestampWithTimeZoneTypeTest.cpp
@@ -28,7 +28,7 @@ class TimestampWithTimeZoneTypeTest : public testing::Test,
 
 TEST_F(TimestampWithTimeZoneTypeTest, basic) {
   ASSERT_EQ(TIMESTAMP_WITH_TIME_ZONE()->name(), "TIMESTAMP WITH TIME ZONE");
-  ASSERT_EQ(TIMESTAMP_WITH_TIME_ZONE()->kindName(), "ROW");
+  ASSERT_EQ(TIMESTAMP_WITH_TIME_ZONE()->kindName(), "BIGINT");
   ASSERT_TRUE(TIMESTAMP_WITH_TIME_ZONE()->parameters().empty());
   ASSERT_EQ(TIMESTAMP_WITH_TIME_ZONE()->toString(), "TIMESTAMP WITH TIME ZONE");
 
@@ -40,4 +40,29 @@ TEST_F(TimestampWithTimeZoneTypeTest, basic) {
 TEST_F(TimestampWithTimeZoneTypeTest, serde) {
   testTypeSerde(TIMESTAMP_WITH_TIME_ZONE());
 }
+
+TEST_F(TimestampWithTimeZoneTypeTest, pack) {
+  std::mt19937 randGen(std::random_device{}());
+  // 0xFFF8000000000000 and 0x7FFFFFFFFFFFF are hexadecimal numbers
+  // that represent the minimum and maximum values that the
+  // TimestampWithTimeZoneType type can represent, respectively.
+  std::uniform_int_distribution<int64_t> millisUtcDis(
+      0xFFF8000000000000L, 0x7FFFFFFFFFFFF);
+
+  // 2233 represents the maximum value of timeZoneKey,
+  // see tzDB in TimeZoneDatabase.cpp
+  std::uniform_int_distribution<int16_t> timeZoneKeyDis(0, 2233);
+
+  for (int64_t i = 0; i < 10'000; ++i) {
+    auto millisUtc = millisUtcDis(randGen);
+    auto timeZoneKey = timeZoneKeyDis(randGen);
+    SCOPED_TRACE(
+        fmt::format("millisUtc={}, timeZoneKey={}", millisUtc, timeZoneKey));
+
+    auto packedTimeMillis = pack(millisUtc, timeZoneKey);
+    ASSERT_EQ(unpackMillisUtc(packedTimeMillis), millisUtc);
+    ASSERT_EQ(unpackZoneKeyId(packedTimeMillis), timeZoneKey);
+  }
+}
+
 } // namespace facebook::velox::test

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -728,25 +728,19 @@ TEST_P(PrestoSerializerTest, emptyMap) {
 }
 
 TEST_P(PrestoSerializerTest, timestampWithTimeZone) {
-  auto timestamp =
-      makeFlatVector<int64_t>(100, [](auto row) { return 10'000 + row; });
-  auto timezone =
-      makeFlatVector<int16_t>(100, [](auto row) { return row % 37; });
-
-  auto vector = std::make_shared<RowVector>(
-      pool_.get(),
-      TIMESTAMP_WITH_TIME_ZONE(),
-      BufferPtr(nullptr),
+  auto timestamp = makeFlatVector<int64_t>(
       100,
-      std::vector<VectorPtr>{timestamp, timezone});
+      [](auto row) { return pack(10'000 + row, row % 37); },
+      /* isNullAt */ nullptr,
+      TIMESTAMP_WITH_TIME_ZONE());
 
-  testRoundTrip(vector);
+  testRoundTrip(timestamp);
 
   // Add some nulls.
   for (auto i = 0; i < 100; i += 7) {
-    vector->setNull(i, true);
+    timestamp->setNull(i, true);
   }
-  testRoundTrip(vector);
+  testRoundTrip(timestamp);
 }
 
 TEST_P(PrestoSerializerTest, intervalDayTime) {


### PR DESCRIPTION
TimestampWithTimeZone is a primitive type in Presto. In contrast,
 it is implemented as a Row<int64_t, int16_t> in Velox and hence 
treated as a complex type implicitly. This PR convert TIMESTAMP_WITH_TIME_ZONE 
to primitive type to achive better consistency between Velox and Presto, 
details of the discussion can be found [here](https://github.com/facebookincubator/velox/discussions/2511).

CC: @mbasmanova @aditi-pandit @majetideepak @kagamiori 