### PR TITLE
Remove unused exception parameter from files inc velox/exec/Task.cpp

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -653,7 +653,7 @@ void Task::start(uint32_t maxDrivers, uint32_t concurrentSplitGroups) {
     }
     initializePartitionOutput();
     createAndStartDrivers(concurrentSplitGroups);
-  } catch (const std::exception& e) {
+  } catch (const std::exception&) {
     if (isRunning()) {
       setError(std::current_exception());
     } else {
@@ -1758,7 +1758,7 @@ ContinueFuture Task::terminate(TaskState terminalState) {
         VELOX_FAIL(
             state_ == TaskState::kCanceled ? "Cancelled"
                                            : "Aborted for external error");
-      } catch (const std::exception& e) {
+      } catch (const std::exception&) {
         exception_ = std::current_exception();
       }
     }
@@ -2281,7 +2281,7 @@ void Task::setError(const std::string& message) {
   // std::current_exception().
   try {
     throw std::runtime_error(message);
-  } catch (const std::runtime_error& e) {
+  } catch (const std::runtime_error&) {
     setError(std::current_exception());
   }
 }

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -165,7 +165,7 @@ void CastExpr::applyToSelectedNoThrowLocal(
         }
         // Avoid double throwing.
         context.setVeloxExceptionError(row, std::current_exception());
-      } catch (const std::exception& e) {
+      } catch (const std::exception&) {
         context.setError(row, std::current_exception());
       }
     });

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -109,7 +109,7 @@ class EvalCtx {
         }
         // Avoid double throwing.
         setVeloxExceptionError(row, std::current_exception());
-      } catch (const std::exception& e) {
+      } catch (const std::exception&) {
         setError(row, std::current_exception());
       }
     });


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: dmm-fb

Differential Revision: D51977780


