### PR TITLE
Enable CI Unit Tests

### DIFF
--- a/.circleci/dist_compile.yml
+++ b/.circleci/dist_compile.yml
@@ -259,7 +259,7 @@ jobs:
       - run:
           name: "Run Unit Tests"
           command: |
-            cd _build/debug && ctest -j 16 -VV --output-on-failure
+            cd _build/debug && ctest -j 16 -VV --output-on-failure --no-tests=error
           no_output_timeout: 1h
       - store_test_results:
           path: /tmp/test_xml_output/

--- a/.circleci/dist_compile.yml
+++ b/.circleci/dist_compile.yml
@@ -361,7 +361,7 @@ jobs:
       - run:
           name: "Run Unit Tests"
           command: |
-            cd _build/release && ctest -j 16 -VV --output-on-failure
+            cd _build/release && ctest -j 16 -VV --output-on-failure --no-tests=error
           no_output_timeout: 1h
       - post-steps
 
@@ -452,7 +452,7 @@ jobs:
             curl -sL https://rpm.nodesource.com/setup_10.x | bash -
             yum install -y nodejs
             npm install -g azurite
-            cd _build/release && ctest -j 16 -VV --output-on-failure
+            cd _build/release && ctest -j 16 -VV --output-on-failure --no-tests=error
           no_output_timeout: 1h
       - post-steps
 

--- a/CMake/resolve_dependency_modules/cpr.cmake
+++ b/CMake/resolve_dependency_modules/cpr.cmake
@@ -37,3 +37,5 @@ FetchContent_Declare(
 set(BUILD_SHARED_LIBS OFF)
 set(CPR_USE_SYSTEM_CURL OFF)
 FetchContent_MakeAvailable(cpr)
+# See issue #7964.
+unset(BUILD_TESTING)

--- a/CMake/resolve_dependency_modules/cpr.cmake
+++ b/CMake/resolve_dependency_modules/cpr.cmake
@@ -37,5 +37,6 @@ FetchContent_Declare(
 set(BUILD_SHARED_LIBS OFF)
 set(CPR_USE_SYSTEM_CURL OFF)
 FetchContent_MakeAvailable(cpr)
-# See issue #7964.
+# libcpr in its CMakeLists.txt file disables the BUILD_TESTING globally when
+# CPR_USE_SYSTEM_CURL=OFF. unset BUILD_TESTING here.
 unset(BUILD_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -554,7 +554,10 @@ if(VELOX_BUILD_TESTING OR VELOX_BUILD_TEST_UTILS)
   resolve_dependency(cpr)
 endif()
 
-include(CTest) # include after project() but before add_subdirectory()
+if(VELOX_BUILD_TESTING)
+  set(BUILD_TESTING ON)
+  include(CTest) # include after project() but before add_subdirectory()
+endif()
 
 include_directories(.)
 

--- a/scripts/docker-command.sh
+++ b/scripts/docker-command.sh
@@ -16,4 +16,4 @@
 set -eu
 # Compilation and testing
 make
-cd _build/release && ctest -j${NUM_THREADS} -VV --output-on-failure
+cd _build/release && ctest -j${NUM_THREADS} -VV --output-on-failure --no-tests=error

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -582,7 +582,8 @@ TEST_F(MockSharedArbitrationTest, arbitrationFailsTask) {
   } catch (const VeloxRuntimeError& e) {
     ASSERT_EQ(velox::error_code::kMemAborted, e.errorCode());
     ASSERT_TRUE(
-        std::string(e.what()).find("usage 384.00MB peak 384.00MB") !=
+        std::string(e.what()).find(
+            "usage 384.00MB reserved 384.00MB peak 384.00MB") !=
         std::string::npos);
   } catch (...) {
     FAIL();


### PR DESCRIPTION
libcpr in its CMakeLists.txt file disables the BUILD_TESTING globally when CPR_USE_SYSTEM_CURL=OFF
As a result, unit tests stopped running in CI. This is now fixed.
An error will now be thrown if no unit tests are detected.

Resolves https://github.com/facebookincubator/velox/issues/7964