### PR TITLE
HashStringAllocator compaction prototype.

### DIFF
--- a/velox/common/memory/AllocationCompactor.cpp
+++ b/velox/common/memory/AllocationCompactor.cpp
@@ -1,0 +1,397 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/memory/AllocationCompactor.h"
+
+namespace facebook::velox::detail {
+
+int64_t tryAccommodate(int64_t destSize, int64_t srcSize, bool isSrcContinued) {
+  static constexpr auto kMinAlloc = HashStringAllocator::kMinAlloc;
+  static constexpr auto kMinBlockSize = AllocationCompactor::kMinBlockSize;
+  static constexpr auto kContinuedPtrSize =
+      HashStringAllocator::Header::kContinuedPtrSize;
+
+  VELOX_CHECK_GE(destSize, kMinAlloc);
+
+  if (srcSize + kMinBlockSize <= destSize || srcSize == destSize) {
+    return srcSize;
+  }
+
+  if (!isSrcContinued) {
+    if (srcSize < destSize) {
+      // After accommodating src block, the rest of space of the 'destBlock' is
+      // not enough for a valid block, use it up.
+      return srcSize;
+    }
+    // src block is larger than dest block, split src block so the first part
+    // can fill the dest block.
+    return destSize - kContinuedPtrSize;
+  }
+
+  // src block is continued.
+  VELOX_CHECK_GE(srcSize, kMinAlloc);
+  if (srcSize - destSize + kContinuedPtrSize >= kMinAlloc) {
+    // src block is larger than dest block and when splitting src block to fill
+    // the dest block, the second part of the splitted block is valid.
+    return destSize - kContinuedPtrSize;
+  }
+
+  // src block's size is slightly different from dest block's size: If src block
+  // is smaller than dest block, the diff is not enough for a valid free block;
+  // otherwise, the diff is not enough to put in a valid continued block. Try
+  // splitting src block into two blocks A and B, put A into dest block so
+  // that remaining of dest block after accommodating A forms a minimum valid
+  // free block(Will not be used for later accommodation, just for keeping the
+  // invariant of HSA). We can put B into another page later. The constraint is
+  // that A and B should both be valid(>= kMinAlloc), if unsatisfied, we can
+  // only skip this dest block and put src block into later page.
+  if (srcSize < destSize) {
+    VELOX_CHECK_GT(srcSize, destSize - kMinBlockSize);
+  } else {
+    VELOX_CHECK_LT(srcSize - destSize + kContinuedPtrSize, kMinAlloc);
+  }
+  const auto sizeA{std::min<int32_t>(
+      destSize - kMinBlockSize - HashStringAllocator::Header::kContinuedPtrSize,
+      srcSize - HashStringAllocator::kMinAlloc)};
+  const auto sizeB{srcSize - sizeA};
+  if (sizeA + HashStringAllocator::Header::kContinuedPtrSize >= kMinAlloc &&
+      sizeB >= kMinAlloc) {
+    return sizeA;
+  }
+  return 0;
+}
+
+} // namespace facebook::velox::detail
+
+namespace facebook::velox {
+
+using Header = AllocationCompactor::Header;
+
+AllocationCompactor::AllocationCompactor(AllocationRange allocationRange)
+    : range_{allocationRange} {
+  if (size() >= kHugePageSize) {
+    VELOX_CHECK_EQ(0, size() % kHugePageSize);
+  }
+
+  // Collects allocation info.
+  int64_t nonFreeBlockSize{0};
+  foreachBlock([&nonFreeBlockSize](Header* header) {
+    if (!header->isFree()) {
+      nonFreeBlockSize += header->size() + sizeof(Header);
+    }
+  });
+  nonFreeBlockSize_ = nonFreeBlockSize;
+}
+
+void AllocationCompactor::accumulateMultipartMap(
+    HeaderMap& multipartMap) const {
+  foreachBlock([&multipartMap](Header* header) {
+    if (!header->isContinued()) {
+      return;
+    }
+    const auto nextContinued{header->nextContinued()};
+    VELOX_CHECK(!multipartMap.contains(nextContinued));
+    multipartMap[nextContinued] = header;
+  });
+}
+
+void AllocationCompactor::foreachBlock(
+    folly::Range<char*> range,
+    const std::function<void(Header*)>& func) {
+  for (int64_t subRangeOffset = 0; subRangeOffset < range.size();
+       subRangeOffset += kHugePageSize) {
+    auto header = reinterpret_cast<Header*>(range.data() + subRangeOffset);
+    while (header) {
+      func(header);
+      header = header->next();
+    }
+  }
+}
+
+Header* AllocationCompactor::squeezeArena(
+    AllocationRange arena,
+    HeaderMap& multipartMap,
+    HeaderMap& movedBlocks) {
+  VELOX_CHECK(
+      reinterpret_cast<Header*>(arena.data() + arena.size())->isArenaEnd());
+
+  auto offsetFromArenaStart = [&arena](Header* header) {
+    return reinterpret_cast<char*>(header) - arena.data();
+  };
+
+  // Returns the next non free block in the arena. Returns nullptr if there is
+  // no. 'header' should be the header of a block within the arena. If 'header'
+  // is nullptr, returns the first non free block in arena.
+  auto nextNonFreeBlockInArena = [&](Header* header) {
+    if (header != nullptr) {
+      auto nextNonFreeBlock = nextBlock(false, header);
+      if (nextNonFreeBlock == nullptr ||
+          offsetFromArenaStart(nextNonFreeBlock) >= arena.size()) {
+        return static_cast<Header*>(nullptr);
+      }
+      return nextNonFreeBlock;
+    }
+
+    header = reinterpret_cast<Header*>(arena.data());
+    while (header) {
+      if (!header->isFree()) {
+        return header;
+      }
+      header = header->next();
+    }
+    return static_cast<Header*>(nullptr);
+  };
+
+  auto movedFrom = nextNonFreeBlockInArena(nullptr);
+  int64_t movedToOffset{0};
+  while (movedFrom != nullptr) {
+    const auto movedFromOffset{offsetFromArenaStart(movedFrom)};
+    if (movedFromOffset == movedToOffset) {
+      movedToOffset = movedFrom->end() - arena.data();
+      movedFrom = nextNonFreeBlockInArena(movedFrom);
+      continue;
+    }
+    VELOX_CHECK_GT(movedFromOffset, movedToOffset);
+
+    auto movedTo = reinterpret_cast<Header*>(arena.data() + movedToOffset);
+    auto nextNonFreeBlock = nextNonFreeBlockInArena(movedFrom);
+    updateMap(movedFrom, movedTo, multipartMap, movedBlocks);
+    // Don't use memcpy here since 'movedTo' and 'movedFrom' might overlap.
+    memmove(movedTo, movedFrom, sizeof(Header) + movedFrom->size());
+    movedTo->clearPreviousFree();
+
+    movedFrom = nextNonFreeBlock;
+    movedToOffset = movedTo->end() - arena.data();
+  }
+
+  if (movedToOffset == arena.size()) {
+    return nullptr;
+  }
+
+  const auto remainingSize{arena.size() - movedToOffset};
+  VELOX_CHECK_GE(remainingSize, kMinBlockSize);
+
+  auto freeBlock =
+      new (arena.data() + movedToOffset) Header(remainingSize - sizeof(Header));
+  freeBlock->setFree();
+  // TODO: Size at the end is not set.
+  return freeBlock;
+}
+
+std::vector<HashStringAllocator::Header*> AllocationCompactor::squeeze(
+    HeaderMap& multipartMap,
+    HeaderMap& movedBlocks) {
+  std::vector<HashStringAllocator::Header*> freeBlocks;
+  for (int64_t subRangeOffset = 0; subRangeOffset < size();
+       subRangeOffset += kHugePageSize) {
+    const auto arenaStart = range_.data() + subRangeOffset;
+    const auto arenaSize =
+        std::min<int64_t>(range_.size(), kHugePageSize) - simd::kPadding;
+    const auto arena = folly::Range<char*>(arenaStart, arenaSize);
+
+    auto freeBlock = squeezeArena(arena, multipartMap, movedBlocks);
+    if (freeBlock != nullptr) {
+      freeBlocks.push_back(freeBlock);
+    }
+  }
+  return freeBlocks;
+}
+
+void AllocationCompactor::updateMapAsNext(
+    Header* from,
+    Header* to,
+    HeaderMap& multipartMap,
+    HeaderMap& movedBlocks) {
+  if (!multipartMap.contains(from)) {
+    VELOX_CHECK(!movedBlocks.contains(from));
+    movedBlocks[from] = to;
+    return;
+  }
+
+  auto prevHeader = multipartMap[from];
+  VELOX_CHECK(!prevHeader->isFree());
+  VELOX_CHECK(!prevHeader->isArenaEnd());
+  VELOX_CHECK(prevHeader->isContinued());
+  VELOX_CHECK_EQ(
+      reinterpret_cast<void*>(prevHeader->nextContinued()),
+      reinterpret_cast<void*>(from));
+  prevHeader->setNextContinued(to);
+  multipartMap.erase(from);
+  multipartMap[to] = prevHeader;
+}
+
+void AllocationCompactor::updateMapAsPrevious(
+    Header* from,
+    Header* to,
+    HeaderMap& multipartMap) {
+  VELOX_CHECK(from->isContinued());
+  auto nextHeader = from->nextContinued();
+  VELOX_CHECK(!nextHeader->isFree());
+  VELOX_CHECK(!nextHeader->isArenaEnd());
+  VELOX_CHECK(multipartMap.contains(nextHeader));
+  multipartMap[nextHeader] = to;
+}
+
+void AllocationCompactor::updateMap(
+    Header* from,
+    Header* to,
+    HeaderMap& multipartMap,
+    HeaderMap& movedBlocks) {
+  updateMapAsNext(from, to, multipartMap, movedBlocks);
+
+  if (from->isContinued()) {
+    updateMapAsPrevious(from, to, multipartMap);
+  }
+}
+
+Header* AllocationCompactor::nextBlock(bool isFree, Header* header) const {
+  if (header != nullptr) {
+    VELOX_CHECK_GE(reinterpret_cast<char*>(header), range_.data());
+    VELOX_CHECK_LT(
+        reinterpret_cast<char*>(header),
+        range_.data() + range_.size() - simd::kPadding);
+    header = reinterpret_cast<Header*>(header->end());
+  } else {
+    header = reinterpret_cast<Header*>(range_.data());
+  }
+
+  while (!header->isArenaEnd()) {
+    if (isFree == header->isFree()) {
+      return header;
+    }
+    header = reinterpret_cast<Header*>(header->end());
+  }
+
+  const auto boundary = reinterpret_cast<char*>(header) + simd::kPadding;
+  VELOX_CHECK_LE(boundary, range_.data() + range_.size());
+  if (boundary == range_.data() + range_.size()) {
+    return nullptr;
+  }
+
+  auto arenaStart = boundary;
+  while (arenaStart < range_.data() + range_.size()) {
+    header = reinterpret_cast<Header*>(arenaStart);
+    while (!header->isArenaEnd()) {
+      if (isFree == header->isFree()) {
+        return header;
+      }
+      header = reinterpret_cast<Header*>(header->end());
+    }
+    arenaStart += kHugePageSize;
+  }
+  return nullptr;
+}
+
+AllocationCompactor::MoveResult AllocationCompactor::moveBlock(
+    Header* srcBlock,
+    int64_t srcOffset,
+    Header** prevContPtr,
+    Header* destBlock,
+    HeaderMap& multipartMap,
+    HeaderMap& movedBlocks) {
+  // Sanity check.
+  VELOX_CHECK(!srcBlock->isFree());
+  VELOX_CHECK(destBlock->isFree());
+  VELOX_CHECK(srcOffset < srcBlock->size());
+  VELOX_CHECK((srcOffset > 0) == (prevContPtr != nullptr));
+  // TODO: check srcBlock and destBlock is not overlapped
+
+  // Determine move size.
+  const auto bytesToMove{srcBlock->size() - srcOffset};
+  auto movableSize = detail::tryAccommodate(
+      destBlock->size(), bytesToMove, srcBlock->isContinued());
+  if (movableSize == 0) {
+    VELOX_CHECK(srcBlock->isContinued());
+    return {0, prevContPtr, nullptr, destBlock->size()};
+  }
+
+  VELOX_CHECK_LE(movableSize, bytesToMove);
+  const auto movingRestOfSrc = (movableSize == bytesToMove);
+  // When moving final part of non-continued block, 'bytesTomove' may be less
+  // than kMinAlloc, which will need padding to make the result block valid.
+  const auto needsPadding = (bytesToMove < HashStringAllocator::kMinAlloc);
+  if (needsPadding) {
+    VELOX_CHECK(!srcBlock->isContinued());
+    VELOX_CHECK(movingRestOfSrc);
+  }
+
+  // Update map
+  if (srcOffset == 0) {
+    updateMapAsNext(srcBlock, destBlock, multipartMap, movedBlocks);
+  }
+  if (movingRestOfSrc && srcBlock->isContinued()) {
+    // Moving last part of a continued 'srcBlock', and this is previous.
+    // Update next->previous
+    updateMapAsPrevious(srcBlock, destBlock, multipartMap);
+  }
+
+  auto destSizeNeeded = movableSize;
+  if (needsPadding) {
+    VELOX_CHECK_LE(movableSize, HashStringAllocator::kMinAlloc);
+    destSizeNeeded = HashStringAllocator::kMinAlloc;
+  } else if (!movingRestOfSrc) {
+    destSizeNeeded += Header::kContinuedPtrSize;
+  }
+  VELOX_CHECK_LE(destSizeNeeded, destBlock->size());
+
+  const auto remainingDestSize{destBlock->size() - destSizeNeeded};
+  Header* remainingDestBlock{nullptr};
+  auto destNewSize{destBlock->size()};
+  if (remainingDestSize >= kMinBlockSize) {
+    // Create a new free block at the end of moved block.
+    // TODO: size at the end.
+    remainingDestBlock = new (destBlock->begin() + destSizeNeeded)
+        Header(destBlock->size() - destSizeNeeded - sizeof(Header));
+    remainingDestBlock->setFree();
+    destNewSize = destSizeNeeded;
+  }
+
+  // Actual move.
+  memcpy(destBlock->begin(), srcBlock->begin() + srcOffset, movableSize);
+  destBlock->clearFree();
+  if (movingRestOfSrc && !srcBlock->isContinued()) {
+    destBlock->clearContinued();
+  } else {
+    destBlock->setContinued();
+  }
+  destBlock->setSize(destNewSize);
+
+  if (prevContPtr != nullptr) {
+    *prevContPtr = destBlock;
+  }
+
+  Header** resultPrevContPtr{nullptr};
+  if (!movingRestOfSrc) {
+    resultPrevContPtr = reinterpret_cast<Header**>(
+        destBlock->end() - Header::kContinuedPtrSize);
+  }
+
+  auto destDiscardedSize{0};
+  // 'srcBlock' is splitted for this move and there is still 'destBlock'
+  // remaining, means that 'srcBlock' is splitted to not break the invariance of
+  // HSA: a block has at least kMinAlloc bytes as data.
+  const auto discardRemaining = (!movingRestOfSrc) && (remainingDestSize > 0);
+  if (discardRemaining) {
+    // TODO: this does not compile
+    // VELOX_CHECK_EQ(remainingDestSize, AllocationCompactor::kMinBlockSize);
+    remainingDestBlock = nullptr;
+    destDiscardedSize = remainingDestSize;
+  }
+
+  return {
+      movableSize, resultPrevContPtr, remainingDestBlock, destDiscardedSize};
+}
+
+} // namespace facebook::velox

--- a/velox/common/memory/AllocationCompactor.h
+++ b/velox/common/memory/AllocationCompactor.h
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/container/F14Map.h>
+#include "velox/common/memory/HashStringAllocator.h"
+
+namespace facebook::velox {
+
+// Provides some helper functionalities for compacting an allocation.
+class AllocationCompactor {
+ public:
+  using AllocationRange = folly::Range<char*>;
+  using Header = HashStringAllocator::Header;
+  using HeaderMap = folly::F14FastMap<Header*, Header*>;
+
+  static constexpr auto kHugePageSize = memory::AllocationTraits::kHugePageSize;
+  static constexpr auto kMinBlockSize =
+      sizeof(Header) + HashStringAllocator::kMinAlloc;
+
+  /// Reservation used for estimating if an arena can accommodate certain size
+  /// of data. There's certain case that the free space of destination free
+  /// block cannot accommodate src block: That is when the src block is a
+  /// continued block and:
+  /// 1. destSize-kMinBlockSize < srcSize < destSize, and
+  /// min(destSize-kMinBlockSize-kContinuedPtrSize, srcSize-kMinAlloc) <
+  /// kMinAlloc-kContinuedPtrSize.
+  /// 2. destSize < srcSize < destSize+kMinAlloc-kContinuedPtrSize, and
+  /// destSize < kMinBlockSize+kMinAlloc.
+  /// In the above cases, src block cannot fit into dest block directly, and
+  /// when splitting it, the result cannot forms the valid blocks. So we can
+  /// only skip the dest block. The largest size of the dest block satisfies the
+  /// above cases are of the size of 'kReservationPerArena'.
+  static constexpr int64_t kReservationPerArena =
+      sizeof(Header) + 2 * HashStringAllocator::kMinAlloc + kMinBlockSize;
+
+ public:
+  explicit AllocationCompactor(AllocationRange allocationRange);
+
+  int64_t size() const {
+    return range_.size();
+  }
+
+  /// Lower bound of size that can be used for accommodating data within this
+  /// allocation and data from reclaimable allocation.
+  int64_t usableSize() const {
+    return size() - simd::kPadding - kReservationPerArena;
+  }
+
+  int64_t nonFreeBlockSize() const {
+    return nonFreeBlockSize_;
+  }
+
+  void setReclaimable() {
+    reclaimable_ = true;
+  }
+
+  bool isReclaimable() const {
+    return reclaimable_;
+  }
+
+  // 'multipartMap' is the mapping from the header of succeeding block to the
+  // header of preceeding block of all the multipart blocks. This method adds
+  // the multipart mapping of this allocation to 'multipartMap'.
+  void accumulateMultipartMap(HeaderMap& multipartMap) const;
+
+  // For each arena within this allocation, shift the non-free blocks towards
+  // the beginning of the arena, make the arena a sequence of non-free blocks
+  // followed by one free block(If there is free space left). Update
+  // 'multipartMap' and 'movedBlocks' during the squeezing. Returns a vector
+  // of header of free blocks, for an allocation with N arenas, at most N
+  // headers are returned.
+  std::vector<Header*> squeeze(HeaderMap& multipartMap, HeaderMap& movedBlocks);
+
+  // Get next free/non-free block starting from 'header'. If 'header' is
+  // nullptr, returns the first free/non-free block in the allocation. Returns
+  // nullptr if there is no such block.
+  Header* nextBlock(bool isFree, Header* header = nullptr) const;
+
+  struct MoveResult {
+    int64_t srcMovedSize;
+    Header** prevContPtr;
+    // nullptr if no remaining or discarded.
+    Header* remainingDestBlock;
+    int64_t destDiscardedSize;
+  };
+
+  // Move non-free block 'srcBlock' to free block 'destBlock'. If 'destBlock'
+  // cannot accommodate the whole 'srcBlock', it might split the 'srcBlock' to
+  // make part of it fit into 'destBlock', or fail the moving. If 'srcOffset'
+  // is not 0, moves part of 'srcBlock' [srcOffset, srcBlockSize). In this
+  // case, the previous part of 'srcBlock' should have continued pointer that
+  // points to this part, which is 'prevContPtr'. 'multipartMap' and
+  // 'movedBlocks' are updated during moving.
+  //
+  // Returns:
+  // 1. 'srcMovedSize': Equals to the size of 'srcBlock' is the whole block is
+  // moved. If 'destBlock' cannot accommodate the whole 'srcBlock', 'srcBlock'
+  // might be splitted and 'srcMovedSize' is the size of splitted block that
+  // fits into 'destBlock'. Equals to 0 if this dest block cannot fit any of
+  // src block.
+  // 2. 'prevContPtr': If 'srcBlock' is splitted, 'prevContPtr' is the first
+  // splitted block's continued ptr. The caller is responsible for filling
+  // 'prevContPtr' when the second splitted block gets moved. If no splitting
+  // happened, 'prevContPtr' is nullptr.
+  // 3. 'remainingDestBlock': In case that 'destBlock' still has free space
+  // after accommodating 'srcBlock', a new free block is created and this is
+  // 'remainingDestBlock'.
+  // 4. 'destDiscardedSize': If 'destBlock' is slightly larger or smaller than
+  // 'srcBlock' and 'srcBlock' needs to be splitted so the remaining
+  // 'destBlock' can be valid(not less than kMinAlloc), the 'srcBlock' is
+  // splitted, and 'destBlock' is also splitted, with the later one being of
+  // size kMinAlloc, this block is discarded.
+  static MoveResult moveBlock(
+      Header* srcBlock,
+      int64_t srcOffset,
+      Header** prevContPtr,
+      Header* destBlock,
+      HeaderMap& multipartMap,
+      HeaderMap& movedBlocks);
+
+  // Update 'multipartMap' and 'movedBlocks' when moving block 'from' to block
+  // 'to'.
+  static void updateMap(
+      Header* from,
+      Header* to,
+      HeaderMap& multipartMap,
+      HeaderMap& movedBlocks);
+
+  // Updates maps as potential "next" block in multipart. If 'from' has the
+  // previous block links to it, updates previous block's next continued
+  // pointer to 'to'. otherwise, inserts {'from', 'to'} to 'movedBlocks'.
+  static void updateMapAsNext(
+      Header* from,
+      Header* to,
+      HeaderMap& multipartMap,
+      HeaderMap& movedBlocks);
+
+  static void
+  updateMapAsPrevious(Header* from, Header* to, HeaderMap& multipartMap);
+
+  static void foreachBlock(
+      folly::Range<char*> range,
+      const std::function<void(Header*)>& func);
+
+  void foreachBlock(const std::function<void(Header*)>& func) const {
+    foreachBlock(range_, func);
+  }
+
+ private:
+  Header* squeezeArena(
+      AllocationRange arena,
+      HeaderMap& multipartMap,
+      HeaderMap& movedBlocks);
+
+  AllocationRange range_;
+  bool reclaimable_{false};
+  // Sum of Non-free block size in this allocation(header included).
+  int64_t nonFreeBlockSize_{0};
+};
+
+} // namespace facebook::velox

--- a/velox/common/memory/AllocationPool.h
+++ b/velox/common/memory/AllocationPool.h
@@ -41,6 +41,9 @@ class AllocationPool {
   // only be power of 2.
   char* allocateFixed(uint64_t bytes, int32_t alignment = 1);
 
+  // Frees the indexth range.
+  void freeRangeAt(int32_t index);
+
   // Starts a new run for variable length allocation. The actual size
   // is at least one machine page. Throws std::bad_alloc if no space.
   void newRun(int64_t preferredSize);

--- a/velox/common/memory/CMakeLists.txt
+++ b/velox/common/memory/CMakeLists.txt
@@ -18,9 +18,11 @@ endif()
 add_library(
   velox_memory
   Allocation.cpp
+  AllocationCompactor.cpp
   AllocationPool.cpp
   ByteStream.cpp
   HashStringAllocator.cpp
+  HashStringAllocatorCompactor.cpp
   MallocAllocator.cpp
   Memory.cpp
   MemoryAllocator.cpp

--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -350,6 +350,7 @@ void HashStringAllocator::removeFromFreeList(Header* header) {
 HashStringAllocator::Header* HashStringAllocator::allocate(
     int32_t size,
     bool exactSize) {
+  requestedContiguous_ |= exactSize;
   if (size > kMaxAlloc && exactSize) {
     VELOX_CHECK_LE(size, Header::kSizeMask);
     auto* header =

--- a/velox/common/memory/HashStringAllocatorCompactor.cpp
+++ b/velox/common/memory/HashStringAllocatorCompactor.cpp
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/memory/HashStringAllocatorCompactor.h"
+
+namespace facebook::velox::detail {
+
+struct AllocationState {
+  int64_t size;
+  int64_t nonFreeBlockSize;
+  int32_t allocationIndex;
+
+  // Priority is given to allocations with larger sizes. When allocations have
+  // identical sizes, those with less stored data take precedence.
+  friend bool operator<(
+      const AllocationState& lhs,
+      const AllocationState& rhs) {
+    if (lhs.size == rhs.size) {
+      return lhs.nonFreeBlockSize < rhs.nonFreeBlockSize;
+    }
+    return lhs.size > rhs.size;
+  }
+};
+
+} // namespace facebook::velox::detail
+
+namespace facebook::velox {
+
+using Header = HashStringAllocator::Header;
+
+int64_t HashStringAllocatorCompactor::estimateReclaimableSize() {
+  if (hsa_->requestedContiguous_ && !hsa_->allowSplittingContiguous_) {
+    return 0;
+  }
+
+  // The last allocation is excluded from the compaction since it's currently in
+  // use for serving allocations.
+  const auto allocations{hsa_->pool_.numRanges() - 1};
+  if (allocations == 0) {
+    return 0;
+  }
+  compactors_.clear();
+  compactors_.reserve(allocations);
+
+  std::vector<detail::AllocationState> entries;
+  entries.reserve(allocations);
+
+  int64_t remainingUsableSize{0};
+  int64_t totalNonFreeBlockSize{0};
+  for (auto i = 0; i < allocations; ++i) {
+    compactors_.emplace_back(hsa_->pool_.rangeAt(i));
+    const auto& compactor{compactors_.back()};
+    remainingUsableSize += compactor.usableSize();
+    totalNonFreeBlockSize += compactor.nonFreeBlockSize();
+    entries.push_back(detail::AllocationState{
+        compactor.size(), compactor.nonFreeBlockSize(), i});
+  }
+
+  std::sort(entries.begin(), entries.end());
+
+  int64_t reclaimableSize{0};
+  for (const auto& entry : entries) {
+    auto& compactor{compactors_[entry.allocationIndex]};
+    if (remainingUsableSize - compactor.usableSize() >= totalNonFreeBlockSize) {
+      remainingUsableSize -= compactor.usableSize();
+      compactor.setReclaimable();
+      reclaimableSize += compactor.size();
+    }
+  }
+  return reclaimableSize;
+}
+
+// TODO: Update cumulativeBytes_.
+std::pair<int64_t, AllocationCompactor::HeaderMap>
+HashStringAllocatorCompactor::compact() {
+  // Redo the estimation to ensure 'compactors_' are up-to-date.
+  if (estimateReclaimableSize() == 0) {
+    return {0, {}};
+  }
+
+  for (const auto& compactor : compactors_) {
+    compactor.accumulateMultipartMap(multipartMap_);
+  }
+
+  // Remove all the free blocks in candidate allocations from free list since:
+  // 1. Reclaimable allocations will be freed to AllocationPool;
+  // 2. Unreclaimable allocations's free blocks will be squeezed, at the
+  // end of the compaction the remaining free blocks will be added back to
+  // free list.
+  clearFreeList();
+  // Check free list has only block in the last allocation, which was excluded
+  // from compaction.
+  checkFreeListInCurrentRange();
+
+  // Compact unreclaimable allocations and collect free blocks.
+  std::queue<Header*> destBlocks;
+  for (auto& compactor : compactors_) {
+    // Squeeze unreclaimable allocations, whose remaining free blocks will be
+    // the destination blocks for the compaction.
+    if (compactor.isReclaimable()) {
+      continue;
+    }
+    auto freeBlocks = compactor.squeeze(multipartMap_, movedBlocks_);
+    for (auto* freeBlock : freeBlocks) {
+      destBlocks.push(freeBlock);
+    }
+  }
+
+  const auto compactedSize =
+      moveBlocksInReclaimableAllocations(std::move(destBlocks));
+
+  // Add free blocks in the unreclaimable allocations to free list after moving
+  // the blocks.
+  addFreeBlocksToFreeList();
+
+  // Free empty allocations.
+  for (int32_t i = compactors_.size() - 1; i >= 0; --i) {
+    if (compactors_[i].isReclaimable()) {
+      LOG(INFO) << "Freeing allocation " << i << " with size of "
+                << compactors_[i].size();
+      hsa_->pool_.freeRangeAt(i);
+    }
+  }
+  compactors_.clear();
+  multipartMap_.clear();
+
+  hsa_->checkConsistency();
+  return {compactedSize, std::move(movedBlocks_)};
+};
+
+// Remove all the free blocks in candidate allocations from free list.
+void HashStringAllocatorCompactor::clearFreeList() {
+  for (auto& compactor : compactors_) {
+    compactor.foreachBlock([&](Header* header) {
+      if (header->isFree()) {
+        hsa_->removeFromFreeList(header);
+        header->setFree();
+        --hsa_->numFree_;
+        hsa_->freeBytes_ -= sizeof(Header) + header->size();
+      }
+    });
+  }
+}
+
+size_t HashStringAllocatorCompactor::moveBlocksInReclaimableAllocations(
+    std::queue<Header*> destBlocks) {
+  size_t compactedSize{0};
+  Header* destBlock{nullptr};
+  for (auto& compactor : compactors_) {
+    if (!compactor.isReclaimable()) {
+      continue;
+    }
+    auto srcBlock = compactor.nextBlock(false /* isFree */);
+    int64_t srcOffset{0};
+    Header** prevContPtr{nullptr};
+    while (srcBlock != nullptr) {
+      if (destBlock == nullptr) {
+        VELOX_CHECK(!destBlocks.empty());
+        destBlock = destBlocks.front();
+        destBlocks.pop();
+      }
+
+      VELOX_CHECK_EQ((srcOffset == 0), (prevContPtr == nullptr));
+      auto moveResult = AllocationCompactor::moveBlock(
+          srcBlock,
+          srcOffset,
+          prevContPtr,
+          destBlock,
+          multipartMap_,
+          movedBlocks_);
+      srcOffset += moveResult.srcMovedSize;
+      if (moveResult.prevContPtr != nullptr) {
+        VELOX_CHECK_GT(moveResult.srcMovedSize, 0);
+        VELOX_CHECK_LT(srcOffset, srcBlock->size());
+        prevContPtr = moveResult.prevContPtr;
+      }
+      if (srcOffset == srcBlock->size()) {
+        srcBlock = compactor.nextBlock(false, srcBlock);
+        srcOffset = 0;
+        prevContPtr = nullptr;
+      }
+      destBlock = moveResult.remainingDestBlock;
+    }
+    compactedSize += compactor.size();
+  }
+  return compactedSize;
+}
+
+void HashStringAllocatorCompactor::checkFreeListInCurrentRange() const {
+  for (auto i = 0; i < HashStringAllocator::kNumFreeLists; ++i) {
+    auto* item = hsa_->free_[i].next();
+    while (item != &hsa_->free_[i]) {
+      auto header = HashStringAllocator::headerOf(item);
+      VELOX_CHECK(hsa_->pool_.isInCurrentRange(header));
+      item = item->next();
+    }
+  }
+}
+
+void HashStringAllocatorCompactor::addFreeBlocksToFreeList() {
+  for (auto& compactor : compactors_) {
+    if (compactor.isReclaimable()) {
+      continue;
+    }
+    compactor.foreachBlock([&](Header* header) {
+      if (!header->isFree()) {
+        return;
+      }
+      header->clearFree();
+      hsa_->free(header);
+    });
+  }
+}
+
+} // namespace facebook::velox

--- a/velox/common/memory/HashStringAllocatorCompactor.h
+++ b/velox/common/memory/HashStringAllocatorCompactor.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/common/memory/AllocationCompactor.h"
+
+namespace facebook::velox {
+
+class HashStringAllocatorCompactor {
+ public:
+  explicit HashStringAllocatorCompactor(HashStringAllocator* hsa)
+      : hsa_(hsa), pool_(&hsa->allocationPool()) {
+    VELOX_CHECK_NOT_NULL(hsa_);
+  }
+
+  /// Estimates reclaimale memory size by identifying reclaimable allocations.
+  /// Builds 'compactors_' for each allocation except the last one. Returns 0 if
+  /// no allocation is reclaimable or if contiguous memory has been explicitly
+  /// requested to 'hsa_' and its 'allowSplittingContiguous_' is false.
+  int64_t estimateReclaimableSize();
+
+  /// Compacts owned memory by squeezing unreclaimable allocations and
+  /// relocating data from reclaimable allocations to unreclaimable allocations.
+  /// Reclaimable allocations are then freed to AllocationPool. Returns the
+  /// bytes freed and the mapping from original pointer of the moved blocks'
+  /// header to their new pointer.
+  std::pair<int64_t, AllocationCompactor::HeaderMap> compact();
+
+ private:
+  void clearFreeList();
+
+  size_t moveBlocksInReclaimableAllocations(
+      std::queue<HashStringAllocator::Header*> destBlocks);
+
+  void checkFreeListInCurrentRange() const;
+
+  void addFreeBlocksToFreeList();
+
+ private:
+  HashStringAllocator* hsa_;
+  const memory::AllocationPool* pool_;
+  std::vector<AllocationCompactor> compactors_;
+  AllocationCompactor::HeaderMap movedBlocks_;
+  // Maps from the header of succeeding block to the header of preceeding block
+  // of all the multipart blocks.
+  AllocationCompactor::HeaderMap multipartMap_;
+};
+
+} // namespace facebook::velox

--- a/velox/examples/CMakeLists.txt
+++ b/velox/examples/CMakeLists.txt
@@ -62,3 +62,6 @@ target_link_libraries(
   velox_exec_test_lib
   velox_memory
   velox_vector_test_lib)
+
+add_executable(velox_example_hsa_compaction HashStringAllocatorCompaction.cpp)
+target_link_libraries(velox_example_hsa_compaction velox_memory)

--- a/velox/examples/HashStringAllocatorCompaction.cpp
+++ b/velox/examples/HashStringAllocatorCompaction.cpp
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// Example program to demonstrate the usage of 'HashStringAllocatorCompactor'.
+/// The program firstly fills random generated blocks into memory allocated via
+/// HSA, then removes some of them to make room for compaction, then uses
+/// HashStringAllocatorCompactor to compact the memory. After the compaction,
+/// verify if all the filled data is still valid.
+/// NOTE: This program is not intended to be merged into main.
+#include <algorithm>
+#include <chrono>
+#include <random>
+
+#include "velox/common/memory/HashStringAllocatorCompactor.h"
+
+using namespace facebook::velox;
+
+using Header = HashStringAllocator::Header;
+
+folly::Random::DefaultGenerator rng;
+std::random_device rd;
+
+/// Generates at least 'bytes' random data with size in range [16,3072] and
+/// fills into block allocated from 'hsa'. Stores the header of the block and
+/// random data pair into corresponding element in 'payloads', indexed by the
+/// allocation id that the block belongs to. Accumulates the data size of each
+/// allocation in 'allocationsDataSize'.
+void fillAllocation(
+    HashStringAllocator* hsa,
+    int64_t bytes,
+    std::vector<std::vector<std::pair<Header*, std::string>>>& payloads,
+    std::vector<size_t>& allocationsDataSize);
+
+/// Frees at least 'bytesToFree' of data in allocation 'allocation_data' from
+/// 'hsa'. Removes corresponding pairs in 'allocation_data'.
+int64_t freeDataAtAllocation(
+    HashStringAllocator* hsa,
+    size_t bytesToFree,
+    std::vector<std::pair<Header*, std::string>>& allocation_data);
+
+/// Verifies if all the payload in 'payloads' match the content stored in the
+/// block that their header point to. If 'movedBlocks' doesn't contain the
+/// header, than the block was not moved, otherwise, it's moved during
+/// compaction and should use the corresponding value in the map as the new
+/// header to do the verification.
+void verifyPayload(
+    const std::vector<std::vector<std::pair<Header*, std::string>>>& payloads,
+    folly::F14FastMap<Header*, Header*>& movedBlocks);
+
+std::string randomString(int32_t size = 0);
+
+int main(int argc, char* argv[]) {
+  if (argc != 2) {
+    LOG(ERROR)
+        << "Usage: " << argv[0] << " [data size to fill in MB].\nFor example, '"
+        << argv[0]
+        << " 4096' will fill 4GB of data, then free some and try compaction.";
+    return 1;
+  }
+  const size_t payloadSize = (1LL << 20) * std::atoi(argv[1]);
+
+  // TODO: use velox_check
+  memory::MemoryManager::initialize({});
+  auto rootPool = memory::memoryManager()->addRootPool(
+      "", memory::kMaxMemory, memory::MemoryReclaimer::create());
+  auto pool =
+      rootPool->addLeafChild("", false, memory::MemoryReclaimer::create());
+
+  auto hsa = std::make_unique<HashStringAllocator>(pool.get());
+  rng.seed(1);
+
+  // Stores all the data(Header and payload) created in HSA indexed by
+  // allocation index.
+  std::vector<std::vector<std::pair<Header*, std::string>>> payloads;
+  // Total data size (header size + payload size) of each allocation.
+  std::vector<size_t> allocationsDataSize;
+
+  // Fills at least 'payloadSize' bytes of random generated data into memory
+  // allocated via HSA.
+  LOG(INFO) << "Filling not less than " << payloadSize << " bytes of data...";
+  fillAllocation(hsa.get(), payloadSize, payloads, allocationsDataSize);
+  if (allocationsDataSize.size() <= 1) {
+    LOG(ERROR)
+        << "HashStringAllocator only allocated 1 allocation, cannot be compacted.";
+    return 0;
+  }
+  LOG(INFO) << "Allocated " << payloads.size() << " allocations.";
+
+  LOG(INFO) << "Randomly free data...";
+  size_t totalFreed{0};
+  for (size_t i = 0; i < allocationsDataSize.size() - 1; ++i) {
+    const auto freeRatio = folly::Random::randDouble01(rng);
+    const auto freed = freeDataAtAllocation(
+        hsa.get(), allocationsDataSize[i] * freeRatio, payloads[i]);
+    LOG(INFO) << "Allocation " << i << ": Freed " << freed << " out of "
+              << allocationsDataSize[i] << " bytes (" << freeRatio * 100
+              << "%).";
+    totalFreed += freed;
+  }
+  LOG(INFO) << "Freed " << totalFreed << " bytes in total.";
+
+  LOG(INFO) << "Memory usage before compaction:\n"
+            << pool->treeMemoryUsage(true);
+
+  HashStringAllocatorCompactor compactor(hsa.get());
+  hsa->allowSplittingContiguous();
+  const auto estimatedReclaimable = compactor.estimateReclaimableSize();
+  LOG(INFO) << "Estimated reclaimable data size:" << estimatedReclaimable;
+
+  LOG(INFO) << "Starting compaction...";
+  const auto startTime = std::chrono::steady_clock::now();
+  auto [bytesFreed, updatedBlocks] = compactor.compact();
+  VELOX_CHECK_EQ(bytesFreed, estimatedReclaimable);
+  const auto elapsed = std::chrono::steady_clock::now() - startTime;
+  // TODO: Make elapsed millisecond.
+  LOG(INFO) << "Compaction done, elapsed time: "
+            << std::chrono::duration_cast<
+                   std::chrono::duration<double, std::ratio<1, 1000>>>(elapsed)
+                   .count()
+            << " milliseconds.";
+
+  LOG(INFO) << "Starting to verify payload...";
+  verifyPayload(payloads, updatedBlocks);
+  VELOX_CHECK_EQ(compactor.estimateReclaimableSize(), 0);
+  LOG(INFO) << "Verification done.";
+
+  LOG(INFO) << "Memory usage after compaction:\n"
+            << pool->treeMemoryUsage(true);
+
+  return 0;
+}
+
+void fillAllocation(
+    HashStringAllocator* hsa,
+    int64_t bytes,
+    std::vector<std::vector<std::pair<Header*, std::string>>>& payloads,
+    std::vector<size_t>& allocationsDataSize) {
+  std::vector<Header*> headers;
+
+  int64_t bytesAllocated{0};
+  while (bytesAllocated < bytes) {
+    const auto size = 16 +
+        (folly::Random::rand32(rng) % (HashStringAllocator::kMaxAlloc - 16));
+    auto header = hsa->allocate(size);
+    VELOX_CHECK(!header->isFree());
+    VELOX_CHECK(!header->isContinued());
+    bytesAllocated += header->size();
+    headers.push_back(header);
+  }
+
+  auto& pool = hsa->allocationPool();
+  const auto allocations = pool.numRanges();
+  std::map<char*, int32_t> rangeStartToAllocId;
+  for (int32_t i = 0; i < allocations; ++i) {
+    rangeStartToAllocId[pool.rangeAt(i).data()] = i;
+  }
+
+  payloads.clear();
+  payloads.resize(allocations);
+  allocationsDataSize.resize(allocations, 0);
+  for (const auto header : headers) {
+    auto it = rangeStartToAllocId.upper_bound(reinterpret_cast<char*>(header));
+    --it;
+    const auto allocationId{it->second};
+
+    auto payload = randomString(header->size());
+    memcpy(header->begin(), payload.data(), header->size());
+    payloads[allocationId].emplace_back(header, std::move(payload));
+
+    allocationsDataSize[allocationId] += header->size() + sizeof(Header);
+  }
+}
+
+int64_t freeDataAtAllocation(
+    HashStringAllocator* hsa,
+    size_t bytesToFree,
+    std::vector<std::pair<Header*, std::string>>& allocation_data) {
+  std::shuffle(
+      allocation_data.begin(), allocation_data.end(), std::mt19937(rd()));
+
+  int64_t freedBytes{0};
+  while (freedBytes < bytesToFree) {
+    if (allocation_data.empty()) {
+      break;
+    }
+    auto& [header, payload] = allocation_data.back();
+    freedBytes += header->size() + sizeof(Header);
+    hsa->free(header);
+    allocation_data.pop_back();
+  }
+  return freedBytes;
+}
+
+// Verify all the content that's not been freed are still valid. Takes an map
+// of moved blocks' header, which is the product of HSA::compact.
+void verifyPayload(
+    const std::vector<std::vector<std::pair<Header*, std::string>>>& payloads,
+    folly::F14FastMap<Header*, Header*>& movedBlocks) {
+  for (const auto& allocationData : payloads) {
+    for (const auto& [header, str] : allocationData) {
+      if (str.empty()) {
+        continue;
+      }
+      auto currentHeader = header;
+      int32_t offset{0};
+      if (movedBlocks.contains(currentHeader)) {
+        currentHeader = movedBlocks[header];
+      }
+      while (true) {
+        VELOX_CHECK(!currentHeader->isFree());
+        const auto sizeToCompare =
+            std::min<int32_t>(currentHeader->usableSize(), str.size() - offset);
+        VELOX_CHECK_GT(sizeToCompare, 0);
+        VELOX_CHECK(!memcmp(
+            currentHeader->begin(), str.data() + offset, sizeToCompare));
+        offset += sizeToCompare;
+        if (offset == str.size()) {
+          break;
+        }
+        VELOX_CHECK(currentHeader->isContinued());
+        currentHeader = currentHeader->nextContinued();
+      }
+    }
+  }
+}
+
+// Stolen from HashStringAllocatorTest.cpp
+std::string randomString(int32_t size) {
+  std::string result;
+  result.resize(
+      size != 0 ? size
+                : 20 +
+              (folly::Random::rand32(rng) % 10 > 8
+                   ? folly::Random::rand32(rng) % 200
+                   : 1000 + folly::Random::rand32(rng) % 1000));
+  for (auto i = 0; i < result.size(); ++i) {
+    result[i] = 32 + (folly::Random::rand32(rng) % 96);
+  }
+  return result;
+}


### PR DESCRIPTION
This PR is the prototype to add compaction support to `HashStringAllocator` as part of #7534:

- Add `HashStringAllocatorCompactor` / `AllocationCompactor` to do the compaction against `HashStringAllocator`.
- Add `freeRangeAt()` to `AllocationPool` to free an `Allocation`.
- Update `HashStringAllocator` to disable compaction if was requested contiguous memory explicitly.
- Add `HashStringAllocatorCompaction` example to demonstrate the usage of `HashStringAllocatorCompactor`.

Idealy this should be splitted into multiple sub-PR to be merged.