### PR TITLE
Assert addressable range in bits::scatterBits

### DIFF
--- a/velox/common/base/BitUtil.h
+++ b/velox/common/base/BitUtil.h
@@ -873,13 +873,18 @@ void copyBitsBackward(
     uint64_t targetOffset,
     uint64_t numBits);
 
-// Copies consecutive bits from 'source' to positions in 'target'
-// where 'targetMask' has a 1. 'source' may be a prefix of 'target',
-// so that contiguous bits of source are scattered in place. The
-// positions of 'target' where 'targetMask' is 0 are 0. A sample use
-// case is reading a column of boolean with nulls. The booleans
-// from the column get inserted into the places given by ones in the
-// present bitmap.
+/// Copies consecutive bits from 'source' to positions in 'target'
+/// where 'targetMask' has a 1. 'source' may be a prefix of 'target',
+/// so that contiguous bits of source are scattered in place. The
+/// positions of 'target' where 'targetMask' is 0 are 0. A sample use
+/// case is reading a column of boolean with nulls. The booleans from
+/// the column get inserted into the places given by ones in the
+/// present bitmap. All source, target and mask bit arrays are
+/// accessed at 64 bit width and must have a minimum of 64 bits plus
+/// one addressable byte after the last bit. Using std::vector as a
+/// bit array without explicit padding, for example, can crash with
+/// access to unmapped address if the vector happens to border on
+/// unmapped memory.
 void scatterBits(
     int32_t numSource,
     int32_t numTarget,

--- a/velox/dwio/dwrf/test/TestByteRle.cpp
+++ b/velox/dwio/dwrf/test/TestByteRle.cpp
@@ -1201,15 +1201,12 @@ TEST(BooleanRle, skipTestWithNulls) {
   std::unique_ptr<SeekableInputStream> stream(
       new SeekableArrayInputStream(buffer, VELOX_ARRAY_SIZE(buffer)));
   std::unique_ptr<ByteRleDecoder> rle = createBooleanDecoder(std::move(stream));
-  std::vector<char> data;
-  // Buffers are expected to be writable in full words. Init a full
-  // word for valgrind, then resize to actually used size.
-  data.resize(bits::roundUp(3, 8));
+  raw_vector<char> data;
   data.resize(3);
   std::vector<uint64_t> someNull(1, ~0x0505050505050505);
   std::vector<uint64_t> allNull(1, bits::kNull64);
   for (size_t i = 0; i < 16384; i += 5) {
-    data.assign(data.size(), -1);
+    std::fill(data.begin(), data.end(), -1);
     rle->next(data.data(), data.size(), someNull.data());
     EXPECT_EQ(0, bits::isBitSet(data.data(), 0)) << "Output wrong at " << i;
     EXPECT_EQ(0, bits::isBitSet(data.data(), 2)) << "Output wrong at " << i;
@@ -1219,7 +1216,7 @@ TEST(BooleanRle, skipTestWithNulls) {
       rle->skip(4);
     }
     rle->skip(0);
-    data.assign(data.size(), -1);
+    std::fill(data.begin(), data.end(), -1);
     ;
     rle->next(data.data(), data.size(), allNull.data());
     for (size_t j = 0; j < data.size(); ++j) {


### PR DESCRIPTION
If the size in bits is a multiple of 8, scatterBits will read/write one byte past the last byte in range in target and mask. This can hit unmapped memory in rare cases, for example if std::vector is used as container and we have a power of two size and the array ends at the last byte of mapped address space.

We intentionally reference one byte past end with ASAN, so that ASAN detects the overread even if the array does not border unmapped memory.