### PR TITLE
Add 'opCall' member to OpCallInfo.

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -395,7 +395,10 @@ size_t OpCallStatusRaw::callDuration() const {
 /*static*/ std::string OpCallStatusRaw::formatCall(
     Operator* op,
     const char* operatorMethod) {
-  return fmt::format("{}::{}", op ? op->operatorType() : "N/A", operatorMethod);
+  return op
+      ? fmt::format(
+            "{}.{}::{}", op->operatorType(), op->planNodeId(), operatorMethod)
+      : fmt::format("null::{}", operatorMethod);
 }
 
 CpuWallTiming Driver::processLazyTiming(

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2000,11 +2000,13 @@ bool Task::getLongRunningOpCalls(
       if (!opCallStatus.empty()) {
         auto callDurationMs = opCallStatus.callDuration();
         if (callDurationMs > thresholdDurationMs) {
+          auto* op = driver->findOperatorNoThrow(opCallStatus.opId);
           out.push_back({
               .durationMs = callDurationMs,
               .tid = driver->state().tid,
               .opId = opCallStatus.opId,
               .taskId = taskId_,
+              .opCall = OpCallStatusRaw::formatCall(op, opCallStatus.method),
           });
         }
       }

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -257,9 +257,12 @@ class Task : public std::enable_shared_from_this<Task> {
   /// Information about an operator call that helps debugging stuck calls.
   struct OpCallInfo {
     size_t durationMs;
+    /// Thread id of where the operator got stuck.
     int32_t tid;
     int32_t opId;
     std::string taskId;
+    /// Call in the format of "<operatorType>.<nodeId>::<operatorMethod>".
+    std::string opCall;
   };
 
   /// Collect long running operator calls across all drivers in this task.


### PR DESCRIPTION
Summary:
To see better which operator stuck in a long call and where
we add a new member to the OpCallInfo structure.
The member will contain "\<operatorType\>.\<nodeId\>::\<operatorMethod\>".

Differential Revision: D53340869


