### PR TITLE
Optimize CAST(timestamp as varchar)

### DIFF
--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -341,21 +341,6 @@ void CastExpr::applyCastKernel(
   try {
     auto inputRowValue = input->valueAt(row);
 
-    if constexpr (
-        FromKind == TypeKind::TIMESTAMP &&
-        (ToKind == TypeKind::VARCHAR || ToKind == TypeKind::VARBINARY)) {
-      auto writer = exec::StringWriter<>(result, row);
-      const auto& queryConfig = context.execCtx()->queryCtx()->queryConfig();
-      auto sessionTzName = queryConfig.sessionTimezone();
-      if (queryConfig.adjustTimestampToTimezone() && !sessionTzName.empty()) {
-        const auto* timeZone = date::locate_zone(sessionTzName);
-        hooks_->castTimestampToString(inputRowValue, writer, timeZone);
-      } else {
-        hooks_->castTimestampToString(inputRowValue, writer);
-      }
-      return;
-    }
-
     // Optimize empty input strings casting by avoiding throwing exceptions.
     if constexpr (
         FromKind == TypeKind::VARCHAR || FromKind == TypeKind::VARBINARY) {

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -283,6 +283,12 @@ class CastExpr : public SpecialForm {
       VectorPtr& result,
       const date::time_zone* timeZone = nullptr);
 
+  VectorPtr applyTimestampToVarcharCast(
+      const TypePtr& toType,
+      const SelectivityVector& rows,
+      exec::EvalCtx& context,
+      const BaseVector& input);
+
   bool nullOnFailure() const {
     return nullOnFailure_;
   }

--- a/velox/expression/CastHooks.h
+++ b/velox/expression/CastHooks.h
@@ -32,17 +32,14 @@ class CastHooks {
 
   virtual int32_t castStringToDate(const StringView& dateString) const = 0;
 
-  // Cast from timestamp to string and write the result to string writer.
-  virtual void castTimestampToString(
-      const Timestamp& timestamp,
-      StringWriter<false>& out,
-      const date::time_zone* timeZone = nullptr) const = 0;
-
   // Returns whether legacy cast semantics are enabled.
   virtual bool legacy() const = 0;
 
   // Trims all leading and trailing UTF8 whitespaces.
   virtual StringView removeWhiteSpaces(const StringView& view) const = 0;
+
+  // Returns the options to cast from timestamp to string.
+  virtual const TimestampToStringOptions& timestampToStringOptions() const = 0;
 
   // Returns whether to cast to int by truncate.
   virtual bool truncate() const = 0;

--- a/velox/expression/PrestoCastHooks.h
+++ b/velox/expression/PrestoCastHooks.h
@@ -24,8 +24,7 @@ namespace facebook::velox::exec {
 // This class provides cast hooks following Presto semantics.
 class PrestoCastHooks : public CastHooks {
  public:
-  explicit PrestoCastHooks(const core::QueryConfig& config)
-      : CastHooks(), legacyCast_(config.isLegacyCast()) {}
+  explicit PrestoCastHooks(const core::QueryConfig& config);
 
   // Uses the default implementation of 'castFromDateString'.
   Timestamp castStringToTimestamp(const StringView& view) const override;
@@ -33,22 +32,21 @@ class PrestoCastHooks : public CastHooks {
   // Uses standard cast mode to cast from string to date.
   int32_t castStringToDate(const StringView& dateString) const override;
 
-  // Applies different cast options according to 'isLegacyCast' config.
-  void castTimestampToString(
-      const Timestamp& timestamp,
-      StringWriter<false>& out,
-      const date::time_zone* timeZone) const override;
-
   // Follows 'isLegacyCast' config.
   bool legacy() const override;
 
   // Returns the input as is.
   StringView removeWhiteSpaces(const StringView& view) const override;
 
+  // Returns cast options following 'isLegacyCast' and session timezone.
+  const TimestampToStringOptions& timestampToStringOptions() const override;
+
   // Returns false.
   bool truncate() const override;
 
  private:
   const bool legacyCast_;
+  TimestampToStringOptions options_ = {
+      .precision = TimestampToStringOptions::Precision::kMilliseconds};
 };
 } // namespace facebook::velox::exec

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -39,21 +39,6 @@ int32_t SparkCastHooks::castStringToDate(const StringView& dateString) const {
       removeWhiteSpaces(dateString), false /*isIso8601*/);
 }
 
-void SparkCastHooks::castTimestampToString(
-    const Timestamp& timestamp,
-    exec::StringWriter<false>& out,
-    const date::time_zone* /*timeZone*/) const {
-  static constexpr TimestampToStringOptions options = {
-      .precision = TimestampToStringOptions::Precision::kMicroseconds,
-      .leadingPositiveSign = true,
-      .skipTrailingZeros = true,
-      .zeroPaddingYear = true,
-      .dateTimeSeparator = ' ',
-  };
-  out.copy_from(timestamp.toString(options));
-  out.finalize();
-}
-
 bool SparkCastHooks::legacy() const {
   return false;
 }
@@ -63,6 +48,18 @@ StringView SparkCastHooks::removeWhiteSpaces(const StringView& view) const {
   stringImpl::trimUnicodeWhiteSpace<true, true, StringView, StringView>(
       output, view);
   return output;
+}
+
+const TimestampToStringOptions& SparkCastHooks::timestampToStringOptions()
+    const {
+  static constexpr TimestampToStringOptions options = {
+      .precision = TimestampToStringOptions::Precision::kMicroseconds,
+      .leadingPositiveSign = true,
+      .skipTrailingZeros = true,
+      .zeroPaddingYear = true,
+      .dateTimeSeparator = ' ',
+  };
+  return options;
 }
 
 bool SparkCastHooks::truncate() const {

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -30,14 +30,6 @@ class SparkCastHooks : public exec::CastHooks {
   /// non-standard cast mode to cast from string to date.
   int32_t castStringToDate(const StringView& dateString) const override;
 
-  /// 1) Does not follow 'isLegacyCast' config. 2) The conversion precision is
-  /// microsecond. 3) Does not append trailing zeros. 4) Adds a positive sign at
-  /// first if the year exceeds 9999.
-  void castTimestampToString(
-      const Timestamp& timestamp,
-      exec::StringWriter<false>& out,
-      const date::time_zone* timeZone) const override;
-
   // Returns false.
   bool legacy() const override;
 
@@ -45,6 +37,11 @@ class SparkCastHooks : public exec::CastHooks {
   /// timestamp types, Spark hook trims all leading and trailing UTF8
   /// whitespaces before cast.
   StringView removeWhiteSpaces(const StringView& view) const override;
+
+  /// 1) Does not follow 'isLegacyCast' and session timezone. 2) The conversion
+  /// precision is microsecond. 3) Does not append trailing zeros. 4) Adds a
+  /// positive sign at first if the year exceeds 9999.
+  const TimestampToStringOptions& timestampToStringOptions() const override;
 
   // Returns true.
   bool truncate() const override;

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -470,7 +470,6 @@ TEST_F(SparkCastExprTest, timestampToString) {
           Timestamp(946729316, 100000000),
           Timestamp(946729316, 129900000),
           Timestamp(946729316, 123456789),
-
           Timestamp(7266, 0),
           Timestamp(-50049331200, 0),
           Timestamp(253405036800, 0),

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -1004,7 +1004,12 @@ std::string DateType::toString(int32_t days) const {
       days);
   TimestampToStringOptions options;
   options.mode = TimestampToStringOptions::Mode::kDateOnly;
-  return Timestamp::tmToString(tmValue, 0, options);
+  std::string result;
+  result.resize(getMaxStringLength(options));
+  const auto view =
+      Timestamp::tmToStringView(tmValue, 0, options, result.data());
+  result.resize(view.size());
+  return result;
 }
 
 int32_t DateType::toDays(folly::StringPiece in) const {

--- a/velox/type/tests/TimestampTest.cpp
+++ b/velox/type/tests/TimestampTest.cpp
@@ -29,7 +29,11 @@ std::string timestampToString(
     const TimestampToStringOptions& options) {
   std::tm tm;
   Timestamp::epochToUtc(ts.getSeconds(), tm);
-  return Timestamp::tmToString(tm, ts.getNanos(), options);
+  std::string result;
+  result.resize(getMaxStringLength(options));
+  const auto view = Timestamp::tsToStringView(ts, options, result.data());
+  result.resize(view.size());
+  return result;
 }
 
 TEST(TimestampTest, fromMillisAndMicros) {
@@ -416,10 +420,13 @@ void testTmToString(
         ASSERT_TRUE(Timestamp::epochToUtc(epoch, actual));
         checkTm(actual, expected);
 
-        auto actualString = Timestamp::tmToString(actual, nanos, options);
+        std::string actualString;
+        actualString.resize(getMaxStringLength(options));
+        const auto view = Timestamp::tmToStringView(
+            actual, nanos, options, actualString.data());
+        actualString.resize(view.size());
         auto expectedString = tmToString(expected, nanos, format, options);
         ASSERT_EQ(expectedString, actualString);
-
       } else {
         ASSERT_FALSE(Timestamp::epochToUtc(epoch, actual));
       }


### PR DESCRIPTION
1) CAST(timestamp as varchar) used to rely on tmToString method, which 
creates intermediate strings during conversion. This PR implements
tsToStringView and tmToStringView which write characters directly to a 
preallocated buffer. These new methods are used to implement CAST.
2) Session timezone could be accessed in cast hooks, so it could be
initialized in the constructor.

The benchmark shows that performance is improved ~3x.

| cast##cast_timestamp  | ms/iter | iters/s |
| ------------- | ------------- | ------------- |
| before | 27.64  |  36.17  | 
| after  | 9.19  | 108.78  |

Fixes https://github.com/facebookincubator/velox/issues/8067.