### PR TITLE
Ensure deterministic order of map keys in multimap_from_entries Presto function

### DIFF
--- a/velox/functions/prestosql/MultimapFromEntries.h
+++ b/velox/functions/prestosql/MultimapFromEntries.h
@@ -28,7 +28,12 @@ struct MultimapFromEntriesFunction {
   FOLLY_ALWAYS_INLINE void call(
       out_type<Map<Generic<T1>, Array<Generic<T2>>>>& out,
       const arg_type<Array<Row<Generic<T1>, Generic<T2>>>>& inputArray) {
-    folly::F14FastMap<
+    // Use std::unordered_map to ensure deterministic order of keys in the
+    // result. Without ensuring deterministic order of keys, the results of
+    // expressions like map_keys(multimap_from_entries(...)) will be
+    // non-deterministic and trigger Fuzzer failures. F14Map is faster, but in
+    // debug builds it returns keys in non-deterministic order (on purpose).
+    std::unordered_map<
         exec::GenericView,
         std::vector<std::optional<exec::GenericView>>>
         keyValuesMap;

--- a/velox/functions/prestosql/benchmarks/MultimapFromEntriesBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/MultimapFromEntriesBenchmark.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::functions;
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+
+  functions::prestosql::registerMapFunctions();
+
+  ExpressionBenchmarkBuilder benchmarkBuilder;
+
+  auto makeInputType = [](const TypePtr& keyType, const TypePtr& valueType) {
+    return ROW({"c0"}, {ARRAY(ROW({keyType, valueType}))});
+  };
+
+  benchmarkBuilder
+      .addBenchmarkSet("integer_bigint", makeInputType(INTEGER(), BIGINT()))
+      .addExpression("", "multimap_from_entries(c0)");
+
+  benchmarkBuilder
+      .addBenchmarkSet("integer_varchar", makeInputType(INTEGER(), VARCHAR()))
+      .addExpression("", "multimap_from_entries(c0)");
+
+  benchmarkBuilder.registerBenchmarks();
+
+  folly::runBenchmarks();
+  return 0;
+}


### PR DESCRIPTION
Summary:
multimap_from_entries uses F14Map to dedup map keys. It used to produce result
map by listing entries from F14Map directly. In debug builds F14Map
intentionally makes the order of entries non-deterministic. This results in
Fuzzer seeing different results for expressions like map_keys
(multimap_from_entries(...)). This change is to ensure that order of keys in
the result is the same as in input.

Fixes https://github.com/facebookincubator/velox/issues/8337

Differential Revision: D52675021


