### PR TITLE
Fix FileHandleGenerator inside HiveConnector

### DIFF
--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -60,7 +60,7 @@ HiveConnector::HiveConnector(
                     SimpleLRUCache<std::string, std::shared_ptr<FileHandle>>>(
                     hiveConfig_->numCacheFileHandles())
               : nullptr,
-          std::make_unique<FileHandleGenerator>(nullptr)),
+          std::make_unique<FileHandleGenerator>(config)),
       executor_(executor) {
   if (hiveConfig_->isFileHandleCacheEnabled()) {
     LOG(INFO) << "Hive connector " << connectorId()

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/CMakeLists.txt
@@ -66,7 +66,10 @@ target_link_libraries(
   gtest_main)
 
 add_executable(velox_s3read_test S3ReadTest.cpp)
-add_test(velox_s3read_test velox_s3read_test)
+add_test(
+  NAME velox_s3read_test
+  COMMAND velox_s3read_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(
   velox_s3read_test
   velox_file

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/CMakeLists.txt
@@ -64,3 +64,17 @@ target_link_libraries(
   velox_exec
   gtest
   gtest_main)
+
+add_executable(velox_s3read_test S3ReadTest.cpp)
+add_test(velox_s3read_test velox_s3read_test)
+target_link_libraries(
+  velox_s3read_test
+  velox_file
+  velox_s3fs
+  velox_hive_config
+  velox_core
+  velox_exec_test_lib
+  velox_dwio_common_exception
+  velox_exec
+  gtest
+  gtest_main)

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/MinioServer.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/MinioServer.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#pragma once
+
 #include "velox/core/Config.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3ReadTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3ReadTest.cpp
@@ -87,7 +87,7 @@ TEST_F(S3ReadTest, s3ReadTest) {
   std::ofstream dest(destinationFile, std::ios::binary);
   // Copy source file to destination bucket.
   dest << src.rdbuf();
-  VELOX_CHECK_GT(dest.tellp(), 0, "Source file {} not found", sourceFile);
+  VELOX_CHECK_GT(dest.tellp(), 0, "Unable to copy from source {}", sourceFile);
   dest.close();
 
   const auto readDirectory{s3URI(bucketName)};

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3ReadTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3ReadTest.cpp
@@ -76,17 +76,18 @@ TEST_F(S3ReadTest, s3ReadTest) {
            kExpectedRows, [](auto row) { return row + 100; }),
        makeFlatVector<int64_t>(
            kExpectedRows, [](auto row) { return row + 1000; })});
-  const auto sourceFile =
-      getDataFilePath("velox/connectors/hive/storage_adapters/s3fs/tests", "../../../../../dwio/parquet/tests/examples/int.parquet");
+  const auto sourceFile = getDataFilePath(
+      "velox/connectors/hive/storage_adapters/s3fs/tests",
+      "../../../../../dwio/parquet/tests/examples/int.parquet");
   const char* bucketName = "data";
   const auto destinationFile = S3Test::localPath(bucketName) + "/int.parquet";
   minioServer_->addBucket(bucketName);
-  
+
   std::ifstream src(sourceFile, std::ios::binary);
   std::ofstream dest(destinationFile, std::ios::binary);
   // Copy source file to destination bucket.
   dest << src.rdbuf();
-  VELOX_CHECK_GT(dest.tellp(), 0, "Source file not found");
+  VELOX_CHECK_GT(dest.tellp(), 0, "Source file {} not found", sourceFile);
   dest.close();
 
   const auto readDirectory{s3URI(bucketName)};

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3ReadTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3ReadTest.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+#include "velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h"
+#include "velox/connectors/hive/storage_adapters/s3fs/tests/S3Test.h"
+#include "velox/dwio/common/tests/utils/DataFiles.h"
+#include "velox/exec/TableWriter.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::core;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+using namespace facebook::velox::connector;
+using namespace facebook::velox::connector::hive;
+using namespace facebook::velox::dwio::common;
+using namespace facebook::velox::test;
+using namespace facebook::velox::filesystems;
+
+class S3ReadTest : public S3Test, public VectorTestBase {
+ public:
+  static constexpr char const* kMinioConnectionString{"127.0.0.1:6000"};
+  /// We use static initialization because we want a single version of the
+  /// Minio server running.
+  /// Each test must use a unique bucket to avoid concurrency issues.
+  static void SetUpTestSuite() {
+    minioServer_ = std::make_shared<MinioServer>(kMinioConnectionString);
+    minioServer_->start();
+
+    ioExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(3);
+    filesystems::registerS3FileSystem();
+    auto hiveConnector =
+        connector::getConnectorFactory(
+            connector::hive::HiveConnectorFactory::kHiveConnectorName)
+            ->newConnector(
+                kHiveConnectorId,
+                minioServer_->hiveConfig(),
+                ioExecutor_.get());
+    connector::registerConnector(hiveConnector);
+  }
+
+  static void TearDownTestSuite() {
+    filesystems::finalizeS3FileSystem();
+    unregisterConnector(kHiveConnectorId);
+    minioServer_->stop();
+    minioServer_ = nullptr;
+  }
+
+  static std::unique_ptr<folly::IOThreadPoolExecutor> ioExecutor_;
+};
+std::unique_ptr<folly::IOThreadPoolExecutor> S3ReadTest::ioExecutor_ = nullptr;
+
+TEST_F(S3ReadTest, s3ReadTest) {
+  const int64_t kExpectedRows = 10;
+  // input is the data in int.parquet file.
+  auto input = makeRowVector(
+      {makeFlatVector<int32_t>(
+           kExpectedRows, [](auto row) { return row + 100; }),
+       makeFlatVector<int64_t>(
+           kExpectedRows, [](auto row) { return row + 1000; })});
+  const auto sourceFile =
+      getDataFilePath("velox/connectors/hive/storage_adapters/s3fs/tests", "../../../../../dwio/parquet/tests/examples/int.parquet");
+  const char* bucketName = "data";
+  const auto destinationFile = S3Test::localPath(bucketName) + "/int.parquet";
+  minioServer_->addBucket(bucketName);
+  
+  std::ifstream src(sourceFile, std::ios::binary);
+  std::ofstream dest(destinationFile, std::ios::binary);
+  // Copy source file to destination bucket.
+  dest << src.rdbuf();
+  VELOX_CHECK_GT(dest.tellp(), 0, "Source file not found");
+  dest.close();
+
+  const auto readDirectory{s3URI(bucketName)};
+  auto rowType = ROW({"int", "bigint"}, {INTEGER(), BIGINT()});
+  auto plan = PlanBuilder().tableScan(rowType).planNode();
+  auto split = HiveConnectorSplitBuilder(
+                   fmt::format("{}/{}", readDirectory, "int.parquet"))
+                   .fileFormat(dwio::common::FileFormat::PARQUET)
+                   .build();
+  auto copy = AssertQueryBuilder(plan).split(split).copyResults(pool());
+  assertEqualResults({input}, {copy});
+}
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::init(&argc, &argv, false);
+  return RUN_ALL_TESTS();
+}

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3ReadTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3ReadTest.cpp
@@ -31,6 +31,7 @@ namespace {
 class S3ReadTest : public S3Test, public test::VectorTestBase {
  public:
   static constexpr char const* kMinioConnectionString{"127.0.0.1:6000"};
+
   /// We use static initialization because we want a single version of the
   /// Minio server running.
   /// Each test must use a unique bucket to avoid concurrency issues.
@@ -66,7 +67,7 @@ TEST_F(S3ReadTest, s3ReadTest) {
   std::ofstream dest(destinationFile, std::ios::binary);
   // Copy source file to destination bucket.
   dest << src.rdbuf();
-  VELOX_CHECK_GT(dest.tellp(), 0, "Unable to copy from source {}", sourceFile);
+  ASSERT_GT(dest.tellp(), 0) << "Unable to copy from source " << sourceFile;
   dest.close();
 
   // Read the parquet file via the S3 bucket.
@@ -88,10 +89,10 @@ TEST_F(S3ReadTest, s3ReadTest) {
            kExpectedRows, [](auto row) { return row + 1000; })});
   assertEqualResults({expectedResults}, {copy});
 }
+} // namespace facebook::velox
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   folly::init(&argc, &argv, false);
   return RUN_ALL_TESTS();
 }
-} // namespace facebook::velox


### PR DESCRIPTION
A recent refactor https://github.com/facebookincubator/velox/pull/7725 missed passing the connector config
to the FileHandleGenerator in the HiveConnector.