### PR TITLE
FlexibleResult

### DIFF
--- a/velox/dwio/common/ResultOrActions.h
+++ b/velox/dwio/common/ResultOrActions.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <functional>
+#include <variant>
+#include <vector>
+
+#include "folly/Range.h"
+#include "folly/Unit.h"
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::dwio::common {
+
+// Use this class if you want to return a result or a set of actions needed
+// before achieving that result.
+// For example, if IO needs to be performed, instead of blocking and doing the
+// IO on the same thread, the reader can return the NEEDS_MORE_IO state and a
+// callback, or a set of callbacks, if parallelizable, to perform the IO.
+// Some states may not require actions.
+// If there's a result, no action is expected.
+//
+// Use ResultOrActions<folly::Unit> if you don't need a result (instead of
+// ResultOrActions<void>, which isn't supported).
+template <typename ResultType, typename ActionSignature = void()>
+class ResultOrActions {
+ public:
+  // This constructor doesn't exist if we don't have a result
+  // (ResultType=folly::Unit)
+  template <
+      typename T = ResultType,
+      typename std::enable_if_t<!std::is_same_v<T, folly::Unit>, int> = 0>
+  /* implicit */ ResultOrActions(std::conditional_t<true, ResultType, T> result)
+      : resultOrActions_(std::move(result)) {}
+
+  /* implicit */ ResultOrActions(std::function<ActionSignature> action)
+      : resultOrActions_{
+            std::vector<std::function<ActionSignature>>{{std::move(action)}}} {}
+
+  /* implicit */ ResultOrActions(
+      std::vector<std::function<ActionSignature>> actions = {})
+      : resultOrActions_{std::move(actions)} {}
+
+  /* implicit */ ResultOrActions(ResultOrActions&& other) noexcept
+      : resultOrActions_{std::move(other.resultOrActions_)} {}
+
+  ResultOrActions& operator=(ResultOrActions&& other) {
+    resultOrActions_ = std::move(other.resultOrActions_);
+    return *this;
+  }
+
+  template <typename T = ResultType>
+  typename std::enable_if_t<!std::is_same_v<T, folly::Unit>, bool> hasResult()
+      const {
+    return resultOrActions_.index() == 1;
+  }
+
+  template <typename T = ResultType>
+  const typename std::enable_if_t<!std::is_same_v<T, folly::Unit>, ResultType>&
+  result() const {
+    VELOX_CHECK(hasResult(), "Result is not set");
+    return std::get<ResultType>(resultOrActions_);
+  }
+
+  template <typename T = ResultType>
+  typename std::enable_if_t<!std::is_same_v<T, folly::Unit>, ResultType>&
+  result() {
+    VELOX_CHECK(hasResult(), "Result is not set");
+    return std::get<ResultType>(resultOrActions_);
+  }
+
+  folly::Range<std::function<ActionSignature>*> actions() {
+    switch (resultOrActions_.index()) {
+      case 0: // Actions
+        return {
+            std::get<std::vector<std::function<ActionSignature>>>(
+                resultOrActions_)
+                .data(),
+            std::get<std::vector<std::function<ActionSignature>>>(
+                resultOrActions_)
+                .size()};
+      case 1: // Result
+        return {};
+      default:
+        VELOX_FAIL("Unexpected variant index");
+    }
+  }
+
+  size_t runAllActions() {
+    size_t numActions = 0;
+    switch (resultOrActions_.index()) {
+      case 0: // Actions
+      {
+        auto& actions = std::get<std::vector<std::function<ActionSignature>>>(
+            resultOrActions_);
+        numActions = actions.size();
+        for (auto& action : actions) {
+          action();
+        }
+        break;
+      }
+      default:
+        break;
+    }
+    return numActions;
+  }
+
+ private:
+  // Otherwise mergeActionsFrom can't read other's private members, since
+  // they're different classes
+  template <typename OtherResultType, typename OtherActionSignature>
+  friend class ResultOrActions;
+
+  void mergeAction(std::function<ActionSignature> action) {
+    switch (resultOrActions_.index()) {
+      case 0: // Actions
+        std::get<std::vector<std::function<ActionSignature>>>(resultOrActions_)
+            .push_back(std::move(action));
+        break;
+      case 1: // Result
+        VELOX_FAIL("Can't merge actions if destination class has a result");
+    }
+  }
+
+  std::variant<std::vector<std::function<ActionSignature>>, ResultType>
+      resultOrActions_;
+};
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(
   ReadFileInputStreamTests.cpp
   ReaderTest.cpp
   RetryTests.cpp
+  ResultOrActionsTests.cpp
   TestBufferedInput.cpp
   TypeTests.cpp
   WriterTest.cpp)

--- a/velox/dwio/common/tests/ResultOrActionsTests.cpp
+++ b/velox/dwio/common/tests/ResultOrActionsTests.cpp
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/ResultOrActions.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <list>
+
+using namespace ::testing;
+using namespace ::facebook::velox::dwio::common;
+
+namespace {
+
+using ReaderResult = ResultOrActions<uint64_t>;
+using SplitResult = ResultOrActions<uint64_t>;
+using VoidResult = ResultOrActions<folly::Unit>;
+
+using ActionsMock = std::vector<int>;
+
+auto getAction(ActionsMock& executedActions) {
+  executedActions.push_back(0);
+  return [&executedActions, i = executedActions.size() - 1]() {
+    executedActions.at(i)++;
+  };
+}
+
+std::vector<std::function<void()>> getActions(
+    ActionsMock& executedActions,
+    int numActions) {
+  std::vector<std::function<void()>> actions;
+  actions.reserve(numActions);
+  for (int i = 0; i < numActions; i++) {
+    actions.push_back(getAction(executedActions));
+  }
+  return actions;
+}
+
+template <typename T>
+class ResultOrActionsTypedTest : public testing::Test {};
+
+} // namespace
+
+TEST(ResultOrActionsTest, HasResult) {
+  ReaderResult readerResult(10);
+  ASSERT_TRUE(readerResult.hasResult());
+  EXPECT_EQ(readerResult.result(), 10);
+  EXPECT_EQ(readerResult.actions().size(), 0);
+}
+
+TEST(ResultOrActionsTest, Void) {
+  {
+    VoidResult readerResult;
+    EXPECT_EQ(readerResult.actions().size(), 0);
+  }
+  {
+    VoidResult readerResult;
+    EXPECT_EQ(readerResult.actions().size(), 0);
+  }
+  ActionsMock executedActions;
+  {
+    VoidResult readerResult(getAction(executedActions));
+    EXPECT_EQ(readerResult.actions().size(), 1);
+  }
+  {
+    VoidResult readerResult(getActions(executedActions, 2));
+    EXPECT_EQ(readerResult.actions().size(), 2);
+  }
+}
+
+using ReaderResultTypes = ::testing::Types<ReaderResult, VoidResult>;
+TYPED_TEST_CASE(ResultOrActionsTypedTest, ReaderResultTypes);
+
+TYPED_TEST(ResultOrActionsTypedTest, NoResult) {
+  ReaderResult readerResult;
+  if constexpr (!std::is_same_v<TypeParam, VoidResult>) {
+    ASSERT_FALSE(readerResult.hasResult());
+    EXPECT_THAT(
+        [&]() { readerResult.result(); },
+        Throws<facebook::velox::VeloxRuntimeError>(Property(
+            &facebook::velox::VeloxRuntimeError::message,
+            HasSubstr("Result is not set"))));
+  }
+  EXPECT_EQ(readerResult.actions().size(), 0);
+  EXPECT_EQ(readerResult.runAllActions(), 0);
+}
+
+TYPED_TEST(ResultOrActionsTypedTest, ActionNeeded) {
+  ActionsMock executedActions;
+  ReaderResult readerResult(getAction(executedActions));
+  if constexpr (!std::is_same_v<TypeParam, VoidResult>) {
+    ASSERT_FALSE(readerResult.hasResult());
+    EXPECT_THAT(
+        [&]() { readerResult.result(); },
+        Throws<facebook::velox::VeloxRuntimeError>(Property(
+            &facebook::velox::VeloxRuntimeError::message,
+            HasSubstr("Result is not set"))));
+  }
+  EXPECT_EQ(readerResult.actions().size(), 1);
+  EXPECT_EQ(executedActions, ActionsMock({0}));
+  readerResult.actions()[0]();
+  EXPECT_EQ(executedActions, ActionsMock({1}));
+  EXPECT_EQ(readerResult.runAllActions(), 1);
+  EXPECT_EQ(executedActions, ActionsMock({2}));
+}
+
+TYPED_TEST(ResultOrActionsTypedTest, ActionsNeeded) {
+  ActionsMock executedActions;
+  ReaderResult readerResult(getActions(executedActions, 2));
+  if constexpr (!std::is_same_v<TypeParam, VoidResult>) {
+    ASSERT_FALSE(readerResult.hasResult());
+    EXPECT_THAT(
+        [&]() { readerResult.result(); },
+        Throws<facebook::velox::VeloxRuntimeError>(Property(
+            &facebook::velox::VeloxRuntimeError::message,
+            HasSubstr("Result is not set"))));
+  }
+  EXPECT_EQ(readerResult.actions().size(), 2);
+  EXPECT_EQ(executedActions, ActionsMock({0, 0}));
+  readerResult.actions()[0]();
+  EXPECT_EQ(executedActions, ActionsMock({1, 0}));
+  readerResult.actions()[1]();
+  EXPECT_EQ(executedActions, ActionsMock({1, 1}));
+  EXPECT_EQ(readerResult.runAllActions(), 2);
+  EXPECT_EQ(executedActions, ActionsMock({2, 2}));
+}
+
+TYPED_TEST(ResultOrActionsTypedTest, MoveConstructor) {
+  ActionsMock executedActions;
+  ReaderResult readerResult(getActions(executedActions, 2));
+  SplitResult splitResult(std::move(readerResult));
+
+  EXPECT_EQ(splitResult.actions().size(), 2);
+  EXPECT_EQ(executedActions, ActionsMock({0, 0}));
+  splitResult.actions()[0]();
+  EXPECT_EQ(executedActions, ActionsMock({1, 0}));
+  splitResult.actions()[1]();
+  EXPECT_EQ(executedActions, ActionsMock({1, 1}));
+  EXPECT_EQ(splitResult.runAllActions(), 2);
+  EXPECT_EQ(executedActions, ActionsMock({2, 2}));
+}
+
+TYPED_TEST(ResultOrActionsTypedTest, CopyAssignment) {
+  ActionsMock executedActions;
+  ReaderResult readerResult(getActions(executedActions, 2));
+  SplitResult splitResult;
+  splitResult = std::move(readerResult);
+
+  EXPECT_EQ(splitResult.actions().size(), 2);
+  EXPECT_EQ(executedActions, ActionsMock({0, 0}));
+  splitResult.actions()[0]();
+  EXPECT_EQ(executedActions, ActionsMock({1, 0}));
+  splitResult.actions()[1]();
+  EXPECT_EQ(executedActions, ActionsMock({1, 1}));
+  EXPECT_EQ(splitResult.runAllActions(), 2);
+  EXPECT_EQ(executedActions, ActionsMock({2, 2}));
+}


### PR DESCRIPTION
Summary:
This will be used from readers to give them the ability of not blocking on IO.

Instead, they'll return a status indicating that they need more IO and a callback to do the IO (potentially in another thread).

There could be other reasons why a reader or data source is blocked too, and we'll take advantage of this class in upper layers too.

Differential Revision: D54095594


