### PR TITLE
Fix shadowed variable in velox/expression/CastExpr-inl.h

### DIFF
--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -101,14 +101,12 @@ StringView convertToStringView(
       // Append remaining fraction digits.
       auto result = std::to_chars(
           writePosition, writePosition + maxVarcharSize, fraction);
-      position = result.ptr;
-      errorCode = result.ec;
       VELOX_DCHECK_EQ(
-          errorCode,
+          result.ec,
           std::errc(),
           "Failed to cast decimal to varchar: {}",
-          std::make_error_code(errorCode).message());
-      writePosition = position;
+          std::make_error_code(result.ec).message());
+      writePosition = result.ptr;
     }
   }
   return StringView(startPosition, writePosition - startPosition);


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: palmje

Differential Revision: D52582937


