### PR TITLE
Turn off testing for companion functions in AggregationFuzzerTest

### DIFF
--- a/velox/exec/tests/AggregationFuzzerTest.cpp
+++ b/velox/exec/tests/AggregationFuzzerTest.cpp
@@ -245,7 +245,8 @@ getCustomInputGenerators() {
 } // namespace facebook::velox::exec::test
 
 int main(int argc, char** argv) {
-  facebook::velox::aggregate::prestosql::registerAllAggregateFunctions();
+  facebook::velox::aggregate::prestosql::registerAllAggregateFunctions(
+      "", false);
   facebook::velox::functions::prestosql::registerAllScalarFunctions();
   facebook::velox::functions::prestosql::registerInternalFunctions();
 
@@ -294,19 +295,10 @@ int main(int argc, char** argv) {
       customVerificationFunctions = {
           // Order-dependent functions.
           {"approx_distinct", ""},
-          {"approx_distinct_partial", ""},
-          {"approx_distinct_merge", ""},
           {"approx_set", ""},
-          {"approx_set_partial", ""},
-          {"approx_set_merge", ""},
           {"approx_percentile", ""},
-          {"approx_percentile_partial", ""},
-          {"approx_percentile_merge", ""},
           {"arbitrary", ""},
           {"array_agg", "\"$internal$canonicalize\"({})"},
-          {"array_agg_partial", "\"$internal$canonicalize\"({})"},
-          {"array_agg_merge", "\"$internal$canonicalize\"({})"},
-          {"array_agg_merge_extract", "\"$internal$canonicalize\"({})"},
           {"set_agg", "\"$internal$canonicalize\"({})"},
           {"set_union", "\"$internal$canonicalize\"({})"},
           {"map_agg", "\"$internal$canonicalize\"(map_keys({}))"},
@@ -316,14 +308,6 @@ int main(int argc, char** argv) {
           {"min_by", ""},
           {"multimap_agg",
            "transform_values({}, (k, v) -> \"$internal$canonicalize\"(v))"},
-          // TODO: Skip result verification of companion functions that return
-          // complex types that contain floating-point fields for now, until we
-          // fix
-          // test utilities in QueryAssertions to tolerate floating-point
-          // imprecision in complex types.
-          // https://github.com/facebookincubator/velox/issues/4481
-          {"avg_partial", ""},
-          {"avg_merge", ""},
           // Semantically inconsistent functions
           {"skewness", ""},
           {"kurtosis", ""},

--- a/velox/exec/tests/SparkAggregationFuzzerTest.cpp
+++ b/velox/exec/tests/SparkAggregationFuzzerTest.cpp
@@ -38,7 +38,7 @@ DEFINE_string(
 
 int main(int argc, char** argv) {
   facebook::velox::functions::aggregate::sparksql::registerAggregateFunctions(
-      "");
+      "", false);
 
   ::testing::InitGoogleTest(&argc, argv);
 
@@ -62,13 +62,6 @@ int main(int argc, char** argv) {
       {"last_ignore_null", ""},
       {"first", ""},
       {"first_ignore_null", ""},
-      // TODO: Skip result verification of companion functions that return
-      // complex types that contain floating-point fields for now, until we
-      // fix test utilities in QueryAssertions to tolerate floating-point
-      // imprecision in complex types.
-      // https://github.com/facebookincubator/velox/issues/4481
-      {"avg_partial", ""},
-      {"avg_merge", ""},
       {"max_by", ""},
       {"min_by", ""}};
 

--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
@@ -829,7 +829,8 @@ void addSignatures(
 } // namespace
 
 exec::AggregateRegistrationResult registerApproxPercentileAggregate(
-    const std::string& prefix) {
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   for (const auto& inputType :
        {"tinyint", "smallint", "integer", "bigint", "real", "double"}) {
@@ -929,7 +930,7 @@ exec::AggregateRegistrationResult registerApproxPercentileAggregate(
                 type->toString());
         }
       },
-      /*registerCompanionFunctions*/ true);
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
@@ -238,7 +238,8 @@ class ArrayAggAggregate : public exec::Aggregate {
 } // namespace
 
 exec::AggregateRegistrationResult registerArrayAggAggregate(
-    const std::string& prefix) {
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("E")
@@ -261,7 +262,7 @@ exec::AggregateRegistrationResult registerArrayAggAggregate(
         return std::make_unique<ArrayAggAggregate>(
             resultType, config.prestoArrayAggIgnoreNulls());
       },
-      /*registerCompanionFunctions*/ true);
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/AverageAggregate.cpp
@@ -30,7 +30,8 @@ namespace facebook::velox::aggregate::prestosql {
 ///     ALL INTs        |     DOUBLE          |    DOUBLE
 ///     DECIMAL         |     DECIMAL         |    DECIMAL
 exec::AggregateRegistrationResult registerAverageAggregate(
-    const std::string& prefix) {
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
   for (const auto& inputType : {"smallint", "integer", "bigint", "double"}) {
@@ -139,7 +140,7 @@ exec::AggregateRegistrationResult registerAverageAggregate(
           }
         }
       },
-      /*registerCompanionFunctions*/ true);
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -21,13 +21,16 @@ namespace facebook::velox::aggregate::prestosql {
 extern exec::AggregateRegistrationResult registerApproxMostFrequentAggregate(
     const std::string& prefix);
 extern exec::AggregateRegistrationResult registerApproxPercentileAggregate(
-    const std::string& prefix);
+    const std::string& prefix,
+    bool withCompanionFunctions);
 extern exec::AggregateRegistrationResult registerArbitraryAggregate(
     const std::string& prefix);
 extern exec::AggregateRegistrationResult registerArrayAggAggregate(
-    const std::string& prefix);
+    const std::string& prefix,
+    bool withCompanionFunctions);
 extern exec::AggregateRegistrationResult registerAverageAggregate(
-    const std::string& prefix);
+    const std::string& prefix,
+    bool withCompanionFunctions);
 extern exec::AggregateRegistrationResult registerBitwiseXorAggregate(
     const std::string& prefix);
 extern exec::AggregateRegistrationResult registerChecksumAggregate(
@@ -61,7 +64,9 @@ extern exec::AggregateRegistrationResult registerSetAggAggregate(
 extern exec::AggregateRegistrationResult registerSetUnionAggregate(
     const std::string& prefix);
 
-extern void registerApproxDistinctAggregates(const std::string& prefix);
+extern void registerApproxDistinctAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions);
 extern void registerBitwiseAggregates(const std::string& prefix);
 extern void registerBoolAggregates(const std::string& prefix);
 extern void registerCentralMomentsAggregates(const std::string& prefix);
@@ -71,13 +76,15 @@ extern void registerMinMaxByAggregates(const std::string& prefix);
 extern void registerSumAggregate(const std::string& prefix);
 extern void registerVarianceAggregates(const std::string& prefix);
 
-void registerAllAggregateFunctions(const std::string& prefix) {
-  registerApproxDistinctAggregates(prefix);
+void registerAllAggregateFunctions(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
+  registerApproxDistinctAggregates(prefix, withCompanionFunctions);
   registerApproxMostFrequentAggregate(prefix);
-  registerApproxPercentileAggregate(prefix);
+  registerApproxPercentileAggregate(prefix, withCompanionFunctions);
   registerArbitraryAggregate(prefix);
-  registerArrayAggAggregate(prefix);
-  registerAverageAggregate(prefix);
+  registerArrayAggAggregate(prefix, withCompanionFunctions);
+  registerAverageAggregate(prefix, withCompanionFunctions);
   registerBitwiseAggregates(prefix);
   registerBitwiseXorAggregate(prefix);
   registerBoolAggregates(prefix);

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h
@@ -19,6 +19,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-void registerAllAggregateFunctions(const std::string& prefix = "");
+void registerAllAggregateFunctions(
+    const std::string& prefix = "",
+    bool withCompanionFunctions = true);
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/tests/ApproxDistinctTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxDistinctTest.cpp
@@ -57,14 +57,6 @@ class ApproxDistinctTest : public AggregationTestBase {
         {fmt::format("approx_set(c0, {})", maxStandardError)},
         {"cardinality(a0)"},
         {expected});
-    testAggregationsWithCompanion(
-        {vectors},
-        [](auto& /*builder*/) {},
-        {},
-        {fmt::format("approx_set(c0, {})", maxStandardError)},
-        {{values->type(), DOUBLE()}},
-        {"cardinality(a0)"},
-        {expected});
   }
 
   void testGlobalAgg(const VectorPtr& values, int64_t expectedResult) {
@@ -84,14 +76,6 @@ class ApproxDistinctTest : public AggregationTestBase {
 
     testAggregations(
         {vectors}, {}, {"approx_set(c0)"}, {"cardinality(a0)"}, {expected});
-    testAggregationsWithCompanion(
-        {vectors},
-        [](auto& /*builder*/) {},
-        {},
-        {"approx_set(c0)"},
-        {{values->type()}},
-        {"cardinality(a0)"},
-        {expected});
   }
 
   template <typename T, typename U>
@@ -130,14 +114,6 @@ class ApproxDistinctTest : public AggregationTestBase {
         {vectors},
         {"c0"},
         {"approx_set(c1)"},
-        {"c0", "cardinality(a0)"},
-        {expected});
-    testAggregationsWithCompanion(
-        {vectors},
-        [](auto& /*builder*/) {},
-        {"c0"},
-        {"approx_set(c1)"},
-        {{values->type()}},
         {"c0", "cardinality(a0)"},
         {expected});
   }

--- a/velox/functions/sparksql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/AverageAggregate.cpp
@@ -84,7 +84,9 @@ class AverageAggregate
 ///     REAL            |     DOUBLE          |    DOUBLE
 ///     ALL INTs        |     DOUBLE          |    DOUBLE
 ///     DECIMAL         |     DECIMAL         |    DECIMAL
-exec::AggregateRegistrationResult registerAverage(const std::string& name) {
+exec::AggregateRegistrationResult registerAverage(
+    const std::string& name,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
   for (const auto& inputType :
@@ -187,7 +189,7 @@ exec::AggregateRegistrationResult registerAverage(const std::string& name) {
           }
         }
       },
-      /*registerCompanionFunctions*/ true);
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/AverageAggregate.h
+++ b/velox/functions/sparksql/aggregates/AverageAggregate.h
@@ -22,6 +22,8 @@
 
 namespace facebook::velox::functions::aggregate::sparksql {
 
-exec::AggregateRegistrationResult registerAverage(const std::string& name);
+exec::AggregateRegistrationResult registerAverage(
+    const std::string& name,
+    bool withCompanionFunctions);
 
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/Register.cpp
+++ b/velox/functions/sparksql/aggregates/Register.cpp
@@ -26,12 +26,14 @@ namespace facebook::velox::functions::aggregate::sparksql {
 extern void registerFirstLastAggregates(const std::string& prefix);
 extern void registerMinMaxByAggregates(const std::string& prefix);
 
-void registerAggregateFunctions(const std::string& prefix) {
+void registerAggregateFunctions(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   registerFirstLastAggregates(prefix);
   registerMinMaxByAggregates(prefix);
   registerBitwiseXorAggregate(prefix);
   registerBloomFilterAggAggregate(prefix + "bloom_filter_agg");
-  registerAverage(prefix + "avg");
+  registerAverage(prefix + "avg", withCompanionFunctions);
   registerSum(prefix + "sum");
 }
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/Register.h
+++ b/velox/functions/sparksql/aggregates/Register.h
@@ -18,5 +18,7 @@
 #include <string>
 
 namespace facebook::velox::functions::aggregate::sparksql {
-void registerAggregateFunctions(const std::string& prefix);
+void registerAggregateFunctions(
+    const std::string& prefix,
+    bool withCompanionFunctions = true);
 } // namespace facebook::velox::functions::aggregate::sparksql


### PR DESCRIPTION
Summary: Avoid testing companion functions since we don't generate valid random input data for them.

Differential Revision: D51409924


