### PR TITLE
[velox] Rename max_arbitrary_buffer_size (part 1)

### DIFF
--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -97,10 +97,10 @@ Generic Configuration
      - The maximum size in bytes for the task's buffered output when output is partitioned using hash of partitioning keys. See PartitionedOutputNode::Kind::kPartitioned.
        The producer Drivers are blocked when the buffered size exceeds this.
        The Drivers are resumed when the buffered size goes below OutputBufferManager::kContinuePct (90)% of this.
-   * - max_arbitrary_buffer_size
+   * - max_output_buffer_size
      - integer
      - 32MB
-     - The maximum size in bytes for the task's buffered output when output is distributed randomly among consumers. See PartitionedOutputNode::Kind::kArbitrary.
+     - The maximum size in bytes for the task's buffered output.
        The producer Drivers are blocked when the buffered size exceeds this.
        The Drivers are resumed when the buffered size goes below OutputBufferManager::kContinuePct (90)% of this.
    * - min_table_rows_for_parallel_join_build

--- a/velox/exec/OutputBuffer.cpp
+++ b/velox/exec/OutputBuffer.cpp
@@ -270,7 +270,7 @@ OutputBuffer::OutputBuffer(
     uint32_t numDrivers)
     : task_(std::move(task)),
       kind_(kind),
-      maxSize_(task_->queryCtx()->queryConfig().maxArbitraryBufferSize()),
+      maxSize_(task_->queryCtx()->queryConfig().maxOutputBufferSize()),
       continueSize_((maxSize_ * kContinuePct) / 100),
       arbitraryBuffer_(
           isArbitrary() ? std::make_unique<ArbitraryBuffer>() : nullptr),


### PR DESCRIPTION
This is part 1 of renaming max_arbitrary_buffer_size to max_output_buffer_size in a backward-compatible way.

Add new max_output_buffer_size property. 