### PR TITLE
Add flatten constant vector option to parquet writer option

### DIFF
--- a/velox/dwio/parquet/tests/writer/SinkTests.cpp
+++ b/velox/dwio/parquet/tests/writer/SinkTests.cpp
@@ -28,13 +28,7 @@ TEST_F(SinkTest, close) {
   auto filePath = fs::path(fmt::format("{}/test_close.txt", tempPath_->path));
   auto sink = createSink(filePath.string());
   auto sinkPtr = sink.get();
-  auto writer = createWriter(
-      std::move(sink),
-      [&]() {
-        return std::make_unique<LambdaFlushPolicy>(
-            kRowsInRowGroup, kBytesInRowGroup, [&]() { return false; });
-      },
-      rowType);
+  auto writer = createWriter(std::move(sink), getWriterOpts(), rowType);
 
   for (auto& batch : batches) {
     writer->write(batch);
@@ -58,13 +52,7 @@ TEST_F(SinkTest, abort) {
   auto filePath = fs::path(fmt::format("{}/test_abort.txt", tempPath_->path));
   auto sink = createSink(filePath.string());
   auto sinkPtr = sink.get();
-  auto writer = createWriter(
-      std::move(sink),
-      [&]() {
-        return std::make_unique<LambdaFlushPolicy>(
-            kRowsInRowGroup, kBytesInRowGroup, [&]() { return false; });
-      },
-      rowType);
+  auto writer = createWriter(std::move(sink), getWriterOpts(), rowType);
 
   for (auto& batch : batches) {
     writer->write(batch);

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -102,6 +102,8 @@ struct WriterOptions {
   std::shared_ptr<CodecOptions> codecOptions;
   std::unordered_map<std::string, common::CompressionKind>
       columnCompressionsMap;
+  // Workaround because REE encoding for constant vectors cannot be used.
+  bool flattenConstantVector = true;
 };
 
 // Writes Velox vectors into  a DataSink using Arrow Parquet writer.


### PR DESCRIPTION
Move the options to flatten a input  constant vector
to the Parquet WriterOptions and use values from the options.
In addition, tests are added that validate usage of the option
and the resulting error if not used.