### PR TITLE
Fix presto bitwise shift functions to accept shift=0

### DIFF
--- a/velox/docs/functions/presto/bitwise.rst
+++ b/velox/docs/functions/presto/bitwise.rst
@@ -19,6 +19,7 @@ Bitwise Functions
 .. function:: bitwise_arithmetic_shift_right(x, shift) -> [bigint]``
 
     Returns the arithmetic right shift operation on ``x`` shifted by ``shift`` in 2’s complement representation.
+    ``shift`` must not be negative.
 
 .. function:: bitwise_left_shift(x, shift) -> [bigint]``
 
@@ -27,6 +28,7 @@ Bitwise Functions
 .. function:: bitwise_logical_shift_right(x, shift, bits) -> [bigint]``
 
     Returns the logical right shift operation on ``x`` (treated as ``bits``-bit integer) shifted by ``shift``.
+    ``shift`` must not be negative.
 
 .. function:: bitwise_not(x) -> [bigint]
 
@@ -47,6 +49,7 @@ Bitwise Functions
 .. function:: bitwise_shift_left(x, shift, bits) -> [bigint]``
 
     Returns the left shift operation on ``x`` (treated as ``bits``-bit integer) shifted by ``shift``.
+    ``shift`` must not be negative.
 
 .. function:: bitwise_xor(x, y) -> [bigint]``
 

--- a/velox/functions/prestosql/Bitwise.h
+++ b/velox/functions/prestosql/Bitwise.h
@@ -82,7 +82,7 @@ struct BitwiseArithmeticShiftRightFunction {
   // Only support bigint inputs.
   FOLLY_ALWAYS_INLINE void
   call(int64_t& result, int64_t number, int64_t shift) {
-    VELOX_USER_CHECK_GE(shift, 0, "Shift must be positive")
+    VELOX_USER_CHECK_GE(shift, 0, "Shift must be non-negative")
     if (shift >= 63) {
       if (number >= 0) {
         result = 0;
@@ -213,7 +213,7 @@ struct BitwiseLogicalShiftRightFunction {
 
     VELOX_USER_CHECK(
         !(bits <= 1 || bits > 64), "Bits must be between 2 and 64");
-    VELOX_USER_CHECK_GT(shift, 0, "Shift must be positive");
+    VELOX_USER_CHECK_GE(shift, 0, "Shift must be non-negative");
 
     result = (number & ((1LL << bits) - 1)) >> shift;
     return true;
@@ -236,7 +236,7 @@ struct BitwiseShiftLeftFunction {
 
     VELOX_USER_CHECK(
         !(bits <= 1 || bits > 64), "Bits must be between 2 and 64");
-    VELOX_USER_CHECK_GT(shift, 0, "Shift must be positive");
+    VELOX_USER_CHECK_GE(shift, 0, "Shift must be non-negative");
 
     if (shift > 64) {
       result = 0;

--- a/velox/functions/prestosql/tests/BitwiseTest.cpp
+++ b/velox/functions/prestosql/tests/BitwiseTest.cpp
@@ -260,8 +260,9 @@ TEST_F(BitwiseTest, arithmeticShiftRight) {
   EXPECT_EQ(bitwiseArithmeticShiftRight(-100, 66), -1);
   EXPECT_EQ(bitwiseArithmeticShiftRight(100, 65), 0);
   EXPECT_EQ(bitwiseArithmeticShiftRight(100, 66), 0);
+  EXPECT_EQ(bitwiseArithmeticShiftRight(7, 0), 7);
   VELOX_ASSERT_THROW(
-      bitwiseArithmeticShiftRight(3, -1), "Shift must be positive");
+      bitwiseArithmeticShiftRight(3, -1), "Shift must be non-negative");
 
   EXPECT_EQ(bitwiseArithmeticShiftRight(kMin16, kMax16), -1);
   EXPECT_EQ(bitwiseArithmeticShiftRight(kMax16, kMax16), 0);
@@ -359,47 +360,45 @@ TEST_F(BitwiseTest, rightShift) {
 }
 
 TEST_F(BitwiseTest, logicalShiftRight) {
-  const auto bitwiseLogicalShiftRight = [&](std::optional<int64_t> number,
-                                            std::optional<int64_t> shift,
-                                            std::optional<int64_t> bits) {
+  const auto evalFunc = [&](std::optional<int64_t> number,
+                            std::optional<int64_t> shift,
+                            std::optional<int64_t> bits) {
     return evaluateOnce<int64_t>(
         "bitwise_logical_shift_right(c0, c1, c2)", number, shift, bits);
   };
 
-  EXPECT_EQ(bitwiseLogicalShiftRight(1, 1, 64), 0);
-  EXPECT_EQ(bitwiseLogicalShiftRight(-1, 1, 2), 1);
-  EXPECT_EQ(bitwiseLogicalShiftRight(-1, 32, 32), 0);
-  EXPECT_EQ(bitwiseLogicalShiftRight(-1, 30, 32), 3);
-  EXPECT_EQ(bitwiseLogicalShiftRight(kMin64, 10, 32), 0);
-  EXPECT_EQ(bitwiseLogicalShiftRight(kMin64, kMax64, 64), -1);
-  EXPECT_EQ(bitwiseLogicalShiftRight(kMax64, kMin64, 64), kMax64);
+  EXPECT_EQ(evalFunc(1, 1, 64), 0);
+  EXPECT_EQ(evalFunc(-1, 1, 2), 1);
+  EXPECT_EQ(evalFunc(-1, 32, 32), 0);
+  EXPECT_EQ(evalFunc(-1, 30, 32), 3);
+  EXPECT_EQ(evalFunc(kMin64, 10, 32), 0);
+  EXPECT_EQ(evalFunc(kMin64, kMax64, 64), -1);
+  EXPECT_EQ(evalFunc(kMax64, kMin64, 64), kMax64);
+  EXPECT_EQ(evalFunc(7, 0, 64), 7);
 
-  VELOX_ASSERT_THROW(
-      bitwiseLogicalShiftRight(3, -1, 3), "Shift must be positive");
-  VELOX_ASSERT_THROW(
-      bitwiseLogicalShiftRight(3, 1, 1), "Bits must be between 2 and 64");
+  VELOX_ASSERT_THROW(evalFunc(3, -1, 3), "Shift must be non-negative");
+  VELOX_ASSERT_THROW(evalFunc(3, 1, 1), "Bits must be between 2 and 64");
 }
 
 TEST_F(BitwiseTest, shiftLeft) {
-  const auto bitwiseLogicalShiftRight = [&](std::optional<int64_t> number,
-                                            std::optional<int64_t> shift,
-                                            std::optional<int64_t> bits) {
+  const auto evalFunc = [&](std::optional<int64_t> number,
+                            std::optional<int64_t> shift,
+                            std::optional<int64_t> bits) {
     return evaluateOnce<int64_t>(
         "bitwise_shift_left(c0, c1, c2)", number, shift, bits);
   };
 
-  EXPECT_EQ(bitwiseLogicalShiftRight(1, 1, 64), 0);
-  EXPECT_EQ(bitwiseLogicalShiftRight(-1, 1, 2), 2);
-  EXPECT_EQ(bitwiseLogicalShiftRight(-1, 32, 32), 0);
-  EXPECT_EQ(bitwiseLogicalShiftRight(-1, 31, 32), 2147483648);
-  EXPECT_EQ(bitwiseLogicalShiftRight(kMin64, 10, 32), 0);
-  EXPECT_EQ(bitwiseLogicalShiftRight(kMin64, kMax64, 64), -1);
-  EXPECT_EQ(bitwiseLogicalShiftRight(kMax64, kMin64, 64), kMax64);
+  EXPECT_EQ(evalFunc(1, 1, 64), 0);
+  EXPECT_EQ(evalFunc(-1, 1, 2), 2);
+  EXPECT_EQ(evalFunc(-1, 32, 32), 0);
+  EXPECT_EQ(evalFunc(-1, 31, 32), 2147483648);
+  EXPECT_EQ(evalFunc(kMin64, 10, 32), 0);
+  EXPECT_EQ(evalFunc(kMin64, kMax64, 64), -1);
+  EXPECT_EQ(evalFunc(kMax64, kMin64, 64), kMax64);
+  EXPECT_EQ(evalFunc(7, 0, 64), 7);
 
-  VELOX_ASSERT_THROW(
-      bitwiseLogicalShiftRight(3, -1, 3), "Shift must be positive");
-  VELOX_ASSERT_THROW(
-      bitwiseLogicalShiftRight(3, 1, 1), "Bits must be between 2 and 64");
+  VELOX_ASSERT_THROW(evalFunc(3, -1, 3), "Shift must be non-negative");
+  VELOX_ASSERT_THROW(evalFunc(3, 1, 1), "Bits must be between 2 and 64");
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
Bitwise shifts allow for shifts=0 and Presto Java
allows it too.
Two of Velox's shifts were not allowing it.
This change fixes it and also changes the error message to
reflect a correct requirement.

Differential Revision: D51337295


