### PR TITLE
Avoid throwing in OutputBufferManager::updateNumDrivers().

### DIFF
--- a/velox/exec/OutputBufferManager.cpp
+++ b/velox/exec/OutputBufferManager.cpp
@@ -132,10 +132,14 @@ bool OutputBufferManager::updateOutputBuffers(
   return false;
 }
 
-void OutputBufferManager::updateNumDrivers(
+bool OutputBufferManager::updateNumDrivers(
     const std::string& taskId,
     uint32_t newNumDrivers) {
-  getBuffer(taskId)->updateNumDrivers(newNumDrivers);
+  if (auto buffer = getBufferIfExists(taskId)) {
+    buffer->updateNumDrivers(newNumDrivers);
+    return true;
+  }
+  return false;
 }
 
 void OutputBufferManager::removeTask(const std::string& taskId) {

--- a/velox/exec/OutputBufferManager.h
+++ b/velox/exec/OutputBufferManager.h
@@ -27,7 +27,7 @@ class OutputBufferManager {
       int numDestinations,
       int numDrivers);
 
-  /// Updates the number of buffers. Return true if the buffer exists for a
+  /// Updates the number of buffers. Returns true if the buffer exists for a
   /// given taskId, else returns false.
   bool updateOutputBuffers(
       const std::string& taskId,
@@ -36,7 +36,8 @@ class OutputBufferManager {
 
   /// When we understand the final number of split groups (for grouped
   /// execution only), we need to update the number of producing drivers here.
-  void updateNumDrivers(const std::string& taskId, uint32_t newNumDrivers);
+  /// Returns true if the buffer exists for a given taskId, else returns false.
+  bool updateNumDrivers(const std::string& taskId, uint32_t newNumDrivers);
 
   // Adds data to the outgoing queue for 'destination'. 'data' must not be
   // nullptr. 'data' is always added but if the buffers are full the future is

--- a/velox/exec/tests/OutputBufferManagerTest.cpp
+++ b/velox/exec/tests/OutputBufferManagerTest.cpp
@@ -1149,6 +1149,9 @@ TEST_F(OutputBufferManagerTest, getDataOnFailedTask) {
       [](std::vector<std::unique_ptr<folly::IOBuf>> pages, int64_t sequence) {
         VELOX_UNREACHABLE();
       }));
+
+  // Missing tasks should be ignored in this call.
+  ASSERT_FALSE(bufferManager_->updateNumDrivers("test.0.2", 1));
 }
 
 TEST_F(OutputBufferManagerTest, updateBrodcastBufferOnFailedTask) {


### PR DESCRIPTION
Summary:
Avoid throwing in OutputBufferManager::updateNumDrivers() if
the buffer for the Task is not found.

The event that triggers OutputBufferManager::updateNumDrivers() might
come after the buffers for the Task were removed.

Differential Revision: D52716775


