### PR TITLE
Remove unused exception parameter from files inc velox/functions/prestosql/types/JsonType.cpp

### DIFF
--- a/velox/functions/prestosql/types/JsonType.cpp
+++ b/velox/functions/prestosql/types/JsonType.cpp
@@ -762,7 +762,7 @@ void castFromJson(
     } else {
       try {
         object = folly::parseJson(inputVector->valueAt(row));
-      } catch (const std::exception& e) {
+      } catch (const std::exception&) {
         writer.commitNull();
         VELOX_USER_FAIL("Not a JSON input: {}", inputVector->valueAt(row));
       }

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -62,7 +62,7 @@ void Timestamp::toGMT(const date::time_zone& zone) {
       sysTime;
   try {
     sysTime = zone.to_sys(localTime);
-  } catch (const date::ambiguous_local_time& error) {
+  } catch (const date::ambiguous_local_time&) {
     // If the time is ambiguous, pick the earlier possibility to be consistent
     // with Presto.
     sysTime = zone.to_sys(localTime, date::choose::earliest);


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: dmm-fb

Differential Revision: D51977677

