### PR TITLE
Drop ExchangeSource responses if ExchangeClient is already closed

### DIFF
--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -116,7 +116,7 @@ class ExchangeClient {
   std::shared_ptr<ExchangeQueue> queue_;
   std::unordered_set<std::string> taskIds_;
   std::vector<std::shared_ptr<ExchangeSource>> sources_;
-  bool closed_{false};
+  std::atomic_bool closed_{false};
 
   // A queue of sources that have returned non-empty response from the latest
   // request.

--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -116,7 +116,7 @@ class ExchangeClient {
   std::shared_ptr<ExchangeQueue> queue_;
   std::unordered_set<std::string> taskIds_;
   std::vector<std::shared_ptr<ExchangeSource>> sources_;
-  std::atomic_bool closed_{false};
+  bool closed_{false};
 
   // A queue of sources that have returned non-empty response from the latest
   // request.


### PR DESCRIPTION
ExchangeClient may get closed while waiting for response from
ExchangeSource::request. In this case, ignore the response and do nothing.

Fixes #7983