### PR TITLE
Add OderBy output stage spill

### DIFF
--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -78,10 +78,6 @@ void OrderBy::reclaim(
     memory::MemoryReclaimer::Stats& stats) {
   VELOX_CHECK(canReclaim());
   VELOX_CHECK(!nonReclaimableSection_);
-  auto* driver = operatorCtx_->driver();
-
-  // NOTE: an order by operator is reclaimable if it is not under
-  // non-reclaimable execution section.
   if (noMoreInput_) {
     sortBuffer_->spillOutput();
   } else {

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -80,11 +80,11 @@ void OrderBy::reclaim(
   VELOX_CHECK(!nonReclaimableSection_);
   auto* driver = operatorCtx_->driver();
 
-  // NOTE: an order by operator is reclaimable if it hasn't started output
-  // processing and is not under non-reclaimable execution section.
+  // NOTE: an order by operator is reclaimable if it is not under
+  // non-reclaimable execution section.
   if (noMoreInput_) {
+    sortBuffer_->spillOutput();
     // TODO: reduce the log frequency if it is too verbose.
-    ++stats.numNonReclaimableAttempts;
     LOG(WARNING)
         << "Can't reclaim from order by operator which has started producing output: "
         << pool()->name()

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -78,13 +78,11 @@ void OrderBy::reclaim(
     memory::MemoryReclaimer::Stats& stats) {
   VELOX_CHECK(canReclaim());
   VELOX_CHECK(!nonReclaimableSection_);
-  if (noMoreInput_) {
-    sortBuffer_->spillOutput();
-  } else {
-    // TODO: support fine-grain disk spilling based on 'targetBytes' after
-    // having row container memory compaction support later.
-    sortBuffer_->spill();
-  }
+
+  // TODO: support fine-grain disk spilling based on 'targetBytes' after
+  // having row container memory compaction support later.
+  sortBuffer_->spill();
+
   // Release the minimum reserved memory.
   pool()->release();
 }

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -84,18 +84,11 @@ void OrderBy::reclaim(
   // non-reclaimable execution section.
   if (noMoreInput_) {
     sortBuffer_->spillOutput();
-    // TODO: reduce the log frequency if it is too verbose.
-    LOG(WARNING)
-        << "Can't reclaim from order by operator which has started producing output: "
-        << pool()->name()
-        << ", usage: " << succinctBytes(pool()->currentBytes())
-        << ", reservation: " << succinctBytes(pool()->reservedBytes());
-    return;
+  } else {
+    // TODO: support fine-grain disk spilling based on 'targetBytes' after
+    // having row container memory compaction support later.
+    sortBuffer_->spill();
   }
-
-  // TODO: support fine-grain disk spilling based on 'targetBytes' after having
-  // row container memory compaction support later.
-  sortBuffer_->spill();
   // Release the minimum reserved memory.
   pool()->release();
 }

--- a/velox/exec/SortBuffer.cpp
+++ b/velox/exec/SortBuffer.cpp
@@ -217,7 +217,7 @@ void SortBuffer::spillOutput() {
 
   auto spillRows = std::vector<char*>(
       sortedRows_.begin() + numOutputRows_, sortedRows_.end());
-  spiller_->spill(std::move(spillRows));
+  spiller_->spill(spillRows);
   data_->clear();
   sortedRows_.clear();
   finishSpill();

--- a/velox/exec/SortBuffer.cpp
+++ b/velox/exec/SortBuffer.cpp
@@ -222,6 +222,12 @@ void SortBuffer::spillOutput() {
   auto spillRows = std::vector<char*>(
       sortedRows_.begin() + numOutputRows_, sortedRows_.end());
   spiller_->spill(std::move(spillRows));
+  // Finish spill, and we shouldn't get any rows from non-spilled partition as
+  // there is only one hash partition for SortBuffer.
+  VELOX_CHECK_NULL(spillMerger_);
+  auto spillPartition = spiller_->finishSpill();
+  spillMerger_ = spillPartition.createOrderedReader(pool());
+
   data_->clear();
   sortedRows_.clear();
 }

--- a/velox/exec/SortBuffer.h
+++ b/velox/exec/SortBuffer.h
@@ -58,10 +58,6 @@ class SortBuffer {
   /// Invoked to spill all the rows from 'data_'.
   void spill();
 
-  /// Invoked to spill the rest of the rows from 'data_' during output
-  /// processing, it should actually spill at most once.
-  void spillOutput();
-
   memory::MemoryPool* pool() const {
     return pool_;
   }
@@ -88,6 +84,8 @@ class SortBuffer {
   // Finish spill, and we shouldn't get any rows from non-spilled partition as
   // there is only one hash partition for SortBuffer.
   void finishSpill();
+
+  std::unique_ptr<Spiller> makeSpiller(Spiller::Type type);
 
   const RowTypePtr input_;
   const std::vector<CompareFlags> sortCompareFlags_;

--- a/velox/exec/SortBuffer.h
+++ b/velox/exec/SortBuffer.h
@@ -58,6 +58,10 @@ class SortBuffer {
   /// Invoked to spill all the rows from 'data_'.
   void spill();
 
+  /// Invoked to spill the rest of the rows from 'data_' during output
+  /// processing, it should actually spill at most once.
+  void spillOutput();
+
   memory::MemoryPool* pool() const {
     return pool_;
   }

--- a/velox/exec/SortBuffer.h
+++ b/velox/exec/SortBuffer.h
@@ -85,6 +85,10 @@ class SortBuffer {
   void getOutputWithoutSpill();
   void getOutputWithSpill();
 
+  // Finish spill, and we shouldn't get any rows from non-spilled partition as
+  // there is only one hash partition for SortBuffer.
+  void finishSpill();
+
   const RowTypePtr input_;
   const std::vector<CompareFlags> sortCompareFlags_;
   velox::memory::MemoryPool* const pool_;

--- a/velox/exec/SortBuffer.h
+++ b/velox/exec/SortBuffer.h
@@ -80,12 +80,13 @@ class SortBuffer {
   void prepareOutput(uint32_t maxOutputRows);
   void getOutputWithoutSpill();
   void getOutputWithSpill();
-
+  // Spill during input stage.
+  void spillInput();
+  // Spill during output stage.
+  void spillOutput();
   // Finish spill, and we shouldn't get any rows from non-spilled partition as
   // there is only one hash partition for SortBuffer.
   void finishSpill();
-
-  std::unique_ptr<Spiller> makeSpiller(Spiller::Type type);
 
   const RowTypePtr input_;
   const std::vector<CompareFlags> sortCompareFlags_;

--- a/velox/exec/SortWindowBuild.cpp
+++ b/velox/exec/SortWindowBuild.cpp
@@ -140,7 +140,7 @@ void SortWindowBuild::setupSpiller() {
 
   spiller_ = std::make_unique<Spiller>(
       // TODO Replace Spiller::Type::kOrderBy.
-      Spiller::Type::kOrderBy,
+      Spiller::Type::kOrderByInput,
       data_.get(),
       inputType_,
       spillCompareFlags_.size(),

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -491,7 +491,7 @@ void Spiller::spill(const RowContainerIterator* startRowIter) {
   checkEmptySpillRuns();
 }
 
-void Spiller::spill(std::vector<char*> rows) {
+void Spiller::spill(std::vector<char*>& rows) {
   CHECK_NOT_FINALIZED();
   VELOX_CHECK_EQ(type_, Type::kOrderByOutput);
   if (rows.empty()) {
@@ -500,7 +500,7 @@ void Spiller::spill(std::vector<char*> rows) {
 
   markAllPartitionsSpilled();
 
-  fillSinglePartition(rows);
+  fillSpillRun(rows);
   runSpill();
   checkEmptySpillRuns();
 }
@@ -615,7 +615,7 @@ void Spiller::fillSpillRuns(const RowContainerIterator* startRowIter) {
   updateSpillFillTime(execTimeUs);
 }
 
-void Spiller::fillSinglePartition(std::vector<char*>& rows) {
+void Spiller::fillSpillRun(std::vector<char*>& rows) {
   VELOX_CHECK_EQ(bits_.numPartitions(), 1);
   checkEmptySpillRuns();
   uint64_t execTimeUs{0};
@@ -623,7 +623,7 @@ void Spiller::fillSinglePartition(std::vector<char*>& rows) {
     MicrosecondTimer timer(&execTimeUs);
     spillRuns_[0].rows =
         SpillRows(rows.begin(), rows.end(), spillRuns_[0].rows.get_allocator());
-    for (auto row : rows) {
+    for (const auto& row : rows) {
       spillRuns_[0].numBytes += container_->rowSize(row);
     }
   }

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -495,7 +495,10 @@ void Spiller::spill(const RowContainerIterator* startRowIter) {
 
 void Spiller::spill(std::vector<char*> rows) {
   CHECK_NOT_FINALIZED();
-  VELOX_CHECK_NE(type_, Type::kHashJoinProbe);
+  VELOX_CHECK_EQ(type_, Type::kOrderByOutput);
+  if (rows.empty()) {
+    return;
+  }
 
   // Marks all the partitions have been spilled as we don't support fine-grained
   // spilling as for now.

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -623,7 +623,7 @@ void Spiller::fillSpillRun(std::vector<char*>& rows) {
     MicrosecondTimer timer(&execTimeUs);
     spillRuns_[0].rows =
         SpillRows(rows.begin(), rows.end(), spillRuns_[0].rows.get_allocator());
-    for (const auto& row : rows) {
+    for (const auto* row : rows) {
       spillRuns_[0].numBytes += container_->rowSize(row);
     }
   }

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -283,8 +283,8 @@ class Spiller {
 
   void checkEmptySpillRuns() const;
 
-  /// Marks all the partitions have been spilled as we don't support
-  /// fine-grained spilling as for now.
+  // Marks all the partitions have been spilled as we don't support
+  // fine-grained spilling as for now.
   void markAllPartitionsSpilled();
 
   // Prepares spill runs for the spillable data from all the hash partitions.
@@ -292,8 +292,8 @@ class Spiller {
   // pointed by 'startRowIter'.
   void fillSpillRuns(const RowContainerIterator* startRowIter = nullptr);
 
-  /// Prepares spill run of a single partition for the spillable data from the
-  /// rows.
+  // Prepares spill run of a single partition for the spillable data from the
+  // rows.
   void fillSpillRun(std::vector<char*>& rows);
 
   // Writes out all the rows collected in spillRuns_.

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -42,6 +42,7 @@ class Spiller {
     // Number of spiller types.
     kNumTypes = 6,
   };
+
   static std::string typeName(Type);
 
   using SpillRows = std::vector<char*, memory::StlAllocator<char*>>;

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -121,7 +121,10 @@ class Spiller {
   /// The caller needs to erase them from the row container.
   void spill(const RowContainerIterator& startRowIter);
 
-  /// Invoked to spill. Spill all rows pointed by the pointers in sortedRows.
+  /// Invoked to spill.Spill all rows pointed by the pointers in sortedRows.This
+  /// is only used by 'kOrderByOutput' spiller type to spill during the order by
+  /// output processing. Similarly, the spilled rows still stays in the row
+  /// container.The caller needs to erase them from the row container.
   void spill(std::vector<char*> sortedRows);
 
   /// Append 'spillVector' into the spill file of given 'partition'. It is now

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -121,11 +121,11 @@ class Spiller {
   /// The caller needs to erase them from the row container.
   void spill(const RowContainerIterator& startRowIter);
 
-  /// Invoked to spill.Spill all rows pointed by the pointers in sortedRows.This
-  /// is only used by 'kOrderByOutput' spiller type to spill during the order by
+  /// Invoked to spill all the rows pointed by rows. This is used by
+  /// 'kOrderByOutput' spiller type to spill during the order by
   /// output processing. Similarly, the spilled rows still stays in the row
-  /// container.The caller needs to erase them from the row container.
-  void spill(std::vector<char*> sortedRows);
+  /// container. The caller needs to erase them from the row container.
+  void spill(std::vector<char*> rows);
 
   /// Append 'spillVector' into the spill file of given 'partition'. It is now
   /// only used by the spilling operator which doesn't need data sort, such as
@@ -283,6 +283,8 @@ class Spiller {
 
   void checkEmptySpillRuns() const;
 
+  /// Marks all the partitions have been spilled as we don't support
+  /// fine-grained spilling as for now.
   void markAllPartitionsSpilled();
 
   // Prepares spill runs for the spillable data from all the hash partitions.
@@ -290,15 +292,8 @@ class Spiller {
   // pointed by 'startRowIter'.
   void fillSpillRuns(const RowContainerIterator* startRowIter = nullptr);
 
-  /// Prepares spill runs for the spillable data from all the hash partitions.
-  void fillSpillRuns(std::vector<char*>& rows);
-
   /// Prepares spill runs for the spillable data from the rows.
-  void fillSpillRuns(
-      std::vector<char*>& rows,
-      int32_t numRows,
-      std::vector<uint64_t>& hashes,
-      bool isSinglePartition);
+  void fillSinglePartition(std::vector<char*>& rows);
 
   // Writes out all the rows collected in spillRuns_.
   void runSpill();

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -125,7 +125,7 @@ class Spiller {
   /// 'kOrderByOutput' spiller type to spill during the order by
   /// output processing. Similarly, the spilled rows still stays in the row
   /// container. The caller needs to erase them from the row container.
-  void spill(std::vector<char*> rows);
+  void spill(std::vector<char*>& rows);
 
   /// Append 'spillVector' into the spill file of given 'partition'. It is now
   /// only used by the spilling operator which doesn't need data sort, such as
@@ -292,8 +292,9 @@ class Spiller {
   // pointed by 'startRowIter'.
   void fillSpillRuns(const RowContainerIterator* startRowIter = nullptr);
 
-  /// Prepares spill runs for the spillable data from the rows.
-  void fillSinglePartition(std::vector<char*>& rows);
+  /// Prepares spill run of a single partition for the spillable data from the
+  /// rows.
+  void fillSpillRun(std::vector<char*>& rows);
 
   // Writes out all the rows collected in spillRuns_.
   void runSpill();

--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -737,7 +737,7 @@ void TopNRowNumber::setupSpiller() {
 
   spiller_ = std::make_unique<Spiller>(
       // TODO Replace Spiller::Type::kOrderBy.
-      Spiller::Type::kOrderBy,
+      Spiller::Type::kOrderByInput,
       data_.get(),
       inputType_,
       spillCompareFlags_.size(),

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -120,7 +120,7 @@ class SpillerTest : public exec::test::RowContainerTestBase {
         compressionKind_(param.compressionKind),
         hashBits_(
             0,
-            (type_ == Spiller::Type::kOrderBy ||
+            (type_ == Spiller::Type::kOrderByInput ||
              type_ == Spiller::Type::kAggregateOutput ||
              type_ == Spiller::Type::kAggregateInput)
                 ? 0
@@ -384,7 +384,7 @@ class SpillerTest : public exec::test::RowContainerTestBase {
     }
   }
 
-  void setupSpillContainer(RowTypePtr rowType, int32_t numKeys) {
+  void setupSpillContainer(const RowTypePtr& rowType, int32_t numKeys) {
     const auto& childTypes = rowType->children();
     std::vector<TypePtr> keys(childTypes.begin(), childTypes.begin() + numKeys);
     std::vector<TypePtr> dependents;
@@ -396,7 +396,7 @@ class SpillerTest : public exec::test::RowContainerTestBase {
     rowType_ = rowType;
   }
 
-  void writeSpillData(std::vector<RowVectorPtr> batches) {
+  void writeSpillData(const std::vector<RowVectorPtr>& batches) {
     vector_size_t numRows = 0;
     for (const auto& batch : batches) {
       numRows += batch->size();
@@ -490,7 +490,7 @@ class SpillerTest : public exec::test::RowContainerTestBase {
           pool_.get(),
           executor());
     } else if (
-        type_ == Spiller::Type::kOrderBy ||
+        type_ == Spiller::Type::kOrderByInput ||
         type_ == Spiller::Type::kAggregateInput) {
       // We spill 'data' in one partition in type of kOrderBy, otherwise in 4
       // partitions.
@@ -1093,7 +1093,7 @@ TEST_P(NoHashJoin, error) {
 }
 
 TEST_P(AllTypes, nonSortedSpillFunctions) {
-  if (type_ == Spiller::Type::kOrderBy ||
+  if (type_ == Spiller::Type::kOrderByInput ||
       type_ == Spiller::Type::kAggregateInput ||
       type_ == Spiller::Type::kAggregateOutput) {
     setupSpillData(rowType_, numKeys_, 1'000, 1, nullptr, {});
@@ -1136,7 +1136,7 @@ class HashJoinBuildOnly : public SpillerTest,
             {Spiller::Type::kAggregateInput,
              Spiller::Type::kAggregateOutput,
              Spiller::Type::kHashJoinProbe,
-             Spiller::Type::kOrderBy}}
+             Spiller::Type::kOrderByInput}}
         .getTestParams();
   }
 };
@@ -1227,7 +1227,7 @@ class AggregationOutputOnly : public SpillerTest,
             {Spiller::Type::kAggregateInput,
              Spiller::Type::kHashJoinBuild,
              Spiller::Type::kHashJoinProbe,
-             Spiller::Type::kOrderBy}}
+             Spiller::Type::kOrderByInput}}
         .getTestParams();
   }
 };

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -1357,7 +1357,7 @@ TEST_P(OrderByOutputOnly, basic) {
     }
     auto spillRows =
         std::vector<char*>(rows.begin(), rows.begin() + numListedRows);
-    spiller_->spill(std::move(spillRows));
+    spiller_->spill(spillRows);
     ASSERT_EQ(rowContainer_->numRows(), numRows);
     rowContainer_->clear();
 


### PR DESCRIPTION
Add a new type of spiller named `kOrderByOutput`.
It is used to spill data during the output processing
stage of `OrderBy` operator. The spiller uses a newly
added API that supports spill data by row pointers.