### PR TITLE
Add append iobuf API support for local/inmemory files

### DIFF
--- a/velox/common/file/File.h
+++ b/velox/common/file/File.h
@@ -216,6 +216,7 @@ class InMemoryWriteFile final : public WriteFile {
   explicit InMemoryWriteFile(std::string* FOLLY_NONNULL file) : file_(file) {}
 
   void append(std::string_view data) final;
+  void append(std::unique_ptr<folly::IOBuf> data) final;
   void flush() final {}
   void close() final {}
   uint64_t size() const final;
@@ -282,6 +283,7 @@ class LocalWriteFile final : public WriteFile {
   ~LocalWriteFile();
 
   void append(std::string_view data) final;
+  void append(std::unique_ptr<folly::IOBuf> data) final;
   void flush() final;
   void close() final;
   uint64_t size() const final;


### PR DESCRIPTION
Add append(std::unique_ptr<folly::IOBuf> data) API support for LocalWriteFile and InMemoryWriteFile.
Added tests for the APIs.