### PR TITLE
Change cast(timestamp as varchar) to pad year to 4 digits using zeros

### DIFF
--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -137,7 +137,7 @@ Expression Evaluation Configuration
      - bool
      - false
      - Enables legacy CAST semantics if set to true. CAST(timestamp AS varchar) uses 'T' as separator between date and
-       time (instead of a space).
+       time (instead of a space), and the year part is not padded.
    * - cast_match_struct_by_name
      - bool
      - false

--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -492,11 +492,11 @@ Valid examples
 From TIMESTAMP
 ^^^^^^^^^^^^^^
 
-By default, casting a timestamp to a string returns ISO 8601 format with an empty space
-as separator between date and time.
+By default, casting a timestamp to a string returns ISO 8601 format with space as separator
+between date and time, and the year part is padded with zeros to 4 characters.
 
 If legacy_cast configuration property is true, the result string uses character 'T'
-as separator between date and time.
+as separator between date and time and the year part is not padded.
 
 Valid examples if legacy_cast = false,
 
@@ -504,6 +504,9 @@ Valid examples if legacy_cast = false,
 
   SELECT cast(timestamp '1970-01-01 00:00:00' as varchar); -- '1970-01-01 00:00:00.000'
   SELECT cast(timestamp '2000-01-01 12:21:56.129' as varchar); -- '2000-01-01 12:21:56.129'
+  SELECT cast(timestamp '384-01-01 08:00:00.000' as varchar); -- '0384-01-01 08:00:00.000'
+  SELECT cast(timestamp '10000-02-01 16:00:00.000' as varchar); -- '10000-02-01 16:00:00.000'
+  SELECT cast(timestamp '-10-02-01 10:00:00.000' as varchar); -- '-0010-02-01 10:00:00.000'
 
 Valid examples if legacy_cast = true,
 
@@ -511,6 +514,8 @@ Valid examples if legacy_cast = true,
 
   SELECT cast(timestamp '1970-01-01 00:00:00' as varchar); -- '1970-01-01T00:00:00.000'
   SELECT cast(timestamp '2000-01-01 12:21:56.129' as varchar); -- '2000-01-01T12:21:56.129'
+  SELECT cast(timestamp '384-01-01 08:00:00.000' as varchar); -- '384-01-01T08:00:00.000'
+  SELECT cast(timestamp '-10-02-01 10:00:00.000' as varchar); -- '-10-02-01T10:00:00.000'
 
 Cast to TIMESTAMP
 -----------------

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -553,6 +553,9 @@ TEST_F(CastExprTest, timestampToString) {
           Timestamp(946729316, 123),
           Timestamp(946729316, 129900000),
           Timestamp(7266, 0),
+          Timestamp(-50049331200, 0),
+          Timestamp(253405036800, 0),
+          Timestamp(-62480037600, 0),
           std::nullopt,
       },
       {
@@ -566,6 +569,9 @@ TEST_F(CastExprTest, timestampToString) {
           "2000-01-01 12:21:56.000",
           "2000-01-01 12:21:56.129",
           "1970-01-01 02:01:06.000",
+          "0384-01-01 08:00:00.000",
+          "10000-02-01 16:00:00.000",
+          "-0010-02-01 10:00:00.000",
           std::nullopt,
       });
 
@@ -574,10 +580,16 @@ TEST_F(CastExprTest, timestampToString) {
       "string",
       {
           Timestamp(946729316, 123),
+          Timestamp(-50049331200, 0),
+          Timestamp(253405036800, 0),
+          Timestamp(-62480037600, 0),
           std::nullopt,
       },
       {
           "2000-01-01T12:21:56.000",
+          "384-01-01T08:00:00.000",
+          "10000-02-01T16:00:00.000",
+          "-10-02-01T10:00:00.000",
           std::nullopt,
       });
 }

--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -409,6 +409,7 @@ struct Converter<TypeKind::VARCHAR, void, TRUNCATE, LEGACY_CAST> {
     TimestampToStringOptions options;
     options.precision = TimestampToStringOptions::Precision::kMilliseconds;
     if constexpr (!LEGACY_CAST) {
+      options.zeroPaddingYear = true;
       options.dateTimeSeparator = ' ';
     }
     return val.toString(options);


### PR DESCRIPTION
Change cast(timestamp as varchar) to pad year to 4 characters
using zeros, if it is earlier than year 1000. Existing behavior is not
to pad year.

Use QueryConfig legacy_cast false to gate this new
behavior. To keep existing behavior, set legacy_cast to true.