### PR TITLE
Fix deprecated use of 0/NULL in velox/external/utf8proc/utf8procImpl.h + 3

### DIFF
--- a/velox/external/utf8proc/utf8procImpl.h
+++ b/velox/external/utf8proc/utf8procImpl.h
@@ -384,7 +384,7 @@ UTF8PROC_DLLEXPORT utf8proc_bool utf8proc_grapheme_break_stateful(
 
 UTF8PROC_DLLEXPORT utf8proc_bool
 utf8proc_grapheme_break(utf8proc_int32_t c1, utf8proc_int32_t c2) {
-  return utf8proc_grapheme_break_stateful(c1, c2, NULL);
+  return utf8proc_grapheme_break_stateful(c1, c2, nullptr);
 }
 
 static utf8proc_int32_t seqindex_decode_entry(const utf8proc_uint16_t** entry) {
@@ -589,7 +589,7 @@ UTF8PROC_DLLEXPORT utf8proc_ssize_t utf8proc_decompose(
     utf8proc_ssize_t bufsize,
     utf8proc_int16_t options) {
   return utf8proc_decompose_custom(
-      str, strlen, buffer, bufsize, options, NULL, NULL);
+      str, strlen, buffer, bufsize, options, nullptr, nullptr);
 }
 
 UTF8PROC_DLLEXPORT utf8proc_ssize_t utf8proc_decompose_custom(

--- a/velox/tpch/gen/dbgen/include/dbgen/dss.h
+++ b/velox/tpch/gen/dbgen/include/dbgen/dss.h
@@ -543,9 +543,9 @@ struct DBGenContext {
   static constexpr double dM = 2147483647.0;
 
   tdef tdefs[10] = {
-      {"part.tbl", "part table", 200000, NULL, NULL, PSUPP, 0},
-      {"partsupp.tbl", "partsupplier table", 200000, NULL, NULL, NONE, 0},
-      {"supplier.tbl", "suppliers table", 10000, NULL, NULL, NONE, 0},
+      {"part.tbl", "part table", 200000, nullptr, nullptr, PSUPP, 0},
+      {"partsupp.tbl", "partsupplier table", 200000, nullptr, nullptr, NONE, 0},
+      {"supplier.tbl", "suppliers table", 10000, nullptr, nullptr, NONE, 0},
       {"customer.tbl", "customers table", 150000, NULL, NULL, NONE, 0},
       {"orders.tbl", "order table", 150000, NULL, NULL, LINE, 0},
       {"lineitem.tbl", "lineitem table", 150000, NULL, NULL, NONE, 0},


### PR DESCRIPTION
Summary:
`nullptr` is typesafe. `0` and `NULL` are not. In the future, only `nullptr` will be allowed.

This diff helps us embrace the future _now_ in service of enabling `-Wzero-as-null-pointer-constant`.

Reviewed By: meyering

Differential Revision: D54163050


