### PR TITLE
Add CAST(real as decimal)

### DIFF
--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -123,7 +123,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      -
-     -
+     - Y
    * - double
      - Y
      - Y
@@ -724,14 +724,15 @@ Invalid examples
   SELECT cast(123 as decimal(6, 4)); -- Out of range
   SELECT cast(123 as decimal(4, 2)); -- Out of range
 
-From double type
-^^^^^^^^^^^^^^^^
+From floating-point types
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Casting a double number to a decimal of given precision and scale is allowed
-if the input value can be represented by the precision and scale. When the
-given scale is less than the number of decimal places, the double value is
-rounded. The conversion precision is up to 15 as double provides 16(±1)
-significant decimal digits precision. Casting from invalid input values throws.
+Casting a floating-point number to a decimal of given precision and scale is allowed
+if the input value can be represented by the precision and scale. When the given
+scale is less than the number of decimal places, the floating-point value is rounded.
+The conversion precision is up to 15 for double and 6 for real according to the
+significant decimal digits precision they provide. Casting from NaN or infinite value
+throws.
 
 Valid example
 
@@ -741,6 +742,7 @@ Valid example
   SELECT cast(0.12 as decimal(4, 1)); -- decimal '0.1'
   SELECT cast(0.19 as decimal(4, 1)); -- decimal '0.2'
   SELECT cast(0.123456789123123 as decimal(38, 18)); -- decimal '0.123456789123123000'
+  SELECT cast(real '0.123456' as decimal(38, 18)); -- decimal '0.123456000000000000'
 
 Invalid example
 

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -460,22 +460,22 @@ void CastExpr::applyIntToDecimalCastKernel(
       });
 }
 
-template <typename TOutput>
-void CastExpr::applyDoubleToDecimalCastKernel(
+template <typename TInput, typename TOutput>
+void CastExpr::applyFloatingPointToDecimalCastKernel(
     const SelectivityVector& rows,
     const BaseVector& input,
     exec::EvalCtx& context,
     const TypePtr& toType,
     VectorPtr& result) {
-  const auto doubleInput = input.as<SimpleVector<double>>();
+  const auto floatingInput = input.as<SimpleVector<TInput>>();
   auto rawResults =
       result->asUnchecked<FlatVector<TOutput>>()->mutableRawValues();
   const auto toPrecisionScale = getDecimalPrecisionScale(*toType);
 
   applyToSelectedNoThrowLocal(context, rows, result, [&](vector_size_t row) {
     TOutput output;
-    const auto status = DecimalUtil::rescaleDouble<TOutput>(
-        doubleInput->valueAt(row),
+    const auto status = DecimalUtil::rescaleFloatingPoint<TInput, TOutput>(
+        floatingInput->valueAt(row),
         toPrecisionScale.first,
         toPrecisionScale.second,
         output);

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -576,8 +576,12 @@ VectorPtr CastExpr::applyDecimal(
       applyIntToDecimalCastKernel<int32_t, toDecimalType>(
           rows, input, context, toType, castResult);
       break;
+    case TypeKind::REAL:
+      applyFloatingPointToDecimalCastKernel<float, toDecimalType>(
+          rows, input, context, toType, castResult);
+      break;
     case TypeKind::DOUBLE:
-      applyDoubleToDecimalCastKernel<toDecimalType>(
+      applyFloatingPointToDecimalCastKernel<double, toDecimalType>(
           rows, input, context, toType, castResult);
       break;
     case TypeKind::BIGINT: {

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -206,8 +206,8 @@ class CastExpr : public SpecialForm {
       const TypePtr& toType,
       VectorPtr& castResult);
 
-  template <typename TOutput>
-  void applyDoubleToDecimalCastKernel(
+  template <typename TInput, typename TOutput>
+  void applyFloatingPointToDecimalCastKernel(
       const SelectivityVector& rows,
       const BaseVector& input,
       exec::EvalCtx& context,

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -296,6 +296,10 @@ class CastExprTest : public functions::test::CastBaseTest {
         fmt::format(
             "Cannot cast {} '100' to DECIMAL(17, 16)", CppToType<T>::name));
   }
+
+  std::string zeros(uint32_t numZeros) {
+    return std::string(numZeros, '0');
+  }
 };
 
 TEST_F(CastExprTest, basics) {
@@ -2019,29 +2023,54 @@ TEST_F(CastExprTest, castInTry) {
 
 TEST_F(CastExprTest, doubleToDecimal) {
   // Double to short decimal.
-  const auto input =
-      makeFlatVector<double>({-3333.03, -2222.02, -1.0, 0.00, 100, 99999.99});
+  const auto input = makeFlatVector<double>(
+      {-3333.03,
+       -2222.02,
+       -1.0,
+       0.00,
+       100,
+       99999.99,
+       10.03,
+       10.05,
+       9.95,
+       -2.123456789});
   testCast(
       input,
       makeFlatVector<int64_t>(
-          {-33'330'300, -22'220'200, -10'000, 0, 1'000'000, 999'999'900},
+          {-33'330'300,
+           -22'220'200,
+           -10'000,
+           0,
+           1'000'000,
+           999'999'900,
+           100'300,
+           100'500,
+           99'500,
+           -21'235},
           DECIMAL(10, 4)));
 
   // Double to long decimal.
   testCast(
       input,
       makeFlatVector<int128_t>(
-          {-33'330'300'000'000,
-           -22'220'200'000'000,
-           -10'000'000'000,
-           0,
-           1'000'000'000'000,
-           999'999'900'000'000},
-          DECIMAL(20, 10)));
+          {
+              HugeInt::parse("-333303" + zeros(16)),
+              HugeInt::parse("-222202" + zeros(16)),
+              -1'000'000'000'000'000'000,
+              0,
+              HugeInt::parse("100" + zeros(18)),
+              HugeInt::parse("9999999" + zeros(16)),
+              HugeInt::parse("1003" + zeros(16)),
+              HugeInt::parse("1005" + zeros(16)),
+              HugeInt::parse("995" + zeros(16)),
+              HugeInt::parse("-2123456789" + zeros(9)),
+          },
+          DECIMAL(38, 18)));
   testCast(
       input,
       makeFlatVector<int128_t>(
-          {-33'330, -22'220, -10, 0, 1'000, 1'000'000}, DECIMAL(20, 1)));
+          {-33'330, -22'220, -10, 0, 1'000, 1'000'000, 100, 101, 100, -21},
+          DECIMAL(20, 1)));
   testCast(
       makeNullableFlatVector<double>(
           {0.13456789,
@@ -2110,6 +2139,116 @@ TEST_F(CastExprTest, doubleToDecimal) {
       DECIMAL(38, 2),
       {NAN},
       "Cannot cast DOUBLE 'NaN' to DECIMAL(38, 2). The input value should be finite.");
+}
+
+TEST_F(CastExprTest, realToDecimal) {
+  // Real to short decimal.
+  const auto input = makeFlatVector<float>(
+      {-3333.03,
+       -2222.02,
+       -1.0,
+       0.00,
+       100,
+       99999.9,
+       10.03,
+       10.05,
+       9.95,
+       -2.12345});
+  testCast(
+      input,
+      makeFlatVector<int64_t>(
+          {-33'330'300,
+           -22'220'200,
+           -10'000,
+           0,
+           1'000'000,
+           999'999'000,
+           100'300,
+           100'500,
+           99'500,
+           -212'35},
+          DECIMAL(10, 4)));
+
+  // Real to long decimal.
+  testCast(
+      input,
+      makeFlatVector<int128_t>(
+          {HugeInt::parse("-333303" + zeros(16)),
+           HugeInt::parse("-222202" + zeros(16)),
+           -1'000'000'000'000'000'000,
+           0,
+           HugeInt::parse("100" + zeros(18)),
+           HugeInt::parse("999999" + zeros(17)),
+           HugeInt::parse("1003" + zeros(16)),
+           HugeInt::parse("1005" + zeros(16)),
+           HugeInt::parse("995" + zeros(16)),
+           -2'123'450'000'000'000'000},
+          DECIMAL(38, 18)));
+  testCast(
+      input,
+      makeFlatVector<int128_t>(
+          {-33'330, -22'220, -10, 0, 1'000, 999'999, 100, 101, 100, -21},
+          DECIMAL(20, 1)));
+  testCast(
+      makeNullableFlatVector<float>(
+          {0.134567, 0.000015, 0.000001, 0.999999, 0.123456, std::nullopt}),
+      makeNullableFlatVector<int128_t>(
+          {134'567'000'000'000'000,
+           15'000'000'000'000,
+           1'000'000'000'000,
+           999'999'000'000'000'000,
+           123'456'000'000'000'000,
+           std::nullopt},
+          DECIMAL(38, 18)));
+
+  testThrow<float>(
+      REAL(), DECIMAL(10, 2), {9999999999999999999999.99}, "Result overflows.");
+  testThrow<float>(
+      REAL(),
+      DECIMAL(10, 2),
+      {static_cast<float>(
+          static_cast<int128_t>(std::numeric_limits<int64_t>::max()) + 1)},
+      "Cannot cast REAL '9223372036854776000' to DECIMAL(10, 2). Result overflows.");
+  testThrow<float>(
+      REAL(),
+      DECIMAL(10, 2),
+      {static_cast<float>(
+          static_cast<int128_t>(std::numeric_limits<int64_t>::min()) - 1)},
+      "Cannot cast REAL '-9223372036854776000' to DECIMAL(10, 2). Result overflows.");
+  testThrow<float>(
+      REAL(),
+      DECIMAL(20, 2),
+      {static_cast<float>(DecimalUtil::kLongDecimalMax)},
+      "Cannot cast REAL '9.999999680285692E37' to DECIMAL(20, 2). Result overflows.");
+  testThrow<float>(
+      REAL(),
+      DECIMAL(20, 2),
+      {static_cast<float>(DecimalUtil::kLongDecimalMin)},
+      "Cannot cast REAL '-9.999999680285692E37' to DECIMAL(20, 2). Result overflows.");
+  testThrow<float>(
+      REAL(),
+      DECIMAL(38, 2),
+      {std::numeric_limits<float>::max()},
+      "Cannot cast REAL '3.4028234663852886E38' to DECIMAL(38, 2). Result overflows.");
+  testThrow<float>(
+      REAL(),
+      DECIMAL(38, 2),
+      {std::numeric_limits<float>::lowest()},
+      "Cannot cast REAL '-3.4028234663852886E38' to DECIMAL(38, 2). Result overflows.");
+  testCast(
+      makeConstant<float>(std::numeric_limits<float>::min(), 1),
+      makeConstant<int128_t>(0, 1, DECIMAL(38, 2)));
+
+  testThrow<float>(
+      REAL(),
+      DECIMAL(38, 2),
+      {INFINITY},
+      "Cannot cast REAL 'Infinity' to DECIMAL(38, 2). The input value should be finite.");
+  testThrow<float>(
+      REAL(),
+      DECIMAL(38, 2),
+      {NAN},
+      "Cannot cast REAL 'NaN' to DECIMAL(38, 2). The input value should be finite.");
 }
 
 TEST_F(CastExprTest, primitiveNullConstant) {


### PR DESCRIPTION
Supports CAST(real as decimal) and makes the result more precise by taking 
below two consideration.

1. The significant decimal digits precision of double and float includes the 
integral part, therefore when scaling up, the integral size needs to be 
excluded from the scale factor. This PR takes integral digits into 
consideration in rescaleFloatingPoint to avoid introduing unexpected digits to 
the result.
E.g. in `cast(99999.99 as decimal(38, 18))`, 99999.99 * 1e15 is 
`99999990000000008192` which is not accurate. But if we take integral digits 
into consideration, and mutliply 99999.99 with 1e10 before rounding,
`999999900000000` is got.

2. When the given scale is less than the precision provided by double or float, 
the input value is scaled up to the max precision before rounding, and scaled 
down to the required scale.
E.g. in `cast(0.95 as decimal(4, 1))`, `(long double)0.95 * 10` is 
`9.499999999` which is rounded to 9. But if we firstly scale it up by 1e6, 
`950000` can be got, and after dividing 1e5 and rounding, 10 is got as the final 
result.

https://github.com/facebookincubator/velox/issues/8412