### PR TITLE
Remove extra semi colon from velox/buffer/Buffer.h

### DIFF
--- a/velox/buffer/Buffer.h
+++ b/velox/buffer/Buffer.h
@@ -58,7 +58,7 @@ class Buffer {
   static inline constexpr bool is_pod_like_v =
       std::is_trivially_destructible_v<T>&& std::is_trivially_copyable_v<T>;
 
-  virtual ~Buffer(){};
+  virtual ~Buffer() {}
 
   void addRef() {
     referenceCount_.fetch_add(1);

--- a/velox/common/memory/CompactDoubleList.h
+++ b/velox/common/memory/CompactDoubleList.h
@@ -108,6 +108,4 @@ class CompactDoubleList {
   uint16_t previousHigh_;
 };
 
-;
-
 } // namespace facebook::velox

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -2029,7 +2029,7 @@ class AssignUniqueIdNode : public PlanNode {
 
   const std::shared_ptr<std::atomic_int64_t>& uniqueIdCounter() const {
     return uniqueIdCounter_;
-  };
+  }
 
   folly::dynamic serialize() const override;
 

--- a/velox/dwio/catalog/fbhive/FileUtils.cpp
+++ b/velox/dwio/catalog/fbhive/FileUtils.cpp
@@ -94,7 +94,7 @@ std::vector<std::pair<std::string, std::string>> extractPartitionKeyValues(
     parserFunc(part, entries);
   }
   return entries;
-};
+}
 
 // Strong assumption that all expressions in the form of a=b means a partition
 // key value pair in '/' separated tokens. We could have stricter validation

--- a/velox/dwio/common/MetricsLog.h
+++ b/velox/dwio/common/MetricsLog.h
@@ -72,7 +72,7 @@ class MetricsLog {
   };
 
   // read path logging methods
-  virtual void logRead(const ReadMetrics& metrics) const {};
+  virtual void logRead(const ReadMetrics& metrics) const {}
 
   virtual void logColumnFilter(
       const ColumnFilter& filter,


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D51995040


