### PR TITLE
Add metric to cacth the double free error in mmap allocator

### DIFF
--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -146,7 +146,6 @@ void registerVeloxMetrics() {
   // The distribution of a root memory pool's initial capacity in range of [0,
   // 256MB] with 32 buckets. It is configured to report the capacity at P50,
   // P90, P99, and P100 percentiles.
-
   DEFINE_HISTOGRAM_METRIC(
       kMetricMemoryPoolInitialCapacityBytes,
       8L << 20,
@@ -162,6 +161,12 @@ void registerVeloxMetrics() {
   // to report the count at P50, P90, P99, and P100 percentiles.
   DEFINE_HISTOGRAM_METRIC(
       kMetricMemoryPoolCapacityGrowCount, 8, 0, 256, 50, 90, 99, 100);
+
+  // Tracks the count of double frees in memory allocator, indicating the
+  // possibility of buffer ownership issues when a buffer is freed more than
+  // once.
+  DEFINE_METRIC(
+      kMetricMemoryAllocatorDoubleFreeCount, facebook::velox::StatType::COUNT);
 
   /// ================== Spill related Counters =================
 

--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -67,6 +67,9 @@ constexpr folly::StringPiece kMetricMemoryPoolUsageLeakBytes{
 constexpr folly::StringPiece kMetricMemoryPoolReservationLeakBytes{
     "velox.memory_pool_reservation_leak_bytes"};
 
+constexpr folly::StringPiece kMetricMemoryAllocatorDoubleFreeCount{
+    "velox.memory_allocator_double_free_count"};
+
 constexpr folly::StringPiece kMetricArbitratorRequestsCount{
     "velox.arbitrator_requests_count"};
 

--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -175,6 +175,11 @@ Memory Management
    * - memory_pool_capacity_leak_bytes
      - Sum
      - The root memory pool reservation leak in bytes.
+   * - memory_allocator_double_free_count
+     - Count
+     - Tracks the count of double frees in memory allocator, indicating the
+       possibility of buffer ownership issues when a buffer is freed more
+       than once.
 
 Spilling
 --------


### PR DESCRIPTION
Currently we only have a warning log for double free in mmap allocator
and we shall also add a metric for production alert.