### PR TITLE
Remove spill write buffer

### DIFF
--- a/velox/common/config/SpillConfig.cpp
+++ b/velox/common/config/SpillConfig.cpp
@@ -20,7 +20,6 @@ namespace facebook::velox::common {
 SpillConfig::SpillConfig(
     const std::string& _filePath,
     uint64_t _maxFileSize,
-    uint64_t _writeBufferSize,
     uint64_t _minSpillRunSize,
     folly::Executor* _executor,
     int32_t _minSpillableReservationPct,
@@ -35,7 +34,6 @@ SpillConfig::SpillConfig(
       maxFileSize(
           _maxFileSize == 0 ? std::numeric_limits<int64_t>::max()
                             : _maxFileSize),
-      writeBufferSize(_writeBufferSize),
       minSpillRunSize(_minSpillRunSize),
       executor(_executor),
       minSpillableReservationPct(_minSpillableReservationPct),

--- a/velox/common/config/SpillConfig.h
+++ b/velox/common/config/SpillConfig.h
@@ -26,7 +26,6 @@ struct SpillConfig {
   SpillConfig(
       const std::string& _filePath,
       uint64_t _maxFileSize,
-      uint64_t _writeBufferSize,
       uint64_t _minSpillRunSize,
       folly::Executor* _executor,
       int32_t _minSpillableReservationPct,
@@ -54,10 +53,6 @@ struct SpillConfig {
   /// The max spill file size. If it is zero, there is no limit on the spill
   /// file size.
   uint64_t maxFileSize;
-
-  /// Specifies the size to buffer the serialized spill data before write to
-  /// storage system for io efficiency.
-  uint64_t writeBufferSize;
 
   /// The min spill run size (bytes) limit used to select partitions for
   /// spilling. The spiller tries to spill a previously spilled partitions if

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -135,7 +135,6 @@ std::optional<common::SpillConfig> DriverCtx::makeSpillConfig(
       makeOperatorSpillPath(
           task->spillDirectory(), pipelineId, driverId, operatorId),
       queryConfig.maxSpillFileSize(),
-      queryConfig.spillWriteBufferSize(),
       queryConfig.minSpillRunSize(),
       task->queryCtx()->spillExecutor(),
       queryConfig.minSpillableReservationPct(),

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -970,7 +970,6 @@ void GroupingSet::spill() {
         rows->keyTypes().size(),
         std::vector<CompareFlags>(),
         spillConfig_->filePath,
-        spillConfig_->writeBufferSize,
         spillConfig_->compressionKind,
         memory::spillMemoryPool(),
         spillConfig_->executor);
@@ -994,7 +993,6 @@ void GroupingSet::spill(const RowContainerIterator& rowIterator) {
       rows,
       makeSpillType(),
       spillConfig_->filePath,
-      spillConfig_->writeBufferSize,
       spillConfig_->compressionKind,
       memory::spillMemoryPool(),
       spillConfig_->executor);

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -235,7 +235,6 @@ void HashBuild::setupSpiller(SpillPartition* spillPartition) {
       std::move(hashBits),
       spillConfig.filePath,
       spillConfig.maxFileSize,
-      spillConfig.writeBufferSize,
       spillConfig.compressionKind,
       memory::spillMemoryPool(),
       spillConfig.executor);

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -256,7 +256,6 @@ void HashProbe::maybeSetupSpillInput(
               spillConfig.joinPartitionBits),
       spillConfig.filePath,
       spillConfig.maxFileSize,
-      spillConfig.writeBufferSize,
       spillConfig.compressionKind,
       memory::spillMemoryPool(),
       spillConfig.executor);

--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -393,7 +393,6 @@ void RowNumber::setupHashTableSpiller() {
       std::move(hashBits),
       spillConfig.filePath,
       spillConfig.maxFileSize,
-      spillConfig.writeBufferSize,
       spillConfig.compressionKind,
       memory::spillMemoryPool(),
       spillConfig.executor);
@@ -410,7 +409,6 @@ void RowNumber::setupInputSpiller() {
       hashBits,
       spillConfig.filePath,
       spillConfig.maxFileSize,
-      spillConfig.writeBufferSize,
       spillConfig.compressionKind,
       memory::spillMemoryPool(),
       spillConfig.executor);

--- a/velox/exec/SortBuffer.cpp
+++ b/velox/exec/SortBuffer.cpp
@@ -184,7 +184,6 @@ void SortBuffer::spill() {
         data_->keyTypes().size(),
         sortCompareFlags_,
         spillConfig_->filePath,
-        spillConfig_->writeBufferSize,
         spillConfig_->compressionKind,
         memory::spillMemoryPool(),
         spillConfig_->executor);

--- a/velox/exec/SortWindowBuild.cpp
+++ b/velox/exec/SortWindowBuild.cpp
@@ -140,7 +140,6 @@ void SortWindowBuild::setupSpiller() {
       spillCompareFlags_.size(),
       spillCompareFlags_,
       spillConfig_->filePath,
-      spillConfig_->writeBufferSize,
       spillConfig_->compressionKind,
       memory::spillMemoryPool(),
       spillConfig_->executor);

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -238,14 +238,13 @@ class SpillFileList {
   /// buffering and constructing the result data read from 'this'.
   ///
   /// When writing sorted spill runs, the caller is responsible for buffering
-  /// and sorting the data. write is called multiple times, followed by flush().
+  /// and sorting the data.
   SpillFileList(
       const RowTypePtr& type,
       int32_t numSortingKeys,
       const std::vector<CompareFlags>& sortCompareFlags,
       const std::string& path,
       uint64_t targetFileSize,
-      uint64_t writeBufferSize,
       common::CompressionKind compressionKind,
       memory::MemoryPool* pool,
       folly::Synchronized<SpillStats>* stats);
@@ -264,7 +263,7 @@ class SpillFileList {
   void finishFile();
 
   SpillFiles files() {
-    VELOX_CHECK(!files_.empty() || (batch_ != nullptr));
+    VELOX_CHECK(!files_.empty());
     finishFile();
     return std::move(files_);
   }
@@ -276,10 +275,6 @@ class SpillFileList {
  private:
   // Returns the current file to write to and creates one if needed.
   WriteFile& currentOutput();
-
-  // Writes data from 'batch_' to the current output file. Returns the actual
-  // written size.
-  uint64_t flush();
 
   // Invoked to update the number of spilled rows.
   void updateAppendStats(uint64_t numRows, uint64_t serializationTimeUs);
@@ -297,12 +292,10 @@ class SpillFileList {
   const std::vector<CompareFlags> sortCompareFlags_;
   const std::string path_;
   const uint64_t targetFileSize_;
-  const uint64_t writeBufferSize_;
   const common::CompressionKind compressionKind_;
   memory::MemoryPool* const pool_;
   folly::Synchronized<SpillStats>* const stats_;
   uint32_t nextFileId_{0};
-  std::unique_ptr<VectorStreamGroup> batch_;
   SpillFiles files_;
 };
 
@@ -604,7 +597,6 @@ class SpillState {
       int32_t numSortingKeys,
       const std::vector<CompareFlags>& sortCompareFlags,
       uint64_t targetFileSize,
-      uint64_t writeBufferSize,
       common::CompressionKind compressionKind,
       memory::MemoryPool* pool,
       folly::Synchronized<SpillStats>* stats);
@@ -695,7 +687,6 @@ class SpillState {
   const int32_t numSortingKeys_;
   const std::vector<CompareFlags> sortCompareFlags_;
   const uint64_t targetFileSize_;
-  const uint64_t writeBufferSize_;
   const common::CompressionKind compressionKind_;
   memory::MemoryPool* const pool_;
   folly::Synchronized<SpillStats>* const stats_;

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -41,7 +41,6 @@ Spiller::Spiller(
     int32_t numSortingKeys,
     const std::vector<CompareFlags>& sortCompareFlags,
     const std::string& path,
-    uint64_t writeBufferSize,
     common::CompressionKind compressionKind,
     memory::MemoryPool* pool,
     folly::Executor* executor)
@@ -54,7 +53,6 @@ Spiller::Spiller(
           sortCompareFlags,
           path,
           std::numeric_limits<uint64_t>::max(),
-          writeBufferSize,
           compressionKind,
           pool,
           executor) {
@@ -71,7 +69,6 @@ Spiller::Spiller(
     RowContainer* container,
     RowTypePtr rowType,
     const std::string& path,
-    uint64_t writeBufferSize,
     common::CompressionKind compressionKind,
     memory::MemoryPool* pool,
     folly::Executor* executor)
@@ -84,7 +81,6 @@ Spiller::Spiller(
           {},
           path,
           std::numeric_limits<uint64_t>::max(),
-          writeBufferSize,
           compressionKind,
           pool,
           executor) {
@@ -103,7 +99,6 @@ Spiller::Spiller(
     HashBitRange bits,
     const std::string& path,
     uint64_t targetFileSize,
-    uint64_t writeBufferSize,
     common::CompressionKind compressionKind,
     memory::MemoryPool* pool,
     folly::Executor* executor)
@@ -116,7 +111,6 @@ Spiller::Spiller(
           {},
           path,
           targetFileSize,
-          writeBufferSize,
           compressionKind,
           pool,
           executor) {
@@ -134,7 +128,6 @@ Spiller::Spiller(
     HashBitRange bits,
     const std::string& path,
     uint64_t targetFileSize,
-    uint64_t writeBufferSize,
     common::CompressionKind compressionKind,
     memory::MemoryPool* pool,
     folly::Executor* executor)
@@ -147,7 +140,6 @@ Spiller::Spiller(
           {},
           path,
           targetFileSize,
-          writeBufferSize,
           compressionKind,
           pool,
           executor) {
@@ -167,7 +159,6 @@ Spiller::Spiller(
     const std::vector<CompareFlags>& sortCompareFlags,
     const std::string& path,
     uint64_t targetFileSize,
-    uint64_t writeBufferSize,
     common::CompressionKind compressionKind,
     memory::MemoryPool* pool,
     folly::Executor* executor)
@@ -183,7 +174,6 @@ Spiller::Spiller(
           numSortingKeys,
           sortCompareFlags,
           targetFileSize,
-          writeBufferSize,
           compressionKind,
           pool_,
           &stats_) {

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -52,7 +52,6 @@ class Spiller {
       int32_t numSortingKeys,
       const std::vector<CompareFlags>& sortCompareFlags,
       const std::string& path,
-      uint64_t writeBufferSize,
       common::CompressionKind compressionKind,
       memory::MemoryPool* pool,
       folly::Executor* executor);
@@ -62,7 +61,6 @@ class Spiller {
       RowContainer* container,
       RowTypePtr rowType,
       const std::string& path,
-      uint64_t writeBufferSize,
       common::CompressionKind compressionKind,
       memory::MemoryPool* pool,
       folly::Executor* executor);
@@ -73,7 +71,6 @@ class Spiller {
       HashBitRange bits,
       const std::string& path,
       uint64_t targetFileSize,
-      uint64_t writeBufferSize,
       common::CompressionKind compressionKind,
       memory::MemoryPool* pool,
       folly::Executor* executor);
@@ -85,7 +82,6 @@ class Spiller {
       HashBitRange bits,
       const std::string& path,
       uint64_t targetFileSize,
-      uint64_t writeBufferSize,
       common::CompressionKind compressionKind,
       memory::MemoryPool* pool,
       folly::Executor* executor);
@@ -191,7 +187,6 @@ class Spiller {
       const std::vector<CompareFlags>& sortCompareFlags,
       const std::string& path,
       uint64_t targetFileSize,
-      uint64_t writeBufferSize,
       common::CompressionKind compressionKind,
       memory::MemoryPool* pool,
       folly::Executor* executor);

--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -740,7 +740,6 @@ void TopNRowNumber::setupSpiller() {
       spillCompareFlags_.size(),
       spillCompareFlags_,
       spillConfig_->filePath,
-      spillConfig_->writeBufferSize,
       spillConfig_->compressionKind,
       memory::spillMemoryPool(),
       spillConfig_->executor);

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -90,7 +90,6 @@ class SpillTest : public ::testing::TestWithParam<common::CompressionKind>,
 
   void setupSpillState(
       int64_t targetFileSize,
-      uint64_t writeBufferSize,
       int numPartitions,
       int numBatches,
       int numRowsPerBatch = 1000,
@@ -157,7 +156,6 @@ class SpillTest : public ::testing::TestWithParam<common::CompressionKind>,
         1,
         compareFlags,
         targetFileSize,
-        writeBufferSize,
         compressionKind_,
         pool(),
         &stats_);
@@ -261,7 +259,6 @@ class SpillTest : public ::testing::TestWithParam<common::CompressionKind>,
     const auto prevGStats = globalSpillStats();
     setupSpillState(
         targetFileSize,
-        0,
         numPartitions,
         numBatches,
         numRowsPerBatch,
@@ -445,7 +442,6 @@ TEST_P(SpillTest, spillTimestamp) {
       1,
       emptyCompareFlags,
       1024,
-      0,
       compressionKind_,
       pool(),
       &stats_);


### PR DESCRIPTION
Spill write buffer provides a middle layer buffer, in between application and file levels. Meta internal file system has a well built buffering mechanism already, and so should other file systems. The buffering should be the responsibility of file system rather than spiller. Hence this feature is removed in this PR.