### PR TITLE
Fix build guide for tpch benchmnark

### DIFF
--- a/velox/docs/develop/TpchBenchmark.rst
+++ b/velox/docs/develop/TpchBenchmark.rst
@@ -16,7 +16,7 @@ following command line to do the build with S3 support:
 
 .. code:: shell
 
-   $ make release EXTRA_CMAKE_FLAGS="-DVELOX_BUILD_BENCHMARKS=ON -DVELOX_ENABLE_S3=ON"
+   $ make release EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_BENCHMARKS=ON -DVELOX_ENABLE_S3=ON"
 
 ----
 


### PR DESCRIPTION
VELOX_BUILD_BENCHMARKS is removed by https://github.com/facebookincubator/velox/pull/8015.