### PR TITLE
Remove incorrect assumption in DwrfRowReader#prefetchUnits

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -139,7 +139,9 @@ class DwrfRowReader : public StrideIndexProvider,
   uint64_t previousRow;
   uint32_t firstStripe;
   uint32_t currentStripe;
-  uint32_t lastStripe; // the stripe AFTER the last one
+  // The the stripe AFTER the last one that should be read. e.g. if the highest
+  // stripe in the RowReader's bounds is 3, then stripeCeiling is 4.
+  uint32_t stripeCeiling;
   uint64_t currentRowInStripe;
   bool newStripeReadyForRead;
   uint64_t rowsInCurrentStripe;
@@ -206,7 +208,7 @@ class DwrfRowReader : public StrideIndexProvider,
   }
 
   bool isEmptyFile() const {
-    return (lastStripe == 0);
+    return (stripeCeiling == firstStripe);
   }
 
   void checkSkipStrides(uint64_t strideSize);

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -886,6 +886,21 @@ TEST_F(TestRowReaderPrefetch, testFirstStripeNotLoadedWithEagerLoadingOff) {
   ASSERT_EQ(units[0].prefetch(), DwrfRowReader::FetchResult::kFetched);
 }
 
+// PrefetchUnits should return empty
+TEST_F(TestRowReaderPrefetch, testEmptyRowRange) {
+  dwio::common::ReaderOptions readerOpts{pool()};
+  RowReaderOptions rowReaderOpts;
+  // Set empty range in rowreader options
+  rowReaderOpts.range(0, 0);
+  auto reader = DwrfReader::create(
+      createFileBufferedInput(getFMSmallFile(), readerOpts.getMemoryPool()),
+      readerOpts);
+  auto rowReaderOwner = reader->createRowReader(rowReaderOpts);
+  auto rowReader = dynamic_cast<DwrfRowReader*>(rowReaderOwner.get());
+  auto units = rowReader->prefetchUnits().value();
+  ASSERT_EQ(0, units.size());
+}
+
 class TestFlatMapReaderFlatLayout
     : public TestWithParam<std::tuple<bool, size_t>>,
       public VectorTestBase {};


### PR DESCRIPTION
Summary: firstStripe is not always less then lastStripe, when there are no rows in range for the reader.

Differential Revision: D51179730


