### PR TITLE
Bound the size of Expr's sharedSubexprResults_ to prevent OOMs

### DIFF
--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -118,6 +118,12 @@ Generic Configuration
      - true
      - Whether to enable caches in expression evaluation. If set to true, optimizations including vector pools and
        evalWithMemo are enabled.
+   * - max_shared_subexpr_results_cached
+     - integer
+     - 10
+     - For a given shared subexpression, the maximum distinct sets of inputs we cache results for. Lambdas can call
+       the same expression with different inputs many times, causing the results we cache to explode in size. Putting
+       a limit contains the memory usage.
    * - driver_cpu_time_slice_limit_ms
      - integer
      - 0

--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -17,6 +17,7 @@
 #include "velox/expression/EvalCtx.h"
 #include <exception>
 #include "velox/common/testutil/TestValue.h"
+#include "velox/core/QueryConfig.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/PeeledEncoding.h"
 
@@ -28,7 +29,13 @@ EvalCtx::EvalCtx(core::ExecCtx* execCtx, ExprSet* exprSet, const RowVector* row)
     : execCtx_(execCtx),
       exprSet_(exprSet),
       row_(row),
-      cacheEnabled_(execCtx->exprEvalCacheEnabled()) {
+      cacheEnabled_(execCtx->exprEvalCacheEnabled()),
+      maxSharedSubexprResultsCached_(
+          execCtx->queryCtx()
+              ? execCtx->queryCtx()
+                    ->queryConfig()
+                    .maxSharedSubexprResultsCached()
+              : core::QueryConfig({}).maxSharedSubexprResultsCached()) {
   // TODO Change the API to replace raw pointers with non-const references.
   // Sanity check inputs to prevent crashes.
   VELOX_CHECK_NOT_NULL(execCtx);
@@ -49,7 +56,13 @@ EvalCtx::EvalCtx(core::ExecCtx* execCtx)
     : execCtx_(execCtx),
       exprSet_(nullptr),
       row_(nullptr),
-      cacheEnabled_(execCtx->exprEvalCacheEnabled()) {
+      cacheEnabled_(execCtx->exprEvalCacheEnabled()),
+      maxSharedSubexprResultsCached_(
+          execCtx->queryCtx()
+              ? execCtx->queryCtx()
+                    ->queryConfig()
+                    .maxSharedSubexprResultsCached()
+              : core::QueryConfig({}).maxSharedSubexprResultsCached()) {
   VELOX_CHECK_NOT_NULL(execCtx);
 }
 

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -327,11 +327,18 @@ class EvalCtx {
     return cacheEnabled_;
   }
 
+  /// Returns the maximum number of distinct inputs to cache results for in a
+  /// given shared subexpression.
+  uint32_t maxSharedSubexprResultsCached() const {
+    return maxSharedSubexprResultsCached_;
+  }
+
  private:
   core::ExecCtx* const FOLLY_NONNULL execCtx_;
   ExprSet* FOLLY_NULLABLE const exprSet_;
   const RowVector* FOLLY_NULLABLE row_;
   const bool cacheEnabled_;
+  const uint32_t maxSharedSubexprResultsCached_;
   bool inputFlatNoNulls_;
 
   // Corresponds 1:1 to children of 'row_'. Set to an inner vector


### PR DESCRIPTION
Summary:
We recently discovered cases where lambdas with shared subexpressions can cause the size of sharedSubexprResults_ to 
explode by getting invoked with different inputs on each iteration within a batch.  See 
https://github.com/facebookincubator/velox/issues/8093 for a more thorough description.

To avoid this case, we bound the size of sharedSubexprResults_.

I set the default limit to 10 as this seems like a reasonable limit that should work in almost all cases (see the explanation in 
the code comments).  However, it's always possible to imagine cases where this limit wouldn't be high enough, so I made it
configurable.  Note that the only negative effect of having too low a limit would be unnecessarily re-evaluating some shared 
expression trees.

Differential Revision: D52335277


