### PR TITLE
optimize redundant code

### DIFF
--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -147,7 +147,7 @@ void Exchange::recordExchangeClientStats() {
 
   auto lockedStats = stats_.wlock();
   const auto exchangeClientStats = exchangeClient_->stats();
-  for (const auto& [name, value] : exchangeClient_->stats()) {
+  for (const auto& [name, value] : exchangeClientStats) {
     lockedStats->runtimeStats.erase(name);
     lockedStats->runtimeStats.insert({name, value});
   }

--- a/velox/serializers/CMakeLists.txt
+++ b/velox/serializers/CMakeLists.txt
@@ -15,8 +15,7 @@ add_library(
   velox_presto_serializer PrestoSerializer.cpp UnsafeRowSerializer.cpp
                           CompactRowSerializer.cpp)
 
-target_link_libraries(velox_presto_serializer velox_dwio_common velox_vector
-                      velox_row_fast)
+target_link_libraries(velox_presto_serializer velox_vector velox_row_fast)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)


### PR DESCRIPTION
optimize redundant code:

remove unuse link libraries velox_dwio_common from velox_presto_serializer
reuse exchangeClientStats for recordExchangeClientStats.
