### PR TITLE
Delete createSerializer from the VectorSerde class

### DIFF
--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -383,8 +383,8 @@ class PrestoSerializerTest
     auto concatenation = BaseVector::create(rowType, 0, pool_.get());
     auto arena = std::make_unique<StreamArena>(pool_.get());
     auto paramOptions = getParamSerdeOptions(serdeOptions);
-    auto serializer =
-        serde_->createSerializer(rowType, 10, arena.get(), &paramOptions);
+    auto serializer = serde_->createIterativeSerializer(
+        rowType, 10, arena.get(), &paramOptions);
 
     for (const auto& vector : vectors) {
       auto data = makeRowVector({"f"}, {vector});
@@ -1213,8 +1213,8 @@ TEST_F(PrestoSerializerTest, deserializeSingleColumn) {
     auto arena = std::make_unique<StreamArena>(pool_.get());
     auto rowType = asRowType(rowVector->type());
     auto numRows = rowVector->size();
-    auto serializer =
-        serde_->createSerializer(rowType, numRows, arena.get(), nullptr);
+    auto serializer = serde_->createIterativeSerializer(
+        rowType, numRows, arena.get(), nullptr);
     serializer->append(rowVector);
     facebook::velox::serializer::presto::PrestoOutputStreamListener listener;
     OStreamOutputStream out(&output, &listener);

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -159,18 +159,6 @@ class VectorSerde {
   ///
   /// This is more appropriate if the use case involves many small writes, e.g.
   /// partitioning a RowVector across multiple destinations.
-  ///
-  /// TODO: Remove createSerializer once Presto is updated to call
-  /// createIterativeSerializer.
-  virtual std::unique_ptr<IterativeVectorSerializer> createSerializer(
-      RowTypePtr type,
-      int32_t numRows,
-      StreamArena* streamArena,
-      const Options* options = nullptr) {
-    return createIterativeSerializer(
-        std::move(type), numRows, streamArena, options);
-  }
-
   virtual std::unique_ptr<IterativeVectorSerializer> createIterativeSerializer(
       RowTypePtr type,
       int32_t numRows,


### PR DESCRIPTION
Summary:
This was deprecated and replaced with createIterativeSerializer.

All known call sites have been updated (including in Presto).

Differential Revision: D54285206


