### PR TITLE
remove FOLLY_ALWAYS_INLINE from expensive and test functions

### DIFF
--- a/velox/docs/develop/scalar-functions.rst
+++ b/velox/docs/develop/scalar-functions.rst
@@ -139,7 +139,7 @@ an array:
     VELOX_DEFINE_FUNCTION_TYPES(TExecParams);
 
     template <typename TInput>
-    FOLLY_ALWAYS_INLINE bool callNullFree(
+    bool callNullFree(
         TInput& out,
         const null_free_arg_type<Array<TInput>>& array) {
       out = INT32_MAX;
@@ -433,7 +433,7 @@ The code below shows an example of a function that concatenates a variable numbe
      struct VariadicArgsReaderFunction {
        VELOX_DEFINE_FUNCTION_TYPES(T);
 
-       FOLLY_ALWAYS_INLINE bool call(
+       bool call(
            out_type<Varchar>& out,
            const arg_type<Variadic<Varchar>>& inputs) {
          for (const auto& input : inputs) {

--- a/velox/examples/OpaqueType.cpp
+++ b/velox/examples/OpaqueType.cpp
@@ -98,7 +98,7 @@ template <typename T>
 struct MapResolverSimpleFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  bool call(
       arg_type<std::shared_ptr<UserDefinedOutput>>& out,
       const arg_type<std::shared_ptr<UserDefinedMap>>& state,
       const int64_t& idx) {

--- a/velox/examples/SimpleFunctions.cpp
+++ b/velox/examples/SimpleFunctions.cpp
@@ -156,7 +156,7 @@ template <typename T>
 struct MyNonDeterministicFunction {
   static constexpr bool is_deterministic = false;
 
-  FOLLY_ALWAYS_INLINE bool call(double& result) {
+  bool call(double& result) {
     result = folly::Random::randDouble01();
     return true;
   }
@@ -288,9 +288,7 @@ struct MySimpleSplitFunction {
 
   const char splitChar{' '};
 
-  FOLLY_ALWAYS_INLINE bool call(
-      out_type<Array<Varchar>>& out,
-      const arg_type<Varchar>& input) {
+  bool call(out_type<Array<Varchar>>& out, const arg_type<Varchar>& input) {
     auto start = input.begin();
     auto cur = start;
 
@@ -405,7 +403,7 @@ struct MyComplexTimesTwoFunction {
   // complex types. This one takes and returns an Array. Arrays proxy objects
   // are currently implemented based on std::vector. Vector elements are
   // currently wrapped by std::optional to represent their nullability.
-  FOLLY_ALWAYS_INLINE bool call(
+  bool call(
       out_type<Array<int64_t>>& result,
       const arg_type<Array<int64_t>>& inputArray) {
     result.reserve(inputArray.size());
@@ -417,7 +415,7 @@ struct MyComplexTimesTwoFunction {
 
   // This method takes and returns a Map. Map proxy objects are implemented
   // using std::unordered_map; values are wrapped by std::optional.
-  FOLLY_ALWAYS_INLINE bool call(
+  bool call(
       out_type<Map<int64_t, double>>& result,
       const arg_type<Map<int64_t, double>>& inputMap) {
     result.reserve(inputMap.size());
@@ -430,7 +428,7 @@ struct MyComplexTimesTwoFunction {
 
   // Takes and returns a Row. Rows are backed by std::tuple; individual elements
   // are std::optional.
-  FOLLY_ALWAYS_INLINE bool call(
+  bool call(
       out_type<Row<int64_t, double>>& result,
       const arg_type<Row<int64_t, double>>& inputRow) {
     const auto& elem0 = inputRow.template at<0>();

--- a/velox/expression/ComplexWriterTypes.h
+++ b/velox/expression/ComplexWriterTypes.h
@@ -137,6 +137,42 @@ class ArrayWriter {
     }
   }
 
+  void push_back(const OptionalAccessor<V>& item) {
+    if (!item.has_value()) {
+      add_null();
+    } else {
+      if constexpr (provide_std_interface<V>) {
+        push_back(item.value());
+      } else {
+        add_item().copy_from(item.value());
+      }
+    }
+  }
+
+  void push_back(const std::optional<GenericView>& inputView) {
+    if (inputView.has_value()) {
+      push_back(*inputView);
+    } else {
+      add_null();
+    }
+  }
+
+  void push_back(const GenericView& item) {
+    add_item().copy_from(item);
+  }
+
+  void push_back(const StringView& item) {
+    add_item().copy_from(item);
+  }
+
+  void push_back(const std::optional<StringView>& item) {
+    if (item.has_value()) {
+      push_back(*item);
+    } else {
+      add_null();
+    }
+  }
+
   // Add a new null item to the array.
   void add_null() {
     resize(length_ + 1);

--- a/velox/expression/benchmarks/CallNullFreeBenchmark.cpp
+++ b/velox/expression/benchmarks/CallNullFreeBenchmark.cpp
@@ -76,9 +76,7 @@ struct ArrayMinSimpleFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   template <typename TInput>
-  FOLLY_ALWAYS_INLINE bool call(
-      TInput& out,
-      const arg_type<Array<TInput>>& array) {
+  bool call(TInput& out, const arg_type<Array<TInput>>& array) {
     if (array.size() == 0) {
       return false; // NULL
     }
@@ -112,7 +110,7 @@ struct ArrayMinDefaultContainsNullsBehaviorFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   template <typename TInput>
-  FOLLY_ALWAYS_INLINE bool callNullFree(
+  bool callNullFree(
       TInput& out,
       const null_free_arg_type<Array<TInput>>& array) {
     if (array.size() == 0) {
@@ -136,9 +134,7 @@ struct ArrayMinNullFreeFastPathFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   template <typename TInput>
-  FOLLY_ALWAYS_INLINE bool call(
-      TInput& out,
-      const arg_type<Array<TInput>>& array) {
+  bool call(TInput& out, const arg_type<Array<TInput>>& array) {
     if (array.size() == 0) {
       return false; // NULL
     }
@@ -167,7 +163,7 @@ struct ArrayMinNullFreeFastPathFunction {
   }
 
   template <typename TInput>
-  FOLLY_ALWAYS_INLINE bool callNullFree(
+  bool callNullFree(
       TInput& out,
       const null_free_arg_type<Array<TInput>>& array) {
     if (array.size() == 0) {

--- a/velox/expression/benchmarks/VariadicBenchmark.cpp
+++ b/velox/expression/benchmarks/VariadicBenchmark.cpp
@@ -31,7 +31,7 @@ template <typename T>
 struct StringConcatSimple {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  bool call(
       out_type<Varchar>& out,
       const arg_type<Varchar>& str1,
       const arg_type<Varchar>& str2,
@@ -48,7 +48,7 @@ template <typename T>
 struct StringConcatVariadic {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  bool call(
       out_type<Varchar>& out,
       const arg_type<Variadic<Varchar>>& strings) {
     for (const auto& string : strings) {

--- a/velox/expression/tests/ArrayViewTest.cpp
+++ b/velox/expression/tests/ArrayViewTest.cpp
@@ -388,9 +388,7 @@ template <typename T>
 struct NestedArrayF {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
-      int64_t& out,
-      const arg_type<Array<Array<int64_t>>>& input) {
+  bool call(int64_t& out, const arg_type<Array<Array<int64_t>>>& input) {
     out = 0;
     for (const auto& inner : input) {
       if (inner) {

--- a/velox/expression/tests/ArrayWriterTest.cpp
+++ b/velox/expression/tests/ArrayWriterTest.cpp
@@ -316,12 +316,16 @@ TEST_F(ArrayWriterTest, testVarChar) {
         stringWriter,
         "test a long string, a bit longer than that, longer, and longer");
   }
+
+  arrayWriter.push_back("new_feature"_sv);
+
   vectorWriter.commit();
   auto expected = std::vector<std::vector<std::optional<StringView>>>{
       {"hi"_sv,
        std::nullopt,
        "welcome"_sv,
-       "test a long string, a bit longer than that, longer, and longer"_sv}};
+       "test a long string, a bit longer than that, longer, and longer"_sv,
+       "new_feature"_sv}};
   assertEqualVectors(result, makeNullableArrayVector(expected));
 }
 
@@ -853,7 +857,6 @@ TEST_F(ArrayWriterTest, nestedArrayWriteThenCommitNull) {
     auto& nestedArray = current.add_item();
     nestedArray.push_back(1);
     nestedArray.push_back(2);
-
     writer.commitNull();
   }
 

--- a/velox/expression/tests/GenericWriterTest.cpp
+++ b/velox/expression/tests/GenericWriterTest.cpp
@@ -116,12 +116,7 @@ struct ArrayTrimFunction {
       const int64_t& n) {
     int64_t end = inputArray.size() - n;
     for (int i = 0; i < end; ++i) {
-      if (inputArray[i].has_value()) {
-        auto& newItem = out.add_item();
-        newItem.copy_from(inputArray[i].value());
-      } else {
-        out.add_null();
-      }
+      out.push_back(inputArray[i]);
     }
   }
 };

--- a/velox/expression/tests/MapViewTest.cpp
+++ b/velox/expression/tests/MapViewTest.cpp
@@ -610,9 +610,7 @@ template <typename T>
 struct MapComplexKeyF {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
-      double& out,
-      const arg_type<Map<Array<double>, double>>& input) {
+  bool call(double& out, const arg_type<Map<Array<double>, double>>& input) {
     out = 0;
     for (const auto& entry : input) {
       for (auto v : entry.first) {

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -222,9 +222,7 @@ template <typename T>
 struct ArrayReaderFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
-      int64_t& out,
-      const arg_type<Array<int64_t>>& input) {
+  bool call(int64_t& out, const arg_type<Array<int64_t>>& input) {
     out = 0;
     for (const auto& v : input) {
       if (v) {
@@ -251,9 +249,7 @@ template <typename T>
 struct ArrayArrayReaderFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
-      int64_t& out,
-      const arg_type<Array<Array<int64_t>>>& input) {
+  bool call(int64_t& out, const arg_type<Array<Array<int64_t>>>& input) {
     out = 0;
     for (const auto& inner : input) {
       if (inner) {
@@ -294,7 +290,7 @@ template <typename T>
 struct RowWriterFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  bool call(
       out_type<Row<int64_t, double>>& out,
       const arg_type<int64_t>& input) {
     out = std::make_tuple(rowVectorCol1[input], rowVectorCol2[input]);
@@ -322,9 +318,7 @@ template <typename T>
 struct RowReaderFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
-      int64_t& out,
-      const arg_type<Row<int64_t, double>>& input) {
+  bool call(int64_t& out, const arg_type<Row<int64_t, double>>& input) {
     out = *input.template at<0>();
     return true;
   }
@@ -349,9 +343,7 @@ template <typename T>
 struct RowArrayReaderFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
-      int64_t& out,
-      const arg_type<Row<Array<int64_t>, double>>& input) {
+  bool call(int64_t& out, const arg_type<Row<Array<int64_t>, double>>& input) {
     out = 0;
     const auto& arrayInput = *input.template at<0>();
     for (const auto& v : arrayInput) {
@@ -390,7 +382,7 @@ template <typename T>
 struct ArrayRowWriterFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  bool call(
       out_type<Array<Row<int64_t, double>>>& out,
       const arg_type<int32_t>& input) {
     // Appends each row three times.
@@ -431,9 +423,7 @@ template <typename T>
 struct ArrayRowReaderFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
-      int64_t& out,
-      const arg_type<Array<Row<int64_t, double>>>& input) {
+  bool call(int64_t& out, const arg_type<Array<Row<int64_t, double>>>& input) {
     out = 0;
     for (size_t i = 0; i < input.size(); i++) {
       auto&& row = *input.at(i);
@@ -477,7 +467,7 @@ template <typename T>
 struct RowOpaqueWriterFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  bool call(
       out_type<Row<std::shared_ptr<MyType>, int64_t>>& out,
       const arg_type<int64_t>& input) {
     out.template get_writer_at<0>() =
@@ -519,7 +509,7 @@ template <typename T>
 struct RowOpaqueReaderFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  bool call(
       int64_t& out,
       const arg_type<Row<std::shared_ptr<MyType>, int64_t>>& input) {
     const auto& myType = *input.template at<0>();
@@ -555,7 +545,7 @@ template <typename T>
 struct DefaultNullBehaviorFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(out_type<bool>&, int64_t) {
+  bool call(out_type<bool>&, int64_t) {
     throw std::runtime_error(
         "Function not supposed to be called on null inputs.");
     return true;
@@ -608,14 +598,14 @@ TEST_F(SimpleFunctionTest, nonDefaultNullBehavior) {
 // Ensure that functions can return null (return false).
 template <typename T>
 struct ReturnNullCallFunction {
-  FOLLY_ALWAYS_INLINE bool call(bool& out, const int64_t& input) {
+  bool call(bool& out, const int64_t& input) {
     return false;
   }
 };
 
 template <typename T>
 struct ReturnNullCallNullableFunction {
-  FOLLY_ALWAYS_INLINE bool callNullable(bool& out, const int64_t* input) {
+  bool callNullable(bool& out, const int64_t* input) {
     return false;
   }
 };

--- a/velox/expression/tests/VariadicViewTest.cpp
+++ b/velox/expression/tests/VariadicViewTest.cpp
@@ -389,9 +389,7 @@ template <typename T>
 struct VariadicArgsReaderFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
-      out_type<Varchar>& out,
-      const arg_type<Variadic<Varchar>>& inputs) {
+  bool call(out_type<Varchar>& out, const arg_type<Variadic<Varchar>>& inputs) {
     writeInputToOutput(out, &inputs);
 
     return true;
@@ -456,7 +454,7 @@ template <typename T>
 struct VariadicArgsReaderWithNullsFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  bool call(
       out_type<Varchar>& out,
       const arg_type<Varchar>& first,
       const arg_type<Variadic<Varchar>>& inputs) {
@@ -467,7 +465,7 @@ struct VariadicArgsReaderWithNullsFunction {
     return true;
   }
 
-  FOLLY_ALWAYS_INLINE bool callNullable(
+  bool callNullable(
       out_type<Varchar>& out,
       const arg_type<Varchar>* first,
       const arg_type<Variadic<Varchar>>* inputs) {
@@ -557,16 +555,14 @@ template <typename T>
 struct VariadicArgsReaderWithAsciiFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
-      out_type<Varchar>& out,
-      const arg_type<Variadic<Varchar>>& inputs) {
+  bool call(out_type<Varchar>& out, const arg_type<Variadic<Varchar>>& inputs) {
     out += callPrefix;
     writeInputToOutput(out, &inputs);
 
     return true;
   }
 
-  FOLLY_ALWAYS_INLINE bool callAscii(
+  bool callAscii(
       out_type<Varchar>& out,
       const arg_type<Variadic<Varchar>>& inputs) {
     out += callAsciiPrefix;

--- a/velox/functions/lib/Re2Functions.h
+++ b/velox/functions/lib/Re2Functions.h
@@ -205,7 +205,7 @@ struct Re2RegexpReplace {
     initialize(config, string, pattern, &emptyReplacement);
   }
 
-  FOLLY_ALWAYS_INLINE bool call(
+  bool call(
       out_type<Varchar>& out,
       const arg_type<Varchar>& string,
       const arg_type<Varchar>& /*pattern*/,

--- a/velox/functions/prestosql/ArrayFunctions.h
+++ b/velox/functions/prestosql/ArrayFunctions.h
@@ -106,7 +106,7 @@ struct ArrayMinMaxFunction {
   }
 
   template <typename TReturn, typename TInput>
-  FOLLY_ALWAYS_INLINE bool call(TReturn& out, const TInput& array) {
+  bool call(TReturn& out, const TInput& array) {
     // Result is null if array is empty.
     if (array.size() == 0) {
       return false;
@@ -196,7 +196,7 @@ struct ArrayJoinFunction {
     }
   }
 
-  FOLLY_ALWAYS_INLINE bool call(
+  bool call(
       out_type<velox::Varchar>& result,
       const arg_type<velox::Array<T>>& inputArray,
       const arg_type<velox::Varchar>& delim) {
@@ -204,7 +204,7 @@ struct ArrayJoinFunction {
     return true;
   }
 
-  FOLLY_ALWAYS_INLINE bool call(
+  bool call(
       out_type<velox::Varchar>& result,
       const arg_type<velox::Array<T>>& inputArray,
       const arg_type<velox::Varchar>& delim,
@@ -377,9 +377,7 @@ template <typename T>
 struct ArrayAverageFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
-      double& out,
-      const arg_type<Array<double>>& array) {
+  bool call(double& out, const arg_type<Array<double>>& array) {
     // If the array is empty, then set result to null.
     if (array.size() == 0) {
       return false;
@@ -399,7 +397,7 @@ struct ArrayAverageFunction {
     return count != 0;
   }
 
-  FOLLY_ALWAYS_INLINE bool callNullFree(
+  bool callNullFree(
       double& out,
       const null_free_arg_type<Array<double>>& array) {
     // If the array is empty, then set result to null.

--- a/velox/functions/prestosql/JsonFunctions.h
+++ b/velox/functions/prestosql/JsonFunctions.h
@@ -40,7 +40,7 @@ template <typename T>
 struct JsonExtractScalarFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  bool call(
       out_type<Varchar>& result,
       const arg_type<Json>& json,
       const arg_type<Varchar>& jsonPath) {
@@ -62,7 +62,7 @@ template <typename T>
 struct JsonExtractFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  bool call(
       out_type<Json>& result,
       const arg_type<Json>& json,
       const arg_type<Varchar>& jsonPath) {
@@ -86,7 +86,7 @@ template <typename T>
 struct JsonArrayLengthFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(int64_t& result, const arg_type<Json>& json) {
+  bool call(int64_t& result, const arg_type<Json>& json) {
     auto parsedJson = folly::parseJson(json);
     if (!parsedJson.isArray()) {
       return false;
@@ -141,7 +141,7 @@ template <typename T>
 struct JsonSizeFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  bool call(
       int64_t& result,
       const arg_type<Json>& json,
       const arg_type<Varchar>& jsonPath) {

--- a/velox/functions/prestosql/MultimapFromEntries.h
+++ b/velox/functions/prestosql/MultimapFromEntries.h
@@ -46,12 +46,9 @@ struct MultimapFromEntriesFunction {
     for (const auto& [key, values] : keyValuesMap) {
       auto [keyWriter, valueWriter] = out.add_item();
       keyWriter.copy_from(key);
+
       for (const auto& value : values) {
-        if (value.has_value()) {
-          valueWriter.add_item().copy_from(value.value());
-        } else {
-          valueWriter.add_null();
-        }
+        valueWriter.push_back(value);
       }
     }
   }

--- a/velox/functions/prestosql/SIMDJsonFunctions.h
+++ b/velox/functions/prestosql/SIMDJsonFunctions.h
@@ -140,7 +140,7 @@ template <typename T>
 struct SIMDJsonArrayLengthFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(int64_t& len, const arg_type<Json>& json) {
+  bool call(int64_t& len, const arg_type<Json>& json) {
     ParserContext ctx(json.data(), json.size());
 
     try {
@@ -171,7 +171,7 @@ template <typename T>
 struct SIMDJsonExtractScalarFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  bool call(
       out_type<Varchar>& result,
       const arg_type<Json>& json,
       const arg_type<Varchar>& jsonPath) {
@@ -297,7 +297,7 @@ template <typename T>
 struct SIMDJsonSizeFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  bool call(
       int64_t& result,
       const arg_type<Json>& json,
       const arg_type<Varchar>& jsonPath) {

--- a/velox/functions/prestosql/SplitPart.h
+++ b/velox/functions/prestosql/SplitPart.h
@@ -36,7 +36,7 @@ struct SplitPart {
   // ASCII input always produces ASCII result.
   static constexpr bool is_default_ascii_behavior = true;
 
-  FOLLY_ALWAYS_INLINE bool call(
+  bool call(
       out_type<Varchar>& result,
       const arg_type<Varchar>& input,
       const arg_type<Varchar>& delimiter,

--- a/velox/functions/prestosql/URLFunctions.h
+++ b/velox/functions/prestosql/URLFunctions.h
@@ -222,9 +222,7 @@ struct UrlExtractProtocolFunction {
   // ASCII input always produces ASCII result.
   static constexpr bool is_default_ascii_behavior = true;
 
-  FOLLY_ALWAYS_INLINE bool call(
-      out_type<Varchar>& result,
-      const arg_type<Varchar>& url) {
+  bool call(out_type<Varchar>& result, const arg_type<Varchar>& url) {
     if (!isValidURI(url)) {
       return false;
     }

--- a/velox/functions/prestosql/benchmarks/ArrayMinMaxBenchmark.h
+++ b/velox/functions/prestosql/benchmarks/ArrayMinMaxBenchmark.h
@@ -29,9 +29,7 @@ struct ArrayMinSimpleFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   template <typename TInput>
-  FOLLY_ALWAYS_INLINE bool call(
-      TInput& out,
-      const arg_type<Array<TInput>>& array) {
+  bool call(TInput& out, const arg_type<Array<TInput>>& array) {
     if (array.size() == 0) {
       return false; // NULL
     }
@@ -65,9 +63,7 @@ struct ArrayMinSimpleFunctionIterator {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   template <typename TInput>
-  FOLLY_ALWAYS_INLINE bool call(
-      TInput& out,
-      const arg_type<Array<TInput>>& array) {
+  bool call(TInput& out, const arg_type<Array<TInput>>& array) {
     const auto size = array.size();
     if (size == 0) {
       return false; // NULL
@@ -105,9 +101,7 @@ struct ArrayMinSimpleFunctionSkipNullIterator {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   template <typename TInput>
-  FOLLY_ALWAYS_INLINE bool call(
-      TInput& out,
-      const arg_type<Array<TInput>>& array) {
+  bool call(TInput& out, const arg_type<Array<TInput>>& array) {
     const auto size = array.size();
     if (size == 0) {
       return false; // NULL

--- a/velox/functions/prestosql/benchmarks/MapInputBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/MapInputBenchmark.cpp
@@ -194,9 +194,7 @@ template <typename T>
 struct MapSumValuesAndKeysSimple {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
-      int64_t& out,
-      const arg_type<Map<int64_t, int64_t>>& map) {
+  bool call(int64_t& out, const arg_type<Map<int64_t, int64_t>>& map) {
     out = 0;
     for (const auto& entry : map) {
       out += entry.first;
@@ -210,7 +208,7 @@ template <typename T>
 struct NestedMapSumValuesAndKeysSimple {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  bool call(
       int64_t& out,
       const arg_type<Map<int64_t, Map<int64_t, int64_t>>>& map) {
     out = 0;
@@ -229,7 +227,7 @@ template <typename T>
 struct NestedMapSumStructBind {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  bool call(
       int64_t& out,
       const arg_type<Map<int64_t, Map<int64_t, int64_t>>>& map) {
     out = 0;


### PR DESCRIPTION
Summary:
We use FOLLY_ALWAYS_INLINE in simple functions when the function cost is too small that a function call 
cost is significant, or when there is potential auto SIMD by the compiler or loop optimizations. 

For complex functions operating on maps and arrays thats almost never the case (except the cardinality function). 
this diff clean up some of the usage.

Differential Revision: D52672969


