### PR TITLE
Remove unnecessary semicolons at the end of the namespace definition

### DIFF
--- a/velox/codegen/Codegen-Stubs.h
+++ b/velox/codegen/Codegen-Stubs.h
@@ -57,4 +57,4 @@ class Codegen {
 
 } // namespace codegen
 } // namespace velox
-}; // namespace facebook
+} // namespace facebook

--- a/velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.cpp
@@ -406,5 +406,5 @@ void GCSFileSystem::rmdir(std::string_view path) {
   VELOX_UNSUPPORTED("rmdir for GCS not implemented");
 }
 
-}; // namespace filesystems
-}; // namespace facebook::velox
+} // namespace filesystems
+} // namespace facebook::velox

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -202,4 +202,4 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
       hiveConfig->filePreloadThreshold());
 }
 
-}; // namespace facebook::velox::connector
+} // namespace facebook::velox::connector

--- a/velox/core/tests/PlanFragmentTest.cpp
+++ b/velox/core/tests/PlanFragmentTest.cpp
@@ -81,7 +81,7 @@ class PlanFragmentTest : public testing::Test {
   std::shared_ptr<memory::MemoryPool> pool_{
       memory::memoryManager()->addLeafPool()};
 };
-}; // namespace
+} // namespace
 
 TEST_F(PlanFragmentTest, orderByCanSpill) {
   struct {

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -106,7 +106,7 @@ void checkKRangeFrameBounds(
   frameBoundCheck(frame.endValue);
 }
 
-}; // namespace
+} // namespace
 
 Window::WindowFrame Window::createWindowFrame(
     const std::shared_ptr<const core::WindowNode>& windowNode,
@@ -289,7 +289,7 @@ void updateKRowsOffsetsColumn(
   }
 }
 
-}; // namespace
+} // namespace
 
 void Window::updateKRowsFrameBounds(
     bool isKPreceding,
@@ -417,7 +417,7 @@ void computeValidFrames(
   validFrames.updateBounds();
 }
 
-}; // namespace
+} // namespace
 
 void Window::computePeerAndFrameBuffers(
     vector_size_t startRow,

--- a/velox/exec/WindowBuild.cpp
+++ b/velox/exec/WindowBuild.cpp
@@ -82,7 +82,7 @@ slice(const std::vector<TypePtr>& types, int32_t start, int32_t end) {
   }
   return result;
 }
-}; // namespace
+} // namespace
 
 WindowBuild::WindowBuild(
     const std::shared_ptr<const core::WindowNode>& windowNode,

--- a/velox/exec/WindowPartition.cpp
+++ b/velox/exec/WindowPartition.cpp
@@ -85,7 +85,7 @@ std::pair<vector_size_t, vector_size_t> findMinMaxFrameBounds(
   return {minFrame, maxFrame};
 }
 
-}; // namespace
+} // namespace
 
 std::optional<std::pair<vector_size_t, vector_size_t>>
 WindowPartition::extractNulls(

--- a/velox/exec/tests/WindowTest.cpp
+++ b/velox/exec/tests/WindowTest.cpp
@@ -182,5 +182,4 @@ TEST_F(WindowTest, duplicateOrOverlappingKeys) {
 }
 
 } // namespace
-
 } // namespace facebook::velox::exec

--- a/velox/experimental/codegen/Codegen.cpp
+++ b/velox/experimental/codegen/Codegen.cpp
@@ -163,4 +163,4 @@ bool Codegen::runInitializationTests() {
 
 } // namespace codegen
 } // namespace velox
-}; // namespace facebook
+} // namespace facebook

--- a/velox/experimental/codegen/ast/ASTAnalysis.h
+++ b/velox/experimental/codegen/ast/ASTAnalysis.h
@@ -28,4 +28,4 @@ bool isDefaultNullStrict(const ASTNode& node);
 // output is null or false if any input is null
 bool isFilterDefaultNull(const ASTNode& node);
 
-}; // namespace facebook::velox::codegen::analysis
+} // namespace facebook::velox::codegen::analysis

--- a/velox/experimental/codegen/ast/ConstantExpressions.h
+++ b/velox/experimental/codegen/ast/ConstantExpressions.h
@@ -141,7 +141,7 @@ class ConstantExpression final : public ASTNode {
  private:
   /// Child expression
   const std::optional<T> value_;
-}; // namespace codegen
+} // namespace codegen
 
 using Int8Literal = ConstantExpression<int8_t>;
 using Int16Literal = ConstantExpression<int16_t>;

--- a/velox/experimental/codegen/ast/ConstantExpressions.h
+++ b/velox/experimental/codegen/ast/ConstantExpressions.h
@@ -141,7 +141,7 @@ class ConstantExpression final : public ASTNode {
  private:
   /// Child expression
   const std::optional<T> value_;
-} // namespace codegen
+};
 
 using Int8Literal = ConstantExpression<int8_t>;
 using Int16Literal = ConstantExpression<int16_t>;

--- a/velox/experimental/codegen/code_generator/tests/ASTAnalysisTest.cpp
+++ b/velox/experimental/codegen/code_generator/tests/ASTAnalysisTest.cpp
@@ -174,4 +174,4 @@ TEST_F(ASTAnalysisTest, FilterDefaultNull) {
       "C0 > 1 AND 1 is NULL", false);
 }
 } // namespace codegen::expressions::test
-}; // namespace facebook::velox
+} // namespace facebook::velox

--- a/velox/experimental/codegen/external_process/Filesystem.h
+++ b/velox/experimental/codegen/external_process/Filesystem.h
@@ -77,4 +77,4 @@ class PathGenerator {
 } // namespace compiler_utils
 } // namespace codegen
 } // namespace velox
-}; // namespace facebook
+} // namespace facebook

--- a/velox/experimental/codegen/functions/CastFunctionStub.h
+++ b/velox/experimental/codegen/functions/CastFunctionStub.h
@@ -41,4 +41,4 @@ struct CodegenConversionStub {
   }
 };
 
-}; // namespace facebook::velox::codegen
+} // namespace facebook::velox::codegen

--- a/velox/experimental/codegen/functions/HashFunctionStub.h
+++ b/velox/experimental/codegen/functions/HashFunctionStub.h
@@ -46,4 +46,4 @@ FOLLY_ALWAYS_INLINE int64_t computeHashStub(const T& arg) {
   }
 }
 
-}; // namespace facebook::velox::codegen
+} // namespace facebook::velox::codegen

--- a/velox/experimental/codegen/proto/ProtoUtils.h
+++ b/velox/experimental/codegen/proto/ProtoUtils.h
@@ -60,6 +60,6 @@ struct ProtoUtils {
   }
 };
 
-}; // namespace proto_utils
+} // namespace proto_utils
 
 } // namespace facebook::velox::codegen::proto

--- a/velox/experimental/codegen/tests/CodegenTestBase.h
+++ b/velox/experimental/codegen/tests/CodegenTestBase.h
@@ -427,4 +427,4 @@ class CodegenTestBase : public CodegenTestCore, public testing::Test {
     init();
   }
 };
-}; // namespace facebook::velox::codegen
+} // namespace facebook::velox::codegen

--- a/velox/experimental/codegen/transform/utils/utils.h
+++ b/velox/experimental/codegen/transform/utils/utils.h
@@ -159,7 +159,7 @@ auto isomorphicTreeTransform(
 
 } // namespace transform
 } // namespace velox
-}; // namespace facebook
+} // namespace facebook
 
 namespace ranges {
 template <typename Range>

--- a/velox/experimental/codegen/vector_function/ConcatExpression-inl.h
+++ b/velox/experimental/codegen/vector_function/ConcatExpression-inl.h
@@ -204,4 +204,4 @@ requires(compiledExpression<T>&&...) // All the type parameters
 
 } // namespace codegen
 } // namespace velox
-}; // namespace facebook
+} // namespace facebook

--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -347,7 +347,7 @@ class Re2SearchAndExtractConstantPattern final : public exec::VectorFunction {
  private:
   RE2 re_;
   const bool emptyNoMatch_;
-}; // namespace
+} // namespace
 
 // The factory function we provide returns a unique instance for each call, so
 // this is safe.

--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -347,7 +347,7 @@ class Re2SearchAndExtractConstantPattern final : public exec::VectorFunction {
  private:
   RE2 re_;
   const bool emptyNoMatch_;
-} // namespace
+};
 
 // The factory function we provide returns a unique instance for each call, so
 // this is safe.

--- a/velox/functions/lib/tests/IsNotNullTest.cpp
+++ b/velox/functions/lib/tests/IsNotNullTest.cpp
@@ -26,7 +26,7 @@ void registerIsNotNull() {
   registerIsNotNullFunction("isnotnull");
 }
 
-}; // namespace facebook::velox::functions
+} // namespace facebook::velox::functions
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;

--- a/velox/functions/lib/window/tests/WindowTestBase.cpp
+++ b/velox/functions/lib/window/tests/WindowTestBase.cpp
@@ -367,4 +367,4 @@ void WindowTestBase::assertWindowFunctionError(
       assertQuery(queryInfo.planNode, queryInfo.querySql), errorMessage);
 }
 
-}; // namespace facebook::velox::window::test
+} // namespace facebook::velox::window::test

--- a/velox/functions/lib/window/tests/WindowTestBase.h
+++ b/velox/functions/lib/window/tests/WindowTestBase.h
@@ -212,4 +212,4 @@ class WindowTestBase : public exec::test::OperatorTestBase {
       const RangeFrameBound& startBound,
       const RangeFrameBound& endBound);
 };
-}; // namespace facebook::velox::window::test
+} // namespace facebook::velox::window::test

--- a/velox/functions/prestosql/DecimalVectorFunctions.cpp
+++ b/velox/functions/prestosql/DecimalVectorFunctions.cpp
@@ -726,7 +726,7 @@ std::shared_ptr<exec::VectorFunction> createDecimalBetweenFunction(
   }
   VELOX_UNSUPPORTED();
 }
-}; // namespace
+} // namespace
 
 VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
     udf_decimal_add,
@@ -767,4 +767,4 @@ VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
     udf_decimal_between,
     decimalBetweenSignature(),
     createDecimalBetweenFunction);
-}; // namespace facebook::velox::functions
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -515,7 +515,7 @@ struct MinMaxByNComplexTypeAccumulator {
     compares.setNull(index, false);
     compares.set(index, pair.first);
   }
-}; // namespace
+} // namespace
 
 template <typename C, typename Compare>
 struct ComplexTypeExtractor {

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -515,7 +515,7 @@ struct MinMaxByNComplexTypeAccumulator {
     compares.setNull(index, false);
     compares.set(index, pair.first);
   }
-} // namespace
+};
 
 template <typename C, typename Compare>
 struct ComplexTypeExtractor {

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -290,4 +290,4 @@ void registerArrayFunctions(const std::string& prefix) {
   registerArrayNormalizeFunctions<float>(prefix);
   registerArrayNormalizeFunctions<double>(prefix);
 }
-}; // namespace facebook::velox::functions
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/window/tests/NthValueTest.cpp
+++ b/velox/functions/prestosql/window/tests/NthValueTest.cpp
@@ -494,5 +494,5 @@ TEST_F(NthValueTest, ignoreNullsCurrentRow) {
       "range between current row and unbounded following");
 }
 
-}; // namespace
-}; // namespace facebook::velox::window::test
+} // namespace
+} // namespace facebook::velox::window::test

--- a/velox/functions/prestosql/window/tests/NtileTest.cpp
+++ b/velox/functions/prestosql/window/tests/NtileTest.cpp
@@ -100,5 +100,5 @@ TEST_F(NtileTest, errorCases) {
       {columnVector}, "ntile(c0)", overClause, bucketError);
 }
 
-}; // namespace
-}; // namespace facebook::velox::window::test
+} // namespace
+} // namespace facebook::velox::window::test

--- a/velox/functions/prestosql/window/tests/RankTest.cpp
+++ b/velox/functions/prestosql/window/tests/RankTest.cpp
@@ -103,5 +103,5 @@ VELOX_INSTANTIATE_TEST_SUITE_P(
     RankTest,
     testing::ValuesIn(getRankTestParams()));
 
-}; // namespace
-}; // namespace facebook::velox::window::test
+} // namespace
+} // namespace facebook::velox::window::test

--- a/velox/functions/sparksql/DecimalArithmetic.cpp
+++ b/velox/functions/sparksql/DecimalArithmetic.cpp
@@ -778,7 +778,7 @@ std::shared_ptr<exec::VectorFunction> createDecimalFunction(
     }
   }
 }
-}; // namespace
+} // namespace
 
 VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
     udf_decimal_add,
@@ -799,4 +799,4 @@ VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
     udf_decimal_div,
     decimalDivideSignature(),
     createDecimalFunction<Divide>);
-}; // namespace facebook::velox::functions::sparksql
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/DecimalRound.cpp
+++ b/velox/functions/sparksql/specialforms/DecimalRound.cpp
@@ -163,7 +163,7 @@ std::shared_ptr<exec::VectorFunction> createDecimalRound(
     }
   }
 }
-}; // namespace
+} // namespace
 
 std::pair<uint8_t, uint8_t>
 DecimalRoundCallToSpecialForm::getResultPrecisionScale(

--- a/velox/functions/sparksql/tests/ComparisonsTest.cpp
+++ b/velox/functions/sparksql/tests/ComparisonsTest.cpp
@@ -440,4 +440,4 @@ TEST_F(ComparisonsTest, notSupportedTypes) {
   }
 }
 } // namespace
-}; // namespace facebook::velox::functions::sparksql::test
+} // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/DecimalArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/DecimalArithmeticTest.cpp
@@ -76,7 +76,7 @@ class DecimalArithmeticTest : public SparkFunctionBaseTest {
     }
     return makeNullableFlatVector<int128_t>(numbers, type);
   }
-}; // namespace
+} // namespace
 
 TEST_F(DecimalArithmeticTest, add) {
   // Precision < 38.

--- a/velox/functions/sparksql/tests/DecimalArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/DecimalArithmeticTest.cpp
@@ -76,7 +76,7 @@ class DecimalArithmeticTest : public SparkFunctionBaseTest {
     }
     return makeNullableFlatVector<int128_t>(numbers, type);
   }
-} // namespace
+};
 
 TEST_F(DecimalArithmeticTest, add) {
   // Precision < 38.

--- a/velox/functions/sparksql/window/tests/SparkWindowTest.cpp
+++ b/velox/functions/sparksql/window/tests/SparkWindowTest.cpp
@@ -106,5 +106,5 @@ VELOX_INSTANTIATE_TEST_SUITE_P(
     SparkWindowTest,
     testing::ValuesIn(getSparkWindowTestParams()));
 
-}; // namespace
-}; // namespace facebook::velox::window::test
+} // namespace
+} // namespace facebook::velox::window::test

--- a/velox/substrait/SubstraitExtensionCollector.h
+++ b/velox/substrait/SubstraitExtensionCollector.h
@@ -114,4 +114,4 @@ struct hash<facebook::velox::substrait::ExtensionFunctionId> {
   }
 };
 
-}; // namespace std
+} // namespace std

--- a/velox/vector/tests/SelectivityVectorTest.cpp
+++ b/velox/vector/tests/SelectivityVectorTest.cpp
@@ -98,7 +98,7 @@ void setValid_normal(bool setToValue) {
   }
 }
 
-}; // namespace
+} // namespace
 
 TEST(SelectivityVectorTest, setValid_true_normal) {
   setValid_normal(true);


### PR DESCRIPTION
I found that there were some unnecessary semicolons at the end of the 
namespace declaration and this patch cleaned them up.

Use the following command(on MacOS):
```
# Replace "}; // namespace" with "} // namespace".
find velox/ \( -name "*.h" -o -name "*.cpp" \) -type f -exec sed -i '' 's/}; \/\/ namespace/} \/\/ namespace /g' {} +
```

No functional changes.