### PR TITLE
Fix array with offsets unnecessary reallocation of buffers

### DIFF
--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -604,6 +604,10 @@ class BaseVector {
     VELOX_UNSUPPORTED("Vector is not a wrapper");
   }
 
+  virtual VectorPtr& valueVector() {
+    VELOX_UNSUPPORTED("Vector is not a wrapper");
+  }
+
   virtual BaseVector* loadedVector() {
     return this;
   }

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -249,6 +249,10 @@ class ConstantVector final : public SimpleVector<T> {
     return valueVector_;
   }
 
+  VectorPtr& valueVector() override {
+    return valueVector_;
+  }
+
   // Index of the element of the base vector that determines the value of this
   // constant vector.
   vector_size_t index() const {

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -121,7 +121,15 @@ class DictionaryVector : public SimpleVector<T> {
     return indices_;
   }
 
+  inline BufferPtr& indices() {
+    return indices_;
+  }
+
   const VectorPtr& valueVector() const override {
+    return dictionaryValues_;
+  }
+
+  VectorPtr& valueVector() override {
     return dictionaryValues_;
   }
 

--- a/velox/vector/SequenceVector.h
+++ b/velox/vector/SequenceVector.h
@@ -126,6 +126,10 @@ class SequenceVector : public SimpleVector<T> {
     return sequenceValues_;
   }
 
+  VectorPtr& valueVector() override {
+    return sequenceValues_;
+  }
+
   BufferPtr getSequenceLengths() const {
     return sequenceLengths_;
   }


### PR DESCRIPTION
Summary: Exposing additional mutable properties (indices and valuesVector) from DictionaryVector without requiring a shared pointer (and messing up ref counting).

Differential Revision: D52706695


