### PR TITLE
Fix segfault in HiveDataSource::next() when preloading an empty split

### DIFF
--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -201,7 +201,7 @@ std::optional<RowVectorPtr> HiveDataSource::next(
     uint64_t size,
     velox::ContinueFuture& /*future*/) {
   VELOX_CHECK(split_ != nullptr, "No split to process. Call addSplit first.");
-  VELOX_CHECK(splitReader_ != nullptr);
+  VELOX_CHECK_NOT_NULL(splitReader_, "No split reader present");
 
   if (splitReader_->emptySplit()) {
     resetSplit();
@@ -325,7 +325,7 @@ std::unordered_map<std::string, RuntimeCounter> HiveDataSource::runtimeStats() {
 void HiveDataSource::setFromDataSource(
     std::unique_ptr<DataSource> sourceUnique) {
   auto source = dynamic_cast<HiveDataSource*>(sourceUnique.get());
-  VELOX_CHECK(source, "Bad DataSource type");
+  VELOX_CHECK_NOT_NULL(source, "Bad DataSource type");
 
   split_ = std::move(source->split_);
   runtimeStats_.skippedSplits += source->runtimeStats_.skippedSplits;

--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -201,8 +201,9 @@ std::optional<RowVectorPtr> HiveDataSource::next(
     uint64_t size,
     velox::ContinueFuture& /*future*/) {
   VELOX_CHECK(split_ != nullptr, "No split to process. Call addSplit first.");
+  VELOX_CHECK(splitReader_ != nullptr);
 
-  if (splitReader_ && splitReader_->emptySplit()) {
+  if (splitReader_->emptySplit()) {
     resetSplit();
     return nullptr;
   }
@@ -327,11 +328,8 @@ void HiveDataSource::setFromDataSource(
   VELOX_CHECK(source, "Bad DataSource type");
 
   split_ = std::move(source->split_);
-  if (source->splitReader_ && source->splitReader_->emptySplit()) {
-    runtimeStats_.skippedSplits += source->runtimeStats_.skippedSplits;
-    runtimeStats_.skippedSplitBytes += source->runtimeStats_.skippedSplitBytes;
-    return;
-  }
+  runtimeStats_.skippedSplits += source->runtimeStats_.skippedSplits;
+  runtimeStats_.skippedSplitBytes += source->runtimeStats_.skippedSplitBytes;
   source->scanSpec_->moveAdaptationFrom(*scanSpec_);
   scanSpec_ = std::move(source->scanSpec_);
   splitReader_ = std::move(source->splitReader_);

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1587,6 +1587,18 @@ TEST_F(TableScanTest, emptyFile) {
   }
 }
 
+TEST_F(TableScanTest, preloadEmptySplit) {
+  auto rowType = ROW({"c0", "c1"}, {BIGINT(), DOUBLE()});
+  auto emptyVector = makeVectors(1, 0, rowType);
+  auto vector = makeVectors(1, 1'000, rowType);
+  auto filePaths = makeFilePaths(2);
+  writeToFile(filePaths[0]->path, vector[0]);
+  writeToFile(filePaths[1]->path, emptyVector[0]);
+  createDuckDbTable(vector);
+  auto op = tableScanNode(rowType);
+  assertQuery(op, filePaths, "SELECT * FROM tmp", 1);
+}
+
 TEST_F(TableScanTest, partitionedTableVarcharKey) {
   auto rowType = ROW({"c0", "c1"}, {BIGINT(), DOUBLE()});
   auto vectors = makeVectors(10, 1'000, rowType);


### PR DESCRIPTION
We are seeing the segfault below in our benchmark cluster.
The segfault is due to the `splitReader_` being accessed as a nullptr;
The `splitReader_` is not initialized for an empty split in the preload path.
The previous `splitReader_` is used and this is fixed.
We confirmed that this change fixes the segfault.

However, I do not have a test where the previous `splitReader_` is a nullptr.
The addSplit() path, where `splitReader_` is always created first, seems to be always taken first before 
the preload path.
It is unclear how the `splitReader_` can become a nullptr in practice.

*** SIGSEGV (@0x0) received by PID 55 (TID 0x7ef6a27fc700) from PID 0; stack trace: ***
    @     0x7f58305b776e google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f582cc1bd20 (unknown)
    @           0x6b0646 facebook::velox::connector::hive::HiveDataSource::next()
    @          0x3a6ebbc facebook::velox::exec::TableScan::getOutput()
    @          0x3953f3b facebook::velox::exec::Driver::runInternal()
    @          0x3956e2d facebook::velox::exec::Driver::run()
    @          0x3956fef _ZN5folly6detail8function14FunctionTraitsIFvvEE9callSmallIZN8facebook5velox4exec6Driver7enqueueESt10shared_ptrIS9_EEUlvE_EEvRNS1_4DataE
    @     0x7f582e83d4f6 folly::ThreadPoolExecutor::runTask()
    @          0x4087575 folly::CPUThreadPoolExecutor::threadRun()
    @     0x7f582e83f007 folly::detail::function::FunctionTraits<>::callSmall<>()
    @     0x7f582b875b23 (unknown)
    @     0x7f582cc111ca start_thread
    @     0x7f582ae7c8d3 __GI___clone
    @                0x0 (unknown)
