### PR TITLE
Add date_format Spark function

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -31,8 +31,9 @@ These functions support TIMESTAMP and DATE input types.
 
 .. spark:function:: date_format(timestamp, format) -> string
 
-    Converts ``timestamp`` to a date/time string in the format specified by ``format``.
-    The result needs to be adjusted according to local time zone.
+    Converts ``timestamp`` to a date/time string (local timezone adjusted) in the format specified by
+    ``format``, such as yyyy-MM-dd HH:mm:ss, yyyy-MM-dd, etc. Invalid ``format`` will cause exception
+    at runtime. ::
 
         SELECT date_format('2016-04-08', 'y'); -- '2016'
         SELECT date_format('2020-08-21 12:21:50', 'yyyy-MM-dd HH:mm:ss'); -- '2020-08-21 12:21:50'

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -31,9 +31,11 @@ These functions support TIMESTAMP and DATE input types.
 
 .. spark:function:: date_format(timestamp, format) -> string
 
-    Converts ``timestamp`` to a date/time string (local timezone adjusted) in the format specified by
-    ``format``, such as yyyy-MM-dd HH:mm:ss, yyyy-MM-dd, etc. Invalid ``format`` will cause exception
-    at runtime. ::
+    Adjusts ``timestamp`` to configured session timezone, then converts it to a formatted time string
+    according to ``format``.
+    `Valid patterns for date format
+    <https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html>`_. Invalid ``format`` will
+    cause an exception at runtime. ::
 
         SELECT date_format('2016-04-08', 'y'); -- '2016'
         SELECT date_format('2020-08-21 12:21:50', 'yyyy-MM-dd HH:mm:ss'); -- '2020-08-21 12:21:50'

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -29,13 +29,15 @@ These functions support TIMESTAMP and DATE input types.
     If num_days is a negative value then these amount of days will be
     deducted from start_date.
 
-.. spark:function:: datediff(endDate, startDate) -> integer
+.. spark:function:: date_format(timestamp, format) -> string
 
-    Returns the number of days from startDate to endDate. Only DATE type is allowed
-    for input. ::
+    Converts ``timestamp`` to a date/time string in the format specified by ``format``.
+    The result needs to be adjusted according to local time zone.
 
-        SELECT datediff('2009-07-31', '2009-07-30'); -- 1
-        SELECT datediff('2009-07-30', '2009-07-31'); -- -1
+        SELECT date_format('2016-04-08', 'y'); -- '2016'
+        SELECT date_format('2020-08-21 12:21:50', 'yyyy-MM-dd HH:mm:ss'); -- '2020-08-21 12:21:50'
+        SELECT date_format('2020-08-21 12:21:50', 'yyyy-MM-dd'); -- '2020-08-21'
+        SELECT date_format('2020-08-21', 'yyyy-MM-dd HH:mm:ss'); -- '2020-08-21 00:00:00'
 
 .. spark:function:: date_sub(start_date, num_days) -> date
 
@@ -45,6 +47,14 @@ These functions support TIMESTAMP and DATE input types.
     and date_sub('2023-07-10', -2147483648) get -5877588-12-29.
 
     num_days can be positive or negative.
+
+.. spark:function:: datediff(endDate, startDate) -> integer
+
+    Returns the number of days from startDate to endDate. Only DATE type is allowed
+    for input. ::
+
+        SELECT datediff('2009-07-31', '2009-07-30'); -- 1
+        SELECT datediff('2009-07-30', '2009-07-31'); -- -1
 
 .. spark:function:: dayofmonth(date) -> integer
 

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -413,18 +413,6 @@ template <typename T>
 struct DateFormatFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  const date::time_zone* sessionTimeZone_ = nullptr;
-  std::shared_ptr<DateTimeFormatter> formatter_;
-  bool isConstFormat_ = false;
-
-  FOLLY_ALWAYS_INLINE void setFormatter(const arg_type<Varchar>* formatString) {
-    if (formatString != nullptr) {
-      formatter_ = buildJodaDateTimeFormatter(
-          std::string_view(formatString->data(), formatString->size()));
-      isConstFormat_ = true;
-    }
-  }
-
   FOLLY_ALWAYS_INLINE void initialize(
       const core::QueryConfig& config,
       const arg_type<Timestamp>* /*timestamp*/,
@@ -449,6 +437,19 @@ struct DateFormatFunction {
       std::memcpy(result.data(), formattedResult.data(), resultSize);
     }
   }
+
+ private:
+  FOLLY_ALWAYS_INLINE void setFormatter(const arg_type<Varchar>* formatString) {
+    if (formatString != nullptr) {
+      formatter_ = buildJodaDateTimeFormatter(
+          std::string_view(formatString->data(), formatString->size()));
+      isConstFormat_ = true;
+    }
+  }
+
+  const date::time_zone* sessionTimeZone_{nullptr};
+  std::shared_ptr<DateTimeFormatter> formatter_;
+  bool isConstFormat_{false};
 };
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -244,6 +244,8 @@ void registerFunctions(const std::string& prefix) {
       {prefix + "make_date"});
   registerFunction<DateDiffFunction, int32_t, Date, Date>(
       {prefix + "datediff"});
+  registerFunction<DateFormatFunction, Varchar, Timestamp, Varchar>(
+      {"date_format"});
   registerFunction<LastDayFunction, Date, Date>({prefix + "last_day"});
   registerFunction<AddMonthsFunction, Date, Date, int32_t>(
       {prefix + "add_months"});

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -458,55 +458,49 @@ TEST_F(DateTimeFunctionsTest, quarterDate) {
 }
 
 TEST_F(DateTimeFunctionsTest, dateFormat) {
-  const auto dateFormat = [&](std::optional<Timestamp> timestamp,
-                              const std::string& formatString) {
+  const auto dateFormat = [&](const StringView& timestampString,
+                              const StringView& formatString) {
+    std::optional<Timestamp> timestamp =
+        util::fromTimestampString(timestampString);
     return evaluateOnce<std::string>(
         fmt::format("date_format(c0, '{}')", formatString), timestamp);
   };
-  using util::fromTimestampString;
 
-  EXPECT_EQ("1969", dateFormat(fromTimestampString("1969-12-31"), "y"));
-  EXPECT_EQ("1970", dateFormat(fromTimestampString("1970-01-01"), "y"));
-  EXPECT_EQ("2020", dateFormat(fromTimestampString("2020-08-21"), "y"));
-  EXPECT_EQ("8", dateFormat(fromTimestampString("2020-08-21"), "M"));
-  EXPECT_EQ("08", dateFormat(fromTimestampString("2020-08-21"), "MM"));
-  EXPECT_EQ("08-21", dateFormat(fromTimestampString("2020-08-21"), "MM-dd"));
+  EXPECT_EQ("1969", dateFormat("1969-12-31", "y"));
+  EXPECT_EQ("1970", dateFormat("1970-01-01", "y"));
+  EXPECT_EQ("2020", dateFormat("2020-08-21", "y"));
+  EXPECT_EQ("8", dateFormat("2020-08-21", "M"));
+  EXPECT_EQ("08", dateFormat("2020-08-21", "MM"));
+  EXPECT_EQ("08-21", dateFormat("2020-08-21", "MM-dd"));
+  EXPECT_EQ("08/21/2020", dateFormat("2020-08-21", "MM/dd/yyyy"));
+  EXPECT_EQ("2020-08-21", dateFormat("2020-08-21 12:21:50", "yyyy-MM-dd"));
   EXPECT_EQ(
-      "08/21/2020",
-      dateFormat(fromTimestampString("2020-08-21"), "MM/dd/yyyy"));
-  EXPECT_EQ(
-      "2020-08-21",
-      dateFormat(fromTimestampString("2020-08-21 12:21:50"), "yyyy-MM-dd"));
-  EXPECT_EQ(
-      "2020-08-21 00:00:00",
-      dateFormat(fromTimestampString("2020-08-21"), "yyyy-MM-dd HH:mm:ss"));
+      "2020-08-21 00:00:00", dateFormat("2020-08-21", "yyyy-MM-dd HH:mm:ss"));
   EXPECT_EQ(
       "2020-08-21 12:31:50",
-      dateFormat(
-          fromTimestampString("2020-08-21 12:31:50"), "yyyy-MM-dd HH:mm:ss"));
+      dateFormat("2020-08-21 12:31:50", "yyyy-MM-dd HH:mm:ss"));
   EXPECT_EQ(
       "2020-08-21 12:31",
-      dateFormat(
-          fromTimestampString("2020-08-21 12:31:50"), "yyyy-MM-dd HH:mm"));
-  EXPECT_EQ(
-      "1969-12-31",
-      dateFormat(fromTimestampString("1969-12-31 23:59:59"), "yyyy-MM-dd"));
+      dateFormat("2020-08-21 12:31:50", "yyyy-MM-dd HH:mm"));
+  EXPECT_EQ("1969-12-31", dateFormat("1969-12-31 23:59:59", "yyyy-MM-dd"));
 
   // 8 hours ahead of UTC.
   setQueryTimeZone("Asia/Shanghai");
   EXPECT_EQ(
-      "2020-08-21 08:00:00",
-      dateFormat(fromTimestampString("2020-08-21"), "yyyy-MM-dd HH:mm:ss"));
+      "2020-08-21 08:00:00", dateFormat("2020-08-21", "yyyy-MM-dd HH:mm:ss"));
   EXPECT_EQ(
       "2020-08-22 07:00:00",
-      dateFormat(
-          fromTimestampString("2020-08-21 23:00:00"), "yyyy-MM-dd HH:mm:ss"));
-  EXPECT_EQ(
-      "1970-01-01",
-      dateFormat(fromTimestampString("1969-12-31 23:59:59"), "yyyy-MM-dd"));
+      dateFormat("2020-08-21 23:00:00", "yyyy-MM-dd HH:mm:ss"));
+  EXPECT_EQ("1970-01-01", dateFormat("1969-12-31 23:59:59", "yyyy-MM-dd"));
 
   // Invalid format.
-  EXPECT_THROW(dateFormat(Timestamp(0, 0), "ABC"), VeloxUserError);
+  VELOX_ASSERT_THROW(
+      dateFormat("2022-10-10", "yyyy-AA"), "Specifier A is not supported.");
+  VELOX_ASSERT_THROW(
+      dateFormat("2022-10-10", "FF/MM/dd"), "Specifier F is not supported");
+  VELOX_ASSERT_THROW(
+      dateFormat("2022-10-10", "yyyy-MM-dd HH:II"),
+      "Specifier I is not supported");
 }
 
 } // namespace

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -504,6 +504,9 @@ TEST_F(DateTimeFunctionsTest, dateFormat) {
   EXPECT_EQ(
       "1970-01-01",
       dateFormat(fromTimestampString("1969-12-31 23:59:59"), "yyyy-MM-dd"));
+
+  // Invalid format.
+  EXPECT_THROW(dateFormat(Timestamp(0, 0), "ABC"), VeloxUserError);
 }
 
 } // namespace

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+#include "velox/type/TimestampConversion.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox::functions::sparksql::test {
@@ -454,6 +455,17 @@ TEST_F(DateTimeFunctionsTest, quarterDate) {
   EXPECT_EQ(4, quarter("2013-11-08"));
   EXPECT_EQ(1, quarter("1987-01-08"));
   EXPECT_EQ(3, quarter("1954-08-08"));
+}
+
+TEST_F(DateTimeFunctionsTest, dateFormat) {
+  const auto dateFormat = [&](std::optional<Timestamp> timestamp,
+                              const std::string& formatString) {
+    return evaluateOnce<std::string>(
+        fmt::format("date_format(c0, '{}')", formatString), timestamp);
+  };
+  using util::fromTimestampString;
+
+  EXPECT_EQ("1970", dateFormat(fromTimestampString("1970-01-01"), "y"));
 }
 
 } // namespace

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -465,7 +465,45 @@ TEST_F(DateTimeFunctionsTest, dateFormat) {
   };
   using util::fromTimestampString;
 
+  EXPECT_EQ("1969", dateFormat(fromTimestampString("1969-12-31"), "y"));
   EXPECT_EQ("1970", dateFormat(fromTimestampString("1970-01-01"), "y"));
+  EXPECT_EQ("2020", dateFormat(fromTimestampString("2020-08-21"), "y"));
+  EXPECT_EQ("8", dateFormat(fromTimestampString("2020-08-21"), "M"));
+  EXPECT_EQ("08", dateFormat(fromTimestampString("2020-08-21"), "MM"));
+  EXPECT_EQ("08-21", dateFormat(fromTimestampString("2020-08-21"), "MM-dd"));
+  EXPECT_EQ(
+      "08/21/2020",
+      dateFormat(fromTimestampString("2020-08-21"), "MM/dd/yyyy"));
+  EXPECT_EQ(
+      "2020-08-21",
+      dateFormat(fromTimestampString("2020-08-21 12:21:50"), "yyyy-MM-dd"));
+  EXPECT_EQ(
+      "2020-08-21 00:00:00",
+      dateFormat(fromTimestampString("2020-08-21"), "yyyy-MM-dd HH:mm:ss"));
+  EXPECT_EQ(
+      "2020-08-21 12:31:50",
+      dateFormat(
+          fromTimestampString("2020-08-21 12:31:50"), "yyyy-MM-dd HH:mm:ss"));
+  EXPECT_EQ(
+      "2020-08-21 12:31",
+      dateFormat(
+          fromTimestampString("2020-08-21 12:31:50"), "yyyy-MM-dd HH:mm"));
+  EXPECT_EQ(
+      "1969-12-31",
+      dateFormat(fromTimestampString("1969-12-31 23:59:59"), "yyyy-MM-dd"));
+
+  // 8 hours ahead of UTC.
+  setQueryTimeZone("Asia/Shanghai");
+  EXPECT_EQ(
+      "2020-08-21 08:00:00",
+      dateFormat(fromTimestampString("2020-08-21"), "yyyy-MM-dd HH:mm:ss"));
+  EXPECT_EQ(
+      "2020-08-22 07:00:00",
+      dateFormat(
+          fromTimestampString("2020-08-21 23:00:00"), "yyyy-MM-dd HH:mm:ss"));
+  EXPECT_EQ(
+      "1970-01-01",
+      dateFormat(fromTimestampString("1969-12-31 23:59:59"), "yyyy-MM-dd"));
 }
 
 } // namespace


### PR DESCRIPTION
`date_format(timestamp, fmt)`, which converts `timestamp` to a value of string in the format specified by the date format `fmt`.

This patch is modified based on the existing function for presto (see [link](https://github.com/facebookincubator/velox/blob/main/velox/functions/prestosql/DateTimeFunctions.h#L1076)). The difference is a JodaDateTimeFormatter is built and used to adapt to Spark's semantic.



Spark impl. [link](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala#L916).