### PR TITLE
Parallelize flat vector copy on FlatMapColumnReader

### DIFF
--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.h
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.h
@@ -171,6 +171,7 @@ class FlatMapColumnReader : public ColumnReader {
   std::unique_ptr<StringKeyBuffer> stringKeyBuffer_;
   bool returnFlatVector_;
   folly::Executor* FOLLY_NULLABLE executor_;
+  size_t decodingParallelismFactor_;
   std::unique_ptr<dwio::common::ParallelFor> parallelForOnKeyNodes_;
 
   void initStringKeyBuffer() {}


### PR DESCRIPTION
Summary:
Strobelight  shows that we spend as much time in copyOne as in decoding the features above in the function:
{F1174633587}

I'll also parallelize copyOne.

Differential Revision: D52164638


