### PR TITLE
Remove unused variables in velox/tpch/gen/dbgen/text.cpp

### DIFF
--- a/velox/tpch/gen/dbgen/text.cpp
+++ b/velox/tpch/gen/dbgen/text.cpp
@@ -244,7 +244,6 @@ static char* gen_terminator(char* dest, seed_t* seed) {
 }
 
 static char* gen_sentence(char* dest, seed_t* seed) {
-  const char* cptr;
   int i;
 
   DSS_HUGE j;
@@ -254,7 +253,6 @@ static char* gen_sentence(char* dest, seed_t* seed) {
   index += grammar.list[1].weight < j;
   index += grammar.list[2].weight < j;
   index += grammar.list[3].weight < j;
-  cptr = grammar.list[index].text;
 
   if (index == 0) {
     dest = gen_np(dest, seed);


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dmm-fb

Differential Revision: D52981074


