### PR TITLE
Move ScopedContextSaver's restoration of context outside destructor.

### DIFF
--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -16,17 +16,13 @@
 
 #include "velox/expression/EvalCtx.h"
 #include <exception>
-#include "velox/common/base/RawVector.h"
+#include "velox/common/testutil/TestValue.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/PeeledEncoding.h"
 
-namespace facebook::velox::exec {
+using facebook::velox::common::testutil::TestValue;
 
-ScopedContextSaver::~ScopedContextSaver() {
-  if (context) {
-    context->restore(*this);
-  }
-}
+namespace facebook::velox::exec {
 
 EvalCtx::EvalCtx(core::ExecCtx* execCtx, ExprSet* exprSet, const RowVector* row)
     : execCtx_(execCtx),
@@ -57,9 +53,7 @@ EvalCtx::EvalCtx(core::ExecCtx* execCtx)
   VELOX_CHECK_NOT_NULL(execCtx);
 }
 
-void EvalCtx::saveAndReset(
-    ScopedContextSaver& saver,
-    const SelectivityVector& rows) {
+void EvalCtx::saveAndReset(ContextSaver& saver, const SelectivityVector& rows) {
   if (saver.context) {
     return;
   }
@@ -136,7 +130,9 @@ void EvalCtx::addErrors(
   });
 }
 
-void EvalCtx::restore(ScopedContextSaver& saver) {
+void EvalCtx::restore(ContextSaver& saver) {
+  TestValue::adjust("facebook::velox::exec::EvalCtx::restore", this);
+
   peeledFields_ = std::move(saver.peeled);
   nullsPruned_ = saver.nullsPruned;
   if (errors_) {

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -943,7 +943,7 @@ SelectivityVector* singleRow(
 
 Expr::PeelEncodingsResult Expr::peelEncodings(
     EvalCtx& context,
-    ScopedContextSaver& saver,
+    ContextSaver& saver,
     const SelectivityVector& rows,
     LocalDecodedVector& localDecoded,
     LocalSelectivityVector& newRowsHolder,
@@ -1033,8 +1033,8 @@ void Expr::evalEncodings(
     if (!hasFlat) {
       VectorPtr wrappedResult;
       // Attempt peeling and bound the scope of the context used for it.
-      {
-        ScopedContextSaver saveContext;
+
+      withContextSaver([&](ContextSaver& saveContext) {
         LocalSelectivityVector newRowsHolder(context);
         LocalSelectivityVector finalRowsHolder(context);
         LocalDecodedVector decodedHolder(context);
@@ -1048,9 +1048,9 @@ void Expr::evalEncodings(
         auto* newRows = peelEncodingsResult.newRows;
         if (newRows) {
           VectorPtr peeledResult;
-          // peelEncodings() can potentially produce an empty selectivity vector
-          // if all selected values we are waiting for are nulls. So, here we
-          // check for such a case.
+          // peelEncodings() can potentially produce an empty selectivity
+          // vector if all selected values we are waiting for are nulls. So,
+          // here we check for such a case.
           if (newRows->hasSelections()) {
             if (peelEncodingsResult.mayCache) {
               evalWithMemo(*newRows, context, peeledResult);
@@ -1061,7 +1061,8 @@ void Expr::evalEncodings(
           wrappedResult = context.getPeeledEncoding()->wrap(
               this->type(), context.pool(), peeledResult, rows);
         }
-      }
+      });
+
       if (wrappedResult != nullptr) {
         context.moveOrCopyResult(wrappedResult, rows, result);
         return;
@@ -1428,7 +1429,6 @@ bool Expr::applyFunctionWithPeeling(
     VectorPtr& result) {
   LocalDecodedVector localDecoded(context);
   LocalSelectivityVector newRowsHolder(context);
-  ScopedContextSaver saver;
   // Attempt peeling.
   std::vector<VectorPtr> peeledVectors;
   auto peeledEncoding = PeeledEncoding::peel(
@@ -1449,21 +1449,23 @@ bool Expr::applyFunctionWithPeeling(
   // pre-existing rows need to be preserved.
   auto newRows = peeledEncoding->translateToInnerRows(applyRows, newRowsHolder);
 
-  // Save context and set the peel.
-  context.saveAndReset(saver, applyRows);
-  context.setPeeledEncoding(peeledEncoding);
+  withContextSaver([&](ContextSaver& saver) {
+    // Save context and set the peel.
+    context.saveAndReset(saver, applyRows);
+    context.setPeeledEncoding(peeledEncoding);
 
-  // Apply the function.
-  VectorPtr peeledResult;
-  applyFunction(*newRows, context, peeledResult);
-  VectorPtr wrappedResult = context.getPeeledEncoding()->wrap(
-      this->type(), context.pool(), peeledResult, applyRows);
-  context.moveOrCopyResult(wrappedResult, applyRows, result);
+    // Apply the function.
+    VectorPtr peeledResult;
+    applyFunction(*newRows, context, peeledResult);
+    VectorPtr wrappedResult = context.getPeeledEncoding()->wrap(
+        this->type(), context.pool(), peeledResult, applyRows);
+    context.moveOrCopyResult(wrappedResult, applyRows, result);
 
-  // Recycle peeledResult if it's not owned by the result vector. Examples of
-  // when this can happen is when the result is a primitive constant vector, or
-  // when moveOrCopyResult copies wrappedResult content.
-  context.releaseVector(peeledResult);
+    // Recycle peeledResult if it's not owned by the result vector. Examples of
+    // when this can happen is when the result is a primitive constant vector,
+    // or when moveOrCopyResult copies wrappedResult content.
+    context.releaseVector(peeledResult);
+  });
 
   return true;
 }

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -408,7 +408,7 @@ class Expr {
 
   PeelEncodingsResult peelEncodings(
       EvalCtx& context,
-      ScopedContextSaver& saver,
+      ContextSaver& saver,
       const SelectivityVector& rows,
       LocalDecodedVector& localDecoded,
       LocalSelectivityVector& newRowsHolder,

--- a/velox/expression/tests/ExprEncodingsTest.cpp
+++ b/velox/expression/tests/ExprEncodingsTest.cpp
@@ -409,12 +409,12 @@ class ExprEncodingsTest
   void runWithError(const std::string& text) {
     exec::ExprSet exprs({parseExpression(text, testDataType_)}, execCtx_.get());
     auto row = testDataRow();
-    exec::EvalCtx context(execCtx_.get(), &exprs, row.get());
     auto size = row->size();
 
     vector_size_t begin = 0;
     vector_size_t end = size / 3 * 2;
     {
+      exec::EvalCtx context(execCtx_.get(), &exprs, row.get());
       auto rows = selectRange(begin, end);
       std::vector<VectorPtr> result(1);
 
@@ -426,6 +426,7 @@ class ExprEncodingsTest
     begin = size / 3;
     end = size;
     {
+      exec::EvalCtx context(execCtx_.get(), &exprs, row.get());
       auto rows = selectRange(begin, end);
       std::vector<VectorPtr> result(1);
 

--- a/velox/expression/tests/TryExprTest.cpp
+++ b/velox/expression/tests/TryExprTest.cpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/testutil/TestValue.h"
 #include "velox/functions/Udf.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/vector/ConstantVector.h"
@@ -25,9 +26,16 @@
 
 namespace facebook::velox {
 
+using namespace common::testutil;
 using namespace facebook::velox::test;
 
-class TryExprTest : public functions::test::FunctionBaseTest {};
+class TryExprTest : public functions::test::FunctionBaseTest {
+ protected:
+  static void SetUpTestCase() {
+    FunctionBaseTest::SetUpTestCase();
+    TestValue::enable();
+  }
+};
 
 TEST_F(TryExprTest, tryExpr) {
   auto a = makeFlatVector<int32_t>({10, 20, 30, 20, 50, 30});
@@ -462,5 +470,26 @@ TEST_F(TryExprTest, decimalDivideByZero) {
   auto expectedLong = makeNullableFlatVector<int128_t>(
       {std::nullopt, std::nullopt, std::nullopt}, DECIMAL(31, 10));
   assertEqualVectors(expectedLong, result);
+}
+
+TEST_F(TryExprTest, errorRestoringContext) {
+  registerFunction<TestingAlwaysThrowsFunction, bool, bool>({"always_throws"});
+  // Use a constant input so the encoding is peeled, triggering the EvalCtx to
+  // be saved and restored.
+  auto data = makeRowVector({makeConstant(true, 3)});
+
+  // EvalCtx::restore calls addError to propagate errors to the original
+  // context, this can resize the ErrorVector leading to exceptions through a
+  // variety of paths.  For the sake of simplicity, the TestValue is used here
+  // to simulate an OOM.
+  std::string exceptionMessage =
+      "Expected exception. Pretend we're out of memory.";
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::EvalCtx::restore",
+      std::function<void(exec::EvalCtx*)>(
+          ([&](exec::EvalCtx*) { VELOX_FAIL(exceptionMessage) })));
+
+  VELOX_ASSERT_THROW(
+      evaluate("try(always_throws(c0))", data), exceptionMessage);
 }
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:
ScopedContextSaver's destructor calls EvalCtx::restore, which among other things, propagates errors from the
new context to the original context.  Propagating errors can involve growing the error vector, which entails
allocating memory from the MemoryPool.

Unfortunately, there are a variety of ways this could lead to exceptions, we could run out of memory, we could
enter arbitration at a time when the Driver is being aborted, etc.

Destructors are by default noexcept, so any exception thrown in the destructor causes the binary to crash.

We could set the destructor to noexcept(false), but we could still see crashes, if the ScopedContextSaver is
destructed as part of unwinding the stack.  E.g. if an out of memory exception gets thrown and
ScopedContextSaver's destructor throws another out of memory exception while destructing as part of stack
unwinding.

To address this, I think we need to change ScopedContextSaver to no longer be "Scoped" and instead rely on
explicitly restoring the context when the new context is no longer needed, rather than doing so in the
destructor.

This is admittedly more error prone, but everywhere where we're using it today the only way to exit the scope
is to reach the end of the block (no premature returns, breaks, etc.) or due to an exception, so it's fairly easy to
get this right, at least for now.  We also lose the restoration of the original context (unless we catch, restore,
and rethrow), but it looks like the scopes where ScopedContextSaver is used, if an exception propagates to
that point, the query will fail anyway.

Differential Revision: D51760874


