### PR TITLE
Fix invalid write in ensureWritable

### DIFF
--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -448,9 +448,6 @@ void FlatVector<T>::ensureWritable(const SelectivityVector& rows) {
       newValues = AlignedBuffer::allocate<T>(newSize, BaseVector::pool_);
     }
 
-    SelectivityVector rowsToCopy(BaseVector::length_);
-    rowsToCopy.deselect(rows);
-
     if constexpr (std::is_same_v<T, bool>) {
       auto rawNewValues = newValues->asMutable<uint64_t>();
       std::memcpy(
@@ -459,6 +456,8 @@ void FlatVector<T>::ensureWritable(const SelectivityVector& rows) {
           std::min(values_->size(), newValues->size()));
     } else {
       auto rawNewValues = newValues->asMutable<T>();
+      SelectivityVector rowsToCopy(BaseVector::length_);
+      rowsToCopy.deselect(rows);
       rowsToCopy.applyToSelected(
           [&](vector_size_t row) { rawNewValues[row] = rawValues_[row]; });
     }

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -453,7 +453,10 @@ void FlatVector<T>::ensureWritable(const SelectivityVector& rows) {
 
     if constexpr (std::is_same_v<T, bool>) {
       auto rawNewValues = newValues->asMutable<uint64_t>();
-      std::memcpy(rawNewValues, rawValues_, values_->size());
+      std::memcpy(
+          rawNewValues,
+          rawValues_,
+          std::min(values_->size(), newValues->size()));
     } else {
       auto rawNewValues = newValues->asMutable<T>();
       rowsToCopy.applyToSelected(

--- a/velox/vector/tests/EnsureWritableVectorTest.cpp
+++ b/velox/vector/tests/EnsureWritableVectorTest.cpp
@@ -853,8 +853,6 @@ TEST_F(EnsureWritableVectorTest, booleanFlatVector) {
         std::move(value),
         std::vector<BufferPtr>());
 
-    auto origin = vector->asFlatVector<bool>()->values();
-
     // Create rows with a length smaller than the value buffer to ensure that
     // the newly created vector is also smaller.
     SelectivityVector rows{100, true};

--- a/velox/vector/tests/EnsureWritableVectorTest.cpp
+++ b/velox/vector/tests/EnsureWritableVectorTest.cpp
@@ -817,19 +817,18 @@ TEST_F(EnsureWritableVectorTest, allNullMap) {
 }
 
 TEST_F(EnsureWritableVectorTest, booleanFlatVector) {
-  auto testEnsureWritableBoolean =
-      [this](VectorPtr& vector, SelectivityVector& rows) {
-        // Make sure vector::values_ buffer is not uniquely referenced so that
-        // the branch in the FlatVector::ensureWritable() that copy old values
-        // to new buffer is executed.
-        auto another = vector->asFlatVector<bool>()->values();
+  auto testEnsureWritable = [this](VectorPtr& vector, SelectivityVector& rows) {
+    // Make sure vector::values_ buffer is not uniquely referenced so that
+    // the branch in the FlatVector::ensureWritable() that copy old values
+    // to new buffer is executed.
+    auto another = vector->asFlatVector<bool>()->values();
 
-        auto vectorPtr = vector.get();
-        ASSERT_NO_THROW(
-            BaseVector::ensureWritable(rows, BOOLEAN(), pool(), vector));
-        ASSERT_EQ(vectorPtr, vector.get());
-        ASSERT_NE(another->as<void>(), vector->valuesAsVoid());
-      };
+    auto vectorPtr = vector.get();
+    ASSERT_NO_THROW(
+        BaseVector::ensureWritable(rows, BOOLEAN(), pool(), vector));
+    ASSERT_EQ(vectorPtr, vector.get());
+    ASSERT_NE(another->as<void>(), vector->valuesAsVoid());
+  };
 
   {
     VectorPtr vector =
@@ -839,7 +838,7 @@ TEST_F(EnsureWritableVectorTest, booleanFlatVector) {
     rows.setValidRange(16, 32, true);
     rows.updateBounds();
 
-    testEnsureWritableBoolean(vector, rows);
+    testEnsureWritable(vector, rows);
   }
 
   {
@@ -857,7 +856,7 @@ TEST_F(EnsureWritableVectorTest, booleanFlatVector) {
     // the newly created vector is also smaller.
     SelectivityVector rows{100, true};
 
-    testEnsureWritableBoolean(vector, rows);
+    testEnsureWritable(vector, rows);
   }
 }
 

--- a/velox/vector/tests/EnsureWritableVectorTest.cpp
+++ b/velox/vector/tests/EnsureWritableVectorTest.cpp
@@ -817,22 +817,51 @@ TEST_F(EnsureWritableVectorTest, allNullMap) {
 }
 
 TEST_F(EnsureWritableVectorTest, booleanFlatVector) {
-  VectorPtr vector =
-      makeFlatVector<bool>(100, [](auto /*row*/) { return true; });
+  auto testEnsureWritableBoolean =
+      [this](VectorPtr& vector, SelectivityVector& rows, BufferPtr& origin) {
+        auto vectorPtr = vector.get();
+        ASSERT_NO_THROW(
+            BaseVector::ensureWritable(rows, BOOLEAN(), pool(), vector));
+        ASSERT_EQ(vectorPtr, vector.get());
 
-  // Make sure vector::values_ buffer is not uniquely referenced so that the
-  // branch in the FlatVector::ensureWritable() that copy old values to new
-  // buffer is executed.
-  auto another = vector->asFlatVector<bool>()->values();
+        // Make sure vector::values_ buffer is not uniquely referenced so that
+        // the branch in the FlatVector::ensureWritable() that copy old values
+        // to new buffer is executed.
+        ASSERT_NE(origin->as<void>(), vector->valuesAsVoid());
+      };
 
-  SelectivityVector rows{200, false};
-  rows.setValidRange(16, 32, true);
-  rows.updateBounds();
+  {
+    VectorPtr vector =
+        makeFlatVector<bool>(100, [](auto /*row*/) { return true; });
 
-  auto vectorPtr = vector.get();
-  ASSERT_NO_THROW(BaseVector::ensureWritable(rows, BOOLEAN(), pool(), vector));
-  ASSERT_EQ(vectorPtr, vector.get());
-  ASSERT_NE(another->as<void>(), vector->valuesAsVoid());
+    auto origin = vector->asFlatVector<bool>()->values();
+
+    SelectivityVector rows{200, false};
+    rows.setValidRange(16, 32, true);
+    rows.updateBounds();
+
+    testEnsureWritableBoolean(vector, rows, origin);
+  }
+
+  {
+    auto value = AlignedBuffer::allocate<bool>(1000, pool(), true);
+    // Create a FlatVector with a length smaller than the value buffer.
+    VectorPtr vector = std::make_shared<FlatVector<bool>>(
+        pool(),
+        BOOLEAN(),
+        nullptr,
+        100,
+        std::move(value),
+        std::vector<BufferPtr>());
+
+    auto origin = vector->asFlatVector<bool>()->values();
+
+    // Create rows with a length smaller than the value buffer to ensure that
+    // the newly created vector is also smaller.
+    SelectivityVector rows{100, true};
+
+    testEnsureWritableBoolean(vector, rows, origin);
+  }
 }
 
 TEST_F(EnsureWritableVectorTest, dataDependentFlags) {

--- a/velox/vector/tests/EnsureWritableVectorTest.cpp
+++ b/velox/vector/tests/EnsureWritableVectorTest.cpp
@@ -818,29 +818,28 @@ TEST_F(EnsureWritableVectorTest, allNullMap) {
 
 TEST_F(EnsureWritableVectorTest, booleanFlatVector) {
   auto testEnsureWritableBoolean =
-      [this](VectorPtr& vector, SelectivityVector& rows, BufferPtr& origin) {
+      [this](VectorPtr& vector, SelectivityVector& rows) {
+        // Make sure vector::values_ buffer is not uniquely referenced so that
+        // the branch in the FlatVector::ensureWritable() that copy old values
+        // to new buffer is executed.
+        auto another = vector->asFlatVector<bool>()->values();
+
         auto vectorPtr = vector.get();
         ASSERT_NO_THROW(
             BaseVector::ensureWritable(rows, BOOLEAN(), pool(), vector));
         ASSERT_EQ(vectorPtr, vector.get());
-
-        // Make sure vector::values_ buffer is not uniquely referenced so that
-        // the branch in the FlatVector::ensureWritable() that copy old values
-        // to new buffer is executed.
-        ASSERT_NE(origin->as<void>(), vector->valuesAsVoid());
+        ASSERT_NE(another->as<void>(), vector->valuesAsVoid());
       };
 
   {
     VectorPtr vector =
         makeFlatVector<bool>(100, [](auto /*row*/) { return true; });
 
-    auto origin = vector->asFlatVector<bool>()->values();
-
     SelectivityVector rows{200, false};
     rows.setValidRange(16, 32, true);
     rows.updateBounds();
 
-    testEnsureWritableBoolean(vector, rows, origin);
+    testEnsureWritableBoolean(vector, rows);
   }
 
   {
@@ -860,7 +859,7 @@ TEST_F(EnsureWritableVectorTest, booleanFlatVector) {
     // the newly created vector is also smaller.
     SelectivityVector rows{100, true};
 
-    testEnsureWritableBoolean(vector, rows, origin);
+    testEnsureWritableBoolean(vector, rows);
   }
 }
 


### PR DESCRIPTION
In `FlatVector::ensureWritable`, `values_->size()` can be greater than `newValues->size()`, 
leading to a program crash due to invalid memory access.

Fixes #4781 