### PR TITLE
Make parquet writer support parquet.block.size and parquet.block.rows parameters

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -24,7 +24,9 @@ if(VELOX_ENABLE_ARROW)
   else()
     set(THRIFT_SOURCE "BUNDLED")
   endif()
-  set(ARROW_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/arrow_ep")
+  set(ARROW_PREFIX
+      "${CMAKE_CURRENT_BINARY_DIR}/arrow_ep"
+      CACHE INTERNAL "arrow prefix")
   set(ARROW_CMAKE_ARGS
       -DARROW_PARQUET=OFF
       -DARROW_WITH_THRIFT=ON
@@ -49,7 +51,9 @@ if(VELOX_ENABLE_ARROW)
     set(THRIFT_LIB ${THRIFT_ROOT}/lib/libthrift.a)
 
     file(MAKE_DIRECTORY ${THRIFT_ROOT}/include)
-    set(THRIFT_INCLUDE_DIR ${THRIFT_ROOT}/include)
+    set(THRIFT_INCLUDE_DIR
+        ${THRIFT_ROOT}/include
+        CACHE INTERNAL "thrift include dir")
   endif()
 
   set_property(TARGET thrift PROPERTY INTERFACE_INCLUDE_DIRECTORIES

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -51,9 +51,7 @@ if(VELOX_ENABLE_ARROW)
     set(THRIFT_LIB ${THRIFT_ROOT}/lib/libthrift.a)
 
     file(MAKE_DIRECTORY ${THRIFT_ROOT}/include)
-    set(THRIFT_INCLUDE_DIR
-        ${THRIFT_ROOT}/include
-        CACHE INTERNAL "thrift include dir")
+    set(THRIFT_INCLUDE_DIR ${THRIFT_ROOT}/include)
   endif()
 
   set_property(TARGET thrift PROPERTY INTERFACE_INCLUDE_DIRECTORIES

--- a/third_party/cmake_modules/FindThrift.cmake
+++ b/third_party/cmake_modules/FindThrift.cmake
@@ -99,7 +99,9 @@ else()
   find_package(PkgConfig QUIET)
   pkg_check_modules(THRIFT_PC thrift)
   if(THRIFT_PC_FOUND)
-    set(THRIFT_INCLUDE_DIR "${THRIFT_PC_INCLUDEDIR}")
+    set(THRIFT_INCLUDE_DIR
+        "${THRIFT_PC_INCLUDEDIR}"
+        CACHE INTERNAL "thrift include dir")
 
     list(APPEND THRIFT_PC_LIBRARY_DIRS "${THRIFT_PC_LIBDIR}")
 

--- a/third_party/cmake_modules/FindThrift.cmake
+++ b/third_party/cmake_modules/FindThrift.cmake
@@ -99,9 +99,7 @@ else()
   find_package(PkgConfig QUIET)
   pkg_check_modules(THRIFT_PC thrift)
   if(THRIFT_PC_FOUND)
-    set(THRIFT_INCLUDE_DIR
-        "${THRIFT_PC_INCLUDEDIR}"
-        CACHE INTERNAL "thrift include dir")
+    set(THRIFT_INCLUDE_DIR "${THRIFT_PC_INCLUDEDIR}")
 
     list(APPEND THRIFT_PC_LIBRARY_DIRS "${THRIFT_PC_LIBDIR}")
 

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -204,6 +204,21 @@ uint64_t HiveConfig::orcWriterMaxDictionaryMemory(const Config* session) const {
   return 16L * 1024L * 1024L;
 }
 
+uint64_t HiveConfig::parquetWriterMaxBlockSizeSession(
+    const Config* session) const {
+  if (session->isValueExists(kParquetWriterMaxBlockSizeSession)) {
+    return toCapacity(
+        session->get<std::string>(kParquetWriterMaxBlockSizeSession).value(),
+        core::CapacityUnit::BYTE);
+  }
+  return 128L * 1024L * 1024L;
+}
+
+uint32_t HiveConfig::parquetWriterMaxBlockRowsSession(
+    const Config* session) const {
+  return config_->get<int32_t>(kParquetWriterMaxBlockRowsSession, 1024 * 1024);
+}
+
 std::string HiveConfig::writeFileCreateConfig() const {
   return config_->get<std::string>(kWriteFileCreateConfig, "");
 }

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -211,11 +211,21 @@ uint64_t HiveConfig::parquetWriterMaxBlockSizeSession(
         session->get<std::string>(kParquetWriterMaxBlockSizeSession).value(),
         core::CapacityUnit::BYTE);
   }
+  if (config_->isValueExists(kParquetWriterMaxBlockSizeSession)) {
+    return toCapacity(
+        config_->get<std::string>(kParquetWriterMaxBlockSizeSession).value(),
+        core::CapacityUnit::BYTE);
+  }
   return 128L * 1024L * 1024L;
 }
 
 int32_t HiveConfig::parquetWriterMaxBlockRowsSession(
     const Config* session) const {
+  if (session->isValueExists(kParquetWriterMaxBlockRowsSession)) {
+    return session->get<int32_t>(
+        kParquetWriterMaxBlockRowsSession, 1024 * 1024);
+  }
+
   return config_->get<int32_t>(kParquetWriterMaxBlockRowsSession, 1024 * 1024);
 }
 

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -214,7 +214,7 @@ uint64_t HiveConfig::parquetWriterMaxBlockSizeSession(
   return 128L * 1024L * 1024L;
 }
 
-uint32_t HiveConfig::parquetWriterMaxBlockRowsSession(
+int32_t HiveConfig::parquetWriterMaxBlockRowsSession(
     const Config* session) const {
   return config_->get<int32_t>(kParquetWriterMaxBlockRowsSession, 1024 * 1024);
 }

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -154,6 +154,11 @@ class HiveConfig {
   static constexpr const char* kOrcWriterMaxDictionaryMemorySession =
       "orc_optimized_writer_max_dictionary_memory";
 
+  static constexpr const char* kParquetWriterMaxBlockSizeSession =
+      "parquet_optimized_writer_max_block_size";
+  static constexpr const char* kParquetWriterMaxBlockRowsSession =
+      "parquet_optimized_writer_max_block_rows";
+
   /// Config used to create write files. This config is provided to underlying
   /// file system through hive connector and data sink. The config is free form.
   /// The form should be defined by the underlying file system.
@@ -226,6 +231,10 @@ class HiveConfig {
   uint64_t orcWriterMaxStripeSize(const Config* session) const;
 
   uint64_t orcWriterMaxDictionaryMemory(const Config* session) const;
+
+  uint64_t parquetWriterMaxBlockSizeSession(const Config* session) const;
+
+  uint32_t parquetWriterMaxBlockRowsSession(const Config* session) const;
 
   std::string writeFileCreateConfig() const;
 

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -154,6 +154,7 @@ class HiveConfig {
   static constexpr const char* kOrcWriterMaxDictionaryMemorySession =
       "orc_optimized_writer_max_dictionary_memory";
 
+  /// Maximum block size and rows in parquet writer.
   static constexpr const char* kParquetWriterMaxBlockSizeSession =
       "parquet_optimized_writer_max_block_size";
   static constexpr const char* kParquetWriterMaxBlockRowsSession =
@@ -234,7 +235,7 @@ class HiveConfig {
 
   uint64_t parquetWriterMaxBlockSizeSession(const Config* session) const;
 
-  uint32_t parquetWriterMaxBlockRowsSession(const Config* session) const;
+  int32_t parquetWriterMaxBlockRowsSession(const Config* session) const;
 
   std::string writeFileCreateConfig() const;
 

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -675,6 +675,12 @@ uint32_t HiveDataSink::appendWriter(const HiveWriterId& id) {
       hiveConfig_->orcWriterMaxStripeSize(connectorSessionProperties));
   options.maxDictionaryMemory = std::optional(
       hiveConfig_->orcWriterMaxDictionaryMemory(connectorSessionProperties));
+  options.maxBlockRows =
+      std::optional(hiveConfig_->parquetWriterMaxBlockRowsSession(
+          connectorSessionProperties));
+  options.maxBlockSize =
+      std::optional(hiveConfig_->parquetWriterMaxBlockSizeSession(
+          connectorSessionProperties));
   ioStats_.emplace_back(std::make_shared<io::IoStatistics>());
 
   // Prevents the memory allocation during the writer creation.

--- a/velox/connectors/hive/tests/CMakeLists.txt
+++ b/velox/connectors/hive/tests/CMakeLists.txt
@@ -35,3 +35,23 @@ target_link_libraries(
   velox_exec_test_lib
   gtest
   gtest_main)
+
+if(VELOX_ENABLE_PARQUET)
+
+  target_include_directories(
+    velox_hive_connector_test PUBLIC ${ARROW_PREFIX}/install/include
+                                     ${THRIFT_INCLUDE_DIR})
+  target_link_libraries(
+    velox_hive_connector_test
+    velox_dwio_native_parquet_reader
+    velox_hive_connector
+    velox_hive_partition_function
+    velox_dwio_common_exception
+    velox_vector_fuzzer
+    velox_vector_test_lib
+    velox_exec
+    velox_exec_test_lib
+    gtest
+    gtest_main)
+
+endif()

--- a/velox/connectors/hive/tests/CMakeLists.txt
+++ b/velox/connectors/hive/tests/CMakeLists.txt
@@ -39,8 +39,7 @@ target_link_libraries(
 if(VELOX_ENABLE_PARQUET)
 
   target_include_directories(
-    velox_hive_connector_test PUBLIC ${ARROW_PREFIX}/install/include
-                                     ${THRIFT_INCLUDE_DIR})
+    velox_hive_connector_test PUBLIC ${ARROW_PREFIX}/install/include)
   target_link_libraries(
     velox_hive_connector_test
     velox_dwio_native_parquet_reader

--- a/velox/connectors/hive/tests/CMakeLists.txt
+++ b/velox/connectors/hive/tests/CMakeLists.txt
@@ -38,8 +38,8 @@ target_link_libraries(
 
 if(VELOX_ENABLE_PARQUET)
 
-  target_include_directories(
-    velox_hive_connector_test PUBLIC ${ARROW_PREFIX}/install/include)
+  target_include_directories(velox_hive_connector_test
+                             PUBLIC ${ARROW_PREFIX}/install/include)
   target_link_libraries(
     velox_hive_connector_test
     velox_dwio_native_parquet_reader

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -61,6 +61,12 @@ TEST(HiveConfigTest, defaultConfig) {
   ASSERT_EQ(
       hiveConfig->sortWriterMaxOutputBytes(emptySession.get()), 10UL << 20);
   ASSERT_EQ(hiveConfig->isPartitionPathAsLowerCase(emptySession.get()), true);
+  ASSERT_EQ(
+      hiveConfig->parquetWriterMaxBlockSizeSession(emptySession.get()),
+      128L * 1024L * 1024L);
+  ASSERT_EQ(
+      hiveConfig->parquetWriterMaxBlockRowsSession(emptySession.get()),
+      1024 * 1024);
 }
 
 TEST(HiveConfigTest, overrideConfig) {
@@ -137,6 +143,8 @@ TEST(HiveConfigTest, overrideSession) {
       {HiveConfig::kFileColumnNamesReadAsLowerCaseSession, "true"},
       {HiveConfig::kOrcWriterMaxStripeSizeSession, "22MB"},
       {HiveConfig::kOrcWriterMaxDictionaryMemorySession, "22MB"},
+      {HiveConfig::kParquetWriterMaxBlockRowsSession, "20"},
+      {HiveConfig::kParquetWriterMaxBlockSizeSession, "22MB"},
       {HiveConfig::kSortWriterMaxOutputRowsSession, "20"},
       {HiveConfig::kSortWriterMaxOutputBytesSession, "20MB"},
       {HiveConfig::kPartitionPathAsLowerCaseSession, "false"}};
@@ -174,4 +182,8 @@ TEST(HiveConfigTest, overrideSession) {
   ASSERT_EQ(hiveConfig->sortWriterMaxOutputRows(session.get()), 20);
   ASSERT_EQ(hiveConfig->sortWriterMaxOutputBytes(session.get()), 20UL << 20);
   ASSERT_EQ(hiveConfig->isPartitionPathAsLowerCase(session.get()), false);
+  ASSERT_EQ(
+      hiveConfig->parquetWriterMaxBlockSizeSession(session.get()),
+      22L * 1024L * 1024L);
+  ASSERT_EQ(hiveConfig->parquetWriterMaxBlockRowsSession(session.get()), 20);
 }

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -483,6 +483,16 @@ Each query can override the config by setting corresponding query session proper
      - string
      - 16M
      - Maximum dictionary memory that can be used in orc writer.
+   * - parquet_optimized_writer_max_block_size
+     - 
+     - string
+     - 128MB
+     - Maximum block size in parquet writer.
+   * - parquet_optimized_writer_max_block_rows
+     - 
+     - integer
+     - 1024KB
+     - Maximum block rows in parquet writer.
 
 ``Amazon S3 Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -564,6 +564,8 @@ struct WriterOptions {
   std::optional<uint64_t> maxStripeSize{std::nullopt};
   std::optional<uint64_t> maxDictionaryMemory{std::nullopt};
   std::map<std::string, std::string> serdeParameters;
+  std::optional<uint64_t> maxBlockRows{std::nullopt};
+  std::optional<uint64_t> maxBlockSize{std::nullopt};
 };
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -565,7 +565,7 @@ struct WriterOptions {
   std::optional<uint64_t> maxDictionaryMemory{std::nullopt};
   std::map<std::string, std::string> serdeParameters;
   std::optional<uint64_t> maxBlockRows{std::nullopt};
-  std::optional<uint64_t> maxBlockSize{std::nullopt};
+  std::optional<uint32_t> maxBlockSize{std::nullopt};
 };
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -564,8 +564,8 @@ struct WriterOptions {
   std::optional<uint64_t> maxStripeSize{std::nullopt};
   std::optional<uint64_t> maxDictionaryMemory{std::nullopt};
   std::map<std::string, std::string> serdeParameters;
-  std::optional<uint64_t> maxBlockRows{std::nullopt};
-  std::optional<uint32_t> maxBlockSize{std::nullopt};
+  std::optional<uint32_t> maxBlockRows{1'024 * 1'024};
+  std::optional<uint64_t> maxBlockSize{128 * 1'024 * 1'024};
 };
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -386,6 +386,16 @@ parquet::WriterOptions getParquetOptions(
   if (options.compressionKind.has_value()) {
     parquetOptions.compression = options.compressionKind.value();
   }
+
+  if (options.maxBlockSize.has_value() && options.maxBlockRows.has_value()) {
+    parquetOptions.flushPolicyFactory = [&]() {
+      return std::make_unique<velox::parquet::LambdaFlushPolicy>(
+          options.maxBlockRows.value(), options.maxBlockSize.value(), [&]() {
+            return false;
+          });
+    };
+  }
+
   return parquetOptions;
 }
 

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -387,7 +387,7 @@ parquet::WriterOptions getParquetOptions(
     parquetOptions.compression = options.compressionKind.value();
   }
 
-  if (options.maxBlockSize.has_value() && options.maxBlockRows.has_value()) {
+  if (options.maxBlockSize.has_value() || options.maxBlockRows.has_value()) {
     parquetOptions.flushPolicyFactory = [&]() {
       return std::make_unique<velox::parquet::LambdaFlushPolicy>(
           options.maxBlockRows.value(), options.maxBlockSize.value(), [&]() {


### PR DESCRIPTION
Spark respects the `parquet.block.rows` and `parquet.block.size` parameters when writing Parquet files. However, Velox currently does not support these parameters when HiveDataSink creates Parquet writer [here](https://github.com/facebookincubator/velox/blob/main/velox/connectors/hive/HiveDataSink.cpp#L686). To address this limitation, we have introduced the `kParquetWriterMaxBlockSizeSession `and `kParquetWriterMaxBlockRowsSession `parameters in this PR to provide support for controlling the maximum block size and number of rows in Velox's Parquet writer.