### PR TITLE
MINOR: eliminate some BufferPtr and shared_ptr copying

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -143,7 +143,7 @@ Expr::Expr(
   constantInputs_.reserve(inputs_.size());
   inputIsConstant_.reserve(inputs_.size());
   for (auto& expr : inputs_) {
-    if (auto constantExpr = std::dynamic_pointer_cast<ConstantExpr>(expr)) {
+    if (auto constantExpr = dynamic_cast<ConstantExpr*>(expr.get())) {
       constantInputs_.emplace_back(constantExpr->value());
       inputIsConstant_.push_back(true);
     } else {
@@ -192,7 +192,7 @@ bool Expr::allSupportFlatNoNullsFastPath(
 
 void Expr::clearMetaData() {
   metaDataComputed_ = false;
-  for (auto child : inputs_) {
+  for (auto& child : inputs_) {
     child->clearMetaData();
   }
   propagatesNulls_ = false;
@@ -1642,7 +1642,7 @@ bool Expr::isConstant() const {
     return false;
   }
   for (auto& input : inputs_) {
-    if (!dynamic_cast<ConstantExpr*>(input.get())) {
+    if (!input->is<ConstantExpr>()) {
       return false;
     }
   }

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -122,7 +122,7 @@ static VectorPtr addDictionary(
   auto pool = vector->pool();
   return std::make_shared<
       DictionaryVector<typename KindToFlatVector<kind>::WrapperType>>(
-      pool, nulls, size, std::move(vector), std::move(indices));
+      pool, std::move(nulls), size, std::move(vector), std::move(indices));
 }
 
 // static
@@ -219,7 +219,7 @@ static VectorPtr addConstant(
       index = constVector->index();
       vector = vector->valueVector();
     } else if (vector->encoding() == VectorEncoding::Simple::DICTIONARY) {
-      BufferPtr indices = vector->as<DictionaryVector<T>>()->indices();
+      const BufferPtr& indices = vector->as<DictionaryVector<T>>()->indices();
       index = indices->as<vector_size_t>()[index];
       vector = vector->valueVector();
     } else {
@@ -340,7 +340,7 @@ VectorPtr BaseVector::createInternal(
     case TypeKind::UNKNOWN: {
       BufferPtr nulls = allocateNulls(size, pool, bits::kNull);
       return std::make_shared<FlatVector<UnknownValue>>(
-          pool, UNKNOWN(), nulls, size, nullptr, std::vector<BufferPtr>());
+          pool, UNKNOWN(), std::move(nulls), size, nullptr, std::vector<BufferPtr>());
     }
     default:
       return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
@@ -471,7 +471,7 @@ void BaseVector::resizeIndices(
     if (indices->size() < newNumBytes) {
       AlignedBuffer::reallocate<vector_size_t>(&indices, newSize, 0);
     }
-    // indices->size() may cover more indices than cureentSize.
+    // indices->size() may cover more indices than currentSize.
     if (newSize > currentSize) {
       auto* raw = indices->asMutable<vector_size_t>();
       std::fill(raw + currentSize, raw + newSize, 0);
@@ -755,10 +755,11 @@ const VectorPtr& BaseVector::loadedVectorShared(const VectorPtr& vector) {
 VectorPtr BaseVector::transpose(BufferPtr indices, VectorPtr&& source) {
   // TODO: Reuse the indices if 'source' is already a dictionary and
   // there are no other users of its indices.
+  vector_size_t size = indices->size() / sizeof(vector_size_t);
   return wrapInDictionary(
       BufferPtr(nullptr),
-      indices,
-      indices->size() / sizeof(vector_size_t),
+      std::move(indices),
+      size,
       std::move(source));
 }
 

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -487,7 +487,7 @@ class BaseVector {
     copyRanges(source, folly::Range(&range, 1));
   }
 
-  /// Converts SelectivityVetor into a list of CopyRanges having sourceIndex ==
+  /// Converts SelectivityVector into a list of CopyRanges having sourceIndex ==
   /// targetIndex. Aims to produce as few ranges as possible. If all rows are
   /// selected, returns a single range.
   static std::vector<CopyRange> toCopyRanges(const SelectivityVector& rows);


### PR DESCRIPTION
When reading the code, I found some place just copying the `BufferPtr` and `std::shared_ptr`. They might calling a `faa` on ctor, and a `faa` on dtor. This patch just reducing them.

Any comment is welcomed.