### PR TITLE
Fix timestamp with timezone comparison

### DIFF
--- a/velox/functions/prestosql/Comparisons.h
+++ b/velox/functions/prestosql/Comparisons.h
@@ -26,14 +26,14 @@ template <typename T>
 struct TimestampWithTimezoneComparisonSupport {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  // Convert TimestampWithTimezone from original timezone to GMT in milliseconds
+  /// Timestamp with time zone values contain the milliseconds
+  /// already adjusted to UTC/GMT.
+  /// That means they are already normalized on UTC. We can directly compare
+  /// the UTC seconds and don't need to convert anything.
   FOLLY_ALWAYS_INLINE
-  int64_t toGMTMillis(
+  int64_t toTimestampMillis(
       const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
     auto inputTimeStamp = unpackTimestampUtc(timestampWithTimezone);
-    const auto timezone = unpackZoneKeyId(timestampWithTimezone);
-    inputTimeStamp.toGMT(timezone);
-
     return inputTimeStamp.toMillis();
   }
 };
@@ -71,19 +71,19 @@ VELOX_GEN_BINARY_EXPR(GteFunction, lhs >= rhs, bool);
 
 VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(
     LtFunction,
-    this->toGMTMillis(lhs) < this->toGMTMillis(rhs),
+    this->toTimestampMillis(lhs) < this->toTimestampMillis(rhs),
     bool);
 VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(
     GtFunction,
-    this->toGMTMillis(lhs) > this->toGMTMillis(rhs),
+    this->toTimestampMillis(lhs) > this->toTimestampMillis(rhs),
     bool);
 VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(
     LteFunction,
-    this->toGMTMillis(lhs) <= this->toGMTMillis(rhs),
+    this->toTimestampMillis(lhs) <= this->toTimestampMillis(rhs),
     bool);
 VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(
     GteFunction,
-    this->toGMTMillis(lhs) >= this->toGMTMillis(rhs),
+    this->toTimestampMillis(lhs) >= this->toTimestampMillis(rhs),
     bool);
 
 #undef VELOX_GEN_BINARY_EXPR
@@ -147,7 +147,7 @@ struct EqFunctionTimestampWithTimezone
       bool& result,
       const arg_type<TimestampWithTimezone>& lhs,
       const arg_type<TimestampWithTimezone>& rhs) {
-    result = this->toGMTMillis(lhs) == this->toGMTMillis(rhs);
+    result = this->toTimestampMillis(lhs) == this->toTimestampMillis(rhs);
   }
 };
 
@@ -184,7 +184,7 @@ struct NeqFunctionTimestampWithTimezone
       bool& result,
       const arg_type<TimestampWithTimezone>& lhs,
       const arg_type<TimestampWithTimezone>& rhs) {
-    result = this->toGMTMillis(lhs) != this->toGMTMillis(rhs);
+    result = this->toTimestampMillis(lhs) != this->toTimestampMillis(rhs);
   }
 };
 

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -3638,17 +3638,26 @@ TEST_F(DateTimeFunctionsTest, timestampWithTimezoneComparisons) {
     test::assertEqualVectors(expectedResult, actual);
   };
 
-  auto timezones = std::vector<TimeZoneKey>{900, 900, 800};
+  /// Timestamp with timezone is internally represented with the milliseconds
+  /// already converted to UTC and thus normalized. The timezone does not play
+  /// a role in the comparison.
+  /// For example, 1970-01-01-06:00:00+02:00 is stored as
+  /// TIMESTAMP WITH TIMEZONE value (14400000, 960). 960 being the tzid
+  /// representing +02:00. And 1970-01-01-04:00:00+00:00 is stored as (14400000,
+  /// 0). These timestamps are equivalent.
+  auto timestampsLhs = std::vector<int64_t>{0, 0, 1000};
+  auto timezonesLhs = std::vector<TimeZoneKey>{900, 900, 800};
   VectorPtr timestampWithTimezoneLhs = makeTimestampWithTimeZoneVector(
-      timezones.size(),
-      [](auto /*row*/) { return 0; },
-      [&](auto row) { return timezones[row]; });
+      timestampsLhs.size(),
+      [&](auto row) { return timestampsLhs[row]; },
+      [&](auto row) { return timezonesLhs[row]; });
 
-  auto timestamps = std::vector<int64_t>{0, 1000, 0};
+  auto timestampsRhs = std::vector<int64_t>{0, 1000, 0};
+  auto timezonesRhs = std::vector<TimeZoneKey>{900, 900, 800};
   VectorPtr timestampWithTimezoneRhs = makeTimestampWithTimeZoneVector(
-      timestamps.size(),
-      [&](auto row) { return timestamps[row]; },
-      [](auto /*row*/) { return 900; });
+      timestampsRhs.size(),
+      [&](auto row) { return timestampsRhs[row]; },
+      [&](auto row) { return timezonesRhs[row]; });
   auto inputs =
       makeRowVector({timestampWithTimezoneLhs, timestampWithTimezoneRhs});
 


### PR DESCRIPTION
In the original comparison the timestamp with timezone value had the millisecond portion
of the value adjusted to UTC based on the timezone id of the value.
However, this is not correct because the millisecond value is already adjusted and normalized
to be in UTC and can, therefore, be directly compared.