### PR TITLE
Add estimateSerializedSize to BatchVectorSerializer

### DIFF
--- a/velox/functions/prestosql/aggregates/tests/SumDataSizeForStatsTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SumDataSizeForStatsTest.cpp
@@ -217,7 +217,7 @@ TEST_F(SumDataSizeForStatsTest, complexRecursiveGlobalAggregate) {
       }),
   })};
 
-  testAggregations(vectors, {}, {"sum_data_size_for_stats(c0)"}, "SELECT 118");
+  testAggregations(vectors, {}, {"sum_data_size_for_stats(c0)"}, "SELECT 115");
 }
 
 TEST_F(SumDataSizeForStatsTest, constantEncodingTest) {
@@ -269,10 +269,10 @@ TEST_F(SumDataSizeForStatsTest, dictionaryEncodingTest) {
       BaseVector::wrapInDictionary(nullptr, indices, size, columnTwo);
   auto vectors = {makeRowVector({columnOne, columnTwoDictionaryEncoded})};
 
-  testAggregations(vectors, {}, {"sum_data_size_for_stats(c1)"}, "SELECT 118");
+  testAggregations(vectors, {}, {"sum_data_size_for_stats(c1)"}, "SELECT 115");
 
   testAggregations(
-      vectors, {"c0"}, {"sum_data_size_for_stats(c1)"}, "VALUES (1,82),(2,36)");
+      vectors, {"c0"}, {"sum_data_size_for_stats(c1)"}, "VALUES (1,79),(2,36)");
 }
 
 TEST_F(SumDataSizeForStatsTest, mask) {

--- a/velox/vector/VectorStream.cpp
+++ b/velox/vector/VectorStream.cpp
@@ -47,6 +47,14 @@ class DefaultBatchVectorSerializer : public BatchVectorSerializer {
     serializer->flush(stream);
   }
 
+  void estimateSerializedSize(
+      VectorPtr vector,
+      const folly::Range<const IndexRange*>& ranges,
+      vector_size_t** sizes,
+      Scratch& scratch) override {
+    serde_->estimateSerializedSize(vector.get(), ranges, sizes, scratch);
+  }
+
  private:
   memory::MemoryPool* const pool_;
   VectorSerde* const serde_;

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -125,6 +125,12 @@ class BatchVectorSerializer {
     serialize(vector, ranges, scratch, stream);
   }
 
+  virtual void estimateSerializedSize(
+      VectorPtr vector,
+      const folly::Range<const IndexRange*>& ranges,
+      vector_size_t** sizes,
+      Scratch& scratch) = 0;
+
   /// Serializes all rows in a vector.
   void serialize(const RowVectorPtr& vector, OutputStream* stream);
 };


### PR DESCRIPTION
Summary:
This change adds an estimateSerializedSize function to the BatchVectorSerializer interface.

In the DefaultBatchVectorSerializer this simple defers to the existing estimateSerializedSize in VectorSerde.  However, in
PrestoBatchVectorSerializer since we preserve encodings, its implementation needs to take this into account.

PrestoBatchVectorSerializer's shares a lot of code with PrestoVectorSerde's estimateSerializedSize, but adds the following:
* estimateConstantSerializedSize: this sets the size to the size of the single constant value, regardless of the width of the
range.
* estimateDictionarySerializedSize: this sets the size to the aggregate of the indices plus the size of the selected entries in
the dictionary.
* estimateSerializedSizeImpl: like estimateSerializedSizeInt in PrestoVectorSerde, this drives the estimation, but now calling
our new functions

I found a few bugs in the existing estimation logic which i fixed.

Note that we inherit a number of inaccuracies from PrestoVectorSerde's estimateSerializedSize, but these are mostly
constants if you ignore that they become multiplied when they occur in the elements of a complex type (it really is just an
estimate).

It also doesn't account for the fact the Serializer may disable dictionary encoding if it doesn't provide value.  I plan to add this
in a follow up to keep this change from becoming more complicated.

Differential Revision: D53593847

