### PR TITLE
Rename addRootPool maxCapacity parameter

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -175,7 +175,7 @@ uint16_t MemoryManager::alignment() const {
 
 std::shared_ptr<MemoryPool> MemoryManager::addRootPool(
     const std::string& name,
-    int64_t capacity,
+    int64_t maxCapacity,
     std::unique_ptr<MemoryReclaimer> reclaimer) {
   std::string poolName = name;
   if (poolName.empty()) {
@@ -185,7 +185,7 @@ std::shared_ptr<MemoryPool> MemoryManager::addRootPool(
 
   MemoryPool::Options options;
   options.alignment = alignment_;
-  options.maxCapacity = capacity;
+  options.maxCapacity = maxCapacity;
   options.trackUsage = true;
   options.debugEnabled = debugEnabled_;
   options.coreOnAllocationFailureEnabled = coreOnAllocationFailureEnabled_;
@@ -206,7 +206,7 @@ std::shared_ptr<MemoryPool> MemoryManager::addRootPool(
   pools_.emplace(poolName, pool);
   VELOX_CHECK_EQ(pool->capacity(), 0);
   arbitrator_->growCapacity(
-      pool.get(), std::min<uint64_t>(poolInitCapacity_, capacity));
+      pool.get(), std::min<uint64_t>(poolInitCapacity_, maxCapacity));
   return pool;
 }
 

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -205,12 +205,12 @@ class MemoryManager {
   /// Returns the memory allocation alignment of this memory manager.
   uint16_t alignment() const;
 
-  /// Creates a root memory pool with specified 'name' and 'capacity'. If 'name'
-  /// is missing, the memory manager generates a default name internally to
-  /// ensure uniqueness.
+  /// Creates a root memory pool with specified 'name' and 'maxCapacity'. If
+  /// 'name' is missing, the memory manager generates a default name internally
+  /// to ensure uniqueness.
   std::shared_ptr<MemoryPool> addRootPool(
       const std::string& name = "",
-      int64_t capacity = kMaxMemory,
+      int64_t maxCapacity = kMaxMemory,
       std::unique_ptr<MemoryReclaimer> reclaimer = nullptr);
 
   /// Creates a leaf memory pool for direct memory allocation use with specified

--- a/velox/docs/develop/memory.rst
+++ b/velox/docs/develop/memory.rst
@@ -398,11 +398,11 @@ Memory Pool Management
 
 .. code-block:: c++
 
-  /// Creates a root memory pool with specified 'name' and 'capacity'.
+  /// Creates a root memory pool with specified 'name' and 'maxCapacity'.
   /// 'reclaimer' is provided for memory arbitration process.
   std::shared_ptr<MemoryPool> MemoryManager::addRootPool(
      const std::string& name = "",
-     int64_t capacity = kMaxMemory,
+     int64_t maxCapacity = kMaxMemory,
      std::unique_ptr<MemoryReclaimer> reclaimer = nullptr);
 
   /// Create an aggregate child memory pool which allows to create child memory


### PR DESCRIPTION
MemoryManager::addRootPool would set the `maxCapacity` of
the root pool, it would be more readable to change the related
parameter from `capacity` to `maxCapacity`.