### PR TITLE
Expose memory leak metrics

### DIFF
--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -96,6 +96,22 @@ void registerVeloxMetrics() {
   DEFINE_METRIC(
       kMetricArbitratorFreeCapacityBytes, facebook::velox::StatType::AVG);
 
+  // Tracks unexpected alive memory pools allocated by user on memory manager
+  // destruction.
+  DEFINE_METRIC(kMetricMemoryLeakPoolCount, facebook::velox::StatType::COUNT);
+
+  // Tracks the unexpected memory usage in terms of reservation bytes.
+  DEFINE_METRIC(
+      kMetricMemoryLeakReservationBytes, facebook::velox::StatType::SUM);
+
+  // Tracks the unexpected memory usage in terms of usedReservation bytes.
+  DEFINE_METRIC(
+      kMetricMemoryLeakUsedReservationBytes, facebook::velox::StatType::SUM);
+
+  // Tracks The unexpected memory usage in terms of minReservation bytes.
+  DEFINE_METRIC(
+      kMetricMemoryLeakMinReservationBytes, facebook::velox::StatType::SUM);
+
   /// ================== Spill related Counters =================
 
   // The number of bytes in memory to spill.

--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -49,6 +49,18 @@ constexpr folly::StringPiece kMetricMemoryReclaimWaitTimeoutCount{
 constexpr folly::StringPiece kMetricMemoryNonReclaimableCount{
     "velox.memory_non_reclaimable_count"};
 
+constexpr folly::StringPiece kMetricMemoryLeakPoolCount{
+    "velox.memory_leak_pool_count"};
+
+constexpr folly::StringPiece kMetricMemoryLeakReservationBytes{
+    "velox.memory_leak_reservation_bytes"};
+
+constexpr folly::StringPiece kMetricMemoryLeakUsedReservationBytes{
+    "velox.memory_leak_used_reservation_bytes"};
+
+constexpr folly::StringPiece kMetricMemoryLeakMinReservationBytes{
+    "velox.memory_leak_min_reservation_bytes"};
+
 constexpr folly::StringPiece kMetricArbitratorRequestsCount{
     "velox.arbitrator_requests_count"};
 

--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -51,7 +51,6 @@ MemoryManager::MemoryManager(const MemoryManagerOptions& options)
            .memoryReclaimWaitMs = options.memoryReclaimWaitMs,
            .arbitrationStateCheckCb = options.arbitrationStateCheckCb})),
       alignment_(std::max(MemoryAllocator::kMinAlignment, options.alignment)),
-      checkUsageLeak_(options.checkUsageLeak),
       debugEnabled_(options.debugEnabled),
       coreOnAllocationFailureEnabled_(options.coreOnAllocationFailureEnabled),
       poolDestructionCb_([&](MemoryPool* pool) { dropPool(pool); }),
@@ -68,7 +67,6 @@ MemoryManager::MemoryManager(const MemoryManagerOptions& options)
               .alignment = alignment_,
               .maxCapacity = kMaxMemory,
               .trackUsage = options.trackDefaultUsage,
-              .checkUsageLeak = options.checkUsageLeak,
               .debugEnabled = options.debugEnabled,
               .coreOnAllocationFailureEnabled =
                   options.coreOnAllocationFailureEnabled})} {
@@ -162,7 +160,6 @@ std::shared_ptr<MemoryPool> MemoryManager::addRootPool(
   options.alignment = alignment_;
   options.maxCapacity = capacity;
   options.trackUsage = true;
-  options.checkUsageLeak = checkUsageLeak_;
   options.debugEnabled = debugEnabled_;
   options.coreOnAllocationFailureEnabled = coreOnAllocationFailureEnabled_;
 

--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "velox/common/memory/Memory.h"
+#include "velox/common/base/Counters.h"
+#include "velox/common/base/StatsReporter.h"
 
 DECLARE_int32(velox_memory_num_shared_leaf_pools);
 
@@ -91,13 +93,12 @@ MemoryManager::MemoryManager(const MemoryManagerOptions& options)
 }
 
 MemoryManager::~MemoryManager() {
-  if (checkUsageLeak_) {
-    VELOX_CHECK_EQ(
-        pools_.size(),
-        0,
-        "There are unexpected alive memory pools allocated by user on memory manager destruction:\n{}",
-        toString(true));
-  }
+  RECORD_METRIC_VALUE(kMetricMemoryLeakPoolCount, pools_.size());
+  VELOX_DCHECK_EQ(
+      pools_.size(),
+      0,
+      "There are unexpected alive memory pools allocated by user on memory manager destruction:\n{}",
+      toString(true));
 }
 
 // static

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -82,12 +82,6 @@ struct MemoryManagerOptions {
   bool trackDefaultUsage{
       FLAGS_velox_enable_memory_usage_track_in_default_memory_pool};
 
-  /// If true, check the memory pool and usage leaks on destruction.
-  ///
-  /// TODO: deprecate this flag after all the existing memory leak use cases
-  /// have been fixed.
-  bool checkUsageLeak{FLAGS_velox_memory_leak_check_enabled};
-
   /// If true, the memory pool will be running in debug mode to track the
   /// allocation and free call stacks to detect the source of memory leak for
   /// testing purpose.
@@ -247,7 +241,6 @@ class MemoryManager {
   // If not null, used to arbitrate the memory capacity among 'pools_'.
   const std::unique_ptr<MemoryArbitrator> arbitrator_;
   const uint16_t alignment_;
-  const bool checkUsageLeak_;
   const bool debugEnabled_;
   const bool coreOnAllocationFailureEnabled_;
   // The destruction callback set for the allocated root memory pools which are

--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -214,7 +214,6 @@ MemoryPool::MemoryPool(
       maxCapacity_(parent_ == nullptr ? options.maxCapacity : kMaxMemory),
       trackUsage_(options.trackUsage),
       threadSafe_(options.threadSafe),
-      checkUsageLeak_(options.checkUsageLeak),
       debugEnabled_(options.debugEnabled),
       coreOnAllocationFailureEnabled_(options.coreOnAllocationFailureEnabled) {
   VELOX_CHECK(!isRoot() || !isLeaf());
@@ -657,7 +656,6 @@ std::shared_ptr<MemoryPool> MemoryPoolImpl::genChild(
           .alignment = alignment_,
           .trackUsage = trackUsage_,
           .threadSafe = threadSafe,
-          .checkUsageLeak = checkUsageLeak_,
           .debugEnabled = debugEnabled_,
           .coreOnAllocationFailureEnabled = coreOnAllocationFailureEnabled_});
 }

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -148,15 +148,6 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
     /// memory pools from the same root memory pool independently.
     bool threadSafe{true};
 
-    /// TODO: deprecate this flag after all the existing memory leak use cases
-    /// have been fixed.
-    ///
-    /// If true, checks the memory usage leak on destruction.
-    ///
-    /// NOTE: user can turn on/off the memory leak check of each individual
-    /// memory pools from the same root memory pool independently.
-    bool checkUsageLeak{FLAGS_velox_memory_leak_check_enabled};
-
     /// If true, tracks the allocation and free call stacks to detect the source
     /// of memory leak for testing purpose.
     bool debugEnabled{FLAGS_velox_memory_pool_debug_enabled};
@@ -210,12 +201,6 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   /// leaf memory pool with memory usage tracking enabled.
   virtual bool threadSafe() const {
     return threadSafe_;
-  }
-
-  /// Returns true if this memory pool checks memory leak on destruction.
-  /// Used only for test purposes.
-  virtual bool testingCheckUsageLeak() const {
-    return checkUsageLeak_;
   }
 
   /// Invoked to traverse the memory pool subtree rooted at this, and calls
@@ -531,7 +516,6 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   const int64_t maxCapacity_;
   const bool trackUsage_;
   const bool threadSafe_;
-  const bool checkUsageLeak_;
   const bool debugEnabled_;
   const bool coreOnAllocationFailureEnabled_;
 

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -616,17 +616,6 @@ TEST_F(MemoryManagerTest, quotaEnforcement) {
   }
 }
 
-TEST_F(MemoryManagerTest, testCheckUsageLeak) {
-  FLAGS_velox_memory_leak_check_enabled = true;
-  auto& manager = MemoryManager::testingSetInstance(
-      memory::MemoryManagerOptions{.checkUsageLeak = false});
-
-  auto rootPool = manager.addRootPool("duplicateRootPool", kMaxMemory);
-  auto leafPool = manager.addLeafPool("duplicateLeafPool", true);
-  ASSERT_FALSE(rootPool->testingCheckUsageLeak());
-  ASSERT_FALSE(leafPool->testingCheckUsageLeak());
-}
-
 } // namespace memory
 } // namespace velox
 } // namespace facebook

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -423,7 +423,6 @@ class MockSharedArbitrationTest : public testing::Test {
     options.memoryPoolInitCapacity = memoryPoolInitCapacity;
     options.memoryPoolTransferCapacity = memoryPoolTransferCapacity;
     options.arbitrationStateCheckCb = std::move(arbitrationStateCheckCb);
-    options.checkUsageLeak = true;
     manager_ = std::make_unique<MemoryManager>(options);
     ASSERT_EQ(manager_->arbitrator()->kind(), arbitratorKind);
     arbitrator_ = static_cast<SharedArbitrator*>(manager_->arbitrator());

--- a/velox/docs/metrics.rst
+++ b/velox/docs/metrics.rst
@@ -124,6 +124,18 @@ Memory Management
      - Average
      - The average of total free memory capacity which is managed by the
        memory arbitrator.
+   * - memory_leak_pool_count
+     - Count
+     - The unexpected alive memory pools allocated by user on memory manager destruction.
+   * - memory_leak_reservation_bytes
+     - Sum
+     - The unexpected memory usage in terms of reservation bytes.
+   * - memory_leak_used_reservation_bytes
+     - Sum
+     - The unexpected memory usage in terms of used reservation bytes.
+   * - memory_leak_min_reservation_bytes
+     - Sum
+     - The unexpected memory usage in terms of min reservation bytes.
 
 Spilling
 --------

--- a/velox/exec/tests/SharedArbitratorTest.cpp
+++ b/velox/exec/tests/SharedArbitratorTest.cpp
@@ -338,7 +338,6 @@ class SharedArbitrationTest : public exec::test::HiveConnectorTestBase {
     options.memoryPoolInitCapacity = memoryPoolInitCapacity;
     options.memoryPoolTransferCapacity = memoryPoolTransferCapacity;
     options.memoryReclaimWaitMs = maxReclaimWaitMs;
-    options.checkUsageLeak = true;
     options.arbitrationStateCheckCb = memoryArbitrationStateCheck;
     memoryManager_ = std::make_unique<MemoryManager>(options);
     ASSERT_EQ(memoryManager_->arbitrator()->kind(), "SHARED");


### PR DESCRIPTION
Expose memory leak metrics, and remove the checkUsageLeak option.
