### PR TITLE
Fix function signature of approx_distinct(DECIMAL(a_precision,a_scale))

### DIFF
--- a/velox/exec/tests/utils/AggregationFuzzer.cpp
+++ b/velox/exec/tests/utils/AggregationFuzzer.cpp
@@ -484,7 +484,7 @@ AggregationFuzzer::AggregationFuzzer(
       if (!signature->variables().empty()) {
         bool skip = false;
         std::unordered_set<std::string> typeVariables;
-        for (auto& [name, variable] : signature->variables()) {
+        for (auto& [variableName, variable] : signature->variables()) {
           if (variable.isIntegerParameter()) {
             LOG(WARNING) << "Skipping generic function signature: " << name
                          << signature->toString();
@@ -492,7 +492,7 @@ AggregationFuzzer::AggregationFuzzer(
             break;
           }
 
-          typeVariables.insert(name);
+          typeVariables.insert(variableName);
         }
         if (skip) {
           continue;

--- a/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
@@ -437,6 +437,7 @@ exec::AggregateRegistrationResult registerApproxDistinct(
           "smallint",
           "integer",
           "bigint",
+          "hugeint",
           "real",
           "double",
           "varchar",
@@ -455,6 +456,21 @@ exec::AggregateRegistrationResult registerApproxDistinct(
                                .argumentType("double")
                                .build());
     }
+    signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                             .typeVariable("a_precision")
+                             .typeVariable("a_scale")
+                             .returnType(returnType)
+                             .intermediateType("varbinary")
+                             .argumentType("DECIMAL(a_precision, a_scale)")
+                             .build());
+    signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                             .typeVariable("a_precision")
+                             .typeVariable("a_scale")
+                             .returnType(returnType)
+                             .intermediateType("varbinary")
+                             .argumentType("DECIMAL(a_precision, a_scale)")
+                             .argumentType("double")
+                             .build());
   }
 
   return exec::registerAggregateFunction(

--- a/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
@@ -457,15 +457,15 @@ exec::AggregateRegistrationResult registerApproxDistinct(
                                .build());
     }
     signatures.push_back(exec::AggregateFunctionSignatureBuilder()
-                             .typeVariable("a_precision")
-                             .typeVariable("a_scale")
+                             .integerVariable("a_precision")
+                             .integerVariable("a_scale")
                              .returnType(returnType)
                              .intermediateType("varbinary")
                              .argumentType("DECIMAL(a_precision, a_scale)")
                              .build());
     signatures.push_back(exec::AggregateFunctionSignatureBuilder()
-                             .typeVariable("a_precision")
-                             .typeVariable("a_scale")
+                             .integerVariable("a_precision")
+                             .integerVariable("a_scale")
                              .returnType(returnType)
                              .intermediateType("varbinary")
                              .argumentType("DECIMAL(a_precision, a_scale)")


### PR DESCRIPTION
Summary:
Integer parameters of decimal type should be registered through .integerVariable() instead of 
.typeVariable() in function signatures. This is needed for aggregation fuzzer to skip these 
signatures because integer parameters are not supported in ArgumentTypeFuzzer yet. This 
diff fixes the function signature of approx_distinct(DECIMAL(a_precision,a_scale)) and 
approx_distinct(DECIMAL(a_precision,a_scale),double). This diff also fixes a small bug in 
AggregationFuzzer in the printing of skipped function signature names.

This diff fixes https://github.com/facebookincubator/velox/issues/7895.

Differential Revision: D51904043


