### PR TITLE
Allow UNKNOWN key type in map_keys and map_values

### DIFF
--- a/velox/functions/prestosql/MapKeysAndValues.cpp
+++ b/velox/functions/prestosql/MapKeysAndValues.cpp
@@ -89,7 +89,7 @@ class MapKeysFunction : public MapKeyValueFunction {
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
     // map(K,V) -> array(K)
     return {exec::FunctionSignatureBuilder()
-                .knownTypeVariable("K")
+                .typeVariable("K")
                 .typeVariable("V")
                 .returnType("array(K)")
                 .argumentType("map(K,V)")
@@ -126,7 +126,7 @@ class MapValuesFunction : public MapKeyValueFunction {
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
     // map(K,V) -> array(V)
     return {exec::FunctionSignatureBuilder()
-                .knownTypeVariable("K")
+                .typeVariable("K")
                 .typeVariable("V")
                 .returnType("array(V)")
                 .argumentType("map(K,V)")

--- a/velox/functions/prestosql/tests/MapKeysAndValuesTest.cpp
+++ b/velox/functions/prestosql/tests/MapKeysAndValuesTest.cpp
@@ -247,6 +247,17 @@ TEST_F(MapKeysTest, constant) {
   test::assertEqualVectors(expected, result);
 }
 
+TEST_F(MapKeysTest, unknown) {
+  auto keys = makeFlatVector<UnknownValue>({}, UNKNOWN());
+  auto values = makeFlatVector<UnknownValue>({}, UNKNOWN());
+  auto map = makeMapVector({0, 0, 0}, keys, values);
+
+  auto result = evaluate("map_keys(c0)", makeRowVector({map}));
+  auto expected = makeArrayVector({0, 0, 0}, keys);
+
+  test::assertEqualVectors(expected, result);
+}
+
 TEST_F(MapValuesTest, noNulls) {
   auto sizeAt = [](vector_size_t row) { return row % 7; };
   testMapValues(sizeAt, nullptr);
@@ -330,5 +341,16 @@ TEST_F(MapValuesTest, noDictionaryReceived) {
       "map_keys(subscript(array_constructor(c0),1))",
       makeRowVector({constantMap}));
   auto expected = makeArrayVector<int64_t>({{100, 200}, {100, 200}});
+  test::assertEqualVectors(expected, result);
+}
+
+TEST_F(MapValuesTest, unknown) {
+  auto keys = makeFlatVector<UnknownValue>({}, UNKNOWN());
+  auto values = makeFlatVector<UnknownValue>({}, UNKNOWN());
+  auto map = makeMapVector({0, 0, 0}, keys, values);
+
+  auto result = evaluate("map_values(c0)", makeRowVector({map}));
+  auto expected = makeArrayVector({0, 0, 0}, values);
+
   test::assertEqualVectors(expected, result);
 }


### PR DESCRIPTION
Summary: This diff fixes https://github.com/facebookincubator/velox/issues/7489.

Differential Revision: D51534119


