### PR TITLE
Fix equality check for simple floating types in RowContainer

### DIFF
--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -976,7 +976,8 @@ class RowContainer {
     }
 
     using T = typename KindToFlatVector<Kind>::HashRowType;
-    return decoded.valueAt<T>(index) == valueAt<T>(row, offset);
+    return SimpleVector<T>::comparePrimitiveAsc(
+               decoded.valueAt<T>(index), valueAt<T>(row, offset)) == 0;
   }
 
   template <TypeKind Kind>

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -347,7 +347,9 @@ class SimpleVector : public BaseVector {
     return asciiInfo;
   }
 
-  static int comparePrimitiveAsc(const T& left, const T& right) {
+  FOLLY_ALWAYS_INLINE static int comparePrimitiveAsc(
+      const T& left,
+      const T& right) {
     if constexpr (std::is_floating_point<T>::value) {
       bool isLeftNan = std::isnan(left);
       bool isRightNan = std::isnan(right);


### PR DESCRIPTION
The row container implementation for
equalsNoNulls and equalsWithNulls contained a bug:

1.  Incorrect equals check for floating point types when NaN values are used.
2. Refactor to use SimpleVector::comparePrimitiveAsc in RowContainer and ContainerRowSerde for a common comparison function.
3. Change static SimpleVector::comparePrimitiveAsc to be static inline to reduce function call overhead in this expanded usage.

This is a continuation of PR #5833 which addressed floating point comparisons for complex types.

Affected operators:
FilterProject, TopN, TopNRowNumber, OrderBy, MergeExchange, LocalMerge, HashProbe, NestedLoopJoinProbe

The lists may not be complete.