### PR TITLE
Remove unused variables in velox/functions/lib/aggregates/DecimalAggregate.h

### DIFF
--- a/velox/functions/lib/aggregates/DecimalAggregate.h
+++ b/velox/functions/lib/aggregates/DecimalAggregate.h
@@ -132,9 +132,6 @@ class DecimalAggregate : public exec::Aggregate {
     decodedRaw_.decode(*args[0], rows);
     if (decodedRaw_.isConstantMapping()) {
       if (!decodedRaw_.isNullAt(0)) {
-        const auto numRows = rows.countSelected();
-        int64_t overflow = 0;
-        int128_t totalSum{0};
         auto value = decodedRaw_.valueAt<TInputType>(0);
         rows.template applyToSelected([&](vector_size_t i) {
           updateNonNullValue(group, TResultType(value));


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: palmje

Differential Revision: D53779487


