### PR TITLE
Fix compilation error caused by testCast

### DIFF
--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -1348,8 +1348,7 @@ TEST_F(CastExprTest, truncateVsRound) {
 
   setCastIntByTruncate(false);
   testCast<int32_t, int8_t>("tinyint", {2, 3}, {2, 3});
-  testCast<int32_t, int8_t>(
-      "tinyint", {1111111, 1000, -100101}, {0, 0, 0}, true);
+  testCast<int32_t, int8_t>("tinyint", {1111111, 1000, -100101}, {0, 0, 0});
 }
 
 TEST_F(CastExprTest, nullInputs) {


### PR DESCRIPTION
Fixes below compilation error as old testCast function was used in https://github.com/facebookincubator/velox/commit/7249cd9b834373c73009fa625b35e289ad247101.

> ../../velox/expression/tests/CastExprTest.cpp:1352:59: error: no matching function for call to ‘facebook::velox::test::{anonymous}::CastExprTest_truncateVsRound_Test::testCast<int32_t, int8_t>(const char [8], <brace-enclosed initializer list>, <brace-enclosed initializer list>, bool)’
1352 |       "tinyint", {1111111, 1000, -100101}, {0, 0, 0}, true);