### PR TITLE
Add ntile() spark window function

### DIFF
--- a/velox/docs/functions/spark/window.rst
+++ b/velox/docs/functions/spark/window.rst
@@ -30,3 +30,8 @@ Returns the rank of a value in a group of values. The rank is one plus the numbe
 
 Returns the rank of a value in a group of values. This is similar to rank(), except that tie values do not produce gaps in the sequence.
 
+.. spark:function:: ntile(n) -> integer
+
+Divides the rows for each window partition into n buckets ranging from 1 to at most ``n``. Bucket values will differ by at most 1. If the number of rows in the partition does not divide evenly into the number of buckets, then the remainder values are distributed one per bucket, starting with the first bucket.
+
+For example, with 6 rows and 4 buckets, the bucket values would be as follows: ``1 1 2 2 3 4``

--- a/velox/functions/lib/window/CMakeLists.txt
+++ b/velox/functions/lib/window/CMakeLists.txt
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_functions_window NthValue.cpp Rank.cpp RowNumber.cpp)
+add_library(velox_functions_window NthValue.cpp Rank.cpp RowNumber.cpp
+                                   Ntile.cpp)
 
 target_link_libraries(velox_functions_window velox_buffer velox_exec
                       Folly::folly)

--- a/velox/functions/lib/window/Ntile.cpp
+++ b/velox/functions/lib/window/Ntile.cpp
@@ -89,21 +89,21 @@ class NtileFunction : public exec::WindowFunction {
   struct BucketMetrics {
     // To compute the bucket number for a row, we find the number of rows in
     // a bucket as the (number of rows in partition) / (number of buckets).
-    int64_t rowsPerBucket;
+    TResult rowsPerBucket;
     // There could be some buckets with rowsPerBucket + 1 number of rows,
     // as the partition rows might not be exactly divisible
     // by the number of buckets. There are
     // (number of rows in partition) % (number of buckets) such buckets.
-    int64_t bucketsWithExtraRow;
+    TResult bucketsWithExtraRow;
     // When assigning bucket numbers, the first 'bucketsWithExtraRow' buckets
     // will have (rowsPerBucket + 1) rows. This row number at this boundary is
     // extraBucketsBoundary = bucketsWithExtraRow * (rowsPerBucket + 1). Beyond
     // this row number in the partition, the buckets will have only
     // rowsPerBucket number of rows. This boundary is useful when computing the
     // bucket value.
-    int64_t extraBucketsBoundary;
+    TResult extraBucketsBoundary;
 
-    int64_t computeBucketValue(vector_size_t rowNumber) const {
+    TResult computeBucketValue(vector_size_t rowNumber) const {
       if (rowNumber < extraBucketsBoundary) {
         return rowNumber / (rowsPerBucket + 1) + 1;
       }
@@ -132,7 +132,7 @@ class NtileFunction : public exec::WindowFunction {
     }
   };
 
-  BucketMetrics computeBucketMetrics(int64_t numBuckets) const {
+  BucketMetrics computeBucketMetrics(TResult numBuckets) const {
     auto rowsPerBucket = numPartitionRows_ / numBuckets;
     auto bucketsWithExtraRow = numPartitionRows_ % numBuckets;
     auto extraBucketsBoundary = (rowsPerBucket + 1) * bucketsWithExtraRow;
@@ -197,7 +197,7 @@ class NtileFunction : public exec::WindowFunction {
 
   // Number of buckets if a constant value. Is optional as the value could
   // be null.
-  std::optional<int64_t> numFixedBuckets_;
+  std::optional<TResult> numFixedBuckets_;
 
   // If number of buckets is greater than the partition rows, then the output
   // bucket number is simply row number + 1. So bucket computation can be
@@ -211,7 +211,7 @@ class NtileFunction : public exec::WindowFunction {
 
   // Current WindowPartition used for accessing rows in the apply method.
   const exec::WindowPartition* partition_;
-  int64_t numPartitionRows_ = 0;
+  TResult numPartitionRows_ = 0;
 
   // Denotes how far along the partition rows are output already.
   int64_t partitionOffset_ = 0;

--- a/velox/functions/lib/window/RegistrationFunctions.h
+++ b/velox/functions/lib/window/RegistrationFunctions.h
@@ -54,4 +54,12 @@ void registerDenseRankInteger(const std::string& name);
 // Returns the percentage ranking of a value in a group of values.
 void registerPercentRank(const std::string& name);
 
+// Register the Presto function ntile() with the bigint data type
+// for the return and input value.
+void registerNtileBigint(const std::string& name);
+
+// Register the Spark function ntile() with the integer data type
+// for the return and input value.
+void registerNtileInteger(const std::string& name);
+
 } // namespace facebook::velox::functions::window

--- a/velox/functions/prestosql/window/CMakeLists.txt
+++ b/velox/functions/prestosql/window/CMakeLists.txt
@@ -15,7 +15,7 @@ if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)
 endif()
 
-add_library(velox_window CumeDist.cpp FirstLastValue.cpp LeadLag.cpp Ntile.cpp
+add_library(velox_window CumeDist.cpp FirstLastValue.cpp LeadLag.cpp
                          WindowFunctionsRegistration.cpp)
 
 target_link_libraries(velox_window velox_buffer velox_exec

--- a/velox/functions/prestosql/window/WindowFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/window/WindowFunctionsRegistration.cpp
@@ -21,7 +21,7 @@ namespace facebook::velox::window {
 namespace prestosql {
 
 extern void registerCumeDist(const std::string& name);
-extern void registerNtile(const std::string& name);
+extern void registerNtileBigint(const std::string& name);
 extern void registerFirstValue(const std::string& name);
 extern void registerLastValue(const std::string& name);
 extern void registerLag(const std::string& name);
@@ -33,7 +33,7 @@ void registerAllWindowFunctions(const std::string& prefix) {
   functions::window::registerDenseRankBigint(prefix + "dense_rank");
   functions::window::registerPercentRank(prefix + "percent_rank");
   registerCumeDist(prefix + "cume_dist");
-  registerNtile(prefix + "ntile");
+  functions::window::registerNtileBigint(prefix + "ntile");
   functions::window::registerNthValueBigint(prefix + "nth_value");
   registerFirstValue(prefix + "first_value");
   registerLastValue(prefix + "last_value");

--- a/velox/functions/sparksql/window/WindowFunctionsRegistration.cpp
+++ b/velox/functions/sparksql/window/WindowFunctionsRegistration.cpp
@@ -23,6 +23,7 @@ void registerWindowFunctions(const std::string& prefix) {
   functions::window::registerRowNumberInteger(prefix + "row_number");
   functions::window::registerRankInteger(prefix + "rank");
   functions::window::registerDenseRankInteger(prefix + "dense_rank");
+  functions::window::registerNtileInteger(prefix + "ntile");
 }
 
 } // namespace facebook::velox::functions::window::sparksql

--- a/velox/functions/sparksql/window/tests/SparkWindowTest.cpp
+++ b/velox/functions/sparksql/window/tests/SparkWindowTest.cpp
@@ -28,7 +28,12 @@ static const std::vector<std::string> kSparkWindowFunctions = {
     std::string("nth_value(c0, c3)"),
     std::string("row_number()"),
     std::string("rank()"),
-    std::string("dense_rank()")};
+    std::string("dense_rank()"),
+    std::string("ntile(c3)"),
+    std::string("ntile(1)"),
+    std::string("ntile(7)"),
+    std::string("ntile(10)"),
+    std::string("ntile(16)")};
 
 struct SparkWindowTestParam {
   const std::string function;


### PR DESCRIPTION
Spark [Ntile function](https://github.com/apache/spark/blob/f824d058b14e3c58b1c90f64fefc45fac105c7dd/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/windowExpressions.scala#L842) divides the rows for each window partition into n buckets ranging from 1 to at most n. Bucket values will differ by at most 1. If the number of rows in the partition does not divide evenly into the number of buckets, then the remainder values are distributed one per bucket, starting with the first bucket. The difference between sparksql and prestosql is the return type, where the sparksql's return type is integer and the prestosql's is bigint. This PR refer the [nth_value()](https://github.com/facebookincubator/velox/blob/b9be1718a70f3f81d184cd1dc57134552a2ed96a/velox/functions/lib/window/NthValue.h#L20) function and move the Ntile.cpp file from
 `velox/functions/prestosql/window into the velox/functions/window`.
 And also provide `registerNtileBigint `and `registerNtileInteger `for prestosql and sparksql.