### PR TITLE
Refactor thriftCodecToCompressionKind() as an utility function

### DIFF
--- a/velox/dwio/parquet/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/reader/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(
   PageReader.cpp
   ParquetColumnReader.cpp
   ParquetData.cpp
+  ParquetReaderUtil.cpp
   RepeatedColumnReader.cpp
   RleBpDecoder.cpp
   Statistics.cpp

--- a/velox/dwio/parquet/reader/PageReader.h
+++ b/velox/dwio/parquet/reader/PageReader.h
@@ -198,8 +198,6 @@ class PageReader {
   // straddles buffers. Allocates or resizes 'copy' as needed.
   const char* FOLLY_NONNULL readBytes(int32_t size, BufferPtr& copy);
 
-  common::CompressionKind thriftCodecToCompressionKind();
-
   // Decompresses data starting at 'pageData_', consuming 'compressedsize' and
   // producing up to 'uncompressedSize' bytes. The start of the decoding
   // result is returned. an intermediate copy may be made in 'decompresseddata_'

--- a/velox/dwio/parquet/reader/ParquetReaderUtil.cpp
+++ b/velox/dwio/parquet/reader/ParquetReaderUtil.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/dwio/parquet/reader/ParquetReaderUtil.h"
+
+namespace facebook::velox::parquet {
+
+common::CompressionKind thriftCodecToCompressionKind(
+    thrift::CompressionCodec::type codec) {
+  switch (codec) {
+    case thrift::CompressionCodec::UNCOMPRESSED:
+      return common::CompressionKind::CompressionKind_NONE;
+      break;
+    case thrift::CompressionCodec::SNAPPY:
+      return common::CompressionKind::CompressionKind_SNAPPY;
+      break;
+    case thrift::CompressionCodec::GZIP:
+      return common::CompressionKind::CompressionKind_GZIP;
+      break;
+    case thrift::CompressionCodec::LZO:
+      return common::CompressionKind::CompressionKind_LZO;
+      break;
+    case thrift::CompressionCodec::LZ4:
+      return common::CompressionKind::CompressionKind_LZ4;
+      break;
+    case thrift::CompressionCodec::ZSTD:
+      return common::CompressionKind::CompressionKind_ZSTD;
+      break;
+    case thrift::CompressionCodec::LZ4_RAW:
+      return common::CompressionKind::CompressionKind_LZ4;
+    default:
+      VELOX_UNSUPPORTED(
+          "Unsupported compression type: " +
+          facebook::velox::parquet::thrift::to_string(codec));
+      break;
+  }
+}
+} // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/ParquetReaderUtil.h
+++ b/velox/dwio/parquet/reader/ParquetReaderUtil.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/dwio/common/compression/Compression.h"
+#include "velox/dwio/parquet/thrift/ParquetThriftTypes.h"
+
+namespace facebook::velox::parquet {
+
+common::CompressionKind thriftCodecToCompressionKind(
+    thrift::CompressionCodec::type codec);
+
+} // namespace facebook::velox::parquet


### PR DESCRIPTION
Refactor thriftCodecToCompressionKind() utility function in ParquetReaderUtil.h/ParquetReaderUtil.cpp.