### PR TITLE
Fix kAtLeastN/kExactlyN fast path unicode input matching

### DIFF
--- a/velox/functions/lib/string/StringImpl.h
+++ b/velox/functions/lib/string/StringImpl.h
@@ -111,6 +111,17 @@ FOLLY_ALWAYS_INLINE int64_t length(const T& input) {
   }
 }
 
+/// Return a capped length(controlled by maxLength) of a string.
+/// The returned length is not greater than maxLength.
+template <bool isAscii, typename T>
+FOLLY_ALWAYS_INLINE int64_t cappedLength(const T& input, size_t maxLength) {
+  if constexpr (isAscii) {
+    return input.size() > maxLength ? maxLength : input.size();
+  } else {
+    return cappedLengthUnicode(input.data(), input.size(), maxLength);
+  }
+}
+
 /// Write the Unicode codePoint as string to the output string. The function
 /// behavior is undefined when code point it invalid. Implements the logic of
 /// presto chr function.

--- a/velox/functions/lib/string/tests/StringImplTest.cpp
+++ b/velox/functions/lib/string/tests/StringImplTest.cpp
@@ -177,6 +177,25 @@ TEST_F(StringImplTest, length) {
   }
 }
 
+TEST_F(StringImplTest, cappedLength) {
+  auto input = std::string("abcd");
+  ASSERT_EQ(cappedLength</*isAscii*/ true>(input, 1), 1);
+  ASSERT_EQ(cappedLength</*isAscii*/ true>(input, 2), 2);
+  ASSERT_EQ(cappedLength</*isAscii*/ true>(input, 3), 3);
+  ASSERT_EQ(cappedLength</*isAscii*/ true>(input, 4), 4);
+  ASSERT_EQ(cappedLength</*isAscii*/ true>(input, 5), 4);
+  ASSERT_EQ(cappedLength</*isAscii*/ true>(input, 6), 4);
+
+  input = std::string("你好a世界");
+  ASSERT_EQ(cappedLength</*isAscii*/ false>(input, 1), 1);
+  ASSERT_EQ(cappedLength</*isAscii*/ false>(input, 2), 2);
+  ASSERT_EQ(cappedLength</*isAscii*/ false>(input, 3), 3);
+  ASSERT_EQ(cappedLength</*isAscii*/ false>(input, 4), 4);
+  ASSERT_EQ(cappedLength</*isAscii*/ false>(input, 5), 5);
+  ASSERT_EQ(cappedLength</*isAscii*/ false>(input, 6), 5);
+  ASSERT_EQ(cappedLength</*isAscii*/ false>(input, 7), 5);
+}
+
 TEST_F(StringImplTest, badUnicodeLength) {
   ASSERT_EQ(0, length</*isAscii*/ false>(std::string("")));
   ASSERT_EQ(2, length</*isAscii*/ false>(std::string("ab")));

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -101,6 +101,8 @@ class Re2FunctionsTest : public test::FunctionBaseTest {
       std::optional<bool> expected,
       const std::string& errorMessage = "") {
     {
+      SCOPED_TRACE(fmt::format("Input: '{}', pattern: '{}'", input, pattern));
+
       // Test literal path.
       auto eval = [&]() {
         return evaluateOnce<bool>(
@@ -788,6 +790,29 @@ TEST_F(Re2FunctionsTest, likePatternAndEscape) {
       '#',
       std::nullopt,
       "Escape character must be followed by '%', '_' or the escape character itself");
+}
+
+TEST_F(Re2FunctionsTest, likePatternUnicode) {
+  // Input contains unicode.
+  testLike("你abc", "______", false);
+  testLike("你abc好", "_____", true);
+  testLike("你abc好", "______", false);
+
+  // Long string.
+  testLike("你abc好好好好好好好好好好好好好好好好", "______", false);
+
+  testLike("你abc好", "_abc%", true);
+  testLike("你abc好", "%abc_", true);
+  testLike("你好", "__%", true);
+  testLike("你好a", "__%", true);
+
+  // Pattern contains unicode.
+  testLike("你好吗?", "你好%", true);
+  testLike("你好吗?", "你%", true);
+  testLike("你abc?", "你%", true);
+  testLike("你abc?", "我%", false);
+  testLike("你好a世界", "你好_世界%", true);
+  testLike("你好吗世界", "你好_世界%", true);
 }
 
 template <typename T>


### PR DESCRIPTION
Previously _ is matched to a byte, it should match a character instead.