### PR TITLE
Limit number of different regexes in regexp_xxx Presto functions

### DIFF
--- a/velox/docs/functions/presto/regexp.rst
+++ b/velox/docs/functions/presto/regexp.rst
@@ -7,6 +7,9 @@ supports only a subset of PCRE syntax and in particular does not support
 backtracking and associated features (e.g. back references).
 See https://github.com/google/re2/wiki/Syntax for more information.
 
+Compiling regular expressions is CPU intensive. Hence, each function is
+limited to 20 different expressions per instance and thread of execution.
+
 .. function:: like(string, pattern) -> boolean
               like(string, pattern, escape) -> boolean
 
@@ -19,9 +22,11 @@ See https://github.com/google/re2/wiki/Syntax for more information.
     wildcard '_' represents exactly one character.
 
     Note: Each function instance allow for a maximum of 20 regular expressions to
-    be compiled throughout the lifetime of the query. Not all Patterns requires
-    compilation of regular expressions; for example a pattern 'aa' does not.
-    Only those that require the compilation of regular expressions are counted.
+    be compiled per thread of execution. Not all patterns require
+    compilation of regular expressions. Patterns 'aaa', 'aaa%', '%aaa', where 'aaa'
+    contains only regular characters and '_' wildcards are evaluated without
+    using regular expressions. Only those patterns that require the compilation of
+    regular expressions are counted towards the limit.
 
         SELECT like('abc', '%b%'); -- true
         SELECT like('a_c', '%#_%', '#'); -- true

--- a/velox/expression/tests/ExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerTest.cpp
@@ -54,6 +54,10 @@ int main(int argc, char** argv) {
       "width_bucket",
       // Fuzzer cannot generate valid 'comparator' lambda.
       "array_sort(array(T),constant function(T,T,bigint)) -> array(T)",
+      // https://github.com/facebookincubator/velox/issues/8438#issuecomment-1907234044
+      "regexp_extract",
+      "regexp_extract_all",
+      "regexp_like",
   };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
   return FuzzerRunner::run(initialSeed, skipFunctions);


### PR DESCRIPTION
Introduce a limit for the number of different regular expressions used in a
specific regexp_xxx function instance. The limit of 20 applies per function 
instance and thread of execution.

The same limit has been applied earlier to LIKE expression with patterns that 
require compiling regular expressions.