### PR TITLE
Remove unused exception parameter from files inc velox/exec/Driver.cpp

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -215,7 +215,7 @@ void BlockingState::setResume(std::shared_ptr<BlockingState> state) {
                   "A ContinueFuture for task {} was realized with error: {}",
                   state->driver_->task()->taskId(),
                   e.what())
-            } catch (const VeloxException& eNew) {
+            } catch (const VeloxException&) {
               state->driver_->task()->setError(std::current_exception());
             }
           });
@@ -727,11 +727,11 @@ StopReason Driver::runInternal(
         }
       }
     }
-  } catch (velox::VeloxException& e) {
+  } catch (velox::VeloxException&) {
     task()->setError(std::current_exception());
     // The CancelPoolGuard will close 'self' and remove from Task.
     return StopReason::kAlreadyTerminated;
-  } catch (std::exception& e) {
+  } catch (std::exception&) {
     task()->setError(std::current_exception());
     // The CancelGuard will close 'self' and remove from Task.
     return StopReason::kAlreadyTerminated;

--- a/velox/exec/ExchangeClient.cpp
+++ b/velox/exec/ExchangeClient.cpp
@@ -33,7 +33,7 @@ void ExchangeClient::addRemoteTaskId(const std::string& taskId) {
     std::shared_ptr<ExchangeSource> source;
     try {
       source = ExchangeSource::create(taskId, destination_, queue_, pool_);
-    } catch (const VeloxException& e) {
+    } catch (const VeloxException&) {
       throw;
     } catch (const std::exception& e) {
       // Task ID can be very long. Truncate to 128 characters.

--- a/velox/exec/SharedArbitrator.cpp
+++ b/velox/exec/SharedArbitrator.cpp
@@ -300,7 +300,7 @@ bool SharedArbitrator::handleOOM(
       VELOX_MEM_POOL_ABORTED(
           memoryPoolAbortMessage(victim, requestor, targetBytes));
     }
-  } catch (VeloxRuntimeError& e) {
+  } catch (VeloxRuntimeError&) {
     abort(victim, std::current_exception());
   }
   // Free up all the unused capacity from the aborted memory pool and gives back


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: dmm-fb

Differential Revision: D51977838


