### PR TITLE
Fix flaky AggregationTest.reclaimFromAggregation

### DIFF
--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -3263,7 +3263,7 @@ TEST_F(AggregationTest, maxSpillBytes) {
   }
 }
 
-TEST_F(AggregationTest, reclaimFromAggregation) {
+DEBUG_ONLY_TEST_F(AggregationTest, reclaimFromAggregation) {
   std::vector<RowVectorPtr> vectors = createVectors(8, rowType_, fuzzerOpts_);
   createDuckDbTable(vectors);
   std::unique_ptr<memory::MemoryManager> memoryManager = createMemoryManager();


### PR DESCRIPTION
The flaky is caused by using the wrong Gtest macro,
`AggregationTest.reclaimFromAggregation` depends
on the `TestValue` utilities which only works in DEBUG mode.