### PR TITLE
Fix integer overflows in ASAN

### DIFF
--- a/velox/common/base/RuntimeMetrics.cpp
+++ b/velox/common/base/RuntimeMetrics.cpp
@@ -34,7 +34,13 @@ void RuntimeMetric::aggregate() {
   min = max = sum;
 }
 
-void RuntimeMetric::merge(const RuntimeMetric& other) {
+void RuntimeMetric::merge(const RuntimeMetric& other)
+#if defined(__has_feature)
+#if __has_feature(__address_sanitizer__)
+    __attribute__((__no_sanitize__("signed-integer-overflow")))
+#endif
+#endif
+{
   VELOX_CHECK_EQ(unit, other.unit);
   sum += other.sum;
   count += other.count;

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -280,7 +280,7 @@ class GroupingSet {
 
   const bool ignoreNullKeys_;
 
-  vector_size_t numInputRows_ = 0;
+  uint64_t numInputRows_ = 0;
 
   // The maximum memory usage that a final aggregation can hold before spilling.
   // If it is zero, then there is no such limit.


### PR DESCRIPTION
the counter of input rows in GroupingSet may wrap around. RuntimeMetrics merge is seen to wrap around in some Prestissimo runs. There is no error stack, the counter is unknown. These break ASAN runs before we hit other errors.