### PR TITLE
Fix flaky tsan shared arbitrator test

### DIFF
--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -193,6 +193,13 @@ std::shared_ptr<Task> AssertQueryBuilder::assertTypeAndNumRows(
 }
 
 RowVectorPtr AssertQueryBuilder::copyResults(memory::MemoryPool* pool) {
+  std::shared_ptr<Task> unused;
+  return copyResults(pool, unused);
+}
+
+RowVectorPtr AssertQueryBuilder::copyResults(
+    memory::MemoryPool* pool,
+    std::shared_ptr<Task>& task) {
   auto [cursor, results] = readCursor();
 
   if (results.empty()) {
@@ -213,6 +220,7 @@ RowVectorPtr AssertQueryBuilder::copyResults(memory::MemoryPool* pool) {
     copyCount += result->size();
   }
 
+  task = cursor->task();
   return copy;
 }
 

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -135,6 +135,11 @@ class AssertQueryBuilder {
   /// query returns empty result.
   RowVectorPtr copyResults(memory::MemoryPool* pool);
 
+  /// Similar to above method and also returns the task.
+  RowVectorPtr copyResults(
+      memory::MemoryPool* pool,
+      std::shared_ptr<Task>& task);
+
  private:
   std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>>
   readCursor();


### PR DESCRIPTION
Duckdb is not threadsafe so switch to compare the result with and without
spilling for data verification. Also make a counter atomic to avoid tsan flakiness