### PR TITLE
Fix memory leak bug when directbufferedinput is enabled

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -226,6 +226,10 @@ class DataSource {
   virtual int64_t estimatedRowSize() {
     return kUnknownRowSize;
   }
+
+  /// Clean up the resources associated with this data source, called when the
+  /// pipeline is finished.
+  virtual void close() {}
 };
 
 /// Collection of context data for use in a DataSource or DataSink. One instance

--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -239,6 +239,7 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
   VLOG(1) << "Adding split " << split_->toString();
 
   if (splitReader_) {
+    splitReader_->close();
     splitReader_.reset();
   }
 

--- a/velox/connectors/hive/HiveDataSource.h
+++ b/velox/connectors/hive/HiveDataSource.h
@@ -80,6 +80,12 @@ class HiveDataSource : public DataSource {
       bool negated,
       SubfieldFilters& filters);
 
+  void close() override {
+    if (splitReader_) {
+      splitReader_->close();
+    }
+  }
+
  protected:
   virtual std::unique_ptr<SplitReader> createSplitReader();
 

--- a/velox/connectors/hive/HiveDataSource.h
+++ b/velox/connectors/hive/HiveDataSource.h
@@ -80,11 +80,7 @@ class HiveDataSource : public DataSource {
       bool negated,
       SubfieldFilters& filters);
 
-  void close() override {
-    if (splitReader_) {
-      splitReader_->close();
-    }
-  }
+  void close() override;
 
  protected:
   virtual std::unique_ptr<SplitReader> createSplitReader();

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -306,6 +306,9 @@ void SplitReader::close() {
   if (baseReader_) {
     baseReader_->close();
   }
+  if (baseRowReader_) {
+    baseRowReader_->close();
+  }
 }
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -302,6 +302,12 @@ std::string SplitReader::toString() const {
       static_cast<const void*>(baseRowReader_.get()));
 }
 
+void SplitReader::close() {
+  if (baseReader_) {
+    baseReader_->close();
+  }
+}
+
 } // namespace facebook::velox::connector::hive
 
 template <>

--- a/velox/connectors/hive/SplitReader.h
+++ b/velox/connectors/hive/SplitReader.h
@@ -108,6 +108,8 @@ class SplitReader {
 
   std::string toString() const;
 
+  void close();
+
  protected:
   // Different table formats may have different meatadata columns. This function
   // will be used to update the scanSpec for these columns.

--- a/velox/dwio/common/BufferedInput.h
+++ b/velox/dwio/common/BufferedInput.h
@@ -145,6 +145,8 @@ class BufferedInput {
     return 0;
   }
 
+  virtual void close() {}
+
  protected:
   std::shared_ptr<ReadFileInputStream> input_;
   memory::MemoryPool& pool_;

--- a/velox/dwio/common/CachedBufferedInput.h
+++ b/velox/dwio/common/CachedBufferedInput.h
@@ -98,11 +98,9 @@ class CachedBufferedInput : public BufferedInput {
         fileSize_(input_->getLength()),
         options_(readerOptions) {}
 
-  ~CachedBufferedInput() override {
-    for (auto& load : allCoalescedLoads_) {
-      load->cancel();
-    }
-  }
+  ~CachedBufferedInput() override;
+
+  void close() override;
 
   std::unique_ptr<SeekableInputStream> enqueue(
       velox::common::Region region,

--- a/velox/dwio/common/DirectBufferedInput.h
+++ b/velox/dwio/common/DirectBufferedInput.h
@@ -124,11 +124,9 @@ class DirectBufferedInput : public BufferedInput {
         fileSize_(input_->getLength()),
         options_(readerOptions) {}
 
-  ~DirectBufferedInput() override {
-    for (auto& load : coalescedLoads_) {
-      load->cancel();
-    }
-  }
+  ~DirectBufferedInput() override;
+
+  void close() override;
 
   std::unique_ptr<SeekableInputStream> enqueue(
       velox::common::Region region,

--- a/velox/dwio/common/Reader.h
+++ b/velox/dwio/common/Reader.h
@@ -196,6 +196,9 @@ class Reader {
    */
   virtual std::unique_ptr<RowReader> createRowReader(
       const RowReaderOptions& options = {}) const = 0;
+
+  /// Invoked on finish to clean up the resource held by this reader.
+  virtual void close() = 0;
 };
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/Reader.h
+++ b/velox/dwio/common/Reader.h
@@ -45,6 +45,8 @@ class RowReader {
 
   virtual ~RowReader() = default;
 
+  virtual void close() {}
+
   /**
    * Fetch the next portion of rows.
    * @param size Max number of rows to read

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -106,6 +106,10 @@ DwrfRowReader::DwrfRowReader(
       std::vector<FetchStatus>(numberOfStripes, FetchStatus::NOT_STARTED));
 }
 
+void DwrfRowReader::close() {
+  StripeReaderBase::close();
+}
+
 uint64_t DwrfRowReader::seekToRow(uint64_t rowNumber) {
   // Empty file
   if (isEmptyFile()) {
@@ -1097,6 +1101,13 @@ std::unique_ptr<DwrfRowReader> DwrfReader::createDwrfRowReader(
     rowReader->startNextStripe();
   }
   return rowReader;
+}
+
+void DwrfReader::close() {
+  if (readerBase_) {
+    readerBase_->close();
+    readerBase_.reset();
+  }
 }
 
 std::unique_ptr<DwrfReader> DwrfReader::create(

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -40,6 +40,8 @@ class DwrfRowReader : public StrideIndexProvider,
 
   ~DwrfRowReader() override = default;
 
+  void close() override;
+
   // Select the columns from the options object
   const dwio::common::ColumnSelector& getColumnSelector() const {
     return *columnSelector_;
@@ -235,6 +237,8 @@ class DwrfReader : public dwio::common::Reader {
 
   ~DwrfReader() override = default;
 
+  void close() override;
+
   common::CompressionKind getCompression() const {
     return readerBase_->getCompressionKind();
   }
@@ -332,13 +336,6 @@ class DwrfReader : public dwio::common::Reader {
 
   std::unique_ptr<DwrfRowReader> createDwrfRowReader(
       const dwio::common::RowReaderOptions& options = {}) const;
-
-  void close() override {
-    if (readerBase_) {
-      readerBase_->close();
-      readerBase_.reset();
-    }
-  }
 
   /**
    * Create a reader to the for the dwrf file.

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -333,6 +333,13 @@ class DwrfReader : public dwio::common::Reader {
   std::unique_ptr<DwrfRowReader> createDwrfRowReader(
       const dwio::common::RowReaderOptions& options = {}) const;
 
+  void close() override {
+    if (readerBase_) {
+      readerBase_->close();
+      readerBase_.reset();
+    }
+  }
+
   /**
    * Create a reader to the for the dwrf file.
    * @param stream the stream to read

--- a/velox/dwio/dwrf/reader/ReaderBase.h
+++ b/velox/dwio/dwrf/reader/ReaderBase.h
@@ -231,6 +231,13 @@ class ReaderBase {
     return postScript_->format();
   }
 
+  void close() {
+    if (input_) {
+      input_->close();
+      input_.reset();
+    }
+  }
+
  private:
   static std::shared_ptr<const Type> convertType(
       const FooterWrapper& footer,

--- a/velox/dwio/dwrf/reader/StripeReaderBase.cpp
+++ b/velox/dwio/dwrf/reader/StripeReaderBase.cpp
@@ -20,6 +20,19 @@ namespace facebook::velox::dwrf {
 
 using dwio::common::LogType;
 
+void StripeReaderBase::close() {
+  if (stripeInput_) {
+    stripeInput_->close();
+  }
+  auto it = prefetchedStripes_.rlock()->begin();
+  while (it != prefetchedStripes_.rlock()->end()) {
+    if (it->second) {
+      it->second->stripeInput->close();
+    }
+    it++;
+  }
+}
+
 // preload is not considered or mutated if stripe has already been fetched. e.g.
 // if fetchStripe(0, false) is called, result will be cached and fetchStripe(0,
 // true) will reuse the result without considering the new preload directive

--- a/velox/dwio/dwrf/reader/StripeReaderBase.h
+++ b/velox/dwio/dwrf/reader/StripeReaderBase.h
@@ -44,7 +44,7 @@ class StripeReaderBase {
     DWIO_ENSURE(stripeFooter->GetArena());
   }
 
-  virtual ~StripeReaderBase() = default;
+  void close();
 
   // Set state to be ready for next stripe, loading stripe information if not
   // prefetched

--- a/velox/dwio/dwrf/test/DirectBufferedInputTest.cpp
+++ b/velox/dwio/dwrf/test/DirectBufferedInputTest.cpp
@@ -97,6 +97,7 @@ class DirectBufferedInputTest : public testing::Test {
       }
     }
     EXPECT_EQ(numIos, file_->numIos() - previous);
+    input->close();
   }
 
   // Marks the numStreams first streams as densely read. A large number of

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -84,6 +84,8 @@ class ReaderBase {
   /// the data still exists in the buffered inputs.
   bool isRowGroupBuffered(int32_t rowGroupIndex) const;
 
+  void close();
+
  private:
   // Reads and parses file footer.
   void loadFileMetaData();
@@ -137,6 +139,18 @@ ReaderBase::ReaderBase(
 
   loadFileMetaData();
   initializeSchema();
+}
+
+void ReaderBase::close() {
+  if (input_) {
+    input_->close();
+    input_.reset();
+  }
+  for (auto& input : inputs_) {
+    input.second->close();
+    input.second.reset();
+  }
+  inputs_.clear();
 }
 
 void ReaderBase::loadFileMetaData() {
@@ -874,6 +888,12 @@ std::unique_ptr<dwio::common::RowReader> ParquetReader::createRowReader(
 
 FileMetaDataPtr ParquetReader::fileMetaData() const {
   return readerBase_->fileMetaData();
+}
+
+void ParquetReader::close() {
+  if (readerBase_) {
+    readerBase_->close();
+  }
 }
 
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/ParquetReader.h
+++ b/velox/dwio/parquet/reader/ParquetReader.h
@@ -105,6 +105,8 @@ class ParquetReader : public dwio::common::Reader {
 
   FileMetaDataPtr fileMetaData() const;
 
+  void close() override;
+
  private:
   std::shared_ptr<ReaderBase> readerBase_;
 };

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -341,4 +341,13 @@ void TableScan::addDynamicFilter(
   pendingDynamicFilters_.emplace(outputChannel, filter);
 }
 
+void TableScan::close() {
+  if (dataSource_) {
+    dataSource_->close();
+    dataSource_.reset();
+  }
+  pendingDynamicFilters_.clear();
+  Operator::close();
+}
+
 } // namespace facebook::velox::exec

--- a/velox/exec/TableScan.h
+++ b/velox/exec/TableScan.h
@@ -56,6 +56,8 @@ class TableScan : public SourceOperator {
     return ioWaitNanos_;
   }
 
+  void close() override;
+
  private:
   // Sets 'maxPreloadSplits' and 'splitPreloader' if prefetching
   // splits is appropriate. The preloader will be applied to the


### PR DESCRIPTION
Fix issue #8204 

The root cause is the speculative fetch of DirectBufferedInput. Like if we have a SQL:

`select A where B=0`

It may prefetch ColumnChunk A where all B acually isn't 0. Then when the task finished, the fetch is still pending and hold the memory block.

The solution is to wait all pending requests finish before descror return.