### PR TITLE
Use Microseconds and CPU time for decoding time

### DIFF
--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -131,7 +131,7 @@ class RowReaderOptions {
   // (in dwrf row reader). todo: encapsulate this and keySelectionCallBack_ in a
   // struct
   std::function<void(uint64_t)> blockedOnIoCallback_;
-  std::function<void(uint64_t)> decodingTimeMsCallback_;
+  std::function<void(uint64_t)> decodingTimeUsCallback_;
   std::function<void(uint16_t)> stripeCountCallback_;
   bool eagerFirstStripeLoad = true;
   uint64_t skipRows_ = 0;
@@ -350,12 +350,12 @@ class RowReaderOptions {
     return blockedOnIoCallback_;
   }
 
-  void setDecodingTimeMsCallback(std::function<void(int64_t)> decodingTimeMs) {
-    decodingTimeMsCallback_ = std::move(decodingTimeMs);
+  void setDecodingTimeUsCallback(std::function<void(int64_t)> decodingTimeUs) {
+    decodingTimeUsCallback_ = std::move(decodingTimeUs);
   }
 
-  std::function<void(int64_t)> getDecodingTimeMsCallback() const {
-    return decodingTimeMsCallback_;
+  std::function<void(int64_t)> getDecodingTimeUsCallback() const {
+    return decodingTimeUsCallback_;
   }
 
   void setStripeCountCallback(

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -132,6 +132,7 @@ class RowReaderOptions {
   // struct
   std::function<void(uint64_t)> blockedOnIoCallback_;
   std::function<void(uint64_t)> decodingTimeMsCallback_;
+  std::function<void(uint16_t)> stripeCountCallback_;
   bool eagerFirstStripeLoad = true;
   uint64_t skipRows_ = 0;
 
@@ -353,8 +354,17 @@ class RowReaderOptions {
     decodingTimeMsCallback_ = std::move(decodingTimeMs);
   }
 
-  const std::function<void(int64_t)> getDecodingTimeMsCallback() const {
+  std::function<void(int64_t)> getDecodingTimeMsCallback() const {
     return decodingTimeMsCallback_;
+  }
+
+  void setStripeCountCallback(
+      std::function<void(uint16_t)> stripeCountCallback) {
+    stripeCountCallback_ = std::move(stripeCountCallback);
+  }
+
+  std::function<void(uint16_t)> getStripeCountCallback() const {
+    return stripeCountCallback_;
   }
 
   void setSkipRows(uint64_t skipRows) {

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -149,7 +149,7 @@ class DwrfRowReader : public StrideIndexProvider,
   std::shared_ptr<StripeDictionaryCache> stripeDictionaryCache_;
   dwio::common::RowReaderOptions options_;
   std::shared_ptr<folly::Executor> executor_;
-  std::function<void(uint64_t)> decodingTimeMsCallback_;
+  std::function<void(uint64_t)> decodingTimeUsCallback_;
   std::function<void(uint16_t)> stripeCountCallback_;
 
   struct PrefetchedStripeState {

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -149,6 +149,8 @@ class DwrfRowReader : public StrideIndexProvider,
   std::shared_ptr<StripeDictionaryCache> stripeDictionaryCache_;
   dwio::common::RowReaderOptions options_;
   std::shared_ptr<folly::Executor> executor_;
+  std::function<void(uint64_t)> decodingTimeMsCallback_;
+  std::function<void(uint16_t)> stripeCountCallback_;
 
   struct PrefetchedStripeState {
     bool preloaded;


### PR DESCRIPTION
Summary:
We want to measure processing, so we're moving from wall to CPU time.

Also, the decoding time are in the single digit ms most of the time, even 1 ms is normal. So let's give it more resolution than 1 ms.

Differential Revision: D53200548


