### PR TITLE
Use glog instead of std::cerr in flex/bison parsers

### DIFF
--- a/velox/expression/signature_parser/SignatureParser.ll
+++ b/velox/expression/signature_parser/SignatureParser.ll
@@ -63,9 +63,9 @@ int yyFlexLexer::yylex() {
 facebook::velox::exec::TypeSignature facebook::velox::exec::parseTypeSignature(
     const std::string& signatureText) {
   std::istringstream is(signatureText);
+  std::ostringstream os;
   facebook::velox::exec::TypeSignaturePtr signature;
-  facebook::velox::exec::Scanner scanner{
-      is, std::cerr, signature, signatureText};
+  facebook::velox::exec::Scanner scanner{is, os, signature, signatureText};
   facebook::velox::exec::Parser parser{&scanner};
   parser.parse();
   VELOX_CHECK(signature, "Failed to parse signature [{}]", signatureText);

--- a/velox/expression/type_calculation/TypeCalculation.ll
+++ b/velox/expression/type_calculation/TypeCalculation.ll
@@ -43,9 +43,12 @@ int yyFlexLexer::yylex() {
 
 #include "velox/expression/type_calculation/TypeCalculation.h"
 
-void facebook::velox::expression::calculation::evaluate(const std::string& calculation, std::unordered_map<std::string, int>& variables) {
-    std::istringstream is(calculation);
-    facebook::velox::expression::calculate::Scanner scanner{ is, std::cerr, variables};
-    facebook::velox::expression::calculate::Parser parser{ &scanner };
-    parser.parse();
+void facebook::velox::expression::calculation::evaluate(
+    const std::string& calculation,
+    std::unordered_map<std::string, int>& variables) {
+  std::istringstream is(calculation);
+  std::ostringstream os;
+  facebook::velox::expression::calculate::Scanner scanner{is, os, variables};
+  facebook::velox::expression::calculate::Parser parser{&scanner};
+  parser.parse();
 }

--- a/velox/type/parser/TypeParser.ll
+++ b/velox/type/parser/TypeParser.ll
@@ -66,8 +66,9 @@ int yyFlexLexer::yylex() {
 facebook::velox::TypePtr facebook::velox::parseType(const std::string& typeText)
  {
     std::istringstream is(typeText);
+    std::ostringstream os;
     facebook::velox::TypePtr type;
-    facebook::velox::type::Scanner scanner{is, std::cerr, type, typeText};
+    facebook::velox::type::Scanner scanner{is, os, type, typeText};
     facebook::velox::type::Parser parser{ &scanner };
     parser.parse();
     VELOX_CHECK(type, "Failed to parse type [{}]", typeText);


### PR DESCRIPTION
Summary:
Using a glog error channel instead of inadvertently writing to
std::cerr in the three flex parsers in velox.

Differential Revision: D52521921


