### PR TITLE
Fix conversion documentation

### DIFF
--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -506,6 +506,42 @@ TEST_F(CastExprTest, basics) {
       {1.888, 2.5, 3.6, 100.44, -100.101, 1.0, -2.0},
       {1.888, 2.5, 3.6, 100.44, -100.101, 1.0, -2.0});
   testCast<bool, std::string>("string", {true, false}, {"true", "false"});
+  testCast<float, bool>(
+      "boolean",
+      {0.0,
+       1.0,
+       1.1,
+       -1.1,
+       0.5,
+       -0.5,
+       std::numeric_limits<float>::quiet_NaN(),
+       std::numeric_limits<float>::infinity(),
+       0.0000000000001},
+      {false, true, true, true, true, true, true, true, true});
+  testCast<std::string, float>(
+      "float",
+      {"1.888",
+       "1.",
+       "1",
+       "1.7E308",
+       "Infinity",
+       "-Infinity",
+       "infinity",
+       "inf",
+       "INFINITY",
+       "NaN",
+       "nan"},
+      {1.888,
+       1.0,
+       1.0,
+       std::numeric_limits<float>::infinity(),
+       std::numeric_limits<float>::infinity(),
+       -std::numeric_limits<float>::infinity(),
+       std::numeric_limits<float>::infinity(),
+       std::numeric_limits<float>::infinity(),
+       std::numeric_limits<float>::infinity(),
+       std::numeric_limits<float>::quiet_NaN(),
+       std::numeric_limits<float>::quiet_NaN()});
 
   gflags::FlagSaver flagSaver;
   FLAGS_experimental_enable_legacy_cast = true;

--- a/velox/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
+++ b/velox/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
@@ -32,6 +32,20 @@ class TimestampWithTimeZoneCastTest : public functions::test::CastBaseTest {
         timestamps->size(),
         std::vector<VectorPtr>({timestamps, timezones}));
   }
+
+ protected:
+  void setQueryTimeZone(const std::string& timeZone) {
+    queryCtx_->testingOverrideConfigUnsafe({
+        {core::QueryConfig::kSessionTimezone, timeZone},
+        {core::QueryConfig::kAdjustTimestampToTimezone, "true"},
+    });
+  }
+
+  void disableAdjustTimestampToTimezone() {
+    queryCtx_->testingOverrideConfigUnsafe({
+        {core::QueryConfig::kAdjustTimestampToTimezone, "false"},
+    });
+  }
 };
 
 TEST_F(TimestampWithTimeZoneCastTest, fromTimestamp) {
@@ -52,8 +66,31 @@ TEST_F(TimestampWithTimeZoneCastTest, toTimestamp) {
           {1996 * kMillisInSecond, 0, 19920 * kMillisInSecond}),
       makeFlatVector<int16_t>({0, 0, 1825 /*America/Los_Angeles*/}));
   tsWithTZVector->setNull(1, true);
-  const auto expected = makeNullableFlatVector<Timestamp>(
-      {Timestamp(1996, 0), std::nullopt, Timestamp(19920 - 8 * 3600, 0)});
 
+  for (const std::string& timezone :
+       {"America/Los_Angeles", "America/New_York"}) {
+    setQueryTimeZone(timezone);
+    auto expected = makeNullableFlatVector<Timestamp>(
+        {Timestamp(1996, 0), std::nullopt, Timestamp(19920, 0)});
+    testCast(TIMESTAMP_WITH_TIME_ZONE(), TIMESTAMP(), tsWithTZVector, expected);
+
+    // Cast('1969-12-31 16:00:00 -08:00' as timestamp).
+    auto result = evaluateOnce<Timestamp>(
+        "cast(from_unixtime(c0, 'America/Los_Angeles') as timestamp)",
+        makeRowVector({makeFlatVector<double>(std::vector<double>(1, 0))}));
+    // 1970-01-01 00:00:00.
+    EXPECT_EQ(Timestamp(0, 0), result.value());
+  }
+
+  disableAdjustTimestampToTimezone();
+  auto expected = makeNullableFlatVector<Timestamp>(
+      {Timestamp(1996, 0), std::nullopt, Timestamp(19920 - 8 * 3600, 0)});
   testCast(TIMESTAMP_WITH_TIME_ZONE(), TIMESTAMP(), tsWithTZVector, expected);
+
+  // Cast('1969-12-31 16:00:00 -08:00' as timestamp).
+  auto result = evaluateOnce<Timestamp>(
+      "cast(from_unixtime(c0, 'America/Los_Angeles') as timestamp)",
+      makeRowVector({makeFlatVector<double>(std::vector<double>(1, 0))}));
+  // 1969-12-31 16:00:00.
+  EXPECT_EQ(Timestamp(-28800, 0), result.value());
 }


### PR DESCRIPTION
Fix some inaccurate descriptions found in conversion.rst. Document the 
limitation of cast from string to real. Add unit tests for cast from float to 
bool, cast from string to float, and cast from timestamp with timezone to
timestamp.
