### PR TITLE
Skip CastExpr evaluation if input context contains errors

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -743,22 +743,30 @@ void CastExpr::apply(
     const TypePtr& fromType,
     const TypePtr& toType,
     VectorPtr& result) {
-  LocalDecodedVector decoded(context, *input, rows);
+  LocalSelectivityVector remainingRows(*context.execCtx(), rows.end());
+  *remainingRows = rows;
+  context.deselectErrors(*remainingRows);
+
+  LocalDecodedVector decoded(context, *input, *remainingRows);
   auto* rawNulls = decoded->nulls();
 
-  LocalSelectivityVector nonNullRows(*context.execCtx(), rows.end());
-  *nonNullRows = rows;
   if (rawNulls) {
-    nonNullRows->deselectNulls(rawNulls, rows.begin(), rows.end());
+    remainingRows->deselectNulls(
+        rawNulls, remainingRows->begin(), remainingRows->end());
   }
 
   VectorPtr localResult;
-  if (!nonNullRows->hasSelections()) {
+  if (!remainingRows->hasSelections()) {
     localResult =
         BaseVector::createNullConstant(toType, rows.end(), context.pool());
   } else if (decoded->isIdentityMapping()) {
     applyPeeled(
-        *nonNullRows, *decoded->base(), context, fromType, toType, localResult);
+        *remainingRows,
+        *decoded->base(),
+        context,
+        fromType,
+        toType,
+        localResult);
   } else {
     withContextSaver([&](ContextSaver& saver) {
       LocalSelectivityVector newRowsHolder(*context.execCtx());
@@ -766,32 +774,32 @@ void CastExpr::apply(
       LocalDecodedVector localDecoded(context);
       std::vector<VectorPtr> peeledVectors;
       auto peeledEncoding = PeeledEncoding::peel(
-          {input}, *nonNullRows, localDecoded, true, peeledVectors);
+          {input}, *remainingRows, localDecoded, true, peeledVectors);
       VELOX_CHECK_EQ(peeledVectors.size(), 1);
       if (peeledVectors[0]->isLazy()) {
         peeledVectors[0] =
             peeledVectors[0]->as<LazyVector>()->loadedVectorShared();
       }
       auto newRows =
-          peeledEncoding->translateToInnerRows(*nonNullRows, newRowsHolder);
+          peeledEncoding->translateToInnerRows(*remainingRows, newRowsHolder);
       // Save context and set the peel.
-      context.saveAndReset(saver, *nonNullRows);
+      context.saveAndReset(saver, *remainingRows);
       context.setPeeledEncoding(peeledEncoding);
       applyPeeled(
           *newRows, *peeledVectors[0], context, fromType, toType, localResult);
 
       localResult = context.getPeeledEncoding()->wrap(
-          toType, context.pool(), localResult, *nonNullRows);
+          toType, context.pool(), localResult, *remainingRows);
     });
   }
-  context.moveOrCopyResult(localResult, *nonNullRows, result);
+  context.moveOrCopyResult(localResult, *remainingRows, result);
   context.releaseVector(localResult);
 
   // If there are nulls in input, add nulls to the result at the same rows.
   VELOX_CHECK_NOT_NULL(result);
-  if (rawNulls) {
+  if (rawNulls || context.errors()) {
     EvalCtx::addNulls(
-        rows, nonNullRows->asRange().bits(), context, toType, result);
+        rows, remainingRows->asRange().bits(), context, toType, result);
   }
 }
 

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -743,8 +743,8 @@ void CastExpr::apply(
     const TypePtr& fromType,
     const TypePtr& toType,
     VectorPtr& result) {
-  LocalSelectivityVector remainingRows(*context.execCtx(), rows.end());
-  *remainingRows = rows;
+  LocalSelectivityVector remainingRows(context, rows);
+
   context.deselectErrors(*remainingRows);
 
   LocalDecodedVector decoded(context, *input, *remainingRows);
@@ -795,7 +795,8 @@ void CastExpr::apply(
   context.moveOrCopyResult(localResult, *remainingRows, result);
   context.releaseVector(localResult);
 
-  // If there are nulls in input, add nulls to the result at the same rows.
+  // If there are nulls or rows that encountered errors in the input, add nulls
+  // to the result at the same rows.
   VELOX_CHECK_NOT_NULL(result);
   if (rawNulls || context.errors()) {
     EvalCtx::addNulls(

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -140,7 +140,7 @@ class EvalCtx {
       ErrorVectorPtr& topLevelErrors);
 
   // Given a mapping from element rows to top-level rows, set errors in
-  // in the elements as nulls int the top level row.
+  // the elements as nulls in the top level row.
   void convertElementErrorsToTopLevelNulls(
       const SelectivityVector& elementRows,
       const BufferPtr& elementToTopLevelRows,

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -20,6 +20,8 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/expression/VectorFunction.h"
+#include "velox/functions/Macros.h"
+#include "velox/functions/Registerer.h"
 #include "velox/functions/prestosql/tests/CastBaseTest.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/type/Type.h"
@@ -29,6 +31,20 @@
 using namespace facebook::velox;
 namespace facebook::velox::test {
 namespace {
+template <typename TExecParams>
+struct ErrorOnOddFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExecParams);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<UnknownValue> /*out*/,
+      const int32_t input) {
+    // Function will always throw an error on odd input.
+    if (input % 2 != 0) {
+      VELOX_USER_FAIL("ErrorOnOdd Function: {}", input);
+    }
+  }
+};
+
 class CastExprTest : public functions::test::CastBaseTest {
  protected:
   CastExprTest() {
@@ -36,6 +52,8 @@ class CastExprTest : public functions::test::CastBaseTest {
         "testing_dictionary",
         TestingDictionaryFunction::signatures(),
         std::make_unique<TestingDictionaryFunction>());
+    registerFunction<ErrorOnOddFunction, UnknownValue, int32_t>(
+        {"error_on_odd"});
   }
 
   void setLegacyCast(bool value) {
@@ -2293,5 +2311,41 @@ TEST_F(CastExprTest, identicalTypes) {
   ASSERT_EQ(result.get(), data->childAt(0).get());
 }
 
+TEST_F(CastExprTest, skipCastEvaluation) {
+  // Inputs to error_on_odd are even, odd.
+  // Input to cast is an UNKNOWN vector which is not supported.
+  {
+    auto data = makeRowVector({
+        makeFlatVector<int>(10, [&](auto row) { return row; }),
+    });
+
+    VELOX_ASSERT_THROW(
+        evaluate("try(cast(error_on_odd(c0) as INTEGER))", data),
+        "not a scalar type! kind: UNKNOWN");
+  }
+
+  // All inputs to error_on_odd are odd.
+  // All inputs to cast are errors, we skip evaluation.
+  {
+    auto data = makeRowVector({
+        makeFlatVector<int>(10, [&](auto row) { return row * 2 + 1; }),
+    });
+
+    auto result = evaluate("try(cast(error_on_odd(c0) as INTEGER))", data);
+    ASSERT_EQ(BaseVector::countNulls(result->nulls(), result->size()), 10);
+  }
+
+  // The result vector can shrink since we remove the error rows.
+  // Check input to cast when the last row is an error.
+  {
+    auto data = makeRowVector({
+        makeFlatVector<int64_t>({1, 2, 3, 0}),
+    });
+    auto result = evaluate("try(cast((c0 / c0) as VARCHAR))", data);
+    auto expected =
+        makeNullableFlatVector<StringView>({"1", "1", "1", std::nullopt});
+    assertEqualVectors(result, expected);
+  }
+}
 } // namespace
 } // namespace facebook::velox::test


### PR DESCRIPTION
The CastExpr always retains the input errors under a try context. 
We skip evaluation if some of the input rows are errors.