### PR TITLE
Add support for UNKNOWN key to map_agg Presto aggregate function

### DIFF
--- a/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
@@ -150,7 +150,7 @@ class MapAggAggregate : public MapAggregateBase<K> {
 void registerMapAggAggregate(const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
-          .knownTypeVariable("K")
+          .typeVariable("K")
           .typeVariable("V")
           .returnType("map(K,V)")
           .intermediateType("map(K,V)")

--- a/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
@@ -365,6 +365,30 @@ TEST_F(MapAggTest, selectiveMaskWithDuplicates) {
   assertQuery(plan, {expectedResult});
 }
 
+TEST_F(MapAggTest, unknownKey) {
+  auto data = makeRowVector({
+      makeFlatVector<int8_t>({1, 2, 1, 2, 1, 2, 1, 2, 1, 2}),
+      makeAllNullFlatVector<UnknownValue>(10),
+      makeConstant<int32_t>(123, 10),
+  });
+
+  testAggregations(
+      {data},
+      {"c0"},
+      {"map_agg(c1, c2)"},
+      "VALUES (1, NULL), (2, NULL)",
+      {},
+      false /*testWithTableScan*/);
+
+  testAggregations(
+      {data},
+      {},
+      {"map_agg(c1, c2)"},
+      "VALUES (NULL)",
+      {},
+      false /*testWithTableScan*/);
+}
+
 TEST_F(MapAggTest, stringLifeCycle) {
   vector_size_t num = 10;
   std::vector<std::string> s(num);


### PR DESCRIPTION
Summary: Presto aggregation function map_agg(key, value) allows keys of UNKNOWN type.

Differential Revision: D52906716


