### PR TITLE
Add SingleThreadedTaskCursor

### DIFF
--- a/velox/connectors/tpch/tests/SpeedTest.cpp
+++ b/velox/connectors/tpch/tests/SpeedTest.cpp
@@ -92,14 +92,14 @@ class TpchSpeedTest {
     params.planNode = plan;
     params.maxDrivers = FLAGS_max_drivers;
 
-    TaskCursor taskCursor(params);
-    taskCursor.start();
+    auto taskCursor = TaskCursor::create(params);
+    taskCursor->start();
 
-    auto task = taskCursor.task();
+    auto task = taskCursor->task();
     addSplits(*task, scanId, numSplits);
 
-    while (taskCursor.moveNext()) {
-      processBatch(taskCursor.current());
+    while (taskCursor->moveNext()) {
+      processBatch(taskCursor->current());
     }
 
     // Wait for the task to finish.

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -78,12 +78,15 @@ class QueryCtx {
   }
 
   folly::Executor* executor() const {
+    VELOX_CHECK(isExecutorSupplied(), "Executor was not supplied.");
     if (executor_ != nullptr) {
       return executor_;
     }
-    auto executor = executorKeepalive_.get();
-    VELOX_CHECK(executor, "Executor was not supplied.");
-    return executor;
+    return executorKeepalive_.get();
+  }
+
+  bool isExecutorSupplied() const {
+    return executor_ != nullptr || executorKeepalive_.get() != nullptr;
   }
 
   const QueryConfig& queryConfig() const {

--- a/velox/exec/tests/AssertQueryBuilderTest.cpp
+++ b/velox/exec/tests/AssertQueryBuilderTest.cpp
@@ -34,6 +34,19 @@ TEST_F(AssertQueryBuilderTest, basic) {
       .assertResults(data);
 }
 
+TEST_F(AssertQueryBuilderTest, singleThreaded) {
+  auto data = makeRowVector({makeFlatVector<int32_t>({1, 2, 3})});
+
+  PlanBuilder builder;
+  const auto& plan = builder.values({data}).planNode();
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .singleThreaded(true)
+      .assertResults("VALUES (1), (2), (3)");
+
+  AssertQueryBuilder(plan).singleThreaded(true).assertResults(data);
+}
+
 TEST_F(AssertQueryBuilderTest, orderedResults) {
   auto data = makeRowVector({makeFlatVector<int32_t>({1, 2, 3})});
 

--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -980,7 +980,7 @@ TEST_F(DriverTest, driverCreationThrow) {
   CursorParameters params;
   params.planNode = plan;
   params.maxDrivers = 5;
-  auto cursor = std::make_unique<TaskCursor>(params);
+  auto cursor = TaskCursor::create(params);
   auto task = cursor->task();
   // Ensure execution threw correct error.
   VELOX_ASSERT_THROW(cursor->moveNext(), "Too many drivers");

--- a/velox/exec/tests/FilterProjectTest.cpp
+++ b/velox/exec/tests/FilterProjectTest.cpp
@@ -346,9 +346,9 @@ TEST_F(FilterProjectTest, nestedFieldReference) {
   params.planNode =
       PlanBuilder().values({vector}).project({"(c0).c0.c0.c0"}).planNode();
   params.copyResult = false;
-  TaskCursor cursor(params);
-  ASSERT_TRUE(cursor.moveNext());
-  auto result = cursor.current();
+  auto cursor = TaskCursor::create(params);
+  ASSERT_TRUE(cursor->moveNext());
+  auto result = cursor->current();
   auto* actual = result->as<RowVector>()->childAt(0).get();
   const BaseVector* expected = vector.get();
   for (int i = 0; i < 4; ++i) {

--- a/velox/exec/tests/GroupedExecutionTest.cpp
+++ b/velox/exec/tests/GroupedExecutionTest.cpp
@@ -468,7 +468,7 @@ TEST_F(GroupedExecutionTest, groupedExecution) {
   params.numConcurrentSplitGroups = 2;
 
   // Create the cursor with the task underneath. It is not started yet.
-  auto cursor = std::make_unique<TaskCursor>(params);
+  auto cursor = TaskCursor::create(params);
   auto task = cursor->task();
 
   // Add one splits before start to ensure we can handle such cases.

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -5001,7 +5001,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, buildReservationReleaseCheck) {
        {core::QueryConfig::kJoinSpillEnabled, "true"}});
   params.maxDrivers = 1;
 
-  auto cursor = std::make_unique<TaskCursor>(params);
+  auto cursor = TaskCursor::create(params);
   auto* task = cursor->task().get();
 
   // Set up a testvalue to trigger task abort when hash build tries to reserve

--- a/velox/exec/tests/LocalPartitionTest.cpp
+++ b/velox/exec/tests/LocalPartitionTest.cpp
@@ -514,7 +514,7 @@ TEST_F(LocalPartitionTest, earlyCancelation) {
   task->requestCancel();
 
   // Fetch the remaining results. This will throw since only one vector can be
-  // buffered in the cursor->
+  // buffered in the cursor.
   try {
     while (cursor->moveNext()) {
       ;

--- a/velox/exec/tests/LocalPartitionTest.cpp
+++ b/velox/exec/tests/LocalPartitionTest.cpp
@@ -310,17 +310,17 @@ TEST_F(LocalPartitionTest, indicesBufferCapacity) {
                         .planNode();
   params.copyResult = false;
   params.maxDrivers = 2;
-  TaskCursor cursor(params);
+  auto cursor = TaskCursor::create(params);
   for (auto i = 0; i < filePaths.size(); ++i) {
     auto id = scanNodeIds[i % 3];
-    cursor.task()->addSplit(
+    cursor->task()->addSplit(
         id, Split(makeHiveConnectorSplit(filePaths[i]->path)));
-    cursor.task()->noMoreSplits(id);
+    cursor->task()->noMoreSplits(id);
   }
   int numRows = 0;
   int capacity = 0;
-  while (cursor.moveNext()) {
-    auto* batch = cursor.current()->as<RowVector>();
+  while (cursor->moveNext()) {
+    auto* batch = cursor->current()->as<RowVector>();
     ASSERT_EQ(batch->childrenSize(), 1);
     auto& column = batch->childAt(0);
     ASSERT_EQ(column->encoding(), VectorEncoding::Simple::DICTIONARY);
@@ -503,7 +503,7 @@ TEST_F(LocalPartitionTest, earlyCancelation) {
   // Make sure results are queued one batch at a time.
   params.bufferedBytes = 100;
 
-  auto cursor = std::make_unique<TaskCursor>(params);
+  auto cursor = TaskCursor::create(params);
   const auto& task = cursor->task();
 
   // Fetch first batch of data.
@@ -514,7 +514,7 @@ TEST_F(LocalPartitionTest, earlyCancelation) {
   task->requestCancel();
 
   // Fetch the remaining results. This will throw since only one vector can be
-  // buffered in the cursor.
+  // buffered in the cursor->
   try {
     while (cursor->moveNext()) {
       ;
@@ -553,7 +553,7 @@ TEST_F(LocalPartitionTest, producerError) {
   CursorParameters params;
   params.planNode = plan;
 
-  auto cursor = std::make_unique<TaskCursor>(params);
+  auto cursor = TaskCursor::create(params);
   const auto& task = cursor->task();
 
   // Expect division by zero error.

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -1413,7 +1413,7 @@ TEST_F(MultiFragmentTest, customPlanNodeWithExchangeClient) {
           .capturePlanNodeId(testNodeId)
           .planNode();
 
-  auto cursor = std::make_unique<TaskCursor>(params);
+  auto cursor = TaskCursor::create(params);
   auto task = cursor->task();
   addRemoteSplits(task, {leafTaskId});
   while (cursor->moveNext()) {

--- a/velox/exec/tests/QueryAssertionsTest.cpp
+++ b/velox/exec/tests/QueryAssertionsTest.cpp
@@ -27,7 +27,22 @@ using namespace facebook::velox;
 
 namespace facebook::velox::test {
 
-class QueryAssertionsTest : public OperatorTestBase {};
+class QueryAssertionsTest : public OperatorTestBase {
+ public:
+  void assertQueryWithThreadingConfigs(
+      const core::PlanNodePtr& plan,
+      const std::string& duckDbSql) {
+    CursorParameters multiThreadedParams{};
+    multiThreadedParams.planNode = plan;
+    multiThreadedParams.singleThreaded = false;
+    assertQuery(multiThreadedParams, duckDbSql);
+
+    CursorParameters singleThreadedParams{};
+    singleThreadedParams.planNode = plan;
+    singleThreadedParams.singleThreaded = true;
+    assertQuery(singleThreadedParams, duckDbSql);
+  }
+};
 
 TEST_F(QueryAssertionsTest, basic) {
   auto data = makeRowVector({
@@ -36,7 +51,7 @@ TEST_F(QueryAssertionsTest, basic) {
   createDuckDbTable({data});
 
   auto plan = PlanBuilder().values({data}).project({"c0"}).planNode();
-  assertQuery(plan, "SELECT c0 FROM tmp");
+  assertQueryWithThreadingConfigs(plan, "SELECT c0 FROM tmp");
 
   EXPECT_NONFATAL_FAILURE(
       assertQuery(plan, "SELECT c0 + 1 FROM tmp"),
@@ -351,7 +366,7 @@ TEST_F(QueryAssertionsTest, nullDecimalValue) {
 
   createDuckDbTable({shortDecimal});
   auto plan = PlanBuilder().values({shortDecimal}).planNode();
-  assertQuery(plan, "SELECT c0 FROM tmp");
+  assertQueryWithThreadingConfigs(plan, "SELECT c0 FROM tmp");
 
   auto longDecimal = makeRowVector(
       {makeNullableFlatVector<int128_t>({std::nullopt}, DECIMAL(20, 2))});
@@ -359,7 +374,7 @@ TEST_F(QueryAssertionsTest, nullDecimalValue) {
 
   createDuckDbTable({longDecimal});
   plan = PlanBuilder().values({longDecimal}).planNode();
-  assertQuery(plan, "SELECT c0 FROM tmp");
+  assertQueryWithThreadingConfigs(plan, "SELECT c0 FROM tmp");
 
   EXPECT_NONFATAL_FAILURE(
       assertEqualResults({shortDecimal}, {longDecimal}),
@@ -432,7 +447,7 @@ TEST_F(QueryAssertionsTest, nullVariant) {
            {{std::nullopt, 1.1}, {2.2, 3.3, 4.4}, {std::nullopt}})});
   createDuckDbTable({input});
   auto plan = PlanBuilder().values({input}).planNode();
-  assertQuery(plan, "SELECT * FROM tmp");
+  assertQueryWithThreadingConfigs(plan, "SELECT * FROM tmp");
 
   input = makeRowVector({makeNullableMapVector<int64_t, double>(
       {std::nullopt,
@@ -443,14 +458,14 @@ TEST_F(QueryAssertionsTest, nullVariant) {
        {{{6, std::nullopt}}}})});
   createDuckDbTable({input});
   plan = PlanBuilder().values({input}).planNode();
-  assertQuery(plan, "SELECT * FROM tmp");
+  assertQueryWithThreadingConfigs(plan, "SELECT * FROM tmp");
 
   input = makeRowVector({makeRowVector(
       {makeNullConstant(TypeKind::BIGINT, 10),
        makeNullConstant(TypeKind::DOUBLE, 10)})});
   createDuckDbTable({input});
   plan = PlanBuilder().values({input}).planNode();
-  assertQuery(plan, "SELECT * FROM tmp");
+  assertQueryWithThreadingConfigs(plan, "SELECT * FROM tmp");
 }
 
 TEST_F(QueryAssertionsTest, varbinary) {
@@ -467,7 +482,7 @@ TEST_F(QueryAssertionsTest, varbinary) {
   ASSERT_TRUE(assertEqualResults(duckResult, rowType, {data}));
 
   auto plan = PlanBuilder().values({data}).planNode();
-  assertQuery(plan, "SELECT * FROM tmp");
+  assertQueryWithThreadingConfigs(plan, "SELECT * FROM tmp");
 }
 
 TEST_F(QueryAssertionsTest, intervalDayTime) {
@@ -479,7 +494,7 @@ TEST_F(QueryAssertionsTest, intervalDayTime) {
 
   createDuckDbTable({data});
   auto plan = PlanBuilder().values({data}).planNode();
-  assertQuery(plan, "SELECT * FROM tmp");
+  assertQueryWithThreadingConfigs(plan, "SELECT * FROM tmp");
 
   data = makeRowVector({makeMapVectorFromJson<int64_t, double>(
       {"null",
@@ -491,7 +506,7 @@ TEST_F(QueryAssertionsTest, intervalDayTime) {
       MAP(INTERVAL_DAY_TIME(), DOUBLE()))});
   createDuckDbTable({data});
   plan = PlanBuilder().values({data}).planNode();
-  assertQuery(plan, "SELECT * FROM tmp");
+  assertQueryWithThreadingConfigs(plan, "SELECT * FROM tmp");
 }
 
 TEST_F(QueryAssertionsTest, plansWithEqualResults) {

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -660,7 +660,7 @@ TEST_F(TaskTest, testTerminateDeadlock) {
           .project({"c0"})
           .planNode();
 
-  auto cursor = std::make_unique<TaskCursor>(params);
+  auto cursor = TaskCursor::create(params);
 
   folly::via(cursor->task()->queryCtx()->executor(), [&]() {
     // We abort after all but last join bridges finish execution. We do this
@@ -1023,7 +1023,7 @@ DEBUG_ONLY_TEST_F(TaskTest, outputDriverFinishEarly) {
       {{core::QueryConfig::kPreferredOutputBatchRows, "1"}});
 
   {
-    auto cursor = std::make_unique<TaskCursor>(params);
+    auto cursor = TaskCursor::create(params);
     std::vector<RowVectorPtr> result;
     auto* task = cursor->task().get();
     while (cursor->moveNext()) {
@@ -1068,7 +1068,7 @@ DEBUG_ONLY_TEST_F(TaskTest, liveStats) {
   params.queryCtx->testingOverrideConfigUnsafe(
       {{core::QueryConfig::kPreferredOutputBatchRows, "1"}});
 
-  auto cursor = std::make_unique<TaskCursor>(params);
+  auto cursor = TaskCursor::create(params);
   std::vector<RowVectorPtr> result;
   task = cursor->task().get();
   while (cursor->moveNext()) {
@@ -1147,7 +1147,7 @@ TEST_F(TaskTest, outputBufferSize) {
 
   // Produce the results to output buffer manager but not consuming them to
   // check the buffer utilization in test.
-  auto cursor = std::make_unique<TaskCursor>(params);
+  auto cursor = TaskCursor::create(params);
   std::vector<RowVectorPtr> result;
   Task* task = cursor->task().get();
   while (cursor->moveNext()) {
@@ -1204,7 +1204,7 @@ DEBUG_ONLY_TEST_F(TaskTest, findPeerOperators) {
     params.queryCtx = std::make_shared<core::QueryCtx>(driverExecutor_.get());
     params.maxDrivers = numDriver;
 
-    auto cursor = std::make_unique<TaskCursor>(params);
+    auto cursor = TaskCursor::create(params);
     auto* task = cursor->task().get();
 
     // Set up a testvalue to trigger task abort when hash build tries to reserve
@@ -1255,7 +1255,7 @@ DEBUG_ONLY_TEST_F(TaskTest, raceBetweenTaskPauseAndTerminate) {
   params.queryCtx = std::make_shared<core::QueryCtx>(driverExecutor_.get());
   params.maxDrivers = 1;
 
-  auto cursor = std::make_unique<TaskCursor>(params);
+  auto cursor = TaskCursor::create(params);
   auto* task = cursor->task().get();
   folly::EventCount taskPauseWait;
   std::atomic<bool> taskPaused{false};
@@ -1364,7 +1364,7 @@ TEST_F(TaskTest, spillDirectoryLifecycleManagement) {
        {core::QueryConfig::kTestingSpillPct, "100"}});
   params.maxDrivers = 1;
 
-  auto cursor = std::make_unique<TaskCursor>(params);
+  auto cursor = TaskCursor::create(params);
   std::shared_ptr<Task> task = cursor->task();
   auto rootTempDir = exec::test::TempDirectoryPath::create();
   auto tmpDirectoryPath =
@@ -1421,7 +1421,7 @@ TEST_F(TaskTest, spillDirNotCreated) {
        {core::QueryConfig::kTestingSpillPct, "0"}});
   params.maxDrivers = 1;
 
-  auto cursor = std::make_unique<TaskCursor>(params);
+  auto cursor = TaskCursor::create(params);
   auto* task = cursor->task().get();
   auto rootTempDir = exec::test::TempDirectoryPath::create();
   auto tmpDirectoryPath = rootTempDir->path + "/spillDirNotCreated";

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -62,6 +62,11 @@ AssertQueryBuilder& AssertQueryBuilder::destination(int32_t destination) {
   return *this;
 }
 
+AssertQueryBuilder& AssertQueryBuilder::singleThreaded(bool singleThreaded) {
+  params_.singleThreaded = singleThreaded;
+  return *this;
+}
+
 AssertQueryBuilder& AssertQueryBuilder::config(
     const std::string& key,
     const std::string& value) {

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -39,6 +39,10 @@ class AssertQueryBuilder {
   /// Default is 0.
   AssertQueryBuilder& destination(int32_t destination);
 
+  /// Use single-threaded execution to execute the Velox plan.
+  /// Default is false.
+  AssertQueryBuilder& singleThreaded(bool singleThreaded);
+
   /// Set configuration property. May be called multiple times to set multiple
   /// properties.
   AssertQueryBuilder& config(const std::string& key, const std::string& value);

--- a/velox/exec/tests/utils/Cursor.h
+++ b/velox/exec/tests/utils/Cursor.h
@@ -121,51 +121,28 @@ class TaskQueue {
 
 class TaskCursor {
  public:
-  explicit TaskCursor(const CursorParameters& params);
+  virtual ~TaskCursor() = default;
 
-  ~TaskCursor() {
-    queue_->close();
-    if (task_ && !atEnd_) {
-      task_->requestCancel();
-    }
-  }
+  static std::unique_ptr<TaskCursor> create(const CursorParameters& params);
 
   /// Starts the task if not started yet.
-  void start();
+  virtual void start() = 0;
 
   /// Fetches another batch from the task queue.
   /// Starts the task if not started yet.
-  bool moveNext();
+  virtual bool moveNext() = 0;
 
-  bool hasNext();
+  virtual bool hasNext() = 0;
 
-  RowVectorPtr& current() {
-    return current_;
-  }
+  virtual RowVectorPtr& current() = 0;
 
-  const std::shared_ptr<Task>& task() {
-    return task_;
-  }
-
- private:
-  static std::atomic<int32_t> serial_;
-
-  const int32_t maxDrivers_;
-  const int32_t numConcurrentSplitGroups_;
-  const int32_t numSplitGroups_;
-
-  std::shared_ptr<folly::Executor> executor_;
-  bool started_ = false;
-  std::shared_ptr<TaskQueue> queue_;
-  std::shared_ptr<exec::Task> task_;
-  RowVectorPtr current_;
-  bool atEnd_{false};
+  virtual const std::shared_ptr<Task>& task() = 0;
 };
 
 class RowCursor {
  public:
   explicit RowCursor(CursorParameters& params) {
-    cursor_ = std::make_unique<TaskCursor>(params);
+    cursor_ = TaskCursor::create(params);
   }
 
   bool isNullAt(int32_t columnIndex) const {

--- a/velox/exec/tests/utils/Cursor.h
+++ b/velox/exec/tests/utils/Cursor.h
@@ -63,6 +63,9 @@ struct CursorParameters {
 
   bool copyResult = true;
 
+  /// If true, use single threaded execution.
+  bool singleThreaded = false;
+
   /// If both 'queryConfigs' and 'queryCtx' are specified, the configurations in
   /// 'queryCtx' will be overridden by 'queryConfig'.
   std::unordered_map<std::string, std::string> queryConfigs;

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -1319,7 +1319,7 @@ std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>> readCursor(
     const CursorParameters& params,
     std::function<void(exec::Task*)> addSplits,
     uint64_t maxWaitMicros) {
-  auto cursor = std::make_unique<TaskCursor>(params);
+  auto cursor = TaskCursor::create(params);
   // 'result' borrows memory from cursor so the life cycle must be shorter.
   std::vector<RowVectorPtr> result;
   auto* task = cursor->task().get();

--- a/velox/experimental/codegen/tests/CodegenTestBase.h
+++ b/velox/experimental/codegen/tests/CodegenTestBase.h
@@ -180,7 +180,7 @@ class CodegenTestCore {
     CursorParameters params;
     params.planNode = planNode;
 
-    taskCursor = std::make_unique<TaskCursor>(params);
+    taskCursor = TaskCursor::create(params);
 
     std::vector<RowVectorPtr> actualResults;
     while (taskCursor->moveNext()) {


### PR DESCRIPTION
The patch adds `SingleThreadedTaskCursor` with minimal code refactors to let developer be able to write test code against Velox's single-threaded execution mode on which some project (e.g., Gluten) relies.

1. Make `TaskCursor` a virtual class;
2. Move `TaskCursor`'s current code to implementation class `MultiThreadedTaskCursor`;
3. Add class `SingleThreadedTaskCursor` as basic test utility against single-threaded execution;
4. Add member function `AssertQueryBuilder::singleThreaded` for running query under single-threaded execution;
5. Basic tests.