### PR TITLE
In RowVector::resize use size() instead of length_ to fix TSAN build failure

### DIFF
--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -644,7 +644,7 @@ void RowVector::unsafeResize(vector_size_t newSize, bool setNotNull) {
 }
 
 void RowVector::resize(vector_size_t newSize, bool setNotNull) {
-  auto oldSize = length_;
+  auto oldSize = size();
   BaseVector::resize(newSize, setNotNull);
 
   // Resize all the children.


### PR DESCRIPTION
Summary:
TSAN builds fail with
   ``` call to deleted constructor of 'tsan_atomic<facebook::velox::vector_size_t>' (aka 'atomic<int>') ```
 when just accessing length_, thus call size() to fix this.

Reviewed By: roticv

Differential Revision: D51164275


