### PR TITLE
Use dedicated timeout thread for LocalExchangeSource

### DIFF
--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -322,6 +322,8 @@ TEST_F(ExchangeClientTest, sourceTimeout) {
       std::function<void(void*)>(([&](void* source) {
         std::lock_guard<std::mutex> l(mutex);
         sourcesWithTimeout.insert(source);
+        LOG(INFO) << "inside lambda" << source
+                  << " n=" << sourcesWithTimeout.size();
       })));
 
 #ifndef NDEBUG
@@ -332,13 +334,13 @@ TEST_F(ExchangeClientTest, sourceTimeout) {
   for (; counter < kMaxIters; ++counter) {
     {
       std::lock_guard<std::mutex> l(mutex);
-      if (sourcesWithTimeout.size() == kNumSources) {
+      if (sourcesWithTimeout.size() >= kNumSources) {
         break;
       }
     }
     std::this_thread::sleep_for(std::chrono::seconds(1));
   }
-  ASSERT_LT(counter, kMaxIters);
+  EXPECT_LT(counter, kMaxIters);
 #endif
 
   const auto& queue = client->queue();
@@ -348,73 +350,30 @@ TEST_F(ExchangeClientTest, sourceTimeout) {
 
   // Fetch one page.
   pages = client->next(1, &atEnd, &future);
-  ASSERT_EQ(1, pages.size());
-  ASSERT_FALSE(atEnd);
+  EXPECT_EQ(1, pages.size());
+  EXPECT_FALSE(atEnd);
 
   // Fetch multiple pages. Each page is slightly larger than 1K bytes, hence,
   // only 4 pages fit.
   pages = client->next(5'000, &atEnd, &future);
-  ASSERT_EQ(4, pages.size());
-  ASSERT_FALSE(atEnd);
+  EXPECT_EQ(4, pages.size());
+  EXPECT_FALSE(atEnd);
 
   // Fetch the rest of the pages.
   pages = client->next(10'000, &atEnd, &future);
-  ASSERT_EQ(5, pages.size());
-  ASSERT_FALSE(atEnd);
+  EXPECT_EQ(5, pages.size());
+  EXPECT_FALSE(atEnd);
 
   // Signal no-more-data for all sources.
   for (auto i = 0; i < kNumSources; ++i) {
     enqueue(*queue, nullptr);
   }
   pages = client->next(10'000, &atEnd, &future);
-  ASSERT_EQ(0, pages.size());
-  ASSERT_TRUE(atEnd);
+  EXPECT_EQ(0, pages.size());
+  EXPECT_TRUE(atEnd);
 
   client->close();
-}
-
-TEST_F(ExchangeClientTest, timeoutDuringValueCallback) {
-  common::testutil::TestValue::enable();
-  auto row = makeRowVector({makeFlatVector<int32_t>({1, 2, 3})});
-
-  auto plan = test::PlanBuilder()
-                  .values({row})
-                  .partitionedOutput({"c0"}, 100)
-                  .planNode();
-  auto taskId = "local://t1";
-  auto task = makeTask(taskId, plan);
-
-  bufferManager_->initializeTask(
-      task, core::PartitionedOutputNode::Kind::kPartitioned, 100, 16);
-
-  auto client = std::make_shared<ExchangeClient>(
-      "t", 17, ExchangeClient::kDefaultMaxQueuedBytes, pool(), executor());
-  client->addRemoteTaskId(taskId);
-  int32_t numTimeouts = 0;
-  SCOPED_TESTVALUE_SET(
-      "facebook::velox::exec::test::LocalExchangeSource::timeout",
-      std::function<void(void*)>(([&](void* /*ignore*/) { ++numTimeouts; })));
-
-  SCOPED_TESTVALUE_SET(
-      "facebook::velox::exec::test::LocalExchangeSource",
-      std::function<void(void*)>(([&](void* /*pages*/) {
-        std::this_thread::sleep_for(
-            std::chrono::seconds(2 * ExchangeClient::kDefaultMaxWaitSeconds));
-      })));
-
-  auto thread = std::thread([&]() {
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    enqueue(taskId, 17, row);
-  });
-
-  fetchPages(*client, 1);
-  thread.join();
-  EXPECT_EQ(0, numTimeouts);
-
-  task->requestCancel();
-  bufferManager_->removeTask(taskId);
-
-  client->close();
+  test::testingShutdownLocalExchangeSource();
 }
 
 } // namespace

--- a/velox/exec/tests/ExchangeFuzzer.cpp
+++ b/velox/exec/tests/ExchangeFuzzer.cpp
@@ -432,5 +432,6 @@ int main(int argc, char** argv) {
     fuzzer.seed(seed);
   }
   fuzzer.run();
+  exec::test::testingShutdownLocalExchangeSource();
   return 0;
 }

--- a/velox/exec/tests/utils/LocalExchangeSource.cpp
+++ b/velox/exec/tests/utils/LocalExchangeSource.cpp
@@ -56,31 +56,33 @@ class LocalExchangeSource : public exec::ExchangeSource {
     VELOX_CHECK(requestPending_);
     auto requestedSequence = sequence_;
     auto self = shared_from_this();
-
-    // Have a flag shared between the data available and timeout callbacks. Only
-    // one of these must run but they could overlap at call time.
-    static std::mutex realizeMutex;
-    auto state = std::make_shared<State>(State::kPending);
-
     // Since this lambda may outlive 'this', we need to capture a
     // shared_ptr to the current object (self).
-    auto resultCallback = [self, requestedSequence, buffers, state, this](
+    auto resultCallback = [self, requestedSequence, buffers, this](
                               std::vector<std::unique_ptr<folly::IOBuf>> data,
                               int64_t sequence) {
       {
-        std::lock_guard<std::mutex> l(realizeMutex);
-        if (*state != State::kPending) {
+        std::lock_guard<std::mutex> l(timeoutMutex_);
+        // This function is called either for a result or timeout. Only the
+        // first of these calls has an effect.
+        auto iter = timeouts_.find(self);
+        if (iter != timeouts_.end()) {
+          timeouts_.erase(iter);
+        } else {
           return;
         }
-        *state = State::kResultReceived;
       }
-      if (requestedSequence > sequence) {
+
+      if (requestedSequence > sequence && !data.empty()) {
         VLOG(2) << "Receives earlier sequence than requested: task " << taskId_
                 << ", destination " << destination_ << ", requested "
                 << sequence << ", received " << requestedSequence;
         int64_t nExtra = requestedSequence - sequence;
         VELOX_CHECK(nExtra < data.size());
         data.erase(data.begin(), data.begin() + nExtra);
+        sequence = requestedSequence;
+      }
+      if (data.empty()) {
         sequence = requestedSequence;
       }
       std::vector<std::unique_ptr<SerializedPage>> pages;
@@ -99,6 +101,11 @@ class LocalExchangeSource : public exec::ExchangeSource {
       }
       numPages_ += pages.size();
       totalBytes_ += totalBytes;
+      if (data.empty()) {
+        LOG(INFO) << "adjust timeout";
+        common::testutil::TestValue::adjust(
+            "facebook::velox::exec::test::LocalExchangeSource::timeout", this);
+      }
 
       try {
         common::testutil::TestValue::adjust(
@@ -124,7 +131,9 @@ class LocalExchangeSource : public exec::ExchangeSource {
             queue_->enqueueLocked(nullptr, queuePromises);
             atEnd_ = true;
           }
-          ackSequence = sequence_ = sequence + pages.size();
+          if (!data.empty()) {
+            ackSequence = sequence_ = sequence + pages.size();
+          }
         }
         for (auto& promise : queuePromises) {
           promise.setValue();
@@ -133,65 +142,16 @@ class LocalExchangeSource : public exec::ExchangeSource {
       // Outside of queue mutex.
       if (atEnd_) {
         buffers->deleteResults(taskId_, destination_);
-      } else {
+      } else if (!data.empty()) {
         buffers->acknowledge(taskId_, destination_, ackSequence);
       }
 
       if (!requestPromise.isFulfilled()) {
         requestPromise.setValue(Response{totalBytes, atEnd_});
       }
-      {
-        std::lock_guard<std::mutex> l(realizeMutex);
-        *state = State::kResultProcessed;
-      }
     };
 
-    // Call the callback in any case after timeout.
-    auto& exec = folly::QueuedImmediateExecutor::instance();
-
-    future = std::move(future).via(&exec).onTimeout(
-        std::chrono::seconds(maxWaitSeconds), [self, state, this] {
-          // The timeout callback detects if a result is being
-          // processed. If so, it waits for the result processing to be
-          // complete. It must not realize promises while a result is
-          // being processed. After the result is processed, returning a
-          // value should be no-op since the promise already has a value.
-          bool done = false;
-          bool timeout = false;
-          do {
-            {
-              std::lock_guard<std::mutex> l(realizeMutex);
-              if (*state == State::kPending) {
-                *state = State::kTimeout;
-                timeout = true;
-                done = true;
-              } else if (*state == State::kResultReceived) {
-                done = true;
-              }
-            }
-            if (!done) {
-              // wait for the result callback to finish on another thread. Must
-              // not set the future until the other thread is finished.
-              std::this_thread::sleep_for(std::chrono::milliseconds(1));
-            }
-          } while (!done);
-          Response response = {0, false};
-          if (timeout) {
-            common::testutil::TestValue::adjust(
-                "facebook::velox::exec::test::LocalExchangeSource::timeout",
-                this);
-            VeloxPromise<Response> requestPromise;
-            {
-              std::lock_guard<std::mutex> l(queue_->mutex());
-              requestPending_ = false;
-              requestPromise = std::move(promise_);
-            }
-            if (!requestPromise.isFulfilled()) {
-              requestPromise.setValue(response);
-            }
-          }
-          return response;
-        });
+    registerTimeout(self, resultCallback, maxWaitSeconds);
 
     buffers->getData(
         taskId_, destination_, maxBytes, sequence_, resultCallback);
@@ -216,12 +176,56 @@ class LocalExchangeSource : public exec::ExchangeSource {
     };
   }
 
+  /// Stops timeout thread and makes sure there are no references to
+  /// sources or their callbacks in global state.
+  static void stop() {
+    if (executor_) {
+      stop_ = true;
+      executor_->join();
+      timeouts_.clear();
+      executor_.reset();
+    }
+  }
+
  private:
-  // state for serializing concurrent result and timeout. If timeout
-  // happens when state is kResultReceived, it must wait until state
-  // is kResultProcessed. If result arrives when state != kPending,
-  // the result is ignored.
-  enum class State { kPending, kResultReceived, kResultProcessed, kTimeout };
+  using ResultCallback = std::function<
+      void(std::vector<std::unique_ptr<folly::IOBuf>> data, int64_t sequence)>;
+  static void registerTimeout(
+      const std::shared_ptr<ExchangeSource>& self,
+      ResultCallback callback,
+      int32_t seconds) {
+    std::lock_guard<std::mutex> l(timeoutMutex_);
+    if (!executor_) {
+      executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(1);
+      if (!exitInitialized_) {
+        exitInitialized_ = true;
+        atexit([]() { stop(); });
+      }
+      stop_ = false;
+      executor_->add([]() {
+        while (!stop_) {
+          auto now = getCurrentTimeSec();
+          ResultCallback callback = nullptr;
+          {
+            std::lock_guard<std::mutex> t(timeoutMutex_);
+            for (auto& pair : timeouts_) {
+              if (pair.second.second < now) {
+                callback = pair.second.first;
+                break;
+              }
+            }
+          }
+          if (callback) {
+            // Outside of mutex.
+            callback({}, 0);
+            continue;
+          }
+          std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+      });
+    }
+    timeouts_[self] = std::make_pair(callback, getCurrentTimeSec() + seconds);
+  }
 
   bool checkSetRequestPromise() {
     VeloxPromise<Response> promise;
@@ -242,7 +246,25 @@ class LocalExchangeSource : public exec::ExchangeSource {
   std::atomic<uint64_t> totalBytes_{0};
   VeloxPromise<Response> promise_{VeloxPromise<Response>::makeEmpty()};
   int32_t numRequests_{0};
+
+  static std::mutex timeoutMutex_;
+  static folly::F14FastMap<
+      std::shared_ptr<ExchangeSource>,
+      std::pair<ResultCallback, size_t>>
+      timeouts_;
+  static std::unique_ptr<folly::CPUThreadPoolExecutor> executor_;
+  static bool stop_;
+  static bool exitInitialized_;
 };
+
+std::mutex LocalExchangeSource::timeoutMutex_;
+folly::F14FastMap<
+    std::shared_ptr<ExchangeSource>,
+    std::pair<LocalExchangeSource::ResultCallback, size_t>>
+    LocalExchangeSource::timeouts_;
+std::unique_ptr<folly::CPUThreadPoolExecutor> LocalExchangeSource::executor_;
+bool LocalExchangeSource::stop_ = false;
+bool LocalExchangeSource::exitInitialized_ = false;
 
 } // namespace
 
@@ -258,6 +280,10 @@ std::unique_ptr<ExchangeSource> createLocalExchangeSource(
     throw std::runtime_error("Testing error");
   }
   return nullptr;
+}
+
+void testingShutdownLocalExchangeSource() {
+  LocalExchangeSource::stop();
 }
 
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/LocalExchangeSource.h
+++ b/velox/exec/tests/utils/LocalExchangeSource.h
@@ -26,4 +26,9 @@ std::unique_ptr<exec::ExchangeSource> createLocalExchangeSource(
     std::shared_ptr<exec::ExchangeQueue> queue,
     memory::MemoryPool* pool);
 
+/// Ensures that there are no references to ExchangeSource callbacks,
+/// e.g. while waiting for timing out. Call this before end of unit
+/// tests to ensure no ASAN errors at exit.
+void testingShutdownLocalExchangeSource();
+
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
Using onTimeout on the future returned from
LocalExchangeSource::request fails flakily on both OSS and fbcode, within a few iterations of velox_exchange_fuzzer_test with asan.

We use a separate thread to issue timeouts and remove the timeout when the future is realized without timeout. As with remote exchange, we use one callback to handle both timeout and data ready.