### PR TITLE
Fix incorrect result of arbitrary() with spilling

### DIFF
--- a/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
@@ -60,10 +60,11 @@ class ArbitraryAggregate : public SimpleNumericAggregate<T, T, T> {
     DecodedVector decoded(*args[0], rows);
 
     if (decoded.isConstantMapping()) {
-      if (decoded.isNullAt(0)) {
+      auto begin = rows.begin();
+      if (decoded.isNullAt(begin)) {
         return;
       }
-      auto value = decoded.valueAt<T>(0);
+      auto value = decoded.valueAt<T>(begin);
       rows.applyToSelected([&](vector_size_t i) {
         if (exec::Aggregate::isNull(groups[i])) {
           updateValue(groups[i], value);
@@ -101,14 +102,15 @@ class ArbitraryAggregate : public SimpleNumericAggregate<T, T, T> {
       return;
     }
     DecodedVector decoded(*args[0], rows);
+    auto begin = rows.begin();
 
     if (decoded.isConstantMapping()) {
-      if (decoded.isNullAt(0)) {
+      if (decoded.isNullAt(begin)) {
         return;
       }
-      updateValue(group, decoded.valueAt<T>(0));
+      updateValue(group, decoded.valueAt<T>(begin));
     } else if (!decoded.mayHaveNulls()) {
-      updateValue(group, decoded.valueAt<T>(0));
+      updateValue(group, decoded.valueAt<T>(begin));
     } else {
       // Find the first non-null value.
       rows.testSelected([&](vector_size_t i) {
@@ -195,7 +197,7 @@ class NonNumericArbitrary : public exec::Aggregate {
       const std::vector<VectorPtr>& args,
       bool /*unused*/) override {
     DecodedVector decoded(*args[0], rows, true);
-    if (decoded.isConstantMapping() && decoded.isNullAt(0)) {
+    if (decoded.isConstantMapping() && decoded.isNullAt(rows.begin())) {
       // nothing to do; all values are nulls
       return;
     }
@@ -232,7 +234,7 @@ class NonNumericArbitrary : public exec::Aggregate {
     }
 
     DecodedVector decoded(*args[0], rows, true);
-    if (decoded.isConstantMapping() && decoded.isNullAt(0)) {
+    if (decoded.isConstantMapping() && decoded.isNullAt(rows.begin())) {
       // nothing to do; all values are nulls
       return;
     }

--- a/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -72,6 +72,7 @@ target_link_libraries(
   velox_simple_aggregate
   velox_type
   velox_vector_fuzzer
+  velox_temp_path
   gflags::gflags
   gtest
   gtest_main)


### PR DESCRIPTION
Summary:
The arbitrary() function returns incorrect result when run with grouped aggregation with 
spilling and the input vector is primitive with no nulls. This error is caused by 
ArbitraryAggregate::addSingleGroupRawInput() incorrectly update the accumulator with 
decoded.valueAt<T>(0) when rows doesn't contain row 0. This diff fixes this bug by 
updating the accumulator with decoded.valueAt<T>(rows.begin()) instead.

This diff fixes https://github.com/facebookincubator/velox/issues/8805.

Differential Revision: D53971859


