### PR TITLE
Add support for deserialization of all-null columns serialized as UNKNOWN type

### DIFF
--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -967,6 +967,50 @@ void checkTypeEncoding(std::string_view encoding, const TypePtr& type) {
       encoding);
 }
 
+// This is used when there's a mismatch between the encoding in the serialized
+// page and the expected output encoding. If the serialized encoding is
+// BYTE_ARRAY, it may represent an all-null vector of the expected output type.
+// We attempt to read the serialized page as an UNKNOWN type, check if all
+// values are null, and set the columnResult accordingly. If all values are
+// null, we return true; otherwise, we return false.
+bool tryReadNullColumn(
+    ByteInputStream* source,
+    velox::memory::MemoryPool* pool,
+    const TypePtr& columnType,
+    VectorPtr& columnResult,
+    vector_size_t resultOffset,
+    bool useLosslessTimestamp) {
+  auto unknownType = UNKNOWN();
+  VectorPtr tempResult = BaseVector::create(unknownType, 0, pool);
+  read<UnknownValue>(
+      source,
+      unknownType,
+      pool,
+      tempResult,
+      0 /*resultOffset*/,
+      useLosslessTimestamp);
+  auto deserializedSize = tempResult->size();
+  // Ensure it contains all null values.
+  auto numNulls = BaseVector::countNulls(tempResult->nulls(), deserializedSize);
+  if (deserializedSize != numNulls) {
+    return false;
+  }
+  if (resultOffset == 0) {
+    columnResult =
+        BaseVector::createNullConstant(columnType, deserializedSize, pool);
+  } else {
+    columnResult->resize(resultOffset + deserializedSize);
+
+    SelectivityVector nullRows(resultOffset + deserializedSize, false);
+    nullRows.setValidRange(resultOffset, resultOffset + deserializedSize, true);
+    nullRows.updateBounds();
+
+    BaseVector::ensureWritable(nullRows, columnType, pool, columnResult);
+    columnResult->addNulls(nullRows);
+  }
+  return true;
+}
+
 void readColumns(
     ByteInputStream* source,
     velox::memory::MemoryPool* pool,
@@ -1024,7 +1068,20 @@ void readColumns(
           resultOffset,
           useLosslessTimestamp);
     } else {
-      checkTypeEncoding(encoding, columnType);
+      auto typeToEncoding = typeToEncodingName(columnType);
+      if (encoding != typeToEncoding) {
+        if (encoding == "BYTE_ARRAY" &&
+            tryReadNullColumn(
+                source,
+                pool,
+                columnType,
+                columnResult,
+                resultOffset,
+                useLosslessTimestamp)) {
+          return;
+        }
+        checkTypeEncoding(encoding, columnType);
+      }
       const auto it = readers.find(columnType->kind());
       VELOX_CHECK(
           it != readers.end(),

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -419,16 +419,60 @@ TEST_P(PrestoSerializerTest, intervalDayTime) {
 }
 
 TEST_P(PrestoSerializerTest, unknown) {
+  // Verify vectors of UNKNOWN type. Also verifies a special case where a
+  // vector, not of UNKNOWN type and with all nulls is serialized as an UNKNOWN
+  // type having BYTE_ARRAY encoding.
+  auto testAllNullSerializedAsUnknown = [&](VectorPtr vector,
+                                            TypePtr outputType) {
+    auto rowVector = makeRowVector({vector});
+    auto expected = makeRowVector(
+        {BaseVector::createNullConstant(outputType, vector->size(), pool())});
+    std::ostringstream out;
+    serialize(rowVector, &out, nullptr);
+
+    auto rowType = asRowType(expected->type());
+    auto deserialized = deserialize(rowType, out.str(), nullptr);
+    assertEqualVectors(expected, deserialized);
+
+    if (rowVector->size() < 3) {
+      return;
+    }
+
+    // Split input into 3 batches. Serialize each separately. Then, deserialize
+    // all into one vector.
+    auto splits = split(rowVector, 3);
+    std::vector<std::string> serialized;
+    for (const auto& split : splits) {
+      std::ostringstream oss;
+      serialize(split, &oss, nullptr);
+      serialized.push_back(oss.str());
+    }
+
+    auto paramOptions = getParamSerdeOptions(nullptr);
+    RowVectorPtr result;
+    vector_size_t offset = 0;
+    for (auto i = 0; i < serialized.size(); ++i) {
+      auto byteStream = toByteStream(serialized[i]);
+      serde_->deserialize(
+          &byteStream, pool_.get(), rowType, &result, offset, &paramOptions);
+      offset = result->size();
+    }
+
+    assertEqualVectors(expected, result);
+  };
+
   const vector_size_t size = 123;
   auto constantVector =
-      BaseVector::createNullConstant(UNKNOWN(), 123, pool_.get());
+      BaseVector::createNullConstant(UNKNOWN(), size, pool_.get());
   testRoundTrip(constantVector);
+  testAllNullSerializedAsUnknown(constantVector, BIGINT());
 
   auto flatVector = BaseVector::create(UNKNOWN(), size, pool_.get());
   for (auto i = 0; i < size; i++) {
     flatVector->setNull(i, true);
   }
   testRoundTrip(flatVector);
+  testAllNullSerializedAsUnknown(flatVector, BIGINT());
 }
 
 TEST_P(PrestoSerializerTest, multiPage) {


### PR DESCRIPTION
Summary:
This change enables the deserialization of a column consisting
entirely of null values, regardless of its data type, when it is
serialized as a column of the UNKNOWN type. Such a vector isn't
produced by the PrestoSerializer, but it can be encountered when
processing vectors not generated by it. For instance, this situation
arose when a constant vector, serialized within the query plan and
created by the Presto coordinator, was being read.

Differential Revision: D52711814


