### PR TITLE
Fix SharedArbitrator.taskWaitTimeout

### DIFF
--- a/velox/exec/tests/SharedArbitratorTest.cpp
+++ b/velox/exec/tests/SharedArbitratorTest.cpp
@@ -2805,7 +2805,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, taskWaitTimeout) {
   const int queryMemoryCapacity = 128 << 20;
   // Creates a large number of vectors based on the query capacity to trigger
   // memory arbitration.
-  const auto vectors = createVectors(rowType_, 1'000, queryMemoryCapacity / 2);
+  const auto vectors = createVectors(rowType_, 10'000, queryMemoryCapacity / 2);
   const int numDrivers = 4;
   const auto expectedResult =
       runHashJoinTask(vectors, nullptr, numDrivers, false).data;


### PR DESCRIPTION
PR https://github.com/facebookincubator/velox/pull/8182 made the test vector having a default string length of 50 compared with previous value 1024. The size change made the test not able to trigger arbitration, hence hanging at waiting for request pause in Task::reclaim forever. Increasing the vector size from 1000 to 10k allows arbitration to happen and hence fix the test