### PR TITLE
Make nulls initialValue to false in EvalCtx#ensureErrorsVectorSize

### DIFF
--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -90,7 +90,7 @@ void EvalCtx::ensureErrorsVectorSize(ErrorVectorPtr& vector, vector_size_t size)
     vector = std::make_shared<ErrorVector>(
         pool(),
         OpaqueType::create<void>(),
-        AlignedBuffer::allocate<bool>(size, pool(), true) /*nulls*/,
+        AlignedBuffer::allocate<bool>(size, pool(), false) /*nulls*/,
         size /*length*/,
         AlignedBuffer::allocate<ErrorVector::value_type>(
             size, pool(), ErrorVector::value_type()),
@@ -102,10 +102,10 @@ void EvalCtx::ensureErrorsVectorSize(ErrorVectorPtr& vector, vector_size_t size)
         size /*representedBytes*/);
   } else if (vector->size() < size) {
     vector->resize(size, false);
-  }
-  // Set all new positions to null, including the one to be set.
-  for (auto i = oldSize; i < size; ++i) {
-    vector->setNull(i, true);
+    // Set all new positions to null, including the one to be set.
+    for (auto i = oldSize; i < size; ++i) {
+      vector->setNull(i, true);
+    }
   }
 }
 


### PR DESCRIPTION
It makes more sense to initialize nulls to false and avoid calling `setNull(true)` when creating new ErrorVector.