### PR TITLE
Add memory reclaim stats in TaskStats

### DIFF
--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -736,6 +736,12 @@ class Task : public std::enable_shared_from_this<Task> {
       return task_.lock();
     }
 
+    uint64_t reclaimTask(
+        const std::shared_ptr<Task>& task,
+        uint64_t targetBytes,
+        uint64_t maxWaitMs,
+        memory::MemoryReclaimer::Stats& stats);
+
     std::weak_ptr<Task> task_;
   };
 

--- a/velox/exec/TaskStats.h
+++ b/velox/exec/TaskStats.h
@@ -105,6 +105,11 @@ struct TaskStats {
   std::string longestRunningOpCall;
   /// The longest still running operator call's duration in ms.
   size_t longestRunningOpCallMs{0};
+
+  /// The total memory reclamation count.
+  uint32_t memoryReclaimCount{0};
+  /// The total memory reclamation time.
+  uint64_t memoryReclaimMs{0};
 };
 
 } // namespace facebook::velox::exec


### PR DESCRIPTION
Add memory reclaim stats (time and count) in TaskStats to help analyze how much time
a task spent on memory reclaim by memory arbitration. If the memory arbitration is initiated
by the query itself. This time will be counted in its operator's  execution time. If not, the task
will be stopped for that long to reclaim memory. This indicates if a slow query is caused by
the background memory arbitration.

The followup is to report the stats as task runtime stats in Prestissimo.