### PR TITLE
Disable unit test SsdFile.writeAndRead

### DIFF
--- a/velox/common/caching/tests/SsdFileTest.cpp
+++ b/velox/common/caching/tests/SsdFileTest.cpp
@@ -232,7 +232,7 @@ class SsdFileTest : public testing::Test {
   std::unique_ptr<SsdFile> ssdFile_;
 };
 
-TEST_F(SsdFileTest, writeAndRead) {
+TEST_F(SsdFileTest, DISABLED_writeAndRead) {
   constexpr int64_t kSsdSize = 16 * SsdFile::kRegionSize;
   std::vector<TestEntry> allEntries;
   initializeCache(128 * kMB, kSsdSize);


### PR DESCRIPTION
SEGFAULT on the unit test after
https://github.com/facebookincubator/velox/pull/6381. Disable the test temporarily.