### PR TITLE
Do not use system curl to build cpr

### DIFF
--- a/CMake/resolve_dependency_modules/cpr.cmake
+++ b/CMake/resolve_dependency_modules/cpr.cmake
@@ -30,5 +30,5 @@ FetchContent_Declare(
   PATCH_COMMAND git apply
                 ${CMAKE_CURRENT_LIST_DIR}/cpr/cpr-libcurl-compatible.patch)
 set(BUILD_SHARED_LIBS OFF)
-set(CPR_USE_SYSTEM_CURL ON)
+set(CPR_USE_SYSTEM_CURL OFF)
 FetchContent_MakeAvailable(cpr)


### PR DESCRIPTION
In #7385 we introduced `libcpr` to Velox. It set `CPR_USE_SYSTEM_CURL`
true, and it may cause a construction issue if the host installed a lower version curl.
This PR disables this flag to force the use of bundled curl in `libcpr`, to avoid
the potential curl version issues, and make the dependencies version more
accurate and controllable and isolated from the state of the host machine.

Also, see the blog https://velox-lib.io/blog/velox-build-experience.
