### PR TITLE
Add stats for null skew in join operator

### DIFF
--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -481,6 +481,8 @@ void OperatorStats::add(const OperatorStats& other) {
   spilledRows += other.spilledRows;
   spilledPartitions += other.spilledPartitions;
   spilledFiles += other.spilledFiles;
+
+  numNullKeys += other.numNullKeys;
 }
 
 void OperatorStats::clear() {

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -152,6 +152,11 @@ struct OperatorStats {
   int64_t lastLazyCpuNanos{0};
   int64_t lastLazyWallNanos{0};
 
+  // Total null keys processed by the operator.
+  // Currently populated only by HashJoin/HashBuild.
+  // HashProbe doesn't populate numNullKeys when build side is empty.
+  int64_t numNullKeys{0};
+
   std::unordered_map<std::string, RuntimeMetric> runtimeStats;
 
   int numDrivers = 0;


### PR DESCRIPTION
Summary: Add stats to join operator - namely keys processed and how many of them were null. Presto Optimizer needs these stats for history based optimizations.

Due to some techinal complications(details in code), HashProbe doesn't populate numNullKeys when build side is empty. But it should be alright as these stats do not affect performance/correctness of the running query.

Differential Revision: D53527685


