### PR TITLE
Upgrade Boost to 1.84.0

### DIFF
--- a/CMake/resolve_dependency_modules/boost/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/boost/CMakeLists.txt
@@ -21,14 +21,14 @@ add_compile_options(-w)
 # We need to use boost > 1.70 to build it with CMake 1.81 was the first to be
 # released as a github release INCLUDING the cmake files (which are not in the
 # officale releases for some reason)
-set(VELOX_BOOST_BUILD_VERSION 1.81.0)
+set(VELOX_BOOST_BUILD_VERSION 1.84.0)
 string(
   CONCAT VELOX_BOOST_SOURCE_URL
          "https://github.com/boostorg/boost/releases/download/"
          "boost-${VELOX_BOOST_BUILD_VERSION}/"
          "boost-${VELOX_BOOST_BUILD_VERSION}.tar.gz")
 set(VELOX_BOOST_BUILD_SHA256_CHECKSUM
-    121da556b718fd7bd700b5f2e734f8004f1cfa78b7d30145471c526ba75a151c)
+    4d27e9efed0f6f152dc28db6430b9d3dfb40c0345da7342eaa5a987dde57bd95)
 
 resolve_dependency_url(BOOST)
 message(STATUS "Building boost from source")
@@ -65,8 +65,5 @@ list(REMOVE_ITEM BOOST_INCLUDE_LIBRARIES headers)
 set(BUILD_SHARED_LIBS ON)
 FetchContent_MakeAvailable(Boost)
 
-# To aling with Boost system install we create Boost::headers target
-add_library(boost_headers INTERFACE)
-add_library(Boost::headers ALIAS boost_headers)
 list(TRANSFORM BOOST_HEADER_ONLY PREPEND Boost::)
 target_link_libraries(boost_headers INTERFACE ${BOOST_HEADER_ONLY})

--- a/scripts/setup-centos8.sh
+++ b/scripts/setup-centos8.sh
@@ -80,7 +80,7 @@ function install_lzo {
 }
 
 function install_boost {
-  wget_and_untar https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.gz boost
+  wget_and_untar https://github.com/boostorg/boost/releases/download/boost-1.84.0/boost-1.84.0.tar.gz boost
   (
    cd boost
    ./bootstrap.sh --prefix=/usr/local

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -25,6 +25,7 @@ COMPILER_FLAGS=$(get_cxx_flags "$CPU_TARGET")
 export COMPILER_FLAGS
 FB_OS_VERSION=v2023.12.04.00
 FMT_VERSION=10.1.1
+BOOST_VERSION=boost-1.84.0
 NPROC=$(getconf _NPROCESSORS_ONLN)
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
 export CMAKE_BUILD_TYPE=Release
@@ -44,7 +45,6 @@ sudo --preserve-env apt update && sudo --preserve-env apt install -y libunwind-d
   libc-ares-dev \
   libcurl4-openssl-dev \
   libssl-dev \
-  libboost-all-dev \
   libicu-dev \
   libdouble-conversion-dev \
   libgoogle-glog-dev \
@@ -70,6 +70,12 @@ sudo --preserve-env apt update && sudo --preserve-env apt install -y libunwind-d
 function install_fmt {
   github_checkout fmtlib/fmt "${FMT_VERSION}"
   cmake_install -DFMT_TEST=OFF
+}
+
+function install_boost {
+  github_checkout boostorg/boost "${BOOST_VERSION}" --recursive
+  ./bootstrap.sh --prefix=/usr/local
+  ./b2 "-j$(nproc)" -d0 install threading=multi
 }
 
 function install_folly {
@@ -115,6 +121,7 @@ function install_conda {
 
 function install_velox_deps {
   run_and_time install_fmt
+  run_and_time install_boost
   run_and_time install_folly
   run_and_time install_fizz
   run_and_time install_wangle


### PR DESCRIPTION
The boost version 1.84.0 fixes a bug that prevents
the addition of a group of inverse functions.
The fix was provided in Boost PR
https://github.com/boostorg/math/pull/1007

The update occurs for the setup scripts for CentOS and Ubuntu. MacOS already installs the
latest available Boost version on brew.

In addition, the requirement for the Boost version is updated to make sure the proper version is used.
There is no known build problem when upgrading the version.
Fixes issue: https://github.com/facebookincubator/velox/issues/8624