### PR TITLE
Specify 'xsimd_SOURCE' to BUNDLED in linux-presto-fuzzer-run CI

### DIFF
--- a/.circleci/dist_compile.yml
+++ b/.circleci/dist_compile.yml
@@ -433,6 +433,7 @@ jobs:
     environment:
       VELOX_DEPENDENCY_SOURCE: SYSTEM
       simdjson_SOURCE: BUNDLED
+      xsimd_SOURCE: BUNDLED
       DuckDB_SOURCE: BUNDLED
     steps:
       - fuzzer-run:


### PR DESCRIPTION
In #8308, the dependency of "xsimd" was modified to `"AUTO"`.
xsimd library is not pre-installed on the CI container, so we need to
explicitly specify it as `"BUNDLED"`.

Fix current linux-presto-fuzzer-run CI failure.