### PR TITLE
Add file-create-config to hive config and propagate to file sink

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -214,4 +214,11 @@ uint64_t HiveConfig::sortWriterMaxOutputBytes(const Config* session) const {
   return 10UL << 20;
 }
 
+std::string HiveConfig::fileCreateConfig(const Config* session) const {
+  if (session->isValueExists(kFileCreateConfig)) {
+    return session->get<std::string>(kFileCreateConfig).value();
+  }
+  return config_->get<std::string>(kFileCreateConfig, "");
+}
+
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -148,6 +148,11 @@ class HiveConfig {
   static constexpr const char* kSortWriterMaxOutputBytesSession =
       "sort_writer_max_output_bytes";
 
+  /// Config used to create sink files. This config is provided to underlying
+  /// file system and the config is free form. The form should be defined by
+  /// the underlying file system.
+  static constexpr const char* kFileCreateConfig = "file-create-config";
+
   InsertExistingPartitionsBehavior insertExistingPartitionsBehavior(
       const Config* session) const;
 
@@ -200,6 +205,8 @@ class HiveConfig {
   uint32_t sortWriterMaxOutputRows(const Config* session) const;
 
   uint64_t sortWriterMaxOutputBytes(const Config* session) const;
+
+  std::string fileCreateConfig(const Config* session) const;
 
   HiveConfig(std::shared_ptr<const Config> config) {
     VELOX_CHECK_NOT_NULL(

--- a/velox/dwio/common/FileSink.h
+++ b/velox/dwio/common/FileSink.h
@@ -41,6 +41,10 @@ class FileSink : public Closeable {
     /// Connector properties are required to create a FileSink on FileSystems
     /// such as S3.
     const std::shared_ptr<const Config>& connectorProperties{nullptr};
+    /// Config used to create sink files. This config is provided to underlying
+    /// file system and the config is free form. The form should be defined by
+    /// the underlying file system.
+    const std::string fileCreateConfig{""};
     memory::MemoryPool* pool{nullptr};
     MetricsLogPtr metricLogger{MetricsLog::voidLog()};
     IoStatistics* stats{nullptr};


### PR DESCRIPTION
This change will allow us to specify the write file create options through hive config or session properties.