### PR TITLE
Add a way to override current time in tests

### DIFF
--- a/velox/common/time/Timer.cpp
+++ b/velox/common/time/Timer.cpp
@@ -16,10 +16,54 @@
 
 #include "velox/common/time/Timer.h"
 
+#include "velox/common/base/Exceptions.h"
+
 namespace facebook::velox {
 
 using namespace std::chrono;
 
+#ifndef NDEBUG
+bool ScopedTestTime::enabled_ = false;
+std::optional<size_t> ScopedTestTime::testTimeUs_ = {};
+
+ScopedTestTime::ScopedTestTime() {
+  VELOX_CHECK(!enabled_, "Only one ScopedTestTime can be active at a time");
+  enabled_ = true;
+}
+
+ScopedTestTime::~ScopedTestTime() {
+  testTimeUs_.reset();
+  enabled_ = false;
+}
+
+void ScopedTestTime::setCurrentTestTimeMs(size_t currentTimeMs) {
+  setCurrentTestTimeMicro(currentTimeMs * 1000);
+}
+
+void ScopedTestTime::setCurrentTestTimeMicro(size_t currentTimeUs) {
+  testTimeUs_ = currentTimeUs;
+}
+
+std::optional<size_t> ScopedTestTime::getCurrentTestTimeMs() {
+  return testTimeUs_.has_value() ? std::make_optional(*testTimeUs_ / 1000L)
+                                 : testTimeUs_;
+}
+std::optional<size_t> ScopedTestTime::getCurrentTestTimeMicro() {
+  return testTimeUs_;
+}
+
+size_t getCurrentTimeMs() {
+  return ScopedTestTime::getCurrentTestTimeMs().value_or(
+      duration_cast<milliseconds>(system_clock::now().time_since_epoch())
+          .count());
+}
+
+size_t getCurrentTimeMicro() {
+  return ScopedTestTime::getCurrentTestTimeMicro().value_or(
+      duration_cast<microseconds>(system_clock::now().time_since_epoch())
+          .count());
+}
+#else
 size_t getCurrentTimeMs() {
   return duration_cast<milliseconds>(system_clock::now().time_since_epoch())
       .count();
@@ -29,5 +73,6 @@ size_t getCurrentTimeMicro() {
   return duration_cast<microseconds>(system_clock::now().time_since_epoch())
       .count();
 }
+#endif
 
 } // namespace facebook::velox

--- a/velox/common/time/Timer.h
+++ b/velox/common/time/Timer.h
@@ -19,6 +19,7 @@
 #include <folly/chrono/Hardware.h>
 #include <atomic>
 #include <chrono>
+#include <optional>
 
 namespace facebook::velox {
 
@@ -74,5 +75,26 @@ size_t getCurrentTimeMs();
 
 /// Returns the current epoch time in microseconds.
 size_t getCurrentTimeMicro();
+
+#ifndef NDEBUG
+// Used to override the current time for testing purposes.
+class ScopedTestTime {
+ public:
+  ScopedTestTime();
+  ~ScopedTestTime();
+
+  void setCurrentTestTimeMs(size_t currentTimeMs);
+  void setCurrentTestTimeMicro(size_t currentTimeUs);
+
+  static std::optional<size_t> getCurrentTestTimeMs();
+  static std::optional<size_t> getCurrentTestTimeMicro();
+
+ private:
+  // Used to verify only one instance of ScopedTestTime exists at a time.
+  static bool enabled_;
+  // The overridden value of current time only.
+  static std::optional<size_t> testTimeUs_;
+};
+#endif
 
 } // namespace facebook::velox

--- a/velox/common/time/tests/TestScopedTestTimer.cpp
+++ b/velox/common/time/tests/TestScopedTestTimer.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/time/Timer.h"
+
+namespace {
+
+using namespace facebook::velox;
+
+// NOTE: we can only build TestScopedTestTimer on debug build.
+#ifndef NDEBUG
+TEST(TestScopedTestTimer, testSetCurrentTimeMs) {
+  {
+    ScopedTestTime scopedTestTime;
+    scopedTestTime.setCurrentTestTimeMs(1);
+    ASSERT_EQ(getCurrentTimeMs(), 1);
+    ASSERT_EQ(getCurrentTimeMicro(), 1000);
+    scopedTestTime.setCurrentTestTimeMs(2);
+    ASSERT_EQ(getCurrentTimeMs(), 2);
+    ASSERT_EQ(getCurrentTimeMicro(), 2000);
+  }
+
+  // This should be the actual time, so we don't know what it is, but it
+  // shouldn't be equal to the overridden value.
+  ASSERT_NE(getCurrentTimeMs(), 2);
+  ASSERT_NE(getCurrentTimeMicro(), 2000);
+}
+
+TEST(TestScopedTestTimer, testSetCurrentTimeMicro) {
+  {
+    ScopedTestTime scopedTestTime;
+    scopedTestTime.setCurrentTestTimeMicro(1000);
+    ASSERT_EQ(getCurrentTimeMs(), 1);
+    ASSERT_EQ(getCurrentTimeMicro(), 1000);
+    scopedTestTime.setCurrentTestTimeMicro(2000);
+    ASSERT_EQ(getCurrentTimeMs(), 2);
+    ASSERT_EQ(getCurrentTimeMicro(), 2000);
+  }
+
+  // This should be the actual time, so we don't know what it is, but it
+  // shouldn't be equal to the overridden value.
+  ASSERT_NE(getCurrentTimeMs(), 2);
+  ASSERT_NE(getCurrentTimeMicro(), 2000);
+}
+
+TEST(TestScopedTestTimer, multipleScopedTestTimes) {
+  {
+    ScopedTestTime scopedTestTime;
+    scopedTestTime.setCurrentTestTimeMs(1);
+    ASSERT_EQ(getCurrentTimeMs(), 1);
+    ASSERT_EQ(getCurrentTimeMicro(), 1000);
+  }
+
+  {
+    ScopedTestTime scopedTestTime;
+    // The previous scoped test time should have been cleared.
+    ASSERT_NE(getCurrentTimeMs(), 1);
+    ASSERT_NE(getCurrentTimeMicro(), 1000);
+
+    scopedTestTime.setCurrentTestTimeMs(1);
+    ASSERT_EQ(getCurrentTimeMs(), 1);
+    ASSERT_EQ(getCurrentTimeMicro(), 1000);
+
+    // Trying to create another ScopedTestTime with one already in scope should
+    // fail.
+    auto createScopedTestTime = []() { ScopedTestTime scopedTestTime2; };
+    VELOX_ASSERT_THROW(
+        createScopedTestTime(),
+        "Only one ScopedTestTime can be active at a time");
+  }
+}
+#endif
+} // namespace


### PR DESCRIPTION
Summary:
Adding a ScopedTestTime class that allows us to override the value returned by
getCurrentTimeMs/getCurrentTimeMicro in tests.

This will be useful for testing some of the times we set in Task for example by making them deterministic.

It only applies in debug mode so there's no risk of breaking or impacting performance in prod.

Differential Revision: D51267554


