### PR TITLE
Remove sparksql regex_replace from registry

### DIFF
--- a/velox/dwio/parquet/reader/DeltaBpDecoder.h
+++ b/velox/dwio/parquet/reader/DeltaBpDecoder.h
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/base/BitUtil.h"
+
+namespace facebook::velox::parquet {
+
+// DeltaBpDecoder is adapted from Apache Arrow:
+// https://github.com/apache/arrow/blob/apache-arrow-12.0.0/cpp/src/parquet/encoding.cc#LL2357C18-L2586C3
+class DeltaBpDecoder {
+ public:
+  DeltaBpDecoder(const char* start, const char* end)
+      : bufferStart_(start), bufferEnd_(end) {
+    initHeader();
+  }
+
+  void skip(uint64_t numValues) {
+    skip<false>(numValues, 0, nullptr);
+  }
+
+  template <bool hasNulls>
+  inline void skip(int32_t numValues, int32_t current, const uint64_t* nulls) {
+    if (hasNulls) {
+      numValues = bits::countNonNulls(nulls, current, current + numValues);
+    }
+    for (int32_t i = 0; i < numValues; ++i) {
+      readLong();
+    }
+  }
+
+  template <bool hasNulls, typename Visitor>
+  void readWithVisitor(const uint64_t* nulls, Visitor visitor) {
+    int32_t current = visitor.start();
+    skip<hasNulls>(current, 0, nulls);
+    int32_t toSkip;
+    bool atEnd = false;
+    const bool allowNulls = hasNulls && visitor.allowNulls();
+    for (;;) {
+      if (hasNulls && allowNulls && bits::isBitNull(nulls, current)) {
+        toSkip = visitor.processNull(atEnd);
+      } else {
+        if (hasNulls && !allowNulls) {
+          toSkip = visitor.checkAndSkipNulls(nulls, current, atEnd);
+          if (!Visitor::dense) {
+            skip<false>(toSkip, current, nullptr);
+          }
+          if (atEnd) {
+            return;
+          }
+        }
+
+        // We are at a non-null value on a row to visit.
+        toSkip = visitor.process(readLong(), atEnd);
+      }
+      ++current;
+      if (toSkip) {
+        skip<hasNulls>(toSkip, current, nulls);
+        current += toSkip;
+      }
+      if (atEnd) {
+        return;
+      }
+    }
+  }
+
+ private:
+  bool getVlqInt(uint64_t& v) {
+    uint64_t tmp = 0;
+    for (int i = 0; i < folly::kMaxVarintLength64; i++) {
+      uint8_t byte = *(bufferStart_++);
+      tmp |= static_cast<uint64_t>(byte & 0x7F) << (7 * i);
+      if ((byte & 0x80) == 0) {
+        v = tmp;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool getZigZagVlqInt(int64_t& v) {
+    uint64_t u;
+    if (!getVlqInt(u))
+      return false;
+    v = (u >> 1) ^ (~(u & 1) + 1);
+    return true;
+  }
+
+  void initHeader() {
+    if (!getVlqInt(valuesPerBlock_) || !getVlqInt(miniBlocksPerBlock_) ||
+        !getVlqInt(totalValueCount_) || !getZigZagVlqInt(lastValue_)) {
+      VELOX_FAIL("initHeader EOF");
+    }
+
+    VELOX_CHECK_GT(valuesPerBlock_, 0, "cannot have zero value per block");
+    VELOX_CHECK_EQ(
+        valuesPerBlock_ % 128,
+        0,
+        "the number of values in a block must be multiple of 128, but it's " +
+            std::to_string(valuesPerBlock_));
+    VELOX_CHECK_GT(
+        miniBlocksPerBlock_, 0, "cannot have zero miniblock per block");
+    valuesPerMiniBlock_ = valuesPerBlock_ / miniBlocksPerBlock_;
+    VELOX_CHECK_GT(
+        valuesPerMiniBlock_, 0, "cannot have zero value per miniblock");
+    VELOX_CHECK_EQ(
+        valuesPerMiniBlock_ % 32,
+        0,
+        "the number of values in a miniblock must be multiple of 32, but it's " +
+            std::to_string(valuesPerMiniBlock_));
+
+    totalValuesRemaining_ = totalValueCount_;
+    deltaBitWidths_.resize(miniBlocksPerBlock_);
+    firstBlockInitialized_ = false;
+    valuesRemainingCurrentMiniBlock_ = 0;
+  }
+
+  void initBlock() {
+    VELOX_DCHECK_GT(totalValuesRemaining_, 0, "initBlock called at EOF");
+
+    if (!getZigZagVlqInt(minDelta_)) {
+      VELOX_FAIL("initBlock EOF")
+    }
+
+    // read the bitwidth of each miniblock
+    for (uint32_t i = 0; i < miniBlocksPerBlock_; ++i) {
+      deltaBitWidths_[i] = *(bufferStart_++);
+      // Note that non-conformant bitwidth entries are allowed by the Parquet
+      // spec for extraneous miniblocks in the last block (GH-14923), so we
+      // check the bitwidths when actually using them (see initMiniBlock()).
+    }
+
+    miniBlockIdx_ = 0;
+    firstBlockInitialized_ = true;
+    initMiniBlock(deltaBitWidths_[0]);
+  }
+
+  void initMiniBlock(int32_t bitWidth) {
+    VELOX_DCHECK_LE(
+        bitWidth,
+        kMaxDeltaBitWidth,
+        "delta bit width larger than integer bit width");
+    deltaBitWidth_ = bitWidth;
+    valuesRemainingCurrentMiniBlock_ = valuesPerMiniBlock_;
+  }
+
+  int64_t readLong() {
+    int64_t value = 0;
+    if (valuesRemainingCurrentMiniBlock_ == 0) {
+      if (!firstBlockInitialized_) {
+        value = lastValue_;
+        // When block is uninitialized we have two different possibilities:
+        // 1. totalValueCount_ == 1, which means that the page may have only
+        // one value (encoded in the header), and we should not initialize
+        // any block.
+        // 2. totalValueCount_ != 1, which means we should initialize the
+        // incoming block for subsequent reads.
+        if (totalValueCount_ != 1) {
+          initBlock();
+        }
+        return value;
+      } else {
+        ++miniBlockIdx_;
+        if (miniBlockIdx_ < miniBlocksPerBlock_) {
+          initMiniBlock(deltaBitWidths_[miniBlockIdx_]);
+        } else {
+          initBlock();
+        }
+      }
+    }
+
+    uint64_t consumedBits =
+        (valuesPerMiniBlock_ - valuesRemainingCurrentMiniBlock_) *
+        deltaBitWidth_;
+    bits::copyBits(
+        reinterpret_cast<const uint64_t*>(bufferStart_),
+        consumedBits,
+        reinterpret_cast<uint64_t*>(&value),
+        0,
+        deltaBitWidth_);
+    // Addition between minDelta_, packed int and lastValue_ should be treated
+    // as unsigned addition. Overflow is as expected.
+    value += minDelta_ + lastValue_;
+    lastValue_ = value;
+    valuesRemainingCurrentMiniBlock_--;
+    totalValuesRemaining_--;
+
+    if (valuesRemainingCurrentMiniBlock_ == 0) {
+      bufferStart_ += bits::nbytes(deltaBitWidth_ * valuesPerMiniBlock_);
+    }
+    return value;
+  }
+
+  static constexpr int kMaxDeltaBitWidth =
+      static_cast<int>(sizeof(int64_t) * 8);
+
+  const char* bufferStart_;
+  const char* bufferEnd_;
+
+  uint64_t valuesPerBlock_;
+  uint64_t miniBlocksPerBlock_;
+  uint64_t valuesPerMiniBlock_;
+  uint64_t totalValueCount_;
+
+  uint64_t totalValuesRemaining_;
+  // Remaining values in current mini block. If the current block is the last
+  // mini block, valuesRemainingCurrentMiniBlock_ may greater than
+  // totalValuesRemaining_.
+  uint64_t valuesRemainingCurrentMiniBlock_;
+
+  // If the page doesn't contain any block, `firstBlockInitialized_` will
+  // always be false. Otherwise, it will be true when first block initialized.
+  bool firstBlockInitialized_;
+  int64_t minDelta_;
+  uint64_t miniBlockIdx_;
+  std::vector<uint8_t> deltaBitWidths_;
+  uint64_t deltaBitWidth_;
+
+  int64_t lastValue_;
+};
+
+} // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/IntegerColumnReader.h
+++ b/velox/dwio/parquet/reader/IntegerColumnReader.h
@@ -34,7 +34,8 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
             std::move(fileType)) {}
 
   bool hasBulkPath() const override {
-    return !this->fileType().type()->isLongDecimal() &&
+    return !formatData_->as<ParquetData>().isDeltaBinaryPacked() &&
+        !this->fileType().type()->isLongDecimal() &&
         ((this->fileType().type()->isShortDecimal())
              ? formatData_->as<ParquetData>().hasDictionary()
              : true);

--- a/velox/dwio/parquet/reader/PageReader.cpp
+++ b/velox/dwio/parquet/reader/PageReader.cpp
@@ -666,6 +666,17 @@ void PageReader::makeDecoder() {
       }
       break;
     case Encoding::DELTA_BINARY_PACKED:
+      switch (parquetType) {
+        case thrift::Type::INT32:
+        case thrift::Type::INT64:
+          deltaBpDecoder_ = std::make_unique<DeltaBpDecoder>(
+              pageData_, pageData_ + encodedDataSize_);
+          break;
+        default:
+          VELOX_UNSUPPORTED(
+              "DELTA_BINARY_PACKED decoder only supports INT32 and INT64");
+      }
+      break;
     default:
       VELOX_UNSUPPORTED("Encoding not supported yet: {}", encoding_);
   }
@@ -698,6 +709,8 @@ void PageReader::skip(int64_t numRows) {
     stringDecoder_->skip(toSkip);
   } else if (booleanDecoder_) {
     booleanDecoder_->skip(toSkip);
+  } else if (deltaBpDecoder_) {
+    deltaBpDecoder_->skip(toSkip);
   } else {
     VELOX_FAIL("No decoder to skip");
   }

--- a/velox/dwio/parquet/reader/PageReader.h
+++ b/velox/dwio/parquet/reader/PageReader.h
@@ -22,6 +22,7 @@
 #include "velox/dwio/common/SelectiveColumnReader.h"
 #include "velox/dwio/common/compression/Compression.h"
 #include "velox/dwio/parquet/reader/BooleanDecoder.h"
+#include "velox/dwio/parquet/reader/DeltaBpDecoder.h"
 #include "velox/dwio/parquet/reader/ParquetTypeWithId.h"
 #include "velox/dwio/parquet/reader/RleBpDataDecoder.h"
 #include "velox/dwio/parquet/reader/StringDecoder.h"
@@ -120,6 +121,10 @@ class PageReader {
   void clearDictionary() {
     dictionary_.clear();
     dictionaryValues_.reset();
+  }
+
+  bool isDeltaBinaryPacked() const {
+    return encoding_ == thrift::Encoding::DELTA_BINARY_PACKED;
   }
 
   /// Returns the range of repdefs for the top level rows covered by the last
@@ -264,6 +269,9 @@ class PageReader {
       if (isDictionary()) {
         auto dictVisitor = visitor.toDictionaryColumnVisitor();
         dictionaryIdDecoder_->readWithVisitor<true>(nulls, dictVisitor);
+      } else if (encoding_ == thrift::Encoding::DELTA_BINARY_PACKED) {
+        nullsFromFastPath = false;
+        deltaBpDecoder_->readWithVisitor<true>(nulls, visitor);
       } else {
         directDecoder_->readWithVisitor<true>(
             nulls, visitor, nullsFromFastPath);
@@ -272,6 +280,8 @@ class PageReader {
       if (isDictionary()) {
         auto dictVisitor = visitor.toDictionaryColumnVisitor();
         dictionaryIdDecoder_->readWithVisitor<false>(nullptr, dictVisitor);
+      } else if (encoding_ == thrift::Encoding::DELTA_BINARY_PACKED) {
+        deltaBpDecoder_->readWithVisitor<false>(nulls, visitor);
       } else {
         directDecoder_->readWithVisitor<false>(
             nulls, visitor, !this->type_->type()->isShortDecimal());
@@ -476,6 +486,7 @@ class PageReader {
   std::unique_ptr<RleBpDataDecoder> dictionaryIdDecoder_;
   std::unique_ptr<StringDecoder> stringDecoder_;
   std::unique_ptr<BooleanDecoder> booleanDecoder_;
+  std::unique_ptr<DeltaBpDecoder> deltaBpDecoder_;
   // Add decoders for other encodings here.
 };
 

--- a/velox/dwio/parquet/reader/ParquetData.h
+++ b/velox/dwio/parquet/reader/ParquetData.h
@@ -175,6 +175,10 @@ class ParquetData : public dwio::common::FormatData {
     return reader_->isDictionary();
   }
 
+  bool isDeltaBinaryPacked() const {
+    return reader_->isDeltaBinaryPacked();
+  }
+
   bool parentNullsInLeaves() const override {
     return true;
   }

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -128,6 +128,22 @@ TEST_F(E2EFilterTest, integerDirect) {
       20);
 }
 
+TEST_F(E2EFilterTest, integerDeltaBinaryPack) {
+  options_.enableDictionary = false;
+  options_.encoding =
+      facebook::velox::parquet::arrow::Encoding::DELTA_BINARY_PACKED;
+
+  testWithTypes(
+      "short_val:smallint,"
+      "int_val:int,"
+      "long_val:bigint,"
+      "long_null:bigint",
+      [&]() { makeAllNulls("long_null"); },
+      true,
+      {"short_val", "int_val", "long_val"},
+      20);
+}
+
 TEST_F(E2EFilterTest, compression) {
   for (const auto compression :
        {common::CompressionKind_SNAPPY,

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -132,6 +132,7 @@ std::shared_ptr<WriterProperties> getArrowParquetWriterOptions(
   }
   properties =
       properties->compression(getArrowParquetCompression(options.compression));
+  properties = properties->encoding(options.encoding);
   properties = properties->data_pagesize(options.dataPageSize);
   properties = properties->max_row_group_length(
       static_cast<int64_t>(flushPolicy->rowsInRowGroup()));

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -23,6 +23,7 @@
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/Writer.h"
 #include "velox/dwio/common/WriterFactory.h"
+#include "velox/dwio/parquet/writer/arrow/Types.h"
 #include "velox/dwio/parquet/writer/arrow/util/Compression.h"
 #include "velox/vector/ComplexVector.h"
 
@@ -93,6 +94,7 @@ struct WriterOptions {
   // folly/FBVector(https://github.com/facebook/folly/blob/main/folly/docs/FBVector.md#memory-handling).
   double bufferGrowRatio = 1.5;
   common::CompressionKind compression = common::CompressionKind_NONE;
+  arrow::Encoding::type encoding = arrow::Encoding::PLAIN;
   velox::memory::MemoryPool* memoryPool;
   // The default factory allows the writer to construct the default flush
   // policy with the configs in its ctor.

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -184,7 +184,6 @@ void registerFunctions(const std::string& prefix) {
       prefix + "regexp_extract", re2ExtractSignatures(), makeRegexExtract);
   exec::registerStatefulVectorFunction(
       prefix + "rlike", re2SearchSignatures(), makeRLike);
-  registerRegexReplace(prefix);
   VELOX_REGISTER_VECTOR_FUNCTION(udf_regexp_split, prefix + "split");
 
   exec::registerStatefulVectorFunction(

--- a/velox/functions/sparksql/tests/RegexFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/RegexFunctionsTest.cpp
@@ -31,6 +31,11 @@ namespace {
 
 class RegexFunctionsTest : public test::SparkFunctionBaseTest {
  public:
+  void SetUp() override {
+    SparkFunctionBaseTest::SetUp();
+    registerRegexReplace("");
+  }
+
   std::optional<bool> rlike(
       std::optional<std::string> str,
       std::string pattern) {


### PR DESCRIPTION
Summary:
This function is failing fuzzer (https://github.com/facebookincubator/velox/issues/7856), remove it from registry until the author fix it.

Also the name registered is not correct, it should be registered with `regexp_replace`.

Differential Revision: D52216960

