### PR TITLE
Fix entropy aggregate function on all null inputs

### DIFF
--- a/velox/functions/prestosql/aggregates/EntropyAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/EntropyAggregates.cpp
@@ -273,7 +273,7 @@ class EntropyAggregate : public exec::Aggregate {
     for (int32_t i = 0; i < numGroups; ++i) {
       char* group = groups[i];
       if (isNull(group)) {
-        vector->setNull(i, true);
+        rawValues[i] = 0.0;
       } else {
         clearNull(rawNulls, i);
         EntropyAccumulator* accData = accumulator(group);

--- a/velox/functions/prestosql/aggregates/tests/EntropyAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/EntropyAggregationTest.cpp
@@ -172,5 +172,18 @@ TEST_F(EntropyAggregationTest, mayHaveNulls) {
   testAggregations({data}, {"c0"}, {"entropy(c1)"}, {"a0"}, {expectedResult});
 }
 
+TEST_F(EntropyAggregationTest, allNulls) {
+  auto data = makeRowVector({makeAllNullFlatVector<int64_t>(10)});
+  auto expectedResult = makeRowVector({makeConstant(0.0, 1)});
+  testAggregations({data}, {}, {"entropy(c0)"}, {expectedResult});
+
+  data = makeRowVector(
+      {makeFlatVector<int32_t>({1, 1, 1, 2, 2, 2}),
+       makeNullableFlatVector<int32_t>(
+           {1, 1, std::nullopt, std::nullopt, std::nullopt, std::nullopt})});
+  expectedResult = makeRowVector({makeFlatVector<double>({1.0, 0.0})});
+  testAggregations({data}, {"c0"}, {"entropy(c1)"}, {"a0"}, {expectedResult});
+}
+
 } // namespace
 } // namespace facebook::velox::aggregate::test


### PR DESCRIPTION
In Presto, entropy aggregate applies to all null inputs
and returns 0.0, but Velox returns null.

```
presto:di> select entropy(x) from unnest(array[null, null]) as t(x);
 _col0
-------
   0.0
(1 row)
```
 Resolve #7630 