### PR TITLE
Remove the spilling after memory reservation fails

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -900,8 +900,10 @@ void GroupingSet::ensureInputFits(const RowVectorPtr& input) {
       return;
     }
   }
-
-  spill();
+  LOG(WARNING) << "Failed to reserve " << succinctBytes(targetIncrementBytes)
+               << " for memory pool " << pool_.name()
+               << ", usage: " << succinctBytes(pool_.currentBytes())
+               << ", reservation: " << succinctBytes(pool_.reservedBytes());
 }
 
 void GroupingSet::ensureOutputFits() {

--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -236,7 +236,10 @@ void RowNumber::ensureInputFits(const RowVectorPtr& input) {
     }
   }
 
-  spill();
+  LOG(WARNING) << "Failed to reserve " << succinctBytes(targetIncrementBytes)
+               << " for memory pool " << pool()->name()
+               << ", usage: " << succinctBytes(pool()->currentBytes())
+               << ", reservation: " << succinctBytes(pool()->reservedBytes());
 }
 
 FlatVector<int64_t>& RowNumber::getOrCreateRowNumberVector(vector_size_t size) {

--- a/velox/exec/SortBuffer.cpp
+++ b/velox/exec/SortBuffer.cpp
@@ -258,8 +258,10 @@ void SortBuffer::ensureInputFits(const VectorPtr& input) {
       return;
     }
   }
-
-  spill();
+  LOG(WARNING) << "Failed to reserve " << succinctBytes(targetIncrementBytes)
+               << " for memory pool " << pool()->name()
+               << ", usage: " << succinctBytes(pool()->currentBytes())
+               << ", reservation: " << succinctBytes(pool()->reservedBytes());
 }
 
 void SortBuffer::updateEstimatedOutputRowSize() {

--- a/velox/exec/SortWindowBuild.cpp
+++ b/velox/exec/SortWindowBuild.cpp
@@ -128,7 +128,11 @@ void SortWindowBuild::ensureInputFits(const RowVectorPtr& input) {
     }
   }
 
-  spill();
+  LOG(WARNING) << "Failed to reserve " << succinctBytes(targetIncrementBytes)
+               << " for memory pool " << data_->pool()->name()
+               << ", usage: " << succinctBytes(data_->pool()->currentBytes())
+               << ", reservation: "
+               << succinctBytes(data_->pool()->reservedBytes());
 }
 
 void SortWindowBuild::setupSpiller() {

--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -713,7 +713,10 @@ void TopNRowNumber::ensureInputFits(const RowVectorPtr& input) {
     }
   }
 
-  spill();
+  LOG(WARNING) << "Failed to reserve " << succinctBytes(targetIncrementBytes)
+               << " for memory pool " << pool()->name()
+               << ", usage: " << succinctBytes(pool()->currentBytes())
+               << ", reservation: " << succinctBytes(pool()->reservedBytes());
 }
 
 void TopNRowNumber::spill() {

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -363,7 +363,10 @@ TEST_F(SortBufferTest, spill) {
     }
   } testSettings[] = {
       {false, true, 0, false}, // spilling is not enabled.
-      {true, true, 0, true}, // memory reservation failure triggers spilling.
+      {true,
+       true,
+       0,
+       false}, // memory reservation failure won't trigger spilling.
       {true, false, 1000, true}, // threshold is small, spilling is triggered.
       {true, false, 1000000, false} // threshold is too large, not triggered
   };
@@ -414,7 +417,7 @@ TEST_F(SortBufferTest, spill) {
       totalNumInput += 1024;
     }
     sortBuffer->noMoreInput();
-    auto spillStats = sortBuffer->spilledStats();
+    const auto spillStats = sortBuffer->spilledStats();
 
     if (!testData.spillTriggered) {
       ASSERT_FALSE(spillStats.has_value());


### PR DESCRIPTION
With memory arbitration enabled, we shall never need to spill after the memory
reservation fails. The memory arbitrator shall always trigger spilling if memory
reservation needs to grow the pool's capacity. Remove the unnecessary spilling
to keep the implementation simple.