### PR TITLE
Remove extra semi colon from velox/dwio/common/RandGen.h

### DIFF
--- a/velox/dwio/common/RandGen.h
+++ b/velox/dwio/common/RandGen.h
@@ -27,7 +27,7 @@ namespace common {
 class RandGen {
  public:
   RandGen()
-      : rand_{}, mt_{rand_()}, dist_(0, std::numeric_limits<int32_t>::max()){};
+      : rand_{}, mt_{rand_()}, dist_(0, std::numeric_limits<int32_t>::max()) {}
 
   template <typename T>
   T gen(int32_t max) {

--- a/velox/experimental/codegen/Codegen.h
+++ b/velox/experimental/codegen/Codegen.h
@@ -74,4 +74,4 @@ class Codegen {
 
 } // namespace codegen
 } // namespace velox
-}; // namespace facebook
+} // namespace facebook

--- a/velox/experimental/codegen/CodegenStubs.cpp
+++ b/velox/experimental/codegen/CodegenStubs.cpp
@@ -59,4 +59,4 @@ bool Codegen::runInitializationTests() {
 
 } // namespace codegen
 } // namespace velox
-}; // namespace facebook
+} // namespace facebook

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -49,7 +49,7 @@ inline std::exception_ptr makeBadCastException(
       std::current_exception(),
       makeErrorMessage(input, row, resultType, errorDetails),
       false));
-};
+}
 
 // Copied from format.h of fmt.
 inline int countDigits(uint128_t n) {

--- a/velox/expression/type_calculation/Scanner.h
+++ b/velox/expression/type_calculation/Scanner.h
@@ -31,7 +31,7 @@ class Scanner : public yyFlexLexer {
       std::istream& arg_yyin,
       std::ostream& arg_yyout,
       std::unordered_map<std::string, int>& values)
-      : yyFlexLexer(&arg_yyin, &arg_yyout), values_(values){};
+      : yyFlexLexer(&arg_yyin, &arg_yyout), values_(values) {}
   int lex(Parser::semantic_type* yylval);
 
   void setValue(const std::string& varName, int value) {


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D51995013


