### PR TITLE
Collect 'longestDriverNoProgressTimeMs' metric.

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1923,6 +1923,12 @@ TaskStats Task::taskStats() const {
       continue;
     }
 
+    const auto pipelineId = driver->driverCtx()->pipelineId;
+    taskStats.pipelineStats[pipelineId].longestDriverNoProgressTimeMs =
+        std::max(
+            taskStats.pipelineStats[pipelineId].longestDriverNoProgressTimeMs,
+            driver->getMsSinceLastProgress());
+
     for (auto& op : driver->operators()) {
       auto statsCopy = op->stats(false);
       aggregateOperatorRuntimeStats(statsCopy.runtimeStats);

--- a/velox/exec/TaskStats.h
+++ b/velox/exec/TaskStats.h
@@ -39,6 +39,9 @@ struct PipelineStats {
   // True if contains the sync node for the task.
   bool outputPipeline;
 
+  /// The longest time since a driver in the pipeline had progress.
+  size_t longestDriverNoProgressTimeMs{0};
+
   PipelineStats(bool _inputPipeline, bool _outputPipeline)
       : inputPipeline{_inputPipeline}, outputPipeline{_outputPipeline} {}
 };


### PR DESCRIPTION
Summary: Collect 'longestDriverNoProgressTimeMs' metric in PipelineStats.

Differential Revision: D52125713


