### PR TITLE
Fix min_by/max_by in Window operation

### DIFF
--- a/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
@@ -766,4 +766,39 @@ TEST_F(MinMaxNTest, double) {
   testNumericGroupBy<double>();
 }
 
+TEST_F(MinMaxNTest, incrementalWindow) {
+  // SELECT
+  //  c0, c1, c2, c3,
+  //  max(c0, c1) over (partition by c2 order by c3 asc)
+  // FROM (
+  //  VALUES
+  //      (1, 10, false, 0),
+  //      (2, 10, false, 1)
+  // ) AS t(c0, c1, c2, c3)
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({1, 2}),
+      makeFlatVector<int64_t>({10, 10}),
+      makeFlatVector<bool>({false, false}),
+      makeFlatVector<int64_t>({0, 1}),
+  });
+
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .window({"max(c0, c1) over (partition by c2 order by c3 asc)"})
+          .planNode();
+
+  auto result = AssertQueryBuilder(plan).copyResults(pool());
+
+  // Expected result: {1, 10, false, 0, [1]}, {2, 10, false, 1, [2, 1]}.
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({1, 2}),
+      makeFlatVector<int64_t>({10, 10}),
+      makeFlatVector<bool>({false, false}),
+      makeFlatVector<int64_t>({0, 1}),
+      makeArrayVector<int64_t>({{1}, {2, 1}}),
+  });
+  facebook::velox::test::assertEqualVectors(expected, result);
+}
+
 } // namespace


### PR DESCRIPTION
Summary:
min_by/max_by(x, y, n) functions produce different results from Presto when invoked in Window operator. There are two bugs:
1. MinMaxByNAggregate::extractValues() should return NULL when the accumulator is empty to follow Presto's behavior.
2. To be consistent with Presto, AggregateWindowFunction::incrementalAggregation() should call aggregate_->extractValues() again even if the current frame is already evaluated at the previous row. This is necessary for some function such as min_by/max_by that change the accumulator by the previous extractValues().

This diff fixes https://github.com/facebookincubator/velox/issues/8138.

Differential Revision: D52575661


