### PR TITLE
Fix integer overflow for window ROWS frame

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -2084,7 +2084,6 @@ class WindowNode : public PlanNode {
   /// Frame bounds can be CURRENT ROW, UNBOUNDED PRECEDING(FOLLOWING)
   /// and k PRECEDING(FOLLOWING). K could be a constant or column.
   ///
-  /// k PRECEDING(FOLLOWING) is only supported for ROW frames now.
   /// k has to be of integer or bigint type.
   struct Frame {
     WindowType type;

--- a/velox/functions/lib/window/tests/WindowTestBase.h
+++ b/velox/functions/lib/window/tests/WindowTestBase.h
@@ -190,7 +190,7 @@ class WindowTestBase : public exec::test::OperatorTestBase {
   void testKRangeFrames(const std::string& function);
 
   /// ParseOptions for the DuckDB Parser. nth_value in Spark expects to parse
-  /// integer as bigint vs bigint in Presto. The default is to parse integer
+  /// integer as int vs bigint in Presto. The default is to parse integer
   /// as bigint (Presto behavior).
   parse::ParseOptions options_;
 


### PR DESCRIPTION
For window ROWS frame, if a large preceding/following value (int32/int64) is used, integer can overflow during the computation for `rawFrameBounds` (int32), which produces unexpected frame and then wrong result.