### PR TITLE
Remove deprecated configs `kCastToIntByTruncate` and `kCastStringToDateIsIso8601`

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -101,25 +101,6 @@ class QueryConfig {
   static constexpr const char* kCastMatchStructByName =
       "cast_match_struct_by_name";
 
-  /// If set, cast from float/double/decimal/string to integer truncates the
-  /// decimal part, otherwise rounds.
-  static constexpr const char* kCastToIntByTruncate = "cast_to_int_by_truncate";
-
-  /// If set, cast from string to date allows only ISO 8601 formatted strings:
-  /// [+-](YYYY-MM-DD). Otherwise, allows all patterns supported by Spark:
-  /// `[+-]yyyy*`
-  /// `[+-]yyyy*-[m]m`
-  /// `[+-]yyyy*-[m]m-[d]d`
-  /// `[+-]yyyy*-[m]m-[d]d *`
-  /// `[+-]yyyy*-[m]m-[d]dT*`
-  /// The asterisk `*` in `yyyy*` stands for any numbers.
-  /// For the last two patterns, the trailing `*` can represent none or any
-  /// sequence of characters, e.g:
-  ///   "1970-01-01 123"
-  ///   "1970-01-01 (BC)"
-  static constexpr const char* kCastStringToDateIsIso8601 =
-      "cast_string_to_date_is_iso_8601";
-
   /// Used for backpressure to block local exchange producers when the local
   /// exchange buffer reaches or exceeds this size.
   static constexpr const char* kMaxLocalExchangeBufferSize =
@@ -508,16 +489,6 @@ class QueryConfig {
 
   bool isMatchStructByName() const {
     return get<bool>(kCastMatchStructByName, false);
-  }
-
-  // TODO: to be removed.
-  bool isCastToIntByTruncate() const {
-    return get<bool>(kCastToIntByTruncate, false);
-  }
-
-  // TODO: to be removed.
-  bool isIso8601() const {
-    return get<bool>(kCastStringToDateIsIso8601, true);
   }
 
   bool codegenEnabled() const {


### PR DESCRIPTION
After https://github.com/facebookincubator/velox/pull/7377, kCastToIntByTruncate and kCastStringToDateIsIso8601 are no longer in use.