### PR TITLE
Fix OOM caused by aggregation calculation on DECIMAL type

### DIFF
--- a/velox/functions/lib/aggregates/DecimalAggregate.h
+++ b/velox/functions/lib/aggregates/DecimalAggregate.h
@@ -74,7 +74,7 @@ class DecimalAggregate : public exec::Aggregate {
   explicit DecimalAggregate(TypePtr resultType) : exec::Aggregate(resultType) {}
 
   int32_t accumulatorFixedWidthSize() const override {
-    return sizeof(DecimalAggregate);
+    return sizeof(LongDecimalWithOverflowState);
   }
 
   int32_t accumulatorAlignmentSize() const override {


### PR DESCRIPTION
For aggregate calculations of type `DECIMAL`,
`LongDecimalWithOverflowState` should be used to save the intermediate 
results of each group. The current implementation incorrectly uses 
`DecimalAggregate`.

`sizeof(DecimalAggregate)` is nearly 400 bytes, but 
`sizeof(LongDecimalWithOverflowState)` is only 32 bytes, so the current 
incorrect implementation will take up more than 10 times the memory. 
Especially when there are many groups(such as TPCH-1TB Q18), it is easy
to cause out of memory (OOM).

It should be noted that although this is a bug, there is no correctness
problem for those queries that can be successfully executed, because
the size of `DecimalAggregate` is larger than 
`LongDecimalWithOverflowState`, but more memory is used (memory that 
should be used).

Fixes #8858 