### PR TITLE
Remove the notion of encodings from PrestoIterativeVectorSerializer

### DIFF
--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -3320,7 +3320,6 @@ class PrestoIterativeVectorSerializer : public IterativeVectorSerializer {
  public:
   PrestoIterativeVectorSerializer(
       const RowTypePtr& rowType,
-      std::vector<VectorEncoding::Simple> encodings,
       int32_t numRows,
       StreamArena* streamArena,
       bool useLosslessTimestamp,
@@ -3332,40 +3331,10 @@ class PrestoIterativeVectorSerializer : public IterativeVectorSerializer {
     streams_.resize(numTypes);
 
     for (int i = 0; i < numTypes; ++i) {
-      std::optional<VectorEncoding::Simple> encoding = std::nullopt;
-      if (i < encodings.size()) {
-        encoding = encodings[i];
-      }
       streams_[i] = std::make_unique<VectorStream>(
           types[i],
-          encoding,
           std::nullopt,
-          streamArena,
-          numRows,
-          useLosslessTimestamp);
-    }
-  }
-
-  // Constructor that takes a row vector instead of only the types. This is
-  // different because then we know exactly how each vector is encoded
-  // (recursively).
-  PrestoIterativeVectorSerializer(
-      const RowVectorPtr& rowVector,
-      StreamArena* streamArena,
-      bool useLosslessTimestamp,
-      common::CompressionKind compressionKind)
-      : streamArena_(streamArena),
-        codec_(common::compressionKindToCodec(compressionKind)) {
-    auto numRows = rowVector->size();
-    auto rowType = rowVector->type();
-    auto numChildren = rowVector->childrenSize();
-    streams_.resize(numChildren);
-
-    for (int i = 0; i < numChildren; i++) {
-      streams_[i] = std::make_unique<VectorStream>(
-          rowType->childAt(i),
           std::nullopt,
-          rowVector->childAt(i),
           streamArena,
           numRows,
           useLosslessTimestamp);
@@ -3420,16 +3389,6 @@ class PrestoIterativeVectorSerializer : public IterativeVectorSerializer {
     flushStreams(streams_, numRows_, *streamArena_, *codec_, out);
   }
 
-  void flushEncoded(const RowVectorPtr& vector, OutputStream* out) {
-    VELOX_CHECK_EQ(0, numRows_);
-
-    std::vector<IndexRange> ranges{{0, vector->size()}};
-    Scratch scratch;
-    append(vector, folly::Range(ranges.data(), ranges.size()), scratch);
-
-    flushStreams(streams_, vector->size(), *streamArena_, *codec_, out);
-  }
-
  private:
   StreamArena* const streamArena_;
   const std::unique_ptr<folly::io::Codec> codec_;
@@ -3464,7 +3423,6 @@ PrestoVectorSerde::createIterativeSerializer(
   const auto prestoOptions = toPrestoOptions(options);
   return std::make_unique<PrestoIterativeVectorSerializer>(
       type,
-      prestoOptions.encodings,
       numRows,
       streamArena,
       prestoOptions.useLosslessTimestamp,
@@ -3477,20 +3435,6 @@ std::unique_ptr<BatchVectorSerializer> PrestoVectorSerde::createBatchSerializer(
   const auto prestoOptions = toPrestoOptions(options);
   return std::make_unique<PrestoBatchVectorSerializer>(
       pool, prestoOptions.useLosslessTimestamp, prestoOptions.compressionKind);
-}
-
-void PrestoVectorSerde::deprecatedSerializeEncoded(
-    const RowVectorPtr& vector,
-    StreamArena* streamArena,
-    const Options* options,
-    OutputStream* out) {
-  auto prestoOptions = toPrestoOptions(options);
-  auto serializer = std::make_unique<PrestoIterativeVectorSerializer>(
-      vector,
-      streamArena,
-      prestoOptions.useLosslessTimestamp,
-      prestoOptions.compressionKind);
-  serializer->flushEncoded(vector, out);
 }
 
 void PrestoVectorSerde::deserialize(

--- a/velox/serializers/PrestoSerializer.h
+++ b/velox/serializers/PrestoSerializer.h
@@ -58,9 +58,6 @@ class PrestoVectorSerde : public VectorSerde {
     bool useLosslessTimestamp{false};
     common::CompressionKind compressionKind{
         common::CompressionKind::CompressionKind_NONE};
-
-    /// Specifies the encoding for each of the top-level child vector.
-    std::vector<VectorEncoding::Simple> encodings;
   };
 
   /// Adds the serialized sizes of the rows of 'vector' in 'ranges[i]' to
@@ -89,25 +86,6 @@ class PrestoVectorSerde : public VectorSerde {
   std::unique_ptr<BatchVectorSerializer> createBatchSerializer(
       memory::MemoryPool* pool,
       const Options* options) override;
-
-  /// Serializes a single RowVector with possibly encoded children, preserving
-  /// their encodings. Encodings are preserved recursively for any RowVector
-  /// children, but not for children of other nested vectors such as Array, Map,
-  /// and Dictionary.
-  ///
-  /// PrestoPage does not support serialization of Dictionaries with nulls;
-  /// in case dictionaries contain null they are serialized as flat buffers.
-  ///
-  /// In order to override the encodings of top-level columns in the RowVector,
-  /// you can specifiy the encodings using PrestoOptions.encodings
-  ///
-  /// DEPRECATED: Use createBatchSerializer and the BatchVectorSerializer's
-  /// serialize function instead.
-  void deprecatedSerializeEncoded(
-      const RowVectorPtr& vector,
-      StreamArena* streamArena,
-      const Options* options,
-      OutputStream* out);
 
   bool supportsAppendInDeserialize() const override {
     return true;


### PR DESCRIPTION
Summary:
PrestoBatchVectorSerializer supports maintaining encodings while serializing through the BatchVectorSerializer interface.
We no longer need it in PrestoIterativeVectorSerializer which is a little dangerous (e.g. append can be called multiple times
before flush breaking serialization).

Differential Revision: D53202362

