### PR TITLE
Extract main() from ConjunctTest.cpp into Main.cpp

### DIFF
--- a/velox/expression/Main.cpp
+++ b/velox/expression/Main.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv, false);
+  return RUN_ALL_TESTS();
+}

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -28,8 +28,8 @@ add_executable(
   CoalesceTest.cpp
   ConjunctTest.cpp
   ConstantFlatVectorReaderTest.cpp
+  Main.cpp
   MapWriterTest.cpp
-  ArrayWriterTest.cpp
   ReverseSignatureBinderTest.cpp
   RowWriterTest.cpp
   EvalSimplifiedTest.cpp

--- a/velox/expression/tests/ConjunctTest.cpp
+++ b/velox/expression/tests/ConjunctTest.cpp
@@ -103,12 +103,3 @@ TEST_F(ConjunctTest, constant) {
         plan, "select c0, c1, c2, if (c0 < 9, c1 and c2, c1 or c2) from tmp");
   }
 }
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  // Calls common init functions in the necessary order, initializing
-  // singletons, installing proper signal handlers for better debugging
-  // experience, and initialize glog and gflags.
-  folly::init(&argc, &argv);
-  return RUN_ALL_TESTS();
-}

--- a/velox/expression/tests/Main.cpp
+++ b/velox/expression/tests/Main.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv, false);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Extract main() from expression/ConjunctTest.cpp into its own Main.cpp.

Remove duplicate ArrayWriterTest.cpp from expression/CMakeLists.txt.