### PR TITLE
Support Spill for Distinct Aggregation

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -224,13 +224,6 @@ void addSortingKeys(
 } // namespace
 
 bool AggregationNode::canSpill(const QueryConfig& queryConfig) const {
-  // TODO: Add spilling for aggregations over distinct inputs.
-  // https://github.com/facebookincubator/velox/issues/7454
-  for (const auto& aggregate : aggregates_) {
-    if (aggregate.distinct) {
-      return false;
-    }
-  }
   // TODO: add spilling for pre-grouped aggregation later:
   // https://github.com/facebookincubator/velox/issues/3264
   return (isFinal() || isSingle()) && preGroupedKeys().empty() &&

--- a/velox/exec/AddressableNonNullValueList.cpp
+++ b/velox/exec/AddressableNonNullValueList.cpp
@@ -46,7 +46,8 @@ HashStringAllocator::Position AddressableNonNullValueList::appendSerialized(
 
 std::unique_ptr<ByteOutputStream> AddressableNonNullValueList::makeOutputStream(
     HashStringAllocator* allocator) {
-  std::unique_ptr<ByteOutputStream> stream{std::make_unique<ByteOutputStream>(allocator)};
+  std::unique_ptr<ByteOutputStream> stream{
+      std::make_unique<ByteOutputStream>(allocator)};
 
   if (!firstHeader_) {
     // An array_agg or related begins with an allocation of 5 words and
@@ -66,8 +67,8 @@ std::unique_ptr<ByteOutputStream> AddressableNonNullValueList::makeOutputStream(
 }
 
 HashStringAllocator::Position AddressableNonNullValueList::finishWrite(
-  HashStringAllocator* allocator,
-  std::unique_ptr<ByteOutputStream>&& stream) {
+    HashStringAllocator* allocator,
+    std::unique_ptr<ByteOutputStream>&& stream) {
   ++size_;
 
   auto startAndFinish = allocator->finishWrite(*stream, 1024);

--- a/velox/exec/AddressableNonNullValueList.h
+++ b/velox/exec/AddressableNonNullValueList.h
@@ -53,9 +53,9 @@ class AddressableNonNullValueList {
       vector_size_t index,
       HashStringAllocator* allocator);
 
-  /// Append an (opaque) serialized set of data. The data passed in should ONLY come
-  /// from an copySerializedTo call. It must be appended in the exact ascending order
-  /// of indices it was copied from.
+  /// Append an (opaque) serialized set of data. The data passed in should ONLY
+  /// come from an copySerializedTo call. It must be appended in the exact
+  /// ascending order of indices it was copied from.
   HashStringAllocator::Position appendSerialized(
       HashStringAllocator* allocator,
       const char* buffer,
@@ -109,11 +109,11 @@ class AddressableNonNullValueList {
 
  private:
   std::unique_ptr<ByteOutputStream> makeOutputStream(
-    HashStringAllocator* allocator);
+      HashStringAllocator* allocator);
 
   HashStringAllocator::Position finishWrite(
-    HashStringAllocator* allocator,
-    std::unique_ptr<ByteOutputStream>&& stream);
+      HashStringAllocator* allocator,
+      std::unique_ptr<ByteOutputStream>&& stream);
 
  private:
   // Memory allocation (potentially multi-part).

--- a/velox/exec/DistinctAggregations.cpp
+++ b/velox/exec/DistinctAggregations.cpp
@@ -220,11 +220,12 @@ class TypedDistinctAggregations : public DistinctAggregations {
       totalBytes += accumulator->maxSpillSize();
     }
 
+    // We will an array with an opaque serialized set of bytes per group.
     auto& elementsVector = arrayVector->elements();
-    elementsVector->resize(totalBytes);
+    elementsVector->resize(groupsSize);
 
     auto* flatVector = elementsVector->asFlatVector<StringView>();
-    flatVector->resize(1);
+    flatVector->resize(totalBytes);
     auto* rawBuffer = flatVector->getRawStringBufferWithSpace(totalBytes, true);
 
     offset = 0;

--- a/velox/exec/DistinctAggregations.h
+++ b/velox/exec/DistinctAggregations.h
@@ -70,6 +70,11 @@ class DistinctAggregations {
       const RowVectorPtr& input,
       const SelectivityVector& rows) = 0;
 
+  virtual void addSingleGroupSpillInput(
+      char* group,
+      const VectorPtr& input,
+      vector_size_t index) = 0;
+
   /// Computes aggregations and stores results in the specified 'result' vector.
   virtual void extractValues(
       folly::Range<char**> groups,

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1115,6 +1115,13 @@ void GroupingSet::initializeRow(SpillMergeStream& stream, char* row) {
         &row, folly::Range<const vector_size_t*>(&zero, 1));
   }
 
+  for (auto i = 0; i < distinctAggregations_.size(); ++i) {
+    if (distinctAggregations_[i] != nullptr) {
+      distinctAggregations_[i]->initializeNewGroups(
+          &row, folly::Range<const vector_size_t*>(&zero, 1));
+    }
+  }
+
   if (sortedAggregations_ != nullptr) {
     sortedAggregations_->initializeNewGroups(
         &row, folly::Range<const vector_size_t*>(&zero, 1));
@@ -1154,6 +1161,15 @@ void GroupingSet::updateRow(SpillMergeStream& input, char* row) {
         input.current().childAt(aggregates_.size() + keyChannels_.size());
     sortedAggregations_->addSingleGroupSpillInput(
         row, vector, input.currentIndex());
+  }
+
+  for (auto i = 0; i < distinctAggregations_.size(); ++i) {
+    if (distinctAggregations_[i] != nullptr) {
+      const auto& vector =
+          input.current().childAt(aggregates_.size() + keyChannels_.size());
+      distinctAggregations_[i]->addSingleGroupSpillInput(
+          row, vector, input.currentIndex());
+    }
   }
 }
 

--- a/velox/exec/tests/AddressableNonNullValueListTest.cpp
+++ b/velox/exec/tests/AddressableNonNullValueListTest.cpp
@@ -180,5 +180,49 @@ TEST_F(AddressableNonNullValueListTest, row) {
   });
 }
 
+TEST_F(AddressableNonNullValueListTest, serializationDeserialization) {
+    AddressableNonNullValueList source;
+
+    const auto data = makeMapVector<int16_t, int64_t>({
+        {{1, 10}, {2, 20}},
+        {{3, 30}, {4, 40}, {5, 50}},
+        {{3, 30}, {4, 40}, {5, 50}},
+        {{1, 10}, {2, 20}},
+        {{1, 10}, {3, 30}, {4, 40}, {6, 60}},
+        {},
+        {{1, 10}, {2, 20}},
+        {},
+        {{3, 30}, {4, 40}, {5, 50}},
+    });
+
+    std::vector<HashStringAllocator::Position> positions;
+
+    DecodedVector decodedVector(*data);
+    for (auto i = 0; i < data->size(); ++i) {
+      auto position = source.append(decodedVector, i, allocator());
+      positions.push_back(position);
+    }
+
+    std::vector<std::vector<char>> buffers(data->size());
+    for (auto i = 0; i < data->size(); ++i) {
+      const auto serializedSize = source.getSerializedSize(positions[i]);
+      buffers[i].resize(serializedSize);
+      source.copySerializedTo(positions[i], buffers[i].data(), buffers[i].size());
+    }
+
+    AddressableNonNullValueList destination;
+
+    for (auto i = 0; i < data->size(); ++i) {
+      destination.appendSerialized(allocator(), buffers[i].data(), buffers[i].size());
+    }
+
+    auto copy = BaseVector::create(data->type(), data->size(), pool());
+    for (auto i = 0; i < positions.size(); ++i) {
+      AddressableNonNullValueList::read(positions[i], *copy, i);
+    }
+
+    test::assertEqualVectors(data, copy);
+}
+
 } // namespace
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/exec/tests/AddressableNonNullValueListTest.cpp
+++ b/velox/exec/tests/AddressableNonNullValueListTest.cpp
@@ -181,47 +181,48 @@ TEST_F(AddressableNonNullValueListTest, row) {
 }
 
 TEST_F(AddressableNonNullValueListTest, serializationDeserialization) {
-    AddressableNonNullValueList source;
+  AddressableNonNullValueList source;
 
-    const auto data = makeMapVector<int16_t, int64_t>({
-        {{1, 10}, {2, 20}},
-        {{3, 30}, {4, 40}, {5, 50}},
-        {{3, 30}, {4, 40}, {5, 50}},
-        {{1, 10}, {2, 20}},
-        {{1, 10}, {3, 30}, {4, 40}, {6, 60}},
-        {},
-        {{1, 10}, {2, 20}},
-        {},
-        {{3, 30}, {4, 40}, {5, 50}},
-    });
+  const auto data = makeMapVector<int16_t, int64_t>({
+      {{1, 10}, {2, 20}},
+      {{3, 30}, {4, 40}, {5, 50}},
+      {{3, 30}, {4, 40}, {5, 50}},
+      {{1, 10}, {2, 20}},
+      {{1, 10}, {3, 30}, {4, 40}, {6, 60}},
+      {},
+      {{1, 10}, {2, 20}},
+      {},
+      {{3, 30}, {4, 40}, {5, 50}},
+  });
 
-    std::vector<HashStringAllocator::Position> positions;
+  std::vector<HashStringAllocator::Position> positions;
 
-    DecodedVector decodedVector(*data);
-    for (auto i = 0; i < data->size(); ++i) {
-      auto position = source.append(decodedVector, i, allocator());
-      positions.push_back(position);
-    }
+  DecodedVector decodedVector(*data);
+  for (auto i = 0; i < data->size(); ++i) {
+    auto position = source.append(decodedVector, i, allocator());
+    positions.push_back(position);
+  }
 
-    std::vector<std::vector<char>> buffers(data->size());
-    for (auto i = 0; i < data->size(); ++i) {
-      const auto serializedSize = source.getSerializedSize(positions[i]);
-      buffers[i].resize(serializedSize);
-      source.copySerializedTo(positions[i], buffers[i].data(), buffers[i].size());
-    }
+  std::vector<std::vector<char>> buffers(data->size());
+  for (auto i = 0; i < data->size(); ++i) {
+    const auto serializedSize = source.getSerializedSize(positions[i]);
+    buffers[i].resize(serializedSize);
+    source.copySerializedTo(positions[i], buffers[i].data(), buffers[i].size());
+  }
 
-    AddressableNonNullValueList destination;
+  AddressableNonNullValueList destination;
 
-    for (auto i = 0; i < data->size(); ++i) {
-      destination.appendSerialized(allocator(), buffers[i].data(), buffers[i].size());
-    }
+  for (auto i = 0; i < data->size(); ++i) {
+    destination.appendSerialized(
+        allocator(), buffers[i].data(), buffers[i].size());
+  }
 
-    auto copy = BaseVector::create(data->type(), data->size(), pool());
-    for (auto i = 0; i < positions.size(); ++i) {
-      AddressableNonNullValueList::read(positions[i], *copy, i);
-    }
+  auto copy = BaseVector::create(data->type(), data->size(), pool());
+  for (auto i = 0; i < positions.size(); ++i) {
+    AddressableNonNullValueList::read(positions[i], *copy, i);
+  }
 
-    test::assertEqualVectors(data, copy);
+  test::assertEqualVectors(data, copy);
 }
 
 } // namespace

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -64,6 +64,7 @@ add_executable(
   RowContainerTest.cpp
   RowNumberTest.cpp
   MarkDistinctTest.cpp
+  SetAccumulatorTest.cpp
   SharedArbitratorTest.cpp
   SpillTest.cpp
   SpillOperatorGroupTest.cpp

--- a/velox/exec/tests/SetAccumulatorTest.cpp
+++ b/velox/exec/tests/SetAccumulatorTest.cpp
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/SetAccumulator.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/testutil/TestValue.h"
+#include "velox/exec/Values.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/type/Type.h"
+#include "velox/vector/tests/VectorTestUtils.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
+#include "velox/vector/tests/utils/VectorMakerStats.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::aggregate::prestosql;
+using namespace facebook::velox::test;
+
+namespace facebook::velox::exec::test {
+
+class SetAccumulatorTest : public OperatorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    OperatorTestBase::SetUpTestCase();
+  }
+
+  void SetUp() override {
+    OperatorTestBase::SetUp();
+  }
+
+  template <TypeKind TKind>
+  void testSpillRoundtrip() {
+    const auto type{createScalarType(TKind)};
+    using TNativeType = typename TypeTraits<TKind>::NativeType;
+
+    SetAccumulator<TNativeType> source{type, allocator_.get()};
+
+    auto generated =
+        genTestData<TNativeType>(100, type, true /* includeNulls */);
+    auto data = generated.data();
+    auto flatVector = makeNullableFlatVector(data, type);
+
+    DecodedVector decoded(*flatVector);
+
+    for (auto i = 0; i < decoded.size(); ++i) {
+      source.addValue(decoded, i, allocator_.get());
+    }
+
+    SetAccumulator<TNativeType> destination{type, allocator_.get()};
+
+    {
+      auto sourceVector = BaseVector::create(VARCHAR(), 100, pool_.get());
+      auto* flatSource = sourceVector->asFlatVector<StringView>();
+      flatSource->resize(1);
+
+      {
+        auto* rawBuffer = flatSource->getRawStringBufferWithSpace(
+            source.maxSpillSize(), true);
+
+        source.extractForSpill(rawBuffer, source.maxSpillSize());
+
+        flatSource->setNoCopy(0, StringView(rawBuffer, source.maxSpillSize()));
+      }
+
+      destination.addFromSpill(*flatSource, allocator_.get());
+    }
+
+    {
+      auto sourceVector = BaseVector::create(type, 100, pool_.get());
+      auto* flatsource = sourceVector->asFlatVector<TNativeType>();
+      flatsource->resize(source.size());
+
+      source.extractValues(*flatsource, 0);
+
+      auto destinationVector = BaseVector::create(type, 100, pool_.get());
+      auto* flatDestination = destinationVector->asFlatVector<TNativeType>();
+      flatDestination->resize(destination.size());
+
+      destination.extractValues(*flatDestination, 0);
+
+      static const CompareFlags kCompareFlags{
+          true, // nullsFirst
+          true, // ascending
+          true, // equalsOnly
+          CompareFlags::NullHandlingMode::kNullAsValue};
+
+      EXPECT_TRUE(
+          flatDestination->compare(flatsource, 0, 0, kCompareFlags)
+              .value_or(-1) == 0);
+    }
+  }
+
+  template <typename T>
+  FlatVectorPtr<EvalType<T>> makeNullableFlatVector(
+      const std::vector<std::optional<T>>& data,
+      const TypePtr& type = CppToType<T>::create()) {
+    return vectorMaker_.flatVectorNullable(data, type);
+  }
+
+  std::shared_ptr<memory::MemoryPool> rootPool_{
+      memory::memoryManager()->addRootPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{rootPool_->addLeafChild("leaf")};
+  std::unique_ptr<HashStringAllocator> allocator_{
+      std::make_unique<HashStringAllocator>(pool())};
+};
+
+TEST_F(SetAccumulatorTest, SpillRoundTripBoolean) {
+  testSpillRoundtrip<TypeKind::BOOLEAN>();
+}
+
+TEST_F(SetAccumulatorTest, SpillRoundTripTinyInt) {
+  testSpillRoundtrip<TypeKind::TINYINT>();
+}
+
+TEST_F(SetAccumulatorTest, SpillRoundTripSmallInt) {
+  testSpillRoundtrip<TypeKind::SMALLINT>();
+}
+
+TEST_F(SetAccumulatorTest, SpillRoundTripInteger) {
+  testSpillRoundtrip<TypeKind::INTEGER>();
+}
+
+TEST_F(SetAccumulatorTest, SpillRoundTripBigInt) {
+  testSpillRoundtrip<TypeKind::BIGINT>();
+}
+
+TEST_F(SetAccumulatorTest, SpillRoundTripDouble) {
+  testSpillRoundtrip<TypeKind::DOUBLE>();
+}
+
+TEST_F(SetAccumulatorTest, SpillRoundTripVarchar) {
+  testSpillRoundtrip<TypeKind::VARCHAR>();
+}
+
+TEST_F(SetAccumulatorTest, SpillRoundTripRow) {
+  const auto type{ROW({{"c0", INTEGER()}})};
+
+  SetAccumulator<ComplexType> source{type, allocator_.get()};
+
+  auto baseVector = BaseVector::create(type, 1, pool_.get());
+  auto rowVector = baseVector->asUnchecked<RowVector>();
+  auto flatVector = rowVector->childAt(0)->asFlatVector<int32_t>();
+  flatVector->resize(100);
+  for (int i = 0; i < flatVector->size(); ++i) {
+    flatVector->set(i, i);
+  }
+
+  DecodedVector decoded(*baseVector);
+
+  for (auto i = 0; i < decoded.size(); ++i) {
+    source.addValue(decoded, i, allocator_.get());
+  }
+
+  SetAccumulator<ComplexType> destination{type, allocator_.get()};
+
+  {
+    auto sourceVector = BaseVector::create(VARCHAR(), 100, pool_.get());
+    auto* flatSource = sourceVector->asFlatVector<StringView>();
+    flatSource->resize(1);
+
+    {
+      auto* rawBuffer =
+          flatSource->getRawStringBufferWithSpace(source.maxSpillSize(), true);
+
+      source.extractForSpill(rawBuffer, source.maxSpillSize());
+
+      flatSource->setNoCopy(0, StringView(rawBuffer, source.maxSpillSize()));
+    }
+
+    destination.addFromSpill(*flatSource, allocator_.get());
+  }
+
+  {
+    auto sourceVector = BaseVector::create(type, 1, pool_.get());
+    auto* rowsource = sourceVector->asUnchecked<RowVector>();
+    rowsource->resize(source.size());
+
+    source.extractValues(*rowsource, 0);
+
+    auto destinationVector = BaseVector::create(type, 1, pool_.get());
+    auto* rowdestination = destinationVector->asUnchecked<RowVector>();
+    rowdestination->resize(destination.size());
+
+    destination.extractValues(*rowdestination, 0);
+
+    static const CompareFlags kCompareFlags{
+        true, // nullsFirst
+        true, // ascending
+        true, // equalsOnly
+        CompareFlags::NullHandlingMode::kNullAsValue};
+
+    EXPECT_TRUE(
+        rowdestination->childAt(0)
+            ->asFlatVector<int32_t>()
+            ->compare(
+                rowsource->childAt(0)->asFlatVector<int32_t>(),
+                0,
+                0,
+                kCompareFlags)
+            .value_or(-1) == 0);
+  }
+}
+
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
Queries with distinct aggregations cannot spill. With this change, they are now capable of doing so.

SetAccumulator accumulates the distinct inputs and will now expose an API showing what the maximum spill data is (maxSpillSize), which then can be used with extractForSpill to extract the serialized data. The clear method allows is then to drop the memory usage. Once it is time to bring the data back from spill, the addFromSpill API is used.

The AddressableNonNullValueList subordinate structure, used for complex types (e.g.: ROW, MAP) also is extended with serialization / deserialization capabilities via the new getSerializedSize, copySerializedTo and appendSerialized methods, which follow the same pattern of getting a size, then getting the data and being able to put it back. Its free method is made to leave the structure in a re-usable state as well.

Tests are added to AggregationsTest for the overall spill with distinct aggregation, both when it is on or off and including the VARCHAR case so get coverage beyond a scalar case.

Additionally, a new test suite is added with SetAccumulatorTest to cover all the serialization / deserialization logic added for SetAccumulator in all its implementation cases, including VARCHAR and ComplexType.

Finally, I also added a test for serialization / deserialization for AddressableNonNullValueList.

Fixes #7454