### PR TITLE
New exchange protocol

### DIFF
--- a/velox/exec/ExchangeQueue.h
+++ b/velox/exec/ExchangeQueue.h
@@ -123,7 +123,7 @@ class ExchangeQueue {
   dequeueLocked(uint32_t maxBytes, bool* atEnd, ContinueFuture* future);
 
   /// Returns the total bytes held by SerializedPages in 'this'.
-  uint64_t totalBytes() const {
+  int64_t totalBytes() const {
     return totalBytes_;
   }
 
@@ -197,7 +197,7 @@ class ExchangeQueue {
   // throw an exception with this message.
   std::string error_;
   // Total size of SerializedPages in queue.
-  uint64_t totalBytes_{0};
+  int64_t totalBytes_{0};
   // Number of SerializedPages received.
   int64_t receivedPages_{0};
   // Total size of SerializedPages received. Used to calculate an average

--- a/velox/exec/ExchangeSource.h
+++ b/velox/exec/ExchangeSource.h
@@ -86,9 +86,7 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
   /// backward compatibility (e.g. communicating with coordinator), we allow
   /// small data (1MB) to be returned.
   virtual folly::SemiFuture<Response> requestDataSizes(
-      uint32_t /*maxWaitSeconds*/) {
-    VELOX_NYI();
-  }
+      uint32_t maxWaitSeconds) = 0;
 
   /// Close the exchange source. May be called before all data
   /// has been received and processed. This can happen in case

--- a/velox/exec/OutputBufferManager.h
+++ b/velox/exec/OutputBufferManager.h
@@ -82,31 +82,6 @@ class OutputBufferManager {
       DataAvailableCallback notify,
       DataConsumerActiveCheckCallback activeCheck = nullptr);
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  bool getData(
-      const std::string& taskId,
-      int destination,
-      uint64_t maxBytes,
-      int64_t sequence,
-      std::function<void(
-          std::vector<std::unique_ptr<folly::IOBuf>> pages,
-          int64_t sequence)> notify,
-      DataConsumerActiveCheckCallback activeCheck = nullptr) {
-    return getData(
-        taskId,
-        destination,
-        maxBytes,
-        sequence,
-        [notify = std::move(notify)](
-            std::vector<std::unique_ptr<folly::IOBuf>> pages,
-            int64_t sequence,
-            std::vector<int64_t> /*remainingBytes*/) mutable {
-          notify(std::move(pages), sequence);
-        },
-        std::move(activeCheck));
-  }
-#endif
-
   void removeTask(const std::string& taskId);
 
   static std::weak_ptr<OutputBufferManager> getInstance();

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -80,7 +80,10 @@ class ExchangeClientTest : public testing::Test,
     return pageSize;
   }
 
-  void fetchPages(ExchangeClient& client, int32_t numPages) {
+  std::vector<std::unique_ptr<SerializedPage>> fetchPages(
+      ExchangeClient& client,
+      int32_t numPages) {
+    std::vector<std::unique_ptr<SerializedPage>> allPages;
     for (auto i = 0; i < numPages; ++i) {
       bool atEnd;
       ContinueFuture future;
@@ -90,8 +93,10 @@ class ExchangeClientTest : public testing::Test,
         std::move(future).via(&exec).wait();
         pages = client.next(1, &atEnd, &future);
       }
-      ASSERT_EQ(1, pages.size());
+      EXPECT_EQ(1, pages.size());
+      allPages.push_back(std::move(pages.at(0)));
     }
+    return allPages;
   }
 
   static void addSources(ExchangeQueue& queue, int32_t numSources) {
@@ -248,6 +253,35 @@ TEST_F(ExchangeClientTest, flowControl) {
     bufferManager_->removeTask(task->taskId());
   }
 
+  client->close();
+}
+
+TEST_F(ExchangeClientTest, largeSinglePage) {
+  auto data = {
+      makeRowVector({makeFlatVector<int64_t>(10000, folly::identity)}),
+      makeRowVector({makeFlatVector<int64_t>(1, folly::identity)}),
+  };
+  auto client =
+      std::make_shared<ExchangeClient>("test", 1, 1000, pool(), executor());
+  auto plan = test::PlanBuilder()
+                  .values({data})
+                  .partitionedOutputArbitrary()
+                  .planNode();
+  auto task = makeTask("local://producer", plan);
+  bufferManager_->initializeTask(
+      task, core::PartitionedOutputNode::Kind::kArbitrary, 1, 1);
+  for (auto& batch : data) {
+    enqueue(task->taskId(), 0, batch);
+  }
+  client->addRemoteTaskId(task->taskId());
+  auto pages = fetchPages(*client, 1);
+  ASSERT_EQ(pages.size(), 1);
+  ASSERT_GT(pages[0]->size(), 1000);
+  pages = fetchPages(*client, 1);
+  ASSERT_EQ(pages.size(), 1);
+  ASSERT_LT(pages[0]->size(), 1000);
+  task->requestCancel();
+  bufferManager_->removeTask(task->taskId());
   client->close();
 }
 

--- a/velox/exec/tests/OutputBufferManagerTest.cpp
+++ b/velox/exec/tests/OutputBufferManagerTest.cpp
@@ -454,6 +454,7 @@ TEST_F(OutputBufferManagerTest, arbitrayBuffer) {
     buffer.enqueue(std::move(page3));
     ASSERT_EQ(
         buffer.toString(), "[ARBITRARY_BUFFER PAGES[2] NO MORE DATA[false]]");
+    ASSERT_TRUE(buffer.getPages(0).empty());
     buffer.noMoreData();
     ASSERT_FALSE(buffer.empty());
     ASSERT_TRUE(buffer.hasNoMoreData());
@@ -475,7 +476,9 @@ TEST_F(OutputBufferManagerTest, arbitrayBuffer) {
     ASSERT_EQ(
         buffer.toString(), "[ARBITRARY_BUFFER PAGES[0] NO MORE DATA[true]]");
     buffer.noMoreData();
-    VELOX_ASSERT_THROW(buffer.getPages(0), "maxBytes can't be zero");
+    pages = buffer.getPages(0);
+    ASSERT_EQ(pages.size(), 1);
+    ASSERT_FALSE(pages[0]);
     // Verify the end marker is persistent.
     for (int i = 0; i < 3; ++i) {
       pages = buffer.getPages(100);
@@ -508,8 +511,7 @@ TEST_F(OutputBufferManagerTest, destinationBuffer) {
   {
     ArbitraryBuffer buffer;
     DestinationBuffer destinationBuffer;
-    VELOX_ASSERT_THROW(
-        destinationBuffer.loadData(&buffer, 0), "maxBytes can't be zero");
+    destinationBuffer.loadData(&buffer, 0);
     destinationBuffer.loadData(&buffer, 100);
     std::atomic<bool> notified{false};
     auto buffers = destinationBuffer.getData(

--- a/velox/exec/tests/utils/LocalExchangeSource.cpp
+++ b/velox/exec/tests/utils/LocalExchangeSource.cpp
@@ -160,6 +160,11 @@ class LocalExchangeSource : public exec::ExchangeSource {
     return future;
   }
 
+  folly::SemiFuture<Response> requestDataSizes(
+      uint32_t maxWaitSeconds) override {
+    return request(0, maxWaitSeconds);
+  }
+
   void close() override {
     checkSetRequestPromise();
 


### PR DESCRIPTION
Summary:
Upgrade the exchange protocol.  We will poll the remaining data sizes using `ExchangeSource::getDataSizes` from all the producers and schedule actual data fetch according to the memory budget.  This reduce the waiting for data time significantly in some cases, for a query that was timing out after 1 hour on 600 nodes cluster, we reduce the wall time to 4.72 minutes on 400 nodes cluster (Java is taking 36.08 minutes on 1000 nodes cluster).

See https://github.com/prestodb/presto/issues/21926

Differential Revision: D54027466


