### PR TITLE
Add aggregations over sorted inputs to AggregationFuzzer

### DIFF
--- a/velox/exec/tests/AggregationFuzzerTest.cpp
+++ b/velox/exec/tests/AggregationFuzzerTest.cpp
@@ -260,6 +260,13 @@ int main(int argc, char** argv) {
 
   auto duckQueryRunner =
       std::make_unique<facebook::velox::exec::test::DuckQueryRunner>();
+  duckQueryRunner->disableAggregateFunctions({
+      "skewness",
+      // DuckDB results on constant inputs are incorrect. Should be NaN,
+      // but DuckDB returns some random value.
+      "kurtosis",
+      "entropy",
+  });
 
   // List of functions that have known bugs that cause crashes or failures.
   static const std::unordered_set<std::string> skipFunctions = {

--- a/velox/exec/tests/utils/DuckQueryRunner.h
+++ b/velox/exec/tests/utils/DuckQueryRunner.h
@@ -23,6 +23,11 @@ class DuckQueryRunner : public ReferenceQueryRunner {
  public:
   DuckQueryRunner();
 
+  /// Specify names of aggregate function to exclude from the list of supported
+  /// functions. Used to exclude functions that are non-determonistic, have bugs
+  /// or whose semantics differ from Velox.
+  void disableAggregateFunctions(const std::vector<std::string>& names);
+
   /// Supports AggregationNode and WindowNode with optional ProjectNode on top.
   /// Assumes that source of AggregationNode or Window Node is 'tmp' table.
   std::optional<std::string> toSql(const core::PlanNodePtr& plan) override;


### PR DESCRIPTION
Enhance AggregationFuzzer to add query plans that run aggregations over sorted
inputs, i.e. SELECT k1, k2, agg(x ORDER BY x) FROM t GROUP BY 1, 2.

Aggregations that are sensitive to the order of inputs (e.g. array_agg) produce
deterministic results when inputs are sorted. This allows for comparing results
between different but logically equivalent query plans and between Velox and a
reference database (DuckDB now, Presto in the near future).

Sorted aggregations apply to aggregate functions with at least one argument 
(count(1) doesn't qualify) as long as types of all arguments are order-able.

Sorted aggregations are tested using 2 logically equivalent plans: Aggregation
over Values and TableScan. TableScan plans are tested with and without
spilling. Sorted aggregations cannot be split into partial and final, hence, such
plans are not tested. Streaming aggregation doesn't support aggregating over 
sorted inputs yet, hence, such plans are not tested.