### PR TITLE
Add format_as for certain enums

### DIFF
--- a/velox/common/base/SpillStats.h
+++ b/velox/common/base/SpillStats.h
@@ -95,6 +95,10 @@ struct SpillStats {
   std::string toString() const;
 };
 
+auto format_as(SpillStats stats) {
+  return stats.toString();
+}
+
 FOLLY_ALWAYS_INLINE std::ostream& operator<<(
     std::ostream& o,
     const common::SpillStats& stats) {

--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -284,6 +284,10 @@ bool MemoryReclaimer::Stats::operator!=(
   return !(*this == other);
 }
 
+std::string format_as(MemoryArbitrator::Stats s) {
+  return s.toString();
+}
+
 MemoryArbitrator::Stats::Stats(
     uint64_t _numRequests,
     uint64_t _numSucceeded,

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -243,6 +243,8 @@ class MemoryArbitrator {
   const bool checkUsageLeak_;
 };
 
+std::string format_as(MemoryArbitrator::Stats s);
+
 FOLLY_ALWAYS_INLINE std::ostream& operator<<(
     std::ostream& o,
     const MemoryArbitrator::Stats& stats) {


### PR DESCRIPTION
**What?**
We add certain format_as declarations for some structs/enums. 

**Why?**
Fmt 9 and above will not automatically format enums or other user defined types. These have to be explicitly made formattable by using the api specified here : https://fmt.dev/9.1.0/api.html#formatting-user-defined-types . 

"For enums {fmt} also provides the format_as extension API. To format an enum via this API define format_as that takes this enum and converts it to the underlying type. format_as should be defined in the same namespace as the enum."

Currently we have updated Velox to fmt 10 and we need to ensure that Prestissimo also can be built with fmt 10 as a dependency. We require these changes to build Prestissimo. 

**Notes**
Tested locally with Prestissimo. 