### PR TITLE
Measure Stripe count

### DIFF
--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -132,6 +132,7 @@ class RowReaderOptions {
   // struct
   std::function<void(uint64_t)> blockedOnIoCallback_;
   std::function<void(uint64_t)> decodingTimeMsCallback_;
+  std::function<void(uint16_t)> stripeCountCallback_;
   bool eagerFirstStripeLoad = true;
   uint64_t skipRows_ = 0;
 
@@ -353,8 +354,17 @@ class RowReaderOptions {
     decodingTimeMsCallback_ = std::move(decodingTimeMs);
   }
 
-  const std::function<void(int64_t)> getDecodingTimeMsCallback() const {
+  std::function<void(int64_t)> getDecodingTimeMsCallback() const {
     return decodingTimeMsCallback_;
+  }
+
+  void setStripeCountCallback(
+      std::function<void(uint16_t)> stripeCountCallback) {
+    stripeCountCallback_ = std::move(stripeCountCallback);
+  }
+
+  std::function<void(uint16_t)> getStripeCountCallback() const {
+    return stripeCountCallback_;
   }
 
   void setSkipRows(uint64_t skipRows) {

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -149,6 +149,8 @@ class DwrfRowReader : public StrideIndexProvider,
   std::shared_ptr<StripeDictionaryCache> stripeDictionaryCache_;
   dwio::common::RowReaderOptions options_;
   std::shared_ptr<folly::Executor> executor_;
+  std::function<void(uint64_t)> decodingTimeMsCallback_;
+  std::function<void(uint16_t)> stripeCountCallback_;
 
   struct PrefetchedStripeState {
     bool preloaded;


### PR DESCRIPTION
Summary:
Pass a callback to the reader to count the number of stripes to be read in a file.

Also, void creating a copy of `ecodingTimeMsCallback` on every check.

Differential Revision: D53102004


