### PR TITLE
Build for GPU on CircleCI

### DIFF
--- a/.circleci/dist_compile.yml
+++ b/.circleci/dist_compile.yml
@@ -596,6 +596,7 @@ workflows:
       - linux-build
       - linux-pr-fuzzer-run
       - linux-build-options
+      - linux-build-gpu
       - linux-adapters
       - linux-presto-fuzzer-run
       - doc-gen-job:
@@ -610,6 +611,7 @@ workflows:
       - linux-build
       - linux-pr-fuzzer-run
       - linux-build-options
+      - linux-build-gpu
       - linux-adapters
       - doc-gen-job:
           filters:

--- a/.circleci/dist_compile.yml
+++ b/.circleci/dist_compile.yml
@@ -135,6 +135,15 @@ executors:
       CXX: /opt/rh/gcc-toolset-9/root/bin/g++
       VELOX_DEPENDENCY_SOURCE: BUNDLED
       simdjson_SOURCE: BUNDLED
+  build-gpu:
+    docker:
+      - image : ghcr.io/facebookincubator/velox-dev:circleci-avx
+    resource_class: gpu.nvidia.medium
+    environment:
+      CC:  /opt/rh/gcc-toolset-9/root/bin/gcc
+      CXX: /opt/rh/gcc-toolset-9/root/bin/g++
+      VELOX_DEPENDENCY_SOURCE: BUNDLED
+      simdjson_SOURCE: BUNDLED
   check:
     docker:
       - image : ghcr.io/facebookincubator/velox-dev:check-avx
@@ -287,11 +296,23 @@ jobs:
           command: |
             make benchmarks-build NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4
           no_output_timeout: 1h
+      - post-steps
+
+  # Build with gpu
+  linux-build-gpu:
+    executor: build-gpu
+    steps:
+      - pre-steps
       - run:
           name: "Build Velox With GPU support"
           command: |
-            make gpu NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4 CUDA_ARCHITECTURES=90 CUDA_COMPILER=/usr/local/cuda-12.3/bin/nvcc
+            make gpu NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4 CUDA_ARCHITECTURES=native CUDA_COMPILER=/usr/local/cuda-12.3/bin/nvcc
           no_output_timeout: 1h
+      # - run:
+      #     name: "Run Unit Tests"
+      #     command: |
+      #       cd _build/release && ctest -j 16 -VV --output-on-failure --no-tests=error
+      #     no_output_timeout: 1h
       - post-steps
 
   linux-adapters:

--- a/.circleci/dist_compile.yml
+++ b/.circleci/dist_compile.yml
@@ -287,6 +287,11 @@ jobs:
           command: |
             make benchmarks-build NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4
           no_output_timeout: 1h
+      - run:
+          name: "Build Velox With GPU support"
+          command: |
+            make gpu NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4 CUDA_ARCHITECTURES=90 CUDA_COMPILER=/usr/local/cuda-12.3/bin/nvcc
+          no_output_timeout: 1h
       - post-steps
 
   linux-adapters:

--- a/.circleci/dist_compile.yml
+++ b/.circleci/dist_compile.yml
@@ -135,15 +135,6 @@ executors:
       CXX: /opt/rh/gcc-toolset-9/root/bin/g++
       VELOX_DEPENDENCY_SOURCE: BUNDLED
       simdjson_SOURCE: BUNDLED
-  build-gpu:
-    machine:
-      image: linux-cuda-12:default
-    resource_class: gpu.nvidia.medium
-    environment:
-      CC:  /opt/rh/gcc-toolset-9/root/bin/gcc
-      CXX: /opt/rh/gcc-toolset-9/root/bin/g++
-      VELOX_DEPENDENCY_SOURCE: BUNDLED
-      simdjson_SOURCE: BUNDLED
   check:
     docker:
       - image : ghcr.io/facebookincubator/velox-dev:check-avx
@@ -296,25 +287,11 @@ jobs:
           command: |
             make benchmarks-build NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4
           no_output_timeout: 1h
-      - post-steps
-
-  # Build with gpu
-  linux-build-gpu:
-    executor: build-gpu
-    docker:
-      - image : ghcr.io/facebookincubator/velox-dev:circleci-avx
-    steps:
-      - pre-steps
       - run:
           name: "Build Velox With GPU support"
           command: |
-            make gpu NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4 CUDA_ARCHITECTURES=native CUDA_COMPILER=/usr/local/cuda-12.3/bin/nvcc
+            make gpu NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4 CUDA_ARCHITECTURES=90 CUDA_COMPILER=/usr/local/cuda-12.3/bin/nvcc
           no_output_timeout: 1h
-      # - run:
-      #     name: "Run Unit Tests"
-      #     command: |
-      #       cd _build/release && ctest -j 16 -VV --output-on-failure --no-tests=error
-      #     no_output_timeout: 1h
       - post-steps
 
   linux-adapters:
@@ -598,7 +575,6 @@ workflows:
       - linux-build
       - linux-pr-fuzzer-run
       - linux-build-options
-      - linux-build-gpu
       - linux-adapters
       - linux-presto-fuzzer-run
       - doc-gen-job:
@@ -613,7 +589,6 @@ workflows:
       - linux-build
       - linux-pr-fuzzer-run
       - linux-build-options
-      - linux-build-gpu
       - linux-adapters
       - doc-gen-job:
           filters:

--- a/.circleci/dist_compile.yml
+++ b/.circleci/dist_compile.yml
@@ -136,8 +136,6 @@ executors:
       VELOX_DEPENDENCY_SOURCE: BUNDLED
       simdjson_SOURCE: BUNDLED
   build-gpu:
-    docker:
-      - image : ghcr.io/facebookincubator/velox-dev:circleci-avx
     machine:
       image: linux-cuda-12:default
     resource_class: gpu.nvidia.medium
@@ -303,6 +301,8 @@ jobs:
   # Build with gpu
   linux-build-gpu:
     executor: build-gpu
+    docker:
+      - image : ghcr.io/facebookincubator/velox-dev:circleci-avx
     steps:
       - pre-steps
       - run:

--- a/.circleci/dist_compile.yml
+++ b/.circleci/dist_compile.yml
@@ -138,6 +138,8 @@ executors:
   build-gpu:
     docker:
       - image : ghcr.io/facebookincubator/velox-dev:circleci-avx
+    machine:
+      image: linux-cuda-12:default
     resource_class: gpu.nvidia.medium
     environment:
       CC:  /opt/rh/gcc-toolset-9/root/bin/gcc

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -66,6 +66,15 @@ jobs:
             tags: "ghcr.io/facebookincubator/velox-dev:presto-java"
 
     steps:
+      - name: Free up some disk space
+        run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          df -h
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -66,14 +66,15 @@ jobs:
             tags: "ghcr.io/facebookincubator/velox-dev:presto-java"
 
     steps:
-      - name: Free up some disk space
+      - name: "Checkout Repo"
+        uses: actions/checkout@v3
+        with:
+          sparse-checkout: |
+            scripts
+
+      - name: Free up disk space
         run: |
-          df -h
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-          df -h
+          ./scripts/gha-free-space.sh
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/CMake/ResolveDependency.cmake
+++ b/CMake/ResolveDependency.cmake
@@ -102,6 +102,10 @@ function(set_with_default var_name envvar_name default)
     set(${var_name}
         $ENV{${envvar_name}}
         PARENT_SCOPE)
+  elseif(DEFINED ${envvar_name})
+    set(${var_name}
+        ${${envvar_name}}
+        PARENT_SCOPE)
   else()
     set(${var_name}
         ${default}

--- a/CMake/resolve_dependency_modules/folly/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/folly/CMakeLists.txt
@@ -28,13 +28,18 @@ message(STATUS "Building Folly from source")
 if(gflags_SOURCE STREQUAL "BUNDLED")
   set(glog_patch && git apply ${CMAKE_CURRENT_LIST_DIR}/folly-gflags-glog.patch)
 endif()
+if(VELOX_ENABLE_GPU)
+  set(cudacc_patch && git apply ${CMAKE_CURRENT_LIST_DIR}/folly-cudacc.patch)
+endif()
+
+set(VELOX_FOLLY_PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/folly-no-export.patch
+                                ${glog_patch} ${cudacc_patch})
 
 FetchContent_Declare(
   folly
   URL ${VELOX_FOLLY_SOURCE_URL}
   URL_HASH ${VELOX_FOLLY_BUILD_SHA256_CHECKSUM}
-  PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/folly-no-export.patch
-                ${glog_patch})
+  PATCH_COMMAND ${VELOX_FOLLY_PATCH_COMMAND})
 
 if(ON_APPLE_M1)
   # folly will wrongly assume x86_64 if this is not set

--- a/CMake/resolve_dependency_modules/folly/folly-cudacc.patch
+++ b/CMake/resolve_dependency_modules/folly/folly-cudacc.patch
@@ -1,0 +1,68 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Rivos, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+--- a/folly/Conv.h
++++ b/folly/Conv.h
+@@ -286,8 +286,8 @@ namespace detail {
+ template <class... T>
+ using LastElement = type_pack_element_t<sizeof...(T) - 1, T...>;
+ 
+-#ifdef _MSC_VER
+-// MSVC can't quite figure out the LastElementImpl::call() stuff
++#if defined(_MSC_VER) || defined(__CUDACC__)
++// MSVC and NVCC can't quite figure out the LastElementImpl::call() stuff
+ // in the base implementation, so we have to use tuples instead,
+ // which result in significantly more templates being compiled,
+ // though the runtime performance is the same.
+--- a/folly/synchronization/RelaxedAtomic.h
++++ b/folly/synchronization/RelaxedAtomic.h
+@@ -98,7 +98,7 @@ struct relaxed_atomic_base : protected std::atomic<T> {
+ };
+ 
+ template <typename T>
+-struct relaxed_atomic_integral_base : private relaxed_atomic_base<T> {
++struct relaxed_atomic_integral_base : protected relaxed_atomic_base<T> {
+  private:
+   using atomic = std::atomic<T>;
+   using base = relaxed_atomic_base<T>;
+@@ -108,7 +108,9 @@ struct relaxed_atomic_integral_base : private relaxed_atomic_base<T> {
+ 
+   using base::relaxed_atomic_base;
+   using base::operator=;
++#ifndef __CUDACC__
+   using base::operator T;
++#endif
+   using base::compare_exchange_strong;
+   using base::compare_exchange_weak;
+   using base::exchange;
+@@ -206,7 +208,9 @@ struct relaxed_atomic : detail::relaxed_atomic_base<T> {
+ 
+   using base::relaxed_atomic_base;
+   using base::operator=;
++#ifndef __CUDACC__
+   using base::operator T;
++#endif
+ };
+ 
+ template <typename T>
+@@ -220,7 +224,9 @@ struct relaxed_atomic<T*> : detail::relaxed_atomic_base<T*> {
+ 
+   using detail::relaxed_atomic_base<T*>::relaxed_atomic_base;
+   using base::operator=;
++#ifndef __CUDACC__
+   using base::operator T*;
++#endif
+ 
+   T* fetch_add(std::ptrdiff_t arg) noexcept {
+     return atomic::fetch_add(arg, std::memory_order_relaxed);

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,14 @@ ifdef AZURESDK_ROOT_DIR
 CMAKE_FLAGS += -DAZURESDK_ROOT_DIR=$(AZURESDK_ROOT_DIR)
 endif
 
+ifdef CUDA_ARCHITECTURES
+CMAKE_FLAGS += -DCMAKE_CUDA_ARCHITECTURES="$(CUDA_ARCHITECTURES)"
+endif
+
+ifdef CUDA_COMPILER
+CMAKE_FLAGS += -DCMAKE_CUDA_COMPILER="$(CUDA_COMPILER)"
+endif
+
 # Use Ninja if available. If Ninja is used, pass through parallelism control flags.
 USE_NINJA ?= 1
 ifeq ($(USE_NINJA), 1)
@@ -107,6 +115,14 @@ min_debug: minimal_debug
 minimal:				 #: Minimal build
 	$(MAKE) cmake BUILD_DIR=release BUILD_TYPE=release EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DVELOX_BUILD_MINIMAL=ON"
 	$(MAKE) build BUILD_DIR=release
+
+gpu:						 #: Build with GPU support
+	$(MAKE) cmake BUILD_DIR=release BUILD_TYPE=release EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DVELOX_ENABLE_GPU=ON -Dfolly_SOURCE=BUNDLED"
+	$(MAKE) build BUILD_DIR=release
+
+gpu_debug:			 #: Build with debugging symbols and GPU support
+	$(MAKE) cmake BUILD_DIR=debug BUILD_TYPE=debug EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DVELOX_ENABLE_GPU=ON -Dfolly_SOURCE=BUNDLED"
+	$(MAKE) build BUILD_DIR=debug
 
 dwio:						#: Minimal build with dwio enabled.
 	$(MAKE) cmake BUILD_DIR=release BUILD_TYPE=release EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} \

--- a/scripts/circleci-container.dockfile
+++ b/scripts/circleci-container.dockfile
@@ -16,6 +16,7 @@
 FROM quay.io/centos/centos:stream8
 ARG cpu_target
 ENV CPU_TARGET=$cpu_target
+ENV AGGRESSIVE_CLEANUP=true
 
 COPY scripts/setup-helper-functions.sh /
 COPY scripts/setup-centos8.sh /

--- a/scripts/gha-free-space.sh
+++ b/scripts/gha-free-space.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -eux
+
+df -h
+# Remove Web browser packages
+sudo apt purge -y \
+  firefox \
+  google-chrome-stable \
+  microsoft-edge-stable
+# Remove things in /usr/local
+echo "::group::/usr/local/*"
+du -msc /usr/local/* | sort -n
+# ~1GB
+sudo rm -rf \
+  /usr/local/aws-cil \
+  /usr/local/aws-sam-cil \
+  /usr/local/julia* || :
+echo "::endgroup::"
+echo "::group::/usr/local/bin/*"
+du -msc /usr/local/bin/* | sort -n
+# ~1GB (From 1.2GB to 214MB)
+sudo rm -rf \
+  /usr/local/bin/aliyun \
+  /usr/local/bin/azcopy \
+  /usr/local/bin/bicep \
+  /usr/local/bin/cmake-gui \
+  /usr/local/bin/cpack \
+  /usr/local/bin/helm \
+  /usr/local/bin/hub \
+  /usr/local/bin/kubectl \
+  /usr/local/bin/minikube \
+  /usr/local/bin/node \
+  /usr/local/bin/packer \
+  /usr/local/bin/pulumi* \
+  /usr/local/bin/sam \
+  /usr/local/bin/stack \
+  /usr/local/bin/terraform || :
+# 142M
+sudo rm -rf /usr/local/bin/oc || :
+echo "::endgroup::"
+echo "::group::/usr/local/share/*"
+du -msc /usr/local/share/* | sort -n
+# 506MB
+sudo rm -rf /usr/local/share/chromium || :
+# 1.3GB
+sudo rm -rf /usr/local/share/powershell || :
+echo "::endgroup::"
+echo "::group::/usr/local/lib/*"
+du -msc /usr/local/lib/* | sort -n
+# 15GB
+sudo rm -rf /usr/local/lib/android || :
+# 341MB
+sudo rm -rf /usr/local/lib/heroku || :
+# 1.2GB
+sudo rm -rf /usr/local/lib/node_modules || :
+echo "::endgroup::"
+echo "::group::/opt/*"
+du -msc /opt/* | sort -n
+# 679MB
+sudo rm -rf /opt/az || :
+echo "::endgroup::"
+echo "::group::/opt/microsoft/*"
+du -msc /opt/microsoft/* | sort -n
+# 197MB
+sudo rm -rf /opt/microsoft/powershell || :
+echo "::endgroup::"
+echo "::group::/opt/hostedtoolcache/*"
+du -msc /opt/hostedtoolcache/* | sort -n
+# 5.3GB
+sudo rm -rf /opt/hostedtoolcache/CodeQL || :
+# 1.4GB
+sudo rm -rf /opt/hostedtoolcache/go || :
+# 489MB
+sudo rm -rf /opt/hostedtoolcache/PyPy || :
+# 376MB
+sudo rm -rf /opt/hostedtoolcache/node || :
+echo "::endgroup::"
+df -h

--- a/scripts/setup-adapters.sh
+++ b/scripts/setup-adapters.sh
@@ -31,6 +31,10 @@ function install_aws_deps {
 
   github_checkout $AWS_REPO_NAME $AWS_SDK_VERSION --depth 1 --recurse-submodules
   cmake_install -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DBUILD_SHARED_LIBS:BOOL=OFF -DMINIMIZE_SIZE:BOOL=ON -DENABLE_TESTING:BOOL=OFF -DBUILD_ONLY:STRING="s3;identity-management"
+  if [ $AGGRESSIVE_CLEANUP = "true" ]; then
+    rm -rf $(basename ${AWS_REPO_NAME})
+  fi
+
   # Dependencies for S3 testing
   # We need this specific version of Minio for testing.
   if [[ "$OSTYPE" == linux-gnu* ]]; then
@@ -62,6 +66,9 @@ function install_gcs-sdk-cpp {
   sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h"
   cmake_install -DBUILD_SHARED_LIBS=OFF \
     -DABSL_BUILD_TESTING=OFF
+  if [ $AGGRESSIVE_CLEANUP = "true" ]; then
+    rm -rf abseil-cpp
+  fi
 
   # crc32
   github_checkout google/crc32c 1.1.2 --depth 1
@@ -69,11 +76,17 @@ function install_gcs-sdk-cpp {
     -DCRC32C_BUILD_TESTS=OFF \
     -DCRC32C_BUILD_BENCHMARKS=OFF \
     -DCRC32C_USE_GLOG=OFF
+  if [ $AGGRESSIVE_CLEANUP = "true" ]; then
+    rm -rf crc32c
+  fi
 
   # nlohmann json
   github_checkout nlohmann/json v3.11.2 --depth 1
   cmake_install -DBUILD_SHARED_LIBS=OFF \
     -DJSON_BuildTests=OFF
+  if [ $AGGRESSIVE_CLEANUP = "true" ]; then
+    rm -rf json
+  fi
 
   # google-cloud-cpp
   github_checkout googleapis/google-cloud-cpp v2.10.1 --depth 1
@@ -81,6 +94,9 @@ function install_gcs-sdk-cpp {
     -DCMAKE_INSTALL_MESSAGE=NEVER \
     -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
     -DGOOGLE_CLOUD_CPP_ENABLE=storage
+  if [ $AGGRESSIVE_CLEANUP = "true" ]; then
+    rm -rf google-cloud-cpp
+  fi
 }
 
 function install_azure-storage-sdk-cpp {
@@ -117,6 +133,10 @@ function install_azure-storage-sdk-cpp {
   # install azure-storage-files-datalake
   cd sdk/storage/azure-storage-files-datalake
   cmake_install -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DBUILD_SHARED_LIBS=OFF
+
+  if [ $AGGRESSIVE_CLEANUP = "true" ]; then
+    rm -rf azure-sdk-for-cpp
+  fi
 }
 
 function install_hdfs_deps {
@@ -132,9 +152,13 @@ function install_hdfs_deps {
     sed -i "s/dumpversion/dumpfullversion/" ./CMake/Platform.cmake
     # Dependencies for Hadoop testing
     wget_and_untar https://archive.apache.org/dist/hadoop/common/hadoop-2.10.1/hadoop-2.10.1.tar.gz hadoop
-    cp -a hadoop /usr/local/
+    mv hadoop /usr/local/
   fi
   cmake_install
+
+  if [ $AGGRESSIVE_CLEANUP = "true" ]; then
+    rm -rf hawq
+  fi
 }
 
 cd "${DEPENDENCY_DIR}" || exit

--- a/scripts/setup-adapters.sh
+++ b/scripts/setup-adapters.sh
@@ -24,6 +24,7 @@ source $SCRIPTDIR/setup-helper-functions.sh
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
 CMAKE_BUILD_TYPE="${BUILD_TYPE:-Release}"
 MACHINE=$(uname -m)
+AGGRESSIVE_CLEANUP="${AGGRESSIVE_CLEANUP:-false}"
 
 function install_aws_deps {
   local AWS_REPO_NAME="aws/aws-sdk-cpp"

--- a/scripts/setup-centos8.sh
+++ b/scripts/setup-centos8.sh
@@ -168,6 +168,13 @@ function install_duckdb {
   fi
 }
 
+function install_cuda {
+  # See https://developer.nvidia.com/cuda-downloads
+  wget --progress=dot:giga https://developer.download.nvidia.com/compute/cuda/12.3.1/local_installers/cuda-repo-rhel7-12-3-local-12.3.1_545.23.08-1.x86_64.rpm
+  rpm -i cuda-repo-rhel7-12-3-local-12.3.1_545.23.08-1.x86_64.rpm
+  dnf_install cuda-toolkit-12-3
+}
+
 function install_velox_deps {
   run_and_time install_conda
   run_and_time install_gflags
@@ -183,6 +190,7 @@ function install_velox_deps {
   run_and_time install_mvfst
   run_and_time install_fbthrift
   run_and_time install_duckdb
+  run_and_time install_cuda
 }
 
 (return 2> /dev/null) && return # If script was sourced, don't run commands.

--- a/scripts/setup-centos8.sh
+++ b/scripts/setup-centos8.sh
@@ -25,6 +25,7 @@ export CXXFLAGS=$CFLAGS  # Used by boost.
 export CPPFLAGS=$CFLAGS  # Used by LZO.
 CMAKE_BUILD_TYPE="${BUILD_TYPE:-Release}"
 BUILD_DUCKDB="${BUILD_DUCKDB:-true}"
+AGGRESSIVE_CLEANUP="${AGGRESSIVE_CLEANUP:-false}"
 
 function dnf_install {
   dnf install -y -q --setopt=install_weak_deps=False "$@"
@@ -59,6 +60,9 @@ function install_gflags {
     cd gflags
     cmake_install -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DBUILD_gflags_LIB=ON -DLIB_SUFFIX=64
   )
+  if [ $AGGRESSIVE_CLEANUP = "true" ]; then
+    rm -rf gflags
+  fi
 }
 
 function install_glog {
@@ -67,6 +71,9 @@ function install_glog {
     cd glog
     cmake_install -DBUILD_SHARED_LIBS=ON
   )
+  if [ $AGGRESSIVE_CLEANUP = "true" ]; then
+    rm -rf glog
+  fi
 }
 
 function install_lzo {
@@ -77,6 +84,9 @@ function install_lzo {
     make "-j$(nproc)"
     make install
   )
+  if [ $AGGRESSIVE_CLEANUP = "true" ]; then
+    rm -rf lzo
+  fi
 }
 
 function install_boost {
@@ -86,6 +96,9 @@ function install_boost {
    ./bootstrap.sh --prefix=/usr/local
    ./b2 "-j$(nproc)" -d0 install threading=multi
   )
+  if [ $AGGRESSIVE_CLEANUP = "true" ]; then
+    rm -rf boost
+  fi
 }
 
 function install_snappy {
@@ -94,6 +107,9 @@ function install_snappy {
     cd snappy
     cmake_install -DSNAPPY_BUILD_TESTS=OFF
   )
+  if [ $AGGRESSIVE_CLEANUP = "true" ]; then
+    rm -rf snappy
+  fi
 }
 
 function install_fmt {
@@ -102,6 +118,9 @@ function install_fmt {
     cd fmt
     cmake_install -DFMT_TEST=OFF
   )
+  if [ $AGGRESSIVE_CLEANUP = "true" ]; then
+    rm -rf fmt
+  fi
 }
 
 function install_protobuf {
@@ -113,6 +132,9 @@ function install_protobuf {
     make install
     ldconfig
   )
+  if [ $AGGRESSIVE_CLEANUP = "true" ]; then
+    rm -rf protobuf
+  fi
 }
 
 FB_OS_VERSION="v2023.12.04.00"
@@ -123,6 +145,9 @@ function install_fizz {
     cd fizz/fizz
     cmake_install -DBUILD_TESTS=OFF
   )
+  if [ $AGGRESSIVE_CLEANUP = "true" ]; then
+    rm -rf fizz
+  fi
 }
 
 function install_folly {
@@ -131,6 +156,9 @@ function install_folly {
     cd folly
     cmake_install -DFOLLY_HAVE_INT128_T=ON
   )
+  if [ $AGGRESSIVE_CLEANUP = "true" ]; then
+    rm -rf folly
+  fi
 }
 
 function install_wangle {
@@ -139,6 +167,9 @@ function install_wangle {
     cd wangle/wangle
     cmake_install -DBUILD_TESTS=OFF
   )
+  if [ $AGGRESSIVE_CLEANUP = "true" ]; then
+    rm -rf wangle
+  fi
 }
 
 function install_fbthrift {
@@ -147,6 +178,9 @@ function install_fbthrift {
     cd fbthrift
     cmake_install -Denable_tests=OFF
   )
+  if [ $AGGRESSIVE_CLEANUP = "true" ]; then
+    rm -rf fbthrift
+  fi
 }
 
 function install_mvfst {
@@ -155,6 +189,9 @@ function install_mvfst {
    cd mvfst
    cmake_install -DBUILD_TESTS=OFF
   )
+  if [ $AGGRESSIVE_CLEANUP = "true" ]; then
+    rm -rf mvfst
+  fi
 }
 
 function install_duckdb {
@@ -165,6 +202,9 @@ function install_duckdb {
       cd duckdb
       cmake_install -DBUILD_UNITTESTS=OFF -DENABLE_SANITIZER=OFF -DENABLE_UBSAN=OFF -DBUILD_SHELL=OFF -DEXPORT_DLL_SYMBOLS=OFF -DCMAKE_BUILD_TYPE=Release
     )
+    if [ $AGGRESSIVE_CLEANUP = "true" ]; then
+      rm -rf duckdb
+    fi
   fi
 }
 
@@ -172,6 +212,7 @@ function install_cuda {
   # See https://developer.nvidia.com/cuda-downloads
   wget --progress=dot:giga https://developer.download.nvidia.com/compute/cuda/12.3.1/local_installers/cuda-repo-rhel7-12-3-local-12.3.1_545.23.08-1.x86_64.rpm
   rpm -i cuda-repo-rhel7-12-3-local-12.3.1_545.23.08-1.x86_64.rpm
+  rm cuda-repo-rhel7-12-3-local-12.3.1_545.23.08-1.x86_64.rpm
   dnf_install cuda-toolkit-12-3
 }
 

--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -99,9 +99,9 @@ function get_cxx_flags {
         CPU_ARCH="arm64"
       fi
 
-    # On MacOs prevent the flood of translation visibility settings warnings.
-    ADDITIONAL_FLAGS="-fvisibility=hidden -fvisibility-inlines-hidden"
-    else [ "$OS" = "Linux" ];
+      # On MacOs prevent the flood of translation visibility settings warnings.
+      ADDITIONAL_FLAGS="-fvisibility=hidden -fvisibility-inlines-hidden"
+    elif [ "$OS" = "Linux" ]; then
 
       local CPU_CAPABILITIES
       CPU_CAPABILITIES=$(cat /proc/cpuinfo | grep flags | head -n 1| awk '{print tolower($0)}')
@@ -133,8 +133,11 @@ function get_cxx_flags {
     "aarch64")
       echo -n "-mcpu=neoverse-n1 -std=c++17 $ADDITIONAL_FLAGS"
     ;;
-  *)
-    echo -n "Architecture not supported!"
+
+    *)
+      echo "Architecture not supported: CPU_ARCH=$CPU_ARCH" 1>&2
+      exit 1
+    ;;
   esac
 
 }

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -2404,3 +2404,11 @@ struct fmt::formatter<facebook::velox::core::JoinType> : formatter<int> {
     return formatter<int>::format(static_cast<int>(s), ctx);
   }
 };
+
+template <>
+struct fmt::formatter<facebook::velox::core::AggregationNode::Step> : formatter<std::string> {
+  auto format(facebook::velox::core::AggregationNode::Step s, format_context& ctx) {
+    return formatter<std::string>::format(
+        facebook::velox::core::mapAggregationStepToName(s), ctx);
+  }
+};

--- a/velox/experimental/gpu/tests/CMakeLists.txt
+++ b/velox/experimental/gpu/tests/CMakeLists.txt
@@ -14,5 +14,3 @@
 
 add_executable(velox_gpu_hash_table_test HashTableTest.cu)
 target_link_libraries(velox_gpu_hash_table_test Folly::folly gflags::gflags)
-set_target_properties(velox_gpu_hash_table_test PROPERTIES CUDA_ARCHITECTURES
-                                                           native)

--- a/velox/experimental/gpu/tests/HashTableTest.cu
+++ b/velox/experimental/gpu/tests/HashTableTest.cu
@@ -280,26 +280,26 @@ __global__ void probe<true>(
     auto rem = hash % sizeof(uint32_t);
     int64_t j = hash - rem;
     uint32_t cmpMask = 0xffffffff << (rem * 8);
-    ([&](){
-      for (;;) {
-        auto hits = __vcmpeq4(*(uint32_t*)&table->tags[j], tag) & cmpMask;
-        while (hits) {
-          auto jj = j + (__ffs(hits) - 1) / 8;
-          if (table->keys[jj] == keys[i]) {
-            hasValue[i] = true;
-            values[i] = table->values[jj];
-            return;
-          }
-          hits &= hits - 1;
+    for (;;) {
+      auto hits = __vcmpeq4(*(uint32_t*)&table->tags[j], tag) & cmpMask;
+      while (hits) {
+        auto jj = j + (__ffs(hits) - 1) / 8;
+        if (table->keys[jj] == keys[i]) {
+          hasValue[i] = true;
+          values[i] = table->values[jj];
+          goto end;
         }
-        if (__vcmpeq4(*(uint32_t*)&table->tags[j], 0) & cmpMask) {
-          hasValue[i] = false;
-          return;
-        }
-        j = (j + sizeof(uint32_t)) & tableSizeMask;
-        cmpMask = 0xffffffff;
+        hits &= hits - 1;
       }
-    })();
+      if (__vcmpeq4(*(uint32_t*)&table->tags[j], 0) & cmpMask) {
+        hasValue[i] = false;
+        goto end;
+      }
+      j = (j + sizeof(uint32_t)) & tableSizeMask;
+      cmpMask = 0xffffffff;
+    }
+  end:
+    ;
   }
 }
 
@@ -602,34 +602,34 @@ __global__ void probePartitioned<true>(
   uint64_t tableSizeMask = partitionSize - 1;
   for (auto i = threadIdx.x + offsets[blockIdx.x]; i < offsets[blockIdx.x + 1];
        i += blockDim.x) {
-    ([&](){
-      auto hash = hashInt(keys[i]) >> shift;
-      uint32_t tag = hashTag(hash);
-      tag = tag | (tag << 8);
-      tag = tag | (tag << 16);
-      hash &= tableSizeMask;
-      auto rem = hash % sizeof(uint32_t);
-      int64_t j = hash - rem;
-      uint32_t cmpMask = 0xffffffff << (rem * 8);
-      for (;;) {
-        auto hits = __vcmpeq4(*(uint32_t*)&tableTags[j], tag) & cmpMask;
-        while (hits) {
-          auto jj = j + (__ffs(hits) - 1) / 8 + partitionSize * blockIdx.x;
-          if (table->keys[jj] == keys[i]) {
-            hasValue[i] = true;
-            values[i] = table->values[jj];
-            return;
-          }
-          hits &= hits - 1;
+    auto hash = hashInt(keys[i]) >> shift;
+    uint32_t tag = hashTag(hash);
+    tag = tag | (tag << 8);
+    tag = tag | (tag << 16);
+    hash &= tableSizeMask;
+    auto rem = hash % sizeof(uint32_t);
+    int64_t j = hash - rem;
+    uint32_t cmpMask = 0xffffffff << (rem * 8);
+    for (;;) {
+      auto hits = __vcmpeq4(*(uint32_t*)&tableTags[j], tag) & cmpMask;
+      while (hits) {
+        auto jj = j + (__ffs(hits) - 1) / 8 + partitionSize * blockIdx.x;
+        if (table->keys[jj] == keys[i]) {
+          hasValue[i] = true;
+          values[i] = table->values[jj];
+          goto end;
         }
-        if (__vcmpeq4(*(uint32_t*)&tableTags[j], 0) & cmpMask) {
-          hasValue[i] = false;
-          return;
-        }
-        j = (j + sizeof(uint32_t)) & tableSizeMask;
-        cmpMask = 0xffffffff;
+        hits &= hits - 1;
       }
-    })();
+      if (__vcmpeq4(*(uint32_t*)&tableTags[j], 0) & cmpMask) {
+        hasValue[i] = false;
+        goto end;
+      }
+      j = (j + sizeof(uint32_t)) & tableSizeMask;
+      cmpMask = 0xffffffff;
+    }
+  end:
+    ;
   }
 }
 

--- a/velox/experimental/wave/common/CMakeLists.txt
+++ b/velox/experimental/wave/common/CMakeLists.txt
@@ -15,8 +15,6 @@
 add_library(velox_wave_common GpuArena.cpp Buffer.cpp Cuda.cu Exception.cpp
                               Type.cpp)
 
-set_target_properties(velox_wave_common PROPERTIES CUDA_ARCHITECTURES native)
-
 target_link_libraries(velox_wave_common velox_exception velox_common_base
                       velox_type)
 

--- a/velox/experimental/wave/common/Cuda.cu
+++ b/velox/experimental/wave/common/Cuda.cu
@@ -171,7 +171,7 @@ struct EventImpl {
 Event::Event(bool withTime) : hasTiming_(withTime) {
   event_ = std::make_unique<EventImpl>();
   CUDA_CHECK(
-      cudaEventCreate(&event_->event, withTime ? 0 : cudaEventDisableTiming));
+      cudaEventCreateWithFlags(&event_->event, withTime ? 0 : cudaEventDisableTiming));
 }
 
 Event::~Event() {}

--- a/velox/experimental/wave/common/Type.cpp
+++ b/velox/experimental/wave/common/Type.cpp
@@ -50,4 +50,33 @@ PhysicalType fromCpuType(const Type& type) {
   return ans;
 }
 
+std::string PhysicalType::kindString(Kind kind) {
+  switch (kind) {
+    case kInt8:
+      return "Int8";
+    case kInt16:
+      return "Int16";
+    case kInt32:
+      return "Int32";
+    case kInt64:
+      return "Int64";
+    case kInt128:
+      return "Int128";
+    case kFloat32:
+      return "Float32";
+    case kFloat64:
+      return "Float64";
+    case kString:
+      return "String";
+    case kArray:
+      return "Array";
+    case kMap:
+      return "Map";
+    case kRow:
+      return "Row";
+  }
+
+  VELOX_UNREACHABLE();
+}
+
 } // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/Type.h
+++ b/velox/experimental/wave/common/Type.h
@@ -17,6 +17,11 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
+#include <fmt/format.h>
+#if FMT_VERSION >= 100100
+#include <fmt/std.h>
+#endif
 
 namespace facebook::velox {
 class Type;
@@ -40,8 +45,21 @@ struct PhysicalType {
   } kind;
   int32_t numChildren;
   PhysicalType** children;
+
+  static std::string kindString(Kind kind);
 };
 
 PhysicalType fromCpuType(const Type&);
 
 } // namespace facebook::velox::wave
+
+template <>
+struct fmt::formatter<facebook::velox::wave::PhysicalType::Kind>
+    : formatter<std::string> {
+  auto format(
+      facebook::velox::wave::PhysicalType::Kind s,
+      format_context& ctx) {
+    return formatter<std::string>::format(
+        facebook::velox::wave::PhysicalType::kindString(s), ctx);
+  }
+};

--- a/velox/experimental/wave/common/tests/BlockTest.cu
+++ b/velox/experimental/wave/common/tests/BlockTest.cu
@@ -11,7 +11,7 @@ __global__ void boolToIndices(
     int32_t** indices,
     int32_t* sizes,
     int64_t* times) {
-  extern __shared__ __align__(alignof(ScanAlgorithm::TempStorage)) char smem[];
+  __shared__ __align__(alignof(ScanAlgorithm::TempStorage)) char smem[1];
   int32_t idx = blockIdx.x;
   // Start cycle timer
   clock_t start = clock();
@@ -41,8 +41,8 @@ void BlockTestStream::testBoolToIndices(
 }
 
 __global__ void sum64(int64_t* numbers, int64_t* results) {
-  extern __shared__ __align__(
-      alignof(cub::BlockReduce<int64_t, 256>::TempStorage)) char smem[];
+  __shared__ __align__(
+      alignof(cub::BlockReduce<int64_t, 256>::TempStorage)) char smem[1];
   int32_t idx = blockIdx.x;
   blockSum<256>(
       [&]() { return numbers[idx * 256 + threadIdx.x]; }, smem, results);

--- a/velox/experimental/wave/common/tests/CMakeLists.txt
+++ b/velox/experimental/wave/common/tests/CMakeLists.txt
@@ -15,9 +15,6 @@
 add_executable(velox_wave_common_test GpuArenaTest.cpp CudaTest.cpp CudaTest.cu
                                       BlockTest.cpp BlockTest.cu)
 
-set_target_properties(velox_wave_common_test PROPERTIES CUDA_ARCHITECTURES
-                                                        native)
-
 add_test(velox_wave_common_test velox_wave_common_test)
 
 target_link_libraries(

--- a/velox/experimental/wave/exec/CMakeLists.txt
+++ b/velox/experimental/wave/exec/CMakeLists.txt
@@ -26,8 +26,6 @@ add_library(
   Wave.cpp
   Project.cpp)
 
-set_target_properties(velox_wave_exec PROPERTIES CUDA_ARCHITECTURES native)
-
 target_link_libraries(velox_wave_exec velox_wave_vector velox_wave_common
                       velox_exception velox_common_base velox_exec)
 

--- a/velox/experimental/wave/exec/ExprKernel.h
+++ b/velox/experimental/wave/exec/ExprKernel.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstdint>
+#include "velox/common/base/Exceptions.h"
 #include "velox/experimental/wave/common/Cuda.h"
 #include "velox/experimental/wave/exec/ErrorCode.h"
 #include "velox/experimental/wave/vector/Operand.h"
@@ -61,6 +62,45 @@ enum class OpCode {
   kNE,
 
 };
+
+inline std::ostream& operator<<(
+    std::ostream& out,
+    const OpCode& opcode) {
+  switch (opcode) {
+    case OpCode::kFilter:
+      return out << "Filter";
+    case OpCode::kWrap:
+      return out << "Wrap";
+    case OpCode::kPlus:
+      return out << "Plus";
+    case OpCode::kMinus:
+      return out << "Minus";
+    case OpCode::kTimes:
+      return out << "Times";
+    case OpCode::kDivide:
+      return out << "Divide";
+    case OpCode::kEquals:
+      return out << "Equals";
+    case OpCode::kLT:
+      return out << "LT";
+    case OpCode::kLTE:
+      return out << "LTE";
+    case OpCode::kGT:
+      return out << "GT";
+    case OpCode::kGTE:
+      return out << "GTE";
+    case OpCode::kNE:
+      return out << "NE";
+  }
+
+  VELOX_UNREACHABLE();
+}
+
+inline std::string mapOpCodeToName(const OpCode& opcode) {
+  std::stringstream ss;
+  ss << opcode;
+  return ss.str();
+}
 
 #define OP_MIX(op, t) \
   static_cast<OpCode>(static_cast<int32_t>(t) + 8 * static_cast<int32_t>(op))
@@ -151,3 +191,11 @@ class WaveKernelStream : public Stream {
 };
 
 } // namespace facebook::velox::wave
+
+template <>
+struct fmt::formatter<facebook::velox::wave::OpCode> : formatter<std::string> {
+  auto format(facebook::velox::wave::OpCode o, format_context& ctx) {
+    return formatter<std::string>::format(
+        facebook::velox::wave::mapOpCodeToName(o), ctx);
+  }
+};

--- a/velox/experimental/wave/exec/tests/CMakeLists.txt
+++ b/velox/experimental/wave/exec/tests/CMakeLists.txt
@@ -14,8 +14,6 @@
 
 add_executable(velox_wave_exec_test FilterProjectTest.cpp Main.cpp)
 
-set_target_properties(velox_wave_exec_test PROPERTIES CUDA_ARCHITECTURES native)
-
 add_test(velox_wave_exec_test velox_wave_exec_test)
 
 target_link_libraries(

--- a/velox/experimental/wave/vector/tests/CMakeLists.txt
+++ b/velox/experimental/wave/vector/tests/CMakeLists.txt
@@ -14,9 +14,6 @@
 
 add_executable(velox_wave_vector_test VectorTest.cpp)
 
-set_target_properties(velox_wave_vector_test PROPERTIES CUDA_ARCHITECTURES
-                                                        native)
-
 add_test(veloxwave__vector_test velox_wave_vector_test)
 
 target_link_libraries(


### PR DESCRIPTION
This change adds just enough support to build Velox with GPU support on
CircleCI. That will help make sure the build with VELOX_ENABLE_GPU
doesn't regress, even if it doesn't test just yet.

Co-authored-by: Sergei Lewis <slewis@rivosinc.com>