### PR TITLE
Allow marking an argument as constant in the simple function API

### DIFF
--- a/velox/expression/tests/SimpleFunctionInitTest.cpp
+++ b/velox/expression/tests/SimpleFunctionInitTest.cpp
@@ -85,7 +85,7 @@ TEST_F(SimpleFunctionInitTest, initializationArray) {
       NonDefaultWithArrayInitFunction,
       Array<int32_t>,
       int32_t,
-      Constant<Array<int32_t>>>({"non_default_behavior_with_init"});
+      Array<int32_t>>({"non_default_behavior_with_init"});
 
   auto testFn =
       [&](const std::optional<int32_t>& first,
@@ -166,7 +166,7 @@ TEST_F(SimpleFunctionInitTest, initializationMap) {
       NonDefaultWithMapInitFunction,
       int64_t,
       int32_t,
-      Constant<Map<int32_t, int64_t>>>({"non_default_behavior_with_map_init"});
+      Map<int32_t, int64_t>>({"non_default_behavior_with_map_init"});
 
   auto mapVectorPtr = makeMapVector<int32_t, int64_t>(
       1,

--- a/velox/expression/tests/SimpleFunctionInitTest.cpp
+++ b/velox/expression/tests/SimpleFunctionInitTest.cpp
@@ -85,7 +85,7 @@ TEST_F(SimpleFunctionInitTest, initializationArray) {
       NonDefaultWithArrayInitFunction,
       Array<int32_t>,
       int32_t,
-      Array<int32_t>>({"non_default_behavior_with_init"});
+      Constant<Array<int32_t>>>({"non_default_behavior_with_init"});
 
   auto testFn =
       [&](const std::optional<int32_t>& first,
@@ -166,7 +166,7 @@ TEST_F(SimpleFunctionInitTest, initializationMap) {
       NonDefaultWithMapInitFunction,
       int64_t,
       int32_t,
-      Map<int32_t, int64_t>>({"non_default_behavior_with_map_init"});
+      Constant<Map<int32_t, int64_t>>>({"non_default_behavior_with_map_init"});
 
   auto mapVectorPtr = makeMapVector<int32_t, int64_t>(
       1,

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -1243,7 +1243,6 @@ TEST_F(SimpleFunctionTest, flatNoNullsPathCallNullFree) {
   testCallNullFreeSupportFlatNotNulls<Varchar, Varchar>(false, false);
 }
 
-namespace {
 template <typename T>
 struct ConstantArgumentFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
@@ -1251,22 +1250,24 @@ struct ConstantArgumentFunction {
   void initialize(
       const core::QueryConfig& /*config*/,
       const arg_type<int32_t>* /*first*/,
-      const arg_type<int32_t>* second,
-      const arg_type<Varchar>* third,
-      const arg_type<Generic<T1>>* fourth) {}
+      const arg_type<int32_t>* /*second*/,
+      const arg_type<Varchar>* /*third*/,
+      const arg_type<Generic<T1>>* /*fourth*/,
+      const arg_type<Array<int32_t>>* /*fifth*/,
+      const arg_type<Map<int32_t, int32_t>>* /*sixth*/) {}
 
   bool callNullable(
       out_type<int64_t>& out,
-      const arg_type<int32_t>* first,
+      const arg_type<int32_t>* /*first*/,
       const arg_type<int32_t>* /*second*/,
       const arg_type<Varchar>* /*third*/,
-      const arg_type<Generic<T1>>* /*fourth*/) {
-    out = 0;
+      const arg_type<Generic<T1>>* /*fourth*/,
+      const arg_type<Array<int32_t>>* /*fifth*/,
+      const arg_type<Map<int32_t, int32_t>>* /*sixth*/) {
+    out = 1;
     return true;
   }
 };
-
-} // namespace
 
 TEST_F(SimpleFunctionTest, constantArgument) {
   registerFunction<
@@ -1275,12 +1276,16 @@ TEST_F(SimpleFunctionTest, constantArgument) {
       int32_t,
       Constant<int32_t>,
       Constant<Varchar>,
-      Constant<Generic<T1>>>({"constant_argument_function"});
+      Constant<Generic<T1>>,
+      Constant<Array<int32_t>>,
+      Constant<Map<int32_t, int32_t>>>({"constant_argument_function"});
   auto signatures = exec::simpleFunctions().getFunctionSignatures(
       "constant_argument_function");
   EXPECT_FALSE(signatures[0]->constantArguments().at(0));
   EXPECT_TRUE(signatures[0]->constantArguments().at(1));
   EXPECT_TRUE(signatures[0]->constantArguments().at(2));
   EXPECT_TRUE(signatures[0]->constantArguments().at(3));
+  EXPECT_TRUE(signatures[0]->constantArguments().at(4));
+  EXPECT_TRUE(signatures[0]->constantArguments().at(5));
 }
 } // namespace

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -76,12 +76,14 @@ class SimpleFunctionTest : public functions::test::FunctionBaseTest {
         CallNullFreeFuncVoidOut<exec::VectorExec>,
         exec::VectorExec,
         int32_t,
-        TArgs...>;
+        ConstantChecker<TArgs...>,
+        typename UnwrapConstant<TArgs>::type...>;
     using holderClassBool = core::UDFHolder<
         CallNullFreeFuncBoolOut<exec::VectorExec>,
         exec::VectorExec,
         int32_t,
-        TArgs...>;
+        ConstantChecker<TArgs...>,
+        typename UnwrapConstant<TArgs>::type...>;
     if (voidOutput) {
       ASSERT_EQ(
           expected,
@@ -1104,6 +1106,7 @@ TEST_F(SimpleFunctionTest, isAsciiArgs) {
       StringInputFunction<exec::VectorExec>,
       exec::VectorExec,
       int32_t,
+      ConstantChecker<Varchar>,
       Varchar>;
   using function_t = exec::SimpleFunctionAdapter<holder_class_t>;
 
@@ -1238,5 +1241,46 @@ TEST_F(SimpleFunctionTest, flatNoNullsPathCallNullFree) {
   testCallNullFreeSupportFlatNotNulls<int32_t>(false, false);
   testCallNullFreeSupportFlatNotNulls<int64_t, int64_t>(false, false);
   testCallNullFreeSupportFlatNotNulls<Varchar, Varchar>(false, false);
+}
+
+namespace {
+template <typename T>
+struct ConstantArgumentFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  void initialize(
+      const core::QueryConfig& /*config*/,
+      const arg_type<int32_t>* /*first*/,
+      const arg_type<int32_t>* second,
+      const arg_type<Varchar>* third,
+      const arg_type<Generic<T1>>* fourth) {}
+
+  bool callNullable(
+      out_type<int64_t>& out,
+      const arg_type<int32_t>* first,
+      const arg_type<int32_t>* /*second*/,
+      const arg_type<Varchar>* /*third*/,
+      const arg_type<Generic<T1>>* /*fourth*/) {
+    out = 0;
+    return true;
+  }
+};
+
+} // namespace
+
+TEST_F(SimpleFunctionTest, constantArgument) {
+  registerFunction<
+      ConstantArgumentFunction,
+      int64_t,
+      int32_t,
+      Constant<int32_t>,
+      Constant<Varchar>,
+      Constant<Generic<T1>>>({"constant_argument_function"});
+  auto signatures = exec::simpleFunctions().getFunctionSignatures(
+      "constant_argument_function");
+  EXPECT_FALSE(signatures[0]->constantArguments().at(0));
+  EXPECT_TRUE(signatures[0]->constantArguments().at(1));
+  EXPECT_TRUE(signatures[0]->constantArguments().at(2));
+  EXPECT_TRUE(signatures[0]->constantArguments().at(3));
 }
 } // namespace

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -77,13 +77,13 @@ class SimpleFunctionTest : public functions::test::FunctionBaseTest {
         exec::VectorExec,
         int32_t,
         ConstantChecker<TArgs...>,
-        typename UnwrapConstant<TArgs>::type...>;
+        typename UnwrapConstantType<TArgs>::type...>;
     using holderClassBool = core::UDFHolder<
         CallNullFreeFuncBoolOut<exec::VectorExec>,
         exec::VectorExec,
         int32_t,
         ConstantChecker<TArgs...>,
-        typename UnwrapConstant<TArgs>::type...>;
+        typename UnwrapConstantType<TArgs>::type...>;
     if (voidOutput) {
       ASSERT_EQ(
           expected,

--- a/velox/functions/Registerer.h
+++ b/velox/functions/Registerer.h
@@ -42,7 +42,7 @@ void registerFunction(const std::vector<std::string>& aliases = {}) {
       exec::VectorExec,
       TReturn,
       ConstantChecker<TArgs...>,
-      typename UnwrapConstant<TArgs>::type...>;
+      typename UnwrapConstantType<TArgs>::type...>;
   exec::registerSimpleFunction<holderClass>(aliases);
 }
 
@@ -58,7 +58,7 @@ void registerFunction(const std::vector<std::string>& aliases = {}) {
       exec::VectorExec,
       TReturn,
       ConstantChecker<TArgs...>,
-      typename UnwrapConstant<TArgs>::type...>;
+      typename UnwrapConstantType<TArgs>::type...>;
   exec::registerSimpleFunction<holderClass>(aliases);
 }
 

--- a/velox/functions/Registerer.h
+++ b/velox/functions/Registerer.h
@@ -37,8 +37,12 @@ using ParameterBinder = TempWrapper<T<exec::VectorExec, TArgs...>>;
 template <typename Func, typename TReturn, typename... TArgs>
 void registerFunction(const std::vector<std::string>& aliases = {}) {
   using funcClass = typename Func::template udf<exec::VectorExec>;
-  using holderClass =
-      core::UDFHolder<funcClass, exec::VectorExec, TReturn, TArgs...>;
+  using holderClass = core::UDFHolder<
+      funcClass,
+      exec::VectorExec,
+      TReturn,
+      ConstantChecker<TArgs...>,
+      typename UnwrapConstant<TArgs>::type...>;
   exec::registerSimpleFunction<holderClass>(aliases);
 }
 
@@ -49,8 +53,12 @@ void registerFunction(const std::vector<std::string>& aliases = {}) {
 template <template <class> typename Func, typename TReturn, typename... TArgs>
 void registerFunction(const std::vector<std::string>& aliases = {}) {
   using funcClass = Func<exec::VectorExec>;
-  using holderClass =
-      core::UDFHolder<funcClass, exec::VectorExec, TReturn, TArgs...>;
+  using holderClass = core::UDFHolder<
+      funcClass,
+      exec::VectorExec,
+      TReturn,
+      ConstantChecker<TArgs...>,
+      typename UnwrapConstant<TArgs>::type...>;
   exec::registerSimpleFunction<holderClass>(aliases);
 }
 

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1873,6 +1873,35 @@ struct Varchar {
 };
 
 template <typename T>
+struct Constant {};
+
+template <typename T>
+struct UnwrapConstant {
+  using type = T;
+};
+
+template <typename T>
+struct UnwrapConstant<Constant<T>> {
+  using type = T;
+};
+
+template <typename T>
+struct isConstantType {
+  static constexpr bool value = false;
+};
+
+template <typename T>
+struct isConstantType<Constant<T>> {
+  static constexpr bool value = true;
+};
+
+template <typename... TArgs>
+struct ConstantChecker {
+  static constexpr bool isConstant[sizeof...(TArgs)] = {
+      isConstantType<TArgs>::value...};
+};
+
+template <typename T>
 struct SimpleTypeTrait {};
 
 template <>

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1876,12 +1876,12 @@ template <typename T>
 struct Constant {};
 
 template <typename T>
-struct UnwrapConstant {
+struct UnwrapConstantType {
   using type = T;
 };
 
 template <typename T>
-struct UnwrapConstant<Constant<T>> {
+struct UnwrapConstantType<Constant<T>> {
   using type = T;
 };
 


### PR DESCRIPTION
Fixes #7877