### PR TITLE
Support store decimal as integer for parquet writer

### DIFF
--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -143,6 +143,7 @@ std::shared_ptr<WriterProperties> getArrowParquetWriterOptions(
   properties = properties->max_row_group_length(
       static_cast<int64_t>(flushPolicy->rowsInRowGroup()));
   properties = properties->codec_options(options.codecOptions);
+  properties = properties->enable_store_decimal_as_integer();
   return properties->build();
 }
 


### PR DESCRIPTION
Parquet support store decimal as integer, rules are
1. int32: for 1 <= precision <= 9.
2. int64: for 10 <= precision <= 18.
3. fixed_len_byte_array: for precision > 18.

Presto support this behavior by default, https://github.com/prestodb/presto/blob/master/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/DecimalValueWriter.java.
Spark has a config for it `spark.sql.parquet.writeLegacyFormat`, default behavior same as Presto, https://github.com/apache/spark/blob/df4d489b67a95c78b22d4def4ffdaf86fefb8931/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala#L1106-L1114.
Arrow related config, https://arrow.apache.org/docs/cpp/api/formats.html#_CPPv4N7parquet16WriterProperties7Builder31enable_store_decimal_as_integerEv.