### PR TITLE
Improve timezone name matching logic

### DIFF
--- a/velox/docs/functions/presto/datetime.rst
+++ b/velox/docs/functions/presto/datetime.rst
@@ -367,3 +367,7 @@ transition: ::
 It can be interpreted as `2014-11-02 01:30:00 PDT`, or `2014-11-02 01:30:00 PST`, which are
 `2014-11-02 08:30:00 UTC` or `2014-11-02 09:30:00 UTC` respectively. The former one is
 picked to be consistent with Presto.
+
+**Timezone Name Parsing**: When parsing strings that contain timezone names, the 
+list of supported timezones follow the definition `here
+<https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>`_.

--- a/velox/type/tz/CMakeLists.txt
+++ b/velox/type/tz/CMakeLists.txt
@@ -16,4 +16,5 @@ if(${VELOX_BUILD_TESTING})
 endif()
 add_library(velox_type_tz TimeZoneMap.h TimeZoneDatabase.cpp TimeZoneMap.cpp)
 
-target_link_libraries(velox_type_tz Boost::regex fmt::fmt Folly::folly)
+target_link_libraries(velox_type_tz velox_exception Boost::regex fmt::fmt
+                      Folly::folly)

--- a/velox/type/tz/TimeZoneMap.cpp
+++ b/velox/type/tz/TimeZoneMap.cpp
@@ -15,46 +15,126 @@
  */
 
 #include "velox/type/tz/TimeZoneMap.h"
+
+#include <boost/algorithm/string.hpp>
 #include <fmt/core.h>
 #include <folly/container/F14Map.h>
+#include <folly/container/F14Set.h>
+#include "velox/common/base/Exceptions.h"
 
 namespace facebook::velox::util {
 
 // Defined on TimeZoneDatabase.cpp
 extern const std::unordered_map<int64_t, std::string>& getTimeZoneDB();
 
+namespace {
+
+folly::F14FastMap<std::string, int64_t> makeReverseMap(
+    const std::unordered_map<int64_t, std::string>& map) {
+  folly::F14FastMap<std::string, int64_t> reversed;
+  reversed.reserve(map.size() + 1);
+
+  for (const auto& entry : map) {
+    reversed.emplace(
+        boost::algorithm::to_lower_copy(entry.second), entry.first);
+  }
+  reversed.emplace("utc", 0);
+  return reversed;
+}
+
+inline bool isDigit(char c) {
+  return c >= '0' && c <= '9';
+}
+
+inline bool startsWith(std::string_view str, const char* prefix) {
+  return str.rfind(prefix, 0) == 0;
+}
+
+// The timezone parsing logic follows what is defined here:
+//   https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+inline bool isUtcEquivalentName(std::string_view zone) {
+  static folly::F14FastSet<std::string> utcSet = {
+      "utc", "uct", "gmt", "gmt0", "greenwich", "universal", "zulu", "z"};
+  return utcSet.find(zone) != utcSet.end();
+}
+
+std::string normalizeTimeZone(const std::string& originalZoneId) {
+  std::string_view zoneId = originalZoneId;
+  const bool startsWithEtc = startsWith(zoneId, "etc/");
+
+  if (startsWithEtc) {
+    zoneId = zoneId.substr(4);
+  }
+
+  // ETC/GMT, ETC/GREENWICH, and others are all valid and link to GMT.
+  if (isUtcEquivalentName(zoneId)) {
+    return "utc";
+  }
+
+  // Check for Etc/GMT(+/-)H[H] pattern.
+  if (startsWithEtc) {
+    if (zoneId.size() > 4 && startsWith(zoneId, "gmt")) {
+      zoneId = zoneId.substr(3);
+      char signChar = zoneId[0];
+
+      if (signChar == '+' || signChar == '-') {
+        // ETC flips the sign.
+        signChar = (signChar == '-') ? '+' : '-';
+
+        // Extract the tens and ones characters for the hour.
+        char hourTens;
+        char hourOnes;
+
+        if (zoneId.size() == 2) {
+          hourTens = '0';
+          hourOnes = zoneId[1];
+        } else {
+          hourTens = zoneId[1];
+          hourOnes = zoneId[2];
+        }
+
+        // Prevent it from returning -00:00, which is just utc.
+        if (hourTens == '0' && hourOnes == '0') {
+          return "utc";
+        }
+
+        if (isDigit(hourTens) && isDigit(hourOnes)) {
+          return std::string() + signChar + hourTens + hourOnes + ":00";
+        }
+      }
+    }
+  }
+  return originalZoneId;
+}
+
+} // namespace
+
 std::string getTimeZoneName(int64_t timeZoneID) {
   const auto& tzDB = getTimeZoneDB();
   auto it = tzDB.find(timeZoneID);
-  if (it == tzDB.end()) {
-    throw std::runtime_error(
-        fmt::format("Unable to resolve timeZoneID '{}'.", timeZoneID));
-  }
+  VELOX_CHECK(
+      it != tzDB.end(), "Unable to resolve timeZoneID '{}'", timeZoneID);
   return it->second;
 }
-
-namespace {
-folly::F14FastMap<std::string_view, int64_t> makeReverseMap(
-    const std::unordered_map<int64_t, std::string>& map) {
-  folly::F14FastMap<std::string_view, int64_t> reversed;
-  reversed.reserve(map.size());
-  for (const auto& entry : map) {
-    reversed.emplace(entry.second, entry.first);
-  }
-  return reversed;
-}
-} // namespace
 
 int64_t getTimeZoneID(std::string_view timeZone) {
-  static folly::F14FastMap<std::string_view, int64_t> nameToIdMap =
+  static folly::F14FastMap<std::string, int64_t> nameToIdMap =
       makeReverseMap(getTimeZoneDB());
+  std::string timeZoneLowered;
+  boost::algorithm::to_lower_copy(
+      std::back_inserter(timeZoneLowered), timeZone);
 
-  auto it = nameToIdMap.find(timeZone);
-  if (it == nameToIdMap.end()) {
-    throw std::runtime_error(fmt::format("Unknown time zone: {}", timeZone));
+  auto it = nameToIdMap.find(timeZoneLowered);
+  if (it != nameToIdMap.end()) {
+    return it->second;
   }
 
-  return it->second;
+  // If an exact match wasn't found, try to normalize the timezone name.
+  it = nameToIdMap.find(normalizeTimeZone(timeZoneLowered));
+  if (it != nameToIdMap.end()) {
+    return it->second;
+  }
+  VELOX_FAIL("Unknown time zone: '{}'", timeZone);
 }
 
 } // namespace facebook::velox::util

--- a/velox/type/tz/tests/CMakeLists.txt
+++ b/velox/type/tz/tests/CMakeLists.txt
@@ -16,4 +16,5 @@ add_executable(velox_type_tz_test TimeZoneMapTest.cpp)
 
 add_test(velox_type_tz_test velox_type_tz_test)
 
-target_link_libraries(velox_type_tz_test velox_type_tz gtest gtest_main pthread)
+target_link_libraries(velox_type_tz_test velox_type_tz velox_exception gtest
+                      gtest_main pthread)

--- a/velox/type/tz/tests/TimeZoneMapTest.cpp
+++ b/velox/type/tz/tests/TimeZoneMapTest.cpp
@@ -16,32 +16,67 @@
 
 #include <gtest/gtest.h>
 
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox::util {
 namespace {
 
-TEST(TimeZoneMapTest, simple) {
+TEST(TimeZoneMapTest, getTimeZoneName) {
   EXPECT_EQ("America/Los_Angeles", getTimeZoneName(1825));
   EXPECT_EQ("Europe/Moscow", getTimeZoneName(2079));
   EXPECT_EQ("Pacific/Kanton", getTimeZoneName(2231));
   EXPECT_EQ("Europe/Kyiv", getTimeZoneName(2232));
   EXPECT_EQ("America/Ciudad_Juarez", getTimeZoneName(2233));
   EXPECT_EQ("-00:01", getTimeZoneName(840));
+}
 
+TEST(TimeZoneMapTest, getTimeZoneID) {
   EXPECT_EQ(1825, getTimeZoneID("America/Los_Angeles"));
   EXPECT_EQ(2079, getTimeZoneID("Europe/Moscow"));
   EXPECT_EQ(2231, getTimeZoneID("Pacific/Kanton"));
   EXPECT_EQ(2232, getTimeZoneID("Europe/Kyiv"));
   EXPECT_EQ(2233, getTimeZoneID("America/Ciudad_Juarez"));
+  EXPECT_EQ(0, getTimeZoneID("UTC"));
+  EXPECT_EQ(0, getTimeZoneID("GMT"));
+  EXPECT_EQ(0, getTimeZoneID("Z"));
+  EXPECT_EQ(0, getTimeZoneID("greenwich"));
+  EXPECT_EQ(0, getTimeZoneID("ETC/GMT"));
+  EXPECT_EQ(0, getTimeZoneID("ETC/GMT0"));
+  EXPECT_EQ(0, getTimeZoneID("ETC/UCT"));
+  EXPECT_EQ(0, getTimeZoneID("ETC/universal"));
+  EXPECT_EQ(0, getTimeZoneID("etc/zulu"));
+
+  // (+/-)XX:MM format.
   EXPECT_EQ(840, getTimeZoneID("-00:01"));
   EXPECT_EQ(0, getTimeZoneID("+00:00"));
+  EXPECT_EQ(454, getTimeZoneID("-06:27"));
+  EXPECT_EQ(541, getTimeZoneID("-05:00"));
+  EXPECT_EQ(1140, getTimeZoneID("+05:00"));
+
+  EXPECT_EQ(0, getTimeZoneID("etc/GMT+0"));
+  EXPECT_EQ(0, getTimeZoneID("etc/GMT-0"));
+  EXPECT_EQ(1020, getTimeZoneID("etc/GMT-3"));
+  EXPECT_EQ(301, getTimeZoneID("etc/GMT+9"));
+  EXPECT_EQ(1680, getTimeZoneID("etc/GMT-14"));
+
+  // Case insensitive.
+  EXPECT_EQ(0, getTimeZoneID("utc"));
+  EXPECT_EQ(1825, getTimeZoneID("america/los_angeles"));
+  EXPECT_EQ(1825, getTimeZoneID("aMERICa/los_angeles"));
 }
 
 TEST(TimeZoneMapTest, invalid) {
-  EXPECT_THROW(getTimeZoneName(99999999), std::runtime_error);
+  VELOX_ASSERT_THROW(getTimeZoneName(99999999), "Unable to resolve timeZoneID");
+  VELOX_ASSERT_THROW(getTimeZoneID("This is a test"), "Unknown time zone");
 
-  EXPECT_THROW(getTimeZoneID("This is a test"), std::runtime_error);
+  VELOX_ASSERT_THROW(getTimeZoneID("ETC/05:00"), "Unknown time zone");
+  VELOX_ASSERT_THROW(getTimeZoneID("ETC+05:00"), "Unknown time zone");
+
+  VELOX_ASSERT_THROW(getTimeZoneID("etc/GMT-15"), "Unknown time zone");
+  VELOX_ASSERT_THROW(getTimeZoneID("etc/GMT+ab"), "Unknown time zone");
+  VELOX_ASSERT_THROW(getTimeZoneID("etc/GMT+300"), "Unknown time zone");
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
Improving the logic that matches timezone names to internal timezone
ids:
- Make it case insensitive
- Add missing aliases for UTC
- Add logic to parse and understand ETC timezones

Differential Revision: D51691106


