### PR TITLE
Fix crashes in FlatVector::set and setNoCopy

### DIFF
--- a/velox/vector/FlatVector.cpp
+++ b/velox/vector/FlatVector.cpp
@@ -39,7 +39,9 @@ Range<bool> FlatVector<bool>::asRange() const {
 
 template <>
 void FlatVector<bool>::set(vector_size_t idx, bool value) {
-  VELOX_DCHECK(idx < BaseVector::length_);
+  VELOX_DCHECK_LT(idx, BaseVector::length_);
+  ensureValues();
+  VELOX_DCHECK(!values_->isView())
   if (BaseVector::rawNulls_) {
     BaseVector::setNull(idx, false);
   }
@@ -101,7 +103,9 @@ void FlatVector<StringView>::prepareForReuse() {
 
 template <>
 void FlatVector<StringView>::set(vector_size_t idx, StringView value) {
-  VELOX_DCHECK(idx < BaseVector::length_);
+  VELOX_DCHECK_LT(idx, BaseVector::length_);
+  ensureValues();
+  VELOX_DCHECK(!values_->isView())
   if (BaseVector::rawNulls_) {
     BaseVector::setNull(idx, false);
   }
@@ -124,12 +128,13 @@ template <>
 void FlatVector<StringView>::setNoCopy(
     const vector_size_t idx,
     const StringView& value) {
-  VELOX_DCHECK(idx < BaseVector::length_);
-  VELOX_DCHECK(!values_->isView());
-  rawValues_[idx] = value;
+  VELOX_DCHECK_LT(idx, BaseVector::length_);
+  ensureValues();
+  VELOX_DCHECK(!values_->isView())
   if (BaseVector::nulls_) {
     BaseVector::setNull(idx, false);
   }
+  rawValues_[idx] = value;
 }
 
 template <>

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -3408,5 +3408,116 @@ TEST_F(VectorTest, dictionaryLoadedVectorRemoveLazy) {
   }
 }
 
+template <typename T>
+FlatVectorPtr<T> makeFlatNullValues(
+    vector_size_t size,
+    const TypePtr& type,
+    BufferPtr nulls,
+    memory::MemoryPool* pool) {
+  return std::make_shared<FlatVector<T>>(
+      pool,
+      type,
+      nulls,
+      size,
+      nullptr, // values
+      std::vector<BufferPtr>{});
+}
+
+TEST_F(VectorTest, flatAllNulls) {
+  // Create FlatVector of all nulls with null values buffer.
+  vector_size_t size = 1'000;
+
+  VELOX_ASSERT_THROW(
+      makeFlatNullValues<int64_t>(
+          size, BIGINT(), allocateNulls(size, pool()), pool()),
+      "FlatVector with null values buffer must have all rows set to null")
+
+  auto nulls = allocateNulls(size, pool(), bits::kNull);
+
+  // BIGINT.
+  {
+    auto flat = makeFlatNullValues<int64_t>(size, BIGINT(), nulls, pool());
+
+    for (auto i = 0; i < size; ++i) {
+      ASSERT_TRUE(flat->isNullAt(i));
+    }
+
+    // Change some rows to non-null.
+    flat->set(7, 123LL);
+    ASSERT_FALSE(flat->isNullAt(7));
+    ASSERT_EQ(123LL, flat->valueAt(7));
+
+    for (auto i = 0; i < size; ++i) {
+      if (i != 7) {
+        ASSERT_TRUE(flat->isNullAt(i));
+      }
+    }
+  }
+
+  // BOOLEAN.
+  {
+    auto flat = makeFlatNullValues<bool>(size, BIGINT(), nulls, pool());
+
+    for (auto i = 0; i < size; ++i) {
+      ASSERT_TRUE(flat->isNullAt(i));
+    }
+
+    // Change some rows to non-null.
+    flat->set(7, true);
+    ASSERT_FALSE(flat->isNullAt(7));
+    ASSERT_EQ(true, flat->valueAt(7));
+
+    flat->set(11, false);
+    ASSERT_FALSE(flat->isNullAt(11));
+    ASSERT_EQ(false, flat->valueAt(11));
+
+    for (auto i = 0; i < size; ++i) {
+      if (i != 7 && i != 11) {
+        ASSERT_TRUE(flat->isNullAt(i));
+      }
+    }
+  }
+
+  // VARCHAR with set.
+  {
+    auto flat = makeFlatNullValues<StringView>(size, VARCHAR(), nulls, pool());
+
+    for (auto i = 0; i < size; ++i) {
+      ASSERT_TRUE(flat->isNullAt(i));
+    }
+
+    // Change some rows to non-null.
+    flat->set(7, "Testing is time consuming");
+    ASSERT_FALSE(flat->isNullAt(7));
+    ASSERT_EQ("Testing is time consuming", flat->valueAt(7).str());
+
+    for (auto i = 0; i < size; ++i) {
+      if (i != 7) {
+        ASSERT_TRUE(flat->isNullAt(i));
+      }
+    }
+  }
+
+  // VARCHAR with setNoCopy.
+  {
+    auto flat = makeFlatNullValues<StringView>(size, VARCHAR(), nulls, pool());
+
+    for (auto i = 0; i < size; ++i) {
+      ASSERT_TRUE(flat->isNullAt(i));
+    }
+
+    // Change some rows to non-null.
+    flat->setNoCopy(7, "Short");
+    ASSERT_FALSE(flat->isNullAt(7));
+    ASSERT_EQ("Short", flat->valueAt(7).str());
+
+    for (auto i = 0; i < size; ++i) {
+      if (i != 7) {
+        ASSERT_TRUE(flat->isNullAt(i));
+      }
+    }
+  }
+}
+
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:
`FlatVector<T>::set` and `FlatVector<StringView>::setNoCopy` used to crash if values
buffer is null.

Also, FlatVector constructor allowed to create vector with null values buffer
and non-null nulls buffer where not all rows were marked as null.

Differential Revision: D51527495


