### PR TITLE
Remove unused variables in velox/tpch/gen/dbgen/speed_seed.cpp

### DIFF
--- a/velox/tpch/gen/dbgen/speed_seed.cpp
+++ b/velox/tpch/gen/dbgen/speed_seed.cpp
@@ -68,10 +68,8 @@ void NthElement(DSS_HUGE N, DSS_HUGE* StartSeed) {
   DSS_HUGE Z;
   DSS_HUGE Mult;
   static int ln = -1;
-  int i;
 
   if ((verbose > 0) && ++ln % 1000 == 0) {
-    i = ln % LN_CNT;
     fprintf(stderr, "%c\b", lnoise[i]);
   }
   Mult = Multiplier;


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: danzimm, meyering

Differential Revision: D52734575


