### PR TITLE
Fix CI run name for Join fuzzer

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -284,7 +284,7 @@ jobs:
         with:
           name: join
 
-      - name: "Run Aggregate Fuzzer"
+      - name: "Run Join Fuzzer"
         run: |
           mkdir -p /tmp/join_fuzzer_repro/
           rm -rfv /tmp/join_fuzzer_repro/*


### PR DESCRIPTION
Join fuzzer runs show up as Aggregation Fuzzer in nightly job. 

<img width="344" alt="Screenshot 2023-12-09 at 5 25 21 AM" src="https://github.com/facebookincubator/velox/assets/27965151/0c6eeb9c-4845-4dda-9ba9-67f63a9527d5">
