### PR TITLE
Remove unused variables in velox/dwio/common/WriterFactory.cpp

### DIFF
--- a/velox/dwio/common/WriterFactory.cpp
+++ b/velox/dwio/common/WriterFactory.cpp
@@ -31,7 +31,7 @@ WriterFactoriesMap& writerFactories() {
 } // namespace
 
 bool registerWriterFactory(std::shared_ptr<WriterFactory> factory) {
-  const bool ok =
+  [[maybe_unused]] const bool ok =
       writerFactories().insert({factory->fileFormat(), factory}).second;
 // TODO: enable the check after Prestissimo adds to register the dwrf writer.
 #if 0


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: palmje

Differential Revision: D53779475


