### PR TITLE
Remove BaseVector::clearIndices API

### DIFF
--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -635,28 +635,19 @@ class BaseVector {
     setNulls(nullptr);
   }
 
-  void
-  clearIndices(BufferPtr& indices, vector_size_t start, vector_size_t end) {
-    if (start == end) {
-      return;
-    }
-    auto* data = indices->asMutable<vector_size_t>();
-    std::fill(data + start, data + end, 0);
-  }
-
-  /// Ensures that '*indices' is singly-referenced and has space for 'size'
-  /// elements. Sets elements between the old and new sizes to 0 if
-  /// the new size > old size.
+  /// Ensures that 'indices' is singly-referenced and has space for 'newSize'
+  /// elements. Sets elements between the 'currentSize' and 'newSize' to 0 if
+  /// 'newSize' > 'currentSize'.
   ///
-  /// If '*indices' is nullptr, read-only, not uniquely-referenced, or doesn't
-  /// have capacity for 'size' elements allocates new buffer and copies data to
-  /// it. Updates '*raw' to point to element 0 of
-  /// (*indices)->as<vector_size_t>().
+  /// If 'indices' is nullptr, read-only, not uniquely-referenced, or doesn't
+  /// have capacity for 'newSize' elements allocates new buffer and copies data
+  /// to it. Updates '*rawIndices' to point to the start of 'indices' buffer.
   static void resizeIndices(
-      vector_size_t size,
+      vector_size_t currentSize,
+      vector_size_t newSize,
       velox::memory::MemoryPool* pool,
-      BufferPtr* indices,
-      const vector_size_t** raw);
+      BufferPtr& indices,
+      const vector_size_t** rawIndices);
 
   // Makes sure '*buffer' has space for 'size' items of T and is writable. Sets
   // 'raw' to point to the writable contents of '*buffer'.

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -299,21 +299,19 @@ struct ArrayVectorBase : BaseVector {
   }
 
   BufferPtr mutableOffsets(size_t size) {
-    BaseVector::resizeIndices(size, pool_, &offsets_, &rawOffsets_);
+    BaseVector::resizeIndices(length_, size, pool_, offsets_, &rawOffsets_);
     return offsets_;
   }
 
   BufferPtr mutableSizes(size_t size) {
-    BaseVector::resizeIndices(size, pool_, &sizes_, &rawSizes_);
+    BaseVector::resizeIndices(length_, size, pool_, sizes_, &rawSizes_);
     return sizes_;
   }
 
   void resize(vector_size_t size, bool setNotNull = true) override {
     if (BaseVector::length_ < size) {
-      BaseVector::resizeIndices(size, pool_, &offsets_, &rawOffsets_);
-      BaseVector::resizeIndices(size, pool_, &sizes_, &rawSizes_);
-      clearIndices(sizes_, length_, size);
-      // No need to clear offset indices since we set sizes to 0.
+      BaseVector::resizeIndices(length_, size, pool_, offsets_, &rawOffsets_);
+      BaseVector::resizeIndices(length_, size, pool_, sizes_, &rawSizes_);
     }
     BaseVector::resize(size, setNotNull);
   }

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -130,7 +130,8 @@ class DictionaryVector : public SimpleVector<T> {
   }
 
   BufferPtr mutableIndices(vector_size_t size) {
-    BaseVector::resizeIndices(size, BaseVector::pool_, &indices_, &rawIndices_);
+    BaseVector::resizeIndices(
+        BaseVector::length_, size, BaseVector::pool_, indices_, &rawIndices_);
     return indices_;
   }
 
@@ -198,9 +199,15 @@ class DictionaryVector : public SimpleVector<T> {
   void resize(vector_size_t size, bool setNotNull = true) override {
     if (size > BaseVector::length_) {
       BaseVector::resizeIndices(
-          size, BaseVector::pool(), &indices_, &rawIndices_);
-      this->clearIndices(indices_, BaseVector::length_, size);
+          BaseVector::length_,
+          size,
+          BaseVector::pool(),
+          indices_,
+          &rawIndices_);
     }
+
+    // TODO Fix the case when base vector is empty.
+    // https://github.com/facebookincubator/velox/issues/7828
 
     BaseVector::resize(size, setNotNull);
   }


### PR DESCRIPTION
Summary:
clearIndices API was always used together with resizeIndices API.

Fold the logic of clearIndices into resizeIndices to reduce API surface.

Part of #7828

Differential Revision: D51810625


