### PR TITLE
Remove DuckDB version inference via git

### DIFF
--- a/CMake/resolve_dependency_modules/duckdb.cmake
+++ b/CMake/resolve_dependency_modules/duckdb.cmake
@@ -24,12 +24,16 @@ resolve_dependency_url(DUCKDB)
 
 message(STATUS "Building DuckDB from source")
 # We need remove-ccache.patch to remove adding ccache to the build command
-# twice. Velox already does this.
+# twice. Velox already does this. We need fix-duckdbversion.patch as DuckDB
+# tries to infer the version via a git commit hash or git tag. This inference
+# can lead to errors when building in another git project such as Prestissimo.
 FetchContent_Declare(
   duckdb
   URL ${VELOX_DUCKDB_SOURCE_URL}
   URL_HASH ${VELOX_DUCKDB_BUILD_SHA256_CHECKSUM}
-  PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/duckdb/remove-ccache.patch)
+  PATCH_COMMAND
+    git apply ${CMAKE_CURRENT_LIST_DIR}/duckdb/remove-ccache.patch && git apply
+    ${CMAKE_CURRENT_LIST_DIR}/duckdb/fix-duckdbversion.patch)
 
 set(BUILD_UNITTESTS OFF)
 set(ENABLE_SANITIZER OFF)

--- a/CMake/resolve_dependency_modules/duckdb/fix-duckdbversion.patch
+++ b/CMake/resolve_dependency_modules/duckdb/fix-duckdbversion.patch
@@ -1,0 +1,59 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -210,56 +210,8 @@
+   set(CXX_EXTRA "${CXX_EXTRA} -mimpure-text")
+   add_definitions(-DSUN=1)
+   set(SUN TRUE)
+-endif()
+-
+-find_package(Git)
+-if(Git_FOUND)
+-  if (NOT DEFINED GIT_COMMIT_HASH)
+-    execute_process(
+-            COMMAND ${GIT_EXECUTABLE} log -1 --format=%h
+-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+-            RESULT_VARIABLE GIT_RESULT
+-            OUTPUT_VARIABLE GIT_COMMIT_HASH
+-            OUTPUT_STRIP_TRAILING_WHITESPACE)
+-  endif()
+-  execute_process(
+-          COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0
+-          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+-          OUTPUT_VARIABLE GIT_LAST_TAG
+-          OUTPUT_STRIP_TRAILING_WHITESPACE)
+-  execute_process(
+-          COMMAND ${GIT_EXECUTABLE} describe --tags --long
+-          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+-          OUTPUT_VARIABLE GIT_ITERATION
+-          OUTPUT_STRIP_TRAILING_WHITESPACE)
+-else()
+-  message("Git NOT FOUND")
+-endif()
+-
+-if(GIT_RESULT EQUAL "0")
+-  string(REGEX REPLACE "v([0-9]+).[0-9]+.[0-9]+" "\\1" DUCKDB_MAJOR_VERSION "${GIT_LAST_TAG}")
+-  string(REGEX REPLACE "v[0-9]+.([0-9]+).[0-9]+" "\\1" DUCKDB_MINOR_VERSION "${GIT_LAST_TAG}")
+-  string(REGEX REPLACE "v[0-9]+.[0-9]+.([0-9]+)" "\\1" DUCKDB_PATCH_VERSION "${GIT_LAST_TAG}")
+-  string(REGEX REPLACE ".*-([0-9]+)-.*" "\\1" DUCKDB_DEV_ITERATION "${GIT_ITERATION}")
+-
+-  if(DUCKDB_DEV_ITERATION EQUAL 0)
+-    # on a tag; directly use the version
+-    set(DUCKDB_VERSION "${GIT_LAST_TAG}")
+-  else()
+-    # not on a tag, increment the patch version by one and add a -devX suffix
+-    math(EXPR DUCKDB_PATCH_VERSION "${DUCKDB_PATCH_VERSION}+1")
+-    set(DUCKDB_VERSION "v${DUCKDB_MAJOR_VERSION}.${DUCKDB_MINOR_VERSION}.${DUCKDB_PATCH_VERSION}-dev${DUCKDB_DEV_ITERATION}")
+-  endif()
+-else()
+-  # fallback for when building from tarball
+-  set(DUCKDB_MAJOR_VERSION 0)
+-  set(DUCKDB_MINOR_VERSION 0)
+-  set(DUCKDB_PATCH_VERSION 1)
+-  set(DUCKDB_DEV_ITERATION 0)
+-  set(DUCKDB_VERSION "v${DUCKDB_MAJOR_VERSION}.${DUCKDB_MINOR_VERSION}.${DUCKDB_PATCH_VERSION}-dev${DUCKDB_DEV_ITERATION}")
+ endif()
+ 
+-message(STATUS "git hash ${GIT_COMMIT_HASH}, version ${DUCKDB_VERSION}")
+ 
+ option(AMALGAMATION_BUILD
+        "Build from the amalgamation files, rather than from the normal sources."


### PR DESCRIPTION
DuckDB tries to infer the version via a git commit hash or git tag.
This inference can lead to errors when building in another git project such as Prestissimo.
```
-- Found Git: /usr/bin/git (found version "2.31.1") 
CMake Error at _build/release/_deps/duckdb-src/CMakeLists.txt:250 (math):
  math cannot parse the expression: "0.285+1": syntax error, unexpected
  exp_NUMBER, expecting $end (6).


-- git hash 4337073287, version v0.285.0.285.ERROR-dev25
```
