### PR TITLE
Add spillType to Accumulator

### DIFF
--- a/velox/exec/DistinctAggregations.cpp
+++ b/velox/exec/DistinctAggregations.cpp
@@ -43,6 +43,7 @@ class TypedDistinctAggregations : public DistinctAggregations {
         sizeof(AccumulatorType),
         false, // usesExternalMemory
         1, // alignment
+        nullptr,
         [](folly::Range<char**> /*groups*/, VectorPtr& /*result*/) {
           VELOX_UNREACHABLE();
         },

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -249,6 +249,9 @@ class GroupingSet {
   // 'keys'. This is called for each row received from a merge of spilled data.
   void updateRow(SpillMergeStream& keys, char* row);
 
+  // Returns a RowType of the spilled data.
+  RowTypePtr makeSpillType() const;
+
   // Copies the finalized state from 'mergeRows' to 'result' and clears
   // 'mergeRows'. Used for producing a batch of results when aggregating spilled
   // groups.

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -34,11 +34,12 @@ class Accumulator {
       int32_t fixedSize,
       bool usesExternalMemory,
       int32_t alignment,
+      TypePtr spillType,
       std::function<void(folly::Range<char**> groups, VectorPtr& result)>
-          extractFunction,
+          spillExtractFunction,
       std::function<void(folly::Range<char**> groups)> destroyFunction);
 
-  explicit Accumulator(Aggregate* aggregate);
+  explicit Accumulator(Aggregate* aggregate, TypePtr spillType);
 
   bool isFixedSize() const;
 
@@ -48,16 +49,19 @@ class Accumulator {
 
   int32_t alignment() const;
 
-  void destroy(folly::Range<char**> groups);
+  const TypePtr& spillType() const;
 
   void extractForSpill(folly::Range<char**> groups, VectorPtr& result) const;
+
+  void destroy(folly::Range<char**> groups);
 
  private:
   const bool isFixedSize_;
   const int32_t fixedSize_;
   const bool usesExternalMemory_;
   const int32_t alignment_;
-  std::function<void(folly::Range<char**>, VectorPtr&)> extractFunction_;
+  const TypePtr spillType_;
+  std::function<void(folly::Range<char**>, VectorPtr&)> spillExtractFunction_;
   std::function<void(folly::Range<char**> groups)> destroyFunction_;
 };
 

--- a/velox/exec/SortedAggregations.cpp
+++ b/velox/exec/SortedAggregations.cpp
@@ -127,6 +127,7 @@ Accumulator SortedAggregations::accumulator() const {
       sizeof(RowPointers),
       false,
       1,
+      nullptr,
       [](folly::Range<char**> /*groups*/, VectorPtr& /*result*/) {
         VELOX_UNREACHABLE();
       },

--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -150,6 +150,7 @@ TopNRowNumber::TopNRowNumber(
         sizeof(TopRows),
         false,
         1,
+        nullptr,
         [](auto, auto) { VELOX_UNREACHABLE(); },
         [](auto) {}};
 

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -566,7 +566,7 @@ TEST_P(HashTableTest, clear) {
       config);
 
   auto table = HashTable<true>::createForAggregation(
-      std::move(keyHashers), {Accumulator{aggregate.get()}}, pool());
+      std::move(keyHashers), {Accumulator{aggregate.get(), nullptr}}, pool());
   ASSERT_NO_THROW(table->clear());
 }
 

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -1035,64 +1035,15 @@ TEST_F(RowContainerTest, estimateRowSize) {
   EXPECT_EQ(0x440000, rowContainer->stringAllocator().retainedSize());
 }
 
-class AggregateWithAlignment : public Aggregate {
- public:
-  explicit AggregateWithAlignment(TypePtr resultType, int alignment)
-      : Aggregate(std::move(resultType)), alignment_(alignment) {}
-
-  int32_t accumulatorFixedWidthSize() const override {
-    return 42;
-  }
-
-  int32_t accumulatorAlignmentSize() const override {
-    return alignment_;
-  }
-
-  void initializeNewGroups(
-      char** /*groups*/,
-      folly::Range<const vector_size_t*> /*indices*/) override {}
-
-  void addRawInput(
-      char** /*groups*/,
-      const SelectivityVector& /*rows*/,
-      const std::vector<VectorPtr>& /*args*/,
-      bool /*mayPushdown*/) override {}
-
-  void extractValues(
-      char** /*groups*/,
-      int32_t /*numGroups*/,
-      VectorPtr* /*result*/) override {}
-
-  void addIntermediateResults(
-      char** /*groups*/,
-      const SelectivityVector& /*rows*/,
-      const std::vector<VectorPtr>& /*args*/,
-      bool /*mayPushdown*/) override {}
-
-  void addSingleGroupRawInput(
-      char* /*group*/,
-      const SelectivityVector& /*rows*/,
-      const std::vector<VectorPtr>& /*args*/,
-      bool /*mayPushdown*/) override {}
-
-  void addSingleGroupIntermediateResults(
-      char* /*group*/,
-      const SelectivityVector& /*rows*/,
-      const std::vector<VectorPtr>& /*args*/,
-      bool /*mayPushdown*/) override {}
-
-  void extractAccumulators(
-      char** /*groups*/,
-      int32_t /*numGroups*/,
-      VectorPtr* /*result*/) override {}
-
- private:
-  int alignment_;
-};
-
 TEST_F(RowContainerTest, alignment) {
-  AggregateWithAlignment aggregate(BIGINT(), 64);
-  std::vector<Accumulator> accumulators{Accumulator(&aggregate)};
+  std::vector<Accumulator> accumulators{Accumulator(
+      true, // isFixedSize
+      42, // fixedSize
+      false, // usesExternalMemory
+      64, // alignment
+      nullptr, // spillType
+      [](auto, auto) { VELOX_UNREACHABLE(); },
+      [](auto) {})};
   RowContainer data(
       {SMALLINT()},
       true,


### PR DESCRIPTION
Add spillType field to Accumulator struct and use it to generate RowType for
spilling.

This allows to provide spilling support for Accumulators that do not correspond
to aggregate functions, i.e. SortedAggregations.

Part of #7455