### PR TITLE
Add counters and stats for cache shrink for monitoring

### DIFF
--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -24,6 +24,14 @@ void registerVeloxCounters() {
   // P50, P90, P99, and P100.
   REPORT_ADD_HISTOGRAM_EXPORT_PERCENTILE(
       kCounterHiveFileHandleGenerateLatencyMs, 10, 0, 100000, 50, 90, 99, 100);
+
+  REPORT_ADD_STAT_EXPORT_TYPE(
+      kCounterCacheShrinkCount, facebook::velox::StatType::COUNT);
+
+  // Track cache shrink latency in range of [0, 100s] and reports P50, P90, P99,
+  // and P100.
+  REPORT_ADD_HISTOGRAM_EXPORT_PERCENTILE(
+      kCounterCacheShrinkTimeMs, 10, 0, 100'000, 50, 90, 99, 100);
 }
 
 } // namespace facebook::velox

--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -25,4 +25,9 @@ void registerVeloxCounters();
 
 constexpr folly::StringPiece kCounterHiveFileHandleGenerateLatencyMs{
     "velox.hive_file_handle_generate_latency_ms"};
+
+constexpr folly::StringPiece kCounterCacheShrinkCount{
+    "velox.cache_shrink_count"};
+
+constexpr folly::StringPiece kCounterCacheShrinkTimeMs{"velox.cache_shrink_ms"};
 } // namespace facebook::velox


### PR DESCRIPTION
Add counters to track the cache shrink count and execution time distribution for monitoring.
This helps us to detect any memory usage pattern changes in prod once we have enabled
memory pushback support as well as check if cache shrink is fast enough