### PR TITLE
Add PlanBuilder::appendColumn API

### DIFF
--- a/velox/exec/tests/AggregationFuzzerTest.cpp
+++ b/velox/exec/tests/AggregationFuzzerTest.cpp
@@ -363,17 +363,15 @@ class ApproxDistinctResultVerifier : public ResultVerifier {
     // pairs of actual and expected values per group. We cannot use join because
     // grouping keys may have nulls.
     auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
-    auto expectedSource =
-        PlanBuilder(planNodeIdGenerator)
-            .values({expected_})
-            .project(append(groupingKeys_, {name_, "'expected' as label"}))
-            .planNode();
+    auto expectedSource = PlanBuilder(planNodeIdGenerator)
+                              .values({expected_})
+                              .appendColumns({"'expected' as label"})
+                              .planNode();
 
-    auto actualSource =
-        PlanBuilder(planNodeIdGenerator)
-            .values({result})
-            .project(append(groupingKeys_, {name_, "'actual' as label"}))
-            .planNode();
+    auto actualSource = PlanBuilder(planNodeIdGenerator)
+                            .values({result})
+                            .appendColumns({"'actual' as label"})
+                            .planNode();
 
     auto mapAgg = fmt::format("map_agg(label, {}) as m", name_);
     auto plan = PlanBuilder(planNodeIdGenerator)
@@ -472,14 +470,6 @@ class ApproxDistinctResultVerifier : public ResultVerifier {
     }
 
     return countDistinctCall;
-  }
-
-  static std::vector<std::string> append(
-      const std::vector<std::string>& values,
-      const std::vector<std::string>& newValues) {
-    std::vector<std::string> combined = values;
-    combined.insert(combined.end(), newValues.begin(), newValues.end());
-    return combined;
   }
 
   const std::string transform_;

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -323,6 +323,17 @@ PlanBuilder& PlanBuilder::project(const std::vector<std::string>& projections) {
   return projectExpressions(expressions);
 }
 
+PlanBuilder& PlanBuilder::appendColumns(
+    const std::vector<std::string>& newColumns) {
+  VELOX_CHECK_NOT_NULL(planNode_, "Project cannot be the source node");
+  std::vector<std::string> allProjections = planNode_->outputType()->names();
+  for (const auto& column : newColumns) {
+    allProjections.push_back(column);
+  }
+
+  return project(allProjections);
+}
+
 PlanBuilder& PlanBuilder::optionalFilter(const std::string& optionalFilter) {
   if (optionalFilter.empty()) {
     return *this;

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -339,6 +339,12 @@ class PlanBuilder {
   /// will produce projected columns named sum_ab, c and p2.
   PlanBuilder& project(const std::vector<std::string>& projections);
 
+  /// Add a ProjectNode to keep all existing columns and append more columns
+  /// using specified expressions.
+  /// @param newColumns A list of one or more expressions to use for computing
+  /// additional columns.
+  PlanBuilder& appendColumns(const std::vector<std::string>& newColumns);
+
   /// Variation of project that takes untyped expressions.  Used for access
   /// deeply nested types, in which case Duck DB often fails to parse or infer
   /// the type.


### PR DESCRIPTION
Add a convenient API to add a ProjectNode to append columns using specified expressions.