### PR TITLE
Fix shadowed variable in velox/common/caching/CachedFactory.h

### DIFF
--- a/velox/common/caching/CachedFactory.h
+++ b/velox/common/caching/CachedFactory.h
@@ -171,7 +171,7 @@ std::pair<bool, Value> CachedFactory<Key, Value, Generator>::generate(
       generatedValue = (*generator_)(key);
     } catch (const std::exception&) {
       {
-        std::lock_guard<std::mutex> pending_lock(pendingMu_);
+        std::lock_guard<std::mutex> pending_lock_2(pendingMu_);
         pending_.erase(key);
       }
       pendingCv_.notify_all();
@@ -185,7 +185,7 @@ std::pair<bool, Value> CachedFactory<Key, Value, Generator>::generate(
     // inconsistent state. Eventually this code should move to
     // folly:synchronized and rewritten with better primitives.
     {
-      std::lock_guard<std::mutex> pending_lock(pendingMu_);
+      std::lock_guard<std::mutex> pending_lock_2(pendingMu_);
       pending_.erase(key);
     }
     pendingCv_.notify_all();


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dmm-fb

Differential Revision: D52582792


