### PR TITLE
Support complex type for the compare param for min_by/max_by with 3 args

### DIFF
--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -93,8 +93,8 @@ struct MinMaxByNAccumulator {
       std::priority_queue<Pair, std::vector<Pair, StlAllocator<Pair>>, Compare>;
   Queue topPairs;
 
-  explicit MinMaxByNAccumulator(HashStringAllocator* allocator)
-      : topPairs{Compare{}, StlAllocator<Pair>(allocator)} {}
+  explicit MinMaxByNAccumulator(HashStringAllocator* allocator, TypePtr compareType)
+      : topPairs{Compare{compareType}, StlAllocator<Pair>(allocator)} {}
 
   int64_t getN() const {
     return n;
@@ -217,8 +217,8 @@ struct MinMaxByNStringViewAccumulator {
   BaseType base;
   ValueSet valueSet;
 
-  explicit MinMaxByNStringViewAccumulator(HashStringAllocator* allocator)
-      : base{allocator}, valueSet{allocator} {}
+  explicit MinMaxByNStringViewAccumulator(HashStringAllocator* allocator, TypePtr compareType)
+      : base{allocator, compareType}, valueSet{allocator} {}
 
   ~MinMaxByNStringViewAccumulator() {
     while (!base.topPairs.empty()) {
@@ -375,8 +375,8 @@ struct MinMaxByNComplexTypeAccumulator {
   BaseType base;
   ValueSet valueSet;
 
-  explicit MinMaxByNComplexTypeAccumulator(HashStringAllocator* allocator)
-      : base{allocator}, valueSet{allocator} {}
+  explicit MinMaxByNComplexTypeAccumulator(HashStringAllocator* allocator, TypePtr compareType)
+      : base{allocator, compareType}, valueSet{allocator} {}
 
   ~MinMaxByNComplexTypeAccumulator() {
     while (!base.topPairs.empty()) {
@@ -523,8 +523,480 @@ struct ComplexTypeExtractor {
   }
 };
 
+template <typename V, typename Compare>
+struct MinMaxByNComplexCompareTypeAccumulator {
+  using TRawValue = typename RawValueExtractor<V>::TRawValue;
+  using BaseType = MinMaxByNAccumulator<V, HashStringAllocator::Position, Compare>;
+  BaseType base;
+  ValueSet valueSet;
+
+  explicit MinMaxByNComplexCompareTypeAccumulator(HashStringAllocator* allocator, TypePtr compareType)
+      : base{allocator, compareType}, valueSet{allocator} {}
+
+  ~MinMaxByNComplexCompareTypeAccumulator() {
+    while (!base.topPairs.empty()) {
+      auto& pair = base.topPairs.top();
+      freePair(pair);
+      base.topPairs.pop();
+    }
+  }
+
+  int64_t getN() const {
+    return base.n;
+  }
+
+  size_t size() const {
+    return base.size();
+  }
+
+  void checkAndSetN(DecodedVector& decodedN, vector_size_t row) {
+    return base.checkAndSetN(decodedN, row);
+  }
+
+  void compareAndAdd(
+      DecodedVector& decodedCompare,
+      vector_size_t compareIndex,
+      std::optional<V> value,
+      Compare& comparator) {
+    auto comparePosition = writeComplex(decodedCompare, compareIndex);
+    if (base.topPairs.size() < base.n) {
+      addToAccumulator(comparePosition, value);
+    } else {
+      const auto& topPair = base.topPairs.top();
+      if (comparator.compare(topPair, decodedCompare, compareIndex)) {
+        freePair(topPair);
+        base.topPairs.pop();
+        addToAccumulator(comparePosition, value);
+      }
+    }
+  }
+
+  /// Moves all values from 'topPairs' into 'values' vector. The queue of
+  /// 'topPairs' will be empty after this call.
+  void extractValues(
+      TRawValue* rawValues,
+      uint64_t* rawValueNulls,
+      vector_size_t offset) {
+    const vector_size_t size = base.topPairs.size();
+    for (auto i = size - 1; i >= 0; --i) {
+      const auto& topPair = base.topPairs.top();
+      const auto index = offset + i;
+
+      const bool valueIsNull = !topPair.second.has_value();
+      bits::setNull(rawValueNulls, index, valueIsNull);
+      if (!valueIsNull) {
+        RawValueExtractor<V>::extract(rawValues, index, topPair.second.value());
+      }
+
+      base.topPairs.pop();
+    }
+  }
+
+  /// Moves all pairs of (comparison, value) from 'topPairs' into
+  /// 'rawComparisons' buffer and 'values' vector. The queue of
+  /// 'topPairs' will be empty after this call.
+  void extractPairs(
+      BaseVector& compares,
+      TRawValue* rawValues,
+      uint64_t* rawValueNulls,
+      vector_size_t offset) {
+    const vector_size_t size = base.topPairs.size();
+    for (auto i = size - 1; i >= 0; --i) {
+      const auto& topPair = base.topPairs.top();
+      const auto index = offset + i;
+
+      extractCompare(topPair, compares, index);
+
+      const bool valueIsNull = !topPair.second.has_value();
+      bits::setNull(rawValueNulls, index, valueIsNull);
+      if (!valueIsNull) {
+        RawValueExtractor<V>::extract(rawValues, index, topPair.second.value());
+      }
+
+      freePair(topPair);
+      base.topPairs.pop();
+    }
+  }
+
+ private:
+  using C = HashStringAllocator::Position;
+  using Pair = typename MinMaxByNAccumulator<V, C, Compare>::Pair;
+
+  void addToAccumulator(C comparePosition, std::optional<V> value) {
+    base.topPairs.push({comparePosition, value});
+  }
+
+  HashStringAllocator::Position writeComplex(
+      DecodedVector& decoded,
+      vector_size_t index) {
+    HashStringAllocator::Position position;
+    valueSet.write(*decoded.base(), decoded.index(index), position);
+    return position;
+  }
+
+  void freePair(typename BaseType::Queue::const_reference topPair) {
+    valueSet.free(topPair.first.header);
+  }
+
+  void
+  extractValue(const Pair& topPair, BaseVector& values, vector_size_t index) {
+    const bool valueIsNull = !topPair.second.has_value();
+    values.setNull(index, valueIsNull);
+    if (!valueIsNull) {
+      auto position = topPair.second.value();
+      valueSet.read(&values, index, position.header);
+    }
+  }
+
+  void extractCompare(
+      const Pair& topPair,
+      BaseVector& compares,
+      vector_size_t index) {
+    auto position = topPair.first;
+    valueSet.read(&compares, index, position.header);
+  }
+}; // namespace
+
+template <typename V, typename Compare>
+struct ComplexCompareTypeExtractor {
+  using TRawValue = typename RawValueExtractor<V>::TRawValue;
+  TRawValue* rawValues;
+  uint64_t* rawValueNulls;
+  BaseVector* compares;
+
+  ComplexCompareTypeExtractor(VectorPtr& values, BaseVector* _compares)
+      : compares{_compares} {
+    rawValues = RawValueExtractor<V>::mutableRawValues(values);
+    rawValueNulls = values->mutableRawNulls();
+    compares = _compares;
+  }
+
+  void extractValues(
+      MinMaxByNComplexCompareTypeAccumulator<V, Compare>* accumulator,
+      vector_size_t offset) {
+    accumulator->extractValues(rawValues, rawValueNulls, offset);
+  }
+
+  void extractPairs(
+      MinMaxByNComplexCompareTypeAccumulator<V, Compare>* accumulator,
+      vector_size_t offset) {
+    accumulator->extractPairs(*compares, rawValues, rawValueNulls, offset);
+  }
+};
+
+template <typename Compare>
+struct MinMaxByNStringViewValueTypeComplexCompareTypeAccumulator {
+  using V = StringView;
+  using C = HashStringAllocator::Position;
+  using Pair = typename MinMaxByNAccumulator<V, C, Compare>::Pair;
+  using BaseType = MinMaxByNAccumulator<V, C, Compare>;
+
+  BaseType base;
+  ValueSet valueSet;
+
+  explicit MinMaxByNStringViewValueTypeComplexCompareTypeAccumulator(
+      HashStringAllocator* allocator,
+      TypePtr compareType)
+      : base{allocator, compareType}, valueSet{allocator} {}
+
+  ~MinMaxByNStringViewValueTypeComplexCompareTypeAccumulator() {
+    while (!base.topPairs.empty()) {
+      auto& pair = base.topPairs.top();
+      freePair(pair);
+      base.topPairs.pop();
+    }
+  }
+
+  int64_t getN() const {
+    return base.n;
+  }
+
+  size_t size() const {
+    return base.size();
+  }
+
+  void checkAndSetN(DecodedVector& decodedN, vector_size_t row) {
+    return base.checkAndSetN(decodedN, row);
+  }
+
+  void compareAndAdd(
+      DecodedVector& decodedCompare,
+      vector_size_t compareIndex,
+      std::optional<V> value,
+      Compare& comparator) {
+    auto comparePosition = writeComplex(decodedCompare, compareIndex);
+    if (base.topPairs.size() < base.n) {
+      addToAccumulator(comparePosition, value);
+    } else {
+      const auto& topPair = base.topPairs.top();
+      if (comparator.compare(topPair, decodedCompare, compareIndex)) {
+        freePair(topPair);
+        base.topPairs.pop();
+        addToAccumulator(comparePosition, value);
+      }
+    }
+  }
+
+  /// Moves all values from 'topPairs' into 'values'
+  /// buffers. The queue of 'topPairs' will be empty after this call.
+  void extractValues(FlatVector<V>& values, vector_size_t offset) {
+    const vector_size_t size = base.topPairs.size();
+    for (auto i = size - 1; i >= 0; --i) {
+      const auto& pair = base.topPairs.top();
+      extractValue(pair, values, offset + i);
+      freePair(pair);
+      base.topPairs.pop();
+    }
+  }
+
+  /// Moves all pairs of (comparison, value) from 'topPairs' into
+  /// 'rawComparisons' buffer and 'values' vector. The queue of
+  /// 'topPairs' will be empty after this call.
+  void extractPairs(
+      BaseVector& compares,
+      FlatVector<V>& values,
+      vector_size_t offset) {
+    const vector_size_t size = base.topPairs.size();
+    for (auto i = size - 1; i >= 0; --i) {
+      const auto& topPair = base.topPairs.top();
+      const auto index = offset + i;
+
+      extractCompare(topPair, compares, index);
+      extractValue(topPair, values, index);
+      freePair(topPair);
+      base.topPairs.pop();
+    }
+  }
+
+ private:
+  std::optional<StringView> writeString(
+      const std::optional<StringView>& value) {
+    if (!value.has_value()) {
+      return std::nullopt;
+    }
+    return valueSet.write(*value);
+  }
+
+  void addToAccumulator(C comparePosition, std::optional<V> value) {
+    base.topPairs.push({comparePosition, writeString(value)});
+  }
+
+  HashStringAllocator::Position writeComplex(
+      DecodedVector& decoded,
+      vector_size_t index) {
+    HashStringAllocator::Position position;
+    valueSet.write(*decoded.base(), decoded.index(index), position);
+    return position;
+  }
+
+  void freePair(typename BaseType::Queue::const_reference topPair) {
+    valueSet.free(topPair.first.header);
+    valueSet.free(*topPair.second);
+  }
+
+  void extractValue(
+      const Pair& topPair,
+      FlatVector<V>& values,
+      vector_size_t index) {
+    const bool valueIsNull = !topPair.second.has_value();
+    values.setNull(index, valueIsNull);
+    if (!valueIsNull) {
+      values.set(index, topPair.second.value());
+    }
+  }
+
+  void extractCompare(
+      const Pair& topPair,
+      BaseVector& compares,
+      vector_size_t index) {
+    auto position = topPair.first;
+    valueSet.read(&compares, index, position.header);
+  }
+};
+
+template <typename Compare>
+struct StringViewValueTypeComplexCompareTypeExtractor {
+  FlatVector<StringView>& values;
+  BaseVector* compares;
+
+  StringViewValueTypeComplexCompareTypeExtractor(VectorPtr& _values, BaseVector* _compares)
+      : values{*_values->asFlatVector<StringView>()}, compares{_compares} {}
+
+  void extractValues(
+      MinMaxByNStringViewValueTypeComplexCompareTypeAccumulator<Compare>*
+          accumulator,
+      vector_size_t offset) {
+    accumulator->extractValues(values, offset);
+  }
+
+  void extractPairs(
+      MinMaxByNStringViewValueTypeComplexCompareTypeAccumulator<Compare>*
+          accumulator,
+      vector_size_t offset) {
+    accumulator->extractPairs(*compares, values, offset);
+  }
+};
+
+template <typename Compare>
+struct MinMaxByNBothComplexTypeAccumulator {
+  using BaseType = MinMaxByNAccumulator<
+      HashStringAllocator::Position,
+      HashStringAllocator::Position,
+      Compare>;
+  BaseType base;
+  ValueSet valueSet;
+
+  explicit MinMaxByNBothComplexTypeAccumulator(HashStringAllocator* allocator, TypePtr compareType)
+      : base{allocator, compareType}, valueSet{allocator} {}
+
+  ~MinMaxByNBothComplexTypeAccumulator() {
+    while (!base.topPairs.empty()) {
+      auto& pair = base.topPairs.top();
+      freePair(pair);
+      base.topPairs.pop();
+    }
+  }
+
+  int64_t getN() const {
+    return base.n;
+  }
+
+  size_t size() const {
+    return base.size();
+  }
+
+  void checkAndSetN(DecodedVector& decodedN, vector_size_t row) {
+    return base.checkAndSetN(decodedN, row);
+  }
+
+  void compareAndAdd(
+      DecodedVector& decodedCompare,
+      vector_size_t compareIndex,
+      DecodedVector& decodedValue,
+      vector_size_t valueIndex,
+      Compare& comparator) {
+    auto comparePosition = writeComplexCompare(decodedCompare, compareIndex);
+    if (base.topPairs.size() < base.n) {
+      auto valuePosition = writeComplexValue(decodedValue, valueIndex);
+      addToAccumulator(comparePosition, valuePosition);
+    } else {
+      const auto& topPair = base.topPairs.top();
+      if (comparator.compare(topPair, decodedCompare, compareIndex)) {
+        freePair(topPair);
+        base.topPairs.pop();
+
+        auto valuePosition = writeComplexValue(decodedValue, valueIndex);
+        addToAccumulator(comparePosition, valuePosition);
+      }
+    }
+  }
+
+  /// Moves all values from 'topPairs' into 'values' vector. The queue of
+  /// 'topPairs' will be empty after this call.
+  void extractValues(BaseVector& values, vector_size_t offset) {
+    const vector_size_t size = base.topPairs.size();
+    for (auto i = size - 1; i >= 0; --i) {
+      const auto& pair = base.topPairs.top();
+      extractValue(pair, values, offset + i);
+      freePair(pair);
+      base.topPairs.pop();
+    }
+  }
+
+  /// Moves all pairs of (comparison, value) from 'topPairs' into
+  /// 'rawComparisons' buffer and 'values' vector. The queue of
+  /// 'topPairs' will be empty after this call.
+  void extractPairs(BaseVector& compares, BaseVector& values, vector_size_t offset) {
+    const vector_size_t size = base.topPairs.size();
+    for (auto i = size - 1; i >= 0; --i) {
+      const auto& topPair = base.topPairs.top();
+      const auto index = offset + i;
+
+      extractCompare(topPair, compares, index);
+      extractValue(topPair, values, index);
+      freePair(topPair);
+      base.topPairs.pop();
+    }
+  }
+
+ private:
+  using V = HashStringAllocator::Position;
+  using C = HashStringAllocator::Position;
+  using Pair = typename MinMaxByNAccumulator<V, C, Compare>::Pair;
+
+  void addToAccumulator(
+      C comparePosition,
+      const std::optional<V>& valuePosition) {
+    base.topPairs.push({comparePosition, valuePosition});
+  }
+
+  HashStringAllocator::Position writeComplexCompare(
+      DecodedVector& decoded,
+      vector_size_t index) {
+    VELOX_CHECK(!decoded.isNullAt(index));
+    HashStringAllocator::Position position;
+    valueSet.write(*decoded.base(), decoded.index(index), position);
+    return position;
+  }
+
+  std::optional<HashStringAllocator::Position> writeComplexValue(
+      DecodedVector& decoded,
+      vector_size_t index) {
+    if (decoded.isNullAt(index)) {
+      return std::nullopt;
+    }
+    HashStringAllocator::Position position;
+    valueSet.write(*decoded.base(), decoded.index(index), position);
+    return position;
+  }
+
+  void freePair(typename BaseType::Queue::const_reference topPair) {
+    valueSet.free(topPair.first.header);
+    valueSet.free(topPair.second->header);
+  }
+
+  void extractValue(const Pair& topPair, BaseVector& values, vector_size_t index) {
+    const bool valueIsNull = !topPair.second.has_value();
+    values.setNull(index, valueIsNull);
+    if (!valueIsNull) {
+      auto position = topPair.second.value();
+      valueSet.read(&values, index, position.header);
+    }
+  }
+
+  void extractCompare(
+      const Pair& topPair,
+      BaseVector& compares,
+      vector_size_t index) {
+    auto position = topPair.first;
+    valueSet.read(&compares, index, position.header);
+  }
+}; // namespace
+
+template <typename Compare>
+struct BothComplexTypeExtractor {
+  BaseVector& values;
+  BaseVector* compares;
+
+  BothComplexTypeExtractor(VectorPtr& _values, BaseVector* _compares)
+      : values{*_values}, compares{_compares} {}
+
+  void extractValues(
+      MinMaxByNBothComplexTypeAccumulator<Compare>* accumulator,
+      vector_size_t offset) {
+    accumulator->extractValues(values, offset);
+  }
+
+  void extractPairs(
+      MinMaxByNBothComplexTypeAccumulator<Compare>* accumulator,
+      vector_size_t offset) {
+    accumulator->extractPairs(*compares, values, offset);
+  }
+};
+
 template <typename V, typename C>
 struct Less {
+  explicit Less(TypePtr /* type */){};
   using Pair = std::pair<C, std::optional<V>>;
   bool operator()(const Pair& lhs, const Pair& rhs) {
     return lhs.first < rhs.first;
@@ -537,6 +1009,7 @@ struct Less {
 
 template <typename V, typename C>
 struct Greater {
+  explicit Greater(TypePtr /* type */){};
   using Pair = std::pair<C, std::optional<V>>;
   bool operator()(const Pair& lhs, const Pair& rhs) {
     return lhs.first > rhs.first;
@@ -546,6 +1019,91 @@ struct Greater {
     return lhs > rhs.first;
   }
 };
+
+template <typename V>
+struct ComplexLess {
+  TypePtr compareType;
+  explicit ComplexLess(TypePtr type) : compareType(type){};
+  using Pair = std::pair<HashStringAllocator::Position, std::optional<V>>;
+  static CompareFlags kCompareFlags;
+
+  bool operator()(const Pair& lhs, const Pair& rhs) {
+    VELOX_CHECK_NOT_NULL(lhs.first.header);
+    VELOX_CHECK_NOT_NULL(rhs.first.header);
+    ByteInputStream lStream =
+        HashStringAllocator::prepareRead(lhs.first.header);
+    ByteInputStream rStream =
+        HashStringAllocator::prepareRead(rhs.first.header);
+    // Returns < 0 if 'left' is less than 'right' at 'index'.
+    std::optional<int32_t> res = exec::ContainerRowSerde::compare(
+        lStream, rStream, compareType.get(), kCompareFlags);
+    return res.value() < 0;
+  }
+
+  bool compare(
+      const Pair& topPair,
+      DecodedVector& decodedCompare,
+      vector_size_t compareIndex) {
+    VELOX_CHECK_NOT_NULL(topPair.first.header);
+    ByteInputStream stream =
+        HashStringAllocator::prepareRead(topPair.first.header);
+    // Returns > 0 if 'topPair' greater than 'vector' at 'index', means it needs
+    // to be pushed into the queue.
+    std::optional<int32_t> res = exec::ContainerRowSerde::compare(
+        stream, decodedCompare, compareIndex, kCompareFlags);
+    return res.value() > 0;
+  }
+};
+
+template <typename V>
+CompareFlags ComplexLess<V>::kCompareFlags{
+    true, // nullsFirst
+    true, // ascending
+    false, // equalsOnly
+    CompareFlags::NullHandlingMode::kNullAsValue};
+
+template <typename V>
+struct ComplexGreater {
+  TypePtr compareType;
+  explicit ComplexGreater(TypePtr type) : compareType(type){};
+
+  using Pair = std::pair<HashStringAllocator::Position, std::optional<V>>;
+  static CompareFlags kCompareFlags;
+
+  bool operator()(const Pair& lhs, const Pair& rhs) {
+    VELOX_CHECK_NOT_NULL(lhs.first.header);
+    VELOX_CHECK_NOT_NULL(rhs.first.header);
+    ByteInputStream lStream =
+        HashStringAllocator::prepareRead(lhs.first.header);
+    ByteInputStream rStream =
+        HashStringAllocator::prepareRead(rhs.first.header);
+    // Returns < 0 if 'left' is greater than 'right' at 'index'.
+    std::optional<int32_t> res = exec::ContainerRowSerde::compare(
+        lStream, rStream, compareType.get(), kCompareFlags);
+    return res.value() > 0;
+  }
+
+  bool compare(
+      const Pair& topPair,
+      DecodedVector& decodedCompare,
+      vector_size_t compareIndex) {
+    VELOX_CHECK_NOT_NULL(topPair.first.header);
+    ByteInputStream stream =
+        HashStringAllocator::prepareRead(topPair.first.header);
+    // Returns < 0 if 'topPair' less than 'vector' at 'index', means it needs
+    // to be pushed into the queue.
+    std::optional<int32_t> res = exec::ContainerRowSerde::compare(
+        stream, decodedCompare, compareIndex, kCompareFlags);
+    return res.value() < 0;
+  }
+};
+
+template <typename V>
+CompareFlags ComplexGreater<V>::kCompareFlags{
+    true, // nullsFirst
+    true, // ascending
+    false, // equalsOnly
+    CompareFlags::NullHandlingMode::kNullAsValue};
 
 template <typename V, typename C, typename Compare>
 struct MinMaxByNAccumulatorTypeTraits {
@@ -590,6 +1148,32 @@ struct MinMaxByNAccumulatorTypeTraits<ComplexType, StringView, Compare> {
   using ExtractorType = ComplexTypeExtractor<StringView, Compare>;
 };
 
+// Use MinMaxByNComplexCompareTypeAccumulator and ComplexCompareTypeExtractor
+// if V is not ComplexType and C is ComplexType.
+template <typename V, typename Compare>
+struct MinMaxByNAccumulatorTypeTraits<V, ComplexType, Compare> {
+  using AccumulatorType = MinMaxByNComplexCompareTypeAccumulator<V, Compare>;
+  using ExtractorType = ComplexCompareTypeExtractor<V, Compare>;
+};
+
+// Use MinMaxByNStringViewValueTypeComplexCompareTypeAccumulator and
+// StringViewValueTypeComplexCompareTypeExtractor if V is StringView and C is
+// ComplexType.
+template <typename Compare>
+struct MinMaxByNAccumulatorTypeTraits<StringView, ComplexType, Compare> {
+  using AccumulatorType =
+      MinMaxByNStringViewValueTypeComplexCompareTypeAccumulator<Compare>;
+  using ExtractorType = StringViewValueTypeComplexCompareTypeExtractor<Compare>;
+};
+
+// Use MinMaxByNBothComplexTypeAccumulator and BothComplexTypeExtractor
+// if both V and C are ComplexType.
+template <typename Compare>
+struct MinMaxByNAccumulatorTypeTraits<ComplexType, ComplexType, Compare> {
+  using AccumulatorType = MinMaxByNBothComplexTypeAccumulator<Compare>;
+  using ExtractorType = BothComplexTypeExtractor<Compare>;
+};
+
 namespace {
 std::pair<vector_size_t*, vector_size_t*> rawOffsetAndSizes(
     ArrayVector& arrayVector) {
@@ -602,8 +1186,10 @@ std::pair<vector_size_t*, vector_size_t*> rawOffsetAndSizes(
 template <typename V, typename C, typename Compare>
 class MinMaxByNAggregate : public exec::Aggregate {
  public:
-  explicit MinMaxByNAggregate(TypePtr resultType)
-      : exec::Aggregate(resultType) {}
+  explicit MinMaxByNAggregate(TypePtr resultType, TypePtr compareType)
+      : exec::Aggregate(resultType),
+        type_(compareType),
+        comparator_(compareType) {}
 
   using AccumulatorType =
       typename MinMaxByNAccumulatorTypeTraits<V, C, Compare>::AccumulatorType;
@@ -621,7 +1207,7 @@ class MinMaxByNAggregate : public exec::Aggregate {
     exec::Aggregate::setAllNulls(groups, indices);
     for (const vector_size_t i : indices) {
       auto group = groups[i];
-      new (group + offset_) AccumulatorType(allocator_);
+      new (group + offset_) AccumulatorType(allocator_, type_);
     }
   }
 
@@ -639,7 +1225,7 @@ class MinMaxByNAggregate : public exec::Aggregate {
     std::optional<ExtractorType> extractor;
     if constexpr (
         std::is_same_v<V, StringView> || std::is_same_v<C, StringView> ||
-        std::is_same_v<V, ComplexType>) {
+        std::is_same_v<V, ComplexType> || std::is_same_v<C, ComplexType>) {
       extractor.emplace(values, nullptr);
     } else {
       extractor.emplace(values);
@@ -688,14 +1274,11 @@ class MinMaxByNAggregate : public exec::Aggregate {
     std::optional<ExtractorType> extractor;
     if constexpr (
         std::is_same_v<V, StringView> || std::is_same_v<C, StringView> ||
-        std::is_same_v<V, ComplexType>) {
+        std::is_same_v<V, ComplexType> || std::is_same_v<C, ComplexType>) {
       extractor.emplace(values, comparisons.get());
     } else {
       extractor.emplace(values);
     }
-
-    TRawComparison* rawComparisons =
-        RawValueExtractor<C>::mutableRawValues(comparisons);
 
     auto [rawValueOffsets, rawValueSizes] = rawOffsetAndSizes(*valueArray);
     auto [rawComparisonOffsets, rawComparisonSizes] =
@@ -719,9 +1302,11 @@ class MinMaxByNAggregate : public exec::Aggregate {
 
         if constexpr (
             std::is_same_v<V, StringView> || std::is_same_v<C, StringView> ||
-            std::is_same_v<V, ComplexType>) {
+            std::is_same_v<V, ComplexType> || std::is_same_v<C, ComplexType>) {
           extractor->extractPairs(accumulator, offset);
         } else {
+          TRawComparison* rawComparisons =
+              RawValueExtractor<C>::mutableRawValues(comparisons);
           extractor->extractPairs(accumulator, rawComparisons, offset);
         }
 
@@ -836,7 +1421,16 @@ class MinMaxByNAggregate : public exec::Aggregate {
     auto* accumulator = value(group);
 
     const auto comparison = decodedComparison_.valueAt<C>(index);
-    if constexpr (std::is_same_v<V, ComplexType>) {
+    if constexpr (std::is_same_v<C, ComplexType>) {
+      if constexpr (std::is_same_v<V, ComplexType>) {
+        accumulator->compareAndAdd(
+            decodedComparison_, index, decodedValue_, index, comparator_);
+      } else {
+        const auto value = optionalValue(decodedValue_, index);
+        accumulator->compareAndAdd(
+            decodedComparison_, index, value, comparator_);
+      }
+    } else if constexpr (std::is_same_v<V, ComplexType>) {
       accumulator->compareAndAdd(comparison, decodedValue_, index, comparator_);
     } else {
       const auto value = optionalValue(decodedValue_, index);
@@ -848,6 +1442,7 @@ class MinMaxByNAggregate : public exec::Aggregate {
     const ArrayVector* valueArray;
     // Used for complex types.
     DecodedVector values;
+    DecodedVector compares;
     // Used for primitive types.
     const FlatVector<V>* flatValues;
     const ArrayVector* comparisonArray;
@@ -875,13 +1470,29 @@ class MinMaxByNAggregate : public exec::Aggregate {
     const auto valueOffset = valueArray->offsetAt(decodedIndex);
     const auto comparisonOffset = comparisonArray->offsetAt(decodedIndex);
     for (auto i = 0; i < numValues; ++i) {
-      const auto comparison = comparisons->valueAt(comparisonOffset + i);
-      if constexpr (std::is_same_v<V, ComplexType>) {
-        accumulator->compareAndAdd(
-            comparison, result.values, valueOffset + i, comparator_);
+      if constexpr (std::is_same_v<C, ComplexType>) {
+        if constexpr (std::is_same_v<V, ComplexType>) {
+          accumulator->compareAndAdd(
+              result.compares,
+              comparisonOffset + i,
+              result.values,
+              valueOffset + i,
+              comparator_);
+        } else {
+          const auto value = optionalValue(*values, valueOffset + i);
+          accumulator->compareAndAdd(
+              result.compares, comparisonOffset + i, value, comparator_);
+        }
       } else {
-        const auto value = optionalValue(*values, valueOffset + i);
-        accumulator->compareAndAdd(comparison, value, comparator_);
+        const auto* comparisons = result.comparisons;
+        const auto comparison = comparisons->valueAt(comparisonOffset + i);
+        if constexpr (std::is_same_v<V, ComplexType>) {
+          accumulator->compareAndAdd(
+              comparison, result.values, valueOffset + i, comparator_);
+        } else {
+          const auto value = optionalValue(*values, valueOffset + i);
+          accumulator->compareAndAdd(comparison, value, comparator_);
+        }
       }
     }
   }
@@ -909,8 +1520,12 @@ class MinMaxByNAggregate : public exec::Aggregate {
       result.flatValues =
           result.valueArray->elements()->template as<FlatVector<V>>();
     }
-    result.comparisons =
-        result.comparisonArray->elements()->template as<FlatVector<C>>();
+    if constexpr (std::is_same_v<C, ComplexType>) {
+      result.compares.decode(*result.comparisonArray->elements());
+    } else {
+      result.comparisons =
+          result.comparisonArray->elements()->template as<FlatVector<C>>();
+    }
 
     return result;
   }
@@ -953,6 +1568,7 @@ class MinMaxByNAggregate : public exec::Aggregate {
     }
   }
 
+  TypePtr type_;
   Compare comparator_;
   DecodedVector decodedValue_;
   DecodedVector decodedComparison_;
@@ -963,8 +1579,8 @@ class MinMaxByNAggregate : public exec::Aggregate {
 template <typename V, typename C>
 class MinByNAggregate : public MinMaxByNAggregate<V, C, Less<V, C>> {
  public:
-  explicit MinByNAggregate(TypePtr resultType)
-      : MinMaxByNAggregate<V, C, Less<V, C>>(resultType) {}
+  explicit MinByNAggregate(TypePtr resultType, TypePtr compareType)
+      : MinMaxByNAggregate<V, C, Less<V, C>>(resultType, compareType) {}
 };
 
 template <typename C>
@@ -974,18 +1590,44 @@ class MinByNAggregate<ComplexType, C>
           C,
           Less<HashStringAllocator::Position, C>> {
  public:
-  explicit MinByNAggregate(TypePtr resultType)
+  explicit MinByNAggregate(TypePtr resultType, TypePtr compareType)
       : MinMaxByNAggregate<
             ComplexType,
             C,
-            Less<HashStringAllocator::Position, C>>(resultType) {}
+            Less<HashStringAllocator::Position, C>>(resultType, compareType) {}
+};
+
+template <typename V>
+class MinByNAggregate<V, ComplexType>
+    : public MinMaxByNAggregate<V, ComplexType, ComplexLess<V>> {
+ public:
+  MinByNAggregate(TypePtr resultType, TypePtr compareType)
+      : MinMaxByNAggregate<V, ComplexType, ComplexLess<V>>(
+            resultType,
+            compareType) {}
+};
+
+template <>
+class MinByNAggregate<ComplexType, ComplexType>
+    : public MinMaxByNAggregate<
+          ComplexType,
+          ComplexType,
+          ComplexLess<HashStringAllocator::Position>> {
+ public:
+  MinByNAggregate(TypePtr resultType, TypePtr compareType)
+      : MinMaxByNAggregate<
+            ComplexType,
+            ComplexType,
+            ComplexLess<HashStringAllocator::Position>>(
+            resultType,
+            compareType) {}
 };
 
 template <typename V, typename C>
 class MaxByNAggregate : public MinMaxByNAggregate<V, C, Greater<V, C>> {
  public:
-  explicit MaxByNAggregate(TypePtr resultType)
-      : MinMaxByNAggregate<V, C, Greater<V, C>>(resultType) {}
+  explicit MaxByNAggregate(TypePtr resultType, TypePtr compareType)
+      : MinMaxByNAggregate<V, C, Greater<V, C>>(resultType, compareType) {}
 };
 
 template <typename C>
@@ -995,11 +1637,39 @@ class MaxByNAggregate<ComplexType, C>
           C,
           Greater<HashStringAllocator::Position, C>> {
  public:
-  explicit MaxByNAggregate(TypePtr resultType)
+  explicit MaxByNAggregate(TypePtr resultType, TypePtr compareType)
       : MinMaxByNAggregate<
             ComplexType,
             C,
-            Greater<HashStringAllocator::Position, C>>(resultType) {}
+            Greater<HashStringAllocator::Position, C>>(
+            resultType,
+            compareType) {}
+};
+
+template <typename V>
+class MaxByNAggregate<V, ComplexType>
+    : public MinMaxByNAggregate<V, ComplexType, ComplexGreater<V>> {
+ public:
+  MaxByNAggregate(TypePtr resultType, TypePtr compareType)
+      : MinMaxByNAggregate<V, ComplexType, ComplexGreater<V>>(
+            resultType,
+            compareType) {}
+};
+
+template <>
+class MaxByNAggregate<ComplexType, ComplexType>
+    : public MinMaxByNAggregate<
+          ComplexType,
+          ComplexType,
+          ComplexGreater<HashStringAllocator::Position>> {
+ public:
+  MaxByNAggregate(TypePtr resultType, TypePtr compareType)
+      : MinMaxByNAggregate<
+            ComplexType,
+            ComplexType,
+            ComplexGreater<HashStringAllocator::Position>>(
+            resultType,
+            compareType) {}
 };
 
 template <template <typename U, typename V> class NAggregate, typename W>
@@ -1009,23 +1679,32 @@ std::unique_ptr<exec::Aggregate> createNArg(
     const std::string& errorMessage) {
   switch (compareType->kind()) {
     case TypeKind::BOOLEAN:
-      return std::make_unique<NAggregate<W, bool>>(resultType);
+      return std::make_unique<NAggregate<W, bool>>(resultType, compareType);
     case TypeKind::TINYINT:
-      return std::make_unique<NAggregate<W, int8_t>>(resultType);
+      return std::make_unique<NAggregate<W, int8_t>>(resultType, compareType);
     case TypeKind::SMALLINT:
-      return std::make_unique<NAggregate<W, int16_t>>(resultType);
+      return std::make_unique<NAggregate<W, int16_t>>(resultType, compareType);
     case TypeKind::INTEGER:
-      return std::make_unique<NAggregate<W, int32_t>>(resultType);
+      return std::make_unique<NAggregate<W, int32_t>>(resultType, compareType);
     case TypeKind::BIGINT:
-      return std::make_unique<NAggregate<W, int64_t>>(resultType);
+      return std::make_unique<NAggregate<W, int64_t>>(resultType, compareType);
     case TypeKind::REAL:
-      return std::make_unique<NAggregate<W, float>>(resultType);
+      return std::make_unique<NAggregate<W, float>>(resultType, compareType);
     case TypeKind::DOUBLE:
-      return std::make_unique<NAggregate<W, double>>(resultType);
+      return std::make_unique<NAggregate<W, double>>(resultType, compareType);
     case TypeKind::VARCHAR:
-      return std::make_unique<NAggregate<W, StringView>>(resultType);
+      return std::make_unique<NAggregate<W, StringView>>(
+          resultType, compareType);
     case TypeKind::TIMESTAMP:
-      return std::make_unique<NAggregate<W, Timestamp>>(resultType);
+      return std::make_unique<NAggregate<W, Timestamp>>(
+          resultType, compareType);
+    case TypeKind::ARRAY:
+      [[fallthrough]];
+    case TypeKind::MAP:
+      [[fallthrough]];
+    case TypeKind::ROW:
+      return std::make_unique<NAggregate<W, ComplexType>>(
+          resultType, compareType);
     default:
       VELOX_FAIL("{}", errorMessage);
       return nullptr;
@@ -1113,31 +1792,18 @@ exec::AggregateRegistrationResult registerMinMaxBy(const std::string& name) {
                            .argumentType("V")
                            .argumentType("C")
                            .build());
-  const std::vector<std::string> supportedCompareTypes = {
-      "boolean",
-      "tinyint",
-      "smallint",
-      "integer",
-      "bigint",
-      "real",
-      "double",
-      "varchar",
-      "date",
-      "timestamp"};
 
   // Add support for all value types to 3-arg version of the aggregate.
-  for (const auto& compareType : supportedCompareTypes) {
-    // V, C, bigint -> row(bigint, array(C), array(V)) -> array(V).
-    signatures.push_back(exec::AggregateFunctionSignatureBuilder()
-                             .typeVariable("V")
-                             .returnType("array(V)")
-                             .intermediateType(fmt::format(
-                                 "row(bigint,array({}),array(V))", compareType))
-                             .argumentType("V")
-                             .argumentType(compareType)
-                             .argumentType("bigint")
-                             .build());
-  }
+  // V, C, bigint -> row(bigint, array(C), array(V)) -> array(V).
+  signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                           .typeVariable("V")
+                           .typeVariable("C")
+                           .returnType("array(V)")
+                           .intermediateType("row(bigint,array(C),array(V))")
+                           .argumentType("V")
+                           .argumentType("C")
+                           .argumentType("bigint")
+                           .build());
 
   return exec::registerAggregateFunction(
       name,

--- a/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -1639,6 +1639,143 @@ TEST_F(MinMaxByNTest, groupBy) {
       {data}, {"c0"}, {"min_by(c1, c2, 3)", "max_by(c1, c2, 4)"}, {expected});
 }
 
+TEST_F(MinMaxByComplexTypes, arrayTypeCompare) {
+  // The data consists of five rows, and the comparison key is arrayType.
+  // Each array contains two elements.
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({8, 3, 4, 5, 6}),
+      makeArrayVector<int64_t>({{3, 4}, {2, 4}, {2, 3}, {0, 3}, {0, 2}}),
+  });
+
+  auto expected = makeRowVector({makeArrayVector<int64_t>({
+      {6, 5},
+  })});
+
+  testAggregations({data}, {}, {"min_by(c0, c1, 2)"}, {expected});
+
+  // The data consists of five rows, and the comparison key is arrayType.
+  // Each array contains two elements.
+  data = makeRowVector({
+      makeFlatVector<int16_t>({1, 2, 1, 2, 1}),
+      makeFlatVector<int64_t>({8, 3, 4, 5, 6}),
+      makeArrayVector<int64_t>({{3, 4}, {2, 4}, {2, 3}, {0, 3}, {0, 2}}),
+  });
+
+  expected = makeRowVector(
+      {makeFlatVector<int16_t>({1, 2}),
+       makeArrayVector<int64_t>({{8, 4}, {3, 5}})});
+
+  testAggregations({data}, {"c0"}, {"max_by(c1, c2, 2)"}, {expected});
+}
+
+TEST_F(MinMaxByComplexTypes, mapTypeCompare) {
+  // The data consists of four rows, and both the comparison key and the value
+  // key are mapType. The first compare row has three elements.
+  auto data = makeRowVector({
+      makeMapVector<int64_t, int64_t>({
+          {{1, 10}, {2, 20}, {3, 30}},
+          {{4, 40}, {5, 50}},
+          {{2, 1}},
+          {{6, 60}, {7, 70}, {8, 80}},
+      }),
+      makeMapVector<int64_t, int64_t>({
+          {{50, 5}, {10, 1}, {20, 2}},
+          {{20, 2}},
+          {{40, 4}, {0, 0}},
+          {{40, 4}, {30, 6}},
+      }),
+  });
+
+  // When comparing a map, it is sorted by key in ascending order, then compare
+  // keys one by one. If all the keys are the same, then the values are
+  // compared. So the second row and the forth row are chosen.
+  auto expected = makeRowVector({makeArrayVector(
+      {0},
+      makeMapVector(
+          {0, 3},
+          makeFlatVector<int64_t>({6, 7, 8, 4, 5}),
+          makeFlatVector<int64_t>({60, 70, 80, 40, 50})))});
+
+  testAggregations({data}, {}, {"max_by(c0, c1, 2)"}, {expected});
+
+  // The data consists of four rows, and both the comparison key and the value
+  // key are mapType. The first compare row has two elements.
+  data = makeRowVector({
+      makeFlatVector<int16_t>({1, 2, 1, 2}),
+      makeMapVector<int64_t, int64_t>({
+          {{1, 10}, {2, 20}, {3, 30}},
+          {{4, 40}, {5, 50}},
+          {{2, 1}},
+          {{6, 60}, {7, 70}, {8, 80}},
+      }),
+      makeMapVector<int64_t, int64_t>({
+          {{40, 4}, {0, 0}},
+          {{40, 4}},
+          {{40, 4}, {0, 2}},
+          {{50, 5}, {30, 6}},
+      }),
+  });
+
+  // For the same reason as above. The first row are chosen in first group and
+  // the second row are chosen in second group.
+  expected = makeRowVector(
+      {makeFlatVector<int16_t>({1, 2}),
+       makeArrayVector(
+           {0, 1},
+           makeMapVector(
+               {0, 3},
+               makeFlatVector<int64_t>({1, 2, 3, 6, 7, 8}),
+               makeFlatVector<int64_t>({10, 20, 30, 60, 70, 80})))});
+
+  testAggregations({data}, {"c0"}, {"min_by(c1, c2, 1)"}, {expected});
+}
+
+TEST_F(MinMaxByComplexTypes, rowTypeCompare) {
+  // The data consists of four rows, and the comparison key is RowType and
+  // the value key are ArrayType. Each comparison key has two attributes.
+  auto data = makeRowVector({
+      makeArrayVector<int64_t>({
+          {1, 2, 3},
+          {4, 5},
+          {6, 7, 8},
+          {9, 10},
+      }),
+      makeRowVector(
+          {makeFlatVector<int32_t>({10, 10, 30, 20}),
+           makeFlatVector<int32_t>({3, 2, 1, 4})}),
+  });
+
+  auto expected = makeRowVector({makeArrayVector(
+      {0},
+      makeArrayVector(
+          {0, 2, 5}, makeFlatVector<int64_t>({4, 5, 1, 2, 3, 9, 10})))});
+
+  testAggregations({data}, {}, {"min_by(c0, c1, 3)"}, {expected});
+
+  // The data consists of four rows, and the comparison key is RowType and
+  // the value key are ArrayType. Each comparison key has two attributes.
+  data = makeRowVector({
+      makeFlatVector<int16_t>({1, 2, 1, 2}),
+      makeArrayVector<int64_t>({
+          {1, 2, 3},
+          {4, 5},
+          {6, 7, 8},
+          {9, 10},
+      }),
+      makeRowVector(
+          {makeFlatVector<int32_t>({10, 10, 30, 20}),
+           makeFlatVector<int32_t>({3, 2, 1, 4})}),
+  });
+
+  expected = makeRowVector(
+      {makeFlatVector<int16_t>({1, 2}),
+       makeArrayVector(
+           {0, 1},
+           makeArrayVector({0, 3}, makeFlatVector<int64_t>({1, 2, 3, 4, 5})))});
+
+  testAggregations({data}, {"c0"}, {"min_by(c1, c2, 1)"}, {expected});
+}
+
 TEST_F(MinMaxByNTest, groupByWithNullCompare) {
   // Rows with null 'compare' should be ignored.
   auto data = makeRowVector({


### PR DESCRIPTION
Presto's min_by/max_by with 3 args support complex type for the compare param, such as array.While Velox does not support it currently.
This PR is opened to support complex type for the compare param for min_by/max_by with 3 args.
Fix issue:https://github.com/facebookincubator/velox/issues/7469