### PR TITLE
Remove unnecessary check in BooleanMix#getFlatBool

### DIFF
--- a/velox/expression/BooleanMix.cpp
+++ b/velox/expression/BooleanMix.cpp
@@ -109,11 +109,7 @@ BooleanMix getFlatBool(
       activeRows.applyToSelected([&](int32_t i) {
         auto index = indices[i];
         bool isNull = nulls && bits::isBitNull(nulls, i);
-        if (mergeNullsToValues && nulls) {
-          if (!isNull && bits::isBitSet(values, index)) {
-            bits::setBit(valuesToSet, i);
-          }
-        } else if (!isNull && bits::isBitSet(values, index)) {
+        if (!isNull && bits::isBitSet(values, index)) {
           bits::setBit(valuesToSet, i);
         }
         if (nullsToSet && isNull) {


### PR DESCRIPTION
`mergeNullsToValues && nulls` check is unnecessary.