### PR TITLE
Return whether registration succeeded in the custom opaque path

### DIFF
--- a/velox/type/OpaqueCustomTypes.h
+++ b/velox/type/OpaqueCustomTypes.h
@@ -33,8 +33,8 @@ class CastOperator;
 template <typename T, const char* customTypeName>
 class OpaqueCustomTypeRegister {
  public:
-  static void registerType() {
-    facebook::velox::registerCustomType(
+  static bool registerType() {
+    return facebook::velox::registerCustomType(
         customTypeName, std::make_unique<const TypeFactory>());
   }
 


### PR DESCRIPTION
Summary: This makes it easier for callers to check and decide whether they need to register serialization hooks

Differential Revision: D53614803


