### PR TITLE
Enable `enable_dereference` flag for spark_expression_fuzzer_test

### DIFF
--- a/.circleci/dist_compile.yml
+++ b/.circleci/dist_compile.yml
@@ -302,6 +302,7 @@ jobs:
                 --velox_fuzzer_enable_expression_reuse \
                 --max_expression_trees_per_step 2 \
                 --retry_with_try \
+                --enable_dereference \
                 --logtostderr=1 \
                 --minloglevel=0 \
                 --repro_persist_path=/tmp/spark_fuzzer_repro \

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -109,6 +109,7 @@ jobs:
                 --velox_fuzzer_enable_expression_reuse \
                 --max_expression_trees_per_step 2 \
                 --retry_with_try \
+                --enable_dereference \
                 --duration_sec 1800 \
                 --logtostderr=1 \
                 --minloglevel=0 \

--- a/velox/expression/RowConstructor.h
+++ b/velox/expression/RowConstructor.h
@@ -30,13 +30,5 @@ class RowConstructorCallToSpecialForm : public FunctionCallToSpecialForm {
       const core::QueryConfig& config) override;
 
   static constexpr const char* kRowConstructor = "row_constructor";
-
- protected:
-  ExprPtr constructSpecialForm(
-      const std::string& name,
-      const TypePtr& type,
-      std::vector<ExprPtr>&& compiledChildren,
-      bool trackCpuUsage,
-      const core::QueryConfig& config);
 };
 } // namespace facebook::velox::exec

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -16,6 +16,7 @@
 #include "velox/functions/sparksql/Register.h"
 
 #include "velox/expression/RegisterSpecialForm.h"
+#include "velox/expression/RowConstructor.h"
 #include "velox/expression/SpecialFormRegistry.h"
 #include "velox/functions/lib/IsNull.h"
 #include "velox/functions/lib/Re2Functions.h"
@@ -66,6 +67,8 @@ static void workAroundRegistrationMacro(const std::string& prefix) {
 
   VELOX_REGISTER_VECTOR_FUNCTION(
       udf_map_allow_duplicates, prefix + "map_from_arrays");
+  VELOX_REGISTER_VECTOR_FUNCTION(
+      udf_concat_row, exec::RowConstructorCallToSpecialForm::kRowConstructor);
   // String functions.
   VELOX_REGISTER_VECTOR_FUNCTION(udf_concat, prefix + "concat");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_lower, prefix + "lower");

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -350,6 +350,9 @@ TEST_F(BinTest, bin) {
       bin(std::numeric_limits<int64_t>::max()),
       "111111111111111111111111111111111111111111111111111111111111111");
   EXPECT_EQ(bin(0), "0");
+  auto result = evaluateOnce<std::string, int64_t>(
+      "bin(row_constructor(c0).c1)", {13}, {BIGINT()});
+  EXPECT_EQ(result, "1101");
 }
 
 TEST_F(ArithmeticTest, hypot) {


### PR DESCRIPTION
Function `row_constructor` was only registered in Presto functions.
In `RowConstructorCallToSpecialForm::constructSpecialForm`, no registration
was found from function map due to the lack of registration in Spark functions. 
Error occurs when accessing an invalid iterator. To fix this issue, this PR 
registers `row_constructor` in Spark functions.
With this fix, `enable_dereference` flag can be enabled for
spark_expression_fuzzer_test.
https://github.com/facebookincubator/velox/issues/5967