### PR TITLE
Remove unused exception parameter from files inc velox/common/caching/AsyncDataCache.cpp

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -279,10 +279,10 @@ bool CoalescedLoad::loadOrFuture(folly::SemiFuture<bool>* wait) {
       entry->setExclusiveToShared();
     }
     setEndState(State::kLoaded);
-  } catch (std::exception& e) {
+  } catch (std::exception&) {
     try {
       setEndState(State::kCancelled);
-    } catch (std::exception& inner) {
+    } catch (std::exception&) {
       // May not throw from inside catch.
     }
     throw;

--- a/velox/common/caching/SsdFile.cpp
+++ b/velox/common/caching/SsdFile.cpp
@@ -756,7 +756,7 @@ void SsdFile::checkpoint(bool force) {
   } catch (const std::exception& e) {
     try {
       checkpointError(-1, e.what());
-    } catch (const std::exception& inner) {
+    } catch (const std::exception&) {
     }
     // Ignore nested exception.
   }
@@ -798,7 +798,7 @@ void SsdFile::initializeCheckpoint() {
                                  << e.what() << ": Starting without checkpoint";
       entries_.clear();
       deleteCheckpoint(true);
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
     }
   }
 }


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: dmm-fb

Differential Revision: D51977716

