### PR TITLE
Fix generic in-predicate for complex types

### DIFF
--- a/velox/functions/prestosql/InPredicate.cpp
+++ b/velox/functions/prestosql/InPredicate.cpp
@@ -47,17 +47,17 @@ class GenericInPredicate : public exec::VectorFunction {
         return;
       }
 
-      const auto valueBaseRow = value->index(row);
-      if (valueBase->containsNullAt(valueBaseRow)) {
-        boolResult->setNull(row, true);
-        return;
-      }
-
       const auto arrayRow = inList->index(row);
       const auto offset = inListBaseArray->offsetAt(arrayRow);
       const auto size = inListBaseArray->sizeAt(arrayRow);
 
       VELOX_USER_CHECK_GT(size, 0, "IN list must not be empty");
+
+      const auto valueBaseRow = value->index(row);
+      if (valueBase->containsNullAt(valueBaseRow)) {
+        boolResult->setNull(row, true);
+        return;
+      }
 
       bool hasNull = false;
       for (auto i = 0; i < size; ++i) {


### PR DESCRIPTION
This fixes a bug where the generic in-predicate, which is employed
when the in-list is not a constant, can return null if the input
contains a null even though the in-list is empty. The correct
behavior is that it should throw an error for the empty in-list.

Fixes #7533

Test Plan:
Added unit test