### PR TITLE
Fix documentation for HiveConfig hive.s3.use-instance-credentials

### DIFF
--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -496,7 +496,7 @@ Each query can override the config by setting corresponding query session proper
      - Description
    * - hive.s3.use-instance-credentials
      - bool
-     - true
+     - false
      - Use the EC2 metadata service to retrieve API credentials. This works with IAM roles in EC2.
    * - hive.s3.aws-access-key
      - string


### PR DESCRIPTION
The default value is false.
https://github.com/facebookincubator/velox/blob/005e5457d146ab42b0ad421f902853b441b11ea7/velox/connectors/hive/HiveConfig.cpp#L93
