### PR TITLE
Reduce link parallelism to fix compilation OOM's

### DIFF
--- a/.circleci/dist_compile.yml
+++ b/.circleci/dist_compile.yml
@@ -624,7 +624,7 @@ jobs:
       - run:
           name: "Build"
           command: |
-            make debug NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=4 EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON"
+            make debug NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4 EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON"
             ccache -s
           no_output_timeout: 1h
       - run:


### PR DESCRIPTION
**What ?**

We reduce the high memory jobs parallelism from 8 to 4 and the max number 
of debug threads to 4 for the linux-pr-fuzzer run.

**Why ?** 

This is to fix #8401 where we are seeing intermittent compilation failures. 

**Notes:**

This change only affects linux-pr-fuzzer-run and not all the other jobs as they
have been succeeding with the level of parallelism. Why linux-pr-fuzzer-run
only fails could be due to additional compile time flags
(-DVELOX_ENABLE_ARROW=ON) that might be adding to the load. We will do a full
fix as a migration of these jobs to Github Actions from CCI. 