### PR TITLE
Fix signature of regexp_replace Spark function and register it in Spark function registry

### DIFF
--- a/velox/functions/sparksql/RegexFunctions.cpp
+++ b/velox/functions/sparksql/RegexFunctions.cpp
@@ -134,7 +134,7 @@ struct RegexpReplaceFunction {
       const arg_type<Varchar>& stringInput,
       const arg_type<Varchar>& pattern,
       const arg_type<Varchar>& replace,
-      const arg_type<int64_t>& position) {
+      const arg_type<int32_t>& position) {
     VELOX_USER_CHECK_GE(position, 1, "regexp_replace requires a position >= 1");
 
     re2::RE2* patternRegex = getCachedRegex(pattern.str());
@@ -245,7 +245,7 @@ void registerRegexpReplace(const std::string& prefix) {
       Varchar,
       Varchar,
       Varchar,
-      int64_t>({prefix + "REGEXP_REPLACE"});
+      int32_t>({prefix + "REGEXP_REPLACE"});
 }
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/RegexFunctions.cpp
+++ b/velox/functions/sparksql/RegexFunctions.cpp
@@ -96,8 +96,8 @@ void ensureRegexIsConstantAndCompatible(
       std::string(pattern.data(), pattern.size()), functionName);
 }
 
-// REGEXP_REPLACE(string, pattern, overwrite) → string
-// REGEXP_REPLACE(string, pattern, overwrite, position) → string
+// regexp_replace(string, pattern, overwrite) → string
+// regexp_replace(string, pattern, overwrite, position) → string
 //
 // If a string has a substring that matches the given pattern, replace
 // the match in the string wither overwrite and return the string. If
@@ -238,14 +238,14 @@ std::shared_ptr<exec::VectorFunction> makeRegexExtract(
 
 void registerRegexpReplace(const std::string& prefix) {
   registerFunction<RegexpReplaceFunction, Varchar, Varchar, Varchar, Varchar>(
-      {prefix + "REGEXP_REPLACE"});
+      {prefix + "regexp_replace"});
   registerFunction<
       RegexpReplaceFunction,
       Varchar,
       Varchar,
       Varchar,
       Varchar,
-      int32_t>({prefix + "REGEXP_REPLACE"});
+      int32_t>({prefix + "regexp_replace"});
 }
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -188,6 +188,7 @@ void registerFunctions(const std::string& prefix) {
       prefix + "regexp_extract", re2ExtractSignatures(), makeRegexExtract);
   exec::registerStatefulVectorFunction(
       prefix + "rlike", re2SearchSignatures(), makeRLike);
+  registerRegexpReplace(prefix);
   VELOX_REGISTER_VECTOR_FUNCTION(udf_regexp_split, prefix + "split");
 
   exec::registerStatefulVectorFunction(

--- a/velox/functions/sparksql/tests/RegexFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/RegexFunctionsTest.cpp
@@ -34,6 +34,10 @@ class RegexFunctionsTest : public test::SparkFunctionBaseTest {
   void SetUp() override {
     SparkFunctionBaseTest::SetUp();
     registerRegexpReplace("");
+    // For parsing literal integers as INTEGER, not BIGINT,
+    // required by regexp_replace because its position argument
+    // is INTEGER.
+    options_.parseIntegerAsBigint = false;
   }
 
   std::optional<bool> rlike(


### PR DESCRIPTION
* This PR fixes the signature for regexp_replace to align with Spark (see below link). The function name is changed to lower case to meet the naming convention. And its position argument should be INTEGER instead of BIGINT.
* It also fixes the lacking of registering regexp_replace in Spark function registry.

https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala#L687