### PR TITLE
Fix parse of s3 uri with special characters like ' '

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
@@ -77,13 +77,46 @@ inline bool isS3File(const std::string_view filename) {
       isOssFile(filename) || isCosFile(filename) || isCosNFile(filename);
 }
 
+inline unsigned char FromHex(unsigned char x) {
+  unsigned char y;
+  if (x >= 'A' && x <= 'Z')
+    y = x - 'A' + 10;
+  else if (x >= 'a' && x <= 'z')
+    y = x - 'a' + 10;
+  else if (x >= '0' && x <= '9')
+    y = x - '0';
+  else
+    assert(0);
+  return y;
+}
+
+inline std::string UrlDecode(const std::string& str) {
+  std::string strTemp = "";
+  size_t length = str.length();
+  for (size_t i = 0; i < length; i++) {
+    if (str[i] == '+')
+      strTemp += ' ';
+    if (str[i] == ' ')
+      strTemp += '+';
+    else if (str[i] == '%') {
+      assert(i + 2 < length);
+      unsigned char high = FromHex((unsigned char)str[++i]);
+      unsigned char low = FromHex((unsigned char)str[++i]);
+      strTemp += high * 16 + low;
+    } else
+      strTemp += str[i];
+  }
+  return strTemp;
+}
+
 inline void getBucketAndKeyFromS3Path(
     const std::string& path,
     std::string& bucket,
     std::string& key) {
-  auto firstSep = path.find_first_of(kSep);
-  bucket = path.substr(0, firstSep);
-  key = path.substr(firstSep + 1);
+  const std::string decodedPath = UrlDecode(path);
+  auto firstSep = decodedPath.find_first_of(kSep);
+  bucket = decodedPath.substr(0, firstSep);
+  key = decodedPath.substr(firstSep + 1);
 }
 
 // TODO: Correctness check for bucket name.

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
@@ -108,3 +108,14 @@ TEST(S3UtilTest, bucketAndKeyFromS3Path) {
   EXPECT_EQ(bucket, "bucket");
   EXPECT_EQ(key, "file.txt");
 }
+
+TEST(S3UtilTest, bucketAndKeyFromS3PathWithDecode) {
+  std::string bucket, key;
+  auto path =
+      "dt=2023-06-02/audience_type=audience_type=NC_ENGAGEMENT ACTIVE_FOLLOWERS_90d_V2//file.txt";
+  getBucketAndKeyFromS3Path(path, bucket, key);
+  EXPECT_EQ(bucket, "dt=2023-06-02");
+  EXPECT_EQ(
+      key,
+      "audience_type=audience_type=NC_ENGAGEMENT+ACTIVE_FOLLOWERS_90d_V2//file.txt");
+}


### PR DESCRIPTION
In Spark, with the give path `audience_type=audience_type=NC_ENGAGEMENT+ACTIVE_FOLLOWERS_90d_V2//file.txt`, it will encode the `+` into ` ` and velox can't recognize it. The PR provides a fix correspondingly.