### PR TITLE
Add custom input generator for lead, lag, nth_value, and ntile in WindowFuzzerTest

### DIFF
--- a/velox/functions/prestosql/fuzzer/CMakeLists.txt
+++ b/velox/functions/prestosql/fuzzer/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(
   velox_window
   velox_expression_test_utility
   velox_functions_prestosql
+  velox_vector_test_lib
   gtest
   gtest_main)
 

--- a/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
@@ -25,6 +25,7 @@
 #include "velox/functions/prestosql/fuzzer/ApproxDistinctResultVerifier.h"
 #include "velox/functions/prestosql/fuzzer/ApproxPercentileInputGenerator.h"
 #include "velox/functions/prestosql/fuzzer/MinMaxInputGenerator.h"
+#include "velox/functions/prestosql/fuzzer/WindowOffsetInputGenerator.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/functions/prestosql/window/WindowFunctionsRegistration.h"
 
@@ -67,6 +68,10 @@ getCustomInputGenerators() {
       {"approx_distinct", std::make_shared<ApproxDistinctInputGenerator>()},
       {"approx_set", std::make_shared<ApproxDistinctInputGenerator>()},
       {"approx_percentile", std::make_shared<ApproxPercentileInputGenerator>()},
+      {"lead", std::make_shared<WindowOffsetInputGenerator>(1)},
+      {"lag", std::make_shared<WindowOffsetInputGenerator>(1)},
+      {"nth_value", std::make_shared<WindowOffsetInputGenerator>(1)},
+      {"ntile", std::make_shared<WindowOffsetInputGenerator>(0)},
   };
 }
 

--- a/velox/functions/prestosql/fuzzer/WindowOffsetInputGenerator.h
+++ b/velox/functions/prestosql/fuzzer/WindowOffsetInputGenerator.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <boost/random/uniform_int_distribution.hpp>
+
+#include "velox/exec/fuzzer/InputGenerator.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
+
+namespace facebook::velox::exec::test {
+
+// Generates an integer 1, 2, 3, or 9'000'000'000 as the argument at
+// argumentIndex for functions.
+class WindowOffsetInputGenerator : public InputGenerator {
+ public:
+  explicit WindowOffsetInputGenerator(int64_t argumentIndex)
+      : argumentIndex_{argumentIndex} {}
+
+  std::vector<VectorPtr> generate(
+      const std::vector<TypePtr>& types,
+      VectorFuzzer& fuzzer,
+      FuzzerGenerator& /*rng*/,
+      memory::MemoryPool* pool) override {
+    if (types.size() <= argumentIndex_) {
+      return {};
+    }
+
+    const auto size = fuzzer.getOptions().vectorSize;
+
+    std::vector<VectorPtr> inputs;
+    inputs.reserve(argumentIndex_ + 1);
+    for (auto i = 0; i < argumentIndex_; ++i) {
+      inputs.push_back(fuzzer.fuzz(types[i]));
+    }
+
+    facebook::velox::test::VectorMaker vectorMaker{pool};
+    auto baseN = vectorMaker.flatVector<int64_t>({1, 2, 3, 9'000'000'000});
+    inputs.push_back(fuzzer.fuzzDictionary(baseN, size));
+
+    return inputs;
+  }
+
+  void reset() override {}
+
+ private:
+  const int64_t argumentIndex_;
+};
+
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary:
Add custom input generator for the argument `n` in lead, lag, nth_value, and ntile functions. The input generator generates 1, 2, 3, or a large number 9'000'000'000 for `n`.

This is part of https://github.com/facebookincubator/velox/issues/7754.

Differential Revision: D52720432


