### PR TITLE
test alternative plans in WindowFuzzer

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1273,6 +1273,9 @@ void addWindowFunction(
     std::stringstream& stream,
     const WindowNode::Function& windowFunction) {
   stream << windowFunction.functionCall->toString() << " ";
+  if (windowFunction.ignoreNulls) {
+    stream << "IGNORE NULLS ";
+  }
   auto frame = windowFunction.frame;
   if (frame.startType == WindowNode::BoundType::kUnboundedFollowing) {
     VELOX_USER_FAIL("Window frame start cannot be UNBOUNDED FOLLOWING");

--- a/velox/exec/fuzzer/AggregationFuzzerBase.cpp
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.cpp
@@ -601,7 +601,8 @@ std::string makeFunctionCall(
     const std::string& name,
     const std::vector<std::string>& argNames,
     bool sortedInputs,
-    bool distinctInputs) {
+    bool distinctInputs,
+    bool ignoreNulls) {
   std::ostringstream call;
   call << name << "(";
 
@@ -612,6 +613,9 @@ std::string makeFunctionCall(
     call << "distinct " << args;
   } else {
     call << args;
+  }
+  if (ignoreNulls) {
+    call << " IGNORE NULLS";
   }
   call << ")";
 

--- a/velox/exec/fuzzer/AggregationFuzzerBase.h
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.h
@@ -296,7 +296,8 @@ std::string makeFunctionCall(
     const std::string& name,
     const std::vector<std::string>& argNames,
     bool sortedInputs = false,
-    bool distinctInputs = false);
+    bool distinctInputs = false,
+    bool ignoreNulls = false);
 
 // Returns a list of column names from c0 to cn.
 std::vector<std::string> makeNames(size_t n);

--- a/velox/exec/fuzzer/CMakeLists.txt
+++ b/velox/exec/fuzzer/CMakeLists.txt
@@ -55,4 +55,5 @@ target_link_libraries(
   velox_vector_fuzzer
   velox_exec_test_lib
   velox_expression_test_utility
-  velox_aggregation_fuzzer_base)
+  velox_aggregation_fuzzer_base
+  velox_temp_path)

--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -288,6 +288,19 @@ std::string toAggregateCallSql(
   return sql.str();
 }
 
+std::string toWindowCallSql(
+    const core::CallTypedExprPtr& call,
+    bool ignoreNulls = false) {
+  std::stringstream sql;
+  sql << call->name() << "(";
+  toCallInputsSql(call->inputs(), sql);
+  sql << ")";
+  if (ignoreNulls) {
+    sql << " IGNORE NULLS";
+  }
+  return sql.str();
+}
+
 bool isSupportedDwrfType(const TypePtr& type) {
   if (type->isDate() || type->isIntervalDayTime() || type->isUnKnown()) {
     return false;
@@ -454,7 +467,7 @@ std::optional<std::string> PrestoQueryRunner::toSql(
   const auto& functions = windowNode->windowFunctions();
   for (auto i = 0; i < functions.size(); ++i) {
     appendComma(i, sql);
-    sql << toCallSql(functions[i].functionCall);
+    sql << toWindowCallSql(functions[i].functionCall, functions[i].ignoreNulls);
 
     sql << " OVER (";
 

--- a/velox/exec/fuzzer/WindowFuzzer.h
+++ b/velox/exec/fuzzer/WindowFuzzer.h
@@ -120,6 +120,15 @@ class WindowFuzzer : public AggregationFuzzerBase {
       bool customVerification,
       bool enableWindowVerification);
 
+  void testAlternativePlans(
+      const std::vector<std::string>& partitionKeys,
+      const std::vector<SortingKeyAndOrder>& sortingKeysAndOrders,
+      const std::string& frame,
+      const std::string& functionCall,
+      const std::vector<RowVectorPtr>& input,
+      bool customVerification,
+      const velox::test::ResultOrError& expected);
+
   const std::unordered_set<std::string> orderDependentFunctions_;
 
   struct Stats : public AggregationFuzzerBase::Stats {


### PR DESCRIPTION
Summary:
Allow window fuzzer to test the following alternative plans and ensure their results are the same with the basic plan `values(input).window(...)`.
* values(input).orderBy(allKeys, false).streamingWindow(...)
* tableScan(inputRowType).localPartition(partitionKeys).window(...)
* tableScan(inputRowType).orderBy(allKeys, false).streamingWindow(...)

Also, this diff allows fuzzer to specify IGNORE NULLS in window function calls with 50% chance.

This is part of https://github.com/facebookincubator/velox/issues/7754.

Differential Revision: D52720371


