### PR TITLE
Add plus and minus functions for timestamp with interval

### DIFF
--- a/velox/docs/functions/presto/datetime.rst
+++ b/velox/docs/functions/presto/datetime.rst
@@ -15,9 +15,15 @@ Date and Time Operators
    * - ``+``
      - ``interval '1' second + interval '1' hour``
      - ``0 01:00:01.000``
+   * - ``+``
+     - ``timestamp '1970-01-01 00:00:00.000' + interval '1' second``
+     - ``1970-01-01 00:00:01.000``
    * - ``-``
      - ``interval '1' hour - interval '1' second``
      - ``0 00:59:59.000``
+   * - ``-``
+     - ``timestamp '1970-01-01 00:00:00.000' - interval '1' second``
+     - ``1969-12-31 23:59:59.000``
    * - ``*``
      - ``interval '1' second * 2``
      - ``0 00:00:02.000``
@@ -36,17 +42,21 @@ Date and Time Operators
 
 .. function:: plus(x, y) -> [same as x]
 
-    Returns the sum of ``x`` and ``y``. ``x`` and ``y`` are both intervals day
-    to second. Returns ``-106751991167 07:12:55.808`` when the addition
-    overflows in positive. Returns ``106751991167 07:12:55.807`` when the
-    addition overflows in negative.
+    Returns the sum of ``x`` and ``y``. Both ``x`` and ``y`` are intervals day
+    to second or one of them can be timestamp. For addition of two intervals day to
+    second, returns ``-106751991167 07:12:55.808`` when the addition overflows
+    in positive and returns ``106751991167 07:12:55.807`` when the addition
+    overflows in negative. When addition of a timestamp with an interval day to
+    second, overflowed results are wrapped around.
 
 .. function:: minus(x, y) -> [same as x]
 
-    Returns the result of subtracting ``y`` from ``x``. ``x`` and ``y`` are
-    both intervals day to second. Returns ``-106751991167 07:12:55.808`` when
-    the subtraction overflows in positive. Returns ``106751991167 07:12:55.807``
-    when the subtraction overflows in negative.
+    Returns the result of subtracting ``y`` from ``x``. Both ``x`` and ``y``
+    are intervals day to second or ``x`` can be timestamp. For subtraction of
+    two intervals day to second, returns ``-106751991167 07:12:55.808`` when
+    the subtraction overflows in positive and returns ``106751991167 07:12:55.807``
+    when the subtraction overflows in negative. For subtraction of an interval
+    day to second from a timestamp, overflowed results are wrapped around.
 
 .. function:: multiply(interval day to second, x) -> interval day to second
 

--- a/velox/docs/functions/presto/datetime.rst
+++ b/velox/docs/functions/presto/datetime.rst
@@ -12,6 +12,12 @@ Date and Time Operators
    * - Operator
      - Example
      - Result
+   * - ``+``
+     - ``interval '1' second + interval '1' hour``
+     - ``0 01:00:01.000``
+   * - ``-``
+     - ``interval '1' hour - interval '1' second``
+     - ``0 00:59:59.000``
    * - ``*``
      - ``interval '1' second * 2``
      - ``0 00:00:02.000``
@@ -27,6 +33,20 @@ Date and Time Operators
    * - ``/``
      - ``interval '15' second / 1.5``
      - ``0 00:00:10.000``
+
+.. function:: plus(x, y) -> [same as x]
+
+    Returns the sum of ``x`` and ``y``. ``x`` and ``y`` are both intervals day
+    to second. Returns ``-106751991167 07:12:55.808`` when the addition
+    overflows in positive. Returns ``106751991167 07:12:55.807`` when the
+    addition overflows in negative.
+
+.. function:: minus(x, y) -> [same as x]
+
+    Returns the result of subtracting ``y`` from ``x``. ``x`` and ``y`` are
+    both intervals day to second. Returns ``-106751991167 07:12:55.808`` when
+    the subtraction overflows in positive. Returns ``106751991167 07:12:55.807``
+    when the subtraction overflows in negative.
 
 .. function:: multiply(interval day to second, x) -> interval day to second
 

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -401,7 +401,7 @@ struct DatePlusIntervalDayTime {
 };
 
 template <typename T>
-struct TimestampMinusIntervalDayTime {
+struct TimestampMinusFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE void call(
@@ -409,6 +409,60 @@ struct TimestampMinusIntervalDayTime {
       const arg_type<Timestamp>& a,
       const arg_type<Timestamp>& b) {
     result = a.toMillis() - b.toMillis();
+  }
+};
+
+template <typename T>
+struct TimestampPlusIntervalDayTime {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Timestamp>& result,
+      const arg_type<Timestamp>& a,
+      const arg_type<IntervalDayTime>& b)
+#if defined(__has_feature)
+#if __has_feature(__address_sanitizer__)
+      __attribute__((__no_sanitize__("signed-integer-overflow")))
+#endif
+#endif
+  {
+    result = Timestamp::fromMillisNoError(a.toMillis() + b);
+  }
+};
+
+template <typename T>
+struct IntervalDayTimePlusTimestamp {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Timestamp>& result,
+      const arg_type<IntervalDayTime>& a,
+      const arg_type<Timestamp>& b)
+#if defined(__has_feature)
+#if __has_feature(__address_sanitizer__)
+      __attribute__((__no_sanitize__("signed-integer-overflow")))
+#endif
+#endif
+  {
+    result = Timestamp::fromMillisNoError(a + b.toMillis());
+  }
+};
+
+template <typename T>
+struct TimestampMinusIntervalDayTime {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Timestamp>& result,
+      const arg_type<Timestamp>& a,
+      const arg_type<IntervalDayTime>& b)
+#if defined(__has_feature)
+#if __has_feature(__address_sanitizer__)
+      __attribute__((__no_sanitize__("signed-integer-overflow")))
+#endif
+#endif
+  {
+    result = Timestamp::fromMillisNoError(a.toMillis() - b);
   }
 };
 

--- a/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
@@ -25,7 +25,17 @@ namespace facebook::velox::functions {
 namespace {
 void registerSimpleFunctions(const std::string& prefix) {
   registerBinaryFloatingPoint<PlusFunction>({prefix + "plus"});
+  registerFunction<
+      PlusFunction,
+      IntervalDayTime,
+      IntervalDayTime,
+      IntervalDayTime>({prefix + "plus"});
   registerBinaryFloatingPoint<MinusFunction>({prefix + "minus"});
+  registerFunction<
+      MinusFunction,
+      IntervalDayTime,
+      IntervalDayTime,
+      IntervalDayTime>({prefix + "minus"});
   registerBinaryFloatingPoint<MultiplyFunction>({prefix + "multiply"});
   registerFunction<MultiplyFunction, IntervalDayTime, IntervalDayTime, int64_t>(
       {prefix + "multiply"});

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -65,6 +65,21 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "plus"});
   registerFunction<
       TimestampMinusIntervalDayTime,
+      Timestamp,
+      Timestamp,
+      IntervalDayTime>({prefix + "minus"});
+  registerFunction<
+      TimestampPlusIntervalDayTime,
+      Timestamp,
+      Timestamp,
+      IntervalDayTime>({prefix + "plus"});
+  registerFunction<
+      IntervalDayTimePlusTimestamp,
+      Timestamp,
+      IntervalDayTime,
+      Timestamp>({prefix + "plus"});
+  registerFunction<
+      TimestampMinusFunction,
       IntervalDayTime,
       Timestamp,
       Timestamp>({prefix + "minus"});

--- a/velox/functions/prestosql/tests/ArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/ArithmeticTest.cpp
@@ -92,6 +92,30 @@ class ArithmeticTest : public functions::test::FunctionBaseTest {
   }
 };
 
+TEST_F(ArithmeticTest, plus) {
+  // Test plus for intervals.
+  auto op1 = makeNullableFlatVector<int64_t>(
+      {-1, 2, -3, 4, kLongMax, -1, std::nullopt, 0}, INTERVAL_DAY_TIME());
+  auto op2 = makeNullableFlatVector<int64_t>(
+      {2, -3, -1, 1, 1, kLongMin, 0, std::nullopt}, INTERVAL_DAY_TIME());
+  auto expected = makeNullableFlatVector<int64_t>(
+      {1, -1, -4, 5, kLongMin, kLongMax, std::nullopt, std::nullopt},
+      INTERVAL_DAY_TIME());
+  assertExpression("c0 + c1", op1, op2, expected);
+}
+
+TEST_F(ArithmeticTest, minus) {
+  // Test plus for intervals.
+  auto op1 = makeNullableFlatVector<int64_t>(
+      {-1, 2, -3, 4, kLongMin, -1, std::nullopt, 0}, INTERVAL_DAY_TIME());
+  auto op2 = makeNullableFlatVector<int64_t>(
+      {2, 3, -4, 1, 1, kLongMax, 0, std::nullopt}, INTERVAL_DAY_TIME());
+  auto expected = makeNullableFlatVector<int64_t>(
+      {-3, -1, 1, 3, kLongMax, kLongMin, std::nullopt, std::nullopt},
+      INTERVAL_DAY_TIME());
+  assertExpression("c0 - c1", op1, op2, expected);
+}
+
 TEST_F(ArithmeticTest, divide)
 #if defined(__has_feature)
 #if __has_feature(__address_sanitizer__)

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -167,6 +167,21 @@ struct Timestamp {
     return Timestamp(second, nano);
   }
 
+  static Timestamp fromMillisNoError(int64_t millis)
+#if defined(__has_feature)
+#if __has_feature(__address_sanitizer__)
+      __attribute__((__no_sanitize__("signed-integer-overflow")))
+#endif
+#endif
+  {
+    if (millis >= 0 || millis % 1'000 == 0) {
+      return Timestamp(millis / 1'000, (millis % 1'000) * 1'000'000);
+    }
+    auto second = millis / 1'000 - 1;
+    auto nano = ((millis - second * 1'000) % 1'000) * 1'000'000;
+    return Timestamp(second, nano);
+  }
+
   static Timestamp fromMicros(int64_t micros) {
     if (micros >= 0 || micros % 1'000'000 == 0) {
       return Timestamp(micros / 1'000'000, (micros % 1'000'000) * 1'000);


### PR DESCRIPTION
Summary:
Add plus(timestamp, interval), plus(interval, timestamp), and minus(timestamp, interval) functions.

This is the forth diff to fix https://github.com/facebookincubator/velox/issues/7490

Differential Revision: D51330143


