### PR TITLE
Add VectorFuzzer::Options in VectorTestBase::createVectors

### DIFF
--- a/velox/exec/tests/SharedArbitratorTest.cpp
+++ b/velox/exec/tests/SharedArbitratorTest.cpp
@@ -1152,7 +1152,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimFromAggregation) {
 TEST_F(SharedArbitrationTest, reclaimFromDistinctAggregation) {
   const uint64_t maxQueryCapacity = 20L << 20;
   std::vector<RowVectorPtr> vectors =
-      createVectors(rowType_, 1024, maxQueryCapacity * 2);
+      createVectors(rowType_, 1024, maxQueryCapacity * 2, fuzzerOpts_);
   createDuckDbTable(vectors);
   const auto spillDirectory = exec::test::TempDirectoryPath::create();
   core::PlanNodeId aggrNodeId;
@@ -1854,7 +1854,7 @@ TEST_F(SharedArbitrationTest, reclaimFromCompletedJoinBuilder) {
 }
 
 TEST_F(SharedArbitrationTest, reclaimFromJoinBuilderWithMultiDrivers) {
-  const auto vectors = createVectors(rowType_, 256, 64 << 20);
+  const auto vectors = createVectors(rowType_, 256, 64 << 20, fuzzerOpts_);
   const int numDrivers = 4;
   const auto expectedResult =
       runHashJoinTask(vectors, nullptr, numDrivers, false).data;
@@ -1874,7 +1874,7 @@ TEST_F(SharedArbitrationTest, reclaimFromJoinBuilderWithMultiDrivers) {
 DEBUG_ONLY_TEST_F(
     SharedArbitrationTest,
     failedToReclaimFromHashJoinBuildersInNonReclaimableSection) {
-  const auto vectors = createVectors(rowType_, 256, 32 << 10);
+  const auto vectors = createVectors(rowType_, 256, 32 << 10, fuzzerOpts_);
   const int numDrivers = 1;
   std::shared_ptr<core::QueryCtx> queryCtx = newQueryCtx(kMemoryCapacity);
   const auto expectedResult =
@@ -1942,7 +1942,7 @@ DEBUG_ONLY_TEST_F(
     SharedArbitrationTest,
     reclaimFromHashJoinBuildInWaitForTableBuild) {
   setupMemory(kMemoryCapacity, 0);
-  const auto vectors = createVectors(rowType_, 256, 32 << 10);
+  const auto vectors = createVectors(rowType_, 256, 32 << 10, fuzzerOpts_);
   const int numDrivers = 4;
   const auto expectedResult =
       runHashJoinTask(vectors, nullptr, numDrivers, false).data;
@@ -2694,7 +2694,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, raceBetweenWriterCloseAndTaskReclaim) {
   const uint64_t memoryCapacity = 512 * MB;
   setupMemory(memoryCapacity);
   std::vector<RowVectorPtr> vectors =
-      createVectors(rowType_, 1'000, memoryCapacity / 8);
+      createVectors(rowType_, 1'000, memoryCapacity / 8, fuzzerOpts_);
   const auto expectedResult = runWriteTask(vectors, nullptr, 1, false).data;
 
   std::shared_ptr<core::QueryCtx> queryCtx = newQueryCtx(memoryCapacity);
@@ -2805,7 +2805,8 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, taskWaitTimeout) {
   const int queryMemoryCapacity = 128 << 20;
   // Creates a large number of vectors based on the query capacity to trigger
   // memory arbitration.
-  const auto vectors = createVectors(rowType_, 10'000, queryMemoryCapacity / 2);
+  const auto vectors =
+      createVectors(rowType_, 10'000, queryMemoryCapacity / 2, fuzzerOpts_);
   const int numDrivers = 4;
   const auto expectedResult =
       runHashJoinTask(vectors, nullptr, numDrivers, false).data;

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -131,10 +131,8 @@ class VectorTestBase {
 
   std::vector<RowVectorPtr> createVectors(
       const RowTypePtr& type,
-      size_t vectorSize,
       uint64_t byteSize,
-      VectorFuzzer::Options fuzzerOpts = {}) {
-    fuzzerOpts.vectorSize = vectorSize;
+      const VectorFuzzer::Options& fuzzerOpts) {
     VectorFuzzer fuzzer(fuzzerOpts, pool());
     uint64_t totalSize{0};
     std::vector<RowVectorPtr> vectors;
@@ -143,6 +141,11 @@ class VectorTestBase {
       totalSize += vectors.back()->estimateFlatSize();
     }
     return vectors;
+  }
+
+  std::vector<RowVectorPtr>
+  createVectors(const RowTypePtr& type, size_t vectorSize, uint64_t byteSize) {
+    return createVectors(type, byteSize, {.vectorSize = vectorSize});
   }
 
   /// Splits input vector into 'n' vectors evenly. Input vector must have at

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -129,9 +129,13 @@ class VectorTestBase {
     return vectorMaker_.rowVector(rowType, size);
   }
 
-  std::vector<RowVectorPtr>
-  createVectors(const RowTypePtr& type, size_t vectorSize, uint64_t byteSize) {
-    VectorFuzzer fuzzer({.vectorSize = vectorSize}, pool());
+  std::vector<RowVectorPtr> createVectors(
+      const RowTypePtr& type,
+      size_t vectorSize,
+      uint64_t byteSize,
+      VectorFuzzer::Options fuzzerOpts = {}) {
+    fuzzerOpts.vectorSize = vectorSize;
+    VectorFuzzer fuzzer(fuzzerOpts, pool());
     uint64_t totalSize{0};
     std::vector<RowVectorPtr> vectors;
     while (totalSize < byteSize) {


### PR DESCRIPTION
The `VectorTestBase::createVectors` API may create
vectors that are not big enough to trigger arbitration,
and caused a timeout issue #8195 or a flakey issue in #8196.
Add a `VectorFuzzer::Options` parameter in the API to control
the vector generation.

Resolve https://github.com/facebookincubator/velox/issues/8196