### PR TITLE
Revert D51867634: Multisect successfully blamed "D51867634: [velox][PR] Scatter struct nulls when deserializing Presto wire format" for otest failure

### DIFF
--- a/velox/exec/SpillFile.cpp
+++ b/velox/exec/SpillFile.cpp
@@ -178,7 +178,7 @@ uint64_t SpillWriter::write(
     MicrosecondTimer timer(&timeUs);
     if (batch_ == nullptr) {
       serializer::presto::PrestoVectorSerde::PrestoOptions options = {
-          kDefaultUseLosslessTimestamp, compressionKind_, true};
+          kDefaultUseLosslessTimestamp, compressionKind_};
       batch_ = std::make_unique<VectorStreamGroup>(pool_);
       batch_->createStreamTree(
           std::static_pointer_cast<const RowType>(rows->type()),
@@ -294,7 +294,7 @@ SpillReadFile::SpillReadFile(
       numSortKeys_(numSortKeys),
       sortCompareFlags_(sortCompareFlags),
       compressionKind_(compressionKind),
-      readOptions_{kDefaultUseLosslessTimestamp, compressionKind_, true},
+      readOptions_{kDefaultUseLosslessTimestamp, compressionKind_},
       pool_(pool) {
   constexpr uint64_t kMaxReadBufferSize =
       (1 << 20) - AlignedBuffer::kPaddedSize; // 1MB - padding.

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -25,9 +25,6 @@
 #include "velox/vector/VectorTypeUtils.h"
 
 namespace facebook::velox::serializer::presto {
-
-using SerdeOpts = PrestoVectorSerde::PrestoOptions;
-
 namespace {
 constexpr int8_t kCompressedBitMask = 1;
 constexpr int8_t kEncryptedBitMask = 2;
@@ -149,23 +146,6 @@ PrestoVectorSerde::PrestoOptions toPrestoOptions(
 
 FOLLY_ALWAYS_INLINE bool needCompression(const folly::io::Codec& codec) {
   return codec.type() != folly::io::CodecType::NO_COMPRESSION;
-}
-
-using StructNullsMap =
-    folly::F14FastMap<int64_t, std::pair<std::vector<uint64_t>, int32_t>>;
-
-auto& structNullsMap() {
-  thread_local std::unique_ptr<StructNullsMap> map;
-  return map;
-}
-
-std::pair<const uint64_t*, int32_t> getStructNulls(int64_t position) {
-  auto& map = structNullsMap();
-  auto it = map->find(position);
-  if (it == map->end()) {
-    return {nullptr, 0};
-  }
-  return {it->second.first.data(), it->second.second};
 }
 
 template <typename T>
@@ -324,40 +304,21 @@ void readDecimalValues(
   }
 }
 
-vector_size_t sizeWithIncomingNulls(
-    vector_size_t size,
-    int32_t numIncomingNulls) {
-  return numIncomingNulls == 0 ? size : numIncomingNulls;
-}
-
 vector_size_t readNulls(
     ByteInputStream* source,
     vector_size_t size,
     BaseVector& result,
-    vector_size_t resultOffset,
-    const uint64_t* incomingNulls,
-    int32_t numIncomingNulls) {
-  VELOX_DCHECK_LE(
-      result.size(), resultOffset + (incomingNulls ? numIncomingNulls : size));
+    vector_size_t resultOffset) {
   if (source->readByte() == 0) {
-    if (incomingNulls) {
-      auto rawNulls = result.mutableRawNulls();
-      bits::copyBits(
-          incomingNulls, 0, rawNulls, resultOffset, numIncomingNulls);
-    } else {
-      result.clearNulls(resultOffset, resultOffset + size);
-    }
-    return incomingNulls
-        ? numIncomingNulls - bits::countBits(incomingNulls, 0, numIncomingNulls)
-        : 0;
+    result.clearNulls(resultOffset, resultOffset + size);
+    return 0;
   }
 
   const bool noPriorNulls = (result.rawNulls() == nullptr);
-  const auto numNewValues = sizeWithIncomingNulls(size, numIncomingNulls);
 
   // Allocate one extra byte in case we cannot use bits from the current last
   // partial byte.
-  BufferPtr& nulls = result.mutableNulls(resultOffset + numNewValues + 8);
+  BufferPtr& nulls = result.mutableNulls(resultOffset + size + 8);
   if (noPriorNulls) {
     bits::fillBits(
         nulls->asMutable<uint64_t>(), 0, resultOffset, bits::kNotNull);
@@ -369,15 +330,6 @@ vector_size_t readNulls(
   source->readBytes(rawNulls, numBytes);
   bits::reverseBits(rawNulls, numBytes);
   bits::negate(reinterpret_cast<char*>(rawNulls), numBytes * 8);
-  // Add incoming nulls if any.
-  if (incomingNulls) {
-    bits::scatterBits(
-        size,
-        numIncomingNulls,
-        reinterpret_cast<const char*>(rawNulls),
-        incomingNulls,
-        reinterpret_cast<char*>(rawNulls));
-  }
 
   // Shift bits if needed.
   if (bits::nbytes(resultOffset) * 8 > resultOffset) {
@@ -386,11 +338,10 @@ vector_size_t readNulls(
         bits::nbytes(resultOffset) * 8,
         nulls->asMutable<uint64_t>(),
         resultOffset,
-        numNewValues);
+        size);
   }
 
-  return BaseVector::countNulls(
-      nulls, resultOffset, resultOffset + numNewValues);
+  return BaseVector::countNulls(nulls, resultOffset, resultOffset + size);
 }
 
 template <typename T>
@@ -400,47 +351,28 @@ void read(
     velox::memory::MemoryPool* pool,
     VectorPtr& result,
     vector_size_t resultOffset,
-    const SerdeOpts& opts,
-    const uint64_t* incomingNulls,
-    int32_t numIncomingNulls) {
+    bool useLosslessTimestamp) {
   const int32_t size = source->read<int32_t>();
-  const auto numNewValues = sizeWithIncomingNulls(size, numIncomingNulls);
-  result->resize(resultOffset + numNewValues);
+  result->resize(resultOffset + size);
 
   auto flatResult = result->asFlatVector<T>();
-  auto nullCount = readNulls(
-      source, size, *flatResult, resultOffset, incomingNulls, numIncomingNulls);
+  auto nullCount = readNulls(source, size, *flatResult, resultOffset);
 
-  BufferPtr values = flatResult->mutableValues(resultOffset + numNewValues);
+  BufferPtr values = flatResult->mutableValues(resultOffset + size);
   if constexpr (std::is_same_v<T, Timestamp>) {
-    if (opts.useLosslessTimestamp) {
+    if (useLosslessTimestamp) {
       readLosslessTimestampValues(
-          source,
-          numNewValues,
-          resultOffset,
-          flatResult->nulls(),
-          nullCount,
-          values);
+          source, size, resultOffset, flatResult->nulls(), nullCount, values);
       return;
     }
   }
   if (type->isLongDecimal()) {
     readDecimalValues(
-        source,
-        numNewValues,
-        resultOffset,
-        flatResult->nulls(),
-        nullCount,
-        values);
+        source, size, resultOffset, flatResult->nulls(), nullCount, values);
     return;
   }
   readValues<T>(
-      source,
-      numNewValues,
-      resultOffset,
-      flatResult->nulls(),
-      nullCount,
-      values);
+      source, size, resultOffset, flatResult->nulls(), nullCount, values);
 }
 
 template <>
@@ -450,29 +382,20 @@ void read<StringView>(
     velox::memory::MemoryPool* pool,
     VectorPtr& result,
     vector_size_t resultOffset,
-    const SerdeOpts& opts,
-    const uint64_t* incomingNulls,
-    int32_t numIncomingNulls) {
+    bool useLosslessTimestamp) {
   const int32_t size = source->read<int32_t>();
-  const int32_t numNewValues = sizeWithIncomingNulls(size, numIncomingNulls);
 
-  result->resize(resultOffset + numNewValues);
+  result->resize(resultOffset + size);
 
   auto flatResult = result->as<FlatVector<StringView>>();
   BufferPtr values = flatResult->mutableValues(resultOffset + size);
   auto rawValues = values->asMutable<StringView>();
-  int32_t lastOffset = 0;
-  for (int32_t i = 0; i < numNewValues; ++i) {
+  for (int32_t i = 0; i < size; ++i) {
     // Set the first int32_t of each StringView to be the offset.
-    if (incomingNulls && bits::isBitNull(incomingNulls, i)) {
-      *reinterpret_cast<int32_t*>(&rawValues[resultOffset + i]) = lastOffset;
-      continue;
-    }
-    lastOffset = *reinterpret_cast<int32_t*>(&rawValues[resultOffset + i]) =
+    *reinterpret_cast<int32_t*>(&rawValues[resultOffset + i]) =
         source->read<int32_t>();
   }
-  readNulls(
-      source, size, *flatResult, resultOffset, incomingNulls, numIncomingNulls);
+  readNulls(source, size, *flatResult, resultOffset);
 
   const int32_t dataSize = source->read<int32_t>();
   if (dataSize == 0) {
@@ -485,7 +408,7 @@ void read<StringView>(
   source->readBytes(rawStrings, dataSize);
   int32_t previousOffset = 0;
   auto rawChars = reinterpret_cast<char*>(rawStrings);
-  for (int32_t i = 0; i < numNewValues; ++i) {
+  for (int32_t i = 0; i < size; ++i) {
     int32_t offset = rawValues[resultOffset + i].size();
     rawValues[resultOffset + i] =
         StringView(rawChars + previousOffset, offset - previousOffset);
@@ -499,9 +422,7 @@ void readColumns(
     const std::vector<TypePtr>& types,
     std::vector<VectorPtr>& result,
     vector_size_t resultOffset,
-    const SerdeOpts& opts,
-    const uint64_t* incomingNulls,
-    int32_t numIncomingNulls);
+    bool useLosslessTimestamp);
 
 void readConstantVector(
     ByteInputStream* source,
@@ -509,38 +430,25 @@ void readConstantVector(
     velox::memory::MemoryPool* pool,
     VectorPtr& result,
     vector_size_t resultOffset,
-    const SerdeOpts& opts,
-    const uint64_t* incomingNulls,
-    int32_t numIncomingNulls) {
+    bool useLosslessTimestamp) {
   const auto size = source->read<int32_t>();
-  const int32_t numNewValues = sizeWithIncomingNulls(size, numIncomingNulls);
   std::vector<TypePtr> childTypes = {type};
   std::vector<VectorPtr> children{BaseVector::create(type, 0, pool)};
-  readColumns(source, pool, childTypes, children, 0, opts, nullptr, 0);
+  readColumns(source, pool, childTypes, children, 0, useLosslessTimestamp);
   VELOX_CHECK_EQ(1, children[0]->size());
 
-  auto constantVector =
-      BaseVector::wrapInConstant(numNewValues, 0, children[0]);
-  if (resultOffset == 0 && !incomingNulls) {
+  auto constantVector = BaseVector::wrapInConstant(size, 0, children[0]);
+  if (resultOffset == 0) {
     result = std::move(constantVector);
   } else {
-    if (!incomingNulls && constantVector->equalValueAt(result.get(), 0, 0)) {
-      result->resize(resultOffset + numNewValues);
-      return;
-    }
-    result->resize(resultOffset + numNewValues);
+    result->resize(resultOffset + size);
 
     SelectivityVector rows(resultOffset + size, false);
-    rows.setValidRange(resultOffset, resultOffset + numNewValues, true);
+    rows.setValidRange(resultOffset, resultOffset + size, true);
     rows.updateBounds();
 
     BaseVector::ensureWritable(rows, type, pool, result);
-    result->copy(constantVector.get(), resultOffset, 0, numNewValues);
-    if (incomingNulls) {
-      bits::forEachUnsetBit(incomingNulls, 0, numNewValues, [&](auto row) {
-        result->setNull(resultOffset + row, true);
-      });
-    }
+    result->copy(constantVector.get(), resultOffset, 0, size);
   }
 }
 
@@ -550,57 +458,34 @@ void readDictionaryVector(
     velox::memory::MemoryPool* pool,
     VectorPtr& result,
     vector_size_t resultOffset,
-    const SerdeOpts& opts,
-    const uint64_t* incomingNulls,
-    int32_t numIncomingNulls) {
+    bool useLosslessTimestamp) {
   const auto size = source->read<int32_t>();
-  const int32_t numNewValues = sizeWithIncomingNulls(size, numIncomingNulls);
 
   std::vector<TypePtr> childTypes = {type};
   std::vector<VectorPtr> children{BaseVector::create(type, 0, pool)};
-  readColumns(source, pool, childTypes, children, 0, opts, nullptr, 0);
+  readColumns(source, pool, childTypes, children, 0, useLosslessTimestamp);
 
   // Read indices.
-  BufferPtr indices = allocateIndices(numNewValues, pool);
-  if (incomingNulls) {
-    auto rawIndices = indices->asMutable<int32_t>();
-    for (auto i = 0; i < numNewValues; ++i) {
-      if (bits::isBitNull(incomingNulls, i)) {
-        rawIndices[i] = 0;
-      } else {
-        rawIndices[i] = source->read<int32_t>();
-      }
-    }
-  } else {
-    source->readBytes(
-        indices->asMutable<char>(), numNewValues * sizeof(int32_t));
-  }
+  BufferPtr indices = allocateIndices(size, pool);
+  source->readBytes(indices->asMutable<char>(), size * sizeof(int32_t));
 
   // Skip 3 * 8 bytes of 'instance id'. Velox doesn't use 'instance id' for
   // dictionary vectors.
   source->skip(24);
 
-  BufferPtr incomingNullsBuffer = nullptr;
-  if (incomingNulls) {
-    incomingNullsBuffer = AlignedBuffer::allocate<bool>(numIncomingNulls, pool);
-    memcpy(
-        incomingNullsBuffer->asMutable<char>(),
-        incomingNulls,
-        bits::nbytes(numIncomingNulls));
-  }
-  auto dictionaryVector = BaseVector::wrapInDictionary(
-      incomingNullsBuffer, indices, size, children[0]);
+  auto dictionaryVector =
+      BaseVector::wrapInDictionary(nullptr, indices, size, children[0]);
   if (resultOffset == 0) {
     result = std::move(dictionaryVector);
   } else {
-    result->resize(resultOffset + numNewValues);
+    result->resize(resultOffset + size);
 
-    SelectivityVector rows(resultOffset + numNewValues, false);
-    rows.setValidRange(resultOffset, resultOffset + numNewValues, true);
+    SelectivityVector rows(resultOffset + size, false);
+    rows.setValidRange(resultOffset, resultOffset + size, true);
     rows.updateBounds();
 
     BaseVector::ensureWritable(rows, type, pool, result);
-    result->copy(dictionaryVector.get(), resultOffset, 0, numNewValues);
+    result->copy(dictionaryVector.get(), resultOffset, 0, size);
   }
 }
 
@@ -610,9 +495,7 @@ void readArrayVector(
     velox::memory::MemoryPool* pool,
     VectorPtr& result,
     vector_size_t resultOffset,
-    const SerdeOpts& opts,
-    const uint64_t* incomingNulls,
-    int32_t numIncomingNulls) {
+    bool useLosslessTimestamp) {
   ArrayVector* arrayVector = result->as<ArrayVector>();
 
   const auto resultElementsOffset = arrayVector->elements()->size();
@@ -625,39 +508,25 @@ void readArrayVector(
       childTypes,
       children,
       resultElementsOffset,
-      opts,
-      nullptr,
-      0);
+      useLosslessTimestamp);
 
-  const vector_size_t size = source->read<int32_t>();
-  const auto numNewValues = sizeWithIncomingNulls(size, numIncomingNulls);
-  arrayVector->resize(resultOffset + numNewValues);
+  vector_size_t size = source->read<int32_t>();
+  arrayVector->resize(resultOffset + size);
   arrayVector->setElements(children[0]);
 
-  BufferPtr offsets = arrayVector->mutableOffsets(resultOffset + numNewValues);
+  BufferPtr offsets = arrayVector->mutableOffsets(resultOffset + size);
   auto rawOffsets = offsets->asMutable<vector_size_t>();
-  BufferPtr sizes = arrayVector->mutableSizes(resultOffset + numNewValues);
+  BufferPtr sizes = arrayVector->mutableSizes(resultOffset + size);
   auto rawSizes = sizes->asMutable<vector_size_t>();
   int32_t base = source->read<int32_t>();
-  for (int32_t i = 0; i < numNewValues; ++i) {
-    if (incomingNulls && bits::isBitNull(incomingNulls, i)) {
-      rawOffsets[resultOffset + i] = 0;
-      rawSizes[resultOffset + i] = 0;
-      continue;
-    }
+  for (int32_t i = 0; i < size; ++i) {
     int32_t offset = source->read<int32_t>();
     rawOffsets[resultOffset + i] = resultElementsOffset + base;
     rawSizes[resultOffset + i] = offset - base;
     base = offset;
   }
 
-  readNulls(
-      source,
-      size,
-      *arrayVector,
-      resultOffset,
-      incomingNulls,
-      numIncomingNulls);
+  readNulls(source, size, *arrayVector, resultOffset);
 }
 
 void readMapVector(
@@ -666,9 +535,7 @@ void readMapVector(
     velox::memory::MemoryPool* pool,
     VectorPtr& result,
     vector_size_t resultOffset,
-    const SerdeOpts& opts,
-    const uint64_t* incomingNulls,
-    int32_t numIncomingNulls) {
+    bool useLosslessTimestamp) {
   MapVector* mapVector = result->as<MapVector>();
   const auto resultElementsOffset = mapVector->mapKeys()->size();
   std::vector<TypePtr> childTypes = {type->childAt(0), type->childAt(1)};
@@ -679,9 +546,7 @@ void readMapVector(
       childTypes,
       children,
       resultElementsOffset,
-      opts,
-      nullptr,
-      0);
+      useLosslessTimestamp);
 
   int32_t hashTableSize = source->read<int32_t>();
   if (hashTableSize != -1) {
@@ -689,31 +554,23 @@ void readMapVector(
     source->skip(hashTableSize * sizeof(int32_t));
   }
 
-  const vector_size_t size = source->read<int32_t>();
-  const vector_size_t numNewValues =
-      sizeWithIncomingNulls(size, numIncomingNulls);
-  mapVector->resize(resultOffset + numNewValues);
+  vector_size_t size = source->read<int32_t>();
+  mapVector->resize(resultOffset + size);
   mapVector->setKeysAndValues(children[0], children[1]);
 
-  BufferPtr offsets = mapVector->mutableOffsets(resultOffset + numNewValues);
+  BufferPtr offsets = mapVector->mutableOffsets(resultOffset + size);
   auto rawOffsets = offsets->asMutable<vector_size_t>();
-  BufferPtr sizes = mapVector->mutableSizes(resultOffset + numNewValues);
+  BufferPtr sizes = mapVector->mutableSizes(resultOffset + size);
   auto rawSizes = sizes->asMutable<vector_size_t>();
   int32_t base = source->read<int32_t>();
-  for (int32_t i = 0; i < numNewValues; ++i) {
-    if (incomingNulls && bits::isBitNull(incomingNulls, i)) {
-      rawOffsets[resultOffset + i] = 0;
-      rawSizes[resultOffset + i] = 0;
-      continue;
-    }
+  for (int32_t i = 0; i < size; ++i) {
     int32_t offset = source->read<int32_t>();
     rawOffsets[resultOffset + i] = resultElementsOffset + base;
     rawSizes[resultOffset + i] = offset - base;
     base = offset;
   }
 
-  readNulls(
-      source, size, *mapVector, resultOffset, incomingNulls, numIncomingNulls);
+  readNulls(source, size, *mapVector, resultOffset);
 }
 
 int64_t packTimestampWithTimeZone(int64_t timestamp, int16_t timezone) {
@@ -732,21 +589,9 @@ void readTimestampWithTimeZone(
     ByteInputStream* source,
     velox::memory::MemoryPool* pool,
     RowVector* result,
-    vector_size_t resultOffset,
-    const uint64_t* incomingNulls,
-    int32_t numIncomingNulls) {
-  SerdeOpts opts;
-  opts.useLosslessTimestamp = false;
+    vector_size_t resultOffset) {
   auto& timestamps = result->childAt(0);
-  read<int64_t>(
-      source,
-      BIGINT(),
-      pool,
-      timestamps,
-      resultOffset,
-      opts,
-      incomingNulls,
-      numIncomingNulls);
+  read<int64_t>(source, BIGINT(), pool, timestamps, resultOffset, false);
 
   auto rawTimestamps = timestamps->asFlatVector<int64_t>()->mutableRawValues();
 
@@ -769,85 +614,338 @@ void readTimestampWithTimeZone(
   }
 }
 
+template <typename T>
+void scatterValues(
+    int32_t numValues,
+    const vector_size_t* indices,
+    T* data,
+    vector_size_t offset) {
+  for (auto index = numValues - 1; index >= 0; --index) {
+    const auto destination = indices[index];
+    if (destination == offset + index) {
+      break;
+    }
+    data[destination] = data[offset + index];
+  }
+}
+
+template <TypeKind kind>
+void scatterFlatValues(
+    vector_size_t scatterSize,
+    const vector_size_t* scatter,
+    BaseVector& vector,
+    vector_size_t offset) {
+  using T = typename TypeTraits<kind>::NativeType;
+  auto* values = vector.asUnchecked<FlatVector<T>>()->mutableRawValues();
+  scatterValues(scatterSize, scatter, values, offset);
+}
+
+template <>
+void scatterFlatValues<TypeKind::BOOLEAN>(
+    vector_size_t scatterSize,
+    const vector_size_t* scatter,
+    BaseVector& vector,
+    vector_size_t offset) {
+  auto* values = const_cast<uint64_t*>(vector.values()->as<uint64_t>());
+
+  for (auto index = scatterSize - 1; index >= 0; --index) {
+    const auto destination = scatter[index];
+    if (destination == offset + index) {
+      break;
+    }
+    bits::setBit(values, destination, bits::isBitSet(values, offset + index));
+  }
+}
+
+void scatterStructNulls(
+    vector_size_t size,
+    vector_size_t scatterSize,
+    const vector_size_t* scatter,
+    const uint64_t* incomingNulls,
+    RowVector& row,
+    vector_size_t rowOffset);
+
+// Scatters existing nulls and adds 'incomingNulls' to the gaps. 'oldSize' is
+// the number of valid bits in the nulls of 'vector'. 'vector' must have been
+// resized to the new size before calling this.
+void scatterNulls(
+    vector_size_t oldSize,
+    const uint64_t* incomingNulls,
+    BaseVector& vector) {
+  const bool hasNulls = vector.mayHaveNulls();
+  const auto size = vector.size();
+
+  if (hasNulls) {
+    auto bits = reinterpret_cast<char*>(vector.mutableRawNulls());
+    bits::scatterBits(oldSize, size, bits, incomingNulls, bits);
+  } else {
+    memcpy(vector.mutableRawNulls(), incomingNulls, bits::nbytes(size));
+  }
+}
+
+// Scatters all rows in 'vector' starting from 'offset'. All these rows are
+// expected to be non-null before this call. vector[offset + i] is copied into
+// vector[offset + scatter[i]] for all i in [0, scatterSize). The gaps are
+// filled with nulls. scatter[i] >= i for all i. scatter[i] >= scatter[j] for
+// all i and j.
+//
+// @param size Size of the 'vector' after scatter. Includes trailing nulls.
+// @param scatterSize Number of rows to scatter, starting from 'offset'.
+// @param scatter Destination row numbers. A total of 'scatterSize' entries.
+// @param incomingNulls A bitmap representation of the 'scatter' covering 'size'
+// rows. First 'offset' bits should be kNotNull.
+// @param vector Vector to modify.
+// @param offset First row to scatter.
+void scatterVector(
+    int32_t size,
+    vector_size_t scatterSize,
+    const vector_size_t* scatter,
+    const uint64_t* incomingNulls,
+    VectorPtr& vector,
+    vector_size_t offset) {
+  const auto oldSize = vector->size();
+  if (scatter != nullptr && scatterSize > 0) {
+    // 'scatter' should have an entry for every row in 'vector' starting from
+    // 'offset'.
+    VELOX_CHECK_EQ(vector->size(), scatterSize + offset);
+
+    // The new vector size should cover all 'scatter' destinations and
+    // trailing nulls.
+    VELOX_CHECK_GE(size, scatter[scatterSize - 1] + 1);
+  }
+
+  if (vector->encoding() == VectorEncoding::Simple::ROW) {
+    vector->asUnchecked<RowVector>()->unsafeResize(size);
+  } else {
+    vector->resize(size);
+  }
+
+  switch (vector->encoding()) {
+    case VectorEncoding::Simple::DICTIONARY: {
+      VELOX_CHECK_EQ(0, offset, "Result offset is not supported yet")
+      if (incomingNulls) {
+        auto dictIndices =
+            const_cast<vector_size_t*>(vector->wrapInfo()->as<vector_size_t>());
+        scatterValues(scatterSize, scatter, dictIndices, 0);
+        scatterNulls(oldSize, incomingNulls, *vector);
+      }
+      auto values = vector->valueVector();
+      scatterVector(values->size(), 0, nullptr, nullptr, values, 0);
+      break;
+    }
+    case VectorEncoding::Simple::CONSTANT: {
+      VELOX_CHECK_EQ(0, offset, "Result offset is not supported yet")
+      auto values = vector->valueVector();
+      if (values) {
+        scatterVector(values->size(), 0, nullptr, nullptr, values, 0);
+      }
+
+      if (incomingNulls) {
+        BaseVector::ensureWritable(
+            SelectivityVector::empty(), vector->type(), vector->pool(), vector);
+        scatterNulls(oldSize, incomingNulls, *vector);
+      }
+      break;
+    }
+    case VectorEncoding::Simple::ARRAY: {
+      auto* array = vector->asUnchecked<ArrayVector>();
+      if (incomingNulls) {
+        auto offsets = const_cast<vector_size_t*>(array->rawOffsets());
+        auto sizes = const_cast<vector_size_t*>(array->rawSizes());
+        scatterValues(scatterSize, scatter, offsets, offset);
+        scatterValues(scatterSize, scatter, sizes, offset);
+        scatterNulls(oldSize, incomingNulls, *vector);
+      }
+      // Find the offset from which 'new' array elements start assuming that
+      // array elements are written in order.
+      vector_size_t elementOffset = 0;
+      for (auto i = offset - 1; i >= 0; --i) {
+        if (!array->isNullAt(i)) {
+          elementOffset = array->offsetAt(i) + array->sizeAt(i);
+          break;
+        }
+      }
+      auto elements = array->elements();
+      scatterVector(
+          elements->size(), 0, nullptr, nullptr, elements, elementOffset);
+      break;
+    }
+    case VectorEncoding::Simple::MAP: {
+      auto* map = vector->asUnchecked<MapVector>();
+      if (incomingNulls) {
+        auto offsets = const_cast<vector_size_t*>(map->rawOffsets());
+        auto sizes = const_cast<vector_size_t*>(map->rawSizes());
+        scatterValues(scatterSize, scatter, offsets, offset);
+        scatterValues(scatterSize, scatter, sizes, offset);
+        scatterNulls(oldSize, incomingNulls, *vector);
+      }
+      // Find out the offset from which 'new' map keys and values start assuming
+      // that map elements are written in order.
+      vector_size_t elementOffset = 0;
+      for (auto i = offset - 1; i >= 0; --i) {
+        if (!map->isNullAt(i)) {
+          elementOffset = map->offsetAt(i) + map->sizeAt(i);
+          break;
+        }
+      }
+      auto keys = map->mapKeys();
+      scatterVector(keys->size(), 0, nullptr, nullptr, keys, elementOffset);
+      auto values = map->mapValues();
+      scatterVector(values->size(), 0, nullptr, nullptr, values, elementOffset);
+      break;
+    }
+    case VectorEncoding::Simple::ROW: {
+      auto* row = vector->asUnchecked<RowVector>();
+      scatterStructNulls(row->size(), 0, nullptr, nullptr, *row, offset);
+      break;
+    }
+    case VectorEncoding::Simple::FLAT: {
+      if (incomingNulls) {
+        VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
+            scatterFlatValues,
+            vector->typeKind(),
+            scatterSize,
+            scatter,
+            *vector,
+            offset);
+        scatterNulls(oldSize, incomingNulls, *vector);
+      }
+      break;
+    }
+    default:
+      VELOX_FAIL("Unsupported encoding in scatter: {}", vector->encoding());
+  }
+}
+
+// A RowVector with nulls is serialized with children having a value
+// only for rows where the struct is non-null. After deserializing,
+// we do an extra traversal to add gaps into struct members where
+// the containing struct is null. As we go down the struct tree, we
+// merge child struct nulls into the nulls from enclosing structs so
+// that the leaves only get scattered once, considering all nulls
+// from all enclosing structs.
+void scatterStructNulls(
+    vector_size_t size,
+    vector_size_t scatterSize,
+    const vector_size_t* scatter,
+    const uint64_t* incomingNulls,
+    RowVector& row,
+    vector_size_t rowOffset) {
+  const auto oldSize = row.size();
+  if (isTimestampWithTimeZoneType(row.type())) {
+    // The timestamp with tz case is special. The child vectors are aligned with
+    // the struct even if the struct has nulls.
+    if (incomingNulls) {
+      scatterVector(
+          size, scatterSize, scatter, incomingNulls, row.childAt(0), rowOffset);
+      scatterVector(
+          size, scatterSize, scatter, incomingNulls, row.childAt(1), rowOffset);
+      row.unsafeResize(size);
+      scatterNulls(oldSize, incomingNulls, row);
+    }
+    return;
+  }
+
+  const uint64_t* childIncomingNulls = incomingNulls;
+  const vector_size_t* childScatter = scatter;
+  auto childScatterSize = scatterSize;
+  raw_vector<vector_size_t> innerScatter;
+  raw_vector<uint64_t> childIncomingNullsVector;
+  if (auto* rawNulls = row.rawNulls()) {
+    innerScatter.resize(size);
+    if (!incomingNulls) {
+      childIncomingNulls = rawNulls;
+      if (rowOffset > 0) {
+        childIncomingNullsVector.resize(bits::nwords(size));
+        auto newNulls = childIncomingNullsVector.data();
+        memcpy(newNulls, rawNulls, bits::nbytes(size));
+
+        // Fill in first 'rowOffset' bits with kNotNull to avoid scattering
+        // nulls for pre-existing rows.
+        bits::fillBits(newNulls, 0, rowOffset, bits::kNotNull);
+        childIncomingNulls = newNulls;
+      }
+      childScatterSize = simd::indicesOfSetBits(
+          rawNulls, rowOffset, size, innerScatter.data());
+    } else {
+      childIncomingNullsVector.resize(bits::nwords(size));
+      auto newNulls = childIncomingNullsVector.data();
+      bits::scatterBits(
+          row.size(),
+          size,
+          reinterpret_cast<const char*>(rawNulls),
+          incomingNulls,
+          reinterpret_cast<char*>(newNulls));
+
+      // Fill in first 'rowOffset' bits with kNotNull to avoid scattering
+      // nulls for pre-existing rows.
+      bits::fillBits(newNulls, 0, rowOffset, bits::kNotNull);
+      childIncomingNulls = newNulls;
+      childScatterSize = simd::indicesOfSetBits(
+          childIncomingNulls, rowOffset, size, innerScatter.data());
+    }
+    childScatter = innerScatter.data();
+  }
+  for (auto i = 0; i < row.childrenSize(); ++i) {
+    auto& child = row.childAt(i);
+    if (child->encoding() == VectorEncoding::Simple::ROW) {
+      scatterStructNulls(
+          size,
+          childScatterSize,
+          childScatter,
+          childIncomingNulls,
+          *child->asUnchecked<RowVector>(),
+          rowOffset);
+    } else {
+      scatterVector(
+          size,
+          childScatterSize,
+          childScatter,
+          childIncomingNulls,
+          row.childAt(i),
+          rowOffset);
+    }
+  }
+  if (incomingNulls) {
+    row.unsafeResize(size);
+    scatterNulls(oldSize, incomingNulls, row);
+  }
+  // On return of scatter we check that child sizes match the struct size. This
+  // is safe also if no scatter.
+  for (auto i = 0; i < row.childrenSize(); ++i) {
+    VELOX_CHECK_EQ(row.childAt(i)->size(), row.size());
+  }
+}
+
 void readRowVector(
     ByteInputStream* source,
     const TypePtr& type,
     velox::memory::MemoryPool* pool,
     VectorPtr& result,
     vector_size_t resultOffset,
-    const SerdeOpts& opts,
-    const uint64_t* incomingNulls,
-    int32_t numIncomingNulls) {
+    bool useLosslessTimestamp) {
   auto* row = result->as<RowVector>();
   if (isTimestampWithTimeZoneType(type)) {
-    readTimestampWithTimeZone(
-        source, pool, row, resultOffset, incomingNulls, numIncomingNulls);
+    readTimestampWithTimeZone(source, pool, row, resultOffset);
     return;
   }
-  BufferPtr combinedNulls;
-  const uint64_t* childNulls = incomingNulls;
-  int32_t numChildNulls = numIncomingNulls;
-  if (opts.nullsFirst) {
-    const auto size = source->read<int32_t>();
-    const auto numNewValues = sizeWithIncomingNulls(size, numIncomingNulls);
-    row->resize(resultOffset + numNewValues);
-    readNulls(
-        source, size, *result, resultOffset, incomingNulls, numIncomingNulls);
-    if (row->rawNulls()) {
-      combinedNulls = AlignedBuffer::allocate<bool>(numNewValues, pool);
-      bits::copyBits(
-          row->rawNulls(),
-          resultOffset,
-          combinedNulls->asMutable<uint64_t>(),
-          0,
-          numNewValues);
-      childNulls = combinedNulls->as<uint64_t>();
-      numChildNulls = numNewValues;
-    }
-  } else {
-    auto [structNulls, numStructNulls] = getStructNulls(source->tellp());
-    // childNulls is the nulls added to the children, i.e. the nulls of this
-    // struct combined with nulls of enclosing structs.
-    if (structNulls) {
-      if (incomingNulls) {
-        combinedNulls = AlignedBuffer::allocate<bool>(numIncomingNulls, pool);
-        bits::scatterBits(
-            numStructNulls,
-            numIncomingNulls,
-            reinterpret_cast<const char*>(structNulls),
-            incomingNulls,
-            combinedNulls->asMutable<char>());
-        childNulls = combinedNulls->as<uint64_t>();
-        numChildNulls = numIncomingNulls;
-      } else {
-        childNulls = structNulls;
-        numChildNulls = numStructNulls;
-      }
-    }
-  }
+
   const int32_t numChildren = source->read<int32_t>();
   auto& children = row->children();
 
   const auto& childTypes = type->asRow().children();
   readColumns(
-      source,
-      pool,
-      childTypes,
-      children,
-      resultOffset,
-      opts,
-      childNulls,
-      numChildNulls);
-  if (!opts.nullsFirst) {
-    const auto size = source->read<int32_t>();
-    const auto numNewValues = sizeWithIncomingNulls(size, numIncomingNulls);
-    row->resize(resultOffset + numNewValues);
-    // Read and discard the offsets. The number of offsets is not affected by
-    // incomingNulls.
-    source->skip((size + 1) * sizeof(int32_t));
-    readNulls(
-        source, size, *result, resultOffset, incomingNulls, numIncomingNulls);
+      source, pool, childTypes, children, resultOffset, useLosslessTimestamp);
+
+  auto size = source->read<int32_t>();
+  // Set the size of the row but do not alter the size of the
+  // children. The children get adjusted in a separate pass over the
+  // data. The parent and child size MUST be separate until the second pass.
+  row->BaseVector::resize(resultOffset + size);
+  for (int32_t i = 0; i <= size; ++i) {
+    source->read<int32_t>();
   }
+  readNulls(source, size, *result, resultOffset);
 }
 
 std::string readLengthPrefixedString(ByteInputStream* source) {
@@ -874,9 +972,7 @@ void readColumns(
     const std::vector<TypePtr>& types,
     std::vector<VectorPtr>& results,
     vector_size_t resultOffset,
-    const SerdeOpts& opts,
-    const uint64_t* incomingNulls,
-    int32_t numIncomingNulls) {
+    bool useLosslessTimestamp) {
   static const std::unordered_map<
       TypeKind,
       std::function<void(
@@ -885,9 +981,7 @@ void readColumns(
           velox::memory::MemoryPool* pool,
           VectorPtr& result,
           vector_size_t resultOffset,
-          const SerdeOpts& opts,
-          const uint64_t* incomingNulls,
-          int32_t numIncomingNulls)>>
+          bool useLosslessTimestamp)>>
       readers = {
           {TypeKind::BOOLEAN, &read<bool>},
           {TypeKind::TINYINT, &read<int8_t>},
@@ -919,9 +1013,7 @@ void readColumns(
           pool,
           columnResult,
           resultOffset,
-          opts,
-          incomingNulls,
-          numIncomingNulls);
+          useLosslessTimestamp);
     } else if (encoding == kDictionary) {
       readDictionaryVector(
           source,
@@ -929,9 +1021,7 @@ void readColumns(
           pool,
           columnResult,
           resultOffset,
-          opts,
-          incomingNulls,
-          numIncomingNulls);
+          useLosslessTimestamp);
     } else {
       checkTypeEncoding(encoding, columnType);
       const auto it = readers.find(columnType->kind());
@@ -946,214 +1036,7 @@ void readColumns(
           pool,
           columnResult,
           resultOffset,
-          opts,
-          incomingNulls,
-          numIncomingNulls);
-    }
-  }
-}
-
-// Reads nulls into 'scratch' and returns count of non-nulls. If 'copy' is
-// given, returns the null bits in 'copy'.
-vector_size_t valueCount(
-    ByteInputStream* source,
-    vector_size_t size,
-    Scratch& scratch,
-    std::vector<uint64_t>* copy = nullptr) {
-  if (source->readByte() == 0) {
-    return size;
-  }
-  ScratchPtr<uint64_t, 16> nullsHolder(scratch);
-  auto rawNulls = nullsHolder.get(bits::nwords(size));
-  auto numBytes = bits::nbytes(size);
-  source->readBytes(rawNulls, numBytes);
-  bits::reverseBits(reinterpret_cast<uint8_t*>(rawNulls), numBytes);
-  bits::negate(reinterpret_cast<char*>(rawNulls), numBytes * 8);
-  if (copy) {
-    copy->resize(bits::nwords(size));
-    memcpy(copy->data(), rawNulls, numBytes);
-  }
-  return bits::countBits(rawNulls, 0, size);
-}
-
-template <typename T>
-void readStructNulls(
-    ByteInputStream* source,
-    const TypePtr& type,
-    bool useLosslessTimestamp,
-    Scratch& scratch) {
-  const int32_t size = source->read<int32_t>();
-  auto numValues = valueCount(source, size, scratch);
-
-  if constexpr (std::is_same_v<T, Timestamp>) {
-    source->skip(
-        numValues *
-        (useLosslessTimestamp ? sizeof(Timestamp) : sizeof(uint64_t)));
-    return;
-  }
-  source->skip(numValues * sizeof(T));
-}
-
-template <>
-void readStructNulls<StringView>(
-    ByteInputStream* source,
-    const TypePtr& type,
-    bool /*useLosslessTimestamp*/,
-    Scratch& scratch) {
-  const int32_t size = source->read<int32_t>();
-  source->skip(size * sizeof(int32_t));
-  valueCount(source, size, scratch);
-  const int32_t dataSize = source->read<int32_t>();
-  source->skip(dataSize);
-}
-
-void readStructNullsColumns(
-    ByteInputStream* source,
-    const std::vector<TypePtr>& types,
-    bool useLoasslessTimestamp,
-    Scratch& scratch);
-
-void readConstantVectorStructNulls(
-    ByteInputStream* source,
-    const TypePtr& type,
-    bool useLosslessTimestamp,
-    Scratch& scratch) {
-  const auto size = source->read<int32_t>();
-  std::vector<TypePtr> childTypes = {type};
-  readStructNullsColumns(source, childTypes, useLosslessTimestamp, scratch);
-}
-
-void readDictionaryVectorStructNulls(
-    ByteInputStream* source,
-    const TypePtr& type,
-    bool useLosslessTimestamp,
-    Scratch& scratch) {
-  const auto size = source->read<int32_t>();
-  std::vector<TypePtr> childTypes = {type};
-  readStructNullsColumns(source, childTypes, useLosslessTimestamp, scratch);
-
-  // Skip indices.
-  source->skip(sizeof(int32_t) * size);
-
-  // Skip 3 * 8 bytes of 'instance id'. Velox doesn't use 'instance id' for
-  // dictionary vectors.
-  source->skip(24);
-}
-
-void readArrayVectorStructNulls(
-    ByteInputStream* source,
-    const TypePtr& type,
-    bool useLosslessTimestamp,
-    Scratch& scratch) {
-  std::vector<TypePtr> childTypes = {type->childAt(0)};
-  readStructNullsColumns(source, childTypes, useLosslessTimestamp, scratch);
-
-  const vector_size_t size = source->read<int32_t>();
-
-  source->skip((size + 1) * sizeof(int32_t));
-  valueCount(source, size, scratch);
-}
-
-void readMapVectorStructNulls(
-    ByteInputStream* source,
-    const TypePtr& type,
-    bool useLosslessTimestamp,
-    Scratch& scratch) {
-  std::vector<TypePtr> childTypes = {type->childAt(0), type->childAt(1)};
-  readStructNullsColumns(source, childTypes, useLosslessTimestamp, scratch);
-
-  int32_t hashTableSize = source->read<int32_t>();
-  if (hashTableSize != -1) {
-    // Skip over serialized hash table from Presto wire format.
-    source->skip(hashTableSize * sizeof(int32_t));
-  }
-
-  const vector_size_t size = source->read<int32_t>();
-
-  source->skip((1 + size) * sizeof(int32_t));
-  valueCount(source, size, scratch);
-}
-
-void readTimestampWithTimeZoneStructNulls(
-    ByteInputStream* source,
-    Scratch& scratch) {
-  readStructNulls<int64_t>(source, BIGINT(), false, scratch);
-}
-
-void readRowVectorStructNulls(
-    ByteInputStream* source,
-    const TypePtr& type,
-    bool useLosslessTimestamp,
-    Scratch& scratch) {
-  if (isTimestampWithTimeZoneType(type)) {
-    readTimestampWithTimeZoneStructNulls(source, scratch);
-    return;
-  }
-  auto streamPos = source->tellp();
-  const int32_t numChildren = source->read<int32_t>();
-  const auto& childTypes = type->asRow().children();
-  readStructNullsColumns(source, childTypes, useLosslessTimestamp, scratch);
-
-  const auto size = source->read<int32_t>();
-  // Read and discard the offsets. The number of offsets is not affected by
-  // nulls.
-  source->skip((size + 1) * sizeof(int32_t));
-  std::vector<uint64_t> nullsCopy;
-  auto numNonNull = valueCount(source, size, scratch, &nullsCopy);
-  if (size != numNonNull) {
-    (*structNullsMap())[streamPos] =
-        std::pair<std::vector<uint64_t>, int32_t>(std::move(nullsCopy), size);
-  }
-}
-
-void readStructNullsColumns(
-    ByteInputStream* source,
-    const std::vector<TypePtr>& types,
-    bool useLosslessTimestamp,
-    Scratch& scratch) {
-  static const std::unordered_map<
-      TypeKind,
-      std::function<void(
-          ByteInputStream * source,
-          const TypePtr& type,
-          bool useLosslessTimestamp,
-          Scratch& scratch)>>
-      readers = {
-          {TypeKind::BOOLEAN, &readStructNulls<bool>},
-          {TypeKind::TINYINT, &readStructNulls<int8_t>},
-          {TypeKind::SMALLINT, &readStructNulls<int16_t>},
-          {TypeKind::INTEGER, &readStructNulls<int32_t>},
-          {TypeKind::BIGINT, &readStructNulls<int64_t>},
-          {TypeKind::HUGEINT, &readStructNulls<int128_t>},
-          {TypeKind::REAL, &readStructNulls<float>},
-          {TypeKind::DOUBLE, &readStructNulls<double>},
-          {TypeKind::TIMESTAMP, &readStructNulls<Timestamp>},
-          {TypeKind::VARCHAR, &readStructNulls<StringView>},
-          {TypeKind::VARBINARY, &readStructNulls<StringView>},
-          {TypeKind::ARRAY, &readArrayVectorStructNulls},
-          {TypeKind::MAP, &readMapVectorStructNulls},
-          {TypeKind::ROW, &readRowVectorStructNulls},
-          {TypeKind::UNKNOWN, &readStructNulls<UnknownValue>}};
-
-  for (int32_t i = 0; i < types.size(); ++i) {
-    const auto& columnType = types[i];
-
-    const auto encoding = readLengthPrefixedString(source);
-    if (encoding == kRLE) {
-      readConstantVectorStructNulls(
-          source, columnType, useLosslessTimestamp, scratch);
-    } else if (encoding == kDictionary) {
-      readDictionaryVectorStructNulls(
-          source, columnType, useLosslessTimestamp, scratch);
-    } else {
-      checkTypeEncoding(encoding, columnType);
-      const auto it = readers.find(columnType->kind());
-      VELOX_CHECK(
-          it != readers.end(),
-          "Column reader for type {} is missing",
-          columnType->kindName());
-
-      it->second(source, columnType, useLosslessTimestamp, scratch);
+          useLosslessTimestamp);
     }
   }
 }
@@ -1210,11 +1093,10 @@ class VectorStream {
       std::optional<VectorEncoding::Simple> encoding,
       StreamArena* streamArena,
       int32_t initialNumRows,
-      const SerdeOpts& opts)
+      bool useLosslessTimestamp)
       : type_(type),
         encoding_{encoding},
-        useLosslessTimestamp_(opts.useLosslessTimestamp),
-        nullsFirst_(opts.nullsFirst),
+        useLosslessTimestamp_(useLosslessTimestamp),
         nulls_(streamArena, true, true),
         lengths_(streamArena),
         values_(streamArena),
@@ -1229,14 +1111,22 @@ class VectorStream {
         case VectorEncoding::Simple::CONSTANT: {
           initializeHeader(kRLE, *streamArena);
           children_.emplace_back(std::make_unique<VectorStream>(
-              type_, std::nullopt, streamArena, initialNumRows, opts));
+              type_,
+              std::nullopt,
+              streamArena,
+              initialNumRows,
+              useLosslessTimestamp));
           return;
         }
         case VectorEncoding::Simple::DICTIONARY: {
           initializeHeader(kDictionary, *streamArena);
           values_.startWrite(initialNumRows * 4);
           children_.emplace_back(std::make_unique<VectorStream>(
-              type_, std::nullopt, streamArena, initialNumRows, opts));
+              type_,
+              std::nullopt,
+              streamArena,
+              initialNumRows,
+              useLosslessTimestamp));
           return;
         }
         default:;
@@ -1265,7 +1155,7 @@ class VectorStream {
               std::nullopt,
               streamArena,
               initialNumRows,
-              opts);
+              useLosslessTimestamp);
         }
         // The first element in the offsets in the wire format is always 0 for
         // nested types.
@@ -1445,19 +1335,13 @@ class VectorStream {
           return;
         }
 
-        if (nullsFirst_) {
-          writeInt32(out, nullCount_ + nonNullCount_);
-          flushNulls(out);
-        }
         writeInt32(out, children_.size());
         for (auto& child : children_) {
           child->flush(out);
         }
-        if (!nullsFirst_) {
-          writeInt32(out, nullCount_ + nonNullCount_);
-          lengths_.flush(out);
-          flushNulls(out);
-        }
+        writeInt32(out, nullCount_ + nonNullCount_);
+        lengths_.flush(out);
+        flushNulls(out);
         return;
 
       case TypeKind::ARRAY:
@@ -1517,7 +1401,6 @@ class VectorStream {
   /// If false, they are serialized with millisecond precision which is
   /// compatible with presto.
   const bool useLosslessTimestamp_;
-  const bool nullsFirst_;
   int32_t nonNullCount_{0};
   int32_t nullCount_{0};
   int32_t totalLength_{0};
@@ -3135,9 +3018,10 @@ class PrestoVectorSerializer : public VectorSerializer {
       std::vector<VectorEncoding::Simple> encodings,
       int32_t numRows,
       StreamArena* streamArena,
-      const SerdeOpts& opts)
+      bool useLosslessTimestamp,
+      common::CompressionKind compressionKind)
       : streamArena_(streamArena),
-        codec_(common::compressionKindToCodec(opts.compressionKind)) {
+        codec_(common::compressionKindToCodec(compressionKind)) {
     auto types = rowType->children();
     auto numTypes = types.size();
     streams_.resize(numTypes);
@@ -3147,7 +3031,7 @@ class PrestoVectorSerializer : public VectorSerializer {
         encoding = encodings[i];
       }
       streams_[i] = std::make_unique<VectorStream>(
-          types[i], encoding, streamArena, numRows, opts);
+          types[i], encoding, streamArena, numRows, useLosslessTimestamp);
     }
   }
 
@@ -3381,7 +3265,12 @@ std::unique_ptr<VectorSerializer> PrestoVectorSerde::createSerializer(
     const Options* options) {
   auto prestoOptions = toPrestoOptions(options);
   return std::make_unique<PrestoVectorSerializer>(
-      type, prestoOptions.encodings, numRows, streamArena, prestoOptions);
+      type,
+      prestoOptions.encodings,
+      numRows,
+      streamArena,
+      prestoOptions.useLosslessTimestamp,
+      prestoOptions.compressionKind);
 }
 
 void PrestoVectorSerde::serializeEncoded(
@@ -3395,61 +3284,6 @@ void PrestoVectorSerde::serializeEncoded(
   static_cast<PrestoVectorSerializer*>(serializer.get())
       ->flushEncoded(vector, out);
 }
-
-namespace {
-bool hasNestedStructs(const TypePtr& type) {
-  if (type->isRow()) {
-    return true;
-  }
-  if (type->isArray()) {
-    return hasNestedStructs(type->childAt(0));
-  }
-  if (type->isMap()) {
-    return hasNestedStructs(type->childAt(0)) ||
-        hasNestedStructs(type->childAt(1));
-  }
-  return false;
-}
-
-bool hasNestedStructs(const std::vector<TypePtr>& types) {
-  for (auto& child : types) {
-    if (hasNestedStructs(child)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-void readTopColumns(
-    ByteInputStream& source,
-    const RowTypePtr& type,
-    velox::memory::MemoryPool* pool,
-    const RowVectorPtr& result,
-    int32_t resultOffset,
-    const SerdeOpts& opts) {
-  auto& children = result->children();
-  const auto& childTypes = type->asRow().children();
-  const auto numColumns = source.read<int32_t>();
-  VELOX_USER_CHECK_EQ(
-      numColumns,
-      type->size(),
-      "Number of columns in serialized data doesn't match "
-      "number of columns requested for deserialization");
-
-  auto guard = folly::makeGuard([&]() { structNullsMap().reset(); });
-
-  if (!opts.nullsFirst && hasNestedStructs(childTypes)) {
-    structNullsMap() = std::make_unique<StructNullsMap>();
-    Scratch scratch;
-    auto position = source.tellp();
-    readStructNullsColumns(
-        &source, childTypes, opts.useLosslessTimestamp, scratch);
-    source.seekp(position);
-  }
-  readColumns(
-      &source, pool, childTypes, children, resultOffset, opts, nullptr, 0);
-}
-} // namespace
 
 void PrestoVectorSerde::deserialize(
     ByteInputStream* source,
@@ -3501,8 +3335,18 @@ void PrestoVectorSerde::deserialize(
       common::compressionKindToString(
           common::codecTypeToCompressionKind(codec->type())));
 
+  auto& children = (*result)->children();
+  const auto& childTypes = type->asRow().children();
   if (!needCompression(*codec)) {
-    readTopColumns(*source, type, pool, *result, resultOffset, prestoOptions);
+    const auto numColumns = source->read<int32_t>();
+    // TODO Fix call sites and tighten the check to _EQ.
+    VELOX_USER_CHECK_GE(
+        numColumns,
+        type->size(),
+        "Number of columns in serialized data doesn't match "
+        "number of columns requested for deserialization");
+    readColumns(
+        source, pool, childTypes, children, resultOffset, useLosslessTimestamp);
   } else {
     auto compressBuf = folly::IOBuf::create(compressedSize);
     source->readBytes(compressBuf->writableData(), compressedSize);
@@ -3512,9 +3356,33 @@ void PrestoVectorSerde::deserialize(
         uncompress->writableData(), (int32_t)uncompress->length(), 0};
     ByteInputStream uncompressedSource({byteRange});
 
-    readTopColumns(
-        uncompressedSource, type, pool, *result, resultOffset, prestoOptions);
+    const auto numColumns = uncompressedSource.read<int32_t>();
+    VELOX_USER_CHECK_EQ(
+        numColumns,
+        type->size(),
+        "Number of columns in serialized data doesn't match "
+        "number of columns requested for deserialization");
+    readColumns(
+        &uncompressedSource,
+        pool,
+        childTypes,
+        children,
+        resultOffset,
+        useLosslessTimestamp);
   }
+
+  scatterStructNulls(
+      (*result)->size(), 0, nullptr, nullptr, **result, resultOffset);
+}
+
+void testingScatterStructNulls(
+    vector_size_t size,
+    vector_size_t scatterSize,
+    const vector_size_t* scatter,
+    const uint64_t* incomingNulls,
+    RowVector& row,
+    vector_size_t rowOffset) {
+  scatterStructNulls(size, scatterSize, scatter, incomingNulls, row, rowOffset);
 }
 
 // static

--- a/velox/serializers/PrestoSerializer.h
+++ b/velox/serializers/PrestoSerializer.h
@@ -29,26 +29,18 @@ class PrestoVectorSerde : public VectorSerde {
 
     PrestoOptions(
         bool _useLosslessTimestamp,
-        common::CompressionKind _compressionKind,
-        bool nullsFirst = false)
+        common::CompressionKind _compressionKind)
         : useLosslessTimestamp(_useLosslessTimestamp),
-          compressionKind(_compressionKind),
-          nullsFirst(nullsFirst) {}
+          compressionKind(_compressionKind) {}
 
     // Currently presto only supports millisecond precision and the serializer
     // converts velox native timestamp to that resulting in loss of precision.
     // This option allows it to serialize with nanosecond precision and is
     // currently used for spilling. Is false by default.
     bool useLosslessTimestamp{false};
-
     common::CompressionKind compressionKind{
         common::CompressionKind::CompressionKind_NONE};
     std::vector<VectorEncoding::Simple> encodings;
-
-    /// Serializes nulls of structs before the columns. Used to allow
-    /// single pass reading of in spilling. TODO: Make Presto also
-    /// serialize nulls before columns of structs.
-    bool nullsFirst{false};
   };
 
   /// Adds the serialized sizes of the rows of 'vector' in 'ranges[i]' to
@@ -105,6 +97,15 @@ class PrestoVectorSerde : public VectorSerde {
 
   static void registerVectorSerde();
 };
+
+// Testing function for nested encodings. See comments in scatterStructNulls().
+void testingScatterStructNulls(
+    vector_size_t size,
+    vector_size_t scatterSize,
+    const vector_size_t* scatter,
+    const uint64_t* incomingNulls,
+    RowVector& row,
+    vector_size_t rowOffset);
 
 class PrestoOutputStreamListener : public OutputStreamListener {
  public:

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -67,11 +67,8 @@ class PrestoSerializerTest
     const bool useLosslessTimestamp =
         serdeOptions == nullptr ? false : serdeOptions->useLosslessTimestamp;
     common::CompressionKind kind = GetParam();
-    const bool nullsFirst =
-        serdeOptions == nullptr ? false : serdeOptions->nullsFirst;
     serializer::presto::PrestoVectorSerde::PrestoOptions paramOptions{
-        useLosslessTimestamp, kind, nullsFirst};
-
+        useLosslessTimestamp, kind};
     return paramOptions;
   }
 
@@ -117,7 +114,7 @@ class PrestoSerializerTest
     }
     auto size = serializer->maxSerializedSize();
     LOG(INFO) << "Size=" << size << " estimate=" << sizeEstimate << " "
-              << (100L * sizeEstimate) / (1 + size) << "%";
+              << (100 * sizeEstimate) / size << "%";
     facebook::velox::serializer::presto::PrestoOutputStreamListener listener;
     OStreamOutputStream out(output, &listener);
     serializer->flush(&out);
@@ -501,6 +498,56 @@ TEST_P(PrestoSerializerTest, encodings) {
   testEncodedRoundTrip(data);
 }
 
+TEST_P(PrestoSerializerTest, scatterEncoded) {
+  // Makes a struct with nulls and constant/dictionary encoded children. The
+  // children need to get gaps where the parent struct has a null.
+  VectorFuzzer::Options opts;
+  opts.timestampPrecision =
+      VectorFuzzer::Options::TimestampPrecision::kMilliSeconds;
+  opts.nullRatio = 0.1;
+  VectorFuzzer fuzzer(opts, pool_.get());
+
+  auto rowType = ROW(
+      {{"inner",
+        ROW(
+            {{"i1", BIGINT()},
+             {"i2", VARCHAR()},
+             {"i3", ARRAY(INTEGER())},
+             {"i4", ROW({{"ii1", BIGINT()}})}})}});
+  auto row = fuzzer.fuzzInputRow(rowType);
+  auto inner =
+      const_cast<RowVector*>(row->childAt(0)->wrappedVector()->as<RowVector>());
+  if (!inner->mayHaveNulls()) {
+    return;
+  }
+  auto numNulls = BaseVector::countNulls(inner->nulls(), 0, inner->size());
+  auto numNonNull = inner->size() - numNulls;
+  auto indices = makeIndices(numNonNull, [](auto row) { return row; });
+
+  inner->children()[0] = BaseVector::createConstant(
+      BIGINT(),
+      variant::create<TypeKind::BIGINT>(11L),
+      numNonNull,
+      pool_.get());
+  inner->children()[1] = BaseVector::wrapInDictionary(
+      BufferPtr(nullptr), indices, numNonNull, inner->childAt(1));
+  inner->children()[2] =
+      BaseVector::wrapInConstant(numNonNull, 3, inner->childAt(2));
+
+  // i4 is a struct that we wrap in constant. We make ths struct like it was
+  // read from seriailization, needing scatter for struct nulls.
+  auto i4 = const_cast<RowVector*>(
+      inner->childAt(3)->wrappedVector()->as<RowVector>());
+  auto i4NonNull = i4->mayHaveNulls()
+      ? i4->size() - BaseVector::countNulls(i4->nulls(), 0, i4->size())
+      : i4->size();
+  i4->childAt(0)->resize(i4NonNull);
+  inner->children()[3] =
+      BaseVector::wrapInConstant(numNonNull, 3, inner->childAt(3));
+  serializer::presto::testingScatterStructNulls(
+      row->size(), row->size(), nullptr, nullptr, *row, 0);
+}
+
 TEST_P(PrestoSerializerTest, lazy) {
   constexpr int kSize = 1000;
   auto rowVector = makeTestVector(kSize);
@@ -519,7 +566,7 @@ TEST_P(PrestoSerializerTest, ioBufRoundTrip) {
   opts.nullRatio = 0.1;
   VectorFuzzer fuzzer(opts, pool_.get());
 
-  const size_t numRounds = 100;
+  const size_t numRounds = 20;
 
   for (size_t i = 0; i < numRounds; ++i) {
     auto rowType = fuzzer.randRowType();
@@ -543,33 +590,14 @@ TEST_P(PrestoSerializerTest, roundTrip) {
   nonNullOpts.nullRatio = 0;
   VectorFuzzer nonNullFuzzer(nonNullOpts, pool_.get());
 
-  const size_t numRounds = 100;
+  const size_t numRounds = 20;
 
   for (size_t i = 0; i < numRounds; ++i) {
     auto rowType = fuzzer.randRowType();
+
     auto inputRowVector = (i % 2 == 0) ? fuzzer.fuzzInputRow(rowType)
                                        : nonNullFuzzer.fuzzInputRow(rowType);
-    serializer::presto::PrestoVectorSerde::PrestoOptions prestoOpts;
-    // Test every 2/4 with struct nulls first.
-    prestoOpts.nullsFirst = i % 4 < 2;
-    testRoundTrip(inputRowVector, &prestoOpts);
-  }
-}
-
-TEST_P(PrestoSerializerTest, encodedRoundtrip) {
-  VectorFuzzer::Options opts;
-  opts.timestampPrecision =
-      VectorFuzzer::Options::TimestampPrecision::kMilliSeconds;
-  opts.nullRatio = 0.1;
-  opts.dictionaryHasNulls = false;
-  VectorFuzzer fuzzer(opts, pool_.get());
-
-  const size_t numRounds = 200;
-
-  for (size_t i = 0; i < numRounds; ++i) {
-    auto rowType = fuzzer.randRowType();
-    auto inputRowVector = fuzzer.fuzzInputRow(rowType);
-    testEncodedRoundTrip(inputRowVector);
+    testRoundTrip(inputRowVector);
   }
 }
 


### PR DESCRIPTION
Summary:
This diff is reverting D51867634
D51867634: [velox][PR] Scatter struct nulls when deserializing Presto wire format by oerling has been identified to be causing the following test failure:

Tests affected:
- [xldb/alpha_jni/alpha-spark:alphajni_lib_test-java11 - testRleEncodingTopLevelNulls(com.facebook.xldb.presto.shaded.com.facebook.presto.common.type.Type)[16 : Type(row(field_0 integer,field_1 integer))] (com.facebook.xldb.alpha.EndToEndTest)](https://www.internalfb.com/intern/test/281475090996697/)

Here's the Multisect link:
https://www.internalfb.com/multisect/3818385
Here are the tasks that are relevant to this breakage:


We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

If you believe this diff has been generated in error you may Commandeer and Abandon it.

Differential Revision: D52278809


