### PR TITLE
Create createSerializer function that takes in RowVector instead of rowType/numRows

### DIFF
--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -3354,6 +3354,18 @@ std::unique_ptr<VectorSerializer> PrestoVectorSerde::createSerializer(
       prestoOptions.compressionKind);
 }
 
+std::unique_ptr<VectorSerializer> PrestoVectorSerde::createSerializerFromRow(
+    const RowVectorPtr& vector,
+    StreamArena* streamArena,
+    const Options* options) {
+  auto prestoOptions = toPrestoOptions(options);
+  return std::make_unique<PrestoVectorSerializer>(
+      vector,
+      streamArena,
+      prestoOptions.useLosslessTimestamp,
+      prestoOptions.compressionKind);
+}
+
 void PrestoVectorSerde::serializeEncoded(
     const RowVectorPtr& vector,
     StreamArena* streamArena,

--- a/velox/serializers/PrestoSerializer.h
+++ b/velox/serializers/PrestoSerializer.h
@@ -83,6 +83,11 @@ class PrestoVectorSerde : public VectorSerde {
       StreamArena* streamArena,
       const Options* options) override;
 
+  std::unique_ptr<VectorSerializer> createSerializerFromRow(
+      const RowVectorPtr& vector,
+      StreamArena* streamArena,
+      const Options* options) override;
+
   /// Serializes a single RowVector with possibly encoded children, preserving
   /// their encodings. Encodings are preserved recursively for any RowVector
   /// children, but not for children of other nested vectors such as Array, Map,

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -125,6 +125,13 @@ class VectorSerde {
       StreamArena* streamArena,
       const Options* options = nullptr) = 0;
 
+  virtual std::unique_ptr<VectorSerializer> createSerializerFromRow(
+      const RowVectorPtr& /* rowVector */,
+      StreamArena* /* streamArena */,
+      const Options* /* options */ = nullptr) {
+    VELOX_UNSUPPORTED();
+  }
+
   virtual void deserialize(
       ByteInputStream* source,
       velox::memory::MemoryPool* pool,


### PR DESCRIPTION
Summary:
As title.

Creates a PrestoSerializer based on RowVector rather than RowType and RowVector. Will be used in callsites where the encoding is not statically available via Options.

Differential Revision: D52569963

