### PR TITLE
Minor fix for cleanning empty spill partitions in HashBuild

### DIFF
--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -790,16 +790,16 @@ bool HashBuild::finishHashBuild() {
 
   if (spiller_ != nullptr) {
     spiller_->finishSpill(spillPartitions);
+  }
 
-    // Remove the spilled partitions which are empty so as we don't need to
-    // trigger unnecessary spilling at hash probe side.
-    auto iter = spillPartitions.begin();
-    while (iter != spillPartitions.end()) {
-      if (iter->second->numFiles() > 0) {
-        ++iter;
-      } else {
-        iter = spillPartitions.erase(iter);
-      }
+  // Remove the spilled partitions which are empty so as we don't need to
+  // trigger unnecessary spilling at hash probe side.
+  auto iter = spillPartitions.begin();
+  while (iter != spillPartitions.end()) {
+    if (iter->second->numFiles() > 0) {
+      ++iter;
+    } else {
+      iter = spillPartitions.erase(iter);
     }
   }
   recordSpillStats();


### PR DESCRIPTION
If current driver does not spill then spiller_ might be nullptr and the collected spill partitons are not optimized for empty partitions cleanup.