### PR TITLE
Pass executor to exchange client to run callback from exchange source

### DIFF
--- a/velox/exec/ExchangeClient.cpp
+++ b/velox/exec/ExchangeClient.cpp
@@ -139,13 +139,12 @@ ExchangeClient::next(uint32_t maxBytes, bool* atEnd, ContinueFuture* future) {
 }
 
 void ExchangeClient::request(const RequestSpec& requestSpec) {
-  auto& exec = folly::QueuedImmediateExecutor::instance();
   auto self = shared_from_this();
   for (auto& source : requestSpec.sources) {
     auto future = source->request(requestSpec.maxBytes, kDefaultMaxWaitSeconds);
     VELOX_CHECK(future.valid());
     std::move(future)
-        .via(&exec)
+        .via(executor_)
         .thenValue([self, requestSource = source](auto&& response) {
           RequestSpec requestSpec;
           {

--- a/velox/exec/ExchangeSource.h
+++ b/velox/exec/ExchangeSource.h
@@ -148,11 +148,7 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
   const std::string taskId_;
   // Destination number of 'this' on producer
   const int destination_;
-  int64_t sequence_ = 0;
-  std::shared_ptr<ExchangeQueue> queue_;
-  std::atomic<bool> requestPending_{false};
-  bool atEnd_ = false;
-
+  const std::shared_ptr<ExchangeQueue> queue_;
   // Holds a shared reference on the memory pool as it might be still possible
   // to be accessed by external components after the query task is destroyed.
   // For instance, in Prestissimo, there might be a pending http request issued
@@ -161,6 +157,10 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
   // so we need to hold an additional shared reference on the memory pool to
   // keeps it alive.
   const std::shared_ptr<memory::MemoryPool> pool_;
+
+  int64_t sequence_{0};
+  std::atomic<bool> requestPending_{false};
+  bool atEnd_{false};
 };
 
 } // namespace facebook::velox::exec

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -349,7 +349,8 @@ BlockingReason MergeExchange::addMergeSources(ContinueFuture* future) {
                 remoteSourceTaskIds_[remoteSourceIndex],
                 operatorCtx_->task()->destination(),
                 maxQueuedBytesPerSource,
-                pool));
+                pool,
+                operatorCtx_->task()->queryCtx()->executor()));
           }
         }
         // TODO Delay this call until all input data has been processed.

--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -121,13 +121,15 @@ class MergeExchangeSource : public MergeSource {
       const std::string& taskId,
       int destination,
       int64_t maxQueuedBytes,
-      memory::MemoryPool* pool)
+      memory::MemoryPool* pool,
+      folly::Executor* executor)
       : mergeExchange_(mergeExchange),
         client_(std::make_shared<ExchangeClient>(
             taskId,
             destination,
+            maxQueuedBytes,
             pool,
-            maxQueuedBytes)) {
+            executor)) {
     client_->addRemoteTaskId(taskId);
     client_->noMoreRemoteTasks();
   }
@@ -210,9 +212,10 @@ std::shared_ptr<MergeSource> MergeSource::createMergeExchangeSource(
     const std::string& taskId,
     int destination,
     int64_t maxQueuedBytes,
-    memory::MemoryPool* pool) {
+    memory::MemoryPool* pool,
+    folly::Executor* executor) {
   return std::make_shared<MergeExchangeSource>(
-      mergeExchange, taskId, destination, maxQueuedBytes, pool);
+      mergeExchange, taskId, destination, maxQueuedBytes, pool, executor);
 }
 
 namespace {

--- a/velox/exec/MergeSource.h
+++ b/velox/exec/MergeSource.h
@@ -44,7 +44,8 @@ class MergeSource {
       const std::string& taskId,
       int destination,
       int64_t maxQueuedBytes,
-      memory::MemoryPool* pool);
+      memory::MemoryPool* pool,
+      folly::Executor* executor);
 };
 
 /// Coordinates data transfer between single producer and single consumer. Used

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -749,7 +749,7 @@ void Task::createAndStartDrivers(uint32_t concurrentSplitGroups) {
     }
 
     // Set and start all Drivers together inside 'mutex_' so that
-    // cancellations and pauses have the well defined timing. For example, do
+    // cancellations and pauses have the well-defined timing. For example, do
     // not pause and restart a task while it is still adding Drivers.
     //
     // NOTE: the executor must not be folly::InlineLikeExecutor for parallel
@@ -2513,8 +2513,9 @@ void Task::createExchangeClientLocked(
   exchangeClients_[pipelineId] = std::make_shared<ExchangeClient>(
       taskId_,
       destination_,
+      queryCtx()->queryConfig().maxExchangeBufferSize(),
       addExchangeClientPool(planNodeId, pipelineId),
-      queryCtx()->queryConfig().maxExchangeBufferSize());
+      queryCtx()->executor());
   exchangeClientByPlanNode_.emplace(planNodeId, exchangeClients_[pipelineId]);
 }
 


### PR DESCRIPTION
Pass executor to exchange client to run exchange source response callback.
This avoids potential deadlock issue if we inline execute the response callback
from exchange source execution context, which might calls back into the
exchange source again.
