### PR TITLE
Fix min_by/max_by(x, y, n)

### DIFF
--- a/velox/docs/develop/aggregate-functions.rst
+++ b/velox/docs/develop/aggregate-functions.rst
@@ -283,6 +283,9 @@ initialize all accumulators.
 The author can also optionally define a `destroy` function that is called when
 *this* accumulator object is destructed.
 
+Notice that `writeIntermediateResult` and `writeFinalResult` are expected to not
+modify contents in the accumulator.
+
 addInput
 """"""""
 
@@ -364,6 +367,9 @@ behavior.
 
 On the other hand, the C++ function signatures of `addInput`, `combine`,
 `writeIntermediateResult`, and `writeFinalResult` are different.
+
+Same as the case for default-null behavior, `writeIntermediateResult` and
+`writeFinalResult` are expected to not modify contents in the accumulator.
 
 addInput
 """"""""
@@ -605,6 +611,7 @@ After implementing the addRawInput() method, we proceed to adding logic for extr
 .. code-block:: c++
 
       // Extracts partial results (used for partial and intermediate aggregations).
+      // This method is expected to not modify contents in accumulators.
       // @param groups Pointers to the start of the group rows.
       // @param numGroups Number of groups to extract results from.
       // @param result The result vector to store the results in.
@@ -625,7 +632,8 @@ Next, we implement the extractValues() method that extracts final results from t
 
 .. code-block:: c++
 
-      // Extracts final results (used for final and single aggregations).
+      // Extracts final results (used for final and single aggregations). This method
+      // is expected to not modify contents in accumulators.
       // @param groups Pointers to the start of the group rows.
       // @param numGroups Number of groups to extract results from.
       // @param result The result vector to store the results in.


### PR DESCRIPTION
Summary:
Same as bug in min/max(x, n) fixed in https://github.com/facebookincubator/velox/pull/8311, min_by/max_by(x, y, n) also breaks the 
assumption of incremental window aggregation because their extractValues() methods 
has a side effect of clearing the accumulator.

This diff fixes this issue by making the extractValues() methods of min_by/max_by(x, y, n) 
not clear the accumulators.

Since Presto's min_by/max_by have the same bug (https://github.com/prestodb/presto/issues/21653). This fix 
will make Velox's min_by/max_by behave differently from Presto when used in Window 
operation, until https://github.com/prestodb/presto/issues/21653 is fixed.

This diff fixes https://github.com/facebookincubator/velox/issues/8138.

Differential Revision: D53139892


