### PR TITLE
Add support for docker image with presto java

### DIFF
--- a/.circleci/dist_compile.yml
+++ b/.circleci/dist_compile.yml
@@ -333,7 +333,7 @@ jobs:
             chmod -R 777 /tmp/aggregate_fuzzer_repro
             _build/debug/velox/exec/tests/velox_aggregation_fuzzer_test \
                 --seed ${RANDOM} \
-                --duration_sec 60 \
+                --duration_sec 1800 \
                 --logtostderr=1 \
                 --minloglevel=0 \
                 --repro_persist_path=/tmp/aggregate_fuzzer_repro \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,11 +52,11 @@ jobs:
             file: "scripts/circleci-container.dockfile"
             args: "cpu_target=avx"
             tags: "ghcr.io/facebookincubator/velox-dev:circleci-avx"
-          - name: Check
+          - name: Torcharrow
             file: "scripts/velox-torcharrow-container.dockfile"
             args: "cpu_target=avx"
             tags: "ghcr.io/facebookincubator/velox-dev:torcharrow-avx"
-          - name: Check
+          - name: Dev
             file: "scripts/ubuntu-22.04-cpp.dockerfile"
             args: ""
             tags: "ghcr.io/facebookincubator/velox-dev:amd64-ubuntu-22.04-avx"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,7 +38,33 @@ permissions:
 
 jobs:
   linux:
+    name: "Build and Push ${{ matrix.name }}"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Check
+            file: "scripts/check-container.dockfile"
+            args: "cpu_target=avx"
+            tags: "ghcr.io/facebookincubator/velox-dev:check-avx"
+          - name: CircleCI
+            file: "scripts/circleci-container.dockfile"
+            args: "cpu_target=avx"
+            tags: "ghcr.io/facebookincubator/velox-dev:circleci-avx"
+          - name: Check
+            file: "scripts/velox-torcharrow-container.dockfile"
+            args: "cpu_target=avx"
+            tags: "ghcr.io/facebookincubator/velox-dev:torcharrow-avx"
+          - name: Check
+            file: "scripts/ubuntu-22.04-cpp.dockerfile"
+            args: ""
+            tags: "ghcr.io/facebookincubator/velox-dev:amd64-ubuntu-22.04-avx"
+          - name: Presto Java
+            file: "scripts/prestojava-container.dockerfile"
+            args: "PRESTO_VERSION=0.284"
+            tags: "ghcr.io/facebookincubator/velox-dev:presto-java"
+
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -55,44 +81,11 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - name: Build and Push check
+      - name: Build and Push
         uses: docker/build-push-action@v3
         with:
           context: scripts
-          file: scripts/check-container.dockfile
-          build-args: cpu_target=avx
+          file: "${{ matrix.file }}"
+          build-args: "${{ matrix.args }}"
           push: ${{ github.repository == 'facebookincubator/velox' && github.event_name != 'pull_request'}}
-          tags: ghcr.io/facebookincubator/velox-dev:check-avx
-
-      - name: Build and Push circle-ci
-        uses: docker/build-push-action@v3
-        with:
-          context: scripts
-          file: scripts/circleci-container.dockfile
-          build-args: cpu_target=avx
-          push: ${{ github.repository == 'facebookincubator/velox' && github.event_name != 'pull_request'}}
-          tags: ghcr.io/facebookincubator/velox-dev:circleci-avx
-
-      - name: Build and Push velox-torcharrow
-        uses: docker/build-push-action@v3
-        with:
-          context: scripts
-          file: scripts/velox-torcharrow-container.dockfile
-          build-args: cpu_target=avx
-          push: ${{ github.repository == 'facebookincubator/velox' && github.event_name != 'pull_request'}}
-          tags: ghcr.io/facebookincubator/velox-dev:torcharrow-avx
-
-      - name: Build and Push dev-image
-        uses: docker/build-push-action@v3
-        with:
-          file: scripts/ubuntu-22.04-cpp.dockerfile
-          push: ${{ github.repository == 'facebookincubator/velox' && github.event_name != 'pull_request'}}
-          tags: ghcr.io/facebookincubator/velox-dev:amd64-ubuntu-22.04-avx
-
-      - name: Build and Push Presto java dev-image
-        uses: docker/build-push-action@v3
-        with:
-          file: scripts/prestojava-container.dockerfile
-          build-args: PRESTO_VERSION=0.284
-          push: ${{ github.repository == 'facebookincubator/velox' && github.event_name != 'pull_request'}}
-          tags: ghcr.io/facebookincubator/velox-dev-presto-java:amd64-ubuntu-22.04-avx
+          tags: "${{ matrix.tags }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -88,3 +88,11 @@ jobs:
           file: scripts/ubuntu-22.04-cpp.dockerfile
           push: ${{ github.repository == 'facebookincubator/velox' && github.event_name != 'pull_request'}}
           tags: ghcr.io/facebookincubator/velox-dev:amd64-ubuntu-22.04-avx
+
+      - name: Build and Push Presto java dev-image
+        uses: docker/build-push-action@v3
+        with:
+          file: scripts/prestojava-container.dockerfile
+          build-args: PRESTO_VERSION=0.284
+          push: ${{ github.repository == 'facebookincubator/velox' && github.event_name != 'pull_request'}}
+          tags: ghcr.io/facebookincubator/velox-dev-presto-java:amd64-ubuntu-22.04-avx

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -79,12 +79,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - uses: actions/checkout@v3
-
       - name: Build and Push
         uses: docker/build-push-action@v3
         with:
-          context: scripts
           file: "${{ matrix.file }}"
           build-args: "${{ matrix.args }}"
           push: ${{ github.repository == 'facebookincubator/velox' && github.event_name != 'pull_request'}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,3 +69,24 @@ services:
     volumes:
       - .:/velox:delegated
     command: cd /velox && make python-test
+
+
+  presto-java:
+  # Usage:
+  #   docker-compose pull presto-java or docker-compose build presto-java
+  #   docker-compose run --rm presto-java
+  #   or
+  #   docker-compose run -e NUM_THREADS=<NUMBER_OF_THREADS_TO_USE> --rm presto-java
+  #   to set the number of threads used during compilation
+    image: ghcr.io/facebookincubator/velox-dev:amd64-centos-8-avx
+    build:
+      args:
+        - PRESTO_VERSION=0.284
+      context: .
+      dockerfile: scripts/prestojava-container.dockerfile
+    environment:
+      NUM_THREADS: 8 # default value for NUM_THREADS
+      CCACHE_DIR: "/velox/.ccache"
+    volumes:
+      - .:/velox:delegated
+    command: /bin/bash -c "scl enable gcc-toolset-9 '/velox/scripts/docker-command.sh'"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
   #   or
   #   docker-compose run -e NUM_THREADS=<NUMBER_OF_THREADS_TO_USE> --rm presto-java
   #   to set the number of threads used during compilation
-    image: ghcr.io/facebookincubator/velox-dev:amd64-centos-8-avx
+    image: ghcr.io/facebookincubator/velox-dev:presto-java
     build:
       args:
         - PRESTO_VERSION=0.284

--- a/scripts/check-container.dockfile
+++ b/scripts/check-container.dockfile
@@ -13,6 +13,6 @@
 # limitations under the License.
 FROM amd64/ubuntu:22.04
 ARG cpu_target
-COPY setup-check.sh /root
-COPY setup-helper-functions.sh /
+COPY scripts/setup-check.sh /root
+COPY scripts/setup-helper-functions.sh /
 RUN CPU_TARGET="$cpu_target" bash /root/setup-check.sh

--- a/scripts/circleci-container.dockfile
+++ b/scripts/circleci-container.dockfile
@@ -15,6 +15,6 @@
 #
 FROM quay.io/centos/centos:stream8
 ARG cpu_target
-COPY setup-circleci.sh /
-COPY setup-helper-functions.sh /
+COPY scripts/setup-circleci.sh /
+COPY scripts/setup-helper-functions.sh /
 RUN mkdir build && ( cd build && CPU_TARGET="$cpu_target" bash /setup-circleci.sh ) && rm -rf build

--- a/scripts/etc/config.properties.example
+++ b/scripts/etc/config.properties.example
@@ -1,0 +1,5 @@
+coordinator=true
+node-scheduler.include-coordinator=true
+http-server.http.port=8080
+discovery-server.enabled=true
+discovery.uri=http://localhost:8080

--- a/scripts/etc/jvm.config.example
+++ b/scripts/etc/jvm.config.example
@@ -1,0 +1,9 @@
+-server
+-Xmx1G
+-XX:+UseG1GC
+-XX:G1HeapRegionSize=32M
+-XX:+UseGCOverheadLimit
+-XX:+ExplicitGCInvokesConcurrent
+-XX:+HeapDumpOnOutOfMemoryError
+-XX:+ExitOnOutOfMemoryError
+-Djdk.attach.allowAttachSelf=true

--- a/scripts/etc/node.properties
+++ b/scripts/etc/node.properties
@@ -1,0 +1,2 @@
+node.environment=test
+node.data-dir=/var/lib/presto/data

--- a/scripts/prestojava-container.dockerfile
+++ b/scripts/prestojava-container.dockerfile
@@ -1,0 +1,47 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Build the test and build container for presto_cpp
+#
+FROM quay.io/centos/centos:stream8
+
+ARG PRESTO_VERSION
+
+ADD scripts /velox/scripts/
+RUN /velox/scripts/setup-centos8.sh
+RUN wget https://repo1.maven.org/maven2/com/facebook/presto/presto-server/${PRESTO_VERSION}/presto-server-${PRESTO_VERSION}.tar.gz
+RUN wget https://repo1.maven.org/maven2/com/facebook/presto/presto-cli/${PRESTO_VERSION}/presto-cli-${PRESTO_VERSION}-executable.jar
+
+ARG PRESTO_PKG=presto-server-$PRESTO_VERSION.tar.gz
+ARG PRESTO_CLI_JAR=presto-cli-$PRESTO_VERSION-executable.jar
+
+ENV PRESTO_HOME="/opt/presto-server"
+RUN cp $PRESTO_CLI_JAR /opt/presto-cli
+
+RUN dnf install -y java-11-openjdk less procps python3 \
+    && ln -s $(which python3) /usr/bin/python \
+    && tar -zxf $PRESTO_PKG \
+    && mv ./presto-server-$PRESTO_VERSION $PRESTO_HOME \
+    && chmod +x /opt/presto-cli \
+    && ln -s /opt/presto-cli /usr/local/bin/ \
+    && mkdir -p $PRESTO_HOME/etc \
+    && mkdir -p $PRESTO_HOME/etc/catalog \
+    && mkdir -p /var/lib/presto/data \
+    && mkdir -p /usr/lib/presto/utils
+
+COPY scripts/etc/config.properties.example $PRESTO_HOME/etc/config.properties
+COPY scripts/etc/jvm.config.example $PRESTO_HOME/etc/jvm.config
+COPY scripts/etc/node.properties $PRESTO_HOME/etc/node.properties
+COPY scripts/start-prestojava.sh /opt
+
+WORKDIR /velox

--- a/scripts/start-prestojava.sh
+++ b/scripts/start-prestojava.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+echo "node.id=$HOSTNAME" >> $PRESTO_HOME/etc/node.properties
+
+$PRESTO_HOME/bin/launcher run

--- a/scripts/velox-torcharrow-container.dockfile
+++ b/scripts/velox-torcharrow-container.dockfile
@@ -16,6 +16,6 @@
 
 FROM quay.io/pypa/manylinux2014_x86_64
 ARG cpu_target
-COPY setup-velox-torcharrow.sh /
-COPY setup-helper-functions.sh /
+COPY scripts/setup-velox-torcharrow.sh /
+COPY scripts/setup-helper-functions.sh /
 RUN mkdir build && ( cd build && CPU_TARGET="$cpu_target" bash /setup-velox-torcharrow.sh ) && rm -rf build


### PR DESCRIPTION
This image will allow us to run Velox + Presto java and allow Velox to use Presto java as a source of truth for its fuzzer runs. 

Once the image is built , you can run presto java on it by calling /opt/start-prestojava.sh 