### PR TITLE
Add .parquet suffix to the file name

### DIFF
--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -737,10 +737,11 @@ std::pair<std::string, std::string> HiveDataSink::getWriterFileNames(
       : targetFileName;
   if (insertTableHandle_->tableStorageFormat() ==
       dwio::common::FileFormat::PARQUET) {
-    return {targetFileName, fmt::format("{}{}", writeFileName, ".parquet")};
-  } else {
-    return {targetFileName, writeFileName};
+    return {
+        fmt::format("{}{}", targetFileName, ".parquet"),
+        fmt::format("{}{}", writeFileName, ".parquet")};
   }
+  return {targetFileName, writeFileName};
 }
 
 HiveWriterParameters::UpdateMode HiveDataSink::getUpdateMode() const {

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -732,15 +732,15 @@ std::pair<std::string, std::string> HiveDataSink::getWriterFileNames(
         connectorQueryCtx_->planNodeId(),
         makeUuid());
   }
-  std::string writeFileName = isCommitRequired()
+  const std::string writeFileName = isCommitRequired()
       ? fmt::format(".tmp.velox.{}_{}", targetFileName, makeUuid())
       : targetFileName;
   if (insertTableHandle_->tableStorageFormat() ==
       dwio::common::FileFormat::PARQUET) {
-    targetFileName += ".parquet";
-    writeFileName += ".parquet";
+    return {targetFileName, fmt::format("{}{}", writeFileName, ".parquet")};
+  } else {
+    return {targetFileName, writeFileName};
   }
-  return {targetFileName, writeFileName};
 }
 
 HiveWriterParameters::UpdateMode HiveDataSink::getUpdateMode() const {

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -732,9 +732,14 @@ std::pair<std::string, std::string> HiveDataSink::getWriterFileNames(
         connectorQueryCtx_->planNodeId(),
         makeUuid());
   }
-  const std::string writeFileName = isCommitRequired()
+  std::string writeFileName = isCommitRequired()
       ? fmt::format(".tmp.velox.{}_{}", targetFileName, makeUuid())
       : targetFileName;
+  if (insertTableHandle_->tableStorageFormat() ==
+      dwio::common::FileFormat::PARQUET) {
+    targetFileName += ".parquet";
+    writeFileName += ".parquet";
+  }
   return {targetFileName, writeFileName};
 }
 

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -766,14 +766,28 @@ class TableWriteTest : public HiveConnectorTestBase {
       const std::string& targetDir) {
     verifyPartitionedDirPath(filePath, targetDir);
     if (commitStrategy_ == CommitStrategy::kNoCommit) {
-      ASSERT_TRUE(RE2::FullMatch(
-          filePath.filename().string(), "0[0-9]+_0_TaskCursorQuery_[0-9]+"))
-          << filePath.filename().string();
+      if (fileFormat_ == FileFormat::PARQUET) {
+        ASSERT_TRUE(RE2::FullMatch(
+            filePath.filename().string(),
+            "0[0-9]+_0_TaskCursorQuery_[0-9]+\\.parquet$"))
+            << filePath.filename().string();
+      } else {
+        ASSERT_TRUE(RE2::FullMatch(
+            filePath.filename().string(), "0[0-9]+_0_TaskCursorQuery_[0-9]+"))
+            << filePath.filename().string();
+      }
     } else {
-      ASSERT_TRUE(RE2::FullMatch(
-          filePath.filename().string(),
-          ".tmp.velox.0[0-9]+_0_TaskCursorQuery_[0-9]+_.+"))
-          << filePath.filename().string();
+      if (fileFormat_ == FileFormat::PARQUET) {
+        ASSERT_TRUE(RE2::FullMatch(
+            filePath.filename().string(),
+            ".tmp.velox.0[0-9]+_0_TaskCursorQuery_[0-9]+_.+\\.parquet$"))
+            << filePath.filename().string();
+      } else {
+        ASSERT_TRUE(RE2::FullMatch(
+            filePath.filename().string(),
+            ".tmp.velox.0[0-9]+_0_TaskCursorQuery_[0-9]+_.+"))
+            << filePath.filename().string();
+      }
     }
   }
 

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -2463,11 +2463,11 @@ TEST_P(AllTableWriterTest, tableWriteOutputCheck) {
       if (commitStrategy_ == CommitStrategy::kNoCommit) {
         ASSERT_EQ(writeFileName, targetFileName);
       } else {
-        std::string suffix = ".parquet";
-        if (folly::StringPiece(targetFileName).endsWith(suffix)) {
+        const std::string kParquetSuffix  = ".parquet";
+        if (folly::StringPiece(targetFileName).endsWith(kParquetSuffix)) {
           // Remove the .parquet suffix.
           auto trimmedFilename =
-              targetFileName.substr(0, targetFileName.size() - suffix.size());
+              targetFileName.substr(0, targetFileName.size() - kParquetSuffix.size());
           ASSERT_TRUE(writeFileName.find(trimmedFilename) != std::string::npos);
         } else {
           ASSERT_TRUE(writeFileName.find(targetFileName) != std::string::npos);

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -2463,11 +2463,11 @@ TEST_P(AllTableWriterTest, tableWriteOutputCheck) {
       if (commitStrategy_ == CommitStrategy::kNoCommit) {
         ASSERT_EQ(writeFileName, targetFileName);
       } else {
-        const std::string kParquetSuffix  = ".parquet";
+        const std::string kParquetSuffix = ".parquet";
         if (folly::StringPiece(targetFileName).endsWith(kParquetSuffix)) {
           // Remove the .parquet suffix.
-          auto trimmedFilename =
-              targetFileName.substr(0, targetFileName.size() - kParquetSuffix.size());
+          auto trimmedFilename = targetFileName.substr(
+              0, targetFileName.size() - kParquetSuffix.size());
           ASSERT_TRUE(writeFileName.find(trimmedFilename) != std::string::npos);
         } else {
           ASSERT_TRUE(writeFileName.find(targetFileName) != std::string::npos);

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -2463,7 +2463,15 @@ TEST_P(AllTableWriterTest, tableWriteOutputCheck) {
       if (commitStrategy_ == CommitStrategy::kNoCommit) {
         ASSERT_EQ(writeFileName, targetFileName);
       } else {
-        ASSERT_TRUE(writeFileName.find(targetFileName) != std::string::npos);
+        std::string suffix = ".parquet";
+        if (folly::StringPiece(targetFileName).endsWith(suffix)) {
+          // Remove the .parquet suffix.
+          auto trimmedFilename =
+              targetFileName.substr(0, targetFileName.size() - suffix.size());
+          ASSERT_TRUE(writeFileName.find(trimmedFilename) != std::string::npos);
+        } else {
+          ASSERT_TRUE(writeFileName.find(targetFileName) != std::string::npos);
+        }
       }
     }
     if (!commitContextVector->isNullAt(i)) {


### PR DESCRIPTION
Spark adds the `.parquet` suffix to the file name when writing a Parquet file,
but Velox does not. This PR addresses this by adding the `.parquet `suffix to
the filename in Velox. 