### PR TITLE
Fix build issues related to Arrow headers

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3InsertTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3InsertTest.cpp
@@ -15,12 +15,10 @@
  */
 
 #include <folly/init/Init.h>
+#include <gtest/gtest.h>
 
-#include "gtest/gtest.h"
-#include "velox/common/file/FileSystems.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/tests/MinioServer.h"
-#include "velox/dwio/parquet/reader/ParquetReader.h"
 #include "velox/exec/TableWriter.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"

--- a/velox/exec/benchmarks/CMakeLists.txt
+++ b/velox/exec/benchmarks/CMakeLists.txt
@@ -37,7 +37,15 @@ add_executable(velox_hash_benchmark HashTableBenchmark.cpp)
 target_link_libraries(velox_hash_benchmark velox_exec velox_exec_test_lib
                       velox_vector_test_lib ${FOLLY_BENCHMARK})
 
-add_executable(velox_sort_benchmark RowContainerSortBenchmark.cpp)
+if(${VELOX_ENABLE_PARQUET})
+  add_executable(velox_sort_benchmark RowContainerSortBenchmark.cpp)
 
-target_link_libraries(velox_sort_benchmark velox_exec velox_exec_test_lib
-                      velox_vector_test_lib ${FOLLY_BENCHMARK})
+  target_link_libraries(
+    velox_sort_benchmark
+    velox_exec
+    velox_exec_test_lib
+    velox_vector_test_lib
+    ${FOLLY_BENCHMARK}
+    arrow
+    thrift)
+endif()


### PR DESCRIPTION
This PR fixes "parquet/level_conversion.h: No such file or directory" issue caused by the recent 
Arrow package move to the Parquet writer. The tests include ParquetReader headers but the 
Parquet reader is not turned on by default (VELOX_ENABLE_PARQUET = OFF), and thus Arrow 
was not enabled and installed, causing the Arrow headers like "parquet/level_conversion.h to be
missing. 

This PR includes two fixes:

1. The include of ParquetReader.h in S3InsertTest.cpp is not needed. The first commit
cleans up the includes for S3InsertTest.cpp.

2. The second commit guards RowContainerSortBenchmark and velox_sort_benchmark with the VELOX_ENABLE_PARQUET setting.

Resolves https://github.com/facebookincubator/velox/issues/7399