### PR TITLE
Remove unused variables in velox/functions/lib/DateTimeFormatter.cpp

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -179,7 +179,6 @@ static std::
             {"NOV", {"EMBER", 11}},
             {"DEC", {"EMBER", 12}},
         };
-constexpr int monthsFullLength[] = {7, 8, 5, 5, 3, 4, 4, 6, 9, 7, 8, 8};
 
 // Pads the content with desired padding characters. E.g. if we need to pad 999
 // with three 0s in front, the result will be '000999'.


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: danzimm, meyering

Differential Revision: D52848052


