### PR TITLE
Avoid implicit narrowing conversion in FlatVector<StringView>::copy

### DIFF
--- a/velox/vector/FlatVector.cpp
+++ b/velox/vector/FlatVector.cpp
@@ -50,7 +50,7 @@ void FlatVector<bool>::set(vector_size_t idx, bool value) {
 
 template <>
 Buffer* FlatVector<StringView>::getBufferWithSpace(
-    int32_t size,
+    size_t size,
     bool exactSize) {
   VELOX_DCHECK_GE(stringBuffers_.size(), stringBufferSet_.size());
 
@@ -63,7 +63,7 @@ Buffer* FlatVector<StringView>::getBufferWithSpace(
   }
 
   // Allocate a new buffer.
-  const int32_t newSize = exactSize ? size : std::max(kInitialStringSize, size);
+  const size_t newSize = exactSize ? size : std::max(kInitialStringSize, size);
   BufferPtr newBuffer = AlignedBuffer::allocate<char>(newSize, pool());
   newBuffer->setSize(0);
   addStringBuffer(newBuffer);
@@ -72,7 +72,7 @@ Buffer* FlatVector<StringView>::getBufferWithSpace(
 
 template <>
 char* FlatVector<StringView>::getRawStringBufferWithSpace(
-    int32_t size,
+    size_t size,
     bool exactSize) {
   Buffer* buffer = getBufferWithSpace(size, exactSize);
   char* rawBuffer = buffer->asMutable<char>() + buffer->size();

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -46,11 +46,11 @@ class FlatVector final : public SimpleVector<T> {
   // Minimum size of a string buffer. 32 KB value is chosen to ensure that a
   // single buffer is sufficient for a "typical" vector: 1K rows, medium size
   // strings.
-  static constexpr vector_size_t kInitialStringSize =
+  static constexpr size_t kInitialStringSize =
       (32 * 1024) - sizeof(AlignedBuffer);
   /// Maximum size of a string buffer to re-use (see
   /// BaseVector::prepareForReuse): 1MB.
-  static constexpr vector_size_t kMaxStringSizeForReuse =
+  static constexpr size_t kMaxStringSizeForReuse =
       (1 << 20) - sizeof(AlignedBuffer);
 
   FlatVector(
@@ -454,7 +454,7 @@ class FlatVector final : public SimpleVector<T> {
   ///
   /// If allocates new buffer and 'exactSize' is true, allocates 'size' bytes.
   /// Otherwise, allocates at least kInitialStringSize bytes.
-  Buffer* getBufferWithSpace(int32_t /*size*/, bool exactSize = false) {
+  Buffer* getBufferWithSpace(size_t /*size*/, bool exactSize = false) {
     return nullptr;
   }
 
@@ -470,7 +470,7 @@ class FlatVector final : public SimpleVector<T> {
   ///
   /// If allocates new buffer and 'exactSize' is true, allocates 'size' bytes.
   /// Otherwise, allocates at least kInitialStringSize bytes.
-  char* getRawStringBufferWithSpace(int32_t /*size*/, bool exactSize = false) {
+  char* getRawStringBufferWithSpace(size_t /*size*/, bool exactSize = false) {
     return nullptr;
   }
 
@@ -582,13 +582,11 @@ void FlatVector<StringView>::validate(
     const VectorValidateOptions& options) const;
 
 template <>
-Buffer* FlatVector<StringView>::getBufferWithSpace(
-    int32_t size,
-    bool exactSize);
+Buffer* FlatVector<StringView>::getBufferWithSpace(size_t size, bool exactSize);
 
 template <>
 char* FlatVector<StringView>::getRawStringBufferWithSpace(
-    int32_t size,
+    size_t size,
     bool exactSize);
 
 template <>

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 #include <cstdint>
 #include <functional>
+#include <limits>
 #include <optional>
 
 #include "velox/common/base/tests/GTestUtils.h"
@@ -3637,6 +3638,13 @@ TEST_F(VectorTest, setType) {
                ROW({"ee", "ff"}, {VARCHAR(), BIGINT()})),
            BIGINT()});
   test(type, newType, invalidNewType);
+}
+
+TEST_F(VectorTest, getLargeStringBuffer) {
+  auto vector = makeFlatVector<StringView>({});
+  size_t size = size_t(std::numeric_limits<int32_t>::max()) + 1;
+  auto* buffer = vector->getBufferWithSpace(size);
+  EXPECT_GE(buffer->capacity(), size);
 }
 
 } // namespace


### PR DESCRIPTION
Summary: Avoid implicit narrowing conversion from size_t (that is uint64_t on some machines) to int32_t that causes negative value when the size_t value is too large.

Differential Revision: D53051400


