### PR TITLE
Fix HashStringAllocator::free for mixed multipart allocations

### DIFF
--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -408,13 +408,6 @@ HashStringAllocator::allocateFromFreeList(
 
 void HashStringAllocator::free(Header* _header) {
   Header* header = _header;
-  if (header->size() > kMaxAlloc && !pool_.isInCurrentRange(header) &&
-      allocationsFromPool_.find(header) != allocationsFromPool_.end()) {
-    // A large free can either be a rest of block or a standalone allocation.
-    VELOX_CHECK(!header->isContinued());
-    freeToPool(header, header->size() + sizeof(Header));
-    return;
-  }
 
   do {
     Header* continued = nullptr;
@@ -422,36 +415,41 @@ void HashStringAllocator::free(Header* _header) {
       continued = header->nextContinued();
       header->clearContinued();
     }
-    VELOX_CHECK(!header->isFree());
-    freeBytes_ += header->size() + sizeof(Header);
-    cumulativeBytes_ -= header->size();
-    Header* next = header->next();
-    if (next) {
-      VELOX_CHECK(!next->isPreviousFree());
-      if (next->isFree()) {
-        --numFree_;
-        removeFromFreeList(next);
-        header->setSize(header->size() + next->size() + sizeof(Header));
-        next = reinterpret_cast<Header*>(header->end());
-        VELOX_CHECK(next->isArenaEnd() || !next->isFree());
-      }
-    }
-    if (header->isPreviousFree()) {
-      auto previousFree = getPreviousFree(header);
-      removeFromFreeList(previousFree);
-      previousFree->setSize(
-          previousFree->size() + header->size() + sizeof(Header));
-
-      header = previousFree;
+    if (header->size() > kMaxAlloc && !pool_.isInCurrentRange(header) &&
+        allocationsFromPool_.find(header) != allocationsFromPool_.end()) {
+      freeToPool(header, header->size() + sizeof(Header));
     } else {
-      ++numFree_;
+      VELOX_CHECK(!header->isFree());
+      freeBytes_ += header->size() + sizeof(Header);
+      cumulativeBytes_ -= header->size();
+      Header* next = header->next();
+      if (next) {
+        VELOX_CHECK(!next->isPreviousFree());
+        if (next->isFree()) {
+          --numFree_;
+          removeFromFreeList(next);
+          header->setSize(header->size() + next->size() + sizeof(Header));
+          next = reinterpret_cast<Header*>(header->end());
+          VELOX_CHECK(next->isArenaEnd() || !next->isFree());
+        }
+      }
+      if (header->isPreviousFree()) {
+        auto previousFree = getPreviousFree(header);
+        removeFromFreeList(previousFree);
+        previousFree->setSize(
+            previousFree->size() + header->size() + sizeof(Header));
+
+        header = previousFree;
+      } else {
+        ++numFree_;
+      }
+      auto freedSize = header->size();
+      auto freeIndex = freeListIndex(freedSize);
+      bits::setBit(freeNonEmpty_, freeIndex);
+      free_[freeIndex].insert(
+          reinterpret_cast<CompactDoubleList*>(header->begin()));
+      markAsFree(header);
     }
-    auto freedSize = header->size();
-    auto freeIndex = freeListIndex(freedSize);
-    bits::setBit(freeNonEmpty_, freeIndex);
-    free_[freeIndex].insert(
-        reinterpret_cast<CompactDoubleList*>(header->begin()));
-    markAsFree(header);
     header = continued;
   } while (header);
 }

--- a/velox/common/memory/tests/HashStringAllocatorTest.cpp
+++ b/velox/common/memory/tests/HashStringAllocatorTest.cpp
@@ -285,6 +285,37 @@ TEST_F(HashStringAllocatorTest, multipart) {
   allocator_->checkConsistency();
 }
 
+TEST_F(HashStringAllocatorTest, mixedMultipart) {
+  // Create multi-part allocation with a mix of block allocated from Arena and
+  // MemoryPool.
+
+  const std::string shortString(25, 'x');
+  const std::string extraLongString(5'000, 'y');
+
+  ByteStream stream(allocator_.get());
+
+  auto start = allocator_->newWrite(stream);
+  stream.appendStringView(shortString);
+  auto current = allocator_->finishWrite(stream, 0);
+
+  allocator_->extendWrite(current.second, stream);
+
+  ByteRange range;
+  allocator_->newContiguousRange(extraLongString.size(), &range);
+  stream.setRange(range, 0);
+
+  stream.appendStringView(extraLongString);
+  current = allocator_->finishWrite(stream, 0);
+
+  allocator_->extendWrite(current.second, stream);
+  stream.appendStringView(shortString);
+  allocator_->finishWrite(stream, 0);
+
+  allocator_->free(start.header);
+
+  allocator_->checkConsistency();
+}
+
 TEST_F(HashStringAllocatorTest, rewrite) {
   ByteStream stream(allocator_.get());
   auto header = allocator_->allocate(5);

--- a/velox/exec/tests/utils/AggregationFuzzer.cpp
+++ b/velox/exec/tests/utils/AggregationFuzzer.cpp
@@ -182,7 +182,7 @@ class AggregationFuzzer {
     VectorFuzzer::Options opts;
     opts.vectorSize = FLAGS_batch_size;
     opts.stringVariableLength = true;
-    opts.stringLength = 100;
+    opts.stringLength = 4'000;
     opts.nullRatio = FLAGS_null_ratio;
     opts.timestampPrecision = timestampPrecision;
     return opts;


### PR DESCRIPTION
A multipart allocation max contain a mix of blocks allocated from the Arena and
MemoryPool. 

Blocks allocated from MemoryPool should be released back to MemoryPool. Blocks
allocated from Arena should be added to the free list.

For blocks allocated from MemoryPool, Header::next is not valid and therefore
should not be used. These Blocks should never be marked free or having previous
free. These blocks can be standalone or have a continuation.

Configure AggregationFuzzer to generate large strings to trigger code paths that 
allocate blocks from MemoryPool.

Fixes #7892.