### PR TITLE
Add to remove from partition output buffer manager in Tssk destructor

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -278,6 +278,17 @@ Task::~Task() {
 
   TestValue::adjust("facebook::velox::exec::Task::~Task", this);
 
+  try {
+    if (hasPartitionedOutput()) {
+      if (auto bufferManager = bufferManager_.lock()) {
+        bufferManager->removeTask(taskId_);
+      }
+    }
+  } catch (const std::exception& e) {
+    LOG(WARNING) << "Caught exception in Task " << taskId()
+                 << " destructor: " << e.what();
+  }
+
   clearStage = "removeSpillDirectoryIfExists";
   removeSpillDirectoryIfExists();
 


### PR DESCRIPTION
In Meta internal shadowing we have seen the leaked memory pools which
is empty but has one pending shared reference. Those empty memory pools
had memory usage (from the peak memory usage) but now has no memory
usage and all the child memory pools have gone. The latter means that the
task has gone as the task hold the child memory pools. It might be due to 
Task::terminate doesn't call remove partition output for some error before
reaches to that point. This PR adds to remove the task from partition output
buffer manager in case it happens.

```
ARBITRATOR[SHARED CAPACITY[38.00GB] RUNNING[false] QUEUING[0] STATS[numRequests 15910 numSucceeded 15890 numAborted 0 numFailures 20 numNonReclaimableAttempts 0 numReserves 11004 numReleases 10995 queueTime 17h 10m 31s arbitrationTime 17h 25m 41s reclaimTime 14m 27s shrunkMemory 4.16TB reclaimedMemory 5.52GB maxCapacity 38.00GB freeCapacity 37.50GB]]], Source: RUNTIME, ErrorCode: INVALID_STATE
E0107 16:24:33.419667    86 ExceptionTracer.cpp:218] terminate() called, exception stack follows
E0107 16:24:33.419674    86 ExceptionTracer.cpp:220] Exception type: facebook::velox::VeloxRuntimeError (9 frames)
    @ 0000000004184f0c __cxa_throw
                       ./fbcode/folly/experimental/exception_tracer/ExceptionTracerLib.cpp:75
    @ 00000000047ade9c void facebook::velox::detail::veloxCheckFail<facebook::velox::VeloxRuntimeError, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>(facebook::velox::detail::VeloxCheckFailArgs const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
                       fbcode/velox/common/base/Exceptions.h:76
    @ 00000000069bce39 facebook::velox::memory::MemoryManager::~MemoryManager()
                       ./fbcode/velox/common/memory/Memory.cpp:120
    @ 00000000069bd859 std::unique_ptr<facebook::velox::memory::MemoryManager, std::default_delete<facebook::velox::memory::MemoryManager> >::~unique_ptr()
                       fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/bits/unique_ptr.h:85
    @ 0000000000047897 __run_exit_handlers
    @ 00000000000479a9 __GI_exit
    @ 000000000002c65d __libc_start_call_main
    @ 000000000002c717 __libc_start_main_alias_2
    @ 000000000565faa0 _start
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/csu/../sysdeps/x86_64/start.S:116
E0107 16:24:33.470386    86 ExceptionTracer.cpp:222] exception stack complete
terminate called after throwing an instance of 'facebook::velox::VeloxRuntimeError'
  what():  Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: pools_.size() != 0 (9 vs 0). There are unexpected alive memory pools allocated by user on memory manager destruction:
Memory Manager[capacity 45.00GB alignment 64B usedBytes 0B number of pools 10
List of root pools:
__sys_root__ usage 0B reserved 0B peak 769.00MB
20240107_215342_42863_nuqxc_10139 usage 0B reserved 0B peak 33.00MB
	refcount 2
20240107_144721_30763_nuqxc_7117 usage 0B reserved 0B peak 1.00MB
	refcount 2
20240107_145457_30987_nuqxc_6701 usage 0B reserved 0B peak 1.26GB
	refcount 2
20240107_090541_12475_nuqxc_2956 usage 0B reserved 0B peak 133.00MB
	refcount 2
20240107_085446_11191_nuqxc_2789 usage 0B reserved 0B peak 6.94GB
	refcount 2
20240107_084351_10752_nuqxc_2662 usage 0B reserved 0B peak 7.00GB
	refcount 2
20240107_084213_10599_nuqxc_2638 usage 0B reserved 0B peak 7.00GB
	refcount 2
20240107_083653_10158_nuqxc_2581 usage 0B reserved 0B peak 3.30GB
	refcount 2
20240107_074343_06594_nuqxc_2154 usage 0B reserved 0B peak 20.00MB
	refcount 2
Memory Allocator[MMAP capacity 11.25MB allocated pages 0 mapped pages 5022866 external mapped pages 0
[size 1: 0(0MB) allocated 128778 mapped]
[size 2: 0(0MB) allocated 462014 mapped]
[size 4: 0(0MB) allocated 67253 mapped]
[size 8: 0(0MB) allocated 17741 mapped]
[size 16: 0(0MB) allocated 15143 mapped]
[size 32: 0(0MB) allocated 19951 mapped]
[size 64: 0(0MB) allocated 22644 mapped]
[size 128: 0(0MB) allocated 4169 mapped]
[size 256: 0(0MB) allocated 2717 mapped]
```