### PR TITLE
Register abfs filesystem during Hive Connector registration

### DIFF
--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -41,7 +41,8 @@ target_link_libraries(
   velox_hive_partition_function
   velox_s3fs
   velox_hdfs
-  velox_gcs)
+  velox_gcs
+  velox_abfs)
 
 add_library(velox_hive_partition_function HivePartitionFunction.cpp)
 

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -31,6 +31,9 @@
 #ifdef VELOX_ENABLE_S3
 #include "velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h" // @manual
 #endif
+#ifdef VELOX_ENABLE_ABFS
+#include "velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.h" // @manual
+#endif
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
 // Meta's buck build system needs this check.
@@ -156,6 +159,9 @@ void HiveConnectorFactory::initialize() {
 #endif
 #ifdef VELOX_ENABLE_GCS
     filesystems::registerGCSFileSystem();
+#endif
+#ifdef VELOX_ENABLE_ABFS
+    filesystems::abfs::registerAbfsFileSystem();
 #endif
     return true;
   }();

--- a/velox/connectors/hive/storage_adapters/abfs/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/abfs/CMakeLists.txt
@@ -22,7 +22,7 @@ if(VELOX_ENABLE_ABFS)
     velox_abfs
     PUBLIC velox_file
            velox_core
-           velox_hive_connector
+           velox_hive_config
            velox_dwio_common_exception
            Azure::azure-storage-blobs
            Folly::folly

--- a/velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.cpp
@@ -25,23 +25,25 @@ namespace facebook::velox::filesystems::abfs {
 #ifdef VELOX_ENABLE_ABFS
 folly::once_flag abfsInitiationFlag;
 
-static std::function<std::shared_ptr<FileSystem>(
-    std::shared_ptr<const Config>,
-    std::string_view)>
-    filesystemGenerator = [](std::shared_ptr<const Config> properties,
-                             std::string_view filePath) {
-      static std::shared_ptr<FileSystem> filesystem;
-      folly::call_once(abfsInitiationFlag, [&properties]() {
-        filesystem = std::make_shared<AbfsFileSystem>(properties);
-      });
-      return filesystem;
-    };
+std::function<std::shared_ptr<
+    FileSystem>(std::shared_ptr<const Config>, std::string_view)>
+abfsFileSystemGenerator() {
+  static auto filesystemGenerator = [](std::shared_ptr<const Config> properties,
+                                       std::string_view filePath) {
+    static std::shared_ptr<FileSystem> filesystem;
+    folly::call_once(abfsInitiationFlag, [&properties]() {
+      filesystem = std::make_shared<AbfsFileSystem>(properties);
+    });
+    return filesystem;
+  };
+  return filesystemGenerator;
+}
 #endif
 
 void registerAbfsFileSystem() {
 #ifdef VELOX_ENABLE_ABFS
   LOG(INFO) << "Register ABFS";
-  registerFileSystem(isAbfsFile, filesystemGenerator);
+  registerFileSystem(isAbfsFile, abfsFileSystemGenerator());
 #endif
 }
 

--- a/velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.cpp
@@ -25,25 +25,21 @@ namespace facebook::velox::filesystems::abfs {
 #ifdef VELOX_ENABLE_ABFS
 folly::once_flag abfsInitiationFlag;
 
-std::function<std::shared_ptr<
-    FileSystem>(std::shared_ptr<const Config>, std::string_view)>
-abfsFileSystemGenerator() {
-  static auto filesystemGenerator = [](std::shared_ptr<const Config> properties,
-                                       std::string_view filePath) {
-    static std::shared_ptr<FileSystem> filesystem;
-    folly::call_once(abfsInitiationFlag, [&properties]() {
-      filesystem = std::make_shared<AbfsFileSystem>(properties);
-    });
-    return filesystem;
-  };
-  return filesystemGenerator;
+std::shared_ptr<FileSystem> abfsFileSystemGenerator(
+    std::shared_ptr<const Config> properties,
+    std::string_view filePath) {
+  static std::shared_ptr<FileSystem> filesystem;
+  folly::call_once(abfsInitiationFlag, [&properties]() {
+    filesystem = std::make_shared<AbfsFileSystem>(properties);
+  });
+  return filesystem;
 }
 #endif
 
 void registerAbfsFileSystem() {
 #ifdef VELOX_ENABLE_ABFS
   LOG(INFO) << "Register ABFS";
-  registerFileSystem(isAbfsFile, abfsFileSystemGenerator());
+  registerFileSystem(isAbfsFile, std::function(abfsFileSystemGenerator));
 #endif
 }
 


### PR DESCRIPTION
The logic to register abfs filesystem during hive connector initialization is missed, this PR use to add it.

Without this PR, when integrate with gluten to read data with velox abfs connector, would encoutner abfs filesytem not found issue.

The PR is part of issue https://github.com/facebookincubator/velox/issues/6415


