### PR TITLE
Add Presto function at_timezone

### DIFF
--- a/velox/docs/functions/presto/datetime.rst
+++ b/velox/docs/functions/presto/datetime.rst
@@ -405,3 +405,11 @@ picked to be consistent with Presto.
 **Timezone Name Parsing**: When parsing strings that contain timezone names, the
 list of supported timezones follow the definition `here
 <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>`_.
+
+**Timezone Conversion**: The ``AT TIME ZONE`` operator sets the time zone of a timestamp: ::
+
+        SELECT timestamp '2012-10-31 01:00 UTC';
+        -- 2012-10-31 01:00:00.000 UTC
+
+        SELECT timestamp '2012-10-31 01:00 UTC' AT TIME ZONE 'America/Los_Angeles';
+        -- 2012-10-30 18:00:00.000 America/Los_Angeles

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -199,6 +199,11 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "from_iso8601_date"});
   registerFunction<CurrentDateFunction, Date>({prefix + "current_date"});
   registerFunction<ToISO8601Function, Varchar, Date>({prefix + "to_iso8601"});
+  registerFunction<
+      AtTimezoneFunction,
+      TimestampWithTimezone,
+      TimestampWithTimezone,
+      Varchar>({prefix + "at_timezone"});
 }
 } // namespace
 

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -4025,3 +4025,46 @@ TEST_F(DateTimeFunctionsTest, toISO8601Date) {
   EXPECT_EQ("-3492-10-05", toISO8601("-3492-10-05"));
   EXPECT_EQ("-0653-07-12", toISO8601("-653-07-12"));
 }
+
+TEST_F(DateTimeFunctionsTest, atTimezoneTest) {
+  const auto at_timezone = [&](std::optional<int64_t> timestampWithTimezone,
+                               std::optional<std::string> targetTimezone) {
+    return evaluateOnce<int64_t>(
+        "at_timezone(c0, c1)",
+        {TIMESTAMP_WITH_TIME_ZONE(), VARCHAR()},
+        timestampWithTimezone,
+        targetTimezone);
+  };
+
+  EXPECT_EQ(
+      at_timezone(
+          pack(1500101514, util::getTimeZoneID("Asia/Kathmandu")),
+          "America/Boise"),
+      pack(1500101514, util::getTimeZoneID("America/Boise")));
+
+  EXPECT_EQ(
+      at_timezone(
+          pack(1500101514, util::getTimeZoneID("America/Boise")),
+          "Europe/London"),
+      pack(1500101514, util::getTimeZoneID("Europe/London")));
+
+  EXPECT_EQ(
+      at_timezone(
+          pack(1500321297, util::getTimeZoneID("Canada/Yukon")),
+          "Australia/Melbourne"),
+      pack(1500321297, util::getTimeZoneID("Australia/Melbourne")));
+
+  EXPECT_EQ(
+      at_timezone(
+          pack(1500321297, util::getTimeZoneID("Atlantic/Bermuda")),
+          "Pacific/Fiji"),
+      pack(1500321297, util::getTimeZoneID("Pacific/Fiji")));
+
+  EXPECT_EQ(
+      at_timezone(
+          pack(1500321297, util::getTimeZoneID("Atlantic/Bermuda")),
+          std::nullopt),
+      std::nullopt);
+
+  EXPECT_EQ(at_timezone(std::nullopt, "Pacific/Fiji"), std::nullopt);
+}


### PR DESCRIPTION
Implement `at time zone` feature from Presto Java, for `TimestampWithTimezone` input. 

Example usage:
```
SELECT timestamp '2012-10-31 01:00 UTC' AT TIME ZONE 'America/Los_Angeles';
2012-10-30 18:00:00.000 America/Los_Angeles
```