### PR TITLE
Fix json_parse for large number

### DIFF
--- a/CMake/resolve_dependency_modules/simdjson.cmake
+++ b/CMake/resolve_dependency_modules/simdjson.cmake
@@ -13,9 +13,9 @@
 # limitations under the License.
 include_guard(GLOBAL)
 
-set(VELOX_SIMDJSON_VERSION 3.1.5)
+set(VELOX_SIMDJSON_VERSION 3.2.0)
 set(VELOX_SIMDJSON_BUILD_SHA256_CHECKSUM
-    5b916be17343324426fc467a4041a30151e481700d60790acfd89716ecc37076)
+    75a684dbbe38cf72b8b3bdbdc430764813f3615899a6029931c26ddd89812da4)
 set(VELOX_SIMDJSON_SOURCE_URL
     "https://github.com/simdjson/simdjson/archive/refs/tags/v${VELOX_SIMDJSON_VERSION}.tar.gz"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -450,7 +450,7 @@ if(${VELOX_BUILD_PYTHON_PACKAGE})
 endif()
 
 set_source(simdjson)
-resolve_dependency(simdjson 3.1.5)
+resolve_dependency(simdjson)
 
 # Locate or build folly.
 add_compile_definitions(FOLLY_HAVE_INT128_T=1)

--- a/velox/functions/prestosql/tests/JsonCastTest.cpp
+++ b/velox/functions/prestosql/tests/JsonCastTest.cpp
@@ -810,6 +810,11 @@ TEST_F(JsonCastTest, toInteger) {
       {"\"NaN\""_sv},
       "The JSON element does not have the requested type");
   testThrow<JsonNativeType>(JSON(), TINYINT(), {""_sv}, "no JSON found");
+  testThrow<JsonNativeType>(
+      JSON(),
+      BIGINT(),
+      {"233897314173811950000"_sv},
+      "Problem while parsing a number");
 }
 
 TEST_F(JsonCastTest, toDouble) {
@@ -827,6 +832,7 @@ TEST_F(JsonCastTest, toDouble) {
        R"("-Infinity")"_sv,
        R"("NaN")"_sv,
        R"("-NaN")"_sv,
+       "233897314173811950000"_sv,
        std::nullopt},
       {1.1,
        2.0001,
@@ -839,6 +845,7 @@ TEST_F(JsonCastTest, toDouble) {
        -HUGE_VAL,
        std::numeric_limits<double>::quiet_NaN(),
        std::numeric_limits<double>::quiet_NaN(),
+       233897314173811950000.0,
        std::nullopt});
   testCast<JsonNativeType, double>(
       JSON(),
@@ -936,6 +943,10 @@ TEST_F(JsonCastTest, toArray) {
       {std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt});
 
   testCast(JSON(), ARRAY(BIGINT()), data, expected);
+
+  data = makeNullableFlatVector<JsonNativeType>({"[233897314173811950000]"_sv});
+  expected = makeArrayVector<double>({{233897314173811950000.0}});
+  testCast(JSON(), ARRAY(DOUBLE()), data, expected);
 }
 
 TEST_F(JsonCastTest, toMap) {

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -202,6 +202,10 @@ TEST_F(JsonFunctionsTest, jsonParse) {
   VELOX_ASSERT_THROW(
       jsonParse(R"({:"k1"})"), "The JSON document has an improper structure");
   VELOX_ASSERT_THROW(jsonParse(R"(not_json)"), "Problem while parsing an atom");
+  VELOX_ASSERT_THROW(
+      jsonParse("[1"),
+      "JSON document ended early in the middle of an object or array");
+  VELOX_ASSERT_THROW(jsonParse(""), "no JSON found");
 
   EXPECT_EQ(jsonParseWithTry(R"(not_json)"), std::nullopt);
   EXPECT_EQ(jsonParseWithTry(R"({"k1":})"), std::nullopt);
@@ -224,7 +228,7 @@ TEST_F(JsonFunctionsTest, jsonParse) {
 
   VELOX_ASSERT_THROW(
       evaluate("json_parse(c0)", data),
-      "missing or superfluous commas, braces, missing keys, etc.");
+      "Unexpected trailing content in the JSON input");
 
   data = makeRowVector({makeFlatVector<StringView>(
       {R"("This is a long sentence")", R"("This is some other sentence")"})});
@@ -239,6 +243,17 @@ TEST_F(JsonFunctionsTest, jsonParse) {
   result = evaluate("json_parse(c0)", data);
   expected = makeFlatVector<StringView>({{R"("apple")", R"("apple")"}}, JSON());
 
+  velox::test::assertEqualVectors(expected, result);
+
+  data = makeRowVector({makeFlatVector<StringView>({"233897314173811950000"})});
+  result = evaluate("json_parse(c0)", data);
+  expected = makeFlatVector<StringView>({{"233897314173811950000"}}, JSON());
+  velox::test::assertEqualVectors(expected, result);
+
+  data =
+      makeRowVector({makeFlatVector<StringView>({"[233897314173811950000]"})});
+  result = evaluate("json_parse(c0)", data);
+  expected = makeFlatVector<StringView>({{"[233897314173811950000]"}}, JSON());
   velox::test::assertEqualVectors(expected, result);
 
   data = makeRowVector(

--- a/velox/functions/prestosql/types/JsonType.cpp
+++ b/velox/functions/prestosql/types/JsonType.cpp
@@ -524,8 +524,7 @@ simdjson::simdjson_result<T> fromString(const std::string_view& s) {
 // following cases are supported:
 //
 // Signed Integer -> Signed Integer
-// Unsigned Integer -> Unsigned Integer
-// Signed Integer / Float / Double -> Float/Double
+// Float | Double -> Float | Double | Signed Integer
 template <typename To, typename From>
 simdjson::error_code convertIfInRange(From x, exec::GenericWriter& writer) {
   static_assert(std::is_signed_v<From> && std::is_signed_v<To>);
@@ -891,8 +890,8 @@ struct CastFromJsonTypedImpl {
     SIMDJSON_ASSIGN_OR_RAISE(auto type, value.type());
     switch (type) {
       case simdjson::ondemand::json_type::number: {
-        SIMDJSON_ASSIGN_OR_RAISE(auto num, value.get_number());
-        return convertIfInRange<T>(num.as_double(), writer);
+        SIMDJSON_ASSIGN_OR_RAISE(auto num, value.get_double());
+        return convertIfInRange<T>(num, writer);
       }
       case simdjson::ondemand::json_type::boolean: {
         writer.castTo<T>() = value.get_bool();


### PR DESCRIPTION
Summary:
When the number is well-formated but outside the range of int64, we
still allow such cases in `json_parse` so that we can cast them to floating
point numbers later.  This is achieved by replacing the DOM parser with a tree
walk visitor with on-demand parser.  Also relax the corresponding number parsing
in JSON cast.

Fix https://github.com/facebookincubator/velox/issues/8066

Differential Revision: D52888389


