### PR TITLE
Skip load data into an inactive destination buffer with notify installed

### DIFF
--- a/velox/exec/OutputBuffer.cpp
+++ b/velox/exec/OutputBuffer.cpp
@@ -94,6 +94,7 @@ std::vector<std::unique_ptr<folly::IOBuf>> DestinationBuffer::getData(
     uint64_t maxBytes,
     int64_t sequence,
     DataAvailableCallback notify,
+    DataConsumerActiveCheckCallback activeCheck,
     ArbitraryBuffer* arbitraryBuffer) {
   VELOX_CHECK_GE(
       sequence, sequence_, "Get received for an already acknowledged item");
@@ -106,12 +107,15 @@ std::vector<std::unique_ptr<folly::IOBuf>> DestinationBuffer::getData(
             << sequence_ << " Setting second notify " << notifySequence_
             << " / " << sequence;
     notify_ = std::move(notify);
+    aliveCheck_ = std::move(activeCheck);
     notifySequence_ = std::min(notifySequence_, sequence);
     notifyMaxBytes_ = maxBytes;
     return {};
   }
+
   if (sequence - sequence_ == data_.size()) {
     notify_ = std::move(notify);
+    aliveCheck_ = std::move(activeCheck);
     notifySequence_ = sequence;
     notifyMaxBytes_ = maxBytes;
     return {};
@@ -149,16 +153,22 @@ void DestinationBuffer::enqueue(std::shared_ptr<SerializedPage> data) {
 
 DataAvailable DestinationBuffer::getAndClearNotify() {
   if (notify_ == nullptr) {
+    VELOX_CHECK_NULL(aliveCheck_);
     return DataAvailable();
   }
   DataAvailable result;
   result.callback = notify_;
   result.sequence = notifySequence_;
-  result.data = getData(notifyMaxBytes_, notifySequence_, nullptr);
+  result.data = getData(notifyMaxBytes_, notifySequence_, nullptr, nullptr);
+  clearNotify();
+  return result;
+}
+
+void DestinationBuffer::clearNotify() {
   notify_ = nullptr;
+  aliveCheck_ = nullptr;
   notifySequence_ = 0;
   notifyMaxBytes_ = 0;
-  return result;
 }
 
 void DestinationBuffer::finish() {
@@ -170,6 +180,11 @@ void DestinationBuffer::finish() {
 void DestinationBuffer::maybeLoadData(ArbitraryBuffer* buffer) {
   VELOX_CHECK(!buffer->empty() || buffer->hasNoMoreData());
   if (notify_ == nullptr) {
+    return;
+  }
+  if (aliveCheck_ != nullptr && !aliveCheck_()) {
+    // Skip load data to an inactive destination buffer.
+    clearNotify();
     return;
   }
   VELOX_CHECK_GT(notifyMaxBytes_, 0);
@@ -633,7 +648,8 @@ void OutputBuffer::getData(
     int destination,
     uint64_t maxBytes,
     int64_t sequence,
-    DataAvailableCallback notify) {
+    DataAvailableCallback notify,
+    DataConsumerActiveCheckCallback activeCheck) {
   std::vector<std::unique_ptr<folly::IOBuf>> data;
   std::vector<std::shared_ptr<SerializedPage>> freed;
   std::vector<ContinuePromise> promises;
@@ -653,7 +669,8 @@ void OutputBuffer::getData(
         sequence);
     freed = buffer->acknowledge(sequence, true);
     updateAfterAcknowledgeLocked(freed, promises);
-    data = buffer->getData(maxBytes, sequence, notify, arbitraryBuffer_.get());
+    data = buffer->getData(
+        maxBytes, sequence, notify, activeCheck, arbitraryBuffer_.get());
   }
   releaseAfterAcknowledge(freed, promises);
   if (!data.empty()) {

--- a/velox/exec/OutputBuffer.h
+++ b/velox/exec/OutputBuffer.h
@@ -27,6 +27,16 @@ namespace facebook::velox::exec {
 using DataAvailableCallback = std::function<
     void(std::vector<std::unique_ptr<folly::IOBuf>> pages, int64_t sequence)>;
 
+/// Callback provided to indicate if the consumer of a destination buffer is
+/// currently active or not. It is used by arbitrary output buffer to optimize
+/// the http based streaming shuffle in Prestissimo. For instance, the arbitrary
+/// output buffer shall skip sending data to inactive destination buffer and
+/// only send to the currently active ones to reduce the time that a buffer
+/// stays in a destination buffer. Note that once a data is sent to a
+/// destination buffer, it can't be sent to the other destination buffers no
+/// matter the current destination buffer is active or not.
+using DataConsumerActiveCheckCallback = std::function<bool()>;
+
 struct DataAvailable {
   DataAvailableCallback callback;
   int64_t sequence;
@@ -115,43 +125,50 @@ class DestinationBuffer {
   /// arbitrary buffer on demand.
   void loadData(ArbitraryBuffer* buffer, uint64_t maxBytes);
 
-  // Returns a shallow copy (folly::IOBuf::clone) of the data starting at
-  // 'sequence', stopping after exceeding 'maxBytes'. If there is no data,
-  // 'notify' is installed so that this gets called when data is added.
+  /// Returns a shallow copy (folly::IOBuf::clone) of the data starting at
+  /// 'sequence', stopping after exceeding 'maxBytes'. If there is no data,
+  /// 'notify' is installed so that this gets called when data is added. If not
+  /// null, 'activeCheck' is used to check if the consumer of a destination
+  /// buffer with 'notify' installed is currently active or not. This only
+  /// applies for arbitrary output buffer for now.
   std::vector<std::unique_ptr<folly::IOBuf>> getData(
       uint64_t maxBytes,
       int64_t sequence,
       DataAvailableCallback notify,
+      DataConsumerActiveCheckCallback activeCheck,
       ArbitraryBuffer* arbitraryBuffer = nullptr);
 
-  // Removes data from the queue and returns removed data. If 'fromGetData' we
-  // do not give a warning for the case where no data is removed, otherwise we
-  // expect that data does get freed. We cannot assert that data gets
-  // deleted because acknowledge messages can arrive out of order.
+  /// Removes data from the queue and returns removed data. If 'fromGetData' we
+  /// do not give a warning for the case where no data is removed, otherwise we
+  /// expect that data does get freed. We cannot assert that data gets deleted
+  /// because acknowledge messages can arrive out of order.
   std::vector<std::shared_ptr<SerializedPage>> acknowledge(
       int64_t sequence,
       bool fromGetData);
 
-  // Removes all remaining data from the queue and returns the removed data.
+  /// Removes all remaining data from the queue and returns the removed data.
   std::vector<std::shared_ptr<SerializedPage>> deleteResults();
 
-  // Returns and clears the notify callback, if any, along with arguments for
-  // the callback.
+  /// Returns and clears the notify callback, if any, along with arguments for
+  /// the callback.
   DataAvailable getAndClearNotify();
 
-  // Finishes this destination buffer, set finished stats.
+  /// Finishes this destination buffer, set finished stats.
   void finish();
 
-  // Returns the stats of this buffer.
+  /// Returns the stats of this buffer.
   Stats stats() const;
 
   std::string toString();
 
  private:
+  void clearNotify();
+
   std::vector<std::shared_ptr<SerializedPage>> data_;
   // The sequence number of the first in 'data_'.
   int64_t sequence_ = 0;
-  DataAvailableCallback notify_ = nullptr;
+  DataAvailableCallback notify_{nullptr};
+  DataConsumerActiveCheckCallback aliveCheck_{nullptr};
   // The sequence number of the first item to pass to 'notify'.
   int64_t notifySequence_{0};
   uint64_t notifyMaxBytes_{0};
@@ -200,6 +217,8 @@ class OutputBuffer {
 
     /// Stats of the OutputBuffer's destinations.
     std::vector<DestinationBuffer::Stats> buffersStats;
+
+    std::string toString() const;
   };
 
   OutputBuffer(
@@ -247,7 +266,8 @@ class OutputBuffer {
       int destination,
       uint64_t maxSize,
       int64_t sequence,
-      DataAvailableCallback notify);
+      DataAvailableCallback notify,
+      DataConsumerActiveCheckCallback activeCheck);
 
   // Continues any possibly waiting producers. Called when the
   // producer task has an error or cancellation.

--- a/velox/exec/OutputBufferManager.cpp
+++ b/velox/exec/OutputBufferManager.cpp
@@ -94,9 +94,10 @@ bool OutputBufferManager::getData(
     int destination,
     uint64_t maxBytes,
     int64_t sequence,
-    DataAvailableCallback notify) {
+    DataAvailableCallback notify,
+    DataConsumerActiveCheckCallback activeCheck) {
   if (auto buffer = getBufferIfExists(taskId)) {
-    buffer->getData(destination, maxBytes, sequence, notify);
+    buffer->getData(destination, maxBytes, sequence, notify, activeCheck);
     return true;
   }
   return false;

--- a/velox/exec/OutputBufferManager.h
+++ b/velox/exec/OutputBufferManager.h
@@ -61,25 +61,26 @@ class OutputBufferManager {
 
   void deleteResults(const std::string& taskId, int destination);
 
-  // Adds up to 'maxBytes' bytes worth of data for 'destination' from
-  // 'taskId'. The sequence number of the data must be >= 'sequence'.
-  // If there is no buffer associated with the given taskId, returns false.
-  // If there is no data, 'notify' will be registered and
-  // called when there is data or the source is at end, the function returns
-  // true.
-  // Existing data with a sequence number < sequence is deleted. The caller is
-  // expected to increment the sequence number between calls by the
-  // number of items received. In this way the next call implicitly
-  // acknowledges receipt of the results from the previous. The
-  // acknowledge method is offered for an early ack, so that the
-  // producer can continue before the consumer is done processing the
-  // received data.
+  /// Adds up to 'maxBytes' bytes worth of data for 'destination' from 'taskId'.
+  /// The sequence number of the data must be >= 'sequence'. If there is no
+  /// buffer associated with the given taskId, returns false. If there is no
+  /// data, 'notify' will be registered and called when there is data or the
+  /// source is at end, the function returns true. Existing data with a sequence
+  /// number < sequence is deleted. The caller is expected to increment the
+  /// sequence number between calls by the number of items received. In this way
+  /// the next call implicitly acknowledges receipt of the results from the
+  /// previous. The acknowledge method is offered for an early ack, so that the
+  /// producer can continue before the consumer is done processing the received
+  /// data. If not null, 'activeCheck' is used to check if data consumer is
+  /// currently active or not. This only applies for arbitrary output buffer for
+  /// now.
   bool getData(
       const std::string& taskId,
       int destination,
       uint64_t maxBytes,
       int64_t sequence,
-      DataAvailableCallback notify);
+      DataAvailableCallback notify,
+      DataConsumerActiveCheckCallback activeCheck = nullptr);
 
   void removeTask(const std::string& taskId);
 


### PR DESCRIPTION
In Meta internal test, we found scale writer can be very slow due to the slow shuffle
between writer stage and source stage which use arbitrary output buffer. Here is
scenario can cause the shuffle slowness:
T1 exchange client writer stage fetch data from arbitrary output buffer from source stage
T2 arbitrary output buffer doesn't have any buffered data and install notify to send data
      to the client when data is ready
T3 exchange client timeout and switch to fetch data from the other source stage buffers
T4 arbitrary output buffer has data and found the destination buffer of the exchange client
     in T1 has installed notify to wait for data. Then it load data into the destination buffer.
T5 the loaded data stays in the destination buffer for quite a while until the exchange client
     switch to fetch data from this source again.

This is inefficient and cause the slow query with scale writer. This PR optimizes this by
adding a destination buffer active check callback. When Prestissimo layer fetch data from
an output buffer, it provides an additional active check callback to indicate whether the
client request is still active or not, and the arbitrary output buffer will leverage this to skip
loading data into a destination buffer if the associated client request is not active. In Prestissimo,
the client request is a http request, and if it has expired, then the request is not active.
The experiment shows the query has shuffled more than 50TB within 30 mins and previously
it takes hours to only shuffle ~10TB.

The followup is to provide the callback in Prestissimo layer to check http request's callback
state.