### PR TITLE
Add isnan Spark function

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -217,7 +217,7 @@ Mathematical Functions
 
     Returns the negative of `x`.  Corresponds to Spark's operator ``-``.
 
-.. spark:function:: is_nan(x) -> boolean
+.. spark:function:: isnan(x) -> boolean
 
     Returns true if x is NaN, or false otherwise.
-    Supported types are: FLOAT.
+    Supported types are: FLOAT, DOUBLE.

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -105,8 +105,12 @@ Mathematical Functions
 
     Returns the square root of `a` squared plus `b` squared.
 
+.. spark:function:: isnan(x) -> boolean
 
-.. function:: log1p(x) -> double
+    Returns true if x is Nan, or false otherwise. Returns false is x is NULL.
+    Supported types are: REAL, DOUBLE.
+
+.. spark::function:: log1p(x) -> double
 
     Returns the natural logarithm of the “given value ``x`` plus one”.
     Return NULL if x is less than or equal to -1.
@@ -146,7 +150,7 @@ Mathematical Functions
 .. spark:function:: pmod(n, m) -> [same as n]
 
     Returns the positive remainder of n divided by m.
-    Supported types are: TINYINT, SMALLINT, INTEGER, BIGINT, FLOAT and DOUBLE.
+    Supported types are: TINYINT, SMALLINT, INTEGER, BIGINT, REAL and DOUBLE.
 
 .. spark:function:: power(x, p) -> double
 
@@ -216,8 +220,3 @@ Mathematical Functions
 .. spark:function:: unaryminus(x) -> [same as x]
 
     Returns the negative of `x`.  Corresponds to Spark's operator ``-``.
-
-.. spark:function:: isnan(x) -> boolean
-
-    Returns true if x is NaN, or false otherwise.
-    Supported types are: FLOAT, DOUBLE.

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -216,3 +216,8 @@ Mathematical Functions
 .. spark:function:: unaryminus(x) -> [same as x]
 
     Returns the negative of `x`.  Corresponds to Spark's operator ``-``.
+
+.. spark:function:: is_nan(x) -> boolean
+
+    Returns true if x is NaN, or false otherwise.
+    Supported types are: FLOAT.

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -305,9 +305,14 @@ struct Log10Function {
 template <typename T>
 struct IsNanFunction {
   template <typename TInput>
+  FOLLY_ALWAYS_INLINE void call(bool& result, TInput a) {
+    result = std::isnan(a);
+  }
+
+  template <typename TInput>
   FOLLY_ALWAYS_INLINE void callNullable(bool& result, const TInput* a) {
     if (a) {
-      result = std::isnan(*a);
+      call(result, *a);
     } else {
       result = false;
     }

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -301,4 +301,16 @@ struct Log10Function {
     return true;
   }
 };
+
+template <typename T>
+struct IsNanFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE void callNullable(bool& result, const TInput* a) {
+    if (a) {
+      result = std::isnan(*a);
+    } else {
+      result = false;
+    }
+  }
+};
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -21,7 +21,6 @@
 #include "velox/functions/lib/IsNull.h"
 #include "velox/functions/lib/Re2Functions.h"
 #include "velox/functions/lib/RegistrationHelpers.h"
-#include "velox/functions/prestosql/Arithmetic.h"
 #include "velox/functions/prestosql/DateTimeFunctions.h"
 #include "velox/functions/prestosql/JsonFunctions.h"
 #include "velox/functions/prestosql/StringFunctions.h"
@@ -79,7 +78,6 @@ static void workAroundRegistrationMacro(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_not, prefix + "not");
   registerIsNullFunction(prefix + "isnull");
   registerIsNotNullFunction(prefix + "isnotnull");
-  registerFunction<IsNanFunction, bool, float>({prefix + "is_nan"});
 }
 
 namespace sparksql {

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -21,6 +21,7 @@
 #include "velox/functions/lib/IsNull.h"
 #include "velox/functions/lib/Re2Functions.h"
 #include "velox/functions/lib/RegistrationHelpers.h"
+#include "velox/functions/prestosql/Arithmetic.h"
 #include "velox/functions/prestosql/DateTimeFunctions.h"
 #include "velox/functions/prestosql/JsonFunctions.h"
 #include "velox/functions/prestosql/StringFunctions.h"
@@ -78,6 +79,7 @@ static void workAroundRegistrationMacro(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_not, prefix + "not");
   registerIsNullFunction(prefix + "isnull");
   registerIsNotNullFunction(prefix + "isnotnull");
+  registerFunction<IsNanFunction, bool, float>({prefix + "is_nan"});
 }
 
 namespace sparksql {

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -96,6 +96,8 @@ void registerArithmeticFunctions(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_sub, prefix + "subtract");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_mul, prefix + "multiply");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_div, prefix + "divide");
+  registerFunction<sparksql::IsNanFunction, bool, float>({prefix + "isnan"});
+  registerFunction<sparksql::IsNanFunction, bool, double>({prefix + "isnan"});
 }
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -147,6 +147,7 @@ class ArithmeticTest : public SparkFunctionBaseTest {
   }
 
   static constexpr float kNan = std::numeric_limits<float>::quiet_NaN();
+  static constexpr double kNanD = std::numeric_limits<double>::quiet_NaN();
   static constexpr float kInf = std::numeric_limits<float>::infinity();
 };
 
@@ -395,13 +396,23 @@ TEST_F(ArithmeticTest, atan2) {
 }
 
 TEST_F(ArithmeticTest, isNan) {
-  const auto isNan = [&](std::optional<float> a) {
-    return evaluateOnce<bool>("is_nan(c0)", a);
+  const auto isNanF = [&](std::optional<float> a) {
+    return evaluateOnce<bool>("isnan(c0)", a);
   };
 
-  EXPECT_EQ(false, isNan(0.0f));
-  EXPECT_EQ(true, isNan(kNan));
-  EXPECT_EQ(true, isNan(0.0f / 0.0f));
+  EXPECT_EQ(false, isNanF(0.0f));
+  EXPECT_EQ(true, isNanF(kNan));
+  EXPECT_EQ(true, isNanF(0.0f / 0.0f));
+  EXPECT_EQ(false, isNanF(std::nullopt));
+
+  const auto isNanD = [&](std::optional<double> a) {
+    return evaluateOnce<bool>("isnan(c0)", a);
+  };
+
+  EXPECT_EQ(false, isNanD(0.0));
+  EXPECT_EQ(true, isNanD(kNanD));
+  EXPECT_EQ(true, isNanD(0.0 / 0.0));
+  EXPECT_EQ(false, isNanD(std::nullopt));
 }
 
 class LogNTest : public SparkFunctionBaseTest {

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -395,24 +395,26 @@ TEST_F(ArithmeticTest, atan2) {
   EXPECT_EQ(atan2(-1.0, -1.0), std::atan2(-1.0, -1.0));
 }
 
-TEST_F(ArithmeticTest, isNan) {
-  const auto isNanF = [&](std::optional<float> a) {
+TEST_F(ArithmeticTest, isNanFloat) {
+  const auto isNan = [&](std::optional<float> a) {
     return evaluateOnce<bool>("isnan(c0)", a);
   };
 
-  EXPECT_EQ(false, isNanF(0.0f));
-  EXPECT_EQ(true, isNanF(kNan));
-  EXPECT_EQ(true, isNanF(0.0f / 0.0f));
-  EXPECT_EQ(false, isNanF(std::nullopt));
+  EXPECT_EQ(false, isNan(0.0f));
+  EXPECT_EQ(true, isNan(kNan));
+  EXPECT_EQ(true, isNan(0.0f / 0.0f));
+  EXPECT_EQ(false, isNan(std::nullopt));
+}
 
-  const auto isNanD = [&](std::optional<double> a) {
+TEST_F(ArithmeticTest, isNanDouble) {
+  const auto isNan = [&](std::optional<double> a) {
     return evaluateOnce<bool>("isnan(c0)", a);
   };
 
-  EXPECT_EQ(false, isNanD(0.0));
-  EXPECT_EQ(true, isNanD(kNanD));
-  EXPECT_EQ(true, isNanD(0.0 / 0.0));
-  EXPECT_EQ(false, isNanD(std::nullopt));
+  EXPECT_EQ(false, isNan(0.0));
+  EXPECT_EQ(true, isNan(kNanD));
+  EXPECT_EQ(true, isNan(0.0 / 0.0));
+  EXPECT_EQ(false, isNan(std::nullopt));
 }
 
 class LogNTest : public SparkFunctionBaseTest {

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -394,6 +394,16 @@ TEST_F(ArithmeticTest, atan2) {
   EXPECT_EQ(atan2(-1.0, -1.0), std::atan2(-1.0, -1.0));
 }
 
+TEST_F(ArithmeticTest, isNan) {
+  const auto isNan = [&](std::optional<float> a) {
+    return evaluateOnce<bool>("is_nan(c0)", a);
+  };
+
+  EXPECT_EQ(false, isNan(0.0f));
+  EXPECT_EQ(true, isNan(kNan));
+  EXPECT_EQ(true, isNan(0.0f / 0.0f));
+}
+
 class LogNTest : public SparkFunctionBaseTest {
  protected:
   static constexpr float kInf = std::numeric_limits<double>::infinity();

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -147,7 +147,7 @@ class ArithmeticTest : public SparkFunctionBaseTest {
   }
 
   static constexpr float kNan = std::numeric_limits<float>::quiet_NaN();
-  static constexpr double kNanD = std::numeric_limits<double>::quiet_NaN();
+  static constexpr double kNanDouble = std::numeric_limits<double>::quiet_NaN();
   static constexpr float kInf = std::numeric_limits<float>::infinity();
 };
 
@@ -412,7 +412,7 @@ TEST_F(ArithmeticTest, isNanDouble) {
   };
 
   EXPECT_EQ(false, isNan(0.0));
-  EXPECT_EQ(true, isNan(kNanD));
+  EXPECT_EQ(true, isNan(kNanDouble));
   EXPECT_EQ(true, isNan(0.0 / 0.0));
   EXPECT_EQ(false, isNan(std::nullopt));
 }


### PR DESCRIPTION
Spark function differs from is_nan Presto function:
1. Spark supports both DOUBLE and REAL inputs.
2. Spark returns false for NULL input.

Spark's implementation: https://github.com/apache/spark/blob/443a957920737143834888726f067bc54acb97f2/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala#L247
