### PR TITLE
Avoid reading underlying stream when seeking RLE decoders

### DIFF
--- a/velox/dwio/common/DirectDecoder.cpp
+++ b/velox/dwio/common/DirectDecoder.cpp
@@ -27,6 +27,7 @@ void DirectDecoder<isSigned>::seekToRowGroup(
   IntDecoder<isSigned>::inputStream->seekToPosition(location);
   // force a re-read from the stream
   IntDecoder<isSigned>::bufferEnd = IntDecoder<isSigned>::bufferStart;
+  this->pendingSkip = 0;
 }
 
 template void DirectDecoder<true>::seekToRowGroup(
@@ -35,19 +36,12 @@ template void DirectDecoder<false>::seekToRowGroup(
     dwio::common::PositionProvider& location);
 
 template <bool isSigned>
-void DirectDecoder<isSigned>::skip(uint64_t numValues) {
-  IntDecoder<isSigned>::skipLongs(numValues);
-}
-
-template void DirectDecoder<true>::skip(uint64_t numValues);
-template void DirectDecoder<false>::skip(uint64_t numValues);
-
-template <bool isSigned>
 template <typename T>
 void DirectDecoder<isSigned>::nextValues(
     T* data,
     uint64_t numValues,
     const uint64_t* nulls) {
+  skipPending();
   uint64_t position = 0;
   // skipNulls()
   if (nulls) {

--- a/velox/dwio/common/DirectDecoder.h
+++ b/velox/dwio/common/DirectDecoder.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include "velox/common/base/Nulls.h"
 #include "velox/dwio/common/DecoderUtil.h"
 #include "velox/dwio/common/IntDecoder.h"
 
@@ -36,7 +35,13 @@ class DirectDecoder : public IntDecoder<isSigned> {
 
   void seekToRowGroup(dwio::common::PositionProvider&) override;
 
-  void skip(uint64_t numValues) override;
+  using IntDecoder<isSigned>::skip;
+
+  void skipPending() final {
+    auto toSkip = this->pendingSkip;
+    this->pendingSkip = 0;
+    this->skipLongs(toSkip);
+  }
 
   template <typename T>
   void nextValues(
@@ -51,25 +56,12 @@ class DirectDecoder : public IntDecoder<isSigned> {
     nextValues<int64_t>(data, numValues, nulls);
   }
 
-  template <bool hasNulls>
-  inline void skip(
-      int32_t numValues,
-      int32_t current,
-      const uint64_t* FOLLY_NULLABLE nulls) {
-    if (!numValues) {
-      return;
-    }
-    if (hasNulls) {
-      numValues = bits::countNonNulls(nulls, current, current + numValues);
-    }
-    IntDecoder<isSigned>::skipLongsFast(numValues);
-  }
-
   template <bool hasNulls, typename Visitor>
   void readWithVisitor(
       const uint64_t* FOLLY_NULLABLE nulls,
       Visitor visitor,
       bool useFastPath = true) {
+    skipPending();
     if constexpr (!std::is_same_v<typename Visitor::DataType, int128_t>) {
       if (useFastPath &&
           dwio::common::useFastPath<Visitor, hasNulls>(visitor)) {
@@ -78,7 +70,7 @@ class DirectDecoder : public IntDecoder<isSigned> {
       }
     }
     int32_t current = visitor.start();
-    skip<hasNulls>(current, 0, nulls);
+    this->template skip<hasNulls>(current, 0, nulls);
     const bool allowNulls = hasNulls && visitor.allowNulls();
     for (;;) {
       bool atEnd = false;
@@ -87,7 +79,7 @@ class DirectDecoder : public IntDecoder<isSigned> {
         if (!allowNulls) {
           toSkip = visitor.checkAndSkipNulls(nulls, current, atEnd);
           if (!Visitor::dense) {
-            skip<false>(toSkip, current, nullptr);
+            this->template skip<false>(toSkip, current, nullptr);
           }
           if (atEnd) {
             return;
@@ -113,7 +105,7 @@ class DirectDecoder : public IntDecoder<isSigned> {
     skip:
       ++current;
       if (toSkip) {
-        skip<hasNulls>(toSkip, current, nulls);
+        this->template skip<hasNulls>(toSkip, current, nulls);
         current += toSkip;
       }
       if (atEnd) {
@@ -141,6 +133,7 @@ class DirectDecoder : public IntDecoder<isSigned> {
   // buffer. If the element would straddle buffers, it is copied to
   // *temp and temp is returned.
   const void* FOLLY_NONNULL readFixed(int32_t size, void* FOLLY_NONNULL temp) {
+    skipPending();
     auto ptr = super::bufferStart;
     if (ptr && ptr + size <= super::bufferEnd) {
       super::bufferStart += size;
@@ -200,7 +193,7 @@ class DirectDecoder : public IntDecoder<isSigned> {
           visitor.setHasNulls();
         }
         if (innerVector->empty()) {
-          skip<false>(tailSkip, 0, nullptr);
+          this->template skip<false>(tailSkip, 0, nullptr);
           visitor.setAllNull(hasFilter ? 0 : numRows);
           return;
         }
@@ -211,7 +204,7 @@ class DirectDecoder : public IntDecoder<isSigned> {
         } else {
           super::bulkReadRows(*innerVector, data);
         }
-        skip<false>(tailSkip, 0, nullptr);
+        this->template skip<false>(tailSkip, 0, nullptr);
         auto dataRows = innerVector
             ? folly::Range<const int*>(innerVector->data(), innerVector->size())
             : folly::Range<const int32_t*>(rows, outerVector->size());
@@ -239,7 +232,7 @@ class DirectDecoder : public IntDecoder<isSigned> {
             super::bufferEnd,
             visitor.filter(),
             visitor.hook());
-        skip<false>(tailSkip, 0, nullptr);
+        this->template skip<false>(tailSkip, 0, nullptr);
       }
     } else {
       if (super::useVInts) {

--- a/velox/dwio/common/SeekableInputStream.cpp
+++ b/velox/dwio/common/SeekableInputStream.cpp
@@ -128,6 +128,7 @@ bool SeekableArrayInputStream::Next(const void** buffer, int32_t* size) {
     *buffer = data + position;
     *size = static_cast<int32_t>(currentSize);
     position += currentSize;
+    totalRead_ += currentSize;
     return true;
   }
 

--- a/velox/dwio/common/SeekableInputStream.h
+++ b/velox/dwio/common/SeekableInputStream.h
@@ -78,6 +78,7 @@ class SeekableArrayInputStream : public SeekableInputStream {
   uint64_t length;
   uint64_t position;
   uint64_t blockSize;
+  int64_t totalRead_ = 0;
   void loadIfAvailable();
 
  public:
@@ -107,6 +108,12 @@ class SeekableArrayInputStream : public SeekableInputStream {
   virtual void seekToPosition(PositionProvider& position) override;
   virtual std::string getName() const override;
   virtual size_t positionSize() override;
+
+  /// Return the total number of bytes returned from Next() calls.  Intended to
+  /// be used for test validation.
+  int64_t totalRead() const {
+    return totalRead_;
+  }
 };
 
 /**

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
@@ -105,11 +105,11 @@ void SelectiveStringDictionaryColumnReader::loadDictionary(
   dwio::common::ensureCapacity<StringView>(
       values.values, values.numValues, &memoryPool_);
   // The lengths are read in the low addresses of the string views array.
-  int64_t* int64Values = values.values->asMutable<int64_t>();
-  lengthDecoder.next(int64Values, values.numValues, nullptr);
+  auto* lengths = values.values->asMutable<int32_t>();
+  lengthDecoder.nextLengths(lengths, values.numValues);
   int64_t stringsBytes = 0;
   for (auto i = 0; i < values.numValues; ++i) {
-    stringsBytes += int64Values[i];
+    stringsBytes += lengths[i];
   }
   // read bytes from underlying string
   values.strings = AlignedBuffer::allocate<char>(stringsBytes, &memoryPool_);
@@ -123,8 +123,8 @@ void SelectiveStringDictionaryColumnReader::loadDictionary(
   // the lengths at the start of values.
   auto offset = stringsBytes;
   for (int32_t i = values.numValues - 1; i >= 0; --i) {
-    offset -= int64Values[i];
-    views[i] = StringView(strings + offset, int64Values[i]);
+    offset -= lengths[i];
+    views[i] = StringView(strings + offset, lengths[i]);
   }
 }
 

--- a/velox/dwio/dwrf/test/TestIntDirect.cpp
+++ b/velox/dwio/dwrf/test/TestIntDirect.cpp
@@ -96,7 +96,7 @@ void testInts(std::function<T()> generator) {
     if (numRead + stride >= count / 2) {
       break;
     }
-    decoder->skipLongsFast(stride);
+    decoder->skip(stride);
     numRead += stride;
     stride = (stride * 2 + 1) % 31;
     int64_t num;


### PR DESCRIPTION
Summary:
`seekToRowGroup` is meant to be a lightweight operation and should not
read the underlying stream.  Currently this is not the case with RLE decoders,
because we eagerly skip the values after seeking, which requires read the RLE
headers from the encoded data.  We have pattern that seek multiple times before
actually reading the data, and the IO and decompression cost of seeking can be
avoided.  This is especially visible in low selectivity queries where
decompression takes majority of the CPU time.

Optimize these repeated IO and decompression away by lazily skipping values in
RLE decoders.  For a typical low selectivity query, this improve the CPU time
from 69.84 hours to 40.2 hours (Presto Java is taking 41.45 hours on the same
query).

Differential Revision: D51947121


