### PR TITLE
Add recursive spill for RowNumber

### DIFF
--- a/velox/common/base/SpillConfig.h
+++ b/velox/common/base/SpillConfig.h
@@ -69,8 +69,7 @@ struct SpillConfig {
   /// the next level of recursive spilling.
   int32_t spillLevel(uint8_t startBitOffset) const;
 
-  /// Checks if the given 'startBitOffset' and 'numPartitionBits' has exceeded
-  /// the max hash join spill limit.
+  /// Checks if the given 'startBitOffset' has exceeded the max spill limit.
   bool exceedSpillLevelLimit(uint8_t startBitOffset) const;
 
   /// A callback function that returns the spill directory path. Implementations

--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -916,7 +916,7 @@ next batch of input.
 
 This operator accumulates state: a hash table mapping partition keys to total
 number of rows seen in this partition so far. Returning the row numbers as
-a column in the output is optional. This operator doesn't support spilling yet.
+a column in the output is optional. This operator supports spilling.
 
 This operator is equivalent to a WindowNode followed by
 FilterNode(row_number <= limit), but it uses less memory and CPU and makes

--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -65,6 +65,10 @@ RowNumber::RowNumber(
     resultProjections_.emplace_back(0, inputType->size());
     results_.resize(1);
   }
+
+  if (spillEnabled()) {
+    setSpillPartitionBits();
+  }
 }
 
 void RowNumber::addInput(RowVectorPtr input) {
@@ -97,8 +101,14 @@ void RowNumber::addInput(RowVectorPtr input) {
 }
 
 void RowNumber::addSpillInput() {
+  ensureInputFits(input_);
+  if (input_ == nullptr) {
+    return;
+  }
+
   const auto numInput = input_->size();
   SelectivityVector rows(numInput);
+
   table_->prepareForGroupProbe(
       *lookup_, input_, rows, false, spillConfig_->startPartitionBit);
   table_->groupProbe(*lookup_);
@@ -107,8 +117,6 @@ void RowNumber::addSpillInput() {
   for (auto i : lookup_->newGroups) {
     setNumRows(lookup_->hits[i], 0);
   }
-
-  // TODO Add support for recursive spilling.
 }
 
 void RowNumber::noMoreInput() {
@@ -134,6 +142,8 @@ void RowNumber::restoreNextSpillPartition() {
   if (hashTableIt != spillHashTablePartitionSet_.end()) {
     spillHashTableReader_ =
         hashTableIt->second->createUnorderedReader(pool(), &spillStats_);
+
+    setSpillPartitionBits(&(it->first));
 
     RowVectorPtr data;
     while (spillHashTableReader_->nextBatch(data)) {
@@ -251,7 +261,19 @@ FlatVector<int64_t>& RowNumber::getOrCreateRowNumberVector(vector_size_t size) {
 
 RowVectorPtr RowNumber::getOutput() {
   if (input_ == nullptr) {
-    return nullptr;
+    if (spillInputReader_ == nullptr) {
+      return nullptr;
+    }
+
+    recursiveSpillInput();
+    if (yield_) {
+      yield_ = false;
+      return nullptr;
+    }
+
+    if (input_ == nullptr) {
+      return nullptr;
+    }
   }
 
   if (!table_) {
@@ -368,8 +390,12 @@ void RowNumber::reclaim(
     return;
   }
 
-  if (inputSpiller_ != nullptr) {
-    // Already spilled.
+  if (exceededMaxSpillLevelLimit_) {
+    LOG(WARNING) << "Exceeded row spill level limit: "
+                 << spillConfig_->maxSpillLevel
+                 << ", and abandon spilling for memory pool: "
+                 << pool()->name();
+    ++spillStats_.wlock()->spillMaxLevelExceededCount;
     return;
   }
 
@@ -380,10 +406,9 @@ SpillPartitionNumSet RowNumber::spillHashTable() {
   // TODO Replace joinPartitionBits and Spiller::Type::kHashJoinBuild.
   VELOX_CHECK_NOT_NULL(table_);
 
-  const auto& spillConfig = spillConfig_.value();
-
   auto columnTypes = table_->rows()->columnTypes();
   auto tableType = ROW(std::move(columnTypes));
+  const auto& spillConfig = spillConfig_.value();
 
   auto hashTableSpiller = std::make_unique<Spiller>(
       Spiller::Type::kRowNumber,
@@ -430,16 +455,11 @@ void RowNumber::setupInputSpiller(
 
 void RowNumber::spill() {
   VELOX_CHECK(spillEnabled());
-  VELOX_CHECK_NULL(inputSpiller_);
-
-  spillPartitionBits_ = HashBitRange(
-      spillConfig_->startPartitionBit,
-      spillConfig_->startPartitionBit + spillConfig_->numPartitionBits);
 
   const auto spillPartitionSet = spillHashTable();
+  VELOX_CHECK_EQ(table_->numDistinct(), 0);
 
   setupInputSpiller(spillPartitionSet);
-
   if (input_ != nullptr) {
     spillInput(input_, memory::spillMemoryPool());
     input_ = nullptr;
@@ -487,6 +507,41 @@ void RowNumber::spillInput(
     inputSpiller_->spill(
         partition, wrap(numInputs, partitionIndices[partition], input));
   }
+}
+
+void RowNumber::recursiveSpillInput() {
+  RowVectorPtr input;
+  while (spillInputReader_->nextBatch(input)) {
+    spillInput(input, pool());
+
+    if (operatorCtx_->driver()->shouldYield()) {
+      yield_ = true;
+      return;
+    }
+  }
+
+  inputSpiller_->finishSpill(spillInputPartitionSet_);
+  spillInputReader_ = nullptr;
+
+  removeEmptyPartitions(spillInputPartitionSet_);
+  restoreNextSpillPartition();
+}
+
+void RowNumber::setSpillPartitionBits(
+    const SpillPartitionId* restoredPartitionId) {
+  const auto startPartitionBitOffset = restoredPartitionId == nullptr
+      ? spillConfig_->startPartitionBit
+      : restoredPartitionId->partitionBitOffset() +
+          spillConfig_->numPartitionBits;
+  if (spillConfig_->exceedSpillLevelLimit(startPartitionBitOffset)) {
+    exceededMaxSpillLevelLimit_ = true;
+    return;
+  }
+
+  exceededMaxSpillLevelLimit_ = false;
+  spillPartitionBits_ = HashBitRange(
+      startPartitionBitOffset,
+      startPartitionBitOffset + spillConfig_->numPartitionBits);
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/RowNumber.h
+++ b/velox/exec/RowNumber.h
@@ -78,6 +78,22 @@ class RowNumber : public Operator {
 
   FlatVector<int64_t>& getOrCreateRowNumberVector(vector_size_t size);
 
+  // Used by recursive spill processing to read the spilled input data from the
+  // previous spill run through 'spillInputReader_' and then spill them back
+  // into a number of sub-partitions. After that, the function restores one of
+  // the newly spilled partitions and resets 'spillInputReader_' accordingly.
+  void recursiveSpillInput();
+
+  // Set 'spillPartitionBits_' for (recursive) spill. If 'restoredPartitionId'
+  // is not null, use it to set 'spillPartitionBits_', otherwise use
+  // 'spillConfig_'. If the new 'spillPartitionBits_' exceeds the
+  // 'maxSpillLevel', set 'exceededMaxSpillLevelLimit_' to true.
+  // NOTE: we don't increment 'spillMaxLevelExceededCount' here, as the actual
+  // increment happens in the 'reclaim()' method if
+  // 'exceededMaxSpillLevelLimit_' is true.
+  void setSpillPartitionBits(
+      const SpillPartitionId* restoredPartitionId = nullptr);
+
   const std::optional<int32_t> limit_;
   const bool generateRowNumber_;
 
@@ -117,5 +133,11 @@ class RowNumber : public Operator {
 
   // Used to calculate the spill partition numbers of the inputs.
   std::unique_ptr<HashPartitionFunction> spillHashFunction_;
+
+  // The cpu may be voluntarily yield after running too long when processing
+  // input from spilled file.
+  bool yield_;
+
+  bool exceededMaxSpillLevelLimit_{false};
 };
 } // namespace facebook::velox::exec


### PR DESCRIPTION
At present, RowNumber only supports single-level spill partitions.
Once a spill takes place, it won't be spilled again. This means that
even if a restored spill partition uses an excessive amount of memory,
it still cannot be reclaimed. Therefore, it would be beneficial to implement
recursive spill support, as outlined in
https://facebookincubator.github.io/velox/develop/spilling.html.

1 Advance 'spillPartitionBits_' based on the partition bit of the currently
restoring spill partition to prepare for potential subsequent spills (recursive).

2 During the recursive spill input process, read the spilled input data from the
previous spill run via 'spillInputReader_', then spill it back into several sub-partitions.
Then restore one of the newly spilled partitions and reset 'spillInputReader' accordingly.

3 It's crucial to separate the recursive input spill process from the spill process itself,
as it can be time-consuming and should yield if it exceeds the CPU time limit.

In summary, the first spill operation writes all data to the disk. Subsequently,
RowNumber reads the data from the disk one partition at a time and clears
the data from the restored partition once it has been processed (#8413).
 In the case of a recursive spill, only the data from the currently restored partition
in memory is spilled to the disk (next level), and only one partition from the next
level is loaded back into memory.

The data layout may look like as follows.

||Memory|Disk|
| -- | -- | -- |
|No-Spill | [P0, P1]| []|
|First Spill | []| [P0, P1]|
|Restore | [P0] | [P1]|
|Second Spill | [] | [P0-0, P0-1, P1]|
|Restore| [P0-0] | [P0-1, P1]|
|Processed |[] |[P0-1, P1]|
|Restored |[P0-1] |[P1]|
|Processed | [] | [P1]|
|Restored | [P1] | []|
