### PR TITLE
Move folly init and gtest init before registration of functions.

### DIFF
--- a/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
@@ -73,6 +73,13 @@ getCustomInputGenerators() {
 } // namespace facebook::velox::exec::test
 
 int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // Calls common init functions in the necessary order, initializing
+  // singletons, installing proper signal handlers for better debugging
+  // experience, and initialize glog and gflags.
+  folly::Init init(&argc, &argv);
+
   // Register only presto supported signatures if we are verifying against
   // Presto.
   if (FLAGS_presto_url.empty()) {
@@ -87,13 +94,6 @@ int main(int argc, char** argv) {
   facebook::velox::window::prestosql::registerAllWindowFunctions();
   facebook::velox::functions::prestosql::registerInternalFunctions();
   facebook::velox::memory::MemoryManager::initialize({});
-
-  ::testing::InitGoogleTest(&argc, argv);
-
-  // Calls common init functions in the necessary order, initializing
-  // singletons, installing proper signal handlers for better debugging
-  // experience, and initialize glog and gflags.
-  folly::Init init(&argc, &argv);
 
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
 


### PR DESCRIPTION
Move the folly init and gtest initialization before registration of any functions. We need to do this as certain gflags  are used to determine which set of aggregate functions to register, for e.g, when running the Aggregation fuzzer with presto as source of truth we only want to register presto supported aggregate signatures. The gflags are only set when folly::init is called and as flags are uninitialized we would only register signatures not supported in Presto. 