### PR TITLE
Fix timezone issue in date_diff

### DIFF
--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -69,13 +69,18 @@ struct TimestampWithTimezoneSupport {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   // Convert timestampWithTimezone to a timestamp representing the moment at the
-  // zone in timestampWithTimezone.
+  // zone in timestampWithTimezone. If `asGMT` is set to true, return the GMT
+  // time at the same moment.
   FOLLY_ALWAYS_INLINE
   Timestamp toTimestamp(
-      const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
+      const arg_type<TimestampWithTimezone>& timestampWithTimezone,
+      bool asGMT = false) {
     const auto milliseconds = *timestampWithTimezone.template at<0>();
+    auto tz = *timestampWithTimezone.template at<1>();
     Timestamp timestamp = Timestamp::fromMillis(milliseconds);
-    timestamp.toTimezone(*timestampWithTimezone.template at<1>());
+    if (!asGMT) {
+      timestamp.toTimezone(*timestampWithTimezone.template at<1>());
+    }
 
     return timestamp;
   }
@@ -1119,8 +1124,8 @@ struct DateDiffFunction : public TimestampWithTimezoneSupport<T> {
     call(
         result,
         unitString,
-        this->toTimestamp(timestamp1),
-        this->toTimestamp(timestamp2));
+        this->toTimestamp(timestamp1, true),
+        this->toTimestamp(timestamp2, true));
   }
 };
 

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -2502,7 +2502,7 @@ TEST_F(DateTimeFunctionsTest, dateDiffTimestampWithTimezone) {
   // timestamp1: 1970-01-01 00:00:00.000 +00:00 (0)
   // timestamp2: 2020-08-25 16:30:10.123 -08:00 (1'598'373'010'123)
   EXPECT_EQ(
-      1598347810123,
+      1598373010123,
       dateDiff(
           "millisecond",
           0,
@@ -2510,15 +2510,15 @@ TEST_F(DateTimeFunctionsTest, dateDiffTimestampWithTimezone) {
           1'598'373'010'123,
           "America/Los_Angeles"));
   EXPECT_EQ(
-      1598347810,
+      1598373010,
       dateDiff(
           "second", 0, "+00:00", 1'598'373'010'123, "America/Los_Angeles"));
   EXPECT_EQ(
-      26639130,
+      26639550,
       dateDiff(
           "minute", 0, "+00:00", 1'598'373'010'123, "America/Los_Angeles"));
   EXPECT_EQ(
-      443985,
+      443992,
       dateDiff("hour", 0, "+00:00", 1'598'373'010'123, "America/Los_Angeles"));
   EXPECT_EQ(
       18499,


### PR DESCRIPTION
Summary:
In Presto Jave, timestamp with time zone is converted to timestamp as
GMT (simply drop the timezone field). Velox needs to match this
behavior.

Differential Revision: D53105892


