### PR TITLE
Remove unused exception parameter from velox/common/caching/AsyncDataCache.cpp

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -851,7 +851,7 @@ bool AsyncDataCache::removeFileEntries(
   for (auto& shard : shards_) {
     try {
       success &= shard->removeFileEntries(filesToRemove, filesRetained);
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
       VELOX_CACHE_LOG(ERROR)
           << "Error removing file entries from AsyncDataCache shard.";
       success = false;


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: dmm-fb

Differential Revision: D53780449


