### PR TITLE
Remove FieldReference::addNullFast usage

### DIFF
--- a/velox/expression/FieldReference.cpp
+++ b/velox/expression/FieldReference.cpp
@@ -30,31 +30,6 @@ void FieldReference::computeDistinctFields() {
   }
 }
 
-// Fast path to avoid copying result.  An alternative way to do this is to
-// ensure that children has null if parent has nulls on corresponding rows,
-// whenever the RowVector is constructed or mutated (eager propagation of
-// nulls).  The current lazy propagation might still be better (more efficient)
-// when adding extra nulls.
-bool FieldReference::addNullsFast(
-    const SelectivityVector& rows,
-    EvalCtx& context,
-    VectorPtr& result,
-    const RowVector* row) {
-  if (result) {
-    return false;
-  }
-  auto& child =
-      inputs_.empty() ? context.getField(index_) : row->childAt(index_);
-  if (row->mayHaveNulls()) {
-    if (!child.unique()) {
-      return false;
-    }
-    addNulls(rows, row->rawNulls(), context, const_cast<VectorPtr&>(child));
-  }
-  result = child;
-  return true;
-}
-
 void FieldReference::apply(
     const SelectivityVector& rows,
     EvalCtx& context,
@@ -115,9 +90,6 @@ void FieldReference::apply(
     auto rowType = dynamic_cast<const RowType*>(row->type().get());
     VELOX_CHECK(rowType);
     index_ = rowType->getChildIdx(field_);
-  }
-  if (!useDecode && addNullsFast(rows, context, result, row)) {
-    return;
   }
   VectorPtr child =
       inputs_.empty() ? context.getField(index_) : row->childAt(index_);

--- a/velox/expression/FieldReference.h
+++ b/velox/expression/FieldReference.h
@@ -86,12 +86,6 @@ class FieldReference : public SpecialForm {
   void
   apply(const SelectivityVector& rows, EvalCtx& context, VectorPtr& result);
 
-  bool addNullsFast(
-      const SelectivityVector& rows,
-      EvalCtx& context,
-      VectorPtr& result,
-      const RowVector* row);
-
   const std::string field_;
   int32_t index_ = -1;
 };

--- a/velox/functions/prestosql/tests/FindFirstTest.cpp
+++ b/velox/functions/prestosql/tests/FindFirstTest.cpp
@@ -212,7 +212,7 @@ TEST_F(FindFirstTest, invalidIndex) {
       "SQL array indices start at 1. Got 0.");
 
   // Mark 3rd row null. Expect no error.
-  data->setNull(2, true);
+  data->childAt(1)->setNull(2, true);
   expected = makeAllNullFlatVector<int32_t>(4);
   verify("find_first(c0, c1, x -> (x > 0))", data, expected);
 }


### PR DESCRIPTION
Summary:
This is causing racing condition when input vector is shared among
different threads.  Need to find out a way to solve it differently.

Differential Revision: D53529155


