### PR TITLE
Fix arbitrary() to always return the first non-null value in Window operation

### DIFF
--- a/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
@@ -226,6 +226,11 @@ class NonNumericArbitrary : public exec::Aggregate {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool /*unused*/) override {
+    auto* accumulator = value<SingleValueAccumulator>(group);
+    if (accumulator->hasValue()) {
+      return;
+    }
+
     DecodedVector decoded(*args[0], rows, true);
     if (decoded.isConstantMapping() && decoded.isNullAt(0)) {
       // nothing to do; all values are nulls
@@ -234,7 +239,6 @@ class NonNumericArbitrary : public exec::Aggregate {
 
     const auto* indices = decoded.indices();
     const auto* baseVector = decoded.base();
-    auto* accumulator = value<SingleValueAccumulator>(group);
     // Find the first non-null value.
     rows.testSelected([&](vector_size_t i) {
       if (!decoded.isNullAt(i)) {

--- a/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -64,6 +64,7 @@ target_link_libraries(
   velox_file
   velox_functions_aggregates
   velox_functions_aggregates_test_lib
+  velox_functions_window_test_lib
   velox_functions_test_lib
   velox_functions_prestosql
   velox_functions_lib


### PR DESCRIPTION
Summary:
The implementation of arbitrary() intends to always return the first non-null value, but it 
doesn't for complex-typed inputs when used in Window operation with incremental frames.
This is because ArbitraryFunction::addSingleGroupRawInput() still updates the accumulator 
even if the accumulator already has a value. This diff fixes this issue by making 
ArbitraryFunction::addSingleGroupRawInput() return immediately if accumulator already has 
a value.

This diff fixes https://github.com/facebookincubator/velox/issues/8593.

Differential Revision: D53328253


