### PR TITLE
Fix bug in regexp_extract_all

### DIFF
--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -239,7 +239,7 @@ class Re2Match final : public VectorFunction {
   }
 };
 
-void checkForBadGroupId(int groupId, const RE2& re) {
+void checkForBadGroupId(int64_t groupId, const RE2& re) {
   if (UNLIKELY(groupId < 0 || groupId > re.NumberOfCapturingGroups())) {
     VELOX_USER_FAIL("No group {} in regex '{}'", groupId, re.pattern());
   }

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -1154,5 +1154,16 @@ TEST_F(Re2FunctionsTest, invalidEscapeChar) {
   }
 }
 
+TEST_F(Re2FunctionsTest, regexExtractAllLarge) {
+  auto input = makeRowVector({});
+  input->resize(1);
+
+  VELOX_ASSERT_THROW(
+      evaluate(
+          "regexp_extract_all('1a 2b 14m', '(\\d+)([a-z]+)', CAST('4611686018427387904' AS BIGINT))",
+          input),
+      "No group 4611686018427387904 in regex '(\\d+)([a-z]+)")
+}
+
 } // namespace
 } // namespace facebook::velox::functions


### PR DESCRIPTION
Summary:
checkForBadGroupId function receiving int should receive int64_t instead.
Fix: https://github.com/facebookincubator/velox/issues/7743

Differential Revision: D51729306


