### PR TITLE
Remove unused exception parameter from velox/common/base/AsyncSource.h

### DIFF
--- a/velox/common/base/AsyncSource.h
+++ b/velox/common/base/AsyncSource.h
@@ -60,7 +60,7 @@ class AsyncSource {
     try {
       CpuWallTimer timer(timing_);
       item = make();
-    } catch (std::exception& e) {
+    } catch (std::exception&) {
       std::lock_guard<std::mutex> l(mutex_);
       exception_ = std::current_exception();
     }
@@ -115,7 +115,7 @@ class AsyncSource {
     if (make) {
       try {
         return make();
-      } catch (const std::exception& e) {
+      } catch (const std::exception&) {
         std::lock_guard<std::mutex> l(mutex_);
         exception_ = std::current_exception();
         throw;


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D51785899


