### PR TITLE
Support the null value in bloom_filter_agg Spark aggregate function

### DIFF
--- a/velox/docs/functions/spark/aggregate.rst
+++ b/velox/docs/functions/spark/aggregate.rst
@@ -24,7 +24,6 @@ General Aggregate Functions
 .. spark:function:: bloom_filter_agg(hash, estimatedNumItems, numBits) -> varbinary
 
     Creates bloom filter from input hashes and returns it serialized into VARBINARY.
-    The caller is expected to apply xxhash64 function to input data before calling bloom_filter_agg.
 
     For example, 
         bloom_filter_agg(xxhash64(x), 100, 1024)

--- a/velox/docs/functions/spark/aggregate.rst
+++ b/velox/docs/functions/spark/aggregate.rst
@@ -41,7 +41,7 @@ General Aggregate Functions
 
     A version of ``bloom_filter_agg`` that uses ``numBits`` computed as ``estimatedNumItems`` * 8.
 
-    ``hash`` cannot be null.
+    ``hash`` can be null.
     ``estimatedNumItems`` provides an estimate of the number of values of ``x`` under the fact of ``hash`` is xxhash64(x).
     Value of ``estimatedNumItems`` is capped at 4,000,000 like to match Spark's implementation.
     But Spark allows for changing the defaults while Velox does not.
@@ -50,7 +50,7 @@ General Aggregate Functions
     
     A version of ``bloom_filter_agg`` that use the value of spark.bloom_filter.max_num_bits configuration property as ``numBits``.
 
-    ``hash`` cannot be null.
+    ``hash`` can be null.
 
 .. spark:function:: collect_list(x) -> array<[same as x]>
 

--- a/velox/docs/functions/spark/aggregate.rst
+++ b/velox/docs/functions/spark/aggregate.rst
@@ -30,7 +30,7 @@ General Aggregate Functions
     In Spark implementation, ``estimatedNumItems`` and ``numBits`` are used to decide the number of hash functions and bloom filter capacity.
     In Velox implementation, ``estimatedNumItems`` is not used.
 
-    ``hash`` cannot be null.
+    ``hash`` can be null.
     ``numBits`` specifies max capacity of the bloom filter, which allows to trade accuracy for memory.
     In Spark, the value of ``numBits`` is automatically capped at config value 67,108,864.
     In Velox, the value of ``numBits`` is automatically capped at the value of spark.bloom_filter.max_num_bits configuration property.

--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
@@ -96,14 +96,6 @@ class BloomFilterAggAggregate : public exec::Aggregate {
     rows.applyToSelected([&](vector_size_t row) { insert(groups, row); });
   }
 
-  void insert(char** groups, vector_size_t row) {
-    auto group = groups[row];
-    auto tracker = trackRowSize(group);
-    auto accumulator = value<BloomFilterAccumulator>(group);
-    accumulator->init(capacity_);
-    accumulator->insert(decodedRaw_.valueAt<int64_t>(row));
-  }
-
   void addIntermediateResults(
       char** groups,
       const SelectivityVector& rows,
@@ -234,6 +226,14 @@ class BloomFilterAggAggregate : public exec::Aggregate {
       estimatedNumItems_ = defaultExpectedNumItems_;
       numBits_ = defaultNumBits_;
     }
+  }
+
+  void insert(char** groups, vector_size_t row) {
+    auto group = groups[row];
+    auto tracker = trackRowSize(group);
+    auto accumulator = value<BloomFilterAccumulator>(group);
+    accumulator->init(capacity_);
+    accumulator->insert(decodedRaw_.valueAt<int64_t>(row));
   }
 
   void computeCapacity() {

--- a/velox/functions/sparksql/aggregates/tests/BloomFilterAggAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/BloomFilterAggAggregateTest.cpp
@@ -71,14 +71,12 @@ TEST_F(BloomFilterAggAggregateTest, emptyInput) {
   testAggregations(vectors, {}, {"bloom_filter_agg(c0, 5, 64)"}, expected);
 }
 
-TEST_F(BloomFilterAggAggregateTest, nullBloomFilter) {
-  auto vectors = {makeRowVector({makeAllNullFlatVector<int64_t>(2)})};
-  auto expectedFake = {makeRowVector(
-      {makeNullableFlatVector<StringView>({std::nullopt}, VARBINARY())})};
-  VELOX_ASSERT_THROW(
-      testAggregations(
-          vectors, {}, {"bloom_filter_agg(c0, 5, 64)"}, expectedFake),
-      "First argument of bloom_filter_agg cannot be null");
+TEST_F(BloomFilterAggAggregateTest, nullInput) {
+  auto vectors = {makeRowVector(
+      {makeFlatVector<int64_t>(100, [](vector_size_t row) { return row % 9; }),
+       makeAllNullFlatVector<int64_t>(1)})};
+  auto expected = {makeRowVector({getSerializedBloomFilter(4)})};
+  testAggregations(vectors, {}, {"bloom_filter_agg(c0, 5, 64)"}, expected);
 }
 
 TEST_F(BloomFilterAggAggregateTest, config) {


### PR DESCRIPTION
Currently, the velox BloomFilterAggregate checks the input row and throws an exception if there are some null values in the row. So we need to be consistent with spark's behavior and ignore null values.

The spark  BloomFilterAggregate will Ignore null values. https://github.com/apache/spark/blob/6cdca10f148433664b3e2be6f655b0ddba817537/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/BloomFilterAggregate.scala#L180-L188 
```
 override def update(buffer: BloomFilter, inputRow: InternalRow): BloomFilter = {
    val value = child.eval(inputRow)
    // Ignore null values.
    if (value == null) {
      return buffer
    }
    updater.update(buffer, value)
    buffer
  }
```

The unittest:
```scala
class VeloxBloomFilteAggregateFunctionsSuite extends VeloxWholeStageTransformerSuite {
  val funcId_bloom_filter_agg = new FunctionIdentifier("bloom_filter_agg")
  override protected val backend: String = "velox"
  override protected val resourcePath: String = "/tpch-data-parquet-velox"
  override protected val fileFormat: String = "parquet"
  val table = "bloomTable"

  protected def registerFunAndcCreatTable(): Unit ={
    val funcId_bloom_filter_agg = new FunctionIdentifier("bloom_filter_agg")
    // Register 'bloom_filter_agg'
    spark.sessionState.functionRegistry.registerFunction(funcId_bloom_filter_agg,
      new ExpressionInfo(classOf[BloomFilterAggregate].getName, "bloom_filter_agg"),
      (children: Seq[Expression]) => children.size match {
        case 1 => new BloomFilterAggregate(children.head)
        case 2 => new BloomFilterAggregate(children.head, children(1))
        case 3 => new BloomFilterAggregate(children.head, children(1), children(2))
      })
    val schema2 = new StructType().add("a2", IntegerType, nullable = true)
      .add("b2", LongType, nullable = true)
      .add("c2", IntegerType, nullable = true)
      .add("d2", IntegerType, nullable = true)
      .add("e2", IntegerType, nullable = true)
      .add("f2", IntegerType, nullable = true)
    val data2 = Seq(Seq(67, 17L, 45, 91, null, null),
      Seq(98, 63L, 0, 89, null, 40),
      Seq(null, null, 68, 75, 20, 19))
    val rdd2 = spark.sparkContext.parallelize(data2)
    val rddRow2 = rdd2.map(s => Row.fromSeq(s))
    spark.createDataFrame(rddRow2, schema2).write.saveAsTable(table)
  }

  protected def dropFunctionAndTable(): Unit ={
    spark.sessionState.functionRegistry.dropFunction(funcId_bloom_filter_agg)
    spark.sql(s"DROP TABLE IF EXISTS $table")
  }

  override def beforeAll(): Unit = {
    super.beforeAll()
    registerFunAndcCreatTable()
  }
  override def afterAll(): Unit = {
    dropFunctionAndTable()
    super.afterAll()
  }

  test("Test bloom_filter_agg with Nulls input") {
    spark.sql(
      s"""
       SELECT  bloom_filter_agg(b2) from $table
         """.stripMargin).show
  }
```