### PR TITLE
Move Linux build, adapters and presto fuzzer to gha

### DIFF
--- a/.circleci/dist_compile.yml
+++ b/.circleci/dist_compile.yml
@@ -524,16 +524,9 @@ workflows:
   longer-fuzzer:
     when: << pipeline.parameters.run-longer-expression-fuzzer >>
     jobs:
-      - linux-build
       - linux-pr-fuzzer-run
-      - linux-build-options
-      - linux-adapters
-      - linux-presto-fuzzer-run
 
   shorter-fuzzer:
     unless: << pipeline.parameters.run-longer-expression-fuzzer >>
     jobs:
-      - linux-build
       - linux-pr-fuzzer-run
-      - linux-build-options
-      - linux-adapters

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,14 +48,49 @@ jobs:
             file: "scripts/check-container.dockfile"
             args: "cpu_target=avx"
             tags: "ghcr.io/facebookincubator/velox-dev:check-avx"
-          - name: CircleCI
-            file: "scripts/circleci-container.dockfile"
+          - name: Centos 8
+            file: "scripts/centos.dockerfile"
             args: "cpu_target=avx"
-            tags: "ghcr.io/facebookincubator/velox-dev:circleci-avx"
+            tags: "ghcr.io/facebookincubator/velox-dev:centos8"
           - name: Dev
             file: "scripts/ubuntu-22.04-cpp.dockerfile"
             args: ""
             tags: "ghcr.io/facebookincubator/velox-dev:amd64-ubuntu-22.04-avx"
+
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and Push
+        uses: docker/build-push-action@v3
+        with:
+          file: "${{ matrix.file }}"
+          build-args: "${{ matrix.args }}"
+          push: ${{ github.repository == 'facebookincubator/velox' && github.event_name != 'pull_request'}}
+          tags: "${{ matrix.tags }}"
+
+  linux-needs:
+    name: "Build and Push ${{ matrix.name }}"
+    needs: linux
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Adapters
+            file: "scripts/adapters.dockerfile"
+            args: "cpu_target=avx"
+            tags: "ghcr.io/facebookincubator/velox-dev:adapters"
           - name: Presto Java
             file: "scripts/prestojava-container.dockerfile"
             args: "PRESTO_VERSION=0.284"

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -22,6 +22,8 @@ on:
       - "CMakeLists.txt"
       - "CMake/**"
       - "third_party/**"
+      - "scripts/setup-ubuntu.sh"
+      - "scripts/setup-helper-functions.sh"
       - ".github/workflows/linux-build.yml"
 
   pull_request:
@@ -31,6 +33,8 @@ on:
       - "CMakeLists.txt"
       - "CMake/**"
       - "third_party/**"
+      - "scripts/setup-ubuntu.sh"
+      - "scripts/setup-helper-functions.sh"
       - ".github/workflows/linux-build.yml"
 
 permissions:
@@ -67,7 +71,7 @@ jobs:
           path: '${{ env.CCACHE_DIR }}'
           key: ccache-linux-adapters
 
-      - name: Build
+      - name: Make Release Build
         env:
           MAKEFLAGS: 'NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4'
         run: |
@@ -126,7 +130,7 @@ jobs:
         run: |
           ccache -sz
 
-      - name: Build
+      - name: Make Debug Build
         env:
           VELOX_DEPENDENCY_SOURCE: BUNDLED
           MAKEFLAGS: "NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4"

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,0 +1,147 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Linux Build
+
+on:
+  push:
+    paths:
+      - "velox/**"
+      - "!velox/docs/**"
+      - "CMakeLists.txt"
+      - "CMake/**"
+      - "third_party/**"
+      - ".github/workflows/linux-build.yml"
+
+  pull_request:
+    paths:
+      - "velox/**"
+      - "!velox/docs/**"
+      - "CMakeLists.txt"
+      - "CMake/**"
+      - "third_party/**"
+      - ".github/workflows/linux-build.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  adapters:
+    name: Linux release with adapters
+    runs-on: 8-core
+    container: ghcr.io/facebookincubator/velox-dev:adapters
+    defaults:
+      run:
+        shell: bash
+    env:
+      CCACHE_DIR: "${{ github.workspace }}/.ccache"
+      CCACHE_BASEDIR: "${{ github.workspace }}"
+      VELOX_DEPENDENCY_SOURCE: SYSTEM
+      simdjson_SOURCE: BUNDLED
+      xsimd_SOURCE: BUNDLED
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fix git permissions
+        # Usually actions/checkout does this but as we run in a container
+        # it doesn't work
+        run: git config --global --add safe.directory /__w/velox/velox
+
+      - uses: assignUser/stash/restore@v1
+        with:
+          path: '${{ env.CCACHE_DIR }}'
+          key: ccache-linux-adapters
+
+      - name: Build
+        env:
+          MAKEFLAGS: 'NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4'
+        run: |
+          EXTRA_CMAKE_FLAGS=(
+            "-DVELOX_ENABLE_BENCHMARKS=ON"
+            "-DVELOX_ENABLE_ARROW=ON"
+            "-DVELOX_ENABLE_PARQUET=ON"
+            "-DVELOX_ENABLE_HDFS=ON"
+            "-DVELOX_ENABLE_S3=ON"
+            "-DVELOX_ENABLE_GCS=ON"
+            "-DVELOX_ENABLE_ABFS=ON"
+            "-DVELOX_ENABLE_SUBSTRAIT=ON"
+            "-DVELOX_ENABLE_REMOTE_FUNCTIONS=ON"
+          )
+          make release EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS[*]}"
+
+      - uses: assignUser/stash/save@v1
+        with:
+          path: '${{ env.CCACHE_DIR }}'
+          key: ccache-linux-adapters
+
+      - name: Run Tests
+        # Some of the adapters dependencies are in the 'adapters' conda env
+        shell: mamba run --no-capture-output -n adapters /usr/bin/bash -e {0}
+        env:
+          LIBHDFS3_CONF: "${{ github.workspace }}/.circleci/hdfs-client.xml"
+        working-directory: _build/release
+        run: |
+          ctest -j 8 --output-on-failure --no-tests=error
+
+  ubuntu-debug:
+    runs-on: 8-core
+    name: "Ubuntu debug with resolve_dependency"
+    env:
+      CCACHE_DIR: "${{ github.workspace }}/.ccache"
+      CCACHE_BASEDIR: "${{ github.workspace }}"
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        run: |
+          source scripts/setup-ubuntu.sh
+
+      - uses: assignUser/stash/restore@v1
+        with:
+          path: '${{ env.CCACHE_DIR }}'
+          key: ccache-ubuntu-debug-default
+
+      - run: |
+          mkdir -p .ccache
+
+      - name: Clear CCache Statistics
+        run: |
+          ccache -sz
+
+      - name: Build
+        env:
+          VELOX_DEPENDENCY_SOURCE: BUNDLED
+          MAKEFLAGS: "NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4"
+        run: |
+          make debug EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON"
+
+      - name: CCache after
+        run: |
+          ccache -vs
+
+      - uses: assignUser/stash/save@v1
+        with:
+          path: '${{ env.CCACHE_DIR }}'
+          key: ccache-ubuntu-debug-default
+
+      - name: Run Tests
+        run: |
+          cd _build/debug && ctest -j 8 --output-on-failure --no-tests=error

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -71,7 +71,7 @@ jobs:
   compile:
     name: Build
     runs-on: 8-core
-    timeout-minutes: 120
+    timeout-minutes: 60
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"
       CCACHE_BASEDIR: "${{ github.workspace }}"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -16,6 +16,16 @@ name: "Fuzzer Jobs"
 
 on:
   pull_request:
+    paths:
+      - "velox/**"
+      - "!velox/docs/**"
+      - "CMakeLists.txt"
+      - "CMake/**"
+      - "third_party/**"
+      - "scripts/setup-ubuntu.sh"
+      - "scripts/setup-helper-functions.sh"
+      - ".github/workflows/linux-build.yml"
+
   schedule:
     - cron: '0 3 * * *'
 

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -225,6 +225,47 @@ jobs:
           path: |
             /tmp/fuzzer_repro
 
+  linux-spark-aggregate-fuzzer-run:
+    name: "Spark Aggregate Fuzzer"
+    runs-on: ubuntu-latest
+    needs: compile
+    timeout-minutes: 60
+    steps:
+
+      - name: "Checkout Repo"
+        uses: actions/checkout@v4
+        with:
+          ref: "${{ inputs.ref }}"
+
+      - name: "Install dependencies"
+        run: source ./scripts/setup-ubuntu.sh
+
+      - name: Download spark aggregation fuzzer
+        uses: actions/download-artifact@v4
+        with:
+          name: spark_aggregation_fuzzer
+
+      - name: "Run Spark Aggregate Fuzzer"
+        run: |
+          mkdir -p /tmp/spark_aggregate_fuzzer_repro/
+          chmod -R 777 /tmp/spark_aggregate_fuzzer_repro
+          chmod +x spark_aggregation_fuzzer_test
+          ./spark_aggregation_fuzzer_test \
+                --seed ${RANDOM} \
+                --duration_sec $DURATION \
+                --logtostderr=1 \
+                --minloglevel=0 \
+                --repro_persist_path=/tmp/spark_aggregate_fuzzer_repro \
+          && echo -e "\n\nSpark Aggregation Fuzzer run finished successfully."
+
+      - name: Archive Spark aggregate production artifacts
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: spark-agg-fuzzer-failure-artifacts
+          path: |
+            /tmp/spark_aggregate_fuzzer_repro
+
   linux-spark-fuzzer-run:
     name: "Spark Fuzzer"
     runs-on: ubuntu-latest
@@ -272,33 +313,6 @@ jobs:
           name: spark-fuzzer-failure-artifacts
           path: |
             /tmp/spark_fuzzer_repro
-
-      - name: Download spark aggregation fuzzer
-        uses: actions/download-artifact@v4
-        with:
-          name: spark_aggregation_fuzzer
-
-      - name: "Run Spark Aggregate Fuzzer"
-        run: |
-          mkdir -p /tmp/spark_aggregate_fuzzer_repro/
-          chmod -R 777 /tmp/spark_aggregate_fuzzer_repro
-          chmod +x spark_aggregation_fuzzer_test
-          ./spark_aggregation_fuzzer_test \
-                --seed ${RANDOM} \
-                --duration_sec $DURATION \
-                --logtostderr=1 \
-                --minloglevel=0 \
-                --repro_persist_path=/tmp/spark_aggregate_fuzzer_repro \
-          && echo -e "\n\nSpark Aggregation Fuzzer run finished successfully."
-
-      - name: Archive Spark aggregate production artifacts
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: spark-agg-fuzzer-failure-artifacts
-          path: |
-            /tmp/spark_aggregate_fuzzer_repro
-
 
   linux-aggregate-fuzzer-run:
     name: "Aggregate Fuzzer"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -12,15 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: "Scheduled Fuzzer Jobs"
+name: "Fuzzer Jobs"
 
 on:
   pull_request:
-    paths:
-      - ".github/workflows/scheduled.yml"
-      - scripts/*
-      - CMake/*
-
   schedule:
     - cron: '0 3 * * *'
 
@@ -41,6 +36,9 @@ on:
       extraCMakeFlags:
         description: 'Additional CMake flags'
         default: ''
+      duration:
+        description: 'Duration of fuzzer run in seconds'
+        default: 1800
 
 defaults:
   run:
@@ -49,8 +47,19 @@ defaults:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+env:
+  # Run for 1 minute on PRs
+  DURATION: "${{ inputs.duration || ( github.event_name == 'pull_request' && 60 || 1800 )}}"
+  # minimize artifact duration for PRs, keep them a bit longer for nightly runs
+  RETENTION: "${{ github.event_name == 'pull_request' && 1 || 3 }}"
+
 jobs:
   compile:
+    name: Build
     runs-on: 8-core
     timeout-minutes: 120
     env:
@@ -60,77 +69,123 @@ jobs:
     steps:
 
       - name: "Restore ccache"
-        uses: actions/cache@v3
+        uses: assignUser/stash/restore@v1
         with:
           path: "${{ env.CCACHE_DIR }}"
-          # We are using the benchmark ccache as it has all
-          # required features enabled, so no need to create a new one
-          key: ccache-benchmark-${{ github.sha }}
-          restore-keys: |
-            ccache-benchmark-
+          key: ccache-fuzzer
 
       - name: "Checkout Repo"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: velox
           submodules: 'recursive'
           ref: "${{ inputs.ref }}"
 
       - name: "Install dependencies"
-        run: cd  velox && sudo ./scripts/setup-ubuntu.sh 
+        env:
+          CMAKE_CXX_COMPILER_LAUNCHER: ccache
+          CMAKE_C_COMPILER_LAUNCHER: ccache
+        run: |
+          cd  velox
+          source ./scripts/setup-ubuntu.sh
+          ccache -vsz
 
-      - name: "Build"
+      - name: Build
         run: |
           cd velox
           make debug NUM_THREADS="${{ inputs.numThreads || 8 }}" MAX_HIGH_MEM_JOBS="${{ inputs.maxHighMemJobs || 8 }}" MAX_LINK_JOBS="${{ inputs.maxLinkJobs || 4 }}" EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON ${{ inputs.extraCMakeFlags }}"
-          ccache -s
+
+      - name: Ccache after
+        run: ccache -vs
+
+      - name: "Save ccache"
+        uses: assignUser/stash/save@v1
+        with:
+          path: "${{ env.CCACHE_DIR }}"
+          key: ccache-fuzzer
+          retention-days: "${{ env.RETENTION }}"
 
       - name: Upload presto fuzzer
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: presto
           path: velox/_build/debug/velox/expression/tests/velox_expression_fuzzer_test
+          retention-days: "${{ env.RETENTION }}"
 
       - name: Upload spark expression fuzzer
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: spark_expression_fuzzer
           path: velox/_build/debug/velox/expression/tests/spark_expression_fuzzer_test
+          retention-days: "${{ env.RETENTION }}"
 
       - name: Upload spark aggregation fuzzer
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: spark_aggregation_fuzzer
           path: velox/_build/debug/velox/functions/sparksql/fuzzer/spark_aggregation_fuzzer_test
+          retention-days: "${{ env.RETENTION }}"
 
       - name: Upload aggregation fuzzer
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: aggregation
           path: velox/_build/debug/velox/functions/prestosql/fuzzer/velox_aggregation_fuzzer_test
+          retention-days: "${{ env.RETENTION }}"
 
       - name: Upload join fuzzer
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: join
           path: velox/_build/debug/velox/exec/tests/velox_join_fuzzer_test
+          retention-days: "${{ env.RETENTION }}"
 
   linux-presto-fuzzer-run:
+    name: "Presto Fuzzer"
     runs-on: ubuntu-latest
     needs: compile
     timeout-minutes: 120
     steps:
 
       - name: "Checkout Repo"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: "${{ inputs.ref }}"
 
       - name: "Install dependencies"
-        run: sudo ./scripts/setup-ubuntu.sh
+        run: source ./scripts/setup-ubuntu.sh
+
+      - uses: dorny/paths-filter@v3
+        if: github.event_name == 'pull_request'
+        id: changes
+        with:
+          filters: |
+            presto:
+              - 'velox/expression/!(test)**'
+              - 'velox/exec/!(test)**'
+              - 'velox/common/!(test)**'
+              - 'velox/core/!(test)**'
+              - 'velox/vector/!(test)**'
+
+      - name: Set presto specific fuzzer duration
+        env:
+          # Run for 30 minutes instead of one, when files relevant to presto are touched
+          pr_duration: "${{ steps.changes.outputs.presto == 'true' && 1800 || 60 }}"
+          # Run for 60 minutes otherwise (2x default duration)
+          other_duration: "${{ inputs.duration || 3600 }}"
+          is_pr: "${{ github.event_name == 'pull_request' }}"
+        run: |
+
+          if [ "$is_pr" == "true" ]; then
+            duration=$pr_duration
+          else
+            duration=$other_duration
+          fi
+
+          echo "DURATION=$duration" >> $GITHUB_ENV
 
       - name: Download presto fuzzer
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: presto
 
@@ -149,36 +204,37 @@ jobs:
                 --max_expression_trees_per_step 2 \
                 --retry_with_try \
                 --enable_dereference \
-                --duration_sec 3600 \
+                --duration_sec $DURATION \
                 --logtostderr=1 \
                 --minloglevel=0 \
                 --repro_persist_path=/tmp/fuzzer_repro \
           && echo -e "\n\nFuzzer run finished successfully."
 
       - name: Archive production artifacts
-        if: always()
-        uses: actions/upload-artifact@v3
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
         with:
           name: presto-fuzzer-failure-artifacts
           path: |
             /tmp/fuzzer_repro
 
   linux-spark-fuzzer-run:
+    name: "Spark Fuzzer"
     runs-on: ubuntu-latest
     needs: compile
     timeout-minutes: 120
     steps:
 
       - name: "Checkout Repo"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: "${{ inputs.ref }}"
 
       - name: "Install dependencies"
-        run: sudo ./scripts/setup-ubuntu.sh
+        run: source ./scripts/setup-ubuntu.sh
 
       - name: Download spark expression fuzzer
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: spark_expression_fuzzer
 
@@ -196,22 +252,22 @@ jobs:
                 --max_expression_trees_per_step 2 \
                 --retry_with_try \
                 --enable_dereference \
-                --duration_sec 1800 \
+                --duration_sec $DURATION \
                 --logtostderr=1 \
                 --minloglevel=0 \
                 --repro_persist_path=/tmp/spark_fuzzer_repro \
             && echo -e "\n\nSpark Fuzzer run finished successfully."
 
       - name: Archive Spark expression production artifacts
-        if: always()
-        uses: actions/upload-artifact@v3
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
         with:
           name: spark-fuzzer-failure-artifacts
           path: |
             /tmp/spark_fuzzer_repro
 
       - name: Download spark aggregation fuzzer
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: spark_aggregation_fuzzer
 
@@ -222,15 +278,15 @@ jobs:
           chmod +x spark_aggregation_fuzzer_test
           ./spark_aggregation_fuzzer_test \
                 --seed ${RANDOM} \
-                --duration_sec 1800 \
+                --duration_sec $DURATION \
                 --logtostderr=1 \
                 --minloglevel=0 \
                 --repro_persist_path=/tmp/spark_aggregate_fuzzer_repro \
           && echo -e "\n\nSpark Aggregation Fuzzer run finished successfully."
 
       - name: Archive Spark aggregate production artifacts
-        if: always()
-        uses: actions/upload-artifact@v3
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
         with:
           name: spark-agg-fuzzer-failure-artifacts
           path: |
@@ -238,21 +294,22 @@ jobs:
 
 
   linux-aggregate-fuzzer-run:
+    name: "Aggregate Fuzzer"
     runs-on: ubuntu-latest
     needs: compile
     timeout-minutes: 120
     steps:
 
       - name: "Checkout Repo"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: "${{ inputs.ref }}"
 
       - name: "Install dependencies"
-        run: sudo ./scripts/setup-ubuntu.sh
+        run: source ./scripts/setup-ubuntu.sh
 
       - name: Download aggregation fuzzer
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: aggregation
 
@@ -264,36 +321,37 @@ jobs:
             chmod +x velox_aggregation_fuzzer_test
             ./velox_aggregation_fuzzer_test \
                 --seed ${RANDOM} \
-                --duration_sec 1800 \
+                --duration_sec $DURATION \
                 --logtostderr=1 \
                 --minloglevel=0 \
                 --repro_persist_path=/tmp/aggregate_fuzzer_repro \
             && echo -e "\n\nAggregation fuzzer run finished successfully."
 
       - name: Archive aggregate production artifacts
-        if: always()
-        uses: actions/upload-artifact@v3
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
         with:
           name: aggregate-fuzzer-failure-artifacts
           path: |
             /tmp/aggregate_fuzzer_repro
 
   linux-join-fuzzer-run:
+    name: "Join Fuzzer"
     runs-on: ubuntu-latest
     needs: compile
     timeout-minutes: 120
     steps:
 
       - name: "Checkout Repo"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: "${{ inputs.ref }}"
 
       - name: "Install dependencies"
-        run:  sudo ./scripts/setup-ubuntu.sh
+        run: source ./scripts/setup-ubuntu.sh
 
       - name: Download join fuzzer
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: join
 
@@ -305,14 +363,14 @@ jobs:
           chmod +x velox_join_fuzzer_test
           ./velox_join_fuzzer_test \
                 --seed ${RANDOM} \
-                --duration_sec 1800 \
+                --duration_sec $DURATION \
                 --logtostderr=1 \
                 --minloglevel=0 \
             && echo -e "\n\nAggregation fuzzer run finished successfully."
 
       - name: Archive aggregate production artifacts
-        if: always()
-        uses: actions/upload-artifact@v3
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
         with:
           name: join-fuzzer-failure-artifacts
           path: |

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -52,8 +52,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Run for 1 minute on PRs
-  DURATION: "${{ inputs.duration || ( github.event_name == 'pull_request' && 60 || 1800 )}}"
+  # Run for 15 minute on PRs
+  DURATION: "${{ inputs.duration || ( github.event_name == 'pull_request' && 900 || 1800 )}}"
   # minimize artifact duration for PRs, keep them a bit longer for nightly runs
   RETENTION: "${{ github.event_name == 'pull_request' && 1 || 3 }}"
 
@@ -82,9 +82,6 @@ jobs:
           ref: "${{ inputs.ref }}"
 
       - name: "Install dependencies"
-        env:
-          CMAKE_CXX_COMPILER_LAUNCHER: ccache
-          CMAKE_C_COMPILER_LAUNCHER: ccache
         run: |
           cd  velox
           source ./scripts/setup-ubuntu.sh
@@ -169,8 +166,8 @@ jobs:
 
       - name: Set presto specific fuzzer duration
         env:
-          # Run for 30 minutes instead of one, when files relevant to presto are touched
-          pr_duration: "${{ steps.changes.outputs.presto == 'true' && 1800 || 60 }}"
+          # Run for 15 minutes instead of one, when files relevant to presto are touched
+          pr_duration: "${{ steps.changes.outputs.presto == 'true' && 1800 || 900 }}"
           # Run for 60 minutes otherwise (2x default duration)
           other_duration: "${{ inputs.duration || 3600 }}"
           is_pr: "${{ github.event_name == 'pull_request' }}"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -71,7 +71,7 @@ jobs:
   compile:
     name: Build
     runs-on: 8-core
-    timeout-minutes: 60
+    timeout-minutes: 120
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"
       CCACHE_BASEDIR: "${{ github.workspace }}"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -176,9 +176,9 @@ jobs:
 
       - name: Set presto specific fuzzer duration
         env:
-          # Run for 15 minutes instead of one, when files relevant to presto are touched
+          # Run for 30 minutes instead of 15, when files relevant to presto are touched
           pr_duration: "${{ steps.changes.outputs.presto == 'true' && 1800 || 900 }}"
-          # Run for 60 minutes otherwise (2x default duration)
+          # Run for 60 minutes if its a scheduled run
           other_duration: "${{ inputs.duration || 3600 }}"
           is_pr: "${{ github.event_name == 'pull_request' }}"
         run: |

--- a/CMake/resolve_dependency_modules/boost/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/boost/CMakeLists.txt
@@ -62,7 +62,7 @@ list(APPEND BOOST_INCLUDE_LIBRARIES ${BOOST_HEADER_ONLY})
 
 # The `headers` target is not created by Boost cmake and leads to a warning
 list(REMOVE_ITEM BOOST_INCLUDE_LIBRARIES headers)
-set(BUILD_SHARED_LIBS ON)
+set(BUILD_SHARED_LIBS OFF)
 FetchContent_MakeAvailable(Boost)
 
 list(TRANSFORM BOOST_HEADER_ONLY PREPEND Boost::)

--- a/CMake/resolve_dependency_modules/boost/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/boost/CMakeLists.txt
@@ -67,3 +67,4 @@ FetchContent_MakeAvailable(Boost)
 
 list(TRANSFORM BOOST_HEADER_ONLY PREPEND Boost::)
 target_link_libraries(boost_headers INTERFACE ${BOOST_HEADER_ONLY})
+add_library(Boost::headers ALIAS boost_headers)

--- a/CMake/resolve_dependency_modules/boost/FindBoost.cmake.in
+++ b/CMake/resolve_dependency_modules/boost/FindBoost.cmake.in
@@ -14,5 +14,6 @@
 message(STATUS "Using Boost - Bundled")
 set(Boost_FOUND TRUE)
 set(Boost_LIBRARIES @BOOST_INCLUDE_LIBRARIES@)
+list(APPEND Boost_LIBRARIES headers)
 list(TRANSFORM Boost_LIBRARIES PREPEND Boost::)
 message(STATUS "Boost targets: ${Boost_LIBRARIES}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,7 +382,6 @@ endif()
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(BOOST_INCLUDE_LIBRARIES
-    headers
     atomic
     context
     date_time

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 cmake_minimum_required(VERSION 3.14)
+message(STATUS "Building using CMake version: ${CMAKE_VERSION}")
 
 # The policy allows us to change options without caching.
 cmake_policy(SET CMP0077 NEW)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,16 +40,19 @@ services:
     #   or
     #   docker-compose run -e NUM_THREADS=<NUMBER_OF_THREADS_TO_USE> --rm centos-cpp
     #   to set the number of threads used during compilation
-    image: ghcr.io/facebookincubator/velox-dev:amd64-centos-8-avx
+    image: ghcr.io/facebookincubator/velox-dev:centos8
     build:
       context: .
-      dockerfile: scripts/centos-8-stream.dockerfile
+      dockerfile: scripts/centos.dockerfile
+      args:
+        image: quay.io/centos/centos:stream8 
     environment:
       NUM_THREADS: 8 # default value for NUM_THREADS
       CCACHE_DIR: "/velox/.ccache"
     volumes:
       - .:/velox:delegated
-    command: /bin/bash -c "scl enable gcc-toolset-9 '/velox/scripts/docker-command.sh'"
+    working_dir: /velox
+    command: /velox/scripts/docker-command.sh
 
   presto-java:
   # Usage:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,4 +72,5 @@ services:
       CCACHE_DIR: "/velox/.ccache"
     volumes:
       - .:/velox:delegated
-    command: /bin/bash -c "scl enable gcc-toolset-9 '/velox/scripts/docker-command.sh'"
+    working_dir: /velox
+    command: /velox/scripts/docker-command.sh

--- a/scripts/adapters.dockerfile
+++ b/scripts/adapters.dockerfile
@@ -1,0 +1,45 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Build the test and build container for presto_cpp
+ARG image=ghcr.io/facebookincubator/velox-dev:centos8
+FROM $image
+ARG cpu_target=avx
+ENV CPU_TARGET=$cpu_target
+
+COPY scripts/setup-adapters.sh /
+RUN mkdir build && ( cd build &&  source /opt/rh/gcc-toolset-9/enable && \
+    bash /setup-adapters.sh ) && rm -rf build && dnf remove -y conda && dnf clean all
+
+# install miniforge
+RUN curl -L -o /tmp/miniforge.sh https://github.com/conda-forge/miniforge/releases/download/23.11.0-0/Mambaforge-23.11.0-0-Linux-x86_64.sh && \
+    bash /tmp/miniforge.sh -b -p /opt/miniforge && \
+    rm /tmp/miniforge.sh
+ENV PATH=/opt/miniforge/condabin:${PATH} 
+
+# install test dependencies
+RUN mamba create -y --name adapters python=3.8
+SHELL ["mamba", "run", "-n", "adapters", "/bin/bash", "-c"]
+
+RUN pip install https://github.com/googleapis/storage-testbench/archive/refs/tags/v0.36.0.tar.gz
+RUN mamba install -y nodejs openjdk
+RUN npm install -g azurite
+
+ENV HADOOP_HOME=/usr/local/hadoop \
+    HADOOP_ROOT_LOGGER="WARN,DRFA" \
+    LC_ALL=C \
+    LIBHDFS3_CONF=/velox/.circleci/hdfs-client.xml \
+    PATH=/usr/local/hadoop/bin:${PATH}
+
+ENTRYPOINT ["/bin/bash", "-c", "source /opt/rh/gcc-toolset-9/enable && exec \"$@\"", "--"]
+CMD ["/bin/bash"]

--- a/scripts/centos.dockerfile
+++ b/scripts/centos.dockerfile
@@ -1,0 +1,36 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Build the test and build container for presto_cpp
+ARG image=quay.io/centos/centos:stream8
+FROM $image
+ARG cpu_target=avx
+ENV CPU_TARGET=$cpu_target
+
+COPY scripts/setup-helper-functions.sh /
+COPY scripts/setup-centos8.sh /
+# The removal of the build dir has to happen in the same layer as the build
+# to minimize the image size. gh & jq are required for CI
+RUN mkdir build && ( cd build && bash /setup-centos8.sh ) && rm -rf build && \
+        dnf install -y -q 'dnf-command(config-manager)' && \
+        dnf config-manager --add-repo 'https://cli.github.com/packages/rpm/gh-cli.repo' && \
+        dnf install -y -q gh jq python39 && \
+        dnf clean all && \
+        alternatives --remove python3 /usr/bin/python3.6
+
+
+ENV CC=/opt/rh/gcc-toolset-9/root/bin/gcc \
+    CXX=/opt/rh/gcc-toolset-9/root/bin/g++
+
+ENTRYPOINT ["/bin/bash", "-c", "source /opt/rh/gcc-toolset-9/enable && exec \"$@\"", "--"]
+CMD ["/bin/bash"]

--- a/scripts/docker-command.sh
+++ b/scripts/docker-command.sh
@@ -16,4 +16,4 @@
 set -eu
 # Compilation and testing
 make
-cd _build/release && ctest -j${NUM_THREADS} -VV --output-on-failure --no-tests=error
+cd _build/release && ctest -j${NUM_THREADS} --output-on-failure --no-tests=error

--- a/scripts/prestojava-container.dockerfile
+++ b/scripts/prestojava-container.dockerfile
@@ -13,12 +13,11 @@
 # limitations under the License.
 # Build the test and build container for presto_cpp
 #
-FROM quay.io/centos/centos:stream8
+FROM ghcr.io/facebookincubator/velox-dev:centos8 
 
-ARG PRESTO_VERSION
+ARG PRESTO_VERSION=0.284
 
 ADD scripts /velox/scripts/
-RUN /velox/scripts/setup-centos8.sh
 RUN wget https://repo1.maven.org/maven2/com/facebook/presto/presto-server/${PRESTO_VERSION}/presto-server-${PRESTO_VERSION}.tar.gz
 RUN wget https://repo1.maven.org/maven2/com/facebook/presto/presto-cli/${PRESTO_VERSION}/presto-cli-${PRESTO_VERSION}-executable.jar
 

--- a/scripts/prestojava-container.dockerfile
+++ b/scripts/prestojava-container.dockerfile
@@ -15,7 +15,7 @@
 #
 FROM ghcr.io/facebookincubator/velox-dev:centos8 
 
-ARG PRESTO_VERSION=0.284
+ARG PRESTO_VERSION=0.286
 
 ADD scripts /velox/scripts/
 RUN wget https://repo1.maven.org/maven2/com/facebook/presto/presto-server/${PRESTO_VERSION}/presto-server-${PRESTO_VERSION}.tar.gz

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -44,6 +44,7 @@ ${SUDO} apt install -y \
   ninja-build \
   checkinstall \
   git \
+  libboost-all-dev \
   libc-ares-dev \
   libcurl4-openssl-dev \
   libssl-dev \
@@ -125,7 +126,6 @@ function install_conda {
 
 function install_velox_deps {
   run_and_time install_fmt
-  run_and_time install_boost
   run_and_time install_folly
   run_and_time install_fizz
   run_and_time install_wangle

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -44,7 +44,6 @@ ${SUDO} apt install -y \
   ninja-build \
   checkinstall \
   git \
-  libboost-all-dev \
   libc-ares-dev \
   libcurl4-openssl-dev \
   libssl-dev \
@@ -126,6 +125,7 @@ function install_conda {
 
 function install_velox_deps {
   run_and_time install_fmt
+  run_and_time install_boost
   run_and_time install_folly
   run_and_time install_fizz
   run_and_time install_wangle


### PR DESCRIPTION
This PR moves the following jobs to gha:
- adapters
- presto fuzzer run
- linux build + short fuzzer

I have integrated the short 60s normal and extended 1800s presto fuzzer into the existing workflow in `scheduled.yml` (which we probably want to rename to `fuzzer.yml` ^^).

I have added new docker files for the adapters job so we can close #8270 @kgpai .

In a follow up pr I will add the signature check and bias fuzzer to the `ubuntu-debug` job. Additionally I will use the new centos docker file to create an image based on manylinux for #9014 .