### PR TITLE
Vector reencoding utilities

### DIFF
--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -209,7 +209,7 @@ void PartitionedOutput::estimateRowSizes() {
   auto numbers = iota(numInput, storage);
   for (int i = 0; i < output_->childrenSize(); ++i) {
     VectorStreamGroup::estimateSerializedSize(
-        output_->childAt(i),
+        output_->childAt(i).get(),
         folly::Range(numbers, numInput),
         sizePointers_.data(),
         scratch_);

--- a/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
@@ -175,7 +175,7 @@ class MaxSizeForStatsAggregate
     });
 
     getVectorSerde()->estimateSerializedSize(
-        vector,
+        vector.get(),
         folly::Range(elementIndices_.data(), elementIndices_.size()),
         elementSizePtrs_.data());
   }

--- a/velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.cpp
@@ -155,7 +155,7 @@ class SumDataSizeForStatsAggregate
     });
 
     getVectorSerde()->estimateSerializedSize(
-        vector,
+        vector.get(),
         folly::Range(rowIndices_.data(), rowIndices_.size()),
         rowSizePtrs_.data());
   }

--- a/velox/serializers/CompactRowSerializer.cpp
+++ b/velox/serializers/CompactRowSerializer.cpp
@@ -20,7 +20,7 @@
 namespace facebook::velox::serializer {
 
 void CompactRowVectorSerde::estimateSerializedSize(
-    VectorPtr /* vector */,
+    const BaseVector* /* vector */,
     const folly::Range<const IndexRange*>& /* ranges */,
     vector_size_t** /* sizes */,
     Scratch& /*scratch*/) {

--- a/velox/serializers/CompactRowSerializer.h
+++ b/velox/serializers/CompactRowSerializer.h
@@ -26,7 +26,7 @@ class CompactRowVectorSerde : public VectorSerde {
 
   // We do not implement this method since it is not used in production code.
   void estimateSerializedSize(
-      VectorPtr vector,
+      const BaseVector* vector,
       const folly::Range<const IndexRange*>& ranges,
       vector_size_t** sizes,
       Scratch& scratch) override;

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -3677,7 +3677,7 @@ class PrestoIterativeVectorSerializer : public IterativeVectorSerializer {
 } // namespace
 
 void PrestoVectorSerde::estimateSerializedSize(
-    VectorPtr vector,
+    const BaseVector* vector,
     const folly::Range<const IndexRange*>& ranges,
     vector_size_t** sizes,
     Scratch& scratch) {
@@ -3685,7 +3685,7 @@ void PrestoVectorSerde::estimateSerializedSize(
 }
 
 void PrestoVectorSerde::estimateSerializedSize(
-    VectorPtr vector,
+    const BaseVector* vector,
     const folly::Range<const vector_size_t*> rows,
     vector_size_t** sizes,
     Scratch& scratch) {

--- a/velox/serializers/PrestoSerializer.h
+++ b/velox/serializers/PrestoSerializer.h
@@ -75,13 +75,13 @@ class PrestoVectorSerde : public VectorSerde {
   /// Adds the serialized sizes of the rows of 'vector' in 'ranges[i]' to
   /// '*sizes[i]'.
   void estimateSerializedSize(
-      VectorPtr vector,
+      const BaseVector* vector,
       const folly::Range<const IndexRange*>& ranges,
       vector_size_t** sizes,
       Scratch& scratch) override;
 
   void estimateSerializedSize(
-      VectorPtr vector,
+      const BaseVector* vector,
       const folly::Range<const vector_size_t*> rows,
       vector_size_t** sizes,
       Scratch& scratch) override;

--- a/velox/serializers/UnsafeRowSerializer.cpp
+++ b/velox/serializers/UnsafeRowSerializer.cpp
@@ -21,7 +21,7 @@
 namespace facebook::velox::serializer::spark {
 
 void UnsafeRowVectorSerde::estimateSerializedSize(
-    VectorPtr /* vector */,
+    const BaseVector* /* vector */,
     const folly::Range<const IndexRange*>& /* ranges */,
     vector_size_t** /* sizes */,
     Scratch& /*scratch*/) {

--- a/velox/serializers/UnsafeRowSerializer.h
+++ b/velox/serializers/UnsafeRowSerializer.h
@@ -24,7 +24,7 @@ class UnsafeRowVectorSerde : public VectorSerde {
   UnsafeRowVectorSerde() = default;
   // We do not implement this method since it is not used in production code.
   void estimateSerializedSize(
-      VectorPtr vector,
+      const BaseVector* vector,
       const folly::Range<const IndexRange*>& ranges,
       vector_size_t** sizes,
       Scratch& scratch) override;

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -62,7 +62,7 @@ class PrestoSerializerTest
       rawRowSizes[i] = &rowSizes[i];
     }
     serde_->estimateSerializedSize(
-        rowVector,
+        rowVector.get(),
         folly::Range(rows.data(), numRows),
         rawRowSizes.data(),
         scratch);
@@ -114,19 +114,19 @@ class PrestoSerializerTest
       raw_vector<vector_size_t*> sizes(indexRanges.value().size());
       std::fill(sizes.begin(), sizes.end(), &sizeEstimate);
       serde_->estimateSerializedSize(
-          rowVector, indexRanges.value(), sizes.data(), scratch);
+          rowVector.get(), indexRanges.value(), sizes.data(), scratch);
       serializer->append(rowVector, indexRanges.value(), scratch);
     } else if (rows.has_value()) {
       raw_vector<vector_size_t*> sizes(rows.value().size());
       std::fill(sizes.begin(), sizes.end(), &sizeEstimate);
       serde_->estimateSerializedSize(
-          rowVector, rows.value(), sizes.data(), scratch);
+          rowVector.get(), rows.value(), sizes.data(), scratch);
       serializer->append(rowVector, rows.value(), scratch);
     } else {
       vector_size_t* sizes = &sizeEstimate;
       IndexRange range{0, rowVector->size()};
       serde_->estimateSerializedSize(
-          rowVector,
+          rowVector.get(),
           folly::Range<const IndexRange*>(&range, 1),
           &sizes,
           scratch);

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -63,6 +63,8 @@ struct VectorValidateOptions {
   std::function<void(const BaseVector&)> callback;
 };
 
+class DecodedVector;
+
 /**
  * Base class for all columnar-based vectors of any type.
  */
@@ -601,6 +603,12 @@ class BaseVector {
   virtual bool isWritable() const {
     return false;
   }
+
+  /// If 'vector' consists of a single value and is longer than one,
+  /// returns an equivalent constant vector, else nullptr.
+  static VectorPtr constantify(
+      const std::shared_ptr<BaseVector>& vector,
+      DecodedVector* decoded = nullptr);
 
   // Flattens the input vector and all of its children.
   static void flattenVector(VectorPtr& vector);

--- a/velox/vector/CMakeLists.txt
+++ b/velox/vector/CMakeLists.txt
@@ -27,7 +27,8 @@ add_library(
   VectorPool.cpp
   VectorPrinter.cpp
   VectorStream.cpp
-  VariantToVector.cpp)
+  VariantToVector.cpp
+  VectorMap.cpp)
 
 target_link_libraries(velox_vector velox_encode velox_memory velox_time
                       velox_type velox_buffer)

--- a/velox/vector/VectorMap.cpp
+++ b/velox/vector/VectorMap.cpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/vector/VectorMap.h"
+#include "velox/vector/FlatVector.h"
+#include "velox/vector/VectorStream.h"
+
+namespace facebook::velox {
+
+VectorMap::VectorMap(BaseVector& alphabet)
+    : alphabet_(&alphabet),
+      isString_(
+          alphabet_->typeKind() == TypeKind::VARCHAR ||
+          alphabet_->typeKind() == TypeKind::VARBINARY),
+      fixedWidth_(
+          alphabet_->type()->isFixedWidth()
+              ? alphabet_->type()->cppSizeInBytes()
+              : kVariableWidth) {
+  auto size = alphabet_->size();
+  // We reserve the size. The assumption is that we run this on an alphabet of a
+  // dictionary vector in preparation for adding elements, so the values are
+  // expected to be distinct.
+  if (isString_) {
+    distinctStrings_.reserve(size);
+  } else {
+    distinctSet_.reserve(size);
+  }
+  for (auto i = 0; i < size; ++i) {
+    addOne(*alphabet_, i, false);
+  }
+}
+
+VectorMap::VectorMap(
+    const TypePtr& type,
+    memory::MemoryPool* pool,
+    int32_t reserve)
+    : isString_(
+          type->kind() == TypeKind::VARCHAR ||
+          type->kind() == TypeKind::VARBINARY),
+      fixedWidth_(
+          type->isFixedWidth() ? type->cppSizeInBytes() : kVariableWidth) {
+  alphabetOwned_ = BaseVector::create(type, 0, pool);
+  alphabet_ = alphabetOwned_.get();
+  if (isString_) {
+    distinctStrings_.reserve(reserve);
+  } else {
+    distinctSet_.reserve(reserve);
+  }
+}
+
+vector_size_t VectorMap::addOne(
+    const BaseVector& topVector,
+    vector_size_t topIndex,
+    bool insertToAlphabet) {
+  const BaseVector* vector = &topVector;
+  vector_size_t index = topIndex;
+  if (topVector.encoding() != VectorEncoding::Simple::FLAT) {
+    vector = topVector.wrappedVector();
+    index = topVector.wrappedIndex(topIndex);
+  }
+  if (LIKELY(isString_)) {
+    StringView string;
+    bool isNull = vector->isNullAt(index);
+    if (UNLIKELY(isNull)) {
+      if (nullIndex_ != kNoNullIndex) {
+        return nullIndex_;
+      }
+    } else {
+      if (LIKELY(vector->encoding() == VectorEncoding::Simple::FLAT)) {
+        string = vector->asUnchecked<FlatVector<StringView>>()->valueAt(index);
+      } else {
+        string = vector->asUnchecked<ConstantVector<StringView>>()->valueAt(0);
+      }
+      auto it = distinctStrings_.find(string);
+      if (it != distinctStrings_.end()) {
+        return it->second;
+      }
+    }
+  } else {
+    auto it = distinctSet_.find(VectorValueSetEntry{vector, index});
+    if (it != distinctSet_.end()) {
+      return it->index;
+    }
+  }
+  int32_t newIndex;
+  if (insertToAlphabet) {
+    VELOX_CHECK(alphabet_ == alphabetOwned_.get());
+    newIndex = alphabet_->size();
+    alphabet_->resize(newIndex + 1);
+    alphabetSizes_.resize(newIndex + 1);
+    alphabet_->copy(vector, newIndex, index, 1);
+  } else {
+    newIndex = topIndex;
+    if (alphabetSizes_.size() < newIndex + 1) {
+      alphabetSizes_.resize(newIndex + 1);
+    }
+  }
+  const bool isNull = vector->isNullAt(index);
+  if (isNull) {
+    alphabetSizes_[newIndex] = 0;
+    nullIndex_ = newIndex;
+  } else if (isString_) {
+    // Add 4 for length.
+    alphabetSizes_[newIndex] = alphabet_->asUnchecked<FlatVector<StringView>>()
+                                   ->valueAt(newIndex)
+                                   .size() +
+        4;
+  } else if (fixedWidth_ == kVariableWidth) {
+    Scratch scratch;
+    ScratchPtr<vector_size_t, 1> indicesHolder(scratch);
+    ScratchPtr<vector_size_t*, 1> sizesHolder(scratch);
+    auto sizeIndices = indicesHolder.get(1);
+    sizeIndices[0] = newIndex;
+    auto sizes = sizesHolder.get(1);
+    alphabetSizes_[newIndex] = 0;
+    sizes[0] = &alphabetSizes_[newIndex];
+    getVectorSerde()->estimateSerializedSize(
+        alphabet_,
+        folly::Range<const vector_size_t*>(sizeIndices, 1),
+        sizes,
+        scratch);
+  }
+  if (isString_) {
+    if (!isNull) {
+      distinctStrings_[alphabet_->asUnchecked<FlatVector<StringView>>()
+                           ->valueAt(newIndex)] = newIndex;
+    }
+  } else {
+    distinctSet_.insert(VectorValueSetEntry{alphabet_, newIndex});
+  }
+  return newIndex;
+}
+
+void VectorMap::addMultiple(
+    BaseVector& vector,
+    folly::Range<const vector_size_t*> rows,
+    bool insertToAlphabet,
+    vector_size_t* ids) {
+  auto size = rows.size();
+  for (auto i = 0; i < size; ++i) {
+    ids[i] = addOne(vector, rows[i], insertToAlphabet);
+  }
+}
+
+} // namespace facebook::velox

--- a/velox/vector/VectorMap.h
+++ b/velox/vector/VectorMap.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/container/F14Set.h>
+#include "velox/common/base/RawVector.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::velox {
+
+struct VectorValueSetEntry {
+  const BaseVector* vector;
+  vector_size_t index;
+};
+
+struct VectorValueSetHasher {
+  size_t operator()(const VectorValueSetEntry& entry) const {
+    return entry.vector->hashValueAt(entry.index);
+  }
+};
+
+struct VectorValueSetComparer {
+  bool operator()(
+      const VectorValueSetEntry& left,
+      const VectorValueSetEntry& right) const {
+    return left.vector->equalValueAt(right.vector, left.index, right.index);
+  }
+};
+
+using VectorValueSet = folly::F14FastSet<
+    VectorValueSetEntry,
+    VectorValueSetHasher,
+    VectorValueSetComparer>;
+
+/// A map translating values in a vector to positions in an alphabet
+/// vector. if the values are complex type or variable length, also
+/// keeps track of the serialized size of the values. Usable for
+/// ad-hoc reencoding for serialization.
+class VectorMap {
+ public:
+  // Constructs 'this' to index the distinct elements in 'alphabet'. 'alphabet'
+  // is not changed and not owned. For example, when concatenating two
+  // dictionaries, the first initializes the map.
+  explicit VectorMap(BaseVector& alphabet);
+
+  // Constructs an empty map initializing alphabet to an empty vector of 'type'.
+  // Alphabet is owned. 'reserve' is the expected count of distinct values.
+  VectorMap(
+      const TypePtr& type,
+      memory::MemoryPool* pool,
+      int32_t reserve = 32);
+
+  /// Assigns a zero-based id to each distinct value in 'vector' at positions
+  /// 'rows'. The ids are returned in 'ids'. If insertToAlphabet is true and the
+  /// value is not previously in alphabet_, the value is added to it. Alphabet
+  /// must be owned if insertToAlphabet is true.
+  void addMultiple(
+      BaseVector& vector,
+      folly::Range<const vector_size_t*> rows,
+      bool insertToAlphabet,
+      vector_size_t* ids);
+
+  // Gets/assigns s an id to single value. The meaning of parameters is as in
+  // addMultiple().
+  vector_size_t addOne(
+      const BaseVector& vector,
+      vector_size_t row,
+      bool insertToAlphabet = true);
+
+  /// Returns the number of distinct values in 'this'.
+  vector_size_t size() const {
+    return isString_ ? distinctStrings_.size() + (nullIndex_ != kNoNullIndex)
+                     : distinctSet_.size();
+  }
+
+  /// Returns the approximate serialized binary length of the 'index'th value in
+  /// 'alphabet_'. The type must be a variable length type.
+  vector_size_t lengthAt(vector_size_t index) const {
+    VELOX_DCHECK_EQ(fixedWidth_, kVariableWidth);
+    return alphabetSizes_[index];
+  }
+
+  const VectorPtr& alphabetOwned() const {
+    return alphabetOwned_;
+  }
+
+ private:
+  static constexpr vector_size_t kNoNullIndex = -1;
+  static constexpr int32_t kVariableWidth = -1;
+
+  // Vector containing all the distinct values.
+  BaseVector* alphabet_;
+
+  // Optional owning pointer to 'alphabet_'.
+  VectorPtr alphabetOwned_;
+
+  // Map from value in 'alphabet_' to the index in 'alphabet_'.
+  VectorValueSet distinctSet_;
+
+  // Map from string value in 'alphabet_' to index in 'alphabet_'. Used only if
+  // 'alphabet_' is a FlatVector<StringView>.
+  folly::F14FastMap<StringView, int32_t> distinctStrings_;
+
+  // Index of null value in 'alphabet_'.
+  vector_size_t nullIndex_{kNoNullIndex};
+
+  // Serialized size estimate for the corresponding element of 'alphabet'.
+  raw_vector<vector_size_t> alphabetSizes_;
+
+  // True if  using 'distinctStrings_'
+  const bool isString_;
+
+  const int32_t fixedWidth_;
+};
+
+} // namespace facebook::velox

--- a/velox/vector/VectorStream.cpp
+++ b/velox/vector/VectorStream.cpp
@@ -171,7 +171,7 @@ void VectorStreamGroup::flush(OutputStream* out) {
 
 // static
 void VectorStreamGroup::estimateSerializedSize(
-    VectorPtr vector,
+    const BaseVector* vector,
     const folly::Range<const IndexRange*>& ranges,
     vector_size_t** sizes,
     Scratch& scratch) {
@@ -180,7 +180,7 @@ void VectorStreamGroup::estimateSerializedSize(
 
 // static
 void VectorStreamGroup::estimateSerializedSize(
-    VectorPtr vector,
+    const BaseVector* vector,
     folly::Range<const vector_size_t*> rows,
     vector_size_t** sizes,
     Scratch& scratch) {

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -133,7 +133,7 @@ class VectorSerde {
 
   /// Adds the serialized size of vector at 'rows[i]' to '*sizes[i]'.
   virtual void estimateSerializedSize(
-      VectorPtr vector,
+      const BaseVector* /*vector*/,
       folly::Range<const vector_size_t*> rows,
       vector_size_t** sizes,
       Scratch& scratch) {
@@ -143,7 +143,7 @@ class VectorSerde {
   /// Adds the serialized sizes of the rows of 'vector' in 'ranges[i]' to
   /// '*sizes[i]'.
   virtual void estimateSerializedSize(
-      VectorPtr vector,
+      const BaseVector* /*vector*/,
       const folly::Range<const IndexRange*>& ranges,
       vector_size_t** sizes,
       Scratch& scratch) {
@@ -151,7 +151,7 @@ class VectorSerde {
   }
 
   virtual void estimateSerializedSize(
-      VectorPtr vector,
+      const BaseVector* vector,
       const folly::Range<const IndexRange*>& ranges,
       vector_size_t** sizes) {
     Scratch scratch;
@@ -253,19 +253,19 @@ class VectorStreamGroup : public StreamArena {
 
   /// Increments sizes[i] for each ith row in 'rows' in 'vector'.
   static void estimateSerializedSize(
-      VectorPtr vector,
+      const BaseVector* vector,
       folly::Range<const vector_size_t*> rows,
       vector_size_t** sizes,
       Scratch& scratch);
 
   static void estimateSerializedSize(
-      VectorPtr vector,
+      const BaseVector* vector,
       const folly::Range<const IndexRange*>& ranges,
       vector_size_t** sizes,
       Scratch& scratch);
 
   static inline void estimateSerializedSize(
-      VectorPtr vector,
+      const BaseVector* vector,
       const folly::Range<const IndexRange*>& ranges,
       vector_size_t** sizes) {
     Scratch scratch;

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(
   LazyVectorTest.cpp
   MayHaveNullsRecursiveTest.cpp
   VariantToVectorTest.cpp
+  EncodingTest.cpp
   VectorTestUtils.cpp)
 
 add_test(velox_vector_test velox_vector_test)

--- a/velox/vector/tests/EncodingTest.cpp
+++ b/velox/vector/tests/EncodingTest.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/vector/VectorMap.h"
+#include "velox/vector/tests/VectorTestUtils.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+
+class EncodingTest : public testing::Test, public test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+    if (!isRegisteredVectorSerde()) {
+      facebook::velox::serializer::presto::PrestoVectorSerde::
+          registerVectorSerde();
+    }
+  }
+
+  EncodingTest() = default;
+
+  template <typename T>
+  T testValue(int32_t i, BufferPtr& space) {
+    return i;
+  }
+
+  VectorPtr mapFromScalar(VectorPtr vector, int itemsPerMap) {
+    auto keys = makeFlatVector<int32_t>(
+        vector->size(), [&](auto row) { return row % itemsPerMap; });
+    auto numMaps = bits::roundUp(vector->size(), itemsPerMap) / itemsPerMap;
+    auto sizes = makeIndices(numMaps, [&](auto) { return itemsPerMap; });
+    auto offsets =
+        makeIndices(numMaps, [&](auto row) { return row * itemsPerMap; });
+    return std::make_shared<MapVector>(
+        pool_.get(),
+        MAP(keys->type(), vector->type()),
+        BufferPtr(nullptr),
+        numMaps,
+        offsets,
+        sizes,
+        keys,
+        vector);
+  }
+
+  template <TypeKind KIND>
+  VectorPtr createScalar(
+      TypePtr type,
+      vector_size_t size,
+      int32_t numDistinct,
+      int32_t step,
+      bool withNulls) {
+    using T = typename TypeTraits<KIND>::NativeType;
+    BufferPtr buffer;
+    VectorPtr base = BaseVector::create(type, size, pool());
+    auto flat = std::dynamic_pointer_cast<FlatVector<T>>(base);
+    for (int32_t i = 0; i < flat->size(); ++i) {
+      if (withNulls && i % 3 == 0) {
+        flat->setNull(i, true);
+      } else {
+        flat->set(i, testValue<T>((i % numDistinct) * step, buffer));
+      }
+    }
+    return base;
+  }
+
+  template <TypeKind kind>
+  void checkTypeEncoding(const TypePtr& type) {
+    auto vector = createScalar<kind>(type, 1000, 1, 0, false);
+    auto constant = BaseVector::constantify(vector);
+    assertEqualVectors(vector, constant);
+    auto indices =
+        makeIndices(vector->size(), [](auto row) { return row / 2; });
+    auto wrappedVector = BaseVector::wrapInDictionary(
+        BufferPtr(nullptr), indices, vector->size(), vector);
+    assertEqualVectors(constant, BaseVector::constantify(wrappedVector));
+
+    auto row = makeRowVector({"c0"}, {vector});
+    auto constantRow = BaseVector::constantify(row);
+    assertEqualVectors(row, constantRow);
+
+    vector = createScalar<kind>(type, 1000, 1, 0, true);
+    // A nullable vector does not make a constant.
+    EXPECT_TRUE(BaseVector::constantify(vector) == nullptr);
+    // It has 2 values, null and the single value.
+    checkDictionarize(vector, 2);
+
+    if (kind == TypeKind::BOOLEAN || kind == TypeKind::TINYINT) {
+      return;
+    }
+
+    vector = createScalar<kind>(type, 1000, 1000, 1, false);
+
+    // A vector with different values does not make a constant.
+    EXPECT_TRUE(BaseVector::constantify(vector) == nullptr);
+    checkDictionarize(vector, 1000);
+    row = makeRowVector({"c0"}, {vector});
+    EXPECT_TRUE(BaseVector::constantify(row) == nullptr);
+
+    checkDictionarize(row, 1000);
+
+    vector = createScalar<kind>(type, 1000, 10, 1, false);
+    // The vector has values repeating in in a 10 value cycle. If each 10 values
+    // are map values with the same key, the map from the base is constant. If
+    // we take every 5 consecutive values as map values with the same keys, we
+    // have 2 distinct maps.
+    auto map = mapFromScalar(vector, 10);
+    auto constantMap = BaseVector::constantify(map);
+    assertEqualVectors(map, constantMap);
+    map = mapFromScalar(vector, 5);
+    EXPECT_TRUE(BaseVector::constantify(map) == nullptr);
+    checkDictionarize(map, 2);
+  }
+
+  void checkDictionarize(const VectorPtr& vector, int expectDistincts) {
+    auto indices =
+        AlignedBuffer::allocate<vector_size_t>(vector->size(), pool_.get());
+    VectorMap map(*vector);
+    EXPECT_EQ(expectDistincts, map.size());
+
+    VectorMap map2(vector->type(), pool_.get());
+    raw_vector<vector_size_t> temp;
+    folly::Range<const vector_size_t*> rows(
+        iota(vector->size(), temp), vector->size());
+    map2.addMultiple(*vector, rows, true, indices->asMutable<vector_size_t>());
+    EXPECT_EQ(expectDistincts, map2.size());
+    assertEqualVectors(
+        vector,
+        BaseVector::wrapInDictionary(
+            BufferPtr(nullptr), indices, vector->size(), map2.alphabetOwned()));
+    if (vector->typeKind() == TypeKind::VARCHAR ||
+        vector->typeKind() == TypeKind::VARBINARY) {
+      for (auto i = 0; i < vector->size(); ++i) {
+        auto length = vector->isNullAt(i)
+            ? 0
+            : vector->as<SimpleVector<StringView>>()->valueAt(i).size() + 4;
+        EXPECT_EQ(map2.lengthAt(indices->as<int32_t>()[i]), length);
+      }
+    }
+  }
+};
+
+template <>
+int128_t EncodingTest::testValue<int128_t>(int32_t i, BufferPtr& /*space*/) {
+  return HugeInt::build(i % 2 ? (i * -1) : i, 0xAAAAAAAAAAAAAAAA);
+}
+
+template <>
+StringView EncodingTest::testValue(int32_t n, BufferPtr& buffer) {
+  if (!buffer || buffer->capacity() < 1000) {
+    buffer = AlignedBuffer::allocate<char>(1000, pool());
+  }
+  std::stringstream out;
+  out << n;
+  for (int32_t i = 0; i < n % 20; ++i) {
+    out << " " << i * i;
+  }
+  std::string str = out.str();
+  EXPECT_LE(str.size(), buffer->capacity());
+  memcpy(buffer->asMutable<char>(), str.data(), str.size());
+  return StringView(buffer->as<char>(), str.size());
+}
+
+template <>
+bool EncodingTest::testValue(int32_t i, BufferPtr& /*space*/) {
+  return (i % 2) == 1;
+}
+
+template <>
+Timestamp EncodingTest::testValue(int32_t i, BufferPtr& /*space*/) {
+  // Return even milliseconds.
+  return Timestamp(i * 1000, (i % 1000) * 1000000);
+}
+
+TEST_F(EncodingTest, basic) {
+  checkTypeEncoding<TypeKind::BOOLEAN>(BOOLEAN());
+  checkTypeEncoding<TypeKind::TINYINT>(TINYINT());
+  checkTypeEncoding<TypeKind::SMALLINT>(SMALLINT());
+  checkTypeEncoding<TypeKind::INTEGER>(INTEGER());
+  checkTypeEncoding<TypeKind::BIGINT>(BIGINT());
+  checkTypeEncoding<TypeKind::VARCHAR>(VARCHAR());
+  checkTypeEncoding<TypeKind::TIMESTAMP>(TIMESTAMP());
+}

--- a/velox/vector/tests/VectorStreamTest.cpp
+++ b/velox/vector/tests/VectorStreamTest.cpp
@@ -21,7 +21,7 @@ namespace facebook::velox::test {
 
 class MockVectorSerde : public VectorSerde {
   void estimateSerializedSize(
-      VectorPtr vector,
+      const BaseVector* /*vector*/,
       const folly::Range<const IndexRange*>& ranges,
       vector_size_t** sizes) override {}
 

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -843,9 +843,9 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
     }
 
     VectorStreamGroup::estimateSerializedSize(
-        source, evenIndices, evenSizePointers.data());
+        source.get(), evenIndices, evenSizePointers.data());
     VectorStreamGroup::estimateSerializedSize(
-        source, oddIndices, oddSizePointers.data());
+        source.get(), oddIndices, oddSizePointers.data());
     even.append(
         sourceRow, folly::Range(evenIndices.data(), evenIndices.size() / 2));
     even.append(


### PR DESCRIPTION
Adds a utility for  changing vectors to
constants if all values are the same.

Adds a VectorMap class for mapping from a value in a vector to its position in another vector. This can be used for dictionarizing vectors, combining dictionaries and generally dealing with distinct values.

Adds a VectorMap class to map from values to positions in a vector of distinct values.

Changes the signature of estimatedSerializedSize so as not to require a shared pointer to the vector. This is convenient for a VectorMap made on a preexisting vector.