### PR TITLE
Fix int64::max() to double conversion issue

### DIFF
--- a/velox/common/base/Doubles.h
+++ b/velox/common/base/Doubles.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace facebook::velox {
+
+/// Comparing double against int64:max() like the following would get compile
+/// time error on some compilers(e.g. clang 12 and above):
+///
+/// ```
+/// double_value <= int64::max()
+/// double_value >= int64::max()
+/// ```
+///
+/// Here `int64::max()` will be implicitly converted to double, but due to the
+/// floating point nature of double, converting `int64::max()` to double lose
+/// precision(see [1]), so instead of comparing double with int64:max(), we
+/// suggest compare it with the max double value below int64:max() 2 ^ 63 -
+/// 1024 for < or <=, 2 ^ 63 for >, >=.
+///
+/// [1].https://en.wikipedia.org/wiki/Double-precision_floating-point_format#Precision_limitations_on_integer_values
+
+/// 2 ^ 63 - 1024
+static constexpr double kMaxDoubleBelowInt64Max = 9223372036854774784.0;
+/// 2 ^ 63
+static constexpr double kMinDoubleAboveInt64Max = 9223372036854775808.0;
+} // namespace facebook::velox

--- a/velox/functions/prestosql/Arithmetic.h
+++ b/velox/functions/prestosql/Arithmetic.h
@@ -27,6 +27,7 @@
 #include <type_traits>
 
 #include "folly/CPortability.h"
+#include "velox/common/base/Doubles.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/functions/Macros.h"
 #include "velox/functions/prestosql/ArithmeticImpl.h"
@@ -95,9 +96,10 @@ struct IntervalMultiplyFunction {
     } else {
       resultDouble = sanitizeInput(b) * a;
     }
+
     if LIKELY (
         std::isfinite(resultDouble) && resultDouble >= kLongMin &&
-        resultDouble <= kLongMax) {
+        resultDouble <= kMaxDoubleBelowInt64Max) {
       result = int64_t(resultDouble);
     } else {
       result = resultDouble > 0 ? kLongMax : kLongMin;
@@ -139,7 +141,7 @@ struct IntervalDivideFunction {
     double resultDouble = a / b;
     if LIKELY (
         std::isfinite(resultDouble) && resultDouble >= kLongMin &&
-        resultDouble <= kLongMax) {
+        resultDouble <= kMaxDoubleBelowInt64Max) {
       result = int64_t(resultDouble);
     } else {
       result = resultDouble > 0 ? kLongMax : kLongMin;

--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -17,6 +17,8 @@
 
 #include <chrono>
 #include <optional>
+
+#include "velox/common/base/Doubles.h"
 #include "velox/external/date/date.h"
 #include "velox/type/Timestamp.h"
 #include "velox/type/TimestampConversion.h"
@@ -39,14 +41,9 @@ FOLLY_ALWAYS_INLINE std::optional<Timestamp> fromUnixtime(double unixtime) {
     return Timestamp(0, 0);
   }
 
-  static const int64_t kMax = std::numeric_limits<int64_t>::max();
   static const int64_t kMin = std::numeric_limits<int64_t>::min();
 
-  // On some compilers if we cast kMax to a double, we can get a number larger
-  // than 'kMax'. This will allow 'unixtime' values > 'kMax'. The workaround
-  // here is to use uint64_t to represent ('kMax' + 1), which can be represented
-  // exactly as double. We then check if the difference with 'unixtime' <= 1.
-  if (FOLLY_UNLIKELY((static_cast<uint64_t>(kMax) + 1) - unixtime <= 1)) {
+  if (FOLLY_UNLIKELY(unixtime >= kMinDoubleAboveInt64Max)) {
     return Timestamp::maxMillis();
   }
 

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -21,6 +21,7 @@
 #include <system_error>
 #include <type_traits>
 
+#include "velox/common/base/Doubles.h"
 #include "velox/functions/Macros.h"
 #include "velox/functions/lib/ToHex.h"
 
@@ -123,11 +124,8 @@ inline int64_t safeDoubleToInt64(const double& arg) {
   }
   static const int64_t kMax = std::numeric_limits<int64_t>::max();
   static const int64_t kMin = std::numeric_limits<int64_t>::min();
-  // On some compilers if we cast 'kMax' to a double, we can get a number larger
-  // than 'kMax'. This will allow 'arg' values > 'kMax'. The workaround
-  // here is to use uint64_t to represent ('kMax' + 1), which can be represented
-  // exactly as double. We then check if the difference with 'arg' <= 1.
-  if ((static_cast<uint64_t>(kMax) + 1) - arg <= 1) {
+
+  if (arg >= kMinDoubleAboveInt64Max) {
     return kMax;
   }
   if (arg < kMin) {


### PR DESCRIPTION
Comparing double against int64:max() like the following would get compile
time error on some compilers(e.g. clang 12 and above):

```
double_value <= int64::max()
double_value >= int64::max()
```

Here `int64::max()` will be implicitly converted to double, but due to the
floating point nature of double, converting `int64::max()` to double lose
precision(see [1]), so instead of comparing double with int64:max(), we
suggest compare it with the max double value below int64:max() 
(2 ^ 63 - 1024) for < or <= and min double value above int64:max() 
(2 ^ 63) for >, >=.

[1].https://en.wikipedia.org/wiki/Double-precision_floating-point_format#Precision_limitations_on_integer_values
