### PR TITLE
Treat timestamp partition value as local time

### DIFF
--- a/velox/connectors/hive/HiveConnectorUtil.h
+++ b/velox/connectors/hive/HiveConnectorUtil.h
@@ -89,20 +89,4 @@ std::unique_ptr<dwio::common::BufferedInput> createBufferedInput(
     std::shared_ptr<io::IoStatistics> ioStats,
     folly::Executor* executor);
 
-template <TypeKind ToKind>
-velox::variant convertFromString(const std::optional<std::string>& value) {
-  if (value.has_value()) {
-    if constexpr (ToKind == TypeKind::VARCHAR) {
-      return velox::variant(value.value());
-    }
-    if constexpr (ToKind == TypeKind::VARBINARY) {
-      return velox::variant::binary((value.value()));
-    }
-    auto result = velox::util::Converter<ToKind>::cast(value.value());
-
-    return velox::variant(result);
-  }
-  return velox::variant(ToKind);
-}
-
 } // namespace facebook::velox::connector::hive

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -133,6 +133,20 @@ void Timestamp::toTimezone(int16_t tzID) {
   }
 }
 
+const date::time_zone& Timestamp::defaultTimezone() {
+  static const date::time_zone* kDefault = ({
+    // TODO: We are hard-coding PST/PDT here to be aligned with the current
+    // behavior in DWRF reader/writer.  Once they are fixed, we can use
+    // date::current_zone() here.
+    //
+    // See https://github.com/facebookincubator/velox/issues/8127
+    auto* tz = date::locate_zone("America/Los_Angeles");
+    VELOX_CHECK_NOT_NULL(tz);
+    tz;
+  });
+  return *kDefault;
+}
+
 namespace {
 
 constexpr int kTmYearBase = 1900;

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -275,6 +275,9 @@ struct Timestamp {
   // Same as above, but accepts PrestoDB time zone ID.
   void toTimezone(int16_t tzID);
 
+  /// A default time zone that is same across the process.
+  static const date::time_zone& defaultTimezone();
+
   bool operator==(const Timestamp& b) const {
     return seconds_ == b.seconds_ && nanos_ == b.nanos_;
   }


### PR DESCRIPTION
Summary:
The timestamp partition value in Presto is interpreted as local time
instead of UTC.  So we need to add an extra layer of conversion when parsing
them.

Differential Revision: D52875805


