### PR TITLE
Fix outputBytes/Rows/Batches stats for PartitionedOutput

### DIFF
--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -93,9 +93,13 @@ BlockingReason Destination::flush(
       *current_->pool(),
       listener.get(),
       std::max<int64_t>(kMinMessageSize, current_->size()));
-  int64_t flushedRows = rowsInCurrent_;
+  const int64_t flushedRows = rowsInCurrent_;
+
   current_->flush(&stream);
   current_.reset();
+
+  const int64_t flushedBytes = stream.tellp();
+
   bytesInCurrent_ = 0;
   rowsInCurrent_ = 0;
   setTargetSizePct();
@@ -106,6 +110,9 @@ BlockingReason Destination::flush(
       std::make_unique<SerializedPage>(
           stream.getIOBuf(bufferReleaseFn), nullptr, flushedRows),
       future);
+
+  recordEnqueued_(flushedBytes, flushedRows);
+
   return blocked ? BlockingReason::kWaitForConsumer
                  : BlockingReason::kNotBlocked;
 }
@@ -184,7 +191,10 @@ void PartitionedOutput::initializeDestinations() {
     auto taskId = operatorCtx_->taskId();
     for (int i = 0; i < numDestinations_; ++i) {
       destinations_.push_back(std::make_unique<detail::Destination>(
-          taskId, i, pool(), eagerFlush_));
+          taskId, i, pool(), eagerFlush_, [&](uint64_t bytes, uint64_t rows) {
+            auto lockedStats = stats_.wlock();
+            lockedStats->addOutputVector(bytes, rows);
+          }));
     }
   }
 }
@@ -218,12 +228,6 @@ void PartitionedOutput::estimateRowSizes() {
 }
 
 void PartitionedOutput::addInput(RowVectorPtr input) {
-  // TODO Report outputBytes as bytes after serialization
-  {
-    auto lockedStats = stats_.wlock();
-    lockedStats->addOutputVector(input->estimateFlatSize(), input->size());
-  }
-
   initializeInput(std::move(input));
 
   initializeDestinations();

--- a/velox/exec/PartitionedOutput.h
+++ b/velox/exec/PartitionedOutput.h
@@ -25,15 +25,19 @@ namespace facebook::velox::exec {
 namespace detail {
 class Destination {
  public:
+  /// @param recordEnqueued Should be called to record each call to
+  /// OutputBufferManager::enqueue. Takes number of bytes and rows.
   Destination(
       const std::string& taskId,
       int destination,
       memory::MemoryPool* pool,
-      bool eagerFlush)
+      bool eagerFlush,
+      std::function<void(uint64_t bytes, uint64_t rows)> recordEnqueued)
       : taskId_(taskId),
         destination_(destination),
         pool_(pool),
-        eagerFlush_(eagerFlush) {
+        eagerFlush_(eagerFlush),
+        recordEnqueued_(std::move(recordEnqueued)) {
     setTargetSizePct();
   }
 
@@ -98,6 +102,7 @@ class Destination {
   const int destination_;
   memory::MemoryPool* const pool_;
   const bool eagerFlush_;
+  const std::function<void(uint64_t bytes, uint64_t rows)> recordEnqueued_;
 
   // Bytes serialized in 'current_'
   uint64_t bytesInCurrent_{0};


### PR DESCRIPTION
PartitionedOutput operator used to report outputBytes/Rows/Batches the same as
inputBytes/Rows/Batches. With this change it reports outputBytes as number of
serialized bytes, outputRows the same as inputRows and outputBatches as number
of serialized pages produced. This helps get an accurate picture while debugging
issues with Exchange.