### PR TITLE
Clear the data in stringBuffers_ when the filtering rate is 100%

### DIFF
--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -159,6 +159,9 @@ class SelectiveColumnReader {
       buff->release();
     }
     stringBuffers_.clear();
+    for(auto child : children()) {
+      child->resetWhenFilterAll();
+    }
   }
 
   // Seeks to offset and reads the rows in 'rows' and applies

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -151,6 +151,16 @@ class SelectiveColumnReader {
   // from a downstream operator.
   virtual void resetFilterCaches();
 
+  virtual void resetWhenFilterAll() {
+    rawStringBuffer_ = nullptr;
+    rawStringSize_ = 0;
+    rawStringUsed_ = 0;
+    for (auto& buff : stringBuffers_) {
+      buff->release();
+    }
+    stringBuffers_.clear();
+  }
+
   // Seeks to offset and reads the rows in 'rows' and applies
   // filters and value processing as given by 'scanSpec supplied at
   // construction. 'offset' is relative to start of stripe. 'rows' are

--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -326,9 +326,7 @@ void SelectiveStructColumnReaderBase::getValues(
   auto* resultRow = static_cast<RowVector*>(result->get());
   resultRow->unsafeResize(rows.size());
   if (!rows.size()) {
-    for(auto child : children_) {
-      child->resetWhenFilterAll();
-    }
+    resetWhenFilterAll();
     return;
   }
   if (nullsInReadRange_) {

--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -326,6 +326,9 @@ void SelectiveStructColumnReaderBase::getValues(
   auto* resultRow = static_cast<RowVector*>(result->get());
   resultRow->unsafeResize(rows.size());
   if (!rows.size()) {
+    for(auto child : children_) {
+      child->resetWhenFilterAll();
+    }
     return;
   }
   if (nullsInReadRange_) {


### PR DESCRIPTION
When the Filter filtering rate is 100%, clear the data in stringBuffers_, otherwise the TableScan operator will occupy a lot of memory.