### PR TITLE
Fix join spill under split group execution mode

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -121,7 +121,8 @@ const core::QueryConfig& DriverCtx::queryConfig() const {
 velox::memory::MemoryPool* DriverCtx::addOperatorPool(
     const core::PlanNodeId& planNodeId,
     const std::string& operatorType) {
-  return task->addOperatorPool(planNodeId, pipelineId, driverId, operatorType);
+  return task->addOperatorPool(
+      planNodeId, splitGroupId, pipelineId, driverId, operatorType);
 }
 
 std::optional<common::SpillConfig> DriverCtx::makeSpillConfig(

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -378,15 +378,30 @@ void Task::initTaskPool() {
 }
 
 velox::memory::MemoryPool* Task::getOrAddNodePool(
-    const core::PlanNodeId& planNodeId,
-    bool isHashJoinNode) {
+    const core::PlanNodeId& planNodeId) {
   if (nodePools_.count(planNodeId) == 1) {
     return nodePools_[planNodeId];
   }
   childPools_.push_back(pool_->addAggregateChild(
-      fmt::format("node.{}", planNodeId), createNodeReclaimer(isHashJoinNode)));
+      fmt::format("node.{}", planNodeId), createNodeReclaimer(false)));
   auto* nodePool = childPools_.back().get();
   nodePools_[planNodeId] = nodePool;
+  return nodePool;
+}
+
+memory::MemoryPool* Task::getOrAddJoinNodePool(
+    const core::PlanNodeId& planNodeId,
+    uint32_t splitGroupId) {
+  const std::string nodeId = splitGroupId == kUngroupedGroupId
+      ? planNodeId
+      : fmt::format("{}[{}]", planNodeId, splitGroupId);
+  if (nodePools_.count(nodeId) == 1) {
+    return nodePools_[nodeId];
+  }
+  childPools_.push_back(pool_->addAggregateChild(
+      fmt::format("node.{}", nodeId), createNodeReclaimer(true)));
+  auto* nodePool = childPools_.back().get();
+  nodePools_[nodeId] = nodePool;
   return nodePool;
 }
 
@@ -421,11 +436,16 @@ std::unique_ptr<memory::MemoryReclaimer> Task::createTaskReclaimer() {
 
 velox::memory::MemoryPool* Task::addOperatorPool(
     const core::PlanNodeId& planNodeId,
+    uint32_t splitGroupId,
     int pipelineId,
     uint32_t driverId,
     const std::string& operatorType) {
-  auto* nodePool =
-      getOrAddNodePool(planNodeId, isHashJoinOperator(operatorType));
+  velox::memory::MemoryPool* nodePool;
+  if (isHashJoinOperator(operatorType)) {
+    nodePool = getOrAddJoinNodePool(planNodeId, splitGroupId);
+  } else {
+    nodePool = getOrAddNodePool(planNodeId);
+  }
   childPools_.push_back(nodePool->addLeafChild(fmt::format(
       "op.{}.{}.{}.{}", planNodeId, pipelineId, driverId, operatorType)));
   return childPools_.back().get();


### PR DESCRIPTION
We found in Meta internal shadowing test that in some edge case that memory arbitrator
can't reclaim memory from hash build operators even through they have many memory to
reclaim. The problem is due to the group execution mode in which drivers are created in
batch for each split group. And the hash join does the coordinated spill so the hash join
memory pool node only reclaims memory from any one of the hash build operator pool and the
chosen one will reclaim memory from all its peers that make sure they spill from the same
set of partitions. With group execution mode, it is likely that the hash join node reclaim from
one of the hash build operators from the previous finished split group. The driver has already
gone is that case so we skip spill as the hash build has been done. This assumption is no longer
valid under split group execution mode, and there might be hash build operators active for
the other split group. 
To fix this issue, we shall create a separate hash join node for each split group. So when we
create operator pool, we shall get or create its parent join node pool use plan node id + split
group id.