### PR TITLE
Add yield when process spill input in hash build

### DIFF
--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -42,17 +42,20 @@ class HashBuild final : public Operator {
   enum class State {
     /// The running state.
     kRunning = 1,
+    /// The yield state that voluntarily yield cpu after running too long when
+    /// processing input from spilled file.
+    kYield = 2,
     /// The state that waits for the pending group spill to finish. This state
     /// only applies if disk spilling is enabled.
-    kWaitForSpill = 2,
+    kWaitForSpill = 3,
     /// The state that waits for the hash tables to be merged together.
-    kWaitForBuild = 3,
+    kWaitForBuild = 4,
     /// The state that waits for the hash probe to finish before start to build
     /// the hash table for one of previously spilled partition. This state only
     /// applies if disk spilling is enabled.
-    kWaitForProbe = 4,
+    kWaitForProbe = 5,
     /// The finishing state.
-    kFinish = 5,
+    kFinish = 6,
   };
   static std::string stateName(State state);
 


### PR DESCRIPTION
When hash build process spill input, it does this in a tight
loop until process all the inputs from spill file. This PR
optimizes this by adding yield after processing each spill input
batch.