### PR TITLE
Fix aggregations over sorted inputs with spilling

### DIFF
--- a/velox/functions/sparksql/aggregates/tests/Main.cpp
+++ b/velox/functions/sparksql/aggregates/tests/Main.cpp
@@ -18,6 +18,6 @@
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
-  folly::init(&argc, &argv, false);
+  folly::Init init(&argc, &argv, false);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Aggregations over sorted inputs are managed primarily by SortedAggregations.
This class is responsible for calling initializeNewGroups, addXxx and
extractXxx APIs. When reading spilled data, GroupingSet::updateRow used to call
Aggregate::addSingleGroupIntermediateResults for all aggregations. In some
cases this corrupted accumulators of aggregates managed by SortedAggregations
and caused the aggregation to produce wrong results.

This would happen rarely because intermediate result of aggregation over sorted
inputs is always null and most aggregations ignore null inputs in
addSingleGroupIntermediateResults. Spark's first and last aggregates are
different. They allow null inputs, hence, are sensitive to this bug.

The issue can be reproduced easily by running AggregationFuzzer:

> spark_aggregation_fuzzer_test --logtostderr --enable_sorted_aggregations --only first

Fixes #7676