### PR TITLE
Reduce parallelism for linux-build.

### DIFF
--- a/.circleci/dist_compile.yml
+++ b/.circleci/dist_compile.yml
@@ -253,7 +253,7 @@ jobs:
       - run:
           name: "Build"
           command: |
-            make debug NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=5 EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON"
+            make debug NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4 EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON"
             ccache -s
           no_output_timeout: 1h
       - run:


### PR DESCRIPTION
**Why**
 Lots of linux-build jobs seem to be OOMing out building Velox, for e.g: https://app.circleci.com/pipelines/github/facebookincubator/velox/43156/workflows/ab5f66a6-6d8a-4234-add2-d84cf434b7c9/jobs/299539.  

**How**
We are currently mitigating this by reducing parallelism . This is a short term fix while we investigate a more long term solution. 
