### PR TITLE
Update GCC minimum version to 9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,10 +466,10 @@ endif()
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
   set(FILESYSTEM "stdc++fs")
 
-  # Ensure we have gcc at least 8+.
-  if(CMAKE_CXX_COMPILER_VERSION LESS 8.0)
+  # Ensure we have gcc at least 9+.
+  if(CMAKE_CXX_COMPILER_VERSION LESS 9.0)
     message(
-      FATAL_ERROR "VELOX requires gcc > 8. Found ${CMAKE_CXX_COMPILER_VERSION}")
+      FATAL_ERROR "VELOX requires gcc > 9. Found ${CMAKE_CXX_COMPILER_VERSION}")
   endif()
 
   # Find Threads library

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Run `make` in the root directory to compile the sources. For development, use
 an optimized version.  Use `make unittest` to build and run tests.
 
 Note that,
-* Velox requires C++17 , thus minimum supported compiler is GCC 5.0 and Clang 5.0.
+* Velox requires a compiler at the minimum GCC 9.0 or Clang 14.0.
 * Velox requires the CPU to support instruction sets:
   * bmi
   * bmi2


### PR DESCRIPTION
I faced some build issues on Centos8 which comes with GCC 8.x as the default.
Using a 9.x version resolved the build issues. We should update the CMake file to reflect this.