### PR TITLE
Fix creation of DuckDB tables with arrays of boolean, tinyint and smallint

### DIFF
--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -40,6 +40,30 @@ template <TypeKind kind>
 }
 
 template <>
+::duckdb::Value duckValueAt<TypeKind::TINYINT>(
+    const VectorPtr& vector,
+    vector_size_t index) {
+  return ::duckdb::Value::TINYINT(
+      vector->as<SimpleVector<int8_t>>()->valueAt(index));
+}
+
+template <>
+::duckdb::Value duckValueAt<TypeKind::SMALLINT>(
+    const VectorPtr& vector,
+    vector_size_t index) {
+  return ::duckdb::Value::SMALLINT(
+      vector->as<SimpleVector<int16_t>>()->valueAt(index));
+}
+
+template <>
+::duckdb::Value duckValueAt<TypeKind::BOOLEAN>(
+    const VectorPtr& vector,
+    vector_size_t index) {
+  return ::duckdb::Value::BOOLEAN(
+      vector->as<SimpleVector<bool>>()->valueAt(index));
+}
+
+template <>
 ::duckdb::Value duckValueAt<TypeKind::VARCHAR>(
     const VectorPtr& vector,
     vector_size_t index) {


### PR DESCRIPTION
Creating DuckDB table with a column of type array(boolean), array(tinyint) or
array(smallint) having a mix of null and non-null array elements used to fail with 

```
INTERNAL Error: Assertion triggered in file "/home/runner/work/velox/velox/_build/debug/_deps/duckdb-src/src/common/types/value.cpp" on line 702: values[i].type() == values[0].type()
```

The problem is that `duckValueAt<TypeKind>` template in QueryAssertions.cpp used
to convert non-null values by calling duckdb::Value(v) API, which is not defined
for bool, int8_t and int16_t. Hence, we ended up calling a version of that API
that takes int32_t and returns a value of type INTEGER. However, code for
converting null values used duckdb::Value(type) API which takes type directly
and therefore creates values of the "right" type. When array value had a mix of
null and non-null values we ended up passing a list of elements of different
types to DuckDB and hit an assertion.

A fix implemented here is to provide explicit overrides for boolean, tinyint and smallint.

This issue happens often in join fuzzer runs.

Fixes #7943