### PR TITLE
Remove parallelism form FlatMapColumnReader (not struct encoded)

### DIFF
--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -1818,7 +1818,7 @@ StructColumnReader::StructColumnReader(
       proto::ColumnEncoding_Kind_DIRECT,
       "Unknown encoding for StructColumnReader");
 
-  // Can parallelize if top level and doesn't have any flatmap children
+  // Can parallelize if top level and doesn't have any parallelized children
   bool canParallelize = fileType->parent() == nullptr; // isTopLevel ?
 
   // count the number of selected sub-columns
@@ -1839,7 +1839,7 @@ StructColumnReader::StructColumnReader(
             executor,
             decodingParallelismFactor,
             makeCopyWithNullDecoder(flatMapContext_));
-        canParallelize = canParallelize && !childColumnReader->isFlatMap();
+        canParallelize = canParallelize && !childColumnReader->isParallelized();
         children_.push_back(std::move(childColumnReader));
       } else {
         children_.push_back(

--- a/velox/dwio/dwrf/reader/ColumnReader.h
+++ b/velox/dwio/dwrf/reader/ColumnReader.h
@@ -107,7 +107,7 @@ class ColumnReader {
     VELOX_NYI();
   }
 
-  virtual bool isFlatMap() const {
+  virtual bool isParallelized() const {
     return false;
   }
 

--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.h
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.h
@@ -149,8 +149,6 @@ class FlatMapColumnReader : public ColumnReader {
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       StripeStreams& stripe,
       const StreamLabels& streamLabels,
-      folly::Executor* FOLLY_NULLABLE executor,
-      size_t decodingParallelismFactor,
       FlatMapContext flatMapContext);
   ~FlatMapColumnReader() override = default;
 
@@ -161,17 +159,11 @@ class FlatMapColumnReader : public ColumnReader {
       VectorPtr& result,
       const uint64_t* FOLLY_NULLABLE nulls) override;
 
-  bool isFlatMap() const override {
-    return true;
-  }
-
  private:
   const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
   std::vector<std::unique_ptr<KeyNode<T>>> keyNodes_;
   std::unique_ptr<StringKeyBuffer> stringKeyBuffer_;
   bool returnFlatVector_;
-  folly::Executor* FOLLY_NULLABLE executor_;
-  std::unique_ptr<dwio::common::ParallelFor> parallelForOnKeyNodes_;
 
   void initStringKeyBuffer() {}
 
@@ -198,7 +190,7 @@ class FlatMapStructEncodingColumnReader : public ColumnReader {
       VectorPtr& result,
       const uint64_t* FOLLY_NULLABLE nulls) override;
 
-  bool isFlatMap() const override {
+  bool isParallelized() const override {
     return true;
   }
 


### PR DESCRIPTION
Summary:
The strobelight shows that the decoding part (KeyNode::load) just takes ~10% of the time:
 {F1174910379} 

So parallelizing that part doesn't help much. Actually, it makes things worse for certain parallelism factor, and just a bit better for others.

So we'll remove it.

Differential Revision: D52175560


