### PR TITLE
Remove semicolon(s) from 3 files inc velox/dwio/parquet/writer/arrow/util/CompressionZstd.cpp

### DIFF
--- a/velox/dwio/parquet/writer/arrow/util/CompressionZstd.cpp
+++ b/velox/dwio/parquet/writer/arrow/util/CompressionZstd.cpp
@@ -281,4 +281,4 @@ class ZSTDCodec : public Codec {
 std::unique_ptr<Codec> MakeZSTDCodec(int compression_level) {
   return std::make_unique<ZSTDCodec>(compression_level);
 }
-}; // namespace facebook::velox::parquet::arrow::util::internal.
+} // namespace facebook::velox::parquet::arrow::util::internal.

--- a/velox/expression/PeeledEncoding.h
+++ b/velox/expression/PeeledEncoding.h
@@ -171,7 +171,7 @@ class PeeledEncoding {
       vector_size_t innerRow = indices ? indices[outerRow] : constantWrapIndex_;
       func(outerRow, innerRow);
     });
-  };
+  }
 
  private:
   PeeledEncoding() = default;

--- a/velox/expression/signature_parser/Scanner.h
+++ b/velox/expression/signature_parser/Scanner.h
@@ -35,7 +35,7 @@ class Scanner : public yyFlexLexer {
       const std::string_view input)
       : yyFlexLexer(&arg_yyin, &arg_yyout),
         outputType_(outputType),
-        input_(input){};
+        input_(input) {}
   int lex(Parser::semantic_type* yylval);
 
   void setTypeSignature(TypeSignaturePtr type) {


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt` found an extra semi

If the code compiles, this is safe to land.

Reviewed By: palmje, dmm-fb

Differential Revision: D53776074


