### PR TITLE
Add get_timestamp Spark function

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -70,6 +70,19 @@ These functions support TIMESTAMP and DATE input types.
 
     This is an alias for :func:`day_of_week`.
 
+.. function:: get_timestamp(string, dateFormat) -> timestamp
+
+    Returns timestamp by parsing ``string`` according to the specified ``dateFormat``.
+    The format follows Spark's
+    `Datetime patterns
+    <https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html>`_.
+    Returns NULL for parsing error or NULL input. Throws exception for invalid format. ::
+
+        SELECT get_timestamp('1970-01-01', 'yyyy-MM-dd);  -- timestamp `1970-01-01`
+        SELECT get_timestamp('1970-01-01', 'yyyy-MM');  -- NULL (parsing error)
+        SELECT get_timestamp('1970-01-01', null);  -- NULL
+        SELECT get_timestamp('2020-06-10', 'A');  -- (throws exception)
+
 .. spark:function:: last_day(date) -> date
 
     Returns the last day of the month which the date belongs to.

--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -366,9 +366,9 @@ int64_t parseTimezoneOffset(const char* cur, const char* end, Date& date) {
         if (std::strncmp(cur + 1, "00:00", 5) == 0) {
           date.timezoneId = 0;
         } else {
-          try {
-            date.timezoneId = util::getTimeZoneID(std::string_view(cur, 6));
-          } catch (VeloxRuntimeError& e) {
+          date.timezoneId =
+              util::getTimeZoneID(std::string_view(cur, 6), false);
+          if (date.timezoneId == -1) {
             return -1;
           }
         }
@@ -385,9 +385,8 @@ int64_t parseTimezoneOffset(const char* cur, const char* end, Date& date) {
           // thread_local buffer to prevent extra allocations.
           std::memcpy(&timezoneBuffer[0], cur, 3);
           std::memcpy(&timezoneBuffer[4], cur + 3, 2);
-          try {
-            date.timezoneId = util::getTimeZoneID(timezoneBuffer);
-          } catch (VeloxRuntimeError& e) {
+          date.timezoneId = util::getTimeZoneID(timezoneBuffer, false);
+          if (date.timezoneId == -1) {
             return -1;
           }
         }
@@ -404,9 +403,8 @@ int64_t parseTimezoneOffset(const char* cur, const char* end, Date& date) {
           // buffer to prevent extra allocations.
           std::memcpy(&timezoneBuffer[0], cur, 3);
           std::memcpy(&timezoneBuffer[4], defaultTrailingOffset, 2);
-          try {
-            date.timezoneId = util::getTimeZoneID(timezoneBuffer);
-          } catch (VeloxRuntimeError& e) {
+          date.timezoneId = util::getTimeZoneID(timezoneBuffer, false);
+          if (date.timezoneId == -1) {
             return -1;
           }
         }

--- a/velox/functions/lib/DateTimeFormatter.h
+++ b/velox/functions/lib/DateTimeFormatter.h
@@ -173,7 +173,11 @@ class DateTimeFormatter {
     return tokens_;
   }
 
-  DateTimeResult parse(const std::string_view& input) const;
+  // If failOnError is false, returns std::nullopt for parsing error.
+  // Otherwise, fail with error thrown.
+  std::optional<DateTimeResult> parse(
+      const std::string_view& input,
+      const bool failOnError = false) const;
 
   /// Returns max size of the formatted string. Can be used to preallocate
   /// memory before calling format() to avoid extra copy.

--- a/velox/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/velox/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -77,13 +77,16 @@ class DateTimeFormatterTest : public testing::Test {
   DateTimeResult parseJoda(
       const std::string_view& input,
       const std::string_view& format) {
-    return buildJodaDateTimeFormatter(format)->parse(input);
+    return buildJodaDateTimeFormatter(format)->parse(input, true).value();
   }
 
   Timestamp parseMysql(
       const std::string_view& input,
       const std::string_view& format) {
-    return buildMysqlDateTimeFormatter(format)->parse(input).timestamp;
+    return buildMysqlDateTimeFormatter(format)
+        ->parse(input, true)
+        .value()
+        .timestamp;
   }
 
   // Parses and returns the timezone converted back to string, to ease
@@ -91,7 +94,8 @@ class DateTimeFormatterTest : public testing::Test {
   std::string parseTZ(
       const std::string_view& input,
       const std::string_view& format) {
-    auto result = buildJodaDateTimeFormatter(format)->parse(input);
+    auto result =
+        buildJodaDateTimeFormatter(format)->parse(input, true).value();
     if (result.timezoneId == 0) {
       return "+00:00";
     }

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -1219,7 +1219,8 @@ struct DateParseFunction {
     }
 
     auto dateTimeResult =
-        format_->parse(std::string_view(input.data(), input.size()));
+        format_->parse(std::string_view(input.data(), input.size()), true)
+            .value();
 
     // Since MySql format has no timezone specifier, simply check if session
     // timezone was provided. If not, fallback to 0 (GMT).
@@ -1330,7 +1331,8 @@ struct ParseDateTimeFunction {
           std::string_view(format.data(), format.size()));
     }
     auto dateTimeResult =
-        format_->parse(std::string_view(input.data(), input.size()));
+        format_->parse(std::string_view(input.data(), input.size()), true)
+            .value();
 
     // If timezone was not parsed, fallback to the session timezone. If there's
     // no session timezone, fallback to 0 (GMT).

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -291,6 +291,9 @@ void registerFunctions(const std::string& prefix) {
 
   registerFunction<NextDayFunction, Date, Date, Varchar>({prefix + "next_day"});
 
+  registerFunction<GetTimestampFunction, Timestamp, Varchar, Varchar>(
+      {prefix + "get_timestamp"});
+
   // Register bloom filter function
   registerFunction<BloomFilterMightContainFunction, bool, Varbinary, int64_t>(
       {prefix + "might_contain"});

--- a/velox/type/tz/TimeZoneMap.cpp
+++ b/velox/type/tz/TimeZoneMap.cpp
@@ -117,7 +117,7 @@ std::string getTimeZoneName(int64_t timeZoneID) {
   return it->second;
 }
 
-int64_t getTimeZoneID(std::string_view timeZone) {
+int64_t getTimeZoneID(std::string_view timeZone, bool failOnError) {
   static folly::F14FastMap<std::string, int64_t> nameToIdMap =
       makeReverseMap(getTimeZoneDB());
   std::string timeZoneLowered;
@@ -134,7 +134,10 @@ int64_t getTimeZoneID(std::string_view timeZone) {
   if (it != nameToIdMap.end()) {
     return it->second;
   }
-  VELOX_FAIL("Unknown time zone: '{}'", timeZone);
+  if (failOnError) {
+    VELOX_FAIL("Unknown time zone: '{}'", timeZone);
+  }
+  return -1;
 }
 
 } // namespace facebook::velox::util

--- a/velox/type/tz/TimeZoneMap.h
+++ b/velox/type/tz/TimeZoneMap.h
@@ -24,6 +24,8 @@ namespace facebook::velox::util {
 std::string getTimeZoneName(int64_t timeZoneID);
 
 // Returns the timeZoneID for the timezone name.
-int64_t getTimeZoneID(std::string_view timeZone);
+// If failOnError = true, throws an exception for unrecognized timezone.
+// Otherwise, returns -1.
+int64_t getTimeZoneID(std::string_view timeZone, bool failOnError = true);
 
 } // namespace facebook::velox::util


### PR DESCRIPTION
Get timestamp by parsing a date string according to the specified date format. This function can be used to support `to_date` function, as Spark breaks `to_date` into `get_timestamp` & `cast` (from timestamp to date). Spark source code [link](https://github.com/apache/spark/blob/4f65413031d8a196a3442fd39cedd50eaf1a7655/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala#L1093).

Also added `failOnError` argument for date/time parse API to just return null for parsing error instead of throwing exception if `failOnError` is false.