### PR TITLE
Fix UnknownValue in castFormJson

### DIFF
--- a/velox/functions/prestosql/types/JsonType.cpp
+++ b/velox/functions/prestosql/types/JsonType.cpp
@@ -575,6 +575,13 @@ simdjson::error_code appendMapKey<TypeKind::TIMESTAMP>(
   return simdjson::INCORRECT_TYPE;
 }
 
+template <>
+simdjson::error_code appendMapKey<TypeKind::UNKNOWN>(
+    const std::string_view& /*value*/,
+    exec::GenericWriter& /*writer*/) {
+  return simdjson::INCORRECT_TYPE;
+}
+
 template <typename Input>
 struct CastFromJsonTypedImpl {
   template <TypeKind kind>


### PR DESCRIPTION
This PR fixes the compilation error for "UnknownValue" path for Json cast:
```
../../velox/functions/prestosql/types/JsonType.cpp:1106:3:   required from here
../../velox/functions/prestosql/types/JsonType.cpp:516:32: error: no matching function for call to ‘tryTo<facebook::velox::UnknownValue>(const string_view&)’
  516 |   auto result = folly::tryTo<T>(s);
```