### PR TITLE
fix Datafiles.h whitespace error

### DIFF
--- a/velox/dwio/common/tests/utils/DataFiles.h
+++ b/velox/dwio/common/tests/utils/DataFiles.h
@@ -22,5 +22,4 @@ namespace facebook::velox::test {
 std::string getDataFilePath(
     const std::string& baseDir,
     const std::string& filePath);
-
 }


### PR DESCRIPTION
Summary:
Metamate justifying all this impact:

**This diff fixes a whitespace error in the DataFiles.h file in the velox project. The code change involves removing an extra line of whitespace that was causing a formatting issue. The changes were made in the fbcode/velox/dwio/common/tests/utils/DataFiles.h file.**

Reviewed By: marxhxxx

Differential Revision: D52241701


