### PR TITLE
Add TraceHistory

### DIFF
--- a/velox/common/caching/CMakeLists.txt
+++ b/velox/common/caching/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(
          velox_exception
          velox_file
          velox_memory
+         velox_process
          Folly::folly
          fmt::fmt
          gflags::gflags

--- a/velox/common/process/CMakeLists.txt
+++ b/velox/common/process/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 add_library(velox_process ProcessBase.cpp StackTrace.cpp ThreadDebugInfo.cpp
-                          TraceContext.cpp)
+                          TraceContext.cpp TraceHistory.cpp)
 
 target_link_libraries(
   velox_process

--- a/velox/common/process/ThreadLocalRegistry.h
+++ b/velox/common/process/ThreadLocalRegistry.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <list>
+#include <memory>
+#include <mutex>
+
+namespace facebook::velox::process {
+
+/// A registry for keeping static thread local objects of type T.  Similar to
+/// folly::ThreadLocal but a little bit more efficient in terms of performance
+/// and memory usage, because we do not support thread local with lexical scope.
+///
+/// NOTE: only one instance of ThreadLocalRegistry<T> can be created with each
+/// T.
+template <typename T>
+class ThreadLocalRegistry {
+ public:
+  class Reference;
+
+  /// Access values from all threads.  Takes a global lock and should be used
+  /// with caution.
+  template <typename F>
+  void forAllValues(F f) {
+    std::lock_guard<std::mutex> entriesLock(entriesMutex_);
+    for (auto& entry : entries_) {
+      std::lock_guard<std::mutex> lk(entry->mutex);
+      f(entry->value);
+    }
+  }
+
+ private:
+  struct Entry {
+    std::mutex mutex;
+    T value;
+  };
+
+  std::list<std::unique_ptr<Entry>> entries_;
+  std::mutex entriesMutex_;
+};
+
+/// Reference to one thread local value.  Should be stored in thread local
+/// memory.
+template <typename T>
+class ThreadLocalRegistry<T>::Reference {
+ public:
+  explicit Reference(const std::shared_ptr<ThreadLocalRegistry>& registry)
+      : registry_(registry) {
+    auto entry = std::make_unique<Entry>();
+    std::lock_guard<std::mutex> lk(registry_->entriesMutex_);
+    iterator_ =
+        registry_->entries_.insert(registry_->entries_.end(), std::move(entry));
+  }
+
+  ~Reference() {
+    std::lock_guard<std::mutex> lk(registry_->entriesMutex_);
+    registry_->entries_.erase(iterator_);
+  }
+
+  /// Obtain the thread local value and process it with the functor `f'.
+  template <typename F>
+  auto withValue(F f) {
+    auto* entry = iterator_->get();
+    std::lock_guard<std::mutex> lk(entry->mutex);
+    return f(entry->value);
+  }
+
+ private:
+  std::shared_ptr<ThreadLocalRegistry> const registry_;
+  typename std::list<std::unique_ptr<Entry>>::iterator iterator_;
+};
+
+} // namespace facebook::velox::process

--- a/velox/common/process/TraceContext.cpp
+++ b/velox/common/process/TraceContext.cpp
@@ -16,23 +16,27 @@
 
 #include "velox/common/process/TraceContext.h"
 
+#include "velox/common/process/ThreadLocalRegistry.h"
+
 #include <sstream>
 
 namespace facebook::velox::process {
 
 namespace {
-folly::Synchronized<std::unordered_map<std::string, TraceData>>& traceMap() {
-  static folly::Synchronized<std::unordered_map<std::string, TraceData>>
-      staticTraceMap;
-  return staticTraceMap;
-}
+
+// We use thread local instead lock here since the critical path is on write
+// side.
+using Registry = ThreadLocalRegistry<folly::F14FastMap<std::string, TraceData>>;
+auto registry = std::make_shared<Registry>();
+thread_local Registry::Reference threadLocalTraceData(registry);
+
 } // namespace
 
 TraceContext::TraceContext(std::string label, bool isTemporary)
     : label_(std::move(label)),
       enterTime_(std::chrono::steady_clock::now()),
       isTemporary_(isTemporary) {
-  traceMap().withWLock([&](auto& counts) {
+  threadLocalTraceData.withValue([&](auto& counts) {
     auto& data = counts[label_];
     ++data.numThreads;
     if (data.numThreads == 1) {
@@ -43,17 +47,18 @@ TraceContext::TraceContext(std::string label, bool isTemporary)
 }
 
 TraceContext::~TraceContext() {
-  traceMap().withWLock([&](auto& counts) {
-    auto& data = counts[label_];
-    --data.numThreads;
+  threadLocalTraceData.withValue([&](auto& counts) {
+    auto it = counts.find(label_);
+    auto& data = it->second;
+    if (--data.numThreads == 0 && isTemporary_) {
+      counts.erase(it);
+      return;
+    }
     auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                   std::chrono::steady_clock::now() - enterTime_)
                   .count();
     data.totalMs += ms;
     data.maxMs = std::max<uint64_t>(data.maxMs, ms);
-    if (!data.numThreads && isTemporary_) {
-      counts.erase(label_);
-    }
   });
 }
 
@@ -61,27 +66,40 @@ TraceContext::~TraceContext() {
 std::string TraceContext::statusLine() {
   std::stringstream out;
   auto now = std::chrono::steady_clock::now();
-  traceMap().withRLock([&](auto& counts) {
-    for (auto& pair : counts) {
-      if (pair.second.numThreads) {
-        auto continued = std::chrono::duration_cast<std::chrono::milliseconds>(
-                             now - pair.second.startTime)
-                             .count();
+  auto counts = status();
+  for (auto& pair : counts) {
+    if (pair.second.numThreads) {
+      auto continued = std::chrono::duration_cast<std::chrono::milliseconds>(
+                           now - pair.second.startTime)
+                           .count();
 
-        out << pair.first << "=" << pair.second.numThreads << " entered "
-            << pair.second.numEnters << " avg ms "
-            << (pair.second.totalMs / pair.second.numEnters) << " max ms "
-            << pair.second.maxMs << " continuous for " << continued
-            << std::endl;
-      }
+      out << pair.first << "=" << pair.second.numThreads << " entered "
+          << pair.second.numEnters << " avg ms "
+          << (pair.second.totalMs / pair.second.numEnters) << " max ms "
+          << pair.second.maxMs << " continuous for " << continued << std::endl;
     }
-  });
+  }
   return out.str();
 }
 
 // static
-std::unordered_map<std::string, TraceData> TraceContext::status() {
-  return traceMap().withRLock([&](auto& map) { return map; });
+folly::F14FastMap<std::string, TraceData> TraceContext::status() {
+  folly::F14FastMap<std::string, TraceData> total;
+  registry->forAllValues([&](auto& counts) {
+    for (auto& [k, v] : counts) {
+      auto& sofar = total[k];
+      if (sofar.numEnters == 0) {
+        sofar.startTime = v.startTime;
+      } else if (v.numEnters > 0) {
+        sofar.startTime = std::min(sofar.startTime, v.startTime);
+      }
+      sofar.numThreads += v.numThreads;
+      sofar.numEnters += v.numEnters;
+      sofar.totalMs += v.totalMs;
+      sofar.maxMs = std::max(sofar.maxMs, v.maxMs);
+    }
+  });
+  return total;
 }
 
 } // namespace facebook::velox::process

--- a/velox/common/process/TraceContext.cpp
+++ b/velox/common/process/TraceContext.cpp
@@ -17,6 +17,7 @@
 #include "velox/common/process/TraceContext.h"
 
 #include "velox/common/process/ThreadLocalRegistry.h"
+#include "velox/common/process/TraceHistory.h"
 
 #include <sstream>
 
@@ -36,6 +37,12 @@ TraceContext::TraceContext(std::string label, bool isTemporary)
     : label_(std::move(label)),
       enterTime_(std::chrono::steady_clock::now()),
       isTemporary_(isTemporary) {
+  TraceHistory::push([&](auto& entry) {
+    entry.time = enterTime_;
+    entry.file = __FILE__;
+    entry.line = __LINE__;
+    snprintf(entry.label, entry.kLabelCapacity, "%s", label_.c_str());
+  });
   threadLocalTraceData.withValue([&](auto& counts) {
     auto& data = counts[label_];
     ++data.numThreads;

--- a/velox/common/process/TraceContext.h
+++ b/velox/common/process/TraceContext.h
@@ -20,7 +20,7 @@
 #include <string>
 #include <unordered_map>
 
-#include <folly/Synchronized.h>
+#include <folly/container/F14Map.h>
 
 namespace facebook::velox::process {
 
@@ -63,7 +63,7 @@ class TraceContext {
   static std::string statusLine();
 
   // Returns a copy of the trace status.
-  static std::unordered_map<std::string, TraceData> status();
+  static folly::F14FastMap<std::string, TraceData> status();
 
  private:
   const std::string label_;

--- a/velox/common/process/TraceHistory.cpp
+++ b/velox/common/process/TraceHistory.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/process/TraceHistory.h"
+
+#include <folly/system/ThreadId.h>
+
+#include <algorithm>
+
+namespace facebook::velox::process {
+
+namespace {
+auto registry = std::make_shared<ThreadLocalRegistry<TraceHistory>>();
+}
+
+namespace detail {
+thread_local ThreadLocalRegistry<TraceHistory>::Reference traceHistory(
+    registry);
+}
+
+TraceHistory::TraceHistory()
+    : threadId_(std::this_thread::get_id()), osTid_(folly::getOSThreadID()) {}
+
+std::vector<TraceHistory::EntriesWithThreadInfo> TraceHistory::listAll() {
+  std::vector<EntriesWithThreadInfo> results;
+  registry->forAllValues([&](auto& history) {
+    EntriesWithThreadInfo result;
+    result.threadId = history.threadId_;
+    result.osTid = history.osTid_;
+    for (int i = 0; i < kCapacity; ++i) {
+      const int j = (history.index_ + kCapacity - 1 - i) % kCapacity;
+      if (!populated(history.data_[j])) {
+        break;
+      }
+      result.entries.push_back(history.data_[j]);
+    }
+    std::reverse(result.entries.begin(), result.entries.end());
+    results.push_back(std::move(result));
+  });
+  return results;
+}
+
+} // namespace facebook::velox::process

--- a/velox/common/process/TraceHistory.h
+++ b/velox/common/process/TraceHistory.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/process/ThreadLocalRegistry.h"
+
+#include <cassert>
+#include <chrono>
+#include <cstdio>
+#include <thread>
+#include <vector>
+
+/// Push an entry to the history ring buffer with a label from format string
+/// (same as printf) and optional arguments.
+#define VELOX_TRACE_HISTORY_PUSH(_format, ...)                             \
+  ::facebook::velox::process::TraceHistory::push([&](auto& entry) {        \
+    entry.time = ::std::chrono::steady_clock::now();                       \
+    entry.file = __FILE__;                                                 \
+    entry.line = __LINE__;                                                 \
+    ::snprintf(entry.label, entry.kLabelCapacity, _format, ##__VA_ARGS__); \
+  })
+
+namespace facebook::velox::process {
+
+class TraceHistory;
+
+namespace detail {
+extern thread_local ThreadLocalRegistry<TraceHistory>::Reference traceHistory;
+}
+
+/// Keep list of labels in a ring buffer that is fixed sized and thread local.
+class TraceHistory {
+ public:
+  TraceHistory();
+
+  /// An entry with tracing information and custom label.
+  struct Entry {
+    std::chrono::steady_clock::time_point time;
+    const char* file;
+    int32_t line;
+
+    static constexpr int kLabelCapacity =
+        64 - sizeof(time) - sizeof(file) - sizeof(line);
+    char label[kLabelCapacity];
+  };
+
+  /// NOTE: usually VELOX_TRACE_HISTORY_PUSH should be used instead of calling
+  /// this function directly.
+  ///
+  /// Add a new entry to the thread local instance.  If there are more than
+  /// `kCapacity' entries, overwrite the oldest ones.  All the mutation on the
+  /// new entry should be done in the functor `init'.
+  template <typename F>
+  static void push(F&& init) {
+    detail::traceHistory.withValue(
+        [init = std::forward<F>(init)](auto& history) {
+          auto& entry = history.data_[history.index_];
+          init(entry);
+          assert(populated(entry));
+          history.index_ = (history.index_ + 1) % kCapacity;
+        });
+  }
+
+  /// All entries in a specific thread.
+  struct EntriesWithThreadInfo {
+    std::thread::id threadId;
+    uint64_t osTid;
+    std::vector<Entry> entries;
+  };
+
+  /// List all entries from all threads.
+  static std::vector<EntriesWithThreadInfo> listAll();
+
+  /// Keep the last `kCapacity' entries per thread.  Must be a power of 2.
+  static constexpr int kCapacity = 16;
+
+ private:
+  static_assert((kCapacity & (kCapacity - 1)) == 0);
+  static_assert(sizeof(Entry) == 64);
+
+  static bool populated(const Entry& entry) {
+    return entry.file != nullptr;
+  }
+
+  alignas(64) Entry data_[kCapacity]{};
+  const std::thread::id threadId_;
+  const uint64_t osTid_;
+  int index_ = 0;
+};
+
+} // namespace facebook::velox::process

--- a/velox/common/process/tests/CMakeLists.txt
+++ b/velox/common/process/tests/CMakeLists.txt
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_process_test TraceContextTest.cpp
-                                  ThreadLocalRegistryTest.cpp)
+add_executable(
+  velox_process_test TraceContextTest.cpp ThreadLocalRegistryTest.cpp
+                     TraceHistoryTest.cpp)
 
 add_test(velox_process_test velox_process_test)
 

--- a/velox/common/process/tests/CMakeLists.txt
+++ b/velox/common/process/tests/CMakeLists.txt
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_process_test TraceContextTest.cpp)
+add_executable(velox_process_test TraceContextTest.cpp
+                                  ThreadLocalRegistryTest.cpp)
 
 add_test(velox_process_test velox_process_test)
 

--- a/velox/common/process/tests/ThreadLocalRegistryTest.cpp
+++ b/velox/common/process/tests/ThreadLocalRegistryTest.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/process/ThreadLocalRegistry.h"
+
+#include <folly/synchronization/Baton.h>
+#include <folly/synchronization/Latch.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+
+namespace facebook::velox::process {
+namespace {
+
+template <typename Tag>
+class TestObject {
+ public:
+  static std::atomic_int& count() {
+    static std::atomic_int value;
+    return value;
+  }
+
+  TestObject() : threadId_(std::this_thread::get_id()) {
+    ++count();
+  }
+
+  ~TestObject() {
+    --count();
+  }
+
+  std::thread::id threadId() const {
+    return threadId_;
+  }
+
+ private:
+  const std::thread::id threadId_;
+};
+
+TEST(ThreadLocalRegistryTest, basic) {
+  struct Tag {};
+  using T = TestObject<Tag>;
+  ASSERT_EQ(T::count(), 0);
+  auto registry = std::make_shared<ThreadLocalRegistry<T>>();
+  registry->forAllValues([](const T&) { FAIL(); });
+  thread_local ThreadLocalRegistry<T>::Reference ref(registry);
+  const T* object = ref.withValue([](const T& x) {
+    EXPECT_EQ(T::count(), 1);
+    return &x;
+  });
+  ASSERT_EQ(object->threadId(), std::this_thread::get_id());
+  ref.withValue([&](const T& x) { ASSERT_EQ(&x, object); });
+  int count = 0;
+  registry->forAllValues([&](const T& x) {
+    ++count;
+    ASSERT_EQ(x.threadId(), std::this_thread::get_id());
+  });
+  ASSERT_EQ(count, 1);
+  ASSERT_EQ(T::count(), 1);
+}
+
+TEST(ThreadLocalRegistryTest, multiThread) {
+  struct Tag {};
+  using T = TestObject<Tag>;
+  ASSERT_EQ(T::count(), 0);
+  auto registry = std::make_shared<ThreadLocalRegistry<T>>();
+  constexpr int kNumThreads = 7;
+  std::vector<std::thread> threads;
+  folly::Latch latch(kNumThreads);
+  folly::Baton<> batons[kNumThreads];
+  const T* objects[kNumThreads];
+  for (int i = 0; i < kNumThreads; ++i) {
+    threads.emplace_back([&, i] {
+      thread_local ThreadLocalRegistry<T>::Reference ref(registry);
+      objects[i] = ref.withValue([](const T& x) { return &x; });
+      latch.count_down();
+      batons[i].wait();
+    });
+  }
+  latch.wait();
+  std::vector<int> indices;
+  registry->forAllValues([&](const T& x) {
+    auto it = std::find(std::begin(objects), std::end(objects), &x);
+    indices.push_back(it - std::begin(objects));
+  });
+  ASSERT_EQ(indices.size(), kNumThreads);
+  std::sort(indices.begin(), indices.end());
+  for (int i = 0; i < kNumThreads; ++i) {
+    ASSERT_EQ(indices[i], i);
+    ASSERT_EQ(objects[i]->threadId(), threads[i].get_id());
+    ASSERT_EQ(T::count(), kNumThreads - i);
+    batons[i].post();
+    threads[i].join();
+  }
+  ASSERT_EQ(T::count(), 0);
+  registry->forAllValues([](const T&) { FAIL(); });
+}
+
+} // namespace
+} // namespace facebook::velox::process

--- a/velox/common/process/tests/TraceHistoryTest.cpp
+++ b/velox/common/process/tests/TraceHistoryTest.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/process/TraceHistory.h"
+
+#include <fmt/format.h>
+#include <folly/synchronization/Baton.h>
+#include <folly/synchronization/Latch.h>
+#include <gtest/gtest.h>
+
+namespace facebook::velox::process {
+namespace {
+
+class TraceHistoryTest : public testing::Test {
+ public:
+  void SetUp() override {
+    ASSERT_TRUE(TraceHistory::listAll().empty());
+  }
+
+  void TearDown() override {
+    ASSERT_TRUE(TraceHistory::listAll().empty());
+  }
+};
+
+TEST_F(TraceHistoryTest, basic) {
+  std::thread([] {
+    auto timeLow = std::chrono::steady_clock::now();
+    constexpr int kStartLine = __LINE__;
+    for (int i = 0; i < TraceHistory::kCapacity + 10; ++i) {
+      VELOX_TRACE_HISTORY_PUSH("Test %d", i);
+    }
+    auto timeHigh = std::chrono::steady_clock::now();
+    auto results = TraceHistory::listAll();
+    ASSERT_EQ(results.size(), 1);
+    ASSERT_EQ(results[0].threadId, std::this_thread::get_id());
+    ASSERT_EQ(results[0].osTid, folly::getOSThreadID());
+    ASSERT_EQ(results[0].entries.size(), TraceHistory::kCapacity);
+    auto lastTime = timeLow;
+    for (int i = 0; i < TraceHistory::kCapacity; ++i) {
+      auto& entry = results[0].entries[i];
+      ASSERT_EQ(entry.line, kStartLine + 2);
+      ASSERT_STREQ(
+          entry.file + strlen(entry.file) - 20, "TraceHistoryTest.cpp");
+      ASSERT_LE(lastTime, entry.time);
+      lastTime = entry.time;
+      ASSERT_EQ(strncmp(entry.label, "Test ", 5), 0);
+      ASSERT_EQ(atoi(entry.label + 5), i + 10);
+    }
+    ASSERT_LE(lastTime, timeHigh);
+  }).join();
+}
+
+TEST_F(TraceHistoryTest, multiThread) {
+  constexpr int kNumThreads = 3;
+  folly::Latch latch(kNumThreads);
+  folly::Baton<> batons[kNumThreads];
+  std::vector<std::thread> threads;
+  auto timeLow = std::chrono::steady_clock::now();
+  constexpr int kStartLine = __LINE__;
+  for (int i = 0; i < kNumThreads; ++i) {
+    threads.emplace_back([&, i] {
+      VELOX_TRACE_HISTORY_PUSH("Test");
+      VELOX_TRACE_HISTORY_PUSH("Test %d", i);
+      latch.count_down();
+      batons[i].wait();
+    });
+  }
+  latch.wait();
+  auto timeHigh = std::chrono::steady_clock::now();
+  auto results = TraceHistory::listAll();
+  ASSERT_EQ(results.size(), kNumThreads);
+  for (auto& result : results) {
+    auto threadIndex =
+        std::find_if(
+            threads.begin(),
+            threads.end(),
+            [&](auto& t) { return t.get_id() == result.threadId; }) -
+        threads.begin();
+    ASSERT_EQ(result.entries.size(), 2);
+    ASSERT_EQ(result.entries[0].line, kStartLine + 3);
+    ASSERT_EQ(result.entries[1].line, kStartLine + 4);
+    ASSERT_STREQ(result.entries[0].label, "Test");
+    ASSERT_EQ(result.entries[1].label, fmt::format("Test {}", threadIndex));
+    for (auto& entry : result.entries) {
+      ASSERT_LE(timeLow, entry.time);
+      ASSERT_LE(entry.time, timeHigh);
+      ASSERT_TRUE(entry.file);
+      ASSERT_STREQ(
+          entry.file + strlen(entry.file) - 20, "TraceHistoryTest.cpp");
+    }
+  }
+  for (int i = 0; i < kNumThreads; ++i) {
+    ASSERT_EQ(TraceHistory::listAll().size(), kNumThreads - i);
+    batons[i].post();
+    threads[i].join();
+  }
+}
+
+TEST_F(TraceHistoryTest, largeLabel) {
+  std::thread([] {
+    VELOX_TRACE_HISTORY_PUSH(
+        "%s",
+        std::string(TraceHistory::Entry::kLabelCapacity + 10, 'x').c_str());
+    auto results = TraceHistory::listAll();
+    ASSERT_EQ(results.size(), 1);
+    ASSERT_EQ(results[0].entries.size(), 1);
+    ASSERT_EQ(
+        results[0].entries[0].label,
+        std::string(TraceHistory::Entry::kLabelCapacity - 1, 'x'));
+  }).join();
+}
+
+} // namespace
+} // namespace facebook::velox::process

--- a/velox/dwio/common/ColumnLoader.cpp
+++ b/velox/dwio/common/ColumnLoader.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/dwio/common/ColumnLoader.h"
 
+#include "velox/common/process/TraceContext.h"
+
 namespace facebook::velox::dwio::common {
 
 // Wraps '*result' in a dictionary to make the contiguous values
@@ -45,6 +47,7 @@ void ColumnLoader::loadInternal(
     ValueHook* hook,
     vector_size_t resultSize,
     VectorPtr* result) {
+  process::TraceContext trace("ColumnLoader::loadInternal");
   VELOX_CHECK_EQ(
       version_,
       structReader_->numReads(),

--- a/velox/dwio/common/SelectiveColumnReader.cpp
+++ b/velox/dwio/common/SelectiveColumnReader.cpp
@@ -66,6 +66,7 @@ const std::vector<SelectiveColumnReader*>& SelectiveColumnReader::children()
 }
 
 void SelectiveColumnReader::seekTo(vector_size_t offset, bool readsNullsOnly) {
+  VELOX_TRACE_HISTORY_PUSH("seekTo %d %d", offset, readsNullsOnly);
   if (offset == readOffset_) {
     return;
   }

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -18,6 +18,7 @@
 #include "velox/common/base/RawVector.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/common/process/ProcessBase.h"
+#include "velox/common/process/TraceHistory.h"
 #include "velox/dwio/common/ColumnSelector.h"
 #include "velox/dwio/common/FormatData.h"
 #include "velox/dwio/common/IntDecoder.h"
@@ -189,7 +190,8 @@ class SelectiveColumnReader {
   // group. Interpretation of 'index' depends on format. Clears counts
   // of skipped enclosing struct nulls for formats where nulls are
   // recorded at each nesting level, i.e. not rep-def.
-  virtual void seekToRowGroup(uint32_t /*index*/) {
+  virtual void seekToRowGroup(uint32_t index) {
+    VELOX_TRACE_HISTORY_PUSH("seekToRowGroup %u", index);
     numParentNulls_ = 0;
     parentNullsRecordedTo_ = 0;
   }

--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/dwio/common/SelectiveStructColumnReader.h"
 
+#include "velox/common/process/TraceContext.h"
 #include "velox/dwio/common/ColumnLoader.h"
 
 namespace facebook::velox::dwio::common {
@@ -56,6 +57,7 @@ void SelectiveStructColumnReaderBase::next(
     uint64_t numValues,
     VectorPtr& result,
     const Mutation* mutation) {
+  process::TraceContext trace("SelectiveStructColumnReaderBase::next");
   if (children_.empty()) {
     if (mutation && mutation->deletedRows) {
       numValues -= bits::countBits(mutation->deletedRows, 0, numValues);

--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -138,6 +138,7 @@ void SelectiveStructColumnReaderBase::read(
   VELOX_CHECK(!childSpecs.empty());
   for (size_t i = 0; i < childSpecs.size(); ++i) {
     auto& childSpec = childSpecs[i];
+    VELOX_TRACE_HISTORY_PUSH("read %s", childSpec->fieldName().c_str());
     if (isChildConstant(*childSpec)) {
       continue;
     }
@@ -341,6 +342,7 @@ void SelectiveStructColumnReaderBase::getValues(
   }
   bool lazyPrepared = false;
   for (auto& childSpec : scanSpec_->children()) {
+    VELOX_TRACE_HISTORY_PUSH("getValues %s", childSpec->fieldName().c_str());
     if (!childSpec->projectOut()) {
       continue;
     }

--- a/velox/dwio/dwrf/reader/ReaderBase.cpp
+++ b/velox/dwio/dwrf/reader/ReaderBase.cpp
@@ -18,6 +18,7 @@
 
 #include <fmt/format.h>
 
+#include "velox/common/process/TraceContext.h"
 #include "velox/dwio/common/exception/Exception.h"
 
 namespace facebook::velox::dwrf {
@@ -100,6 +101,7 @@ ReaderBase::ReaderBase(
       footerEstimatedSize_(footerEstimatedSize),
       filePreloadThreshold_(filePreloadThreshold),
       input_(std::move(input)) {
+  process::TraceContext trace("ReaderBase::ReaderBase");
   // read last bytes into buffer to get PostScript
   // If file is small, load the entire file.
   // TODO: make a config

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -20,6 +20,7 @@
 #include "velox/common/base/Portability.h"
 #include "velox/common/base/SimdUtil.h"
 #include "velox/common/process/ProcessBase.h"
+#include "velox/common/process/TraceContext.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/vector/VectorTypeUtils.h"
@@ -857,6 +858,7 @@ bool HashTable<ignoreNullKeys>::canApplyParallelJoinBuild() const {
 
 template <bool ignoreNullKeys>
 void HashTable<ignoreNullKeys>::parallelJoinBuild() {
+  process::TraceContext trace("HashTable::parallelJoinBuild");
   TestValue::adjust(
       "facebook::velox::exec::HashTable::parallelJoinBuild", rows_->pool());
   VELOX_CHECK_LE(1 + otherTables_.size(), std::numeric_limits<uint8_t>::max());


### PR DESCRIPTION
Summary:
The new class is created for tracing the history.  Last 16 values are
kept per thread.  Add the tracing to each `TraceContext` constructor, and also
lower level important locations in the reader, e.g. seeking on the column reader
and subfield reading.

Differential Revision: D53198236


