### PR TITLE
Support to collect spilling stats from table writer

### DIFF
--- a/velox/common/base/SpillStats.cpp
+++ b/velox/common/base/SpillStats.cpp
@@ -16,7 +16,6 @@
 
 #include "velox/common/base/SpillStats.h"
 #include "velox/common/base/Exceptions.h"
-
 #include "velox/common/base/SuccinctPrinter.h"
 
 namespace facebook::velox::common {

--- a/velox/connectors/Connector.cpp
+++ b/velox/connectors/Connector.cpp
@@ -31,6 +31,18 @@ std::unordered_map<std::string, std::shared_ptr<Connector>>& connectors() {
 }
 } // namespace
 
+bool DataSink::Stats::empty() const {
+  return numWrittenBytes == 0 && numWrittenFiles == 0 && spillStats.empty();
+}
+
+std::string DataSink::Stats::toString() const {
+  return fmt::format(
+      "numWrittenBytes {} numWrittenFiles {} {}",
+      succinctBytes(numWrittenBytes),
+      numWrittenFiles,
+      spillStats.toString());
+}
+
 bool registerConnectorFactory(std::shared_ptr<ConnectorFactory> factory) {
   factory->initialize();
   bool ok =

--- a/velox/dwio/common/SortingWriter.cpp
+++ b/velox/dwio/common/SortingWriter.cpp
@@ -22,15 +22,18 @@ SortingWriter::SortingWriter(
     std::unique_ptr<Writer> writer,
     std::unique_ptr<exec::SortBuffer> sortBuffer,
     uint32_t maxOutputRowsConfig,
-    uint64_t maxOutputBytesConfig)
+    uint64_t maxOutputBytesConfig,
+    velox::common::SpillStats* spillStats)
     : outputWriter_(std::move(writer)),
       maxOutputRowsConfig_(maxOutputRowsConfig),
       maxOutputBytesConfig_(maxOutputBytesConfig),
       sortPool_(sortBuffer->pool()),
       canReclaim_(sortBuffer->canSpill()),
+      spillStats_(spillStats),
       sortBuffer_(std::move(sortBuffer)) {
   VELOX_CHECK_GT(maxOutputRowsConfig_, 0);
   VELOX_CHECK_GT(maxOutputBytesConfig_, 0);
+  VELOX_CHECK_NOT_NULL(spillStats_);
   if (sortPool_->parent()->reclaimer() != nullptr) {
     sortPool_->setReclaimer(MemoryReclaimer::create(this));
   }
@@ -56,6 +59,11 @@ void SortingWriter::close() {
   while (output != nullptr) {
     outputWriter_->write(output);
     output = sortBuffer_->getOutput(maxOutputBatchRows);
+  }
+  auto spillStatsOr = sortBuffer_->spilledStats();
+  if (spillStatsOr.has_value()) {
+    VELOX_CHECK(canReclaim_);
+    *spillStats_ = spillStatsOr.value();
   }
   sortBuffer_.reset();
   sortPool_->release();

--- a/velox/dwio/common/SortingWriter.h
+++ b/velox/dwio/common/SortingWriter.h
@@ -29,7 +29,8 @@ class SortingWriter : public Writer {
       std::unique_ptr<Writer> writer,
       std::unique_ptr<exec::SortBuffer> sortBuffer,
       uint32_t maxOutputRowsConfig,
-      uint64_t maxOutputBytesConfig);
+      uint64_t maxOutputBytesConfig,
+      velox::common::SpillStats* spillStats);
 
   void write(const VectorPtr& data) override;
 
@@ -75,9 +76,10 @@ class SortingWriter : public Writer {
   const std::unique_ptr<Writer> outputWriter_;
   const uint32_t maxOutputRowsConfig_;
   const uint64_t maxOutputBytesConfig_;
-
   memory::MemoryPool* const sortPool_;
   const bool canReclaim_;
+  velox::common::SpillStats* const spillStats_;
+
   std::unique_ptr<exec::SortBuffer> sortBuffer_;
 };
 

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -60,7 +60,6 @@ GroupingSet::GroupingSet(
     const std::vector<vector_size_t>& globalGroupingSets,
     const std::optional<column_index_t>& groupIdChannel,
     const common::SpillConfig* spillConfig,
-    uint32_t* numSpillRuns,
     tsan_atomic<bool>* nonReclaimableSection,
     OperatorCtx* operatorCtx)
     : preGroupedKeyChannels_(std::move(preGroupedKeys)),
@@ -78,7 +77,6 @@ GroupingSet::GroupingSet(
       globalGroupingSets_(globalGroupingSets),
       groupIdChannel_(groupIdChannel),
       spillConfig_(spillConfig),
-      numSpillRuns_(numSpillRuns),
       nonReclaimableSection_(nonReclaimableSection),
       stringAllocator_(operatorCtx->pool()),
       rows_(operatorCtx->pool()),
@@ -158,7 +156,6 @@ std::unique_ptr<GroupingSet> GroupingSet::createForMarkDistinct(
       /*globalGroupingSets*/ std::vector<vector_size_t>{},
       /*groupIdColumn*/ std::nullopt,
       /*spillConfig*/ nullptr,
-      /*numSpillRuns*/ nullptr,
       nonReclaimableSection,
       operatorCtx);
 };
@@ -972,7 +969,6 @@ void GroupingSet::spill() {
         memory::spillMemoryPool(),
         spillConfig_->executor);
   }
-  ++(*numSpillRuns_);
   spiller_->spill();
   if (sortedAggregations_) {
     sortedAggregations_->clear();
@@ -1000,7 +996,6 @@ void GroupingSet::spill(const RowContainerIterator& rowIterator) {
       memory::spillMemoryPool(),
       spillConfig_->executor);
 
-  ++(*numSpillRuns_);
   spiller_->spill(rowIterator);
   table_->clear();
 }

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -39,7 +39,6 @@ class GroupingSet {
       const std::vector<vector_size_t>& globalGroupingSets,
       const std::optional<column_index_t>& groupIdChannel,
       const common::SpillConfig* spillConfig,
-      uint32_t* numSpillRuns,
       tsan_atomic<bool>* nonReclaimableSection,
       OperatorCtx* operatorCtx);
 
@@ -293,8 +292,6 @@ class GroupingSet {
   std::optional<column_index_t> groupIdChannel_;
 
   const common::SpillConfig* const spillConfig_;
-
-  uint32_t* const numSpillRuns_;
 
   // Indicates if this grouping set and the associated hash aggregation operator
   // is under non-reclaimable execution section or not.

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -214,7 +214,6 @@ void HashAggregation::initialize() {
       aggregationNode_->globalGroupingSets(),
       groupIdChannel,
       spillConfig_.has_value() ? &spillConfig_.value() : nullptr,
-      &numSpillRuns_,
       &nonReclaimableSection_,
       operatorCtx_.get());
 
@@ -300,12 +299,9 @@ void HashAggregation::updateRuntimeStats() {
 
 void HashAggregation::recordSpillStats() {
   auto spillStatsOr = groupingSet_->spilledStats();
-  if (!spillStatsOr.has_value()) {
-    return;
+  if (spillStatsOr.has_value()) {
+    Operator::recordSpillStats(spillStatsOr.value());
   }
-  VELOX_CHECK_EQ(spillStatsOr.value().spillRuns, 0);
-  spillStatsOr.value().spillRuns = numSpillRuns_;
-  Operator::recordSpillStats(spillStatsOr.value());
 }
 
 void HashAggregation::prepareOutput(vector_size_t size) {

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -672,7 +672,6 @@ void HashBuild::runSpill(const std::vector<Operator*>& spillOperators) {
   for (auto& spillOp : spillOperators) {
     HashBuild* build = dynamic_cast<HashBuild*>(spillOp);
     VELOX_CHECK_NOT_NULL(build);
-    ++build->numSpillRuns_;
     build->addAndClearSpillTarget(targetRows, targetBytes);
   }
   VELOX_CHECK_GT(targetRows, 0);
@@ -1133,7 +1132,6 @@ void HashBuild::reclaim(
   auto* spillExecutor = spillConfig()->executor;
   for (auto* op : operators) {
     HashBuild* buildOp = static_cast<HashBuild*>(op);
-    ++buildOp->numSpillRuns_;
     spillTasks.push_back(
         std::make_shared<AsyncSource<SpillResult>>([buildOp]() {
           try {

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -246,7 +246,6 @@ void HashProbe::maybeSetupSpillInput(
   // If 'spillInputPartitionIds_' is not empty, then we set up a spiller to
   // spill the incoming probe inputs.
   const auto& spillConfig = spillConfig_.value();
-  ++numSpillRuns_;
   spiller_ = std::make_unique<Spiller>(
       Spiller::Type::kHashJoinProbe,
       probeType_,

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -351,10 +351,11 @@ void Operator::recordSpillStats(const common::SpillStats& spillStats) {
                 Timestamp::kNanosecondsInMicrosecond),
             RuntimeCounter::Unit::kNanos});
   }
-  if (numSpillRuns_ != 0) {
+  if (spillStats.spillRuns != 0) {
     lockedStats->addRuntimeStat(
-        "spillRuns", RuntimeCounter{static_cast<int64_t>(numSpillRuns_)});
-    common::updateGlobalSpillRunStats(numSpillRuns_);
+        "spillRuns",
+        RuntimeCounter{static_cast<int64_t>(spillStats.spillRuns)});
+    common::updateGlobalSpillRunStats(spillStats.spillRuns);
   }
 
   if (spillStats.spillMaxLevelExceededCount != 0) {

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -713,9 +713,6 @@ class Operator : public BaseRuntimeStatWriter {
 
   std::unordered_map<column_index_t, std::shared_ptr<common::Filter>>
       dynamicFilters_;
-
-  /// The number of times that spilling run on this operator.
-  uint32_t numSpillRuns_{0};
 };
 
 /// Given a row type returns indices for the specified subset of columns.

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -65,7 +65,6 @@ OrderBy::OrderBy(
       sortCompareFlags,
       pool(),
       &nonReclaimableSection_,
-      &numSpillRuns_,
       spillConfig_.has_value() ? &(spillConfig_.value()) : nullptr,
       operatorCtx_->driverCtx()->queryConfig().orderBySpillMemoryThreshold());
 }
@@ -125,7 +124,7 @@ void OrderBy::abort() {
 
 void OrderBy::recordSpillStats() {
   VELOX_CHECK_NOT_NULL(sortBuffer_);
-  const auto spillStats = sortBuffer_->spilledStats();
+  auto spillStats = sortBuffer_->spilledStats();
   if (spillStats.has_value()) {
     Operator::recordSpillStats(spillStats.value());
   }

--- a/velox/exec/SortBuffer.cpp
+++ b/velox/exec/SortBuffer.cpp
@@ -26,21 +26,18 @@ SortBuffer::SortBuffer(
     const std::vector<CompareFlags>& sortCompareFlags,
     velox::memory::MemoryPool* pool,
     tsan_atomic<bool>* nonReclaimableSection,
-    uint32_t* numSpillRuns,
     const common::SpillConfig* spillConfig,
     uint64_t spillMemoryThreshold)
     : input_(input),
       sortCompareFlags_(sortCompareFlags),
       pool_(pool),
       nonReclaimableSection_(nonReclaimableSection),
-      numSpillRuns_(numSpillRuns),
       spillConfig_(spillConfig),
       spillMemoryThreshold_(spillMemoryThreshold) {
   VELOX_CHECK_GE(input_->size(), sortCompareFlags_.size());
   VELOX_CHECK_GT(sortCompareFlags_.size(), 0);
   VELOX_CHECK_EQ(sortColumnIndices.size(), sortCompareFlags_.size());
   VELOX_CHECK_NOT_NULL(nonReclaimableSection_);
-  VELOX_CHECK_NOT_NULL(numSpillRuns_);
 
   std::vector<TypePtr> sortedColumnTypes;
   std::vector<TypePtr> nonSortedColumnTypes;
@@ -170,7 +167,6 @@ void SortBuffer::spill() {
   }
   updateEstimatedOutputRowSize();
 
-  ++(*numSpillRuns_);
   if (spiller_ == nullptr) {
     spiller_ = std::make_unique<Spiller>(
         Spiller::Type::kOrderBy,

--- a/velox/exec/SortBuffer.h
+++ b/velox/exec/SortBuffer.h
@@ -36,7 +36,6 @@ class SortBuffer {
       const std::vector<CompareFlags>& sortCompareFlags,
       velox::memory::MemoryPool* pool,
       tsan_atomic<bool>* nonReclaimableSection,
-      uint32_t* numSpillRuns,
       const common::SpillConfig* spillConfig = nullptr,
       uint64_t spillMemoryThreshold = 0);
 
@@ -89,8 +88,6 @@ class SortBuffer {
   // TableWriter to indicate if this sort buffer object is under non-reclaimable
   // execution section or not.
   tsan_atomic<bool>* const nonReclaimableSection_;
-  // A recorder for number of spill runs passed in from order by operator.
-  uint32_t* const numSpillRuns_;
   const common::SpillConfig* const spillConfig_;
   // The maximum size that an SortBuffer can hold in memory before spilling.
   // Zero indicates no limit.

--- a/velox/exec/SortWindowBuild.cpp
+++ b/velox/exec/SortWindowBuild.cpp
@@ -211,13 +211,9 @@ void SortWindowBuild::noMoreInput() {
     // spilled data.
     spill();
 
-    SpillPartitionSet spillPartitionSet;
-    spiller_->finishSpill(spillPartitionSet);
-    VELOX_CHECK_LE(spillPartitionSet.size(), 1);
     VELOX_CHECK_NULL(merge_);
-    auto& spillPartition = spillPartitionSet.begin()->second;
-    VELOX_CHECK_NOT_NULL(spillPartition);
-    merge_ = spillPartition->createOrderedReader();
+    auto spillPartition = spiller_->finishSpill();
+    merge_ = spillPartition.createOrderedReader();
   } else {
     // At this point we have seen all the input rows. The operator is
     // being prepared to output rows now.

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -398,6 +398,8 @@ std::unique_ptr<Spiller::SpillStatus> Spiller::writeSpill(int32_t partition) {
 }
 
 void Spiller::runSpill() {
+  ++stats_.wlock()->spillRuns;
+
   std::vector<std::shared_ptr<AsyncSource<SpillStatus>>> writes;
   for (auto partition = 0; partition < spillRuns_.size(); ++partition) {
     VELOX_CHECK(

--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -186,11 +186,7 @@ class TableWriter : public Operator {
 
   void abortDataSink();
 
-  // Updates physicalWrittenBytes in OperatorStats with current written bytes.
-  void updateWrittenBytes();
-
-  // Updates numWrittenFiles in runtimeStats.
-  void updateNumWrittenFiles();
+  void updateStats(const connector::DataSink::Stats& stats);
 
   std::string createTableCommitContext(bool lastOutput);
 

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -108,10 +108,11 @@ void verifyTaskSpilledRuntimeStats(const exec::Task& task, bool expectedSpill) {
           ASSERT_EQ(op.runtimeStats["spillDiskWrites"].count, 0);
           ASSERT_EQ(op.runtimeStats["spillWriteTime"].count, 0);
         } else {
-          ASSERT_GT(op.runtimeStats["spillRuns"].count, 0);
           if (op.operatorType == "HashBuild") {
+            ASSERT_GT(op.runtimeStats["spillRuns"].count, 0);
             ASSERT_GT(op.runtimeStats["spillFillTime"].sum, 0);
           } else {
+            ASSERT_EQ(op.runtimeStats["spillRuns"].count, 0);
             ASSERT_EQ(op.runtimeStats["spillFillTime"].sum, 0);
           }
           ASSERT_EQ(op.runtimeStats["spillSortTime"].sum, 0);

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -81,9 +81,8 @@ class SortBufferTest : public OperatorTestBase {
   const std::shared_ptr<folly::Executor> executor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
           std::thread::hardware_concurrency())};
-  tsan_atomic<bool> nonReclaimableSection_{false};
-  uint32_t numSpillRuns_;
 
+  tsan_atomic<bool> nonReclaimableSection_{false};
   folly::Random::DefaultGenerator rng_;
 };
 
@@ -124,8 +123,7 @@ TEST_F(SortBufferTest, singleKey) {
         sortColumnIndices_,
         testData.sortCompareFlags,
         pool_.get(),
-        &nonReclaimableSection_,
-        &numSpillRuns_);
+        &nonReclaimableSection_);
 
     RowVectorPtr data = makeRowVector(
         {makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
@@ -155,8 +153,7 @@ TEST_F(SortBufferTest, multipleKeys) {
       sortColumnIndices_,
       sortCompareFlags_,
       pool_.get(),
-      &nonReclaimableSection_,
-      &numSpillRuns_);
+      &nonReclaimableSection_);
 
   RowVectorPtr data = makeRowVector(
       {makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
@@ -236,8 +233,7 @@ TEST_F(SortBufferTest, DISABLED_randomData) {
         testData.sortColumnIndices,
         testData.sortCompareFlags,
         pool_.get(),
-        &nonReclaimableSection_,
-        &numSpillRuns_);
+        &nonReclaimableSection_);
 
     const std::shared_ptr<memory::MemoryPool> fuzzerPool =
         memory::addDefaultLeafMemoryPool("VectorFuzzer");
@@ -308,7 +304,6 @@ TEST_F(SortBufferTest, batchOutput) {
         sortCompareFlags_,
         pool_.get(),
         &nonReclaimableSection_,
-        &numSpillRuns_,
         testData.triggerSpill ? &spillConfig : nullptr,
         0);
     ASSERT_EQ(sortBuffer->canSpill(), testData.triggerSpill);
@@ -402,7 +397,6 @@ TEST_F(SortBufferTest, spill) {
         sortCompareFlags_,
         pool_.get(),
         &nonReclaimableSection_,
-        &numSpillRuns_,
         testData.spillEnabled ? &spillConfig : nullptr,
         testData.spillMemoryThreshold);
 
@@ -462,7 +456,6 @@ TEST_F(SortBufferTest, emptySpill) {
         sortCompareFlags_,
         pool_.get(),
         &nonReclaimableSection_,
-        &numSpillRuns_,
         &spillConfig,
         0);
 


### PR DESCRIPTION
Add to support collecting spill stats from table writer. Refactor the data sink
API to return all the stats in one dedicated API DataSink::stats() which include
number of written bytes, number of written files, partition metadata and spilled
stats.