### PR TITLE
Clear raw_vector move source

### DIFF
--- a/velox/common/base/RawVector.h
+++ b/velox/common/base/RawVector.h
@@ -67,7 +67,9 @@ class raw_vector {
     data_ = other.data_;
     size_ = other.size_;
     capacity_ = other.capacity_;
-    simd::memset(&other, 0, sizeof(other));
+    other.data_ = nullptr;
+    other.size_ = 0;
+    other.capacity_ = 0;
   }
 
   bool empty() const {


### PR DESCRIPTION
Clear raw_vector move source

gcc 11 complains about use after ::free if raw_vector move source
members are cleared with memset instead of assignment. Use assignment
instead.

