### PR TITLE
Fix outdated comments in MemoryPool

### DIFF
--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -80,33 +80,32 @@ using SetMemoryReclaimer = std::function<void(MemoryPool*)>;
 /// one per each query plan node. The task pool is the parent of all the node
 /// pools from the task's physical query plan fragment. The node pool is created
 /// by the first operator instantiated for the corresponding plan node. It is
-/// owned by Task via 'childPools_'
+/// owned by Task via 'childPools_'.
 ///
 /// The bottom level consists of per-operator pools. These are children of the
 /// node pool that corresponds to the plan node from which the operator is
 /// created. Operator and node pools are owned by the Task via 'childPools_'.
 ///
-/// The query pool is created from MemoryManager::getChild() as a child of a
-/// singleton root pool object (system pool). There is only one system pool for
-/// a velox process. Hence each query pool objects forms a subtree rooted from
-/// the system pool.
+/// The query pool is created from MemoryManager::addRootPool(), it has no
+/// parent. Each query pool is the root node of its corresponding subtree. While
+/// a query pool is owned by QueryCtx, all query pools are recorded in
+/// MemoryManager::pools_ through weak pointers.
 ///
 /// Each child pool object holds a shared reference to its parent pool object.
-/// The parent object tracks its child pool objects through the raw pool object
-/// pointer protected by a mutex. The child pool object destruction first
-/// removes its raw pointer from its parent through dropChild() and then drops
-/// the shared reference on the parent.
+/// The parent object tracks its child pool objects through weak pointers
+/// protected by a mutex. The child pool object destruction first removes its
+/// weak pointer from its parent through dropChild() and then drops the shared
+/// reference on the parent.
 ///
 /// NOTE: for the users that integrate at expression evaluation level, we don't
 /// need to build the memory pool hierarchy as described above. Users can either
-/// create a single memory pool from MemoryManager::getChild() to share with
+/// create a single memory pool from MemoryManager::addLeafPool() to share with
 /// all the concurrent expression evaluations or create one dedicated memory
 /// pool for each expression evaluation if they need per-expression memory quota
 /// enforcement.
 ///
 /// In addition to providing memory allocation functions, the memory pool object
-/// also provides memory usage accounting through MemoryUsageTracker. This will
-/// be merged into memory pool object later.
+/// also provides memory usage accounting.
 class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
  public:
   /// Defines the kinds of a memory pool.
@@ -497,8 +496,9 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
  protected:
   static constexpr uint64_t kMB = 1 << 20;
 
-  /// Invoked by addChild() to create a child memory pool object. 'parent' is
-  /// a shared pointer created from this.
+  /// Invoked by addLeafChild() and addAggregateChild() to create a child memory
+  /// pool object. 'parent' is a shared pointer created from this, ie,
+  /// shared_from_this().
   virtual std::shared_ptr<MemoryPool> genChild(
       std::shared_ptr<MemoryPool> parent,
       const std::string& name,
@@ -530,9 +530,6 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   std::exception_ptr abortError_{nullptr};
 
   mutable folly::SharedMutex poolMutex_;
-  // NOTE: we use raw pointer instead of weak pointer here to minimize
-  // visitChildren() cost as we don't have to upgrade the weak pointer and copy
-  // out the upgraded shared pointers.git
   std::unordered_map<std::string, std::weak_ptr<MemoryPool>> children_;
 
   friend class TestMemoryReclaimer;

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -87,9 +87,10 @@ using SetMemoryReclaimer = std::function<void(MemoryPool*)>;
 /// created. Operator and node pools are owned by the Task via 'childPools_'.
 ///
 /// The query pool is created from MemoryManager::addRootPool(), it has no
-/// parent. Each query pool is the root node of its corresponding subtree. While
-/// a query pool is owned by QueryCtx, all query pools are recorded in
-/// MemoryManager::pools_ through weak pointers.
+/// parent and is the root node of its corresponding subtree. Each query pool is
+/// owned by QueryCtx (such as in Prestissimo), and the memory manager also
+/// tracks the current alive query pools in MemoryManager::pools_ through weak
+/// pointers.
 ///
 /// Each child pool object holds a shared reference to its parent pool object.
 /// The parent object tracks its child pool objects through weak pointers


### PR DESCRIPTION
1. All query pools no longer have the same parent (in fact, they have
   no parent).
2. Each MemoryPool also no longer uses "raw pointers" to record its
   children.
3. MemoryUsageTracker has already been merged into MemoryPool.