### PR TITLE
Add state to dwio common writer

### DIFF
--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(
   SeekableInputStream.cpp
   TypeUtils.cpp
   TypeWithId.cpp
+  Writer.cpp
   WriterFactory.cpp
   SortingWriter.cpp
   SortingWriter.h)

--- a/velox/dwio/common/SortingWriter.h
+++ b/velox/dwio/common/SortingWriter.h
@@ -68,14 +68,9 @@ class SortingWriter : public Writer {
 
   uint64_t reclaim(uint64_t targetBytes, memory::MemoryReclaimer::Stats& stats);
 
-  // Sets the sort writer as closed on close or abort. The function returns true
-  // if this sort writer has already been closed.
-  bool setClose();
-
   const std::unique_ptr<Writer> outputWriter_;
   memory::MemoryPool* const sortPool_;
   const bool canReclaim_;
-  bool closed_{false};
   std::unique_ptr<exec::SortBuffer> sortBuffer_;
 };
 

--- a/velox/dwio/common/Writer.cpp
+++ b/velox/dwio/common/Writer.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/Writer.h"
+
+namespace facebook::velox::dwio::common {
+void Writer::checkStateTransition(State oldState, State newState) {
+  switch (oldState) {
+    case State::kInit:
+      if (newState == State::kRunning) {
+        return;
+      }
+      break;
+    case State::kRunning:
+      if (newState == State::kAborted || newState == State::kClosed) {
+        return;
+      }
+      break;
+    case State::kAborted:
+      [[fallthrough]];
+    case State::kClosed:
+      [[fallthrough]];
+    default:
+      break;
+  }
+  VELOX_FAIL("Unexpected state transition from {} to {}", oldState, newState);
+}
+
+std::string Writer::stateString(State state) {
+  switch (state) {
+    case State::kInit:
+      return "INIT";
+    case State::kRunning:
+      return "RUNNING";
+    case State::kClosed:
+      return "CLOSED";
+    case State::kAborted:
+      return "ABORTED";
+    default:
+      VELOX_UNREACHABLE("BAD STATE: {}", static_cast<int>(state));
+  }
+}
+
+bool Writer::isRunning() const {
+  return state_ == State::kRunning;
+}
+
+void Writer::checkRunning() const {
+  VELOX_CHECK_EQ(state_, State::kRunning, "Writer is not running: {}", state_);
+}
+
+void Writer::setState(State state) {
+  checkStateTransition(state_, state);
+  state_ = state;
+}
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/Writer.h
+++ b/velox/dwio/common/Writer.h
@@ -35,7 +35,20 @@ namespace facebook::velox::dwio::common {
  */
 class Writer {
  public:
+  /// Defines the states of a file writer.
+  enum class State {
+    kInit = 0,
+    kRunning = 1,
+    kAborted = 2,
+    kClosed = 3,
+  };
+  static std::string stateString(State state);
+
   virtual ~Writer() = default;
+
+  State state() const {
+    return state_;
+  }
 
   /**
    * Appends 'data' to writer. Data might still be in memory and not
@@ -60,6 +73,25 @@ class Writer {
    *  Data can no longer be written.
    */
   virtual void abort() = 0;
+
+ protected:
+  bool isRunning() const;
+
+  void checkRunning() const;
+
+  /// Invoked to set writer 'state_' to new 'state'.
+  void setState(State state);
+
+  /// Validates the state transition from 'oldState' to 'newState'.
+  static void checkStateTransition(State oldState, State newState);
+
+  State state_{State::kInit};
 };
 
+FOLLY_ALWAYS_INLINE std::ostream& operator<<(
+    std::ostream& os,
+    Writer::State state) {
+  os << Writer::stateString(state);
+  return os;
+}
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -30,7 +30,8 @@ add_executable(
   ReaderTest.cpp
   RetryTests.cpp
   TestBufferedInput.cpp
-  TypeTests.cpp)
+  TypeTests.cpp
+  WriterTest.cpp)
 add_test(velox_dwio_common_test velox_dwio_common_test)
 target_link_libraries(
   velox_dwio_common_test

--- a/velox/dwio/common/tests/WriterTest.cpp
+++ b/velox/dwio/common/tests/WriterTest.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/Writer.h"
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+
+namespace facebook::velox::dwio::common {
+namespace {
+TEST(WriterTest, stateString) {
+  ASSERT_EQ(Writer::stateString(Writer::State::kInit), "INIT");
+  ASSERT_EQ(Writer::stateString(Writer::State::kRunning), "RUNNING");
+  ASSERT_EQ(Writer::stateString(Writer::State::kClosed), "CLOSED");
+  ASSERT_EQ(Writer::stateString(Writer::State::kAborted), "ABORTED");
+}
+} // namespace
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/dwrf/writer/Writer.h
+++ b/velox/dwio/dwrf/writer/Writer.h
@@ -143,10 +143,6 @@ class Writer : public dwio::common::Writer {
     return *nonReclaimableSection_;
   }
 
-  bool testingClosed() const {
-    return closed_;
-  }
-
  protected:
   std::shared_ptr<WriterBase> writerBase_;
 
@@ -209,8 +205,7 @@ class Writer : public dwio::common::Writer {
   // If not null, used by memory arbitration to track if this file writer is
   // under memory reclaimable section or not.
   tsan_atomic<bool>* const nonReclaimableSection_{nullptr};
-  // Indicates if this file writer has been closed or aborted.
-  bool closed_{false};
+
   std::unique_ptr<DWRFFlushPolicy> flushPolicy_;
   std::unique_ptr<LayoutPlanner> layoutPlanner_;
   std::unique_ptr<ColumnWriter> writer_;


### PR DESCRIPTION
Add state to dwio common writer and apply to SortWriter and dwrf writer.
We can leverage this for common state transition handling and ease memory
arbitration related processing.