### PR TITLE
Document stats counters and stats macros rename

### DIFF
--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -19,47 +19,44 @@
 
 namespace facebook::velox {
 
-void registerVeloxCounters() {
+void registerVeloxMetrics() {
   // Tracks hive handle generation latency in range of [0, 100s] and reports
   // P50, P90, P99, and P100.
-  REPORT_ADD_HISTOGRAM_EXPORT_PERCENTILE(
-      kCounterHiveFileHandleGenerateLatencyMs, 10, 0, 100000, 50, 90, 99, 100);
+  DEFINE_HISTOGRAM_METRIC(
+      kMetricHiveFileHandleGenerateLatencyMs, 10, 0, 100000, 50, 90, 99, 100);
 
-  REPORT_ADD_STAT_EXPORT_TYPE(
-      kCounterCacheShrinkCount, facebook::velox::StatType::COUNT);
+  DEFINE_METRIC(kMetricCacheShrinkCount, facebook::velox::StatType::COUNT);
 
   // Tracks cache shrink latency in range of [0, 100s] and reports P50, P90,
   // P99, and P100.
-  REPORT_ADD_HISTOGRAM_EXPORT_PERCENTILE(
-      kCounterCacheShrinkTimeMs, 10, 0, 100'000, 50, 90, 99, 100);
+  DEFINE_HISTOGRAM_METRIC(
+      kMetricCacheShrinkTimeMs, 10, 0, 100'000, 50, 90, 99, 100);
 
   // Tracks memory reclaim exec time in range of [0, 600s] and reports
   // P50, P90, P99, and P100.
-  REPORT_ADD_HISTOGRAM_EXPORT_PERCENTILE(
-      kCounterMemoryReclaimExecTimeMs, 20, 0, 600'000, 50, 90, 99, 100);
+  DEFINE_HISTOGRAM_METRIC(
+      kMetricMemoryReclaimExecTimeMs, 20, 0, 600'000, 50, 90, 99, 100);
 
   // Tracks memory reclaim task wait time in range of [0, 60s] and reports
   // P50, P90, P99, and P100.
-  REPORT_ADD_HISTOGRAM_EXPORT_PERCENTILE(
-      kCounterMemoryReclaimWaitTimeMs, 10, 0, 60'000, 50, 90, 99, 100);
+  DEFINE_HISTOGRAM_METRIC(
+      kMetricMemoryReclaimWaitTimeMs, 10, 0, 60'000, 50, 90, 99, 100);
 
   // Tracks memory reclaim bytes.
-  REPORT_ADD_STAT_EXPORT_TYPE(
-      kCounterMemoryReclaimedBytes, facebook::velox::StatType::SUM);
+  DEFINE_METRIC(kMetricMemoryReclaimedBytes, facebook::velox::StatType::SUM);
 
   // Tracks the number of times that the memory reclaim wait timeouts.
-  REPORT_ADD_STAT_EXPORT_TYPE(
-      kCounterMemoryReclaimWaitTimeoutCount, facebook::velox::StatType::SUM);
+  DEFINE_METRIC(
+      kMetricMemoryReclaimWaitTimeoutCount, facebook::velox::StatType::SUM);
 
   // Tracks the number of times that the memory reclaim fails because of
   // non-reclaimable section which is an indicator that the memory reservation
   // is not sufficient.
-  REPORT_ADD_STAT_EXPORT_TYPE(
-      kCounterMemoryNonReclaimableCount, facebook::velox::StatType::COUNT);
+  DEFINE_METRIC(
+      kMetricMemoryNonReclaimableCount, facebook::velox::StatType::COUNT);
 
   // Tracks the number of times that we hit the max spill level limit.
-  REPORT_ADD_STAT_EXPORT_TYPE(
-      kCounterMaxSpillLevelExceededCount, facebook::velox::StatType::COUNT);
+  DEFINE_METRIC(
+      kMetricMaxSpillLevelExceededCount, facebook::velox::StatType::COUNT);
 }
-
 } // namespace facebook::velox

--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -20,32 +20,38 @@
 
 namespace facebook::velox {
 
-/// Velox Counter Registration
-void registerVeloxCounters();
+/// Velox metrics Registration.
+void registerVeloxMetrics();
 
-constexpr folly::StringPiece kCounterHiveFileHandleGenerateLatencyMs{
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+inline void registerVeloxCounters() {
+  registerVeloxMetrics();
+}
+#endif
+
+constexpr folly::StringPiece kMetricHiveFileHandleGenerateLatencyMs{
     "velox.hive_file_handle_generate_latency_ms"};
 
-constexpr folly::StringPiece kCounterCacheShrinkCount{
+constexpr folly::StringPiece kMetricCacheShrinkCount{
     "velox.cache_shrink_count"};
 
-constexpr folly::StringPiece kCounterCacheShrinkTimeMs{"velox.cache_shrink_ms"};
+constexpr folly::StringPiece kMetricCacheShrinkTimeMs{"velox.cache_shrink_ms"};
 
-constexpr folly::StringPiece kCounterMemoryReclaimExecTimeMs{
+constexpr folly::StringPiece kMetricMemoryReclaimExecTimeMs{
     "velox.memory_reclaim_exec_ms"};
 
-constexpr folly::StringPiece kCounterMemoryReclaimedBytes{
+constexpr folly::StringPiece kMetricMemoryReclaimedBytes{
     "velox.memory_reclaim_bytes"};
 
-constexpr folly::StringPiece kCounterMemoryReclaimWaitTimeMs{
+constexpr folly::StringPiece kMetricMemoryReclaimWaitTimeMs{
     "velox.memory_reclaim_wait_ms"};
 
-constexpr folly::StringPiece kCounterMemoryReclaimWaitTimeoutCount{
+constexpr folly::StringPiece kMetricMemoryReclaimWaitTimeoutCount{
     "velox.memory_reclaim_wait_timeout_count"};
 
-constexpr folly::StringPiece kCounterMemoryNonReclaimableCount{
+constexpr folly::StringPiece kMetricMemoryNonReclaimableCount{
     "velox.memory_non_reclaimable_count"};
 
-constexpr folly::StringPiece kCounterMaxSpillLevelExceededCount{
+constexpr folly::StringPiece kMetricMaxSpillLevelExceededCount{
     "velox.spill_max_level_exceeded_count"};
 } // namespace facebook::velox

--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -92,10 +92,10 @@ TEST_F(StatsReporterTest, trivialReporter) {
   auto reporter = std::dynamic_pointer_cast<TestReporter>(
       folly::Singleton<BaseStatsReporter>::try_get());
 
-  REPORT_ADD_STAT_EXPORT_TYPE("key1", StatType::COUNT);
-  REPORT_ADD_STAT_EXPORT_TYPE("key2", StatType::SUM);
-  REPORT_ADD_STAT_EXPORT_TYPE("key3", StatType::RATE);
-  REPORT_ADD_HISTOGRAM_EXPORT_PERCENTILE("key4", 10, 0, 100, 50, 99, 100);
+  DEFINE_METRIC("key1", StatType::COUNT);
+  DEFINE_METRIC("key2", StatType::SUM);
+  DEFINE_METRIC("key3", StatType::RATE);
+  DEFINE_HISTOGRAM_METRIC("key4", 10, 0, 100, 50, 99, 100);
 
   EXPECT_EQ(StatType::COUNT, reporter->statTypeMap["key1"]);
   EXPECT_EQ(StatType::SUM, reporter->statTypeMap["key2"]);
@@ -105,15 +105,15 @@ TEST_F(StatsReporterTest, trivialReporter) {
   EXPECT_TRUE(
       reporter->statTypeMap.find("key5") == reporter->statTypeMap.end());
 
-  REPORT_ADD_STAT_VALUE("key1", 10);
-  REPORT_ADD_STAT_VALUE("key1", 11);
-  REPORT_ADD_STAT_VALUE("key1", 15);
-  REPORT_ADD_STAT_VALUE("key2", 1001);
-  REPORT_ADD_STAT_VALUE("key2", 1200);
-  REPORT_ADD_STAT_VALUE("key3");
-  REPORT_ADD_STAT_VALUE("key3", 1100);
-  REPORT_ADD_HISTOGRAM_VALUE("key4", 50);
-  REPORT_ADD_HISTOGRAM_VALUE("key4", 100);
+  RECORD_METRIC_VALUE("key1", 10);
+  RECORD_METRIC_VALUE("key1", 11);
+  RECORD_METRIC_VALUE("key1", 15);
+  RECORD_METRIC_VALUE("key2", 1001);
+  RECORD_METRIC_VALUE("key2", 1200);
+  RECORD_METRIC_VALUE("key3");
+  RECORD_METRIC_VALUE("key3", 1100);
+  RECORD_HISTOGRAM_METRIC_VALUE("key4", 50);
+  RECORD_HISTOGRAM_METRIC_VALUE("key4", 100);
 
   EXPECT_EQ(36, reporter->counterMap["key1"]);
   EXPECT_EQ(2201, reporter->counterMap["key2"]);

--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -695,7 +695,7 @@ bool AsyncDataCache::makeSpace(
 uint64_t AsyncDataCache::shrink(uint64_t targetBytes) {
   VELOX_CHECK_GT(targetBytes, 0);
 
-  REPORT_ADD_STAT_VALUE(kCounterCacheShrinkCount);
+  RECORD_METRIC_VALUE(kMetricCacheShrinkCount);
   LOG(INFO) << "Try to shrink cache to free up "
             << velox::succinctBytes(targetBytes) << "  memory";
 
@@ -724,7 +724,7 @@ uint64_t AsyncDataCache::shrink(uint64_t targetBytes) {
     allocator_->unmap(memory::AllocationTraits::numPages(targetBytes));
   }
 
-  REPORT_ADD_HISTOGRAM_VALUE(kCounterCacheShrinkTimeMs, shrinkTimeUs / 1'000);
+  RECORD_HISTOGRAM_METRIC_VALUE(kMetricCacheShrinkTimeMs, shrinkTimeUs / 1'000);
   LOG(INFO) << "Freed " << velox::succinctBytes(evictedBytes)
             << " cache memory, spent " << velox::succinctMicros(shrinkTimeUs)
             << "\n"

--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -172,9 +172,9 @@ uint64_t MemoryReclaimer::run(
   }
   stats.reclaimExecTimeUs += execTimeUs;
   stats.reclaimedBytes += reclaimedBytes;
-  REPORT_ADD_HISTOGRAM_VALUE(
-      kCounterMemoryReclaimExecTimeMs, execTimeUs / 1'000);
-  REPORT_ADD_STAT_VALUE(kCounterMemoryReclaimedBytes, reclaimedBytes);
+  RECORD_HISTOGRAM_METRIC_VALUE(
+      kMetricMemoryReclaimExecTimeMs, execTimeUs / 1'000);
+  RECORD_METRIC_VALUE(kMetricMemoryReclaimedBytes, reclaimedBytes);
   return reclaimedBytes;
 }
 

--- a/velox/connectors/hive/FileHandle.cpp
+++ b/velox/connectors/hive/FileHandle.cpp
@@ -50,8 +50,8 @@ std::shared_ptr<FileHandle> FileHandleGenerator::operator()(
     VLOG(1) << "Generating file handle for: " << filename
             << " uuid: " << fileHandle->uuid.id();
   }
-  REPORT_ADD_HISTOGRAM_VALUE(
-      kCounterHiveFileHandleGenerateLatencyMs, elapsedTimeUs / 1000);
+  RECORD_HISTOGRAM_METRIC_VALUE(
+      kMetricHiveFileHandleGenerateLatencyMs, elapsedTimeUs / 1000);
   // TODO: build the hash map/etc per file type -- presumably after reading
   // the appropriate magic number from the file, or perhaps we include the file
   // type in the file handle key.

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -877,7 +877,7 @@ uint64_t HiveDataSink::WriterReclaimer::reclaim(
   }
 
   if (*writerInfo_->nonReclaimableSectionHolder.get()) {
-    REPORT_ADD_STAT_VALUE(kCounterMemoryNonReclaimableCount);
+    RECORD_METRIC_VALUE(kMetricMemoryNonReclaimableCount);
     LOG(WARNING) << "Can't reclaim from hive writer pool " << pool->name()
                  << " which is under non-reclaimable section, "
                  << " used memory: " << succinctBytes(pool->currentBytes())

--- a/velox/docs/index.rst
+++ b/velox/docs/index.rst
@@ -10,6 +10,7 @@ Velox Documentation
     functions
     spark_functions
     configs
+    stats
     bindings/python/README_generated_pyvelox
     develop
     programming-guide

--- a/velox/docs/stats.rst
+++ b/velox/docs/stats.rst
@@ -1,0 +1,120 @@
+==============
+Runtime Metric
+==============
+
+Runtime metric is used to collect the metrics of important velox runtime events
+for monitoring purpose. The collected metrics can provide insights into the
+continuous availability and performance analysis of a Velox runtime system. For
+instance, the collected data can help automatically generate alerts at an
+outage. Velox provides a framework to collect the metrics which consists of
+three steps:
+
+**Define**: define the name and type for the metric through DEFINE_METRIC and
+DEFINE_HISTOGRAM_METRIC macros. DEFINE_HISTOGRAM_METRIC is used for histogram
+metric type and DEFINE_METRIC is used for the other types (see metric type
+definition below). BaseStatsReporter provides methods for metric definition.
+Register metrics during startup using registerVeloxMetrics() API.
+
+**Record**: record the metric data point using RECORD_METRIC_VALUE and
+RECORD_HISTOGRAM_METRIC_VALUE macros when the corresponding event happens.
+BaseStatsReporter provides methods for metric recording.
+
+**Export**: aggregates the collected data points based on the defined metrics,
+and periodically exports to the backend monitoring service, such as ODS used by
+Meta, Apache projects `OpenCensus <https://opencensus.io/>`_  and `Prometheus <https://prometheus.io/>`_ provided by OSS. A derived
+implementation of BaseStatsReporter is required to integrate with a specific
+monitoring service. The metric aggregation granularity and export interval are
+also configured based on the actual used monitoring service.
+
+**Count**: tracks the count of events, such as the number of query failures.
+
+**Sum**: tracks the sum of event data point values, such as sum of query scan
+read bytes.
+
+**Avg**: tracks the average of event data point values, such as average of query
+execution time.
+
+**Rate**: tracks the sum of event data point values per second, such as the
+number of shuffle requests per second.
+
+**Histogram**: tracks the distribution of event data point values, such as query
+execution time distribution. The histogram metric divides the entire data range
+into a series of adjacent equal-sized intervals or buckets, and then count how
+many data values fall into each bucket. DEFINE_HISTOGRAM_STAT specifies the data
+range by min/max values, and the number of buckets. Any collected data value
+less than min is counted in min bucket, and any one larger than max is counted
+in max bucket. It also allows to specify the value percentiles to report for
+monitoring. This allows BaseStatsReporter and the backend monitoring service to
+optimize the aggregated data storage.
+
+Memory Management
+-----------------
+
+.. list-table::
+   :widths: 40 10 50
+   :header-rows: 1
+
+   * - Metric Name
+     - Type
+     - Description
+   * - cache_shrink_count
+     - Count
+     - The number of times that in-memory data cache has been shrunk under
+       memory pressure.
+   * - cache_shrink_ms
+     - Histogram
+     - The distribution of cache shrink latency in range of [0, 100s] with 10
+       buckets. It is configured to report the latency at P50, P90, P99, and
+       P100 percentiles.
+   * - memory_reclaim_exec_ms
+     - Histogram
+     - The distribution of memory reclaim execution time in range of [0, 600s]
+       with 20 buckets. It is configured to report latency at P50, P90, P99, and
+       P100 percentiles.
+   * - memory_reclaim_bytes
+     - Sum
+     - The sum of reclaimed memory bytes.
+   * - memory_reclaim_wait_ms
+     - Histogram
+     - The distribution of memory reclaim wait time in range of [0, 60s] with 10
+       buckets. It is configured to report latency at P50, P90, P99, and P100
+       percentiles.
+   * - memory_reclaim_wait_timeout_count
+     - Count
+     - The number of times that the memory reclaim wait timeouts.
+   * - memory_non_reclaimable_count
+     - Count
+     - The number of times that the memory reclaim fails because of
+       non-reclaimable section which is an indicator that the memory reservation
+       is not sufficient.
+
+Spilling
+--------
+
+.. list-table::
+   :widths: 40 10 50
+   :header-rows: 1
+
+   * - Metric Name
+     - Type
+     - Description
+   * - spill_max_level_exceeded_count
+     - Count
+     - The number of times that a spillable operator hits the max spill level
+       limit.
+
+Hive Connector
+--------------
+
+.. list-table::
+   :widths: 40 10 50
+   :header-rows: 1
+
+   * - Metric Name
+     - Type
+     - Description
+   * - hive_file_handle_generate_latency_ms
+     - Histogram
+     - The distribution of hive file open latency in range of [0, 100s] with 10
+       buckets. It is configured to report latency at P50, P90, P99, and P100
+       percentiles.

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -728,7 +728,7 @@ uint64_t Writer::MemoryReclaimer::reclaim(
   }
 
   if (*writer_->nonReclaimableSection_) {
-    REPORT_ADD_STAT_VALUE(kCounterMemoryNonReclaimableCount);
+    RECORD_METRIC_VALUE(kMetricMemoryNonReclaimableCount);
     LOG(WARNING)
         << "Can't reclaim from dwrf writer which is under non-reclaimable section: "
         << pool->name();

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -222,7 +222,7 @@ void HashBuild::setupSpiller(SpillPartition* spillPartition) {
     // Disable spilling if exceeding the max spill level and the query might run
     // out of memory if the restored partition still can't fit in memory.
     if (spillConfig.exceedJoinSpillLevelLimit(startBit)) {
-      REPORT_ADD_STAT_VALUE(kCounterMaxSpillLevelExceededCount);
+      RECORD_METRIC_VALUE(kMetricMaxSpillLevelExceededCount);
       LOG(WARNING) << "Exceeded spill level limit: "
                    << spillConfig.maxSpillLevel
                    << ", and disable spilling for memory pool: "

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -607,7 +607,7 @@ uint64_t Operator::MemoryReclaimer::reclaim(
   if (op_->nonReclaimableSection_) {
     // TODO: reduce the log frequency if it is too verbose.
     ++stats.numNonReclaimableAttempts;
-    REPORT_ADD_STAT_VALUE(kCounterMemoryNonReclaimableCount);
+    RECORD_METRIC_VALUE(kMetricMemoryNonReclaimableCount);
     LOG(WARNING) << "Can't reclaim from memory pool " << pool->name()
                  << " which is under non-reclaimable section, memory usage: "
                  << succinctBytes(pool->currentBytes())

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2573,7 +2573,7 @@ uint64_t Task::MemoryReclaimer::reclaim(
   }
   VELOX_CHECK(paused || maxWaitMs != 0);
   if (!paused) {
-    REPORT_ADD_STAT_VALUE(kCounterMemoryReclaimWaitTimeoutCount, 1);
+    RECORD_METRIC_VALUE(kMetricMemoryReclaimWaitTimeoutCount, 1);
     VELOX_FAIL(
         "Memory reclaim failed to wait for task {} to pause after {} with max timeout {}",
         task->taskId(),
@@ -2582,8 +2582,8 @@ uint64_t Task::MemoryReclaimer::reclaim(
   }
 
   stats.reclaimWaitTimeUs += reclaimWaitTimeUs;
-  REPORT_ADD_HISTOGRAM_VALUE(
-      kCounterMemoryReclaimWaitTimeMs, reclaimWaitTimeUs / 1'000);
+  RECORD_HISTOGRAM_METRIC_VALUE(
+      kMetricMemoryReclaimWaitTimeMs, reclaimWaitTimeUs / 1'000);
 
   // Don't reclaim from a cancelled task as it will terminate soon.
   if (task->isCancelled()) {


### PR DESCRIPTION
Add velox metrics counter documentation and code refactor:
rename stats to metric and update the macros for metric definition
and record:
DEFINE_METRIC/DEFINE_HISTOGRAM_METRICS: define metrics
RECORD_METRIC_VALUE/RECORD_HISTOGRAM_METRIC_VALUE: record metrics

The followup will migrate Prestissimo to use new apis and deprecate
the old ones.