### PR TITLE
Allow choosing to register companion functions for all aggregate functions

### DIFF
--- a/velox/functions/lib/aggregates/BitwiseAggregateBase.h
+++ b/velox/functions/lib/aggregates/BitwiseAggregateBase.h
@@ -72,6 +72,7 @@ class BitwiseAggregateBase : public SimpleNumericAggregate<T, T, T> {
 template <template <typename U> class T>
 exec::AggregateRegistrationResult registerBitwise(
     const std::string& name,
+    bool withCompanionFunctions,
     bool onlyPrestoSignatures) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   std::vector<std::string> typeList{"tinyint", "smallint", "integer", "bigint"};
@@ -112,7 +113,8 @@ exec::AggregateRegistrationResult registerBitwise(
                 name,
                 inputType->kindName());
         }
-      });
+      },
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::functions::aggregate

--- a/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
@@ -351,7 +351,9 @@ std::unique_ptr<exec::Aggregate> makeApproxMostFrequentAggregate(
 
 } // namespace
 
-void registerApproxMostFrequentAggregate(const std::string& prefix) {
+void registerApproxMostFrequentAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   for (const auto& valueType :
        {"tinyint", "smallint", "integer", "bigint", "varchar"}) {
@@ -384,7 +386,8 @@ void registerApproxMostFrequentAggregate(const std::string& prefix) {
             resultType,
             name,
             valueType);
-      });
+      },
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
@@ -260,7 +260,9 @@ class NonNumericArbitrary : public exec::Aggregate {
 
 } // namespace
 
-void registerArbitraryAggregate(const std::string& prefix) {
+void registerArbitraryAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -316,7 +318,8 @@ void registerArbitraryAggregate(const std::string& prefix) {
                 name,
                 inputType->kindName());
         }
-      });
+      },
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/BitwiseAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/BitwiseAggregates.cpp
@@ -103,11 +103,12 @@ class BitwiseAndAggregate : public BitwiseAggregateBase<T> {
 
 void registerBitwiseAggregates(
     const std::string& prefix,
+    bool withCompanionFunctions,
     bool onlyPrestoSignatures) {
   registerBitwise<BitwiseOrAggregate>(
-      prefix + kBitwiseOr, onlyPrestoSignatures);
+      prefix + kBitwiseOr, withCompanionFunctions, onlyPrestoSignatures);
   registerBitwise<BitwiseAndAggregate>(
-      prefix + kBitwiseAnd, onlyPrestoSignatures);
+      prefix + kBitwiseAnd, withCompanionFunctions, onlyPrestoSignatures);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/BitwiseXorAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/BitwiseXorAggregate.cpp
@@ -68,6 +68,7 @@ class BitwiseXorAggregate {
 
 void registerBitwiseXorAggregate(
     const std::string& prefix,
+    bool withCompanionFunctions,
     bool onlyPrestoSignatures) {
   const std::string name = prefix + kBitwiseXor;
 
@@ -119,7 +120,7 @@ void registerBitwiseXorAggregate(
                 inputType->toString());
         }
       },
-      false);
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/BoolAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/BoolAggregates.cpp
@@ -178,7 +178,9 @@ class BoolOrAggregate final : public BoolAndOrAggregate {
 };
 
 template <class T>
-exec::AggregateRegistrationResult registerBool(const std::string& name) {
+exec::AggregateRegistrationResult registerBool(
+    const std::string& name,
+    bool withCompanionFunctions) {
   // TODO Fix signature to match Presto.
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures = {
       exec::AggregateFunctionSignatureBuilder()
@@ -205,15 +207,18 @@ exec::AggregateRegistrationResult registerBool(const std::string& name) {
             name,
             inputType->kindName());
         return std::make_unique<T>();
-      });
+      },
+      withCompanionFunctions);
 }
 
 } // namespace
 
-void registerBoolAggregates(const std::string& prefix) {
-  registerBool<BoolAndAggregate>(prefix + kBoolAnd);
-  registerBool<BoolAndAggregate>(prefix + kEvery);
-  registerBool<BoolOrAggregate>(prefix + kBoolOr);
+void registerBoolAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
+  registerBool<BoolAndAggregate>(prefix + kBoolAnd, withCompanionFunctions);
+  registerBool<BoolAndAggregate>(prefix + kEvery, withCompanionFunctions);
+  registerBool<BoolOrAggregate>(prefix + kBoolOr, withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CentralMomentsAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/CentralMomentsAggregates.cpp
@@ -492,7 +492,8 @@ void checkAccumulatorRowType(
 
 template <typename TResultAccessor>
 exec::AggregateRegistrationResult registerCentralMoments(
-    const std::string& name) {
+    const std::string& name,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   std::vector<std::string> inputTypes = {
       "smallint", "integer", "bigint", "real", "double"};
@@ -552,14 +553,19 @@ exec::AggregateRegistrationResult registerCentralMoments(
           return std::make_unique<
               CentralMomentsAggregate<int64_t, TResultAccessor>>(resultType);
         }
-      });
+      },
+      withCompanionFunctions);
 }
 
 } // namespace
 
-void registerCentralMomentsAggregates(const std::string& prefix) {
-  registerCentralMoments<KurtosisResultAccessor>(prefix + kKurtosis);
-  registerCentralMoments<SkewnessResultAccessor>(prefix + kSkewness);
+void registerCentralMomentsAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
+  registerCentralMoments<KurtosisResultAccessor>(
+      prefix + kKurtosis, withCompanionFunctions);
+  registerCentralMoments<SkewnessResultAccessor>(
+      prefix + kSkewness, withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
@@ -230,7 +230,9 @@ class ChecksumAggregate : public exec::Aggregate {
 
 } // namespace
 
-void registerChecksumAggregate(const std::string& prefix) {
+void registerChecksumAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -257,7 +259,8 @@ void registerChecksumAggregate(const std::string& prefix) {
         }
 
         return std::make_unique<ChecksumAggregate>(VARBINARY());
-      });
+      },
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CountAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountAggregate.cpp
@@ -150,7 +150,9 @@ class CountAggregate : public SimpleNumericAggregate<bool, int64_t, int64_t> {
 
 } // namespace
 
-void registerCountAggregate(const std::string& prefix) {
+void registerCountAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .returnType("bigint")
@@ -177,7 +179,8 @@ void registerCountAggregate(const std::string& prefix) {
         VELOX_CHECK_LE(
             argTypes.size(), 1, "{} takes at most one argument", name);
         return std::make_unique<CountAggregate>();
-      });
+      },
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
@@ -170,7 +170,9 @@ class CountIfAggregate : public exec::Aggregate {
 
 } // namespace
 
-void registerCountIfAggregate(const std::string& prefix) {
+void registerCountIfAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .returnType("bigint")
@@ -201,7 +203,8 @@ void registerCountIfAggregate(const std::string& prefix) {
         }
 
         return std::make_unique<CountIfAggregate>();
-      });
+      },
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CovarianceAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/CovarianceAggregates.cpp
@@ -571,7 +571,9 @@ template <
     typename TIntermediateInput,
     typename TIntermediateResult,
     typename TResultAccessor>
-exec::AggregateRegistrationResult registerCovariance(const std::string& name) {
+exec::AggregateRegistrationResult registerCovariance(
+    const std::string& name,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures = {
       // (double, double) -> double
       exec::AggregateFunctionSignatureBuilder()
@@ -620,37 +622,41 @@ exec::AggregateRegistrationResult registerCovariance(const std::string& name) {
                 "Unsupported raw input type: {}. Expected DOUBLE or REAL.",
                 rawInputType->toString())
         }
-      });
+      },
+      withCompanionFunctions);
 }
 
 } // namespace
 
-void registerCovarianceAggregates(const std::string& prefix) {
+void registerCovarianceAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   registerCovariance<
       CovarAccumulator,
       CovarIntermediateInput,
       CovarIntermediateResult,
-      CovarPopResultAccessor>(prefix + kCovarPop);
+      CovarPopResultAccessor>(prefix + kCovarPop, withCompanionFunctions);
   registerCovariance<
       CovarAccumulator,
       CovarIntermediateInput,
       CovarIntermediateResult,
-      CovarSampResultAccessor>(prefix + kCovarSamp);
+      CovarSampResultAccessor>(prefix + kCovarSamp, withCompanionFunctions);
   registerCovariance<
       CorrAccumulator,
       CorrIntermediateInput,
       CorrIntermediateResult,
-      CorrResultAccessor>(prefix + kCorr);
+      CorrResultAccessor>(prefix + kCorr, withCompanionFunctions);
   registerCovariance<
       RegrAccumulator,
       RegrIntermediateInput,
       RegrIntermediateResult,
-      RegrInterceptResultAccessor>(prefix + kRegrIntercept);
+      RegrInterceptResultAccessor>(
+      prefix + kRegrIntercept, withCompanionFunctions);
   registerCovariance<
       RegrAccumulator,
       RegrIntermediateInput,
       RegrIntermediateResult,
-      RegrSlopeResultAccessor>(prefix + kRegrSlop);
+      RegrSlopeResultAccessor>(prefix + kRegrSlop, withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/EntropyAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/EntropyAggregates.cpp
@@ -336,7 +336,9 @@ void checkRowType(const TypePtr& type, const std::string& errorMessage) {
 
 } // namespace
 
-void registerEntropyAggregate(const std::string& prefix) {
+void registerEntropyAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   std::vector<std::string> inputTypes = {"smallint", "integer", "bigint"};
   for (const auto& inputType : inputTypes) {
@@ -382,7 +384,8 @@ void registerEntropyAggregate(const std::string& prefix) {
           // final agg not use template T, int64_t here has no effect.
           return std::make_unique<EntropyAggregate<int64_t>>(resultType);
         }
-      });
+      },
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/GeometricMeanAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/GeometricMeanAggregate.cpp
@@ -82,7 +82,9 @@ class GeometricMeanAggregate {
 
 } // namespace
 
-void registerGeometricMeanAggregate(const std::string& prefix) {
+void registerGeometricMeanAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   const std::string name = prefix + kGeometricMean;
 
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
@@ -133,7 +135,7 @@ void registerGeometricMeanAggregate(const std::string& prefix) {
                 inputType->toString());
         }
       },
-      false);
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
@@ -340,7 +340,9 @@ class HistogramAggregate : public exec::Aggregate {
 
 } // namespace
 
-void registerHistogramAggregate(const std::string& prefix) {
+void registerHistogramAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   for (const auto inputType :
        {"boolean",
@@ -405,7 +407,8 @@ void registerHistogramAggregate(const std::string& prefix) {
                 name,
                 inputType->kindName());
         }
-      });
+      },
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
@@ -147,7 +147,9 @@ class MapAggAggregate : public MapAggregateBase<K> {
 
 } // namespace
 
-void registerMapAggAggregate(const std::string& prefix) {
+void registerMapAggAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("K")
@@ -208,7 +210,8 @@ void registerMapAggAggregate(const std::string& prefix) {
             VELOX_UNREACHABLE(
                 "Unexpected type {}", mapTypeKindToName(typeKind));
         }
-      });
+      },
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MapUnionAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapUnionAggregate.cpp
@@ -75,7 +75,9 @@ class MapUnionAggregate : public MapAggregateBase<K> {
 
 } // namespace
 
-void registerMapUnionAggregate(const std::string& prefix) {
+void registerMapUnionAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("K")
@@ -102,7 +104,8 @@ void registerMapUnionAggregate(const std::string& prefix) {
             name);
 
         return createMapAggregate<MapUnionAggregate>(resultType);
-      });
+      },
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
@@ -347,7 +347,9 @@ std::unique_ptr<exec::Aggregate> createMapUnionSumAggregate(
 
 } // namespace
 
-void registerMapUnionSumAggregate(const std::string& prefix) {
+void registerMapUnionSumAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   const std::vector<std::string> keyTypes = {
       "tinyint",
       "smallint",
@@ -417,7 +419,8 @@ void registerMapUnionSumAggregate(const std::string& prefix) {
           default:
             VELOX_UNREACHABLE();
         }
-      });
+      },
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
@@ -204,7 +204,9 @@ class MaxSizeForStatsAggregate
 
 } // namespace
 
-void registerMaxDataSizeForStatsAggregate(const std::string& prefix) {
+void registerMaxDataSizeForStatsAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
   signatures.push_back(exec::AggregateFunctionSignatureBuilder()
@@ -228,7 +230,8 @@ void registerMaxDataSizeForStatsAggregate(const std::string& prefix) {
         auto inputType = argTypes[0];
 
         return std::make_unique<MaxSizeForStatsAggregate>(resultType);
-      });
+      },
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -906,7 +906,9 @@ template <
     typename TNonNumeric,
     template <typename T>
     class TNumericN>
-exec::AggregateRegistrationResult registerMinMax(const std::string& name) {
+exec::AggregateRegistrationResult registerMinMax(
+    const std::string& name,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   signatures.push_back(exec::AggregateFunctionSignatureBuilder()
                            .orderableTypeVariable("T")
@@ -1010,16 +1012,19 @@ exec::AggregateRegistrationResult registerMinMax(const std::string& name) {
                   inputType->kindName());
           }
         }
-      });
+      },
+      withCompanionFunctions);
 }
 
 } // namespace
 
-void registerMinMaxAggregates(const std::string& prefix) {
+void registerMinMaxAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   registerMinMax<MinAggregate, NonNumericMinAggregate, MinNAggregate>(
-      prefix + kMin);
+      prefix + kMin, withCompanionFunctions);
   registerMinMax<MaxAggregate, NonNumericMaxAggregate, MaxNAggregate>(
-      prefix + kMax);
+      prefix + kMax, withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -1122,7 +1122,9 @@ template <
     bool isMaxFunc,
     template <typename U, typename V>
     class NAggregate>
-exec::AggregateRegistrationResult registerMinMaxBy(const std::string& name) {
+exec::AggregateRegistrationResult registerMinMaxBy(
+    const std::string& name,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   // V, C -> row(V, C) -> V.
   signatures.push_back(exec::AggregateFunctionSignatureBuilder()
@@ -1184,16 +1186,19 @@ exec::AggregateRegistrationResult registerMinMaxBy(const std::string& name) {
           return create<Aggregate, Comparator, isMaxFunc>(
               resultType, argTypes[0], argTypes[1], errorMessage, true);
         }
-      });
+      },
+      withCompanionFunctions);
 }
 
 } // namespace
 
-void registerMinMaxByAggregates(const std::string& prefix) {
+void registerMinMaxByAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   registerMinMaxBy<MinMaxByAggregateBase, true, MaxByNAggregate>(
-      prefix + kMaxBy);
+      prefix + kMaxBy, withCompanionFunctions);
   registerMinMaxBy<MinMaxByAggregateBase, false, MinByNAggregate>(
-      prefix + kMinBy);
+      prefix + kMinBy, withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MultiMapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MultiMapAggAggregate.cpp
@@ -477,7 +477,9 @@ class MultiMapAggAggregate : public exec::Aggregate {
 
 } // namespace
 
-void registerMultiMapAggAggregate(const std::string& prefix) {
+void registerMultiMapAggAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("K")
@@ -535,7 +537,8 @@ void registerMultiMapAggAggregate(const std::string& prefix) {
             VELOX_UNREACHABLE(
                 "Unexpected type {}", mapTypeKindToName(typeKind));
         }
-      });
+      },
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ReduceAgg.cpp
+++ b/velox/functions/prestosql/aggregates/ReduceAgg.cpp
@@ -786,7 +786,7 @@ class ReduceAgg : public exec::Aggregate {
 
 } // namespace
 
-void registerReduceAgg(const std::string& prefix) {
+void registerReduceAgg(const std::string& prefix, bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -810,7 +810,8 @@ void registerReduceAgg(const std::string& prefix) {
           const TypePtr& resultType,
           const core::QueryConfig& config) -> std::unique_ptr<exec::Aggregate> {
         return std::make_unique<ReduceAgg>(resultType);
-      });
+      },
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -45,7 +45,9 @@ extern void registerMaxDataSizeForStatsAggregate(const std::string& prefix);
 extern void registerMultiMapAggAggregate(const std::string& prefix);
 extern void registerSumDataSizeForStatsAggregate(const std::string& prefix);
 extern void registerReduceAgg(const std::string& prefix);
-extern void registerSetAggAggregate(const std::string& prefix);
+extern void registerSetAggAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions);
 extern void registerSetUnionAggregate(const std::string& prefix);
 
 extern void registerApproxDistinctAggregates(
@@ -92,7 +94,7 @@ void registerAllAggregateFunctions(
   registerMinMaxAggregates(prefix);
   registerMinMaxByAggregates(prefix);
   registerReduceAgg(prefix);
-  registerSetAggAggregate(prefix);
+  registerSetAggAggregate(prefix, withCompanionFunctions);
   registerSetUnionAggregate(prefix);
   registerSumAggregate(prefix);
   registerVarianceAggregates(prefix);

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -18,11 +18,15 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-extern void registerApproxMostFrequentAggregate(const std::string& prefix);
+extern void registerApproxMostFrequentAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions);
 extern void registerApproxPercentileAggregate(
     const std::string& prefix,
     bool withCompanionFunctions);
-extern void registerArbitraryAggregate(const std::string& prefix);
+extern void registerArbitraryAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions);
 extern void registerArrayAggAggregate(
     const std::string& prefix,
     bool withCompanionFunctions);
@@ -31,73 +35,119 @@ extern void registerAverageAggregate(
     bool withCompanionFunctions);
 extern void registerBitwiseXorAggregate(
     const std::string& prefix,
+    bool withCompanionFunctions,
     bool onlyPrestoSignatures);
-extern void registerChecksumAggregate(const std::string& prefix);
-extern void registerCountAggregate(const std::string& prefix);
-extern void registerCountIfAggregate(const std::string& prefix);
-extern void registerEntropyAggregate(const std::string& prefix);
-extern void registerGeometricMeanAggregate(const std::string& prefix);
-extern void registerHistogramAggregate(const std::string& prefix);
-extern void registerMapAggAggregate(const std::string& prefix);
-extern void registerMapUnionAggregate(const std::string& prefix);
-extern void registerMapUnionSumAggregate(const std::string& prefix);
-extern void registerMaxDataSizeForStatsAggregate(const std::string& prefix);
-extern void registerMultiMapAggAggregate(const std::string& prefix);
-extern void registerSumDataSizeForStatsAggregate(const std::string& prefix);
-extern void registerReduceAgg(const std::string& prefix);
+extern void registerChecksumAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions);
+extern void registerCountAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions);
+extern void registerCountIfAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions);
+extern void registerEntropyAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions);
+extern void registerGeometricMeanAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions);
+extern void registerHistogramAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions);
+extern void registerMapAggAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions);
+extern void registerMapUnionAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions);
+extern void registerMapUnionSumAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions);
+extern void registerMaxDataSizeForStatsAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions);
+extern void registerMultiMapAggAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions);
+extern void registerSumDataSizeForStatsAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions);
+extern void registerReduceAgg(
+    const std::string& prefix,
+    bool withCompanionFunctions);
 extern void registerSetAggAggregate(
     const std::string& prefix,
     bool withCompanionFunctions);
-extern void registerSetUnionAggregate(const std::string& prefix);
+extern void registerSetUnionAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions);
 
 extern void registerApproxDistinctAggregates(
     const std::string& prefix,
     bool withCompanionFunctions);
 extern void registerBitwiseAggregates(
     const std::string& prefix,
+    bool withCompanionFunctions,
     bool onlyPrestoSignatures);
-extern void registerBoolAggregates(const std::string& prefix);
-extern void registerCentralMomentsAggregates(const std::string& prefix);
-extern void registerCovarianceAggregates(const std::string& prefix);
-extern void registerMinMaxAggregates(const std::string& prefix);
-extern void registerMinMaxByAggregates(const std::string& prefix);
-extern void registerSumAggregate(const std::string& prefix);
-extern void registerVarianceAggregates(const std::string& prefix);
+extern void registerBoolAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions);
+extern void registerCentralMomentsAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions);
+extern void registerCovarianceAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions);
+extern void registerMinMaxAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions);
+extern void registerMinMaxByAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions);
+extern void registerSumAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions);
+extern void registerVarianceAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions);
 
 void registerAllAggregateFunctions(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool onlyPrestoSignatures) {
   registerApproxDistinctAggregates(prefix, withCompanionFunctions);
-  registerApproxMostFrequentAggregate(prefix);
+  registerApproxMostFrequentAggregate(prefix, withCompanionFunctions);
   registerApproxPercentileAggregate(prefix, withCompanionFunctions);
-  registerArbitraryAggregate(prefix);
+  registerArbitraryAggregate(prefix, withCompanionFunctions);
   registerArrayAggAggregate(prefix, withCompanionFunctions);
   registerAverageAggregate(prefix, withCompanionFunctions);
-  registerBitwiseAggregates(prefix, onlyPrestoSignatures);
-  registerBitwiseXorAggregate(prefix, onlyPrestoSignatures);
-  registerBoolAggregates(prefix);
-  registerCentralMomentsAggregates(prefix);
-  registerChecksumAggregate(prefix);
-  registerCountAggregate(prefix);
-  registerCountIfAggregate(prefix);
-  registerCovarianceAggregates(prefix);
-  registerEntropyAggregate(prefix);
-  registerGeometricMeanAggregate(prefix);
-  registerHistogramAggregate(prefix);
-  registerMapAggAggregate(prefix);
-  registerMapUnionAggregate(prefix);
-  registerMapUnionSumAggregate(prefix);
-  registerMaxDataSizeForStatsAggregate(prefix);
-  registerMultiMapAggAggregate(prefix);
-  registerSumDataSizeForStatsAggregate(prefix);
-  registerMinMaxAggregates(prefix);
-  registerMinMaxByAggregates(prefix);
-  registerReduceAgg(prefix);
+  registerBitwiseAggregates(
+      prefix, withCompanionFunctions, onlyPrestoSignatures);
+  registerBitwiseXorAggregate(
+      prefix, withCompanionFunctions, onlyPrestoSignatures);
+  registerBoolAggregates(prefix, withCompanionFunctions);
+  registerCentralMomentsAggregates(prefix, withCompanionFunctions);
+  registerChecksumAggregate(prefix, withCompanionFunctions);
+  registerCountAggregate(prefix, withCompanionFunctions);
+  registerCountIfAggregate(prefix, withCompanionFunctions);
+  registerCovarianceAggregates(prefix, withCompanionFunctions);
+  registerEntropyAggregate(prefix, withCompanionFunctions);
+  registerGeometricMeanAggregate(prefix, withCompanionFunctions);
+  registerHistogramAggregate(prefix, withCompanionFunctions);
+  registerMapAggAggregate(prefix, withCompanionFunctions);
+  registerMapUnionAggregate(prefix, withCompanionFunctions);
+  registerMapUnionSumAggregate(prefix, withCompanionFunctions);
+  registerMaxDataSizeForStatsAggregate(prefix, withCompanionFunctions);
+  registerMultiMapAggAggregate(prefix, withCompanionFunctions);
+  registerSumDataSizeForStatsAggregate(prefix, withCompanionFunctions);
+  registerMinMaxAggregates(prefix, withCompanionFunctions);
+  registerMinMaxByAggregates(prefix, withCompanionFunctions);
+  registerReduceAgg(prefix, withCompanionFunctions);
   registerSetAggAggregate(prefix, withCompanionFunctions);
-  registerSetUnionAggregate(prefix);
-  registerSumAggregate(prefix);
-  registerVarianceAggregates(prefix);
+  registerSetUnionAggregate(prefix, withCompanionFunctions);
+  registerSumAggregate(prefix, withCompanionFunctions);
+  registerVarianceAggregates(prefix, withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/SetAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/SetAggregates.cpp
@@ -427,7 +427,9 @@ std::unique_ptr<exec::Aggregate> create(
 
 } // namespace
 
-void registerSetAggAggregate(const std::string& prefix) {
+void registerSetAggAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures = {
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -491,7 +493,8 @@ void registerSetAggAggregate(const std::string& prefix) {
             VELOX_UNREACHABLE(
                 "Unexpected type {}", mapTypeKindToName(typeKind));
         }
-      });
+      },
+      withCompanionFunctions);
 }
 
 void registerSetUnionAggregate(const std::string& prefix) {

--- a/velox/functions/prestosql/aggregates/SetAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/SetAggregates.cpp
@@ -497,7 +497,9 @@ void registerSetAggAggregate(
       withCompanionFunctions);
 }
 
-void registerSetUnionAggregate(const std::string& prefix) {
+void registerSetUnionAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures = {
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -519,7 +521,8 @@ void registerSetUnionAggregate(const std::string& prefix) {
         VELOX_CHECK_EQ(argTypes.size(), 1);
 
         return create<SetUnionAggregate>(argTypes[0]->childAt(0), resultType);
-      });
+      },
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/SumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/SumAggregate.cpp
@@ -24,7 +24,9 @@ template <typename TInput, typename TAccumulator, typename ResultType>
 using SumAggregate = SumAggregateBase<TInput, TAccumulator, ResultType, false>;
 
 template <template <typename U, typename V, typename W> class T>
-exec::AggregateRegistrationResult registerSum(const std::string& name) {
+exec::AggregateRegistrationResult registerSum(
+    const std::string& name,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .returnType("real")
@@ -107,12 +109,15 @@ exec::AggregateRegistrationResult registerSum(const std::string& name) {
                 name,
                 inputType->kindName());
         }
-      });
+      },
+      withCompanionFunctions);
 }
 } // namespace
 
-void registerSumAggregate(const std::string& prefix) {
-  registerSum<SumAggregate>(prefix + kSum);
+void registerSumAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
+  registerSum<SumAggregate>(prefix + kSum, withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.cpp
@@ -184,7 +184,9 @@ class SumDataSizeForStatsAggregate
 
 } // namespace
 
-void registerSumDataSizeForStatsAggregate(const std::string& prefix) {
+void registerSumDataSizeForStatsAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
   signatures.push_back(exec::AggregateFunctionSignatureBuilder()
@@ -208,7 +210,8 @@ void registerSumDataSizeForStatsAggregate(const std::string& prefix) {
         auto inputType = argTypes[0];
 
         return std::make_unique<SumDataSizeForStatsAggregate>(resultType);
-      });
+      },
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/VarianceAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/VarianceAggregates.cpp
@@ -465,7 +465,9 @@ void checkSumCountRowType(
 }
 
 template <template <typename TInput> class TClass>
-exec::AggregateRegistrationResult registerVariance(const std::string& name) {
+exec::AggregateRegistrationResult registerVariance(
+    const std::string& name,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   std::vector<std::string> inputTypes = {
       "smallint", "integer", "bigint", "real", "double"};
@@ -514,18 +516,25 @@ exec::AggregateRegistrationResult registerVariance(const std::string& name) {
               "(count:bigint, mean:double, m2:double) struct");
           return std::make_unique<TClass<int64_t>>(resultType);
         }
-      });
+      },
+      withCompanionFunctions);
 }
 
 } // namespace
 
-void registerVarianceAggregates(const std::string& prefix) {
-  registerVariance<StdDevSampAggregate>(prefix + kStdDev);
-  registerVariance<StdDevPopAggregate>(prefix + kStdDevPop);
-  registerVariance<StdDevSampAggregate>(prefix + kStdDevSamp);
-  registerVariance<VarSampAggregate>(prefix + kVariance);
-  registerVariance<VarPopAggregate>(prefix + kVarPop);
-  registerVariance<VarSampAggregate>(prefix + kVarSamp);
+void registerVarianceAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
+  registerVariance<StdDevSampAggregate>(
+      prefix + kStdDev, withCompanionFunctions);
+  registerVariance<StdDevPopAggregate>(
+      prefix + kStdDevPop, withCompanionFunctions);
+  registerVariance<StdDevSampAggregate>(
+      prefix + kStdDevSamp, withCompanionFunctions);
+  registerVariance<VarSampAggregate>(
+      prefix + kVariance, withCompanionFunctions);
+  registerVariance<VarPopAggregate>(prefix + kVarPop, withCompanionFunctions);
+  registerVariance<VarSampAggregate>(prefix + kVarSamp, withCompanionFunctions);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/sparksql/aggregates/BitwiseXorAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/BitwiseXorAggregate.cpp
@@ -66,9 +66,10 @@ class BitwiseXorAggregate : public BitwiseAggregateBase<T> {
 } // namespace
 
 exec::AggregateRegistrationResult registerBitwiseXorAggregate(
-    const std::string& prefix) {
+    const std::string& prefix,
+    bool withCompanionFunctions) {
   return functions::aggregate::registerBitwise<BitwiseXorAggregate>(
-      prefix + "bit_xor", false);
+      prefix + "bit_xor", withCompanionFunctions, false);
 }
 
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/BitwiseXorAggregate.h
+++ b/velox/functions/sparksql/aggregates/BitwiseXorAggregate.h
@@ -23,6 +23,7 @@
 namespace facebook::velox::functions::aggregate::sparksql {
 
 exec::AggregateRegistrationResult registerBitwiseXorAggregate(
-    const std::string& name);
+    const std::string& name,
+    bool withCompanionFunctions);
 
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
@@ -288,7 +288,8 @@ class BloomFilterAggAggregate : public exec::Aggregate {
 } // namespace
 
 exec::AggregateRegistrationResult registerBloomFilterAggAggregate(
-    const std::string& name) {
+    const std::string& name,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .argumentType("bigint")
@@ -318,6 +319,7 @@ exec::AggregateRegistrationResult registerBloomFilterAggAggregate(
           const TypePtr& resultType,
           const core::QueryConfig& config) -> std::unique_ptr<exec::Aggregate> {
         return std::make_unique<BloomFilterAggAggregate>(resultType, config);
-      });
+      },
+      withCompanionFunctions);
 }
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.h
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.h
@@ -23,6 +23,7 @@
 namespace facebook::velox::functions::aggregate::sparksql {
 
 exec::AggregateRegistrationResult registerBloomFilterAggAggregate(
-    const std::string& name);
+    const std::string& name,
+    bool withCompanionFunctions);
 
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/FirstLastAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/FirstLastAggregate.cpp
@@ -429,7 +429,9 @@ class LastAggregate : public FirstLastAggregateBase<numeric, TData> {
 } // namespace
 
 template <template <bool B1, typename T, bool B2> class TClass, bool ignoreNull>
-AggregateRegistrationResult registerFirstLast(const std::string& name) {
+AggregateRegistrationResult registerFirstLast(
+    const std::string& name,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<AggregateFunctionSignature>> signatures = {
       AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -499,14 +501,21 @@ AggregateRegistrationResult registerFirstLast(const std::string& name) {
                 name,
                 inputType->toString());
         }
-      });
+      },
+      withCompanionFunctions);
 }
 
-void registerFirstLastAggregates(const std::string& prefix) {
-  registerFirstLast<FirstAggregate, false>(prefix + "first");
-  registerFirstLast<FirstAggregate, true>(prefix + "first_ignore_null");
-  registerFirstLast<LastAggregate, false>(prefix + "last");
-  registerFirstLast<LastAggregate, true>(prefix + "last_ignore_null");
+void registerFirstLastAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
+  registerFirstLast<FirstAggregate, false>(
+      prefix + "first", withCompanionFunctions);
+  registerFirstLast<FirstAggregate, true>(
+      prefix + "first_ignore_null", withCompanionFunctions);
+  registerFirstLast<LastAggregate, false>(
+      prefix + "last", withCompanionFunctions);
+  registerFirstLast<LastAggregate, true>(
+      prefix + "last_ignore_null", withCompanionFunctions);
 }
 
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/MinMaxByAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/MinMaxByAggregate.cpp
@@ -86,7 +86,9 @@ template <
         class C>
     class Aggregate,
     bool isMaxFunc>
-exec::AggregateRegistrationResult registerMinMaxBy(const std::string& name) {
+exec::AggregateRegistrationResult registerMinMaxBy(
+    const std::string& name,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   // V, C -> row(V, C) -> V.
   signatures.push_back(exec::AggregateFunctionSignatureBuilder()
@@ -137,14 +139,19 @@ exec::AggregateRegistrationResult registerMinMaxBy(const std::string& name) {
           return create<Aggregate, SparkComparator, isMaxFunc>(
               resultType, valueType, compareType, errorMessage);
         }
-      });
+      },
+      withCompanionFunctions);
 }
 
 } // namespace
 
-void registerMinMaxByAggregates(const std::string& prefix) {
-  registerMinMaxBy<MinMaxByAggregateBase, true>(prefix + "max_by");
-  registerMinMaxBy<MinMaxByAggregateBase, false>(prefix + "min_by");
+void registerMinMaxByAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions) {
+  registerMinMaxBy<MinMaxByAggregateBase, true>(
+      prefix + "max_by", withCompanionFunctions);
+  registerMinMaxBy<MinMaxByAggregateBase, false>(
+      prefix + "min_by", withCompanionFunctions);
 }
 
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/Register.cpp
+++ b/velox/functions/sparksql/aggregates/Register.cpp
@@ -23,16 +23,21 @@
 
 namespace facebook::velox::functions::aggregate::sparksql {
 
-extern void registerFirstLastAggregates(const std::string& prefix);
-extern void registerMinMaxByAggregates(const std::string& prefix);
+extern void registerFirstLastAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions);
+extern void registerMinMaxByAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions);
 
 void registerAggregateFunctions(
     const std::string& prefix,
     bool withCompanionFunctions) {
-  registerFirstLastAggregates(prefix);
-  registerMinMaxByAggregates(prefix);
-  registerBitwiseXorAggregate(prefix);
-  registerBloomFilterAggAggregate(prefix + "bloom_filter_agg");
+  registerFirstLastAggregates(prefix, withCompanionFunctions);
+  registerMinMaxByAggregates(prefix, withCompanionFunctions);
+  registerBitwiseXorAggregate(prefix, withCompanionFunctions);
+  registerBloomFilterAggAggregate(
+      prefix + "bloom_filter_agg", withCompanionFunctions);
   registerAverage(prefix + "avg", withCompanionFunctions);
   registerSum(prefix + "sum", withCompanionFunctions);
 }


### PR DESCRIPTION
This change allow Spark to use companion functions of all aggregate functions.