### PR TITLE
Fix DecimalUtil::computeAverage accuracy issue

### DIFF
--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -232,7 +232,7 @@ class DecimalUtil {
       ++quotient;
     }
     r = quotient * resultSign;
-    return remainder;
+    return remainder * resultSign;
   }
 
   /*
@@ -311,38 +311,12 @@ class DecimalUtil {
     return sum;
   }
 
-  /*
-   * Computes average. If there is an overflow value uses the following
-   * expression to compute the average.
-   *                       ---                                         ---
-   *                      |    overflow_multiplier          sum          |
-   * average = overflow * |     -----------------  +  ---------------    |
-   *                      |         count              count * overflow  |
-   *                       ---                                         ---
-   */
-  inline static void computeAverage(
+  /// avg = (sum + overflow * kOverflowMultiplier) / count
+  static void computeAverage(
       int128_t& avg,
       const int128_t& sum,
-      const int64_t count,
-      const int64_t overflow) {
-    if (overflow == 0) {
-      divideWithRoundUp<int128_t, int128_t, int64_t>(
-          avg, sum, count, false, 0, 0);
-    } else {
-      __uint128_t sumA{0};
-      auto remainderA =
-          DecimalUtil::divideWithRoundUp<__uint128_t, __uint128_t, int64_t>(
-              sumA, kOverflowMultiplier, count, true, 0, 0);
-      double totalRemainder = (double)remainderA / count;
-      __uint128_t sumB{0};
-      auto remainderB =
-          DecimalUtil::divideWithRoundUp<__uint128_t, __int128_t, int64_t>(
-              sumB, sum, count * overflow, true, 0, 0);
-      totalRemainder += (double)remainderB / (count * overflow);
-      DecimalUtil::addWithOverflow(avg, sumA, sumB);
-      avg = avg * overflow + (int)(totalRemainder * overflow);
-    }
-  }
+      int64_t count,
+      int64_t overflow);
 
   /// Origins from java side BigInteger#bitLength.
   ///

--- a/velox/type/tests/DecimalTest.cpp
+++ b/velox/type/tests/DecimalTest.cpp
@@ -193,6 +193,22 @@ TEST(DecimalTest, valueInPrecisionRange) {
       DecimalUtil::kLongDecimalMin - 1, LongDecimalType::kMaxPrecision));
 }
 
+TEST(DecimalTest, computeAverage) {
+  auto validateSameValues = [](int128_t value, int64_t maxCount) {
+    SCOPED_TRACE(fmt::format("value={} maxCount={}", value, maxCount));
+    int128_t sum = 0;
+    int64_t overflow = 0;
+    for (int64_t i = 1; i <= maxCount; ++i) {
+      overflow += DecimalUtil::addWithOverflow(sum, sum, value);
+      int128_t avg;
+      DecimalUtil::computeAverage(avg, sum, i, overflow);
+      ASSERT_EQ(avg, value);
+    }
+  };
+  validateSameValues(DecimalUtil::kLongDecimalMin, 1'000'000);
+  validateSameValues(DecimalUtil::kLongDecimalMax, 1'000'000);
+}
+
 TEST(DecimalAggregateTest, adjustSumForOverflow) {
   struct SumWithOverflow {
     int128_t sum{0};


### PR DESCRIPTION
Summary:
We are converting decimal into double during the computation and this
reduces the accuracy.  Change the calculation to make the result exact.

Resolves https://github.com/facebookincubator/velox/issues/7434

Differential Revision: D51997944


