### PR TITLE
Allow registering an aggregation function with multiple names at once

### DIFF
--- a/velox/exec/Aggregate.cpp
+++ b/velox/exec/Aggregate.cpp
@@ -55,8 +55,8 @@ getAggregateFunctionEntry(const std::string& name) {
 
 AggregateRegistrationResult registerAggregateFunction(
     const std::string& name,
-    std::vector<std::shared_ptr<AggregateFunctionSignature>> signatures,
-    AggregateFunctionFactory factory,
+    const std::vector<std::shared_ptr<AggregateFunctionSignature>>& signatures,
+    const AggregateFunctionFactory& factory,
     bool registerCompanionFunctions,
     bool overwrite) {
   auto sanitizedName = sanitizeName(name);
@@ -96,6 +96,21 @@ AggregateRegistrationResult registerAggregateFunction(
             name, signatures, overwrite);
   }
   return registered;
+}
+
+std::vector<AggregateRegistrationResult> registerAggregateFunction(
+    const std::vector<std::string>& names,
+    const std::vector<std::shared_ptr<AggregateFunctionSignature>>& signatures,
+    const AggregateFunctionFactory& factory,
+    bool registerCompanionFunctions,
+    bool overwrite) {
+  auto size = names.size();
+  std::vector<AggregateRegistrationResult> registrationResults{size};
+  for (int i = 0; i < size; ++i) {
+    registrationResults[i] = registerAggregateFunction(
+        names[i], signatures, factory, registerCompanionFunctions, overwrite);
+  }
+  return registrationResults;
 }
 
 std::unordered_map<

--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -420,8 +420,17 @@ using AggregateFunctionFactory = std::function<std::unique_ptr<Aggregate>(
 /// false without overwriting the registry.
 AggregateRegistrationResult registerAggregateFunction(
     const std::string& name,
-    std::vector<std::shared_ptr<AggregateFunctionSignature>> signatures,
-    AggregateFunctionFactory factory,
+    const std::vector<std::shared_ptr<AggregateFunctionSignature>>& signatures,
+    const AggregateFunctionFactory& factory,
+    bool registerCompanionFunctions = false,
+    bool overwrite = false);
+
+// Register an aggregation function with multiple names. Returns a vector of
+// AggregateRegistrationResult, one for each name at the corresponding index.
+std::vector<AggregateRegistrationResult> registerAggregateFunction(
+    const std::vector<std::string>& names,
+    const std::vector<std::shared_ptr<AggregateFunctionSignature>>& signatures,
+    const AggregateFunctionFactory& factory,
     bool registerCompanionFunctions = false,
     bool overwrite = false);
 

--- a/velox/exec/AggregateUtil.h
+++ b/velox/exec/AggregateUtil.h
@@ -24,6 +24,14 @@ struct AggregateRegistrationResult {
   bool mergeFunction{false};
   bool extractFunction{false};
   bool mergeExtractFunction{false};
+
+  bool operator==(const AggregateRegistrationResult& other) const {
+    return mainFunction == other.mainFunction &&
+        partialFunction == other.partialFunction &&
+        mergeFunction == other.mergeFunction &&
+        extractFunction == other.extractFunction &&
+        mergeExtractFunction == other.mergeExtractFunction;
+  }
 };
 
 } // namespace facebook::velox::exec


### PR DESCRIPTION
Summary: Allow users to provide a list of names when registering one aggregation function.

Reviewed By: amitkdutta

Differential Revision: D51438947


