### PR TITLE
Ensure regex authority is matched to fix sanitizer arrays

### DIFF
--- a/velox/docs/functions/presto/url.rst
+++ b/velox/docs/functions/presto/url.rst
@@ -66,7 +66,7 @@ Extraction Functions
 
 .. function:: url_extract_port(url) -> bigint
 
-    Returns the port number from ``url``.
+    Returns the port number from ``url``. Returns NULL if port is missing.
 
 .. function:: url_extract_protocol(url) -> varchar
 

--- a/velox/functions/prestosql/tests/URLFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/URLFunctionsTest.cpp
@@ -114,6 +114,14 @@ TEST_F(URLFunctionsTest, validateURL) {
       std::nullopt,
       std::nullopt,
       std::nullopt);
+  validate(
+      "IC6S!8hGVRpo+!,yTaJEy/$RUZpqcr",
+      "",
+      "",
+      "IC6S!8hGVRpo !,yTaJEy/$RUZpqcr",
+      "",
+      "",
+      std::nullopt);
 }
 
 TEST_F(URLFunctionsTest, extractPath) {
@@ -133,6 +141,7 @@ TEST_F(URLFunctionsTest, extractPath) {
       extractPath("https://www.ucu.edu.uy/agenda/evento/%%UCUrlCompartir%%"));
   EXPECT_EQ("foo", extractPath("foo"));
   EXPECT_EQ(std::nullopt, extractPath("BAD URL!"));
+  EXPECT_EQ("", extractPath("http://www.yahoo.com"));
 }
 
 TEST_F(URLFunctionsTest, extractParameter) {


### PR DESCRIPTION
Summary: It is possible to trigger address sanitizer when passed garbage strings in matchAuthorityAndPath function. We need to ensure that subgroups are actually matched, since accessing an unmatched string can lead to asan errors.

Differential Revision: D51822902


