### PR TITLE
Always run RIGHT SEMI JOIN single-threaded

### DIFF
--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -224,6 +224,12 @@ uint32_t maxDrivers(
       // Merge join must run single-threaded.
       return 1;
     } else if (
+        auto join = std::dynamic_pointer_cast<const core::HashJoinNode>(node)) {
+      // Right semi project doesn't support multi-threaded execution.
+      if (join->isRightSemiProjectJoin()) {
+        return 1;
+      }
+    } else if (
         auto tableWrite =
             std::dynamic_pointer_cast<const core::TableWriteNode>(node)) {
       const auto& connectorInsertHandle =

--- a/velox/exec/tests/JoinFuzzer.cpp
+++ b/velox/exec/tests/JoinFuzzer.cpp
@@ -277,22 +277,9 @@ std::vector<RowVectorPtr> flatten(const std::vector<RowVectorPtr>& vectors) {
   return flatVectors;
 }
 
-bool isNullAwareRightSemiProjectJoin(const core::PlanNodePtr& plan) {
-  if (auto joinNode = dynamic_cast<const core::HashJoinNode*>(plan.get())) {
-    return joinNode->isNullAware() &&
-        joinNode->joinType() == core::JoinType::kRightSemiProject;
-  }
-
-  return false;
-}
-
 RowVectorPtr JoinFuzzer::execute(const PlanWithSplits& plan, bool injectSpill) {
   LOG(INFO) << "Executing query plan: " << std::endl
             << plan.plan->toString(true, true);
-
-  // Null-aware right semi project join doesn't support multi-threaded
-  // execution.
-  const int maxDrivers = isNullAwareRightSemiProjectJoin(plan.plan) ? 1 : 2;
 
   AssertQueryBuilder builder(plan.plan);
   for (const auto& [nodeId, nodeSplits] : plan.splits) {
@@ -308,7 +295,7 @@ RowVectorPtr JoinFuzzer::execute(const PlanWithSplits& plan, bool injectSpill) {
         .spillDirectory(spillDirectory->path);
   }
 
-  auto result = builder.maxDrivers(maxDrivers).copyResults(pool_.get());
+  auto result = builder.maxDrivers(2).copyResults(pool_.get());
   LOG(INFO) << "Results: " << result->toString();
   if (VLOG_IS_ON(1)) {
     VLOG(1) << std::endl << result->toString(0, result->size());


### PR DESCRIPTION
Current implementation of the RIGHT SEMI JOIN relies on knowing whether probe
side is empty or not. This is tricky to figure out when running multi-threaded.
For now, make sure that RIGHT SEMI JOIN always runs single-threaded.

Fixes #8470