### PR TITLE
Improve error message: size <= kSizeMask

### DIFF
--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -324,7 +324,7 @@ void HashStringAllocator::removeFromFreeList(Header* header) {
 HashStringAllocator::Header* FOLLY_NULLABLE
 HashStringAllocator::allocate(int32_t size, bool exactSize) {
   if (size > kMaxAlloc && exactSize) {
-    VELOX_CHECK(size <= Header::kSizeMask);
+    VELOX_CHECK_LE(size, Header::kSizeMask);
     auto header =
         reinterpret_cast<Header*>(allocateFromPool(size + sizeof(Header)));
     new (header) Header(size);

--- a/velox/common/memory/HashStringAllocator.h
+++ b/velox/common/memory/HashStringAllocator.h
@@ -63,7 +63,7 @@ class HashStringAllocator : public StreamArena {
     static constexpr uint32_t kArenaEnd = 0xf0aeab0d;
 
     explicit Header(uint32_t size) : data_(size) {
-      VELOX_CHECK(size <= kSizeMask);
+      VELOX_CHECK_LE(size, kSizeMask);
     }
 
     bool isContinued() const {
@@ -115,7 +115,7 @@ class HashStringAllocator : public StreamArena {
     }
 
     void setSize(int32_t size) {
-      VELOX_CHECK(size <= kSizeMask);
+      VELOX_CHECK_LE(size, kSizeMask);
       data_ = size | (data_ & ~kSizeMask);
     }
 


### PR DESCRIPTION
Use VELOX_CHECK_LE to add details to 'VeloxRuntimeError: size <= kSizeMask' error message.