### PR TITLE
Fix SparkAggregationFuzzer failure for 'first' aggregate function

### DIFF
--- a/velox/functions/lib/aggregates/SingleValueAccumulator.cpp
+++ b/velox/functions/lib/aggregates/SingleValueAccumulator.cpp
@@ -38,7 +38,10 @@ void SingleValueAccumulator::write(
 
 void SingleValueAccumulator::read(const VectorPtr& vector, vector_size_t index)
     const {
-  VELOX_CHECK_NOT_NULL(start_.header);
+  if (start_.header == nullptr) {
+    // Nothing needs to be done because hasValue() returns false.
+    return;
+  }
 
   auto stream = HashStringAllocator::prepareRead(start_.header);
   exec::ContainerRowSerde::deserialize(stream, index, vector.get());

--- a/velox/functions/sparksql/aggregates/FirstLastAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/FirstLastAggregate.cpp
@@ -195,7 +195,8 @@ class FirstAggregate : public FirstLastAggregateBase<numeric, TData> {
     this->decodedValue_.decode(*args[0], rows);
 
     rows.testSelected([&](vector_size_t i) {
-      return updateValue(i, group, this->decodedValue_);
+      return updateValue(
+          i, group, this->decodedValue_, true /*ignoreExisting*/);
     });
   }
 
@@ -243,9 +244,10 @@ class FirstAggregate : public FirstLastAggregateBase<numeric, TData> {
   bool updateValue(
       vector_size_t index,
       char* group,
-      const DecodedVector& decodedVector) {
+      const DecodedVector& decodedVector,
+      bool ignoreExisting = false) {
     auto accumulator = Aggregate::value<TAccumulator>(group);
-    if (accumulator->has_value()) {
+    if (!ignoreExisting && accumulator->has_value()) {
       return false;
     }
 


### PR DESCRIPTION
Fixes `start_.header != nullptr` exception.

Tested with below command.
> ./spark_aggregation_fuzzer_test --logtostderr --log_signature_stats --only first --duration_sec 60 --enable_sorted_aggregations
> 
```
I1124 14:40:25.552326 698033 AggregationFuzzer.cpp:976] ==============================> Done with iteration 147
I1124 14:40:25.552357 698033 AggregationFuzzer.cpp:1714] Total functions tested: 1
I1124 14:40:25.552369 698033 AggregationFuzzer.cpp:1715] Total masked aggregations: 15 (10.14%)
I1124 14:40:25.552386 698033 AggregationFuzzer.cpp:1717] Total global aggregations: 10 (6.76%)
I1124 14:40:25.552399 698033 AggregationFuzzer.cpp:1719] Total group-by aggregations: 106 (71.62%)
I1124 14:40:25.552412 698033 AggregationFuzzer.cpp:1721] Total distinct aggregations: 16 (10.81%)
I1124 14:40:25.552424 698033 AggregationFuzzer.cpp:1723] Total aggregations over sorted inputs: 19 (12.84%)
I1124 14:40:25.552438 698033 AggregationFuzzer.cpp:1725] Total window expressions: 16 (10.81%)
I1124 14:40:25.552450 698033 AggregationFuzzer.cpp:1727] Total aggregations verified against reference DB: 16 (10.81%)
I1124 14:40:25.552462 698033 AggregationFuzzer.cpp:1729] Total aggregations not verified (non-deterministic function / not supported by reference DB / reference DB failed): 113 (76.35%) / 16 (10.81%) / 3 (2.03%)
I1124 14:40:25.552479 698033 AggregationFuzzer.cpp:1734] Total failed aggregations: 0 (0.00%)
```