### PR TITLE
Fix shadowed variable in velox/dwio/common/SeekableInputStream.cpp

### DIFF
--- a/velox/dwio/common/SeekableInputStream.cpp
+++ b/velox/dwio/common/SeekableInputStream.cpp
@@ -167,8 +167,8 @@ google::protobuf::int64 SeekableArrayInputStream::ByteCount() const {
   return static_cast<google::protobuf::int64>(position);
 }
 
-void SeekableArrayInputStream::seekToPosition(PositionProvider& position) {
-  this->position = position.next();
+void SeekableArrayInputStream::seekToPosition(PositionProvider& position_2) {
+  this->position = position_2.next();
 }
 
 std::string SeekableArrayInputStream::getName() const {


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dmm-fb

Differential Revision: D52959199


