### PR TITLE
Add prefix to GCS and S3 uri separators

### DIFF
--- a/velox/connectors/hive/storage_adapters/gcs/GCSUtil.h
+++ b/velox/connectors/hive/storage_adapters/gcs/GCSUtil.h
@@ -21,7 +21,7 @@
 namespace facebook::velox {
 
 namespace {
-constexpr const char* kSep{"/"};
+constexpr std::string_view kGCSSep{"/"};
 constexpr std::string_view kGCSScheme{"gs://"};
 
 } // namespace
@@ -36,7 +36,7 @@ inline void setBucketAndKeyFromGCSPath(
     const std::string& path,
     std::string& bucket,
     std::string& key) {
-  auto firstSep = path.find_first_of(kSep);
+  auto firstSep = path.find_first_of(kGCSSep);
   bucket = path.substr(0, firstSep);
   key = path.substr(firstSep + 1);
 }
@@ -45,7 +45,7 @@ inline std::string gcsURI(const std::string& bucket) {
 }
 
 inline std::string gcsURI(const std::string& bucket, const std::string& key) {
-  return gcsURI(bucket) + kSep + key;
+  return gcsURI(bucket) + std::string(kGCSSep) + key;
 }
 
 inline std::string gcsPath(const std::string_view& path) {

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
@@ -29,7 +29,7 @@
 namespace facebook::velox {
 
 namespace {
-constexpr std::string_view kSep{"/"};
+constexpr std::string_view kS3Sep{"/"};
 // AWS S3 EMRFS, Hadoop block storage filesystem on-top of Amazon S3 buckets.
 constexpr std::string_view kS3Scheme{"s3://"};
 // This should not be mixed with s3 nor the s3a.
@@ -81,7 +81,7 @@ inline void getBucketAndKeyFromS3Path(
     const std::string& path,
     std::string& bucket,
     std::string& key) {
-  auto firstSep = path.find_first_of(kSep);
+  auto firstSep = path.find_first_of(kS3Sep);
   bucket = path.substr(0, firstSep);
   key = path.substr(firstSep + 1);
 }
@@ -98,7 +98,7 @@ inline std::string s3URI(const std::string& bucket) {
 }
 
 inline std::string s3URI(const std::string& bucket, const std::string& key) {
-  return s3URI(bucket) + "/" + key;
+  return s3URI(bucket) + std::string(kS3Sep) + key;
 }
 
 inline std::string s3Path(const std::string_view& path) {


### PR DESCRIPTION
Storage adapters for both GCS and S3 use a separator for their URIs. The symbols in each adapter use a prefix to avoid collisions. However, this is not the case for the symbol kSep. This change fixes such potential collision.