### PR TITLE
Back out "Add support for decimals in approx_distinct aggregate function"

### DIFF
--- a/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
@@ -437,7 +437,6 @@ exec::AggregateRegistrationResult registerApproxDistinct(
           "smallint",
           "integer",
           "bigint",
-          "hugeint",
           "real",
           "double",
           "varchar",
@@ -456,21 +455,6 @@ exec::AggregateRegistrationResult registerApproxDistinct(
                                .argumentType("double")
                                .build());
     }
-    signatures.push_back(exec::AggregateFunctionSignatureBuilder()
-                             .typeVariable("a_precision")
-                             .typeVariable("a_scale")
-                             .returnType(returnType)
-                             .intermediateType("varbinary")
-                             .argumentType("DECIMAL(a_precision, a_scale)")
-                             .build());
-    signatures.push_back(exec::AggregateFunctionSignatureBuilder()
-                             .typeVariable("a_precision")
-                             .typeVariable("a_scale")
-                             .returnType(returnType)
-                             .intermediateType("varbinary")
-                             .argumentType("DECIMAL(a_precision, a_scale)")
-                             .argumentType("double")
-                             .build());
   }
 
   return exec::registerAggregateFunction(

--- a/velox/functions/prestosql/aggregates/tests/ApproxDistinctTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxDistinctTest.cpp
@@ -32,8 +32,7 @@ class ApproxDistinctTest : public AggregationTestBase {
   void testGlobalAgg(
       const VectorPtr& values,
       double maxStandardError,
-      int64_t expectedResult,
-      bool testWithTableScan = true) {
+      int64_t expectedResult) {
     auto vectors = makeRowVector({values});
     auto expected =
         makeRowVector({makeNullableFlatVector<int64_t>({expectedResult})});
@@ -42,9 +41,7 @@ class ApproxDistinctTest : public AggregationTestBase {
         {vectors},
         {},
         {fmt::format("approx_distinct(c0, {})", maxStandardError)},
-        {expected},
-        {},
-        testWithTableScan);
+        {expected});
     testAggregationsWithCompanion(
         {vectors},
         [](auto& /*builder*/) {},
@@ -59,26 +56,15 @@ class ApproxDistinctTest : public AggregationTestBase {
         {},
         {fmt::format("approx_set(c0, {})", maxStandardError)},
         {"cardinality(a0)"},
-        {expected},
-        {},
-        testWithTableScan);
+        {expected});
   }
 
-  void testGlobalAgg(
-      const VectorPtr& values,
-      int64_t expectedResult,
-      bool testWithTableScan = true) {
+  void testGlobalAgg(const VectorPtr& values, int64_t expectedResult) {
     auto vectors = makeRowVector({values});
     auto expected =
         makeRowVector({makeNullableFlatVector<int64_t>({expectedResult})});
 
-    testAggregations(
-        {vectors},
-        {},
-        {"approx_distinct(c0)"},
-        {expected},
-        {},
-        testWithTableScan);
+    testAggregations({vectors}, {}, {"approx_distinct(c0)"}, {expected});
     testAggregationsWithCompanion(
         {vectors},
         [](auto& /*builder*/) {},
@@ -89,13 +75,7 @@ class ApproxDistinctTest : public AggregationTestBase {
         {expected});
 
     testAggregations(
-        {vectors},
-        {},
-        {"approx_set(c0)"},
-        {"cardinality(a0)"},
-        {expected},
-        {},
-        testWithTableScan);
+        {vectors}, {}, {"approx_set(c0)"}, {"cardinality(a0)"}, {expected});
   }
 
   template <typename T, typename U>
@@ -322,19 +302,6 @@ TEST_F(ApproxDistinctTest, globalAggAllNulls) {
            .project({"cardinality(a0)"})
            .planNode();
   EXPECT_TRUE(readSingleValue(op).isNull());
-}
-
-TEST_F(ApproxDistinctTest, hugeInt) {
-  auto hugeIntValues =
-      makeFlatVector<int128_t>(50000, [](auto row) { return row; });
-  // Last param is set false to disable tablescan test
-  // as DWRF writer doesn't have hugeint support.
-  // Refer:https://github.com/facebookincubator/velox/issues/7775
-  testGlobalAgg(hugeIntValues, 49669, false);
-  testGlobalAgg(
-      hugeIntValues, common::hll::kLowestMaxStandardError, 50110, false);
-  testGlobalAgg(
-      hugeIntValues, common::hll::kHighestMaxStandardError, 41741, false);
 }
 
 TEST_F(ApproxDistinctTest, streaming) {


### PR DESCRIPTION
Summary:
Original commit changeset: 7b9cead380c5

Original Phabricator Diff: D51811791

Aggregate fuzzer is not able to resolve decimal types, back it out to unbreak the test

Differential Revision: D51863784


