### PR TITLE
Do not use session based file create config in datasink

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -233,11 +233,4 @@ uint64_t HiveConfig::filePreloadThreshold() const {
   return config_->get<uint64_t>(kFilePreloadThreshold, 8UL << 20);
 }
 
-std::string HiveConfig::fileCreateConfig(const Config* session) const {
-  if (session->isValueExists(kFileCreateConfig)) {
-    return session->get<std::string>(kFileCreateConfig).value();
-  }
-  return config_->get<std::string>(kFileCreateConfig, "");
-}
-
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -169,11 +169,6 @@ class HiveConfig {
   static constexpr const char* kSortWriterMaxOutputBytesSession =
       "sort_writer_max_output_bytes";
 
-  /// Config used to create sink files. This config is provided to underlying
-  /// file system and the config is free form. The form should be defined by
-  /// the underlying file system.
-  static constexpr const char* kFileCreateConfig = "file-create-config";
-
   InsertExistingPartitionsBehavior insertExistingPartitionsBehavior(
       const Config* session) const;
 
@@ -236,8 +231,6 @@ class HiveConfig {
   uint64_t footerEstimatedSize() const;
 
   uint64_t filePreloadThreshold() const;
-
-  std::string fileCreateConfig(const Config* session) const;
 
   HiveConfig(std::shared_ptr<const Config> config) {
     VELOX_CHECK_NOT_NULL(

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -618,8 +618,7 @@ uint32_t HiveDataSink::appendWriter(const HiveWriterId& id) {
           writePath,
           {.bufferWrite = false,
            .connectorProperties = hiveConfig_->config(),
-           .fileCreateConfig =
-               hiveConfig_->fileCreateConfig(connectorSessionProperties),
+           .fileCreateConfig = hiveConfig_->writeFileCreateConfig(),
            .pool = writerInfo_.back()->sinkPool.get(),
            .metricLogger = dwio::common::MetricsLog::voidLog(),
            .stats = ioStats_.back().get()}),


### PR DESCRIPTION
Summary: As OSS requested we do not want to expose this property through session config. We instead use catalog system config for writer file create config. This diff also enables the encoding for batch write configs.

Differential Revision: D52602972


