### PR TITLE
Add to support cache shrink

### DIFF
--- a/velox/common/caching/SsdCache.cpp
+++ b/velox/common/caching/SsdCache.cpp
@@ -18,10 +18,13 @@
 #include <folly/portability/SysUio.h>
 #include "velox/common/caching/FileIds.h"
 #include "velox/common/file/FileSystems.h"
+#include "velox/common/testutil/TestValue.h"
 #include "velox/common/time/Timer.h"
 
 #include <filesystem>
 #include <numeric>
+
+using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::cache {
 
@@ -81,6 +84,8 @@ bool SsdCache::startWrite() {
 void SsdCache::write(std::vector<CachePin> pins) {
   VELOX_CHECK_LE(numShards_, writesInProgress_);
 
+  TestValue::adjust("facebook::velox::cache::SsdCache::write", this);
+
   const auto startTimeUs = getCurrentTimeMicro();
 
   uint64_t bytes = 0;
@@ -116,6 +121,7 @@ void SsdCache::write(std::vector<CachePin> pins) {
         VELOX_SSD_CACHE_LOG(WARNING)
             << "Ignoring error in SsdFile::write: " << e.what();
       }
+      pinHolder->pins.clear();
       if (--writesInProgress_ == 0) {
         // Typically occurs every few GB. Allows detecting unusually slow rates
         // from failing devices.

--- a/velox/common/memory/Allocation.h
+++ b/velox/common/memory/Allocation.h
@@ -47,7 +47,7 @@ struct AllocationTraits {
   }
 
   /// Returns the round up page bytes.
-  FOLLY_ALWAYS_INLINE static MachinePageCount roundUpPageBytes(uint64_t bytes) {
+  FOLLY_ALWAYS_INLINE static uint64_t roundUpPageBytes(uint64_t bytes) {
     return bits::roundUp(bytes, kPageSize);
   }
 

--- a/velox/common/memory/MallocAllocator.h
+++ b/velox/common/memory/MallocAllocator.h
@@ -67,6 +67,12 @@ class MallocAllocator : public MemoryAllocator {
 
   void freeBytes(void* p, uint64_t bytes) noexcept override;
 
+  MachinePageCount unmap(MachinePageCount targetPages) override {
+    // NOTE: MallocAllocator doesn't support unmap as it delegates all the
+    // memory allocations to std::malloc.
+    return 0;
+  }
+
   size_t totalUsedBytes() const override {
     return allocatedBytes_;
   }

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -109,6 +109,8 @@ class MmapAllocator : public MemoryAllocator {
 
   int64_t freeNonContiguous(Allocation& allocation) override;
 
+  MachinePageCount unmap(MachinePageCount targetPages) override;
+
   void freeBytes(void* p, uint64_t bytes) noexcept override;
 
   /// Checks internal consistency of allocation data structures. Returns true if
@@ -360,7 +362,7 @@ class MmapAllocator : public MemoryAllocator {
 
   // Frees 'allocation and returns the number of freed pages. Does not
   // update 'numAllocated'.
-  MachinePageCount freeInternal(Allocation& allocation);
+  MachinePageCount freeNonContiguousInternal(Allocation& allocation);
 
   void markAllMapped(const Allocation& allocation);
 


### PR DESCRIPTION
Velox tracks all the memory usage inside velox and makes sure its rss is within
the configured limit. So when a query system uses velox, we ensure the velox
memory usage is within the limit. However, there is non-velox memory usage
in query system like Prestissimo, the memory usage from http-based streaming
shuffle and remote storage access is not tracked by velox. Prestissimo and velox
has mechanism built to throttle or limit those non-velox memory usage but it is
not sufficient to handle the memory usage spike from those components, and 
if there is any regression in those components, we might run into sever out of
memory issue. It might be good for Velox to provide a way to free up unused Velox
memory to mitigate this problem in production. Whenever, query system like
Prestissimo detects server low memory condition, it can put the server in a pushback
state and calls into Velox to free up unused memory. In Meta internal production
cluster, we have seen most of memory is used by cache which is freeable.

Given that, this PR adds to support cache shrink to allow query system using velox to
shrink cache space to get out of server low memory condition. The cache shrink
is different than the regular cache eviction triggered by memory allocation retry: (1) it
does fast evictions on unreferenced cache space without triggering ssd save; (2) it
unmapped the freed cache space to returns those physical pages back to operating
system. This PR also include a couple small fixes in stats collection and memory free up.