### PR TITLE
Allow the creation of a writer without writing and closing

### DIFF
--- a/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.h
+++ b/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.h
@@ -24,8 +24,42 @@ namespace facebook::velox::dwrf {
 class E2EWriterTestUtil {
  public:
   /**
-   * Writes data and returns the writer so that the caller can control
+   * Creates and returns the writer so that the caller can control
    * its life cycle. The writer is constructed with the supplied parameters.
+   *    sink                    the container for writer output, could be
+   *                            in-memory or on-disk.
+   *    type                    schema of the output data
+   *    config                  ORC configs
+   *    flushPolicyFactory      supplies the policy writer use to determine
+   *                            when to flush the current stripe and start a
+   *                            new one
+   *    layoutPlannerFactory    supplies the layout planner and determine how
+   *                            order of the data streams prior to flush
+   *    writerMemoryCap         total memory budget for the writer
+   */
+  static std::unique_ptr<Writer> createWriter(
+      std::unique_ptr<dwio::common::FileSink> sink,
+      const std::shared_ptr<const Type>& type,
+      const std::shared_ptr<Config>& config,
+      std::function<std::unique_ptr<DWRFFlushPolicy>()> flushPolicyFactory =
+          nullptr,
+      std::function<std::unique_ptr<LayoutPlanner>(
+          const dwio::common::TypeWithId&)> layoutPlannerFactory = nullptr,
+      const int64_t writerMemoryCap = std::numeric_limits<int64_t>::max());
+
+  /**
+   * Writes data and returns the same writer so that the caller can control
+   * its life cycle. Parameters:
+   *    writer                  the writer to write data into
+   *    batches                 generated data
+   */
+  static std::unique_ptr<Writer> writeData(
+      std::unique_ptr<Writer> writer,
+      const std::vector<VectorPtr>& batches);
+
+  /*
+   * Combines createWriter and writeData.
+   * The writer is constructed with the supplied parameters.
    *    sink                    the container for writer output, could be
    *                            in-memory or on-disk.
    *    type                    schema of the output data
@@ -48,7 +82,6 @@ class E2EWriterTestUtil {
       std::function<std::unique_ptr<LayoutPlanner>(
           const dwio::common::TypeWithId&)> layoutPlannerFactory = nullptr,
       const int64_t writerMemoryCap = std::numeric_limits<int64_t>::max());
-
   /**
    * Creates a writer with the supplied configuration and check the IO
    * characteristics and the content of its output. Uses writeData to perform


### PR DESCRIPTION
Summary: We'll need this for future tests where we want to write more data and we don't want to keep it in memory all the time, but be able to write as we generate the data.

Differential Revision: D51308958


