### PR TITLE
Add nightly experimental job to run Aggregation Fuzzer with --enable_sorted_aggregations

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -1,0 +1,182 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Experimental Fuzzer Jobs"
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/experimental.yml"
+
+  schedule:
+    - cron: '0 1 * * *'
+
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Ref to checkout out'
+        default: 'main'
+      numThreads:
+        description: 'Number of threads'
+        default: 16
+      maxHighMemJobs:
+        description: 'Number of high memory jobs'
+        default: 8
+      maxLinkJobs:
+        description: 'Maximum number of link jobs'
+        default: 4
+      extraCMakeFlags:
+        description: 'Additional CMake flags'
+        default: ''
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  compile:
+    runs-on: 16-core
+    timeout-minutes: 120
+    env:
+      CCACHE_DIR: "${{ github.workspace }}/.ccache/"
+      CCACHE_BASEDIR: "${{ github.workspace }}"
+      LINUX_DISTRO: "ubuntu"
+    steps:
+
+      - name: "Restore ccache"
+        uses: actions/cache@v3
+        with:
+          path: "${{ env.CCACHE_DIR }}"
+          # We are using the benchmark ccache as it has all
+          # required features enabled, so no need to create a new one
+          key: ccache-benchmark-${{ github.sha }}
+          restore-keys: |
+            ccache-benchmark-
+      - name: "Checkout Repo"
+        uses: actions/checkout@v3
+        with:
+          path: velox
+          submodules: 'recursive'
+          ref: "${{ inputs.ref || 'main' }}"
+
+      - name: "Install dependencies"
+        run: cd  velox && source ./scripts/setup-ubuntu.sh
+
+      - name: "Build"
+        run: |
+          cd velox
+          make debug NUM_THREADS="${{ inputs.numThreads || 8 }}" MAX_HIGH_MEM_JOBS="${{ inputs.maxHighMemJobs || 8 }}" MAX_LINK_JOBS="${{ inputs.maxLinkJobs || 4 }}" EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON ${{ inputs.extraCMakeFlags }}"
+          ccache -s
+
+      - name: Upload aggregation fuzzer
+        uses: actions/upload-artifact@v3
+        with:
+          name: aggregation
+          path: velox/_build/debug/velox/exec/tests/velox_aggregation_fuzzer_test
+
+      - name: Upload spark fuzzer
+        uses: actions/upload-artifact@v3
+        with:
+          name: spark
+          path: |
+            velox/_build/debug/velox/expression/tests/spark_expression_fuzzer_test
+            velox/_build/debug/velox/expression/tests/spark_aggregation_fuzzer_test
+
+
+  presto-java-aggregation-fuzzer-run:
+    runs-on: ubuntu-latest
+    container: ghcr.io/facebookincubator/velox-dev:presto-java
+    needs: compile
+    timeout-minutes: 120
+    steps:
+
+      - name: "Checkout Repo"
+        uses: actions/checkout@v3
+        with:
+          ref: "${{ inputs.ref || 'main' }}"
+
+      - name: "Install dependencies"
+        run: source ./scripts/setup-ubuntu.sh
+
+      - name: Download aggregation fuzzer
+        uses: actions/download-artifact@v3
+        with:
+          name: aggregation
+
+      - name: "Run Aggregate Fuzzer"
+        run: |  
+          mkdir -p /tmp/aggregate_fuzzer_repro/
+          rm -rfv /tmp/aggregate_fuzzer_repro/*
+          chmod -R 777 /tmp/aggregate_fuzzer_repro
+          chmod +x velox_aggregation_fuzzer_test
+          ./velox_aggregation_fuzzer_test \
+                --seed ${RANDOM} \
+                --duration_sec 3600 \
+                --logtostderr=1 \
+                --minloglevel=0 \
+                --repro_persist_path=/tmp/aggregate_fuzzer_repro \
+                --enable_sorted_aggregations=true \
+          && echo -e "\n\nAggregation fuzzer run finished successfully."
+      - name: Archive aggregate production artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: aggregate-fuzzer-failure-artifacts
+          path: |
+            /tmp/aggregate_fuzzer_repro
+
+  linux-spark-fuzzer-run:
+    runs-on: ubuntu-latest
+    needs: compile
+    timeout-minutes: 120
+    steps:
+
+      - name: "Checkout Repo"
+        uses: actions/checkout@v3
+        with:
+          ref: "${{ inputs.ref || 'main' }}"
+
+      - name: "Install dependencies"
+        run: source ./scripts/setup-ubuntu.sh
+
+      - name: Download spark fuzzer
+        uses: actions/download-artifact@v3
+        with:
+          name: spark
+
+      - name: "Run Spark Aggregate Fuzzer"
+        run: |
+          mkdir -p /tmp/spark_aggregate_fuzzer_repro/
+          chmod -R 777 /tmp/spark_aggregate_fuzzer_repro
+          chmod +x spark_aggregation_fuzzer_test
+          ./spark_aggregation_fuzzer_test \
+                --seed ${RANDOM} \
+                --duration_sec 1800 \
+                --logtostderr=1 \
+                --minloglevel=0 \
+                --repro_persist_path=/tmp/spark_aggregate_fuzzer_repro \
+                --enable_sorted_aggregations=true \
+          && echo -e "\n\nSpark Aggregation Fuzzer run finished successfully."
+
+      - name: Archive Spark aggregate production artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: spark-agg-fuzzer-failure-artifacts
+          path: |
+            /tmp/spark_aggregate_fuzzer_repro
+


### PR DESCRIPTION
Adds experimental GA job to test out fuzzer runs with flags that are not yet stable (e.g --enable_sorted_aggregations). This will run in Github Actions tab, and will be available as 'experimental' job : https://github.com/facebookincubator/velox/actions 
This job can be triggered manually at any time. 