### PR TITLE
PrestoBatchSerializer should not preserve Dictionary encoding if it makes the data larger

### DIFF
--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -384,6 +384,8 @@ class BaseVector {
     return this;
   }
 
+  static const VectorPtr& wrappedVectorShared(const VectorPtr& vector);
+
   // Returns the index to apply for 'index' in the vector returned by
   // wrappedVector(). Translates the index over any nesting of
   // dictionaries, sequences and constants.


### PR DESCRIPTION
Summary:
This change adds some basic heuristics which serializeDictionaryVector can use to flatten a Vector as part of serializing it
rather than preserving the Dictionary encoding.

The checks are:
* if the size of the Vector type is smaller than or equal to int32_t (the indices into the dictionary)
* if the Vector type is fixed width and we determine that the size of the indices + the size of the alphabet is larger than the size of the original data
* regardless of the Vector type, if the alphabet contains unique values

This helps to ensure the preserving encodings during serialization won't actually make the serialized data larger.

Differential Revision: D53484809

