### PR TITLE
Fix flaky test reclaimFromNonReclaimableSortTableWriter

### DIFF
--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -3905,6 +3905,7 @@ DEBUG_ONLY_TEST_F(
   ASSERT_EQ(arbitrator->stats().numReserves, 1);
   const auto updatedSpillStats = common::globalSpillStats();
   ASSERT_EQ(updatedSpillStats, spillStats);
+  waitForAllTasksToBeDeleted();
 }
 
 DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, tableFileWriteError) {


### PR DESCRIPTION
The test fails on exceptions thrown by ~MemoryManager().

When test finishes, sometimes the task could still be running. 
It caused unexpected alive memory pools allocated by user on 
memory manager destruction.