### PR TITLE
Fix variance edge case

### DIFF
--- a/velox/functions/prestosql/aggregates/VarianceAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/VarianceAggregates.cpp
@@ -38,7 +38,7 @@ struct VarianceAccumulator {
   VarianceAccumulator(int64_t count, double value)
       : count_(count), mean_(value), m2_(0.0) {}
 
-  double count() const {
+  int64_t count() const {
     return count_;
   }
 
@@ -63,6 +63,12 @@ struct VarianceAccumulator {
 
   void merge(int64_t countOther, double meanOther, double m2Other) {
     if (countOther == 0) {
+      return;
+    }
+    if (count_ == 0) {
+      count_ = countOther;
+      mean_ = meanOther;
+      m2_ = m2Other;
       return;
     }
     int64_t newCount = countOther + count();

--- a/velox/functions/prestosql/aggregates/tests/VarianceAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/VarianceAggregationTest.cpp
@@ -292,5 +292,22 @@ TEST_F(VarianceAggregationTest, varianceWithoutPrecisionLoss) {
   }
 }
 
+TEST_F(VarianceAggregationTest, varianceMergeEmpty) {
+  auto accumulators = makeRowVector({
+      makeRowVector({
+          makeFlatVector<int64_t>({0, 2}),
+          makeFlatVector<double>({0, 1.45419e163}),
+          makeFlatVector<double>({0, HUGE_VAL}),
+      }),
+  });
+  auto node = PlanBuilder(pool())
+                  .values({accumulators})
+                  .finalAggregation({}, {"variance(c0)"}, {{DOUBLE()}})
+                  .planNode();
+  auto expected =
+      makeRowVector({makeFlatVector(std::vector<double>({HUGE_VAL}))});
+  AssertQueryBuilder(node).assertResults(expected);
+}
+
 } // namespace
 } // namespace facebook::velox::aggregate::test

--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -758,6 +758,10 @@ bool equalsFloatingPointWithEpsilonTyped(const variant& a, const variant& b) {
   if (std::isnan(f1) && std::isnan(f2)) {
     return true;
   }
+  if (std::isinf(f1)) {
+    // fabs(inf - inf) is indeterminate.
+    return f1 == f2;
+  }
 
   // Check if the numbers are really close -- needed
   // when comparing numbers near zero.


### PR DESCRIPTION
Summary:
When the current accumulator is empty, and then we are adding another
accumulator with `m2` is infinity and `mean` with a very large value that when
squared would become infinity, the new `m2` calculation is indeterminate ($` \infty \times 0`$) and becomes `NaN`.  The correct new `m2` should be infinity.  We should just
take the values of second accumulator directly in this case.

Also update the merge function of covariance just to be safe.

Differential Revision: D52132799


