### PR TITLE
Fix fmt error in RuntimeMetrics

### DIFF
--- a/velox/common/base/RuntimeMetrics.cpp
+++ b/velox/common/base/RuntimeMetrics.cpp
@@ -41,7 +41,7 @@ void RuntimeMetric::merge(const RuntimeMetric& other)
 #endif
 #endif
 {
-  VELOX_CHECK_EQ(unit, other.unit);
+  VELOX_CHECK(unit == other.unit);
   sum += other.sum;
   count += other.count;
   min = std::min(min, other.min);


### PR DESCRIPTION
After fmt package was updated, some of the VELOX_CHECK_XXX fails. An example error message:
    "error: 'fmt::v10::detail::type_is_unformattable_for<const facebook::velox::RuntimeCounter::Unit, char> _' has incomplete type". This commit fixes this error in RuntimeMetrics.cpp.

The full error log can be found https://app.circleci.com/pipelines/github/facebookincubator/velox/44177/workflows/079e5931-917d-410a-85a5-c62201dae588/jobs/308209
```
/root/project/./velox/common/base/Exceptions.h:153:49:   required from 'std::string facebook::velox::detail::errorMessage(fmt::v10::string_view, const Args& ...) [with Args = {facebook::velox::RuntimeCounter::Unit, facebook::velox::RuntimeCounter::Unit}; std::string = std::__cxx11::basic_string<char>; fmt::v10::string_view = fmt::v10::basic_string_view<char>]'
/root/project/velox/common/base/RuntimeMetrics.cpp:38:3:   required from here
/usr/local/include/fmt/core.h:1576:63: error: 'fmt::v10::detail::type_is_unformattable_for<const facebook::velox::RuntimeCounter::Unit, char> _' has incomplete type
 1576 |     type_is_unformattable_for<T, typename Context::char_type> _;
      |                                                               ^
/usr/local/include/fmt/core.h:1580:7: error: static assertion failed: Cannot format an argument. To make type T formattable provide a formatter<T> specialization: https://fmt.dev/latest/api.html#udt
 1580 |       formattable,
      |       ^~~~~~~~~~~
cc1plus: error: unrecognized command line option '-Wno-stringop-overread' [-Werror]
```