### PR TITLE
Fix flakiness in 2 tests in TableWriterArbitrationTest

### DIFF
--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -3724,6 +3724,7 @@ DEBUG_ONLY_TEST_F(
   ASSERT_EQ(arbitrator->stats().numFailures, 1);
   ASSERT_EQ(arbitrator->stats().numNonReclaimableAttempts, 1);
   ASSERT_EQ(arbitrator->stats().numReserves, 1);
+  waitForAllTasksToBeDeleted();
 }
 
 DEBUG_ONLY_TEST_F(
@@ -3815,6 +3816,7 @@ DEBUG_ONLY_TEST_F(
   ASSERT_EQ(arbitrator->stats().numFailures, 0);
   ASSERT_GT(arbitrator->stats().numReclaimedBytes, 0);
   ASSERT_EQ(arbitrator->stats().numReserves, 1);
+  waitForAllTasksToBeDeleted();
 }
 
 DEBUG_ONLY_TEST_F(


### PR DESCRIPTION
Summary:
This fixes flakiness in these tests that may be encountered if the test finishes
before the Tasks get a chance to be destroyed. If this happens then when the
memory manager gets deleted, it can lead to errors because some memory
pools (which are maintained by the potentially active Tasks) would still exist
holding onto memory whereas it expects all to be destoryed. The fix here is
to simply wait for the Tasks to be deleted.

Reviewed By: xiaoxmeng

Differential Revision: D54226837


