### PR TITLE
Optimizing casting GenericView to primitives.

### DIFF
--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -681,6 +681,10 @@ class ArrayView {
     return offset_;
   }
 
+  TypeKind elementKind() const {
+    return elementsVector()->typeKind();
+  }
+
  private:
   const reader_t* reader_;
   vector_size_t offset_;
@@ -1119,11 +1123,19 @@ class GenericView {
             "castTo type is not compatible with type of vector, vector type is {}",
             type()->toString()));
 
-    // TODO: We can distinguish if this is a null-free or not null-free
-    // generic. And based on that determine if we want to call operator[] or
-    // readNullFree. For now we always return nullable.
-    return ensureReader<ToType>()->operator[](
-        index_); // We pass the non-decoded index.
+    // If its a primitive type, then the casted reader always exisits at
+    // castReaders_[0], and is set in Vector readers.
+    if constexpr (SimpleTypeTrait<ToType>::isPrimitiveType) {
+      return static_cast<VectorReader<ToType>*>(castReaders_[0].get())
+          ->
+          operator[](index_);
+    } else {
+      // TODO: We can distinguish if this is a null-free or not null-free
+      // generic. And based on that determine if we want to call operator[] or
+      // readNullFree. For now we always return nullable.
+      return ensureReader<ToType>()->operator[](
+          index_); // We pass the non-decoded index.
+    }
   }
 
   template <typename ToType>
@@ -1136,7 +1148,6 @@ class GenericView {
         index_); // We pass the non-decoded index.
   }
 
- private:
   template <typename B>
   VectorReader<B>* ensureReader() const {
     static_assert(
@@ -1147,7 +1158,6 @@ class GenericView {
     // the user is always casting to the same type.
     // Types are divided into three sets, for 1, and 2 we do not do the check,
     // since no two types can ever refer to the same vector.
-
     if constexpr (!HasGeneric<B>::value()) {
       // Two types with no generic can never represent same vector.
       return ensureReaderImpl<B, 0>();
@@ -1174,6 +1184,7 @@ class GenericView {
     }
   }
 
+ private:
   template <typename B, size_t I>
   VectorReader<B>* ensureReaderImpl() const {
     auto* reader = static_cast<VectorReader<B>*>(castReaders_[I].get());

--- a/velox/expression/GenericWriter.cpp
+++ b/velox/expression/GenericWriter.cpp
@@ -31,21 +31,6 @@ bool constexpr fastPathSupportedStatic() {
   return TypeTraits<kind>::isPrimitiveType && kind != TypeKind::UNKNOWN;
 }
 
-template <TypeKind kind>
-struct KindToSimpleType {
-  using type = typename TypeTraits<kind>::NativeType;
-};
-
-template <>
-struct KindToSimpleType<TypeKind::VARCHAR> {
-  using type = Varchar;
-};
-
-template <>
-struct KindToSimpleType<TypeKind::VARBINARY> {
-  using type = Varbinary;
-};
-
 // Base case for primitives.
 template <TypeKind T>
 void copy_from_internal(GenericWriter& out, const GenericView& in) {

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -176,3 +176,8 @@ add_executable(velox_functions_prestosql_benchmarks_map_subscript
                MapSubscriptCachingBenchmark.cpp)
 target_link_libraries(velox_functions_prestosql_benchmarks_map_subscript
                       ${BENCHMARK_DEPENDENCIES})
+
+add_executable(velox_functions_prestosql_benchmarks_generic
+               GenericBenchmark.cpp)
+target_link_libraries(velox_functions_prestosql_benchmarks_generic
+                      ${BENCHMARK_DEPENDENCIES})

--- a/velox/functions/prestosql/benchmarks/GenericBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/GenericBenchmark.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
+#include "velox/expression/ComplexViewTypes.h"
+#include "velox/functions/Registerer.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/type/Type.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/DecodedVector.h"
+
+using namespace facebook::velox;
+
+namespace {
+// The following two functions is used to measure the cost of the cast of
+// generic view.
+
+// A function that takes array<X> and returns the summation as int64_t. For
+// simplicity is here handling double and int64_t.
+template <typename T>
+struct GenericInputArraySum {
+  template <typename TInput>
+  void call(int64_t& out, const TInput& arrayOfGeneric) {
+    out = 0;
+    if (arrayOfGeneric.elementKind() == TypeKind::DOUBLE) {
+      for (auto e : arrayOfGeneric) {
+        if (e.has_value()) {
+          out += e.value().template castTo<double>();
+        }
+      }
+    } else if (arrayOfGeneric.elementKind() == TypeKind::BIGINT) {
+      for (auto e : arrayOfGeneric) {
+        if (e.has_value()) {
+          out += e.value().template castTo<int64_t>();
+        }
+      }
+    } else {
+      out = 0;
+    }
+  }
+};
+
+template <typename T>
+struct TypedArraySum {
+  template <typename TInput>
+  void call(int64_t& out, const TInput& typedArray) {
+    out = 0;
+    for (auto e : typedArray) {
+      if (e.has_value()) {
+        out += e.value();
+      }
+    }
+  }
+};
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+
+  ExpressionBenchmarkBuilder benchmarkBuilder;
+
+  facebook::velox::registerFunction<GenericInputArraySum, int64_t, Array<Any>>(
+      {"generic_input_sum"});
+  facebook::velox::registerFunction<TypedArraySum, int64_t, Array<double>>(
+      {"typed_sum"});
+  facebook::velox::registerFunction<TypedArraySum, int64_t, Array<int64_t>>(
+      {"typed_sum"});
+
+  auto* pool = benchmarkBuilder.pool();
+  auto& vm = benchmarkBuilder.vectorMaker();
+
+  benchmarkBuilder
+      .addBenchmarkSet(
+          fmt::format("array_sum"),
+          ROW({"c0", "c1"}, {ARRAY(BIGINT()), ARRAY(DOUBLE())}))
+      .addExpression("generic_input_int", "generic_input_sum(c0)")
+      .addExpression("typed_int", "typed_sum(c0)")
+      .addExpression("generic_input_double", "generic_input_sum(c1)")
+      .addExpression("typed_double", "typed_sum(c1)");
+
+  benchmarkBuilder.registerBenchmarks();
+
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1901,6 +1901,21 @@ struct ConstantChecker {
       isConstantType<TArgs>::value...};
 };
 
+template <TypeKind kind>
+struct KindToSimpleType {
+  using type = typename TypeTraits<kind>::NativeType;
+};
+
+template <>
+struct KindToSimpleType<TypeKind::VARCHAR> {
+  using type = Varchar;
+};
+
+template <>
+struct KindToSimpleType<TypeKind::VARBINARY> {
+  using type = Varbinary;
+};
+
 template <typename T>
 struct SimpleTypeTrait {};
 


### PR DESCRIPTION
Summary:
When casting a genericView, the underlying reader is first ensured to have been created. 
while its only created once, the check that is created happens over and over for each row. 

When the generic view represents a primitive type, there is only one valid destination type, 
in that case we can ensure the casted reader when the vector reader is created and avoid the check 
for each row. The diff does this optimization.

after
```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
array_sum##generic_input_int                               55.21ms     18.11
array_sum##typed_int                                       53.03ms     18.86
array_sum##generic_input_double                            59.23ms     16.88
array_sum##typed_double                                    58.89ms     16.98
```

before:
```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
array_sum##generic_input_int                               73.16ms     13.67
array_sum##typed_int                                       55.23ms     18.10
array_sum##generic_input_double                            72.83ms     13.73
array_sum##typed_double                                    59.04ms     16.94
```

Reviewed By: Yuhta

Differential Revision: D52223370


