### PR TITLE
Fix Parquet writer to produce evenly-sized row groups

### DIFF
--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <arrow/record_batch.h>
+
 #include "velox/common/compression/Compression.h"
 #include "velox/dwio/common/DataBuffer.h"
 #include "velox/dwio/common/FileSink.h"
@@ -43,7 +45,7 @@ class DefaultFlushPolicy : public dwio::common::FlushPolicy {
 
   bool shouldFlush(
       const dwio::common::StripeProgress& stripeProgress) override {
-    return stripeProgress.stripeRowCount >= rowsInRowGroup_ ||
+    return stripeProgress.stripeRowCount == rowsInRowGroup_ ||
         stripeProgress.stripeSizeEstimate >= bytesInRowGroup_;
   }
 
@@ -146,6 +148,11 @@ class Writer : public dwio::common::Writer {
   std::shared_ptr<ArrowContext> arrowContext_;
 
   std::unique_ptr<DefaultFlushPolicy> flushPolicy_;
+
+  void stageBatch(
+      const std::shared_ptr<::arrow::RecordBatch>& recordBatch,
+      uint64_t numRows,
+      int64_t bytes);
 };
 
 class ParquetWriterFactory : public dwio::common::WriterFactory {


### PR DESCRIPTION
When setting `parquet::DefaultFlushPolicy::rowsInRowGroup_`, Velox parquet writer might not produce consistent row groups in the output file. This patch ensures the exact number of rows for each row group is flushed if possible.

This PR makes the following changes:

When a new call to `write(data)` is made, it first flushes the cached batches if the staging rows or bytes meet the flush condition. Whether flushed or not, it performs the following operations on the input data:

1. If stagingRows + data->size() <= `parquet::DefaultFlushPolicy::rowsInRowGroup_`, cache the data and return.
2. If stagingRows + data->size() > `parquet::DefaultFlushPolicy::rowsInRowGroup_`, slice the data in a loop so that each block has exactly `rowsInRowGroup_` rows, until the remainingData <= `rowsInRowGrop_`. 
After slicing, the data will be like: `| stagingRows + sliced data1 | sliced data2 | ... | (remaining data)`
Except for the remaining data, all data will be flushed before the next slice. Cache the remaining data and return.

Issue: #7733 