### PR TITLE
Fix aggregation over all-null keys with ignoreNullKeys = true

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -225,6 +225,12 @@ void GroupingSet::addInputForActiveRows(
       "facebook::velox::exec::GroupingSet::addInputForActiveRows", this);
 
   table_->prepareForGroupProbe(*lookup_, input, activeRows_, ignoreNullKeys_);
+  if (lookup_->rows.empty()) {
+    // No rows to probe. Can happen when ignoreNullKeys_ is true and all rows
+    // have null keys.
+    return;
+  }
+
   table_->groupProbe(*lookup_);
   masks_.addInput(input, activeRows_);
 

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -3592,4 +3592,45 @@ TEST_F(AggregationTest, reclaimFromCompletedAggregation) {
   }
 }
 
+TEST_F(AggregationTest, ignoreNullKeys) {
+  // Some keys are null.
+  auto data = makeRowVector({
+      makeNullableFlatVector<int32_t>(
+          {std::nullopt, 1, std::nullopt, 2, std::nullopt, 1, 2}),
+      makeFlatVector<int32_t>({-1, 1, -2, 2, -3, 3, 4}),
+  });
+
+  auto makePlan = [&](bool ignoreNullKeys) {
+    return PlanBuilder()
+        .values({data})
+        .aggregation(
+            {"c0"},
+            {"sum(c1)"},
+            {},
+            core::AggregationNode::Step::kPartial,
+            ignoreNullKeys)
+        .planNode();
+  };
+
+  auto expected = makeRowVector({
+      makeFlatVector<int32_t>({1, 2}),
+      makeFlatVector<int64_t>({4, 6}),
+  });
+  AssertQueryBuilder(makePlan(true)).assertResults(expected);
+
+  expected = makeRowVector({
+      makeNullableFlatVector<int32_t>({std::nullopt, 1, 2}),
+      makeFlatVector<int64_t>({-6, 4, 6}),
+  });
+  AssertQueryBuilder(makePlan(false)).assertResults(expected);
+
+  // All keys are null.
+  data = makeRowVector({
+      makeAllNullFlatVector<int32_t>(3),
+      makeFlatVector<int32_t>({1, 2, 3}),
+  });
+
+  AssertQueryBuilder(makePlan(true)).assertEmptyResults();
+}
+
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary:
Aggregation with ignoreNullKeys = true over dataset with all rows having null keys used to fail:

```
Error Code: INVALID_STATE
Reason: (0 vs. 0)
Retriable: False
Expression: n > 0
Function: incrementProbes
File: buck-out/v2/gen/fbcode/28058b72fcf9a4f4/velox/exec/__velox_exec_lib__/buck-headers/velox/exec/HashTable.h
Line: 861
```

Fixes https://github.com/facebookincubator/velox/issues/8320

Differential Revision: D52850618


