### PR TITLE
Fix HashStringAllocator::storeStringFast corner case exception

### DIFF
--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -537,12 +537,11 @@ inline bool HashStringAllocator::storeStringFast(
   } else {
     auto& freeList = free_[kNumFreeLists - 1];
     header = headerOf(freeList.next());
-    auto size = header->size();
-    if (roundedBytes > size) {
+    const auto spaceTaken = roundedBytes + sizeof(Header);
+    if (spaceTaken > header->size()) {
       return false;
     }
-    const auto spaceTaken = roundedBytes + sizeof(Header);
-    if (size - spaceTaken > kMaxAlloc) {
+    if (header->size() - spaceTaken > kMaxAlloc) {
       // The entry after allocation stays in the largest free list.
       // The size at the end of the block is changed in place.
       reinterpret_cast<int32_t*>(header->end())[-1] -= spaceTaken;

--- a/velox/common/memory/tests/HashStringAllocatorTest.cpp
+++ b/velox/common/memory/tests/HashStringAllocatorTest.cpp
@@ -544,5 +544,15 @@ TEST_F(HashStringAllocatorTest, strings) {
   allocator_->checkConsistency();
 }
 
+TEST_F(HashStringAllocatorTest, storeStringFast) {
+  allocator_->allocate(HashStringAllocator::kMinAlloc);
+  std::string s(allocator_->freeSpace() + sizeof(void*), 'x');
+  StringView sv(s);
+  allocator_->copyMultipart(reinterpret_cast<char*>(&sv), 0);
+  ASSERT_NE(sv.data(), s.data());
+  ASSERT_EQ(sv, StringView(s));
+  allocator_->checkConsistency();
+}
+
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:
When we decide whether to go the fast path to edit the block in place,
we do not take the header overhead into consideration, result in subsequent
check (`size <= kSizeMask`) failing and thus query failure.

Differential Revision: D51403029


