### PR TITLE
Optimize kRelaxedSubstring LIKE pattern

### DIFF
--- a/velox/docs/functions/presto/regexp.rst
+++ b/velox/docs/functions/presto/regexp.rst
@@ -23,7 +23,8 @@ limited to 20 different expressions per instance and thread of execution.
 
     Note: Each function instance allow for a maximum of 20 regular expressions to
     be compiled per thread of execution. Not all patterns require
-    compilation of regular expressions. Patterns 'aaa', 'aaa%', '%aaa', where 'aaa'
+    compilation of regular expressions. Patterns 'hello', 'hello%', '_hello__%',
+    '%hello', '%__hello_', '%hello%', '%_hello__velox%' where 'hello', 'velox'
     contains only regular characters and '_' wildcards are evaluated without
     using regular expressions. Only those patterns that require the compilation of
     regular expressions are counted towards the limit.

--- a/velox/functions/lib/Re2Functions.h
+++ b/velox/functions/lib/Re2Functions.h
@@ -105,7 +105,7 @@ class PatternMetadata {
   static PatternMetadata substring(const std::string& fixedPattern);
 
   static PatternMetadata relaxedSubstring(
-      const std::string& fixedPattern,
+      const std::string fixedPattern,
       const std::vector<SubPatternMetadata>& subPatterns);
 
   const PatternKind patternKind() const {

--- a/velox/functions/lib/Re2Functions.h
+++ b/velox/functions/lib/Re2Functions.h
@@ -50,6 +50,9 @@ enum class PatternKind {
   kRelaxedSuffix,
   /// Patterns matching '%{c0}%', such as '%foo%%', '%%%hello%'.
   kSubstring,
+  /// Patterns matching '%<kRelaxedFixed>%', such as '%_pr_es_to_%%',
+  /// '%%%_pr_es_to_%'.
+  kRelaxedSubstring,
   /// Patterns which do not fit any of the above types, such as 'hello_world',
   /// '_presto%'.
   kGeneric,
@@ -101,12 +104,34 @@ class PatternMetadata {
 
   static PatternMetadata substring(const std::string& fixedPattern);
 
-  PatternKind patternKind() const {
+  static PatternMetadata relaxedSubstring(
+      const std::string& fixedPattern,
+      const std::vector<SubPatternMetadata>& subPatterns);
+
+  const PatternKind patternKind() const {
     return patternKind_;
   }
 
   size_t length() const {
     return length_;
+  }
+
+  /// Length of the specified sub-pattern ranges.
+  const size_t lengthOf(size_t startIndexInclusive, size_t endIndexInclusive)
+      const {
+    if (startIndexInclusive == 0 && endIndexInclusive == numSubPatterns() - 1) {
+      return length_;
+    }
+
+    size_t length = 0;
+    for (auto i = startIndexInclusive; i <= endIndexInclusive; ++i) {
+      length += subPatterns_[i].length;
+    }
+    return length;
+  }
+
+  const size_t numSubPatterns() const {
+    return subPatterns_.size();
   }
 
   const std::vector<SubPatternMetadata>& subPatterns() const {

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -930,6 +930,42 @@ TEST_F(Re2FunctionsTest, likeSubstringPattern) {
 }
 
 TEST_F(Re2FunctionsTest, likeRelaxedSubstringPattern) {
+  // In the following code, we will be use some notation described here:
+  // - <Sx>: a kSingleCharWildcard pattern. e.g. <S0>, <S1>
+  // - <Lx>: a kLiteralString pattern. e.g. <L0>, <L1>
+
+  // For case: `%<L0><S0>%`
+  testLike("abdef", "%abc__%", false);
+  testLike("abcd", "%abc__%", false);
+  testLike("abcde", "%abc__%", true);
+  testLike("abcdef", "%abc__%", true);
+  testLike("xabcdef", "%abc__%", true);
+
+  // For case: `%<S0><L0>%`
+  testLike("abdef", "%__abc%", false);
+  testLike("abc", "%__abc%", false);
+  testLike("xabc", "%__abc%", false);
+  testLike("xxabc", "%__abc%", true);
+  testLike("xxxabc", "%__abc%", true);
+  testLike("xxxabcx", "%__abc%", true);
+
+  // For case: `%<S0><L0><S1>%`
+  testLike("abdef", "%_abc__%", false);
+  testLike("xabcd", "%_abc__%", false);
+  testLike("xabcd", "%_abc__%", false);
+  testLike("abcde", "%_abc__%", false);
+  testLike("abcabcde", "%_abc__%", true);
+  testLike("abcabcdef", "%_abc__%", true);
+
+  // For case: `%<L0><S1><L1>%`
+  testLike("abdef", "%abc__de%", false);
+  testLike("abcxxxe", "%abc__de%", false);
+  testLike("abcxxxde", "%abc__de%", false);
+  testLike("abcxxxdeabc", "%abc__de%", false);
+  testLike("abcxxxdeabcxxde", "%abc__de%", true);
+  testLike("abcxxxdeabcxxdef", "%abc__de%", true);
+  testLike("abcxxxdeabcxxdefg", "%abc__de%", true);
+
   // Basic tests.
   testLike("abcde", "%_bcd_%%", true);
   testLike("abcde", "%%b_de%", true);

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -930,25 +930,35 @@ TEST_F(Re2FunctionsTest, likeSubstringPattern) {
 }
 
 TEST_F(Re2FunctionsTest, likeRelaxedSubstringPattern) {
+  // Basic tests.
   testLike("abcde", "%_bcd_%%", true);
   testLike("abcde", "%%b_de%", true);
+  testLike("abcde", "%%_b_d_%", true);
+  testLike("abcde", "%cc_%", false);
+  testLike("abcde", "%%_ccd_%%%", false);
+  testLike("abcde", "%%_be_%", false);
+  testLike("abcde", "%_cb%%", false);
   testLike("ABCDE", "%%C_%%%", true);
   testLike("ABCDE", "%%_C%%%", true);
   testLike("ABCDE", "%%_C_%%%", true);
+  testLike("ABCDE", "%_BD_%%", false);
+  testLike("ABCDE", "%%_BDE%", false);
+  testLike("ABCDE", "%_de%%", false);
+  testLike("ABCDE", "%%Ab_%", false);
+
   testLike("FGH_ABCDE", "%_ABCDE%", true);
   testLike("ABCDE", "%_ABCDE%", false);
   testLike("_ABCDE", "%_ABCDE%", true);
-
-  testLike("abcde", "%cc_%", false);
-  testLike("ABCDE", "%_BD_%%", false);
-  testLike("abcde", "%%_ccd_%%%", false);
-  testLike("ABCDE", "%%_BDE%", false);
-  testLike("abcde", "%%_be_%", false);
-  testLike("ABCDE", "%_de%%", false);
-  testLike("abcde", "%_cb%%", false);
-  testLike("ABCDE", "%%Ab_%", false);
   testLike("a_a_b_ca_b", "%a_b_c%", true);
 
+  // Inputs with special chars.
+  testLike("\nabc\nde\n", "%\n_e%%", true);
+  testLike("\nabcde\n", "%%_de%", true);
+  testLike("\nabc\tde\b", "%%%_d%%", true);
+  testLike("\nabcde\t", "%%_e\t%%", true);
+  testLike("\nabcde\n", "%%_d\n%", false);
+
+  // Unicode test.
   testLike("你好啊世界", "%_好啊_%%", true);
   testLike("你好啊世界", "%%好_世界%", true);
   testLike("你好你好哈哈世界", "%%你好__世界%", true);
@@ -959,15 +969,8 @@ TEST_F(Re2FunctionsTest, likeRelaxedSubstringPattern) {
   testLike("你好啊世界", "%_好好_%%", false);
   testLike("你好啊世界", "%%_好世_%", false);
 
-  testLike("\nabc\nde\n", "%\n_e%%", true);
-  testLike("\nabcde\n", "%%_de%", true);
-  testLike("\nabc\tde\b", "%%%_d%%", true);
-  testLike("\nabcde\t", "%%_e\t%%", true);
-  testLike("\nabcde\n", "%%_d\n%", false);
-
   testLike("aaaaaaaaaaaaaaaaaaaaaaabcdef", "%a_c%", true);
   testLike("aaaaaaaaaaaaaaaaaaaaaaabcdef", "%a_c_e%", true);
-
   testLike("abababababababaaaaaaaaaaaaaaaabcdef", "%ab_d%", true);
 
   // There are a lot 'noise': a_b which is similar to our pattern: a_b_c, it
@@ -988,6 +991,9 @@ TEST_F(Re2FunctionsTest, likeRelaxedSubstringPattern) {
       "a_b__ca_b__ca_b__ca_b__ca_b__ca_b__ca_b__ca_b__ca_b__cdef",
       "%a_b_c%",
       false);
+
+  // This one needs backtrack(in our implementation).
+  testLike("a_b_aab_b", "%a__b%", true);
 
   // Test literal '_' & '%' in pattern.
   testLike("cd_be", R"(%_\_b%)", '\\', true);


### PR DESCRIPTION
kRelaxedSubstring LIKE pattern is patterns that contains '%' but it only occurs at the beginning and end of the pattern, and it also contains '_'. e.g. '%Hello_Velox%'.

The algorithm is as follows:

kRelaxedSubstring pattern is consists of two kinds of sub patterns: `kLiteralString`, `kSingleCharWildcard`, we will use notation `L0`, `Li`, `S0`, `Si` etc to describe them in the following, e.g. `<L0><S0>` is a pattern like: `%hello__%`, while `<S0><L0>` is a pattern like `%__hello%`

1. We start by set the target sub-pattern to search as `L0`(currentSubPattern = L0).
2. We search for `currentSubPattern` in the input and record the result in `currentMatchingOffsetInInput`.
3. If it is not found(`currentMatchingOffsetInInput < 0`), algorithm finish with return result `false`.
4. If it is found, we then match the right part sub-patterns
  a. If it fails at some sub-pattern `Li`, we update `currentSubPattern` as `Li`, update `currentMatchingOffsetInInput` as the next byte where we failed the matching, and jump to step 2.
  b. If it fails at some sub-pattern `Si`, algorithm finish with return result `false`.
5. If the right sub-patterns matches, we continue match left sub-patterns.
  a. If it matches, algorithm finish with return result `true`.
  b. If it failed at some sub-pattern `Lj`, we update `currentSubPattern` as `Lj`, update `currentMatchingOffsetInInput` as the next byte where we failed the matching, and jump to step 2.
  c. If it failed at some sub-pattern `Sj`, we keep `currentSubPattern` not changed, and increment `currentMatchingOffsetInInput` by one byte, and jump to step 2.

 We designed benchmarks which consists of 4 tests:

- easy: no noise in the input.
- normal: many noise in the input, but easy to have fast path.
- hard_ascii: many noise in the pure ASCII input.
- hard_unicode: many noise in the Unicode input.

Before this optimization:

```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
relaxed_substring##easy                                      1.06s   945.37m
relaxed_substring##normal                                 994.73ms      1.01
relaxed_substring##hard_ascii                                4.67s   213.91m
relaxed_substring##hard_unicode                              7.08s   141.33m
```

After this optimization:

```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
relaxed_substring##easy                                     5.73ms    174.64
relaxed_substring##normal                                   6.93ms    144.36
relaxed_substring##hard_ascii                                1.20s   836.17m
relaxed_substring##hard_unicode                              1.79s   559.71m
```

So in summary: for normal input this optimization gives us 180x speedup, for hard pure ASCII or Unicode input it gives us 4x speedup.