### PR TITLE
Add function DecimalUtil::rescaleDouble

### DIFF
--- a/velox/common/base/tests/GTestUtils.h
+++ b/velox/common/base/tests/GTestUtils.h
@@ -54,6 +54,13 @@
   VELOX_ASSERT_THROW_IMPL(                                     \
       facebook::velox::VeloxRuntimeError, _expression, _errorMessage)
 
+#define VELOX_ASSERT_ERROR_STATUS(_expression, _statusCode, _errorMessage) \
+  const auto status = (_expression);                                       \
+  ASSERT_TRUE(status.code() == _statusCode);                               \
+  ASSERT_TRUE(status.message().find(_errorMessage) != std::string::npos)   \
+      << "Expected error message to contain '" << (_errorMessage)          \
+      << "', but received '" << status.message() << "'."
+
 #ifndef NDEBUG
 #define DEBUG_ONLY_TEST(test_fixture, test_name) TEST(test_fixture, test_name)
 #define DEBUG_ONLY_TEST_F(test_fixture, test_name) \

--- a/velox/type/tests/DecimalTest.cpp
+++ b/velox/type/tests/DecimalTest.cpp
@@ -23,6 +23,29 @@ namespace facebook::velox {
 
 namespace {
 
+template <typename T>
+void assertRescaleDouble(double value, const TypePtr& type, T expectedValue) {
+  const auto [precision, scale] = getDecimalPrecisionScale(*type);
+  T actualValue;
+  const auto status =
+      DecimalUtil::rescaleDouble<T>(value, precision, scale, actualValue);
+  ASSERT_TRUE(status.ok());
+  ASSERT_EQ(actualValue, expectedValue);
+}
+
+template <typename T>
+void assertRescaleDoubleFail(
+    double value,
+    const TypePtr& type,
+    const std::string& expectedErrorMessage) {
+  const auto [precision, scale] = getDecimalPrecisionScale(*type);
+  T actualValue;
+  VELOX_ASSERT_ERROR_STATUS(
+      DecimalUtil::rescaleDouble<T>(value, precision, scale, actualValue),
+      StatusCode::kUserError,
+      expectedErrorMessage);
+}
+
 void testToByteArray(int128_t value, int8_t* expected, int32_t size) {
   char out[size];
   int32_t length = DecimalUtil::toByteArray(value, out);
@@ -263,105 +286,82 @@ TEST(DecimalAggregateTest, adjustSumForOverflow) {
   EXPECT_FALSE(accumulator.adjustedSum().has_value());
 }
 
-template <typename T>
-void checkRescaleDouble(double value, const TypePtr& type, T expectedValue) {
-  auto [precision, scale] = getDecimalPrecisionScale(*type);
-  folly::Expected<T, DecimalUtil::RescalingErrors> result =
-      DecimalUtil::rescaleDouble<T>(value, precision, scale);
-  ASSERT_FALSE(result.hasError());
-  ASSERT_TRUE(result.hasValue());
-  ASSERT_EQ(result.value(), expectedValue);
-}
-
-template <typename T>
-void checkRescaleDoubleFails(
-    double value,
-    const TypePtr& type,
-    const DecimalUtil::RescalingErrors expectedErrorCode) {
-  auto [precision, scale] = getDecimalPrecisionScale(*type);
-  folly::Expected<T, DecimalUtil::RescalingErrors> result =
-      DecimalUtil::rescaleDouble<T>(value, precision, scale);
-  ASSERT_TRUE(result.hasError());
-  ASSERT_FALSE(result.hasValue());
-  ASSERT_EQ(result.error(), expectedErrorCode);
-}
-
 TEST(DecimalTest, rescaleDouble) {
-  checkRescaleDouble<int64_t>(-3333.03, DECIMAL(10, 4), -33'330'300);
-  checkRescaleDouble<int128_t>(-3333.03, DECIMAL(20, 1), -33'330);
-  checkRescaleDouble<int128_t>(-3333.03, DECIMAL(20, 10), -33'330'300'000'000);
+  assertRescaleDouble<int64_t>(-3333.03, DECIMAL(10, 4), -33'330'300);
+  assertRescaleDouble<int128_t>(-3333.03, DECIMAL(20, 1), -33'330);
+  assertRescaleDouble<int128_t>(-3333.03, DECIMAL(20, 10), -33'330'300'000'000);
 
-  checkRescaleDouble<int64_t>(-2222.02, DECIMAL(10, 4), -22'220'200);
-  checkRescaleDouble<int128_t>(-2222.02, DECIMAL(20, 1), -22'220);
-  checkRescaleDouble<int128_t>(-2222.02, DECIMAL(20, 10), -22'220'200'000'000);
+  assertRescaleDouble<int64_t>(-2222.02, DECIMAL(10, 4), -22'220'200);
+  assertRescaleDouble<int128_t>(-2222.02, DECIMAL(20, 1), -22'220);
+  assertRescaleDouble<int128_t>(-2222.02, DECIMAL(20, 10), -22'220'200'000'000);
 
-  checkRescaleDouble<int64_t>(-1.0, DECIMAL(10, 4), -10'000);
-  checkRescaleDouble<int128_t>(-1.0, DECIMAL(20, 1), -10);
-  checkRescaleDouble<int128_t>(-1.0, DECIMAL(20, 10), -10'000'000'000);
+  assertRescaleDouble<int64_t>(-1.0, DECIMAL(10, 4), -10'000);
+  assertRescaleDouble<int128_t>(-1.0, DECIMAL(20, 1), -10);
+  assertRescaleDouble<int128_t>(-1.0, DECIMAL(20, 10), -10'000'000'000);
 
-  checkRescaleDouble<int64_t>(0.00, DECIMAL(10, 4), 0);
-  checkRescaleDouble<int128_t>(0.00, DECIMAL(20, 1), 0);
-  checkRescaleDouble<int128_t>(0.00, DECIMAL(20, 10), 0);
+  assertRescaleDouble<int64_t>(0.00, DECIMAL(10, 4), 0);
+  assertRescaleDouble<int128_t>(0.00, DECIMAL(20, 1), 0);
+  assertRescaleDouble<int128_t>(0.00, DECIMAL(20, 10), 0);
 
-  checkRescaleDouble<int64_t>(100, DECIMAL(10, 4), 1'000'000);
-  checkRescaleDouble<int128_t>(100, DECIMAL(20, 1), 1'000);
-  checkRescaleDouble<int128_t>(100, DECIMAL(20, 10), 1'000'000'000'000);
+  assertRescaleDouble<int64_t>(100, DECIMAL(10, 4), 1'000'000);
+  assertRescaleDouble<int128_t>(100, DECIMAL(20, 1), 1'000);
+  assertRescaleDouble<int128_t>(100, DECIMAL(20, 10), 1'000'000'000'000);
 
-  checkRescaleDouble<int64_t>(99999.99, DECIMAL(10, 4), 999'999'900);
-  checkRescaleDouble<int128_t>(99999.99, DECIMAL(20, 1), 1'000'000);
-  checkRescaleDouble<int128_t>(99999.99, DECIMAL(20, 10), 999'999'900'000'000);
+  assertRescaleDouble<int64_t>(99999.99, DECIMAL(10, 4), 999'999'900);
+  assertRescaleDouble<int128_t>(99999.99, DECIMAL(20, 1), 1'000'000);
+  assertRescaleDouble<int128_t>(99999.99, DECIMAL(20, 10), 999'999'900'000'000);
 
-  checkRescaleDouble<int128_t>(
-      std::numeric_limits<double>::min(), DECIMAL(38, 2), 0);
+  assertRescaleDouble<int128_t>(
+      0.034567890, DECIMAL(38, 18), 34'567'890'000'000'000);
+  assertRescaleDouble<int128_t>(
+      0.999999999999999, DECIMAL(38, 18), 999'999'999'999'999'000);
+  assertRescaleDouble<int128_t>(
+      0.123456789123123, DECIMAL(38, 18), 123'456'789'123'123'000);
+  assertRescaleDouble<int64_t>(21.54551, DECIMAL(12, 3), 21546);
 
-  checkRescaleDoubleFails<int128_t>(
-      std::numeric_limits<double>::max(),
+  assertRescaleDoubleFail<int128_t>(
+      std::numeric_limits<double>::max(), DECIMAL(38, 38), "Result overflows.");
+  assertRescaleDoubleFail<int128_t>(
+      std::numeric_limits<double>::lowest(),
       DECIMAL(38, 2),
-      DecimalUtil::RescalingErrors::kOverflowedRescaledValue);
+      "Result overflows.");
 
-  // Test infinity double type numbers.
-  checkRescaleDoubleFails<int64_t>(
-      NAN,
-      DECIMAL(10, 2),
-      DecimalUtil::RescalingErrors::kInfiniteFloatingNumber);
-  checkRescaleDoubleFails<int64_t>(
-      INFINITY,
-      DECIMAL(10, 2),
-      DecimalUtil::RescalingErrors::kInfiniteFloatingNumber);
+  assertRescaleDoubleFail<int64_t>(
+      NAN, DECIMAL(10, 2), "The input value should be finite.");
+  assertRescaleDoubleFail<int64_t>(
+      INFINITY, DECIMAL(10, 2), "The input value should be finite.");
 
-  checkRescaleDoubleFails<int64_t>(
-      9999999999999999999999.99,
-      DECIMAL(10, 2),
-      DecimalUtil::RescalingErrors::kOverflowedRescaledValue);
-
-  checkRescaleDoubleFails<int64_t>(
+  assertRescaleDoubleFail<int64_t>(
+      9999999999999999999999.99, DECIMAL(10, 2), "Result overflows.");
+  assertRescaleDoubleFail<int64_t>(
       static_cast<double>(
           static_cast<int128_t>(std::numeric_limits<int64_t>::max()) + 1),
       DECIMAL(10, 2),
-      DecimalUtil::RescalingErrors::kOverflowedRescaledValue);
-  checkRescaleDoubleFails<int64_t>(
+      "Result overflows.");
+  assertRescaleDoubleFail<int64_t>(
       static_cast<double>(
           static_cast<int128_t>(std::numeric_limits<int64_t>::min()) - 1),
       DECIMAL(10, 2),
-      DecimalUtil::RescalingErrors::kOverflowedRescaledValue);
-
-  checkRescaleDoubleFails<int64_t>(
+      "Result overflows.");
+  assertRescaleDoubleFail<int64_t>(
       static_cast<double>(DecimalUtil::kShortDecimalMax),
       DECIMAL(10, 2),
-      DecimalUtil::RescalingErrors::kOverflowedRescaledValue);
-  checkRescaleDoubleFails<int64_t>(
+      "Result overflows.");
+  assertRescaleDoubleFail<int64_t>(
       static_cast<double>(DecimalUtil::kShortDecimalMin),
       DECIMAL(10, 2),
-      DecimalUtil::RescalingErrors::kOverflowedRescaledValue);
-
-  checkRescaleDoubleFails<int128_t>(
+      "Result overflows.");
+  assertRescaleDoubleFail<int128_t>(
       static_cast<double>(DecimalUtil::kLongDecimalMax),
       DECIMAL(20, 2),
-      DecimalUtil::RescalingErrors::kOverflowedRescaledValue);
-  checkRescaleDoubleFails<int128_t>(
+      "Result overflows.");
+  assertRescaleDoubleFail<int128_t>(
       static_cast<double>(DecimalUtil::kLongDecimalMin),
       DECIMAL(20, 2),
-      DecimalUtil::RescalingErrors::kOverflowedRescaledValue);
+      "Result overflows.");
+
+  assertRescaleDoubleFail<int64_t>(
+      99999.99, DECIMAL(6, 4), "Result cannot fit in the given precision 6.");
 }
 
 } // namespace


### PR DESCRIPTION
Add function DecimalUtil::rescaleDouble which rescales double input as decimal 
value of given precision and scale. Used in CAST (double as decimal).
Based on https://github.com/facebookincubator/velox/pull/6051 from @wuxueyang96.
https://github.com/facebookincubator/velox/issues/8412