### PR TITLE
Add support for returning results as Velox Vectors to ReferenceQueryRunner

### DIFF
--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -491,6 +491,13 @@ std::multiset<std::vector<variant>> PrestoQueryRunner::execute(
     const std::string& sql,
     const std::vector<RowVectorPtr>& input,
     const RowTypePtr& resultType) {
+  return exec::test::materialize(executeVector(sql, input, resultType));
+}
+
+std::vector<velox::RowVectorPtr> PrestoQueryRunner::executeVector(
+    const std::string& sql,
+    const std::vector<velox::RowVectorPtr>& input,
+    const velox::RowTypePtr& resultType) {
   auto inputType = asRowType(input[0]->type());
   if (inputType->size() == 0) {
     // The query doesn't need to read any columns, but it needs to see a
@@ -509,7 +516,7 @@ std::multiset<std::vector<variant>> PrestoQueryRunner::execute(
         nullptr,
         numInput,
         std::vector<VectorPtr>{column});
-    return execute(sql, {rowVector}, resultType);
+    return executeVector(sql, {rowVector}, resultType);
   }
 
   // Create tmp table in Presto using DWRF file format and add a single
@@ -548,9 +555,7 @@ std::multiset<std::vector<variant>> PrestoQueryRunner::execute(
   writeToFile(newFilePath, input, writerPool.get());
 
   // Run the query.
-  results = execute(sql);
-
-  return exec::test::materialize(results);
+  return execute(sql);
 }
 
 std::vector<RowVectorPtr> PrestoQueryRunner::execute(const std::string& sql) {
@@ -609,6 +614,10 @@ std::string PrestoQueryRunner::fetchNext(const std::string& nextUri) {
       nextUri,
       response.error.message);
   return response.text;
+}
+
+bool PrestoQueryRunner::supportsVeloxVectorResults() const {
+  return true;
 }
 
 } // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/PrestoQueryRunner.h
+++ b/velox/exec/fuzzer/PrestoQueryRunner.h
@@ -60,6 +60,13 @@ class PrestoQueryRunner : public velox::exec::test::ReferenceQueryRunner {
   /// the query must already exist.
   std::vector<velox::RowVectorPtr> execute(const std::string& sql);
 
+  bool supportsVeloxVectorResults() const override;
+
+  std::vector<RowVectorPtr> executeVector(
+      const std::string& sql,
+      const std::vector<RowVectorPtr>& input,
+      const RowTypePtr& resultType) override;
+
  private:
   velox::memory::MemoryPool* rootPool() {
     return rootPool_.get();

--- a/velox/exec/fuzzer/ReferenceQueryRunner.h
+++ b/velox/exec/fuzzer/ReferenceQueryRunner.h
@@ -35,6 +35,21 @@ class ReferenceQueryRunner {
       const std::string& sql,
       const std::vector<RowVectorPtr>& input,
       const RowTypePtr& resultType) = 0;
+
+  /// Returns true if 'executeVector' can be called to get results as Velox
+  /// Vector.
+  virtual bool supportsVeloxVectorResults() const {
+    return false;
+  }
+
+  /// Similar to 'execute' but returns results in RowVector format.
+  /// Caller should ensure 'supportsVeloxVectorResults' returns true.
+  virtual std::vector<RowVectorPtr> executeVector(
+      const std::string& sql,
+      const std::vector<RowVectorPtr>& input,
+      const RowTypePtr& resultType) {
+    VELOX_UNSUPPORTED();
+  }
 };
 
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
**What**
This PR adds support for the ReferenceQueryRunner to return results in Velox vector format. To do this we add function supportsVeloxVectorResults which returns true if the  Query Runner supports returning results in RowVector format. At the moment only PrestoQueryRunner supports returning the results of executing an SQL query as Velox vectors.

**Why**
Adding support for getting the results as a Velox Vector will allow us to call the compare() api for certain nondeterministic functions that have custom result verifiers. This will allow us to compare results where the output of the reference db differs from Velox for e.g in cases where the ordering is different, and ensure the results of the function are correct. 
Currently we are only able to do this for sorted input for certain plans (Single aggregation); with the above support we will be able to do it for unsorted input also. 

**Note**
The support to use this in the aggregation fuzzer will follow in another PR. 