### PR TITLE
Register Hive Connector in JoinFuzzer

### DIFF
--- a/velox/exec/tests/JoinFuzzer.cpp
+++ b/velox/exec/tests/JoinFuzzer.cpp
@@ -149,6 +149,7 @@ JoinFuzzer::JoinFuzzer(size_t initialSeed)
           connector::hive::HiveConnectorFactory::kHiveConnectorName)
           ->newConnector(
               kHiveConnectorId, std::make_shared<core::MemConfig>(hiveConfig));
+  connector::registerConnector(hiveConnector);
 
   seed(initialSeed);
 }


### PR DESCRIPTION
Summary: This line got accidentally deleted in https://github.com/facebookincubator/velox/pull/8702

Differential Revision: D53547345


