### PR TITLE
Make ngrams size to be integer to match presto.

### DIFF
--- a/velox/functions/prestosql/ArrayFunctions.h
+++ b/velox/functions/prestosql/ArrayFunctions.h
@@ -757,7 +757,7 @@ struct ArrayNGramsFunction {
 
   // Fast path for primitives.
   template <typename Out, typename In>
-  void call(Out& out, const In& input, int64_t n) {
+  void call(Out& out, const In& input, int32_t n) {
     VELOX_USER_CHECK_GT(n, 0, "N must be greater than zero.");
 
     if (n > input.size()) {
@@ -783,7 +783,7 @@ struct ArrayNGramsFunction {
   void call(
       out_type<Array<Array<Generic<T1>>>>& out,
       const arg_type<Array<Generic<T1>>>& input,
-      int64_t n) {
+      int32_t n) {
     VELOX_USER_CHECK_GT(n, 0, "N must be greater than zero.");
 
     if (n > input.size()) {
@@ -807,7 +807,7 @@ struct ArrayNGramsFunction {
 };
 
 template <typename T>
-struct ArrayNGramsFunctionFunctionString {
+struct ArrayNGramsFunctionString {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   static constexpr int32_t reuse_strings_from_arg = 0;
@@ -816,7 +816,7 @@ struct ArrayNGramsFunctionFunctionString {
   void call(
       out_type<Array<Array<Varchar>>>& out,
       const arg_type<Array<Varchar>>& input,
-      int64_t n) {
+      int32_t n) {
     VELOX_USER_CHECK_GT(n, 0, "N must be greater than zero.");
 
     if (n > input.size()) {

--- a/velox/functions/prestosql/registration/ArrayNGramsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayNGramsRegistration.cpp
@@ -21,7 +21,7 @@ namespace facebook::velox::functions {
 namespace {
 template <typename T>
 inline void registerArrayNGramsFunctions(const std::string& prefix) {
-  registerFunction<ArrayNGramsFunction, Array<Array<T>>, Array<T>, int64_t>(
+  registerFunction<ArrayNGramsFunction, Array<Array<T>>, Array<T>, int32_t>(
       {prefix + "ngrams"});
 }
 
@@ -40,9 +40,9 @@ void registerArrayNGramsFunctions(const std::string& prefix) {
   registerArrayNGramsFunctions<Varbinary>(prefix);
   registerArrayNGramsFunctions<Generic<T1>>(prefix);
   registerFunction<
-      ArrayNGramsFunctionFunctionString,
+      ArrayNGramsFunctionString,
       Array<Array<Varchar>>,
       Array<Varchar>,
-      int64_t>({prefix + "ngrams"});
+      int32_t>({prefix + "ngrams"});
 }
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/ArrayNGramsTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayNGramsTest.cpp
@@ -26,14 +26,14 @@ class ArrayNGramsTest : public test::FunctionBaseTest {
   template <typename T>
   void testNgram(
       const std::vector<std::optional<T>>& inputArray,
-      int64_t n,
+      int32_t n,
       const std::vector<std::optional<std::vector<std::optional<T>>>>&
           expectedOutput) {
     std::vector<std::optional<std::vector<std::optional<T>>>> inputVec(
         {inputArray});
     auto input = makeNullableArrayVector<T>(inputVec);
-    auto result =
-        evaluate(fmt::format("ngrams(c0, {})", n), makeRowVector({input}));
+    auto result = evaluate(
+        fmt::format("ngrams(c0, {}::INTEGER)", n), makeRowVector({input}));
 
     auto expected = makeNullableNestedArrayVector<T>({expectedOutput});
     assertEqualVectors(expected, result);
@@ -48,10 +48,6 @@ TEST_F(ArrayNGramsTest, integers) {
   testNgram<int64_t>({1, 2, 3, 4}, 5, {{{1, 2, 3, 4}}});
   testNgram<int64_t>(
       {1, 2, 3, 4}, std::numeric_limits<int32_t>::max(), {{{1, 2, 3, 4}}});
-  testNgram<int64_t>(
-      {1, 2, 3, 4},
-      std::numeric_limits<int32_t>::max() + (int64_t)(1000),
-      {{{1, 2, 3, 4}}});
   testNgram<int64_t>({}, 1, {{{}}});
   testNgram<int64_t>({}, 10, {{{}}});
 }
@@ -59,14 +55,14 @@ TEST_F(ArrayNGramsTest, integers) {
 TEST_F(ArrayNGramsTest, invalidN) {
   auto input = makeArrayVector<int64_t>({{1, 2, 3, 4}});
   VELOX_ASSERT_THROW(
-      evaluate("ngrams(c0, 0)", makeRowVector({input})),
+      evaluate("ngrams(c0, 0::INTEGER)", makeRowVector({input})),
       "(0 vs. 0) N must be greater than zero");
   VELOX_ASSERT_THROW(
-      evaluate("ngrams(c0, -5)", makeRowVector({input})),
-      "(-5 vs. 0) N must be greater than zero");
+      evaluate("ngrams(c0, -5::INTEGER)", makeRowVector({input})),
+      "Scalar function signature is not supported");
   input = makeArrayVector<int64_t>({{}});
   VELOX_ASSERT_THROW(
-      evaluate("ngrams(c0, 0)", makeRowVector({input})),
+      evaluate("ngrams(c0, 0::INTEGER)", makeRowVector({input})),
       "(0 vs. 0) N must be greater than zero");
 }
 


### PR DESCRIPTION
Summary: In Presto, Ngrams take [Integer](https://github.com/prestodb/presto/blob/4b458d41b8988f02c09bf9ff85e5d7bacf093b98/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayNgramsFunction.java#L39) as the second argument.

Differential Revision: D53055195


