### PR TITLE
Fix compiler warning issues in velox/exec/SharedArbitrator.h

### DIFF
--- a/velox/exec/SharedArbitrator.h
+++ b/velox/exec/SharedArbitrator.h
@@ -21,9 +21,8 @@
 #include "velox/common/future/VeloxPromise.h"
 #include "velox/common/memory/Memory.h"
 
-using namespace facebook::velox::memory;
-
 namespace facebook::velox::exec {
+using namespace facebook::velox::memory;
 
 /// Used to achieve dynamic memory sharing among running queries. When a
 /// memory pool exceeds its current memory capacity, the arbitrator tries to


### PR DESCRIPTION
Summary:
This diff fixes issues identified by one or more of these compiler warning flags:
* `-Wpessimizing-move`
* `-Wmissing-braces `
* `-Wself-assign`
* `-Wunused-lambda-capture `
* `-Wheader-hygiene`
* `-Wunused-variable`

If the code compiles, it should work.

Differential Revision: D51571575


