### PR TITLE
Allow serializeEncode to accept ranges from callers

### DIFF
--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -3173,14 +3173,16 @@ class PrestoVectorSerializer : public VectorSerializer {
     flushInternal(numRows_, out);
   }
 
-  void flushEncoded(const RowVectorPtr& vector, OutputStream* out) {
+  void flushEncoded(
+      const RowVectorPtr& vector,
+      const folly::Range<const IndexRange*>& ranges,
+      OutputStream* out) {
     VELOX_CHECK_EQ(0, numRows_);
 
-    std::vector<IndexRange> ranges{{0, vector->size()}};
     Scratch scratch;
-    append(vector, folly::Range(ranges.data(), ranges.size()), scratch);
+    append(vector, ranges, scratch);
 
-    flushInternal(vector->size(), out);
+    flushInternal(numRows_, out);
   }
 
  private:
@@ -3356,6 +3358,7 @@ std::unique_ptr<VectorSerializer> PrestoVectorSerde::createSerializer(
 
 void PrestoVectorSerde::serializeEncoded(
     const RowVectorPtr& vector,
+    const folly::Range<const IndexRange*>& ranges,
     StreamArena* streamArena,
     const Options* options,
     OutputStream* out) {
@@ -3365,7 +3368,7 @@ void PrestoVectorSerde::serializeEncoded(
       streamArena,
       prestoOptions.useLosslessTimestamp,
       prestoOptions.compressionKind);
-  serializer->flushEncoded(vector, out);
+  serializer->flushEncoded(vector, ranges, out);
 }
 
 void PrestoVectorSerde::deserialize(

--- a/velox/serializers/PrestoSerializer.h
+++ b/velox/serializers/PrestoSerializer.h
@@ -95,9 +95,24 @@ class PrestoVectorSerde : public VectorSerde {
   /// you can specifiy the encodings using PrestoOptions.encodings
   void serializeEncoded(
       const RowVectorPtr& vector,
+      const folly::Range<const IndexRange*>& ranges,
       StreamArena* streamArena,
       const Options* options,
       OutputStream* out);
+
+  void serializeEncoded(
+      const RowVectorPtr& vector,
+      StreamArena* streamArena,
+      const Options* options,
+      OutputStream* out) {
+    std::vector<IndexRange> ranges{{0, vector->size()}};
+    serializeEncoded(
+        vector,
+        folly::Range(ranges.data(), ranges.size()),
+        streamArena,
+        options,
+        out);
+  }
 
   bool supportsAppendInDeserialize() const override {
     return true;


### PR DESCRIPTION
Summary:
Right now, the serializeEncoded path in the PrestoSerializer does not allow for the caller to specify the ranges of rows in their call to serialize.

This is a departure from the previous behavior where creating a serializer and using ->append() allowed for specifying ranges. 

This diff adds that functionality back, but leaves the option for the caller to not specify ranges, and uses a default full set of ranges if so.

Differential Revision: D53276501


