### PR TITLE
Support SparkSQL decode and encode functions

### DIFF
--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -307,3 +307,19 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
     Returns string with all characters changed to uppercase. ::
 
         SELECT upper('SparkSql'); -- SPARKSQL
+
+.. spark:function:: decode(bin, charset) -> varchar
+
+    Decodes the binary into a string using the provided charset.
+    Supported charsets: UTF-8, UTF-16, UTF-16BE, UTF-16LE, ISO-8859-1, US-ASCII.
+    Throws VeloxUserError for conversion errors. ::
+
+        SELECT decode('48656C6C6F20576F726C64', "utf-8"); -- "Hello World"
+
+.. spark:function:: encode(string, charset) -> varbinary
+
+    Encodes the string into a binary representation using the provided charset.
+    Supported charsets: UTF-8, UTF-16, UTF-16BE, UTF-16LE, ISO-8859-1, US-ASCII.
+    Throws VeloxUserError for conversion errors. ::
+
+        SELECT decode('Hello World', "utf-8"); -- "48656C6C6F20576F726C64"

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -264,6 +264,11 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<ConvFunction, Varchar, Varchar, int32_t, int32_t>(
       {prefix + "conv"});
 
+  registerFunction<sparksql::DecodeFunction, Varchar, Varbinary, Varchar>(
+      {prefix + "decode"});
+  registerFunction<sparksql::EncodeFunction, Varbinary, Varchar, Varchar>(
+      {prefix + "encode"});
+
   registerFunction<ReplaceFunction, Varchar, Varchar, Varchar>(
       {prefix + "replace"});
   registerFunction<ReplaceFunction, Varchar, Varchar, Varchar, Varchar>(


### PR DESCRIPTION
Draft PR for SparkSQL encode and decode.

Needs testing on big endian systems. Seeing weird behavior on...
```
Architecture:            x86_64
  CPU op-mode(s):        32-bit, 64-bit
  Address sizes:         46 bits physical, 57 bits virtual
  Byte Order:            Little Endian
CPU(s):                  144
  On-line CPU(s) list:   0-143
Vendor ID:               GenuineIntel
  Model name:            Intel(R) Xeon(R) Platinum 8360Y CPU @ 2.40GHz
.....
PRETTY_NAME="Ubuntu 22.04.2 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.2 LTS (Jammy Jellyfish)
```
Where endianness is properly detected but output of wstring_convert appears to be BE. 

Code also needs some cleanup. When endianness is resolved and code is cleaned will convert from draft.
