### PR TITLE
Replace tableScan API with tableScanBuilder

### DIFF
--- a/velox/connectors/fuzzer/tests/FuzzerConnectorTest.cpp
+++ b/velox/connectors/fuzzer/tests/FuzzerConnectorTest.cpp
@@ -31,8 +31,12 @@ TEST_F(FuzzerConnectorTest, singleSplit) {
   const size_t numRows = 100;
   auto type = ROW({BIGINT(), DOUBLE(), VARCHAR()});
 
-  auto plan =
-      PlanBuilder().tableScan(type, makeFuzzerTableHandle(), {}).planNode();
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .outputType(type)
+                  .tableHandle(makeFuzzerTableHandle())
+                  .endTableScan()
+                  .planNode();
 
   exec::test::AssertQueryBuilder(plan)
       .split(makeFuzzerSplit(numRows))
@@ -43,8 +47,12 @@ TEST_F(FuzzerConnectorTest, floatingPoints) {
   const size_t numRows = 1000;
   auto type = ROW({REAL(), DOUBLE()});
 
-  auto plan =
-      PlanBuilder().tableScan(type, makeFuzzerTableHandle(), {}).planNode();
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .outputType(type)
+                  .tableHandle(makeFuzzerTableHandle())
+                  .endTableScan()
+                  .planNode();
 
   exec::test::AssertQueryBuilder(plan)
       .split(makeFuzzerSplit(numRows))
@@ -59,8 +67,12 @@ TEST_F(FuzzerConnectorTest, complexTypes) {
       REAL(),
   });
 
-  auto plan =
-      PlanBuilder().tableScan(type, makeFuzzerTableHandle(), {}).planNode();
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .outputType(type)
+                  .tableHandle(makeFuzzerTableHandle())
+                  .endTableScan()
+                  .planNode();
 
   exec::test::AssertQueryBuilder(plan)
       .split(makeFuzzerSplit(numRows))
@@ -72,8 +84,12 @@ TEST_F(FuzzerConnectorTest, multipleSplits) {
   const size_t numSplits = 10;
   auto type = ROW({BIGINT(), DOUBLE(), VARCHAR()});
 
-  auto plan =
-      PlanBuilder().tableScan(type, makeFuzzerTableHandle(), {}).planNode();
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .outputType(type)
+                  .tableHandle(makeFuzzerTableHandle())
+                  .endTableScan()
+                  .planNode();
 
   exec::test::AssertQueryBuilder(plan)
       .splits(makeFuzzerSplits(rowsPerSplit, numSplits))
@@ -89,8 +105,12 @@ TEST_F(FuzzerConnectorTest, randomTypes) {
   for (size_t i = 0; i < iterations; ++i) {
     auto type = VectorFuzzer({}, pool()).randRowType();
 
-    auto plan =
-        PlanBuilder().tableScan(type, makeFuzzerTableHandle(), {}).planNode();
+    auto plan = PlanBuilder()
+                    .startTableScan()
+                    .outputType(type)
+                    .tableHandle(makeFuzzerTableHandle())
+                    .endTableScan()
+                    .planNode();
     exec::test::AssertQueryBuilder(plan)
         .splits(makeFuzzerSplits(rowsPerSplit, numSplits))
         .assertTypeAndNumRows(type, rowsPerSplit * numSplits);
@@ -101,14 +121,18 @@ TEST_F(FuzzerConnectorTest, reproducible) {
   const size_t numRows = 100;
   auto type = ROW({BIGINT(), ARRAY(INTEGER()), VARCHAR()});
 
-  auto plan1 =
-      PlanBuilder()
-          .tableScan(type, makeFuzzerTableHandle(/*fuzerSeed=*/1234), {})
-          .planNode();
-  auto plan2 =
-      PlanBuilder()
-          .tableScan(type, makeFuzzerTableHandle(/*fuzerSeed=*/1234), {})
-          .planNode();
+  auto plan1 = PlanBuilder()
+                   .startTableScan()
+                   .outputType(type)
+                   .tableHandle(makeFuzzerTableHandle(/*fuzerSeed=*/1234))
+                   .endTableScan()
+                   .planNode();
+  auto plan2 = PlanBuilder()
+                   .startTableScan()
+                   .outputType(type)
+                   .tableHandle(makeFuzzerTableHandle(/*fuzerSeed=*/1234))
+                   .endTableScan()
+                   .planNode();
 
   auto results1 = exec::test::AssertQueryBuilder(plan1)
                       .split(makeFuzzerSplit(numRows))

--- a/velox/exec/tests/AssertQueryBuilderTest.cpp
+++ b/velox/exec/tests/AssertQueryBuilderTest.cpp
@@ -86,10 +86,11 @@ TEST_F(AssertQueryBuilderTest, hiveSplits) {
 
   AssertQueryBuilder(
       PlanBuilder()
-          .tableScan(
-              ROW({"c0", "ds"}, {INTEGER(), VARCHAR()}),
-              makeTableHandle(),
-              assignments)
+          .startTableScan()
+          .outputType(ROW({"c0", "ds"}, {INTEGER(), VARCHAR()}))
+          .tableHandle(makeTableHandle())
+          .assignments(assignments)
+          .endTableScan()
           .planNode(),
       duckDbQueryRunner_)
       .split(HiveConnectorSplitBuilder(file->path)

--- a/velox/exec/tests/AsyncConnectorTest.cpp
+++ b/velox/exec/tests/AsyncConnectorTest.cpp
@@ -193,7 +193,10 @@ TEST_F(AsyncConnectorTest, basic) {
   auto tableHandle = std::make_shared<TestTableHandle>();
   core::PlanNodeId scanId;
   auto plan = PlanBuilder()
-                  .tableScan(ROW({"a"}, {BIGINT()}), tableHandle, {})
+                  .startTableScan()
+                  .outputType(ROW({"a"}, {BIGINT()}))
+                  .tableHandle(tableHandle)
+                  .endTableScan()
                   .capturePlanNodeId(scanId)
                   .singleAggregation({}, {"min(a)"})
                   .planNode();

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -4126,8 +4126,6 @@ TEST_F(HashJoinTest, dynamicFilters) {
     auto op = PlanBuilder(planNodeIdGenerator, pool_.get())
                   .startTableScan()
                   .outputType(scanOutputType)
-                  .tableHandle(makeTableHandle(
-                      common::test::SubfieldFiltersBuilder().build()))
                   .assignments(assignments)
                   .endTableScan()
                   .capturePlanNodeId(probeScanId)
@@ -4880,8 +4878,6 @@ TEST_F(HashJoinTest, dynamicFilterOnPartitionKey) {
           .partitionKey("k", "0")
           .build();
   auto outputType = ROW({"n1_0", "n1_1"}, {BIGINT(), BIGINT()});
-  std::shared_ptr<connector::hive::HiveTableHandle> tableHandle =
-      makeTableHandle();
   ColumnHandleMap assignments = {
       {"n1_0", regularColumn("c0", BIGINT())},
       {"n1_1", partitionKey("k", BIGINT())}};
@@ -4892,7 +4888,6 @@ TEST_F(HashJoinTest, dynamicFilterOnPartitionKey) {
       PlanBuilder(planNodeIdGenerator)
           .startTableScan()
           .outputType(outputType)
-          .tableHandle(tableHandle)
           .assignments(assignments)
           .endTableScan()
           .capturePlanNodeId(probeScanId)

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -108,19 +108,6 @@ PlanBuilder& PlanBuilder::tableScan(
       .endTableScan();
 }
 
-PlanBuilder& PlanBuilder::tableScan(
-    const RowTypePtr& outputType,
-    const std::shared_ptr<connector::ConnectorTableHandle>& tableHandle,
-    const std::unordered_map<
-        std::string,
-        std::shared_ptr<connector::ColumnHandle>>& assignments) {
-  return TableScanBuilder(*this)
-      .outputType(outputType)
-      .tableHandle(tableHandle)
-      .assignments(assignments)
-      .endTableScan();
-}
-
 PlanBuilder& PlanBuilder::tpchTableScan(
     tpch::Table table,
     std::vector<std::string>&& columnNames,

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -146,20 +146,6 @@ class PlanBuilder {
       const std::string& remainingFilter = "",
       const RowTypePtr& dataColumns = nullptr);
 
-  /// Add a TableScanNode using a connector-specific table handle and
-  /// assignments. Supports any connector, not just Hive connector.
-  ///
-  /// @param outputType List of column names and types to project out. Column
-  /// names should match the keys in the 'assignments' map. The 'assignments'
-  /// map may contain more columns then 'outputType' if some columns are only
-  /// used by pushed-down filters.
-  PlanBuilder& tableScan(
-      const RowTypePtr& outputType,
-      const std::shared_ptr<connector::ConnectorTableHandle>& tableHandle,
-      const std::unordered_map<
-          std::string,
-          std::shared_ptr<connector::ColumnHandle>>& assignments);
-
   /// Add a TableScanNode to scan a TPC-H table.
   ///
   /// @param tpchTableHandle The handle that specifies the target TPC-H table

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -192,6 +192,15 @@ class PlanBuilder {
       return *this;
     }
 
+    /// @param subfieldFilter A SQL expression for the range filter
+    /// to apply to an individual column. Supported filters are: column <=
+    /// value, column < value, column >= value, column > value, column = value,
+    /// column IN (v1, v2,.. vN), column < v1 OR column >= v2.
+    TableScanBuilder& subfieldFilter(std::string subfieldFilter) {
+      subfieldFilters_.emplace_back(std::move(subfieldFilter));
+      return *this;
+    }
+
     /// @param remainingFilter SQL expression for the additional conjunct. May
     /// include multiple columns and SQL functions. The remainingFilter is
     /// AND'ed with all the subfieldFilters.


### PR DESCRIPTION
Remove the tableScan API that is less popular to keep the planBuilder API clean.