### PR TITLE
Fix hang in distinct aggregation

### DIFF
--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -150,10 +150,10 @@ void HashAggregation::addInput(RowVectorPtr input) {
     if (newDistincts_) {
       // Save input to use for output in getOutput().
       input_ = input;
-    } else if (abandonPartialEarly) {
-      // If no new distinct groups (meaning we don't have anything to output)
-      // and we are abandoning the partial aggregation, then we need to ensure
-      // we 'need input'. For that we need to reset the 'partial full' flag.
+    } else {
+      // If no new distinct groups (meaning we don't have anything to output),
+      // then we need to ensure we 'need input'. For that we need to reset
+      // the 'partial full' flag.
       partialFull_ = false;
     }
   }


### PR DESCRIPTION
HashAggregation::addInput receives a batch of inputs, calls
groupingSet_->addInput() which doesn't find any new distinct keys, but
allocates additional memory crossing the threshold and setting partialFull_ to
true. 

Note that HashTable::groupProbe may resize hash table and allocate memory even
if there are no new keys. This method always resizes the table to make sure
that if all input is unique, then it will fit into the hash table.

With newDistincts_ false and partialFull_ true, HashAggregation::getOutput keeps
returning null and HashAggregation::needsInput() keeps returning false putting
Driver::runInternal into the infinite loop and hanging the query.

A fix is to not set partialFull_ to true if there are not new keys and wait for a batch 
with new keys before flushing.

Fixes #7967