### PR TITLE
Use Status as return type for rescaleWithRoundUp

### DIFF
--- a/velox/functions/sparksql/specialforms/DecimalRound.cpp
+++ b/velox/functions/sparksql/specialforms/DecimalRound.cpp
@@ -91,15 +91,16 @@ class DecimalRoundFunction : public exec::VectorFunction {
  private:
   inline TResult applyRound(const TInput& input) const {
     if (scale_ >= 0) {
-      const auto rescaledValue =
-          DecimalUtil::rescaleWithRoundUp<TInput, TResult>(
-              input,
-              inputPrecision_,
-              inputScale_,
-              resultPrecision_,
-              resultScale_);
-      VELOX_DCHECK(rescaledValue.has_value());
-      return rescaledValue.value();
+      TResult rescaledValue;
+      const auto status = DecimalUtil::rescaleWithRoundUp<TInput, TResult>(
+          input,
+          inputPrecision_,
+          inputScale_,
+          resultPrecision_,
+          resultScale_,
+          rescaledValue);
+      VELOX_DCHECK(status.ok());
+      return rescaledValue;
     } else {
       TResult rescaledValue;
       DecimalUtil::divideWithRoundUp<TResult, TInput, int128_t>(

--- a/velox/type/CMakeLists.txt
+++ b/velox/type/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(
   velox_exception
   velox_serialization
   velox_external_date
+  velox_status
   Boost::headers
   Folly::folly
   re2::re2)


### PR DESCRIPTION
In `rescaleWithRoundUp` method, exception is thrown for overflow. The caller 
needs to try-catch an exception to check if overflow occurs, but this is slow 
on performance. To avoid try-catch, this PR changes to use Status to represent 
the computing outcome of the this method.