### PR TITLE
Remove gtest dependency for velox_dwio_common_compression

### DIFF
--- a/velox/dwio/common/compression/CMakeLists.txt
+++ b/velox/dwio/common/compression/CMakeLists.txt
@@ -16,4 +16,4 @@ add_library(velox_dwio_common_compression Compression.cpp PagedInputStream.cpp
                                           PagedOutputStream.cpp)
 
 target_link_libraries(velox_dwio_common_compression velox_dwio_common xsimd
-                      gtest Folly::folly)
+                      Folly::folly)


### PR DESCRIPTION
This is causing a Prestissimo build failure when testing is disabled on CentOS8