### PR TITLE
Fix Presto aggregate function 'avg' bug when counts are zero

### DIFF
--- a/velox/exec/DistinctAggregations.cpp
+++ b/velox/exec/DistinctAggregations.cpp
@@ -122,11 +122,13 @@ class TypedDistinctAggregations : public DistinctAggregations {
           accumulator->extractValues(*(data->template as<FlatVector<T>>()), 0);
         }
 
-        rows.resize(data->size());
-        std::vector<VectorPtr> inputForAggregation_ =
-            makeInputForAggregation(data);
-        aggregate.function->addSingleGroupRawInput(
-            group, rows, inputForAggregation_, false);
+        if (data->size() > 0) {
+          rows.resize(data->size());
+          std::vector<VectorPtr> inputForAggregation =
+              makeInputForAggregation(data);
+          aggregate.function->addSingleGroupRawInput(
+              group, rows, inputForAggregation, false);
+        }
       }
 
       aggregate.function->extractValues(


### PR DESCRIPTION
**What**
This PR fixes Presto aggregate function avg to return Null rather than 0 when count is 0.

**Why**
Currently avg return's Nan when the count of a group is 0. In Presto java , the avg function returns ‘Null’ if the count is 0 : https://github.com/prestodb/presto/blob/master/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AverageAggregations.java#L58 . 
 
 This PR fixes this behavior to be equivalent to one in Presto. Typically we get zero counts when we run single aggregations on distinct values.  
 
 Fixes : https://github.com/facebookincubator/velox/issues/8573 


**Notes**
N/A