### PR TITLE
Do not sort map entries in a RowContainer dependent column

### DIFF
--- a/velox/exec/AddressableNonNullValueList.cpp
+++ b/velox/exec/AddressableNonNullValueList.cpp
@@ -48,8 +48,9 @@ AddressableNonNullValueList::Entry AddressableNonNullValueList::append(
   const auto originalSize = stream.size();
 
   // Write value.
+  exec::ContainerRowSerdeOptions options{};
   exec::ContainerRowSerde::serialize(
-      *decoded.base(), decoded.index(index), stream);
+      *decoded.base(), decoded.index(index), stream, options);
   ++size_;
 
   auto startAndFinish = allocator->finishWrite(stream, 1024);

--- a/velox/exec/ContainerRowSerde.h
+++ b/velox/exec/ContainerRowSerde.h
@@ -21,6 +21,11 @@
 
 namespace facebook::velox::exec {
 
+struct ContainerRowSerdeOptions {
+  /// Used for ex., sorting maps by map keys, when occurring as key.
+  bool isKey = true;
+};
+
 /// Row-wise serialization for use in hash tables and order by.
 class ContainerRowSerde {
  public:
@@ -29,7 +34,8 @@ class ContainerRowSerde {
   static void serialize(
       const BaseVector& source,
       vector_size_t index,
-      ByteOutputStream& out);
+      ByteOutputStream& out,
+      const ContainerRowSerdeOptions& options);
 
   static void
   deserialize(ByteInputStream& in, vector_size_t index, BaseVector* result);
@@ -37,7 +43,8 @@ class ContainerRowSerde {
   /// Returns < 0 if 'left' is less than 'right' at 'index', 0 if
   /// equal and > 0 otherwise. flags.nullHandlingMode can be only NullAsValue
   /// and support null-safe equal. Top level rows in right are not allowed to be
-  /// null.
+  /// null. Note that the assumption for Map is the serialized map entries are
+  /// sorted in the order of key to be comparable.
   static int32_t compare(
       ByteInputStream& left,
       const DecodedVector& right,
@@ -46,7 +53,8 @@ class ContainerRowSerde {
 
   /// Returns < 0 if 'left' is less than 'right' at 'index', 0 if
   /// equal and > 0 otherwise. flags.nullHandlingMode can be only NullAsValue
-  /// and support null-safe equal.
+  /// and support null-safe equal. Note that the assumption for Map is the
+  /// serialized map entries are sorted in the order of key to be comparable.
   static int32_t compare(
       ByteInputStream& left,
       ByteInputStream& right,
@@ -57,7 +65,9 @@ class ContainerRowSerde {
   /// equal and > 0 otherwise. If flags.nullHandlingMode is StopAtNull,
   /// returns std::nullopt if either 'left' or 'right' value is null or contains
   /// a null. If flags.nullHandlingMode is NullAsValue then NULL is considered
-  /// equal to NULL. Top level rows in right are not allowed to be null.
+  /// equal to NULL. Top level rows in right are not allowed to be null. Note
+  /// that the assumption for Map is the serialized map entries are
+  /// sorted in the order of key to be comparable.
   static std::optional<int32_t> compareWithNulls(
       ByteInputStream& left,
       const DecodedVector& right,
@@ -68,7 +78,8 @@ class ContainerRowSerde {
   /// equal and > 0 otherwise. If flags.nullHandlingMode is StopAtNull,
   /// returns std::nullopt if either 'left' or 'right' value is null or contains
   /// a null. If flags.nullHandlingMode is NullAsValue then NULL is considered
-  /// equal to NULL.
+  /// equal to NULL. Note that the assumption for Map is the serialized map
+  /// entries are sorted in the order of key to be comparable.
   static std::optional<int32_t> compareWithNulls(
       ByteInputStream& left,
       ByteInputStream& right,

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -828,6 +828,7 @@ class RowContainer {
   inline void storeWithNulls(
       const DecodedVector& decoded,
       vector_size_t index,
+      bool isKey,
       char* FOLLY_NONNULL row,
       int32_t offset,
       int32_t nullByte,
@@ -851,6 +852,7 @@ class RowContainer {
   inline void storeNoNulls(
       const DecodedVector& decoded,
       vector_size_t index,
+      bool isKey,
       char* FOLLY_NONNULL group,
       int32_t offset) {
     using T = typename TypeTraits<Kind>::NativeType;
@@ -1066,6 +1068,7 @@ class RowContainer {
   void storeComplexType(
       const DecodedVector& decoded,
       vector_size_t index,
+      bool isKey,
       char* FOLLY_NONNULL row,
       int32_t offset,
       int32_t nullByte = 0,
@@ -1251,66 +1254,73 @@ template <>
 inline void RowContainer::storeWithNulls<TypeKind::ROW>(
     const DecodedVector& decoded,
     vector_size_t index,
+    bool isKey,
     char* FOLLY_NONNULL row,
     int32_t offset,
     int32_t nullByte,
     uint8_t nullMask) {
-  storeComplexType(decoded, index, row, offset, nullByte, nullMask);
+  storeComplexType(decoded, index, isKey, row, offset, nullByte, nullMask);
 }
 
 template <>
 inline void RowContainer::storeNoNulls<TypeKind::ROW>(
     const DecodedVector& decoded,
     vector_size_t index,
+    bool isKey,
     char* FOLLY_NONNULL row,
     int32_t offset) {
-  storeComplexType(decoded, index, row, offset);
+  storeComplexType(decoded, index, isKey, row, offset);
 }
 
 template <>
 inline void RowContainer::storeWithNulls<TypeKind::ARRAY>(
     const DecodedVector& decoded,
     vector_size_t index,
+    bool isKey,
     char* FOLLY_NONNULL row,
     int32_t offset,
     int32_t nullByte,
     uint8_t nullMask) {
-  storeComplexType(decoded, index, row, offset, nullByte, nullMask);
+  storeComplexType(decoded, index, isKey, row, offset, nullByte, nullMask);
 }
 
 template <>
 inline void RowContainer::storeNoNulls<TypeKind::ARRAY>(
     const DecodedVector& decoded,
     vector_size_t index,
+    bool isKey,
     char* FOLLY_NONNULL row,
     int32_t offset) {
-  storeComplexType(decoded, index, row, offset);
+  storeComplexType(decoded, index, isKey, row, offset);
 }
 
 template <>
 inline void RowContainer::storeWithNulls<TypeKind::MAP>(
     const DecodedVector& decoded,
     vector_size_t index,
+    bool isKey,
     char* FOLLY_NONNULL row,
     int32_t offset,
     int32_t nullByte,
     uint8_t nullMask) {
-  storeComplexType(decoded, index, row, offset, nullByte, nullMask);
+  storeComplexType(decoded, index, isKey, row, offset, nullByte, nullMask);
 }
 
 template <>
 inline void RowContainer::storeNoNulls<TypeKind::MAP>(
     const DecodedVector& decoded,
     vector_size_t index,
+    bool isKey,
     char* FOLLY_NONNULL row,
     int32_t offset) {
-  storeComplexType(decoded, index, row, offset);
+  storeComplexType(decoded, index, isKey, row, offset);
 }
 
 template <>
 inline void RowContainer::storeWithNulls<TypeKind::HUGEINT>(
     const DecodedVector& decoded,
     vector_size_t index,
+    bool /*isKey*/,
     char* FOLLY_NONNULL row,
     int32_t offset,
     int32_t nullByte,
@@ -1325,6 +1335,7 @@ template <>
 inline void RowContainer::storeNoNulls<TypeKind::HUGEINT>(
     const DecodedVector& decoded,
     vector_size_t index,
+    bool /*isKey*/,
     char* FOLLY_NONNULL row,
     int32_t offset) {
   HugeInt::serialize(decoded.valueAt<int128_t>(index), row + offset);

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -797,9 +797,13 @@ TEST_F(RowContainerTest, types) {
       if (column < keys.size()) {
         EXPECT_TRUE(
             data->equals<false>(rows[i], data->columnAt(column), decoded, i));
-      } else {
+      } else if (!columnType->isMap()) {
         EXPECT_TRUE(
             data->equals<true>(rows[i], data->columnAt(column), decoded, i));
+      }
+      // Non-key map columns are not comparable, as the map keys are not sorted.
+      if (columnType->isMap() && column >= keys.size()) {
+        continue;
       }
       if (i > 0) {
         // We compare the values on consecutive rows.

--- a/velox/functions/lib/aggregates/SingleValueAccumulator.cpp
+++ b/velox/functions/lib/aggregates/SingleValueAccumulator.cpp
@@ -32,7 +32,8 @@ void SingleValueAccumulator::write(
     allocator->extendWrite(start_, stream);
   }
 
-  exec::ContainerRowSerde::serialize(*vector, index, stream);
+  static const exec::ContainerRowSerdeOptions options{};
+  exec::ContainerRowSerde::serialize(*vector, index, stream, options);
   allocator->finishWrite(stream, 0);
 }
 

--- a/velox/functions/lib/aggregates/ValueSet.cpp
+++ b/velox/functions/lib/aggregates/ValueSet.cpp
@@ -29,7 +29,8 @@ void ValueSet::write(
     allocator_->extendWrite(position, stream);
   }
 
-  exec::ContainerRowSerde::serialize(vector, index, stream);
+  static const exec::ContainerRowSerdeOptions options{};
+  exec::ContainerRowSerde::serialize(vector, index, stream, options);
   allocator_->finishWrite(stream, 0);
 }
 

--- a/velox/functions/prestosql/aggregates/ValueList.cpp
+++ b/velox/functions/prestosql/aggregates/ValueList.cpp
@@ -65,7 +65,8 @@ void ValueList::appendNonNull(
   allocator->extendWrite(dataCurrent_, stream);
   // The stream may have a tail of a previous write.
   const auto initialSize = stream.size();
-  exec::ContainerRowSerde::serialize(values, index, stream);
+  static const exec::ContainerRowSerdeOptions options{};
+  exec::ContainerRowSerde::serialize(values, index, stream, options);
   ++size_;
   bytes_ += stream.size() - initialSize;
 

--- a/velox/row/benchmark/UnsafeRowSerializeBenchmark.cpp
+++ b/velox/row/benchmark/UnsafeRowSerializeBenchmark.cpp
@@ -189,8 +189,9 @@ class SerializeBenchmark {
       HashStringAllocator& allocator) {
     ByteOutputStream out(&allocator);
     auto position = allocator.newWrite(out);
+    const exec::ContainerRowSerdeOptions options{};
     for (auto i = 0; i < data->size(); ++i) {
-      exec::ContainerRowSerde::serialize(*data, i, out);
+      exec::ContainerRowSerde::serialize(*data, i, out, options);
     }
     allocator.finishWrite(out, 0);
     return position;


### PR DESCRIPTION
If a Map column is not a key column but a dependent column of
a RowContainer, do not sort map entries during serialization.
Only key columns have to be sorted, since they are used for
comparision, ex. in the case of being the key of HashBuild.
It is assumed that a dependent column of unsorted Map could not
be called by RowContainerSerde::compare().