### PR TITLE
Fix crash in future callback in ExchangeClient::request().

### DIFF
--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -22,7 +22,7 @@ namespace facebook::velox::exec {
 
 // Handle for a set of producers. This may be shared by multiple Exchanges, one
 // per consumer thread.
-class ExchangeClient {
+class ExchangeClient : public std::enable_shared_from_this<ExchangeClient> {
  public:
   static constexpr int32_t kDefaultMaxQueuedBytes = 32 << 20; // 32 MB.
   static constexpr int32_t kDefaultMaxWaitSeconds = 2;

--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -123,7 +123,7 @@ class MergeExchangeSource : public MergeSource {
       int64_t maxQueuedBytes,
       memory::MemoryPool* pool)
       : mergeExchange_(mergeExchange),
-        client_(std::make_unique<ExchangeClient>(
+        client_(std::make_shared<ExchangeClient>(
             taskId,
             destination,
             pool,
@@ -187,7 +187,7 @@ class MergeExchangeSource : public MergeSource {
 
  private:
   MergeExchange* const mergeExchange_;
-  std::unique_ptr<ExchangeClient> client_;
+  std::shared_ptr<ExchangeClient> client_;
   std::optional<ByteInputStream> inputStream_;
   std::unique_ptr<SerializedPage> currentPage_;
   bool atEnd_ = false;


### PR DESCRIPTION
Summary:
It might be possible for ExchangeClient object to be destroyed
before ExchangeSource::request() got result.
Getting result in ExchangeSource::request() sets the promise's value,
which triggers future callback in ExchangeClient::request().
Having captured only 'this' we can address memory of already destroyed
instance of ExchangeClient, thus causing segfault.

This crash is pretty rare.
In this change we capture ExchangeClient by shared pointer to avoid
such scenario.

Reviewed By: mbasmanova

Differential Revision: D52609608


