### PR TITLE
Add trailing zeros when cast decimal to string if value is 0

### DIFF
--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -488,6 +488,7 @@ Valid examples
   SELECT cast(cast(-22.51 as DECIMAL(4, 2)) as varchar); -- '-22.51'
   SELECT cast(cast(0.123 as DECIMAL(3, 3)) as varchar); -- '0.123'
   SELECT cast(cast(1 as DECIMAL(6, 2)) as varchar); -- '1.00'
+  SELECT cast(cast(0 as DECIMAL(6, 2)) as varchar); -- '0.00'
 
 From TIMESTAMP
 ^^^^^^^^^^^^^^

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -89,6 +89,12 @@ StringView convertToStringView(
   char* writePosition = startPosition;
   if (unscaledValue == 0) {
     *writePosition++ = '0';
+    if (scale > 0) {
+      *writePosition++ = '.';
+      // Append leading zeros.
+      std::memset(writePosition, '0', scale);
+      writePosition += scale;
+    }
   } else {
     if (unscaledValue < 0) {
       *writePosition++ = '-';

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -1566,7 +1566,16 @@ TEST_F(CastExprTest, decimalToVarchar) {
       "c0",
       flatForInline,
       makeNullableFlatVector<StringView>(
-          {"1234567.89", "-3333333.33", "0", "0.05", "-0.09", std::nullopt}));
+          {"1234567.89",
+           "-3333333.33",
+           "0.00",
+           "0.05",
+           "-0.09",
+           std::nullopt}));
+
+  auto shortFlatForZero = makeNullableFlatVector<int64_t>({0}, DECIMAL(6, 0));
+  testComplexCast(
+      "c0", shortFlatForZero, makeNullableFlatVector<StringView>({"0"}));
 
   auto shortFlat = makeNullableFlatVector<int64_t>(
       {DecimalUtil::kShortDecimalMin,
@@ -1582,7 +1591,7 @@ TEST_F(CastExprTest, decimalToVarchar) {
       makeNullableFlatVector<StringView>(
           {"-0.999999999999999999",
            "-0.000000000000000003",
-           "0",
+           "0.000000000000000000",
            "0.000000000000000055",
            "0.999999999999999999",
            std::nullopt}));
@@ -1600,11 +1609,15 @@ TEST_F(CastExprTest, decimalToVarchar) {
       longFlat,
       makeNullableFlatVector<StringView>(
           {"-999999999999999999999999999999999.99999",
-           "0",
+           "0.00000",
            "999999999999999999999999999999999.99999",
            "-0.00001",
            "12089258196146291747.06175",
            std::nullopt}));
+
+  auto longFlatForZero = makeNullableFlatVector<int128_t>({0}, DECIMAL(25, 0));
+  testComplexCast(
+      "c0", longFlatForZero, makeNullableFlatVector<StringView>({"0"}));
 }
 
 TEST_F(CastExprTest, decimalToDecimal) {

--- a/velox/type/DecimalUtil.cpp
+++ b/velox/type/DecimalUtil.cpp
@@ -23,7 +23,11 @@ std::string formatDecimal(uint8_t scale, int128_t unscaledValue) {
   VELOX_DCHECK_GE(scale, 0);
   VELOX_DCHECK_LT(
       static_cast<size_t>(scale), sizeof(DecimalUtil::kPowersOfTen));
+  const bool isFraction = (scale > 0);
   if (unscaledValue == 0) {
+    if (isFraction) {
+      return fmt::format("{:.{}f}", 0.0, scale);
+    }
     return "0";
   }
 
@@ -33,7 +37,6 @@ std::string formatDecimal(uint8_t scale, int128_t unscaledValue) {
   }
   int128_t integralPart = unscaledValue / DecimalUtil::kPowersOfTen[scale];
 
-  bool isFraction = (scale > 0);
   std::string fractionString;
   if (isFraction) {
     auto fraction =

--- a/velox/type/tests/DecimalTest.cpp
+++ b/velox/type/tests/DecimalTest.cpp
@@ -60,7 +60,7 @@ TEST(DecimalTest, decimalToString) {
   ASSERT_EQ("1.000", DecimalUtil::toString(1000, DECIMAL(20, 3)));
   ASSERT_EQ("0.0000001000", DecimalUtil::toString(1000, DECIMAL(20, 10)));
   ASSERT_EQ("-0.001000", DecimalUtil::toString(-1000, DECIMAL(20, 6)));
-  ASSERT_EQ("0", DecimalUtil::toString(0, DECIMAL(20, 9)));
+  ASSERT_EQ("0.000000000", DecimalUtil::toString(0, DECIMAL(20, 9)));
 
   const auto minShortDecimal =
       DecimalUtil::toString(DecimalUtil::kShortDecimalMin, DECIMAL(18, 0));

--- a/velox/vector/tests/VectorToStringTest.cpp
+++ b/velox/vector/tests/VectorToStringTest.cpp
@@ -114,7 +114,7 @@ TEST_F(VectorToStringTest, decimals) {
       "1: 35.610\n"
       "2: -314.159\n"
       "3: 0.007\n"
-      "4: 0");
+      "4: 0.000");
 
   auto longDecimalFlatVector =
       makeFlatVector<int128_t>({1000265, 35610, -314159, 7, 0}, DECIMAL(20, 4));
@@ -127,7 +127,7 @@ TEST_F(VectorToStringTest, decimals) {
       "1: 3.5610\n"
       "2: -31.4159\n"
       "3: 0.0007\n"
-      "4: 0");
+      "4: 0.0000");
 }
 
 TEST_F(VectorToStringTest, nullableDecimals) {


### PR DESCRIPTION
When Spark and Presto convert decimal with data of 0 into string, the 0 will be aligned with zeros according to scale.
```
spark-sql> select cast(cast(0 as decimal(38, 5)) as string);
0.00000
Time taken: 0.642 seconds, Fetched 1 row(s)

presto> select cast(cast(0 as decimal(38, 5)) as varchar);
  _col0
---------
 0.00000
(1 row)
```

CC: @rui-mo @mbasmanova 