### PR TITLE
Remove unused variables in velox/exec/ContainerRowSerde.cpp

### DIFF
--- a/velox/exec/ContainerRowSerde.cpp
+++ b/velox/exec/ContainerRowSerde.cpp
@@ -167,8 +167,6 @@ void serializeOne<TypeKind::MAP>(
     ByteOutputStream& out) {
   auto map = vector.wrappedVector()->asUnchecked<MapVector>();
   auto wrappedIndex = vector.wrappedIndex(index);
-  auto size = map->sizeAt(wrappedIndex);
-  auto offset = map->offsetAt(wrappedIndex);
   auto indices = map->sortedKeyIndices(wrappedIndex);
   serializeArray(*map->mapKeys(), indices, out);
   serializeArray(*map->mapValues(), indices, out);


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: bunnypak, dmm-fb

Differential Revision: D53011654


