### PR TITLE
Support named row fields in type signature and binding

### DIFF
--- a/velox/exec/tests/FunctionSignatureBuilderTest.cpp
+++ b/velox/exec/tests/FunctionSignatureBuilderTest.cpp
@@ -86,7 +86,7 @@ TEST_F(FunctionSignatureBuilderTest, basicTypeTests) {
           .argumentType("T")
           .argumentType("array(M)")
           .build(),
-      "Type doesn't exist: M");
+      "Type doesn't exist: 'M'");
 
   // Only supported types.
   VELOX_ASSERT_THROW(
@@ -95,7 +95,7 @@ TEST_F(FunctionSignatureBuilderTest, basicTypeTests) {
           .returnType("nosuchtype")
           .argumentType("array(T)")
           .build(),
-      "Type doesn't exist: NOSUCHTYPE");
+      "Type doesn't exist: 'NOSUCHTYPE'");
 
   // Any Type.
   EXPECT_TRUE(
@@ -122,9 +122,9 @@ TEST_F(FunctionSignatureBuilderTest, typeParamTests) {
       FunctionSignatureBuilder()
           .typeVariable("T")
           .returnType("integer")
-          .argumentType("row(T ..., varchar)")
+          .argumentType("row(..., varchar)")
           .build(),
-      "Type doesn't exist: T ...");
+      "Type doesn't exist: '...'");
 
   // Type params cant have type params.
   VELOX_ASSERT_THROW(
@@ -134,7 +134,7 @@ TEST_F(FunctionSignatureBuilderTest, typeParamTests) {
           .returnType("integer")
           .argumentType("T(M)")
           .build(),
-      "Named type cannot have parameters : T(M)");
+      "Named type cannot have parameters: 'T(M)'");
 }
 
 TEST_F(FunctionSignatureBuilderTest, anyInReturn) {

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -98,11 +98,23 @@ class SignatureVariable {
 };
 
 // Base type (e.g. map) and optional parameters (e.g. K, V).
-// All parameters must be of the same ParameterType.
 class TypeSignature {
  public:
-  TypeSignature(std::string baseName, std::vector<TypeSignature> parameters)
-      : baseName_{std::move(baseName)}, parameters_{std::move(parameters)} {}
+  /// @param baseName The base name of the type. Could describe a concrete type
+  /// name (e.g. map, bigint, double), or a variable (e.g. K, V).
+  /// @param parameters The optional parameters for the type. For example, the
+  /// signature "map(K, V)" would have two parameters, "K", and "V". All
+  /// parameters must be of the same ParameterType.
+  /// @param rowFieldName if this type signature is a field of another parent
+  /// row type, it can optionally have a name. E.g. `row(id bigint)` would have
+  /// "id" set as rowFieldName in the "bigint" parameter.
+  TypeSignature(
+      std::string baseName,
+      std::vector<TypeSignature> parameters,
+      std::optional<std::string> rowFieldName = std::nullopt)
+      : baseName_{std::move(baseName)},
+        parameters_{std::move(parameters)},
+        rowFieldName_(rowFieldName) {}
 
   const std::string& baseName() const {
     return baseName_;
@@ -112,15 +124,24 @@ class TypeSignature {
     return parameters_;
   }
 
+  const std::optional<std::string>& rowFieldName() const {
+    return rowFieldName_;
+  }
+
   std::string toString() const;
 
   bool operator==(const TypeSignature& rhs) const {
-    return baseName_ == rhs.baseName_ && parameters_ == rhs.parameters_;
+    return baseName_ == rhs.baseName_ && parameters_ == rhs.parameters_ &&
+        rowFieldName_ == rhs.rowFieldName_;
   }
 
  private:
   const std::string baseName_;
   const std::vector<TypeSignature> parameters_;
+
+  // If this object is a field of another parent row type, it can optionally
+  // have a name, e.g, `row(id bigint)`
+  std::optional<std::string> rowFieldName_;
 };
 
 class FunctionSignature {
@@ -239,16 +260,21 @@ inline void addVariable(
 
 /// Parses a string into TypeSignature. The format of the string is type name,
 /// optionally followed by type parameters enclosed in parenthesis.
+///
 /// Examples:
 ///     - bigint
 ///     - double
 ///     - array(T)
 ///     - map(K,V)
-///     - row(bigint,array(tinyint),T)
+///     - row(named bigint,array(tinyint),T)
 ///     - function(S,T,R)
+///
+/// Row fields are allowed to be named or anonymous, e.g. "row(foo bigint)" or
+/// "row(bigint)"
 TypeSignature parseTypeSignature(const std::string& signature);
 
 /// Convenience class for creating FunctionSignature instances.
+///
 /// Example of usage:
 ///     - signature of "concat" function: varchar... -> varchar
 ///

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -78,6 +78,22 @@ std::optional<int64_t> tryResolveLongLiteral(
   return integerVariablesBindings.at(variable);
 }
 
+// If the parameter is a named field from a row, ensure the names are
+// compatible. For example:
+//
+// > row(bigint) - binds any row with bigint as field.
+// > row(foo bigint) - only binds rows where bigint field is named foo.
+bool checkNamedRowField(
+    const TypeSignature& signature,
+    const TypePtr& actualType,
+    size_t idx) {
+  if (signature.rowFieldName().has_value() &&
+      (*signature.rowFieldName() != asRowType(actualType)->nameOf(idx))) {
+    return false;
+  }
+  return true;
+}
+
 } // namespace
 
 bool SignatureBinder::tryBind() {
@@ -191,6 +207,7 @@ bool SignatureBinderBase::tryBind(
   if (params.size() != actualType->parameters().size()) {
     return false;
   }
+
   for (auto i = 0; i < params.size(); i++) {
     const auto& actualParameter = actualType->parameters()[i];
     switch (actualParameter.kind) {
@@ -201,6 +218,10 @@ bool SignatureBinderBase::tryBind(
         }
         break;
       case TypeParameterKind::kType:
+        if (!checkNamedRowField(params[i], actualType, i)) {
+          return false;
+        }
+
         if (!tryBind(params[i], actualParameter.type)) {
           return false;
         }

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -20,7 +20,8 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
-using namespace facebook::velox;
+namespace facebook::velox::exec::test {
+namespace {
 
 void testSignatureBinder(
     const std::shared_ptr<exec::FunctionSignature>& signature,
@@ -810,7 +811,7 @@ TEST(SignatureBinderTest, customType) {
           .returnType("bigint")
           .argumentType("fancy_type")
           .build(),
-      "Type doesn't exist: FANCY_TYPE");
+      "Type doesn't exist: 'FANCY_TYPE'");
 }
 
 TEST(SignatureBinderTest, hugeIntType) {
@@ -823,3 +824,84 @@ TEST(SignatureBinderTest, hugeIntType) {
     testSignatureBinder(signature, {HUGEINT()}, HUGEINT());
   }
 }
+
+TEST(SignatureBinderTest, namedRows) {
+  registerCustomType(
+      "timestamp with time zone",
+      std::make_unique<const TimestampWithTimeZoneTypeFactories>());
+
+  // Simple named row field.
+  {
+    auto signature = exec::FunctionSignatureBuilder()
+                         .returnType("varchar")
+                         .argumentType("row(bla varchar)")
+                         .build();
+    testSignatureBinder(signature, {ROW({{"bla", VARCHAR()}})}, VARCHAR());
+
+    // Cannot bind if field doesn't have the same name set.
+    assertCannotResolve(signature, {ROW({{VARCHAR()}})});
+  }
+
+  // Multiple named row field.
+  {
+    auto signature = exec::FunctionSignatureBuilder()
+                         .returnType("varchar")
+                         .argumentType("row(foo varchar, bigint, bar double)")
+                         .build();
+    testSignatureBinder(
+        signature,
+        {ROW({{"foo", VARCHAR()}, {"", BIGINT()}, {"bar", DOUBLE()}})},
+        VARCHAR());
+
+    // Binds even if the middle (unnamed) field has a name.
+    testSignatureBinder(
+        signature,
+        {ROW({{"foo", VARCHAR()}, {"fighters", BIGINT()}, {"bar", DOUBLE()}})},
+        VARCHAR());
+
+    // But not if one of the named fields is not.
+    assertCannotResolve(
+        signature,
+        {ROW({{"foo", VARCHAR()}, {"fighters", BIGINT()}, {"bla", DOUBLE()}})});
+  }
+
+  // Type with a space in the name.
+  {
+    auto signature = exec::FunctionSignatureBuilder()
+                         .returnType("varchar")
+                         .argumentType("row(timestamp with time zone)")
+                         .build();
+    testSignatureBinder(
+        signature, {ROW({TIMESTAMP_WITH_TIME_ZONE()})}, VARCHAR());
+
+    // Ok to bind if even if the type has a field name set.
+    testSignatureBinder(
+        signature, {ROW({{"name", TIMESTAMP_WITH_TIME_ZONE()}})}, VARCHAR());
+  }
+
+  // Named type with a space.
+  {
+    auto signature = exec::FunctionSignatureBuilder()
+                         .returnType("varchar")
+                         .argumentType("row(named timestamp with time zone)")
+                         .build();
+    testSignatureBinder(
+        signature, {ROW({{"named", TIMESTAMP_WITH_TIME_ZONE()}})}, VARCHAR());
+  }
+
+  // Nested named.
+  {
+    auto signature =
+        exec::FunctionSignatureBuilder()
+            .returnType("varchar")
+            .argumentType("row(my_map map(bigint, row(bla varchar)))")
+            .build();
+    testSignatureBinder(
+        signature,
+        {ROW({{"my_map", MAP(BIGINT(), ROW({{"bla", VARCHAR()}}))}})},
+        VARCHAR());
+  }
+}
+
+} // namespace
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary:
Adding support for named row fields in type signature definition, and
honoring them when binding types. For example:

> row(bigint) - binds any row with bigint as field.
> row(foo bigint) - only binds rows where bigint field is named foo.

Differential Revision: D51225525


