### PR TITLE
Remove unused exception parameter from velox/expression/SimpleFunctionAdapter.h

### DIFF
--- a/velox/expression/SimpleFunctionAdapter.h
+++ b/velox/expression/SimpleFunctionAdapter.h
@@ -236,7 +236,7 @@ class SimpleFunctionAdapter : public VectorFunction {
         unpackInitialize<0>(config, constantInputs);
       } catch (const VeloxRuntimeError&) {
         throw;
-      } catch (const std::exception& e) {
+      } catch (const std::exception&) {
         initializeException_ = std::current_exception();
       }
     }


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D51785792


