### PR TITLE
Split spill file r/w and use operator pool for spill read

### DIFF
--- a/velox/common/base/SpillStats.cpp
+++ b/velox/common/base/SpillStats.cpp
@@ -238,12 +238,11 @@ void updateGlobalSpillSortTime(uint64_t timeUs) {
 }
 
 void updateGlobalSpillWriteStats(
-    uint32_t numDiskWrites,
     uint64_t spilledBytes,
     uint64_t flushTimeUs,
     uint64_t writeTimeUs) {
   auto statsLocked = localSpillStats().wlock();
-  statsLocked->spillDiskWrites += numDiskWrites;
+  ++statsLocked->spillDiskWrites;
   statsLocked->spilledBytes += spilledBytes;
   statsLocked->spillFlushTimeUs += flushTimeUs;
   statsLocked->spillWriteTimeUs += writeTimeUs;

--- a/velox/common/base/SpillStats.h
+++ b/velox/common/base/SpillStats.h
@@ -121,7 +121,6 @@ void updateGlobalSpillSortTime(uint64_t timeUs);
 /// the written bytes, the time spent on copying out (compression) for disk
 /// writes, the time spent on disk writes.
 void updateGlobalSpillWriteStats(
-    uint32_t numDiskWrites,
     uint64_t spilledBytes,
     uint64_t flushTimeUs,
     uint64_t writeTimeUs);

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -64,6 +64,7 @@ add_library(
   SortedAggregations.cpp
   SortWindowBuild.cpp
   Spill.cpp
+  SpillFile.cpp
   SpillOperatorGroup.cpp
   Spiller.cpp
   StreamingAggregation.cpp

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1034,7 +1034,7 @@ bool GroupingSet::getOutputWithSpill(
 
     VELOX_CHECK_NULL(merge_);
     auto spillPartition = spiller_->finishSpill();
-    merge_ = spillPartition.createOrderedReader();
+    merge_ = spillPartition.createOrderedReader(&pool_);
   }
   VELOX_CHECK_EQ(spiller_->state().maxPartitions(), 1);
   if (merge_ == nullptr) {

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -198,6 +198,7 @@ void HashBuild::setupSpiller(SpillPartition* spillPartition) {
   if (!spillEnabled()) {
     return;
   }
+
   const auto& spillConfig = spillConfig_.value();
   HashBitRange hashBits(
       spillConfig.startPartitionBit,
@@ -211,7 +212,8 @@ void HashBuild::setupSpiller(SpillPartition* spillPartition) {
     LOG(INFO) << "Setup reader to read spilled input from "
               << spillPartition->toString()
               << ", memory pool: " << pool()->name();
-    spillInputReader_ = spillPartition->createUnorderedReader();
+
+    spillInputReader_ = spillPartition->createUnorderedReader(pool());
 
     const auto startBit = spillPartition->id().partitionBitOffset() +
         spillConfig.joinPartitionBits;

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -233,7 +233,7 @@ void HashProbe::maybeSetupSpillInput(
     VELOX_CHECK(iter != spillPartitionSet_.end());
     auto partition = std::move(iter->second);
     VELOX_CHECK_EQ(partition->id(), restoredPartitionId.value());
-    spillInputReader_ = partition->createUnorderedReader();
+    spillInputReader_ = partition->createUnorderedReader(pool());
     spillPartitionSet_.erase(iter);
   }
 

--- a/velox/exec/Limit.cpp
+++ b/velox/exec/Limit.cpp
@@ -42,7 +42,7 @@ bool Limit::needsInput() const {
 }
 
 void Limit::addInput(RowVectorPtr input) {
-  VELOX_CHECK(input_ == nullptr);
+  VELOX_CHECK_NULL(input_);
   input_ = input;
 }
 
@@ -61,10 +61,11 @@ RowVectorPtr Limit::getOutput() {
 
   if (remainingOffset_ > 0) {
     // Return a subset of input_ rows.
-    auto outputSize = std::min(inputSize - remainingOffset_, remainingLimit_);
+    const auto outputSize =
+        std::min(inputSize - remainingOffset_, remainingLimit_);
 
     BufferPtr indices = allocateIndices(outputSize, pool());
-    auto rawIndices = indices->asMutable<vector_size_t>();
+    auto* rawIndices = indices->asMutable<vector_size_t>();
     std::iota(rawIndices, rawIndices + outputSize, remainingOffset_);
 
     auto output = fillOutput(outputSize, indices);

--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -133,12 +133,12 @@ void RowNumber::restoreNextSpillPartition() {
   }
 
   auto it = spillInputPartitionSet_.begin();
-  spillInputReader_ = it->second->createUnorderedReader();
+  spillInputReader_ = it->second->createUnorderedReader(pool());
 
   // Find matching partition for the hash table.
   auto hashTableIt = spillHashTablePartitionSet_.find(it->first);
   if (hashTableIt != spillHashTablePartitionSet_.end()) {
-    spillHashTableReader_ = hashTableIt->second->createUnorderedReader();
+    spillHashTableReader_ = hashTableIt->second->createUnorderedReader(pool());
 
     RowVectorPtr data;
     while (spillHashTableReader_->nextBatch(data)) {

--- a/velox/exec/SortBuffer.cpp
+++ b/velox/exec/SortBuffer.cpp
@@ -137,7 +137,7 @@ void SortBuffer::noMoreInput() {
     // there is only one hash partition for SortBuffer.
     VELOX_CHECK_NULL(spillMerger_);
     auto spillPartition = spiller_->finishSpill();
-    spillMerger_ = spillPartition.createOrderedReader();
+    spillMerger_ = spillPartition.createOrderedReader(pool());
   }
 }
 

--- a/velox/exec/SortWindowBuild.cpp
+++ b/velox/exec/SortWindowBuild.cpp
@@ -47,7 +47,9 @@ SortWindowBuild::SortWindowBuild(
     : WindowBuild(node, pool, spillConfig, nonReclaimableSection),
       numPartitionKeys_{node->partitionKeys().size()},
       spillCompareFlags_{
-          makeSpillCompareFlags(numPartitionKeys_, node->sortingOrders())} {
+          makeSpillCompareFlags(numPartitionKeys_, node->sortingOrders())},
+      pool_(pool) {
+  VELOX_CHECK_NOT_NULL(pool_);
   allKeyInfo_.reserve(partitionKeyInfo_.size() + sortKeyInfo_.size());
   allKeyInfo_.insert(
       allKeyInfo_.cend(), partitionKeyInfo_.begin(), partitionKeyInfo_.end());
@@ -213,7 +215,7 @@ void SortWindowBuild::noMoreInput() {
 
     VELOX_CHECK_NULL(merge_);
     auto spillPartition = spiller_->finishSpill();
-    merge_ = spillPartition.createOrderedReader();
+    merge_ = spillPartition.createOrderedReader(pool_);
   } else {
     // At this point we have seen all the input rows. The operator is
     // being prepared to output rows now.

--- a/velox/exec/SortWindowBuild.h
+++ b/velox/exec/SortWindowBuild.h
@@ -81,6 +81,8 @@ class SortWindowBuild : public WindowBuild {
   // Used to sort 'data_' while spilling.
   const std::vector<CompareFlags> spillCompareFlags_;
 
+  memory::MemoryPool* const pool_;
+
   // allKeyInfo_ is a combination of (partitionKeyInfo_ and sortKeyInfo_).
   // It is used to perform a full sorting of the input rows to be able to
   // separate partitions and sort the rows in it. The rows are output in

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -23,24 +23,6 @@
 using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::exec {
-namespace {
-// Spilling currently uses the default PrestoSerializer which by default
-// serializes timestamp with millisecond precision to maintain compatibility
-// with presto. Since velox's native timestamp implementation supports
-// nanosecond precision, we use this serde option to ensure the serializer
-// preserves precision.
-static const bool kDefaultUseLosslessTimestamp = true;
-} // namespace
-std::atomic<int32_t> SpillFile::ordinalCounter_;
-
-void SpillInput::next(bool /*throwIfPastEnd*/) {
-  int32_t readBytes = std::min(input_->size() - offset_, buffer_->capacity());
-  VELOX_CHECK_LT(0, readBytes, "Reading past end of spill file");
-  setRange({buffer_->asMutable<uint8_t>(), readBytes, 0});
-  input_->pread(offset_, readBytes, buffer_->asMutable<char>());
-  offset_ += readBytes;
-}
-
 void SpillMergeStream::pop() {
   if (++index_ >= size_) {
     setNextBatch();
@@ -64,7 +46,7 @@ int32_t SpillMergeStream::compare(const MergeStream& other) const {
       if (result != 0) {
         return result;
       }
-    } while (++key < numSortingKeys());
+    } while (++key < numSortKeys());
   } else {
     do {
       auto result = children[key]
@@ -77,228 +59,16 @@ int32_t SpillMergeStream::compare(const MergeStream& other) const {
       if (result != 0) {
         return result;
       }
-    } while (++key < numSortingKeys());
+    } while (++key < numSortKeys());
   }
   return 0;
-}
-
-SpillFile::SpillFile(
-    uint32_t id,
-    RowTypePtr type,
-    int32_t numSortingKeys,
-    const std::vector<CompareFlags>& sortCompareFlags,
-    const std::string& path,
-    common::CompressionKind compressionKind,
-    memory::MemoryPool* pool,
-    const std::unordered_map<std::string, std::string>& writeFileOptions)
-    : id_(id),
-      type_(std::move(type)),
-      numSortingKeys_(numSortingKeys),
-      sortCompareFlags_(sortCompareFlags),
-      ordinal_(ordinalCounter_++),
-      path_(fmt::format("{}-{}", path, ordinal_)),
-      compressionKind_(compressionKind),
-      writeFileOptions_(filesystems::FileOptions{writeFileOptions, nullptr}),
-      pool_(pool) {
-  // NOTE: if the spilling operator has specified the sort comparison flags,
-  // then it must match the number of sorting keys.
-  VELOX_CHECK(
-      sortCompareFlags_.empty() || sortCompareFlags_.size() == numSortingKeys_);
-}
-
-WriteFile& SpillFile::output() {
-  if (!output_) {
-    auto fs = filesystems::getFileSystem(path_, nullptr);
-    output_ = fs->openFileForWrite(path_, writeFileOptions_);
-  }
-  return *output_;
-}
-
-void SpillFile::startRead() {
-  constexpr uint64_t kMaxReadBufferSize =
-      (1 << 20) - AlignedBuffer::kPaddedSize; // 1MB - padding.
-  VELOX_CHECK(!output_);
-  VELOX_CHECK(!input_);
-  auto fs = filesystems::getFileSystem(path_, nullptr);
-  auto file = fs->openFileForRead(path_);
-  auto buffer = AlignedBuffer::allocate<char>(
-      std::min<uint64_t>(fileSize_, kMaxReadBufferSize), pool_);
-  input_ = std::make_unique<SpillInput>(std::move(file), std::move(buffer));
-}
-
-bool SpillFile::nextBatch(RowVectorPtr& rowVector) {
-  if (input_->atEnd()) {
-    return false;
-  }
-  serializer::presto::PrestoVectorSerde::PrestoOptions options = {
-      kDefaultUseLosslessTimestamp, compressionKind_};
-  VectorStreamGroup::read(input_.get(), pool_, type_, &rowVector, &options);
-  return true;
-}
-
-SpillFileList::SpillFileList(
-    const RowTypePtr& type,
-    int32_t numSortingKeys,
-    const std::vector<CompareFlags>& sortCompareFlags,
-    const std::string& path,
-    uint64_t targetFileSize,
-    uint64_t writeBufferSize,
-    common::CompressionKind compressionKind,
-    memory::MemoryPool* pool,
-    folly::Synchronized<common::SpillStats>* stats,
-    const std::unordered_map<std::string, std::string>& writeFileOptions)
-    : type_(type),
-      numSortingKeys_(numSortingKeys),
-      sortCompareFlags_(sortCompareFlags),
-      path_(path),
-      targetFileSize_(targetFileSize),
-      writeBufferSize_(writeBufferSize),
-      compressionKind_(compressionKind),
-      writeFileOptions_(writeFileOptions),
-      pool_(pool),
-      stats_(stats) {
-  // NOTE: if the associated spilling operator has specified the sort
-  // comparison flags, then it must match the number of sorting keys.
-  VELOX_CHECK(
-      sortCompareFlags_.empty() || sortCompareFlags_.size() == numSortingKeys_);
-}
-
-WriteFile& SpillFileList::currentOutput() {
-  if (files_.empty() || !files_.back()->isWritable() ||
-      files_.back()->size() > targetFileSize_) {
-    if (!files_.empty() && files_.back()->isWritable()) {
-      files_.back()->finishWrite();
-      updateSpilledFiles(files_.back()->size());
-    }
-    files_.push_back(std::make_unique<SpillFile>(
-        nextFileId_++,
-        type_,
-        numSortingKeys_,
-        sortCompareFlags_,
-        fmt::format("{}-{}", path_, files_.size()),
-        compressionKind_,
-        pool_,
-        writeFileOptions_));
-  }
-  return files_.back()->output();
-}
-
-uint64_t SpillFileList::flush() {
-  uint64_t writtenBytes = 0;
-  if (batch_) {
-    IOBufOutputStream out(
-        *pool_, nullptr, std::max<int64_t>(64 * 1024, batch_->size()));
-    uint64_t flushTimeUs{0};
-    {
-      MicrosecondTimer timer(&flushTimeUs);
-      batch_->flush(&out);
-    }
-
-    batch_.reset();
-    auto iobuf = out.getIOBuf();
-    auto& file = currentOutput();
-    uint64_t writeTimeUs{0};
-    uint32_t numDiskWrites{0};
-    {
-      MicrosecondTimer timer(&writeTimeUs);
-      for (auto& range : *iobuf) {
-        ++numDiskWrites;
-        file.append(std::string_view(
-            reinterpret_cast<const char*>(range.data()), range.size()));
-        writtenBytes += range.size();
-      }
-    }
-    updateWriteStats(numDiskWrites, writtenBytes, flushTimeUs, writeTimeUs);
-  }
-  return writtenBytes;
-}
-
-uint64_t SpillFileList::write(
-    const RowVectorPtr& rows,
-    const folly::Range<IndexRange*>& indices) {
-  uint64_t timeUs{0};
-  {
-    MicrosecondTimer timer(&timeUs);
-    if (batch_ == nullptr) {
-      serializer::presto::PrestoVectorSerde::PrestoOptions options = {
-          kDefaultUseLosslessTimestamp, compressionKind_};
-      batch_ = std::make_unique<VectorStreamGroup>(pool_);
-      batch_->createStreamTree(
-          std::static_pointer_cast<const RowType>(rows->type()),
-          1000,
-          &options);
-    }
-    batch_->append(rows, indices);
-  }
-  updateAppendStats(rows->size(), timeUs);
-  if (batch_->size() < writeBufferSize_) {
-    return 0;
-  }
-  return flush();
-}
-
-void SpillFileList::updateAppendStats(
-    uint64_t numRows,
-    uint64_t serializationTimeUs) {
-  auto statsLocked = stats_->wlock();
-  statsLocked->spilledRows += numRows;
-  statsLocked->spillSerializationTimeUs += serializationTimeUs;
-  common::updateGlobalSpillAppendStats(numRows, serializationTimeUs);
-}
-
-void SpillFileList::updateWriteStats(
-    uint32_t numDiskWrites,
-    uint64_t spilledBytes,
-    uint64_t flushTimeUs,
-    uint64_t fileWriteTimeUs) {
-  auto statsLocked = stats_->wlock();
-  statsLocked->spilledBytes += spilledBytes;
-  statsLocked->spillFlushTimeUs += flushTimeUs;
-  statsLocked->spillWriteTimeUs += fileWriteTimeUs;
-  statsLocked->spillDiskWrites += numDiskWrites;
-  common::updateGlobalSpillWriteStats(
-      numDiskWrites, spilledBytes, flushTimeUs, fileWriteTimeUs);
-}
-
-void SpillFileList::updateSpilledFiles(uint64_t fileSize) {
-  ++stats_->wlock()->spilledFiles;
-  addThreadLocalRuntimeStat(
-      "spillFileSize", RuntimeCounter(fileSize, RuntimeCounter::Unit::kBytes));
-  common::incrementGlobalSpilledFiles();
-}
-
-void SpillFileList::finishFile() {
-  flush();
-  if (files_.empty()) {
-    return;
-  }
-  if (files_.back()->isWritable()) {
-    files_.back()->finishWrite();
-    updateSpilledFiles(files_.back()->size());
-  }
-}
-
-std::vector<std::string> SpillFileList::testingSpilledFilePaths() const {
-  std::vector<std::string> spilledFiles;
-  for (auto& file : files_) {
-    spilledFiles.push_back(file->testingFilePath());
-  }
-  return spilledFiles;
-}
-
-std::vector<uint32_t> SpillFileList::testingSpilledFileIds() const {
-  std::vector<uint32_t> fileIds;
-  for (auto& file : files_) {
-    fileIds.push_back(file->id());
-  }
-  return fileIds;
 }
 
 SpillState::SpillState(
     common::GetSpillDirectoryPathCB getSpillDirPathCb,
     const std::string& fileNamePrefix,
     int32_t maxPartitions,
-    int32_t numSortingKeys,
+    int32_t numSortKeys,
     const std::vector<CompareFlags>& sortCompareFlags,
     uint64_t targetFileSize,
     uint64_t writeBufferSize,
@@ -309,7 +79,7 @@ SpillState::SpillState(
     : getSpillDirPathCb_(getSpillDirPathCb),
       fileNamePrefix_(fileNamePrefix),
       maxPartitions_(maxPartitions),
-      numSortingKeys_(numSortingKeys),
+      numSortKeys_(numSortKeys),
       sortCompareFlags_(sortCompareFlags),
       targetFileSize_(targetFileSize),
       writeBufferSize_(writeBufferSize),
@@ -317,9 +87,9 @@ SpillState::SpillState(
       writeFileOptions_(writeFileOptions),
       pool_(pool),
       stats_(stats),
-      files_(maxPartitions_) {}
+      partitionWriters_(maxPartitions_) {}
 
-void SpillState::setPartitionSpilled(int32_t partition) {
+void SpillState::setPartitionSpilled(uint32_t partition) {
   VELOX_DCHECK_LT(partition, maxPartitions_);
   VELOX_DCHECK_LT(spilledPartitionSet_.size(), maxPartitions_);
   VELOX_DCHECK(!spilledPartitionSet_.contains(partition));
@@ -335,7 +105,7 @@ void SpillState::updateSpilledInputBytes(uint64_t bytes) {
 }
 
 uint64_t SpillState::appendToPartition(
-    int32_t partition,
+    uint32_t partition,
     const RowVectorPtr& rows) {
   VELOX_CHECK(
       isPartitionSpilled(partition), "Partition {} is not spilled", partition);
@@ -348,33 +118,46 @@ uint64_t SpillState::appendToPartition(
   const std::string& spillDir = getSpillDirPathCb_();
   VELOX_CHECK(!spillDir.empty(), "Spill directory does not exist");
   // Ensure that partition exist before writing.
-  if (!files_.at(partition)) {
-    files_[partition] = std::make_unique<SpillFileList>(
+  if (partitionWriters_.at(partition) == nullptr) {
+    partitionWriters_[partition] = std::make_unique<SpillWriter>(
         std::static_pointer_cast<const RowType>(rows->type()),
-        numSortingKeys_,
+        numSortKeys_,
         sortCompareFlags_,
+        compressionKind_,
         fmt::format("{}/{}-spill-{}", spillDir, fileNamePrefix_, partition),
         targetFileSize_,
         writeBufferSize_,
-        compressionKind_,
+        writeFileOptions_,
         pool_,
-        stats_,
-        writeFileOptions_);
+        stats_);
   }
+
   updateSpilledInputBytes(rows->estimateFlatSize());
 
   IndexRange range{0, rows->size()};
-  return files_[partition]->write(rows, folly::Range<IndexRange*>(&range, 1));
+  return partitionWriters_[partition]->write(
+      rows, folly::Range<IndexRange*>(&range, 1));
 }
 
-SpillFiles SpillState::files(int32_t partition) {
-  VELOX_CHECK_LT(partition, files_.size());
+SpillWriter* SpillState::partitionWriter(uint32_t partition) const {
+  VELOX_DCHECK(isPartitionSpilled(partition));
+  return partitionWriters_[partition].get();
+}
 
-  auto list = std::move(files_[partition]);
-  if (list == nullptr) {
+void SpillState::finishFile(uint32_t partition) {
+  auto* writer = partitionWriter(partition);
+  if (writer == nullptr) {
+    return;
+  }
+  writer->finishFile();
+}
+
+SpillFiles SpillState::finish(uint32_t partition) {
+  auto* writer = partitionWriter(partition);
+  if (writer == nullptr) {
     return {};
   }
-  return list->files();
+  return writer->finish();
 }
 
 const SpillPartitionNumSet& SpillState::spilledPartitionSet() const {
@@ -383,13 +166,13 @@ const SpillPartitionNumSet& SpillState::spilledPartitionSet() const {
 
 std::vector<std::string> SpillState::testingSpilledFilePaths() const {
   std::vector<std::string> spilledFiles;
-  for (const auto& list : files_) {
-    if (list != nullptr) {
-      const auto spilledFilesFromList = list->testingSpilledFilePaths();
+  for (const auto& writer : partitionWriters_) {
+    if (writer != nullptr) {
+      const auto partitionSpilledFiles = writer->testingSpilledFilePaths();
       spilledFiles.insert(
           spilledFiles.end(),
-          spilledFilesFromList.begin(),
-          spilledFilesFromList.end());
+          partitionSpilledFiles.begin(),
+          partitionSpilledFiles.end());
     }
   }
   return spilledFiles;
@@ -397,13 +180,13 @@ std::vector<std::string> SpillState::testingSpilledFilePaths() const {
 
 std::vector<uint32_t> SpillState::testingSpilledFileIds(
     int32_t partitionNum) const {
-  return files_[partitionNum]->testingSpilledFileIds();
+  return partitionWriters_[partitionNum]->testingSpilledFileIds();
 }
 
 SpillPartitionNumSet SpillState::testingNonEmptySpilledPartitionSet() const {
   SpillPartitionNumSet partitionSet;
   for (uint32_t partition = 0; partition < maxPartitions_; ++partition) {
-    if (files_[partition] != nullptr) {
+    if (partitionWriters_[partition] != nullptr) {
       partitionSet.insert(partition);
     }
   }
@@ -442,11 +225,13 @@ std::string SpillPartition::toString() const {
 }
 
 std::unique_ptr<UnorderedStreamReader<BatchStream>>
-SpillPartition::createUnorderedReader() {
+SpillPartition::createUnorderedReader(memory::MemoryPool* pool) {
+  VELOX_CHECK_NOT_NULL(pool);
   std::vector<std::unique_ptr<BatchStream>> streams;
   streams.reserve(files_.size());
-  for (auto& file : files_) {
-    streams.push_back(FileSpillBatchStream::create(std::move(file)));
+  for (auto& fileInfo : files_) {
+    streams.push_back(
+        FileSpillBatchStream::create(SpillReadFile::create(fileInfo, pool)));
   }
   files_.clear();
   return std::make_unique<UnorderedStreamReader<BatchStream>>(
@@ -454,11 +239,12 @@ SpillPartition::createUnorderedReader() {
 }
 
 std::unique_ptr<TreeOfLosers<SpillMergeStream>>
-SpillPartition::createOrderedReader() {
+SpillPartition::createOrderedReader(memory::MemoryPool* pool) {
   std::vector<std::unique_ptr<SpillMergeStream>> streams;
   streams.reserve(files_.size());
-  for (auto& file : files_) {
-    streams.push_back(FileSpillMergeStream::create(std::move(file)));
+  for (auto& fileInfo : files_) {
+    streams.push_back(
+        FileSpillMergeStream::create(SpillReadFile::create(fileInfo, pool)));
   }
   files_.clear();
   // Check if the partition is empty or not.

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -23,6 +23,7 @@
 #include "velox/common/compression/Compression.h"
 #include "velox/common/file/File.h"
 #include "velox/common/file/FileSystems.h"
+#include "velox/exec/SpillFile.h"
 #include "velox/exec/TreeOfLosers.h"
 #include "velox/exec/UnorderedStreamReader.h"
 #include "velox/vector/ComplexVector.h"
@@ -30,217 +31,6 @@
 #include "velox/vector/VectorStream.h"
 
 namespace facebook::velox::exec {
-/// Input stream backed by spill file.
-///
-/// TODO Usage of ByteInputStream as base class is hacky and just happens to
-/// work. For example, ByteInputStream::size(), seekp(), tellp(),
-/// remainingSize() APIs do not work properly.
-class SpillInput : public ByteInputStream {
- public:
-  // Reads from 'input' using 'buffer' for buffering reads.
-  SpillInput(std::unique_ptr<ReadFile>&& input, BufferPtr buffer)
-      : input_(std::move(input)),
-        buffer_(std::move(buffer)),
-        size_(input_->size()) {
-    next(true);
-  }
-
-  // True if all of the file has been read into vectors.
-  bool atEnd() const override {
-    return offset_ >= size_ && ranges()[0].position >= ranges()[0].size;
-  }
-
- private:
-  void next(bool throwIfPastEnd) override;
-
-  std::unique_ptr<ReadFile> input_;
-  BufferPtr buffer_;
-  const uint64_t size_;
-  // Offset of first byte not in 'buffer_'
-  uint64_t offset_ = 0;
-};
-
-/// Represents a spill file that is first in write mode and then
-/// turns into a source of spilled RowVectors. Owns a file system file that
-/// contains the spilled data and is live for the duration of 'this'.
-
-/// NOTE: The class will not delete spill file upon destruction, so the user
-/// needs to remove the unused spill files at some point later. For example, a
-/// query Task deletes all the generated spill files in one operation using
-/// rmdir() call.
-class SpillFile {
- public:
-  SpillFile(
-      uint32_t id,
-      RowTypePtr type,
-      int32_t numSortingKeys,
-      const std::vector<CompareFlags>& sortCompareFlags,
-      const std::string& path,
-      common::CompressionKind compressionKind,
-      memory::MemoryPool* pool,
-      const std::unordered_map<std::string, std::string>& writeFileOptions);
-
-  uint32_t id() const {
-    return id_;
-  }
-
-  int32_t numSortingKeys() const {
-    return numSortingKeys_;
-  }
-
-  const std::vector<CompareFlags>& sortCompareFlags() const {
-    return sortCompareFlags_;
-  }
-
-  /// Returns a file for writing spilled data. The caller constructs
-  /// this, then calls output() and writes serialized data to the file
-  /// and calls finishWrite when the file has reached its final
-  /// size. For sorted spilling, the data in one file is expected to be
-  // sorted.
-  WriteFile& output();
-
-  bool isWritable() const {
-    return output_ != nullptr;
-  }
-
-  /// Finishes writing and flushes any unwritten data.
-  void finishWrite() {
-    VELOX_CHECK(output_);
-    fileSize_ = output_->size();
-    output_ = nullptr;
-  }
-
-  /// Prepares 'this' for reading. Positions the read at the first row of
-  /// content. The caller must call output() and finishWrite() before this.
-  void startRead();
-
-  bool nextBatch(RowVectorPtr& rowVector);
-
-  /// Returns the file size in bytes. During the writing phase this is
-  /// the current size of the file, during reading this is the final
-  // size.
-  uint64_t size() const {
-    if (output_) {
-      return output_->size();
-    }
-    return fileSize_;
-  }
-
-  std::string label() const {
-    return fmt::format("{}", ordinal_);
-  }
-
-  const std::string& testingFilePath() const {
-    return path_;
-  }
-
- private:
-  static std::atomic<int32_t> ordinalCounter_;
-
-  // The spill file id which is monotonically increasing and unique for each
-  // associated spill partition.
-  const uint32_t id_;
-  // Type of 'rowVector_'. Needed for setting up writing.
-  const RowTypePtr type_;
-  const int32_t numSortingKeys_;
-  const std::vector<CompareFlags> sortCompareFlags_;
-  // Ordinal number used for making a label for debugging.
-  const int32_t ordinal_;
-  const std::string path_;
-  const common::CompressionKind compressionKind_;
-  const filesystems::FileOptions writeFileOptions_;
-  memory::MemoryPool* const pool_;
-
-  // Byte size of the backing file. Set when finishing writing.
-  uint64_t fileSize_ = 0;
-  std::unique_ptr<WriteFile> output_;
-  std::unique_ptr<SpillInput> input_;
-};
-
-using SpillFiles = std::vector<std::unique_ptr<SpillFile>>;
-
-/// Sequence of files for one partition of the spilled data. If data is
-/// sorted, each file is sorted. The globally sorted order is produced
-/// by merging the constituent files.
-class SpillFileList {
- public:
-  /// Constructs a set of spill files. 'type' is a RowType describing the
-  /// content. 'numSortingKeys' is the number of leading columns on which the
-  /// data is sorted. 'path' is a file path prefix. ' 'targetFileSize' is the
-  /// target byte size of a single file in the file set. 'pool' is used for
-  /// buffering and constructing the result data read from 'this'.
-  ///
-  /// When writing sorted spill runs, the caller is responsible for buffering
-  /// and sorting the data. write is called multiple times, followed by flush().
-  SpillFileList(
-      const RowTypePtr& type,
-      int32_t numSortingKeys,
-      const std::vector<CompareFlags>& sortCompareFlags,
-      const std::string& path,
-      uint64_t targetFileSize,
-      uint64_t writeBufferSize,
-      common::CompressionKind compressionKind,
-      memory::MemoryPool* pool,
-      folly::Synchronized<common::SpillStats>* stats,
-      const std::unordered_map<std::string, std::string>& writeFileOptions);
-
-  /// Adds 'rows' for the positions in 'indices' into 'this'. The indices
-  /// must produce a view where the rows are sorted if sorting is desired.
-  /// Consecutive calls must have sorted data so that the first row of the
-  /// next call is not less than the last row of the previous call.
-  /// Returns the size to write.
-  uint64_t write(
-      const RowVectorPtr& rows,
-      const folly::Range<IndexRange*>& indices);
-
-  /// Closes the current output file if any. Subsequent calls to write will
-  /// start a new one.
-  void finishFile();
-
-  SpillFiles files() {
-    VELOX_CHECK(!files_.empty() || (batch_ != nullptr));
-    finishFile();
-    return std::move(files_);
-  }
-
-  std::vector<std::string> testingSpilledFilePaths() const;
-
-  std::vector<uint32_t> testingSpilledFileIds() const;
-
- private:
-  // Returns the current file to write to and creates one if needed.
-  WriteFile& currentOutput();
-
-  // Writes data from 'batch_' to the current output file. Returns the actual
-  // written size.
-  uint64_t flush();
-
-  // Invoked to update the number of spilled rows.
-  void updateAppendStats(uint64_t numRows, uint64_t serializationTimeUs);
-  // Invoked to increment the number of spilled files and the file size.
-  void updateSpilledFiles(uint64_t fileSize);
-  // Invoked to update the disk write stats.
-  void updateWriteStats(
-      uint32_t numDiskWrites,
-      uint64_t spilledBytes,
-      uint64_t flushTimeUs,
-      uint64_t writeTimeUs);
-
-  const RowTypePtr type_;
-  const int32_t numSortingKeys_;
-  const std::vector<CompareFlags> sortCompareFlags_;
-  const std::string path_;
-  const uint64_t targetFileSize_;
-  const uint64_t writeBufferSize_;
-  const common::CompressionKind compressionKind_;
-  const std::unordered_map<std::string, std::string> writeFileOptions_;
-  memory::MemoryPool* const pool_;
-  folly::Synchronized<common::SpillStats>* const stats_;
-  uint32_t nextFileId_{0};
-  std::unique_ptr<VectorStreamGroup> batch_;
-  SpillFiles files_;
-};
-
 // A source of sorted spilled RowVectors coming either from a file or memory.
 class SpillMergeStream : public MergeStream {
  public:
@@ -277,14 +67,14 @@ class SpillMergeStream : public MergeStream {
     return index_;
   }
 
-  // Returns a DecodedVector set decoding the 'index'th child of 'rowVector_'
+  /// Returns a DecodedVector set decoding the 'index'th child of 'rowVector_'
   DecodedVector& decoded(int32_t index) {
     ensureDecodedValid(index);
     return decoded_[index];
   }
 
  protected:
-  virtual int32_t numSortingKeys() const = 0;
+  virtual int32_t numSortKeys() const = 0;
 
   virtual const std::vector<CompareFlags>& sortCompareFlags() const = 0;
 
@@ -340,8 +130,7 @@ class SpillMergeStream : public MergeStream {
 class FileSpillMergeStream : public SpillMergeStream {
  public:
   static std::unique_ptr<SpillMergeStream> create(
-      std::unique_ptr<SpillFile> spillFile) {
-    spillFile->startRead();
+      std::unique_ptr<SpillReadFile> spillFile) {
     auto* spillStream = new FileSpillMergeStream(std::move(spillFile));
     spillStream->nextBatch();
     return std::unique_ptr<SpillMergeStream>(spillStream);
@@ -350,13 +139,13 @@ class FileSpillMergeStream : public SpillMergeStream {
   uint32_t id() const override;
 
  private:
-  explicit FileSpillMergeStream(std::unique_ptr<SpillFile> spillFile)
+  explicit FileSpillMergeStream(std::unique_ptr<SpillReadFile> spillFile)
       : spillFile_(std::move(spillFile)) {
     VELOX_CHECK_NOT_NULL(spillFile_);
   }
 
-  int32_t numSortingKeys() const override {
-    return spillFile_->numSortingKeys();
+  int32_t numSortKeys() const override {
+    return spillFile_->numSortKeys();
   }
 
   const std::vector<CompareFlags>& sortCompareFlags() const override {
@@ -365,7 +154,7 @@ class FileSpillMergeStream : public SpillMergeStream {
 
   void nextBatch() override;
 
-  std::unique_ptr<SpillFile> spillFile_;
+  std::unique_ptr<SpillReadFile> spillFile_;
 };
 
 /// A source of spilled RowVectors coming from a file. The spill data might not
@@ -375,31 +164,22 @@ class FileSpillMergeStream : public SpillMergeStream {
 class FileSpillBatchStream : public BatchStream {
  public:
   static std::unique_ptr<BatchStream> create(
-      std::unique_ptr<SpillFile> spillFile) {
+      std::unique_ptr<SpillReadFile> spillFile) {
     auto* spillStream = new FileSpillBatchStream(std::move(spillFile));
     return std::unique_ptr<BatchStream>(spillStream);
   }
 
   bool nextBatch(RowVectorPtr& batch) override {
-    if (FOLLY_UNLIKELY(!isFileOpened_)) {
-      spillFile_->startRead();
-      isFileOpened_ = true;
-    }
     return spillFile_->nextBatch(batch);
   }
 
  private:
-  explicit FileSpillBatchStream(std::unique_ptr<SpillFile> spillFile)
-      : isFileOpened_(false), spillFile_(std::move(spillFile)) {
+  explicit FileSpillBatchStream(std::unique_ptr<SpillReadFile> spillFile)
+      : spillFile_(std::move(spillFile)) {
     VELOX_CHECK_NOT_NULL(spillFile_);
   }
 
-  // Indicates if 'spillFile_' has been opened for stream read or not.
-  //
-  // NOTE: we open the file until the first read on this stream object so that
-  // we don't open too many files at the same time.
-  bool isFileOpened_;
-  std::unique_ptr<SpillFile> spillFile_;
+  std::unique_ptr<SpillReadFile> spillFile_;
 };
 
 /// Identifies a spill partition generated from a given spilling operator. It
@@ -482,7 +262,7 @@ class SpillPartition {
   void addFiles(SpillFiles files) {
     files_.reserve(files_.size() + files.size());
     for (auto& file : files) {
-      size_ += file->size();
+      size_ += file.size;
       files_.push_back(std::move(file));
     }
   }
@@ -508,11 +288,13 @@ class SpillPartition {
 
   /// Invoked to create an unordered stream reader from this spill partition.
   /// The created reader will take the ownership of the spill files.
-  std::unique_ptr<UnorderedStreamReader<BatchStream>> createUnorderedReader();
+  std::unique_ptr<UnorderedStreamReader<BatchStream>> createUnorderedReader(
+      memory::MemoryPool* pool);
 
   /// Invoked to create an ordered stream reader from this spill partition.
   /// The created reader will take the ownership of the spill files.
-  std::unique_ptr<TreeOfLosers<SpillMergeStream>> createOrderedReader();
+  std::unique_ptr<TreeOfLosers<SpillMergeStream>> createOrderedReader(
+      memory::MemoryPool* pool);
 
   std::string toString() const;
 
@@ -533,7 +315,7 @@ class SpillState {
   /// Constructs a SpillState. 'type' is the content RowType. 'path' is the file
   /// system path prefix. 'bits' is the hash bit field for partitioning data
   /// between files. This also gives the maximum number of partitions.
-  /// 'numSortingKeys' is the number of leading columns on which the data is
+  /// 'numSortKeys' is the number of leading columns on which the data is
   /// sorted, 0 if only hash partitioning is used. 'targetFileSize' is the
   /// target size of a single file.  'pool' owns the memory for state and
   /// results.
@@ -541,7 +323,7 @@ class SpillState {
       common::GetSpillDirectoryPathCB getSpillDirectoryPath,
       const std::string& fileNamePrefix,
       int32_t maxPartitions,
-      int32_t numSortingKeys,
+      int32_t numSortKeys,
       const std::vector<CompareFlags>& sortCompareFlags,
       uint64_t targetFileSize,
       uint64_t writeBufferSize,
@@ -552,13 +334,13 @@ class SpillState {
           {});
 
   /// Indicates if a given 'partition' has been spilled or not.
-  bool isPartitionSpilled(int32_t partition) const {
+  bool isPartitionSpilled(uint32_t partition) const {
     VELOX_DCHECK_LT(partition, maxPartitions_);
     return spilledPartitionSet_.contains(partition);
   }
 
   // Sets a partition as spilled.
-  void setPartitionSpilled(int32_t partition);
+  void setPartitionSpilled(uint32_t partition);
 
   // Returns how many ways spilled data can be partitioned.
   int32_t maxPartitions() const {
@@ -590,24 +372,17 @@ class SpillState {
   /// for a sorted spill and must hash to 'partition'. It is safe to call this
   /// on multiple threads if all threads specify a different partition. Returns
   /// the size to append to partition.
-  uint64_t appendToPartition(int32_t partition, const RowVectorPtr& rows);
+  uint64_t appendToPartition(uint32_t partition, const RowVectorPtr& rows);
 
   /// Finishes a sorted run for 'partition'. If write is called for 'partition'
   /// again, the data does not have to be sorted relative to the data written so
   /// far.
-  void finishWrite(int32_t partition) {
-    VELOX_DCHECK(isPartitionSpilled(partition));
-    files_[partition]->finishFile();
-  }
+  void finishFile(uint32_t partition);
 
   /// Returns the spill file objects from a given 'partition'. The function
   /// returns an empty list if either the partition has not been spilled or has
   /// no spilled data.
-  SpillFiles files(int32_t partition);
-
-  bool hasFiles(int32_t partition) const {
-    return partition < files_.size() && files_[partition];
-  }
+  SpillFiles finish(uint32_t partition);
 
   /// Returns the spilled partition number set.
   const SpillPartitionNumSet& spilledPartitionSet() const;
@@ -624,6 +399,8 @@ class SpillState {
  private:
   void updateSpilledInputBytes(uint64_t bytes);
 
+  SpillWriter* partitionWriter(uint32_t partition) const;
+
   const RowTypePtr type_;
 
   // A callback function that returns the spill directory path. Implementations
@@ -633,7 +410,7 @@ class SpillState {
   /// Prefix for spill files.
   const std::string fileNamePrefix_;
   const int32_t maxPartitions_;
-  const int32_t numSortingKeys_;
+  const int32_t numSortKeys_;
   const std::vector<CompareFlags> sortCompareFlags_;
   const uint64_t targetFileSize_;
   const uint64_t writeBufferSize_;
@@ -647,7 +424,7 @@ class SpillState {
 
   // A file list for each spilled partition. Only partitions that have
   // started spilling have an entry here.
-  std::vector<std::unique_ptr<SpillFileList>> files_;
+  std::vector<std::unique_ptr<SpillWriter>> partitionWriters_;
 };
 
 /// Generate partition id set from given spill partition set.

--- a/velox/exec/SpillFile.cpp
+++ b/velox/exec/SpillFile.cpp
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/SpillFile.h"
+#include "velox/common/base/RuntimeMetrics.h"
+#include "velox/common/file/FileSystems.h"
+
+namespace facebook::velox::exec {
+namespace {
+// Spilling currently uses the default PrestoSerializer which by default
+// serializes timestamp with millisecond precision to maintain compatibility
+// with presto. Since velox's native timestamp implementation supports
+// nanosecond precision, we use this serde option to ensure the serializer
+// preserves precision.
+static const bool kDefaultUseLosslessTimestamp = true;
+} // namespace
+
+void SpillInputStream::next(bool /*throwIfPastEnd*/) {
+  const int32_t readBytes = std::min(size_ - offset_, buffer_->capacity());
+  VELOX_CHECK_LT(0, readBytes, "Reading past end of spill file");
+  setRange({buffer_->asMutable<uint8_t>(), readBytes, 0});
+  file_->pread(offset_, readBytes, buffer_->asMutable<char>());
+  offset_ += readBytes;
+}
+
+std::unique_ptr<SpillWriteFile> SpillWriteFile::create(
+    uint32_t id,
+    const std::string& pathPrefix,
+    const std::unordered_map<std::string, std::string>& fileOptions) {
+  return std::unique_ptr<SpillWriteFile>(
+      new SpillWriteFile(id, pathPrefix, fileOptions));
+}
+
+SpillWriteFile::SpillWriteFile(
+    uint32_t id,
+    const std::string& pathPrefix,
+    const std::unordered_map<std::string, std::string>& fileOptions)
+    : id_(id), path_(fmt::format("{}-{}", pathPrefix, ordinalCounter_++)) {
+  auto fs = filesystems::getFileSystem(path_, nullptr);
+  file_ = fs->openFileForWrite(
+      path_, filesystems::FileOptions{fileOptions, nullptr});
+}
+
+void SpillWriteFile::finish() {
+  VELOX_CHECK_NOT_NULL(file_);
+  size_ = file_->size();
+  file_->close();
+  file_ = nullptr;
+}
+
+uint64_t SpillWriteFile::size() const {
+  if (file_ != nullptr) {
+    return file_->size();
+  }
+  return size_;
+}
+
+uint64_t SpillWriteFile::write(std::unique_ptr<folly::IOBuf> iobuf) {
+  uint64_t writtenBytes{0};
+  // TODO: extend velox file system to support write with a chained io buffers.
+  for (auto& range : *iobuf) {
+    writtenBytes += range.size();
+    file_->append(std::string_view(
+        reinterpret_cast<const char*>(range.data()), range.size()));
+  }
+  return writtenBytes;
+}
+
+SpillWriter::SpillWriter(
+    const RowTypePtr& type,
+    const uint32_t numSortKeys,
+    const std::vector<CompareFlags>& sortCompareFlags,
+    common::CompressionKind compressionKind,
+    const std::string& pathPrefix,
+    uint64_t targetFileSize,
+    uint64_t writeBufferSize,
+    const std::unordered_map<std::string, std::string>& fileOptions,
+    memory::MemoryPool* pool,
+    folly::Synchronized<common::SpillStats>* stats)
+    : type_(type),
+      numSortKeys_(numSortKeys),
+      sortCompareFlags_(sortCompareFlags),
+      compressionKind_(compressionKind),
+      pathPrefix_(pathPrefix),
+      targetFileSize_(targetFileSize),
+      writeBufferSize_(writeBufferSize),
+      fileOptions_(fileOptions),
+      pool_(pool),
+      stats_(stats) {
+  // NOTE: if the associated spilling operator has specified the sort
+  // comparison flags, then it must match the number of sorting keys.
+  VELOX_CHECK(
+      sortCompareFlags_.empty() || sortCompareFlags_.size() == numSortKeys_);
+}
+
+SpillWriteFile* SpillWriter::ensureFile() {
+  if ((currentFile_ != nullptr) && (currentFile_->size() > targetFileSize_)) {
+    closeFile();
+  }
+  if (currentFile_ == nullptr) {
+    currentFile_ = SpillWriteFile::create(
+        nextFileId_++,
+        fmt::format("{}-{}", pathPrefix_, finishedFiles_.size()),
+        fileOptions_);
+  }
+  return currentFile_.get();
+}
+
+void SpillWriter::closeFile() {
+  if (currentFile_ == nullptr) {
+    return;
+  }
+  currentFile_->finish();
+  updateSpilledFileStats(currentFile_->size());
+  finishedFiles_.push_back(SpillFileInfo{
+      .id = currentFile_->id(),
+      .type = type_,
+      .path = currentFile_->path(),
+      .size = currentFile_->size(),
+      .numSortKeys = numSortKeys_,
+      .sortFlags = sortCompareFlags_,
+      .compressionKind = compressionKind_});
+  currentFile_.reset();
+}
+
+uint64_t SpillWriter::flush() {
+  if (batch_ == nullptr) {
+    return 0;
+  }
+
+  auto* file = ensureFile();
+  VELOX_CHECK_NOT_NULL(file);
+
+  IOBufOutputStream out(
+      *pool_, nullptr, std::max<int64_t>(64 * 1024, batch_->size()));
+  uint64_t flushTimeUs{0};
+  {
+    MicrosecondTimer timer(&flushTimeUs);
+    batch_->flush(&out);
+  }
+  batch_.reset();
+
+  uint64_t writeTimeUs{0};
+  uint64_t writtenBytes{0};
+  auto iobuf = out.getIOBuf();
+  {
+    MicrosecondTimer timer(&writeTimeUs);
+    writtenBytes = file->write(std::move(iobuf));
+  }
+  updateWriteStats(writtenBytes, flushTimeUs, writeTimeUs);
+  return writtenBytes;
+}
+
+uint64_t SpillWriter::write(
+    const RowVectorPtr& rows,
+    const folly::Range<IndexRange*>& indices) {
+  checkNotFinished();
+
+  uint64_t timeUs{0};
+  {
+    MicrosecondTimer timer(&timeUs);
+    if (batch_ == nullptr) {
+      serializer::presto::PrestoVectorSerde::PrestoOptions options = {
+          kDefaultUseLosslessTimestamp, compressionKind_};
+      batch_ = std::make_unique<VectorStreamGroup>(pool_);
+      batch_->createStreamTree(
+          std::static_pointer_cast<const RowType>(rows->type()),
+          1'000,
+          &options);
+    }
+    batch_->append(rows, indices);
+  }
+  updateAppendStats(rows->size(), timeUs);
+  if (batch_->size() < writeBufferSize_) {
+    return 0;
+  }
+  return flush();
+}
+
+void SpillWriter::updateAppendStats(
+    uint64_t numRows,
+    uint64_t serializationTimeUs) {
+  auto statsLocked = stats_->wlock();
+  statsLocked->spilledRows += numRows;
+  statsLocked->spillSerializationTimeUs += serializationTimeUs;
+  common::updateGlobalSpillAppendStats(numRows, serializationTimeUs);
+}
+
+void SpillWriter::updateWriteStats(
+    uint64_t spilledBytes,
+    uint64_t flushTimeUs,
+    uint64_t fileWriteTimeUs) {
+  auto statsLocked = stats_->wlock();
+  statsLocked->spilledBytes += spilledBytes;
+  statsLocked->spillFlushTimeUs += flushTimeUs;
+  statsLocked->spillWriteTimeUs += fileWriteTimeUs;
+  ++statsLocked->spillDiskWrites;
+  common::updateGlobalSpillWriteStats(
+      spilledBytes, flushTimeUs, fileWriteTimeUs);
+}
+
+void SpillWriter::updateSpilledFileStats(uint64_t fileSize) {
+  ++stats_->wlock()->spilledFiles;
+  addThreadLocalRuntimeStat(
+      "spillFileSize", RuntimeCounter(fileSize, RuntimeCounter::Unit::kBytes));
+  common::incrementGlobalSpilledFiles();
+}
+
+void SpillWriter::finishFile() {
+  checkNotFinished();
+  flush();
+  closeFile();
+  VELOX_CHECK_NULL(currentFile_);
+}
+
+SpillFiles SpillWriter::finish() {
+  checkNotFinished();
+  auto finishGuard = folly::makeGuard([this]() { finished_ = true; });
+
+  finishFile();
+  return std::move(finishedFiles_);
+}
+
+std::vector<std::string> SpillWriter::testingSpilledFilePaths() const {
+  checkNotFinished();
+
+  std::vector<std::string> spilledFilePaths;
+  for (auto& file : finishedFiles_) {
+    spilledFilePaths.push_back(file.path);
+  }
+  if (currentFile_ != nullptr) {
+    spilledFilePaths.push_back(currentFile_->path());
+  }
+  return spilledFilePaths;
+}
+
+std::vector<uint32_t> SpillWriter::testingSpilledFileIds() const {
+  checkNotFinished();
+
+  std::vector<uint32_t> fileIds;
+  for (auto& file : finishedFiles_) {
+    fileIds.push_back(file.id);
+  }
+  if (currentFile_ != nullptr) {
+    fileIds.push_back(currentFile_->id());
+  }
+  return fileIds;
+}
+
+std::unique_ptr<SpillReadFile> SpillReadFile::create(
+    const SpillFileInfo& fileInfo,
+    memory::MemoryPool* pool) {
+  return std::unique_ptr<SpillReadFile>(new SpillReadFile(
+      fileInfo.id,
+      fileInfo.path,
+      fileInfo.size,
+      fileInfo.type,
+      fileInfo.numSortKeys,
+      fileInfo.sortFlags,
+      fileInfo.compressionKind,
+      pool));
+}
+
+SpillReadFile::SpillReadFile(
+    uint32_t id,
+    const std::string& path,
+    uint64_t size,
+    const RowTypePtr& type,
+    uint32_t numSortKeys,
+    const std::vector<CompareFlags>& sortCompareFlags,
+    common::CompressionKind compressionKind,
+    memory::MemoryPool* pool)
+    : id_(id),
+      path_(path),
+      size_(size),
+      type_(type),
+      numSortKeys_(numSortKeys),
+      sortCompareFlags_(sortCompareFlags),
+      compressionKind_(compressionKind),
+      readOptions_{kDefaultUseLosslessTimestamp, compressionKind_},
+      pool_(pool) {
+  constexpr uint64_t kMaxReadBufferSize =
+      (1 << 20) - AlignedBuffer::kPaddedSize; // 1MB - padding.
+  auto fs = filesystems::getFileSystem(path_, nullptr);
+  auto file = fs->openFileForRead(path_);
+  auto buffer = AlignedBuffer::allocate<char>(
+      std::min<uint64_t>(size_, kMaxReadBufferSize), pool_);
+  input_ =
+      std::make_unique<SpillInputStream>(std::move(file), std::move(buffer));
+}
+
+bool SpillReadFile::nextBatch(RowVectorPtr& rowVector) {
+  if (input_->atEnd()) {
+    return false;
+  }
+  VectorStreamGroup::read(
+      input_.get(), pool_, type_, &rowVector, &readOptions_);
+  return true;
+}
+} // namespace facebook::velox::exec

--- a/velox/exec/SpillFile.h
+++ b/velox/exec/SpillFile.h
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/container/F14Set.h>
+
+#include "velox/common/base/SpillConfig.h"
+#include "velox/common/base/SpillStats.h"
+#include "velox/common/compression/Compression.h"
+#include "velox/common/file/File.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/exec/TreeOfLosers.h"
+#include "velox/exec/UnorderedStreamReader.h"
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/DecodedVector.h"
+#include "velox/vector/VectorStream.h"
+
+namespace facebook::velox::exec {
+
+/// Represents a spill file for writing the serialized spilled data into a disk
+/// file.
+class SpillWriteFile {
+ public:
+  static std::unique_ptr<SpillWriteFile> create(
+      uint32_t id,
+      const std::string& pathPrefix,
+      const std::unordered_map<std::string, std::string>& fileOptions);
+
+  uint32_t id() const {
+    return id_;
+  }
+
+  /// Returns the file size in bytes.
+  uint64_t size() const;
+
+  const std::string& path() const {
+    return path_;
+  }
+
+  uint64_t write(std::unique_ptr<folly::IOBuf> iobuf);
+
+  WriteFile* file() {
+    return file_.get();
+  }
+
+  /// Finishes writing and flushes any unwritten data.
+  void finish();
+
+ private:
+  static inline std::atomic<int32_t> ordinalCounter_{0};
+
+  SpillWriteFile(
+      uint32_t id,
+      const std::string& pathPrefix,
+      const std::unordered_map<std::string, std::string>& fileOptions);
+
+  // The spill file id which is monotonically increasing and unique for each
+  // associated spill partition.
+  const uint32_t id_;
+  const std::string path_;
+
+  std::unique_ptr<WriteFile> file_;
+  // Byte size of the backing file. Set when finishing writing.
+  uint64_t size_{0};
+};
+
+/// Records info of a finished spill file which is used for read.
+struct SpillFileInfo {
+  uint32_t id;
+  RowTypePtr type;
+  std::string path;
+  /// The file size in bytes.
+  uint64_t size;
+  uint32_t numSortKeys;
+  std::vector<CompareFlags> sortFlags;
+  common::CompressionKind compressionKind;
+};
+
+using SpillFiles = std::vector<SpillFileInfo>;
+
+/// Used to write the spilled data to a sequence of files for one partition. If
+/// data is sorted, each file is sorted. The globally sorted order is produced
+/// by merging the constituent files.
+class SpillWriter {
+ public:
+  /// 'type' is a RowType describing the content. 'numSortKeys' is the number
+  /// of leading columns on which the data is sorted. 'path' is a file path
+  /// prefix. ' 'targetFileSize' is the target byte size of a single file.
+  /// 'writeBufferSize' specifies the size limit of the buffered data before
+  /// write to file. 'fileOptions' specifies the file layout on remote storage
+  /// which is storage system specific. 'pool' is used for buffering and
+  /// constructing the result data read from 'this'. 'stats' is used to collect
+  /// the spill write stats.
+  ///
+  /// When writing sorted spill runs, the caller is responsible for buffering
+  /// and sorting the data. write is called multiple times, followed by flush().
+  SpillWriter(
+      const RowTypePtr& type,
+      const uint32_t numSortKeys,
+      const std::vector<CompareFlags>& sortCompareFlags,
+      common::CompressionKind compressionKind,
+      const std::string& pathPrefix,
+      uint64_t targetFileSize,
+      uint64_t writeBufferSize,
+      const std::unordered_map<std::string, std::string>& fileOptions,
+      memory::MemoryPool* pool,
+      folly::Synchronized<common::SpillStats>* stats);
+
+  /// Adds 'rows' for the positions in 'indices' into 'this'. The indices
+  /// must produce a view where the rows are sorted if sorting is desired.
+  /// Consecutive calls must have sorted data so that the first row of the
+  /// next call is not less than the last row of the previous call.
+  /// Returns the size to write.
+  uint64_t write(
+      const RowVectorPtr& rows,
+      const folly::Range<IndexRange*>& indices);
+
+  /// Closes the current output file if any. Subsequent calls to write will
+  /// start a new one.
+  void finishFile();
+
+  /// Finishes this file writer and returns the written spill files info.
+  ///
+  /// NOTE: we don't allow write to a spill writer after t
+  SpillFiles finish();
+
+  std::vector<std::string> testingSpilledFilePaths() const;
+
+  std::vector<uint32_t> testingSpilledFileIds() const;
+
+ private:
+  FOLLY_ALWAYS_INLINE void checkNotFinished() const {
+    VELOX_CHECK(!finished_, "SpillWriter has finished");
+  }
+
+  // Returns an open spill file for write. If there is no open spill file, then
+  // the function creates a new one. If the current open spill file exceeds the
+  // target file size limit, then it first closes the current one and then
+  // creates a new one. 'currentFile_' points to the current open spill file.
+  SpillWriteFile* ensureFile();
+
+  // Closes the current open spill file pointed by 'currentFile_'.
+  void closeFile();
+
+  // Writes data from 'batch_' to the current output file. Returns the actual
+  // written size.
+  uint64_t flush();
+
+  // Invoked to increment the number of spilled files and the file size.
+  void updateSpilledFileStats(uint64_t fileSize);
+
+  // Invoked to update the number of spilled rows.
+  void updateAppendStats(uint64_t numRows, uint64_t serializationTimeUs);
+
+  // Invoked to update the disk write stats.
+  void updateWriteStats(
+      uint64_t spilledBytes,
+      uint64_t flushTimeUs,
+      uint64_t writeTimeUs);
+
+  const RowTypePtr type_;
+  const uint32_t numSortKeys_;
+  const std::vector<CompareFlags> sortCompareFlags_;
+  const common::CompressionKind compressionKind_;
+  const std::string pathPrefix_;
+  const uint64_t targetFileSize_;
+  const uint64_t writeBufferSize_;
+  const std::unordered_map<std::string, std::string> fileOptions_;
+  memory::MemoryPool* const pool_;
+  folly::Synchronized<common::SpillStats>* const stats_;
+
+  bool finished_{false};
+  uint32_t nextFileId_{0};
+  std::unique_ptr<VectorStreamGroup> batch_;
+  std::unique_ptr<SpillWriteFile> currentFile_;
+  SpillFiles finishedFiles_;
+};
+
+/// Input stream backed by spill file.
+///
+/// TODO Usage of ByteInputStream as base class is hacky and just happens to
+/// work. For example, ByteInputStream::size(), seekp(), tellp(),
+/// remainingSize() APIs do not work properly.
+class SpillInputStream : public ByteInputStream {
+ public:
+  /// Reads from 'input' using 'buffer' for buffering reads.
+  SpillInputStream(std::unique_ptr<ReadFile>&& file, BufferPtr buffer)
+      : file_(std::move(file)),
+        size_(file_->size()),
+        buffer_(std::move(buffer)) {
+    next(true);
+  }
+
+  /// True if all of the file has been read into vectors.
+  bool atEnd() const override {
+    return offset_ >= size_ && ranges()[0].position >= ranges()[0].size;
+  }
+
+ private:
+  void next(bool throwIfPastEnd) override;
+
+  const std::unique_ptr<ReadFile> file_;
+  const uint64_t size_;
+  const BufferPtr buffer_;
+
+  // Offset of first byte not in 'buffer_'
+  uint64_t offset_ = 0;
+};
+
+/// Represents a spill file for read which turns the serialized spilled data on
+/// disk back into a sequence of spilled row vectors.
+///
+/// NOTE: The class will not delete spill file upon destruction, so the user
+/// needs to remove the unused spill files at some point later. For example, a
+/// query Task deletes all the generated spill files in one operation using
+/// rmdir() call.
+class SpillReadFile {
+ public:
+  static std::unique_ptr<SpillReadFile> create(
+      const SpillFileInfo& fileInfo,
+      memory::MemoryPool* pool);
+
+  uint32_t id() const {
+    return id_;
+  }
+
+  int32_t numSortKeys() const {
+    return numSortKeys_;
+  }
+
+  const std::vector<CompareFlags>& sortCompareFlags() const {
+    return sortCompareFlags_;
+  }
+
+  bool nextBatch(RowVectorPtr& rowVector);
+
+  /// Returns the file size in bytes.
+  uint64_t size() const {
+    return size_;
+  }
+
+  const std::string& testingFilePath() const {
+    return path_;
+  }
+
+ private:
+  SpillReadFile(
+      uint32_t id,
+      const std::string& path,
+      uint64_t size,
+      const RowTypePtr& type,
+      uint32_t numSortKeys,
+      const std::vector<CompareFlags>& sortCompareFlags,
+      common::CompressionKind compressionKind,
+      memory::MemoryPool* pool);
+
+  // The spill file id which is monotonically increasing and unique for each
+  // associated spill partition.
+  const uint32_t id_;
+  const std::string path_;
+  // The file size in bytes.
+  const uint64_t size_;
+  // The data type of spilled data.
+  const RowTypePtr type_;
+  const uint32_t numSortKeys_;
+  const std::vector<CompareFlags> sortCompareFlags_;
+  const common::CompressionKind compressionKind_;
+  const serializer::presto::PrestoVectorSerde::PrestoOptions readOptions_;
+  memory::MemoryPool* const pool_;
+
+  std::unique_ptr<SpillInputStream> input_;
+};
+} // namespace facebook::velox::exec

--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -282,7 +282,7 @@ void TopNRowNumber::noMoreInput() {
 
     VELOX_CHECK_NULL(merge_);
     auto spillPartition = spiller_->finishSpill();
-    merge_ = spillPartition.createOrderedReader();
+    merge_ = spillPartition.createOrderedReader(pool());
     recordSpillStats(spiller_->stats());
   } else {
     outputRows_.resize(outputBatchSize_);

--- a/velox/exec/tests/HashJoinBridgeTest.cpp
+++ b/velox/exec/tests/HashJoinBridgeTest.cpp
@@ -87,29 +87,21 @@ class HashJoinBridgeTest : public testing::Test,
     return futures;
   }
 
-  void createFile(const std::string& filePath) {
-    auto fs = filesystems::getFileSystem(filePath, nullptr);
-    // File object dtor will close the file.
-    auto file = fs->openFileForWrite(filePath);
-  }
-
   SpillFiles makeFakeSpillFiles(int32_t numFiles) {
     static uint32_t fakeFileId{0};
     SpillFiles files;
     files.reserve(numFiles);
+    const std::string filePathPrefix = tempDir_->path + "/Spill";
     for (int32_t i = 0; i < numFiles; ++i) {
-      files.push_back(std::make_unique<SpillFile>(
-          fakeFileId++,
-          rowType_,
-          1,
-          std::vector<CompareFlags>({}),
-          tempDir_->path + "/Spill",
-          common::CompressionKind_NONE,
-          pool_.get(),
-          std::unordered_map<std::string, std::string>{}));
-      // Create a fake file to avoid too many exception logs in test when spill
-      // file deletion fails.
-      createFile(files.back()->testingFilePath());
+      const auto fileId = fakeFileId;
+      files.push_back(
+          {fileId,
+           rowType_,
+           tempDir_->path + "/Spill_" + std::to_string(fileId),
+           1024,
+           1,
+           std::vector<CompareFlags>({}),
+           common::CompressionKind_NONE});
     }
     return files;
   }

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -560,9 +560,9 @@ class SpillerTest : public exec::test::RowContainerTestBase {
 
     // We make a merge reader that merges the spill files and the rows that
     // are still in the RowContainer.
-    auto merge = spillPartition->createOrderedReader();
+    auto merge = spillPartition->createOrderedReader(pool());
     ASSERT_TRUE(merge != nullptr);
-    ASSERT_TRUE(spillPartition->createOrderedReader() == nullptr);
+    ASSERT_TRUE(spillPartition->createOrderedReader(pool()) == nullptr);
 
     // We read the spilled data back and check that it matches the sorted
     // order of the partition.
@@ -856,7 +856,7 @@ class SpillerTest : public exec::test::RowContainerTestBase {
       const int partition = spillPartitionEntry.first.partitionNumber();
       ASSERT_EQ(
           hashBits_.begin(), spillPartitionEntry.first.partitionBitOffset());
-      auto reader = spillPartitionEntry.second->createUnorderedReader();
+      auto reader = spillPartitionEntry.second->createUnorderedReader(pool());
       if (type_ == Spiller::Type::kHashJoinProbe) {
         // For hash probe type, we append each input vector as one batch in
         // spill file so that we can do one-to-one comparison.
@@ -928,7 +928,7 @@ class SpillerTest : public exec::test::RowContainerTestBase {
       const int partition = spillPartitionEntry.first.partitionNumber();
       ASSERT_EQ(
           hashBits_.begin(), spillPartitionEntry.first.partitionBitOffset());
-      auto reader = spillPartitionEntry.second->createUnorderedReader();
+      auto reader = spillPartitionEntry.second->createUnorderedReader(pool());
       if (type_ == Spiller::Type::kHashJoinProbe) {
         // For hash probe type, we append each input vector as one batch in
         // spill file so that we can do one-to-one comparison.
@@ -1272,7 +1272,7 @@ TEST_P(AggregationOutputOnly, basic) {
     ASSERT_TRUE(spiller_->finalized());
 
     const int expectedNumSpilledRows = numRows - numListedRows;
-    auto merge = spillPartition.createOrderedReader();
+    auto merge = spillPartition.createOrderedReader(pool());
     if (expectedNumSpilledRows == 0) {
       ASSERT_TRUE(merge == nullptr);
     } else {


### PR DESCRIPTION
Split SpillFile into SpillWriteFile, SpillReadFile and SpillFileInfo:
- SpillWriteFile is responsible to write serialized spill data onto disk;
- SpillFileInfo contains the written spill file info like spill data type file path, size, and
   compression kind etc. It is used to read back the spill data on disk;
- SpillReadFile read the serialized spill data from disk and turns them back into a 
   sequence of row vectors
Rename SpillFileList to SpillWriter which is responsible to write spill data stream into
a sequence of spill files, and returns the generated SpillFileInfo for read. There is one
SpillWriter per partition.
SpillReadFile takes the operator memory pool instead of system spill memory pool.

The followup is to refactor the spiller constructor and remove the spiller type enum.