### PR TITLE
Propogate allocation errors from mem allocator

### DIFF
--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -398,6 +398,10 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
     isPersistentFailureInjection_ = false;
   }
 
+  /// Sets a thread level failure message describing the reason for the last
+  /// allocation failure.
+  void setAllocatorFailureMessage(std::string message);
+
   /// Returns extra information after returning false from any of the allocate
   /// functions. The error message is scoped to the most recent call on the
   /// thread. The message is cleared after return.

--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -68,26 +68,29 @@ bool MmapAllocator::allocateNonContiguousWithoutRetry(
     return true;
   }
   const SizeMix mix = allocationSize(numPages, minSizeClass);
-  if (testingHasInjectedFailure(InjectedFailure::kCap)) {
-    if ((bytesFreed != 0) && (reservationCB != nullptr)) {
-      reservationCB(bytesFreed, false);
-    }
-    return false;
-  }
 
-  if (numAllocated_ + mix.totalPages > capacity_) {
-    VELOX_MEM_LOG_EVERY_MS(WARNING, 1000)
-        << "Exceeding memory allocator limit when allocate " << mix.totalPages
-        << " pages with capacity of " << capacity_ << " pages";
+  if (numAllocated_ + mix.totalPages > capacity_ ||
+      testingHasInjectedFailure(InjectedFailure::kCap)) {
+    const std::string errorMsg = fmt::format(
+        "Exceeded memory allocator limit when allocating {} pages with "
+        "capacity of {} pages",
+        mix.totalPages,
+        capacity_);
+    VELOX_MEM_LOG_EVERY_MS(WARNING, 1000) << errorMsg;
+    setAllocatorFailureMessage(errorMsg);
     if ((bytesFreed != 0) && (reservationCB != nullptr)) {
       reservationCB(bytesFreed, false);
     }
     return false;
   }
   if (numAllocated_.fetch_add(mix.totalPages) + mix.totalPages > capacity_) {
-    VELOX_MEM_LOG_EVERY_MS(WARNING, 1000)
-        << "Exceeded memory allocator limit when allocate " << mix.totalPages
-        << " pages with capacity of " << capacity_ << " pages";
+    const std::string errorMsg = fmt::format(
+        "Exceeding memory allocator limit when allocating {} pages with "
+        "capacity of {} pages",
+        mix.totalPages,
+        capacity_);
+    VELOX_MEM_LOG_EVERY_MS(WARNING, 1000) << errorMsg;
+    setAllocatorFailureMessage(errorMsg);
     numAllocated_.fetch_sub(mix.totalPages);
     if ((bytesFreed != 0) && (reservationCB != nullptr)) {
       reservationCB(bytesFreed, false);
@@ -129,8 +132,12 @@ bool MmapAllocator::allocateNonContiguousWithoutRetry(
     if (!success) {
       // This does not normally happen since any size class can accommodate
       // all the capacity. 'allocatedPages_' must be out of sync.
-      VELOX_MEM_LOG(WARNING) << "Failed allocation in size class " << i
-                             << " for " << mix.sizeCounts[i] << " pages";
+      const std::string errorMsg = fmt::format(
+          "Failed allocation in size class {} for {} pages",
+          i,
+          mix.sizeCounts[i]);
+      VELOX_MEM_LOG(WARNING) << errorMsg;
+      setAllocatorFailureMessage(errorMsg);
       const auto failedPages = mix.totalPages - out.numPages();
       freeNonContiguous(out);
       numAllocated_.fetch_sub(failedPages);
@@ -148,9 +155,13 @@ bool MmapAllocator::allocateNonContiguousWithoutRetry(
     return true;
   }
 
-  VELOX_MEM_LOG(WARNING) << "Could not advise away enough for " << newMapsNeeded
-                         << " pages with total allocation of << "
-                         << mix.totalPages << " pages";
+  const std::string errorMsg = fmt::format(
+      "Could not advise away enough for {} pages for total allocation "
+      "of {} pages",
+      newMapsNeeded,
+      mix.totalPages);
+  VELOX_MEM_LOG(WARNING) << errorMsg;
+  setAllocatorFailureMessage(errorMsg);
   freeNonContiguous(out);
   if (reservationCB != nullptr) {
     reservationCB(AllocationTraits::pageBytes(mix.totalPages), false);
@@ -330,10 +341,15 @@ bool MmapAllocator::allocateContiguousImpl(
   if (newPages > 0 &&
       (numAllocated > capacity_ ||
        testingHasInjectedFailure(InjectedFailure::kCap))) {
-    VELOX_MEM_LOG_EVERY_MS(WARNING, 1000)
-        << "Exceeded memory allocator limit when allocate " << newPages
-        << " new pages for total allocation of " << numPages
-        << " pages, the memory allocator capacity is " << capacity_ << " pages";
+    const std::string errorMsg = fmt::format(
+        "Exceeded memory allocator limit when allocating {} new pages for "
+        "total allocation of {} pages, the memory allocator capacity is"
+        " {} pages",
+        newPages,
+        numPages,
+        capacity_);
+    VELOX_MEM_LOG_EVERY_MS(WARNING, 1000) << errorMsg;
+    setAllocatorFailureMessage(errorMsg);
     rollbackAllocation(0);
     return false;
   }
@@ -342,9 +358,13 @@ bool MmapAllocator::allocateContiguousImpl(
   const int64_t numToMap = numPages - numCollateralUnmap;
   if (numToMap > 0) {
     if (!ensureEnoughMappedPages(numToMap)) {
-      VELOX_MEM_LOG(WARNING)
-          << "Could not advise away enough for " << numToMap
-          << " pages for total allocation of " << numPages << " pages";
+      const std::string errorMsg = fmt::format(
+          "Could not advise away enough for {} pages for total allocation "
+          "of {} pages",
+          numToMap,
+          numPages);
+      VELOX_MEM_LOG(WARNING) << errorMsg;
+      setAllocatorFailureMessage(errorMsg);
       rollbackAllocation(0);
       return false;
     }
@@ -372,9 +392,12 @@ bool MmapAllocator::allocateContiguousImpl(
   }
   // TODO: add handling of MAP_FAILED.
   if (data == nullptr) {
-    VELOX_MEM_LOG(ERROR) << "Mmap failed with " << numPages
-                         << " pages, use MmapArena "
-                         << (useMmapArena_ ? "true" : "false");
+    const std::string errorMsg = fmt::format(
+        "Mmap failed with {} pages use MmapArena {}",
+        numPages,
+        (useMmapArena_ ? "true" : "false"));
+    VELOX_MEM_LOG(ERROR) << errorMsg;
+    setAllocatorFailureMessage(errorMsg);
     // If the mmap failed, we have unmapped former 'allocation' and the extra to
     // be mapped.
     rollbackAllocation(numToMap);
@@ -427,10 +450,15 @@ bool MmapAllocator::growContiguousWithoutRetry(
   auto numAllocated = numAllocated_.fetch_add(increment) + increment;
   if (numAllocated > capacity_ ||
       testingHasInjectedFailure(InjectedFailure::kCap)) {
-    VELOX_MEM_LOG_EVERY_MS(WARNING, 1000)
-        << "Exceeded memory allocator limit when adding " << increment
-        << " new pages for total allocation of " << allocation.numPages()
-        << " pages, the memory allocator capacity is " << capacity_ << " pages";
+    const std::string errorMsg = fmt::format(
+        "Exceeded memory allocator limit when allocating {} new pages for "
+        "total allocation of {} pages, the memory allocator capacity is"
+        " {} pages",
+        increment,
+        allocation.numPages(),
+        capacity_);
+    VELOX_MEM_LOG_EVERY_MS(WARNING, 1000) << errorMsg;
+    setAllocatorFailureMessage(errorMsg);
     numAllocated_ -= increment;
     if (reservationCB != nullptr) {
       reservationCB(AllocationTraits::pageBytes(increment), false);
@@ -439,11 +467,15 @@ bool MmapAllocator::growContiguousWithoutRetry(
   }
 
   // Check if need to advise away
-  if (!ensureEnoughMappedPages(increment) ||
-      testingHasInjectedFailure(InjectedFailure::kMmap)) {
-    VELOX_MEM_LOG(WARNING) << "Could not advise away enough for " << increment
-                           << " pages for growing allocation of "
-                           << allocation.numPages() << " pages";
+  if (testingHasInjectedFailure(InjectedFailure::kMmap) ||
+      !ensureEnoughMappedPages(increment)) {
+    const std::string errorMsg = fmt::format(
+        "Could not advise away enough for {} pages for growing allocation "
+        "of {} pages",
+        increment,
+        allocation.numPages());
+    VELOX_MEM_LOG(WARNING) << errorMsg;
+    setAllocatorFailureMessage(errorMsg);
     if (reservationCB != nullptr) {
       reservationCB(AllocationTraits::pageBytes(increment), false);
     }

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -28,6 +28,7 @@
 #include <folly/Range.h>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
+#include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
 DECLARE_int32(velox_memory_pool_mb);
@@ -839,6 +840,21 @@ TEST_P(MemoryAllocatorTest, nonContiguousFailure) {
                        Allocation::PageRun::kMaxPagesInRun,
                        MemoryAllocator::InjectedFailure::kMadvise},
                       {200, 100, MemoryAllocator::InjectedFailure::kMadvise}};
+  std::unordered_map<MemoryAllocator::InjectedFailure, std::string>
+      expectedErrorMsg = {
+          {MemoryAllocator::InjectedFailure::kAllocate,
+           "Malloc failed to allocate"}};
+  if (useMmap_) {
+    expectedErrorMsg = {
+        {MemoryAllocator::InjectedFailure::kCap,
+         "Exceeded memory allocator limit"},
+        {MemoryAllocator::InjectedFailure::kMadvise,
+         "Could not advise away enough"},
+        {MemoryAllocator::InjectedFailure::kAllocate,
+         "Failed allocation in size class"}};
+  }
+  // Some error messages are only set when a reservationCB is provided
+  auto dummyReservationCB = [](int64_t /*bytes*/, bool /*preAllocation*/) {};
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(
         fmt::format("{}, useMmap:{}", testData.debugString(), useMmap_));
@@ -855,8 +871,12 @@ TEST_P(MemoryAllocatorTest, nonContiguousFailure) {
     }
     ASSERT_GE(allocation.numPages(), testData.numOldPages);
     allocator_->testingSetFailureInjection(testData.injectedFailure, true);
-    ASSERT_FALSE(
-        allocator_->allocateNonContiguous(testData.numNewPages, allocation));
+    ASSERT_FALSE(allocator_->allocateNonContiguous(
+        testData.numNewPages, allocation, dummyReservationCB));
+    auto failureMsg = instance_->getAndClearFailureMessage();
+    EXPECT_THAT(
+        failureMsg,
+        testing::HasSubstr(expectedErrorMsg[testData.injectedFailure]));
     ASSERT_EQ(allocator_->numAllocated(), 0);
     allocator_->testingClearFailureInjection();
   }
@@ -976,6 +996,14 @@ TEST_P(MemoryAllocatorTest, allocContiguousFail) {
       {100, 0, 100, MemoryAllocator::InjectedFailure::kMadvise},
       {200, 0, 100, MemoryAllocator::InjectedFailure::kMadvise},
       {100, 0, 200, MemoryAllocator::InjectedFailure::kMadvise}};
+
+  std::unordered_map<MemoryAllocator::InjectedFailure, std::string>
+      expectedErrorMsg = {
+          {MemoryAllocator::InjectedFailure::kCap,
+           "Exceeded memory allocator limit"},
+          {MemoryAllocator::InjectedFailure::kMmap, "Mmap failed with"},
+          {MemoryAllocator::InjectedFailure::kMadvise,
+           "Could not advise away enough"}};
   for (const auto& testData : testSettings) {
     if ((testData.injectedFailure !=
          MemoryAllocator::InjectedFailure::kAllocate) &&
@@ -1003,6 +1031,10 @@ TEST_P(MemoryAllocatorTest, allocContiguousFail) {
 
     ASSERT_FALSE(instance_->allocateContiguous(
         testData.newContiguousPages, &allocation, contiguousAllocation));
+    auto failureMsg = instance_->getAndClearFailureMessage();
+    EXPECT_THAT(
+        failureMsg,
+        testing::HasSubstr(expectedErrorMsg[testData.injectedFailure]));
     ASSERT_EQ(instance_->numAllocated(), 0);
 
     if (useMmap_) {
@@ -1047,7 +1079,19 @@ TEST_P(MemoryAllocatorTest, allocContiguousGrow) {
   EXPECT_TRUE(instance_->allocateContiguous(
       kInitialLarge, nullptr, large, nullptr, kCapacityPages));
   EXPECT_FALSE(instance_->growContiguous(kMinGrow, large));
+  auto failureMsg = instance_->getAndClearFailureMessage();
+  auto expected = "Exceeded memory allocator limit";
+  EXPECT_THAT(failureMsg, testing::HasSubstr(expected));
   freeSmall(kMinGrow);
+  if (useMmap_) {
+    // Also test mmap failure path
+    instance_->testingSetFailureInjection(
+        MemoryAllocator::InjectedFailure::kMmap, false);
+    EXPECT_FALSE(instance_->growContiguous(kMinGrow, large));
+    failureMsg = instance_->getAndClearFailureMessage();
+    expected = "Could not advise away enough";
+    EXPECT_THAT(failureMsg, testing::HasSubstr(expected));
+  }
   EXPECT_TRUE(instance_->growContiguous(kMinGrow, large));
   EXPECT_EQ(instance_->numAllocated(), kCapacityPages);
   freeSmall(4 * kMinGrow);

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -596,7 +596,14 @@ TEST_P(MemoryPoolTest, MemoryCapExceptions) {
                     "parent[MemoryCapExceptions] MMAP track-usage {}]<max "
                     "capacity 256.00MB capacity 256.00MB used 0B available 0B "
                     "reservation [used 0B, reserved 0B, min 0B] counters [allocs "
-                    "1, frees 0, reserves 0, releases 0, collisions 0])> Failed to evict from cache state: AsyncDataCache:\nCache size: 0B tinySize: 0B large size: 0B\nCache entries: 0 read pins: 0 write pins: 0 pinned shared: 0B pinned exclusive: 0B\n num write wait: 0 empty entries: 0\nCache access miss: 0 hit: 0 hit bytes: 0B eviction: 0 eviction checks: 0\nPrefetch entries: 0 bytes: 0B\nAlloc Megaclocks 0\nAllocated pages: 0 cached pages: 0\n",
+                    "1, frees 0, reserves 0, releases 0, collisions 0])> Failed to"
+                    " evict from cache state: AsyncDataCache:\nCache size: 0B "
+                    "tinySize: 0B large size: 0B\nCache entries: 0 read pins: "
+                    "0 write pins: 0 pinned shared: 0B pinned exclusive: 0B\n "
+                    "num write wait: 0 empty entries: 0\nCache access miss: 0 "
+                    "hit: 0 hit bytes: 0B eviction: 0 eviction checks: 0\nPrefetch"
+                    " entries: 0 bytes: 0B\nAlloc Megaclocks 0\nAllocated pages: 0"
+                    " cached pages: 0\n",
                     isLeafThreadSafe_ ? "thread-safe" : "non-thread-safe"),
                 ex.message());
           } else {
@@ -607,7 +614,10 @@ TEST_P(MemoryPoolTest, MemoryCapExceptions) {
                     "parent[MemoryCapExceptions] MMAP track-usage {}]<max "
                     "capacity 256.00MB capacity 256.00MB used 0B available 0B "
                     "reservation [used 0B, reserved 0B, min 0B] counters [allocs "
-                    "1, frees 0, reserves 0, releases 0, collisions 0])> ",
+                    "1, frees 0, reserves 0, releases 0, collisions 0])> "
+                    "Exceeded memory allocator limit when allocating 32769 "
+                    "new pages for total allocation of 32769 pages, the memory"
+                    " allocator capacity is 32768 pages",
                     isLeafThreadSafe_ ? "thread-safe" : "non-thread-safe"),
                 ex.message());
           }


### PR DESCRIPTION
Previously, when allocation encountered various failure modes, the
errors were only logged and not propagated. This change ensures that
a useful error message is generated for these failures, which can
then be propagated as an execution failure error to facilitate
debugging.

Test Plan:
added unit tests