### PR TITLE
Add private mutex to ExchangeClient

### DIFF
--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -114,6 +114,7 @@ class ExchangeClient {
   const int64_t maxQueuedBytes_;
   memory::MemoryPool* const pool_;
   std::shared_ptr<ExchangeQueue> queue_;
+  mutable std::mutex mutex_;
   std::unordered_set<std::string> taskIds_;
   std::vector<std::shared_ptr<ExchangeSource>> sources_;
   bool closed_{false};

--- a/velox/exec/ExchangeQueue.h
+++ b/velox/exec/ExchangeQueue.h
@@ -130,6 +130,7 @@ class ExchangeQueue {
   }
 
   void addSourceLocked() {
+    std::lock_guard<std::mutex> l(mutex_);
     VELOX_CHECK(!noMoreSources_, "addSource called after noMoreSources");
     numSources_++;
   }


### PR DESCRIPTION
ExchangeClient used to rely on ExchangeQueue::mutex(), which is also used by
ExchangeSource. This caused lock contention in multi-threaded environments.

Add private mutex to ExchangeClient to protect private members（taskIds_ ,
sources_, closed_, producingSources_, emptySources_).

And ExchangeClient access  to the ExchangeQueue lock will fail, triggered a core dump.
see issue: https://github.com/facebookincubator/velox/issues/8044

So when having a private mutex, in the case of multi-threaded processing, there is no need to worry about whether the ExchangeQueue will be destructed, leading to mutex acquisition failure.

Fixes #8044
