### PR TITLE
Count IoStats in BufferedInput level

### DIFF
--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -682,7 +682,7 @@ std::unordered_map<std::string, RuntimeCounter> HiveDataSource::runtimeStats() {
         RuntimeCounter(ioStats_->ramHit().sum(), RuntimeCounter::Unit::kBytes)},
        {"totalScanTime",
         RuntimeCounter(
-            ioStats_->totalScanTime(), RuntimeCounter::Unit::kNanos)},
+            ioStats_->totalScanTime() * 1000, RuntimeCounter::Unit::kNanos)},
        {"totalRemainingFilterTime",
         RuntimeCounter(
             totalRemainingFilterTime_.load(std::memory_order_relaxed),

--- a/velox/dwio/common/CacheInputStream.cpp
+++ b/velox/dwio/common/CacheInputStream.cpp
@@ -198,6 +198,7 @@ void CacheInputStream::loadSync(Region region) {
         std::move(wait).via(&exec).wait();
       }
       ioStats_->queryThreadIoLatency().increment(usec);
+      ioStats_->incTotalScanTime(usec);
       continue;
     }
     auto entry = pin_.checkedEntry();
@@ -217,7 +218,7 @@ void CacheInputStream::loadSync(Region region) {
       }
       ioStats_->read().increment(region.length);
       ioStats_->queryThreadIoLatency().increment(usec);
-      ioStats_->incTotalScanTime(usec * 1'000);
+      ioStats_->incTotalScanTime(usec);
       entry->setExclusiveToShared();
     } else {
       // Hit memory cache.
@@ -281,6 +282,7 @@ bool CacheInputStream::loadFromSsd(
   pin_ = std::move(pins[0]);
   ioStats_->ssdRead().increment(region.length);
   ioStats_->queryThreadIoLatency().increment(usec);
+  ioStats_->incTotalScanTime(usec);
   entry.setExclusiveToShared();
   return true;
 }
@@ -306,6 +308,7 @@ void CacheInputStream::loadPosition() {
         }
       }
       ioStats_->queryThreadIoLatency().increment(usec);
+      ioStats_->incTotalScanTime(usec);
     }
     auto loadRegion = region_;
     // Quantize position to previous multiple of 'loadQuantum_'.

--- a/velox/dwio/common/CachedBufferedInput.h
+++ b/velox/dwio/common/CachedBufferedInput.h
@@ -69,12 +69,12 @@ class CachedBufferedInput : public BufferedInput {
       : BufferedInput(
             std::move(readFile),
             readerOptions.getMemoryPool(),
-            metricsLog),
+            metricsLog,
+            std::move(ioStats)),
         cache_(cache),
         fileNum_(fileNum),
         tracker_(std::move(tracker)),
         groupId_(groupId),
-        ioStats_(std::move(ioStats)),
         executor_(executor),
         fileSize_(input_->getLength()),
         options_(readerOptions) {}
@@ -88,12 +88,14 @@ class CachedBufferedInput : public BufferedInput {
       std::shared_ptr<IoStatistics> ioStats,
       folly::Executor* FOLLY_NULLABLE executor,
       const io::ReaderOptions& readerOptions)
-      : BufferedInput(std::move(input), readerOptions.getMemoryPool()),
+      : BufferedInput(
+            std::move(input),
+            readerOptions.getMemoryPool(),
+            std::move(ioStats)),
         cache_(cache),
         fileNum_(fileNum),
         tracker_(std::move(tracker)),
         groupId_(groupId),
-        ioStats_(std::move(ioStats)),
         executor_(executor),
         fileSize_(input_->getLength()),
         options_(readerOptions) {}
@@ -179,7 +181,6 @@ class CachedBufferedInput : public BufferedInput {
   const uint64_t fileNum_;
   std::shared_ptr<cache::ScanTracker> tracker_;
   const uint64_t groupId_;
-  std::shared_ptr<IoStatistics> ioStats_;
   folly::Executor* const FOLLY_NULLABLE executor_;
 
   // Regions that are candidates for loading.

--- a/velox/dwio/common/DirectBufferedInput.h
+++ b/velox/dwio/common/DirectBufferedInput.h
@@ -115,11 +115,11 @@ class DirectBufferedInput : public BufferedInput {
       : BufferedInput(
             std::move(readFile),
             readerOptions.getMemoryPool(),
-            metricsLog),
+            metricsLog,
+            std::move(ioStats)),
         fileNum_(fileNum),
         tracker_(std::move(tracker)),
         groupId_(groupId),
-        ioStats_(std::move(ioStats)),
         executor_(executor),
         fileSize_(input_->getLength()),
         options_(readerOptions) {}
@@ -182,11 +182,13 @@ class DirectBufferedInput : public BufferedInput {
       std::shared_ptr<IoStatistics> ioStats,
       folly::Executor* executor,
       const io::ReaderOptions& readerOptions)
-      : BufferedInput(std::move(input), readerOptions.getMemoryPool()),
+      : BufferedInput(
+            std::move(input),
+            readerOptions.getMemoryPool(),
+            std::move(ioStats)),
         fileNum_(fileNum),
         tracker_(std::move(tracker)),
         groupId_(groupId),
-        ioStats_(std::move(ioStats)),
         executor_(executor),
         fileSize_(input_->getLength()),
         options_(readerOptions) {}
@@ -204,7 +206,6 @@ class DirectBufferedInput : public BufferedInput {
   const uint64_t fileNum_;
   const std::shared_ptr<cache::ScanTracker> tracker_;
   const uint64_t groupId_;
-  const std::shared_ptr<IoStatistics> ioStats_;
   folly::Executor* const executor_;
   const uint64_t fileSize_;
 

--- a/velox/dwio/common/DirectInputStream.cpp
+++ b/velox/dwio/common/DirectInputStream.cpp
@@ -145,7 +145,6 @@ void DirectInputStream::loadSync() {
 
   process::TraceContext trace("DirectInputStream::loadSync");
 
-  ioStats_->incRawBytesRead(loadedRegion_.length);
   auto ranges = makeRanges(loadedRegion_.length, data_, tinyData_);
   uint64_t usecs = 0;
   {
@@ -153,8 +152,9 @@ void DirectInputStream::loadSync() {
     input_->read(ranges, loadedRegion_.offset, LogType::FILE);
   }
   ioStats_->read().increment(loadedRegion_.length);
+  ioStats_->incRawBytesRead(loadedRegion_.length);
   ioStats_->queryThreadIoLatency().increment(usecs);
-  ioStats_->incTotalScanTime(usecs * 1'000);
+  ioStats_->incTotalScanTime(usecs);
 }
 
 void DirectInputStream::loadPosition() {
@@ -175,6 +175,7 @@ void DirectInputStream::loadPosition() {
         loadedRegion_.length = load->getData(region_.offset, data_, tinyData_);
       }
       ioStats_->queryThreadIoLatency().increment(usecs);
+      ioStats_->incTotalScanTime(usecs);
     } else {
       // Standalone stream, not part of coalesced load.
       loadedRegion_.offset = 0;

--- a/velox/dwio/common/InputStream.cpp
+++ b/velox/dwio/common/InputStream.cpp
@@ -75,7 +75,7 @@ void ReadFileInputStream::read(
   std::string_view data_read = readFile_->pread(offset, length, buf);
   if (stats_) {
     stats_->incRawBytesRead(length);
-    stats_->incTotalScanTime((getCurrentTimeMicro() - readStartMicros) * 1000);
+    stats_->incTotalScanTime(getCurrentTimeMicro() - readStartMicros);
   }
 
   DWIO_ENSURE_EQ(
@@ -145,7 +145,7 @@ void ReadFileInputStream::vread(
   readFile_->preadv(regions, iobufs);
   if (stats_) {
     stats_->incRawBytesRead(length);
-    stats_->incTotalScanTime((getCurrentTimeMicro() - readStartMicros) * 1000);
+    stats_->incTotalScanTime(getCurrentTimeMicro() - readStartMicros);
   }
 }
 


### PR DESCRIPTION
Before this patch, IoStats was counted in both BufferedInput level and InputStream level, this may lead to duplicate/missing counting of some metrics.

After this patch, IoStats will only be counted in BufferedInput level in Velox to keep consistency, and InputStream still accept IoStats in its ctor for some non-Velox use cases.

Fixes: #8087 