### PR TITLE
Remove unused exception parameter from velox/common/caching/AsyncDataCache.cpp

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -279,10 +279,10 @@ bool CoalescedLoad::loadOrFuture(folly::SemiFuture<bool>* wait) {
       entry->setExclusiveToShared();
     }
     setEndState(State::kLoaded);
-  } catch (std::exception& e) {
+  } catch (std::exception&) {
     try {
       setEndState(State::kCancelled);
-    } catch (std::exception& inner) {
+    } catch (std::exception&) {
       // May not throw from inside catch.
     }
     throw;


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D51785846


