### PR TITLE
Add Presto key_sampling_percent scalar function

### DIFF
--- a/velox/docs/functions/presto/string.rst
+++ b/velox/docs/functions/presto/string.rst
@@ -255,3 +255,8 @@ Unicode Functions
 .. function:: to_utf8(string) -> varbinary
 
     Encodes ``string`` into a UTF-8 varbinary representation.
+
+.. function:: key_sampling_percent(varchar) -> double
+
+    Generates a double value between 0.0 and 1.0 based on the hash of the given ``varchar``.
+    This function is useful for deterministic sampling of data.

--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#define XXH_INLINE_ALL
+#include "velox/external/xxhash/xxhash.h"
 #include "velox/functions/Udf.h"
 #include "velox/functions/lib/string/StringCore.h"
 #include "velox/functions/lib/string/StringImpl.h"
@@ -430,4 +432,17 @@ struct LevenshteinDistanceFunction {
   }
 };
 
+template <typename T>
+struct KeySamplingPercentFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<double>& result,
+      const arg_type<Varchar>& string) {
+    static constexpr auto kTypeLength = sizeof(int64_t);
+    int64_t hash = XXH64(string.data(), string.size(), 0);
+    memcpy(&result, &hash, kTypeLength);
+    result = fmod(abs(result), 100) / 100;
+  }
+};
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -127,5 +127,8 @@ void registerStringFunctions(const std::string& prefix) {
       {prefix + "strrpos"});
   registerFunction<StrRPosFunction, int64_t, Varchar, Varchar, int64_t>(
       {prefix + "strrpos"});
+
+  registerFunction<KeySamplingPercentFunction, double, Varchar>(
+      {prefix + "key_sampling_percent"});
 }
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -1862,3 +1862,20 @@ TEST_F(StringFunctionsTest, varbinaryLength) {
   auto result = evaluate("length(c0)", makeRowVector({vector}));
   test::assertEqualVectors(expected, result);
 }
+
+TEST_F(StringFunctionsTest, keySamplingPercent) {
+  const auto keySamplingPercent = [&](std::optional<std::string> string) {
+    return evaluateOnce<double>("key_sampling_percent(c0)", string);
+  };
+
+  EXPECT_EQ(std::nullopt, keySamplingPercent(std::nullopt));
+  EXPECT_EQ(0.56, keySamplingPercent("abc"));
+  EXPECT_EQ(6.11561179120687E-153, keySamplingPercent("abcdefghskwkjadhwd"));
+  EXPECT_EQ(2.393674127734674E-93, keySamplingPercent("001yxzuj"));
+  EXPECT_EQ(0.48, keySamplingPercent("56wfythjhdhvgewuikwemn"));
+  EXPECT_EQ(0.7520703125, keySamplingPercent("special_#@,$|%/^~?{}+-"));
+  EXPECT_EQ(0.4, keySamplingPercent("     "));
+  EXPECT_EQ(0.28, keySamplingPercent(""));
+  EXPECT_EQ(
+      4.143659858002825E-274, keySamplingPercent("Hello World from Velox!"));
+}


### PR DESCRIPTION
Add key_sampling_percent Scalar function.

This function is an SQL function in Presto. Setting `inline-sql-functions=true` seems to
work in certain cases but not all.
For example, this is required when KEY_BASED_SAMPLING_ENABLED=true in Presto.

Resolves: https://github.com/prestodb/presto/issues/20592

Reference: https://github.com/prestodb/presto/blob/d1ede7cf62fc9f4fdae4cfd459b39f45777954a8/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/SimpleSamplingPercent.java#L21