### PR TITLE
Report rawInputPositions stat for MergeExchange

### DIFF
--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -167,6 +167,7 @@ class MergeExchangeSource : public MergeSource {
 
       auto lockedStats = mergeExchange_->stats().wlock();
       lockedStats->addInputVector(data->estimateFlatSize(), data->size());
+      lockedStats->rawInputPositions += data->size();
     }
 
     // Since VectorStreamGroup::read() may cause inputStream to be at end,


### PR DESCRIPTION
Source operators are expected to report rawInputBytes and rawInputPositions.
MergeExchange didn't report rawInputPositions.

Prestissimo uses 'rawInputPositions' to show number of rows processed by a task
in the coordinator UI. When this stat is missing, the UI shows zero.