### PR TITLE
Fix shadowed variable in velox/dwio/common/BitPackDecoder.cpp

### DIFF
--- a/velox/dwio/common/BitPackDecoder.cpp
+++ b/velox/dwio/common/BitPackDecoder.cpp
@@ -281,15 +281,15 @@ void unpack(
   if (anyUnsafe) {
     auto lastSafeWord = bufferEnd - sizeof(uint64_t);
     VELOX_DCHECK(lastSafeWord);
-    for (auto i = numSafeRows; i < numRows; ++i) {
-      auto bit = bitOffset + (rows[i]) * bitWidth;
+    for (auto i_2 = numSafeRows; i_2 < numRows; ++i_2) {
+      auto bit = bitOffset + (rows[i_2]) * bitWidth;
       auto byte = bit / 8;
       auto shift = bit & 7;
-      result[i] = safeLoadBits(
-                      reinterpret_cast<const char*>(bits) + byte,
-                      shift,
-                      bitWidth,
-                      lastSafeWord) &
+      result[i_2] = safeLoadBits(
+                        reinterpret_cast<const char*>(bits) + byte,
+                        shift,
+                        bitWidth,
+                        lastSafeWord) &
           mask;
     }
   }


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: palmje

Differential Revision: D52582944


