### PR TITLE
Back out "Correctly record the rawBytesRead_ metric in TableScan"

### DIFF
--- a/velox/dwio/common/CacheInputStream.cpp
+++ b/velox/dwio/common/CacheInputStream.cpp
@@ -314,9 +314,6 @@ void CacheInputStream::loadPosition() {
     // 'region_'
     loadRegion.length = std::min<int32_t>(
         loadQuantum_, region_.length - (loadRegion.offset - region_.offset));
-
-    // There is no need to update the metric in the loadData method because
-    // loadSync is always executed regardless and updates the metric.
     loadSync(loadRegion);
   }
   auto* entry = pin_.checkedEntry();

--- a/velox/dwio/common/DirectBufferedInput.cpp
+++ b/velox/dwio/common/DirectBufferedInput.cpp
@@ -274,7 +274,6 @@ std::vector<cache::CachePin> DirectCoalescedLoad::loadData(bool isPrefetch) {
   }
   input_->read(buffers, requests_[0].region.offset, LogType::FILE);
   ioStats_->read().increment(size);
-  ioStats_->incRawBytesRead(size - overread);
   ioStats_->incRawOverreadBytes(overread);
   if (isPrefetch) {
     ioStats_->prefetch().increment(size);

--- a/velox/dwio/common/DirectInputStream.cpp
+++ b/velox/dwio/common/DirectInputStream.cpp
@@ -190,9 +190,6 @@ void DirectInputStream::loadPosition() {
     loadedRegion_.length = (offsetInRegion_ + loadQuantum_ <= region_.length)
         ? loadQuantum_
         : (region_.length - offsetInRegion_);
-
-    // Since the loadSync method updates the metric, but it is conditionally
-    // executed, we also need to update the metric in the loadData method.
     loadSync();
   }
 

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -241,8 +241,7 @@ TEST_F(TableScanTest, allColumns) {
   auto scanNodeId = plan->id();
   auto it = planStats.find(scanNodeId);
   ASSERT_TRUE(it != planStats.end());
-  ASSERT_GT(it->second.peakMemoryBytes, 0);
-  ASSERT_GT(it->second.rawInputBytes, 0);
+  ASSERT_TRUE(it->second.peakMemoryBytes > 0);
   EXPECT_LT(0, exec::TableScan::ioWaitNanos());
 }
 


### PR DESCRIPTION
Summary:
Original commit changeset: f56f72167ff4

Original Phabricator Diff: D52616884

The original change is causing negative value reported as `rawBytesRead` and failing queries: P1101501191

Reviewed By: mbasmanova

Differential Revision: D53089642


