### PR TITLE
Add overloading append() method to WriteFile

### DIFF
--- a/velox/common/file/File.h
+++ b/velox/common/file/File.h
@@ -143,6 +143,11 @@ class WriteFile {
   // Appends data to the end of the file.
   virtual void append(std::string_view data) = 0;
 
+  // Appends data to the end of the file.
+  virtual void append(std::unique_ptr<folly::IOBuf> /* data */) {
+    VELOX_NYI("IOBuf appending is not implemented");
+  }
+
   // Flushes any local buffers, i.e. ensures the backing medium received
   // all data that has been appended.
   virtual void flush() = 0;


### PR DESCRIPTION
Add this new append API that supports IOBuf append. This can allow us to have better support on io coalesce in fs client underneath.