### PR TITLE
Fix fuzzer option containerHasNulls meaning

### DIFF
--- a/velox/row/tests/CompactRowTest.cpp
+++ b/velox/row/tests/CompactRowTest.cpp
@@ -496,7 +496,6 @@ TEST_F(CompactRowTest, fuzz) {
   opts.vectorSize = 100;
   opts.containerLength = 5;
   opts.nullRatio = 0.1;
-  opts.containerHasNulls = true;
   opts.dictionaryHasNulls = false;
   opts.stringVariableLength = true;
   opts.stringLength = 20;

--- a/velox/row/tests/UnsafeRowFuzzTest.cpp
+++ b/velox/row/tests/UnsafeRowFuzzTest.cpp
@@ -48,7 +48,6 @@ class UnsafeRowFuzzTests : public ::testing::Test {
     VectorFuzzer::Options opts;
     opts.vectorSize = kNumBuffers;
     opts.nullRatio = 0.1;
-    opts.containerHasNulls = false;
     opts.dictionaryHasNulls = false;
     opts.stringVariableLength = true;
     opts.stringLength = 20;

--- a/velox/serializers/tests/CompactRowSerializerTest.cpp
+++ b/velox/serializers/tests/CompactRowSerializerTest.cpp
@@ -112,7 +112,6 @@ TEST_F(CompactRowSerializerTest, fuzz) {
   VectorFuzzer::Options opts;
   opts.vectorSize = 5;
   opts.nullRatio = 0.1;
-  opts.containerHasNulls = false;
   opts.dictionaryHasNulls = false;
   opts.stringVariableLength = true;
   opts.stringLength = 20;
@@ -129,7 +128,7 @@ TEST_F(CompactRowSerializerTest, fuzz) {
   SCOPED_TRACE(fmt::format("seed: {}", seed));
   VectorFuzzer fuzzer(opts, pool_.get(), seed);
 
-  auto data = fuzzer.fuzzRow(rowType);
+  auto data = fuzzer.fuzzInputRow(rowType);
   testRoundTrip(data);
 }
 

--- a/velox/serializers/tests/UnsafeRowSerializerTest.cpp
+++ b/velox/serializers/tests/UnsafeRowSerializerTest.cpp
@@ -302,7 +302,6 @@ TEST_F(UnsafeRowSerializerTest, types) {
   VectorFuzzer::Options opts;
   opts.vectorSize = 5;
   opts.nullRatio = 0.1;
-  opts.containerHasNulls = false;
   opts.dictionaryHasNulls = false;
   opts.stringVariableLength = true;
   opts.stringLength = 20;
@@ -319,7 +318,7 @@ TEST_F(UnsafeRowSerializerTest, types) {
   SCOPED_TRACE(fmt::format("seed: {}", seed));
   VectorFuzzer fuzzer(opts, pool_.get(), seed);
 
-  auto data = fuzzer.fuzzRow(rowType);
+  auto data = fuzzer.fuzzInputRow(rowType);
   testRoundTrip(data);
 }
 

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -87,11 +87,14 @@ class VectorFuzzer {
     /// double between 0 and 1).
     double nullRatio{0};
 
-    /// If true, fuzzer will generate top-level nulls for containers
-    /// (arrays/maps/rows), i.e, nulls for the containers themselves, not the
-    /// elements.
+    /// If false, fuzzer will not generate nulls for elements within containers
+    /// (arrays/maps/rows). It might still generate null for the container
+    /// itself.
     ///
-    /// The amount of nulls are controlled by `nullRatio`.
+    /// The amount of nulls (if true) is controlled by `nullRatio`.
+    ///
+    /// If you want to prevent the top-level row containers from being null, see
+    /// `fuzzInputRow()` instead.
     bool containerHasNulls{true};
 
     /// If true, fuzzer will generate top-level nulls for dictionaries.

--- a/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
+++ b/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
@@ -415,6 +415,100 @@ TEST_F(VectorFuzzerTest, row) {
       vector->type()->asRow().names(), ::testing::ElementsAre("c0", "c1"));
 }
 
+TEST_F(VectorFuzzerTest, containerHasNulls) {
+  auto countNulls = [](const VectorPtr& vec) {
+    if (!vec->nulls()) {
+      return 0;
+    }
+    return BaseVector::countNulls(vec->nulls(), vec->size());
+  };
+
+  VectorFuzzer::Options opts;
+  opts.vectorSize = 1000;
+  opts.nullRatio = 0.5;
+  opts.normalizeMapKeys = false;
+  opts.containerHasNulls = true;
+
+  {
+    VectorFuzzer fuzzer(opts, pool());
+
+    auto arrayVector = fuzzer.fuzz(ARRAY(BIGINT()));
+    auto mapVector = fuzzer.fuzz(MAP(BIGINT(), BIGINT()));
+    auto rowVector = fuzzer.fuzz(ROW({BIGINT(), BIGINT()}));
+
+    // Check that both top level and elements have nulls.
+    EXPECT_GT(countNulls(arrayVector), 0);
+    EXPECT_GT(countNulls(mapVector), 0);
+    EXPECT_GT(countNulls(rowVector), 0);
+
+    auto arrayElements = arrayVector->as<ArrayVector>()->elements();
+    auto mapKeys = mapVector->as<MapVector>()->mapKeys();
+    auto mapValues = mapVector->as<MapVector>()->mapValues();
+    auto rowCol0 = rowVector->as<RowVector>()->childAt(0);
+    auto rowCol1 = rowVector->as<RowVector>()->childAt(1);
+
+    EXPECT_GT(countNulls(arrayElements), 0);
+    EXPECT_GT(countNulls(mapKeys), 0);
+    EXPECT_GT(countNulls(mapValues), 0);
+    EXPECT_GT(countNulls(rowCol0), 0);
+    EXPECT_GT(countNulls(rowCol1), 0);
+  }
+
+  // Test with containerHasNulls false.
+  {
+    opts.containerHasNulls = false;
+    VectorFuzzer fuzzer(opts, pool());
+
+    auto arrayVector = fuzzer.fuzz(ARRAY(BIGINT()));
+    auto mapVector = fuzzer.fuzz(MAP(BIGINT(), BIGINT()));
+    auto rowVector = fuzzer.fuzz(ROW({BIGINT(), BIGINT()}));
+
+    // Check that both top level and elements have nulls.
+    EXPECT_GT(countNulls(arrayVector), 0);
+    EXPECT_GT(countNulls(mapVector), 0);
+    EXPECT_GT(countNulls(rowVector), 0);
+
+    auto arrayElements = arrayVector->as<ArrayVector>()->elements();
+    auto mapKeys = mapVector->as<MapVector>()->mapKeys();
+    auto mapValues = mapVector->as<MapVector>()->mapValues();
+    auto rowCol0 = rowVector->as<RowVector>()->childAt(0);
+    auto rowCol1 = rowVector->as<RowVector>()->childAt(1);
+
+    EXPECT_EQ(countNulls(arrayElements), 0);
+    EXPECT_EQ(countNulls(mapKeys), 0);
+    EXPECT_EQ(countNulls(mapValues), 0);
+    EXPECT_EQ(countNulls(rowCol0), 0);
+    EXPECT_EQ(countNulls(rowCol1), 0);
+  }
+
+  // Test with containerHasNulls false. Flat vector version.
+  {
+    opts.containerHasNulls = false;
+    VectorFuzzer fuzzer(opts, pool());
+
+    auto arrayVector = fuzzer.fuzzFlat(ARRAY(BIGINT()));
+    auto mapVector = fuzzer.fuzzFlat(MAP(BIGINT(), BIGINT()));
+    auto rowVector = fuzzer.fuzzFlat(ROW({BIGINT(), BIGINT()}));
+
+    // Check that both top level and elements have nulls.
+    EXPECT_GT(countNulls(arrayVector), 0);
+    EXPECT_GT(countNulls(mapVector), 0);
+    EXPECT_GT(countNulls(rowVector), 0);
+
+    auto arrayElements = arrayVector->as<ArrayVector>()->elements();
+    auto mapKeys = mapVector->as<MapVector>()->mapKeys();
+    auto mapValues = mapVector->as<MapVector>()->mapValues();
+    auto rowCol0 = rowVector->as<RowVector>()->childAt(0);
+    auto rowCol1 = rowVector->as<RowVector>()->childAt(1);
+
+    EXPECT_EQ(countNulls(arrayElements), 0);
+    EXPECT_EQ(countNulls(mapKeys), 0);
+    EXPECT_EQ(countNulls(mapValues), 0);
+    EXPECT_EQ(countNulls(rowCol0), 0);
+    EXPECT_EQ(countNulls(rowCol1), 0);
+  }
+}
+
 FlatVectorPtr<Timestamp> genTimestampVector(
     VectorFuzzer::Options::TimestampPrecision precision,
     size_t vectorSize,


### PR DESCRIPTION
Summary:
`containerHasNulls` used to control whether top-level container values can be
null, and the container elements themselves, as the name suggests. With this
change, I removed the reference to the flag to callsites where nullRatio is
already zero (and hence this is meaningless), check that other callsites are
covered and work well with the new meaning, and implemented the new semantic
described above. 
Added unit tests to ensure it works as expected.

Differential Revision: D51487492

Part of #7637 
