### PR TITLE
Add reverse(varbinary) Presto function

### DIFF
--- a/velox/docs/functions/presto/string.rst
+++ b/velox/docs/functions/presto/string.rst
@@ -102,7 +102,12 @@ String Functions
 .. function:: reverse(string) -> varchar
     :noindex:
 
-    Reverses ``string``.
+    Returns input string with characters in reverse order.
+
+.. function:: reverse(varbinary) -> varbinary
+    :noindex:
+
+    Returns input binary with bytes in reversed order.
 
 .. function:: rpad(string, size, padstring) -> varchar
 

--- a/velox/functions/lib/StringEncodingUtils.h
+++ b/velox/functions/lib/StringEncodingUtils.h
@@ -24,11 +24,14 @@ namespace facebook::velox::functions {
 /// Helper function that prepares a string result vector and initializes it.
 /// It will use the input argToReuse vector instead of creating new one when
 /// possible. Returns true if argToReuse vector was moved to results
+///
+/// @param resultType VARCHAR() or VARBINARY().
 bool prepareFlatResultsVector(
     VectorPtr& result,
     const SelectivityVector& rows,
     exec::EvalCtx& context,
-    VectorPtr& argToReuse);
+    VectorPtr& argToReuse,
+    const TypePtr& resultType = VARCHAR());
 
 /// Return the string encoding of a vector, if not set UTF8 is returned
 static bool isAscii(BaseVector* vector, const SelectivityVector& rows) {


### PR DESCRIPTION
Summary:
Presto 'reverse' function allows 3 types of input: array, varchar and varbinary.
Before this change Velox supported array and varchar inputs, but not
varbinary.

When applied to varchar input, the function returns input string with characters
in reversed order. When applies to varbinary input, the function returns input
binary with bytes in reversed order.

Differential Revision: D52868694


