### PR TITLE
Enable parse_url for SparkSQL

### DIFF
--- a/velox/docs/functions/spark/url.rst
+++ b/velox/docs/functions/spark/url.rst
@@ -5,24 +5,27 @@ URL Functions
 Introduction
 ------------
 
-The URL extraction function extracts components from HTTP URLs (or any valid URIs conforming to `RFC 3986 <https://tools.ietf.org/html/rfc3986.html>`_). The following syntax is supported:
+The URL extraction functions extract components from HTTP URLs (or any valid URIs conforming to `RFC 3986 <https://tools.ietf.org/html/rfc3986.html>`_). The following syntax is supported:
 
 .. code-block:: bash
 
-    [protocol:][//host[:port]][path][?query][#fragment]
+    [protocol]://[[userinfo@]host[:port]][[path][?query]][#ref]
 
 
 Consider for example the below URI:
 
 .. code-block::
 
-    http://www.ics.uci.edu/pub/ietf/uri/?k1=v1#Related
+    http://user:pass@example.com:8080/path1/p.php?k1=v1&k2=v2#Ref1
 
-    scheme    = http
-    authority = www.ics.uci.edu
-    path      = /pub/ietf/uri/
-    query     = k1=v1
-    fragment  = Related
+    protocol  = http
+    host      = example.com
+    path      = /path1/p.php
+    userinfo  = user:pass
+    authority = user:pass@example.com:8080
+    file      = /path1/p.php?k1=v1&k2=v2
+    query     = k1=v1&k2=v2
+    ref       = Ref1
 
 
 Invalid URI's
@@ -36,25 +39,29 @@ digits after the percent character "%". All the url extract functions will retur
     # Examples of url functions with Invalid URI's.
 
     # Invalid URI due to whitespace
-    SELECT url_extract_path('foo '); -- NULL (1 row)
-    SELECT url_extract_host('http://www.foo.com '); -- NULL (1 row)
+    SELECT parse_url('foo ', 'FILE'); -- NULL (1 row)
+    SELECT parse_url('http://www.foo.com ', 'FILE'); -- NULL (1 row)
 
     # Invalid URI due to improper escaping of '%'
-    SELECT url_extract_path('https://www.ucu.edu.uy/agenda/evento/%%UCUrlCompartir%%'); -- NULL (1 row)
-    SELECT url_extract_host('https://www.ucu.edu.uy/agenda/evento/%%UCUrlCompartir%%'); -- NULL (1 row)
+    SELECT parse_url('https://www.ucu.edu.uy/agenda/evento/%%UCUrlCompartir%%', 'FILE'); -- NULL (1 row)
+    SELECT parse_url('https://www.ucu.edu.uy/agenda/evento/%%UCUrlCompartir%%', 'FILE'); -- NULL (1 row)
 
 .. spark:function:: parse_url(string, partToExtract) -> varchar
 
     Extracts a part from a URL. The part to extract can be one of the following:
 
+    * `PROTOCOL`: The protocol.
     * `HOST`: The host name.
     * `PATH`: The path.
+    * `USERINFO` : The username and/or password.
+    * `AUTHORITY` : The host and optionally userinfo and/or port.
+    * `FILE` : The file.
     * `QUERY`: The query.
-    * `FRAGMENT`: The fragment.
-    * `PROTOCOL`: The protocol.
+    * `REF` : The reference.
+
 
     :param string: The URL to extract the part from.
-    :param partToExtract: The part to extract from the URL.
+    :param partToExtract: The part to extract from the URL. Must be uppercase, lowercase values will return null.
     :return: The extracted part of the URL.
 
     .. code-block:: sql
@@ -68,7 +75,7 @@ digits after the percent character "%". All the url extract functions will retur
         SELECT parse_url('http://www.ics.uci.edu/pub/ietf/uri/?k1=v1#Related', 'QUERY');
         -- k1=v1
 
-        SELECT parse_url('http://www.ics.uci.edu/pub/ietf/uri/?k1=v1#Related', 'FRAGMENT');
+        SELECT parse_url('http://www.ics.uci.edu/pub/ietf/uri/?k1=v1#Related', 'REF');
         -- Related
 
         SELECT parse_url('http://www.ics.uci.edu/pub/ietf/uri/?k1=v1#Related', 'PROTOCOL');

--- a/velox/docs/functions/spark/url.rst
+++ b/velox/docs/functions/spark/url.rst
@@ -1,0 +1,92 @@
+============================
+URL Functions
+============================
+
+Introduction
+------------
+
+The URL extraction function extracts components from HTTP URLs (or any valid URIs conforming to `RFC 3986 <https://tools.ietf.org/html/rfc3986.html>`_). The following syntax is supported:
+
+.. code-block:: bash
+
+    [protocol:][//host[:port]][path][?query][#fragment]
+
+
+Consider for example the below URI:
+
+.. code-block::
+
+    http://www.ics.uci.edu/pub/ietf/uri/?k1=v1#Related
+
+    scheme    = http
+    authority = www.ics.uci.edu
+    path      = /pub/ietf/uri/
+    query     = k1=v1
+    fragment  = Related
+
+
+Invalid URI's
+-------------
+
+Well formed URI's should not contain ascii whitespace. `Percent-encoded URI's <https://www.rfc-editor.org/rfc/rfc3986#section-2.1>`_ should be followed by two hexadecimal
+digits after the percent character "%". All the url extract functions will return null when passed an invalid uri.
+
+.. code-block::
+
+    # Examples of url functions with Invalid URI's.
+
+    # Invalid URI due to whitespace
+    SELECT url_extract_path('foo '); -- NULL (1 row)
+    SELECT url_extract_host('http://www.foo.com '); -- NULL (1 row)
+
+    # Invalid URI due to improper escaping of '%'
+    SELECT url_extract_path('https://www.ucu.edu.uy/agenda/evento/%%UCUrlCompartir%%'); -- NULL (1 row)
+    SELECT url_extract_host('https://www.ucu.edu.uy/agenda/evento/%%UCUrlCompartir%%'); -- NULL (1 row)
+
+.. spark:function:: parse_url(string, partToExtract) -> varchar
+
+    Extracts a part from a URL. The part to extract can be one of the following:
+
+    * `HOST`: The host name.
+    * `PATH`: The path.
+    * `QUERY`: The query.
+    * `FRAGMENT`: The fragment.
+    * `PROTOCOL`: The protocol.
+
+    :param string: The URL to extract the part from.
+    :param partToExtract: The part to extract from the URL.
+    :return: The extracted part of the URL.
+
+    .. code-block:: sql
+
+        SELECT parse_url('http://www.ics.uci.edu/pub/ietf/uri/?k1=v1#Related', 'HOST');
+        -- www.ics.uci.edu
+
+        SELECT parse_url('http://www.ics.uci.edu/pub/ietf/uri/?k1=v1#Related', 'PATH');
+        -- /pub/ietf/uri/
+
+        SELECT parse_url('http://www.ics.uci.edu/pub/ietf/uri/?k1=v1#Related', 'QUERY');
+        -- k1=v1
+
+        SELECT parse_url('http://www.ics.uci.edu/pub/ietf/uri/?k1=v1#Related', 'FRAGMENT');
+        -- Related
+
+        SELECT parse_url('http://www.ics.uci.edu/pub/ietf/uri/?k1=v1#Related', 'PROTOCOL');
+        -- http
+
+.. spark:function:: parse_url(string, partToExtract, key) -> varchar
+
+    Extracts a part from a URL. The part to extract must be QUERY, otherwise function will return null:
+
+    :param string: The URL to extract the part from.
+    :param partToExtract: The part to extract from the URL.
+    :param key: The key to extract from the query part of the URL.
+    :return: The extracted part of the URL.
+
+    .. code-block:: sql
+
+        SELECT parse_url('http://www.ics.uci.edu/pub/ietf/uri/?k1=v1#Related', 'QUERY', 'k1');
+        -- v1
+
+        SELECT parse_url('http://www.ics.uci.edu/pub/ietf/uri/?k1=v1#Related', 'PROTOCOL', 'k2');
+        -- NULL

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -41,6 +41,7 @@
 #include "velox/functions/sparksql/SparkPartitionId.h"
 #include "velox/functions/sparksql/String.h"
 #include "velox/functions/sparksql/StringToMap.h"
+#include "velox/functions/sparksql/URLFunctions.h"
 #include "velox/functions/sparksql/UnscaledValueFunction.h"
 #include "velox/functions/sparksql/Uuid.h"
 #include "velox/functions/sparksql/specialforms/DecimalRound.h"
@@ -387,6 +388,11 @@ void registerFunctions(const std::string& prefix) {
   // Register bloom filter function
   registerFunction<BloomFilterMightContainFunction, bool, Varbinary, int64_t>(
       {prefix + "might_contain"});
+
+  registerFunction<ParseUrlFunction, Varchar, Varchar, Varchar>(
+      {prefix + "parse_url"});
+  registerFunction<ParseUrlFunction, Varchar, Varchar, Varchar, Varchar>(
+      {prefix + "parse_url"});
 
   registerArrayMinMaxFunctions(prefix);
 

--- a/velox/functions/sparksql/URLFunctions.h
+++ b/velox/functions/sparksql/URLFunctions.h
@@ -1,0 +1,310 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <boost/regex.hpp>
+#include <folly/CPortability.h>
+#include <cctype>
+#include "velox/functions/Macros.h"
+
+namespace facebook::velox::functions::sparksql {
+namespace {
+
+/// Performs initial validation of the URI.
+/// Checks if the URI contains ascii whitespaces or
+/// unescaped '%' chars.
+bool isValidURI(StringView input) {
+  const char* p = input.data();
+  const char* end = p + input.size();
+  char buf[3];
+  buf[2] = '\0';
+  char* endptr;
+  for (; p < end; ++p) {
+    if (facebook::velox::functions::stringImpl::isAsciiWhiteSpace(*p)) {
+      return false;
+    }
+
+    if (*p == '%') {
+      if (p + 2 < end) {
+        buf[0] = p[1];
+        buf[1] = p[2];
+        strtol(buf, &endptr, 16);
+        p += 2;
+        if (endptr != buf + 2) {
+          return false;
+        }
+      } else {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+static const boost::regex kUriRegex(
+    "(([a-zA-Z][a-zA-Z0-9+.-]*):)?" // scheme:
+    "([^?#]*)" // authority and path
+    "(?:\\?([^#]*))?" // ?query
+    "(?:#(.*))?"); // #fragment
+template <typename T>
+T submatch(const boost::cmatch& match, int indx);
+
+template <>
+FOLLY_ALWAYS_INLINE std::string_view submatch(
+    const boost::cmatch& match,
+    int idx) {
+  const auto& sub = match[idx];
+  return std::string_view(sub.first, sub.length());
+}
+
+template <>
+FOLLY_ALWAYS_INLINE StringView submatch(const boost::cmatch& match, int idx) {
+  const auto& sub = match[idx];
+  return StringView(sub.first, sub.length());
+}
+
+template <typename TInString>
+bool parse(const TInString& rawUrl, boost::cmatch& match) {
+  if (!isValidURI(rawUrl)) {
+    return false;
+  }
+  return boost::regex_match(
+      rawUrl.data(), rawUrl.data() + rawUrl.size(), match, kUriRegex);
+}
+// PARSE_URL(url, partToExtract) → string
+// PARSE_URL(url, partToExtract, key) → string
+//
+// Extracts a part of a URL. The partToExtract argument can be one of
+// 'PROTOCOL', 'HOST', 'PATH', 'REF', 'AUTHORITY', 'FILE', 'USERINFO',
+// 'QUERY', 'FRAGMENT'.
+//
+// If the URL is invalid, return null.
+template <typename T>
+struct ParseUrlFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // Results refer to strings in the first argument.
+  static constexpr int32_t reuse_strings_from_arg = 0;
+
+  // ASCII input always produces ASCII result.
+  static constexpr bool is_default_ascii_behavior = true;
+
+  static constexpr int kAuthPath = 3;
+  static constexpr int kQuery = 4;
+  static constexpr int kHost = 3;
+  static constexpr int kProto = 2;
+  static constexpr int kRef = 5;
+  // submatch indexes for authorityMatch
+  static constexpr int kPathHasAuth = 2;
+  static constexpr int kPathNoAuth = 3;
+  static constexpr int kUser = 1;
+  static constexpr int kPass = 2;
+  static constexpr int kPort = 4;
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& url,
+      const arg_type<Varchar>& partToExtract) {
+    boost::cmatch match;
+    if (!parse(url, match)) {
+      return false;
+    }
+    if (partToExtract == "PROTOCOL") {
+      return simpleMatch(match, kProto, result);
+    } else if (partToExtract == "QUERY") {
+      return simpleMatch(match, kQuery, result);
+    } else if (partToExtract == "REF") {
+      return simpleMatch(match, kRef, result);
+    }
+
+    boost::cmatch authAndPathMatch;
+    boost::cmatch authorityMatch;
+    bool hasAuthority = false;
+    if (!matchAuthorityAndPath(
+            match, authAndPathMatch, authorityMatch, hasAuthority)) {
+      return false;
+    } else if (partToExtract == "HOST") {
+      if (!hasAuthority) {
+        return false;
+      }
+      return simpleMatch(authorityMatch, kHost, result);
+    } else if (partToExtract == "PATH") {
+      std::string_view path = submatch<std::string_view>(match, kAuthPath);
+      if (hasAuthority) {
+        path = submatch<std::string_view>(authAndPathMatch, 2);
+      }
+      result.setNoCopy(StringView(path.data(), path.size()));
+      return true;
+    }
+    // Path[?Query].
+    else if (partToExtract == "FILE") {
+      std::string_view path = submatch<std::string_view>(match, kAuthPath);
+      if (hasAuthority) {
+        path = submatch<std::string_view>(authAndPathMatch, 2);
+      }
+      std::string_view query = submatch<std::string_view>(match, kQuery);
+      if (!query.empty()) {
+        result.setNoCopy(StringView(
+            path.data(), (query.data() + query.size()) - path.data()));
+      } else {
+        result.setNoCopy(StringView(path.data(), path.size()));
+      }
+      return true;
+    }
+
+    // Username[:Password].
+    else if (partToExtract == "USERINFO") {
+      if (!hasAuthority) {
+        return false;
+      }
+      std::string_view username = submatch<std::string_view>(authorityMatch, 1);
+      std::string_view password = submatch<std::string_view>(authorityMatch, 2);
+      if (!password.empty()) {
+        result.setNoCopy(
+            StringView(username.data(), password.end() - username.begin()));
+        return true;
+      } else if (!username.empty()) {
+        result.setNoCopy(StringView(username.data(), username.size()));
+        return true;
+      } else {
+        return false;
+      }
+    }
+    // [Userinfo@]Host[:Port].
+    else if (partToExtract == "AUTHORITY") {
+      if (!hasAuthority) {
+        return false;
+      }
+      std::string_view host = submatch<std::string_view>(authorityMatch, kHost);
+      std::string_view first = host;
+      std::string_view last = host;
+
+      std::string_view username = submatch<std::string_view>(authorityMatch, 1);
+      std::string_view port = submatch<std::string_view>(authorityMatch, 4);
+      if (!username.empty()) {
+        first = username;
+      }
+      if (!port.empty()) {
+        last = port;
+      }
+      result.setNoCopy(StringView(first.data(), last.end() - first.begin()));
+      return true;
+    }
+
+    return false;
+  }
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& url,
+      const arg_type<Varchar>& partToExtract,
+      const arg_type<Varchar>& key) {
+    // Only "QUERY" support the third parameter.
+    if (partToExtract != "QUERY") {
+      return false;
+    }
+    if (key.empty()) {
+      return false;
+    }
+
+    boost::cmatch match;
+    if (!parse(url, match)) {
+      return false;
+    }
+
+    // Parse query string.
+    static const boost::regex kQueryParamRegex(
+        "(^|&)" // start of query or start of parameter "&"
+        "([^=&]*)=?" // parameter name and "=" if value is expected
+        "([^=&]*)" // parameter value
+        "(?=(&|$))" // forward reference, next should be end of query or
+                    // start of next parameter
+    );
+
+    auto query = submatch<StringView>(match, kQuery);
+    const boost::cregex_iterator begin(
+        query.data(), query.data() + query.size(), kQueryParamRegex);
+    boost::cregex_iterator end;
+
+    for (auto it = begin; it != end; ++it) {
+      if (it->length(2) != 0) { // key shouldn't be empty.
+        auto k = submatch<StringView>((*it), 2);
+        if (key.compare(k) == 0) {
+          auto value = submatch<StringView>((*it), 3);
+          if (value != "") {
+            result.setNoCopy(value);
+            return true;
+          } else {
+            return false;
+          }
+        }
+      }
+    }
+
+    return false;
+  }
+
+ private:
+  FOLLY_ALWAYS_INLINE bool matchAuthorityAndPath(
+      const boost::cmatch& urlMatch,
+      boost::cmatch& authAndPathMatch,
+      boost::cmatch& authorityMatch,
+      bool& hasAuthority) {
+    static const boost::regex kAuthorityAndPathRegex("//([^/]*)(/.*)?");
+    auto authorityAndPath = submatch<StringView>(urlMatch, kAuthPath);
+    if (!boost::regex_match(
+            authorityAndPath.begin(),
+            authorityAndPath.end(),
+            authAndPathMatch,
+            kAuthorityAndPathRegex)) {
+      // Does not start with //, doesn't have authority.
+      hasAuthority = false;
+      return true;
+    }
+
+    static const boost::regex kAuthorityRegex(
+        "(?:([^@:]*)(?::([^@]*))?@)?" // username, password.
+        "(\\[[^\\]]*\\]|[^\\[:]*)" // host (IP-literal (e.g. '['+IPv6+']',
+        // dotted-IPv4, or named host).
+        "(?::(\\d*))?"); // port.
+
+    const auto authority = authAndPathMatch[1];
+    if (!boost::regex_match(
+            authority.first,
+            authority.second,
+            authorityMatch,
+            kAuthorityRegex)) {
+      return false; // Invalid URI Authority.
+    }
+
+    hasAuthority = true;
+    return true;
+  }
+  FOLLY_ALWAYS_INLINE bool simpleMatch(
+      const boost::cmatch& urlMatch,
+      const int index,
+      out_type<Varchar>& result) {
+    std::string_view sub = submatch<std::string_view>(urlMatch, index);
+    if (sub.empty()) {
+      return false;
+    }
+    result.setNoCopy(StringView(sub.data(), sub.size()));
+    return true;
+  }
+};
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(
   StringToMapTest.cpp
   UnscaledValueFunctionTest.cpp
   UuidTest.cpp
+  URLFunctionsTest.cpp
   XxHash64Test.cpp)
 
 add_test(velox_functions_spark_test velox_functions_spark_test)

--- a/velox/functions/sparksql/tests/URLFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/URLFunctionsTest.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <gmock/gmock.h>
 #include <optional>
 
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"

--- a/velox/functions/sparksql/tests/URLFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/URLFunctionsTest.cpp
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gmock/gmock.h>
+#include <optional>
+
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+namespace facebook::velox::functions::sparksql::test {
+
+namespace {
+std::optional<std::string> operator+(
+    const std::optional<std::string>& opt1,
+    const std::optional<std::string>& opt2) {
+  if (!opt1.has_value()) {
+    return opt2;
+  }
+  if (!opt2.has_value()) {
+    return opt1;
+  }
+  return opt1.value() + opt2.value();
+}
+
+std::optional<std::string> operator&(
+    const std::optional<std::string>& opt1,
+    const std::optional<std::string>& opt2) {
+  if (!opt1.has_value() || !opt2.has_value()) {
+    return std::nullopt;
+  }
+  return opt1.value() + opt2.value();
+}
+
+class URLFunctionsTest
+    : public functions::sparksql::test::SparkFunctionBaseTest {
+ protected:
+  void validate(
+      const std::optional<std::string>& url,
+      const std::optional<std::string>& expectedProtocol,
+      const std::optional<std::string>& expectedUserinfo,
+      const std::optional<std::string>& expectedHost,
+      const std::optional<std::string>& expectedPort,
+      const std::optional<std::string>& expectedPath,
+      const std::optional<std::string>& expectedQuery,
+      const std::optional<std::string>& expectedRef) {
+    const auto parseUrl = [&](const std::optional<std::string>& partToExtract)
+        -> std::optional<std::string> {
+      return evaluateOnce<std::string>("parse_url(c0, c1)", url, partToExtract);
+    };
+
+    EXPECT_EQ(parseUrl("PROTOCOL"), expectedProtocol);
+
+    EXPECT_EQ(parseUrl("USERINFO"), expectedUserinfo);
+    EXPECT_EQ(parseUrl("HOST"), expectedHost);
+    auto expectedAuthority =
+        (expectedUserinfo & "@") + expectedHost + (":" & expectedPort);
+    EXPECT_EQ(parseUrl("AUTHORITY"), expectedAuthority);
+
+    EXPECT_EQ(parseUrl("PATH"), expectedPath);
+    EXPECT_EQ(parseUrl("QUERY"), expectedQuery);
+
+    auto expectedFile = expectedPath + ("?" & expectedQuery);
+    EXPECT_EQ(parseUrl("FILE"), expectedFile);
+
+    EXPECT_EQ(parseUrl("REF"), expectedRef);
+  }
+};
+
+TEST_F(URLFunctionsTest, validateURL) {
+  validate(
+      "http://user:pass@example.com:8080/path1/p.php?k1=v1&k2=v2#Ref1",
+      "http",
+      "user:pass",
+      "example.com",
+      "8080",
+      "/path1/p.php",
+      "k1=v1&k2=v2",
+      "Ref1");
+  validate(
+      "HTTP://example.com/path1/p.php",
+      "HTTP",
+      std::nullopt,
+      "example.com",
+      std::nullopt,
+      "/path1/p.php",
+      std::nullopt,
+      std::nullopt);
+  validate(
+      "http://example.com:8080/path1/p.php?k1=v1&k2=v2#Ref1",
+      "http",
+      std::nullopt,
+      "example.com",
+      "8080",
+      "/path1/p.php",
+      "k1=v1&k2=v2",
+      "Ref1");
+  validate(
+      "https://username@example.com",
+      "https",
+      "username",
+      "example.com",
+      std::nullopt,
+      "",
+      std::nullopt,
+      std::nullopt);
+  validate(
+      "https:/auth/login.html",
+      "https",
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
+      "/auth/login.html",
+      std::nullopt,
+      std::nullopt);
+  validate(
+      "foo",
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
+      "foo",
+      std::nullopt,
+      std::nullopt);
+}
+
+TEST_F(URLFunctionsTest, validateParameter) {
+  const auto checkParseUrlWithKey =
+      [&](const std::optional<std::string>& expected,
+          const std::optional<std::string>& url,
+          const std::optional<std::string>& key) {
+        const std::optional<std::string>& partToExtract = "QUERY";
+        EXPECT_EQ(
+            evaluateOnce<std::string>(
+                "parse_url(c0, c1, c2)", url, partToExtract, key),
+            expected);
+      };
+
+  checkParseUrlWithKey(
+      "v2", "http://example.com/path1/p.php?k1=v1&k2=v2#Ref1", "k2");
+  checkParseUrlWithKey(
+      "v1", "http://example.com/path1/p.php?k1=v1&k2=v2&k3&k4#Ref1", "k1");
+  checkParseUrlWithKey(
+      std::nullopt,
+      "http://example.com/path1/p.php?k1=v1&k2=v2&k3&k4#Ref1",
+      "k3");
+  checkParseUrlWithKey(
+      std::nullopt,
+      "http://example.com/path1/p.php?k1=v1&k2=v2&k3&k4#Ref1",
+      "k6");
+  checkParseUrlWithKey(std::nullopt, "foo", "");
+}
+
+TEST_F(URLFunctionsTest, sparkUT) {
+  const auto checkParseUrl =
+      [&](const std::optional<std::string>& expected,
+          const std::optional<std::string>& url,
+          const std::optional<std::string>& partToExtract) {
+        EXPECT_EQ(
+            evaluateOnce<std::string>("parse_url(c0, c1)", url, partToExtract),
+            expected);
+      };
+  const auto checkParseUrlWithKey =
+      [&](const std::optional<std::string>& expected,
+          const std::optional<std::string>& url,
+          const std::optional<std::string>& partToExtract,
+          const std::optional<std::string>& key) {
+        EXPECT_EQ(
+            evaluateOnce<std::string>(
+                "parse_url(c0, c1, c2)", url, partToExtract, key),
+            expected);
+      };
+
+  checkParseUrl(
+      "spark.apache.org", "http://spark.apache.org/path?query=1", "HOST");
+  checkParseUrl("/path", "http://spark.apache.org/path?query=1", "PATH");
+  checkParseUrl("query=1", "http://spark.apache.org/path?query=1", "QUERY");
+  checkParseUrl("Ref", "http://spark.apache.org/path?query=1#Ref", "REF");
+  checkParseUrl("http", "http://spark.apache.org/path?query=1", "PROTOCOL");
+  checkParseUrl(
+      "/path?query=1", "http://spark.apache.org/path?query=1", "FILE");
+  checkParseUrl(
+      "spark.apache.org:8080",
+      "http://spark.apache.org:8080/path?query=1",
+      "AUTHORITY");
+  checkParseUrl(
+      "userinfo", "http://userinfo@spark.apache.org/path?query=1", "USERINFO");
+  checkParseUrlWithKey(
+      "1", "http://spark.apache.org/path?query=1", "QUERY", "query");
+
+  // Null checking.
+  checkParseUrl(std::nullopt, std::nullopt, "HOST");
+  checkParseUrl(
+      std::nullopt, "http://spark.apache.org/path?query=1", std::nullopt);
+  checkParseUrl(std::nullopt, std::nullopt, std::nullopt);
+  checkParseUrl(std::nullopt, "test", "HOST");
+  checkParseUrl(std::nullopt, "http://spark.apache.org/path?query=1", "NO");
+  checkParseUrl(
+      std::nullopt, "http://spark.apache.org/path?query=1", "USERINFO");
+  checkParseUrlWithKey(
+      std::nullopt, "http://spark.apache.org/path?query=1", "HOST", "query");
+  checkParseUrlWithKey(
+      std::nullopt, "http://spark.apache.org/path?query=1", "QUERY", "quer");
+  checkParseUrlWithKey(
+      std::nullopt,
+      "http://spark.apache.org/path?query=1",
+      "QUERY",
+      std::nullopt);
+  checkParseUrlWithKey(
+      std::nullopt, "http://spark.apache.org/path?query=1", "QUERY", "");
+}
+
+TEST_F(URLFunctionsTest, testInvalidURLs) {
+  const std::optional<std::string> query = "QUERY";
+  const auto checkParseUrl =
+      [&](const std::optional<std::string>& expected,
+          const std::optional<std::string>& url,
+          const std::optional<std::string>& partToExtract) {
+        EXPECT_EQ(
+            evaluateOnce<std::string>("parse_url(c0, c1)", url, partToExtract),
+            expected);
+      };
+  const auto checkParseUrlWithKey =
+      [&](const std::optional<std::string>& expected,
+          const std::optional<std::string>& url,
+          const std::optional<std::string>& key) {
+        EXPECT_EQ(
+            evaluateOnce<std::string>("parse_url(c0, c1, c2)", url, query, key),
+            expected);
+      };
+  const auto checkBoth = [&](const std::optional<std::string>& expected,
+                             const std::optional<std::string>& url,
+                             const std::optional<std::string>& partToExtract) {
+    checkParseUrl(expected, url, partToExtract);
+    checkParseUrlWithKey(expected, url, partToExtract);
+  };
+  checkBoth(std::nullopt, "foo ", "PATH");
+  checkBoth(std::nullopt, "https://www.foo.com  ", "HOST");
+  checkBoth(
+      std::nullopt, "https://spark.apache.org/path/%%UCUrlCompartir%%", "PATH");
+  checkBoth(
+      std::nullopt, "https://spark.apache.org/path/%%UCUrlCompartir%%", "HOST");
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
Copied over from #6143

May need to re-structure code for PrestoSQL parse_url to use a limited version of this extended version. Need to do path-finding first