### PR TITLE
Drop support for TIMESTAMP input from dayofweek Spark function

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -71,17 +71,12 @@ These functions support TIMESTAMP and DATE input types.
 
         SELECT dayofyear('2016-04-09'); -- 100
 
-.. spark:function:: dayofweek(date/timestamp) -> integer
+.. spark:function:: dayofweek(date) -> integer
 
-    Returns the day of the week for date/timestamp (1 = Sunday, 2 = Monday, ..., 7 = Saturday).
-    We can use `dow` as alias for ::
+    Returns the day of the week for date (1 = Sunday, 2 = Monday, ..., 7 = Saturday).
 
         SELECT dayofweek('2009-07-30'); -- 5
-        SELECT dayofweek('2023-08-22 11:23:00.100'); -- 3
-
-.. spark:function:: dow(x) -> integer
-
-    This is an alias for :spark:func:`dayofweek`.
+        SELECT dayofweek('2023-08-22'); -- 3
 
 .. spark:function:: from_unixtime(unixTime, format) -> string
 

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -396,18 +396,12 @@ struct DateSubFunction {
 };
 
 template <typename T>
-struct DayOfWeekFunction : public InitSessionTimezone<T> {
+struct DayOfWeekFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   // 1 = Sunday, 2 = Monday, ..., 7 = Saturday
   FOLLY_ALWAYS_INLINE int32_t getDayOfWeek(const std::tm& time) {
     return time.tm_wday + 1;
-  }
-
-  FOLLY_ALWAYS_INLINE void call(
-      int32_t& result,
-      const arg_type<Timestamp>& timestamp) {
-    result = getDayOfWeek(getDateTime(timestamp, this->timeZone_));
   }
 
   FOLLY_ALWAYS_INLINE void call(int32_t& result, const arg_type<Date>& date) {

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -304,10 +304,7 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<DayOfYearFunction, int32_t, Date>(
       {prefix + "doy", prefix + "dayofyear"});
 
-  registerFunction<DayOfWeekFunction, int32_t, Timestamp>(
-      {prefix + "dow", prefix + "dayofweek"});
-  registerFunction<DayOfWeekFunction, int32_t, Date>(
-      {prefix + "dow", prefix + "dayofweek"});
+  registerFunction<DayOfWeekFunction, int32_t, Date>({prefix + "dayofweek"});
 
   registerFunction<QuarterFunction, int32_t, Date>({prefix + "quarter"});
 

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -431,26 +431,23 @@ TEST_F(DateTimeFunctionsTest, dayOfWeekDate) {
     return evaluateOnce<int32_t, int32_t>("dayofweek(c0)", {date}, {DATE()});
   };
 
-    EXPECT_EQ(std::nullopt, dayOfWeek(std::nullopt));
-    EXPECT_EQ(5, dayOfWeek(0));
-    EXPECT_EQ(4, dayOfWeek(-1));
-    EXPECT_EQ(7, dayOfWeek(-40));
-    EXPECT_EQ(5, dayOfWeek(parseDate("2009-07-30")));
-    EXPECT_EQ(1, dayOfWeek(parseDate("2023-08-20")));
-    EXPECT_EQ(2, dayOfWeek(parseDate("2023-08-21")));
-    EXPECT_EQ(3, dayOfWeek(parseDate("2023-08-22")));
-    EXPECT_EQ(4, dayOfWeek(parseDate("2023-08-23")));
-    EXPECT_EQ(5, dayOfWeek(parseDate("2023-08-24")));
-    EXPECT_EQ(6, dayOfWeek(parseDate("2023-08-25")));
-    EXPECT_EQ(7, dayOfWeek(parseDate("2023-08-26")));
-    EXPECT_EQ(1, dayOfWeek(parseDate("2023-08-27")));
-    EXPECT_EQ(6, dayOfWeek(util::fromDateString("2011-05-06")));
-    EXPECT_EQ(
-        4, dayOfWeek(util::fromDateString("2015-04-08")));
-    EXPECT_EQ(
-        7, dayOfWeek(util::fromDateString("2017-05-27")));
-    EXPECT_EQ(
-        6, dayOfWeek(util::fromDateString("1582-10-15")));
+  EXPECT_EQ(std::nullopt, dayOfWeek(std::nullopt));
+  EXPECT_EQ(5, dayOfWeek(0));
+  EXPECT_EQ(4, dayOfWeek(-1));
+  EXPECT_EQ(7, dayOfWeek(-40));
+  EXPECT_EQ(5, dayOfWeek(parseDate("2009-07-30")));
+  EXPECT_EQ(1, dayOfWeek(parseDate("2023-08-20")));
+  EXPECT_EQ(2, dayOfWeek(parseDate("2023-08-21")));
+  EXPECT_EQ(3, dayOfWeek(parseDate("2023-08-22")));
+  EXPECT_EQ(4, dayOfWeek(parseDate("2023-08-23")));
+  EXPECT_EQ(5, dayOfWeek(parseDate("2023-08-24")));
+  EXPECT_EQ(6, dayOfWeek(parseDate("2023-08-25")));
+  EXPECT_EQ(7, dayOfWeek(parseDate("2023-08-26")));
+  EXPECT_EQ(1, dayOfWeek(parseDate("2023-08-27")));
+  EXPECT_EQ(6, dayOfWeek(util::fromDateString("2011-05-06")));
+  EXPECT_EQ(4, dayOfWeek(util::fromDateString("2015-04-08")));
+  EXPECT_EQ(7, dayOfWeek(util::fromDateString("2017-05-27")));
+  EXPECT_EQ(6, dayOfWeek(util::fromDateString("1582-10-15")));
 }
 
 TEST_F(DateTimeFunctionsTest, dateDiffDate) {

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -427,73 +427,30 @@ TEST_F(DateTimeFunctionsTest, dayOfMonth) {
 }
 
 TEST_F(DateTimeFunctionsTest, dayOfWeekDate) {
-  const auto dayOfWeek = [&](std::optional<int32_t> date,
-                             const std::string& func) {
-    return evaluateOnce<int32_t, int32_t>(
-        fmt::format("{}(c0)", func), {date}, {DATE()});
+  const auto dayOfWeek = [&](std::optional<int32_t> date) {
+    return evaluateOnce<int32_t, int32_t>("dayofweek(c0)", {date}, {DATE()});
   };
 
-  for (const auto& func : {"dayofweek", "dow"}) {
-    EXPECT_EQ(std::nullopt, dayOfWeek(std::nullopt, func));
-    EXPECT_EQ(5, dayOfWeek(0, func));
-    EXPECT_EQ(4, dayOfWeek(-1, func));
-    EXPECT_EQ(7, dayOfWeek(-40, func));
-    EXPECT_EQ(5, dayOfWeek(parseDate("2009-07-30"), func));
-    EXPECT_EQ(1, dayOfWeek(parseDate("2023-08-20"), func));
-    EXPECT_EQ(2, dayOfWeek(parseDate("2023-08-21"), func));
-    EXPECT_EQ(3, dayOfWeek(parseDate("2023-08-22"), func));
-    EXPECT_EQ(4, dayOfWeek(parseDate("2023-08-23"), func));
-    EXPECT_EQ(5, dayOfWeek(parseDate("2023-08-24"), func));
-    EXPECT_EQ(6, dayOfWeek(parseDate("2023-08-25"), func));
-    EXPECT_EQ(7, dayOfWeek(parseDate("2023-08-26"), func));
-    EXPECT_EQ(1, dayOfWeek(parseDate("2023-08-27"), func));
-
-    // test cases from spark's DateExpressionSuite.
-    EXPECT_EQ(6, dayOfWeek(util::fromDateString("2011-05-06"), func));
-  }
-}
-
-TEST_F(DateTimeFunctionsTest, dayofWeekTs) {
-  const auto dayOfWeek = [&](std::optional<Timestamp> date,
-                             const std::string& func) {
-    return evaluateOnce<int32_t>(fmt::format("{}(c0)", func), date);
-  };
-
-  for (const auto& func : {"dayofweek", "dow"}) {
-    EXPECT_EQ(5, dayOfWeek(Timestamp(0, 0), func));
-    EXPECT_EQ(4, dayOfWeek(Timestamp(-1, 0), func));
+    EXPECT_EQ(std::nullopt, dayOfWeek(std::nullopt));
+    EXPECT_EQ(5, dayOfWeek(0));
+    EXPECT_EQ(4, dayOfWeek(-1));
+    EXPECT_EQ(7, dayOfWeek(-40));
+    EXPECT_EQ(5, dayOfWeek(parseDate("2009-07-30")));
+    EXPECT_EQ(1, dayOfWeek(parseDate("2023-08-20")));
+    EXPECT_EQ(2, dayOfWeek(parseDate("2023-08-21")));
+    EXPECT_EQ(3, dayOfWeek(parseDate("2023-08-22")));
+    EXPECT_EQ(4, dayOfWeek(parseDate("2023-08-23")));
+    EXPECT_EQ(5, dayOfWeek(parseDate("2023-08-24")));
+    EXPECT_EQ(6, dayOfWeek(parseDate("2023-08-25")));
+    EXPECT_EQ(7, dayOfWeek(parseDate("2023-08-26")));
+    EXPECT_EQ(1, dayOfWeek(parseDate("2023-08-27")));
+    EXPECT_EQ(6, dayOfWeek(util::fromDateString("2011-05-06")));
     EXPECT_EQ(
-        1,
-        dayOfWeek(util::fromTimestampString("2023-08-20 20:23:00.001"), func));
+        4, dayOfWeek(util::fromDateString("2015-04-08")));
     EXPECT_EQ(
-        2,
-        dayOfWeek(util::fromTimestampString("2023-08-21 21:23:00.030"), func));
+        7, dayOfWeek(util::fromDateString("2017-05-27")));
     EXPECT_EQ(
-        3,
-        dayOfWeek(util::fromTimestampString("2023-08-22 11:23:00.100"), func));
-    EXPECT_EQ(
-        4,
-        dayOfWeek(util::fromTimestampString("2023-08-23 22:23:00.030"), func));
-    EXPECT_EQ(
-        5,
-        dayOfWeek(util::fromTimestampString("2023-08-24 15:23:00.000"), func));
-    EXPECT_EQ(
-        6,
-        dayOfWeek(util::fromTimestampString("2023-08-25 03:23:04.000"), func));
-    EXPECT_EQ(
-        7,
-        dayOfWeek(util::fromTimestampString("2023-08-26 01:03:00.300"), func));
-    EXPECT_EQ(
-        1,
-        dayOfWeek(util::fromTimestampString("2023-08-27 01:13:00.000"), func));
-    // test cases from spark's DateExpressionSuite.
-    EXPECT_EQ(
-        4, dayOfWeek(util::fromTimestampString("2015-04-08 13:10:15"), func));
-    EXPECT_EQ(
-        7, dayOfWeek(util::fromTimestampString("2017-05-27 13:10:15"), func));
-    EXPECT_EQ(
-        6, dayOfWeek(util::fromTimestampString("1582-10-15 13:10:15"), func));
-  }
+        6, dayOfWeek(util::fromDateString("1582-10-15")));
 }
 
 TEST_F(DateTimeFunctionsTest, dateDiffDate) {


### PR DESCRIPTION
In Spark `dayofweek` doesn't directly accept TIMESTAMP input. For TIMESTAMP input, Spark will add a cast expression to convert it to date type, so only DATE type can be considered in Velox.

Also removing alias `dow`.

Spark function doc - https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.dayofweek.html

Addresses #8736 