### PR TITLE
Fix scan time metrics for vread

### DIFF
--- a/velox/dwio/common/InputStream.cpp
+++ b/velox/dwio/common/InputStream.cpp
@@ -141,11 +141,11 @@ void ReadFileInputStream::vread(
       size_t(0),
       [&](size_t acc, const auto& r) { return acc + r.length; });
   logRead(regions[0].offset, length, purpose);
-  auto readStartMs = getCurrentTimeMs();
+  auto readStartMicros = getCurrentTimeMicro();
   readFile_->preadv(regions, iobufs);
   if (stats_) {
     stats_->incRawBytesRead(length);
-    stats_->incTotalScanTime(getCurrentTimeMs() - readStartMs);
+    stats_->incTotalScanTime((getCurrentTimeMicro() - readStartMicros) * 1000);
   }
 }
 


### PR DESCRIPTION
`totalScanTime_`'s unit should be nano second.
https://github.com/facebookincubator/velox/blob/c7bc0e0bbb601429196f91edad8631b5f6ba748b/velox/connectors/hive/HiveDataSource.cpp#L677