### PR TITLE
Mark TableScanTest.tableScanSplitsAndWeights as DEBUG_ONLY.

### DIFF
--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1375,7 +1375,7 @@ TEST_F(TableScanTest, waitForSplit) {
       duckDbQueryRunner_);
 }
 
-TEST_F(TableScanTest, tableScanSplitsAndWeights) {
+DEBUG_ONLY_TEST_F(TableScanTest, tableScanSplitsAndWeights) {
   // Create 10 data files for 10 splits.
   const size_t numSplits{10};
   const auto filePaths = makeFilePaths(numSplits);


### PR DESCRIPTION
Summary:
The test uses debug-only instrumentation SCOPED_TESTVALUE_SET, so must
be debug only.

Differential Revision: D54214343


