### PR TITLE
Remove unused function from velox/functions/lib/StringEncodingUtils.h

### DIFF
--- a/velox/functions/lib/StringEncodingUtils.cpp
+++ b/velox/functions/lib/StringEncodingUtils.cpp
@@ -57,4 +57,14 @@ bool prepareFlatResultsVector(
   return false;
 }
 
+/// Return the string encoding of a vector, if not set UTF8 is returned
+bool isAscii(BaseVector* vector, const SelectivityVector& rows) {
+  if (auto simpleVector = vector->template as<SimpleVector<StringView>>()) {
+    auto ascii = simpleVector->isAscii(rows);
+    return ascii.has_value() && ascii.value();
+  }
+  VELOX_UNREACHABLE();
+  return false;
+};
+
 } // namespace facebook::velox::functions

--- a/velox/functions/lib/StringEncodingUtils.h
+++ b/velox/functions/lib/StringEncodingUtils.h
@@ -34,14 +34,7 @@ bool prepareFlatResultsVector(
     const TypePtr& resultType = VARCHAR());
 
 /// Return the string encoding of a vector, if not set UTF8 is returned
-static bool isAscii(BaseVector* vector, const SelectivityVector& rows) {
-  if (auto simpleVector = vector->template as<SimpleVector<StringView>>()) {
-    auto ascii = simpleVector->isAscii(rows);
-    return ascii.has_value() && ascii.value();
-  }
-  VELOX_UNREACHABLE();
-  return false;
-};
+bool isAscii(BaseVector* vector, const SelectivityVector& rows);
 
 /// Wrap an input function with the appropriate ascii instantiation.
 /// Func is a struct templated on boolean with a static function


### PR DESCRIPTION
Summary: `-Wunused-function` has identified an unused function. This diff removes it. In many cases these functions have existed for years in an unused state.

Reviewed By: palmje

Differential Revision: D53049729


