### PR TITLE
Fixed bug allowing a nameless function to be registered

### DIFF
--- a/velox/docs/develop/scalar-functions.rst
+++ b/velox/docs/develop/scalar-functions.rst
@@ -783,7 +783,8 @@ Use exec::registerVectorFunction to register a stateless vector function.
 exec::registerVectorFunction takes a name, a list of supported signatures
 and unique_ptr to an instance of the function. An optional “overwrite” flag
 specifies whether to overwrite a function if a function with the specified
-name already exists.
+name already exists. The function name cannot be empty or Velox will throw
+an exception.
 
 Use exec::registerStatefulVectorFunction to register a stateful vector
 function.

--- a/velox/expression/SimpleFunctionRegistry.h
+++ b/velox/expression/SimpleFunctionRegistry.h
@@ -67,8 +67,8 @@ class SimpleFunctionRegistry {
       registerFunctionInternal(metadata->getName(), metadata, factory);
     } else {
       for (const auto& name : aliases) {
-        VELOX_CHECK_NE(
-            name, "", "Cannot register a function with an empty name.");
+        VELOX_CHECK(
+            !name.empty(), "Cannot register a function with an empty name.");
         registerFunctionInternal(name, metadata, factory);
       }
     }

--- a/velox/expression/SimpleFunctionRegistry.h
+++ b/velox/expression/SimpleFunctionRegistry.h
@@ -67,6 +67,8 @@ class SimpleFunctionRegistry {
       registerFunctionInternal(metadata->getName(), metadata, factory);
     } else {
       for (const auto& name : aliases) {
+        VELOX_CHECK_NE(
+            name, "", "Cannot register a function with an empty name.");
         registerFunctionInternal(name, metadata, factory);
       }
     }

--- a/velox/expression/VectorFunction.cpp
+++ b/velox/expression/VectorFunction.cpp
@@ -98,6 +98,7 @@ bool registerStatefulVectorFunction(
     VectorFunctionFactory factory,
     VectorFunctionMetadata metadata,
     bool overwrite) {
+  VELOX_CHECK_NE(name, "", "Cannot register a function without a name.")
   auto sanitizedName = sanitizeName(name);
 
   if (overwrite) {

--- a/velox/expression/VectorFunction.cpp
+++ b/velox/expression/VectorFunction.cpp
@@ -91,14 +91,15 @@ std::shared_ptr<VectorFunction> getVectorFunction(
 
 /// Registers a new vector function. When overwrite = true, previous functions
 /// with the given name will be replaced.
-/// Returns true iff an insertion actually happened
+/// Returns true iff an insertion actually happened.
+/// Throws an exception if the provided name is empty.
 bool registerStatefulVectorFunction(
     const std::string& name,
     std::vector<FunctionSignaturePtr> signatures,
     VectorFunctionFactory factory,
     VectorFunctionMetadata metadata,
     bool overwrite) {
-  VELOX_CHECK_NE(name, "", "Cannot register a function without a name.")
+  VELOX_CHECK(!name.empty(), "Cannot register a function without a name.")
   auto sanitizedName = sanitizeName(name);
 
   if (overwrite) {

--- a/velox/functions/tests/FunctionRegistryTest.cpp
+++ b/velox/functions/tests/FunctionRegistryTest.cpp
@@ -95,6 +95,17 @@ struct VariadicFunc {
   }
 };
 
+template <typename T>
+struct EmtpyFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool call(
+      int64_t& /* result */,
+      const int64_t& /* arg1 */) {
+    return true;
+  }
+};
+
 class VectorFuncOne : public velox::exec::VectorFunction {
  public:
   void apply(
@@ -222,6 +233,14 @@ inline void registerTestFunctions() {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_vector_func_two, "vector_func_two");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_vector_func_three, "vector_func_three");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_vector_func_four, "vector_func_four");
+}
+
+inline void registerEmtpyScalarFunction() {
+  registerFunction<EmtpyFunction, int64_t, int64_t>({""});
+}
+
+inline void registerEmptyVectorFunction() {
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_vector_func_four, "");
 }
 } // namespace
 
@@ -385,6 +404,11 @@ TEST_F(FunctionRegistryTest, getFunctionSignatures) {
 TEST_F(FunctionRegistryTest, hasSimpleFunctionSignature) {
   auto result = resolveFunction("func_one", {VARCHAR()});
   ASSERT_EQ(*result, *VARCHAR());
+}
+
+TEST_F(FunctionRegistryTest, registerEmptyFunction) {
+  EXPECT_THROW(registerEmtpyScalarFunction(), VeloxRuntimeError);
+  EXPECT_THROW(registerEmptyVectorFunction(), VeloxRuntimeError);
 }
 
 TEST_F(FunctionRegistryTest, hasSimpleFunctionSignatureWrongArgType) {


### PR DESCRIPTION
This PR addresses #7537.  The fix for empty scalar functions is implemented and has test coverage. The fix (if required) for empty vector functions is in progress along with its test coverage.

The current implementation is a draft that requires a couple questions to be answered.

1. Should we raise an exception if a user attempts to declare an unnamed function?
2. If we do raise an exception, is VeloxUserError the correct exception?
3. When other "aliases" are provided, should we just skip the empty alias instead of raising an exception?
4. Are there required documentation changes? Taking a look at develop/scalar-functions.rst, the documentation already states we cannot declare unnamed functions. On first look I couldn't find a "vector-functions.rst", but I will look spend some more time to find that documentation.

I ran into some issues testing empty vector functions. I tried to model the test around the standards used in FunctionRegistryTest.cpp, but I cannot declare a vector function and not define it. For the test to work the vector function needs to be defined within the tests scope, but getting that to work has been puzzling at first look. If I cannot get it to work within those standards I will try to find a different way to create this test.