### PR TITLE
Remove unused function from velox/tpch/gen/dbgen/text.cpp

### DIFF
--- a/velox/tpch/gen/dbgen/text.cpp
+++ b/velox/tpch/gen/dbgen/text.cpp
@@ -65,57 +65,6 @@
 #include "dbgen/dss.h" // @manual
 
 /*
- * txt_vp() --
- *		generate a verb phrase by
- *		1) selecting a verb phrase form
- *		2) parsing it to select parts of speech
- *		3) selecting appropriate words
- *		4) adding punctuation as required
- *
- *	Returns: length of generated phrase
- *	Called By: txt_sentence()
- *	Calls: pick_str()
- */
-static int txt_vp(char* dest, seed_t* seed) {
-  char syntax[MAX_GRAMMAR_LEN + 1], *cptr, *parse_target;
-  distribution* src;
-  int i, res = 0;
-
-  pick_str(&vp, seed, &syntax[0]);
-  parse_target = syntax;
-  while ((cptr = strtok(parse_target, " ")) != NULL) {
-    src = NULL;
-    switch (*cptr) {
-      case 'D':
-        src = &adverbs;
-        break;
-      case 'V':
-        src = &verbs;
-        break;
-      case 'X':
-        src = &auxillaries;
-        break;
-    } /* end of POS switch statement */
-    i = pick_str(src, seed, dest);
-    i = (int)strlen(DIST_MEMBER(src, i));
-    dest += i;
-    res += i;
-    if (*(++cptr)) /* miscelaneous fillagree, like punctuation */
-    {
-      dest += 1;
-      res += 1;
-      *dest = *cptr;
-    }
-    *dest = ' ';
-    dest++;
-    res++;
-    parse_target = NULL;
-  } /* end of while loop */
-
-  return (res);
-}
-
-/*
  * txt_np() --
  *		generate a noun phrase by
  *		1) selecting a noun phrase form


### PR DESCRIPTION
Summary: `-Wunused-function` has identified an unused function. This diff removes it. In many cases these functions have existed for years in an unused state.

Differential Revision: D52846511


