### PR TITLE
Honor distinct in Aggregates in QueryRunner

### DIFF
--- a/velox/exec/fuzzer/DuckQueryRunner.cpp
+++ b/velox/exec/fuzzer/DuckQueryRunner.cpp
@@ -42,9 +42,15 @@ std::string toCallSql(const core::CallTypedExprPtr& call) {
 std::string toAggregateCallSql(
     const core::CallTypedExprPtr& call,
     const std::vector<core::FieldAccessTypedExprPtr>& sortingKeys,
-    const std::vector<core::SortOrder>& sortingOrders) {
+    const std::vector<core::SortOrder>& sortingOrders,
+    bool distinct) {
   std::stringstream sql;
   sql << call->name() << "(";
+
+  if (distinct) {
+    sql << "distinct ";
+  }
+
   for (auto i = 0; i < call->inputs().size(); ++i) {
     appendComma(i, sql);
     sql << std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
@@ -194,7 +200,10 @@ std::optional<std::string> DuckQueryRunner::toSql(
       appendComma(i, sql);
       const auto& aggregate = aggregates[i];
       sql << toAggregateCallSql(
-          aggregate.call, aggregate.sortingKeys, aggregate.sortingOrders);
+          aggregate.call,
+          aggregate.sortingKeys,
+          aggregate.sortingOrders,
+          aggregate.distinct);
 
       if (aggregate.mask != nullptr) {
         sql << " filter (where " << aggregate.mask->name() << ")";

--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -212,13 +212,15 @@ std::string toTypeSql(const TypePtr& type) {
   }
 }
 
-std::string toCallSql(const core::CallTypedExprPtr& call) {
-  std::stringstream sql;
-  sql << call->name() << "(";
-  for (auto i = 0; i < call->inputs().size(); ++i) {
+std::string toCallSql(const core::CallTypedExprPtr& call);
+
+void toCallInputsSql(
+    const std::vector<core::TypedExprPtr>& inputs,
+    std::stringstream& sql) {
+  for (auto i = 0; i < inputs.size(); ++i) {
     appendComma(i, sql);
 
-    const auto& input = call->inputs()[i];
+    const auto& input = inputs.at(i);
     if (auto field =
             std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
                 input)) {
@@ -236,9 +238,9 @@ std::string toCallSql(const core::CallTypedExprPtr& call) {
       VELOX_CHECK_NOT_NULL(body);
 
       sql << "(";
-      for (auto i = 0; i < signature->size(); ++i) {
-        appendComma(i, sql);
-        sql << signature->nameOf(i);
+      for (auto j = 0; j < signature->size(); ++j) {
+        appendComma(j, sql);
+        sql << signature->nameOf(j);
       }
 
       sql << ") -> " << toCallSql(body);
@@ -246,7 +248,12 @@ std::string toCallSql(const core::CallTypedExprPtr& call) {
       VELOX_NYI();
     }
   }
+}
 
+std::string toCallSql(const core::CallTypedExprPtr& call) {
+  std::stringstream sql;
+  sql << call->name() << "(";
+  toCallInputsSql(call->inputs(), sql);
   sql << ")";
   return sql.str();
 }
@@ -264,37 +271,7 @@ std::string toAggregateCallSql(
     sql << "distinct ";
   }
 
-  for (auto i = 0; i < call->inputs().size(); ++i) {
-    appendComma(i, sql);
-
-    const auto& input = call->inputs()[i];
-    if (auto field =
-            std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
-                input)) {
-      sql << field->name();
-    } else if (
-        auto call =
-            std::dynamic_pointer_cast<const core::CallTypedExpr>(input)) {
-      sql << toCallSql(call);
-    } else if (
-        auto lambda =
-            std::dynamic_pointer_cast<const core::LambdaTypedExpr>(input)) {
-      const auto& signature = lambda->signature();
-      const auto& body =
-          std::dynamic_pointer_cast<const core::CallTypedExpr>(lambda->body());
-      VELOX_CHECK_NOT_NULL(body);
-
-      sql << "(";
-      for (auto i = 0; i < signature->size(); ++i) {
-        appendComma(i, sql);
-        sql << signature->nameOf(i);
-      }
-
-      sql << ") -> " << toCallSql(body);
-    } else {
-      VELOX_NYI();
-    }
-  }
+  toCallInputsSql(call->inputs(), sql);
 
   if (!sortingKeys.empty()) {
     sql << " ORDER BY ";

--- a/velox/exec/tests/PrestoQueryRunnerTest.cpp
+++ b/velox/exec/tests/PrestoQueryRunnerTest.cpp
@@ -150,12 +150,11 @@ TEST_F(PrestoQueryRunnerTest, distinctAggregation) {
 
   auto plan = velox::exec::test::PlanBuilder()
                   .values({data})
-                  .singleAggregation(
-                      {}, {"multimap_agg(distinct c0, c1 order by c0 asc)"})
+                  .singleAggregation({}, {"array_agg(distinct c0)"})
                   .planNode();
 
-  VELOX_ASSERT_THROW(
-      queryRunner->toSql(plan),
-      "Presto Query Runner does not support distinct aggregates");
+  auto sql = queryRunner->toSql(plan);
+  ASSERT_TRUE(sql.has_value());
+  ASSERT_EQ("SELECT array_agg(distinct c0) as a0 FROM tmp", sql.value());
 }
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
Currently, QueryRunners do not honor distinct aggregates,
and generate the wrong SQL. It is nice to insert a 'distinct'
qualifier to in the generated SQL statement.

Part of https://github.com/facebookincubator/velox/issues/7666