### PR TITLE
Fix memory reservation in hash join spill

### DIFF
--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -455,7 +455,7 @@ bool HashBuild::reserveMemory(const RowVectorPtr& input) {
       rows->stringAllocator().retainedSize() - outOfLineFreeBytes;
   const auto outOfLineBytesPerRow =
       std::max<uint64_t>(1, numRows == 0 ? 0 : outOfLineBytes / numRows);
-  const auto currentUsage = pool()->parent()->currentBytes();
+  const auto currentUsage = pool()->currentBytes();
 
   if (numRows != 0) {
     // Test-only spill path.
@@ -467,9 +467,10 @@ bool HashBuild::reserveMemory(const RowVectorPtr& input) {
 
     // We check usage from the parent pool to take peers' allocations into
     // account.
-    if (spillMemoryThreshold_ != 0 && currentUsage > spillMemoryThreshold_) {
+    const auto nodeUsage = pool()->parent()->currentBytes();
+    if (spillMemoryThreshold_ != 0 && nodeUsage > spillMemoryThreshold_) {
       const int64_t bytesToSpill =
-          currentUsage * spillConfig()->spillableReservationGrowthPct / 100;
+          nodeUsage * spillConfig()->spillableReservationGrowthPct / 100;
       numSpillRows_ = std::max<int64_t>(
           1, bytesToSpill / (rows->fixedRowSize() + outOfLineBytesPerRow));
       numSpillBytes_ = numSpillRows_ * outOfLineBytesPerRow;


### PR DESCRIPTION
The current hash join spill reservation is based on the parent node's
memory usage which can cause unnecessary spilling such as few MB
memory usage cause hundred MB reservation. This PR fixes this to use
operator's memory usage for reservation and only uses the parent node's
memory usage for threshold based spilling trigger

