### PR TITLE
Wrap op->isFinished() into CALL_OPERATOR()

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -681,7 +681,13 @@ StopReason Driver::runInternal(
               return StopReason::kBlock;
             }
           }
-          if (op->isFinished()) {
+          bool finished{false};
+          CALL_OPERATOR(
+              finished = op->isFinished(),
+              op,
+              curOperatorId_,
+              kOpMethodIsFinished);
+          if (finished) {
             guard.notThrown();
             close();
             return StopReason::kAtEnd;


### PR DESCRIPTION
Summary:
We have CALL_OPERATOR() wrapper around all
significant operator calls. Missed one case.

Differential Revision: D52100016


