### PR TITLE
Add plus and minus function for InvervalDayTime type

### DIFF
--- a/velox/docs/functions/presto/datetime.rst
+++ b/velox/docs/functions/presto/datetime.rst
@@ -12,6 +12,12 @@ Date and Time Operators
    * - Operator
      - Example
      - Result
+   * - ``+``
+     - ``interval '1' second + interval '1' hour``
+     - ``0 01:00:01.000``
+   * - ``-``
+     - ``interval '1' hour - interval '1' second``
+     - ``0 00:59:59.000``
    * - ``*``
      - ``interval '1' second * 2``
      - ``0 00:00:02.000``
@@ -27,6 +33,20 @@ Date and Time Operators
    * - ``/``
      - ``interval '15' second / 1.5``
      - ``0 00:00:10.000``
+
+.. function:: plus(x, y) -> [same as x]
+
+    Returns the sum of ``x`` and ``y``. ``x`` and ``y`` are both intervals day
+    to second. Returns ``-106751991167 07:12:55.808`` when the addition
+    overflows in positive. Returns ``106751991167 07:12:55.807`` when the
+    addition overflows in negative.
+
+.. function:: minus(x, y) -> [same as x]
+
+    Returns the result of subtracting ``y`` from ``x``. ``x`` and ``y`` are
+    both intervals day to second. Returns ``-106751991167 07:12:55.808`` when
+    the subtraction overflows in positive. Returns ``106751991167 07:12:55.807``
+    when the subtraction overflows in negative.
 
 .. function:: multiply(interval day to second, x) -> interval day to second
 

--- a/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
@@ -25,7 +25,17 @@ namespace facebook::velox::functions {
 namespace {
 void registerSimpleFunctions(const std::string& prefix) {
   registerBinaryFloatingPoint<PlusFunction>({prefix + "plus"});
+  registerFunction<
+      PlusFunction,
+      IntervalDayTime,
+      IntervalDayTime,
+      IntervalDayTime>({prefix + "plus"});
   registerBinaryFloatingPoint<MinusFunction>({prefix + "minus"});
+  registerFunction<
+      MinusFunction,
+      IntervalDayTime,
+      IntervalDayTime,
+      IntervalDayTime>({prefix + "minus"});
   registerBinaryFloatingPoint<MultiplyFunction>({prefix + "multiply"});
   registerFunction<MultiplyFunction, IntervalDayTime, IntervalDayTime, int64_t>(
       {prefix + "multiply"});

--- a/velox/functions/prestosql/tests/ArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/ArithmeticTest.cpp
@@ -92,6 +92,30 @@ class ArithmeticTest : public functions::test::FunctionBaseTest {
   }
 };
 
+TEST_F(ArithmeticTest, plus) {
+  // Test plus for intervals.
+  auto op1 = makeNullableFlatVector<int64_t>(
+      {-1, 2, -3, 4, kLongMax, -1, std::nullopt, 0}, INTERVAL_DAY_TIME());
+  auto op2 = makeNullableFlatVector<int64_t>(
+      {2, -3, -1, 1, 1, kLongMin, 0, std::nullopt}, INTERVAL_DAY_TIME());
+  auto expected = makeNullableFlatVector<int64_t>(
+      {1, -1, -4, 5, kLongMin, kLongMax, std::nullopt, std::nullopt},
+      INTERVAL_DAY_TIME());
+  assertExpression("c0 + c1", op1, op2, expected);
+}
+
+TEST_F(ArithmeticTest, minus) {
+  // Test plus for intervals.
+  auto op1 = makeNullableFlatVector<int64_t>(
+      {-1, 2, -3, 4, kLongMin, -1, std::nullopt, 0}, INTERVAL_DAY_TIME());
+  auto op2 = makeNullableFlatVector<int64_t>(
+      {2, 3, -4, 1, 1, kLongMax, 0, std::nullopt}, INTERVAL_DAY_TIME());
+  auto expected = makeNullableFlatVector<int64_t>(
+      {-3, -1, 1, 3, kLongMax, kLongMin, std::nullopt, std::nullopt},
+      INTERVAL_DAY_TIME());
+  assertExpression("c0 - c1", op1, op2, expected);
+}
+
 TEST_F(ArithmeticTest, divide)
 #if defined(__has_feature)
 #if __has_feature(__address_sanitizer__)


### PR DESCRIPTION
Summary:
Add plus(interval, interval) and minus(interval, interval) functions with unit tests.

This is the third diff to fix https://github.com/facebookincubator/velox/issues/7490

Differential Revision: D51279587


