### PR TITLE
Test side-effect-free of Aggregate::extractXxx

### DIFF
--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -667,10 +667,20 @@ class TypedExprs {
     return dynamic_cast<const ConstantTypedExpr*>(expr.get()) != nullptr;
   }
 
-  /// Returns 'expr' as ConstantTypedExprPtr or null if not field access
+  /// Returns 'expr' as ConstantTypedExprPtr or null if not a constant
   /// expression.
   static ConstantTypedExprPtr asConstant(const TypedExprPtr& expr) {
     return std::dynamic_pointer_cast<const ConstantTypedExpr>(expr);
+  }
+
+  /// Returns true if 'expr' is a lambda expression.
+  static bool isLambda(const TypedExprPtr& expr) {
+    return dynamic_cast<const LambdaTypedExpr*>(expr.get()) != nullptr;
+  }
+
+  /// Returns 'expr' as LambdaTypedExprPtr or null if not a lambda expression.
+  static LambdaTypedExprPtr asLambda(const TypedExprPtr& expr) {
+    return std::dynamic_pointer_cast<const LambdaTypedExpr>(expr);
   }
 };
 } // namespace facebook::velox::core

--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -208,6 +208,10 @@ class Aggregate {
   // 'result' and its parts are expected to be singly referenced. If
   // other threads or operators hold references that they would use
   // after 'result' has been updated by this, effects will be unpredictable.
+  // This method should not have side effects, i.e., calling this method
+  // doesn't change the content of the accumulators. This is needed for an
+  // optimization in Window operator where aggregations for expanding frames are
+  // computed incrementally.
   virtual void
   extractValues(char** groups, int32_t numGroups, VectorPtr* result) = 0;
 
@@ -216,7 +220,7 @@ class Aggregate {
   // @param numGroups Number of groups to extract results from.
   // @param result The result vector to store the results in.
   //
-  // See comment on 'result' in extractValues().
+  // See comment on 'result' and side effects in extractValues().
   virtual void
   extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result) = 0;
 

--- a/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h
+++ b/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h
@@ -245,8 +245,19 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
     testStreaming_ = true;
   }
 
+  void disableTestIncremental() {
+    testIncremental_ = false;
+  }
+
+  void enableTestIncremental() {
+    testIncremental_ = true;
+  }
+
   /// Whether testStreaming should be called in testAggregations.
   bool testStreaming_{true};
+
+  /// Whether testIncrementalAggregation should be called in testAggregations.
+  bool testIncremental_{true};
 
  private:
   // Test streaming use case where raw inputs are added after intermediate
@@ -263,6 +274,15 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
       vector_size_t rawInput1Size,
       const std::vector<VectorPtr>& rawInput2,
       vector_size_t rawInput2Size,
+      const std::unordered_map<std::string, std::string>& config = {});
+
+  // Test to ensure that when extractValues() or extractAccumulators() is called
+  // twice on the same accumulator, the extracted results are the same. This
+  // ensures that extractValues() and extractAccumulators() are free of side
+  // effects.
+  void testIncrementalAggregation(
+      const std::function<void(exec::test::PlanBuilder&)>& makeSource,
+      const std::vector<std::string>& aggregates,
       const std::unordered_map<std::string, std::string>& config = {});
 
   void testAggregationsImpl(

--- a/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
@@ -441,6 +441,11 @@ TEST_F(AverageAggregationTest, decimalAccumulator) {
 }
 
 TEST_F(AverageAggregationTest, avgDecimal) {
+  // Disable incremental aggregation tests because DecimalAggregate doesn't set
+  // StringView::prefix when extracting accumulators, leaving the prefix field
+  // undefined that fails the test.
+  AggregationTestBase::disableTestIncremental();
+
   // Skip testing with TableScan because decimal is not supported in writers.
   auto shortDecimal = makeNullableFlatVector<int64_t>(
       {1'000, 2'000, 3'000, 4'000, 5'000, std::nullopt}, DECIMAL(10, 1));
@@ -589,9 +594,13 @@ TEST_F(AverageAggregationTest, avgDecimal) {
       expectedResult,
       /*config*/ {},
       /*testWithTableScan*/ false);
+
+  AggregationTestBase::enableTestIncremental();
 }
 
 TEST_F(AverageAggregationTest, avgDecimalWithMultipleRowVectors) {
+  AggregationTestBase::disableTestIncremental();
+
   auto inputRows = {
       makeRowVector({makeFlatVector<int64_t>({100, 200}, DECIMAL(5, 2))}),
       makeRowVector({makeFlatVector<int64_t>({300, 400}, DECIMAL(5, 2))}),
@@ -608,6 +617,8 @@ TEST_F(AverageAggregationTest, avgDecimalWithMultipleRowVectors) {
       expectedResult,
       /*config*/ {},
       /*testWithTableScan*/ false);
+
+  AggregationTestBase::enableTestIncremental();
 }
 
 TEST_F(AverageAggregationTest, constantVectorOverflow) {

--- a/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -1370,6 +1370,7 @@ class MinMaxByNTest : public AggregationTestBase {
     AggregationTestBase::SetUp();
     AggregationTestBase::allowInputShuffle();
     AggregationTestBase::enableTestStreaming();
+    AggregationTestBase::disableTestIncremental();
   }
 };
 

--- a/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
@@ -492,6 +492,7 @@ class MinMaxNTest : public functions::aggregate::test::AggregationTestBase {
   void SetUp() override {
     AggregationTestBase::SetUp();
     allowInputShuffle();
+    AggregationTestBase::disableTestIncremental();
   }
 
   template <typename T>

--- a/velox/functions/prestosql/aggregates/tests/SumTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SumTest.cpp
@@ -111,6 +111,11 @@ TEST_F(SumTest, sumDoubleAndFloat) {
 }
 
 TEST_F(SumTest, sumDecimal) {
+  // Disable incremental aggregation tests because DecimalAggregate doesn't set
+  // StringView::prefix when extracting accumulators, leaving the prefix field
+  // undefined that fails the test.
+  AggregationTestBase::disableTestIncremental();
+
   // Skip testing with TableScan because decimal is not supported in writers.
   std::vector<std::optional<int64_t>> shortDecimalRawVector;
   std::vector<std::optional<int128_t>> longDecimalRawVector;
@@ -172,9 +177,13 @@ TEST_F(SumTest, sumDecimal) {
       expectedResult,
       /*config*/ {},
       /*testWithTableScan*/ false);
+
+  AggregationTestBase::enableTestIncremental();
 }
 
 TEST_F(SumTest, sumDecimalOverflow) {
+  AggregationTestBase::disableTestIncremental();
+
   // Short decimals do not overflow easily.
   std::vector<int64_t> shortDecimalInput;
   for (int i = 0; i < 10'000; ++i) {
@@ -255,6 +264,8 @@ TEST_F(SumTest, sumDecimalOverflow) {
   VELOX_ASSERT_THROW(
       decimalSumOverflow(longDecimalInput, longDecimalOutput),
       "Value '-100000000000000000000000000000000000000' is not in the range of Decimal Type");
+
+  AggregationTestBase::enableTestIncremental();
 }
 
 TEST_F(SumTest, sumWithMask) {

--- a/velox/functions/sparksql/aggregates/tests/FirstAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/FirstAggregateTest.cpp
@@ -33,6 +33,9 @@ class FirstAggregateTest : public AggregationTestBase {
   void SetUp() override {
     AggregationTestBase::SetUp();
     registerAggregateFunctions("spark_");
+    // Disable incremental aggregation tests because the boolean field in
+    // intermediate result of spark_first is unset and has undefined value.
+    AggregationTestBase::disableTestIncremental();
   }
 
   template <typename T>

--- a/velox/functions/sparksql/aggregates/tests/LastAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/LastAggregateTest.cpp
@@ -27,6 +27,9 @@ class LastAggregateTest : public aggregate::test::AggregationTestBase {
   void SetUp() override {
     aggregate::test::AggregationTestBase::SetUp();
     registerAggregateFunctions("spark_");
+    // Disable incremental aggregation tests because the boolean field in
+    // intermediate result of spark_last is unset and has undefined value.
+    AggregationTestBase::disableTestIncremental();
   }
 
   template <typename T>


### PR DESCRIPTION
Summary:
Add a test in testAggregations to check that Aggregate::extractAccumulators and 
Aggregate::extractValues don't have side effects of changing the accumulators.

Differential Revision: D52755566


