### PR TITLE
Add option to print out the child memory pools with empty usage in treeMemoryUsage

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -280,14 +280,14 @@ std::string MemoryManager::toString(bool detail) const {
       << "\n";
   out << "List of root pools:\n";
   if (detail) {
-    out << defaultRoot_->treeMemoryUsage();
+    out << defaultRoot_->treeMemoryUsage(false);
   } else {
     out << "\t" << defaultRoot_->name() << "\n";
   }
   std::vector<std::shared_ptr<MemoryPool>> pools = getAlivePools();
   for (const auto& pool : pools) {
     if (detail) {
-      out << pool->treeMemoryUsage();
+      out << pool->treeMemoryUsage(true);
     } else {
       out << "\t" << pool->name() << "\n";
     }

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -466,8 +466,9 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   virtual std::string toString() const = 0;
 
   /// Invoked to generate a descriptive memory usage summary of the entire tree.
-  /// MemoryPoolImpl::treeMemoryUsage()
-  virtual std::string treeMemoryUsage() const = 0;
+  /// MemoryPoolImpl::treeMemoryUsage(). If 'skipEmptyPool' is true, then skip
+  /// print out the child memory pools with empty memory usage.
+  virtual std::string treeMemoryUsage(bool skipEmptyPool = true) const = 0;
 
   /// Indicates if this is a leaf memory pool or not.
   FOLLY_ALWAYS_INLINE bool isLeaf() const {
@@ -650,30 +651,30 @@ class MemoryPoolImpl : public MemoryPool {
     return toStringLocked();
   }
 
-  // Detailed debug pool state printout by traversing the pool structure from
-  // the root memory pool.
-  //
-  // Exceeded memory cap of 5.00MB when requesting 2.00MB
-  // default_root_1 usage 5.00MB peak 5.00MB
-  //     task.test_cursor 1 usage 5.00MB peak 5.00MB
-  //         node.N/A usage 0B peak 0B
-  //             op.N/A.0.0.CallbackSink usage 0B peak 0B
-  //         node.2 usage 4.00MB peak 4.00MB
-  //             op.2.0.0.Aggregation usage 3.77MB peak 3.77MB
-  //         node.1 usage 1.00MB peak 1.00MB
-  //             op.1.0.0.FilterProject usage 12.00KB peak 12.00KB
-  //         node.3 usage 0B peak 0B
-  //             op.3.0.0.OrderBy usage 0B peak 0B
-  //         node.0 usage 0B peak 0B
-  //             op.0.0.0.Values usage 0B peak 0B
-  //
-  // Top 5 leaf memory pool usages:
-  //     op.2.0.0.Aggregation usage 3.77MB peak 3.77MB
-  //     op.1.0.0.FilterProject usage 12.00KB peak 12.00KB
-  //     op.N/A.0.0.CallbackSink usage 0B peak 0B
-  //     op.3.0.0.OrderBy usage 0B peak 0B
-  //     op.0.0.0.Values usage 0B peak 0B
-  std::string treeMemoryUsage() const override;
+  /// Detailed debug pool state printout by traversing the pool structure from
+  /// the root memory pool.
+  ///
+  /// Exceeded memory cap of 5.00MB when requesting 2.00MB
+  /// default_root_1 usage 5.00MB peak 5.00MB
+  ///     task.test_cursor 1 usage 5.00MB peak 5.00MB
+  ///         node.N/A usage 0B peak 0B
+  ///             op.N/A.0.0.CallbackSink usage 0B peak 0B
+  ///         node.2 usage 4.00MB peak 4.00MB
+  ///             op.2.0.0.Aggregation usage 3.77MB peak 3.77MB
+  ///         node.1 usage 1.00MB peak 1.00MB
+  ///             op.1.0.0.FilterProject usage 12.00KB peak 12.00KB
+  ///         node.3 usage 0B peak 0B
+  ///             op.3.0.0.OrderBy usage 0B peak 0B
+  ///         node.0 usage 0B peak 0B
+  ///             op.0.0.0.Values usage 0B peak 0B
+  ///
+  /// Top 5 leaf memory pool usages:
+  ///     op.2.0.0.Aggregation usage 3.77MB peak 3.77MB
+  ///     op.1.0.0.FilterProject usage 12.00KB peak 12.00KB
+  ///     op.N/A.0.0.CallbackSink usage 0B peak 0B
+  ///     op.3.0.0.OrderBy usage 0B peak 0B
+  ///     op.0.0.0.Values usage 0B peak 0B
+  std::string treeMemoryUsage(bool skipEmptyPool = true) const override;
 
   Stats stats() const override;
 

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include <gmock/gmock-matchers.h>
 #include "velox/common/base/VeloxException.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/MallocAllocator.h"
@@ -280,6 +281,20 @@ TEST_F(MemoryManagerTest, defaultMemoryManager) {
   ASSERT_EQ(
       managerB.toString(),
       "Memory Manager[capacity UNLIMITED alignment 64B usedBytes 0B number of pools 1\nList of root pools:\n\t__sys_root__\nMemory Allocator[MALLOC capacity UNLIMITED allocated bytes 0 allocated pages 0 mapped pages 0]\nARBIRTATOR[NOOP CAPACITY[UNLIMITED]]]");
+  const std::string detailedManagerStr = managerA.toString(true);
+  ASSERT_THAT(
+      detailedManagerStr,
+      testing::HasSubstr(
+          "Memory Manager[capacity UNLIMITED alignment 64B usedBytes 0B number of pools 1\nList of root pools:\n__sys_root__ usage 0B reserved 0B peak 0B\n"));
+  ASSERT_THAT(
+      detailedManagerStr,
+      testing::HasSubstr("__sys_spilling__ usage 0B reserved 0B peak 0B\n"));
+  for (int i = 0; i < 32; ++i) {
+    ASSERT_THAT(
+        managerA.toString(true),
+        testing::HasSubstr(fmt::format(
+            "default_shared_leaf_pool_{} usage 0B reserved 0B peak 0B\n", i)));
+  }
 }
 
 // TODO: remove this test when remove deprecatedAddDefaultLeafMemoryPool.

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -137,7 +137,7 @@ class MemoryPoolTest : public testing::TestWithParam<TestParam> {
   MemoryReclaimer::Stats stats_;
 };
 
-TEST_P(MemoryPoolTest, Ctor) {
+TEST_P(MemoryPoolTest, ctor) {
   constexpr uint16_t kAlignment = 64;
   setupMemory({.alignment = 64, .allocatorCapacity = kDefaultCapacity});
   MemoryManager& manager = *getMemoryManager();
@@ -203,7 +203,7 @@ TEST_P(MemoryPoolTest, Ctor) {
       "Memory pool rootWithZeroMaxCapacity max capacity can't be zero");
 }
 
-TEST_P(MemoryPoolTest, AddChild) {
+TEST_P(MemoryPoolTest, addChild) {
   MemoryManager& manager = *getMemoryManager();
   auto root = manager.addRootPool("root");
   ASSERT_EQ(root->parent(), nullptr);
@@ -227,6 +227,18 @@ TEST_P(MemoryPoolTest, AddChild) {
   ASSERT_EQ(root->getChildCount(), 1);
   childOne = root->addLeafChild("child_one", isLeafThreadSafe_);
   ASSERT_EQ(root->getChildCount(), 2);
+  ASSERT_EQ(root->treeMemoryUsage(), "root usage 0B reserved 0B peak 0B\n");
+  ASSERT_EQ(root->treeMemoryUsage(true), "root usage 0B reserved 0B peak 0B\n");
+  const std::string treeUsageWithEmptyPool = root->treeMemoryUsage(false);
+  ASSERT_THAT(
+      treeUsageWithEmptyPool,
+      testing::HasSubstr("root usage 0B reserved 0B peak 0B\n"));
+  ASSERT_THAT(
+      treeUsageWithEmptyPool,
+      testing::HasSubstr("child_one usage 0B reserved 0B peak 0B\n"));
+  ASSERT_THAT(
+      treeUsageWithEmptyPool,
+      testing::HasSubstr("child_two usage 0B reserved 0B peak 0B\n"));
 }
 
 TEST_P(MemoryPoolTest, dropChild) {

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -225,7 +225,7 @@ class MockMemoryPool : public velox::memory::MemoryPool {
     VELOX_UNSUPPORTED("{} unsupported", __FUNCTION__);
   }
 
-  std::string treeMemoryUsage() const override {
+  std::string treeMemoryUsage(bool /*unused*/) const override {
     VELOX_UNSUPPORTED("{} unsupported", __FUNCTION__);
   }
 


### PR DESCRIPTION
Add a detail option print out the child memory pools with empty memory usage
in treeMemoryUsage. And use it in memory pool leak error message in memory
manager
