### PR TITLE
Parallelize StructColumnReader

### DIFF
--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -26,14 +26,15 @@ add_library(
   BitConcatenation.cpp
   BitPackDecoder.cpp
   BufferedInput.cpp
-  CachedBufferedInput.cpp
   CacheInputStream.cpp
-  DirectBufferedInput.cpp
-  DirectInputStream.cpp
+  CachedBufferedInput.cpp
+  ColumnLoader.cpp
   ColumnSelector.cpp
   DataBufferHolder.cpp
   DecoderUtil.cpp
+  DirectBufferedInput.cpp
   DirectDecoder.cpp
+  DirectInputStream.cpp
   DwioMetricsLog.cpp
   ExecutorBarrier.cpp
   FileSink.cpp
@@ -43,22 +44,22 @@ add_library(
   MetadataFilter.cpp
   Options.cpp
   OutputStream.cpp
+  ParallelFor.cpp
   Range.cpp
   Reader.cpp
   ReaderFactory.cpp
   ScanSpec.cpp
-  ColumnLoader.cpp
+  SeekableInputStream.cpp
   SelectiveByteRleColumnReader.cpp
   SelectiveColumnReader.cpp
   SelectiveRepeatedColumnReader.cpp
   SelectiveStructColumnReader.cpp
-  SeekableInputStream.cpp
+  SortingWriter.cpp
+  SortingWriter.h
   TypeUtils.cpp
   TypeWithId.cpp
   Writer.cpp
-  WriterFactory.cpp
-  SortingWriter.cpp
-  SortingWriter.h)
+  WriterFactory.cpp)
 
 target_include_directories(velox_dwio_common PRIVATE ${Protobuf_INCLUDE_DIRS})
 

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -117,6 +117,7 @@ class RowReaderOptions {
   // 'ioExecutor' enables parallelism when performing file system read
   // operations.
   std::shared_ptr<folly::Executor> decodingExecutor_;
+  size_t decodingParallelismFactor_{0};
   bool appendRowNumberColumn_ = false;
   // Function to populate metrics related to feature projection stats
   // in Koski. This gets fired in FlatMapColumnReader.
@@ -308,6 +309,10 @@ class RowReaderOptions {
     decodingExecutor_ = executor;
   }
 
+  void setDecodingParallelismFactor(size_t factor) {
+    decodingParallelismFactor_ = factor;
+  }
+
   /*
    * Set to true, if you want to add a new column to the results containing the
    * row numbers.  These row numbers are relative to the beginning of file (0 as
@@ -362,6 +367,10 @@ class RowReaderOptions {
 
   const std::shared_ptr<folly::Executor>& getDecodingExecutor() const {
     return decodingExecutor_;
+  }
+
+  size_t getDecodingParallelismFactor() const {
+    return decodingParallelismFactor_;
   }
 };
 

--- a/velox/dwio/common/ParallelFor.cpp
+++ b/velox/dwio/common/ParallelFor.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/ParallelFor.h"
+#include "velox/common/base/Exceptions.h"
+#include "velox/dwio/common/ExecutorBarrier.h"
+
+namespace facebook::velox::dwio::common {
+
+namespace {
+
+std::vector<std::pair<size_t, size_t>>
+splitRange(size_t from, size_t to, size_t factor) {
+  VELOX_CHECK_LE(from, to);
+  std::vector<std::pair<size_t, size_t>> ranges;
+
+  if (from == to) {
+    return ranges;
+  }
+
+  if (factor <= 1) {
+    ranges.emplace_back(from, to);
+    return ranges;
+  }
+
+  auto rangeSize = to - from;
+  auto chunkSize = rangeSize / factor;
+  auto remainder = rangeSize % factor;
+  auto start = from;
+  for (size_t i = 0; i < factor; ++i) {
+    auto end = start + chunkSize;
+    if (remainder > 0) {
+      --remainder;
+      ++end;
+    }
+    // If `factor > (to - from)`, the rest of the chunks will be empty
+    if (end > start) {
+      ranges.emplace_back(start, end);
+    } else {
+      break;
+    }
+    start = end;
+  }
+  return ranges;
+}
+
+} // namespace
+
+ParallelFor::ParallelFor(
+    folly::Executor* executor,
+    size_t from,
+    size_t to,
+    size_t parallelismFactor)
+    : executor_(executor),
+      ranges_{splitRange(from, to, (executor_ ? parallelismFactor : 0))} {}
+
+ParallelFor::ParallelFor(
+    std::shared_ptr<folly::Executor> executor,
+    size_t from,
+    size_t to,
+    size_t parallelismFactor)
+    : ParallelFor{executor.get(), from, to, parallelismFactor} {
+  owned_ = std::move(executor);
+}
+
+void ParallelFor::execute(std::function<void(size_t)> func) {
+  // Otherwise from == to
+  if (ranges_.empty()) {
+    return;
+  }
+  if (ranges_.size() == 1) {
+    for (size_t i = ranges_[0].first, end = ranges_[0].second; i < end; ++i) {
+      func(i);
+    }
+  } else {
+    VELOX_CHECK(
+        executor_,
+        "Executor wasn't provided so we shouldn't have more than 1 range");
+    ExecutorBarrier barrier(*executor_);
+    const size_t last = ranges_.size() - 1;
+    // First N-1 ranges in executor threads
+    for (size_t r = 0; r < last; ++r) {
+      auto& range = ranges_[r];
+      barrier.add([begin = range.first, end = range.second, &func]() {
+        for (size_t i = begin; i < end; ++i) {
+          func(i);
+        }
+      });
+    }
+    // Last range in calling thread
+    auto& range = ranges_[last];
+    for (size_t i = range.first, end = range.second; i < end; ++i) {
+      func(i);
+    }
+    barrier.waitAll();
+  }
+}
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/ParallelFor.h
+++ b/velox/dwio/common/ParallelFor.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "folly/Executor.h"
+
+namespace facebook::velox::dwio::common {
+
+/*
+ * A helper class that allows to run a function on a range of indices in
+ * multiple threads.
+ * The range (from, to] is split into equal-sized chunks and each chunk is
+ * scheduled in a different thread. The number of threads is: parallelismFactor
+ * It means that if parallelismFactor == 1 (or 0), the function will be executed
+ * in the calling thread for the entire range. If parallelismFactor == 2, the
+ * function will be called for half of the range in one thread in the executor,
+ * and for the last half in the calling thread (and so on). If no executor is
+ * passed (nullptr), the function will be executed in the calling thread for the
+ * entire range.
+ */
+class ParallelFor {
+ public:
+  ParallelFor(
+      folly::Executor* FOLLY_NULLABLE executor,
+      size_t from, // start index
+      size_t to, // past end index
+      // number of threads.
+      size_t parallelismFactor);
+
+  ParallelFor(
+      std::shared_ptr<folly::Executor> executor,
+      size_t from, // start index
+      size_t to, // past end index
+      // number of threads
+      size_t parallelismFactor);
+
+  void execute(std::function<void(size_t)> func);
+
+ private:
+  std::shared_ptr<folly::Executor> owned_;
+  folly::Executor* executor_;
+  std::vector<std::pair<size_t, size_t>> ranges_;
+};
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(
   ExecutorBarrierTest.cpp
   LocalFileSinkTest.cpp
   LoggedExceptionTest.cpp
+  ParallelForTest.cpp
   RangeTests.cpp
   ReadFileInputStreamTests.cpp
   ReaderTest.cpp

--- a/velox/dwio/common/tests/ParallelForTest.cpp
+++ b/velox/dwio/common/tests/ParallelForTest.cpp
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/ParallelFor.h"
+#include "folly/Executor.h"
+#include "folly/executors/CPUThreadPoolExecutor.h"
+#include "folly/executors/InlineExecutor.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "velox/common/base/VeloxException.h"
+
+using namespace ::testing;
+using namespace ::facebook::velox::dwio::common;
+
+namespace {
+
+class CountingExecutor : public folly::Executor {
+ public:
+  explicit CountingExecutor(folly::Executor& executor)
+      : executor_(executor), count_(0) {}
+
+  void add(folly::Func f) override {
+    executor_.add(std::move(f));
+    ++count_;
+  }
+
+  size_t getCount() const {
+    return count_;
+  }
+
+ private:
+  folly::Executor& executor_;
+  size_t count_;
+};
+
+void testParallelFor(
+    folly::Executor* executor,
+    size_t from,
+    size_t to,
+    size_t parallelismFactor) {
+  std::optional<CountingExecutor> countedExecutor;
+  std::ostringstream oss;
+  oss << "ParallelFor(executor: " << executor << ", from: " << from
+      << ", to: " << to << ", parallelismFactor: " << parallelismFactor << ")";
+  SCOPED_TRACE(oss.str());
+  if (executor) {
+    countedExecutor.emplace(*executor);
+    executor = &countedExecutor.value();
+  }
+
+  std::unordered_map<size_t, std::atomic<size_t>> indexInvoked;
+  for (size_t i = from; i < to; ++i) {
+    indexInvoked[i] = 0UL;
+  }
+
+  ParallelFor(executor, from, to, parallelismFactor)
+      .execute([&indexInvoked](size_t i) {
+        auto it = indexInvoked.find(i);
+        ASSERT_NE(it, indexInvoked.end());
+        ++it->second;
+      });
+
+  // Parallel For should have thrown otherwise
+  ASSERT_LE(from, to);
+
+  // The method was called for each index just once, and didn't call out of
+  // bounds indices.
+  EXPECT_EQ(indexInvoked.size(), (to - from));
+  for (auto& [i, count] : indexInvoked) {
+    if (i < from || i >= to) {
+      EXPECT_EQ(indexInvoked[i], 0);
+    } else {
+      EXPECT_EQ(indexInvoked[i], 1);
+    }
+  }
+
+  if (countedExecutor) {
+    const auto extraThreadsUsed = countedExecutor->getCount();
+    const auto numTasks = to - from;
+    const auto expectedExtraThreads = std::min(
+        parallelismFactor > 0 ? parallelismFactor - 1 : 0,
+        numTasks > 0 ? numTasks - 1 : 0);
+    EXPECT_EQ(extraThreadsUsed, expectedExtraThreads);
+  }
+}
+
+} // namespace
+
+TEST(ParallelForTest, E2E) {
+  auto inlineExecutor = folly::InlineExecutor::instance();
+  for (size_t parallelism = 0; parallelism < 25; ++parallelism) {
+    for (size_t begin = 0; begin < 25; ++begin) {
+      for (size_t end = 0; end < 25; ++end) {
+        if (begin <= end) {
+          testParallelFor(&inlineExecutor, begin, end, parallelism);
+        } else {
+          EXPECT_THROW(
+              testParallelFor(&inlineExecutor, begin, end, parallelism),
+              facebook::velox::VeloxRuntimeError);
+        }
+      }
+    }
+  }
+}
+
+TEST(ParallelForTest, E2EParallel) {
+  for (size_t parallelism = 1; parallelism < 2; ++parallelism) {
+    folly::CPUThreadPoolExecutor executor(parallelism);
+    for (size_t begin = 0; begin < 25; ++begin) {
+      for (size_t end = 0; end < 25; ++end) {
+        if (begin <= end) {
+          testParallelFor(&executor, begin, end, parallelism);
+        } else {
+          EXPECT_THROW(
+              testParallelFor(&executor, begin, end, parallelism),
+              facebook::velox::VeloxRuntimeError);
+        }
+      }
+    }
+  }
+}
+
+TEST(ParallelForTest, CanOwnExecutor) {
+  auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(2);
+  const size_t indexInvokedSize = 100;
+  std::unordered_map<size_t, std::atomic<size_t>> indexInvoked;
+  indexInvoked.reserve(indexInvokedSize);
+  for (size_t i = 0; i < indexInvokedSize; ++i) {
+    indexInvoked[i] = 0UL;
+  }
+
+  ParallelFor pf(executor, 0, indexInvokedSize, 9);
+  pf.execute([&indexInvoked](size_t i) { ++indexInvoked[i]; });
+
+  EXPECT_EQ(indexInvoked.size(), indexInvokedSize);
+  for (size_t i = 0; i < indexInvokedSize; ++i) {
+    EXPECT_EQ(indexInvoked[i], 1);
+  }
+}

--- a/velox/dwio/dwrf/reader/ColumnReader.h
+++ b/velox/dwio/dwrf/reader/ColumnReader.h
@@ -107,6 +107,10 @@ class ColumnReader {
     VELOX_NYI();
   }
 
+  virtual bool isFlatMap() const {
+    return false;
+  }
+
   /**
    * Create a reader for the given stripe.
    */

--- a/velox/dwio/dwrf/reader/ColumnReader.h
+++ b/velox/dwio/dwrf/reader/ColumnReader.h
@@ -116,6 +116,7 @@ class ColumnReader {
       StripeStreams& stripe,
       const StreamLabels& streamLabels,
       folly::Executor* FOLLY_NULLABLE executor,
+      size_t decodingParallelismFactor,
       FlatMapContext flatMapContext = {});
 };
 
@@ -128,6 +129,7 @@ class ColumnReaderFactory {
       StripeStreams& stripe,
       const StreamLabels& streamLabels,
       folly::Executor* FOLLY_NULLABLE executor,
+      size_t decodingParallelismFactor,
       FlatMapContext flatMapContext = {}) {
     return ColumnReader::build(
         requestedType,
@@ -135,6 +137,7 @@ class ColumnReaderFactory {
         stripe,
         streamLabels,
         executor,
+        decodingParallelismFactor,
         std::move(flatMapContext));
   }
 

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -37,6 +37,10 @@ DwrfRowReader::DwrfRowReader(
       executor_{options_.getDecodingExecutor()},
       columnSelector_{std::make_shared<ColumnSelector>(
           ColumnSelector::apply(opts.getSelector(), reader->getSchema()))} {
+  if (executor_) {
+    LOG(INFO) << "Using parallel decoding with a parallelism factor of "
+              << options_.getDecodingParallelismFactor();
+  }
   auto& fileFooter = getReader().getFooter();
   uint32_t numberOfStripes = fileFooter.stripesSize();
   currentStripe_ = numberOfStripes;
@@ -526,6 +530,7 @@ DwrfRowReader::FetchResult DwrfRowReader::fetch(uint32_t stripeIndex) {
         stripeStreams,
         streamLabels,
         executor_.get(),
+        options_.getDecodingParallelismFactor(),
         flatMapContext);
   }
   DWIO_ENSURE(

--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.h
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.h
@@ -161,6 +161,10 @@ class FlatMapColumnReader : public ColumnReader {
       VectorPtr& result,
       const uint64_t* FOLLY_NULLABLE nulls) override;
 
+  bool isFlatMap() const override {
+    return true;
+  }
+
  private:
   const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
   std::vector<std::unique_ptr<KeyNode<T>>> keyNodes_;
@@ -193,6 +197,10 @@ class FlatMapStructEncodingColumnReader : public ColumnReader {
       uint64_t numValues,
       VectorPtr& result,
       const uint64_t* FOLLY_NULLABLE nulls) override;
+
+  bool isFlatMap() const override {
+    return true;
+  }
 
  private:
   const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;

--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.h
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.h
@@ -20,6 +20,7 @@
 #include "velox/common/base/BitUtil.h"
 #include "velox/dwio/common/DataBuffer.h"
 #include "velox/dwio/common/FlatMapHelper.h"
+#include "velox/dwio/common/ParallelFor.h"
 #include "velox/dwio/common/TypeWithId.h"
 #include "velox/dwio/dwrf/reader/ColumnReader.h"
 #include "velox/dwio/dwrf/reader/ConstantColumnReader.h"
@@ -148,6 +149,8 @@ class FlatMapColumnReader : public ColumnReader {
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       StripeStreams& stripe,
       const StreamLabels& streamLabels,
+      folly::Executor* FOLLY_NULLABLE executor,
+      size_t decodingParallelismFactor,
       FlatMapContext flatMapContext);
   ~FlatMapColumnReader() override = default;
 
@@ -163,6 +166,8 @@ class FlatMapColumnReader : public ColumnReader {
   std::vector<std::unique_ptr<KeyNode<T>>> keyNodes_;
   std::unique_ptr<StringKeyBuffer> stringKeyBuffer_;
   bool returnFlatVector_;
+  folly::Executor* FOLLY_NULLABLE executor_;
+  std::unique_ptr<dwio::common::ParallelFor> parallelForOnKeyNodes_;
 
   void initStringKeyBuffer() {}
 
@@ -178,6 +183,7 @@ class FlatMapStructEncodingColumnReader : public ColumnReader {
       StripeStreams& stripe,
       const StreamLabels& streamLabels,
       folly::Executor* FOLLY_NULLABLE executor,
+      size_t decodingParallelismFactor,
       FlatMapContext flatMapContext);
   ~FlatMapStructEncodingColumnReader() override = default;
 
@@ -193,6 +199,7 @@ class FlatMapStructEncodingColumnReader : public ColumnReader {
   std::vector<std::unique_ptr<KeyNode<T>>> keyNodes_;
   std::unique_ptr<NullColumnReader> nullColumnReader_;
   folly::Executor* FOLLY_NULLABLE executor_;
+  dwio::common::ParallelFor parallelForOnKeyNodes_;
   BufferPtr mergedNulls_;
 };
 
@@ -204,6 +211,7 @@ class FlatMapColumnReaderFactory {
       StripeStreams& stripe,
       const StreamLabels& streamLabels,
       folly::Executor* FOLLY_NULLABLE executor,
+      size_t decodingParallelismFactor,
       FlatMapContext flatMapContext);
 };
 

--- a/velox/dwio/dwrf/test/ColumnWriterTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTest.cpp
@@ -351,6 +351,7 @@ void testDataTypeWriter(
         streams,
         labels,
         nullptr,
+        0,
         FlatMapContext{
             .sequence = sequence,
             .inMapDecoder = nullptr,
@@ -936,7 +937,7 @@ void testMapWriter(
       memory::AllocationPool allocPool(pool.get());
       StreamLabels labels(allocPool);
       const auto reader = ColumnReader::build(
-          dataTypeWithId, dataTypeWithId, streams, labels, nullptr);
+          dataTypeWithId, dataTypeWithId, streams, labels, nullptr, 0);
       VectorPtr out;
 
       // Read map/row
@@ -1072,7 +1073,7 @@ void testMapWriterRow(
       memory::AllocationPool allocPool(pool.get());
       StreamLabels labels(allocPool);
       const auto reader = ColumnReader::build(
-          dataTypeWithId, dataTypeWithId, streams, labels, nullptr);
+          dataTypeWithId, dataTypeWithId, streams, labels, nullptr, 0);
       VectorPtr out;
 
       // Read map/row
@@ -2081,7 +2082,7 @@ struct IntegerColumnWriterTypedTestCase {
       memory::AllocationPool allocPool(pool.get());
       StreamLabels labels(allocPool);
       auto columnReader =
-          ColumnReader::build(reqType, reqType, streams, labels, nullptr);
+          ColumnReader::build(reqType, reqType, streams, labels, nullptr, 0);
 
       for (size_t j = 0; j != repetitionCount; ++j) {
         // TODO Make reuse work
@@ -3318,7 +3319,7 @@ struct StringColumnWriterTestCase {
       memory::AllocationPool allocPool(pool.get());
       StreamLabels labels(allocPool);
       auto columnReader =
-          ColumnReader::build(reqType, reqType, streams, labels, nullptr);
+          ColumnReader::build(reqType, reqType, streams, labels, nullptr, 0);
 
       for (size_t j = 0; j != repetitionCount; ++j) {
         if (!writeDirect) {
@@ -4395,7 +4396,7 @@ struct DictColumnWriterTestCase {
     memory::AllocationPool allocPool(pool.get());
     StreamLabels labels(allocPool);
     auto reader =
-        ColumnReader::build(reqType, reqType, streams, labels, nullptr);
+        ColumnReader::build(reqType, reqType, streams, labels, nullptr, 0);
     VectorPtr out;
     reader->next(batch->size(), out);
     compareResults(batch, out);

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -82,9 +82,14 @@ class TestReaderP
  protected:
   folly::Executor* executor() {
     if (GetParam() && !executor_) {
-      std::make_shared<folly::CPUThreadPoolExecutor>(2);
+      std::make_shared<folly::CPUThreadPoolExecutor>(
+          getDecodingParallelismFactor());
     }
     return executor_.get();
+  }
+
+  size_t getDecodingParallelismFactor() {
+    return GetParam() ? 2 : 0;
   }
 
  private:
@@ -1818,7 +1823,8 @@ TEST_P(TestReaderP, testUpcastBoolean) {
       TypeWithId::create(rowType),
       streams,
       labels,
-      executor());
+      executor(),
+      getDecodingParallelismFactor());
 
   VectorPtr batch;
   reader->next(104, batch);
@@ -1868,7 +1874,8 @@ TEST_P(TestReaderP, testUpcastIntDirect) {
       TypeWithId::create(rowType),
       streams,
       labels,
-      executor());
+      executor(),
+      getDecodingParallelismFactor());
 
   VectorPtr batch;
   reader->next(100, batch);
@@ -1935,7 +1942,8 @@ TEST_P(TestReaderP, testUpcastIntDict) {
       TypeWithId::create(rowType),
       streams,
       labels,
-      executor());
+      executor(),
+      getDecodingParallelismFactor());
 
   VectorPtr batch;
   reader->next(100, batch);
@@ -1990,7 +1998,8 @@ TEST_P(TestReaderP, testUpcastFloat) {
       TypeWithId::create(rowType),
       streams,
       labels,
-      executor());
+      executor(),
+      getDecodingParallelismFactor());
 
   VectorPtr batch;
   reader->next(100, batch);

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -159,7 +159,8 @@ class ColumnReaderTestBase {
           fileTypeWithId,
           streams_,
           labels_,
-          executor_.get());
+          executor_.get(),
+          parallelDecoding() ? 2 : 0);
       selectiveColumnReader_ = nullptr;
     }
   }


### PR DESCRIPTION
Summary:
Only if it's top level. Otherwise we may deadlock since children StructColumnReaders could schedule their columns in the same executor, which may only have one thread.

Also, since children flatmaps could also parallelize, blocking their thread, they can also deadlock. So, if I have one or more flatmap children columns, we don't parallelize the struct. Flatmaps can only be direct child of top level structs. They can't be at greater depth in the tree.

Differential Revision: D52128393


