### PR TITLE
Remove legacy memory management code

### DIFF
--- a/velox/benchmarks/basic/LikeTpchBenchmark.cpp
+++ b/velox/benchmarks/basic/LikeTpchBenchmark.cpp
@@ -173,8 +173,7 @@ class LikeFunctionsBenchmark : public FunctionBaseTest,
  private:
   static constexpr const char* kWildcardCharacterSet = "%_";
   static constexpr const char* kAnyWildcardCharacter = "%";
-  std::shared_ptr<MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+  std::shared_ptr<MemoryPool> pool_{memory::memoryManager()->addLeafPool()};
   VectorPtr inputFuzzer_;
 };
 

--- a/velox/benchmarks/basic/VectorSlice.cpp
+++ b/velox/benchmarks/basic/VectorSlice.cpp
@@ -37,7 +37,7 @@ constexpr int kVectorSize = 16 << 10;
 
 struct BenchmarkData {
   BenchmarkData()
-      : pool_(memory::MemoryManager::getInstance()->addLeafPool(
+      : pool_(memory::memoryManager()->addLeafPool(
             "BenchmarkData",
             FLAGS_use_thread_safe_memory_usage_track)) {
     VectorFuzzer::Options opts;

--- a/velox/buffer/tests/StringViewBufferHolderTest.cpp
+++ b/velox/buffer/tests/StringViewBufferHolderTest.cpp
@@ -44,7 +44,7 @@ class StringViewBufferHolderTest : public testing::Test {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
 };
 
 TEST_F(StringViewBufferHolderTest, inlinedStringViewDoesNotCopyToBuffer) {

--- a/velox/common/base/tests/IdMapTest.cpp
+++ b/velox/common/base/tests/IdMapTest.cpp
@@ -81,7 +81,7 @@ class IdMapTest : public testing::Test {
   }
 
   void SetUp() override {
-    root_ = memory::MemoryManager::getInstance()->addRootPool("IdMapRoot");
+    root_ = memory::memoryManager()->addRootPool("IdMapRoot");
     pool_ = root_->addLeafChild("IdMapLeakLeaf");
   }
 

--- a/velox/common/hyperloglog/tests/DenseHllTest.cpp
+++ b/velox/common/hyperloglog/tests/DenseHllTest.cpp
@@ -105,7 +105,7 @@ class DenseHllTest : public ::testing::TestWithParam<int8_t> {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   HashStringAllocator allocator_{pool_.get()};
 };
 

--- a/velox/common/hyperloglog/tests/SparseHllTest.cpp
+++ b/velox/common/hyperloglog/tests/SparseHllTest.cpp
@@ -103,7 +103,7 @@ class SparseHllTest : public ::testing::Test {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   HashStringAllocator allocator_{pool_.get()};
 };
 
@@ -188,7 +188,7 @@ class SparseHllToDenseTest : public ::testing::TestWithParam<int8_t> {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   HashStringAllocator allocator_{pool_.get()};
 };
 

--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -281,6 +281,14 @@ std::vector<std::shared_ptr<MemoryPool>> MemoryManager::getAlivePools() const {
   return pools;
 }
 
+void initializeMemoryManager(const MemoryManagerOptions& options) {
+  MemoryManager::initialize(options);
+}
+
+MemoryManager* memoryManager() {
+  return MemoryManager::getInstance();
+}
+
 MemoryManager& deprecatedDefaultMemoryManager() {
   return MemoryManager::deprecatedGetInstance();
 }

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -142,12 +142,6 @@ class MemoryManager {
   /// memory manager has already been created by an easier call.
   static void initialize(const MemoryManagerOptions& options);
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  FOLLY_EXPORT static MemoryManager& getInstance(
-      const MemoryManagerOptions& options) {
-    return deprecatedGetInstance(options);
-  }
-#endif
   /// Returns process-wide memory manager. Throws if 'initialize' hasn't been
   /// called yet.
   static MemoryManager* getInstance();
@@ -262,6 +256,19 @@ class MemoryManager {
   std::unordered_map<std::string, std::weak_ptr<MemoryPool>> pools_;
 };
 
+/// Initializes the process-wide memory manager based on the specified
+/// 'options'.
+///
+/// NOTE: user should only call this once on query system startup. Otherwise,
+/// the function throws.
+void initializeMemoryManager(const MemoryManagerOptions& options);
+
+/// Returns the process-wide memory manager.
+///
+/// NOTE: user should have already initialized memory manager by calling.
+/// Otherwise, the function throws.
+MemoryManager* memoryManager();
+
 /// Deprecated. Do not use.
 MemoryManager& deprecatedDefaultMemoryManager();
 
@@ -272,18 +279,6 @@ MemoryManager& deprecatedDefaultMemoryManager();
 std::shared_ptr<MemoryPool> deprecatedAddDefaultLeafMemoryPool(
     const std::string& name = "",
     bool threadSafe = true);
-
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-inline MemoryManager& defaultMemoryManager() {
-  return deprecatedDefaultMemoryManager();
-}
-
-inline std::shared_ptr<MemoryPool> addDefaultLeafMemoryPool(
-    const std::string& name = "",
-    bool threadSafe = true) {
-  return deprecatedAddDefaultLeafMemoryPool(name, threadSafe);
-}
-#endif
 
 /// Default unmanaged leaf pool with no threadsafe stats support. Libraries
 /// using this method can get a pool that is shared with other threads. The goal

--- a/velox/common/memory/tests/HashStringAllocatorTest.cpp
+++ b/velox/common/memory/tests/HashStringAllocatorTest.cpp
@@ -41,7 +41,7 @@ class HashStringAllocatorTest : public testing::Test {
   }
 
   void SetUp() override {
-    pool_ = memory::MemoryManager::getInstance()->addLeafPool();
+    pool_ = memory::memoryManager()->addLeafPool();
     allocator_ = std::make_unique<HashStringAllocator>(pool_.get());
     rng_.seed(1);
   }
@@ -486,8 +486,7 @@ TEST_F(HashStringAllocatorTest, stlAllocatorOverflow) {
 
 TEST_F(HashStringAllocatorTest, externalLeak) {
   constexpr int32_t kSize = HashStringAllocator ::kMaxAlloc * 10;
-  auto root =
-      memory::MemoryManager::getInstance()->addRootPool("HSALeakTestRoot");
+  auto root = memory::memoryManager()->addRootPool("HSALeakTestRoot");
   auto pool = root->addLeafChild("HSALeakLeaf");
   auto initialBytes = pool->currentBytes();
   auto allocator = std::make_unique<HashStringAllocator>(pool.get());

--- a/velox/common/memory/tests/MemoryArbitratorTest.cpp
+++ b/velox/common/memory/tests/MemoryArbitratorTest.cpp
@@ -297,7 +297,7 @@ TEST_F(MemoryReclaimerTest, common) {
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     std::vector<std::shared_ptr<MemoryPool>> pools;
-    auto pool = memory::MemoryManager::getInstance()->addRootPool(
+    auto pool = memory::memoryManager()->addRootPool(
         "shrinkAPIs", kMaxMemory, memory::MemoryReclaimer::create());
     pools.push_back(pool);
 
@@ -425,7 +425,7 @@ TEST_F(MemoryReclaimerTest, mockReclaim) {
   const int numAllocationsPerLeaf = 10;
   const int allocBytes = 10;
   std::atomic<uint64_t> totalUsedBytes{0};
-  auto root = memory::MemoryManager::getInstance()->addRootPool(
+  auto root = memory::memoryManager()->addRootPool(
       "mockReclaim", kMaxMemory, MemoryReclaimer::create());
   std::vector<std::shared_ptr<MemoryPool>> childPools;
   for (int i = 0; i < numChildren; ++i) {
@@ -485,7 +485,7 @@ TEST_F(MemoryReclaimerTest, mockReclaimMoreThanAvailable) {
   const int numAllocationsPerLeaf = 10;
   const int allocBytes = 100;
   std::atomic<uint64_t> totalUsedBytes{0};
-  auto root = memory::MemoryManager::getInstance()->addRootPool(
+  auto root = memory::memoryManager()->addRootPool(
       "mockReclaimMoreThanAvailable", kMaxMemory, MemoryReclaimer::create());
   std::vector<std::shared_ptr<MemoryPool>> childPools;
   for (int i = 0; i < numChildren; ++i) {
@@ -525,7 +525,7 @@ TEST_F(MemoryReclaimerTest, orderedReclaim) {
   const std::vector<int> initAllocUnitsVec = {10, 11, 8, 16, 5};
   ASSERT_EQ(initAllocUnitsVec.size(), numChildren);
   std::atomic<uint64_t> totalUsedBytes{0};
-  auto root = memory::MemoryManager::getInstance()->addRootPool(
+  auto root = memory::memoryManager()->addRootPool(
       "orderedReclaim", kMaxMemory, MemoryReclaimer::create());
   int totalAllocUnits{0};
   std::vector<std::shared_ptr<MemoryPool>> childPools;
@@ -653,7 +653,7 @@ TEST_F(MemoryReclaimerTest, orderedReclaim) {
 }
 
 TEST_F(MemoryReclaimerTest, arbitrationContext) {
-  auto root = memory::MemoryManager::getInstance()->addRootPool(
+  auto root = memory::memoryManager()->addRootPool(
       "arbitrationContext", kMaxMemory, MemoryReclaimer::create());
   ASSERT_FALSE(isSpillMemoryPool(root.get()));
   ASSERT_TRUE(isSpillMemoryPool(spillMemoryPool()));
@@ -694,7 +694,7 @@ TEST_F(MemoryReclaimerTest, arbitrationContext) {
 }
 
 TEST_F(MemoryReclaimerTest, concurrentRandomMockReclaims) {
-  auto root = memory::MemoryManager::getInstance()->addRootPool(
+  auto root = memory::memoryManager()->addRootPool(
       "concurrentRandomMockReclaims", kMaxMemory, MemoryReclaimer::create());
 
   std::atomic<uint64_t> totalUsedBytes{0};

--- a/velox/common/memory/tests/MemoryCapExceededTest.cpp
+++ b/velox/common/memory/tests/MemoryCapExceededTest.cpp
@@ -97,8 +97,7 @@ TEST_P(MemoryCapExceededTest, singleDriver) {
                   .planNode();
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   queryCtx->testingOverrideMemoryPool(
-      memory::MemoryManager::getInstance()->addRootPool(
-          queryCtx->queryId(), kMaxBytes));
+      memory::memoryManager()->addRootPool(queryCtx->queryId(), kMaxBytes));
   CursorParameters params;
   params.planNode = plan;
   params.queryCtx = queryCtx;
@@ -156,8 +155,7 @@ TEST_P(MemoryCapExceededTest, multipleDrivers) {
                   .planNode();
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   queryCtx->testingOverrideMemoryPool(
-      memory::MemoryManager::getInstance()->addRootPool(
-          queryCtx->queryId(), kMaxBytes));
+      memory::memoryManager()->addRootPool(queryCtx->queryId(), kMaxBytes));
 
   const int32_t numDrivers = 10;
   CursorParameters params;

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -401,9 +401,16 @@ TEST_F(MemoryManagerTest, memoryPoolManagement) {
 // effects for other tests using process singleton memory manager. Might need to
 // use folly::Singleton for isolation by tag.
 TEST_F(MemoryManagerTest, globalMemoryManager) {
-  MemoryManager::initialize({});
-  auto* manager = MemoryManager::getInstance();
-  auto* managerII = MemoryManager::getInstance();
+  initializeMemoryManager({});
+  auto* globalManager = memoryManager();
+  ASSERT_TRUE(globalManager != nullptr);
+  VELOX_ASSERT_THROW(initializeMemoryManager({}), "");
+  ASSERT_EQ(memoryManager(), globalManager);
+  MemoryManager::testingSetInstance({});
+  auto* manager = memoryManager();
+  ASSERT_NE(manager, globalManager);
+  ASSERT_EQ(manager, memoryManager());
+  auto* managerII = memoryManager();
   const auto kSharedPoolCount = FLAGS_velox_memory_num_shared_leaf_pools;
   {
     auto& rootI = manager->testingDefaultRoot();

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
@@ -188,8 +188,7 @@ TEST_F(S3FileSystemTest, writeFileAndRead) {
 
   auto hiveConfig = minioServer_->hiveConfig();
   filesystems::S3FileSystem s3fs(hiveConfig);
-  auto pool =
-      memory::MemoryManager::getInstance()->addLeafPool("S3FileSystemTest");
+  auto pool = memory::memoryManager()->addLeafPool("S3FileSystemTest");
   auto writeFile = s3fs.openFileForWrite(s3File, {{}, pool.get()});
   auto s3WriteFile = dynamic_cast<filesystems::S3WriteFile*>(writeFile.get());
   std::string dataContent =

--- a/velox/connectors/hive/tests/HiveConnectorTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorTest.cpp
@@ -32,7 +32,7 @@ using namespace facebook::velox::exec::test;
 class HiveConnectorTest : public exec::test::HiveConnectorTestBase {
  protected:
   std::shared_ptr<memory::MemoryPool> pool_ =
-      memory::MemoryManager::getInstance()->addLeafPool();
+      memory::memoryManager()->addLeafPool();
 };
 
 void validateNullConstant(const ScanSpec& spec, const Type& type) {

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -107,7 +107,7 @@ class HiveDataSinkTest : public exec::test::HiveConnectorTestBase {
     opPool_.reset();
     root_.reset();
 
-    root_ = memory::MemoryManager::getInstance()->addRootPool(
+    root_ = memory::memoryManager()->addRootPool(
         "HiveDataSinkTest", 1L << 30, exec::MemoryReclaimer::create());
     opPool_ = root_->addLeafChild("operator");
     connectorPool_ =
@@ -192,7 +192,7 @@ class HiveDataSinkTest : public exec::test::HiveConnectorTestBase {
   }
 
   const std::shared_ptr<memory::MemoryPool> pool_ =
-      memory::MemoryManager::getInstance()->addLeafPool();
+      memory::memoryManager()->addLeafPool();
 
   std::shared_ptr<memory::MemoryPool> root_;
   std::shared_ptr<memory::MemoryPool> opPool_;

--- a/velox/core/tests/PlanFragmentTest.cpp
+++ b/velox/core/tests/PlanFragmentTest.cpp
@@ -79,7 +79,7 @@ class PlanFragmentTest : public testing::Test {
   std::vector<RowVectorPtr> emptyProbeVectors_;
   std::shared_ptr<PlanNode> probeValueNode_;
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
 };
 }; // namespace
 

--- a/velox/core/tests/QueryConfigTest.cpp
+++ b/velox/core/tests/QueryConfigTest.cpp
@@ -147,7 +147,7 @@ TEST_F(QueryConfigTest, taskWriterCountConfig) {
 
 TEST_F(QueryConfigTest, enableExpressionEvaluationCacheConfig) {
   std::shared_ptr<memory::MemoryPool> rootPool{
-      memory::MemoryManager::getInstance()->addRootPool()};
+      memory::memoryManager()->addRootPool()};
   std::shared_ptr<memory::MemoryPool> pool{rootPool->addLeafChild("leaf")};
 
   auto testConfig = [&](bool enableExpressionEvaluationCache) {

--- a/velox/docs/programming-guide/chapter01.rst
+++ b/velox/docs/programming-guide/chapter01.rst
@@ -15,7 +15,7 @@ Let’s start by getting access to a MemoryPool:
 
     #include "velox/common/memory/Memory.h"
 
-    auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+    auto pool = memory::memoryManager()->addLeafPool();
 
 `pool` is a std::shared_ptr<velox::memory::MemoryPool>. We can use it to
 allocate buffers.

--- a/velox/dwio/common/tests/BitConcatenationTest.cpp
+++ b/velox/dwio/common/tests/BitConcatenationTest.cpp
@@ -23,8 +23,7 @@ using namespace facebook::velox::dwio::common;
 
 TEST(BitConcatenationTests, basic) {
   memory::MemoryManager::testingSetInstance({});
-  auto pool =
-      facebook::velox::memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
   BitConcatenation bits(*pool);
   BufferPtr result;
 

--- a/velox/dwio/common/tests/ChainedBufferTests.cpp
+++ b/velox/dwio/common/tests/ChainedBufferTests.cpp
@@ -34,7 +34,7 @@ class ChainedBufferTests : public Test {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
 };
 
 TEST_F(ChainedBufferTests, testCreate) {

--- a/velox/dwio/common/tests/DataBufferBenchmark.cpp
+++ b/velox/dwio/common/tests/DataBufferBenchmark.cpp
@@ -24,8 +24,7 @@ using namespace facebook::velox::dwio;
 using namespace facebook::velox::dwio::common;
 
 BENCHMARK(DataBufferOps, iters) {
-  auto pool =
-      facebook::velox::memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
   constexpr size_t size = 1024 * 1024 * 16;
   for (size_t i = 0; i < iters; ++i) {
     DataBuffer<int32_t> buf{*pool};
@@ -40,8 +39,7 @@ BENCHMARK(DataBufferOps, iters) {
 }
 
 BENCHMARK(ChainedBufferOps, iters) {
-  auto pool =
-      facebook::velox::memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
   constexpr size_t size = 1024 * 1024 * 16;
   for (size_t i = 0; i < iters; ++i) {
     ChainedBuffer<int32_t> buf{*pool, size, size * 4};

--- a/velox/dwio/common/tests/DataBufferTests.cpp
+++ b/velox/dwio/common/tests/DataBufferTests.cpp
@@ -34,8 +34,7 @@ class DataBufferTest : public testing::Test {
     MemoryManager::testingSetInstance({});
   }
 
-  const std::shared_ptr<MemoryPool> pool_ =
-      MemoryManager::getInstance()->addLeafPool();
+  const std::shared_ptr<MemoryPool> pool_ = memoryManager()->addLeafPool();
 };
 
 TEST_F(DataBufferTest, ZeroOut) {

--- a/velox/dwio/common/tests/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/E2EFilterTestBase.h
@@ -83,8 +83,7 @@ class E2EFilterTestBase : public testing::Test {
   }
 
   void SetUp() override {
-    rootPool_ =
-        memory::MemoryManager::getInstance()->addRootPool("E2EFilterTestBase");
+    rootPool_ = memory::memoryManager()->addRootPool("E2EFilterTestBase");
     leafPool_ = rootPool_->addLeafChild("E2EFilterTestBase");
   }
 

--- a/velox/dwio/common/tests/LocalFileSinkTest.cpp
+++ b/velox/dwio/common/tests/LocalFileSinkTest.cpp
@@ -47,7 +47,7 @@ class LocalFileSinkTest : public testing::Test {
   }
 
   std::shared_ptr<velox::memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
 };
 
 TEST_F(LocalFileSinkTest, missingRegistration) {

--- a/velox/dwio/common/tests/TestBufferedInput.cpp
+++ b/velox/dwio/common/tests/TestBufferedInput.cpp
@@ -113,8 +113,7 @@ class TestBufferedInput : public testing::Test {
     MemoryManager::testingSetInstance({});
   }
 
-  const std::shared_ptr<MemoryPool> pool_ =
-      MemoryManager::getInstance()->addLeafPool();
+  const std::shared_ptr<MemoryPool> pool_ = memoryManager()->addLeafPool();
 };
 } // namespace
 

--- a/velox/dwio/dwrf/test/CacheInputTest.cpp
+++ b/velox/dwio/dwrf/test/CacheInputTest.cpp
@@ -381,7 +381,7 @@ class CacheTest : public testing::Test {
   std::shared_ptr<IoStatistics> ioStats_;
   std::unique_ptr<folly::IOThreadPoolExecutor> executor_;
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
 
   // Id of simulated streams. Corresponds 1:1 to 'streamStarts_'.
   std::vector<std::unique_ptr<dwrf::DwrfStreamIdentifier>> streamIds_;

--- a/velox/dwio/dwrf/test/ColumnWriterIndexTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterIndexTest.cpp
@@ -273,8 +273,7 @@ class WriterEncodingIndexTest2 {
  public:
   WriterEncodingIndexTest2()
       : config_{std::make_shared<Config>()},
-        pool_{facebook::velox::memory::MemoryManager::getInstance()
-                  ->addLeafPool()} {}
+        pool_{facebook::velox::memory::memoryManager()->addLeafPool()} {}
 
   virtual ~WriterEncodingIndexTest2() = default;
 
@@ -303,7 +302,7 @@ class WriterEncodingIndexTest2 {
     ASSERT_EQ(recordPositionCount.size(), backfillPositionCount.size());
     WriterContext context{
         config_,
-        velox::memory::MemoryManager::getInstance()->addRootPool(
+        velox::memory::memoryManager()->addRootPool(
             "WriterEncodingIndexTest2")};
     context.initBuffer();
     std::vector<StrictMock<MockIndexBuilder>*> mocks;
@@ -689,7 +688,7 @@ TYPED_TEST(FloatColumnWriterEncodingIndexTest, TestIndex) {
 class IntegerColumnWriterDirectEncodingIndexTest : public testing::Test {
  public:
   explicit IntegerColumnWriterDirectEncodingIndexTest(bool abandonDict = false)
-      : pool_{memory::MemoryManager::getInstance()->addLeafPool()},
+      : pool_{memory::memoryManager()->addLeafPool()},
         config_{std::make_shared<Config>()},
         abandonDict_{abandonDict} {
     config_->set(
@@ -734,7 +733,7 @@ class IntegerColumnWriterDirectEncodingIndexTest : public testing::Test {
       std::function<bool(size_t, size_t)> callAbandonDict) {
     WriterContext context{
         config_,
-        velox::memory::MemoryManager::getInstance()->addRootPool(
+        velox::memory::memoryManager()->addRootPool(
             "IntegerColumnWriterDirectEncodingIndexTest")};
     context.initBuffer();
     auto mockIndexBuilder = std::make_unique<StrictMock<MockIndexBuilder>>();
@@ -900,7 +899,7 @@ TEST_F(IntegerColumnWriterAbandonDictionaryIndexTest, AbandonDictionary) {
 class StringColumnWriterDictionaryEncodingIndexTest : public testing::Test {
  public:
   explicit StringColumnWriterDictionaryEncodingIndexTest()
-      : rootPool_{memory::MemoryManager::getInstance()->addRootPool(
+      : rootPool_{memory::memoryManager()->addRootPool(
             "StringColumnWriterDictionaryEncodingIndexTest")},
         leafPool_{rootPool_->addLeafChild(
             "StringColumnWriterDictionaryEncodingIndexTest")},
@@ -1009,7 +1008,7 @@ TEST_F(StringColumnWriterDictionaryEncodingIndexTest, OmitInDictStream) {
 class StringColumnWriterDirectEncodingIndexTest : public testing::Test {
  public:
   explicit StringColumnWriterDirectEncodingIndexTest(bool abandonDict = false)
-      : rootPool_{memory::MemoryManager::getInstance()->addRootPool(
+      : rootPool_{memory::memoryManager()->addRootPool(
             "StringColumnWriterDirectEncodingIndexTest")},
         leafPool_{rootPool_->addLeafChild(
             "StringColumnWriterDirectEncodingIndexTest")},

--- a/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
@@ -146,8 +146,7 @@ class ColumnWriterStatsTest : public ::testing::Test {
   }
 
   void SetUp() override {
-    rootPool_ = memory::MemoryManager::getInstance()->addRootPool(
-        "ColumnWriterStatsTest");
+    rootPool_ = memory::memoryManager()->addRootPool("ColumnWriterStatsTest");
     leafPool_ = rootPool_->addLeafChild("ColumnWriterStatsTest");
   }
 

--- a/velox/dwio/dwrf/test/CompressionTest.cpp
+++ b/velox/dwio/dwrf/test/CompressionTest.cpp
@@ -167,8 +167,7 @@ class CompressionTest : public TestWithParam<TestParams> {
   CompressionKind kind_;
   const Encrypter* encrypter_;
   const Decrypter* decrypter_;
-  std::shared_ptr<MemoryPool> pool_ =
-      MemoryManager::getInstance()->addLeafPool();
+  std::shared_ptr<MemoryPool> pool_ = memoryManager()->addLeafPool();
 };
 
 TEST_P(CompressionTest, compressOriginalString) {
@@ -313,8 +312,7 @@ class RecordPositionTest : public TestWithParam<TestParams2> {
  protected:
   CompressionKind kind_;
   const Encrypter* encrypter_;
-  std::shared_ptr<MemoryPool> pool_ =
-      MemoryManager::getInstance()->addLeafPool();
+  std::shared_ptr<MemoryPool> pool_ = memoryManager()->addLeafPool();
 };
 
 TEST_P(RecordPositionTest, testRecordPosition) {
@@ -409,7 +407,7 @@ TEST_P(CompressionTest, getCompressionBufferOOM) {
     config->set<uint64_t>(Config::COMPRESSION_BLOCK_SIZE, compressBlockSize);
     WriterContext context{
         config,
-        MemoryManager::getInstance()->addRootPool(
+        memoryManager()->addRootPool(
             "oomOnCompression",
             kind_ == facebook::velox::common::CompressionKind_NONE ? 3L << 20
                                                                    : 6L << 20)};

--- a/velox/dwio/dwrf/test/DataBufferHolderTests.cpp
+++ b/velox/dwio/dwrf/test/DataBufferHolderTests.cpp
@@ -28,8 +28,7 @@ class DataBufferHolderTest : public testing::Test {
     MemoryManager::testingSetInstance({});
   }
 
-  std::shared_ptr<MemoryPool> pool_{
-      MemoryManager::getInstance()->addLeafPool()};
+  std::shared_ptr<MemoryPool> pool_{memoryManager()->addLeafPool()};
 };
 
 TEST_F(DataBufferHolderTest, InputCheck) {

--- a/velox/dwio/dwrf/test/DirectBufferedInputTest.cpp
+++ b/velox/dwio/dwrf/test/DirectBufferedInputTest.cpp
@@ -130,7 +130,7 @@ class DirectBufferedInputTest : public testing::Test {
   std::shared_ptr<IoStatistics> fileIoStats_;
   std::unique_ptr<folly::IOThreadPoolExecutor> executor_;
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
 };
 
 TEST_F(DirectBufferedInputTest, basic) {

--- a/velox/dwio/dwrf/test/E2EReaderTest.cpp
+++ b/velox/dwio/dwrf/test/E2EReaderTest.cpp
@@ -109,7 +109,7 @@ class E2EReaderTest : public testing::TestWithParam<ValueTypes> {
 TEST_P(E2EReaderTest, SharedDictionaryFlatmapReadAsStruct) {
   const size_t batchCount = 10;
   size_t size = 1;
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
 
   std::vector<uint32_t> flatMapCols(GetParam().size());
   std::iota(flatMapCols.begin(), flatMapCols.end(), 0);

--- a/velox/dwio/dwrf/test/E2EWriterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTest.cpp
@@ -58,8 +58,7 @@ class E2EWriterTest : public testing::Test {
   }
 
   E2EWriterTest() {
-    rootPool_ =
-        memory::MemoryManager::getInstance()->addRootPool("E2EWriterTest");
+    rootPool_ = memory::memoryManager()->addRootPool("E2EWriterTest");
     leafPool_ = rootPool_->addLeafChild("leaf");
   }
 
@@ -379,7 +378,7 @@ TEST_F(E2EWriterTest, FlatMapDictionaryEncoding) {
   // Start with a size larger than stride to cover splitting into
   // strides. Continue with smaller size for faster test.
   size_t size = 1100;
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
 
   HiveTypeParser parser;
   auto type = parser.parse(
@@ -419,7 +418,7 @@ TEST_F(E2EWriterTest, MaxFlatMapKeys) {
   const uint32_t keyLimit = 2000;
   const auto randomStart = Random::rand32(100);
 
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   b::row row;
   for (int32_t i = 0; i < keyLimit; ++i) {
     row.push_back(b::pair{randomStart + i, Random::rand64()});
@@ -450,8 +449,7 @@ TEST_F(E2EWriterTest, PresentStreamIsSuppressedOnFlatMap) {
 
   const auto randomStart = Random::rand32(100);
 
-  auto pool =
-      facebook::velox::memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
   b::row row;
   row.push_back(b::pair{randomStart, Random::rand64()});
 
@@ -500,7 +498,7 @@ TEST_F(E2EWriterTest, TooManyFlatMapKeys) {
   const uint32_t keyLimit = 2000;
   const auto randomStart = Random::rand32(100);
 
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   b::row row;
   for (int32_t i = 0; i < (keyLimit + 1); ++i) {
     row.push_back(b::pair{randomStart + i, Random::rand64()});
@@ -527,7 +525,7 @@ TEST_F(E2EWriterTest, TooManyFlatMapKeys) {
 }
 
 TEST_F(E2EWriterTest, FlatMapBackfill) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
 
   using keyType = int32_t;
   using valueType = int32_t;
@@ -590,7 +588,7 @@ void testFlatMapWithNulls(
     bool firstRowNotNull,
     bool enableFlatmapDictionaryEncoding = false,
     bool shareDictionary = false) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
 
   using keyType = int32_t;
   using valueType = int32_t;
@@ -658,7 +656,7 @@ TEST_F(E2EWriterTest, FlatMapWithNullsSharedDict) {
 }
 
 TEST_F(E2EWriterTest, FlatMapEmpty) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
 
   using keyType = int32_t;
   using valueType = int32_t;
@@ -857,8 +855,7 @@ TEST_F(E2EWriterTest, PartialStride) {
 }
 
 TEST_F(E2EWriterTest, OversizeRows) {
-  auto pool =
-      facebook::velox::memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
 
   HiveTypeParser parser;
   auto type = parser.parse(
@@ -896,8 +893,7 @@ TEST_F(E2EWriterTest, OversizeRows) {
 }
 
 TEST_F(E2EWriterTest, OversizeBatches) {
-  auto pool =
-      facebook::velox::memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
 
   HiveTypeParser parser;
   auto type = parser.parse(
@@ -945,8 +941,7 @@ TEST_F(E2EWriterTest, OversizeBatches) {
 }
 
 TEST_F(E2EWriterTest, OverflowLengthIncrements) {
-  auto pool =
-      facebook::velox::memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
 
   HiveTypeParser parser;
   auto type = parser.parse(
@@ -1356,7 +1351,7 @@ VectorPtr createKeys(
 }
 
 TEST_F(E2EWriterTest, fuzzSimple) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   auto type = ROW({
       {"bool_val", BOOLEAN()},
       {"byte_val", TINYINT()},
@@ -1405,7 +1400,7 @@ TEST_F(E2EWriterTest, fuzzSimple) {
 }
 
 TEST_F(E2EWriterTest, fuzzComplex) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   auto type = ROW({
       {"array", ARRAY(REAL())},
       {"map", MAP(INTEGER(), DOUBLE())},
@@ -1460,7 +1455,7 @@ TEST_F(E2EWriterTest, fuzzComplex) {
 }
 
 TEST_F(E2EWriterTest, fuzzFlatmap) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   auto type = ROW({
       {"flatmap1", MAP(INTEGER(), REAL())},
       {"flatmap2", MAP(VARCHAR(), ARRAY(REAL()))},
@@ -1557,7 +1552,7 @@ TEST_F(E2EWriterTest, memoryConfigError) {
   options.schema = type;
   const common::SpillConfig spillConfig = getSpillConfig(10, 20);
   options.spillConfig = &spillConfig;
-  auto writerPool = memory::MemoryManager::getInstance()->addRootPool(
+  auto writerPool = memory::memoryManager()->addRootPool(
       "memoryReclaim", 1L << 30, exec::MemoryReclaimer::create());
   auto dwrfPool = writerPool->addAggregateChild("writer");
   auto sinkPool =
@@ -1602,7 +1597,7 @@ DEBUG_ONLY_TEST_F(E2EWriterTest, memoryReclaimOnWrite) {
     if (enableReclaim) {
       options.spillConfig = &spillConfig;
     }
-    auto writerPool = memory::MemoryManager::getInstance()->addRootPool(
+    auto writerPool = memory::memoryManager()->addRootPool(
         "memoryReclaim", 1L << 30, exec::MemoryReclaimer::create());
     auto dwrfPool = writerPool->addAggregateChild("writer");
     auto sinkPool =
@@ -1718,7 +1713,7 @@ DEBUG_ONLY_TEST_F(E2EWriterTest, memoryReclaimOnFlush) {
     if (enableReclaim) {
       options.spillConfig = &spillConfig;
     }
-    auto writerPool = memory::MemoryManager::getInstance()->addRootPool(
+    auto writerPool = memory::memoryManager()->addRootPool(
         "memoryReclaim", 1L << 30, exec::MemoryReclaimer::create());
     auto dwrfPool = writerPool->addAggregateChild("writer");
     auto sinkPool =
@@ -1822,7 +1817,7 @@ TEST_F(E2EWriterTest, memoryReclaimAfterClose) {
     if (testData.canReclaim) {
       options.spillConfig = &spillConfig;
     }
-    auto writerPool = memory::MemoryManager::getInstance()->addRootPool(
+    auto writerPool = memory::memoryManager()->addRootPool(
         "memoryReclaim", 1L << 30, exec::MemoryReclaimer::create());
     auto dwrfPool = writerPool->addAggregateChild("writer");
     auto sinkPool =
@@ -1902,7 +1897,7 @@ DEBUG_ONLY_TEST_F(E2EWriterTest, memoryReclaimDuringInit) {
     if (reclaimable) {
       options.spillConfig = &spillConfig;
     }
-    auto writerPool = memory::MemoryManager::getInstance()->addRootPool(
+    auto writerPool = memory::memoryManager()->addRootPool(
         "memoryReclaimDuringInit", 1L << 30, exec::MemoryReclaimer::create());
     auto dwrfPool = writerPool->addAggregateChild("writer");
     auto sinkPool =
@@ -1984,7 +1979,7 @@ TEST_F(E2EWriterTest, memoryReclaimThreshold) {
     options.nonReclaimableSection = &nonReclaimableSection;
     options.spillConfig = &spillConfig;
 
-    auto writerPool = memory::MemoryManager::getInstance()->addRootPool(
+    auto writerPool = memory::memoryManager()->addRootPool(
         "memoryReclaimThreshold", 1L << 30, exec::MemoryReclaimer::create());
     auto dwrfPool = writerPool->addAggregateChild("writer");
     auto sinkPool =

--- a/velox/dwio/dwrf/test/FloatColumnWriterBenchmark.cpp
+++ b/velox/dwio/dwrf/test/FloatColumnWriterBenchmark.cpp
@@ -42,7 +42,7 @@ void runBenchmark(int nullEvery) {
 
   auto type = CppToType<float>::create();
   auto typeWithId = TypeWithId::create(type, 1);
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   VectorPtr vector;
   // Prepare input
   BufferPtr values = AlignedBuffer::allocate<float>(kVectorSize, pool.get());
@@ -78,8 +78,7 @@ void runBenchmark(int nullEvery) {
     auto config = std::make_shared<dwrf::Config>();
     WriterContext context{
         config,
-        memory::MemoryManager::getInstance()->addRootPool(
-            "FloatColumnWriterBenchmark")};
+        memory::memoryManager()->addRootPool("FloatColumnWriterBenchmark")};
     auto writer = BaseColumnWriter::create(context, *typeWithId, 0);
     writer->write(vector, common::Ranges::of(0, kVectorSize));
   }

--- a/velox/dwio/dwrf/test/FlushPolicyTest.cpp
+++ b/velox/dwio/dwrf/test/FlushPolicyTest.cpp
@@ -146,9 +146,7 @@ TEST_F(DefaultFlushPolicyTest, InvalidCases) {
 TEST_F(DefaultFlushPolicyTest, DictionaryCriteriaTest) {
   auto config = std::make_shared<Config>();
   WriterContext context{
-      config,
-      memory::MemoryManager::getInstance()->addRootPool(
-          "DictionaryCriteriaTest")};
+      config, memory::memoryManager()->addRootPool("DictionaryCriteriaTest")};
 
   RowsPerStripeFlushPolicy policy({42});
   EXPECT_EQ(

--- a/velox/dwio/dwrf/test/IntEncoderBenchmark.cpp
+++ b/velox/dwio/dwrf/test/IntEncoderBenchmark.cpp
@@ -30,7 +30,7 @@ using namespace facebook::velox::memory;
 
 static size_t generateAutoId(int64_t startId, int64_t count) {
   size_t capacity = count * folly::kMaxVarintLength64;
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   DataBufferHolder holder{*pool, capacity};
   auto output = std::make_unique<BufferedOutputStream>(holder);
   auto encoder =
@@ -44,7 +44,7 @@ static size_t generateAutoId(int64_t startId, int64_t count) {
 
 static size_t generateAutoId2(int64_t startId, int64_t count) {
   size_t capacity = count * folly::kMaxVarintLength64;
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   DataBufferHolder holder{*pool, capacity};
   auto output = std::make_unique<BufferedOutputStream>(holder);
   auto encoder =

--- a/velox/dwio/dwrf/test/LayoutPlannerTests.cpp
+++ b/velox/dwio/dwrf/test/LayoutPlannerTests.cpp
@@ -102,7 +102,7 @@ TEST_F(LayoutPlannerTest, Basic) {
       Config::COMPRESSION, common::CompressionKind::CompressionKind_NONE);
   WriterContext context{
       config,
-      facebook::velox::memory::MemoryManager::getInstance()->addRootPool(
+      facebook::velox::memory::memoryManager()->addRootPool(
           "LayoutPlannerTests")};
   // fake streams
   std::vector<DwrfStreamIdentifier> streams;

--- a/velox/dwio/dwrf/test/OrcTest.h
+++ b/velox/dwio/dwrf/test/OrcTest.h
@@ -39,8 +39,7 @@ inline std::string getExampleFilePath(const std::string& fileName) {
 
 class MockStripeStreams : public StripeStreams {
  public:
-  MockStripeStreams()
-      : pool_{memory::MemoryManager::getInstance()->addLeafPool()} {};
+  MockStripeStreams() : pool_{memory::memoryManager()->addLeafPool()} {};
   ~MockStripeStreams() = default;
 
   std::unique_ptr<dwio::common::SeekableInputStream> getStream(

--- a/velox/dwio/dwrf/test/ReaderBaseTests.cpp
+++ b/velox/dwio/dwrf/test/ReaderBaseTests.cpp
@@ -53,7 +53,7 @@ class EncryptedStatsTest : public Test {
   }
 
   void SetUp() override {
-    pool_ = MemoryManager::getInstance()->addRootPool("EncryptedStatsTest");
+    pool_ = memoryManager()->addRootPool("EncryptedStatsTest");
     sinkPool_ = pool_->addLeafChild("sink");
     ProtoWriter writer{pool_, *sinkPool_};
     auto& context = const_cast<const ProtoWriter&>(writer).getContext();
@@ -177,8 +177,7 @@ TEST_F(EncryptedStatsTest, getColumnStatisticsKeyNotLoaded) {
 std::unique_ptr<ReaderBase> createCorruptedFileReader(
     uint64_t footerLen,
     uint32_t cacheLen) {
-  auto pool =
-      facebook::velox::memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
   MemorySink sink{1024, {.pool = pool.get()}};
   DataBufferHolder holder{*pool, 1024, 0, DEFAULT_PAGE_GROW_RATIO, &sink};
   BufferedOutputStream output{holder};

--- a/velox/dwio/dwrf/test/StreamLabelsTests.cpp
+++ b/velox/dwio/dwrf/test/StreamLabelsTests.cpp
@@ -30,8 +30,7 @@ class StreamLabelsTest : public testing::Test {
 };
 
 TEST_F(StreamLabelsTest, E2E) {
-  auto pool =
-      facebook::velox::memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
   AllocationPool allocationPool(pool.get());
   StreamLabels root(allocationPool);
   auto c0 = root.append("c0");

--- a/velox/dwio/dwrf/test/StripeReaderBaseTests.cpp
+++ b/velox/dwio/dwrf/test/StripeReaderBaseTests.cpp
@@ -67,7 +67,7 @@ class StripeLoadKeysTest : public Test {
 
     TestDecrypterFactory factory;
     auto handler = DecryptionHandler::create(FooterWrapper(footer), &factory);
-    pool_ = MemoryManager::getInstance()->addLeafPool();
+    pool_ = memoryManager()->addLeafPool();
 
     reader_ = std::make_unique<ReaderBase>(
         *pool_,

--- a/velox/dwio/dwrf/test/TestBufferedOutputStream.cpp
+++ b/velox/dwio/dwrf/test/TestBufferedOutputStream.cpp
@@ -30,8 +30,7 @@ class BufferedOutputStreamTest : public testing::Test {
     MemoryManager::testingSetInstance({});
   }
 
-  std::shared_ptr<MemoryPool> pool_ =
-      MemoryManager::getInstance()->addLeafPool();
+  std::shared_ptr<MemoryPool> pool_ = memoryManager()->addLeafPool();
 };
 
 TEST_F(BufferedOutputStreamTest, blockAligned) {
@@ -244,8 +243,7 @@ class AppendOnlyBufferedStreamTest : public testing::Test {
     MemoryManager::testingSetInstance({});
   }
 
-  std::shared_ptr<MemoryPool> pool_ =
-      MemoryManager::getInstance()->addLeafPool();
+  std::shared_ptr<MemoryPool> pool_ = memoryManager()->addLeafPool();
 };
 
 TEST_F(AppendOnlyBufferedStreamTest, Basic) {

--- a/velox/dwio/dwrf/test/TestByteRLEEncoder.cpp
+++ b/velox/dwio/dwrf/test/TestByteRLEEncoder.cpp
@@ -118,7 +118,7 @@ class ByteRleEncoderTest : public testing::Test {
 };
 
 TEST_F(ByteRleEncoderTest, random_chars) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool.get()});
 
   uint64_t block = 1024;
@@ -138,7 +138,7 @@ TEST_F(ByteRleEncoderTest, random_chars) {
 }
 
 TEST_F(ByteRleEncoderTest, random_chars_with_null) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool.get()});
 
   uint64_t block = 1024;
@@ -167,7 +167,7 @@ class BooleanRleEncoderTest : public testing::Test {
 };
 
 TEST_F(BooleanRleEncoderTest, random_bits_not_aligned) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool.get()});
 
   uint64_t block = 1024;
@@ -187,7 +187,7 @@ TEST_F(BooleanRleEncoderTest, random_bits_not_aligned) {
 }
 
 TEST_F(BooleanRleEncoderTest, random_bits_aligned) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool.get()});
 
   uint64_t block = 1024;
@@ -207,7 +207,7 @@ TEST_F(BooleanRleEncoderTest, random_bits_aligned) {
 }
 
 TEST_F(BooleanRleEncoderTest, random_bits_aligned_with_null) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool.get()});
 
   uint64_t block = 1024;

--- a/velox/dwio/dwrf/test/TestDecompression.cpp
+++ b/velox/dwio/dwrf/test/TestDecompression.cpp
@@ -57,8 +57,7 @@ class DecompressionTest : public testing::Test {
         std::move(file), 0, 200, *pool_, LogType::TEST, 20);
   }
 
-  std::shared_ptr<MemoryPool> pool_ =
-      memory::MemoryManager::getInstance()->addLeafPool();
+  std::shared_ptr<MemoryPool> pool_ = memory::memoryManager()->addLeafPool();
 };
 
 TEST_F(DecompressionTest, testPrintBufferEmpty) {
@@ -925,8 +924,7 @@ class TestSeek : public ::testing::Test {
     offset2 = compress(input2, inputSize, output, offset1, codec);
   }
 
-  std::shared_ptr<MemoryPool> pool_ =
-      memory::MemoryManager::getInstance()->addLeafPool();
+  std::shared_ptr<MemoryPool> pool_ = memory::memoryManager()->addLeafPool();
 };
 
 TEST_F(TestSeek, Zlib) {

--- a/velox/dwio/dwrf/test/TestDictionaryEncodingUtils.cpp
+++ b/velox/dwio/dwrf/test/TestDictionaryEncodingUtils.cpp
@@ -98,7 +98,7 @@ TEST_F(DictionaryEncodingUtilsTest, StringGetSortedIndexLookupTable) {
           {0, 1, 2, 3}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = MemoryManager::getInstance()->addLeafPool();
+    auto pool = memoryManager()->addLeafPool();
     StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       stringDictEncoder.addKey(key, 0);
@@ -303,7 +303,7 @@ TEST_F(DictionaryEncodingUtilsTest, StringStrideDictOptimization) {
   };
 
   for (const auto& testCase : testCases) {
-    auto pool = MemoryManager::getInstance()->addLeafPool();
+    auto pool = memoryManager()->addLeafPool();
     StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     size_t rowCount = 0;
     for (const auto& key : testCase.addKeySequence) {

--- a/velox/dwio/dwrf/test/TestEncodingSelector.cpp
+++ b/velox/dwio/dwrf/test/TestEncodingSelector.cpp
@@ -29,7 +29,7 @@ class EntropyEncodingSelectorTests : public testing::Test {
 };
 
 TEST_F(EntropyEncodingSelectorTests, Ctor) {
-  auto pool = MemoryManager::getInstance()->addLeafPool();
+  auto pool = memoryManager()->addLeafPool();
   float slightlyOver = 1.0f + std::numeric_limits<float>::epsilon() * 2;
   float slightlyUnder = -std::numeric_limits<float>::epsilon();
   EXPECT_ANY_THROW(
@@ -76,7 +76,7 @@ class EntropyEncodingSelectorTest {
         decision_{decision} {}
 
   void runTest() const {
-    auto pool = MemoryManager::getInstance()->addLeafPool();
+    auto pool = memoryManager()->addLeafPool();
     StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     dwio::common::DataBuffer<uint32_t> rows{*pool};
     rows.reserve(size_);

--- a/velox/dwio/dwrf/test/TestIntDirect.cpp
+++ b/velox/dwio/dwrf/test/TestIntDirect.cpp
@@ -30,7 +30,7 @@ using namespace facebook::velox::dwrf;
 
 template <typename T, bool isSigned, bool vInt>
 void testInts(std::function<T()> generator) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   constexpr size_t count = 10240;
   DataBuffer<T> buffer{*pool, count};
   std::array<uint64_t, count / 64> nulls;

--- a/velox/dwio/dwrf/test/TestIntegerDictionaryEncoder.cpp
+++ b/velox/dwio/dwrf/test/TestIntegerDictionaryEncoder.cpp
@@ -51,7 +51,7 @@ TEST_F(TestIntegerDictionaryEncoder, AddKey) {
       TestCase{{-2, 2, 2, -2, 2}, {0, 1, 1, 0, 1}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = MemoryManager::getInstance()->addLeafPool();
+    auto pool = memoryManager()->addLeafPool();
     IntegerDictionaryEncoder<int64_t> intDictEncoder{*pool, *pool};
     std::vector<size_t> actualEncodedSequence{};
     for (const auto& key : testCase.addKeySequence) {
@@ -84,7 +84,7 @@ TEST_F(TestIntegerDictionaryEncoder, GetCount) {
           {3, 2, 3, 3, 2}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = MemoryManager::getInstance()->addLeafPool();
+    auto pool = memoryManager()->addLeafPool();
     IntegerDictionaryEncoder<int64_t> intDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       intDictEncoder.addKey(key);
@@ -116,7 +116,7 @@ TEST_F(TestIntegerDictionaryEncoder, GetTotalCount) {
       TestCase{{-2, 1, 2, 0, -1, 1, 0, 2, 0, -2, -1, -2, 1}, 13}};
 
   for (const auto& testCase : testCases) {
-    auto pool = MemoryManager::getInstance()->addLeafPool();
+    auto pool = memoryManager()->addLeafPool();
     IntegerDictionaryEncoder<int64_t> intDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       intDictEncoder.addKey(key);
@@ -127,7 +127,7 @@ TEST_F(TestIntegerDictionaryEncoder, GetTotalCount) {
 }
 
 TEST_F(TestIntegerDictionaryEncoder, Clear) {
-  auto pool = MemoryManager::getInstance()->addLeafPool();
+  auto pool = memoryManager()->addLeafPool();
   {
     IntegerDictionaryEncoder<int64_t> intDictEncoder{*pool, *pool};
     EXPECT_EQ(1, intDictEncoder.refCount_);
@@ -208,7 +208,7 @@ TEST_F(TestIntegerDictionaryEncoder, Clear) {
 }
 
 TEST_F(TestIntegerDictionaryEncoder, RepeatedFlush) {
-  auto pool = MemoryManager::getInstance()->addLeafPool();
+  auto pool = memoryManager()->addLeafPool();
   IntegerDictionaryEncoder<int64_t> intDictEncoder{*pool, *pool};
   std::vector<int> keys{0, 1, 4, 9, 16, 25, 9, 1};
   for (const auto& key : keys) {
@@ -234,7 +234,7 @@ TEST_F(TestIntegerDictionaryEncoder, RepeatedFlush) {
 }
 
 TEST_F(TestIntegerDictionaryEncoder, Limit) {
-  auto pool = MemoryManager::getInstance()->addLeafPool();
+  auto pool = memoryManager()->addLeafPool();
   IntegerDictionaryEncoder<int16_t> intDictEncoder{*pool, *pool};
   for (size_t iter = 0; iter < 2; ++iter) {
     int16_t val = std::numeric_limits<int16_t>::min();
@@ -271,7 +271,7 @@ void testGetSortedIndexLookupTable() {
       TestCase{{-1, 0, -2, 2, 1}, false, {0, 1, 2, 3, 4}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = MemoryManager::getInstance()->addLeafPool();
+    auto pool = memoryManager()->addLeafPool();
     IntegerDictionaryEncoder<T> intDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       intDictEncoder.addKey(key);
@@ -338,7 +338,7 @@ TEST_F(TestIntegerDictionaryEncoder, ShortIntegerDictionary) {
     values.emplace_back(static_cast<int16_t>(i));
   }
 
-  auto pool = MemoryManager::getInstance()->addLeafPool();
+  auto pool = memoryManager()->addLeafPool();
   IntegerDictionaryEncoder<int16_t> intDictEncoder{*pool, *pool};
   dwio::common::DataBuffer<bool> inDict{*pool};
   dwio::common::DataBuffer<int16_t> lookupTable{*pool};
@@ -451,7 +451,7 @@ void testInfrequentKeyOptimization() {
           24}};
 
   for (const auto& testCase : testCases) {
-    auto pool = MemoryManager::getInstance()->addLeafPool();
+    auto pool = memoryManager()->addLeafPool();
     IntegerDictionaryEncoder<T> intDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       intDictEncoder.addKey(key);

--- a/velox/dwio/dwrf/test/TestRLEv1Encoder.cpp
+++ b/velox/dwio/dwrf/test/TestRLEv1Encoder.cpp
@@ -93,7 +93,7 @@ class RleEncoderV1Test : public testing::Test {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
 };
 
 TEST_F(RleEncoderV1Test, encodeMinAndMax) {

--- a/velox/dwio/dwrf/test/TestRle.cpp
+++ b/velox/dwio/dwrf/test/TestRle.cpp
@@ -31,7 +31,7 @@ std::vector<int64_t> decodeRLEv2(
     size_t n,
     size_t count,
     const uint64_t* nulls = nullptr) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   std::unique_ptr<dwio::common::IntDecoder<true>> rle = createRleDecoder<true>(
       std::make_unique<dwio::common::SeekableArrayInputStream>(bytes, l),
       RleVersion_2,
@@ -181,7 +181,7 @@ TEST_F(RLEv2Test, basicDelta4) {
 };
 
 TEST_F(RLEv2Test, delta0Width) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   const unsigned char buffer[] = {
       0x4e, 0x2, 0x0, 0x1, 0x2, 0xc0, 0x2, 0x42, 0x0};
   std::unique_ptr<dwio::common::IntDecoder<false>> decoder =
@@ -275,7 +275,7 @@ TEST_F(RLEv2Test, multiByteShortRepeats) {
 };
 
 TEST_F(RLEv2Test, 0to2Repeat1Direct) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   const unsigned char buffer[] = {0x46, 0x02, 0x02, 0x40};
   std::unique_ptr<dwio::common::IntDecoder<true>> rle = createRleDecoder<true>(
       std::unique_ptr<dwio::common::SeekableInputStream>(
@@ -373,7 +373,7 @@ TEST_F(RLEv2Test, multipleRunsDirect) {
 };
 
 TEST_F(RLEv2Test, largeNegativesDirect) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   const unsigned char buffer[] = {
       0x7e, 0x04, 0xcf, 0xca, 0xcc, 0x91, 0xba, 0x38, 0x93, 0xab, 0x00,
       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -556,7 +556,7 @@ TEST_F(RLEv2Test, mixedPatchedAndShortRepeats) {
 };
 
 TEST_F(RLEv2Test, basicDirectSeek) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   // 0,1 repeated 10 times (signed ints) followed by
   // 0,2 repeated 10 times (signed ints)
   const unsigned char bytes[] = {
@@ -608,7 +608,7 @@ TEST_F(RLEv2Test, basicDirectSeek) {
 };
 
 TEST_F(RLEv2Test, bitsLeftByPreviousStream) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   // test for #109
   // 118 DIRECT values, followed by PATHCED values
   const unsigned char bytes[] = {
@@ -681,7 +681,7 @@ class RLEv1Test : public testing::Test {
 };
 
 TEST_F(RLEv1Test, simpleTest) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   const unsigned char buffer[] = {
       0x61, 0xff, 0x64, 0xfb, 0x02, 0x03, 0x5, 0x7, 0xb};
   std::unique_ptr<dwio::common::IntDecoder<false>> rle =
@@ -707,7 +707,7 @@ TEST_F(RLEv1Test, simpleTest) {
 };
 
 TEST_F(RLEv1Test, signedNullLiteralTest) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   const unsigned char buffer[] = {0xf8, 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7};
   std::unique_ptr<dwio::common::IntDecoder<true>> rle = createRleDecoder<true>(
       std::unique_ptr<dwio::common::SeekableInputStream>(
@@ -727,7 +727,7 @@ TEST_F(RLEv1Test, signedNullLiteralTest) {
 }
 
 TEST_F(RLEv1Test, splitHeader) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   const unsigned char buffer[] = {0x0, 0x00, 0xdc, 0xba, 0x98, 0x76};
   std::unique_ptr<dwio::common::IntDecoder<false>> rle =
       createRleDecoder<false>(
@@ -747,7 +747,7 @@ TEST_F(RLEv1Test, splitHeader) {
 }
 
 TEST_F(RLEv1Test, splitRuns) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   const unsigned char buffer[] = {
       0x7d, 0x01, 0xff, 0x01, 0xfb, 0x01, 0x02, 0x03, 0x04, 0x05};
   dwio::common::SeekableInputStream* const stream =
@@ -781,7 +781,7 @@ TEST_F(RLEv1Test, splitRuns) {
 }
 
 TEST_F(RLEv1Test, testSigned) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   const unsigned char buffer[] = {0x7f, 0xff, 0x20};
   dwio::common::SeekableInputStream* const stream =
       new dwio::common::SeekableArrayInputStream(
@@ -805,7 +805,7 @@ TEST_F(RLEv1Test, testSigned) {
 }
 
 TEST_F(RLEv1Test, testNull) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   const unsigned char buffer[] = {0x75, 0x02, 0x00};
   dwio::common::SeekableInputStream* const stream =
       new dwio::common::SeekableArrayInputStream(
@@ -837,7 +837,7 @@ TEST_F(RLEv1Test, testNull) {
 }
 
 TEST_F(RLEv1Test, testAllNulls) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   const unsigned char buffer[] = {0xf0, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
                                   0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
                                   0x0d, 0x0e, 0x0f, 0x3d, 0x00, 0x12};
@@ -877,7 +877,7 @@ TEST_F(RLEv1Test, testAllNulls) {
 }
 
 TEST_F(RLEv1Test, skipTest) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   // Create the RLE stream from Java's TestRunLengthIntegerEncoding.testSkips
   // for (size_t i = 0; i < 1024; ++i)
   //   out.write(i);
@@ -1119,7 +1119,7 @@ TEST_F(RLEv1Test, skipTest) {
 }
 
 TEST_F(RLEv1Test, seekTest) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   // Create the RLE stream from Java's
   // TestRunLengthIntegerEncoding.testUncompressedSeek
   // for (size_t i = 0; i < 1024; ++i)
@@ -3043,7 +3043,7 @@ TEST_F(RLEv1Test, seekTest) {
 }
 
 TEST_F(RLEv1Test, testLeadingNulls) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   const unsigned char buffer[] = {0xfb, 0x01, 0x02, 0x03, 0x04, 0x05};
   std::unique_ptr<dwio::common::IntDecoder<false>> rle =
       createRleDecoder<false>(

--- a/velox/dwio/dwrf/test/TestStatisticsBuilderUtils.cpp
+++ b/velox/dwio/dwrf/test/TestStatisticsBuilderUtils.cpp
@@ -59,7 +59,7 @@ class TestStatisticsBuilderUtils : public testing::Test {
   }
 
   const std::shared_ptr<memory::MemoryPool> pool_ =
-      memory::MemoryManager::getInstance()->addLeafPool();
+      memory::memoryManager()->addLeafPool();
 };
 
 TEST_F(TestStatisticsBuilderUtils, addIntegerValues) {

--- a/velox/dwio/dwrf/test/TestStringDictionaryEncoder.cpp
+++ b/velox/dwio/dwrf/test/TestStringDictionaryEncoder.cpp
@@ -50,7 +50,7 @@ TEST_F(TestStringDictionaryEncoder, AddKey) {
       TestCase{{"doe", "sow", "sow", "doe", "sow"}, {0, 1, 1, 0, 1}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = MemoryManager::getInstance()->addLeafPool();
+    auto pool = memoryManager()->addLeafPool();
     StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     std::vector<size_t> actualEncodedSequence{};
     for (const auto& key : testCase.addKeySequence) {
@@ -94,7 +94,7 @@ TEST_F(TestStringDictionaryEncoder, GetIndex) {
           {0, 3, 4, 2, 1, 3, 2, 4, 2, 0, 1, 0, 3}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = MemoryManager::getInstance()->addLeafPool();
+    auto pool = memoryManager()->addLeafPool();
     StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       stringDictEncoder.addKey(key, 0);
@@ -143,7 +143,7 @@ TEST_F(TestStringDictionaryEncoder, GetCount) {
           {3, 2, 3, 3, 2}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = MemoryManager::getInstance()->addLeafPool();
+    auto pool = memoryManager()->addLeafPool();
     StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       stringDictEncoder.addKey(key, 0);
@@ -197,7 +197,7 @@ TEST_F(TestStringDictionaryEncoder, GetStride) {
           {1, 1, 6, 3, 4}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = MemoryManager::getInstance()->addLeafPool();
+    auto pool = memoryManager()->addLeafPool();
     StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     for (const auto& kv : testCase.addKeySequence) {
       stringDictEncoder.addKey(kv.first, kv.second);
@@ -220,7 +220,7 @@ std::string genPaddedIntegerString(size_t integer, size_t length) {
 }
 
 TEST_F(TestStringDictionaryEncoder, Clear) {
-  auto pool = MemoryManager::getInstance()->addLeafPool();
+  auto pool = memoryManager()->addLeafPool();
   StringDictionaryEncoder stringDictEncoder{*pool, *pool};
   std::string baseString{"jjkkll"};
   for (size_t i = 0; i != 2500; ++i) {
@@ -242,7 +242,7 @@ TEST_F(TestStringDictionaryEncoder, Clear) {
 }
 
 TEST_F(TestStringDictionaryEncoder, MemBenchmark) {
-  auto pool = MemoryManager::getInstance()->addLeafPool();
+  auto pool = memoryManager()->addLeafPool();
   StringDictionaryEncoder stringDictEncoder{*pool, *pool};
   std::string baseString{"jjkkll"};
   for (size_t i = 0; i != 10000; ++i) {
@@ -253,7 +253,7 @@ TEST_F(TestStringDictionaryEncoder, MemBenchmark) {
 }
 
 TEST_F(TestStringDictionaryEncoder, Limit) {
-  auto pool = MemoryManager::getInstance()->addLeafPool();
+  auto pool = memoryManager()->addLeafPool();
   StringDictionaryEncoder encoder{*pool, *pool};
   encoder.addKey(folly::StringPiece{"abc"}, 0);
   dwio::common::DataBuffer<char> buf{*pool};

--- a/velox/dwio/dwrf/test/TestStripeDictionaryCache.cpp
+++ b/velox/dwio/dwrf/test/TestStripeDictionaryCache.cpp
@@ -62,7 +62,7 @@ class StripeDictionaryCacheTest : public testing::Test {
   }
 
   std::shared_ptr<velox::memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
 };
 } // namespace
 

--- a/velox/dwio/dwrf/test/TestStripeStream.cpp
+++ b/velox/dwio/dwrf/test/TestStripeStream.cpp
@@ -110,8 +110,7 @@ class StripeStreamTest : public testing::Test {
     MemoryManager::testingSetInstance({});
   }
 
-  std::shared_ptr<MemoryPool> pool_{
-      MemoryManager::getInstance()->addLeafPool()};
+  std::shared_ptr<MemoryPool> pool_{memoryManager()->addLeafPool()};
 };
 } // namespace
 
@@ -388,7 +387,7 @@ void addNode(T& t, uint32_t node, uint32_t offset = 0) {
 }
 
 TEST_F(StripeStreamTest, readEncryptedStreams) {
-  auto pool = MemoryManager::getInstance()->addRootPool("readEncryptedStreams");
+  auto pool = memoryManager()->addRootPool("readEncryptedStreams");
   google::protobuf::Arena arena;
   proto::PostScript ps;
   ps.set_compression(proto::CompressionKind::ZSTD);
@@ -474,7 +473,7 @@ TEST_F(StripeStreamTest, readEncryptedStreams) {
 }
 
 TEST_F(StripeStreamTest, schemaMismatch) {
-  auto pool = MemoryManager::getInstance()->addRootPool("schemaMismatch");
+  auto pool = memoryManager()->addRootPool("schemaMismatch");
   google::protobuf::Arena arena;
   proto::PostScript ps;
   ps.set_compression(proto::CompressionKind::ZSTD);

--- a/velox/dwio/dwrf/test/WriterContextTest.cpp
+++ b/velox/dwio/dwrf/test/WriterContextTest.cpp
@@ -34,9 +34,7 @@ class WriterContextTest : public testing::Test {
 TEST_F(WriterContextTest, GetIntDictionaryEncoder) {
   auto config = std::make_shared<Config>();
   WriterContext context{
-      config,
-      memory::MemoryManager::getInstance()->addRootPool(
-          "GetIntDictionaryEncoder")};
+      config, memory::memoryManager()->addRootPool("GetIntDictionaryEncoder")};
 
   EXPECT_EQ(0, context.dictEncoders_.size());
   auto& intEncoder_1_0 = context.getIntDictionaryEncoder<int32_t>(
@@ -71,7 +69,7 @@ TEST_F(WriterContextTest, RemoveIntDictionaryEncoderForNode) {
   config->set(Config::MAP_FLAT_DICT_SHARE, false);
   WriterContext context{
       config,
-      memory::MemoryManager::getInstance()->addRootPool(
+      memory::memoryManager()->addRootPool(
           "RemoveIntDictionaryEncoderForNode")};
 
   context.getIntDictionaryEncoder<int32_t>(
@@ -123,8 +121,7 @@ TEST_F(WriterContextTest, BuildPhysicalSizeAggregators) {
   auto config = std::make_shared<Config>();
   WriterContext context{
       config,
-      memory::MemoryManager::getInstance()->addRootPool(
-          "BuildPhysicalSizeAggregators")};
+      memory::memoryManager()->addRootPool("BuildPhysicalSizeAggregators")};
   auto type = ROW({
       {"array", ARRAY(REAL())},
       {"map", MAP(INTEGER(), DOUBLE())},
@@ -152,7 +149,7 @@ TEST_F(WriterContextTest, BuildPhysicalSizeAggregators) {
 }
 
 TEST_F(WriterContextTest, memory) {
-  auto writerRoot = memory::MemoryManager::getInstance()->addRootPool(
+  auto writerRoot = memory::memoryManager()->addRootPool(
       "memory", 1L << 30, exec::MemoryReclaimer::create());
   WriterContext context{std::make_shared<Config>(), writerRoot};
   ASSERT_EQ(context.getTotalMemoryUsage(), 0);
@@ -222,7 +219,7 @@ TEST_F(WriterContextTest, memory) {
 }
 
 TEST_F(WriterContextTest, abort) {
-  auto writerRoot = memory::MemoryManager::getInstance()->addRootPool(
+  auto writerRoot = memory::memoryManager()->addRootPool(
       "abort", 1L << 30, exec::MemoryReclaimer::create());
   WriterContext context{std::make_shared<Config>(), writerRoot};
   ASSERT_EQ(context.getTotalMemoryUsage(), 0);

--- a/velox/dwio/dwrf/test/WriterExtendedTests.cpp
+++ b/velox/dwio/dwrf/test/WriterExtendedTests.cpp
@@ -124,8 +124,7 @@ class E2EWriterTest : public testing::Test {
 TEST_F(E2EWriterTest, FlushPolicySimpleEncoding) {
   const size_t batchCount = 200;
   const size_t size = 1000;
-  auto pool =
-      facebook::velox::memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
 
   HiveTypeParser parser;
   auto type = parser.parse(
@@ -179,8 +178,7 @@ TEST_F(E2EWriterTest, FlushPolicySimpleEncoding) {
 TEST_F(E2EWriterTest, FlushPolicyDictionaryEncoding) {
   const size_t batchCount = 500;
   const size_t size = 1000;
-  auto pool =
-      facebook::velox::memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
 
   HiveTypeParser parser;
   auto type = parser.parse(
@@ -322,8 +320,7 @@ TEST_F(E2EWriterTest, FlushPolicyDictionaryEncoding) {
 TEST_F(E2EWriterTest, FlushPolicyNestedTypes) {
   const size_t batchCount = 10;
   const size_t size = 1000;
-  auto pool =
-      facebook::velox::memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
 
   HiveTypeParser parser;
   auto type = parser.parse(
@@ -384,8 +381,7 @@ TEST_F(E2EWriterTest, FlushPolicyNestedTypes) {
 TEST_F(E2EWriterTest, FlushPolicyFlatMap) {
   const size_t batchCount = 10;
   const size_t size = 500;
-  auto pool =
-      facebook::velox::memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
 
   HiveTypeParser parser;
   // A mixture of columns where dictionary sharing is not necessarily

--- a/velox/dwio/dwrf/test/WriterSinkTest.cpp
+++ b/velox/dwio/dwrf/test/WriterSinkTest.cpp
@@ -51,7 +51,7 @@ class WriterSinkTest : public Test {
 };
 
 TEST_F(WriterSinkTest, Checksum) {
-  auto pool = MemoryManager::getInstance()->addLeafPool();
+  auto pool = memoryManager()->addLeafPool();
   MemorySink out{1024 + 3, {.pool = pool.get()}};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::CRC32);
@@ -94,7 +94,7 @@ TEST_F(WriterSinkTest, Checksum) {
 }
 
 TEST_F(WriterSinkTest, NoChecksum) {
-  auto pool = MemoryManager::getInstance()->addLeafPool();
+  auto pool = memoryManager()->addLeafPool();
   MemorySink out{1024 + 3, {.pool = pool.get()}};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::NULL_);
@@ -111,7 +111,7 @@ TEST_F(WriterSinkTest, NoChecksum) {
 }
 
 TEST_F(WriterSinkTest, NoCache) {
-  auto pool = MemoryManager::getInstance()->addLeafPool();
+  auto pool = memoryManager()->addLeafPool();
   MemorySink out{1024, {.pool = pool.get()}};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::NULL_);
@@ -136,7 +136,7 @@ TEST_F(WriterSinkTest, NoCache) {
 }
 
 TEST_F(WriterSinkTest, CacheIndex) {
-  auto pool = MemoryManager::getInstance()->addLeafPool();
+  auto pool = memoryManager()->addLeafPool();
   MemorySink out{1024, {.pool = pool.get()}};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::NULL_);
@@ -179,7 +179,7 @@ TEST_F(WriterSinkTest, CacheIndex) {
 }
 
 TEST_F(WriterSinkTest, CacheFooter) {
-  auto pool = MemoryManager::getInstance()->addLeafPool();
+  auto pool = memoryManager()->addLeafPool();
   MemorySink out{1024, {.pool = pool.get()}};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::NULL_);
@@ -222,7 +222,7 @@ TEST_F(WriterSinkTest, CacheFooter) {
 }
 
 TEST_F(WriterSinkTest, CacheBothEmptyIndex) {
-  auto pool = MemoryManager::getInstance()->addLeafPool();
+  auto pool = memoryManager()->addLeafPool();
   MemorySink out{1024, {.pool = pool.get()}};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::NULL_);
@@ -251,7 +251,7 @@ TEST_F(WriterSinkTest, CacheBothEmptyIndex) {
 }
 
 TEST_F(WriterSinkTest, CacheBoth) {
-  auto pool = MemoryManager::getInstance()->addLeafPool();
+  auto pool = memoryManager()->addLeafPool();
   MemorySink out{1024, {.pool = pool.get()}};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::NULL_);
@@ -300,7 +300,7 @@ TEST_F(WriterSinkTest, CacheBoth) {
 }
 
 TEST_F(WriterSinkTest, CacheExceedsLimit) {
-  auto pool = MemoryManager::getInstance()->addLeafPool();
+  auto pool = memoryManager()->addLeafPool();
   MemorySink out{1024, {.pool = pool.get()}};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::NULL_);
@@ -428,7 +428,7 @@ TEST_F(WriterSinkTest, CacheExceedsLimit) {
 }
 
 TEST_F(WriterSinkTest, CacheLarge) {
-  auto pool = MemoryManager::getInstance()->addLeafPool();
+  auto pool = memoryManager()->addLeafPool();
   MemorySink out{10 * 1024 * 1024 + 3, {.pool = pool.get()}};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::NULL_);
@@ -455,7 +455,7 @@ TEST_F(WriterSinkTest, CacheLarge) {
 }
 
 TEST_F(WriterSinkTest, SetModeOutOfOrder) {
-  auto pool = MemoryManager::getInstance()->addLeafPool();
+  auto pool = memoryManager()->addLeafPool();
   MemorySink out{1024, {.pool = pool.get()}};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::CRC32);

--- a/velox/dwio/dwrf/test/WriterTest.cpp
+++ b/velox/dwio/dwrf/test/WriterTest.cpp
@@ -36,8 +36,7 @@ class WriterTest : public Test {
     MemoryManager::testingSetInstance({});
   }
 
-  WriterTest()
-      : pool_(MemoryManager::getInstance()->addLeafPool("WriterTest")) {}
+  WriterTest() : pool_(memoryManager()->addLeafPool("WriterTest")) {}
 
   WriterBase& createWriter(
       const std::shared_ptr<Config>& config,
@@ -50,8 +49,7 @@ class WriterTest : public Test {
     }
     writer_ = std::make_unique<WriterBase>(std::move(sink));
     writer_->initContext(
-        config,
-        memory::MemoryManager::getInstance()->addRootPool("WriterTest"));
+        config, memory::memoryManager()->addRootPool("WriterTest"));
     auto& context = writer_->getContext();
     context.initBuffer();
     writer_->getSink().init(
@@ -466,8 +464,7 @@ class MockFileSink : public dwio::common::FileSink {
 
 TEST_F(WriterTest, FlushWriterSinkUponClose) {
   auto config = std::make_shared<Config>();
-  auto pool = memory::MemoryManager::getInstance()->addRootPool(
-      "FlushWriterSinkUponClose");
+  auto pool = memory::memoryManager()->addRootPool("FlushWriterSinkUponClose");
   auto sink = std::make_unique<MockFileSink>();
   MockFileSink* sinkPtr = sink.get();
   EXPECT_CALL(*sinkPtr, write(_)).Times(1);

--- a/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
+++ b/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
@@ -46,9 +46,7 @@ namespace facebook::velox::dwrf {
   options.layoutPlannerFactory = layoutPlannerFactory;
 
   return std::make_unique<dwrf::Writer>(
-      std::move(sink),
-      options,
-      velox::memory::MemoryManager::getInstance()->addRootPool());
+      std::move(sink), options, velox::memory::memoryManager()->addRootPool());
 }
 
 /* static */ std::unique_ptr<Writer> E2EWriterTestUtil::writeData(

--- a/velox/dwio/dwrf/utils/test/BufferedWriterTest.cpp
+++ b/velox/dwio/dwrf/utils/test/BufferedWriterTest.cpp
@@ -30,8 +30,7 @@ class BufferedWriterTest : public testing::TestWithParam<bool> {
  protected:
   BufferedWriterTest()
       : usePool_(GetParam()),
-        pool_(memory::MemoryManager::getInstance()->addLeafPool(
-            "BufferedWriterTest")) {}
+        pool_(memory::memoryManager()->addLeafPool("BufferedWriterTest")) {}
 
   void SetUp() override {}
 

--- a/velox/dwio/parquet/tests/ParquetTestBase.h
+++ b/velox/dwio/parquet/tests/ParquetTestBase.h
@@ -39,8 +39,7 @@ class ParquetTestBase : public testing::Test, public test::VectorTestBase {
 
   void SetUp() override {
     dwio::common::LocalFileSink::registerFactory();
-    rootPool_ =
-        memory::MemoryManager::getInstance()->addRootPool("ParquetTests");
+    rootPool_ = memory::memoryManager()->addRootPool("ParquetTests");
     leafPool_ = rootPool_->addLeafChild("ParquetTests");
     tempPath_ = exec::test::TempDirectoryPath::create();
   }

--- a/velox/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -81,7 +81,7 @@ class ParquetTpchTest : public testing::Test {
 
   void saveTpchTablesAsParquet() {
     std::shared_ptr<memory::MemoryPool> rootPool{
-        memory::MemoryManager::getInstance()->addRootPool()};
+        memory::memoryManager()->addRootPool()};
     std::shared_ptr<memory::MemoryPool> pool{rootPool->addLeafChild("leaf")};
 
     for (const auto& table : tpch::tables) {

--- a/velox/dwio/parquet/tests/reader/NestedStructureDecoderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/NestedStructureDecoderBenchmark.cpp
@@ -30,7 +30,7 @@ class NestedStructureDecoderBenchmark {
       : numValues_(numValues),
         definitionLevels_(new unsigned char[numValues]()),
         repetitionLevels_(new unsigned char[numValues]()),
-        pool_(memory::MemoryManager::getInstance()->addLeafPool()) {}
+        pool_(memory::memoryManager()->addLeafPool()) {}
 
   void setUp(uint16_t maxDefinition, uint16_t maxRepetition) {
     dwio::common::ensureCapacity<uint64_t>(

--- a/velox/dwio/parquet/tests/reader/NestedStructureDecoderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/NestedStructureDecoderTest.cpp
@@ -33,7 +33,7 @@ class NestedStructureDecoderTest : public testing::Test {
   }
 
   void SetUp() override {
-    pool_ = memory::MemoryManager::getInstance()->addLeafPool();
+    pool_ = memory::memoryManager()->addLeafPool();
 
     dwio::common::ensureCapacity<bool>(
         nullsBuffer_, kMaxNumValues, pool_.get());

--- a/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
@@ -43,8 +43,7 @@ class ParquetReaderBenchmark {
       bool disableDictionary,
       const RowTypePtr& rowType)
       : disableDictionary_(disableDictionary) {
-    rootPool_ = memory::MemoryManager::getInstance()->addRootPool(
-        "ParquetReaderBenchmark");
+    rootPool_ = memory::memoryManager()->addRootPool("ParquetReaderBenchmark");
     leafPool_ = rootPool_->addLeafChild("ParquetReaderBenchmark");
     dataSetBuilder_ = std::make_unique<DataSetBuilder>(*leafPool_, 0);
     auto path = fileFolder_->path + "/" + fileName_;

--- a/velox/examples/ExpressionEval.cpp
+++ b/velox/examples/ExpressionEval.cpp
@@ -67,7 +67,7 @@ int main(int argc, char** argv) {
   //
   // Optionally, one can control the per-thread memory cap by passing it as an
   // argument to add() - no limit by default.
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   core::ExecCtx execCtx{pool.get(), queryCtx.get()};
 
   // Next, let's create an expression tree to be executed in this example. On a

--- a/velox/examples/OpaqueType.cpp
+++ b/velox/examples/OpaqueType.cpp
@@ -190,7 +190,7 @@ int main(int argc, char** argv) {
   memory::MemoryManager::initialize({});
   // Create memory pool and other query-related structures.
   auto queryCtx = std::make_shared<core::QueryCtx>();
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   core::ExecCtx execCtx{pool.get(), queryCtx.get()};
 
   // Next, we need to generate an input batch of data (rowVector). We create a

--- a/velox/examples/OperatorExtensibility.cpp
+++ b/velox/examples/OperatorExtensibility.cpp
@@ -171,7 +171,7 @@ int main(int argc, char** argv) {
 
   // Create a new memory pool to in this example.
   memory::MemoryManager::initialize({});
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
 
   // VectorMaker is a test utility that helps you build vectors. Shouldn't be
   // used in production.

--- a/velox/examples/ScanAndSort.cpp
+++ b/velox/examples/ScanAndSort.cpp
@@ -46,7 +46,7 @@ int main(int argc, char** argv) {
 
   // Default memory allocator used throughout this example.
   memory::MemoryManager::initialize({});
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
 
   // For this example, the input dataset will be comprised of a single BIGINT
   // column ("my_col"), containing 10 rows.

--- a/velox/examples/ScanOrc.cpp
+++ b/velox/examples/ScanOrc.cpp
@@ -42,8 +42,7 @@ int main(int argc, char** argv) {
   filesystems::registerLocalFileSystem();
   dwrf::registerDwrfReaderFactory();
   facebook::velox::memory::MemoryManager::initialize({});
-  auto pool =
-      facebook::velox::memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
 
   std::string filePath{argv[1]};
   dwio::common::ReaderOptions readerOpts{pool.get()};

--- a/velox/examples/VectorReaderWriter.cpp
+++ b/velox/examples/VectorReaderWriter.cpp
@@ -47,7 +47,7 @@ int main() {
   // Array<Map<int,int>>
   auto type = TypeFactory<TypeKind::ARRAY>::create(
       TypeFactory<TypeKind::MAP>::create(BIGINT(), BIGINT()));
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
 
   // result vector
   VectorPtr result;

--- a/velox/exec/benchmarks/ExchangeBenchmark.cpp
+++ b/velox/exec/benchmarks/ExchangeBenchmark.cpp
@@ -292,8 +292,7 @@ class ExchangeBenchmark : public VectorTestBase {
     auto queryCtx = std::make_shared<core::QueryCtx>(
         executor_.get(), core::QueryConfig(std::move(configCopy)));
     queryCtx->testingOverrideMemoryPool(
-        memory::MemoryManager::getInstance()->addRootPool(
-            queryCtx->queryId(), maxMemory));
+        memory::memoryManager()->addRootPool(queryCtx->queryId(), maxMemory));
     core::PlanFragment planFragment{planNode};
     return Task::create(
         taskId,

--- a/velox/exec/benchmarks/HashTableBenchmark.cpp
+++ b/velox/exec/benchmarks/HashTableBenchmark.cpp
@@ -561,7 +561,7 @@ class HashTableBenchmark : public VectorTestBase {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   std::unique_ptr<VectorMaker> vectorMaker_{
       std::make_unique<VectorMaker>(pool_.get())};
   // Bitmap of positions in batches_ that end up in the table.

--- a/velox/exec/benchmarks/RowContainerSortBenchmark.cpp
+++ b/velox/exec/benchmarks/RowContainerSortBenchmark.cpp
@@ -63,7 +63,7 @@ facebook::velox::parquet::ParquetReader createReader(
 std::vector<std::optional<StringView>> getDataFromFile() {
   const std::string sample(getExampleFilePath("str_sort.parquet"));
   auto rowType = ROW({"query_sig", "result_sig"}, {VARCHAR(), VARCHAR()});
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   facebook::velox::dwio::common::ReaderOptions readerOptions{pool.get()};
   facebook::velox::parquet::ParquetReader reader =
       createReader(sample, readerOptions);
@@ -101,7 +101,7 @@ std::vector<char*> store(
 template <typename T>
 void rowContainerStdSortBenchmark(uint32_t iterations, size_t cardinality) {
   folly::BenchmarkSuspender suspender;
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   VectorMaker vectorMaker(pool.get());
 
   for (size_t k = 0; k < iterations; ++k) {
@@ -131,7 +131,7 @@ void rowContainerStdSortBenchmark(uint32_t iterations, size_t cardinality) {
 template <typename T>
 void rowContainerTimSortBenchmark(uint32_t iterations, size_t cardinality) {
   folly::BenchmarkSuspender suspender;
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   VectorMaker vectorMaker(pool.get());
 
   for (size_t k = 0; k < iterations; ++k) {
@@ -166,7 +166,7 @@ void BM_Int64_timSort(uint32_t iterations, size_t cardinality) {
 
 void BM_STR_stdSort(uint32_t iterations) {
   folly::BenchmarkSuspender suspender;
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   VectorMaker vectorMaker(pool.get());
   auto data = getDataFromFile();
   auto vector =
@@ -191,7 +191,7 @@ void BM_STR_stdSort(uint32_t iterations) {
 
 void BM_STR_timSort(uint32_t iterations) {
   folly::BenchmarkSuspender suspender;
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   VectorMaker vectorMaker(pool.get());
   auto data = getDataFromFile();
   auto vector =

--- a/velox/exec/benchmarks/VectorHasherBenchmark.cpp
+++ b/velox/exec/benchmarks/VectorHasherBenchmark.cpp
@@ -58,7 +58,7 @@ class BenchmarkBase {
 
  private:
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   VectorMaker vectorMaker_{pool_.get()};
 };
 

--- a/velox/exec/fuzzer/AggregationFuzzerBase.h
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.h
@@ -232,7 +232,7 @@ class AggregationFuzzerBase {
   size_t currentSeed_{0};
 
   std::shared_ptr<memory::MemoryPool> rootPool_{
-      memory::MemoryManager::getInstance()->addRootPool()};
+      memory::memoryManager()->addRootPool()};
   std::shared_ptr<memory::MemoryPool> pool_{rootPool_->addLeafChild("leaf")};
   VectorFuzzer vectorFuzzer_;
 };

--- a/velox/exec/fuzzer/PrestoQueryRunner.h
+++ b/velox/exec/fuzzer/PrestoQueryRunner.h
@@ -88,7 +88,7 @@ class PrestoQueryRunner : public velox::exec::test::ReferenceQueryRunner {
   const std::chrono::milliseconds timeout_;
   folly::EventBaseThread eventBaseThread_{false};
   std::shared_ptr<velox::memory::MemoryPool> rootPool_{
-      velox::memory::MemoryManager::getInstance()->addRootPool()};
+      velox::memory::memoryManager()->addRootPool()};
   std::shared_ptr<velox::memory::MemoryPool> pool_{
       rootPool_->addLeafChild("leaf")};
 };

--- a/velox/exec/prefixsort/benchmarks/PrefixSortAlgorithmBenchmark.cpp
+++ b/velox/exec/prefixsort/benchmarks/PrefixSortAlgorithmBenchmark.cpp
@@ -54,7 +54,7 @@ class PrefixSortAlgorithmBenchmark {
 
  private:
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   folly::Random::DefaultGenerator rng_;
 };
 

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -2027,9 +2027,8 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringInputProcessing) {
 
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-    queryCtx->testingOverrideMemoryPool(
-        memory::MemoryManager::getInstance()->addRootPool(
-            queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
+    queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
+        queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
     auto expectedResult =
         AssertQueryBuilder(
             PlanBuilder()
@@ -2170,9 +2169,8 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringReserve) {
 
   auto tempDirectory = exec::test::TempDirectoryPath::create();
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-  queryCtx->testingOverrideMemoryPool(
-      memory::MemoryManager::getInstance()->addRootPool(
-          queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
+  queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
+      queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
   auto expectedResult =
       AssertQueryBuilder(PlanBuilder()
                              .values(batches)
@@ -2281,8 +2279,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringAllocation) {
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
-        memory::MemoryManager::getInstance()->addRootPool(
-            queryCtx->queryId(), kMaxBytes));
+        memory::memoryManager()->addRootPool(queryCtx->queryId(), kMaxBytes));
     auto expectedResult =
         AssertQueryBuilder(
             PlanBuilder()
@@ -2406,9 +2403,8 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringOutputProcessing) {
     SCOPED_TRACE(fmt::format("enableSpilling {}", enableSpilling));
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-    queryCtx->testingOverrideMemoryPool(
-        memory::MemoryManager::getInstance()->addRootPool(
-            queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
+    queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
+        queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
     auto expectedResult =
         AssertQueryBuilder(
             PlanBuilder()
@@ -2551,8 +2547,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringNonReclaimableSection) {
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
-        memory::MemoryManager::getInstance()->addRootPool(
-            queryCtx->queryId(), kMaxBytes));
+        memory::memoryManager()->addRootPool(queryCtx->queryId(), kMaxBytes));
     auto expectedResult =
         AssertQueryBuilder(
             PlanBuilder()
@@ -2704,8 +2699,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimWithEmptyAggregationTable) {
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
-        memory::MemoryManager::getInstance()->addRootPool(
-            queryCtx->queryId(), kMaxBytes));
+        memory::memoryManager()->addRootPool(queryCtx->queryId(), kMaxBytes));
     auto expectedResult =
         AssertQueryBuilder(
             PlanBuilder()
@@ -2838,9 +2832,8 @@ DEBUG_ONLY_TEST_F(AggregationTest, abortDuringOutputProcessing) {
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-    queryCtx->testingOverrideMemoryPool(
-        memory::MemoryManager::getInstance()->addRootPool(
-            queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
+    queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
+        queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
     auto expectedResult =
         AssertQueryBuilder(
             PlanBuilder()
@@ -2927,9 +2920,8 @@ DEBUG_ONLY_TEST_F(AggregationTest, abortDuringInputgProcessing) {
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-    queryCtx->testingOverrideMemoryPool(
-        memory::MemoryManager::getInstance()->addRootPool(
-            queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
+    queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
+        queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
     auto expectedResult =
         AssertQueryBuilder(
             PlanBuilder()
@@ -3115,9 +3107,8 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimEmptyInput) {
 
   auto tempDirectory = exec::test::TempDirectoryPath::create();
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-  queryCtx->testingOverrideMemoryPool(
-      memory::MemoryManager::getInstance()->addRootPool(
-          queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
+  queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
+      queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
   core::PlanNodeId aggNodeId;
   auto task =
       AssertQueryBuilder(
@@ -3188,9 +3179,8 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimEmptyOutput) {
 
   auto tempDirectory = exec::test::TempDirectoryPath::create();
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-  queryCtx->testingOverrideMemoryPool(
-      memory::MemoryManager::getInstance()->addRootPool(
-          queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
+  queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
+      queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
   core::PlanNodeId aggNodeId;
   auto task =
       AssertQueryBuilder(PlanBuilder()

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -61,7 +61,7 @@ class ExchangeClientTest : public testing::Test,
       const core::PlanNodePtr& planNode) {
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
-        memory::MemoryManager::getInstance()->addRootPool(queryCtx->queryId()));
+        memory::memoryManager()->addRootPool(queryCtx->queryId()));
     return Task::create(
         taskId, core::PlanFragment{planNode}, 0, std::move(queryCtx));
   }

--- a/velox/exec/tests/ExchangeFuzzer.cpp
+++ b/velox/exec/tests/ExchangeFuzzer.cpp
@@ -259,9 +259,7 @@ class ExchangeFuzzer : public VectorTestBase {
       }
       LOG(INFO) << "Memory after run="
                 << succinctBytes(memory::AllocationTraits::pageBytes(
-                       memory::MemoryManager::getInstance()
-                           ->allocator()
-                           .numAllocated()));
+                       memory::memoryManager()->allocator().numAllocated()));
 
       if (FLAGS_duration_sec == 0 && FLAGS_steps &&
           counter + 1 >= FLAGS_steps) {
@@ -371,8 +369,7 @@ class ExchangeFuzzer : public VectorTestBase {
     auto queryCtx = std::make_shared<core::QueryCtx>(
         executor_.get(), core::QueryConfig(std::move(configCopy)));
     queryCtx->testingOverrideMemoryPool(
-        memory::MemoryManager::getInstance()->addRootPool(
-            queryCtx->queryId(), maxMemory));
+        memory::memoryManager()->addRootPool(queryCtx->queryId(), maxMemory));
     core::PlanFragment planFragment{planNode};
     return Task::create(
         taskId,

--- a/velox/exec/tests/HashJoinBridgeTest.cpp
+++ b/velox/exec/tests/HashJoinBridgeTest.cpp
@@ -134,7 +134,7 @@ class HashJoinBridgeTest : public testing::Test,
   const uint32_t numSpillFilesPerPartition_{20};
 
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   memory::MemoryAllocator* allocator_{memory::MemoryAllocator::getInstance()};
   std::shared_ptr<TempDirectoryPath> tempDir_;
 
@@ -484,8 +484,7 @@ TEST_P(HashJoinBridgeTest, multiThreading) {
 }
 
 TEST_P(HashJoinBridgeTest, isHashBuildMemoryPool) {
-  auto root = memory::MemoryManager::getInstance()->addRootPool(
-      "isHashBuildMemoryPool");
+  auto root = memory::memoryManager()->addRootPool("isHashBuildMemoryPool");
   struct {
     std::string poolName;
     bool expectedHashBuildPool;

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -4947,7 +4947,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringInputProcessing) {
     SCOPED_TRACE(testData.debugString());
 
     auto tempDirectory = exec::test::TempDirectoryPath::create();
-    auto queryPool = memory::MemoryManager::getInstance()->addRootPool(
+    auto queryPool = memory::memoryManager()->addRootPool(
         "", kMaxBytes, memory::MemoryReclaimer::create());
 
     core::PlanNodeId probeScanId;
@@ -5094,7 +5094,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringReserve) {
   createDuckDbTable("u", buildVectors);
 
   auto tempDirectory = exec::test::TempDirectoryPath::create();
-  auto queryPool = memory::MemoryManager::getInstance()->addRootPool(
+  auto queryPool = memory::memoryManager()->addRootPool(
       "", kMaxBytes, memory::MemoryReclaimer::create());
 
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
@@ -5224,8 +5224,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringAllocation) {
     SCOPED_TRACE(fmt::format("enableSpilling {}", enableSpilling));
 
     auto tempDirectory = exec::test::TempDirectoryPath::create();
-    auto queryPool =
-        memory::MemoryManager::getInstance()->addRootPool("", kMaxBytes);
+    auto queryPool = memory::memoryManager()->addRootPool("", kMaxBytes);
 
     core::PlanNodeId probeScanId;
     auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
@@ -5356,7 +5355,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringOutputProcessing) {
   for (const auto enableSpilling : enableSpillings) {
     SCOPED_TRACE(fmt::format("enableSpilling {}", enableSpilling));
     auto tempDirectory = exec::test::TempDirectoryPath::create();
-    auto queryPool = memory::MemoryManager::getInstance()->addRootPool(
+    auto queryPool = memory::memoryManager()->addRootPool(
         "", kMaxBytes, memory::MemoryReclaimer::create());
 
     core::PlanNodeId probeScanId;
@@ -5482,7 +5481,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringWaitForProbe) {
   createDuckDbTable("u", buildVectors);
 
   auto tempDirectory = exec::test::TempDirectoryPath::create();
-  auto queryPool = memory::MemoryManager::getInstance()->addRootPool(
+  auto queryPool = memory::memoryManager()->addRootPool(
       "", kMaxBytes, memory::MemoryReclaimer::create());
 
   core::PlanNodeId probeScanId;
@@ -5631,7 +5630,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashBuildAbortDuringOutputProcessing) {
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
-    auto queryPool = memory::MemoryManager::getInstance()->addRootPool(
+    auto queryPool = memory::memoryManager()->addRootPool(
         "", kMaxBytes, memory::MemoryReclaimer::create());
 
     core::PlanNodeId probeScanId;
@@ -5736,7 +5735,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashBuildAbortDuringInputgProcessing) {
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
-    auto queryPool = memory::MemoryManager::getInstance()->addRootPool(
+    auto queryPool = memory::memoryManager()->addRootPool(
         "", kMaxBytes, memory::MemoryReclaimer::create());
 
     core::PlanNodeId probeScanId;
@@ -5842,7 +5841,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashProbeAbortDuringInputProcessing) {
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
-    auto queryPool = memory::MemoryManager::getInstance()->addRootPool(
+    auto queryPool = memory::memoryManager()->addRootPool(
         "", kMaxBytes, memory::MemoryReclaimer::create());
 
     core::PlanNodeId probeScanId;

--- a/velox/exec/tests/JoinFuzzer.cpp
+++ b/velox/exec/tests/JoinFuzzer.cpp
@@ -132,7 +132,7 @@ class JoinFuzzer {
   size_t currentSeed_{0};
 
   std::shared_ptr<memory::MemoryPool> rootPool_{
-      memory::MemoryManager::getInstance()->addRootPool()};
+      memory::memoryManager()->addRootPool()};
   std::shared_ptr<memory::MemoryPool> pool_{rootPool_->addLeafChild("leaf")};
   VectorFuzzer vectorFuzzer_;
 };

--- a/velox/exec/tests/MemoryReclaimerTest.cpp
+++ b/velox/exec/tests/MemoryReclaimerTest.cpp
@@ -26,8 +26,7 @@ using namespace facebook::velox::memory;
 
 class MemoryReclaimerTest : public OperatorTestBase {
  protected:
-  MemoryReclaimerTest()
-      : pool_(memory::MemoryManager::getInstance()->addLeafPool()) {
+  MemoryReclaimerTest() : pool_(memory::memoryManager()->addLeafPool()) {
     const auto seed =
         std::chrono::system_clock::now().time_since_epoch().count();
     rng_.seed(seed);
@@ -87,7 +86,7 @@ TEST_F(MemoryReclaimerTest, abortTest) {
   for (const auto& leafPool : {false, true}) {
     const std::string testName = fmt::format("leafPool: {}", leafPool);
     SCOPED_TRACE(testName);
-    auto rootPool = memory::MemoryManager::getInstance()->addRootPool(
+    auto rootPool = memory::memoryManager()->addRootPool(
         testName, kMaxMemory, exec::MemoryReclaimer::create());
     ASSERT_FALSE(rootPool->aborted());
     if (leafPool) {

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -68,9 +68,8 @@ class MultiFragmentTest : public HiveConnectorTestBase {
     auto configCopy = configSettings_;
     auto queryCtx = std::make_shared<core::QueryCtx>(
         executor_.get(), core::QueryConfig(std::move(configCopy)));
-    queryCtx->testingOverrideMemoryPool(
-        memory::MemoryManager::getInstance()->addRootPool(
-            queryCtx->queryId(), maxMemory, MemoryReclaimer::create()));
+    queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
+        queryCtx->queryId(), maxMemory, MemoryReclaimer::create()));
     core::PlanFragment planFragment{planNode};
     return Task::create(
         taskId,

--- a/velox/exec/tests/OperatorUtilsTest.cpp
+++ b/velox/exec/tests/OperatorUtilsTest.cpp
@@ -125,7 +125,7 @@ class OperatorUtilsTest
   }
 
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   std::shared_ptr<Task> task_;
   std::shared_ptr<Driver> driver_;
   std::unique_ptr<DriverCtx> driverCtx_;

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -551,8 +551,7 @@ TEST_F(OrderByTest, spillWithMemoryLimit) {
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
-        memory::MemoryManager::getInstance()->addRootPool(
-            queryCtx->queryId(), kMaxBytes));
+        memory::memoryManager()->addRootPool(queryCtx->queryId(), kMaxBytes));
     auto results =
         AssertQueryBuilder(
             PlanBuilder()
@@ -615,9 +614,8 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringInputProcessing) {
 
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-    queryCtx->testingOverrideMemoryPool(
-        memory::MemoryManager::getInstance()->addRootPool(
-            queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
+    queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
+        queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
     auto expectedResult =
         AssertQueryBuilder(
             PlanBuilder()
@@ -755,9 +753,8 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringReserve) {
 
   auto tempDirectory = exec::test::TempDirectoryPath::create();
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-  queryCtx->testingOverrideMemoryPool(
-      memory::MemoryManager::getInstance()->addRootPool(
-          queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
+  queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
+      queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
   auto expectedResult =
       AssertQueryBuilder(
           PlanBuilder()
@@ -870,8 +867,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringAllocation) {
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
-        memory::MemoryManager::getInstance()->addRootPool(
-            queryCtx->queryId(), kMaxBytes));
+        memory::memoryManager()->addRootPool(queryCtx->queryId(), kMaxBytes));
     auto expectedResult =
         AssertQueryBuilder(
             PlanBuilder()
@@ -1000,9 +996,8 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringOutputProcessing) {
     SCOPED_TRACE(fmt::format("enableSpilling {}", enableSpilling));
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-    queryCtx->testingOverrideMemoryPool(
-        memory::MemoryManager::getInstance()->addRootPool(
-            queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
+    queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
+        queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
     auto expectedResult =
         AssertQueryBuilder(
             PlanBuilder()
@@ -1131,9 +1126,8 @@ DEBUG_ONLY_TEST_F(OrderByTest, abortDuringOutputProcessing) {
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-    queryCtx->testingOverrideMemoryPool(
-        memory::MemoryManager::getInstance()->addRootPool(
-            queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
+    queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
+        queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
     auto expectedResult =
         AssertQueryBuilder(
             PlanBuilder()
@@ -1225,9 +1219,8 @@ DEBUG_ONLY_TEST_F(OrderByTest, abortDuringInputgProcessing) {
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-    queryCtx->testingOverrideMemoryPool(
-        memory::MemoryManager::getInstance()->addRootPool(
-            queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
+    queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
+        queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
     auto expectedResult =
         AssertQueryBuilder(
             PlanBuilder()

--- a/velox/exec/tests/OutputBufferManagerTest.cpp
+++ b/velox/exec/tests/OutputBufferManagerTest.cpp
@@ -41,8 +41,7 @@ class OutputBufferManagerTest : public testing::Test {
   }
 
   void SetUp() override {
-    pool_ =
-        facebook::velox::memory::MemoryManager::getInstance()->addLeafPool();
+    pool_ = facebook::velox::memory::memoryManager()->addLeafPool();
     bufferManager_ = OutputBufferManager::getInstance().lock();
     if (!isRegisteredVectorSerde()) {
       facebook::velox::serializer::presto::PrestoVectorSerde::

--- a/velox/exec/tests/RoundRobinPartitionFunctionTest.cpp
+++ b/velox/exec/tests/RoundRobinPartitionFunctionTest.cpp
@@ -32,7 +32,7 @@ class RoundRobinPartitionFunctionTest : public test::VectorTestBase,
 TEST_F(RoundRobinPartitionFunctionTest, basic) {
   exec::RoundRobinPartitionFunction partitionFunction(10);
 
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   test::VectorMaker vm(pool.get());
 
   auto data = vm.rowVector(ROW({}, {}), 1024);

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -76,9 +76,7 @@ class SortBufferTest : public OperatorTestBase {
 
   const int64_t maxBytes_ = 20LL << 20; // 20 MB
   const std::shared_ptr<memory::MemoryPool> rootPool_{
-      memory::MemoryManager::getInstance()->addRootPool(
-          "SortBufferTest",
-          maxBytes_)};
+      memory::memoryManager()->addRootPool("SortBufferTest", maxBytes_)};
   const std::shared_ptr<memory::MemoryPool> pool_{
       rootPool_->addLeafChild("SortBufferTest", maxBytes_)};
   const std::shared_ptr<folly::Executor> executor_{
@@ -239,7 +237,7 @@ TEST_F(SortBufferTest, DISABLED_randomData) {
         &nonReclaimableSection_);
 
     const std::shared_ptr<memory::MemoryPool> fuzzerPool =
-        memory::MemoryManager::getInstance()->addLeafPool("VectorFuzzer");
+        memory::memoryManager()->addLeafPool("VectorFuzzer");
 
     std::vector<RowVectorPtr> inputVectors;
     inputVectors.reserve(3);
@@ -313,7 +311,7 @@ TEST_F(SortBufferTest, batchOutput) {
     ASSERT_EQ(sortBuffer->canSpill(), testData.triggerSpill);
 
     const std::shared_ptr<memory::MemoryPool> fuzzerPool =
-        memory::MemoryManager::getInstance()->addLeafPool("VectorFuzzer");
+        memory::memoryManager()->addLeafPool("VectorFuzzer");
 
     std::vector<RowVectorPtr> inputVectors;
     inputVectors.reserve(testData.numInputRows.size());
@@ -409,7 +407,7 @@ TEST_F(SortBufferTest, spill) {
         testData.spillMemoryThreshold);
 
     const std::shared_ptr<memory::MemoryPool> fuzzerPool =
-        memory::MemoryManager::getInstance()->addLeafPool("spillSource");
+        memory::memoryManager()->addLeafPool("spillSource");
     VectorFuzzer fuzzer({.vectorSize = 1024}, fuzzerPool.get());
     uint64_t totalNumInput = 0;
 
@@ -452,7 +450,7 @@ TEST_F(SortBufferTest, spill) {
 
 TEST_F(SortBufferTest, emptySpill) {
   const std::shared_ptr<memory::MemoryPool> fuzzerPool =
-      memory::MemoryManager::getInstance()->addLeafPool("emptySpillSource");
+      memory::memoryManager()->addLeafPool("emptySpillSource");
 
   for (bool hasPostSpillData : {false, true}) {
     SCOPED_TRACE(fmt::format("hasPostSpillData {}", hasPostSpillData));

--- a/velox/exec/tests/SpillOperatorGroupTest.cpp
+++ b/velox/exec/tests/SpillOperatorGroupTest.cpp
@@ -31,7 +31,7 @@ class SpillOperatorGroupTest : public testing::Test {
  protected:
   SpillOperatorGroupTest(int32_t numOperators = 1)
       : numOperators_(numOperators),
-        pool_(memory::MemoryManager::getInstance()->addLeafPool()) {
+        pool_(memory::memoryManager()->addLeafPool()) {
     // All this is to prepare valid driver context for our mock operators.
     VectorMaker vectorMaker{pool_.get()};
     std::vector<RowVectorPtr> values = {vectorMaker.rowVector(

--- a/velox/exec/tests/SpillerBenchmarkBase.cpp
+++ b/velox/exec/tests/SpillerBenchmarkBase.cpp
@@ -80,8 +80,8 @@ using namespace facebook::velox::memory;
 namespace facebook::velox::exec::test {
 
 void SpillerBenchmarkBase::setUp() {
-  rootPool_ = memory::MemoryManager::getInstance()->addRootPool(
-      FLAGS_spiller_benchmark_name);
+  rootPool_ =
+      memory::memoryManager()->addRootPool(FLAGS_spiller_benchmark_name);
   pool_ = rootPool_->addLeafChild(FLAGS_spiller_benchmark_name);
 
   rowType_ =

--- a/velox/exec/tests/utils/Cursor.h
+++ b/velox/exec/tests/utils/Cursor.h
@@ -76,8 +76,7 @@ class TaskQueue {
   };
 
   explicit TaskQueue(uint64_t maxBytes)
-      : pool_(memory::MemoryManager::getInstance()->addLeafPool()),
-        maxBytes_(maxBytes) {}
+      : pool_(memory::memoryManager()->addLeafPool()), maxBytes_(maxBytes) {}
 
   void setNumProducers(int32_t n) {
     numProducers_ = n;

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -143,7 +143,7 @@ class TpchQueryBuilder {
   static constexpr const char* kSupplier = "supplier";
   static constexpr const char* kPartsupp = "partsupp";
   std::shared_ptr<memory::MemoryPool> pool_ =
-      memory::MemoryManager::getInstance()->addLeafPool();
+      memory::memoryManager()->addLeafPool();
 };
 
 } // namespace facebook::velox::exec::test

--- a/velox/experimental/codegen/code_generator/tests/CodegenExpressionsTestBase.h
+++ b/velox/experimental/codegen/code_generator/tests/CodegenExpressionsTestBase.h
@@ -586,7 +586,7 @@ class ExpressionCodegenTestBase : public testing::Test {
 
   std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   std::unique_ptr<core::ExecCtx> execCtx_{
       std::make_unique<facebook::velox::core::ExecCtx>(
           pool_.get(),

--- a/velox/experimental/codegen/tests/CodegenASTAnalysisTest.cpp
+++ b/velox/experimental/codegen/tests/CodegenASTAnalysisTest.cpp
@@ -57,7 +57,7 @@ class GenerateAstTest : public CodegenTestBase {
     registerVeloxArithmeticUDFs(udfManager_);
     useBuiltInForArithmetic_ = false;
 
-    pool_ = memory::MemoryManager::getInstance()->addLeafPool();
+    pool_ = memory::memoryManager()->addLeafPool();
 
     rowType_ = ROW({"c0", "c1", "c2"}, {DOUBLE(), DOUBLE(), DOUBLE()});
 

--- a/velox/experimental/codegen/tests/CodegenTestBase.h
+++ b/velox/experimental/codegen/tests/CodegenTestBase.h
@@ -104,7 +104,7 @@ class CodegenTestCore {
             udfManager_,
             useSymbolForArithmetic_,
             eventSequence_);
-    pool_ = MemoryManager::getInstance()->addLeafPool();
+    pool_ = memoryManager()->addLeafPool();
     queryCtx_ = std::make_shared<core::QueryCtx>(executor_.get());
     execCtx_ = std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get());
 

--- a/velox/experimental/codegen/vector_function/tests/CodegenVectorFunctionTest.cpp
+++ b/velox/experimental/codegen/vector_function/tests/CodegenVectorFunctionTest.cpp
@@ -96,7 +96,7 @@ TEST(TestConcat, EvalConcatFunction) {
   auto outRowType =
       ROW({"pl", "mi"},
           {std::make_shared<DoubleType>(), std::make_shared<DoubleType>()});
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   auto inRowVector = BaseVector::create(inRowType, rowLength, pool.get());
   auto outRowVector = BaseVector::create(outRowType, rowLength, pool.get());
 
@@ -198,7 +198,7 @@ struct GeneratedVectorFunctionConfigBool {
 
 TEST(TestBooEvalVectorFunction, EvalBoolExpression) {
   // TODO: Move those to test class
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   const size_t vectorSize = 1000;
   auto queryCtx = std::make_shared<core::QueryCtx>();
   auto execCtx = std::make_unique<core::ExecCtx>(pool.get(), queryCtx.get());

--- a/velox/experimental/codegen/vector_function/tests/VectorReaderTest.cpp
+++ b/velox/experimental/codegen/vector_function/tests/VectorReaderTest.cpp
@@ -33,7 +33,7 @@ TEST_F(VectorReaderTest, ReadDoublesVectors) {
   auto inRowType = ROW({"columnA", "columnB"}, {DOUBLE(), DOUBLE()});
   auto outRowType = ROW({"expr1", "expr2"}, {DOUBLE(), DOUBLE()});
 
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   auto inRowVector = BaseVector::create(inRowType, vectorSize, pool.get());
   auto outRowVector = BaseVector::create(outRowType, vectorSize, pool.get());
 
@@ -61,7 +61,7 @@ TEST_F(VectorReaderTest, ReadDoublesVectors) {
 
 TEST_F(VectorReaderTest, ReadBoolVectors) {
   // TODO: Move those to test class
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   const size_t vectorSize = 1000;
 
   auto inRowType = ROW({"columnA", "columnB"}, {BOOLEAN(), BOOLEAN()});

--- a/velox/experimental/wave/common/tests/CudaTest.cpp
+++ b/velox/experimental/wave/common/tests/CudaTest.cpp
@@ -457,7 +457,7 @@ class CudaTest : public testing::Test {
 
     options.allocator = mmapAllocator_.get();
     memory::MemoryManager::initialize(options);
-    manager_ = memory::MemoryManager::getInstance();
+    manager_ = memory::memoryManager();
   }
 
   void waitFinish() {
@@ -612,7 +612,7 @@ class CudaTest : public testing::Test {
   void createData(int32_t numBatches, int32_t numColumns, int32_t numRows) {
     batches_.clear();
     if (!batchPool_) {
-      batchPool_ = memory::MemoryManager::getInstance()->addLeafPool();
+      batchPool_ = memory::memoryManager()->addLeafPool();
     }
     int32_t sequence = 1;
     for (auto i = 0; i < numBatches; ++i) {

--- a/velox/expression/tests/ExprToSubfieldFilterTest.cpp
+++ b/velox/expression/tests/ExprToSubfieldFilterTest.cpp
@@ -67,7 +67,7 @@ class ExprToSubfieldFilterTest : public testing::Test {
 
  private:
   std::shared_ptr<memory::MemoryPool> pool_ =
-      memory::MemoryManager::getInstance()->addLeafPool();
+      memory::memoryManager()->addLeafPool();
   core::QueryCtx queryCtx_;
   SimpleExpressionEvaluator evaluator_{&queryCtx_, pool_.get()};
 };

--- a/velox/expression/tests/ExpressionFuzzerUnitTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerUnitTest.cpp
@@ -55,7 +55,7 @@ class ExpressionFuzzerUnitTest : public testing::Test {
     return kSupportedTypes[index];
   }
   std::shared_ptr<memory::MemoryPool> pool{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
 
   std::shared_ptr<VectorFuzzer> vectorfuzzer{
       std::make_shared<VectorFuzzer>(VectorFuzzer::Options{}, pool.get())};

--- a/velox/expression/tests/ExpressionRunnerUnitTest.cpp
+++ b/velox/expression/tests/ExpressionRunnerUnitTest.cpp
@@ -40,7 +40,7 @@ class ExpressionRunnerUnitTest : public testing::Test, public VectorTestBase {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   core::QueryCtx queryCtx_{};
   core::ExecCtx execCtx_{pool_.get(), &queryCtx_};
 };

--- a/velox/expression/tests/ExpressionVerifierUnitTest.cpp
+++ b/velox/expression/tests/ExpressionVerifierUnitTest.cpp
@@ -80,7 +80,7 @@ class ExpressionVerifierUnitTest : public testing::Test, public VectorTestBase {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   core::QueryCtx queryCtx_{};
   core::ExecCtx execCtx_{pool_.get(), &queryCtx_};
 };

--- a/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
+++ b/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
@@ -96,7 +96,7 @@ class FunctionBenchmarkBase {
  protected:
   std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
   facebook::velox::test::VectorMaker vectorMaker_{execCtx_.pool()};
   parse::ParseOptions options_;

--- a/velox/functions/lib/tests/KllSketchTest.cpp
+++ b/velox/functions/lib/tests/KllSketchTest.cpp
@@ -380,7 +380,7 @@ TEST_F(KllSketchTest, mergeDeserialized) {
 // 2. Otherwise it's \f$ K \sum_i \(\frac{2}{3}\)^i \f$ and it converges to
 //    about O(3K).
 TEST_F(KllSketchTest, memoryUsage) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   HashStringAllocator alloc(pool.get());
   KllSketch<int64_t, StlAllocator<int64_t>> kll(
       1024, StlAllocator<int64_t>(&alloc));

--- a/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
@@ -80,7 +80,7 @@ class ValueListTest : public functions::test::FunctionBaseTest {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   std::unique_ptr<HashStringAllocator> allocator_{
       std::make_unique<HashStringAllocator>(pool_.get())};
 };

--- a/velox/functions/prestosql/benchmarks/ArrayConstructorBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayConstructorBenchmark.cpp
@@ -29,7 +29,7 @@ int main(int argc, char** argv) {
 
   functions::prestosql::registerArrayFunctions();
   memory::MemoryManager::initialize({});
-  auto anotherPool = memory::MemoryManager::getInstance()->addLeafPool("bm");
+  auto anotherPool = memory::memoryManager()->addLeafPool("bm");
 
   ExpressionBenchmarkBuilder benchmarkBuilder;
 

--- a/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
@@ -49,7 +49,7 @@ class HyperLogLogFunctionsTest : public functions::test::FunctionBaseTest {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   HashStringAllocator allocator_{pool_.get()};
 };
 

--- a/velox/functions/prestosql/tests/InPredicateTest.cpp
+++ b/velox/functions/prestosql/tests/InPredicateTest.cpp
@@ -55,7 +55,7 @@ class InPredicateTest : public FunctionBaseTest {
       this->options_.parseDecimalAsDouble = false;
     }
     std::shared_ptr<memory::MemoryPool> pool{
-        memory::MemoryManager::getInstance()->addLeafPool()};
+        memory::memoryManager()->addLeafPool()};
 
     const vector_size_t size = 1'000;
     auto inList = getInList<T>({1, 3, 5}, type);

--- a/velox/functions/remote/server/RemoteFunctionService.h
+++ b/velox/functions/remote/server/RemoteFunctionService.h
@@ -36,7 +36,7 @@ class RemoteFunctionServiceHandler
 
  private:
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   const std::string functionPrefix_;
 };
 

--- a/velox/parse/tests/QueryPlannerTest.cpp
+++ b/velox/parse/tests/QueryPlannerTest.cpp
@@ -59,7 +59,7 @@ class QueryPlannerTest : public testing::Test {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
 };
 
 TEST_F(QueryPlannerTest, values) {

--- a/velox/row/benchmark/DynamicRowVectorDeserializeBenchmark.cpp
+++ b/velox/row/benchmark/DynamicRowVectorDeserializeBenchmark.cpp
@@ -50,7 +50,7 @@ class UnsaferowBatchDeserializer : public Deserializer {
 
  private:
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
 };
 
 class BenchmarkHelper {
@@ -116,7 +116,7 @@ class BenchmarkHelper {
       ROW({INTEGER()})};
 
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
 };
 
 int deserialize(

--- a/velox/row/benchmark/UnsafeRowSerializeBenchmark.cpp
+++ b/velox/row/benchmark/UnsafeRowSerializeBenchmark.cpp
@@ -201,7 +201,7 @@ class SerializeBenchmark {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
 };
 
 #define SERDE_BENCHMARKS(name, rowType)      \

--- a/velox/row/tests/UnsafeRowFuzzTest.cpp
+++ b/velox/row/tests/UnsafeRowFuzzTest.cpp
@@ -94,7 +94,7 @@ class UnsafeRowFuzzTests : public ::testing::Test {
   std::array<char[kBufferSize], kNumBuffers> buffers_{};
 
   std::shared_ptr<memory::MemoryPool> pool_ =
-      memory::MemoryManager::getInstance()->addLeafPool();
+      memory::memoryManager()->addLeafPool();
 };
 
 TEST_F(UnsafeRowFuzzTests, fast) {

--- a/velox/serializers/tests/CompactRowSerializerTest.cpp
+++ b/velox/serializers/tests/CompactRowSerializerTest.cpp
@@ -29,7 +29,7 @@ class CompactRowSerializerTest : public ::testing::Test,
   }
 
   void SetUp() override {
-    pool_ = memory::MemoryManager::getInstance()->addLeafPool();
+    pool_ = memory::memoryManager()->addLeafPool();
     serde_ = std::make_unique<serializer::CompactRowVectorSerde>();
   }
 

--- a/velox/serializers/tests/UnsafeRowSerializerTest.cpp
+++ b/velox/serializers/tests/UnsafeRowSerializerTest.cpp
@@ -29,7 +29,7 @@ class UnsafeRowSerializerTest : public ::testing::Test,
   }
 
   void SetUp() override {
-    pool_ = memory::MemoryManager::getInstance()->addLeafPool();
+    pool_ = memory::memoryManager()->addLeafPool();
     serde_ = std::make_unique<serializer::spark::UnsafeRowVectorSerde>();
   }
 

--- a/velox/substrait/tests/FunctionTest.cpp
+++ b/velox/substrait/tests/FunctionTest.cpp
@@ -39,7 +39,7 @@ class FunctionTest : public ::testing::Test {
       std::make_shared<core::QueryCtx>();
 
   std::shared_ptr<memory::MemoryPool> pool_ =
-      memory::MemoryManager::getInstance()->addLeafPool();
+      memory::memoryManager()->addLeafPool();
 
   std::shared_ptr<vestrait::SubstraitParser> substraitParser_ =
       std::make_shared<vestrait::SubstraitParser>();

--- a/velox/substrait/tests/Substrait2VeloxPlanConversionTest.cpp
+++ b/velox/substrait/tests/Substrait2VeloxPlanConversionTest.cpp
@@ -122,7 +122,7 @@ TEST_F(Substrait2VeloxPlanConversionTest, DISABLED_q6) {
            VARCHAR(),
            VARCHAR()});
   std::shared_ptr<memory::MemoryPool> pool{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   std::vector<VectorPtr> vectors;
   // TPC-H lineitem table has 16 columns.
   int colNum = 16;

--- a/velox/tpch/gen/tests/TpchGenTest.cpp
+++ b/velox/tpch/gen/tests/TpchGenTest.cpp
@@ -34,8 +34,7 @@ class TpchGenTestNationTest : public testing::Test {
   }
 
   void SetUp() override {
-    pool_ = memory::MemoryManager::getInstance()->addLeafPool(
-        "TpchGenTestNationTest");
+    pool_ = memory::memoryManager()->addLeafPool("TpchGenTestNationTest");
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
@@ -142,8 +141,7 @@ class TpchGenTestRegionTest : public testing::Test {
   }
 
   void SetUp() override {
-    pool_ = memory::MemoryManager::getInstance()->addLeafPool(
-        "TpchGenTestRegionTest");
+    pool_ = memory::memoryManager()->addLeafPool("TpchGenTestRegionTest");
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
@@ -209,8 +207,7 @@ class TpchGenTestOrdersTest : public testing::Test {
   }
 
   void SetUp() override {
-    pool_ = memory::MemoryManager::getInstance()->addLeafPool(
-        "TpchGenTestOrdersTest");
+    pool_ = memory::memoryManager()->addLeafPool("TpchGenTestOrdersTest");
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
@@ -320,8 +317,7 @@ class TpchGenTestLineItemTest : public testing::Test {
   }
 
   void SetUp() override {
-    pool_ = memory::MemoryManager::getInstance()->addLeafPool(
-        "TpchGenTestLineItemTest");
+    pool_ = memory::memoryManager()->addLeafPool("TpchGenTestLineItemTest");
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
@@ -436,8 +432,7 @@ class TpchGenTestSupplierTest : public testing::Test {
   }
 
   void SetUp() override {
-    pool_ = memory::MemoryManager::getInstance()->addLeafPool(
-        "TpchGenTestSupplierTest");
+    pool_ = memory::memoryManager()->addLeafPool("TpchGenTestSupplierTest");
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
@@ -533,8 +528,7 @@ class TpchGenTestPartTest : public testing::Test {
   }
 
   void SetUp() override {
-    pool_ = memory::MemoryManager::getInstance()->addLeafPool(
-        "TpchGenTestPartTest");
+    pool_ = memory::memoryManager()->addLeafPool("TpchGenTestPartTest");
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
@@ -623,8 +617,7 @@ class TpchGenTestPartSuppTest : public testing::Test {
   }
 
   void SetUp() override {
-    pool_ = memory::MemoryManager::getInstance()->addLeafPool(
-        "TpchGenTestPartSuppTest");
+    pool_ = memory::memoryManager()->addLeafPool("TpchGenTestPartSuppTest");
   }
 
   bool partSuppCheck(
@@ -772,8 +765,7 @@ class TpchGenTestCustomerTest : public testing::Test {
   }
 
   void SetUp() override {
-    pool_ = memory::MemoryManager::getInstance()->addLeafPool(
-        "TpchGenTestCustomerTest");
+    pool_ = memory::memoryManager()->addLeafPool("TpchGenTestCustomerTest");
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -359,7 +359,7 @@ class ArrowBridgeArrayExportTest : public testing::Test {
   // Boiler plate structures required by vectorMaker.
   std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
   facebook::velox::test::VectorMaker vectorMaker_{execCtx_.pool()};
 };
@@ -1432,7 +1432,7 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
 };
 
 class ArrowBridgeArrayImportAsViewerTest : public ArrowBridgeArrayImportTest {

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -173,7 +173,7 @@ class ArrowBridgeSchemaExportTest : public testing::Test {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
 };
 
 TEST_F(ArrowBridgeSchemaExportTest, scalar) {
@@ -437,7 +437,7 @@ class ArrowBridgeSchemaTest : public testing::Test {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
 };
 
 TEST_F(ArrowBridgeSchemaTest, roundtrip) {

--- a/velox/vector/benchmarks/CopyBenchmark.cpp
+++ b/velox/vector/benchmarks/CopyBenchmark.cpp
@@ -69,7 +69,7 @@ size_t runBenchmark(
 BENCHMARK_MULTI(copyArray) {
   folly::BenchmarkSuspender suspender;
   std::shared_ptr<memory::MemoryPool> pool{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -86,7 +86,7 @@ BENCHMARK_MULTI(copyArray) {
 BENCHMARK_MULTI(copyArrayWithNulls) {
   folly::BenchmarkSuspender suspender;
   std::shared_ptr<memory::MemoryPool> pool{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -104,7 +104,7 @@ BENCHMARK_MULTI(copyArrayWithNulls) {
 BENCHMARK_MULTI(copyArrayDictionaryEncoded) {
   folly::BenchmarkSuspender suspender;
   std::shared_ptr<memory::MemoryPool> pool{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -135,7 +135,7 @@ BENCHMARK_MULTI(copyArrayDictionaryEncoded) {
 BENCHMARK_MULTI(copyArrayOneAtATime) {
   folly::BenchmarkSuspender suspender;
   std::shared_ptr<memory::MemoryPool> pool{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -152,7 +152,7 @@ BENCHMARK_MULTI(copyArrayOneAtATime) {
 BENCHMARK_MULTI(copyArrayTwoAtATime) {
   folly::BenchmarkSuspender suspender;
   std::shared_ptr<memory::MemoryPool> pool{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -169,7 +169,7 @@ BENCHMARK_MULTI(copyArrayTwoAtATime) {
 BENCHMARK_MULTI(copyArrayOfVarchar) {
   folly::BenchmarkSuspender suspender;
   std::shared_ptr<memory::MemoryPool> pool{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 50'000;
@@ -199,7 +199,7 @@ BENCHMARK_MULTI(copyArrayOfVarchar) {
 BENCHMARK_MULTI(copyArrayOfArray) {
   folly::BenchmarkSuspender suspender;
   std::shared_ptr<memory::MemoryPool> pool{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -228,7 +228,7 @@ BENCHMARK_MULTI(copyArrayOfArray) {
 BENCHMARK_MULTI(copyMap) {
   folly::BenchmarkSuspender suspender;
   std::shared_ptr<memory::MemoryPool> pool{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -247,7 +247,7 @@ BENCHMARK_MULTI(copyMap) {
 BENCHMARK_MULTI(copyMapWithNulls) {
   folly::BenchmarkSuspender suspender;
   std::shared_ptr<memory::MemoryPool> pool{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -267,7 +267,7 @@ BENCHMARK_MULTI(copyMapWithNulls) {
 BENCHMARK_MULTI(copyMapDictionaryEncoded) {
   folly::BenchmarkSuspender suspender;
   std::shared_ptr<memory::MemoryPool> pool{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -301,7 +301,7 @@ BENCHMARK_MULTI(copyMapDictionaryEncoded) {
 BENCHMARK_MULTI(copyMapOneAtATime) {
   folly::BenchmarkSuspender suspender;
   std::shared_ptr<memory::MemoryPool> pool{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -320,7 +320,7 @@ BENCHMARK_MULTI(copyMapOneAtATime) {
 BENCHMARK_MULTI(copyMapTwoAtATime) {
   folly::BenchmarkSuspender suspender;
   std::shared_ptr<memory::MemoryPool> pool{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -339,7 +339,7 @@ BENCHMARK_MULTI(copyMapTwoAtATime) {
 BENCHMARK_MULTI(copyStructNonContiguous) {
   folly::BenchmarkSuspender suspender;
   std::shared_ptr<memory::MemoryPool> pool{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
   constexpr vector_size_t kSize = 2'000;
   std::vector<VectorPtr> children = {

--- a/velox/vector/benchmarks/SimpleVectorHashAllBenchmark.cpp
+++ b/velox/vector/benchmarks/SimpleVectorHashAllBenchmark.cpp
@@ -89,7 +89,7 @@ void vectorBenchmark(
     bool sequences,
     VectorEncoding::Simple encoding) {
   folly::BenchmarkSuspender suspender;
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   VectorMaker vectorMaker(pool.get());
 
   for (size_t k = 0; k < iterations; ++k) {

--- a/velox/vector/fuzzer/examples/ArrayGeneratorExample.cpp
+++ b/velox/vector/fuzzer/examples/ArrayGeneratorExample.cpp
@@ -39,7 +39,7 @@ int main() {
 
   FuzzerGenerator rng;
   memory::MemoryManager::initialize({});
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
 
   GeneratorSpecPtr randomArray =
       RANDOM_ARRAY(RANDOM_DOUBLE(normal, nullProbability), uniform);

--- a/velox/vector/fuzzer/examples/EncodingGeneratorExample.cpp
+++ b/velox/vector/fuzzer/examples/EncodingGeneratorExample.cpp
@@ -48,7 +48,7 @@ int main() {
 
   FuzzerGenerator rng;
   memory::MemoryManager::initialize({});
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   GeneratorSpecPtr encodedNormalDoubleGenerator =
       ENCODE(RANDOM_DOUBLE(normal, nullProbability), encoding, 1, 5, 0.3);
 

--- a/velox/vector/fuzzer/examples/MapGeneratorExample.cpp
+++ b/velox/vector/fuzzer/examples/MapGeneratorExample.cpp
@@ -40,7 +40,7 @@ int main() {
 
   FuzzerGenerator rng;
   memory::MemoryManager::initialize({});
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
 
   GeneratorSpecPtr randomMap =
       RANDOM_MAP(RANDOM_INTEGER(uniform), RANDOM_DOUBLE(normal), lengthDist);

--- a/velox/vector/fuzzer/examples/RowGeneratorExample.cpp
+++ b/velox/vector/fuzzer/examples/RowGeneratorExample.cpp
@@ -40,7 +40,7 @@ int main() {
 
   FuzzerGenerator rng;
   memory::MemoryManager::initialize({});
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
 
   GeneratorSpecPtr randomRow = RANDOM_ROW(
       {RANDOM_INTEGER(uniform),

--- a/velox/vector/fuzzer/examples/ScalarGeneratorExample.cpp
+++ b/velox/vector/fuzzer/examples/ScalarGeneratorExample.cpp
@@ -50,7 +50,7 @@ int main() {
 
   FuzzerGenerator rng;
   memory::MemoryManager::initialize({});
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
 
   GeneratorSpecPtr uniformIntGenerator =
       RANDOM_INTEGER(uniform, nullProbability);

--- a/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
+++ b/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
@@ -83,7 +83,7 @@ class VectorFuzzerTest : public testing::Test {
 
  private:
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
 };
 
 TEST_F(VectorFuzzerTest, flatPrimitive) {

--- a/velox/vector/tests/BiasVectorTest.cpp
+++ b/velox/vector/tests/BiasVectorTest.cpp
@@ -29,7 +29,7 @@ class BiasVectorTestBase : public testing::Test {
   }
 
   std::shared_ptr<velox::memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   VectorMaker vectorMaker_{pool_.get()};
 };
 

--- a/velox/vector/tests/MayHaveNullsRecursiveTest.cpp
+++ b/velox/vector/tests/MayHaveNullsRecursiveTest.cpp
@@ -27,7 +27,7 @@ class MayHaveNullsRecursiveTest : public testing::Test {
   }
 
   std::shared_ptr<velox::memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   VectorMaker vectorMaker_{pool_.get()};
 
   enum class TestOptions {

--- a/velox/vector/tests/SimpleVectorTestHelper.h
+++ b/velox/vector/tests/SimpleVectorTestHelper.h
@@ -107,7 +107,7 @@ class SimpleVectorTest : public ::testing::Test {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   VectorMaker maker_{pool_.get()};
 };
 

--- a/velox/vector/tests/VariantToVectorTest.cpp
+++ b/velox/vector/tests/VariantToVectorTest.cpp
@@ -26,7 +26,7 @@ using namespace facebook::velox;
 
 class VariantToVectorTest : public testing::Test {
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
 
  public:
   static void SetUpTestCase() {

--- a/velox/vector/tests/VectorCompareTest.cpp
+++ b/velox/vector/tests/VectorCompareTest.cpp
@@ -225,7 +225,7 @@ TEST_F(VectorCompareTest, compareStopAtNullRow) {
 }
 
 TEST_F(VectorCompareTest, CompareWithNullChildVector) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   test::VectorMaker maker{pool.get()};
   auto rowType = ROW({"a", "b", "c"}, {INTEGER(), INTEGER(), INTEGER()});
   const auto& rowVector1 = std::make_shared<RowVector>(

--- a/velox/vector/tests/VectorMakerTest.cpp
+++ b/velox/vector/tests/VectorMakerTest.cpp
@@ -31,7 +31,7 @@ class VectorMakerTest : public ::testing::Test {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::MemoryManager::getInstance()->addLeafPool()};
+      memory::memoryManager()->addLeafPool()};
   VectorMaker maker_{pool_.get()};
 };
 

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -2580,7 +2580,7 @@ TEST_F(VectorTest, mapSliceMutability) {
 TEST_F(VectorTest, lifetime) {
   ASSERT_DEATH(
       {
-        auto childPool = memory::MemoryManager::getInstance()->addLeafPool();
+        auto childPool = memory::memoryManager()->addLeafPool();
         auto v = BaseVector::create(INTEGER(), 10, childPool.get());
 
         // BUG: Memory pool needs to stay alive until all memory allocated from

--- a/velox/vector/tests/VectorTestUtils.h
+++ b/velox/vector/tests/VectorTestUtils.h
@@ -83,7 +83,7 @@ class VectorGeneratedData {
 
   // In case T is StringView, the buffer below holds their actual data.
   std::shared_ptr<memory::MemoryPool> scopedPool =
-      memory::MemoryManager::getInstance()->addLeafPool();
+      memory::memoryManager()->addLeafPool();
   StringViewBufferHolder stringViewBufferHolder_ =
       StringViewBufferHolder(scopedPool.get());
 };
@@ -271,7 +271,7 @@ template <typename T>
 SimpleVectorPtr<T> createAndAssert(
     const ExpectedData<T>& expected,
     VectorEncoding::Simple encoding) {
-  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   VectorMaker maker(pool.get());
 
   auto vector = maker.encodedVector(encoding, expected);

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -765,7 +765,7 @@ class VectorTestBase {
   }
 
   std::shared_ptr<memory::MemoryPool> rootPool_{
-      memory::MemoryManager::getInstance()->addRootPool()};
+      memory::memoryManager()->addRootPool()};
   std::shared_ptr<memory::MemoryPool> pool_{rootPool_->addLeafChild("leaf")};
   velox::test::VectorMaker vectorMaker_{pool_.get()};
   std::shared_ptr<folly::Executor> executor_{


### PR DESCRIPTION
Remove the legacy memory management apis used by Prestissimo.
Add two explicit global utilities to setup and access the process wide
memory manager.