### PR TITLE
Allow choosing to register companion functions through registerAllAggregateFunctions()

### DIFF
--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
@@ -829,7 +829,8 @@ void addSignatures(
 } // namespace
 
 exec::AggregateRegistrationResult registerApproxPercentileAggregate(
-    const std::string& prefix) {
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   for (const auto& inputType :
        {"tinyint", "smallint", "integer", "bigint", "real", "double"}) {
@@ -929,7 +930,7 @@ exec::AggregateRegistrationResult registerApproxPercentileAggregate(
                 type->toString());
         }
       },
-      /*registerCompanionFunctions*/ true);
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
@@ -238,7 +238,8 @@ class ArrayAggAggregate : public exec::Aggregate {
 } // namespace
 
 exec::AggregateRegistrationResult registerArrayAggAggregate(
-    const std::string& prefix) {
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("E")
@@ -261,7 +262,7 @@ exec::AggregateRegistrationResult registerArrayAggAggregate(
         return std::make_unique<ArrayAggAggregate>(
             resultType, config.prestoArrayAggIgnoreNulls());
       },
-      /*registerCompanionFunctions*/ true);
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/AverageAggregate.cpp
@@ -30,7 +30,8 @@ namespace facebook::velox::aggregate::prestosql {
 ///     ALL INTs        |     DOUBLE          |    DOUBLE
 ///     DECIMAL         |     DECIMAL         |    DECIMAL
 exec::AggregateRegistrationResult registerAverageAggregate(
-    const std::string& prefix) {
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
   for (const auto& inputType : {"smallint", "integer", "bigint", "double"}) {
@@ -139,7 +140,7 @@ exec::AggregateRegistrationResult registerAverageAggregate(
           }
         }
       },
-      /*registerCompanionFunctions*/ true);
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -21,13 +21,16 @@ namespace facebook::velox::aggregate::prestosql {
 extern exec::AggregateRegistrationResult registerApproxMostFrequentAggregate(
     const std::string& prefix);
 extern exec::AggregateRegistrationResult registerApproxPercentileAggregate(
-    const std::string& prefix);
+    const std::string& prefix,
+    bool withCompanionFunctions);
 extern exec::AggregateRegistrationResult registerArbitraryAggregate(
     const std::string& prefix);
 extern exec::AggregateRegistrationResult registerArrayAggAggregate(
-    const std::string& prefix);
+    const std::string& prefix,
+    bool withCompanionFunctions);
 extern exec::AggregateRegistrationResult registerAverageAggregate(
-    const std::string& prefix);
+    const std::string& prefix,
+    bool withCompanionFunctions);
 extern exec::AggregateRegistrationResult registerBitwiseXorAggregate(
     const std::string& prefix);
 extern exec::AggregateRegistrationResult registerChecksumAggregate(
@@ -61,7 +64,9 @@ extern exec::AggregateRegistrationResult registerSetAggAggregate(
 extern exec::AggregateRegistrationResult registerSetUnionAggregate(
     const std::string& prefix);
 
-extern void registerApproxDistinctAggregates(const std::string& prefix);
+extern void registerApproxDistinctAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions);
 extern void registerBitwiseAggregates(const std::string& prefix);
 extern void registerBoolAggregates(const std::string& prefix);
 extern void registerCentralMomentsAggregates(const std::string& prefix);
@@ -71,13 +76,15 @@ extern void registerMinMaxByAggregates(const std::string& prefix);
 extern void registerSumAggregate(const std::string& prefix);
 extern void registerVarianceAggregates(const std::string& prefix);
 
-void registerAllAggregateFunctions(const std::string& prefix) {
-  registerApproxDistinctAggregates(prefix);
+void registerAllAggregateFunctions(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
+  registerApproxDistinctAggregates(prefix, withCompanionFunctions);
   registerApproxMostFrequentAggregate(prefix);
-  registerApproxPercentileAggregate(prefix);
+  registerApproxPercentileAggregate(prefix, withCompanionFunctions);
   registerArbitraryAggregate(prefix);
-  registerArrayAggAggregate(prefix);
-  registerAverageAggregate(prefix);
+  registerArrayAggAggregate(prefix, withCompanionFunctions);
+  registerAverageAggregate(prefix, withCompanionFunctions);
   registerBitwiseAggregates(prefix);
   registerBitwiseXorAggregate(prefix);
   registerBoolAggregates(prefix);

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h
@@ -19,6 +19,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-void registerAllAggregateFunctions(const std::string& prefix = "");
+void registerAllAggregateFunctions(
+    const std::string& prefix = "",
+    bool withCompanionFunctions = true);
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/tests/ApproxDistinctTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxDistinctTest.cpp
@@ -57,14 +57,6 @@ class ApproxDistinctTest : public AggregationTestBase {
         {fmt::format("approx_set(c0, {})", maxStandardError)},
         {"cardinality(a0)"},
         {expected});
-    testAggregationsWithCompanion(
-        {vectors},
-        [](auto& /*builder*/) {},
-        {},
-        {fmt::format("approx_set(c0, {})", maxStandardError)},
-        {{values->type(), DOUBLE()}},
-        {"cardinality(a0)"},
-        {expected});
   }
 
   void testGlobalAgg(const VectorPtr& values, int64_t expectedResult) {
@@ -84,14 +76,6 @@ class ApproxDistinctTest : public AggregationTestBase {
 
     testAggregations(
         {vectors}, {}, {"approx_set(c0)"}, {"cardinality(a0)"}, {expected});
-    testAggregationsWithCompanion(
-        {vectors},
-        [](auto& /*builder*/) {},
-        {},
-        {"approx_set(c0)"},
-        {{values->type()}},
-        {"cardinality(a0)"},
-        {expected});
   }
 
   template <typename T, typename U>
@@ -130,14 +114,6 @@ class ApproxDistinctTest : public AggregationTestBase {
         {vectors},
         {"c0"},
         {"approx_set(c1)"},
-        {"c0", "cardinality(a0)"},
-        {expected});
-    testAggregationsWithCompanion(
-        {vectors},
-        [](auto& /*builder*/) {},
-        {"c0"},
-        {"approx_set(c1)"},
-        {{values->type()}},
         {"c0", "cardinality(a0)"},
         {expected});
   }

--- a/velox/functions/sparksql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/AverageAggregate.cpp
@@ -84,7 +84,9 @@ class AverageAggregate
 ///     REAL            |     DOUBLE          |    DOUBLE
 ///     ALL INTs        |     DOUBLE          |    DOUBLE
 ///     DECIMAL         |     DECIMAL         |    DECIMAL
-exec::AggregateRegistrationResult registerAverage(const std::string& name) {
+exec::AggregateRegistrationResult registerAverage(
+    const std::string& name,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
   for (const auto& inputType :
@@ -187,7 +189,7 @@ exec::AggregateRegistrationResult registerAverage(const std::string& name) {
           }
         }
       },
-      /*registerCompanionFunctions*/ true);
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/AverageAggregate.h
+++ b/velox/functions/sparksql/aggregates/AverageAggregate.h
@@ -22,6 +22,8 @@
 
 namespace facebook::velox::functions::aggregate::sparksql {
 
-exec::AggregateRegistrationResult registerAverage(const std::string& name);
+exec::AggregateRegistrationResult registerAverage(
+    const std::string& name,
+    bool withCompanionFunctions);
 
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/Register.cpp
+++ b/velox/functions/sparksql/aggregates/Register.cpp
@@ -26,12 +26,14 @@ namespace facebook::velox::functions::aggregate::sparksql {
 extern void registerFirstLastAggregates(const std::string& prefix);
 extern void registerMinMaxByAggregates(const std::string& prefix);
 
-void registerAggregateFunctions(const std::string& prefix) {
+void registerAggregateFunctions(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   registerFirstLastAggregates(prefix);
   registerMinMaxByAggregates(prefix);
   registerBitwiseXorAggregate(prefix);
   registerBloomFilterAggAggregate(prefix + "bloom_filter_agg");
-  registerAverage(prefix + "avg");
+  registerAverage(prefix + "avg", withCompanionFunctions);
   registerSum(prefix + "sum");
 }
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/Register.h
+++ b/velox/functions/sparksql/aggregates/Register.h
@@ -18,5 +18,7 @@
 #include <string>
 
 namespace facebook::velox::functions::aggregate::sparksql {
-void registerAggregateFunctions(const std::string& prefix);
+void registerAggregateFunctions(
+    const std::string& prefix,
+    bool withCompanionFunctions = true);
 } // namespace facebook::velox::functions::aggregate::sparksql


### PR DESCRIPTION
Summary:
Allow users to pass a boolean indicating whether to register compaion functions with aggregation
functions through the registerAllAggregateFunctions API. Currently, only companion functions that
has been tested are registered when withCompanionFunctions is set to true, including compaion
functions for avg, array_agg, approx_percentile, and approx_distinct functions.

Also, since approx_set and merge are already companion functions themselves, this diff avoid 
generating companion functions for them.

Differential Revision: D51406822


