### PR TITLE
Back out "Revert D50984132: [velox][PR] Fast path for RowContainer string equals"

### DIFF
--- a/velox/common/base/SimdUtil-inl.h
+++ b/velox/common/base/SimdUtil-inl.h
@@ -294,7 +294,7 @@ inline bool copyNextWord(void*& to, const void*& from, int32_t& bytes) {
 } // namespace detail
 
 template <typename A>
-void memcpy(void* to, const void* from, int32_t bytes, const A& arch) {
+inline void memcpy(void* to, const void* from, int32_t bytes, const A& arch) {
   while (bytes >= batchByteSize(arch)) {
     if (!detail::copyNextWord<xsimd::batch<int8_t, A>, A>(to, from, bytes)) {
       return;
@@ -1352,26 +1352,86 @@ xsimd::batch<T, A> reinterpretBatch(xsimd::batch<U, A> data, const A& arch) {
   return detail::ReinterpretBatch<T, U, A>::apply(data, arch);
 }
 
-template <typename A>
-inline bool memEqualUnsafe(const void* x, const void* y, int32_t size) {
-  constexpr int32_t kBatch = xsimd::batch<uint8_t, A>::size;
+namespace detail {
+template <typename T>
+inline bool
+oneOrTwoScalarsEqual(const uint8_t* left, const uint8_t* right, int32_t size) {
+  return *reinterpret_cast<const T*>(left) ==
+      *reinterpret_cast<const T*>(right) &&
+      (size == sizeof(T) ||
+       *reinterpret_cast<const T*>(left + size - sizeof(T)) ==
+           *reinterpret_cast<const T*>(right + size - sizeof(T)));
+}
+} // namespace detail
 
+template <typename A>
+inline bool memEqual(const void* x, const void* y, int32_t size) {
+  constexpr int32_t kBatch = xsimd::batch<uint8_t, A>::size;
   auto left = reinterpret_cast<const uint8_t*>(x);
   auto right = reinterpret_cast<const uint8_t*>(y);
-  while (size > 0) {
-    auto bits = toBitMask(
-        xsimd::batch<uint8_t, A>::load_unaligned(left) ==
-        xsimd::batch<uint8_t, A>::load_unaligned(right));
-    if (bits == allSetBitMask<uint8_t, A>()) {
+  if (size >= kBatch) {
+    do {
+      auto bits = toBitMask(
+          xsimd::batch<uint8_t, A>::load_unaligned(left) ==
+          xsimd::batch<uint8_t, A>::load_unaligned(right));
+      if (bits != allSetBitMask<uint8_t, A>()) {
+        return false;
+      }
       left += kBatch;
       right += kBatch;
       size -= kBatch;
-      continue;
+    } while (size >= kBatch);
+    if (size > 0) {
+      return toBitMask(
+                 xsimd::batch<uint8_t, A>::load_unaligned(
+                     left + size - kBatch) ==
+                 xsimd::batch<uint8_t, A>::load_unaligned(
+                     right + size - kBatch)) == allSetBitMask<uint8_t, A>();
     }
-    auto leading = __builtin_ctz(~bits);
-    return leading >= size;
+    return true;
   }
-  return true;
+#if XSIMD_WITH_AVX
+  using HalfBatch = xsimd::batch<uint8_t, xsimd::sse4_1>;
+  constexpr int32_t kHalfSize = HalfBatch::size;
+
+  if (size >= kHalfSize) {
+    if (simd::toBitMask(
+            HalfBatch::load_unaligned(left) ==
+            HalfBatch::load_unaligned(right)) !=
+        allSetBitMask<uint8_t, xsimd::sse4_1>()) {
+      return false;
+    }
+    if (size > kHalfSize) {
+      return simd::toBitMask(
+                 HalfBatch::load_unaligned(left + size - kHalfSize) ==
+                 HalfBatch::load_unaligned(right + size - kHalfSize)) ==
+          allSetBitMask<uint8_t, xsimd::sse4_1>();
+    }
+
+    return true;
+  }
+  if (size >= sizeof(uint64_t)) {
+    return detail::oneOrTwoScalarsEqual<uint64_t>(left, right, size);
+  }
+
+#else
+  while (size >= sizeof(uint64_t)) {
+    if (*reinterpret_cast<const uint64_t*>(left) !=
+        *reinterpret_cast<const uint64_t*>(right)) {
+      return false;
+    }
+    left += sizeof(uint64_t);
+    right += sizeof(uint64_t);
+    size -= sizeof(uint64_t);
+  }
+#endif
+  if (size >= sizeof(uint32_t)) {
+    return detail::oneOrTwoScalarsEqual<uint32_t>(left, right, size);
+  }
+  if (size >= sizeof(uint16_t)) {
+    return detail::oneOrTwoScalarsEqual<uint16_t>(left, right, size);
+  }
+  return size == 0 || *left == *right;
 }
 
 } // namespace facebook::velox::simd

--- a/velox/common/base/SimdUtil.h
+++ b/velox/common/base/SimdUtil.h
@@ -385,7 +385,7 @@ inline T* addBytes(T* pointer, int32_t bytes) {
 // 'memcpy' implementation that copies at maximum width and unrolls
 // when 'bytes' is constant.
 template <typename A = xsimd::default_arch>
-void memcpy(void* to, const void* from, int32_t bytes, const A& = {});
+inline void memcpy(void* to, const void* from, int32_t bytes, const A& = {});
 
 // memset implementation that writes at maximum width and unrolls for
 // constant values of 'bytes'.
@@ -426,9 +426,9 @@ template <typename T, typename U, typename A = xsimd::default_arch>
 xsimd::batch<T, A> reinterpretBatch(xsimd::batch<U, A>, const A& = {});
 
 // Compares memory at 'x' and 'y' and returns true if 'size' leading bytes are
-// equal. May address up to SIMD width -1 past end of either 'x' or 'y'.
+// equal.
 template <typename A = xsimd::default_arch>
-inline bool memEqualUnsafe(const void* x, const void* y, int32_t size);
+inline bool memEqual(const void* x, const void* y, int32_t size);
 
 } // namespace facebook::velox::simd
 

--- a/velox/common/base/tests/SimdUtilTest.cpp
+++ b/velox/common/base/tests/SimdUtilTest.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/common/base/SimdUtil.h"
 #include <folly/Random.h>
+#include "velox/common/time/Timer.h"
 
 #include <gtest/gtest.h>
 
@@ -377,26 +378,112 @@ TEST_F(SimdUtilTest, reinterpretBatch) {
 }
 
 TEST_F(SimdUtilTest, memEqual) {
-  constexpr int32_t kSize = 132;
-  struct {
-    char x[kSize];
-    char y[kSize];
-    char padding[sizeof(xsimd::batch<uint8_t>)];
-  } data;
-  memset(&data, 11, sizeof(data));
-  EXPECT_TRUE(simd::memEqualUnsafe(data.x, data.y, kSize));
-  EXPECT_TRUE(simd::memEqualUnsafe(data.x, data.y, 17));
-  EXPECT_TRUE(simd::memEqualUnsafe(data.x, data.y, 32));
-  EXPECT_TRUE(simd::memEqualUnsafe(data.x, data.y, 33));
+  constexpr int32_t kSize = 200;
+  constexpr int32_t kPad = xsimd::batch<int32_t>::size;
+  std::string s1;
+  std::string s2;
+  s1.resize(kSize + kPad);
+  s2.resize(kSize + kPad);
+  for (auto i = 0; i < kSize; ++i) {
+    EXPECT_TRUE(simd::memEqual(s1.data(), s2.data(), i));
 
-  // Make data at 67 not equal.
-  data.y[67] = 0;
-  EXPECT_TRUE(simd::memEqualUnsafe(data.x, data.y, 67));
-  EXPECT_FALSE(simd::memEqualUnsafe(data.x, data.y, 68));
+    // Change a byte right after the compared range and check equals.
+    ++s2[i];
+    EXPECT_TRUE(simd::memEqual(s1.data(), s2.data(), i));
+    --s2[i];
 
-  // Redo the test offset by 1 to test unaligned.
-  EXPECT_TRUE(simd::memEqualUnsafe(&data.x[1], &data.y[1], 66));
-  EXPECT_FALSE(simd::memEqualUnsafe(&data.x[1], &data.y[1], 67));
+    if (i > 0) {
+      // Change the last byte in range and assert not equal
+      ++s2[i - 1];
+      EXPECT_FALSE(simd::memEqual(s1.data(), s2.data(), i));
+      // Try the same, starting at unaligned address.
+      if (i > 1) {
+        EXPECT_FALSE(simd::memEqual(s1.data() + 1, s2.data() + 1, i - 1));
+      }
+      --s2[i - 1];
+
+      // Change in the middle and check false.
+      ++s1[i / 2];
+      EXPECT_FALSE(simd::memEqual(s1.data(), s2.data(), i));
+      --s1[i / 2];
+    }
+  }
+}
+
+TEST_F(SimdUtilTest, memcpyTime) {
+  constexpr int64_t kMaxMove = 128;
+  constexpr int64_t kSize = (128 << 20) + kMaxMove;
+  constexpr uint64_t kSizeMask = (128 << 20) - 1;
+  constexpr int32_t kMoveMask = kMaxMove - 1;
+  constexpr uint64_t kMagic1 = 0x5231871;
+  constexpr uint64_t kMagic3 = 0xfae1;
+  constexpr uint64_t kMagic2 = 0x817952491;
+  std::vector<char> dataV(kSize);
+
+  auto data = dataV.data();
+  uint64_t simd = 0;
+  uint64_t sys = 0;
+  {
+    MicrosecondTimer t(&simd);
+    for (auto ctr = 0; ctr < 100; ++ctr) {
+      for (auto i = 0; i < 10000; ++i) {
+        char* from = data + ((i * kMagic1) & kSizeMask);
+        char* to = data + ((i * kMagic2) & kSizeMask);
+        int32_t size = (i * kMagic3) % kMoveMask;
+        simd::memcpy(to, from, size);
+      }
+    }
+  }
+  {
+    MicrosecondTimer t(&sys);
+    for (auto ctr = 0; ctr < 100; ++ctr) {
+      for (auto i = 0; i < 10000; ++i) {
+        char* from = data + ((i * kMagic1) & kSizeMask);
+        char* to = data + ((i * kMagic2) & kSizeMask);
+        int32_t size = (i * kMagic3) % kMoveMask;
+        ::memcpy(to, from, size);
+      }
+    }
+  }
+  LOG(INFO) << "simd=" << simd << " sys=" << sys;
+}
+
+TEST_F(SimdUtilTest, memcmpTime) {
+  constexpr int64_t kMaxCompare = 64;
+  constexpr int64_t kSize = (128 << 20) + kMaxCompare;
+  constexpr uint64_t kSizeMask = (128 << 20) - 1;
+  constexpr int32_t kCmpMask = kMaxCompare - 1;
+  constexpr uint64_t kMagic1 = 0x5231871;
+  constexpr uint64_t kMagic3 = 0xfae1;
+  constexpr uint64_t kMagic2 = 0x817952491;
+  std::vector<char> dataV(kSize);
+
+  auto data = dataV.data();
+  uint64_t simd = 0;
+  uint64_t sys = 0;
+  {
+    MicrosecondTimer t(&simd);
+    for (auto ctr = 0; ctr < 100; ++ctr) {
+      for (auto i = 0; i < 10000; ++i) {
+        char* from = data + ((i * kMagic1) & kSizeMask);
+        char* to = data + ((i * kMagic2) & kSizeMask);
+        int32_t size = (i * kMagic3) % kCmpMask;
+        ASSERT_TRUE(simd::memEqual(to, from, size));
+      }
+    }
+  }
+  {
+    MicrosecondTimer t(&sys);
+    for (auto ctr = 0; ctr < 100; ++ctr) {
+      for (auto i = 0; i < 10000; ++i) {
+        char* from = data + ((i * kMagic1) & kSizeMask);
+        char* to = data + ((i * kMagic2) & kSizeMask);
+        int32_t size = (i * kMagic3) % kCmpMask;
+        ASSERT_EQ(0, ::memcmp(to, from, size));
+      }
+    }
+  }
+  LOG(INFO) << "simd=" << simd << " sys=" << sys;
 }
 
 } // namespace

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -964,8 +964,8 @@ class RowContainer {
       return compareComplexType(row, offset, decoded, index) == 0;
     }
     if (Kind == TypeKind::VARCHAR || Kind == TypeKind::VARBINARY) {
-      return compareStringAsc(
-                 valueAt<StringView>(row, offset), decoded, index) == 0;
+      return compareStringEqual(
+          valueAt<StringView>(row, offset), decoded, index);
     }
     return decoded.valueAt<T>(index) == valueAt<T>(row, offset);
   }
@@ -983,8 +983,8 @@ class RowContainer {
       return compareComplexType(row, offset, decoded, index) == 0;
     }
     if (Kind == TypeKind::VARCHAR || Kind == TypeKind::VARBINARY) {
-      return compareStringAsc(
-                 valueAt<StringView>(row, offset), decoded, index) == 0;
+      return compareStringEqual(
+          valueAt<StringView>(row, offset), decoded, index);
     }
 
     return decoded.valueAt<T>(index) == valueAt<T>(row, offset);
@@ -1114,6 +1114,27 @@ class RowContainer {
       StringView value,
       FlatVector<StringView>* FOLLY_NONNULL values,
       vector_size_t index);
+
+  static inline bool compareStringEqual(
+      StringView left,
+      const DecodedVector& decoded,
+      vector_size_t index) {
+    StringView right = decoded.valueAt<StringView>(index);
+    if (left.sizeAndPrefixAsInt64() != right.sizeAndPrefixAsInt64()) {
+      return false;
+    }
+    if (left.isInline()) {
+      return left.inlinedAsInt64() == right.inlinedAsInt64();
+    }
+    auto header = HashStringAllocator::headerOf(left.data());
+    if (LIKELY(header->size() >= left.size())) {
+      return simd::memEqual(left.data() + 4, right.data() + 4, left.size() - 4);
+    }
+    std::string storage;
+    HashStringAllocator::contiguousString(left, storage);
+    return simd::memEqual(
+        storage.data() + 4, right.data() + 4, left.size() - 4);
+  }
 
   static int32_t compareStringAsc(
       StringView left,

--- a/velox/type/StringView.cpp
+++ b/velox/type/StringView.cpp
@@ -78,7 +78,7 @@ int32_t StringView::linearSearch(
         if (isInline ? inlined ==
                     reinterpret_cast<const uint64_t*>(
                            &strings[indices[i + offset]])[1]
-                     : simd::memEqualUnsafe(
+                     : simd::memEqual(
                            body,
                            strings[indices[i + offset]].data() + 4,
                            bodySize)) {
@@ -118,8 +118,7 @@ int32_t StringView::linearSearch(
             return offset;
           }
           if (!isInline) {
-            if (simd::memEqualUnsafe(
-                    body, strings[offset].data() + 4, bodySize)) {
+            if (simd::memEqual(body, strings[offset].data() + 4, bodySize)) {
               return offset;
             }
           }

--- a/velox/type/StringView.h
+++ b/velox/type/StringView.h
@@ -250,7 +250,6 @@ struct StringView {
       const int32_t* indices,
       int32_t numStrings);
 
- private:
   inline int64_t sizeAndPrefixAsInt64() const {
     return reinterpret_cast<const int64_t*>(this)[0];
   }
@@ -259,6 +258,7 @@ struct StringView {
     return reinterpret_cast<const int64_t*>(this)[1];
   }
 
+ private:
   int32_t prefixAsInt() const {
     return *reinterpret_cast<const int32_t*>(&prefix_);
   }


### PR DESCRIPTION
Summary:
Original commit changeset: b76dc9e5d2d2

Original Phabricator Diff: D50984132

Differential Revision: D51183551


