### PR TITLE
Add support to provide an alias for a connector factory

### DIFF
--- a/velox/connectors/Connector.cpp
+++ b/velox/connectors/Connector.cpp
@@ -54,6 +54,19 @@ bool registerConnectorFactory(std::shared_ptr<ConnectorFactory> factory) {
   return true;
 }
 
+bool registerConnectorFactoryAlias(
+    const std::string& alias,
+    const std::string& connectorId) {
+  auto factory = getConnectorFactory(connectorId);
+  bool ok = connectorFactories().insert({alias, factory}).second;
+  VELOX_CHECK(
+      ok,
+      "Alias '{}' is already registered for factory '{}'",
+      alias,
+      connectorId);
+  return true;
+}
+
 std::shared_ptr<ConnectorFactory> getConnectorFactory(
     const std::string& connectorName) {
   auto it = connectorFactories().find(connectorName);

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -421,6 +421,13 @@ class ConnectorFactory {
 /// FB_ANONYMOUS_VARIABLE.
 bool registerConnectorFactory(std::shared_ptr<ConnectorFactory> factory);
 
+/// Adds an alias for an existing factory. Throws if factory with the
+/// connectorName is not already present. Throws if the alias for the
+/// connectorName is already present.
+bool registerConnectorFactoryAlias(
+    const std::string& alias,
+    const std::string& connectorName);
+
 /// Returns a factory for creating connectors with the specified name. Throws if
 /// factory doesn't exist.
 std::shared_ptr<ConnectorFactory> getConnectorFactory(

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -220,6 +220,5 @@ void registerHivePartitionFunctionSerDe() {
 }
 
 VELOX_REGISTER_CONNECTOR_FACTORY(std::make_shared<HiveConnectorFactory>())
-VELOX_REGISTER_CONNECTOR_FACTORY(
-    std::make_shared<HiveHadoop2ConnectorFactory>())
+
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -83,13 +83,8 @@ class HiveConnector : public Connector {
 class HiveConnectorFactory : public ConnectorFactory {
  public:
   static constexpr const char* FOLLY_NONNULL kHiveConnectorName = "hive";
-  static constexpr const char* FOLLY_NONNULL kHiveHadoop2ConnectorName =
-      "hive-hadoop2";
 
   HiveConnectorFactory() : ConnectorFactory(kHiveConnectorName) {}
-
-  explicit HiveConnectorFactory(const char* FOLLY_NONNULL connectorName)
-      : ConnectorFactory(connectorName) {}
 
   /// Register HiveConnector components such as Dwrf, Parquet readers and
   /// writers and FileSystems.
@@ -101,12 +96,6 @@ class HiveConnectorFactory : public ConnectorFactory {
       folly::Executor* FOLLY_NULLABLE executor = nullptr) override {
     return std::make_shared<HiveConnector>(id, config, executor);
   }
-};
-
-class HiveHadoop2ConnectorFactory : public HiveConnectorFactory {
- public:
-  HiveHadoop2ConnectorFactory()
-      : HiveConnectorFactory(kHiveHadoop2ConnectorName) {}
 };
 
 class HivePartitionFunctionSpec : public core::PartitionFunctionSpec {

--- a/velox/connectors/hive/tests/CMakeLists.txt
+++ b/velox/connectors/hive/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(
   HivePartitionFunctionTest.cpp
   FileHandleTest.cpp
   HivePartitionUtilTest.cpp
+  HiveConnectorFactoryTest.cpp
   HiveConnectorTest.cpp
   HiveConnectorUtilTest.cpp
   HiveConnectorSerDeTest.cpp

--- a/velox/connectors/hive/tests/HiveConnectorFactoryTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorFactoryTest.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/connectors/Connector.h"
+
+namespace facebook::velox::connector::hive {
+namespace {
+
+TEST(HiveConnectorFactoryTest, aliases) {
+  auto factory = connector::getConnectorFactory("hive");
+  ASSERT_EQ(factory->connectorName(), "hive");
+
+  registerConnectorFactoryAlias("hive-hadoop2", factory->connectorName());
+  registerConnectorFactoryAlias("iceberg", factory->connectorName());
+
+  ASSERT_EQ(
+      connector::getConnectorFactory("hive-hadoop2")->connectorName(),
+      factory->connectorName());
+  ASSERT_EQ(
+      connector::getConnectorFactory("iceberg")->connectorName(),
+      factory->connectorName());
+
+  VELOX_ASSERT_THROW(
+      registerConnectorFactoryAlias("iceberg", factory->connectorName()),
+      "Alias 'iceberg' is already registered for factory 'hive'");
+  VELOX_ASSERT_THROW(
+      registerConnectorFactoryAlias("foo", "hivefoo"),
+      "ConnectorFactory with name 'hivefoo' not registered");
+}
+
+} // namespace
+} // namespace facebook::velox::connector::hive


### PR DESCRIPTION
The hive connector factory supports both hive-hadoop2 and iceberg connectors from Presto.
Add API to provide an alias to a ConnectorFactory.
