### PR TITLE
Fix duckValueAt for DATE values

### DIFF
--- a/velox/dwio/common/tests/utils/BatchMaker.cpp
+++ b/velox/dwio/common/tests/utils/BatchMaker.cpp
@@ -48,7 +48,7 @@ VectorPtr createScalar(
   BufferPtr values = AlignedBuffer::allocate<T>(size, &pool);
   auto valuesPtr = values->asMutableRange<T>();
 
-  BufferPtr nulls = AlignedBuffer::allocate<char>(bits::nbytes(size), &pool);
+  BufferPtr nulls = allocateNulls(size, &pool);
   auto* nullsPtr = nulls->asMutable<uint64_t>();
 
   size_t nullCount = 0;
@@ -68,7 +68,7 @@ VectorPtr createScalar(
 
 template <TypeKind KIND>
 VectorPtr BatchMaker::createVector(
-    const std::shared_ptr<const Type>& /* unused */,
+    const TypePtr& /* unused */,
     size_t /* unused */,
     memory::MemoryPool& /* unused */,
     std::mt19937& /* unused */,
@@ -78,7 +78,7 @@ VectorPtr BatchMaker::createVector(
 
 template <>
 VectorPtr BatchMaker::createVector<TypeKind::BOOLEAN>(
-    const std::shared_ptr<const Type>& /* unused */,
+    const TypePtr& /* unused */,
     size_t size,
     MemoryPool& pool,
     std::mt19937& gen,
@@ -93,7 +93,7 @@ VectorPtr BatchMaker::createVector<TypeKind::BOOLEAN>(
 
 template <>
 VectorPtr BatchMaker::createVector<TypeKind::TINYINT>(
-    const std::shared_ptr<const Type>& /* unused */,
+    const TypePtr& /* unused */,
     size_t size,
     MemoryPool& pool,
     std::mt19937& gen,
@@ -108,7 +108,7 @@ VectorPtr BatchMaker::createVector<TypeKind::TINYINT>(
 
 template <>
 VectorPtr BatchMaker::createVector<TypeKind::SMALLINT>(
-    const std::shared_ptr<const Type>& /* unused */,
+    const TypePtr& /* unused */,
     size_t size,
     MemoryPool& pool,
     std::mt19937& gen,
@@ -123,7 +123,7 @@ VectorPtr BatchMaker::createVector<TypeKind::SMALLINT>(
 
 template <>
 VectorPtr BatchMaker::createVector<TypeKind::INTEGER>(
-    const std::shared_ptr<const Type>& /* unused */,
+    const TypePtr& type,
     size_t size,
     MemoryPool& pool,
     std::mt19937& gen,
@@ -133,12 +133,13 @@ VectorPtr BatchMaker::createVector<TypeKind::INTEGER>(
       gen,
       [&gen]() { return static_cast<int32_t>(Random::rand32(gen)); },
       pool,
-      isNullAt);
+      isNullAt,
+      type);
 }
 
 template <>
 VectorPtr BatchMaker::createVector<TypeKind::BIGINT>(
-    const std::shared_ptr<const Type>& /* unused */,
+    const TypePtr& /*type*/,
     size_t size,
     MemoryPool& pool,
     std::mt19937& gen,
@@ -149,7 +150,7 @@ VectorPtr BatchMaker::createVector<TypeKind::BIGINT>(
 
 template <>
 VectorPtr BatchMaker::createVector<TypeKind::REAL>(
-    const std::shared_ptr<const Type>& /* unused */,
+    const TypePtr& /* unused */,
     size_t size,
     MemoryPool& pool,
     std::mt19937& gen,
@@ -164,7 +165,7 @@ VectorPtr BatchMaker::createVector<TypeKind::REAL>(
 
 template <>
 VectorPtr BatchMaker::createVector<TypeKind::DOUBLE>(
-    const std::shared_ptr<const Type>& /* unused */,
+    const TypePtr& /* unused */,
     size_t size,
     MemoryPool& pool,
     std::mt19937& gen,
@@ -179,7 +180,7 @@ VectorPtr BatchMaker::createVector<TypeKind::DOUBLE>(
 
 template <>
 VectorPtr BatchMaker::createVector<TypeKind::HUGEINT>(
-    const std::shared_ptr<const Type>& type,
+    const TypePtr& type,
     size_t size,
     MemoryPool& pool,
     std::mt19937& gen,
@@ -249,7 +250,7 @@ VectorPtr createBinary(
 
 template <>
 VectorPtr BatchMaker::createVector<TypeKind::VARCHAR>(
-    const std::shared_ptr<const Type>& /* unused */,
+    const TypePtr& /* unused */,
     size_t size,
     MemoryPool& pool,
     std::mt19937& gen,
@@ -259,7 +260,7 @@ VectorPtr BatchMaker::createVector<TypeKind::VARCHAR>(
 
 template <>
 VectorPtr BatchMaker::createVector<TypeKind::VARBINARY>(
-    const std::shared_ptr<const Type>& /* unused */,
+    const TypePtr& /* unused */,
     size_t size,
     MemoryPool& pool,
     std::mt19937& gen,
@@ -269,7 +270,7 @@ VectorPtr BatchMaker::createVector<TypeKind::VARBINARY>(
 
 template <>
 VectorPtr BatchMaker::createVector<TypeKind::TIMESTAMP>(
-    const std::shared_ptr<const Type>& /* unused */,
+    const TypePtr& /* unused */,
     size_t size,
     MemoryPool& pool,
     std::mt19937& gen,
@@ -289,7 +290,7 @@ VectorPtr BatchMaker::createVector<TypeKind::TIMESTAMP>(
 
 template <>
 VectorPtr BatchMaker::createVector<TypeKind::ROW>(
-    const std::shared_ptr<const Type>& type,
+    const TypePtr& type,
     size_t size,
     MemoryPool& pool,
     std::mt19937& gen,
@@ -297,7 +298,7 @@ VectorPtr BatchMaker::createVector<TypeKind::ROW>(
 
 template <>
 VectorPtr BatchMaker::createVector<TypeKind::ARRAY>(
-    const std::shared_ptr<const Type>& type,
+    const TypePtr& type,
     size_t size,
     MemoryPool& pool,
     std::mt19937& gen,
@@ -305,14 +306,14 @@ VectorPtr BatchMaker::createVector<TypeKind::ARRAY>(
 
 template <>
 VectorPtr BatchMaker::createVector<TypeKind::MAP>(
-    const std::shared_ptr<const Type>& type,
+    const TypePtr& type,
     size_t size,
     MemoryPool& pool,
     std::mt19937& gen,
     std::function<bool(vector_size_t /*index*/)> isNullAt);
 
 VectorPtr createRows(
-    const std::shared_ptr<const Type>& type,
+    const TypePtr& type,
     size_t size,
     bool allowNulls,
     MemoryPool& pool,
@@ -322,7 +323,7 @@ VectorPtr createRows(
   size_t nullCount = 0;
 
   if (allowNulls) {
-    nulls = AlignedBuffer::allocate<char>(bits::nbytes(size), &pool);
+    nulls = allocateNulls(size, &pool);
     auto* nullsPtr = nulls->asMutable<uint64_t>();
     for (size_t i = 0; i < size; ++i) {
       auto notNull = isNotNull(gen, i, isNullAt);
@@ -353,7 +354,7 @@ VectorPtr createRows(
 
 template <>
 VectorPtr BatchMaker::createVector<TypeKind::ROW>(
-    const std::shared_ptr<const Type>& type,
+    const TypePtr& type,
     size_t size,
     MemoryPool& pool,
     std::mt19937& gen,
@@ -363,18 +364,18 @@ VectorPtr BatchMaker::createVector<TypeKind::ROW>(
 
 template <>
 VectorPtr BatchMaker::createVector<TypeKind::ARRAY>(
-    const std::shared_ptr<const Type>& type,
+    const TypePtr& type,
     size_t size,
     MemoryPool& pool,
     std::mt19937& gen,
     std::function<bool(vector_size_t /*index*/)> isNullAt) {
-  BufferPtr offsets = AlignedBuffer::allocate<int32_t>(size, &pool);
+  BufferPtr offsets = allocateOffsets(size, &pool);
   auto* offsetsPtr = offsets->asMutable<int32_t>();
 
-  BufferPtr lengths = AlignedBuffer::allocate<vector_size_t>(size, &pool);
+  BufferPtr lengths = allocateSizes(size, &pool);
   auto* lengthsPtr = lengths->asMutable<vector_size_t>();
 
-  BufferPtr nulls = AlignedBuffer::allocate<char>(bits::nbytes(size), &pool);
+  BufferPtr nulls = allocateNulls(size, &pool);
   auto* nullsPtr = nulls->asMutable<uint64_t>();
 
   size_t nullCount = 0;
@@ -564,18 +565,18 @@ VectorPtr createMapKeys(
 
 template <>
 VectorPtr BatchMaker::createVector<TypeKind::MAP>(
-    const std::shared_ptr<const Type>& type,
+    const TypePtr& type,
     size_t size,
     MemoryPool& pool,
     std::mt19937& gen,
     std::function<bool(vector_size_t /*index*/)> isNullAt) {
-  BufferPtr offsets = AlignedBuffer::allocate<vector_size_t>(size, &pool);
+  BufferPtr offsets = allocateOffsets(size, &pool);
   auto* offsetsPtr = offsets->asMutable<vector_size_t>();
 
-  BufferPtr lengths = AlignedBuffer::allocate<vector_size_t>(size, &pool);
+  BufferPtr lengths = allocateSizes(size, &pool);
   auto* lengthsPtr = lengths->asMutable<vector_size_t>();
 
-  BufferPtr nulls = AlignedBuffer::allocate<char>(bits::nbytes(size), &pool);
+  BufferPtr nulls = allocateNulls(size, &pool);
   auto* nullsPtr = nulls->asMutable<uint64_t>();
 
   size_t nullCount = 0;
@@ -613,7 +614,7 @@ VectorPtr BatchMaker::createVector<TypeKind::MAP>(
 }
 
 VectorPtr BatchMaker::createBatch(
-    const std::shared_ptr<const Type>& type,
+    const TypePtr& type,
     uint64_t capacity,
     MemoryPool& memoryPool,
     std::mt19937& gen,
@@ -625,7 +626,7 @@ VectorPtr BatchMaker::createBatch(
 }
 
 VectorPtr BatchMaker::createBatch(
-    const std::shared_ptr<const Type>& type,
+    const TypePtr& type,
     uint64_t capacity,
     MemoryPool& memoryPool,
     std::function<bool(vector_size_t /*index*/)> isNullAt,

--- a/velox/dwio/common/tests/utils/BatchMaker.h
+++ b/velox/dwio/common/tests/utils/BatchMaker.h
@@ -31,14 +31,14 @@ void propagateNullsRecursive(BaseVector& vector);
 
 struct BatchMaker {
   static VectorPtr createBatch(
-      const std::shared_ptr<const Type>& type,
+      const TypePtr& type,
       uint64_t capacity,
       memory::MemoryPool& memoryPool,
       std::mt19937& gen,
       std::function<bool(vector_size_t /*index*/)> isNullAt = nullptr);
 
   static VectorPtr createBatch(
-      const std::shared_ptr<const Type>& type,
+      const TypePtr& type,
       uint64_t capacity,
       memory::MemoryPool& memoryPool,
       std::function<bool(vector_size_t /*index*/)> isNullAt = nullptr,
@@ -46,7 +46,7 @@ struct BatchMaker {
 
   template <TypeKind KIND>
   static VectorPtr createVector(
-      const std::shared_ptr<const Type>& type,
+      const TypePtr& type,
       size_t size,
       memory::MemoryPool& pool,
       std::mt19937& gen,
@@ -54,7 +54,7 @@ struct BatchMaker {
 
   template <TypeKind KIND>
   static VectorPtr createVector(
-      const std::shared_ptr<const Type>& type,
+      const TypePtr& type,
       size_t size,
       memory::MemoryPool& pool,
       std::function<bool(vector_size_t /*index*/)> isNullAt = nullptr,


### PR DESCRIPTION
Summary:
Fix JoinFuzzer's failure when processing DuckDB results of type MAP<DATE,SMALLINT>.

duckValueAt<TypeKind> template needs to be specialized for TypeKind::INTEGER to
allow it to process both INTEGER and DATE values correctly.

```
I1130 04:11:53.702302 81607 JoinFuzzer.cpp:867] ==============================> Started iteration 3 (seed: 923335250)
I1130 04:11:53.710649 81607 JoinFuzzer.cpp:281] Executing query plan:
-- HashJoin[LEFT SEMI (PROJECT) t1=u1 AND t3=u3 AND t0=u0 AND t2=u2] -> tp6:MAP<DATE,SMALLINT>, tp4:INTEGER, t2:TINYINT, tp5:INTEGER, t3:DOUBLE, t1:INTEGER, match:BOOLEAN
  -- Values[500 rows in 5 vectors] -> t0:TINYINT, t1:INTEGER, t2:TINYINT, t3:DOUBLE, tp4:INTEGER, tp5:INTEGER, tp6:MAP<DATE,SMALLINT>
  -- Values[55 rows in 5 vectors] -> u0:TINYINT, u1:INTEGER, u2:TINYINT, u3:DOUBLE

I1130 04:11:53.818156 81607 JoinFuzzer.cpp:299] Results: [ROW ROW<tp6:MAP<DATE,SMALLINT>,tp4:INTEGER,t2:TINYINT,tp5:INTEGER,t3:DOUBLE,t1:INTEGER,match:BOOLEAN>: 500 elements, no nulls]
terminate called after throwing an instance of 'duckdb::InvalidInputException'
  what():  Invalid Input Error: Failed to cast value: Unimplemented type for cast (INTEGER -> DATE)

```

Differential Revision: D51708552

Fixes #7744


