### PR TITLE
Allow offline pre-compilation of 'xsimd' dependency

### DIFF
--- a/.circleci/dist_compile.yml
+++ b/.circleci/dist_compile.yml
@@ -395,6 +395,7 @@ jobs:
       VELOX_DEPENDENCY_SOURCE: SYSTEM
       ICU_SOURCE: BUNDLED
       simdjson_SOURCE: BUNDLED
+      xsimd_SOURCE: BUNDLED
       DuckDB_SOURCE: SYSTEM
     steps:
       - pre-steps

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -545,7 +545,7 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
 endif()
 
 set_source(xsimd)
-resolve_dependency(xsimd)
+resolve_dependency(xsimd 10.0.0)
 
 if(VELOX_BUILD_TESTING)
   set(BUILD_TESTING ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,7 +544,7 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
       PARENT_SCOPE)
 endif()
 
-set(xsimd_SOURCE BUNDLED)
+set_source(xsimd)
 resolve_dependency(xsimd)
 
 if(VELOX_BUILD_TESTING)


### PR DESCRIPTION
`set(xsimd_SOURCE BUNDLED)` will force the 'xsimd' library to be
compiled from source, but this will make it impossible to compile Velox
offline. We should use `set_source(xsimd)` so that it respects the
`VELOX_DEPENDENCY_SOURCE` global cmake variable.

If it is really needed to force the 'xsimd' library to be compiled from
source in a certain environment, use the following method to achieve it.

```
cmake -Dxsimd_SOURCE=BUNDLED ...
```