### PR TITLE
Faster hash modes test

### DIFF
--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -1231,6 +1231,7 @@ void HashTable<ignoreNullKeys>::rehash(bool initNormalizedKeys) {
 template <bool ignoreNullKeys>
 void HashTable<ignoreNullKeys>::setHashMode(HashMode mode, int32_t numNew) {
   VELOX_CHECK_NE(hashMode_, HashMode::kHash);
+  TestValue::adjust("facebook::velox::exec::HashTable::setHashMode", &mode);
   if (mode == HashMode::kArray) {
     const auto bytes = capacity_ * tableSlotSize();
     const auto numPages = memory::AllocationTraits::numPages(bytes);


### PR DESCRIPTION
AggregationTest.hashmodes covers the required cases with less data in about half the time. Less timeouts. Checks that the end state is kHash.