### PR TITLE
Fix flaky test `DecimalUtilTest.divideWithRoundUp`

### DIFF
--- a/velox/functions/sparksql/tests/DecimalUtilTest.cpp
+++ b/velox/functions/sparksql/tests/DecimalUtilTest.cpp
@@ -30,7 +30,7 @@ class DecimalUtilTest : public testing::Test {
       R expectedResult,
       bool expectedOverflow) {
     R r;
-    bool overflow;
+    bool overflow = false;
     DecimalUtil::divideWithRoundUp<R, A, B>(r, a, b, aRescale, overflow);
     ASSERT_EQ(overflow, expectedOverflow);
     ASSERT_EQ(r, expectedResult);


### PR DESCRIPTION
The variable `overflow` could be accessed without initialization, which causes 
flaky result.