### PR TITLE
Remove unused function from velox/parse/Expressions.cpp

### DIFF
--- a/velox/parse/Expressions.cpp
+++ b/velox/parse/Expressions.cpp
@@ -29,13 +29,6 @@ namespace facebook::velox::core {
 Expressions::TypeResolverHook Expressions::resolverHook_;
 
 namespace {
-std::vector<TypePtr> getTypes(const std::vector<TypedExprPtr>& inputs) {
-  std::vector<TypePtr> types{};
-  for (auto& i : inputs) {
-    types.push_back(i->type());
-  }
-  return types;
-}
 
 // Determine output type based on input types.
 TypePtr resolveTypeImpl(
@@ -85,7 +78,7 @@ std::vector<TypePtr> implicitCastTargets(const TypePtr& type) {
       break;
     }
     default: // make compilers happy
-        ;
+      (void)0; // Statement to avoid empty semicolon warning
   }
   return targetTypes;
 }


### PR DESCRIPTION
Summary: `-Wunused-function` has identified an unused function. This diff removes it. In many cases these functions have existed for years in an unused state.

Differential Revision: D52846489


