### PR TITLE
Make ByteStream::size() consistent across use cases

### DIFF
--- a/velox/common/memory/StreamArena.cpp
+++ b/velox/common/memory/StreamArena.cpp
@@ -20,7 +20,10 @@ namespace facebook::velox {
 
 StreamArena::StreamArena(memory::MemoryPool* pool) : pool_(pool) {}
 
-void StreamArena::newRange(int32_t bytes, ByteRange* range) {
+void StreamArena::newRange(
+    int32_t bytes,
+    ByteRange* /*lastRange*/,
+    ByteRange* range) {
   VELOX_CHECK_GT(bytes, 0, "StreamArena::newRange can't be zero length");
   const memory::MachinePageCount numPages =
       memory::AllocationTraits::numPages(bytes);
@@ -62,7 +65,10 @@ void StreamArena::newRange(int32_t bytes, ByteRange* range) {
   }
 }
 
-void StreamArena::newTinyRange(int32_t bytes, ByteRange* range) {
+void StreamArena::newTinyRange(
+    int32_t bytes,
+    ByteRange* /*lastRange*/,
+    ByteRange* range) {
   VELOX_CHECK_GT(bytes, 0, "StreamArena::newTinyRange can't be zero length");
   tinyRanges_.emplace_back();
   tinyRanges_.back().resize(bytes);

--- a/velox/common/memory/StreamArena.h
+++ b/velox/common/memory/StreamArena.h
@@ -30,16 +30,28 @@ class StreamArena {
 
   virtual ~StreamArena() = default;
 
-  /// Sets range to the request 'bytes' of writable memory owned by 'this'.
-  /// We allocate non-contiguous memory to store range bytes if requested
-  /// 'bytes' is equal or less than the largest class page size. Otherwise, we
-  /// allocate from contiguous memory.
-  virtual void newRange(int32_t bytes, ByteRange* range);
+  /// Sets range to the request 'bytes' of writable memory owned by
+  /// 'this'.  We allocate non-contiguous memory to store range bytes
+  /// if requested 'bytes' is equal or less than the largest class
+  /// page size. Otherwise, we allocate from contiguous
+  /// memory. 'range' is set to point to the allocated memory. If
+  /// 'lastRange' is non-nullptr, it is the last range of the stream
+  /// to which we are adding the new range. 'lastRange' is nullptr if
+  /// adding the first range to a stream. The memory is stays owned by
+  /// 'this' in all cases. Used by HashStringAllocator when extending
+  /// a multipart entry. The previously last part has its last 8 bytes
+  /// moved to the next part and gets a pointer to the next part as
+  /// its last 8 bytes. When extending, we need to update the entry so
+  /// that the next pointer is not seen when reading the content and
+  /// is also not counted in the payload size of the multipart entry.
+  virtual void newRange(int32_t bytes, ByteRange* lastRange, ByteRange* range);
 
   /// sets 'range' to point to a small piece of memory owned by this. These
   /// always come from the heap. The use case is for headers that may change
-  /// length based on data properties, not for bulk data.
-  virtual void newTinyRange(int32_t bytes, ByteRange* range);
+  /// length based on data properties, not for bulk data. See 'newRange' for the
+  /// meaning of 'lastRange'.
+  virtual void
+  newTinyRange(int32_t bytes, ByteRange* lastRange, ByteRange* range);
 
   /// Returns the Total size in bytes held by all Allocations.
   virtual size_t size() const {

--- a/velox/common/memory/tests/HashStringAllocatorTest.cpp
+++ b/velox/common/memory/tests/HashStringAllocatorTest.cpp
@@ -544,6 +544,71 @@ TEST_F(HashStringAllocatorTest, strings) {
   allocator_->checkConsistency();
 }
 
+TEST_F(HashStringAllocatorTest, sizeAndPosition) {
+  // We make a stream consisting of multiple non-contiguous ranges
+  // and verify that it is writable and appendable and that its
+  // size() always reflects the number of written bytes, excluding
+  // any overheads.
+
+  // First, we make a free list to make sure things are multipart.
+  constexpr int32_t kUnitSize = 256;
+  std::vector<HashStringAllocator::Header*> pieces;
+  for (auto i = 0; i < 100; ++i) {
+    pieces.push_back(allocator_->allocate(kUnitSize + 30));
+  }
+  for (auto i = 0; i < pieces.size(); i += 2) {
+    allocator_->free(pieces[i]);
+  }
+
+  // We write each nth character of stream to be  n % kunitSize.
+  std::string allChars;
+  allChars.resize(kUnitSize);
+  for (auto i = 0; i < kUnitSize; ++i) {
+    allChars[i] = i;
+  }
+
+  ByteStream stream(allocator_.get());
+  auto position = allocator_->newWrite(stream, 20);
+  // Nothing written yet.
+  EXPECT_EQ(0, stream.size());
+  for (auto i = 0; i < 10; ++i) {
+    stream.appendStringView(allChars);
+    // We check that the size reflects the payload size after each write.
+    EXPECT_EQ((i + 1) * kUnitSize, stream.size());
+  }
+  // We expect a multipart allocation.
+  EXPECT_TRUE(position.header->isContinued());
+  EXPECT_EQ(kUnitSize * 10, stream.tellp());
+
+  // we check and rewrite different offsets in the stream, not to pass past end.
+  for (auto start = 90; start < kUnitSize * 9; start += 125) {
+    stream.seekp(start);
+    EXPECT_EQ(start, stream.tellp());
+    EXPECT_EQ(kUnitSize * 10, stream.size());
+    ByteInputStream input = stream.inputStream();
+    input.seekp(start);
+    EXPECT_EQ(kUnitSize * 10 - start, input.remainingSize());
+    for (auto c = 0; c < 10; ++c) {
+      uint8_t byte = input.readByte();
+      EXPECT_EQ(byte, (start + c) % kUnitSize);
+    }
+    // Overwrite the bytes just read.
+    stream.seekp(start);
+    stream.appendStringView(std::string_view(allChars.data(), 100));
+    input = stream.inputStream();
+    input.seekp(start);
+    for (auto c = 0; c < 100; ++c) {
+      uint8_t byte = input.readByte();
+      EXPECT_EQ(byte, c % kUnitSize);
+    }
+  }
+  EXPECT_EQ(kUnitSize * 10, stream.size());
+  stream.seekp(kUnitSize * 10 - 100);
+  stream.appendStringView(allChars);
+  // The last write extends the size.
+  EXPECT_EQ(kUnitSize * 11 - 100, stream.size());
+}
+
 TEST_F(HashStringAllocatorTest, storeStringFast) {
   allocator_->allocate(HashStringAllocator::kMinAlloc);
   std::string s(allocator_->freeSpace() + sizeof(void*), 'x');

--- a/velox/common/memory/tests/StreamArenaTest.cpp
+++ b/velox/common/memory/tests/StreamArenaTest.cpp
@@ -107,7 +107,7 @@ TEST_F(StreamArenaTest, newRange) {
     auto arena = newArena();
     ByteRange range;
     for (int i = 0; i < testData.requestRangeSizes.size(); ++i) {
-      arena->newRange(testData.requestRangeSizes[i], &range);
+      arena->newRange(testData.requestRangeSizes[i], nullptr, &range);
       ASSERT_EQ(range.size, testData.expectedRangeSizes[i]) << range.toString();
       ASSERT_EQ(range.position, 0);
       ASSERT_TRUE(range.buffer != nullptr);
@@ -135,18 +135,18 @@ TEST_F(StreamArenaTest, randomRange) {
     if (folly::Random::oneIn(4)) {
       const int requestSize =
           1 + folly::Random::rand32() % (2 * AllocationTraits::kPageSize);
-      arena->newTinyRange(requestSize, &range);
+      arena->newTinyRange(requestSize, nullptr, &range);
       ASSERT_EQ(range.size, requestSize);
     } else if (folly::Random::oneIn(3)) {
       const int requestSize =
           AllocationTraits::pageBytes(pool_->largestSizeClass()) +
           (folly::Random::rand32() % (4 << 20));
-      arena->newRange(requestSize, &range);
+      arena->newRange(requestSize, nullptr, &range);
       ASSERT_EQ(AllocationTraits::roundUpPageBytes(requestSize), range.size);
     } else {
       const int requestSize =
           1 + folly::Random::rand32() % pool_->largestSizeClass();
-      arena->newRange(requestSize, &range);
+      arena->newRange(requestSize, nullptr, &range);
       ASSERT_LE(range.size, AllocationTraits::roundUpPageBytes(requestSize));
     }
     ASSERT_EQ(range.position, 0);
@@ -158,8 +158,9 @@ TEST_F(StreamArenaTest, error) {
   auto arena = newArena();
   ByteRange range;
   VELOX_ASSERT_THROW(
-      arena->newTinyRange(0, &range),
+      arena->newTinyRange(0, nullptr, &range),
       "StreamArena::newTinyRange can't be zero length");
   VELOX_ASSERT_THROW(
-      arena->newRange(0, &range), "StreamArena::newRange can't be zero length");
+      arena->newRange(0, nullptr, &range),
+      "StreamArena::newRange can't be zero length");
 }

--- a/velox/exec/Strings.cpp
+++ b/velox/exec/Strings.cpp
@@ -39,12 +39,13 @@ StringView Strings::append(StringView value, HashStringAllocator& allocator) {
   }
 
   // Check if there is enough space left.
-  if (stream.ranges().back().size < requiredBytes) {
+  auto& currentRange = stream.ranges().back();
+  if (currentRange.size - currentRange.position < requiredBytes) {
     // Not enough space. Allocate new block.
     ByteRange newRange;
     allocator.newContiguousRange(requiredBytes, &newRange);
 
-    stream.setRange(newRange);
+    stream.setRange(newRange, 0);
   }
 
   VELOX_DCHECK_LE(requiredBytes, stream.ranges().back().size);

--- a/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
@@ -112,7 +112,7 @@ TEST_F(ValueListTest, integers) {
 
 TEST_F(ValueListTest, arrays) {
   // No nulls.
-  int32_t kSizeCaps[] = {500, 4000, 6000, 50000};
+  int32_t kSizeCaps[] = {730, 4000, 7500, 50000};
   int32_t counter = 0;
   for (auto size : kTestSizes) {
     auto data = makeArrayVector<int32_t>(

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -1169,7 +1169,7 @@ class VectorStream {
   }
 
   void initializeHeader(std::string_view name, StreamArena& streamArena) {
-    streamArena.newTinyRange(50, &header_);
+    streamArena.newTinyRange(50, nullptr, &header_);
     header_.size = name.size() + sizeof(int32_t);
     *reinterpret_cast<int32_t*>(header_.buffer) = name.size();
     memcpy(header_.buffer + sizeof(int32_t), &name[0], name.size());


### PR DESCRIPTION
ByteStream::size is expected to have the semantics of the length of std::stringstream. It is the offset of the first unwritten byte from the start. This does not move backward when seeking to mid stream and writing, for example.  been written.

Adds a test to verify proper function when randomly overwriting a ByteStream backed by HashStringAllocator multipart entries.