### PR TITLE
Remove extra semi colon from velox/type/Tree.h

### DIFF
--- a/velox/type/Tree.h
+++ b/velox/type/Tree.h
@@ -88,11 +88,11 @@ class Tree {
 
   const_iterator begin() const {
     return cbegin();
-  };
+  }
 
   const_iterator end() const {
     return cend();
-  };
+  }
 
   const_iterator cbegin() const {
     return const_iterator{*this, 0};


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: dmm-fb

Differential Revision: D51777916


