### PR TITLE
Fix conversion of VARBINARY values to variant in QueryAssertions.*

### DIFF
--- a/velox/exec/tests/QueryAssertionsTest.cpp
+++ b/velox/exec/tests/QueryAssertionsTest.cpp
@@ -452,4 +452,21 @@ TEST_F(QueryAssertionsTest, nullVariant) {
   assertQuery(plan, "SELECT * FROM tmp");
 }
 
+TEST_F(QueryAssertionsTest, varbinary) {
+  auto data = makeRowVector({makeFlatVector<std::string>(
+      {"Short string", "Longer strings...", "abc"}, VARBINARY())});
+
+  auto rowType = asRowType(data->type());
+
+  createDuckDbTable({data});
+
+  auto duckResult = duckDbQueryRunner_.execute("SELECT * FROM tmp", rowType);
+  ASSERT_EQ(duckResult.size(), data->size());
+  ASSERT_EQ(duckResult.begin()->begin()->kind(), TypeKind::VARBINARY);
+  ASSERT_TRUE(assertEqualResults(duckResult, rowType, {data}));
+
+  auto plan = PlanBuilder().values({data}).planNode();
+  assertQuery(plan, "SELECT * FROM tmp");
+}
+
 } // namespace facebook::velox::test


### PR DESCRIPTION
VARBINARY result from Velox and DuckDB used to be converted to variant with 
TypeKind::VARCHAR causing confusing failures in the AggregationFuzzer.