### PR TITLE
Add find_in_set Spark function

### DIFF
--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -55,6 +55,18 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
         SELECT endswith('js SQL', 'js'); -- false
         SELECT endswith('js SQL', NULL); -- NULL
 
+.. spark:function:: find_in_set(str, strArray) -> integer
+
+    Returns the index (1-based) of the given string ``str`` in the comma-delimited list ``strArray``.
+    Returns 0, if the string was not found or if the given string ``str`` contains a comma. ::
+
+        SELECT find_in_set('ab', 'abc,b,ab,c,def'); -- 3
+        SELECT find_in_set('', ''); -- 1
+        SELECT find_in_set('', '123,'); -- 2
+        SELECT find_in_set('', ',123'); -- 1
+        SELECT find_in_set(NULL, ',123'); -- NULL
+        SELECT find_in_set("abc", NULL); -- NULL
+
 .. spark:function:: instr(string, substring) -> integer
 
     Returns the starting position of the first instance of ``substring`` in

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -57,10 +57,12 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 
 .. spark:function:: find_in_set(str, strArray) -> integer
 
-    Returns the index (1-based) of the given string ``str`` in the comma-delimited list ``strArray``.
+    Returns 1-based index of the given string ``str`` in the comma-delimited list ``strArray``.
     Returns 0, if the string was not found or if the given string ``str`` contains a comma. ::
 
         SELECT find_in_set('ab', 'abc,b,ab,c,def'); -- 3
+        SELECT find_in_set('ab,', 'abc,b,ab,c,def'); -- 0
+        SELECT find_in_set('dfg', 'abc,b,ab,c,def'); -- 0
         SELECT find_in_set('', ''); -- 1
         SELECT find_in_set('', '123,'); -- 2
         SELECT find_in_set('', ',123'); -- 1

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -248,6 +248,9 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<ReplaceFunction, Varchar, Varchar, Varchar, Varchar>(
       {prefix + "replace"});
 
+  registerFunction<FindInSetFunction, int32_t, Varchar, Varchar>(
+      {prefix + "find_in_set"});
+
   // Register array sort functions.
   exec::registerStatefulVectorFunction(
       prefix + "array_sort", arraySortSignatures(), makeArraySort);

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -1141,22 +1141,19 @@ struct FindInSetFunction {
     int32_t index = 1;
     int32_t lastComma = -1;
 
-    auto match = std::string_view(str);
-    auto arrayStr = std::string_view(strArray);
-
-    if (match.find(',') != std::string::npos) {
+    if (str.find(',') != std::string::npos) {
       result = 0;
       return;
     }
 
-    auto arrayData = arrayStr.data();
-    size_t arraySize = arrayStr.size();
-    size_t matchSize = match.size();
+    auto arrayData = strArray.data();
+    size_t arraySize = strArray.size();
+    size_t matchSize = str.size();
 
     for (int i = 0; i < arraySize; i++) {
       if (arrayData[i] == ',') {
         if (i - (lastComma + 1) == matchSize &&
-            arrayStr.compare(lastComma + 1, i - (lastComma + 1), match) == 0) {
+            strArray.compare(lastComma + 1, i - (lastComma + 1), str) == 0) {
           result = index;
           return;
         }
@@ -1166,7 +1163,7 @@ struct FindInSetFunction {
     }
 
     if (arraySize - (lastComma + 1) == matchSize) {
-      if (arrayStr.compare(lastComma + 1, arraySize - (lastComma + 1), match) ==
+      if (strArray.compare(lastComma + 1, arraySize - (lastComma + 1), str) ==
           0) {
         result = index;
         return;

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -1153,8 +1153,9 @@ struct FindInSetFunction {
     for (int i = 0; i < arraySize; i++) {
       if (arrayData[i] == ',') {
         if (i - (lastComma + 1) == matchSize &&
-            strArray ==
-                StringView(str.data() + (lastComma + 1), i - (lastComma + 1))) {
+            str ==
+                StringView(
+                    strArray.data() + (lastComma + 1), i - (lastComma + 1))) {
           result = index;
           return;
         }
@@ -1164,9 +1165,9 @@ struct FindInSetFunction {
     }
 
     if (arraySize - (lastComma + 1) == matchSize) {
-      if (strArray ==
+      if (str ==
           StringView(
-              str.data() + (lastComma + 1), arraySize - (lastComma + 1))) {
+              strArray.data() + (lastComma + 1), arraySize - (lastComma + 1))) {
         result = index;
         return;
       }

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -1138,24 +1138,23 @@ struct FindInSetFunction {
       out_type<int32_t>& result,
       const arg_type<Varchar>& str,
       const arg_type<Varchar>& strArray) {
-    int32_t index = 1;
-    int32_t lastComma = -1;
-
     if (std::string_view(str).find(',') != std::string::npos) {
       result = 0;
       return;
     }
 
+    int32_t index = 1;
+    int32_t lastComma = -1;
     auto arrayData = strArray.data();
+    auto matchData = str.data();
     size_t arraySize = strArray.size();
     size_t matchSize = str.size();
 
     for (int i = 0; i < arraySize; i++) {
       if (arrayData[i] == ',') {
         if (i - (lastComma + 1) == matchSize &&
-            str ==
-                StringView(
-                    strArray.data() + (lastComma + 1), i - (lastComma + 1))) {
+            std::memcmp(arrayData + (lastComma + 1), matchData, matchSize) ==
+                0) {
           result = index;
           return;
         }
@@ -1164,13 +1163,10 @@ struct FindInSetFunction {
       }
     }
 
-    if (arraySize - (lastComma + 1) == matchSize) {
-      if (str ==
-          StringView(
-              strArray.data() + (lastComma + 1), arraySize - (lastComma + 1))) {
-        result = index;
-        return;
-      }
+    if (arraySize - (lastComma + 1) == matchSize &&
+        std::memcmp(arrayData + (lastComma + 1), matchData, matchSize) == 0) {
+      result = index;
+      return;
     }
 
     result = 0;

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -1141,22 +1141,20 @@ struct FindInSetFunction {
     int32_t index = 1;
     int32_t lastComma = -1;
 
-    auto match = std::string_view(str);
-    auto arrayStr = std::string_view(strArray);
-
-    if (match.find(',') != std::string::npos) {
+    if (std::string_view(str).find(',') != std::string::npos) {
       result = 0;
       return;
     }
 
-    auto arrayData = arrayStr.data();
-    size_t arraySize = arrayStr.size();
-    size_t matchSize = match.size();
+    auto arrayData = strArray.data();
+    size_t arraySize = strArray.size();
+    size_t matchSize = str.size();
 
     for (int i = 0; i < arraySize; i++) {
       if (arrayData[i] == ',') {
         if (i - (lastComma + 1) == matchSize &&
-            arrayStr.compare(lastComma + 1, i - (lastComma + 1), match) == 0) {
+            strArray ==
+                StringView(str.data() + (lastComma + 1), i - (lastComma + 1))) {
           result = index;
           return;
         }
@@ -1166,8 +1164,9 @@ struct FindInSetFunction {
     }
 
     if (arraySize - (lastComma + 1) == matchSize) {
-      if (arrayStr.compare(lastComma + 1, arraySize - (lastComma + 1), match) ==
-          0) {
+      if (strArray ==
+          StringView(
+              str.data() + (lastComma + 1), arraySize - (lastComma + 1))) {
         result = index;
         return;
       }

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -1141,19 +1141,22 @@ struct FindInSetFunction {
     int32_t index = 1;
     int32_t lastComma = -1;
 
-    if (str.find(',') != std::string::npos) {
+    auto match = std::string_view(str);
+    auto arrayStr = std::string_view(strArray);
+
+    if (match.find(',') != std::string::npos) {
       result = 0;
       return;
     }
 
-    auto arrayData = strArray.data();
-    size_t arraySize = strArray.size();
-    size_t matchSize = str.size();
+    auto arrayData = arrayStr.data();
+    size_t arraySize = arrayStr.size();
+    size_t matchSize = match.size();
 
     for (int i = 0; i < arraySize; i++) {
       if (arrayData[i] == ',') {
         if (i - (lastComma + 1) == matchSize &&
-            strArray.compare(lastComma + 1, i - (lastComma + 1), str) == 0) {
+            arrayStr.compare(lastComma + 1, i - (lastComma + 1), match) == 0) {
           result = index;
           return;
         }
@@ -1163,7 +1166,7 @@ struct FindInSetFunction {
     }
 
     if (arraySize - (lastComma + 1) == matchSize) {
-      if (strArray.compare(lastComma + 1, arraySize - (lastComma + 1), str) ==
+      if (arrayStr.compare(lastComma + 1, arraySize - (lastComma + 1), match) ==
           0) {
         result = index;
         return;

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -823,6 +823,7 @@ TEST_F(StringTest, replace) {
 TEST_F(StringTest, findInSet) {
   EXPECT_EQ(findInSet("ab", "abc,b,ab,c,def"), 3);
   EXPECT_EQ(findInSet("abc", "abc,b,ab,c,def"), 1);
+  EXPECT_EQ(findInSet("ab,", "abc,b,ab,c,def"), 0);
   EXPECT_EQ(findInSet("ab", "abc,b,ab,ab,ab"), 3);
   EXPECT_EQ(findInSet("abc", "abc,abc,abc,abc,abc"), 1);
   EXPECT_EQ(findInSet("c", "abc,b,ab,c,def"), 4);

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -219,6 +219,12 @@ class StringTest : public SparkFunctionBaseTest {
     return evaluateOnce<std::string>(
         "replace(c0, c1, c2)", str, replaced, replacement);
   }
+
+  std::optional<int32_t> findInSet(
+      std::optional<std::string> str,
+      std::optional<std::string> strArray) {
+    return evaluateOnce<int32_t>("find_in_set(c0, c1)", str, strArray);
+  }
 };
 
 TEST_F(StringTest, Ascii) {
@@ -812,6 +818,36 @@ TEST_F(StringTest, replace) {
   EXPECT_EQ(
       replace("123\u6570\u6570\u636E", "\u6570\u636E", "data"),
       "123\u6570data");
+}
+
+TEST_F(StringTest, findInSet) {
+  EXPECT_EQ(findInSet("ab", "abc,b,ab,c,def"), 3);
+  EXPECT_EQ(findInSet("abc", "abc,b,ab,c,def"), 1);
+  EXPECT_EQ(findInSet("ab", "abc,b,ab,ab,ab"), 3);
+  EXPECT_EQ(findInSet("abc", "abc,abc,abc,abc,abc"), 1);
+  EXPECT_EQ(findInSet("c", "abc,b,ab,c,def"), 4);
+  EXPECT_EQ(findInSet("dfg", "abc,b,ab,c,def"), 0);
+  EXPECT_EQ(findInSet("dfg", "dfgdsiaq"), 0);
+  EXPECT_EQ(findInSet("dfg", "dfgdsiaq, dshadad"), 0);
+  EXPECT_EQ(findInSet("", ""), 1);
+  EXPECT_EQ(findInSet("", "123"), 0);
+  EXPECT_EQ(findInSet("123", ""), 0);
+  EXPECT_EQ(findInSet("", "123,"), 2);
+  EXPECT_EQ(findInSet("", ",123"), 1);
+  EXPECT_EQ(findInSet("dfg", std::nullopt), std::nullopt);
+  EXPECT_EQ(findInSet(std::nullopt, "abc"), std::nullopt);
+  EXPECT_EQ(findInSet(std::nullopt, std::nullopt), std::nullopt);
+  EXPECT_EQ(findInSet("\u0061\u0062", "abc,b,ab,c,def"), 3);
+  EXPECT_EQ(findInSet("\u0063", "abc,b,ab,c,def"), 4);
+  EXPECT_EQ(findInSet("", "\u002c\u0031\u0032\u0033"), 1);
+  EXPECT_EQ(findInSet("123", "\u002c\u0031\u0032\u0033"), 2);
+  EXPECT_EQ(findInSet("😊", "🌍,😊"), 2);
+  EXPECT_EQ(findInSet("😊", "😊,123"), 1);
+  EXPECT_EQ(findInSet("abåæçè", ",abåæçè"), 2);
+  EXPECT_EQ(findInSet("abåæçè", "abåæçè,"), 1);
+  EXPECT_EQ(findInSet("\u0061\u0062\u00e5\u00e6\u00e7\u00e8", ",abåæçè"), 2);
+  EXPECT_EQ(
+      findInSet("abåæçè", "\u002c\u0061\u0062\u00e5\u00e6\u00e7\u00e8"), 2);
 }
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
Returns 1-based index of the given string in the comma-delimited list.
Returns 0, if the string was not found or if the given string contains a comma. 

Examples:

```
SELECT find_in_set('ab','abc,b,ab,c,def'); -- 3
SELECT find_in_set(NULL,'abc,b,ab,c,def'); -- NULL
SELECT find_in_set('abcdef','abc,b,ab,c,def'); -- 0
```

Spark documentation: https://spark.apache.org/docs/latest/api/sql/index.html#find_in_set