### PR TITLE
Remove unused variables in velox/dwio/common/tests/utils/BatchMaker.cpp

### DIFF
--- a/velox/dwio/common/tests/utils/BatchMaker.cpp
+++ b/velox/dwio/common/tests/utils/BatchMaker.cpp
@@ -51,14 +51,11 @@ VectorPtr createScalar(
   BufferPtr nulls = allocateNulls(size, &pool);
   auto* nullsPtr = nulls->asMutable<uint64_t>();
 
-  size_t nullCount = 0;
   for (size_t i = 0; i < size; ++i) {
     auto notNull = isNotNull(gen, i, isNullAt);
     bits::setNull(nullsPtr, i, !notNull);
     if (notNull) {
       valuesPtr[i] = val();
-    } else {
-      nullCount++;
     }
   }
 


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dmm-fb

Differential Revision: D52981057


