### PR TITLE
Exclude velox/vector/arrow/Abi.h from headers

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -19,7 +19,6 @@
 #include "velox/core/Expressions.h"
 #include "velox/core/QueryConfig.h"
 
-#include "velox/vector/arrow/Abi.h"
 #include "velox/vector/arrow/Bridge.h"
 
 namespace facebook::velox::core {

--- a/velox/exec/ArrowStream.cpp
+++ b/velox/exec/ArrowStream.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/exec/ArrowStream.h"
+#include "velox/vector/arrow/Abi.h"
 
 namespace facebook::velox::exec {
 

--- a/velox/exec/ArrowStream.h
+++ b/velox/exec/ArrowStream.h
@@ -16,7 +16,7 @@
 #include "velox/core/PlanNode.h"
 #include "velox/exec/Operator.h"
 
-#include "velox/vector/arrow/Abi.h"
+#include "velox/vector/arrow/Bridge.h"
 
 namespace facebook::velox::exec {
 

--- a/velox/vector/arrow/Abi.h
+++ b/velox/vector/arrow/Abi.h
@@ -16,7 +16,14 @@
 
 // This file is a drop-in copy of Arrow's C Data Interface, as defined in:
 //   https://arrow.apache.org/docs/format/CDataInterface.html
-
+//
+// Note: Do not include this header in other Velox's public header
+//   files. We let user decide including one of the following:
+//   1. <arrow/c/abi.h> or
+//   2. "velox/vector/arrow/Abi.h"
+//
+// Try including velox/vector/arrow/Bridge.h instead, if Arrow ABI structs'
+//   declarations are needed in Velox's public header files.
 #pragma once
 
 #include <stdint.h>

--- a/velox/vector/arrow/Bridge.h
+++ b/velox/vector/arrow/Bridge.h
@@ -19,11 +19,12 @@
 #include "velox/common/memory/Memory.h"
 #include "velox/vector/BaseVector.h"
 
-/// These 2 definitions should be included by user from either
+/// These 3 definitions should be included by user from either
 ///   1. <arrow/c/abi.h> or
 ///   2. "velox/vector/arrow/Abi.h"
 struct ArrowArray;
 struct ArrowSchema;
+struct ArrowArrayStream;
 
 struct ArrowOptions {
   bool flattenDictionary{false};


### PR DESCRIPTION
`velox/vector/arrow/Abi.h` and `arrow/c/abi.h` have the same definition for the ABI structs. The patch is to exclude Velox's `Abi.h` from public headers then user could choose to include the canonical Arrow ABI header `arrow/c/abi.h` without encountering redefinition compilation errors.