### PR TITLE
Adding at_timezone feature

### DIFF
--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -483,8 +483,7 @@ struct TimestampAtTimezoneFunction : public TimestampWithTimezoneSupport<T> {
       const arg_type<Varchar>* /*timeZone*/) {
     sessionTimezone = getTimeZoneFromConfig(config);
     sessionTzName =
-         (sessionTimezone != NULL ? sessionTimezone->name()
-                                           : "Africa/Abidjan");
+        (sessionTimezone != NULL ? sessionTimezone->name() : "Africa/Abidjan");
   }
 
   FOLLY_ALWAYS_INLINE void initialize(
@@ -509,7 +508,9 @@ struct TimestampAtTimezoneFunction : public TimestampWithTimezoneSupport<T> {
     // "Africa/Abidjan" timezone has offset +00:00; use this timezone to convert
     // to UTC.
 
-    auto starting_timepoint = date::make_zoned(sessionTzName, date::local_seconds{(std::chrono::seconds)(ts.getSeconds())});
+    auto starting_timepoint = date::make_zoned(
+        sessionTzName,
+        date::local_seconds{(std::chrono::seconds)(ts.getSeconds())});
     auto UTC_timepoint = date::make_zoned("Africa/Abidjan", starting_timepoint);
 
     auto UTC_time = UTC_timepoint.get_local_time();

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -508,12 +508,14 @@ struct TimestampAtTimezoneFunction : public TimestampWithTimezoneSupport<T> {
         std::chrono::seconds{ts.getSeconds()}};
 
     // We are to interpret the input timestamp as being at session timezone;
-    // date::make_zoned() returns a zoned_time type that is constructed similarly to 
-    // TimestampWithTimezone, containing a sys_time<duration> to represent a UTC timestamp, as well as
-    // a TimeZonePtr to hold the timezone said timestamp must be resolved to.
+    // date::make_zoned() returns a zoned_time type that is constructed
+    // similarly to TimestampWithTimezone, containing a sys_time<duration> to
+    // represent a UTC timestamp, as well as a TimeZonePtr to hold the timezone
+    // said timestamp must be resolved to.
 
-    // date::make_zoned() converts the input timestamp, interpreted relative to the input timezone (in this case, session timezone)
-    // to a UTC-relative system time, stored in the returned zoned_time object.
+    // date::make_zoned() converts the input timestamp, interpreted relative to
+    // the input timezone (in this case, session timezone) to a UTC-relative
+    // system time, stored in the returned zoned_time object.
 
     auto starting_timepoint = date::make_zoned(
         sessionTzName,

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -500,7 +500,12 @@ struct TimestampAtTimezoneFunction : public TimestampWithTimezoneSupport<T> {
     // "Africa/Abidjan" timezone has offset +00:00; use this timezone to convert
     // to UTC.
 
-    auto starting_timepoint = date::make_zoned(sessionTzName, tp);
+    // date::local_seconds{}
+    auto starting_timepoint = date::make_zoned(sessionTzName, date::local_seconds{(std::chrono::seconds)(1500101514)});
+    auto LA_timept = date::make_zoned("America/Los_Angeles", starting_timepoint);
+
+
+
     auto UTC_timepoint = date::make_zoned("Africa/Abidjan", starting_timepoint);
 
     auto UTC_time = UTC_timepoint.get_local_time();

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -479,7 +479,10 @@ struct TimestampAtTimezoneFunction : public TimestampWithTimezoneSupport<T> {
       const core::QueryConfig& config,
       const arg_type<Timestamp>& ts,
       const arg_type<Varchar>& timeZone) {
-    auto sessionTzName = config.sessionTimezone();
+    
+    // Check if session timezone was provided. 
+    // If not, fallback to UTC (represented by "Africa/Abidjan" timezone).
+    auto sessionTzName = (config.sessionTimezone().empty() ? "Africa/Abidjan" : config.sessionTimezone());
   }
 
   FOLLY_ALWAYS_INLINE void call(
@@ -493,7 +496,8 @@ struct TimestampAtTimezoneFunction : public TimestampWithTimezoneSupport<T> {
     // We are to interpret the input timestamp as being at session timezone;
     // we must convert it to UTC to derive the UTC millisecond offset
     // with which we can create the output TimestampWithTimezone type.
-    // Africa/Abidjan has offset +00:00; use this timezone to convert to UTC.
+    // "Africa/Abidjan" timezone has offset +00:00; use this timezone to convert to UTC.
+
     auto starting_timepoint = date::make_zoned(sessionTzName, tp);
     auto UTC_timepoint = date::make_zoned("Africa/Abidjan", starting_timepoint);
 

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -479,10 +479,11 @@ struct TimestampAtTimezoneFunction : public TimestampWithTimezoneSupport<T> {
       const core::QueryConfig& config,
       const arg_type<Timestamp>& ts,
       const arg_type<Varchar>& timeZone) {
-    
-    // Check if session timezone was provided. 
+    // Check if session timezone was provided.
     // If not, fallback to UTC (represented by "Africa/Abidjan" timezone).
-    auto sessionTzName = (config.sessionTimezone().empty() ? "Africa/Abidjan" : config.sessionTimezone());
+    auto sessionTzName =
+        (config.sessionTimezone().empty() ? "Africa/Abidjan"
+                                          : config.sessionTimezone());
   }
 
   FOLLY_ALWAYS_INLINE void call(
@@ -496,7 +497,8 @@ struct TimestampAtTimezoneFunction : public TimestampWithTimezoneSupport<T> {
     // We are to interpret the input timestamp as being at session timezone;
     // we must convert it to UTC to derive the UTC millisecond offset
     // with which we can create the output TimestampWithTimezone type.
-    // "Africa/Abidjan" timezone has offset +00:00; use this timezone to convert to UTC.
+    // "Africa/Abidjan" timezone has offset +00:00; use this timezone to convert
+    // to UTC.
 
     auto starting_timepoint = date::make_zoned(sessionTzName, tp);
     auto UTC_timepoint = date::make_zoned("Africa/Abidjan", starting_timepoint);

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -502,13 +502,15 @@ struct TimestampAtTimezoneFunction : public TimestampWithTimezoneSupport<T> {
       out_type<TimestampWithTimezone>& result,
       const arg_type<TimestampWithTimezone>& tsWithTz,
       const arg_type<Varchar>& timeZone) {
+
     auto timeZoneStr = std::string_view(timeZone.data(), timeZone.size());
     auto zone = date::locate_zone(timeZoneStr);
-    std::chrono::system_clock::time_point tp{
-        std::chrono::seconds{ts.getSeconds()}};
 
-    const auto inputMs = *timestampWithTimezone.template at<0>();
-    const auto inputTz = *timestampWithTimezone.template at<1>();
+    const auto inputMs = *tsWithTz.template at<0>();
+    const auto inputTz = *tsWithTz.template at<1>();
+
+    std::chrono::system_clock::time_point tp{
+    std::chrono::seconds{(inputMs/1000)}};
 
     // We are to interpret the input timestamp as being at GMT;
     // Africa/Abidjan has offset +00:00; use this timezone to establish GMT as

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -473,17 +473,17 @@ template <typename T>
 struct TimestampAtTimezoneFunction : public TimestampWithTimezoneSupport<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  std::string sessionTzName;
+  std::string sessionTzName = "";
+  const date::time_zone* sessionTimezone = nullptr;
 
   FOLLY_ALWAYS_INLINE void initialize(
       const core::QueryConfig& config,
-      const arg_type<Timestamp>& ts,
-      const arg_type<Varchar>& timeZone) {
-    // Check if session timezone was provided.
-    // If not, fallback to UTC (represented by "Africa/Abidjan" timezone).
-    auto sessionTzName =
-        (config.sessionTimezone().empty() ? "Africa/Abidjan"
-                                          : config.sessionTimezone());
+      const arg_type<Timestamp>* /*ts*/,
+      const arg_type<Varchar>* /*timestamp*/) {
+    sessionTimezone = getTimeZoneFromConfig(config);
+    sessionTzName =
+         (sessionTimezone != NULL ? sessionTimezone->name()
+                                           : "Africa/Abidjan");
   }
 
   FOLLY_ALWAYS_INLINE void call(

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -487,6 +487,7 @@ struct TimestampAtTimezoneFunction : public TimestampWithTimezoneSupport<T> {
 
     // below statements causing issue - timeZone is NULL here,
     // are args not processed in init()?
+
     // auto timeZoneStr = std::string_view(timeZone->data(), timeZone->size());
     // targetTimezoneID = util::getTimeZoneID(timeZoneStr);
   }
@@ -495,8 +496,8 @@ struct TimestampAtTimezoneFunction : public TimestampWithTimezoneSupport<T> {
       const core::QueryConfig& config,
       const arg_type<TimestampWithTimezone>* /*tsWithTz*/,
       const arg_type<Varchar>* timeZone) {
-    auto timeZoneStr = std::string_view(timeZone->data(), timeZone->size());
-    targetTimezoneID = util::getTimeZoneID(timeZoneStr);
+    // auto timeZoneStr = std::string_view(timeZone->data(), timeZone->size());
+    // targetTimezoneID = util::getTimeZoneID(timeZoneStr);
   }
 
   FOLLY_ALWAYS_INLINE void call(
@@ -535,6 +536,9 @@ struct TimestampAtTimezoneFunction : public TimestampWithTimezoneSupport<T> {
       const arg_type<TimestampWithTimezone>& tsWithTz,
       const arg_type<Varchar>& timeZone) {
     const auto inputMs = *tsWithTz.template at<0>();
+
+    auto timeZoneStr = std::string_view(timeZone.data(), timeZone.size());
+    targetTimezoneID = util::getTimeZoneID(timeZoneStr);
 
     // <0> of a TimestampWithTimezone tuple always represents
     // milliseconds relative to GMT - so the input and output

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -479,7 +479,6 @@ struct TimestampAtTimezoneFunction : public TimestampWithTimezoneSupport<T> {
       const core::QueryConfig& config,
       const arg_type<Timestamp>& ts,
       const arg_type<Varchar>& timeZone) {
-
     auto sessionTzName = config.sessionTimezone();
   }
 
@@ -500,8 +499,8 @@ struct TimestampAtTimezoneFunction : public TimestampWithTimezoneSupport<T> {
 
     auto UTC_time = UTC_timepoint.get_local_time();
     auto UTC_seconds = std::chrono::duration_cast<std::chrono::seconds>(
-                               UTC_time.time_since_epoch())
-                               .count();
+                           UTC_time.time_since_epoch())
+                           .count();
 
     result.template get_writer_at<0>() = UTC_seconds;
     result.template get_writer_at<1>() = util::getTimeZoneID(timeZoneStr);
@@ -511,17 +510,17 @@ struct TimestampAtTimezoneFunction : public TimestampWithTimezoneSupport<T> {
       out_type<TimestampWithTimezone>& result,
       const arg_type<TimestampWithTimezone>& tsWithTz,
       const arg_type<Varchar>& timeZone) {
-
     auto timeZoneStr = std::string_view(timeZone.data(), timeZone.size());
     auto zone = date::locate_zone(timeZoneStr);
 
     const auto inputMs = *tsWithTz.template at<0>();
     const auto inputTz = *tsWithTz.template at<1>();
 
-    // <0> of a TimestampWithTimezone tuple always represents 
-    // milliseconds relative to GMT - so the input and output TimestampWithTimezones should
-    // not have different millisecond values (<0>), rather solely timezone <1> should differ.
-    // The millisecond offset is then resolved to the respective timezone at the time of display.
+    // <0> of a TimestampWithTimezone tuple always represents
+    // milliseconds relative to GMT - so the input and output
+    // TimestampWithTimezones should not have different millisecond values
+    // (<0>), rather solely timezone <1> should differ. The millisecond offset
+    // is then resolved to the respective timezone at the time of display.
     result.template get_writer_at<0>() = inputMs;
     result.template get_writer_at<1>() = util::getTimeZoneID(timeZoneStr);
   }

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -179,12 +179,12 @@ void registerSimpleFunctions(const std::string& prefix) {
       TimestampAtTimezoneFunction,
       TimestampWithTimezone,
       Timestamp,
-      Varchar>({prefix + "timezone"});
+      Varchar>({prefix + "at_timezone"});
   registerFunction<
       TimestampAtTimezoneFunction,
       TimestampWithTimezone,
       TimestampWithTimezone,
-      Varchar>({prefix + "timezone"});
+      Varchar>({prefix + "at_timezone"});
 }
 } // namespace
 

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -175,6 +175,11 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerFunction<DateParseFunction, Timestamp, Varchar, Varchar>(
       {prefix + "date_parse"});
   registerFunction<CurrentDateFunction, Date>({prefix + "current_date"});
+  registerFunction<
+      TimestampAtTimezoneFunction,
+      TimestampWithTimezone,
+      Timestamp,
+      Varchar>({prefix + "timezone"});
 }
 } // namespace
 

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -180,6 +180,11 @@ void registerSimpleFunctions(const std::string& prefix) {
       TimestampWithTimezone,
       Timestamp,
       Varchar>({prefix + "timezone"});
+  registerFunction<
+      TimestampAtTimezoneFunction,
+      TimestampWithTimezone,
+      TimestampWithTimezone,
+      Varchar>({prefix + "timezone"});
 }
 } // namespace
 

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -1070,17 +1070,6 @@ TEST_F(DateTimeFunctionsTest, timestampAtTimezoneTestTimestampInput) {
 TEST_F(
     DateTimeFunctionsTest,
     timestampAtTimezoneTestTimestampWithTimezoneInput) {
-    // EXPECT_EQ(
-    //     TimestampWithTimezone(1500101514,
-    //     util::getTimeZoneID("America/Boise")), timestampAtTimezone(
-    //           TimestampWithTimezone(1500101514,
-    //           util::getTimeZoneID("Asia/Kathmandu")),
-    //                                   "America/Boise"));
-
-  //   EXPECT_EQ(
-  //       1973,
-  //       evaluateWithTimestampWithTimezone<int64_t>(
-  //           "year(c0)", 123456789000, "+14:00"));
 
   EXPECT_EQ(
       TimestampWithTimezone(1500101514, util::getTimeZoneID("America/Boise")),
@@ -1090,13 +1079,17 @@ TEST_F(
   EXPECT_EQ(
       TimestampWithTimezone(1500101514, util::getTimeZoneID("Europe/London")),
       timestampWithTimezoneAtTimezone(
-          1500101514, "Asia/Kathmandu", "Europe/London"));
+          1500101514, "America/Boise", "Europe/London"));
 
-  // should fail
   EXPECT_EQ(
-      TimestampWithTimezone(1500101514, util::getTimeZoneID("Europe/London")),
+      TimestampWithTimezone(1500321297, util::getTimeZoneID("Australia/Melbourne")),
       timestampWithTimezoneAtTimezone(
-          1500101513, "Asia/Kathmandu", "Europe/London"));
+          1500321297, "Canada/Yukon", "Australia/Melbourne"));
+
+  EXPECT_EQ(
+      TimestampWithTimezone(-2749482486, util::getTimeZoneID("Pacific/Fiji")),
+      timestampWithTimezoneAtTimezone(
+          -2749482486, "Atlantic/Bermuda", "Pacific/Fiji"));
 }
 
 TEST_F(DateTimeFunctionsTest, dayOfMonthTimestampWithTimezone) {

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -1019,7 +1019,7 @@ TEST_F(DateTimeFunctionsTest, timestampAtTimezoneTestTimestampInput) {
           1500101514 + 14400, util::getTimeZoneID("America/Boise")),
       timestampAtTimezone(Timestamp(1500101514, 0), "America/Boise"));
 
-   // New York 2017 = UTC -04:00 = -14400 sec
+  // New York 2017 = UTC -04:00 = -14400 sec
   EXPECT_EQ(
       TimestampWithTimezone(
           1500101514 + 14400, util::getTimeZoneID("Asia/Baghdad")),
@@ -1031,16 +1031,16 @@ TEST_F(DateTimeFunctionsTest, timestampAtTimezoneTestTimestampInput) {
           1510728714 + 18000, util::getTimeZoneID("Asia/Baghdad")),
       timestampAtTimezone(Timestamp(1510728714, 0), "Asia/Baghdad"));
 
-      // New York 1892 = UTC -4:56:02 = -(14400 + 3360 + 2) sec
-    EXPECT_EQ(
+  // New York 1892 = UTC -4:56:02 = -(14400 + 3360 + 2) sec
+  EXPECT_EQ(
       TimestampWithTimezone(
           -2749482486 + 17762, util::getTimeZoneID("Europe/London")),
       timestampAtTimezone(Timestamp(-2749482486, 0), "Europe/London"));
 
-    setQueryTimeZone("America/Los_Angeles");
+  setQueryTimeZone("America/Los_Angeles");
 
-    // Los Angeles 1880 = UTC -7:52:58 = -(25200 + 3180 ) = 28378 sec
-    EXPECT_EQ(
+  // Los Angeles 1880 = UTC -7:52:58 = -(25200 + 3180 ) = 28378 sec
+  EXPECT_EQ(
       TimestampWithTimezone(
           -2938784886 + 28378, util::getTimeZoneID("Europe/London")),
       timestampAtTimezone(Timestamp(-2938784886, 0), "Europe/London"));
@@ -1060,7 +1060,7 @@ TEST_F(DateTimeFunctionsTest, timestampAtTimezoneTestTimestampInput) {
 
   setQueryTimeZone("Africa/Bamako");
 
-//   // Africa/Bamako = UTC +0:00
+  //   // Africa/Bamako = UTC +0:00
   EXPECT_EQ(
       TimestampWithTimezone(
           1500101514, util::getTimeZoneID("Pacific/Galapagos")),
@@ -1070,7 +1070,6 @@ TEST_F(DateTimeFunctionsTest, timestampAtTimezoneTestTimestampInput) {
 TEST_F(
     DateTimeFunctionsTest,
     timestampAtTimezoneTestTimestampWithTimezoneInput) {
-
   EXPECT_EQ(
       TimestampWithTimezone(1500101514, util::getTimeZoneID("America/Boise")),
       timestampWithTimezoneAtTimezone(
@@ -1082,7 +1081,8 @@ TEST_F(
           1500101514, "America/Boise", "Europe/London"));
 
   EXPECT_EQ(
-      TimestampWithTimezone(1500321297, util::getTimeZoneID("Australia/Melbourne")),
+      TimestampWithTimezone(
+          1500321297, util::getTimeZoneID("Australia/Melbourne")),
       timestampWithTimezoneAtTimezone(
           1500321297, "Canada/Yukon", "Australia/Melbourne"));
 

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -1006,51 +1006,51 @@ TEST_F(DateTimeFunctionsTest, minusTimestamp) {
 }
 
 TEST_F(DateTimeFunctionsTest, timestampAtTimezoneTestTimestampInput) {
+  // Passing a Timestamp along with a timezone string
+  // into at_timezone() should return a
+  // TimestampWithTimezone type, comprised of seconds (int64) relative to UTC,
+  // and a timezone ID (int16) corresponding to the input timezone string.
 
-    // Passing a Timestamp along with a timezone string
-    // into at_timezone() should return a 
-    // TimestampWithTimezone type, comprised of seconds (int64) relative to UTC, 
-    // and a timezone ID (int16) corresponding to the input timezone string.
-    
-    setQueryTimeZone("America/New_York");
+  setQueryTimeZone("America/New_York");
 
-    // New York 2017 = UTC -04:00 = -14400 sec
-    EXPECT_EQ(
+  // New York 2017 = UTC -04:00 = -14400 sec
+  EXPECT_EQ(
       TimestampWithTimezone(
           1500101514 + 14400, util::getTimeZoneID("America/Boise")),
       timestampAtTimezone(Timestamp(1500101514, 0), "America/Boise"));
 
-    // New York 2017 = UTC -04:00 = -14400 sec
-    EXPECT_EQ(
+  // New York 2017 = UTC -04:00 = -14400 sec
+  EXPECT_EQ(
       TimestampWithTimezone(
           1500101514 + 14400, util::getTimeZoneID("Asia/Baghdad")),
       timestampAtTimezone(Timestamp(1500101514, 0), "Asia/Baghdad"));
 
-    // New York 2017 DST = UTC -05:00 = -18000 sec
-    EXPECT_EQ(
+  // New York 2017 DST = UTC -05:00 = -18000 sec
+  EXPECT_EQ(
       TimestampWithTimezone(
           1510728714 + 18000, util::getTimeZoneID("Asia/Baghdad")),
       timestampAtTimezone(Timestamp(1510728714, 0), "Asia/Baghdad"));
 
-    setQueryTimeZone("Asia/Baghdad");
+  setQueryTimeZone("Asia/Baghdad");
 
-    // Asia/Baghdad = UTC +03:00 = +10800 sec
-    EXPECT_EQ(
-        TimestampWithTimezone(
-            1500101514 - 10800, util::getTimeZoneID("Europe/London")),
-        timestampAtTimezone(Timestamp(1500101514, 0), "Europe/London"));
+  // Asia/Baghdad = UTC +03:00 = +10800 sec
+  EXPECT_EQ(
+      TimestampWithTimezone(
+          1500101514 - 10800, util::getTimeZoneID("Europe/London")),
+      timestampAtTimezone(Timestamp(1500101514, 0), "Europe/London"));
 
-    EXPECT_EQ(
-        TimestampWithTimezone(
-            1500321297 - 10800, util::getTimeZoneID("America/New_York")),
-        timestampAtTimezone(Timestamp(1500321297, 0), "America/New_York"));
+  EXPECT_EQ(
+      TimestampWithTimezone(
+          1500321297 - 10800, util::getTimeZoneID("America/New_York")),
+      timestampAtTimezone(Timestamp(1500321297, 0), "America/New_York"));
 
-    setQueryTimeZone("Africa/Bamako");
+  setQueryTimeZone("Africa/Bamako");
 
-    // Africa/Bamako = UTC +0:00
-    EXPECT_EQ(
-        TimestampWithTimezone(1500101514, util::getTimeZoneID("Pacific/Galapagos")),
-        timestampAtTimezone(Timestamp(1500101514, 0), "Pacific/Galapagos"));
+  // Africa/Bamako = UTC +0:00
+  EXPECT_EQ(
+      TimestampWithTimezone(
+          1500101514, util::getTimeZoneID("Pacific/Galapagos")),
+      timestampAtTimezone(Timestamp(1500101514, 0), "Pacific/Galapagos"));
 }
 
 TEST_F(

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -1006,43 +1006,51 @@ TEST_F(DateTimeFunctionsTest, minusTimestamp) {
 }
 
 TEST_F(DateTimeFunctionsTest, timestampAtTimezoneTestTimestampInput) {
+
+    // Passing a Timestamp along with a timezone string
+    // into at_timezone() should return a 
+    // TimestampWithTimezone type, comprised of seconds (int64) relative to UTC, 
+    // and a timezone ID (int16) corresponding to the input timezone string.
     
     setQueryTimeZone("America/New_York");
-  // New York = GMT -04:00, -14400 sec
-  EXPECT_EQ(
+
+    // New York 2017 = UTC -04:00 = -14400 sec
+    EXPECT_EQ(
       TimestampWithTimezone(
-          1500101514 - 14400, util::getTimeZoneID("America/Boise")),
+          1500101514 + 14400, util::getTimeZoneID("America/Boise")),
       timestampAtTimezone(Timestamp(1500101514, 0), "America/Boise"));
 
-  //   // GMT +03:00, +10800 sec
-  //   EXPECT_EQ(
-  //       TimestampWithTimezone(
-  //           1500101514 + 10800, util::getTimeZoneID("Asia/Baghdad")),
-  //       timestampAtTimezone(Timestamp(1500101514, 0), "Asia/Baghdad"));
+    // New York 2017 = UTC -04:00 = -14400 sec
+    EXPECT_EQ(
+      TimestampWithTimezone(
+          1500101514 + 14400, util::getTimeZoneID("Asia/Baghdad")),
+      timestampAtTimezone(Timestamp(1500101514, 0), "Asia/Baghdad"));
 
-  //   // GMT +0:00
-  //   EXPECT_EQ(
-  //       TimestampWithTimezone(1500101514,
-  //       util::getTimeZoneID("Africa/Bamako")),
-  //       timestampAtTimezone(Timestamp(1500101514, 0), "Africa/Bamako"));
+    // New York 2017 DST = UTC -05:00 = -18000 sec
+    EXPECT_EQ(
+      TimestampWithTimezone(
+          1510728714 + 18000, util::getTimeZoneID("Asia/Baghdad")),
+      timestampAtTimezone(Timestamp(1510728714, 0), "Asia/Baghdad"));
 
-  //   // GMT -07:00, -25200 sec
-  //   EXPECT_EQ(
-  //       TimestampWithTimezone(
-  //           1513299114 - 25200, util::getTimeZoneID("America/Boise")),
-  //       timestampAtTimezone(Timestamp(1513299114, 0), "America/Boise"));
+    setQueryTimeZone("Asia/Baghdad");
 
-  //   // GMT +01:00, +3600 sec
-  //   EXPECT_EQ(
-  //       TimestampWithTimezone(
-  //           507034293 + 3600, util::getTimeZoneID("Europe/Prague")),
-  //       timestampAtTimezone(Timestamp(507034293, 0), "Europe/Prague"));
+    // Asia/Baghdad = UTC +03:00 = +10800 sec
+    EXPECT_EQ(
+        TimestampWithTimezone(
+            1500101514 - 10800, util::getTimeZoneID("Europe/London")),
+        timestampAtTimezone(Timestamp(1500101514, 0), "Europe/London"));
 
-  //   // GMT +05:45, +20700 sec
-  //   EXPECT_EQ(
-  //       TimestampWithTimezone(
-  //           75325423914 + 20700, util::getTimeZoneID("Asia/Kathmandu")),
-  //       timestampAtTimezone(Timestamp(75325423914, 0), "Asia/Kathmandu"));
+    EXPECT_EQ(
+        TimestampWithTimezone(
+            1500321297 - 10800, util::getTimeZoneID("America/New_York")),
+        timestampAtTimezone(Timestamp(1500321297, 0), "America/New_York"));
+
+    setQueryTimeZone("Africa/Bamako");
+
+    // Africa/Bamako = UTC +0:00
+    EXPECT_EQ(
+        TimestampWithTimezone(1500101514, util::getTimeZoneID("Pacific/Galapagos")),
+        timestampAtTimezone(Timestamp(1500101514, 0), "Pacific/Galapagos"));
 }
 
 TEST_F(

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -1006,7 +1006,8 @@ TEST_F(DateTimeFunctionsTest, minusTimestamp) {
 }
 
 TEST_F(DateTimeFunctionsTest, timestampAtTimezoneTestTimestampInput) {
-  setQueryTimeZone("America/New_York");
+    
+    setQueryTimeZone("America/New_York");
   // New York = GMT -04:00, -14400 sec
   EXPECT_EQ(
       TimestampWithTimezone(

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -128,6 +128,38 @@ class DateTimeFunctionsTest : public functions::test::FunctionBaseTest {
         makeRowVector(
             {makeNullableFlatVector<Timestamp>({t1}),
              makeNullableFlatVector<std::string>({t2})}));
+
+    EXPECT_EQ(1, resultVector->size());
+
+    if (resultVector->isNullAt(0)) {
+      return std::nullopt;
+    }
+
+    auto rowVector = resultVector->as<RowVector>();
+    return TimestampWithTimezone{
+        rowVector->children()[0]->as<SimpleVector<int64_t>>()->valueAt(0),
+        rowVector->children()[1]->as<SimpleVector<int16_t>>()->valueAt(0)};
+  }
+  
+  std::optional<TimestampWithTimezone> evaluateWithTimestampWithTimezone2(
+      std::optional<int64_t> timestamp,
+      const std::optional<std::string>& timeZoneName,
+      const std::optional<std::string>& newTimeZoneName) {
+    // if (!timestamp.has_value() || !timeZoneName.has_value()) {
+    //   return evaluateOnce<T>(
+    //       "timezone(c0, c1)",
+    //       makeRowVector(
+    //         {BaseVector::createNullConstant(
+    //           TIMESTAMP_WITH_TIME_ZONE(), 1, pool()),
+    //         makeNullableFlatVector<std::string>({newTimeZoneName})}));
+    // }
+
+    auto resultVector = evaluate(
+        "timezone(c0, c1)",
+        makeRowVector(
+            {makeTimestampWithTimeZoneVector(timestamp.value(), timeZoneName.value().c_str()),
+            makeNullableFlatVector<std::string>({newTimeZoneName})}));
+
     EXPECT_EQ(1, resultVector->size());
 
     if (resultVector->isNullAt(0)) {
@@ -971,41 +1003,74 @@ TEST_F(DateTimeFunctionsTest, minusTimestamp) {
       "Could not convert Timestamp(-9223372036854776, 0) to milliseconds");
 }
 
-TEST_F(DateTimeFunctionsTest, timestampAtTimezoneTest) {
-  // GMT -06:00, -21600 sec
+TEST_F(DateTimeFunctionsTest, timestampAtTimezoneTestTimestampInput) {
+
+  setQueryTimeZone("America/New_York");
+  // New York = GMT -04:00, -14400 sec
   EXPECT_EQ(
       TimestampWithTimezone(
-          1500101514 - 21600, util::getTimeZoneID("America/Boise")),
+          1500101514 - 14400, util::getTimeZoneID("America/Boise")),
       timestampAtTimezone(Timestamp(1500101514, 0), "America/Boise"));
 
-  // GMT +03:00, +10800 sec
-  EXPECT_EQ(
-      TimestampWithTimezone(
-          1500101514 + 10800, util::getTimeZoneID("Asia/Baghdad")),
-      timestampAtTimezone(Timestamp(1500101514, 0), "Asia/Baghdad"));
+//   // GMT +03:00, +10800 sec
+//   EXPECT_EQ(
+//       TimestampWithTimezone(
+//           1500101514 + 10800, util::getTimeZoneID("Asia/Baghdad")),
+//       timestampAtTimezone(Timestamp(1500101514, 0), "Asia/Baghdad"));
 
-  // GMT +0:00
-  EXPECT_EQ(
-      TimestampWithTimezone(1500101514, util::getTimeZoneID("Africa/Bamako")),
-      timestampAtTimezone(Timestamp(1500101514, 0), "Africa/Bamako"));
+//   // GMT +0:00
+//   EXPECT_EQ(
+//       TimestampWithTimezone(1500101514, util::getTimeZoneID("Africa/Bamako")),
+//       timestampAtTimezone(Timestamp(1500101514, 0), "Africa/Bamako"));
 
-  // GMT -07:00, -25200 sec
-  EXPECT_EQ(
-      TimestampWithTimezone(
-          1513299114 - 25200, util::getTimeZoneID("America/Boise")),
-      timestampAtTimezone(Timestamp(1513299114, 0), "America/Boise"));
+//   // GMT -07:00, -25200 sec
+//   EXPECT_EQ(
+//       TimestampWithTimezone(
+//           1513299114 - 25200, util::getTimeZoneID("America/Boise")),
+//       timestampAtTimezone(Timestamp(1513299114, 0), "America/Boise"));
 
-  // GMT +01:00, +3600 sec
-  EXPECT_EQ(
-      TimestampWithTimezone(
-          507034293 + 3600, util::getTimeZoneID("Europe/Prague")),
-      timestampAtTimezone(Timestamp(507034293, 0), "Europe/Prague"));
+//   // GMT +01:00, +3600 sec
+//   EXPECT_EQ(
+//       TimestampWithTimezone(
+//           507034293 + 3600, util::getTimeZoneID("Europe/Prague")),
+//       timestampAtTimezone(Timestamp(507034293, 0), "Europe/Prague"));
 
-  // GMT +05:45, +20700 sec
+//   // GMT +05:45, +20700 sec
+//   EXPECT_EQ(
+//       TimestampWithTimezone(
+//           75325423914 + 20700, util::getTimeZoneID("Asia/Kathmandu")),
+//       timestampAtTimezone(Timestamp(75325423914, 0), "Asia/Kathmandu"));
+}
+
+TEST_F(DateTimeFunctionsTest, timestampAtTimezoneTestTimestampWithTimezoneInput) {
+
+//   EXPECT_EQ(
+//       TimestampWithTimezone(1500101514, util::getTimeZoneID("America/Boise")),
+//       timestampAtTimezone(
+//             TimestampWithTimezone(1500101514, util::getTimeZoneID("Asia/Kathmandu")), 
+//                                     "America/Boise"));
+
+//   EXPECT_EQ(
+//       1973,
+//       evaluateWithTimestampWithTimezone<int64_t>(
+//           "year(c0)", 123456789000, "+14:00"));
+
   EXPECT_EQ(
-      TimestampWithTimezone(
-          75325423914 + 20700, util::getTimeZoneID("Asia/Kathmandu")),
-      timestampAtTimezone(Timestamp(75325423914, 0), "Asia/Kathmandu"));
+      TimestampWithTimezone(1500101514, util::getTimeZoneID("America/Boise")),
+      evaluateWithTimestampWithTimezone2(1500101514, "Asia/Kathmandu", "America/Boise")
+      );
+
+  EXPECT_EQ(
+      TimestampWithTimezone(1500101514, util::getTimeZoneID("Europe/London")),
+      evaluateWithTimestampWithTimezone2(1500101514, "Asia/Kathmandu", "Europe/London")
+      );
+
+  // should fail
+  EXPECT_EQ(
+      TimestampWithTimezone(1500101514, util::getTimeZoneID("Europe/London")),
+      evaluateWithTimestampWithTimezone2(1500101513, "Asia/Kathmandu", "Europe/London")
+      );
+
 }
 
 TEST_F(DateTimeFunctionsTest, dayOfMonthTimestampWithTimezone) {

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -140,26 +140,26 @@ class DateTimeFunctionsTest : public functions::test::FunctionBaseTest {
         rowVector->children()[0]->as<SimpleVector<int64_t>>()->valueAt(0),
         rowVector->children()[1]->as<SimpleVector<int16_t>>()->valueAt(0)};
   }
-  
+
   std::optional<TimestampWithTimezone> timestampWithTimezoneAtTimezone(
       std::optional<int64_t> timestamp,
       const std::optional<std::string>& timeZoneName,
       const std::optional<std::string>& newTimeZoneName) {
-
-        facebook::velox::VectorPtr resultVector;
+    facebook::velox::VectorPtr resultVector;
     if (!timestamp.has_value() || !timeZoneName.has_value()) {
-        resultVector = evaluate(
-        "at_timezone(c0, c1)",
-        makeRowVector(
-            {BaseVector::createNullConstant(
-              TIMESTAMP_WITH_TIME_ZONE(), 1, pool()),
-            makeNullableFlatVector<std::string>({newTimeZoneName})}));
+      resultVector = evaluate(
+          "at_timezone(c0, c1)",
+          makeRowVector(
+              {BaseVector::createNullConstant(
+                   TIMESTAMP_WITH_TIME_ZONE(), 1, pool()),
+               makeNullableFlatVector<std::string>({newTimeZoneName})}));
     } else {
-        resultVector = evaluate(
-        "at_timezone(c0, c1)",
-        makeRowVector(
-            {makeTimestampWithTimeZoneVector(timestamp.value(), timeZoneName.value().c_str()),
-            makeNullableFlatVector<std::string>({newTimeZoneName})}));
+      resultVector = evaluate(
+          "at_timezone(c0, c1)",
+          makeRowVector(
+              {makeTimestampWithTimeZoneVector(
+                   timestamp.value(), timeZoneName.value().c_str()),
+               makeNullableFlatVector<std::string>({newTimeZoneName})}));
     }
 
     EXPECT_EQ(1, resultVector->size());
@@ -1006,7 +1006,6 @@ TEST_F(DateTimeFunctionsTest, minusTimestamp) {
 }
 
 TEST_F(DateTimeFunctionsTest, timestampAtTimezoneTestTimestampInput) {
-
   setQueryTimeZone("America/New_York");
   // New York = GMT -04:00, -14400 sec
   EXPECT_EQ(
@@ -1014,65 +1013,67 @@ TEST_F(DateTimeFunctionsTest, timestampAtTimezoneTestTimestampInput) {
           1500101514 - 14400, util::getTimeZoneID("America/Boise")),
       timestampAtTimezone(Timestamp(1500101514, 0), "America/Boise"));
 
-//   // GMT +03:00, +10800 sec
-//   EXPECT_EQ(
-//       TimestampWithTimezone(
-//           1500101514 + 10800, util::getTimeZoneID("Asia/Baghdad")),
-//       timestampAtTimezone(Timestamp(1500101514, 0), "Asia/Baghdad"));
+  //   // GMT +03:00, +10800 sec
+  //   EXPECT_EQ(
+  //       TimestampWithTimezone(
+  //           1500101514 + 10800, util::getTimeZoneID("Asia/Baghdad")),
+  //       timestampAtTimezone(Timestamp(1500101514, 0), "Asia/Baghdad"));
 
-//   // GMT +0:00
-//   EXPECT_EQ(
-//       TimestampWithTimezone(1500101514, util::getTimeZoneID("Africa/Bamako")),
-//       timestampAtTimezone(Timestamp(1500101514, 0), "Africa/Bamako"));
+  //   // GMT +0:00
+  //   EXPECT_EQ(
+  //       TimestampWithTimezone(1500101514,
+  //       util::getTimeZoneID("Africa/Bamako")),
+  //       timestampAtTimezone(Timestamp(1500101514, 0), "Africa/Bamako"));
 
-//   // GMT -07:00, -25200 sec
-//   EXPECT_EQ(
-//       TimestampWithTimezone(
-//           1513299114 - 25200, util::getTimeZoneID("America/Boise")),
-//       timestampAtTimezone(Timestamp(1513299114, 0), "America/Boise"));
+  //   // GMT -07:00, -25200 sec
+  //   EXPECT_EQ(
+  //       TimestampWithTimezone(
+  //           1513299114 - 25200, util::getTimeZoneID("America/Boise")),
+  //       timestampAtTimezone(Timestamp(1513299114, 0), "America/Boise"));
 
-//   // GMT +01:00, +3600 sec
-//   EXPECT_EQ(
-//       TimestampWithTimezone(
-//           507034293 + 3600, util::getTimeZoneID("Europe/Prague")),
-//       timestampAtTimezone(Timestamp(507034293, 0), "Europe/Prague"));
+  //   // GMT +01:00, +3600 sec
+  //   EXPECT_EQ(
+  //       TimestampWithTimezone(
+  //           507034293 + 3600, util::getTimeZoneID("Europe/Prague")),
+  //       timestampAtTimezone(Timestamp(507034293, 0), "Europe/Prague"));
 
-//   // GMT +05:45, +20700 sec
-//   EXPECT_EQ(
-//       TimestampWithTimezone(
-//           75325423914 + 20700, util::getTimeZoneID("Asia/Kathmandu")),
-//       timestampAtTimezone(Timestamp(75325423914, 0), "Asia/Kathmandu"));
+  //   // GMT +05:45, +20700 sec
+  //   EXPECT_EQ(
+  //       TimestampWithTimezone(
+  //           75325423914 + 20700, util::getTimeZoneID("Asia/Kathmandu")),
+  //       timestampAtTimezone(Timestamp(75325423914, 0), "Asia/Kathmandu"));
 }
 
-TEST_F(DateTimeFunctionsTest, timestampAtTimezoneTestTimestampWithTimezoneInput) {
+TEST_F(
+    DateTimeFunctionsTest,
+    timestampAtTimezoneTestTimestampWithTimezoneInput) {
+  //   EXPECT_EQ(
+  //       TimestampWithTimezone(1500101514,
+  //       util::getTimeZoneID("America/Boise")), timestampAtTimezone(
+  //             TimestampWithTimezone(1500101514,
+  //             util::getTimeZoneID("Asia/Kathmandu")),
+  //                                     "America/Boise"));
 
-//   EXPECT_EQ(
-//       TimestampWithTimezone(1500101514, util::getTimeZoneID("America/Boise")),
-//       timestampAtTimezone(
-//             TimestampWithTimezone(1500101514, util::getTimeZoneID("Asia/Kathmandu")), 
-//                                     "America/Boise"));
-
-//   EXPECT_EQ(
-//       1973,
-//       evaluateWithTimestampWithTimezone<int64_t>(
-//           "year(c0)", 123456789000, "+14:00"));
+  //   EXPECT_EQ(
+  //       1973,
+  //       evaluateWithTimestampWithTimezone<int64_t>(
+  //           "year(c0)", 123456789000, "+14:00"));
 
   EXPECT_EQ(
       TimestampWithTimezone(1500101514, util::getTimeZoneID("America/Boise")),
-      timestampWithTimezoneAtTimezone(1500101514, "Asia/Kathmandu", "America/Boise")
-      );
+      timestampWithTimezoneAtTimezone(
+          1500101514, "Asia/Kathmandu", "America/Boise"));
 
   EXPECT_EQ(
       TimestampWithTimezone(1500101514, util::getTimeZoneID("Europe/London")),
-      timestampWithTimezoneAtTimezone(1500101514, "Asia/Kathmandu", "Europe/London")
-      );
+      timestampWithTimezoneAtTimezone(
+          1500101514, "Asia/Kathmandu", "Europe/London"));
 
   // should fail
   EXPECT_EQ(
       TimestampWithTimezone(1500101514, util::getTimeZoneID("Europe/London")),
-      timestampWithTimezoneAtTimezone(1500101513, "Asia/Kathmandu", "Europe/London")
-      );
-
+      timestampWithTimezoneAtTimezone(
+          1500101513, "Asia/Kathmandu", "Europe/London"));
 }
 
 TEST_F(DateTimeFunctionsTest, dayOfMonthTimestampWithTimezone) {

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -1019,7 +1019,7 @@ TEST_F(DateTimeFunctionsTest, timestampAtTimezoneTestTimestampInput) {
           1500101514 + 14400, util::getTimeZoneID("America/Boise")),
       timestampAtTimezone(Timestamp(1500101514, 0), "America/Boise"));
 
-  // New York 2017 = UTC -04:00 = -14400 sec
+   // New York 2017 = UTC -04:00 = -14400 sec
   EXPECT_EQ(
       TimestampWithTimezone(
           1500101514 + 14400, util::getTimeZoneID("Asia/Baghdad")),
@@ -1030,6 +1030,20 @@ TEST_F(DateTimeFunctionsTest, timestampAtTimezoneTestTimestampInput) {
       TimestampWithTimezone(
           1510728714 + 18000, util::getTimeZoneID("Asia/Baghdad")),
       timestampAtTimezone(Timestamp(1510728714, 0), "Asia/Baghdad"));
+
+      // New York 1892 = UTC -4:56:02 = -(14400 + 3360 + 2) sec
+    EXPECT_EQ(
+      TimestampWithTimezone(
+          -2749482486 + 17762, util::getTimeZoneID("Europe/London")),
+      timestampAtTimezone(Timestamp(-2749482486, 0), "Europe/London"));
+
+    setQueryTimeZone("America/Los_Angeles");
+
+    // Los Angeles 1880 = UTC -7:52:58 = -(25200 + 3180 ) = 28378 sec
+    EXPECT_EQ(
+      TimestampWithTimezone(
+          -2938784886 + 28378, util::getTimeZoneID("Europe/London")),
+      timestampAtTimezone(Timestamp(-2938784886, 0), "Europe/London"));
 
   setQueryTimeZone("Asia/Baghdad");
 
@@ -1046,7 +1060,7 @@ TEST_F(DateTimeFunctionsTest, timestampAtTimezoneTestTimestampInput) {
 
   setQueryTimeZone("Africa/Bamako");
 
-  // Africa/Bamako = UTC +0:00
+//   // Africa/Bamako = UTC +0:00
   EXPECT_EQ(
       TimestampWithTimezone(
           1500101514, util::getTimeZoneID("Pacific/Galapagos")),
@@ -1056,12 +1070,12 @@ TEST_F(DateTimeFunctionsTest, timestampAtTimezoneTestTimestampInput) {
 TEST_F(
     DateTimeFunctionsTest,
     timestampAtTimezoneTestTimestampWithTimezoneInput) {
-  //   EXPECT_EQ(
-  //       TimestampWithTimezone(1500101514,
-  //       util::getTimeZoneID("America/Boise")), timestampAtTimezone(
-  //             TimestampWithTimezone(1500101514,
-  //             util::getTimeZoneID("Asia/Kathmandu")),
-  //                                     "America/Boise"));
+    // EXPECT_EQ(
+    //     TimestampWithTimezone(1500101514,
+    //     util::getTimeZoneID("America/Boise")), timestampAtTimezone(
+    //           TimestampWithTimezone(1500101514,
+    //           util::getTimeZoneID("Asia/Kathmandu")),
+    //                                   "America/Boise"));
 
   //   EXPECT_EQ(
   //       1973,


### PR DESCRIPTION
Adding at_timezone ("timestamp at timezone") feature.

```
SELECT timestamp '2012-10-31 01:00 UTC' AT TIME ZONE 'America/Los_Angeles';

2012-10-30 18:00:00.000 America/Los_Angeles
```