### PR TITLE
Remove unused variables in velox/type/Type.cpp

### DIFF
--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -714,11 +714,7 @@ std::shared_ptr<const RowType> ROW(
 }
 
 std::shared_ptr<const RowType> ROW(std::vector<TypePtr>&& types) {
-  std::vector<std::string> names;
-  names.reserve(types.size());
-  for (auto& p : types) {
-    names.push_back("");
-  }
+  std::vector<std::string> names(types.size());
   return TypeFactory<TypeKind::ROW>::create(std::move(names), std::move(types));
 }
 


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: bunnypak, dmm-fb

Differential Revision: D53011687


