### PR TITLE
Add from_unixtime Spark function

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -29,14 +29,6 @@ These functions support TIMESTAMP and DATE input types.
     If num_days is a negative value then these amount of days will be
     deducted from start_date.
 
-.. spark:function:: datediff(endDate, startDate) -> integer
-
-    Returns the number of days from startDate to endDate. Only DATE type is allowed
-    for input. ::
-
-        SELECT datediff('2009-07-31', '2009-07-30'); -- 1
-        SELECT datediff('2009-07-30', '2009-07-31'); -- -1
-
 .. spark:function:: date_sub(start_date, num_days) -> date
 
     Returns the date that is num_days before start_date. According to the inputs,
@@ -45,6 +37,14 @@ These functions support TIMESTAMP and DATE input types.
     and date_sub('2023-07-10', -2147483648) get -5877588-12-29.
 
     num_days can be positive or negative.
+
+.. spark:function:: datediff(endDate, startDate) -> integer
+
+    Returns the number of days from startDate to endDate. Only DATE type is allowed
+    for input. ::
+
+        SELECT datediff('2009-07-31', '2009-07-30'); -- 1
+        SELECT datediff('2009-07-30', '2009-07-31'); -- -1
 
 .. spark:function:: dayofmonth(date) -> integer
 
@@ -66,9 +66,22 @@ These functions support TIMESTAMP and DATE input types.
         SELECT dayofweek('2009-07-30'); -- 5
         SELECT dayofweek('2023-08-22 11:23:00.100'); -- 3
 
-.. function:: dow(x) -> integer
+.. spark::function:: dow(x) -> integer
 
     This is an alias for :func:`day_of_week`.
+
+.. spark::function::from_unixtime(unixTime, format) -> string
+
+    Adjusts ``unixTime``(elapsed seconds since UNIX epoch) to configured session timezone, then
+    converts it to a formatted time string according to ``format``.
+    `Valid patterns for date format
+    <https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html>`_. Throws exception for
+    invalid ``format``. This function will convert input to milliseconds, and integer overflow is
+    allowed in the conversion, which aligns with Spark. For example, from_unixtime(INT64_MAX, 'yyyy')
+    will use overflowed milliseconds to calculate result. ::
+
+        SELECT from_unixtime(100, 'yyyy-MM-dd HH:mm:ss'); -- '1970-01-01 00:01:40'
+        SELECT from_unixtime(3600, 'yyyy'); -- '1970'
 
 .. function:: get_timestamp(string, dateFormat) -> timestamp
 

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -77,11 +77,12 @@ These functions support TIMESTAMP and DATE input types.
     `Valid patterns for date format
     <https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html>`_. Throws exception for
     invalid ``format``. This function will convert input to milliseconds, and integer overflow is
-    allowed in the conversion, which aligns with Spark. For example, from_unixtime(INT64_MAX, 'yyyy')
-    will use overflowed milliseconds to calculate result. ::
+    allowed in the conversion, which aligns with Spark. See the below third example where INT64_MAX
+    is used, -1000 milliseconds are produced by INT64_MAX * 1000 due to integer overflow. ::
 
         SELECT from_unixtime(100, 'yyyy-MM-dd HH:mm:ss'); -- '1970-01-01 00:01:40'
         SELECT from_unixtime(3600, 'yyyy'); -- '1970'
+        SELECT from_unixtime(9223372036854775807, "yyyy-MM-dd HH:mm:ss");  -- '1969-12-31 23:59:59'
 
 .. function:: get_timestamp(string, dateFormat) -> timestamp
 

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -72,8 +72,9 @@ These functions support TIMESTAMP and DATE input types.
 
 .. spark::function::from_unixtime(unixTime, format) -> string
 
-    Adjusts ``unixTime``(elapsed seconds since UNIX epoch) to configured session timezone, then
-    converts it to a formatted time string according to ``format``.
+    Adjusts ``unixTime`` (elapsed seconds since UNIX epoch) to configured session timezone, then
+    converts it to a formatted time string according to ``format``. Only allows BIGINT type for
+    ``unixTime``.
     `Valid patterns for date format
     <https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html>`_. Throws exception for
     invalid ``format``. This function will convert input to milliseconds, and integer overflow is

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -73,7 +73,7 @@ These functions support TIMESTAMP and DATE input types.
 .. spark::function::from_unixtime(unixTime, format) -> string
 
     Adjusts ``unixTime`` (elapsed seconds since UNIX epoch) to configured session timezone, then
-    converts it to a formatted time string according to ``format``. Only allows BIGINT type for
+    converts it to a formatted time string according to ``format``. Only supports BIGINT type for
     ``unixTime``.
     `Valid patterns for date format
     <https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html>`_. Throws exception for

--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -1014,12 +1014,13 @@ int32_t DateTimeFormatter::format(
     const Timestamp& timestamp,
     const date::time_zone* timezone,
     const uint32_t maxResultSize,
-    char* result) const {
+    char* result,
+    bool allowOverflow) const {
   Timestamp t = timestamp;
   if (timezone != nullptr) {
     t.toTimezone(*timezone);
   }
-  const auto timePoint = t.toTimePoint();
+  const auto timePoint = t.toTimePoint(allowOverflow);
   const auto daysTimePoint = date::floor<date::days>(timePoint);
 
   const auto durationInTheDay = date::make_time(timePoint - daysTimePoint);

--- a/velox/functions/lib/DateTimeFormatter.h
+++ b/velox/functions/lib/DateTimeFormatter.h
@@ -185,11 +185,16 @@ class DateTimeFormatter {
 
   /// Result buffer is pre-allocated according to maxResultSize.
   /// Returns actual size.
+  ///
+  /// The timestamp will be firstly converted to millisecond then to
+  /// std::chrono::time_point. If allowOverflow is true, integer overflow is
+  /// allowed in converting to milliseconds.
   int32_t format(
       const Timestamp& timestamp,
       const date::time_zone* timezone,
       const uint32_t maxResultSize,
-      char* result) const;
+      char* result,
+      bool allowOverflow = false) const;
 
  private:
   std::unique_ptr<char[]> literalBuf_;

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -239,7 +239,7 @@ struct FromUnixtimeFunction {
   }
 
  private:
-  FOLLY_ALWAYS_INLINE void setFormatter(const arg_type<Varchar> format) {
+  FOLLY_ALWAYS_INLINE void setFormatter(const arg_type<Varchar>& format) {
     formatter_ = buildJodaDateTimeFormatter(
         std::string_view(format.data(), format.size()));
     maxResultSize_ = formatter_->maxResultSize(sessionTimeZone_);

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -207,6 +207,50 @@ struct UnixTimestampParseWithFormatFunction
   bool invalidFormat_{false};
 };
 
+// Parses unix time in seconds to a formatted string.
+template <typename T>
+struct FromUnixtimeFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const core::QueryConfig& config,
+      const arg_type<int64_t>* /*unixtime*/,
+      const arg_type<Varchar>* format) {
+    sessionTimeZone_ = getTimeZoneFromConfig(config);
+    if (format != nullptr) {
+      setFormatter(*format);
+      isConstantTimeFormat_ = true;
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Varchar>& result,
+      const arg_type<int64_t>& second,
+      const arg_type<Varchar>& format) {
+    if (!isConstantTimeFormat_) {
+      setFormatter(format);
+    }
+    const Timestamp timestamp{second, 0};
+    result.reserve(maxResultSize_);
+    int32_t resultSize;
+    resultSize = formatter_->format(
+        timestamp, sessionTimeZone_, maxResultSize_, result.data(), true);
+    result.resize(resultSize);
+  }
+
+ private:
+  FOLLY_ALWAYS_INLINE void setFormatter(const arg_type<Varchar> format) {
+    formatter_ = buildJodaDateTimeFormatter(
+        std::string_view(format.data(), format.size()));
+    maxResultSize_ = formatter_->maxResultSize(sessionTimeZone_);
+  }
+
+  const date::time_zone* sessionTimeZone_{nullptr};
+  std::shared_ptr<DateTimeFormatter> formatter_;
+  uint32_t maxResultSize_;
+  bool isConstantTimeFormat_{false};
+};
+
 /// Converts date string to Timestmap type.
 template <typename T>
 struct GetTimestampFunction {

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -269,6 +269,8 @@ void registerFunctions(const std::string& prefix) {
       int64_t,
       Varchar,
       Varchar>({prefix + "unix_timestamp", prefix + "to_unix_timestamp"});
+  registerFunction<FromUnixtimeFunction, Varchar, int64_t, Varchar>(
+      {prefix + "from_unixtime"});
   registerFunction<MakeDateFunction, Date, int32_t, int32_t, int32_t>(
       {prefix + "make_date"});
   registerFunction<DateDiffFunction, int32_t, Date, Date>(

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -600,5 +600,57 @@ TEST_F(DateTimeFunctionsTest, hour) {
   EXPECT_EQ(2, hour("1969-01-01 13:23:00.001"));
 }
 
+TEST_F(DateTimeFunctionsTest, fromUnixtime) {
+  const auto getUnixTime = [&](const StringView str) {
+    Timestamp t = util::fromTimestampString(str);
+    return t.getSeconds();
+  };
+
+  const auto fromUnixTime = [&](const std::optional<int64_t> unixTime,
+                                const std::optional<std::string> timeFormat) {
+    return evaluateOnce<std::string>(
+        "from_unixtime(c0, c1)", unixTime, timeFormat);
+  };
+
+  EXPECT_EQ(fromUnixTime(0, "yyyy-MM-dd HH:mm:ss"), "1970-01-01 00:00:00");
+  EXPECT_EQ(fromUnixTime(100, "yyyy-MM-dd"), "1970-01-01");
+  EXPECT_EQ(fromUnixTime(120, "yyyy-MM-dd HH:mm"), "1970-01-01 00:02");
+  EXPECT_EQ(fromUnixTime(100, "yyyy-MM-dd HH:mm:ss"), "1970-01-01 00:01:40");
+  EXPECT_EQ(fromUnixTime(-59, "yyyy-MM-dd HH:mm:ss"), "1969-12-31 23:59:01");
+  EXPECT_EQ(fromUnixTime(3600, "yyyy"), "1970");
+  EXPECT_EQ(
+      fromUnixTime(getUnixTime("2020-06-30 11:29:59"), "yyyy-MM-dd HH:mm:ss"),
+      "2020-06-30 11:29:59");
+  EXPECT_EQ(
+      fromUnixTime(getUnixTime("2020-06-30 11:29:59"), "yyyy-MM-dd"),
+      "2020-06-30");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2020-06-30 11:29:59"), "MM-dd"), "06-30");
+  EXPECT_EQ(
+      fromUnixTime(getUnixTime("2020-06-30 11:29:59"), "HH:mm:ss"), "11:29:59");
+  EXPECT_EQ(
+      fromUnixTime(getUnixTime("2020-06-30 23:59:59"), "yyyy-MM-dd HH:mm:ss"),
+      "2020-06-30 23:59:59");
+
+  // 8 hours ahead UTC.
+  setQueryTimeZone("Asia/Shanghai");
+  EXPECT_EQ(fromUnixTime(0, "yyyy-MM-dd HH:mm:ss"), "1970-01-01 08:00:00");
+  EXPECT_EQ(fromUnixTime(120, "yyyy-MM-dd HH:mm"), "1970-01-01 08:02");
+  EXPECT_EQ(fromUnixTime(-59, "yyyy-MM-dd HH:mm:ss"), "1970-01-01 07:59:01");
+  EXPECT_EQ(
+      fromUnixTime(getUnixTime("2014-07-21 16:00:00"), "yyyy-MM-dd"),
+      "2014-07-22");
+  EXPECT_EQ(
+      fromUnixTime(getUnixTime("2020-06-30 23:59:59"), "yyyy-MM-dd HH:mm:ss"),
+      "2020-07-01 07:59:59");
+
+  // Invalid format.
+  VELOX_ASSERT_THROW(
+      fromUnixTime(0, "yyyy-AA"), "Specifier A is not supported.");
+  VELOX_ASSERT_THROW(
+      fromUnixTime(0, "FF/MM/dd"), "Specifier F is not supported");
+  VELOX_ASSERT_THROW(
+      fromUnixTime(0, "yyyy-MM-dd HH:II"), "Specifier I is not supported");
+}
+
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -631,6 +631,11 @@ TEST_F(DateTimeFunctionsTest, fromUnixtime) {
       fromUnixTime(getUnixTime("2020-06-30 23:59:59"), "yyyy-MM-dd HH:mm:ss"),
       "2020-06-30 23:59:59");
 
+  // Integer overflow in the internal conversion from seconds to milliseconds.
+  EXPECT_EQ(
+      fromUnixTime(std::numeric_limits<int64_t>::max(), "yyyy-MM-dd HH:mm:ss"),
+      "1969-12-31 23:59:59");
+
   // 8 hours ahead UTC.
   setQueryTimeZone("Asia/Shanghai");
   EXPECT_EQ(fromUnixTime(0, "yyyy-MM-dd HH:mm:ss"), "1970-01-01 08:00:00");

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -631,10 +631,14 @@ TEST_F(DateTimeFunctionsTest, fromUnixtime) {
       fromUnixTime(getUnixTime("2020-06-30 23:59:59"), "yyyy-MM-dd HH:mm:ss"),
       "2020-06-30 23:59:59");
 
+// In debug mode, Timestamp constructor will throw exception if range check
+// fails.
+#ifdef NDEBUG
   // Integer overflow in the internal conversion from seconds to milliseconds.
   EXPECT_EQ(
       fromUnixTime(std::numeric_limits<int64_t>::max(), "yyyy-MM-dd HH:mm:ss"),
       "1969-12-31 23:59:59");
+#endif
 
   // 8 hours ahead UTC.
   setQueryTimeZone("Asia/Shanghai");

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -601,13 +601,13 @@ TEST_F(DateTimeFunctionsTest, hour) {
 }
 
 TEST_F(DateTimeFunctionsTest, fromUnixtime) {
-  const auto getUnixTime = [&](const StringView str) {
+  const auto getUnixTime = [&](const StringView& str) {
     Timestamp t = util::fromTimestampString(str);
     return t.getSeconds();
   };
 
-  const auto fromUnixTime = [&](const std::optional<int64_t> unixTime,
-                                const std::optional<std::string> timeFormat) {
+  const auto fromUnixTime = [&](const std::optional<int64_t>& unixTime,
+                                const std::optional<std::string>& timeFormat) {
     return evaluateOnce<std::string>(
         "from_unixtime(c0, c1)", unixTime, timeFormat);
   };

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -108,9 +108,10 @@ void validateTimePoint(const std::chrono::time_point<
 } // namespace
 
 std::chrono::time_point<std::chrono::system_clock, std::chrono::milliseconds>
-Timestamp::toTimePoint() const {
+Timestamp::toTimePoint(bool allowOverflow) const {
   using namespace std::chrono;
-  auto tp = time_point<system_clock, milliseconds>(milliseconds(toMillis()));
+  auto tp = time_point<system_clock, milliseconds>(
+      milliseconds(allowOverflow ? toMillisAllowOverflow() : toMillis()));
   validateTimePoint(tp);
   return tp;
 }

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -84,63 +84,6 @@ void Timestamp::toGMT(int16_t tzID) {
   }
 }
 
-inline int64_t Timestamp::toNanos() const {
-  // int64 can store around 292 years in nanos ~ till 2262-04-12.
-  // When an integer overflow occurs in the calculation,
-  // an exception will be thrown.
-  try {
-    return checkedPlus(
-        checkedMultiply(seconds_, (int64_t)1'000'000'000), (int64_t)nanos_);
-  } catch (const std::exception& e) {
-    VELOX_USER_FAIL(
-        "Could not convert Timestamp({}, {}) to nanoseconds, {}",
-        seconds_,
-        nanos_,
-        e.what());
-  }
-}
-
-inline int64_t Timestamp::toMillis() const {
-  // We use int128_t to make sure the computation does not overflows since
-  // there are cases such that seconds*1000 does not fit in int64_t,
-  // but seconds*1000 + nanos does, an example is TimeStamp::minMillis().
-
-  // If the final result does not fit in int64_tw we throw.
-  __int128_t result =
-      (__int128_t)seconds_ * 1'000 + (int64_t)(nanos_ / 1'000'000);
-  if (result < std::numeric_limits<int64_t>::min() ||
-      result > std::numeric_limits<int64_t>::max()) {
-    VELOX_USER_FAIL(
-        "Could not convert Timestamp({}, {}) to milliseconds",
-        seconds_,
-        nanos_);
-  }
-  return result;
-}
-
-inline int64_t Timestamp::toMillisAllowOverflow() const {
-  // Similar to the above toMillis() except that overflowed integer is allowed
-  // as result.
-  auto result = seconds_ * 1'000 + (int64_t)(nanos_ / 1'000'000);
-  return result;
-}
-
-inline int64_t Timestamp::toMicros() const {
-  // When an integer overflow occurs in the calculation,
-  // an exception will be thrown.
-  try {
-    return checkedPlus(
-        checkedMultiply(seconds_, (int64_t)1'000'000),
-        (int64_t)(nanos_ / 1'000));
-  } catch (const std::exception& e) {
-    VELOX_USER_FAIL(
-        "Could not convert Timestamp({}, {}) to microseconds, {}",
-        seconds_,
-        nanos_,
-        e.what());
-  }
-}
-
 namespace {
 void validateTimePoint(const std::chrono::time_point<
                        std::chrono::system_clock,

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -84,7 +84,7 @@ void Timestamp::toGMT(int16_t tzID) {
   }
 }
 
-int64_t Timestamp::toNanos() const {
+inline int64_t Timestamp::toNanos() const {
   // int64 can store around 292 years in nanos ~ till 2262-04-12.
   // When an integer overflow occurs in the calculation,
   // an exception will be thrown.
@@ -100,7 +100,7 @@ int64_t Timestamp::toNanos() const {
   }
 }
 
-int64_t Timestamp::toMillis() const {
+inline int64_t Timestamp::toMillis() const {
   // We use int128_t to make sure the computation does not overflows since
   // there are cases such that seconds*1000 does not fit in int64_t,
   // but seconds*1000 + nanos does, an example is TimeStamp::minMillis().
@@ -118,14 +118,14 @@ int64_t Timestamp::toMillis() const {
   return result;
 }
 
-int64_t Timestamp::toMillisAllowOverflow() const {
+inline int64_t Timestamp::toMillisAllowOverflow() const {
   // Similar to the above toMillis() except that overflowed integer is allowed
   // as result.
   auto result = seconds_ * 1'000 + (int64_t)(nanos_ / 1'000'000);
   return result;
 }
 
-int64_t Timestamp::toMicros() const {
+inline int64_t Timestamp::toMicros() const {
   // When an integer overflow occurs in the calculation,
   // an exception will be thrown.
   try {

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -84,6 +84,63 @@ void Timestamp::toGMT(int16_t tzID) {
   }
 }
 
+int64_t Timestamp::toNanos() const {
+  // int64 can store around 292 years in nanos ~ till 2262-04-12.
+  // When an integer overflow occurs in the calculation,
+  // an exception will be thrown.
+  try {
+    return checkedPlus(
+        checkedMultiply(seconds_, (int64_t)1'000'000'000), (int64_t)nanos_);
+  } catch (const std::exception& e) {
+    VELOX_USER_FAIL(
+        "Could not convert Timestamp({}, {}) to nanoseconds, {}",
+        seconds_,
+        nanos_,
+        e.what());
+  }
+}
+
+int64_t Timestamp::toMillis() const {
+  // We use int128_t to make sure the computation does not overflows since
+  // there are cases such that seconds*1000 does not fit in int64_t,
+  // but seconds*1000 + nanos does, an example is TimeStamp::minMillis().
+
+  // If the final result does not fit in int64_tw we throw.
+  __int128_t result =
+      (__int128_t)seconds_ * 1'000 + (int64_t)(nanos_ / 1'000'000);
+  if (result < std::numeric_limits<int64_t>::min() ||
+      result > std::numeric_limits<int64_t>::max()) {
+    VELOX_USER_FAIL(
+        "Could not convert Timestamp({}, {}) to milliseconds",
+        seconds_,
+        nanos_);
+  }
+  return result;
+}
+
+int64_t Timestamp::toMillisAllowOverflow() const {
+  // Similar to the above toMillis() except that overflowed integer is allowed
+  // as result.
+  auto result = seconds_ * 1'000 + (int64_t)(nanos_ / 1'000'000);
+  return result;
+}
+
+int64_t Timestamp::toMicros() const {
+  // When an integer overflow occurs in the calculation,
+  // an exception will be thrown.
+  try {
+    return checkedPlus(
+        checkedMultiply(seconds_, (int64_t)1'000'000),
+        (int64_t)(nanos_ / 1'000));
+  } catch (const std::exception& e) {
+    VELOX_USER_FAIL(
+        "Could not convert Timestamp({}, {}) to microseconds, {}",
+        seconds_,
+        nanos_,
+        e.what());
+  }
+}
+
 namespace {
 void validateTimePoint(const std::chrono::time_point<
                        std::chrono::system_clock,

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -151,6 +151,13 @@ struct Timestamp {
     return result;
   }
 
+  int64_t toMillisAllowOverflow() const {
+    // Similar to the above toMillis() except that overflowed integer is allowed
+    // as result.
+    auto result = seconds_ * 1'000 + (int64_t)(nanos_ / 1'000'000);
+    return result;
+  }
+
   int64_t toMicros() const {
     // When an integer overflow occurs in the calculation,
     // an exception will be thrown.
@@ -169,8 +176,10 @@ struct Timestamp {
 
   /// Due to the limit of std::chrono, throws if timestamp is outside of
   /// [-32767-01-01, 32767-12-31] range.
+  /// If allowOverflow is true, integer overflow is allowed in converting
+  /// timestmap to milliseconds.
   std::chrono::time_point<std::chrono::system_clock, std::chrono::milliseconds>
-  toTimePoint() const;
+  toTimePoint(bool allowOverflow = false) const;
 
   static Timestamp fromMillis(int64_t millis) {
     if (millis >= 0 || millis % 1'000 == 0) {

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -117,62 +117,13 @@ struct Timestamp {
     return nanos_;
   }
 
-  int64_t toNanos() const {
-    // int64 can store around 292 years in nanos ~ till 2262-04-12.
-    // When an integer overflow occurs in the calculation,
-    // an exception will be thrown.
-    try {
-      return checkedPlus(
-          checkedMultiply(seconds_, (int64_t)1'000'000'000), (int64_t)nanos_);
-    } catch (const std::exception& e) {
-      VELOX_USER_FAIL(
-          "Could not convert Timestamp({}, {}) to nanoseconds, {}",
-          seconds_,
-          nanos_,
-          e.what());
-    }
-  }
+  int64_t toNanos() const;
 
-  int64_t toMillis() const {
-    // We use int128_t to make sure the computation does not overflows since
-    // there are cases such that seconds*1000 does not fit in int64_t,
-    // but seconds*1000 + nanos does, an example is TimeStamp::minMillis().
+  int64_t toMillis() const;
 
-    // If the final result does not fit in int64_tw we throw.
-    __int128_t result =
-        (__int128_t)seconds_ * 1'000 + (int64_t)(nanos_ / 1'000'000);
-    if (result < std::numeric_limits<int64_t>::min() ||
-        result > std::numeric_limits<int64_t>::max()) {
-      VELOX_USER_FAIL(
-          "Could not convert Timestamp({}, {}) to milliseconds",
-          seconds_,
-          nanos_);
-    }
-    return result;
-  }
+  int64_t toMillisAllowOverflow() const;
 
-  int64_t toMillisAllowOverflow() const {
-    // Similar to the above toMillis() except that overflowed integer is allowed
-    // as result.
-    auto result = seconds_ * 1'000 + (int64_t)(nanos_ / 1'000'000);
-    return result;
-  }
-
-  int64_t toMicros() const {
-    // When an integer overflow occurs in the calculation,
-    // an exception will be thrown.
-    try {
-      return checkedPlus(
-          checkedMultiply(seconds_, (int64_t)1'000'000),
-          (int64_t)(nanos_ / 1'000));
-    } catch (const std::exception& e) {
-      VELOX_USER_FAIL(
-          "Could not convert Timestamp({}, {}) to microseconds, {}",
-          seconds_,
-          nanos_,
-          e.what());
-    }
-  }
+  int64_t toMicros() const;
 
   /// Due to the limit of std::chrono, throws if timestamp is outside of
   /// [-32767-01-01, 32767-12-31] range.

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -117,13 +117,66 @@ struct Timestamp {
     return nanos_;
   }
 
-  int64_t toNanos() const;
+  // Keep it in header for getting inlined.
+  int64_t toNanos() const {
+    // int64 can store around 292 years in nanos ~ till 2262-04-12.
+    // When an integer overflow occurs in the calculation,
+    // an exception will be thrown.
+    try {
+      return checkedPlus(
+          checkedMultiply(seconds_, (int64_t)1'000'000'000), (int64_t)nanos_);
+    } catch (const std::exception& e) {
+      VELOX_USER_FAIL(
+          "Could not convert Timestamp({}, {}) to nanoseconds, {}",
+          seconds_,
+          nanos_,
+          e.what());
+    }
+  }
 
-  int64_t toMillis() const;
+  // Keep it in header for getting inlined.
+  int64_t toMillis() const {
+    // We use int128_t to make sure the computation does not overflows since
+    // there are cases such that seconds*1000 does not fit in int64_t,
+    // but seconds*1000 + nanos does, an example is TimeStamp::minMillis().
 
-  int64_t toMillisAllowOverflow() const;
+    // If the final result does not fit in int64_tw we throw.
+    __int128_t result =
+        (__int128_t)seconds_ * 1'000 + (int64_t)(nanos_ / 1'000'000);
+    if (result < std::numeric_limits<int64_t>::min() ||
+        result > std::numeric_limits<int64_t>::max()) {
+      VELOX_USER_FAIL(
+          "Could not convert Timestamp({}, {}) to milliseconds",
+          seconds_,
+          nanos_);
+    }
+    return result;
+  }
 
-  int64_t toMicros() const;
+  // Keep it in header for getting inlined.
+  int64_t toMillisAllowOverflow() const {
+    // Similar to the above toMillis() except that overflowed integer is allowed
+    // as result.
+    auto result = seconds_ * 1'000 + (int64_t)(nanos_ / 1'000'000);
+    return result;
+  }
+
+  // Keep it in header for getting inlined.
+  int64_t toMicros() const {
+    // When an integer overflow occurs in the calculation,
+    // an exception will be thrown.
+    try {
+      return checkedPlus(
+          checkedMultiply(seconds_, (int64_t)1'000'000),
+          (int64_t)(nanos_ / 1'000));
+    } catch (const std::exception& e) {
+      VELOX_USER_FAIL(
+          "Could not convert Timestamp({}, {}) to microseconds, {}",
+          seconds_,
+          nanos_,
+          e.what());
+    }
+  }
 
   /// Due to the limit of std::chrono, throws if timestamp is outside of
   /// [-32767-01-01, 32767-12-31] range.

--- a/velox/type/tests/TimestampTest.cpp
+++ b/velox/type/tests/TimestampTest.cpp
@@ -309,6 +309,9 @@ TEST(TimestampTest, outOfRange) {
       t.toTimezone(*timezone), "Timestamp is outside of supported range");
 }
 
+// In debug mode, Timestamp constructor will throw exception if range check
+// fails.
+#ifdef NDEBUG
 TEST(TimestampTest, overflow) {
   Timestamp t(std::numeric_limits<int64_t>::max(), 0);
   VELOX_ASSERT_THROW(
@@ -319,6 +322,7 @@ TEST(TimestampTest, overflow) {
           0));
   ASSERT_NO_THROW(t.toTimePoint(true));
 }
+#endif
 
 void checkTm(const std::tm& actual, const std::tm& expected) {
   ASSERT_EQ(expected.tm_year, actual.tm_year);

--- a/velox/type/tests/TimestampTest.cpp
+++ b/velox/type/tests/TimestampTest.cpp
@@ -309,6 +309,17 @@ TEST(TimestampTest, outOfRange) {
       t.toTimezone(*timezone), "Timestamp is outside of supported range");
 }
 
+TEST(TimestampTest, overflow) {
+  Timestamp t(std::numeric_limits<int64_t>::max(), 0);
+  VELOX_ASSERT_THROW(
+      t.toTimePoint(false),
+      fmt::format(
+          "Could not convert Timestamp({}, {}) to milliseconds",
+          std::numeric_limits<int64_t>::max(),
+          0));
+  ASSERT_NO_THROW(t.toTimePoint(true));
+}
+
 void checkTm(const std::tm& actual, const std::tm& expected) {
   ASSERT_EQ(expected.tm_year, actual.tm_year);
   ASSERT_EQ(expected.tm_yday, actual.tm_yday);


### PR DESCRIPTION
Add Spark function from_unixtime(unixTime, format) to convert unixTime (elapsed seconds since UNIX epoch) to a date time string with specified format.

Spark implementation: https://github.com/apache/spark/blob/9a990b5a40de3c3a17801dd4dbd4f48e3f399815/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala#L1380.