### PR TITLE
Add more output buffer stats and update in TaskStats

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1979,7 +1979,7 @@ TaskStats Task::taskStats() const {
   auto bufferManager = bufferManager_.lock();
   taskStats.outputBufferUtilization = bufferManager->getUtilization(taskId_);
   taskStats.outputBufferOverutilized = bufferManager->isOverutilized(taskId_);
-
+  taskStats.outputBufferStats = bufferManager->stats(taskId_);
   return taskStats;
 }
 

--- a/velox/exec/TaskStats.h
+++ b/velox/exec/TaskStats.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "velox/exec/Driver.h"
+#include "velox/exec/OutputBuffer.h"
 
 namespace facebook::velox::exec {
 
@@ -96,6 +97,9 @@ struct TaskStats {
   double outputBufferUtilization{0};
   /// Indicates if output buffer is over-utilized and thus blocks the producers.
   bool outputBufferOverutilized{false};
+
+  /// Output buffer stats if present.
+  std::optional<OutputBuffer::Stats> outputBufferStats;
 
   /// The longest still running operator call in "op::call" format.
   std::string longestRunningOpCall;


### PR DESCRIPTION
Add bufferedBytes, bufferedPages, totalRowsSent and totalPagesSent in
OutputBuffer::Stats to be aligned with Java. We also add OutputBuffer::Stats
into TaskStats so Prestissimo can report this to coordinator as live output stats.