### PR TITLE
Remove unused variables in velox/expression/ComplexWriterTypes.h

### DIFF
--- a/velox/expression/ComplexWriterTypes.h
+++ b/velox/expression/ComplexWriterTypes.h
@@ -472,7 +472,6 @@ class ArrayWriter {
 
   template <typename Input>
   void addItemsBoolFastPath(const Input& sourceArray) {
-    auto* vector = sourceArray.elementsVectorBase();
     auto* flatOutput =
         this->elementsVector()->template asUnchecked<FlatVector<bool>>();
 


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: palmje

Differential Revision: D53779459


