### PR TITLE
Make special form names case insensitive

### DIFF
--- a/velox/expression/SpecialFormRegistry.cpp
+++ b/velox/expression/SpecialFormRegistry.cpp
@@ -29,8 +29,10 @@ SpecialFormRegistry& specialFormRegistryInternal() {
 void SpecialFormRegistry::registerFunctionCallToSpecialForm(
     const std::string& name,
     std::unique_ptr<FunctionCallToSpecialForm> functionCallToSpecialForm) {
-  registry_.withWLock(
-      [&](auto& map) { map[name] = std::move(functionCallToSpecialForm); });
+  const auto sanitizedName = sanitizeName(name);
+  registry_.withWLock([&](auto& map) {
+    map[sanitizedName] = std::move(functionCallToSpecialForm);
+  });
 }
 
 void SpecialFormRegistry::unregisterAllFunctionCallToSpecialForm() {
@@ -39,9 +41,10 @@ void SpecialFormRegistry::unregisterAllFunctionCallToSpecialForm() {
 
 FunctionCallToSpecialForm* FOLLY_NULLABLE
 SpecialFormRegistry::getSpecialForm(const std::string& name) const {
+  const auto sanitizedName = sanitizeName(name);
   FunctionCallToSpecialForm* specialForm = nullptr;
   registry_.withRLock([&](const auto& map) {
-    auto it = map.find(name);
+    auto it = map.find(sanitizedName);
     if (it != map.end()) {
       specialForm = it->second.get();
     }

--- a/velox/expression/tests/FunctionCallToSpecialFormTest.cpp
+++ b/velox/expression/tests/FunctionCallToSpecialFormTest.cpp
@@ -185,3 +185,48 @@ TEST_F(FunctionCallToSpecialFormTest, notASpecialForm) {
       config_);
   ASSERT_EQ(specialForm, nullptr);
 }
+
+class FunctionCallToSpecialFormSanitizeNameTest : public testing::Test,
+                                                  public VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    // This class does not pre-register the special forms.
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
+
+TEST_F(FunctionCallToSpecialFormSanitizeNameTest, sanitizeName) {
+  // Make sure no special forms are registered.
+  unregisterAllFunctionCallToSpecialForm();
+
+  ASSERT_FALSE(isFunctionCallToSpecialFormRegistered("and"));
+  ASSERT_FALSE(isFunctionCallToSpecialFormRegistered("AND"));
+  ASSERT_FALSE(isFunctionCallToSpecialFormRegistered("or"));
+  ASSERT_FALSE(isFunctionCallToSpecialFormRegistered("OR"));
+
+  registerFunctionCallToSpecialForm(
+      "and", std::make_unique<ConjunctCallToSpecialForm>(true /* isAnd */));
+  registerFunctionCallToSpecialForm(
+      "OR", std::make_unique<ConjunctCallToSpecialForm>(false /* isAnd */));
+
+  auto testLookup = [this](const std::string& name) {
+    auto type = resolveTypeForSpecialForm(name, {BOOLEAN(), BOOLEAN()});
+    ASSERT_EQ(type, BOOLEAN());
+
+    auto specialForm = constructSpecialForm(
+        name,
+        BOOLEAN(),
+        {std::make_shared<ConstantExpr>(
+             vectorMaker_.constantVector<bool>({true})),
+         std::make_shared<ConstantExpr>(
+             vectorMaker_.constantVector<bool>({false}))},
+        false,
+        core::QueryConfig{{}});
+    ASSERT_EQ(typeid(*specialForm), typeid(const ConjunctExpr&));
+  };
+
+  testLookup("and");
+  testLookup("AND");
+  testLookup("or");
+  testLookup("OR");
+}


### PR DESCRIPTION
Summary:
Since SQL is case insensitive, we convert function names to lower case when registering and resolving functions. We do this 
for simple functions and vector functions today.  This change does the same for special forms to make it consistent.

Differential Revision: D53580611


