### PR TITLE
Remove comment about DistinctAggregations limitation

### DIFF
--- a/velox/exec/DistinctAggregations.h
+++ b/velox/exec/DistinctAggregations.h
@@ -29,7 +29,6 @@ class DistinctAggregations {
   /// @param aggregates Non-empty list of
   /// aggregates that require inputs to be de-duplicated. All
   /// aggregates should have the same inputs.
-  /// Aggregates with multiple inputs are not supported.
   /// @param inputType Input row type for the aggregation operator.
   /// @param pool Memory pool.
   static std::unique_ptr<DistinctAggregations> create(


### PR DESCRIPTION
Aggregates with multiple inputs are supported since https://github.com/facebookincubator/velox/pull/6167