### PR TITLE
Allow process termination with core on allocation failure

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -39,6 +39,7 @@ MemoryManager::MemoryManager(const MemoryManagerOptions& options)
       alignment_(std::max(MemoryAllocator::kMinAlignment, options.alignment)),
       checkUsageLeak_(options.checkUsageLeak),
       debugEnabled_(options.debugEnabled),
+      coreOnAllocationFailureEnabled_(options.coreOnAllocationFailureEnabled),
       poolDestructionCb_([&](MemoryPool* pool) { dropPool(pool); }),
       defaultRoot_{std::make_shared<MemoryPoolImpl>(
           this,
@@ -54,7 +55,9 @@ MemoryManager::MemoryManager(const MemoryManagerOptions& options)
               .maxCapacity = kMaxMemory,
               .trackUsage = options.trackDefaultUsage,
               .checkUsageLeak = options.checkUsageLeak,
-              .debugEnabled = options.debugEnabled})} {
+              .debugEnabled = options.debugEnabled,
+              .coreOnAllocationFailureEnabled =
+                  options.coreOnAllocationFailureEnabled})} {
   VELOX_CHECK_NOT_NULL(allocator_);
   VELOX_CHECK_NOT_NULL(arbitrator_);
   VELOX_CHECK_EQ(
@@ -116,6 +119,7 @@ std::shared_ptr<MemoryPool> MemoryManager::addRootPool(
   options.trackUsage = true;
   options.checkUsageLeak = checkUsageLeak_;
   options.debugEnabled = debugEnabled_;
+  options.coreOnAllocationFailureEnabled = coreOnAllocationFailureEnabled_;
 
   folly::SharedMutex::WriteHolder guard{mutex_};
   if (pools_.find(poolName) != pools_.end()) {

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -93,6 +93,9 @@ struct MemoryManagerOptions {
   /// testing purpose.
   bool debugEnabled{FLAGS_velox_memory_pool_debug_enabled};
 
+  /// Terminates the process and generates a core file on an allocation failure
+  bool coreOnAllocationFailureEnabled{false};
+
   /// Specifies the backing memory allocator.
   MemoryAllocator* allocator{MemoryAllocator::getInstance()};
 
@@ -221,6 +224,7 @@ class MemoryManager {
   const uint16_t alignment_;
   const bool checkUsageLeak_;
   const bool debugEnabled_;
+  const bool coreOnAllocationFailureEnabled_;
   // The destruction callback set for the allocated root memory pools which are
   // tracked by 'pools_'. It is invoked on the root pool destruction and removes
   // the pool from 'pools_'.

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -160,6 +160,10 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
     /// If true, tracks the allocation and free call stacks to detect the source
     /// of memory leak for testing purpose.
     bool debugEnabled{FLAGS_velox_memory_pool_debug_enabled};
+
+    /// Terminates the process and generates a core file on an allocation
+    /// failure
+    bool coreOnAllocationFailureEnabled{false};
   };
 
   /// Constructs a named memory pool with specified 'name', 'parent' and 'kind'.
@@ -524,6 +528,7 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   const bool threadSafe_;
   const bool checkUsageLeak_;
   const bool debugEnabled_;
+  const bool coreOnAllocationFailureEnabled_;
 
   /// Indicates if the memory pool has been aborted by the memory arbitrator or
   /// not.
@@ -961,6 +966,8 @@ class MemoryPoolImpl : public MemoryPool {
   // memory pool destruction. We only check this if debug mode of this memory
   // pool is enabled.
   void leakCheckDbg();
+
+  void handleAllocationFailure(const std::string& failureMessage);
 
   MemoryManager* const manager_;
   MemoryAllocator* const allocator_;


### PR DESCRIPTION
In certain cases crashing with core on allocation failure is desired for diagnostic purposes