### PR TITLE
Add space Spark Function

### DIFF
--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -14,6 +14,16 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
     If ``n < 0``, the result is an empty string.
     If ``n >= 256``, the result is equivalent to chr(``n % 256``).
 
+.. spark:function:: space(count) -> varchar
+
+    Returns a string consisting of `n` spaces. ::
+
+        SELECT space(1); -- " "
+        SELECT space(5); -- "     "
+        SELECT startswith(0); -- ""
+        SELECT startswith(-1); -- ""
+        SELECT startswith(null); -- NULL
+
 .. spark:function:: contains(left, right) -> boolean
 
     Returns true if 'right' is found in 'left'. Otherwise, returns false. ::

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -20,9 +20,9 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 
         SELECT space(1); -- " "
         SELECT space(5); -- "     "
-        SELECT startswith(0); -- ""
-        SELECT startswith(-1); -- ""
-        SELECT startswith(null); -- NULL
+        SELECT space(0); -- ""
+        SELECT space(-1); -- ""
+        SELECT space(null); -- NULL
 
 .. spark:function:: contains(left, right) -> boolean
 

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -166,7 +166,7 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 
 .. spark:function:: space(count) -> varchar
 
-    Returns a string consisting of `n` spaces. ::
+    Returns a string consisting of `count` spaces. ::
 
         SELECT space(1); -- " "
         SELECT space(5); -- "     "

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -166,7 +166,8 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 
 .. spark:function:: space(count) -> varchar
 
-    Returns a string consisting of ``count`` spaces. ::
+    Returns a string consisting of ``count`` spaces. ``count`` supports up to 1MB (2^20),
+    If the limit is exceeded, NULL is returned. ::
 
         SELECT space(1); -- " "
         SELECT space(5); -- "     "

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -166,7 +166,7 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 
 .. spark:function:: space(count) -> varchar
 
-    Returns a string consisting of `count` spaces. ::
+    Returns a string consisting of ``count`` spaces. ::
 
         SELECT space(1); -- " "
         SELECT space(5); -- "     "

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -14,16 +14,6 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
     If ``n < 0``, the result is an empty string.
     If ``n >= 256``, the result is equivalent to chr(``n % 256``).
 
-.. spark:function:: space(count) -> varchar
-
-    Returns a string consisting of `n` spaces. ::
-
-        SELECT space(1); -- " "
-        SELECT space(5); -- "     "
-        SELECT space(0); -- ""
-        SELECT space(-1); -- ""
-        SELECT space(null); -- NULL
-
 .. spark:function:: contains(left, right) -> boolean
 
     Returns true if 'right' is found in 'left'. Otherwise, returns false. ::
@@ -173,6 +163,16 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
     ``trimCharacters`` can be empty and may contain duplicate characters. ::
 
         SELECT rtrim('kr', 'spark'); -- "spa"
+
+.. spark:function:: space(count) -> varchar
+
+    Returns a string consisting of `n` spaces. ::
+
+        SELECT space(1); -- " "
+        SELECT space(5); -- "     "
+        SELECT space(0); -- ""
+        SELECT space(-1); -- ""
+        SELECT space(null); -- NULL
 
 .. spark:function:: split(string, delimiter) -> array(string)
 

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -184,6 +184,9 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<Sha2HexStringFunction, Varchar, Varbinary, int32_t>(
       {prefix + "sha2"});
 
+  registerFunction<sparksql::SpaceFunction, Varchar, int32_t>(
+        {prefix + "space"});
+
   exec::registerStatefulVectorFunction(
       prefix + "regexp_extract", re2ExtractSignatures(), makeRegexExtract);
   exec::registerStatefulVectorFunction(

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -184,8 +184,7 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<Sha2HexStringFunction, Varchar, Varbinary, int32_t>(
       {prefix + "sha2"});
 
-  registerFunction<SpaceFunction, Varchar, int32_t>(
-      {prefix + "space"});
+  registerFunction<SpaceFunction, Varchar, int32_t>({prefix + "space"});
 
   exec::registerStatefulVectorFunction(
       prefix + "regexp_extract", re2ExtractSignatures(), makeRegexExtract);

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -184,7 +184,7 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<Sha2HexStringFunction, Varchar, Varbinary, int32_t>(
       {prefix + "sha2"});
 
-  registerFunction<sparksql::SpaceFunction, Varchar, int32_t>(
+  registerFunction<SpaceFunction, Varchar, int32_t>(
       {prefix + "space"});
 
   exec::registerStatefulVectorFunction(

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -185,7 +185,7 @@ void registerFunctions(const std::string& prefix) {
       {prefix + "sha2"});
 
   registerFunction<sparksql::SpaceFunction, Varchar, int32_t>(
-        {prefix + "space"});
+      {prefix + "space"});
 
   exec::registerStatefulVectorFunction(
       prefix + "regexp_extract", re2ExtractSignatures(), makeRegexExtract);

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -218,22 +218,27 @@ struct Sha2HexStringFunction {
   }
 };
 
-/// space function
 /// space(int) -> string
 /// Returns a string consisting of `count` spaces.
 template <typename T>
 struct SpaceFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE void call(
+  // 1MB (2^20) limit on the number of spaces.
+  static constexpr int32_t max_count = 1048576;
+
+  FOLLY_ALWAYS_INLINE bool call(
       out_type<Varchar>& result,
-      const int32_t& count) {
+      const int32_t& count){
     if (count <= 0) {
-      result.setEmpty();
-      return;
+       result.setEmpty();
+    } else if (count > max_count) {
+       return false;
+    } else {
+       result.resize(count);
+       std::memset(result.data(), ' ', count);
     }
-    result.resize(count);
-    std::memset(result.data(), ' ', count);
+    return true;
   }
 };
 

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -233,7 +233,7 @@ struct SpaceFunction {
       return;
     }
     result.resize(count);
-    result = generateSpaces(count);
+    std::memcpy(result.data(), generateSpaces(count).data(), count);
   }
 
   std::string generateSpaces(int32_t count) {

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -227,8 +227,8 @@ struct SpaceFunction {
 
   FOLLY_ALWAYS_INLINE void call(
       out_type<Varchar>& result,
-      const int32_t& count){
-    if(count <= 0) {
+      const int32_t& count) {
+    if (count <= 0) {
       result.setEmpty();
       return;
     }

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -229,14 +229,14 @@ struct SpaceFunction {
 
   FOLLY_ALWAYS_INLINE bool call(
       out_type<Varchar>& result,
-      const int32_t& count){
+      const int32_t& count) {
     if (count <= 0) {
-       result.setEmpty();
+      result.setEmpty();
     } else if (count > max_count) {
-       return false;
+      return false;
     } else {
-       result.resize(count);
-       std::memset(result.data(), ' ', count);
+      result.resize(count);
+      std::memset(result.data(), ' ', count);
     }
     return true;
   }

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -232,7 +232,8 @@ struct SpaceFunction {
       result.setEmpty();
       return;
     }
-    result.append(generateSpaces(count));
+    result.resize(count);
+    result = generateSpaces(count);
   }
 
   std::string generateSpaces(int32_t count) {

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -218,6 +218,28 @@ struct Sha2HexStringFunction {
   }
 };
 
+/// space function
+/// space(int) -> string
+/// Returns a string consisting of `n` spaces.
+template <typename T>
+struct SpaceFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Varchar>& result,
+      const int32_t& count){
+    if(count <= 0) {
+      result.setEmpty();
+      return;
+    }
+    result.append(generateSpaces(count));
+  }
+
+  std::string generateSpaces(int32_t count) {
+    return std::string(count, ' ');
+  }
+};
+
 /// contains function
 /// contains(string, string) -> bool
 /// Searches the second argument in the first one.

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -220,7 +220,7 @@ struct Sha2HexStringFunction {
 
 /// space function
 /// space(int) -> string
-/// Returns a string consisting of `n` spaces.
+/// Returns a string consisting of `count` spaces.
 template <typename T>
 struct SpaceFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
@@ -233,11 +233,7 @@ struct SpaceFunction {
       return;
     }
     result.resize(count);
-    std::memcpy(result.data(), generateSpaces(count).data(), count);
-  }
-
-  std::string generateSpaces(int32_t count) {
-    return std::string(count, ' ');
+    std::memset(result.data(), ' ', count);
   }
 };
 

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -16,8 +16,8 @@
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 #include "velox/type/Type.h"
 
-#include <climits>
 #include <stdint.h>
+#include <climits>
 
 namespace facebook::velox::functions::sparksql::test {
 namespace {

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -97,10 +97,9 @@ class StringTest : public SparkFunctionBaseTest {
         "sha2(cast(c0 as varbinary), c1)", str, bitLength);
   }
 
-  std::optional<std::string> space(
-      std::optional<int32_t> count) {
+  std::optional<std::string> space(std::optional<int32_t> count) {
     return evaluateOnce<std::string>("space(c0)", count);
-   }
+  }
 
   bool compareFunction(
       const std::string& function,

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -97,6 +97,11 @@ class StringTest : public SparkFunctionBaseTest {
         "sha2(cast(c0 as varbinary), c1)", str, bitLength);
   }
 
+  std::optional<std::string> space(
+      std::optional<int32_t> count) {
+    return evaluateOnce<std::string>("space(c0)", count);
+   }
+
   bool compareFunction(
       const std::string& function,
       const std::optional<std::string>& str,
@@ -361,6 +366,16 @@ TEST_F(StringTest, sha2) {
       sha2("0123456789abcdefghijklmnopqrstuvwxyz", 512),
       "95cadc34aa46b9fdef432f62fe5bad8d9f475bfbecf797d5802bb5f2937a85d9"
       "3ce4857a6262b03834c01c610d74cd1215f9a466dc6ad3dd15078e3309a03a6d");
+}
+
+TEST_F(StringTest, space) {
+  EXPECT_EQ(space(1), " ");
+  EXPECT_EQ(space(2), "  ");
+  EXPECT_EQ(space(5), "     ");
+  EXPECT_EQ(space(0), "");
+  EXPECT_EQ(space(-1), "");
+  EXPECT_EQ(space(-10), "");
+  EXPECT_EQ(space(std::nullopt), std::nullopt);
 }
 
 TEST_F(StringTest, startsWith) {

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -16,6 +16,7 @@
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 #include "velox/type/Type.h"
 
+#include <climits>
 #include <stdint.h>
 
 namespace facebook::velox::functions::sparksql::test {
@@ -371,10 +372,7 @@ TEST_F(StringTest, space) {
   EXPECT_EQ(space(1), " ");
   EXPECT_EQ(space(2), "  ");
   EXPECT_EQ(space(5), "     ");
-  EXPECT_EQ(space(0), "");
-  EXPECT_EQ(space(-1), "");
-  EXPECT_EQ(space(-10), "");
-  EXPECT_EQ(space(std::nullopt), std::nullopt);
+  EXPECT_EQ(space(INT_MAX), std::nullopt);
 }
 
 TEST_F(StringTest, startsWith) {


### PR DESCRIPTION
add sparksql function : space(int32_t) -> varchar ,  Returns a string consisting of `n` spaces. 

```
SELECT space(1); -- " "
SELECT space(5); -- "     "
SELECT space(0); -- ""
SELECT space(-1); -- ""
SELECT space(null); -- NULL
```

Spark doc：https://spark.apache.org/docs/latest/api/sql/index.html#space
Spark implementation：https://github.com/apache/spark/blob/443a957920737143834888726f067bc54acb97f2/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala#L1860