### PR TITLE
Remove unused exception parameter from velox/vector/arrow/Bridge.cpp

### DIFF
--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -969,7 +969,7 @@ TypePtr importFromArrowImpl(
         // Parse ",".
         int scale = std::stoi(&format[2 + sz + 1], &sz);
         return DECIMAL(precision, scale);
-      } catch (std::invalid_argument& err) {
+      } catch (std::invalid_argument&) {
         VELOX_USER_FAIL(
             "Unable to convert '{}' ArrowSchema decimal format to Velox decimal",
             format);
@@ -1155,7 +1155,7 @@ void exportToArrow(
           exportToArrow(rows.childAt(i), *currentSchema, options);
           currentSchema->name = bridgeHolder->rowType->nameOf(i).data();
           arrowSchema.children[i] = currentSchema.get();
-        } catch (const VeloxException& e) {
+        } catch (const VeloxException&) {
           // Release any children that have already been built before
           // re-throwing the exception back to the client.
           for (size_t j = 0; j < i; ++j) {


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D51785871


