### PR TITLE
Add support for allocations that exceed the PageRun limit

### DIFF
--- a/velox/common/memory/Allocation.cpp
+++ b/velox/common/memory/Allocation.cpp
@@ -30,13 +30,19 @@ Allocation::~Allocation() {
   }
 }
 
-void Allocation::append(uint8_t* address, int32_t numPages) {
+void Allocation::append(uint8_t* address, uint32_t numPages) {
   numPages_ += numPages;
   VELOX_CHECK(
       runs_.empty() || address != runs_.back().data(),
       "Appending a duplicate address into a PageRun");
-  runs_.emplace_back(address, numPages);
+  while (numPages > 0) {
+    const auto numPagesInRun = std::min(numPages, PageRun::kMaxPagesInRun);
+    runs_.emplace_back(address, numPagesInRun);
+    address += AllocationTraits::pageBytes(numPagesInRun);
+    numPages -= numPagesInRun;
+  }
 }
+
 void Allocation::appendMove(Allocation& other) {
   for (auto& run : other.runs_) {
     numPages_ += run.numPages();

--- a/velox/common/memory/Allocation.cpp
+++ b/velox/common/memory/Allocation.cpp
@@ -30,13 +30,14 @@ Allocation::~Allocation() {
   }
 }
 
-void Allocation::append(uint8_t* address, uint32_t numPages) {
+void Allocation::append(uint8_t* address, MachinePageCount numPages) {
   numPages_ += numPages;
   VELOX_CHECK(
       runs_.empty() || address != runs_.back().data(),
       "Appending a duplicate address into a PageRun");
   while (numPages > 0) {
-    const auto numPagesInRun = std::min(numPages, PageRun::kMaxPagesInRun);
+    const auto numPagesInRun = std::min(
+        numPages, static_cast<MachinePageCount>(PageRun::kMaxPagesInRun));
     runs_.emplace_back(address, numPagesInRun);
     address += AllocationTraits::pageBytes(numPagesInRun);
     numPages -= numPagesInRun;

--- a/velox/common/memory/Allocation.h
+++ b/velox/common/memory/Allocation.h
@@ -171,7 +171,7 @@ class Allocation {
     VELOX_CHECK(numPages_ != 0 || pool_ == nullptr);
   }
 
-  void append(uint8_t* address, int32_t numPages);
+  void append(uint8_t* address, uint32_t numPages);
 
   void clear() {
     runs_.clear();
@@ -193,6 +193,7 @@ class Allocation {
   VELOX_FRIEND_TEST(MemoryAllocatorTest, allocationClass2);
   VELOX_FRIEND_TEST(AllocationTest, append);
   VELOX_FRIEND_TEST(AllocationTest, appendMove);
+  VELOX_FRIEND_TEST(AllocationTest, multiplePageRuns);
 };
 
 /// Represents a run of contiguous pages that do not belong to any size class.
@@ -263,7 +264,7 @@ class ContiguousAllocation {
 
   // Adjusts 'size' towards 'maxSize' by 'increment' pages. Rounds
   // 'increment' to huge pages, since this is the unit of growth of
-  // RSS for large contiguous runs.  Increases the reservation in in
+  // RSS for large contiguous runs.  Increases the reservation in
   // 'pool_' and its allocator. May fail by cap exceeded. If failing,
   // the size is not changed. 'size_' cannot exceed 'maxSize_'.
   void grow(MachinePageCount increment);

--- a/velox/common/memory/Allocation.h
+++ b/velox/common/memory/Allocation.h
@@ -171,7 +171,7 @@ class Allocation {
     VELOX_CHECK(numPages_ != 0 || pool_ == nullptr);
   }
 
-  void append(uint8_t* address, uint32_t numPages);
+  void append(uint8_t* address, MachinePageCount numPages);
 
   void clear() {
     runs_.clear();

--- a/velox/common/memory/MallocAllocator.cpp
+++ b/velox/common/memory/MallocAllocator.cpp
@@ -72,7 +72,7 @@ bool MallocAllocator::allocateNonContiguousWithoutRetry(
     }
   }
 
-  std::vector<void*> pages;
+  std::unordered_map<void*, MachinePageCount> pages;
   pages.reserve(mix.numSizes);
   for (int32_t i = 0; i < mix.numSizes; ++i) {
     MachinePageCount numSizeClassPages =
@@ -99,14 +99,14 @@ bool MallocAllocator::allocateNonContiguousWithoutRetry(
       setAllocatorFailureMessage(errorMsg);
       break;
     }
-    pages.emplace_back(ptr);
+    pages.emplace(ptr, numSizeClassPages);
     out.append(reinterpret_cast<uint8_t*>(ptr), numSizeClassPages); // NOLINT
   }
 
   if (pages.size() != mix.numSizes) {
     // Failed to allocate memory using malloc. Free any malloced pages and
     // return false.
-    for (auto ptr : pages) {
+    for (const auto& [ptr, numMachinePages] : pages) {
       ::free(ptr);
     }
     out.clear();
@@ -242,20 +242,28 @@ int64_t MallocAllocator::freeNonContiguous(Allocation& allocation) {
   MachinePageCount numFreed = 0;
   for (int32_t i = 0; i < allocation.numRuns(); ++i) {
     Allocation::PageRun run = allocation.runAt(i);
-    numFreed += run.numPages();
     void* ptr = run.data();
+    MachinePageCount numPages;
     {
       std::lock_guard<std::mutex> l(mallocsMutex_);
-      const auto ret = mallocs_.erase(ptr);
-      VELOX_CHECK_EQ(ret, 1, "Bad free page pointer: {}", ptr);
+      const auto mapElement = mallocs_.find(ptr);
+      VELOX_CHECK(
+          mapElement != mallocs_.end(), "Bad free page pointer: {}", ptr);
+      numPages = mapElement->second;
+      mallocs_.erase(mapElement);
     }
-    stats_.recordFree(
-        std::min<int64_t>(
-            AllocationTraits::pageBytes(sizeClassSizes_.back()),
-            AllocationTraits::pageBytes(run.numPages())),
-        [&]() {
-          ::free(ptr); // NOLINT
-        });
+    numFreed += numPages;
+    stats_.recordFree(AllocationTraits::pageBytes(numPages), [&]() {
+      ::free(ptr); // NOLINT
+    });
+    auto pagesInCurrentRun = run.numPages();
+    // It is possible that an allocation spans multiple PageRuns.
+    while (numPages > pagesInCurrentRun) {
+      numPages -= pagesInCurrentRun;
+      VELOX_CHECK_LT(++i, allocation.numRuns());
+      pagesInCurrentRun = allocation.runAt(i).numPages();
+    }
+    VELOX_CHECK_EQ(numPages, pagesInCurrentRun);
   }
 
   const auto freedBytes = AllocationTraits::pageBytes(numFreed);

--- a/velox/common/memory/MallocAllocator.h
+++ b/velox/common/memory/MallocAllocator.h
@@ -161,8 +161,12 @@ class MallocAllocator : public MemoryAllocator {
   /// Mutex for 'mallocs_'.
   std::mutex mallocsMutex_;
 
-  /// Tracks malloc'd pointers to detect bad frees.
-  std::unordered_set<void*> mallocs_;
+  /// Tracks malloc'd pointers and the corresponding MachinePageCount in
+  /// non-contiguous allocations to detect bad frees.
+  /// Since an allocation can span across multiple PageRuns, we need to store
+  /// the MachinePageCount for each allocation to identify allocation boundaries
+  /// across the PageRuns.
+  std::unordered_map<void*, MachinePageCount> mallocs_;
 
   std::shared_ptr<Cache> cache_;
 };

--- a/velox/common/memory/MallocAllocator.h
+++ b/velox/common/memory/MallocAllocator.h
@@ -158,15 +158,15 @@ class MallocAllocator : public MemoryAllocator {
   /// Current total allocated bytes by this 'MallocAllocator'.
   std::atomic<int64_t> allocatedBytes_{0};
 
-  /// Mutex for 'mallocs_'.
-  std::mutex mallocsMutex_;
+  /// Mutex for 'nonContiguousMallocs_'.
+  std::mutex nonContiguousMallocsMutex_;
 
   /// Tracks malloc'd pointers and the corresponding MachinePageCount in
   /// non-contiguous allocations to detect bad frees.
   /// Since an allocation can span across multiple PageRuns, we need to store
   /// the MachinePageCount for each allocation to identify allocation boundaries
   /// across the PageRuns.
-  std::unordered_map<void*, MachinePageCount> mallocs_;
+  std::unordered_map<void*, MachinePageCount> nonContiguousMallocs_;
 
   std::shared_ptr<Cache> cache_;
 };

--- a/velox/common/memory/MemoryAllocator.cpp
+++ b/velox/common/memory/MemoryAllocator.cpp
@@ -98,14 +98,6 @@ MemoryAllocator::SizeMix MemoryAllocator::allocationSize(
       ++numUnits;
       needed -= size;
     }
-    if (FOLLY_UNLIKELY(numUnits * size > Allocation::PageRun::kMaxPagesInRun)) {
-      VELOX_MEM_ALLOC_ERROR(fmt::format(
-          "Too many pages {} to allocate, the number of units {} at size class of {} exceeds the PageRun limit {}",
-          numPages,
-          numUnits,
-          size,
-          Allocation::PageRun::kMaxPagesInRun));
-    }
     mix.sizeCounts[mix.numSizes] = numUnits;
     pagesToAlloc += numUnits * size;
     mix.sizeIndices[mix.numSizes++] = sizeIndex;

--- a/velox/common/memory/tests/AllocationTest.cpp
+++ b/velox/common/memory/tests/AllocationTest.cpp
@@ -85,4 +85,26 @@ TEST_F(AllocationTest, appendMove) {
   allocation.clear();
 }
 
+TEST_F(AllocationTest, multiplePageRuns) {
+  Allocation allocation;
+  const uint64_t startBufAddrValue = 4096;
+  uint8_t* const firstBufAddr = reinterpret_cast<uint8_t*>(startBufAddrValue);
+  allocation.append(firstBufAddr, Allocation::PageRun::kMaxPagesInRun + 100);
+  ASSERT_EQ(allocation.numPages(), Allocation::PageRun::kMaxPagesInRun + 100);
+  ASSERT_EQ(allocation.numRuns(), 2);
+
+  uint8_t* const secondBufAddr = reinterpret_cast<uint8_t*>(
+      startBufAddrValue + AllocationTraits::pageBytes(allocation.numPages()));
+  allocation.append(secondBufAddr, Allocation::PageRun::kMaxPagesInRun - 100);
+  ASSERT_EQ(allocation.numPages(), Allocation::PageRun::kMaxPagesInRun * 2);
+  ASSERT_EQ(allocation.numRuns(), 3);
+
+  uint8_t* const thirdBufAddr = reinterpret_cast<uint8_t*>(
+      firstBufAddr + 2 * AllocationTraits::pageBytes(allocation.numPages()));
+  allocation.append(thirdBufAddr, Allocation::PageRun::kMaxPagesInRun * 2);
+  ASSERT_EQ(allocation.numPages(), Allocation::PageRun::kMaxPagesInRun * 4);
+  ASSERT_EQ(allocation.numRuns(), 5);
+  allocation.clear();
+}
+
 } // namespace facebook::velox::memory

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -1342,14 +1342,13 @@ TEST_P(MemoryAllocatorTest, StlMemoryAllocator) {
   }
 }
 
-TEST_P(MemoryAllocatorTest, badNonContiguousAllocation) {
+TEST_P(MemoryAllocatorTest, nonContiguousAllocationBounds) {
   // Set the num of pages to allocate exceeds one PageRun limit.
   constexpr MachinePageCount kNumPages =
       Allocation::PageRun::kMaxPagesInRun + 1;
   std::unique_ptr<Allocation> allocation(new Allocation());
-  ASSERT_THROW(
-      instance_->allocateNonContiguous(kNumPages, *allocation),
-      VeloxRuntimeError);
+  ASSERT_TRUE(instance_->allocateNonContiguous(kNumPages, *allocation));
+  instance_->freeNonContiguous(*allocation);
   ASSERT_TRUE(instance_->allocateNonContiguous(kNumPages - 1, *allocation));
   instance_->freeNonContiguous(*allocation);
 }

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -1784,9 +1784,9 @@ TEST_P(MemoryPoolTest, contiguousAllocateGrowExceedMemoryPoolLimit) {
   ASSERT_EQ(allocation.numPages(), kMaxNumPages / 2);
 }
 
-TEST_P(MemoryPoolTest, badNonContiguousAllocation) {
+TEST_P(MemoryPoolTest, nonContiguousAllocationBounds) {
   auto manager = getMemoryManager();
-  auto pool = manager->addLeafPool("badNonContiguousAllocation");
+  auto pool = manager->addLeafPool("nonContiguousAllocationBounds");
   Allocation allocation;
   // Bad zero page allocation size.
   ASSERT_THROW(pool->allocateNonContiguous(0, allocation), VeloxRuntimeError);
@@ -1794,8 +1794,9 @@ TEST_P(MemoryPoolTest, badNonContiguousAllocation) {
   // Set the num of pages to allocate exceeds one PageRun limit.
   constexpr MachinePageCount kNumPages =
       Allocation::PageRun::kMaxPagesInRun + 1;
-  ASSERT_THROW(
-      pool->allocateNonContiguous(kNumPages, allocation), VeloxRuntimeError);
+  pool->allocateNonContiguous(kNumPages, allocation);
+  ASSERT_GE(allocation.numPages(), kNumPages);
+  pool->freeNonContiguous(allocation);
   pool->allocateNonContiguous(kNumPages - 1, allocation);
   ASSERT_GE(allocation.numPages(), kNumPages - 1);
   pool->freeNonContiguous(allocation);


### PR DESCRIPTION
This change enables an allocation to exceed the PageRun limit. We do this by splitting an allocation
across multiple PageRuns.
Non-contiguous allocations in the MallocAllocator use malloc to allocate and store the address
to later verify the allocation. Since an allocation can now span across multiple PageRuns, we need to
store the MachinePageCount for each allocation to identify allocation boundaries across the PageRuns.
Fix stats for `recordFree` in MallocAllocator nonContiguousFree.