### PR TITLE
Make the kPartitionPathAsLowerCaseSession parameter from session

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -149,10 +149,7 @@ bool HiveConfig::isFileColumnNamesReadAsLowerCase(const Config* session) const {
 }
 
 bool HiveConfig::isPartitionPathAsLowerCase(const Config* session) const {
-  if (session->isValueExists(kPartitionPathAsLowerCaseSession)) {
-    return session->get<bool>(kPartitionPathAsLowerCaseSession).value();
-  }
-  return true;
+  return session->get<bool>(kPartitionPathAsLowerCaseSession, true);
 }
 
 int64_t HiveConfig::maxCoalescedBytes() const {

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -149,7 +149,10 @@ bool HiveConfig::isFileColumnNamesReadAsLowerCase(const Config* session) const {
 }
 
 bool HiveConfig::isPartitionPathAsLowerCase(const Config* session) const {
-  return config_->get<bool>(kPartitionPathAsLowerCaseSession, true);
+  if (session->isValueExists(kPartitionPathAsLowerCaseSession)) {
+    return session->get<bool>(kPartitionPathAsLowerCaseSession).value();
+  }
+  return true;
 }
 
 int64_t HiveConfig::maxCoalescedBytes() const {

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -137,7 +137,8 @@ TEST(HiveConfigTest, overrideSession) {
       {HiveConfig::kOrcWriterMaxStripeSizeSession, "22MB"},
       {HiveConfig::kOrcWriterMaxDictionaryMemorySession, "22MB"},
       {HiveConfig::kSortWriterMaxOutputRowsSession, "20"},
-      {HiveConfig::kSortWriterMaxOutputBytesSession, "20MB"}};
+      {HiveConfig::kSortWriterMaxOutputBytesSession, "20MB"},
+      {HiveConfig::kPartitionPathAsLowerCaseSession, "false"}};
   const auto session = std::make_unique<MemConfig>(sessionOverride);
   ASSERT_EQ(
       hiveConfig->insertExistingPartitionsBehavior(session.get()),
@@ -171,4 +172,5 @@ TEST(HiveConfigTest, overrideSession) {
       22L * 1024L * 1024L);
   ASSERT_EQ(hiveConfig->sortWriterMaxOutputRows(session.get()), 20);
   ASSERT_EQ(hiveConfig->sortWriterMaxOutputBytes(session.get()), 20UL << 20);
+  ASSERT_EQ(hiveConfig->isPartitionPathAsLowerCase(session.get()), false);
 }

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -60,6 +60,7 @@ TEST(HiveConfigTest, defaultConfig) {
   ASSERT_EQ(hiveConfig->sortWriterMaxOutputRows(emptySession.get()), 1024);
   ASSERT_EQ(
       hiveConfig->sortWriterMaxOutputBytes(emptySession.get()), 10UL << 20);
+  ASSERT_EQ(hiveConfig->isPartitionPathAsLowerCase(emptySession.get()), true);
 }
 
 TEST(HiveConfigTest, overrideConfig) {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -419,7 +419,7 @@ Each query can override the config by setting corresponding query session proper
      - false
      - True if reading the source file column names as lower case, and planner should guarantee
        the input column name and filter is also lower case to achive case-insensitive read.
-   * - partition-path-as-lower-case
+   * - partition_path_as_lower_case
      -
      - bool
      - true


### PR DESCRIPTION
Currently, the `kPartitionPathAsLowerCaseSession `value can only be obtained from static configuration. However, it is necessary to extend its support to retrieve the value from the session as well.