### PR TITLE
Fix formulas rendering in the docs

### DIFF
--- a/velox/docs/conf.py
+++ b/velox/docs/conf.py
@@ -54,7 +54,6 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
-    "sphinx.ext.imgmath",
     "sphinx.ext.todo",
     "sphinx.ext.intersphinx",
     "sphinx.ext.autosummary",

--- a/velox/docs/develop/types.rst
+++ b/velox/docs/develop/types.rst
@@ -97,8 +97,8 @@ point in a number. For example, the number `123.45` has a precision of `5` and a
 scale of `2`. DECIMAL types are backed by `BIGINT` and `HUGEINT` physical types,
 which store the unscaled value. For example, the unscaled value of decimal
 `123.45` is `12345`. `BIGINT` is used upto 18 precision, and has a range of
-[:math:`-10^{18} + 1, +10^{18} - 1`]. `HUGEINT` is used starting from 19 precision
-upto 38 precision, with a range of [:math:`-10^{38} + 1, +10^{38} - 1`].
+:math:`[-10^{18} + 1, +10^{18} - 1]`. `HUGEINT` is used starting from 19 precision
+upto 38 precision, with a range of :math:`[-10^{38} + 1, +10^{38} - 1]`.
 
 All the three values, precision, scale, unscaled value are required to represent a
 decimal value.


### PR DESCRIPTION
sphinx.ext.mathjax and sphinx.ext.imgmath are conflicting. sphinx.ext.imgmath
requires the use of LaTeX to render formulas which may not be available.
Without sphinx.ext.imgmath formulas are rendered uses MathJax producing
effective and visually appealing results. This change removes
sphinx.ext.imgmath to fix rendering of formulas in the documentation of entropy
and other functions.