### PR TITLE
Add options for disable DirectBufferedInput

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -167,6 +167,11 @@ int32_t HiveConfig::numCacheFileHandles(const Config* config) {
 }
 
 // static.
+int32_t HiveConfig::isUseDirectBufferedInput(const Config* config) {
+  return config->get<bool>(KUseDirectBufferedInput, true);
+}
+
+// static.
 bool HiveConfig::isFileHandleCacheEnabled(const Config* config) {
   return config->get<bool>(kEnableFileHandleCache, true);
 }

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -108,7 +108,8 @@ class HiveConfig {
   static constexpr const char* kNumCacheFileHandles = "num_cached_file_handles";
 
   /// Maximum number of entries in the file handle cache.
-  static constexpr const char* KUseDirectBufferedInput = "direct_buffered_input_used";
+  static constexpr const char* KUseDirectBufferedInput =
+      "direct_buffered_input_used";
 
   /// Enable file handle cache.
   static constexpr const char* kEnableFileHandleCache =

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -107,6 +107,9 @@ class HiveConfig {
   /// Maximum number of entries in the file handle cache.
   static constexpr const char* kNumCacheFileHandles = "num_cached_file_handles";
 
+  /// Maximum number of entries in the file handle cache.
+  static constexpr const char* KUseDirectBufferedInput = "direct_buffered_input_used";
+
   /// Enable file handle cache.
   static constexpr const char* kEnableFileHandleCache =
       "file_handle_cache_enabled";
@@ -167,6 +170,8 @@ class HiveConfig {
   static int32_t maxCoalescedDistanceBytes(const Config* config);
 
   static int32_t numCacheFileHandles(const Config* config);
+
+  static int32_t isUseDirectBufferedInput(const Config* config);
 
   static bool isFileHandleCacheEnabled(const Config* config);
 

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -107,7 +107,7 @@ class HiveConfig {
   /// Maximum number of entries in the file handle cache.
   static constexpr const char* kNumCacheFileHandles = "num_cached_file_handles";
 
-  /// Maximum number of entries in the file handle cache.
+  /// Use DirectBufferedInput, selective BufferedInput without cache.
   static constexpr const char* KUseDirectBufferedInput =
       "direct_buffered_input_used";
 

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -97,6 +97,8 @@ std::unique_ptr<DataSource> HiveConnector::createDataSource(
           connectorQueryCtx->config()));
   options.setUseColumnNamesForColumnMapping(
       HiveConfig::isOrcUseColumnNames(connectorQueryCtx->config()));
+  options.setUseDirectBufferedInput(
+      HiveConfig::isUseDirectBufferedInput(connectorQueryCtx->config()));
 
   return std::make_unique<HiveDataSource>(
       outputType,

--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -808,15 +808,22 @@ HiveDataSource::createBufferedInput(
         executor_,
         readerOpts);
   }
-  return std::make_unique<dwio::common::DirectBufferedInput>(
+  if (readerOpts.isUseDirectBufferedInput()) {
+    return std::make_unique<dwio::common::DirectBufferedInput>(
+        fileHandle.file,
+        dwio::common::MetricsLog::voidLog(),
+        fileHandle.uuid.id(),
+        Connector::getTracker(scanId_, readerOpts.loadQuantum()),
+        fileHandle.groupId.id(),
+        ioStats_,
+        executor_,
+        readerOpts);
+  }
+  return std::make_unique<dwio::common::BufferedInput>(
       fileHandle.file,
+      readerOpts.getMemoryPool(),
       dwio::common::MetricsLog::voidLog(),
-      fileHandle.uuid.id(),
-      Connector::getTracker(scanId_, readerOpts.loadQuantum()),
-      fileHandle.groupId.id(),
-      ioStats_,
-      executor_,
-      readerOpts);
+      ioStats_.get());
 }
 
 vector_size_t HiveDataSource::evaluateRemainingFilter(RowVectorPtr& rowVector) {

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -379,6 +379,7 @@ class ReaderOptions : public io::ReaderOptions {
   uint64_t filePreloadThreshold{kDefaultFilePreloadThreshold};
   bool fileColumnNamesReadAsLowerCase{false};
   bool useColumnNamesForColumnMapping_{false};
+  bool useDirectBufferedInput_{true};
   std::shared_ptr<folly::Executor> ioExecutor_;
 
  public:
@@ -485,6 +486,11 @@ class ReaderOptions : public io::ReaderOptions {
     return *this;
   }
 
+  ReaderOptions& setUseDirectBufferedInput(bool flag) {
+    useDirectBufferedInput_ = flag;
+    return *this;
+  }
+
   ReaderOptions& setIOExecutor(std::shared_ptr<folly::Executor> executor) {
     ioExecutor_ = std::move(executor);
     return *this;
@@ -543,6 +549,10 @@ class ReaderOptions : public io::ReaderOptions {
 
   bool isUseColumnNamesForColumnMapping() const {
     return useColumnNamesForColumnMapping_;
+  }
+
+  bool isUseDirectBufferedInput() const {
+    return useDirectBufferedInput_;
   }
 };
 


### PR DESCRIPTION
Add `direct_buffered_input_used` HiveConfig to enable DirectBufferedInput for HiveDataSource, default is true.

Fixes: #7535 