### PR TITLE
Remove extra isNullAt check in cast

### DIFF
--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -636,14 +636,10 @@ VectorPtr CastExpr::applyDecimalToVarcharCast(
   if (StringView::isInline(rowSize)) {
     char inlined[StringView::kInlineSize];
     applyToSelectedNoThrowLocal(context, rows, result, [&](vector_size_t row) {
-      if (simpleInput->isNullAt(row)) {
-        result->setNull(row, true);
-      } else {
-        flatResult->setNoCopy(
-            row,
-            convertToStringView<FromNativeType>(
-                simpleInput->valueAt(row), scale, rowSize, inlined));
-      }
+      flatResult->setNoCopy(
+          row,
+          convertToStringView<FromNativeType>(
+              simpleInput->valueAt(row), scale, rowSize, inlined));
     });
     return result;
   }
@@ -653,17 +649,13 @@ VectorPtr CastExpr::applyDecimalToVarcharCast(
   char* rawBuffer = buffer->asMutable<char>() + buffer->size();
 
   applyToSelectedNoThrowLocal(context, rows, result, [&](vector_size_t row) {
-    if (simpleInput->isNullAt(row)) {
-      result->setNull(row, true);
-    } else {
-      auto stringView = convertToStringView<FromNativeType>(
-          simpleInput->valueAt(row), scale, rowSize, rawBuffer);
-      flatResult->setNoCopy(row, stringView);
-      if (!stringView.isInline()) {
-        // If string view is inline, correponding bytes on the raw string buffer
-        // are not needed.
-        rawBuffer += stringView.size();
-      }
+    auto stringView = convertToStringView<FromNativeType>(
+        simpleInput->valueAt(row), scale, rowSize, rawBuffer);
+    flatResult->setNoCopy(row, stringView);
+    if (!stringView.isInline()) {
+      // If string view is inline, corresponding bytes on the raw string buffer
+      // are not needed.
+      rawBuffer += stringView.size();
     }
   });
   // Update the exact buffer size.


### PR DESCRIPTION
It is ensured that input rows for cast contain no null, so isNullAt check could 
be removed.

https://github.com/facebookincubator/velox/blob/1ab113266487e32a1d168ad2925bf0b87364f88e/velox/expression/CastExpr.cpp#L755-L757