### PR TITLE
Remove connector factory registrations

### DIFF
--- a/velox/benchmarks/QueryBenchmarkBase.cpp
+++ b/velox/benchmarks/QueryBenchmarkBase.cpp
@@ -186,6 +186,8 @@ void QueryBenchmarkBase::initialize() {
       std::move(configurationValues));
 
   // Create hive connector with config...
+  connector::registerConnectorFactory(
+      std::make_shared<connector::hive::HiveConnectorFactory>());
   auto hiveConnector =
       connector::getConnectorFactory(
           connector::hive::HiveConnectorFactory::kHiveConnectorName)

--- a/velox/connectors/Connector.cpp
+++ b/velox/connectors/Connector.cpp
@@ -44,7 +44,6 @@ std::string DataSink::Stats::toString() const {
 }
 
 bool registerConnectorFactory(std::shared_ptr<ConnectorFactory> factory) {
-  factory->initialize();
   bool ok =
       connectorFactories().insert({factory->connectorName(), factory}).second;
   VELOX_CHECK(

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -444,9 +444,6 @@ class ConnectorFactory {
 
   virtual ~ConnectorFactory() = default;
 
-  /// Initialize is called during the factory registration.
-  virtual void initialize() {}
-
   const std::string& connectorName() const {
     return name_;
   }
@@ -496,9 +493,4 @@ std::shared_ptr<Connector> getConnector(const std::string& connectorId);
 const std::unordered_map<std::string, std::shared_ptr<Connector>>&
 getAllConnectors();
 
-#define VELOX_REGISTER_CONNECTOR_FACTORY(theFactory)                      \
-  namespace {                                                             \
-  static bool FB_ANONYMOUS_VARIABLE(g_ConnectorFactory) =                 \
-      facebook::velox::connector::registerConnectorFactory((theFactory)); \
-  }
 } // namespace facebook::velox::connector

--- a/velox/connectors/fuzzer/FuzzerConnector.cpp
+++ b/velox/connectors/fuzzer/FuzzerConnector.cpp
@@ -69,6 +69,4 @@ std::optional<RowVectorPtr> FuzzerDataSource::next(
   return outputVector;
 }
 
-VELOX_REGISTER_CONNECTOR_FACTORY(std::make_shared<FuzzerConnectorFactory>())
-
 } // namespace facebook::velox::connector::fuzzer

--- a/velox/connectors/fuzzer/tests/FuzzerConnectorTestBase.h
+++ b/velox/connectors/fuzzer/tests/FuzzerConnectorTestBase.h
@@ -26,6 +26,8 @@ class FuzzerConnectorTestBase : public exec::test::OperatorTestBase {
 
   void SetUp() override {
     OperatorTestBase::SetUp();
+    connector::registerConnectorFactory(
+        std::make_shared<connector::fuzzer::FuzzerConnectorFactory>());
     std::shared_ptr<const config::ConfigBase> config;
     auto fuzzerConnector =
         connector::getConnectorFactory(
@@ -36,6 +38,8 @@ class FuzzerConnectorTestBase : public exec::test::OperatorTestBase {
 
   void TearDown() override {
     connector::unregisterConnector(kFuzzerConnectorId);
+    connector::unregisterConnectorFactory(
+        connector::fuzzer::FuzzerConnectorFactory::kFuzzerConnectorName);
     OperatorTestBase::TearDown();
   }
 

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -21,18 +21,6 @@
 #include "velox/connectors/hive/HiveDataSink.h"
 #include "velox/connectors/hive/HiveDataSource.h"
 #include "velox/connectors/hive/HivePartitionFunction.h"
-#include "velox/dwio/dwrf/RegisterDwrfReader.h"
-#include "velox/dwio/dwrf/RegisterDwrfWriter.h"
-
-#include "velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.h" // @manual
-#include "velox/connectors/hive/storage_adapters/gcs/RegisterGCSFileSystem.h" // @manual
-#include "velox/connectors/hive/storage_adapters/hdfs/RegisterHdfsFileSystem.h" // @manual
-#include "velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h" // @manual
-#include "velox/dwio/dwrf/reader/DwrfReader.h"
-#include "velox/dwio/dwrf/writer/Writer.h"
-#include "velox/dwio/orc/reader/OrcReader.h"
-#include "velox/dwio/parquet/RegisterParquetReader.h" // @manual
-#include "velox/dwio/parquet/RegisterParquetWriter.h" // @manual
 #include "velox/expression/FieldReference.h"
 
 #include <boost/lexical_cast.hpp>
@@ -120,24 +108,6 @@ std::unique_ptr<core::PartitionFunction> HivePartitionFunctionSpec::create(
       constValues_);
 }
 
-void HiveConnectorFactory::initialize() {
-  [[maybe_unused]] static bool once = []() {
-    dwio::common::registerFileSinks();
-    dwrf::registerDwrfReaderFactory();
-    dwrf::registerDwrfWriterFactory();
-    orc::registerOrcReaderFactory();
-
-    parquet::registerParquetReaderFactory();
-    parquet::registerParquetWriterFactory();
-
-    filesystems::registerS3FileSystem();
-    filesystems::registerHdfsFileSystem();
-    filesystems::registerGCSFileSystem();
-    filesystems::abfs::registerAbfsFileSystem();
-    return true;
-  }();
-}
-
 std::string HivePartitionFunctionSpec::toString() const {
   std::ostringstream keys;
   size_t constIndex = 0;
@@ -201,7 +171,4 @@ void registerHivePartitionFunctionSerDe() {
       "HivePartitionFunctionSpec", HivePartitionFunctionSpec::deserialize);
 }
 
-VELOX_REGISTER_CONNECTOR_FACTORY(std::make_shared<HiveConnectorFactory>())
-VELOX_REGISTER_CONNECTOR_FACTORY(
-    std::make_shared<HiveHadoop2ConnectorFactory>())
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -84,16 +84,11 @@ class HiveConnector : public Connector {
 class HiveConnectorFactory : public ConnectorFactory {
  public:
   static constexpr const char* kHiveConnectorName = "hive";
-  static constexpr const char* kHiveHadoop2ConnectorName = "hive-hadoop2";
 
   HiveConnectorFactory() : ConnectorFactory(kHiveConnectorName) {}
 
   explicit HiveConnectorFactory(const char* connectorName)
       : ConnectorFactory(connectorName) {}
-
-  /// Register HiveConnector components such as Dwrf, Parquet readers and
-  /// writers and FileSystems.
-  void initialize() override;
 
   std::shared_ptr<Connector> newConnector(
       const std::string& id,
@@ -101,12 +96,6 @@ class HiveConnectorFactory : public ConnectorFactory {
       folly::Executor* executor = nullptr) override {
     return std::make_shared<HiveConnector>(id, config, executor);
   }
-};
-
-class HiveHadoop2ConnectorFactory : public HiveConnectorFactory {
- public:
-  HiveHadoop2ConnectorFactory()
-      : HiveConnectorFactory(kHiveHadoop2ConnectorName) {}
 };
 
 class HivePartitionFunctionSpec : public core::PartitionFunctionSpec {

--- a/velox/connectors/hive/SplitReader.h
+++ b/velox/connectors/hive/SplitReader.h
@@ -19,6 +19,7 @@
 #include "velox/common/base/RandomUtil.h"
 #include "velox/connectors/hive/FileHandle.h"
 #include "velox/dwio/common/Options.h"
+#include "velox/dwio/common/Reader.h"
 
 namespace facebook::velox {
 class BaseVector;
@@ -36,8 +37,6 @@ class ConnectorQueryCtx;
 } // namespace facebook::velox::connector
 
 namespace facebook::velox::dwio::common {
-class Reader;
-class RowReader;
 struct RuntimeStatistics;
 } // namespace facebook::velox::dwio::common
 

--- a/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.h
+++ b/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.h
@@ -22,6 +22,7 @@
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/connectors/hive/iceberg/IcebergSplitReader.h"
 #include "velox/dwio/common/tests/utils/DataSetBuilder.h"
+#include "velox/dwio/dwrf/RegisterDwrfReader.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
@@ -45,6 +46,7 @@ class IcebergSplitReaderBenchmark {
     dataSetBuilder_ =
         std::make_unique<facebook::velox::test::DataSetBuilder>(*leafPool_, 0);
     filesystems::registerLocalFileSystem();
+    dwrf::registerDwrfReaderFactory();
   }
 
   ~IcebergSplitReaderBenchmark() {}

--- a/velox/connectors/hive/storage_adapters/abfs/tests/AbfsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/tests/AbfsFileSystemTest.cpp
@@ -263,7 +263,7 @@ TEST_F(AbfsFileSystemTest, missingFile) {
       abfs.openFileForRead(abfsFile), error_code::kFileNotFound, "404");
 }
 
-TEST_F(AbfsFileSystemTest, OpenFileForWriteTest) {
+TEST_F(AbfsFileSystemTest, openFileForWriteTest) {
   const std::string abfsFile =
       filesystems::test::AzuriteABFSEndpoint + "writetest.txt";
   auto mockClient =

--- a/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsFileSystemTest.cpp
@@ -42,6 +42,7 @@ static const std::unordered_map<std::string, std::string> configurationValues(
 class HdfsFileSystemTest : public testing::Test {
  public:
   static void SetUpTestSuite() {
+    filesystems::registerHdfsFileSystem();
     if (miniCluster == nullptr) {
       miniCluster = std::make_shared<filesystems::test::HdfsMiniCluster>();
       miniCluster->start();

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3ReadTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3ReadTest.cpp
@@ -21,6 +21,7 @@
 #include "velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/tests/S3Test.h"
 #include "velox/dwio/common/tests/utils/DataFiles.h"
+#include "velox/dwio/parquet/RegisterParquetReader.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 
@@ -38,15 +39,21 @@ class S3ReadTest : public S3Test {
   void SetUp() override {
     S3Test::SetUp();
     filesystems::registerS3FileSystem();
+    connector::registerConnectorFactory(
+        std::make_shared<connector::hive::HiveConnectorFactory>());
     auto hiveConnector =
         connector::getConnectorFactory(
             connector::hive::HiveConnectorFactory::kHiveConnectorName)
             ->newConnector(kHiveConnectorId, minioServer_->hiveConfig());
     connector::registerConnector(hiveConnector);
+    parquet::registerParquetReaderFactory();
   }
 
   void TearDown() override {
+    parquet::unregisterParquetReaderFactory();
     filesystems::finalizeS3FileSystem();
+    connector::unregisterConnectorFactory(
+        connector::hive::HiveConnectorFactory::kHiveConnectorName);
     connector::unregisterConnector(kHiveConnectorId);
     S3Test::TearDown();
   }

--- a/velox/connectors/tpch/TpchConnector.cpp
+++ b/velox/connectors/tpch/TpchConnector.cpp
@@ -162,6 +162,4 @@ std::optional<RowVectorPtr> TpchDataSource::next(
   return projectOutputColumns(outputVector);
 }
 
-VELOX_REGISTER_CONNECTOR_FACTORY(std::make_shared<TpchConnectorFactory>())
-
 } // namespace facebook::velox::connector::tpch

--- a/velox/connectors/tpch/tests/SpeedTest.cpp
+++ b/velox/connectors/tpch/tests/SpeedTest.cpp
@@ -56,6 +56,8 @@ using std::chrono::system_clock;
 class TpchSpeedTest {
  public:
   TpchSpeedTest() {
+    connector::registerConnectorFactory(
+        std::make_shared<connector::tpch::TpchConnectorFactory>());
     auto tpchConnector =
         connector::getConnectorFactory(
             connector::tpch::TpchConnectorFactory::kTpchConnectorName)
@@ -68,6 +70,8 @@ class TpchSpeedTest {
 
   ~TpchSpeedTest() {
     connector::unregisterConnector(kTpchConnectorId_);
+    connector::unregisterConnectorFactory(
+        connector::tpch::TpchConnectorFactory::kTpchConnectorName);
   }
 
   void run(tpch::Table table, size_t scaleFactor, size_t numSplits) {

--- a/velox/connectors/tpch/tests/TpchConnectorTest.cpp
+++ b/velox/connectors/tpch/tests/TpchConnectorTest.cpp
@@ -36,6 +36,8 @@ class TpchConnectorTest : public exec::test::OperatorTestBase {
 
   void SetUp() override {
     OperatorTestBase::SetUp();
+    connector::registerConnectorFactory(
+        std::make_shared<connector::tpch::TpchConnectorFactory>());
     auto tpchConnector =
         connector::getConnectorFactory(
             connector::tpch::TpchConnectorFactory::kTpchConnectorName)
@@ -48,6 +50,8 @@ class TpchConnectorTest : public exec::test::OperatorTestBase {
 
   void TearDown() override {
     connector::unregisterConnector(kTpchConnectorId);
+    connector::unregisterConnectorFactory(
+        connector::tpch::TpchConnectorFactory::kTpchConnectorName);
     OperatorTestBase::TearDown();
   }
 

--- a/velox/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -49,10 +49,13 @@ class ParquetTpchTest : public testing::Test {
 
     parse::registerTypeResolver();
     filesystems::registerLocalFileSystem();
+    dwio::common::registerFileSinks();
 
     parquet::registerParquetReaderFactory();
     parquet::registerParquetWriterFactory();
 
+    connector::registerConnectorFactory(
+        std::make_shared<connector::hive::HiveConnectorFactory>());
     auto hiveConnector =
         connector::getConnectorFactory(
             connector::hive::HiveConnectorFactory::kHiveConnectorName)
@@ -62,6 +65,8 @@ class ParquetTpchTest : public testing::Test {
                     std::unordered_map<std::string, std::string>()));
     connector::registerConnector(hiveConnector);
 
+    connector::registerConnectorFactory(
+        std::make_shared<connector::tpch::TpchConnectorFactory>());
     auto tpchConnector =
         connector::getConnectorFactory(
             connector::tpch::TpchConnectorFactory::kTpchConnectorName)
@@ -76,6 +81,10 @@ class ParquetTpchTest : public testing::Test {
   }
 
   static void TearDownTestSuite() {
+    connector::unregisterConnectorFactory(
+        connector::hive::HiveConnectorFactory::kHiveConnectorName);
+    connector::unregisterConnectorFactory(
+        connector::tpch::TpchConnectorFactory::kTpchConnectorName);
     connector::unregisterConnector(kHiveConnectorId);
     connector::unregisterConnector(kTpchConnectorId);
     parquet::unregisterParquetReaderFactory();

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -41,20 +41,6 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
  protected:
   using OperatorTestBase::assertQuery;
 
-  void SetUp() {
-    OperatorTestBase::SetUp();
-    registerParquetReaderFactory();
-
-    auto hiveConnector =
-        connector::getConnectorFactory(
-            connector::hive::HiveConnectorFactory::kHiveConnectorName)
-            ->newConnector(
-                kHiveConnectorId,
-                std::make_shared<config::ConfigBase>(
-                    std::unordered_map<std::string, std::string>()));
-    connector::registerConnector(hiveConnector);
-  }
-
   void assertSelect(
       std::vector<std::string>&& outputColumnNames,
       const std::string& sql) {

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -42,6 +42,8 @@ class ParquetWriterTest : public ParquetTestBase {
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance({});
     testutil::TestValue::enable();
+    connector::registerConnectorFactory(
+        std::make_shared<connector::hive::HiveConnectorFactory>());
     auto hiveConnector =
         connector::getConnectorFactory(
             connector::hive::HiveConnectorFactory::kHiveConnectorName)

--- a/velox/examples/ScanAndSort.cpp
+++ b/velox/examples/ScanAndSort.cpp
@@ -84,6 +84,9 @@ int main(int argc, char** argv) {
   // We need a connector id string to identify the connector.
   const std::string kHiveConnectorId = "test-hive";
 
+  // Register the Hive Connector Factory.
+  connector::registerConnectorFactory(
+      std::make_shared<connector::hive::HiveConnectorFactory>());
   // Create a new connector instance from the connector factory and register
   // it:
   auto hiveConnector =

--- a/velox/exec/fuzzer/AggregationFuzzerBase.h
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.h
@@ -17,6 +17,8 @@
 
 #include "velox/common/file/FileSystems.h"
 #include "velox/connectors/hive/HiveConnector.h"
+#include "velox/dwio/dwrf/RegisterDwrfReader.h"
+#include "velox/dwio/dwrf/RegisterDwrfWriter.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/Split.h"
 #include "velox/exec/fuzzer/FuzzerUtil.h"
@@ -75,6 +77,8 @@ class AggregationFuzzerBase {
         referenceQueryRunner_{std::move(referenceQueryRunner)},
         vectorFuzzer_{getFuzzerOptions(timestampPrecision), pool_.get()} {
     filesystems::registerLocalFileSystem();
+    connector::registerConnectorFactory(
+        std::make_shared<connector::hive::HiveConnectorFactory>());
     auto configs = hiveConfigs;
     auto hiveConnector =
         connector::getConnectorFactory(
@@ -83,7 +87,8 @@ class AggregationFuzzerBase {
                 kHiveConnectorId,
                 std::make_shared<config::ConfigBase>(std::move(configs)));
     connector::registerConnector(hiveConnector);
-
+    dwrf::registerDwrfReaderFactory();
+    dwrf::registerDwrfWriterFactory();
     seed(initialSeed);
   }
 

--- a/velox/exec/fuzzer/JoinFuzzer.cpp
+++ b/velox/exec/fuzzer/JoinFuzzer.cpp
@@ -19,6 +19,7 @@
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/PartitionIdGenerator.h"
+#include "velox/dwio/dwrf/RegisterDwrfReader.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/fuzzer/FuzzerUtil.h"
 #include "velox/exec/fuzzer/ReferenceQueryRunner.h"
@@ -339,6 +340,8 @@ JoinFuzzer::JoinFuzzer(
   // Make sure not to run out of open file descriptors.
   std::unordered_map<std::string, std::string> hiveConfig = {
       {connector::hive::HiveConfig::kNumCacheFileHandles, "1000"}};
+  connector::registerConnectorFactory(
+      std::make_shared<connector::hive::HiveConnectorFactory>());
   auto hiveConnector =
       connector::getConnectorFactory(
           connector::hive::HiveConnectorFactory::kHiveConnectorName)
@@ -346,6 +349,7 @@ JoinFuzzer::JoinFuzzer(
               kHiveConnectorId,
               std::make_shared<config::ConfigBase>(std::move(hiveConfig)));
   connector::registerConnector(hiveConnector);
+  dwrf::registerDwrfReaderFactory();
 
   seed(initialSeed);
 }

--- a/velox/exec/fuzzer/RowNumberFuzzer.cpp
+++ b/velox/exec/fuzzer/RowNumberFuzzer.cpp
@@ -20,6 +20,7 @@
 #include "velox/common/file/FileSystems.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/dwio/dwrf/RegisterDwrfReader.h"
 #include "velox/exec/fuzzer/FuzzerUtil.h"
 #include "velox/exec/fuzzer/ReferenceQueryRunner.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
@@ -171,10 +172,13 @@ RowNumberFuzzer::RowNumberFuzzer(
     : vectorFuzzer_{getFuzzerOptions(), pool_.get()},
       referenceQueryRunner_{std::move(referenceQueryRunner)} {
   filesystems::registerLocalFileSystem();
+  dwrf::registerDwrfReaderFactory();
 
   // Make sure not to run out of open file descriptors.
   std::unordered_map<std::string, std::string> hiveConfig = {
       {connector::hive::HiveConfig::kNumCacheFileHandles, "1000"}};
+  connector::registerConnectorFactory(
+      std::make_shared<connector::hive::HiveConnectorFactory>());
   auto hiveConnector =
       connector::getConnectorFactory(
           connector::hive::HiveConnectorFactory::kHiveConnectorName)

--- a/velox/exec/fuzzer/WriterFuzzerRunner.h
+++ b/velox/exec/fuzzer/WriterFuzzerRunner.h
@@ -24,6 +24,9 @@
 
 #include "velox/common/file/FileSystems.h"
 #include "velox/connectors/hive/HiveConnector.h"
+#include "velox/dwio/common/FileSink.h"
+#include "velox/dwio/dwrf/RegisterDwrfReader.h"
+#include "velox/dwio/dwrf/RegisterDwrfWriter.h"
 #include "velox/exec/fuzzer/FuzzerUtil.h"
 #include "velox/exec/fuzzer/WriterFuzzer.h"
 #include "velox/expression/fuzzer/FuzzerToolkit.h"
@@ -71,6 +74,8 @@ class WriterFuzzerRunner {
       size_t seed,
       std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner) {
     filesystems::registerLocalFileSystem();
+    connector::registerConnectorFactory(
+        std::make_shared<connector::hive::HiveConnectorFactory>());
     auto hiveConnector =
         connector::getConnectorFactory(
             connector::hive::HiveConnectorFactory::kHiveConnectorName)
@@ -79,6 +84,9 @@ class WriterFuzzerRunner {
                 std::make_shared<config::ConfigBase>(
                     std::unordered_map<std::string, std::string>()));
     connector::registerConnector(hiveConnector);
+    dwrf::registerDwrfReaderFactory();
+    dwrf::registerDwrfWriterFactory();
+    dwio::common::registerFileSinks();
     facebook::velox::exec::test::writerFuzzer(
         seed, std::move(referenceQueryRunner));
     // Calling gtest here so that it can be recognized as tests in CI systems.

--- a/velox/exec/tests/VeloxIn10MinDemo.cpp
+++ b/velox/exec/tests/VeloxIn10MinDemo.cpp
@@ -47,7 +47,11 @@ class VeloxIn10MinDemo : public VectorTestBase {
     // Register type resolver with DuckDB SQL parser.
     parse::registerTypeResolver();
 
-    // Register TPC-H connector.
+    // Register the TPC-H Connector Factory.
+    connector::registerConnectorFactory(
+        std::make_shared<connector::tpch::TpchConnectorFactory>());
+
+    // Create and register a TPC-H connector.
     auto tpchConnector =
         connector::getConnectorFactory(
             connector::tpch::TpchConnectorFactory::kTpchConnectorName)
@@ -60,6 +64,8 @@ class VeloxIn10MinDemo : public VectorTestBase {
 
   ~VeloxIn10MinDemo() {
     connector::unregisterConnector(kTpchConnectorId);
+    connector::unregisterConnectorFactory(
+        connector::tpch::TpchConnectorFactory::kTpchConnectorName);
   }
 
   /// Parse SQL expression into a typed expression tree using DuckDB SQL parser.

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -22,6 +22,8 @@
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/writer/FlushPolicy.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
+#include "velox/dwio/parquet/RegisterParquetReader.h"
+#include "velox/dwio/parquet/RegisterParquetWriter.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 
 namespace facebook::velox::exec::test {
@@ -33,6 +35,8 @@ HiveConnectorTestBase::HiveConnectorTestBase() {
 
 void HiveConnectorTestBase::SetUp() {
   OperatorTestBase::SetUp();
+  connector::registerConnectorFactory(
+      std::make_shared<connector::hive::HiveConnectorFactory>());
   auto hiveConnector =
       connector::getConnectorFactory(
           connector::hive::HiveConnectorFactory::kHiveConnectorName)
@@ -42,13 +46,24 @@ void HiveConnectorTestBase::SetUp() {
                   std::unordered_map<std::string, std::string>()),
               ioExecutor_.get());
   connector::registerConnector(hiveConnector);
+  dwio::common::registerFileSinks();
+  dwrf::registerDwrfReaderFactory();
+  dwrf::registerDwrfWriterFactory();
+  parquet::registerParquetReaderFactory();
+  parquet::registerParquetWriterFactory();
 }
 
 void HiveConnectorTestBase::TearDown() {
   // Make sure all pending loads are finished or cancelled before unregister
   // connector.
   ioExecutor_.reset();
+  dwrf::unregisterDwrfReaderFactory();
+  dwrf::unregisterDwrfWriterFactory();
+  parquet::unregisterParquetReaderFactory();
+  parquet::unregisterParquetWriterFactory();
   connector::unregisterConnector(kHiveConnectorId);
+  connector::unregisterConnectorFactory(
+      connector::hive::HiveConnectorFactory::kHiveConnectorName);
   OperatorTestBase::TearDown();
 }
 

--- a/velox/experimental/wave/exec/WaveHiveDataSource.cpp
+++ b/velox/experimental/wave/exec/WaveHiveDataSource.cpp
@@ -159,6 +159,8 @@ void WaveHiveDataSource::registerConnector() {
   auto config = std::make_shared<const config::ConfigBase>(
       std::unordered_map<std::string, std::string>());
 
+  connector::registerConnectorFactory(
+      std::make_shared<connector::hive::HiveConnectorFactory>());
   // Create hive connector with config...
   auto hiveConnector =
       connector::getConnectorFactory(

--- a/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
@@ -21,6 +21,9 @@
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
+#include "velox/dwio/dwrf/RegisterDwrfReader.h"
+#include "velox/dwio/dwrf/RegisterDwrfWriter.h"
+#include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/exec/AggregateCompanionSignatures.h"
 #include "velox/exec/PlanNodeStats.h"
@@ -67,6 +70,8 @@ std::vector<RowVectorPtr> AggregationTestBase::makeVectors(
 void AggregationTestBase::SetUp() {
   OperatorTestBase::SetUp();
   filesystems::registerLocalFileSystem();
+  connector::registerConnectorFactory(
+      std::make_shared<connector::hive::HiveConnectorFactory>());
   auto hiveConnector =
       connector::getConnectorFactory(
           connector::hive::HiveConnectorFactory::kHiveConnectorName)
@@ -75,10 +80,14 @@ void AggregationTestBase::SetUp() {
               std::make_shared<config::ConfigBase>(
                   std::unordered_map<std::string, std::string>()));
   connector::registerConnector(hiveConnector);
+  dwrf::registerDwrfReaderFactory();
 }
 
 void AggregationTestBase::TearDown() {
+  dwrf::unregisterDwrfReaderFactory();
   connector::unregisterConnector(kHiveConnectorId);
+  connector::unregisterConnectorFactory(
+      connector::hive::HiveConnectorFactory::kHiveConnectorName);
   OperatorTestBase::TearDown();
 }
 


### PR DESCRIPTION
We must register connector factories in the client and not in the Velox library.
The registration of dwrf, parquet, and storage adapters along with HiveConnectorFactory introduces an unnecessary
dependency among these modules.