### PR TITLE
Add nightly exchange fuzzer.

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -413,10 +413,10 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          ref: "${{ inputs.ref || 'main' }}"
+          ref: "${{ inputs.ref }}"
 
       - name: Install dependencies
-        run: sudo ./scripts/setup-ubuntu.sh
+        run: source ./scripts/setup-ubuntu.sh
 
       - name: Download exchange fuzzer
         uses: actions/download-artifact@v4
@@ -440,7 +440,7 @@ jobs:
             && echo -e "\n\Exchange fuzzer run finished successfully."
 
       - name: Archive Exchange production artifacts
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
             name: exchange-fuzzer-failure-artifacts

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -147,6 +147,13 @@ jobs:
           path: velox/_build/debug/velox/exec/tests/velox_join_fuzzer_test
           retention-days: "${{ env.RETENTION }}"
 
+      - name: Upload exchange fuzzer
+        uses: actions/upload-artifact@v4
+        with:
+          name: exchange
+          path: velox/_build/debug//velox/exec/tests/velox_exchange_fuzzer_test
+          retention-days: "${{ env.RETENTION }}"
+
   linux-presto-fuzzer-run:
     name: "Presto Fuzzer"
     runs-on: ubuntu-latest
@@ -396,3 +403,46 @@ jobs:
           name: join-fuzzer-failure-artifacts
           path: |
             /tmp/join_fuzzer_repro
+
+  linux-exchange-fuzzer-run:
+    runs-on: ubuntu-latest
+    needs: compile
+    timeout-minutes: 120
+    steps:
+
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          ref: "${{ inputs.ref || 'main' }}"
+
+      - name: Install dependencies
+        run: sudo ./scripts/setup-ubuntu.sh
+
+      - name: Download exchange fuzzer
+        uses: actions/download-artifact@v4
+        with:
+          name: exchange
+
+      - name: Run exchange Fuzzer
+        run: |
+          sudo sysctl -w vm.max_map_count=67108864
+          cat /proc/sys/vm/max_map_count
+          mkdir -p /tmp/exchange_fuzzer_repro/
+          rm -rfv /tmp/exchange_fuzzer_repro/*
+          chmod -R 777 /tmp/exchange_fuzzer_repro
+          chmod +x velox_exchange_fuzzer_test
+          ./velox_exchange_fuzzer_test \
+                --seed ${RANDOM} \
+                --duration_sec $DURATION \
+                --logtostderr=1 \
+                --minloglevel=0 \
+                --repro_path=/tmp/exchange_fuzzer_repro \
+            && echo -e "\n\Exchange fuzzer run finished successfully."
+
+      - name: Archive Exchange production artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+            name: exchange-fuzzer-failure-artifacts
+            path: |
+              /tmp/exchange_fuzzer_repro

--- a/velox/exec/tests/ExchangeFuzzer.cpp
+++ b/velox/exec/tests/ExchangeFuzzer.cpp
@@ -408,7 +408,7 @@ int main(int argc, char** argv) {
   folly::Init init{&argc, &argv};
   memory::MemoryManagerOptions options;
   options.useMmapAllocator = true;
-  options.allocatorCapacity = 20UL << 30;
+  options.allocatorCapacity = 8UL << 30;
   options.useMmapArena = true;
   options.mmapArenaCapacityRatio = 1;
   memory::MemoryManager::initialize(options);


### PR DESCRIPTION
This PR adds a nightly fuzzer run for the exchange fuzzer. It runs along with the other scheduled nightly jobs and the failure repros are  saved to artifacts. The job runs for 30 minutes and locally I saw 100 odd iterations. 