### PR TITLE
Improve Type Parser support for types with spaces

### DIFF
--- a/velox/type/parser/CMakeLists.txt
+++ b/velox/type/parser/CMakeLists.txt
@@ -18,7 +18,8 @@ endif()
 
 bison_target(
   TypeParser TypeParser.yy ${CMAKE_CURRENT_BINARY_DIR}/TypeParser.yy.cc
-  DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/TypeParser.yy.h)
+  DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/TypeParser.yy.h
+  COMPILE_FLAGS "-Werror -Wno-deprecated")
 
 flex_target(
   TypeParserScanner TypeParser.ll ${CMAKE_CURRENT_BINARY_DIR}/Scanner.cpp

--- a/velox/type/parser/TypeParser.yy
+++ b/velox/type/parser/TypeParser.yy
@@ -39,7 +39,7 @@
 %token YYEOF         0
 
 %nterm <std::shared_ptr<const Type>> special_type function_type decimal_type row_type array_type map_type variable_type
-%nterm <std::shared_ptr<const Type>> type
+%nterm <std::shared_ptr<const Type>> type single_word_type
 %nterm <RowArguments> type_list_opt_names
 %nterm <std::vector<std::shared_ptr<const Type>>> type_list
 %nterm <std::pair<std::string, std::shared_ptr<const Type>>> named_type
@@ -52,22 +52,27 @@ type_spec : named_type           { scanner->setType($1.second); }
           | error                { yyerrok; }
           ;
 
-named_type : QUOTED_ID type       { $1.erase(0, 1); $1.pop_back(); $$ = std::make_pair($1, $2); }  // Remove the quotes.
+named_type : QUOTED_ID type             { $1.erase(0, 1); $1.pop_back(); $$ = std::make_pair($1, $2); }  // Remove the quotes.
            | QUOTED_ID type_with_spaces { $1.erase(0, 1); $1.pop_back(); auto type = inferTypeWithSpaces($2, true); $$ = std::make_pair($1, type.second); }  // Remove the quotes.
-           | WORD special_type    { $$ = std::make_pair($1, $2); }
-           | type_with_spaces     { $$ = inferTypeWithSpaces($1); }
+           | WORD special_type          { $$ = std::make_pair($1, $2); }
+           | WORD variable_type         { $$ = std::make_pair($1, $2); }
+           | WORD decimal_type          { $$ = std::make_pair($1, $2); }
+           | type_with_spaces           { $$ = inferTypeWithSpaces($1); }
            ;
 
 special_type : array_type                  { $$ = $1; }
              | map_type                    { $$ = $1; }
              | row_type                    { $$ = $1; }
              | function_type               { $$ = $1; }
-             | variable_type               { $$ = $1; }
-             | decimal_type                { $$ = $1; }
              ;
 
-type : special_type    { $$ = $1; }
-     | WORD            { $$ = typeFromString($1); }
+single_word_type : WORD          { $$ = typeFromString($1); }
+                 | variable_type { $$ = $1; }
+                 | decimal_type                { $$ = $1; }
+
+type : special_type     { $$ = $1; }
+     | single_word_type { $$ = $1; }
+     ;
 
 type_with_spaces : type_with_spaces WORD { $1.push_back($2); $$ = std::move($1); }
                  | WORD WORD             { $$.push_back($1); $$.push_back($2); }
@@ -76,9 +81,6 @@ type_with_spaces : type_with_spaces WORD { $1.push_back($2); $$ = std::move($1);
 variable_type : VARIABLE LPAREN NUMBER RPAREN  { $$ = typeFromString($1); }
               | VARIABLE                       { $$ = typeFromString($1); }
               ;
-
-array_type : ARRAY LPAREN type RPAREN { $$ = ARRAY($3); }
-           ;
 
 decimal_type : DECIMAL LPAREN NUMBER COMMA NUMBER RPAREN { $$ = DECIMAL($3, $5); }
              ;
@@ -98,7 +100,15 @@ type_list_opt_names : type_list_opt_names COMMA named_type { $1.names.push_back(
 row_type : ROW LPAREN type_list_opt_names RPAREN  { $$ = ROW(std::move($3.names), std::move($3.types)); }
          ;
 
-map_type : MAP LPAREN type COMMA type RPAREN { $$ = MAP($3, $5); }
+array_type : ARRAY LPAREN type RPAREN             { $$ = ARRAY($3); }
+           | ARRAY LPAREN type_with_spaces RPAREN { $$ = ARRAY(inferTypeWithSpaces($3, true).second); }
+           ;
+
+map_type : MAP LPAREN single_word_type COMMA type RPAREN             { $$ = MAP($3, $5); }
+         | MAP LPAREN single_word_type COMMA type_with_spaces RPAREN { $$ = MAP($3, inferTypeWithSpaces($5, true).second); }
+         | MAP LPAREN type_with_spaces COMMA type RPAREN             { $$ = MAP(inferTypeWithSpaces($3, true).second, $5); }
+         | MAP LPAREN type_with_spaces COMMA type_with_spaces RPAREN { $$ = MAP(inferTypeWithSpaces($3, true).second,
+                                                                                inferTypeWithSpaces($5, true).second); }
          ;
 
 function_type : FUNCTION LPAREN type_list RPAREN { auto returnType = $3.back(); $3.pop_back();

--- a/velox/type/parser/tests/TypeParserTest.cpp
+++ b/velox/type/parser/tests/TypeParserTest.cpp
@@ -96,17 +96,43 @@ TEST_F(TestTypeSignature, arrayType) {
   ASSERT_EQ(*parseType("array(array(bigint))"), *ARRAY(ARRAY(BIGINT())));
 
   ASSERT_EQ(*parseType("array(array(int))"), *ARRAY(ARRAY(INTEGER())));
+
+  ASSERT_EQ(
+      *parseType("array(timestamp with time zone)"),
+      *ARRAY(TIMESTAMP_WITH_TIME_ZONE()));
+
+  ASSERT_EQ(*parseType("array(DECIMAL(10,5))"), *ARRAY(DECIMAL(10, 5)));
 }
 
 TEST_F(TestTypeSignature, mapType) {
   ASSERT_EQ(*parseType("map(bigint,bigint)"), *MAP(BIGINT(), BIGINT()));
 
   ASSERT_EQ(
+      *parseType("map(timestamp with time zone,bigint)"),
+      *MAP(TIMESTAMP_WITH_TIME_ZONE(), BIGINT()));
+
+  ASSERT_EQ(
+      *parseType("map(timestamp with time zone, timestamp with time zone)"),
+      *MAP(TIMESTAMP_WITH_TIME_ZONE(), TIMESTAMP_WITH_TIME_ZONE()));
+
+  ASSERT_EQ(
+      *parseType("map(json, timestamp with time zone)"),
+      *MAP(JSON(), TIMESTAMP_WITH_TIME_ZONE()));
+
+  ASSERT_EQ(
       *parseType("map(bigint,array(bigint))"), *MAP(BIGINT(), ARRAY(BIGINT())));
+
+  ASSERT_EQ(
+      *parseType("map(timestamp with time zone, varchar)"),
+      *MAP(TIMESTAMP_WITH_TIME_ZONE(), VARCHAR()));
 
   ASSERT_EQ(
       *parseType("map(bigint,map(bigint,map(varchar,bigint)))"),
       *MAP(BIGINT(), MAP(BIGINT(), MAP(VARCHAR(), BIGINT()))));
+
+  ASSERT_EQ(
+      *parseType("maP(DECIMAL(10,5), DECIMAL(20, 4))"),
+      *MAP(DECIMAL(10, 5), DECIMAL(20, 4)));
 }
 
 TEST_F(TestTypeSignature, invalidType) {
@@ -131,10 +157,14 @@ TEST_F(TestTypeSignature, rowType) {
       *ROW({"a", "b", "c"}, {BIGINT(), VARCHAR(), REAL()}));
 
   ASSERT_EQ(
-      *parseType("row(a bigint,b array(bigint),c row(a bigint))"),
+      *parseType("row(a timestamp with time zone,b json,c real)"),
+      *ROW({"a", "b", "c"}, {TIMESTAMP_WITH_TIME_ZONE(), JSON(), REAL()}));
+
+  ASSERT_EQ(
+      *parseType("row(a bigint,b array(bigint),c row(a decimal(10,5)))"),
       *ROW(
           {"a", "b", "c"},
-          {BIGINT(), ARRAY(BIGINT()), ROW({"a"}, {BIGINT()})}));
+          {BIGINT(), ARRAY(BIGINT()), ROW({"a"}, {DECIMAL(10, 5)})}));
 
   // Quoted field name starting with number and scalar type.
   ASSERT_EQ(


### PR DESCRIPTION
Add missing support for types with spaces as row, array, and map fields