### PR TITLE
Refactor HiveDataSource

### DIFF
--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -26,7 +26,8 @@ add_library(
   HivePartitionUtil.cpp
   PartitionIdGenerator.cpp
   SplitReader.cpp
-  TableHandle.cpp)
+  TableHandle.cpp
+  HiveConnectorUtil.cpp)
 
 target_link_libraries(
   velox_hive_connector

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -82,29 +82,14 @@ std::unique_ptr<DataSource> HiveConnector::createDataSource(
         std::string,
         std::shared_ptr<connector::ColumnHandle>>& columnHandles,
     ConnectorQueryCtx* connectorQueryCtx) {
-  dwio::common::ReaderOptions options(connectorQueryCtx->memoryPool());
-  options.setMaxCoalesceBytes(hiveConfig_->maxCoalescedBytes());
-  options.setMaxCoalesceDistance(hiveConfig_->maxCoalescedDistanceBytes());
-  options.setPrefetchRowGroups(hiveConfig_->prefetchRowGroups());
-  options.setLoadQuantum(hiveConfig_->loadQuantum());
-  options.setFileColumnNamesReadAsLowerCase(
-      hiveConfig_->isFileColumnNamesReadAsLowerCase(
-          connectorQueryCtx->sessionProperties()));
-  options.setUseColumnNamesForColumnMapping(
-      hiveConfig_->isOrcUseColumnNames(connectorQueryCtx->sessionProperties()));
-  options.setFooterEstimatedSize(hiveConfig_->footerEstimatedSize());
-  options.setFilePreloadThreshold(hiveConfig_->filePreloadThreshold());
-
   return std::make_unique<HiveDataSource>(
       outputType,
       tableHandle,
       columnHandles,
       &fileHandleFactory_,
-      connectorQueryCtx->expressionEvaluator(),
-      connectorQueryCtx->cache(),
-      connectorQueryCtx->scanId(),
       executor_,
-      options);
+      connectorQueryCtx,
+      hiveConfig_);
 }
 
 std::unique_ptr<DataSink> HiveConnector::createDataSink(

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -1,0 +1,589 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "HiveConnectorUtil.h"
+
+#include "velox/connectors/hive/FileHandle.h"
+#include "velox/connectors/hive/HiveConfig.h"
+#include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/connectors/hive/TableHandle.h"
+#include "velox/dwio/common/BufferedInput.h"
+#include "velox/dwio/common/CachedBufferedInput.h"
+#include "velox/dwio/common/DirectBufferedInput.h"
+#include "velox/dwio/common/Reader.h"
+
+namespace facebook::velox::connector::hive {
+
+namespace {
+
+struct SubfieldSpec {
+  const common::Subfield* subfield;
+  bool filterOnly;
+};
+
+template <typename T>
+void deduplicate(std::vector<T>& values) {
+  std::sort(values.begin(), values.end());
+  values.erase(std::unique(values.begin(), values.end()), values.end());
+}
+
+// Floating point map key subscripts are truncated toward 0 in Presto.  For
+// example given `a' as a map with floating point key, if user queries a[0.99],
+// Presto coordinator will generate a required subfield a[0]; for a[-1.99] it
+// will generate a[-1]; for anything larger than 9223372036854775807, it
+// generates a[9223372036854775807]; for anything smaller than
+// -9223372036854775808 it generates a[-9223372036854775808].
+template <typename T>
+std::unique_ptr<common::Filter> makeFloatingPointMapKeyFilter(
+    const std::vector<int64_t>& subscripts) {
+  std::vector<std::unique_ptr<common::Filter>> filters;
+  for (auto subscript : subscripts) {
+    T lower = subscript;
+    T upper = subscript;
+    bool lowerUnbounded = subscript == std::numeric_limits<int64_t>::min();
+    bool upperUnbounded = subscript == std::numeric_limits<int64_t>::max();
+    bool lowerExclusive = false;
+    bool upperExclusive = false;
+    if (lower <= 0 && !lowerUnbounded) {
+      if (lower > subscript - 1) {
+        lower = subscript - 1;
+      } else {
+        lower = std::nextafter(lower, -std::numeric_limits<T>::infinity());
+      }
+      lowerExclusive = true;
+    }
+    if (upper >= 0 && !upperUnbounded) {
+      if (upper < subscript + 1) {
+        upper = subscript + 1;
+      } else {
+        upper = std::nextafter(upper, std::numeric_limits<T>::infinity());
+      }
+      upperExclusive = true;
+    }
+    if (lowerUnbounded && upperUnbounded) {
+      continue;
+    }
+    filters.push_back(std::make_unique<common::FloatingPointRange<T>>(
+        lower,
+        lowerUnbounded,
+        lowerExclusive,
+        upper,
+        upperUnbounded,
+        upperExclusive,
+        false));
+  }
+  if (filters.size() == 1) {
+    return std::move(filters[0]);
+  }
+  return std::make_unique<common::MultiRange>(std::move(filters), false, false);
+}
+
+// Recursively add subfields to scan spec.
+void addSubfields(
+    const Type& type,
+    std::vector<SubfieldSpec>& subfields,
+    int level,
+    memory::MemoryPool* pool,
+    common::ScanSpec& spec) {
+  int newSize = 0;
+  for (int i = 0; i < subfields.size(); ++i) {
+    if (level < subfields[i].subfield->path().size()) {
+      subfields[newSize++] = subfields[i];
+    } else if (!subfields[i].filterOnly) {
+      spec.addAllChildFields(type);
+      return;
+    }
+  }
+  subfields.resize(newSize);
+  switch (type.kind()) {
+    case TypeKind::ROW: {
+      folly::F14FastMap<std::string, std::vector<SubfieldSpec>> required;
+      for (auto& subfield : subfields) {
+        auto* element = subfield.subfield->path()[level].get();
+        auto* nestedField =
+            dynamic_cast<const common::Subfield::NestedField*>(element);
+        VELOX_CHECK(
+            nestedField,
+            "Unsupported for row subfields pruning: {}",
+            element->toString());
+        required[nestedField->name()].push_back(subfield);
+      }
+      auto& rowType = type.asRow();
+      for (int i = 0; i < rowType.size(); ++i) {
+        auto& childName = rowType.nameOf(i);
+        auto& childType = rowType.childAt(i);
+        auto* child = spec.addField(childName, i);
+        auto it = required.find(childName);
+        if (it == required.end()) {
+          child->setConstantValue(
+              BaseVector::createNullConstant(childType, 1, pool));
+        } else {
+          addSubfields(*childType, it->second, level + 1, pool, *child);
+        }
+      }
+      break;
+    }
+    case TypeKind::MAP: {
+      auto& keyType = type.childAt(0);
+      auto* keys = spec.addMapKeyFieldRecursively(*keyType);
+      addSubfields(
+          *type.childAt(1),
+          subfields,
+          level + 1,
+          pool,
+          *spec.addMapValueField());
+      if (subfields.empty()) {
+        return;
+      }
+      bool stringKey = keyType->isVarchar() || keyType->isVarbinary();
+      std::vector<std::string> stringSubscripts;
+      std::vector<int64_t> longSubscripts;
+      for (auto& subfield : subfields) {
+        auto* element = subfield.subfield->path()[level].get();
+        if (dynamic_cast<const common::Subfield::AllSubscripts*>(element)) {
+          return;
+        }
+        if (stringKey) {
+          auto* subscript =
+              dynamic_cast<const common::Subfield::StringSubscript*>(element);
+          VELOX_CHECK(
+              subscript,
+              "Unsupported for string map pruning: {}",
+              element->toString());
+          stringSubscripts.push_back(subscript->index());
+        } else {
+          auto* subscript =
+              dynamic_cast<const common::Subfield::LongSubscript*>(element);
+          VELOX_CHECK(
+              subscript,
+              "Unsupported for long map pruning: {}",
+              element->toString());
+          longSubscripts.push_back(subscript->index());
+        }
+      }
+      std::unique_ptr<common::Filter> filter;
+      if (stringKey) {
+        deduplicate(stringSubscripts);
+        filter = std::make_unique<common::BytesValues>(stringSubscripts, false);
+      } else {
+        deduplicate(longSubscripts);
+        if (keyType->isReal()) {
+          filter = makeFloatingPointMapKeyFilter<float>(longSubscripts);
+        } else if (keyType->isDouble()) {
+          filter = makeFloatingPointMapKeyFilter<double>(longSubscripts);
+        } else {
+          filter = common::createBigintValues(longSubscripts, false);
+        }
+      }
+      keys->setFilter(std::move(filter));
+      break;
+    }
+    case TypeKind::ARRAY: {
+      addSubfields(
+          *type.childAt(0),
+          subfields,
+          level + 1,
+          pool,
+          *spec.addArrayElementField());
+      if (subfields.empty()) {
+        return;
+      }
+      constexpr long kMaxIndex = std::numeric_limits<vector_size_t>::max();
+      long maxIndex = -1;
+      for (auto& subfield : subfields) {
+        auto* element = subfield.subfield->path()[level].get();
+        if (dynamic_cast<const common::Subfield::AllSubscripts*>(element)) {
+          return;
+        }
+        auto* subscript =
+            dynamic_cast<const common::Subfield::LongSubscript*>(element);
+        VELOX_CHECK(
+            subscript,
+            "Unsupported for array pruning: {}",
+            element->toString());
+        VELOX_USER_CHECK_GT(
+            subscript->index(),
+            0,
+            "Non-positive array subscript cannot be push down");
+        maxIndex = std::max(maxIndex, std::min(kMaxIndex, subscript->index()));
+      }
+      spec.setMaxArrayElementsCount(maxIndex);
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+inline uint8_t parseDelimiter(const std::string& delim) {
+  for (char const& ch : delim) {
+    if (!std::isdigit(ch)) {
+      return delim[0];
+    }
+  }
+  return stoi(delim);
+}
+
+} // namespace
+
+const std::string& getColumnName(const common::Subfield& subfield) {
+  VELOX_CHECK_GT(subfield.path().size(), 0);
+  auto* field = dynamic_cast<const common::Subfield::NestedField*>(
+      subfield.path()[0].get());
+  VELOX_CHECK(field);
+  return field->name();
+}
+
+void checkColumnNameLowerCase(const std::shared_ptr<const Type>& type) {
+  switch (type->kind()) {
+    case TypeKind::ARRAY:
+      checkColumnNameLowerCase(type->asArray().elementType());
+      break;
+    case TypeKind::MAP: {
+      checkColumnNameLowerCase(type->asMap().keyType());
+      checkColumnNameLowerCase(type->asMap().valueType());
+
+    } break;
+    case TypeKind::ROW: {
+      for (auto& outputName : type->asRow().names()) {
+        VELOX_CHECK(
+            !std::any_of(outputName.begin(), outputName.end(), isupper));
+      }
+      for (auto& childType : type->asRow().children()) {
+        checkColumnNameLowerCase(childType);
+      }
+    } break;
+    default:
+      VLOG(1) << "No need to check type lowercase mode" << type->toString();
+  }
+}
+
+void checkColumnNameLowerCase(const SubfieldFilters& filters) {
+  for (auto& pair : filters) {
+    if (auto name = pair.first.toString(); name == kPath || name == kBucket) {
+      continue;
+    }
+    auto& path = pair.first.path();
+
+    for (int i = 0; i < path.size(); ++i) {
+      auto nestedField =
+          dynamic_cast<const common::Subfield::NestedField*>(path[i].get());
+      if (nestedField == nullptr) {
+        continue;
+      }
+      VELOX_CHECK(!std::any_of(
+          nestedField->name().begin(), nestedField->name().end(), isupper));
+    }
+  }
+}
+
+void checkColumnNameLowerCase(const core::TypedExprPtr& typeExpr) {
+  if (typeExpr == nullptr) {
+    return;
+  }
+  checkColumnNameLowerCase(typeExpr->type());
+  for (auto& type : typeExpr->inputs()) {
+    checkColumnNameLowerCase(type);
+  }
+}
+
+std::shared_ptr<common::ScanSpec> makeScanSpec(
+    const RowTypePtr& rowType,
+    const folly::F14FastMap<std::string, std::vector<const common::Subfield*>>&
+        outputSubfields,
+    const SubfieldFilters& filters,
+    const RowTypePtr& dataColumns,
+    const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
+        partitionKeys,
+    memory::MemoryPool* pool) {
+  auto spec = std::make_shared<common::ScanSpec>("root");
+  folly::F14FastMap<std::string, std::vector<const common::Subfield*>>
+      filterSubfields;
+  std::vector<SubfieldSpec> subfieldSpecs;
+  for (auto& [subfield, _] : filters) {
+    if (auto name = subfield.toString();
+        name != kPath && name != kBucket && partitionKeys.count(name) == 0) {
+      filterSubfields[getColumnName(subfield)].push_back(&subfield);
+    }
+  }
+
+  // Process columns that will be projected out.
+  for (int i = 0; i < rowType->size(); ++i) {
+    auto& name = rowType->nameOf(i);
+    auto& type = rowType->childAt(i);
+    auto it = outputSubfields.find(name);
+    if (it == outputSubfields.end()) {
+      spec->addFieldRecursively(name, *type, i);
+      filterSubfields.erase(name);
+      continue;
+    }
+    for (auto* subfield : it->second) {
+      subfieldSpecs.push_back({subfield, false});
+    }
+    it = filterSubfields.find(name);
+    if (it != filterSubfields.end()) {
+      for (auto* subfield : it->second) {
+        subfieldSpecs.push_back({subfield, true});
+      }
+      filterSubfields.erase(it);
+    }
+    addSubfields(*type, subfieldSpecs, 1, pool, *spec->addField(name, i));
+    subfieldSpecs.clear();
+  }
+
+  // Now process the columns that will not be projected out.
+  if (!filterSubfields.empty()) {
+    VELOX_CHECK_NOT_NULL(dataColumns);
+    for (auto& [fieldName, subfields] : filterSubfields) {
+      for (auto* subfield : subfields) {
+        subfieldSpecs.push_back({subfield, true});
+      }
+      auto& type = dataColumns->findChild(fieldName);
+      auto* fieldSpec = spec->getOrCreateChild(common::Subfield(fieldName));
+      addSubfields(*type, subfieldSpecs, 1, pool, *fieldSpec);
+      subfieldSpecs.clear();
+    }
+  }
+
+  for (auto& pair : filters) {
+    // SelectiveColumnReader doesn't support constant columns with filters,
+    // hence, we can't have a filter for a $path or $bucket column.
+    //
+    // Unfortunately, Presto happens to specify a filter for $path or
+    // $bucket column. This filter is redundant and needs to be removed.
+    // TODO Remove this check when Presto is fixed to not specify a filter
+    // on $path and $bucket column.
+    if (auto name = pair.first.toString(); name == kPath || name == kBucket) {
+      continue;
+    }
+    auto fieldSpec = spec->getOrCreateChild(pair.first);
+    fieldSpec->addFilter(*pair.second);
+  }
+
+  return spec;
+}
+
+std::unique_ptr<dwio::common::SerDeOptions> parseSerdeParameters(
+    const std::unordered_map<std::string, std::string>& serdeParameters) {
+  auto fieldIt = serdeParameters.find(dwio::common::SerDeOptions::kFieldDelim);
+  if (fieldIt == serdeParameters.end()) {
+    fieldIt = serdeParameters.find("serialization.format");
+  }
+  auto collectionIt =
+      serdeParameters.find(dwio::common::SerDeOptions::kCollectionDelim);
+  if (collectionIt == serdeParameters.end()) {
+    // For collection delimiter, Hive 1.x, 2.x uses "colelction.delim", but
+    // Hive 3.x uses "collection.delim".
+    // See: https://issues.apache.org/jira/browse/HIVE-16922)
+    collectionIt = serdeParameters.find("colelction.delim");
+  }
+  auto mapKeyIt =
+      serdeParameters.find(dwio::common::SerDeOptions::kMapKeyDelim);
+
+  if (fieldIt == serdeParameters.end() &&
+      collectionIt == serdeParameters.end() &&
+      mapKeyIt == serdeParameters.end()) {
+    return nullptr;
+  }
+
+  uint8_t fieldDelim = '\1';
+  uint8_t collectionDelim = '\2';
+  uint8_t mapKeyDelim = '\3';
+  if (fieldIt != serdeParameters.end()) {
+    fieldDelim = parseDelimiter(fieldIt->second);
+  }
+  if (collectionIt != serdeParameters.end()) {
+    collectionDelim = parseDelimiter(collectionIt->second);
+  }
+  if (mapKeyIt != serdeParameters.end()) {
+    mapKeyDelim = parseDelimiter(mapKeyIt->second);
+  }
+  auto serDeOptions = std::make_unique<dwio::common::SerDeOptions>(
+      fieldDelim, collectionDelim, mapKeyDelim);
+  return serDeOptions;
+}
+
+void configureReaderOptions(
+    dwio::common::ReaderOptions& readerOptions,
+    const std::shared_ptr<HiveConfig>& hiveConfig,
+    const Config* sessionProperties,
+    const RowTypePtr& fileSchema,
+    std::shared_ptr<HiveConnectorSplit> hiveSplit) {
+  readerOptions.setMaxCoalesceBytes(hiveConfig->maxCoalescedBytes());
+  readerOptions.setMaxCoalesceDistance(hiveConfig->maxCoalescedDistanceBytes());
+  readerOptions.setFileColumnNamesReadAsLowerCase(
+      hiveConfig->isFileColumnNamesReadAsLowerCase(sessionProperties));
+  readerOptions.setUseColumnNamesForColumnMapping(
+      hiveConfig->isOrcUseColumnNames(sessionProperties));
+  readerOptions.setFileSchema(fileSchema);
+  readerOptions.setFooterEstimatedSize(hiveConfig->footerEstimatedSize());
+  readerOptions.setFilePreloadThreshold(hiveConfig->filePreloadThreshold());
+
+  if (readerOptions.getFileFormat() != dwio::common::FileFormat::UNKNOWN) {
+    VELOX_CHECK(
+        readerOptions.getFileFormat() == hiveSplit->fileFormat,
+        "HiveDataSource received splits of different formats: {} and {}",
+        dwio::common::toString(readerOptions.getFileFormat()),
+        dwio::common::toString(hiveSplit->fileFormat));
+  } else {
+    auto serDeOptions = parseSerdeParameters(hiveSplit->serdeParameters);
+    if (serDeOptions) {
+      readerOptions.setSerDeOptions(*serDeOptions);
+    }
+
+    readerOptions.setFileFormat(hiveSplit->fileFormat);
+  }
+}
+
+void configureRowReaderOptions(
+    dwio::common::RowReaderOptions& rowReaderOptions,
+    const std::unordered_map<std::string, std::string>& tableParameters,
+    std::shared_ptr<common::ScanSpec> scanSpec,
+    std::shared_ptr<common::MetadataFilter> metadataFilter,
+    const RowTypePtr& rowType,
+    std::shared_ptr<HiveConnectorSplit> hiveSplit) {
+  auto skipRowsIt =
+      tableParameters.find(dwio::common::TableParameter::kSkipHeaderLineCount);
+  if (skipRowsIt != tableParameters.end()) {
+    rowReaderOptions.setSkipRows(folly::to<uint64_t>(skipRowsIt->second));
+  }
+
+  rowReaderOptions.setScanSpec(scanSpec);
+  rowReaderOptions.setMetadataFilter(metadataFilter);
+
+  std::vector<std::string> columnNames;
+  for (auto& spec : scanSpec->children()) {
+    if (!spec->isConstant()) {
+      columnNames.push_back(spec->fieldName());
+    }
+  }
+  std::shared_ptr<dwio::common::ColumnSelector> cs;
+  if (columnNames.empty()) {
+    static const RowTypePtr kEmpty{ROW({}, {})};
+    cs = std::make_shared<dwio::common::ColumnSelector>(kEmpty);
+  } else {
+    cs = std::make_shared<dwio::common::ColumnSelector>(rowType, columnNames);
+  }
+  rowReaderOptions.select(cs).range(hiveSplit->start, hiveSplit->length);
+}
+
+bool applyPartitionFilter(
+    TypeKind kind,
+    const std::string& partitionValue,
+    common::Filter* filter) {
+  switch (kind) {
+    case TypeKind::BIGINT:
+    case TypeKind::INTEGER:
+    case TypeKind::SMALLINT:
+    case TypeKind::TINYINT: {
+      return applyFilter(*filter, folly::to<int64_t>(partitionValue));
+    }
+    case TypeKind::REAL:
+    case TypeKind::DOUBLE: {
+      return applyFilter(*filter, folly::to<double>(partitionValue));
+    }
+    case TypeKind::BOOLEAN: {
+      return applyFilter(*filter, folly::to<bool>(partitionValue));
+    }
+    case TypeKind::VARCHAR: {
+      return applyFilter(*filter, partitionValue);
+    }
+    default:
+      VELOX_FAIL("Bad type {} for partition value: {}", kind, partitionValue);
+  }
+}
+
+bool testFilters(
+    common::ScanSpec* scanSpec,
+    dwio::common::Reader* reader,
+    const std::string& filePath,
+    const std::unordered_map<std::string, std::optional<std::string>>&
+        partitionKey,
+    std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
+        partitionKeysHandle) {
+  auto totalRows = reader->numberOfRows();
+  const auto& fileTypeWithId = reader->typeWithId();
+  const auto& rowType = reader->rowType();
+  for (const auto& child : scanSpec->children()) {
+    if (child->filter()) {
+      const auto& name = child->fieldName();
+      if (!rowType->containsChild(name)) {
+        // If missing column is partition key.
+        auto iter = partitionKey.find(name);
+        if (iter != partitionKey.end() && iter->second.has_value()) {
+          return applyPartitionFilter(
+              (*partitionKeysHandle)[name]->dataType()->kind(),
+              iter->second.value(),
+              child->filter());
+        }
+        // Column is missing. Most likely due to schema evolution.
+        if (child->filter()->isDeterministic() &&
+            !child->filter()->testNull()) {
+          return false;
+        }
+      } else {
+        const auto& typeWithId = fileTypeWithId->childByName(name);
+        auto columnStats = reader->columnStatistics(typeWithId->id());
+        if (columnStats != nullptr &&
+            !testFilter(
+                child->filter(),
+                columnStats.get(),
+                totalRows.value(),
+                typeWithId->type())) {
+          VLOG(1) << "Skipping " << filePath
+                  << " based on stats and filter for column "
+                  << child->fieldName();
+          return false;
+        }
+      }
+    }
+  }
+
+  return true;
+}
+
+std::unique_ptr<dwio::common::BufferedInput> createBufferedInput(
+    const FileHandle& fileHandle,
+    const dwio::common::ReaderOptions& readerOpts,
+    const ConnectorQueryCtx* connectorQueryCtx,
+    std::shared_ptr<io::IoStatistics> ioStats,
+    folly::Executor* executor) {
+  if (connectorQueryCtx->cache()) {
+    return std::make_unique<dwio::common::CachedBufferedInput>(
+        fileHandle.file,
+        dwio::common::MetricsLog::voidLog(),
+        fileHandle.uuid.id(),
+        connectorQueryCtx->cache(),
+        Connector::getTracker(
+            connectorQueryCtx->scanId(), readerOpts.loadQuantum()),
+        fileHandle.groupId.id(),
+        ioStats,
+        executor,
+        readerOpts);
+  }
+  return std::make_unique<dwio::common::DirectBufferedInput>(
+      fileHandle.file,
+      dwio::common::MetricsLog::voidLog(),
+      fileHandle.uuid.id(),
+      Connector::getTracker(
+          connectorQueryCtx->scanId(), readerOpts.loadQuantum()),
+      fileHandle.groupId.id(),
+      ioStats,
+      executor,
+      readerOpts);
+}
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConnectorUtil.h
+++ b/velox/connectors/hive/HiveConnectorUtil.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <folly/Executor.h>
+#include <folly/container/F14Map.h>
+
+#include "velox/connectors/Connector.h"
+#include "velox/connectors/hive/FileHandle.h"
+#include "velox/dwio/common/BufferedInput.h"
+#include "velox/dwio/common/Reader.h"
+
+namespace facebook::velox::connector::hive {
+
+class HiveColumnHandle;
+class HiveConfig;
+class HiveConnectorSplit;
+
+using SubfieldFilters =
+    std::unordered_map<common::Subfield, std::unique_ptr<common::Filter>>;
+
+constexpr const char* kPath = "$path";
+constexpr const char* kBucket = "$bucket";
+
+const std::string& getColumnName(const common::Subfield& subfield);
+
+void checkColumnNameLowerCase(const std::shared_ptr<const Type>& type);
+
+void checkColumnNameLowerCase(const SubfieldFilters& filters);
+
+void checkColumnNameLowerCase(const core::TypedExprPtr& typeExpr);
+
+std::shared_ptr<common::ScanSpec> makeScanSpec(
+    const RowTypePtr& rowType,
+    const folly::F14FastMap<std::string, std::vector<const common::Subfield*>>&
+        outputSubfields,
+    const SubfieldFilters& filters,
+    const RowTypePtr& dataColumns,
+    const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
+        partitionKeys,
+    memory::MemoryPool* pool);
+
+void configureReaderOptions(
+    dwio::common::ReaderOptions& readerOptions,
+    const std::shared_ptr<HiveConfig>& config,
+    const Config* sessionProperties,
+    const RowTypePtr& fileSchema,
+    std::shared_ptr<HiveConnectorSplit> hiveSplit);
+
+void configureRowReaderOptions(
+    dwio::common::RowReaderOptions& rowReaderOptions,
+    const std::unordered_map<std::string, std::string>& tableParameters,
+    std::shared_ptr<common::ScanSpec> scanSpec,
+    std::shared_ptr<common::MetadataFilter> metadataFilter,
+    const RowTypePtr& rowType,
+    std::shared_ptr<HiveConnectorSplit> hiveSplit);
+
+bool applyPartitionFilter(
+    TypeKind kind,
+    const std::string& partitionValue,
+    common::Filter* filter);
+
+bool testFilters(
+    common::ScanSpec* scanSpec,
+    dwio::common::Reader* reader,
+    const std::string& filePath,
+    const std::unordered_map<std::string, std::optional<std::string>>&
+        partitionKey,
+    std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
+        partitionKeysHandle);
+
+std::unique_ptr<dwio::common::BufferedInput> createBufferedInput(
+    const FileHandle& fileHandle,
+    const dwio::common::ReaderOptions& readerOpts,
+    const ConnectorQueryCtx* connectorQueryCtx,
+    std::shared_ptr<io::IoStatistics> ioStats,
+    folly::Executor* executor);
+
+template <TypeKind ToKind>
+velox::variant convertFromString(const std::optional<std::string>& value) {
+  if (value.has_value()) {
+    if constexpr (ToKind == TypeKind::VARCHAR) {
+      return velox::variant(value.value());
+    }
+    if constexpr (ToKind == TypeKind::VARBINARY) {
+      return velox::variant::binary((value.value()));
+    }
+    auto result = velox::util::Converter<ToKind>::cast(value.value());
+
+    return velox::variant(result);
+  }
+  return velox::variant(ToKind);
+}
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -19,9 +19,8 @@
 #include <string>
 #include <unordered_map>
 
-#include "velox/common/caching/CacheTTLController.h"
-#include "velox/dwio/common/CachedBufferedInput.h"
-#include "velox/dwio/common/DirectBufferedInput.h"
+#include "velox/connectors/hive/HiveConfig.h"
+#include "velox/connectors/hive/HiveConnectorUtil.h"
 #include "velox/dwio/common/ReaderFactory.h"
 #include "velox/expression/ExprToSubfieldFilter.h"
 #include "velox/expression/FieldReference.h"
@@ -33,271 +32,11 @@ class HiveColumnHandle;
 
 namespace {
 
-struct SubfieldSpec {
-  const common::Subfield* subfield;
-  bool filterOnly;
-};
-
-template <typename T>
-void deduplicate(std::vector<T>& values) {
-  std::sort(values.begin(), values.end());
-  values.erase(std::unique(values.begin(), values.end()), values.end());
-}
-
-// Floating point map key subscripts are truncated toward 0 in Presto.  For
-// example given `a' as a map with floating point key, if user queries a[0.99],
-// Presto coordinator will generate a required subfield a[0]; for a[-1.99] it
-// will generate a[-1]; for anything larger than 9223372036854775807, it
-// generates a[9223372036854775807]; for anything smaller than
-// -9223372036854775808 it generates a[-9223372036854775808].
-template <typename T>
-std::unique_ptr<common::Filter> makeFloatingPointMapKeyFilter(
-    const std::vector<int64_t>& subscripts) {
-  std::vector<std::unique_ptr<common::Filter>> filters;
-  for (auto subscript : subscripts) {
-    T lower = subscript;
-    T upper = subscript;
-    bool lowerUnbounded = subscript == std::numeric_limits<int64_t>::min();
-    bool upperUnbounded = subscript == std::numeric_limits<int64_t>::max();
-    bool lowerExclusive = false;
-    bool upperExclusive = false;
-    if (lower <= 0 && !lowerUnbounded) {
-      if (lower > subscript - 1) {
-        lower = subscript - 1;
-      } else {
-        lower = std::nextafter(lower, -std::numeric_limits<T>::infinity());
-      }
-      lowerExclusive = true;
-    }
-    if (upper >= 0 && !upperUnbounded) {
-      if (upper < subscript + 1) {
-        upper = subscript + 1;
-      } else {
-        upper = std::nextafter(upper, std::numeric_limits<T>::infinity());
-      }
-      upperExclusive = true;
-    }
-    if (lowerUnbounded && upperUnbounded) {
-      continue;
-    }
-    filters.push_back(std::make_unique<common::FloatingPointRange<T>>(
-        lower,
-        lowerUnbounded,
-        lowerExclusive,
-        upper,
-        upperUnbounded,
-        upperExclusive,
-        false));
-  }
-  if (filters.size() == 1) {
-    return std::move(filters[0]);
-  }
-  return std::make_unique<common::MultiRange>(std::move(filters), false, false);
-}
-
-// Recursively add subfields to scan spec.
-void addSubfields(
-    const Type& type,
-    std::vector<SubfieldSpec>& subfields,
-    int level,
-    memory::MemoryPool* pool,
-    common::ScanSpec& spec) {
-  int newSize = 0;
-  for (int i = 0; i < subfields.size(); ++i) {
-    if (level < subfields[i].subfield->path().size()) {
-      subfields[newSize++] = subfields[i];
-    } else if (!subfields[i].filterOnly) {
-      spec.addAllChildFields(type);
-      return;
-    }
-  }
-  subfields.resize(newSize);
-  switch (type.kind()) {
-    case TypeKind::ROW: {
-      folly::F14FastMap<std::string, std::vector<SubfieldSpec>> required;
-      for (auto& subfield : subfields) {
-        auto* element = subfield.subfield->path()[level].get();
-        auto* nestedField =
-            dynamic_cast<const common::Subfield::NestedField*>(element);
-        VELOX_CHECK(
-            nestedField,
-            "Unsupported for row subfields pruning: {}",
-            element->toString());
-        required[nestedField->name()].push_back(subfield);
-      }
-      auto& rowType = type.asRow();
-      for (int i = 0; i < rowType.size(); ++i) {
-        auto& childName = rowType.nameOf(i);
-        auto& childType = rowType.childAt(i);
-        auto* child = spec.addField(childName, i);
-        auto it = required.find(childName);
-        if (it == required.end()) {
-          child->setConstantValue(
-              BaseVector::createNullConstant(childType, 1, pool));
-        } else {
-          addSubfields(*childType, it->second, level + 1, pool, *child);
-        }
-      }
-      break;
-    }
-    case TypeKind::MAP: {
-      auto& keyType = type.childAt(0);
-      auto* keys = spec.addMapKeyFieldRecursively(*keyType);
-      addSubfields(
-          *type.childAt(1),
-          subfields,
-          level + 1,
-          pool,
-          *spec.addMapValueField());
-      if (subfields.empty()) {
-        return;
-      }
-      bool stringKey = keyType->isVarchar() || keyType->isVarbinary();
-      std::vector<std::string> stringSubscripts;
-      std::vector<int64_t> longSubscripts;
-      for (auto& subfield : subfields) {
-        auto* element = subfield.subfield->path()[level].get();
-        if (dynamic_cast<const common::Subfield::AllSubscripts*>(element)) {
-          return;
-        }
-        if (stringKey) {
-          auto* subscript =
-              dynamic_cast<const common::Subfield::StringSubscript*>(element);
-          VELOX_CHECK(
-              subscript,
-              "Unsupported for string map pruning: {}",
-              element->toString());
-          stringSubscripts.push_back(subscript->index());
-        } else {
-          auto* subscript =
-              dynamic_cast<const common::Subfield::LongSubscript*>(element);
-          VELOX_CHECK(
-              subscript,
-              "Unsupported for long map pruning: {}",
-              element->toString());
-          longSubscripts.push_back(subscript->index());
-        }
-      }
-      std::unique_ptr<common::Filter> filter;
-      if (stringKey) {
-        deduplicate(stringSubscripts);
-        filter = std::make_unique<common::BytesValues>(stringSubscripts, false);
-      } else {
-        deduplicate(longSubscripts);
-        if (keyType->isReal()) {
-          filter = makeFloatingPointMapKeyFilter<float>(longSubscripts);
-        } else if (keyType->isDouble()) {
-          filter = makeFloatingPointMapKeyFilter<double>(longSubscripts);
-        } else {
-          filter = common::createBigintValues(longSubscripts, false);
-        }
-      }
-      keys->setFilter(std::move(filter));
-      break;
-    }
-    case TypeKind::ARRAY: {
-      addSubfields(
-          *type.childAt(0),
-          subfields,
-          level + 1,
-          pool,
-          *spec.addArrayElementField());
-      if (subfields.empty()) {
-        return;
-      }
-      constexpr long kMaxIndex = std::numeric_limits<vector_size_t>::max();
-      long maxIndex = -1;
-      for (auto& subfield : subfields) {
-        auto* element = subfield.subfield->path()[level].get();
-        if (dynamic_cast<const common::Subfield::AllSubscripts*>(element)) {
-          return;
-        }
-        auto* subscript =
-            dynamic_cast<const common::Subfield::LongSubscript*>(element);
-        VELOX_CHECK(
-            subscript,
-            "Unsupported for array pruning: {}",
-            element->toString());
-        VELOX_USER_CHECK_GT(
-            subscript->index(),
-            0,
-            "Non-positive array subscript cannot be push down");
-        maxIndex = std::max(maxIndex, std::min(kMaxIndex, subscript->index()));
-      }
-      spec.setMaxArrayElementsCount(maxIndex);
-      break;
-    }
-    default:
-      break;
-  }
-}
-
 core::CallTypedExprPtr replaceInputs(
     const core::CallTypedExpr* call,
     std::vector<core::TypedExprPtr>&& inputs) {
   return std::make_shared<core::CallTypedExpr>(
       call->type(), std::move(inputs), call->name());
-}
-
-void checkColumnNameLowerCase(const std::shared_ptr<const Type>& type) {
-  switch (type->kind()) {
-    case TypeKind::ARRAY:
-      checkColumnNameLowerCase(type->asArray().elementType());
-      break;
-    case TypeKind::MAP: {
-      checkColumnNameLowerCase(type->asMap().keyType());
-      checkColumnNameLowerCase(type->asMap().valueType());
-
-    } break;
-    case TypeKind::ROW: {
-      for (auto& outputName : type->asRow().names()) {
-        VELOX_CHECK(
-            !std::any_of(outputName.begin(), outputName.end(), isupper));
-      }
-      for (auto& childType : type->asRow().children()) {
-        checkColumnNameLowerCase(childType);
-      }
-    } break;
-    default:
-      VLOG(1) << "No need to check type lowercase mode" << type->toString();
-  }
-}
-
-void checkColumnNameLowerCase(const SubfieldFilters& filters) {
-  for (auto& pair : filters) {
-    if (auto name = pair.first.toString(); name == kPath || name == kBucket) {
-      continue;
-    }
-    auto& path = pair.first.path();
-
-    for (int i = 0; i < path.size(); ++i) {
-      auto nestedField =
-          dynamic_cast<const common::Subfield::NestedField*>(path[i].get());
-      if (nestedField == nullptr) {
-        continue;
-      }
-      VELOX_CHECK(!std::any_of(
-          nestedField->name().begin(), nestedField->name().end(), isupper));
-    }
-  }
-}
-
-void checkColumnNameLowerCase(const core::TypedExprPtr& typeExpr) {
-  if (typeExpr == nullptr) {
-    return;
-  }
-  checkColumnNameLowerCase(typeExpr->type());
-  for (auto& type : typeExpr->inputs()) {
-    checkColumnNameLowerCase(type);
-  }
-}
-
-const std::string& getColumnName(const common::Subfield& subfield) {
-  VELOX_CHECK_GT(subfield.path().size(), 0);
-  auto* field = dynamic_cast<const common::Subfield::NestedField*>(
-      subfield.path()[0].get());
-  VELOX_CHECK(field);
-  return field->name();
 }
 
 } // namespace
@@ -359,19 +98,16 @@ HiveDataSource::HiveDataSource(
         std::string,
         std::shared_ptr<connector::ColumnHandle>>& columnHandles,
     FileHandleFactory* fileHandleFactory,
-    core::ExpressionEvaluator* expressionEvaluator,
-    cache::AsyncDataCache* cache,
-    const std::string& scanId,
     folly::Executor* executor,
-    const dwio::common::ReaderOptions& options)
-    : fileHandleFactory_(fileHandleFactory),
-      readerOpts_(options),
-      pool_(&options.getMemoryPool()),
+    const ConnectorQueryCtx* connectorQueryCtx,
+    const std::shared_ptr<HiveConfig>& hiveConfig)
+    : pool_(connectorQueryCtx->memoryPool()),
       outputType_(outputType),
-      expressionEvaluator_(expressionEvaluator),
-      cache_(cache),
-      scanId_(scanId),
-      executor_(executor) {
+      expressionEvaluator_(connectorQueryCtx->expressionEvaluator()),
+      fileHandleFactory_(fileHandleFactory),
+      executor_(executor),
+      connectorQueryCtx_(connectorQueryCtx),
+      hiveConfig_(hiveConfig) {
   // Column handled keyed on the column alias, the name used in the query.
   for (const auto& [canonicalizedName, columnHandle] : columnHandles) {
     auto handle = std::dynamic_pointer_cast<HiveColumnHandle>(columnHandle);
@@ -411,7 +147,8 @@ HiveDataSource::HiveDataSource(
   VELOX_CHECK(
       hiveTableHandle_ != nullptr,
       "TableHandle must be an instance of HiveTableHandle");
-  if (readerOpts_.isFileColumnNamesReadAsLowerCase()) {
+  if (hiveConfig_->isFileColumnNamesReadAsLowerCase(
+          connectorQueryCtx->sessionProperties())) {
     checkColumnNameLowerCase(outputType_);
     checkColumnNameLowerCase(hiveTableHandle_->subfieldFilters());
     checkColumnNameLowerCase(hiveTableHandle_->remainingFilter());
@@ -475,62 +212,21 @@ HiveDataSource::HiveDataSource(
         *scanSpec_, *remainingFilter, expressionEvaluator_);
   }
 
-  readerOpts_.setFileSchema(hiveTableHandle_->dataColumns());
   ioStats_ = std::make_shared<io::IoStatistics>();
-}
-
-inline uint8_t parseDelimiter(const std::string& delim) {
-  for (char const& ch : delim) {
-    if (!std::isdigit(ch)) {
-      return delim[0];
-    }
-  }
-  return stoi(delim);
-}
-
-void HiveDataSource::parseSerdeParameters(
-    const std::unordered_map<std::string, std::string>& serdeParameters) {
-  auto fieldIt = serdeParameters.find(dwio::common::SerDeOptions::kFieldDelim);
-  if (fieldIt == serdeParameters.end()) {
-    fieldIt = serdeParameters.find("serialization.format");
-  }
-  auto collectionIt =
-      serdeParameters.find(dwio::common::SerDeOptions::kCollectionDelim);
-  if (collectionIt == serdeParameters.end()) {
-    // For collection delimiter, Hive 1.x, 2.x uses "colelction.delim", but
-    // Hive 3.x uses "collection.delim".
-    // See: https://issues.apache.org/jira/browse/HIVE-16922)
-    collectionIt = serdeParameters.find("colelction.delim");
-  }
-  auto mapKeyIt =
-      serdeParameters.find(dwio::common::SerDeOptions::kMapKeyDelim);
-
-  if (fieldIt == serdeParameters.end() &&
-      collectionIt == serdeParameters.end() &&
-      mapKeyIt == serdeParameters.end()) {
-    return;
-  }
-
-  uint8_t fieldDelim = '\1';
-  uint8_t collectionDelim = '\2';
-  uint8_t mapKeyDelim = '\3';
-  if (fieldIt != serdeParameters.end()) {
-    fieldDelim = parseDelimiter(fieldIt->second);
-  }
-  if (collectionIt != serdeParameters.end()) {
-    collectionDelim = parseDelimiter(collectionIt->second);
-  }
-  if (mapKeyIt != serdeParameters.end()) {
-    mapKeyDelim = parseDelimiter(mapKeyIt->second);
-  }
-  dwio::common::SerDeOptions serDeOptions(
-      fieldDelim, collectionDelim, mapKeyDelim);
-  readerOpts_.setSerDeOptions(serDeOptions);
 }
 
 std::unique_ptr<SplitReader> HiveDataSource::createSplitReader() {
   return SplitReader::create(
-      split_, readerOutputType_, partitionKeys_, scanSpec_, pool_);
+      split_,
+      hiveTableHandle_,
+      scanSpec_,
+      readerOutputType_,
+      &partitionKeys_,
+      fileHandleFactory_,
+      executor_,
+      connectorQueryCtx_,
+      hiveConfig_,
+      ioStats_);
 }
 
 void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
@@ -542,37 +238,12 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
 
   VLOG(1) << "Adding split " << split_->toString();
 
-  if (readerOpts_.getFileFormat() != dwio::common::FileFormat::UNKNOWN) {
-    VELOX_CHECK(
-        readerOpts_.getFileFormat() == split_->fileFormat,
-        "HiveDataSource received splits of different formats: {} and {}",
-        toString(readerOpts_.getFileFormat()),
-        toString(split_->fileFormat));
-  } else {
-    parseSerdeParameters(split_->serdeParameters);
-    readerOpts_.setFileFormat(split_->fileFormat);
-  }
-
-  auto fileHandle = fileHandleFactory_->generate(split_->filePath).second;
-  // Here we keep adding new entries to CacheTTLController when new fileHandles
-  // are generated, if CacheTTLController was created. Creator of
-  // CacheTTLController needs to make sure a size control strategy was available
-  // such as removing aged out entries.
-  if (auto* cacheTTLController = cache::CacheTTLController::getInstance()) {
-    cacheTTLController->addOpenFileInfo(fileHandle->uuid.id());
-  }
-  auto input = createBufferedInput(*fileHandle, readerOpts_);
-
   if (splitReader_) {
     splitReader_.reset();
   }
+
   splitReader_ = createSplitReader();
-  splitReader_->prepareSplit(
-      hiveTableHandle_,
-      readerOpts_,
-      std::move(input),
-      metadataFilter_,
-      runtimeStats_);
+  splitReader_->prepareSplit(metadataFilter_, runtimeStats_);
 }
 
 std::optional<RowVectorPtr> HiveDataSource::next(
@@ -726,109 +397,6 @@ int64_t HiveDataSource::estimatedRowSize() {
     return kUnknownRowSize;
   }
   return splitReader_->estimatedRowSize();
-}
-
-std::shared_ptr<common::ScanSpec> HiveDataSource::makeScanSpec(
-    const RowTypePtr& rowType,
-    const folly::F14FastMap<std::string, std::vector<const common::Subfield*>>&
-        outputSubfields,
-    const SubfieldFilters& filters,
-    const RowTypePtr& dataColumns,
-    const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
-        partitionKeys,
-    memory::MemoryPool* pool) {
-  auto spec = std::make_shared<common::ScanSpec>("root");
-  folly::F14FastMap<std::string, std::vector<const common::Subfield*>>
-      filterSubfields;
-  std::vector<SubfieldSpec> subfieldSpecs;
-  for (auto& [subfield, _] : filters) {
-    if (auto name = subfield.toString();
-        name != kPath && name != kBucket && partitionKeys.count(name) == 0) {
-      filterSubfields[getColumnName(subfield)].push_back(&subfield);
-    }
-  }
-
-  // Process columns that will be projected out.
-  for (int i = 0; i < rowType->size(); ++i) {
-    auto& name = rowType->nameOf(i);
-    auto& type = rowType->childAt(i);
-    auto it = outputSubfields.find(name);
-    if (it == outputSubfields.end()) {
-      spec->addFieldRecursively(name, *type, i);
-      filterSubfields.erase(name);
-      continue;
-    }
-    for (auto* subfield : it->second) {
-      subfieldSpecs.push_back({subfield, false});
-    }
-    it = filterSubfields.find(name);
-    if (it != filterSubfields.end()) {
-      for (auto* subfield : it->second) {
-        subfieldSpecs.push_back({subfield, true});
-      }
-      filterSubfields.erase(it);
-    }
-    addSubfields(*type, subfieldSpecs, 1, pool, *spec->addField(name, i));
-    subfieldSpecs.clear();
-  }
-
-  // Now process the columns that will not be projected out.
-  if (!filterSubfields.empty()) {
-    VELOX_CHECK_NOT_NULL(dataColumns);
-    for (auto& [fieldName, subfields] : filterSubfields) {
-      for (auto* subfield : subfields) {
-        subfieldSpecs.push_back({subfield, true});
-      }
-      auto& type = dataColumns->findChild(fieldName);
-      auto* fieldSpec = spec->getOrCreateChild(common::Subfield(fieldName));
-      addSubfields(*type, subfieldSpecs, 1, pool, *fieldSpec);
-      subfieldSpecs.clear();
-    }
-  }
-
-  for (auto& pair : filters) {
-    // SelectiveColumnReader doesn't support constant columns with filters,
-    // hence, we can't have a filter for a $path or $bucket column.
-    //
-    // Unfortunately, Presto happens to specify a filter for $path or
-    // $bucket column. This filter is redundant and needs to be removed.
-    // TODO Remove this check when Presto is fixed to not specify a filter
-    // on $path and $bucket column.
-    if (auto name = pair.first.toString(); name == kPath || name == kBucket) {
-      continue;
-    }
-    auto fieldSpec = spec->getOrCreateChild(pair.first);
-    fieldSpec->addFilter(*pair.second);
-  }
-
-  return spec;
-}
-
-std::unique_ptr<dwio::common::BufferedInput>
-HiveDataSource::createBufferedInput(
-    const FileHandle& fileHandle,
-    const dwio::common::ReaderOptions& readerOpts) {
-  if (cache_) {
-    return std::make_unique<dwio::common::CachedBufferedInput>(
-        fileHandle.file,
-        dwio::common::MetricsLog::voidLog(),
-        fileHandle.uuid.id(),
-        cache_,
-        Connector::getTracker(scanId_, readerOpts.loadQuantum()),
-        fileHandle.groupId.id(),
-        ioStats_,
-        executor_,
-        readerOpts);
-  }
-  return std::make_unique<dwio::common::DirectBufferedInput>(
-      fileHandle.file,
-      dwio::common::MetricsLog::voidLog(),
-      fileHandle.uuid.id(),
-      Connector::getTracker(scanId_, readerOpts.loadQuantum()),
-      fileHandle.groupId.id(),
-      ioStats_,
-      executor_,
-      readerOpts);
 }
 
 vector_size_t HiveDataSource::evaluateRemainingFilter(RowVectorPtr& rowVector) {

--- a/velox/connectors/hive/HiveDataSource.h
+++ b/velox/connectors/hive/HiveDataSource.h
@@ -21,13 +21,16 @@
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/SplitReader.h"
 #include "velox/connectors/hive/TableHandle.h"
-#include "velox/dwio/common/BufferedInput.h"
-#include "velox/dwio/common/Reader.h"
-#include "velox/dwio/common/ScanSpec.h"
+#include "velox/dwio/common/Statistics.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/expression/Expr.h"
 
 namespace facebook::velox::connector::hive {
+
+class HiveConfig;
+
+using SubfieldFilters =
+    std::unordered_map<common::Subfield, std::unique_ptr<common::Filter>>;
 
 class HiveDataSource : public DataSource {
  public:
@@ -38,11 +41,9 @@ class HiveDataSource : public DataSource {
           std::string,
           std::shared_ptr<connector::ColumnHandle>>& columnHandles,
       FileHandleFactory* fileHandleFactory,
-      core::ExpressionEvaluator* expressionEvaluator,
-      cache::AsyncDataCache* cache,
-      const std::string& scanId,
       folly::Executor* executor,
-      const dwio::common::ReaderOptions& options);
+      const ConnectorQueryCtx* connectorQueryCtx,
+      const std::shared_ptr<HiveConfig>& hiveConfig);
 
   void addSplit(std::shared_ptr<ConnectorSplit> split) override;
 
@@ -73,19 +74,6 @@ class HiveDataSource : public DataSource {
 
   // Internal API, made public to be accessible in unit tests.  Do not use in
   // other places.
-  static std::shared_ptr<common::ScanSpec> makeScanSpec(
-      const RowTypePtr& rowType,
-      const folly::F14FastMap<
-          std::string,
-          std::vector<const common::Subfield*>>& outputSubfields,
-      const SubfieldFilters& filters,
-      const RowTypePtr& dataColumns,
-      const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
-          partitionKeys,
-      memory::MemoryPool* pool);
-
-  // Internal API, made public to be accessible in unit tests.  Do not use in
-  // other places.
   static core::TypedExprPtr extractFiltersFromRemainingFilter(
       const core::TypedExprPtr& expr,
       core::ExpressionEvaluator* evaluator,
@@ -95,15 +83,9 @@ class HiveDataSource : public DataSource {
  protected:
   virtual std::unique_ptr<SplitReader> createSplitReader();
 
-  std::unique_ptr<dwio::common::BufferedInput> createBufferedInput(
-      const FileHandle&,
-      const dwio::common::ReaderOptions&);
-
   std::shared_ptr<HiveConnectorSplit> split_;
-  FileHandleFactory* fileHandleFactory_;
-  dwio::common::ReaderOptions readerOpts_;
-  std::shared_ptr<common::ScanSpec> scanSpec_;
   memory::MemoryPool* pool_;
+  std::shared_ptr<common::ScanSpec> scanSpec_;
   VectorPtr output_;
   std::unique_ptr<SplitReader> splitReader_;
 
@@ -128,9 +110,6 @@ class HiveDataSource : public DataSource {
   // hold adaptation.
   void resetSplit();
 
-  void parseSerdeParameters(
-      const std::unordered_map<std::string, std::string>& serdeParameters);
-
   const RowVectorPtr& getEmptyOutput() {
     if (!emptyOutput_) {
       emptyOutput_ = RowVector::createEmpty(outputType_, pool_);
@@ -140,7 +119,7 @@ class HiveDataSource : public DataSource {
 
   std::shared_ptr<HiveTableHandle> hiveTableHandle_;
 
-  // The row type for the data source output, not including filter only columns
+  // The row type for the data source output, not including filter-only columns
   const RowTypePtr outputType_;
   std::shared_ptr<io::IoStatistics> ioStats_;
   std::shared_ptr<common::MetadataFilter> metadataFilter_;
@@ -156,9 +135,10 @@ class HiveDataSource : public DataSource {
   SelectivityVector filterRows_;
   exec::FilterEvalCtx filterEvalCtx_;
 
-  cache::AsyncDataCache* const cache_{nullptr};
-  const std::string& scanId_;
-  folly::Executor* executor_;
+  FileHandleFactory* const fileHandleFactory_;
+  folly::Executor* const executor_;
+  const ConnectorQueryCtx* const connectorQueryCtx_;
+  const std::shared_ptr<HiveConfig> hiveConfig_;
 };
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -16,141 +16,88 @@
 
 #include "velox/connectors/hive/SplitReader.h"
 
+#include "velox/common/caching/CacheTTLController.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/connectors/hive/HiveConnectorUtil.h"
 #include "velox/connectors/hive/TableHandle.h"
+#include "velox/dwio/common/CachedBufferedInput.h"
 #include "velox/dwio/common/ReaderFactory.h"
 
 namespace facebook::velox::connector::hive {
 
-namespace {
-
-bool applyPartitionFilter(
-    TypeKind kind,
-    const std::string& partitionValue,
-    common::Filter* filter) {
-  switch (kind) {
-    case TypeKind::BIGINT:
-    case TypeKind::INTEGER:
-    case TypeKind::SMALLINT:
-    case TypeKind::TINYINT: {
-      return applyFilter(*filter, folly::to<int64_t>(partitionValue));
-    }
-    case TypeKind::REAL:
-    case TypeKind::DOUBLE: {
-      return applyFilter(*filter, folly::to<double>(partitionValue));
-    }
-    case TypeKind::BOOLEAN: {
-      return applyFilter(*filter, folly::to<bool>(partitionValue));
-    }
-    case TypeKind::VARCHAR: {
-      return applyFilter(*filter, partitionValue);
-    }
-    default:
-      VELOX_FAIL("Bad type {} for partition value: {}", kind, partitionValue);
-      break;
-  }
-}
-
-bool testFilters(
-    common::ScanSpec* scanSpec,
-    dwio::common::Reader* reader,
-    const std::string& filePath,
-    const std::unordered_map<std::string, std::optional<std::string>>&
-        partitionKey,
-    std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
-        partitionKeysHandle) {
-  auto totalRows = reader->numberOfRows();
-  const auto& fileTypeWithId = reader->typeWithId();
-  const auto& rowType = reader->rowType();
-  for (const auto& child : scanSpec->children()) {
-    if (child->filter()) {
-      const auto& name = child->fieldName();
-      if (!rowType->containsChild(name)) {
-        // If missing column is partition key.
-        auto iter = partitionKey.find(name);
-        if (iter != partitionKey.end() && iter->second.has_value()) {
-          return applyPartitionFilter(
-              partitionKeysHandle[name]->dataType()->kind(),
-              iter->second.value(),
-              child->filter());
-        }
-        // Column is missing. Most likely due to schema evolution.
-        if (child->filter()->isDeterministic() &&
-            !child->filter()->testNull()) {
-          return false;
-        }
-      } else {
-        const auto& typeWithId = fileTypeWithId->childByName(name);
-        auto columnStats = reader->columnStatistics(typeWithId->id());
-        if (columnStats != nullptr &&
-            !testFilter(
-                child->filter(),
-                columnStats.get(),
-                totalRows.value(),
-                typeWithId->type())) {
-          VLOG(1) << "Skipping " << filePath
-                  << " based on stats and filter for column "
-                  << child->fieldName();
-          return false;
-        }
-      }
-    }
-  }
-
-  return true;
-}
-
-template <TypeKind ToKind>
-velox::variant convertFromString(const std::optional<std::string>& value) {
-  if (value.has_value()) {
-    if constexpr (ToKind == TypeKind::VARCHAR) {
-      return velox::variant(value.value());
-    }
-    if constexpr (ToKind == TypeKind::VARBINARY) {
-      return velox::variant::binary((value.value()));
-    }
-    auto result = velox::util::Converter<ToKind>::cast(value.value());
-
-    return velox::variant(result);
-  }
-  return velox::variant(ToKind);
-}
-
-} // namespace
-
 std::unique_ptr<SplitReader> SplitReader::create(
     std::shared_ptr<velox::connector::hive::HiveConnectorSplit> hiveSplit,
-    const RowTypePtr readerOutputType,
-    std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
-        partitionKeys,
+    std::shared_ptr<HiveTableHandle> hiveTableHandle,
     std::shared_ptr<common::ScanSpec> scanSpec,
-    memory::MemoryPool* pool) {
-  //  Create the SplitReader based on hiveSplit->customSplitInfo["table_format"]
+    const RowTypePtr readerOutputType,
+    std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
+        partitionKeys,
+    FileHandleFactory* fileHandleFactory,
+    folly::Executor* executor,
+    const ConnectorQueryCtx* connectorQueryCtx,
+    const std::shared_ptr<HiveConfig> hiveConfig,
+    std::shared_ptr<io::IoStatistics> ioStats) {
   return std::make_unique<SplitReader>(
-      hiveSplit, readerOutputType, partitionKeys, scanSpec, pool);
+      hiveSplit,
+      hiveTableHandle,
+      scanSpec,
+      readerOutputType,
+      partitionKeys,
+      fileHandleFactory,
+      executor,
+      connectorQueryCtx,
+      hiveConfig,
+      ioStats);
 }
 
 SplitReader::SplitReader(
     std::shared_ptr<velox::connector::hive::HiveConnectorSplit> hiveSplit,
-    const RowTypePtr readerOutputType,
-    std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
-        partitionKeys,
+    std::shared_ptr<HiveTableHandle> hiveTableHandle,
     std::shared_ptr<common::ScanSpec> scanSpec,
-    memory::MemoryPool* pool)
-    : hiveSplit_(std::move(hiveSplit)),
+    const RowTypePtr readerOutputType,
+    std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
+        partitionKeys,
+    FileHandleFactory* fileHandleFactory,
+    folly::Executor* executor,
+    const ConnectorQueryCtx* connectorQueryCtx,
+    const std::shared_ptr<HiveConfig> hiveConfig,
+    std::shared_ptr<io::IoStatistics> ioStats)
+    : hiveSplit_(hiveSplit),
+      hiveTableHandle_(hiveTableHandle),
+      scanSpec_(scanSpec),
       readerOutputType_(readerOutputType),
       partitionKeys_(partitionKeys),
-      scanSpec_(std::move(scanSpec)),
-      pool_(pool) {}
+      pool_(connectorQueryCtx->memoryPool()),
+      fileHandleFactory_(fileHandleFactory),
+      executor_(executor),
+      connectorQueryCtx_(connectorQueryCtx),
+      hiveConfig_(hiveConfig),
+      ioStats_(ioStats),
+      baseReaderOpts_(connectorQueryCtx->memoryPool()) {}
 
 void SplitReader::prepareSplit(
-    const std::shared_ptr<HiveTableHandle>& hiveTableHandle,
-    const dwio::common::ReaderOptions& readerOptions,
-    std::unique_ptr<dwio::common::BufferedInput> baseFileInput,
     std::shared_ptr<common::MetadataFilter> metadataFilter,
     dwio::common::RuntimeStatistics& runtimeStats) {
-  baseReader_ = dwio::common::getReaderFactory(readerOptions.getFileFormat())
-                    ->createReader(std::move(baseFileInput), readerOptions);
+  configureReaderOptions(
+      baseReaderOpts_,
+      hiveConfig_,
+      connectorQueryCtx_->sessionProperties(),
+      hiveTableHandle_->dataColumns(),
+      hiveSplit_);
+
+  auto fileHandle = fileHandleFactory_->generate(hiveSplit_->filePath).second;
+  // Here we keep adding new entries to CacheTTLController when new fileHandles
+  // are generated, if CacheTTLController was created. Creator of
+  // CacheTTLController needs to make sure a size control strategy was available
+  // such as removing aged out entries.
+  if (auto* cacheTTLController = cache::CacheTTLController::getInstance()) {
+    cacheTTLController->addOpenFileInfo(fileHandle->uuid.id());
+  }
+  auto baseFileInput = createBufferedInput(
+      *fileHandle, baseReaderOpts_, connectorQueryCtx_, ioStats_, executor_);
+
+  baseReader_ = dwio::common::getReaderFactory(baseReaderOpts_.getFileFormat())
+                    ->createReader(std::move(baseFileInput), baseReaderOpts_);
 
   // Note that this doesn't apply to Hudi tables.
   emptySplit_ = false;
@@ -174,23 +121,19 @@ void SplitReader::prepareSplit(
   }
 
   auto& fileType = baseReader_->rowType();
-  auto columnTypes = adaptColumns(fileType, readerOptions.getFileSchema());
+  auto columnTypes = adaptColumns(fileType, baseReaderOpts_.getFileSchema());
 
-  auto skipRowsIt = hiveTableHandle->tableParameters().find(
-      dwio::common::TableParameter::kSkipHeaderLineCount);
-  if (skipRowsIt != hiveTableHandle->tableParameters().end()) {
-    rowReaderOpts_.setSkipRows(folly::to<uint64_t>(skipRowsIt->second));
-  }
-
-  rowReaderOpts_.setScanSpec(scanSpec_);
-  rowReaderOpts_.setMetadataFilter(metadataFilter);
   configureRowReaderOptions(
-      rowReaderOpts_,
-      ROW(std::vector<std::string>(fileType->names()), std::move(columnTypes)));
+      baseRowReaderOpts_,
+      hiveTableHandle_->tableParameters(),
+      scanSpec_,
+      metadataFilter,
+      ROW(std::vector<std::string>(fileType->names()), std::move(columnTypes)),
+      hiveSplit_);
   // NOTE: we firstly reset the finished 'baseRowReader_' of previous split
   // before setting up for the next one to avoid doubling the peak memory usage.
   baseRowReader_.reset();
-  baseRowReader_ = baseReader_->createRowReader(rowReaderOpts_);
+  baseRowReader_ = baseReader_->createRowReader(baseRowReaderOpts_);
 }
 
 std::vector<TypePtr> SplitReader::adaptColumns(
@@ -287,22 +230,24 @@ void SplitReader::setConstantValue(
     common::ScanSpec* spec,
     const TypePtr& type,
     const velox::variant& value) const {
-  spec->setConstantValue(BaseVector::createConstant(type, value, 1, pool_));
+  spec->setConstantValue(BaseVector::createConstant(
+      type, value, 1, connectorQueryCtx_->memoryPool()));
 }
 
 void SplitReader::setNullConstantValue(
     common::ScanSpec* spec,
     const TypePtr& type) const {
-  spec->setConstantValue(BaseVector::createNullConstant(type, 1, pool_));
+  spec->setConstantValue(BaseVector::createNullConstant(
+      type, 1, connectorQueryCtx_->memoryPool()));
 }
 
 void SplitReader::setPartitionValue(
     common::ScanSpec* spec,
     const std::string& partitionKey,
     const std::optional<std::string>& value) const {
-  auto it = partitionKeys_.find(partitionKey);
+  auto it = partitionKeys_->find(partitionKey);
   VELOX_CHECK(
-      it != partitionKeys_.end(),
+      it != partitionKeys_->end(),
       "ColumnHandle is missing for partition key {}",
       partitionKey);
   auto constValue = VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
@@ -310,30 +255,11 @@ void SplitReader::setPartitionValue(
   setConstantValue(spec, it->second->dataType(), constValue);
 }
 
-void SplitReader::configureRowReaderOptions(
-    dwio::common::RowReaderOptions& options,
-    const RowTypePtr& rowType) {
-  std::vector<std::string> columnNames;
-  for (auto& spec : scanSpec_->children()) {
-    if (!spec->isConstant()) {
-      columnNames.push_back(spec->fieldName());
-    }
-  }
-  std::shared_ptr<dwio::common::ColumnSelector> cs;
-  if (columnNames.empty()) {
-    static const RowTypePtr kEmpty{ROW({}, {})};
-    cs = std::make_shared<dwio::common::ColumnSelector>(kEmpty);
-  } else {
-    cs = std::make_shared<dwio::common::ColumnSelector>(rowType, columnNames);
-  }
-  options.select(cs).range(hiveSplit_->start, hiveSplit_->length);
-}
-
 std::string SplitReader::toString() const {
   std::string partitionKeys;
   std::for_each(
-      partitionKeys_.begin(),
-      partitionKeys_.end(),
+      partitionKeys_->begin(),
+      partitionKeys_->end(),
       [&](std::pair<
           const std::string,
           std::shared_ptr<facebook::velox::connector::hive::HiveColumnHandle>>

--- a/velox/connectors/hive/SplitReader.h
+++ b/velox/connectors/hive/SplitReader.h
@@ -16,39 +16,68 @@
 
 #pragma once
 
-#include "velox/dwio/common/Reader.h"
-#include "velox/type/Type.h"
+#include "velox/connectors/hive/FileHandle.h"
+#include "velox/dwio/common/Options.h"
+
+namespace facebook::velox {
+class BaseVector;
+class variant;
+using VectorPtr = std::shared_ptr<BaseVector>;
+} // namespace facebook::velox
+
+namespace facebook::velox::common {
+class MetadataFilter;
+class ScanSpec;
+} // namespace facebook::velox::common
+
+namespace facebook::velox::connector {
+class ConnectorQueryCtx;
+} // namespace facebook::velox::connector
 
 namespace facebook::velox::dwio::common {
-class BufferedInput;
+class Reader;
+class RowReader;
+class RuntimeStatistics;
+} // namespace facebook::velox::dwio::common
+
+namespace facebook::velox::memory {
+class MemoryPool;
 }
 
 namespace facebook::velox::connector::hive {
 
-constexpr const char* kPath = "$path";
-constexpr const char* kBucket = "$bucket";
-
 struct HiveConnectorSplit;
 class HiveTableHandle;
 class HiveColumnHandle;
+class HiveConfig;
 
 class SplitReader {
  public:
   static std::unique_ptr<SplitReader> create(
       std::shared_ptr<velox::connector::hive::HiveConnectorSplit> hiveSplit,
-      const RowTypePtr readerOutputType,
-      std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
-          partitionKeys,
+      std::shared_ptr<HiveTableHandle> hiveTableHandle,
       std::shared_ptr<common::ScanSpec> scanSpec,
-      memory::MemoryPool* pool);
+      const RowTypePtr readerOutputType,
+      std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
+          partitionKeys,
+      FileHandleFactory* fileHandleFactory,
+      folly::Executor* executor,
+      const ConnectorQueryCtx* connectorQueryCtx,
+      const std::shared_ptr<HiveConfig> hiveConfig,
+      std::shared_ptr<io::IoStatistics> ioStats);
 
   SplitReader(
       std::shared_ptr<velox::connector::hive::HiveConnectorSplit> hiveSplit,
-      const RowTypePtr readerOutputType,
-      std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
-          partitionKeys,
+      std::shared_ptr<HiveTableHandle> hiveTableHandle,
       std::shared_ptr<common::ScanSpec> scanSpec,
-      memory::MemoryPool* pool);
+      const RowTypePtr readerOutputType,
+      std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
+          partitionKeys,
+      FileHandleFactory* fileHandleFactory,
+      folly::Executor* executor,
+      const ConnectorQueryCtx* connectorQueryCtx,
+      const std::shared_ptr<HiveConfig> hiveConfig,
+      std::shared_ptr<io::IoStatistics> ioStats);
 
   virtual ~SplitReader() = default;
 
@@ -56,9 +85,6 @@ class SplitReader {
   /// do additional preparations before reading the split, e.g. Open delete
   /// files or log files, and add column adapatations for metadata columns
   virtual void prepareSplit(
-      const std::shared_ptr<HiveTableHandle>& hiveTableHandle,
-      const dwio::common::ReaderOptions& readerOptions,
-      std::unique_ptr<dwio::common::BufferedInput> baseFileInput,
       std::shared_ptr<common::MetadataFilter> metadataFilter,
       dwio::common::RuntimeStatistics& runtimeStats);
 
@@ -100,20 +126,23 @@ class SplitReader {
       const std::optional<std::string>& value) const;
 
   std::shared_ptr<HiveConnectorSplit> hiveSplit_;
-  RowTypePtr readerOutputType_;
-  std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
-      partitionKeys_;
+  std::shared_ptr<HiveTableHandle> hiveTableHandle_;
   std::shared_ptr<common::ScanSpec> scanSpec_;
-  memory::MemoryPool* pool_;
+  RowTypePtr readerOutputType_;
+  std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
+      partitionKeys_;
+  memory::MemoryPool* const pool_;
   std::unique_ptr<dwio::common::Reader> baseReader_;
-  dwio::common::RowReaderOptions rowReaderOpts_;
   std::unique_ptr<dwio::common::RowReader> baseRowReader_;
+  FileHandleFactory* const fileHandleFactory_;
+  folly::Executor* const executor_;
+  const ConnectorQueryCtx* const connectorQueryCtx_;
+  const std::shared_ptr<HiveConfig> hiveConfig_;
+  std::shared_ptr<io::IoStatistics> ioStats_;
+  dwio::common::ReaderOptions baseReaderOpts_;
+  dwio::common::RowReaderOptions baseRowReaderOpts_;
 
  private:
-  void configureRowReaderOptions(
-      dwio::common::RowReaderOptions& options,
-      const RowTypePtr& rowType);
-
   bool emptySplit_;
 };
 

--- a/velox/connectors/hive/tests/HiveConnectorTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorTest.cpp
@@ -20,6 +20,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnector.h"
+#include "velox/connectors/hive/HiveConnectorUtil.h"
 #include "velox/connectors/hive/HiveDataSource.h"
 #include "velox/expression/ExprToSubfieldFilter.h"
 
@@ -86,7 +87,7 @@ TEST_F(HiveConnectorTest, makeScanSpec_requiredSubfields_multilevel) {
             VARCHAR(), ROW({{"c0c1c0", BIGINT()}, {"c0c1c1", BIGINT()}})))}});
   auto rowType = ROW({{"c0", columnType}});
   auto subfields = makeSubfields({"c0.c0c1[3][\"foo\"].c0c1c0"});
-  auto scanSpec = HiveDataSource::makeScanSpec(
+  auto scanSpec = makeScanSpec(
       rowType, groupSubfields(subfields), {}, nullptr, {}, pool_.get());
   auto* c0c0 = scanSpec->childByName("c0")->childByName("c0c0");
   validateNullConstant(*c0c0, *BIGINT());
@@ -115,7 +116,7 @@ TEST_F(HiveConnectorTest, makeScanSpec_requiredSubfields_mergeFields) {
              {"c0c0c2", BIGINT()}})},
        {"c0c1", ROW({{"c0c1c0", BIGINT()}, {"c0c1c1", BIGINT()}})}});
   auto rowType = ROW({{"c0", columnType}});
-  auto scanSpec = HiveDataSource::makeScanSpec(
+  auto scanSpec = makeScanSpec(
       rowType,
       groupSubfields(makeSubfields(
           {"c0.c0c0.c0c0c0", "c0.c0c0.c0c0c2", "c0.c0c1", "c0.c0c1.c0c1c0"})),
@@ -138,7 +139,7 @@ TEST_F(HiveConnectorTest, makeScanSpec_requiredSubfields_mergeArray) {
   auto columnType =
       ARRAY(ROW({{"c0c0", BIGINT()}, {"c0c1", BIGINT()}, {"c0c2", BIGINT()}}));
   auto rowType = ROW({{"c0", columnType}});
-  auto scanSpec = HiveDataSource::makeScanSpec(
+  auto scanSpec = makeScanSpec(
       rowType,
       groupSubfields(makeSubfields({"c0[1].c0c0", "c0[2].c0c2"})),
       {},
@@ -160,8 +161,7 @@ TEST_F(HiveConnectorTest, makeScanSpec_requiredSubfields_mergeArrayNegative) {
   auto subfields = makeSubfields({"c0[1].c0c0", "c0[-1].c0c2"});
   auto groupedSubfields = groupSubfields(subfields);
   VELOX_ASSERT_USER_THROW(
-      HiveDataSource::makeScanSpec(
-          rowType, groupedSubfields, {}, nullptr, {}, pool_.get()),
+      makeScanSpec(rowType, groupedSubfields, {}, nullptr, {}, pool_.get()),
       "Non-positive array subscript cannot be push down");
 }
 
@@ -170,7 +170,7 @@ TEST_F(HiveConnectorTest, makeScanSpec_requiredSubfields_mergeMap) {
       MAP(BIGINT(),
           ROW({{"c0c0", BIGINT()}, {"c0c1", BIGINT()}, {"c0c2", BIGINT()}}));
   auto rowType = ROW({{"c0", columnType}});
-  auto scanSpec = HiveDataSource::makeScanSpec(
+  auto scanSpec = makeScanSpec(
       rowType,
       groupSubfields(makeSubfields({"c0[10].c0c0", "c0[20].c0c2"})),
       {},
@@ -195,7 +195,7 @@ TEST_F(HiveConnectorTest, makeScanSpec_requiredSubfields_allSubscripts) {
   auto rowType = ROW({{"c0", columnType}});
   for (auto* path : {"c0", "c0[*]", "c0[*][*]"}) {
     SCOPED_TRACE(path);
-    auto scanSpec = HiveDataSource::makeScanSpec(
+    auto scanSpec = makeScanSpec(
         rowType,
         groupSubfields(makeSubfields({path})),
         {},
@@ -213,7 +213,7 @@ TEST_F(HiveConnectorTest, makeScanSpec_requiredSubfields_allSubscripts) {
     ASSERT_FALSE(elements->childByName("c0c0")->isConstant());
     ASSERT_FALSE(elements->childByName("c0c1")->isConstant());
   }
-  auto scanSpec = HiveDataSource::makeScanSpec(
+  auto scanSpec = makeScanSpec(
       rowType,
       groupSubfields(makeSubfields({"c0[*][*].c0c0"})),
       {},
@@ -235,7 +235,7 @@ TEST_F(HiveConnectorTest, makeScanSpec_requiredSubfields_allSubscripts) {
 TEST_F(HiveConnectorTest, makeScanSpec_requiredSubfields_doubleMapKey) {
   auto rowType =
       ROW({{"c0", MAP(REAL(), BIGINT())}, {"c1", MAP(DOUBLE(), BIGINT())}});
-  auto scanSpec = HiveDataSource::makeScanSpec(
+  auto scanSpec = makeScanSpec(
       rowType,
       groupSubfields(makeSubfields({"c0[0]", "c1[-1]"})),
       {},
@@ -261,7 +261,7 @@ TEST_F(HiveConnectorTest, makeScanSpec_requiredSubfields_doubleMapKey) {
   ASSERT_FALSE(applyFilter(*keysFilter, -2.0));
 
   // Integer min and max means infinities.
-  scanSpec = HiveDataSource::makeScanSpec(
+  scanSpec = makeScanSpec(
       rowType,
       groupSubfields(makeSubfields(
           {"c0[-9223372036854775808]", "c1[9223372036854775807]"})),
@@ -279,7 +279,7 @@ TEST_F(HiveConnectorTest, makeScanSpec_requiredSubfields_doubleMapKey) {
                    ->filter();
   ASSERT_TRUE(applyFilter(*keysFilter, 1e100));
   ASSERT_FALSE(applyFilter(*keysFilter, 9223372036854700000.0));
-  scanSpec = HiveDataSource::makeScanSpec(
+  scanSpec = makeScanSpec(
       rowType,
       groupSubfields(makeSubfields(
           {"c0[9223372036854775807]", "c0[-9223372036854775808]"})),
@@ -295,7 +295,7 @@ TEST_F(HiveConnectorTest, makeScanSpec_requiredSubfields_doubleMapKey) {
   ASSERT_TRUE(applyFilter(*keysFilter, 1e30f));
 
   // Unrepresentable values.
-  scanSpec = HiveDataSource::makeScanSpec(
+  scanSpec = makeScanSpec(
       rowType,
       groupSubfields(makeSubfields({"c0[-100000000]", "c0[100000000]"})),
       {},
@@ -330,7 +330,7 @@ TEST_F(HiveConnectorTest, makeScanSpec_filtersNotInRequiredSubfields) {
   filters.emplace(Subfield("c0.c0c2"), exec::isNotNull());
   filters.emplace(Subfield("c0.c0c3"), exec::isNotNull());
   filters.emplace(Subfield("c1.c1c0.c1c0c0"), exec::equal(43));
-  auto scanSpec = HiveDataSource::makeScanSpec(
+  auto scanSpec = makeScanSpec(
       ROW({{"c0", c0Type}}),
       groupSubfields(makeSubfields({"c0.c0c1", "c0.c0c3"})),
       filters,
@@ -373,7 +373,7 @@ TEST_F(HiveConnectorTest, makeScanSpec_duplicateSubfields) {
   auto c0Type = MAP(BIGINT(), MAP(BIGINT(), BIGINT()));
   auto c1Type = MAP(VARCHAR(), MAP(BIGINT(), BIGINT()));
   auto rowType = ROW({{"c0", c0Type}, {"c1", c1Type}});
-  auto scanSpec = HiveDataSource::makeScanSpec(
+  auto scanSpec = makeScanSpec(
       rowType,
       groupSubfields(makeSubfields(
           {"c0[10][1]", "c0[10][2]", "c1[\"foo\"][1]", "c1[\"foo\"][2]"})),
@@ -392,7 +392,7 @@ TEST_F(HiveConnectorTest, makeScanSpec_filterPartitionKey) {
   auto rowType = ROW({{"c0", BIGINT()}});
   SubfieldFilters filters;
   filters.emplace(Subfield("ds"), exec::equal("2023-10-13"));
-  auto scanSpec = HiveDataSource::makeScanSpec(
+  auto scanSpec = makeScanSpec(
       rowType, {}, filters, rowType, {{"ds", nullptr}}, pool_.get());
   ASSERT_TRUE(scanSpec->childByName("c0")->projectOut());
   ASSERT_FALSE(scanSpec->childByName("ds")->projectOut());


### PR DESCRIPTION
The upcoming IcebergSplitReader will need to use fileHandleFactory_, executor_, connectorQueryCtx_, etc because it needs to create another HiveDataSource to read the delete files. This PR copies these required fields to SplitReader. Moreover, most utility functions like makeScanspec configureReaderOptions, testFilters are moved into the newly created HiveConnectorUtil.h and cpp files, since they will be used by multiple classes like the SplitReaders, HiveDataSource, and the upcoming Iceberg DeleteFileReader.