### PR TITLE
Remove unused function from velox/functions/FunctionRegistry.cpp

### DIFF
--- a/velox/functions/FunctionRegistry.cpp
+++ b/velox/functions/FunctionRegistry.cpp
@@ -32,19 +32,6 @@
 namespace facebook::velox {
 namespace {
 
-exec::TypeSignature typeToTypeSignature(std::shared_ptr<const Type> type) {
-  std::vector<exec::TypeSignature> children;
-  if (type->size()) {
-    children.reserve(type->size());
-    for (auto i = 0; i < type->size(); i++) {
-      children.emplace_back(typeToTypeSignature(type->childAt(i)));
-    }
-  }
-  const std::string& kindName = type->kindName();
-  return exec::TypeSignature(
-      boost::algorithm::to_lower_copy(kindName), std::move(children));
-}
-
 void populateSimpleFunctionSignatures(FunctionSignatureMap& map) {
   const auto& simpleFunctions = exec::simpleFunctions();
   for (const auto& functionName : simpleFunctions.getFunctionNames()) {


### PR DESCRIPTION
Summary: `-Wunused-function` has identified an unused function. This diff removes it. In many cases these functions have existed for years in an unused state.

Differential Revision: D52846494


