### PR TITLE
Fix One Definition Rule (`-Wodr`), LTO Type Mismatch (`-Wlto-type-mismatch`)  and Strict Aliasing warnings when building Velox with LTO

### DIFF
--- a/velox/expression/signature_parser/SignatureParser.yy
+++ b/velox/expression/signature_parser/SignatureParser.yy
@@ -1,4 +1,5 @@
 %{
+#define yyFlexLexer veloxspFlexLexer
 #include <FlexLexer.h>
 #include "velox/common/base/Exceptions.h"
 #include "velox/expression/TypeSignature.h"

--- a/velox/expression/type_calculation/TypeCalculation.yy
+++ b/velox/expression/type_calculation/TypeCalculation.yy
@@ -1,4 +1,5 @@
 %{
+#define yyFlexLexer veloxtcFlexLexer
 #include <FlexLexer.h>
 #include <velox/common/base/Exceptions.h>
 %}


### PR DESCRIPTION
When building and static linking velox with LTO, I encountered the following warnings:

```
build/_deps/velox-src/./velox/expression/type_calculation/Scanner.h:28: error: type ‘struct Scanner’ violates the C++ One Definition Rule [-Werror=odr]
   28 | class Scanner : public yyFlexLexer ***
      | 
build/_deps/velox-src/./velox/expression/type_calculation/Scanner.h:28: note: a type with the same name but different base type is defined in another translation unit
   28 | class Scanner : public yyFlexLexer ***
      | 
/usr/include/FlexLexer.h:119: note: type name ‘yyFlexLexer’ should match type name ‘veloxtcFlexLexer’
  119 | class yyFlexLexer : public FlexLexer ***
      | 
build/_deps/velox-src/./velox/expression/signature_parser/Scanner.h:29: error: type ‘struct Scanner’ violates the C++ One Definition Rule [-Werror=odr]
   29 | class Scanner : public yyFlexLexer ***
      | 
build/_deps/velox-src/./velox/expression/signature_parser/Scanner.h:29: note: a type with the same name but different base type is defined in another translation unit
   29 | class Scanner : public yyFlexLexer ***
      | 
/usr/include/FlexLexer.h:119: note: type name ‘yyFlexLexer’ should match type name ‘veloxspFlexLexer’
  119 | class yyFlexLexer : public FlexLexer ***
      | 
build/_deps/velox-src/./velox/expression/signature_parser/Scanner.h:39: error: type of ‘lex’ does not match original declaration [-Werror=lto-type-mismatch]
   39 |   int lex(Parser::semantic_type* yylval);
      | 
build/_deps/velox-build/velox/expression/signature_parser/Scanner.cpp:1275: note: ‘lex’ was previously declared here
 1275 | YY_DECL
      | 
build/_deps/velox-build/velox/expression/signature_parser/Scanner.cpp:1275: note: code may be misoptimized unless ‘-fno-strict-aliasing’ is used
build/_deps/velox-src/./velox/expression/type_calculation/Scanner.h:35: error: type of ‘lex’ does not match original declaration [-Werror=lto-type-mismatch]
   35 |   int lex(Parser::semantic_type* yylval);
      | 
build/_deps/velox-build/velox/expression/type_calculation/Scanner.cpp:1045: note: ‘lex’ was previously declared here
 1045 | YY_DECL
      | 
build/_deps/velox-build/velox/expression/type_calculation/Scanner.cpp:1045: note: code may be misoptimized unless ‘-fno-strict-aliasing’ is used
```

(Pertinent compiler flags: 
`/usr/bin/g++-12 -O3 -DNDEBUG -flto=auto -fno-fat-lto-objects  -Werror -Wall -Wextra -pedantic -Wl,--fatal-warnings`)


I fixed these warnings /errors by adding `#define yyFlexLexer` macros to `velox/expression/signature_parser/SignatureParser.yy` and `velox/expression/type_calculation/TypeCalculation.yy`, which respectively match what was auto-generated in `SignatureParser.yy.cc` and `TypeCalculation.yy.cc`, respectively.