### PR TITLE
Fix build for devtoolset-9 on CentOS 7

### DIFF
--- a/velox/exec/tests/AggregateFunctionRegistryTest.cpp
+++ b/velox/exec/tests/AggregateFunctionRegistryTest.cpp
@@ -266,7 +266,7 @@ TEST_F(FunctionRegistryTest, multipleNames) {
       "aggregate_func2", {BIGINT(), DOUBLE()}, BIGINT(), ARRAY(BIGINT()));
 
   auto registrationResults = registerAggregateFunction(
-      {std::string("aggregate_func2"), std::string("aggregate_func3")},
+      std::vector<std::string>{"aggregate_func2", "aggregate_func3"},
       signatures,
       factory,
       /*registerCompanionFunctions*/ true,


### PR DESCRIPTION
devtoolset-9 has some issue on choosing the right template when building unit tests

```
/root/velox/velox/exec/tests/AggregateFunctionRegistryTest.cpp: In member function 'virtual void facebook::velox::exec::test::FunctionRegistryTest_multipleNames_Test::TestBody()':
/root/velox/velox/exec/tests/AggregateFunctionRegistryTest.cpp:273:26: error: call of overloaded 'registerAggregateFunction(<brace-enclosed initializer list>, std::vector<std::shared_ptr<facebook::velox::exec::AggregateFunctionSignature> >&, facebook::velox::exec::test::FunctionRegistryTest_multipleNames_Test::TestBody()::<lambda(facebook::velox::core::AggregationNode::Step, const std::vector<std::shared_ptr<const facebook::velox::Type> >&, const TypePtr&, const facebook::velox::core::QueryConfig&)>&, bool, bool)' is ambiguous
  273 |       /*overwrite*/ false);
      |                          ^
In file included from /root/velox/velox/exec/tests/AggregateFunctionRegistryTest.cpp:19:
/root/velox/./velox/exec/Aggregate.h:421:29: note: candidate: 'facebook::velox::exec::AggregateRegistrationResult facebook::velox::exec::registerAggregateFunction(const string&, const std::vector<std::shared_ptr<facebook::velox::exec::AggregateFunctionSignature> >&, const AggregateFunctionFactory&, bool, bool)'
  421 | AggregateRegistrationResult registerAggregateFunction(
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~
/root/velox/./velox/exec/Aggregate.h:430:42: note: candidate: 'std::vector<facebook::velox::exec::AggregateRegistrationResult> facebook::velox::exec::registerAggregateFunction(const std::vector<std::basic_string<char> >&, const std::vector<std::shared_ptr<facebook::velox::exec::AggregateFunctionSignature> >&, const AggregateFunctionFactory&, bool, bool)'
  430 | std::vector<AggregateRegistrationResult> registerAggregateFunction(
      |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~
````