### PR TITLE
Register memory reclaimers for parquet writer mem pools

### DIFF
--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -141,6 +141,9 @@ class Writer : public dwio::common::Writer {
   void abort() override;
 
  private:
+  // Sets the memory reclaimers for all the memory pools used by this writer.
+  void setMemoryReclaimers();
+
   // Pool for 'stream_'.
   std::shared_ptr<memory::MemoryPool> pool_;
   std::shared_ptr<memory::MemoryPool> generalPool_;


### PR DESCRIPTION
The parquet writer memory pools did not have associated memory reclaimers which prevented the worker from being suspended. To resolve the issue the default memory reclaimer is registered with all memory pools used by the parquet writer.