### PR TITLE
Fix HashTable::toString()

### DIFF
--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -1465,27 +1465,31 @@ void HashTable<ignoreNullKeys>::decideHashMode(
 template <bool ignoreNullKeys>
 std::string HashTable<ignoreNullKeys>::toString() {
   std::stringstream out;
-  int64_t occupied = 0;
-
-  out << "[HashTable  size: " << capacity_
+  out << "[HashTable keys: " << hashers_.size()
+      << " hash mode: " << modeString(hashMode_) << " capacity: " << capacity_
       << " distinct count: " << numDistinct_
-      << " tombstone count: " << numTombstones_ << "]";
+      << " tombstones count: " << numTombstones_ << "]";
   if (table_ == nullptr) {
-    out << "(no table) ";
+    out << " (no table)";
   }
+
   for (auto& hasher : hashers_) {
-    out << hasher->toString();
+    out << std::endl << hasher->toString();
   }
+  out << std::endl;
+
   if (kTrackLoads) {
-    out << std::endl;
     out << fmt::format(
-        "{} probes {} tag loads {} row loads {} hits",
-        numProbes_,
-        numTagLoads_,
-        numRowLoads_,
-        numHits_);
+               "{} probes {} tag loads {} row loads {} hits",
+               numProbes_,
+               numTagLoads_,
+               numRowLoads_,
+               numHits_)
+        << std::endl;
   }
+
   if (hashMode_ == HashMode::kArray) {
+    int64_t occupied = 0;
     if (table_ && tableAllocation_.data() && tableAllocation_.size()) {
       // 'size_' and 'table_' may not be set if initializing.
       uint64_t size = std::min<uint64_t>(
@@ -1494,22 +1498,77 @@ std::string HashTable<ignoreNullKeys>::toString() {
         occupied += table_[i] != nullptr;
       }
     }
+    out << "Total slots used: " << occupied << std::endl;
   } else {
-    // Count of groups indexed by number of non-empty slots.
-    int64_t numGroups[sizeof(TagVector) + 1] = {};
+    int64_t occupied = 0;
+
+    // Count of buckets indexed by the number of non-empty slots.
+    // Each bucket has 16 slots. Hence, the number of non-empty slots is between
+    // 0 and 16 (17 possible values).
+    int64_t numBuckets[sizeof(TagVector) + 1] = {};
     for (int64_t bucketOffset = 0; bucketOffset < sizeMask_;
          bucketOffset += kBucketSize) {
       auto tags = loadTags(bucketOffset);
       auto filled = simd::toBitMask(tags != TagVector::broadcast(0));
-      ++numGroups[__builtin_popcount(filled)];
-      occupied += filled;
+      auto numOccupied = __builtin_popcount(filled);
+
+      ++numBuckets[numOccupied];
+      occupied += numOccupied;
     }
-    out << " occupied=" << occupied;
-    out << std::endl;
-    for (auto i = 0; i < sizeof(numGroups) / sizeof(numGroups[0]); ++i) {
-      out << numGroups[i] << " groups with " << i << " entries" << std::endl;
+
+    out << "Total buckets: " << (sizeMask_ / kBucketSize + 1) << std::endl;
+    out << "Total slots used: " << occupied << std::endl;
+    for (auto i = 1; i < sizeof(TagVector) + 1; ++i) {
+      if (numBuckets[i] > 0) {
+        out << numBuckets[i] << " buckets with " << i << " slots used"
+            << std::endl;
+      }
     }
   }
+
+  return out.str();
+}
+
+template <bool ignoreNullKeys>
+std::string HashTable<ignoreNullKeys>::toString(
+    int64_t startBucket,
+    int64_t numBuckets) const {
+  if (table_ == nullptr) {
+    return "(no table)";
+  }
+
+  VELOX_CHECK_GE(startBucket, 0);
+  VELOX_CHECK_GT(numBuckets, 0);
+
+  const int64_t totalBuckets = sizeMask_ / kBucketSize + 1;
+  if (startBucket >= totalBuckets) {
+    return "";
+  }
+
+  const int64_t endBucket =
+      std::min<int64_t>(startBucket + numBuckets, totalBuckets);
+
+  std::ostringstream out;
+  for (int64_t i = startBucket; i < endBucket; ++i) {
+    out << std::setw(1 + endBucket / 10) << i << ": ";
+
+    auto bucket = bucketAt(i * kBucketSize);
+    for (auto j = 0; j < sizeof(TagVector); ++j) {
+      if (j > 0) {
+        out << ", ";
+      }
+      const auto tag = bucket->tagAt(j);
+      if (tag == ProbeState::kTombstoneTag) {
+        out << std::setw(3) << "T";
+      } else if (tag == ProbeState::kEmptyTag) {
+        out << std::setw(3) << "E";
+      } else {
+        out << (int)tag;
+      }
+    }
+    out << std::endl;
+  }
+
   return out.str();
 }
 

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -487,6 +487,11 @@ class HashTable : public BaseHashTable {
 
   std::string toString() override;
 
+  /// Returns the details of the range of buckets. The range starts from
+  /// zero-based 'startBucket' and contains 'numBuckets' or however many there
+  /// are left till the end of the table.
+  std::string toString(int64_t startBucket, int64_t numBuckets = 1) const;
+
   /// Invoked to check the consistency of the internal state. The function scans
   /// all the table slots to check if the relevant slot counting are correct
   /// such as the number of used slots ('numDistinct_') and the number of


### PR DESCRIPTION
HashTable::toString() used to show incorrect total number of occupied slots.

Sample output:

```

[HashTable keys: 1 hash mode: HASH capacity: 2048 distinct count: 1000 tombstones count: 0]
<VectorHasher type=BIGINT  isRange_=0 rangeSize= 1 min=0 max=0 multiplier=1 numDistinct=0>
0 probes 1000 tag loads 512 row loads 500 hits
Total buckets: 128
Total slots used: 500
8 buckets with 1 slots used
21 buckets with 2 slots used
25 buckets with 3 slots used
27 buckets with 4 slots used
18 buckets with 5 slots used
12 buckets with 6 slots used
10 buckets with 7 slots used
2 buckets with 8 slots used
1 buckets with 9 slots used
1 buckets with 10 slots used
```

Also, add toString(startBucket, numBuckets) API to print details for a range of 
buckets. For each bucket, prints 16 tags: a value, E if empty, T if tombstone.

For example, toString(31, 5):

```
  31: 194, 208, 249, 224,   E,   E,   E,   E,   E,   E,   E,   E,   E,   E,   E,   E
  32: 130, 249, 134, 129, 136, 161, 134,   E,   E,   E,   E,   E,   E,   E,   E,   E
  33: 227, 208, 245, 147, 182,   E,   E,   E,   E,   E,   E,   E,   E,   E,   E,   E
  34: 180, 193,   E,   E,   E,   E,   E,   E,   E,   E,   E,   E,   E,   E,   E,   E
  35: 246, 134, 241,   E,   E,   E,   E,   E,   E,   E,   E,   E,   E,   E,   E,   E
```