### PR TITLE
Register companion functions for set_agg

### DIFF
--- a/velox/functions/prestosql/aggregates/SetAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/SetAggregates.cpp
@@ -479,7 +479,8 @@ void registerSetAggAggregate(const std::string& prefix) {
             VELOX_UNREACHABLE(
                 "Unexpected type {}", mapTypeKindToName(typeKind));
         }
-      });
+      },
+      /*registerCompanionFunctions*/ true);
 }
 
 void registerSetUnionAggregate(const std::string& prefix) {


### PR DESCRIPTION
Register companion functions for set_agg, so that Spark can support `PartialMerge` mode for `collect_set`