### PR TITLE
Support TimestampWithTimezons in format_datetime()

### DIFF
--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -163,6 +163,11 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerFunction<FormatDateTimeFunction, Varchar, Timestamp, Varchar>(
       {prefix + "format_datetime"});
   registerFunction<
+      FormatDateTimeFunction,
+      Varchar,
+      TimestampWithTimezone,
+      Varchar>({prefix + "format_datetime"});
+  registerFunction<
       ParseDateTimeFunction,
       TimestampWithTimezone,
       Varchar,

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.cpp
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.cpp
@@ -18,6 +18,7 @@
 
 namespace facebook::velox {
 namespace {
+
 void castFromTimestamp(
     const SimpleVector<Timestamp>& inputVector,
     exec::EvalCtx& context,


### PR DESCRIPTION
Summary: Support TimestampWithTimezons in format_datetime.

Differential Revision: D51776777

Fixes #7839

