### PR TITLE
Add support for individual file to check.py

### DIFF
--- a/scripts/check.py
+++ b/scripts/check.py
@@ -189,9 +189,12 @@ def get_files(commit, path):
         )
         filelist = stdout.splitlines()
     else:
-        for root, dirs, files in os.walk(path):
-            for name in files:
-                filelist.append(os.path.join(root, name))
+        if os.path.isfile(path):
+            filelist.append(path)
+        else:
+            for root, dirs, files in os.walk(path):
+                for name in files:
+                    filelist.append(os.path.join(root, name))
 
     return [
         file


### PR DESCRIPTION
Currently, "scripts/check.py" only works when it receives a directory,
it does nothing when it receives an individual file.  However, sometimes
we may want to only check an individual file (for example, we only
modified one file and want to check it quickly), and this patch adds
this capability to it.

With this patch, the following command can be used to fix the format
of an individual file:
```
  scripts/check.py format tree --fix path/to/a/file
```