### PR TITLE
Relax column count check in PrestoSerializer

### DIFF
--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -2339,7 +2339,8 @@ void PrestoVectorSerde::deserialize(
   const auto& childTypes = type->asRow().children();
   if (!needCompression(*codec)) {
     const auto numColumns = source->read<int32_t>();
-    VELOX_USER_CHECK_EQ(
+    // TODO Fix call sites and tighten the check to _EQ.
+    VELOX_USER_CHECK_GE(
         numColumns,
         type->size(),
         "Number of columns in serialized data doesn't match "


### PR DESCRIPTION
Summary:
Some call sites deserialize only a subset of columns. Relax the check to avoid
breaking these. Investigate and fix these call sites, then restore the check as
a follow-up.

Differential Revision: D51230660


