### PR TITLE
Change cast(double as json) to pad 0 and use scientific notation

### DIFF
--- a/velox/docs/functions/presto/json.rst
+++ b/velox/docs/functions/presto/json.rst
@@ -37,6 +37,8 @@ be JSON. Behaviors of the casts are shown with the examples below:
     SELECT CAST('abc' AS JSON); -- JSON '"abc"'
     SELECT CAST(true AS JSON); -- JSON 'true'
     SELECT CAST(1.234 AS JSON); -- JSON '1.234'
+    SELECT CAST(-0.00012 AS JSON); -- JSON '-1.2E-4'
+    SELECT CAST(10000000.0 AS JSON); -- JSON '1.0E7'
     SELECT CAST(ARRAY[1, 23, 456] AS JSON); -- JSON '[1,23,456]'
     SELECT CAST(ARRAY[1, NULL, 456] AS JSON); -- JSON '[1,null,456]'
     SELECT CAST(ARRAY[ARRAY[1, 23], ARRAY[456]] AS JSON); -- JSON '[[1,23],[456]]'
@@ -51,6 +53,12 @@ have nulls in it.
 Another thing to be aware of is that when casting from ROW to JSON, the
 result is a JSON array rather than a JSON object. This is because positions
 are more important than names for rows in SQL.
+
+Also note that casting from REAL or DOUBLE returns the JSON text represented
+in standard notation if the magnitude of input value is greater than or equal
+to 10 :superscript:`-3` but less than 10 :superscript:`7`, and returns the JSON
+text in scientific notation otherwise. The standard and scientific notation
+always has the fractional part, such as ``10.0``.
 
 Finally, keep in mind that casting a VARCHAR string to JSON does not directly
 turn the original string into JSON type. Instead, it creates a JSON text

--- a/velox/functions/prestosql/tests/JsonCastTest.cpp
+++ b/velox/functions/prestosql/tests/JsonCastTest.cpp
@@ -268,18 +268,72 @@ TEST_F(JsonCastTest, fromBoolean) {
       {std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt});
 }
 
-TEST_F(JsonCastTest, fromDouble) {
+TEST_F(JsonCastTest, fromDoubleAndReal) {
   testCastToJson<double>(
       DOUBLE(),
-      {1.1, 2.0001, 10.0, 3.14e0, kNan, kInf, -kInf, std::nullopt},
+      {1.1,
+       2.0001,
+       10.0,
+       3.14e0,
+       -0.0,
+       0.00012,
+       -0.001,
+       12345.0,
+       10'000'000.0,
+       123456789.01234567,
+       kNan,
+       -kNan,
+       kInf,
+       -kInf,
+       std::nullopt},
       {"1.1"_sv,
        "2.0001"_sv,
-       "10"_sv,
+       "10.0"_sv,
        "3.14"_sv,
+       "-0.0"_sv,
+       "1.2E-4"_sv,
+       "-0.001"_sv,
+       "12345.0"_sv,
+       "1.0E7"_sv,
+       "1.2345678901234567E8"_sv,
+       "NaN"_sv,
        "NaN"_sv,
        "Infinity"_sv,
        "-Infinity"_sv,
        std::nullopt});
+  testCastToJson<float>(
+      REAL(),
+      {1.1,
+       2.0001,
+       10.0,
+       3.14e0,
+       -0.0,
+       0.00012,
+       -0.001,
+       12345.0,
+       10'000'000.0,
+       123456780.0,
+       kNan,
+       -kNan,
+       kInf,
+       -kInf,
+       std::nullopt},
+      {"1.1"_sv,
+       "2.0001"_sv,
+       "10.0"_sv,
+       "3.14"_sv,
+       "-0.0"_sv,
+       "1.2E-4"_sv,
+       "-0.001"_sv,
+       "12345.0"_sv,
+       "1.0E7"_sv,
+       "1.2345678E8"_sv,
+       "NaN"_sv,
+       "NaN"_sv,
+       "Infinity"_sv,
+       "-Infinity"_sv,
+       std::nullopt});
+
   testCastToJson<double>(
       DOUBLE(),
       {std::nullopt, std::nullopt, std::nullopt, std::nullopt},
@@ -428,9 +482,9 @@ TEST_F(JsonCastTest, fromMap) {
 
   // Tests map with floating-point keys.
   std::vector<std::vector<Pair<double, int64_t>>> mapDoubleKey{
-      {{4.4, std::nullopt}, {3.3, 2}}, {}};
+      {{4.4, std::nullopt}, {3.3, 2}, {10.0, 9}, {-100000000.5, 99}}, {}};
   std::vector<std::optional<JsonNativeType>> expectedDoubleKey{
-      R"({"3.3":2,"4.4":null})", "{}"};
+      R"({"-1.000000005E8":99,"10.0":9,"3.3":2,"4.4":null})", "{}"};
   testCastFromMap(MAP(DOUBLE(), BIGINT()), mapDoubleKey, expectedDoubleKey);
 
   // Tests map with boolean keys.
@@ -466,14 +520,14 @@ TEST_F(JsonCastTest, fromMap) {
 
   // Tests map whose elements are wrapped in a dictionary.
   std::vector<std::optional<double>> values{
-      1.1e3, 2.2, 3.14e0, -4.4, std::nullopt, -6e-10, -7.7};
+      1.1e3, 2.2, 3.14e0, -4.4, std::nullopt, -0.0000000006, -7.7};
   auto mapOfDictElements = makeMapWithDictionaryElements(keys, values, 2);
 
   auto mapOfDictElementsExpected = makeNullableFlatVector<JsonNativeType>(
-      {R"({"f":-6E-10,"g":null})",
+      {R"({"f":-6.0E-10,"g":null})",
        R"({"d":-4.4,"e":null})",
        R"({"b":2.2,"c":3.14})",
-       R"({"a":1100})"},
+       R"({"a":1100.0})"},
       JSON());
   testCast(mapOfDictElements, mapOfDictElementsExpected);
 
@@ -481,7 +535,10 @@ TEST_F(JsonCastTest, fromMap) {
   auto jsonMapOfDictElements =
       makeMapWithDictionaryElements(keys, values, 2, MAP(JSON(), DOUBLE()));
   auto jsonMapOfDictElementsExpected = makeNullableFlatVector<JsonNativeType>(
-      {"{f:-6E-10,g:null}", "{d:-4.4,e:null}", "{b:2.2,c:3.14}", "{a:1100}"},
+      {"{f:-6.0E-10,g:null}",
+       "{d:-4.4,e:null}",
+       "{b:2.2,c:3.14}",
+       "{a:1100.0}"},
       JSON());
   testCast(jsonMapOfDictElements, jsonMapOfDictElementsExpected);
 

--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -464,6 +464,9 @@ struct Converter<TypeKind::VARCHAR, void, TPolicy> {
         return str;
       }
 
+      // Implementation below is close to String.of(double) of Java. For
+      // example, for some rare cases the result differs in precision by
+      // the least significant bit.
       if (FOLLY_UNLIKELY(std::isinf(val) || std::isnan(val))) {
         return folly::to<std::string>(val);
       }


### PR DESCRIPTION
Make the returned json padded with .0, if the input double or real
value equals to an integer. For example, cast(1.0 as json)
returns json '1' before and will return json '1.0' after this change.

Also if the magnitude of the input double or real value is greater
than or equal to 10^7, or less than 10^-3, return scientific
notation instead of standard notation. For example,
cast(0.0001 as json) returns json '0.0001' before and will return
json '1.0E-4' after this change.

This change also applies to cast(map|array|row as json) if the input
map, array or row has nested double or real elements.

It is then exactly the same behavior as cast(double as varchar).
And thus they will use the same util::Converter util.

Put this change behind the config legacy_cast = false, similar to
the change to cast(double as varchar).

It will also propagate to the return value format of
cast(cast(double as json) as varchar), and
json_format(cast(double as json)).