### PR TITLE
Fix incorrect result of first_value/last_value functions

### DIFF
--- a/velox/functions/prestosql/window/FirstLastValue.cpp
+++ b/velox/functions/prestosql/window/FirstLastValue.cpp
@@ -127,11 +127,13 @@ class FirstLastValueFunction : public exec::WindowFunction {
       // The function returns null for this case. -1 correctly maps to
       // kNullRow as expected for rowNumbers_ extraction.
       if constexpr (TValue == ValueType::kFirst) {
-        rowNumbers_[i] = bits::findFirstBit(
+        auto position = bits::findFirstBit(
             rawNonNulls, frameStart - leastFrame, frameEnd - leastFrame + 1);
+        rowNumbers_[i] = (position == -1) ? -1 : position + leastFrame;
       } else {
-        rowNumbers_[i] = bits::findLastBit(
+        auto position = bits::findLastBit(
             rawNonNulls, frameStart - leastFrame, frameEnd - leastFrame + 1);
+        rowNumbers_[i] = (position == -1) ? -1 : position + leastFrame;
       }
     });
   }

--- a/velox/functions/prestosql/window/tests/NthValueTest.cpp
+++ b/velox/functions/prestosql/window/tests/NthValueTest.cpp
@@ -335,6 +335,32 @@ TEST_F(NthValueTest, ignoreNulls) {
   }
 }
 
+TEST_F(NthValueTest, frameStartsFromFollowing) {
+  auto input = makeRowVector({
+      makeNullableFlatVector<int64_t>({1, std::nullopt, 2}),
+      makeFlatVector<bool>({false, false, false}),
+      makeFlatVector<int64_t>({1, 2, 3}),
+  });
+  auto expected = makeRowVector(
+      {makeNullableFlatVector<int64_t>({1, std::nullopt, 2}),
+       makeFlatVector<bool>({false, false, false}),
+       makeFlatVector<int64_t>({1, 2, 3}),
+       makeNullableFlatVector<int64_t>({2, 2, std::nullopt})});
+
+  WindowTestBase::testWindowFunction(
+      {input},
+      "first_value(c0 IGNORE NULLS)",
+      "partition by c1 order by c2",
+      "rows between 1 following and unbounded following",
+      expected);
+  WindowTestBase::testWindowFunction(
+      {input},
+      "last_value(c0 IGNORE NULLS)",
+      "partition by c1 order by c2",
+      "rows between 1 following and unbounded following",
+      expected);
+}
+
 // These tests are added since DuckDB has issues with
 // CURRENT ROW frames. These tests will be replaced by DuckDB based
 // tests after it is upgraded to v0.8.


### PR DESCRIPTION
Summary:
The first_value and last_value functions produce incorrect results when used with 
IGNORE NULLS and when the frame doesn't start from the first row. In this situation, 
FirstLastValueFunction::setRowNumbersIgnoreNulls() attemps to find the index of 
the first non-null value from `leastFrame` to `leastFrame + frameSize`. But 
the index found is relative to `leastFrame`, so setRowNumbersIgnoreNulls() should 
add leastFrame to the index before returning it.

This diff fixes https://github.com/facebookincubator/velox/issues/8427.

Differential Revision: D53295212


