### PR TITLE
Fix infinite parallel join probe loop

### DIFF
--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -24,6 +24,34 @@
 namespace facebook::velox::exec {
 
 using PartitionBoundIndexType = int64_t;
+/// Provides the partition info for parallel join table build use.
+struct TableInsertPartitionInfo {
+  /// ['start', 'end') specifies the insert range of this table partition.
+  PartitionBoundIndexType start;
+  PartitionBoundIndexType end;
+  /// Used to contains the overflowed rows which can't be inserted into the
+  /// given table partition range.
+  std::vector<char*>& overflows;
+
+  TableInsertPartitionInfo(
+      PartitionBoundIndexType _start,
+      PartitionBoundIndexType _end,
+      std::vector<char*>& _overflows)
+      : start(_start), end(_end), overflows(_overflows) {
+    VELOX_CHECK_GE(start, 0);
+    VELOX_CHECK_LT(start, end);
+  }
+
+  /// Indicates if 'index' is within this partition range.
+  bool inRange(PartitionBoundIndexType index) const {
+    return index >= start && index < end;
+  }
+
+  /// Adds 'row' falls outside of this partititon range into 'overflows'.
+  void addOverflow(char* row) {
+    overflows.push_back(row);
+  }
+};
 
 /// Contains input and output parameters for groupProbe and joinProbe APIs.
 struct HashLookup {
@@ -352,6 +380,10 @@ FOLLY_ALWAYS_INLINE std::ostream& operator<<(
 }
 
 class ProbeState;
+namespace test {
+template <bool ignoreNullKeys>
+class HashTableTestHelper;
+}
 
 template <bool ignoreNullKeys>
 class HashTable : public BaseHashTable {
@@ -536,10 +568,6 @@ class HashTable : public BaseHashTable {
   /// purpose.
   void checkConsistency() const;
 
-  void testingSetHashMode(HashMode mode, int32_t numNew) {
-    setHashMode(mode, numNew);
-  }
-
   auto& testingOtherTables() const {
     return otherTables_;
   }
@@ -683,22 +711,19 @@ class HashTable : public BaseHashTable {
       raw_vector<uint64_t>& hashes,
       bool initNormalizedKeys);
 
-  // Inserts 'numGroups' entries into 'this'. 'groups' point to
-  // contents in a RowContainer owned by 'this'. 'hashes' are the hash
-  // numbers or array indices (if kArray mode) for each
-  // group. Duplicate key rows are chained via their next link. if
-  // parallel build, partitionEnd is the index of the first entry
-  // after the partition being inserted. If a row would be inserted to
-  // the right of the end, it is not inserted but rather added to the
-  // end of 'overflows'.
+  /// Inserts 'numGroups' entries into 'this'. 'groups' point to contents in a
+  /// RowContainer owned by 'this'. 'hashes' are the hash numbers or array
+  /// indices (if kArray mode) for each group. Duplicate key rows are chained
+  /// via their next link. If not null, 'partitionInfo' provides the table
+  /// partition info for parallel join table build. It specifies the first and
+  /// (exclusive) last indexes of the insert entries in the table. If a row
+  /// can't be inserted within this range, it is not inserted but rather added
+  /// to the end of 'overflows' in 'partitionInfo'.
   void insertForJoin(
       char** groups,
       uint64_t* hashes,
       int32_t numGroups,
-      PartitionBoundIndexType partitionBegin = 0,
-      PartitionBoundIndexType partitionEnd =
-          std::numeric_limits<PartitionBoundIndexType>::max(),
-      std::vector<char*>* overflows = nullptr);
+      TableInsertPartitionInfo* = nullptr);
 
   // Inserts 'numGroups' entries into 'this'. 'groups' point to
   // contents in a RowContainer owned by 'this'. 'hashes' are the hash
@@ -778,17 +803,15 @@ class HashTable : public BaseHashTable {
   // with the same key.
   void pushNext(char* row, char* next);
 
-  // Finishes inserting an entry into a join hash table. If the insert
-  // would fall outside of 'partitionBegin' ... 'partitionEnd', the
-  // insert is not made but the row is instead added to 'overflow'.
+  // Finishes inserting an entry into a join hash table. If 'partitionInfo' is
+  // not null and the insert falls out-side of the partition range, then insert
+  // is not made but row is instead added to 'overflow' in 'partitionInfo'
   void buildFullProbe(
       ProbeState& state,
       uint64_t hash,
       char* row,
       bool extraCheck,
-      PartitionBoundIndexType partitionBegin,
-      PartitionBoundIndexType partitionEnd,
-      std::vector<char*>* overflows);
+      TableInsertPartitionInfo* partitionInfo);
 
   // Updates 'hashers_' to correspond to the keys in the
   // content. Returns true if all hashers offer a mapping to value ids
@@ -812,9 +835,14 @@ class HashTable : public BaseHashTable {
 
   // Returns the byte offset of the next bucket from 'offset'. Wraps around at
   // the end of the table.
-  int64_t nextBucketOffset(int32_t offset) const {
-    VELOX_DCHECK_EQ(0, offset & (kBucketSize - 1));
-    return sizeMask_ & (offset + kBucketSize);
+  int64_t nextBucketOffset(int64_t bucketOffset) const {
+    VELOX_DCHECK_EQ(0, bucketOffset & (kBucketSize - 1));
+    VELOX_DCHECK_LT(bucketOffset, sizeMask_);
+    return sizeMask_ & (bucketOffset + kBucketSize);
+  }
+
+  int64_t numBuckets() const {
+    return numBuckets_;
   }
 
   // Return the row pointer at 'slotIndex' of bucket at 'bucketOffset'.
@@ -864,8 +892,7 @@ class HashTable : public BaseHashTable {
   // many threads can set this.
   std::atomic<bool> hasDuplicates_{false};
 
-  // Offset of next row link for join build side, 0 if none. Copied
-  // from 'rows_'.
+  // Offset of next row link for join build side set from 'rows_'.
   int32_t nextOffset_;
   char** table_ = nullptr;
   memory::ContiguousAllocation tableAllocation_;
@@ -880,6 +907,7 @@ class HashTable : public BaseHashTable {
   // Mask used to get the byte offset of a bucket from 'table_' given a hash
   // number.
   int64_t bucketOffsetMask_{0};
+  int64_t numBuckets_{0};
   int64_t numDistinct_{0};
   // Counts the number of tombstone table slots.
   int64_t numTombstones_{0};
@@ -903,8 +931,6 @@ class HashTable : public BaseHashTable {
   // Number of times a match is found.
   mutable tsan_atomic<int64_t> numHits_{0};
 
-  friend class ProbeState;
-
   // Bounds of independently buildable index ranges in the table. The
   // range of partition i starts at [i] and ends at [i +1]. Bounds are multiple
   // of cache line  size.
@@ -921,6 +947,9 @@ class HashTable : public BaseHashTable {
 
   // If true, avoids using VectorHasher value ranges with kArray hash mode.
   bool disableRangeArrayHash_{false};
+
+  friend class ProbeState;
+  friend test::HashTableTestHelper<ignoreNullKeys>;
 };
 
 } // namespace facebook::velox::exec

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -988,8 +988,8 @@ int32_t RowContainer::listPartitionRows(
         atEnd = true;
       }
       while (bits) {
-        int32_t hit = __builtin_ctz(bits);
-        auto distance = hit + startRow - iter.rowNumber;
+        const int32_t hit = __builtin_ctz(bits);
+        const auto distance = hit + startRow - iter.rowNumber;
         skip(iter, distance);
         result[numResults++] = iter.currentRow();
         if (numResults == maxRows) {

--- a/velox/exec/benchmarks/HashTableBenchmark.cpp
+++ b/velox/exec/benchmarks/HashTableBenchmark.cpp
@@ -561,8 +561,8 @@ class HashTableBenchmark : public VectorTestBase {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
-  std::unique_ptr<test::VectorMaker> vectorMaker_{
-      std::make_unique<test::VectorMaker>(pool_.get())};
+  std::unique_ptr<VectorMaker> vectorMaker_{
+      std::make_unique<VectorMaker>(pool_.get())};
   // Bitmap of positions in batches_ that end up in the table.
   std::vector<uint64_t> isInTable_;
   // Test payload, keys first.

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -33,6 +33,52 @@ using namespace facebook::velox;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::test;
 
+namespace facebook::velox::exec::test {
+
+template <bool ignoreNullKeys>
+class HashTableTestHelper {
+ public:
+  static HashTableTestHelper create(HashTable<ignoreNullKeys>* table) {
+    return HashTableTestHelper(table);
+  }
+
+  int64_t nextBucketOffset(int64_t offset) const {
+    return table_->nextBucketOffset(offset);
+  }
+
+  uint64_t bucketSize() const {
+    return HashTable<ignoreNullKeys>::kBucketSize;
+  }
+
+  void allocateTables(uint64_t size) {
+    table_->allocateTables(size);
+  }
+
+  size_t tableSlotSize() const {
+    return table_->tableSlotSize();
+  }
+
+  void insertForJoin(
+      char** groups,
+      uint64_t* hashes,
+      int32_t numGroups,
+      TableInsertPartitionInfo* partitionInfo) {
+    table_->insertForJoin(groups, hashes, numGroups, partitionInfo);
+  }
+
+  void setHashMode(BaseHashTable::HashMode mode, int32_t numNew) {
+    table_->setHashMode(mode, numNew);
+  }
+
+ private:
+  explicit HashTableTestHelper(HashTable<ignoreNullKeys>* table)
+      : table_(table) {
+    VELOX_CHECK_NOT_NULL(table_);
+  }
+
+  HashTable<ignoreNullKeys>* const table_;
+};
+
 // Test framework for join hash tables. Generates probe keys, of which
 // some percent are inserted in a hashTable. The placement of the
 // payload is shuffled so as not to correlate with the probe
@@ -92,6 +138,7 @@ class HashTableTest : public testing::TestWithParam<bool>,
       sequence += size;
       if (!topTable_) {
         topTable_ = std::move(table);
+        numRows += topTable_->rows()->numRows();
       } else {
         numRows += table->rows()->numRows();
         otherTables.push_back(std::move(table));
@@ -99,7 +146,7 @@ class HashTableTest : public testing::TestWithParam<bool>,
       batches_.insert(batches_.end(), batches.begin(), batches.end());
       startOffset += size;
     }
-    numRows += topTable_->rows()->numRows();
+
     const uint64_t estimatedTableSize =
         topTable_->estimateHashTableSize(numRows);
     const uint64_t usedMemoryBytes = topTable_->rows()->pool()->currentBytes();
@@ -236,7 +283,7 @@ class HashTableTest : public testing::TestWithParam<bool>,
       const std::vector<RowVectorPtr>& batches,
       int32_t tableOffset,
       BaseHashTable* table) {
-    int32_t batchSize = batches[0]->size();
+    const int32_t batchSize = batches[0]->size();
     raw_vector<uint64_t> dummy(batchSize);
     int32_t batchOffset = 0;
     rowOfKey_.resize(tableOffset + batchSize * batches.size());
@@ -248,9 +295,9 @@ class HashTableTest : public testing::TestWithParam<bool>,
     SelectivityVector rows(batchSize);
     SelectivityVector insertedRows(batchSize);
     for (auto& batch : batches) {
-      // If we are only inserting a fraction of the rows, we set
-      // insertedRows to that fraction so that the VectorHashers only
-      // see keys that will actually be inserted.
+      // If we are only inserting a fraction of the rows, we set insertedRows to
+      // that fraction so that the VectorHashers only see keys that will
+      // actually be inserted.
       if (insertPct_ < 100) {
         bits::copyBits(
             isInTable_.data(),
@@ -277,13 +324,12 @@ class HashTableTest : public testing::TestWithParam<bool>,
       batchOffset += batchSize;
     }
 
-    auto size = batchSize * batches.size();
-    auto powerOfTwo = bits::nextPowerOfTwo(size);
-    int32_t mask = powerOfTwo - 1;
+    const auto size = batchSize * batches.size();
+    const auto powerOfTwo = bits::nextPowerOfTwo(size);
+    const int32_t mask = powerOfTwo - 1;
     int32_t position = 0;
     int32_t delta = 1;
-    int32_t numInserted = 0;
-    auto nextOffset = rowContainer->nextOffset();
+    const auto nextOffset = rowContainer->nextOffset();
 
     // We insert values in a geometric skip order. 1, 2, 4, 7,
     // 11,... where the skip increments by one. We wrap around at the
@@ -296,12 +342,11 @@ class HashTableTest : public testing::TestWithParam<bool>,
            bits::isBitSet(isInTable_.data(), tableOffset + position))) {
         char* newRow = rowContainer->newRow();
         rowOfKey_[tableOffset + position] = newRow;
-        auto batchIndex = position / batchSize;
-        auto rowIndex = position % batchSize;
-        if (nextOffset) {
+        const auto batchIndex = position / batchSize;
+        const auto rowIndex = position % batchSize;
+        if (nextOffset > 0) {
           *reinterpret_cast<char**>(newRow + nextOffset) = nullptr;
         }
-        ++numInserted;
         for (auto i = 0; i < batches[batchIndex]->type()->size(); ++i) {
           rowContainer->store(decoded[batchIndex][i], rowIndex, newRow, i);
         }
@@ -383,9 +428,9 @@ class HashTableTest : public testing::TestWithParam<bool>,
 
   void testProbe() {
     auto lookup = std::make_unique<HashLookup>(topTable_->hashers());
-    auto batchSize = batches_[0]->size();
+    const auto batchSize = batches_[0]->size();
     SelectivityVector rows(batchSize);
-    auto mode = topTable_->hashMode();
+    const auto mode = topTable_->hashMode();
     SelectivityInfo hashTime;
     SelectivityInfo probeTime;
     int32_t numHashed = 0;
@@ -394,14 +439,14 @@ class HashTableTest : public testing::TestWithParam<bool>,
     auto& hashers = topTable_->hashers();
     VectorHasher::ScratchMemory scratchMemory;
     for (auto batchIndex = 0; batchIndex < batches_.size(); ++batchIndex) {
-      auto batch = batches_[batchIndex];
+      const auto& batch = batches_[batchIndex];
       lookup->reset(batch->size());
       rows.setAll();
       numHashed += batch->size();
       {
         SelectivityTimer timer(hashTime, 0);
         for (auto i = 0; i < hashers.size(); ++i) {
-          auto key = batch->childAt(i);
+          auto& key = batch->childAt(i);
           if (mode != BaseHashTable::HashMode::kHash) {
             hashers[i]->lookupValueIds(
                 *key, rows, scratchMemory, lookup->hashes);
@@ -419,11 +464,12 @@ class HashTableTest : public testing::TestWithParam<bool>,
       } else {
         constexpr int32_t kPadding = simd::kPadding / sizeof(int32_t);
         lookup->rows.resize(bits::roundUp(rows.size() + kPadding, kPadding));
-        auto numRows = simd::indicesOfSetBits(
+        const auto numRows = simd::indicesOfSetBits(
             rows.asRange().bits(), 0, batch->size(), lookup->rows.data());
         lookup->rows.resize(numRows);
       }
-      auto startOffset = batchIndex * batchSize;
+
+      const auto startOffset = batchIndex * batchSize;
       if (lookup->rows.empty()) {
         // the keys disqualify all entries. The table is not consulted.
         for (auto i = startOffset; i < startOffset + batch->size(); ++i) {
@@ -436,21 +482,12 @@ class HashTableTest : public testing::TestWithParam<bool>,
           topTable_->joinProbe(*lookup);
         }
         for (auto i = 0; i < lookup->rows.size(); ++i) {
-          auto key = lookup->rows[i];
+          const auto key = lookup->rows[i];
           numHit += lookup->hits[key] != nullptr;
           ASSERT_EQ(rowOfKey_[startOffset + key], lookup->hits[key]);
         }
       }
     }
-    LOG(INFO)
-        << fmt::format(
-               "Hashed: {} Probed: {} Hit: {} Hash time/row {} probe time/row {}",
-               numHashed,
-               numProbed,
-               numHit,
-               hashTime.timeToDropValue() / numHashed,
-               probeTime.timeToDropValue() / numProbed)
-        << std::endl;
   }
 
   // Erases every strideth non-erased item in the hash table.
@@ -753,9 +790,10 @@ TEST_P(HashTableTest, checkSizeValidation) {
   auto rowType = ROW({"a"}, {BIGINT()});
   auto table = createHashTableForAggregation(rowType, 1);
   auto lookup = std::make_unique<HashLookup>(table->hashers());
+  auto testHelper = HashTableTestHelper<false>::create(table.get());
 
   // The initial set hash mode with table size of 256K entries.
-  table->testingSetHashMode(BaseHashTable::HashMode::kHash, 131'072);
+  testHelper.setHashMode(BaseHashTable::HashMode::kHash, 131'072);
   ASSERT_EQ(table->capacity(), 256 << 10);
 
   auto vector1 = makeRowVector(
@@ -790,11 +828,6 @@ TEST_P(HashTableTest, listNullKeyRows) {
   testListNullKeyRows(keys, BaseHashTable::HashMode::kHash);
 }
 
-VELOX_INSTANTIATE_TEST_SUITE_P(
-    HashTableTests,
-    HashTableTest,
-    testing::Values(true, false));
-
 TEST(HashTableTest, modeString) {
   ASSERT_EQ("HASH", BaseHashTable::modeString(BaseHashTable::HashMode::kHash));
   ASSERT_EQ(
@@ -806,6 +839,79 @@ TEST(HashTableTest, modeString) {
       "Unknown HashTable mode:100",
       BaseHashTable::modeString(static_cast<BaseHashTable::HashMode>(100)));
 }
+
+DEBUG_ONLY_TEST_P(HashTableTest, nextBucketOffset) {
+  auto runTest = [&](BaseHashTable::HashMode mode, const RowTypePtr& type) {
+    std::vector<std::unique_ptr<VectorHasher>> keyHashers;
+    for (auto channel = 0; channel < type->size(); ++channel) {
+      keyHashers.emplace_back(
+          std::make_unique<VectorHasher>(type->childAt(channel), channel));
+    }
+    auto table = HashTable<true>::createForJoin(
+        std::move(keyHashers), {}, true, false, 1'000, pool());
+    auto testHelper = HashTableTestHelper<true>::create(table.get());
+    const uint64_t numDistincts = bits::nextPowerOfTwo(
+        2UL * std::numeric_limits<int32_t>::max() / testHelper.tableSlotSize());
+    const uint64_t totalSize = numDistincts * testHelper.tableSlotSize();
+    testHelper.allocateTables(numDistincts);
+    const auto bucketSize = testHelper.bucketSize();
+
+    struct {
+      uint64_t offset;
+      bool expectedNextOffsetError;
+      uint64_t expectedNextOffset;
+
+      std::string debugString() const {
+        return fmt::format(
+            "offset {}, expectedNextOffsetError {}, expectedNextOffset {}",
+            succinctBytes(offset),
+            expectedNextOffsetError,
+            succinctBytes(expectedNextOffset));
+      }
+    } testSettings[] = {
+        {1, true, 0},
+        {bucketSize - 1, true, 0},
+        {bucketSize + 1, true, 0},
+        {0, false, bucketSize},
+        {bucketSize, false, bucketSize + bucketSize},
+        {bits::nextPowerOfTwo(std::numeric_limits<int32_t>::max()),
+         false,
+         bits::nextPowerOfTwo(std::numeric_limits<int32_t>::max()) +
+             bucketSize},
+        {bits::nextPowerOfTwo(std::numeric_limits<int32_t>::max()) + 1,
+         true,
+         0},
+        {bits::nextPowerOfTwo(std::numeric_limits<int32_t>::max()) + bucketSize,
+         false,
+         bits::nextPowerOfTwo(std::numeric_limits<int32_t>::max()) +
+             2 * bucketSize},
+        {totalSize, true, 0},
+        {totalSize + bucketSize, true, 0},
+        {totalSize + 1, true, 0},
+        {totalSize - bucketSize, false, 0}};
+
+    for (const auto& testData : testSettings) {
+      SCOPED_TRACE(testData.debugString());
+
+      if (testData.expectedNextOffsetError) {
+        VELOX_ASSERT_THROW(testHelper.nextBucketOffset(testData.offset), "");
+      } else {
+        ASSERT_EQ(
+            testHelper.nextBucketOffset(testData.offset),
+            testData.expectedNextOffset);
+      }
+    }
+  };
+
+  const auto type = ROW({"key"}, {ROW({"k1"}, {BIGINT()})});
+  runTest(BaseHashTable::HashMode::kHash, type);
+  runTest(BaseHashTable::HashMode::kNormalizedKey, type);
+}
+
+VELOX_INSTANTIATE_TEST_SUITE_P(
+    HashTableTests,
+    HashTableTest,
+    testing::Values(true, false));
 
 /// This tests an issue only seen when the number of unique entries
 /// in the HashTable, crosses over int32 limit. The HashTable::loadTag()
@@ -852,7 +958,7 @@ DEBUG_ONLY_TEST_P(HashTableTest, failureInCreateRowPartitions) {
         std::move(hashers), {BIGINT()}, true, false, 1, pool());
     copyVectorsToTable({batch}, 0, table.get());
 
-    if (!topTable) {
+    if (topTable == nullptr) {
       topTable = std::move(table);
     } else {
       otherTables.emplace_back(std::move(table));
@@ -860,6 +966,7 @@ DEBUG_ONLY_TEST_P(HashTableTest, failureInCreateRowPartitions) {
   }
 
   topTable->prepareJoinTable(std::move(otherTables), executor_.get());
+  auto topTabletestHelper = HashTableTestHelper<false>::create(topTable.get());
 
   const std::string expectedFailureMessage =
       "Triggering expected failure in allocation";
@@ -917,7 +1024,7 @@ DEBUG_ONLY_TEST_P(HashTableTest, failureInCreateRowPartitions) {
   // Set hash mode to HASH and numNew to something much larger than the
   // capacity to trigger a rehash.
   VELOX_ASSERT_THROW(
-      topTable->testingSetHashMode(
+      topTabletestHelper.setHashMode(
           BaseHashTable::HashMode::kHash, topTable->capacity() * 2),
       expectedFailureMessage);
 
@@ -981,3 +1088,47 @@ TEST_P(HashTableTest, toStringMultipleKeys) {
 
   ASSERT_NO_THROW(table->toString());
 }
+
+TEST(HashTableTest, tableInsertPartitionInfo) {
+  std::vector<char*> overflows;
+  const auto testFn = [&](PartitionBoundIndexType start,
+                          PartitionBoundIndexType end) {
+    TableInsertPartitionInfo info{start, end, overflows};
+  };
+  struct {
+    PartitionBoundIndexType start;
+    PartitionBoundIndexType end;
+
+    std::string debugString() const {
+      return fmt::format("start {}, end {}", start, end);
+    }
+  } badSettings[] = {
+      {0, 0}, {-2, -1}, {-1, -1}, {-1, 0}, {-1, 1}, {32, 1}, {32, 32}};
+  for (const auto& badData : badSettings) {
+    SCOPED_TRACE(badData.debugString());
+    VELOX_ASSERT_THROW(testFn(badData.start, badData.end), "");
+  }
+  ASSERT_TRUE(overflows.empty());
+
+  TableInsertPartitionInfo info{1, 1000, overflows};
+  ASSERT_TRUE(info.inRange(1));
+  ASSERT_FALSE(info.inRange(0));
+  ASSERT_FALSE(info.inRange(-1));
+  ASSERT_TRUE(info.inRange(999));
+  ASSERT_FALSE(info.inRange(1'000));
+  ASSERT_FALSE(info.inRange(12'000));
+  ASSERT_TRUE(overflows.empty());
+
+  const std::vector<uint64_t> insertBuffers{100, 200, 300, 500};
+  for (const auto insertBuffer : insertBuffers) {
+    info.addOverflow(reinterpret_cast<char*>(insertBuffer));
+  }
+  ASSERT_EQ(overflows.size(), insertBuffers.size());
+  for (int i = 0; i < insertBuffers.size(); ++i) {
+    ASSERT_EQ(insertBuffers[i], reinterpret_cast<uint64_t>(info.overflows[i]));
+  }
+  for (int i = 0; i < overflows.size(); ++i) {
+    ASSERT_EQ(overflows[i], info.overflows[i]);
+  }
+}
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
There is infinite loop problem found in parallel table build in Meta internal test.
If bucketOffset_ (int64_t) in ProbeState exceeds int32_t max limit,  then
HashTable::nextBucketOffset(int32_t) might cast it to a smaller value which cause
fullProbe to restart the probe from a lower bucket offset and repeat this process
forever.
This PR fixes the problem by (1) change nextBucketOffset to take int64_t to int32_t
to prevent offset integer overflow, and (2) fall back to the overflow insert path if the
next bucket offset is below the starting bucket offset; (3) to prevent the similar bug
to happen, we add to count the number of probed buckets and throws if the count
exceeds the total number of buckets in the table. This fails a query but will not hang
the driver thread.
Also refactor the code by putting all the parallel join build related parameter into a
TableInsertPartitionInfo data structure to simplify the implementation.