### PR TITLE
support add_items(std::vector<GenericView>) in array writer

### DIFF
--- a/velox/expression/ComplexWriterTypes.h
+++ b/velox/expression/ComplexWriterTypes.h
@@ -137,6 +137,42 @@ class ArrayWriter {
     }
   }
 
+  void push_back(const OptionalAccessor<V>& item) {
+    if (!item.has_value()) {
+      add_null();
+    } else {
+      if constexpr (provide_std_interface<V>) {
+        push_back(item.value());
+      } else {
+        add_item().copy_from(item.value());
+      }
+    }
+  }
+
+  void push_back(const std::optional<GenericView>& inputView) {
+    if (inputView.has_value()) {
+      push_back(*inputView);
+    } else {
+      add_null();
+    }
+  }
+
+  void push_back(const GenericView& item) {
+    add_item().copy_from(item);
+  }
+
+  void push_back(const StringView& item) {
+    add_item().copy_from(item);
+  }
+
+  void push_back(const std::optional<StringView>& item) {
+    if (item.has_value()) {
+      push_back(*item);
+    } else {
+      add_null();
+    }
+  }
+
   // Add a new null item to the array.
   void add_null() {
     resize(length_ + 1);

--- a/velox/expression/tests/ArrayWriterTest.cpp
+++ b/velox/expression/tests/ArrayWriterTest.cpp
@@ -316,12 +316,16 @@ TEST_F(ArrayWriterTest, testVarChar) {
         stringWriter,
         "test a long string, a bit longer than that, longer, and longer");
   }
+
+  arrayWriter.push_back("new_feature"_sv);
+
   vectorWriter.commit();
   auto expected = std::vector<std::vector<std::optional<StringView>>>{
       {"hi"_sv,
        std::nullopt,
        "welcome"_sv,
-       "test a long string, a bit longer than that, longer, and longer"_sv}};
+       "test a long string, a bit longer than that, longer, and longer"_sv,
+       "new_feature"_sv}};
   assertEqualVectors(result, makeNullableArrayVector(expected));
 }
 
@@ -853,7 +857,6 @@ TEST_F(ArrayWriterTest, nestedArrayWriteThenCommitNull) {
     auto& nestedArray = current.add_item();
     nestedArray.push_back(1);
     nestedArray.push_back(2);
-
     writer.commitNull();
   }
 

--- a/velox/expression/tests/GenericWriterTest.cpp
+++ b/velox/expression/tests/GenericWriterTest.cpp
@@ -116,12 +116,7 @@ struct ArrayTrimFunction {
       const int64_t& n) {
     int64_t end = inputArray.size() - n;
     for (int i = 0; i < end; ++i) {
-      if (inputArray[i].has_value()) {
-        auto& newItem = out.add_item();
-        newItem.copy_from(inputArray[i].value());
-      } else {
-        out.add_null();
-      }
+      out.push_back(inputArray[i]);
     }
   }
 };

--- a/velox/functions/prestosql/ArrayFunctions.h
+++ b/velox/functions/prestosql/ArrayFunctions.h
@@ -810,9 +810,7 @@ struct ArrayRemoveFunction {
       }
     }
 
-    for (const auto& item : toCopyItems) {
-      out.push_back(item);
-    }
+    out.addItems(toCopyItems);
   }
 };
 

--- a/velox/functions/prestosql/MultimapFromEntries.h
+++ b/velox/functions/prestosql/MultimapFromEntries.h
@@ -46,12 +46,9 @@ struct MultimapFromEntriesFunction {
     for (const auto& [key, values] : keyValuesMap) {
       auto [keyWriter, valueWriter] = out.add_item();
       keyWriter.copy_from(key);
+
       for (const auto& value : values) {
-        if (value.has_value()) {
-          valueWriter.add_item().copy_from(value.value());
-        } else {
-          valueWriter.add_null();
-        }
+        valueWriter.push_back(value);
       }
     }
   }

--- a/velox/functions/prestosql/MultimapFromEntries.h
+++ b/velox/functions/prestosql/MultimapFromEntries.h
@@ -47,9 +47,7 @@ struct MultimapFromEntriesFunction {
       auto [keyWriter, valueWriter] = out.add_item();
       keyWriter.copy_from(key);
 
-      for (const auto& value : values) {
-        valueWriter.push_back(value);
-      }
+      valueWriter.add_items(values);
     }
   }
 };


### PR DESCRIPTION
Summary:
test need to be added will attach this to task as explanation.

this is a perf opt + API simplifications. 
casting with castTo is cheap, the issue is int he type check per row and the dynamoc dispatch of copy_from 
which is avoided if this api is used.

Differential Revision: D52677182


