### PR TITLE
Fix wrong cast in DecimalUtil::divideWithRoundUp()

### DIFF
--- a/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
@@ -314,6 +314,18 @@ TEST_F(DecimalArithmeticTest, decimalDivTest) {
       "divide(c0, c1)",
       {shortFlat, longFlat});
 
+  testDecimalExpr<TypeKind::HUGEINT>(
+      makeFlatVector<int128_t>(
+          {HugeInt::parse("20000000000000000"),
+           HugeInt::parse("50000000000000000")},
+          DECIMAL(38, 19)),
+      "divide(c0, c1)",
+      {makeFlatVector<int64_t>({100, 200}, DECIMAL(17, 4)),
+       makeFlatVector<int128_t>(
+           {HugeInt::parse("50000000000000000000"),
+            HugeInt::parse("40000000000000000000")},
+           DECIMAL(21, 19))});
+
   // Divide long and long, returning long.
   testDecimalExpr<TypeKind::HUGEINT>(
       makeFlatVector<int128_t>({500, 300}, DECIMAL(22, 2)),

--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -251,7 +251,7 @@ class DecimalUtil {
       uint8_t /*bRescale*/) {
     VELOX_USER_CHECK_NE(b, 0, "Division by zero");
     int resultSign = 1;
-    A unsignedDividendRescaled(a);
+    R unsignedDividendRescaled(a);
     if (a < 0) {
       resultSign = -1;
       unsignedDividendRescaled *= -1;


### PR DESCRIPTION
Decimal divide function returned wrong results when short decimal / long 
decimal. The cause is that in DecimalUtil::divideWithRoundUp(), when 
calculating `unsignedDividendRescaled`, the int128_t type is forcibly 
cast to int64_t type, resulting in an incorrect value for 
`unsignedDividendRescaled`. 

Fixes #8598