### PR TITLE
Fix shadowed variable in velox/exec/Aggregate.cpp

### DIFF
--- a/velox/exec/Aggregate.cpp
+++ b/velox/exec/Aggregate.cpp
@@ -70,9 +70,9 @@ AggregateRegistrationResult registerAggregateFunction(
   } else {
     auto inserted =
         aggregateFunctions().withWLock([&](auto& aggregationFunctionMap) {
-          auto [_, inserted] = aggregationFunctionMap.insert(
+          auto [_, inserted_2] = aggregationFunctionMap.insert(
               {sanitizedName, {signatures, factory}});
-          return inserted;
+          return inserted_2;
         });
     registered.mainFunction = inserted;
   }


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dmm-fb

Differential Revision: D52582788


