### PR TITLE
Improve private variable naming in DwrfReader

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -442,14 +442,14 @@ DwrfRowReader::prefetchUnits() {
 
 DwrfRowReader::FetchResult DwrfRowReader::fetch(uint32_t stripeIndex) {
   FetchStatus prevStatus;
-  stripeLoadStatuses_.withWLock([&](auto& loadRequestIssued) {
-    if (stripeIndex < 0 || stripeIndex >= loadRequestIssued.size()) {
+  stripeLoadStatuses_.withWLock([&](auto& stripeLoadStatus) {
+    if (stripeIndex < 0 || stripeIndex >= stripeLoadStatus.size()) {
       prevStatus = FetchStatus::ERROR;
     }
 
-    prevStatus = loadRequestIssued[stripeIndex];
+    prevStatus = stripeLoadStatus[stripeIndex];
     if (prevStatus == FetchStatus::NOT_STARTED) {
-      loadRequestIssued[stripeIndex] = FetchStatus::IN_PROGRESS;
+      stripeLoadStatus[stripeIndex] = FetchStatus::IN_PROGRESS;
     }
   });
 

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -55,15 +55,15 @@ class DwrfRowReader : public StrideIndexProvider,
   }
 
   std::shared_ptr<const dwio::common::TypeWithId> getSelectedType() const {
-    if (!selectedSchema) {
-      selectedSchema = columnSelector_->buildSelected();
+    if (!selectedSchema_) {
+      selectedSchema_ = columnSelector_->buildSelected();
     }
 
-    return selectedSchema;
+    return selectedSchema_;
   }
 
   uint64_t getRowNumber() const {
-    return previousRow;
+    return previousRow_;
   }
 
   uint64_t seekToRow(uint64_t rowNumber);
@@ -71,7 +71,7 @@ class DwrfRowReader : public StrideIndexProvider,
   uint64_t skipRows(uint64_t numberOfRowsToSkip);
 
   uint32_t getCurrentStripe() const {
-    return currentStripe;
+    return currentStripe_;
   }
 
   uint64_t getStrideIndex() const override {
@@ -132,19 +132,19 @@ class DwrfRowReader : public StrideIndexProvider,
   FetchResult prefetch(uint32_t stripeToFetch);
 
   // footer
-  std::vector<uint64_t> firstRowOfStripe;
-  mutable std::shared_ptr<const dwio::common::TypeWithId> selectedSchema;
+  std::vector<uint64_t> firstRowOfStripe_;
+  mutable std::shared_ptr<const dwio::common::TypeWithId> selectedSchema_;
 
   // reading state
-  uint64_t previousRow;
-  uint32_t firstStripe;
-  uint32_t currentStripe;
+  uint64_t previousRow_;
+  uint32_t firstStripe_;
+  uint32_t currentStripe_;
   // The the stripe AFTER the last one that should be read. e.g. if the highest
-  // stripe in the RowReader's bounds is 3, then stripeCeiling is 4.
-  uint32_t stripeCeiling;
-  uint64_t currentRowInStripe;
-  bool newStripeReadyForRead;
-  uint64_t rowsInCurrentStripe;
+  // stripe in the RowReader's bounds is 3, then stripeCeiling_ is 4.
+  uint32_t stripeCeiling_;
+  uint64_t currentRowInStripe_;
+  bool newStripeReadyForRead_;
+  uint64_t rowsInCurrentStripe_;
   uint64_t strideIndex_;
   std::shared_ptr<StripeDictionaryCache> stripeDictionaryCache_;
   dwio::common::RowReaderOptions options_;
@@ -208,7 +208,7 @@ class DwrfRowReader : public StrideIndexProvider,
   }
 
   bool isEmptyFile() const {
-    return (stripeCeiling == firstStripe);
+    return (stripeCeiling_ == firstStripe_);
   }
 
   void checkSkipStrides(uint64_t strideSize);


### PR DESCRIPTION
Summary: From what I've gathered the lack of `_` suffix for certain variables isn't preferred due to any convention. Let's fix this to make clear what are member variables.

Differential Revision: D51339197


