### PR TITLE
Fix shadowed variable in velox/common/memory/HashStringAllocator.cpp

### DIFF
--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -216,8 +216,8 @@ HashStringAllocator::finishWrite(
   // and the block was extended. Calculate the new position.
   if (startPosition_.header->isContinued()) {
     auto header = startPosition_.header;
-    const auto offset = startPosition_.offset();
-    const auto extra = offset - header->usableSize();
+    const auto offset_2 = startPosition_.offset();
+    const auto extra = offset_2 - header->usableSize();
     if (extra > 0) {
       auto newHeader = header->nextContinued();
       auto newPosition = newHeader->begin() + extra;


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dmm-fb

Differential Revision: D52959059


