### PR TITLE
Back out "use folly:: F14FastMap index for RowType lookup"

### DIFF
--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -307,19 +307,6 @@ std::vector<TypeParameter> createTypeParameters(
   return parameters;
 }
 
-// Returns children names index name -> first idx of occurence.
-const folly::F14FastMap<std::string, uint32_t> createdChildrenIndex(
-    const std::vector<std::string>& names) {
-  folly::F14FastMap<std::string, uint32_t> index;
-  index.reserve(names.size());
-  for (uint32_t i = 0; i < names.size(); ++i) {
-    if (index.find(names[i]) == index.end()) {
-      index[names[i]] = i;
-    }
-  }
-  return index;
-}
-
 std::string namesAndTypesToString(
     const std::vector<std::string>& names,
     const std::vector<TypePtr>& types) {
@@ -351,9 +338,7 @@ std::string namesAndTypesToString(
 RowType::RowType(std::vector<std::string>&& names, std::vector<TypePtr>&& types)
     : names_{std::move(names)},
       children_{std::move(types)},
-      parameters_{createTypeParameters(children_)},
-      // TODO: lazily initialize index on first access instead.
-      childrenIndices_{createdChildrenIndex(names_)} {
+      parameters_{createTypeParameters(children_)} {
   VELOX_CHECK_EQ(
       names_.size(),
       children_.size(),
@@ -393,11 +378,11 @@ std::string makeFieldNotFoundErrorMessage(
 }
 } // namespace
 
-// Returns type of first child with matching name.
 const TypePtr& RowType::findChild(folly::StringPiece name) const {
-  auto idx = getChildIdxIfExists(std::string(name));
-  if (idx) {
-    return children_[*idx];
+  for (uint32_t i = 0; i < names_.size(); ++i) {
+    if (names_.at(i) == name) {
+      return children_.at(i);
+    }
   }
   VELOX_USER_FAIL(makeFieldNotFoundErrorMessage(name, names_));
 }
@@ -417,10 +402,9 @@ bool RowType::isComparable() const {
 }
 
 bool RowType::containsChild(std::string_view name) const {
-  return getChildIdxIfExists(std::string(name)).has_value();
+  return std::find(names_.begin(), names_.end(), name) != names_.end();
 }
 
-// Returns index of first child with matching name.
 uint32_t RowType::getChildIdx(const std::string& name) const {
   auto index = getChildIdxIfExists(name);
   if (!index.has_value()) {
@@ -431,9 +415,10 @@ uint32_t RowType::getChildIdx(const std::string& name) const {
 
 std::optional<uint32_t> RowType::getChildIdxIfExists(
     const std::string& name) const {
-  const auto it = childrenIndices_.find(name);
-  if (it != childrenIndices_.end()) {
-    return it->second;
+  for (uint32_t i = 0; i < names_.size(); i++) {
+    if (names_.at(i) == name) {
+      return i;
+    }
   }
   return std::nullopt;
 }

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -969,7 +969,6 @@ class RowType : public TypeBase<TypeKind::ROW> {
   const std::vector<std::string> names_;
   const std::vector<std::shared_ptr<const Type>> children_;
   const std::vector<TypeParameter> parameters_;
-  const folly::F14FastMap<std::string, uint32_t> childrenIndices_;
 };
 
 using RowTypePtr = std::shared_ptr<const RowType>;


### PR DESCRIPTION
Summary:
Original commit changeset: 4db2387567b6

Original Phabricator Diff: D47599033

As explained in https://docs.google.com/document/d/1h_JEEy1iF323-PMxpyFu02OqSnFoOFH8SOsUZAVKMTw/edit
this diff adds significant memory regression for runtime use case of ta-koski pytorch op. While unlanding it will increase latency of user-visible operations when constructing dataframe, it is something we can resolve differently without runtime implications.

Reviewed By: Magoja

Differential Revision: D52522536


