### PR TITLE
feat: Add unified compression API and lz4_frame/lz4_raw/lz4_hadoop codec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,7 @@ option(VELOX_ENABLE_ARROW "Enable Arrow support" OFF)
 option(VELOX_ENABLE_GEO "Enable Geospatial support" OFF)
 option(VELOX_ENABLE_REMOTE_FUNCTIONS "Enable remote function support" OFF)
 option(VELOX_ENABLE_CCACHE "Use ccache if installed." ON)
+option(VELOX_ENABLE_COMPRESSION_LZ4 "Enable Lz4 compression support." OFF)
 
 option(VELOX_BUILD_TEST_UTILS "Builds Velox test utilities" OFF)
 option(VELOX_BUILD_VECTOR_TEST_UTILS "Builds Velox vector test utilities" OFF)
@@ -192,6 +193,12 @@ if(VELOX_BUILD_TESTING OR VELOX_BUILD_TEST_UTILS)
   velox_resolve_dependency(cpr)
   set(VELOX_ENABLE_DUCKDB ON)
   set(VELOX_ENABLE_PARSE ON)
+endif()
+
+if(${VELOX_BUILD_TESTING}
+   OR ${VELOX_BUILD_MINIMAL_WITH_DWIO}
+   OR ${VELOX_ENABLE_HIVE_CONNECTOR})
+  set(VELOX_ENABLE_COMPRESSION_LZ4 ON)
 endif()
 
 if(${VELOX_ENABLE_EXAMPLES})
@@ -463,12 +470,15 @@ velox_resolve_dependency(glog)
 velox_set_source(fmt)
 velox_resolve_dependency(fmt 9.0.0)
 
+if(VELOX_ENABLE_COMPRESSION_LZ4)
+  find_package(lz4 REQUIRED)
+endif()
+
 if(${VELOX_BUILD_MINIMAL_WITH_DWIO} OR ${VELOX_ENABLE_HIVE_CONNECTOR})
   # DWIO needs all sorts of stream compression libraries.
   #
   # TODO: make these optional and pluggable.
   find_package(ZLIB REQUIRED)
-  find_package(lz4 REQUIRED)
   find_package(lzo2 REQUIRED)
   find_package(zstd REQUIRED)
   find_package(Snappy REQUIRED)

--- a/velox/common/compression/CMakeLists.txt
+++ b/velox/common/compression/CMakeLists.txt
@@ -19,5 +19,13 @@ endif()
 velox_add_library(velox_common_compression Compression.cpp LzoDecompressor.cpp)
 velox_link_libraries(
   velox_common_compression
-  PUBLIC Folly::folly
+  PUBLIC velox_status Folly::folly
   PRIVATE velox_exception)
+
+if(VELOX_ENABLE_COMPRESSION_LZ4)
+  velox_sources(velox_common_compression PRIVATE Lz4Compression.cpp
+                HadoopCompressionFormat.cpp)
+  velox_link_libraries(velox_common_compression PUBLIC lz4::lz4)
+  velox_compile_definitions(velox_common_compression
+                            PRIVATE VELOX_ENABLE_COMPRESSION_LZ4)
+endif()

--- a/velox/common/compression/Compression.cpp
+++ b/velox/common/compression/Compression.cpp
@@ -16,6 +16,9 @@
 
 #include "velox/common/compression/Compression.h"
 #include "velox/common/base/Exceptions.h"
+#ifdef VELOX_ENABLE_COMPRESSION_LZ4
+#include "velox/common/compression/Lz4Compression.h"
+#endif
 
 #include <folly/Conv.h>
 
@@ -98,5 +101,133 @@ CompressionKind stringToCompressionKind(const std::string& kind) {
   } else {
     VELOX_UNSUPPORTED("Not support compression kind {}", kind);
   }
+}
+
+Status Codec::init() {
+  return Status::OK();
+}
+
+bool Codec::supportsGetUncompressedLength(CompressionKind kind) {
+  // TODO: Return true if it's supported by compression kind.
+  return false;
+}
+
+bool Codec::supportsStreamingCompression(CompressionKind kind) {
+  switch (kind) {
+#ifdef VELOX_ENABLE_COMPRESSION_LZ4
+    case CompressionKind::CompressionKind_LZ4:
+      return true;
+#endif
+    default:
+      return false;
+  }
+}
+
+bool Codec::supportsCompressFixedLength(CompressionKind kind) {
+  // TODO: Return true if it's supported by compression kind.
+  return false;
+}
+
+Expected<std::unique_ptr<Codec>> Codec::create(
+    CompressionKind kind,
+    const CodecOptions& codecOptions) {
+  if (!isAvailable(kind)) {
+    auto name = compressionKindToString(kind);
+    VELOX_RETURN_UNEXPECTED_IF(
+        folly::StringPiece({name}).startsWith("unknown"),
+        Status::Invalid("Unrecognized codec: ", name));
+    return folly::makeUnexpected(Status::Invalid(
+        "Support for codec '{}' is either not built or not implemented.",
+        name));
+  }
+
+  auto compressionLevel = codecOptions.compressionLevel;
+  std::unique_ptr<Codec> codec;
+  switch (kind) {
+#ifdef VELOX_ENABLE_COMPRESSION_LZ4
+    case CompressionKind::CompressionKind_LZ4:
+      if (auto options = dynamic_cast<const Lz4CodecOptions*>(&codecOptions)) {
+        switch (options->type) {
+          case Lz4CodecOptions::kLz4Frame:
+            codec = makeLz4FrameCodec(compressionLevel);
+            break;
+          case Lz4CodecOptions::kLz4Raw:
+            codec = makeLz4RawCodec(compressionLevel);
+            break;
+          case Lz4CodecOptions::kLz4Hadoop:
+            codec = makeLz4HadoopCodec();
+            break;
+        }
+      }
+      // By default, create LZ4 Frame codec.
+      codec = makeLz4FrameCodec(compressionLevel);
+      break;
+#endif
+    default:
+      break;
+  }
+  VELOX_RETURN_UNEXPECTED_IF(
+      codec == nullptr,
+      Status::Invalid(fmt::format(
+          "Support for codec '{}' is either not built or not implemented.",
+          compressionKindToString(kind))));
+
+  VELOX_RETURN_UNEXPECTED_NOT_OK(codec->init());
+
+  return codec;
+}
+
+Expected<std::unique_ptr<Codec>> Codec::create(
+    CompressionKind kind,
+    int32_t compressionLevel) {
+  return create(kind, CodecOptions{compressionLevel});
+}
+
+bool Codec::isAvailable(CompressionKind kind) {
+  switch (kind) {
+    case CompressionKind::CompressionKind_NONE:
+      return true;
+#ifdef VELOX_ENABLE_COMPRESSION_LZ4
+    case CompressionKind::CompressionKind_LZ4:
+      return true;
+#endif
+    default:
+      return false;
+  }
+}
+
+std::optional<uint64_t> Codec::getUncompressedLength(
+    const uint8_t* input,
+    uint64_t inputLength) const {
+  return std::nullopt;
+}
+
+Expected<uint64_t> Codec::compressFixedLength(
+    const uint8_t* input,
+    uint64_t inputLength,
+    uint8_t* output,
+    uint64_t outputLength) {
+  return folly::makeUnexpected(
+      Status::Invalid("'{}' doesn't support fixed-length compression", name()));
+}
+
+Expected<std::shared_ptr<StreamingCompressor>>
+Codec::makeStreamingCompressor() {
+  return folly::makeUnexpected(Status::Invalid(
+      "Streaming compression is unsupported with {} format.", name()));
+}
+
+Expected<std::shared_ptr<StreamingDecompressor>>
+Codec::makeStreamingDecompressor() {
+  return folly::makeUnexpected(Status::Invalid(
+      "Streaming decompression is unsupported with {} format.", name()));
+}
+
+int32_t Codec::compressionLevel() const {
+  return kUseDefaultCompressionLevel;
+}
+
+std::string Codec::name() const {
+  return compressionKindToString(compressionKind());
 }
 } // namespace facebook::velox::common

--- a/velox/common/compression/Compression.cpp
+++ b/velox/common/compression/Compression.cpp
@@ -115,7 +115,7 @@ bool Codec::supportsGetUncompressedLength(CompressionKind kind) {
 bool Codec::supportsStreamingCompression(CompressionKind kind) {
   switch (kind) {
 #ifdef VELOX_ENABLE_COMPRESSION_LZ4
-    case CompressionKind::CompressionKind_LZ4:
+    case CompressionKind_LZ4:
       return true;
 #endif
     default:
@@ -145,7 +145,7 @@ Expected<std::unique_ptr<Codec>> Codec::create(
   std::unique_ptr<Codec> codec;
   switch (kind) {
 #ifdef VELOX_ENABLE_COMPRESSION_LZ4
-    case CompressionKind::CompressionKind_LZ4:
+    case CompressionKind_LZ4:
       if (auto options = dynamic_cast<const Lz4CodecOptions*>(&codecOptions)) {
         switch (options->type) {
           case Lz4CodecOptions::kLz4Frame:
@@ -185,10 +185,10 @@ Expected<std::unique_ptr<Codec>> Codec::create(
 
 bool Codec::isAvailable(CompressionKind kind) {
   switch (kind) {
-    case CompressionKind::CompressionKind_NONE:
+    case CompressionKind_NONE:
       return true;
 #ifdef VELOX_ENABLE_COMPRESSION_LZ4
-    case CompressionKind::CompressionKind_LZ4:
+    case CompressionKind_LZ4:
       return true;
 #endif
     default:

--- a/velox/common/compression/Compression.cpp
+++ b/velox/common/compression/Compression.cpp
@@ -131,9 +131,9 @@ Expected<std::unique_ptr<Codec>> Codec::create(
   std::unique_ptr<Codec> codec;
   switch (kind) {
 #ifdef VELOX_ENABLE_COMPRESSION_LZ4
-    case CompressionKind_LZ4:
+    case CompressionKind_LZ4: {
       if (auto options = dynamic_cast<const Lz4CodecOptions*>(&codecOptions)) {
-        switch (options->type) {
+        switch (options->lz4Type) {
           case Lz4CodecOptions::kLz4Frame:
             codec = makeLz4FrameCodec(compressionLevel);
             break;
@@ -148,7 +148,7 @@ Expected<std::unique_ptr<Codec>> Codec::create(
         // By default, create LZ4 Frame codec.
         codec = makeLz4FrameCodec(compressionLevel);
       }
-      break;
+    } break;
 #endif
     default:
       break;
@@ -214,10 +214,6 @@ Codec::makeStreamingDecompressor() {
 }
 
 int32_t Codec::compressionLevel() const {
-  return kUseDefaultCompressionLevel;
-}
-
-std::string Codec::name() const {
-  return compressionKindToString(compressionKind());
+  return kDefaultCompressionLevel;
 }
 } // namespace facebook::velox::common

--- a/velox/common/compression/Compression.h
+++ b/velox/common/compression/Compression.h
@@ -110,9 +110,10 @@ class Codec {
   /// `kUseDefaultCompressionLevel` will be returned.
   virtual int32_t defaultCompressionLevel() const = 0;
 
-  /// Performs one-shot compression.
+  /// Performs one-shot compression. The actual compressed length is returned.
   /// `outputLength` must first have been computed using maxCompressedLength().
-  /// The actual compressed length will be written to actualOutputLength.
+  /// `output` must be a valid, non-null pointer, otherwise compression will
+  /// fail.
   /// Note: One-shot compression is not always compatible with streaming
   /// decompression. Depending on the codec (e.g. LZ4), different formats may
   /// be used.
@@ -122,9 +123,12 @@ class Codec {
       uint8_t* output,
       uint64_t outputLength) = 0;
 
-  /// One-shot decompression function.
-  /// `outputLength` must be correct and therefore be obtained in advance.
-  /// The actual decompressed length is returned.
+  /// One-shot decompression function. The actual decompressed length is
+  /// returned.
+  /// `outputLength` must be correct and therefore be obtained in
+  /// advance. `output` may be null **only if** `outputLength` is 0. In all
+  /// other cases, `output` must be a valid, non-null pointer. If `output` is
+  /// null while `outputLength` is non-zero, decompression will fail.
   /// Note: One-shot decompression is not always compatible with streaming
   /// compression. Depending on the codec (e.g. LZ4), different formats may
   /// be used.

--- a/velox/common/compression/Compression.h
+++ b/velox/common/compression/Compression.h
@@ -72,8 +72,8 @@ class StreamingCompressor {
   };
 
   /// Compress some input.
-  /// If CompressResult.outputTooSmall is true on return, then a larger output
-  /// buffer should be supplied.
+  /// If CompressResult.outputTooSmall is true on return, compress() should be
+  /// called again with a larger output buffer.
   virtual Expected<CompressResult> compress(
       const uint8_t* input,
       uint64_t inputLength,
@@ -82,15 +82,15 @@ class StreamingCompressor {
 
   /// Flush part of the compressed output.
   /// If FlushResult.outputTooSmall is true on return, flush() should be called
-  /// again with a larger buffer.
+  /// again with a larger output buffer.
   virtual Expected<FlushResult> flush(
       uint8_t* output,
       uint64_t outputLength) = 0;
 
   /// End compressing, doing whatever is necessary to end the stream.
   /// If EndResult.outputTooSmall is true on return, end() should be called
-  /// again with a larger buffer. Otherwise, the StreamingCompressor should not
-  /// be used anymore. end() will flush the compressed output.
+  /// again with a larger output buffer. Otherwise, the StreamingCompressor
+  /// should not be used anymore. end() will flush the compressed output.
   virtual Expected<EndResult> end(uint8_t* output, uint64_t outputLength) = 0;
 };
 
@@ -105,8 +105,8 @@ class StreamingDecompressor {
   };
 
   /// Decompress some input.
-  /// If outputTooSmall is true on return, a larger output buffer needs
-  /// to be supplied.
+  /// If DecompressResult.outputTooSmall is true on return, decompress() should
+  /// be called again with a larger output buffer.
   virtual Expected<DecompressResult> decompress(
       const uint8_t* input,
       uint64_t inputLength,

--- a/velox/common/compression/Compression.h
+++ b/velox/common/compression/Compression.h
@@ -112,11 +112,11 @@ class Codec {
 
   /// Performs one-shot compression. The actual compressed length is returned.
   /// `outputLength` must first have been computed using maxCompressedLength().
-  /// `output` must be a valid, non-null pointer, otherwise compression will
-  /// fail.
+  /// `input` and `output` must be valid, non-null pointers, otherwise
+  /// compression will fail.
   /// Note: One-shot compression is not always compatible with streaming
-  /// decompression. Depending on the codec (e.g. LZ4), different formats may
-  /// be used.
+  /// decompression. Depending on the codec (e.g. LZ4), different formats may be
+  /// used.
   virtual Expected<uint64_t> compress(
       const uint8_t* input,
       uint64_t inputLength,
@@ -126,11 +126,11 @@ class Codec {
   /// One-shot decompression function. The actual decompressed length is
   /// returned.
   /// `outputLength` must be correct and therefore be obtained in advance.
-  /// `output` must be a valid, non-null pointer, otherwise decompression will
-  /// fail.
+  /// `input` and `output` must be valid, non-null pointers, otherwise
+  /// decompression will fail.
   /// Note: One-shot decompression is not always compatible with streaming
-  /// compression. Depending on the codec (e.g. LZ4), different formats may
-  /// be used.
+  /// compression. Depending on the codec (e.g. LZ4), different formats may be
+  /// used.
   virtual Expected<uint64_t> decompress(
       const uint8_t* input,
       uint64_t inputLength,
@@ -145,7 +145,6 @@ class Codec {
   /// be written in this call will be written in subsequent calls to this
   /// function. This is useful when fixed-length compression blocks are required
   /// by the caller.
-  /// Note: Only Gzip and Zstd codec supports this function.
   virtual Expected<uint64_t> compressFixedLength(
       const uint8_t* input,
       uint64_t inputLength,
@@ -221,6 +220,8 @@ class StreamingCompressor {
   /// Compress some input.
   /// If CompressResult.outputTooSmall is true on return, compress() should be
   /// called again with a larger output buffer, such as doubling its size.
+  /// `input` and `output` must be valid, non-null pointers, otherwise
+  /// compression will fail.
   virtual Expected<CompressResult> compress(
       const uint8_t* input,
       uint64_t inputLength,
@@ -229,15 +230,17 @@ class StreamingCompressor {
 
   /// Flush part of the compressed output.
   /// If FlushResult.outputTooSmall is true on return, flush() should be called
-  /// again with a larger output buffer, such as doubling its size.
+  /// again with a larger output buffer, such as doubling its size. `output`
+  /// must be a valid, non-null pointer.
   virtual Expected<FlushResult> flush(
       uint8_t* output,
       uint64_t outputLength) = 0;
 
   /// End compressing, doing whatever is necessary to end the stream, and
-  /// flushing the compressed output.
-  /// If EndResult.outputTooSmall is true on return, end() should be called
-  /// again with a larger output buffer, such as doubling its size.
+  /// flushing the compressed output. `output` must be a valid, non-null
+  /// pointer.
+  /// If EndResult.outputTooSmall is true on return, finalize() should be
+  /// called again with a larger output buffer, such as doubling its size.
   /// Otherwise, the StreamingCompressor should not be used anymore.
   virtual Expected<EndResult> finalize(
       uint8_t* output,
@@ -264,6 +267,8 @@ class StreamingDecompressor {
   /// Decompress some input.
   /// If DecompressResult.outputTooSmall is true on return, decompress() should
   /// be called again with a larger output buffer, such as doubling its size.
+  /// `input` and `output` must be valid, non-null pointers, otherwise
+  /// decompression will fail.
   virtual Expected<DecompressResult> decompress(
       const uint8_t* input,
       uint64_t inputLength,

--- a/velox/common/compression/Compression.h
+++ b/velox/common/compression/Compression.h
@@ -17,8 +17,11 @@
 #pragma once
 
 #include <fmt/format.h>
+#include <folly/Expected.h>
 #include <folly/compression/Compression.h>
 #include <string>
+
+#include "velox/common/base/Status.h"
 
 namespace facebook::velox::common {
 
@@ -45,6 +48,201 @@ CompressionKind stringToCompressionKind(const std::string& kind);
 
 constexpr uint64_t DEFAULT_COMPRESSION_BLOCK_SIZE = 256 * 1024;
 
+static constexpr int32_t kUseDefaultCompressionLevel =
+    std::numeric_limits<int32_t>::min();
+
+class StreamingCompressor {
+ public:
+  virtual ~StreamingCompressor() = default;
+
+  struct CompressResult {
+    uint64_t bytesRead;
+    uint64_t bytesWritten;
+    bool outputTooSmall;
+  };
+
+  struct FlushResult {
+    uint64_t bytesWritten;
+    bool outputTooSmall;
+  };
+
+  struct EndResult {
+    uint64_t bytesWritten;
+    bool outputTooSmall;
+  };
+
+  /// Compress some input.
+  /// If CompressResult.outputTooSmall is true on return, then a larger output
+  /// buffer should be supplied.
+  virtual Expected<CompressResult> compress(
+      const uint8_t* input,
+      uint64_t inputLength,
+      uint8_t* output,
+      uint64_t outputLength) = 0;
+
+  /// Flush part of the compressed output.
+  /// If FlushResult.outputTooSmall is true on return, flush() should be called
+  /// again with a larger buffer.
+  virtual Expected<FlushResult> flush(
+      uint8_t* output,
+      uint64_t outputLength) = 0;
+
+  /// End compressing, doing whatever is necessary to end the stream.
+  /// If EndResult.outputTooSmall is true on return, end() should be called
+  /// again with a larger buffer. Otherwise, the StreamingCompressor should not
+  /// be used anymore. end() will flush the compressed output.
+  virtual Expected<EndResult> end(uint8_t* output, uint64_t outputLength) = 0;
+};
+
+class StreamingDecompressor {
+ public:
+  virtual ~StreamingDecompressor() = default;
+
+  struct DecompressResult {
+    uint64_t bytesRead;
+    uint64_t bytesWritten;
+    bool outputTooSmall;
+  };
+
+  /// Decompress some input.
+  /// If outputTooSmall is true on return, a larger output buffer needs
+  /// to be supplied.
+  virtual Expected<DecompressResult> decompress(
+      const uint8_t* input,
+      uint64_t inputLength,
+      uint8_t* output,
+      uint64_t outputLength) = 0;
+
+  // Return whether the compressed stream is finished.
+  virtual bool isFinished() = 0;
+
+  // Reinitialize decompressor, making it ready for a new compressed stream.
+  virtual Status reset() = 0;
+};
+
+struct CodecOptions {
+  int32_t compressionLevel;
+
+  CodecOptions(int32_t compressionLevel = kUseDefaultCompressionLevel)
+      : compressionLevel(compressionLevel) {}
+
+  virtual ~CodecOptions() = default;
+};
+
+class Codec {
+ public:
+  virtual ~Codec() = default;
+
+  // Create a kind for the given compression algorithm with CodecOptions.
+  static Expected<std::unique_ptr<Codec>> create(
+      CompressionKind kind,
+      const CodecOptions& codecOptions = CodecOptions{});
+
+  // Create a kind for the given compression algorithm.
+  static Expected<std::unique_ptr<Codec>> create(
+      CompressionKind kind,
+      int32_t compressionLevel);
+
+  // Return true if support for indicated kind has been enabled.
+  static bool isAvailable(CompressionKind kind);
+
+  /// Return true if indicated kind supports extracting uncompressed length
+  /// from compressed data.
+  static bool supportsGetUncompressedLength(CompressionKind kind);
+
+  /// Return true if indicated kind supports one-shot compression with fixed
+  /// compressed length.
+  static bool supportsCompressFixedLength(CompressionKind kind);
+
+  // Return true if indicated kind supports creating streaming de/compressor.
+  static bool supportsStreamingCompression(CompressionKind kind);
+
+  /// Return the smallest supported compression level.
+  /// If the codec doesn't support compression level,
+  /// `kUseDefaultCompressionLevel` will be returned.
+  virtual int32_t minimumCompressionLevel() const = 0;
+
+  /// Return the largest supported compression level.
+  /// If the codec doesn't support compression level,
+  /// `kUseDefaultCompressionLevel` will be returned.
+  virtual int32_t maximumCompressionLevel() const = 0;
+
+  /// Return the default compression level.
+  /// If the codec doesn't support compression level,
+  /// `kUseDefaultCompressionLevel` will be returned.
+  virtual int32_t defaultCompressionLevel() const = 0;
+
+  /// Performs one-shot compression.
+  /// `outputLength` must first have been computed using maxCompressedLength().
+  /// The actual compressed length will be written to actualOutputLength.
+  /// Note: One-shot compression is not always compatible with streaming
+  /// decompression. Depending on the codec (e.g. LZ4), different formats may
+  /// be used.
+  virtual Expected<uint64_t> compress(
+      const uint8_t* input,
+      uint64_t inputLength,
+      uint8_t* output,
+      uint64_t outputLength) = 0;
+
+  /// One-shot decompression function.
+  /// `outputLength` must be correct and therefore be obtained in advance.
+  /// The actual decompressed length is returned.
+  /// Note: One-shot decompression is not always compatible with streaming
+  /// compression. Depending on the codec (e.g. LZ4), different formats may
+  /// be used.
+  virtual Expected<uint64_t> decompress(
+      const uint8_t* input,
+      uint64_t inputLength,
+      uint8_t* output,
+      uint64_t outputLength) = 0;
+
+  /// Performs one-shot compression.
+  /// This function compresses data and writes the output up to the specified
+  /// outputLength. If outputLength is too small to hold all the compressed
+  /// data, the function doesn't fail. Instead, it returns the number of bytes
+  /// actually written to the output buffer. Any remaining data that couldn't
+  /// be written in this call will be written in subsequent calls to this
+  /// function. This is useful when fixed-length compression blocks are required
+  /// by the caller.
+  /// Note: Only Gzip and Zstd codec supports this function.
+  virtual Expected<uint64_t> compressFixedLength(
+      const uint8_t* input,
+      uint64_t inputLength,
+      uint8_t* output,
+      uint64_t outputLength);
+
+  // Maximum compressed length of given input length.
+  virtual uint64_t maxCompressedLength(uint64_t inputLength) = 0;
+
+  /// Retrieves the actual uncompressed length of data using the specified
+  /// compression library.
+  /// Note: This functionality is not universally supported by all compression
+  /// libraries. If not supported, `std::nullopt` will be returned.
+  virtual std::optional<uint64_t> getUncompressedLength(
+      const uint8_t* input,
+      uint64_t inputLength) const;
+
+  // Create a streaming compressor instance.
+  virtual Expected<std::shared_ptr<StreamingCompressor>>
+  makeStreamingCompressor();
+
+  // Create a streaming compressor instance.
+  virtual Expected<std::shared_ptr<StreamingDecompressor>>
+  makeStreamingDecompressor();
+
+  // This Codec's compression type.
+  virtual CompressionKind compressionKind() const = 0;
+
+  // This Codec's compression level, if applicable.
+  virtual int32_t compressionLevel() const;
+
+  // The name of this Codec's compression type.
+  std::string name() const;
+
+ private:
+  // Initializes the codec's resources.
+  virtual Status init();
+};
 } // namespace facebook::velox::common
 
 template <>

--- a/velox/common/compression/Compression.h
+++ b/velox/common/compression/Compression.h
@@ -125,10 +125,9 @@ class Codec {
 
   /// One-shot decompression function. The actual decompressed length is
   /// returned.
-  /// `outputLength` must be correct and therefore be obtained in
-  /// advance. `output` may be null **only if** `outputLength` is 0. In all
-  /// other cases, `output` must be a valid, non-null pointer. If `output` is
-  /// null while `outputLength` is non-zero, decompression will fail.
+  /// `outputLength` must be correct and therefore be obtained in advance.
+  /// `output` must be a valid, non-null pointer, otherwise decompression will
+  /// fail.
   /// Note: One-shot decompression is not always compatible with streaming
   /// compression. Depending on the codec (e.g. LZ4), different formats may
   /// be used.

--- a/velox/common/compression/HadoopCompressionFormat.cpp
+++ b/velox/common/compression/HadoopCompressionFormat.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/compression/HadoopCompressionFormat.h"
+#include "velox/common/base/Exceptions.h"
+
+#include <folly/lang/Bits.h>
+
+namespace facebook::velox::common {
+
+bool HadoopCompressionFormat::tryDecompressHadoop(
+    const uint8_t* input,
+    uint64_t inputLength,
+    uint8_t* output,
+    uint64_t outputLength,
+    uint64_t& actualDecompressedSize) {
+  uint64_t totalDecompressedSize = 0;
+
+  while (inputLength >= kPrefixLength) {
+    const uint32_t expectedDecompressedSize =
+        folly::Endian::big(folly::loadUnaligned<uint32_t>(input));
+    const uint32_t expectedCompressedSize = folly::Endian::big(
+        folly::loadUnaligned<uint32_t>(input + sizeof(uint32_t)));
+    input += kPrefixLength;
+    inputLength -= kPrefixLength;
+
+    if (inputLength < expectedCompressedSize) {
+      // Not enough bytes for Hadoop "frame".
+      return false;
+    }
+    if (outputLength < expectedDecompressedSize) {
+      // Not enough bytes to hold advertised output => probably not Hadoop.
+      return false;
+    }
+    // Try decompressing and compare with expected decompressed length.
+    auto maybeDecompressedSize =
+        decompressInternal(input, expectedCompressedSize, output, outputLength);
+    if (maybeDecompressedSize.hasError() ||
+        maybeDecompressedSize.value() != expectedDecompressedSize) {
+      return false;
+    }
+
+    input += expectedCompressedSize;
+    inputLength -= expectedCompressedSize;
+    output += expectedDecompressedSize;
+    outputLength -= expectedDecompressedSize;
+    totalDecompressedSize += expectedDecompressedSize;
+  }
+
+  if (inputLength == 0) {
+    actualDecompressedSize = totalDecompressedSize;
+    return true;
+  }
+  return false;
+}
+} // namespace facebook::velox::common

--- a/velox/common/compression/HadoopCompressionFormat.h
+++ b/velox/common/compression/HadoopCompressionFormat.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/Expected.h>
+#include <cstdint>
+#include "velox/common/base/Status.h"
+
+namespace facebook::velox::common {
+
+/// Parquet files written with the Hadoop compression codecs use their own
+/// framing.
+/// The input buffer can contain an arbitrary number of "frames", each
+/// with the following structure:
+/// - bytes 0..3: big-endian uint32_t representing the frame decompressed
+/// size
+/// - bytes 4..7: big-endian uint32_t representing the frame compressed size
+/// - bytes 8...: frame compressed data
+class HadoopCompressionFormat {
+ protected:
+  /// Try to decompress input data in Hadoop's compression format.
+  /// Returns true if decompression is successful, false otherwise.
+  bool tryDecompressHadoop(
+      const uint8_t* input,
+      uint64_t inputLength,
+      uint8_t* output,
+      uint64_t outputLength,
+      uint64_t& actualDecompressedSize);
+
+  /// Called by tryDecompressHadoop to decompress a single frame and
+  /// should be implemented based on the specific compression format.
+  /// E.g. Lz4HadoopCodec uses Lz4RawCodec::decompress to decompress a frame.
+  virtual Expected<uint64_t> decompressInternal(
+      const uint8_t* input,
+      uint64_t inputLength,
+      uint8_t* output,
+      uint64_t outputLength) = 0;
+
+  // Offset starting at which page data can be read/written.
+  static constexpr uint64_t kPrefixLength = sizeof(uint32_t) * 2;
+};
+} // namespace facebook::velox::common

--- a/velox/common/compression/Lz4Compression.cpp
+++ b/velox/common/compression/Lz4Compression.cpp
@@ -428,6 +428,7 @@ Expected<uint64_t> Lz4FrameCodec::compress(
     uint64_t inputLength,
     uint8_t* output,
     uint64_t outputLength) {
+  VELOX_CHECK_NOT_NULL(output);
   auto ret = LZ4F_compressFrame(
       output,
       static_cast<size_t>(outputLength),
@@ -444,6 +445,7 @@ Expected<uint64_t> Lz4FrameCodec::decompress(
     uint64_t inputLength,
     uint8_t* output,
     uint64_t outputLength) {
+  VELOX_CHECK_NOT_NULL(output);
   return makeStreamingDecompressor().then(
       [&](const auto& decompressor) -> Expected<uint64_t> {
         uint64_t bytesWritten = 0;
@@ -501,6 +503,7 @@ Expected<uint64_t> Lz4RawCodec::compress(
     uint64_t inputLength,
     uint8_t* output,
     uint64_t outputLength) {
+  VELOX_CHECK_NOT_NULL(output);
   uint64_t compressedSize;
 #ifdef LZ4HC_CLEVEL_MIN
   constexpr int32_t kMinHcClevel = LZ4HC_CLEVEL_MIN;
@@ -531,6 +534,7 @@ Expected<uint64_t> Lz4RawCodec::decompress(
     uint64_t inputLength,
     uint8_t* output,
     uint64_t outputLength) {
+  VELOX_CHECK_NOT_NULL(output);
   auto decompressedSize = LZ4_decompress_safe(
       reinterpret_cast<const char*>(input),
       reinterpret_cast<char*>(output),
@@ -556,6 +560,7 @@ Expected<uint64_t> Lz4HadoopCodec::compress(
     uint64_t inputLength,
     uint8_t* output,
     uint64_t outputLength) {
+  VELOX_CHECK_NOT_NULL(output);
   VELOX_RETURN_UNEXPECTED_IF(
       outputLength < kPrefixLength,
       Status::IOError(
@@ -584,6 +589,7 @@ Expected<uint64_t> Lz4HadoopCodec::decompress(
     uint64_t inputLength,
     uint8_t* output,
     uint64_t outputLength) {
+  VELOX_CHECK_NOT_NULL(output);
   uint64_t decompressedSize;
   if (tryDecompressHadoop(
           input, inputLength, output, outputLength, decompressedSize)) {

--- a/velox/common/compression/Lz4Compression.cpp
+++ b/velox/common/compression/Lz4Compression.cpp
@@ -232,6 +232,8 @@ Expected<StreamingCompressor::CompressResult> LZ4Compressor::compress(
     uint64_t inputLength,
     uint8_t* output,
     uint64_t outputLength) {
+  VELOX_CHECK_NOT_NULL(input);
+  VELOX_CHECK_NOT_NULL(output);
   auto inputSize = static_cast<size_t>(inputLength);
   auto outputSize = static_cast<size_t>(outputLength);
   uint64_t bytesWritten = 0;
@@ -263,6 +265,7 @@ Expected<StreamingCompressor::CompressResult> LZ4Compressor::compress(
 Expected<StreamingCompressor::FlushResult> LZ4Compressor::flush(
     uint8_t* output,
     uint64_t outputLength) {
+  VELOX_CHECK_NOT_NULL(output);
   auto outputSize = static_cast<size_t>(outputLength);
   uint64_t bytesWritten = 0;
 
@@ -294,6 +297,7 @@ Expected<StreamingCompressor::FlushResult> LZ4Compressor::flush(
 Expected<StreamingCompressor::EndResult> LZ4Compressor::finalize(
     uint8_t* output,
     uint64_t outputLength) {
+  VELOX_CHECK_NOT_NULL(output);
   auto outputSize = static_cast<size_t>(outputLength);
   uint64_t bytesWritten = 0;
 
@@ -366,6 +370,8 @@ Expected<StreamingDecompressor::DecompressResult> LZ4Decompressor::decompress(
     uint64_t inputLength,
     uint8_t* output,
     uint64_t outputLength) {
+  VELOX_CHECK_NOT_NULL(input);
+  VELOX_CHECK_NOT_NULL(output);
   auto inputSize = static_cast<size_t>(inputLength);
   auto outputSize = static_cast<size_t>(outputLength);
 
@@ -428,6 +434,7 @@ Expected<uint64_t> Lz4FrameCodec::compress(
     uint64_t inputLength,
     uint8_t* output,
     uint64_t outputLength) {
+  VELOX_CHECK_NOT_NULL(input);
   VELOX_CHECK_NOT_NULL(output);
   auto ret = LZ4F_compressFrame(
       output,
@@ -445,6 +452,7 @@ Expected<uint64_t> Lz4FrameCodec::decompress(
     uint64_t inputLength,
     uint8_t* output,
     uint64_t outputLength) {
+  VELOX_CHECK_NOT_NULL(input);
   VELOX_CHECK_NOT_NULL(output);
   return makeStreamingDecompressor().then(
       [&](const auto& decompressor) -> Expected<uint64_t> {
@@ -503,6 +511,7 @@ Expected<uint64_t> Lz4RawCodec::compress(
     uint64_t inputLength,
     uint8_t* output,
     uint64_t outputLength) {
+  VELOX_CHECK_NOT_NULL(input);
   VELOX_CHECK_NOT_NULL(output);
   uint64_t compressedSize;
 #ifdef LZ4HC_CLEVEL_MIN
@@ -534,6 +543,7 @@ Expected<uint64_t> Lz4RawCodec::decompress(
     uint64_t inputLength,
     uint8_t* output,
     uint64_t outputLength) {
+  VELOX_CHECK_NOT_NULL(input);
   VELOX_CHECK_NOT_NULL(output);
   auto decompressedSize = LZ4_decompress_safe(
       reinterpret_cast<const char*>(input),
@@ -560,6 +570,7 @@ Expected<uint64_t> Lz4HadoopCodec::compress(
     uint64_t inputLength,
     uint8_t* output,
     uint64_t outputLength) {
+  VELOX_CHECK_NOT_NULL(input);
   VELOX_CHECK_NOT_NULL(output);
   VELOX_RETURN_UNEXPECTED_IF(
       outputLength < kPrefixLength,
@@ -589,6 +600,7 @@ Expected<uint64_t> Lz4HadoopCodec::decompress(
     uint64_t inputLength,
     uint8_t* output,
     uint64_t outputLength) {
+  VELOX_CHECK_NOT_NULL(input);
   VELOX_CHECK_NOT_NULL(output);
   uint64_t decompressedSize;
   if (tryDecompressHadoop(

--- a/velox/common/compression/Lz4Compression.cpp
+++ b/velox/common/compression/Lz4Compression.cpp
@@ -230,7 +230,7 @@ Status LZ4Compressor::compressBegin(
   return Status::OK();
 }
 
-Status common::LZ4Decompressor::init() {
+Status LZ4Decompressor::init() {
   finished_ = false;
   auto ret = LZ4F_createDecompressionContext(&ctx_, LZ4F_VERSION);
   VELOX_RETURN_IF(LZ4F_isError(ret), lz4Error("LZ4 init failed: ", ret));
@@ -304,7 +304,7 @@ int32_t Lz4CodecBase::compressionLevel() const {
 }
 
 CompressionKind Lz4CodecBase::compressionKind() const {
-  return CompressionKind::CompressionKind_LZ4;
+  return CompressionKind_LZ4;
 }
 
 Lz4FrameCodec::Lz4FrameCodec(int32_t compressionLevel)
@@ -361,6 +361,10 @@ Expected<uint64_t> Lz4FrameCodec::decompress(
                 "Lz4 compressed input contains less than one frame."));
         return bytesWritten;
       });
+}
+
+bool Lz4FrameCodec::supportsStreamingCompression() const {
+  return true;
 }
 
 Expected<std::shared_ptr<StreamingCompressor>>
@@ -430,6 +434,10 @@ Expected<uint64_t> Lz4RawCodec::decompress(
   return static_cast<uint64_t>(decompressedSize);
 }
 
+std::string Lz4RawCodec::name() const {
+  return "lz4_raw";
+}
+
 Lz4HadoopCodec::Lz4HadoopCodec() : Lz4RawCodec(kLz4DefaultCompressionLevel) {}
 
 uint64_t Lz4HadoopCodec::maxCompressedLength(uint64_t inputLength) {
@@ -489,6 +497,10 @@ int32_t Lz4HadoopCodec::maximumCompressionLevel() const {
 
 int32_t Lz4HadoopCodec::defaultCompressionLevel() const {
   return kUseDefaultCompressionLevel;
+}
+
+std::string Lz4HadoopCodec::name() const {
+  return "lz4_hadoop";
 }
 
 Expected<uint64_t> Lz4HadoopCodec::decompressInternal(

--- a/velox/common/compression/Lz4Compression.cpp
+++ b/velox/common/compression/Lz4Compression.cpp
@@ -1,0 +1,513 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/compression/Lz4Compression.h"
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::common {
+namespace {
+
+constexpr int32_t kLz4DefaultCompressionLevel = 1;
+constexpr int32_t kLz4MinCompressionLevel = 1;
+
+#if (defined(LZ4_VERSION_NUMBER) && LZ4_VERSION_NUMBER < 10800)
+constexpr int32_t kLegacyLz4MaxCompressionLevel = 12;
+#endif
+
+static inline Status lz4Error(
+    const char* prefixMessage,
+    LZ4F_errorCode_t errorCode) {
+  return Status::IOError(prefixMessage, LZ4F_getErrorName(errorCode));
+}
+
+LZ4F_preferences_t defaultPreferences() {
+  LZ4F_preferences_t prefs;
+  memset(&prefs, 0, sizeof(prefs));
+  return prefs;
+}
+
+LZ4F_preferences_t defaultPreferences(int32_t compressionLevel) {
+  LZ4F_preferences_t prefs = defaultPreferences();
+  prefs.compressionLevel = compressionLevel;
+  return prefs;
+}
+} // namespace
+
+class LZ4Compressor : public StreamingCompressor {
+ public:
+  explicit LZ4Compressor(int32_t compressionLevel);
+
+  ~LZ4Compressor() override;
+
+  Status init();
+
+  Expected<CompressResult> compress(
+      const uint8_t* input,
+      uint64_t inputLength,
+      uint8_t* output,
+      uint64_t outputLength) override;
+
+  Expected<FlushResult> flush(uint8_t* output, uint64_t outputLength) override;
+
+  Expected<EndResult> end(uint8_t* output, uint64_t outputLength) override;
+
+ protected:
+  Status
+  compressBegin(uint8_t* output, size_t& outputLen, uint64_t& bytesWritten);
+
+  int32_t compressionLevel_;
+  LZ4F_compressionContext_t ctx_{nullptr};
+  LZ4F_preferences_t prefs_;
+  bool firstTime_;
+};
+
+class LZ4Decompressor : public StreamingDecompressor {
+ public:
+  LZ4Decompressor() {}
+
+  ~LZ4Decompressor() override {
+    if (ctx_ != nullptr) {
+      LZ4F_freeDecompressionContext(ctx_);
+    }
+  }
+
+  Expected<DecompressResult> decompress(
+      const uint8_t* input,
+      uint64_t inputLength,
+      uint8_t* output,
+      uint64_t outputLength) override;
+
+  bool isFinished() override;
+
+  Status reset() override;
+
+  Status init();
+
+ protected:
+  LZ4F_decompressionContext_t ctx_{nullptr};
+  bool finished_{false};
+};
+
+LZ4Compressor::LZ4Compressor(int32_t compressionLevel)
+    : compressionLevel_(compressionLevel) {}
+
+LZ4Compressor::~LZ4Compressor() {
+  if (ctx_ != nullptr) {
+    LZ4F_freeCompressionContext(ctx_);
+  }
+}
+
+Status LZ4Compressor::init() {
+  LZ4F_errorCode_t ret;
+  prefs_ = defaultPreferences(compressionLevel_);
+  firstTime_ = true;
+
+  ret = LZ4F_createCompressionContext(&ctx_, LZ4F_VERSION);
+  VELOX_RETURN_IF(LZ4F_isError(ret), lz4Error("LZ4 init failed: ", ret));
+  return Status::OK();
+}
+
+Expected<StreamingCompressor::CompressResult> LZ4Compressor::compress(
+    const uint8_t* input,
+    uint64_t inputLength,
+    uint8_t* output,
+    uint64_t outputLength) {
+  auto inputSize = static_cast<size_t>(inputLength);
+  auto outputSize = static_cast<size_t>(outputLength);
+  uint64_t bytesWritten = 0;
+
+  if (firstTime_) {
+    // Output too small to write LZ4F header.
+    if (outputLength < LZ4F_HEADER_SIZE_MAX) {
+      return CompressResult{0, 0, true};
+    }
+    VELOX_RETURN_UNEXPECTED_NOT_OK(
+        compressBegin(output, outputSize, bytesWritten));
+  }
+
+  if (outputSize < LZ4F_compressBound(inputSize, &prefs_)) {
+    // Output too small to compress into.
+    return CompressResult{0, bytesWritten, true};
+  }
+  auto numBytesOrError = LZ4F_compressUpdate(
+      ctx_, output, outputSize, input, inputSize, nullptr /* options */);
+  VELOX_RETURN_UNEXPECTED_IF(
+      LZ4F_isError(numBytesOrError),
+      lz4Error("LZ4 compress updated failed: ", numBytesOrError));
+  bytesWritten += static_cast<int64_t>(numBytesOrError);
+
+  VELOX_DCHECK_LE(bytesWritten, outputSize);
+  return CompressResult{inputLength, bytesWritten, false};
+}
+
+Expected<StreamingCompressor::FlushResult> LZ4Compressor::flush(
+    uint8_t* output,
+    uint64_t outputLength) {
+  auto outputSize = static_cast<size_t>(outputLength);
+  uint64_t bytesWritten = 0;
+
+  if (firstTime_) {
+    // Output too small to write LZ4F header.
+    if (outputLength < LZ4F_HEADER_SIZE_MAX) {
+      return FlushResult{0, true};
+    }
+    VELOX_RETURN_UNEXPECTED_NOT_OK(
+        compressBegin(output, outputSize, bytesWritten));
+  }
+
+  if (outputSize < LZ4F_compressBound(0, &prefs_)) {
+    // Output too small to flush into.
+    return FlushResult{bytesWritten, true};
+  }
+
+  auto numBytesOrError =
+      LZ4F_flush(ctx_, output, outputSize, nullptr /* options */);
+  VELOX_RETURN_UNEXPECTED_IF(
+      LZ4F_isError(numBytesOrError),
+      lz4Error("LZ4 flush failed: ", numBytesOrError));
+  bytesWritten += static_cast<uint64_t>(numBytesOrError);
+
+  VELOX_DCHECK_LE(bytesWritten, outputLength);
+  return FlushResult{bytesWritten, false};
+}
+
+Expected<StreamingCompressor::EndResult> LZ4Compressor::end(
+    uint8_t* output,
+    uint64_t outputLength) {
+  auto outputSize = static_cast<size_t>(outputLength);
+  uint64_t bytesWritten = 0;
+
+  if (firstTime_) {
+    // Output too small to write LZ4F header.
+    if (outputLength < LZ4F_HEADER_SIZE_MAX) {
+      return EndResult{0, true};
+    }
+    VELOX_RETURN_UNEXPECTED_NOT_OK(
+        compressBegin(output, outputSize, bytesWritten));
+  }
+
+  if (outputSize < LZ4F_compressBound(0, &prefs_)) {
+    // Output too small to end frame into.
+    return EndResult{bytesWritten, true};
+  }
+
+  auto numBytesOrError =
+      LZ4F_compressEnd(ctx_, output, outputSize, nullptr /* options */);
+  VELOX_RETURN_UNEXPECTED_IF(
+      LZ4F_isError(numBytesOrError),
+      lz4Error("LZ4 end failed: ", numBytesOrError));
+  bytesWritten += static_cast<uint64_t>(numBytesOrError);
+
+  VELOX_DCHECK_LE(bytesWritten, outputLength);
+  return EndResult{bytesWritten, false};
+}
+
+Status LZ4Compressor::compressBegin(
+    uint8_t* output,
+    size_t& outputLen,
+    uint64_t& bytesWritten) {
+  auto numBytesOrError = LZ4F_compressBegin(ctx_, output, outputLen, &prefs_);
+  VELOX_RETURN_IF(
+      LZ4F_isError(numBytesOrError),
+      lz4Error("LZ4 compress begin failed: ", numBytesOrError));
+  firstTime_ = false;
+  output += numBytesOrError;
+  outputLen -= numBytesOrError;
+  bytesWritten += static_cast<uint64_t>(numBytesOrError);
+  return Status::OK();
+}
+
+Status common::LZ4Decompressor::init() {
+  finished_ = false;
+  auto ret = LZ4F_createDecompressionContext(&ctx_, LZ4F_VERSION);
+  VELOX_RETURN_IF(LZ4F_isError(ret), lz4Error("LZ4 init failed: ", ret));
+  return Status::OK();
+}
+
+Status LZ4Decompressor::reset() {
+#if defined(LZ4_VERSION_NUMBER) && LZ4_VERSION_NUMBER >= 10800
+  // LZ4F_resetDecompressionContext appeared in 1.8.0
+  if (ctx_ == nullptr) {
+    return Status::Invalid("LZ4 decompression context is null.");
+  }
+  LZ4F_resetDecompressionContext(ctx_);
+  finished_ = false;
+  return Status::OK();
+#else
+  if (ctx_ != nullptr) {
+    LZ4F_freeDecompressionContext(ctx_);
+  }
+  return init();
+#endif
+}
+
+Expected<StreamingDecompressor::DecompressResult> LZ4Decompressor::decompress(
+    const uint8_t* input,
+    uint64_t inputLength,
+    uint8_t* output,
+    uint64_t outputLength) {
+  auto inputSize = static_cast<size_t>(inputLength);
+  auto outputSize = static_cast<size_t>(outputLength);
+
+  auto ret = LZ4F_decompress(
+      ctx_, output, &outputSize, input, &inputSize, nullptr /* options */);
+  VELOX_RETURN_UNEXPECTED_IF(
+      LZ4F_isError(ret), lz4Error("LZ4 decompress failed: ", ret));
+  finished_ = (ret == 0);
+  return DecompressResult{
+      static_cast<uint64_t>(inputSize),
+      static_cast<uint64_t>(outputSize),
+      (inputSize == 0 && outputSize == 0)};
+}
+
+bool LZ4Decompressor::isFinished() {
+  return finished_;
+}
+
+Lz4CodecBase::Lz4CodecBase(int32_t compressionLevel)
+    : compressionLevel_(
+          compressionLevel == kUseDefaultCompressionLevel
+              ? kLz4DefaultCompressionLevel
+              : compressionLevel) {}
+
+int32_t Lz4CodecBase::minimumCompressionLevel() const {
+  return kLz4MinCompressionLevel;
+}
+
+int32_t Lz4CodecBase::maximumCompressionLevel() const {
+#if (defined(LZ4_VERSION_NUMBER) && LZ4_VERSION_NUMBER < 10800)
+  return kLegacyLz4MaxCompressionLevel;
+#else
+  return LZ4F_compressionLevel_max();
+#endif
+}
+
+int32_t Lz4CodecBase::defaultCompressionLevel() const {
+  return kLz4DefaultCompressionLevel;
+}
+
+int32_t Lz4CodecBase::compressionLevel() const {
+  return compressionLevel_;
+}
+
+CompressionKind Lz4CodecBase::compressionKind() const {
+  return CompressionKind::CompressionKind_LZ4;
+}
+
+Lz4FrameCodec::Lz4FrameCodec(int32_t compressionLevel)
+    : Lz4CodecBase(compressionLevel),
+      prefs_(defaultPreferences(compressionLevel_)) {}
+
+uint64_t Lz4FrameCodec::maxCompressedLength(uint64_t inputLen) {
+  return static_cast<int64_t>(
+      LZ4F_compressFrameBound(static_cast<size_t>(inputLen), &prefs_));
+}
+
+Expected<uint64_t> Lz4FrameCodec::compress(
+    const uint8_t* input,
+    uint64_t inputLength,
+    uint8_t* output,
+    uint64_t outputLength) {
+  auto ret = LZ4F_compressFrame(
+      output,
+      static_cast<size_t>(outputLength),
+      input,
+      static_cast<size_t>(inputLength),
+      &prefs_);
+  VELOX_RETURN_UNEXPECTED_IF(
+      LZ4F_isError(ret), lz4Error("Lz4 compression failure: ", ret));
+  return static_cast<uint64_t>(ret);
+}
+
+Expected<uint64_t> Lz4FrameCodec::decompress(
+    const uint8_t* input,
+    uint64_t inputLength,
+    uint8_t* output,
+    uint64_t outputLength) {
+  return makeStreamingDecompressor().then(
+      [&](const auto& decompressor) -> Expected<uint64_t> {
+        uint64_t bytesWritten = 0;
+        while (!decompressor->isFinished() && inputLength != 0) {
+          auto maybeResult = decompressor->decompress(
+              input, inputLength, output, outputLength);
+          VELOX_RETURN_UNEXPECTED(maybeResult);
+
+          const auto& result = maybeResult.value();
+          input += result.bytesRead;
+          inputLength -= result.bytesRead;
+          output += result.bytesWritten;
+          outputLength -= result.bytesWritten;
+          bytesWritten += result.bytesWritten;
+          VELOX_RETURN_UNEXPECTED_IF(
+              result.outputTooSmall,
+              Status::IOError("Lz4 decompression buffer too small."));
+        }
+        VELOX_RETURN_UNEXPECTED_IF(
+            !decompressor->isFinished() || inputLength != 0,
+            Status::IOError(
+                "Lz4 compressed input contains less than one frame."));
+        return bytesWritten;
+      });
+}
+
+Expected<std::shared_ptr<StreamingCompressor>>
+Lz4FrameCodec::makeStreamingCompressor() {
+  auto ptr = std::make_shared<LZ4Compressor>(compressionLevel_);
+  VELOX_RETURN_UNEXPECTED_NOT_OK(ptr->init());
+  return ptr;
+}
+
+Expected<std::shared_ptr<StreamingDecompressor>>
+Lz4FrameCodec::makeStreamingDecompressor() {
+  auto ptr = std::make_shared<LZ4Decompressor>();
+  VELOX_RETURN_UNEXPECTED_NOT_OK(ptr->init());
+  return ptr;
+}
+
+Lz4RawCodec::Lz4RawCodec(int32_t compressionLevel)
+    : Lz4CodecBase(compressionLevel) {}
+
+uint64_t Lz4RawCodec::maxCompressedLength(uint64_t inputLength) {
+  return static_cast<uint64_t>(
+      LZ4_compressBound(static_cast<int>(inputLength)));
+}
+
+Expected<uint64_t> Lz4RawCodec::compress(
+    const uint8_t* input,
+    uint64_t inputLength,
+    uint8_t* output,
+    uint64_t outputLength) {
+  uint64_t compressedSize;
+#ifdef LZ4HC_CLEVEL_MIN
+  constexpr int32_t kMinHcClevel = LZ4HC_CLEVEL_MIN;
+#else // For older versions of the lz4 library.
+  constexpr int32_t kMinHcClevel = 3;
+#endif
+  if (compressionLevel_ < kMinHcClevel) {
+    compressedSize = LZ4_compress_default(
+        reinterpret_cast<const char*>(input),
+        reinterpret_cast<char*>(output),
+        static_cast<int>(inputLength),
+        static_cast<int>(outputLength));
+  } else {
+    compressedSize = LZ4_compress_HC(
+        reinterpret_cast<const char*>(input),
+        reinterpret_cast<char*>(output),
+        static_cast<int>(inputLength),
+        static_cast<int>(outputLength),
+        compressionLevel_);
+  }
+  VELOX_RETURN_UNEXPECTED_IF(
+      compressedSize == 0, Status::IOError("Lz4 compression failure."));
+  return static_cast<uint64_t>(compressedSize);
+}
+
+Expected<uint64_t> Lz4RawCodec::decompress(
+    const uint8_t* input,
+    uint64_t inputLength,
+    uint8_t* output,
+    uint64_t outputLength) {
+  auto decompressedSize = LZ4_decompress_safe(
+      reinterpret_cast<const char*>(input),
+      reinterpret_cast<char*>(output),
+      static_cast<int>(inputLength),
+      static_cast<int>(outputLength));
+  VELOX_RETURN_UNEXPECTED_IF(
+      decompressedSize < 0, Status::IOError("Lz4 decompression failure."));
+  return static_cast<uint64_t>(decompressedSize);
+}
+
+Lz4HadoopCodec::Lz4HadoopCodec() : Lz4RawCodec(kLz4DefaultCompressionLevel) {}
+
+uint64_t Lz4HadoopCodec::maxCompressedLength(uint64_t inputLength) {
+  return kPrefixLength + Lz4RawCodec::maxCompressedLength(inputLength);
+}
+
+Expected<uint64_t> Lz4HadoopCodec::compress(
+    const uint8_t* input,
+    uint64_t inputLength,
+    uint8_t* output,
+    uint64_t outputLength) {
+  VELOX_RETURN_UNEXPECTED_IF(
+      outputLength < kPrefixLength,
+      Status::IOError(
+          "Output buffer too small for Lz4HadoopCodec compression."));
+
+  return Lz4RawCodec::compress(
+             input,
+             inputLength,
+             output + kPrefixLength,
+             outputLength - kPrefixLength)
+      .then([&](const auto& compressedSize) {
+        // Prepend decompressed size in bytes and compressed size in bytes
+        // to be compatible with Hadoop Lz4RawCodec.
+        const uint32_t decompressedLength =
+            folly::Endian::big(static_cast<uint32_t>(inputLength));
+        const uint32_t compressedLength =
+            folly::Endian::big(static_cast<uint32_t>(compressedSize));
+        folly::storeUnaligned(output, decompressedLength);
+        folly::storeUnaligned(output + sizeof(uint32_t), compressedLength);
+        return kPrefixLength + compressedSize;
+      });
+}
+
+Expected<uint64_t> Lz4HadoopCodec::decompress(
+    const uint8_t* input,
+    uint64_t inputLength,
+    uint8_t* output,
+    uint64_t outputLength) {
+  uint64_t decompressedSize;
+  if (tryDecompressHadoop(
+          input, inputLength, output, outputLength, decompressedSize)) {
+    return decompressedSize;
+  }
+  // Fall back on raw LZ4 codec (for files produces by earlier versions of
+  // Parquet C++).
+  return Lz4RawCodec::decompress(input, inputLength, output, outputLength);
+}
+
+int32_t Lz4HadoopCodec::minimumCompressionLevel() const {
+  return kUseDefaultCompressionLevel;
+}
+
+int32_t Lz4HadoopCodec::maximumCompressionLevel() const {
+  return kUseDefaultCompressionLevel;
+}
+
+int32_t Lz4HadoopCodec::defaultCompressionLevel() const {
+  return kUseDefaultCompressionLevel;
+}
+
+Expected<uint64_t> Lz4HadoopCodec::decompressInternal(
+    const uint8_t* input,
+    uint64_t inputLength,
+    uint8_t* output,
+    uint64_t outputLength) {
+  return Lz4RawCodec::decompress(input, inputLength, output, outputLength);
+}
+
+std::unique_ptr<Codec> makeLz4FrameCodec(int32_t compressionLevel) {
+  return std::make_unique<Lz4FrameCodec>(compressionLevel);
+}
+
+std::unique_ptr<Codec> makeLz4RawCodec(int32_t compressionLevel) {
+  return std::make_unique<Lz4RawCodec>(compressionLevel);
+}
+
+std::unique_ptr<Codec> makeLz4HadoopCodec() {
+  return std::make_unique<Lz4HadoopCodec>();
+}
+} // namespace facebook::velox::common

--- a/velox/common/compression/Lz4Compression.h
+++ b/velox/common/compression/Lz4Compression.h
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <lz4.h>
+#include <lz4frame.h>
+#include <lz4hc.h>
+#include <memory>
+#include "velox/common/compression/Compression.h"
+#include "velox/common/compression/HadoopCompressionFormat.h"
+
+namespace facebook::velox::common {
+
+struct Lz4CodecOptions : CodecOptions {
+  enum Type { kLz4Frame, kLz4Raw, kLz4Hadoop };
+
+  Lz4CodecOptions(
+      Lz4CodecOptions::Type type,
+      int32_t compressionLevel = kUseDefaultCompressionLevel)
+      : CodecOptions(compressionLevel), type(type) {}
+
+  Lz4CodecOptions::Type type;
+};
+
+class Lz4CodecBase : public Codec {
+ public:
+  explicit Lz4CodecBase(int32_t compressionLevel);
+
+  int32_t minimumCompressionLevel() const override;
+
+  int32_t maximumCompressionLevel() const override;
+
+  int32_t defaultCompressionLevel() const override;
+
+  int32_t compressionLevel() const override;
+
+  CompressionKind compressionKind() const override;
+
+ protected:
+  const int32_t compressionLevel_;
+};
+
+class Lz4FrameCodec : public Lz4CodecBase {
+ public:
+  explicit Lz4FrameCodec(int32_t compressionLevel);
+
+  uint64_t maxCompressedLength(uint64_t inputLength) override;
+
+  Expected<uint64_t> compress(
+      const uint8_t* input,
+      uint64_t inputLength,
+      uint8_t* output,
+      uint64_t outputLength) override;
+
+  Expected<uint64_t> decompress(
+      const uint8_t* input,
+      uint64_t inputLength,
+      uint8_t* output,
+      uint64_t outputLength) override;
+
+  Expected<std::shared_ptr<StreamingCompressor>> makeStreamingCompressor()
+      override;
+
+  Expected<std::shared_ptr<StreamingDecompressor>> makeStreamingDecompressor()
+      override;
+
+ protected:
+  const LZ4F_preferences_t prefs_;
+};
+
+class Lz4RawCodec : public Lz4CodecBase {
+ public:
+  explicit Lz4RawCodec(int32_t compressionLevel);
+
+  uint64_t maxCompressedLength(uint64_t inputLength) override;
+
+  Expected<uint64_t> compress(
+      const uint8_t* input,
+      uint64_t inputLength,
+      uint8_t* output,
+      uint64_t outputLength) override;
+
+  Expected<uint64_t> decompress(
+      const uint8_t* input,
+      uint64_t inputLength,
+      uint8_t* output,
+      uint64_t outputLength) override;
+};
+
+/// The Hadoop Lz4Codec source code can be found here:
+/// https://github.com/apache/hadoop/blob/trunk/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/native/src/codec/Lz4Codec.cc
+class Lz4HadoopCodec : public Lz4RawCodec, public HadoopCompressionFormat {
+ public:
+  Lz4HadoopCodec();
+
+  uint64_t maxCompressedLength(uint64_t inputLength) override;
+
+  Expected<uint64_t> compress(
+      const uint8_t* input,
+      uint64_t inputLength,
+      uint8_t* output,
+      uint64_t outputLength) override;
+
+  Expected<uint64_t> decompress(
+      const uint8_t* input,
+      uint64_t inputLength,
+      uint8_t* output,
+      uint64_t outputLength) override;
+
+  int32_t minimumCompressionLevel() const override;
+
+  int32_t maximumCompressionLevel() const override;
+
+  int32_t defaultCompressionLevel() const override;
+
+ private:
+  Expected<uint64_t> decompressInternal(
+      const uint8_t* input,
+      uint64_t inputLength,
+      uint8_t* output,
+      uint64_t outputLength) override;
+};
+
+// Lz4 frame format codec.
+std::unique_ptr<Codec> makeLz4FrameCodec(
+    int32_t compressionLevel = kUseDefaultCompressionLevel);
+
+// Lz4 "raw" format codec.
+std::unique_ptr<Codec> makeLz4RawCodec(
+    int32_t compressionLevel = kUseDefaultCompressionLevel);
+
+// Lz4 "Hadoop" format codec (Lz4 raw codec prefixed with lengths header).
+std::unique_ptr<Codec> makeLz4HadoopCodec();
+} // namespace facebook::velox::common

--- a/velox/common/compression/Lz4Compression.h
+++ b/velox/common/compression/Lz4Compression.h
@@ -29,11 +29,11 @@ struct Lz4CodecOptions : CodecOptions {
   enum Type { kLz4Frame, kLz4Raw, kLz4Hadoop };
 
   Lz4CodecOptions(
-      Lz4CodecOptions::Type type,
+      Type type,
       int32_t compressionLevel = kUseDefaultCompressionLevel)
       : CodecOptions(compressionLevel), type(type) {}
 
-  Lz4CodecOptions::Type type;
+  Type type;
 };
 
 class Lz4CodecBase : public Codec {
@@ -72,6 +72,8 @@ class Lz4FrameCodec : public Lz4CodecBase {
       uint8_t* output,
       uint64_t outputLength) override;
 
+  bool supportsStreamingCompression() const override;
+
   Expected<std::shared_ptr<StreamingCompressor>> makeStreamingCompressor()
       override;
 
@@ -99,6 +101,8 @@ class Lz4RawCodec : public Lz4CodecBase {
       uint64_t inputLength,
       uint8_t* output,
       uint64_t outputLength) override;
+
+  std::string name() const override;
 };
 
 /// The Hadoop Lz4Codec source code can be found here:
@@ -126,6 +130,8 @@ class Lz4HadoopCodec : public Lz4RawCodec, public HadoopCompressionFormat {
   int32_t maximumCompressionLevel() const override;
 
   int32_t defaultCompressionLevel() const override;
+
+  std::string name() const override;
 
  private:
   Expected<uint64_t> decompressInternal(

--- a/velox/common/compression/Lz4Compression.h
+++ b/velox/common/compression/Lz4Compression.h
@@ -26,128 +26,23 @@
 namespace facebook::velox::common {
 
 struct Lz4CodecOptions : CodecOptions {
-  enum Type { kLz4Frame, kLz4Raw, kLz4Hadoop };
+  enum Lz4Type { kLz4Frame, kLz4Raw, kLz4Hadoop };
 
   Lz4CodecOptions(
-      Type type,
-      int32_t compressionLevel = kUseDefaultCompressionLevel)
-      : CodecOptions(compressionLevel), type(type) {}
+      Lz4Type lz4Type,
+      int32_t compressionLevel = kDefaultCompressionLevel)
+      : CodecOptions(compressionLevel), lz4Type(lz4Type) {}
 
-  Type type;
-};
-
-class Lz4CodecBase : public Codec {
- public:
-  explicit Lz4CodecBase(int32_t compressionLevel);
-
-  int32_t minimumCompressionLevel() const override;
-
-  int32_t maximumCompressionLevel() const override;
-
-  int32_t defaultCompressionLevel() const override;
-
-  int32_t compressionLevel() const override;
-
-  CompressionKind compressionKind() const override;
-
- protected:
-  const int32_t compressionLevel_;
-};
-
-class Lz4FrameCodec : public Lz4CodecBase {
- public:
-  explicit Lz4FrameCodec(int32_t compressionLevel);
-
-  uint64_t maxCompressedLength(uint64_t inputLength) override;
-
-  Expected<uint64_t> compress(
-      const uint8_t* input,
-      uint64_t inputLength,
-      uint8_t* output,
-      uint64_t outputLength) override;
-
-  Expected<uint64_t> decompress(
-      const uint8_t* input,
-      uint64_t inputLength,
-      uint8_t* output,
-      uint64_t outputLength) override;
-
-  bool supportsStreamingCompression() const override;
-
-  Expected<std::shared_ptr<StreamingCompressor>> makeStreamingCompressor()
-      override;
-
-  Expected<std::shared_ptr<StreamingDecompressor>> makeStreamingDecompressor()
-      override;
-
- protected:
-  const LZ4F_preferences_t prefs_;
-};
-
-class Lz4RawCodec : public Lz4CodecBase {
- public:
-  explicit Lz4RawCodec(int32_t compressionLevel);
-
-  uint64_t maxCompressedLength(uint64_t inputLength) override;
-
-  Expected<uint64_t> compress(
-      const uint8_t* input,
-      uint64_t inputLength,
-      uint8_t* output,
-      uint64_t outputLength) override;
-
-  Expected<uint64_t> decompress(
-      const uint8_t* input,
-      uint64_t inputLength,
-      uint8_t* output,
-      uint64_t outputLength) override;
-
-  std::string name() const override;
-};
-
-/// The Hadoop Lz4Codec source code can be found here:
-/// https://github.com/apache/hadoop/blob/trunk/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/native/src/codec/Lz4Codec.cc
-class Lz4HadoopCodec : public Lz4RawCodec, public HadoopCompressionFormat {
- public:
-  Lz4HadoopCodec();
-
-  uint64_t maxCompressedLength(uint64_t inputLength) override;
-
-  Expected<uint64_t> compress(
-      const uint8_t* input,
-      uint64_t inputLength,
-      uint8_t* output,
-      uint64_t outputLength) override;
-
-  Expected<uint64_t> decompress(
-      const uint8_t* input,
-      uint64_t inputLength,
-      uint8_t* output,
-      uint64_t outputLength) override;
-
-  int32_t minimumCompressionLevel() const override;
-
-  int32_t maximumCompressionLevel() const override;
-
-  int32_t defaultCompressionLevel() const override;
-
-  std::string name() const override;
-
- private:
-  Expected<uint64_t> decompressInternal(
-      const uint8_t* input,
-      uint64_t inputLength,
-      uint8_t* output,
-      uint64_t outputLength) override;
+  Lz4Type lz4Type;
 };
 
 // Lz4 frame format codec.
 std::unique_ptr<Codec> makeLz4FrameCodec(
-    int32_t compressionLevel = kUseDefaultCompressionLevel);
+    int32_t compressionLevel = kDefaultCompressionLevel);
 
 // Lz4 "raw" format codec.
 std::unique_ptr<Codec> makeLz4RawCodec(
-    int32_t compressionLevel = kUseDefaultCompressionLevel);
+    int32_t compressionLevel = kDefaultCompressionLevel);
 
 // Lz4 "Hadoop" format codec (Lz4 raw codec prefixed with lengths header).
 std::unique_ptr<Codec> makeLz4HadoopCodec();

--- a/velox/common/compression/tests/CompressionTest.cpp
+++ b/velox/common/compression/tests/CompressionTest.cpp
@@ -65,10 +65,13 @@ std::vector<TestParams> generateLz4TestParams() {
 }
 
 std::vector<uint8_t> makeRandomData(size_t n) {
-  std::vector<uint8_t> data(n);
+  // Allocate at least 1 byte to ensure data.data() is not nullptr.
+  size_t bytes = n == 0 ? 1 : n;
+  std::vector<uint8_t> data(bytes);
   std::default_random_engine engine(42);
   std::uniform_int_distribution<uint8_t> dist(0, 255);
   std::generate(data.begin(), data.end(), [&]() { return dist(engine); });
+  data.resize(n);
   return data;
 }
 

--- a/velox/common/compression/tests/CompressionTest.cpp
+++ b/velox/common/compression/tests/CompressionTest.cpp
@@ -14,13 +14,315 @@
  * limitations under the License.
  */
 
+#include <algorithm>
+#include <cstring>
+#include <memory>
+#include <random>
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 
-#include "velox/common/base/VeloxException.h"
+#include "velox/common/base/Exceptions.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/compression/Compression.h"
+#include "velox/common/compression/Lz4Compression.h"
 
 namespace facebook::velox::common {
+
+namespace {
+
+void throwsNotOk(const Status& status) {
+  VELOX_USER_FAIL("{}", status.message());
+}
+
+const std::shared_ptr<CodecOptions> kDefaultCodecOptions =
+    std::make_shared<CodecOptions>();
+
+struct TestParams {
+  CompressionKind compressionKind;
+  std::shared_ptr<CodecOptions> codecOptions;
+
+  explicit TestParams(
+      common::CompressionKind compressionKind,
+      std::shared_ptr<CodecOptions> codecOptions = kDefaultCodecOptions)
+      : compressionKind(compressionKind),
+        codecOptions(std::move(codecOptions)) {}
+};
+
+std::vector<TestParams> generateLz4TestParams() {
+  std::vector<TestParams> params;
+  for (auto type :
+       {Lz4CodecOptions::kLz4Raw,
+        Lz4CodecOptions::kLz4Frame,
+        Lz4CodecOptions::kLz4Hadoop}) {
+    params.emplace_back(
+        CompressionKind::CompressionKind_LZ4,
+        std::make_shared<Lz4CodecOptions>(type));
+  }
+  return params;
+}
+
+std::vector<uint8_t> makeRandomData(size_t n) {
+  std::vector<uint8_t> data(n);
+  std::default_random_engine engine(42);
+  std::uniform_int_distribution<uint8_t> dist(0, 255);
+  std::generate(data.begin(), data.end(), [&]() { return dist(engine); });
+  return data;
+}
+
+std::vector<uint8_t> makeCompressibleData(size_t size) {
+  std::string baseData = "The quick brown fox jumps over the lazy dog";
+  auto repeats = static_cast<int32_t>(1 + size / baseData.size());
+
+  std::vector<uint8_t> data(baseData.size() * repeats);
+  for (int i = 0; i < repeats; ++i) {
+    std::memcpy(
+        data.data() + i * baseData.size(), baseData.data(), baseData.size());
+  }
+  data.resize(size);
+  return data;
+}
+
+std::function<uint64_t()> makeRandomInputSize() {
+  std::default_random_engine engine(42);
+  std::uniform_int_distribution<uint64_t> sizeDistribution(10, 40);
+  return [=]() mutable -> uint64_t { return sizeDistribution(engine); };
+}
+
+// Check roundtrip of one-shot compression and decompression functions.
+void checkCodecRoundtrip(
+    Codec* c1,
+    Codec* c2,
+    const std::vector<uint8_t>& data) {
+  auto maxCompressedLen =
+      static_cast<size_t>(c1->maxCompressedLength(data.size()));
+  std::vector<uint8_t> compressed(maxCompressedLen);
+  std::vector<uint8_t> decompressed(data.size());
+
+  // Compress with codec c1.
+  auto compressionLength =
+      c1->compress(
+            data.data(), data.size(), compressed.data(), maxCompressedLen)
+          .thenOrThrow(folly::identity, throwsNotOk);
+  compressed.resize(compressionLength);
+
+  // Decompress with codec c2.
+  auto decompressedLength = c2->decompress(
+                                  compressed.data(),
+                                  compressed.size(),
+                                  decompressed.data(),
+                                  decompressed.size())
+                                .thenOrThrow(folly::identity, throwsNotOk);
+  ASSERT_EQ(data, decompressed);
+  ASSERT_EQ(data.size(), decompressedLength);
+}
+
+// Use same codec for both compression and decompression.
+void checkCodecRoundtrip(
+    const std::unique_ptr<Codec>& codec,
+    const std::vector<uint8_t>& data) {
+  checkCodecRoundtrip(codec.get(), codec.get(), data);
+}
+
+// Compress with codec c1 and decompress with codec c2.
+void checkCodecRoundtrip(
+    const std::unique_ptr<Codec>& c1,
+    const std::unique_ptr<Codec>& c2,
+    const std::vector<uint8_t>& data) {
+  checkCodecRoundtrip(c1.get(), c2.get(), data);
+}
+
+void streamingCompress(
+    const std::shared_ptr<StreamingCompressor>& compressor,
+    const std::vector<uint8_t>& uncompressed,
+    std::vector<uint8_t>& compressed) {
+  const uint8_t* input = uncompressed.data();
+  uint64_t remaining = uncompressed.size();
+  uint64_t compressedSize = 0;
+  compressed.resize(10);
+  bool doFlush = false;
+
+  // Generate small random input buffer size.
+  auto randomInputSize = makeRandomInputSize();
+
+  // Continue decompressing until consuming all compressed data .
+  while (remaining > 0) {
+    // Feed a small amount each time.
+    auto inputLength = std::min(remaining, randomInputSize());
+    auto outputLength = compressed.size() - compressedSize;
+    uint8_t* output = compressed.data() + compressedSize;
+
+    // Compress once.
+    auto compressResult =
+        compressor->compress(input, inputLength, output, outputLength)
+            .thenOrThrow(folly::identity, throwsNotOk);
+    ASSERT_LE(compressResult.bytesRead, inputLength);
+    ASSERT_LE(compressResult.bytesWritten, outputLength);
+
+    // Update result.
+    compressedSize += compressResult.bytesWritten;
+    input += compressResult.bytesRead;
+    remaining -= compressResult.bytesRead;
+
+    // Grow compressed buffer if it's too small.
+    if (compressResult.outputTooSmall) {
+      compressed.resize(compressed.capacity() * 2);
+    }
+
+    // Once every two iterations, do a flush.
+    if (doFlush) {
+      bool outputTooSmall;
+      do {
+        outputLength = compressed.size() - compressedSize;
+        output = compressed.data() + compressedSize;
+        auto flushResult = compressor->flush(output, outputLength)
+                               .thenOrThrow(folly::identity, throwsNotOk);
+        ASSERT_LE(flushResult.bytesWritten, outputLength);
+        compressedSize += flushResult.bytesWritten;
+
+        outputTooSmall = flushResult.outputTooSmall;
+        if (outputTooSmall) {
+          compressed.resize(compressed.capacity() * 2);
+        }
+      } while (outputTooSmall);
+    }
+    doFlush = !doFlush;
+  }
+
+  // End the compressed stream.
+  {
+    bool outputTooSmall;
+    do {
+      int64_t outputLength = compressed.size() - compressedSize;
+      uint8_t* output = compressed.data() + compressedSize;
+      auto endResult = compressor->end(output, outputLength)
+                           .thenOrThrow(folly::identity, throwsNotOk);
+      ASSERT_LE(endResult.bytesWritten, outputLength);
+      compressedSize += endResult.bytesWritten;
+
+      outputTooSmall = endResult.outputTooSmall;
+      if (outputTooSmall) {
+        compressed.resize(compressed.capacity() * 2);
+      }
+    } while (outputTooSmall);
+  }
+  compressed.resize(compressedSize);
+}
+
+void streamingDecompress(
+    const std::shared_ptr<StreamingDecompressor>& decompressor,
+    const std::vector<uint8_t>& compressed,
+    std::vector<uint8_t>& decompressed) {
+  const uint8_t* input = compressed.data();
+  uint64_t remaining = compressed.size();
+  uint64_t decompressedSize = 0;
+  decompressed.resize(10);
+
+  // Generate small random input buffer size.
+  auto ramdomInputSize = makeRandomInputSize();
+
+  // Continue decompressing until finishes.
+  while (!decompressor->isFinished()) {
+    // Feed a small amount each time.
+    auto inputLength = std::min(remaining, ramdomInputSize());
+    auto outputLength = decompressed.size() - decompressedSize;
+    uint8_t* output = decompressed.data() + decompressedSize;
+
+    // Decompress once.
+    auto decompressResult =
+        decompressor->decompress(input, inputLength, output, outputLength)
+            .thenOrThrow(folly::identity, throwsNotOk);
+    ASSERT_LE(decompressResult.bytesRead, inputLength);
+    ASSERT_LE(decompressResult.bytesWritten, outputLength);
+    ASSERT_TRUE(
+        decompressResult.outputTooSmall || decompressResult.bytesWritten > 0 ||
+        decompressResult.bytesRead > 0)
+        << "Decompression not progressing anymore";
+
+    // Update decompressResult.
+    decompressedSize += decompressResult.bytesWritten;
+    input += decompressResult.bytesRead;
+    remaining -= decompressResult.bytesRead;
+
+    // Grow decompressed buffer if it's too small.
+    if (decompressResult.outputTooSmall) {
+      decompressed.resize(decompressed.capacity() * 2);
+    }
+  }
+  ASSERT_TRUE(decompressor->isFinished());
+  ASSERT_EQ(remaining, 0);
+  decompressed.resize(decompressedSize);
+}
+
+std::shared_ptr<StreamingCompressor> makeStreamingCompressor(Codec* codec) {
+  return codec->makeStreamingCompressor().thenOrThrow(
+      folly::identity, throwsNotOk);
+}
+
+std::shared_ptr<StreamingDecompressor> makeStreamingDecompressor(Codec* codec) {
+  return codec->makeStreamingDecompressor().thenOrThrow(
+      folly::identity, throwsNotOk);
+}
+
+// Check the streaming compressor against one-shot decompression.
+void checkStreamingCompressor(Codec* codec, const std::vector<uint8_t>& data) {
+  // Run streaming compression.
+  std::vector<uint8_t> compressed;
+  const auto& compressor = makeStreamingCompressor(codec);
+  streamingCompress(compressor, data, compressed);
+
+  // Check decompressing the compressed data.
+  std::vector<uint8_t> decompressed(data.size());
+  ASSERT_NO_THROW(codec->decompress(
+      compressed.data(),
+      compressed.size(),
+      decompressed.data(),
+      decompressed.size()));
+  ASSERT_EQ(data, decompressed);
+}
+
+// Check the streaming decompressor against one-shot compression.
+void checkStreamingDecompressor(
+    Codec* codec,
+    const std::vector<uint8_t>& data) {
+  // Create compressed data.
+  auto maxCompressedLen = codec->maxCompressedLength(data.size());
+  std::vector<uint8_t> compressed(maxCompressedLen);
+  auto compressedLength =
+      codec
+          ->compress(
+              data.data(), data.size(), compressed.data(), maxCompressedLen)
+          .thenOrThrow(folly::identity, throwsNotOk);
+  compressed.resize(compressedLength);
+
+  // Run streaming decompression.
+  std::vector<uint8_t> decompressed;
+  const auto& decompressor = makeStreamingDecompressor(codec);
+  streamingDecompress(decompressor, compressed, decompressed);
+
+  // Check the decompressed data.
+  ASSERT_EQ(data.size(), decompressed.size());
+  ASSERT_EQ(data, decompressed);
+}
+
+// Check the streaming compressor and decompressor together.
+void checkStreamingRoundtrip(
+    const std::shared_ptr<StreamingCompressor>& compressor,
+    const std::shared_ptr<StreamingDecompressor>& decompressor,
+    const std::vector<uint8_t>& data) {
+  std::vector<uint8_t> compressed;
+  streamingCompress(compressor, data, compressed);
+  std::vector<uint8_t> decompressed;
+  streamingDecompress(decompressor, compressed, decompressed);
+  ASSERT_EQ(data, decompressed);
+}
+
+void checkStreamingRoundtrip(Codec* codec, const std::vector<uint8_t>& data) {
+  checkStreamingRoundtrip(
+      makeStreamingCompressor(codec), makeStreamingDecompressor(codec), data);
+}
+} // namespace
 
 class CompressionTest : public testing::Test {};
 
@@ -31,6 +333,7 @@ TEST_F(CompressionTest, testCompressionNames) {
   EXPECT_EQ("lzo", compressionKindToString(CompressionKind_LZO));
   EXPECT_EQ("lz4", compressionKindToString(CompressionKind_LZ4));
   EXPECT_EQ("zstd", compressionKindToString(CompressionKind_ZSTD));
+  EXPECT_EQ("gzip", compressionKindToString(CompressionKind_GZIP));
   EXPECT_EQ(
       "unknown - 99",
       compressionKindToString(static_cast<CompressionKind>(99)));
@@ -58,5 +361,155 @@ TEST_F(CompressionTest, stringToCompressionKind) {
   EXPECT_EQ(stringToCompressionKind("gzip"), CompressionKind_GZIP);
   VELOX_ASSERT_THROW(
       stringToCompressionKind("bz2"), "Not support compression kind bz2");
+}
+
+class CodecTest : public ::testing::TestWithParam<TestParams> {
+ protected:
+  static CompressionKind getCompressionKind() {
+    return GetParam().compressionKind;
+  }
+
+  static const CodecOptions& getCodecOptions() {
+    return *GetParam().codecOptions;
+  }
+
+  static std::unique_ptr<Codec> makeCodec() {
+    return Codec::create(getCompressionKind(), getCodecOptions())
+        .thenOrThrow(
+            [](auto codec) { return codec; },
+            [](const Status& invalid) {
+              VELOX_FAIL("Failed to create codec: {}", invalid);
+            });
+  }
+};
+
+TEST_P(CodecTest, specifyCompressionLevel) {
+  std::vector<uint8_t> data = makeRandomData(2000);
+  const auto kind = getCompressionKind();
+  if (!Codec::isAvailable(kind)) {
+    // Support for this codec hasn't been built.
+    VELOX_ASSERT_THROW(
+        Codec::create(kind, kUseDefaultCompressionLevel),
+        "Support for codec '" + compressionKindToString(kind) +
+            "' is either not built or not implemented.");
+    return;
+  }
+  auto codecDefault =
+      Codec::create(kind).thenOrThrow(folly::identity, throwsNotOk);
+  checkCodecRoundtrip(codecDefault, data);
+
+  for (const auto& compressionLevel :
+       {codecDefault->defaultCompressionLevel(),
+        codecDefault->minimumCompressionLevel(),
+        codecDefault->maximumCompressionLevel()}) {
+    auto codec = Codec::create(kind, compressionLevel)
+                     .thenOrThrow(folly::identity, throwsNotOk);
+    checkCodecRoundtrip(codec, data);
+  }
+}
+
+TEST_P(CodecTest, getUncompressedLength) {
+  auto codec = makeCodec();
+  auto inputLength = 100;
+  auto input = makeRandomData(inputLength);
+  std::vector<uint8_t> compressed(codec->maxCompressedLength(input.size()));
+  auto compressedLength =
+      codec
+          ->compress(
+              input.data(), inputLength, compressed.data(), compressed.size())
+          .thenOrThrow(folly::identity, throwsNotOk);
+  compressed.resize(compressedLength);
+
+  if (Codec::supportsGetUncompressedLength(getCompressionKind())) {
+    ASSERT_EQ(
+        codec->getUncompressedLength(compressed.data(), compressedLength),
+        inputLength);
+  } else {
+    ASSERT_EQ(
+        codec->getUncompressedLength(compressed.data(), compressedLength),
+        std::nullopt);
+  }
+}
+
+TEST_P(CodecTest, codecRoundtrip) {
+  auto codec = makeCodec();
+  for (int dataSize : {0, 10, 10000, 100000}) {
+    checkCodecRoundtrip(codec, makeRandomData(dataSize));
+    checkCodecRoundtrip(codec, makeCompressibleData(dataSize));
+  }
+}
+
+TEST_P(CodecTest, streamingCompressor) {
+  if (!Codec::supportsStreamingCompression(getCompressionKind())) {
+    return;
+  }
+
+  for (auto dataSize : {0, 10, 10000, 100000}) {
+    auto codec = makeCodec();
+    checkStreamingCompressor(codec.get(), makeRandomData(dataSize));
+    checkStreamingCompressor(codec.get(), makeCompressibleData(dataSize));
+  }
+}
+
+TEST_P(CodecTest, streamingDecompressor) {
+  if (!Codec::supportsStreamingCompression(getCompressionKind())) {
+    return;
+  }
+
+  for (auto dataSize : {0, 10, 10000, 100000}) {
+    auto codec = makeCodec();
+    checkStreamingDecompressor(codec.get(), makeRandomData(dataSize));
+    checkStreamingDecompressor(codec.get(), makeCompressibleData(dataSize));
+  }
+}
+
+TEST_P(CodecTest, streamingRoundtrip) {
+  if (!Codec::supportsStreamingCompression(getCompressionKind())) {
+    return;
+  }
+
+  for (auto dataSize : {0, 10, 10000, 100000}) {
+    auto codec = makeCodec();
+    checkStreamingRoundtrip(codec.get(), makeRandomData(dataSize));
+    checkStreamingRoundtrip(codec.get(), makeCompressibleData(dataSize));
+  }
+}
+
+TEST_P(CodecTest, streamingDecompressorReuse) {
+  if (!Codec::supportsStreamingCompression(getCompressionKind())) {
+    return;
+  }
+
+  auto codec = makeCodec();
+  const auto& decompressor = makeStreamingDecompressor(codec.get());
+  checkStreamingRoundtrip(
+      makeStreamingCompressor(codec.get()), decompressor, makeRandomData(100));
+
+  // StreamingDecompressor::reset() should allow reusing decompressor for a
+  // new stream.
+  ASSERT_TRUE(decompressor->reset().ok());
+  checkStreamingRoundtrip(
+      makeStreamingCompressor(codec.get()), decompressor, makeRandomData(200));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    TestLz4,
+    CodecTest,
+    ::testing::ValuesIn(generateLz4TestParams()));
+
+TEST(CodecLZ4HadoopTest, compatibility) {
+  // LZ4 Hadoop codec should be able to read back LZ4 raw blocks.
+  auto c1 = Codec::create(
+                CompressionKind::CompressionKind_LZ4,
+                Lz4CodecOptions{Lz4CodecOptions::kLz4Raw})
+                .thenOrThrow([](auto codec) { return codec; }, throwsNotOk);
+  auto c2 = Codec::create(
+                CompressionKind::CompressionKind_LZ4,
+                Lz4CodecOptions{Lz4CodecOptions::kLz4Hadoop})
+                .thenOrThrow([](auto codec) { return codec; }, throwsNotOk);
+
+  for (auto dataSize : {0, 10, 10000, 100000}) {
+    checkCodecRoundtrip(c1, c2, makeRandomData(dataSize));
+  }
 }
 } // namespace facebook::velox::common

--- a/velox/dwio/dwrf/reader/ReaderBase.h
+++ b/velox/dwio/dwrf/reader/ReaderBase.h
@@ -177,7 +177,7 @@ class ReaderBase {
   uint64_t compressionBlockSize() const {
     return postScript_->hasCompressionBlockSize()
         ? postScript_->compressionBlockSize()
-        : common::DEFAULT_COMPRESSION_BLOCK_SIZE;
+        : common::kDefaultCompressionBlockSize;
   }
 
   common::CompressionKind compressionKind() const {

--- a/velox/dwio/dwrf/test/TestDecompression.cpp
+++ b/velox/dwio/dwrf/test/TestDecompression.cpp
@@ -847,8 +847,12 @@ void writeHeader(char* buffer, size_t compressedSize, bool original) {
   buffer[2] = static_cast<char>(compressedSize >> 15);
 }
 
-size_t
-compress(char* buf, size_t size, char* output, size_t offset, Codec& codec) {
+size_t compress(
+    char* buf,
+    size_t size,
+    char* output,
+    size_t offset,
+    folly::io::Codec& codec) {
   auto ioBuf = folly::IOBuf::wrapBuffer(buf, size);
   auto compressed = codec.compress(ioBuf.get());
   auto str = compressed->moveToFbString();
@@ -873,7 +877,7 @@ class TestSeek : public ::testing::Test {
         kind, std::move(input), bufferSize, *pool_, "Test Decompression");
   }
 
-  void runTest(Codec& codec, CompressionKind kind) {
+  void runTest(folly::io::Codec& codec, CompressionKind kind) {
     constexpr size_t inputSize = 1024;
     constexpr size_t outputSize = 4096;
     char output[outputSize];
@@ -914,7 +918,7 @@ class TestSeek : public ::testing::Test {
   }
 
   static void prepareTestData(
-      Codec& codec,
+      folly::io::Codec& codec,
       char* input1,
       char* input2,
       size_t inputSize,


### PR DESCRIPTION
Initial implementation of the proposed unified compression API. This patch defines the Compression Codec API inspired by Apache Arrow and adds missing functions used in Velox. Adds support for codecs LZ4_FRAME, LZ4_RAW, and LZ4_HADOOP. Include unit tests.

Discussion: https://github.com/facebookincubator/velox/issues/7471