### PR TITLE
Remove unused exception parameter from velox/functions/prestosql/FindFirst.cpp

### DIFF
--- a/velox/functions/prestosql/FindFirst.cpp
+++ b/velox/functions/prestosql/FindFirst.cpp
@@ -23,7 +23,7 @@ namespace {
 void recordInvalidStartIndex(vector_size_t row, exec::EvalCtx& context) {
   try {
     VELOX_USER_FAIL("SQL array indices start at 1. Got 0.");
-  } catch (const VeloxUserError& exception) {
+  } catch (const VeloxUserError&) {
     context.setVeloxExceptionError(row, std::current_exception());
   }
 }
@@ -322,7 +322,7 @@ class FindFirstFunction : public FindFirstFunctionBase {
           if (flatArray->elements()->isNullAt(firstMatchingIndex)) {
             try {
               VELOX_USER_FAIL("find_first found NULL as the first match");
-            } catch (const VeloxUserError& exception) {
+            } catch (const VeloxUserError&) {
               context.setVeloxExceptionError(row, std::current_exception());
             }
           } else {


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: dmm-fb

Differential Revision: D53780448


