### PR TITLE
Guard against AppendWindow destructor throw

### DIFF
--- a/velox/common/memory/tests/ByteStreamTest.cpp
+++ b/velox/common/memory/tests/ByteStreamTest.cpp
@@ -326,10 +326,14 @@ TEST_F(ByteStreamTest, bits) {
 }
 
 TEST_F(ByteStreamTest, appendWindow) {
+  // A littel over 1MB. We must test appendss that involve multiple extend()
+  // calls for one window.
+  constexpr int32_t kNumWords = 140000;
   Scratch scratch;
   std::vector<uint64_t> words;
   uint64_t seed = 0x12345689abcdefLLU;
-  for (auto i = 0; i < 1000; ++i) {
+  words.reserve(kNumWords);
+  for (auto i = 0; i < kNumWords; ++i) {
     words.push_back(seed * (i + 1));
   }
   auto arena = newArena();
@@ -339,13 +343,21 @@ TEST_F(ByteStreamTest, appendWindow) {
   std::vector<int32_t> sizes = {1, 19, 52, 58, 129};
   int32_t counter = 0;
   while (offset < words.size()) {
-    auto numWords =
-        std::min<int32_t>(words.size() - offset, sizes[counter % sizes.size()]);
-    AppendWindow<uint64_t> window(stream, scratch);
-    auto ptr = window.get(numWords);
-    memcpy(ptr, words.data() + offset, numWords * sizeof(words[0]));
-    offset += numWords;
-    ++counter;
+    // there is one large window that spans multiple extend() calls.
+    auto numWords = std::min<int32_t>(
+        words.size() - offset,
+        (counter == 2 ? 130000 : sizes[counter % sizes.size()]));
+    int32_t bytes = -1;
+    {
+      AppendWindow<uint64_t> window(stream, scratch);
+      auto ptr = window.get(numWords);
+      bytes = arena->pool()->currentBytes();
+      memcpy(ptr, words.data() + offset, numWords * sizeof(words[0]));
+      offset += numWords;
+      ++counter;
+    }
+    // We check that there is no allocation at exit of AppendWindow block.k
+    EXPECT_EQ(arena->pool()->currentBytes(), bytes);
   }
   std::stringstream stringStream;
   OStreamOutputStream out(&stringStream);


### PR DESCRIPTION
AppendWindow is a scoped guard over a fixed size append to a ByteStream. If the ByteStream does not have space, then a scratch piece of memory is used to provide contiguous space and is then appended to the ByteStream on exit. This last append may however fail. This may throw from stack unwinding and kill the process.

To prevent this, we ensure that all the memory is available at AppendWindow construction time. The destructor cannot throw because of failure to extend the stream. We add a LOG(FATAL) to mark the unreachable throw from destructor.