### PR TITLE
LMDBInodeCatalog + LMDBFileContentStore

### DIFF
--- a/build/fbcode_builder/CMake/FindLMDB.cmake
+++ b/build/fbcode_builder/CMake/FindLMDB.cmake
@@ -1,0 +1,19 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This software may be used and distributed according to the terms of the
+# GNU General Public License version 2.
+
+find_library(LMDB_LIBRARIES NAMES lmdb liblmdb)
+mark_as_advanced(LMDB_LIBRARIES)
+
+find_path(LMDB_INCLUDE_DIR NAMES  lmdb.h)
+mark_as_advanced(LMDB_INCLUDE_DIR)
+
+find_package_handle_standard_args(
+     LMDB
+     REQUIRED_VARS LMDB_LIBRARIES LMDB_INCLUDE_DIR)
+
+if(LMDB_FOUND)
+  set(LMDB_LIBRARIES ${LMDB_LIBRARIES})
+  set(LMDB_INCLUDE_DIR, ${LMDB_INCLUDE_DIR})
+endif()

--- a/build/fbcode_builder/manifests/eden
+++ b/build/fbcode_builder/manifests/eden
@@ -52,6 +52,8 @@ osxfuse
 libcurl
 # Added so that OSS doesn't see system "python" which is python 2 on darwin and some linux
 python
+# TODO: teach getdeps to compile lmdb on Windows.
+lmdb
 
 [shipit.pathmap.fb=on]
 # for internal builds that use getdeps

--- a/build/fbcode_builder/manifests/lmdb
+++ b/build/fbcode_builder/manifests/lmdb
@@ -1,0 +1,17 @@
+[manifest]
+name = lmdb
+
+[build]
+builder = make
+subdir = lmdb-LMDB_0.9.31/libraries/liblmdb
+
+[download]
+url = https://github.com/LMDB/lmdb/archive/refs/tags/LMDB_0.9.31.tar.gz
+sha256 = dd70a8c67807b3b8532b3e987b0a4e998962ecc28643e1af5ec77696b081c9b0
+
+[make.build_args]
+BUILD_STATIC_ONLY=y
+
+[make.install_args]
+install
+BUILD_STATIC_ONLY=y


### PR DESCRIPTION
Summary: ties all of the pieces together. The bulk of the net-new logic is in `OverlayFile`, with the LMDB stuff being ported from other implementations or just delegating calls to other classes.

Reviewed By: kmancini

Differential Revision: D46914322


