### PR TITLE
Add basic WindowFuzzerTest

### DIFF
--- a/velox/exec/fuzzer/CMakeLists.txt
+++ b/velox/exec/fuzzer/CMakeLists.txt
@@ -30,7 +30,7 @@ target_link_libraries(
   velox_dwio_dwrf_writer
   velox_type
   velox_vector_fuzzer
-  velox_exec_test_lib
+  velox_fuzzer_util
   velox_expression_test_utility
   velox_vector
   velox_core)
@@ -45,3 +45,14 @@ target_link_libraries(
   velox_expression_test_utility
   velox_aggregation_fuzzer_base
   velox_fuzzer_util)
+
+add_library(velox_window_fuzzer WindowFuzzer.cpp)
+
+target_link_libraries(
+  velox_window_fuzzer
+  velox_fuzzer_util
+  velox_type
+  velox_vector_fuzzer
+  velox_exec_test_lib
+  velox_expression_test_utility
+  velox_aggregation_fuzzer_base)

--- a/velox/exec/fuzzer/WindowFuzzer.cpp
+++ b/velox/exec/fuzzer/WindowFuzzer.cpp
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/fuzzer/WindowFuzzer.h"
+
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+DEFINE_bool(
+    enable_window_reference_verification,
+    false,
+    "When true, the results of the window aggregation are compared to reference DB results");
+
+namespace facebook::velox::exec::test {
+
+namespace {
+
+void logVectors(const std::vector<RowVectorPtr>& vectors) {
+  for (auto i = 0; i < vectors.size(); ++i) {
+    VLOG(1) << "Input batch " << i << ":";
+    for (auto j = 0; j < vectors[i]->size(); ++j) {
+      VLOG(1) << "\tRow " << j << ": " << vectors[i]->toString(j);
+    }
+  }
+}
+
+} // namespace
+
+void WindowFuzzer::addWindowFunctionSignatures(
+    const WindowFunctionMap& signatureMap) {
+  for (const auto& [name, entry] : signatureMap) {
+    ++functionsStats.numFunctions;
+    bool hasSupportedSignature = false;
+    for (auto& signature : entry.signatures) {
+      hasSupportedSignature |= addSignature(name, signature);
+    }
+    if (hasSupportedSignature) {
+      ++functionsStats.numSupportedFunctions;
+    }
+  }
+}
+
+const std::string WindowFuzzer::generateFrameClause() {
+  // TODO: allow randomly generating the frame clauses.
+  return "RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW";
+}
+
+const std::string WindowFuzzer::generateOrderByClause(
+    const std::vector<SortingKeyAndOrder>& sortingKeysAndOrders) {
+  std::stringstream frame;
+  frame << " order by ";
+  for (auto i = 0; i < sortingKeysAndOrders.size(); ++i) {
+    if (i != 0) {
+      frame << ", ";
+    }
+    frame << sortingKeysAndOrders[i].key_ << " "
+          << sortingKeysAndOrders[i].order_ << " "
+          << sortingKeysAndOrders[i].nullsOrder_;
+  }
+  return frame.str();
+}
+
+std::string WindowFuzzer::getFrame(
+    const std::vector<std::string>& partitionKeys,
+    const std::vector<SortingKeyAndOrder>& sortingKeysAndOrders,
+    const std::string& frameClause) {
+  std::stringstream frame;
+  VELOX_CHECK(!partitionKeys.empty());
+  frame << "partition by " << folly::join(", ", partitionKeys);
+  if (!sortingKeysAndOrders.empty()) {
+    frame << generateOrderByClause(sortingKeysAndOrders);
+  }
+  frame << " " << frameClause;
+  return frame.str();
+}
+
+std::vector<WindowFuzzer::SortingKeyAndOrder>
+WindowFuzzer::generateSortingKeysAndOrders(
+    const std::string& prefix,
+    std::vector<std::string>& names,
+    std::vector<TypePtr>& types) {
+  auto keys = generateSortingKeys(prefix, names, types);
+  std::vector<SortingKeyAndOrder> results;
+  // TODO: allow randomly generating orders.
+  for (auto i = 0; i < keys.size(); ++i) {
+    std::string order = "asc";
+    std::string nullsOrder = "nulls last";
+    results.push_back(SortingKeyAndOrder(keys[i], order, nullsOrder));
+  }
+  return results;
+}
+
+void WindowFuzzer::go() {
+  VELOX_CHECK(
+      FLAGS_steps > 0 || FLAGS_duration_sec > 0,
+      "Either --steps or --duration_sec needs to be greater than zero.")
+
+  auto startTime = std::chrono::system_clock::now();
+  size_t iteration = 0;
+
+  while (!isDone(iteration, startTime)) {
+    LOG(INFO) << "==============================> Started iteration "
+              << iteration << " (seed: " << currentSeed_ << ")";
+
+    auto signatureWithStats = pickSignature();
+    signatureWithStats.second.numRuns++;
+
+    auto signature = signatureWithStats.first;
+    stats_.functionNames.insert(signature.name);
+
+    const bool customVerification =
+        customVerificationFunctions_.count(signature.name) != 0;
+    const bool requireSortedInput =
+        orderDependentFunctions_.count(signature.name) != 0;
+
+    std::vector<TypePtr> argTypes = signature.args;
+    std::vector<std::string> argNames = makeNames(argTypes.size());
+
+    auto call = makeFunctionCall(signature.name, argNames, false);
+
+    std::vector<SortingKeyAndOrder> sortingKeysAndOrders;
+    // 50% chance without order-by clause.
+    if (vectorFuzzer_.coinToss(0.5)) {
+      sortingKeysAndOrders =
+          generateSortingKeysAndOrders("s", argNames, argTypes);
+    }
+    auto partitionKeys = generateSortingKeys("p", argNames, argTypes);
+    auto frameClause = generateFrameClause();
+    auto input = generateInputDataWithRowNumber(argNames, argTypes, signature);
+    // If the function is order-dependent, sort all input rows by row_number
+    // additionally.
+    if (requireSortedInput) {
+      sortingKeysAndOrders.push_back(
+          SortingKeyAndOrder("row_number", "asc", "nulls last"));
+      ++stats_.numSortedInputs;
+    }
+
+    logVectors(input);
+
+    bool failed = verifyWindow(
+        partitionKeys,
+        sortingKeysAndOrders,
+        frameClause,
+        call,
+        input,
+        customVerification,
+        FLAGS_enable_window_reference_verification);
+    if (failed) {
+      signatureWithStats.second.numFailed++;
+    }
+
+    LOG(INFO) << "==============================> Done with iteration "
+              << iteration;
+
+    if (persistAndRunOnce_) {
+      LOG(WARNING)
+          << "Iteration succeeded with --persist_and_run_once flag enabled "
+             "(expecting crash failure)";
+      exit(0);
+    }
+
+    reSeed();
+    ++iteration;
+  }
+
+  stats_.print(iteration);
+  printSignatureStats();
+}
+
+void WindowFuzzer::go(const std::string& /*planPath*/) {
+  // TODO: allow running window fuzzer with saved plans and splits.
+  VELOX_NYI();
+}
+
+bool WindowFuzzer::verifyWindow(
+    const std::vector<std::string>& partitionKeys,
+    const std::vector<SortingKeyAndOrder>& sortingKeysAndOrders,
+    const std::string& frameClause,
+    const std::string& functionCall,
+    const std::vector<RowVectorPtr>& input,
+    bool customVerification,
+    bool enableWindowVerification) {
+  auto frame = getFrame(partitionKeys, sortingKeysAndOrders, frameClause);
+  auto plan = PlanBuilder()
+                  .values(input)
+                  .window({fmt::format("{} over ({})", functionCall, frame)})
+                  .planNode();
+  if (persistAndRunOnce_) {
+    persistReproInfo({{plan, {}}}, reproPersistPath_);
+  }
+  try {
+    auto resultOrError = execute(plan);
+    if (resultOrError.exceptionPtr) {
+      ++stats_.numFailed;
+    }
+
+    if (!customVerification && enableWindowVerification) {
+      if (resultOrError.result) {
+        auto referenceResult = computeReferenceResults(plan, input);
+        stats_.updateReferenceQueryStats(referenceResult.second);
+        if (auto expectedResult = referenceResult.first) {
+          ++stats_.numVerified;
+          stats_.verifiedFunctionNames.insert(
+              retrieveWindowFunctionName(plan)[0]);
+          VELOX_CHECK(
+              assertEqualResults(
+                  expectedResult.value(),
+                  plan->outputType(),
+                  {resultOrError.result}),
+              "Velox and reference DB results don't match");
+          LOG(INFO) << "Verified results against reference DB";
+        }
+      }
+    } else {
+      // TODO: support custom verification.
+      LOG(INFO) << "Verification skipped";
+      ++stats_.numVerificationSkipped;
+    }
+
+    return resultOrError.exceptionPtr != nullptr;
+  } catch (...) {
+    if (!reproPersistPath_.empty()) {
+      persistReproInfo({{plan, {}}}, reproPersistPath_);
+    }
+    throw;
+  }
+}
+
+void windowFuzzer(
+    AggregateFunctionSignatureMap aggregationSignatureMap,
+    WindowFunctionMap windowSignatureMap,
+    size_t seed,
+    const std::unordered_map<std::string, std::shared_ptr<ResultVerifier>>&
+        customVerificationFunctions,
+    const std::unordered_map<std::string, std::shared_ptr<InputGenerator>>&
+        customInputGenerators,
+    const std::unordered_set<std::string>& orderDependentFunctions,
+    VectorFuzzer::Options::TimestampPrecision timestampPrecision,
+    const std::unordered_map<std::string, std::string>& queryConfigs,
+    const std::optional<std::string>& planPath,
+    std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner) {
+  auto windowFuzzer = WindowFuzzer(
+      std::move(aggregationSignatureMap),
+      std::move(windowSignatureMap),
+      seed,
+      customVerificationFunctions,
+      customInputGenerators,
+      orderDependentFunctions,
+      timestampPrecision,
+      queryConfigs,
+      std::move(referenceQueryRunner));
+  planPath.has_value() ? windowFuzzer.go(planPath.value()) : windowFuzzer.go();
+}
+
+void WindowFuzzer::Stats::print(size_t numIterations) const {
+  AggregationFuzzerBase::Stats::print(numIterations);
+  LOG(INFO) << "Total functions verified in reference DB: "
+            << verifiedFunctionNames.size();
+}
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/WindowFuzzer.h
+++ b/velox/exec/fuzzer/WindowFuzzer.h
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/WindowFunction.h"
+#include "velox/exec/fuzzer/AggregationFuzzerBase.h"
+#include "velox/exec/fuzzer/PrestoQueryRunner.h"
+#include "velox/exec/fuzzer/ReferenceQueryRunner.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+DECLARE_bool(enable_window_reference_verification);
+
+namespace facebook::velox::exec::test {
+
+class WindowFuzzer : public AggregationFuzzerBase {
+ public:
+  WindowFuzzer(
+      AggregateFunctionSignatureMap aggregationSignatureMap,
+      WindowFunctionMap windowSignatureMap,
+      size_t seed,
+      const std::unordered_map<std::string, std::shared_ptr<ResultVerifier>>&
+          customVerificationFunctions,
+      const std::unordered_map<std::string, std::shared_ptr<InputGenerator>>&
+          customInputGenerators,
+      const std::unordered_set<std::string>& orderDependentFunctions,
+      VectorFuzzer::Options::TimestampPrecision timestampPrecision,
+      const std::unordered_map<std::string, std::string>& queryConfigs,
+      std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner)
+      : AggregationFuzzerBase{seed, customVerificationFunctions, customInputGenerators, timestampPrecision, queryConfigs, std::move(referenceQueryRunner)},
+        orderDependentFunctions_{orderDependentFunctions} {
+    VELOX_CHECK(
+        !aggregationSignatureMap.empty() || !windowSignatureMap.empty(),
+        "No function signatures available.");
+
+    if (persistAndRunOnce_ && reproPersistPath_.empty()) {
+      std::cerr
+          << "--repro_persist_path must be specified if --persist_and_run_once is specified"
+          << std::endl;
+      exit(1);
+    }
+
+    // Presto doesn't allow complex-typed vectors with NULL elements to be
+    // partition keys, so we disable it for all inputs.
+    // TODO: allow complex-typed vectors with NULL elements as non-key columns.
+    if (dynamic_cast<PrestoQueryRunner*>(referenceQueryRunner_.get())) {
+      auto options = vectorFuzzer_.getOptions();
+      options.containerHasNulls = false;
+      vectorFuzzer_.setOptions(options);
+    }
+
+    addAggregationSignatures(aggregationSignatureMap);
+    addWindowFunctionSignatures(windowSignatureMap);
+    printStats(functionsStats);
+
+    sortCallableSignatures(signatures_);
+    sortSignatureTemplates(signatureTemplates_);
+
+    signatureStats_.resize(signatures_.size() + signatureTemplates_.size());
+  }
+
+  void go();
+  void go(const std::string& planPath);
+
+ private:
+  struct SortingKeyAndOrder {
+    std::string key_;
+    std::string order_;
+    std::string nullsOrder_;
+
+    SortingKeyAndOrder() = delete;
+
+    SortingKeyAndOrder(
+        const std::string& key,
+        const std::string& order,
+        const std::string& nullsOrder) {
+      key_ = key;
+      order_ = order;
+      nullsOrder_ = nullsOrder;
+    }
+  };
+
+  void addWindowFunctionSignatures(const WindowFunctionMap& signatureMap);
+
+  const std::string generateFrameClause();
+
+  const std::string generateOrderByClause(
+      const std::vector<SortingKeyAndOrder>& sortingKeysAndOrders);
+
+  std::string getFrame(
+      const std::vector<std::string>& partitionKeys,
+      const std::vector<SortingKeyAndOrder>& sortingKeysAndOrders,
+      const std::string& frameClause);
+
+  std::vector<SortingKeyAndOrder> generateSortingKeysAndOrders(
+      const std::string& prefix,
+      std::vector<std::string>& names,
+      std::vector<TypePtr>& types);
+
+  // Return 'true' if query plans failed.
+  bool verifyWindow(
+      const std::vector<std::string>& partitionKeys,
+      const std::vector<SortingKeyAndOrder>& sortingKeysAndOrders,
+      const std::string& frameClause,
+      const std::string& functionCall,
+      const std::vector<RowVectorPtr>& input,
+      bool customVerification,
+      bool enableWindowVerification);
+
+  const std::unordered_set<std::string> orderDependentFunctions_;
+
+  struct Stats : public AggregationFuzzerBase::Stats {
+    std::unordered_set<std::string> verifiedFunctionNames;
+
+    void print(size_t numIterations) const;
+  } stats_;
+};
+
+/// Runs the window fuzzer.
+/// @param aggregationSignatureMap Map of all aggregate function signatures.
+/// @param windowSignatureMap Map of all window function signatures.
+/// @param seed Random seed - Pass the same seed for reproducibility.
+/// @param orderDependentFunctions Map of functions that depend on order of
+/// input.
+/// @param planPath Path to persisted plan information. If this is
+/// supplied, fuzzer will only verify the plans.
+/// @param referenceQueryRunner Reference query runner for results
+/// verification.
+void windowFuzzer(
+    AggregateFunctionSignatureMap aggregationSignatureMap,
+    WindowFunctionMap windowSignatureMap,
+    size_t seed,
+    const std::unordered_map<std::string, std::shared_ptr<ResultVerifier>>&
+        customVerificationFunctions,
+    const std::unordered_map<std::string, std::shared_ptr<InputGenerator>>&
+        customInputGenerators,
+    const std::unordered_set<std::string>& orderDependentFunctions,
+    VectorFuzzer::Options::TimestampPrecision timestampPrecision,
+    const std::unordered_map<std::string, std::string>& queryConfigs,
+    const std::optional<std::string>& planPath,
+    std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner);
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/WindowFuzzerRunner.h
+++ b/velox/exec/fuzzer/WindowFuzzerRunner.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/String.h>
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "velox/common/file/FileSystems.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/fuzzer/AggregationFuzzerOptions.h"
+#include "velox/exec/fuzzer/WindowFuzzer.h"
+#include "velox/expression/tests/utils/FuzzerToolkit.h"
+#include "velox/parse/TypeResolver.h"
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+namespace facebook::velox::exec::test {
+
+class WindowFuzzerRunner {
+ public:
+  static int run(
+      size_t seed,
+      std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner,
+      const AggregationFuzzerOptions& options) {
+    return runFuzzer(
+        seed, std::nullopt, std::move(referenceQueryRunner), options);
+  }
+
+  static int runRepro(
+      const std::optional<std::string>& planPath,
+      std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner) {
+    return runFuzzer(0, planPath, std::move(referenceQueryRunner), {});
+  }
+
+ protected:
+  static int runFuzzer(
+      size_t seed,
+      const std::optional<std::string>& planPath,
+      std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner,
+      const AggregationFuzzerOptions& options) {
+    auto aggregationSignatures =
+        facebook::velox::exec::getAggregateFunctionSignatures();
+    auto windowSignatures = facebook::velox::exec::windowFunctions();
+    if (aggregationSignatures.empty() && windowSignatures.empty()) {
+      LOG(ERROR) << "No function registered.";
+      exit(1);
+    }
+
+    auto filteredAggregationSignatures = velox::test::filterSignatures(
+        aggregationSignatures, options.onlyFunctions, options.skipFunctions);
+    auto filteredWindowSignatures = velox::test::filterSignatures(
+        windowSignatures, options.onlyFunctions, options.skipFunctions);
+    if (filteredAggregationSignatures.empty() &&
+        filteredWindowSignatures.empty()) {
+      LOG(ERROR)
+          << "No function left after filtering using 'only' and 'skip' lists.";
+      exit(1);
+    }
+
+    facebook::velox::parse::registerTypeResolver();
+    facebook::velox::serializer::presto::PrestoVectorSerde::
+        registerVectorSerde();
+    facebook::velox::filesystems::registerLocalFileSystem();
+
+    facebook::velox::exec::test::windowFuzzer(
+        filteredAggregationSignatures,
+        filteredWindowSignatures,
+        seed,
+        options.customVerificationFunctions,
+        options.customInputGenerators,
+        options.orderDependentFunctions,
+        options.timestampPrecision,
+        options.queryConfigs,
+        planPath,
+        std::move(referenceQueryRunner));
+    // Calling gtest here so that it can be recognized as tests in CI systems.
+    return RUN_ALL_TESTS();
+  }
+};
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -161,6 +161,7 @@ target_link_libraries(
   velox_functions_lib
   velox_functions_prestosql
   velox_functions_test_lib
+  velox_window
   velox_hive_connector
   velox_memory
   velox_serialization

--- a/velox/exec/tests/PrestoQueryRunnerTest.cpp
+++ b/velox/exec/tests/PrestoQueryRunnerTest.cpp
@@ -174,7 +174,18 @@ TEST_F(PrestoQueryRunnerTest, toSql) {
             .planNode();
     EXPECT_EQ(
         queryRunner->toSql(plan),
-        "SELECT c0, c1, c2, first_value(c0) OVER (PARTITION BY c1 order by c2 ASC NULLS LAST) FROM tmp");
+        "SELECT c0, c1, c2, first_value(c0) OVER (PARTITION BY c1 ORDER BY c2 ASC NULLS LAST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM tmp");
+
+    plan =
+        PlanBuilder()
+            .tableScan("tmp", dataType)
+            .window(
+                {"first_value(c0) over (partition by c1 order by c2 desc nulls first rows between 1 following and unbounded following)",
+                 "last_value(c0) over (partition by c1 order by c2 desc nulls first)"})
+            .planNode();
+    EXPECT_EQ(
+        queryRunner->toSql(plan),
+        "SELECT c0, c1, c2, first_value(c0) OVER (PARTITION BY c1 ORDER BY c2 DESC NULLS FIRST ROWS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING), last_value(c0) OVER (PARTITION BY c1 ORDER BY c2 DESC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM tmp");
   }
 
   // Test aggregation queries.

--- a/velox/functions/prestosql/fuzzer/CMakeLists.txt
+++ b/velox/functions/prestosql/fuzzer/CMakeLists.txt
@@ -22,3 +22,16 @@ target_link_libraries(
   velox_window
   gtest
   gtest_main)
+
+# Window Fuzzer
+add_executable(velox_window_fuzzer_test WindowFuzzerTest.cpp)
+
+target_link_libraries(
+  velox_window_fuzzer_test
+  velox_window_fuzzer
+  velox_fuzzer_util
+  velox_aggregates
+  velox_window
+  velox_expression_test_utility
+  gtest
+  gtest_main)


### PR DESCRIPTION
This diff adds a basic version of window fuzzer test that tests the Window operator with window functions and aggregation functions. 

At every iteration, this fuzzer chooses a random signature among all registered aggregation and window function signatures (excluding functions in the `skipFunctions` list), and execute a plan of window operation with randomly generated set of partition keys, an optional set of sorting keys (with 50% chance), and the default frame (`RANGE between UNBOUNDED PRECEDING and CURRENT ROW`). For functions in the `orderDependentFunctions` list, the set of sorting keys include the row_number column to ensure the input is fully sorted. The input columns are either generated randomly, or generated via the custom input generator if provided. A GFLAG `enable_window_reference_verification` (with the default value `false`) controls whether the result is verified against DuckDB. For functions in the `customVerificationFunctions` list, results are not verified even if `enable_window_reference_verification` is set to true.

The following GFLAGs are supported in the basic version: 
enable_window_reference_verification
seed
only
steps
duration_sec
batch_size
num_batches
max_num_varargs
null_ratio
repro_persist_path
persist_and_run_once
log_signature_stats

Function stats are printed before iteration starts, e.g.,
```
31219 20:14:25.472924 2372852 AggregationFuzzerBase.cpp:541] Total functions: 87 (509 signatures)
I20231219 20:14:25.472947 2372852 AggregationFuzzerBase.cpp:545] Functions with at least one supported signature: 87 (100.00%)
I20231219 20:14:25.472965 2372852 AggregationFuzzerBase.cpp:551] Functions with no supported signature: 0 (0.00%)
I20231219 20:14:25.472975 2372852 AggregationFuzzerBase.cpp:554] Supported function signatures: 497 (97.64%)
I20231219 20:14:25.472982 2372852 AggregationFuzzerBase.cpp:560] Unsupported function signatures: 12 (2.36%)
I202
```

Test stats are printed after all iterations complete, e.g.,
```
I20231219 20:14:54.414773 2372852 WindowFuzzer.cpp:224] Total functions tested: 3
I20231219 20:14:54.414824 2372852 WindowFuzzer.cpp:225] Total functions requiring sorted inputs: 0 (0.00%)
I20231219 20:14:54.414860 2372852 WindowFuzzer.cpp:227] Total functions verified against reference DB: 1 (25.00%)
I20231219 20:14:54.414870 2372852 WindowFuzzer.cpp:229] Total functions not verified (verification skipped / not supported by reference DB / reference DB failed): 2 (50.00%) / 0 (0.00%) / 0 (0.00%)
I20231219 20:14:54.414880 2372852 WindowFuzzer.cpp:234] Total failed functions: 1 (25.00%)
I20231219 20:15:59.899459 2372852 AggregationFuzzerBase.cpp:344] Signature #49 failed 1 out of 1 times: approx_most_frequent( BIGINT SMALLINT BIGINT ) -> MAP<SMALLINT,BIGINT>
```

The window fuzzer test currently have the following limitations:
* Not supporting reproduction of test failures from saved files.
* Not using randomly-generated frames.
* Not allowing custom result verifiers.
* Verify results against DuckDB instead of Presto.

The limitations will be addressed next in the subsequent PRs.

This is the second piece of https://github.com/facebookincubator/velox/issues/7754.

Differential Revision: D51880255


