### PR TITLE
Add driver thread debug context when enqueue a closed driver

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -240,6 +240,8 @@ std::ostream& operator<<(std::ostream& out, const StopReason& reason) {
 
 // static
 void Driver::enqueue(std::shared_ptr<Driver> driver) {
+  process::ScopedThreadDebugInfo scopedInfo(
+      driver->driverCtx()->threadDebugInfo);
   // This is expected to be called inside the Driver's Tasks's mutex.
   driver->enqueueInternal();
   if (driver->closed_) {


### PR DESCRIPTION
We found some time the driver thread debug context is not set on server
crash if it is triggered by driver destruction throws when we enqueue a
closed driver.
This PR adds the driver thread debug context when we enqueue a driver
to make sure any exception case is covered.