### PR TITLE
Specify units of individual counters in ExchangeSource.stats

### DIFF
--- a/velox/exec/ExchangeClient.cpp
+++ b/velox/exec/ExchangeClient.cpp
@@ -92,7 +92,12 @@ folly::F14FastMap<std::string, RuntimeMetric> ExchangeClient::stats() const {
   folly::F14FastMap<std::string, RuntimeMetric> stats;
   for (const auto& source : sources_) {
     for (const auto& [name, value] : source->stats()) {
-      stats[name].addValue(value);
+      if (UNLIKELY(stats.count(name) == 0)) {
+        stats.insert(std::pair(name, RuntimeMetric(value.unit)));
+      } else {
+        VELOX_CHECK_EQ(stats.at(name).unit, value.unit);
+      }
+      stats.at(name).addValue(value.value);
     }
   }
 

--- a/velox/exec/ExchangeClient.cpp
+++ b/velox/exec/ExchangeClient.cpp
@@ -93,6 +93,9 @@ folly::F14FastMap<std::string, RuntimeMetric> ExchangeClient::stats() const {
   for (const auto& source : sources_) {
     if (source->supportsMetrics()) {
       for (const auto& [name, value] : source->metrics()) {
+        if (UNLIKELY(stats.count(name) == 0)) {
+          stats.insert(std::pair(name, RuntimeMetric(value.unit)));
+        }
         stats[name].merge(value);
       }
     } else {

--- a/velox/exec/ExchangeClient.cpp
+++ b/velox/exec/ExchangeClient.cpp
@@ -91,13 +91,14 @@ folly::F14FastMap<std::string, RuntimeMetric> ExchangeClient::stats() const {
 
   folly::F14FastMap<std::string, RuntimeMetric> stats;
   for (const auto& source : sources_) {
-    for (const auto& [name, value] : source->stats()) {
-      if (UNLIKELY(stats.count(name) == 0)) {
-        stats.insert(std::pair(name, RuntimeMetric(value.unit)));
-      } else {
-        VELOX_CHECK_EQ(stats.at(name).unit, value.unit);
+    if (source->supportsMetrics()) {
+      for (const auto& [name, value] : source->metrics()) {
+        stats.at(name).merge(value);
       }
-      stats.at(name).addValue(value.value);
+    } else {
+      for (const auto& [name, value] : source->stats()) {
+        stats.at(name).addValue(value);
+      }
     }
   }
 

--- a/velox/exec/ExchangeClient.cpp
+++ b/velox/exec/ExchangeClient.cpp
@@ -93,11 +93,11 @@ folly::F14FastMap<std::string, RuntimeMetric> ExchangeClient::stats() const {
   for (const auto& source : sources_) {
     if (source->supportsMetrics()) {
       for (const auto& [name, value] : source->metrics()) {
-        stats.at(name).merge(value);
+        stats[name].merge(value);
       }
     } else {
       for (const auto& [name, value] : source->stats()) {
-        stats.at(name).addValue(value);
+        stats[name].addValue(value);
       }
     }
   }

--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -15,7 +15,6 @@
  */
 #pragma once
 
-#include "velox/common/base/RuntimeMetrics.h"
 #include "velox/exec/ExchangeQueue.h"
 #include "velox/exec/ExchangeSource.h"
 

--- a/velox/exec/ExchangeSource.h
+++ b/velox/exec/ExchangeSource.h
@@ -101,14 +101,16 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
   // Returns runtime statistics. ExchangeSource is expected to report
   // background CPU time by including a runtime metric named
   // ExchangeClient::kBackgroundCpuTimeMs.
-  virtual folly::F14FastMap<std::string, int64_t> stats() const = 0;
+  virtual folly::F14FastMap<std::string, int64_t> stats() const {
+    VELOX_UNREACHABLE();
+  }
 
   /// Returns runtime statistics. ExchangeSource is expected to report
   /// Specify units of individual counters in ExchangeSource.
   /// for an example: 'totalBytes ：count: 9, sum: 11.17GB, max: 1.39GB,
   /// min:  1.16GB'
   virtual folly::F14FastMap<std::string, RuntimeMetric> metrics() const {
-    return {};
+    VELOX_NYI();
   }
 
   virtual std::string toString() {

--- a/velox/exec/ExchangeSource.h
+++ b/velox/exec/ExchangeSource.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/common/base/RuntimeMetrics.h"
 #include "velox/exec/ExchangeQueue.h"
 
 namespace facebook::velox::exec {
@@ -94,7 +95,7 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
   // Returns runtime statistics. ExchangeSource is expected to report
   // background CPU time by including a runtime metric named
   // ExchangeClient::kBackgroundCpuTimeMs.
-  virtual folly::F14FastMap<std::string, int64_t> stats() const = 0;
+  virtual folly::F14FastMap<std::string, RuntimeCounter> stats() const = 0;
 
   virtual std::string toString() {
     std::stringstream out;

--- a/velox/exec/ExchangeSource.h
+++ b/velox/exec/ExchangeSource.h
@@ -46,6 +46,12 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
     VELOX_UNREACHABLE();
   }
 
+  /// Temporary API to indicate whether 'metrics()' API
+  /// is supported.
+  virtual bool supportsMetrics() const {
+    return false;
+  }
+
   /// Returns true if there is no request to the source pending or if
   /// this should be retried. If true, the caller is expected to call
   /// request(). This is expected to be called while holding lock over
@@ -95,7 +101,15 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
   // Returns runtime statistics. ExchangeSource is expected to report
   // background CPU time by including a runtime metric named
   // ExchangeClient::kBackgroundCpuTimeMs.
-  virtual folly::F14FastMap<std::string, RuntimeCounter> stats() const = 0;
+  virtual folly::F14FastMap<std::string, int64_t> stats() const = 0;
+
+  /// Returns runtime statistics. ExchangeSource is expected to report
+  /// Specify units of individual counters in ExchangeSource.
+  /// for an example: 'totalBytes ：count: 9, sum: 11.17GB, max: 1.39GB,
+  /// min:  1.16GB'
+  virtual folly::F14FastMap<std::string, RuntimeMetric> metrics() const {
+    return {};
+  }
 
   virtual std::string toString() {
     std::stringstream out;

--- a/velox/exec/tests/utils/LocalExchangeSource.cpp
+++ b/velox/exec/tests/utils/LocalExchangeSource.cpp
@@ -30,6 +30,10 @@ class LocalExchangeSource : public exec::ExchangeSource {
       memory::MemoryPool* pool)
       : ExchangeSource(taskId, destination, queue, pool) {}
 
+  bool supportsMetrics() const override {
+    return true;
+  }
+
   bool shouldRequestLocked() override {
     if (atEnd_) {
       return false;
@@ -163,6 +167,16 @@ class LocalExchangeSource : public exec::ExchangeSource {
         {"localExchangeSource.numPages", numPages_},
         {"localExchangeSource.totalBytes", totalBytes_},
         {ExchangeClient::kBackgroundCpuTimeMs, 123},
+    };
+  }
+
+  folly::F14FastMap<std::string, RuntimeMetric> metrics() const override {
+    return {
+        {"localExchangeSource.numPages", RuntimeMetric(numPages_)},
+        {"localExchangeSource.totalBytes",
+         RuntimeMetric(totalBytes_, RuntimeCounter::Unit::kBytes)},
+        {ExchangeClient::kBackgroundCpuTimeMs,
+         RuntimeMetric(123 * 1000000, RuntimeCounter::Unit::kNanos)},
     };
   }
 

--- a/velox/exec/tests/utils/LocalExchangeSource.cpp
+++ b/velox/exec/tests/utils/LocalExchangeSource.cpp
@@ -158,13 +158,12 @@ class LocalExchangeSource : public exec::ExchangeSource {
     buffers->deleteResults(taskId_, destination_);
   }
 
-  folly::F14FastMap<std::string, RuntimeCounter> stats() const override {
+  folly::F14FastMap<std::string, int64_t> stats() const override {
     return {
-        {"localExchangeSource.numPages", RuntimeCounter(numPages_)},
-        {"localExchangeSource.totalBytes",
-         RuntimeCounter(totalBytes_, RuntimeCounter::Unit::kBytes)},
-        {ExchangeClient::kBackgroundCpuTimeMs,
-         RuntimeCounter(123 * 1000000, RuntimeCounter::Unit::kNanos)}};
+        {"localExchangeSource.numPages", numPages_},
+        {"localExchangeSource.totalBytes", totalBytes_},
+        {ExchangeClient::kBackgroundCpuTimeMs, 123},
+    };
   }
 
  private:

--- a/velox/exec/tests/utils/LocalExchangeSource.cpp
+++ b/velox/exec/tests/utils/LocalExchangeSource.cpp
@@ -158,12 +158,13 @@ class LocalExchangeSource : public exec::ExchangeSource {
     buffers->deleteResults(taskId_, destination_);
   }
 
-  folly::F14FastMap<std::string, int64_t> stats() const override {
+  folly::F14FastMap<std::string, RuntimeCounter> stats() const override {
     return {
-        {"localExchangeSource.numPages", numPages_},
-        {"localExchangeSource.totalBytes", totalBytes_},
-        {ExchangeClient::kBackgroundCpuTimeMs, 123},
-    };
+        {"localExchangeSource.numPages", RuntimeCounter(numPages_)},
+        {"localExchangeSource.totalBytes",
+         RuntimeCounter(totalBytes_, RuntimeCounter::Unit::kBytes)},
+        {ExchangeClient::kBackgroundCpuTimeMs,
+         RuntimeCounter(123 * 1000000, RuntimeCounter::Unit::kNanos)}};
   }
 
  private:

--- a/velox/exec/tests/utils/LocalExchangeSource.cpp
+++ b/velox/exec/tests/utils/LocalExchangeSource.cpp
@@ -162,14 +162,6 @@ class LocalExchangeSource : public exec::ExchangeSource {
     buffers->deleteResults(taskId_, destination_);
   }
 
-  folly::F14FastMap<std::string, int64_t> stats() const override {
-    return {
-        {"localExchangeSource.numPages", numPages_},
-        {"localExchangeSource.totalBytes", totalBytes_},
-        {ExchangeClient::kBackgroundCpuTimeMs, 123},
-    };
-  }
-
   folly::F14FastMap<std::string, RuntimeMetric> metrics() const override {
     return {
         {"localExchangeSource.numPages", RuntimeMetric(numPages_)},


### PR DESCRIPTION
Before this change, stats reported by ExchangeSource didn't have units. This
change allows to specify units for individual stats by using RuntimeCounter
instead of int64_t.

Before (no units):
```
prestoExchangeSource.totalBytes ：count: 9, sum: 12,004,020,858, max: 1500,670,068, min:  1,249,825,816
```

After (with units):
```
prestoExchangeSource.totalBytes ：count: 9, sum: 11.17GB, max: 1.39GB, min:  1.16GB
```

this pr change
```
add new supportsMetrics() API and new metrics() API to ExchangeSource
default implementation to deprecated old stats() API that throws VELOX_UNREACHABLE() .
```
