### PR TITLE
Ensure wrapping over a loaded lazy vector strips the lazy layer

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1282,7 +1282,7 @@ void computeIsAsciiForInputs(
       auto* vector =
           inputValues[index]->template as<SimpleVector<StringView>>();
 
-      VELOX_CHECK(vector);
+      VELOX_CHECK(vector, inputValues[index]->toString());
       vector->computeAndSetIsAscii(rows);
     }
   }

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -372,6 +372,9 @@ class ConstantVector final : public SimpleVector<T> {
       // Do not load Lazy vector
       return;
     }
+    // Ensure any internal state in valueVector_ is initialized, and it points
+    // to the loaded vector underneath any lazy layers.
+    valueVector_ = BaseVector::loadedVectorShared(valueVector_);
 
     isNull_ = valueVector_->isNullAt(index_);
     BaseVector::distinctValueCount_ = isNull_ ? 0 : 1;

--- a/velox/vector/DictionaryVector-inl.h
+++ b/velox/vector/DictionaryVector-inl.h
@@ -40,6 +40,9 @@ void DictionaryVector<T>::setInternalState() {
     // Do not load Lazy vector
     return;
   }
+  // Ensure any internal state in dictionaryValues_ is initialized, and it
+  // points to the loaded vector underneath any lazy layers.
+  dictionaryValues_ = BaseVector::loadedVectorShared(dictionaryValues_);
 
   if (dictionaryValues_->isScalar()) {
     scalarDictionaryValues_ =


### PR DESCRIPTION
Currently, dictionary or constant vectors remain in uninitialized
state if they are wrapped over an unloaded lazy vector (lets call
it valuesVector). However, that state needs to be initialized
correctly if the valuesVector either loaded explicitly (not via
the wrapped layer) or the wrapping was done over a loaded lazy
vector. In both these cases, the dictionary or constant would end
up pointing to a loaded lazy vector which would retain the lazy
layer. This is wasteful and can cause issues during expression
eval where peeling would only peel away the encoding layer and
pass on the lazy layer to udfs and expression.
This change ensure that the lazy layer is stripped away by
pointing the vector returned by valuesVector->loadedVectorShared().
This also the ensures internal state of valuesVector is always
initialized incase it has nested encoding layers.

Test Plan:
Added test cases in VectorTest