### PR TITLE
Fix shadowed variable in velox/dwio/common/FilterNode.h

### DIFF
--- a/velox/dwio/common/FilterNode.h
+++ b/velox/dwio/common/FilterNode.h
@@ -102,14 +102,14 @@ struct FilterNode {
     return name == other.name;
   }
 
-  bool match(const std::string_view& name_to_match) const {
+  bool match(const std::string_view& name_to_match_2) const {
     // no match if any is invalid
     if (!valid()) {
       // even current is invlaid
       return false;
     }
 
-    return name == name_to_match;
+    return name == name_to_match_2;
   }
 
   // expect the incoming list has all valid nodes
@@ -117,8 +117,8 @@ struct FilterNode {
   std::vector<FilterNode>::const_iterator in(
       const std::vector<FilterNode>& list) const {
     return std::find_if(
-        list.cbegin(), list.cend(), [this](const FilterNode& filter_node) {
-          return filter_node.match(*this);
+        list.cbegin(), list.cend(), [this](const FilterNode& filter_node_2) {
+          return filter_node_2.match(*this);
         });
   }
 


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: palmje

Differential Revision: D52582849


