### PR TITLE
Scatter struct nulls when deserializing Presto wire format

### DIFF
--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -1001,7 +1001,7 @@ TEST_P(PrestoSerializerTest, encodedRoundtrip) {
     auto rowType = fuzzer.randRowType();
     auto inputRowVector = fuzzer.fuzzInputRow(rowType);
     serializer::presto::PrestoVectorSerde::PrestoOptions serdeOpts;
-    serdeOpts.nullsFirst = true;
+    serdeOpts.nullsFirst = i % 2 == 0;
     testEncodedRoundTrip(inputRowVector, &serdeOpts);
   }
 }
@@ -1050,7 +1050,7 @@ TEST_P(PrestoSerializerTest, encodedConcatenation) {
     makePermutations(vectors, 4, temp, permutations);
     for (auto i = 0; i < permutations.size(); ++i) {
       serializer::presto::PrestoVectorSerde::PrestoOptions opts;
-      opts.nullsFirst = true;
+      opts.nullsFirst = i % 2 == 0;
       testEncodedConcatenation(permutations[i], &opts);
     }
   }


### PR DESCRIPTION
Scatter struct nulls when deserializing Presto wire format

Reads Presto serialization in two passes: First reads struct nulls and
skips everything else. Then reads the serialization and passes down
nulls from enclosing structs, so that there are gaps in nested columns
for both nulls of said column as well as nulls from enclosing structs. This order of processing is due to struct nulls being serialized after the struct members. The struct members do not have values for rows where the struct is null.

When reading spill serialization, struct nulls are written before the struct columns and the reading can proceed i a single pass.

When reading in two passes, the first pass places the struct nulls in
a map keyed by the start offset of the struct serialization. The body
storing the nulls is a raw_vector, padded with SIMD padding above the
last byte. This is required by bits::scatterBits which accesses the
tail of its arguments at 64 bit width and may read past the end of a
std::vector.

Adds a test for encoding preserving roud trips. Adds a test for
concatenating different encodings in a message, e.g. constant,
dictionary, flat in all combinations of same/different encoding/value
domain.


