### PR TITLE
fix eden build with python 3.12

### DIFF
--- a/build/fbcode_builder/CMake/fb_py_test_main.py
+++ b/build/fbcode_builder/CMake/fb_py_test_main.py
@@ -194,7 +194,7 @@ class CallbackStream(object):
         return self._fileno
 
 
-class BuckTestResult(unittest._TextTestResult):
+class BuckTestResult(unittest.TextTestResult):
     """
     Our own TestResult class that outputs data in a format that can be easily
     parsed by buck's test runner.


### PR DESCRIPTION
Summary:
fix eden build with python 3.12

python 3.12 removes many long deprecated unittest features including  _TextTestResult (deprecated in Python 3.2)

notices as fedora 39 ships with python 3.12

X-link: https://github.com/facebook/sapling/pull/778

Differential Revision: D51455615


