### PR TITLE
Fix OutputBuffer::isOverutilized

### DIFF
--- a/velox/exec/OutputBuffer.cpp
+++ b/velox/exec/OutputBuffer.cpp
@@ -637,7 +637,7 @@ double OutputBuffer::getUtilization() const {
 }
 
 bool OutputBuffer::isOverutilized() const {
-  return (totalSize_ > maxSize_) && !atEnd_;
+  return (totalSize_ > (0.5 * maxSize_)) && !atEnd_;
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/OutputBuffer.h
+++ b/velox/exec/OutputBuffer.h
@@ -187,8 +187,9 @@ class OutputBuffer {
   // Gets the memory utilization ratio in this output buffer.
   double getUtilization() const;
 
-  // Indicates if this output buffer is over-utilized and thus blocks its
-  // producers.
+  // Indicates if this output buffer is over-utilized, i.e. at least half full,
+  // and will start blocking producers soon. This is used to dynamically scale
+  // the number of consumers, for example, increase number of TableWriter tasks.
   bool isOverutilized() const;
 
  private:


### PR DESCRIPTION
OutputBuffer::isOverutilized() should return true if it is half-full. It used to
return true only when full preventing effective scaling of consumers. The
buffer maintains is-full state only for a short duration of time. Since
producers are blocked, one fetch from one consumer resets the state to
not-null. Thus the coordinator that's monitoring output buffers may never see
buffer getting over-utilized and mitigate by scaling the number of consumers.
This caused some queries to be very slow as they used only 4 threads for
TableWrite.