### PR TITLE
Allow for not counting off-thread times into calling thread

### DIFF
--- a/velox/common/base/AsyncSource.cpp
+++ b/velox/common/base/AsyncSource.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/AsyncSource.h"
+
+DEFINE_bool(
+    account_for_off_thread_times,
+    true,
+    "whether to account for off-thread times");

--- a/velox/common/base/AsyncSource.h
+++ b/velox/common/base/AsyncSource.h
@@ -21,12 +21,15 @@
 #include <folly/futures/Future.h>
 #include <functional>
 #include <memory>
+#include <optional>
 #include "velox/common/time/CpuWallTimer.h"
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/Portability.h"
 #include "velox/common/future/VeloxPromise.h"
 #include "velox/common/testutil/TestValue.h"
+
+DECLARE_bool(account_for_off_thread_times);
 
 namespace facebook::velox {
 
@@ -58,7 +61,10 @@ class AsyncSource {
     }
     std::unique_ptr<Item> item;
     try {
-      CpuWallTimer timer(timing_);
+      std::optional<CpuWallTimer> timer{
+        FLAGS_account_for_off_thread_times
+          ? std::optional<CpuWallTimer>{timing_}
+          : std::nullopt};
       item = make();
     } catch (std::exception& e) {
       std::lock_guard<std::mutex> l(mutex_);

--- a/velox/common/base/AsyncSource.h
+++ b/velox/common/base/AsyncSource.h
@@ -62,9 +62,9 @@ class AsyncSource {
     std::unique_ptr<Item> item;
     try {
       std::optional<CpuWallTimer> timer{
-        FLAGS_account_for_off_thread_times
-          ? std::optional<CpuWallTimer>{timing_}
-          : std::nullopt};
+          FLAGS_account_for_off_thread_times
+              ? std::optional<CpuWallTimer>{timing_}
+              : std::nullopt};
       item = make();
     } catch (std::exception& e) {
       std::lock_guard<std::mutex> l(mutex_);

--- a/velox/common/base/CMakeLists.txt
+++ b/velox/common/base/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(
 
 add_library(
   velox_common_base
+  AsyncSource.cpp
   BitUtil.cpp
   Counters.cpp
   Fs.cpp

--- a/velox/common/base/tests/AsyncSourceTest.cpp
+++ b/velox/common/base/tests/AsyncSourceTest.cpp
@@ -47,6 +47,14 @@ TEST(AsyncSourceTest, basic) {
   EXPECT_TRUE(error.hasValue());
 }
 
+TEST(AsyncSourceTest, doNotAccountForOffThreadTimes) {
+  FLAGS_account_for_off_thread_times = false;
+  AsyncSource<Gizmo> gizmo([]() { return std::make_unique<Gizmo>(11); });
+  EXPECT_FALSE(gizmo.hasValue());
+  gizmo.prepare();
+  EXPECT_EQ(0, gizmo.prepareTiming().count);
+}
+
 TEST(AsyncSourceTest, threads) {
   constexpr int32_t kNumThreads = 10;
   constexpr int32_t kNumGizmos = 2000;


### PR DESCRIPTION
This change adds an option so we will not count off-thread times to wallNanos. By default, we will retain the current behavior, so this change is a nop unless someone changes the flag first.

Fixes #7993