### PR TITLE
Unify the spiller finish and unspill code path

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1038,9 +1038,10 @@ bool GroupingSet::getOutputWithSpill(
     }
 
     VELOX_CHECK_EQ(table_->rows()->numRows(), 0);
-    spiller_->finalizeSpill();
 
-    merge_ = spiller_->startMerge();
+    VELOX_CHECK_NULL(merge_);
+    auto spillPartition = spiller_->finishSpill();
+    merge_ = spillPartition.createOrderedReader();
   }
   VELOX_CHECK_EQ(spiller_->state().maxPartitions(), 1);
   if (merge_ == nullptr) {

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -211,7 +211,7 @@ void HashBuild::setupSpiller(SpillPartition* spillPartition) {
     LOG(INFO) << "Setup reader to read spilled input from "
               << spillPartition->toString()
               << ", memory pool: " << pool()->name();
-    spillInputReader_ = spillPartition->createReader();
+    spillInputReader_ = spillPartition->createUnorderedReader();
 
     const auto startBit = spillPartition->id().partitionBitOffset() +
         spillConfig.joinPartitionBits;

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -233,7 +233,7 @@ void HashProbe::maybeSetupSpillInput(
     VELOX_CHECK(iter != spillPartitionSet_.end());
     auto partition = std::move(iter->second);
     VELOX_CHECK_EQ(partition->id(), restoredPartitionId.value());
-    spillInputReader_ = partition->createReader();
+    spillInputReader_ = partition->createUnorderedReader();
     spillPartitionSet_.erase(iter);
   }
 

--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -133,12 +133,12 @@ void RowNumber::restoreNextSpillPartition() {
   }
 
   auto it = spillInputPartitionSet_.begin();
-  spillInputReader_ = it->second->createReader();
+  spillInputReader_ = it->second->createUnorderedReader();
 
   // Find matching partition for the hash table.
   auto hashTableIt = spillHashTablePartitionSet_.find(it->first);
   if (hashTableIt != spillHashTablePartitionSet_.end()) {
-    spillHashTableReader_ = hashTableIt->second->createReader();
+    spillHashTableReader_ = hashTableIt->second->createUnorderedReader();
 
     RowVectorPtr data;
     while (spillHashTableReader_->nextBatch(data)) {

--- a/velox/exec/SortBuffer.cpp
+++ b/velox/exec/SortBuffer.cpp
@@ -138,11 +138,9 @@ void SortBuffer::noMoreInput() {
 
     // Finish spill, and we shouldn't get any rows from non-spilled partition as
     // there is only one hash partition for SortBuffer.
-    spiller_->finalizeSpill();
-    VELOX_CHECK_LE(spiller_->stats().spilledPartitions, 1);
-
     VELOX_CHECK_NULL(spillMerger_);
-    spillMerger_ = spiller_->startMerge();
+    auto spillPartition = spiller_->finishSpill();
+    spillMerger_ = spillPartition.createOrderedReader();
   }
 }
 

--- a/velox/exec/SortWindowBuild.cpp
+++ b/velox/exec/SortWindowBuild.cpp
@@ -210,8 +210,13 @@ void SortWindowBuild::noMoreInput() {
     // spilled data.
     spill();
 
-    spiller_->finalizeSpill();
-    merge_ = spiller_->startMerge();
+    SpillPartitionSet spillPartitionSet;
+    spiller_->finishSpill(spillPartitionSet);
+    VELOX_CHECK_LE(spillPartitionSet.size(), 1);
+    VELOX_CHECK_NULL(merge_);
+    auto& spillPartition = spillPartitionSet.begin()->second;
+    VELOX_CHECK_NOT_NULL(spillPartition);
+    merge_ = spillPartition->createOrderedReader();
   } else {
     // At this point we have seen all the input rows. The operator is
     // being prepared to output rows now.

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -374,27 +374,6 @@ uint64_t SpillState::appendToPartition(
   return files_[partition]->write(rows, folly::Range<IndexRange*>(&range, 1));
 }
 
-std::unique_ptr<TreeOfLosers<SpillMergeStream>> SpillState::startMerge(
-    int32_t partition,
-    std::unique_ptr<SpillMergeStream>&& extra) {
-  VELOX_CHECK_LT(partition, files_.size());
-  std::vector<std::unique_ptr<SpillMergeStream>> result;
-  auto list = std::move(files_[partition]);
-  if (list != nullptr) {
-    for (auto& file : list->files()) {
-      result.push_back(FileSpillMergeStream::create(std::move(file)));
-    }
-  }
-  if (extra != nullptr) {
-    result.push_back(std::move(extra));
-  }
-  // Check if the partition is empty or not.
-  if (FOLLY_UNLIKELY(result.empty())) {
-    return nullptr;
-  }
-  return std::make_unique<TreeOfLosers<SpillMergeStream>>(std::move(result));
-}
-
 SpillFiles SpillState::files(int32_t partition) {
   VELOX_CHECK_LT(partition, files_.size());
 
@@ -470,7 +449,7 @@ std::string SpillPartition::toString() const {
 }
 
 std::unique_ptr<UnorderedStreamReader<BatchStream>>
-SpillPartition::createReader() {
+SpillPartition::createUnorderedReader() {
   std::vector<std::unique_ptr<BatchStream>> streams;
   streams.reserve(files_.size());
   for (auto& file : files_) {
@@ -479,6 +458,21 @@ SpillPartition::createReader() {
   files_.clear();
   return std::make_unique<UnorderedStreamReader<BatchStream>>(
       std::move(streams));
+}
+
+std::unique_ptr<TreeOfLosers<SpillMergeStream>>
+SpillPartition::createOrderedReader() {
+  std::vector<std::unique_ptr<SpillMergeStream>> streams;
+  streams.reserve(files_.size());
+  for (auto& file : files_) {
+    streams.push_back(FileSpillMergeStream::create(std::move(file)));
+  }
+  files_.clear();
+  // Check if the partition is empty or not.
+  if (FOLLY_UNLIKELY(streams.empty())) {
+    return nullptr;
+  }
+  return std::make_unique<TreeOfLosers<SpillMergeStream>>(std::move(streams));
 }
 
 uint32_t FileSpillMergeStream::id() const {

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -581,7 +581,11 @@ class SpillPartition {
 
   /// Invoked to create an unordered stream reader from this spill partition.
   /// The created reader will take the ownership of the spill files.
-  std::unique_ptr<UnorderedStreamReader<BatchStream>> createReader();
+  std::unique_ptr<UnorderedStreamReader<BatchStream>> createUnorderedReader();
+
+  /// Invoked to create an ordered stream reader from this spill partition.
+  /// The created reader will take the ownership of the spill files.
+  std::unique_ptr<TreeOfLosers<SpillMergeStream>> createOrderedReader();
 
   std::string toString() const;
 
@@ -672,13 +676,6 @@ class SpillState {
   /// returns an empty list if either the partition has not been spilled or has
   /// no spilled data.
   SpillFiles files(int32_t partition);
-
-  /// Starts reading values for 'partition'. If 'extra' is non-null, it can be
-  /// a stream of rows from a RowContainer so as to merge unspilled data with
-  /// spilled data.
-  std::unique_ptr<TreeOfLosers<SpillMergeStream>> startMerge(
-      int32_t partition,
-      std::unique_ptr<SpillMergeStream>&& extra);
 
   bool hasFiles(int32_t partition) const {
     return partition < files_.size() && files_[partition];

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -524,6 +524,14 @@ void Spiller::finishSpill(SpillPartitionSet& partitionSet) {
   }
 }
 
+SpillPartition Spiller::finishSpill() {
+  VELOX_CHECK_EQ(state_.maxPartitions(), 1);
+  VELOX_CHECK(state_.isPartitionSpilled(0));
+
+  finalizeSpill();
+  return SpillPartition(SpillPartitionId{bits_.begin(), 0}, state_.files(0));
+}
+
 void Spiller::finalizeSpill() {
   CHECK_NOT_FINALIZED();
   finalized_ = true;
@@ -533,30 +541,6 @@ void Spiller::finalizeSpill() {
       state_.finishWrite(partition);
     }
   }
-}
-
-std::unique_ptr<TreeOfLosers<SpillMergeStream>> Spiller::startMerge() {
-  CHECK_FINALIZED();
-
-  VELOX_CHECK_EQ(state_.maxPartitions(), 1);
-  // We expect the spilled data are sorted for sort merge read except
-  // 'kAggregateOutput' type which is used during the aggregation output
-  // processing. The latter only only has one merge stream with one row per each
-  // distinct aggregation group. Hence, we don't need to sort in that case.
-  if (type_ != Type::kAggregateOutput) {
-    VELOX_CHECK(
-        needSort(), "Can't sort merge the unsorted spill data: {}", toString());
-  }
-
-  auto merger = state_.startMerge(0, spillMergeStreamOverRows(0));
-  if (merger != nullptr && type_ == Type::kAggregateOutput) {
-    VELOX_CHECK_EQ(
-        merger->numStreams(),
-        1,
-        "{} spiller can only have one merge stream",
-        typeName(type_));
-  }
-  return merger;
 }
 
 void Spiller::fillSpillRuns(const RowContainerIterator* startRowIter) {

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -121,11 +121,6 @@ class Spiller {
   /// spill any data buffered in row container before call this.
   void spill(uint32_t partition, const RowVectorPtr& spillVector);
 
-  /// Invoked to finalize the spiller and flush any buffered spill to disk.
-  void finalizeSpill();
-
-  std::unique_ptr<TreeOfLosers<SpillMergeStream>> startMerge();
-
   /// Extracts up to 'maxRows' or 'maxBytes' from 'rows' into 'spillVector'. The
   /// extract starts at nextBatchIndex and updates nextBatchIndex to be the
   /// index of the first non-extracted element of 'rows'. Returns the byte size
@@ -137,9 +132,12 @@ class Spiller {
       RowVectorPtr& spillVector,
       size_t& nextBatchIndex);
 
-  /// Finishes spilling and accumulate the spilled partition data in
-  /// 'partitionSet' by spill partition id.
+  /// Finishes spilling and accumulate the spilled partition metadata in
+  /// 'partitionSet' indexed by spill partition id.
   void finishSpill(SpillPartitionSet& partitionSet);
+
+  /// Finishes spilling and expects single partition.
+  SpillPartition finishSpill();
 
   const SpillState& state() const {
     return state_;
@@ -218,6 +216,9 @@ class Spiller {
   // rows for the spill partition  'partition'. finishSpill()
   // first and 'partition' must specify a partition that has started spilling.
   std::unique_ptr<SpillMergeStream> spillMergeStreamOverRows(int32_t partition);
+
+  // Invoked to finalize the spiller and flush any buffered spill to disk.
+  void finalizeSpill();
 
   // Represents a run of rows from a spillable partition of
   // a RowContainer. Rows that hash to the same partition are accumulated here

--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -280,10 +280,10 @@ void TopNRowNumber::noMoreInput() {
     // spilled data.
     spill();
 
-    spiller_->finalizeSpill();
+    VELOX_CHECK_NULL(merge_);
+    auto spillPartition = spiller_->finishSpill();
+    merge_ = spillPartition.createOrderedReader();
     recordSpillStats(spiller_->stats());
-
-    merge_ = spiller_->startMerge();
   } else {
     outputRows_.resize(outputBatchSize_);
   }

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -330,8 +330,11 @@ class SpillTest : public ::testing::TestWithParam<common::CompressionKind>,
     ASSERT_EQ(prevGStats.spilledBytes + totalFileBytes, newGStats.spilledBytes);
 
     for (auto partition = 0; partition < state_->maxPartitions(); ++partition) {
+      auto spillFiles = state_->files(partition);
+      auto spillPartition =
+          SpillPartition(SpillPartitionId{0, partition}, std::move(spillFiles));
+      auto merge = spillPartition.createOrderedReader();
       int numReadBatches = 0;
-      auto merge = state_->startMerge(partition, nullptr);
       // We expect all the rows in dense increasing order.
       for (auto i = 0; i < numBatches * numRowsPerBatch; ++i) {
         auto stream = merge->next();
@@ -366,6 +369,7 @@ class SpillTest : public ::testing::TestWithParam<common::CompressionKind>,
       // We do two append writes per each input batch.
       ASSERT_EQ(numBatches, numReadBatches);
     }
+
     const auto finalStats = stats_.copy();
     ASSERT_EQ(
         finalStats.toString(),
@@ -458,7 +462,10 @@ TEST_P(SpillTest, spillTimestamp) {
   state.finishWrite(partitionIndex);
   EXPECT_TRUE(state.hasFiles(partitionIndex));
 
-  auto merge = state.startMerge(partitionIndex, nullptr);
+  SpillPartition spillPartition(SpillPartitionId{0, 0}, state.files(0));
+  auto merge = spillPartition.createOrderedReader();
+  ASSERT_TRUE(merge != nullptr);
+  ASSERT_TRUE(spillPartition.createOrderedReader() == nullptr);
   for (auto i = 0; i < timeValues.size(); ++i) {
     auto stream = merge->next();
     ASSERT_NE(nullptr, stream);
@@ -560,7 +567,7 @@ TEST_P(SpillTest, spillPartitionSet) {
           fmt::format(
               "SPILLED PARTITION[ID:{} FILES:0 SIZE:0B]", id.toString()));
       // Expect an empty reader.
-      auto reader = spillPartitions.back()->createReader();
+      auto reader = spillPartitions.back()->createUnorderedReader();
       ASSERT_FALSE(reader->nextBatch(output));
     }
 
@@ -632,7 +639,7 @@ TEST_P(SpillTest, spillPartitionSet) {
               i,
               expectedPartitionFiles[i],
               succinctBytes(expectedPartitionSizes[i])));
-      auto reader = spillPartitions[i]->createReader();
+      auto reader = spillPartitions[i]->createUnorderedReader();
       for (int j = 0; j < numBatchesPerPartition; ++j) {
         ASSERT_TRUE(reader->nextBatch(output));
         for (int row = 0; row < numRowsPerBatch; ++row) {
@@ -646,7 +653,7 @@ TEST_P(SpillTest, spillPartitionSet) {
     // Check spill partition state after creating the reader.
     ASSERT_EQ(0, spillPartitions[i]->numFiles());
     {
-      auto reader = spillPartitions[i]->createReader();
+      auto reader = spillPartitions[i]->createUnorderedReader();
       ASSERT_FALSE(reader->nextBatch(output));
     }
   }
@@ -692,7 +699,7 @@ TEST_P(SpillTest, spillPartitionSpilt) {
     // Read verification.
     int batchIdx = 0;
     for (int32_t i = 0; i < numShards; ++i) {
-      auto reader = spillPartitionShards[i]->createReader();
+      auto reader = spillPartitionShards[i]->createUnorderedReader();
       RowVectorPtr output;
       while (reader->nextBatch(output)) {
         for (int row = 0; row < numRowsPerBatch; ++row) {


### PR DESCRIPTION
Currently ordered spill and unordered spill has different way to finish spilling
(or finalize the spiller) and then use different ways to create the unspill path.
For ordered spill, it creates the sort merger as part of spiller finish code path.
For unordered spill, it creates the unordered reader from the spilled partition object.
This makes the code complicated in spiller and how user use it.

This PR unifies the two code paths by always returning a spilled partition object on
finish and create either ordered or unordered readers from it per user request.