### PR TITLE
Test optional coroutine support

### DIFF
--- a/velox/dwio/dwrf/reader/ColumnReader.h
+++ b/velox/dwio/dwrf/reader/ColumnReader.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "folly/Executor.h"
+#include "folly/experimental/coro/Task.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/ColumnSelector.h"
 #include "velox/dwio/common/TypeWithId.h"
@@ -90,6 +91,27 @@ class ColumnReader {
       uint64_t numValues,
       VectorPtr& result,
       const uint64_t* nulls = nullptr) = 0;
+
+#if FOLLY_HAS_COROUTINES
+
+  /**
+   * Skip number of specified rows.
+   * @param numValues the number of values to skip
+   * @return the number of non-null values skipped
+   */
+  virtual folly::coro::Task<uint64_t> co_skip(uint64_t numValues);
+
+  /**
+   * Read the next group of values into a RowVector.
+   * @param numValues the number of values to read
+   * @param vector to read into
+   */
+  virtual folly::coro::Task<void> co_next(
+      uint64_t numValues,
+      VectorPtr& result,
+      const uint64_t* nulls = nullptr) = 0;
+
+#endif // FOLLY_HAS_COROUTINES
 
   // Return list of strides/rowgroups that can be skipped (based on statistics).
   // Stride indices are monotonically increasing.

--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.h
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.h
@@ -158,6 +158,17 @@ class FlatMapColumnReader : public ColumnReader {
       VectorPtr& result,
       const uint64_t* FOLLY_NULLABLE nulls) override;
 
+#if FOLLY_HAS_COROUTINES
+
+  folly::coro::Task<uint64_t> co_skip(uint64_t numValues) override;
+
+  folly::coro::Task<void> co_next(
+      uint64_t numValues,
+      VectorPtr& result,
+      const uint64_t* nulls = nullptr) override;
+
+#endif // FOLLY_HAS_COROUTINES
+
  private:
   const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
   std::vector<std::unique_ptr<KeyNode<T>>> keyNodes_;
@@ -187,6 +198,17 @@ class FlatMapStructEncodingColumnReader : public ColumnReader {
       uint64_t numValues,
       VectorPtr& result,
       const uint64_t* FOLLY_NULLABLE nulls) override;
+
+#if FOLLY_HAS_COROUTINES
+
+  folly::coro::Task<uint64_t> co_skip(uint64_t numValues) override;
+
+  folly::coro::Task<void> co_next(
+      uint64_t numValues,
+      VectorPtr& result,
+      const uint64_t* nulls = nullptr) override;
+
+#endif // FOLLY_HAS_COROUTINES
 
  private:
   const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;


### PR DESCRIPTION
Summary:
Test new co_routine methods.

For now I'll keep the executor barrier. When I start refactoring the coroutine methods I'll remove that executor usage and schedule coroutines in the executor instead.

Differential Revision: D51479750


