### PR TITLE
Add loadQuantum in Options copy operator

### DIFF
--- a/velox/common/io/Options.h
+++ b/velox/common/io/Options.h
@@ -84,6 +84,7 @@ class ReaderOptions {
     maxCoalesceDistance_ = other.maxCoalesceDistance_;
     maxCoalesceBytes_ = other.maxCoalesceBytes_;
     prefetchRowGroups_ = other.prefetchRowGroups_;
+    loadQuantum_ = other.loadQuantum_;
     return *this;
   }
 


### PR DESCRIPTION
it's a quick bug fix. loadQuantum is missing in Options' copy operator.