### PR TITLE
Fix set_union and set_agg Presto functions to preserve order of inputs

### DIFF
--- a/velox/exec/SetAccumulator.h
+++ b/velox/exec/SetAccumulator.h
@@ -34,24 +34,41 @@ template <
     typename Hash = std::hash<T>,
     typename EqualTo = std::equal_to<T>>
 struct SetAccumulator {
-  bool hasNull{false};
-  folly::F14FastSet<T, Hash, EqualTo, AlignedStlAllocator<T, 16>> uniqueValues;
+  std::optional<vector_size_t> nullIndex;
+
+  folly::F14FastMap<
+      T,
+      int32_t,
+      Hash,
+      EqualTo,
+      AlignedStlAllocator<std::pair<const T, vector_size_t>, 16>>
+      uniqueValues;
 
   SetAccumulator(const TypePtr& /*type*/, HashStringAllocator* allocator)
-      : uniqueValues{AlignedStlAllocator<T, 16>(allocator)} {}
+      : uniqueValues{AlignedStlAllocator<std::pair<const T, vector_size_t>, 16>(
+            allocator)} {}
 
   SetAccumulator(Hash hash, EqualTo equalTo, HashStringAllocator* allocator)
-      : uniqueValues{0, hash, equalTo, AlignedStlAllocator<T, 16>(allocator)} {}
+      : uniqueValues{
+            0,
+            hash,
+            equalTo,
+            AlignedStlAllocator<std::pair<const T, vector_size_t>, 16>(
+                allocator)} {}
 
   /// Adds value if new. No-op if the value was added before.
   void addValue(
       const DecodedVector& decoded,
       vector_size_t index,
       HashStringAllocator* /*allocator*/) {
+    const auto cnt = uniqueValues.size();
     if (decoded.isNullAt(index)) {
-      hasNull = true;
+      if (!nullIndex.has_value()) {
+        nullIndex = cnt;
+      }
     } else {
-      uniqueValues.insert(decoded.valueAt<T>(index));
+      uniqueValues.insert(
+          {decoded.valueAt<T>(index), nullIndex.has_value() ? cnt + 1 : cnt});
     }
   }
 
@@ -71,22 +88,22 @@ struct SetAccumulator {
 
   /// Returns number of unique values including null.
   size_t size() const {
-    return uniqueValues.size() + (hasNull ? 1 : 0);
+    return uniqueValues.size() + (nullIndex.has_value() ? 1 : 0);
   }
 
   /// Copies the unique values and null into the specified vector starting at
   /// the specified offset.
   vector_size_t extractValues(FlatVector<T>& values, vector_size_t offset) {
-    vector_size_t index = offset;
     for (auto value : uniqueValues) {
-      values.set(index++, value);
+      values.set(offset + value.second, value.first);
     }
 
-    if (hasNull) {
-      values.setNull(index++, true);
+    if (nullIndex.has_value()) {
+      values.setNull(offset + nullIndex.value(), true);
     }
 
-    return index - offset;
+    return nullIndex.has_value() ? uniqueValues.size() + 1
+                                 : uniqueValues.size();
   }
 
   void free(HashStringAllocator& allocator) {
@@ -110,8 +127,11 @@ struct StringViewSetAccumulator {
       const DecodedVector& decoded,
       vector_size_t index,
       HashStringAllocator* allocator) {
+    const auto cnt = base.uniqueValues.size();
     if (decoded.isNullAt(index)) {
-      base.hasNull = true;
+      if (!base.nullIndex.has_value()) {
+        base.nullIndex = cnt;
+      }
     } else {
       auto value = decoded.valueAt<StringView>(index);
       if (!value.isInline()) {
@@ -120,7 +140,8 @@ struct StringViewSetAccumulator {
         }
         value = strings.append(value, *allocator);
       }
-      base.uniqueValues.insert(value);
+      base.uniqueValues.insert(
+          {value, base.nullIndex.has_value() ? cnt + 1 : cnt});
     }
   }
 
@@ -176,12 +197,17 @@ struct ComplexTypeSetAccumulator {
       const DecodedVector& decoded,
       vector_size_t index,
       HashStringAllocator* allocator) {
+    const auto cnt = base.uniqueValues.size();
     if (decoded.isNullAt(index)) {
-      base.hasNull = true;
+      if (!base.nullIndex.has_value()) {
+        base.nullIndex = cnt;
+      }
     } else {
       auto position = values.append(decoded, index, allocator);
 
-      if (!base.uniqueValues.insert(position).second) {
+      if (!base.uniqueValues
+               .insert({position, base.nullIndex.has_value() ? cnt + 1 : cnt})
+               .second) {
         values.removeLast(position);
       }
     }
@@ -205,16 +231,16 @@ struct ComplexTypeSetAccumulator {
   }
 
   vector_size_t extractValues(BaseVector& values, vector_size_t offset) {
-    vector_size_t index = offset;
     for (const auto& position : base.uniqueValues) {
-      AddressableNonNullValueList::read(position, values, index++);
+      AddressableNonNullValueList::read(
+          position.first, values, offset + position.second);
     }
 
-    if (base.hasNull) {
-      values.setNull(index++, true);
+    if (base.nullIndex.has_value()) {
+      values.setNull(offset + base.nullIndex.value(), true);
     }
 
-    return index - offset;
+    return base.uniqueValues.size() + (base.nullIndex.has_value() ? 1 : 0);
   }
 
   void free(HashStringAllocator& allocator) {

--- a/velox/functions/prestosql/aggregates/tests/SetAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SetAggTest.cpp
@@ -413,5 +413,102 @@ TEST_F(SetAggTest, rowCheckNull) {
       "ROW comparison not supported for values that contain nulls");
 }
 
+TEST_F(SetAggTest, inputOrder) {
+  // Presto preserves order of input.
+
+  auto testInputOrder = [&](const RowVectorPtr& data,
+                            const RowVectorPtr& expected) {
+    auto plan = PlanBuilder()
+                    .values({data})
+                    .singleAggregation({}, {"set_agg(c0)"})
+                    .planNode();
+    assertQuery(plan, expected);
+  };
+
+  // Integers.
+
+  auto data = makeRowVector({
+      makeNullableFlatVector<int32_t>(
+          {1, 2, 3, std::nullopt, 3, 4, 4, 5, 6, 7, std::nullopt}),
+  });
+
+  auto expected = makeRowVector({
+      makeArrayVectorFromJson<int32_t>({"[1, 2, 3, null, 4, 5, 6, 7]"}),
+  });
+
+  testInputOrder(data, expected);
+
+  // Strings.
+  data = makeRowVector({
+      makeNullableFlatVector<StringView>(
+          {"abc",
+           "bxy",
+           "cde",
+           "abc",
+           "bxy",
+           "cdef",
+           "hijk",
+           std::nullopt,
+           "abc",
+           "some very long string to test long strings"}),
+  });
+
+  expected = makeRowVector({
+      makeNullableArrayVector<StringView>({
+          {"abc",
+           "bxy",
+           "cde",
+           "cdef",
+           "hijk",
+           std::nullopt,
+           "some very long string to test long strings"},
+      }),
+  });
+
+  testInputOrder(data, expected);
+
+  // Complex types.
+
+  data = makeRowVector({
+      makeArrayVectorFromJson<int32_t>({
+          "[1, 2]",
+          "[5, 6]",
+          "null",
+          "[3, 4]",
+          "[1, 2]",
+          "[7, 8]",
+      }),
+  });
+
+  expected = makeRowVector({
+      makeNestedArrayVectorFromJson<int32_t>(
+          {"[[1,2], [5, 6], null, [3,4], [7, 8]]"}),
+  });
+
+  testInputOrder(data, expected);
+
+  // Group by
+  data = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 2, 1, 1, 1, 2, 2, 1, 2, 1}),
+      makeNullableFlatVector<int32_t>(
+          {1, 2, 3, std::nullopt, 3, 4, 4, 5, 6, 7, std::nullopt}),
+  });
+
+  expected = makeRowVector({
+      makeFlatVector<int32_t>({1, 2}),
+      makeNullableArrayVector<int32_t>({
+          {1, std::nullopt, 3, 4, 6},
+          {2, 3, 4, 5, 7},
+      }),
+  });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .singleAggregation({"c0"}, {"set_agg(c1)"})
+                  .planNode();
+
+  assertQuery(plan, expected);
+}
+
 } // namespace
 } // namespace facebook::velox::aggregate::test


### PR DESCRIPTION
Presto's set_union and set_agg functions preserve order of inputs. Velox should do the same. 

Fixes #7657