### PR TITLE
Add support for Nan/-Nan/Inf/-Inf and negative floating point numbers in vector fuzzer.

### DIFF
--- a/velox/docs/develop/testing/fuzzer.rst
+++ b/velox/docs/develop/testing/fuzzer.rst
@@ -153,6 +153,8 @@ In addition, Aggregation Fuzzer also supports tuning parameters:
 
 * ``--num_batches``: The number of input vectors of size `--batch_size` to generate. Default is 10.
 
+* ``--velox_fuzzer_nan_inf_threshold``: The chance by which a NaN or Infinity is produced in the fuzzed data. Default is 0 (that is turned off).
+
 If running from CLion IDE, add ``--logtostderr=1`` to see the full output.
 
 An example set of arguments to run the fuzzer with all features enabled is as follows:

--- a/velox/vector/fuzzer/CMakeLists.txt
+++ b/velox/vector/fuzzer/CMakeLists.txt
@@ -14,7 +14,8 @@
 
 add_library(velox_vector_fuzzer VectorFuzzer.cpp GeneratorSpec.cpp Utils.cpp)
 
-target_link_libraries(velox_vector_fuzzer velox_type velox_vector)
+target_link_libraries(velox_vector_fuzzer velox_type velox_vector
+                      gflags::gflags)
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   target_compile_options(velox_vector_fuzzer
                          PRIVATE -Wno-deprecated-declarations)


### PR DESCRIPTION
**What**
This PR adds support for :
1. Nan/Inf/-Inf in vector fuzzer , these are gated by  flag `velox_fuzzer_nan_inf_threshold` and are turned off by default.
2. Add support for negative numbers for floating point types. 

**Why**
This increases our test coverage and hopefully encounter new bugs. Currently we have seen several issues due to NaN (#8759, #8749, etc) due to which NaN support is turned off by default. It can be enabled by setting the `velox_fuzzer_nan_inf_threshold` flag to a value > 0.0. 

**NOTES**
Negative numbers for integers is not part of this as it requires fixes to places where fuzzed dictionary indexes are created.

Fixes : #8638 