### PR TITLE
Fix shadowed variable in velox/expression/ExprCompiler.cpp

### DIFF
--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -188,9 +188,9 @@ std::vector<ExprPtr> compileInputs(
       if (flattenIf.has_value()) {
         std::vector<TypedExprPtr> flat;
         flattenInput(input, flattenIf.value(), flat);
-        for (auto& input : flat) {
+        for (auto& input_2 : flat) {
           compiledInputs.push_back(compileExpression(
-              input,
+              input_2,
               scope,
               config,
               pool,
@@ -434,12 +434,12 @@ ExprPtr compileRewrittenExpression(
           simpleFunctionEntry->type(),
           resultType,
           folly::join(", ", inputTypes));
-      auto func = simpleFunctionEntry->createFunction()->createVectorFunction(
+      auto func_2 = simpleFunctionEntry->createFunction()->createVectorFunction(
           getConstantInputs(compiledInputs), config);
       result = std::make_shared<Expr>(
           resultType,
           std::move(compiledInputs),
-          std::move(func),
+          std::move(func_2),
           call->name(),
           trackCpuUsage);
     } else {


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dmm-fb

Differential Revision: D52582906


