### PR TITLE
Remove unused variables in velox/common/memory/MmapArena.cpp

### DIFF
--- a/velox/common/memory/MmapArena.cpp
+++ b/velox/common/memory/MmapArena.cpp
@@ -194,11 +194,9 @@ void MmapArena::removeFreeBlock(std::map<uint64_t, uint64_t>::iterator& iter) {
 
 bool MmapArena::checkConsistency() const {
   uint64_t numErrors = 0;
-  uint64_t bytes = 0;
   auto arenaEndAddress = reinterpret_cast<uint64_t>(address_) + byteSize_;
   auto iter = freeList_.begin();
   auto end = freeList_.end();
-  uint8_t* current = reinterpret_cast<uint8_t*>(address_);
   int64_t freeListTotalBytes = 0;
   while (iter != end) {
     // Lookup list should contain the address


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: bunnypak, dmm-fb

Differential Revision: D53011662


