### PR TITLE
Remove unused function from velox/parse/Expressions.cpp

### DIFF
--- a/velox/parse/Expressions.cpp
+++ b/velox/parse/Expressions.cpp
@@ -134,21 +134,6 @@ TypedExprPtr adjustLastNArguments(
   return nullptr;
 }
 
-std::string toString(
-    const std::shared_ptr<const core::CallExpr>& expr,
-    const std::vector<TypedExprPtr>& inputs) {
-  std::ostringstream signature;
-  signature << expr->getFunctionName() << "(";
-  for (auto i = 0; i < inputs.size(); i++) {
-    if (i > 0) {
-      signature << ", ";
-    }
-    signature << inputs[i]->type()->toString();
-  }
-  signature << ")";
-  return signature.str();
-}
-
 TypedExprPtr createWithImplicitCast(
     const std::shared_ptr<const core::CallExpr>& expr,
     const std::vector<TypedExprPtr>& inputs) {


### PR DESCRIPTION
Summary: `-Wunused-function` has identified an unused function. This diff removes it. In many cases these functions have existed for years in an unused state.

Differential Revision: D53049726


