### PR TITLE
Add support for proxy in S3FileSystem

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -202,4 +202,8 @@ uint64_t HiveConfig::filePreloadThreshold() const {
   return config_->get<uint64_t>(kFilePreloadThreshold, 8UL << 20);
 }
 
+bool HiveConfig::s3UseProxyFromEnv() const {
+  return config_->get<bool>(kS3UseProxyFromEnv, false);
+}
+
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -175,6 +175,9 @@ class HiveConfig {
   static constexpr const char* kSortWriterMaxOutputBytesSession =
       "sort_writer_max_output_bytes";
 
+  static constexpr const char* kS3UseProxyFromEnv =
+      "hive.s3.use-proxy-from-env";
+
   InsertExistingPartitionsBehavior insertExistingPartitionsBehavior(
       const Config* session) const;
 
@@ -241,6 +244,8 @@ class HiveConfig {
   uint64_t footerEstimatedSize() const;
 
   uint64_t filePreloadThreshold() const;
+
+  bool s3UseProxyFromEnv() const;
 
   HiveConfig(std::shared_ptr<const Config> config) {
     VELOX_CHECK_NOT_NULL(

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
@@ -23,6 +23,7 @@
 
 #include <aws/s3/S3Errors.h>
 #include <aws/s3/model/HeadObjectResult.h>
+#include <folly/Uri.h>
 
 #include "velox/common/base/Exceptions.h"
 
@@ -176,6 +177,31 @@ inline std::string getRequestID(
       VELOX_FAIL(errMsg)                                                                                                       \
     }                                                                                                                          \
   }
+
+bool isHostExcludedFromProxy(
+    const std::string& hostname,
+    const std::string& noProxyList);
+
+std::string getHttpProxyEnvVar();
+std::string getHttpsProxyEnvVar();
+std::string getNoProxyEnvVar();
+
+class S3ProxyConfigurationBuilder {
+ public:
+  S3ProxyConfigurationBuilder(const std::string& s3Endpoint)
+      : s3Endpoint_(s3Endpoint){};
+
+  S3ProxyConfigurationBuilder& useSsl(const bool& useSsl) {
+    useSsl_ = useSsl;
+    return *this;
+  }
+
+  std::optional<folly::Uri> build();
+
+ private:
+  const std::string s3Endpoint_;
+  bool useSsl_;
+};
 
 } // namespace facebook::velox
 

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
@@ -42,6 +42,9 @@ class S3FileSystemTest : public S3Test {
 } // namespace
 
 TEST_F(S3FileSystemTest, writeAndRead) {
+  /// The hive config used for Minio defaults to turning
+  /// off using proxy settings if the environment provides them.
+  setenv("HTTP_PROXY", "http://test:test@127.0.0.1:8888", 1);
   const char* bucketName = "data";
   const char* file = "test.txt";
   const std::string filename = localPath(bucketName) + "/" + file;

--- a/velox/docs/develop/connectors.rst
+++ b/velox/docs/develop/connectors.rst
@@ -99,3 +99,26 @@ are `gs://`.
 
 ABS (Azure Blob Storage) is supported using the
 `Azure SDK for C++ <https://github.com/Azure/azure-sdk-for-cpp>`_ library. ABS supported schemes are `abfs(s)://`.
+
+S3 Storage adapter using a proxy
+********************************
+
+By default, the C++ AWS S3 client does not honor the configuration of the
+environment variables http_proxy, https_proxy, and no_proxy.
+The Java AWS S3 client supports this.
+The environment variables can be specified as lower case, upper case or both.
+In order to enable the use of a proxy the hive connector configuration variable
+`hive.s3.use-proxy-from-env` must be set to `true`. By default, the value
+is `false`.
+
+This is the behavior when the proxy settings are enabled:
+
+1. http_proxy/HTTP_PROXY, https_proxy/HTTPS_PROXY and no_proxy/NO_PROXY
+   environment variables are read. If lower case and upper case variables are set
+   lower case variables take precendence.
+2. The no_proxy/NO_PROXY content is scanned for exact and suffix matches.
+3. CIDR expressions provided in no_proxy/NO_PROXY are not supported for matching.
+4. IP addresses or domains can be specified.
+5. The no_proxy/NO_PROXY list is comma separated.
+6. Use . or \*. to indicate domain suffix matching, e.g. `.foobar.com` will
+   match `test.foobar.com` or `foo.foobar.com`.

--- a/velox/exec/tests/utils/TempDirectoryPath.cpp
+++ b/velox/exec/tests/utils/TempDirectoryPath.cpp
@@ -28,7 +28,7 @@ std::shared_ptr<TempDirectoryPath> TempDirectoryPath::create() {
 }
 
 TempDirectoryPath::~TempDirectoryPath() {
-  LOG(INFO) << "TempDirectoryPath:: removing all files from" << path;
+  LOG(INFO) << "TempDirectoryPath:: removing all files from " << path;
   try {
     boost::filesystem::remove_all(path.c_str());
   } catch (...) {


### PR DESCRIPTION
The AWS C++ S3 Client does not automatically pick up
http proxy configurations set at the OS environment
level using the HTTP_PROXY, HTTPS_PROXY and
NO_PROXY environment variables. 
The AWS Java S3 Client does.

The environment variables themselves can be
lower case and upper case. If both versions are provided
then the lower case values take precedence.
The following is supported:
1. http_proxy/HTTP_PROXY, https_proxy/HTTPS_PROXY and no_proxy/NO_PROXY environment variables are read.
2. The NO_PROXY content is scanned for exact and suffix matches.
3. CIDR expressions provided in NO_PROXY  are not supported for matching.
4. IP addresses or domains can be specified.
5. NO_PROXY list is comma separated.
6. Use . or *. to indicate domain suffix matching, e.g. .foobar.com will match test.foobar.com or  foo.foobar.com.

A new a new hive config variable “hive.s3.use-proxy-from-env”
 is added to enable reading the environment variables if present. 
The default is false.