### PR TITLE
Remove the spilling after memory reservation fails in ensureOutputFits

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -931,7 +931,11 @@ void GroupingSet::ensureOutputFits() {
       return;
     }
   }
-  spill(RowContainerIterator{});
+  LOG(WARNING) << "Failed to reserve "
+               << succinctBytes(outputBufferSizeToReserve)
+               << " for memory pool " << pool_.name()
+               << ", usage: " << succinctBytes(pool_.currentBytes())
+               << ", reservation: " << succinctBytes(pool_.reservedBytes());
 }
 
 RowTypePtr GroupingSet::makeSpillType() const {


### PR DESCRIPTION
Remove the unnecessary spilling in GroupingSet::ensureOutputFits
to keep the implementation simple.
This is a follow-up of #7846 