### PR TITLE
Add reclaim metrics in MemoryReclaimer::Stats

### DIFF
--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -241,7 +241,7 @@ void MemoryReclaimer::abort(MemoryPool* pool, const std::exception_ptr& error) {
 void MemoryReclaimer::Stats::reset() {
   numNonReclaimableAttempts = 0;
   reclaimExecTimeUs = 0;
-  reclaimBytes = 0;
+  reclaimedBytes = 0;
   reclaimWaitTimeUs = 0;
 }
 
@@ -249,7 +249,7 @@ bool MemoryReclaimer::Stats::operator==(
     const MemoryReclaimer::Stats& other) const {
   return numNonReclaimableAttempts == other.numNonReclaimableAttempts &&
       reclaimExecTimeUs == other.reclaimExecTimeUs &&
-      reclaimBytes == other.reclaimBytes &&
+      reclaimedBytes == other.reclaimedBytes &&
       reclaimWaitTimeUs == other.reclaimWaitTimeUs;
 }
 

--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -157,6 +157,21 @@ std::unique_ptr<MemoryReclaimer> MemoryReclaimer::create() {
   return std::unique_ptr<MemoryReclaimer>(new MemoryReclaimer());
 }
 
+// static
+uint64_t MemoryReclaimer::run(
+    const std::function<uint64_t()>& func,
+    Stats& stats) {
+  uint64_t execTimeUs{0};
+  uint64_t bytes{0};
+  {
+    MicrosecondTimer timer{&execTimeUs};
+    bytes = func();
+  }
+  stats.reclaimExecTimeUs += execTimeUs;
+  stats.reclaimedBytes += bytes;
+  return bytes;
+}
+
 bool MemoryReclaimer::reclaimableBytes(
     const MemoryPool& pool,
     uint64_t& reclaimableBytes) const {

--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -240,11 +240,17 @@ void MemoryReclaimer::abort(MemoryPool* pool, const std::exception_ptr& error) {
 
 void MemoryReclaimer::Stats::reset() {
   numNonReclaimableAttempts = 0;
+  reclaimExecTimeUs = 0;
+  reclaimBytes = 0;
+  reclaimWaitTimeUs = 0;
 }
 
 bool MemoryReclaimer::Stats::operator==(
     const MemoryReclaimer::Stats& other) const {
-  return numNonReclaimableAttempts == other.numNonReclaimableAttempts;
+  return numNonReclaimableAttempts == other.numNonReclaimableAttempts &&
+      reclaimExecTimeUs == other.reclaimExecTimeUs &&
+      reclaimBytes == other.reclaimBytes &&
+      reclaimWaitTimeUs == other.reclaimWaitTimeUs;
 }
 
 bool MemoryReclaimer::Stats::operator!=(

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -276,17 +276,7 @@ class MemoryReclaimer {
 
   static std::unique_ptr<MemoryReclaimer> create();
 
-  static uint64_t run(const std::function<uint64_t()>& func, Stats& stats) {
-    uint64_t execTimeUs{0};
-    uint64_t bytes{0};
-    {
-      MicrosecondTimer timer{&execTimeUs};
-      bytes = func();
-    }
-    stats.reclaimExecTimeUs += execTimeUs;
-    stats.reclaimedBytes += bytes;
-    return bytes;
-  }
+  static uint64_t run(const std::function<uint64_t()>& func, Stats& stats);
 
   /// Invoked by the memory arbitrator before entering the memory arbitration
   /// processing. The default implementation does nothing but user can override

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -260,23 +260,11 @@ class MemoryReclaimer {
     /// The total execution time to do the reclaim in microseconds.
     uint64_t reclaimExecTimeUs{0};
 
-    /// The total reclaimed bytes.
-    uint64_t reclaimBytes{0};
+    /// The total reclaimed memory bytes.
+    uint64_t reclaimedBytes{0};
 
     /// The total time of task pause during reclaim in microseconds.
     uint64_t reclaimWaitTimeUs{0};
-
-    uint64_t reclaimAndStat(const std::function<uint64_t()>& func) {
-      uint64_t execTimeUs{0};
-      uint64_t bytes{0};
-      {
-        MicrosecondTimer timer{&execTimeUs};
-        bytes = func();
-      }
-      reclaimExecTimeUs += execTimeUs;
-      reclaimBytes += bytes;
-      return bytes;
-    }
 
     void reset();
 
@@ -287,6 +275,18 @@ class MemoryReclaimer {
   virtual ~MemoryReclaimer() = default;
 
   static std::unique_ptr<MemoryReclaimer> create();
+
+  static uint64_t run(const std::function<uint64_t()>& func, Stats& stats) {
+    uint64_t execTimeUs{0};
+    uint64_t bytes{0};
+    {
+      MicrosecondTimer timer{&execTimeUs};
+      bytes = func();
+    }
+    stats.reclaimExecTimeUs += execTimeUs;
+    stats.reclaimedBytes += bytes;
+    return bytes;
+  }
 
   /// Invoked by the memory arbitrator before entering the memory arbitration
   /// processing. The default implementation does nothing but user can override

--- a/velox/common/memory/tests/MemoryArbitratorTest.cpp
+++ b/velox/common/memory/tests/MemoryArbitratorTest.cpp
@@ -314,8 +314,11 @@ TEST_F(MemoryReclaimerTest, common) {
       ASSERT_FALSE(pool->reclaimableBytes(reclaimableBytes));
       ASSERT_EQ(reclaimableBytes, 0);
       ASSERT_EQ(pool->reclaim(0, stats_), 0);
+      ASSERT_EQ(stats_, MemoryReclaimer::Stats{});
       ASSERT_EQ(pool->reclaim(100, stats_), 0);
+      ASSERT_EQ(stats_, MemoryReclaimer::Stats{});
       ASSERT_EQ(pool->reclaim(kMaxMemory, stats_), 0);
+      ASSERT_EQ(stats_, MemoryReclaimer::Stats{});
     }
     ASSERT_EQ(stats_, MemoryReclaimer::Stats{});
     for (const auto& allocation : allocations) {
@@ -352,6 +355,7 @@ class MockLeafMemoryReclaimer : public MemoryReclaimer {
       reclaimedBytes += allocations_.front().size;
       allocations_.pop_front();
     }
+    stats.reclaimBytes += reclaimedBytes;
     return reclaimedBytes;
   }
 
@@ -433,18 +437,25 @@ TEST_F(MemoryReclaimerTest, mockReclaim) {
   for (int iter = 0; iter < numReclaims; ++iter) {
     const auto reclaimedBytes = root->reclaim(numBytesToReclaim, stats_);
     ASSERT_EQ(reclaimedBytes, numBytesToReclaim);
+    ASSERT_EQ(reclaimedBytes, stats_.reclaimBytes);
     ASSERT_TRUE(root->reclaimableBytes(reclaimableBytes));
     ASSERT_EQ(reclaimableBytes, totalUsedBytes);
+    stats_.reset();
   }
   ASSERT_TRUE(root->reclaimableBytes(reclaimableBytes));
   ASSERT_EQ(totalUsedBytes, reclaimableBytes);
   ASSERT_EQ(root->reclaim(allocBytes + 1, stats_), 2 * allocBytes);
   ASSERT_EQ(root->reclaim(allocBytes - 1, stats_), allocBytes);
+  ASSERT_EQ(3 * allocBytes, stats_.reclaimBytes);
+
   const uint64_t expectedReclaimedBytes = totalUsedBytes;
   ASSERT_EQ(root->reclaim(0, stats_), expectedReclaimedBytes);
+  ASSERT_EQ(3 * allocBytes + expectedReclaimedBytes, stats_.reclaimBytes);
   ASSERT_EQ(totalUsedBytes, 0);
   ASSERT_TRUE(root->reclaimableBytes(reclaimableBytes));
   ASSERT_EQ(reclaimableBytes, 0);
+
+  stats_.reset();
   ASSERT_EQ(stats_, MemoryReclaimer::Stats{});
 }
 
@@ -477,9 +488,11 @@ TEST_F(MemoryReclaimerTest, mockReclaimMoreThanAvailable) {
   const uint64_t expectedReclaimedBytes = totalUsedBytes;
   ASSERT_EQ(
       root->reclaim(totalUsedBytes + 100, stats_), expectedReclaimedBytes);
+  ASSERT_EQ(expectedReclaimedBytes, stats_.reclaimBytes);
   ASSERT_EQ(totalUsedBytes, 0);
   ASSERT_TRUE(root->reclaimableBytes(reclaimableBytes));
   ASSERT_EQ(reclaimableBytes, 0);
+  stats_.reset();
   ASSERT_EQ(stats_, MemoryReclaimer::Stats{});
 }
 
@@ -537,6 +550,7 @@ TEST_F(MemoryReclaimerTest, orderedReclaim) {
   ASSERT_EQ(
       root->reclaimer()->reclaim(root.get(), 2 * allocUnitBytes, stats_),
       2 * allocUnitBytes);
+  ASSERT_EQ(2 * allocUnitBytes, stats_.reclaimBytes);
   totalAllocUnits -= 2;
   verify({10, 11, 8, 14, 5});
 
@@ -546,6 +560,7 @@ TEST_F(MemoryReclaimerTest, orderedReclaim) {
   ASSERT_EQ(
       root->reclaimer()->reclaim(root.get(), 2 * allocUnitBytes, stats_),
       2 * allocUnitBytes);
+  ASSERT_EQ(4 * allocUnitBytes, stats_.reclaimBytes);
   totalAllocUnits -= 2;
   verify({10, 11, 8, 12, 5});
 
@@ -555,6 +570,7 @@ TEST_F(MemoryReclaimerTest, orderedReclaim) {
   ASSERT_EQ(
       root->reclaimer()->reclaim(root.get(), 8 * allocUnitBytes, stats_),
       8 * allocUnitBytes);
+  ASSERT_EQ(12 * allocUnitBytes, stats_.reclaimBytes);
   totalAllocUnits -= 8;
   verify({10, 11, 8, 4, 5});
 
@@ -611,6 +627,7 @@ TEST_F(MemoryReclaimerTest, orderedReclaim) {
       totalAllocUnits * allocUnitBytes);
   totalAllocUnits = 0;
   verify({0, 0, 0, 0, 0});
+  stats_.reset();
   ASSERT_EQ(stats_, MemoryReclaimer::Stats{});
 }
 
@@ -679,6 +696,7 @@ TEST_F(MemoryReclaimerTest, concurrentRandomMockReclaims) {
   }
 
   const int32_t kNumReclaims = 100;
+  uint64_t totalReclaimedBytes = 0;
   std::thread reclaimerThread([&]() {
     for (int i = 0; i < kNumReclaims; ++i) {
       const uint64_t oldUsedBytes = totalUsedBytes;
@@ -695,6 +713,7 @@ TEST_F(MemoryReclaimerTest, concurrentRandomMockReclaims) {
         }
       }
       const auto reclaimedBytes = root->reclaim(bytesToReclaim, stats_);
+      totalReclaimedBytes += reclaimedBytes;
       if (reclaimedBytes < bytesToReclaim) {
         ASSERT_GT(bytesToReclaim, oldUsedBytes);
       }
@@ -733,10 +752,12 @@ TEST_F(MemoryReclaimerTest, concurrentRandomMockReclaims) {
   ASSERT_EQ(reclaimableBytes, totalUsedBytes);
 
   root->reclaim(0, stats_);
+  ASSERT_EQ(totalReclaimedBytes + reclaimableBytes, stats_.reclaimBytes);
 
   ASSERT_TRUE(root->reclaimableBytes(reclaimableBytes));
   ASSERT_EQ(reclaimableBytes, 0);
   ASSERT_EQ(totalUsedBytes, 0);
+  stats_.reset();
   ASSERT_EQ(stats_, MemoryReclaimer::Stats{});
 }
 

--- a/velox/common/memory/tests/MemoryArbitratorTest.cpp
+++ b/velox/common/memory/tests/MemoryArbitratorTest.cpp
@@ -355,7 +355,7 @@ class MockLeafMemoryReclaimer : public MemoryReclaimer {
       reclaimedBytes += allocations_.front().size;
       allocations_.pop_front();
     }
-    stats.reclaimBytes += reclaimedBytes;
+    stats.reclaimedBytes += reclaimedBytes;
     return reclaimedBytes;
   }
 
@@ -437,7 +437,7 @@ TEST_F(MemoryReclaimerTest, mockReclaim) {
   for (int iter = 0; iter < numReclaims; ++iter) {
     const auto reclaimedBytes = root->reclaim(numBytesToReclaim, stats_);
     ASSERT_EQ(reclaimedBytes, numBytesToReclaim);
-    ASSERT_EQ(reclaimedBytes, stats_.reclaimBytes);
+    ASSERT_EQ(reclaimedBytes, stats_.reclaimedBytes);
     ASSERT_TRUE(root->reclaimableBytes(reclaimableBytes));
     ASSERT_EQ(reclaimableBytes, totalUsedBytes);
     stats_.reset();
@@ -446,11 +446,11 @@ TEST_F(MemoryReclaimerTest, mockReclaim) {
   ASSERT_EQ(totalUsedBytes, reclaimableBytes);
   ASSERT_EQ(root->reclaim(allocBytes + 1, stats_), 2 * allocBytes);
   ASSERT_EQ(root->reclaim(allocBytes - 1, stats_), allocBytes);
-  ASSERT_EQ(3 * allocBytes, stats_.reclaimBytes);
+  ASSERT_EQ(3 * allocBytes, stats_.reclaimedBytes);
 
   const uint64_t expectedReclaimedBytes = totalUsedBytes;
   ASSERT_EQ(root->reclaim(0, stats_), expectedReclaimedBytes);
-  ASSERT_EQ(3 * allocBytes + expectedReclaimedBytes, stats_.reclaimBytes);
+  ASSERT_EQ(3 * allocBytes + expectedReclaimedBytes, stats_.reclaimedBytes);
   ASSERT_EQ(totalUsedBytes, 0);
   ASSERT_TRUE(root->reclaimableBytes(reclaimableBytes));
   ASSERT_EQ(reclaimableBytes, 0);
@@ -488,7 +488,7 @@ TEST_F(MemoryReclaimerTest, mockReclaimMoreThanAvailable) {
   const uint64_t expectedReclaimedBytes = totalUsedBytes;
   ASSERT_EQ(
       root->reclaim(totalUsedBytes + 100, stats_), expectedReclaimedBytes);
-  ASSERT_EQ(expectedReclaimedBytes, stats_.reclaimBytes);
+  ASSERT_EQ(expectedReclaimedBytes, stats_.reclaimedBytes);
   ASSERT_EQ(totalUsedBytes, 0);
   ASSERT_TRUE(root->reclaimableBytes(reclaimableBytes));
   ASSERT_EQ(reclaimableBytes, 0);
@@ -550,7 +550,7 @@ TEST_F(MemoryReclaimerTest, orderedReclaim) {
   ASSERT_EQ(
       root->reclaimer()->reclaim(root.get(), 2 * allocUnitBytes, stats_),
       2 * allocUnitBytes);
-  ASSERT_EQ(2 * allocUnitBytes, stats_.reclaimBytes);
+  ASSERT_EQ(2 * allocUnitBytes, stats_.reclaimedBytes);
   totalAllocUnits -= 2;
   verify({10, 11, 8, 14, 5});
 
@@ -560,7 +560,7 @@ TEST_F(MemoryReclaimerTest, orderedReclaim) {
   ASSERT_EQ(
       root->reclaimer()->reclaim(root.get(), 2 * allocUnitBytes, stats_),
       2 * allocUnitBytes);
-  ASSERT_EQ(4 * allocUnitBytes, stats_.reclaimBytes);
+  ASSERT_EQ(4 * allocUnitBytes, stats_.reclaimedBytes);
   totalAllocUnits -= 2;
   verify({10, 11, 8, 12, 5});
 
@@ -570,7 +570,7 @@ TEST_F(MemoryReclaimerTest, orderedReclaim) {
   ASSERT_EQ(
       root->reclaimer()->reclaim(root.get(), 8 * allocUnitBytes, stats_),
       8 * allocUnitBytes);
-  ASSERT_EQ(12 * allocUnitBytes, stats_.reclaimBytes);
+  ASSERT_EQ(12 * allocUnitBytes, stats_.reclaimedBytes);
   totalAllocUnits -= 8;
   verify({10, 11, 8, 4, 5});
 
@@ -752,7 +752,7 @@ TEST_F(MemoryReclaimerTest, concurrentRandomMockReclaims) {
   ASSERT_EQ(reclaimableBytes, totalUsedBytes);
 
   root->reclaim(0, stats_);
-  ASSERT_EQ(totalReclaimedBytes + reclaimableBytes, stats_.reclaimBytes);
+  ASSERT_EQ(totalReclaimedBytes + reclaimableBytes, stats_.reclaimedBytes);
 
   ASSERT_TRUE(root->reclaimableBytes(reclaimableBytes));
   ASSERT_EQ(reclaimableBytes, 0);

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -172,7 +172,7 @@ class MockMemoryOperator {
       }
       reclaimTargetBytes_.push_back(targetBytes);
       auto reclaimBytes = op_->reclaim(pool, targetBytes);
-      stats.reclaimBytes += reclaimBytes;
+      stats.reclaimedBytes += reclaimBytes;
       return reclaimBytes;
     }
 

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -171,7 +171,9 @@ class MockMemoryOperator {
         reclaimInjectCb_(pool, targetBytes);
       }
       reclaimTargetBytes_.push_back(targetBytes);
-      return op_->reclaim(pool, targetBytes);
+      auto reclaimBytes = op_->reclaim(pool, targetBytes);
+      stats.reclaimBytes += reclaimBytes;
+      return reclaimBytes;
     }
 
     void enterArbitration() override {

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -662,12 +662,16 @@ TEST_F(HiveDataSinkTest, memoryReclaim) {
       ASSERT_TRUE(root_->reclaimableBytes(reclaimableBytes));
       ASSERT_GT(reclaimableBytes, 0);
       ASSERT_GT(root_->reclaim(256L << 20, stats), 0);
+      ASSERT_GT(stats.reclaimExecTimeUs, 0);
+      ASSERT_GT(stats.reclaimedBytes, 0);
       // We expect dwrf writer set numNonReclaimableAttempts counter.
       ASSERT_LE(stats.numNonReclaimableAttempts, 1);
     } else {
       ASSERT_FALSE(root_->reclaimableBytes(reclaimableBytes));
       ASSERT_EQ(reclaimableBytes, 0);
       ASSERT_EQ(root_->reclaim(256L << 20, stats), 0);
+      ASSERT_EQ(stats.reclaimExecTimeUs, 0);
+      ASSERT_EQ(stats.reclaimedBytes, 0);
       if (testData.expectedWriterReclaimEnabled) {
         if (testData.sortWriter) {
           ASSERT_GE(stats.numNonReclaimableAttempts, 1);
@@ -818,6 +822,8 @@ TEST_F(HiveDataSinkTest, memoryReclaimAfterClose) {
       ASSERT_EQ(reclaimableBytes, 0);
     }
     ASSERT_EQ(root_->reclaim(1L << 30, stats), 0);
+    ASSERT_EQ(stats.reclaimExecTimeUs, 0);
+    ASSERT_EQ(stats.reclaimedBytes, 0);
     if (testData.expectedWriterReclaimEnabled) {
       if (testData.sortWriter) {
         ASSERT_GE(stats.numNonReclaimableAttempts, 1);

--- a/velox/dwio/dwrf/test/E2EWriterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTest.cpp
@@ -1634,7 +1634,7 @@ DEBUG_ONLY_TEST_F(E2EWriterTest, memoryReclaimOnWrite) {
       ASSERT_LT(writerPool->capacity(), oldCapacity);
       ASSERT_GT(stats.reclaimedBytes, 0);
       ASSERT_GT(stats.reclaimExecTimeUs, 0);
-      static_cast<memory::MemoryPoolImpl*>(writerPool.get())
+      dynamic_cast<memory::MemoryPoolImpl*>(writerPool.get())
           ->testingSetCapacity(oldCapacity);
     } else {
       ASSERT_EQ(writerPool->capacity(), oldCapacity);

--- a/velox/dwio/dwrf/test/E2EWriterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTest.cpp
@@ -1632,10 +1632,13 @@ DEBUG_ONLY_TEST_F(E2EWriterTest, memoryReclaimOnWrite) {
     ASSERT_EQ(stats.numNonReclaimableAttempts, 0);
     if (enableReclaim) {
       ASSERT_LT(writerPool->capacity(), oldCapacity);
+      ASSERT_GT(stats.reclaimedBytes, 0);
+      ASSERT_GT(stats.reclaimExecTimeUs, 0);
       static_cast<memory::MemoryPoolImpl*>(writerPool.get())
           ->testingSetCapacity(oldCapacity);
     } else {
       ASSERT_EQ(writerPool->capacity(), oldCapacity);
+      ASSERT_EQ(stats, memory::MemoryReclaimer::Stats{});
     }
 
     // Expect a throw if we don't set the non-reclaimable section.
@@ -1650,7 +1653,7 @@ DEBUG_ONLY_TEST_F(E2EWriterTest, memoryReclaimOnWrite) {
     if (!enableReclaim) {
       ASSERT_FALSE(reservationCalled);
       ASSERT_EQ(writerPool->reclaim(1L << 30, stats), 0);
-      ASSERT_EQ(stats.numNonReclaimableAttempts, 0);
+      ASSERT_EQ(stats, memory::MemoryReclaimer::Stats{});
     } else {
       ASSERT_TRUE(reservationCalled);
       writer->testingNonReclaimableSection() = true;
@@ -1660,6 +1663,8 @@ DEBUG_ONLY_TEST_F(E2EWriterTest, memoryReclaimOnWrite) {
       stats.numNonReclaimableAttempts = 0;
       ASSERT_GT(writerPool->reclaim(1L << 30, stats), 0);
       ASSERT_EQ(stats.numNonReclaimableAttempts, 0);
+      ASSERT_GT(stats.reclaimedBytes, 0);
+      ASSERT_GT(stats.reclaimExecTimeUs, 0);
     }
     writer->close();
   }
@@ -1846,6 +1851,9 @@ TEST_F(E2EWriterTest, memoryReclaimAfterClose) {
     } else {
       ASSERT_EQ(stats.numNonReclaimableAttempts, 0);
     }
+    // Reclaim does not happen as the writer is either aborted or closed.
+    ASSERT_EQ(stats.reclaimExecTimeUs, 0);
+    ASSERT_EQ(stats.reclaimedBytes, 0);
   }
 }
 
@@ -1900,9 +1908,11 @@ DEBUG_ONLY_TEST_F(E2EWriterTest, memoryReclaimDuringInit) {
             ASSERT_GE(reclaimableBytes, 0);
             // We can't reclaim during writer init.
             ASSERT_EQ(stats.numNonReclaimableAttempts, 1);
+            ASSERT_EQ(stats.reclaimedBytes, 0);
+            ASSERT_EQ(stats.reclaimExecTimeUs, 0);
           } else {
             ASSERT_EQ(reclaimableBytes, 0);
-            ASSERT_EQ(stats.numNonReclaimableAttempts, 0);
+            ASSERT_EQ(stats, memory::MemoryReclaimer::Stats{});
           }
         }));
 
@@ -1985,11 +1995,16 @@ TEST_F(E2EWriterTest, memoryReclaimThreshold) {
           *writerPool, reclaimableBytes));
       ASSERT_GT(reclaimableBytes, 0);
       ASSERT_GT(writerPool->reclaim(1L << 30, stats), 0);
+      ASSERT_GT(stats.reclaimExecTimeUs, 0);
+      ASSERT_GT(stats.reclaimedBytes, 0);
     } else {
       ASSERT_FALSE(writerPool->reclaimer()->reclaimableBytes(
           *writerPool, reclaimableBytes));
       ASSERT_EQ(reclaimableBytes, 0);
       ASSERT_EQ(writerPool->reclaim(1L << 30, stats), 0);
+      ASSERT_GT(stats.numNonReclaimableAttempts, 0);
+      ASSERT_EQ(stats.reclaimExecTimeUs, 0);
+      ASSERT_EQ(stats.reclaimedBytes, 0);
     }
     writer->flush();
     writer->close();

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -747,8 +747,14 @@ uint64_t Writer::MemoryReclaimer::reclaim(
     ++stats.numNonReclaimableAttempts;
     return 0;
   }
-  writer_->flushInternal(false);
-  return pool->shrink(targetBytes);
+
+  auto reclaimBytes = memory::MemoryReclaimer::run(
+      [&]() {
+        writer_->flushInternal(false);
+        return pool->shrink(targetBytes);
+      },
+      stats);
+  return reclaimBytes;
 }
 
 dwrf::WriterOptions getDwrfOptions(const dwio::common::WriterOptions& options) {

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -611,8 +611,13 @@ uint64_t Operator::MemoryReclaimer::reclaim(
   }
 
   RuntimeStatWriterScopeGuard opStatsGuard(op_);
-  op_->reclaim(targetBytes, stats);
-  return pool->shrink(targetBytes);
+
+  auto reclaimBytes = stats.reclaimAndStat([&]() {
+    op_->reclaim(targetBytes, stats);
+    return pool->shrink(targetBytes);
+  });
+
+  return reclaimBytes;
 }
 
 void Operator::MemoryReclaimer::abort(

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -612,10 +612,12 @@ uint64_t Operator::MemoryReclaimer::reclaim(
 
   RuntimeStatWriterScopeGuard opStatsGuard(op_);
 
-  auto reclaimBytes = stats.reclaimAndStat([&]() {
-    op_->reclaim(targetBytes, stats);
-    return pool->shrink(targetBytes);
-  });
+  auto reclaimBytes = memory::MemoryReclaimer::run(
+      [&]() {
+        op_->reclaim(targetBytes, stats);
+        return pool->shrink(targetBytes);
+      },
+      stats);
 
   return reclaimBytes;
 }

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -334,9 +334,11 @@ uint64_t TableWriter::ConnectorReclaimer::reclaim(
   }
 
   RuntimeStatWriterScopeGuard opStatsGuard(op_);
-  auto reclaimBytes = stats.reclaimAndStat([&]() {
-    return memory::MemoryReclaimer::reclaim(pool, targetBytes, stats);
-  });
+  auto reclaimBytes = memory::MemoryReclaimer::run(
+      [&]() {
+        return memory::MemoryReclaimer::reclaim(pool, targetBytes, stats);
+      },
+      stats);
 
   return reclaimBytes;
 }

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -332,8 +332,13 @@ uint64_t TableWriter::ConnectorReclaimer::reclaim(
         << ", memory usage: " << succinctBytes(pool->currentBytes());
     return 0;
   }
+
   RuntimeStatWriterScopeGuard opStatsGuard(op_);
-  return memory::MemoryReclaimer::reclaim(pool, targetBytes, stats);
+  auto reclaimBytes = stats.reclaimAndStat([&]() {
+    return memory::MemoryReclaimer::reclaim(pool, targetBytes, stats);
+  });
+
+  return reclaimBytes;
 }
 
 // static

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -332,15 +332,8 @@ uint64_t TableWriter::ConnectorReclaimer::reclaim(
         << ", memory usage: " << succinctBytes(pool->currentBytes());
     return 0;
   }
-
   RuntimeStatWriterScopeGuard opStatsGuard(op_);
-  auto reclaimBytes = memory::MemoryReclaimer::run(
-      [&]() {
-        return memory::MemoryReclaimer::reclaim(pool, targetBytes, stats);
-      },
-      stats);
-
-  return reclaimBytes;
+  return memory::MemoryReclaimer::reclaim(pool, targetBytes, stats);
 }
 
 // static

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -376,6 +376,16 @@ class AggregationTest : public OperatorTestBase {
         pool_.get());
   }
 
+  static void reclaimAndRestoreCapacity(
+      const Operator* op,
+      uint64_t targetBytes,
+      memory::MemoryReclaimer::Stats& reclaimerStats) {
+    const auto oldCapacity = op->pool()->capacity();
+    op->pool()->reclaim(targetBytes, reclaimerStats);
+    static_cast<memory::MemoryPoolImpl*>(op->pool())
+        ->testingSetCapacity(oldCapacity);
+  }
+
   RowTypePtr rowType_{
       ROW({"c0", "c1", "c2", "c3", "c4", "c5", "c6"},
           {BIGINT(),
@@ -1997,7 +2007,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringInputProcessing) {
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
         memory::defaultMemoryManager().addRootPool(
-            queryCtx->queryId(), kMaxBytes));
+            queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
     auto expectedResult =
         AssertQueryBuilder(
             PlanBuilder()
@@ -2090,9 +2100,13 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringInputProcessing) {
 
     if (testData.expectedReclaimable) {
       const auto usedMemory = op->pool()->currentBytes();
-      op->reclaim(
+      reclaimAndRestoreCapacity(
+          op,
           folly::Random::oneIn(2) ? 0 : folly::Random::rand32(rng_),
           reclaimerStats_);
+      ASSERT_GT(reclaimerStats_.reclaimExecTimeUs, 0);
+      ASSERT_GT(reclaimerStats_.reclaimedBytes, 0);
+      reclaimerStats_.reset();
       // The hash table itself in the grouping set is not cleared so it still
       // uses some memory.
       ASSERT_LT(op->pool()->currentBytes(), usedMemory);
@@ -2136,7 +2150,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringReserve) {
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   queryCtx->testingOverrideMemoryPool(
       memory::defaultMemoryManager().addRootPool(
-          queryCtx->queryId(), kMaxBytes));
+          queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
   auto expectedResult =
       AssertQueryBuilder(PlanBuilder()
                              .values(batches)
@@ -2211,9 +2225,13 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringReserve) {
   ASSERT_GT(reclaimableBytes, 0);
 
   const auto usedMemory = op->pool()->currentBytes();
-  op->reclaim(
+  reclaimAndRestoreCapacity(
+      op,
       folly::Random::oneIn(2) ? 0 : folly::Random::rand32(rng_),
       reclaimerStats_);
+  ASSERT_GT(reclaimerStats_.reclaimExecTimeUs, 0);
+  ASSERT_GT(reclaimerStats_.reclaimedBytes, 0);
+  reclaimerStats_.reset();
   // The hash table itself in the grouping set is not cleared so it still
   // uses some memory.
   ASSERT_LT(op->pool()->currentBytes(), usedMemory);
@@ -2368,7 +2386,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringOutputProcessing) {
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
         memory::defaultMemoryManager().addRootPool(
-            queryCtx->queryId(), kMaxBytes));
+            queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
     auto expectedResult =
         AssertQueryBuilder(
             PlanBuilder()
@@ -2451,11 +2469,15 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringOutputProcessing) {
     if (enableSpilling) {
       ASSERT_GT(reclaimableBytes, 0);
       const auto usedMemory = op->pool()->currentBytes();
-      op->reclaim(
+      reclaimAndRestoreCapacity(
+          op,
           folly::Random::oneIn(2) ? 0 : folly::Random::rand32(rng_),
           reclaimerStats_);
       ASSERT_EQ(reclaimerStats_.numNonReclaimableAttempts, 0);
       ASSERT_GT(usedMemory, op->pool()->currentBytes());
+      ASSERT_GT(reclaimerStats_.reclaimedBytes, 0);
+      ASSERT_GT(reclaimerStats_.reclaimExecTimeUs, 0);
+      reclaimerStats_.reset();
     } else {
       ASSERT_EQ(reclaimableBytes, 0);
       VELOX_ASSERT_THROW(
@@ -2736,9 +2758,11 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimWithEmptyAggregationTable) {
     if (enableSpilling) {
       ASSERT_EQ(reclaimableBytes, 0);
       const auto usedMemory = op->pool()->currentBytes();
-      op->reclaim(
+      reclaimAndRestoreCapacity(
+          op,
           folly::Random::oneIn(2) ? 0 : folly::Random::rand32(rng_),
           reclaimerStats_);
+      ASSERT_EQ(reclaimerStats_, memory::MemoryReclaimer::Stats{});
       // No reclaim as the operator has started output processing.
       ASSERT_EQ(usedMemory, op->pool()->currentBytes());
     } else {
@@ -3011,6 +3035,9 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimEmptyInput) {
           SuspendedSection suspendedSection(driver);
           task->pool()->reclaim(kMaxBytes, stats);
           ASSERT_EQ(stats.numNonReclaimableAttempts, 0);
+          ASSERT_GT(stats.reclaimExecTimeUs, 0);
+          ASSERT_GT(stats.reclaimedBytes, 0);
+          ASSERT_GT(stats.reclaimWaitTimeUs, 0);
         }
         static_cast<memory::MemoryPoolImpl*>(task->pool())
             ->testingSetCapacity(kMaxBytes);
@@ -3078,6 +3105,9 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimEmptyOutput) {
           SuspendedSection suspendedSection(driver);
           task->pool()->reclaim(kMaxBytes, stats);
           ASSERT_EQ(stats.numNonReclaimableAttempts, 0);
+          ASSERT_GT(stats.reclaimExecTimeUs, 0);
+          ASSERT_GT(stats.reclaimedBytes, 0);
+          ASSERT_GT(stats.reclaimWaitTimeUs, 0);
         }
         // Sets back the memory capacity to proceed the test.
         static_cast<memory::MemoryPoolImpl*>(task->pool())

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -382,7 +382,7 @@ class AggregationTest : public OperatorTestBase {
       memory::MemoryReclaimer::Stats& reclaimerStats) {
     const auto oldCapacity = op->pool()->capacity();
     op->pool()->reclaim(targetBytes, reclaimerStats);
-    static_cast<memory::MemoryPoolImpl*>(op->pool())
+    dynamic_cast<memory::MemoryPoolImpl*>(op->pool())
         ->testingSetCapacity(oldCapacity);
   }
 

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -846,7 +846,7 @@ class HashJoinTest : public HiveConnectorTestBase {
       memory::MemoryReclaimer::Stats& reclaimerStats) {
     const auto oldCapacity = op->pool()->capacity();
     op->pool()->reclaim(targetBytes, reclaimerStats);
-    static_cast<memory::MemoryPoolImpl*>(op->pool())
+    dynamic_cast<memory::MemoryPoolImpl*>(op->pool())
         ->testingSetCapacity(oldCapacity);
   }
 

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -840,6 +840,16 @@ class HashJoinTest : public HiveConnectorTestBase {
         joinNode->outputType());
   }
 
+  static void reclaimAndRestoreCapacity(
+      const Operator* op,
+      uint64_t targetBytes,
+      memory::MemoryReclaimer::Stats& reclaimerStats) {
+    const auto oldCapacity = op->pool()->capacity();
+    op->pool()->reclaim(targetBytes, reclaimerStats);
+    static_cast<memory::MemoryPoolImpl*>(op->pool())
+        ->testingSetCapacity(oldCapacity);
+  }
+
   const int32_t numDrivers_;
 
   // The default left and right table types used for test.
@@ -4933,7 +4943,8 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringInputProcessing) {
     SCOPED_TRACE(testData.debugString());
 
     auto tempDirectory = exec::test::TempDirectoryPath::create();
-    auto queryPool = memory::defaultMemoryManager().addRootPool("", kMaxBytes);
+    auto queryPool = memory::defaultMemoryManager().addRootPool(
+        "", kMaxBytes, memory::MemoryReclaimer::create());
 
     core::PlanNodeId probeScanId;
     auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
@@ -5034,9 +5045,13 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringInputProcessing) {
     }
 
     if (testData.expectedReclaimable) {
-      op->reclaim(
+      reclaimAndRestoreCapacity(
+          op,
           folly::Random::oneIn(2) ? 0 : folly::Random::rand32(),
           reclaimerStats_);
+      ASSERT_GT(reclaimerStats_.reclaimExecTimeUs, 0);
+      ASSERT_GT(reclaimerStats_.reclaimedBytes, 0);
+      reclaimerStats_.reset();
       ASSERT_EQ(op->pool()->currentBytes(), 0);
     } else {
       VELOX_ASSERT_THROW(
@@ -5075,7 +5090,8 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringReserve) {
   createDuckDbTable("u", buildVectors);
 
   auto tempDirectory = exec::test::TempDirectoryPath::create();
-  auto queryPool = memory::defaultMemoryManager().addRootPool("", kMaxBytes);
+  auto queryPool = memory::defaultMemoryManager().addRootPool(
+      "", kMaxBytes, memory::MemoryReclaimer::create());
 
   core::PlanNodeId probeScanId;
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
@@ -5163,9 +5179,14 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringReserve) {
   ASSERT_TRUE(reclaimable);
   ASSERT_GT(reclaimableBytes, 0);
 
-  op->reclaim(
-      folly::Random::oneIn(2) ? 0 : folly::Random::rand32(), reclaimerStats_);
+  reclaimAndRestoreCapacity(
+      op,
+      folly::Random::oneIn(2) ? 0 : folly::Random::rand32(),
+      reclaimerStats_);
+  ASSERT_GT(reclaimerStats_.reclaimedBytes, 0);
+  ASSERT_GT(reclaimerStats_.reclaimExecTimeUs, 0);
   ASSERT_EQ(op->pool()->currentBytes(), 0);
+  reclaimerStats_.reset();
 
   driverWait.notify();
   Task::resume(task);
@@ -5328,7 +5349,8 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringOutputProcessing) {
   for (const auto enableSpilling : enableSpillings) {
     SCOPED_TRACE(fmt::format("enableSpilling {}", enableSpilling));
     auto tempDirectory = exec::test::TempDirectoryPath::create();
-    auto queryPool = memory::defaultMemoryManager().addRootPool("", kMaxBytes);
+    auto queryPool = memory::defaultMemoryManager().addRootPool(
+        "", kMaxBytes, memory::MemoryReclaimer::create());
 
     core::PlanNodeId probeScanId;
     auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
@@ -5410,9 +5432,12 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringOutputProcessing) {
     if (enableSpilling) {
       ASSERT_GT(reclaimableBytes, 0);
       const auto usedMemoryBytes = op->pool()->currentBytes();
-      op->reclaim(
+      reclaimAndRestoreCapacity(
+          op,
           folly::Random::oneIn(2) ? 0 : folly::Random::rand32(),
           reclaimerStats_);
+      ASSERT_GT(reclaimerStats_.reclaimedBytes, 0);
+      ASSERT_GT(reclaimerStats_.reclaimExecTimeUs, 0);
       // No reclaim as the operator has started output processing.
       ASSERT_EQ(usedMemoryBytes, op->pool()->currentBytes());
     } else {
@@ -5429,7 +5454,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringOutputProcessing) {
 
     taskThread.join();
   }
-  ASSERT_EQ(reclaimerStats_, memory::MemoryReclaimer::Stats{1});
+  ASSERT_EQ(reclaimerStats_.numNonReclaimableAttempts, 1);
 }
 
 DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringWaitForProbe) {
@@ -5450,7 +5475,8 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringWaitForProbe) {
   createDuckDbTable("u", buildVectors);
 
   auto tempDirectory = exec::test::TempDirectoryPath::create();
-  auto queryPool = memory::defaultMemoryManager().addRootPool("", kMaxBytes);
+  auto queryPool = memory::defaultMemoryManager().addRootPool(
+      "", kMaxBytes, memory::MemoryReclaimer::create());
 
   core::PlanNodeId probeScanId;
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
@@ -5549,8 +5575,13 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringWaitForProbe) {
   ASSERT_GT(reclaimableBytes, 0);
 
   const auto usedMemoryBytes = op->pool()->currentBytes();
-  op->reclaim(
-      folly::Random::oneIn(2) ? 0 : folly::Random::rand32(), reclaimerStats_);
+  reclaimerStats_.reset();
+  reclaimAndRestoreCapacity(
+      op,
+      folly::Random::oneIn(2) ? 0 : folly::Random::rand32(),
+      reclaimerStats_);
+  ASSERT_GT(reclaimerStats_.reclaimedBytes, 0);
+  ASSERT_GT(reclaimerStats_.reclaimExecTimeUs, 0);
   // No reclaim as the build operator is not in building table state.
   ASSERT_EQ(usedMemoryBytes, op->pool()->currentBytes());
 
@@ -5559,7 +5590,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringWaitForProbe) {
   task.reset();
 
   taskThread.join();
-  ASSERT_EQ(reclaimerStats_, memory::MemoryReclaimer::Stats{1});
+  ASSERT_EQ(reclaimerStats_.numNonReclaimableAttempts, 1);
 }
 
 DEBUG_ONLY_TEST_F(HashJoinTest, hashBuildAbortDuringOutputProcessing) {

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -223,7 +223,7 @@ class OrderByTest : public OperatorTestBase {
       memory::MemoryReclaimer::Stats& reclaimerStats) {
     const auto oldCapacity = op->pool()->capacity();
     op->pool()->reclaim(targetBytes, reclaimerStats);
-    static_cast<memory::MemoryPoolImpl*>(op->pool())
+    dynamic_cast<memory::MemoryPoolImpl*>(op->pool())
         ->testingSetCapacity(oldCapacity);
   }
 

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -217,6 +217,16 @@ class OrderByTest : public OperatorTestBase {
     }
   }
 
+  static void reclaimAndRestoreCapacity(
+      const Operator* op,
+      uint64_t targetBytes,
+      memory::MemoryReclaimer::Stats& reclaimerStats) {
+    const auto oldCapacity = op->pool()->capacity();
+    op->pool()->reclaim(targetBytes, reclaimerStats);
+    static_cast<memory::MemoryPoolImpl*>(op->pool())
+        ->testingSetCapacity(oldCapacity);
+  }
+
   folly::Random::DefaultGenerator rng_;
   memory::MemoryReclaimer::Stats reclaimerStats_;
 };
@@ -597,7 +607,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringInputProcessing) {
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
         memory::defaultMemoryManager().addRootPool(
-            queryCtx->queryId(), kMaxBytes));
+            queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
     auto expectedResult =
         AssertQueryBuilder(
             PlanBuilder()
@@ -689,9 +699,13 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringInputProcessing) {
     }
 
     if (testData.expectedReclaimable) {
-      op->reclaim(
+      reclaimAndRestoreCapacity(
+          op,
           folly::Random::oneIn(2) ? 0 : folly::Random::rand32(rng_),
           reclaimerStats_);
+      ASSERT_GT(reclaimerStats_.reclaimedBytes, 0);
+      ASSERT_GT(reclaimerStats_.reclaimExecTimeUs, 0);
+      reclaimerStats_.reset();
       ASSERT_EQ(op->pool()->currentBytes(), 0);
     } else {
       VELOX_ASSERT_THROW(
@@ -733,7 +747,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringReserve) {
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   queryCtx->testingOverrideMemoryPool(
       memory::defaultMemoryManager().addRootPool(
-          queryCtx->queryId(), kMaxBytes));
+          queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
   auto expectedResult =
       AssertQueryBuilder(
           PlanBuilder()
@@ -809,9 +823,13 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringReserve) {
   ASSERT_TRUE(reclaimable);
   ASSERT_GT(reclaimableBytes, 0);
 
-  op->reclaim(
+  reclaimAndRestoreCapacity(
+      op,
       folly::Random::oneIn(2) ? 0 : folly::Random::rand32(rng_),
       reclaimerStats_);
+  ASSERT_GT(reclaimerStats_.reclaimedBytes, 0);
+  ASSERT_GT(reclaimerStats_.reclaimExecTimeUs, 0);
+  reclaimerStats_.reset();
   ASSERT_EQ(op->pool()->currentBytes(), 0);
 
   driverWait.notify();
@@ -974,7 +992,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringOutputProcessing) {
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
         memory::defaultMemoryManager().addRootPool(
-            queryCtx->queryId(), kMaxBytes));
+            queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
     auto expectedResult =
         AssertQueryBuilder(
             PlanBuilder()
@@ -1055,9 +1073,12 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringOutputProcessing) {
     if (enableSpilling) {
       ASSERT_GT(reclaimableBytes, 0);
       const auto usedMemoryBytes = op->pool()->currentBytes();
-      op->reclaim(
+      reclaimAndRestoreCapacity(
+          op,
           folly::Random::oneIn(2) ? 0 : folly::Random::rand32(rng_),
           reclaimerStats_);
+      ASSERT_GT(reclaimerStats_.reclaimedBytes, 0);
+      ASSERT_GT(reclaimerStats_.reclaimExecTimeUs, 0);
       // No reclaim as the operator has started output processing.
       ASSERT_EQ(usedMemoryBytes, op->pool()->currentBytes());
     } else {
@@ -1077,7 +1098,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringOutputProcessing) {
     ASSERT_EQ(stats[0].operatorStats[1].spilledPartitions, 0);
     OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
   }
-  ASSERT_EQ(reclaimerStats_, memory::MemoryReclaimer::Stats{1});
+  ASSERT_EQ(reclaimerStats_.numNonReclaimableAttempts, 1);
 }
 
 DEBUG_ONLY_TEST_F(OrderByTest, abortDuringOutputProcessing) {


### PR DESCRIPTION
Add reclaim metrics in MemoryReclaimer::Stats,
- **reclaimExecTimeUs**, execution time consumed of reclaim,
  collected in the leaf layer memory reclaimers.
- **reclaimBytes**, total reclaimed bytes,
  collected in the leaf layer memory reclaimers.
- **reclaimWaitTimeUs**, task pause time during reclaim,
  collected in the `Task::MemoryReclaimer`.