### PR TITLE
Fix tests failures for MD5 and sha1 spark functions

### DIFF
--- a/velox/benchmarks/basic/LikeTpchBenchmark.cpp
+++ b/velox/benchmarks/basic/LikeTpchBenchmark.cpp
@@ -19,7 +19,7 @@
 
 #include "velox/functions/lib/Re2Functions.h"
 #include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/tpch/gen/TpchGen.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
@@ -45,7 +45,7 @@ enum class TpchBenchmarkCase {
   TpchQuery20,
 };
 
-class LikeFunctionsBenchmark : public FunctionBaseTest,
+class LikeFunctionsBenchmark : public PrestoFunctionBaseTest,
                                public FunctionBenchmarkBase {
  public:
   explicit LikeFunctionsBenchmark() {
@@ -165,9 +165,10 @@ class LikeFunctionsBenchmark : public FunctionBaseTest,
     return cnt;
   }
 
-  // We inherit from FunctionBaseTest so that we can get access to the helpers
-  // it defines, but since it is supposed to be a test fixture TestBody() is
-  // declared pure virtual.  We must provide an implementation here.
+  // We inherit from PrestoFunctionBaseTest so that we can get access to the
+  // helpers it defines, but since it is supposed to be a test fixture
+  // TestBody() is declared pure virtual.  We must provide an implementation
+  // here.
   void TestBody() override {}
 
  private:

--- a/velox/docs/develop/scalar-functions.rst
+++ b/velox/docs/develop/scalar-functions.rst
@@ -929,9 +929,9 @@ types.
 Testing
 -------
 
-Add a test using FunctionBaseTest from
-velox/functions/prestosql/tests/utils/FunctionBaseTest.h as a base class. Name your test
-and the .cpp file <function-name>Test, e.g. CardinalityTest in
+Add a test using PrestoFunctionBaseTest or SparkFunctionBaseTest as a base class.
+They are based on FunctionBaseTest from velox/functions/prestosql/tests/utils/FunctionBaseTest.h.
+Name your test and the .cpp file <function-name>Test, e.g. CardinalityTest in
 CardinalityTest.cpp or IsNullTest in IsNullTest.cpp.
 
 FunctionBaseTest has many helper methods for generating test vectors. It also

--- a/velox/exec/tests/FunctionResolutionTest.cpp
+++ b/velox/exec/tests/FunctionResolutionTest.cpp
@@ -20,7 +20,7 @@
 #include "velox/expression/SimpleFunctionRegistry.h"
 #include "velox/functions/Udf.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
@@ -113,7 +113,7 @@ void registerVectorFunctions() {
 namespace facebook::velox::exec {
 namespace {
 
-class FunctionResolutionTest : public functions::test::FunctionBaseTest {
+class FunctionResolutionTest : public functions::test::PrestoFunctionBaseTest {
  protected:
   void checkResults(const std::string& func, int32_t expected) {
     auto results = evaluateOnce<int32_t, int32_t, int32_t>(

--- a/velox/exec/tests/FunctionSignatureBuilderTest.cpp
+++ b/velox/exec/tests/FunctionSignatureBuilderTest.cpp
@@ -17,13 +17,13 @@
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/expression/FunctionSignature.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
 
-class FunctionSignatureBuilderTest : public functions::test::FunctionBaseTest {
-};
+class FunctionSignatureBuilderTest
+    : public functions::test::PrestoFunctionBaseTest {};
 
 TEST_F(FunctionSignatureBuilderTest, basicTypeTests) {
   // All type variables should be used in the inputs arguments.

--- a/velox/expression/tests/ArrayViewTest.cpp
+++ b/velox/expression/tests/ArrayViewTest.cpp
@@ -22,7 +22,7 @@
 #include "velox/common/base/VeloxException.h"
 #include "velox/expression/VectorReaders.h"
 #include "velox/functions/Udf.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/type/OpaqueCustomTypes.h"
 
 namespace {
@@ -37,7 +37,7 @@ DecodedVector* decode(DecodedVector& decoder, const BaseVector& vector) {
 }
 
 template <bool returnsOptionalValues>
-class ArrayViewTest : public functions::test::FunctionBaseTest {
+class ArrayViewTest : public functions::test::PrestoFunctionBaseTest {
   template <typename T>
   exec::ArrayView<returnsOptionalValues, T> read(
       exec::VectorReader<Array<T>>& reader,

--- a/velox/expression/tests/ArrayWriterTest.cpp
+++ b/velox/expression/tests/ArrayWriterTest.cpp
@@ -22,7 +22,7 @@
 
 #include "velox/expression/VectorWriters.h"
 #include "velox/functions/Udf.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/type/OpaqueCustomTypes.h"
 #include "velox/type/StringView.h"
 #include "velox/type/Type.h"
@@ -61,7 +61,7 @@ struct Func {
   }
 };
 
-class ArrayWriterTest : public functions::test::FunctionBaseTest {
+class ArrayWriterTest : public functions::test::PrestoFunctionBaseTest {
  public:
   VectorPtr prepareResult(const TypePtr& arrayType, vector_size_t size = 1) {
     VectorPtr result;

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -21,7 +21,7 @@
 #include "velox/common/memory/Memory.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/prestosql/tests/CastBaseTest.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/TypeAliases.h"

--- a/velox/expression/tests/CoalesceTest.cpp
+++ b/velox/expression/tests/CoalesceTest.cpp
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
 
-class CoalesceTest : public functions::test::FunctionBaseTest {};
+class CoalesceTest : public functions::test::PrestoFunctionBaseTest {};
 
 TEST_F(CoalesceTest, basic) {
   vector_size_t size = 20;

--- a/velox/expression/tests/ConstantFlatVectorReaderTest.cpp
+++ b/velox/expression/tests/ConstantFlatVectorReaderTest.cpp
@@ -19,12 +19,13 @@
 #include <cstdint>
 
 #include "velox/expression/VectorReaders.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/vector/BaseVector.h"
 
 namespace facebook::velox::exec {
 
-class ConstantFlatVectorReaderTest : public functions::test::FunctionBaseTest {
+class ConstantFlatVectorReaderTest
+    : public functions::test::PrestoFunctionBaseTest {
  public:
   ConstantFlatVectorReader<int32_t> makeConstantFlatVectorReader(
       const VectorPtr& vector) {

--- a/velox/expression/tests/CustomTypeTest.cpp
+++ b/velox/expression/tests/CustomTypeTest.cpp
@@ -19,12 +19,12 @@
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/Macros.h"
 #include "velox/functions/Registerer.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/type/OpaqueCustomTypes.h"
 
 namespace facebook::velox::test {
 
-class CustomTypeTest : public functions::test::FunctionBaseTest {};
+class CustomTypeTest : public functions::test::PrestoFunctionBaseTest {};
 
 namespace {
 struct FancyInt {

--- a/velox/expression/tests/EvalSimplifiedTest.cpp
+++ b/velox/expression/tests/EvalSimplifiedTest.cpp
@@ -16,13 +16,13 @@
 
 #include "gtest/gtest.h"
 
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
-using functions::test::FunctionBaseTest;
+using functions::test::PrestoFunctionBaseTest;
 
 // This test suite tests the simplified eval engine by:
 //
@@ -31,7 +31,7 @@ using functions::test::FunctionBaseTest;
 //  and common eval engines
 //  3. Asserting that result vectors are the same.
 //
-class EvalSimplifiedTest : public FunctionBaseTest {
+class EvalSimplifiedTest : public PrestoFunctionBaseTest {
  protected:
   void assertExceptions(
       std::exception_ptr commonPtr,

--- a/velox/expression/tests/ExprStatsTest.cpp
+++ b/velox/expression/tests/ExprStatsTest.cpp
@@ -19,7 +19,7 @@
 #include "velox/expression/EvalCtx.h"
 #include "velox/expression/Expr.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/parse/TypeResolver.h"
@@ -27,7 +27,7 @@
 using namespace facebook::velox;
 using namespace facebook::velox::test;
 
-class ExprStatsTest : public functions::test::FunctionBaseTest {
+class ExprStatsTest : public functions::test::PrestoFunctionBaseTest {
  protected:
   void SetUp() override {
     functions::prestosql::registerAllScalarFunctions();

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -32,7 +32,7 @@
 #include "velox/expression/SwitchExpr.h"
 #include "velox/functions/Udf.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/parse/TypeResolver.h"

--- a/velox/expression/tests/GenericViewTest.cpp
+++ b/velox/expression/tests/GenericViewTest.cpp
@@ -21,7 +21,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/expression/VectorReaders.h"
 #include "velox/functions/Udf.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/type/Type.h"
 
 namespace facebook::velox {
@@ -32,7 +32,7 @@ DecodedVector* decode(DecodedVector& decoder, const BaseVector& vector) {
   return &decoder;
 }
 
-class GenericViewTest : public functions::test::FunctionBaseTest {
+class GenericViewTest : public functions::test::PrestoFunctionBaseTest {
  protected:
   using array_data_t =
       std::vector<std::optional<std::vector<std::optional<int64_t>>>>;

--- a/velox/expression/tests/GenericWriterTest.cpp
+++ b/velox/expression/tests/GenericWriterTest.cpp
@@ -18,7 +18,7 @@
 #include "velox/expression/VectorWriters.h"
 #include "velox/functions/Udf.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/type/Type.h"
 #include "velox/vector/ComplexVector.h"
@@ -32,7 +32,7 @@ using namespace facebook::velox::exec;
 namespace facebook::velox {
 namespace {
 
-class GenericWriterTest : public functions::test::FunctionBaseTest {};
+class GenericWriterTest : public functions::test::PrestoFunctionBaseTest {};
 
 TEST_F(GenericWriterTest, boolean) {
   VectorPtr result;

--- a/velox/expression/tests/MapViewTest.cpp
+++ b/velox/expression/tests/MapViewTest.cpp
@@ -21,7 +21,7 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/expression/VectorReaders.h"
 #include "velox/functions/Udf.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 namespace {
 using namespace facebook::velox;
@@ -33,7 +33,7 @@ DecodedVector* decode(DecodedVector& decoder, const BaseVector& vector) {
 }
 
 template <bool returnsOptionalValues>
-class MapViewTest : public functions::test::FunctionBaseTest {
+class MapViewTest : public functions::test::PrestoFunctionBaseTest {
   using ViewType = exec::MapView<returnsOptionalValues, int64_t, int64_t>;
   using ReadFunction = std::function<
       ViewType(exec::VectorReader<Map<int64_t, int64_t>>&, size_t)>;

--- a/velox/expression/tests/MapWriterTest.cpp
+++ b/velox/expression/tests/MapWriterTest.cpp
@@ -27,7 +27,7 @@
 #include "folly/container/F14Map.h"
 #include "velox/expression/VectorWriters.h"
 #include "velox/functions/Udf.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/type/StringView.h"
 #include "velox/type/Type.h"
 namespace facebook::velox {
@@ -71,7 +71,7 @@ struct Func {
   }
 };
 
-class MapWriterTest : public functions::test::FunctionBaseTest {
+class MapWriterTest : public functions::test::PrestoFunctionBaseTest {
  public:
   template <typename K, typename V>
   using map_pairs_t = std::vector<std::pair<K, std::optional<V>>>;

--- a/velox/expression/tests/RowViewTest.cpp
+++ b/velox/expression/tests/RowViewTest.cpp
@@ -19,7 +19,7 @@
 
 #include "velox/expression/VectorReaders.h"
 #include "velox/functions/Udf.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 namespace {
 
@@ -32,7 +32,7 @@ DecodedVector* decode(DecodedVector& decoder, const BaseVector& vector) {
 }
 
 template <bool returnsOptionalValues>
-class RowViewTest : public functions::test::FunctionBaseTest {
+class RowViewTest : public functions::test::PrestoFunctionBaseTest {
   using ViewType = exec::RowView<returnsOptionalValues, int32_t, float>;
   using ReadFunction =
       std::function<ViewType(exec::VectorReader<Row<int32_t, float>>&, size_t)>;
@@ -206,7 +206,7 @@ TEST_F(NullableRowViewTest, materialize) {
   ASSERT_EQ(reader[0].materialize(), expected);
 }
 
-class DynamicRowViewTest : public functions::test::FunctionBaseTest {};
+class DynamicRowViewTest : public functions::test::PrestoFunctionBaseTest {};
 
 TEST_F(DynamicRowViewTest, emptyRow) {
   auto rowVector = vectorMaker_.rowVector({});

--- a/velox/expression/tests/RowWriterTest.cpp
+++ b/velox/expression/tests/RowWriterTest.cpp
@@ -23,7 +23,7 @@
 #include "velox/core/CoreTypeSystem.h"
 #include "velox/expression/VectorWriters.h"
 #include "velox/functions/Udf.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/type/StringView.h"
 #include "velox/type/Timestamp.h"
 #include "velox/type/Type.h"
@@ -48,7 +48,7 @@ struct FuncPrimitivesTest {
   }
 };
 
-class RowWriterTest : public functions::test::FunctionBaseTest {
+class RowWriterTest : public functions::test::PrestoFunctionBaseTest {
  public:
   VectorPtr prepareResult(const TypePtr& rowType, vector_size_t size = 1) {
     VectorPtr result;

--- a/velox/expression/tests/SimpleFunctionCallNullFreeTest.cpp
+++ b/velox/expression/tests/SimpleFunctionCallNullFreeTest.cpp
@@ -18,7 +18,7 @@
 #include <gtest/gtest.h>
 
 #include "velox/functions/Udf.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/type/Type.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/SelectivityVector.h"
@@ -28,7 +28,7 @@ namespace facebook::velox {
 using namespace facebook::velox::test;
 
 class SimpleFunctionCallNullFreeTest
-    : public functions::test::FunctionBaseTest {};
+    : public functions::test::PrestoFunctionBaseTest {};
 
 // Test that function with default contains nulls behavior won't get called when
 // inputs are all null.

--- a/velox/expression/tests/SimpleFunctionInitTest.cpp
+++ b/velox/expression/tests/SimpleFunctionInitTest.cpp
@@ -19,7 +19,7 @@
 
 #include "velox/expression/Expr.h"
 #include "velox/functions/Udf.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/ComplexVector.h"
@@ -29,7 +29,8 @@ namespace facebook::velox {
 
 using namespace facebook::velox::test;
 
-class SimpleFunctionInitTest : public functions::test::FunctionBaseTest {};
+class SimpleFunctionInitTest : public functions::test::PrestoFunctionBaseTest {
+};
 
 namespace {
 template <typename T>

--- a/velox/expression/tests/SimpleFunctionPresetNullsTest.cpp
+++ b/velox/expression/tests/SimpleFunctionPresetNullsTest.cpp
@@ -20,7 +20,7 @@
 
 #include "velox/expression/Expr.h"
 #include "velox/functions/Udf.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/type/StringView.h"
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
@@ -39,7 +39,8 @@ using namespace facebook::velox::test;
 
 namespace {
 
-class SimpleFunctionPresetNullsTest : public functions::test::FunctionBaseTest {
+class SimpleFunctionPresetNullsTest
+    : public functions::test::PrestoFunctionBaseTest {
   // Helper class to create the test function for type T.
   template <typename T>
   struct TestFunction {

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -25,7 +25,7 @@
 #include "velox/expression/SimpleFunctionAdapter.h"
 #include "velox/functions/Udf.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/ComplexVector.h"
@@ -36,7 +36,7 @@ using namespace facebook::velox;
 using namespace facebook::velox::test;
 namespace {
 
-class SimpleFunctionTest : public functions::test::FunctionBaseTest {
+class SimpleFunctionTest : public functions::test::PrestoFunctionBaseTest {
  protected:
   VectorPtr arraySum(const std::vector<std::vector<int64_t>>& data) {
     return makeFlatVector<int64_t>(data.size(), [&](auto row) {

--- a/velox/expression/tests/StringWriterTest.cpp
+++ b/velox/expression/tests/StringWriterTest.cpp
@@ -18,11 +18,11 @@
 #include <glog/logging.h>
 #include "folly/Range.h"
 #include "gtest/gtest.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 namespace facebook::velox::expressions::test {
 
-class StringWriterTest : public functions::test::FunctionBaseTest {};
+class StringWriterTest : public functions::test::PrestoFunctionBaseTest {};
 
 TEST_F(StringWriterTest, append) {
   auto vector = makeFlatVector<StringView>(2);

--- a/velox/expression/tests/TryExprTest.cpp
+++ b/velox/expression/tests/TryExprTest.cpp
@@ -20,7 +20,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/functions/Udf.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/vector/ConstantVector.h"
 #include "velox/vector/tests/TestingAlwaysThrowsFunction.h"
 
@@ -29,10 +29,9 @@ namespace facebook::velox {
 using namespace common::testutil;
 using namespace facebook::velox::test;
 
-class TryExprTest : public functions::test::FunctionBaseTest {
+class TryExprTest : public functions::test::PrestoFunctionBaseTest {
  protected:
   static void SetUpTestCase() {
-    FunctionBaseTest::SetUpTestCase();
     TestValue::enable();
   }
 };

--- a/velox/expression/tests/VectorReaderTest.cpp
+++ b/velox/expression/tests/VectorReaderTest.cpp
@@ -18,7 +18,7 @@
 #include <gtest/gtest.h>
 
 #include "velox/expression/VectorReaders.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using facebook::velox::exec::LocalDecodedVector;
 namespace facebook::velox {
@@ -29,7 +29,7 @@ DecodedVector* decode(DecodedVector& decoder, const BaseVector& vector) {
   return &decoder;
 }
 
-class VectorReaderTest : public functions::test::FunctionBaseTest {};
+class VectorReaderTest : public functions::test::PrestoFunctionBaseTest {};
 
 TEST_F(VectorReaderTest, scalarContainsNull) {
   // Vector is:

--- a/velox/functions/README.md
+++ b/velox/functions/README.md
@@ -181,10 +181,13 @@ VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(udf_in, InPredicate::create);
 
 ## UnitTest Functions
 
-When writing tests for functions, it is convenient to use FunctionBaseTest base class. These class has methods for
-making new vectors via VectorMaker utility class. PlanBuilder is useful for building query plans. FunctionBaseTest
-provides an "evaluate" method that takes a SQL expression string and an input vector, evaluates the expression and
-returns the results. Here is how one can write a simple test for multiply function:
+When writing tests for functions, it is convenient to use PrestoFunctionBaseTest or 
+SparkFunctionBaseTest as base class. These classes are based on FunctionBaseTest that 
+provides methods for making new vectors via VectorMaker utility class, and an "evaluate" 
+method that takes a SQL expression string and an input vector, evaluates the expression 
+and returns the results.
+PlanBuilder is useful for building query plans. Here is how one can write a simple test  
+for multiply function:
 
 ```c++
 vector_size_t size = 1'000;
@@ -202,4 +205,4 @@ vector_size_t size = 1'000;
   }
 ```
 
-You can find more examples in the code base by searching for FunctionBaseTest
+You can find more examples in the code base by searching for FunctionBaseTest.

--- a/velox/functions/lib/tests/IsNotNullTest.cpp
+++ b/velox/functions/lib/tests/IsNotNullTest.cpp
@@ -16,7 +16,7 @@
 
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/IsNull.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/parse/TypeResolver.h"
 
 namespace facebook::velox::functions {
@@ -31,7 +31,7 @@ void registerIsNotNull() {
 using namespace facebook::velox;
 using namespace facebook::velox::test;
 
-class IsNotNullTest : public functions::test::FunctionBaseTest {
+class IsNotNullTest : public functions::test::PrestoFunctionBaseTest {
  public:
   static void SetUpTestCase() {
     functions::registerIsNotNull();

--- a/velox/functions/lib/tests/IsNullTest.cpp
+++ b/velox/functions/lib/tests/IsNullTest.cpp
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
 
-class IsNullTest : public functions::test::FunctionBaseTest {};
+class IsNullTest : public functions::test::PrestoFunctionBaseTest {};
 
 TEST_F(IsNullTest, basic) {
   vector_size_t size = 20;

--- a/velox/functions/lib/tests/MapConcatTest.cpp
+++ b/velox/functions/lib/tests/MapConcatTest.cpp
@@ -14,16 +14,15 @@
  * limitations under the License.
  */
 #include "velox/functions/lib/MapConcat.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/parse/TypeResolver.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::functions::test;
 
-class MapConcatTest : public FunctionBaseTest {
+class MapConcatTest : public PrestoFunctionBaseTest {
  protected:
   static void SetUpTestCase() {
-    FunctionBaseTest::SetUpTestCase();
     facebook::velox::functions::registerMapConcatEmptyNullsFunction(
         "map_concat_empty_nulls");
   }

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -24,7 +24,7 @@
 
 #include "velox/common/base/VeloxException.h"
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/parse/TypeResolver.h"
 #include "velox/type/StringView.h"
 #include "velox/vector/BaseVector.h"
@@ -44,10 +44,9 @@ std::shared_ptr<exec::VectorFunction> makeRegexExtract(
   return makeRe2Extract(name, inputArgs, config, /*emptyNoMatch=*/false);
 }
 
-class Re2FunctionsTest : public test::FunctionBaseTest {
+class Re2FunctionsTest : public test::PrestoFunctionBaseTest {
  public:
   static void SetUpTestCase() {
-    test::FunctionBaseTest::SetUpTestCase();
     exec::registerStatefulVectorFunction(
         "re2_match", re2MatchSignatures(), makeRe2Match);
     exec::registerStatefulVectorFunction(
@@ -174,7 +173,7 @@ void addRow(Table& dataset, const Row& row, std::index_sequence<I...>) {
 //   2) One batch of 1024 identical rows per test case using FlatVectors.
 //   3) One batch of 1024 identical rows per test case using ConstantVectors.
 template <typename ReturnType, typename... T>
-class VectorFunctionTester : public test::FunctionBaseTest {
+class VectorFunctionTester : public test::PrestoFunctionBaseTest {
  public:
   explicit VectorFunctionTester(std::string expr) : expr(expr) {}
 
@@ -238,9 +237,10 @@ class VectorFunctionTester : public test::FunctionBaseTest {
     }
   }
 
-  // We inherit from FunctionBaseTest so that we can get access to the helpers
-  // it defines, but since it is supposed to be a test fixture TestBody() is
-  // declared pure virtual.  We must provide an implementation here.
+  // We inherit from PrestoFunctionBaseTest so that we can get access to the
+  // helpers it defines, but since it is supposed to be a test fixture
+  // TestBody() is declared pure virtual.  We must provide an implementation
+  // here.
   void TestBody() override {}
 };
 

--- a/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
@@ -15,15 +15,15 @@
  */
 #include "velox/functions/prestosql/aggregates/ValueList.h"
 #include <gtest/gtest.h>
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
 
-class ValueListTest : public functions::test::FunctionBaseTest {
+class ValueListTest : public functions::test::PrestoFunctionBaseTest {
  protected:
-  ValueListTest() : functions::test::FunctionBaseTest() {}
+  ValueListTest() : functions::test::PrestoFunctionBaseTest() {}
 
   // Make sure to test sizes that are multiples of 64.
   static constexpr vector_size_t kTestSizes[6] =

--- a/velox/functions/prestosql/tests/ArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/ArithmeticTest.cpp
@@ -22,7 +22,7 @@
 #include <velox/common/base/VeloxException.h>
 #include <velox/vector/SimpleVector.h>
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 namespace facebook::velox {
 namespace {
@@ -42,7 +42,7 @@ MATCHER(IsInf, "is Infinity") {
   return arg && std::isinf(*arg);
 }
 
-class ArithmeticTest : public functions::test::FunctionBaseTest {
+class ArithmeticTest : public functions::test::PrestoFunctionBaseTest {
  protected:
   template <typename T, typename TExpected = T>
   void assertExpression(

--- a/velox/functions/prestosql/tests/ArrayAllMatchTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayAllMatchTest.cpp
@@ -15,12 +15,12 @@
  */
 
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
 
-class ArrayAllMatchTest : public functions::test::FunctionBaseTest {
+class ArrayAllMatchTest : public functions::test::PrestoFunctionBaseTest {
  protected:
   void testAllMatchExpr(
       const std::vector<std::optional<bool>>& expected,

--- a/velox/functions/prestosql/tests/ArrayAnyMatchTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayAnyMatchTest.cpp
@@ -15,12 +15,12 @@
  */
 
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
 
-class ArrayAnyMatchTest : public functions::test::FunctionBaseTest {
+class ArrayAnyMatchTest : public functions::test::PrestoFunctionBaseTest {
  protected:
   void testAnyMatchExpr(
       const std::vector<std::optional<bool>>& expected,

--- a/velox/functions/prestosql/tests/ArrayAverageTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayAverageTest.cpp
@@ -15,7 +15,7 @@
  */
 
 #include <optional>
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -23,7 +23,7 @@ using namespace facebook::velox::functions::test;
 
 namespace {
 
-class ArrayAverageTest : public FunctionBaseTest {
+class ArrayAverageTest : public PrestoFunctionBaseTest {
  protected:
   // Evaluate an expression.
   void testExpr(const VectorPtr& expected, const VectorPtr& input) {

--- a/velox/functions/prestosql/tests/ArrayCombinationsTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayCombinationsTest.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -23,7 +23,7 @@ using namespace facebook::velox::functions::test;
 
 namespace {
 
-class ArrayCombinationsTest : public FunctionBaseTest {
+class ArrayCombinationsTest : public PrestoFunctionBaseTest {
  protected:
   void testExpr(
       const VectorPtr& expected,

--- a/velox/functions/prestosql/tests/ArrayConcatTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayConcatTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -23,7 +23,7 @@ using namespace facebook::velox::functions::test;
 
 namespace {
 
-class ArrayConcatTest : public FunctionBaseTest {
+class ArrayConcatTest : public PrestoFunctionBaseTest {
  protected:
   void testExpression(
       const std::string& expression,

--- a/velox/functions/prestosql/tests/ArrayConstructorTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayConstructorTest.cpp
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 
 namespace {
 
-class ArrayConstructorTest : public functions::test::FunctionBaseTest {};
+class ArrayConstructorTest : public functions::test::PrestoFunctionBaseTest {};
 
 TEST_F(ArrayConstructorTest, basic) {
   vector_size_t size = 1'000;

--- a/velox/functions/prestosql/tests/ArrayContainsTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayContainsTest.cpp
@@ -16,7 +16,7 @@
 
 #include <optional>
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -25,7 +25,7 @@ using namespace facebook::velox::functions::test;
 
 namespace {
 
-class ArrayContainsTest : public FunctionBaseTest {
+class ArrayContainsTest : public PrestoFunctionBaseTest {
  public:
   void testContainsConstantKey(
       const ArrayVectorPtr& arrayVector,

--- a/velox/functions/prestosql/tests/ArrayDistinctTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayDistinctTest.cpp
@@ -15,7 +15,7 @@
  */
 
 #include <optional>
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -24,7 +24,7 @@ using namespace facebook::velox::functions::test;
 namespace {
 
 // Class to test the array_distinct operator.
-class ArrayDistinctTest : public FunctionBaseTest {
+class ArrayDistinctTest : public PrestoFunctionBaseTest {
  protected:
   // Evaluate an expression.
   void testExpr(

--- a/velox/functions/prestosql/tests/ArrayDuplicatesTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayDuplicatesTest.cpp
@@ -15,7 +15,7 @@
  */
 
 #include <optional>
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -24,7 +24,7 @@ using namespace facebook::velox::functions::test;
 namespace {
 
 // Class to test the array_duplicates operator.
-class ArrayDuplicatesTest : public FunctionBaseTest {
+class ArrayDuplicatesTest : public PrestoFunctionBaseTest {
  protected:
   // Evaluate an expression.
   void testExpr(

--- a/velox/functions/prestosql/tests/ArrayExceptTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayExceptTest.cpp
@@ -15,7 +15,7 @@
  */
 
 #include <optional>
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/vector/tests/TestingDictionaryArrayElementsFunction.h"
 
 using namespace facebook::velox;
@@ -24,7 +24,7 @@ using namespace facebook::velox::functions::test;
 
 namespace {
 
-class ArrayExceptTest : public FunctionBaseTest {
+class ArrayExceptTest : public PrestoFunctionBaseTest {
  protected:
   void testExpr(
       const VectorPtr& expected,

--- a/velox/functions/prestosql/tests/ArrayFilterTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayFilterTest.cpp
@@ -15,12 +15,12 @@
  */
 
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
 
-class ArrayFilterTest : public functions::test::FunctionBaseTest {
+class ArrayFilterTest : public functions::test::PrestoFunctionBaseTest {
  protected:
   template <typename T>
   void checkArrayFilter(

--- a/velox/functions/prestosql/tests/ArrayFlattenTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayFlattenTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -23,7 +23,7 @@ using namespace facebook::velox::functions::test;
 
 namespace {
 
-class ArrayFlattenTest : public FunctionBaseTest {
+class ArrayFlattenTest : public PrestoFunctionBaseTest {
  protected:
   void testExpression(
       const std::string& expression,

--- a/velox/functions/prestosql/tests/ArrayFrequencyTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayFrequencyTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using facebook::velox::test::assertEqualVectors;
 
@@ -22,7 +22,7 @@ namespace facebook::velox::functions::test {
 
 namespace {
 
-class ArrayFrequencyTest : public functions::test::FunctionBaseTest {
+class ArrayFrequencyTest : public functions::test::PrestoFunctionBaseTest {
  protected:
   void testArrayFrequency(const VectorPtr& expected, const VectorPtr& input) {
     auto result =

--- a/velox/functions/prestosql/tests/ArrayHasDuplicatesTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayHasDuplicatesTest.cpp
@@ -15,7 +15,7 @@
  */
 
 #include <optional>
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -23,7 +23,7 @@ using namespace facebook::velox::functions::test;
 
 namespace {
 
-class ArrayHasDuplicatesTest : public FunctionBaseTest {
+class ArrayHasDuplicatesTest : public PrestoFunctionBaseTest {
  protected:
   // Evaluate an expression.
   void testExpr(

--- a/velox/functions/prestosql/tests/ArrayIntersectTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayIntersectTest.cpp
@@ -15,7 +15,7 @@
  */
 
 #include <optional>
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/vector/tests/TestingDictionaryArrayElementsFunction.h"
 
 using namespace facebook::velox;
@@ -24,7 +24,7 @@ using namespace facebook::velox::functions::test;
 
 namespace {
 
-class ArrayIntersectTest : public FunctionBaseTest {
+class ArrayIntersectTest : public PrestoFunctionBaseTest {
  protected:
   void testExpr(
       const VectorPtr& expected,

--- a/velox/functions/prestosql/tests/ArrayJoinTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayJoinTest.cpp
@@ -15,7 +15,7 @@
  */
 
 #include <optional>
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -23,7 +23,7 @@ using namespace facebook::velox::functions::test;
 
 namespace {
 
-class ArrayJoinTest : public FunctionBaseTest {
+class ArrayJoinTest : public PrestoFunctionBaseTest {
  protected:
   void testExpr(
       const VectorPtr& expected,

--- a/velox/functions/prestosql/tests/ArrayMaxTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayMaxTest.cpp
@@ -15,7 +15,7 @@
  */
 
 #include <optional>
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -23,7 +23,7 @@ using namespace facebook::velox::functions::test;
 
 namespace {
 
-class ArrayMaxTest : public FunctionBaseTest {
+class ArrayMaxTest : public PrestoFunctionBaseTest {
  protected:
   void testArrayMax(const VectorPtr& input, const VectorPtr& expected) {
     auto result = evaluate<BaseVector>("array_max(C0)", makeRowVector({input}));
@@ -166,7 +166,7 @@ TEST_F(ArrayMaxTest, docs) {
 }
 
 template <typename Type>
-class ArrayMaxIntegralTest : public FunctionBaseTest {
+class ArrayMaxIntegralTest : public PrestoFunctionBaseTest {
  public:
   using T = typename Type::NativeType::NativeType;
 
@@ -231,7 +231,7 @@ class ArrayMaxIntegralTest : public FunctionBaseTest {
 };
 
 template <typename Type>
-class ArrayMaxFloatingPointTest : public FunctionBaseTest {
+class ArrayMaxFloatingPointTest : public PrestoFunctionBaseTest {
  public:
   using T = typename Type::NativeType::NativeType;
 

--- a/velox/functions/prestosql/tests/ArrayMinTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayMinTest.cpp
@@ -15,7 +15,7 @@
  */
 
 #include <optional>
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -23,7 +23,7 @@ using namespace facebook::velox::functions::test;
 
 namespace {
 
-class ArrayMinTest : public FunctionBaseTest {
+class ArrayMinTest : public PrestoFunctionBaseTest {
  protected:
   template <typename T, typename TExpected = T>
   void testExpr(

--- a/velox/functions/prestosql/tests/ArrayNoneMatchTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayNoneMatchTest.cpp
@@ -15,12 +15,12 @@
  */
 
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
 
-class ArrayNoneMatchTest : public functions::test::FunctionBaseTest {
+class ArrayNoneMatchTest : public functions::test::PrestoFunctionBaseTest {
  protected:
   void testNoneMatchExpr(
       const std::vector<std::optional<bool>>& expected,

--- a/velox/functions/prestosql/tests/ArrayNormalizeTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayNormalizeTest.cpp
@@ -16,7 +16,7 @@
 
 #include <optional>
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -25,7 +25,7 @@ using namespace facebook::velox::functions::test;
 
 namespace {
 
-class ArrayNormalizeTest : public FunctionBaseTest {
+class ArrayNormalizeTest : public PrestoFunctionBaseTest {
  protected:
   void testExpr(
       const VectorPtr& expected,

--- a/velox/functions/prestosql/tests/ArrayPositionTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayPositionTest.cpp
@@ -16,7 +16,7 @@
 
 #include <optional>
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -28,7 +28,7 @@ namespace {
 template <typename T>
 using TwoDimVector = std::vector<std::vector<std::optional<T>>>;
 
-class ArrayPositionTest : public FunctionBaseTest {
+class ArrayPositionTest : public PrestoFunctionBaseTest {
  protected:
   void evalExpr(
       const std::vector<VectorPtr>& input,

--- a/velox/functions/prestosql/tests/ArrayRemoveNullsTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayRemoveNullsTest.cpp
@@ -17,14 +17,14 @@
 #include <cstdint>
 #include <optional>
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
 using namespace facebook::velox::functions::test;
 
 namespace {
-class ArrayRemoveNullsTest : public FunctionBaseTest {
+class ArrayRemoveNullsTest : public PrestoFunctionBaseTest {
  protected:
   void testArrayRemoveNull(const VectorPtr& expected, const VectorPtr& input) {
     auto result = evaluate("remove_nulls(c0)", makeRowVector({input}));

--- a/velox/functions/prestosql/tests/ArrayRemoveTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayRemoveTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -23,7 +23,7 @@ using namespace facebook::velox::functions::test;
 
 namespace {
 
-class ArrayRemoveTest : public FunctionBaseTest {
+class ArrayRemoveTest : public PrestoFunctionBaseTest {
  protected:
   void testExpression(
       const std::string& expression,

--- a/velox/functions/prestosql/tests/ArrayShuffleTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayShuffleTest.cpp
@@ -22,7 +22,7 @@
 #include <sstream>
 
 #include "velox/expression/VectorReaders.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -74,7 +74,7 @@ std::string printArray(const std::vector<T>& input) {
 } // namespace
 
 namespace {
-class ArrayShuffleTest : public FunctionBaseTest {
+class ArrayShuffleTest : public PrestoFunctionBaseTest {
  protected:
   template <typename T>
   void testShuffle(const VectorPtr& input) {

--- a/velox/functions/prestosql/tests/ArraySortTest.cpp
+++ b/velox/functions/prestosql/tests/ArraySortTest.cpp
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 #include <fmt/format.h>
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
-using facebook::velox::functions::test::FunctionBaseTest;
+using facebook::velox::functions::test::PrestoFunctionBaseTest;
 
 namespace {
 
@@ -39,7 +39,7 @@ const std::unordered_set<TypeKind> kSupportedTypes = {
 using TestArrayType = std::vector<std::optional<StringView>>;
 using TestRowType = variant;
 
-class ArraySortTest : public FunctionBaseTest,
+class ArraySortTest : public PrestoFunctionBaseTest,
                       public testing::WithParamInterface<TypeKind> {
  protected:
   ArraySortTest() : numValues_(10), numVectors_(5) {}

--- a/velox/functions/prestosql/tests/ArraySumTest.cpp
+++ b/velox/functions/prestosql/tests/ArraySumTest.cpp
@@ -16,7 +16,7 @@
 
 #include <optional>
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -24,7 +24,7 @@ using namespace facebook::velox::functions::test;
 
 namespace {
 
-class ArraySumTest : public FunctionBaseTest {
+class ArraySumTest : public PrestoFunctionBaseTest {
  protected:
   // Evaluate an expression.
   template <typename T>

--- a/velox/functions/prestosql/tests/ArrayTrimTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayTrimTest.cpp
@@ -17,7 +17,7 @@
 #include <cstdint>
 #include <optional>
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -25,7 +25,7 @@ using namespace facebook::velox::exec;
 using namespace facebook::velox::functions::test;
 
 namespace {
-class ArrayTrimTest : public FunctionBaseTest {};
+class ArrayTrimTest : public PrestoFunctionBaseTest {};
 
 TEST_F(ArrayTrimTest, bigintArrays) {
   auto test = [this](

--- a/velox/functions/prestosql/tests/ArrayUnionTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayUnionTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -23,7 +23,7 @@ using namespace facebook::velox::functions::test;
 
 namespace {
 
-class ArrayUnionTest : public FunctionBaseTest {
+class ArrayUnionTest : public PrestoFunctionBaseTest {
  protected:
   void testExpression(
       const std::string& expression,

--- a/velox/functions/prestosql/tests/ArraysOverlapTest.cpp
+++ b/velox/functions/prestosql/tests/ArraysOverlapTest.cpp
@@ -15,7 +15,7 @@
  */
 
 #include <optional>
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/vector/tests/TestingDictionaryArrayElementsFunction.h"
 
 using namespace facebook::velox;
@@ -23,7 +23,7 @@ using namespace facebook::velox::test;
 using namespace facebook::velox::functions::test;
 
 namespace {
-class ArraysOverlapTest : public FunctionBaseTest {
+class ArraysOverlapTest : public PrestoFunctionBaseTest {
  protected:
   void testExpr(
       const VectorPtr& expected,

--- a/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
@@ -19,7 +19,7 @@
 #include <limits>
 #include "velox/common/base/VeloxException.h"
 #include "velox/expression/Expr.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
@@ -39,7 +39,7 @@ std::string hexToDec(const std::string& str) {
   return out;
 }
 
-class BinaryFunctionsTest : public FunctionBaseTest {};
+class BinaryFunctionsTest : public PrestoFunctionBaseTest {};
 
 TEST_F(BinaryFunctionsTest, md5) {
   const auto md5 = [&](std::optional<std::string> arg) {

--- a/velox/functions/prestosql/tests/BitwiseTest.cpp
+++ b/velox/functions/prestosql/tests/BitwiseTest.cpp
@@ -16,7 +16,7 @@
 #include <optional>
 
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 namespace facebook::velox {
 
@@ -30,7 +30,7 @@ static constexpr auto kMin64 = std::numeric_limits<int64_t>::min();
 static constexpr auto kMax64 = std::numeric_limits<int64_t>::max();
 static constexpr int kMaxBits = std::numeric_limits<uint64_t>::digits;
 
-class BitwiseTest : public functions::test::FunctionBaseTest {
+class BitwiseTest : public functions::test::PrestoFunctionBaseTest {
  protected:
   template <typename T>
   std::optional<int64_t> bitwiseFunction(

--- a/velox/functions/prestosql/tests/CardinalityTest.cpp
+++ b/velox/functions/prestosql/tests/CardinalityTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
@@ -22,7 +22,7 @@ using namespace facebook::velox::functions::test;
 
 namespace {
 
-class CardinalityTest : public FunctionBaseTest {
+class CardinalityTest : public PrestoFunctionBaseTest {
  protected:
   void testArrayCardinality(
       std::function<vector_size_t(vector_size_t /* row */)> sizeAt,

--- a/velox/functions/prestosql/tests/CastBaseTest.h
+++ b/velox/functions/prestosql/tests/CastBaseTest.h
@@ -20,14 +20,14 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/core/Expressions.h"
 #include "velox/core/ITypedExpr.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/vector/tests/TestingDictionaryFunction.h"
 
 namespace facebook::velox::functions::test {
 
 using namespace facebook::velox::test;
 
-class CastBaseTest : public FunctionBaseTest {
+class CastBaseTest : public PrestoFunctionBaseTest {
  protected:
   CastBaseTest() {
     exec::registerVectorFunction(

--- a/velox/functions/prestosql/tests/CeilFloorTest.cpp
+++ b/velox/functions/prestosql/tests/CeilFloorTest.cpp
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 
-class CeilFloorTest : public functions::test::FunctionBaseTest {
+class CeilFloorTest : public functions::test::PrestoFunctionBaseTest {
  protected:
   template <typename T>
   void runCeilFloorTest(

--- a/velox/functions/prestosql/tests/ComparisonsTest.cpp
+++ b/velox/functions/prestosql/tests/ComparisonsTest.cpp
@@ -16,11 +16,11 @@
 #include <string>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/Udf.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 
-class ComparisonsTest : public functions::test::FunctionBaseTest {
+class ComparisonsTest : public functions::test::PrestoFunctionBaseTest {
  public:
   void SetUp() override {
     this->options_.parseDecimalAsDouble = false;
@@ -639,7 +639,7 @@ typedef ::testing::Types<
 } // namespace
 
 template <typename ComparisonTypeOp>
-class SimdComparisonsTest : public functions::test::FunctionBaseTest {
+class SimdComparisonsTest : public functions::test::PrestoFunctionBaseTest {
  public:
   using T = typename ComparisonTypeOp::type::NativeType::NativeType;
   using ComparisonOp = typename ComparisonTypeOp::fn;

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -18,14 +18,14 @@
 #include <string>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/external/date/tz.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
 
-class DateTimeFunctionsTest : public functions::test::FunctionBaseTest {
+class DateTimeFunctionsTest : public functions::test::PrestoFunctionBaseTest {
  protected:
   std::string daysShort[7] = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
 

--- a/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -23,7 +23,7 @@ using namespace facebook::velox::functions::test;
 
 namespace facebook::velox {
 
-class DecimalArithmeticTest : public FunctionBaseTest {
+class DecimalArithmeticTest : public PrestoFunctionBaseTest {
  public:
   DecimalArithmeticTest() {
     options_.parseDecimalAsDouble = false;

--- a/velox/functions/prestosql/tests/ElementAtTest.cpp
+++ b/velox/functions/prestosql/tests/ElementAtTest.cpp
@@ -19,7 +19,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/expression/Expr.h"
 #include "velox/functions/lib/SubscriptUtil.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/SelectivityVector.h"
 
@@ -29,7 +29,7 @@ using facebook::velox::functions::SubscriptImpl;
 
 namespace {
 
-class ElementAtTest : public FunctionBaseTest {
+class ElementAtTest : public PrestoFunctionBaseTest {
  protected:
   static const vector_size_t kVectorSize{1'000};
 

--- a/velox/functions/prestosql/tests/FindFirstTest.cpp
+++ b/velox/functions/prestosql/tests/FindFirstTest.cpp
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 namespace facebook::velox::functions {
 namespace {
 
-class FindFirstTest : public functions::test::FunctionBaseTest {
+class FindFirstTest : public functions::test::PrestoFunctionBaseTest {
  protected:
   void verify(
       const std::string& expression,

--- a/velox/functions/prestosql/tests/FromUtf8Test.cpp
+++ b/velox/functions/prestosql/tests/FromUtf8Test.cpp
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 namespace facebook::velox::functions {
 
 namespace {
 
-class FromUtf8Test : public test::FunctionBaseTest {
+class FromUtf8Test : public test::PrestoFunctionBaseTest {
  protected:
   std::optional<std::string> fromUtf8(std::optional<std::string> value) {
     return evaluateOnce<std::string, std::string>(

--- a/velox/functions/prestosql/tests/GreatestLeastTest.cpp
+++ b/velox/functions/prestosql/tests/GreatestLeastTest.cpp
@@ -16,11 +16,11 @@
 
 #include <optional>
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 
-class GreatestLeastTest : public functions::test::FunctionBaseTest {
+class GreatestLeastTest : public functions::test::PrestoFunctionBaseTest {
  protected:
   template <typename T>
   void runTest(

--- a/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include "velox/common/hyperloglog/SparseHll.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
 #define XXH_INLINE_ALL
 #include <xxhash.h>
@@ -30,7 +30,8 @@ uint64_t hashOne(T value) {
   return XXH64(&value, sizeof(value), 0);
 }
 
-class HyperLogLogFunctionsTest : public functions::test::FunctionBaseTest {
+class HyperLogLogFunctionsTest
+    : public functions::test::PrestoFunctionBaseTest {
  protected:
   static std::string serialize(
       int8_t indexBitLength,

--- a/velox/functions/prestosql/tests/InPredicateTest.cpp
+++ b/velox/functions/prestosql/tests/InPredicateTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox::test;
 using namespace facebook::velox::functions::test;
@@ -22,7 +22,7 @@ using namespace facebook::velox::functions::test;
 namespace facebook::velox::functions {
 namespace {
 
-class InPredicateTest : public FunctionBaseTest {
+class InPredicateTest : public PrestoFunctionBaseTest {
  protected:
   template <typename T>
   std::string getInList(

--- a/velox/functions/prestosql/tests/JsonExtractScalarTest.cpp
+++ b/velox/functions/prestosql/tests/JsonExtractScalarTest.cpp
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 
 namespace facebook::velox::functions::prestosql {
 
 namespace {
 
-class JsonExtractScalarTest : public functions::test::FunctionBaseTest {
+class JsonExtractScalarTest : public functions::test::PrestoFunctionBaseTest {
  protected:
   VectorPtr makeVector(std::optional<std::string> json, const TypePtr& type) {
     std::optional<StringView> s = json.has_value()

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 
 namespace facebook::velox::functions::prestosql {
@@ -62,7 +62,7 @@ const std::string kJson = R"(
     }
     )";
 
-class JsonFunctionsTest : public functions::test::FunctionBaseTest {
+class JsonFunctionsTest : public functions::test::PrestoFunctionBaseTest {
  protected:
   VectorPtr makeJsonVector(std::optional<std::string> json) {
     std::optional<StringView> s = json.has_value()

--- a/velox/functions/prestosql/tests/MapEntriesTest.cpp
+++ b/velox/functions/prestosql/tests/MapEntriesTest.cpp
@@ -15,12 +15,12 @@
  */
 
 #include "velox/expression/VectorFunction.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::functions::test;
 
-class MapEntriesTest : public FunctionBaseTest {
+class MapEntriesTest : public PrestoFunctionBaseTest {
  protected:
   /// Create an ARRAY vector of size 1 using specified 'elements' vector.
   VectorPtr makeSingleRowArrayVector(const VectorPtr& elements) {

--- a/velox/functions/prestosql/tests/MapFilterTest.cpp
+++ b/velox/functions/prestosql/tests/MapFilterTest.cpp
@@ -16,12 +16,12 @@
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
 
-class MapFilterTest : public functions::test::FunctionBaseTest {
+class MapFilterTest : public functions::test::PrestoFunctionBaseTest {
  protected:
   template <typename K, typename V>
   void checkMapFilter(

--- a/velox/functions/prestosql/tests/MapFromEntriesTest.cpp
+++ b/velox/functions/prestosql/tests/MapFromEntriesTest.cpp
@@ -17,7 +17,7 @@
 #include <optional>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/lib/CheckDuplicateKeys.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/vector/tests/TestingDictionaryArrayElementsFunction.h"
 
 using namespace facebook::velox;
@@ -32,7 +32,7 @@ std::optional<std::vector<std::pair<int32_t, std::optional<int32_t>>>> O(
 } // namespace
 
 namespace {
-class MapFromEntriesTest : public FunctionBaseTest {
+class MapFromEntriesTest : public PrestoFunctionBaseTest {
  protected:
   /// Create an MAP vector of size 1 using specified 'keys' and 'values' vector.
   VectorPtr makeSingleRowMapVector(

--- a/velox/functions/prestosql/tests/MapKeysAndValuesTest.cpp
+++ b/velox/functions/prestosql/tests/MapKeysAndValuesTest.cpp
@@ -15,7 +15,7 @@
  */
 
 #include <cstdint>
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
@@ -23,7 +23,7 @@ using namespace facebook::velox::functions::test;
 
 namespace {
 
-class MapKeysAndValuesTest : public FunctionBaseTest {
+class MapKeysAndValuesTest : public PrestoFunctionBaseTest {
  protected:
   void checkResult(
       MapVectorPtr mapVector,

--- a/velox/functions/prestosql/tests/MapMatchTest.cpp
+++ b/velox/functions/prestosql/tests/MapMatchTest.cpp
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 namespace facebook::velox::functions {
 namespace {
 
-class MapMatchTest : public functions::test::FunctionBaseTest {
+class MapMatchTest : public functions::test::PrestoFunctionBaseTest {
  protected:
   void match(
       const std::string& functionName,

--- a/velox/functions/prestosql/tests/MapTest.cpp
+++ b/velox/functions/prestosql/tests/MapTest.cpp
@@ -17,7 +17,7 @@
 #include <optional>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -25,7 +25,7 @@ using namespace facebook::velox::functions::test;
 
 namespace {
 
-class MapTest : public FunctionBaseTest {};
+class MapTest : public PrestoFunctionBaseTest {};
 
 TEST_F(MapTest, noNulls) {
   auto size = 1'000;

--- a/velox/functions/prestosql/tests/MapZipWithTest.cpp
+++ b/velox/functions/prestosql/tests/MapZipWithTest.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
 using namespace facebook::velox;
@@ -23,7 +23,7 @@ using namespace facebook::velox::functions::test;
 
 namespace {
 
-class MapZipWithTest : public FunctionBaseTest {};
+class MapZipWithTest : public PrestoFunctionBaseTest {};
 
 TEST_F(MapZipWithTest, basic) {
   auto data = makeRowVector({

--- a/velox/functions/prestosql/tests/NotTest.cpp
+++ b/velox/functions/prestosql/tests/NotTest.cpp
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
 
-class NotTest : public functions::test::FunctionBaseTest {};
+class NotTest : public functions::test::PrestoFunctionBaseTest {};
 
 TEST_F(NotTest, noNulls) {
   constexpr vector_size_t size = 1'000;

--- a/velox/functions/prestosql/tests/ProbabilityTest.cpp
+++ b/velox/functions/prestosql/tests/ProbabilityTest.cpp
@@ -17,7 +17,7 @@
 #include <gmock/gmock.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 namespace facebook::velox {
 namespace {
@@ -39,7 +39,7 @@ MATCHER(IsInf, "is Infinity") {
   return arg && std::isinf(*arg);
 }
 
-class ProbabilityTest : public functions::test::FunctionBaseTest {
+class ProbabilityTest : public functions::test::PrestoFunctionBaseTest {
  protected:
   template <typename ValueType>
   auto poissonCDF(

--- a/velox/functions/prestosql/tests/RandTest.cpp
+++ b/velox/functions/prestosql/tests/RandTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -23,7 +23,7 @@ namespace facebook::velox::functions {
 
 namespace {
 
-class RandTest : public functions::test::FunctionBaseTest {
+class RandTest : public functions::test::PrestoFunctionBaseTest {
  protected:
   template <typename T>
   std::optional<T> random(T n) {

--- a/velox/functions/prestosql/tests/ReduceTest.cpp
+++ b/velox/functions/prestosql/tests/ReduceTest.cpp
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
 
-class ReduceTest : public functions::test::FunctionBaseTest {};
+class ReduceTest : public functions::test::PrestoFunctionBaseTest {};
 
 TEST_F(ReduceTest, basic) {
   vector_size_t size = 1'000;

--- a/velox/functions/prestosql/tests/RegexpReplaceTest.cpp
+++ b/velox/functions/prestosql/tests/RegexpReplaceTest.cpp
@@ -16,12 +16,12 @@
 #include <exception>
 #include <optional>
 
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 namespace facebook::velox {
 namespace {
 
-class RegexFunctionsTest : public functions::test::FunctionBaseTest {
+class RegexFunctionsTest : public functions::test::PrestoFunctionBaseTest {
  protected:
   std::optional<std::string> regexp_replace(
       const std::optional<std::string>& string,

--- a/velox/functions/prestosql/tests/RepeatTest.cpp
+++ b/velox/functions/prestosql/tests/RepeatTest.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -23,7 +23,7 @@ using namespace facebook::velox::functions::test;
 
 namespace {
 
-class RepeatTest : public FunctionBaseTest {
+class RepeatTest : public PrestoFunctionBaseTest {
  protected:
   void testExpression(
       const std::string& expression,

--- a/velox/functions/prestosql/tests/ReverseTest.cpp
+++ b/velox/functions/prestosql/tests/ReverseTest.cpp
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
 using namespace facebook::velox::functions::test;
 
 namespace {
-class ReverseTest : public FunctionBaseTest {
+class ReverseTest : public PrestoFunctionBaseTest {
  protected:
   void testExpr(const VectorPtr& expected, const VectorPtr& input) {
     auto result = evaluate("reverse(C0)", makeRowVector({input}));

--- a/velox/functions/prestosql/tests/RoundTest.cpp
+++ b/velox/functions/prestosql/tests/RoundTest.cpp
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 
-class RoundTest : public functions::test::FunctionBaseTest {
+class RoundTest : public functions::test::PrestoFunctionBaseTest {
  protected:
   template <typename T>
   void runRoundTest(const std::vector<std::tuple<T, T>>& data) {

--- a/velox/functions/prestosql/tests/SequenceTest.cpp
+++ b/velox/functions/prestosql/tests/SequenceTest.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/type/TimestampConversion.h"
 
 using namespace facebook::velox;
@@ -24,7 +24,7 @@ using namespace facebook::velox::functions::test;
 
 namespace {
 
-class SequenceTest : public FunctionBaseTest {
+class SequenceTest : public PrestoFunctionBaseTest {
  protected:
   void testExpression(
       const std::string& expression,

--- a/velox/functions/prestosql/tests/SliceTest.cpp
+++ b/velox/functions/prestosql/tests/SliceTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -22,7 +22,7 @@ using namespace facebook::velox::functions::test;
 
 namespace {
 
-class SliceTest : public FunctionBaseTest {
+class SliceTest : public PrestoFunctionBaseTest {
  protected:
   static const vector_size_t kVectorSize{1000};
 

--- a/velox/functions/prestosql/tests/SplitPartTest.cpp
+++ b/velox/functions/prestosql/tests/SplitPartTest.cpp
@@ -16,7 +16,7 @@
 #include <gtest/gtest.h>
 #include "velox/expression/Expr.h"
 #include "velox/functions/Udf.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/parse/Expressions.h"
 
 namespace facebook::velox::functions::test {
@@ -24,7 +24,7 @@ namespace facebook::velox::functions::test {
 namespace {
 
 // Class to test 'split_part' function.
-class SplitPartTest : public FunctionBaseTest {
+class SplitPartTest : public PrestoFunctionBaseTest {
  protected:
   auto split_part(
       std::optional<std::string> input,

--- a/velox/functions/prestosql/tests/SplitTest.cpp
+++ b/velox/functions/prestosql/tests/SplitTest.cpp
@@ -17,7 +17,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/expression/Expr.h"
 #include "velox/functions/Udf.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/parse/Expressions.h"
 
 using namespace facebook::velox;
@@ -26,7 +26,7 @@ using namespace facebook::velox::functions::test;
 using namespace facebook::velox::test;
 
 /// Class to test 'split' vector function.
-class SplitTest : public FunctionBaseTest {
+class SplitTest : public PrestoFunctionBaseTest {
  protected:
   /// Method runs the given split function, f.e. split(C0, C1), where C0 is the
   /// input column and the C1 is delimiter column.

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -22,7 +22,7 @@
 #include "velox/expression/Expr.h"
 #include "velox/functions/lib/StringEncodingUtils.h"
 #include "velox/functions/lib/string/StringImpl.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
@@ -66,7 +66,7 @@ int expectedLength(int i) {
 }
 } // namespace
 
-class StringFunctionsTest : public FunctionBaseTest {
+class StringFunctionsTest : public PrestoFunctionBaseTest {
  protected:
   VectorPtr makeStrings(
       vector_size_t size,

--- a/velox/functions/prestosql/tests/TransformKeysTest.cpp
+++ b/velox/functions/prestosql/tests/TransformKeysTest.cpp
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
 
-class TransformKeysTest : public functions::test::FunctionBaseTest {};
+class TransformKeysTest : public functions::test::PrestoFunctionBaseTest {};
 
 TEST_F(TransformKeysTest, basic) {
   vector_size_t size = 1'000;

--- a/velox/functions/prestosql/tests/TransformTest.cpp
+++ b/velox/functions/prestosql/tests/TransformTest.cpp
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
 
-class TransformTest : public functions::test::FunctionBaseTest {};
+class TransformTest : public functions::test::PrestoFunctionBaseTest {};
 
 TEST_F(TransformTest, basic) {
   vector_size_t size = 1'000;

--- a/velox/functions/prestosql/tests/TransformValuesTest.cpp
+++ b/velox/functions/prestosql/tests/TransformValuesTest.cpp
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
 
-class TransformValuesTest : public functions::test::FunctionBaseTest {};
+class TransformValuesTest : public functions::test::PrestoFunctionBaseTest {};
 
 TEST_F(TransformValuesTest, basic) {
   vector_size_t size = 1'000;

--- a/velox/functions/prestosql/tests/TrimFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/TrimFunctionsTest.cpp
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 #include <boost/random/uniform_int_distribution.hpp>
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace std::string_literals;
 
 namespace facebook::velox::functions {
 namespace {
 
-class TrimFunctionsTest : public test::FunctionBaseTest {
+class TrimFunctionsTest : public test::PrestoFunctionBaseTest {
  protected:
   static std::string generateInvalidUtf8() {
     std::string str;

--- a/velox/functions/prestosql/tests/URLFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/URLFunctionsTest.cpp
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 #include <gmock/gmock.h>
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 namespace facebook::velox {
 
 namespace {
-class URLFunctionsTest : public functions::test::FunctionBaseTest {
+class URLFunctionsTest : public functions::test::PrestoFunctionBaseTest {
  protected:
   void validate(
       const std::string& url,

--- a/velox/functions/prestosql/tests/WidthBucketArrayTest.cpp
+++ b/velox/functions/prestosql/tests/WidthBucketArrayTest.cpp
@@ -15,7 +15,7 @@
  */
 #include <optional>
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -24,7 +24,7 @@ using namespace facebook::velox::functions::test;
 
 namespace {
 
-class WidthBucketArrayTest : public FunctionBaseTest {
+class WidthBucketArrayTest : public PrestoFunctionBaseTest {
  protected:
   static constexpr double kInf = std::numeric_limits<double>::infinity();
   static constexpr double kNan = std::numeric_limits<double>::quiet_NaN();

--- a/velox/functions/prestosql/tests/ZipTest.cpp
+++ b/velox/functions/prestosql/tests/ZipTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -23,7 +23,7 @@ using namespace facebook::velox::functions::test;
 
 namespace {
 
-class ZipTest : public FunctionBaseTest {};
+class ZipTest : public PrestoFunctionBaseTest {};
 
 /// Test if we can zip two integer arrays.
 TEST_F(ZipTest, simpleInt) {

--- a/velox/functions/prestosql/tests/ZipWithTest.cpp
+++ b/velox/functions/prestosql/tests/ZipWithTest.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
 using namespace facebook::velox;
@@ -23,7 +23,7 @@ using namespace facebook::velox::functions::test;
 
 namespace {
 
-class ZipWithTest : public FunctionBaseTest {};
+class ZipWithTest : public PrestoFunctionBaseTest {};
 
 TEST_F(ZipWithTest, basic) {
   auto data = makeRowVector({

--- a/velox/functions/prestosql/tests/utils/FunctionBaseTest.cpp
+++ b/velox/functions/prestosql/tests/utils/FunctionBaseTest.cpp
@@ -15,16 +15,8 @@
  */
 #include "FunctionBaseTest.h"
 #include "velox/functions/FunctionRegistry.h"
-#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
-#include "velox/parse/TypeResolver.h"
 
 namespace facebook::velox::functions::test {
-
-void FunctionBaseTest::SetUpTestCase() {
-  parse::registerTypeResolver();
-  functions::prestosql::registerAllScalarFunctions();
-  memory::MemoryManager::testingSetInstance({});
-}
 
 // static
 std::unordered_set<std::string> FunctionBaseTest::getSignatureStrings(

--- a/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
@@ -20,7 +20,6 @@
 #include "velox/expression/Expr.h"
 #include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
-#include "velox/type/Type.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 namespace facebook::velox::functions::test {
@@ -42,8 +41,6 @@ class FunctionBaseTest : public testing::Test,
       RealType>;
 
  protected:
-  static void SetUpTestCase();
-
   static std::function<vector_size_t(vector_size_t row)> modN(int n) {
     return [n](vector_size_t row) { return row % n; };
   }

--- a/velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/parse/TypeResolver.h"
+
+namespace facebook::velox::functions::test {
+
+class PrestoFunctionBaseTest : public FunctionBaseTest {
+ protected:
+  static void SetUpTestCase() {
+    parse::registerTypeResolver();
+    functions::prestosql::registerAllScalarFunctions();
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
+
+} // namespace facebook::velox::functions::test

--- a/velox/functions/remote/client/tests/RemoteFunctionTest.cpp
+++ b/velox/functions/remote/client/tests/RemoteFunctionTest.cpp
@@ -26,7 +26,7 @@
 #include "velox/functions/lib/CheckedArithmetic.h"
 #include "velox/functions/prestosql/Arithmetic.h"
 #include "velox/functions/prestosql/StringFunctions.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/PrestoFunctionBaseTest.h"
 #include "velox/functions/remote/client/Remote.h"
 #include "velox/functions/remote/if/gen-cpp2/RemoteFunctionService.h"
 #include "velox/functions/remote/server/RemoteFunctionService.h"
@@ -40,7 +40,7 @@ namespace {
 // Parametrize in the serialization format so we can test both presto page and
 // unsafe row.
 class RemoteFunctionTest
-    : public functions::test::FunctionBaseTest,
+    : public functions::test::PrestoFunctionBaseTest,
       public ::testing::WithParamInterface<remote::PageFormat> {
  public:
   void SetUp() override {

--- a/velox/functions/sparksql/tests/ArraySortTest.cpp
+++ b/velox/functions/sparksql/tests/ArraySortTest.cpp
@@ -16,7 +16,6 @@
 
 #include <optional>
 
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/functions/sparksql/tests/ArraySortTestData.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 #include "velox/vector/ComplexVector.h"

--- a/velox/functions/sparksql/tests/MapTest.cpp
+++ b/velox/functions/sparksql/tests/MapTest.cpp
@@ -16,7 +16,6 @@
 
 #include "velox/common/base/VeloxException.h"
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 #include "velox/type/Variant.h"
 

--- a/velox/functions/sparksql/tests/RegexFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/RegexFunctionsTest.cpp
@@ -32,7 +32,6 @@ namespace {
 class RegexFunctionsTest : public test::SparkFunctionBaseTest {
  public:
   void SetUp() override {
-    SparkFunctionBaseTest::SetUp();
     registerRegexReplace("");
   }
 

--- a/velox/functions/sparksql/tests/SortArrayTest.cpp
+++ b/velox/functions/sparksql/tests/SortArrayTest.cpp
@@ -18,7 +18,6 @@
 #include <limits>
 #include <optional>
 
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/functions/sparksql/Register.h"
 #include "velox/functions/sparksql/tests/ArraySortTestData.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"


### PR DESCRIPTION
Moves the registration of Presto functions from `FunctionBaseTest` to
`PrestoFunctionBaseTest`, and make `FunctionBaseTest` a shared base class of
`PrestoFunctionBaseTest` and `SparkFunctionBaseTest`.
Fixes https://github.com/facebookincubator/velox/issues/8121.