### PR TITLE
Allow custom result verifiers in AggregationFuzzer

### DIFF
--- a/velox/exec/tests/SparkAggregationFuzzerTest.cpp
+++ b/velox/exec/tests/SparkAggregationFuzzerTest.cpp
@@ -57,13 +57,16 @@ int main(int argc, char** argv) {
   // doesn't depend on the order of inputs. If such transformation exists, it
   // can be specified to be used for results verification. If no transformation
   // is specified, results are not verified.
-  std::unordered_map<std::string, std::string> customVerificationFunctions = {
-      {"last", ""},
-      {"last_ignore_null", ""},
-      {"first", ""},
-      {"first_ignore_null", ""},
-      {"max_by", ""},
-      {"min_by", ""}};
+  std::unordered_map<
+      std::string,
+      std::shared_ptr<facebook::velox::exec::test::ResultVerifier>>
+      customVerificationFunctions = {
+          {"last", nullptr},
+          {"last_ignore_null", nullptr},
+          {"first", nullptr},
+          {"first_ignore_null", nullptr},
+          {"max_by", nullptr},
+          {"min_by", nullptr}};
 
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
   auto duckQueryRunner =

--- a/velox/exec/tests/utils/AggregationFuzzerRunner.h
+++ b/velox/exec/tests/utils/AggregationFuzzerRunner.h
@@ -89,7 +89,8 @@ class AggregationFuzzerRunner {
     /// Keys are function names. Values are optional transformations. "{}"
     /// should be used to indicate the original value, i.e. "f({})"
     /// transformation applies function 'f' to aggregation result.
-    std::unordered_map<std::string, std::string> customVerificationFunctions;
+    std::unordered_map<std::string, std::shared_ptr<ResultVerifier>>
+        customVerificationFunctions;
 
     std::unordered_map<std::string, std::shared_ptr<InputGenerator>>
         customInputGenerators;


### PR DESCRIPTION
Introduce ResultVerifier interface to customize result comparison and
verification for individual aggregate functions. This can be used to (1) apply
custom transformation to results before comparing, e.g. canonicalize an array
for array_agg; (2) verify results of approx_xxx functions by comparing these
with "perfect" results.

Add TransformResultVerifier implementation to apply transformation to results
before comparing. Use it for array_agg, set_agg, set_union and other
functions.

Before this change it was already possible to apply custom transformations
before comparing results. This change generalizes this logic to allow for more
sophisticated custom verifiers. For example, verifier for approx_distinct will
compare results with results of count(distinct).

Follow-up PRs will introduce custom verifiers for approx_distinct and
approx_percentile.