### PR TITLE
Improve error message in check-function-signatures CI job

### DIFF
--- a/.circleci/dist_compile.yml
+++ b/.circleci/dist_compile.yml
@@ -642,7 +642,7 @@ jobs:
             pip install deepdiff
             python ./scripts/signature.py export --presto presto_pr_signatures.json
             python ./scripts/signature.py export --spark spark_pr_signatures.json
-            if python ./scripts/signature.py bias presto_merge_base_signatures.json presto_pr_signatures.json /tmp/presto_bias_functions ; \
+            if python ./scripts/signature.py bias presto_merge_base_signatures.json presto_pr_signatures.json /tmp/presto_bias_functions 2>&1 > /tmp/presto-err-message; \
             then echo "Presto signature check success" ; else echo "Presto signature check failed" > /tmp/presto-signature-error-code ; fi
             if python ./scripts/signature.py bias spark_merge_base_signatures.json spark_pr_signatures.json /tmp/spark_bias_functions ; \
             then echo "Spark signature check success"; else echo "Spark signature check failed" > /tmp/spark-signature-error-code ; fi
@@ -684,7 +684,11 @@ jobs:
       - run:
           name: "Surface only Presto function signature errors if any"
           command: |
-              if [ -f /tmp/presto-signature-error-code ]; then return 1 ; fi
+              if [ -f /tmp/presto-signature-error-code ]; then \
+              echo "Incompatible changes have been made to function signatures:\n"; \
+              cat /tmp/presto-err-message ; \
+              exit 1 ; \
+              fi
 
 
 workflows:


### PR DESCRIPTION
**What ?** 
 We add messaging at end of the CI job which checks function signatures if it fails.
 
**Why ?**
 Previously we used to fail as soon as we detected a backwards incompatible change to the function registry, however in many cases these backwards incompatible changes were intentional and we still wanted to ensure they got full fuzzer coverage without loosing the ability to warn the user. Unfortunately currently the only way to warn is via failing in CCI. The previous change however would only fail at the end of the fuzzer run but not communicate why it failed . 

With this change we now we surface this error at the end of the CI run.See description below:

```
 Incompatible changes have been made to function signatures:\n

Incompatible changes in function signatures have been detected.

Function 'chr' has been removed.


Changing or removing function signatures breaks backwards compatibility as some users may rely on function signatures that no longer exist.


Exited with code exit status 1

```

**How ?**
We save the results of the signature run to a file and output it at the end of the run. 

An example run is here : https://app.circleci.com/pipelines/github/facebookincubator/velox/42298/workflows/7e154551-f3a5-4a55-b7bb-ebdea8a5dea8/jobs/292280 