### PR TITLE
Fix LimitNode's offset and count type.

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1844,8 +1844,8 @@ class LimitNode : public PlanNode {
   // nodes.
   LimitNode(
       const PlanNodeId& id,
-      int32_t offset,
-      int32_t count,
+      int64_t offset,
+      int64_t count,
       bool isPartial,
       const PlanNodePtr& source)
       : PlanNode(id),
@@ -1867,11 +1867,11 @@ class LimitNode : public PlanNode {
     return sources_;
   }
 
-  int32_t offset() const {
+  int64_t offset() const {
     return offset_;
   }
 
-  int32_t count() const {
+  int64_t count() const {
     return count_;
   }
 
@@ -1890,8 +1890,8 @@ class LimitNode : public PlanNode {
  private:
   void addDetails(std::stringstream& stream) const override;
 
-  const int32_t offset_;
-  const int32_t count_;
+  const int64_t offset_;
+  const int64_t count_;
   const bool isPartial_;
   const std::vector<PlanNodePtr> sources_;
 };

--- a/velox/exec/Limit.h
+++ b/velox/exec/Limit.h
@@ -39,8 +39,8 @@ class Limit : public Operator {
   }
 
  private:
-  int32_t remainingOffset_;
-  int32_t remainingLimit_;
+  int64_t remainingOffset_;
+  int64_t remainingLimit_;
   bool finished_{false};
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/LimitTest.cpp
+++ b/velox/exec/tests/LimitTest.cpp
@@ -36,18 +36,24 @@ TEST_F(LimitTest, basic) {
   }
   createDuckDbTable(vectors);
 
-  auto makePlan = [&](int32_t offset, int32_t limit) {
+  auto makePlan = [&](int64_t offset, int64_t limit) {
     return PlanBuilder().values(vectors).limit(offset, limit, true).planNode();
   };
 
   assertQuery(makePlan(0, 10), "SELECT * FROM tmp LIMIT 10");
-  assertQuery(makePlan(0, 1'000), "SELECT * FROM tmp LIMIT 1000");
+  assertQuery(
+      makePlan(0, 100'0000'000'000), "SELECT * FROM tmp LIMIT 1000000000000");
   assertQuery(makePlan(0, 1'234), "SELECT * FROM tmp LIMIT 1234");
 
   assertQuery(makePlan(17, 10), "SELECT * FROM tmp OFFSET 17 LIMIT 10");
   assertQuery(makePlan(17, 983), "SELECT * FROM tmp OFFSET 17 LIMIT 983");
-  assertQuery(makePlan(17, 1'000), "SELECT * FROM tmp OFFSET 17 LIMIT 1000");
+  assertQuery(
+      makePlan(17, 100'0000'000'000),
+      "SELECT * FROM tmp OFFSET 17 LIMIT 1000000000000");
   assertQuery(makePlan(17, 2'000), "SELECT * FROM tmp OFFSET 17 LIMIT 2000");
+  assertQuery(
+      makePlan(100'000'000'000, 100'0000'000'000),
+      "SELECT * FROM tmp OFFSET 100000000000 LIMIT 1000000000000");
 
   assertQuery(makePlan(1'000, 145), "SELECT * FROM tmp OFFSET 1000 LIMIT 145");
   assertQuery(

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -1011,7 +1011,7 @@ PlanBuilder& PlanBuilder::topN(
   return *this;
 }
 
-PlanBuilder& PlanBuilder::limit(int32_t offset, int32_t count, bool isPartial) {
+PlanBuilder& PlanBuilder::limit(int64_t offset, int64_t count, bool isPartial) {
   planNode_ = std::make_shared<core::LimitNode>(
       nextPlanNodeId(), offset, count, isPartial, planNode_);
   return *this;

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -693,7 +693,7 @@ class PlanBuilder {
   /// @param isPartial Boolean indicating whether the limit node is partial or
   /// final. Partial limit can run multi-threaded. Final limit must run
   /// single-threaded.
-  PlanBuilder& limit(int32_t offset, int32_t count, bool isPartial);
+  PlanBuilder& limit(int64_t offset, int64_t count, bool isPartial);
 
   /// Add an EnforceSingleRowNode to ensure input has at most one row at
   /// runtime.


### PR DESCRIPTION
Summary: LimitNode offset and count is 32bit integer. It does not work for 64bit integer. Also when [Presto converts LimitNode to Velox LimitNode](https://github.com/prestodb/presto/blob/master/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.h#L1908), a 64 bit integer is converted to 32 bit causing errors like `VeloxRuntimeError: count > 0 (-727379968 vs. 0) Limit must specify greater than zero number of rows to keep`. Here we fix this issue.

Differential Revision: D51966656


