### PR TITLE
Add ignore_missing_files Hive config

### DIFF
--- a/velox/common/base/Exceptions.h
+++ b/velox/common/base/Exceptions.h
@@ -286,12 +286,12 @@ DECLARE_CHECK_FAIL_TEMPLATES(::facebook::velox::VeloxRuntimeError);
       /* isRetriable */ false,                                   \
       ##__VA_ARGS__)
 
-#define VELOX_FILE_NOT_FOUND_ERROR(...)                          \
-  _VELOX_THROW(                                                  \
-      ::facebook::velox::VeloxRuntimeError,                      \
-      ::facebook::velox::error_source::kErrorSourceUser.c_str(), \
-      ::facebook::velox::error_code::kFileNotFound.c_str(),      \
-      /* isRetriable */ false,                                   \
+#define VELOX_FILE_NOT_FOUND_ERROR(...)                             \
+  _VELOX_THROW(                                                     \
+      ::facebook::velox::VeloxRuntimeError,                         \
+      ::facebook::velox::error_source::kErrorSourceRuntime.c_str(), \
+      ::facebook::velox::error_code::kFileNotFound.c_str(),         \
+      /* isRetriable */ false,                                      \
       ##__VA_ARGS__)
 
 #define VELOX_UNREACHABLE(...)                                      \

--- a/velox/common/base/Exceptions.h
+++ b/velox/common/base/Exceptions.h
@@ -286,6 +286,14 @@ DECLARE_CHECK_FAIL_TEMPLATES(::facebook::velox::VeloxRuntimeError);
       /* isRetriable */ false,                                   \
       ##__VA_ARGS__)
 
+#define VELOX_FILE_NOT_FOUND_ERROR(...)                          \
+  _VELOX_THROW(                                                  \
+      ::facebook::velox::VeloxRuntimeError,                      \
+      ::facebook::velox::error_source::kErrorSourceUser.c_str(), \
+      ::facebook::velox::error_code::kFileNotFound.c_str(),      \
+      /* isRetriable */ false,                                   \
+      ##__VA_ARGS__)
+
 #define VELOX_UNREACHABLE(...)                                      \
   _VELOX_THROW(                                                     \
       ::facebook::velox::VeloxRuntimeError,                         \

--- a/velox/common/base/VeloxException.h
+++ b/velox/common/base/VeloxException.h
@@ -105,6 +105,9 @@ inline constexpr auto kSpillLimitExceeded = "SPILL_LIMIT_EXCEEDED"_fs;
 // Errors indicating file read corruptions.
 inline constexpr auto kFileCorruption = "FILE_CORRUPTION"_fs;
 
+// Errors indicating file not found.
+inline constexpr auto kFileNotFound = "FILE_NOT_FOUND"_fs;
+
 // We do not know how to classify it yet.
 inline constexpr auto kUnknown = "UNKNOWN"_fs;
 } // namespace error_code

--- a/velox/common/base/tests/GTestUtils.h
+++ b/velox/common/base/tests/GTestUtils.h
@@ -63,7 +63,7 @@
       << "Expected error message to contain '" << (_errorMessage)          \
       << "', but received '" << status.message() << "'."
 
-#define VELOX_ASSERT_ERROR_CODE(_expression, _type, _errorCode)               \
+#define VELOX_ASSERT_ERROR_CODE_IMPL(_type, _expression, _errorCode)          \
   try {                                                                       \
     (_expression);                                                            \
     FAIL() << "Expected an exception";                                        \
@@ -72,6 +72,18 @@
         << "Expected error code to be '" << _errorCode << "', but received '" \
         << e.errorCode() << "'.";                                             \
   }
+
+#define VELOX_ASSERT_THROW_CODE(_expression, _errorCode) \
+  VELOX_ASSERT_ERROR_CODE_IMPL(                          \
+      facebook::velox::VeloxException, _expression, _errorCode)
+
+#define VELOX_ASSERT_USER_THROW_CODE(_expression, _errorCode) \
+  VELOX_ASSERT_ERROR_CODE_IMPL(                               \
+      facebook::velox::VeloxUserError, _expression, _errorCode)
+
+#define VELOX_ASSERT_RUNTIME_THROW_CODE(_expression, _errorCode) \
+  VELOX_ASSERT_ERROR_CODE_IMPL(                                  \
+      facebook::velox::VeloxRuntimeError, _expression, _errorCode)
 
 #ifndef NDEBUG
 #define DEBUG_ONLY_TEST(test_fixture, test_name) TEST(test_fixture, test_name)

--- a/velox/common/base/tests/GTestUtils.h
+++ b/velox/common/base/tests/GTestUtils.h
@@ -63,6 +63,16 @@
       << "Expected error message to contain '" << (_errorMessage)          \
       << "', but received '" << status.message() << "'."
 
+#define VELOX_ASSERT_ERROR_CODE(_expression, _type, _errorCode)               \
+  try {                                                                       \
+    (_expression);                                                            \
+    FAIL() << "Expected an exception";                                        \
+  } catch (const _type& e) {                                                  \
+    ASSERT_TRUE(e.errorCode() == _errorCode)                                  \
+        << "Expected error code to be '" << _errorCode << "', but received '" \
+        << e.errorCode() << "'.";                                             \
+  }
+
 #ifndef NDEBUG
 #define DEBUG_ONLY_TEST(test_fixture, test_name) TEST(test_fixture, test_name)
 #define DEBUG_ONLY_TEST_F(test_fixture, test_name) \

--- a/velox/common/file/File.cpp
+++ b/velox/common/file/File.cpp
@@ -105,7 +105,7 @@ LocalReadFile::LocalReadFile(std::string_view path) : path_(path) {
   fd_ = open(path_.c_str(), O_RDONLY);
   if (fd_ < 0) {
     if (errno == ENOENT) {
-      VELOX_FILE_NOT_FOUND_ERROR("file {} does not exist", path);
+      VELOX_FILE_NOT_FOUND_ERROR("file {} does not exist.", path);
     } else {
       VELOX_FAIL(
           "open failure in LocalReadFile constructor, {} {} {}.",

--- a/velox/common/file/File.cpp
+++ b/velox/common/file/File.cpp
@@ -105,7 +105,7 @@ LocalReadFile::LocalReadFile(std::string_view path) : path_(path) {
   fd_ = open(path_.c_str(), O_RDONLY);
   if (fd_ < 0) {
     if (errno == ENOENT) {
-      VELOX_FILE_NOT_FOUND_ERROR("file {} does not exist.", path);
+      VELOX_FILE_NOT_FOUND_ERROR("No such file or directory: {}", path);
     } else {
       VELOX_FAIL(
           "open failure in LocalReadFile constructor, {} {} {}.",

--- a/velox/common/file/File.cpp
+++ b/velox/common/file/File.cpp
@@ -103,13 +103,17 @@ uint64_t InMemoryWriteFile::size() const {
 
 LocalReadFile::LocalReadFile(std::string_view path) : path_(path) {
   fd_ = open(path_.c_str(), O_RDONLY);
-  VELOX_CHECK_GE(
-      fd_,
-      0,
-      "open failure in LocalReadFile constructor, {} {} {}.",
-      fd_,
-      path,
-      folly::errnoStr(errno));
+  if (fd_ < 0) {
+    if (errno == ENOENT) {
+      VELOX_FILE_NOT_FOUND_ERROR("file {} does not exist", path);
+    } else {
+      VELOX_FAIL(
+          "open failure in LocalReadFile constructor, {} {} {}.",
+          fd_,
+          path,
+          folly::errnoStr(errno));
+    }
+  }
   const off_t rc = lseek(fd_, 0, SEEK_END);
   VELOX_CHECK_GE(
       rc,

--- a/velox/common/file/tests/FileTest.cpp
+++ b/velox/common/file/tests/FileTest.cpp
@@ -16,6 +16,7 @@
 
 #include <fcntl.h>
 
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/File.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
@@ -322,12 +323,8 @@ TEST(LocalFile, fileNotFound) {
   auto tempFolder = ::exec::test::TempDirectoryPath::create();
   auto path = fmt::format("{}/file", tempFolder->path);
   auto localFs = filesystems::getFileSystem(path, nullptr);
-  {
-    try {
-      LocalReadFile readFile(path);
-      ASSERT_FALSE(true) << "Function should throw.";
-    } catch (VeloxRuntimeError& e) {
-      ASSERT_EQ(e.errorCode(), error_code::kFileNotFound);
-    }
-  }
+  VELOX_ASSERT_ERROR_CODE(
+      localFs->openFileForRead(path),
+      VeloxRuntimeError,
+      error_code::kFileNotFound);
 }

--- a/velox/common/file/tests/FileTest.cpp
+++ b/velox/common/file/tests/FileTest.cpp
@@ -323,8 +323,6 @@ TEST(LocalFile, fileNotFound) {
   auto tempFolder = ::exec::test::TempDirectoryPath::create();
   auto path = fmt::format("{}/file", tempFolder->path);
   auto localFs = filesystems::getFileSystem(path, nullptr);
-  VELOX_ASSERT_ERROR_CODE(
-      localFs->openFileForRead(path),
-      VeloxRuntimeError,
-      error_code::kFileNotFound);
+  VELOX_ASSERT_RUNTIME_THROW_CODE(
+      localFs->openFileForRead(path), error_code::kFileNotFound);
 }

--- a/velox/common/file/tests/FileTest.cpp
+++ b/velox/common/file/tests/FileTest.cpp
@@ -316,3 +316,18 @@ TEST(LocalFile, rmdir) {
   // deleted, which is not an error.
   EXPECT_NO_THROW(localFs->rmdir(tempFolder->path));
 }
+
+TEST(LocalFile, fileNotFound) {
+  filesystems::registerLocalFileSystem();
+  auto tempFolder = ::exec::test::TempDirectoryPath::create();
+  auto path = fmt::format("{}/file", tempFolder->path);
+  auto localFs = filesystems::getFileSystem(path, nullptr);
+  {
+    try {
+      LocalReadFile readFile(path);
+      ASSERT_FALSE(true) << "Function should throw.";
+    } catch (VeloxRuntimeError& e) {
+      ASSERT_EQ(e.errorCode(), error_code::kFileNotFound);
+    }
+  }
+}

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -153,11 +153,7 @@ bool HiveConfig::isPartitionPathAsLowerCase(const Config* session) const {
 }
 
 bool HiveConfig::ignoreMissingFiles(const Config* session) const {
-  if (session->isValueExists(kIgnoreMissingFilesSession)) {
-    return session->get<bool>(kIgnoreMissingFilesSession).value();
-  } else {
-    return false;
-  }
+  return session->get<bool>(kIgnoreMissingFilesSession, false);
 }
 
 int64_t HiveConfig::maxCoalescedBytes() const {

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -152,6 +152,14 @@ bool HiveConfig::isPartitionPathAsLowerCase(const Config* session) const {
   return session->get<bool>(kPartitionPathAsLowerCaseSession, true);
 }
 
+bool HiveConfig::ignoreMissingFiles(const Config* session) const {
+  if (session->isValueExists(kIgnoreMissingFilesSession)) {
+    return session->get<bool>(kIgnoreMissingFilesSession).value();
+  } else {
+    return false;
+  }
+}
+
 int64_t HiveConfig::maxCoalescedBytes() const {
   return config_->get<int64_t>(kMaxCoalescedBytes, 128 << 20);
 }

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -113,6 +113,9 @@ class HiveConfig {
   static constexpr const char* kPartitionPathAsLowerCaseSession =
       "partition_path_as_lower_case";
 
+  static constexpr const char* kIgnoreMissingFilesSession =
+      "ignore_missing_files";
+
   /// The max coalesce bytes for a request.
   static constexpr const char* kMaxCoalescedBytes = "max-coalesced-bytes";
 
@@ -208,6 +211,8 @@ class HiveConfig {
   bool isFileColumnNamesReadAsLowerCase(const Config* session) const;
 
   bool isPartitionPathAsLowerCase(const Config* session) const;
+
+  bool ignoreMissingFiles(const Config* session) const;
 
   int64_t maxCoalescedBytes() const;
 

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -17,6 +17,7 @@
 #include "velox/connectors/hive/SplitReader.h"
 
 #include "velox/common/caching/CacheTTLController.h"
+#include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/HiveConnectorUtil.h"
 #include "velox/connectors/hive/TableHandle.h"
@@ -91,7 +92,19 @@ void SplitReader::prepareSplit(
   VELOX_CHECK_NE(
       baseReaderOpts_.getFileFormat(), dwio::common::FileFormat::UNKNOWN);
 
-  auto fileHandle = fileHandleFactory_->generate(hiveSplit_->filePath).second;
+  std::shared_ptr<FileHandle> fileHandle = nullptr;
+  try {
+    fileHandle = fileHandleFactory_->generate(hiveSplit_->filePath).second;
+  } catch (VeloxRuntimeError& e) {
+    if (e.errorCode() == error_code::kFileNotFound.c_str() &&
+        hiveConfig_->ignoreMissingFiles(
+            connectorQueryCtx_->sessionProperties())) {
+      emptySplit_ = true;
+      return;
+    } else {
+      throw;
+    }
+  }
   // Here we keep adding new entries to CacheTTLController when new fileHandles
   // are generated, if CacheTTLController was created. Creator of
   // CacheTTLController needs to make sure a size control strategy was available

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -92,7 +92,7 @@ void SplitReader::prepareSplit(
   VELOX_CHECK_NE(
       baseReaderOpts_.getFileFormat(), dwio::common::FileFormat::UNKNOWN);
 
-  std::shared_ptr<FileHandle> fileHandle = nullptr;
+  std::shared_ptr<FileHandle> fileHandle;
   try {
     fileHandle = fileHandleFactory_->generate(hiveSplit_->filePath).second;
   } catch (VeloxRuntimeError& e) {

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -139,7 +139,8 @@ TEST(HiveConfigTest, overrideSession) {
       {HiveConfig::kOrcWriterMaxDictionaryMemorySession, "22MB"},
       {HiveConfig::kSortWriterMaxOutputRowsSession, "20"},
       {HiveConfig::kSortWriterMaxOutputBytesSession, "20MB"},
-      {HiveConfig::kPartitionPathAsLowerCaseSession, "false"}};
+      {HiveConfig::kPartitionPathAsLowerCaseSession, "false"},
+      {HiveConfig::kIgnoreMissingFilesSession, "true"}};
   const auto session = std::make_unique<MemConfig>(sessionOverride);
   ASSERT_EQ(
       hiveConfig->insertExistingPartitionsBehavior(session.get()),
@@ -174,4 +175,5 @@ TEST(HiveConfigTest, overrideSession) {
   ASSERT_EQ(hiveConfig->sortWriterMaxOutputRows(session.get()), 20);
   ASSERT_EQ(hiveConfig->sortWriterMaxOutputBytes(session.get()), 20UL << 20);
   ASSERT_EQ(hiveConfig->isPartitionPathAsLowerCase(session.get()), false);
+  ASSERT_EQ(hiveConfig->ignoreMissingFiles(session.get()), true);
 }

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -424,6 +424,11 @@ Each query can override the config by setting corresponding query session proper
      - bool
      - true
      - If true, the partition directory will be converted to lowercase when executing a table write operation.
+   * - ignore_missing_files
+     -
+     - bool
+     - false
+     - If true, the task will continue to run when encountering missing files and the split woule be marked as empty split.
    * - max-coalesced-bytes
      -
      - integer

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -428,7 +428,7 @@ Each query can override the config by setting corresponding query session proper
      -
      - bool
      - false
-     - If true, the task will continue to run when encountering missing files and the split woule be marked as empty split.
+     - If true, splits that refer to missing files don't generate errors and are processed as empty splits.
    * - max-coalesced-bytes
      -
      - integer


### PR DESCRIPTION
Spark provides support for the data source configuration 
`spark.sql.files.ignoreMissingFiles`, to ignore missing files while reading data 
from files. 
https://spark.apache.org/docs/latest/sql-data-sources-generic-options.html#ignore-missing-files

Introduce Hive config ignore_missing_files to match this behavior. 