### PR TITLE
Add support for lambda functions to ExpressionFuzzer

### DIFF
--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -180,6 +180,11 @@ class FunctionSignature {
     return constantArguments_;
   }
 
+  bool hasConstantArgument() const {
+    return std::any_of(
+        constantArguments_.begin(), constantArguments_.end(), folly::identity);
+  }
+
   bool variableArity() const {
     return variableArity_;
   }

--- a/velox/expression/tests/ExpressionFuzzer.h
+++ b/velox/expression/tests/ExpressionFuzzer.h
@@ -191,6 +191,16 @@ class ExpressionFuzzer {
 
   core::TypedExprPtr generateArg(const TypePtr& arg);
 
+  // Given lambda argument type, generate matching LambdaTypedExpr.
+  //
+  // The 'arg' specifies inputs types and result type for the lambda. This
+  // method finds all matching signatures and signature templates, picks one
+  // randomly and generates LambdaTypedExpr. If no matching signatures or
+  // signature templates found, this method returns LambdaTypedExpr that
+  // represents a constant lambda, i.e lambda that returns the same value for
+  // all input. The constant value is generated using 'generateArgConstant'.
+  core::TypedExprPtr generateArgFunction(const TypePtr& arg);
+
   std::vector<core::TypedExprPtr> generateArgs(const CallableSignature& input);
 
   std::vector<core::TypedExprPtr> generateArgs(
@@ -239,6 +249,13 @@ class ExpressionFuzzer {
       const TypePtr& returnType,
       const std::string& functionName);
 
+  /// Returns a signature with matching input types and return type. Returns
+  /// nullptr if matching signature doesn't exist.
+  const CallableSignature* findConcreteSignature(
+      const std::vector<TypePtr>& argTypes,
+      const TypePtr& returnType,
+      const std::string& functionName);
+
   /// Generate an expression by randomly selecting a concrete function
   /// signature that returns 'returnType' among all signatures that the
   /// function named 'functionName' supports.
@@ -250,6 +267,14 @@ class ExpressionFuzzer {
   /// in expressionToTemplatedSignature_ whose return type can match
   /// returnType. Return nullptr if no such signature template exists.
   const SignatureTemplate* chooseRandomSignatureTemplate(
+      const TypePtr& returnType,
+      const std::string& typeName,
+      const std::string& functionName);
+
+  /// Returns a signature template with matching input types and return type.
+  /// Returns nullptr if matching signature template doesn't exist.
+  const SignatureTemplate* findSignatureTemplate(
+      const std::vector<TypePtr>& argTypes,
       const TypePtr& returnType,
       const std::string& typeName,
       const std::string& functionName);

--- a/velox/expression/tests/ExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerTest.cpp
@@ -52,6 +52,9 @@ int main(int argc, char** argv) {
 
   // TODO: List of the functions that at some point crash or fail and need to
   // be fixed before we can enable.
+  // This list can include a mix of function names and function signatures.
+  // Use function name to exclude all signatures of a given function from
+  // testing. Use function signature to exclude only a specific signature.
   std::unordered_set<std::string> skipFunctions = {
       // Fuzzer and the underlying engine are confused about cardinality(HLL)
       // (since HLL is a user defined type), and end up trying to use
@@ -60,6 +63,8 @@ int main(int argc, char** argv) {
       "cardinality",
       "element_at",
       "width_bucket",
+      // Fuzzer cannot generate valid 'comparator' lambda.
+      "array_sort(array(T),constant function(T,T,bigint)) -> array(T)",
   };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
   return FuzzerRunner::run(

--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -581,7 +581,7 @@ class LikeGeneric final : public VectorFunction {
 
       auto [it, inserted] = compiledRegularExpressions_.emplace(
           key, std::make_unique<RE2>(toStringPiece(regex), opt));
-      VELOX_CHECK_LE(
+      VELOX_USER_CHECK_LE(
           compiledRegularExpressions_.size(),
           kMaxCompiledRegexes,
           "Max number of regex reached");


### PR DESCRIPTION
The tricky part of supporting lambda functions is finding a way to generate
lambdas given both input types and the result type, i.e. generate
LambdaTypedExpr to match given FunctionType.  This implementation is very
basic. It looks for a matching function signature or signature template and if
none found uses a lambda expression that returns constant value.

For example, lambda for filter(array, function(T) -> boolean) can be 
x -> is_null(x) or x -> cast(x as boolean) or x -> true.

This very simple implementation is quite effective. It helped discover a number 
of bugs: #7821 #7824 #7828 #7829 #7831 #7851 #7861

This new logic cannot generate valid lambda for 'comparator' argument of
array_sort. Hence, added support for skipping individual function signatures
and used it to exclude this particular signature for array_sort.

Ran the Fuzzer multiple times for 10 minutes each and collected custom stats on
the lambda functions tested and lambda expressions generated. 20 functions
were tested using 154 different lambda expressions. More details in 
https://gist.github.com/mbasmanova/1530e3cdfe2f6f4fef35a03f07ee4a39

```
velox_expression_fuzzer_test --logtostderr --velox_fuzzer_enable_complex_types --enable_variadic_signatures --lazy_vector_generation_ratio 0.2 --velox_fuzzer_enable_column_reuse --velox_fuzzer_enable_expression_reuse --max_expression_trees_per_step 2 --retry_with_try --enable_dereference --duration_sec 1200 
```