### PR TITLE
Add TraceContext to various system calls that can block

### DIFF
--- a/velox/common/caching/CMakeLists.txt
+++ b/velox/common/caching/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(
          velox_exception
          velox_file
          velox_memory
+         velox_process
          Folly::folly
          fmt::fmt
          gflags::gflags

--- a/velox/common/process/ThreadLocalRegistry.h
+++ b/velox/common/process/ThreadLocalRegistry.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <list>
+#include <memory>
+#include <mutex>
+
+namespace facebook::velox::process {
+
+/// A registry for keeping static thread local objects of type T.  Similar to
+/// folly::ThreadLocal but a little bit more efficient in terms of performance
+/// and memory usage, because we do not support thread local with lexical scope.
+///
+/// NOTE: only one instance of ThreadLocalRegistry<T> can be created with each
+/// T.
+template <typename T>
+class ThreadLocalRegistry {
+ public:
+  class Reference;
+
+  /// Access values from all threads.  Takes a global lock and should be used
+  /// with caution.
+  template <typename F>
+  void forAllValues(F f) {
+    std::lock_guard<std::mutex> entriesLock(entriesMutex_);
+    for (auto& entry : entries_) {
+      std::lock_guard<std::mutex> lk(entry->mutex);
+      f(entry->value);
+    }
+  }
+
+ private:
+  struct Entry {
+    std::mutex mutex;
+    T value;
+  };
+
+  std::list<std::unique_ptr<Entry>> entries_;
+  std::mutex entriesMutex_;
+};
+
+/// Reference to one thread local value.  Should be stored in thread local
+/// memory.
+template <typename T>
+class ThreadLocalRegistry<T>::Reference {
+ public:
+  explicit Reference(const std::shared_ptr<ThreadLocalRegistry>& registry)
+      : registry_(registry) {
+    auto entry = std::make_unique<Entry>();
+    std::lock_guard<std::mutex> lk(registry_->entriesMutex_);
+    iterator_ =
+        registry_->entries_.insert(registry_->entries_.end(), std::move(entry));
+  }
+
+  ~Reference() {
+    std::lock_guard<std::mutex> lk(registry_->entriesMutex_);
+    registry_->entries_.erase(iterator_);
+  }
+
+  /// Obtain the thread local value and process it with the functor `f'.
+  template <typename F>
+  auto withValue(F f) {
+    auto* entry = iterator_->get();
+    std::lock_guard<std::mutex> lk(entry->mutex);
+    return f(entry->value);
+  }
+
+ private:
+  std::shared_ptr<ThreadLocalRegistry> const registry_;
+  typename std::list<std::unique_ptr<Entry>>::iterator iterator_;
+};
+
+} // namespace facebook::velox::process

--- a/velox/common/process/TraceContext.cpp
+++ b/velox/common/process/TraceContext.cpp
@@ -16,23 +16,27 @@
 
 #include "velox/common/process/TraceContext.h"
 
+#include "velox/common/process/ThreadLocalRegistry.h"
+
 #include <sstream>
 
 namespace facebook::velox::process {
 
 namespace {
-folly::Synchronized<std::unordered_map<std::string, TraceData>>& traceMap() {
-  static folly::Synchronized<std::unordered_map<std::string, TraceData>>
-      staticTraceMap;
-  return staticTraceMap;
-}
+
+// We use thread local instead lock here since the critical path is on write
+// side.
+using Registry = ThreadLocalRegistry<folly::F14FastMap<std::string, TraceData>>;
+auto registry = std::make_shared<Registry>();
+thread_local Registry::Reference threadLocalTraceData(registry);
+
 } // namespace
 
 TraceContext::TraceContext(std::string label, bool isTemporary)
     : label_(std::move(label)),
       enterTime_(std::chrono::steady_clock::now()),
       isTemporary_(isTemporary) {
-  traceMap().withWLock([&](auto& counts) {
+  threadLocalTraceData.withValue([&](auto& counts) {
     auto& data = counts[label_];
     ++data.numThreads;
     if (data.numThreads == 1) {
@@ -43,17 +47,18 @@ TraceContext::TraceContext(std::string label, bool isTemporary)
 }
 
 TraceContext::~TraceContext() {
-  traceMap().withWLock([&](auto& counts) {
-    auto& data = counts[label_];
-    --data.numThreads;
+  threadLocalTraceData.withValue([&](auto& counts) {
+    auto it = counts.find(label_);
+    auto& data = it->second;
+    if (--data.numThreads == 0 && isTemporary_) {
+      counts.erase(it);
+      return;
+    }
     auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                   std::chrono::steady_clock::now() - enterTime_)
                   .count();
     data.totalMs += ms;
     data.maxMs = std::max<uint64_t>(data.maxMs, ms);
-    if (!data.numThreads && isTemporary_) {
-      counts.erase(label_);
-    }
   });
 }
 
@@ -61,27 +66,40 @@ TraceContext::~TraceContext() {
 std::string TraceContext::statusLine() {
   std::stringstream out;
   auto now = std::chrono::steady_clock::now();
-  traceMap().withRLock([&](auto& counts) {
-    for (auto& pair : counts) {
-      if (pair.second.numThreads) {
-        auto continued = std::chrono::duration_cast<std::chrono::milliseconds>(
-                             now - pair.second.startTime)
-                             .count();
+  auto counts = status();
+  for (auto& pair : counts) {
+    if (pair.second.numThreads) {
+      auto continued = std::chrono::duration_cast<std::chrono::milliseconds>(
+                           now - pair.second.startTime)
+                           .count();
 
-        out << pair.first << "=" << pair.second.numThreads << " entered "
-            << pair.second.numEnters << " avg ms "
-            << (pair.second.totalMs / pair.second.numEnters) << " max ms "
-            << pair.second.maxMs << " continuous for " << continued
-            << std::endl;
-      }
+      out << pair.first << "=" << pair.second.numThreads << " entered "
+          << pair.second.numEnters << " avg ms "
+          << (pair.second.totalMs / pair.second.numEnters) << " max ms "
+          << pair.second.maxMs << " continuous for " << continued << std::endl;
     }
-  });
+  }
   return out.str();
 }
 
 // static
-std::unordered_map<std::string, TraceData> TraceContext::status() {
-  return traceMap().withRLock([&](auto& map) { return map; });
+folly::F14FastMap<std::string, TraceData> TraceContext::status() {
+  folly::F14FastMap<std::string, TraceData> total;
+  registry->forAllValues([&](auto& counts) {
+    for (auto& [k, v] : counts) {
+      auto& sofar = total[k];
+      if (sofar.numEnters == 0) {
+        sofar.startTime = v.startTime;
+      } else if (v.numEnters > 0) {
+        sofar.startTime = std::min(sofar.startTime, v.startTime);
+      }
+      sofar.numThreads += v.numThreads;
+      sofar.numEnters += v.numEnters;
+      sofar.totalMs += v.totalMs;
+      sofar.maxMs = std::max(sofar.maxMs, v.maxMs);
+    }
+  });
+  return total;
 }
 
 } // namespace facebook::velox::process

--- a/velox/common/process/TraceContext.h
+++ b/velox/common/process/TraceContext.h
@@ -20,7 +20,7 @@
 #include <string>
 #include <unordered_map>
 
-#include <folly/Synchronized.h>
+#include <folly/container/F14Map.h>
 
 namespace facebook::velox::process {
 
@@ -63,7 +63,7 @@ class TraceContext {
   static std::string statusLine();
 
   // Returns a copy of the trace status.
-  static std::unordered_map<std::string, TraceData> status();
+  static folly::F14FastMap<std::string, TraceData> status();
 
  private:
   const std::string label_;

--- a/velox/common/process/tests/CMakeLists.txt
+++ b/velox/common/process/tests/CMakeLists.txt
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_process_test TraceContextTest.cpp)
+add_executable(velox_process_test TraceContextTest.cpp
+                                  ThreadLocalRegistryTest.cpp)
 
 add_test(velox_process_test velox_process_test)
 

--- a/velox/common/process/tests/ThreadLocalRegistryTest.cpp
+++ b/velox/common/process/tests/ThreadLocalRegistryTest.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/process/ThreadLocalRegistry.h"
+
+#include <folly/synchronization/Baton.h>
+#include <folly/synchronization/Latch.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+
+namespace facebook::velox::process {
+namespace {
+
+template <typename Tag>
+class TestObject {
+ public:
+  static std::atomic_int& count() {
+    static std::atomic_int value;
+    return value;
+  }
+
+  TestObject() : threadId_(std::this_thread::get_id()) {
+    ++count();
+  }
+
+  ~TestObject() {
+    --count();
+  }
+
+  std::thread::id threadId() const {
+    return threadId_;
+  }
+
+ private:
+  const std::thread::id threadId_;
+};
+
+TEST(ThreadLocalRegistryTest, basic) {
+  struct Tag {};
+  using T = TestObject<Tag>;
+  ASSERT_EQ(T::count(), 0);
+  auto registry = std::make_shared<ThreadLocalRegistry<T>>();
+  registry->forAllValues([](const T&) { FAIL(); });
+  thread_local ThreadLocalRegistry<T>::Reference ref(registry);
+  const T* object = ref.withValue([](const T& x) {
+    EXPECT_EQ(T::count(), 1);
+    return &x;
+  });
+  ASSERT_EQ(object->threadId(), std::this_thread::get_id());
+  ref.withValue([&](const T& x) { ASSERT_EQ(&x, object); });
+  int count = 0;
+  registry->forAllValues([&](const T& x) {
+    ++count;
+    ASSERT_EQ(x.threadId(), std::this_thread::get_id());
+  });
+  ASSERT_EQ(count, 1);
+  ASSERT_EQ(T::count(), 1);
+}
+
+TEST(ThreadLocalRegistryTest, multiThread) {
+  struct Tag {};
+  using T = TestObject<Tag>;
+  ASSERT_EQ(T::count(), 0);
+  auto registry = std::make_shared<ThreadLocalRegistry<T>>();
+  constexpr int kNumThreads = 7;
+  std::vector<std::thread> threads;
+  folly::Latch latch(kNumThreads);
+  folly::Baton<> batons[kNumThreads];
+  const T* objects[kNumThreads];
+  for (int i = 0; i < kNumThreads; ++i) {
+    threads.emplace_back([&, i] {
+      thread_local ThreadLocalRegistry<T>::Reference ref(registry);
+      objects[i] = ref.withValue([](const T& x) { return &x; });
+      latch.count_down();
+      batons[i].wait();
+    });
+  }
+  latch.wait();
+  std::vector<int> indices;
+  registry->forAllValues([&](const T& x) {
+    auto it = std::find(std::begin(objects), std::end(objects), &x);
+    indices.push_back(it - std::begin(objects));
+  });
+  ASSERT_EQ(indices.size(), kNumThreads);
+  std::sort(indices.begin(), indices.end());
+  for (int i = 0; i < kNumThreads; ++i) {
+    ASSERT_EQ(indices[i], i);
+    ASSERT_EQ(objects[i]->threadId(), threads[i].get_id());
+    ASSERT_EQ(T::count(), kNumThreads - i);
+    batons[i].post();
+    threads[i].join();
+  }
+  ASSERT_EQ(T::count(), 0);
+  registry->forAllValues([](const T&) { FAIL(); });
+}
+
+} // namespace
+} // namespace facebook::velox::process

--- a/velox/dwio/common/ColumnLoader.cpp
+++ b/velox/dwio/common/ColumnLoader.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/dwio/common/ColumnLoader.h"
 
+#include "velox/common/process/TraceContext.h"
+
 namespace facebook::velox::dwio::common {
 
 // Wraps '*result' in a dictionary to make the contiguous values
@@ -45,6 +47,7 @@ void ColumnLoader::loadInternal(
     ValueHook* hook,
     vector_size_t resultSize,
     VectorPtr* result) {
+  process::TraceContext trace("ColumnLoader::loadInternal");
   VELOX_CHECK_EQ(
       version_,
       structReader_->numReads(),

--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/dwio/common/SelectiveStructColumnReader.h"
 
+#include "velox/common/process/TraceContext.h"
 #include "velox/dwio/common/ColumnLoader.h"
 
 namespace facebook::velox::dwio::common {
@@ -56,6 +57,7 @@ void SelectiveStructColumnReaderBase::next(
     uint64_t numValues,
     VectorPtr& result,
     const Mutation* mutation) {
+  process::TraceContext trace("SelectiveStructColumnReaderBase::next");
   if (children_.empty()) {
     if (mutation && mutation->deletedRows) {
       numValues -= bits::countBits(mutation->deletedRows, 0, numValues);

--- a/velox/dwio/dwrf/reader/ReaderBase.cpp
+++ b/velox/dwio/dwrf/reader/ReaderBase.cpp
@@ -18,6 +18,7 @@
 
 #include <fmt/format.h>
 
+#include "velox/common/process/TraceContext.h"
 #include "velox/dwio/common/exception/Exception.h"
 
 namespace facebook::velox::dwrf {
@@ -100,6 +101,7 @@ ReaderBase::ReaderBase(
       footerEstimatedSize_(footerEstimatedSize),
       filePreloadThreshold_(filePreloadThreshold),
       input_(std::move(input)) {
+  process::TraceContext trace("ReaderBase::ReaderBase");
   // read last bytes into buffer to get PostScript
   // If file is small, load the entire file.
   // TODO: make a config

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -20,6 +20,7 @@
 #include "velox/common/base/Portability.h"
 #include "velox/common/base/SimdUtil.h"
 #include "velox/common/process/ProcessBase.h"
+#include "velox/common/process/TraceContext.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/vector/VectorTypeUtils.h"
@@ -857,6 +858,7 @@ bool HashTable<ignoreNullKeys>::canApplyParallelJoinBuild() const {
 
 template <bool ignoreNullKeys>
 void HashTable<ignoreNullKeys>::parallelJoinBuild() {
+  process::TraceContext trace("HashTable::parallelJoinBuild");
   TestValue::adjust(
       "facebook::velox::exec::HashTable::parallelJoinBuild", rows_->pool());
   VELOX_CHECK_LE(1 + otherTables_.size(), std::numeric_limits<uint8_t>::max());


### PR DESCRIPTION
Summary: Also optimize `TraceContext` for writing by using thread local memory.

Differential Revision: D53146503


