### PR TITLE
Fix GCC OOM when building by reducing parallelism.

### DIFF
--- a/.circleci/dist_compile.yml
+++ b/.circleci/dist_compile.yml
@@ -105,7 +105,7 @@ commands:
       - run:
           name: "Build Benchmarks - << parameters.benchmark_class >>"
           command: |
-            make benchmarks-basic-build NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=8
+            make benchmarks-basic-build NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4
             ccache -s
             mkdir -p << parameters.binary_output >>
             cp -r --verbose _build/release/velox/benchmarks/basic/* << parameters.binary_output >>
@@ -127,7 +127,7 @@ commands:
       - run:
           name: Build
           command: |
-            make debug NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=4
+            make debug NUM_THREADS=8 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=4
             ccache -s
           no_output_timeout: 1h
       - run:
@@ -389,7 +389,7 @@ jobs:
       - run:
           name: "Build Velox With Benchmarks and Without Testing"
           command: |
-            make benchmarks-build NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=16
+            make benchmarks-build NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4
           no_output_timeout: 1h
       - post-steps
 


### PR DESCRIPTION
**Why**

Builds OOM with the following error : https://app.circleci.com/pipelines/github/facebookincubator/velox/43449/workflows/0ecff160-1cb9-4084-9f1e-21ae5b484321/jobs/302064 . We reduced the parallelism recently but dint reduce it for all jobs (https://github.com/facebookincubator/velox/pull/8530) - In this PR we set it for all _debug_ jobs (which are most likely to OOM )

**How**
 We reduce parallelism as a stop gap to fix this issue and unblock folks.  We have an issue here for a long term fix : https://github.com/facebookincubator/velox/issues/8539 
 
 