### PR TITLE
Use folly::dynamic as propagation media for printing

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -958,10 +958,10 @@ std::string Driver::toString() const {
   return out.str();
 }
 
-std::string Driver::toJsonString() const {
+folly::dynamic Driver::toJson() const {
   folly::dynamic obj = folly::dynamic::object;
   obj["blockingReason"] = blockingReasonToString(blockingReason_);
-  obj["state"] = state_.toJsonString();
+  obj["state"] = state_.toJson();
   obj["closed"] = closed_.load();
   obj["queueTimeStartMicros"] = queueTimeStartMicros_;
   const auto ocs = opCallStatus();
@@ -974,11 +974,11 @@ std::string Driver::toJsonString() const {
   folly::dynamic operatorsObj = folly::dynamic::object;
   int index = 0;
   for (auto& op : operators_) {
-    operatorsObj[std::to_string(index++)] = op->toJsonString();
+    operatorsObj[std::to_string(index++)] = op->toJson();
   }
   obj["operators"] = operatorsObj;
 
-  return folly::toJson(obj);
+  return obj;
 }
 
 SuspendedSection::SuspendedSection(Driver* driver) : driver_(driver) {

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -978,7 +978,7 @@ std::string Driver::toJsonString() const {
   }
   obj["operators"] = operatorsObj;
 
-  return folly::toPrettyJson(obj);
+  return folly::toJson(obj);
 }
 
 SuspendedSection::SuspendedSection(Driver* driver) : driver_(driver) {

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -141,7 +141,7 @@ struct ThreadState {
     return getCurrentTimeMs() - startExecTimeMs;
   }
 
-  std::string toJsonString() const {
+  folly::dynamic toJson() const {
     folly::dynamic obj = folly::dynamic::object;
     obj["onThread"] = std::to_string(isOnThread());
     obj["tid"] = tid.load();
@@ -150,7 +150,7 @@ struct ThreadState {
     obj["hasBlockingFuture"] = hasBlockingFuture;
     obj["isSuspended"] = isSuspended;
     obj["startExecTime"] = startExecTimeMs;
-    return folly::toJson(obj);
+    return obj;
   }
 };
 
@@ -391,7 +391,7 @@ class Driver : public std::enable_shared_from_this<Driver> {
 
   std::string toString() const;
 
-  std::string toJsonString() const;
+  folly::dynamic toJson() const;
 
   OpCallStatusRaw opCallStatus() const {
     return opCallStatus_();

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -150,7 +150,7 @@ struct ThreadState {
     obj["hasBlockingFuture"] = hasBlockingFuture;
     obj["isSuspended"] = isSuspended;
     obj["startExecTime"] = startExecTimeMs;
-    return folly::toPrettyJson(obj);
+    return folly::toJson(obj);
   }
 };
 

--- a/velox/exec/ExchangeClient.cpp
+++ b/velox/exec/ExchangeClient.cpp
@@ -252,16 +252,17 @@ std::string ExchangeClient::toString() const {
   return out.str();
 }
 
-std::string ExchangeClient::toJsonString() const {
+folly::dynamic ExchangeClient::toJson() const {
   folly::dynamic obj = folly::dynamic::object;
   obj["taskId"] = taskId_;
   obj["closed"] = closed_;
   folly::dynamic clientsObj = folly::dynamic::object;
   int index = 0;
   for (auto& source : sources_) {
-    clientsObj[std::to_string(index++)] = source->toJsonString();
+    clientsObj[std::to_string(index++)] = source->toJson();
   }
-  return folly::toJson(obj);
+  obj["clients"] = clientsObj;
+  return obj;
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/ExchangeClient.cpp
+++ b/velox/exec/ExchangeClient.cpp
@@ -261,7 +261,7 @@ std::string ExchangeClient::toJsonString() const {
   for (auto& source : sources_) {
     clientsObj[std::to_string(index++)] = source->toJsonString();
   }
-  return folly::toPrettyJson(obj);
+  return folly::toJson(obj);
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -94,7 +94,7 @@ class ExchangeClient : public std::enable_shared_from_this<ExchangeClient> {
 
   std::string toString() const;
 
-  std::string toJsonString() const;
+  folly::dynamic toJson() const;
 
  private:
   // A list of sources to request data from and how much to request from each

--- a/velox/exec/ExchangeSource.h
+++ b/velox/exec/ExchangeSource.h
@@ -127,7 +127,7 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
     obj["sequence"] = sequence_;
     obj["requestPending"] = requestPending_.load();
     obj["atEnd"] = atEnd_;
-    return folly::toPrettyJson(obj);
+    return folly::toJson(obj);
   }
 
   using Factory = std::function<std::shared_ptr<ExchangeSource>(

--- a/velox/exec/ExchangeSource.h
+++ b/velox/exec/ExchangeSource.h
@@ -120,6 +120,17 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
     return out.str();
   }
 
+  virtual folly::dynamic toJson() {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["taskId"] = taskId_;
+    obj["destination"] = destination_;
+    obj["sequence"] = sequence_;
+    obj["requestPending"] = requestPending_.load();
+    obj["atEnd"] = atEnd_;
+    return obj;
+  }
+
+  // TODO(jtan6): Remove after presto native toJson implementation
   virtual std::string toJsonString() {
     folly::dynamic obj = folly::dynamic::object;
     obj["taskId"] = taskId_;
@@ -127,7 +138,7 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
     obj["sequence"] = sequence_;
     obj["requestPending"] = requestPending_.load();
     obj["atEnd"] = atEnd_;
-    return folly::toJson(obj);
+    return folly::toPrettyJson(obj);
   }
 
   using Factory = std::function<std::shared_ptr<ExchangeSource>(

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -459,8 +459,10 @@ class Operator : public BaseRuntimeStatWriter {
   virtual std::string toString() const;
 
   /// Used in debug ednpoints.
-  virtual std::string toJsonString() const {
-    return toString();
+  virtual folly::dynamic toJson() const {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["operator"] = toString();
+    return obj;
   }
 
   velox::memory::MemoryPool* pool() const {

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -53,10 +53,9 @@ TableScan::TableScan(
   connector_ = connector::getConnector(tableHandle_->connectorId());
 }
 
-std::string TableScan::toJsonString() const {
-  auto ret = SourceOperator::toJsonString();
-  ret += ", status: ";
-  ret += curStatus_;
+folly::dynamic TableScan::toJson() const {
+  auto ret = SourceOperator::toJson();
+  ret["status"] = curStatus_.load();
   return ret;
 }
 

--- a/velox/exec/TableScan.h
+++ b/velox/exec/TableScan.h
@@ -27,7 +27,7 @@ class TableScan : public SourceOperator {
       DriverCtx* driverCtx,
       std::shared_ptr<const core::TableScanNode> tableScanNode);
 
-  std::string toJsonString() const override;
+  folly::dynamic toJson() const override;
 
   RowVectorPtr getOutput() override;
 

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2112,30 +2112,38 @@ std::string Task::toString() const {
   return out.str();
 }
 
+// TODO(jtan6): remove after toJson() is landed on presto native side
 std::string Task::toShortJsonString() const {
-  std::lock_guard<std::timed_mutex> l(mutex_);
-  folly::dynamic obj = folly::dynamic::object;
-  obj["shortId"] = shortId(taskId_);
-  obj["id"] = taskId_;
-  obj["state"] = taskStateString(state_);
-  obj["numRunningDrivers"] = numRunningDrivers_;
-  obj["numTotalDrivers_"] = numTotalDrivers_;
-  obj["numFinishedDrivers"] = numFinishedDrivers_;
-  obj["numThreads"] = numThreads_;
-  obj["terminateRequested_"] = std::to_string(terminateRequested_);
-  obj["pauseRequested_"] = std::to_string(pauseRequested_);
-  return folly::toJson(obj);
+  return folly::toPrettyJson(toShortJson());
 }
 
+// TODO(jtan6): remove after toJson() is landed on presto native side
 std::string Task::toJsonString() const {
-  std::lock_guard<std::timed_mutex> l(mutex_);
+  return folly::toPrettyJson(toJson());
+}
+
+folly::dynamic Task::toShortJsonLocked() const {
   folly::dynamic obj = folly::dynamic::object;
   obj["shortId"] = shortId(taskId_);
   obj["id"] = taskId_;
   obj["state"] = taskStateString(state_);
   obj["numRunningDrivers"] = numRunningDrivers_;
-  obj["numTotalDrivers_"] = numTotalDrivers_;
+  obj["numTotalDrivers"] = numTotalDrivers_;
   obj["numFinishedDrivers"] = numFinishedDrivers_;
+  obj["numThreads"] = numThreads_;
+  obj["terminateRequested"] = terminateRequested_.load();
+  obj["pauseRequested"] = pauseRequested_.load();
+  return obj;
+}
+
+folly::dynamic Task::toShortJson() const {
+  std::lock_guard<std::timed_mutex> l(mutex_);
+  return toShortJsonLocked();
+}
+
+folly::dynamic Task::toJson() const {
+  std::lock_guard<std::timed_mutex> l(mutex_);
+  auto obj = toShortJsonLocked();
   obj["numDriversPerSplitGroup"] = numDriversPerSplitGroup_;
   obj["numDriversUngrouped"] = numDriversUngrouped_;
   obj["groupedPartitionedOutput"] = groupedPartitionedOutput_;
@@ -2144,9 +2152,7 @@ std::string Task::toJsonString() const {
   obj["numDriversUngrouped"] = numDriversUngrouped_;
   obj["partitionedOutputConsumed"] = partitionedOutputConsumed_;
   obj["noMoreOutputBuffers"] = noMoreOutputBuffers_;
-  obj["numThreads"] = numThreads_;
-  obj["onThreadSince"] = std::to_string(onThreadSince_);
-  obj["terminateRequested_"] = std::to_string(terminateRequested_);
+  obj["onThreadSince"] = onThreadSince_;
 
   if (exception_) {
     obj["exception"] = errorMessageLocked();
@@ -2156,11 +2162,10 @@ std::string Task::toJsonString() const {
     obj["plan"] = planFragment_.planNode->toString(true, true);
   }
 
-  folly::dynamic driverObj = folly::dynamic::object;
+  folly::dynamic driverObj = folly::dynamic::array;
   int index = 0;
   for (auto& driver : drivers_) {
-    driverObj[std::to_string(index++)] =
-        driver ? driver->toJsonString() : "null";
+    driverObj[std::to_string(index++)] = driver ? driver->toJson() : "null";
   }
   obj["drivers"] = driverObj;
 
@@ -2172,11 +2177,11 @@ std::string Task::toJsonString() const {
 
   folly::dynamic exchangeClients = folly::dynamic::object;
   for (const auto& [id, client] : exchangeClientByPlanNode_) {
-    exchangeClients[id] = client->toJsonString();
+    exchangeClients[id] = client->toJson();
   }
   obj["exchangeClientByPlanNode"] = exchangeClients;
 
-  return folly::toJson(obj);
+  return obj;
 }
 
 std::shared_ptr<MergeSource> Task::addLocalMergeSource(

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2124,7 +2124,7 @@ std::string Task::toShortJsonString() const {
   obj["numThreads"] = numThreads_;
   obj["terminateRequested_"] = std::to_string(terminateRequested_);
   obj["pauseRequested_"] = std::to_string(pauseRequested_);
-  return folly::toPrettyJson(obj);
+  return folly::toJson(obj);
 }
 
 std::string Task::toJsonString() const {
@@ -2153,7 +2153,7 @@ std::string Task::toJsonString() const {
   }
 
   if (planFragment_.planNode) {
-    obj["plan"] = planFragment_.planNode->toString();
+    obj["plan"] = planFragment_.planNode->toString(true, true);
   }
 
   folly::dynamic driverObj = folly::dynamic::object;
@@ -2176,7 +2176,7 @@ std::string Task::toJsonString() const {
   }
   obj["exchangeClientByPlanNode"] = exchangeClients;
 
-  return folly::toPrettyJson(obj);
+  return folly::toJson(obj);
 }
 
 std::shared_ptr<MergeSource> Task::addLocalMergeSource(

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -83,6 +83,10 @@ class Task : public std::enable_shared_from_this<Task> {
 
   std::string toShortJsonString() const;
 
+  folly::dynamic toJson() const;
+
+  folly::dynamic toShortJson() const;
+
   /// Returns universally unique identifier of the task.
   const std::string& uuid() const {
     return uuid_;
@@ -702,6 +706,8 @@ class Task : public std::enable_shared_from_this<Task> {
   // Returns task execution error message or empty string if not error
   // occurred. This should only be called inside mutex_ protection.
   std::string errorMessageLocked() const;
+
+  folly::dynamic toShortJsonLocked() const;
 
   class MemoryReclaimer : public exec::MemoryReclaimer {
    public:

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -524,11 +524,11 @@ TEST_F(TaskTest, wrongPlanNodeForSplit) {
   ASSERT_EQ(
       task->toString(), "{Task task-1 (task-1)Plan: -- Project\n\n drivers:\n");
   ASSERT_EQ(
-      task->toJsonString(),
-      "{\n  \"concurrentSplitGroups\": 1,\n  \"drivers\": {},\n  \"exchangeClientByPlanNode\": {},\n  \"groupedPartitionedOutput\": false,\n  \"id\": \"task-1\",\n  \"noMoreOutputBuffers\": false,\n  \"numDriversPerSplitGroup\": 0,\n  \"numDriversUngrouped\": 0,\n  \"numFinishedDrivers\": 0,\n  \"numRunningDrivers\": 0,\n  \"numRunningSplitGroups\": 0,\n  \"numThreads\": 0,\n  \"numTotalDrivers_\": 0,\n  \"onThreadSince\": \"0\",\n  \"partitionedOutputConsumed\": false,\n  \"plan\": \"-- Project\\n\",\n  \"shortId\": \"task-1\",\n  \"state\": \"Running\",\n  \"terminateRequested_\": \"0\"\n}");
+      folly::toPrettyJson(task->toJson()),
+      "{\n  \"concurrentSplitGroups\": 1,\n  \"drivers\": [],\n  \"exchangeClientByPlanNode\": {},\n  \"groupedPartitionedOutput\": false,\n  \"id\": \"task-1\",\n  \"noMoreOutputBuffers\": false,\n  \"numDriversPerSplitGroup\": 0,\n  \"numDriversUngrouped\": 0,\n  \"numFinishedDrivers\": 0,\n  \"numRunningDrivers\": 0,\n  \"numRunningSplitGroups\": 0,\n  \"numThreads\": 0,\n  \"numTotalDrivers\": 0,\n  \"onThreadSince\": 0,\n  \"partitionedOutputConsumed\": false,\n  \"pauseRequested\": false,\n  \"plan\": \"-- Project[expressions: (p0:INTEGER, multiply(ROW[\\\"a\\\"],ROW[\\\"a\\\"])), (p1:DOUBLE, plus(ROW[\\\"b\\\"],ROW[\\\"b\\\"]))] -> p0:INTEGER, p1:DOUBLE\\n  -- TableScan[table: hive_table] -> a:INTEGER, b:DOUBLE\\n\",\n  \"shortId\": \"task-1\",\n  \"state\": \"Running\",\n  \"terminateRequested\": false\n}");
   ASSERT_EQ(
-      task->toShortJsonString(),
-      "{\n  \"id\": \"task-1\",\n  \"numFinishedDrivers\": 0,\n  \"numRunningDrivers\": 0,\n  \"numThreads\": 0,\n  \"numTotalDrivers_\": 0,\n  \"pauseRequested_\": \"0\",\n  \"shortId\": \"task-1\",\n  \"state\": \"Running\",\n  \"terminateRequested_\": \"0\"\n}");
+      folly::toPrettyJson(task->toShortJson()),
+      "{\n  \"id\": \"task-1\",\n  \"numFinishedDrivers\": 0,\n  \"numRunningDrivers\": 0,\n  \"numThreads\": 0,\n  \"numTotalDrivers\": 0,\n  \"pauseRequested\": false,\n  \"shortId\": \"task-1\",\n  \"state\": \"Running\",\n  \"terminateRequested\": false\n}");
 
   // Add split for the source node.
   task->addSplit("0", exec::Split(folly::copy(connectorSplit)));


### PR DESCRIPTION
Using string carrying json content to propagate will create many escapes that at final rendering often is hard to read. Change to folly::dynamic solves the problem