### PR TITLE
Remove unused variables in velox/functions/lib/KllSketch-inl.h

### DIFF
--- a/velox/functions/lib/KllSketch-inl.h
+++ b/velox/functions/lib/KllSketch-inl.h
@@ -403,15 +403,13 @@ int KllSketch<T, A, C>::findLevelToCompact() const {
 
 template <typename T, typename A, typename C>
 void KllSketch<T, A, C>::addEmptyTopLevelToCompletelyFullSketch() {
-  const uint32_t curTotalCap = levels_.back();
-
   // Make sure that we are following a certain growth scheme.
   VELOX_DCHECK_EQ(levels_[0], 0);
-  VELOX_DCHECK_EQ(items_.size(), curTotalCap);
+  VELOX_DCHECK_EQ(items_.size(), levels_.back());
 
   const uint32_t deltaCap = detail::levelCapacity(k_, numLevels() + 1, 0);
   shiftItems(deltaCap);
-  VELOX_DCHECK_EQ(levels_.back(), curTotalCap + deltaCap);
+  VELOX_DCHECK_EQ(levels_.back(), levels_.back() + deltaCap);
   levels_.push_back(levels_.back());
 }
 


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: palmje

Differential Revision: D53779441


