### PR TITLE
Simplify the calculation of the number of pages

### DIFF
--- a/velox/common/memory/MemoryAllocator.cpp
+++ b/velox/common/memory/MemoryAllocator.cpp
@@ -142,8 +142,7 @@ void MemoryAllocator::alignmentCheck(
 MachinePageCount MemoryAllocator::roundUpToSizeClassSize(
     size_t bytes,
     const std::vector<MachinePageCount>& sizes) {
-  auto pages = bits::roundUp(bytes, AllocationTraits::kPageSize) /
-      AllocationTraits::kPageSize;
+  auto pages = AllocationTraits::numPages(bytes);
   VELOX_CHECK_LE(pages, sizes.back());
   return *std::lower_bound(sizes.begin(), sizes.end(), pages);
 }

--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -532,8 +532,7 @@ void* MmapAllocator::allocateBytesWithoutRetry(
   }
 
   ContiguousAllocation allocation;
-  auto numPages = bits::roundUp(bytes, AllocationTraits::kPageSize) /
-      AllocationTraits::kPageSize;
+  auto numPages = AllocationTraits::numPages(bytes);
   if (!allocateContiguousWithoutRetry(numPages, nullptr, allocation)) {
     return nullptr;
   }

--- a/velox/dwio/common/CachedBufferedInput.cpp
+++ b/velox/dwio/common/CachedBufferedInput.cpp
@@ -517,9 +517,7 @@ std::unique_ptr<SeekableInputStream> CachedBufferedInput::read(
 }
 
 bool CachedBufferedInput::prefetch(Region region) {
-  int32_t numPages =
-      bits::roundUp(region.length, memory::AllocationTraits::kPageSize) /
-      memory::AllocationTraits::kPageSize;
+  int32_t numPages = memory::AllocationTraits::numPages(region.length);
   if (!shouldPreload(numPages)) {
     return false;
   }


### PR DESCRIPTION
To calculate the number of pages corresponding to a given 'bytes', we
can use the `AllocationTraits::numPages()` util method without tedious
manual calculation, which can also improve readability a little bit.

No functional changes.