### PR TITLE
Create new docker image for linux adapters.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,3 +90,21 @@ services:
     volumes:
       - .:/velox:delegated
     command: /bin/bash -c "scl enable gcc-toolset-9 '/velox/scripts/docker-command.sh'"
+
+  linux-adapters:
+    # Usage:
+    #   docker-compose pull linux-adapters or docker-compose build linux-adapters
+    #   docker-compose run --rm linux-adapters
+    #   or
+    #   docker-compose run -e NUM_THREADS=<NUMBER_OF_THREADS_TO_USE> --rm linux-adapters
+    #   to set the number of threads used during compilation
+    image: ghcr.io/facebookincubator/velox-dev:linux-adapters
+    build:
+      context: .
+      dockerfile: scripts/adapters-container.dockerfile
+    environment:
+      NUM_THREADS: 8 # default value for NUM_THREADS
+      CCACHE_DIR: "/velox/.ccache"
+    volumes:
+      - .:/velox:delegated
+    command: /bin/bash -c "scl enable gcc-toolset-9 '/velox/scripts/docker-command.sh'"

--- a/scripts/adapters-container.dockerfile
+++ b/scripts/adapters-container.dockerfile
@@ -1,0 +1,21 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Build the test and build container for presto_cpp
+#
+FROM ghcr.io/facebookincubator/velox-dev:circleci-avx
+
+RUN dnf install java-1.8.0-openjdk wget\
+    && wget https://dl.min.io/server/minio/release/linux-amd64/archive/minio-20220526054841.0.0.x86_64.rpm \
+    && rpm -i minio-20220526054841.0.0.x86_64.rpm \
+    && rm minio-20220526054841.0.0.x86_64.rpm \


### PR DESCRIPTION
This PR creates a docker image which uses our default circleci script as base but also adds minio and jdk on top. This will allow us to not download mino / install jdk for every build.  