### PR TITLE
Disable build ZLIB when building cpr

### DIFF
--- a/CMake/resolve_dependency_modules/cpr.cmake
+++ b/CMake/resolve_dependency_modules/cpr.cmake
@@ -36,8 +36,8 @@ FetchContent_Declare(
                 ${CMAKE_CURRENT_LIST_DIR}/cpr/cpr-libcurl-compatible.patch)
 set(BUILD_SHARED_LIBS OFF)
 set(CPR_USE_SYSTEM_CURL OFF)
-# ZLIB has already been found by find_package(ZLIB, REQUIRED),
-# set CURL_ZLIB=OFF to save compile time.
+# ZLIB has already been found by find_package(ZLIB, REQUIRED), set CURL_ZLIB=OFF
+# to save compile time.
 set(CURL_ZLIB OFF)
 FetchContent_MakeAvailable(cpr)
 # libcpr in its CMakeLists.txt file disables the BUILD_TESTING globally when

--- a/CMake/resolve_dependency_modules/cpr.cmake
+++ b/CMake/resolve_dependency_modules/cpr.cmake
@@ -36,7 +36,8 @@ FetchContent_Declare(
                 ${CMAKE_CURRENT_LIST_DIR}/cpr/cpr-libcurl-compatible.patch)
 set(BUILD_SHARED_LIBS OFF)
 set(CPR_USE_SYSTEM_CURL OFF)
-# ZLIB is required by find_package, do not need build again, set CURL_ZLIB=OFF to save compile time.
+# ZLIB is required by find_package, do not need build again,
+# set CURL_ZLIB=OFF to save compile time.
 set(CURL_ZLIB OFF)
 FetchContent_MakeAvailable(cpr)
 # libcpr in its CMakeLists.txt file disables the BUILD_TESTING globally when

--- a/CMake/resolve_dependency_modules/cpr.cmake
+++ b/CMake/resolve_dependency_modules/cpr.cmake
@@ -36,6 +36,8 @@ FetchContent_Declare(
                 ${CMAKE_CURRENT_LIST_DIR}/cpr/cpr-libcurl-compatible.patch)
 set(BUILD_SHARED_LIBS OFF)
 set(CPR_USE_SYSTEM_CURL OFF)
+# ZLIB is required by find_package, do not need build again, set CURL_ZLIB=OFF to save compile time.
+set(CURL_ZLIB OFF)
 FetchContent_MakeAvailable(cpr)
 # libcpr in its CMakeLists.txt file disables the BUILD_TESTING globally when
 # CPR_USE_SYSTEM_CURL=OFF. unset BUILD_TESTING here.

--- a/CMake/resolve_dependency_modules/cpr.cmake
+++ b/CMake/resolve_dependency_modules/cpr.cmake
@@ -36,7 +36,7 @@ FetchContent_Declare(
                 ${CMAKE_CURRENT_LIST_DIR}/cpr/cpr-libcurl-compatible.patch)
 set(BUILD_SHARED_LIBS OFF)
 set(CPR_USE_SYSTEM_CURL OFF)
-# ZLIB is required by find_package, do not need build again,
+# ZLIB has already been found by find_package(ZLIB, REQUIRED),
 # set CURL_ZLIB=OFF to save compile time.
 set(CURL_ZLIB OFF)
 FetchContent_MakeAvailable(cpr)


### PR DESCRIPTION
After https://github.com/facebookincubator/velox/pull/7853, compiling cpr still takes up a significant amount of time because cpr try fetch and compile ZLIB, which breaks offline build. However, ZLIB has already been found by find_package(ZLIB, REQUIRED), let's avoid recompile ZLIB when compiling curl for cpr.

https://github.com/libcpr/cpr/blob/51915127d9b4b9f75965b239a5cd7a765722d1df/CMakeLists.txt#L202-L209