### PR TITLE
Pass spill write file options down from SpillConfig

### DIFF
--- a/velox/common/config/SpillConfig.cpp
+++ b/velox/common/config/SpillConfig.cpp
@@ -30,7 +30,8 @@ SpillConfig::SpillConfig(
     int32_t _maxSpillLevel,
     uint64_t _writerFlushThresholdSize,
     int32_t _testSpillPct,
-    const std::string& _compressionKind)
+    const std::string& _compressionKind,
+    const std::unordered_map<std::string, std::string>& _writeFileOptions)
     : filePath(_filePath),
       maxFileSize(
           _maxFileSize == 0 ? std::numeric_limits<int64_t>::max()
@@ -45,7 +46,8 @@ SpillConfig::SpillConfig(
       maxSpillLevel(_maxSpillLevel),
       writerFlushThresholdSize(_writerFlushThresholdSize),
       testSpillPct(_testSpillPct),
-      compressionKind(common::stringToCompressionKind(_compressionKind)) {
+      compressionKind(common::stringToCompressionKind(_compressionKind)),
+      writeFileOptions(_writeFileOptions) {
   VELOX_USER_CHECK_GE(
       spillableReservationGrowthPct,
       minSpillableReservationPct,

--- a/velox/common/config/SpillConfig.h
+++ b/velox/common/config/SpillConfig.h
@@ -36,7 +36,9 @@ struct SpillConfig {
       int32_t _maxSpillLevel,
       uint64_t _writerFlushThresholdSize,
       int32_t _testSpillPct,
-      const std::string& _compressionKind);
+      const std::string& _compressionKind,
+      const std::unordered_map<std::string, std::string>& _writeFileOptions =
+          {});
 
   /// Returns the hash join spilling level with given 'startBitOffset'.
   ///
@@ -103,5 +105,8 @@ struct SpillConfig {
 
   /// CompressionKind when spilling, CompressionKind_NONE means no compression.
   common::CompressionKind compressionKind;
+
+  /// Custom options passed to velox::FileSystem to create spill WriteFile.
+  std::unordered_map<std::string, std::string> writeFileOptions;
 };
 } // namespace facebook::velox::common

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -44,7 +44,8 @@ Spiller::Spiller(
     uint64_t writeBufferSize,
     common::CompressionKind compressionKind,
     memory::MemoryPool* pool,
-    folly::Executor* executor)
+    folly::Executor* executor,
+    const std::unordered_map<std::string, std::string>& writeFileOptions)
     : Spiller(
           type,
           container,
@@ -57,7 +58,8 @@ Spiller::Spiller(
           writeBufferSize,
           compressionKind,
           pool,
-          executor) {
+          executor,
+          writeFileOptions) {
   VELOX_CHECK(
       type_ == Type::kOrderBy || type_ == Type::kAggregateInput,
       "Unexpected spiller type: {}",
@@ -74,7 +76,8 @@ Spiller::Spiller(
     uint64_t writeBufferSize,
     common::CompressionKind compressionKind,
     memory::MemoryPool* pool,
-    folly::Executor* executor)
+    folly::Executor* executor,
+    const std::unordered_map<std::string, std::string>& writeFileOptions)
     : Spiller(
           type,
           container,
@@ -87,7 +90,8 @@ Spiller::Spiller(
           writeBufferSize,
           compressionKind,
           pool,
-          executor) {
+          executor,
+          writeFileOptions) {
   VELOX_CHECK_EQ(
       type,
       Type::kAggregateOutput,
@@ -106,7 +110,8 @@ Spiller::Spiller(
     uint64_t writeBufferSize,
     common::CompressionKind compressionKind,
     memory::MemoryPool* pool,
-    folly::Executor* executor)
+    folly::Executor* executor,
+    const std::unordered_map<std::string, std::string>& writeFileOptions)
     : Spiller(
           type,
           nullptr,
@@ -119,7 +124,8 @@ Spiller::Spiller(
           writeBufferSize,
           compressionKind,
           pool,
-          executor) {
+          executor,
+          writeFileOptions) {
   VELOX_CHECK_EQ(
       type_,
       Type::kHashJoinProbe,
@@ -137,7 +143,8 @@ Spiller::Spiller(
     uint64_t writeBufferSize,
     common::CompressionKind compressionKind,
     memory::MemoryPool* pool,
-    folly::Executor* executor)
+    folly::Executor* executor,
+    const std::unordered_map<std::string, std::string>& writeFileOptions)
     : Spiller(
           type,
           container,
@@ -150,7 +157,8 @@ Spiller::Spiller(
           writeBufferSize,
           compressionKind,
           pool,
-          executor) {
+          executor,
+          writeFileOptions) {
   VELOX_CHECK_EQ(
       type_,
       Type::kHashJoinBuild,
@@ -170,7 +178,8 @@ Spiller::Spiller(
     uint64_t writeBufferSize,
     common::CompressionKind compressionKind,
     memory::MemoryPool* pool,
-    folly::Executor* executor)
+    folly::Executor* executor,
+    const std::unordered_map<std::string, std::string>& writeFileOptions)
     : type_(type),
       container_(container),
       executor_(executor),
@@ -186,7 +195,8 @@ Spiller::Spiller(
           writeBufferSize,
           compressionKind,
           pool_,
-          &stats_) {
+          &stats_,
+          writeFileOptions) {
   TestValue::adjust(
       "facebook::velox::exec::Spiller", const_cast<HashBitRange*>(&bits_));
 

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -55,7 +55,9 @@ class Spiller {
       uint64_t writeBufferSize,
       common::CompressionKind compressionKind,
       memory::MemoryPool* pool,
-      folly::Executor* executor);
+      folly::Executor* executor,
+      const std::unordered_map<std::string, std::string>& writeFileOptions =
+          {});
 
   Spiller(
       Type type,
@@ -65,7 +67,9 @@ class Spiller {
       uint64_t writeBufferSize,
       common::CompressionKind compressionKind,
       memory::MemoryPool* pool,
-      folly::Executor* executor);
+      folly::Executor* executor,
+      const std::unordered_map<std::string, std::string>& writeFileOptions =
+          {});
 
   Spiller(
       Type type,
@@ -76,7 +80,9 @@ class Spiller {
       uint64_t writeBufferSize,
       common::CompressionKind compressionKind,
       memory::MemoryPool* pool,
-      folly::Executor* executor);
+      folly::Executor* executor,
+      const std::unordered_map<std::string, std::string>& writeFileOptions =
+          {});
 
   Spiller(
       Type type,
@@ -88,7 +94,9 @@ class Spiller {
       uint64_t writeBufferSize,
       common::CompressionKind compressionKind,
       memory::MemoryPool* pool,
-      folly::Executor* executor);
+      folly::Executor* executor,
+      const std::unordered_map<std::string, std::string>& writeFileOptions =
+          {});
 
   Type type() const {
     return type_;
@@ -194,7 +202,8 @@ class Spiller {
       uint64_t writeBufferSize,
       common::CompressionKind compressionKind,
       memory::MemoryPool* pool,
-      folly::Executor* executor);
+      folly::Executor* executor,
+      const std::unordered_map<std::string, std::string>& writeFileOptions);
 
   // Invoked to spill. If 'startRowIter' is not null, then we only spill rows
   // from row container starting at the offset pointed by 'startRowIter'.

--- a/velox/exec/tests/HashJoinBridgeTest.cpp
+++ b/velox/exec/tests/HashJoinBridgeTest.cpp
@@ -105,7 +105,8 @@ class HashJoinBridgeTest : public testing::Test,
           std::vector<CompareFlags>({}),
           tempDir_->path + "/Spill",
           common::CompressionKind_NONE,
-          pool_.get()));
+          pool_.get(),
+          std::unordered_map<std::string, std::string>{}));
       // Create a fake file to avoid too many exception logs in test when spill
       // file deletion fails.
       createFile(files.back()->testingFilePath());


### PR DESCRIPTION
Depending on detailed implementations, WriteFile might need additional parameters for configuration. Spill uses WriteFile as its spilling media so we need to allow the spill framework to be able to pass down additional custom options/parameters down.