### PR TITLE
Remove extra semi colon from velox/buffer/Buffer.h

### DIFF
--- a/velox/buffer/Buffer.h
+++ b/velox/buffer/Buffer.h
@@ -58,7 +58,7 @@ class Buffer {
   static inline constexpr bool is_pod_like_v =
       std::is_trivially_destructible_v<T>&& std::is_trivially_copyable_v<T>;
 
-  virtual ~Buffer(){};
+  virtual ~Buffer() {}
 
   void addRef() {
     referenceCount_.fetch_add(1);


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: dmm-fb

Differential Revision: D51777980


