### PR TITLE
Rename NoStop null handling mode to NullAsValue

### DIFF
--- a/pyvelox/pyvelox.h
+++ b/pyvelox/pyvelox.h
@@ -121,7 +121,7 @@ inline void checkRowVectorBounds(const RowVectorPtr& v, vector_size_t idx) {
 
 bool compareRowVector(const RowVectorPtr& u, const RowVectorPtr& v) {
   CompareFlags compFlags;
-  compFlags.nullHandlingMode = CompareFlags::NullHandlingMode::NoStop;
+  compFlags.nullHandlingMode = CompareFlags::NullHandlingMode::kNullAsValue;
   compFlags.equalsOnly = true;
   if (u->size() != v->size()) {
     return false;

--- a/velox/benchmarks/basic/VectorCompare.cpp
+++ b/velox/benchmarks/basic/VectorCompare.cpp
@@ -81,7 +81,7 @@ class VectorCompareBenchmark : public functions::test::FunctionBenchmarkBase {
       true,
       true,
       false,
-      CompareFlags::NullHandlingMode::NoStop};
+      CompareFlags::NullHandlingMode::kNullAsValue};
 
   const size_t vectorSize_;
   SelectivityVector rows_;

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -344,7 +344,7 @@ HiveDataSink::HiveDataSink(
           {sortedProperty.at(i)->sortOrder().isNullsFirst(),
            sortedProperty.at(i)->sortOrder().isAscending(),
            false,
-           CompareFlags::NullHandlingMode::NoStop});
+           CompareFlags::NullHandlingMode::kNullAsValue});
     }
   }
 }

--- a/velox/exec/ContainerRowSerde.cpp
+++ b/velox/exec/ContainerRowSerde.cpp
@@ -809,7 +809,7 @@ int32_t ContainerRowSerde::compare(
     CompareFlags flags) {
   VELOX_DCHECK(
       !right.isNullAt(index), "Null top-level values are not supported");
-  VELOX_DCHECK(!flags.mayStopAtNull(), "not supported null handling mode");
+  VELOX_DCHECK(flags.nullAsValue(), "not supported null handling mode");
   return compareSwitch(left, *right.base(), right.index(index), flags).value();
 }
 
@@ -819,7 +819,7 @@ int32_t ContainerRowSerde::compare(
     ByteInputStream& right,
     const Type* type,
     CompareFlags flags) {
-  VELOX_DCHECK(!flags.mayStopAtNull(), "not supported null handling mode");
+  VELOX_DCHECK(flags.nullAsValue(), "not supported null handling mode");
 
   return compareSwitch(left, right, type, flags).value();
 }

--- a/velox/exec/ContainerRowSerde.h
+++ b/velox/exec/ContainerRowSerde.h
@@ -33,9 +33,9 @@ class ContainerRowSerde {
   deserialize(ByteInputStream& in, vector_size_t index, BaseVector* result);
 
   /// Returns < 0 if 'left' is less than 'right' at 'index', 0 if
-  /// equal and > 0 otherwise. flags.nullHandlingMode can be only NoStop and
-  /// support null-safe equal.
-  /// Top level rows in right are not allowed to be null.
+  /// equal and > 0 otherwise. flags.nullHandlingMode can be only NullAsValue
+  /// and support null-safe equal. Top level rows in right are not allowed to be
+  /// null.
   static int32_t compare(
       ByteInputStream& left,
       const DecodedVector& right,
@@ -43,8 +43,8 @@ class ContainerRowSerde {
       CompareFlags flags);
 
   /// Returns < 0 if 'left' is less than 'right' at 'index', 0 if
-  /// equal and > 0 otherwise. flags.nullHandlingMode can be only NoStop and
-  /// support null-safe equal.
+  /// equal and > 0 otherwise. flags.nullHandlingMode can be only NullAsValue
+  /// and support null-safe equal.
   static int32_t compare(
       ByteInputStream& left,
       ByteInputStream& right,
@@ -54,9 +54,8 @@ class ContainerRowSerde {
   /// Returns < 0 if 'left' is less than 'right' at 'index', 0 if
   /// equal and > 0 otherwise. If flags.nullHandlingMode is StopAtNull,
   /// returns std::nullopt if either 'left' or 'right' value is null or contains
-  /// a null. If flags.nullHandlingMode is NoStop then NULL is considered equal
-  /// to NULL.
-  /// Top level rows in right are not allowed to be null.
+  /// a null. If flags.nullHandlingMode is NullAsValue then NULL is considered
+  /// equal to NULL. Top level rows in right are not allowed to be null.
   static std::optional<int32_t> compareWithNulls(
       ByteInputStream& left,
       const DecodedVector& right,
@@ -66,8 +65,8 @@ class ContainerRowSerde {
   /// Returns < 0 if 'left' is less than 'right' at 'index', 0 if
   /// equal and > 0 otherwise. If flags.nullHandlingMode is StopAtNull,
   /// returns std::nullopt if either 'left' or 'right' value is null or contains
-  /// a null. If flags.nullHandlingMode is NoStop then NULL is considered equal
-  /// to NULL.
+  /// a null. If flags.nullHandlingMode is NullAsValue then NULL is considered
+  /// equal to NULL.
   static std::optional<int32_t> compareWithNulls(
       ByteInputStream& left,
       ByteInputStream& right,

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -192,8 +192,7 @@ bool SourceStream::operator<(const MergeStream& other) const {
   for (auto i = 0; i < sortingKeys_.size(); ++i) {
     const auto& [_, compareFlags] = sortingKeys_[i];
     VELOX_DCHECK(
-        compareFlags.nullHandlingMode == CompareFlags::NullHandlingMode::NoStop,
-        "not supported null handling mode");
+        compareFlags.nullAsValue(), "not supported null handling mode");
     if (auto result = keyColumns_[i]
                           ->compare(
                               otherCursor.keyColumns_[i],

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -26,7 +26,7 @@ CompareFlags fromSortOrderToCompareFlags(const core::SortOrder& sortOrder) {
       sortOrder.isNullsFirst(),
       sortOrder.isAscending(),
       false,
-      CompareFlags::NullHandlingMode::NoStop};
+      CompareFlags::NullHandlingMode::kNullAsValue};
 }
 } // namespace
 

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -699,7 +699,7 @@ int RowContainer::compareComplexType(
     const DecodedVector& decoded,
     vector_size_t index,
     CompareFlags flags) {
-  VELOX_DCHECK(!flags.mayStopAtNull(), "not supported null handling mode");
+  VELOX_DCHECK(flags.nullAsValue(), "not supported null handling mode");
 
   auto stream = prepareRead(row, offset);
   return ContainerRowSerde::compare(stream, decoded, index, flags);
@@ -719,7 +719,7 @@ int32_t RowContainer::compareComplexType(
     int32_t leftOffset,
     int32_t rightOffset,
     CompareFlags flags) {
-  VELOX_DCHECK(!flags.mayStopAtNull(), "not supported null handling mode");
+  VELOX_DCHECK(flags.nullAsValue(), "not supported null handling mode");
 
   auto leftStream = prepareRead(left, leftOffset);
   auto rightStream = prepareRead(right, rightOffset);

--- a/velox/exec/tests/ContainerRowSerdeTest.cpp
+++ b/velox/exec/tests/ContainerRowSerdeTest.cpp
@@ -135,7 +135,7 @@ class ContainerRowSerdeTest : public testing::Test,
         true, // nullsFirst
         true, // ascending
         true,
-        CompareFlags::NullHandlingMode::NoStop};
+        CompareFlags::NullHandlingMode::kNullAsValue};
 
     DecodedVector decodedVector(*vector);
 
@@ -254,19 +254,19 @@ TEST_F(ContainerRowSerdeTest, compareNullsInArrayVector) {
       positions,
       {{0}, {1}, {-1}, std::nullopt, std::nullopt, std::nullopt},
       false,
-      CompareFlags::NullHandlingMode::StopAtNull);
+      CompareFlags::NullHandlingMode::kStopAtNull);
   testCompareWithNulls(
       decodedVector,
       positions,
       {{0}, {1}, {1}, {1}, std::nullopt, {1}},
       true,
-      CompareFlags::NullHandlingMode::StopAtNull);
+      CompareFlags::NullHandlingMode::kStopAtNull);
   testCompareWithNulls(
       decodedVector,
       positions,
       {{0}, {1}, {-1}, {1}, {0}, {-1}},
       false,
-      CompareFlags::NullHandlingMode::NoStop);
+      CompareFlags::NullHandlingMode::kNullAsValue);
 
   allocator_.clear();
 }
@@ -292,19 +292,19 @@ TEST_F(ContainerRowSerdeTest, compareNullsInMapVector) {
       positions,
       {{-1}, {0}, {1}, std::nullopt},
       false,
-      CompareFlags::NullHandlingMode::StopAtNull);
+      CompareFlags::NullHandlingMode::kStopAtNull);
   testCompareWithNulls(
       decodedVector,
       positions,
       {{1}, {0}, {1}, std::nullopt},
       true,
-      CompareFlags::NullHandlingMode::StopAtNull);
+      CompareFlags::NullHandlingMode::kStopAtNull);
   testCompareWithNulls(
       decodedVector,
       positions,
       {{1}, {0}, {1}, {0}},
       true,
-      CompareFlags::NullHandlingMode::NoStop);
+      CompareFlags::NullHandlingMode::kNullAsValue);
 
   allocator_.clear();
 }
@@ -321,13 +321,13 @@ TEST_F(ContainerRowSerdeTest, compareNullsInRowVector) {
       positions,
       {{0}, {-1}, {1}, std::nullopt},
       false,
-      CompareFlags::NullHandlingMode::StopAtNull);
+      CompareFlags::NullHandlingMode::kStopAtNull);
   testCompareWithNulls(
       decodedVector,
       positions,
       {{0}, {-1}, {1}, {1}},
       false,
-      CompareFlags::NullHandlingMode::NoStop);
+      CompareFlags::NullHandlingMode::kNullAsValue);
 
   allocator_.clear();
 }
@@ -359,21 +359,21 @@ TEST_F(ContainerRowSerdeTest, compareNullsInArrayByteStream) {
       {{0}, {1}, {-1}, std::nullopt, std::nullopt, std::nullopt},
       ARRAY(BIGINT()),
       false,
-      CompareFlags::NullHandlingMode::StopAtNull);
+      CompareFlags::NullHandlingMode::kStopAtNull);
   testCompareByteStreamWithNulls(
       leftPositions,
       rightPositions,
       {{0}, {1}, {1}, {1}, std::nullopt, {1}},
       ARRAY(BIGINT()),
       true,
-      CompareFlags::NullHandlingMode::StopAtNull);
+      CompareFlags::NullHandlingMode::kStopAtNull);
   testCompareByteStreamWithNulls(
       leftPositions,
       rightPositions,
       {{0}, {1}, {-1}, {1}, {0}, {-1}},
       ARRAY(BIGINT()),
       false,
-      CompareFlags::NullHandlingMode::NoStop);
+      CompareFlags::NullHandlingMode::kNullAsValue);
 
   allocator_.clear();
 }
@@ -394,14 +394,14 @@ TEST_F(ContainerRowSerdeTest, compareNullsInRowByteStream) {
       {{0}, {-1}, {1}, std::nullopt},
       ROW({INTEGER(), INTEGER()}),
       false,
-      CompareFlags::NullHandlingMode::StopAtNull);
+      CompareFlags::NullHandlingMode::kStopAtNull);
   testCompareByteStreamWithNulls(
       leftPositions,
       rightPositions,
       {{0}, {-1}, {1}, {1}},
       ROW({INTEGER(), INTEGER()}),
       false,
-      CompareFlags::NullHandlingMode::NoStop);
+      CompareFlags::NullHandlingMode::kNullAsValue);
 
   allocator_.clear();
 }
@@ -429,21 +429,21 @@ TEST_F(ContainerRowSerdeTest, compareNullsInMapByteStream) {
       {{-1}, {0}, {1}, std::nullopt},
       MAP(BIGINT(), BIGINT()),
       false,
-      CompareFlags::NullHandlingMode::StopAtNull);
+      CompareFlags::NullHandlingMode::kStopAtNull);
   testCompareByteStreamWithNulls(
       leftPositions,
       rightPositions,
       {{1}, {0}, {1}, std::nullopt},
       MAP(BIGINT(), BIGINT()),
       true,
-      CompareFlags::NullHandlingMode::StopAtNull);
+      CompareFlags::NullHandlingMode::kStopAtNull);
   testCompareByteStreamWithNulls(
       leftPositions,
       rightPositions,
       {{1}, {0}, {1}, {0}},
       MAP(BIGINT(), BIGINT()),
       true,
-      CompareFlags::NullHandlingMode::NoStop);
+      CompareFlags::NullHandlingMode::kNullAsValue);
 
   allocator_.clear();
 }

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -57,8 +57,8 @@ class SortBufferTest : public OperatorTestBase {
   // Specifies the sort columns ["c4", "c1"].
   std::vector<column_index_t> sortColumnIndices_{4, 1};
   std::vector<CompareFlags> sortCompareFlags_{
-      {true, true, false, CompareFlags::NullHandlingMode::NoStop},
-      {true, true, false, CompareFlags::NullHandlingMode::NoStop}};
+      {true, true, false, CompareFlags::NullHandlingMode::kNullAsValue},
+      {true, true, false, CompareFlags::NullHandlingMode::kNullAsValue}};
 
   const int64_t maxBytes_ = 20LL << 20; // 20 MB
   const std::shared_ptr<memory::MemoryPool> rootPool_{
@@ -94,12 +94,12 @@ TEST_F(SortBufferTest, singleKey) {
       {{{true,
          true,
          false,
-         CompareFlags::NullHandlingMode::NoStop}}, // Ascending
+         CompareFlags::NullHandlingMode::kNullAsValue}}, // Ascending
        {1, 2, 3, 4, 5}},
       {{{true,
          false,
          false,
-         CompareFlags::NullHandlingMode::NoStop}}, // Descending
+         CompareFlags::NullHandlingMode::kNullAsValue}}, // Descending
        {5, 4, 3, 2, 1}}};
 
   // Specifies the sort columns ["c1"].
@@ -194,7 +194,7 @@ TEST_F(SortBufferTest, DISABLED_randomData) {
             {"c4", DOUBLE()},
             {"c5", VARCHAR()}}),
        {2},
-       {{true, true, false, CompareFlags::NullHandlingMode::NoStop}}},
+       {{true, true, false, CompareFlags::NullHandlingMode::kNullAsValue}}},
       {ROW(
            {{"c0", BIGINT()},
             {"c1", INTEGER()},
@@ -203,8 +203,8 @@ TEST_F(SortBufferTest, DISABLED_randomData) {
             {"c4", DOUBLE()},
             {"c5", VARCHAR()}}),
        {4, 1},
-       {{true, true, false, CompareFlags::NullHandlingMode::NoStop},
-        {true, true, false, CompareFlags::NullHandlingMode::NoStop}}},
+       {{true, true, false, CompareFlags::NullHandlingMode::kNullAsValue},
+        {true, true, false, CompareFlags::NullHandlingMode::kNullAsValue}}},
       {ROW(
            {{"c0", BIGINT()},
             {"c1", INTEGER()},
@@ -213,8 +213,8 @@ TEST_F(SortBufferTest, DISABLED_randomData) {
             {"c4", DOUBLE()},
             {"c5", VARCHAR()}}),
        {4, 1},
-       {{true, true, false, CompareFlags::NullHandlingMode::NoStop},
-        {false, false, false, CompareFlags::NullHandlingMode::NoStop}}}};
+       {{true, true, false, CompareFlags::NullHandlingMode::kNullAsValue},
+        {false, false, false, CompareFlags::NullHandlingMode::kNullAsValue}}}};
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());

--- a/velox/expression/tests/GenericViewTest.cpp
+++ b/velox/expression/tests/GenericViewTest.cpp
@@ -143,7 +143,7 @@ TEST_F(GenericViewTest, compare) {
   ASSERT_NE(reader[0].compare(reader[1], flags).value(), 0);
   ASSERT_NE(reader[0].compare(reader[2], flags).value(), 0);
 
-  flags.nullHandlingMode = CompareFlags::NullHandlingMode::StopAtNull;
+  flags.nullHandlingMode = CompareFlags::NullHandlingMode::kStopAtNull;
   ASSERT_FALSE(reader[0].compare(reader[2], flags).has_value());
   ASSERT_TRUE(reader[0].compare(reader[1], flags).has_value());
 }

--- a/velox/functions/lib/aggregates/SingleValueAccumulator.h
+++ b/velox/functions/lib/aggregates/SingleValueAccumulator.h
@@ -37,7 +37,8 @@ struct SingleValueAccumulator {
   /// then new value; >0 if stored value is greater than new value. If
   /// flags.nullHandlingMode is StopAtNull, returns std::nullopt
   /// in case of null array elements, map values, and struct fields.
-  /// If flags.nullHandlingMode is NoStop then NULL is considered equal to NULL.
+  /// If flags.nullHandlingMode is NullAsValue then NULL is considered equal to
+  /// NULL.
   std::optional<int32_t> compare(
       const DecodedVector& decoded,
       vector_size_t index,

--- a/velox/functions/prestosql/ArrayContains.cpp
+++ b/velox/functions/prestosql/ArrayContains.cpp
@@ -112,7 +112,7 @@ void applyComplexType(
             searchBase,
             elementIndices[offset + i],
             searchIndex,
-            CompareFlags::NullHandlingMode::StopAtNull);
+            CompareFlags::NullHandlingMode::kStopAtNull);
         VELOX_USER_CHECK(
             result.has_value(),
             "contains does not support arrays with elements that contain null");

--- a/velox/functions/prestosql/ArrayFunctions.h
+++ b/velox/functions/prestosql/ArrayFunctions.h
@@ -842,7 +842,7 @@ struct ArrayRemoveFunction {
       const arg_type<Array<Generic<T1>>>& array,
       const arg_type<Generic<T1>>& element) {
     static constexpr CompareFlags kFlags = {
-        false, false, true, CompareFlags::NullHandlingMode::StopAtNull};
+        false, false, true, CompareFlags::NullHandlingMode::kStopAtNull};
     std::vector<std::optional<exec::GenericView>> toCopyItems;
     for (const auto& item : array) {
       if (item.has_value()) {

--- a/velox/functions/prestosql/ArraySort.cpp
+++ b/velox/functions/prestosql/ArraySort.cpp
@@ -45,7 +45,7 @@ BufferPtr sortElements(
 
   CompareFlags flags{.nullsFirst = false, .ascending = ascending};
   if (throwOnNestedNull) {
-    flags.nullHandlingMode = CompareFlags::NullHandlingMode::StopAtNull;
+    flags.nullHandlingMode = CompareFlags::NullHandlingMode::kStopAtNull;
   }
 
   auto decodedIndices = decodedElements->indices();

--- a/velox/functions/prestosql/Comparisons.h
+++ b/velox/functions/prestosql/Comparisons.h
@@ -130,7 +130,7 @@ struct EqFunction : public TimestampWithTimezoneComparisonSupport<T> {
         false,
         false,
         /*euqalsOnly*/ true,
-        CompareFlags::NullHandlingMode::StopAtNull /*nullHandlingMode*/};
+        CompareFlags::NullHandlingMode::kStopAtNull /*nullHandlingMode*/};
     auto result = lhs.compare(rhs, kFlags);
     if (!result.has_value()) {
       return false;

--- a/velox/functions/prestosql/aggregates/Compare.cpp
+++ b/velox/functions/prestosql/aggregates/Compare.cpp
@@ -28,7 +28,7 @@ int32_t compare(
       true, // nullsFirst
       true, // ascending
       false, // equalsOnly
-      CompareFlags::NullHandlingMode::StopAtNull};
+      CompareFlags::NullHandlingMode::kStopAtNull};
 
   auto result = accumulator->compare(decoded, index, kCompareFlags);
   VELOX_USER_CHECK(

--- a/velox/functions/sparksql/aggregates/MinMaxByAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/MinMaxByAggregate.cpp
@@ -60,7 +60,7 @@ struct SparkComparator {
         true, // nullsFirst
         true, // ascending
         false, // equalsOnly
-        CompareFlags::NullHandlingMode::NoStop};
+        CompareFlags::NullHandlingMode::kNullAsValue};
     auto result = accumulator->compare(decoded, index, kCompareFlags);
     return result.value();
   }

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -262,14 +262,14 @@ class BaseVector {
         false,
         false,
         true /*equalOnly*/,
-        CompareFlags::NullHandlingMode::NoStop /*nullHandlingMode**/};
-    // Will always have value because nullHandlingMode is NoStop.
+        CompareFlags::NullHandlingMode::kNullAsValue};
+    // Will always have value because nullHandlingMode is NullAsValue.
     return compare(other, index, otherIndex, kEqualValueAtFlags).value() == 0;
   }
 
   /// Returns true if this vector has the same value at the given index as the
   /// other vector at the other vector's index (including if both are null when
-  /// nullHandlingMode is NoStop), false otherwise. If nullHandlingMode is
+  /// nullHandlingMode is NullAsValue), false otherwise. If nullHandlingMode is
   /// StopAtNull, returns std::nullopt if null encountered.
   virtual std::optional<bool> equalValueAt(
       const BaseVector* other,
@@ -289,7 +289,7 @@ class BaseVector {
   /// than 'other' at 'otherIndex', 0 if equal and > 0 otherwise.
   /// When CompareFlags is DESCENDING, returns < 0 if 'this' at 'index' is
   /// larger than 'other' at 'otherIndex', 0 if equal and < 0 otherwise. If
-  /// flags.nullHandlingMode is not NoStop, the function may returns
+  /// flags.nullHandlingMode is not NullAsValue, the function may returns
   /// std::nullopt if null encountered.
   virtual std::optional<int32_t> compare(
       const BaseVector* other,
@@ -805,9 +805,9 @@ class BaseVector {
   compareNulls(bool thisNull, bool otherNull, CompareFlags flags) {
     DCHECK(thisNull || otherNull);
     switch (flags.nullHandlingMode) {
-      case CompareFlags::NullHandlingMode::StopAtNull:
+      case CompareFlags::NullHandlingMode::kStopAtNull:
         return std::nullopt;
-      case CompareFlags::NullHandlingMode::NoStop:
+      case CompareFlags::NullHandlingMode::kNullAsValue:
       default:
         break;
     }

--- a/velox/vector/tests/VectorCompareTest.cpp
+++ b/velox/vector/tests/VectorCompareTest.cpp
@@ -36,7 +36,7 @@ class VectorCompareTest : public testing::Test,
       bool expectNull,
       bool equalsOnly = false) {
     CompareFlags testFlags;
-    testFlags.nullHandlingMode = CompareFlags::NullHandlingMode::StopAtNull;
+    testFlags.nullHandlingMode = CompareFlags::NullHandlingMode::kStopAtNull;
     testFlags.equalsOnly = equalsOnly;
 
     ASSERT_EQ(
@@ -60,7 +60,7 @@ TEST_F(VectorCompareTest, compareStopAtNullFlat) {
 // Test SimpleVector<ComplexType>::compare()
 TEST_F(VectorCompareTest, compareStopAtNullSimpleComplex) {
   CompareFlags testFlags;
-  testFlags.nullHandlingMode = CompareFlags::NullHandlingMode::StopAtNull;
+  testFlags.nullHandlingMode = CompareFlags::NullHandlingMode::kStopAtNull;
 
   auto flatVector =
       vectorMaker_.arrayVectorNullable<int32_t>({{{1, 2, 3}}, std::nullopt});

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -3234,20 +3234,20 @@ TEST_F(VectorTest, primitiveTypeNullEqual) {
   auto equalNoStop = [&](vector_size_t i, vector_size_t j) {
     return base
         ->equalValueAt(
-            other.get(), i, j, CompareFlags::NullHandlingMode::NoStop)
+            other.get(), i, j, CompareFlags::NullHandlingMode::kNullAsValue)
         .value();
   };
 
   auto equalStopAtNull = [&](vector_size_t i, vector_size_t j) {
     return base->equalValueAt(
-        other.get(), i, j, CompareFlags::NullHandlingMode::StopAtNull);
+        other.get(), i, j, CompareFlags::NullHandlingMode::kStopAtNull);
   };
 
   // No null compare.
   ASSERT_TRUE(equalNoStop(0, 0));
   ASSERT_TRUE(equalStopAtNull(0, 0).value());
 
-  // Null compare in NoStop mode.
+  // Null compare in NullAsValue mode.
   ASSERT_FALSE(equalNoStop(1, 1));
   ASSERT_FALSE(equalNoStop(2, 2));
 
@@ -3264,13 +3264,13 @@ TEST_F(VectorTest, complexTypeNullEqual) {
   auto equalNoStop = [&](vector_size_t i, vector_size_t j) {
     return base
         ->equalValueAt(
-            other.get(), i, j, CompareFlags::NullHandlingMode::NoStop)
+            other.get(), i, j, CompareFlags::NullHandlingMode::kNullAsValue)
         .value();
   };
 
   auto equalStopAtNull = [&](vector_size_t i, vector_size_t j) {
     return base->equalValueAt(
-        other.get(), i, j, CompareFlags::NullHandlingMode::StopAtNull);
+        other.get(), i, j, CompareFlags::NullHandlingMode::kStopAtNull);
   };
 
   // No null compare, [0, 1] vs [0, 1].
@@ -3281,7 +3281,7 @@ TEST_F(VectorTest, complexTypeNullEqual) {
   ASSERT_FALSE(equalNoStop(2, 2));
   ASSERT_FALSE(equalStopAtNull(2, 2).value());
 
-  // Null compare in NoStop mode, [2, 2] vs [2, null].
+  // Null compare in NullAsValue mode, [2, 2] vs [2, null].
   ASSERT_FALSE(equalNoStop(1, 1));
 
   // Null compare in StopAtNull mode, [2, 2] vs [2, null].
@@ -3305,13 +3305,13 @@ TEST_F(VectorTest, dictionaryNullEqual) {
   auto equalNoStop = [&](vector_size_t i, vector_size_t j) {
     return dictVector
         ->equalValueAt(
-            other.get(), i, j, CompareFlags::NullHandlingMode::NoStop)
+            other.get(), i, j, CompareFlags::NullHandlingMode::kNullAsValue)
         .value();
   };
 
   auto equalStopAtNull = [&](vector_size_t i, vector_size_t j) {
     return dictVector->equalValueAt(
-        other.get(), i, j, CompareFlags::NullHandlingMode::StopAtNull);
+        other.get(), i, j, CompareFlags::NullHandlingMode::kStopAtNull);
   };
 
   for (vector_size_t i = 0; i < 2; ++i) {
@@ -3323,7 +3323,7 @@ TEST_F(VectorTest, dictionaryNullEqual) {
     ASSERT_FALSE(equalNoStop(2 + i * baseVectorSize, 2));
     ASSERT_FALSE(equalStopAtNull(2 + i * baseVectorSize, 2).value());
 
-    // Null compare in NoStop mode, [2, 2] vs [2, null].
+    // Null compare in NullAsValue mode, [2, 2] vs [2, null].
     ASSERT_FALSE(equalNoStop(1 + i * baseVectorSize, 1));
 
     // Null compare in StopAtNull mode, [2, 2] vs [2, null].
@@ -3345,20 +3345,20 @@ TEST_F(VectorTest, constantNullEqual) {
   auto equalNoStop = [&](vector_size_t i, vector_size_t j) {
     return constantVector
         ->equalValueAt(
-            other.get(), i, j, CompareFlags::NullHandlingMode::NoStop)
+            other.get(), i, j, CompareFlags::NullHandlingMode::kNullAsValue)
         .value();
   };
 
   auto equalStopAtNull = [&](vector_size_t i, vector_size_t j) {
     return constantVector->equalValueAt(
-        other.get(), i, j, CompareFlags::NullHandlingMode::StopAtNull);
+        other.get(), i, j, CompareFlags::NullHandlingMode::kStopAtNull);
   };
 
   // No null compare, [2, null] vs [0, 1], [2, null] vs [1, 2].
   ASSERT_FALSE(equalNoStop(0, 0));
   ASSERT_FALSE(equalStopAtNull(0, 2).value());
 
-  // Null compare in NoStop mode, [2, null] vs [2, null].
+  // Null compare in NullAsValue mode, [2, null] vs [2, null].
   ASSERT_TRUE(equalNoStop(0, 1));
 
   // Null compare in StopAtNull mode, [2, null] vs [2, null].


### PR DESCRIPTION
Summary:
This is the first diff of a sequence of diffs implementing the proposed solution in
https://github.com/facebookincubator/velox/issues/7536#issuecomment-1812947077

When nullHandlingMode is NullAsValue mode null is treated as a value such that
- null == null is true.
- null == value is false.
- if flags.equalsOnly=false, order of null determined by the flag nullsFirst.

This diff also exposed some the current usages of NoStop that are wrong and probably need to be changed.
this is not complete set since some other usages might be using the default constructor.

Differential Revision: D51378394


