### PR TITLE
Add option to limit input size in expression fuzzer

### DIFF
--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -821,6 +821,12 @@ core::TypedExprPtr ExpressionFuzzer::generateArgColumn(const TypePtr& arg) {
   auto& listOfCandidateCols = state.typeToColumnNames_[arg->toString()];
   bool reuseColumn = options_.enableColumnReuse &&
       !listOfCandidateCols.empty() && vectorFuzzer_->coinToss(0.3);
+
+  if (!reuseColumn && options_.maxInputsThreshold.has_value() &&
+      state.inputRowTypes_.size() >= options_.maxInputsThreshold.value()) {
+    reuseColumn = !listOfCandidateCols.empty();
+  }
+
   if (!reuseColumn) {
     state.inputRowTypes_.emplace_back(arg);
     state.inputRowNames_.emplace_back(

--- a/velox/expression/tests/ExpressionFuzzer.h
+++ b/velox/expression/tests/ExpressionFuzzer.h
@@ -90,6 +90,13 @@ class ExpressionFuzzer {
     //   "width_bucket",
     //   "array_sort(array(T),constant function(T,T,bigint)) -> array(T)"}
     std::unordered_set<std::string> skipFunctions;
+
+    // When set, when the input size of the generated expressions reaches
+    // maxInputsThreshold, fuzzing input columns will reuse one of the existing
+    // columns if any is already generated with the same type.
+    // This can be used to control the size of the input of the fuzzer
+    // expression.
+    std::optional<int32_t> maxInputsThreshold = std::nullopt;
   };
 
   ExpressionFuzzer(


### PR DESCRIPTION
Summary:
Add the option maxInputsThreshold to ExpressionFuzzer::options
when maxInputsThreshold is true, if the input size is reached to maxInputsThreshold, then 
when fuzzing new input columns, if an already fuzzed column of the same type exists then it will be used
instead of fuzzing new one. 


This is needed for some internal meta fuzzer tests where input size used to blow up.

Differential Revision: D52642521


