### PR TITLE
Introduce BatchVectorSerializer to better support preserving encodings when serializing Vectors

### DIFF
--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -33,6 +33,12 @@ struct IndexRange {
   vector_size_t size;
 };
 
+/// Serializer that can iteratively build up a buffer of serialized rows from
+/// one or more RowVectors.
+///
+/// Uses successive calls to `append` to add more rows to the serialization
+/// buffer.  Then call `flush` to write the aggregate serialized data to an
+/// OutputStream.
 class VectorSerializer {
  public:
   virtual ~VectorSerializer() = default;
@@ -82,6 +88,34 @@ class VectorSerializer {
   virtual void flush(OutputStream* stream) = 0;
 };
 
+/// Serializer that writes a subset of rows from a single RowVector to the
+/// OutputStream.
+///
+/// Each serialize() call serializes the specified range(s) of `vector` and
+/// write them to the output stream.
+class BatchVectorSerializer {
+ public:
+  virtual ~BatchVectorSerializer() = default;
+
+  /// Serializes a subset of rows in a vector.
+  virtual void serialize(
+      const RowVectorPtr& vector,
+      const folly::Range<const IndexRange*>& ranges,
+      Scratch& scratch,
+      OutputStream* stream) = 0;
+
+  virtual void serialize(
+      const RowVectorPtr& vector,
+      const folly::Range<const IndexRange*>& ranges,
+      OutputStream* stream) {
+    Scratch scratch;
+    serialize(vector, ranges, scratch, stream);
+  }
+
+  /// Serializes all rows in a vector.
+  void serialize(const RowVectorPtr& vector, OutputStream* stream);
+};
+
 class VectorSerde {
  public:
   virtual ~VectorSerde() = default;
@@ -119,11 +153,26 @@ class VectorSerde {
     estimateSerializedSize(vector, ranges, sizes, scratch);
   }
 
+  /// Creates a Vector Serializer that iteratively builds up a buffer of
+  /// serialized rows from one or more RowVectors via append, and then writes to
+  /// an OutputSteam via flush.
+  ///
+  /// This is more appropriate if the use case involves many small writes, e.g.
+  /// partitioning a RowVector across multiple destinations.
   virtual std::unique_ptr<VectorSerializer> createSerializer(
       RowTypePtr type,
       int32_t numRows,
       StreamArena* streamArena,
       const Options* options = nullptr) = 0;
+
+  /// Creates a Vector Serializer that writes a subset of rows from a single
+  /// RowVector to the OutputStream via a single serialize API.
+  ///
+  /// This is more appropriate if the use case involves large writes, e.g.
+  /// sending an entire RowVector to a particular destination.
+  virtual std::unique_ptr<BatchVectorSerializer> createBatchSerializer(
+      memory::MemoryPool* pool,
+      const Options* options = nullptr);
 
   virtual void deserialize(
       ByteInputStream* source,


### PR DESCRIPTION
Summary:
High Level Goal:
Support preserving encodings in serialized Vectors from PartitionedOutput when the "arbitrary" partitioning scheme is 
enabled.  This is specifically for Presto, in order to match the Presto Java behavior, and because we've seen in practice this 
can dramatically reduce the amount of shuffled data improving performance.

This change:
Looking at the way PrestoVectorSerializer handles encodings, it's currently not generic, and it looks very fragile.  E.g. we need 
to make sure that flush is called after every append, which is currently impossible at compile time, and I'm not 100% confident is always guaranteed at run time.

Since we now need to expose this through the generic VectorSerde interface, I figured it was a good time to clean it up a little before it's further cemented.  To do this, I've added a new interface BatchVectorSerializer which only supports a single API serialize which effectively combines append and flush so we guarantee that only rows from a single Vector are written for every flush.  Thanks to this it also doesn't have to maintain the streams across calls, so it doesn't need the VectorStreamGroup.

In the PrestoBatchVectorSerializer implementation, we can take advantage of this to set the encodings based on the single RowVector we're serializing on each call.

My hope is with this, we can remove PrestoVectorSerde::serializeEncoded replacing it with BatchVectorSerializer, and also remove the notion of encodings from PrestoVectorSerializer so we don't need to worry about calling append twice without a flush on a PrestoVectorSerializer initialized with encodings.  If there's general agreement on this approach I'll do that in a follow up shortly after this.

This will also give me a bit more isolation to implement the rest of the features that are needed for the high level goal (calculating the serialized size of Vector slices with encodings, splitting very large RowVectors while maintaining encodings, etc.) in order to match the Presto Java behavior, without breaking the existing serialization logic.

Differential Revision: D53144805


