### PR TITLE
Optimize count(distinct <complex type>)

### DIFF
--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -123,15 +123,26 @@ void HashStringAllocator::freeToPool(void* ptr, size_t size) {
 }
 
 // static
-ByteInputStream HashStringAllocator::prepareRead(const Header* begin) {
+ByteInputStream HashStringAllocator::prepareRead(
+    const Header* begin,
+    size_t maxBytes) {
   std::vector<ByteRange> ranges;
   auto header = const_cast<Header*>(begin);
+
+  size_t totalBytes = 0;
+
   for (;;) {
     ranges.push_back(ByteRange{
         reinterpret_cast<uint8_t*>(header->begin()), header->usableSize(), 0});
+    totalBytes += ranges.back().size;
     if (!header->isContinued()) {
       break;
     }
+
+    if (totalBytes >= maxBytes) {
+      break;
+    }
+
     header = header->nextContinued();
   }
   return ByteInputStream(std::move(ranges));

--- a/velox/common/memory/HashStringAllocator.h
+++ b/velox/common/memory/HashStringAllocator.h
@@ -239,7 +239,11 @@ class HashStringAllocator : public StreamArena {
 
   // Returns ByteInputStream over the data in the range of 'header' and
   // possible continuation ranges.
-  static ByteInputStream prepareRead(const Header* header);
+  // @param maxBytes If provided, the returned stream will cover at most that
+  // many bytes.
+  static ByteInputStream prepareRead(
+      const Header* header,
+      size_t maxBytes = std::numeric_limits<size_t>::max());
 
   // Returns the number of payload bytes between 'header->begin()' and
   // 'position'.

--- a/velox/exec/SetAccumulator.h
+++ b/velox/exec/SetAccumulator.h
@@ -179,7 +179,7 @@ struct StringViewSetAccumulator {
 struct ComplexTypeSetAccumulator {
   /// A set of pointers to values stored in AddressableNonNullValueList.
   SetAccumulator<
-      HashStringAllocator::Position,
+      AddressableNonNullValueList::Entry,
       AddressableNonNullValueList::Hash,
       AddressableNonNullValueList::EqualTo>
       base;
@@ -203,12 +203,12 @@ struct ComplexTypeSetAccumulator {
         base.nullIndex = cnt;
       }
     } else {
-      auto position = values.append(decoded, index, allocator);
+      auto entry = values.append(decoded, index, allocator);
 
       if (!base.uniqueValues
-               .insert({position, base.nullIndex.has_value() ? cnt + 1 : cnt})
+               .insert({entry, base.nullIndex.has_value() ? cnt + 1 : cnt})
                .second) {
-        values.removeLast(position);
+        values.removeLast(entry);
       }
     }
   }

--- a/velox/exec/benchmarks/SetAccumulatorBenchmark.cpp
+++ b/velox/exec/benchmarks/SetAccumulatorBenchmark.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/common/memory/Memory.h"
+#include "velox/exec/SetAccumulator.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+
+namespace {
+
+// Adds 10M mostly unique values to a single SetAccumulator, then extracts
+// unique values from it.
+class SetAccumulatorBenchmark : public facebook::velox::test::VectorTestBase {
+ public:
+  void setup() {
+    VectorFuzzer::Options opts;
+    opts.vectorSize = 1'000'000;
+    VectorFuzzer fuzzer(opts, pool());
+
+    auto rowType = ROW({"a", "b", "c"}, {BIGINT(), BIGINT(), VARCHAR()});
+    for (auto i = 0; i < 10; ++i) {
+      rowVectors_.emplace_back(fuzzer.fuzzInputRow(rowType));
+    }
+  }
+
+  void runBigint() {
+    runPrimitive<int64_t>("a");
+  }
+
+  void runVarchar() {
+    runPrimitive<StringView>("c");
+  }
+
+  void runTwoBigints() {
+    HashStringAllocator allocator(pool());
+    const TypePtr type = ROW({BIGINT(), BIGINT()});
+    aggregate::prestosql::SetAccumulator<ComplexType> accumulator(
+        type, &allocator);
+
+    for (const auto& rowVector : rowVectors_) {
+      auto vector =
+          makeRowVector({rowVector->childAt("a"), rowVector->childAt("b")});
+      DecodedVector decoded(*vector);
+      for (auto i = 0; i < rowVector->size(); ++i) {
+        accumulator.addValue(decoded, i, &allocator);
+      }
+    }
+
+    auto result = BaseVector::create(type, accumulator.size(), pool());
+    accumulator.extractValues(*result, 0);
+    folly::doNotOptimizeAway(result);
+  }
+
+ private:
+  template <typename T>
+  void runPrimitive(const std::string& name) {
+    const auto& type = rowVectors_[0]->childAt(name)->type();
+
+    HashStringAllocator allocator(pool());
+    aggregate::prestosql::SetAccumulator<T> accumulator(type, &allocator);
+
+    for (const auto& rowVector : rowVectors_) {
+      DecodedVector decoded(*rowVector->childAt(name));
+      for (auto i = 0; i < rowVector->size(); ++i) {
+        accumulator.addValue(decoded, i, &allocator);
+      }
+    }
+
+    auto result =
+        BaseVector::create<FlatVector<T>>(type, accumulator.size(), pool());
+    accumulator.extractValues(*result, 0);
+    folly::doNotOptimizeAway(result);
+  }
+
+  std::vector<RowVectorPtr> rowVectors_;
+};
+
+std::unique_ptr<SetAccumulatorBenchmark> bm;
+
+BENCHMARK(bigint) {
+  bm->runBigint();
+}
+
+BENCHMARK(varchar) {
+  bm->runVarchar();
+}
+
+BENCHMARK(twoBigints) {
+  bm->runTwoBigints();
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+  memory::MemoryManager::initialize({});
+
+  bm = std::make_unique<SetAccumulatorBenchmark>();
+  bm->setup();
+
+  folly::runBenchmarks();
+
+  bm.reset();
+
+  return 0;
+}

--- a/velox/exec/tests/AddressableNonNullValueListTest.cpp
+++ b/velox/exec/tests/AddressableNonNullValueListTest.cpp
@@ -29,7 +29,7 @@ class AddressableNonNullValueListTest : public testing::Test,
   }
 
   void test(const VectorPtr& data, const VectorPtr& uniqueData) {
-    using T = HashStringAllocator::Position;
+    using T = AddressableNonNullValueList::Entry;
     using Set = folly::F14FastSet<
         T,
         AddressableNonNullValueList::Hash,
@@ -44,32 +44,32 @@ class AddressableNonNullValueListTest : public testing::Test,
 
     AddressableNonNullValueList values;
 
-    std::vector<HashStringAllocator::Position> positions;
+    std::vector<T> entries;
 
     DecodedVector decodedVector(*data);
     for (auto i = 0; i < data->size(); ++i) {
-      auto position = values.append(decodedVector, i, allocator());
+      auto entry = values.append(decodedVector, i, allocator());
 
-      if (uniqueValues.contains(position)) {
-        values.removeLast(position);
+      if (uniqueValues.contains(entry)) {
+        values.removeLast(entry);
         continue;
       }
 
-      positions.push_back(position);
+      entries.push_back(entry);
 
-      ASSERT_TRUE(uniqueValues.insert(position).second);
-      ASSERT_TRUE(uniqueValues.contains(position));
-      ASSERT_FALSE(uniqueValues.insert(position).second);
+      ASSERT_TRUE(uniqueValues.insert(entry).second);
+      ASSERT_TRUE(uniqueValues.contains(entry));
+      ASSERT_FALSE(uniqueValues.insert(entry).second);
     }
 
     ASSERT_EQ(uniqueData->size(), values.size());
     ASSERT_EQ(uniqueData->size(), uniqueValues.size());
 
     auto copy = BaseVector::create(data->type(), uniqueData->size(), pool());
-    for (auto i = 0; i < positions.size(); ++i) {
-      auto position = positions[i];
-      ASSERT_TRUE(uniqueValues.contains(position));
-      AddressableNonNullValueList::read(position, *copy, i);
+    for (auto i = 0; i < entries.size(); ++i) {
+      auto entry = entries[i];
+      ASSERT_TRUE(uniqueValues.contains(entry));
+      AddressableNonNullValueList::read(entry, *copy, i);
     }
 
     test::assertEqualVectors(uniqueData, copy);

--- a/velox/functions/prestosql/aggregates/MapAccumulator.h
+++ b/velox/functions/prestosql/aggregates/MapAccumulator.h
@@ -161,7 +161,7 @@ struct StringViewMapAccumulator {
 struct ComplexTypeMapAccumulator {
   /// A set of pointers to values stored in AddressableNonNullValueList.
   MapAccumulator<
-      HashStringAllocator::Position,
+      AddressableNonNullValueList::Entry,
       AddressableNonNullValueList::Hash,
       AddressableNonNullValueList::EqualTo>
       base;
@@ -180,11 +180,11 @@ struct ComplexTypeMapAccumulator {
       const DecodedVector& decodedValues,
       vector_size_t index,
       HashStringAllocator& allocator) {
-    auto position = serializedKeys.append(decodedKeys, index, &allocator);
+    auto entry = serializedKeys.append(decodedKeys, index, &allocator);
 
     auto cnt = base.keys.size();
-    if (!base.keys.insert({position, cnt}).second) {
-      serializedKeys.removeLast(position);
+    if (!base.keys.insert({entry, cnt}).second) {
+      serializedKeys.removeLast(entry);
       return;
     }
 

--- a/velox/functions/prestosql/aggregates/MultiMapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MultiMapAggAggregate.cpp
@@ -138,7 +138,7 @@ struct MultiMapAccumulator {
 
 struct ComplexTypeMultiMapAccumulator {
   MultiMapAccumulator<
-      HashStringAllocator::Position,
+      AddressableNonNullValueList::Entry,
       AddressableNonNullValueList::Hash,
       AddressableNonNullValueList::EqualTo>
       base;
@@ -168,9 +168,9 @@ struct ComplexTypeMultiMapAccumulator {
       const DecodedVector& decodedValues,
       vector_size_t index,
       HashStringAllocator& allocator) {
-    const auto position = serializedKeys.append(decodedKeys, index, &allocator);
+    const auto entry = serializedKeys.append(decodedKeys, index, &allocator);
 
-    auto& values = insertKey(position);
+    auto& values = insertKey(entry);
     values.appendValue(decodedValues, index, &allocator);
   }
 
@@ -182,19 +182,18 @@ struct ComplexTypeMultiMapAccumulator {
       vector_size_t valueIndex,
       vector_size_t numValues,
       HashStringAllocator& allocator) {
-    const auto position =
-        serializedKeys.append(decodedKeys, keyIndex, &allocator);
+    const auto entry = serializedKeys.append(decodedKeys, keyIndex, &allocator);
 
-    auto& values = insertKey(position);
+    auto& values = insertKey(entry);
     for (auto i = 0; i < numValues; ++i) {
       values.appendValue(decodedValues, valueIndex + i, &allocator);
     }
   }
 
-  ValueList& insertKey(HashStringAllocator::Position position) {
-    auto result = base.keys.insert({position, ValueList()});
+  ValueList& insertKey(const AddressableNonNullValueList::Entry& key) {
+    auto result = base.keys.insert({key, ValueList()});
     if (!result.second) {
-      serializedKeys.removeLast(position);
+      serializedKeys.removeLast(key);
     }
 
     return result.first->second;


### PR DESCRIPTION
Aggregations over distinct inputs use `SetAccumulator<ComplexType>`, which in
turn uses AddressableNonNullValueList to store unique complex type values in a
single non-contiguous allocation within HashStringAllocator.

Storing thousands or millions of values requires allocation with hundrends or
thousands of contiguous pieces. Calling HashStringAllocator::prepareRead on
such allocation ends up populating an `std::vector<ByteRange>` with thousands
of entries. Calling this repeatedly for each value as part of
SetAccumulator::extractValues() becomes very slow.

SetAccumulator::extractValues calls AddressableNonNullValueList::read for each
unique value (there can be millions of these):

    for (const auto& position : base.uniqueValues) {
      AddressableNonNullValueList::read(
          position.first.position, values, offset + position.second);
    }

AddressableNonNullValueList::read calls HashStringAllocator::prepareRead, which
collects thousands of byte ranges into a vector passed to ByteInputStream
constructor:

    auto stream = HashStringAllocator::prepareRead(header);

As a result, queries like count(distrinct <complex type>) are very slow.

A fix is to modify HashStringAllocator::prepareRead to accept an optional limit
on how many bytes to prepare for read, then use this in
AddressableNonNullValueList::read to prepare only as many bytes as needed to
extract a single value.

In addition, do not store hashes of the values in HSA to avoid calling
HashStringAllocator::prepareRead altogether just to fetch the hash.

Added benchmark for SetAccumulator to add 10M mostly unique values and read them
back. Without the optimizations, the benchmark couldn't finish within a
reasonable time (a few mininutes). Changing benchmark to process 100K values
allowed it to compelete.


Before (100K values):

```
============================================================================
[...]enchmarks/SetAccumulatorBenchmark.cpp     relative  time/iter   iters/s
============================================================================
bigint                                                      2.87ms    348.07
varchar                                                    22.22ms     45.01
twoBigints                                                988.08ms      1.01
```

After (100K values):

```
============================================================================
[...]enchmarks/SetAccumulatorBenchmark.cpp     relative  time/iter   iters/s
============================================================================
bigint                                                      2.80ms    356.87
varchar                                                    21.19ms     47.19
twoBigints                                                 38.83ms     25.76
```

After the optimizations, the original benchmark processing 10M values is 
finishing within a few seconds.


After (10M values):

```
============================================================================
[...]enchmarks/SetAccumulatorBenchmark.cpp     relative  time/iter   iters/s
============================================================================
bigint                                                       1.23s   814.20m
varchar                                                      2.96s   338.39m
twoBigints                                                   6.30s   158.70m
```