### PR TITLE
Enable spilling support for partial aggregation

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -233,8 +233,20 @@ bool AggregationNode::canSpill(const QueryConfig& queryConfig) const {
   }
   // TODO: add spilling for pre-grouped aggregation later:
   // https://github.com/facebookincubator/velox/issues/3264
-  return (isFinal() || isSingle()) && preGroupedKeys().empty() &&
-      queryConfig.aggregationSpillEnabled();
+  if (!preGroupedKeys().empty()) {
+    return false;
+  }
+
+  if ((isFinal() || isSingle()) && queryConfig.aggregationSpillEnabled()) {
+    return true;
+  }
+
+  if ((isIntermediate() || isPartial()) &&
+      queryConfig.partialAggregationSpillEnabled()) {
+    return true;
+  }
+
+  return false;
 }
 
 void AggregationNode::addDetails(std::stringstream& stream) const {

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -620,6 +620,14 @@ class AggregationNode : public PlanNode {
     return step_ == Step::kSingle;
   }
 
+  bool isIntermediate() const {
+    return step_ == Step::kIntermediate;
+  }
+
+  bool isPartial() const {
+    return step_ == Step::kPartial;
+  }
+
   folly::dynamic serialize() const override;
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -201,6 +201,14 @@ class QueryConfig {
   static constexpr const char* kAggregationSpillEnabled =
       "aggregation_spill_enabled";
 
+  /// Partial aggregation spilling flag, only applies if "spill_enabled" flag is
+  /// set.
+  /// If true, partial aggregation flushing will be disabled. Which means,
+  /// settings of kMaxPartialAggregationMemory and
+  /// kMaxExtendedPartialAggregationMemory will be ignored.
+  static constexpr const char* kPartialAggregationSpillEnabled =
+      "partial_aggregation_spill_enabled";
+
   /// Join spilling flag, only applies if "spill_enabled" flag is set.
   static constexpr const char* kJoinSpillEnabled = "join_spill_enabled";
 
@@ -525,9 +533,15 @@ class QueryConfig {
   }
 
   /// Returns 'is aggregation spilling enabled' flag. Must also check the
-  /// spillEnabled()!g
+  /// spillEnabled()!
   bool aggregationSpillEnabled() const {
     return get<bool>(kAggregationSpillEnabled, true);
+  }
+
+  /// Returns 'is partial aggregation spilling enabled' flag. Must also check
+  /// the spillEnabled()!
+  bool partialAggregationSpillEnabled() const {
+    return get<bool>(kPartialAggregationSpillEnabled, false);
   }
 
   /// Returns 'is join spilling enabled' flag. Must also check the

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -215,6 +215,12 @@ Spilling
      - boolean
      - true
      - When `spill_enabled` is true, determines whether HashAggregation operator can spill to disk under memory pressure.
+   * - partial_aggregation_spill_enabled
+     - boolean
+     - false
+     - When `spill_enabled` is true, determines whether the partial phase of HashAggregation operator can spill to disk under memory pressure.
+       Flushing will be disabled so max_partial_aggregation_memory and max_extended_partial_aggregation_memory will be ignored when turning the option on.
+       this option.
    * - join_spill_enabled
      - boolean
      - true

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -219,7 +219,7 @@ Spilling
      - boolean
      - false
      - When `spill_enabled` is true, determines whether the partial phase of HashAggregation operator can spill to disk under memory pressure.
-       Flushing will be disabled so max_partial_aggregation_memory and max_extended_partial_aggregation_memory will be ignored when turning the option on.
+       Flushing will be disabled so max_partial_aggregation_memory and max_extended_partial_aggregation_memory will be ignored when turning this option on.
        this option.
    * - join_spill_enabled
      - boolean

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -219,8 +219,9 @@ Spilling
      - boolean
      - false
      - When `spill_enabled` is true, determines whether the partial phase of HashAggregation operator can spill to disk under memory pressure.
-       Flushing will be disabled so max_partial_aggregation_memory and max_extended_partial_aggregation_memory will be ignored when turning this option on.
-       this option.
+       When true, flushing will be disabled so settings of max_partial_aggregation_memory and max_extended_partial_aggregation_memory will be ignored.
+       Comparing to flushing, enabling spilling would make Velox reduce data size from partial aggregation phase as much as possible however would slow
+       down partial aggregation's own processing.
    * - join_spill_enabled
      - boolean
      - true

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -116,7 +116,7 @@ bool HashAggregation::abandonPartialAggregationEarly(int64_t numOutput) const {
   if (groupingSet_->hasSpilled()) {
     // Once spilling kicked in, disable the abandoning code path.
     // This is because spilled rows did not count to
-    // numOutput yet based on current way of computation.
+    // numOutput yet based on current way of calculation.
     return false;
   }
   return numInputRows_ > abandonPartialAggregationMinRows_ &&

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -115,6 +115,8 @@ bool HashAggregation::abandonPartialAggregationEarly(int64_t numOutput) const {
   VELOX_CHECK(isPartialOutput_ && !isGlobal_);
   if (groupingSet_->hasSpilled()) {
     // Once spilling kicked in, disable the abandoning code path.
+    // This is because spilled rows did not count to
+    // numOutput yet based on current way of computation.
     return false;
   }
   return numInputRows_ > abandonPartialAggregationMinRows_ &&

--- a/velox/exec/fuzzer/AggregationFuzzer.cpp
+++ b/velox/exec/fuzzer/AggregationFuzzer.cpp
@@ -166,6 +166,7 @@ class AggregationFuzzer : public AggregationFuzzerBase {
       testPlan(
           planWithSplits,
           false /*injectSpill*/,
+          false /*injectPartialSpill*/,
           false /*abandonPartial*/,
           customVerification,
           customVerifiers,
@@ -176,6 +177,19 @@ class AggregationFuzzer : public AggregationFuzzerBase {
       testPlan(
           planWithSplits,
           true /*injectSpill*/,
+          false /*injectPartialSpill*/,
+          false /*abandonPartial*/,
+          customVerification,
+          customVerifiers,
+          expected,
+          maxDrivers);
+
+      LOG(INFO) << "Testing plan #" << i
+                << " with partial aggregation spilling";
+      testPlan(
+          planWithSplits,
+          true /*injectSpill*/,
+          true /*injectPartialSpill*/,
           false /*abandonPartial*/,
           customVerification,
           customVerifiers,
@@ -188,6 +202,7 @@ class AggregationFuzzer : public AggregationFuzzerBase {
         testPlan(
             planWithSplits,
             false /*injectSpill*/,
+            false /*injectPartialSpill*/,
             true /*abandonPartial*/,
             customVerification,
             customVerifiers,

--- a/velox/exec/fuzzer/AggregationFuzzerBase.cpp
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.cpp
@@ -359,6 +359,7 @@ velox::test::ResultOrError AggregationFuzzerBase::execute(
     const core::PlanNodePtr& plan,
     const std::vector<exec::Split>& splits,
     bool injectSpill,
+    bool injectPartialSpill,
     bool abandonPartial,
     int32_t maxDrivers) {
   LOG(INFO) << "Executing query plan: " << std::endl
@@ -376,6 +377,14 @@ velox::test::ResultOrError AggregationFuzzerBase::execute(
       builder.spillDirectory(spillDirectory->path)
           .config(core::QueryConfig::kSpillEnabled, "true")
           .config(core::QueryConfig::kAggregationSpillEnabled, "true")
+          .config(core::QueryConfig::kTestingSpillPct, "100");
+    }
+
+    if (injectPartialSpill) {
+      spillDirectory = exec::test::TempDirectoryPath::create();
+      builder.spillDirectory(spillDirectory->path)
+          .config(core::QueryConfig::kSpillEnabled, "true")
+          .config(core::QueryConfig::kPartialAggregationSpillEnabled, "true")
           .config(core::QueryConfig::kTestingSpillPct, "100");
     }
 
@@ -431,6 +440,7 @@ AggregationFuzzerBase::computeReferenceResults(
 void AggregationFuzzerBase::testPlan(
     const PlanWithSplits& planWithSplits,
     bool injectSpill,
+    bool injectPartialSpill,
     bool abandonPartial,
     bool customVerification,
     const std::vector<std::shared_ptr<ResultVerifier>>& customVerifiers,
@@ -440,6 +450,7 @@ void AggregationFuzzerBase::testPlan(
       planWithSplits.plan,
       planWithSplits.splits,
       injectSpill,
+      injectPartialSpill,
       abandonPartial,
       maxDrivers);
 

--- a/velox/exec/fuzzer/AggregationFuzzerBase.cpp
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.cpp
@@ -372,20 +372,18 @@ velox::test::ResultOrError AggregationFuzzerBase::execute(
 
     builder.configs(queryConfigs_);
 
-    if (injectSpill) {
+    if (injectSpill || injectPartialSpill) {
       spillDirectory = exec::test::TempDirectoryPath::create();
       builder.spillDirectory(spillDirectory->path)
           .config(core::QueryConfig::kSpillEnabled, "true")
-          .config(core::QueryConfig::kAggregationSpillEnabled, "true")
           .config(core::QueryConfig::kTestingSpillPct, "100");
-    }
-
-    if (injectPartialSpill) {
-      spillDirectory = exec::test::TempDirectoryPath::create();
-      builder.spillDirectory(spillDirectory->path)
-          .config(core::QueryConfig::kSpillEnabled, "true")
-          .config(core::QueryConfig::kPartialAggregationSpillEnabled, "true")
-          .config(core::QueryConfig::kTestingSpillPct, "100");
+      if (injectSpill) {
+        builder.config(core::QueryConfig::kAggregationSpillEnabled, "true");
+      }
+      if (injectPartialSpill) {
+        builder.config(
+            core::QueryConfig::kPartialAggregationSpillEnabled, "true");
+      }
     }
 
     if (abandonPartial) {

--- a/velox/exec/fuzzer/AggregationFuzzerBase.h
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.h
@@ -190,6 +190,7 @@ class AggregationFuzzerBase {
       const core::PlanNodePtr& plan,
       const std::vector<exec::Split>& splits = {},
       bool injectSpill = false,
+      bool injectPartialSpill = false,
       bool abandonPartial = false,
       int32_t maxDrivers = 2);
 
@@ -201,6 +202,7 @@ class AggregationFuzzerBase {
   void testPlan(
       const PlanWithSplits& planWithSplits,
       bool injectSpill,
+      bool injectPartialSpill,
       bool abandonPartial,
       bool customVerification,
       const std::vector<std::shared_ptr<ResultVerifier>>& customVerifiers,

--- a/velox/exec/tests/SharedArbitratorTest.cpp
+++ b/velox/exec/tests/SharedArbitratorTest.cpp
@@ -1171,7 +1171,7 @@ TEST_F(SharedArbitrationTest, reclaimFromDistinctAggregation) {
   createDuckDbTable(vectors);
   const auto spillDirectory = exec::test::TempDirectoryPath::create();
   core::PlanNodeId aggrNodeId;
-  std::shared_ptr<core::QueryCtx> queryCtx = newQueryCtx(maxQueryCapacity);
+  auto queryCtx = newQueryCtx(maxQueryCapacity);
   auto task = AssertQueryBuilder(duckDbQueryRunner_)
                   .spillDirectory(spillDirectory->path)
                   .config(core::QueryConfig::kSpillEnabled, "true")
@@ -1197,7 +1197,7 @@ TEST_F(SharedArbitrationTest, reclaimFromPartialAggregation) {
   const auto spillDirectory = exec::test::TempDirectoryPath::create();
   core::PlanNodeId partialAggNodeId;
   core::PlanNodeId finalAggNodeId;
-  std::shared_ptr<core::QueryCtx> queryCtx = newQueryCtx(maxQueryCapacity);
+  auto queryCtx = newQueryCtx(maxQueryCapacity);
   auto task =
       AssertQueryBuilder(duckDbQueryRunner_)
           .spillDirectory(spillDirectory->path)
@@ -1243,7 +1243,7 @@ TEST_F(
   const auto spillDirectory = exec::test::TempDirectoryPath::create();
   core::PlanNodeId partialAggNodeId;
   core::PlanNodeId finalAggNodeId;
-  std::shared_ptr<core::QueryCtx> queryCtx = newQueryCtx(maxQueryCapacity);
+  auto queryCtx = newQueryCtx(maxQueryCapacity);
   auto task =
       AssertQueryBuilder(duckDbQueryRunner_)
           .spillDirectory(spillDirectory->path)

--- a/velox/exec/tests/SharedArbitratorTest.cpp
+++ b/velox/exec/tests/SharedArbitratorTest.cpp
@@ -1190,6 +1190,99 @@ TEST_F(SharedArbitrationTest, reclaimFromDistinctAggregation) {
   waitForAllTasksToBeDeleted();
 }
 
+TEST_F(SharedArbitrationTest, reclaimFromPartialAggregation) {
+  const uint64_t maxQueryCapacity = 20L << 20;
+  std::vector<RowVectorPtr> vectors = newVectors(1024, maxQueryCapacity * 2);
+  createDuckDbTable(vectors);
+  const auto spillDirectory = exec::test::TempDirectoryPath::create();
+  core::PlanNodeId partialAggNodeId;
+  core::PlanNodeId finalAggNodeId;
+  std::shared_ptr<core::QueryCtx> queryCtx = newQueryCtx(maxQueryCapacity);
+  auto task =
+      AssertQueryBuilder(duckDbQueryRunner_)
+          .spillDirectory(spillDirectory->path)
+          .config(core::QueryConfig::kSpillEnabled, "true")
+          .config(core::QueryConfig::kPartialAggregationSpillEnabled, "true")
+          .config(core::QueryConfig::kAggregationSpillEnabled, "true")
+          .config(
+              core::QueryConfig::kMaxPartialAggregationMemory,
+              std::to_string(1LL << 30)) // disable flush
+          .config(
+              core::QueryConfig::kMaxExtendedPartialAggregationMemory,
+              std::to_string(1LL << 30)) // disable flush
+          .config(
+              core::QueryConfig::kAbandonPartialAggregationMinPct,
+              "200") // avoid abandoning
+          .config(
+              core::QueryConfig::kAbandonPartialAggregationMinRows,
+              std::to_string(1LL << 30)) // avoid abandoning
+          .queryCtx(queryCtx)
+          .plan(PlanBuilder()
+                    .values(vectors)
+                    .partialAggregation({"c0"}, {"count(1)"})
+                    .capturePlanNodeId(partialAggNodeId)
+                    .finalAggregation()
+                    .capturePlanNodeId(finalAggNodeId)
+                    .planNode())
+          .assertResults("SELECT c0, count(1) FROM tmp GROUP BY c0");
+  auto taskStats = exec::toPlanStats(task->taskStats());
+  auto& partialStats = taskStats.at(partialAggNodeId);
+  auto& finalStats = taskStats.at(finalAggNodeId);
+  ASSERT_GT(partialStats.spilledBytes, 0);
+  ASSERT_GT(finalStats.spilledBytes, 0);
+  task.reset();
+  waitForAllTasksToBeDeleted();
+}
+
+TEST_F(
+    SharedArbitrationTest,
+    reclaimFromPartialAggregationAndIgnoreFlushingSettings) {
+  const uint64_t maxQueryCapacity = 20L << 20;
+  std::vector<RowVectorPtr> vectors = newVectors(1024, maxQueryCapacity * 2);
+  createDuckDbTable(vectors);
+  const auto spillDirectory = exec::test::TempDirectoryPath::create();
+  core::PlanNodeId partialAggNodeId;
+  core::PlanNodeId finalAggNodeId;
+  std::shared_ptr<core::QueryCtx> queryCtx = newQueryCtx(maxQueryCapacity);
+  auto task =
+      AssertQueryBuilder(duckDbQueryRunner_)
+          .spillDirectory(spillDirectory->path)
+          .config(core::QueryConfig::kSpillEnabled, "true")
+          .config(core::QueryConfig::kPartialAggregationSpillEnabled, "true")
+          .config(core::QueryConfig::kAggregationSpillEnabled, "true")
+          .config(
+              core::QueryConfig::kMaxPartialAggregationMemory,
+              std::to_string(1L))
+          .config(
+              core::QueryConfig::kMaxExtendedPartialAggregationMemory,
+              std::to_string(1L))
+          .config(
+              core::QueryConfig::kAbandonPartialAggregationMinPct,
+              "200") // avoid abandoning
+          .config(
+              core::QueryConfig::kAbandonPartialAggregationMinRows,
+              std::to_string(1LL << 30)) // avoid abandoning
+          .queryCtx(queryCtx)
+          .plan(PlanBuilder()
+                    .values(vectors)
+                    .partialAggregation({"c0"}, {"count(1)"})
+                    .capturePlanNodeId(partialAggNodeId)
+                    .finalAggregation()
+                    .capturePlanNodeId(finalAggNodeId)
+                    .planNode())
+          .assertResults("SELECT c0, count(1) FROM tmp GROUP BY c0");
+  auto taskStats = exec::toPlanStats(task->taskStats());
+  auto& partialStats = taskStats.at(partialAggNodeId);
+  auto& finalStats = taskStats.at(finalAggNodeId);
+  ASSERT_EQ(
+      partialStats.customStats.find("flushRowCount"),
+      partialStats.customStats.end());
+  ASSERT_GT(partialStats.spilledBytes, 0);
+  ASSERT_GT(finalStats.spilledBytes, 0);
+  task.reset();
+  waitForAllTasksToBeDeleted();
+}
+
 DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimFromAggregationOnNoMoreInput) {
   const int numVectors = 32;
   std::vector<RowVectorPtr> vectors;

--- a/velox/exec/tests/utils/TempDirectoryPath.cpp
+++ b/velox/exec/tests/utils/TempDirectoryPath.cpp
@@ -28,7 +28,7 @@ std::shared_ptr<TempDirectoryPath> TempDirectoryPath::create() {
 }
 
 TempDirectoryPath::~TempDirectoryPath() {
-  LOG(INFO) << "TempDirectoryPath:: removing all files from" << path;
+  LOG(INFO) << "TempDirectoryPath:: removing all files from " << path;
   try {
     boost::filesystem::remove_all(path.c_str());
   } catch (...) {


### PR DESCRIPTION
Resolves https://github.com/facebookincubator/velox/issues/7930, also be related to https://github.com/facebookincubator/velox/issues/7511

Partial aggregation currently relies on following options to reduce memory usage:

* kMaxPartialAggregationMemory
* kMaxExtendedPartialAggregationMemory

The PR adds the following one to enable flushing on partial aggregation:

* kPartialAggregationSpillEnabled (default value: false)

When `kPartialAggregationSpillEnabled` is set to true, partial aggregation will try spilling data to disk just like final aggregation can do. At the same time, flushing will be disabled.

Also, when spilling has been triggered, code path of abandoning partial aggregation will be disabled.
