### PR TITLE
Rename tableScan to tpchTableScan in PlanBuilder

### DIFF
--- a/velox/connectors/tpch/tests/SpeedTest.cpp
+++ b/velox/connectors/tpch/tests/SpeedTest.cpp
@@ -74,7 +74,7 @@ class TpchSpeedTest {
     core::PlanNodeId scanId;
     auto plan =
         PlanBuilder()
-            .tableScan(
+            .tpchTableScan(
                 table, folly::copy(getTableSchema(table)->names()), scaleFactor)
             .capturePlanNodeId(scanId)
             .planNode();

--- a/velox/docs/velox-in-10-min.rst
+++ b/velox/docs/velox-in-10-min.rst
@@ -324,7 +324,7 @@ provide a split.
 .. code-block:: c++
 
   plan = PlanBuilder()
-             .tableScan(
+             .tpchTableScan(
                  tpch::Table::TBL_NATION,
                  {"n_nationkey", "n_name"},
                  1 /*scaleFactor*/)
@@ -367,14 +367,14 @@ IDs.
   core::PlanNodeId nationScanId;
   core::PlanNodeId regionScanId;
   plan = PlanBuilder(planNodeIdGenerator)
-             .tableScan(
+             .tpchTableScan(
                  tpch::Table::TBL_NATION, {"n_regionkey"}, 1 /*scaleFactor*/)
              .capturePlanNodeId(nationScanId)
              .hashJoin(
                  {"n_regionkey"},
                  {"r_regionkey"},
                  PlanBuilder(planNodeIdGenerator)
-                     .tableScan(
+                     .tpchTableScan(
                          tpch::Table::TBL_REGION,
                          {"r_regionkey", "r_name"},
                          1 /*scaleFactor*/)

--- a/velox/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -85,7 +85,7 @@ class ParquetTpchTest : public testing::Test {
       auto tableSchema = tpch::getTableSchema(table);
       auto columnNames = tableSchema->names();
       auto plan = PlanBuilder()
-                      .tableScan(table, std::move(columnNames), 0.01)
+                      .tpchTableScan(table, std::move(columnNames), 0.01)
                       .planNode();
       auto split =
           exec::Split(std::make_shared<connector::tpch::TpchConnectorSplit>(

--- a/velox/exec/tests/VeloxIn10MinDemo.cpp
+++ b/velox/exec/tests/VeloxIn10MinDemo.cpp
@@ -233,7 +233,7 @@ void VeloxIn10MinDemo::run() {
   // nation table and print first 10 rows.
 
   plan = PlanBuilder()
-             .tableScan(
+             .tpchTableScan(
                  tpch::Table::TBL_NATION,
                  {"n_nationkey", "n_name"},
                  1 /*scaleFactor*/)
@@ -259,14 +259,14 @@ void VeloxIn10MinDemo::run() {
   core::PlanNodeId nationScanId;
   core::PlanNodeId regionScanId;
   plan = PlanBuilder(planNodeIdGenerator)
-             .tableScan(
+             .tpchTableScan(
                  tpch::Table::TBL_NATION, {"n_regionkey"}, 1 /*scaleFactor*/)
              .capturePlanNodeId(nationScanId)
              .hashJoin(
                  {"n_regionkey"},
                  {"r_regionkey"},
                  PlanBuilder(planNodeIdGenerator)
-                     .tableScan(
+                     .tpchTableScan(
                          tpch::Table::TBL_REGION,
                          {"r_regionkey", "r_name"},
                          1 /*scaleFactor*/)

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -121,7 +121,7 @@ PlanBuilder& PlanBuilder::tableScan(
       .endTableScan();
 }
 
-PlanBuilder& PlanBuilder::tableScan(
+PlanBuilder& PlanBuilder::tpchTableScan(
     tpch::Table table,
     std::vector<std::string>&& columnNames,
     double scaleFactor) {

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -166,7 +166,7 @@ class PlanBuilder {
   /// and scale factor.
   /// @param columnNames The columns to be returned from that table.
   /// @param scaleFactor The TPC-H scale factor.
-  PlanBuilder& tableScan(
+  PlanBuilder& tpchTableScan(
       tpch::Table table,
       std::vector<std::string>&& columnNames,
       double scaleFactor = 1);


### PR DESCRIPTION
A `tableScan` API in PlanBuilder is specific to the TPC-H connector.
Rename it to `tpchTableScan` to clarify the scope.