### PR TITLE
Migrate circleci worklfows to github actions

### DIFF
--- a/.github/actions/fuzzer-run/action.yml
+++ b/.github/actions/fuzzer-run/action.yml
@@ -1,0 +1,42 @@
+name: fuzzer-run
+description: Fuzzer run
+inputs:
+  fuzzer-output:
+    description: Fuzzer output
+    required: true
+  fuzzer-repro:
+    description: Fuzzer repro
+    required: true
+  fuzzer-name:
+    description: Fuzzer name
+    required: true
+  fuzzer-exe:
+    description: Fuzzer command
+    required: true
+  fuzzer-args:
+    description: Fuzzer arguments
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Build
+      shell: bash
+      run: |
+        make debug NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=4
+    - name: "Run ${{ inputs.fuzzer-name }} Fuzzer"
+      shell: bash
+      run: |
+        eval ' ${{ inputs.fuzzer-exe }} ${{ inputs.fuzzer-args }} ' \
+              2>&1 | tee "${{ inputs.fuzzer-output }}" || ( \
+                tail -n 1000 "${{ inputs.fuzzer-output }}" ; \
+                echo "FAIL: ${{ inputs.fuzzer-name }} run failed"; \
+                exit 1; \
+              )
+            echo -e "\n ${{ inputs.fuzzer-name }} run finished successfully."
+    - name: "Upload artifacts"
+      uses: actions/upload-artifact@v3.1.3
+      with:
+        name: ${{ join( inputs.fuzzer-name, '-') }}fuzzer-artifacts
+        path: |
+          ${{ inputs.fuzzer-output }}
+          ${{ inputs.fuzzer-repro }}

--- a/.github/actions/macos-build/action.yml
+++ b/.github/actions/macos-build/action.yml
@@ -1,0 +1,49 @@
+name: macos-build
+description: MacOS build
+runs:
+  using: composite
+  steps:
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: ~/deps
+        key: velox-${{ runner.os }}-deps-v1-${{ hashFiles('.github/workflows/longer-fuzzer.yml') }}-${{ hashFiles('scripts/setup-macos.sh') }}
+    - name: "Calculate merge-base date for CCache"
+      run: git show -s --format=%cd --date="format:%Y%m%d" $(git merge-base origin/main HEAD) | tee merge-base-date
+      shell: bash
+    - name: Ccache cache
+      uses: actions/cache@v2
+      with:
+        path: .ccache
+        key: velox-ccache-${{ runner.os }}-${{ hashFiles('merge-base-date') }}
+    - name: "Install dependencies"
+      run: |
+        set -xu
+        mkdir -p ~/deps ~/deps-src
+        curl -L https://github.com/Homebrew/brew/tarball/master | tar xz --strip 1 -C ~/deps
+        PATH=~/deps/bin:${PATH} DEPENDENCY_DIR=~/deps-src INSTALL_PREFIX=~/deps PROMPT_ALWAYS_RESPOND=n ./scripts/setup-macos.sh
+        rm -rf ~/deps/.git ~/deps/Library/Taps/  # Reduce cache size by 70%.
+      shell: bash
+    - name: "Build on MacOS"
+      run: |
+        export PATH=~/deps/bin:~/deps/opt/bison/bin:~/deps/opt/flex/bin:${PATH}
+        mkdir -p .ccache
+        export CCACHE_DIR=$(pwd)/.ccache
+        ccache -sz -M 5Gi
+        brew install openssl@1.1
+        brew link --overwrite --force openssl@1.1
+        export PATH="/Users/distiller/deps/opt/openssl@1.1/bin:$PATH"
+        export OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)
+        cmake \
+            -B _build/debug \
+            -GNinja \
+            -DTREAT_WARNINGS_AS_ERRORS=1 \
+            -DENABLE_ALL_WARNINGS=1 \
+            -DVELOX_ENABLE_PARQUET=ON \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_PREFIX_PATH=~/deps \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DFLEX_INCLUDE_DIR=~/deps/opt/flex/include
+        ninja -C _build/debug
+        ccache -s
+      shell: bash

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -1,0 +1,31 @@
+name: setup-environment
+description: Setup environment for Velox CI
+runs:
+  using: composite
+  steps:
+    # - name: Install dependencies
+    #   shell: bash
+    #   run: |
+    #     sudo ./scripts/setup-ubuntu.sh
+    - name: Setup environment
+      shell: bash
+      run: |-
+        git config --global --add safe.directory $GITHUB_WORKSPACE
+        # Calculate ccache key.
+        git show -s --format=%cd --date="format:%Y%m%d" $(git merge-base origin/main HEAD) | tee merge-base-date
+
+        # Set up xml gtest output.
+        mkdir -p /tmp/test_xml_output/
+        echo "export XML_OUTPUT_FILE=\"/tmp/test_xml_output/\"" >> $GITHUB_ENV
+
+        # Set up ccache configs.
+        mkdir -p .ccache
+        echo "export CCACHE_DIR=$(realpath .ccache)" >> $GITHUB_ENV
+        ccache -sz -M 5Gi
+        if [ -e /opt/rh/gcc-toolset-9/enable ]; then
+          source /opt/rh/gcc-toolset-9/enable
+        fi
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2.10
+      with:
+        key: velox-ccache-debug-${{ runner.os }}-${{ hashFiles('merge-base-date') }}

--- a/.github/workflows/doc-gen-job.yml
+++ b/.github/workflows/doc-gen-job.yml
@@ -1,0 +1,40 @@
+name: doc-gen-job
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  doc-gen-job:
+    runs-on: 8-core
+    container:
+      image : ghcr.io/facebookincubator/velox-dev:circleci-avx
+    env:
+      CC:  /opt/rh/gcc-toolset-9/root/bin/gcc
+      CXX: /opt/rh/gcc-toolset-9/root/bin/g++
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+        with:
+          submodules: recursive
+      - name: Build docs and update gh-pages
+        run: |
+          git config --global user.email "velox@users.noreply.github.com"
+          git config --global user.name "velox"
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          git fetch origin
+          git checkout origin/main
+          conda init bash
+          source ~/.bashrc
+          conda create -y --name docgenenv python=3.7
+          conda activate docgenenv
+          pip install sphinx sphinx-tabs breathe sphinx_rtd_theme chardet
+          source /opt/rh/gcc-toolset-9/enable
+          ./scripts/gen-docs.sh docgenenv
+          git checkout gh-pages
+          cp -R velox/docs/_build/html/* docs
+          git add docs
+          if [ -n "$(git status --porcelain --untracked-files=no)" ]
+          then
+            git commit -m "Update documentation"
+            git push
+          fi

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,0 +1,23 @@
+name: format-check
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  format-check:
+    runs-on: ubuntu-latest
+    container:
+      image : ghcr.io/facebookincubator/velox-dev:check-avx
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Check formatting
+        run: |
+          if ! make format-check; then
+            make format-fix
+            echo -e "\n==== Apply using:"
+            echo "patch -p1 \<<EOF"
+            git --no-pager diff
+            echo "EOF"
+            false
+          fi

--- a/.github/workflows/header-check.yml
+++ b/.github/workflows/header-check.yml
@@ -1,0 +1,23 @@
+name: header-check
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  header-check:
+    runs-on: ubuntu-latest
+    container:
+      image : ghcr.io/facebookincubator/velox-dev:check-avx
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Check license headers
+        run: |
+          if ! make header-check; then
+            make header-fix
+            echo -e "\n==== Apply using:"
+            echo "patch -p1 \<<EOF"
+            git --no-pager diff
+            echo "EOF"
+            false
+          fi

--- a/.github/workflows/linux-adapters.yml
+++ b/.github/workflows/linux-adapters.yml
@@ -1,0 +1,75 @@
+name: linux-adapters
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  linux-adapters:
+    runs-on: 32-core
+    container:
+      image : ghcr.io/facebookincubator/velox-dev:circleci-avx
+    env:
+      CC:  /opt/rh/gcc-toolset-9/root/bin/gcc
+      CXX: /opt/rh/gcc-toolset-9/root/bin/g++
+      VELOX_DEPENDENCY_SOURCE: BUNDLED
+      ICU_SOURCE: BUNDLED
+      simdjson_SOURCE: BUNDLED
+    defaults:
+      run:
+        shell: bash -el {0}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+        with:
+          submodules: recursive
+      - uses: ./.github/actions/setup-environment
+      - name: Install Adapter Dependencies
+        run: |
+          mkdir -p ~/adapter-deps/install/bin
+          set -xu
+          DEPENDENCY_DIR=~/adapter-deps PROMPT_ALWAYS_RESPOND=n ./scripts/setup-adapters.sh
+      - name: Install Minio Server
+        run: |
+          set -xu
+          cd ~/adapter-deps/install/bin/
+          wget https://dl.min.io/server/minio/release/linux-amd64/archive/minio-20220526054841.0.0.x86_64.rpm
+          rpm -i minio-20220526054841.0.0.x86_64.rpm
+          rm minio-20220526054841.0.0.x86_64.rpm
+      - name: Install Hadoop Dependency
+        run: |
+          set -xu
+          yum -y install java-1.8.0-openjdk
+      - name: Build including all Benchmarks
+        run: |
+          EXTRA_CMAKE_FLAGS=(
+            "-DVELOX_ENABLE_BENCHMARKS=ON"
+            "-DVELOX_ENABLE_ARROW=ON"
+            "-DVELOX_ENABLE_PARQUET=ON"
+            "-DVELOX_ENABLE_HDFS=ON"
+            "-DVELOX_ENABLE_S3=ON"
+            "-DVELOX_ENABLE_GCS=ON"
+            "-DVELOX_ENABLE_ABFS=ON"
+            "-DVELOX_ENABLE_SUBSTRAIT=ON"
+            "-DVELOX_ENABLE_REMOTE_FUNCTIONS=ON"
+          )
+          make release EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS[*]}" AWSSDK_ROOT_DIR=~/adapter-deps/install GCSSDK_ROOT_DIR=~/adapter-deps/install NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=8
+          ccache -s
+      - name: Run Unit Tests
+        run: |
+          conda init bash
+          conda create -y --name testbench python=3.7
+          conda activate testbench
+          pip install https://github.com/googleapis/storage-testbench/archive/refs/tags/v0.36.0.tar.gz
+          export LC_ALL=C
+          export JAVA_HOME=/usr/lib/jvm/jre-1.8.0-openjdk
+          export HADOOP_ROOT_LOGGER="WARN,DRFA"
+          export LIBHDFS3_CONF=$(pwd)/.circleci/hdfs-client.xml
+          export HADOOP_HOME='/usr/local/hadoop'
+          export PATH=~/adapter-deps/install/bin:/usr/local/hadoop/bin:${PATH}
+          # The following is used to install Azurite in the CI for running Abfs Hive Connector unit tests.
+          # Azurite is an emulator for local Azure Storage development, and it is a required component for running Abfs Hive Connector unit tests. 
+          # It can be installed using npm. The following is used to install Node.js and npm for Azurite installation.
+          curl -sL https://rpm.nodesource.com/setup_10.x | bash -
+          sudo apt-get install -y nodejs
+          npm install -g azurite
+          cd _build/release && ctest -j 16 -VV --output-on-failure

--- a/.github/workflows/linux-build-options.yml
+++ b/.github/workflows/linux-build-options.yml
@@ -1,0 +1,26 @@
+name: linux-build-options
+on:
+    workflow_dispatch:
+    pull_request:
+
+jobs:
+  linux-build-options:
+    runs-on: 32-core
+    container:
+      image : ghcr.io/facebookincubator/velox-dev:circleci-avx
+    env:
+      CC:  /opt/rh/gcc-toolset-9/root/bin/gcc
+      CXX: /opt/rh/gcc-toolset-9/root/bin/g++
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+        with:
+          submodules: recursive
+      - uses: "./.github/actions/setup-environment"
+      - name: Build Velox Minimal
+        run: |
+          make min_debug NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=16
+      - name: Build Velox Without Testing
+        run: |
+          make clean
+          make debug EXTRA_CMAKE_FLAGS="-DVELOX_BUILD_TESTING=OFF" NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=16

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,0 +1,118 @@
+name: linux-build
+on:
+    workflow_dispatch:
+    pull_request:
+
+jobs:
+  linux-build:
+    runs-on: 32-core
+    container:
+      image : ghcr.io/facebookincubator/velox-dev:circleci-avx
+    env:
+      CC:  /opt/rh/gcc-toolset-9/root/bin/gcc
+      CXX: /opt/rh/gcc-toolset-9/root/bin/g++
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+        with:
+          submodules: recursive
+      - uses: "./.github/actions/setup-environment"
+      - name: Build
+        run: |-
+          make debug NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=5 EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON"
+      - name: Run Unit Tests
+        run: |-
+          cd _build/debug && ctest -j 16 -VV --output-on-failure
+      - name: Archive test results
+        uses: actions/upload-artifact@v3.1.3
+        with:
+          name: test-results
+          path: /tmp/test_xml_output
+      - name: Run Fuzzer Tests
+        run: |-
+          mkdir -p /tmp/fuzzer_repro/
+              chmod -R 777 /tmp/fuzzer_repro
+              _build/debug/velox/expression/tests/velox_expression_fuzzer_test \
+                  --seed ${RANDOM} \
+                  --enable_variadic_signatures \
+                  --velox_fuzzer_enable_complex_types \
+                  --lazy_vector_generation_ratio 0.2 \
+                  --velox_fuzzer_enable_column_reuse \
+                  --velox_fuzzer_enable_expression_reuse \
+                  --max_expression_trees_per_step 2 \
+                  --retry_with_try \
+                  --enable_dereference \
+                  --duration_sec 60 \
+                  --logtostderr=1 \
+                  --minloglevel=0 \
+                  --repro_persist_path=/tmp/fuzzer_repro \
+              && echo -e "\n\nFuzzer run finished successfully."
+      - name: Archive fuzzer results
+        uses: actions/upload-artifact@v3.1.3
+        with:
+          name: fuzzer-results
+          path: /tmp/fuzzer_repro
+      - name: Run Spark Fuzzer Tests
+        run: |
+          mkdir -p /tmp/spark_fuzzer_repro/
+          chmod -R 777 /tmp/spark_fuzzer_repro
+          _build/debug/velox/expression/tests/spark_expression_fuzzer_test \
+              --seed ${RANDOM} \
+              --duration_sec 60 \
+              --enable_variadic_signatures \
+              --lazy_vector_generation_ratio 0.2 \
+              --velox_fuzzer_enable_column_reuse \
+              --velox_fuzzer_enable_expression_reuse \
+              --max_expression_trees_per_step 2 \
+              --retry_with_try \
+              --logtostderr=1 \
+              --minloglevel=0 \
+              --repro_persist_path=/tmp/spark_fuzzer_repro \
+          && echo -e "\n\nSpark Fuzzer run finished successfully."
+      - name: Archive spark fuzzer results
+        uses: actions/upload-artifact@v3.1.3
+        with:
+          name: spark-fuzzer-results
+          path: /tmp/spark_fuzzer_repro
+      - name: Run Spark Aggregate Fuzzer Tests
+        run: |
+          mkdir -p /tmp/spark_aggregate_fuzzer_repro/
+          chmod -R 777 /tmp/spark_aggregate_fuzzer_repro
+          _build/debug/velox/exec/tests/spark_aggregation_fuzzer_test \
+              --seed ${RANDOM} \
+              --duration_sec 60 \
+              --logtostderr=1 \
+              --minloglevel=0 \
+              --repro_persist_path=/tmp/spark_aggregate_fuzzer_repro \
+          && echo -e "\n\nSpark Aggregation Fuzzer run finished successfully."
+      - name: Archive spark aggregate fuzzer results
+        uses: actions/upload-artifact@v3.1.3
+        with:
+          name: spark-aggregate-fuzzer-results
+          path: /tmp/spark_aggregate_fuzzer_repro
+      - name: Run Aggregate Fuzzer Tests
+      # Run aggregation fuzzer using the built executable.
+        run: |
+          mkdir -p /tmp/aggregate_fuzzer_repro/
+          rm -rfv /tmp/aggregate_fuzzer_repro/*
+          chmod -R 777 /tmp/aggregate_fuzzer_repro
+          _build/debug/velox/exec/tests/velox_aggregation_fuzzer_test \
+              --seed ${RANDOM} \
+              --duration_sec 60 \
+              --logtostderr=1 \
+              --minloglevel=0 \
+              --repro_persist_path=/tmp/aggregate_fuzzer_repro \
+          && echo -e "\n\nAggregation fuzzer run finished successfully."
+      - name: Archive aggregate fuzzer results
+        uses: actions/upload-artifact@v3.1.3
+        with:
+          name: aggregate-fuzzer-results
+          path: /tmp/aggregate_fuzzer_repro
+      - name: "Run Example Binaries"
+        run: |
+          find _build/debug/velox/examples/ -maxdepth 1 -type f -executable -exec "{}" \;
+      - name: Archive ninja log
+        uses: actions/upload-artifact@v3.1.3
+        with:
+          name: ninja-log
+          path: _build/debug/.ninja.log

--- a/.github/workflows/linux-pr-fuzzer-run.yml
+++ b/.github/workflows/linux-pr-fuzzer-run.yml
@@ -1,0 +1,97 @@
+name: linux-pr-fuzzer-run
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  linux-pr-fuzzer-run:
+    runs-on: 32-core
+    container:
+      image : ghcr.io/facebookincubator/velox-dev:circleci-avx
+    env:
+      CC:  /opt/rh/gcc-toolset-9/root/bin/gcc
+      CXX: /opt/rh/gcc-toolset-9/root/bin/g++
+      VELOX_DEPENDENCY_SOURCE: BUNDLED
+      simdjson_SOURCE: BUNDLED
+    defaults:
+      run:
+        shell: bash -el {0}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+        with:
+          submodules: recursive
+      - uses: "./.github/actions/setup-environment"
+      - name: Get merge base function signatures
+        run: |
+          conda create -y --name pyveloxenv python=3.7
+          conda activate pyveloxenv
+          cp ./scripts/signature.py /tmp/signature.py
+          pip install deepdiff
+          git remote add upstream https://github.com/facebookincubator/velox
+          git fetch upstream
+          echo "HEAD: $(git rev-parse HEAD)"
+          echo "upstream/main: $(git rev-parse upstream/main)"
+          echo "merge base: $(git merge-base  'upstream/main' `git rev-parse HEAD`)"
+          merge_base=$(git merge-base  'upstream/main' `git rev-parse HEAD`) || \
+          { echo "::error::Failed to find merge_base"; exit 1; }
+          echo "Merge Base: $merge_base"
+          git checkout $merge_base
+          git submodule update --init --recursive
+          LD_LIBRARY_PATH=/usr/local/lib make python-clean
+          LD_LIBRARY_PATH=/usr/local/lib make python-build
+          python /tmp/signature.py export --spark spark_merge_base_signatures.json
+          python /tmp/signature.py export --presto presto_merge_base_signatures.json
+      - name: Build
+        run: |
+          make debug NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=4 EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON"
+      - name: Build and test PyVelox
+        run: |
+          conda init bash
+          conda activate pyveloxenv
+          LD_LIBRARY_PATH=/usr/local/lib make python-test
+      - name: Check and create bias function signatures
+        run: |
+          conda activate pyveloxenv
+          pip install deepdiff
+          python ./scripts/signature.py export --presto presto_pr_signatures.json
+          python ./scripts/signature.py export --spark spark_pr_signatures.json
+          python ./scripts/signature.py bias presto_merge_base_signatures.json presto_pr_signatures.json /tmp/presto_bias_functions
+          python ./scripts/signature.py bias spark_merge_base_signatures.json spark_pr_signatures.json /tmp/spark_bias_functions
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3.1.3
+        with:
+          name: linux-pr-fuzzer-artifacts
+          path: |
+            presto_merge_base_signatures.json
+            presto_pr_signatures.json
+            spark_merge_base_signatures.json
+            spark_pr_signatures.json
+      - uses: "./.github/actions/fuzzer-run"
+        with:
+          fuzzer-output: /tmp/fuzzer/log
+          fuzzer-repro: /tmp/fuzzer_repro
+          fuzzer-name: Expression Bias Run
+          fuzzer-exe: "if [ -f /tmp/presto_bias_functions ]; then _build/debug/velox/expression/tests/velox_expression_fuzzer_test"
+          fuzzer-args: " --seed ${RANDOM} --lazy_vector_generation_ratio 0.2 \
+            --assign_function_tickets  $(cat /tmp/presto_bias_functions) \
+            --duration_sec 3600 --enable_variadic_signatures \
+            --velox_fuzzer_enable_complex_types \
+            --velox_fuzzer_enable_column_reuse \
+            --velox_fuzzer_enable_expression_reuse \
+            --max_expression_trees_per_step 2 \
+            --retry_with_try \
+            --enable_dereference \
+            --logtostderr=1 --minloglevel=0 \
+            --repro_persist_path=/tmp/fuzzer_repro ; fi"
+      - uses: "./.github/actions/fuzzer-run"
+        with:
+          fuzzer-output: "/tmp/spark_fuzzer.log"
+          fuzzer-repro: "/tmp/spark_fuzzer_repro"
+          fuzzer-name: Spark Bias Run
+          fuzzer-exe: "if [ -f /tmp/spark_bias_functions ];  then _build/debug/velox/expression/tests/spark_expression_fuzzer_test"
+          fuzzer-args: " --seed ${RANDOM} --duration_sec 3600 --logtostderr=1 --minloglevel=0 \
+            --assign_function_tickets  $(cat /tmp/spark_bias_functions) \
+            --repro_persist_path=/tmp/spark_fuzzer_repro ; fi"
+
+  

--- a/.github/workflows/linux-presto-fuzzer-run.yml
+++ b/.github/workflows/linux-presto-fuzzer-run.yml
@@ -1,0 +1,43 @@
+name: linux-presto-fuzzer-run
+on:
+  workflow_dispatch:
+  pull_request:
+    paths-ignore:
+    - 'velox/expression/**test**'
+    - 'velox/exec/**test**'
+    - 'velox/common/**test**'
+    - 'velox/core/**test**'
+    - 'velox/vector/**test**'
+
+jobs:
+  linux-presto-fuzzer-run:
+    runs-on: 32-core
+    container:
+      image : ghcr.io/facebookincubator/velox-dev:circleci-avx
+    env:
+      CC:  /opt/rh/gcc-toolset-9/root/bin/gcc
+      CXX: /opt/rh/gcc-toolset-9/root/bin/g++
+      VELOX_DEPENDENCY_SOURCE: SYSTEM
+      simdjson_SOURCE: BUNDLED
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+        with:
+          submodules: recursive
+      - uses: "./.github/actions/setup-environment"
+      - uses: "./.github/actions/fuzzer-run"
+        with:
+          fuzzer-output: "/tmp/fuzzer.log"
+          fuzzer-repro: "/tmp/fuzzer_repro"
+          fuzzer-name: Expression
+          fuzzer-exe: "_build/debug/velox/expression/tests/velox_expression_fuzzer_test"
+          fuzzer-args: " --seed ${RANDOM} --lazy_vector_generation_ratio 0.2 \
+            --duration_sec 1800 --enable_variadic_signatures \
+            --velox_fuzzer_enable_complex_types \
+            --velox_fuzzer_enable_column_reuse \
+            --velox_fuzzer_enable_expression_reuse \
+            --max_expression_trees_per_step 2 \
+            --retry_with_try \
+            --enable_dereference \
+            --logtostderr=1 --minloglevel=0 \
+            --repro_persist_path=/tmp/fuzzer_repro"

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -1,0 +1,27 @@
+name: MacOS Build
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  macos-build:
+    strategy:
+      matrix:
+        # macos-12-large == intel
+        # macos-latest-xlarge == m1
+        # https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners#about-macos-larger-runners
+        os: [macos-12-large, macos-latest-xlarge]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -el {0}
+    env:
+      ICU_SOURCE: BUNDLED
+      simdjson_SOURCE: BUNDLED
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+        with:
+          submodules: recursive
+      - uses: './.github/actions/macos-build'
+


### PR DESCRIPTION
This pull request converts the CircleCI workflows to GitHub actions workflows.

The GitHub actions workflows need runner groups with [larger runners configured for the organization](https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/managing-larger-runners).

The following runner group is needed:
- 32-core

For my testing, I have these runner groups populated with the following runners:
| Group       | Runner size                         | OS            |
|-------------|-------------------------------------|---------------|
| 32-core     | 32-cores · 128 GB RAM · 1200 GB SSD | Ubuntu Latest |

**Issues**  
There are issue with some of the workflow that someone smarter than me needs to address.  
1. linux-pr-fuzzer-run  
This appears to fail getting the merge base. I'm not sure why this is happening.  

2. linux-adapters  
The error is...  
```
ninja: build stopped: subcommand failed.
make[1]: *** [Makefile:98: build] Error 1
make[1]: Leaving directory '/__w/velox/velox'
make: *** [Makefile:105: release] Error 2
Error: Process completed with exit code 2.
```

https://fburl.com/workplace/f6mz6tmw