### PR TITLE
Skip any_value from AggregationFuzzer.

### DIFF
--- a/velox/exec/tests/AggregationFuzzerTest.cpp
+++ b/velox/exec/tests/AggregationFuzzerTest.cpp
@@ -554,6 +554,7 @@ int main(int argc, char** argv) {
           {"approx_set", nullptr},
           {"approx_percentile", nullptr},
           {"arbitrary", nullptr},
+          {"any_value", nullptr},
           {"array_agg", makeArrayVerifier()},
           {"set_agg", makeArrayVerifier()},
           {"set_union", makeArrayVerifier()},


### PR DESCRIPTION
Summary: any_value is an alias for arbitrary. Skipping result verification in aggregation fuzzer. Note that, the fuzzer will still generate plans with this function and alert if there are any failures or crashes.

Reviewed By: kgpai

Differential Revision: D51601633


