### PR TITLE
Fix the race between memory arbitration and test finish

### DIFF
--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -1291,7 +1291,22 @@ std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>> readCursor(
     addSplits(task);
   }
 
-  EXPECT_TRUE(waitForTaskCompletion(task, maxWaitMicros)) << task->taskId();
+  if (!waitForTaskCompletion(task, maxWaitMicros)) {
+    // NOTE: there is async memory arbitration might fail the task after all the
+    // results have been consumed and before the task finishes. So we might run
+    // into the failed task state in some rare case such as exposed by
+    // concurrent memory arbitration test.
+    if (task->state() != TaskState::kFinished &&
+        task->state() != TaskState::kRunning) {
+      waitForTaskDriversToFinish(task, maxWaitMicros);
+      std::rethrow_exception(task->error());
+    } else {
+      VELOX_FAIL(
+          "Failed to wait for task to complete after {}, task: {}",
+          succinctMicros(maxWaitMicros),
+          task->toString());
+    }
+  }
   return {std::move(cursor), std::move(result)};
 }
 


### PR DESCRIPTION
The background memory arbitration might fail a task after all the results have been
consumed by readCursor and before the task finishes. So when readCursor wait for
task to finish, the state transition might time out if it happens as the task state is a
failure state.
This PR fixes the race in readCursor by checking if the task state is a failure state when
the state transition time out, and throw the task error instead of return a task finish wait
timeout failure back to the test. We found this in memory arbitration concurrent test
which expect memory related failures from test. Verified with 1'000 test iterations.