### PR TITLE
Fix arrow include guards

### DIFF
--- a/velox/vector/arrow/Abi.h
+++ b/velox/vector/arrow/Abi.h
@@ -27,7 +27,9 @@ extern "C" {
 
 // Add a definition check here to avoid duplication with the definition
 // included from velox/external/duckdb/duckdb.hpp.
-#ifndef ARROW_FLAG_DICTIONARY_ORDERED
+#ifndef ARROW_C_DATA_INTERFACE
+#define ARROW_C_DATA_INTERFACE
+
 #define ARROW_FLAG_DICTIONARY_ORDERED 1
 #define ARROW_FLAG_NULLABLE 2
 #define ARROW_FLAG_MAP_KEYS_SORTED 4
@@ -65,7 +67,12 @@ struct ArrowArray {
   void* private_data;
 };
 
+#endif  // ARROW_C_DATA_INTERFACE
+
 // EXPERIMENTAL: C stream interface
+
+#ifndef ARROW_C_STREAM_INTERFACE
+#define ARROW_C_STREAM_INTERFACE
 
 struct ArrowArrayStream {
   // Callback to get the stream type
@@ -105,7 +112,7 @@ struct ArrowArrayStream {
   void* private_data;
 };
 
-#endif
+#endif  // ARROW_C_STREAM_INTERFACE
 
 #ifdef __cplusplus
 }

--- a/velox/vector/arrow/Abi.h
+++ b/velox/vector/arrow/Abi.h
@@ -67,7 +67,7 @@ struct ArrowArray {
   void* private_data;
 };
 
-#endif  // ARROW_C_DATA_INTERFACE
+#endif // ARROW_C_DATA_INTERFACE
 
 // EXPERIMENTAL: C stream interface
 
@@ -112,7 +112,7 @@ struct ArrowArrayStream {
   void* private_data;
 };
 
-#endif  // ARROW_C_STREAM_INTERFACE
+#endif // ARROW_C_STREAM_INTERFACE
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The arrow C abi (https://arrow.apache.org/docs/format/CDataInterface.html#structure-definitions) requires that #ARROW_C_DATA_INTERFACE is used as the guard instead of #ARROW_FLAG_DICTIONARY_ORDERED. If the definition from the Arrow source is included before the definition from the Velox source, then it would crash with a redefinition error. This PR fixes this bug to be compatible with https://github.com/apache/arrow/blob/main/cpp/src/arrow/c/abi.h.