### PR TITLE
Add decimal support for min_by and max_by functions

### DIFF
--- a/velox/functions/lib/aggregates/MinMaxByAggregatesBase.h
+++ b/velox/functions/lib/aggregates/MinMaxByAggregatesBase.h
@@ -581,6 +581,9 @@ std::unique_ptr<exec::Aggregate> create(
     case TypeKind::DOUBLE:
       return std::make_unique<Aggregate<W, double, isMaxFunc, Comparator>>(
           resultType);
+    case TypeKind::HUGEINT:
+      return std::make_unique<Aggregate<W, int128_t, isMaxFunc, Comparator>>(
+          resultType);
     case TypeKind::VARBINARY:
       [[fallthrough]];
     case TypeKind::VARCHAR:
@@ -635,6 +638,9 @@ std::unique_ptr<exec::Aggregate> create(
     case TypeKind::BIGINT:
       return create<Aggregate, isMaxFunc, Comparator, int64_t>(
           resultType, compareType, errorMessage, throwOnNestedNulls);
+    case TypeKind::HUGEINT:
+      return create<Aggregate, isMaxFunc, Comparator, int128_t>(
+          resultType, compareType, errorMessage);
     case TypeKind::REAL:
       return create<Aggregate, isMaxFunc, Comparator, float>(
           resultType, compareType, errorMessage, throwOnNestedNulls);

--- a/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -45,7 +45,8 @@ const std::vector<TypeKind> kSupportedTypes = {
     TypeKind::REAL,
     TypeKind::DOUBLE,
     TypeKind::VARCHAR,
-    TypeKind::TIMESTAMP};
+    TypeKind::TIMESTAMP,
+    TypeKind::HUGEINT};
 
 std::vector<TestParam> getTestParams() {
   std::vector<TestParam> params;
@@ -74,6 +75,9 @@ std::vector<TestParam> getTestParams() {
         break;                                                       \
       case TypeKind::BIGINT:                                         \
         testFunc<valueType, int64_t>();                              \
+        break;                                                       \
+      case TypeKind::HUGEINT:                                        \
+        testFunc<valueType, int128_t>();                             \
         break;                                                       \
       case TypeKind::REAL:                                           \
         testFunc<valueType, float>();                                \
@@ -110,6 +114,9 @@ std::vector<TestParam> getTestParams() {
         break;                                                  \
       case TypeKind::BIGINT:                                    \
         EXECUTE_TEST_BY_VALUE_TYPE(testFunc, int64_t);          \
+        break;                                                  \
+      case TypeKind::HUGEINT:                                   \
+        EXECUTE_TEST_BY_VALUE_TYPE(testFunc, int128_t);         \
         break;                                                  \
       case TypeKind::REAL:                                      \
         EXECUTE_TEST_BY_VALUE_TYPE(testFunc, float);            \
@@ -203,6 +210,21 @@ class MinMaxByAggregationTestBase : public AggregationTestBase {
   std::vector<RowVectorPtr> rowVectors_;
 };
 
+template <>
+FlatVectorPtr<int128_t> MinMaxByAggregationTestBase::buildDataVector(
+    vector_size_t size,
+    folly::Range<const int*> values) {
+  if (values.empty()) {
+    return makeFlatVector<int128_t>(
+        size, [](auto row) { return HugeInt::build(row - 3, row - 3); });
+  } else {
+    VELOX_CHECK_EQ(values.size(), size);
+    return makeFlatVector<int128_t>(size, [&](auto row) {
+      return HugeInt::build(values[row], values[row]);
+    });
+  }
+}
+
 // Build a flat vector with StringView. The value in the returned flat vector
 // is in ascending order.
 template <>
@@ -274,6 +296,8 @@ VectorPtr MinMaxByAggregationTestBase::buildDataVector(
       return buildDataVector<float>(size, values);
     case TypeKind::DOUBLE:
       return buildDataVector<double>(size, values);
+    case TypeKind::HUGEINT:
+      return buildDataVector<int128_t>(size, values);
     case TypeKind::VARCHAR:
       return buildDataVector<StringView>(size, values);
     case TypeKind::TIMESTAMP:
@@ -326,6 +350,9 @@ void MinMaxByAggregationTestBase::SetUp() {
         break;
       case TypeKind::BIGINT:
         dataVectorsByType_.emplace(type, buildDataVector<int64_t>(numValues_));
+        break;
+      case TypeKind::HUGEINT:
+        dataVectorsByType_.emplace(type, buildDataVector<int128_t>(numValues_));
         break;
       case TypeKind::REAL:
         dataVectorsByType_.emplace(type, buildDataVector<float>(numValues_));


### PR DESCRIPTION
This change introduces decimal signature for min_by/max_by functions.
For 2-arg version of min_by/max_by, the existing signature definition is generic and no additional changes needed.
For 3-arg version of min_by/max_by, an explicit signature for decimal as compare type need to be added. The 3-arg version doesn't support complex types as compare type and this we cannot define a generic signature.

**Segmentation Fault in priority_queue STL:**
For min_by/max_by aggregates with 3 arguments (specifies N for top N results), we need to maintain a priority_queue (PQ).
This PQ is part of the accumulator. We take care of Accumulator to be memory aligned with int128_t type but PQ itself
must be 128-bit aligned or else we hit a segfault. To avoid this, we can use AlignedStlAllocator to allocate PQ elements whenever value and compare types are int128_t. This seems to fix this test failure:
```
280: [ RUN      ] MinMaxByGlobalByAggregationTest.decimalSignatureTest
280: *** Aborted at 1707784514 (Unix time, try 'date -d @1707784514') ***
280: *** Signal 11 (SIGSEGV) (0x0) received by PID 27168 (pthread TID 0x7f75aa623700) (linux TID 85440) (code: 128), stack trace: ***
280: (error retrieving stack trace)
```

Testing:
Added unit tests for decimals.
Also, extended the existing tests to include HUGEINT type.
Some of the min_by/max_by unit tests also test plan with tableScans. But, due to this issue: https://github.com/facebookincubator/velox/issues/7775, HUGEINT type is not tested for tableScans. This PR: https://github.com/facebookincubator/velox/pull/8910 already skips testing tableScans if type is not supported by DWRF.