### PR TITLE
Fix duplicate root memory pool

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -39,7 +39,7 @@ MemoryManager::MemoryManager(const MemoryManagerOptions& options)
       alignment_(std::max(MemoryAllocator::kMinAlignment, options.alignment)),
       checkUsageLeak_(options.checkUsageLeak),
       debugEnabled_(options.debugEnabled),
-      poolDestructionCb_([&](MemoryPool* pool) { dropPool(pool); }),
+      poolShutdownCb_([&](MemoryPool* pool) { dropPool(pool); }),
       defaultRoot_{std::make_shared<MemoryPoolImpl>(
           this,
           kDefaultRootName.str(),
@@ -127,7 +127,7 @@ std::shared_ptr<MemoryPool> MemoryManager::addRootPool(
       MemoryPool::Kind::kAggregate,
       nullptr,
       std::move(reclaimer),
-      poolDestructionCb_,
+      poolShutdownCb_,
       options);
   pools_.emplace(poolName, pool);
   VELOX_CHECK_EQ(pool->capacity(), 0);

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -224,7 +224,7 @@ class MemoryManager {
   // The destruction callback set for the allocated  root memory pools which are
   // tracked by 'pools_'. It is invoked on the root pool destruction and removes
   // the pool from 'pools_'.
-  const MemoryPoolImpl::DestructionCallback poolDestructionCb_;
+  const MemoryPoolImpl::ShutdownCallback poolShutdownCb_;
 
   const std::shared_ptr<MemoryPool> defaultRoot_;
   std::vector<std::shared_ptr<MemoryPool>> sharedLeafPools_;

--- a/velox/core/QueryCtx.cpp
+++ b/velox/core/QueryCtx.cpp
@@ -69,6 +69,10 @@ QueryCtx::QueryCtx(
   initPool(queryId);
 }
 
+QueryCtx::~QueryCtx() {
+  pool_->shutdown();
+}
+
 /*static*/ std::string QueryCtx::generatePoolName(const std::string& queryId) {
   // We attach a monotonically increasing sequence number to ensure the pool
   // name is unique.

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -66,6 +66,8 @@ class QueryCtx {
       std::shared_ptr<memory::MemoryPool> pool = nullptr,
       const std::string& queryId = "");
 
+  ~QueryCtx();
+
   static std::string generatePoolName(const std::string& queryId);
 
   memory::MemoryPool* pool() const {


### PR DESCRIPTION
Add state to memory pool to track if a memory pool has been shutdown or not.
And provides API to shutdown a memory pool which invokes the shutdown callback
once. The shutdown call is the previous destruction callback registered by the
memory pool user to remove the memory pool from the memory manager. We only
allows to shutdown a memory pool if it has no memory reservations.