### PR TITLE
Update TaskTest to verify executionEndTimeMs and terminationTimeMs

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1744,15 +1744,15 @@ ContinueFuture Task::terminate(TaskState terminalState) {
     if (taskStats_.executionEndTimeMs == 0) {
       taskStats_.executionEndTimeMs = getCurrentTimeMs();
     }
-    if (taskStats_.terminationTimeMs == 0) {
-      // In case terminate gets called multiple times somehow,
-      // this represents the first time.
-      taskStats_.terminationTimeMs = getCurrentTimeMs();
-    }
     if (not isRunningLocked()) {
       return makeFinishFutureLocked("Task::terminate");
     }
     state_ = terminalState;
+    VELOX_CHECK_EQ(
+        taskStats_.terminationTimeMs,
+        0,
+        "Termination time has already been set, this should only happen once.");
+    taskStats_.terminationTimeMs = getCurrentTimeMs();
     if (state_ == TaskState::kCanceled || state_ == TaskState::kAborted) {
       try {
         VELOX_FAIL(

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -1092,6 +1092,9 @@ DEBUG_ONLY_TEST_F(TaskTest, liveStats) {
     EXPECT_EQ(0, liveStats[i].numTerminatedDrivers);
     EXPECT_EQ(1, liveStats[i].numRunningDrivers);
     EXPECT_EQ(0, liveStats[i].numBlockedDrivers.size());
+
+    EXPECT_EQ(0, liveStats[i].executionEndTimeMs);
+    EXPECT_EQ(0, liveStats[i].terminationTimeMs);
   }
 
   EXPECT_EQ(1, finishStats.numTotalDrivers);
@@ -1108,6 +1111,19 @@ DEBUG_ONLY_TEST_F(TaskTest, liveStats) {
   EXPECT_EQ(1, operatorStats.finishTiming.count);
   // No operators with background CPU time yet.
   EXPECT_EQ(0, operatorStats.backgroundTiming.count);
+
+  EXPECT_NE(0, finishStats.executionEndTimeMs);
+  EXPECT_NE(0, finishStats.terminationTimeMs);
+  const auto terminationTimeMs = finishStats.terminationTimeMs;
+
+  // Sleep to allow time to pass, so the values change.
+  std::this_thread::sleep_for(std::chrono::milliseconds{5});
+  EXPECT_NE(0, task->timeSinceEndMs());
+  EXPECT_NE(0, task->timeSinceTerminationMs());
+
+  // This should be a no-op.
+  task->requestCancel();
+  EXPECT_EQ(terminationTimeMs, task->taskStats().terminationTimeMs);
 }
 
 TEST_F(TaskTest, outputBufferSize) {


### PR DESCRIPTION
Summary:
Today, we don't have any tests that executionEndTimeMs and terminationTimeMs are not set while the task is
running and set once the task terminates.

This change updates the tests to cover these stats.

In addition, it moves where we set terminationTimeMs to the code in terminate that is only called once, so we
don't need the if statement.

Differential Revision: D51270201


