### PR TITLE
Remove unused include from Arithmetic.h.

### DIFF
--- a/velox/functions/prestosql/Arithmetic.h
+++ b/velox/functions/prestosql/Arithmetic.h
@@ -28,7 +28,6 @@
 #include "folly/CPortability.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/functions/Macros.h"
-#include "velox/functions/Udf.h"
 #include "velox/functions/prestosql/ArithmeticImpl.h"
 
 namespace facebook::velox::functions {


### PR DESCRIPTION
Summary: Removing unused include. It's also caused build time regression.

Reviewed By: spershin

Differential Revision: D51236674


