### PR TITLE
Add multiply function for IntervalDayTime type

### DIFF
--- a/velox/docs/functions/presto/datetime.rst
+++ b/velox/docs/functions/presto/datetime.rst
@@ -1,6 +1,45 @@
 =====================================
-Date and Time Functions
+Date and Time Functions and Operators
 =====================================
+
+Date and Time Operators
+-----------------------
+
+.. list-table::
+   :widths: 15 60 25
+   :header-rows: 1
+
+   * - Operator
+     - Example
+     - Result
+   * - ``*``
+     - ``interval '1' second * 2``
+     - ``0 00:00:02.000``
+   * - ``*``
+     - ``2 * interval '1' second``
+     - ``0 00:00:02.000``
+   * - ``*``
+     - ``interval '1' second * 0.001``
+     - ``0 00:00:00.001``
+   * - ``*``
+     - ``0.001 * interval '1' second``
+     - ``0 00:00:00.001``
+
+.. function:: multiply(interval day to second, x) -> interval day to second
+
+    Returns the result of multiplying ``interval day to second`` by ``x``.
+    ``x`` can be a bigint or double. Returns ``0`` when ``x`` is NaN. Returns
+    ``106751991167 07:12:55.807`` when ``x`` is infinity or when the
+    multiplication overflow in positive. Returns ``-106751991167 07:12:55.808``
+    when ``x`` is -infinity or when the multiplication overflow in negiative.
+
+.. function:: multiply(x, interval day to second) -> interval day to second
+
+    Returns the result of multiplying ``x`` by ``interval day to second``.
+    Same as ``multiply(interval day to second, x)``.
+
+Date and Time Functions
+-----------------------
 
 .. function:: current_date() -> date
 

--- a/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
@@ -27,6 +27,20 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerBinaryFloatingPoint<PlusFunction>({prefix + "plus"});
   registerBinaryFloatingPoint<MinusFunction>({prefix + "minus"});
   registerBinaryFloatingPoint<MultiplyFunction>({prefix + "multiply"});
+  registerFunction<MultiplyFunction, IntervalDayTime, IntervalDayTime, int64_t>(
+      {prefix + "multiply"});
+  registerFunction<MultiplyFunction, IntervalDayTime, int64_t, IntervalDayTime>(
+      {prefix + "multiply"});
+  registerFunction<
+      IntervalMultiplyFunction,
+      IntervalDayTime,
+      IntervalDayTime,
+      double>({prefix + "multiply"});
+  registerFunction<
+      IntervalMultiplyFunction,
+      IntervalDayTime,
+      double,
+      IntervalDayTime>({prefix + "multiply"});
   registerBinaryFloatingPoint<DivideFunction>({prefix + "divide"});
   registerBinaryFloatingPoint<ModulusFunction>({prefix + "mod"});
   registerUnaryNumeric<CeilFunction>({prefix + "ceil", prefix + "ceiling"});


### PR DESCRIPTION
Summary:
This diff adds the following functions:
multiply(IntervalDayTime, Bigint),
multiply(Bigint, IntervalDayTime),
multiply(IntervalDayTime, double),
multiply(double, IntervalDayTime).

This is the first diff to fix https://github.com/facebookincubator/velox/issues/7490.

Differential Revision: D51224979


