### PR TITLE
Fix deprecated this capture in velox/vector/tests/utils/VectorMaker.h

### DIFF
--- a/velox/vector/tests/utils/VectorMaker.h
+++ b/velox/vector/tests/utils/VectorMaker.h
@@ -145,7 +145,7 @@ class VectorMaker {
         pool_,
         CppToType<T>::create(),
         size,
-        std::make_unique<SimpleVectorLoader>([=](RowSet rowSet) {
+        std::make_unique<SimpleVectorLoader>([=, this](RowSet rowSet) {
           // Populate requested rows with correct data and fill in gaps with
           // "garbage".
           SelectivityVector rows(rowSet.back() + 1, false);


### PR DESCRIPTION
Summary:
In the future LLVM will require that lambdas capture `this` explicitly. `-Wdeprecated-this-capture` checks for and enforces this now.

This diff adds an explicit `this` capture to a lambda to fix an issue that presents similarly to this:
```
   -> fbcode/path/to/my_file.cpp:66:47: error: implicit capture of 'this' with a capture default of '=' is deprecated [-Werror,-
Wdeprecated-this-capture]
   ->           detail::createIOWorkerProvider(evb, requestsRegistry_);
   ->                                               ^
   -> fbcode/path/to/my_file.cpp:61:30: note: add an explicit capture of 'this' to capture '*this' by reference
   ->   evb->runInEventBaseThread([=, self_weak = std::move(self_weak)]() {
   ->                              ^
   ->                               , this
```

Reviewed By: meyering

Differential Revision: D52279196


