### PR TITLE
Fix build error

### DIFF
--- a/velox/common/base/SimdUtil.h
+++ b/velox/common/base/SimdUtil.h
@@ -401,7 +401,7 @@ inline void storeLeading(
 #endif
     for (auto i = 0; i < n; ++i) {
       reinterpret_cast<T*>(destination)[i] =
-          *reinterpret_cast<const T*>(&data)[i];
+          reinterpret_cast<const T*>(&data)[i];
     }
 #if XSIMD_WITH_AVX2
   }


### PR DESCRIPTION
A build error is caused by trying to dereference a non-pointer type.
```C++
reinterpret_cast<T*>(destination)[i] =
          *reinterpret_cast<const T*>(&data)[i];
```

Fixes #7765