### PR TITLE
Add kPartitionPathAsLowerCase to control whether make the partition path as lower case

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -148,6 +148,10 @@ bool HiveConfig::isFileColumnNamesReadAsLowerCase(const Config* session) const {
   return config_->get<bool>(kFileColumnNamesReadAsLowerCase, false);
 }
 
+bool HiveConfig::isPartitionPathAsLowerCase(const Config* session) const {
+  return config_->get<bool>(kPartitionPathAsLowerCaseSession, true);
+}
+
 int64_t HiveConfig::maxCoalescedBytes() const {
   return config_->get<int64_t>(kMaxCoalescedBytes, 128 << 20);
 }

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -110,6 +110,9 @@ class HiveConfig {
   static constexpr const char* kFileColumnNamesReadAsLowerCaseSession =
       "file_column_names_read_as_lower_case";
 
+  static constexpr const char* kPartitionPathAsLowerCaseSession =
+      "partition_path_as_lower_case";
+
   /// The max coalesce bytes for a request.
   static constexpr const char* kMaxCoalescedBytes = "max-coalesced-bytes";
 
@@ -203,6 +206,8 @@ class HiveConfig {
   bool isOrcUseColumnNames(const Config* session) const;
 
   bool isFileColumnNamesReadAsLowerCase(const Config* session) const;
+
+  bool isPartitionPathAsLowerCase(const Config* session) const;
 
   int64_t maxCoalescedBytes() const;
 

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -364,7 +364,7 @@ HiveDataSink::HiveDataSink(
                     partitionChannels_,
                     maxOpenWriters_,
                     connectorQueryCtx_->memoryPool(),
-                    hiveConfig_->isFileColumnNamesReadAsLowerCase(
+                    hiveConfig_->isPartitionPathAsLowerCase(
                         connectorQueryCtx->sessionProperties()))
               : nullptr),
       dataChannels_(

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -419,7 +419,11 @@ Each query can override the config by setting corresponding query session proper
      - false
      - True if reading the source file column names as lower case, and planner should guarantee
        the input column name and filter is also lower case to achive case-insensitive read.
-       If true, the partition directory will be converted to lowercase when executing a table write operation.
+   * - partition-path-as-lower-case
+     -
+     - bool
+     - true
+     - If true, the partition directory will be converted to lowercase when executing a table write operation.
    * - max-coalesced-bytes
      -
      - integer


### PR DESCRIPTION
Spark does not respect case sensitivity when calculating the partition path in
[getPartitionPathString]
(https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtils.scala#L133)
and [escapePathName]
(https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtils.scala#L70).
As a result, we cannot utilize the `kFileColumnNamesReadAsLowerCase `parameter
to determine whether to convert the partition path to lowercase. To address
this issue, a new parameter called `kPartitionPathAsLowerCaseSession `has been
introduced in this pull request. This parameter helps differentiate between
Spark and Presto's behavior when calculating the partition path.