### PR TITLE
Remove unused exception parameter from velox/common/base/VeloxException.cpp

### DIFF
--- a/velox/common/base/VeloxException.cpp
+++ b/velox/common/base/VeloxException.cpp
@@ -25,7 +25,7 @@ namespace velox {
 std::exception_ptr toVeloxException(const std::exception_ptr& exceptionPtr) {
   try {
     std::rethrow_exception(exceptionPtr);
-  } catch (const VeloxException& e) {
+  } catch (const VeloxException&) {
     return exceptionPtr;
   } catch (const std::exception& e) {
     return std::make_exception_ptr(


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D51785796


