### PR TITLE
Add TableScan::curStatus_ to track down where TableScan is stuck.

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -978,9 +978,9 @@ std::string Driver::toJsonString() const {
   folly::dynamic operatorsObj = folly::dynamic::object;
   int index = 0;
   for (auto& op : operators_) {
-    operatorsObj[std::to_string(index++)] = op->toString();
+    operatorsObj[std::to_string(index++)] = op->toJsonString();
   }
-  obj["operatorsObj"] = operatorsObj;
+  obj["operators"] = operatorsObj;
 
   return folly::toPrettyJson(obj);
 }

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -458,6 +458,11 @@ class Operator : public BaseRuntimeStatWriter {
 
   virtual std::string toString() const;
 
+  /// Used in debug ednpoints.
+  virtual std::string toJsonString() const {
+    return toString();
+  }
+
   velox::memory::MemoryPool* pool() const {
     return operatorCtx_->pool();
   }

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -53,17 +53,28 @@ TableScan::TableScan(
   connector_ = connector::getConnector(tableHandle_->connectorId());
 }
 
+std::string TableScan::toJsonString() const {
+  auto ret = SourceOperator::toJsonString();
+  ret += ", status: ";
+  ret += curStatus_;
+  return ret;
+}
+
 RowVectorPtr TableScan::getOutput() {
+  auto exitCurStatusGuard = folly::makeGuard([this]() { curStatus_ = ""; });
+
   if (noMoreSplits_) {
     return nullptr;
   }
 
+  curStatus_ = "getOutput: enter";
   const auto startTimeMs = getCurrentTimeMs();
   for (;;) {
     if (needNewSplit_) {
       // Check if our Task needs us to yield or we've been running for too long
       // w/o producing a result. In this case we return with the Yield blocking
       // reason and an already fulfilled future.
+      curStatus_ = "getOutput: task->shouldStop";
       if (this->driverCtx_->task->shouldStop() != StopReason::kNone or
           (getOutputTimeLimitMs_ != 0 and
            (getCurrentTimeMs() - startTimeMs) >= getOutputTimeLimitMs_)) {
@@ -79,6 +90,7 @@ RowVectorPtr TableScan::getOutput() {
       TestValue::adjust("facebook::velox::exec::TableScan::getOutput", this);
 
       exec::Split split;
+      curStatus_ = "getOutput: task->getSplitOrFuture";
       blockingReason_ = driverCtx_->task->getSplitOrFuture(
           driverCtx_->splitGroupId,
           planNodeId(),
@@ -94,6 +106,7 @@ RowVectorPtr TableScan::getOutput() {
         noMoreSplits_ = true;
         pendingDynamicFilters_.clear();
         if (dataSource_) {
+          curStatus_ = "getOutput: noMoreSplits_=1, updating stats_";
           auto connectorStats = dataSource_->runtimeStats();
           auto lockedStats = stats_.wlock();
           for (const auto& [name, counter] : connectorStats) {
@@ -123,6 +136,7 @@ RowVectorPtr TableScan::getOutput() {
           "Got splits with different connector IDs");
 
       if (!dataSource_) {
+        curStatus_ = "getOutput: creating dataSource_";
         connectorQueryCtx_ = operatorCtx_->createConnectorQueryCtx(
             connectorSplit->connectorId, planNodeId(), connectorPool_);
         dataSource_ = connector_->createDataSource(
@@ -147,6 +161,7 @@ RowVectorPtr TableScan::getOutput() {
            &debugString_});
 
       if (connectorSplit->dataSource) {
+        curStatus_ = "getOutput: preloaded split";
         ++numPreloadedSplits_;
         // The AsyncSource returns a unique_ptr to a shared_ptr. The
         // unique_ptr will be nullptr if there was a cancellation.
@@ -161,10 +176,13 @@ RowVectorPtr TableScan::getOutput() {
         }
         dataSource_->setFromDataSource(std::move(preparedDataSource));
       } else {
+        curStatus_ = "getOutput: adding split";
         dataSource_->addSplit(connectorSplit);
       }
+      curStatus_ = "getOutput: updating stats_.numSplits";
       ++stats_.wlock()->numSplits;
 
+      curStatus_ = "getOutput: dataSource_->estimatedRowSize";
       auto estimatedRowSize = dataSource_->estimatedRowSize();
       readBatchSize_ =
           estimatedRowSize == connector::DataSource::kUnknownRowSize
@@ -175,6 +193,7 @@ RowVectorPtr TableScan::getOutput() {
     const auto ioTimeStartMicros = getCurrentTimeMicro();
     // Check for  cancellation since scans that filter everything out will not
     // hit the check in Driver.
+    curStatus_ = "getOutput: task->isCancelled";
     if (operatorCtx_->task()->isCancelled()) {
       return nullptr;
     }
@@ -190,10 +209,13 @@ RowVectorPtr TableScan::getOutput() {
           maxReadBatchSize_,
           static_cast<int>(readBatchSize / maxFilteringRatio_));
     }
+    curStatus_ = "getOutput: dataSource_->next";
     auto dataOptional = dataSource_->next(readBatchSize, blockingFuture_);
+    curStatus_ = "getOutput: checkPreload";
     checkPreload();
 
     {
+      curStatus_ = "getOutput: updating stats_.dataSourceWallNanos";
       auto lockedStats = stats_.wlock();
       lockedStats->addRuntimeStat(
           "dataSourceWallNanos",
@@ -206,6 +228,7 @@ RowVectorPtr TableScan::getOutput() {
         return nullptr;
       }
 
+      curStatus_ = "getOutput: updating stats_.rawInput";
       lockedStats->rawInputPositions = dataSource_->getCompletedRows();
       lockedStats->rawInputBytes = dataSource_->getCompletedBytes();
       auto data = dataOptional.value();
@@ -224,6 +247,7 @@ RowVectorPtr TableScan::getOutput() {
     }
 
     {
+      curStatus_ = "getOutput: updating stats_.preloadedSplits";
       auto lockedStats = stats_.wlock();
       if (numPreloadedSplits_ > 0) {
         lockedStats->addRuntimeStat(
@@ -237,6 +261,7 @@ RowVectorPtr TableScan::getOutput() {
       }
     }
 
+    curStatus_ = "getOutput: task->splitFinished";
     driverCtx_->task->splitFinished();
     needNewSplit_ = true;
   }

--- a/velox/exec/TableScan.h
+++ b/velox/exec/TableScan.h
@@ -27,6 +27,8 @@ class TableScan : public SourceOperator {
       DriverCtx* driverCtx,
       std::shared_ptr<const core::TableScanNode> tableScanNode);
 
+  std::string toJsonString() const override;
+
   RowVectorPtr getOutput() override;
 
   BlockingReason isBlocked(ContinueFuture* future) override {
@@ -116,6 +118,10 @@ class TableScan : public SourceOperator {
 
   // String shown in ExceptionContext inside DataSource and LazyVector loading.
   std::string debugString_;
+
+  // Holds the current status of the operator. Used when debugging to understand
+  // what operator is doing.
+  std::atomic<const char*> curStatus_{""};
 
   // The last value of the IO wait time of 'this' that has been added to the
   // global static 'ioWaitNanos_'.


### PR DESCRIPTION
Summary:
Ovserving weird cases of driver threads getting stuck in
TableScan::getOutput() - we can see that from debug endpoints.
No further details, no tool can give us a call stack.
So, adding TableScan::curStatus_ to get more information on this.

Differential Revision: D52921486


