### PR TITLE
Back out "Back out "Revert D50984132: [velox][PR] Fast path for RowContainer string equals""

### DIFF
--- a/velox/common/base/SimdUtil-inl.h
+++ b/velox/common/base/SimdUtil-inl.h
@@ -1405,86 +1405,26 @@ xsimd::batch<T, A> reinterpretBatch(xsimd::batch<U, A> data, const A& arch) {
   return detail::ReinterpretBatch<T, U, A>::apply(data, arch);
 }
 
-namespace detail {
-template <typename T>
-inline bool
-oneOrTwoScalarsEqual(const uint8_t* left, const uint8_t* right, int32_t size) {
-  return *reinterpret_cast<const T*>(left) ==
-      *reinterpret_cast<const T*>(right) &&
-      (size == sizeof(T) ||
-       *reinterpret_cast<const T*>(left + size - sizeof(T)) ==
-           *reinterpret_cast<const T*>(right + size - sizeof(T)));
-}
-} // namespace detail
-
 template <typename A>
-inline bool memEqual(const void* x, const void* y, int32_t size) {
+inline bool memEqualUnsafe(const void* x, const void* y, int32_t size) {
   constexpr int32_t kBatch = xsimd::batch<uint8_t, A>::size;
+
   auto left = reinterpret_cast<const uint8_t*>(x);
   auto right = reinterpret_cast<const uint8_t*>(y);
-  if (size >= kBatch) {
-    do {
-      auto bits = toBitMask(
-          xsimd::batch<uint8_t, A>::load_unaligned(left) ==
-          xsimd::batch<uint8_t, A>::load_unaligned(right));
-      if (bits != allSetBitMask<uint8_t, A>()) {
-        return false;
-      }
+  while (size > 0) {
+    auto bits = toBitMask(
+        xsimd::batch<uint8_t, A>::load_unaligned(left) ==
+        xsimd::batch<uint8_t, A>::load_unaligned(right));
+    if (bits == allSetBitMask<uint8_t, A>()) {
       left += kBatch;
       right += kBatch;
       size -= kBatch;
-    } while (size >= kBatch);
-    if (size > 0) {
-      return toBitMask(
-                 xsimd::batch<uint8_t, A>::load_unaligned(
-                     left + size - kBatch) ==
-                 xsimd::batch<uint8_t, A>::load_unaligned(
-                     right + size - kBatch)) == allSetBitMask<uint8_t, A>();
+      continue;
     }
-    return true;
+    auto leading = __builtin_ctz(~bits);
+    return leading >= size;
   }
-#if XSIMD_WITH_AVX
-  using HalfBatch = xsimd::batch<uint8_t, xsimd::sse4_1>;
-  constexpr int32_t kHalfSize = HalfBatch::size;
-
-  if (size >= kHalfSize) {
-    if (simd::toBitMask(
-            HalfBatch::load_unaligned(left) ==
-            HalfBatch::load_unaligned(right)) !=
-        allSetBitMask<uint8_t, xsimd::sse4_1>()) {
-      return false;
-    }
-    if (size > kHalfSize) {
-      return simd::toBitMask(
-                 HalfBatch::load_unaligned(left + size - kHalfSize) ==
-                 HalfBatch::load_unaligned(right + size - kHalfSize)) ==
-          allSetBitMask<uint8_t, xsimd::sse4_1>();
-    }
-
-    return true;
-  }
-  if (size >= sizeof(uint64_t)) {
-    return detail::oneOrTwoScalarsEqual<uint64_t>(left, right, size);
-  }
-
-#else
-  while (size >= sizeof(uint64_t)) {
-    if (*reinterpret_cast<const uint64_t*>(left) !=
-        *reinterpret_cast<const uint64_t*>(right)) {
-      return false;
-    }
-    left += sizeof(uint64_t);
-    right += sizeof(uint64_t);
-    size -= sizeof(uint64_t);
-  }
-#endif
-  if (size >= sizeof(uint32_t)) {
-    return detail::oneOrTwoScalarsEqual<uint32_t>(left, right, size);
-  }
-  if (size >= sizeof(uint16_t)) {
-    return detail::oneOrTwoScalarsEqual<uint16_t>(left, right, size);
-  }
-  return size == 0 || *left == *right;
+  return true;
 }
 
 } // namespace facebook::velox::simd

--- a/velox/common/base/SimdUtil.h
+++ b/velox/common/base/SimdUtil.h
@@ -493,9 +493,9 @@ template <typename T, typename U, typename A = xsimd::default_arch>
 xsimd::batch<T, A> reinterpretBatch(xsimd::batch<U, A>, const A& = {});
 
 // Compares memory at 'x' and 'y' and returns true if 'size' leading bytes are
-// equal.
+// equal. May address up to SIMD width -1 past end of either 'x' or 'y'.
 template <typename A = xsimd::default_arch>
-inline bool memEqual(const void* x, const void* y, int32_t size);
+inline bool memEqualUnsafe(const void* x, const void* y, int32_t size);
 
 } // namespace facebook::velox::simd
 

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -964,8 +964,8 @@ class RowContainer {
       return compareComplexType(row, offset, decoded, index) == 0;
     }
     if (Kind == TypeKind::VARCHAR || Kind == TypeKind::VARBINARY) {
-      return compareStringEqual(
-          valueAt<StringView>(row, offset), decoded, index);
+      return compareStringAsc(
+                 valueAt<StringView>(row, offset), decoded, index) == 0;
     }
     return decoded.valueAt<T>(index) == valueAt<T>(row, offset);
   }
@@ -983,8 +983,8 @@ class RowContainer {
       return compareComplexType(row, offset, decoded, index) == 0;
     }
     if (Kind == TypeKind::VARCHAR || Kind == TypeKind::VARBINARY) {
-      return compareStringEqual(
-          valueAt<StringView>(row, offset), decoded, index);
+      return compareStringAsc(
+                 valueAt<StringView>(row, offset), decoded, index) == 0;
     }
 
     return decoded.valueAt<T>(index) == valueAt<T>(row, offset);
@@ -1114,27 +1114,6 @@ class RowContainer {
       StringView value,
       FlatVector<StringView>* FOLLY_NONNULL values,
       vector_size_t index);
-
-  static inline bool compareStringEqual(
-      StringView left,
-      const DecodedVector& decoded,
-      vector_size_t index) {
-    StringView right = decoded.valueAt<StringView>(index);
-    if (left.sizeAndPrefixAsInt64() != right.sizeAndPrefixAsInt64()) {
-      return false;
-    }
-    if (left.isInline()) {
-      return left.inlinedAsInt64() == right.inlinedAsInt64();
-    }
-    auto header = HashStringAllocator::headerOf(left.data());
-    if (LIKELY(header->size() >= left.size())) {
-      return simd::memEqual(left.data() + 4, right.data() + 4, left.size() - 4);
-    }
-    std::string storage;
-    HashStringAllocator::contiguousString(left, storage);
-    return simd::memEqual(
-        storage.data() + 4, right.data() + 4, left.size() - 4);
-  }
 
   static int32_t compareStringAsc(
       StringView left,

--- a/velox/type/StringView.cpp
+++ b/velox/type/StringView.cpp
@@ -78,7 +78,7 @@ int32_t StringView::linearSearch(
         if (isInline ? inlined ==
                     reinterpret_cast<const uint64_t*>(
                            &strings[indices[i + offset]])[1]
-                     : simd::memEqual(
+                     : simd::memEqualUnsafe(
                            body,
                            strings[indices[i + offset]].data() + 4,
                            bodySize)) {
@@ -118,7 +118,8 @@ int32_t StringView::linearSearch(
             return offset;
           }
           if (!isInline) {
-            if (simd::memEqual(body, strings[offset].data() + 4, bodySize)) {
+            if (simd::memEqualUnsafe(
+                    body, strings[offset].data() + 4, bodySize)) {
               return offset;
             }
           }

--- a/velox/type/StringView.h
+++ b/velox/type/StringView.h
@@ -250,6 +250,7 @@ struct StringView {
       const int32_t* indices,
       int32_t numStrings);
 
+ private:
   inline int64_t sizeAndPrefixAsInt64() const {
     return reinterpret_cast<const int64_t*>(this)[0];
   }
@@ -258,7 +259,6 @@ struct StringView {
     return reinterpret_cast<const int64_t*>(this)[1];
   }
 
- private:
   int32_t prefixAsInt() const {
     return *reinterpret_cast<const int32_t*>(&prefix_);
   }


### PR DESCRIPTION
Summary:
Original commit changeset: c00203dde24e

Original Phabricator Diff: D51183551

Differential Revision: D51667526


