### PR TITLE
Avoid unnecessary shared_ptr construction/destruction in ensureWritable

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -581,7 +581,7 @@ void BaseVector::ensureWritable(
     }
     return;
   }
-  auto resultType = result->type();
+  const auto& resultType = result->type();
   bool isUnknownType = resultType->containsUnknown();
   if (result->encoding() == VectorEncoding::Simple::LAZY) {
     result = BaseVector::loadedVectorShared(result);


### PR DESCRIPTION
Summary: When calling copy() on complex types in a loop, the profile is filled with share_ptr construction/destruction. Replace the related logic with reference.

Reviewed By: mbasmanova

Differential Revision: D51603289


