### PR TITLE
Change all pools to not skip empty pool when print detail

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -287,7 +287,7 @@ std::string MemoryManager::toString(bool detail) const {
   std::vector<std::shared_ptr<MemoryPool>> pools = getAlivePools();
   for (const auto& pool : pools) {
     if (detail) {
-      out << pool->treeMemoryUsage(true);
+      out << pool->treeMemoryUsage(false);
     } else {
       out << "\t" << pool->name() << "\n";
     }


### PR DESCRIPTION
For query root pools we need to also not skip empty memory pools when print detail.