### PR TITLE
Reuse Serializer

### DIFF
--- a/velox/common/memory/ByteStream.h
+++ b/velox/common/memory/ByteStream.h
@@ -246,7 +246,16 @@ class ByteOutputStream {
     return ranges_;
   }
 
+  /// Prepares 'this' for writing. Can be called several times,
+  /// e.g. PrestoSerializer resets these. The memory formerly backing
+  /// 'ranges_' is not owned and the caller needs to recycle or free
+  /// this independently.
   void startWrite(int32_t initialSize) {
+    ranges_.clear();
+    isReversed_ = false;
+    allocatedBytes_ = 0;
+    current_ = nullptr;
+    lastRangeEnd_ = 0;
     extend(initialSize);
   }
 

--- a/velox/common/memory/HashStringAllocator.h
+++ b/velox/common/memory/HashStringAllocator.h
@@ -326,7 +326,7 @@ class HashStringAllocator : public StreamArena {
   }
 
   // Frees all memory associated with 'this' and leaves 'this' ready for reuse.
-  void clear();
+  void clear() override;
 
   memory::MemoryPool* FOLLY_NONNULL pool() const {
     return pool_.pool();

--- a/velox/common/memory/StreamArena.cpp
+++ b/velox/common/memory/StreamArena.cpp
@@ -76,4 +76,14 @@ void StreamArena::newTinyRange(
   range->buffer = reinterpret_cast<uint8_t*>(tinyRanges_.back().data());
   range->size = bytes;
 }
+void StreamArena::clear() {
+  allocations_.clear();
+  pool_->freeNonContiguous(allocation_);
+  currentRun_ = 0;
+  currentOffset_ = 0;
+  largeAllocations_.clear();
+  size_ = 0;
+  tinyRanges_.clear();
+}
+
 } // namespace facebook::velox

--- a/velox/common/memory/StreamArena.h
+++ b/velox/common/memory/StreamArena.h
@@ -62,6 +62,10 @@ class StreamArena {
     return pool_;
   }
 
+  /// Restores 'this' to post-construction state. Used in recycling streams for
+  /// serilizers.
+  virtual void clear();
+
  private:
   memory::MemoryPool* const pool_;
   const memory::MachinePageCount allocationQuantum_{2};

--- a/velox/common/memory/tests/ByteStreamTest.cpp
+++ b/velox/common/memory/tests/ByteStreamTest.cpp
@@ -381,3 +381,15 @@ TEST_F(ByteStreamTest, nextViewNegativeSize) {
   ByteInputStream byteStream({ByteRange{buffer, kBufferSize, 0}});
   EXPECT_THROW(byteStream.nextView(-100), VeloxRuntimeError);
 }
+
+TEST_F(ByteStreamTest, reuse) {
+  auto arena = newArena();
+  ByteOutputStream stream(arena.get());
+  char bytes[10000] = {};
+  for (auto i = 0; i < 10; ++i) {
+    arena->clear();
+    stream.startWrite(i * 100);
+    stream.appendStringView(std::string_view(bytes, sizeof(bytes)));
+    EXPECT_EQ(sizeof(bytes), stream.size());
+  }
+}

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -73,7 +73,7 @@ BlockingReason Destination::flush(
     OutputBufferManager& bufferManager,
     const std::function<void()>& bufferReleaseFn,
     ContinueFuture* future) {
-  if (!current_) {
+  if (!current_ || rowsInCurrent_ == 0) {
     return BlockingReason::kNotBlocked;
   }
 
@@ -87,7 +87,7 @@ BlockingReason Destination::flush(
   const int64_t flushedRows = rowsInCurrent_;
 
   current_->flush(&stream);
-  current_.reset();
+  current_->clear();
 
   const int64_t flushedBytes = stream.tellp();
 

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -86,6 +86,11 @@ class IterativeVectorSerializer {
 
   /// Write serialized data to 'stream'.
   virtual void flush(OutputStream* stream) = 0;
+
+  /// Resets 'this' to post construction state.
+  virtual void clear() {
+    VELOX_UNSUPPORTED("clear");
+  }
 };
 
 /// Serializer that writes a subset of rows from a single RowVector to the
@@ -296,6 +301,11 @@ class VectorStreamGroup : public StreamArena {
       RowTypePtr type,
       RowVectorPtr* result,
       const VectorSerde::Options* options = nullptr);
+
+  void clear() override {
+    StreamArena::clear();
+    serializer_->clear();
+  }
 
  private:
   std::unique_ptr<IterativeVectorSerializer> serializer_;


### PR DESCRIPTION
Adds VectorSerializer::clear(). This makes serializer trees reusable. This reduces memory allocation and more importantly allows keeping a history of data characteristics. This enables adaptivity in the use of compression and reencoding. A combination of the these reduces exchange data volume to half on the average.