### PR TITLE
Fix toSqlType for nested structs

### DIFF
--- a/velox/expression/ConstantExpr.cpp
+++ b/velox/expression/ConstantExpr.cpp
@@ -118,7 +118,7 @@ std::string toSqlType(const TypePtr& type) {
         if (i > 0) {
           out << ", ";
         }
-        out << type->asRow().nameOf(i) << " " << type->childAt(i)->toString();
+        out << type->asRow().nameOf(i) << " " << toSqlType(type->childAt(i));
       }
       out << ")";
       return out.str();

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2697,6 +2697,12 @@ TEST_P(ParameterizedExprTest, constantToSql) {
       toSqlComplex(BaseVector::createNullConstant(
           ROW({"a", "b"}, {BOOLEAN(), DOUBLE()}), 10, pool())),
       "NULL::STRUCT(a BOOLEAN, b DOUBLE)");
+  ASSERT_EQ(
+      toSqlComplex(BaseVector::createNullConstant(
+          ROW({"a", "b"}, {BOOLEAN(), ROW({"c", "d"}, {DOUBLE(), VARCHAR()})}),
+          10,
+          pool())),
+      "NULL::STRUCT(a BOOLEAN, b STRUCT(c DOUBLE, d VARCHAR))");
 }
 
 TEST_P(ParameterizedExprTest, toSql) {


### PR DESCRIPTION
Converting nested struct types to SQL used to generate non-parsable results:

```
Reason: Cannot parse expression: NULL::STRUCT(a BOOLEAN, b ROW<c:DOUBLE,d:VARCHAR>). Parser Error: syntax error at or near "<"
LINE 1: SELECT NULL::STRUCT(a BOOLEAN, b ROW<c:DOUBLE,d:VARCHAR>)
``