### PR TITLE
Enhance empty file handling

### DIFF
--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -361,7 +361,7 @@ class RowReaderOptions {
     skipRows_ = skipRows;
   }
 
-  bool getSkipRows() const {
+  uint64_t getSkipRows() const {
     return skipRows_;
   }
 


### PR DESCRIPTION
Summary:
Enhance empty file handling especially for empty files with headers by
checking if the reader actually reads
nothing.
1. The current implementation checks if `pos_` is `0` which does not
cover the case when a header is present in the file.
2. When `skipLine()` returns true the loop should not be broken as
logic like elements counting and null setting still yet to happen.

Differential Revision: D52929853


