### PR TITLE
Add PrestoQueryRunner to velox_fuzzer_util

### DIFF
--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "velox/exec/fuzzer/PrestoQueryRunner.h"
-#include <cpr/cpr.h>
+#include <cpr/cpr.h> // @manual
 #include <folly/json.h>
 #include <iostream>
 #include "velox/common/base/Fs.h"


### PR DESCRIPTION
Summary:
Adds support for PrestoQueryRunner. PrestoQueryRunner allows us to use Presto as source of truth. This requires cpr as a dependency which is provided by the dependent diffs.

Currently tests utilizing PQR are disabled as they need a running presto instance, however with this change we will be able to run these tests on our external CI.

NOTE:  One thing I want to call attention to is that cpr autogenerates its cprver.h file via CMAKE build. For the moment I used this autogenerated file (it only adds version information ) and added it to the includes. Since we are unlikely to update very frequently just changing the cprver.h file when updating seems like a reasonable compromise instead of adding special BUCK logic mimicking what cpr does in CMAKE.

Differential Revision: D52549494


