### PR TITLE
Reduce the lock contention in MallocAllocator by sharded memory reservation

### DIFF
--- a/velox/common/base/ConcurrentCounter.h
+++ b/velox/common/base/ConcurrentCounter.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <new>
+
+#include "velox/common/base/BitUtil.h"
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox {
+
+/// The class provides concurrent updates to a counter with minimum lock
+/// contention. The template argument T specifies the counter type. The counter
+/// is N-way sharded internally. Each update goes to one of the sharded counters
+/// based on the update thread id.
+template <class T>
+class ConcurrentCounter {
+ public:
+  /// Creates a concurrent counter with specified number of shards.
+  ///
+  /// NOTE: the constructor sets the actual number of shards to be the next
+  /// power of 2.
+  explicit ConcurrentCounter(size_t numShards)
+      : numShards_(bits::nextPowerOfTwo(numShards)),
+        shardMask_(numShards_ - 1),
+        counters_(numShards_) {
+    VELOX_CHECK_GE(numShards_, 1);
+    for (auto& counter : counters_) {
+      counter.value = T();
+    }
+  }
+
+  ConcurrentCounter(const ConcurrentCounter&) = delete;
+  ConcurrentCounter& operator=(const ConcurrentCounter&) = delete;
+
+  /// Invoked to read the sum of values from 'counters_'.
+  T read() const {
+    T sum = T();
+    for (size_t i = 0; i < numShards_; ++i) {
+      sum += counters_[i].read();
+    }
+    return sum;
+  }
+
+  /// Invoked to update with 'delta'.
+  void update(T delta) {
+    counters_[shardIndex()].update(delta);
+  }
+
+  /// Invoked to update with 'delta' and user provided 'updateFn'. The function
+  /// picks up the shard to apply the customized update.
+  using UpdateFn = std::function<bool(T& counter, T delta, std::mutex& lock)>;
+  bool update(T delta, const UpdateFn& updateFn) {
+    return counters_[shardIndex()].update(delta, updateFn);
+  }
+
+  void testingClear() {
+    for (auto& counter : counters_) {
+      counter.value = T();
+    }
+  }
+
+  T testingRead(size_t index) const {
+    return counters_[index].read();
+  }
+
+  bool testingUpdate(size_t index, T delta, const UpdateFn& updateFn) {
+    return counters_[index].update(delta, updateFn);
+  }
+
+ private:
+  struct alignas(folly::hardware_destructive_interference_size) Counter {
+    mutable std::mutex lock;
+    T value;
+
+    T read() const {
+      std::lock_guard<std::mutex> l(lock);
+      return value;
+    }
+
+    void update(T delta) {
+      std::lock_guard<std::mutex> l(lock);
+      value += delta;
+    }
+
+    bool update(T delta, const UpdateFn& updateFn) {
+      return updateFn(value, delta, lock);
+    }
+  };
+
+  size_t shardIndex() const {
+    const size_t hash =
+        std::hash<std::thread::id>{}(std::this_thread::get_id());
+    const size_t index = hash & shardMask_;
+    VELOX_DCHECK_LT(index, counters_.size());
+    return index;
+  }
+
+  const size_t numShards_;
+  const size_t shardMask_;
+
+  std::vector<Counter> counters_;
+};
+} // namespace facebook::velox

--- a/velox/common/base/tests/CMakeLists.txt
+++ b/velox/common/base/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(
   BitUtilTest.cpp
   BloomFilterTest.cpp
   CoalesceIoTest.cpp
+  ConcurrentCounterTest.cpp
   ExceptionTest.cpp
   FsTest.cpp
   RangeTest.cpp

--- a/velox/common/base/tests/ConcurrentCounterTest.cpp
+++ b/velox/common/base/tests/ConcurrentCounterTest.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/ConcurrentCounter.h"
+
+#include <fmt/format.h>
+#include <folly/Random.h>
+#include <gflags/gflags.h>
+#include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
+
+namespace facebook::velox::common::test {
+
+class ConcurrentCounterTest : public testing::TestWithParam<bool> {
+ protected:
+  void SetUp() override {
+    setupCounter();
+  }
+
+  void update(int64_t delta) {
+    if (useUpdateFn_) {
+      counter_->update(
+          delta, [&](int64_t& counter, int64_t delta, std::mutex& lock) {
+            std::lock_guard<std::mutex> l(lock);
+            counter += delta;
+            return true;
+          });
+    } else {
+      counter_->update(delta);
+    }
+  }
+
+  int64_t read() const {
+    return counter_->read();
+  }
+
+  void setupCounter() {
+    counter_ = std::make_unique<ConcurrentCounter<int64_t>>(
+        std::thread::hardware_concurrency());
+  }
+
+  const bool useUpdateFn_{GetParam()};
+
+  std::unique_ptr<ConcurrentCounter<int64_t>> counter_;
+};
+
+TEST_P(ConcurrentCounterTest, basic) {
+  ASSERT_EQ(read(), 0);
+  update(1);
+  ASSERT_EQ(read(), 1);
+  update(1);
+  ASSERT_EQ(read(), 2);
+  update(-1);
+  ASSERT_EQ(read(), 1);
+  update(-3);
+  ASSERT_EQ(read(), -2);
+}
+
+TEST_P(ConcurrentCounterTest, multithread) {
+  const int32_t numUpdatesPerThread = 5'000;
+  std::vector<int> numThreads;
+  numThreads.push_back(1);
+  numThreads.push_back(std::thread::hardware_concurrency());
+  numThreads.push_back(std::thread::hardware_concurrency() * 2);
+  for (int numThreads : numThreads) {
+    SCOPED_TRACE(fmt::format("numThreads: {}", numThreads));
+    counter_->testingClear();
+    ASSERT_EQ(counter_->read(), 0);
+
+    std::vector<std::thread> threads;
+    threads.reserve(numThreads);
+    std::vector<int64_t> counts(numThreads, 0);
+    for (size_t i = 0; i < numThreads; ++i) {
+      ASSERT_EQ(counts[i], 0);
+      threads.emplace_back([&, i]() {
+        folly::Random::DefaultGenerator rng;
+        rng.seed(1234 + i);
+        ASSERT_EQ(counts[i], 0);
+        for (int j = 0; j < numUpdatesPerThread; ++j) {
+          const int delta = folly::Random::rand32(rng);
+          counts[i] += delta;
+          update(delta);
+        }
+      });
+    }
+
+    for (auto& th : threads) {
+      th.join();
+    }
+    int64_t expectedCount{0};
+    for (int i = 0; i < numThreads; ++i) {
+      expectedCount += counts[i];
+    }
+    ASSERT_EQ(read(), expectedCount);
+  }
+}
+
+VELOX_INSTANTIATE_TEST_SUITE_P(
+    ConcurrentCounterTestSuite,
+    ConcurrentCounterTest,
+    testing::ValuesIn({false, true}));
+
+} // namespace facebook::velox::common::test

--- a/velox/common/memory/MallocAllocator.h
+++ b/velox/common/memory/MallocAllocator.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "velox/common/base/ConcurrentCounter.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/common/memory/MemoryAllocator.h"
 
@@ -25,17 +26,9 @@ namespace facebook::velox::memory {
 /// The implementation of MemoryAllocator using malloc.
 class MallocAllocator : public MemoryAllocator {
  public:
-  explicit MallocAllocator(size_t capacity);
+  MallocAllocator(size_t capacity, uint32_t reservationByteLimit);
 
-  ~MallocAllocator() override {
-    // TODO: Remove the check when memory leak issue is resolved.
-    if (FLAGS_velox_memory_leak_check_enabled) {
-      VELOX_CHECK(
-          (allocatedBytes_ == 0) && (numAllocated_ == 0) && (numMapped_ == 0),
-          "{}",
-          toString());
-    }
-  }
+  ~MallocAllocator() override;
 
   void registerCache(const std::shared_ptr<Cache>& cache) override {
     VELOX_CHECK_NULL(cache_);
@@ -74,7 +67,7 @@ class MallocAllocator : public MemoryAllocator {
   }
 
   size_t totalUsedBytes() const override {
-    return allocatedBytes_;
+    return allocatedBytes_ - reservations_.read();
   }
 
   MachinePageCount numAllocated() const override {
@@ -98,14 +91,14 @@ class MallocAllocator : public MemoryAllocator {
 
   bool allocateContiguousWithoutRetry(
       MachinePageCount numPages,
-      Allocation* FOLLY_NULLABLE collateral,
+      Allocation* collateral,
       ContiguousAllocation& allocation,
       ReservationCallback reservationCB = nullptr,
       MachinePageCount maxPages = 0) override;
 
   bool allocateContiguousImpl(
       MachinePageCount numPages,
-      Allocation* FOLLY_NULLABLE collateral,
+      Allocation* collateral,
       ContiguousAllocation& allocation,
       ReservationCallback reservationCB,
       MachinePageCount maxPages);
@@ -116,13 +109,52 @@ class MallocAllocator : public MemoryAllocator {
 
   void* allocateZeroFilledWithoutRetry(uint64_t bytes) override;
 
-  // Increment current usage and check current allocator consistency to make
-  // sure current usage does not go above 'capacity_'. If it goes above
+  // Increments current usage and check current 'allocatedBytes_' counter to
+  // make sure current usage does not go above 'capacity_'. If it goes above
   // 'capacity_', the increment will not be applied. Returns true if within
   // capacity, false otherwise.
   //
-  // NOTE: This method should always be called BEFORE actual allocation.
+  // NOTE: This method should always be called BEFORE the actual allocation.
   inline bool incrementUsage(int64_t bytes) {
+    if (bytes < reservationByteLimit_) {
+      return incrementUsageWithReservation(bytes);
+    }
+    return incrementUsageWithoutReservation(bytes);
+  }
+
+  // Increments the memory usage in the local sharded counter from
+  // 'reservations_' for memory allocation with size < 'reservationByteLimit_'
+  // without updating the global 'allocatedBytes_' counter. If there is not
+  // enough reserved bytes in local sharded counter, then 'reserveFunc_' is
+  // called to reserve 'reservationByteLimit_' bytes from the global counter at
+  // a time.
+  inline bool incrementUsageWithReservation(uint32_t bytes) {
+    return reservations_.update(bytes, reserveFunc_);
+  }
+
+  inline bool incrementUsageWithReservationFunc(
+      uint32_t& counter,
+      uint32_t increment,
+      std::mutex& lock) {
+    VELOX_CHECK_LT(increment, reservationByteLimit_);
+    std::lock_guard<std::mutex> l(lock);
+    if (counter > increment) {
+      counter -= increment;
+      return true;
+    }
+    if (!incrementUsageWithoutReservation(reservationByteLimit_)) {
+      return false;
+    }
+    counter += reservationByteLimit_;
+    counter -= increment;
+    VELOX_CHECK_GT(counter, 0);
+    return true;
+  }
+
+  // Increments the memory usage from the global 'allocatedBytes_' counter
+  // directly.
+  inline bool incrementUsageWithoutReservation(int64_t bytes) {
+    VELOX_CHECK_GE(bytes, reservationByteLimit_);
     const auto originalBytes = allocatedBytes_.fetch_add(bytes);
     // We don't do the check when capacity_ is 0, meaning unlimited capacity.
     if (capacity_ != 0 && originalBytes + bytes > capacity_) {
@@ -132,11 +164,46 @@ class MallocAllocator : public MemoryAllocator {
     return true;
   }
 
-  // Decrement current usage and check current allocator consistency to make
-  // sure current usage does not go below 0. Throws if usage goes below 0.
+  // Decrements current usage and check current 'allocatedBytes_' counter to
+  // make sure current usage does not go below 0. Throws if usage goes below 0.
   //
   // NOTE: This method should always be called AFTER actual free.
   inline void decrementUsage(int64_t bytes) {
+    if (bytes < reservationByteLimit_) {
+      decrementUsageWithReservation(bytes);
+      return;
+    }
+    decrementUsageWithoutReservation(bytes);
+  }
+
+  // Decrements the memory usage in the local sharded counter from
+  // 'reservations_' for memory free with size < 'reservationByteLimit_'
+  // without updating the global 'allocatedBytes_' counter. If there is more
+  // than 2 * 'reservationByteLimit_' free reserved bytes in local sharded
+  // counter, then 'releaseFunc_' is called to release 'reservationByteLimit_'
+  // bytes back to the global counter.
+  inline void decrementUsageWithReservation(int64_t bytes) {
+    reservations_.update(bytes, releaseFunc_);
+  }
+
+  inline void decrementUsageWithReservationFunc(
+      uint32_t& counter,
+      uint32_t decrement,
+      std::mutex& lock) {
+    VELOX_CHECK_LT(decrement, reservationByteLimit_);
+    std::lock_guard<std::mutex> l(lock);
+    counter += decrement;
+    if (counter >= 2 * reservationByteLimit_) {
+      decrementUsageWithoutReservation(reservationByteLimit_);
+      counter -= reservationByteLimit_;
+    }
+    VELOX_CHECK_GE(counter, 0);
+    VELOX_CHECK_LT(counter, 2 * reservationByteLimit_);
+  }
+
+  // Decrements the memory usage from the global 'allocatedBytes_' counter
+  // directly.
+  inline void decrementUsageWithoutReservation(int64_t bytes) {
     const auto originalBytes = allocatedBytes_.fetch_sub(bytes);
     if (originalBytes - bytes < 0) {
       // In case of inconsistency while freeing memory, do not revert in this
@@ -154,6 +221,12 @@ class MallocAllocator : public MemoryAllocator {
   // Capacity in bytes. Total allocation byte is not allowed to exceed this
   // value.
   const size_t capacity_;
+  const uint32_t reservationByteLimit_;
+
+  const ConcurrentCounter<uint32_t>::UpdateFn reserveFunc_;
+  const ConcurrentCounter<uint32_t>::UpdateFn releaseFunc_;
+
+  ConcurrentCounter<uint32_t> reservations_;
 
   // Current total allocated bytes by this 'MallocAllocator'.
   std::atomic<int64_t> allocatedBytes_{0};

--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -44,7 +44,9 @@ std::shared_ptr<MemoryAllocator> createAllocator(
     mmapOptions.mmapArenaCapacityRatio = options.mmapArenaCapacityRatio;
     return std::make_shared<MmapAllocator>(mmapOptions);
   } else {
-    return std::make_shared<MallocAllocator>(options.allocatorCapacity);
+    return std::make_shared<MallocAllocator>(
+        options.allocatorCapacity,
+        options.allocationSizeThresholdWithReservation);
   }
 }
 

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -121,6 +121,17 @@ struct MemoryManagerOptions {
   /// NOTE: this only applies for MmapAllocator.
   int32_t maxMallocBytes{3072};
 
+  /// The memory allocations with size smaller than this threshold check the
+  /// capacity with local sharded counter to reduce the lock contention on the
+  /// global allocation counter. The sharded local counters reserve/release
+  /// memory capacity from the global counter in batch. With this optimization,
+  /// we don't have to update the global counter for each individual small
+  /// memory allocation. If it is zero, then this optimization is disabled. The
+  /// default is 1MB.
+  ///
+  /// NOTE: this only applies for MallocAllocator.
+  uint32_t allocationSizeThresholdWithReservation{1 << 20};
+
   /// ================== 'MemoryArbitrator' settings =================
 
   /// Memory capacity available for query/task memory pools. This capacity

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -477,7 +477,7 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
   }
 
   // If 'data' is sufficiently large, enables/disables adaptive  huge pages
-  // for the address raneg.
+  // for the address range.
   void useHugePages(const ContiguousAllocation& data, bool enable);
 
   // The machine page counts corresponding to different sizes in order

--- a/velox/common/memory/tests/ConcurrentAllocationBenchmark.cpp
+++ b/velox/common/memory/tests/ConcurrentAllocationBenchmark.cpp
@@ -36,7 +36,7 @@ DEFINE_uint32(
     "The type of memory allocator. 0 is malloc allocator, 1 is mmap allocator");
 DEFINE_uint32(
     memory_allocation_type,
-    1,
+    0,
     "The type of memory allocation. 0 is small allocation, 1 non-contiguous allocation");
 DEFINE_uint32(
     num_runs,

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -996,7 +996,9 @@ TEST_P(MemoryPoolTest, nonContiguousAllocate) {
 }
 
 TEST_P(MemoryPoolTest, allocationFailStats) {
-  setupMemory({.allocatorCapacity = 16 * KB});
+  setupMemory(
+      {.allocatorCapacity = 16 * KB,
+       .allocationSizeThresholdWithReservation = false});
   auto manager = getMemoryManager();
   auto pool = manager->addLeafPool("allocationFailStats");
   auto allocatorCapacity = manager->capacity();

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -1122,9 +1122,8 @@ void HashBuild::reclaim(
       ++stats.numNonReclaimableAttempts;
       LOG(WARNING) << "Can't reclaim from hash build operator, state_["
                    << stateName(buildOp->state_) << "], nonReclaimableSection_["
-                   << nonReclaimableSection_ << "], spiller_["
-                   << (spiller_->finalized() ? "finalized" : "non-finalized")
-                   << "], " << buildOp->pool()->name() << ", usage: "
+                   << buildOp->nonReclaimableSection_ << "], "
+                   << buildOp->pool()->name() << ", usage: "
                    << succinctBytes(buildOp->pool()->currentBytes());
       return;
     }

--- a/velox/exec/tests/SharedArbitratorTest.cpp
+++ b/velox/exec/tests/SharedArbitratorTest.cpp
@@ -274,7 +274,9 @@ class SharedArbitrationTest : public exec::test::HiveConnectorTestBase {
       uint64_t maxReclaimWaitMs = 0) {
     memoryCapacity = (memoryCapacity != 0) ? memoryCapacity : kMemoryCapacity;
     MemoryManagerOptions options;
-    options.allocatorCapacity = memoryCapacity;
+    options.arbitratorCapacity = memoryCapacity;
+    // Avoid allocation failure in unit tests.
+    options.allocatorCapacity = memoryCapacity * 2;
     options.arbitratorKind = "SHARED";
     options.memoryPoolInitCapacity = memoryPoolInitCapacity;
     options.memoryPoolTransferCapacity = memoryPoolTransferCapacity;

--- a/velox/exec/tests/utils/ArbitratorTestUtil.cpp
+++ b/velox/exec/tests/utils/ArbitratorTestUtil.cpp
@@ -46,12 +46,14 @@ std::shared_ptr<core::QueryCtx> newQueryCtx(
 }
 
 std::unique_ptr<memory::MemoryManager> createMemoryManager(
-    int64_t allocatorCapacity,
+    int64_t arbitratorCapacity,
     uint64_t memoryPoolInitCapacity,
     uint64_t memoryPoolTransferCapacity,
     uint64_t maxReclaimWaitMs) {
   memory::MemoryManagerOptions options;
-  options.allocatorCapacity = allocatorCapacity;
+  options.arbitratorCapacity = arbitratorCapacity;
+  // Avoid allocation failure in unit tests.
+  options.allocatorCapacity = arbitratorCapacity * 2;
   options.arbitratorKind = "SHARED";
   options.memoryPoolInitCapacity = memoryPoolInitCapacity;
   options.memoryPoolTransferCapacity = memoryPoolTransferCapacity;

--- a/velox/exec/tests/utils/ArbitratorTestUtil.h
+++ b/velox/exec/tests/utils/ArbitratorTestUtil.h
@@ -94,7 +94,7 @@ std::shared_ptr<core::QueryCtx> newQueryCtx(
     std::unique_ptr<MemoryReclaimer>&& reclaimer = nullptr);
 
 std::unique_ptr<memory::MemoryManager> createMemoryManager(
-    int64_t allocatorCapacity = kMemoryCapacity,
+    int64_t arbitratorCapacity = kMemoryCapacity,
     uint64_t memoryPoolInitCapacity = kMemoryPoolInitCapacity,
     uint64_t memoryPoolTransferCapacity = kMemoryPoolTransferCapacity,
     uint64_t maxReclaimWaitMs = 0);


### PR DESCRIPTION
Reduce the lock contention in MallocAllocator by adding the sharded counters to
reserve a small chunk of capacity from the global allocation counter. When we do
small memory allocations, instead of checking capacity against the global allocation
counter, we check against one of the sharded counter based on the allocation thread
id. When there is insufficient memory reservation in the sharded counter, we reserve
a chunk of capacity from the global counter. When we free small memory allocation, 
we return the memory capacity to one of the sharded counter. If there is too many free
reservation in the sharded counter, we return a chunk of free capacity back to the
global counter. This can help to avoid updating the global allocation counter for every
single memory allocation. This reduces the execution time of concurrent benchmark by
4x.

We introduce an option in MemoryManagerOptions: allocationSizeThresholdWithReservation
to define the memory allocation size threshold to apply this optimization. For memory
allocation larger than this size, we update from the global counter directly. If this is set
to zero, we disable this sharded memory reservation optimization.

This PR also adds ConcurrentCounter abstraction to handle similar use cases in Velox.
