### PR TITLE
Velox bug: ConstantVector is not setting RawNulls correctly

### DIFF
--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -415,10 +415,8 @@ class ConstantVector final : public SimpleVector<T> {
       return;
     }
     BaseVector::nulls_ =
-        AlignedBuffer::allocate<uint64_t>(1, BaseVector::pool());
-    BaseVector::nulls_->setSize(1);
+        allocateNulls(BaseVector::size(), BaseVector::pool(), bits::kNull64);
     BaseVector::rawNulls_ = BaseVector::nulls_->as<uint64_t>();
-    *BaseVector::nulls_->asMutable<uint64_t>() = bits::kNull64;
   }
 
   // 'valueVector_' element 'index_' represents a complex constant

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -1934,6 +1934,11 @@ class VectorCreateConstantTest : public VectorTest {
       ASSERT_TRUE(simpleVector->isNullAt(i));
     }
 
+    const auto* rawNulls = simpleVector->rawNulls();
+    for (auto i = 0; i < simpleVector->size(); i++) {
+      ASSERT_TRUE(bits::isBitNull(rawNulls, i));
+    }
+
     auto expectedStr = fmt::format(
         "[CONSTANT {}: {} elements, null]", type->toString(), size_);
     EXPECT_EQ(expectedStr, baseVector->toString());
@@ -1944,7 +1949,7 @@ class VectorCreateConstantTest : public VectorTest {
 
  protected:
   // Theoretical "size" of the constant vector created.
-  const size_t size_{23};
+  const size_t size_{100};
 };
 
 TEST_F(VectorCreateConstantTest, scalar) {


### PR DESCRIPTION
Summary:
# What I see
Velox does not seem to set `rawNulls()` buffer as it create `ConstantVector`. `isNullAt()` is overridden to return a single value, so no problem. But any logic depends on `rawNulls()` would have a problem.

# Observation
In my reading, the `rawNulls()` would return a buffer ONLY if the const is `NULL`. However, it creates `nulls()` buffer only with size `1`. So any access beyond the byte size, would read garbage memory. This would lead to undefined behavior.

# Solution
Allocate `null` buffer with the given `ConstantVector` size so that it would not break the contract.

I'm not sure why the number `23` is selected in the test. I changed it to `100` to reproduce the problem.

Differential Revision: D53877757


