### PR TITLE
Fix deprecated this capture in velox/vector/tests/utils/VectorTestBase.h

### DIFF
--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -739,7 +739,7 @@ class VectorTestBase {
         pool(),
         CppToType<T>::create(),
         size,
-        std::make_unique<SimpleVectorLoader>([=](RowSet rows) {
+        std::make_unique<SimpleVectorLoader>([=, this](RowSet rows) {
           if (expectedSize.has_value()) {
             VELOX_CHECK_EQ(rows.size(), *expectedSize);
           }
@@ -757,7 +757,7 @@ class VectorTestBase {
         pool(),
         vector->type(),
         vector->size(),
-        std::make_unique<SimpleVectorLoader>([=](RowSet /*rows*/) {
+        std::make_unique<SimpleVectorLoader>([=, this](RowSet /*rows*/) {
           auto indices =
               makeIndices(vector->size(), [](auto row) { return row; });
           return wrapInDictionary(indices, vector->size(), vector);


### PR DESCRIPTION
Summary:
In the future LLVM will require that lambdas capture `this` explicitly. `-Wdeprecated-this-capture` checks for and enforces this now.

This diff adds an explicit `this` capture to a lambda to fix an issue that presents similarly to this:
```
   -> fbcode/path/to/my_file.cpp:66:47: error: implicit capture of 'this' with a capture default of '=' is deprecated [-Werror,-
Wdeprecated-this-capture]
   ->           detail::createIOWorkerProvider(evb, requestsRegistry_);
   ->                                               ^
   -> fbcode/path/to/my_file.cpp:61:30: note: add an explicit capture of 'this' to capture '*this' by reference
   ->   evb->runInEventBaseThread([=, self_weak = std::move(self_weak)]() {
   ->                              ^
   ->                               , this
```

Reviewed By: meyering

Differential Revision: D52279210


