### PR TITLE
Fix fuzz different output types for generated expression sets in expression fuzzer

### DIFF
--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -1009,10 +1009,9 @@ ExpressionFuzzer::FuzzedExpressionData ExpressionFuzzer::fuzzExpressions(
   VELOX_CHECK_EQ(
       state.remainingLevelOfNesting_, std::max(1, options_.maxLevelOfNesting));
 
-  auto outType = fuzzReturnType();
-
   std::vector<core::TypedExprPtr> expressions;
   for (int i = 0; i < numberOfExpressions; i++) {
+    auto outType = fuzzReturnType();
     expressions.push_back(generateExpression(outType));
   }
   return {


### PR DESCRIPTION
Summary:
A previous refactor resulted in a bug that makes all the fields of the fuzzed expression 
final output be of the same type. 

This fix it.

Differential Revision: D51926820


