### PR TITLE
Fix transform_keys to check new keys for null

### DIFF
--- a/velox/functions/lib/CheckDuplicateKeys.cpp
+++ b/velox/functions/lib/CheckDuplicateKeys.cpp
@@ -32,6 +32,9 @@ void checkDuplicateKeys(
   auto sizes = mapVector->rawSizes();
   auto mapKeys = mapVector->mapKeys();
   context.applyToSelectedNoThrow(rows, [&](auto row) {
+    if (mapVector->isNullAt(row)) {
+      return;
+    }
     auto offset = offsets[row];
     auto size = sizes[row];
     for (auto i = 1; i < size; i++) {

--- a/velox/functions/prestosql/Map.cpp
+++ b/velox/functions/prestosql/Map.cpp
@@ -51,10 +51,9 @@ class MapFunction : public exec::VectorFunction {
 
             VELOX_USER_CHECK(
                 !keysElements->containsNullAt(offset + i),
-                fmt::format(
-                    "{}: {}",
-                    kIndeterminateKeyErrorMessage,
-                    keysElements->toString(offset + i)));
+                "{}: {}",
+                kIndeterminateKeyErrorMessage,
+                keysElements->toString(offset + i));
           }
         };
     // When context.throwOnError is false, some rows will be marked as


### PR DESCRIPTION
transform_keys must check new keys for null and throw.

Fixes #7831