### PR TITLE
Do not use TimestampWithTimezoneSupport for Spark's DayOfWeekFunction

### DIFF
--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -16,7 +16,6 @@
 
 #include "velox/functions/lib/DateTimeFormatter.h"
 #include "velox/functions/lib/TimeUtils.h"
-#include "velox/functions/prestosql/DateTimeImpl.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox::functions::sparksql {
@@ -299,8 +298,7 @@ struct DateSubFunction {
 };
 
 template <typename T>
-struct DayOfWeekFunction : public InitSessionTimezone<T>,
-                           public TimestampWithTimezoneSupport<T> {
+struct DayOfWeekFunction : public InitSessionTimezone<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   // 1 = Sunday, 2 = Monday, ..., 7 = Saturday


### PR DESCRIPTION
Remove the Spark Function `DayOfWeekFunction` extends `TimestampWithTimezoneSupport`.

For following reasons:
1. `TimestampWithTimezoneSupport` is `prestosql`'s struct, we should not extends across modules.
2. `TimestampWithTimezoneSupport` not been used in `DayOfWeekFunction`