### PR TITLE
Back out "Merge small batches of data into larger vectors in Exchange"

### DIFF
--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -66,20 +66,11 @@ class ExchangeClient {
   // runtime metric named ExchangeClient::kBackgroundCpuTimeMs.
   folly::F14FastMap<std::string, RuntimeMetric> stats() const;
 
-  const std::shared_ptr<ExchangeQueue>& queue() const {
+  std::shared_ptr<ExchangeQueue> queue() const {
     return queue_;
   }
 
-  /// Returns up to 'maxBytes' pages of data, but no less than one.
-  ///
-  /// If no data is available returns empty list and sets 'atEnd' to true if no
-  /// more data is expected. If data is still expected, sets 'atEnd' to false
-  /// and sets 'future' to a Future that will comlete when data arrives.
-  ///
-  /// The data may be compressed, in which case 'maxBytes' applies to compressed
-  /// size.
-  std::vector<std::unique_ptr<SerializedPage>>
-  next(uint32_t maxBytes, bool* atEnd, ContinueFuture* future);
+  std::unique_ptr<SerializedPage> next(bool* atEnd, ContinueFuture* future);
 
   std::string toString() const;
 

--- a/velox/exec/ExchangeQueue.h
+++ b/velox/exec/ExchangeQueue.h
@@ -73,6 +73,12 @@ class SerializedPage {
 // for input.
 class ExchangeQueue {
  public:
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  explicit ExchangeQueue(int64_t /*minBytes*/) {}
+
+  ExchangeQueue() = default;
+#endif
+
   ~ExchangeQueue() {
     clearAllPromises();
   }
@@ -94,29 +100,9 @@ class ExchangeQueue {
   // Exchanges to throw with the message.
   void setError(const std::string& error);
 
-  /// Returns pages of data.
-  ///
-  /// Returns empty list if no data is available. If data is still expected,
-  /// sets 'atEnd' to false and 'future' to a Future that will complete when
-  /// data arrives. If no more data is expected, sets 'atEnd' to true. Returns
-  /// at least one page if data is available. If multiple pages are available,
-  /// returns as many pages as fit within 'maxBytes', but no fewer than onc.
-  /// Calling this method with 'maxBytes' of 1 returns at most one page.
-  ///
-  /// The data may be compressed, in which case 'maxBytes' applies to compressed
-  /// size.
-  std::vector<std::unique_ptr<SerializedPage>>
-  dequeueLocked(uint32_t maxBytes, bool* atEnd, ContinueFuture* future);
-
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
   std::unique_ptr<SerializedPage> dequeueLocked(
       bool* atEnd,
-      ContinueFuture* future) {
-    auto pages = dequeueLocked(1, atEnd, future);
-    VELOX_CHECK_LE(pages.size(), 1);
-    return pages.empty() ? nullptr : std::move(pages.front());
-  }
-#endif
+      ContinueFuture* future);
 
   /// Returns the total bytes held by SerializedPages in 'this'.
   uint64_t totalBytes() const {

--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -47,8 +47,6 @@ void PlanNodeStats::addTotals(const OperatorStats& stats) {
   cpuWallTiming.add(stats.getOutputTiming);
   cpuWallTiming.add(stats.finishTiming);
 
-  backgroundTiming.add(stats.backgroundTiming);
-
   blockedWallNanos += stats.blockedWallNanos;
 
   peakMemoryBytes += stats.memoryStats.peakTotalMemoryReservation;

--- a/velox/exec/PlanNodeStats.h
+++ b/velox/exec/PlanNodeStats.h
@@ -78,11 +78,6 @@ struct PlanNodeStats {
   /// up.
   CpuWallTiming cpuWallTiming;
 
-  /// Sum of CPU, scheduled and wall times spent on background activities
-  /// (activities that are not running on driver threads) for all corresponding
-  /// operators.
-  CpuWallTiming backgroundTiming;
-
   /// Sum of blocked wall time for all corresponding operators.
   uint64_t blockedWallNanos{0};
 

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -54,12 +54,14 @@ class ExchangeClientTest : public testing::Test,
 
   std::shared_ptr<Task> makeTask(
       const std::string& taskId,
-      const core::PlanNodePtr& planNode) {
+      const core::PlanNodePtr& planNode,
+      int destination) {
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
         memory::defaultMemoryManager().addRootPool(queryCtx->queryId()));
+    core::PlanFragment planFragment{planNode};
     return Task::create(
-        taskId, core::PlanFragment{planNode}, 0, std::move(queryCtx));
+        taskId, std::move(planFragment), destination, std::move(queryCtx));
   }
 
   int32_t enqueue(
@@ -79,38 +81,9 @@ class ExchangeClientTest : public testing::Test,
     for (auto i = 0; i < numPages; ++i) {
       bool atEnd;
       ContinueFuture future;
-      auto pages = client.next(1, &atEnd, &future);
-      ASSERT_EQ(1, pages.size());
+      auto page = client.next(&atEnd, &future);
+      ASSERT_TRUE(page != nullptr);
     }
-  }
-
-  static void addSources(ExchangeQueue& queue, int32_t numSources) {
-    {
-      std::lock_guard<std::mutex> l(queue.mutex());
-      for (auto i = 0; i < numSources; ++i) {
-        queue.addSourceLocked();
-      }
-    }
-    queue.noMoreSources();
-  }
-
-  static void enqueue(
-      ExchangeQueue& queue,
-      std::unique_ptr<SerializedPage> page) {
-    std::vector<ContinuePromise> promises;
-    {
-      std::lock_guard<std::mutex> l(queue.mutex());
-      queue.enqueueLocked(std::move(page), promises);
-    }
-    for (auto& promise : promises) {
-      promise.setValue();
-    }
-  }
-
-  static std::unique_ptr<SerializedPage> makePage(uint64_t size) {
-    auto ioBuf = folly::IOBuf::create(size);
-    ioBuf->append(size);
-    return std::make_unique<SerializedPage>(std::move(ioBuf));
   }
 
   std::shared_ptr<OutputBufferManager> bufferManager_;
@@ -147,7 +120,7 @@ TEST_F(ExchangeClientTest, stats) {
                   .partitionedOutput({"c0"}, 100)
                   .planNode();
   auto taskId = "local://t1";
-  auto task = makeTask(taskId, plan);
+  auto task = makeTask(taskId, plan, 17);
 
   bufferManager_->initializeTask(
       task, core::PartitionedOutputNode::Kind::kPartitioned, 100, 16);
@@ -197,7 +170,7 @@ TEST_F(ExchangeClientTest, flowControl) {
   std::vector<std::shared_ptr<Task>> tasks;
   for (auto i = 0; i < 10; ++i) {
     auto taskId = fmt::format("local://t{}", i);
-    auto task = makeTask(taskId, plan);
+    auto task = makeTask(taskId, plan, 17);
 
     bufferManager_->initializeTask(
         task, core::PartitionedOutputNode::Kind::kPartitioned, 100, 16);
@@ -222,46 +195,6 @@ TEST_F(ExchangeClientTest, flowControl) {
     task->requestCancel();
     bufferManager_->removeTask(task->taskId());
   }
-}
-
-TEST_F(ExchangeClientTest, multiPageFetch) {
-  ExchangeClient client("test", 17, pool(), 1 << 20);
-
-  bool atEnd;
-  ContinueFuture future;
-  auto pages = client.next(1, &atEnd, &future);
-  ASSERT_EQ(0, pages.size());
-  ASSERT_FALSE(atEnd);
-
-  const auto& queue = client.queue();
-  addSources(*queue, 1);
-
-  for (auto i = 0; i < 10; ++i) {
-    enqueue(*queue, makePage(1'000 + i));
-  }
-
-  // Fetch one page.
-  pages = client.next(1, &atEnd, &future);
-  ASSERT_EQ(1, pages.size());
-  ASSERT_FALSE(atEnd);
-
-  // Fetch multiple pages. Each page is slightly larger than 1K bytes, hence,
-  // only 4 pages fit.
-  pages = client.next(5'000, &atEnd, &future);
-  ASSERT_EQ(4, pages.size());
-  ASSERT_FALSE(atEnd);
-
-  // Fetch the rest of the pages.
-  pages = client.next(10'000, &atEnd, &future);
-  ASSERT_EQ(5, pages.size());
-  ASSERT_FALSE(atEnd);
-
-  // Signal no-more-data.
-  enqueue(*queue, nullptr);
-
-  pages = client.next(10'000, &atEnd, &future);
-  ASSERT_EQ(0, pages.size());
-  ASSERT_TRUE(atEnd);
 }
 
 } // namespace

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -62,7 +62,7 @@ class MultiFragmentTest : public HiveConnectorTestBase {
   std::shared_ptr<Task> makeTask(
       const std::string& taskId,
       const core::PlanNodePtr& planNode,
-      int destination = 0,
+      int destination,
       Consumer consumer = nullptr,
       int64_t maxMemory = memory::kMaxMemory) {
     auto configCopy = configSettings_;
@@ -148,39 +148,12 @@ class MultiFragmentTest : public HiveConnectorTestBase {
     createDuckDbTable(vectors_);
   }
 
-  std::unique_ptr<SerializedPage> toSerializedPage(const RowVectorPtr& vector) {
-    auto data = std::make_unique<VectorStreamGroup>(pool());
-    auto size = vector->size();
-    auto range = IndexRange{0, size};
-    data->createStreamTree(asRowType(vector->type()), size);
-    data->append(vector, folly::Range(&range, 1));
-    auto listener = bufferManager_->newListener();
-    IOBufOutputStream stream(*pool(), listener.get(), data->size());
-    data->flush(&stream);
-    return std::make_unique<SerializedPage>(stream.getIOBuf());
-  }
-
-  int32_t enqueue(
-      const std::string& taskId,
-      int32_t destination,
-      const RowVectorPtr& data) {
-    auto page = toSerializedPage(data);
-    const auto pageSize = page->size();
-
-    ContinueFuture unused;
-    auto blocked =
-        bufferManager_->enqueue(taskId, destination, std::move(page), &unused);
-    VELOX_CHECK(!blocked);
-    return pageSize;
-  }
-
   void verifyExchangeStats(
       const std::shared_ptr<Task>& task,
       int32_t expectedNumPagesCount,
       int32_t expectedBackgroundCpuCount) const {
-    auto taskStats = exec::toPlanStats(task->taskStats());
-
-    const auto& exchangeStats = taskStats.at("0").customStats;
+    auto exchangeStats =
+        task->taskStats().pipelineStats[0].operatorStats[0].runtimeStats;
     ASSERT_EQ(1, exchangeStats.count("localExchangeSource.numPages"));
     ASSERT_EQ(
         expectedNumPagesCount,
@@ -188,8 +161,9 @@ class MultiFragmentTest : public HiveConnectorTestBase {
     ASSERT_EQ(
         expectedBackgroundCpuCount,
         exchangeStats.at(ExchangeClient::kBackgroundCpuTimeMs).count);
-    ASSERT_EQ(
-        expectedBackgroundCpuCount, taskStats.at("0").backgroundTiming.count);
+    auto cpuBackgroundTimeMs =
+        task->taskStats().pipelineStats[0].operatorStats[0].backgroundTiming;
+    ASSERT_EQ(expectedBackgroundCpuCount, cpuBackgroundTimeMs.count);
   }
 
   RowTypePtr rowType_{
@@ -198,8 +172,6 @@ class MultiFragmentTest : public HiveConnectorTestBase {
   std::unordered_map<std::string, std::string> configSettings_;
   std::vector<std::shared_ptr<TempFilePath>> filePaths_;
   std::vector<RowVectorPtr> vectors_;
-  std::shared_ptr<OutputBufferManager> bufferManager_{
-      OutputBufferManager::getInstance().lock()};
 };
 
 TEST_F(MultiFragmentTest, aggregationSingleKey) {
@@ -551,8 +523,9 @@ TEST_F(MultiFragmentTest, partitionedOutput) {
                         .planNode();
     auto leafTask = makeTask(leafTaskId, leafPlan, 0);
     leafTask->start(4);
+    auto bufferMgr = OutputBufferManager::getInstance().lock();
     // Delete the results asynchronously to simulate abort from downstream.
-    bufferManager_->deleteResults(leafTaskId, 0);
+    bufferMgr->deleteResults(leafTaskId, 0);
 
     ASSERT_TRUE(waitForTaskCompletion(leafTask.get())) << leafTask->taskId();
   }
@@ -582,8 +555,8 @@ TEST_F(MultiFragmentTest, partitionedOutputWithLargeInput) {
 
     auto task =
         assertQuery(op, {leafTaskId}, "SELECT c0, c1, c2, c3, c4 FROM tmp");
-    auto taskStats = toPlanStats(task->taskStats());
-    ASSERT_GT(taskStats.at("0").inputVectors, 2);
+    auto exchangeStats = task->taskStats().pipelineStats[0].operatorStats[0];
+    ASSERT_GT(exchangeStats.inputVectors, 2);
     ASSERT_TRUE(waitForTaskCompletion(leafTask.get()))
         << leafTask->taskId() << "state: " << leafTask->state();
   }
@@ -623,9 +596,8 @@ TEST_F(MultiFragmentTest, partitionedOutputWithLargeInput) {
 
     auto task = assertQuery(
         op, intermediateTaskIds, "SELECT c0, c1, c2, c3, c4 FROM tmp");
-    auto taskStats = toPlanStats(task->taskStats());
-    ASSERT_GT(taskStats.at("0").inputVectors, 2);
-
+    auto exchangeStats = task->taskStats().pipelineStats[0].operatorStats[0];
+    ASSERT_GT(exchangeStats.inputVectors, 2);
     ASSERT_TRUE(waitForTaskCompletion(leafTask.get()))
         << "state: " << leafTask->state();
   }
@@ -1450,6 +1422,7 @@ TEST_F(MultiFragmentTest, taskTerminateWithPendingOutputBuffers) {
   task->start(1);
   addHiveSplits(task, filePaths_);
 
+  auto bufferManager = OutputBufferManager::getInstance().lock();
   const uint64_t maxBytes = std::numeric_limits<uint64_t>::max();
   const int destination = 0;
   std::vector<std::unique_ptr<folly::IOBuf>> receivedIobufs;
@@ -1457,7 +1430,7 @@ TEST_F(MultiFragmentTest, taskTerminateWithPendingOutputBuffers) {
   for (;;) {
     auto dataPromise = ContinuePromise("WaitForOutput");
     bool complete{false};
-    ASSERT_TRUE(bufferManager_->getData(
+    ASSERT_TRUE(bufferManager->getData(
         taskId,
         destination,
         maxBytes,
@@ -1646,8 +1619,12 @@ class DataFetcher {
  private:
   static constexpr int64_t kInitialSequence = 0;
 
+  std::shared_ptr<OutputBufferManager> bufferManager() {
+    return OutputBufferManager::getInstance().lock();
+  }
+
   void doFetch(int64_t sequence) {
-    bool ok = bufferManager_->getData(
+    bool ok = bufferManager()->getData(
         taskId_,
         destination_,
         maxBytes_,
@@ -1655,10 +1632,10 @@ class DataFetcher {
         [&](auto pages, auto sequence) mutable {
           const auto nextSequence = sequence + pages.size();
           const bool atEnd = processData(std::move(pages), sequence);
-          bufferManager_->acknowledge(taskId_, destination_, nextSequence);
+          bufferManager()->acknowledge(taskId_, destination_, nextSequence);
 
           if (atEnd) {
-            bufferManager_->deleteResults(taskId_, destination_);
+            bufferManager()->deleteResults(taskId_, destination_);
             promise_.setValue();
           } else {
             doFetch(nextSequence);
@@ -1695,9 +1672,6 @@ class DataFetcher {
   int32_t numPackets_{0};
   int32_t numPages_{0};
   int64_t totalBytes_{0};
-
-  std::shared_ptr<OutputBufferManager> bufferManager_{
-      OutputBufferManager::getInstance().lock()};
 };
 
 /// Verify that POBM::getData() honors maxBytes parameter roughly at 1MB
@@ -1863,65 +1837,5 @@ TEST_F(MultiFragmentTest, earlyTaskFailure) {
         << partialSortTask->taskId();
   }
 }
-
-TEST_F(MultiFragmentTest, mergeSmallBatchesInExchange) {
-  auto data = makeRowVector({makeFlatVector<int32_t>({1, 2, 3})});
-
-  const int32_t numPartitions = 100;
-  auto producerPlan = test::PlanBuilder()
-                          .values({data})
-                          .partitionedOutput({"c0"}, numPartitions)
-                          .planNode();
-  const auto producerTaskId = "local://t1";
-
-  auto plan = test::PlanBuilder().exchange(asRowType(data->type())).planNode();
-
-  auto expected = makeRowVector({
-      makeFlatVector<int32_t>(3'000, [](auto row) { return 1 + row % 3; }),
-  });
-
-  auto test = [&](uint64_t maxBytes, int32_t expectedBatches) {
-    auto producerTask = makeTask(producerTaskId, producerPlan);
-
-    bufferManager_->initializeTask(
-        producerTask,
-        core::PartitionedOutputNode::Kind::kPartitioned,
-        numPartitions,
-        1);
-
-    auto cleanupGuard = folly::makeGuard([&]() {
-      producerTask->requestCancel();
-      bufferManager_->removeTask(producerTaskId);
-    });
-
-    // Enqueue many small pages.
-    const int32_t numPages = 1'000;
-    for (auto i = 0; i < numPages; ++i) {
-      enqueue(producerTaskId, 17, data);
-    }
-    bufferManager_->noMoreData(producerTaskId);
-
-    auto task = test::AssertQueryBuilder(plan)
-                    .split(remoteSplit(producerTaskId))
-                    .destination(17)
-                    .config(
-                        core::QueryConfig::kPreferredOutputBatchBytes,
-                        std::to_string(maxBytes))
-                    .assertResults(expected);
-
-    auto taskStats = exec::toPlanStats(task->taskStats());
-    const auto& stats = taskStats.at("0");
-
-    ASSERT_EQ(expected->size(), stats.outputRows);
-    ASSERT_EQ(expectedBatches, stats.outputVectors);
-    ASSERT_EQ(numPages, stats.customStats.at("numReceivedPages").sum);
-  };
-
-  test(1, 1'000);
-  test(1'000, 56);
-  test(10'000, 6);
-  test(100'000, 1);
-}
-
 } // namespace
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/OutputBufferManagerTest.cpp
+++ b/velox/exec/tests/OutputBufferManagerTest.cpp
@@ -998,8 +998,7 @@ TEST_F(OutputBufferManagerTest, errorInQueue) {
   std::lock_guard<std::mutex> l(queue->mutex());
   ContinueFuture future;
   bool atEnd = false;
-  VELOX_ASSERT_THROW(
-      queue->dequeueLocked(1, &atEnd, &future), "Forced failure");
+  VELOX_ASSERT_THROW(queue->dequeueLocked(&atEnd, &future), "Forced failure");
 }
 
 TEST_F(OutputBufferManagerTest, setQueueErrorWithPendingPages) {
@@ -1025,8 +1024,7 @@ TEST_F(OutputBufferManagerTest, setQueueErrorWithPendingPages) {
   std::lock_guard<std::mutex> l(queue->mutex());
   ContinueFuture future;
   bool atEnd = false;
-  VELOX_ASSERT_THROW(
-      queue->dequeueLocked(1, &atEnd, &future), "Forced failure");
+  VELOX_ASSERT_THROW(queue->dequeueLocked(&atEnd, &future), "Forced failure");
 }
 
 TEST_F(OutputBufferManagerTest, getDataOnFailedTask) {

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -57,11 +57,6 @@ AssertQueryBuilder& AssertQueryBuilder::maxDrivers(int32_t maxDrivers) {
   return *this;
 }
 
-AssertQueryBuilder& AssertQueryBuilder::destination(int32_t destination) {
-  params_.destination = destination;
-  return *this;
-}
-
 AssertQueryBuilder& AssertQueryBuilder::config(
     const std::string& key,
     const std::string& value) {

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -35,10 +35,6 @@ class AssertQueryBuilder {
   /// Change requested number of drivers. Default is 1.
   AssertQueryBuilder& maxDrivers(int32_t maxDrivers);
 
-  /// Change task's 'destination', the partition number assigned to the task.
-  /// Default is 0.
-  AssertQueryBuilder& destination(int32_t destination);
-
   /// Set configuration property. May be called multiple times to set multiple
   /// properties.
   AssertQueryBuilder& config(const std::string& key, const std::string& value);

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -107,10 +107,6 @@ class VectorSerde {
       RowVectorPtr* result,
       vector_size_t resultOffset,
       const Options* options = nullptr) {
-    if (resultOffset == 0) {
-      deserialize(source, pool, type, result, options);
-      return;
-    }
     VELOX_UNSUPPORTED();
   }
 };


### PR DESCRIPTION
Summary:
Original commit changeset: 952ca173faee

Original Phabricator Diff: D50988887

It's causing many errors errors in Alpha, we need to un-land an check. One test that it broke for example is:
```
buck2 test 'fbcode//mode/opt' fbcode//xldb/alpha_jni/alpha-spark:alphajni_lib_test-java11 -- --exact 'xldb/alpha_jni/alpha-spark:alphajni_lib_test-java11 - testRleEncodingTopLevelNulls(com.facebook.xldb.presto.shaded.com.facebook.presto.common.type.Type)[36 : Type(row(field_0 varbinary,field_1 varbinary))] (com.facebook.xldb.alpha.EndToEndTest)'
```

Differential Revision: D51174702


