### PR TITLE
Fix dependencies for iceberg reader

### DIFF
--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -16,13 +16,7 @@ add_library(
   velox_hive_iceberg_splitreader IcebergSplitReader.cpp IcebergSplit.cpp
                                  PositionalDeleteFileReader.cpp)
 
-target_link_libraries(
-  velox_hive_iceberg_splitreader
-  Folly::folly
-  gflags::gflags
-  glog::glog
-  gtest
-  gtest_main
-  xsimd)
+target_link_libraries(velox_hive_iceberg_splitreader velox_connector
+                      Folly::folly)
 
 add_subdirectory(tests)


### PR DESCRIPTION
The original implementation added the gtest, gtest_main, glog and gflag 
which are unused. Including gtest/gtest_main causes a build problems
for upstream projects such as prestissimo.
In addition, xsimd is replaced by the connector library velox_connector
because objects from that library are being referenced replacing
xsimd.