### PR TITLE
getdeps: Don't use system deps on CentOS for gflags and glog

### DIFF
--- a/build/fbcode_builder/manifests/gflags
+++ b/build/fbcode_builder/manifests/gflags
@@ -17,6 +17,3 @@ BUILD_gflags_LIB = ON
 
 [debs]
 libgflags-dev
-
-[rpms]
-gflags-devel

--- a/build/fbcode_builder/manifests/glog
+++ b/build/fbcode_builder/manifests/glog
@@ -23,6 +23,3 @@ HAVE_TR1_UNORDERED_SET=OFF
 
 [debs]
 libgoogle-glog-dev
-
-[rpms]
-glog-devel


### PR DESCRIPTION
Summary:
Building projects using `--allow-system-packages` on CentOS for
projects that rely on `gflags` fails. I'm not completely sure why this is the
case and myself and kmancini have spent some time trying to investigate this.

Fix these builds by disabling the system packages on CentOS.

Reviewed By: chadaustin

Differential Revision: D51813855


