### PR TITLE
Optimize casting generic writer to primitives.

### DIFF
--- a/velox/expression/GenericWriter.cpp
+++ b/velox/expression/GenericWriter.cpp
@@ -31,21 +31,6 @@ bool constexpr fastPathSupportedStatic() {
   return TypeTraits<kind>::isPrimitiveType && kind != TypeKind::UNKNOWN;
 }
 
-template <TypeKind kind>
-struct KindToSimpleType {
-  using type = typename TypeTraits<kind>::NativeType;
-};
-
-template <>
-struct KindToSimpleType<TypeKind::VARCHAR> {
-  using type = Varchar;
-};
-
-template <>
-struct KindToSimpleType<TypeKind::VARBINARY> {
-  using type = Varbinary;
-};
-
 // Base case for primitives.
 template <TypeKind T>
 void copy_from_internal(GenericWriter& out, const GenericView& in) {

--- a/velox/expression/VectorWriters.h
+++ b/velox/expression/VectorWriters.h
@@ -526,9 +526,20 @@ struct VectorWriter<Generic<T, comparable, orderable>>
     }
   }
 
+  template <TypeKind kind>
+  void ensureCastedWriter() {
+    if constexpr (TypeTraits<kind>::isPrimitiveType) {
+      writer_.ensureWriter<typename KindToSimpleType<kind>::type>();
+    }
+  }
+
   void init(vector_t& vector) {
     vector_ = &vector;
     writer_.initialize(vector_);
+    if (vector.type()->isPrimitiveType()) {
+      TypeKind kind = vector.typeKind();
+      VELOX_DYNAMIC_TYPE_DISPATCH_ALL(ensureCastedWriter, kind);
+    }
   }
 
   void ensureSize(size_t size) override {

--- a/velox/expression/tests/GenericViewTest.cpp
+++ b/velox/expression/tests/GenericViewTest.cpp
@@ -756,7 +756,7 @@ struct ArrayHasDuplicateFunc {
       }
 
       if (set.count(*item)) {
-        // Item already exisits.
+        // Item already exists.
         out = true;
         return true;
       }

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -176,3 +176,8 @@ add_executable(velox_functions_prestosql_benchmarks_map_subscript
                MapSubscriptCachingBenchmark.cpp)
 target_link_libraries(velox_functions_prestosql_benchmarks_map_subscript
                       ${BENCHMARK_DEPENDENCIES})
+
+add_executable(velox_functions_prestosql_benchmarks_generic
+               GenericBenchmark.cpp)
+target_link_libraries(velox_functions_prestosql_benchmarks_generic
+                      ${BENCHMARK_DEPENDENCIES})

--- a/velox/functions/prestosql/benchmarks/GenericBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/GenericBenchmark.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
+#include "velox/expression/ComplexViewTypes.h"
+#include "velox/functions/Registerer.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/type/Type.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/DecodedVector.h"
+
+using namespace facebook::velox;
+
+namespace {
+// The following two functions is used to measure the cost of the cast of
+// generic view.
+
+// A function that takes array<X> and returns the summation as int64_t. For
+// simplicity is here handling double and int64_t.
+template <typename T>
+struct GenericInputArraySum {
+  template <typename TInput>
+  void call(int64_t& out, const TInput& arrayOfGeneric) {
+    out = 0;
+    if (arrayOfGeneric.elementKind() == TypeKind::DOUBLE) {
+      for (auto e : arrayOfGeneric) {
+        if (e.has_value()) {
+          out += e.value().template castTo<double>();
+        }
+      }
+    } else if (arrayOfGeneric.elementKind() == TypeKind::BIGINT) {
+      for (auto e : arrayOfGeneric) {
+        if (e.has_value()) {
+          out += e.value().template castTo<int64_t>();
+        }
+      }
+    } else {
+      out = 0;
+    }
+  }
+};
+
+template <typename T>
+struct TypedArraySum {
+  template <typename TInput>
+  void call(int64_t& out, const TInput& typedArray) {
+    out = 0;
+    for (auto e : typedArray) {
+      if (e.has_value()) {
+        out += e.value();
+      }
+    }
+  }
+};
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+
+  ExpressionBenchmarkBuilder benchmarkBuilder;
+
+  facebook::velox::registerFunction<GenericInputArraySum, int64_t, Array<Any>>(
+      {"generic_input_sum"});
+  facebook::velox::registerFunction<TypedArraySum, int64_t, Array<double>>(
+      {"typed_sum"});
+  facebook::velox::registerFunction<TypedArraySum, int64_t, Array<int64_t>>(
+      {"typed_sum"});
+
+  auto* pool = benchmarkBuilder.pool();
+  auto& vm = benchmarkBuilder.vectorMaker();
+
+  benchmarkBuilder
+      .addBenchmarkSet(
+          fmt::format("array_sum"),
+          ROW({"c0", "c1"}, {ARRAY(BIGINT()), ARRAY(DOUBLE())}))
+      .addExpression("generic_input_int", "generic_input_sum(c0)")
+      .addExpression("typed_int", "typed_sum(c0)")
+      .addExpression("generic_input_double", "generic_input_sum(c1)")
+      .addExpression("typed_double", "typed_sum(c1)");
+
+  benchmarkBuilder.registerBenchmarks();
+
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1901,6 +1901,21 @@ struct ConstantChecker {
       isConstantType<TArgs>::value...};
 };
 
+template <TypeKind kind>
+struct KindToSimpleType {
+  using type = typename TypeTraits<kind>::NativeType;
+};
+
+template <>
+struct KindToSimpleType<TypeKind::VARCHAR> {
+  using type = Varchar;
+};
+
+template <>
+struct KindToSimpleType<TypeKind::VARBINARY> {
+  using type = Varbinary;
+};
+
 template <typename T>
 struct SimpleTypeTrait {};
 


### PR DESCRIPTION
Summary:
When a generic represents a primitive there is only one valid castTo type, 
hence
1) We can ensure the casted writer at construction and simply read the casted type (no need to 
ensure on each invocation). 
2) No need to check that we are casting to the same type (since there is no one valid type, unlike for 
example when its array you can cast to array<int> or array<generic>.

More optimization will come next to make the registration for primitive fast path not needed in most 
cases.

before
```
array_sum##full_generic_int                               245.42ms      4.07
```
after
```
array_sum##full_generic_int                               141.58ms      7.06
```

When primitive fast path registration removed for array_concat.
before
```
array_concat_BOOLEAN_10##2arg                             633.41ms      1.58
array_concat_BOOLEAN_10##3arg                             950.59ms      1.05
array_concat_BOOLEAN_10##4arg                                1.49s   671.89m
array_concat_BOOLEAN_20##2arg                                1.47s   682.56m
array_concat_BOOLEAN_20##3arg                                2.26s   443.41m
array_concat_BOOLEAN_20##4arg                                2.97s   336.67m
array_concat_BOOLEAN_40##2arg                                2.78s   360.31m
array_concat_BOOLEAN_40##3arg                                4.22s   236.72m
array_concat_BOOLEAN_40##4arg                                5.93s   168.77m
array_concat_BOOLEAN_5##2arg                              366.07ms      2.73
array_concat_BOOLEAN_5##3arg                              581.12ms      1.72
array_concat_BOOLEAN_5##4arg                              771.37ms      1.30
array_concat_INTEGER_10##2arg                             563.68ms      1.77
array_concat_INTEGER_10##3arg                             868.29ms      1.15
array_concat_INTEGER_10##4arg                                1.37s   728.94m
array_concat_INTEGER_20##2arg                                1.36s   736.37m
array_concat_INTEGER_20##3arg                                1.80s   555.73m
array_concat_INTEGER_20##4arg                                2.44s   410.36m
array_concat_INTEGER_40##2arg                                2.31s   432.82m
array_concat_INTEGER_40##3arg                                3.59s   278.61m
array_concat_INTEGER_40##4arg                                5.00s   199.99m
array_concat_INTEGER_5##2arg                              322.62ms      3.10
array_concat_INTEGER_5##3arg                              519.79ms      1.92
array_concat_INTEGER_5##4arg                              667.87ms      1.50
array_concat_VARCHAR_10##2arg                                1.07s   935.79m
array_concat_VARCHAR_10##3arg                                1.57s   638.00m
array_concat_VARCHAR_10##4arg                                2.08s   479.78m
array_concat_VARCHAR_20##2arg                                3.10s   322.93m
array_concat_VARCHAR_20##3arg                                4.10s   244.09m
array_concat_VARCHAR_20##4arg                                5.24s   190.92m
array_concat_VARCHAR_40##2arg                                5.28s   189.57m
array_concat_VARCHAR_40##3arg                                9.40s   106.33m
array_concat_VARCHAR_40##4arg                               11.54s    86.63m
array_concat_VARCHAR_5##2arg                              489.14ms      2.04
array_concat_VARCHAR_5##3arg                              720.43ms      1.39
array_concat_VARCHAR_5##4arg                              967.95ms      1.03�
```
after
```
array_concat_BOOLEAN_10##2arg                             458.93ms      2.18
array_concat_BOOLEAN_10##3arg                             653.87ms      1.53
array_concat_BOOLEAN_10##4arg                                1.03s   971.88m
array_concat_BOOLEAN_20##2arg                                1.03s   970.26m
array_concat_BOOLEAN_20##3arg                                1.50s   668.59m
array_concat_BOOLEAN_20##4arg                                1.99s   502.25m
array_concat_BOOLEAN_40##2arg                                1.96s   511.39m
array_concat_BOOLEAN_40##3arg                                2.85s   350.31m
array_concat_BOOLEAN_40##4arg                                4.02s   248.60m
array_concat_BOOLEAN_5##2arg                              269.55ms      3.71
array_concat_BOOLEAN_5##3arg                              407.40ms      2.45
array_concat_BOOLEAN_5##4arg                              541.61ms      1.85
array_concat_INTEGER_10##2arg                             382.28ms      2.62
array_concat_INTEGER_10##3arg                             572.88ms      1.75
array_concat_INTEGER_10##4arg                             819.01ms      1.22
array_concat_INTEGER_20##2arg                             726.46ms      1.38
array_concat_INTEGER_20##3arg                                1.11s   897.79m
array_concat_INTEGER_20##4arg                                1.47s   681.52m
array_concat_INTEGER_40##2arg                                1.39s   718.86m
array_concat_INTEGER_40##3arg                                2.18s   458.49m
array_concat_INTEGER_40##4arg                                3.15s   317.62m
array_concat_INTEGER_5##2arg                              197.05ms      5.07
array_concat_INTEGER_5##3arg                              302.67ms      3.30
array_concat_INTEGER_5##4arg                              422.73ms      2.37
array_concat_VARCHAR_10##2arg                             817.54ms      1.22
array_concat_VARCHAR_10##3arg                                1.20s   830.08m
array_concat_VARCHAR_10##4arg                                1.65s   604.71m
array_concat_VARCHAR_20##2arg                                2.45s   408.37m
array_concat_VARCHAR_20##3arg                                3.10s   322.51m
array_concat_VARCHAR_20##4arg                                4.00s   249.86m
array_concat_VARCHAR_40##2arg                                4.71s   212.29m
array_concat_VARCHAR_40##3arg                                8.23s   121.45m
array_concat_VARCHAR_40##4arg                                9.16s   109.12m
array_concat_VARCHAR_5##2arg                              377.03ms      2.65
array_concat_VARCHAR_5##3arg                              566.50ms      1.77
array_concat_VARCHAR_5##4arg                              742.47ms      1.35
```

Reviewed By: Yuhta

Differential Revision: D52391871


