### PR TITLE
Improve scheduled fuzzer workflow

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -49,7 +49,7 @@ permissions:
 jobs:
   compile:
     runs-on: 8-core
-    timeout: 120
+    timeout-minutes: 120
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"
       CCACHE_BASEDIR: "${{ github.workspace }}"
@@ -111,6 +111,7 @@ jobs:
 
   linux-presto-fuzzer-run:
     runs-on: 8-core
+    needs: compile
     timeout-minutes: 120
     steps:
 
@@ -149,6 +150,7 @@ jobs:
 
   linux-spark-fuzzer-run:
     runs-on: 8-core
+    needs: compile
     timeout-minutes: 120
     steps:
 
@@ -206,6 +208,7 @@ jobs:
 
   linux-aggregate-fuzzer-run:
     runs-on: 8-core
+    needs: compile
     timeout-minutes: 120
     steps:
 
@@ -237,6 +240,7 @@ jobs:
 
   linux-join-fuzzer-run:
     runs-on: 8-core
+    needs: compile
     timeout-minutes: 120
     steps:
 

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -28,7 +28,7 @@ defaults:
 
 jobs:
   linux-presto-fuzzer-run:
-    runs-on: 16-core
+    runs-on: 8-core
     timeout-minutes: 120
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"
@@ -83,7 +83,7 @@ jobs:
 
 
   linux-spark-fuzzer-run:
-    runs-on: 16-core
+    runs-on: 8-core
     timeout-minutes: 120
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"
@@ -152,7 +152,7 @@ jobs:
 
 
   linux-aggregate-fuzzer-run:
-    runs-on: 16-core
+    runs-on: 8-core
     timeout-minutes: 120
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"
@@ -195,7 +195,7 @@ jobs:
             /tmp/aggregate_fuzzer_repro
 
   linux-join-fuzzer-run:
-    runs-on: 16-core
+    runs-on: 8-core
     timeout-minutes: 120
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -59,8 +59,7 @@ jobs:
         uses: rui314/setup-mold@v1
 
       - name: "Restore ccache"
-        uses: actions/cache/restore@v3
-        id: restore-cache
+        uses: actions/cache@v3
         with:
           path: "${{ env.CCACHE_DIR }}"
           # We are using the benchmark ccache as it has all 

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -123,6 +123,7 @@ jobs:
         run: |
           mkdir -p /tmp/fuzzer_repro/
           chmod -R 777 /tmp/fuzzer_repro
+          chmod +x velox_expression_fuzzer_test 
           ./velox_expression_fuzzer_test \
                 --seed ${RANDOM} \
                 --enable_variadic_signatures \
@@ -162,6 +163,7 @@ jobs:
         run: |
           mkdir -p /tmp/spark_fuzzer_repro/
             chmod -R 777 /tmp/spark_fuzzer_repro
+            chmod +x spark_expression_fuzzer_test 
             ./spark_expression_fuzzer_test \
                 --seed ${RANDOM} \
                 --enable_variadic_signatures \
@@ -188,6 +190,7 @@ jobs:
         run: |
           mkdir -p /tmp/spark_aggregate_fuzzer_repro/
           chmod -R 777 /tmp/spark_aggregate_fuzzer_repro
+          chmod +x spark_aggregation_fuzzer_test
           ./spark_aggregation_fuzzer_test \
                 --seed ${RANDOM} \
                 --duration_sec 1800 \
@@ -221,7 +224,8 @@ jobs:
           mkdir -p /tmp/aggregate_fuzzer_repro/
             rm -rfv /tmp/aggregate_fuzzer_repro/*
             chmod -R 777 /tmp/aggregate_fuzzer_repro
-            _build/debug/velox/exec/tests/velox_aggregation_fuzzer_test \
+            chmod +x velox_aggregation_fuzzer_test
+            ./velox_aggregation_fuzzer_test \
                 --seed ${RANDOM} \
                 --duration_sec 1800 \
                 --logtostderr=1 \
@@ -253,6 +257,7 @@ jobs:
           mkdir -p /tmp/join_fuzzer_repro/
           rm -rfv /tmp/join_fuzzer_repro/*
           chmod -R 777 /tmp/join_fuzzer_repro
+          chmod +x velox_join_fuzzer_test 
           ./velox_join_fuzzer_test \
                 --seed ${RANDOM} \
                 --duration_sec 1800 \

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -15,6 +15,10 @@
 name: "Scheduled Fuzzer Jobs"
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/scheduled.yml"
+
   schedule:
     - cron: '0 3 * * *'
 
@@ -39,6 +43,9 @@ jobs:
 
       - name: "Install dependencies"
         run: source ./scripts/setup-ubuntu.sh
+
+      - name: "Install mold as default linker"
+        uses: rui314/setup-mold@v1
 
       - name: "Build"
         run: |

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -55,8 +55,6 @@ jobs:
       CCACHE_BASEDIR: "${{ github.workspace }}"
       LINUX_DISTRO: "ubuntu"
     steps:
-      - name: "Install mold as default linker"
-        uses: rui314/setup-mold@v1
 
       - name: "Restore ccache"
         uses: actions/cache@v3

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -114,6 +114,11 @@ jobs:
     timeout-minutes: 120
     steps:
 
+      - name: "Checkout Repo"
+        uses: actions/checkout@v3
+        with:
+          ref: "${{ inputs.ref || 'main' }}"
+
       - name: "Install dependencies"
         run: source ./scripts/setup-ubuntu.sh
 
@@ -156,6 +161,11 @@ jobs:
     needs: compile
     timeout-minutes: 120
     steps:
+
+      - name: "Checkout Repo"
+        uses: actions/checkout@v3
+        with:
+          ref: "${{ inputs.ref || 'main' }}"
 
       - name: "Install dependencies"
         run: source ./scripts/setup-ubuntu.sh
@@ -220,6 +230,11 @@ jobs:
     timeout-minutes: 120
     steps:
 
+      - name: "Checkout Repo"
+        uses: actions/checkout@v3
+        with:
+          ref: "${{ inputs.ref || 'main' }}"
+
       - name: "Install dependencies"
         run: source ./scripts/setup-ubuntu.sh
 
@@ -255,6 +270,11 @@ jobs:
     needs: compile
     timeout-minutes: 120
     steps:
+
+      - name: "Checkout Repo"
+        uses: actions/checkout@v3
+        with:
+          ref: "${{ inputs.ref || 'main' }}"
 
       - name: "Install dependencies"
         run: source ./scripts/setup-ubuntu.sh

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -114,6 +114,9 @@ jobs:
     timeout-minutes: 120
     steps:
 
+      - name: "Install dependencies"
+        run: source ./scripts/setup-ubuntu.sh
+
       - name: Download presto fuzzer 
         uses: actions/download-artifact@v3
         with:
@@ -153,6 +156,9 @@ jobs:
     needs: compile
     timeout-minutes: 120
     steps:
+
+      - name: "Install dependencies"
+        run: source ./scripts/setup-ubuntu.sh
 
       - name: Download spark fuzzer 
         uses: actions/download-artifact@v3
@@ -214,6 +220,9 @@ jobs:
     timeout-minutes: 120
     steps:
 
+      - name: "Install dependencies"
+        run: source ./scripts/setup-ubuntu.sh
+
       - name: Download aggregation fuzzer 
         uses: actions/download-artifact@v3
         with:
@@ -246,6 +255,9 @@ jobs:
     needs: compile
     timeout-minutes: 120
     steps:
+
+      - name: "Install dependencies"
+        run: source ./scripts/setup-ubuntu.sh
 
       - name: Download join fuzzer 
         uses: actions/download-artifact@v3

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: "Build"
         run: |
-           make debug NUM_THREADS=8 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=2 EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON"
+          make debug NUM_THREADS=8 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=2 EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON"
           ccache -s
 
       - name: "Run Presto Fuzzer"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -71,14 +71,16 @@ jobs:
       - name: "Checkout Repo"
         uses: actions/checkout@v3
         with:
+          path: velox
           submodules: 'recursive'
           ref: "${{ inputs.ref || 'main' }}"
 
       - name: "Install dependencies"
-        run: source ./scripts/setup-ubuntu.sh
+        run: cd  velox && source ./scripts/setup-ubuntu.sh
 
       - name: "Build"
         run: |
+          cd velox
           make debug NUM_THREADS="${{ inputs.numThreads || 8 }}" MAX_HIGH_MEM_JOBS="${{ inputs.maxHighMemJobs || 8 }}" MAX_LINK_JOBS="${{ inputs.maxLinkJobs || 4 }}" EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON ${{ inputs.extraCMakeFlags }}"
           ccache -s
 
@@ -86,27 +88,27 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: presto
-          path: _build/debug/velox/expression/tests/velox_expression_fuzzer_test
+          path: velox/_build/debug/velox/expression/tests/velox_expression_fuzzer_test
             
       - name: Upload spark fuzzer 
         uses: actions/upload-artifact@v3
         with:
           name: spark
           path: |
-            _build/debug/velox/expression/tests/spark_expression_fuzzer_test
-            _build/debug/velox/expression/tests/spark_aggregation_fuzzer_test
+            velox/_build/debug/velox/expression/tests/spark_expression_fuzzer_test
+            velox/_build/debug/velox/expression/tests/spark_aggregation_fuzzer_test
 
       - name: Upload aggregation fuzzer 
         uses: actions/upload-artifact@v3
         with:
           name: aggregation
-          path: _build/debug/velox/exec/tests/velox_aggregation_fuzzer_test
+          path: velox/_build/debug/velox/exec/tests/velox_aggregation_fuzzer_test
 
       - name: Upload join fuzzer 
         uses: actions/upload-artifact@v3
         with:
           name: join
-          path: _build/debug/velox/exec/tests/velox_join_fuzzer_test      
+          path: velox/_build/debug/velox/exec/tests/velox_join_fuzzer_test      
 
   linux-presto-fuzzer-run:
     runs-on: 8-core

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: "Build"
         run: |
-          make debug NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=2 EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON"
+           make debug NUM_THREADS=8 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=2 EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON"
           ccache -s
 
       - name: "Run Presto Fuzzer"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -152,6 +152,7 @@ jobs:
 
 
   linux-aggregate-fuzzer-run:
+    if: false
     runs-on: 8-core
     timeout-minutes: 120
     env:
@@ -195,6 +196,7 @@ jobs:
             /tmp/aggregate_fuzzer_repro
 
   linux-join-fuzzer-run:
+    if: false
     runs-on: 8-core
     timeout-minutes: 120
     env:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -111,7 +111,7 @@ jobs:
           path: velox/_build/debug/velox/exec/tests/velox_join_fuzzer_test      
 
   linux-presto-fuzzer-run:
-    runs-on: 8-core
+    runs-on: ubuntu-latest 
     needs: compile
     timeout-minutes: 120
     steps:
@@ -159,7 +159,7 @@ jobs:
             /tmp/fuzzer_repro
 
   linux-spark-fuzzer-run:
-    runs-on: 8-core
+    runs-on: ubuntu-latest
     needs: compile
     timeout-minutes: 120
     steps:
@@ -227,7 +227,7 @@ jobs:
 
 
   linux-aggregate-fuzzer-run:
-    runs-on: 8-core
+    runs-on: ubuntu-latest
     needs: compile
     timeout-minutes: 120
     steps:
@@ -268,7 +268,7 @@ jobs:
             /tmp/aggregate_fuzzer_repro
 
   linux-join-fuzzer-run:
-    runs-on: 8-core
+    runs-on: ubuntu-latest 
     needs: compile
     timeout-minutes: 120
     steps:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -22,41 +22,108 @@ on:
   schedule:
     - cron: '0 3 * * *'
 
+  workflow_dispatch:
+    ref:
+      description: 'Ref to checkout out'
+      default: 'main'
+    numThreads:
+      description: 'Number of threads'
+      default: 16
+    maxHighMemJobs:
+      description: 'Number of high memory jobs'
+      default: 8
+    maxLinkJobs:
+      description: 'Maximum number of link jobs'
+      default: 4
+    extraCMakeFlags:
+      description: 'Additional CMake flags'
+      default: ''
+
 defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
-  linux-presto-fuzzer-run:
+  compile:
     runs-on: 8-core
-    timeout-minutes: 120
+    timeout: 120
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"
       CCACHE_BASEDIR: "${{ github.workspace }}"
       LINUX_DISTRO: "ubuntu"
     steps:
+      - name: "Install mold as default linker"
+        uses: rui314/setup-mold@v1
+
+      - name: "Restore ccache"
+        uses: actions/cache/restore@v3
+        id: restore-cache
+        with:
+          path: "${{ env.CCACHE_DIR }}"
+          # We are using the benchmark ccache as it has all 
+          # required features enabled, so no need to create a new one
+          key: ccache-benchmark-${{ github.sha }}
+          restore-keys: |
+            ccache-benchmark-
 
       - name: "Checkout Repo"
         uses: actions/checkout@v3
         with:
           submodules: 'recursive'
+          ref: "${{ inputs.ref || 'main' }}"
 
       - name: "Install dependencies"
         run: source ./scripts/setup-ubuntu.sh
 
-      - name: "Install mold as default linker"
-        uses: rui314/setup-mold@v1
-
       - name: "Build"
         run: |
-          make debug NUM_THREADS=8 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=2 EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON"
+          make debug NUM_THREADS="${{ inputs.numThreads || 8 }}" MAX_HIGH_MEM_JOBS="${{ inputs.maxHighMemJobs || 8 }}" MAX_LINK_JOBS="${{ inputs.maxLinkJobs || 4 }}" EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON ${{ inputs.extraCMakeFlags }}"
           ccache -s
 
+      - name: Upload presto fuzzer 
+        uses: actions/upload-artifact@v3
+        with:
+          name: presto
+          path: _build/debug/velox/expression/tests/velox_expression_fuzzer_test
+            
+      - name: Upload spark fuzzer 
+        uses: actions/upload-artifact@v3
+        with:
+          name: spark
+          path: |
+            _build/debug/velox/expression/tests/spark_expression_fuzzer_test
+            _build/debug/velox/expression/tests/spark_aggregation_fuzzer_test
+
+      - name: Upload aggregation fuzzer 
+        uses: actions/upload-artifact@v3
+        with:
+          name: aggregation
+          path: _build/debug/velox/exec/tests/velox_aggregation_fuzzer_test
+
+      - name: Upload join fuzzer 
+        uses: actions/upload-artifact@v3
+        with:
+          name: join
+          path: _build/debug/velox/exec/tests/velox_join_fuzzer_test      
+
+  linux-presto-fuzzer-run:
+    runs-on: 8-core
+    timeout-minutes: 120
+    steps:
+
+      - name: Download presto fuzzer 
+        uses: actions/download-artifact@v3
+        with:
+          name: presto
+          
       - name: "Run Presto Fuzzer"
         run: |
           mkdir -p /tmp/fuzzer_repro/
           chmod -R 777 /tmp/fuzzer_repro
-          _build/debug/velox/expression/tests/velox_expression_fuzzer_test \
+          ./velox_expression_fuzzer_test \
                 --seed ${RANDOM} \
                 --enable_variadic_signatures \
                 --velox_fuzzer_enable_complex_types \
@@ -80,35 +147,21 @@ jobs:
           path: |
             /tmp/fuzzer_repro
 
-
-
   linux-spark-fuzzer-run:
     runs-on: 8-core
     timeout-minutes: 120
-    env:
-      CCACHE_DIR: "${{ github.workspace }}/.ccache/"
-      CCACHE_BASEDIR: "${{ github.workspace }}"
-      LINUX_DISTRO: "ubuntu"
     steps:
 
-      - name: "Checkout Repo"
-        uses: actions/checkout@v3
+      - name: Download spark fuzzer 
+        uses: actions/download-artifact@v3
         with:
-          submodules: 'recursive'
-
-      - name: "Install dependencies"
-        run: source ./scripts/setup-ubuntu.sh
-
-      - name: "Build"
-        run: |
-          make debug NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=4 EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON"
-          ccache -s
+          name: spark
 
       - name: "Run Spark Fuzzer"
         run: |
           mkdir -p /tmp/spark_fuzzer_repro/
             chmod -R 777 /tmp/spark_fuzzer_repro
-            _build/debug/velox/expression/tests/spark_expression_fuzzer_test \
+            ./spark_expression_fuzzer_test \
                 --seed ${RANDOM} \
                 --enable_variadic_signatures \
                 --lazy_vector_generation_ratio 0.2 \
@@ -134,7 +187,7 @@ jobs:
         run: |
           mkdir -p /tmp/spark_aggregate_fuzzer_repro/
           chmod -R 777 /tmp/spark_aggregate_fuzzer_repro
-          _build/debug/velox/exec/tests/spark_aggregation_fuzzer_test \
+          ./spark_aggregation_fuzzer_test \
                 --seed ${RANDOM} \
                 --duration_sec 1800 \
                 --logtostderr=1 \
@@ -152,27 +205,14 @@ jobs:
 
 
   linux-aggregate-fuzzer-run:
-    if: false
     runs-on: 8-core
     timeout-minutes: 120
-    env:
-      CCACHE_DIR: "${{ github.workspace }}/.ccache/"
-      CCACHE_BASEDIR: "${{ github.workspace }}"
-      LINUX_DISTRO: "ubuntu"
     steps:
 
-      - name: "Checkout Repo"
-        uses: actions/checkout@v3
+      - name: Download aggregation fuzzer 
+        uses: actions/download-artifact@v3
         with:
-          submodules: 'recursive'
-
-      - name: "Install dependencies"
-        run: source ./scripts/setup-ubuntu.sh
-
-      - name: "Build"
-        run: |
-          make debug NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=4 EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON"
-          ccache -s
+          name: aggregation
 
       - name: "Run Aggregate Fuzzer"
         run: |
@@ -196,34 +236,21 @@ jobs:
             /tmp/aggregate_fuzzer_repro
 
   linux-join-fuzzer-run:
-    if: false
     runs-on: 8-core
     timeout-minutes: 120
-    env:
-      CCACHE_DIR: "${{ github.workspace }}/.ccache/"
-      CCACHE_BASEDIR: "${{ github.workspace }}"
-      LINUX_DISTRO: "ubuntu"
     steps:
 
-      - name: "Checkout Repo"
-        uses: actions/checkout@v3
+      - name: Download join fuzzer 
+        uses: actions/download-artifact@v3
         with:
-          submodules: 'recursive'
-
-      - name: "Install dependencies"
-        run: source ./scripts/setup-ubuntu.sh
-
-      - name: "Build"
-        run: |
-          make debug NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=4 EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON"
-          ccache -s
+          name: join
 
       - name: "Run Aggregate Fuzzer"
         run: |
           mkdir -p /tmp/join_fuzzer_repro/
           rm -rfv /tmp/join_fuzzer_repro/*
           chmod -R 777 /tmp/join_fuzzer_repro
-          _build/debug/velox/exec/tests/velox_join_fuzzer_test \
+          ./velox_join_fuzzer_test \
                 --seed ${RANDOM} \
                 --duration_sec 1800 \
                 --logtostderr=1 \

--- a/Makefile
+++ b/Makefile
@@ -63,12 +63,6 @@ GENERATOR += -DVELOX_FORCE_COLORED_OUTPUT=ON
 endif
 endif
 
-ifndef USE_CCACHE
-ifneq ($(shell which ccache), )
-USE_CCACHE=-DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-endif
-endif
-
 NUM_THREADS ?= $(shell getconf _NPROCESSORS_CONF 2>/dev/null || echo 1)
 CPU_TARGET ?= "avx"
 
@@ -88,7 +82,6 @@ cmake:					#: Use CMake to create a Makefile build system
 		"$(BUILD_BASE_DIR)/$(BUILD_DIR)" \
 		${CMAKE_FLAGS} \
 		$(GENERATOR) \
-		$(USE_CCACHE) \
 		${EXTRA_CMAKE_FLAGS}
 
 cmake-gpu:


### PR DESCRIPTION
This PR tackles several issues with the scheduled fuzzer workflow:
- workaround compilation being OOMkilled by using only 8 threads and using `mold` as a linker
  - this is a stopgap measure only, we should really look at our build times/footprint and see how we can optimize that as a 45 minute build on an 8 core machine is pretty massive. 
- only compile once (saves ~ 1.5h of CI time)
- use actions/cache to save the ccache to further improve build times
- add `workflow_dispatch` trigger to enable ad hoc runs of the fuzzer jobs
- add `pull_request` trigger to enable testing of the workflow in PRs (like this one ^^)
  - we could easily move the remaining CCI fuzzer job over to this workflow as well 

Reverts #7811 to use 8-core machines again. Supersedes #7810  