### PR TITLE
Fix fast path in map Presto function for input arrays with nulls

### DIFF
--- a/velox/functions/prestosql/Map.cpp
+++ b/velox/functions/prestosql/Map.cpp
@@ -87,7 +87,7 @@ class MapFunction : public exec::VectorFunction {
       auto mapVector = std::make_shared<MapVector>(
           context.pool(),
           outputType,
-          nullptr,
+          keysArray->nulls(),
           rows.end(),
           keysArray->offsets(),
           keysArray->sizes(),
@@ -306,6 +306,14 @@ class MapFunction : public exec::VectorFunction {
       return false;
     }
     for (auto row = 0; row < keys->size(); ++row) {
+      if (keys->isNullAt(row)) {
+        continue;
+      }
+
+      if (values->isNullAt(row)) {
+        return false;
+      }
+
       if (keys->offsetAt(row) != values->offsetAt(row) ||
           keys->sizeAt(row) != values->sizeAt(row)) {
         return false;

--- a/velox/functions/prestosql/tests/MapTest.cpp
+++ b/velox/functions/prestosql/tests/MapTest.cpp
@@ -59,6 +59,36 @@ TEST_F(MapTest, someNulls) {
   assertEqualVectors(expectedMap, result);
 }
 
+TEST_F(MapTest, nullWithNonZeroSizes) {
+  auto keys = makeArrayVectorFromJson<int32_t>({
+      "[1, 2, 3]",
+      "[1, 2]",
+      "[1, 2, 3]",
+  });
+
+  auto values = makeArrayVectorFromJson<int64_t>({
+      "[10, 20, 30]",
+      "[11, 21]",
+      "[12, 22, 32]",
+  });
+
+  // Set null for one of the rows. Also, set offset and size for the row to
+  // values that exceed the size of the 'elements' vector.
+  keys->setNull(1, true);
+  keys->setOffsetAndSize(1, 100, 10);
+  values->setNull(1, true);
+  values->setOffsetAndSize(1, 100, 10);
+
+  auto result = evaluate("map(c0, c1)", makeRowVector({keys, values}));
+
+  auto expected = makeMapVectorFromJson<int32_t, int64_t>({
+      "{1: 10, 2: 20, 3: 30}",
+      "null",
+      "{1: 12, 2: 22, 3: 32}",
+  });
+  assertEqualVectors(expected, result);
+}
+
 TEST_F(MapTest, partiallyPopulated) {
   auto size = 1'000;
 


### PR DESCRIPTION
Fast path in the "map" Presto function could produce invalid MapVector if input
arrays had null rows with out-of-bounds  offsets/sizes.

Fixes #7861