### PR TITLE
Decrease max link jobs so that we can ensure builds for nightly jobs.

### DIFF
--- a/.circleci/dist_compile.yml
+++ b/.circleci/dist_compile.yml
@@ -333,7 +333,7 @@ jobs:
             chmod -R 777 /tmp/aggregate_fuzzer_repro
             _build/debug/velox/exec/tests/velox_aggregation_fuzzer_test \
                 --seed ${RANDOM} \
-                --duration_sec 60 \
+                --duration_sec 1800 \
                 --logtostderr=1 \
                 --minloglevel=0 \
                 --repro_persist_path=/tmp/aggregate_fuzzer_repro \

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: "Build"
         run: |
-          make debug NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=4 EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON"
+          make debug NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=2 EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON"
           ccache -s
 
       - name: "Run Presto Fuzzer"


### PR DESCRIPTION
All nightly GA jobs are failing at link time : https://github.com/facebookincubator/velox/actions/runs/7027480730 because of possible OOM. Decrease link time jobs so that we can build and test. 