### PR TITLE
Clear hash table for each spilled partition in RowNumber

### DIFF
--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -314,6 +314,7 @@ RowVectorPtr RowNumber::getOutput() {
     } else {
       input_ = nullptr;
       spillInputReader_ = nullptr;
+      table_->clear();
       restoreNextSpillPartition();
     }
   } else {


### PR DESCRIPTION
The RowNumber operator spills the whole HashTable, stops
producing output and spilling all future input.

After receiving (and spilling) all input, the RowNumber operator
would process spilled data one spilled partition at a time.

For each spilled partition, the RowNumber operator first restores
the HashTable for a partition reading spilled input one vector at a time,
and produces output. 

The table will keep increasing memory usage as it restores the spilled
partitions one by one during the output processing. We should clear the
table after processing each partition.

With this change, the execution time may be less when the input size is
large although it will clear more times(at least 3 more). However, for the
large input, it will save the allocation time and maybe memory capacity
growing (even arbitration) execution time.