### PR TITLE
Make ScopedTestTime compile outside of debug mode

### DIFF
--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -23,6 +23,7 @@
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/common/memory/MmapAllocator.h"
+#include "velox/common/testutil/ScopedTestTime.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 

--- a/velox/common/testutil/CMakeLists.txt
+++ b/velox/common/testutil/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_test_util TestValue.cpp)
+add_library(velox_test_util ScopedTestTime.cpp TestValue.cpp)
 target_link_libraries(velox_test_util PUBLIC velox_exception)
 
 if(${VELOX_BUILD_TESTING})

--- a/velox/common/testutil/ScopedTestTime.cpp
+++ b/velox/common/testutil/ScopedTestTime.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/testutil/ScopedTestTime.h"
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::common::testutil {
+bool ScopedTestTime::enabled_ = false;
+std::optional<size_t> ScopedTestTime::testTimeUs_ = {};
+
+ScopedTestTime::ScopedTestTime() {
+#ifndef NDEBUG
+  VELOX_CHECK(!enabled_, "Only one ScopedTestTime can be active at a time");
+  enabled_ = true;
+#else
+  VELOX_UNREACHABLE("ScopedTestTime should only be used in debug mode");
+#endif
+}
+
+ScopedTestTime::~ScopedTestTime() {
+  testTimeUs_.reset();
+  enabled_ = false;
+}
+
+void ScopedTestTime::setCurrentTestTimeSec(size_t currentTimeSec) {
+  setCurrentTestTimeMicro(currentTimeSec * 1000000);
+}
+
+void ScopedTestTime::setCurrentTestTimeMs(size_t currentTimeMs) {
+  setCurrentTestTimeMicro(currentTimeMs * 1000);
+}
+
+void ScopedTestTime::setCurrentTestTimeMicro(size_t currentTimeUs) {
+  testTimeUs_ = currentTimeUs;
+}
+
+std::optional<size_t> ScopedTestTime::getCurrentTestTimeSec() {
+  return testTimeUs_.has_value() ? std::make_optional(*testTimeUs_ / 1000000L)
+                                 : testTimeUs_;
+}
+std::optional<size_t> ScopedTestTime::getCurrentTestTimeMs() {
+  return testTimeUs_.has_value() ? std::make_optional(*testTimeUs_ / 1000L)
+                                 : testTimeUs_;
+}
+
+std::optional<size_t> ScopedTestTime::getCurrentTestTimeMicro() {
+  return testTimeUs_;
+}
+} // namespace facebook::velox::common::testutil

--- a/velox/common/testutil/ScopedTestTime.h
+++ b/velox/common/testutil/ScopedTestTime.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <optional>
+
+namespace facebook::velox::common::testutil {
+// Used to override the current time for testing purposes.
+class ScopedTestTime {
+ public:
+  ScopedTestTime();
+  ~ScopedTestTime();
+
+  void setCurrentTestTimeSec(size_t currentTimeSec);
+  void setCurrentTestTimeMs(size_t currentTimeMs);
+  void setCurrentTestTimeMicro(size_t currentTimeUs);
+
+  static std::optional<size_t> getCurrentTestTimeSec();
+  static std::optional<size_t> getCurrentTestTimeMs();
+  static std::optional<size_t> getCurrentTestTimeMicro();
+
+ private:
+  // Used to verify only one instance of ScopedTestTime exists at a time.
+  static bool enabled_;
+  // The overridden value of current time only.
+  static std::optional<size_t> testTimeUs_;
+};
+} // namespace facebook::velox::common::testutil

--- a/velox/common/testutil/tests/CMakeLists.txt
+++ b/velox/common/testutil/tests/CMakeLists.txt
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 include(GoogleTest)
-add_executable(velox_test_util_test TestValueTest.cpp)
+add_executable(velox_test_util_test TestScopedTestTime.cpp TestValueTest.cpp)
 gtest_add_tests(velox_test_util_test "" AUTO)
 
 target_link_libraries(
-  velox_test_util_test PRIVATE velox_test_util velox_exception velox_exec gtest
-                               gtest_main)
+  velox_test_util_test PRIVATE velox_test_util velox_exception velox_exec
+                               velox_time gtest gtest_main)

--- a/velox/common/testutil/tests/TestScopedTestTime.cpp
+++ b/velox/common/testutil/tests/TestScopedTestTime.cpp
@@ -18,15 +18,16 @@
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/testutil/ScopedTestTime.h"
 #include "velox/common/time/Timer.h"
 
 namespace {
 
 using namespace facebook::velox;
+using namespace facebook::velox::common::testutil;
 
-// NOTE: we can only build TestScopedTestTimer on debug build.
-#ifndef NDEBUG
-TEST(TestScopedTestTimer, testSetCurrentTimeMs) {
+// NOTE: we can only construct ScopedTestTime in debug builds.
+DEBUG_ONLY_TEST(TestScopedTestTime, testSetCurrentTimeMs) {
   {
     ScopedTestTime scopedTestTime;
     scopedTestTime.setCurrentTestTimeMs(1);
@@ -43,7 +44,7 @@ TEST(TestScopedTestTimer, testSetCurrentTimeMs) {
   ASSERT_NE(getCurrentTimeMicro(), 2000);
 }
 
-TEST(TestScopedTestTimer, testSetCurrentTimeMicro) {
+DEBUG_ONLY_TEST(TestScopedTestTime, testSetCurrentTimeMicro) {
   {
     ScopedTestTime scopedTestTime;
     scopedTestTime.setCurrentTestTimeMicro(1000);
@@ -60,7 +61,7 @@ TEST(TestScopedTestTimer, testSetCurrentTimeMicro) {
   ASSERT_NE(getCurrentTimeMicro(), 2000);
 }
 
-TEST(TestScopedTestTimer, multipleScopedTestTimes) {
+DEBUG_ONLY_TEST(TestScopedTestTime, multipleScopedTestTimes) {
   {
     ScopedTestTime scopedTestTime;
     scopedTestTime.setCurrentTestTimeMs(1);
@@ -86,5 +87,4 @@ TEST(TestScopedTestTimer, multipleScopedTestTimes) {
         "Only one ScopedTestTime can be active at a time");
   }
 }
-#endif
 } // namespace

--- a/velox/common/time/CMakeLists.txt
+++ b/velox/common/time/CMakeLists.txt
@@ -16,4 +16,5 @@ if(${VELOX_BUILD_TESTING})
 endif()
 
 add_library(velox_time Timer.cpp CpuWallTimer.cpp)
-target_link_libraries(velox_time PUBLIC velox_process Folly::folly fmt::fmt)
+target_link_libraries(velox_time PUBLIC velox_process velox_test_util
+                                        Folly::folly fmt::fmt)

--- a/velox/common/time/Timer.cpp
+++ b/velox/common/time/Timer.cpp
@@ -16,49 +16,14 @@
 
 #include "velox/common/time/Timer.h"
 
-#include "velox/common/base/Exceptions.h"
+#include "velox/common/testutil/ScopedTestTime.h"
 
 namespace facebook::velox {
 
 using namespace std::chrono;
+using common::testutil::ScopedTestTime;
 
 #ifndef NDEBUG
-bool ScopedTestTime::enabled_ = false;
-std::optional<size_t> ScopedTestTime::testTimeUs_ = {};
-
-ScopedTestTime::ScopedTestTime() {
-  VELOX_CHECK(!enabled_, "Only one ScopedTestTime can be active at a time");
-  enabled_ = true;
-}
-
-ScopedTestTime::~ScopedTestTime() {
-  testTimeUs_.reset();
-  enabled_ = false;
-}
-
-void ScopedTestTime::setCurrentTestTimeSec(size_t currentTimeSec) {
-  setCurrentTestTimeMicro(currentTimeSec * 1000000);
-}
-
-void ScopedTestTime::setCurrentTestTimeMs(size_t currentTimeMs) {
-  setCurrentTestTimeMicro(currentTimeMs * 1000);
-}
-
-void ScopedTestTime::setCurrentTestTimeMicro(size_t currentTimeUs) {
-  testTimeUs_ = currentTimeUs;
-}
-
-std::optional<size_t> ScopedTestTime::getCurrentTestTimeSec() {
-  return testTimeUs_.has_value() ? std::make_optional(*testTimeUs_ / 1000000L)
-                                 : testTimeUs_;
-}
-std::optional<size_t> ScopedTestTime::getCurrentTestTimeMs() {
-  return testTimeUs_.has_value() ? std::make_optional(*testTimeUs_ / 1000L)
-                                 : testTimeUs_;
-}
-std::optional<size_t> ScopedTestTime::getCurrentTestTimeMicro() {
-  return testTimeUs_;
-}
 
 size_t getCurrentTimeSec() {
   return ScopedTestTime::getCurrentTestTimeSec().value_or(

--- a/velox/common/time/Timer.h
+++ b/velox/common/time/Timer.h
@@ -79,27 +79,4 @@ size_t getCurrentTimeMs();
 /// Returns the current epoch time in microseconds.
 size_t getCurrentTimeMicro();
 
-#ifndef NDEBUG
-// Used to override the current time for testing purposes.
-class ScopedTestTime {
- public:
-  ScopedTestTime();
-  ~ScopedTestTime();
-
-  void setCurrentTestTimeSec(size_t currentTimeSec);
-  void setCurrentTestTimeMs(size_t currentTimeMs);
-  void setCurrentTestTimeMicro(size_t currentTimeUs);
-
-  static std::optional<size_t> getCurrentTestTimeSec();
-  static std::optional<size_t> getCurrentTestTimeMs();
-  static std::optional<size_t> getCurrentTestTimeMicro();
-
- private:
-  // Used to verify only one instance of ScopedTestTime exists at a time.
-  static bool enabled_;
-  // The overridden value of current time only.
-  static std::optional<size_t> testTimeUs_;
-};
-#endif
-
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:
Wrapping the entire ScopedTestTime class definition in a #ifndef NDEBUG macro makes it so that tests using it don't build
outside of debug mode.

The intent was that ScopedTestTime shouldn't be used outside of debug mode.  Since the implementations of 
getCurrentTime that use the class are already wrapped with the macro to protect production, we can achieve the same intent
by throwing an exception if the class is constructed outside of debug mode. This way, the test still compiles outside of debug
mode.

Differential Revision: D52340499


