### PR TITLE
Rename ByteStream as ByteOutputStream

### DIFF
--- a/velox/common/memory/ByteStream.cpp
+++ b/velox/common/memory/ByteStream.cpp
@@ -81,7 +81,7 @@ std::streampos ByteInputStream::tellp() const {
     }
     size += range.size;
   }
-  VELOX_FAIL("ByteStream 'current_' is not in 'ranges_'.");
+  VELOX_FAIL("ByteInputStream 'current_' is not in 'ranges_'.");
 }
 
 void ByteInputStream::seekp(std::streampos position) {
@@ -106,7 +106,7 @@ void ByteInputStream::next(bool throwIfPastEnd) {
   VELOX_CHECK_LT(position, ranges_.size());
   if (position == ranges_.size() - 1) {
     if (throwIfPastEnd) {
-      VELOX_FAIL("Reading past end of ByteStream");
+      VELOX_FAIL("Reading past end of ByteInputStream");
     }
     return;
   }
@@ -167,7 +167,7 @@ void ByteInputStream::skip(int32_t size) {
   }
 }
 
-size_t ByteStream::size() const {
+size_t ByteOutputStream::size() const {
   if (ranges_.empty()) {
     return 0;
   }
@@ -178,7 +178,7 @@ size_t ByteStream::size() const {
   return total + std::max(ranges_.back().position, lastRangeEnd_);
 }
 
-void ByteStream::appendBool(bool value, int32_t count) {
+void ByteOutputStream::appendBool(bool value, int32_t count) {
   if (count == 1 && current_->size > current_->position) {
     bits::setBit(
         reinterpret_cast<uint64_t*>(current_->buffer),
@@ -206,7 +206,10 @@ void ByteStream::appendBool(bool value, int32_t count) {
   }
 }
 
-void ByteStream::appendBits(const uint64_t* bits, int32_t begin, int32_t end) {
+void ByteOutputStream::appendBits(
+    const uint64_t* bits,
+    int32_t begin,
+    int32_t end) {
   VELOX_DCHECK(isBits_);
   int32_t count = end - begin;
   int32_t offset = 0;
@@ -229,11 +232,11 @@ void ByteStream::appendBits(const uint64_t* bits, int32_t begin, int32_t end) {
   }
 }
 
-void ByteStream::appendStringView(StringView value) {
+void ByteOutputStream::appendStringView(StringView value) {
   appendStringView((std::string_view)value);
 }
 
-void ByteStream::appendStringView(std::string_view value) {
+void ByteOutputStream::appendStringView(std::string_view value) {
   const int32_t bytes = value.size();
   int32_t offset = 0;
   for (;;) {
@@ -250,7 +253,7 @@ void ByteStream::appendStringView(std::string_view value) {
   }
 }
 
-std::streampos ByteStream::tellp() const {
+std::streampos ByteOutputStream::tellp() const {
   if (ranges_.empty()) {
     return 0;
   }
@@ -262,10 +265,10 @@ std::streampos ByteStream::tellp() const {
     }
     size += range.size;
   }
-  VELOX_FAIL("ByteStream 'current_' is not in 'ranges_'.");
+  VELOX_FAIL("ByteOutputStream 'current_' is not in 'ranges_'.");
 }
 
-void ByteStream::seekp(std::streampos position) {
+void ByteOutputStream::seekp(std::streampos position) {
   int64_t toSkip = position;
   // Record how much was written pre-seek.
   updateEnd();
@@ -280,10 +283,10 @@ void ByteStream::seekp(std::streampos position) {
     }
     toSkip -= range.size;
   }
-  VELOX_FAIL("Seeking past end of ByteStream: {}", position);
+  VELOX_FAIL("Seeking past end of ByteOutputStream: {}", position);
 }
 
-void ByteStream::flush(OutputStream* out) {
+void ByteOutputStream::flush(OutputStream* out) {
   updateEnd();
   for (int32_t i = 0; i < ranges_.size(); ++i) {
     int32_t count = i == ranges_.size() - 1 ? lastRangeEnd_ : ranges_[i].size;
@@ -298,17 +301,17 @@ void ByteStream::flush(OutputStream* out) {
   }
 }
 
-char* ByteStream::writePosition() {
+char* ByteOutputStream::writePosition() {
   if (ranges_.empty()) {
     return nullptr;
   }
   return reinterpret_cast<char*>(current_->buffer) + current_->position;
 }
 
-void ByteStream::extend(int32_t bytes) {
+void ByteOutputStream::extend(int32_t bytes) {
   if (current_ && current_->position != current_->size) {
-    LOG(FATAL) << "Extend ByteStream before range full: " << current_->position
-               << " vs. " << current_->size;
+    LOG(FATAL) << "Extend ByteOutputStream before range full: "
+               << current_->position << " vs. " << current_->size;
   }
 
   // Check if rewriting existing content. If so, move to next range and start at
@@ -330,7 +333,7 @@ void ByteStream::extend(int32_t bytes) {
   }
 }
 
-int32_t ByteStream::newRangeSize(int32_t bytes) const {
+int32_t ByteOutputStream::newRangeSize(int32_t bytes) const {
   const int32_t newSize = allocatedBytes_ + bytes;
   if (newSize < 128) {
     return 128;
@@ -344,10 +347,10 @@ int32_t ByteStream::newRangeSize(int32_t bytes) const {
   return bits::roundUp(bytes, memory::AllocationTraits::kPageSize);
 }
 
-std::string ByteStream::toString() const {
+std::string ByteOutputStream::toString() const {
   std::stringstream oss;
-  oss << "ByteStream[lastRangeEnd " << lastRangeEnd_ << ", " << ranges_.size()
-      << " ranges (position/size) [";
+  oss << "ByteOutputStream[lastRangeEnd " << lastRangeEnd_ << ", "
+      << ranges_.size() << " ranges (position/size) [";
   for (const auto& range : ranges_) {
     oss << "(" << range.position << "/" << range.size
         << (&range == current_ ? " current" : "") << ")";

--- a/velox/common/memory/ByteStream.h
+++ b/velox/common/memory/ByteStream.h
@@ -214,18 +214,18 @@ class ByteInputStream {
 /// in hash tables. The stream is seekable and supports overwriting of
 /// previous content, for example, writing a message body and then
 /// seeking back to start to write a length header.
-class ByteStream {
+class ByteOutputStream {
  public:
   /// For output.
-  ByteStream(
+  ByteOutputStream(
       StreamArena* arena,
       bool isBits = false,
       bool isReverseBitOrder = false)
       : arena_(arena), isBits_(isBits), isReverseBitOrder_(isReverseBitOrder) {}
 
-  ByteStream(const ByteStream& other) = delete;
+  ByteOutputStream(const ByteOutputStream& other) = delete;
 
-  void operator=(const ByteStream& other) = delete;
+  void operator=(const ByteOutputStream& other) = delete;
 
   void setRange(ByteRange range) {
     ranges_.resize(1);
@@ -392,7 +392,7 @@ class ByteStream {
 template <typename T>
 class AppendWindow {
  public:
-  AppendWindow(ByteStream& stream, Scratch& scratch)
+  AppendWindow(ByteOutputStream& stream, Scratch& scratch)
       : stream_(stream), scratchPtr_(scratch) {}
 
   ~AppendWindow() {
@@ -408,7 +408,7 @@ class AppendWindow {
   }
 
  private:
-  ByteStream& stream_;
+  ByteOutputStream& stream_;
   ScratchPtr<T> scratchPtr_;
 };
 
@@ -434,7 +434,7 @@ class IOBufOutputStream : public OutputStream {
       int32_t initialSize = memory::AllocationTraits::kPageSize)
       : OutputStream(listener),
         arena_(std::make_shared<StreamArena>(&pool)),
-        out_(std::make_unique<ByteStream>(arena_.get())) {
+        out_(std::make_unique<ByteOutputStream>(arena_.get())) {
     out_->startWrite(initialSize);
   }
 
@@ -455,7 +455,7 @@ class IOBufOutputStream : public OutputStream {
 
  private:
   std::shared_ptr<StreamArena> arena_;
-  std::unique_ptr<ByteStream> out_;
+  std::unique_ptr<ByteOutputStream> out_;
 };
 
 } // namespace facebook::velox

--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -138,7 +138,7 @@ ByteInputStream HashStringAllocator::prepareRead(const Header* begin) {
 }
 
 HashStringAllocator::Position HashStringAllocator::newWrite(
-    ByteStream& stream,
+    ByteOutputStream& stream,
     int32_t preferredSize) {
   VELOX_CHECK(
       !currentHeader_,
@@ -156,7 +156,9 @@ HashStringAllocator::Position HashStringAllocator::newWrite(
   return startPosition_;
 }
 
-void HashStringAllocator::extendWrite(Position position, ByteStream& stream) {
+void HashStringAllocator::extendWrite(
+    Position position,
+    ByteOutputStream& stream) {
   auto header = position.header;
   const auto offset = position.offset();
   VELOX_CHECK_GE(
@@ -180,7 +182,9 @@ void HashStringAllocator::extendWrite(Position position, ByteStream& stream) {
 }
 
 std::pair<HashStringAllocator::Position, HashStringAllocator::Position>
-HashStringAllocator::finishWrite(ByteStream& stream, int32_t numReserveBytes) {
+HashStringAllocator::finishWrite(
+    ByteOutputStream& stream,
+    int32_t numReserveBytes) {
   VELOX_CHECK(
       currentHeader_, "Must call newWrite or extendWrite before finishWrite");
   auto writePosition = stream.writePosition();
@@ -506,7 +510,7 @@ void HashStringAllocator::ensureAvailable(int32_t bytes, Position& position) {
     return;
   }
 
-  ByteStream stream(this);
+  ByteOutputStream stream(this);
   extendWrite(position, stream);
   static char data[128];
   while (bytes) {
@@ -578,7 +582,7 @@ void HashStringAllocator::copyMultipartNoInline(
     return;
   }
   // Write the string as non-contiguous chunks.
-  ByteStream stream(this, false, false);
+  ByteOutputStream stream(this, false, false);
   auto position = newWrite(stream, numBytes);
   stream.appendStringView(*string);
   finishWrite(stream, 0);

--- a/velox/common/memory/HashStringAllocator.h
+++ b/velox/common/memory/HashStringAllocator.h
@@ -28,8 +28,8 @@
 namespace facebook::velox {
 
 // Implements an arena backed by MappedMemory::Allocation. This is for backing
-// ByteStream or for allocating single blocks. Blocks can be individually freed.
-// Adjacent frees are coalesced and free blocks are kept in a free list.
+// ByteOutputStream or for allocating single blocks. Blocks can be individually
+// freed. Adjacent frees are coalesced and free blocks are kept in a free list.
 // Allocated blocks are prefixed with a Header. This has a size and flags.
 // kContinue means that last 8 bytes are a pointer to another Header after which
 // the contents of this allocation continue. kFree means the block is free. A
@@ -263,11 +263,13 @@ class HashStringAllocator : public StreamArena {
   // kMinContiguous bytes of contiguous space. finishWrite finalizes
   // the allocation information after the write is done.
   // Returns the position at the start of the allocated block.
-  Position newWrite(ByteStream& stream, int32_t preferredSize = kMinContiguous);
+  Position newWrite(
+      ByteOutputStream& stream,
+      int32_t preferredSize = kMinContiguous);
 
   // Sets 'stream' to write starting at 'position'. If new ranges have to
   // be allocated when writing, headers will be updated accordingly.
-  void extendWrite(Position position, ByteStream& stream);
+  void extendWrite(Position position, ByteOutputStream& stream);
 
   // Completes a write prepared with newWrite or
   // extendWrite. Up to 'numReserveBytes' unused bytes, if available, are left
@@ -275,7 +277,7 @@ class HashStringAllocator : public StreamArena {
   // positions: (1) position at the start of this 'write', (2) position
   // immediately after the last written byte.
   std::pair<Position, Position> finishWrite(
-      ByteStream& stream,
+      ByteOutputStream& stream,
       int32_t numReserveBytes);
 
   /// Allocates a new range for a stream writing to 'this'. Sets the last word

--- a/velox/common/memory/tests/ByteStreamTest.cpp
+++ b/velox/common/memory/tests/ByteStreamTest.cpp
@@ -236,7 +236,7 @@ TEST_F(ByteStreamTest, newRangeAllocation) {
 
     const auto prevAllocCount = pool_->stats().numAllocs;
     auto arena = newArena();
-    ByteStream byteStream(arena.get());
+    ByteOutputStream byteStream(arena.get());
     byteStream.startWrite(0);
     for (int i = 0; i < testData.newRangeSizes.size(); ++i) {
       const auto newRangeSize = testData.newRangeSizes[i];
@@ -260,9 +260,9 @@ TEST_F(ByteStreamTest, newRangeAllocation) {
 TEST_F(ByteStreamTest, randomRangeAllocationFromMultiStreamsTest) {
   auto arena = newArena();
   const int numByteStreams = 10;
-  std::vector<std::unique_ptr<ByteStream>> byteStreams;
+  std::vector<std::unique_ptr<ByteOutputStream>> byteStreams;
   for (int i = 0; i < numByteStreams; ++i) {
-    byteStreams.push_back(std::make_unique<ByteStream>(arena.get()));
+    byteStreams.push_back(std::make_unique<ByteOutputStream>(arena.get()));
     byteStreams.back()->startWrite(0);
   }
   const int testIterations = 1000;
@@ -293,7 +293,7 @@ TEST_F(ByteStreamTest, bits) {
     bits.push_back(seed * (i + 1));
   }
   auto arena = newArena();
-  ByteStream bitStream(arena.get(), true);
+  ByteOutputStream bitStream(arena.get(), true);
   bitStream.startWrite(11);
   int32_t offset = 0;
   // Odd number of sizes.
@@ -334,7 +334,7 @@ TEST_F(ByteStreamTest, appendWindow) {
   }
   auto arena = newArena();
 
-  ByteStream stream(arena.get());
+  ByteOutputStream stream(arena.get());
   int32_t offset = 0;
   std::vector<int32_t> sizes = {1, 19, 52, 58, 129};
   int32_t counter = 0;

--- a/velox/common/memory/tests/HashStringAllocatorTest.cpp
+++ b/velox/common/memory/tests/HashStringAllocatorTest.cpp
@@ -113,7 +113,7 @@ TEST_F(HashStringAllocatorTest, headerToString) {
 
   ASSERT_NO_THROW(allocator_->toString());
 
-  ByteStream stream(allocator_.get());
+  ByteOutputStream stream(allocator_.get());
   auto h4 = allocator_->newWrite(stream).header;
   std::string data(123'456, 'x');
   stream.appendStringView(data);
@@ -164,7 +164,7 @@ TEST_F(HashStringAllocatorTest, allocateLarge) {
 }
 
 TEST_F(HashStringAllocatorTest, finishWrite) {
-  ByteStream stream(allocator_.get());
+  ByteOutputStream stream(allocator_.get());
   auto start = allocator_->newWrite(stream);
 
   // Write a short string.
@@ -246,7 +246,7 @@ TEST_F(HashStringAllocatorTest, multipart) {
         continue;
       }
       auto chars = randomString();
-      ByteStream stream(allocator_.get());
+      ByteOutputStream stream(allocator_.get());
       if (data[i].start.header) {
         if (rand32() % 5) {
           // 4/5 of cases append to the end.
@@ -286,7 +286,7 @@ TEST_F(HashStringAllocatorTest, multipart) {
 }
 
 TEST_F(HashStringAllocatorTest, rewrite) {
-  ByteStream stream(allocator_.get());
+  ByteOutputStream stream(allocator_.get());
   auto header = allocator_->allocate(5);
   EXPECT_EQ(16, header->size()); // Rounds up to kMinAlloc.
   HSA::Position current = HSA::Position::atOffset(header, 0);

--- a/velox/docs/develop/arena.rst
+++ b/velox/docs/develop/arena.rst
@@ -85,9 +85,9 @@ StlAllocator, an allocator backed by HashStringAllocator that can be used with
 STL containers, is implemented using the above allocate() and free() methods.
 
 NewWrite(), extendWrite() and finishWrite() methods allow for serializing
-variable width data whose size is not known in advance using ByteStream. When
-using ByteStream, the underlying data may come from multiple non-contiguous
-blocks. ByteStream transparently manages allocation of additional blocks by
+variable width data whose size is not known in advance using ByteOutputStream. When
+using ByteOutputStream, the underlying data may come from multiple non-contiguous
+blocks. ByteOutputStream transparently manages allocation of additional blocks by
 calling HashStringAllocator::newRange() method.
 
 .. code-block:: c++
@@ -97,19 +97,19 @@ calling HashStringAllocator::newRange() method.
       // kMinContiguous bytes of contiguous space. finishWrite finalizes
       // the allocation information after the write is done.
       // Returns the position at the start of the allocated block.
-      Position newWrite(ByteStream& stream, int32_t preferredSize = kMinContiguous);
+      Position newWrite(ByteOutputStream& stream, int32_t preferredSize = kMinContiguous);
 
       // Completes a write prepared with newWrite or
       // extendWrite. Up to 'numReserveBytes' unused bytes, if available, are left
       // after the end of the write to accommodate another write. Returns the
       // position immediately after the last written byte.
-      Position finishWrite(ByteStream& stream, int32_t numReserveBytes);
+      Position finishWrite(ByteOutputStream& stream, int32_t numReserveBytes);
 
       // Sets 'stream' to write starting at 'position'. If new ranges have to
       // be allocated when writing, headers will be updated accordingly.
-      void extendWrite(Position position, ByteStream& stream);
+      void extendWrite(Position position, ByteOutputStream& stream);
 
-The prepareRead() method allows deserializing the data using ByteStream.
+The prepareRead() method allows deserializing the data using ByteInputStream.
 
 .. code-block:: c++
 
@@ -117,7 +117,7 @@ The prepareRead() method allows deserializing the data using ByteStream.
     // possible continuation ranges.
     static void prepareRead(
         const Header* FOLLY_NONNULL header,
-        ByteStream& stream);
+        ByteInputStream& stream);
 
 Examples of Usage
 -----------------
@@ -139,22 +139,22 @@ The accumulator calls finishWrite() after writing the value.
 .. code-block:: c++
 
         // Write first value
-        ByteStream stream(allocator);
+        ByteOutputStream stream(allocator);
         auto begin = allocator->newWrite(stream);
         // ... write to the stream
         allocator->finishWrite(stream);
 
         // Update the value
-        ByteStream stream(allocator);
+        ByteOutputStream stream(allocator);
         auto begin = allocator->extendWrite(begin, stream);
         // ... write to the stream
         allocator->finishWrite(stream);
 
-The accumulator uses prepareRead() to read the data back using ByteStream.
+The accumulator uses prepareRead() to read the data back using ByteInputStream.
 
 .. code-block:: c++
 
-        ByteStream stream;
+        ByteInputStream stream;
         exec::HashStringAllocator::prepareRead(begin, stream);
         // … read from the stream
 
@@ -174,13 +174,13 @@ write.
 .. code-block:: c++
 
         // Write first value
-        ByteStream stream(allocator);
+        ByteOutputStream stream(allocator);
         auto begin = allocator->newWrite(stream);
         // ... write to the stream
         auto current = allocator->finishWrite(stream);
 
         // Update the value
-        ByteStream stream(allocator);
+        ByteOutputStream stream(allocator);
         auto begin = allocator->extendWrite(current, stream);
         // ... write to the stream
         allocator->finishWrite(stream);

--- a/velox/exec/AddressableNonNullValueList.cpp
+++ b/velox/exec/AddressableNonNullValueList.cpp
@@ -22,7 +22,7 @@ HashStringAllocator::Position AddressableNonNullValueList::append(
     const DecodedVector& decoded,
     vector_size_t index,
     HashStringAllocator* allocator) {
-  ByteStream stream(allocator);
+  ByteOutputStream stream(allocator);
   if (!firstHeader_) {
     // An array_agg or related begins with an allocation of 5 words and
     // 4 bytes for header. This is compact for small arrays (up to 5

--- a/velox/exec/ContainerRowSerde.h
+++ b/velox/exec/ContainerRowSerde.h
@@ -26,8 +26,10 @@ class ContainerRowSerde {
  public:
   /// Serializes value from source[index] into 'out'. The value must not be
   /// null.
-  static void
-  serialize(const BaseVector& source, vector_size_t index, ByteStream& out);
+  static void serialize(
+      const BaseVector& source,
+      vector_size_t index,
+      ByteOutputStream& out);
 
   static void
   deserialize(ByteInputStream& in, vector_size_t index, BaseVector* result);

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -520,7 +520,7 @@ int32_t RowContainer::storeVariableSizeAt(
     }
   } else {
     if (size > 0) {
-      ByteStream stream(stringAllocator_.get(), false, false);
+      ByteOutputStream stream(stringAllocator_.get(), false, false);
       const auto position = stringAllocator_->newWrite(stream);
       stream.appendStringView(std::string_view(data + 4, size));
       stringAllocator_->finishWrite(stream, 0);
@@ -663,7 +663,7 @@ void RowContainer::storeComplexType(
     return;
   }
   RowSizeTracker tracker(row[rowSizeOffset_], *stringAllocator_);
-  ByteStream stream(stringAllocator_.get(), false, false);
+  ByteOutputStream stream(stringAllocator_.get(), false, false);
   auto position = stringAllocator_->newWrite(stream);
   ContainerRowSerde::serialize(*decoded.base(), decoded.index(index), stream);
   stringAllocator_->finishWrite(stream, 0);
@@ -671,7 +671,7 @@ void RowContainer::storeComplexType(
   valueAt<std::string_view>(row, offset) = std::string_view(
       reinterpret_cast<char*>(position.position), stream.size());
 
-  // TODO Fix ByteStream::size() API. @oerling is looking into that.
+  // TODO Fix ByteOutputStream::size() API. @oerling is looking into that.
   // Fix the 'size' of the std::string_view.
   // stream.size() is the capacity
   // stream.size() - stream.remainingSize() is the size of the data + size of

--- a/velox/exec/SortedAggregations.cpp
+++ b/velox/exec/SortedAggregations.cpp
@@ -27,7 +27,7 @@ struct RowPointers {
   size_t size{0};
 
   void append(char* row, HashStringAllocator& allocator) {
-    ByteStream stream(&allocator);
+    ByteOutputStream stream(&allocator);
     if (firstBlock == nullptr) {
       // Allocate first block.
       currentBlock = allocator.newWrite(stream);

--- a/velox/exec/Strings.cpp
+++ b/velox/exec/Strings.cpp
@@ -29,7 +29,7 @@ StringView Strings::append(StringView value, HashStringAllocator& allocator) {
   const int32_t requiredBytes =
       value.size() + HashStringAllocator::Header::kContinuedPtrSize + 8;
 
-  ByteStream stream(&allocator);
+  ByteOutputStream stream(&allocator);
   if (firstBlock == nullptr) {
     // Allocate first block.
     currentBlock = allocator.newWrite(stream, requiredBytes);

--- a/velox/exec/tests/ContainerRowSerdeTest.cpp
+++ b/velox/exec/tests/ContainerRowSerdeTest.cpp
@@ -29,7 +29,7 @@ class ContainerRowSerdeTest : public testing::Test,
   // Writes all rows together and returns a position at the start of this
   // combined write.
   HashStringAllocator::Position serialize(const VectorPtr& data) {
-    ByteStream out(&allocator_);
+    ByteOutputStream out(&allocator_);
     auto position = allocator_.newWrite(out);
     for (auto i = 0; i < data->size(); ++i) {
       ContainerRowSerde::serialize(*data, i, out);
@@ -46,7 +46,7 @@ class ContainerRowSerdeTest : public testing::Test,
     positions.reserve(size);
 
     for (auto i = 0; i < size; ++i) {
-      ByteStream out(&allocator_);
+      ByteOutputStream out(&allocator_);
       auto position = allocator_.newWrite(out);
       ContainerRowSerde::serialize(*data, i, out);
       allocator_.finishWrite(out, 0);

--- a/velox/functions/lib/aggregates/SingleValueAccumulator.cpp
+++ b/velox/functions/lib/aggregates/SingleValueAccumulator.cpp
@@ -25,7 +25,7 @@ void SingleValueAccumulator::write(
     const BaseVector* vector,
     vector_size_t index,
     HashStringAllocator* allocator) {
-  ByteStream stream(allocator);
+  ByteOutputStream stream(allocator);
   if (start_.header == nullptr) {
     start_ = allocator->newWrite(stream);
   } else {

--- a/velox/functions/lib/aggregates/ValueSet.cpp
+++ b/velox/functions/lib/aggregates/ValueSet.cpp
@@ -22,7 +22,7 @@ void ValueSet::write(
     const BaseVector& vector,
     vector_size_t index,
     HashStringAllocator::Position& position) const {
-  ByteStream stream(allocator_);
+  ByteOutputStream stream(allocator_);
   if (position.header == nullptr) {
     position = allocator_->newWrite(stream);
   } else {

--- a/velox/functions/prestosql/aggregates/ValueList.cpp
+++ b/velox/functions/prestosql/aggregates/ValueList.cpp
@@ -39,7 +39,7 @@ void ValueList::prepareAppend(HashStringAllocator* allocator) {
 }
 
 void ValueList::writeLastNulls(HashStringAllocator* allocator) {
-  ByteStream stream(allocator);
+  ByteOutputStream stream(allocator);
   if (nullsBegin_) {
     allocator->extendWrite(nullsCurrent_, stream);
   } else {
@@ -61,7 +61,7 @@ void ValueList::appendNonNull(
     vector_size_t index,
     HashStringAllocator* allocator) {
   prepareAppend(allocator);
-  ByteStream stream(allocator);
+  ByteOutputStream stream(allocator);
   allocator->extendWrite(dataCurrent_, stream);
   exec::ContainerRowSerde::serialize(values, index, stream);
   ++size_;

--- a/velox/row/benchmark/UnsafeRowSerializeBenchmark.cpp
+++ b/velox/row/benchmark/UnsafeRowSerializeBenchmark.cpp
@@ -187,7 +187,7 @@ class SerializeBenchmark {
   HashStringAllocator::Position serialize(
       const RowVectorPtr& data,
       HashStringAllocator& allocator) {
-    ByteStream out(&allocator);
+    ByteOutputStream out(&allocator);
     auto position = allocator.newWrite(out);
     for (auto i = 0; i < data->size(); ++i) {
       exec::ContainerRowSerde::serialize(*data, i, out);

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -1322,9 +1322,9 @@ class VectorStream {
   int32_t totalLength_{0};
   bool hasLengths_{false};
   ByteRange header_;
-  ByteStream nulls_;
-  ByteStream lengths_;
-  ByteStream values_;
+  ByteOutputStream nulls_;
+  ByteOutputStream lengths_;
+  ByteOutputStream values_;
   std::vector<std::unique_ptr<VectorStream>> children_;
 };
 

--- a/velox/serializers/tests/UnsafeRowSerializerTest.cpp
+++ b/velox/serializers/tests/UnsafeRowSerializerTest.cpp
@@ -277,7 +277,8 @@ TEST_F(UnsafeRowSerializerTest, incompleteRow) {
   // Cut in the middle of the `size` integer.
   buffers = {{rawData, 2}};
   VELOX_ASSERT_RUNTIME_THROW(
-      testDeserialize(buffers, expected), "Reading past end of ByteStream");
+      testDeserialize(buffers, expected),
+      "Reading past end of ByteInputStream");
 }
 
 TEST_F(UnsafeRowSerializerTest, types) {


### PR DESCRIPTION
ByteStream class was used both for reading and writing to a multi-part buffer.
Mixing reading and writing logic and APIs in a single class is confusing.
https://github.com/facebookincubator/velox/pull/7541 has been landed to extract reading logic and APIs into ByteInputStream
class. This change is to rename ByteStream as ByteOutputStream.