### PR TITLE
Remove unused exception parameter from velox/common/caching/CachedFactory.h

### DIFF
--- a/velox/common/caching/CachedFactory.h
+++ b/velox/common/caching/CachedFactory.h
@@ -169,7 +169,7 @@ std::pair<bool, Value> CachedFactory<Key, Value, Generator>::generate(
     // TODO: consider using folly/ScopeGuard here.
     try {
       generatedValue = (*generator_)(key);
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
       {
         std::lock_guard<std::mutex> pending_lock(pendingMu_);
         pending_.erase(key);


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D51785886


