### PR TITLE
Add any_value alias for arbitrary aggregate.

### DIFF
--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -21,6 +21,10 @@ General Aggregate Functions
 
     Returns an arbitrary non-null value of ``x``, if one exists.
 
+.. function:: any_value(x) -> [same as x]
+
+    This is an alias for :func:`arbitrary(x)`.
+
 .. function:: array_agg(x) -> array<[same as x]>
 
     Returns an array created from the input ``x`` elements. Ignores null

--- a/velox/functions/prestosql/aggregates/AggregateNames.h
+++ b/velox/functions/prestosql/aggregates/AggregateNames.h
@@ -23,6 +23,7 @@ const char* const kApproxMostFrequent = "approx_most_frequent";
 const char* const kApproxPercentile = "approx_percentile";
 const char* const kApproxSet = "approx_set";
 const char* const kArbitrary = "arbitrary";
+const char* const kAnyValue = "any_value";
 const char* const kArrayAgg = "array_agg";
 const char* const kAvg = "avg";
 const char* const kBitwiseAnd = "bitwise_and_agg";

--- a/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
@@ -256,8 +256,7 @@ class NonNumericArbitrary : public exec::Aggregate {
 
 } // namespace
 
-exec::AggregateRegistrationResult registerArbitraryAggregate(
-    const std::string& prefix) {
+void registerArbitraryAggregate(const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -266,11 +265,11 @@ exec::AggregateRegistrationResult registerArbitraryAggregate(
           .argumentType("T")
           .build()};
 
-  auto name = prefix + kArbitrary;
-  return exec::registerAggregateFunction(
-      name,
+  std::vector<std::string> names = {prefix + kArbitrary, prefix + kAnyValue};
+  exec::registerAggregateFunction(
+      names,
       std::move(signatures),
-      [name](
+      [name = names.front()](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& /*resultType*/,

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -23,8 +23,7 @@ extern exec::AggregateRegistrationResult registerApproxMostFrequentAggregate(
 extern exec::AggregateRegistrationResult registerApproxPercentileAggregate(
     const std::string& prefix,
     bool withCompanionFunctions);
-extern exec::AggregateRegistrationResult registerArbitraryAggregate(
-    const std::string& prefix);
+void registerArbitraryAggregate(const std::string& prefix);
 extern exec::AggregateRegistrationResult registerArrayAggAggregate(
     const std::string& prefix,
     bool withCompanionFunctions);

--- a/velox/functions/prestosql/aggregates/tests/ArbitraryTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ArbitraryTest.cpp
@@ -43,10 +43,10 @@ TEST_F(ArbitraryTest, noNulls) {
   std::vector<std::string> aggregates = {
       "arbitrary(c1)",
       "arbitrary(c2)",
-      "arbitrary(c3)",
+      "any_value(c3)",
       "arbitrary(c4)",
       "arbitrary(c5)",
-      "arbitrary(c6)"};
+      "any_value(c6)"};
 
   // We do not test with TableScan because having two input splits makes the
   // result non-deterministic.


### PR DESCRIPTION
Summary:
Presto added `any_value` alias for arbitrary aggregate in
https://github.com/prestodb/presto/pull/21389

Differential Revision: D51521293


