### PR TITLE
Add VELOX_DCHECK_NULL macro

### DIFF
--- a/velox/common/base/Exceptions.h
+++ b/velox/common/base/Exceptions.h
@@ -312,6 +312,7 @@ DECLARE_CHECK_FAIL_TEMPLATES(::facebook::velox::VeloxRuntimeError);
 #define VELOX_DCHECK_LE(e1, e2, ...) VELOX_CHECK(true)
 #define VELOX_DCHECK_EQ(e1, e2, ...) VELOX_CHECK(true)
 #define VELOX_DCHECK_NE(e1, e2, ...) VELOX_CHECK(true)
+#define VELOX_DCHECK_NULL(e, ...) VELOX_CHECK(true)
 #define VELOX_DCHECK_NOT_NULL(e, ...) VELOX_CHECK(true)
 #endif
 


### PR DESCRIPTION
A follow-up to https://github.com/facebookincubator/velox/pull/100.

VELOX_DCHECK_NULL is not defined in release build so using it causes build error. The patch fixes the issue.