### PR TITLE
Add TaskOutput Operator for shuffling with a single destination

### DIFF
--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -48,7 +48,7 @@ LimitNode                   Limit
 UnnestNode                  Unnest
 TableWriteNode              TableWrite
 TableWriteMergeNode         TableWriteMerge
-PartitionedOutputNode       PartitionedOutput
+PartitionedOutputNode       PartitionedOutput or TaskOutput
 ExchangeNode                Exchange                                         Y
 ExpandNode                  Expand
 MergeExchangeNode           MergeExchange                                    Y
@@ -316,7 +316,7 @@ constructor within the Project operation.
    * - names
      - A list of new column names.
 
-ExpandNode is typically used to compute GROUPING SETS, CUBE, ROLLUP and COUNT DISTINCT.   
+ExpandNode is typically used to compute GROUPING SETS, CUBE, ROLLUP and COUNT DISTINCT.
 
 To illustrate how ExpandNode works lets examine the following SQL query:
 
@@ -347,7 +347,7 @@ After the computation by the ExpandNode, each row will generate 3 rows of data. 
 
 .. code-block::
 
-  l_suppkey l_orderkey l_partkey grouping_id_0 
+  l_suppkey l_orderkey l_partkey grouping_id_0
   93        1          673       0
   93        1          null      1
   93        null       null      3
@@ -389,15 +389,15 @@ For example, if the input rows are:
 .. code-block::
 
   l_suppkey l_partkey
-  93        673     
-  75        674      
+  93        673
+  75        674
   38        22
 
 After the computation by the ExpandNode, each row will generate 2 rows of data. So there will be a total of 6 rows:
 
 .. code-block::
 
-  l_suppkey l_partkey grouping_id_0 
+  l_suppkey l_partkey grouping_id_0
   93        null      1
   null      673       2
   75        null      1
@@ -409,7 +409,7 @@ Aggregation operator that follows, groups these rows by (l_suppkey, l_partkey, g
 
 .. code-block::
 
-  l_suppkey l_partkey grouping_id_0 
+  l_suppkey l_partkey grouping_id_0
   93        null      1
   75        null      1
   38        null      1
@@ -732,7 +732,7 @@ distribution fields.
    * - keys
      - Zero or more input fields to use for calculating a partition for each row.
    * - numPartitions
-     - Number of partitions to split the data into.g
+     - Number of partitions to split the data into. If 1 the execution will use the TaskOutput operator, otherwise the PartitionedOutput operator will be used.
    * - replicateNullsAndAny
      - Boolean flag indicating whether rows with nulls in the keys should be sent to all partitions and, in case there are no such rows, whether a single arbitrarily chosen row should be sent to all partitions. Used to provide global-scope information necessary to implement anti join semantics on a single node.
    * - partitionFunctionFactory

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -77,6 +77,7 @@ add_library(
   TableWriteMerge.cpp
   TableWriter.cpp
   Task.cpp
+  TaskOutput.cpp
   TopN.cpp
   TopNRowNumber.cpp
   Unnest.cpp

--- a/velox/exec/OutputBufferManager.h
+++ b/velox/exec/OutputBufferManager.h
@@ -143,12 +143,24 @@ class OutputBufferManager {
     return compressionKind_;
   }
 
+  void testingSetMinCompressionRatio(const float minCompressionRatio) {
+    *const_cast<float*>(&minCompressionRatio_) = minCompressionRatio;
+  }
+
+  float minCompressionRatio() const {
+    return minCompressionRatio_;
+  }
+
  private:
   // Retrieves the set of buffers for a query.
   // Throws an exception if buffer doesn't exist.
   std::shared_ptr<OutputBuffer> getBuffer(const std::string& taskId);
 
   const common::CompressionKind compressionKind_;
+
+  // If compression is enabled, this is the minimum compression that
+  // must be achieved before starting to skip compression. Used for testing.
+  const float minCompressionRatio_ = 0.8;
 
   folly::Synchronized<
       std::unordered_map<std::string, std::shared_ptr<OutputBuffer>>,

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -57,7 +57,8 @@ BlockingReason Destination::advance(
     serializer::presto::PrestoVectorSerde::PrestoOptions options;
     options.compressionKind =
         OutputBufferManager::getInstance().lock()->compressionKind();
-    options.minCompressionRatio = PartitionedOutput::minCompressionRatio();
+    options.minCompressionRatio =
+        OutputBufferManager::getInstance().lock()->minCompressionRatio();
     current_->createStreamTree(rowType, rowsInCurrent_, &options);
   }
   current_->append(

--- a/velox/exec/PartitionedOutput.h
+++ b/velox/exec/PartitionedOutput.h
@@ -185,14 +185,6 @@ class PartitionedOutput : public Operator {
     destinations_.clear();
   }
 
-  static void testingSetMinCompressionRatio(float ratio) {
-    minCompressionRatio_ = ratio;
-  }
-
-  static float minCompressionRatio() {
-    return minCompressionRatio_;
-  }
-
  private:
   void initializeInput(RowVectorPtr input);
 
@@ -204,10 +196,6 @@ class PartitionedOutput : public Operator {
 
   /// Collect all rows with null keys into nullRows_.
   void collectNullRows();
-
-  // If compression in serde is enabled, this is the minimum compression that
-  // must be achieved before starting to skip compression. Used for testing.
-  inline static float minCompressionRatio_ = 0.8;
 
   const std::vector<column_index_t> keyChannels_;
   const int numDestinations_;

--- a/velox/exec/TaskOutput.cpp
+++ b/velox/exec/TaskOutput.cpp
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/TaskOutput.h"
+
+#include "velox/exec/OutputBufferManager.h"
+#include "velox/exec/Task.h"
+
+namespace facebook::velox::exec {
+namespace {
+void generateSplits(
+    const std::unique_ptr<BatchVectorSerializer>& serializer,
+    const VectorPtr& input,
+    const IndexRange& inputRange,
+    vector_size_t previousSize,
+    vector_size_t targetSize,
+    Scratch& scratch,
+    std::vector<detail::Split>& splits) {
+  if (inputRange.size == 1) {
+    splits.push_back({inputRange, previousSize});
+    return;
+  }
+
+  vector_size_t size;
+  vector_size_t* sizePtr = &size;
+
+  serializer->estimateSerializedSize(
+      input, {&inputRange, 1}, &sizePtr, scratch);
+
+  if (size <= targetSize || size == previousSize) {
+    splits.push_back({inputRange, size});
+    return;
+  }
+
+  IndexRange left{inputRange.begin, inputRange.size / 2};
+  IndexRange right{
+      inputRange.begin + inputRange.size / 2,
+      inputRange.size - inputRange.size / 2};
+
+  generateSplits(serializer, input, left, size, targetSize, scratch, splits);
+  generateSplits(serializer, input, right, size, targetSize, scratch, splits);
+}
+} // namespace
+
+TaskOutput::TaskOutput(
+    int32_t operatorId,
+    DriverCtx* ctx,
+    const std::shared_ptr<const core::PartitionedOutputNode>& planNode)
+    : Operator(
+          ctx,
+          planNode->outputType(),
+          operatorId,
+          planNode->id(),
+          "TaskOutput"),
+      outputChannels_(calculateOutputChannels(
+          planNode->inputType(),
+          planNode->outputType(),
+          planNode->outputType())),
+      bufferManager_(OutputBufferManager::getInstance()),
+      // NOTE: 'bufferReleaseFn_' holds a reference on the associated task to
+      // prevent it from deleting while there are output buffers being accessed
+      // out of the partitioned output buffer manager such as in Prestissimo,
+      // the http server holds the buffers while sending the data response.
+      bufferReleaseFn_([task = operatorCtx_->task()]() {}),
+      taskId_(operatorCtx_->taskId()) {
+  serializer::presto::PrestoVectorSerde::PrestoOptions options;
+  options.compressionKind =
+      OutputBufferManager::getInstance().lock()->compressionKind();
+  options.minCompressionRatio =
+      OutputBufferManager::getInstance().lock()->minCompressionRatio();
+  serializer_ = getVectorSerde()->createBatchSerializer(pool(), &options);
+}
+
+void TaskOutput::initializeOutput(const RowVectorPtr& input) {
+  if (outputType_->size() == 0) {
+    output_ = std::make_shared<RowVector>(
+        input->pool(),
+        outputType_,
+        nullptr /*nulls*/,
+        input->size(),
+        std::vector<VectorPtr>{});
+  } else if (outputChannels_.empty()) {
+    output_ = input;
+  } else {
+    std::vector<VectorPtr> outputColumns;
+    outputColumns.reserve(outputChannels_.size());
+    for (auto i : outputChannels_) {
+      outputColumns.push_back(input->childAt(i));
+    }
+
+    output_ = std::make_shared<RowVector>(
+        input->pool(),
+        outputType_,
+        nullptr /*nulls*/,
+        input->size(),
+        outputColumns);
+  }
+}
+
+void TaskOutput::addInput(RowVectorPtr input) {
+  initializeOutput(input);
+
+  splits_.clear();
+  splitIdx_ = 0;
+
+  // Limit serialized pages to ~1MB.
+  static const vector_size_t kBaseTargetSize = 1 << 20;
+  vector_size_t targetSizePct = 70 + (folly::Random::rand32(rng_) % 50);
+  vector_size_t targetSize = (kBaseTargetSize * targetSizePct) / 100;
+
+  generateSplits(
+      serializer_,
+      output_,
+      {0, output_->size()},
+      0,
+      targetSize,
+      scratch_,
+      splits_);
+}
+
+RowVectorPtr TaskOutput::getOutput() {
+  if (finished_) {
+    return nullptr;
+  }
+
+  blockingReason_ = BlockingReason::kNotBlocked;
+  auto bufferManager = bufferManager_.lock();
+  VELOX_CHECK_NOT_NULL(
+      bufferManager, "OutputBufferManager was already destructed");
+
+  while (blockingReason_ == BlockingReason::kNotBlocked &&
+         splitIdx_ < splits_.size()) {
+    static constexpr vector_size_t kMinMessageSize = 128;
+
+    const auto& split = splits_[splitIdx_++];
+    auto listener = bufferManager->newListener();
+    IOBufOutputStream stream(
+        *pool(),
+        listener.get(),
+        std::max<vector_size_t>(kMinMessageSize, split.estimatedSize));
+    const int64_t flushedRows = split.range.size;
+
+    serializer_->serialize(output_, {&split.range, 1}, scratch_, &stream);
+
+    const int64_t flushedBytes = stream.tellp();
+
+    const bool blocked = bufferManager->enqueue(
+        taskId_,
+        0,
+        std::make_unique<SerializedPage>(
+            stream.getIOBuf(bufferReleaseFn_), nullptr, flushedRows),
+        &future_);
+
+    {
+      auto lockedStats = stats_.wlock();
+      lockedStats->addOutputVector(flushedBytes, flushedRows);
+    }
+
+    blockingReason_ = blocked ? BlockingReason::kWaitForConsumer
+                              : BlockingReason::kNotBlocked;
+  }
+
+  if (blockingReason_ != BlockingReason::kNotBlocked) {
+    // The input isn't fully processed yet.
+    return nullptr;
+  }
+
+  if (noMoreInput_) {
+    bufferManager->noMoreData(taskId_);
+    finished_ = true;
+
+    // Update the runtime stats with the serializer stats.
+    const auto serializerStats = serializer_->runtimeStats();
+    auto lockedStats = stats().wlock();
+    for (auto& pair : serializerStats) {
+      lockedStats->addRuntimeStat(pair.first, pair.second);
+    }
+  }
+  // The input is fully processed, drop the reference to allow reuse.
+  output_ = nullptr;
+  return nullptr;
+}
+
+bool TaskOutput::isFinished() {
+  return finished_;
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/TaskOutput.h
+++ b/velox/exec/TaskOutput.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/Random.h>
+#include "velox/exec/Operator.h"
+#include "velox/exec/OutputBufferManager.h"
+#include "velox/vector/VectorStream.h"
+
+namespace facebook::velox::exec {
+namespace detail {
+struct Split {
+  IndexRange range;
+  vector_size_t estimatedSize;
+};
+} // namespace detail
+
+// In a distributed query engine data needs to be broadcast to workers. Either
+// so that each worker has a copy of the data, e.g. a join where one side is
+// small, or to distribute work arbitrarily to roughly balance the number of
+// rows. TaskOutput operator is responsible for this process: it takes a stream
+// of data that is destined for a single OutputBuffer to be broadcast from, and
+// breaks the stream into a series of batches which are written to the
+// OutputBuffer. This operator is also capable of re-ordering and dropping
+// columns from its input.
+class TaskOutput : public Operator {
+ public:
+  TaskOutput(
+      int32_t operatorId,
+      DriverCtx* ctx,
+      const std::shared_ptr<const core::PartitionedOutputNode>& planNode);
+
+  void addInput(RowVectorPtr input) override;
+
+  // Always returns nullptr. The action is to further process
+  // unprocessed input. If all input has been processed, 'this' is in
+  // a non-blocked state, otherwise blocked.
+  RowVectorPtr getOutput() override;
+
+  // Always true but the caller will check isBlocked before adding input, hence
+  // the blocked state does not accumulate input.
+  bool needsInput() const override {
+    return true;
+  }
+
+  BlockingReason isBlocked(ContinueFuture* future) override {
+    if (blockingReason_ != BlockingReason::kNotBlocked) {
+      *future = std::move(future_);
+      blockingReason_ = BlockingReason::kNotBlocked;
+      return BlockingReason::kWaitForConsumer;
+    }
+    return BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override;
+
+ private:
+  void initializeOutput(const RowVectorPtr& input);
+
+  std::unique_ptr<BatchVectorSerializer> serializer_;
+  // Empty if column order in the output is exactly the same as in input.
+  const std::vector<column_index_t> outputChannels_;
+  const std::weak_ptr<exec::OutputBufferManager> bufferManager_;
+  const std::function<void()> bufferReleaseFn_;
+  const std::string taskId_;
+
+  BlockingReason blockingReason_{BlockingReason::kNotBlocked};
+  ContinueFuture future_;
+  bool finished_{false};
+  RowVectorPtr output_;
+
+  // Specifies ranges of the input vector that will be written as batches to the
+  // output buffer.
+  std::vector<detail::Split> splits_;
+  vector_size_t splitIdx_{0};
+
+  // Generator for varying target batch size. Randomly seeded at construction.
+  folly::Random::DefaultGenerator rng_;
+
+  // Reusable memory.
+  Scratch scratch_;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -133,6 +133,12 @@ class BatchVectorSerializer {
 
   /// Serializes all rows in a vector.
   void serialize(const RowVectorPtr& vector, OutputStream* stream);
+
+  /// Returns serializer-dependent counters, e.g. about compression, data
+  /// distribution, encoding etc.
+  virtual std::unordered_map<std::string, RuntimeCounter> runtimeStats() {
+    return {};
+  }
 };
 
 class VectorSerde {


### PR DESCRIPTION
Summary:
Currently we use the same logic whether a PartitionedOutput operator has 1 destination (OutputBuffer) or many.

With the BatchVectorSerializer we can take advantage of the fact data is going to a single destination to maintain encodings
in the serialized data reducing the amount of data shuffled.  In order to use this we need to change the way input RowVectors
are divided into pages.  With the IterativeVectorSerializer we can add rows one by one until a byte size or row number limit is
hit.  With BatchVectorSerializer the size of individual rows is no longer independent, and neither is the serialization, so we
need to estimate the size of batches of rows (splits) from the same RowVector and serialize these batches in a single request.

This fundamentally changes the strategy for preparing rows to be serialized, as well as the process of serializing them such
that I thought splitting it into a separate Operator, which I've called TaskOutput (borrowed from Presto).  This operator is 
overall much simpler than PartitionedOutput with only a small amount of duplicated code.

The general flow is:
* addInput constructs the output from the input based on the outputChannels
* the output is divided into splits by recursively splitting it in half until the estimated size of each split is less than the limit
* getOutput serializes one batch at a time to the OutputBuffer until all the input is written out or the Buffer blocks

Note that I did not implement the row limit from PartitionedOutput.  I assumed that that was added to make sure we don't buffer many rows when the rows are really small, which could delay processing (we could be processing rather than waiting for more).  Since TaskOutput is guaranteed to output after each input there's no need to worry about waiting too long buffering.

Differential Revision: D53717840


