### PR TITLE
Add API to clear connector caches

### DIFF
--- a/velox/connectors/Connector.cpp
+++ b/velox/connectors/Connector.cpp
@@ -80,6 +80,12 @@ getAllConnectors() {
   return connectors();
 }
 
+void clearConnectorsCache() {
+  for (const auto& connectorEntry : getAllConnectors()) {
+    connectorEntry.second->clearCache();
+  }
+}
+
 folly::Synchronized<
     std::unordered_map<std::string_view, std::weak_ptr<cache::ScanTracker>>>
     Connector::trackers_;

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -127,6 +127,10 @@ std::unique_ptr<DataSink> HiveConnector::createDataSink(
       connectorProperties());
 }
 
+void HiveConnector::clearCache() {
+  fileHandleFactory_.clearCache();
+}
+
 std::unique_ptr<core::PartitionFunction> HivePartitionFunctionSpec::create(
     int numPartitions) const {
   std::vector<int> bucketToPartitions;

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -31,7 +31,7 @@ class HiveConnector : public Connector {
   HiveConnector(
       const std::string& id,
       std::shared_ptr<const Config> properties,
-      folly::Executor* FOLLY_NULLABLE executor);
+      folly::Executor* executor);
 
   bool canAddDynamicFilter() const override {
     return true;
@@ -55,7 +55,9 @@ class HiveConnector : public Connector {
       ConnectorQueryCtx* connectorQueryCtx,
       CommitStrategy commitStrategy) override final;
 
-  folly::Executor* FOLLY_NULLABLE executor() const override {
+  void clearCache() override;
+
+  folly::Executor* executor() const override {
     return executor_;
   }
 
@@ -71,7 +73,7 @@ class HiveConnector : public Connector {
 
  protected:
   FileHandleFactory fileHandleFactory_;
-  folly::Executor* FOLLY_NULLABLE executor_;
+  folly::Executor* executor_;
 };
 
 class HiveConnectorFactory : public ConnectorFactory {
@@ -92,7 +94,7 @@ class HiveConnectorFactory : public ConnectorFactory {
   std::shared_ptr<Connector> newConnector(
       const std::string& id,
       std::shared_ptr<const Config> properties,
-      folly::Executor* FOLLY_NULLABLE executor = nullptr) override {
+      folly::Executor* executor = nullptr) override {
     return std::make_shared<HiveConnector>(id, properties, executor);
   }
 };

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -239,6 +239,11 @@ TEST_F(TableScanTest, connectorStats) {
 
   verifyCacheStats(hiveConnector->fileHandleCacheStats(), 99, 0, 99);
   verifyCacheStats(hiveConnector->clearFileHandleCache(), 0, 0, 99);
+
+  connector::clearConnectorsCache();
+
+  // Clear cache only clear the cached file handles but keep the stats.
+  verifyCacheStats(hiveConnector->fileHandleCacheStats(), 0, 0, 99);
 }
 
 TEST_F(TableScanTest, columnAliases) {


### PR DESCRIPTION
The new API is used to clear file handle cache in HiveConnector.

We also consider to optimize the file cache access on table scan path to
mitigate the potential performance impact on the cleared file handle cache.