### PR TITLE
Add error messages when malloc allocator hits capacity limit

### DIFF
--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -408,11 +408,13 @@ MemoryPoolImpl::~MemoryPoolImpl() {
 
   if (isLeaf()) {
     if (usedReservationBytes_ > 0) {
+      LOG(ERROR) << "Memory leak (Used memory): " << toString();
       RECORD_METRIC_VALUE(
           kMetricMemoryPoolUsageLeakBytes, usedReservationBytes_);
     }
 
     if (minReservationBytes_ > 0) {
+      LOG(ERROR) << "Memory leak (Reserved Memory): " << toString();
       RECORD_METRIC_VALUE(
           kMetricMemoryPoolReservationLeakBytes, minReservationBytes_);
     }

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -630,7 +630,14 @@ TEST_P(MemoryPoolTest, MemoryCapExceptions) {
                     "parent[MemoryCapExceptions] MALLOC track-usage {}]"
                     "<max capacity 256.00MB capacity 256.00MB used 0B available "
                     "0B reservation [used 0B, reserved 0B, min 0B] counters "
-                    "[allocs 1, frees 0, reserves 0, releases 0, collisions 0])> Failed to evict from cache state: AsyncDataCache:\nCache size: 0B tinySize: 0B large size: 0B\nCache entries: 0 read pins: 0 write pins: 0 pinned shared: 0B pinned exclusive: 0B\n num write wait: 0 empty entries: 0\nCache access miss: 0 hit: 0 hit bytes: 0B eviction: 0 eviction checks: 0\nPrefetch entries: 0 bytes: 0B\nAlloc Megaclocks 0\nAllocated pages: 0 cached pages: 0\n",
+                    "[allocs 1, frees 0, reserves 0, releases 0, collisions 0])>"
+                    " Failed to evict from cache state: AsyncDataCache:\nCache "
+                    "size: 0B tinySize: 0B large size: 0B\nCache entries: 0 "
+                    "read pins: 0 write pins: 0 pinned shared: 0B pinned "
+                    "exclusive: 0B\n num write wait: 0 empty entries: 0\nCache "
+                    "access miss: 0 hit: 0 hit bytes: 0B eviction: 0 eviction "
+                    "checks: 0\nPrefetch entries: 0 bytes: 0B\nAlloc Megaclocks"
+                    " 0\nAllocated pages: 0 cached pages: 0\n",
                     isLeafThreadSafe_ ? "thread-safe" : "non-thread-safe"),
                 ex.message());
           } else {
@@ -641,7 +648,9 @@ TEST_P(MemoryPoolTest, MemoryCapExceptions) {
                     "parent[MemoryCapExceptions] MALLOC track-usage {}]"
                     "<max capacity 256.00MB capacity 256.00MB used 0B available "
                     "0B reservation [used 0B, reserved 0B, min 0B] counters "
-                    "[allocs 1, frees 0, reserves 0, releases 0, collisions 0])> ",
+                    "[allocs 1, frees 0, reserves 0, releases 0, collisions 0])>"
+                    " Failed to allocateBytes 128.00MB: Exceeded memory "
+                    "allocator limit of 128.00MB",
                     isLeafThreadSafe_ ? "thread-safe" : "non-thread-safe"),
                 ex.message());
           }


### PR DESCRIPTION
Adds useful error messages when capacity limit is hit while
using MallocAllocator
Added a log line in the memory pool leak checking codepath
that would help attribute leaks to its respective query in
non-debug builds.

Test Plan:
Added unit tests