### PR TITLE
Make copies of Vectors in Values Operator

### DIFF
--- a/velox/exec/Values.cpp
+++ b/velox/exec/Values.cpp
@@ -36,7 +36,10 @@ Values::Values(
   values_.reserve(values->values().size());
   for (auto& vector : values->values()) {
     if (vector->size() > 0) {
-      values_.emplace_back(vector);
+      auto copy = BaseVector::create<RowVector>(
+          vector->type(), vector->size(), vector->pool());
+      copy->copy(vector.get(), 0, 0, vector->size());
+      values_.emplace_back(copy);
     }
   }
 }

--- a/velox/functions/prestosql/aggregates/tests/ApproxMostFrequentTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxMostFrequentTest.cpp
@@ -140,14 +140,16 @@ TEST_F(ApproxMostFrequentTestInt, invalidBuckets) {
   static_cast<memory::MemoryPoolImpl*>(pool())->testingSetCapacity(1 << 21);
   auto run = [&](int64_t buckets) {
     auto rows = makeRowVector({
-        makeConstant<int64_t>(buckets, buckets),
         makeFlatVector<int>(buckets, folly::identity),
-        makeConstant<int64_t>(buckets, buckets),
     });
-    auto plan = exec::test::PlanBuilder()
-                    .values({rows})
-                    .singleAggregation({}, {"approx_most_frequent(c0, c1, c2)"})
-                    .planNode();
+    auto plan =
+        exec::test::PlanBuilder()
+            .values({rows})
+            .singleAggregation(
+                {},
+                {fmt::format(
+                    "approx_most_frequent({}, c0, {})", buckets, buckets)})
+            .planNode();
     return exec::test::AssertQueryBuilder(plan).copyResults(pool());
   };
   ASSERT_EQ(run(10)->size(), 1);

--- a/velox/parse/QueryPlanner.cpp
+++ b/velox/parse/QueryPlanner.cpp
@@ -108,15 +108,18 @@ PlanNodePtr toVeloxPlan(
     QueryContext& queryContext) {
   std::vector<std::string> names;
   std::vector<TypePtr> types;
+  std::vector<VectorPtr> children;
   for (auto i = 0; i < logicalDummyScan.types.size(); ++i) {
     names.push_back(queryContext.nextColumnName());
     types.push_back(duckdb::toVeloxType(logicalDummyScan.types[i]));
+    children.emplace_back(
+        BaseVector::createNullConstant(types.back(), 1, pool));
   }
 
   auto rowType = ROW(std::move(names), std::move(types));
 
-  std::vector<RowVectorPtr> vectors = {std::make_shared<RowVector>(
-      pool, rowType, nullptr, 1, std::vector<VectorPtr>{})};
+  std::vector<RowVectorPtr> vectors = {
+      std::make_shared<RowVector>(pool, rowType, nullptr, 1, children)};
   return std::make_shared<ValuesNode>(queryContext.nextNodeId(), vectors);
 }
 


### PR DESCRIPTION
Summary:
The Values Operator takes a std::vector of RowVectors and simply returns them, it's usually used as a source in test queries.

The std::vector of RowVectors comes from the Plan.  There's a risk of concurrency issues because the std::vector is shared 
across Drivers running on multiple threads.

This is demonstrated by the AssertQueryBuilderTest.concurrency test which currently fails with TSAN. It makes a copy of the
output RowVectors, which are simply the Vectors read from Values, which leads to data races as the field 
containsLazyNotLoaded_ gets updated by the concurrent copies.

Since the Drivers are created on a single thread doing the copies when the Operators are created is thread safe.  Since it's
only done once at Driver startup the cost of the copy is minimal.

Differential Revision: D53251319


