### PR TITLE
Add Status class

### DIFF
--- a/velox/common/base/CMakeLists.txt
+++ b/velox/common/base/CMakeLists.txt
@@ -54,3 +54,9 @@ target_link_libraries(
   Folly::folly
   fmt::fmt
   gflags::gflags)
+
+add_library(velox_status Status.cpp)
+target_link_libraries(
+  velox_status
+  PUBLIC fmt::fmt Folly::folly
+  PRIVATE glog::glog)

--- a/velox/common/base/Exceptions.cpp
+++ b/velox/common/base/Exceptions.cpp
@@ -16,13 +16,9 @@
 
 #include "velox/common/base/Exceptions.h"
 
-namespace facebook {
-namespace velox {
-namespace detail {
+namespace facebook::velox::detail {
 
 DEFINE_CHECK_FAIL_TEMPLATES(::facebook::velox::VeloxRuntimeError);
 DEFINE_CHECK_FAIL_TEMPLATES(::facebook::velox::VeloxUserError);
 
-} // namespace detail
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox::detail

--- a/velox/common/base/Status.cpp
+++ b/velox/common/base/Status.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/Status.h"
+
+#include <glog/logging.h>
+#include <cassert>
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+
+namespace facebook::velox {
+
+std::string_view toString(StatusCode code) {
+  switch (code) {
+    case StatusCode::kOK:
+      return "OK";
+    case StatusCode::kUserError:
+      return "User error";
+    case StatusCode::kTypeError:
+      return "Type error";
+    case StatusCode::kIndexError:
+      return "Index error";
+    case StatusCode::kKeyError:
+      return "Key error";
+    case StatusCode::kAlreadyExists:
+      return "Already exists";
+    case StatusCode::kOutOfMemory:
+      return "Out of memory";
+    case StatusCode::kIOError:
+      return "IOError";
+    case StatusCode::kCancelled:
+      return "Cancelled";
+    case StatusCode::kInvalid:
+      return "Invalid";
+    case StatusCode::kUnknownError:
+      return "Unknown error";
+    case StatusCode::kNotImplemented:
+      return "NotImplemented";
+  }
+  return ""; // no-op
+}
+
+Status::Status(StatusCode code, std::string msg) {
+  if (FOLLY_UNLIKELY(code == StatusCode::kOK)) {
+    throw std::invalid_argument("Cannot construct ok status with message");
+  }
+  state_ = new State;
+  state_->code = code;
+  state_->msg = std::move(msg);
+}
+
+void Status::copyFrom(const Status& s) {
+  delete state_;
+  if (s.state_ == nullptr) {
+    state_ = nullptr;
+  } else {
+    state_ = new State(*s.state_);
+  }
+}
+
+std::string_view Status::codeAsString() const {
+  if (state_ == nullptr) {
+    return "OK";
+  }
+  return ::facebook::velox::toString(code());
+}
+
+std::string Status::toString() const {
+  std::string result(codeAsString());
+  if (state_ == nullptr) {
+    return result;
+  }
+  result += ": ";
+  result += state_->msg;
+  return result;
+}
+
+void Status::abort() const {
+  abort("");
+}
+
+void Status::abort(const std::string_view& message) const {
+  std::cerr << "-- Velox Fatal Error --\n";
+  if (!message.empty()) {
+    std::cerr << message << "\n";
+  }
+  std::cerr << toString() << std::endl;
+  std::abort();
+}
+
+void Status::warn() const {
+  LOG(WARNING) << toString();
+}
+
+void Status::warn(const std::string_view& message) const {
+  LOG(WARNING) << message << ": " << toString();
+}
+
+} // namespace facebook::velox

--- a/velox/common/base/Status.h
+++ b/velox/common/base/Status.h
@@ -1,0 +1,508 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#pragma once
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <folly/Likely.h>
+#include <string>
+#include <utility>
+
+namespace facebook::velox {
+
+/// The Status object is an object holding the outcome of an operation (success
+/// or error).
+///
+/// The outcome is represented as a StatusCode, holding either a success
+/// (StatusCode::kOK) or an error (any other of the StatusCode enumeration
+/// values). If an error occurred, a specific error message is generally
+/// attached.
+///
+/// The status object is commonly allocated in the stack, so it needs be compact
+/// to be efficient. For the common success case, its size is a single (nullptr)
+/// pointer. For failure cases, it allocates an external object containing the
+/// StatusCode and error message. This keeps the object compact and prevents
+/// allocations in the common success case. The same strategy is used in Status
+/// object from other well-known libraries like Apache Arrow, RocksDB, Kudu, and
+/// others.
+///
+/// Simple usage:
+///
+///  Status operation() {
+///    if (noMoreMemory) {
+///      return Status::OutOfMemory("Not enough memory to run 'operation'!");
+///    }
+///    return Status::OK();
+///  }
+///
+/// Call site:
+///
+///  auto status = operation();
+///  if (status.ok()) {
+///    ...
+///  } else if (status.isOutOfMemory()) {
+///    (gracefully handle out of memory)
+///  } else if (status.isNotImplemented()) {
+///    (and so on)
+///  }
+///
+/// Other common usage patterns:
+///
+/// The same logic above can be implemented using helper macros:
+///
+///  Status operation() {
+///    VELOX_RETURN_IF(noMoreMemory, Status::OutOfMemory(
+///       "Not enough memory to run 'operation'!"));
+///    ...
+///    return Status::OK();
+///  }
+///
+/// To ensure operations succeed (or if not, return the same status from the
+/// current function):
+///
+///  ...
+///  VELOX_RETURN_NOT_OK(operation1());
+///  VELOX_RETURN_NOT_OK(operation2());
+///  VELOX_RETURN_NOT_OK(operation3());
+///  ...
+
+/// This enum represents common categories of errors found in the library. These
+/// are not meant to cover every specific error situation, but rather cover
+/// broader categories of errors. Therefore, additions to this list should be
+/// infrequent.
+///
+/// Errors should be further described by attaching an error message to the
+/// Status object.
+///
+/// The error classes are loosely defined as follows:
+///
+/// - kOk: A successful operation. No errors.
+///
+/// - kUserError: An error triggered by bad input from an API user. The user
+///   in this context usually means the program using Velox (or its end users).
+///
+/// - kTypeError: An error triggered by a logical type mismatch (e.g. expecting
+///   BIGINT but REAL provided).
+///
+/// - kIndexError: An error triggered by the index of something being invalid or
+///   out-of-bounds.
+///
+/// - kKeyError: An error triggered by the key of something in a map/set being
+///   invalid or not found.
+///
+/// - kAlreadyExists: An error triggered by an operation meant to create some
+///   form of resource which already exists.
+///
+/// - kOutOfMemory: A failure triggered by a lack of available memory to
+///   complete the operation.
+///
+/// - kIOError: An error triggered by IO failures (e.g: network or disk/SSD read
+///   error).
+///
+/// - kCancelled: An error triggered because a certain resource required has
+///   been stopped or cancelled.
+///
+/// - kInvalid: An error triggered by an invalid program state. Usually
+///   triggered by bugs.
+///
+/// - kUnknownError: An error triggered by an unknown cause. Also usually
+///   triggered by bugs. Should be used scarcely, favoring a more specific error
+///   class above.
+///
+/// - kNotImplemented: An error triggered by a feature not being implemented
+///   yet.
+///
+enum class StatusCode : int8_t {
+  kOK = 0,
+  kUserError = 1,
+  kTypeError = 2,
+  kIndexError = 3,
+  kKeyError = 4,
+  kAlreadyExists = 5,
+  kOutOfMemory = 6,
+  kIOError = 7,
+  kCancelled = 8,
+  kInvalid = 9,
+  kUnknownError = 10,
+  kNotImplemented = 11,
+};
+std::string_view toString(StatusCode code);
+
+class [[nodiscard]] Status {
+ public:
+  // Create a success status.
+  constexpr Status() noexcept : state_(nullptr) {}
+
+  ~Status() noexcept {
+    if (FOLLY_UNLIKELY(state_ != nullptr)) {
+      deleteState();
+    }
+  }
+
+  Status(StatusCode code, std::string msg);
+
+  // Copy the specified status.
+  inline Status(const Status& s);
+  inline Status& operator=(const Status& s);
+
+  // Move the specified status.
+  inline Status(Status&& s) noexcept;
+  inline Status& operator=(Status&& s) noexcept;
+
+  inline bool operator==(const Status& other) const noexcept;
+  inline bool operator!=(const Status& other) const noexcept {
+    return !(*this == other);
+  }
+
+  // AND the statuses.
+  inline Status operator&(const Status& s) const noexcept;
+  inline Status operator&(Status&& s) const noexcept;
+  inline Status& operator&=(const Status& s) noexcept;
+  inline Status& operator&=(Status&& s) noexcept;
+
+  inline friend std::ostream& operator<<(std::ostream& ss, const Status& s) {
+    return ss << s.toString();
+  }
+
+  /// Return a success status.
+  static Status OK() {
+    return Status();
+  }
+
+  // The static factory methods below do not follow the lower camel-case pattern
+  // as they are meant to represent classes of errors. For example:
+  //
+  //   auto st1 = Status::UserError("my error"):
+  //   auto st2 = Status::TypeError("my other error"):
+
+  /// Return an error status for out-of-memory conditions.
+  template <typename... Args>
+  static Status UserError(Args&&... args) {
+    return Status::fromArgs(
+        StatusCode::kUserError, std::forward<Args>(args)...);
+  }
+
+  /// Return an error status for type errors (such as mismatching data types)
+  template <typename... Args>
+  static Status TypeError(Args&&... args) {
+    return Status::fromArgs(
+        StatusCode::kTypeError, std::forward<Args>(args)...);
+  }
+
+  /// Return an error status when an index is out of bounds
+  template <typename... Args>
+  static Status IndexError(Args&&... args) {
+    return Status::fromArgs(
+        StatusCode::kIndexError, std::forward<Args>(args)...);
+  }
+
+  /// Return an error status for failed key lookups (e.g. column name in a
+  /// table)
+  template <typename... Args>
+  static Status KeyError(Args&&... args) {
+    return Status::fromArgs(StatusCode::kKeyError, std::forward<Args>(args)...);
+  }
+
+  template <typename... Args>
+  static Status AlreadyExists(Args&&... args) {
+    return Status::fromArgs(
+        StatusCode::kAlreadyExists, std::forward<Args>(args)...);
+  }
+
+  /// Return an error status for out-of-memory conditions.
+  template <typename... Args>
+  static Status OutOfMemory(Args&&... args) {
+    return Status::fromArgs(
+        StatusCode::kOutOfMemory, std::forward<Args>(args)...);
+  }
+
+  /// Return an error status when some IO-related operation failed
+  template <typename... Args>
+  static Status IOError(Args&&... args) {
+    return Status::fromArgs(StatusCode::kIOError, std::forward<Args>(args)...);
+  }
+
+  /// Return an error status for cancelled operation
+  template <typename... Args>
+  static Status Cancelled(Args&&... args) {
+    return Status::fromArgs(
+        StatusCode::kCancelled, std::forward<Args>(args)...);
+  }
+
+  /// Return an error status for invalid data (for example a string that fails
+  /// parsing)
+  template <typename... Args>
+  static Status Invalid(Args&&... args) {
+    return Status::fromArgs(StatusCode::kInvalid, std::forward<Args>(args)...);
+  }
+
+  /// Return an error status for unknown errors
+  template <typename... Args>
+  static Status UnknownError(Args&&... args) {
+    return Status::fromArgs(
+        StatusCode::kUnknownError, std::forward<Args>(args)...);
+  }
+
+  /// Return an error status when an operation or a combination of operation and
+  /// data types is unimplemented
+  template <typename... Args>
+  static Status NotImplemented(Args&&... args) {
+    return Status::fromArgs(
+        StatusCode::kNotImplemented, std::forward<Args>(args)...);
+  }
+
+  /// Return true iff the status indicates success.
+  constexpr bool ok() const {
+    return (state_ == nullptr);
+  }
+
+  /// Return true iff the status indicates an user error.
+  constexpr bool isUserError() const {
+    return code() == StatusCode::kUserError;
+  }
+
+  /// Return true iff the status indicates a type error.
+  constexpr bool isTypeError() const {
+    return code() == StatusCode::kTypeError;
+  }
+
+  /// Return true iff the status indicates an out of bounds index.
+  constexpr bool isIndexError() const {
+    return code() == StatusCode::kIndexError;
+  }
+
+  /// Return true iff the status indicates a key lookup error.
+  constexpr bool isKeyError() const {
+    return code() == StatusCode::kKeyError;
+  }
+
+  /// Return true iff the status indicates that something already exists.
+  constexpr bool isAlreadyExists() const {
+    return code() == StatusCode::kAlreadyExists;
+  }
+
+  /// Return true iff the status indicates an out-of-memory error.
+  constexpr bool isOutOfMemory() const {
+    return code() == StatusCode::kOutOfMemory;
+  }
+
+  /// Return true iff the status indicates an IO-related failure.
+  constexpr bool isIOError() const {
+    return code() == StatusCode::kIOError;
+  }
+
+  /// Return true iff the status indicates a cancelled operation.
+  constexpr bool isCancelled() const {
+    return code() == StatusCode::kCancelled;
+  }
+
+  /// Return true iff the status indicates invalid data.
+  constexpr bool isInvalid() const {
+    return code() == StatusCode::kInvalid;
+  }
+
+  /// Return true iff the status indicates an unknown error.
+  constexpr bool isUnknownError() const {
+    return code() == StatusCode::kUnknownError;
+  }
+
+  /// Return true iff the status indicates an unimplemented operation.
+  constexpr bool isNotImplemented() const {
+    return code() == StatusCode::kNotImplemented;
+  }
+
+  /// Return a string representation of this status suitable for printing.
+  ///
+  /// The string "OK" is returned for success.
+  std::string toString() const;
+
+  /// Return a string representation of the status code, without the message
+  /// text or POSIX code information.
+  std::string_view codeAsString() const;
+  static std::string_view codeAsString(StatusCode);
+
+  /// Return the StatusCode value attached to this status.
+  constexpr StatusCode code() const {
+    return ok() ? StatusCode::kOK : state_->code;
+  }
+
+  /// Return the specific error message attached to this status.
+  const std::string& message() const {
+    static const std::string kNoMessage = "";
+    return ok() ? kNoMessage : state_->msg;
+  }
+
+  /// Return a new Status with changed message, copying the existing status
+  /// code.
+  template <typename... Args>
+  Status withMessage(Args&&... args) const {
+    return fromArgs(code(), std::forward<Args>(args)...);
+  }
+
+  void warn() const;
+  void warn(const std::string_view& message) const;
+
+  [[noreturn]] void abort() const;
+  [[noreturn]] void abort(const std::string_view& message) const;
+
+ private:
+  template <typename... Args>
+  static Status
+  fromArgs(StatusCode code, fmt::string_view fmt, Args&&... args) {
+    return Status(code, fmt::vformat(fmt, fmt::make_format_args(args...)));
+  }
+
+  void deleteState() {
+    delete state_;
+    state_ = nullptr;
+  }
+
+  void copyFrom(const Status& s);
+  inline void moveFrom(Status& s);
+
+  struct State {
+    StatusCode code;
+    std::string msg;
+  };
+
+  // OK status has a `nullptr` state_.  Otherwise, `state_` points to
+  // a `State` structure containing the error code and message(s)
+  State* state_;
+};
+
+// Copy the specified status.
+Status::Status(const Status& s)
+    : state_((s.state_ == nullptr) ? nullptr : new State(*s.state_)) {}
+
+Status& Status::operator=(const Status& s) {
+  // The following condition catches both aliasing (when this == &s),
+  // and the common case where both s and *this are ok.
+  if (state_ != s.state_) {
+    copyFrom(s);
+  }
+  return *this;
+}
+
+// Move the specified status.
+Status::Status(Status&& s) noexcept : state_(s.state_) {
+  s.state_ = nullptr;
+}
+
+Status& Status::operator=(Status&& s) noexcept {
+  moveFrom(s);
+  return *this;
+}
+
+inline bool Status::operator==(const Status& other) const noexcept {
+  if (state_ == other.state_) {
+    return true;
+  }
+
+  if (ok() || other.ok()) {
+    return false;
+  }
+  return (code() == other.code()) && (message() == other.message());
+}
+
+Status Status::operator&(const Status& s) const noexcept {
+  if (ok()) {
+    return s;
+  } else {
+    return *this;
+  }
+}
+
+Status Status::operator&(Status&& s) const noexcept {
+  if (ok()) {
+    return std::move(s);
+  } else {
+    return *this;
+  }
+}
+
+Status& Status::operator&=(const Status& s) noexcept {
+  if (ok() && !s.ok()) {
+    copyFrom(s);
+  }
+  return *this;
+}
+
+Status& Status::operator&=(Status&& s) noexcept {
+  if (ok() && !s.ok()) {
+    moveFrom(s);
+  }
+  return *this;
+}
+
+void Status::moveFrom(Status& s) {
+  delete state_;
+  state_ = s.state_;
+  s.state_ = nullptr;
+}
+
+// Helper Macros.
+
+#define _VELOX_STRINGIFY(x) #x
+
+/// Return with given status if condition is met.
+#define VELOX_RETURN_IF(condition, status) \
+  do {                                     \
+    if (FOLLY_UNLIKELY(condition)) {       \
+      return (status);                     \
+    }                                      \
+  } while (0)
+
+/// Propagate any non-successful Status to the caller.
+#define VELOX_RETURN_NOT_OK(status)                           \
+  do {                                                        \
+    ::facebook::velox::Status __s =                           \
+        ::facebook::velox::internal::genericToStatus(status); \
+    VELOX_RETURN_IF(!__s.ok(), __s);                          \
+  } while (false)
+
+namespace internal {
+
+/// Common API for extracting Status from either Status or Result<T> (the latter
+/// is defined in Result.h).
+/// Useful for status check macros such as VELOX_RETURN_NOT_OK.
+inline const Status& genericToStatus(const Status& st) {
+  return st;
+}
+inline Status genericToStatus(Status&& st) {
+  return std::move(st);
+}
+
+} // namespace internal
+} // namespace facebook::velox
+
+template <>
+struct fmt::formatter<facebook::velox::Status> : fmt::formatter<std::string> {
+  auto format(const facebook::velox::Status& s, format_context& ctx) {
+    return formatter<std::string>::format(s.toString(), ctx);
+  }
+};
+
+template <>
+struct fmt::formatter<facebook::velox::StatusCode>
+    : fmt::formatter<std::string_view> {
+  auto format(facebook::velox::StatusCode code, format_context& ctx) {
+    return formatter<std::string_view>::format(
+        facebook::velox::toString(code), ctx);
+  }
+};

--- a/velox/common/base/tests/CMakeLists.txt
+++ b/velox/common/base/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(
   SpillConfigTest.cpp
   SpillStatsTest.cpp
   StatsReporterTest.cpp
+  StatusTest.cpp
   SuccinctPrinterTest.cpp)
 
 add_test(velox_base_test velox_base_test)
@@ -38,6 +39,7 @@ target_link_libraries(
   velox_base_test
   PRIVATE velox_common_base
           velox_time
+          velox_status
           velox_exception
           velox_temp_path
           Boost::filesystem
@@ -46,6 +48,7 @@ target_link_libraries(
           fmt::fmt
           gflags::gflags
           gtest
+          gmock
           gtest_main)
 
 add_executable(velox_id_map_test IdMapTest.cpp)

--- a/velox/common/base/tests/StatusTest.cpp
+++ b/velox/common/base/tests/StatusTest.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/Status.h"
+#include <gtest/gtest.h>
+#include <sstream>
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+namespace facebook::velox::test {
+namespace {
+
+TEST(StatusTest, testCodeAndMessage) {
+  Status ok = Status::OK();
+  ASSERT_EQ(StatusCode::kOK, ok.code());
+  ASSERT_EQ("", ok.message());
+  ASSERT_EQ("OK", ok.codeAsString());
+  ASSERT_TRUE(ok.ok());
+  ASSERT_FALSE(ok.isIOError());
+
+  Status fileError = Status::IOError("file error");
+  ASSERT_EQ(StatusCode::kIOError, fileError.code());
+  ASSERT_EQ("file error", fileError.message());
+}
+
+TEST(StatusTest, testToString) {
+  Status fileError = Status::IOError("file error");
+  ASSERT_EQ("IOError: file error", fileError.toString());
+  ASSERT_EQ("IOError", fileError.codeAsString());
+
+  std::stringstream ss;
+  ss << fileError;
+  ASSERT_EQ(fileError.toString(), ss.str());
+
+  // Check that fmt has the right specializations.
+  ASSERT_EQ(fileError.toString(), fmt::format("{}", fileError));
+  ASSERT_EQ("Unknown error", fmt::format("{}", StatusCode::kUnknownError));
+}
+
+TEST(StatusTest, andStatus) {
+  Status a = Status::OK();
+  Status b = Status::OK();
+  Status c = Status::Invalid("invalid value");
+  Status d = Status::IOError("file error");
+
+  Status res;
+  res = a & b;
+  ASSERT_TRUE(res.ok());
+  res = a & c;
+  ASSERT_TRUE(res.isInvalid());
+  res = d & c;
+  ASSERT_TRUE(res.isIOError());
+
+  res = Status::OK();
+  res &= c;
+  ASSERT_TRUE(res.isInvalid());
+  res &= d;
+  ASSERT_TRUE(res.isInvalid());
+
+  // With rvalues.
+  res = Status::OK() & Status::Invalid("foo");
+  ASSERT_TRUE(res.isInvalid());
+  res = Status::Invalid("foo") & Status::OK();
+  ASSERT_TRUE(res.isInvalid());
+  res = Status::Invalid("foo") & Status::IOError("bar");
+  ASSERT_TRUE(res.isInvalid());
+
+  res = Status::OK();
+  res &= Status::OK();
+  ASSERT_TRUE(res.ok());
+  res &= Status::Invalid("foo");
+  ASSERT_TRUE(res.isInvalid());
+  res &= Status::IOError("bar");
+  ASSERT_TRUE(res.isInvalid());
+}
+
+TEST(StatusTest, testEquality) {
+  ASSERT_EQ(Status(), Status::OK());
+  ASSERT_EQ(Status::Invalid("error"), Status::Invalid("error"));
+
+  ASSERT_NE(Status::Invalid("error"), Status::OK());
+  ASSERT_NE(Status::Invalid("error"), Status::Invalid("other error"));
+}
+
+TEST(StatusTest, testAbort) {
+  Status a = Status::Invalid("will abort process");
+  ASSERT_DEATH(a.abort(), "");
+}
+
+Status returnIf(bool cond) {
+  VELOX_RETURN_IF(cond, Status::Invalid("error"));
+  return Status::OK();
+}
+
+Status returnNotOk(Status s) {
+  VELOX_RETURN_NOT_OK(s);
+  return Status::Invalid("invalid");
+}
+
+TEST(StatusTest, macros) {
+  ASSERT_EQ(returnIf(true), Status::Invalid("error"));
+  ASSERT_EQ(returnIf(false), Status::OK());
+
+  ASSERT_EQ(returnNotOk(Status::UserError("user")), Status::UserError("user"));
+  ASSERT_EQ(returnNotOk(Status::OK()), Status::Invalid("invalid"));
+
+  VELOX_CHECK_OK(Status::OK()); // does not throw.
+
+  bool didThrow = false;
+  try {
+    VELOX_CHECK_OK(Status::Invalid("invalid"));
+  } catch (const VeloxRuntimeError& e) {
+    didThrow = true;
+  }
+  ASSERT_TRUE(didThrow) << "VELOX_CHECK_OK did not throw";
+}
+
+} // namespace
+} // namespace facebook::velox::test


### PR DESCRIPTION
This is the first PR of a set of 3.

- This first one introduces a Status object that carries the (success or error) status of an operation. Based on arrow::Status.
- The second will add a `Result` object able to represent a value returned from an operation along with a Status code. This is also based on arrow::Result
- The third one will refactor our Parquet Write to use these object and remove more dependencies from Arrow.

The idea is to start using these classes more widely throughout the library, especially in places where returning errors as exception add too much overhead.

See class documentation and usage examples in the header file.