### PR TITLE
Add RowVector::childAt(name) API

### DIFF
--- a/velox/exec/tests/AggregationFuzzerTest.cpp
+++ b/velox/exec/tests/AggregationFuzzerTest.cpp
@@ -450,8 +450,7 @@ class ApproxDistinctResultVerifier : public ResultVerifier {
         std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(args[1]);
     VELOX_CHECK_NOT_NULL(field);
     auto errorVector =
-        input->childAt(input->type()->asRow().getChildIdx(field->name()))
-            ->as<SimpleVector<double>>();
+        input->childAt(field->name())->as<SimpleVector<double>>();
     return errorVector->valueAt(0);
   }
 

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -133,6 +133,16 @@ class RowVector : public BaseVector {
     return children_[index];
   }
 
+  /// Returns child vector for the specified field name. Throws if field with
+  /// specified name doesn't exist.
+  VectorPtr& childAt(const std::string& name) {
+    return children_[type_->asRow().getChildIdx(name)];
+  }
+
+  const VectorPtr& childAt(const std::string& name) const {
+    return children_[type_->asRow().getChildIdx(name)];
+  }
+
   std::vector<VectorPtr>& children() {
     return children_;
   }

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -1077,6 +1077,14 @@ TEST_F(VectorTest, row) {
   VELOX_ASSERT_THROW(
       rowVector->childAt(3)->resize(vectorSize_),
       "Trying to access non-existing child in RowVector:");
+
+  ASSERT_EQ(
+      rowVector->childAt("parent_bigint").get(), rowVector->childAt(0).get());
+  ASSERT_EQ(
+      rowVector->childAt("parent_row").get(), rowVector->childAt(1).get());
+  VELOX_ASSERT_THROW(
+      rowVector->childAt("foo"),
+      "Field not found: foo. Available fields are: parent_bigint, parent_row.");
 }
 
 TEST_F(VectorTest, array) {


### PR DESCRIPTION
Add convenience API to get a child vector by name from a RowVector.