### PR TITLE
Use delayInjectedInSeconds consistently across naming

### DIFF
--- a/velox/common/io/IoStatistics.cpp
+++ b/velox/common/io/IoStatistics.cpp
@@ -77,7 +77,7 @@ void IoStatistics::incOperationCounters(
     const uint64_t globalThrottleCount,
     const uint64_t retryCount,
     const uint64_t latencyInMs,
-    const uint64_t delayInjectedInSecs) {
+    const uint64_t delayInjectedInSeconds) {
   std::lock_guard<std::mutex> lock{operationStatsMutex_};
   operationStats_[operation].localThrottleCount += localThrottleCount;
   operationStats_[operation].resourceThrottleCount += resourceThrottleCount;
@@ -85,7 +85,7 @@ void IoStatistics::incOperationCounters(
   operationStats_[operation].retryCount += retryCount;
   operationStats_[operation].latencyInMs += latencyInMs;
   operationStats_[operation].requestCount++;
-  operationStats_[operation].delayInjectedInSecs += delayInjectedInSecs;
+  operationStats_[operation].delayInjectedInSeconds += delayInjectedInSeconds;
 }
 
 std::unordered_map<std::string, OperationCounters>
@@ -118,7 +118,7 @@ void OperationCounters::merge(const OperationCounters& other) {
   retryCount += other.retryCount;
   latencyInMs += other.latencyInMs;
   requestCount += other.requestCount;
-  delayInjectedInSecs += other.delayInjectedInSecs;
+  delayInjectedInSeconds += other.delayInjectedInSeconds;
 }
 
 folly::dynamic serialize(const OperationCounters& counters) {
@@ -129,7 +129,7 @@ folly::dynamic serialize(const OperationCounters& counters) {
   json["globalThrottleCount"] = counters.globalThrottleCount;
   json["retryCount"] = counters.retryCount;
   json["requestCount"] = counters.requestCount;
-  json["delayInjectedInSecs"] = counters.delayInjectedInSecs;
+  json["delayInjectedInSeconds"] = counters.delayInjectedInSeconds;
   return json;
 }
 

--- a/velox/common/io/IoStatistics.h
+++ b/velox/common/io/IoStatistics.h
@@ -33,7 +33,7 @@ struct OperationCounters {
   uint64_t retryCount{0};
   uint64_t latencyInMs{0};
   uint64_t requestCount{0};
-  uint64_t delayInjectedInSecs{0};
+  uint64_t delayInjectedInSeconds{0};
 
   void merge(const OperationCounters& other);
 };
@@ -129,7 +129,7 @@ class IoStatistics {
       const uint64_t globalThrottleCount,
       const uint64_t retryCount,
       const uint64_t latencyInMs,
-      const uint64_t delayInjectedInSecs);
+      const uint64_t delayInjectedInSeconds);
 
   std::unordered_map<std::string, OperationCounters> operationStats() const;
 


### PR DESCRIPTION
Summary: When working on D54223780 I noticed all other field names were consistent with the WS key name, but not this one. Let's fix it.

Differential Revision: D54223779


