### PR TITLE
Disable pyvelox wheels build in macos temporarily.

### DIFF
--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-11]
+        os: [ubuntu-22.04]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
We are seeing pyvelox wheel builds fail on MacOS ( see issue [8635](https://github.com/facebookincubator/velox/issues/8635) ). This PR disables these builds while we investigate a fix. 