### PR TITLE
Back out "In RowVector::resize use size() instead of length_ to fix TSAN build failure"

### DIFF
--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -644,7 +644,7 @@ void RowVector::unsafeResize(vector_size_t newSize, bool setNotNull) {
 }
 
 void RowVector::resize(vector_size_t newSize, bool setNotNull) {
-  auto oldSize = size();
+  auto oldSize = length_;
   BaseVector::resize(newSize, setNotNull);
 
   // Resize all the children.


### PR DESCRIPTION
Summary:
Original commit changeset: 1496b4e0363b

Original Phabricator Diff: D51164275

Problem: https://fb.workplace.com/groups/koski.users/permalink/24472736322311586/

Differential Revision: D51232614


