### PR TITLE
Extract toAggregateInfo(AggregationNode) helper function

### DIFF
--- a/velox/exec/AggregateUtil.cpp
+++ b/velox/exec/AggregateUtil.cpp
@@ -35,7 +35,7 @@ std::vector<core::LambdaTypedExprPtr> extractLambdaInputs(
 }
 } // namespace
 
-std::vector<AggregateInfo> AggregateUtil::toAggregateInfo(
+std::vector<AggregateInfo> toAggregateInfo(
     const core::AggregationNode& aggregationNode,
     const OperatorCtx& operatorCtx,
     uint32_t numKeys,

--- a/velox/exec/AggregateUtil.cpp
+++ b/velox/exec/AggregateUtil.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/AggregateUtil.h"
+#include "velox/exec/Aggregate.h"
+
+namespace facebook::velox::exec {
+
+void AggregateUtil::populateAggregateMask(
+    const core::AggregationNode::Aggregate& aggregate,
+    const RowTypePtr& inputType,
+    AggregateInfo& info) {
+  if (const auto& mask = aggregate.mask) {
+    info.mask = inputType->asRow().getChildIdx(mask->name());
+  } else {
+    info.mask = std::nullopt;
+  }
+}
+
+void AggregateUtil::populateAggregateKeysOrders(
+    const core::AggregationNode::Aggregate& aggregate,
+    const RowTypePtr& inputType,
+    AggregateInfo& info) {
+  const auto numSortingKeys = aggregate.sortingKeys.size();
+  VELOX_CHECK_EQ(numSortingKeys, aggregate.sortingOrders.size());
+  info.sortingOrders = aggregate.sortingOrders;
+
+  info.sortingKeys.reserve(numSortingKeys);
+  for (const auto& key : aggregate.sortingKeys) {
+    info.sortingKeys.push_back(exprToChannel(key.get(), inputType));
+  }
+}
+
+void AggregateUtil::populateAggregateFunction(
+    const core::AggregationNode::Aggregate& aggregate,
+    const RowTypePtr& outputType,
+    core::AggregationNode::Step step,
+    AggregateInfo& info,
+    const std::unique_ptr<OperatorCtx>& operatorCtx,
+    uint32_t index) {
+  const auto& aggResultType = outputType->childAt(index);
+  info.function = Aggregate::create(
+      aggregate.call->name(),
+      isPartialOutput(step) ? core::AggregationNode::Step::kPartial
+                            : core::AggregationNode::Step::kSingle,
+      aggregate.rawInputTypes,
+      aggResultType,
+      operatorCtx->driverCtx()->queryConfig());
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/AggregateUtil.cpp
+++ b/velox/exec/AggregateUtil.cpp
@@ -35,102 +35,111 @@ std::vector<core::LambdaTypedExprPtr> extractLambdaInputs(
 }
 } // namespace
 
-AggregateInfo AggregateUtil::toAggregateInfo(
-    const core::AggregationNode::Aggregate& aggregate,
+std::vector<AggregateInfo> AggregateUtil::toAggregateInfo(
+    const core::AggregationNode& aggregationNode,
     const RowTypePtr& inputType,
     const RowTypePtr& outputType,
     core::AggregationNode::Step step,
     const OperatorCtx& operatorCtx,
-    uint32_t index,
+    uint32_t numKeys,
     std::shared_ptr<core::ExpressionEvaluator>& expressionEvaluator,
     bool isStreaming) {
-  // TODO: Add support for StreamingAggregation
-  if (isStreaming && !aggregate.sortingKeys.empty()) {
-    VELOX_UNSUPPORTED(
-        "Streaming aggregation doesn't support aggregations over sorted inputs yet");
-  }
-  if (isStreaming && aggregate.distinct) {
-    VELOX_UNSUPPORTED(
-        "Streaming aggregation doesn't support aggregations over distinct inputs yet");
-  }
+  const auto numAggregates = aggregationNode.aggregates().size();
+  std::vector<AggregateInfo> aggregates;
+  aggregates.reserve(numAggregates);
 
-  AggregateInfo info;
-  // Populate input.
-  auto& channels = info.inputs;
-  auto& constants = info.constantInputs;
-  for (const auto& arg : aggregate.call->inputs()) {
-    if (auto field =
-            dynamic_cast<const core::FieldAccessTypedExpr*>(arg.get())) {
-      channels.push_back(inputType->getChildIdx(field->name()));
-      constants.push_back(nullptr);
-    } else if (
-        auto constant =
-            dynamic_cast<const core::ConstantTypedExpr*>(arg.get())) {
-      channels.push_back(kConstantChannel);
-      constants.push_back(constant->toConstantVector(operatorCtx.pool()));
-    } else if (
-        auto lambda = dynamic_cast<const core::LambdaTypedExpr*>(arg.get())) {
-      VELOX_USER_CHECK(
-          !isStreaming,
-          "StreamingAggregation doesn't support lambda functions yet.");
-      for (const auto& name : lambda->signature()->names()) {
-        if (auto captureIndex = inputType->getChildIdxIfExists(name)) {
-          channels.push_back(captureIndex.value());
-          constants.push_back(nullptr);
+  for (auto i = 0; i < numAggregates; i++) {
+    const auto& aggregate = aggregationNode.aggregates()[i];
+
+    // TODO: Add support for StreamingAggregation
+    if (isStreaming && !aggregate.sortingKeys.empty()) {
+      VELOX_UNSUPPORTED(
+          "Streaming aggregation doesn't support aggregations over sorted inputs yet");
+    }
+    if (isStreaming && aggregate.distinct) {
+      VELOX_UNSUPPORTED(
+          "Streaming aggregation doesn't support aggregations over distinct inputs yet");
+    }
+
+    AggregateInfo info;
+    // Populate input.
+    auto& channels = info.inputs;
+    auto& constants = info.constantInputs;
+    for (const auto& arg : aggregate.call->inputs()) {
+      if (auto field =
+              dynamic_cast<const core::FieldAccessTypedExpr*>(arg.get())) {
+        channels.push_back(inputType->getChildIdx(field->name()));
+        constants.push_back(nullptr);
+      } else if (
+          auto constant =
+              dynamic_cast<const core::ConstantTypedExpr*>(arg.get())) {
+        channels.push_back(kConstantChannel);
+        constants.push_back(constant->toConstantVector(operatorCtx.pool()));
+      } else if (
+          auto lambda = dynamic_cast<const core::LambdaTypedExpr*>(arg.get())) {
+        VELOX_USER_CHECK(
+            !isStreaming,
+            "StreamingAggregation doesn't support lambda functions yet.");
+        for (const auto& name : lambda->signature()->names()) {
+          if (auto captureIndex = inputType->getChildIdxIfExists(name)) {
+            channels.push_back(captureIndex.value());
+            constants.push_back(nullptr);
+          }
         }
+      } else {
+        VELOX_FAIL(
+            "Expression must be field access, constant, or "
+            "lambda (HashAggregation): {}",
+            arg->toString());
       }
+    }
+
+    info.distinct = aggregate.distinct;
+    info.intermediateType = Aggregate::intermediateType(
+        aggregate.call->name(), aggregate.rawInputTypes);
+
+    // Setup aggregation mask: convert the Variable Reference name to the
+    // channel (projection) index, if there is a mask.
+    if (const auto& mask = aggregate.mask) {
+      info.mask = inputType->asRow().getChildIdx(mask->name());
     } else {
-      VELOX_FAIL(
-          "Expression must be field access, constant, or "
-          "lambda (HashAggregation): {}",
-          arg->toString());
+      info.mask = std::nullopt;
     }
-  }
 
-  info.distinct = aggregate.distinct;
-  info.intermediateType = Aggregate::intermediateType(
-      aggregate.call->name(), aggregate.rawInputTypes);
+    auto index = numKeys + i;
+    const auto& aggResultType = outputType->childAt(index);
+    info.function = Aggregate::create(
+        aggregate.call->name(),
+        isPartialOutput(step) ? core::AggregationNode::Step::kPartial
+                              : core::AggregationNode::Step::kSingle,
+        aggregate.rawInputTypes,
+        aggResultType,
+        operatorCtx.driverCtx()->queryConfig());
 
-  // Setup aggregation mask: convert the Variable Reference name to the
-  // channel (projection) index, if there is a mask.
-  if (const auto& mask = aggregate.mask) {
-    info.mask = inputType->asRow().getChildIdx(mask->name());
-  } else {
-    info.mask = std::nullopt;
-  }
-
-  const auto& aggResultType = outputType->childAt(index);
-  info.function = Aggregate::create(
-      aggregate.call->name(),
-      isPartialOutput(step) ? core::AggregationNode::Step::kPartial
-                            : core::AggregationNode::Step::kSingle,
-      aggregate.rawInputTypes,
-      aggResultType,
-      operatorCtx.driverCtx()->queryConfig());
-
-  if (!isStreaming) {
-    auto lambdas = extractLambdaInputs(aggregate);
-    if (!lambdas.empty()) {
-      if (expressionEvaluator == nullptr) {
-        expressionEvaluator = std::make_shared<SimpleExpressionEvaluator>(
-            operatorCtx.execCtx()->queryCtx(), operatorCtx.execCtx()->pool());
+    if (!isStreaming) {
+      auto lambdas = extractLambdaInputs(aggregate);
+      if (!lambdas.empty()) {
+        if (expressionEvaluator == nullptr) {
+          expressionEvaluator = std::make_shared<SimpleExpressionEvaluator>(
+              operatorCtx.execCtx()->queryCtx(), operatorCtx.execCtx()->pool());
+        }
+        info.function->setLambdaExpressions(lambdas, expressionEvaluator);
       }
-      info.function->setLambdaExpressions(lambdas, expressionEvaluator);
     }
+
+    // Sorting keys and orders.
+    const auto numSortingKeys = aggregate.sortingKeys.size();
+    VELOX_CHECK_EQ(numSortingKeys, aggregate.sortingOrders.size());
+    info.sortingOrders = aggregate.sortingOrders;
+    info.sortingKeys.reserve(numSortingKeys);
+    for (const auto& key : aggregate.sortingKeys) {
+      info.sortingKeys.push_back(exprToChannel(key.get(), inputType));
+    }
+
+    info.output = index;
+    aggregates.emplace_back(std::move(info));
   }
-
-  // Sorting keys and orders.
-  const auto numSortingKeys = aggregate.sortingKeys.size();
-  VELOX_CHECK_EQ(numSortingKeys, aggregate.sortingOrders.size());
-  info.sortingOrders = aggregate.sortingOrders;
-  info.sortingKeys.reserve(numSortingKeys);
-  for (const auto& key : aggregate.sortingKeys) {
-    info.sortingKeys.push_back(exprToChannel(key.get(), inputType));
-  }
-
-  info.output = index;
-
-  return info;
+  return aggregates;
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/AggregateUtil.cpp
+++ b/velox/exec/AggregateUtil.cpp
@@ -37,9 +37,6 @@ std::vector<core::LambdaTypedExprPtr> extractLambdaInputs(
 
 std::vector<AggregateInfo> AggregateUtil::toAggregateInfo(
     const core::AggregationNode& aggregationNode,
-    const RowTypePtr& inputType,
-    const RowTypePtr& outputType,
-    core::AggregationNode::Step step,
     const OperatorCtx& operatorCtx,
     uint32_t numKeys,
     std::shared_ptr<core::ExpressionEvaluator>& expressionEvaluator,
@@ -47,6 +44,10 @@ std::vector<AggregateInfo> AggregateUtil::toAggregateInfo(
   const auto numAggregates = aggregationNode.aggregates().size();
   std::vector<AggregateInfo> aggregates;
   aggregates.reserve(numAggregates);
+
+  const auto& inputType = aggregationNode.sources()[0]->outputType();
+  const auto& outputType = aggregationNode.outputType();
+  const auto step = aggregationNode.step();
 
   for (auto i = 0; i < numAggregates; i++) {
     const auto& aggregate = aggregationNode.aggregates()[i];

--- a/velox/exec/AggregateUtil.cpp
+++ b/velox/exec/AggregateUtil.cpp
@@ -16,41 +16,64 @@
 
 #include "velox/exec/AggregateUtil.h"
 #include "velox/exec/Aggregate.h"
+#include "velox/expression/Expr.h"
 
 namespace facebook::velox::exec {
 
-void AggregateUtil::populateAggregateMask(
+AggregateInfo AggregateUtil::toAggregateInfo(
     const core::AggregationNode::Aggregate& aggregate,
     const RowTypePtr& inputType,
-    AggregateInfo& info) {
+    const RowTypePtr& outputType,
+    core::AggregationNode::Step step,
+    const std::unique_ptr<OperatorCtx>& operatorCtx,
+    memory::MemoryPool* pool,
+    uint32_t index,
+    std::shared_ptr<core::ExpressionEvaluator>& expressionEvaluator,
+    bool supportLambda) {
+  AggregateInfo info;
+  // Populate input.
+  auto& channels = info.inputs;
+  auto& constants = info.constantInputs;
+  for (const auto& arg : aggregate.call->inputs()) {
+    if (auto field =
+            dynamic_cast<const core::FieldAccessTypedExpr*>(arg.get())) {
+      channels.push_back(inputType->getChildIdx(field->name()));
+      constants.push_back(nullptr);
+    } else if (
+        auto constant =
+            dynamic_cast<const core::ConstantTypedExpr*>(arg.get())) {
+      channels.push_back(kConstantChannel);
+      constants.push_back(constant->toConstantVector(pool));
+    } else if (
+        auto lambda = dynamic_cast<const core::LambdaTypedExpr*>(arg.get())) {
+      VELOX_USER_CHECK(
+          supportLambda,
+          "Streaming aggregation doesn't support lambda functions yet");
+      for (const auto& name : lambda->signature()->names()) {
+        if (auto captureIndex = inputType->getChildIdxIfExists(name)) {
+          channels.push_back(captureIndex.value());
+          constants.push_back(nullptr);
+        }
+      }
+    } else {
+      VELOX_FAIL(
+          "Expression must be field access, constant, or lambda: {}",
+          arg->toString());
+    }
+  }
+
+  info.distinct = aggregate.distinct;
+  info.intermediateType = Aggregate::intermediateType(
+      aggregate.call->name(), aggregate.rawInputTypes);
+
+  // Setup aggregation mask: convert the Variable Reference name to the
+  // channel (projection) index, if there is a mask.
   if (const auto& mask = aggregate.mask) {
     info.mask = inputType->asRow().getChildIdx(mask->name());
   } else {
     info.mask = std::nullopt;
   }
-}
 
-void AggregateUtil::populateAggregateKeysOrders(
-    const core::AggregationNode::Aggregate& aggregate,
-    const RowTypePtr& inputType,
-    AggregateInfo& info) {
-  const auto numSortingKeys = aggregate.sortingKeys.size();
-  VELOX_CHECK_EQ(numSortingKeys, aggregate.sortingOrders.size());
-  info.sortingOrders = aggregate.sortingOrders;
-
-  info.sortingKeys.reserve(numSortingKeys);
-  for (const auto& key : aggregate.sortingKeys) {
-    info.sortingKeys.push_back(exprToChannel(key.get(), inputType));
-  }
-}
-
-void AggregateUtil::populateAggregateFunction(
-    const core::AggregationNode::Aggregate& aggregate,
-    const RowTypePtr& outputType,
-    core::AggregationNode::Step step,
-    AggregateInfo& info,
-    const std::unique_ptr<OperatorCtx>& operatorCtx,
-    uint32_t index) {
   const auto& aggResultType = outputType->childAt(index);
   info.function = Aggregate::create(
       aggregate.call->name(),
@@ -59,6 +82,43 @@ void AggregateUtil::populateAggregateFunction(
       aggregate.rawInputTypes,
       aggResultType,
       operatorCtx->driverCtx()->queryConfig());
+
+  if (supportLambda) {
+    auto lambdas = extractLambdaInputs(aggregate);
+    if (!lambdas.empty()) {
+      if (expressionEvaluator == nullptr) {
+        expressionEvaluator = std::make_shared<SimpleExpressionEvaluator>(
+            operatorCtx->execCtx()->queryCtx(), operatorCtx->execCtx()->pool());
+      }
+      info.function->setLambdaExpressions(lambdas, expressionEvaluator);
+    }
+  }
+
+  // Sorting keys and orders.
+  const auto numSortingKeys = aggregate.sortingKeys.size();
+  VELOX_CHECK_EQ(numSortingKeys, aggregate.sortingOrders.size());
+  info.sortingOrders = aggregate.sortingOrders;
+  info.sortingKeys.reserve(numSortingKeys);
+  for (const auto& key : aggregate.sortingKeys) {
+    info.sortingKeys.push_back(exprToChannel(key.get(), inputType));
+  }
+
+  info.output = index;
+
+  return info;
+}
+
+std::vector<core::LambdaTypedExprPtr> AggregateUtil::extractLambdaInputs(
+    const core::AggregationNode::Aggregate& aggregate) {
+  std::vector<core::LambdaTypedExprPtr> lambdas;
+  for (const auto& arg : aggregate.call->inputs()) {
+    if (auto lambda =
+            std::dynamic_pointer_cast<const core::LambdaTypedExpr>(arg)) {
+      lambdas.push_back(lambda);
+    }
+  }
+
+  return lambdas;
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/AggregateUtil.h
+++ b/velox/exec/AggregateUtil.h
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
+
+#include "velox/exec/AggregateInfo.h"
+#include "velox/exec/Operator.h"
 
 namespace facebook::velox::exec {
 
@@ -32,6 +36,30 @@ struct AggregateRegistrationResult {
         extractFunction == other.extractFunction &&
         mergeExtractFunction == other.mergeExtractFunction;
   }
+};
+
+class AggregateUtil {
+ public:
+  /// Setup aggregation mask: convert the Variable Reference name to the
+  /// channel (projection) index, if there is a mask.
+  static void populateAggregateMask(
+      const core::AggregationNode::Aggregate& aggregate,
+      const RowTypePtr& inputType,
+      AggregateInfo& info);
+
+  /// Sorting keys and orders.
+  static void populateAggregateKeysOrders(
+      const core::AggregationNode::Aggregate& aggregate,
+      const RowTypePtr& inputType,
+      AggregateInfo& info);
+
+  static void populateAggregateFunction(
+      const core::AggregationNode::Aggregate& aggregate,
+      const RowTypePtr& outputType,
+      core::AggregationNode::Step step,
+      AggregateInfo& info,
+      const std::unique_ptr<OperatorCtx>& operatorCtx,
+      uint32_t index);
 };
 
 } // namespace facebook::velox::exec

--- a/velox/exec/AggregateUtil.h
+++ b/velox/exec/AggregateUtil.h
@@ -38,29 +38,25 @@ struct AggregateRegistrationResult {
   }
 };
 
-class AggregateUtil {
- public:
-  /// Translate an AggregationNode to a list of AggregationInfo, which could be
-  /// a hash aggregation plan node or a streaming aggregation plan node.
-  ///
-  /// @param aggregationNode Plan node of this aggregation.
-  /// @param operatorCtx Operator context.
-  /// @param numKeys Number of grouping keys.
-  /// @param expressionEvaluator An Expression evaluator. It is used by an
-  /// aggregate operator to compile and eval lambda expression. It should be
-  /// initiated/assigned for at most one time.
-  /// @param isStreaming Indicate whether this aggregation is streaming or not.
-  /// Pass true if the aggregate operator is a StreamingAggregation and false if
-  /// the aggregate operator is a HashAggregation. This parameter will be
-  /// removed after sorted, distinct aggregation, and lambda functions support
-  /// are added to StreamingAggregation.
-  /// @return List of AggregationInfo.
-  static std::vector<AggregateInfo> toAggregateInfo(
-      const core::AggregationNode& aggregationNode,
-      const OperatorCtx& operatorCtx,
-      uint32_t numKeys,
-      std::shared_ptr<core::ExpressionEvaluator>& expressionEvaluator,
-      bool isStreaming = false);
-};
-
+/// Translate an AggregationNode to a list of AggregationInfo, which could be
+/// a hash aggregation plan node or a streaming aggregation plan node.
+///
+/// @param aggregationNode Plan node of this aggregation.
+/// @param operatorCtx Operator context.
+/// @param numKeys Number of grouping keys.
+/// @param expressionEvaluator An Expression evaluator. It is used by an
+/// aggregate operator to compile and eval lambda expression. It should be
+/// initiated/assigned for at most one time.
+/// @param isStreaming Indicate whether this aggregation is streaming or not.
+/// Pass true if the aggregate operator is a StreamingAggregation and false if
+/// the aggregate operator is a HashAggregation. This parameter will be
+/// removed after sorted, distinct aggregation, and lambda functions support
+/// are added to StreamingAggregation.
+/// @return List of AggregationInfo.
+std::vector<AggregateInfo> toAggregateInfo(
+    const core::AggregationNode& aggregationNode,
+    const OperatorCtx& operatorCtx,
+    uint32_t numKeys,
+    std::shared_ptr<core::ExpressionEvaluator>& expressionEvaluator,
+    bool isStreaming = false);
 } // namespace facebook::velox::exec

--- a/velox/exec/AggregateUtil.h
+++ b/velox/exec/AggregateUtil.h
@@ -45,14 +45,10 @@ class AggregateUtil {
       const RowTypePtr& inputType,
       const RowTypePtr& outputType,
       core::AggregationNode::Step step,
-      const std::unique_ptr<OperatorCtx>& operatorCtx,
-      memory::MemoryPool* pool,
+      const OperatorCtx& operatorCtx,
       uint32_t index,
       std::shared_ptr<core::ExpressionEvaluator>& expressionEvaluator,
-      bool supportLambda = true);
-
-  static std::vector<core::LambdaTypedExprPtr> extractLambdaInputs(
-      const core::AggregationNode::Aggregate& aggregate);
+      bool isStreaming = false);
 };
 
 } // namespace facebook::velox::exec

--- a/velox/exec/AggregateUtil.h
+++ b/velox/exec/AggregateUtil.h
@@ -40,26 +40,19 @@ struct AggregateRegistrationResult {
 
 class AggregateUtil {
  public:
-  /// Setup aggregation mask: convert the Variable Reference name to the
-  /// channel (projection) index, if there is a mask.
-  static void populateAggregateMask(
+  static AggregateInfo toAggregateInfo(
       const core::AggregationNode::Aggregate& aggregate,
       const RowTypePtr& inputType,
-      AggregateInfo& info);
-
-  /// Sorting keys and orders.
-  static void populateAggregateKeysOrders(
-      const core::AggregationNode::Aggregate& aggregate,
-      const RowTypePtr& inputType,
-      AggregateInfo& info);
-
-  static void populateAggregateFunction(
-      const core::AggregationNode::Aggregate& aggregate,
       const RowTypePtr& outputType,
       core::AggregationNode::Step step,
-      AggregateInfo& info,
       const std::unique_ptr<OperatorCtx>& operatorCtx,
-      uint32_t index);
+      memory::MemoryPool* pool,
+      uint32_t index,
+      std::shared_ptr<core::ExpressionEvaluator>& expressionEvaluator,
+      bool supportLambda = true);
+
+  static std::vector<core::LambdaTypedExprPtr> extractLambdaInputs(
+      const core::AggregationNode::Aggregate& aggregate);
 };
 
 } // namespace facebook::velox::exec

--- a/velox/exec/AggregateUtil.h
+++ b/velox/exec/AggregateUtil.h
@@ -44,19 +44,19 @@ class AggregateUtil {
   /// a hash aggregation plan node or a streaming aggregation plan node.
   ///
   /// @param aggregationNode Plan node of this aggregation.
-  /// @param inputType Input type of the aggregationNode.
-  /// @param outputType Output type of the aggregationNode.
-  /// @param step Aggregation step of the aggregationNode.
   /// @param operatorCtx Operator context.
-  /// @param numKeys Number of group keys.
-  /// @param expressionEvaluator Expression evaluation.
-  /// @param isStreaming Indicate this aggregation if streaming or not.
+  /// @param numKeys Number of grouping keys.
+  /// @param expressionEvaluator An Expression evaluator. It is used by an
+  /// aggregate operator to compile and eval lambda expression. It should be
+  /// initiated/assigned for at most one time.
+  /// @param isStreaming Indicate whether this aggregation is streaming or not.
+  /// Pass true if the aggregate operator is a StreamingAggregation and false if
+  /// the aggregate operator is a HashAggregation. This parameter will be
+  /// removed after sorted, distinct aggregation, and lambda functions support
+  /// are added to StreamingAggregation.
   /// @return List of AggregationInfo.
   static std::vector<AggregateInfo> toAggregateInfo(
       const core::AggregationNode& aggregationNode,
-      const RowTypePtr& inputType,
-      const RowTypePtr& outputType,
-      core::AggregationNode::Step step,
       const OperatorCtx& operatorCtx,
       uint32_t numKeys,
       std::shared_ptr<core::ExpressionEvaluator>& expressionEvaluator,

--- a/velox/exec/AggregateUtil.h
+++ b/velox/exec/AggregateUtil.h
@@ -40,13 +40,25 @@ struct AggregateRegistrationResult {
 
 class AggregateUtil {
  public:
-  static AggregateInfo toAggregateInfo(
-      const core::AggregationNode::Aggregate& aggregate,
+  /// Translate an AggregationNode to a list of AggregationInfo, which could be
+  /// a hash aggregation plan node or a streaming aggregation plan node.
+  ///
+  /// @param aggregationNode Plan node of this aggregation.
+  /// @param inputType Input type of the aggregationNode.
+  /// @param outputType Output type of the aggregationNode.
+  /// @param step Aggregation step of the aggregationNode.
+  /// @param operatorCtx Operator context.
+  /// @param numKeys Number of group keys.
+  /// @param expressionEvaluator Expression evaluation.
+  /// @param isStreaming Indicate this aggregation if streaming or not.
+  /// @return List of AggregationInfo.
+  static std::vector<AggregateInfo> toAggregateInfo(
+      const core::AggregationNode& aggregationNode,
       const RowTypePtr& inputType,
       const RowTypePtr& outputType,
       core::AggregationNode::Step step,
       const OperatorCtx& operatorCtx,
-      uint32_t index,
+      uint32_t numKeys,
       std::shared_ptr<core::ExpressionEvaluator>& expressionEvaluator,
       bool isStreaming = false);
 };

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(
   AggregateCompanionAdapter.cpp
   AggregateCompanionSignatures.cpp
   AggregateFunctionRegistry.cpp
+  AggregateUtil.cpp
   AggregationMasks.cpp
   AggregateWindow.cpp
   ArrowStream.cpp

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -66,7 +66,7 @@ void HashAggregation::initialize() {
   }
 
   std::shared_ptr<core::ExpressionEvaluator> expressionEvaluator;
-  std::vector<AggregateInfo> aggregateInfos = AggregateUtil::toAggregateInfo(
+  std::vector<AggregateInfo> aggregateInfos = toAggregateInfo(
       *aggregationNode_, *operatorCtx_, numHashers, expressionEvaluator);
 
   // Check that aggregate result type match the output type.

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -78,8 +78,7 @@ void HashAggregation::initialize() {
         inputType,
         outputType_,
         aggregationNode_->step(),
-        operatorCtx_,
-        pool(),
+        *operatorCtx_,
         numHashers + i,
         expressionEvaluator);
     aggregateInfos.emplace_back(std::move(info));

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -54,7 +54,6 @@ void HashAggregation::initialize() {
   VELOX_CHECK(pool()->trackUsage());
 
   auto inputType = aggregationNode_->sources()[0]->outputType();
-
   auto hashers =
       createVectorHashers(inputType, aggregationNode_->groupingKeys());
   auto numHashers = hashers.size();
@@ -68,13 +67,7 @@ void HashAggregation::initialize() {
 
   std::shared_ptr<core::ExpressionEvaluator> expressionEvaluator;
   std::vector<AggregateInfo> aggregateInfos = AggregateUtil::toAggregateInfo(
-      *aggregationNode_,
-      inputType,
-      outputType_,
-      aggregationNode_->step(),
-      *operatorCtx_,
-      numHashers,
-      expressionEvaluator);
+      *aggregationNode_, *operatorCtx_, numHashers, expressionEvaluator);
 
   // Check that aggregate result type match the output type.
   for (auto i = 0; i < aggregateInfos.size(); i++) {

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -66,23 +66,15 @@ void HashAggregation::initialize() {
     preGroupedChannels.push_back(channel);
   }
 
-  const auto numAggregates = aggregationNode_->aggregates().size();
-  std::vector<AggregateInfo> aggregateInfos;
-  aggregateInfos.reserve(numAggregates);
   std::shared_ptr<core::ExpressionEvaluator> expressionEvaluator;
-
-  for (auto i = 0; i < numAggregates; i++) {
-    const auto& aggregate = aggregationNode_->aggregates()[i];
-    AggregateInfo info = AggregateUtil::toAggregateInfo(
-        aggregate,
-        inputType,
-        outputType_,
-        aggregationNode_->step(),
-        *operatorCtx_,
-        numHashers + i,
-        expressionEvaluator);
-    aggregateInfos.emplace_back(std::move(info));
-  }
+  std::vector<AggregateInfo> aggregateInfos = AggregateUtil::toAggregateInfo(
+      *aggregationNode_,
+      inputType,
+      outputType_,
+      aggregationNode_->step(),
+      *operatorCtx_,
+      numHashers,
+      expressionEvaluator);
 
   // Check that aggregate result type match the output type.
   for (auto i = 0; i < aggregateInfos.size(); i++) {

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -138,9 +138,9 @@ void HashAggregation::initialize() {
     // Setup aggregation mask: convert the Variable Reference name to the
     // channel (projection) index, if there is a mask.
     if (const auto& mask = aggregate.mask) {
-      if (mask != nullptr) {
-        info.mask = inputType->asRow().getChildIdx(mask->name());
-      }
+      info.mask = inputType->asRow().getChildIdx(mask->name());
+    } else {
+      info.mask = std::nullopt;
     }
 
     const auto& resultType = outputType_->childAt(numHashers + i);

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -58,7 +58,7 @@ void StreamingAggregation::initialize() {
   }
 
   std::shared_ptr<core::ExpressionEvaluator> expressionEvaluator;
-  aggregates_ = AggregateUtil::toAggregateInfo(
+  aggregates_ = toAggregateInfo(
       *aggregationNode_, *operatorCtx_, numKeys, expressionEvaluator, true);
 
   // Setup masks and accumulators

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -59,14 +59,7 @@ void StreamingAggregation::initialize() {
 
   std::shared_ptr<core::ExpressionEvaluator> expressionEvaluator;
   aggregates_ = AggregateUtil::toAggregateInfo(
-      *aggregationNode_,
-      inputType,
-      outputType_,
-      aggregationNode_->step(),
-      *operatorCtx_,
-      numKeys,
-      expressionEvaluator,
-      true);
+      *aggregationNode_, *operatorCtx_, numKeys, expressionEvaluator, true);
 
   // Setup masks and accumulators
   const auto numAggregates = aggregationNode_->aggregates().size();

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -58,27 +58,15 @@ void StreamingAggregation::initialize() {
 
   for (auto i = 0; i < numAggregates; i++) {
     const auto& aggregate = aggregationNode_->aggregates()[i];
-    if (!aggregate.sortingKeys.empty()) {
-      VELOX_UNSUPPORTED(
-          "Streaming aggregation doesn't support aggregations over sorted inputs yet");
-    }
-
-    if (aggregate.distinct) {
-      VELOX_UNSUPPORTED(
-          "Streaming aggregation doesn't support aggregations over distinct inputs yet");
-    }
-
     AggregateInfo info = AggregateUtil::toAggregateInfo(
         aggregate,
         inputType,
         outputType_,
         aggregationNode_->step(),
-        operatorCtx_,
-        pool(),
+        *operatorCtx_,
         numKeys + i,
         expressionEvaluator,
-        false);
-
+        true);
     aggregates_.emplace_back(std::move(info));
   }
 

--- a/velox/exec/StreamingAggregation.h
+++ b/velox/exec/StreamingAggregation.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "velox/exec/Aggregate.h"
+#include "velox/exec/AggregateInfo.h"
 #include "velox/exec/AggregationMasks.h"
 #include "velox/exec/Operator.h"
 
@@ -79,10 +80,8 @@ class StreamingAggregation : public Operator {
   const core::AggregationNode::Step step_;
 
   std::vector<column_index_t> groupingKeys_;
-  std::vector<std::unique_ptr<Aggregate>> aggregates_;
+  std::vector<AggregateInfo> aggregates_;
   std::unique_ptr<AggregationMasks> masks_;
-  std::vector<std::vector<column_index_t>> args_;
-  std::vector<std::vector<VectorPtr>> constantArgs_;
   std::vector<DecodedVector> decodedKeys_;
 
   // Storage of grouping keys and accumulators.


### PR DESCRIPTION
Refactor HashAggregation to extract toAggregateInfo(AggregationNode). 

Use the new function in StreamingAggregation to reduce copy-paste.

Part of #7665