### PR TITLE
Fix memory leak of HdfsBuilder

### DIFF
--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.cpp
@@ -31,6 +31,7 @@ class HdfsFileSystem::Impl {
     hdfsBuilderSetNameNode(builder, endpoint.host.c_str());
     hdfsBuilderSetNameNodePort(builder, atoi(endpoint.port.data()));
     hdfsClient_ = hdfsBuilderConnect(builder);
+    hdfsFreeBuilder(builder);
     VELOX_CHECK_NOT_NULL(
         hdfsClient_,
         "Unable to connect to HDFS: {}, got error: {}.",


### PR DESCRIPTION
ASAN report memory leak of HdfsBuilder, after checking libhdfs source code, `hdfsBuilderConnect` does not free hdfsBuilder as its doc claimed. https://github.com/apache/hawq/blob/e9d43144f7e947e071bba48871af9da354d177d0/depends/libhdfs3/src/client/Hdfs.cpp#L406

Gluten issue: https://github.com/oap-project/gluten/issues/3713