### PR TITLE
Fix crash in FlatVector::hashAll

### DIFF
--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -91,7 +91,7 @@ std::unique_ptr<SimpleVector<uint64_t>> FlatVector<T>::hashAll() const {
   }
 
   // overwrite the null hash values
-  if (BaseVector::getNullCount().value_or(1) > 0) {
+  if (BaseVector::rawNulls_ != nullptr) {
     for (size_t i = 0; i < BaseVector::length_; ++i) {
       if (bits::isBitNull(BaseVector::rawNulls_, i)) {
         hashData[i] = BaseVector::kNullHash;

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -3517,5 +3517,23 @@ TEST_F(VectorTest, flatAllNulls) {
   }
 }
 
+TEST_F(VectorTest, hashAll) {
+  auto data = makeFlatVector<int32_t>({1, 2, 3});
+  ASSERT_TRUE(data->getNullCount().has_value());
+
+  auto hashes = data->hashAll();
+
+  // Make a similar vector, but without stats, e.g. nullCount unset.
+  auto copy = std::make_shared<FlatVector<int32_t>>(
+      pool(), INTEGER(), nullptr, 3, data->values(), std::vector<BufferPtr>{});
+  ASSERT_FALSE(copy->getNullCount().has_value());
+
+  auto hashesCopy = copy->hashAll();
+
+  for (auto i = 0; i < 3; ++i) {
+    ASSERT_EQ(hashes->valueAt(i), hashesCopy->valueAt(i));
+  }
+}
+
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
FlatVector::hashAll used to crash if nullCount metadata was missing or non-zero, but nulls was buffer was not present.

Fixes #7868