### PR TITLE
Fail array_sort if comparator lambda is not supported

### DIFF
--- a/velox/expression/LambdaExpr.cpp
+++ b/velox/expression/LambdaExpr.cpp
@@ -105,6 +105,7 @@ class ExprCallable : public Callable {
       const BufferPtr& wrapCapture,
       const std::vector<VectorPtr>& args,
       vector_size_t size) {
+    VELOX_CHECK_EQ(signature_->size(), args.size())
     std::vector<VectorPtr> allVectors = args;
     for (auto index = args.size(); index < capture_->childrenSize(); ++index) {
       auto values = capture_->childAt(index);

--- a/velox/functions/prestosql/ArraySort.cpp
+++ b/velox/functions/prestosql/ArraySort.cpp
@@ -491,13 +491,17 @@ core::TypedExprPtr rewriteArraySortCall(
     return nullptr;
   }
 
+  static const std::string kNotSupported =
+      "array_sort with comparator lambda that cannot be rewritten "
+      "into a transform is not supported: {}";
+
   if (auto comparison =
           functions::prestosql::isSimpleComparison(prefix, *lambda)) {
     std::string name = comparison->isLessThen ? prefix + "array_sort"
                                               : prefix + "array_sort_desc";
 
     if (!comparison->expr->type()->isOrderable()) {
-      return nullptr;
+      VELOX_USER_FAIL(kNotSupported, lambda->toString())
     }
 
     auto rewritten = std::make_shared<core::CallTypedExpr>(
@@ -514,7 +518,7 @@ core::TypedExprPtr rewriteArraySortCall(
     return rewritten;
   }
 
-  return nullptr;
+  VELOX_USER_FAIL(kNotSupported, lambda->toString())
 }
 
 // Register function.

--- a/velox/functions/prestosql/tests/ArraySortTest.cpp
+++ b/velox/functions/prestosql/tests/ArraySortTest.cpp
@@ -550,6 +550,19 @@ TEST_F(ArraySortTest, lambda) {
       "(x, y) -> if(length(x) < length(y), 1, if(length(x) = length(y), 0, -1))");
 }
 
+TEST_F(ArraySortTest, unsupporteLambda) {
+  auto data = makeRowVector({
+      makeArrayVectorFromJson<int32_t>({
+          "[1, 2, 3, 4]",
+          "[1, 2, 3]",
+      }),
+  });
+
+  VELOX_ASSERT_THROW(
+      evaluate("array_sort(c0, (a, b) -> 0)", data),
+      "array_sort with comparator lambda that cannot be rewritten into a transform is not supported");
+}
+
 TEST_F(ArraySortTest, failOnMapTypeSort) {
   static const std::string kErrorMessage =
       "Scalar function signature is not supported"_sv;


### PR DESCRIPTION
Fail expression evaluation if comparator lambda specified for array_sort cannot
be rewritten as a transform. Before this change, such expressions would crash.

Fixes #7829