### PR TITLE
Improve output of WindowNode::toString

### DIFF
--- a/velox/exec/tests/PlanBuilderTest.cpp
+++ b/velox/exec/tests/PlanBuilderTest.cpp
@@ -115,7 +115,7 @@ TEST_F(PlanBuilderTest, windowFunctionCall) {
           .planNode()
           ->toString(true, false),
       "-- Window[partition by [a] order by [b ASC NULLS LAST] "
-      "d := window1(ROW[\"c\"]) RANGE between UNBOUNDED PRECEDING and CURRENT ROW inputsSorted [0]] "
+      "d := window1(ROW[\"c\"]) RANGE between UNBOUNDED PRECEDING and CURRENT ROW] "
       "-> a:VARCHAR, b:BIGINT, c:BIGINT, d:BIGINT\n");
 
   VELOX_CHECK_EQ(
@@ -124,8 +124,8 @@ TEST_F(PlanBuilderTest, windowFunctionCall) {
           .window({"window1(c) over (partition by a) as d"})
           .planNode()
           ->toString(true, false),
-      "-- Window[partition by [a] order by [] "
-      "d := window1(ROW[\"c\"]) RANGE between UNBOUNDED PRECEDING and CURRENT ROW inputsSorted [0]] "
+      "-- Window[partition by [a] "
+      "d := window1(ROW[\"c\"]) RANGE between UNBOUNDED PRECEDING and CURRENT ROW] "
       "-> a:VARCHAR, b:BIGINT, c:BIGINT, d:BIGINT\n");
 
   VELOX_CHECK_EQ(
@@ -134,8 +134,7 @@ TEST_F(PlanBuilderTest, windowFunctionCall) {
           .window({"window1(c) over ()"})
           .planNode()
           ->toString(true, false),
-      "-- Window[partition by [] order by [] "
-      "w0 := window1(ROW[\"c\"]) RANGE between UNBOUNDED PRECEDING and CURRENT ROW inputsSorted [0]] "
+      "-- Window[w0 := window1(ROW[\"c\"]) RANGE between UNBOUNDED PRECEDING and CURRENT ROW] "
       "-> a:VARCHAR, b:BIGINT, c:BIGINT, w0:BIGINT\n");
 
   VELOX_ASSERT_THROW(
@@ -184,7 +183,7 @@ TEST_F(PlanBuilderTest, windowFrame) {
       "d7 := window1(ROW[\"c\"]) ROWS between CURRENT ROW and UNBOUNDED FOLLOWING, "
       "d8 := window1(ROW[\"c\"]) RANGE between CURRENT ROW and UNBOUNDED FOLLOWING, "
       "d9 := window1(ROW[\"c\"]) RANGE between UNBOUNDED PRECEDING and UNBOUNDED FOLLOWING, "
-      "d10 := window1(ROW[\"c\"]) RANGE between UNBOUNDED PRECEDING and UNBOUNDED FOLLOWING inputsSorted [0]] "
+      "d10 := window1(ROW[\"c\"]) RANGE between UNBOUNDED PRECEDING and UNBOUNDED FOLLOWING] "
       "-> a:VARCHAR, b:BIGINT, c:BIGINT, d1:BIGINT, d2:BIGINT, d3:BIGINT, d4:BIGINT, "
       "d5:BIGINT, d6:BIGINT, d7:BIGINT, d8:BIGINT, d9:BIGINT, d10:BIGINT\n");
 


### PR DESCRIPTION
Improve the output of WindowNode::toString:

- Remove inputsSorted [0] suffix
- Replace inputsSorted [1] suffix with STREAMING prefix