### PR TITLE
Remove semicolon(s) from 3 files inc velox/type/Subfield.cpp

### DIFF
--- a/velox/type/Subfield.cpp
+++ b/velox/type/Subfield.cpp
@@ -40,7 +40,7 @@ Subfield::Subfield(
 Subfield::Subfield(std::vector<std::unique_ptr<Subfield::PathElement>>&& path)
     : path_(std::move(path)) {
   VELOX_CHECK_GE(path_.size(), 1);
-};
+}
 
 Subfield Subfield::clone() const {
   Subfield subfield;

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -725,14 +725,14 @@ std::shared_ptr<const RowType> ROW(std::vector<TypePtr>&& types) {
 std::shared_ptr<const MapType> MAP(TypePtr keyType, TypePtr valType) {
   return std::make_shared<const MapType>(
       std::move(keyType), std::move(valType));
-};
+}
 
 std::shared_ptr<const FunctionType> FUNCTION(
     std::vector<TypePtr>&& argumentTypes,
     TypePtr returnType) {
   return std::make_shared<const FunctionType>(
       std::move(argumentTypes), std::move(returnType));
-};
+}
 
 #define VELOX_DEFINE_SCALAR_ACCESSOR(KIND)                   \
   std::shared_ptr<const ScalarType<TypeKind::KIND>> KIND() { \
@@ -1041,7 +1041,7 @@ const SingletonTypeMap& singletonBuiltInTypes() {
       {"UNKNOWN", UNKNOWN()},
   };
   return kTypes;
-};
+}
 
 class DecimalParametricType {
  public:

--- a/velox/vector/DecodedVector.cpp
+++ b/velox/vector/DecodedVector.cpp
@@ -42,7 +42,7 @@ const std::vector<vector_size_t>& DecodedVector::consecutiveIndices() {
 const std::vector<vector_size_t>& DecodedVector::zeroIndices() {
   static std::vector<vector_size_t> indices(10'000);
   return indices;
-};
+}
 
 void DecodedVector::decode(
     const BaseVector& vector,


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt` found an extra semi

If the code compiles, this is safe to land.

Reviewed By: palmje, dmm-fb

Differential Revision: D53776105


