### PR TITLE
Remove unneeded string copy construction in StringIdMap

### DIFF
--- a/velox/common/caching/StringIdMap.cpp
+++ b/velox/common/caching/StringIdMap.cpp
@@ -67,7 +67,7 @@ uint64_t StringIdMap::makeId(std::string_view string) {
     return it->second;
   }
   Entry entry;
-  entry.string = std::string(string);
+  entry.string = string;
   // Check that we do not use an id twice. In practice this never
   // happens because the int64 counter would have to wrap around for
   // this. Even if this happened, the time spent in the loop would


### PR DESCRIPTION
A variable of type `std::string_view` can be directly assigned to a 
variable of type `std::string`. There is no need to construct a 
temporary variable first and then assign the value. The latter will 
cause a redundant copy construction.

No functional changes.