### PR TITLE
Fix datetime parsing for half day when hour is not specified

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -61,7 +61,7 @@ struct Date {
 
   bool isClockHour = false; // Whether most recent hour specifier is clockhour
   bool isHourOfHalfDay =
-      false; // Whether most recent hour specifier is of half day.
+      true; // Whether most recent hour specifier is of half day.
 
   std::vector<int32_t> dayOfMonthValues;
   std::vector<int32_t> dayOfYearValues;

--- a/velox/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/velox/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -1004,6 +1004,17 @@ TEST_F(JodaDateTimeFormatterTest, parseHalfOfDay) {
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 12:00:00"),
       parseJoda("1 AM 12", "h a H").timestamp);
+
+  // Half of day still has effect even though hour or clockhour is not provided.
+  EXPECT_EQ(
+      util::fromTimestampString("1970-01-01 12:00:00"),
+      parseJoda("PM", "a").timestamp);
+  EXPECT_EQ(
+      util::fromTimestampString("1970-01-01 12:11:11"),
+      parseJoda("11:11 PM", "mm:ss a").timestamp);
+  EXPECT_EQ(
+      util::fromTimestampString("2018-04-28 12:59:30"),
+      parseJoda("2018-04-28 59:30 PM", "yyyy-MM-dd mm:ss a").timestamp);
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseMinute) {


### PR DESCRIPTION
In spark, half day specifier "PM" still takes effect even though hour is not specified. For example, parsing `("2018-04-28 59:30 PM", "yyyy-MM-dd mm:ss a")` should return the timestamp of `2018-04-28 12:59:30`, but Velox returns `2018-04-28 00:59:30`, which has 12-hour difference.