### PR TITLE
Add `[[noreturn]]` to 1 file inc velox/type/TimestampConversion.cpp

### DIFF
--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -671,7 +671,7 @@ Timestamp fromDatetime(int64_t daysSinceEpoch, int64_t microsSinceMidnight) {
 
 namespace {
 
-void parserError(const char* str, size_t len) {
+[[noreturn]] void parserError(const char* str, size_t len) {
   VELOX_USER_FAIL(
       "Unable to parse timestamp value: \"{}\", "
       "expected format is (YYYY-MM-DD HH:MM:SS[.MS])",


### PR DESCRIPTION
Summary: LLVM-15 has a warning `-Wno-return` which can be used to identify functions that do not return. Qualifying these functions with `[[noreturn]]` is a perf optimization.

Differential Revision: D53815460


