### PR TITLE
Make return type void during aggregate registration.

### DIFF
--- a/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
@@ -351,8 +351,7 @@ std::unique_ptr<exec::Aggregate> makeApproxMostFrequentAggregate(
 
 } // namespace
 
-exec::AggregateRegistrationResult registerApproxMostFrequentAggregate(
-    const std::string& prefix) {
+void registerApproxMostFrequentAggregate(const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   for (const auto& valueType :
        {"tinyint", "smallint", "integer", "bigint", "varchar"}) {
@@ -367,7 +366,7 @@ exec::AggregateRegistrationResult registerApproxMostFrequentAggregate(
             .build());
   }
   auto name = prefix + kApproxMostFrequent;
-  return exec::registerAggregateFunction(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
@@ -828,7 +828,7 @@ void addSignatures(
 
 } // namespace
 
-exec::AggregateRegistrationResult registerApproxPercentileAggregate(
+void registerApproxPercentileAggregate(
     const std::string& prefix,
     bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
@@ -842,7 +842,7 @@ exec::AggregateRegistrationResult registerApproxPercentileAggregate(
         signatures);
   }
   auto name = prefix + kApproxPercentile;
-  return exec::registerAggregateFunction(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
@@ -237,7 +237,7 @@ class ArrayAggAggregate : public exec::Aggregate {
 
 } // namespace
 
-exec::AggregateRegistrationResult registerArrayAggAggregate(
+void registerArrayAggAggregate(
     const std::string& prefix,
     bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
@@ -249,7 +249,7 @@ exec::AggregateRegistrationResult registerArrayAggAggregate(
           .build()};
 
   auto name = prefix + kArrayAgg;
-  return exec::registerAggregateFunction(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/AverageAggregate.cpp
@@ -29,7 +29,7 @@ namespace facebook::velox::aggregate::prestosql {
 ///     REAL            |     DOUBLE          |    REAL
 ///     ALL INTs        |     DOUBLE          |    DOUBLE
 ///     DECIMAL         |     DECIMAL         |    DECIMAL
-exec::AggregateRegistrationResult registerAverageAggregate(
+void registerAverageAggregate(
     const std::string& prefix,
     bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
@@ -57,7 +57,7 @@ exec::AggregateRegistrationResult registerAverageAggregate(
                            .build());
 
   auto name = prefix + kAvg;
-  return exec::registerAggregateFunction(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/BitwiseXorAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/BitwiseXorAggregate.cpp
@@ -66,8 +66,7 @@ class BitwiseXorAggregate {
 
 } // namespace
 
-exec::AggregateRegistrationResult registerBitwiseXorAggregate(
-    const std::string& prefix) {
+void registerBitwiseXorAggregate(const std::string& prefix) {
   const std::string name = prefix + kBitwiseXor;
 
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
@@ -80,7 +79,7 @@ exec::AggregateRegistrationResult registerBitwiseXorAggregate(
                              .build());
   }
 
-  return exec::registerAggregateFunction(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
@@ -209,8 +209,7 @@ class ChecksumAggregate : public exec::Aggregate {
 
 } // namespace
 
-exec::AggregateRegistrationResult registerChecksumAggregate(
-    const std::string& prefix) {
+void registerChecksumAggregate(const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -221,7 +220,7 @@ exec::AggregateRegistrationResult registerChecksumAggregate(
   };
 
   auto name = prefix + kChecksum;
-  return exec::registerAggregateFunction(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [&name](

--- a/velox/functions/prestosql/aggregates/CountAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountAggregate.cpp
@@ -150,8 +150,7 @@ class CountAggregate : public SimpleNumericAggregate<bool, int64_t, int64_t> {
 
 } // namespace
 
-exec::AggregateRegistrationResult registerCountAggregate(
-    const std::string& prefix) {
+void registerCountAggregate(const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .returnType("bigint")
@@ -166,7 +165,7 @@ exec::AggregateRegistrationResult registerCountAggregate(
   };
 
   auto name = prefix + kCount;
-  return exec::registerAggregateFunction(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
@@ -170,8 +170,7 @@ class CountIfAggregate : public exec::Aggregate {
 
 } // namespace
 
-exec::AggregateRegistrationResult registerCountIfAggregate(
-    const std::string& prefix) {
+void registerCountIfAggregate(const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .returnType("bigint")
@@ -181,7 +180,7 @@ exec::AggregateRegistrationResult registerCountIfAggregate(
   };
 
   auto name = prefix + kCountIf;
-  return exec::registerAggregateFunction(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/EntropyAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/EntropyAggregates.cpp
@@ -336,8 +336,7 @@ void checkRowType(const TypePtr& type, const std::string& errorMessage) {
 
 } // namespace
 
-exec::AggregateRegistrationResult registerEntropyAggregate(
-    const std::string& prefix) {
+void registerEntropyAggregate(const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   std::vector<std::string> inputTypes = {"smallint", "integer", "bigint"};
   for (const auto& inputType : inputTypes) {
@@ -349,7 +348,7 @@ exec::AggregateRegistrationResult registerEntropyAggregate(
   }
 
   auto name = prefix + kEntropy;
-  return exec::registerAggregateFunction(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/GeometricMeanAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/GeometricMeanAggregate.cpp
@@ -82,8 +82,7 @@ class GeometricMeanAggregate {
 
 } // namespace
 
-exec::AggregateRegistrationResult registerGeometricMeanAggregate(
-    const std::string& prefix) {
+void registerGeometricMeanAggregate(const std::string& prefix) {
   const std::string name = prefix + kGeometricMean;
 
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
@@ -103,7 +102,7 @@ exec::AggregateRegistrationResult registerGeometricMeanAggregate(
                            .argumentType("real")
                            .build());
 
-  return exec::registerAggregateFunction(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
@@ -340,8 +340,7 @@ class HistogramAggregate : public exec::Aggregate {
 
 } // namespace
 
-exec::AggregateRegistrationResult registerHistogramAggregate(
-    const std::string& prefix) {
+void registerHistogramAggregate(const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   for (const auto inputType :
        {"boolean",
@@ -364,7 +363,7 @@ exec::AggregateRegistrationResult registerHistogramAggregate(
   }
 
   auto name = prefix + kHistogram;
-  return exec::registerAggregateFunction(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
@@ -147,8 +147,7 @@ class MapAggAggregate : public MapAggregateBase<K> {
 
 } // namespace
 
-exec::AggregateRegistrationResult registerMapAggAggregate(
-    const std::string& prefix) {
+void registerMapAggAggregate(const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .knownTypeVariable("K")
@@ -160,7 +159,7 @@ exec::AggregateRegistrationResult registerMapAggAggregate(
           .build()};
 
   auto name = prefix + kMapAgg;
-  return exec::registerAggregateFunction(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/MapUnionAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapUnionAggregate.cpp
@@ -75,8 +75,7 @@ class MapUnionAggregate : public MapAggregateBase<K> {
 
 } // namespace
 
-exec::AggregateRegistrationResult registerMapUnionAggregate(
-    const std::string& prefix) {
+void registerMapUnionAggregate(const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("K")
@@ -87,7 +86,7 @@ exec::AggregateRegistrationResult registerMapUnionAggregate(
           .build()};
 
   auto name = prefix + kMapUnion;
-  return exec::registerAggregateFunction(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
@@ -347,8 +347,7 @@ std::unique_ptr<exec::Aggregate> createMapUnionSumAggregate(
 
 } // namespace
 
-exec::AggregateRegistrationResult registerMapUnionSumAggregate(
-    const std::string& prefix) {
+void registerMapUnionSumAggregate(const std::string& prefix) {
   const std::vector<std::string> keyTypes = {
       "tinyint",
       "smallint",
@@ -380,7 +379,7 @@ exec::AggregateRegistrationResult registerMapUnionSumAggregate(
   }
 
   auto name = prefix + kMapUnionSum;
-  return exec::registerAggregateFunction(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
@@ -204,8 +204,7 @@ class MaxSizeForStatsAggregate
 
 } // namespace
 
-exec::AggregateRegistrationResult registerMaxDataSizeForStatsAggregate(
-    const std::string& prefix) {
+void registerMaxDataSizeForStatsAggregate(const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
   signatures.push_back(exec::AggregateFunctionSignatureBuilder()
@@ -216,7 +215,7 @@ exec::AggregateRegistrationResult registerMaxDataSizeForStatsAggregate(
                            .build());
 
   auto name = prefix + kMaxSizeForStats;
-  return exec::registerAggregateFunction(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/MultiMapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MultiMapAggAggregate.cpp
@@ -478,8 +478,7 @@ class MultiMapAggAggregate : public exec::Aggregate {
 
 } // namespace
 
-exec::AggregateRegistrationResult registerMultiMapAggAggregate(
-    const std::string& prefix) {
+void registerMultiMapAggAggregate(const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("K")
@@ -491,7 +490,7 @@ exec::AggregateRegistrationResult registerMultiMapAggAggregate(
           .build()};
 
   auto name = prefix + kMultiMapAgg;
-  return exec::registerAggregateFunction(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/ReduceAgg.cpp
+++ b/velox/functions/prestosql/aggregates/ReduceAgg.cpp
@@ -786,7 +786,7 @@ class ReduceAgg : public exec::Aggregate {
 
 } // namespace
 
-exec::AggregateRegistrationResult registerReduceAgg(const std::string& prefix) {
+void registerReduceAgg(const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -801,7 +801,7 @@ exec::AggregateRegistrationResult registerReduceAgg(const std::string& prefix) {
 
   const std::string name = prefix + kReduceAgg;
 
-  return exec::registerAggregateFunction(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -18,50 +18,33 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-extern exec::AggregateRegistrationResult registerApproxMostFrequentAggregate(
-    const std::string& prefix);
-extern exec::AggregateRegistrationResult registerApproxPercentileAggregate(
+extern void registerApproxMostFrequentAggregate(const std::string& prefix);
+extern void registerApproxPercentileAggregate(
     const std::string& prefix,
     bool withCompanionFunctions);
-void registerArbitraryAggregate(const std::string& prefix);
-extern exec::AggregateRegistrationResult registerArrayAggAggregate(
+extern void registerArbitraryAggregate(const std::string& prefix);
+extern void registerArrayAggAggregate(
     const std::string& prefix,
     bool withCompanionFunctions);
-extern exec::AggregateRegistrationResult registerAverageAggregate(
+extern void registerAverageAggregate(
     const std::string& prefix,
     bool withCompanionFunctions);
-extern exec::AggregateRegistrationResult registerBitwiseXorAggregate(
-    const std::string& prefix);
-extern exec::AggregateRegistrationResult registerChecksumAggregate(
-    const std::string& prefix);
-extern exec::AggregateRegistrationResult registerCountAggregate(
-    const std::string& prefix);
-extern exec::AggregateRegistrationResult registerCountIfAggregate(
-    const std::string& prefix);
-extern exec::AggregateRegistrationResult registerEntropyAggregate(
-    const std::string& prefix);
-extern exec::AggregateRegistrationResult registerGeometricMeanAggregate(
-    const std::string& prefix);
-extern exec::AggregateRegistrationResult registerHistogramAggregate(
-    const std::string& prefix);
-extern exec::AggregateRegistrationResult registerMapAggAggregate(
-    const std::string& prefix);
-extern exec::AggregateRegistrationResult registerMapUnionAggregate(
-    const std::string& prefix);
-extern exec::AggregateRegistrationResult registerMapUnionSumAggregate(
-    const std::string& prefix);
-extern exec::AggregateRegistrationResult registerMaxDataSizeForStatsAggregate(
-    const std::string& prefix);
-extern exec::AggregateRegistrationResult registerMultiMapAggAggregate(
-    const std::string& prefix);
-extern exec::AggregateRegistrationResult registerSumDataSizeForStatsAggregate(
-    const std::string& prefix);
-extern exec::AggregateRegistrationResult registerReduceAgg(
-    const std::string& prefix);
-extern exec::AggregateRegistrationResult registerSetAggAggregate(
-    const std::string& prefix);
-extern exec::AggregateRegistrationResult registerSetUnionAggregate(
-    const std::string& prefix);
+extern void registerBitwiseXorAggregate(const std::string& prefix);
+extern void registerChecksumAggregate(const std::string& prefix);
+extern void registerCountAggregate(const std::string& prefix);
+extern void registerCountIfAggregate(const std::string& prefix);
+extern void registerEntropyAggregate(const std::string& prefix);
+extern void registerGeometricMeanAggregate(const std::string& prefix);
+extern void registerHistogramAggregate(const std::string& prefix);
+extern void registerMapAggAggregate(const std::string& prefix);
+extern void registerMapUnionAggregate(const std::string& prefix);
+extern void registerMapUnionSumAggregate(const std::string& prefix);
+extern void registerMaxDataSizeForStatsAggregate(const std::string& prefix);
+extern void registerMultiMapAggAggregate(const std::string& prefix);
+extern void registerSumDataSizeForStatsAggregate(const std::string& prefix);
+extern void registerReduceAgg(const std::string& prefix);
+extern void registerSetAggAggregate(const std::string& prefix);
+extern void registerSetUnionAggregate(const std::string& prefix);
 
 extern void registerApproxDistinctAggregates(
     const std::string& prefix,

--- a/velox/functions/prestosql/aggregates/SetAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/SetAggregates.cpp
@@ -421,8 +421,7 @@ std::unique_ptr<exec::Aggregate> create(
 
 } // namespace
 
-exec::AggregateRegistrationResult registerSetAggAggregate(
-    const std::string& prefix) {
+void registerSetAggAggregate(const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures = {
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -432,7 +431,7 @@ exec::AggregateRegistrationResult registerSetAggAggregate(
           .build()};
 
   auto name = prefix + kSetAgg;
-  return exec::registerAggregateFunction(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](
@@ -483,8 +482,7 @@ exec::AggregateRegistrationResult registerSetAggAggregate(
       });
 }
 
-exec::AggregateRegistrationResult registerSetUnionAggregate(
-    const std::string& prefix) {
+void registerSetUnionAggregate(const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures = {
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -494,7 +492,7 @@ exec::AggregateRegistrationResult registerSetUnionAggregate(
           .build()};
 
   auto name = prefix + kSetUnion;
-  return exec::registerAggregateFunction(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.cpp
@@ -184,8 +184,7 @@ class SumDataSizeForStatsAggregate
 
 } // namespace
 
-exec::AggregateRegistrationResult registerSumDataSizeForStatsAggregate(
-    const std::string& prefix) {
+void registerSumDataSizeForStatsAggregate(const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
   signatures.push_back(exec::AggregateFunctionSignatureBuilder()
@@ -196,7 +195,7 @@ exec::AggregateRegistrationResult registerSumDataSizeForStatsAggregate(
                            .build());
 
   auto name = prefix + kSumDataSizeForStats;
-  return exec::registerAggregateFunction(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](


### PR DESCRIPTION
Summary: Aggregate function registration does not utilize return type. Some registrations are done with void and some are done with return type - where return type is unused. Making all of them void, similar to what is done in  https://github.com/facebookincubator/velox/pull/7689

Differential Revision: D51593723


