### PR TITLE
Extract ByteInputStream from ByteStream

### DIFF
--- a/velox/common/memory/ByteStream.cpp
+++ b/velox/common/memory/ByteStream.cpp
@@ -22,6 +22,150 @@ std::string ByteRange::toString() const {
   return fmt::format("[{} starting at {}]", succinctBytes(size), position);
 }
 
+std::string ByteInputStream::toString() const {
+  std::stringstream oss;
+  oss << ranges_.size() << " ranges (position/size) [";
+  for (const auto& range : ranges_) {
+    oss << "(" << range.position << "/" << range.size
+        << (&range == current_ ? " current" : "") << ")";
+    if (&range != &ranges_.back()) {
+      oss << ",";
+    }
+  }
+  oss << "]";
+  return oss.str();
+}
+
+bool ByteInputStream::atEnd() const {
+  if (!current_) {
+    return false;
+  }
+  if (current_->position < current_->size) {
+    return false;
+  }
+
+  VELOX_CHECK(current_ >= ranges_.data() && current_ <= &ranges_.back());
+  return current_ == &ranges_.back();
+}
+
+size_t ByteInputStream::size() const {
+  size_t total = 0;
+  for (const auto& range : ranges_) {
+    total += range.size;
+  }
+  return total;
+}
+
+size_t ByteInputStream::remainingSize() const {
+  if (ranges_.empty()) {
+    return 0;
+  }
+  const auto* lastRange = &ranges_[ranges_.size() - 1];
+  auto cur = current_;
+  size_t total = cur->size - cur->position;
+  while (++cur <= lastRange) {
+    total += cur->size;
+  }
+  return total;
+}
+
+std::streampos ByteInputStream::tellp() const {
+  if (ranges_.empty()) {
+    return 0;
+  }
+  assert(current_);
+  int64_t size = 0;
+  for (auto& range : ranges_) {
+    if (&range == current_) {
+      return current_->position + size;
+    }
+    size += range.size;
+  }
+  VELOX_FAIL("ByteStream 'current_' is not in 'ranges_'.");
+}
+
+void ByteInputStream::seekp(std::streampos position) {
+  if (ranges_.empty() && position == 0) {
+    return;
+  }
+  int64_t toSkip = position;
+  for (auto& range : ranges_) {
+    if (toSkip <= range.size) {
+      current_ = &range;
+      current_->position = toSkip;
+      return;
+    }
+    toSkip -= range.size;
+  }
+  VELOX_FAIL("Seeking past end of ByteInputStream: {}", position);
+}
+
+void ByteInputStream::next(bool throwIfPastEnd) {
+  VELOX_CHECK(current_ >= &ranges_[0]);
+  size_t position = current_ - &ranges_[0];
+  VELOX_CHECK_LT(position, ranges_.size());
+  if (position == ranges_.size() - 1) {
+    if (throwIfPastEnd) {
+      VELOX_FAIL("Reading past end of ByteStream");
+    }
+    return;
+  }
+  ++current_;
+  current_->position = 0;
+}
+
+uint8_t ByteInputStream::readByte() {
+  if (current_->position < current_->size) {
+    return current_->buffer[current_->position++];
+  }
+  next();
+  return readByte();
+}
+
+void ByteInputStream::readBytes(uint8_t* bytes, int32_t size) {
+  int32_t offset = 0;
+  for (;;) {
+    int32_t available = current_->size - current_->position;
+    int32_t numUsed = std::min(available, size);
+    memcpy(bytes + offset, current_->buffer + current_->position, numUsed);
+    offset += numUsed;
+    size -= numUsed;
+    current_->position += numUsed;
+    if (!size) {
+      return;
+    }
+    next();
+  }
+}
+
+std::string_view ByteInputStream::nextView(int32_t size) {
+  if (current_->position == current_->size) {
+    if (current_ == &ranges_.back()) {
+      return std::string_view(nullptr, 0);
+    }
+    next();
+  }
+  VELOX_CHECK(current_->size);
+  auto position = current_->position;
+  auto viewSize = std::min(current_->size - current_->position, size);
+  current_->position += viewSize;
+  return std::string_view(
+      reinterpret_cast<char*>(current_->buffer) + position, viewSize);
+}
+
+void ByteInputStream::skip(int32_t size) {
+  for (;;) {
+    int32_t available = current_->size - current_->position;
+    int32_t numUsed = std::min(available, size);
+    size -= numUsed;
+    current_->position += numUsed;
+    if (!size) {
+      return;
+    }
+    next();
+  }
+}
+
 size_t ByteStream::size() const {
   if (ranges_.empty()) {
     return 0;
@@ -62,72 +206,6 @@ bool ByteStream::atEnd() const {
 
   VELOX_CHECK(current_ >= ranges_.data() && current_ <= &ranges_.back());
   return current_ == &ranges_.back();
-}
-
-void ByteStream::next(bool throwIfPastEnd) {
-  VELOX_CHECK(current_ >= &ranges_[0]);
-  size_t position = current_ - &ranges_[0];
-  VELOX_CHECK_LT(position, ranges_.size());
-  if (position == ranges_.size() - 1) {
-    if (throwIfPastEnd) {
-      VELOX_FAIL("Reading past end of ByteStream");
-    }
-    return;
-  }
-  ++current_;
-  current_->position = 0;
-}
-
-uint8_t ByteStream::readByte() {
-  if (current_->position < current_->size) {
-    return current_->buffer[current_->position++];
-  }
-  next();
-  return readByte();
-}
-
-void ByteStream::readBytes(uint8_t* bytes, int32_t size) {
-  int32_t offset = 0;
-  for (;;) {
-    int32_t available = current_->size - current_->position;
-    int32_t numUsed = std::min(available, size);
-    memcpy(bytes + offset, current_->buffer + current_->position, numUsed);
-    offset += numUsed;
-    size -= numUsed;
-    current_->position += numUsed;
-    if (!size) {
-      return;
-    }
-    next();
-  }
-}
-
-std::string_view ByteStream::nextView(int32_t size) {
-  if (current_->position == current_->size) {
-    if (current_ == &ranges_.back()) {
-      return std::string_view(nullptr, 0);
-    }
-    next();
-  }
-  VELOX_CHECK(current_->size);
-  auto position = current_->position;
-  auto viewSize = std::min(current_->size - current_->position, size);
-  current_->position += viewSize;
-  return std::string_view(
-      reinterpret_cast<char*>(current_->buffer) + position, viewSize);
-}
-
-void ByteStream::skip(int32_t size) {
-  for (;;) {
-    int32_t available = current_->size - current_->position;
-    int32_t numUsed = std::min(available, size);
-    size -= numUsed;
-    current_->position += numUsed;
-    if (!size) {
-      return;
-    }
-    next();
-  }
 }
 
 void ByteStream::appendBool(bool value, int32_t count) {

--- a/velox/common/memory/ByteStream.h
+++ b/velox/common/memory/ByteStream.h
@@ -19,6 +19,7 @@
 #include "velox/type/Type.h"
 
 #include <folly/io/IOBuf.h>
+#include <memory>
 
 namespace facebook::velox {
 
@@ -88,6 +89,123 @@ class OStreamOutputStream : public OutputStream {
   std::ostream* out_;
 };
 
+/// Read-only stream over one or more byte buffers.
+class ByteInputStream {
+ protected:
+  /// TODO Remove after refactoring SpillInput.
+  ByteInputStream() {}
+
+ public:
+  explicit ByteInputStream(std::vector<ByteRange> ranges)
+      : ranges_{std::move(ranges)} {
+    VELOX_CHECK(!ranges_.empty());
+    current_ = &ranges_[0];
+  }
+
+  /// Disable copy constructor.
+  ByteInputStream(const ByteInputStream&) = delete;
+
+  /// Disable copy assignment operator.
+  ByteInputStream& operator=(const ByteInputStream& other) = delete;
+
+  /// Enable move constructor.
+  ByteInputStream(ByteInputStream&& other) noexcept
+      : ranges_{std::move(other.ranges_)}, current_{other.current_} {}
+
+  /// Enable move assignment operator.
+  ByteInputStream& operator=(ByteInputStream&& other) noexcept {
+    if (this != &other) {
+      ranges_ = std::move(other.ranges_);
+      current_ = other.current_;
+      other.current_ = nullptr;
+    }
+    return *this;
+  }
+
+  /// TODO Remove after refactoring SpillInput.
+  virtual ~ByteInputStream() = default;
+
+  /// Returns total number of bytes available in the stream.
+  size_t size() const;
+
+  /// Returns true if all input has been read.
+  ///
+  /// TODO: Remove 'virtual' after refactoring SpillInput.
+  virtual bool atEnd() const;
+
+  /// Returns current position (number of bytes from the start) in the stream.
+  std::streampos tellp() const;
+
+  /// Moves current position to specified one.
+  void seekp(std::streampos pos);
+
+  /// Returns the remaining size left from current reading position.
+  size_t remainingSize() const;
+
+  std::string toString() const;
+
+  uint8_t readByte();
+
+  void readBytes(uint8_t* bytes, int32_t size);
+
+  template <typename T>
+  T read() {
+    if (current_->position + sizeof(T) <= current_->size) {
+      current_->position += sizeof(T);
+      return *reinterpret_cast<const T*>(
+          current_->buffer + current_->position - sizeof(T));
+    }
+    // The number straddles two buffers. We read byte by byte and make
+    // a little-endian uint64_t. The bytes can be cast to any integer
+    // or floating point type since the wire format has the machine byte order.
+    static_assert(sizeof(T) <= sizeof(uint64_t));
+    uint64_t value = 0;
+    for (int32_t i = 0; i < sizeof(T); ++i) {
+      value |= static_cast<uint64_t>(readByte()) << (i * 8);
+    }
+    return *reinterpret_cast<const T*>(&value);
+  }
+
+  template <typename Char>
+  void readBytes(Char* data, int32_t size) {
+    readBytes(reinterpret_cast<uint8_t*>(data), size);
+  }
+
+  /// Returns a view over the read buffer for up to 'size' next
+  /// bytes. The size of the value may be less if the current byte
+  /// range ends within 'size' bytes from the current position.  The
+  /// size will be 0 if at end.
+  std::string_view nextView(int32_t size);
+
+  void skip(int32_t size);
+
+ protected:
+  /// Sets 'current_' to point to the next range of input.  // The
+  /// input is consecutive ByteRanges in 'ranges_' for the base class
+  /// but any view over external buffers can be made by specialization.
+  ///
+  /// TODO: Remove 'virtual' after refactoring SpillInput.
+  virtual void next(bool throwIfPastEnd = true);
+
+  // TODO: Remove  after refactoring SpillInput.
+  const std::vector<ByteRange>& ranges() const {
+    return ranges_;
+  }
+
+  // TODO: Remove  after refactoring SpillInput.
+  void setRange(ByteRange range) {
+    ranges_.resize(1);
+    ranges_[0] = range;
+    current_ = ranges_.data();
+  }
+
+ private:
+  std::vector<ByteRange> ranges_;
+
+  // Pointer to the current element of 'ranges_'.
+  ByteRange* current_{nullptr};
+};
+
 /// Stream over a chain of ByteRanges. Provides read, write and
 /// comparison for equality between stream contents and memory. Used
 /// for streams in repartitioning or for complex variable length data
@@ -96,9 +214,32 @@ class OStreamOutputStream : public OutputStream {
 /// seeking back to start to write a length header.
 class ByteStream {
  public:
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
   /// For input.
   ByteStream() : isBits_(false), isReverseBitOrder_(false) {}
-  virtual ~ByteStream() = default;
+
+  void resetInput(std::vector<ByteRange>&& ranges) {
+    ranges_ = std::move(ranges);
+    current_ = &ranges_[0];
+  }
+
+  template <typename Char>
+  void readBytes(Char* data, int32_t size) {
+    ByteInputStream inputStream(ranges_);
+    inputStream.seekp(tellp());
+    inputStream.readBytes(data, size);
+    seekp(inputStream.tellp());
+  }
+
+  template <typename T>
+  T read() {
+    ByteInputStream inputStream(ranges_);
+    inputStream.seekp(tellp());
+    auto value = inputStream.read<T>();
+    seekp(inputStream.tellp());
+    return value;
+  }
+#endif
 
   /// For output.
   ByteStream(
@@ -110,12 +251,6 @@ class ByteStream {
   ByteStream(const ByteStream& other) = delete;
 
   void operator=(const ByteStream& other) = delete;
-
-  void resetInput(std::vector<ByteRange>&& ranges) {
-    ranges_ = std::move(ranges);
-    current_ = &ranges_[0];
-    lastRangeEnd_ = ranges_.back().size;
-  }
 
   void setRange(ByteRange range) {
     ranges_.resize(1);
@@ -156,46 +291,6 @@ class ByteStream {
     updateEnd();
     return lastRangeEnd_;
   }
-
-  /// Sets 'current_' to point to the next range of input.  // The
-  /// input is consecutive ByteRanges in 'ranges_' for the base class
-  /// but any view over external buffers can be made by specialization.
-  virtual void next(bool throwIfPastEnd = true);
-
-  uint8_t readByte();
-
-  void readBytes(uint8_t* bytes, int32_t size);
-
-  template <typename T>
-  T read() {
-    if (current_->position + sizeof(T) <= current_->size) {
-      current_->position += sizeof(T);
-      return *reinterpret_cast<const T*>(
-          current_->buffer + current_->position - sizeof(T));
-    }
-    // The number straddles two buffers. We read byte by byte and make
-    // a little-endian uint64_t. The bytes can be cast to any integer
-    // or floating point type since the wire format has the machine byte order.
-    static_assert(sizeof(T) <= sizeof(uint64_t));
-    uint64_t value = 0;
-    for (int32_t i = 0; i < sizeof(T); ++i) {
-      value |= static_cast<uint64_t>(readByte()) << (i * 8);
-    }
-    return *reinterpret_cast<const T*>(&value);
-  }
-
-  template <typename Char>
-  void readBytes(Char* data, int32_t size) {
-    readBytes(reinterpret_cast<uint8_t*>(data), size);
-  }
-
-  /// Returns a view over the read buffer for up to 'size' next
-  /// bytes. The size of the value may be less if the current byte
-  /// range ends within 'size' bytes from the current position.  The
-  /// size will be 0 if at end.
-  std::string_view nextView(int32_t size);
-
-  void skip(int32_t size);
 
   template <typename T>
   void append(folly::Range<const T*> values) {
@@ -276,14 +371,14 @@ class ByteStream {
 };
 
 template <>
-inline Timestamp ByteStream::read<Timestamp>() {
+inline Timestamp ByteInputStream::read<Timestamp>() {
   Timestamp value;
   readBytes(reinterpret_cast<uint8_t*>(&value), sizeof(value));
   return value;
 }
 
 template <>
-inline int128_t ByteStream::read<int128_t>() {
+inline int128_t ByteInputStream::read<int128_t>() {
   int128_t value;
   readBytes(reinterpret_cast<uint8_t*>(&value), sizeof(value));
   return value;

--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -123,7 +123,7 @@ void HashStringAllocator::freeToPool(void* ptr, size_t size) {
 }
 
 // static
-void HashStringAllocator::prepareRead(const Header* begin, ByteStream& stream) {
+ByteInputStream HashStringAllocator::prepareRead(const Header* begin) {
   std::vector<ByteRange> ranges;
   auto header = const_cast<Header*>(begin);
   for (;;) {
@@ -134,7 +134,7 @@ void HashStringAllocator::prepareRead(const Header* begin, ByteStream& stream) {
     }
     header = header->nextContinued();
   }
-  stream.resetInput(std::move(ranges));
+  return ByteInputStream(std::move(ranges));
 }
 
 HashStringAllocator::Position HashStringAllocator::newWrite(
@@ -289,8 +289,7 @@ StringView HashStringAllocator::contiguousString(
     return view;
   }
 
-  ByteStream stream;
-  prepareRead(headerOf(view.data()), stream);
+  auto stream = prepareRead(headerOf(view.data()));
   storage.resize(view.size());
   stream.readBytes(storage.data(), view.size());
   return StringView(storage);

--- a/velox/common/memory/HashStringAllocator.h
+++ b/velox/common/memory/HashStringAllocator.h
@@ -237,11 +237,9 @@ class HashStringAllocator : public StreamArena {
         1;
   }
 
-  // Sets 'stream' to range over the data in the range of 'header' and
+  // Returns ByteInputStream over the data in the range of 'header' and
   // possible continuation ranges.
-  static void prepareRead(
-      const Header* FOLLY_NONNULL header,
-      ByteStream& stream);
+  static ByteInputStream prepareRead(const Header* header);
 
   // Returns the number of payload bytes between 'header->begin()' and
   // 'position'.

--- a/velox/common/memory/tests/ByteStreamTest.cpp
+++ b/velox/common/memory/tests/ByteStreamTest.cpp
@@ -100,7 +100,7 @@ TEST_F(ByteStreamTest, outputStream) {
   EXPECT_EQ(0, mmapAllocator_->numAllocated());
 }
 
-TEST_F(ByteStreamTest, resetInput) {
+TEST_F(ByteStreamTest, inputStream) {
   uint8_t* const kFakeBuffer = reinterpret_cast<uint8_t*>(this);
   std::vector<ByteRange> byteRanges;
   size_t totalBytes{0};
@@ -110,12 +110,8 @@ TEST_F(ByteStreamTest, resetInput) {
     totalBytes += 4096 + i;
   }
   lastRangeEnd = byteRanges.back().size;
-  ByteStream byteStream;
-  ASSERT_EQ(byteStream.size(), 0);
-  ASSERT_EQ(byteStream.lastRangeEnd(), 0);
-  byteStream.resetInput(std::move(byteRanges));
+  ByteInputStream byteStream(std::move(byteRanges));
   ASSERT_EQ(byteStream.size(), totalBytes);
-  ASSERT_EQ(byteStream.lastRangeEnd(), lastRangeEnd);
 }
 
 TEST_F(ByteStreamTest, remainingSize) {
@@ -128,8 +124,7 @@ TEST_F(ByteStreamTest, remainingSize) {
     byteRanges.push_back(
         ByteRange{reinterpret_cast<uint8_t*>(buffers.back()), kBufferSize, 0});
   }
-  ByteStream byteStream;
-  byteStream.resetInput(std::move(byteRanges));
+  ByteInputStream byteStream(std::move(byteRanges));
   const int32_t kReadBytes = 2048;
   int32_t remainingSize = kSize * kBufferSize;
   uint8_t* tempBuffer = reinterpret_cast<uint8_t*>(pool_->allocate(kReadBytes));
@@ -155,19 +150,19 @@ TEST_F(ByteStreamTest, toString) {
     byteRanges.push_back(
         ByteRange{reinterpret_cast<uint8_t*>(buffers.back()), kBufferSize, 0});
   }
-  ByteStream byteStream;
-  byteStream.resetInput(std::move(byteRanges));
+  ByteInputStream byteStream(std::move(byteRanges));
   const int32_t kReadBytes = 2048;
   uint8_t* tempBuffer = reinterpret_cast<uint8_t*>(pool_->allocate(kReadBytes));
   for (int32_t i = 0; i < kSize / 2; i++) {
     byteStream.readBytes(tempBuffer, kReadBytes);
   }
-  std::string byteStreamStr = byteStream.toString();
+
   EXPECT_EQ(
-      byteStreamStr,
-      "ByteStream[lastRangeEnd 4096, 10 ranges "
+      byteStream.toString(),
+      "10 ranges "
       "(position/size) [(4096/4096),(4096/4096),(2048/4096 current),"
-      "(0/4096),(0/4096),(0/4096),(0/4096),(0/4096),(0/4096),(0/4096)]]");
+      "(0/4096),(0/4096),(0/4096),(0/4096),(0/4096),(0/4096),(0/4096)]");
+
   for (int32_t i = 0; i < kSize; i++) {
     pool_->free(buffers[i], kBufferSize);
   }

--- a/velox/common/memory/tests/HashStringAllocatorTest.cpp
+++ b/velox/common/memory/tests/HashStringAllocatorTest.cpp
@@ -205,15 +205,15 @@ TEST_F(HashStringAllocatorTest, finishWrite) {
       replaceStart.offset() + 4);
 
   // Read back long and short strings.
-  HSA::prepareRead(longStart.header, stream);
+  auto inputStream = HSA::prepareRead(longStart.header);
 
   std::string copy;
   copy.resize(longString.size());
-  stream.readBytes(copy.data(), copy.size());
+  inputStream.readBytes(copy.data(), copy.size());
   ASSERT_EQ(copy, longString);
 
   copy.resize(4);
-  stream.readBytes(copy.data(), 4);
+  inputStream.readBytes(copy.data(), 4);
   ASSERT_EQ(copy, "abcd");
 
   allocator_->checkConsistency();
@@ -227,10 +227,10 @@ TEST_F(HashStringAllocatorTest, finishWrite) {
     stream.appendStringPiece(folly::StringPiece(largeString));
     allocator_->finishWrite(stream, 0);
 
-    HSA::prepareRead(start.header, stream);
+    auto inStream = HSA::prepareRead(start.header);
     std::string copy;
     copy.resize(largeString.size());
-    stream.readBytes(copy.data(), copy.size());
+    inStream.readBytes(copy.data(), copy.size());
     ASSERT_EQ(copy, largeString);
     allocator_->checkConsistency();
   }
@@ -310,10 +310,10 @@ TEST_F(HashStringAllocatorTest, rewrite) {
     stream.appendOne(67890LL);
     position = allocator_->finishWrite(stream, 0).second;
     EXPECT_EQ(3 * sizeof(int64_t), HSA::offset(header, position));
-    HSA::prepareRead(header, stream);
-    EXPECT_EQ(123456789012345LL, stream.read<int64_t>());
-    EXPECT_EQ(12345LL, stream.read<int64_t>());
-    EXPECT_EQ(67890LL, stream.read<int64_t>());
+    auto inStream = HSA::prepareRead(header);
+    EXPECT_EQ(123456789012345LL, inStream.read<int64_t>());
+    EXPECT_EQ(12345LL, inStream.read<int64_t>());
+    EXPECT_EQ(67890LL, inStream.read<int64_t>());
   }
   // The stream contains 3 int64_t's.
   auto end = HSA::seek(header, 3 * sizeof(int64_t));

--- a/velox/exec/ContainerRowSerde.h
+++ b/velox/exec/ContainerRowSerde.h
@@ -30,14 +30,14 @@ class ContainerRowSerde {
   serialize(const BaseVector& source, vector_size_t index, ByteStream& out);
 
   static void
-  deserialize(ByteStream& in, vector_size_t index, BaseVector* result);
+  deserialize(ByteInputStream& in, vector_size_t index, BaseVector* result);
 
   /// Returns < 0 if 'left' is less than 'right' at 'index', 0 if
   /// equal and > 0 otherwise. flags.nullHandlingMode can be only NoStop and
   /// support null-safe equal.
   /// Top level rows in right are not allowed to be null.
   static int32_t compare(
-      ByteStream& left,
+      ByteInputStream& left,
       const DecodedVector& right,
       vector_size_t index,
       CompareFlags flags);
@@ -46,8 +46,8 @@ class ContainerRowSerde {
   /// equal and > 0 otherwise. flags.nullHandlingMode can be only NoStop and
   /// support null-safe equal.
   static int32_t compare(
-      ByteStream& left,
-      ByteStream& right,
+      ByteInputStream& left,
+      ByteInputStream& right,
       const Type* type,
       CompareFlags flags);
 
@@ -58,7 +58,7 @@ class ContainerRowSerde {
   /// to NULL.
   /// Top level rows in right are not allowed to be null.
   static std::optional<int32_t> compareWithNulls(
-      ByteStream& left,
+      ByteInputStream& left,
       const DecodedVector& right,
       vector_size_t index,
       CompareFlags flags);
@@ -69,12 +69,12 @@ class ContainerRowSerde {
   /// a null. If flags.nullHandlingMode is NoStop then NULL is considered equal
   /// to NULL.
   static std::optional<int32_t> compareWithNulls(
-      ByteStream& left,
-      ByteStream& right,
+      ByteInputStream& left,
+      ByteInputStream& right,
       const Type* type,
       CompareFlags flags);
 
-  static uint64_t hash(ByteStream& data, const Type* type);
+  static uint64_t hash(ByteInputStream& data, const Type* type);
 };
 
 } // namespace facebook::velox::exec

--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -109,8 +109,7 @@ RowVectorPtr Exchange::getOutput() {
   for (const auto& page : currentPages_) {
     rawInputBytes += page->size();
 
-    ByteStream inputStream;
-    page->prepareStreamForDeserialize(&inputStream);
+    auto inputStream = page->prepareStreamForDeserialize();
 
     while (!inputStream.atEnd()) {
       getSerde()->deserialize(

--- a/velox/exec/ExchangeQueue.cpp
+++ b/velox/exec/ExchangeQueue.cpp
@@ -39,8 +39,8 @@ SerializedPage::~SerializedPage() {
   }
 }
 
-void SerializedPage::prepareStreamForDeserialize(ByteStream* input) {
-  input->resetInput(std::move(ranges_));
+ByteInputStream SerializedPage::prepareStreamForDeserialize() {
+  return ByteInputStream(std::move(ranges_));
 }
 
 void ExchangeQueue::noMoreSources() {

--- a/velox/exec/ExchangeQueue.h
+++ b/velox/exec/ExchangeQueue.h
@@ -37,7 +37,13 @@ class SerializedPage {
 
   // Makes 'input' ready for deserializing 'this' with
   // VectorStreamGroup::read().
-  void prepareStreamForDeserialize(ByteStream* input);
+  ByteInputStream prepareStreamForDeserialize();
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  void prepareStreamForDeserialize(ByteStream* stream) {
+    stream->resetInput(std::move(ranges_));
+  }
+#endif
 
   std::unique_ptr<folly::IOBuf> getIOBuf() const {
     return iobuf_->clone();

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -934,10 +934,7 @@ class RowContainer {
     }
   }
 
-  static void prepareRead(
-      const char* FOLLY_NONNULL row,
-      int32_t offset,
-      ByteStream& stream);
+  static ByteInputStream prepareRead(const char* row, int32_t offset);
 
   template <TypeKind Kind>
   void hashTyped(
@@ -1090,7 +1087,6 @@ class RowContainer {
       RowColumn column,
       int32_t resultOffset,
       const VectorPtr& result) {
-    ByteStream stream;
     auto nullByte = column.nullByte();
     auto nullMask = column.nullMask();
     auto offset = column.offset();
@@ -1108,7 +1104,7 @@ class RowContainer {
       if (!row || isNullAt(row, nullByte, nullMask)) {
         result->setNull(resultIndex, true);
       } else {
-        prepareRead(row, offset, stream);
+        auto stream = prepareRead(row, offset);
         ContainerRowSerde::deserialize(stream, resultIndex, result.get());
       }
     }

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -28,8 +28,12 @@
 
 namespace facebook::velox::exec {
 
-// Input stream backed by spill file.
-class SpillInput : public ByteStream {
+/// Input stream backed by spill file.
+///
+/// TODO Usage of ByteInputStream as base class is hacky and just happens to
+/// work. For example, ByteInputStream::size(), seekp(), tellp(),
+/// remainingSize() APIs do not work properly.
+class SpillInput : public ByteInputStream {
  public:
   // Reads from 'input' using 'buffer' for buffering reads.
   SpillInput(std::unique_ptr<ReadFile>&& input, BufferPtr buffer)
@@ -39,14 +43,14 @@ class SpillInput : public ByteStream {
     next(true);
   }
 
-  void next(bool throwIfPastEnd) override;
-
   // True if all of the file has been read into vectors.
-  bool atEnd() const {
+  bool atEnd() const override {
     return offset_ >= size_ && ranges()[0].position >= ranges()[0].size;
   }
 
  private:
+  void next(bool throwIfPastEnd) override;
+
   std::unique_ptr<ReadFile> input_;
   BufferPtr buffer_;
   const uint64_t size_;

--- a/velox/exec/tests/ContainerRowSerdeTest.cpp
+++ b/velox/exec/tests/ContainerRowSerdeTest.cpp
@@ -67,8 +67,7 @@ class ContainerRowSerdeTest : public testing::Test,
       data->setNull(i, true);
     }
 
-    ByteStream in;
-    HashStringAllocator::prepareRead(position.header, in);
+    auto in = HashStringAllocator::prepareRead(position.header);
     for (auto i = 0; i < numRows; ++i) {
       ContainerRowSerde::deserialize(in, i, data.get());
     }
@@ -96,8 +95,7 @@ class ContainerRowSerdeTest : public testing::Test,
         mode};
 
     for (auto i = 0; i < expected.size(); ++i) {
-      ByteStream stream;
-      HashStringAllocator::prepareRead(positions.at(i).header, stream);
+      auto stream = HashStringAllocator::prepareRead(positions.at(i).header);
       ASSERT_EQ(
           expected.at(i),
           ContainerRowSerde::compareWithNulls(
@@ -119,11 +117,10 @@ class ContainerRowSerdeTest : public testing::Test,
         mode};
 
     for (auto i = 0; i < expected.size(); ++i) {
-      ByteStream leftStream;
-      HashStringAllocator::prepareRead(leftPositions.at(i).header, leftStream);
-      ByteStream rightStream;
-      HashStringAllocator::prepareRead(
-          rightPositions.at(i).header, rightStream);
+      auto leftStream =
+          HashStringAllocator::prepareRead(leftPositions.at(i).header);
+      auto rightStream =
+          HashStringAllocator::prepareRead(rightPositions.at(i).header);
       ASSERT_EQ(
           expected.at(i),
           ContainerRowSerde::compareWithNulls(
@@ -143,8 +140,7 @@ class ContainerRowSerdeTest : public testing::Test,
     DecodedVector decodedVector(*vector);
 
     for (auto i = 0; i < positions.size(); ++i) {
-      ByteStream stream;
-      HashStringAllocator::prepareRead(positions.at(i).header, stream);
+      auto stream = HashStringAllocator::prepareRead(positions.at(i).header);
       ASSERT_EQ(
           0, ContainerRowSerde::compare(stream, decodedVector, i, compareFlags))
           << "at " << i << ": " << vector->toString(i);

--- a/velox/functions/lib/aggregates/SingleValueAccumulator.cpp
+++ b/velox/functions/lib/aggregates/SingleValueAccumulator.cpp
@@ -40,8 +40,7 @@ void SingleValueAccumulator::read(const VectorPtr& vector, vector_size_t index)
     const {
   VELOX_CHECK_NOT_NULL(start_.header);
 
-  ByteStream stream;
-  HashStringAllocator::prepareRead(start_.header, stream);
+  auto stream = HashStringAllocator::prepareRead(start_.header);
   exec::ContainerRowSerde::deserialize(stream, index, vector.get());
 }
 
@@ -55,8 +54,7 @@ std::optional<int32_t> SingleValueAccumulator::compare(
     CompareFlags compareFlags) const {
   VELOX_CHECK_NOT_NULL(start_.header);
 
-  ByteStream stream;
-  HashStringAllocator::prepareRead(start_.header, stream);
+  auto stream = HashStringAllocator::prepareRead(start_.header);
   return exec::ContainerRowSerde::compareWithNulls(
       stream, decoded, index, compareFlags);
 }

--- a/velox/functions/lib/aggregates/ValueSet.cpp
+++ b/velox/functions/lib/aggregates/ValueSet.cpp
@@ -53,8 +53,7 @@ void ValueSet::read(
     const HashStringAllocator::Header* header) const {
   VELOX_CHECK_NOT_NULL(header);
 
-  ByteStream stream;
-  HashStringAllocator::prepareRead(header, stream);
+  auto stream = HashStringAllocator::prepareRead(header);
   exec::ContainerRowSerde::deserialize(stream, index, vector);
 }
 

--- a/velox/functions/prestosql/aggregates/ValueList.cpp
+++ b/velox/functions/prestosql/aggregates/ValueList.cpp
@@ -102,10 +102,9 @@ void ValueList::appendRange(
 ValueListReader::ValueListReader(ValueList& values)
     : size_{values.size()},
       lastNullsStart_{size_ % 64 == 0 ? size_ - 64 : size_ - size_ % 64},
-      lastNulls_{values.lastNulls()} {
-  HashStringAllocator::prepareRead(values.dataBegin(), dataStream_);
-  HashStringAllocator::prepareRead(values.nullsBegin(), nullsStream_);
-}
+      lastNulls_{values.lastNulls()},
+      dataStream_{HashStringAllocator::prepareRead(values.dataBegin())},
+      nullsStream_{HashStringAllocator::prepareRead(values.nullsBegin())} {}
 
 bool ValueListReader::next(BaseVector& output, vector_size_t outputIndex) {
   if (pos_ == lastNullsStart_) {

--- a/velox/functions/prestosql/aggregates/ValueList.h
+++ b/velox/functions/prestosql/aggregates/ValueList.h
@@ -126,8 +126,8 @@ class ValueListReader {
   const vector_size_t size_;
   const vector_size_t lastNullsStart_;
   const uint64_t lastNulls_;
-  ByteStream dataStream_;
-  ByteStream nullsStream_;
+  ByteInputStream dataStream_;
+  ByteInputStream nullsStream_;
   uint64_t nulls_;
   vector_size_t pos_{0};
 };

--- a/velox/row/benchmark/UnsafeRowSerializeBenchmark.cpp
+++ b/velox/row/benchmark/UnsafeRowSerializeBenchmark.cpp
@@ -99,8 +99,7 @@ class SerializeBenchmark {
 
     auto copy = BaseVector::create(rowType, data->size(), pool());
 
-    ByteStream in;
-    HashStringAllocator::prepareRead(position.header, in);
+    auto in = HashStringAllocator::prepareRead(position.header);
     for (auto i = 0; i < data->size(); ++i) {
       exec::ContainerRowSerde::deserialize(in, i, copy.get());
     }

--- a/velox/serializers/CompactRowSerializer.cpp
+++ b/velox/serializers/CompactRowSerializer.cpp
@@ -96,7 +96,7 @@ class CompactRowVectorSerializer : public VectorSerializer {
 
 // Read from the stream until the full row is concatenated.
 std::string concatenatePartialRow(
-    ByteStream* source,
+    ByteInputStream* source,
     std::string_view rowFragment,
     CompactRowVectorSerializer::TRowSize rowSize) {
   std::string rowBuffer;
@@ -127,7 +127,7 @@ std::unique_ptr<VectorSerializer> CompactRowVectorSerde::createSerializer(
 }
 
 void CompactRowVectorSerde::deserialize(
-    ByteStream* source,
+    ByteInputStream* source,
     velox::memory::MemoryPool* pool,
     RowTypePtr type,
     RowVectorPtr* result,

--- a/velox/serializers/CompactRowSerializer.h
+++ b/velox/serializers/CompactRowSerializer.h
@@ -23,6 +23,7 @@ namespace facebook::velox::serializer {
 class CompactRowVectorSerde : public VectorSerde {
  public:
   CompactRowVectorSerde() = default;
+
   // We do not implement this method since it is not used in production code.
   void estimateSerializedSize(
       VectorPtr vector,
@@ -39,7 +40,7 @@ class CompactRowVectorSerde : public VectorSerde {
 
   // This method is used when reading data from the exchange.
   void deserialize(
-      ByteStream* source,
+      ByteInputStream* source,
       velox::memory::MemoryPool* pool,
       RowTypePtr type,
       RowVectorPtr* result,

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -45,7 +45,7 @@ int64_t computeChecksum(
 }
 
 int64_t computeChecksum(
-    ByteStream* source,
+    ByteInputStream* source,
     int codecMarker,
     int numRows,
     int uncompressedSize) {
@@ -150,7 +150,7 @@ FOLLY_ALWAYS_INLINE bool needCompression(const folly::io::Codec& codec) {
 
 template <typename T>
 void readValues(
-    ByteStream* source,
+    ByteInputStream* source,
     vector_size_t size,
     vector_size_t offset,
     BufferPtr nulls,
@@ -176,7 +176,7 @@ void readValues(
 
 template <>
 void readValues<bool>(
-    ByteStream* source,
+    ByteInputStream* source,
     vector_size_t size,
     vector_size_t offset,
     BufferPtr nulls,
@@ -201,14 +201,14 @@ void readValues<bool>(
   }
 }
 
-Timestamp readTimestamp(ByteStream* source) {
+Timestamp readTimestamp(ByteInputStream* source) {
   int64_t millis = source->read<int64_t>();
   return Timestamp::fromMillis(millis);
 }
 
 template <>
 void readValues<Timestamp>(
-    ByteStream* source,
+    ByteInputStream* source,
     vector_size_t size,
     vector_size_t offset,
     BufferPtr nulls,
@@ -233,14 +233,14 @@ void readValues<Timestamp>(
   }
 }
 
-Timestamp readLosslessTimestamp(ByteStream* source) {
+Timestamp readLosslessTimestamp(ByteInputStream* source) {
   int64_t seconds = source->read<int64_t>();
   uint64_t nanos = source->read<uint64_t>();
   return Timestamp(seconds, nanos);
 }
 
 void readLosslessTimestampValues(
-    ByteStream* source,
+    ByteInputStream* source,
     vector_size_t size,
     vector_size_t offset,
     BufferPtr nulls,
@@ -265,8 +265,8 @@ void readLosslessTimestampValues(
   }
 }
 
-int128_t readJavaDecimal(ByteStream* source) {
-  // ByteStream does not support reading int128_t values.
+int128_t readJavaDecimal(ByteInputStream* source) {
+  // ByteInputStream does not support reading int128_t values.
   auto low = source->read<int64_t>();
   auto high = source->read<int64_t>();
   // 'high' is in signed magnitude representation.
@@ -279,7 +279,7 @@ int128_t readJavaDecimal(ByteStream* source) {
 }
 
 void readDecimalValues(
-    ByteStream* source,
+    ByteInputStream* source,
     vector_size_t size,
     vector_size_t offset,
     BufferPtr nulls,
@@ -305,7 +305,7 @@ void readDecimalValues(
 }
 
 vector_size_t readNulls(
-    ByteStream* source,
+    ByteInputStream* source,
     vector_size_t size,
     BaseVector& result,
     vector_size_t resultOffset) {
@@ -346,7 +346,7 @@ vector_size_t readNulls(
 
 template <typename T>
 void read(
-    ByteStream* source,
+    ByteInputStream* source,
     const TypePtr& type,
     velox::memory::MemoryPool* pool,
     VectorPtr& result,
@@ -377,7 +377,7 @@ void read(
 
 template <>
 void read<StringView>(
-    ByteStream* source,
+    ByteInputStream* source,
     const TypePtr& type,
     velox::memory::MemoryPool* pool,
     VectorPtr& result,
@@ -417,7 +417,7 @@ void read<StringView>(
 }
 
 void readColumns(
-    ByteStream* source,
+    ByteInputStream* source,
     velox::memory::MemoryPool* pool,
     const std::vector<TypePtr>& types,
     std::vector<VectorPtr>& result,
@@ -425,7 +425,7 @@ void readColumns(
     bool useLosslessTimestamp);
 
 void readConstantVector(
-    ByteStream* source,
+    ByteInputStream* source,
     const TypePtr& type,
     velox::memory::MemoryPool* pool,
     VectorPtr& result,
@@ -453,7 +453,7 @@ void readConstantVector(
 }
 
 void readDictionaryVector(
-    ByteStream* source,
+    ByteInputStream* source,
     const TypePtr& type,
     velox::memory::MemoryPool* pool,
     VectorPtr& result,
@@ -490,7 +490,7 @@ void readDictionaryVector(
 }
 
 void readArrayVector(
-    ByteStream* source,
+    ByteInputStream* source,
     const TypePtr& type,
     velox::memory::MemoryPool* pool,
     VectorPtr& result,
@@ -530,7 +530,7 @@ void readArrayVector(
 }
 
 void readMapVector(
-    ByteStream* source,
+    ByteInputStream* source,
     const TypePtr& type,
     velox::memory::MemoryPool* pool,
     VectorPtr& result,
@@ -586,7 +586,7 @@ void unpackTimestampWithTimeZone(
 }
 
 void readTimestampWithTimeZone(
-    ByteStream* source,
+    ByteInputStream* source,
     velox::memory::MemoryPool* pool,
     RowVector* result,
     vector_size_t resultOffset) {
@@ -918,7 +918,7 @@ void scatterStructNulls(
 }
 
 void readRowVector(
-    ByteStream* source,
+    ByteInputStream* source,
     const TypePtr& type,
     velox::memory::MemoryPool* pool,
     VectorPtr& result,
@@ -948,7 +948,7 @@ void readRowVector(
   readNulls(source, size, *result, resultOffset);
 }
 
-std::string readLengthPrefixedString(ByteStream* source) {
+std::string readLengthPrefixedString(ByteInputStream* source) {
   int32_t size = source->read<int32_t>();
   std::string value;
   value.resize(size);
@@ -967,7 +967,7 @@ void checkTypeEncoding(std::string_view encoding, const TypePtr& type) {
 }
 
 void readColumns(
-    ByteStream* source,
+    ByteInputStream* source,
     velox::memory::MemoryPool* pool,
     const std::vector<TypePtr>& types,
     std::vector<VectorPtr>& results,
@@ -976,7 +976,7 @@ void readColumns(
   static const std::unordered_map<
       TypeKind,
       std::function<void(
-          ByteStream * source,
+          ByteInputStream * source,
           const TypePtr& type,
           velox::memory::MemoryPool* pool,
           VectorPtr& result,
@@ -2286,7 +2286,7 @@ void PrestoVectorSerde::serializeEncoded(
 }
 
 void PrestoVectorSerde::deserialize(
-    ByteStream* source,
+    ByteInputStream* source,
     velox::memory::MemoryPool* pool,
     RowTypePtr type,
     RowVectorPtr* result,
@@ -2354,8 +2354,7 @@ void PrestoVectorSerde::deserialize(
     auto uncompress = codec->uncompress(compressBuf.get(), uncompressedSize);
     ByteRange byteRange{
         uncompress->writableData(), (int32_t)uncompress->length(), 0};
-    ByteStream uncompressedSource;
-    uncompressedSource.resetInput({byteRange});
+    ByteInputStream uncompressedSource({byteRange});
 
     const auto numColumns = uncompressedSource.read<int32_t>();
     VELOX_USER_CHECK_EQ(

--- a/velox/serializers/PrestoSerializer.h
+++ b/velox/serializers/PrestoSerializer.h
@@ -70,7 +70,7 @@ class PrestoVectorSerde : public VectorSerde {
   }
 
   void deserialize(
-      ByteStream* source,
+      ByteInputStream* source,
       velox::memory::MemoryPool* pool,
       RowTypePtr type,
       RowVectorPtr* result,
@@ -79,7 +79,7 @@ class PrestoVectorSerde : public VectorSerde {
   }
 
   void deserialize(
-      ByteStream* source,
+      ByteInputStream* source,
       velox::memory::MemoryPool* pool,
       RowTypePtr type,
       RowVectorPtr* result,

--- a/velox/serializers/UnsafeRowSerializer.cpp
+++ b/velox/serializers/UnsafeRowSerializer.cpp
@@ -98,7 +98,7 @@ class UnsafeRowVectorSerializer : public VectorSerializer {
 
 // Read from the stream until the full row is concatenated.
 std::string concatenatePartialRow(
-    ByteStream* source,
+    ByteInputStream* source,
     std::string_view rowFragment,
     UnsafeRowVectorSerializer::TRowSize rowSize) {
   std::string rowBuffer;
@@ -129,7 +129,7 @@ std::unique_ptr<VectorSerializer> UnsafeRowVectorSerde::createSerializer(
 }
 
 void UnsafeRowVectorSerde::deserialize(
-    ByteStream* source,
+    ByteInputStream* source,
     velox::memory::MemoryPool* pool,
     RowTypePtr type,
     RowVectorPtr* result,

--- a/velox/serializers/UnsafeRowSerializer.h
+++ b/velox/serializers/UnsafeRowSerializer.h
@@ -38,7 +38,7 @@ class UnsafeRowVectorSerde : public VectorSerde {
 
   // This method is used when reading data from the exchange.
   void deserialize(
-      ByteStream* source,
+      ByteInputStream* source,
       velox::memory::MemoryPool* pool,
       RowTypePtr type,
       RowVectorPtr* result,

--- a/velox/serializers/tests/CompactRowSerializerTest.cpp
+++ b/velox/serializers/tests/CompactRowSerializerTest.cpp
@@ -48,7 +48,7 @@ class CompactRowSerializerTest : public ::testing::Test,
     ASSERT_EQ(size, output->tellp());
   }
 
-  std::unique_ptr<ByteStream> toByteStream(
+  ByteInputStream toByteStream(
       const std::string_view& input,
       size_t pageSize = 32) {
     auto rawBytes = reinterpret_cast<uint8_t*>(const_cast<char*>(input.data()));
@@ -65,9 +65,7 @@ class CompactRowSerializerTest : public ::testing::Test,
       offset += pageSize;
     }
 
-    auto byteStream = std::make_unique<ByteStream>();
-    byteStream->resetInput(std::move(ranges));
-    return byteStream;
+    return ByteInputStream(std::move(ranges));
   }
 
   RowVectorPtr deserialize(
@@ -76,7 +74,7 @@ class CompactRowSerializerTest : public ::testing::Test,
     auto byteStream = toByteStream(input);
 
     RowVectorPtr result;
-    serde_->deserialize(byteStream.get(), pool_.get(), rowType, &result);
+    serde_->deserialize(&byteStream, pool_.get(), rowType, &result);
     return result;
   }
 

--- a/velox/serializers/tests/UnsafeRowSerializerTest.cpp
+++ b/velox/serializers/tests/UnsafeRowSerializerTest.cpp
@@ -48,8 +48,7 @@ class UnsafeRowSerializerTest : public ::testing::Test,
     ASSERT_EQ(size, output->tellp());
   }
 
-  std::unique_ptr<ByteStream> toByteStream(
-      const std::vector<std::string_view>& inputs) {
+  ByteInputStream toByteStream(const std::vector<std::string_view>& inputs) {
     std::vector<ByteRange> ranges;
     ranges.reserve(inputs.size());
 
@@ -59,9 +58,7 @@ class UnsafeRowSerializerTest : public ::testing::Test,
            (int32_t)input.length(),
            0});
     }
-    auto byteStream = std::make_unique<ByteStream>();
-    byteStream->resetInput(std::move(ranges));
-    return byteStream;
+    return ByteInputStream(std::move(ranges));
   }
 
   RowVectorPtr deserialize(
@@ -70,7 +67,7 @@ class UnsafeRowSerializerTest : public ::testing::Test,
     auto byteStream = toByteStream(input);
 
     RowVectorPtr result;
-    serde_->deserialize(byteStream.get(), pool_.get(), rowType, &result);
+    serde_->deserialize(&byteStream, pool_.get(), rowType, &result);
     return result;
   }
 

--- a/velox/vector/VectorStream.cpp
+++ b/velox/vector/VectorStream.cpp
@@ -124,7 +124,7 @@ void VectorStreamGroup::estimateSerializedSize(
 
 // static
 void VectorStreamGroup::read(
-    ByteStream* source,
+    ByteInputStream* source,
     velox::memory::MemoryPool* pool,
     RowTypePtr type,
     RowVectorPtr* result,
@@ -168,8 +168,7 @@ RowVectorPtr IOBufToRowVector(
         const_cast<uint8_t*>(range.data()), (int32_t)range.size(), 0});
   }
 
-  ByteStream byteStream;
-  byteStream.resetInput(std::move(ranges));
+  ByteInputStream byteStream(std::move(ranges));
   RowVectorPtr outputVector;
 
   // If not supplied, use the default one.

--- a/velox/vector/tests/VectorStreamTest.cpp
+++ b/velox/vector/tests/VectorStreamTest.cpp
@@ -34,7 +34,7 @@ class MockVectorSerde : public VectorSerde {
   };
 
   void deserialize(
-      ByteStream* source,
+      ByteInputStream* source,
       velox::memory::MemoryPool* pool,
       RowTypePtr type,
       RowVectorPtr* result,


### PR DESCRIPTION
ByteStream class is used both for reading and writing to a multi-part buffer.

Mixing reading and writing logic and APIs in a single class is confusing.

First step is to extract reading logic and APIs into ByteInputStream class.