### PR TITLE
Fix slow scale writer in Prestissimo

### DIFF
--- a/velox/exec/OutputBuffer.cpp
+++ b/velox/exec/OutputBuffer.cpp
@@ -695,7 +695,7 @@ double OutputBuffer::getUtilization() const {
 }
 
 bool OutputBuffer::isOverutilized() const {
-  return (totalSize_ > (0.5 * maxSize_)) && !atEnd_;
+  return (totalSize_ > (0.5 * maxSize_)) || atEnd_;
 }
 
 OutputBuffer::Stats OutputBuffer::stats() {

--- a/velox/exec/tests/OutputBufferManagerTest.cpp
+++ b/velox/exec/tests/OutputBufferManagerTest.cpp
@@ -358,10 +358,8 @@ class OutputBufferManagerTest : public testing::Test {
       ASSERT_TRUE(overutilized);
     }
     if (outputBufferStatus == OutputBufferStatus::kNoMoreProducer) {
-      // output buffer is over utilized but since there is no more producer
-      // outputBufferOverutilized is not true (producers are not blocked)
-      ASSERT_GT(utilization, 0.5);
-      ASSERT_FALSE(overutilized);
+      // output buffer is over utilized if no more producer is set.
+      ASSERT_TRUE(overutilized);
     }
   }
 
@@ -573,7 +571,6 @@ TEST_F(OutputBufferManagerTest, destinationBuffer) {
 
 TEST_F(OutputBufferManagerTest, basicPartitioned) {
   vector_size_t size = 100;
-
   std::string taskId = "t0";
   auto task = initializeTask(
       taskId, rowType_, PartitionedOutputNode::Kind::kPartitioned, 5, 1);
@@ -643,7 +640,7 @@ TEST_F(OutputBufferManagerTest, basicPartitioned) {
     fetchEndMarker(taskId, destination, 2);
   }
   EXPECT_TRUE(task->isRunning());
-  verifyOutputBuffer(task, OutputBufferStatus::kRunning);
+  verifyOutputBuffer(task, OutputBufferStatus::kNoMoreProducer);
 
   deleteResults(taskId, 3);
   fetchEndMarker(taskId, 4, 2);
@@ -692,7 +689,7 @@ TEST_F(OutputBufferManagerTest, basicBroadcast) {
   bufferManager_->updateOutputBuffers(taskId, 5, false);
   EXPECT_FALSE(bufferManager_->isFinished(taskId));
   bufferManager_->updateOutputBuffers(taskId, 6, false);
-  verifyOutputBuffer(task, OutputBufferStatus::kRunning);
+  verifyOutputBuffer(task, OutputBufferStatus::kNoMoreProducer);
 
   // Fetch all for the new added destinations.
   fetch(taskId, 5, 0, 1'000'000'000, 3, true);

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -1143,7 +1143,7 @@ TEST_F(TaskTest, outputBufferSize) {
   // Need to call requestCancel to explicitly terminate the task.
   EXPECT_GT(finishStats.outputBufferUtilization, 0);
   EXPECT_LT(finishStats.outputBufferUtilization, 1);
-  EXPECT_FALSE(finishStats.outputBufferOverutilized);
+  EXPECT_TRUE(finishStats.outputBufferOverutilized);
   task->requestCancel();
 }
 


### PR DESCRIPTION
In Meta internal staging test, we found Presto java scheduled way more writers
than native for even small query which executed less 1 min in Java. Java scheduled
writer tasks on 87 workers while native only scheduled 1. Even through native uses
much less cpu than java but the wall time takes much longer, native took 5.89 mins
while java only took 27s.
We first suspected that this is caused by the difference in physical written bytes
reporting mechanism. The native starts to report physical written bytes after the file
writer flushes the encoded data to the file sink. It is latter to record the bytes written
to the storage layer. And table writer report the written bytes from the file sink but
not the file writer. The java starts to report physical written bytes early: 
```
OrcFileWriter::getWrittenBytes() {
   return orcWriter.getWrittenBytes() + orcWriter.getBufferedBytes();
}
```
It actually reports the physical written bytes + buffered bytes in memory which hasn't 
flushed to the file sink layer yet. With a temporary change in native to switch to report
the logical bytes, this doesn't change much. The coordinator schedules table writers 
on 4 workers and execution time drops from 5.89 mins down to 1.3 mins but still much
less than java side. The physical written bytes is leveraged by coordinator to make sure
each scheduled writer has written minimum required data on storage before scheduling
a new one to avoid too much small files. "writer_min_size" is the corresponding session
property which is 128MB by default. We shall anyway fix this in a separate PR to report
estimated on-disk size of buffered file data + physical written bytes.

With further debugging, we found the output buffer over-utilization setting in native is
different than java, native set the flag if buffer usage is >50% and there is more incoming
data (OutputBuffer::isOverutilized()) but java set the flag if either buffer usage is >50% or
there is no more incoming data ArbitraryOutputBuffer::isOverutilized(). I am not sure what's
the heuristic underneath on java side but this apparently ends up scheduling more writers.
With this only change in native to make this behaves the same as java side,  native scheduled
writers on 105 workers and execution time drops from 5.89 mins to 35s. 

We also tried to reduce the output buffer size from 214MB to 32MB on native, it can also
reduce the execution time from 5.89 mins to 32s with 108 scheduled workers.