### PR TITLE
Remove use of executor in flat map struct encoding co_next

### DIFF
--- a/velox/dwio/dwrf/reader/ColumnReader.h
+++ b/velox/dwio/dwrf/reader/ColumnReader.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "folly/Executor.h"
+#include "folly/experimental/coro/Task.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/ColumnSelector.h"
 #include "velox/dwio/common/TypeWithId.h"
@@ -90,6 +91,27 @@ class ColumnReader {
       uint64_t numValues,
       VectorPtr& result,
       const uint64_t* nulls = nullptr) = 0;
+
+#if FOLLY_HAS_COROUTINES
+
+  /**
+   * Skip number of specified rows.
+   * @param numValues the number of values to skip
+   * @return the number of non-null values skipped
+   */
+  virtual folly::coro::Task<uint64_t> co_skip(uint64_t numValues);
+
+  /**
+   * Read the next group of values into a RowVector.
+   * @param numValues the number of values to read
+   * @param vector to read into
+   */
+  virtual folly::coro::Task<void> co_next(
+      uint64_t numValues,
+      VectorPtr& result,
+      const uint64_t* nulls = nullptr) = 0;
+
+#endif // FOLLY_HAS_COROUTINES
 
   // Return list of strides/rowgroups that can be skipped (based on statistics).
   // Stride indices are monotonically increasing.

--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
@@ -15,10 +15,13 @@
  */
 
 #include "velox/dwio/dwrf/reader/FlatMapColumnReader.h"
-#include <folly/Conv.h>
-#include <folly/container/F14Set.h>
-#include <folly/json.h>
 
+#include "folly/Conv.h"
+#include "folly/container/F14Set.h"
+#include "folly/experimental/coro/BlockingWait.h"
+#include "folly/experimental/coro/Collect.h"
+#include "folly/experimental/coro/Invoke.h"
+#include "folly/json.h"
 #include "velox/common/base/BitUtil.h"
 #include "velox/dwio/common/ExecutorBarrier.h"
 #include "velox/dwio/common/FlatMapHelper.h"
@@ -690,6 +693,25 @@ void KeyNode<T>::loadAsChild(
   DWIO_ENSURE_EQ(numValues, vec->size(), "items loaded assurance");
 }
 
+#if FOLLY_HAS_COROUTINES
+
+template <typename T>
+folly::coro::Task<void> KeyNode<T>::co_loadAsChild(
+    VectorPtr& vec,
+    uint64_t numValues,
+    uint64_t nonNullMaps,
+    const uint64_t* nulls) {
+  co_await folly::coro::co_reschedule_on_current_executor;
+  DWIO_ENSURE_GT(numValues, 0, "numValues should be positive");
+  BufferPtr mergedNulls;
+  co_await reader_->co_next(
+      numValues, vec, mergeNulls(numValues, mergedNulls, nonNullMaps, nulls));
+  DWIO_ENSURE_EQ(numValues, vec->size(), "items loaded assurance");
+  co_return;
+}
+
+#endif // FOLLY_HAS_COROUTINES
+
 template <typename T>
 const uint64_t* KeyNode<T>::mergeNulls(
     uint64_t numValues,
@@ -965,6 +987,7 @@ folly::coro::Task<void> FlatMapStructEncodingColumnReader<T>::co_next(
     uint64_t numValues,
     VectorPtr& result,
     const uint64_t* incomingNulls) {
+  co_await folly::coro::co_reschedule_on_current_executor;
   auto rowVector = detail::resetIfWrongVectorType<RowVector>(result);
   std::vector<VectorPtr> children;
   if (rowVector) {
@@ -992,44 +1015,20 @@ folly::coro::Task<void> FlatMapStructEncodingColumnReader<T>::co_next(
     childrenPtr = &children;
   }
 
-  if (executor_) {
-    dwio::common::ExecutorBarrier barrier(*executor_);
-    auto mergedNullsBuffers = std::make_shared<
-        folly::Synchronized<std::unordered_map<std::thread::id, BufferPtr>>>();
-    for (size_t i = 0; i < keyNodes_.size(); ++i) {
-      auto& node = keyNodes_[i];
-      auto& child = (*childrenPtr)[i];
+  std::vector<folly::coro::Task<void>> tasks;
+  tasks.reserve(keyNodes_.size());
+  for (size_t i = 0; i < keyNodes_.size(); ++i) {
+    auto& node = keyNodes_[i];
+    auto& child = (*childrenPtr)[i];
 
-      if (node) {
-        barrier.add([&node,
-                     &child,
-                     numValues,
-                     nonNullMaps,
-                     nullsPtr,
-                     mergedNullsBuffers]() {
-          auto mergedNullsBuffer =
-              getBufferForCurrentThread(*mergedNullsBuffers);
-          node->loadAsChild(
-              child, numValues, mergedNullsBuffer, nonNullMaps, nullsPtr);
-        });
-      } else {
-        nullColumnReader_->next(numValues, child, nullsPtr);
-      }
-    }
-    barrier.waitAll();
-  } else {
-    for (size_t i = 0; i < keyNodes_.size(); ++i) {
-      auto& node = keyNodes_[i];
-      auto& child = (*childrenPtr)[i];
-
-      if (node) {
-        node->loadAsChild(
-            child, numValues, mergedNulls_, nonNullMaps, nullsPtr);
-      } else {
-        nullColumnReader_->next(numValues, child, nullsPtr);
-      }
+    if (node) {
+      tasks.push_back(
+          node->co_loadAsChild(child, numValues, nonNullMaps, nullsPtr));
+    } else {
+      tasks.push_back(nullColumnReader_->co_next(numValues, child, nullsPtr));
     }
   }
+  co_await folly::coro::collectAllRange(std::move(tasks));
 
   if (result) {
     result->setNullCount(nullCount);

--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.h
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.h
@@ -158,6 +158,17 @@ class FlatMapColumnReader : public ColumnReader {
       VectorPtr& result,
       const uint64_t* FOLLY_NULLABLE nulls) override;
 
+#if FOLLY_HAS_COROUTINES
+
+  folly::coro::Task<uint64_t> co_skip(uint64_t numValues) override;
+
+  folly::coro::Task<void> co_next(
+      uint64_t numValues,
+      VectorPtr& result,
+      const uint64_t* nulls = nullptr) override;
+
+#endif // FOLLY_HAS_COROUTINES
+
  private:
   const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
   std::vector<std::unique_ptr<KeyNode<T>>> keyNodes_;
@@ -187,6 +198,17 @@ class FlatMapStructEncodingColumnReader : public ColumnReader {
       uint64_t numValues,
       VectorPtr& result,
       const uint64_t* FOLLY_NULLABLE nulls) override;
+
+#if FOLLY_HAS_COROUTINES
+
+  folly::coro::Task<uint64_t> co_skip(uint64_t numValues) override;
+
+  folly::coro::Task<void> co_next(
+      uint64_t numValues,
+      VectorPtr& result,
+      const uint64_t* nulls = nullptr) override;
+
+#endif // FOLLY_HAS_COROUTINES
 
  private:
   const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;

--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.h
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.h
@@ -87,6 +87,16 @@ class KeyNode {
       uint64_t nonNullMaps,
       const uint64_t* FOLLY_NULLABLE nulls);
 
+#if FOLLY_HAS_COROUTINES
+
+  folly::coro::Task<void> co_loadAsChild(
+      VectorPtr& vec,
+      uint64_t numValues,
+      uint64_t nonNullMaps,
+      const uint64_t* FOLLY_NULLABLE nulls);
+
+#endif // FOLLY_HAS_COROUTINES
+
   const uint64_t* FOLLY_NULLABLE mergeNulls(
       uint64_t numValues,
       BufferPtr& mergedNulls,


### PR DESCRIPTION
Summary: Optimize the method for co_routines and forget about the executor

Differential Revision: D51482286


