### PR TITLE
Add support for spilling aggregations over sorted inputs

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -228,11 +228,10 @@ void addSortingKeys(
 } // namespace
 
 bool AggregationNode::canSpill(const QueryConfig& queryConfig) const {
-  // TODO: add spilling for aggregations with sorting or with distinct later:
+  // TODO: Add spilling for aggregations over distinct inputs.
   // https://github.com/facebookincubator/velox/issues/7454
-  // https://github.com/facebookincubator/velox/issues/7455
   for (const auto& aggregate : aggregates_) {
-    if (aggregate.distinct || !aggregate.sortingKeys.empty()) {
+    if (aggregate.distinct) {
       return false;
     }
   }

--- a/velox/exec/SortedAggregations.h
+++ b/velox/exec/SortedAggregations.h
@@ -62,11 +62,19 @@ class SortedAggregations {
 
   void addSingleGroupInput(char* group, const RowVectorPtr& input);
 
+  void addSingleGroupSpillInput(
+      char* group,
+      const VectorPtr& input,
+      vector_size_t index);
+
   void noMoreInput();
 
   /// Sorts input row for the specified groups, computes aggregations and stores
   /// results in the specified 'result' vector.
   void extractValues(folly::Range<char**> groups, const RowVectorPtr& result);
+
+  /// Clears all data accumulated so far. Used to release memory after spilling.
+  void clear();
 
  private:
   void addNewRow(char* group, char* newRow);
@@ -89,6 +97,8 @@ class SortedAggregations {
       std::vector<char*>& groupRows,
       const AggregateInfo& aggregate,
       std::vector<VectorPtr>& inputVectors);
+
+  void extractForSpill(folly::Range<char**> groups, VectorPtr& result) const;
 
   struct Hash {
     static uint64_t hashSortOrder(const core::SortOrder& sortOrder) {


### PR DESCRIPTION
SortedAggregations accumulates raw inputs by group. It spill
these inputs as ARRAY(VARBINARY()) using RowContainer::extractSerializedRows
and loads it back using RowContainer::storeSerializedRow.

Fixes #7455