### PR TITLE
Make spillPool a member of MemoryManager

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -72,7 +72,8 @@ MemoryManager::MemoryManager(const MemoryManagerOptions& options)
               .trackUsage = options.trackDefaultUsage,
               .debugEnabled = options.debugEnabled,
               .coreOnAllocationFailureEnabled =
-                  options.coreOnAllocationFailureEnabled})} {
+                  options.coreOnAllocationFailureEnabled})},
+      spillPool_{addLeafPool("_sys.spilling")} {
   VELOX_CHECK_NOT_NULL(allocator_);
   VELOX_CHECK_NOT_NULL(arbitrator_);
   VELOX_CHECK_EQ(
@@ -313,9 +314,7 @@ MemoryPool& deprecatedSharedLeafPool() {
 }
 
 memory::MemoryPool* spillMemoryPool() {
-  static auto pool =
-      memory::MemoryManager::getInstance()->addLeafPool("_sys.spilling");
-  return pool.get();
+  return memory::MemoryManager::getInstance()->spillPool();
 }
 
 bool isSpillMemoryPool(memory::MemoryPool* pool) {

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -217,6 +217,11 @@ class MemoryManager {
     return *defaultRoot_;
   }
 
+  /// Returns the process wide leaf memory pool used for disk spilling.
+  MemoryPool* spillPool() {
+    return spillPool_.get();
+  }
+
   const std::vector<std::shared_ptr<MemoryPool>>& testingSharedLeafPools() {
     return sharedLeafPools_;
   }
@@ -259,6 +264,8 @@ class MemoryManager {
   const MemoryPoolImpl::GrowCapacityCallback poolGrowCb_;
 
   const std::shared_ptr<MemoryPool> defaultRoot_;
+  const std::shared_ptr<MemoryPool> spillPool_;
+
   std::vector<std::shared_ptr<MemoryPool>> sharedLeafPools_;
 
   mutable folly::SharedMutex mutex_;


### PR DESCRIPTION
The spillPool is being held as a static variable in `memory::spillMemoryPool`,
it would be nice to make it a member of the `MemoryManager`
and access through `MemoryManager::spillPool()`.
