### PR TITLE
Randomize fetch data from exchange sources

### DIFF
--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <algorithm>
+#include <random>
 #include "velox/exec/ExchangeClient.h"
 #include "velox/exec/Operator.h"
 
@@ -66,6 +68,12 @@ class Exchange : public SourceOperator {
   virtual VectorSerde* getSerde();
 
  private:
+  // Invoked to create exchange client for remote tasks.
+  // The function shuffles the source task ids first to randomize the source
+  // tasks we fetch data from. This helps to avoid different tasks fetching from
+  // the same source task in a distributed system.
+  void addTaskIds(std::vector<std::string>& taskIds);
+
   /// Fetches splits from the task until there are no more splits or task
   /// returns a future that will be complete when more splits arrive. Adds
   /// splits to exchangeClient_. Returns true if received a future from the task
@@ -96,6 +104,7 @@ class Exchange : public SourceOperator {
   std::shared_ptr<ExchangeClient> exchangeClient_;
   std::vector<std::unique_ptr<SerializedPage>> currentPages_;
   bool atEnd_{false};
+  std::default_random_engine rng_{std::random_device{}()};
 };
 
 } // namespace facebook::velox::exec


### PR DESCRIPTION
When exchangeOperator fetches from downstream tasks, it fetches in order.

By randomizing taskIds, we avoid reading from the same downstream 
task at the same time for different exchangesOperators. 
It helps uniform distribution of traffic in a distributed environment.