### PR TITLE
Remove unnecessary check in provide_std_interface in ComplexWriterTypes.h

### DIFF
--- a/velox/expression/ComplexWriterTypes.h
+++ b/velox/expression/ComplexWriterTypes.h
@@ -91,9 +91,8 @@ struct PrimitiveWriter {
 };
 
 template <typename V>
-bool constexpr provide_std_interface =
-    SimpleTypeTrait<V>::isPrimitiveType && !std::is_same_v<Varchar, V> &&
-    !std::is_same_v<Varbinary, V> && !std::is_same_v<Any, V>;
+bool constexpr provide_std_interface = SimpleTypeTrait<V>::isPrimitiveType &&
+    !std::is_same_v<Varchar, V> && !std::is_same_v<Varbinary, V>;
 
 // bool is an exception, it requires commit but also provides std::interface.
 template <typename V>

--- a/velox/expression/ComplexWriterTypes.h
+++ b/velox/expression/ComplexWriterTypes.h
@@ -981,9 +981,7 @@ class RowWriter {
     (
         [&]() {
           using current_t = std::tuple_element_t<Is, children_types>;
-          if constexpr (
-              !provide_std_interface<current_t> &&
-              !isOpaqueType<current_t>::value) {
+          if constexpr (!provide_std_interface<current_t>) {
             if (UNLIKELY(std::get<Is>(needCommit_))) {
               std::get<Is>(childrenWriters_).finalizeNull();
               std::get<Is>(needCommit_) = false;


### PR DESCRIPTION
Since `SimpleTypeTrait<Generic<T, comparable, orderable>>::isPrimitiveType` is false, then `!std::is_same_v<Any, V>` is unnecessary. Same for `!isOpaqueType<current_t>::value`.