### PR TITLE
Use simdjson in cast from JSON operator

### DIFF
--- a/velox/functions/prestosql/SIMDJsonFunctions.h
+++ b/velox/functions/prestosql/SIMDJsonFunctions.h
@@ -175,6 +175,14 @@ struct SIMDJsonExtractScalarFunction {
       out_type<Varchar>& result,
       const arg_type<Json>& json,
       const arg_type<Varchar>& jsonPath) {
+    return callImpl(result, json, jsonPath) == simdjson::SUCCESS;
+  }
+
+ private:
+  FOLLY_ALWAYS_INLINE bool callImpl(
+      out_type<Varchar>& result,
+      const arg_type<Json>& json,
+      const arg_type<Varchar>& jsonPath) {
     bool resultPopulated = false;
     std::optional<std::string> resultStr;
     auto consumer = [&resultStr, &resultPopulated](auto& v) {
@@ -182,7 +190,7 @@ struct SIMDJsonExtractScalarFunction {
         // We should just get a single value, if we see multiple, it's an error
         // and we should return null.
         resultStr = std::nullopt;
-        return true;
+        return simdjson::SUCCESS;
       }
 
       resultPopulated = true;
@@ -207,19 +215,16 @@ struct SIMDJsonExtractScalarFunction {
           SIMDJSON_ASSIGN_OR_RAISE(resultStr, simdjson::to_json_string(v));
         }
       }
-      return true;
+      return simdjson::SUCCESS;
     };
 
-    if (!simdJsonExtract(json, jsonPath, consumer)) {
-      // If there's an error parsing the JSON, return null.
-      return false;
-    }
+    SIMDJSON_TRY(simdJsonExtract(json, jsonPath, consumer));
 
     if (resultStr.has_value()) {
       result.copy_from(*resultStr);
-      return true;
+      return simdjson::SUCCESS;
     } else {
-      return false;
+      return simdjson::NO_SUCH_FIELD;
     }
   }
 };
@@ -229,6 +234,14 @@ struct SIMDJsonExtractFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   bool call(
+      out_type<Json>& result,
+      const arg_type<Json>& json,
+      const arg_type<Varchar>& jsonPath) {
+    return callImpl(result, json, jsonPath) == simdjson::SUCCESS;
+  }
+
+ private:
+  simdjson::error_code callImpl(
       out_type<Json>& result,
       const arg_type<Json>& json,
       const arg_type<Varchar>& jsonPath) {
@@ -268,17 +281,14 @@ struct SIMDJsonExtractFunction {
           results += kNullString;
           break;
       }
-      return true;
+      return simdjson::SUCCESS;
     };
 
-    if (!simdJsonExtract(json, jsonPath, consumer)) {
-      // If there's an error parsing the JSON, return null.
-      return false;
-    }
+    SIMDJSON_TRY(simdJsonExtract(json, jsonPath, consumer));
 
     if (resultSize == 0) {
       // If the path didn't map to anything in the JSON object, return null.
-      return false;
+      return simdjson::NO_SUCH_FIELD;
     }
 
     if (resultSize == 1) {
@@ -289,7 +299,7 @@ struct SIMDJsonExtractFunction {
       // Add the square brackets to make it a valid JSON array.
       result.copy_from("[" + results + "]");
     }
-    return true;
+    return simdjson::SUCCESS;
   }
 };
 
@@ -298,6 +308,14 @@ struct SIMDJsonSizeFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE bool call(
+      int64_t& result,
+      const arg_type<Json>& json,
+      const arg_type<Varchar>& jsonPath) {
+    return callImpl(result, json, jsonPath) == simdjson::SUCCESS;
+  }
+
+ private:
+  FOLLY_ALWAYS_INLINE simdjson::error_code callImpl(
       int64_t& result,
       const arg_type<Json>& json,
       const arg_type<Varchar>& jsonPath) {
@@ -328,22 +346,19 @@ struct SIMDJsonSizeFunction {
             break;
         }
       }
-      return true;
+      return simdjson::SUCCESS;
     };
 
-    if (!simdJsonExtract(json, jsonPath, consumer)) {
-      // If there's an error parsing the JSON, return null.
-      return false;
-    }
+    SIMDJSON_TRY(simdJsonExtract(json, jsonPath, consumer));
 
     if (resultCount == 0) {
       // If the path didn't map to anything in the JSON object, return null.
-      return false;
+      return simdjson::NO_SUCH_FIELD;
     }
 
     result = resultCount == 1 ? singleResultSize : resultCount;
 
-    return true;
+    return simdjson::SUCCESS;
   }
 };
 

--- a/velox/functions/prestosql/json/CMakeLists.txt
+++ b/velox/functions/prestosql/json/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 add_library(velox_functions_json JsonExtractor.cpp JsonPathTokenizer.cpp
-                                 SIMDJsonExtractor.cpp)
+                                 SIMDJsonExtractor.cpp SIMDJsonUtil.cpp)
 
 target_link_libraries(velox_functions_json velox_exception Folly::folly
                       simdjson::simdjson)

--- a/velox/functions/prestosql/json/SIMDJsonExtractor.cpp
+++ b/velox/functions/prestosql/json/SIMDJsonExtractor.cpp
@@ -42,12 +42,6 @@ namespace facebook::velox::functions::detail {
   return *it.first->second;
 }
 
-simdjson::simdjson_result<simdjson::ondemand::document>
-SIMDJsonExtractor::parse(const simdjson::padded_string& json) {
-  thread_local static simdjson::ondemand::parser parser;
-  return parser.iterate(json);
-}
-
 bool SIMDJsonExtractor::tokenize(const std::string& path) {
   thread_local static JsonPathTokenizer tokenizer;
 
@@ -71,7 +65,7 @@ bool SIMDJsonExtractor::tokenize(const std::string& path) {
   return true;
 }
 
-bool extractObject(
+simdjson::error_code extractObject(
     simdjson::ondemand::value& jsonValue,
     const std::string& key,
     std::optional<simdjson::ondemand::value>& ret) {
@@ -80,13 +74,13 @@ bool extractObject(
     SIMDJSON_ASSIGN_OR_RAISE(auto currentKey, field.unescaped_key());
     if (currentKey == key) {
       ret.emplace(field.value());
-      return true;
+      return simdjson::SUCCESS;
     }
   }
-  return true;
+  return simdjson::SUCCESS;
 }
 
-bool extractArray(
+simdjson::error_code extractArray(
     simdjson::ondemand::value& jsonValue,
     const std::string& index,
     std::optional<simdjson::ondemand::value>& ret) {
@@ -98,6 +92,6 @@ bool extractArray(
       ret.emplace(std::move(val));
     }
   }
-  return true;
+  return simdjson::SUCCESS;
 }
 } // namespace facebook::velox::functions::detail

--- a/velox/functions/prestosql/json/SIMDJsonExtractor.h
+++ b/velox/functions/prestosql/json/SIMDJsonExtractor.h
@@ -21,25 +21,14 @@
 #include "folly/Range.h"
 #include "folly/dynamic.h"
 #include "velox/common/base/Exceptions.h"
-#include "velox/common/base/Macros.h"
 #include "velox/functions/prestosql/json/JsonPathTokenizer.h"
-#include "velox/functions/prestosql/json/SIMDJsonWrapper.h"
+#include "velox/functions/prestosql/json/SIMDJsonUtil.h"
 #include "velox/type/StringView.h"
-
-#define SIMDJSON_ASSIGN_OR_RAISE_IMPL(_resultName, _lhs, _rexpr) \
-  auto&& _resultName = (_rexpr);                                 \
-  if (_resultName.error() != ::simdjson::SUCCESS) {              \
-    return false;                                                \
-  }                                                              \
-  _lhs = std::move(_resultName).value_unsafe();
-
-#define SIMDJSON_ASSIGN_OR_RAISE(_lhs, _rexpr) \
-  SIMDJSON_ASSIGN_OR_RAISE_IMPL(VELOX_VARNAME(_simdjsonResult), _lhs, _rexpr)
 
 namespace facebook::velox::functions {
 
 template <typename TConsumer>
-bool simdJsonExtract(
+simdjson::error_code simdJsonExtract(
     const velox::StringView& json,
     const velox::StringView& path,
     TConsumer&& consumer);
@@ -51,7 +40,7 @@ using JsonVector = std::vector<simdjson::ondemand::value>;
 class SIMDJsonExtractor {
  public:
   template <typename TConsumer>
-  bool extract(
+  simdjson::error_code extract(
       simdjson::ondemand::value& json,
       TConsumer& consumer,
       size_t tokenStartIndex = 0);
@@ -61,15 +50,12 @@ class SIMDJsonExtractor {
     return tokens_.empty();
   }
 
-  simdjson::simdjson_result<simdjson::ondemand::document> parse(
-      const simdjson::padded_string& json);
-
- private:
   // Use this method to get an instance of SIMDJsonExtractor given a JSON path.
   // Given the nature of the cache, it's important this is only used by
   // simdJsonExtract.
   static SIMDJsonExtractor& getInstance(folly::StringPiece path);
 
+ private:
   // Shouldn't instantiate directly - use getInstance().
   explicit SIMDJsonExtractor(const std::string& path) {
     if (!tokenize(path)) {
@@ -83,26 +69,20 @@ class SIMDJsonExtractor {
   static const uint32_t kMaxCacheSize{32};
 
   std::vector<std::string> tokens_;
-
-  template <typename TConsumer>
-  friend bool facebook::velox::functions::simdJsonExtract(
-      const velox::StringView& json,
-      const velox::StringView& path,
-      TConsumer&& consumer);
 };
 
-bool extractObject(
+simdjson::error_code extractObject(
     simdjson::ondemand::value& jsonObj,
     const std::string& key,
     std::optional<simdjson::ondemand::value>& ret);
 
-bool extractArray(
+simdjson::error_code extractArray(
     simdjson::ondemand::value& jsonValue,
     const std::string& index,
     std::optional<simdjson::ondemand::value>& ret);
 
 template <typename TConsumer>
-bool SIMDJsonExtractor::extract(
+simdjson::error_code SIMDJsonExtractor::extract(
     simdjson::ondemand::value& json,
     TConsumer& consumer,
     size_t tokenStartIndex) {
@@ -114,36 +94,28 @@ bool SIMDJsonExtractor::extract(
        tokenIndex++) {
     auto& token = tokens_[tokenIndex];
     if (input.type() == simdjson::ondemand::json_type::object) {
-      if (!extractObject(input, token, result)) {
-        return false;
-      }
+      SIMDJSON_TRY(extractObject(input, token, result));
     } else if (input.type() == simdjson::ondemand::json_type::array) {
       if (token == "*") {
         for (auto child : input.get_array()) {
           if (tokenIndex == tokens_.size() - 1) {
             // If this is the last token in the path, consume each element in
             // the array.
-            if (!consumer(child.value())) {
-              return false;
-            }
+            SIMDJSON_TRY(consumer(child.value()));
           } else {
             // If not, then recursively call the extract function on each
             // element in the array.
-            if (!extract(child.value(), consumer, tokenIndex + 1)) {
-              return false;
-            }
+            SIMDJSON_TRY(extract(child.value(), consumer, tokenIndex + 1));
           }
         }
 
-        return true;
+        return simdjson::SUCCESS;
       } else {
-        if (!extractArray(input, token, result)) {
-          return false;
-        }
+        SIMDJSON_TRY(extractArray(input, token, result));
       }
     }
     if (!result) {
-      return true;
+      return simdjson::SUCCESS;
     }
 
     input = result.value();
@@ -152,6 +124,7 @@ bool SIMDJsonExtractor::extract(
 
   return consumer(input);
 }
+
 } // namespace detail
 
 /**
@@ -169,12 +142,12 @@ bool SIMDJsonExtractor::extract(
  *                  Note that once consumer returns, it should be assumed that
  *                  the argument passed in is no longer valid, so do not attempt
  *                  to store it as is in the consumer.
- * @return Return true on success.
- *         If any errors are encountered parsing the JSON, returns false.
+ * @return Return simdjson::SUCCESS on success.
+ *         If any errors are encountered parsing the JSON, returns the error.
  */
 
 template <typename TConsumer>
-bool simdJsonExtract(
+simdjson::error_code simdJsonExtract(
     const velox::StringView& json,
     const velox::StringView& path,
     TConsumer&& consumer) {
@@ -182,7 +155,7 @@ bool simdJsonExtract(
   // we want to let this exception bubble up to the client.
   auto& extractor = detail::SIMDJsonExtractor::getInstance(path);
   simdjson::padded_string paddedJson(json.data(), json.size());
-  SIMDJSON_ASSIGN_OR_RAISE(auto jsonDoc, extractor.parse(paddedJson));
+  SIMDJSON_ASSIGN_OR_RAISE(auto jsonDoc, simdjsonParse(paddedJson));
 
   if (extractor.isRootOnlyPath()) {
     // If the path is just to return the original object, call consumer on the
@@ -195,7 +168,7 @@ bool simdJsonExtract(
 }
 
 template <typename TConsumer>
-bool simdJsonExtract(
+simdjson::error_code simdJsonExtract(
     const std::string& json,
     const std::string& path,
     TConsumer&& consumer) {

--- a/velox/functions/prestosql/json/SIMDJsonUtil.cpp
+++ b/velox/functions/prestosql/json/SIMDJsonUtil.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/json/SIMDJsonUtil.h"
+
+#include "velox/common/base/VeloxException.h"
+
+namespace facebook::velox {
+
+void simdjsonErrorsToExceptions(
+    std::exception_ptr exceptions[simdjson::NUM_ERROR_CODES]) {
+  for (int i = 1; i < simdjson::NUM_ERROR_CODES; ++i) {
+    simdjson::simdjson_error e(static_cast<simdjson::error_code>(i));
+    exceptions[i] = toVeloxException(std::make_exception_ptr(e));
+  }
+}
+
+simdjson::simdjson_result<simdjson::ondemand::document> simdjsonParse(
+    const simdjson::padded_string_view& json) {
+  thread_local simdjson::ondemand::parser parser;
+  return parser.iterate(json);
+}
+
+} // namespace facebook::velox

--- a/velox/functions/prestosql/json/SIMDJsonUtil.h
+++ b/velox/functions/prestosql/json/SIMDJsonUtil.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/functions/prestosql/json/SIMDJsonWrapper.h"
+
+#include <folly/Preprocessor.h>
+
+#define SIMDJSON_ASSIGN_OR_RAISE_IMPL(_resultName, _lhs, _rexpr) \
+  auto&& _resultName = (_rexpr);                                 \
+  if (_resultName.error() != ::simdjson::SUCCESS) {              \
+    return _resultName.error();                                  \
+  }                                                              \
+  _lhs = std::move(_resultName).value_unsafe();
+
+/// Helper to extract simdjson_result<T>.  Return immediately if the result is
+/// an error.  Examples:
+///
+///   std::string s;
+///   SIMDJSON_ASSIGN_OR_RAISE(s, simdjson::to_json_string(v));
+///
+///   SIMDJSON_ASSIGN_OR_RAISE(auto s, simdjson::to_json_string(v));
+#define SIMDJSON_ASSIGN_OR_RAISE(_lhs, _rexpr) \
+  SIMDJSON_ASSIGN_OR_RAISE_IMPL(               \
+      FB_ANONYMOUS_VARIABLE(_simdjsonResult), _lhs, _rexpr)
+
+namespace facebook::velox {
+
+/// Initialize the exceptions array with all possible simdjson error codes.
+void simdjsonErrorsToExceptions(
+    std::exception_ptr exceptions[simdjson::NUM_ERROR_CODES]);
+
+/// Parse the input json string using a thread local on demand parser.
+simdjson::simdjson_result<simdjson::ondemand::document> simdjsonParse(
+    const simdjson::padded_string_view& json);
+
+} // namespace facebook::velox

--- a/velox/functions/prestosql/json/tests/SIMDJsonExtractorTest.cpp
+++ b/velox/functions/prestosql/json/tests/SIMDJsonExtractorTest.cpp
@@ -49,10 +49,10 @@ class SIMDJsonExtractorTest : public testing::Test {
     auto consumer = [&res](auto& v) {
       SIMDJSON_ASSIGN_OR_RAISE(auto jsonStr, simdjson::to_json_string(v));
       res.emplace_back(jsonStr);
-      return true;
+      return simdjson::SUCCESS;
     };
 
-    EXPECT_TRUE(simdJsonExtract(json, path, consumer))
+    EXPECT_EQ(simdJsonExtract(json, path, consumer), simdjson::SUCCESS)
         << "with json " << json << " and path " << path;
 
     if (!expected) {
@@ -80,7 +80,7 @@ class SIMDJsonExtractorTest : public testing::Test {
         // We expect a single value, if consumer gets called multiple times,
         // e.g. the path contains [*], return null.
         actual = std::nullopt;
-        return true;
+        return simdjson::SUCCESS;
       }
 
       resultPopulated = true;
@@ -105,10 +105,10 @@ class SIMDJsonExtractorTest : public testing::Test {
           SIMDJSON_ASSIGN_OR_RAISE(actual, simdjson::to_json_string(v));
         }
       }
-      return true;
+      return simdjson::SUCCESS;
     };
 
-    EXPECT_TRUE(simdJsonExtract(json, path, consumer))
+    EXPECT_EQ(simdJsonExtract(json, path, consumer), simdjson::SUCCESS)
         << "with json " << json << " and path " << path;
 
     EXPECT_EQ(expected, actual) << "with json " << json << " and path " << path;
@@ -464,7 +464,7 @@ TEST_F(SIMDJsonExtractorTest, reextractJsonTest) {
   std::string ret;
   auto consumer = [&ret](auto& v) {
     SIMDJSON_ASSIGN_OR_RAISE(ret, simdjson::to_json_string(v));
-    return true;
+    return simdjson::SUCCESS;
   };
 
   simdJsonExtract(json, "$", consumer);
@@ -510,7 +510,7 @@ TEST_F(SIMDJsonExtractorTest, jsonMultipleExtractsTest) {
   std::string ret;
   auto consumer = [&ret](auto& v) {
     SIMDJSON_ASSIGN_OR_RAISE(ret, simdjson::to_json_string(v));
-    return true;
+    return simdjson::SUCCESS;
   };
 
   simdJsonExtract(json, "$.store", consumer);
@@ -523,17 +523,17 @@ TEST_F(SIMDJsonExtractorTest, jsonMultipleExtractsTest) {
 
 TEST_F(SIMDJsonExtractorTest, invalidJson) {
   // No-op consumer.
-  auto consumer = [](auto& /* unused */) { return true; };
+  auto consumer = [](auto& /* unused */) { return simdjson::SUCCESS; };
 
   // Object key is invalid.
   std::string json = "{\"foo: \"bar\"}";
-  EXPECT_FALSE(simdJsonExtract(json, "$.foo", consumer));
+  EXPECT_NE(simdJsonExtract(json, "$.foo", consumer), simdjson::SUCCESS);
   // Object value is invalid.
   json = "{\"foo\": \"bar}";
-  EXPECT_FALSE(simdJsonExtract(json, "$.foo", consumer));
+  EXPECT_NE(simdJsonExtract(json, "$.foo", consumer), simdjson::SUCCESS);
   // Value in array is invalid.
   // Inner object is invalid.
   json = "{\"foo\": [\"bar\", \"baz]}";
-  EXPECT_FALSE(simdJsonExtract(json, "$.foo[0]", consumer));
+  EXPECT_NE(simdJsonExtract(json, "$.foo[0]", consumer), simdjson::SUCCESS);
 }
 } // namespace

--- a/velox/functions/prestosql/types/CMakeLists.txt
+++ b/velox/functions/prestosql/types/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(velox_presto_types HyperLogLogType.cpp JsonType.cpp
                                TimestampWithTimeZoneType.cpp)
 
 target_link_libraries(velox_presto_types velox_memory velox_expression
-                      velox_functions_util)
+                      velox_functions_util velox_functions_json)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/functions/prestosql/types/JsonType.h
+++ b/velox/functions/prestosql/types/JsonType.h
@@ -20,38 +20,6 @@
 
 namespace facebook::velox {
 
-/// Custom operator for casts from and to Json type.
-class JsonCastOperator : public exec::CastOperator {
- public:
-  static const std::shared_ptr<const CastOperator>& get() {
-    static const std::shared_ptr<const CastOperator> instance{
-        new JsonCastOperator()};
-
-    return instance;
-  }
-
-  bool isSupportedFromType(const TypePtr& other) const override;
-
-  bool isSupportedToType(const TypePtr& other) const override;
-
-  void castTo(
-      const BaseVector& input,
-      exec::EvalCtx& context,
-      const SelectivityVector& rows,
-      const TypePtr& resultType,
-      VectorPtr& result) const override;
-
-  void castFrom(
-      const BaseVector& input,
-      exec::EvalCtx& context,
-      const SelectivityVector& rows,
-      const TypePtr& resultType,
-      VectorPtr& result) const override;
-
- private:
-  JsonCastOperator() = default;
-};
-
 /// Represents JSON as a string.
 class JsonType : public VarcharType {
   JsonType() = default;
@@ -61,10 +29,6 @@ class JsonType : public VarcharType {
     static const std::shared_ptr<const JsonType> instance{new JsonType()};
 
     return instance;
-  }
-
-  static const std::shared_ptr<const exec::CastOperator>& getCastOperator() {
-    return JsonCastOperator::get();
   }
 
   bool equivalent(const Type& other) const override {
@@ -104,19 +68,6 @@ struct JsonT {
 };
 
 using Json = CustomType<JsonT>;
-
-class JsonTypeFactories : public CustomTypeFactories {
- public:
-  JsonTypeFactories() = default;
-
-  TypePtr getType() const override {
-    return JSON();
-  }
-
-  exec::CastOperatorPtr getCastOperator() const override {
-    return JsonCastOperator::get();
-  }
-};
 
 void registerJsonType();
 


### PR DESCRIPTION
Summary:
This improves the overall performance of cast from JSON expressions,
and especially for malformed/mismatch input, the change results in an huge
improvement more than 70 times more efficient than before (from 135.42 CPU days
to 1.74 CPU days, comparing to Presto Java using 28.31 CPU days).

Differential Revision: D52482150


