### PR TITLE
Fix memory reservation leak if sort writer fails on close

### DIFF
--- a/velox/dwio/common/SortingWriter.cpp
+++ b/velox/dwio/common/SortingWriter.cpp
@@ -40,6 +40,10 @@ SortingWriter::SortingWriter(
   setState(State::kRunning);
 }
 
+SortingWriter::~SortingWriter() {
+  sortPool_->release();
+}
+
 void SortingWriter::write(const VectorPtr& data) {
   checkRunning();
   sortBuffer_->addInput(data);

--- a/velox/dwio/common/SortingWriter.h
+++ b/velox/dwio/common/SortingWriter.h
@@ -32,6 +32,8 @@ class SortingWriter : public Writer {
       uint64_t maxOutputBytesConfig,
       velox::common::SpillStats* spillStats);
 
+  ~SortingWriter() override;
+
   void write(const VectorPtr& data) override;
 
   /// No action because we need to accumulate all data and sort before data can

--- a/velox/exec/tests/OperatorUtilsTest.cpp
+++ b/velox/exec/tests/OperatorUtilsTest.cpp
@@ -447,9 +447,9 @@ TEST_F(OperatorUtilsTest, memStatsFromPool) {
   auto leafPool = rootPool_->addLeafChild("leaf-1.0");
   void* buffer;
   buffer = leafPool->allocate(2L << 20);
-  leafPool->free(buffer, 1L << 20);
-  auto stats = MemoryStats::memStatsFromPool(leafPool.get());
-  ASSERT_EQ(stats.userMemoryReservation, 1L << 20);
+  leafPool->free(buffer, 2L << 20);
+  const auto stats = MemoryStats::memStatsFromPool(leafPool.get());
+  ASSERT_EQ(stats.userMemoryReservation, 0);
   ASSERT_EQ(stats.systemMemoryReservation, 0);
   ASSERT_EQ(stats.peakUserMemoryReservation, 2L << 20);
   ASSERT_EQ(stats.peakSystemMemoryReservation, 0);

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -31,9 +31,10 @@
 #include "velox/parse/TypeResolver.h"
 #include "velox/serializers/PrestoSerializer.h"
 
-using namespace facebook::velox::common::testutil;
-
+DECLARE_bool(velox_memory_leak_check_enabled);
 DECLARE_bool(velox_enable_memory_usage_track_in_default_memory_pool);
+
+using namespace facebook::velox::common::testutil;
 
 namespace facebook::velox::exec::test {
 
@@ -54,6 +55,7 @@ OperatorTestBase::~OperatorTestBase() {
 
 void OperatorTestBase::SetUpTestCase() {
   FLAGS_velox_enable_memory_usage_track_in_default_memory_pool = true;
+  FLAGS_velox_memory_leak_check_enabled = true;
   exec::SharedArbitrator::registerFactory();
   functions::prestosql::registerAllScalarFunctions();
   aggregate::prestosql::registerAllAggregateFunctions();


### PR DESCRIPTION
Fix the memory reservation leak from sort pool when data sink close
fails. We add to release the unused reserved memory on sort writer
destruction. Add a unit test to reproduce the crash and verify the fix.

This PR also adds to respect the min memory reservation spill config
discovered by the new unit test.