### PR TITLE
Add optional coroutine support

### DIFF
--- a/velox/dwio/dwrf/reader/ColumnReader.h
+++ b/velox/dwio/dwrf/reader/ColumnReader.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "folly/Executor.h"
+#include "folly/experimental/coro/Task.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/ColumnSelector.h"
 #include "velox/dwio/common/TypeWithId.h"
@@ -90,6 +91,27 @@ class ColumnReader {
       uint64_t numValues,
       VectorPtr& result,
       const uint64_t* nulls = nullptr) = 0;
+
+#if FOLLY_HAS_COROUTINES
+
+  /**
+   * Skip number of specified rows.
+   * @param numValues the number of values to skip
+   * @return the number of non-null values skipped
+   */
+  virtual folly::coro::Task<uint64_t> co_skip(uint64_t numValues);
+
+  /**
+   * Read the next group of values into a RowVector.
+   * @param numValues the number of values to read
+   * @param vector to read into
+   */
+  virtual folly::coro::Task<void> co_next(
+      uint64_t numValues,
+      VectorPtr& result,
+      const uint64_t* nulls = nullptr) = 0;
+
+#endif // FOLLY_HAS_COROUTINES
 
   // Return list of strides/rowgroups that can be skipped (based on statistics).
   // Stride indices are monotonically increasing.

--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.h
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.h
@@ -158,6 +158,17 @@ class FlatMapColumnReader : public ColumnReader {
       VectorPtr& result,
       const uint64_t* FOLLY_NULLABLE nulls) override;
 
+#if FOLLY_HAS_COROUTINES
+
+  folly::coro::Task<uint64_t> co_skip(uint64_t numValues) override;
+
+  folly::coro::Task<void> co_next(
+      uint64_t numValues,
+      VectorPtr& result,
+      const uint64_t* nulls = nullptr) override;
+
+#endif // FOLLY_HAS_COROUTINES
+
  private:
   const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
   std::vector<std::unique_ptr<KeyNode<T>>> keyNodes_;
@@ -187,6 +198,17 @@ class FlatMapStructEncodingColumnReader : public ColumnReader {
       uint64_t numValues,
       VectorPtr& result,
       const uint64_t* FOLLY_NULLABLE nulls) override;
+
+#if FOLLY_HAS_COROUTINES
+
+  folly::coro::Task<uint64_t> co_skip(uint64_t numValues) override;
+
+  folly::coro::Task<void> co_next(
+      uint64_t numValues,
+      VectorPtr& result,
+      const uint64_t* nulls = nullptr) override;
+
+#endif // FOLLY_HAS_COROUTINES
 
  private:
   const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;


### PR DESCRIPTION
Summary:
Coroutines isn't supported by all compilers (specially in the open source repo), so the support must be optional.

To make the review easier, in this diff I'm just duplicating the `next` and `skip` methods to `co_next` and `co_skip` methods, and transforming them into coroutines by:
- making them return a `folly::coro::Task<>`
- adding at least a `co_return` in those methods
- Calling `co_` versions of methods from those transformed methods and `co_await`ing them

So this review is just doing that, we don't need to review the logic, since it's existing logic.

In the next diff I'll test all this, and from then on I'll start, diff my diff, to modify the logic to take advantage of those methods being co routines. I'll, for example, remove the use of executor.add(), and only parallelize on coroutines, with coroutine methods.

Once (and if) we're able to use coroutines in all compilers, and make sure that there aren't  performance regressions for running the `co_` versions of the methods when single threaded, we can remove the non-coroutine versions of the methods.

Differential Revision: D51479591


