### PR TITLE
Enable `-Wimplicit-fallthrough` in f5b/PACKAGE

### DIFF
--- a/velox/experimental/codegen/ast/ASTNode.h
+++ b/velox/experimental/codegen/ast/ASTNode.h
@@ -168,6 +168,8 @@ class ASTNode {
             return;
           }
         }
+        setMaybeNull(false);
+        return;
       case ExpressionNullMode::NotNull:
         setMaybeNull(false);
         return;


### PR DESCRIPTION
Summary:
This diff enables the titular warning flag for the directory in question. Further details are in [this workplace post](https://fb.workplace.com/permalink.php?story_fbid=pfbid02XaWNiCVk69r1ghfvDVpujB8Hr9Y61uDvNakxiZFa2jwiPHscVdEQwCBHrmWZSyMRl&id=100051201402394).

This is a low-risk diff. There are **no run-time effects** and the diff has already been observed to compile locally. **If the code compiles, it works; test errors are spurious.**

If the diff does not pass, it will be closed automatically.

Reviewed By: dmm-fb

Differential Revision: D53545504


