### PR TITLE
Update aws-sdk-cpp version to 1.11.169 (from 1.10.57)

### DIFF
--- a/scripts/setup-adapters.sh
+++ b/scripts/setup-adapters.sh
@@ -25,7 +25,7 @@ DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
 
 function install_aws-sdk-cpp {
   local AWS_REPO_NAME="aws/aws-sdk-cpp"
-  local AWS_SDK_VERSION="1.10.57"
+  local AWS_SDK_VERSION="1.11.169"
 
   github_checkout $AWS_REPO_NAME $AWS_SDK_VERSION --depth 1 --recurse-submodules
   cmake_install -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS:BOOL=OFF -DMINIMIZE_SIZE:BOOL=ON -DENABLE_TESTING:BOOL=OFF -DBUILD_ONLY:STRING="s3;identity-management"


### PR DESCRIPTION
There is deadlock issue in current aws-sdk-cpp version, refer [link](https://github.com/aws/aws-sdk-cpp/issues/2331). And some later version also has [memory leak](https://github.com/aws/aws-sdk-cpp/issues/2331) issue, like 1.11.4. Here we update to version 1.11.169.