### PR TITLE
Add reserved bytes in local OOM error message

### DIFF
--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -435,6 +435,8 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   struct Stats {
     /// The current memory usage.
     uint64_t currentBytes{0};
+    /// The current reserved memory.
+    uint64_t reservedBytes{0};
     /// The peak memory usage.
     uint64_t peakBytes{0};
     /// The accumulative memory usage.
@@ -466,11 +468,11 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
 
     std::string toString() const;
 
-    /// Returns true if the current bytes is zero.
+    /// Returns true if the current and reserved bytes are zero.
     /// Note that peak or cumulative bytes might be non-zero and we are still
     /// empty at this moment.
     bool empty() const {
-      return currentBytes == 0;
+      return currentBytes == 0 && reservedBytes == 0;
     }
   };
 

--- a/velox/common/memory/tests/MemoryCapExceededTest.cpp
+++ b/velox/common/memory/tests/MemoryCapExceededTest.cpp
@@ -72,10 +72,10 @@ TEST_P(MemoryCapExceededTest, singleDriver) {
       "2.00MB, memory manager cap is UNLIMITED, requestor "
       "'op.2.0.0.Aggregation' with current usage 3.70MB"};
   std::vector<std::string> expectedDetailedTexts = {
-      "node.1 usage 1.00MB peak 1.00MB",
-      "op.1.0.0.FilterProject usage 12.00KB peak 12.00KB",
-      "node.2 usage 4.00MB peak 4.00MB",
-      "op.2.0.0.Aggregation usage 3.70MB peak 3.70MB",
+      "node.1 usage 1.00MB reserved 1.00MB peak 1.00MB",
+      "op.1.0.0.FilterProject usage 12.00KB reserved 1.00MB peak 12.00KB",
+      "node.2 usage 4.00MB reserved 4.00MB peak 4.00MB",
+      "op.2.0.0.Aggregation usage 3.70MB reserved 4.00MB peak 3.70MB",
       "Top 2 leaf memory pool usages:"};
 
   std::vector<RowVectorPtr> data;


### PR DESCRIPTION
Add reserved bytes in local OOM error message to help debugging the
case that the actual memory usage is much lower than the aggregated
report. One possibility is that some spillable operator doesn't release
the reserved memory in some edge case.