### PR TITLE
Make DuckDbQueryRunner.createTable flush once after all rows are written instead of after every row

### DIFF
--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -891,9 +891,9 @@ void DuckDbQueryRunner::createTable(
   auto res = con.Query(sql);
   verifyDuckDBResult(res, sql);
 
+  ::duckdb::Appender appender(con, name);
   for (auto& vector : data) {
     for (int32_t row = 0; row < vector->size(); row++) {
-      ::duckdb::Appender appender(con, name);
       appender.BeginRow();
       for (int32_t column = 0; column < rowType.size(); column++) {
         auto columnVector = vector->childAt(column);


### PR DESCRIPTION
Summary:
I noticed the tests under ParquetTpchTest run very slowly particularly with TSAN enabled.

I tracked it down to where we create the TPCH tables in DuckDbQueryRunner.createTable, it flushes after every row, which
triggers some code that looks to be particularly affected by TSAN.

Flushing once after all the rows are written makes a huge difference, down from minutes of execution time to under 1 second.

Differential Revision: D53249450


