### PR TITLE
Optimize LIKE for more relaxed patterns

### DIFF
--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -383,13 +383,220 @@ class Re2SearchAndExtract final : public VectorFunction {
   const bool emptyNoMatch_;
 };
 
+namespace {
+
+// Sub-pattern's stats in a top-level pattern.
+struct SubPatternStats {
+  SubPatternKind kind;
+
+  // Number of times this sub-pattern occurs in the overall pattern.
+  size_t count = 0;
+
+  // First index of this pattern kind.
+  std::optional<size_t> firstIndex = std::nullopt;
+
+  // Last index of this pattern kind. lastIndex will be set as the same value as
+  // firstIndex if the kind of sub-pattern only occur once.
+  std::optional<size_t> lastIndex = std::nullopt;
+
+  void update(size_t index) {
+    count++;
+    if (!firstIndex.has_value()) {
+      firstIndex = index;
+    }
+
+    lastIndex = index;
+  }
+};
+
+// Construct SubPatternMetadata from subPatternKinds, subPatternRanges.
+// Caller need to make sure the specified range only contains
+// fixed(kLiteralString, kSingleWildcard) patterns.
+size_t buildFixedSubPatterns(
+    const std::vector<SubPatternKind>& subPatternKinds,
+    const std::vector<std::pair<size_t, size_t>>& subPatternRanges,
+    size_t start,
+    size_t end,
+    std::vector<SubPatternMetadata>& subPatterns) {
+  size_t indexInFixedPattern = 0;
+  for (auto i = start; i < end; i++) {
+    const auto kind = subPatternKinds[i];
+    if (kind == SubPatternKind::kLiteralString ||
+        kind == SubPatternKind::kSingleCharWildcard) {
+      subPatterns.push_back(
+          {kind, indexInFixedPattern, subPatternRanges[i].second});
+    } else {
+      VELOX_UNREACHABLE();
+    }
+    indexInFixedPattern += subPatternRanges[i].second;
+  }
+
+  return indexInFixedPattern;
+}
+
+// Return the length of the fixed part(literal chars or single char wildcard) of
+// the pattern, it is mainly used to get the length of the fixed part in a
+// pattern, so we can extract the fixed part out.
+size_t fixedLength(
+    const std::vector<SubPatternKind>& subPatternKinds,
+    const std::vector<std::pair<size_t, size_t>>& subPatternRanges) {
+  size_t result = 0;
+  for (auto i = 0; i < subPatternKinds.size(); i++) {
+    if (subPatternKinds[i] != SubPatternKind::kAnyCharsWildcard) {
+      result += subPatternRanges[i].second;
+    }
+  }
+
+  return result;
+}
+
+// Return the number of bytes in the specified unicode character. Returns 1 if
+// specified character is not a valid UTF-8.
+size_t unicodeCharLength(const char* str) {
+  auto size = utf8proc_char_length(str);
+  // Skip bad byte if we get utf length < 0.
+  return UNLIKELY(size < 0) ? 1 : size;
+}
+
+} // namespace
+
 // Match string 'input' with a fixed pattern (with no wildcard characters).
 bool matchExactPattern(
     StringView input,
     const std::string& pattern,
     size_t length) {
-  return input.size() == pattern.size() &&
-      std::memcmp(input.data(), pattern.data(), length) == 0;
+  if (FOLLY_LIKELY(pattern.size() > 0)) {
+    return input.size() == pattern.size() &&
+        std::memcmp(input.data(), pattern.data(), length) == 0;
+  }
+
+  return input.size() == 0;
+}
+
+bool matchRelaxedFixedForwardAscii(
+    StringView input,
+    const PatternMetadata& patternMetadata,
+    size_t start) {
+  // Compare the length first.
+  if (input.size() - start < patternMetadata.length()) {
+    return false;
+  }
+
+  for (const auto& subPattern : patternMetadata.subPatterns()) {
+    if (subPattern.kind == SubPatternKind::kLiteralString &&
+        std::memcmp(
+            input.data() + start + subPattern.start,
+            patternMetadata.fixedPattern().data() + subPattern.start,
+            subPattern.length) != 0) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool matchRelaxedFixedForwardUnicode(
+    StringView input,
+    const PatternMetadata& patternMetadata,
+    size_t start) {
+  // Compare the length first.
+  if (input.size() - start < patternMetadata.length()) {
+    return false;
+  }
+
+  auto cursor = start;
+  for (const auto& subPattern : patternMetadata.subPatterns()) {
+    if (subPattern.kind == SubPatternKind::kSingleCharWildcard) {
+      // Match every single char wildcard.
+      for (auto i = 0; i < subPattern.length; i++) {
+        if (cursor >= input.size()) {
+          return false;
+        }
+
+        auto numBytes = unicodeCharLength(input.data() + cursor);
+        cursor += numBytes;
+      }
+    } else {
+      const auto currentLength = subPattern.length;
+      if (cursor + currentLength > input.size() ||
+          std::memcmp(
+              input.data() + cursor,
+              patternMetadata.fixedPattern().data() + subPattern.start,
+              currentLength) != 0) {
+        return false;
+      }
+
+      cursor += currentLength;
+    }
+  }
+
+  return true;
+}
+
+// Match the input(from the position of start) with relaxed pattern forward.
+template <bool isAscii>
+bool matchRelaxedFixedForward(
+    StringView input,
+    const PatternMetadata& patternMetadata,
+    size_t start) {
+  if constexpr (isAscii) {
+    return matchRelaxedFixedForwardAscii(input, patternMetadata, start);
+  } else {
+    return matchRelaxedFixedForwardUnicode(input, patternMetadata, start);
+  }
+}
+
+// Match the input(from the position of start) with relaxed pattern backward.
+// Unlike matchRelaxedFixedForward which has different path for utf8 and
+// ascii, this function only has implementation for utf8 because only utf8
+// input use this function.
+bool matchRelaxedFixedBackwardUnicode(
+    StringView input,
+    const PatternMetadata& patternMetadata,
+    size_t start) {
+  // Compare the length first.
+  if ((start + 1) < patternMetadata.length()) {
+    return false;
+  }
+
+  const auto& subPatterns = patternMetadata.subPatterns();
+  auto cursor = start;
+  for (int32_t i = subPatterns.size() - 1; i >= 0; i--) {
+    if (cursor < 0) {
+      return false;
+    }
+
+    const auto subPattern = subPatterns[i];
+    if (subPattern.kind == SubPatternKind::kSingleCharWildcard) {
+      int32_t charsToSkip = subPattern.length;
+      while (charsToSkip > 0) {
+        if (cursor < 0) {
+          return false;
+        }
+
+        // We need to skip the number of 'first byte' -- skip one 'first byte'
+        // means skip one character.
+        if (utf8proc_char_first_byte(input.data() + cursor)) {
+          charsToSkip--;
+        }
+        cursor--;
+      }
+    } else {
+      const auto currentLength = subPattern.length;
+      const auto startIdx = cursor - (currentLength - 1);
+      if (startIdx < 0 ||
+          std::memcmp(
+              input.data() + startIdx,
+              patternMetadata.fixedPattern().data() + subPattern.start,
+              currentLength) != 0) {
+        return false;
+      }
+
+      cursor -= currentLength;
+    }
+  }
+
+  return true;
 }
 
 // Match the first 'length' characters of string 'input' and prefix pattern.
@@ -436,38 +643,67 @@ FOLLY_ALWAYS_INLINE static bool isAsciiArg(
 template <PatternKind P>
 class OptimizedLike final : public VectorFunction {
  public:
-  OptimizedLike(std::string pattern, size_t reducedPatternLength)
-      : pattern_{std::move(pattern)},
-        reducedPatternLength_{reducedPatternLength} {}
+  explicit OptimizedLike(const PatternMetadata& patternMetadata)
+      : patternMetadata_(std::move(patternMetadata)) {}
 
   template <bool isAscii>
   static bool match(
       const StringView& input,
-      const std::string& pattern,
-      size_t reducedPatternLength) {
-    switch (P) {
-      case PatternKind::kExactlyN:
-        if constexpr (isAscii) {
-          return input.size() == reducedPatternLength;
-        } else {
+      const PatternMetadata& patternMetadata) {
+    if constexpr (isAscii) {
+      switch (P) {
+        case PatternKind::kExactlyN:
+          return input.size() == patternMetadata.length();
+        case PatternKind::kAtLeastN:
+          return input.size() >= patternMetadata.length();
+        case PatternKind::kFixed:
+          return matchExactPattern(
+              input, patternMetadata.fixedPattern(), patternMetadata.length());
+        case PatternKind::kRelaxedFixed:
+          return matchRelaxedFixedForward<true>(input, patternMetadata, 0);
+        case PatternKind::kPrefix:
+          return matchPrefixPattern(
+              input, patternMetadata.fixedPattern(), patternMetadata.length());
+        case PatternKind::kRelaxedPrefix:
+          return matchRelaxedFixedForward<true>(input, patternMetadata, 0);
+        case PatternKind::kSuffix:
+          return matchSuffixPattern(
+              input, patternMetadata.fixedPattern(), patternMetadata.length());
+        case PatternKind::kRelaxedSuffix:
+          return matchRelaxedFixedForward<true>(
+              input, patternMetadata, input.size() - patternMetadata.length());
+        case PatternKind::kSubstring:
+          return matchSubstringPattern(input, patternMetadata.fixedPattern());
+      }
+    } else {
+      switch (P) {
+        case PatternKind::kExactlyN:
+          return stringImpl::cappedLength<false>(
+                     input, patternMetadata.length() + 1) ==
+              patternMetadata.length();
+        case PatternKind::kAtLeastN:
           return stringImpl::cappedLength<isAscii>(
-                     input, reducedPatternLength + 1) == reducedPatternLength;
-        }
-      case PatternKind::kAtLeastN:
-        if constexpr (isAscii) {
-          return input.size() >= reducedPatternLength;
-        } else {
-          return stringImpl::cappedLength<isAscii>(
-                     input, reducedPatternLength + 1) >= reducedPatternLength;
-        }
-      case PatternKind::kFixed:
-        return matchExactPattern(input, pattern, reducedPatternLength);
-      case PatternKind::kPrefix:
-        return matchPrefixPattern(input, pattern, reducedPatternLength);
-      case PatternKind::kSuffix:
-        return matchSuffixPattern(input, pattern, reducedPatternLength);
-      case PatternKind::kSubstring:
-        return matchSubstringPattern(input, pattern);
+                     input, patternMetadata.length() + 1) >=
+              patternMetadata.length();
+        case PatternKind::kFixed:
+          return matchExactPattern(
+              input, patternMetadata.fixedPattern(), patternMetadata.length());
+        case PatternKind::kRelaxedFixed:
+          return matchRelaxedFixedForward<false>(input, patternMetadata, 0);
+        case PatternKind::kPrefix:
+          return matchPrefixPattern(
+              input, patternMetadata.fixedPattern(), patternMetadata.length());
+        case PatternKind::kRelaxedPrefix:
+          return matchRelaxedFixedForward<false>(input, patternMetadata, 0);
+        case PatternKind::kSuffix:
+          return matchSuffixPattern(
+              input, patternMetadata.fixedPattern(), patternMetadata.length());
+        case PatternKind::kRelaxedSuffix:
+          return matchRelaxedFixedBackwardUnicode(
+              input, patternMetadata, input.size() - 1);
+        case PatternKind::kSubstring:
+          return matchSubstringPattern(input, patternMetadata.fixedPattern());
+      }
     }
   }
 
@@ -480,7 +716,10 @@ class OptimizedLike final : public VectorFunction {
     VELOX_CHECK(args.size() == 2 || args.size() == 3);
 
     constexpr bool isUtf8SensitivePattern =
-        (P == PatternKind::kExactlyN || P == PatternKind::kAtLeastN);
+        (P == PatternKind::kExactlyN || P == PatternKind::kAtLeastN ||
+         P == PatternKind::kRelaxedFixed || P == PatternKind::kRelaxedPrefix ||
+         P == PatternKind::kRelaxedSuffix);
+
     bool needsUtf8Processing =
         isUtf8SensitivePattern && !isAsciiArg(rows, args[0]);
     FlatVector<bool>& result = ensureWritableBool(rows, context, resultRef);
@@ -491,17 +730,11 @@ class OptimizedLike final : public VectorFunction {
       auto input = toSearch->data<StringView>();
       if (!needsUtf8Processing) {
         context.applyToSelectedNoThrow(rows, [&](vector_size_t i) {
-          result.set(
-              i,
-              match</*isAscii*/ true>(
-                  input[i], pattern_, reducedPatternLength_));
+          result.set(i, match</*isAscii*/ true>(input[i], patternMetadata_));
         });
       } else {
         context.applyToSelectedNoThrow(rows, [&](vector_size_t i) {
-          result.set(
-              i,
-              match</*isAscii*/ false>(
-                  input[i], pattern_, reducedPatternLength_));
+          result.set(i, match</*isAscii*/ false>(input[i], patternMetadata_));
         });
       }
       return;
@@ -509,13 +742,12 @@ class OptimizedLike final : public VectorFunction {
 
     if (toSearch->isConstantMapping()) {
       auto input = toSearch->valueAt<StringView>(0);
+
       bool matchResult;
       if (!needsUtf8Processing) {
-        matchResult =
-            match</*isAscii*/ true>(input, pattern_, reducedPatternLength_);
+        matchResult = match</*isAscii*/ true>(input, patternMetadata_);
       } else {
-        matchResult =
-            match</*isAscii*/ false>(input, pattern_, reducedPatternLength_);
+        matchResult = match</*isAscii*/ false>(input, patternMetadata_);
       }
       context.applyToSelectedNoThrow(
           rows, [&](vector_size_t i) { result.set(i, matchResult); });
@@ -529,8 +761,7 @@ class OptimizedLike final : public VectorFunction {
   }
 
  private:
-  const std::string pattern_;
-  const size_t reducedPatternLength_;
+  const PatternMetadata patternMetadata_;
 };
 
 // This function is used when pattern and escape are constants. And there is not
@@ -640,52 +871,50 @@ class LikeGeneric final : public VectorFunction {
                         const std::optional<char>& escapeChar) -> bool {
       PatternMetadata patternMetadata =
           determinePatternKind(std::string_view(pattern), escapeChar);
-      const auto reducedLength = patternMetadata.length;
-      const auto& fixedPattern = patternMetadata.fixedPattern;
 
       if (isAscii) {
-        switch (patternMetadata.patternKind) {
+        switch (patternMetadata.patternKind()) {
           case PatternKind::kExactlyN:
             return OptimizedLike<PatternKind::kExactlyN>::match<
-                /*isAscii*/ true>(input, pattern, reducedLength);
+                /*isAscii*/ true>(input, patternMetadata);
           case PatternKind::kAtLeastN:
             return OptimizedLike<PatternKind::kAtLeastN>::match<
-                /*isAscii*/ true>(input, pattern, reducedLength);
+                /*isAscii*/ true>(input, patternMetadata);
           case PatternKind::kFixed:
             return OptimizedLike<PatternKind::kFixed>::match</*isAscii*/ true>(
-                input, fixedPattern, reducedLength);
+                input, patternMetadata);
           case PatternKind::kPrefix:
             return OptimizedLike<PatternKind::kPrefix>::match</*isAscii*/ true>(
-                input, fixedPattern, reducedLength);
+                input, patternMetadata);
           case PatternKind::kSuffix:
             return OptimizedLike<PatternKind::kSuffix>::match</*isAscii*/ true>(
-                input, fixedPattern, reducedLength);
+                input, patternMetadata);
           case PatternKind::kSubstring:
             return OptimizedLike<PatternKind::kSubstring>::match<
-                /*isAscii*/ true>(input, fixedPattern, reducedLength);
+                /*isAscii*/ true>(input, patternMetadata);
           default:
             return applyWithRegex(input, pattern, escapeChar);
         }
       } else {
-        switch (patternMetadata.patternKind) {
+        switch (patternMetadata.patternKind()) {
           case PatternKind::kExactlyN:
             return OptimizedLike<PatternKind::kExactlyN>::match<
-                /*isAscii*/ false>(input, pattern, reducedLength);
+                /*isAscii*/ false>(input, patternMetadata);
           case PatternKind::kAtLeastN:
             return OptimizedLike<PatternKind::kAtLeastN>::match<
-                /*isAscii*/ false>(input, pattern, reducedLength);
+                /*isAscii*/ false>(input, patternMetadata);
           case PatternKind::kFixed:
             return OptimizedLike<PatternKind::kFixed>::match</*isAscii*/ false>(
-                input, fixedPattern, reducedLength);
+                input, patternMetadata);
           case PatternKind::kPrefix:
             return OptimizedLike<PatternKind::kPrefix>::match<
-                /*isAscii*/ false>(input, fixedPattern, reducedLength);
+                /*isAscii*/ false>(input, patternMetadata);
           case PatternKind::kSuffix:
             return OptimizedLike<PatternKind::kSuffix>::match<
-                /*isAscii*/ false>(input, fixedPattern, reducedLength);
+                /*isAscii*/ false>(input, patternMetadata);
           case PatternKind::kSubstring:
             return OptimizedLike<PatternKind::kSubstring>::match<
-                /*isAscii*/ false>(input, fixedPattern, reducedLength);
+                /*isAscii*/ false>(input, patternMetadata);
           default:
             return applyWithRegex(input, pattern, escapeChar);
         }
@@ -1040,55 +1269,73 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> re2ExtractSignatures() {
   };
 }
 
-std::string unescape(
-    std::string_view pattern,
-    size_t start,
-    size_t end,
-    std::optional<char> escapeChar) {
-  if (!escapeChar) {
-    return std::string(pattern.data() + start, end - start);
-  }
-
-  std::ostringstream os;
-  auto cursor = pattern.begin() + start;
-  auto endCursor = pattern.begin() + end;
-  while (cursor < endCursor) {
-    auto previous = cursor;
-
-    // Find the next escape char.
-    cursor = std::find(cursor, endCursor, escapeChar.value());
-    if (cursor < endCursor) {
-      // There are non-escape chars, append them.
-      if (previous < cursor) {
-        os.write(previous, cursor - previous);
-      }
-
-      // Make sure there is a following normal char.
-      VELOX_USER_CHECK(
-          cursor + 1 < endCursor,
-          "Escape character must be followed by '%', '_' or the escape character itself");
-
-      // Make sure the escaped char is valid.
-      cursor++;
-      auto current = *cursor;
-      VELOX_USER_CHECK(
-          current == escapeChar || current == '_' || current == '%',
-          "Escape character must be followed by '%', '_' or the escape character itself");
-
-      // Append the escaped char.
-      os << current;
-    } else {
-      // Escape char not found, append all the non-escape chars.
-      os.write(previous, endCursor - previous);
-      break;
-    }
-
-    // Advance the cursor.
-    cursor++;
-  }
-
-  return os.str();
+PatternMetadata PatternMetadata::generic() {
+  return {PatternKind::kGeneric, 0, "", {}};
 }
+
+PatternMetadata PatternMetadata::atLeastN(size_t length) {
+  return {PatternKind::kAtLeastN, length, "", {}};
+}
+
+PatternMetadata PatternMetadata::exactlyN(size_t length) {
+  return {PatternKind::kExactlyN, length, "", {}};
+}
+
+PatternMetadata PatternMetadata::fixed(const std::string& fixedPattern) {
+  return {PatternKind::kFixed, fixedPattern.length(), fixedPattern, {}};
+}
+
+PatternMetadata PatternMetadata::relaxedFixed(
+    const std::string& fixedPattern,
+    const std::vector<SubPatternMetadata>& subPatterns) {
+  return {
+      PatternKind::kRelaxedFixed,
+      fixedPattern.length(),
+      fixedPattern,
+      std::move(subPatterns)};
+}
+
+PatternMetadata PatternMetadata::prefix(const std::string& fixedPattern) {
+  return {PatternKind::kPrefix, fixedPattern.length(), fixedPattern, {}};
+}
+
+PatternMetadata PatternMetadata::relaxedPrefix(
+    const std::string& fixedPattern,
+    const std::vector<SubPatternMetadata>& subPatterns) {
+  return {
+      PatternKind::kRelaxedPrefix,
+      fixedPattern.length(),
+      fixedPattern,
+      std::move(subPatterns)};
+}
+
+PatternMetadata PatternMetadata::suffix(const std::string& fixedPattern) {
+  return {PatternKind::kSuffix, fixedPattern.length(), fixedPattern, {}};
+}
+
+PatternMetadata PatternMetadata::relaxedSuffix(
+    const std::string& fixedPattern,
+    const std::vector<SubPatternMetadata>& subPatterns) {
+  return {
+      PatternKind::kRelaxedSuffix,
+      fixedPattern.length(),
+      fixedPattern,
+      std::move(subPatterns)};
+}
+
+PatternMetadata PatternMetadata::substring(const std::string& fixedPattern) {
+  return {PatternKind::kSubstring, fixedPattern.length(), fixedPattern, {}};
+}
+
+PatternMetadata::PatternMetadata(
+    PatternKind patternKind,
+    size_t length,
+    std::string fixedPattern,
+    std::vector<SubPatternMetadata> subPatterns)
+    : patternKind_{patternKind},
+      length_{length},
+      fixedPattern_(fixedPattern),
+      subPatterns_(subPatterns) {}
 
 // Iterates through a pattern string. Transparently handles escape sequences.
 class PatternStringIterator {
@@ -1105,10 +1352,6 @@ class PatternStringIterator {
     if (nextStart_ == pattern_.size()) {
       return false;
     }
-
-    isPreviousWildcard_ =
-        (charKind_ == CharKind::kSingleCharWildcard ||
-         charKind_ == CharKind::kAnyCharsWildcard);
 
     currentStart_ = nextStart_;
     auto currentChar = charAt(currentStart_);
@@ -1137,20 +1380,36 @@ class PatternStringIterator {
     } else {
       if (currentChar == '_') {
         charKind_ = CharKind::kSingleCharWildcard;
+        nextStart_ = currentStart_ + 1;
       } else if (currentChar == '%') {
         charKind_ = CharKind::kAnyCharsWildcard;
+        nextStart_ = currentStart_ + 1;
       } else {
         charKind_ = CharKind::kNormal;
+
+        // Unicode.
+        if (currentChar & 0x80) {
+          auto numBytes = unicodeCharLength(pattern_.data() + currentStart_);
+          nextStart_ = currentStart_ + numBytes;
+        } else {
+          nextStart_ = currentStart_ + 1;
+        }
       }
-      nextStart_ = currentStart_ + 1;
     }
 
     return true;
   }
 
-  // Start index of the current character.
-  size_t currentStart() const {
-    return currentStart_;
+  // Char at current cursor, since it can be a multibyte character, here we use
+  // a string_view to represent.
+  std::string_view current() const {
+    // Escaped.
+    if (charAt(currentStart_) == escapeChar_) {
+      return std::string_view(pattern_.data() + currentStart_ + 1, 1);
+    } else {
+      return std::string_view(
+          pattern_.data() + currentStart_, nextStart_ - currentStart_);
+    }
   }
 
   bool isAnyCharsWildcard() const {
@@ -1159,14 +1418,6 @@ class PatternStringIterator {
 
   bool isSingleCharWildcard() const {
     return charKind_ == CharKind::kSingleCharWildcard;
-  }
-
-  bool isWildcard() {
-    return isAnyCharsWildcard() || isSingleCharWildcard();
-  }
-
-  bool isPreviousWildcard() {
-    return isPreviousWildcard_;
   }
 
  private:
@@ -1193,120 +1444,242 @@ class PatternStringIterator {
   std::string_view pattern_;
   const std::optional<char> escapeChar_;
 
+  // Index of current char(including the escape char if there is).
   size_t currentStart_{0};
+  // Index of next char.
   size_t nextStart_{0};
   CharKind charKind_{CharKind::kNormal};
-  bool isPreviousWildcard_{false};
 };
 
-PatternMetadata determinePatternKind(
+// Is the specified sub-patterns an optimization candidate?
+// Return true if it *might* be optimized, return false if it is not
+// optimize-able.
+bool isOptimizedLikeCandidate(
+    const std::array<SubPatternStats, 3>& stats,
+    int numSubPatterns,
+    SubPatternKind firstPatternKind,
+    SubPatternKind lastPatternKind) {
+  if (stats[kLiteralString].count == 0) {
+    return true;
+  }
+
+  // More than 2 '%' , no fast path for it.
+  if (stats[kAnyCharsWildcard].count > 2) {
+    return false;
+  }
+
+  // Only 2 '%', but the '%' is not at the beginning and end of the pattern, no
+  // fast path for it.
+  if (stats[kAnyCharsWildcard].count == 2 &&
+      (firstPatternKind != SubPatternKind::kAnyCharsWildcard ||
+       lastPatternKind != SubPatternKind::kAnyCharsWildcard)) {
+    return false;
+  }
+
+  // Only one '%', but it is not the first/last pattern, no fast path for it.
+  if (stats[kAnyCharsWildcard].count == 1 &&
+      (stats[kAnyCharsWildcard].firstIndex > 0 &&
+       stats[kAnyCharsWildcard].firstIndex < numSubPatterns - 1)) {
+    return false;
+  }
+
+  return true;
+}
+
+// Parse the pattern into sub-patterns.
+std::optional<std::string> parsePattern(
     std::string_view pattern,
-    std::optional<char> escapeChar) {
-  const size_t patternLength = pattern.size();
-
-  // Index of the first % or _ character(not escaped).
-  int32_t wildcardStart = -1;
-  // Index of the first character that is not % and not _.
-  int32_t fixedPatternStart = -1;
-  // Index of the last character in the fixed pattern, used to retrieve the
-  // fixed string for patterns of type kSubstring.
-  int32_t fixedPatternEnd = -1;
-  // Count of wildcard character sequences in pattern.
-  size_t numWildcardSequences = 0;
-  // Total number of % characters.
-  size_t anyCharacterWildcardCount = 0;
-  // Total number of _ characters.
-  size_t singleCharacterWildcardCount = 0;
-
+    std::optional<char> escapeChar,
+    std::vector<SubPatternKind>& subPatternKinds,
+    std::vector<std::pair<size_t, size_t>>& subPatternRanges) {
   PatternStringIterator iterator{pattern, escapeChar};
 
   // Iterate through the pattern string to collect the stats for the simple
   // patterns that we can optimize.
+  std::ostringstream os;
+  SubPatternKind previousKind;
+  size_t currentSubPatternStart = 0;
+  size_t cursor = 0;
+
+  int32_t firstAnyCharsPatternIndex = -1;
   while (iterator.next()) {
-    const size_t currentStart = iterator.currentStart();
-    if (iterator.isWildcard()) {
-      if (wildcardStart == -1) {
-        wildcardStart = currentStart;
-      }
-
-      if (iterator.isSingleCharWildcard()) {
-        ++singleCharacterWildcardCount;
-      } else {
-        ++anyCharacterWildcardCount;
-      }
-
-      if (!iterator.isPreviousWildcard()) {
-        ++numWildcardSequences;
-      }
-
-      // Mark the end of the fixed pattern.
-      if (fixedPatternStart != -1 && fixedPatternEnd == -1) {
-        fixedPatternEnd = currentStart - 1;
-      }
+    SubPatternKind currentKind;
+    if (iterator.isSingleCharWildcard()) {
+      currentKind = SubPatternKind::kSingleCharWildcard;
+    } else if (iterator.isAnyCharsWildcard()) {
+      currentKind = SubPatternKind::kAnyCharsWildcard;
     } else {
-      // Record the first fixed pattern start.
-      if (fixedPatternStart == -1) {
-        fixedPatternStart = currentStart;
-      } else {
-        // This is not the first fixed pattern, not supported, so fallback.
-        if (iterator.isPreviousWildcard()) {
-          return PatternMetadata{PatternKind::kGeneric, 0};
+      currentKind = SubPatternKind::kLiteralString;
+    }
+
+    // New sub pattern occurs.
+    if (currentKind != previousKind && cursor > 0) {
+      subPatternKinds.push_back(previousKind);
+      subPatternRanges.push_back(
+          {currentSubPatternStart, cursor - currentSubPatternStart});
+      currentSubPatternStart = cursor;
+    }
+
+    // Advance the cursor.
+    std::string_view currentChar = iterator.current();
+    cursor += currentChar.size();
+    previousKind = currentKind;
+
+    // We only need to collect the unescaped chars if user specified escape
+    // char.
+    if (escapeChar.has_value()) {
+      os << iterator.current();
+    }
+  }
+
+  // Handle the last sub-pattern.
+  subPatternKinds.push_back(previousKind);
+  subPatternRanges.push_back(
+      {currentSubPatternStart, cursor - currentSubPatternStart});
+
+  return escapeChar.has_value() ? std::make_optional(os.str()) : std::nullopt;
+}
+
+PatternMetadata determinePatternKind(
+    std::string_view pattern,
+    std::optional<char> escapeChar) {
+  if (FOLLY_UNLIKELY(pattern.empty())) {
+    return PatternMetadata::fixed("");
+  }
+
+  // Parse the pattern into sub-patterns.
+  std::vector<SubPatternKind> subPatternKinds;
+  std::vector<std::pair<size_t, size_t>> subPatternRanges;
+
+  std::optional<std::string> parsedPattern =
+      parsePattern(pattern, escapeChar, subPatternKinds, subPatternRanges);
+  std::string_view unescapedPattern =
+      escapeChar.has_value() ? parsedPattern.value() : pattern;
+
+  const auto numSubPatterns = subPatternKinds.size();
+  std::array<SubPatternStats, 3> stats = {
+      SubPatternStats{kSingleCharWildcard},
+      SubPatternStats{kAnyCharsWildcard},
+      SubPatternStats{kLiteralString}};
+
+  // Collect the sub-pattern stats.
+  for (auto i = 0; i < numSubPatterns; i++) {
+    stats[subPatternKinds[i]].update(i);
+  }
+
+  // Determine optimized pattern base on stats we have.
+  const auto firstSubPatternKind = subPatternKinds[0];
+  const auto firstSubPatternLength = subPatternRanges[0].second;
+
+  const auto lastSubPatternKind = subPatternKinds[numSubPatterns - 1];
+  const auto lastSubPatternStart = subPatternRanges[numSubPatterns - 1].first;
+  const auto lastSubPatternLength = subPatternRanges[numSubPatterns - 1].second;
+
+  // Fail fast if we have no fast path for it.
+  if (!isOptimizedLikeCandidate(
+          stats, numSubPatterns, firstSubPatternKind, lastSubPatternKind)) {
+    return PatternMetadata::generic();
+  }
+
+  // Single sub-pattern.
+  if (numSubPatterns == 1) {
+    if (firstSubPatternKind == SubPatternKind::kSingleCharWildcard) {
+      return PatternMetadata::exactlyN(firstSubPatternLength);
+    } else if (firstSubPatternKind == SubPatternKind::kAnyCharsWildcard) {
+      return PatternMetadata::atLeastN(0);
+    }
+
+    return PatternMetadata::fixed(std::string(unescapedPattern));
+  } else { // Multiple sub-patterns.
+    // No kLiteralString sub-pattern.
+    if (stats[kLiteralString].count == 0) {
+      const auto singleCharacterWildcardCount =
+          fixedLength(subPatternKinds, subPatternRanges);
+      return PatternMetadata::atLeastN(singleCharacterWildcardCount);
+    } else {
+      // At this point, the pattern contains at least one kLiteralString
+      // sub-pattern.
+
+      // If there are only one literal sub-pattern and several any-wildcard
+      // sub-patterns.
+      if (stats[kSingleCharWildcard].count == 0 &&
+          stats[kLiteralString].count == 1 &&
+          stats[kAnyCharsWildcard].count > 0) {
+        if (firstSubPatternKind == SubPatternKind::kLiteralString) {
+          return PatternMetadata::prefix(
+              std::string(unescapedPattern, 0, firstSubPatternLength));
+        } else if (lastSubPatternKind == SubPatternKind::kLiteralString) {
+          return PatternMetadata::suffix(std::string(
+              unescapedPattern, lastSubPatternStart, lastSubPatternLength));
+        } else if (
+            numSubPatterns == 3 &&
+            firstSubPatternKind == SubPatternKind::kAnyCharsWildcard &&
+            lastSubPatternKind == SubPatternKind::kAnyCharsWildcard) {
+          return PatternMetadata::substring(std::string(
+              unescapedPattern,
+              subPatternRanges[1].first,
+              subPatternRanges[1].second));
+        }
+      }
+
+      // No any-wildcard sub-pattern.
+      if (stats[kAnyCharsWildcard].count == 0 &&
+          stats[kSingleCharWildcard].count > 0) {
+        std::vector<SubPatternMetadata> subPatterns;
+        buildFixedSubPatterns(
+            subPatternKinds, subPatternRanges, 0, numSubPatterns, subPatterns);
+        return PatternMetadata::relaxedFixed(
+            std::string(unescapedPattern), std::move(subPatterns));
+      }
+
+      // Pattern contains kAnyCharsWildcard, kSingleCharWildcard &
+      // kLiteralString.
+      if (stats[kSingleCharWildcard].count > 0 &&
+          stats[kAnyCharsWildcard].count > 0) {
+        const auto firstOfLiteralOrSingleWildcard = std::min(
+            stats[kLiteralString].firstIndex.value(),
+            stats[kSingleCharWildcard].firstIndex.value());
+        const auto lastOfLiteralOrSingleWildcard = std::max(
+            stats[kLiteralString].lastIndex.value(),
+            stats[kSingleCharWildcard].lastIndex.value());
+
+        if (lastOfLiteralOrSingleWildcard <
+            stats[kAnyCharsWildcard].firstIndex) {
+          std::vector<SubPatternMetadata> subPatterns;
+          size_t fixedLength = buildFixedSubPatterns(
+              subPatternKinds,
+              subPatternRanges,
+              firstOfLiteralOrSingleWildcard,
+              lastOfLiteralOrSingleWildcard + 1,
+              subPatterns);
+          return PatternMetadata::relaxedPrefix(
+              std::string(
+                  unescapedPattern,
+                  subPatternRanges[firstOfLiteralOrSingleWildcard].first,
+                  fixedLength),
+              std::move(subPatterns));
+        } else if (
+            firstOfLiteralOrSingleWildcard >
+            stats[kAnyCharsWildcard].lastIndex) {
+          std::vector<SubPatternMetadata> subPatterns;
+          const auto fixedLength = buildFixedSubPatterns(
+              subPatternKinds,
+              subPatternRanges,
+              firstOfLiteralOrSingleWildcard,
+              lastOfLiteralOrSingleWildcard + 1,
+              subPatterns);
+          return PatternMetadata::relaxedSuffix(
+              std::string(
+                  unescapedPattern,
+                  subPatternRanges[firstOfLiteralOrSingleWildcard].first,
+                  fixedLength),
+              std::move(subPatterns));
         }
       }
     }
   }
 
-  // The pattern end may not been marked if there is no wildcard char after
-  // pattern start, so we mark it here.
-  if (fixedPatternStart != -1 && fixedPatternEnd == -1) {
-    fixedPatternEnd = patternLength - 1;
-  }
-
-  // At this point pattern has max of one fixed pattern.
-  // Pattern contains wildcard characters only.
-  if (fixedPatternStart == -1) {
-    if (anyCharacterWildcardCount == 0) {
-      return PatternMetadata{
-          PatternKind::kExactlyN, singleCharacterWildcardCount};
-    }
-    return PatternMetadata{
-        PatternKind::kAtLeastN, singleCharacterWildcardCount};
-  }
-
-  // At this point pattern contains exactly one fixed pattern.
-  // Pattern contains no wildcard characters (is a fixed pattern).
-  if (wildcardStart == -1) {
-    auto fixedPattern = unescape(pattern, 0, patternLength, escapeChar);
-    return PatternMetadata{
-        PatternKind::kFixed, fixedPattern.size(), fixedPattern};
-  }
-
-  // Pattern is generic if it has '_' wildcard characters and a fixed pattern.
-  if (singleCharacterWildcardCount > 0) {
-    return PatternMetadata{PatternKind::kGeneric, 0};
-  }
-
-  // Classify pattern as prefix, fixed center, or suffix pattern based on the
-  // position and count of the wildcard character sequence and fixed pattern.
-  if (fixedPatternStart < wildcardStart) {
-    auto fixedPattern = unescape(pattern, 0, wildcardStart, escapeChar);
-    return PatternMetadata{
-        PatternKind::kPrefix, fixedPattern.size(), fixedPattern};
-  }
-
-  // if numWildcardSequences > 1, then fixed pattern must be in between them.
-  if (numWildcardSequences == 2) {
-    auto fixedPattern =
-        unescape(pattern, fixedPatternStart, fixedPatternEnd + 1, escapeChar);
-    return PatternMetadata{
-        PatternKind::kSubstring, fixedPattern.size(), fixedPattern};
-  }
-
-  auto fixedPattern =
-      unescape(pattern, fixedPatternStart, patternLength, escapeChar);
-
-  return PatternMetadata{
-      PatternKind::kSuffix, fixedPattern.size(), fixedPattern};
+  return PatternMetadata::generic();
 }
 
 std::shared_ptr<exec::VectorFunction> makeLike(
@@ -1327,6 +1700,10 @@ std::shared_ptr<exec::VectorFunction> makeLike(
       return std::make_shared<exec::ApplyNeverCalled>();
     }
 
+    // TODO(xumingming) Presto actually support multi-byte escape char(see [1]),
+    // we should support too.
+    //
+    // [1].https://github.com/facebookincubator/velox/issues/8363
     try {
       VELOX_USER_CHECK_EQ(
           constantEscape->valueAt(0).size(),
@@ -1349,7 +1726,7 @@ std::shared_ptr<exec::VectorFunction> makeLike(
   }
   auto pattern = constantPattern->as<ConstantVector<StringView>>()->valueAt(0);
 
-  PatternMetadata patternMetadata;
+  PatternMetadata patternMetadata = PatternMetadata::generic();
   try {
     patternMetadata =
         determinePatternKind(std::string_view(pattern), escapeChar);
@@ -1358,28 +1735,34 @@ std::shared_ptr<exec::VectorFunction> makeLike(
         std::current_exception());
   }
 
-  size_t reducedLength = patternMetadata.length;
-  auto fixedPattern = patternMetadata.fixedPattern;
-
-  switch (patternMetadata.patternKind) {
+  switch (patternMetadata.patternKind()) {
     case PatternKind::kExactlyN:
       return std::make_shared<OptimizedLike<PatternKind::kExactlyN>>(
-          pattern, reducedLength);
+          patternMetadata);
     case PatternKind::kAtLeastN:
       return std::make_shared<OptimizedLike<PatternKind::kAtLeastN>>(
-          pattern, reducedLength);
+          patternMetadata);
     case PatternKind::kFixed:
       return std::make_shared<OptimizedLike<PatternKind::kFixed>>(
-          fixedPattern, reducedLength);
+          patternMetadata);
+    case PatternKind::kRelaxedFixed:
+      return std::make_shared<OptimizedLike<PatternKind::kRelaxedFixed>>(
+          patternMetadata);
     case PatternKind::kPrefix:
       return std::make_shared<OptimizedLike<PatternKind::kPrefix>>(
-          fixedPattern, reducedLength);
+          patternMetadata);
+    case PatternKind::kRelaxedPrefix:
+      return std::make_shared<OptimizedLike<PatternKind::kRelaxedPrefix>>(
+          patternMetadata);
     case PatternKind::kSuffix:
       return std::make_shared<OptimizedLike<PatternKind::kSuffix>>(
-          fixedPattern, reducedLength);
+          patternMetadata);
+    case PatternKind::kRelaxedSuffix:
+      return std::make_shared<OptimizedLike<PatternKind::kRelaxedSuffix>>(
+          patternMetadata);
     case PatternKind::kSubstring:
       return std::make_shared<OptimizedLike<PatternKind::kSubstring>>(
-          fixedPattern, reducedLength);
+          patternMetadata);
     default:
       return std::make_shared<LikeWithRe2>(pattern, escapeChar);
   }

--- a/velox/functions/lib/Re2Functions.h
+++ b/velox/functions/lib/Re2Functions.h
@@ -30,15 +30,24 @@ namespace facebook::velox::functions {
 enum class PatternKind {
   /// Pattern containing wildcard character '_' only, such as _, __, ____.
   kExactlyN,
-  /// Pattern containing wildcard characters ('_' or '%') only with atleast one
+  /// Pattern containing wildcard characters ('_' or '%') only with at least one
   /// '%', such as ___%, _%__.
   kAtLeastN,
   /// Pattern with no wildcard characters, such as 'presto', 'foo'.
   kFixed,
+  /// Pattern with single wildcard chars(_) & normal chars, such as
+  /// '_pr_es_to_'.
+  kRelaxedFixed,
   /// Fixed pattern followed by one or more '%', such as 'hello%', 'foo%%%%'.
   kPrefix,
+  /// kRelaxedFixed pattern followed by one or more '%', such as '_pr_es_to_%',
+  /// '_pr_es_to_%%%%'.
+  kRelaxedPrefix,
   /// Fixed pattern preceded by one or more '%', such as '%foo', '%%%hello'.
   kSuffix,
+  /// kRelaxedFixed preceded by one or more '%', such as '%_pr_es_to_',
+  /// '%%%_pr_es_to_'.
+  kRelaxedSuffix,
   /// Patterns matching '%{c0}%', such as '%foo%%', '%%%hello%'.
   kSubstring,
   /// Patterns which do not fit any of the above types, such as 'hello_world',
@@ -46,17 +55,93 @@ enum class PatternKind {
   kGeneric,
 };
 
-struct PatternMetadata {
-  PatternKind patternKind;
-  // Contains the length of the unescaped fixed pattern for patterns of kind
-  // kFixed, kPrefix, kSuffix and kSubstring. Contains the count of wildcard
-  // character '_' for patterns of kind kExactlyN and kAtLeastN. Contains 0
-  // otherwise.
-  size_t length;
-  // Contains the unescaped fixed pattern in patterns of kind kFixed, kPrefix,
-  // kSuffix and kSubstring.
-  std::string fixedPattern = "";
+// Kind of sub-pattern.
+enum SubPatternKind {
+  /// e.g. '___'.
+  kSingleCharWildcard = 0,
+  // e.g. '%%'.
+  kAnyCharsWildcard = 1,
+  // e.g. 'abc'.
+  kLiteralString = 2
 };
+
+struct SubPatternMetadata {
+  SubPatternKind kind;
+  // The index of current pattern in terms of 'bytes'.
+  size_t start;
+  // Length in terms of bytes.
+  size_t length;
+};
+
+class PatternMetadata {
+ public:
+  static PatternMetadata generic();
+
+  static PatternMetadata atLeastN(size_t length);
+
+  static PatternMetadata exactlyN(size_t length);
+
+  static PatternMetadata fixed(const std::string& fixedPattern);
+
+  static PatternMetadata relaxedFixed(
+      const std::string& fixedPattern,
+      const std::vector<SubPatternMetadata>& subPatterns);
+
+  static PatternMetadata prefix(const std::string& fixedPattern);
+
+  static PatternMetadata relaxedPrefix(
+      const std::string& fixedPattern,
+      const std::vector<SubPatternMetadata>& subPatterns);
+
+  static PatternMetadata suffix(const std::string& fixedPattern);
+
+  static PatternMetadata relaxedSuffix(
+      const std::string& fixedPattern,
+      const std::vector<SubPatternMetadata>& subPatterns);
+
+  static PatternMetadata substring(const std::string& fixedPattern);
+
+  const PatternKind patternKind() const {
+    return patternKind_;
+  }
+
+  const size_t length() const {
+    return length_;
+  }
+
+  const std::vector<SubPatternMetadata>& subPatterns() const {
+    return subPatterns_;
+  }
+
+  const std::string& fixedPattern() const {
+    return fixedPattern_;
+  }
+
+ private:
+  PatternMetadata(
+      PatternKind patternKind,
+      size_t length,
+      std::string fixedPattern,
+      std::vector<SubPatternMetadata> subPatterns);
+
+  PatternKind patternKind_;
+
+  /// Contains the length of the unescaped fixed pattern for patterns of kind
+  /// k[Relaxed]Fixed, k[Relaxed]Prefix, k[Relaxed]Suffix and
+  /// k[Relaxed]Substring. Contains the count of wildcard character '_' for
+  /// patterns of kind kExactlyN and kAtLeastN. Contains 0 otherwise.
+  size_t length_;
+
+  /// Contains the fixed pattern in patterns of kind k[Relaxed]Fixed,
+  /// k[Relaxed]Prefix, k[Relaxed]Suffix and k[Relaxed]Substring.
+  std::string fixedPattern_;
+
+  /// Contains the literal/single char wildcard sub patterns, it is only
+  /// used for kRelaxedXxx patterns. e.g. If the pattern is: _pr_sto%, we will
+  /// have four sub-patterns here: _, pr, _ and sto.
+  std::vector<SubPatternMetadata> subPatterns_;
+};
+
 inline const int kMaxCompiledRegexes = 20;
 
 /// The functions in this file use RE2 as the regex engine. RE2 is fast, but

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -467,20 +467,30 @@ TEST_F(Re2FunctionsTest, likeDeterminePatternKind) {
       [&](std::string_view pattern, PatternKind patternKind, size_t length) {
         PatternMetadata patternMetadata =
             determinePatternKind(pattern, std::nullopt);
-        EXPECT_EQ(patternMetadata.patternKind, patternKind);
-        EXPECT_EQ(patternMetadata.length, length);
+
+        SCOPED_TRACE(fmt::format(
+            "pattern: '{}', length: {}, actualLength: {}",
+            pattern,
+            length,
+            patternMetadata.length()));
+        EXPECT_EQ(patternMetadata.patternKind(), patternKind);
+        EXPECT_EQ(patternMetadata.length(), length);
       };
 
   auto testPatternString = [&](std::string_view pattern,
                                PatternKind patternKind,
                                std::string_view fixedPattern) {
+    SCOPED_TRACE(fmt::format(
+        "pattern: '{}', fixedPattern: '{}'", pattern, fixedPattern));
+
     PatternMetadata patternMetadata =
         determinePatternKind(pattern, std::nullopt);
-    EXPECT_EQ(patternMetadata.patternKind, patternKind);
-    EXPECT_EQ(patternMetadata.length, fixedPattern.size());
-    EXPECT_EQ(patternMetadata.fixedPattern, fixedPattern);
+    EXPECT_EQ(patternMetadata.patternKind(), patternKind);
+    EXPECT_EQ(patternMetadata.length(), fixedPattern.size());
+    EXPECT_EQ(patternMetadata.fixedPattern(), fixedPattern);
   };
 
+  testPattern("", PatternKind::kFixed, 0);
   testPattern("_", PatternKind::kExactlyN, 1);
   testPattern("____", PatternKind::kExactlyN, 4);
   testPattern("%", PatternKind::kAtLeastN, 0);
@@ -496,17 +506,38 @@ TEST_F(Re2FunctionsTest, likeDeterminePatternKind) {
       "helloPrestoWorld", PatternKind::kFixed, "helloPrestoWorld");
   testPatternString("aBcD", PatternKind::kFixed, "aBcD");
 
+  testPatternString("_pr_es_to_", PatternKind::kRelaxedFixed, "_pr_es_to_");
+  testPatternString("_presto", PatternKind::kRelaxedFixed, "_presto");
+  testPatternString("presto_", PatternKind::kRelaxedFixed, "presto_");
+  testPatternString("_a", PatternKind::kRelaxedFixed, "_a");
+  testPatternString("a_", PatternKind::kRelaxedFixed, "a_");
+  testPatternString("_a_", PatternKind::kRelaxedFixed, "_a_");
+
   testPattern("presto%", PatternKind::kPrefix, 6);
   testPattern("hello%%", PatternKind::kPrefix, 5);
   testPattern("a%", PatternKind::kPrefix, 1);
   testPattern("helloPrestoWorld%%%", PatternKind::kPrefix, 16);
   testPattern("aBcD%", PatternKind::kPrefix, 4);
 
+  testPatternString("_pr_es_to_%", PatternKind::kRelaxedPrefix, "_pr_es_to_");
+  testPatternString("_presto%", PatternKind::kRelaxedPrefix, "_presto");
+  testPatternString("presto_%%", PatternKind::kRelaxedPrefix, "presto_");
+  testPatternString("_a%", PatternKind::kRelaxedPrefix, "_a");
+  testPatternString("a_%%", PatternKind::kRelaxedPrefix, "a_");
+  testPatternString("_a_%", PatternKind::kRelaxedPrefix, "_a_");
+
   testPattern("%presto", PatternKind::kSuffix, 6);
   testPattern("%%hello", PatternKind::kSuffix, 5);
   testPattern("%a", PatternKind::kSuffix, 1);
   testPattern("%%%helloPrestoWorld", PatternKind::kSuffix, 16);
   testPattern("%aBcD", PatternKind::kSuffix, 4);
+
+  testPatternString("%_pr_es_to_", PatternKind::kRelaxedSuffix, "_pr_es_to_");
+  testPatternString("%_presto", PatternKind::kRelaxedSuffix, "_presto");
+  testPatternString("%%presto_", PatternKind::kRelaxedSuffix, "presto_");
+  testPatternString("%_a", PatternKind::kRelaxedSuffix, "_a");
+  testPatternString("%%a_", PatternKind::kRelaxedSuffix, "a_");
+  testPatternString("%_a_", PatternKind::kRelaxedSuffix, "_a_");
 
   testPatternString("%presto%%", PatternKind::kSubstring, "presto");
   testPatternString("%%hello%", PatternKind::kSubstring, "hello");
@@ -516,15 +547,34 @@ TEST_F(Re2FunctionsTest, likeDeterminePatternKind) {
 
   testPattern("_b%%__", PatternKind::kGeneric, 0);
   testPattern("%_%p", PatternKind::kGeneric, 0);
-  testPattern("aBcD_", PatternKind::kGeneric, 0);
-  testPattern("%aBc_D%", PatternKind::kGeneric, 0);
   testPattern("aBcD%%e%", PatternKind::kGeneric, 0);
-  testPattern("aBc_D%%", PatternKind::kGeneric, 0);
   testPattern("%%_%aBcD", PatternKind::kGeneric, 0);
   testPattern("%%a%%BcD", PatternKind::kGeneric, 0);
   testPattern("%%aBcD%_%", PatternKind::kGeneric, 0);
+  testPattern("aBcD%_%", PatternKind::kGeneric, 0);
   testPattern("foo%bar", PatternKind::kGeneric, 0);
-  testPattern("_aBcD", PatternKind::kGeneric, 0);
+
+  // Test for pattern with unicode.
+  testPattern("_b%%__", PatternKind::kGeneric, 0);
+}
+
+TEST_F(Re2FunctionsTest, likeDeterminePatternKindUnicode) {
+  auto testPattern = [&](std::string_view pattern,
+                         PatternKind patternKind,
+                         std::string_view fixedPattern) {
+    PatternMetadata patternMetadata = determinePatternKind(pattern, '\\');
+    EXPECT_EQ(patternMetadata.patternKind(), patternKind);
+    EXPECT_EQ(patternMetadata.length(), fixedPattern.size());
+    EXPECT_EQ(patternMetadata.fixedPattern(), fixedPattern);
+  };
+
+  // '你好' is 'hello' in Chinese, '世界' is 'world' in Chinese.
+  testPattern("你好%", PatternKind::kPrefix, "你好");
+  testPattern("a你好%", PatternKind::kPrefix, "a你好");
+  testPattern("你好a%", PatternKind::kPrefix, "你好a");
+  testPattern("%%你好", PatternKind::kSuffix, "你好");
+  testPattern("%%你好%", PatternKind::kSubstring, "你好");
+  testPattern("%%你好%世界", PatternKind::kGeneric, "");
 }
 
 TEST_F(Re2FunctionsTest, likeDeterminePatternKindWithEscapeChar) {
@@ -532,25 +582,33 @@ TEST_F(Re2FunctionsTest, likeDeterminePatternKindWithEscapeChar) {
                          PatternKind patternKind,
                          std::string_view fixedPattern) {
     PatternMetadata patternMetadata = determinePatternKind(pattern, '\\');
-    EXPECT_EQ(patternMetadata.patternKind, patternKind);
-    EXPECT_EQ(patternMetadata.length, fixedPattern.size());
-    EXPECT_EQ(patternMetadata.fixedPattern, fixedPattern);
+    EXPECT_EQ(patternMetadata.patternKind(), patternKind);
+    EXPECT_EQ(patternMetadata.length(), fixedPattern.size());
+    EXPECT_EQ(patternMetadata.fixedPattern(), fixedPattern);
   };
 
   testPattern(R"(\_)", PatternKind::kFixed, "_");
   testPattern(R"(\_\_\_\_)", PatternKind::kFixed, "____");
   testPattern(R"(a\_\_b\_\_c)", PatternKind::kFixed, "a__b__c");
 
+  testPattern(R"(_a\_\_b_\_\_c_)", PatternKind::kRelaxedFixed, "_a__b___c_");
+
   testPattern(R"(\%)", PatternKind::kFixed, "%");
   testPattern(R"(\%\%\%)", PatternKind::kFixed, "%%%");
   testPattern(R"(a\%b\%c\%d)", PatternKind::kFixed, "a%b%c%d");
 
+  testPattern(R"(_a\%b\%c_\%d_)", PatternKind::kRelaxedFixed, "_a%b%c_%d_");
+
   testPattern(R"(\_\_%%)", PatternKind::kPrefix, "__");
   testPattern(R"(a\_b\_c%%)", PatternKind::kPrefix, "a_b_c");
+
+  testPattern(R"(_a\__b\_c%%)", PatternKind::kRelaxedPrefix, "_a__b_c");
 
   testPattern(R"(%%\_\_)", PatternKind::kSuffix, "__");
   testPattern(R"(%%a\_b\_c)", PatternKind::kSuffix, "a_b_c");
   testPattern(R"(%\_\%)", PatternKind::kSuffix, "_%");
+
+  testPattern(R"(%%a\_b_\_c_)", PatternKind::kRelaxedSuffix, "a_b__c_");
 
   testPattern(R"(%\_%%)", PatternKind::kSubstring, "_");
   testPattern(R"(%\_\%%%)", PatternKind::kSubstring, "_%");
@@ -606,7 +664,7 @@ TEST_F(Re2FunctionsTest, likePatternEscapingEscapeChar) {
 }
 
 TEST_F(Re2FunctionsTest, likePatternFixed) {
-  testLike("", "", true);
+  /*testLike("", "", true);
   testLike("abcde", "abcde", true);
   testLike("ABCDE", "ABCDE", true);
   testLike("abcde", "uvwxy", false);
@@ -628,16 +686,36 @@ TEST_F(Re2FunctionsTest, likePatternFixed) {
   testLike("\nab\tcd\b", "\nabcd\b", false);
 
   // Test literal '_' & '%' in pattern.
-  testLike("a", R"(\_)", '\\', false);
+  testLike("a", R"(\_)", '\\', false);*/
   testLike("_b", R"(\_b)", '\\', true);
-  testLike("abc_d", R"(abc\_d)", '\\', true);
+  /*testLike("abc_d", R"(abc\_d)", '\\', true);
 
   testLike("a", R"(\%)", '\\', false);
   testLike("abc%d", R"(abc\%d)", '\\', true);
   testLike("abc%d", R"(a\%d)", '\\', false);
 
   std::string input = generateString(kLikePatternCharacterSet, 66);
-  testLike(input, input, true);
+  testLike(input, input, true);*/
+}
+
+TEST_F(Re2FunctionsTest, likePatternRelaxedFixed) {
+  testLike("_ab_cde_", "_ab_cde_", true);
+  testLike("xabxcdex", "_ab_cde_", true);
+  testLike("xacxcdex", "_ab_cde_", false);
+
+  testLike("ABCDEx", "ABCDE_", true);
+  testLike("ABCDEy", "ABCDE_", true);
+  testLike("ABCDCy", "ABCDE_", false);
+  testLike("abcdey", "ABCDE_", false);
+
+  // Test literal '_' & '%' in pattern.
+  testLike("_x", R"(\__)", '\\', true);
+  testLike("xx", R"(\__)", '\\', false);
+  testLike("abc_dx", R"(abc\_d_)", '\\', true);
+
+  testLike("aa", R"(\%_)", '\\', false);
+  testLike("%a", R"(\%_)", '\\', true);
+  testLike("xabc%d", R"(_abc\%d)", '\\', true);
 }
 
 TEST_F(Re2FunctionsTest, likePatternPrefix) {
@@ -681,6 +759,27 @@ TEST_F(Re2FunctionsTest, likePatternPrefix) {
   testLike(input, input + generateString(kAnyWildcardCharacter), true);
 }
 
+TEST_F(Re2FunctionsTest, likePatternRelaxedPrefix) {
+  testLike("abcdef", "abcd_%", true);
+  testLike("abcdef", "abcd_%%%", true);
+  testLike("abcdef", "_b_d_%", true);
+  testLike("abcdef", "bb_d_%", false);
+
+  testLike("ABCDE", "ABC_%", true);
+  testLike("ABCDE", "A_C_%", true);
+  testLike("ABCDE", "__C_%", true);
+  testLike("ABCDE", "BBC_%", false);
+  testLike("abcde", "__C_%", false);
+
+  // Test literal '_' & '%' in pattern.
+  testLike("a_b", R"(_\_%)", '\\', true);
+  testLike("b_b", R"(_\_%)", '\\', true);
+  testLike("bbb", R"(_\_%)", '\\', false);
+
+  testLike("%ab", R"(\%_b%)", '\\', true);
+  testLike("a_c%defg", R"(a_c\%d%)", '\\', true);
+}
+
 TEST_F(Re2FunctionsTest, likePatternSuffix) {
   testLike("", "%", true);
   testLike("abcde", "%bcde", true);
@@ -720,6 +819,36 @@ TEST_F(Re2FunctionsTest, likePatternSuffix) {
 
   std::string input = generateString(kLikePatternCharacterSet, 65);
   testLike(input, generateString(kAnyWildcardCharacter) + input, true);
+}
+
+TEST_F(Re2FunctionsTest, likeRelaxedSuffixPattern) {
+  testLike("abcde", "%_cde", true);
+  testLike("ABCDE", "%_DE", true);
+  testLike("abcde", "%%_d_", true);
+  testLike("ABCDE", "%%D_", true);
+  testLike("abcde", "%%_e", true);
+  testLike("ABCDE", "%%_E", true);
+
+  testLike("abcde", "%cc_e", false);
+  testLike("ABCDE", "%BD_", false);
+  testLike("abcde", "%%cc_e", false);
+  testLike("ABCDE", "%%BD_", false);
+  testLike("abcde", "%be_", false);
+  testLike("ABCDE", "%_de", false);
+  testLike("abcde", "%%_ce", false);
+  testLike("ABCDE", "%%e", false);
+  testLike("\nabc\nde\n", "%_\nde\n", true);
+  testLike("\nabcde\n", "%%_de\n", true);
+  testLike("\nabc\tde\b", "%_\tde\b", true);
+  testLike("\nabcde\t", "%%_de\t", true);
+  testLike("\nabcde\n", "%d_\b", false);
+  testLike("\nabcde\n", "%_d\n", false);
+  testLike("\nabcde\n", "%e_\n", false);
+
+  // Test literal '_' & '%' in pattern.
+  testLike("a_b", R"(%\__)", '\\', true);
+  testLike("cd_bc", R"(%\_b_)", '\\', true);
+  testLike("efgabc_d", R"(%a_c\_d)", '\\', true);
 }
 
 TEST_F(Re2FunctionsTest, likeSubstringPattern) {

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -664,7 +664,7 @@ TEST_F(Re2FunctionsTest, likePatternEscapingEscapeChar) {
 }
 
 TEST_F(Re2FunctionsTest, likePatternFixed) {
-  /*testLike("", "", true);
+  testLike("", "", true);
   testLike("abcde", "abcde", true);
   testLike("ABCDE", "ABCDE", true);
   testLike("abcde", "uvwxy", false);
@@ -686,16 +686,16 @@ TEST_F(Re2FunctionsTest, likePatternFixed) {
   testLike("\nab\tcd\b", "\nabcd\b", false);
 
   // Test literal '_' & '%' in pattern.
-  testLike("a", R"(\_)", '\\', false);*/
+  testLike("a", R"(\_)", '\\', false);
   testLike("_b", R"(\_b)", '\\', true);
-  /*testLike("abc_d", R"(abc\_d)", '\\', true);
+  testLike("abc_d", R"(abc\_d)", '\\', true);
 
   testLike("a", R"(\%)", '\\', false);
   testLike("abc%d", R"(abc\%d)", '\\', true);
   testLike("abc%d", R"(a\%d)", '\\', false);
 
   std::string input = generateString(kLikePatternCharacterSet, 66);
-  testLike(input, input, true);*/
+  testLike(input, input, true);
 }
 
 TEST_F(Re2FunctionsTest, likePatternRelaxedFixed) {
@@ -707,6 +707,14 @@ TEST_F(Re2FunctionsTest, likePatternRelaxedFixed) {
   testLike("ABCDEy", "ABCDE_", true);
   testLike("ABCDCy", "ABCDE_", false);
   testLike("abcdey", "ABCDE_", false);
+
+  testLike("fblearner_global", "fblearner_", false);
+  testLike("fblearner", "fblearner_", false);
+  testLike("fblearner_", "fblearner_", true);
+
+  testLike("你好_世界", "你好_", false);
+  testLike("你好", "你好_", false);
+  testLike("你好_", "你好_", true);
 
   // Test literal '_' & '%' in pattern.
   testLike("_x", R"(\__)", '\\', true);
@@ -770,6 +778,14 @@ TEST_F(Re2FunctionsTest, likePatternRelaxedPrefix) {
   testLike("ABCDE", "__C_%", true);
   testLike("ABCDE", "BBC_%", false);
   testLike("abcde", "__C_%", false);
+
+  testLike("fblearner_global", "fblearner_%", true);
+  testLike("fblearner", "fblearner_%", false);
+  testLike("fblearner_", "fblearner_%", true);
+
+  testLike("你好_世界", "你好_%", true);
+  testLike("你好", "你好_%", false);
+  testLike("你好_", "你好_%", true);
 
   // Test literal '_' & '%' in pattern.
   testLike("a_b", R"(_\_%)", '\\', true);
@@ -844,6 +860,14 @@ TEST_F(Re2FunctionsTest, likeRelaxedSuffixPattern) {
   testLike("\nabcde\n", "%d_\b", false);
   testLike("\nabcde\n", "%_d\n", false);
   testLike("\nabcde\n", "%e_\n", false);
+
+  testLike("global_fblearner", "%_fblearner", true);
+  testLike("fblearner", "%_fblearner", false);
+  testLike("_fblearner", "%_fblearner", true);
+
+  testLike("世界_你好", "%_你好", true);
+  testLike("你好", "%_你好", false);
+  testLike("_你好", "%_你好", true);
 
   // Test literal '_' & '%' in pattern.
   testLike("a_b", R"(%\__)", '\\', true);

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -708,9 +708,9 @@ TEST_F(Re2FunctionsTest, likePatternRelaxedFixed) {
   testLike("ABCDCy", "ABCDE_", false);
   testLike("abcdey", "ABCDE_", false);
 
-  testLike("fblearner_global", "fblearner_", false);
-  testLike("fblearner", "fblearner_", false);
-  testLike("fblearner_", "fblearner_", true);
+  testLike("ABCDE_FGH", "ABCDE_", false);
+  testLike("ABCDE", "ABCDE_", false);
+  testLike("ABCDE_", "ABCDE_", true);
 
   testLike("你好_世界", "你好_", false);
   testLike("你好", "你好_", false);
@@ -779,9 +779,9 @@ TEST_F(Re2FunctionsTest, likePatternRelaxedPrefix) {
   testLike("ABCDE", "BBC_%", false);
   testLike("abcde", "__C_%", false);
 
-  testLike("fblearner_global", "fblearner_%", true);
-  testLike("fblearner", "fblearner_%", false);
-  testLike("fblearner_", "fblearner_%", true);
+  testLike("ABCDE_FGH", "ABCDE_%", true);
+  testLike("ABCDE", "ABCDE_%", false);
+  testLike("ABCDE_", "ABCDE_%", true);
 
   testLike("你好_世界", "你好_%", true);
   testLike("你好", "你好_%", false);
@@ -861,9 +861,9 @@ TEST_F(Re2FunctionsTest, likeRelaxedSuffixPattern) {
   testLike("\nabcde\n", "%_d\n", false);
   testLike("\nabcde\n", "%e_\n", false);
 
-  testLike("global_fblearner", "%_fblearner", true);
-  testLike("fblearner", "%_fblearner", false);
-  testLike("_fblearner", "%_fblearner", true);
+  testLike("FGH_ABCDE", "%_ABCDE", true);
+  testLike("ABCDE", "%_ABCDE", false);
+  testLike("_ABCDE", "%_ABCDE", true);
 
   testLike("世界_你好", "%_你好", true);
   testLike("你好", "%_你好", false);


### PR DESCRIPTION
In this PR we optimize LIKE operations for patterns which I call them
kRelaxed[Prefix|Suffix] patterns, e.g.

- kRelaxedPrefix: _a_bc%%
- kRelaxedSuffix: %%_a_bc

'Relaxed' here means there is less restrictions than their counterparts.
The algorithm of recognizing these relaxed patterns can be explained by
an example, say we have a pattern '___hello___%%', it is split into 4
sub patterns:

- [0] kSingleCharWildcard: ___
- [1] kLiteralString: hello
- [2] kSingleCharWildcard: ___
- [3] kAnyCharsWildcard: %%

Since the 'kAnyCharsWildcard' only occurs at the end of the pattern, we can
determine it is a kRelaxedPrefix pattern, and then use the first 3 fixed
sub-patterns to do the matching.

The benchmark result:

Before(kGeneric):

```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
like_generic##like_generic                                   1.34s   747.38m
----------------------------------------------------------------------------
----------------------------------------------------------------------------
like_prefix##like_prefix                                  340.30ms      2.94
like_prefix##like_relaxed_prefix_1                        334.77ms      2.99
like_prefix##like_relaxed_prefix_2                        350.70ms      2.85
like_prefix##starts_with                                    5.35ms    187.05
like_substring##like_substring                               1.26s   790.87m
like_substring##strpos                                     20.55ms     48.67
like_suffix##like_suffix                                  957.06ms      1.04
like_suffix##like_relaxed_suffix_1                        935.90ms      1.07
like_suffix##like_relaxed_suffix_2                           1.08s   926.79m
like_suffix##ends_with                                      5.35ms    187.07
```

After(kRelaxedPrefix, kRelaxedSuffix):

```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
like_generic##like_generic                                   1.48s   674.92m
----------------------------------------------------------------------------
----------------------------------------------------------------------------
like_prefix##like_prefix                                    7.05ms    141.80
like_prefix##like_relaxed_prefix_1                          9.06ms    110.36
like_prefix##like_relaxed_prefix_2                          8.55ms    116.94
like_prefix##starts_with                                    5.34ms    187.22
like_substring##like_substring                             22.47ms     44.50
like_substring##strpos                                     20.72ms     48.27
like_suffix##like_suffix                                    7.05ms    141.82
like_suffix##like_relaxed_suffix_1                          9.08ms    110.16
like_suffix##like_relaxed_suffix_2                          8.52ms    117.30
like_suffix##ends_with                                      5.35ms    187.07
```

The speedup for kRelaxedPrefix is about 40x, speedup for kRelaxedSuffix is about 100x.