### PR TITLE
Refactor type parsing grammar to allow tokens as field names

### DIFF
--- a/velox/type/parser/TypeParser.ll
+++ b/velox/type/parser/TypeParser.ll
@@ -36,7 +36,6 @@ Z   [Z|z]
 WORD              ([[:alpha:][:alnum:]_]*)
 QUOTED_ID         (['"'][[:alnum:][:space:]_]*['"'])
 NUMBER            ([[:digit:]]+)
-ROW               (ROW|STRUCT)
 VARIABLE          (VARCHAR|VARBINARY)
 
 %%
@@ -48,7 +47,7 @@ VARIABLE          (VARCHAR|VARBINARY)
 (MAP)              return Parser::token::MAP;
 (FUNCTION)         return Parser::token::FUNCTION;
 (DECIMAL)          return Parser::token::DECIMAL;
-{ROW}              return Parser::token::ROW;
+(ROW)              return Parser::token::ROW;
 {VARIABLE}         yylval->build<std::string>(YYText()); return Parser::token::VARIABLE;
 {NUMBER}           yylval->build<long long>(folly::to<int>(YYText())); return Parser::token::NUMBER;
 {WORD}             yylval->build<std::string>(YYText()); return Parser::token::WORD;

--- a/velox/type/parser/TypeParser.yy
+++ b/velox/type/parser/TypeParser.yy
@@ -38,42 +38,61 @@
 %token <long long>   NUMBER
 %token YYEOF         0
 
-%nterm <std::shared_ptr<const Type>> type special_type function_type decimal_type row_type array_type map_type variable_type
+%nterm <std::shared_ptr<const Type>> type type_single_word 
+%nterm <std::shared_ptr<const Type>> special_type function_type decimal_type row_type array_type map_type variable_type
 %nterm <RowArguments> type_list_opt_names
 %nterm <std::vector<std::shared_ptr<const Type>>> type_list
 %nterm <std::pair<std::string, std::shared_ptr<const Type>>> named_type
 %nterm <std::vector<std::string>> type_with_spaces
+%nterm <std::string> field_name
+
+%start type_spec
 
 %%
 
-type_spec : named_type           { scanner->setType($1.second); }
-          | type                 { scanner->setType($1); }
+/* The grammar entry point. */
+type_spec : type                 { scanner->setType($1); }
           | error                { yyerrok; }
           ;
 
-named_type : QUOTED_ID type             { $1.erase(0, 1); $1.pop_back(); $$ = std::make_pair($1, $2); }  // Remove the quotes.
-           | QUOTED_ID type_with_spaces { $1.erase(0, 1); $1.pop_back(); auto type = inferTypeWithSpaces($2, true); $$ = std::make_pair($1, type.second); }  // Remove the quotes.
-           | WORD special_type          { $$ = std::make_pair($1, $2); }
-           | WORD variable_type         { $$ = std::make_pair($1, $2); }
-           | WORD decimal_type          { $$ = std::make_pair($1, $2); }
-           | type_with_spaces           { $$ = inferTypeWithSpaces($1); }
-           ;
+type : type_single_word  { $$ = $1; }
+     | type_with_spaces  { $$ = inferTypeWithSpaces($1, true).second; }
+     ;
 
-special_type : array_type                  { $$ = $1; }
-             | map_type                    { $$ = $1; }
-             | row_type                    { $$ = $1; }
-             | function_type               { $$ = $1; }
-             ;
+type_single_word : WORD         { $$ = typeFromString($1); } // Handles most primitive types (e.g. bigint, etc).
+                 | special_type { $$ = $1; }
 
-type : WORD          { $$ = typeFromString($1); }
-     | special_type  { $$ = $1; }
-     | variable_type { $$ = $1; }
-     | decimal_type  { $$ = $1; }
+special_type : array_type     { $$ = $1; }
+             | map_type       { $$ = $1; }
+             | row_type       { $$ = $1; }
+             | function_type  { $$ = $1; }
+             | variable_type  { $$ = $1; }
+             | decimal_type   { $$ = $1; }
 
-type_with_spaces : type_with_spaces WORD { $1.push_back($2); $$ = std::move($1); }
-                 | WORD WORD             { $$.push_back($1); $$.push_back($2); }
+/* 
+ * Types with spaces have at least two words. They are joined in an 
+ * std::vector here, and resolved by `inferTypeWithSpaces()`. The first
+ * word is special to allow for tokens such as "map", "array", etc, to 
+ * be used as field names. 
+ */
+type_with_spaces : type_with_spaces WORD  { $1.push_back($2); $$ = std::move($1); }
+                 | field_name WORD        { $$.push_back($1); $$.push_back($2); }
                  ;
 
+/* List of allowed field names. */
+field_name : WORD     { $$ = $1; }
+           | ARRAY    { $$ = "array"; }
+           | MAP      { $$ = "map"; }
+           | FUNCTION { $$ = "function"; }
+           | DECIMAL  { $$ = "decimal"; }
+           | ROW      { $$ = "row"; }
+           | VARIABLE { $$ = $1; }
+           ;
+
+/* 
+ * Varchar and varbinary have an optional `(int)`
+ * e.g. both `varchar` and `varchar(4)` are valid.
+ */
 variable_type : VARIABLE LPAREN NUMBER RPAREN  { $$ = typeFromString($1); }
               | VARIABLE                       { $$ = typeFromString($1); }
               ;
@@ -81,34 +100,51 @@ variable_type : VARIABLE LPAREN NUMBER RPAREN  { $$ = typeFromString($1); }
 decimal_type : DECIMAL LPAREN NUMBER COMMA NUMBER RPAREN { $$ = DECIMAL($3, $5); }
              ;
 
-type_list : type                   { $$.push_back($1); }
-          | type_list COMMA type   { $1.push_back($3); $$ = std::move($1); }
-          ;
-
-type_list_opt_names : type_list_opt_names COMMA named_type { $1.names.push_back($3.first); $1.types.push_back($3.second);
-                                                             $$.names = std::move($1.names); $$.types = std::move($1.types); }
-                    | named_type                           { $$.names.push_back($1.first); $$.types.push_back($1.second); }
-                    | type_list_opt_names COMMA type       { $1.names.push_back(""); $1.types.push_back($3);
-                                                             $$.names = std::move($1.names); $$.types = std::move($1.types); }
-                    | type                                 { $$.names.push_back(""); $$.types.push_back($1); }
-                    ;
-
-row_type : ROW LPAREN type_list_opt_names RPAREN  { $$ = ROW(std::move($3.names), std::move($3.types)); }
-         ;
-
-array_type : ARRAY LPAREN type RPAREN             { $$ = ARRAY($3); }
-           | ARRAY LPAREN type_with_spaces RPAREN { $$ = ARRAY(inferTypeWithSpaces($3, true).second); }
+array_type : ARRAY LPAREN type RPAREN { $$ = ARRAY($3); }
            ;
 
-map_type : MAP LPAREN type COMMA type RPAREN                         { $$ = MAP($3, $5); }
-         | MAP LPAREN type COMMA type_with_spaces RPAREN             { $$ = MAP($3, inferTypeWithSpaces($5, true).second); }
-         | MAP LPAREN type_with_spaces COMMA type RPAREN             { $$ = MAP(inferTypeWithSpaces($3, true).second, $5); }
-         | MAP LPAREN type_with_spaces COMMA type_with_spaces RPAREN { $$ = MAP(inferTypeWithSpaces($3, true).second,
-                                                                                inferTypeWithSpaces($5, true).second); }
+map_type : MAP LPAREN type COMMA type RPAREN { $$ = MAP($3, $5); }
          ;
 
 function_type : FUNCTION LPAREN type_list RPAREN { auto returnType = $3.back(); $3.pop_back();
                                                    $$ = FUNCTION(std::move($3), returnType); }
+
+row_type : ROW LPAREN type_list_opt_names RPAREN  { $$ = ROW(std::move($3.names), std::move($3.types)); }
+         ;
+
+/* Consecutive list of types, separated by a comma. */
+type_list : type                   { $$.push_back($1); }
+          | type_list COMMA type   { $1.push_back($3); $$ = std::move($1); }
+          ;
+
+/* 
+ * Consecutive list of types which can optionally have a "name".
+ * Only allowed inside row definitions.
+ */
+type_list_opt_names : type_list_opt_names COMMA named_type   { $1.names.push_back($3.first); 
+                                                               $1.types.push_back($3.second);
+                                                               $$.names = std::move($1.names); 
+                                                               $$.types = std::move($1.types); }
+                    | named_type                             { $$.names.push_back($1.first); $$.types.push_back($1.second); }
+                    ;
+
+/*
+ * Named type is a type definition with an optional name. The name can be 
+ * quoted. Since types with spaces are allowed, there is potential ambiguity
+ * in definitions with multiple words, for example:
+ *
+ * > my type
+ * 
+ * Is "my" the name and "type" the type, or "my type" is the type name? We first
+ * check if there is a type matching all words ("my type"), and if not, check if 
+ * there is a type matching all but the first wor ("type") and assume the first 
+ * ("my") to be the field name. See `inferTypeWithSpaces()`.
+ */
+named_type : type_single_word        { $$ = std::make_pair("", $1); }
+           | field_name special_type { $$ = std::make_pair($1, $2); }
+           | type_with_spaces        { $$ = inferTypeWithSpaces($1, false); }
+           | QUOTED_ID type          { $1.erase(0, 1); $1.pop_back(); $$ = std::make_pair($1, $2); }  // Remove the quotes.
+           ;
 
 %%
 

--- a/velox/type/parser/tests/TypeParserTest.cpp
+++ b/velox/type/parser/tests/TypeParserTest.cpp
@@ -148,7 +148,9 @@ TEST_F(TestTypeSignature, mapType) {
 
 TEST_F(TestTypeSignature, invalidType) {
   VELOX_ASSERT_THROW(
-      parseType("blah()"), "Failed to parse type [blah]. Type not registered.");
+      parseType("blah()"),
+      "Failed to parse type [blah()]. "
+      "syntax error, unexpected LPAREN, expecting WORD");
 
   VELOX_ASSERT_THROW(parseType("array()"), "Failed to parse type [array()]");
 
@@ -159,10 +161,16 @@ TEST_F(TestTypeSignature, invalidType) {
   // Ensure this is not treated as a row type.
   VELOX_ASSERT_THROW(
       parseType("rowxxx(a)"),
-      "Failed to parse type [rowxxx]. Type not registered.");
+      "Failed to parse type [rowxxx(a)]. "
+      "syntax error, unexpected LPAREN, expecting WORD");
 }
 
 TEST_F(TestTypeSignature, rowType) {
+  // Unnamed fields.
+  ASSERT_EQ(
+      *parseType("row(bigint,varchar, real, timestamp with time zone)"),
+      *ROW({BIGINT(), VARCHAR(), REAL(), TIMESTAMP_WITH_TIME_ZONE()}));
+
   ASSERT_EQ(
       *parseType("row(a bigint,b varchar,c real)"),
       *ROW({"a", "b", "c"}, {BIGINT(), VARCHAR(), REAL()}));
@@ -181,6 +189,13 @@ TEST_F(TestTypeSignature, rowType) {
   ASSERT_EQ(
       *parseType("row(\"12 tb\" bigint,b bigint,c bigint)"),
       *ROW({"12 tb", "b", "c"}, {BIGINT(), BIGINT(), BIGINT()}));
+
+  ASSERT_EQ(
+      *parseType("row(\"a\" bigint, \"b\" array(varchar), "
+                 "\"c\" timestamp with time zone)"),
+      *ROW(
+          {"a", "b", "c"},
+          {BIGINT(), ARRAY(VARCHAR()), TIMESTAMP_WITH_TIME_ZONE()}));
 
   ASSERT_EQ(
       *parseType("row(a varchar(10),b row(a bigint))"),
@@ -229,6 +244,11 @@ TEST_F(TestTypeSignature, rowType) {
 
   // Field type canonicalization.
   ASSERT_EQ(*parseType("row(col iNt)"), *ROW({"col"}, {INTEGER()}));
+
+  // Can only have names within rows.
+  VELOX_ASSERT_THROW(
+      parseType("asd bigint"),
+      "Failed to parse type [asd bigint]. Type not registered.");
 }
 
 TEST_F(TestTypeSignature, typesWithSpaces) {
@@ -303,6 +323,33 @@ TEST_F(TestTypeSignature, decimalType) {
       parseType("decimal(20)"), "Failed to parse type [decimal(20)]");
   VELOX_ASSERT_THROW(
       parseType("decimal(, 20)"), "Failed to parse type [decimal(, 20)]");
+}
+
+// Checks that type names can also be field names.
+TEST_F(TestTypeSignature, fieldNames) {
+  ASSERT_EQ(
+      *parseType("row(bigint bigint, map bigint, row bigint, array bigint, "
+                 "decimal bigint, function bigint, struct bigint, "
+                 "varchar map(bigint, tinyint), varbinary array(bigint))"),
+      *ROW(
+          {"bigint",
+           "map",
+           "row",
+           "array",
+           "decimal",
+           "function",
+           "struct",
+           "varchar",
+           "varbinary"},
+          {BIGINT(),
+           BIGINT(),
+           BIGINT(),
+           BIGINT(),
+           BIGINT(),
+           BIGINT(),
+           BIGINT(),
+           MAP(BIGINT(), TINYINT()),
+           ARRAY(BIGINT())}));
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
Refactoring type parsing grammar to simplify it, fix a few bugs (e.g
disallow field names in top level types - check added unit tests), plus adding
support for common tokens like "array", "map", etc to be defined as type field
names.

Differential Revision: D52341881


