### PR TITLE
Remove unused exception parameter from velox/common/base/tests/AsyncSourceTest.cpp

### DIFF
--- a/velox/common/base/tests/AsyncSourceTest.cpp
+++ b/velox/common/base/tests/AsyncSourceTest.cpp
@@ -137,7 +137,7 @@ TEST(AsyncSourceTest, errorsWithThreads) {
             auto gizmo =
                 gizmos[folly::Random::rand32(rng) % gizmos.size()]->move();
             EXPECT_EQ(nullptr, gizmo);
-          } catch (std::exception& e) {
+          } catch (std::exception&) {
             ++numErrors;
           }
         }


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: dmm-fb

Differential Revision: D52957852


