### PR TITLE
Ensure fuzzer runs for modified Presto function signatures.

### DIFF
--- a/.circleci/dist_compile.yml
+++ b/.circleci/dist_compile.yml
@@ -446,7 +446,7 @@ jobs:
             export HADOOP_HOME='/usr/local/hadoop'
             export PATH=~/adapter-deps/install/bin:/usr/local/hadoop/bin:${PATH}
             # The following is used to install Azurite in the CI for running Abfs Hive Connector unit tests.
-            # Azurite is an emulator for local Azure Storage development, and it is a required component for running Abfs Hive Connector unit tests. 
+            # Azurite is an emulator for local Azure Storage development, and it is a required component for running Abfs Hive Connector unit tests.
             # It can be installed using npm. The following is used to install Node.js and npm for Azurite installation.
             curl -sL https://rpm.nodesource.com/setup_10.x | bash -
             yum install -y nodejs
@@ -643,8 +643,11 @@ jobs:
             pip install deepdiff
             python ./scripts/signature.py export --presto presto_pr_signatures.json
             python ./scripts/signature.py export --spark spark_pr_signatures.json
-            python ./scripts/signature.py bias presto_merge_base_signatures.json presto_pr_signatures.json /tmp/presto_bias_functions
-            python ./scripts/signature.py bias spark_merge_base_signatures.json spark_pr_signatures.json /tmp/spark_bias_functions
+            if python ./scripts/signature.py bias presto_merge_base_signatures.json presto_pr_signatures.json /tmp/presto_bias_functions ; \
+            then echo "Presto signature check success" ; else echo "Presto signature check failed" > /tmp/presto-signature-error-code ; fi
+            if python ./scripts/signature.py bias spark_merge_base_signatures.json spark_pr_signatures.json /tmp/spark_bias_functions ; \
+            then echo "Spark signature check success"; else echo "Spark signature check failed" > /tmp/spark-signature-error-code ; fi
+
       - store_artifacts:
           path: 'presto_merge_base_signatures.json'
       - store_artifacts:
@@ -676,8 +679,13 @@ jobs:
           fuzzer_name: "Spark Bias Run"
           fuzzer_exe: "if [ -f /tmp/spark_bias_functions ];  then _build/debug/velox/expression/tests/spark_expression_fuzzer_test"
           fuzzer_args: " --seed ${RANDOM} --duration_sec 3600 --logtostderr=1 --minloglevel=0 \
-          --assign_function_tickets  $(cat /tmp/spark_bias_functions) \
-          --repro_persist_path=/tmp/spark_fuzzer_repro ; fi"
+                --assign_function_tickets  $(cat /tmp/spark_bias_functions) \
+                --repro_persist_path=/tmp/spark_fuzzer_repro ; fi"
+
+      - run:
+          name: "Surface only Presto function signature errors if any"
+          command: |
+              if [ -f /tmp/presto-signature-error-code ]; then return 1 ; fi
 
 
 workflows:

--- a/scripts/signature.py
+++ b/scripts/signature.py
@@ -126,42 +126,34 @@ def bias(args):
     bias_output, status = bias_signatures(
         base_signatures, contender_signatures, tickets
     )
-    if status:
-        return status
 
     if bias_output:
         with open(args.output_path, "w") as f:
             print(f"{bias_output}", file=f, end="")
 
-    return 0
+    return status
 
 
 def bias_signatures(base_signatures, contender_signatures, tickets):
     """Returns newly added functions as string and a status flag.
     Newly added functions are biased like so `fn_name1=<ticket_count>,fn_name2=<ticket_count>`.
-    If it detects incompatible changes returns 1 in the status and empty string.
+    If it detects incompatible changes returns 1 in the status.
     """
     delta, status = diff_signatures(base_signatures, contender_signatures)
 
-    # Return if the signature check call flags incompatible changes.
-    if status:
-        return "", status
-
     if not delta:
         print(f"{bcolors.BOLD} No changes detected: Nothing to do!")
-        return "", 0
+        return "", status
 
     function_set = set()
     for items in delta.values():
         for item in items:
             function_set.add(item.get_root_key())
 
-    print(f"{bcolors.BOLD}Functions to be biased: {function_set}")
-
     if function_set:
-        return f"{f'={tickets},'.join(sorted(function_set)) + f'={tickets}'}", 0
+        return f"{f'={tickets},'.join(sorted(function_set)) + f'={tickets}'}", status
 
-    return "", 0
+    return "", status
 
 
 def get_tickets(val):


### PR DESCRIPTION
* We move the signature check error code to end of the function signature run for presto. 
* To do the above, we make changes to the signature.py script so it always writes output to the bias file. 
* Finally we ignore the function signature error output for spark , but still run the fuzzer for it when possible. 

