### PR TITLE
Fix null handling in Presto comparison operations

### DIFF
--- a/velox/common/base/CompareFlags.h
+++ b/velox/common/base/CompareFlags.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include <fmt/core.h>
+#include <optional>
 #include <sstream>
 #include <string>
 
@@ -21,19 +22,10 @@
 
 namespace facebook::velox {
 
+constexpr auto kIndeterminate = std::nullopt;
+
 // Describes value collation in comparison.
 struct CompareFlags {
-  enum class NullHandlingMode {
-    // This is the default null handling mode, in this mode nulls are treated as
-    // values such that:
-    //  - null == null is true,
-    //  - null == value is false.
-    //  - when equalsOnly=false null ordering is determined using the nullsFirst
-    // flag.
-    kNullAsValue,
-    kStopAtNull
-  };
-
   bool nullsFirst = true;
 
   bool ascending = true;
@@ -41,11 +33,118 @@ struct CompareFlags {
   // When true, comparison should return non-0 early when sizes mismatch.
   bool equalsOnly = false;
 
-  NullHandlingMode nullHandlingMode = NullHandlingMode::kNullAsValue;
+  enum class NullHandlingMode {
+    /*
+     This is the default null handling mode, in this mode nulls are treated as
+     values such that:
+        - null == null is true,
+        - null == value is false.
+        - when equalsOnly=false null ordering is determined using the nullsFirst
+         flag.
+       */
+    kNullAsValue,
+    /*
+     This mode implements presto semantics for handling nulls. It matches the
+     behavior of ==, >, < functions and many other presto functions such as
+     array_remove and array_contains.
 
-  bool mayStopAtNull() const {
-    return nullHandlingMode == CompareFlags::NullHandlingMode::kStopAtNull;
-  }
+     Under this mode, result of comparison can be indeterminate; indeterminate
+     result is represented as std::nullopt, and means that the function can not
+     decide on the result of the comparison due to some existing nulls. But not
+     every null results in indeterminate result.
+
+     ## When equalsOnly=true:
+     The compare can return kIndeterminate, or a value according to the
+     following:
+        1. Primitive types and top level nulls:
+          - Comparing null with anything else is indeterminate, otherwise a
+            value result is returned.
+
+          - Comapring top level nulls in complex types is indeterminate.
+
+        2. Arrays:
+          - If the compared array sizes are different then result is false,
+            ex:[null] == [null, null] is false.
+
+           - If any two elements compare result is false, result is false
+             ex: [null, 1] = [null, 2] is false.
+
+           - If result is not false and any two elements compared result is
+             indeterminate, then result is indeterminate.
+             ex: [null, 1] = [null, 1] is indeterminate.
+
+           - If if elements comapre results are true, then result is true.
+             ex: [1, 1] = [1, 1] is true.
+
+        3. Rows: Follows the same logic as array, with fields being elements.
+          - If any two fields compare result is false, result is false
+            ex: (null, 1) = (null, 2) is false.
+
+          - If result is not false and any two fields compare result is
+            indeterminate, then the result is indeterminate.
+            ex: (null, 1) = (null, 1) is indeterminate.
+
+            - If all fields comapre results are true, then result is true.
+            ex: (1, 1) = (1, 1) is indeterminate.
+
+        4. Maps:
+          - Keys are compared first, if keys are not equal values are not
+            checked even if they have nulls and result is false.
+
+         - If keys are the same for all maps, values are compared by applying
+           the array compare logic explained above observing each map as an
+           array of values.
+           ex: {1:null, 2:2} = {1:null, 2:3} is false.
+           ex: {1:null, 2:2} = {1:null, 2:2} is indeterminate.
+           ex: {1:1, 2:2} = {1:1, 2:2} is true.
+
+     ## When equalsOnly=false:
+      The compare either returns a value or throws a user error if a null is
+      encountered before result is determined, as explained below:
+
+        1. Primitive types and top level nulls:
+          - Comparing null with anything else throws (note that functions like
+            >, < do not pass nulls to compare since they are default nulls
+            functions).
+
+          - Comparing top level nulls also throws.
+
+        2. Arrays:
+          - Only elements up to index min(rhs.size(), lhs.size()) are compared.
+
+          - Elements are compared in order starting from index 0.
+
+          - If all elements in the range above are the same, then sizes are
+            compared.
+            ex: [1, null] > [1] -> result is true, and null is not read.
+
+          - If any two elements are different but not null, then result is
+            determined and remaining uncompared elements are ignored.
+            ex: [1, null] > [2, null] -> result is false and nulls are not
+            compared.
+
+          - If a null element is encountered before result is determined then
+            the compare throws a user exception.
+            ex: [1, null, null] > [1, 2]-> throws.
+
+        3. Rows:
+          - Fields are compared in order starting from index 0.
+
+          - If any two fields are different but not null, then result is
+            determined and remaining uncompared elements are ignored.
+            ex: (1, null) > (2, null) -> result is false and nulls not compared.
+
+          - If a null element is encountered before result is determined then
+            the compare throws a user exception.
+            ex: (1, null) > (1, 2) -> throws.
+
+        4. Maps:
+          - This mode does not allow ordering maps.
+    */
+    kNullAsIndeterminate
+  };
+
+  NullHandlingMode nullHandlingMode = NullHandlingMode::kNullAsValue;
 
   bool nullAsValue() const {
     return nullHandlingMode == CompareFlags::NullHandlingMode::kNullAsValue;
@@ -62,8 +161,8 @@ struct CompareFlags {
     switch (mode) {
       case CompareFlags::NullHandlingMode::kNullAsValue:
         return "NullAsValue";
-      case CompareFlags::NullHandlingMode::kStopAtNull:
-        return "StopAtNull";
+      case CompareFlags::NullHandlingMode::kNullAsIndeterminate:
+        return "NullAsIndeterminate";
       default:
         return fmt::format(
             "Unknown Null Handling mode {}", static_cast<int>(mode));

--- a/velox/docs/functions/presto/array.rst
+++ b/velox/docs/functions/presto/array.rst
@@ -157,7 +157,7 @@ Array Functions
         SELECT array_sort(ARRAY [NULL, 1, NULL]); -- [1, NULL, NULL]
         SELECT array_sort(ARRAY [NULL, 2, 1]); -- [1, 2, NULL]
         SELECT array_sort(ARRAY [ARRAY [1, 2], ARRAY [2, null]]); -- [[1, 2], [2, null]]
-        SELECT array_sort(ARRAY [ARRAY [1, 2], ARRAY [1, null]]); -- failed: array_sort contains nested nulls not supported for comparison
+        SELECT array_sort(ARRAY [ARRAY [1, 2], ARRAY [1, null]]); -- failed: Ordering nulls is not supported
 
 .. function:: array_sort(array(T), function(T,U)) -> array(T)
 
@@ -182,7 +182,7 @@ Array Functions
         SELECT array_sort_desc(ARRAY [NULL, 1, NULL]); -- [1, NULL, NULL]
         SELECT array_sort_desc(ARRAY [NULL, 2, 1]); -- [2, 1, NULL]
         SELECT array_sort(ARRAY [ARRAY [1, 2], ARRAY [2, null]]); -- [[1, 2], [2, null]]
-        SELECT array_sort(ARRAY [ARRAY [1, 2], ARRAY [1, null]]); -- failed: array_sort contains nested nulls not supported for comparison
+        SELECT array_sort(ARRAY [ARRAY [1, 2], ARRAY [1, null]]); -- failed: Ordering nulls is not supported
 
 .. function:: array_sort_desc(array(T), function(T,U)) -> array(T)
 

--- a/velox/expression/tests/GenericViewTest.cpp
+++ b/velox/expression/tests/GenericViewTest.cpp
@@ -131,21 +131,37 @@ TEST_F(GenericViewTest, primitive) {
 }
 
 TEST_F(GenericViewTest, compare) {
-  std::vector<std::optional<int64_t>> data = {1, 2, std::nullopt, 1};
+  {
+    auto vector = makeNullableFlatVector<int64_t>({1, 2, std::nullopt, 1});
+    DecodedVector decoded;
+    exec::VectorReader<Any> reader(decode(decoded, *vector));
 
-  auto vector = vectorMaker_.flatVectorNullable<int64_t>(data);
-  DecodedVector decoded;
-  exec::VectorReader<Any> reader(decode(decoded, *vector));
-  CompareFlags flags;
-  ASSERT_EQ(reader[0].compare(reader[0], flags).value(), 0);
-  ASSERT_EQ(reader[0].compare(reader[3], flags).value(), 0);
+    CompareFlags flags;
+    ASSERT_EQ(reader[0].compare(reader[0], flags).value(), 0);
+    ASSERT_EQ(reader[0].compare(reader[3], flags).value(), 0);
 
-  ASSERT_NE(reader[0].compare(reader[1], flags).value(), 0);
-  ASSERT_NE(reader[0].compare(reader[2], flags).value(), 0);
+    ASSERT_NE(reader[0].compare(reader[1], flags).value(), 0);
+    ASSERT_NE(reader[0].compare(reader[2], flags).value(), 0);
 
-  flags.nullHandlingMode = CompareFlags::NullHandlingMode::kStopAtNull;
-  ASSERT_FALSE(reader[0].compare(reader[2], flags).has_value());
-  ASSERT_TRUE(reader[0].compare(reader[1], flags).has_value());
+    flags.nullHandlingMode =
+        CompareFlags::NullHandlingMode::kNullAsIndeterminate;
+    VELOX_ASSERT_THROW(
+        reader[0].compare(reader[2], flags), "Ordering nulls is not supported");
+    ASSERT_TRUE(reader[0].compare(reader[1], flags).has_value());
+  }
+
+  // Test that [null, 1] = [null, 2] is false, and that
+  // [null, 1] = [null, 1] is indeterminate.
+  {
+    CompareFlags flags = CompareFlags::equality(
+        CompareFlags::NullHandlingMode::kNullAsIndeterminate);
+    auto arrayVector =
+        makeArrayVectorFromJson<int64_t>({"[null, 1]", "[null, 2]"});
+    DecodedVector decoded;
+    exec::VectorReader<Any> reader(decode(decoded, *arrayVector));
+    ASSERT_EQ(reader[0].compare(reader[1], flags).value(), -1);
+    ASSERT_EQ(reader[0].compare(reader[0], flags), kIndeterminate);
+  }
 }
 
 // Test reader<Generic> where generic elements are arrays<ints>

--- a/velox/functions/prestosql/ArrayContains.cpp
+++ b/velox/functions/prestosql/ArrayContains.cpp
@@ -112,7 +112,7 @@ void applyComplexType(
             searchBase,
             elementIndices[offset + i],
             searchIndex,
-            CompareFlags::NullHandlingMode::kStopAtNull);
+            CompareFlags::NullHandlingMode::kNullAsIndeterminate);
         VELOX_USER_CHECK(
             result.has_value(),
             "contains does not support arrays with elements that contain null");

--- a/velox/functions/prestosql/ArrayFunctions.h
+++ b/velox/functions/prestosql/ArrayFunctions.h
@@ -841,8 +841,8 @@ struct ArrayRemoveFunction {
       out_type<Array<Generic<T1>>>& out,
       const arg_type<Array<Generic<T1>>>& array,
       const arg_type<Generic<T1>>& element) {
-    static constexpr CompareFlags kFlags =
-        CompareFlags::equality(CompareFlags::NullHandlingMode::kStopAtNull);
+    static constexpr CompareFlags kFlags = CompareFlags::equality(
+        CompareFlags::NullHandlingMode::kNullAsIndeterminate);
     std::vector<std::optional<exec::GenericView>> toCopyItems;
     for (const auto& item : array) {
       if (item.has_value()) {

--- a/velox/functions/prestosql/ArraySort.cpp
+++ b/velox/functions/prestosql/ArraySort.cpp
@@ -45,7 +45,8 @@ BufferPtr sortElements(
 
   CompareFlags flags{.nullsFirst = false, .ascending = ascending};
   if (throwOnNestedNull) {
-    flags.nullHandlingMode = CompareFlags::NullHandlingMode::kStopAtNull;
+    flags.nullHandlingMode =
+        CompareFlags::NullHandlingMode::kNullAsIndeterminate;
   }
 
   auto decodedIndices = decodedElements->indices();
@@ -77,8 +78,7 @@ BufferPtr sortElements(
               baseElementsVector, decodedIndices[a], decodedIndices[b], flags);
 
           if (!result.has_value()) {
-            VELOX_USER_FAIL(
-                "array_sort contains nested nulls not supported for comparison");
+            VELOX_USER_FAIL("Ordering nulls is not supported");
           }
 
           return result.value() < 0;

--- a/velox/functions/prestosql/Comparisons.h
+++ b/velox/functions/prestosql/Comparisons.h
@@ -126,8 +126,8 @@ struct EqFunction : public TimestampWithTimezoneComparisonSupport<T> {
       bool& out,
       const arg_type<Generic<T1>>& lhs,
       const arg_type<Generic<T1>>& rhs) {
-    static constexpr CompareFlags kFlags =
-        CompareFlags::equality(CompareFlags::NullHandlingMode::kStopAtNull);
+    static constexpr CompareFlags kFlags = CompareFlags::equality(
+        CompareFlags::NullHandlingMode::kNullAsIndeterminate);
 
     auto result = lhs.compare(rhs, kFlags);
     if (!result.has_value()) {

--- a/velox/functions/prestosql/aggregates/Compare.cpp
+++ b/velox/functions/prestosql/aggregates/Compare.cpp
@@ -28,7 +28,7 @@ int32_t compare(
       true, // nullsFirst
       true, // ascending
       false, // equalsOnly
-      CompareFlags::NullHandlingMode::kStopAtNull};
+      CompareFlags::NullHandlingMode::kNullAsIndeterminate};
 
   auto result = accumulator->compare(decoded, index, kCompareFlags);
   VELOX_USER_CHECK(

--- a/velox/functions/prestosql/tests/ArrayRemoveTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayRemoveTest.cpp
@@ -125,6 +125,21 @@ TEST_F(ArrayRemoveTest, arrayWithComplexTypes) {
       "array_remove(c0, c1)",
       {arrayOfArrays, elementVector},
       "array_remove does not support arrays with elements that are null or contain null");
+
+  // Test array_remove([[null ,1]], [null, 2]).
+  // This does not throw because [null ,1] = [null, 2] is false.
+  {
+    std::string nestedArray =
+        "array_constructor(array_constructor(null::bigint, 1))";
+    auto result = evaluate(
+        fmt::format(
+            "array_remove({}, array_constructor(null::bigint, 2))",
+            nestedArray),
+        makeRowVector({makeFlatVector<int32_t>(1)}));
+    auto expected =
+        evaluate(nestedArray, makeRowVector({makeFlatVector<int32_t>(1)}));
+    assertEqualVectors(result, expected);
+  }
 }
 
 ////  Remove null from array.

--- a/velox/functions/prestosql/tests/ArraySortTest.cpp
+++ b/velox/functions/prestosql/tests/ArraySortTest.cpp
@@ -589,8 +589,7 @@ TEST_F(ArraySortTest, failOnArrayNullCompare) {
       "[5, null]",
       "null",
   });
-  static const std::string kErrorMessage =
-      "array_sort contains nested nulls not supported for comparison";
+  static const std::string kErrorMessage = "Ordering nulls is not supported";
 
   // [2, null] vs [4, 4], [5, null] vs null no throw.
   const auto noNullCompareBatch = makeRowVector({
@@ -639,8 +638,7 @@ TEST_F(ArraySortTest, failOnRowNullCompare) {
           {1, 1, 2, std::nullopt, 4, std::nullopt, 0}),
   });
   baseVector->setNull(6, true);
-  static const std::string kErrorMessage =
-      "array_sort contains nested nulls not supported for comparison";
+  static const std::string kErrorMessage = "Ordering nulls is not supported";
 
   // (2, null) vs (4, 4), (5, null) vs null no throw.
   const auto noNullCompareBatch = makeRowVector({

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -808,21 +808,21 @@ class BaseVector {
   compareNulls(bool thisNull, bool otherNull, CompareFlags flags) {
     DCHECK(thisNull || otherNull);
     switch (flags.nullHandlingMode) {
-      case CompareFlags::NullHandlingMode::kStopAtNull:
-        return std::nullopt;
+      case CompareFlags::NullHandlingMode::kNullAsIndeterminate:
+        if (flags.equalsOnly) {
+          return kIndeterminate;
+        } else {
+          VELOX_USER_FAIL("Ordering nulls is not supported");
+        }
       case CompareFlags::NullHandlingMode::kNullAsValue:
-      default:
-        break;
-    }
+        if (thisNull && otherNull) {
+          return 0;
+        }
 
-    if (thisNull) {
-      if (otherNull) {
-        return 0;
-      }
-      return flags.nullsFirst ? -1 : 1;
-    }
-    if (otherNull) {
-      return flags.nullsFirst ? 1 : -1;
+        if (flags.nullsFirst) {
+          return thisNull ? -1 : 1;
+        }
+        return thisNull ? 1 : -1;
     }
 
     VELOX_UNREACHABLE(

--- a/velox/vector/tests/VectorCompareTest.cpp
+++ b/velox/vector/tests/VectorCompareTest.cpp
@@ -18,10 +18,15 @@
 #include <gtest/gtest.h>
 #include <optional>
 
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 namespace facebook::velox {
+
+static constexpr int32_t kNeq = 1;
+static constexpr int32_t kEq = 0;
+
 class VectorCompareTest : public testing::Test,
                           public velox::test::VectorTestBase {
  public:
@@ -33,195 +38,369 @@ class VectorCompareTest : public testing::Test,
   bool static constexpr kExpectNotNull = false;
   bool static constexpr kEqualsOnly = true;
 
-  void testCompareWithStopAtNull(
+  CompareFlags kEquality = CompareFlags::equality(
+      CompareFlags::NullHandlingMode::kNullAsIndeterminate);
+
+  CompareFlags kOrderingAsc = {
+      .ascending = true,
+      .nullHandlingMode = CompareFlags::NullHandlingMode::kNullAsIndeterminate};
+  CompareFlags kOrderingDesc = {
+      .ascending = false,
+      .nullHandlingMode = CompareFlags::NullHandlingMode::kNullAsIndeterminate};
+  void testCompare(
       const VectorPtr& vector,
       vector_size_t index1,
       vector_size_t index2,
-      bool expectNull,
-      bool equalsOnly = false) {
-    CompareFlags testFlags;
-    testFlags.nullHandlingMode = CompareFlags::NullHandlingMode::kStopAtNull;
-    testFlags.equalsOnly = equalsOnly;
+      CompareFlags testFlags,
+      std::optional<int32_t> expectedResult) {
+    testCompare(vector, index1, vector, index2, testFlags, expectedResult);
+  }
 
-    ASSERT_EQ(
-        expectNull,
-        !vector->compare(vector.get(), index1, index2, testFlags).has_value());
+  void testCompare(
+      const VectorPtr& vector1,
+      vector_size_t index1,
+      const VectorPtr& vector2,
+      vector_size_t index2,
+      CompareFlags testFlags,
+      std::optional<int32_t> expectedResult) {
+    if (testFlags.equalsOnly && expectedResult.has_value() &&
+        expectedResult.value() != kEq) {
+      // If we are checking for non-equality we just check that output is 0.
+      ASSERT_NE(
+          0,
+          vector1->compare(vector2.get(), index1, index2, testFlags).value());
 
-    ASSERT_TRUE(vector->compare(vector.get(), index1, index2, CompareFlags())
-                    .has_value());
+      // Test that NullAsIndeterminate results matche NullAsValue results when
+      // results are determined.
+      testFlags.nullHandlingMode = CompareFlags::NullHandlingMode::kNullAsValue;
+      ASSERT_NE(
+          0,
+          vector1->compare(vector2.get(), index1, index2, testFlags).value());
+    } else {
+      ASSERT_EQ(
+          expectedResult,
+          vector1->compare(vector2.get(), index1, index2, testFlags));
+
+      // Test that NullAsIndeterminate results matche NullAsValue results when
+      // results are determined.
+      if (expectedResult.has_value()) {
+        testFlags.nullHandlingMode =
+            CompareFlags::NullHandlingMode::kNullAsValue;
+
+        ASSERT_EQ(
+            expectedResult,
+            vector1->compare(vector2.get(), index1, index2, testFlags));
+      }
+    }
+  }
+
+  void testOrderingThrow(
+      const VectorPtr& vector,
+      vector_size_t index1,
+      vector_size_t index2) {
+    testOrderingThrow(vector, index1, vector, index2);
+    testOrderingThrow(vector, index2, vector, index1);
+  }
+
+  void testOrderingThrow(
+      const VectorPtr& vector1,
+      vector_size_t index1,
+      const VectorPtr& vector2,
+      vector_size_t index2) {
+    VELOX_ASSERT_THROW(
+        testCompare(
+            vector1, index1, vector2, index2, kOrderingDesc, kIndeterminate),
+        "Ordering nulls is not supported");
+    VELOX_ASSERT_THROW(
+        testCompare(
+            vector1, index1, vector2, index2, kOrderingAsc, kIndeterminate),
+        "Ordering nulls is not supported");
   }
 };
 
-TEST_F(VectorCompareTest, compareStopAtNullFlat) {
-  auto flatVector = vectorMaker_.flatVectorNullable<int32_t>({1, std::nullopt});
+TEST_F(VectorCompareTest, compareNullAsIndeterminateFlat) {
+  auto flatVector =
+      vectorMaker_.flatVectorNullable<int32_t>({1, std::nullopt, 3});
 
-  testCompareWithStopAtNull(flatVector, 0, 0, kExpectNotNull);
-  testCompareWithStopAtNull(flatVector, 0, 1, kExpectNull);
-  testCompareWithStopAtNull(flatVector, 1, 0, kExpectNull);
-  testCompareWithStopAtNull(flatVector, 1, 1, kExpectNull);
+  // Test equality.
+  {
+    testCompare(flatVector, 0, 0, kEquality, kEq);
+    testCompare(flatVector, 0, 2, kEquality, kNeq);
+    testCompare(flatVector, 0, 1, kEquality, kIndeterminate);
+    testCompare(flatVector, 1, 0, kEquality, kIndeterminate);
+    testCompare(flatVector, 1, 1, kEquality, kIndeterminate);
+  }
+
+  // Test ordering with nulls.
+  {
+    testOrderingThrow(flatVector, 0, 1);
+    testOrderingThrow(flatVector, 1, 0);
+    testOrderingThrow(flatVector, 1, 1);
+  }
+
+  // Test ordering.
+  {
+    testCompare(flatVector, 0, 0, kOrderingDesc, 0);
+    testCompare(flatVector, 0, 2, kOrderingDesc, 1);
+    testCompare(flatVector, 2, 0, kOrderingDesc, -1);
+
+    testCompare(flatVector, 0, 0, kOrderingAsc, 0);
+    testCompare(flatVector, 0, 2, kOrderingAsc, -1);
+    testCompare(flatVector, 2, 0, kOrderingAsc, 1);
+  }
 }
 
 // Test SimpleVector<ComplexType>::compare()
-TEST_F(VectorCompareTest, compareStopAtNullSimpleComplex) {
-  CompareFlags testFlags;
-  testFlags.nullHandlingMode = CompareFlags::NullHandlingMode::kStopAtNull;
+TEST_F(VectorCompareTest, compareNullAsIndeterminateSimpleOfComplex) {
+  auto flatVector = vectorMaker_.arrayVectorNullable<int32_t>(
+      {{{1, 2, 3}}, std::nullopt, {{1, 2, 4}}});
 
-  auto flatVector =
-      vectorMaker_.arrayVectorNullable<int32_t>({{{1, 2, 3}}, std::nullopt});
-  // Test constant.
   auto constantVectorNull = BaseVector::wrapInConstant(2, 1, flatVector);
-  auto constantVectorNotNull = BaseVector::wrapInConstant(2, 0, flatVector);
+  auto constantVectorOne = BaseVector::wrapInConstant(2, 0, flatVector);
+  auto constantVectorTwo = BaseVector::wrapInConstant(2, 2, flatVector);
 
-  EXPECT_FALSE(
-      constantVectorNull->compare(constantVectorNull.get(), 0, 1, testFlags)
-          .has_value());
-  EXPECT_TRUE(constantVectorNotNull
-                  ->compare(constantVectorNotNull.get(), 0, 1, testFlags)
-                  .has_value());
-  EXPECT_FALSE(
-      constantVectorNull->compare(constantVectorNotNull.get(), 0, 1, testFlags)
-          .has_value());
-  EXPECT_FALSE(
-      constantVectorNotNull->compare(constantVectorNull.get(), 0, 1, testFlags)
-          .has_value());
-  // Test dictionary.
-  auto indices = makeIndicesInReverse(2);
+  auto indices = makeIndices({0, 1, 2});
   auto dictionary =
-      BaseVector::wrapInDictionary(nullptr, indices, 2, flatVector);
-  EXPECT_FALSE(
-      dictionary->compare(dictionary.get(), 0, 1, testFlags).has_value());
-  EXPECT_FALSE(
-      dictionary->compare(dictionary.get(), 0, 0, testFlags).has_value());
-  EXPECT_TRUE(
-      dictionary->compare(dictionary.get(), 1, 1, testFlags).has_value());
+      BaseVector::wrapInDictionary(nullptr, indices, 3, flatVector);
+
+  // Test equality with nulls.
+  {
+    CompareFlags equalityFlags = CompareFlags::equality(
+        CompareFlags::NullHandlingMode::kNullAsIndeterminate);
+
+    // Constat vector.
+    testCompare(
+        constantVectorNull, 0, constantVectorOne, 1, kEquality, kIndeterminate);
+
+    testCompare(
+        constantVectorOne, 0, constantVectorNull, 1, kEquality, kIndeterminate);
+
+    testCompare(
+        constantVectorNull,
+        0,
+        constantVectorNull,
+        1,
+        kEquality,
+        kIndeterminate);
+
+    // Dictionary vector.
+    testCompare(dictionary, 0, 1, kEquality, kIndeterminate);
+    testCompare(dictionary, 1, 0, kEquality, kIndeterminate);
+    testCompare(dictionary, 1, 1, kEquality, kIndeterminate);
+  }
+
+  // Test ordering with nulls.
+  {
+    // Constat vector.
+    testOrderingThrow(constantVectorNull, 0, constantVectorOne, 1);
+
+    testOrderingThrow(constantVectorOne, 0, constantVectorNull, 1);
+
+    testOrderingThrow(constantVectorNull, 0, constantVectorNull, 1);
+
+    // Dictionary vector.
+    testOrderingThrow(dictionary, 0, 1);
+    testOrderingThrow(dictionary, 1, 0);
+    testOrderingThrow(dictionary, 1, 1);
+  }
+
+  // Some tests without nulls.
+  testCompare(constantVectorOne, 0, constantVectorOne, 1, kEquality, kEq);
+  testCompare(constantVectorOne, 0, constantVectorOne, 1, kOrderingDesc, 0);
+  testCompare(constantVectorOne, 0, constantVectorOne, 1, kOrderingAsc, 0);
+
+  testCompare(constantVectorOne, 0, constantVectorTwo, 1, kEquality, kNeq);
+  testCompare(constantVectorOne, 0, constantVectorTwo, 1, kOrderingDesc, 1);
+  testCompare(constantVectorOne, 0, constantVectorTwo, 1, kOrderingAsc, -1);
+
+  testCompare(dictionary, 0, 2, kOrderingAsc, -1);
+  testCompare(dictionary, 0, 2, kOrderingDesc, 1);
+  testCompare(dictionary, 2, 2, kEquality, kEq);
 }
 
-TEST_F(VectorCompareTest, compareStopAtNullArray) {
-  auto test = [&](const std::optional<std::vector<std::optional<int64_t>>>&
-                      array1,
-                  const std::optional<std::vector<std::optional<int64_t>>>&
-                      array2,
-                  bool expectNull,
-                  bool equalsOnly = false) {
-    auto vector = vectorMaker_.arrayVectorNullable<int64_t>({array1, array2});
-    testCompareWithStopAtNull(vector, 0, 1, expectNull, equalsOnly);
+TEST_F(VectorCompareTest, compareNullAsIndeterminateArray) {
+  auto test = [&](const std::string& array1,
+                  const std::string& array2,
+                  CompareFlags flags,
+                  std::optional<int32_t> expected) {
+    auto vector = vectorMaker_.arrayVectorFromJson<int64_t>({array1, array2});
+    testCompare(vector, 0, 1, flags, expected);
   };
 
-  test(std::nullopt, std::nullopt, kExpectNull);
-  test(std::nullopt, {{1}}, kExpectNull);
-  test({{1}}, std::nullopt, kExpectNull);
-
-  test({{1, 2, 3}}, {{1, 2, 3}}, kExpectNotNull);
-
-  // Checking the first element is enough to determine the result of the
-  // compare.
-  test({{1, std::nullopt}}, {{6, 2}}, kExpectNotNull);
-
-  test({{1, std::nullopt}}, {{1, 2}}, kExpectNull);
-
-  // When two arrays are of different sizes the checked elements are:
-  // equalsOnly=true  -> none.
-  // equalsOnly=false -> the size of the smallest.
-  test({{}}, {{std::nullopt, std::nullopt}}, kExpectNotNull);
-  test({{1, 2}}, {{1, 2, std::nullopt}}, kExpectNotNull);
-  test({{std::nullopt}}, {{std::nullopt, std::nullopt}}, kExpectNull);
-
-  // Since the two arrays are of different size and equalsOnly is enabled, no
-  // elements is read and hence no null encountered.
-  test(
-      {{std::nullopt, std::nullopt}},
-      {{std::nullopt, std::nullopt, std::nullopt}},
-      kExpectNotNull,
-      kEqualsOnly);
-
-  // Since kEqualsOnly = false, the first two elements will be read.
-  test(
-      {{std::nullopt, std::nullopt}},
-      {{std::nullopt, std::nullopt, std::nullopt}},
-      kExpectNull);
-
-  test(
-      {{std::nullopt, std::nullopt}},
-      {{std::nullopt, std::nullopt}},
-      kExpectNull,
-      kEqualsOnly);
-
-  test(
-      {{std::nullopt, std::nullopt}},
-      {{std::nullopt, std::nullopt}},
-      kExpectNull);
-}
-
-TEST_F(VectorCompareTest, compareStopAtNullMap) {
-  using map_t =
-      std::optional<std::vector<std::pair<int64_t, std::optional<int64_t>>>>;
-  auto test = [&](const map_t& map1,
-                  const map_t& map2,
-                  bool expectNull,
-                  bool equalsOnly = false) {
-    auto vector = makeNullableMapVector<int64_t, int64_t>({map1, map2});
-    testCompareWithStopAtNull(vector, 0, 1, expectNull, equalsOnly);
+  auto orderingThrow = [&](const std::string& array1,
+                           const std::string& array2) {
+    auto vector = vectorMaker_.arrayVectorFromJson<int64_t>({array1, array2});
+    testOrderingThrow(vector, 0, 1);
   };
 
-  test({{{1, 2}, {3, 4}}}, {{{1, 2}, {3, 4}}}, kExpectNotNull);
+  // Top level nulls.
+  orderingThrow("null", "null");
+  orderingThrow("null", "[]");
+  orderingThrow("[]", "null");
 
-  // Null map entries.
-  test(std::nullopt, {{{1, 2}, {3, 4}}}, kExpectNull);
-  test({{{1, 2}, {3, 4}}}, std::nullopt, kExpectNull);
+  test("null", "[1, 2]", kEquality, kIndeterminate);
+  test("null", "null", kEquality, kIndeterminate);
+  test("[]", "null", kEquality, kIndeterminate);
 
-  // Null in values should be read.
-  test({{{1, std::nullopt}, {3, 4}}}, {{{1, 2}, {3, 4}}}, kExpectNull);
-  test({{{1, 2}, {3, 4}}}, {{{1, 2}, {3, std::nullopt}}}, kExpectNull);
-  test(
-      {{{1, std::nullopt}, {2, std::nullopt}}},
-      {{{1, std::nullopt}, {2, std::nullopt}}},
-      kExpectNull);
+  // Testing equality.
+  {
+    // False dominates indeterminate.
+    test("[null, 1]", "[null, 2]", kEquality, kNeq);
+    test("[1, null]", "[2, null]", kEquality, kNeq);
 
-  // Compare will find results before reading null.
-  // All keys are compared before values.
-  test({{{1, std::nullopt}, {3, 4}}}, {{{2, 2}, {3, 4}}}, kExpectNotNull);
-  test(
-      {{{1, std::nullopt}, {2, std::nullopt}}},
-      {{{1, std::nullopt}, {3, std::nullopt}}},
-      kExpectNotNull);
-  test(
-      {{{2, std::nullopt}, {1, std::nullopt}}},
-      {{{1, std::nullopt}, {3, std::nullopt}}},
-      kExpectNotNull);
+    // If the mode is equality and the arrays have different lengths, then
+    // values are not read.
+    test("[null]", "[null, null]", kEquality, kNeq);
+    test("[]", "[null, null]", kEquality, kNeq);
+    test("[1]", "[2, null, null]", kEquality, kNeq);
 
-  // Different sizes.
-  test({{{1, 2}, {1, std::nullopt}}}, {{{1, std::nullopt}}}, kExpectNotNull);
-  test(
-      {{{1, 2}, {1, std::nullopt}}},
-      {{{1, std::nullopt}}},
-      kExpectNotNull,
-      kEqualsOnly);
+    // Indeterminate dominates true.
+    test("[1, null]", "[1, null]", kEquality, kIndeterminate);
+    test("[1, 1, 2]", "[1, 1, null]", kEquality, kIndeterminate);
+    test("[1, 1, 2]", "[null, 1, 2]", kEquality, kIndeterminate);
+    test("[null,1 , 2]", "[1, 1, 2]", kEquality, kIndeterminate);
+
+    test("[1, 2]", "[1, 2]", kEquality, kEq);
+    test("[1, 2]", "[1, 3]", kEquality, kNeq);
+    test("[1, 2]", "[1, 2, 3]", kEquality, kNeq);
+  }
+
+  // Testing ordering.
+  {
+    orderingThrow("[null]", "[null]");
+    orderingThrow("[null]", "[1]");
+    orderingThrow("[null]", "[1, 2]");
+    orderingThrow("[1, 2, null]", "[1, 2, null]");
+
+    // Only elements between 0 and min size are read.
+    test("[1]", "[1, null, 3]", kOrderingAsc, -2);
+    test("[1]", "[1, null, 3]", kOrderingDesc, 2);
+    test("[1, null, 3]", "[1]", kOrderingAsc, 2);
+    test("[1, null, 3]", "[1]", kOrderingDesc, -2);
+
+    // If order is determined before null is seen, no throw happen and null is
+    // not read.
+    test("[1, 2, null]", "[1, 3, null]", kOrderingAsc, -1);
+    test("[1, 2, null]", "[1, 3, null]", kOrderingDesc, 1);
+    test("[1, 3, null]", "[1, 2, null]", kOrderingAsc, 1);
+    test("[1, 3, null]", "[1, 2, null]", kOrderingDesc, -1);
+  }
 }
 
-TEST_F(VectorCompareTest, compareStopAtNullRow) {
+TEST_F(VectorCompareTest, compareNullAsIndeterminateNullMap) {
+  auto test = [&](const std::string& map1,
+                  const std::string& map2,
+                  CompareFlags flags,
+                  std::optional<int32_t> expected) {
+    auto vector = makeMapVectorFromJson<int64_t, int64_t>({map1, map2});
+    testCompare(vector, 0, 1, flags, expected);
+  };
+
+  // Map is NOT orderable in NullAsIndeterminate mode.
+  VELOX_ASSERT_THROW(
+      test("{}", "{}", kOrderingAsc, kIndeterminate),
+      "Map is not orderable type");
+  VELOX_ASSERT_THROW(
+      test("{}", "{}", kOrderingDesc, kIndeterminate),
+      "Map is not orderable type");
+
+  // Map is orderable in NullAsValue mode.
+  test("{}", "{}", CompareFlags{.ascending = true}, 0);
+  test("{}", "{}", CompareFlags{.ascending = false}, 0);
+
+  // Only need to check equality.
+
+  // Top level nulls.
+  test("null", "{}", kEquality, kIndeterminate);
+
+  // If keys are different, values are not looked at. Note that keys cant be
+  // null or contain nested nulls in presto.
+  test("{1: null, 2: null}", "{1: null, 3: null}", kEquality, kNeq);
+  test("{1: null, 2: null}", "{1: null}", kEquality, kNeq);
+
+  // If keys are equal, values are compared as arrays.
+  // == [null, null] = [null, null]
+  test("{1: null, 2: null}", "{1: null, 2: null}", kEquality, kIndeterminate);
+
+  // == [1, null] = [2, null]
+  test("{1: 1, 2: null}", "{1: 2, 2: null}", kEquality, kNeq);
+  test("{1: 2, 2: null}", "{1: 1, 2: null}", kEquality, kNeq);
+
+  // == [null, 1] = [null, 2]
+  test("{1: null, 2: 1}", "{1: null, 2: 2}", kEquality, kNeq);
+  test("{1: null, 2: 2}", "{1: null, 2: 1}", kEquality, kNeq);
+}
+
+TEST_F(VectorCompareTest, compareNullAsIndeterminateRow) {
   auto test =
       [&](const std::tuple<std::optional<int64_t>, std::optional<int64_t>>&
               row1,
           const std::tuple<std::optional<int64_t>, std::optional<int64_t>>&
               row2,
-          bool expectNull,
-          bool equalsOnly = false) {
+          CompareFlags testFlags,
+          const std::optional<int32_t> expected) {
         auto vector = vectorMaker_.rowVector(
             {vectorMaker_.flatVectorNullable<int64_t>(
                  {std::get<0>(row1), std::get<0>(row2)}),
              vectorMaker_.flatVectorNullable<int64_t>(
                  {std::get<1>(row1), std::get<1>(row2)})});
-
-        testCompareWithStopAtNull(vector, 0, 1, expectNull, equalsOnly);
+        testCompare(vector, 0, 1, testFlags, expected);
       };
 
-  test({1, 2}, {2, 3}, kExpectNotNull);
-  test({1, 2}, {1, 2}, kExpectNotNull);
-  test({2, std::nullopt}, {1, 2}, kExpectNotNull);
+  auto orderingThrow =
+      [&](const std::tuple<std::optional<int64_t>, std::optional<int64_t>>&
+              row1,
+          const std::tuple<std::optional<int64_t>, std::optional<int64_t>>&
+              row2) {
+        auto vector = vectorMaker_.rowVector(
+            {vectorMaker_.flatVectorNullable<int64_t>(
+                 {std::get<0>(row1), std::get<0>(row2)}),
+             vectorMaker_.flatVectorNullable<int64_t>(
+                 {std::get<1>(row1), std::get<1>(row2)})});
+        testOrderingThrow(vector, 0, 1);
+      };
 
-  test({1, 2}, {1, std::nullopt}, kExpectNull);
-  test({1, std::nullopt}, {1, 2}, kExpectNull);
-  test({1, 2}, {std::nullopt, 2}, kExpectNull);
+  // Top level nulls.
+  {
+    auto vector = vectorMaker_.rowVector(
+        {vectorMaker_.flatVector<int64_t>(0),
+         vectorMaker_.flatVector<int64_t>(0)});
+    ASSERT_EQ(vector->size(), 0);
+    vector->appendNulls(2);
+    testCompare(vector, 0, 1, kEquality, kIndeterminate);
+    testOrderingThrow(vector, 0, 1);
+  }
+
+  const auto kNull = std::nullopt;
+
+  // Testing equality.
+  {
+    // False dominates indeterminate.
+    test({kNull, 1}, {kNull, 2}, kEquality, kNeq);
+    test({kNull, 2}, {kNull, 1}, kEquality, kNeq);
+
+    // Indeterminate dominates true.
+    test({1, kNull}, {1, kNull}, kEquality, kIndeterminate);
+    test({kNull, 1}, {kNull, 1}, kEquality, kIndeterminate);
+
+    test({1, 2}, {1, 2}, kEquality, kEq);
+    test({1, 2}, {1, 3}, kEquality, kNeq);
+  }
+
+  // Testing ordering.
+  {
+    orderingThrow({kNull, kNull}, {kNull, kNull});
+    orderingThrow({1, kNull}, {1, kNull});
+    orderingThrow({1, kNull}, {kNull, kNull});
+    orderingThrow({kNull, kNull}, {1, kNull});
+
+    // If order is determined before null is seen, no throw happens and null is
+    // not read.
+    test({1, kNull}, {2, kNull}, kOrderingAsc, -1);
+    test({1, kNull}, {2, kNull}, kOrderingDesc, 1);
+    test({2, kNull}, {1, kNull}, kOrderingDesc, -1);
+    test({2, kNull}, {1, kNull}, kOrderingAsc, 1);
+  }
 }
 
 TEST_F(VectorCompareTest, CompareWithNullChildVector) {

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -3273,7 +3273,10 @@ TEST_F(VectorTest, primitiveTypeNullEqual) {
 
   auto equalStopAtNull = [&](vector_size_t i, vector_size_t j) {
     return base->equalValueAt(
-        other.get(), i, j, CompareFlags::NullHandlingMode::kStopAtNull);
+        other.get(),
+        i,
+        j,
+        CompareFlags::NullHandlingMode::kNullAsIndeterminate);
   };
 
   // No null compare.
@@ -3303,7 +3306,10 @@ TEST_F(VectorTest, complexTypeNullEqual) {
 
   auto equalStopAtNull = [&](vector_size_t i, vector_size_t j) {
     return base->equalValueAt(
-        other.get(), i, j, CompareFlags::NullHandlingMode::kStopAtNull);
+        other.get(),
+        i,
+        j,
+        CompareFlags::NullHandlingMode::kNullAsIndeterminate);
   };
 
   // No null compare, [0, 1] vs [0, 1].
@@ -3344,7 +3350,10 @@ TEST_F(VectorTest, dictionaryNullEqual) {
 
   auto equalStopAtNull = [&](vector_size_t i, vector_size_t j) {
     return dictVector->equalValueAt(
-        other.get(), i, j, CompareFlags::NullHandlingMode::kStopAtNull);
+        other.get(),
+        i,
+        j,
+        CompareFlags::NullHandlingMode::kNullAsIndeterminate);
   };
 
   for (vector_size_t i = 0; i < 2; ++i) {
@@ -3384,7 +3393,10 @@ TEST_F(VectorTest, constantNullEqual) {
 
   auto equalStopAtNull = [&](vector_size_t i, vector_size_t j) {
     return constantVector->equalValueAt(
-        other.get(), i, j, CompareFlags::NullHandlingMode::kStopAtNull);
+        other.get(),
+        i,
+        j,
+        CompareFlags::NullHandlingMode::kNullAsIndeterminate);
   };
 
   // No null compare, [2, null] vs [0, 1], [2, null] vs [1, 2].


### PR DESCRIPTION
Summary:
Velox used to depend to use the StopAtNull mode to implement presto semantics
of comparisons. However as discussed in https://github.com/facebookincubator/velox/issues/7536
that mode does not correctly implement presto semantics.

This diff replaces StopAtNull mode with NullAsIndeterminate mode. NullAsIndeterminate
implements presto semantics for comparisons, the diff contains a detailed documentation of the
mode. But here I summarize how it differs from StopAtNull.

1) When equalsOnly=true, for complex types,  StopAtNull stops at first null encountered,
while NullAsIndeterminate checks all children and if any is false, the final result is false.
ex: [null, 1] = [null, 2] is false under NullAsIndeterminate.

2) When equalsOnly=false, if any null is encountered, NullAsIndeterminate throws a user error
"Ordering nulls is not supported" while StopAtNull returns std::nullopt. And callers used to
 manually handle that.

3) When equalsOnly=false comparing maps will throw a runtime error, "Map is not orderable
 type" while StopAtNull used to allow it.

This changes the behavior of several existing functions some of which are tested in this diff such as
array_remove, contains and ==.

Differential Revision: D51518489


