### PR TITLE
Draft PR for regexp_replace fuzzer issues

### DIFF
--- a/velox/docs/functions/spark/regexp.rst
+++ b/velox/docs/functions/spark/regexp.rst
@@ -35,7 +35,7 @@ See https://github.com/google/re2/wiki/Syntax for more information.
 
         SELECT rlike('1a 2b 14m', '\d+b'); -- true
 
-.. spark:function:: regex_replace(string, pattern, overwrite) -> varchar
+.. spark:function:: regexp_replace(string, pattern, overwrite) -> varchar
 
     Replaces all substrings in ``string`` that match the regular expression ``pattern`` with the string ``overwrite``. If no match is found, the original string is returned as is.
     There is a limit to the number of unique regexes to be compiled per function call, which is 20.
@@ -50,11 +50,11 @@ See https://github.com/google/re2/wiki/Syntax for more information.
 
     ::
 
-        SELECT regex_replace('Hello, World!', 'l', 'L'); -- 'HeLLo, WorLd!'
-        SELECT regex_replace('300-300', '(\\d+)-(\\d+)', '400'); -- '400'
-        SELECT regex_replace('300-300', '(\\d+)', '400'); -- '400-400'
+        SELECT regexp_replace('Hello, World!', 'l', 'L'); -- 'HeLLo, WorLd!'
+        SELECT regexp_replace('300-300', '(\\d+)-(\\d+)', '400'); -- '400'
+        SELECT regexp_replace('300-300', '(\\d+)', '400'); -- '400-400'
 
-.. spark:function:: regex_replace(string, pattern, overwrite, position) -> varchar
+.. spark:function:: regexp_replace(string, pattern, overwrite, position) -> varchar
     :noindex:
 
     Replaces all substrings in ``string`` that match the regular expression ``pattern`` with the string ``overwrite`` starting from the specified ``position``. If the ``position`` is less than one, the function returns an error. If ``position`` is greater than the length of ``string``, the function returns the original ``string`` without any modifications.
@@ -72,8 +72,8 @@ See https://github.com/google/re2/wiki/Syntax for more information.
 
     ::
 
-        SELECT regex_replace('Hello, World!', 'l', 'L', 6); -- 'Hello, WorLd!'
+        SELECT regexp_replace('Hello, World!', 'l', 'L', 6); -- 'Hello, WorLd!'
 
-        SELECT regex_replace('Hello, World!', 'l', 'L', -5); -- 'Hello, World!'
+        SELECT regexp_replace('Hello, World!', 'l', 'L', -5); -- 'Hello, World!'
 
-        SELECT regex_replace('Hello, World!', 'l', 'L', 100); -- ERROR: Position exceeds string length.
+        SELECT regexp_replace('Hello, World!', 'l', 'L', 100); -- ERROR: Position exceeds string length.

--- a/velox/functions/sparksql/RegexFunctions.cpp
+++ b/velox/functions/sparksql/RegexFunctions.cpp
@@ -46,7 +46,7 @@ void checkForBadPattern(const RE2& re) {
 // error messages.
 //
 // @throws VELOX_USER_FAIL If the pattern is found to use unsupported features.
-// @note  Default functionName is "REGEX_REPLACE" because it uses non-constant
+// @note  Default functionName is "regexp_replace" because it uses non-constant
 // patterns so it cannot be checked with "ensureRegexIsCompatible". No
 // other functions work with non-constant patterns, but they may in the future.
 //
@@ -96,8 +96,8 @@ void ensureRegexIsConstantAndCompatible(
       std::string(pattern.data(), pattern.size()), functionName);
 }
 
-// REGEX_REPLACE(string, pattern, overwrite) → string
-// REGEX_REPLACE(string, pattern, overwrite, position) → string
+// regexp_replace(string, pattern, overwrite) → string
+// regexp_replace(string, pattern, overwrite, position) → string
 //
 // If a string has a substring that matches the given pattern, replace
 // the match in the string wither overwrite and return the string. If
@@ -135,7 +135,7 @@ struct RegexReplaceFunction {
       const arg_type<Varchar>& pattern,
       const arg_type<Varchar>& replace,
       const arg_type<int64_t>& position) {
-    VELOX_USER_CHECK_GE(position, 1, "regex_replace requires a position >= 1");
+    VELOX_USER_CHECK_GE(position, 1, "regexp_replace requires a position >= 1");
 
     re2::RE2* patternRegex = getCachedRegex(pattern.str());
     re2::StringPiece replaceStringPiece = toStringPiece(replace);
@@ -155,7 +155,7 @@ struct RegexReplaceFunction {
       int charLength =
           utf8proc_char_length(inputStringPiece.data() + utf8Position);
       VELOX_USER_CHECK_GT(
-          charLength, 0, "regex_replace encountered invalid UTF-8 character");
+          charLength, 0, "regexp_replace encountered invalid UTF-8 character");
       ++numCodePoints;
       utf8Position += charLength;
     }
@@ -196,9 +196,9 @@ struct RegexReplaceFunction {
     VELOX_USER_CHECK_LT(
         patternCache_.size(),
         kMaxCompiledRegexes,
-        "regex_replace hit the maximum number of unique regexes: {}",
+        "regexp_replace hit the maximum number of unique regexes: {}",
         kMaxCompiledRegexes);
-    checkForCompatiblePattern(pattern, "regex_replace");
+    checkForCompatiblePattern(pattern, "regexp_replace");
     auto patternRegex = std::make_unique<re2::RE2>(pattern);
     auto* rawPatternRegex = patternRegex.get();
     checkForBadPattern(*rawPatternRegex);
@@ -238,14 +238,14 @@ std::shared_ptr<exec::VectorFunction> makeRegexExtract(
 
 void registerRegexReplace(const std::string& prefix) {
   registerFunction<RegexReplaceFunction, Varchar, Varchar, Varchar, Varchar>(
-      {prefix + "REGEX_REPLACE"});
+      {prefix + "regexp_replace"});
   registerFunction<
       RegexReplaceFunction,
       Varchar,
       Varchar,
       Varchar,
       Varchar,
-      int64_t>({prefix + "REGEX_REPLACE"});
+      int64_t>({prefix + "regexp_replace"});
 }
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/RegexFunctions.cpp
+++ b/velox/functions/sparksql/RegexFunctions.cpp
@@ -47,15 +47,6 @@ void checkForBadPattern(const RE2& re) {
 // error messages.
 //
 // @throws VELOX_USER_FAIL If the pattern is found to use unsupported features.
-<<<<<<< HEAD
-=======
-// @note  Default functionName is "regexp_replace" because it uses non-constant
-// patterns so it cannot be checked with "ensureRegexIsCompatible". No
-// other functions work with non-constant patterns, but they may in the future.
-//
-// @note Leaving functionName as an optional parameter makes room for
-// other functions to enable non-constant patterns in the future.
->>>>>>> 0910bee6fabbd162ca70d7588191733cbb59af4a
 void checkForCompatiblePattern(
     const std::string& pattern,
     const char* functionName) {
@@ -146,14 +137,10 @@ struct RegexReplaceFunction {
       const arg_type<Varchar>& pattern,
       const arg_type<Varchar>& replace,
       const arg_type<int64_t>& position) {
-<<<<<<< HEAD
     if (position < 1) {
       return false;
     }
     //VELOX_USER_CHECK_GE(position, 1, "regex_replace requires a position >= 1");
-=======
-    VELOX_USER_CHECK_GE(position, 1, "regexp_replace requires a position >= 1");
->>>>>>> 0910bee6fabbd162ca70d7588191733cbb59af4a
 
     re2::RE2* patternRegex = nullptr;
     try {
@@ -179,16 +166,11 @@ struct RegexReplaceFunction {
     while (numCodePoints < position - 1 && utf8Position <= stringInput.size()) {
       int charLength =
           utf8proc_char_length(inputStringPiece.data() + utf8Position);
-<<<<<<< HEAD
       if (charLength < 1) {
         return false;
       }
       // VELOX_USER_CHECK_GT(
       //     charLength, 0, "regex_replace encountered invalid UTF-8 character");
-=======
-      VELOX_USER_CHECK_GT(
-          charLength, 0, "regexp_replace encountered invalid UTF-8 character");
->>>>>>> 0910bee6fabbd162ca70d7588191733cbb59af4a
       ++numCodePoints;
       utf8Position += charLength;
     }

--- a/velox/functions/sparksql/RegexFunctions.h
+++ b/velox/functions/sparksql/RegexFunctions.h
@@ -62,8 +62,8 @@ std::shared_ptr<exec::VectorFunction> makeRegexExtract(
 
 /// Full implementation of RegexReplace found in SparkSQL only,
 /// due to semantic mismatches betweeen Spark and Presto
-/// regex_replace(string, pattern, overwrite) → string
-/// regex_replace(string, pattern, overwrite, position) → string
+/// regexp_replace(string, pattern, overwrite) → string
+/// regexp_replace(string, pattern, overwrite, position) → string
 ///
 /// If a string has a substring that matches the given pattern, replace
 /// the match in the string with overwrite and return the string. If

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -184,7 +184,6 @@ void registerFunctions(const std::string& prefix) {
       prefix + "regexp_extract", re2ExtractSignatures(), makeRegexExtract);
   exec::registerStatefulVectorFunction(
       prefix + "rlike", re2SearchSignatures(), makeRLike);
-  registerRegexReplace(prefix);
   VELOX_REGISTER_VECTOR_FUNCTION(udf_regexp_split, prefix + "split");
 
   exec::registerStatefulVectorFunction(

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -184,6 +184,7 @@ void registerFunctions(const std::string& prefix) {
       prefix + "regexp_extract", re2ExtractSignatures(), makeRegexExtract);
   exec::registerStatefulVectorFunction(
       prefix + "rlike", re2SearchSignatures(), makeRLike);
+  registerRegexReplace(prefix);
   VELOX_REGISTER_VECTOR_FUNCTION(udf_regexp_split, prefix + "split");
 
   exec::registerStatefulVectorFunction(

--- a/velox/functions/sparksql/tests/RegexFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/RegexFunctionsTest.cpp
@@ -31,6 +31,11 @@ namespace {
 
 class RegexFunctionsTest : public test::SparkFunctionBaseTest {
  public:
+  void SetUp() override {
+    SparkFunctionBaseTest::SetUp();
+    registerRegexReplace("");
+  }
+
   std::optional<bool> rlike(
       std::optional<std::string> str,
       std::string pattern) {

--- a/velox/functions/sparksql/tests/RegexFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/RegexFunctionsTest.cpp
@@ -57,12 +57,12 @@ class RegexFunctionsTest : public test::SparkFunctionBaseTest {
     auto result = [&] {
       if (!position) {
         return evaluateOnce<std::string>(
-            fmt::format("regex_replace(c0, '{}', '{}')", pattern, replace),
+            fmt::format("regexp_replace(c0, '{}', '{}')", pattern, replace),
             input);
       } else {
         return evaluateOnce<std::string>(
             fmt::format(
-                "regex_replace(c0, '{}', '{}', {})",
+                "regexp_replace(c0, '{}', '{}', {})",
                 pattern,
                 replace,
                 position.value()),
@@ -99,7 +99,7 @@ class RegexFunctionsTest : public test::SparkFunctionBaseTest {
     std::shared_ptr<SimpleVector<StringView>> result;
     if (position) {
       result = evaluate<SimpleVector<StringView>>(
-          "regex_replace(c0, c1, c2, c3)",
+          "regexp_replace(c0, c1, c2, c3)",
           makeRowVector(
               {inputStringVector,
                patternStringVector,
@@ -107,7 +107,7 @@ class RegexFunctionsTest : public test::SparkFunctionBaseTest {
                positionIntVector}));
     } else {
       result = evaluate<SimpleVector<StringView>>(
-          "regex_replace(c0, c1, c2)",
+          "regexp_replace(c0, c1, c2)",
           makeRowVector(
               {inputStringVector, patternStringVector, replaceStringVector}));
     }
@@ -128,12 +128,12 @@ class RegexFunctionsTest : public test::SparkFunctionBaseTest {
       auto positionIntVector = makeFlatVector<int32_t>(*position);
 
       result = evaluate<SimpleVector<StringView>>(
-          fmt::format("regex_replace(c0, '{}', c1, c2)", pattern),
+          fmt::format("regexp_replace(c0, '{}', c1, c2)", pattern),
           makeRowVector(
               {inputStringVector, replaceStringVector, positionIntVector}));
     } else {
       result = evaluate<SimpleVector<StringView>>(
-          fmt::format("regex_replace(c0, '{}', c1)", pattern),
+          fmt::format("regexp_replace(c0, '{}', c1)", pattern),
           makeRowVector({inputStringVector, replaceStringVector}));
     }
     return result;
@@ -489,7 +489,7 @@ TEST_F(RegexFunctionsTest, regexReplaceDataframeLastCharacter) {
 
 // Test to match
 // https://github.com/apache/spark/blob/master/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala#L180-L184
-// This test is the crux of why regex_replace needed to support non-constant
+// This test is the crux of why regexp_replace needed to support non-constant
 // parameters. Used position {0,0} out of convenience, ideally we create another
 // function that does not pass a position parameter.
 TEST_F(RegexFunctionsTest, regexReplaceMatchSparkSqlTest) {


### PR DESCRIPTION
This is just a draft PR for @kagamiori to see fuzzer issues. Seed is 3732405514

After building, run: `_build/debug/velox/expression/tests/spark_expression_fuzzer_test --duration_sec 60 --enable_variadic_signatures --lazy_vector_generation_ratio 0.2 --velox_fuzzer_enable_column_reuse --velox_fuzzer_enable_expression_reuse --max_expression_trees_per_step 2 --retry_with_try --enable_dereference --seed 3732405514 --logtostderr=1 --minloglevel=0`

to replicate

<img width="1116" alt="image" src="https://github.com/facebookincubator/velox/assets/14911410/943c11a5-befa-454b-85dd-01cfd1159df1">

