### PR TITLE
Switch boost site to archives.boost.io in setup-centos8.sh

### DIFF
--- a/scripts/setup-centos8.sh
+++ b/scripts/setup-centos8.sh
@@ -66,7 +66,7 @@ function wget_and_untar {
 wget_and_untar https://github.com/gflags/gflags/archive/v2.2.2.tar.gz gflags &
 wget_and_untar https://github.com/google/glog/archive/v0.4.0.tar.gz glog &
 wget_and_untar http://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz lzo &
-wget_and_untar  https://archives.boost.io/release/1.72.0/source/boost_1_72_0.tar.gz boost &
+wget_and_untar https://archives.boost.io/release/1.72.0/source/boost_1_72_0.tar.gz boost &
 wget_and_untar https://github.com/google/snappy/archive/1.1.8.tar.gz snappy &
 wget_and_untar https://github.com/fmtlib/fmt/archive/8.0.1.tar.gz fmt &
 

--- a/scripts/setup-centos8.sh
+++ b/scripts/setup-centos8.sh
@@ -66,7 +66,7 @@ function wget_and_untar {
 wget_and_untar https://github.com/gflags/gflags/archive/v2.2.2.tar.gz gflags &
 wget_and_untar https://github.com/google/glog/archive/v0.4.0.tar.gz glog &
 wget_and_untar http://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz lzo &
-wget_and_untar https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.gz boost &
+wget_and_untar  https://archives.boost.io/release/1.72.0/source/boost_1_72_0.tar.gz boost &
 wget_and_untar https://github.com/google/snappy/archive/1.1.8.tar.gz snappy &
 wget_and_untar https://github.com/fmtlib/fmt/archive/8.0.1.tar.gz fmt &
 


### PR DESCRIPTION
Change boost site from `boostorg.jfrog.io` to `archives.boost.io`

Resolves #8207 