### PR TITLE
Eliminate redundant Expr::addNulls calls

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1122,7 +1122,7 @@ bool Expr::removeSureNulls(
   }
   if (result) {
     result->updateBounds();
-    return true;
+    return result->countSelected() != rows.countSelected();
   }
   return false;
 }
@@ -1441,7 +1441,7 @@ void Expr::evalAllImpl(
 
   // Write non-selected rows in remainingRows as nulls in the result if some
   // rows have been skipped.
-  if (remainingRows.mayHaveChanged()) {
+  if (remainingRows.hasChanged()) {
     addNulls(rows, remainingRows.rows().asRange().bits(), context, result);
   }
   releaseInputValues(context);

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -119,13 +119,12 @@ class MutableRemainingRows {
     return mutableRows_->hasSelections();
   }
 
-  /// @return true if current set of rows might be different from the original
+  /// @return true if current set of rows is different from the original
   /// set of rows, which may happen if deselectNull() or deselectErrors() were
-  /// called. May return 'true' even if current set of rows is the same as
-  /// original set. Returns 'false' only if current set of rows is for sure the
-  /// same as original.
-  bool mayHaveChanged() const {
-    return mutableRows_ != nullptr && !mutableRows_->isAllSelected();
+  /// called.
+  bool hasChanged() const {
+    return mutableRows_ != nullptr &&
+        mutableRows_->countSelected() != originalRows_->countSelected();
   }
 
  private:

--- a/velox/functions/prestosql/TransformKeys.cpp
+++ b/velox/functions/prestosql/TransformKeys.cpp
@@ -80,7 +80,8 @@ class TransformKeysFunction : public exec::VectorFunction {
           elementToTopLevelRows,
           &transformedKeys);
 
-      if (transformedKeys->mayHaveNulls()) {
+      if (transformedKeys->mayHaveNulls() ||
+          transformedKeys->mayHaveNullsRecursive()) {
         static const char* kNullKeyErrorMessage = "map key cannot be null";
         static const char* kIndeterminateKeyErrorMessage =
             "map key cannot be indeterminate";


### PR DESCRIPTION
Summary:
Expr::addNulls can be expensive as it my require making vector writable by
copying it into a new vector. Hence, it is important to make sure not to call
it if there are no nulls to add. 

This change avoids calling Expr::addNulls unnecessarily by tightening checks for
new nulls in MutableRemainingRows::mayHaveChanged and Expr::removeSureNulls.
Rename MutableRemainingRows::mayHaveChanged to hasChanged to match new
behavior.

This optimization reduces expression evaluation CPU and wall time 2x for one of
the affected queries.

This change uncovered a bug in tranform_keys Presto lambda function. The check
for keys containing nulls was incorrectly skipped if there were no null keys. This change
includes a fix.

Differential Revision: D53264651


