### PR TITLE
Add physicalWrittenBytes to PlanNodeStats

### DIFF
--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -54,6 +54,8 @@ void PlanNodeStats::addTotals(const OperatorStats& stats) {
   peakMemoryBytes += stats.memoryStats.peakTotalMemoryReservation;
   numMemoryAllocations += stats.memoryStats.numMemoryAllocations;
 
+  physicalWrittenBytes += stats.physicalWrittenBytes;
+
   for (const auto& [name, runtimeStats] : stats.runtimeStats) {
     if (UNLIKELY(customStats.count(name) == 0)) {
       customStats.insert(std::make_pair(name, runtimeStats));
@@ -154,6 +156,7 @@ folly::dynamic toPlanStatsJson(const facebook::velox::exec::TaskStats& stats) {
       stat["blockedWallNanos"] = operatorStat.second->blockedWallNanos;
       stat["peakMemoryBytes"] = operatorStat.second->peakMemoryBytes;
       stat["numMemoryAllocations"] = operatorStat.second->numMemoryAllocations;
+      stat["physicalWrittenBytes"] = operatorStat.second->physicalWrittenBytes;
       stat["numDrivers"] = operatorStat.second->numDrivers;
       stat["numSplits"] = operatorStat.second->numSplits;
       stat["spilledInputBytes"] = operatorStat.second->spilledInputBytes;

--- a/velox/exec/PlanNodeStats.h
+++ b/velox/exec/PlanNodeStats.h
@@ -92,6 +92,8 @@ struct PlanNodeStats {
 
   uint64_t numMemoryAllocations{0};
 
+  uint64_t physicalWrittenBytes{0};
+
   /// Operator-specific counters.
   std::unordered_map<std::string, RuntimeMetric> customStats;
 

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -2953,6 +2953,7 @@ TEST_P(AllTableWriterTest, tableWriterStats) {
 
   auto planStats = exec::toPlanStats(task->taskStats());
   auto& stats = planStats.at(tableWriteNodeId_);
+  ASSERT_GT(stats.physicalWrittenBytes, fixedWrittenBytes);
   ASSERT_GT(
       stats.operatorStats.at("TableWrite")->physicalWrittenBytes,
       fixedWrittenBytes);

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -2953,13 +2953,14 @@ TEST_P(AllTableWriterTest, tableWriterStats) {
 
   auto planStats = exec::toPlanStats(task->taskStats());
   auto& stats = planStats.at(tableWriteNodeId_);
-  for (const auto& entry : stats.operatorStats) {
-    if (entry.first == "TableWrite") {
-      ASSERT_GT(entry.second->physicalWrittenBytes, fixedWrittenBytes);
-      ASSERT_EQ(
-          entry.second->customStats.at("numWrittenFiles").sum, numWrittenFiles);
-    }
-  }
+  ASSERT_GT(
+      stats.operatorStats.at("TableWrite")->physicalWrittenBytes,
+      fixedWrittenBytes);
+  ASSERT_EQ(
+      stats.operatorStats.at("TableWrite")
+          ->customStats.at("numWrittenFiles")
+          .sum,
+      numWrittenFiles);
 }
 
 DEBUG_ONLY_TEST_P(


### PR DESCRIPTION
The physicalWrittenBytes metric is available in the OperatorStats class, but not
in the PlanNodeStats. When accessing metrics from Task::taskStats(), we are
unable to retrieve the physicalWrittenBytes' value. 

Ad physicalWrittenBytes metric to PlanNodeStats.