### PR TITLE
Back out "Change cpu driver slicing limit to 1 second by default"

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -732,7 +732,7 @@ class QueryConfig {
   }
 
   uint32_t driverCpuTimeSliceLimitMs() const {
-    return get<uint32_t>(kDriverCpuTimeSliceLimitMs, 1'000);
+    return get<uint32_t>(kDriverCpuTimeSliceLimitMs, 0);
   }
 
   template <typename T>


### PR DESCRIPTION
Summary:
Backing this out as this is breaking internal tests that utilize the
sync driver API Driver::next(). A forward fix will be later added
that disables driver slicing feature for the aforementioned sync API.

Differential Revision: D52526939


