### PR TITLE
Fix convertStringToInt on "+1" input

### DIFF
--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -290,7 +290,9 @@ Valid examples if cast_to_int_by_truncate=true
   SELECT cast('12345.67' as bigint); -- 12345
   SELECT cast('1.2' as tinyint); -- 1
   SELECT cast('-1.8' as tinyint); -- -1
+  SELECT cast('+1' as tinyint); -- 1
   SELECT cast('1.' as tinyint); -- 1
+  SELECT cast('-1' as tinyint); -- -1
   SELECT cast('-1.' as tinyint); -- -1
   SELECT cast('0.' as tinyint); -- 0
   SELECT cast('.' as tinyint); -- 0

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -1150,8 +1150,6 @@ TEST_F(CastExprTest, primitiveInvalidCornerCases) {
         "bigint", {"infinity"}, "Encountered a non-digit character");
     testInvalidCast<std::string>(
         "bigint", {"nan"}, "Encountered a non-digit character");
-    testInvalidCast<std::string>(
-        "tinyint", {"+1"}, "Encountered a non-digit character");
   }
 
   // To floating-point.
@@ -1253,7 +1251,9 @@ TEST_F(CastExprTest, primitiveValidCornerCases) {
     testCast<std::string, int8_t>("tinyint", {"1.23444"}, {1});
     testCast<std::string, int8_t>("tinyint", {".2355"}, {0});
     testCast<std::string, int8_t>("tinyint", {"-1.8"}, {-1});
+    testCast<std::string, int8_t>("tinyint", {"+1"}, {1});
     testCast<std::string, int8_t>("tinyint", {"1."}, {1});
+    testCast<std::string, int8_t>("tinyint", {"-1"}, {-1});
     testCast<std::string, int8_t>("tinyint", {"-1."}, {-1});
     testCast<std::string, int8_t>("tinyint", {"0."}, {0});
     testCast<std::string, int8_t>("tinyint", {"."}, {0});

--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -103,11 +103,12 @@ struct Converter<
       bool negative = false;
       // Setting decimalPoint flag
       bool decimalPoint = false;
-      if (v[0] == '-') {
+      if (v[0] == '-' || v[0] == '+') {
         if (len == 1) {
-          VELOX_USER_FAIL("Cannot cast an '-' string to an integral value.");
+          VELOX_USER_FAIL(
+              "Cannot cast an '{}' string to an integral value.", v[0]);
         }
-        negative = true;
+        negative = v[0] == '-';
         index = 1;
       }
       if (negative) {

--- a/velox/type/tests/ConversionsTest.cpp
+++ b/velox/type/tests/ConversionsTest.cpp
@@ -485,6 +485,7 @@ TEST_F(ConversionsTest, toIntegeralTypes) {
             "0.",
             ".",
             "-.",
+            "+1",
         },
         {
             1,
@@ -496,12 +497,9 @@ TEST_F(ConversionsTest, toIntegeralTypes) {
             0,
             0,
             0,
+            1,
         },
         /*truncate*/ true);
-
-    // When TRUNCATE = true, invalid cases.
-    testConversion<std::string, int8_t>(
-        {"1234567", "+1"}, {}, /*truncate*/ true, false, /*expectError*/ true);
     testConversion<std::string, int64_t>(
         {
             "1a",


### PR DESCRIPTION
Fix below exception in convertStringToInt on "+1" input.

```
C++ exception with description "Exception: VeloxUserError
Error Source: USER
Error Code: INVALID_ARGUMENT
Reason: Cannot cast VARCHAR '+1' to TINYINT. Encountered a non-digit character
```