### PR TITLE
Move duckdb compile before re2 and fmt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,6 +421,11 @@ else()
 endif()
 resolve_dependency(glog)
 
+if(${VELOX_ENABLE_DUCKDB})
+  set_source(DuckDB)
+  resolve_dependency(DuckDB)
+endif()
+
 set_source(fmt)
 resolve_dependency(fmt)
 
@@ -527,11 +532,6 @@ if(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
 endif()
 find_package(BISON 3.0.4 REQUIRED)
 find_package(FLEX 2.5.13 REQUIRED)
-
-if(${VELOX_ENABLE_DUCKDB})
-  set_source(DuckDB)
-  resolve_dependency(DuckDB)
-endif()
 
 include_directories(SYSTEM velox)
 include_directories(SYSTEM velox/external)


### PR DESCRIPTION
After DuckDB upgrade (PR #6725) we see build errors:

```
/opt/gluten/ep/build-velox/build/velox_ep/_build/release/_deps/duckdb-src/src/planner/binder/expression/bind_star_expression.cpp:123:4: error: 'duckdb_re2' has not been declared
  123 |    duckdb_re2::RE2 regex(regex_str);
      |    ^~~~~~~~~~
```

If we compile re2 and fmt before DuckDB, there will cause dependency conflict. 

A fix is to compile DuckDB before re2 and fmt.