### PR TITLE
Increase resource usage for scheduled jobs

### DIFF
--- a/.circleci/dist_compile.yml
+++ b/.circleci/dist_compile.yml
@@ -333,7 +333,7 @@ jobs:
             chmod -R 777 /tmp/aggregate_fuzzer_repro
             _build/debug/velox/exec/tests/velox_aggregation_fuzzer_test \
                 --seed ${RANDOM} \
-                --duration_sec 60 \
+                --duration_sec 1800 \
                 --logtostderr=1 \
                 --minloglevel=0 \
                 --repro_persist_path=/tmp/aggregate_fuzzer_repro \

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -24,7 +24,7 @@ defaults:
 
 jobs:
   linux-presto-fuzzer-run:
-    runs-on: 8-core
+    runs-on: 16-core
     timeout-minutes: 120
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"
@@ -76,7 +76,7 @@ jobs:
 
 
   linux-spark-fuzzer-run:
-    runs-on: 8-core
+    runs-on: 16-core
     timeout-minutes: 120
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"
@@ -145,7 +145,7 @@ jobs:
 
 
   linux-aggregate-fuzzer-run:
-    runs-on: 8-core
+    runs-on: 16-core
     timeout-minutes: 120
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"
@@ -188,7 +188,7 @@ jobs:
             /tmp/aggregate_fuzzer_repro
 
   linux-join-fuzzer-run:
-    runs-on: 8-core
+    runs-on: 16-core
     timeout-minutes: 120
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"


### PR DESCRIPTION
Scheduled fuzzer jobs are currently ooming, https://github.com/facebookincubator/velox/actions/runs/7041471735/job/19164078488 . 
Run them on larger instances. 