### PR TITLE
Look up custom type cast operators by name instead of full toString

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -725,7 +725,7 @@ std::string CastExpr::toSql(std::vector<VectorPtr>* complexConstants) const {
 }
 
 CastOperatorPtr CastExpr::getCastOperator(const TypePtr& type) {
-  const auto key = type->toString();
+  const auto* key = type->name();
 
   auto it = castOperators_.find(key);
   if (it != castOperators_.end()) {


### PR DESCRIPTION
Summary:
Today we look up custom type cast operator in CastExpr using the full toString instead of just the type name.

Looking at the implementation of getCustomTypeCastOperator, it looks up the CustomTypeFactories for the
type, and this mapping is based on type name, so passing in the return value of toString is technically
incorrect, although in practice toString() normally just returns name() unless it's a complex type.

The larger problem comes with https://github.com/facebookincubator/velox/pull/7256 toString is called on
every batch at every level of  the type tree on both the to and from types.  This problem existed prior that PR,
but with that change it becomes a significant performance issue for large row types in particular.
```
============================================================================
[...]pression/benchmarks/CastBenchmark.cpp     relative  time/iter   iters/s
============================================================================
scalar                                                     13.69ns    73.06M
renameSmallStruct                                         231.17ns     4.33M
renameLargeStruct                                          76.32us    13.10K
smallStructNested                                         275.48ns     3.63M
largeStructNested                                          90.98us    10.99K
```

after this change
```
============================================================================
[...]pression/benchmarks/CastBenchmark.cpp     relative  time/iter   iters/s
============================================================================
scalar                                                     14.85ns    67.32M
renameSmallStruct                                           8.03ns   124.50M
renameLargeStruct                                         215.92ns     4.63M
smallStructNested                                          44.93ns    22.26M
largeStructNested                                          13.99us    71.46K
```

note renameLargeStruct is several hundred times faster

Differential Revision: D51206341


