### PR TITLE
Fix non-null Constant to Arrow conversion error

### DIFF
--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -1029,6 +1029,7 @@ void exportToArrow(const VectorPtr& vec, ArrowSchema& arrowSchema) {
       valuesChild->format =
           exportArrowFormatStr(type, bridgeHolder->formatBuffer);
     }
+    valuesChild->name = "values";
 
     bridgeHolder->setChildAtIndex(
         0, newArrowSchema("i", "run_ends"), arrowSchema);

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -906,6 +906,33 @@ TEST_F(ArrowBridgeArrayExportTest, constantComplex) {
       vector, std::vector<std::optional<int64_t>>{1, 2, 3});
 }
 
+TEST_F(ArrowBridgeArrayExportTest, constantCrossValidate) {
+  auto vector =
+      BaseVector::createConstant(VARCHAR(), "hello", 100, pool_.get());
+  auto array = toArrow(vector, pool_.get());
+
+  ASSERT_OK(array->ValidateFull());
+  EXPECT_EQ(array->null_count(), 0);
+  ASSERT_EQ(
+      *array->type(), *arrow::run_end_encoded(arrow::int32(), arrow::utf8()));
+  const auto& reeArray = static_cast<const arrow::RunEndEncodedArray&>(*array);
+
+  const auto& runEnds = reeArray.run_ends();
+  const auto& values = reeArray.values();
+
+  ASSERT_EQ(*runEnds->type(), *arrow::int32());
+  ASSERT_EQ(*values->type(), *arrow::utf8());
+
+  const auto& valuesArray = static_cast<const arrow::StringArray&>(*values);
+  const auto& runEndsArray = static_cast<const arrow::Int32Array&>(*runEnds);
+
+  ASSERT_EQ(valuesArray.length(), 1);
+  ASSERT_EQ(runEndsArray.length(), 1);
+
+  EXPECT_EQ(valuesArray.GetString(0), std::string("hello"));
+  EXPECT_EQ(runEndsArray.Value(0), 100);
+}
+
 class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
  protected:
   // Used by this base test class to import Arrow data and create Velox Vector.

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -42,9 +42,14 @@ class ArrowBridgeSchemaExportTest : public testing::Test {
 
   void verifyScalarType(
       const ArrowSchema& arrowSchema,
-      const char* arrowFormat) {
-    EXPECT_EQ(std::string{arrowFormat}, std::string{arrowSchema.format});
-    EXPECT_EQ(nullptr, arrowSchema.name);
+      const char* arrowFormat,
+      const char* name = nullptr) {
+    EXPECT_STREQ(arrowFormat, arrowSchema.format);
+    if (name == nullptr) {
+      EXPECT_EQ(nullptr, arrowSchema.name);
+    } else {
+      EXPECT_STREQ(name, arrowSchema.name);
+    }
     EXPECT_EQ(nullptr, arrowSchema.metadata);
     EXPECT_EQ(arrowSchema.flags | ARROW_FLAG_NULLABLE, ARROW_FLAG_NULLABLE);
 
@@ -70,13 +75,13 @@ class ArrowBridgeSchemaExportTest : public testing::Test {
 
   void verifyNestedType(const TypePtr& type, ArrowSchema* schema) {
     if (type->kind() == TypeKind::ARRAY) {
-      EXPECT_EQ(std::string{"+l"}, std::string{schema->format});
+      EXPECT_STREQ("+l", schema->format);
     } else if (type->kind() == TypeKind::MAP) {
-      EXPECT_EQ(std::string{"+m"}, std::string{schema->format});
+      EXPECT_STREQ("+m", schema->format);
       ASSERT_EQ(schema->n_children, 1);
       schema = schema->children[0];
     } else if (type->kind() == TypeKind::ROW) {
-      EXPECT_EQ(std::string{"+s"}, std::string{schema->format});
+      EXPECT_STREQ("+s", schema->format);
     }
     // Scalar type.
     else {
@@ -113,7 +118,7 @@ class ArrowBridgeSchemaExportTest : public testing::Test {
 
     velox::exportToArrow(constantVector, arrowSchema);
 
-    EXPECT_EQ("+r", std::string{arrowSchema.format});
+    EXPECT_STREQ("+r", arrowSchema.format);
     EXPECT_EQ(nullptr, arrowSchema.name);
 
     EXPECT_EQ(2, arrowSchema.n_children);
@@ -124,8 +129,8 @@ class ArrowBridgeSchemaExportTest : public testing::Test {
     EXPECT_NE(nullptr, arrowSchema.children[0]);
     const auto& runEnds = *arrowSchema.children[0];
 
-    EXPECT_EQ("i", std::string{runEnds.format});
-    EXPECT_EQ("run_ends", std::string{runEnds.name});
+    EXPECT_STREQ("i", runEnds.format);
+    EXPECT_STREQ("run_ends", runEnds.name);
     EXPECT_EQ(0, runEnds.n_children);
     EXPECT_EQ(nullptr, runEnds.children);
     EXPECT_EQ(nullptr, runEnds.dictionary);
@@ -134,9 +139,9 @@ class ArrowBridgeSchemaExportTest : public testing::Test {
     EXPECT_NE(nullptr, arrowSchema.children[1]);
 
     if (isScalar) {
-      verifyScalarType(*arrowSchema.children[1], arrowFormat);
+      verifyScalarType(*arrowSchema.children[1], arrowFormat, "values");
     } else {
-      EXPECT_EQ(arrowFormat, std::string{arrowSchema.children[1]->format});
+      EXPECT_STREQ(arrowFormat, arrowSchema.children[1]->format);
       verifyNestedType(type, arrowSchema.children[1]);
     }
 


### PR DESCRIPTION
Summary:
Arrow fails when importing an REE Array when the children name are not
set. Set name to the canonical names as defined in the Arrow spec, and adding
cross-validation unit tests

Differential Revision: D51694517

Fixes #7690

