### PR TITLE
migrate from exception_wrapper from_catch_ref ctor (assorted)

### DIFF
--- a/velox/dwio/common/ExecutorBarrier.cpp
+++ b/velox/dwio/common/ExecutorBarrier.cpp
@@ -62,14 +62,6 @@ auto ExecutorBarrier::wrapMethod(folly::Func f) {
           barrierElement = BarrierElement(count_, mutex_, cv_)]() mutable {
     try {
       f();
-    } catch (const std::exception& e) {
-      std::lock_guard lock{mutex_};
-      if (!exception_.has_exception_ptr()) {
-        exception_ = folly::exception_wrapper(
-            ::folly::exception_wrapper::from_catch_ref_t{},
-            std::current_exception(),
-            e);
-      }
     } catch (...) {
       std::lock_guard lock{mutex_};
       if (!exception_.has_exception_ptr()) {


### PR DESCRIPTION
Summary: Migrate sites which call the `from_catch_ref` ctor of `folly::exception_wrapper`, merging otherwise-equivalent cases or otherwise simplifying code where possible.

Reviewed By: anps77

Differential Revision: D52046402


