### PR TITLE
Fix ExchangeQueue::dequeueLocked

### DIFF
--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -85,7 +85,7 @@ class ExchangeClient : public std::enable_shared_from_this<ExchangeClient> {
   ///
   /// If no data is available returns empty list and sets 'atEnd' to true if no
   /// more data is expected. If data is still expected, sets 'atEnd' to false
-  /// and sets 'future' to a Future that will comlete when data arrives.
+  /// and sets 'future' to a Future that will complete when data arrives.
   ///
   /// The data may be compressed, in which case 'maxBytes' applies to compressed
   /// size.

--- a/velox/exec/ExchangeQueue.cpp
+++ b/velox/exec/ExchangeQueue.cpp
@@ -111,7 +111,7 @@ std::vector<std::unique_ptr<SerializedPage>> ExchangeQueue::dequeueLocked(
     if (queue_.empty()) {
       if (atEnd_) {
         *atEnd = true;
-      } else {
+      } else if (pages.empty()) {
         promises_.emplace_back("ExchangeQueue::dequeue");
         *future = promises_.back().getSemiFuture();
       }

--- a/velox/exec/ExchangeQueue.h
+++ b/velox/exec/ExchangeQueue.h
@@ -114,7 +114,7 @@ class ExchangeQueue {
   /// sets 'atEnd' to false and 'future' to a Future that will complete when
   /// data arrives. If no more data is expected, sets 'atEnd' to true. Returns
   /// at least one page if data is available. If multiple pages are available,
-  /// returns as many pages as fit within 'maxBytes', but no fewer than onc.
+  /// returns as many pages as fit within 'maxBytes', but no fewer than one.
   /// Calling this method with 'maxBytes' of 1 returns at most one page.
   ///
   /// The data may be compressed, in which case 'maxBytes' applies to compressed


### PR DESCRIPTION
ExchangeQueue::dequeueLocked used to set the 'future' even when returning
non-empty list of pages. It should not do that because the caller expects
the 'future' only if there is no data and ignores the 'future' if data has been
returned.

Fixes #8680