### PR TITLE
Add BaseVector::setType API

### DIFF
--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -177,10 +177,10 @@ class BaseVector {
     return type_;
   }
 
-  // Changes vector type. The new type can have a different
-  // logical representation while maintaining the same physical type.
-  // Additionally, note that the caller must ensure that this vector is not
-  // shared, i.e. singly-referenced.
+  /// Changes vector type. The new type can have a different
+  /// logical representation while maintaining the same physical type.
+  /// Additionally, note that the caller must ensure that this vector is not
+  /// shared, i.e. singly-referenced.
   virtual void setType(const TypePtr& type) {
     VELOX_CHECK_NOT_NULL(type);
     VELOX_CHECK(

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -177,6 +177,14 @@ class BaseVector {
     return type_;
   }
 
+  void setType(TypePtr type) {
+    VELOX_CHECK_NOT_NULL(type);
+    VELOX_CHECK(
+        type_->kindEquals(type),
+        "The set type should be kindEquals() with type_ except names");
+    type_ = type;
+  }
+
   TypeKind typeKind() const {
     return typeKind_;
   }
@@ -868,7 +876,7 @@ class BaseVector {
     return sliceBuffer(*BOOLEAN(), nulls_, offset, length, pool_);
   }
 
-  const TypePtr type_;
+  TypePtr type_;
   const TypeKind typeKind_;
   const VectorEncoding::Simple encoding_;
   BufferPtr nulls_;

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -177,10 +177,10 @@ class BaseVector {
     return type_;
   }
 
-  // Update the type_ with the new type. The new type can have a different
+  // Changes vector type. The new type can have a different
   // logical representation while maintaining the same physical type.
-  // Additionally, note that this method is mutating, so ensure that the vector
-  // is writable before calling it.
+  // Additionally, note that the caller must ensure that this vector is not
+  // shared, i.e. singly-referenced.
   void setType(const TypePtr& type) {
     VELOX_CHECK_NOT_NULL(type);
     VELOX_CHECK(

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -177,11 +177,17 @@ class BaseVector {
     return type_;
   }
 
-  void setType(TypePtr type) {
+  // Update the type_ with the new type. The new type can have a different
+  // logical representation while maintaining the same physical type.
+  // Additionally, note that this method is mutating, so ensure that the vector
+  // is writable before calling it.
+  void setType(const TypePtr& type) {
     VELOX_CHECK_NOT_NULL(type);
     VELOX_CHECK(
         type_->kindEquals(type),
-        "The set type should be kindEquals() with type_ except names");
+        "Cannot change vector type from {} to {}. The old and new types can be different logical types, but the underlying physical types must match.",
+        type_,
+        type);
     type_ = type;
   }
 

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -181,7 +181,7 @@ class BaseVector {
   // logical representation while maintaining the same physical type.
   // Additionally, note that the caller must ensure that this vector is not
   // shared, i.e. singly-referenced.
-  void setType(const TypePtr& type) {
+  virtual void setType(const TypePtr& type) {
     VELOX_CHECK_NOT_NULL(type);
     VELOX_CHECK(
         type_->kindEquals(type),

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -271,6 +271,13 @@ void RowVector::copy(
   }
 }
 
+void RowVector::setType(const TypePtr& type) {
+  BaseVector::setType(type);
+  for (auto i = 0; i < childrenSize_; i++) {
+    children_[i]->setType(type_->asRow().childAt(i));
+  }
+}
+
 namespace {
 
 // Runs quick checks to determine whether input vector has only null values.
@@ -844,6 +851,11 @@ std::optional<int32_t> ArrayVector::compare(
       flags);
 }
 
+void ArrayVector::setType(const TypePtr& type) {
+  BaseVector::setType(type);
+  elements_->setType(type_->asArray().elementType());
+}
+
 namespace {
 uint64_t hashArray(
     uint64_t hash,
@@ -1095,6 +1107,13 @@ bool MapVector::isSorted(vector_size_t index) const {
     }
   }
   return true;
+}
+
+void MapVector::setType(const TypePtr& type) {
+  BaseVector::setType(type);
+  auto mapType = type_->asMap();
+  keys_->setType(mapType.keyType());
+  values_->setType(mapType.valueType());
 }
 
 // static

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -1111,7 +1111,7 @@ bool MapVector::isSorted(vector_size_t index) const {
 
 void MapVector::setType(const TypePtr& type) {
   BaseVector::setType(type);
-  auto mapType = type_->asMap();
+  const auto& mapType = type_->asMap();
   keys_->setType(mapType.keyType());
   values_->setType(mapType.valueType());
 }

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -101,6 +101,21 @@ class RowVector : public BaseVector {
     return const_cast<RowVector*>(this)->loadedVector();
   }
 
+  void setType(const TypePtr& type) override {
+    VELOX_CHECK_NOT_NULL(type);
+    VELOX_CHECK(
+        type_->kindEquals(type),
+        "Cannot change vector type from {} to {}. The old and new types can be different logical types, but the underlying physical types must match.",
+        type_,
+        type);
+    type_ = type;
+
+    auto rowType = std::dynamic_pointer_cast<const RowType>(type_);
+    for (auto i = 0; i < childrenSize_; i++) {
+      children_[i]->setType(rowType->childAt(i));
+    }
+  }
+
   std::unique_ptr<SimpleVector<uint64_t>> hashAll() const override;
 
   /// Return the number of child vectors.

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -444,6 +444,19 @@ class ArrayVector : public ArrayVectorBase {
     return elements_;
   }
 
+  void setType(const TypePtr& type) override {
+    VELOX_CHECK_NOT_NULL(type);
+    VELOX_CHECK(
+        type_->kindEquals(type),
+        "Cannot change vector type from {} to {}. The old and new types can be different logical types, but the underlying physical types must match.",
+        type_,
+        type);
+    type_ = type;
+
+    auto arrayType = std::dynamic_pointer_cast<const ArrayType>(type);
+    elements_->setType(arrayType->elementType());
+  }
+
   void setElements(VectorPtr elements) {
     elements_ = BaseVector::getOrCreateEmpty(
         std::move(elements), type()->childAt(0), pool_);
@@ -563,6 +576,20 @@ class MapVector : public ArrayVectorBase {
 
   VectorPtr& mapValues() {
     return values_;
+  }
+
+  void setType(const TypePtr& type) override {
+    VELOX_CHECK_NOT_NULL(type);
+    VELOX_CHECK(
+        type_->kindEquals(type),
+        "Cannot change vector type from {} to {}. The old and new types can be different logical types, but the underlying physical types must match.",
+        type_,
+        type);
+    type_ = type;
+
+    auto mapType = std::dynamic_pointer_cast<const MapType>(type);
+    keys_->setType(mapType->keyType());
+    values_->setType(mapType->valueType());
   }
 
   bool hasSortedKeys() const {

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -101,21 +101,6 @@ class RowVector : public BaseVector {
     return const_cast<RowVector*>(this)->loadedVector();
   }
 
-  void setType(const TypePtr& type) override {
-    VELOX_CHECK_NOT_NULL(type);
-    VELOX_CHECK(
-        type_->kindEquals(type),
-        "Cannot change vector type from {} to {}. The old and new types can be different logical types, but the underlying physical types must match.",
-        type_,
-        type);
-    type_ = type;
-
-    auto rowType = std::dynamic_pointer_cast<const RowType>(type_);
-    for (auto i = 0; i < childrenSize_; i++) {
-      children_[i]->setType(rowType->childAt(i));
-    }
-  }
-
   std::unique_ptr<SimpleVector<uint64_t>> hashAll() const override;
 
   /// Return the number of child vectors.
@@ -165,6 +150,8 @@ class RowVector : public BaseVector {
   const std::vector<VectorPtr>& children() const {
     return children_;
   }
+
+  void setType(const TypePtr& type) override;
 
   void copy(
       const BaseVector* source,
@@ -444,23 +431,12 @@ class ArrayVector : public ArrayVectorBase {
     return elements_;
   }
 
-  void setType(const TypePtr& type) override {
-    VELOX_CHECK_NOT_NULL(type);
-    VELOX_CHECK(
-        type_->kindEquals(type),
-        "Cannot change vector type from {} to {}. The old and new types can be different logical types, but the underlying physical types must match.",
-        type_,
-        type);
-    type_ = type;
-
-    auto arrayType = std::dynamic_pointer_cast<const ArrayType>(type);
-    elements_->setType(arrayType->elementType());
-  }
-
   void setElements(VectorPtr elements) {
     elements_ = BaseVector::getOrCreateEmpty(
         std::move(elements), type()->childAt(0), pool_);
   }
+
+  void setType(const TypePtr& type) override;
 
   void copyRanges(
       const BaseVector* source,
@@ -578,19 +554,7 @@ class MapVector : public ArrayVectorBase {
     return values_;
   }
 
-  void setType(const TypePtr& type) override {
-    VELOX_CHECK_NOT_NULL(type);
-    VELOX_CHECK(
-        type_->kindEquals(type),
-        "Cannot change vector type from {} to {}. The old and new types can be different logical types, but the underlying physical types must match.",
-        type_,
-        type);
-    type_ = type;
-
-    auto mapType = std::dynamic_pointer_cast<const MapType>(type);
-    keys_->setType(mapType->keyType());
-    values_->setType(mapType->valueType());
-  }
+  void setType(const TypePtr& type) override;
 
   bool hasSortedKeys() const {
     return sortedKeys_;

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -3541,7 +3541,7 @@ TEST_F(VectorTest, setType) {
 
   auto newType = ROW({"bb"}, {BIGINT()});
   vector->setType(newType);
-  EXPECT_EQ(vector->type()->toString(), newType->toString());
+  EXPECT_EQ(vector->type()->name(), newType->name());
 
   auto failedType = ROW({"bb"}, {VARCHAR()});
   VELOX_ASSERT_RUNTIME_THROW(
@@ -3549,14 +3549,18 @@ TEST_F(VectorTest, setType) {
       "Cannot change vector type from ROW<bb:BIGINT> to ROW<bb:VARCHAR>. The old and new types can be different logical types, but the underlying physical types must match.")
 }
 
-TEST_F(VectorTest, setNestType) {
-  auto type = ROW({"nest3"}, {ROW({"nest2"}, {ROW({"nest1"}, {BIGINT()})})});
+TEST_F(VectorTest, setNestedType) {
+  auto type =
+      ROW({"a", "b"}, {ROW({"c", "d"}, {BIGINT(), BIGINT()}), BIGINT()});
   auto vector = BaseVector::create(type, 1'000, pool());
 
   auto newType =
-      ROW({"newnest3"}, {ROW({"newnest2"}, {ROW({"newnest1"}, {BIGINT()})})});
+      ROW({"a", "b"}, {ROW({"cc", "dd"}, {BIGINT(), BIGINT()}), BIGINT()});
   vector->setType(newType);
-  EXPECT_EQ(vector->type()->toString(), newType->toString());
+  auto rowVector = std::static_pointer_cast<const RowVector>(vector);
+  auto rowType = std::static_pointer_cast<const RowType>(newType);
+  EXPECT_EQ(
+      rowVector->children()[0]->type()->name(), rowType->childAt(0)->name());
 }
 
 } // namespace

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -3538,13 +3538,25 @@ TEST_F(VectorTest, hashAll) {
 TEST_F(VectorTest, setType) {
   auto type = ROW({"aa"}, {BIGINT()});
   auto vector = BaseVector::create(type, 1'000, pool());
+
   auto newType = ROW({"bb"}, {BIGINT()});
   vector->setType(newType);
   EXPECT_EQ(vector->type()->toString(), newType->toString());
+
   auto failedType = ROW({"bb"}, {VARCHAR()});
   VELOX_ASSERT_RUNTIME_THROW(
       vector->setType(failedType),
       "Cannot change vector type from ROW<bb:BIGINT> to ROW<bb:VARCHAR>. The old and new types can be different logical types, but the underlying physical types must match.")
+}
+
+TEST_F(VectorTest, setNestType) {
+  auto type = ROW({"nest3"}, {ROW({"nest2"}, {ROW({"nest1"}, {BIGINT()})})});
+  auto vector = BaseVector::create(type, 1'000, pool());
+
+  auto newType =
+      ROW({"newnest3"}, {ROW({"newnest2"}, {ROW({"newnest1"}, {BIGINT()})})});
+  vector->setType(newType);
+  EXPECT_EQ(vector->type()->toString(), newType->toString());
 }
 
 } // namespace

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -3541,7 +3541,10 @@ TEST_F(VectorTest, setType) {
 
   auto newType = ROW({"bb"}, {BIGINT()});
   vector->setType(newType);
-  EXPECT_EQ(vector->type()->name(), newType->name());
+
+  EXPECT_EQ(
+      std::static_pointer_cast<const RowType>(vector->type())->names()[0],
+      "bb");
 
   auto failedType = ROW({"bb"}, {VARCHAR()});
   VELOX_ASSERT_RUNTIME_THROW(
@@ -3549,7 +3552,7 @@ TEST_F(VectorTest, setType) {
       "Cannot change vector type from ROW<bb:BIGINT> to ROW<bb:VARCHAR>. The old and new types can be different logical types, but the underlying physical types must match.")
 }
 
-TEST_F(VectorTest, setNestedType) {
+TEST_F(VectorTest, setROWNestROWType) {
   auto type =
       ROW({"a", "b"}, {ROW({"c", "d"}, {BIGINT(), BIGINT()}), BIGINT()});
   auto vector = BaseVector::create(type, 1'000, pool());
@@ -3557,10 +3560,58 @@ TEST_F(VectorTest, setNestedType) {
   auto newType =
       ROW({"a", "b"}, {ROW({"cc", "dd"}, {BIGINT(), BIGINT()}), BIGINT()});
   vector->setType(newType);
-  auto rowVector = std::static_pointer_cast<const RowVector>(vector);
-  auto rowType = std::static_pointer_cast<const RowType>(newType);
-  EXPECT_EQ(
-      rowVector->children()[0]->type()->name(), rowType->childAt(0)->name());
+
+  auto rowType = std::static_pointer_cast<const RowType>(vector->type());
+  auto names =
+      std::static_pointer_cast<const RowType>(rowType->childAt(0))->names();
+  EXPECT_EQ(names[0], "cc");
+  EXPECT_EQ(names[1], "dd");
+}
+
+TEST_F(VectorTest, setARRAYNestROWType) {
+  auto type =
+      ROW({"a", "b"}, {ARRAY(ROW({"c", "d"}, {BIGINT(), BIGINT()})), BIGINT()});
+  auto vector = BaseVector::create(type, 1'000, pool());
+
+  auto newType = ROW(
+      {"a", "b"}, {ARRAY(ROW({"cc", "dd"}, {BIGINT(), BIGINT()})), BIGINT()});
+  vector->setType(newType);
+  auto rowType = std::static_pointer_cast<const RowType>(vector->type());
+  auto arrayType =
+      std::static_pointer_cast<const ArrayType>(rowType->childAt(0));
+  auto names = std::static_pointer_cast<const RowType>(arrayType->elementType())
+                   ->names();
+  EXPECT_EQ(names[0], "cc");
+  EXPECT_EQ(names[1], "dd");
+}
+
+TEST_F(VectorTest, setMAPNestROWType) {
+  auto type =
+      ROW({"a", "b"},
+          {MAP(ROW({"c", "d"}, {BIGINT(), BIGINT()}),
+               ROW({"e", "f"}, {BIGINT(), BIGINT()})),
+           BIGINT()});
+  auto vector = BaseVector::create(type, 1'000, pool());
+
+  auto newType =
+      ROW({"a", "b"},
+          {MAP(ROW({"cc", "dd"}, {BIGINT(), BIGINT()}),
+               ROW({"ee", "ff"}, {BIGINT(), BIGINT()})),
+           BIGINT()});
+  vector->setType(newType);
+  auto rowType = std::static_pointer_cast<const RowType>(vector->type());
+  auto mapType = std::static_pointer_cast<const MapType>(rowType->childAt(0));
+  auto keyType = std::static_pointer_cast<const RowType>(mapType->keyType());
+  auto valueType =
+      std::static_pointer_cast<const RowType>(mapType->valueType());
+
+  auto keyNames = keyType->names();
+  EXPECT_EQ(keyNames[0], "cc");
+  EXPECT_EQ(keyNames[1], "dd");
+
+  auto valueNames = valueType->names();
+  EXPECT_EQ(valueNames[0], "ee");
+  EXPECT_EQ(valueNames[1], "ff");
 }
 
 } // namespace

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -3535,5 +3535,13 @@ TEST_F(VectorTest, hashAll) {
   }
 }
 
+TEST_F(VectorTest, setType) {
+  auto type = ROW({"aa"}, {BIGINT()});
+  VectorPtr vector = BaseVector::create(type, 1'000, pool());
+  auto newType = ROW({"bb"}, {BIGINT()});
+  vector->setType(newType);
+  EXPECT_EQ(vector->type()->toString(), newType->toString());
+}
+
 } // namespace
 } // namespace facebook::velox

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -18,7 +18,6 @@
 #include <gtest/gtest.h>
 #include <cstdint>
 #include <functional>
-#include <iostream>
 #include <optional>
 
 #include "velox/common/base/tests/GTestUtils.h"

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -3537,20 +3537,6 @@ TEST_F(VectorTest, hashAll) {
 }
 
 TEST_F(VectorTest, setType) {
-  auto type = ROW({"aa"}, {BIGINT()});
-  auto vector = BaseVector::create(type, 1'000, pool());
-
-  auto newType = ROW({"bb"}, {BIGINT()});
-  vector->setType(newType);
-
-  EXPECT_EQ(vector->type()->toString(), newType->toString());
-
-  VELOX_ASSERT_RUNTIME_THROW(
-      vector->setType(ROW({"bb"}, {VARCHAR()})),
-      "Cannot change vector type from ROW<bb:BIGINT> to ROW<bb:VARCHAR>. The old and new types can be different logical types, but the underlying physical types must match.")
-}
-
-TEST_F(VectorTest, setNestedType) {
   auto test = [&](auto& type, auto& newType, auto& invalidNewType) {
     auto vector = BaseVector::create(type, 1'000, pool());
 
@@ -3565,12 +3551,17 @@ TEST_F(VectorTest, setNestedType) {
             invalidNewType->toString()));
   };
 
+  // ROW
+  auto type = ROW({"aa"}, {BIGINT()});
+  auto newType = ROW({"bb"}, {BIGINT()});
+  auto invalidNewType = ROW({"bb"}, {VARCHAR()});
+  test(type, newType, invalidNewType);
+
   // ROW(ROW)
-  auto type =
-      ROW({"a", "b"}, {ROW({"c", "d"}, {BIGINT(), BIGINT()}), BIGINT()});
-  auto newType =
+  type = ROW({"a", "b"}, {ROW({"c", "d"}, {BIGINT(), BIGINT()}), BIGINT()});
+  newType =
       ROW({"a", "b"}, {ROW({"cc", "dd"}, {BIGINT(), BIGINT()}), BIGINT()});
-  auto invalidNewType =
+  invalidNewType =
       ROW({"a", "b"}, {ROW({"cc", "dd"}, {VARCHAR(), BIGINT()}), BIGINT()});
   test(type, newType, invalidNewType);
 

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -3537,10 +3537,14 @@ TEST_F(VectorTest, hashAll) {
 
 TEST_F(VectorTest, setType) {
   auto type = ROW({"aa"}, {BIGINT()});
-  VectorPtr vector = BaseVector::create(type, 1'000, pool());
+  auto vector = BaseVector::create(type, 1'000, pool());
   auto newType = ROW({"bb"}, {BIGINT()});
   vector->setType(newType);
   EXPECT_EQ(vector->type()->toString(), newType->toString());
+  auto failedType = ROW({"bb"}, {VARCHAR()});
+  VELOX_ASSERT_RUNTIME_THROW(
+      vector->setType(failedType),
+      "Cannot change vector type from ROW<bb:BIGINT> to ROW<bb:VARCHAR>. The old and new types can be different logical types, but the underlying physical types must match.")
 }
 
 } // namespace


### PR DESCRIPTION
Sometimes it is useful to be able to change the logical type of a vector without making a copy.

The new BaseVector::setType API allows to change vector type to a compatible logical type, e.g. 
change ROW("a" BIGINT) to ROW("b" BIGINT).

For example, in https://github.com/facebookincubator/velox/pull/6074 