### PR TITLE
Like function: Error while using double escape char in pattern string

### DIFF
--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -1133,12 +1133,12 @@ PatternMetadata determinePatternKind(
   const size_t patternLength = pattern.size();
 
   // Index of the first % or _ character(not escaped).
-  size_t wildcardStart = -1;
+  int32_t wildcardStart = -1;
   // Index of the first character that is not % and not _.
-  size_t fixedPatternStart = -1;
+  int32_t fixedPatternStart = -1;
   // Index of the last character in the fixed pattern, used to retrieve the
   // fixed string for patterns of type kSubstring.
-  size_t fixedPatternEnd = -1;
+  int32_t fixedPatternEnd = -1;
   // Count of wildcard character sequences in pattern.
   size_t numWildcardSequences = 0;
   // Total number of % characters.

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -591,6 +591,18 @@ TEST_F(Re2FunctionsTest, likePatternWildcard) {
   testLike("\nabcde\n", "%bcf%", false);
 }
 
+TEST_F(Re2FunctionsTest, likePatternEscapingEscapeChar) {
+  testLike(R"(\)", R"(\\)", '\\', true);
+  testLike(R"(\abc)", R"(\\%)", '\\', true);
+  testLike(R"(\abc)", R"(\\abc)", '\\', true);
+  testLike(R"(abc\abc)", R"(abc\\abc)", '\\', true);
+  testLike(R"(\abcdef)", R"(\\abc%)", '\\', true);
+  testLike(R"(\abcdefghijkl)", R"(\\abc%gh%)", '\\', true);
+  testLike(R"(abc\abc)", R"(%\\%)", '\\', true);
+  testLike(R"(abcdef\abcdef)", R"(%\\abc%)", '\\', true);
+  testLike(R"(abcdef\\\abcdef)", R"(%\\\\\\abc%)", '\\', true);
+}
+
 TEST_F(Re2FunctionsTest, likePatternFixed) {
   testLike("", "", true);
   testLike("abcde", "abcde", true);

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -592,15 +592,15 @@ TEST_F(Re2FunctionsTest, likePatternWildcard) {
 }
 
 TEST_F(Re2FunctionsTest, likePatternEscapingEscapeChar) {
-  //  testLike(R"(\)", R"(\\)", '\\', true);
-  //  testLike(R"(\abc)", R"(\\%)", '\\', true);
-  //  testLike(R"(\abc)", R"(\\abc)", '\\', true);
-  //  testLike(R"(abc\abc)", R"(abc\\abc)", '\\', true);
-  //  testLike(R"(\abcdef)", R"(\\abc%)", '\\', true);
-  //  testLike(R"(\abcdefghijkl)", R"(\\abc%gh%)", '\\', true);
-  //  testLike(R"(abc\abc)", R"(%\\%)", '\\', true);
+  testLike(R"(\)", R"(\\)", '\\', true);
+  testLike(R"(\abc)", R"(\\%)", '\\', true);
+  testLike(R"(\abc)", R"(\\abc)", '\\', true);
+  testLike(R"(abc\abc)", R"(abc\\abc)", '\\', true);
+  testLike(R"(\abcdef)", R"(\\abc%)", '\\', true);
+  testLike(R"(\abcdefghijkl)", R"(\\abc%gh%)", '\\', true);
+  testLike(R"(abc\abc)", R"(%\\%)", '\\', true);
   testLike(R"(abcdef\abcdef)", R"(%\\abc%)", '\\', true);
-  //  testLike(R"(abcdef\\\abcdef)", R"(%\\\\\\abc%)", '\\', true);
+  testLike(R"(abcdef\\\abcdef)", R"(%\\\\\\abc%)", '\\', true);
 }
 
 TEST_F(Re2FunctionsTest, likePatternFixed) {

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -592,15 +592,15 @@ TEST_F(Re2FunctionsTest, likePatternWildcard) {
 }
 
 TEST_F(Re2FunctionsTest, likePatternEscapingEscapeChar) {
-  testLike(R"(\)", R"(\\)", '\\', true);
-  testLike(R"(\abc)", R"(\\%)", '\\', true);
-  testLike(R"(\abc)", R"(\\abc)", '\\', true);
-  testLike(R"(abc\abc)", R"(abc\\abc)", '\\', true);
-  testLike(R"(\abcdef)", R"(\\abc%)", '\\', true);
-  testLike(R"(\abcdefghijkl)", R"(\\abc%gh%)", '\\', true);
-  testLike(R"(abc\abc)", R"(%\\%)", '\\', true);
+  //  testLike(R"(\)", R"(\\)", '\\', true);
+  //  testLike(R"(\abc)", R"(\\%)", '\\', true);
+  //  testLike(R"(\abc)", R"(\\abc)", '\\', true);
+  //  testLike(R"(abc\abc)", R"(abc\\abc)", '\\', true);
+  //  testLike(R"(\abcdef)", R"(\\abc%)", '\\', true);
+  //  testLike(R"(\abcdefghijkl)", R"(\\abc%gh%)", '\\', true);
+  //  testLike(R"(abc\abc)", R"(%\\%)", '\\', true);
   testLike(R"(abcdef\abcdef)", R"(%\\abc%)", '\\', true);
-  testLike(R"(abcdef\\\abcdef)", R"(%\\\\\\abc%)", '\\', true);
+  //  testLike(R"(abcdef\\\abcdef)", R"(%\\\\\\abc%)", '\\', true);
 }
 
 TEST_F(Re2FunctionsTest, likePatternFixed) {


### PR DESCRIPTION
Expression:

```cpp
like(R"(abcdef\abcdef)", R"(%\\abc%)", '\\')
```

Error:

```
Error Source: USER
Error Code: INVALID_ARGUMENT
Reason: Escape character must be followed by '%', '_' or the escape character itself
Retriable: False
Expression: current == escapeChar || current == '_' || current == '%'
Function: unescape
File: ../../velox/functions/lib/Re2Functions.cpp
```

The bug is a regression caused by https://github.com/facebookincubator/velox/pull/7730