### PR TITLE
Add support for tinyint/smallint inputs for date_add/sub Spark functions

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -25,9 +25,10 @@ These functions support TIMESTAMP and DATE input types.
 
 .. spark:function:: date_add(start_date, num_days) -> date
 
-    Returns the date that is num_days after start_date.
-    If num_days is a negative value then these amount of days will be
+    Returns the date that is ``num_days`` after ``start_date``.
+    If ``num_days`` is a negative value then these amount of days will be
     deducted from start_date.
+    Supported types for ``num_days`` are: TINYINT, SMALLINT, INTEGER.
 
 .. spark:function:: datediff(endDate, startDate) -> integer
 
@@ -39,12 +40,13 @@ These functions support TIMESTAMP and DATE input types.
 
 .. spark:function:: date_sub(start_date, num_days) -> date
 
-    Returns the date that is num_days before start_date. According to the inputs,
+    Returns the date that is ``num_days`` before ``start_date``. According to the inputs,
     the returned date will wrap around between the minimum negative date and
     maximum positive date. date_sub('1969-12-31', -2147483648) get 5881580-07-11,
     and date_sub('2023-07-10', -2147483648) get -5877588-12-29.
 
-    num_days can be positive or negative.
+    ``num_days`` can be positive or negative.
+    Supported types for ``num_days`` are: TINYINT, SMALLINT, INTEGER.
 
 .. spark:function:: dayofmonth(date) -> integer
 

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -25,9 +25,13 @@ These functions support TIMESTAMP and DATE input types.
 
 .. spark:function:: date_add(start_date, num_days) -> date
 
-    Returns the date that is ``num_days`` after ``start_date``.
+    Returns the date that is ``num_days`` after ``start_date``. According to the inputs,
+    the returned date will wrap around between the minimum negative date and
+    maximum positive date. date_add('1969-12-31', 2147483647) get 5881580-07-10,
+    and date_add('2024-01-22', 2147483647) get -5877587-07-12.
+
     If ``num_days`` is a negative value then these amount of days will be
-    deducted from start_date.
+    deducted from ``start_date``.
     Supported types for ``num_days`` are: TINYINT, SMALLINT, INTEGER.
 
 .. spark:function:: datediff(endDate, startDate) -> integer

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -323,7 +323,7 @@ struct DateAddFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE void
   call(out_type<Date>& result, const arg_type<Date>& date, const TInput value) {
-    result = addToDate(date, DateTimeUnit::kDay, static_cast<int32_t>(value));
+    result = addToDate(date, DateTimeUnit::kDay, value);
   }
 };
 

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -321,8 +321,10 @@ struct DateAddFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   template <typename TInput>
-  FOLLY_ALWAYS_INLINE void
-  call(out_type<Date>& result, const arg_type<Date>& date, const TInput value) {
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Date>& result,
+      const arg_type<Date>& date,
+      const TInput& value) {
     __builtin_add_overflow(date, value, &result);
   }
 };
@@ -332,8 +334,10 @@ struct DateSubFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   template <typename TInput>
-  FOLLY_ALWAYS_INLINE void
-  call(out_type<Date>& result, const arg_type<Date>& date, const TInput value) {
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Date>& result,
+      const arg_type<Date>& date,
+      const TInput& value) {
     __builtin_sub_overflow(date, value, &result);
   }
 };

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -323,7 +323,7 @@ struct DateAddFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE void
   call(out_type<Date>& result, const arg_type<Date>& date, const TInput value) {
-    result = addToDate(date, DateTimeUnit::kDay, value);
+    __builtin_add_overflow(date, value, &result);
   }
 };
 
@@ -334,17 +334,7 @@ struct DateSubFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE void
   call(out_type<Date>& result, const arg_type<Date>& date, const TInput value) {
-    constexpr int32_t kMin = std::numeric_limits<int32_t>::min();
-    if (value > kMin) {
-      int32_t subValue = 0 - value;
-      result = addToDate(date, DateTimeUnit::kDay, subValue);
-    } else {
-      // If input values is kMin,  0 - value overflows.
-      // Subtract kMin in 2 steps to avoid overflow: -(-(kMin+1)), then -1.
-      int32_t subValue = 0 - (kMin + 1);
-      result = addToDate(date, DateTimeUnit::kDay, subValue);
-      result = addToDate(result, DateTimeUnit::kDay, 1);
-    }
+    __builtin_sub_overflow(date, value, &result);
   }
 };
 

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -320,11 +320,10 @@ template <typename T>
 struct DateAddFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE void call(
-      out_type<Date>& result,
-      const arg_type<Date>& date,
-      const int32_t value) {
-    result = addToDate(date, DateTimeUnit::kDay, value);
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE void
+  call(out_type<Date>& result, const arg_type<Date>& date, const TInput value) {
+    result = addToDate(date, DateTimeUnit::kDay, static_cast<int32_t>(value));
   }
 };
 
@@ -332,10 +331,9 @@ template <typename T>
 struct DateSubFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE void call(
-      out_type<Date>& result,
-      const arg_type<Date>& date,
-      const int32_t value) {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE void
+  call(out_type<Date>& result, const arg_type<Date>& date, const TInput value) {
     constexpr int32_t kMin = std::numeric_limits<int32_t>::min();
     if (value > kMin) {
       int32_t subValue = 0 - value;

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -277,12 +277,13 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<AddMonthsFunction, Date, Date, int32_t>(
       {prefix + "add_months"});
 
-  registerFunction<DateAddFunction, Date, Date, int32_t>({prefix + "date_add"});
-  registerFunction<DateAddFunction, Date, Date, int16_t>({prefix + "date_add"});
   registerFunction<DateAddFunction, Date, Date, int8_t>({prefix + "date_add"});
-  registerFunction<DateSubFunction, Date, Date, int32_t>({prefix + "date_sub"});
-  registerFunction<DateSubFunction, Date, Date, int16_t>({prefix + "date_sub"});
+  registerFunction<DateAddFunction, Date, Date, int16_t>({prefix + "date_add"});
+  registerFunction<DateAddFunction, Date, Date, int32_t>({prefix + "date_add"});
+
   registerFunction<DateSubFunction, Date, Date, int8_t>({prefix + "date_sub"});
+  registerFunction<DateSubFunction, Date, Date, int16_t>({prefix + "date_sub"});
+  registerFunction<DateSubFunction, Date, Date, int32_t>({prefix + "date_sub"});
 
   registerFunction<DayFunction, int32_t, Date>(
       {prefix + "day", prefix + "dayofmonth"});

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -278,7 +278,11 @@ void registerFunctions(const std::string& prefix) {
       {prefix + "add_months"});
 
   registerFunction<DateAddFunction, Date, Date, int32_t>({prefix + "date_add"});
+  registerFunction<DateAddFunction, Date, Date, int16_t>({prefix + "date_add"});
+  registerFunction<DateAddFunction, Date, Date, int8_t>({prefix + "date_add"});
   registerFunction<DateSubFunction, Date, Date, int32_t>({prefix + "date_sub"});
+  registerFunction<DateSubFunction, Date, Date, int16_t>({prefix + "date_sub"});
+  registerFunction<DateSubFunction, Date, Date, int8_t>({prefix + "date_sub"});
 
   registerFunction<DayFunction, int32_t, Date>(
       {prefix + "day", prefix + "dayofmonth"});

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -266,11 +266,13 @@ TEST_F(DateTimeFunctionsTest, dateAdd) {
 
 TEST_F(DateTimeFunctionsTest, dateAddSmallint) {
   const auto dateAdd = [&](std::optional<int32_t> date,
-                           std::optional<int32_t> value) {
-    return evaluateOnce<int32_t, int32_t>(
-        "date_add(c0, cast(c1 as smallint))",
-        {date, value},
-        {DATE(), INTEGER()});
+                           std::optional<int16_t> value) {
+    auto rowVectorPtr = makeRowVector(
+        {makeNullableFlatVector(
+             std::vector<std::optional<int32_t>>{date}, DATE()),
+         makeNullableFlatVector(
+             std::vector<std::optional<int16_t>>{value}, SMALLINT())});
+    return evaluateOnce<int32_t>("date_add(c0, c1)", rowVectorPtr);
   };
 
   // Check null behaviors
@@ -299,11 +301,13 @@ TEST_F(DateTimeFunctionsTest, dateAddSmallint) {
 
 TEST_F(DateTimeFunctionsTest, dateAddTinyint) {
   const auto dateAdd = [&](std::optional<int32_t> date,
-                           std::optional<int32_t> value) {
-    return evaluateOnce<int32_t, int32_t>(
-        "date_add(c0, cast(c1 as tinyint))",
-        {date, value},
-        {DATE(), INTEGER()});
+                           std::optional<int8_t> value) {
+    auto rowVectorPtr = makeRowVector(
+        {makeNullableFlatVector(
+             std::vector<std::optional<int32_t>>{date}, DATE()),
+         makeNullableFlatVector(
+             std::vector<std::optional<int8_t>>{value}, TINYINT())});
+    return evaluateOnce<int32_t>("date_add(c0, c1)", rowVectorPtr);
   };
 
   // Check null behaviors
@@ -353,15 +357,17 @@ TEST_F(DateTimeFunctionsTest, dateSub) {
 
 TEST_F(DateTimeFunctionsTest, dateSubSmallint) {
   const auto dateSubFunc = [&](std::optional<int32_t> date,
-                               std::optional<int32_t> value) {
-    return evaluateOnce<int32_t, int32_t>(
-        "date_sub(c0, cast(c1 as smallint))",
-        {date, value},
-        {DATE(), INTEGER()});
+                               std::optional<int16_t> value) {
+    auto rowVectorPtr = makeRowVector(
+        {makeNullableFlatVector(
+             std::vector<std::optional<int32_t>>{date}, DATE()),
+         makeNullableFlatVector(
+             std::vector<std::optional<int16_t>>{value}, SMALLINT())});
+    return evaluateOnce<int32_t>("date_sub(c0, c1)", rowVectorPtr);
   };
 
   const auto dateSub = [&](const std::string& dateStr,
-                           std::optional<int32_t> value) {
+                           std::optional<int16_t> value) {
     return dateSubFunc(parseDate(dateStr), value);
   };
 
@@ -381,15 +387,17 @@ TEST_F(DateTimeFunctionsTest, dateSubSmallint) {
 
 TEST_F(DateTimeFunctionsTest, dateSubTinyint) {
   const auto dateSubFunc = [&](std::optional<int32_t> date,
-                               std::optional<int32_t> value) {
-    return evaluateOnce<int32_t, int32_t>(
-        "date_sub(c0, cast(c1 as tinyint))",
-        {date, value},
-        {DATE(), INTEGER()});
+                               std::optional<int8_t> value) {
+    auto rowVectorPtr = makeRowVector(
+        {makeNullableFlatVector(
+             std::vector<std::optional<int32_t>>{date}, DATE()),
+         makeNullableFlatVector(
+             std::vector<std::optional<int8_t>>{value}, TINYINT())});
+    return evaluateOnce<int32_t>("date_sub(c0, c1)", rowVectorPtr);
   };
 
   const auto dateSub = [&](const std::string& dateStr,
-                           std::optional<int32_t> value) {
+                           std::optional<int8_t> value) {
     return dateSubFunc(parseDate(dateStr), value);
   };
 

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -270,6 +270,8 @@ TEST_F(DateTimeFunctionsTest, dateAdd) {
   EXPECT_EQ(parseDate("-5877641-06-23"), dateAdd("1970-01-01", kMin));
   EXPECT_EQ(parseDate("1969-12-31"), dateAdd("5881580-07-11", kMin));
   EXPECT_EQ(parseDate("5881580-07-10"), dateAdd("1969-12-31", kMax));
+
+  EXPECT_EQ(parseDate("-5877587-07-11"), dateAdd("2024-01-22", kMax - 1));
   EXPECT_EQ(parseDate("-5877587-07-12"), dateAdd("2024-01-22", kMax));
 }
 
@@ -295,6 +297,8 @@ TEST_F(DateTimeFunctionsTest, dateAddSmallint) {
   // Check for minimum and maximum tests.
   EXPECT_EQ(parseDate("2059-09-17"), dateAdd("1969-12-31", kMaxSmallint));
   EXPECT_EQ(parseDate("1880-04-13"), dateAdd("1969-12-31", kMinSmallint));
+
+  EXPECT_EQ(parseDate("2113-10-09"), dateAdd("2024-01-22", kMaxSmallint));
 }
 
 TEST_F(DateTimeFunctionsTest, dateAddTinyint) {
@@ -310,6 +314,8 @@ TEST_F(DateTimeFunctionsTest, dateAddTinyint) {
   EXPECT_EQ(parseDate("1970-05-07"), dateAdd("1969-12-31", kMaxTinyint));
 
   EXPECT_EQ(parseDate("1969-08-25"), dateAdd("1969-12-31", kMinTinyint));
+
+  EXPECT_EQ(parseDate("2024-05-28"), dateAdd("2024-01-22", kMaxTinyint));
 }
 
 TEST_F(DateTimeFunctionsTest, dateSub) {
@@ -334,6 +340,8 @@ TEST_F(DateTimeFunctionsTest, dateSub) {
   EXPECT_EQ(parseDate("1970-01-01"), dateSub("5881580-07-11", kMax));
   EXPECT_EQ(parseDate("1970-01-01"), dateSub("-5877641-06-23", kMin));
   EXPECT_EQ(parseDate("5881580-07-11"), dateSub("1969-12-31", kMin));
+
+  EXPECT_EQ(parseDate("-5877588-12-28"), dateSub("2023-07-10", kMin + 1));
   EXPECT_EQ(parseDate("-5877588-12-29"), dateSub("2023-07-10", kMin));
 }
 
@@ -356,6 +364,8 @@ TEST_F(DateTimeFunctionsTest, dateSubSmallint) {
 
   EXPECT_EQ(parseDate("1880-04-15"), dateSub("1970-01-01", kMaxSmallint));
   EXPECT_EQ(parseDate("2059-09-19"), dateSub("1970-01-01", kMinSmallint));
+
+  EXPECT_EQ(parseDate("2113-03-28"), dateSub("2023-07-10", kMinSmallint));
 }
 
 TEST_F(DateTimeFunctionsTest, dateSubTinyint) {
@@ -371,6 +381,8 @@ TEST_F(DateTimeFunctionsTest, dateSubTinyint) {
 
   EXPECT_EQ(parseDate("1969-08-27"), dateSub("1970-01-01", kMaxTinyint));
   EXPECT_EQ(parseDate("1970-05-09"), dateSub("1970-01-01", kMinTinyint));
+
+  EXPECT_EQ(parseDate("2023-11-15"), dateSub("2023-07-10", kMinTinyint));
 }
 
 TEST_F(DateTimeFunctionsTest, dayOfYear) {

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -246,90 +246,70 @@ TEST_F(DateTimeFunctionsTest, lastDay) {
 }
 
 TEST_F(DateTimeFunctionsTest, dateAdd) {
-  const auto dateAdd = [&](std::optional<int32_t> date,
+  const auto dateAdd = [&](const std::string& dateStr,
                            std::optional<int32_t> value) {
     return evaluateDateFuncOnce<int32_t, int32_t>(
-        "date_add(c0, c1)", date, value);
+        "date_add(c0, c1)", parseDate(dateStr), value);
   };
 
-  // Check null behaviors
-  EXPECT_EQ(std::nullopt, dateAdd(std::nullopt, 1));
-  EXPECT_EQ(std::nullopt, dateAdd(parseDate("2019-02-28"), std::nullopt));
-  EXPECT_EQ(std::nullopt, dateAdd(std::nullopt, std::nullopt));
-
   // Check simple tests.
-  EXPECT_EQ(parseDate("2019-03-01"), dateAdd(parseDate("2019-03-01"), 0));
-  EXPECT_EQ(parseDate("2019-03-01"), dateAdd(parseDate("2019-02-28"), 1));
+  EXPECT_EQ(parseDate("2019-03-01"), dateAdd("2019-03-01", 0));
+  EXPECT_EQ(parseDate("2019-03-01"), dateAdd("2019-02-28", 1));
 
   // Account for the last day of a year-month
-  EXPECT_EQ(parseDate("2020-02-29"), dateAdd(parseDate("2019-01-30"), 395));
-  EXPECT_EQ(parseDate("2020-02-29"), dateAdd(parseDate("2019-01-30"), 395));
+  EXPECT_EQ(parseDate("2020-02-29"), dateAdd("2019-01-30", 395));
+  EXPECT_EQ(parseDate("2020-02-29"), dateAdd("2019-01-30", 395));
 
   // Check for negative intervals
-  EXPECT_EQ(parseDate("2019-02-28"), dateAdd(parseDate("2020-02-29"), -366));
-  EXPECT_EQ(parseDate("2019-02-28"), dateAdd(parseDate("2020-02-29"), -366));
+  EXPECT_EQ(parseDate("2019-02-28"), dateAdd("2020-02-29", -366));
+  EXPECT_EQ(parseDate("2019-02-28"), dateAdd("2020-02-29", -366));
 
   // Check for minimum and maximum tests.
-  EXPECT_EQ(parseDate("5881580-07-11"), dateAdd(parseDate("1970-01-01"), kMax));
-  EXPECT_EQ(
-      parseDate("1969-12-31"), dateAdd(parseDate("-5877641-06-23"), kMax));
-  EXPECT_EQ(
-      parseDate("-5877641-06-23"), dateAdd(parseDate("1970-01-01"), kMin));
-  EXPECT_EQ(parseDate("1969-12-31"), dateAdd(parseDate("5881580-07-11"), kMin));
+  EXPECT_EQ(parseDate("5881580-07-11"), dateAdd("1970-01-01", kMax));
+  EXPECT_EQ(parseDate("1969-12-31"), dateAdd("-5877641-06-23", kMax));
+  EXPECT_EQ(parseDate("-5877641-06-23"), dateAdd("1970-01-01", kMin));
+  EXPECT_EQ(parseDate("1969-12-31"), dateAdd("5881580-07-11", kMin));
+  EXPECT_EQ(parseDate("5881580-07-10"), dateAdd("1969-12-31", kMax));
+  EXPECT_EQ(parseDate("-5877587-07-12"), dateAdd("2024-01-22", kMax));
 }
 
 TEST_F(DateTimeFunctionsTest, dateAddSmallint) {
-  const auto dateAdd = [&](std::optional<int32_t> date,
+  const auto dateAdd = [&](const std::string& dateStr,
                            std::optional<int16_t> value) {
     return evaluateDateFuncOnce<int32_t, int16_t>(
-        "date_add(c0, c1)", date, value);
+        "date_add(c0, c1)", parseDate(dateStr), value);
   };
 
-  // Check null behaviors
-  EXPECT_EQ(std::nullopt, dateAdd(std::nullopt, 1));
-  EXPECT_EQ(std::nullopt, dateAdd(parseDate("2019-02-28"), std::nullopt));
-  EXPECT_EQ(std::nullopt, dateAdd(std::nullopt, std::nullopt));
-
   // Check simple tests.
-  EXPECT_EQ(parseDate("2019-03-01"), dateAdd(parseDate("2019-03-01"), 0));
-  EXPECT_EQ(parseDate("2019-03-01"), dateAdd(parseDate("2019-02-28"), 1));
+  EXPECT_EQ(parseDate("2019-03-01"), dateAdd("2019-03-01", 0));
+  EXPECT_EQ(parseDate("2019-03-01"), dateAdd("2019-02-28", 1));
 
   // Account for the last day of a year-month
-  EXPECT_EQ(parseDate("2020-02-29"), dateAdd(parseDate("2019-01-30"), 395));
-  EXPECT_EQ(parseDate("2020-02-29"), dateAdd(parseDate("2019-01-30"), 395));
+  EXPECT_EQ(parseDate("2020-02-29"), dateAdd("2019-01-30", 395));
+  EXPECT_EQ(parseDate("2020-02-29"), dateAdd("2019-01-30", 395));
 
   // Check for negative intervals
-  EXPECT_EQ(parseDate("2019-02-28"), dateAdd(parseDate("2020-02-29"), -366));
-  EXPECT_EQ(parseDate("2019-02-28"), dateAdd(parseDate("2020-02-29"), -366));
+  EXPECT_EQ(parseDate("2019-02-28"), dateAdd("2020-02-29", -366));
+  EXPECT_EQ(parseDate("2019-02-28"), dateAdd("2020-02-29", -366));
 
   // Check for minimum and maximum tests.
-  EXPECT_EQ(
-      parseDate("2059-09-17"), dateAdd(parseDate("1969-12-31"), kMaxSmallint));
-  EXPECT_EQ(
-      parseDate("1880-04-13"), dateAdd(parseDate("1969-12-31"), kMinSmallint));
+  EXPECT_EQ(parseDate("2059-09-17"), dateAdd("1969-12-31", kMaxSmallint));
+  EXPECT_EQ(parseDate("1880-04-13"), dateAdd("1969-12-31", kMinSmallint));
 }
 
 TEST_F(DateTimeFunctionsTest, dateAddTinyint) {
-  const auto dateAdd = [&](std::optional<int32_t> date,
+  const auto dateAdd = [&](const std::string& dateStr,
                            std::optional<int8_t> value) {
     return evaluateDateFuncOnce<int32_t, int8_t>(
-        "date_add(c0, c1)", date, value);
+        "date_add(c0, c1)", parseDate(dateStr), value);
   };
-
-  // Check null behaviors
-  EXPECT_EQ(std::nullopt, dateAdd(std::nullopt, 1));
-  EXPECT_EQ(std::nullopt, dateAdd(parseDate("2019-02-28"), std::nullopt));
-  EXPECT_EQ(std::nullopt, dateAdd(std::nullopt, std::nullopt));
-
   // Check simple tests.
-  EXPECT_EQ(parseDate("2019-03-01"), dateAdd(parseDate("2019-03-01"), 0));
-  EXPECT_EQ(parseDate("2019-03-01"), dateAdd(parseDate("2019-02-28"), 1));
+  EXPECT_EQ(parseDate("2019-03-01"), dateAdd("2019-03-01", 0));
+  EXPECT_EQ(parseDate("2019-03-01"), dateAdd("2019-02-28", 1));
 
-  EXPECT_EQ(
-      parseDate("1970-05-07"), dateAdd(parseDate("1969-12-31"), kMaxTinyint));
+  EXPECT_EQ(parseDate("1970-05-07"), dateAdd("1969-12-31", kMaxTinyint));
 
-  EXPECT_EQ(
-      parseDate("1969-08-25"), dateAdd(parseDate("1969-12-31"), kMinTinyint));
+  EXPECT_EQ(parseDate("1969-08-25"), dateAdd("1969-12-31", kMinTinyint));
 }
 
 TEST_F(DateTimeFunctionsTest, dateSub) {
@@ -354,6 +334,7 @@ TEST_F(DateTimeFunctionsTest, dateSub) {
   EXPECT_EQ(parseDate("1970-01-01"), dateSub("5881580-07-11", kMax));
   EXPECT_EQ(parseDate("1970-01-01"), dateSub("-5877641-06-23", kMin));
   EXPECT_EQ(parseDate("5881580-07-11"), dateSub("1969-12-31", kMin));
+  EXPECT_EQ(parseDate("-5877588-12-29"), dateSub("2023-07-10", kMin));
 }
 
 TEST_F(DateTimeFunctionsTest, dateSubSmallint) {

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -41,6 +41,18 @@ class DateTimeFunctionsTest : public SparkFunctionBaseTest {
   int32_t parseDate(const std::string& dateStr) {
     return DATE()->toDays(dateStr);
   }
+
+  template <typename ReturnType, typename Arg>
+  std::optional<ReturnType> evaluateDateFuncOnce(
+      const std::string& expr,
+      const std::optional<int32_t>& date,
+      const std::optional<Arg>& value) {
+    auto rowVectorPtr = makeRowVector(
+        {makeNullableFlatVector(
+             std::vector<std::optional<int32_t>>{date}, DATE()),
+         makeNullableFlatVector(std::vector<std::optional<Arg>>{value})});
+    return evaluateOnce<ReturnType>(expr, rowVectorPtr);
+  }
 };
 
 TEST_F(DateTimeFunctionsTest, year) {
@@ -234,8 +246,8 @@ TEST_F(DateTimeFunctionsTest, lastDay) {
 TEST_F(DateTimeFunctionsTest, dateAdd) {
   const auto dateAdd = [&](std::optional<int32_t> date,
                            std::optional<int32_t> value) {
-    return evaluateOnce<int32_t, int32_t>(
-        "date_add(c0, c1)", {date, value}, {DATE(), INTEGER()});
+    return evaluateDateFuncOnce<int32_t, int32_t>(
+        "date_add(c0, c1)", date, value);
   };
 
   // Check null behaviors
@@ -267,12 +279,8 @@ TEST_F(DateTimeFunctionsTest, dateAdd) {
 TEST_F(DateTimeFunctionsTest, dateAddSmallint) {
   const auto dateAdd = [&](std::optional<int32_t> date,
                            std::optional<int16_t> value) {
-    auto rowVectorPtr = makeRowVector(
-        {makeNullableFlatVector(
-             std::vector<std::optional<int32_t>>{date}, DATE()),
-         makeNullableFlatVector(
-             std::vector<std::optional<int16_t>>{value}, SMALLINT())});
-    return evaluateOnce<int32_t>("date_add(c0, c1)", rowVectorPtr);
+    return evaluateDateFuncOnce<int32_t, int16_t>(
+        "date_add(c0, c1)", date, value);
   };
 
   // Check null behaviors
@@ -302,12 +310,8 @@ TEST_F(DateTimeFunctionsTest, dateAddSmallint) {
 TEST_F(DateTimeFunctionsTest, dateAddTinyint) {
   const auto dateAdd = [&](std::optional<int32_t> date,
                            std::optional<int8_t> value) {
-    auto rowVectorPtr = makeRowVector(
-        {makeNullableFlatVector(
-             std::vector<std::optional<int32_t>>{date}, DATE()),
-         makeNullableFlatVector(
-             std::vector<std::optional<int8_t>>{value}, TINYINT())});
-    return evaluateOnce<int32_t>("date_add(c0, c1)", rowVectorPtr);
+    return evaluateDateFuncOnce<int32_t, int8_t>(
+        "date_add(c0, c1)", date, value);
   };
 
   // Check null behaviors
@@ -327,15 +331,10 @@ TEST_F(DateTimeFunctionsTest, dateAddTinyint) {
 }
 
 TEST_F(DateTimeFunctionsTest, dateSub) {
-  const auto dateSubFunc = [&](std::optional<int32_t> date,
-                               std::optional<int32_t> value) {
-    return evaluateOnce<int32_t, int32_t>(
-        "date_sub(c0, c1)", {date, value}, {DATE(), INTEGER()});
-  };
-
   const auto dateSub = [&](const std::string& dateStr,
                            std::optional<int32_t> value) {
-    return dateSubFunc(parseDate(dateStr), value);
+    return evaluateDateFuncOnce<int32_t, int32_t>(
+        "date_sub(c0, c1)", parseDate(dateStr), value);
   };
 
   // Check simple tests.
@@ -356,19 +355,10 @@ TEST_F(DateTimeFunctionsTest, dateSub) {
 }
 
 TEST_F(DateTimeFunctionsTest, dateSubSmallint) {
-  const auto dateSubFunc = [&](std::optional<int32_t> date,
-                               std::optional<int16_t> value) {
-    auto rowVectorPtr = makeRowVector(
-        {makeNullableFlatVector(
-             std::vector<std::optional<int32_t>>{date}, DATE()),
-         makeNullableFlatVector(
-             std::vector<std::optional<int16_t>>{value}, SMALLINT())});
-    return evaluateOnce<int32_t>("date_sub(c0, c1)", rowVectorPtr);
-  };
-
   const auto dateSub = [&](const std::string& dateStr,
                            std::optional<int16_t> value) {
-    return dateSubFunc(parseDate(dateStr), value);
+    return evaluateDateFuncOnce<int32_t, int16_t>(
+        "date_sub(c0, c1)", parseDate(dateStr), value);
   };
 
   // Check simple tests.
@@ -386,19 +376,10 @@ TEST_F(DateTimeFunctionsTest, dateSubSmallint) {
 }
 
 TEST_F(DateTimeFunctionsTest, dateSubTinyint) {
-  const auto dateSubFunc = [&](std::optional<int32_t> date,
-                               std::optional<int8_t> value) {
-    auto rowVectorPtr = makeRowVector(
-        {makeNullableFlatVector(
-             std::vector<std::optional<int32_t>>{date}, DATE()),
-         makeNullableFlatVector(
-             std::vector<std::optional<int8_t>>{value}, TINYINT())});
-    return evaluateOnce<int32_t>("date_sub(c0, c1)", rowVectorPtr);
-  };
-
   const auto dateSub = [&](const std::string& dateStr,
                            std::optional<int8_t> value) {
-    return dateSubFunc(parseDate(dateStr), value);
+    return evaluateDateFuncOnce<int32_t, int8_t>(
+        "date_sub(c0, c1)", parseDate(dateStr), value);
   };
 
   // Check simple tests.

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -229,9 +229,10 @@ TEST_F(DateTimeFunctionsTest, lastDay) {
 
 TEST_F(DateTimeFunctionsTest, dateAdd) {
   const auto dateAdd = [&](std::optional<int32_t> date,
-                           std::optional<int32_t> value) {
+                           std::optional<int32_t> value,
+                           std::string expr = "date_add(c0, c1)") {
     return evaluateOnce<int32_t, int32_t>(
-        "date_add(c0, c1)", {date, value}, {DATE(), INTEGER()});
+        expr, {date, value}, {DATE(), INTEGER()});
   };
 
   // Check null behaviors
@@ -258,18 +259,38 @@ TEST_F(DateTimeFunctionsTest, dateAdd) {
   EXPECT_EQ(
       parseDate("-5877641-06-23"), dateAdd(parseDate("1970-01-01"), kMin));
   EXPECT_EQ(parseDate("1969-12-31"), dateAdd(parseDate("5881580-07-11"), kMin));
+
+  // Check smallint type num_days.
+  auto smallintExpr = "date_add(c0, cast(c1 as smallint))";
+  EXPECT_EQ(
+      parseDate("2019-02-28"),
+      dateAdd(parseDate("2019-03-01"), -1, smallintExpr));
+  EXPECT_EQ(
+      parseDate("2019-03-01"),
+      dateAdd(parseDate("2019-02-28"), 1, smallintExpr));
+
+  // Check tinyint type num_days.
+  auto tinyintExpr = "date_add(c0, cast(c1 as tinyint))";
+  EXPECT_EQ(
+      parseDate("2019-02-28"),
+      dateAdd(parseDate("2019-03-01"), -1, tinyintExpr));
+  EXPECT_EQ(
+      parseDate("2019-03-01"),
+      dateAdd(parseDate("2019-02-28"), 1, tinyintExpr));
 }
 
 TEST_F(DateTimeFunctionsTest, dateSub) {
   const auto dateSubFunc = [&](std::optional<int32_t> date,
-                               std::optional<int32_t> value) {
+                               std::optional<int32_t> value,
+                               std::string expr = "date_sub(c0, c1)") {
     return evaluateOnce<int32_t, int32_t>(
-        "date_sub(c0, c1)", {date, value}, {DATE(), INTEGER()});
+        expr, {date, value}, {DATE(), INTEGER()});
   };
 
   const auto dateSub = [&](const std::string& dateStr,
-                           std::optional<int32_t> value) {
-    return dateSubFunc(parseDate(dateStr), value);
+                           std::optional<int32_t> value,
+                           std::string expr = "date_sub(c0, c1)") {
+    return dateSubFunc(parseDate(dateStr), value, expr);
   };
 
   // Check simple tests.
@@ -287,6 +308,16 @@ TEST_F(DateTimeFunctionsTest, dateSub) {
   EXPECT_EQ(parseDate("1970-01-01"), dateSub("5881580-07-11", kMax));
   EXPECT_EQ(parseDate("1970-01-01"), dateSub("-5877641-06-23", kMin));
   EXPECT_EQ(parseDate("5881580-07-11"), dateSub("1969-12-31", kMin));
+
+  // Check smallint type num_days.
+  auto smallintExpr = "date_sub(c0, cast(c1 as smallint))";
+  EXPECT_EQ(parseDate("2019-02-28"), dateSub("2019-03-01", 1, smallintExpr));
+  EXPECT_EQ(parseDate("2019-03-01"), dateSub("2019-02-28", -1, smallintExpr));
+
+  // Check tinyint type num_days.
+  auto tinyintExpr = "date_sub(c0, cast(c1 as tinyint))";
+  EXPECT_EQ(parseDate("2019-02-28"), dateSub("2019-03-01", 1, tinyintExpr));
+  EXPECT_EQ(parseDate("2019-03-01"), dateSub("2019-02-28", -1, tinyintExpr));
 }
 
 TEST_F(DateTimeFunctionsTest, dayOfYear) {

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -42,16 +42,18 @@ class DateTimeFunctionsTest : public SparkFunctionBaseTest {
     return DATE()->toDays(dateStr);
   }
 
-  template <typename ReturnType, typename Arg>
-  std::optional<ReturnType> evaluateDateFuncOnce(
+  template <typename TOutput, typename TValue>
+  std::optional<TOutput> evaluateDateFuncOnce(
       const std::string& expr,
       const std::optional<int32_t>& date,
-      const std::optional<Arg>& value) {
-    auto rowVectorPtr = makeRowVector(
-        {makeNullableFlatVector(
-             std::vector<std::optional<int32_t>>{date}, DATE()),
-         makeNullableFlatVector(std::vector<std::optional<Arg>>{value})});
-    return evaluateOnce<ReturnType>(expr, rowVectorPtr);
+      const std::optional<TValue>& value) {
+    return evaluateOnce<TOutput>(
+        expr,
+        makeRowVector(
+            {makeNullableFlatVector(
+                 std::vector<std::optional<int32_t>>{date}, DATE()),
+             makeNullableFlatVector(
+                 std::vector<std::optional<TValue>>{value})}));
   }
 };
 


### PR DESCRIPTION
1. Support tinyint, smallint for `num_days` of date_add, date_sub Spark function.
2. Implement date_add and date_sub with `__builtin_add_overflow` and `__builtin_sub_overflow`.
https://github.com/apache/spark/blob/173ba2c6327ff74bab74c1660c80c0c8b43707c9/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala#L310