### PR TITLE
Fix shadowed variable in velox/functions/prestosql/ArrayConstructor.cpp

### DIFF
--- a/velox/functions/prestosql/ArrayConstructor.cpp
+++ b/velox/functions/prestosql/ArrayConstructor.cpp
@@ -95,11 +95,11 @@ class ArrayConstructor : public exec::VectorFunction {
         for (int i = 1; i < numArgs; i++) {
           targetRows.clearAll();
 
-          vector_size_t offset = baseOffset;
+          vector_size_t offset_2 = baseOffset;
           rows.applyToSelected([&](vector_size_t row) {
-            targetRows.setValid(offset + i, true);
-            toSourceRow[offset + i] = row;
-            offset += numArgs;
+            targetRows.setValid(offset_2 + i, true);
+            toSourceRow[offset_2 + i] = row;
+            offset_2 += numArgs;
           });
 
           targetRows.updateBounds();


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dmm-fb

Differential Revision: D52582909


