### PR TITLE
Fix PartitionedOutput with constant keys

### DIFF
--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -288,6 +288,9 @@ void PartitionedOutput::collectNullRows() {
   decodedVectors_.resize(keyChannels_.size());
 
   for (auto i : keyChannels_) {
+    if (i == kConstantChannel) {
+      continue;
+    }
     auto& keyVector = input_->childAt(i);
     if (keyVector->mayHaveNulls()) {
       decodedVectors_[i].decode(*keyVector, rows_);

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -1006,7 +1006,9 @@ class PlanBuilder {
   std::shared_ptr<const core::FieldAccessTypedExpr> field(
       const std::string& name);
 
-  std::vector<core::TypedExprPtr> exprs(const std::vector<std::string>& names);
+  std::vector<core::TypedExprPtr> exprs(
+      const std::vector<std::string>& expressions,
+      const RowTypePtr& inputType);
 
   std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>> fields(
       const std::vector<std::string>& names);


### PR DESCRIPTION
PartitionedOutput operator used to fail if some of the partitioning keys are constant.

```
VeloxRuntimeError: index < childrenSize_ (4294967295 vs. 1) Trying to access non-existing child in RowVector: [ROW ROW<foo_id:BIGINT>: 418 elements, no nulls]
...
	at Unknown.# 2  facebook::velox::RowVector::childAt(unsigned int)(Unknown Source)
	at Unknown.# 3  facebook::velox::exec::PartitionedOutput::collectNullRows()(Unknown Source)
```