### PR TITLE
Fix folly::dynamic mismatch in driverObj

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2155,7 +2155,9 @@ folly::dynamic Task::toJson() const {
   folly::dynamic driverObj = folly::dynamic::array;
   int index = 0;
   for (auto& driver : drivers_) {
-    driverObj[std::to_string(index++)] = driver ? driver->toJson() : "null";
+    if (driver) {
+      driverObj[index++] = driver->toJson();
+    }
   }
   obj["drivers"] = driverObj;
 


### PR DESCRIPTION
Summary: driverObj is declared as folly::dynamic::array but we are trying to create elements using std::string. Changing it to object to fix the issue

Differential Revision: D53292507


