### PR TITLE
Remove semicolon(s) from 3 files inc unicorn/utils/TestMain.h

### DIFF
--- a/velox/dwio/common/Reader.h
+++ b/velox/dwio/common/Reader.h
@@ -136,7 +136,7 @@ class RowReader {
    */
   virtual std::optional<std::vector<PrefetchUnit>> prefetchUnits() {
     return std::nullopt;
-  };
+  }
 
   /**
    * Helper function used by non-selective reader to project top level columns


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt` found an extra semi

If the code compiles, this is safe to land.

Reviewed By: palmje, dmm-fb

Differential Revision: D53776086


