### PR TITLE
Extract storeBitsToByte to be reused

### DIFF
--- a/velox/common/base/tests/BitUtilTest.cpp
+++ b/velox/common/base/tests/BitUtilTest.cpp
@@ -853,6 +853,23 @@ TEST_F(BitUtilTest, countLeadingZeros) {
   EXPECT_EQ(
       countLeadingZeros<__uint128_t>(HugeInt::build(0x08FFFFFFFFFFFFFF, 0)), 4);
 }
+
+TEST_F(BitUtilTest, storeBitsToByte) {
+  uint8_t bytes[3]{};
+  storeBitsToByte<8>(0xAA, bytes, 0);
+  ASSERT_EQ(bytes[0], 0xAA);
+  ASSERT_EQ(bytes[1], 0);
+  ASSERT_EQ(bytes[2], 0);
+  storeBitsToByte<4>(0x5, bytes, 8);
+  ASSERT_EQ(bytes[0], 0xAA);
+  ASSERT_EQ(bytes[1], 0x5);
+  ASSERT_EQ(bytes[2], 0);
+  storeBitsToByte<4>(0xA, bytes, 12);
+  ASSERT_EQ(bytes[0], 0xAA);
+  ASSERT_EQ(bytes[1], 0xA5);
+  ASSERT_EQ(bytes[2], 0);
+}
+
 } // namespace bits
 } // namespace velox
 } // namespace facebook

--- a/velox/dwio/common/DecoderUtil.cpp
+++ b/velox/dwio/common/DecoderUtil.cpp
@@ -92,16 +92,7 @@ bool nonNullRowsFromSparse(
     if (isDense(rows.data() + i, width)) {
       uint16_t flags = load8Bits(nulls, rows[i]) & widthMask;
       if (outputNulls) {
-        if constexpr (kStep == 8) {
-          resultNullBytes[i / 8] = flags;
-        } else {
-          VELOX_DCHECK_EQ(kStep, 4);
-          if (i % 8 == 0) {
-            resultNullBytes[i / 8] = flags;
-          } else {
-            resultNullBytes[i / 8] |= flags << 4;
-          }
-        }
+        bits::storeBitsToByte<kStep>(flags, resultNullBytes, i);
         anyNull |= flags != widthMask;
       }
       if (!flags) {
@@ -131,16 +122,7 @@ bool nonNullRowsFromSparse(
       auto next8Rows = xsimd::load_unaligned(rows.data() + i);
       uint16_t flags = simd::gather8Bits(nulls, next8Rows, width);
       if (outputNulls) {
-        if constexpr (kStep == 8) {
-          resultNullBytes[i / 8] = flags;
-        } else {
-          VELOX_DCHECK_EQ(kStep, 4);
-          if (i % 8 == 0) {
-            resultNullBytes[i / 8] = flags;
-          } else {
-            resultNullBytes[i / 8] |= flags << 4;
-          }
-        }
+        bits::storeBitsToByte<kStep>(flags, resultNullBytes, i);
         anyNull |= flags != widthMask;
       }
       if (!flags) {


### PR DESCRIPTION
Summary:
We will need this to fix `simd::gatherBits` for non-AVX cases.

See https://github.com/facebookincubator/velox/pull/8415

Differential Revision: D52837098


