### PR TITLE
Fix metric of total scan time

### DIFF
--- a/velox/dwio/common/CacheInputStream.cpp
+++ b/velox/dwio/common/CacheInputStream.cpp
@@ -217,6 +217,7 @@ void CacheInputStream::loadSync(Region region) {
       }
       ioStats_->read().increment(region.length);
       ioStats_->queryThreadIoLatency().increment(usec);
+      ioStats_->incTotalScanTime(usec * 1'000);
       entry->setExclusiveToShared();
     } else {
       // Hit memory cache.

--- a/velox/dwio/common/DirectInputStream.cpp
+++ b/velox/dwio/common/DirectInputStream.cpp
@@ -154,6 +154,7 @@ void DirectInputStream::loadSync() {
   }
   ioStats_->read().increment(loadedRegion_.length);
   ioStats_->queryThreadIoLatency().increment(usecs);
+  ioStats_->incTotalScanTime(usecs * 1'000);
 }
 
 void DirectInputStream::loadPosition() {

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1834,9 +1834,20 @@ TEST_F(TableScanTest, statsBasedSkippingNulls) {
         "SELECT * FROM tmp WHERE " + filter);
   };
 
-  auto task = assertQuery("c0 IS NULL");
+  auto task = TableScanTest::assertQuery(
+      PlanBuilder().tableScan(rowType).planNode(),
+      filePaths,
+      "SELECT * FROM tmp");
 
   auto stats = getTableScanStats(task);
+  EXPECT_EQ(31'234, stats.rawInputRows);
+  EXPECT_EQ(31'234, stats.inputRows);
+  EXPECT_EQ(31'234, stats.outputRows);
+  EXPECT_GT(getTableScanRuntimeStats(task)["totalScanTime"].sum, 0);
+
+  task = assertQuery("c0 IS NULL");
+
+  stats = getTableScanStats(task);
   EXPECT_EQ(0, stats.rawInputRows);
   EXPECT_EQ(0, stats.inputRows);
   EXPECT_EQ(0, stats.outputRows);


### PR DESCRIPTION
`CachedBufferedInput` and `DirectBufferedInput` created in HiveDataSource do 
not send the ioStats to BufferedInput, so stats_ is nullptr in `ReadFileInputStream`
and metrics are not updated. This PR updates total scan time in `CacheInputStream`
and `DirectInputStream`.

