### PR TITLE
Remove extra semi colon from velox/type/Subfield.cpp

### DIFF
--- a/velox/type/Subfield.cpp
+++ b/velox/type/Subfield.cpp
@@ -40,7 +40,7 @@ Subfield::Subfield(
 Subfield::Subfield(std::vector<std::unique_ptr<Subfield::PathElement>>&& path)
     : path_(std::move(path)) {
   VELOX_CHECK_GE(path_.size(), 1);
-};
+}
 
 Subfield Subfield::clone() const {
   Subfield subfield;


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: dmm-fb

Differential Revision: D52968942


