### PR TITLE
Remove unused variables in velox/dwio/common/ReaderFactory.cpp

### DIFF
--- a/velox/dwio/common/ReaderFactory.cpp
+++ b/velox/dwio/common/ReaderFactory.cpp
@@ -31,7 +31,8 @@ ReaderFactoriesMap& readerFactories() {
 } // namespace
 
 bool registerReaderFactory(std::shared_ptr<ReaderFactory> factory) {
-  bool ok = readerFactories().insert({factory->fileFormat(), factory}).second;
+  [[maybe_unused]] const bool ok =
+      readerFactories().insert({factory->fileFormat(), factory}).second;
   // NOTE: re-enable this check after Prestissimo has updated dwrf registration.
 #if 0
   VELOX_CHECK(


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: palmje

Differential Revision: D53779583


