### PR TITLE
Correctly record the rawInputBytes metric in TableScan

### DIFF
--- a/velox/dwio/common/CacheInputStream.cpp
+++ b/velox/dwio/common/CacheInputStream.cpp
@@ -314,6 +314,9 @@ void CacheInputStream::loadPosition() {
     // 'region_'
     loadRegion.length = std::min<int32_t>(
         loadQuantum_, region_.length - (loadRegion.offset - region_.offset));
+
+    // There is no need to update the metric in the loadData method because
+    // loadSync is always executed regardless and updates the metric.
     loadSync(loadRegion);
   }
   auto* entry = pin_.checkedEntry();

--- a/velox/dwio/common/DirectBufferedInput.cpp
+++ b/velox/dwio/common/DirectBufferedInput.cpp
@@ -270,11 +270,11 @@ std::vector<cache::CachePin> DirectCoalescedLoad::loadData(bool isPrefetch) {
       buffers.push_back(folly::Range(request.tinyData.data(), region.length));
     }
     lastEnd = region.offset + request.loadSize;
-    size += std::min<int32_t>(loadQuantum_, region.length);
+    size += request.loadSize;
   }
   input_->read(buffers, requests_[0].region.offset, LogType::FILE);
   ioStats_->read().increment(size);
-  ioStats_->incRawBytesRead((size > overread) ? size - overread : 0);
+  ioStats_->incRawBytesRead(size - overread);
   ioStats_->incRawOverreadBytes(overread);
   if (isPrefetch) {
     ioStats_->prefetch().increment(size);

--- a/velox/dwio/common/DirectBufferedInput.cpp
+++ b/velox/dwio/common/DirectBufferedInput.cpp
@@ -274,6 +274,7 @@ std::vector<cache::CachePin> DirectCoalescedLoad::loadData(bool isPrefetch) {
   }
   input_->read(buffers, requests_[0].region.offset, LogType::FILE);
   ioStats_->read().increment(size);
+  ioStats_->incRawBytesRead((size > overread) ? size - overread : 0);
   ioStats_->incRawOverreadBytes(overread);
   if (isPrefetch) {
     ioStats_->prefetch().increment(size);

--- a/velox/dwio/common/DirectInputStream.cpp
+++ b/velox/dwio/common/DirectInputStream.cpp
@@ -190,6 +190,9 @@ void DirectInputStream::loadPosition() {
     loadedRegion_.length = (offsetInRegion_ + loadQuantum_ <= region_.length)
         ? loadQuantum_
         : (region_.length - offsetInRegion_);
+
+    // Since the loadSync method updates the metric, but it is conditionally
+    // executed, we also need to update the metric in the loadData method.
     loadSync();
   }
 

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -241,7 +241,8 @@ TEST_F(TableScanTest, allColumns) {
   auto scanNodeId = plan->id();
   auto it = planStats.find(scanNodeId);
   ASSERT_TRUE(it != planStats.end());
-  ASSERT_TRUE(it->second.peakMemoryBytes > 0);
+  ASSERT_GT(it->second.peakMemoryBytes, 0);
+  ASSERT_GT(it->second.rawInputBytes, 0);
   EXPECT_LT(0, exec::TableScan::ioWaitNanos());
 }
 


### PR DESCRIPTION
Follow up https://github.com/facebookincubator/velox/pull/8536 and https://github.com/facebookincubator/velox/pull/8147.

This PR adds a check to set the size to 0 if the difference between the size and overread is less than 0.
