### PR TITLE
PrestoSerializer should check the checksum before anything else

### DIFF
--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -1188,6 +1188,46 @@ TEST_P(PrestoSerializerTest, lexer) {
   }
 }
 
+TEST_P(PrestoSerializerTest, checksum) {
+  std::ostringstream output;
+  // The payload (doesn't matter what as long as it's not 0).
+  vector_size_t data = 4;
+
+  // Write out the number of rows.
+  vector_size_t numRows = std::numeric_limits<int32_t>::max();
+  output.write(reinterpret_cast<char*>(&numRows), sizeof(numRows));
+  // Set the bit indicating there's a checksum.
+  char marker = 4;
+  output.write(&marker, sizeof(marker));
+  vector_size_t size = sizeof(data);
+  // Write out the uncompressed size and size (we're not compressing the data so
+  // they're the same).
+  output.write(reinterpret_cast<char*>(&size), sizeof(size));
+  output.write(reinterpret_cast<char*>(&size), sizeof(size));
+  // Write out the checksum, it shouldn't match the checksum of data.
+  int64_t checksum = 0;
+  output.write(reinterpret_cast<char*>(&checksum), sizeof(checksum));
+  output.write(reinterpret_cast<char*>(&data), sizeof(data));
+
+  auto paramOptions = getParamSerdeOptions(nullptr);
+  RowVectorPtr result;
+  auto serialized = output.str();
+  auto byteStream = toByteStream(serialized);
+  // Make a small memory pool, if we try to allocate a Vector with numRows we'll
+  // OOM.
+  auto pool = memory::memoryManager()->addRootPool("checksum", 1UL << 10);
+  // This should fail because the checksums don't match.
+  VELOX_ASSERT_THROW(
+      serde_->deserialize(
+          &byteStream,
+          pool->addLeafChild("child").get(),
+          ROW({BIGINT()}),
+          &result,
+          0,
+          &paramOptions),
+      "Received corrupted serialized page.");
+}
+
 INSTANTIATE_TEST_SUITE_P(
     PrestoSerializerTest,
     PrestoSerializerTest,


### PR DESCRIPTION
Summary:
Today, when deserializing, PrestoSerializer reads the header, allocates a RowVector of size `numRows` and then checks the checksum.

We should check the checksum before allocating the RowVector.  Admittedly, `numRows` isn't included in the checksum so local corruptions of `numRows` can't be detected, but if the serialized data is complete garbage `numRows` could be huge and the MemoryPool could end up OOM'ing.  By checking the checksum first we get a clearer error message that better points to the true issue.

Differential Revision: D54284594


