### PR TITLE
Replace the overuse of StringView with std::string_view in Re2Function

### DIFF
--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -967,7 +967,7 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> re2ExtractSignatures() {
 }
 
 std::string unescape(
-    const std::string_view& pattern,
+    const std::string_view pattern,
     size_t start,
     size_t end,
     std::optional<char> escapeChar) {
@@ -1123,7 +1123,7 @@ class PatternStringIterator {
 };
 
 PatternMetadata determinePatternKind(
-    const std::string_view& pattern,
+    const std::string_view pattern,
     std::optional<char> escapeChar) {
   int32_t patternLength = pattern.size();
 

--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -20,10 +20,6 @@
 #include <optional>
 #include <string>
 
-#include "velox/expression/VectorWriters.h"
-#include "velox/type/StringView.h"
-#include "velox/vector/BaseVector.h"
-
 namespace facebook::velox::functions {
 namespace {
 
@@ -594,7 +590,7 @@ class LikeGeneric final : public VectorFunction {
                         const StringView& pattern,
                         const std::optional<char>& escapeChar) -> bool {
       PatternMetadata patternMetadata =
-          determinePatternKind(pattern, escapeChar);
+          determinePatternKind(std::string_view(pattern), escapeChar);
       const auto reducedLength = patternMetadata.length;
       const auto& fixedPattern = patternMetadata.fixedPattern;
 
@@ -971,7 +967,7 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> re2ExtractSignatures() {
 }
 
 std::string unescape(
-    StringView pattern,
+    const std::string_view& pattern,
     size_t start,
     size_t end,
     std::optional<char> escapeChar) {
@@ -1023,7 +1019,9 @@ std::string unescape(
 // Iterates through a pattern string. Transparently handles escape sequences.
 class PatternStringIterator {
  public:
-  PatternStringIterator(StringView pattern, std::optional<char> escapeChar)
+  PatternStringIterator(
+      std::string_view pattern,
+      std::optional<char> escapeChar)
       : pattern_(pattern),
         escapeChar_(escapeChar),
         lastIndex_{pattern_.size() - 1} {}
@@ -1115,7 +1113,7 @@ class PatternStringIterator {
     return pattern_.data()[currentIndex_];
   }
 
-  const StringView pattern_;
+  const std::string_view pattern_;
   const std::optional<char> escapeChar_;
   const size_t lastIndex_;
 
@@ -1125,7 +1123,7 @@ class PatternStringIterator {
 };
 
 PatternMetadata determinePatternKind(
-    StringView pattern,
+    const std::string_view& pattern,
     std::optional<char> escapeChar) {
   int32_t patternLength = pattern.size();
 
@@ -1275,7 +1273,8 @@ std::shared_ptr<exec::VectorFunction> makeLike(
 
   PatternMetadata patternMetadata;
   try {
-    patternMetadata = determinePatternKind(pattern, escapeChar);
+    patternMetadata =
+        determinePatternKind(std::string_view(pattern), escapeChar);
   } catch (...) {
     return std::make_shared<exec::AlwaysFailingVectorFunction>(
         std::current_exception());

--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -967,7 +967,7 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> re2ExtractSignatures() {
 }
 
 std::string unescape(
-    const std::string_view pattern,
+    std::string_view pattern,
     size_t start,
     size_t end,
     std::optional<char> escapeChar) {
@@ -1113,7 +1113,7 @@ class PatternStringIterator {
     return pattern_.data()[currentIndex_];
   }
 
-  const std::string_view pattern_;
+  std::string_view pattern_;
   const std::optional<char> escapeChar_;
   const size_t lastIndex_;
 
@@ -1123,7 +1123,7 @@ class PatternStringIterator {
 };
 
 PatternMetadata determinePatternKind(
-    const std::string_view pattern,
+    std::string_view pattern,
     std::optional<char> escapeChar) {
   int32_t patternLength = pattern.size();
 

--- a/velox/functions/lib/Re2Functions.h
+++ b/velox/functions/lib/Re2Functions.h
@@ -118,7 +118,7 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> re2ExtractSignatures();
 /// characters} for patterns with wildcard characters only. Return
 /// {kGenericPattern, 0} for generic patterns).
 PatternMetadata determinePatternKind(
-    StringView pattern,
+    const std::string_view& pattern,
     std::optional<char> escapeChar);
 
 std::shared_ptr<exec::VectorFunction> makeLike(

--- a/velox/functions/lib/Re2Functions.h
+++ b/velox/functions/lib/Re2Functions.h
@@ -118,7 +118,7 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> re2ExtractSignatures();
 /// characters} for patterns with wildcard characters only. Return
 /// {kGenericPattern, 0} for generic patterns).
 PatternMetadata determinePatternKind(
-    const std::string_view pattern,
+    std::string_view pattern,
     std::optional<char> escapeChar);
 
 std::shared_ptr<exec::VectorFunction> makeLike(

--- a/velox/functions/lib/Re2Functions.h
+++ b/velox/functions/lib/Re2Functions.h
@@ -118,7 +118,7 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> re2ExtractSignatures();
 /// characters} for patterns with wildcard characters only. Return
 /// {kGenericPattern, 0} for generic patterns).
 PatternMetadata determinePatternKind(
-    const std::string_view& pattern,
+    const std::string_view pattern,
     std::optional<char> escapeChar);
 
 std::shared_ptr<exec::VectorFunction> makeLike(

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -462,16 +462,16 @@ TEST_F(Re2FunctionsTest, likePattern) {
 
 TEST_F(Re2FunctionsTest, likeDeterminePatternKind) {
   auto testPattern =
-      [&](StringView pattern, PatternKind patternKind, vector_size_t length) {
+      [&](std::string_view pattern, PatternKind patternKind, size_t length) {
         PatternMetadata patternMetadata =
             determinePatternKind(pattern, std::nullopt);
         EXPECT_EQ(patternMetadata.patternKind, patternKind);
         EXPECT_EQ(patternMetadata.length, length);
       };
 
-  auto testPatternString = [&](StringView pattern,
+  auto testPatternString = [&](std::string_view pattern,
                                PatternKind patternKind,
-                               StringView fixedPattern) {
+                               std::string_view fixedPattern) {
     PatternMetadata patternMetadata =
         determinePatternKind(pattern, std::nullopt);
     EXPECT_EQ(patternMetadata.patternKind, patternKind);
@@ -526,9 +526,9 @@ TEST_F(Re2FunctionsTest, likeDeterminePatternKind) {
 }
 
 TEST_F(Re2FunctionsTest, likeDeterminePatternKindWithEscapeChar) {
-  auto testPattern = [&](StringView pattern,
+  auto testPattern = [&](std::string_view pattern,
                          PatternKind patternKind,
-                         StringView fixedPattern) {
+                         std::string_view fixedPattern) {
     PatternMetadata patternMetadata = determinePatternKind(pattern, '\\');
     EXPECT_EQ(patternMetadata.patternKind, patternKind);
     EXPECT_EQ(patternMetadata.length, fixedPattern.size());


### PR DESCRIPTION
Currently there are some overuse of StringView in Re2Functions.h/cpp. It's not good because StringView is not a replacement of std::string_view, its copy is expensive than std::string_view, its data() is not safe to point to for copied short StringView.

In this PR we replace StringView with std::string_view if it is a field of struct or a function param which is not feed by XxxVector directly.