### PR TITLE
Remove unused exception parameter from velox/common/memory/MallocAllocator.cpp

### DIFF
--- a/velox/common/memory/MallocAllocator.cpp
+++ b/velox/common/memory/MallocAllocator.cpp
@@ -58,7 +58,7 @@ bool MallocAllocator::allocateNonContiguousWithoutRetry(
     bytesToAllocate = AllocationTraits::pageBytes(mix.totalPages) - freedBytes;
     try {
       reservationCB(bytesToAllocate, true);
-    } catch (std::exception& e) {
+    } catch (std::exception&) {
       VELOX_MEM_LOG(WARNING)
           << "Failed to reserve " << succinctBytes(bytesToAllocate)
           << " for non-contiguous allocation of " << numPages
@@ -204,7 +204,7 @@ bool MallocAllocator::allocateContiguousImpl(
   if (reservationCB != nullptr) {
     try {
       reservationCB(AllocationTraits::pageBytes(numNeededPages), true);
-    } catch (std::exception& e) {
+    } catch (std::exception&) {
       // If the new memory reservation fails, we need to release the memory
       // reservation of the freed contiguous and non-contiguous memory.
       VELOX_MEM_LOG(WARNING)


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D51785849


