### PR TITLE
feat: Add support for Spilling of Distinct Aggregations

### DIFF
--- a/velox/connectors/tpch/CMakeLists.txt
+++ b/velox/connectors/tpch/CMakeLists.txt
@@ -14,9 +14,15 @@
 
 velox_add_library(velox_tpch_connector OBJECT TpchConnector.cpp)
 
-velox_link_libraries(velox_tpch_connector velox_connector velox_tpch_gen
-                     velox_core velox_exec velox_expression velox_vector
-                     fmt::fmt)
+velox_link_libraries(
+  velox_tpch_connector
+  velox_connector
+  velox_tpch_gen
+  velox_core
+  velox_exec
+  velox_expression
+  velox_vector
+  fmt::fmt)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -276,13 +276,6 @@ void addVectorSerdeKind(VectorSerde::Kind kind, std::stringstream& stream) {
 } // namespace
 
 bool AggregationNode::canSpill(const QueryConfig& queryConfig) const {
-  // TODO: Add spilling for aggregations over distinct inputs.
-  // https://github.com/facebookincubator/velox/issues/7454
-  for (const auto& aggregate : aggregates_) {
-    if (aggregate.distinct) {
-      return false;
-    }
-  }
   // TODO: add spilling for pre-grouped aggregation later:
   // https://github.com/facebookincubator/velox/issues/3264
   return (isFinal() || isSingle()) && !groupingKeys().empty() &&

--- a/velox/exec/DistinctAggregations.cpp
+++ b/velox/exec/DistinctAggregations.cpp
@@ -43,9 +43,9 @@ class TypedDistinctAggregations : public DistinctAggregations {
         sizeof(AccumulatorType),
         false, // usesExternalMemory
         1, // alignment
-        nullptr,
-        [](folly::Range<char**> /*groups*/, VectorPtr& /*result*/) {
-          VELOX_UNREACHABLE();
+        ARRAY(VARBINARY()),
+        [this](folly::Range<char**> groups, VectorPtr& result) {
+          extractForSpill(groups, result);
         },
         [this](folly::Range<char**> groups) {
           for (auto* group : groups) {
@@ -90,6 +90,21 @@ class TypedDistinctAggregations : public DistinctAggregations {
     });
 
     inputForAccumulator_.reset();
+  }
+
+  void addSingleGroupSpillInput(
+      char* group,
+      const VectorPtr& input,
+      vector_size_t index) override {
+    auto* arrayVector = input->as<ArrayVector>();
+    auto* elementsVector = arrayVector->elements()->asFlatVector<StringView>();
+
+    const auto size = arrayVector->sizeAt(index);
+    const auto offset = arrayVector->offsetAt(index);
+
+    auto* accumulator = reinterpret_cast<AccumulatorType*>(group + offset_);
+    RowSizeTracker<char, uint32_t> tracker(group[rowSizeOffset_], *allocator_);
+    accumulator->deserialize(*elementsVector, offset, size, allocator_);
   }
 
   void extractValues(folly::Range<char**> groups, const RowVectorPtr& result)
@@ -152,6 +167,8 @@ class TypedDistinctAggregations : public DistinctAggregations {
     }
   }
 
+  void clear() override {}
+
  private:
   bool isSingleInputAggregate() const {
     return aggregates_[0]->inputs.size() == 1;
@@ -197,6 +214,35 @@ class TypedDistinctAggregations : public DistinctAggregations {
       return {std::move(input)};
     }
     return input->template asUnchecked<RowVector>()->children();
+  }
+
+  void extractForSpill(folly::Range<char**> groups, VectorPtr& result) const {
+    auto* arrayVector = result->as<ArrayVector>();
+    arrayVector->resize(groups.size());
+
+    auto* rawOffsets =
+        arrayVector->mutableOffsets(groups.size())->asMutable<vector_size_t>();
+    auto* rawSizes =
+        arrayVector->mutableSizes(groups.size())->asMutable<vector_size_t>();
+
+    vector_size_t offset = 0;
+    for (auto i = 0; i < groups.size(); ++i) {
+      auto* accumulator =
+          reinterpret_cast<AccumulatorType*>(groups[i] + offset_);
+      rawSizes[i] = accumulator->size() + 1;
+      rawOffsets[i] = offset;
+      offset += accumulator->size() + 1;
+    }
+
+    auto& elementsVector = arrayVector->elements();
+    elementsVector->resize(offset);
+    offset = 0;
+    for (auto i = 0; i < groups.size(); ++i) {
+      auto* accumulator =
+          reinterpret_cast<AccumulatorType*>(groups[i] + offset_);
+      accumulator->serialize(elementsVector, offset);
+      offset += accumulator->size() + 1;
+    }
   }
 
   memory::MemoryPool* const pool_;

--- a/velox/exec/DistinctAggregations.h
+++ b/velox/exec/DistinctAggregations.h
@@ -86,10 +86,17 @@ class DistinctAggregations {
       const RowVectorPtr& input,
       const SelectivityVector& rows) = 0;
 
+  virtual void addSingleGroupSpillInput(
+      char* group,
+      const VectorPtr& input,
+      vector_size_t index) = 0;
+
   /// Computes aggregations and stores results in the specified 'result' vector.
   virtual void extractValues(
       folly::Range<char**> groups,
       const RowVectorPtr& result) = 0;
+
+  virtual void clear() = 0;
 
  protected:
   // Initializes null flags and accumulators for newly encountered groups.  This

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1050,6 +1050,13 @@ void GroupingSet::spill() {
   if (sortedAggregations_) {
     sortedAggregations_->clear();
   }
+
+  for (const auto& agg : distinctAggregations_) {
+    if (agg != nullptr) {
+      agg->clear();
+    }
+  }
+
   table_->clear(/*freeTable=*/true);
 }
 
@@ -1072,6 +1079,17 @@ void GroupingSet::spill(const RowContainerIterator& rowIterator) {
   // guarantee we don't accidentally enter an unsafe situation.
   rows->stringAllocator().freezeAndExecute(
       [&]() { outputSpiller_->spill(rowIterator); });
+
+  if (sortedAggregations_) {
+    sortedAggregations_->clear();
+  }
+
+  for (const auto& agg : distinctAggregations_) {
+    if (agg != nullptr) {
+      agg->clear();
+    }
+  }
+
   table_->clear(/*freeTable=*/true);
 }
 
@@ -1332,6 +1350,13 @@ void GroupingSet::initializeRow(SpillMergeStream& stream, char* row) {
     sortedAggregations_->initializeNewGroups(
         &row, folly::Range<const vector_size_t*>(&zero, 1));
   }
+
+  for (const auto& agg : distinctAggregations_) {
+    if (agg != nullptr) {
+      agg->initializeNewGroups(
+          &row, folly::Range<const vector_size_t*>(&zero, 1));
+    }
+  }
 }
 
 void GroupingSet::extractSpillResult(const RowVectorPtr& result) {
@@ -1378,11 +1403,20 @@ void GroupingSet::updateRow(SpillMergeStream& input, char* row) {
   }
   mergeSelection_.setValid(input.currentIndex(), false);
 
+  int index = aggregates_.size() + keyChannels_.size();
   if (sortedAggregations_ != nullptr) {
-    const auto& vector =
-        input.current().childAt(aggregates_.size() + keyChannels_.size());
+    const auto& vector = input.current().childAt(index);
     sortedAggregations_->addSingleGroupSpillInput(
         row, vector, input.currentIndex());
+    index++;
+  }
+
+  for (const auto& agg : distinctAggregations_) {
+    if (agg != nullptr) {
+      agg->addSingleGroupSpillInput(
+          row, input.current().childAt(index), input.currentIndex());
+      index++;
+    }
   }
 }
 

--- a/velox/exec/SetAccumulator.h
+++ b/velox/exec/SetAccumulator.h
@@ -16,6 +16,8 @@
 #pragma once
 
 #include <folly/container/F14Set.h>
+
+#include "velox/common/base/IOUtils.h"
 #include "velox/common/memory/HashStringAllocator.h"
 #include "velox/exec/AddressableNonNullValueList.h"
 #include "velox/exec/Strings.h"
@@ -29,6 +31,22 @@ namespace detail {
 
 /// Maintains a set of unique values. Non-null values are stored in F14FastSet.
 /// A separate flag tracks presence of the null value.
+/// The SetAccumulator also tracks the order in which the values are added to
+/// the accumulator (for ordered aggregations). So each value is associated with
+/// an index of its position.
+
+/// SetAccumulator supports serialization/deserialization to/from an array of
+/// byte streams.
+/// These are used in the spilling logic of operators using SetAccumulator.
+
+/// The serialization format is :
+/// i) The first element of the array is the index of the null value
+/// (or -1 if no null value).
+/// ii) The list of values (and optionally some metadata) in the order of
+/// their positions. The null position (if one) is skipped.
+/// iii) For scalar and string types, only the value is serialized in the
+/// order of their indexes in the accumulator. For a complex type, a tuple
+/// of (hash, value) is serialized.
 template <
     typename T,
     typename Hash = std::hash<T>,
@@ -114,6 +132,26 @@ struct SetAccumulator {
     }
   }
 
+  /// Deserializes accumulator from previously serialized value.
+  void deserialize(
+      const FlatVector<StringView>& vector,
+      vector_size_t index,
+      vector_size_t size,
+      HashStringAllocator* /*allocator*/) {
+    // The serialized value is the nullIndex (kNoNullIndex if no null is
+    // present) followed by the unique values ordered by index.
+    deserializeNullIndex(vector.valueAt(index).data());
+
+    // Mark the nullPosition beyond values to correctly offset when reading the
+    // stream.
+    const auto nullPosition = nullIndex.has_value() ? nullIndex.value() : size;
+    for (auto i = 1, j = 0; i < size; i++, j++) {
+      T value = *reinterpret_cast<const T*>(vector.valueAt(index + i).data());
+      auto pos = (j < nullPosition) ? j : i;
+      uniqueValues.insert({value, pos});
+    }
+  }
+
   /// Returns number of unique values including null.
   size_t size() const {
     return uniqueValues.size() + (nullIndex.has_value() ? 1 : 0);
@@ -134,10 +172,51 @@ struct SetAccumulator {
                                  : uniqueValues.size();
   }
 
+  /// Serializes a sequence of VARBINARY values starting at result[index].
+  /// This is used for the spill of this accumulator.
+  void serialize(const VectorPtr& result, vector_size_t index) {
+    auto* flatResult = result->as<FlatVector<StringView>>();
+    VELOX_CHECK_LE(uniqueValues.size() + 1, flatResult->size());
+
+    auto nullIndexValue = nullIndexSerializationValue();
+    flatResult->set(
+        index,
+        StringView(
+            reinterpret_cast<const char*>(&nullIndexValue),
+            sizeof(vector_size_t)));
+
+    // The null position is skipped when serializing values, so setting an out
+    // of bound value for no null position.
+    const auto nullPosition =
+        nullIndex.has_value() ? nullIndex.value() : uniqueValues.size();
+    const auto sizeOfT = sizeof(T);
+    for (const auto& value : uniqueValues) {
+      auto pos = value.second;
+      auto offset = (pos < nullPosition ? pos : pos - 1) + index + 1;
+      flatResult->set(
+          offset,
+          StringView(reinterpret_cast<const char*>(&value.first), sizeOfT));
+    }
+  }
+
   void free(HashStringAllocator& allocator) {
     using UT = decltype(uniqueValues);
     uniqueValues.~UT();
   }
+
+  void deserializeNullIndex(const char* input) {
+    VELOX_CHECK(!nullIndex.has_value());
+    auto streamNullIndex = *reinterpret_cast<const vector_size_t*>(input);
+    if (streamNullIndex != kNoNullIndex) {
+      nullIndex = streamNullIndex;
+    }
+  }
+
+  vector_size_t nullIndexSerializationValue() {
+    return nullIndex.has_value() ? nullIndex.value() : kNoNullIndex;
+  }
+
+  static const vector_size_t kNoNullIndex = -1;
 };
 
 /// Maintains a set of unique strings.
@@ -162,14 +241,7 @@ struct StringViewSetAccumulator {
       }
     } else {
       auto value = decoded.valueAt<StringView>(index);
-      if (!value.isInline()) {
-        if (base.uniqueValues.contains(value)) {
-          return;
-        }
-        value = strings.append(value, *allocator);
-      }
-      base.uniqueValues.insert(
-          {value, base.nullIndex.has_value() ? cnt + 1 : cnt});
+      addValue(value, base.nullIndex.has_value() ? cnt + 1 : cnt, allocator);
     }
   }
 
@@ -218,6 +290,23 @@ struct StringViewSetAccumulator {
     }
   }
 
+  void deserialize(
+      const FlatVector<StringView>& vector,
+      vector_size_t index,
+      vector_size_t size,
+      HashStringAllocator* allocator) {
+    base.deserializeNullIndex(vector.valueAt(index).data());
+
+    // Mark the nullPosition beyond values to correctly offset when reading the
+    // stream.
+    const auto nullPosition =
+        base.nullIndex.has_value() ? base.nullIndex.value() : size;
+    for (auto i = 1; i < size; i++) {
+      auto pos = i - 1 < nullPosition ? i - 1 : i;
+      addUniqueValue(vector.valueAt(index + i), pos, allocator);
+    }
+  }
+
   size_t size() const {
     return base.size();
   }
@@ -228,10 +317,56 @@ struct StringViewSetAccumulator {
     return base.extractValues(values, offset);
   }
 
+  /// Serialize an array of VARBINARY representation starting from
+  /// result[index]. This is used for the spill of this accumulator.
+  void serialize(const VectorPtr& result, vector_size_t index) {
+    auto* flatResult = result->as<FlatVector<StringView>>();
+    VELOX_CHECK_LE(base.uniqueValues.size() + 1, flatResult->size());
+
+    auto nullIndexValue = base.nullIndexSerializationValue();
+    flatResult->set(
+        index, StringView((const char*)&nullIndexValue, sizeof(vector_size_t)));
+
+    // The null position is skipped when serializing values, so setting an out
+    // of bound value for no null position.
+    const auto nullPosition = base.nullIndex.has_value()
+        ? base.nullIndex.value()
+        : base.uniqueValues.size();
+    for (const auto& value : base.uniqueValues) {
+      auto pos = value.second;
+      auto offset = (pos < nullPosition ? pos : pos - 1) + index + 1;
+      flatResult->set(offset, value.first);
+    }
+  }
+
   void free(HashStringAllocator& allocator) {
     strings.free(allocator);
     using Base = decltype(base);
     base.~Base();
+  }
+
+ private:
+  void addValue(
+      const StringView& value,
+      vector_size_t index,
+      HashStringAllocator* allocator) {
+    if (base.uniqueValues.contains(value)) {
+      return;
+    }
+
+    addUniqueValue(value, index, allocator);
+  }
+
+  void addUniqueValue(
+      const StringView& value,
+      vector_size_t index,
+      HashStringAllocator* allocator) {
+    VELOX_CHECK(!base.uniqueValues.contains(value));
+    StringView valueCopy = value;
+    if (!valueCopy.isInline()) {
+      valueCopy = strings.append(value, *allocator);
+    }
+    base.uniqueValues.insert({valueCopy, index});
   }
 };
 
@@ -246,6 +381,12 @@ struct ComplexTypeSetAccumulator {
 
   /// Stores unique non-null values.
   AddressableNonNullValueList values;
+
+  // Tracks the size of the biggest ComplexType in the set. This is used for
+  // allocating a temporary buffer during serialization.
+  size_t maxSize = 0;
+
+  static constexpr size_t kSizeOfHash = sizeof(uint64_t);
 
   ComplexTypeSetAccumulator(const TypePtr& type, HashStringAllocator* allocator)
       : base{
@@ -263,13 +404,9 @@ struct ComplexTypeSetAccumulator {
         base.nullIndex = cnt;
       }
     } else {
-      auto entry = values.append(decoded, index, allocator);
-
-      if (!base.uniqueValues
-               .insert({entry, base.nullIndex.has_value() ? cnt + 1 : cnt})
-               .second) {
-        values.removeLast(entry);
-      }
+      const auto entry = values.append(decoded, index, allocator);
+      const auto position = base.nullIndex.has_value() ? cnt + 1 : cnt;
+      addEntry(entry, position);
     }
   }
 
@@ -315,6 +452,30 @@ struct ComplexTypeSetAccumulator {
     }
   }
 
+  void deserialize(
+      const FlatVector<StringView>& vector,
+      vector_size_t index,
+      vector_size_t size,
+      HashStringAllocator* allocator) {
+    base.deserializeNullIndex(vector.valueAt(index).data());
+
+    // Mark the nullPosition beyond values to correctly offset when reading the
+    // stream.
+    const auto nullPosition =
+        base.nullIndex.has_value() ? base.nullIndex.value() : size;
+    for (auto i = 1; i < size; i++) {
+      auto value = vector.valueAt(index + i);
+      auto stream = common::InputByteStream(value.data());
+      auto hash = stream.read<uint64_t>();
+      auto length = value.size() - kSizeOfHash;
+      auto contents = StringView(stream.read<char>(length), length);
+      auto position = values.appendSerialized(contents, allocator);
+
+      auto pos = (i - 1 < nullPosition) ? i - 1 : i;
+      addEntry({position, contents.size(), hash}, pos);
+    }
+  }
+
   size_t size() const {
     return base.size();
   }
@@ -332,10 +493,78 @@ struct ComplexTypeSetAccumulator {
     return base.uniqueValues.size() + (base.nullIndex.has_value() ? 1 : 0);
   }
 
+  /// Starting from result[index] append a sequence of VARBINARY values for
+  /// serialization for spilling..
+  void serialize(const VectorPtr& result, vector_size_t index) {
+    auto* flatResult = result->as<FlatVector<StringView>>();
+    VELOX_CHECK_LE(base.uniqueValues.size() + 1, flatResult->size());
+
+    auto nullIndexValue = base.nullIndexSerializationValue();
+    flatResult->set(
+        index, StringView((const char*)&nullIndexValue, sizeof(vector_size_t)));
+
+    // Temporary buffer used during serialization.
+    auto* tempBuffer =
+        (char*)(flatResult->pool()->allocate(maxSize + kSizeOfHash));
+
+    // The null position is skipped when serializing values, so setting an out
+    // of bound value for no null position.
+    const auto nullPosition = base.nullIndex.has_value()
+        ? base.nullIndex.value()
+        : base.uniqueValues.size();
+    for (const auto& value : base.uniqueValues) {
+      auto pos = value.second;
+      auto offset = (pos < nullPosition ? pos : pos - 1) + index + 1;
+      SerializationStream stream(tempBuffer, kSizeOfHash + value.first.size);
+      // Complex type hash.
+      stream.append(&value.first.hash, kSizeOfHash);
+      // Complex type value.
+      stream.append(value.first);
+      flatResult->set(
+          offset, StringView(tempBuffer, kSizeOfHash + value.first.size));
+    }
+
+    flatResult->pool()->free(tempBuffer, maxSize + kSizeOfHash);
+  }
+
   void free(HashStringAllocator& allocator) {
     values.free(allocator);
     using Base = decltype(base);
     base.~Base();
+  }
+
+ private:
+  // Simple stream abstraction for serialization logic. 'append' calls to concat
+  // values to the stream (for the input buffer) are exposed to the user.
+  struct SerializationStream {
+    char* rawBuffer;
+    const vector_size_t totalSize;
+    vector_size_t offset = 0;
+
+    SerializationStream(char* buffer, vector_size_t totalSize)
+        : rawBuffer(buffer), totalSize(totalSize) {}
+
+    void append(const void* value, vector_size_t size) {
+      VELOX_CHECK_LE(offset + size, totalSize);
+      memcpy(rawBuffer + offset, value, size);
+      offset += size;
+    }
+
+    void append(const AddressableNonNullValueList::Entry& entry) {
+      VELOX_CHECK_LE(offset + entry.size, totalSize);
+      AddressableNonNullValueList::readSerialized(entry, rawBuffer + offset);
+      offset += entry.size;
+    }
+  };
+
+  void addEntry(
+      const AddressableNonNullValueList::Entry& entry,
+      vector_size_t index) {
+    if (!base.uniqueValues.insert({entry, index}).second) {
+      values.removeLast(entry);
+    } else {
+      maxSize = maxSize < entry.size ? entry.size : maxSize;
+    }
   }
 };
 
@@ -387,6 +616,20 @@ class UnknownTypeSetAccumulator {
     }
     values.setNull(offset, true);
     return 1;
+  }
+
+  /// Starting from result[index] append a sequence of VARBINARY values for
+  /// serialization for spilling..
+  void serialize(const VectorPtr& result, vector_size_t index) {
+    VELOX_NYI("Spilling not supported for UnknownTypeSets");
+  }
+
+  void deserialize(
+      const FlatVector<StringView>& vector,
+      vector_size_t index,
+      vector_size_t size,
+      HashStringAllocator* allocator) {
+    VELOX_NYI("Spilling not supported for UnknownTypeSets");
   }
 
   void free(HashStringAllocator& /*allocator*/) {}
@@ -512,6 +755,20 @@ struct CustomComparisonSetAccumulator {
       FlatVector<NativeType>& values,
       vector_size_t offset) {
     return base.extractValues(values, offset);
+  }
+
+  /// Starting from result[index] append a sequence of VARBINARY values for
+  /// serialization for spilling..
+  void serialize(const VectorPtr& result, vector_size_t index) {
+    base.serialize(result, index);
+  }
+
+  void deserialize(
+      const FlatVector<StringView>& vector,
+      vector_size_t index,
+      vector_size_t size,
+      HashStringAllocator* allocator) {
+    base.deserialize(vector, index, size, allocator);
   }
 
   void free(HashStringAllocator& allocator) {

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -2050,24 +2050,36 @@ TEST_F(AggregationTest, spillingForAggrsWithDistinct) {
   createDuckDbTable(vectors);
   auto spillDirectory = exec::test::TempDirectoryPath::create();
   core::PlanNodeId aggrNodeId;
-  TestScopedSpillInjection scopedSpillInjection(100);
-  auto task =
-      AssertQueryBuilder(duckDbQueryRunner_)
-          .spillDirectory(spillDirectory->getPath())
-          .config(QueryConfig::kSpillEnabled, true)
-          .config(QueryConfig::kAggregationSpillEnabled, true)
-          .plan(PlanBuilder()
-                    .values(vectors)
-                    .singleAggregation({"c1"}, {"count(DISTINCT c0)"}, {})
-                    .capturePlanNodeId(aggrNodeId)
-                    .planNode())
-          .assertResults("SELECT c1, count(DISTINCT c0) FROM tmp GROUP BY c1");
-  // Verify that spilling is not triggered.
-  const auto& queryConfig = task->queryCtx()->queryConfig();
-  ASSERT_TRUE(queryConfig.spillEnabled());
-  ASSERT_TRUE(queryConfig.aggregationSpillEnabled());
-  ASSERT_EQ(toPlanStats(task->taskStats()).at(aggrNodeId).spilledBytes, 0);
-  OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
+
+  auto testPlan = [&](const core::PlanNodePtr& plan, const std::string& sql) {
+    TestScopedSpillInjection scopedSpillInjection(100);
+    auto task = AssertQueryBuilder(duckDbQueryRunner_)
+                    .spillDirectory(spillDirectory->getPath())
+                    .config(QueryConfig::kSpillEnabled, "true")
+                    .config(QueryConfig::kAggregationSpillEnabled, "true")
+                    .plan(plan)
+                    .assertResults(sql);
+
+    auto taskStats = exec::toPlanStats(task->taskStats());
+    auto& stats = taskStats.at(aggrNodeId);
+    checkSpillStats(stats, true);
+    OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
+  };
+
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .singleAggregation({"c1"}, {"count(DISTINCT c0)"}, {})
+                  .capturePlanNodeId(aggrNodeId)
+                  .planNode();
+  testPlan(plan, "SELECT c1, count(DISTINCT c0) FROM tmp GROUP BY c1");
+
+  plan = PlanBuilder()
+             .values(vectors)
+             .project({"c0 % 7", "c1"})
+             .singleAggregation({"p0"}, {"count(DISTINCT c1)"}, {})
+             .capturePlanNodeId(aggrNodeId)
+             .planNode();
+  testPlan(plan, "SELECT c0 % 7, count(DISTINCT c1) FROM tmp GROUP BY 1");
 }
 
 TEST_F(AggregationTest, spillingForAggrsWithSorting) {

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -80,6 +80,7 @@ add_executable(
   RowNumberTest.cpp
   ScaledScanControllerTest.cpp
   ScaleWriterLocalPartitionTest.cpp
+  SetAccumulatorTest.cpp
   SortBufferTest.cpp
   SpillerTest.cpp
   SpillTest.cpp

--- a/velox/exec/tests/SetAccumulatorTest.cpp
+++ b/velox/exec/tests/SetAccumulatorTest.cpp
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/SetAccumulator.h"
+
+#include <gtest/gtest.h>
+#include "velox/exec/AddressableNonNullValueList.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::aggregate::prestosql {
+
+namespace {
+
+// The tests in this class validate the following
+// (for both Primitive and Complex types) :
+// i) Builds a SetAccumulator from the input data.
+// ii) Tracks the unique values in the input data for validation.
+// iii) Serializes the SetAccumulator and de-serializes the result in a second
+//      accumulator.
+// The test validates that both accumulators have the same contents and the
+// contents of the deserialized accumulator comprise the unique values from
+// the input data.
+class SetAccumulatorTest : public testing::Test, public test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  template <typename T>
+  void testPrimitive(const VectorPtr& data) {
+    std::unordered_set<T> uniqueValues;
+    SetAccumulator<T> accumulator(data->type(), allocator());
+    DecodedVector decodedVector(*data);
+    vector_size_t nullPosition = -1;
+    for (auto i = 0; i < data->size(); ++i) {
+      if (decodedVector.isNullAt(i)) {
+        nullPosition = i;
+      }
+      accumulator.addValue(decodedVector, i, allocator());
+      uniqueValues.insert(decodedVector.valueAt<T>(i));
+    }
+    ASSERT_EQ(accumulator.size(), uniqueValues.size());
+
+    auto serializedSize =
+        nullPosition == -1 ? uniqueValues.size() + 1 : uniqueValues.size();
+    auto serialized = BaseVector::create(VARBINARY(), serializedSize, pool());
+    accumulator.serialize(serialized, 0);
+
+    // Initialize another accumulator from the serialized vector.
+    SetAccumulator<T> accumulator2(data->type(), allocator());
+    auto flatSerialized = serialized->template asFlatVector<StringView>();
+    accumulator2.deserialize(
+        *flatSerialized, 0, serialized->size(), allocator());
+
+    // Extract the contents of the accumulator. The contents should match
+    // all the uniqueValues.
+    auto copy = BaseVector::create(data->type(), accumulator2.size(), pool());
+    auto copyFlat = copy->template asFlatVector<T>();
+    accumulator2.extractValues(*copyFlat, 0);
+
+    ASSERT_EQ(copy->size(), accumulator.size());
+    for (auto i = 0; i < copy->size(); i++) {
+      if (copyFlat->isNullAt(i)) {
+        ASSERT_EQ(i, nullPosition);
+      } else {
+        ASSERT_TRUE(uniqueValues.count(copyFlat->valueAt(i)) != 0);
+      }
+    }
+  }
+
+  void testComplexType(const VectorPtr& data) {
+    using T = AddressableNonNullValueList::Entry;
+    using Set = folly::F14FastSet<
+        T,
+        AddressableNonNullValueList::Hash,
+        AddressableNonNullValueList::EqualTo,
+        AlignedStlAllocator<T, 16>>;
+
+    // Unique values set used for validation in the tests.
+    AddressableNonNullValueList values;
+    Set uniqueValues{
+        0,
+        AddressableNonNullValueList::Hash{},
+        AddressableNonNullValueList::EqualTo{data->type()},
+        AlignedStlAllocator<T, 16>(allocator())};
+
+    // Build an accumulator from the input data. Also create a set of the
+    // unique values for validation.
+    SetAccumulator<ComplexType> accumulator1(data->type(), allocator());
+    DecodedVector decodedVector(*data);
+    vector_size_t nullPosition = -1;
+    for (auto i = 0; i < data->size(); ++i) {
+      accumulator1.addValue(decodedVector, i, allocator());
+      if (!decodedVector.isNullAt(i)) {
+        auto entry = values.append(decodedVector, i, allocator());
+        if (uniqueValues.contains(entry)) {
+          values.removeLast(entry);
+          continue;
+        }
+        ASSERT_TRUE(uniqueValues.insert(entry).second);
+        ASSERT_TRUE(uniqueValues.contains(entry));
+        ASSERT_FALSE(uniqueValues.insert(entry).second);
+      } else {
+        nullPosition = i;
+      }
+    }
+
+    auto accumulatorSizeCheck =
+        [&](const SetAccumulator<ComplexType>& accumulator) {
+          if (nullPosition != -1) {
+            ASSERT_EQ(accumulator.size(), uniqueValues.size() + 1);
+          } else {
+            ASSERT_EQ(accumulator.size(), uniqueValues.size());
+          }
+        };
+    accumulatorSizeCheck(accumulator1);
+
+    // Serialize the accumulator.
+    auto serialized =
+        BaseVector::create(VARBINARY(), uniqueValues.size() + 1, pool());
+    accumulator1.serialize(serialized, 0);
+
+    // Initialize another accumulator from the serialized vector.
+    SetAccumulator<ComplexType> accumulator2(data->type(), allocator());
+    auto serializedFlat = serialized->asFlatVector<StringView>();
+    accumulator2.deserialize(
+        *serializedFlat, 0, serialized->size(), allocator());
+    ASSERT_EQ(accumulator2.size(), accumulator1.size());
+    accumulatorSizeCheck(accumulator2);
+
+    // Extract the contents of the deserialized accumulator.
+    // All the values extracted are in the uniqueValues set already.
+    auto copy = BaseVector::create(data->type(), accumulator2.size(), pool());
+    accumulator2.extractValues(*copy, 0);
+    DecodedVector copyDecoded(*copy);
+    for (auto i = 0; i < copy->size(); ++i) {
+      if (copyDecoded.isNullAt(i)) {
+        ASSERT_EQ(i, nullPosition);
+      } else {
+        auto position = values.append(copyDecoded, i, allocator());
+        ASSERT_TRUE(uniqueValues.contains(position));
+        values.removeLast(position);
+      }
+    }
+  }
+
+  HashStringAllocator* allocator() {
+    return allocator_.get();
+  }
+
+  std::unique_ptr<HashStringAllocator> allocator_{
+      std::make_unique<HashStringAllocator>(pool())};
+};
+
+TEST_F(SetAccumulatorTest, integral) {
+  auto data1 = makeFlatVector<int32_t>({1, 2, 3, 4, 5});
+  testPrimitive<int32_t>(data1);
+  auto data2 = makeFlatVector<int16_t>({1, 2, 2, 3, 3, 4, 5, 5});
+  testPrimitive<int16_t>(data2);
+  auto data3 = makeFlatVector<int64_t>({1, 2, 2, 3, 4, 5, 3, 1, 4});
+  testPrimitive<int64_t>(data3);
+  auto data4 = makeNullableFlatVector<int32_t>({std::nullopt, 1, 2});
+  testPrimitive<int32_t>(data4);
+}
+
+TEST_F(SetAccumulatorTest, date) {
+  auto data = makeFlatVector<int32_t>({1, 2, 3, 4, 5}, DATE());
+  testPrimitive<int32_t>(data);
+  data = makeFlatVector<int32_t>({1, 2, 2, 3, 3, 4, 5, 5}, DATE());
+  testPrimitive<int32_t>(data);
+  data = makeFlatVector<int32_t>({1, 2, 2, 3, 4, 5, 3, 1, 4}, DATE());
+  testPrimitive<int32_t>(data);
+  data = makeNullableFlatVector<int32_t>({1, 2, std::nullopt}, DATE());
+  testPrimitive<int32_t>(data);
+}
+
+TEST_F(SetAccumulatorTest, strings) {
+  auto data =
+      makeFlatVector<StringView>({"abc", "non-inline string", "1234!@#$"});
+  testPrimitive<StringView>(data);
+
+  data = makeFlatVector<StringView>(
+      {"abc",
+       "non-inline string",
+       "non-inline string",
+       "reallylongstringreallylongstringreallylongstring",
+       "1234!@#$",
+       "abc"});
+  testPrimitive<StringView>(data);
+
+  data = makeNullableFlatVector<StringView>({"abc", std::nullopt, "def"});
+  testPrimitive<StringView>(data);
+}
+
+TEST_F(SetAccumulatorTest, array) {
+  auto data = makeArrayVector<int32_t>({
+      {1, 2, 3},
+      {4, 5},
+      {6, 7, 8, 9},
+      {},
+  });
+  testComplexType(data);
+
+  data = makeNullableArrayVector<int32_t>({
+      {1, 2, 3},
+      {4, 5},
+      {std::nullopt},
+      {6, 7, 8, 9},
+      {},
+  });
+  testComplexType(data);
+
+  data = makeArrayVector<int32_t>({
+      {1, 2, 3},
+      {1, 2, 3},
+      {4, 5},
+      {6, 7, 8, 9},
+      {},
+      {4, 5},
+      {1, 2, 3},
+      {},
+  });
+  testComplexType(data);
+}
+
+TEST_F(SetAccumulatorTest, map) {
+  auto data = makeMapVector<int32_t, float>({
+      {{1, 10.1213}, {2, 20}},
+      {{3, 30}, {4, 40.258703570235497205}, {5, 50}},
+      {{1, 10.4324}, {3, 30}, {4, 40.45209809}, {6, 60}},
+      {},
+  });
+  testComplexType(data);
+
+  data = makeNullableMapVector<int32_t, StringView>({
+      {{{1, "abc"}, {2, "this is a non-inline string"}}},
+      std::nullopt,
+      {{{3, "qrs"}, {4, "m"}, {5, "%&^%&^af489372843"}}},
+      {{}},
+  });
+  testComplexType(data);
+
+  // Has non-unique rows.
+  data = makeMapVector<int16_t, int64_t>({
+      {{1, 10}, {2, 20}},
+      {{3, 30}, {4, 40}, {5, 50}},
+      {{3, 30}, {4, 40}, {5, 50}},
+      {{1, 10}, {2, 20}},
+      {{1, 10}, {3, 30}, {4, 40}, {6, 60}},
+      {},
+      {{1, 10}, {2, 20}},
+      {},
+      {{3, 30}, {4, 40}, {5, 50}},
+  });
+  testComplexType(data);
+}
+
+TEST_F(SetAccumulatorTest, row) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
+      makeFlatVector<StringView>(
+          {"abc", "this is a non-inline string", "def", "ghij", "klm"}),
+      makeFlatVector<int64_t>({11, 22, 33, 44, 55}),
+  });
+  testComplexType(data);
+
+  // Has non-unique rows.
+  data = makeRowVector({
+      makeFlatVector<int16_t>({1, 2, 3, 4, 2, 5, 3}),
+      makeFlatVector<float>(
+          {10.1, 20.1234567, 30.35, 40, 20.1234567, 50.42309234, 30}),
+      makeFlatVector<int32_t>({11, 22, 33, 44, 22, 55, 33}, DATE()),
+  });
+  testComplexType(data);
+
+  data = makeRowVector({
+      makeNullableFlatVector<int16_t>({1, 2, std::nullopt, 4, 5}),
+      makeNullableFlatVector<int32_t>({10, 20, 30, std::nullopt, 50}),
+      makeNullableFlatVector<int64_t>({std::nullopt, 22, 33, std::nullopt, 55}),
+  });
+  testComplexType(data);
+}
+
+} // namespace
+} // namespace facebook::velox::aggregate::prestosql


### PR DESCRIPTION
HashAggregation supports spilling in general. However, it didn't support spilling for a DISTINCT aggregation. e.g. Like SQL query

`SELECT c1, count(DISTINCT c0) FROM tmp GROUP BY c1`

Distinct aggregations work by capturing the column parameter values in a SetAccumulator to track only the DISTINCT values. The outer aggregation is computed over the contents of these SetAccumulators.

To support spilling in this context multiple changes are needed:

- Enhance the RowContainer/GroupingSet code for spill extraction and re-building aggregation contents from the spill to perform these functions for the DistinctAggregations as well. 
- Add capabilities to extract spill contents and rebuild accumulators from previous spill in the SetAccumulators.
- SetAccumulators are of 3 types : i) For fixed-width types ii) String types iii) Complex types. Each of these are enhanced to extract spill and add from spill contents. The spill extraction involves serializing to a blob the set accumulator contents in the order of their indices captured from the input streams. String SetAccumulators serialize (length + contents) for each entry. ComplexType SetAccumulators serialize (length + contents) as well.
- Serializing ComplexTypes involves using an AddressableNonNullValueList structure. 
-- This class needed new methods to copy what appears externally a contiguous set of bytes into a ByteStream to extract a spill from it. 
-- A new method to append a stream of previously serialized contents from the spill was also added. 
-- Since we need to serialize the length of each ComplexType entry in the SetAccumulator the append method was enhanced as well to return the number of serialized bytes for it as well.
- Exhaustive tests for the SetAccumulator spill extraction and reconstruction are added.