### PR TITLE
Add compression codec name to parquet file name suffix

### DIFF
--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -802,9 +802,32 @@ std::pair<std::string, std::string> HiveDataSink::getWriterFileNames(
       : targetFileName;
   if (insertTableHandle_->tableStorageFormat() ==
       dwio::common::FileFormat::PARQUET) {
+    std::string compressionSuffix;
+    if (insertTableHandle_->compressionKind().has_value()) {
+      switch (
+          static_cast<int32_t>(insertTableHandle_->compressionKind().value())) {
+        case common::CompressionKind_NONE:
+          compressionSuffix = "";
+          break;
+        case common::CompressionKind_GZIP:
+          compressionSuffix = ".gz";
+          break;
+        case common::CompressionKind_LZ4:
+          compressionSuffix = ".lz4hadoop";
+          break;
+        default:
+          compressionSuffix =
+              "." +
+              common::compressionKindToString(
+                  insertTableHandle_->compressionKind().value());
+          break;
+      }
+    } else {
+      compressionSuffix = "";
+    }
     return {
-        fmt::format("{}{}", targetFileName, ".parquet"),
-        fmt::format("{}{}", writeFileName, ".parquet")};
+        fmt::format("{}{}{}", targetFileName, compressionSuffix, ".parquet"),
+        fmt::format("{}{}{}", writeFileName, compressionSuffix, ".parquet")};
   }
   return {targetFileName, writeFileName};
 }


### PR DESCRIPTION
Spark follows the parquet hadoop file name format `xxx.$compressionCodec.parquet`, here is the [compression codec name mapping](https://github.com/apache/parquet-mr/blob/e87b80308869b77f914fcfd04364686e11158950/parquet-common/src/main/java/org/apache/parquet/hadoop/metadata/CompressionCodecName.java#L25-L33)

```scala
UNCOMPRESSED((String)null, CompressionCodec.UNCOMPRESSED, ""),
SNAPPY("org.apache.parquet.hadoop.codec.SnappyCodec", CompressionCodec.SNAPPY, ".snappy"),
GZIP("org.apache.hadoop.io.compress.GzipCodec", CompressionCodec.GZIP, ".gz"),
LZO("com.hadoop.compression.lzo.LzoCodec", CompressionCodec.LZO, ".lzo"),
BROTLI("org.apache.hadoop.io.compress.BrotliCodec", CompressionCodec.BROTLI, ".br"),
LZ4("org.apache.hadoop.io.compress.Lz4Codec", CompressionCodec.LZ4, ".lz4hadoop"),
ZSTD("org.apache.parquet.hadoop.codec.ZstandardCodec", CompressionCodec.ZSTD, ".zstd"),
LZ4_RAW("org.apache.parquet.hadoop.codec.Lz4RawCodec", CompressionCodec.LZ4_RAW, ".lz4raw");
```

This pr adds the compression codec name to parquet file name suffix.