### PR TITLE
Move velox/external/date to vendored namespace

### DIFF
--- a/velox/external/date/date.h
+++ b/velox/external/date/date.h
@@ -86,6 +86,10 @@
 #   pragma warning(disable : 4127)
 #endif
 
+namespace facebook
+{
+namespace velox
+{
 namespace date
 {
 
@@ -7933,7 +7937,9 @@ operator<<(std::basic_ostream<CharT, Traits>& os,
                  detail::get_units<CharT>(typename Period::type{});
 }
 
-}  // namespace date
+} // namespace date
+} // namespace velox
+} // namespace facebook
 
 #ifdef _MSC_VER
 #   pragma warning(pop)

--- a/velox/external/date/ios.h
+++ b/velox/external/date/ios.h
@@ -32,16 +32,22 @@
 # if TARGET_OS_IPHONE
 #   include <string>
 
+    namespace facebook
+    {
+    namespace velox
+    {
     namespace date
     {
     namespace iOSUtils
     {
-    
+
     std::string get_tzdata_path();
     std::string get_current_timezone();
-    
+
     }  // namespace iOSUtils
     }  // namespace date
+    }  // namespace velox
+    }  // namespace facebook
 
 # endif  // TARGET_OS_IPHONE
 #else   // !__APPLE__

--- a/velox/external/date/patches/add_namespacing-pr-8332.patch
+++ b/velox/external/date/patches/add_namespacing-pr-8332.patch
@@ -1,0 +1,143 @@
+diff --git a/fbcode/velox/external/date/date.h b/fbcode/velox/external/date/date.h
+--- a/fbcode/velox/external/date/date.h
++++ b/fbcode/velox/external/date/date.h
+@@ -86,6 +86,10 @@
+ #   pragma warning(disable : 4127)
+ #endif
+ 
++namespace facebook
++{
++namespace velox
++{
+ namespace date
+ {
+ 
+@@ -7933,7 +7937,9 @@
+                  detail::get_units<CharT>(typename Period::type{});
+ }
+ 
+-}  // namespace date
++} // namespace date
++} // namespace velox
++} // namespace facebook
+ 
+ #ifdef _MSC_VER
+ #   pragma warning(pop)
+diff --git a/fbcode/velox/external/date/ios.h b/fbcode/velox/external/date/ios.h
+--- a/fbcode/velox/external/date/ios.h
++++ b/fbcode/velox/external/date/ios.h
+@@ -32,16 +32,22 @@
+ # if TARGET_OS_IPHONE
+ #   include <string>
+ 
++    namespace facebook
++    {
++    namespace velox
++    {
+     namespace date
+     {
+     namespace iOSUtils
+     {
+-    
++
+     std::string get_tzdata_path();
+     std::string get_current_timezone();
+-    
++
+     }  // namespace iOSUtils
+     }  // namespace date
++    }  // namespace velox
++    }  // namespace facebook
+ 
+ # endif  // TARGET_OS_IPHONE
+ #else   // !__APPLE__
+diff --git a/fbcode/velox/external/date/tz.cpp b/fbcode/velox/external/date/tz.cpp
+--- a/fbcode/velox/external/date/tz.cpp
++++ b/fbcode/velox/external/date/tz.cpp
+@@ -268,6 +268,10 @@
+ 
+ #endif  // !USE_OS_TZDB
+ 
++namespace facebook
++{
++namespace velox
++{
+ namespace date
+ {
+ // +---------------------+
+@@ -3860,6 +3864,8 @@
+ }
+ 
+ }  // namespace date
++}  // namespace velox
++}  // namespace facebook
+ 
+ #if defined(__GNUC__) && __GNUC__ < 5
+ # pragma GCC diagnostic pop
+diff --git a/fbcode/velox/external/date/tz.h b/fbcode/velox/external/date/tz.h
+--- a/fbcode/velox/external/date/tz.h
++++ b/fbcode/velox/external/date/tz.h
+@@ -143,6 +143,10 @@
+ #  endif
+ #endif
+ 
++namespace facebook
++{
++namespace velox
++{
+ namespace date
+ {
+ 
+@@ -2790,5 +2794,7 @@
+ #endif  // !MISSING_LEAP_SECONDS
+ 
+ }  // namespace date
++}  // namespace velox
++}  // namespace facebook
+ 
+ #endif  // TZ_H
+diff --git a/fbcode/velox/external/date/tz_private.h b/fbcode/velox/external/date/tz_private.h
+--- a/fbcode/velox/external/date/tz_private.h
++++ b/fbcode/velox/external/date/tz_private.h
+@@ -34,6 +34,12 @@
+ #include <vector>
+ #endif
+ 
++namespace facebook
++{
++
++namespace velox
++{
++
+ namespace date
+ {
+ 
+@@ -309,6 +315,10 @@
+ 
+ }  // namespace date
+ 
++}  // namespace velox
++
++}  // namespace facebook
++
+ #if defined(_MSC_VER) && (_MSC_VER < 1900)
+ #include "tz.h"
+ #endif
+diff --git a/fbcode/velox/type/Timestamp.h b/fbcode/velox/type/Timestamp.h
+--- a/fbcode/velox/type/Timestamp.h
++++ b/fbcode/velox/type/Timestamp.h
+@@ -24,12 +24,12 @@
+ #include "velox/common/base/CheckedArithmetic.h"
+ #include "velox/type/StringView.h"
+ 
++namespace facebook::velox {
++
+ namespace date {
+ class time_zone;
+ }
+ 
+-namespace facebook::velox {
+-
+ struct TimestampToStringOptions {
+   enum class Precision : int8_t {
+     kMilliseconds = 3, // 10^3 milliseconds are equal to one second.

--- a/velox/external/date/tz.cpp
+++ b/velox/external/date/tz.cpp
@@ -268,6 +268,10 @@ get_download_folder()
 
 #endif  // !USE_OS_TZDB
 
+namespace facebook
+{
+namespace velox
+{
 namespace date
 {
 // +---------------------+
@@ -3860,6 +3864,8 @@ current_zone()
 }
 
 }  // namespace date
+}  // namespace velox
+}  // namespace facebook
 
 #if defined(__GNUC__) && __GNUC__ < 5
 # pragma GCC diagnostic pop

--- a/velox/external/date/tz.h
+++ b/velox/external/date/tz.h
@@ -143,6 +143,10 @@ static_assert(HAS_REMOTE_API == 0 ? AUTO_DOWNLOAD == 0 : true,
 #  endif
 #endif
 
+namespace facebook
+{
+namespace velox
+{
 namespace date
 {
 
@@ -2790,5 +2794,7 @@ to_gps_time(const tai_time<Duration>& t)
 #endif  // !MISSING_LEAP_SECONDS
 
 }  // namespace date
+}  // namespace velox
+}  // namespace facebook
 
 #endif  // TZ_H

--- a/velox/external/date/tz_private.h
+++ b/velox/external/date/tz_private.h
@@ -34,6 +34,12 @@
 #include <vector>
 #endif
 
+namespace facebook
+{
+
+namespace velox
+{
+
 namespace date
 {
 
@@ -308,6 +314,10 @@ struct transition
 }  // namespace detail
 
 }  // namespace date
+
+}  // namespace velox
+
+}  // namespace facebook
 
 #if defined(_MSC_VER) && (_MSC_VER < 1900)
 #include "tz.h"

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -24,11 +24,11 @@
 #include "velox/common/base/CheckedArithmetic.h"
 #include "velox/type/StringView.h"
 
+namespace facebook::velox {
+
 namespace date {
 class time_zone;
 }
-
-namespace facebook::velox {
 
 struct TimestampToStringOptions {
   enum class Precision : int8_t {


### PR DESCRIPTION
Summary:
Moving velox/external/date symbols to a velox namespace to prevent
them from clashing with other project that might also vendor or link the same
code.

Differential Revision: D52649957


