### PR TITLE
Refactor struct Converter and reduce template parameters

### DIFF
--- a/velox/experimental/codegen/functions/CastFunctionStub.h
+++ b/velox/experimental/codegen/functions/CastFunctionStub.h
@@ -27,11 +27,16 @@ struct CodegenConversionStub {
 
   template <typename T>
   static ReturnType<T> cast(const T& arg) {
+    using CastPolicy = typename std::conditional<
+        castByTruncate,
+        util::TTruncateCastPolicy,
+        util::TDefaultCastPolicy>::type;
+
     if constexpr (std::is_same_v<codegen::TempString<TempsAllocator>, T>) {
-      return util::Converter<kind, void, castByTruncate>::cast(
+      return util::Converter<kind, void, CastPolicy>::cast(
           folly::StringPiece(arg.data(), arg.size()));
     } else {
-      return util::Converter<kind, void, castByTruncate>::cast(arg);
+      return util::Converter<kind, void, CastPolicy>::cast(arg);
     }
   }
 };

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -166,10 +166,11 @@ class CastExpr : public SpecialForm {
   /// The per-row level Kernel
   /// @tparam ToKind The cast target type
   /// @tparam FromKind The expression type
+  /// @tparam TPolicy The policy used by the cast
   /// @param row The index of the current row
   /// @param input The input vector (of type FromKind)
   /// @param result The output vector (of type ToKind)
-  template <TypeKind ToKind, TypeKind FromKind, bool Truncate, bool LegacyCast>
+  template <TypeKind ToKind, TypeKind FromKind, typename TPolicy>
   void applyCastKernel(
       vector_size_t row,
       EvalCtx& context,

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -33,10 +33,10 @@ void PrestoCastHooks::castTimestampToString(
     StringWriter<false>& out) const {
   out.copy_from(
       legacyCast_
-          ? util::Converter<TypeKind::VARCHAR, void, false, true>::cast(
-                timestamp)
-          : util::Converter<TypeKind::VARCHAR, void, false, false>::cast(
-                timestamp));
+          ? util::Converter<TypeKind::VARCHAR, void, util::LegacyCastPolicy>::
+                cast(timestamp)
+          : util::Converter<TypeKind::VARCHAR, void, util::DefaultCastPolicy>::
+                cast(timestamp));
   out.finalize();
 }
 

--- a/velox/functions/prestosql/ArrayFunctions.h
+++ b/velox/functions/prestosql/ArrayFunctions.h
@@ -206,7 +206,8 @@ struct ArrayJoinFunction {
   template <typename C>
   void writeValue(out_type<velox::Varchar>& result, const C& value) {
     result +=
-        util::Converter<TypeKind::VARCHAR, void, false, false>::cast(value);
+        util::Converter<TypeKind::VARCHAR, void, util::DefaultCastPolicy>::cast(
+            value);
   }
 
   template <typename C>

--- a/velox/type/tests/ConversionsTest.cpp
+++ b/velox/type/tests/ConversionsTest.cpp
@@ -42,13 +42,14 @@ class ConversionsTest : public testing::Test {
 
     auto cast = [&](TFrom input) -> TTo {
       if (truncate & legacyCast) {
-        return Converter<toTypeKind, void, true, true>::cast(input);
+        return Converter<toTypeKind, void, TruncateLegacyCastPolicy>::cast(
+            input);
       } else if (!truncate & legacyCast) {
-        return Converter<toTypeKind, void, false, true>::cast(input);
+        return Converter<toTypeKind, void, LegacyCastPolicy>::cast(input);
       } else if (truncate & !legacyCast) {
-        return Converter<toTypeKind, void, true, false>::cast(input);
+        return Converter<toTypeKind, void, TruncateCastPolicy>::cast(input);
       } else {
-        return Converter<toTypeKind, void, false, false>::cast(input);
+        return Converter<toTypeKind, void, DefaultCastPolicy>::cast(input);
       }
     };
 


### PR DESCRIPTION
Refactor struct Converter in Conversions.h to remove the code
complexity from the template parameter TRUNCATE and LEGACY_CAST.
Wrap them into a single template parameter TPolicy as well as
any future additional parameter.

struct Converter holds the core logic of the CAST expression
between scalar/primitive types. Benchmarking shows ignorable
impact on perf.

Also refactor the case of ToKind being BOOLEAN, and move the logic
into a single template specialization. The logic used to spread
over two template specializations, for TRUNCATE true and false.