### PR TITLE
Remove extra semi colon from velox/type/Timestamp.h

### DIFF
--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -318,7 +318,7 @@ struct Timestamp {
   // Needed for serialization of FlatVector<Timestamp>
   operator StringView() const {
     return StringView("TODO: Implement");
-  };
+  }
 
   std::string toString(const TimestampToStringOptions& options = {}) const {
     std::tm tm;

--- a/velox/type/Tree.h
+++ b/velox/type/Tree.h
@@ -88,11 +88,11 @@ class Tree {
 
   const_iterator begin() const {
     return cbegin();
-  };
+  }
 
   const_iterator end() const {
     return cend();
-  };
+  }
 
   const_iterator cbegin() const {
     return const_iterator{*this, 0};


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D51995017


