### PR TITLE
Add hour Spark Function

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -83,6 +83,12 @@ These functions support TIMESTAMP and DATE input types.
         SELECT get_timestamp('1970-01-01', null);  -- NULL
         SELECT get_timestamp('2020-06-10', 'A');  -- (throws exception)
 
+.. spark:function:: hour(timestamp) -> integer
+
+    Returns the hour of ``timestamp``.::
+
+        SELECT hour('2009-07-30 12:58:59'); -- 12
+
 .. spark:function:: last_day(date) -> date
 
     Returns the last day of the month which the date belongs to.
@@ -124,12 +130,6 @@ These functions support TIMESTAMP and DATE input types.
         SELECT next_day('2015-07-23', "Tue"); -- '2015-07-28'
         SELECT next_day('2015-07-23', "tu"); -- '2015-07-28'
         SELECT next_day('2015-07-23', "we"); -- '2015-07-29'
-
-.. spark:function:: hour(timestamp) -> integer
-
-    Returns the hour of ``timestamp``. ::
-
-        SELECT hour('2009-07-30 12:58:59'); -- 12
 
 .. spark:function:: to_unix_timestamp(string) -> integer
 

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -83,9 +83,9 @@ These functions support TIMESTAMP and DATE input types.
         SELECT get_timestamp('1970-01-01', null);  -- NULL
         SELECT get_timestamp('2020-06-10', 'A');  -- (throws exception)
 
-.. spark:function:: hour(timestamp) -> integer
+.. spark:function:: hour(string/timestamp) -> integer
 
-    Returns the hour of ``timestamp``.::
+    Returns the hour of ``string/timestamp``.::
 
         SELECT hour('2009-07-30 12:58:59'); -- 12
 

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -125,6 +125,12 @@ These functions support TIMESTAMP and DATE input types.
         SELECT next_day('2015-07-23', "tu"); -- '2015-07-28'
         SELECT next_day('2015-07-23', "we"); -- '2015-07-29'
 
+.. spark:function:: hour(timestamp) -> integer
+
+    Returns the hour of ``timestamp``. ::
+
+        SELECT hour('2009-07-30 12:58:59'); -- 12
+
 .. spark:function:: to_unix_timestamp(string) -> integer
 
     Alias for ``unix_timestamp(string) -> integer``.

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -83,9 +83,9 @@ These functions support TIMESTAMP and DATE input types.
         SELECT get_timestamp('1970-01-01', null);  -- NULL
         SELECT get_timestamp('2020-06-10', 'A');  -- (throws exception)
 
-.. spark:function:: hour(string/timestamp) -> integer
+.. spark:function:: hour(timestamp) -> integer
 
-    Returns the hour of ``string/timestamp``.::
+    Returns the hour of ``timestamp``.::
 
         SELECT hour('2009-07-30 12:58:59'); -- 12
 

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -518,8 +518,7 @@ struct NextDayFunction {
 };
 
 template <typename T>
-struct HourFunction : public InitSessionTimezone<T>,
-                      public TimestampWithTimezoneSupport<T> {
+struct HourFunction : public InitSessionTimezone<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE void call(

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -517,4 +517,15 @@ struct NextDayFunction {
   bool invalidFormat_{false};
 };
 
+template <typename T>
+struct HourFunction : public InitSessionTimezone<T>,
+                      public TimestampWithTimezoneSupport<T> {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      int32_t& result,
+      const arg_type<Timestamp>& timestamp) {
+    result = getDateTime(timestamp, this->timeZone_).tm_hour;
+  }
+};
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -299,6 +299,8 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<GetTimestampFunction, Timestamp, Varchar, Varchar>(
       {prefix + "get_timestamp"});
 
+  registerFunction<HourFunction, int32_t, Timestamp>({prefix + "hour"});
+
   // Register bloom filter function
   registerFunction<BloomFilterMightContainFunction, bool, Varbinary, int64_t>(
       {prefix + "might_contain"});

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -581,26 +581,20 @@ TEST_F(DateTimeFunctionsTest, hour) {
   const auto hour = [&](std::optional<Timestamp> date) {
     return evaluateOnce<int32_t>("hour(c0)", date);
   };
+
   EXPECT_EQ(std::nullopt, hour(std::nullopt));
-  EXPECT_EQ(0, hour(Timestamp(0, 0)));
-  EXPECT_EQ(23, hour(Timestamp(-1, 9000)));
-  EXPECT_EQ(23, hour(Timestamp(-1, Timestamp::kMaxNanos)));
-  EXPECT_EQ(7, hour(Timestamp(4000000000, 0)));
-  EXPECT_EQ(7, hour(Timestamp(4000000000, 123000000)));
-  EXPECT_EQ(10, hour(Timestamp(998474645, 321000000)));
-  EXPECT_EQ(19, hour(Timestamp(998423705, 321000000)));
+  EXPECT_EQ(0, hour(util::fromTimestampString("2024-01-08 00:23:00.001")));
+  EXPECT_EQ(0, hour(util::fromTimestampString("2024-01-08 00:59:59.999")));
+  EXPECT_EQ(1, hour(util::fromTimestampString("2024-01-08 01:23:00.001")));
+  EXPECT_EQ(13, hour(util::fromTimestampString("2024-01-20 13:23:00.001")));
 
   setQueryTimeZone("Pacific/Apia");
 
   EXPECT_EQ(std::nullopt, hour(std::nullopt));
-  EXPECT_EQ(13, hour(Timestamp(0, 0)));
-  EXPECT_EQ(12, hour(Timestamp(-1, Timestamp::kMaxNanos)));
-  // Disabled for now because the TZ for Pacific/Apia in 2096 varies between
-  // systems.
-  // EXPECT_EQ(21, hour(Timestamp(4000000000, 0)));
-  // EXPECT_EQ(21, hour(Timestamp(4000000000, 123000000)));
-  EXPECT_EQ(23, hour(Timestamp(998474645, 321000000)));
-  EXPECT_EQ(8, hour(Timestamp(998423705, 321000000)));
+  EXPECT_EQ(13, hour(util::fromTimestampString("2024-01-08 00:23:00.001")));
+  EXPECT_EQ(13, hour(util::fromTimestampString("2024-01-08 00:59:59.999")));
+  EXPECT_EQ(14, hour(util::fromTimestampString("2024-01-08 01:23:00.001")));
+  EXPECT_EQ(2, hour(util::fromTimestampString("2024-01-20 13:23:00.001")));
 }
 
 } // namespace

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -590,7 +590,7 @@ TEST_F(DateTimeFunctionsTest, hour) {
   EXPECT_EQ(13, hour("2024-01-20 13:23:00.001"));
   EXPECT_EQ(13, hour("1969-01-01 13:23:00.001"));
 
-  // set time zone to Pacific/Apia (13 hours ahead of UTC)
+  // Set time zone to Pacific/Apia (13 hours ahead of UTC).
   setQueryTimeZone("Pacific/Apia");
 
   EXPECT_EQ(13, hour("2024-01-08 00:23:00.001"));

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -578,23 +578,26 @@ TEST_F(DateTimeFunctionsTest, getTimestamp) {
 }
 
 TEST_F(DateTimeFunctionsTest, hour) {
-  const auto hour = [&](std::optional<Timestamp> date) {
-    return evaluateOnce<int32_t>("hour(c0)", date);
+  const auto hour = [&](const StringView& timestampStr) {
+    const auto timeStamp =
+        std::make_optional(util::fromTimestampString(timestampStr));
+    return evaluateOnce<int32_t>("hour(c0)", timeStamp);
   };
 
-  EXPECT_EQ(std::nullopt, hour(std::nullopt));
-  EXPECT_EQ(0, hour(util::fromTimestampString("2024-01-08 00:23:00.001")));
-  EXPECT_EQ(0, hour(util::fromTimestampString("2024-01-08 00:59:59.999")));
-  EXPECT_EQ(1, hour(util::fromTimestampString("2024-01-08 01:23:00.001")));
-  EXPECT_EQ(13, hour(util::fromTimestampString("2024-01-20 13:23:00.001")));
+  EXPECT_EQ(0, hour("2024-01-08 00:23:00.001"));
+  EXPECT_EQ(0, hour("2024-01-08 00:59:59.999"));
+  EXPECT_EQ(1, hour("2024-01-08 01:23:00.001"));
+  EXPECT_EQ(13, hour("2024-01-20 13:23:00.001"));
+  EXPECT_EQ(13, hour("1969-01-01 13:23:00.001"));
 
+  // set time zone to Pacific/Apia(13 hours ahead of UTC)
   setQueryTimeZone("Pacific/Apia");
 
-  EXPECT_EQ(std::nullopt, hour(std::nullopt));
-  EXPECT_EQ(13, hour(util::fromTimestampString("2024-01-08 00:23:00.001")));
-  EXPECT_EQ(13, hour(util::fromTimestampString("2024-01-08 00:59:59.999")));
-  EXPECT_EQ(14, hour(util::fromTimestampString("2024-01-08 01:23:00.001")));
-  EXPECT_EQ(2, hour(util::fromTimestampString("2024-01-20 13:23:00.001")));
+  EXPECT_EQ(13, hour("2024-01-08 00:23:00.001"));
+  EXPECT_EQ(13, hour("2024-01-08 00:59:59.999"));
+  EXPECT_EQ(14, hour("2024-01-08 01:23:00.001"));
+  EXPECT_EQ(2, hour("2024-01-20 13:23:00.001"));
+  EXPECT_EQ(2, hour("1969-01-01 13:23:00.001"));
 }
 
 } // namespace

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -578,7 +578,7 @@ TEST_F(DateTimeFunctionsTest, getTimestamp) {
 }
 
 TEST_F(DateTimeFunctionsTest, hour) {
-  const auto hour = [&](const StringView& timestampStr) {
+  const auto hour = [&](const StringView timestampStr) {
     const auto timeStamp =
         std::make_optional(util::fromTimestampString(timestampStr));
     return evaluateOnce<int32_t>("hour(c0)", timeStamp);

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -590,7 +590,7 @@ TEST_F(DateTimeFunctionsTest, hour) {
   EXPECT_EQ(13, hour("2024-01-20 13:23:00.001"));
   EXPECT_EQ(13, hour("1969-01-01 13:23:00.001"));
 
-  // set time zone to Pacific/Apia(13 hours ahead of UTC)
+  // set time zone to Pacific/Apia (13 hours ahead of UTC)
   setQueryTimeZone("Pacific/Apia");
 
   EXPECT_EQ(13, hour("2024-01-08 00:23:00.001"));

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -577,5 +577,31 @@ TEST_F(DateTimeFunctionsTest, getTimestamp) {
       "Specifier I is not supported");
 }
 
+TEST_F(DateTimeFunctionsTest, hour) {
+  const auto hour = [&](std::optional<Timestamp> date) {
+    return evaluateOnce<int32_t>("hour(c0)", date);
+  };
+  EXPECT_EQ(std::nullopt, hour(std::nullopt));
+  EXPECT_EQ(0, hour(Timestamp(0, 0)));
+  EXPECT_EQ(23, hour(Timestamp(-1, 9000)));
+  EXPECT_EQ(23, hour(Timestamp(-1, Timestamp::kMaxNanos)));
+  EXPECT_EQ(7, hour(Timestamp(4000000000, 0)));
+  EXPECT_EQ(7, hour(Timestamp(4000000000, 123000000)));
+  EXPECT_EQ(10, hour(Timestamp(998474645, 321000000)));
+  EXPECT_EQ(19, hour(Timestamp(998423705, 321000000)));
+
+  setQueryTimeZone("Pacific/Apia");
+
+  EXPECT_EQ(std::nullopt, hour(std::nullopt));
+  EXPECT_EQ(13, hour(Timestamp(0, 0)));
+  EXPECT_EQ(12, hour(Timestamp(-1, Timestamp::kMaxNanos)));
+  // Disabled for now because the TZ for Pacific/Apia in 2096 varies between
+  // systems.
+  // EXPECT_EQ(21, hour(Timestamp(4000000000, 0)));
+  // EXPECT_EQ(21, hour(Timestamp(4000000000, 123000000)));
+  EXPECT_EQ(23, hour(Timestamp(998474645, 321000000)));
+  EXPECT_EQ(8, hour(Timestamp(998423705, 321000000)));
+}
+
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
In Spark, hour function returns the hour component of the string/timestamp.

This function takes timestamp as input and returns an int32 (different from Presto which returns an int64).

> SELECT hour('2009-07-30 12:58:59'); => 12


Spark's implementation: https://github.com/apache/spark/blob/b74b1592c9ec07b3d29b6d4d900b1d3ba1417cd1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala?#L419-L424

and unit test: https://github.com/apache/spark/blob/b74b1592c9ec07b3d29b6d4d900b1d3ba1417cd1/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala#L334-L363