### PR TITLE
Remove extra semi colon from velox/type/Timestamp.h

### DIFF
--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -318,7 +318,7 @@ struct Timestamp {
   // Needed for serialization of FlatVector<Timestamp>
   operator StringView() const {
     return StringView("TODO: Implement");
-  };
+  }
 
   std::string toString(const TimestampToStringOptions& options = {}) const {
     std::tm tm;


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: dmm-fb

Differential Revision: D51777965


