### PR TITLE
Fix adapters issue caused by null config in FileHandleGenerator

### DIFF
--- a/velox/common/file/FileSystems.h
+++ b/velox/common/file/FileSystems.h
@@ -49,9 +49,7 @@ struct FileOptions {
 class FileSystem {
  public:
   FileSystem(std::shared_ptr<const Config> config)
-      : config_(std::move(config)) {
-    VELOX_CHECK_NOT_NULL(config_)
-  }
+      : config_(std::move(config)) {}
   virtual ~FileSystem() = default;
 
   /// Returns the name of the File System

--- a/velox/common/file/FileSystems.h
+++ b/velox/common/file/FileSystems.h
@@ -49,7 +49,9 @@ struct FileOptions {
 class FileSystem {
  public:
   FileSystem(std::shared_ptr<const Config> config)
-      : config_(std::move(config)) {}
+      : config_(std::move(config)) {
+    VELOX_CHECK_NOT_NULL(config_)
+  }
   virtual ~FileSystem() = default;
 
   /// Returns the name of the File System

--- a/velox/connectors/hive/FileHandle.h
+++ b/velox/connectors/hive/FileHandle.h
@@ -66,7 +66,7 @@ class FileHandleGenerator {
  public:
   explicit FileHandleGenerator(std::shared_ptr<const Config> properties)
       : properties_(std::move(properties)) {
-    VELOX_CHECK_NOT_NULL(properties_)
+    VELOX_CHECK_NOT_NULL(properties_);
   }
   std::shared_ptr<FileHandle> operator()(const std::string& filename);
 

--- a/velox/connectors/hive/FileHandle.h
+++ b/velox/connectors/hive/FileHandle.h
@@ -64,9 +64,10 @@ using FileHandleCache = SimpleLRUCache<std::string, FileHandle>;
 // Creates FileHandles via the Generator interface the CachedFactory requires.
 class FileHandleGenerator {
  public:
-  FileHandleGenerator() {}
-  FileHandleGenerator(std::shared_ptr<const Config> properties)
-      : properties_(std::move(properties)) {}
+  explicit FileHandleGenerator(std::shared_ptr<const Config> properties)
+      : properties_(std::move(properties)) {
+    VELOX_CHECK_NOT_NULL(properties_)
+  }
   std::shared_ptr<FileHandle> operator()(const std::string& filename);
 
  private:

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -60,7 +60,7 @@ HiveConnector::HiveConnector(
                     SimpleLRUCache<std::string, std::shared_ptr<FileHandle>>>(
                     hiveConfig_->numCacheFileHandles())
               : nullptr,
-          std::make_unique<FileHandleGenerator>(nullptr)),
+          std::make_unique<FileHandleGenerator>(config)),
       executor_(executor) {
   if (hiveConfig_->isFileHandleCacheEnabled()) {
     LOG(INFO) << "Hive connector " << connectorId()

--- a/velox/connectors/hive/tests/FileHandleTest.cpp
+++ b/velox/connectors/hive/tests/FileHandleTest.cpp
@@ -20,6 +20,7 @@
 #include "velox/common/caching/SimpleLRUCache.h"
 #include "velox/common/file/File.h"
 #include "velox/common/file/FileSystems.h"
+#include "velox/core/Config.h"
 #include "velox/exec/tests/utils/TempFilePath.h"
 
 using namespace facebook::velox;
@@ -39,7 +40,8 @@ TEST(FileHandleTest, localFile) {
   FileHandleFactory factory(
       std::make_unique<
           SimpleLRUCache<std::string, std::shared_ptr<FileHandle>>>(1000),
-      std::make_unique<FileHandleGenerator>());
+      std::make_unique<FileHandleGenerator>(
+          std::make_shared<const core::MemConfig>()));
   auto fileHandle = factory.generate(filename).second;
   ASSERT_EQ(fileHandle->file->size(), 3);
   char buffer[3];


### PR DESCRIPTION
PR #7725 pass nullptr properties to FileHandleGenerator which used to create static adapters, it cause null pointer issue when access config in FileSystem, such as S3, GCS and our internal adapter.

This patch is a quick fix for FileHandleGenerator to force pass config in ctor.