### PR TITLE
Add InitGoogleTest to ExchangeFuzzer

### DIFF
--- a/velox/exec/tests/ExchangeFuzzer.cpp
+++ b/velox/exec/tests/ExchangeFuzzer.cpp
@@ -404,6 +404,7 @@ class ExchangeFuzzer : public VectorTestBase {
 int32_t ExchangeFuzzer::iteration_;
 
 int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
   folly::Init init{&argc, &argv};
   memory::MemoryManagerOptions options;
   options.useMmapAllocator = true;


### PR DESCRIPTION
Summary:
We call InitGoogleTest in our fuzzer tests so they can be invoked like GTests, including all the flags, even though they're not.

It looks like ExchangeFuzzer is missing this call, so it fails when invoked like a GTest when built in Release mode.

Differential Revision: D53250534


