### PR TITLE
Allow custom input generators in Aggregation Fuzzer

### DIFF
--- a/velox/exec/tests/AggregationFuzzerTest.cpp
+++ b/velox/exec/tests/AggregationFuzzerTest.cpp
@@ -19,10 +19,13 @@
 #include <gtest/gtest.h>
 #include <unordered_set>
 
+#include <boost/random/uniform_int_distribution.hpp>
 #include "velox/exec/tests/utils/AggregationFuzzerRunner.h"
 #include "velox/exec/tests/utils/DuckQueryRunner.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/vector/FlatVector.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
 
 DEFINE_int64(
     seed,
@@ -36,6 +39,210 @@ DEFINE_string(
     "If specified, Fuzzer will only choose functions from "
     "this comma separated list of function names "
     "(e.g: --only \"min\" or --only \"sum,avg\").");
+
+namespace facebook::velox::exec::test {
+namespace {
+
+class MinMaxInputGenerator : public InputGenerator {
+ public:
+  MinMaxInputGenerator(const std::string& name) : indexOfN_{indexOfN(name)} {}
+
+  std::vector<VectorPtr> generate(
+      const std::vector<TypePtr>& types,
+      VectorFuzzer& fuzzer,
+      FuzzerGenerator& rng,
+      memory::MemoryPool* pool) override {
+    // TODO Generate inputs free of nested nulls.
+    if (types.size() <= indexOfN_) {
+      return {};
+    }
+
+    // Make sure to use the same value of 'n' for all batches in a given Fuzzer
+    // iteration.
+    if (!n_.has_value()) {
+      n_ = boost::random::uniform_int_distribution<int64_t>(0, 9'999)(rng);
+    }
+
+    const auto size = fuzzer.getOptions().vectorSize;
+
+    std::vector<VectorPtr> inputs;
+    inputs.reserve(types.size());
+    for (auto i = 0; i < types.size() - 1; ++i) {
+      inputs.push_back(fuzzer.fuzz(types[i]));
+    }
+
+    VELOX_CHECK(
+        types.back()->isBigint(),
+        "Unexpected type: {}",
+        types.back()->toString())
+    inputs.push_back(
+        BaseVector::createConstant(BIGINT(), n_.value(), size, pool));
+    return inputs;
+  }
+
+  void reset() override {
+    n_.reset();
+  }
+
+ private:
+  // Returns zero-based index of the 'n' argument, 1 for min and max. 2 for
+  // min_by and max_by.
+  static int32_t indexOfN(const std::string& name) {
+    if (name == "min" || name == "max") {
+      return 1;
+    }
+
+    if (name == "min_by" || name == "max_by") {
+      return 2;
+    }
+
+    VELOX_FAIL("Unexpected function name: {}", name)
+  }
+
+  // Zero-based index of the 'n' argument.
+  const int32_t indexOfN_;
+  std::optional<int64_t> n_;
+};
+
+class ApproxDistinctInputGenerator : public InputGenerator {
+ public:
+  std::vector<VectorPtr> generate(
+      const std::vector<TypePtr>& types,
+      VectorFuzzer& fuzzer,
+      FuzzerGenerator& rng,
+      memory::MemoryPool* pool) override {
+    if (types.size() != 2) {
+      return {};
+    }
+
+    // Make sure to use the same value of 'e' for all batches in a given Fuzzer
+    // iteration.
+    if (!e_.has_value()) {
+      // Generate value in [0.0040625, 0.26] range.
+      static constexpr double kMin = 0.0040625;
+      static constexpr double kMax = 0.26;
+      e_ = kMin + (kMax - kMin) * boost::random::uniform_01<double>()(rng);
+    }
+
+    const auto size = fuzzer.getOptions().vectorSize;
+
+    VELOX_CHECK(
+        types.back()->isDouble(),
+        "Unexpected type: {}",
+        types.back()->toString())
+    return {
+        fuzzer.fuzz(types[0]),
+        BaseVector::createConstant(DOUBLE(), e_.value(), size, pool)};
+  }
+
+  void reset() override {
+    e_.reset();
+  }
+
+ private:
+  std::optional<double> e_;
+};
+
+class ApproxPercentileInputGenerator : public InputGenerator {
+ public:
+  std::vector<VectorPtr> generate(
+      const std::vector<TypePtr>& types,
+      VectorFuzzer& fuzzer,
+      FuzzerGenerator& rng,
+      memory::MemoryPool* pool) override {
+    // The arguments are: x, [w], percentile(s), [accuracy].
+    //
+    // First argument is always 'x'. If second argument's type is BIGINT, then
+    // it is 'w'. Otherwise, it is percentile(x).
+
+    const auto size = fuzzer.getOptions().vectorSize;
+
+    std::vector<VectorPtr> inputs;
+    inputs.reserve(types.size());
+    inputs.push_back(fuzzer.fuzz(types[0]));
+
+    if (types[1]->isBigint()) {
+      velox::test::VectorMaker vectorMaker{pool};
+      auto weight = vectorMaker.flatVector<int64_t>(size, [&](auto row) {
+        return boost::random::uniform_int_distribution<int64_t>(1, 1'000)(rng);
+      });
+
+      inputs.push_back(weight);
+    }
+
+    const int percentileTypeIndex = types[1]->isBigint() ? 2 : 1;
+    const TypePtr& percentileType = types[percentileTypeIndex];
+    if (percentileType->isDouble()) {
+      if (!percentile_.has_value()) {
+        // Generate value in [0, 1] range.
+        percentile_ = boost::random::uniform_01<double>()(rng);
+      }
+
+      inputs.push_back(BaseVector::createConstant(
+          DOUBLE(), percentile_.value(), size, pool));
+    } else {
+      VELOX_CHECK(percentileType->isArray());
+      VELOX_CHECK(percentileType->childAt(0)->isDouble());
+
+      if (percentiles_.empty()) {
+        percentiles_.push_back(boost::random::uniform_01<double>()(rng));
+        percentiles_.push_back(boost::random::uniform_01<double>()(rng));
+        percentiles_.push_back(boost::random::uniform_01<double>()(rng));
+      }
+
+      auto arrayVector =
+          BaseVector::create<ArrayVector>(ARRAY(DOUBLE()), 1, pool);
+      auto elementsVector = arrayVector->elements()->asFlatVector<double>();
+      elementsVector->resize(percentiles_.size());
+      for (auto i = 0; i < percentiles_.size(); ++i) {
+        elementsVector->set(i, percentiles_[i]);
+      }
+      arrayVector->setOffsetAndSize(0, 0, percentiles_.size());
+
+      inputs.push_back(BaseVector::wrapInConstant(size, 0, arrayVector));
+    }
+
+    if (types.size() > percentileTypeIndex + 1) {
+      // Last argument is 'accuracy'.
+      VELOX_CHECK(types.back()->isDouble());
+      if (!accuracy_.has_value()) {
+        accuracy_ = boost::random::uniform_01<double>()(rng);
+      }
+
+      inputs.push_back(
+          BaseVector::createConstant(DOUBLE(), accuracy_.value(), size, pool));
+    }
+
+    return inputs;
+  }
+
+  void reset() override {
+    percentile_.reset();
+    percentiles_.clear();
+    accuracy_.reset();
+  }
+
+ private:
+  std::optional<double> percentile_;
+  std::vector<double> percentiles_;
+  std::optional<double> accuracy_;
+};
+
+std::unordered_map<std::string, std::shared_ptr<InputGenerator>>
+getCustomInputGenerators() {
+  return {
+      {"min", std::make_shared<MinMaxInputGenerator>("min")},
+      {"min_by", std::make_shared<MinMaxInputGenerator>("min_by")},
+      {"max", std::make_shared<MinMaxInputGenerator>("max")},
+      {"max_by", std::make_shared<MinMaxInputGenerator>("max_by")},
+      {"approx_distinct", std::make_shared<ApproxDistinctInputGenerator>()},
+      {"approx_set", std::make_shared<ApproxDistinctInputGenerator>()},
+      {"approx_percentile", std::make_shared<ApproxPercentileInputGenerator>()},
+  };
+}
+
+} // namespace
+} // namespace facebook::velox::exec::test
 
 int main(int argc, char** argv) {
   facebook::velox::aggregate::prestosql::registerAllAggregateFunctions();
@@ -60,6 +267,13 @@ int main(int argc, char** argv) {
       "stddev_pop",
       // Lambda functions are not supported yet.
       "reduce_agg",
+      // TODO Allow skipping all companion functions, perhaps, by adding a flag
+      // to register API to disable registration of companion functions.
+      "approx_distinct_partial",
+      "approx_distinct_merge",
+      "approx_set_partial",
+      "approx_percentile_partial",
+      "approx_percentile_merge",
   };
 
   // Functions whose results verification should be skipped. These can be
@@ -78,6 +292,7 @@ int main(int argc, char** argv) {
           {"approx_set", ""},
           {"approx_set_partial", ""},
           {"approx_set_merge", ""},
+          {"approx_percentile", ""},
           {"approx_percentile_partial", ""},
           {"approx_percentile_merge", ""},
           {"arbitrary", ""},
@@ -92,7 +307,6 @@ int main(int argc, char** argv) {
           {"map_union_sum", "\"$internal$canonicalize\"(map_keys({}))"},
           {"max_by", ""},
           {"min_by", ""},
-          {"map_union_sum", "\"$internal$canonicalize\"(map_keys({}))"},
           {"multimap_agg",
            "transform_values({}, (k, v) -> \"$internal$canonicalize\"(v))"},
           // TODO: Skip result verification of companion functions that return
@@ -118,6 +332,8 @@ int main(int argc, char** argv) {
   options.onlyFunctions = FLAGS_only;
   options.skipFunctions = skipFunctions;
   options.customVerificationFunctions = customVerificationFunctions;
+  options.customInputGenerators =
+      facebook::velox::exec::test::getCustomInputGenerators();
   options.timestampPrecision =
       facebook::velox::VectorFuzzer::Options::TimestampPrecision::kMilliSeconds;
   return Runner::run(initialSeed, std::move(duckQueryRunner), options);

--- a/velox/exec/tests/utils/AggregationFuzzer.h
+++ b/velox/exec/tests/utils/AggregationFuzzer.h
@@ -23,6 +23,22 @@ namespace facebook::velox::exec::test {
 
 static constexpr const std::string_view kPlanNodeFileName = "plan_nodes";
 
+class InputGenerator {
+ public:
+  virtual ~InputGenerator() = default;
+
+  /// Generates function inputs of the specified types. May return an empty list
+  /// to let Fuzzer use randomly-generated inputs.
+  virtual std::vector<VectorPtr> generate(
+      const std::vector<TypePtr>& types,
+      VectorFuzzer& fuzzer,
+      FuzzerGenerator& rng,
+      memory::MemoryPool* pool) = 0;
+
+  /// Called after generating all inputs for a given fuzzer iteration.
+  virtual void reset() = 0;
+};
+
 /// Runs the aggregation fuzzer.
 /// @param signatureMap Map of all aggregate function signatures.
 /// @param seed Random seed - Pass the same seed for reproducibility.
@@ -36,6 +52,8 @@ void aggregateFuzzer(
     AggregateFunctionSignatureMap signatureMap,
     size_t seed,
     const std::unordered_map<std::string, std::string>& orderDependentFunctions,
+    const std::unordered_map<std::string, std::shared_ptr<InputGenerator>>&
+        customInputGenerators,
     VectorFuzzer::Options::TimestampPrecision timestampPrecision,
     const std::unordered_map<std::string, std::string>& queryConfigs,
     const std::optional<std::string>& planPath,

--- a/velox/exec/tests/utils/AggregationFuzzerRunner.h
+++ b/velox/exec/tests/utils/AggregationFuzzerRunner.h
@@ -91,6 +91,9 @@ class AggregationFuzzerRunner {
     /// transformation applies function 'f' to aggregation result.
     std::unordered_map<std::string, std::string> customVerificationFunctions;
 
+    std::unordered_map<std::string, std::shared_ptr<InputGenerator>>
+        customInputGenerators;
+
     /// Timestamp precision to use when generating inputs of type TIMESTAMP.
     VectorFuzzer::Options::TimestampPrecision timestampPrecision{
         VectorFuzzer::Options::TimestampPrecision::kNanoSeconds};
@@ -144,6 +147,7 @@ class AggregationFuzzerRunner {
         filteredSignatures,
         seed,
         options.customVerificationFunctions,
+        options.customInputGenerators,
         options.timestampPrecision,
         options.queryConfigs,
         planPath,


### PR DESCRIPTION
Introduce InputGenerator interface to customize input generation for individual
aggregate functions. Use this to customize (1) 'n' argument for
min/max/min_by/max_by to use a constant value within [0, 10000] range, (2) 'e' 
argument for approx_distinct to use a constant value within [0.0040625, 0.26] 
range; (3) w, percentile(s) and accuracy arguments for approx_percentile to 
use valid values.

Fix approx_distinct function to allow 'e' argument to be constant, but not necessarily 
constant-encoded.

Fix approx_percentile to allow percentile(s) and accuracy arguments to be constant, 
but not necessarily constant-encoded.

Add logic to keep track of signatures that fail more than 50% of the time. This
data will help prioritize adding custom input generators.

Part of #7596