### PR TITLE
Setup AggregationFuzzer to use Presto as source of truth in experimental jobs.

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -96,33 +96,53 @@ jobs:
 
 
   presto-java-aggregation-fuzzer-run:
-    runs-on: ubuntu-latest
+    runs-on: 8-core
     container: ghcr.io/facebookincubator/velox-dev:presto-java
-    needs: compile
     timeout-minutes: 120
+    env:
+      CCACHE_DIR: "${{ github.workspace }}/.ccache/"
+      CCACHE_BASEDIR: "${{ github.workspace }}"
+      LINUX_DISTRO: "centos"
     steps:
+
+      - name: "Restore ccache"
+        uses: actions/cache@v3
+        with:
+          path: "${{ env.CCACHE_DIR }}"
+          # We are using the benchmark ccache as it has all
+          # required features enabled, so no need to create a new one
+          key: ccache-presto-${{ github.sha }}
+          restore-keys: |
+            ccache-presto-
 
       - name: "Checkout Repo"
         uses: actions/checkout@v3
         with:
+          path: velox
+          submodules: 'recursive'
           ref: "${{ inputs.ref || 'main' }}"
 
-      - name: "Install dependencies"
-        run: source ./scripts/setup-ubuntu.sh
 
-      - name: Download aggregation fuzzer
-        uses: actions/download-artifact@v3
-        with:
-          name: aggregation
+      - name: "Build"
+        run: |
+          cd velox
+          source /opt/rh/gcc-toolset-9/enable
+          make debug NUM_THREADS="${{ inputs.numThreads || 8 }}" MAX_HIGH_MEM_JOBS="${{ inputs.maxHighMemJobs || 8 }}" MAX_LINK_JOBS="${{ inputs.maxLinkJobs || 4 }}" EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON ${{ inputs.extraCMakeFlags }}"
+          ccache -s
 
       - name: "Run Aggregate Fuzzer"
         run: |
-          /opt/start-prestojava.sh 2>&1 >> /tmp/server.log &
+          cd  velox
+          cp ./scripts/etc/hive.properties $PRESTO_HOME/etc/catalog
+          ls -lR $PRESTO_HOME/etc
+          /opt/start-prestojava.sh > /tmp/server.log 2>&1 &
+          # Sleep for 60 seconds to allow Presto server to start.
+          sleep 60          
+          /opt/presto-cli --server 127.0.0.1:8080 --execute 'CREATE SCHEMA hive.tpch;'
           mkdir -p /tmp/aggregate_fuzzer_repro/
           rm -rfv /tmp/aggregate_fuzzer_repro/*
           chmod -R 777 /tmp/aggregate_fuzzer_repro
-          chmod +x velox_aggregation_fuzzer_test
-          ./velox_aggregation_fuzzer_test \
+          _build/debug/velox/functions/prestosql/fuzzer/velox_aggregation_fuzzer_test \
                 --seed ${RANDOM} \
                 --duration_sec 3600 \
                 --logtostderr=1 \
@@ -139,6 +159,7 @@ jobs:
           name: aggregate-fuzzer-failure-artifacts
           path: |
             /tmp/aggregate_fuzzer_repro
+            /tmp/server.log
 
   linux-spark-fuzzer-run:
     runs-on: ubuntu-latest

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -115,6 +115,10 @@ jobs:
         with:
           name: aggregation
 
+      - name: "Start Presto Java"
+        - run: |
+            - /opt/start-prestojava.sh
+
       - name: "Run Aggregate Fuzzer"
         run: |
           mkdir -p /tmp/aggregate_fuzzer_repro/
@@ -128,6 +132,7 @@ jobs:
                 --minloglevel=0 \
                 --repro_persist_path=/tmp/aggregate_fuzzer_repro \
                 --enable_sorted_aggregations=true \
+                --presto_url=http://127.0.0.1:8080 \
           && echo -e "\n\nAggregation fuzzer run finished successfully."
       - name: Archive aggregate production artifacts
         if: always()

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: aggregation
-          path: velox/_build/debug/velox/exec/tests/velox_aggregation_fuzzer_test
+          path: velox/_build/debug/velox/functions/prestosql/fuzzer/velox_aggregation_fuzzer_test
 
       - name: Upload spark fuzzer
         uses: actions/upload-artifact@v3
@@ -115,12 +115,9 @@ jobs:
         with:
           name: aggregation
 
-      - name: "Start Presto Java"
-        - run: |
-            - /opt/start-prestojava.sh
-
       - name: "Run Aggregate Fuzzer"
         run: |
+          /opt/start-prestojava.sh 2>&1 >> /tmp/server.log &
           mkdir -p /tmp/aggregate_fuzzer_repro/
           rm -rfv /tmp/aggregate_fuzzer_repro/*
           chmod -R 777 /tmp/aggregate_fuzzer_repro
@@ -134,6 +131,7 @@ jobs:
                 --enable_sorted_aggregations=true \
                 --presto_url=http://127.0.0.1:8080 \
           && echo -e "\n\nAggregation fuzzer run finished successfully."
+
       - name: Archive aggregate production artifacts
         if: always()
         uses: actions/upload-artifact@v3

--- a/scripts/etc/hive.properties
+++ b/scripts/etc/hive.properties
@@ -1,0 +1,4 @@
+connector.name=hive-hadoop2
+hive.metastore=file
+hive.metastore.catalog.dir=file:/opt/presto-server/etc/data
+hive.allow-drop-table=true

--- a/scripts/etc/jvm.config.example
+++ b/scripts/etc/jvm.config.example
@@ -7,3 +7,4 @@
 -XX:+HeapDumpOnOutOfMemoryError
 -XX:+ExitOnOutOfMemoryError
 -Djdk.attach.allowAttachSelf=true
+-Duser.timezone=America/Los_Angeles

--- a/scripts/etc/node.properties
+++ b/scripts/etc/node.properties
@@ -1,2 +1,3 @@
-node.environment=test
-node.data-dir=/var/lib/presto/data
+node.environment=production
+node.id=ffffffff-ffff-ffff-ffff-ffffffffffff
+node.data-dir=/tmp/presto/data

--- a/scripts/prestojava-container.dockerfile
+++ b/scripts/prestojava-container.dockerfile
@@ -39,9 +39,9 @@ RUN dnf install -y java-11-openjdk less procps python3 tzdata \
     && mkdir -p $PRESTO_HOME/etc/data \
     && mkdir -p /usr/lib/presto/utils
 
-
-# Setting timezone to deal with Velox timezone conversion problem
-ENV TZ=America/Bahia_Banderas
+# We set the timezone to America/Los_Angeles due to issue
+# detailed here : https://github.com/facebookincubator/velox/issues/8127
+ENV TZ=America/Los_Angeles
 
 COPY scripts/etc/config.properties.example $PRESTO_HOME/etc/config.properties
 COPY scripts/etc/jvm.config.example $PRESTO_HOME/etc/jvm.config

--- a/scripts/prestojava-container.dockerfile
+++ b/scripts/prestojava-container.dockerfile
@@ -36,12 +36,13 @@ RUN dnf install -y java-11-openjdk less procps python3 \
     && ln -s /opt/presto-cli /usr/local/bin/ \
     && mkdir -p $PRESTO_HOME/etc \
     && mkdir -p $PRESTO_HOME/etc/catalog \
-    && mkdir -p /var/lib/presto/data \
+    && mkdir -p $PRESTO_HOME/etc/data \
     && mkdir -p /usr/lib/presto/utils
 
 COPY scripts/etc/config.properties.example $PRESTO_HOME/etc/config.properties
 COPY scripts/etc/jvm.config.example $PRESTO_HOME/etc/jvm.config
 COPY scripts/etc/node.properties $PRESTO_HOME/etc/node.properties
+COPY scripts/etc/hive.properties $PRESTO_HOME/etc/catalog
 COPY scripts/start-prestojava.sh /opt
 
 WORKDIR /velox

--- a/scripts/prestojava-container.dockerfile
+++ b/scripts/prestojava-container.dockerfile
@@ -28,7 +28,7 @@ ARG PRESTO_CLI_JAR=presto-cli-$PRESTO_VERSION-executable.jar
 ENV PRESTO_HOME="/opt/presto-server"
 RUN cp $PRESTO_CLI_JAR /opt/presto-cli
 
-RUN dnf install -y java-11-openjdk less procps python3 \
+RUN dnf install -y java-11-openjdk less procps python3 tzdata \
     && ln -s $(which python3) /usr/bin/python \
     && tar -zxf $PRESTO_PKG \
     && mv ./presto-server-$PRESTO_VERSION $PRESTO_HOME \
@@ -38,6 +38,10 @@ RUN dnf install -y java-11-openjdk less procps python3 \
     && mkdir -p $PRESTO_HOME/etc/catalog \
     && mkdir -p $PRESTO_HOME/etc/data \
     && mkdir -p /usr/lib/presto/utils
+
+
+# Setting timezone to deal with Velox timezone conversion problem
+ENV TZ=America/Bahia_Banderas
 
 COPY scripts/etc/config.properties.example $PRESTO_HOME/etc/config.properties
 COPY scripts/etc/jvm.config.example $PRESTO_HOME/etc/jvm.config

--- a/scripts/start-prestojava.sh
+++ b/scripts/start-prestojava.sh
@@ -15,8 +15,5 @@
 
 set -e
 
-nohup $PRESTO_HOME/bin/launcher --pid-file=/tmp/pidfile  run >  /tmp/server.log
-#wait a few seconds for presto to start
-sleep 60
-echo 'CREATE SCHEMA hive.tpch;' > /tmp/hive_create.sql
-/opt/presto-cli --server 127.0.0.1:8080 --file /tmp/hive_create.sql
+$PRESTO_HOME/bin/launcher --pid-file=/tmp/pidfile  run
+

--- a/scripts/start-prestojava.sh
+++ b/scripts/start-prestojava.sh
@@ -15,4 +15,8 @@
 
 set -e
 
-$PRESTO_HOME/bin/launcher run
+nohup $PRESTO_HOME/bin/launcher --pid-file=/tmp/pidfile  run >  /tmp/server.log
+#wait a few seconds for presto to start
+sleep 60
+echo 'CREATE SCHEMA hive.tpch;' > /tmp/hive_create.sql
+/opt/presto-cli --server 127.0.0.1:8080 --file /tmp/hive_create.sql

--- a/scripts/start-prestojava.sh
+++ b/scripts/start-prestojava.sh
@@ -14,6 +14,5 @@
 # limitations under the License.
 
 set -e
-echo "node.id=$HOSTNAME" >> $PRESTO_HOME/etc/node.properties
 
 $PRESTO_HOME/bin/launcher run


### PR DESCRIPTION
**What ?** 
  Recently support for [PrestoQueryRunner ](https://github.com/facebookincubator/velox/pull/7628)was added to AggregationFuzzer, so that it can use Presto as a source of truth.  This PR sets up an experimental job that uses the Presto Java container to run Aggregation Fuzzer with Presto as source of truth.

**Why ?** 
  Running the aggregation fuzzer against Presto gives us greater confidence on the correctness of our aggregate functions. 

**How ?** 
   1. [Previously we created a docker image with support for java and Presto](https://github.com/facebookincubator/velox/pull/7920) 
   2. This still requires some changes to get Presto to work with AggregationFuzzer. These changes are listed below.
   3. Adds support for Hive metastore - we do this via a file based metastore  by adding the hive.properties file to $PRESTO_HOME/etc/catalog (see https://github.com/facebookincubator/velox/issues/8111)
   4. We also set the pid file on the launcher to ensure there is only one run of the Presto server
   5. Another thing to note is that we set the timezone to be ['Americas/Los_Angeles' due to details described here ](https://github.com/facebookincubator/velox/issues/8127).
   
**Testing:**

There is no automated way to test this. Here are manual steps I follow: 

1. Create presto-java-container by running `docker-compose build presto-java`
6. Ssh into the presto-java-container 
7. Copy Velox sources into the presto-java-container and build Velox
8. Launch Presto service: /opt/start-prestojava.sh 
9. Run Aggregation fuzzer with --presto_url=http://127.0.0.1:8080 flag 

Example Run: Here is an example run https://github.com/facebookincubator/velox/actions/runs/7508139395/job/20443035814