### PR TITLE
Add support for deserializing a single column in presto page format

### DIFF
--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -3458,6 +3458,43 @@ void PrestoVectorSerde::deserialize(
       (*result)->size(), 0, nullptr, nullptr, **result, resultOffset);
 }
 
+void PrestoVectorSerde::deserializeSingleColumn(
+    ByteInputStream* source,
+    velox::memory::MemoryPool* pool,
+    TypePtr type,
+    VectorPtr* result,
+    const Options* options) {
+  const auto prestoOptions = toPrestoOptions(options);
+  VELOX_CHECK_EQ(
+      prestoOptions.compressionKind,
+      common::CompressionKind::CompressionKind_NONE);
+  const bool useLosslessTimestamp = prestoOptions.useLosslessTimestamp;
+
+  if (*result && result->unique()) {
+    VELOX_CHECK(
+        *(*result)->type() == *type,
+        "Unexpected type: {} vs. {}",
+        (*result)->type()->toString(),
+        type->toString());
+    (*result)->prepareForReuse();
+  } else {
+    *result = BaseVector::create(type, 0, pool);
+  }
+
+  auto types = {type};
+  std::vector<VectorPtr> resultList = {*result};
+  readColumns(source, pool, types, resultList, 0, useLosslessTimestamp);
+
+  auto rowType = asRowType(ROW(types));
+  RowVectorPtr tempRow = std::make_shared<velox::RowVector>(
+      pool, rowType, nullptr, resultList[0]->size(), resultList);
+  scatterStructNulls(tempRow->size(), 0, nullptr, nullptr, *tempRow, 0);
+  // A copy of the 'result' shared_ptr was passed to scatterStructNulls() via
+  // 'resultList'. Make sure we re-assign 'result' in case the copy was replaced
+  // with a new vector.
+  *result = resultList[0];
+}
+
 void testingScatterStructNulls(
     vector_size_t size,
     vector_size_t scatterSize,

--- a/velox/serializers/PrestoSerializer.h
+++ b/velox/serializers/PrestoSerializer.h
@@ -120,6 +120,18 @@ class PrestoVectorSerde : public VectorSerde {
       vector_size_t resultOffset,
       const Options* options) override;
 
+  /// This function is used to deserialize a single column that is serialized in
+  /// PrestoPage format. It is important to note that the PrestoPage format used
+  /// here does not include the Presto page header. Therefore, the 'source'
+  /// should contain uncompressed, serialized binary data, beginning at the
+  /// column header.
+  void deserializeSingleColumn(
+      ByteInputStream* source,
+      velox::memory::MemoryPool* pool,
+      TypePtr type,
+      VectorPtr* result,
+      const Options* options);
+
   static void registerVectorSerde();
 };
 

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -36,8 +36,10 @@ class PrestoSerializerTest
     : public ::testing::TestWithParam<common::CompressionKind>,
       public VectorTestBase {
  protected:
-  static void SetUpTestCase() {
-    serializer::presto::PrestoVectorSerde::registerVectorSerde();
+  static void SetUpTestSuite() {
+    if (!isRegisteredVectorSerde()) {
+      serializer::presto::PrestoVectorSerde::registerVectorSerde();
+    }
     memory::MemoryManager::testingSetInstance({});
   }
 
@@ -690,3 +692,76 @@ INSTANTIATE_TEST_SUITE_P(
         common::CompressionKind::CompressionKind_ZSTD,
         common::CompressionKind::CompressionKind_LZ4,
         common::CompressionKind::CompressionKind_GZIP));
+
+TEST_F(PrestoSerializerTest, deserializeSingleColumn) {
+  // Verify that deserializeSingleColumn API can handle all supported types.
+  static const size_t kPrestoPageHeaderBytes = 21;
+  static const size_t kNumOfColumnsSerializedBytes = sizeof(int32_t);
+  static const size_t kBytesToTrim =
+      kPrestoPageHeaderBytes + kNumOfColumnsSerializedBytes;
+
+  auto testRoundTripSingleColumn = [&](const VectorPtr& vector) {
+    auto rowVector = makeRowVector({vector});
+    // Serialize to PrestoPage format.
+    std::ostringstream output;
+    auto arena = std::make_unique<StreamArena>(pool_.get());
+    auto rowType = asRowType(rowVector->type());
+    auto numRows = rowVector->size();
+    auto serializer =
+        serde_->createSerializer(rowType, numRows, arena.get(), nullptr);
+    serializer->append(rowVector);
+    facebook::velox::serializer::presto::PrestoOutputStreamListener listener;
+    OStreamOutputStream out(&output, &listener);
+    serializer->flush(&out);
+
+    // Remove the PrestoPage header and Number of columns section from the
+    // serialized data.
+    std::string input = output.str().substr(kBytesToTrim);
+
+    auto byteStream = toByteStream(input);
+    VectorPtr deserialized;
+    serde_->deserializeSingleColumn(
+        &byteStream, pool(), vector->type(), &deserialized, nullptr);
+    assertEqualVectors(vector, deserialized);
+  };
+
+  std::vector<TypePtr> typesToTest = {
+      BOOLEAN(),
+      TINYINT(),
+      SMALLINT(),
+      INTEGER(),
+      BIGINT(),
+      REAL(),
+      DOUBLE(),
+      VARCHAR(),
+      TIMESTAMP(),
+      ROW({VARCHAR(), INTEGER()}),
+      ARRAY(INTEGER()),
+      ARRAY(INTEGER()),
+      MAP(VARCHAR(), INTEGER()),
+      MAP(VARCHAR(), ARRAY(INTEGER())),
+  };
+
+  VectorFuzzer::Options opts;
+  opts.vectorSize = 5;
+  opts.nullRatio = 0.1;
+  opts.dictionaryHasNulls = false;
+  opts.stringVariableLength = true;
+  opts.stringLength = 20;
+  opts.containerVariableLength = false;
+  opts.timestampPrecision =
+      VectorFuzzer::Options::TimestampPrecision::kMilliSeconds;
+  opts.containerLength = 10;
+
+  auto seed = 0;
+
+  LOG(ERROR) << "Seed: " << seed;
+  SCOPED_TRACE(fmt::format("seed: {}", seed));
+  VectorFuzzer fuzzer(opts, pool_.get(), seed);
+
+  for (const auto& type : typesToTest) {
+    SCOPED_TRACE(fmt::format("Type: {}", type->toString()));
+    auto data = fuzzer.fuzz(type);
+    testRoundTripSingleColumn(data);
+  }
+}


### PR DESCRIPTION
Summary:
This adds the ability to read a column serialized in presto page
format with only the [Column header][Column Data] section. These
types of serialized vectors are commonly found as base64 encoded
constants within query plans generated by the Presto coordinator.

Differential Revision: D52711707


