### PR TITLE
Remove unused function from velox/vector/arrow/Bridge.cpp

### DIFF
--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -800,19 +800,6 @@ void exportFlattenedVector(
       flattenAndExport, vec.typeKind(), vec, rows, out, pool, holder);
 }
 
-// Set the array as using "Null Layout" - no buffers are allocated.
-void setNullArray(ArrowArray& array, size_t length) {
-  array.length = length;
-  array.null_count = length;
-  array.offset = 0;
-  array.n_buffers = 0;
-  array.n_children = 0;
-  array.buffers = nullptr;
-  array.children = nullptr;
-  array.dictionary = nullptr;
-  array.release = releaseArrowArray;
-}
-
 void exportConstantValue(
     const BaseVector& vec,
     ArrowArray& out,


### PR DESCRIPTION
Summary: `-Wunused-function` has identified an unused function. This diff removes it. In many cases these functions have existed for years in an unused state.

Differential Revision: D52355714


