### PR TITLE
Enabled variable override functions for ExpressionFuzzer

### DIFF
--- a/velox/expression/tests/ExpressionFuzzer.h
+++ b/velox/expression/tests/ExpressionFuzzer.h
@@ -90,6 +90,10 @@ class ExpressionFuzzer {
     //   "width_bucket",
     //   "array_sort(array(T),constant function(T,T,bigint)) -> array(T)"}
     std::unordered_set<std::string> skipFunctions;
+
+    // This list should be composed of functions supported
+    // in ExpressionFuzzer::initializeMemberFunctionMap().
+    std::unordered_set<std::string> overrideFunctions;
   };
 
   ExpressionFuzzer(
@@ -337,6 +341,9 @@ class ExpressionFuzzer {
   // Returns random integer between min and max inclusive.
   int32_t rand32(int32_t min, int32_t max);
 
+  void initializeMemberFunctionMap();
+  void applyOverrides();
+
   static const inline std::string kTypeParameterName = "T";
 
   const Options options_;
@@ -380,6 +387,10 @@ class ExpressionFuzzer {
 
   std::unordered_map<std::string, ArgsOverrideFunc> funcArgOverrides_;
 
+  using MemberFuncPtr = std::vector<std::shared_ptr<const core::ITypedExpr>> (
+      ExpressionFuzzer::*)(const CallableSignature&);
+
+  std::unordered_map<std::string, MemberFuncPtr> memberFunctionMap;
   std::shared_ptr<VectorFuzzer> vectorFuzzer_;
 
   FuzzerGenerator rng_;

--- a/velox/expression/tests/ExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerTest.cpp
@@ -55,6 +55,11 @@ int main(int argc, char** argv) {
       // Fuzzer cannot generate valid 'comparator' lambda.
       "array_sort(array(T),constant function(T,T,bigint)) -> array(T)",
   };
+  std::unordered_set<std::string> overrideFunctions = {
+      "empty_approx_set",
+      "regexp_replace",
+      "switch",
+  };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
-  return FuzzerRunner::run(initialSeed, skipFunctions);
+  return FuzzerRunner::run(initialSeed, skipFunctions, overrideFunctions);
 }

--- a/velox/expression/tests/FuzzerRunner.cpp
+++ b/velox/expression/tests/FuzzerRunner.cpp
@@ -161,7 +161,8 @@ VectorFuzzer::Options getVectorFuzzerOptions() {
 }
 
 ExpressionFuzzer::Options getExpressionFuzzerOptions(
-    const std::unordered_set<std::string>& skipFunctions) {
+    const std::unordered_set<std::string>& skipFunctions,
+    const std::unordered_set<std::string>& overrideFunctions) {
   ExpressionFuzzer::Options opts;
   opts.maxLevelOfNesting = FLAGS_velox_fuzzer_max_level_of_nesting;
   opts.maxNumVarArgs = FLAGS_max_num_varargs;
@@ -175,11 +176,13 @@ ExpressionFuzzer::Options getExpressionFuzzerOptions(
   opts.specialForms = FLAGS_special_forms;
   opts.useOnlyFunctions = FLAGS_only;
   opts.skipFunctions = skipFunctions;
+  opts.overrideFunctions = overrideFunctions;
   return opts;
 }
 
 ExpressionFuzzerVerifier::Options getExpressionFuzzerVerifierOptions(
-    const std::unordered_set<std::string>& skipFunctions) {
+    const std::unordered_set<std::string>& skipFunctions,
+    const std::unordered_set<std::string>& overrideFunctions) {
   ExpressionFuzzerVerifier::Options opts;
   opts.steps = FLAGS_steps;
   opts.durationSeconds = FLAGS_duration_sec;
@@ -192,7 +195,8 @@ ExpressionFuzzerVerifier::Options getExpressionFuzzerVerifierOptions(
   opts.lazyVectorGenerationRatio = FLAGS_lazy_vector_generation_ratio;
   opts.maxExpressionTreesPerStep = FLAGS_max_expression_trees_per_step;
   opts.vectorFuzzerOptions = getVectorFuzzerOptions();
-  opts.expressionFuzzerOptions = getExpressionFuzzerOptions(skipFunctions);
+  opts.expressionFuzzerOptions =
+      getExpressionFuzzerOptions(skipFunctions, overrideFunctions);
   return opts;
 }
 
@@ -201,18 +205,22 @@ ExpressionFuzzerVerifier::Options getExpressionFuzzerVerifierOptions(
 // static
 int FuzzerRunner::run(
     size_t seed,
-    const std::unordered_set<std::string>& skipFunctions) {
-  runFromGtest(seed, skipFunctions);
+    const std::unordered_set<std::string>& skipFunctions,
+    const std::unordered_set<std::string>& overrideFunctions) {
+  runFromGtest(seed, skipFunctions, overrideFunctions);
   return RUN_ALL_TESTS();
 }
 
 // static
 void FuzzerRunner::runFromGtest(
     size_t seed,
-    const std::unordered_set<std::string>& skipFunctions) {
+    const std::unordered_set<std::string>& skipFunctions,
+    const std::unordered_set<std::string>& overrideFunctions) {
   auto signatures = facebook::velox::getFunctionSignatures();
   ExpressionFuzzerVerifier(
-      signatures, seed, getExpressionFuzzerVerifierOptions(skipFunctions))
+      signatures,
+      seed,
+      getExpressionFuzzerVerifierOptions(skipFunctions, overrideFunctions))
       .go();
 }
 } // namespace facebook::velox::test

--- a/velox/expression/tests/FuzzerRunner.h
+++ b/velox/expression/tests/FuzzerRunner.h
@@ -31,11 +31,13 @@ class FuzzerRunner {
  public:
   static int run(
       size_t seed,
-      const std::unordered_set<std::string>& skipFunctions);
+      const std::unordered_set<std::string>& skipFunctions,
+      const std::unordered_set<std::string>& overrideFunctions);
 
   static void runFromGtest(
       size_t seed,
-      const std::unordered_set<std::string>& skipFunctions);
+      const std::unordered_set<std::string>& skipFunctions,
+      const std::unordered_set<std::string>& overrideFunctions);
 };
 
 } // namespace facebook::velox::test

--- a/velox/expression/tests/SparkExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/SparkExpressionFuzzerTest.cpp
@@ -52,5 +52,10 @@ int main(int argc, char** argv) {
       "replace",
       "might_contain",
       "unix_timestamp"};
-  return FuzzerRunner::run(FLAGS_seed, skipFunctions);
+  // All execution engines use 'switch' so its parameter
+  // overrides must be included.
+  std::unordered_set<std::string> overrideFunctions = {
+      "switch",
+  };
+  return FuzzerRunner::run(FLAGS_seed, skipFunctions, overrideFunctions);
 }


### PR DESCRIPTION
This pull request addresses the issue discussed in #8157. 

We introduce a new parameter to FuzzerRunner::run() called overrideFunctions which is an unordered set of strings. These values are placed in ExpressionFuzzer's options_ member. 

During instantiation, if the options_.overrideFunctions set is not empty, we initialize a memberFunctionMap which is a map of std::string to MemberFuncPtr. MemberFuncPtr is a new alias to `std::vector<std::shared_ptr<const core::ITypedExpr>> (
      ExpressionFuzzer::*)(const CallableSignature&);`. This differs from ArgsOverrideFunc in two ways.

1. It does not need to be bound to an instance (leaving the binding to ExpressionFuzzer::registerFuncOverride)
2. Whatever function is stored here must be a member of ExpressionFuzzer. 

After this map is initialized, applyOverrides is called which checks if each of the passed options_.overrideFunctions exists in the map. If it does, registerFuncOverride is called.

Before these changes, ExpressionFuzzer by default overrided empty_approx_set, regexp_replace, and switch. These defaults were moved to the Presto ExpressionFuzzerTest.cpp. 

1. empty_approx_set appears to be only defined for Presto. 
2. The regexp_replace override applies only for Presto regexp_replace as it ensures constant 2nd and 3rd variables. 
3. switch is a special function that all execution engines use. It is included in the SparkExpressionFuzzer.cpp 

In my local testing, after resolving issues present in regexp_replace, this fix prevents the fuzzer from passing Spark regexp_replace arguments meant for Presto regexp_replace. 