### PR TITLE
Fix NaN in Spark array_intersect and array_except functions

### DIFF
--- a/velox/functions/lib/ArrayIntersectExceptFunction.cpp
+++ b/velox/functions/lib/ArrayIntersectExceptFunction.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/lib/ArrayIntersectExceptFunction.h"
+
+namespace facebook::velox::functions {
+
+DecodedVector* decodeArrayElements(
+    exec::LocalDecodedVector& arrayDecoder,
+    exec::LocalDecodedVector& elementsDecoder,
+    const SelectivityVector& rows) {
+  auto decodedVector = arrayDecoder.get();
+  auto baseArrayVector = arrayDecoder->base()->as<ArrayVector>();
+
+  // Decode and acquire array elements vector.
+  auto elementsVector = baseArrayVector->elements();
+  auto elementsSelectivityRows = toElementRows(
+      elementsVector->size(), rows, baseArrayVector, decodedVector->indices());
+  elementsDecoder.get()->decode(*elementsVector, elementsSelectivityRows);
+  auto decodedElementsVector = elementsDecoder.get();
+  return decodedElementsVector;
+}
+
+std::vector<std::shared_ptr<exec::FunctionSignature>> signatures(
+    const std::string& returnTypeTemplate) {
+  std::vector<std::shared_ptr<exec::FunctionSignature>> signatures;
+  for (const auto& type : exec::primitiveTypeNames()) {
+    signatures.push_back(
+        exec::FunctionSignatureBuilder()
+            .returnType(
+                fmt::format(fmt::runtime(returnTypeTemplate.c_str()), type))
+            .argumentType(fmt::format("array({})", type))
+            .argumentType(fmt::format("array({})", type))
+            .build());
+  }
+  return signatures;
+}
+
+void validateMatchingArrayTypes(
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    const std::string& name,
+    vector_size_t expectedArgCount) {
+  VELOX_USER_CHECK_EQ(
+      inputArgs.size(),
+      expectedArgCount,
+      "{} requires exactly {} parameters",
+      name,
+      expectedArgCount);
+
+  auto arrayType = inputArgs.front().type;
+  VELOX_USER_CHECK_EQ(
+      arrayType->kind(),
+      TypeKind::ARRAY,
+      "{} requires arguments of type ARRAY",
+      name);
+
+  for (auto& arg : inputArgs) {
+    VELOX_USER_CHECK(
+        arrayType->kindEquals(arg.type),
+        "{} function requires all arguments of the same type: {} vs. {}",
+        name,
+        arg.type->toString(),
+        arrayType->toString());
+  }
+}
+} // namespace facebook::velox::functions

--- a/velox/functions/lib/ArrayIntersectExceptFunction.h
+++ b/velox/functions/lib/ArrayIntersectExceptFunction.h
@@ -1,0 +1,346 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/expression/VectorFunction.h"
+#include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
+
+namespace facebook::velox::functions {
+
+template <typename T>
+struct SetWithNull {
+  SetWithNull(vector_size_t initialSetSize = kInitialSetSize) {
+    set.reserve(initialSetSize);
+  }
+
+  void reset() {
+    set.clear();
+    hasNull = false;
+  }
+
+  folly::F14FastSet<T> set;
+  bool hasNull{false};
+  bool hasNaN{false};
+  static constexpr vector_size_t kInitialSetSize{128};
+};
+
+// Generates a set based on the elements of an ArrayVector. Note that we take
+// rightSet as a parameter (instead of returning a new one) to reuse the
+// allocated memory.
+template <typename T, bool recordNaN, typename TVector>
+void generateSet(
+    const ArrayVector* arrayVector,
+    const TVector* arrayElements,
+    vector_size_t idx,
+    SetWithNull<T>& rightSet) {
+  auto size = arrayVector->sizeAt(idx);
+  auto offset = arrayVector->offsetAt(idx);
+  rightSet.reset();
+
+  for (vector_size_t i = offset; i < (offset + size); ++i) {
+    if (arrayElements->isNullAt(i)) {
+      rightSet.hasNull = true;
+    } else {
+      // Function can be called with either FlatVector or DecodedVector, but
+      // their APIs are slightly different.
+      T value;
+      if constexpr (std::is_same_v<TVector, DecodedVector>) {
+        value = arrayElements->template valueAt<T>(i);
+      } else {
+        value = arrayElements->valueAt(i);
+      }
+      if constexpr (
+          recordNaN &&
+          (std::is_same_v<T, float> || std::is_same_v<T, double>)) {
+        if (std::isnan(value)) {
+          rightSet.hasNaN = true;
+        }
+      }
+      rightSet.set.insert(value);
+    }
+  }
+}
+
+DecodedVector* decodeArrayElements(
+    exec::LocalDecodedVector& arrayDecoder,
+    exec::LocalDecodedVector& elementsDecoder,
+    const SelectivityVector& rows);
+
+/// See documentation at https://prestodb.io/docs/current/functions/array.html
+/// @tparam isIntersect: if true, the function is array_intersect, otherwise
+/// array_except.
+/// @tparam equalNaN: if true, NaN is considered equal to NaN, otherwise it is
+/// not.
+/// @tparam T: the type of the array elements.
+template <bool isIntersect, bool equalNaN, typename T>
+class ArrayIntersectExceptFunction : public exec::VectorFunction {
+ public:
+  /// This class is used for both array_intersect and array_except functions
+  /// (behavior controlled at compile time by the isIntersect template
+  /// variable). Both these functions take two ArrayVectors as inputs (left and
+  /// right) and leverage two sets to calculate the intersection (or except):
+  ///
+  /// - rightSet: a set that contains all (distinct) elements from the
+  ///   right-hand side array.
+  /// - outputSet: a set that contains the elements that were already added to
+  ///   the output (to prevent duplicates).
+  ///
+  /// Along with each set, we maintain a `hasNull` flag that indicates whether
+  /// null is present in the arrays, to prevent the use of optional types or
+  /// special values.
+  ///
+  /// Zero element copy:
+  ///
+  /// In order to prevent copies of array elements, the function reuses the
+  /// internal elements() vector from the left-hand side ArrayVector.
+  ///
+  /// First a new vector is created containing the indices of the elements
+  /// which will be present in the output, and wrapped into a DictionaryVector.
+  /// Next the `lengths` and `offsets` vectors that control where output arrays
+  /// start and end are wrapped into the output ArrayVector.
+  ///
+  /// Constant optimization:
+  ///
+  /// If the rhs values passed to either array_intersect() or array_except()
+  /// are constant (array literals) we create a set before instantiating the
+  /// object and pass as a constructor parameter (constantSet).
+
+  ArrayIntersectExceptFunction() = default;
+
+  explicit ArrayIntersectExceptFunction(SetWithNull<T> constantSet)
+      : constantSet_(std::move(constantSet)) {}
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    memory::MemoryPool* pool = context.pool();
+    BaseVector* left = args[0].get();
+    BaseVector* right = args[1].get();
+
+    exec::LocalDecodedVector leftHolder(context, *left, rows);
+    auto decodedLeftArray = leftHolder.get();
+    auto baseLeftArray = decodedLeftArray->base()->as<ArrayVector>();
+
+    // Decode and acquire array elements vector.
+    exec::LocalDecodedVector leftElementsDecoder(context);
+    auto decodedLeftElements =
+        decodeArrayElements(leftHolder, leftElementsDecoder, rows);
+
+    auto leftElementsCount =
+        countElements<ArrayVector>(rows, *decodedLeftArray);
+    vector_size_t rowCount = left->size();
+
+    // Allocate new vectors for indices, nulls, length and offsets.
+    BufferPtr newIndices = allocateIndices(leftElementsCount, pool);
+    BufferPtr newElementNulls =
+        AlignedBuffer::allocate<bool>(leftElementsCount, pool, bits::kNotNull);
+    BufferPtr newLengths = allocateSizes(rowCount, pool);
+    BufferPtr newOffsets = allocateOffsets(rowCount, pool);
+
+    // Pointers and cursors to the raw data.
+    auto rawNewIndices = newIndices->asMutable<vector_size_t>();
+    auto rawNewElementNulls = newElementNulls->asMutable<uint64_t>();
+    auto rawNewLengths = newLengths->asMutable<vector_size_t>();
+    auto rawNewOffsets = newOffsets->asMutable<vector_size_t>();
+
+    vector_size_t indicesCursor = 0;
+
+    // Lambda that process each row. This is detached from the code so we can
+    // apply it differently based on whether the right-hand side set is constant
+    // or not.
+    auto processRow = [&](vector_size_t row,
+                          const SetWithNull<T>& rightSet,
+                          SetWithNull<T>& outputSet) {
+      auto idx = decodedLeftArray->index(row);
+      auto size = baseLeftArray->sizeAt(idx);
+      auto offset = baseLeftArray->offsetAt(idx);
+      bool hasNaN = false;
+
+      outputSet.reset();
+      rawNewOffsets[row] = indicesCursor;
+
+      // Scans the array elements on the left-hand side.
+      for (vector_size_t i = offset; i < (offset + size); ++i) {
+        if (decodedLeftElements->isNullAt(i)) {
+          // For a NULL value not added to the output row yet, insert in
+          // array_intersect if it was found on the rhs (and not found in the
+          // case of array_except).
+          if (!outputSet.hasNull) {
+            bool setNull = false;
+            if constexpr (isIntersect) {
+              setNull = rightSet.hasNull;
+            } else {
+              setNull = !rightSet.hasNull;
+            }
+            if (setNull) {
+              bits::setNull(rawNewElementNulls, indicesCursor++, true);
+              outputSet.hasNull = true;
+            }
+          }
+        } else {
+          auto val = decodedLeftElements->valueAt<T>(i);
+          // For array_intersect, add the element if it is found (not found
+          // for array_except) in the right-hand side, and wasn't added already
+          // (check outputSet).
+          bool addValue = false;
+          constexpr bool isFloating =
+              std::is_same_v<T, float> || std::is_same_v<T, double>;
+          if constexpr (isIntersect) {
+            bool addNaN = false;
+            if constexpr (equalNaN && isFloating) {
+              // For a NaN value not added to the output row yet, insert in
+              // array_intersect if it was found on the rhs (and not found in
+              // the case of array_except).
+              addNaN = rightSet.hasNaN && std::isnan(val);
+            }
+            addValue = rightSet.set.count(val) > 0 || addNaN;
+          } else {
+            bool addNaN = true;
+            if constexpr (equalNaN && isFloating) {
+              addNaN = !rightSet.hasNaN || !std::isnan(val);
+            }
+            addValue = rightSet.set.count(val) == 0 && addNaN;
+          }
+          if (addValue) {
+            auto it = outputSet.set.insert(val);
+            if (it.second) {
+              rawNewIndices[indicesCursor++] = i;
+            }
+          }
+        }
+      }
+      rawNewLengths[row] = indicesCursor - rawNewOffsets[row];
+    };
+
+    SetWithNull<T> outputSet;
+
+    // Optimized case when the right-hand side array is constant.
+    if (constantSet_.has_value()) {
+      rows.applyToSelected([&](vector_size_t row) {
+        processRow(row, *constantSet_, outputSet);
+      });
+    }
+    // General case when no arrays are constant and both sets need to be
+    // computed for each row.
+    else {
+      exec::LocalDecodedVector rightHolder(context, *right, rows);
+      // Decode and acquire array elements vector.
+      exec::LocalDecodedVector rightElementsHolder(context);
+      auto decodedRightElements =
+          decodeArrayElements(rightHolder, rightElementsHolder, rows);
+      SetWithNull<T> rightSet;
+      auto rightArrayVector = rightHolder.get()->base()->as<ArrayVector>();
+      rows.applyToSelected([&](vector_size_t row) {
+        auto idx = rightHolder.get()->index(row);
+        generateSet<T, equalNaN>(
+            rightArrayVector, decodedRightElements, idx, rightSet);
+        processRow(row, rightSet, outputSet);
+      });
+    }
+
+    auto newElements = BaseVector::wrapInDictionary(
+        newElementNulls, newIndices, indicesCursor, baseLeftArray->elements());
+    auto resultArray = std::make_shared<ArrayVector>(
+        pool,
+        outputType,
+        nullptr,
+        rowCount,
+        newOffsets,
+        newLengths,
+        newElements);
+    context.moveOrCopyResult(resultArray, rows, result);
+  }
+
+  // If one of the arrays is constant, this member will store a pointer to the
+  // set generated from its elements, which is calculated only once, before
+  // instantiating this object.
+  std::optional<SetWithNull<T>> constantSet_;
+}; // class ArrayIntersectExcept
+
+template <typename T, bool recordNaN>
+SetWithNull<T> validateConstantVectorAndGenerateSet(
+    const BaseVector* baseVector) {
+  auto constantVector = baseVector->as<ConstantVector<velox::ComplexType>>();
+  auto constantArray = constantVector->as<ConstantVector<velox::ComplexType>>();
+  VELOX_CHECK_NOT_NULL(constantArray, "wrong constant type found");
+  VELOX_CHECK_NOT_NULL(constantVector, "wrong constant type found");
+  auto arrayVecPtr = constantVector->valueVector()->as<ArrayVector>();
+  VELOX_CHECK_NOT_NULL(arrayVecPtr, "wrong array literal type");
+
+  auto idx = constantArray->index();
+  auto elementBegin = arrayVecPtr->offsetAt(idx);
+  auto elementEnd = elementBegin + arrayVecPtr->sizeAt(idx);
+
+  SelectivityVector rows{elementEnd, false};
+  rows.setValidRange(elementBegin, elementEnd, true);
+  rows.updateBounds();
+
+  DecodedVector decodedElements{*arrayVecPtr->elements(), rows};
+
+  SetWithNull<T> constantSet;
+  generateSet<T, recordNaN>(arrayVecPtr, &decodedElements, idx, constantSet);
+  return constantSet;
+}
+
+template <bool isIntersect, TypeKind kind>
+std::shared_ptr<exec::VectorFunction> createTypedArraysIntersectExcept(
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    bool equalNaN) {
+  using T = typename TypeTraits<kind>::NativeType;
+
+  VELOX_CHECK_EQ(inputArgs.size(), 2);
+  BaseVector* rhs = inputArgs[1].constantValue.get();
+
+  // We don't optimize the case where lhs is a constant expression for
+  // array_intersect() because that would make this function non-deterministic.
+  // For example, a constant lhs would mean the constantSet is created based on
+  // lhs; the same data encoded as a regular column could result in the set
+  // being created based on rhs. Running this function with different sets could
+  // results in arrays in different orders.
+  //
+  // If rhs is a constant value:
+  if (rhs != nullptr) {
+    if (equalNaN) {
+      return std::make_shared<
+          ArrayIntersectExceptFunction<isIntersect, true, T>>(
+          validateConstantVectorAndGenerateSet<T, true>(rhs));
+    } else {
+      return std::make_shared<
+          ArrayIntersectExceptFunction<isIntersect, false, T>>(
+          validateConstantVectorAndGenerateSet<T, false>(rhs));
+    }
+  } else {
+    if (equalNaN) {
+      return std::make_shared<
+          ArrayIntersectExceptFunction<isIntersect, true, T>>();
+    } else {
+      return std::make_shared<
+          ArrayIntersectExceptFunction<isIntersect, false, T>>();
+    }
+  }
+}
+
+void validateMatchingArrayTypes(
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    const std::string& name,
+    vector_size_t expectedArgCount);
+
+std::vector<std::shared_ptr<exec::FunctionSignature>> signatures(
+    const std::string& returnTypeTemplate);
+
+} // namespace facebook::velox::functions

--- a/velox/functions/lib/CMakeLists.txt
+++ b/velox/functions/lib/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(velox_functions_util velox_vector velox_common_base)
 
 add_library(
   velox_functions_lib
+  ArrayIntersectExceptFunction.cpp
   CheckDuplicateKeys.cpp
   DateTimeFormatter.cpp
   DateTimeFormatterBuilder.cpp

--- a/velox/functions/prestosql/ArrayIntersectExcept.cpp
+++ b/velox/functions/prestosql/ArrayIntersectExcept.cpp
@@ -13,245 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/expression/VectorFunction.h"
-#include "velox/functions/lib/LambdaFunctionUtil.h"
-#include "velox/functions/lib/RowsTranslationUtil.h"
+#include "velox/functions/lib/ArrayIntersectExceptFunction.h"
 
 namespace facebook::velox::functions {
 namespace {
-template <typename T>
-
-struct SetWithNull {
-  SetWithNull(vector_size_t initialSetSize = kInitialSetSize) {
-    set.reserve(initialSetSize);
-  }
-
-  void reset() {
-    set.clear();
-    hasNull = false;
-  }
-
-  folly::F14FastSet<T> set;
-  bool hasNull{false};
-  static constexpr vector_size_t kInitialSetSize{128};
-};
-// Generates a set based on the elements of an ArrayVector. Note that we take
-// rightSet as a parameter (instead of returning a new one) to reuse the
-// allocated memory.
-template <typename T, typename TVector>
-void generateSet(
-    const ArrayVector* arrayVector,
-    const TVector* arrayElements,
-    vector_size_t idx,
-    SetWithNull<T>& rightSet) {
-  auto size = arrayVector->sizeAt(idx);
-  auto offset = arrayVector->offsetAt(idx);
-  rightSet.reset();
-
-  for (vector_size_t i = offset; i < (offset + size); ++i) {
-    if (arrayElements->isNullAt(i)) {
-      rightSet.hasNull = true;
-    } else {
-      // Function can be called with either FlatVector or DecodedVector, but
-      // their APIs are slightly different.
-      if constexpr (std::is_same_v<TVector, DecodedVector>) {
-        rightSet.set.insert(arrayElements->template valueAt<T>(i));
-      } else {
-        rightSet.set.insert(arrayElements->valueAt(i));
-      }
-    }
-  }
-}
-
-DecodedVector* decodeArrayElements(
-    exec::LocalDecodedVector& arrayDecoder,
-    exec::LocalDecodedVector& elementsDecoder,
-    const SelectivityVector& rows) {
-  auto decodedVector = arrayDecoder.get();
-  auto baseArrayVector = arrayDecoder->base()->as<ArrayVector>();
-
-  // Decode and acquire array elements vector.
-  auto elementsVector = baseArrayVector->elements();
-  auto elementsSelectivityRows = toElementRows(
-      elementsVector->size(), rows, baseArrayVector, decodedVector->indices());
-  elementsDecoder.get()->decode(*elementsVector, elementsSelectivityRows);
-  auto decodedElementsVector = elementsDecoder.get();
-  return decodedElementsVector;
-}
-
-// See documentation at https://prestodb.io/docs/current/functions/array.html
-template <bool isIntersect, typename T>
-class ArrayIntersectExceptFunction : public exec::VectorFunction {
- public:
-  /// This class is used for both array_intersect and array_except functions
-  /// (behavior controlled at compile time by the isIntersect template
-  /// variable). Both these functions take two ArrayVectors as inputs (left and
-  /// right) and leverage two sets to calculate the intersection (or except):
-  ///
-  /// - rightSet: a set that contains all (distinct) elements from the
-  ///   right-hand side array.
-  /// - outputSet: a set that contains the elements that were already added to
-  ///   the output (to prevent duplicates).
-  ///
-  /// Along with each set, we maintain a `hasNull` flag that indicates whether
-  /// null is present in the arrays, to prevent the use of optional types or
-  /// special values.
-  ///
-  /// Zero element copy:
-  ///
-  /// In order to prevent copies of array elements, the function reuses the
-  /// internal elements() vector from the left-hand side ArrayVector.
-  ///
-  /// First a new vector is created containing the indices of the elements
-  /// which will be present in the output, and wrapped into a DictionaryVector.
-  /// Next the `lengths` and `offsets` vectors that control where output arrays
-  /// start and end are wrapped into the output ArrayVector.
-  ///
-  /// Constant optimization:
-  ///
-  /// If the rhs values passed to either array_intersect() or array_except()
-  /// are constant (array literals) we create a set before instantiating the
-  /// object and pass as a constructor parameter (constantSet).
-
-  ArrayIntersectExceptFunction() = default;
-
-  explicit ArrayIntersectExceptFunction(SetWithNull<T> constantSet)
-      : constantSet_(std::move(constantSet)) {}
-
-  void apply(
-      const SelectivityVector& rows,
-      std::vector<VectorPtr>& args,
-      const TypePtr& outputType,
-      exec::EvalCtx& context,
-      VectorPtr& result) const override {
-    memory::MemoryPool* pool = context.pool();
-    BaseVector* left = args[0].get();
-    BaseVector* right = args[1].get();
-
-    exec::LocalDecodedVector leftHolder(context, *left, rows);
-    auto decodedLeftArray = leftHolder.get();
-    auto baseLeftArray = decodedLeftArray->base()->as<ArrayVector>();
-
-    // Decode and acquire array elements vector.
-    exec::LocalDecodedVector leftElementsDecoder(context);
-    auto decodedLeftElements =
-        decodeArrayElements(leftHolder, leftElementsDecoder, rows);
-
-    auto leftElementsCount =
-        countElements<ArrayVector>(rows, *decodedLeftArray);
-    vector_size_t rowCount = left->size();
-
-    // Allocate new vectors for indices, nulls, length and offsets.
-    BufferPtr newIndices = allocateIndices(leftElementsCount, pool);
-    BufferPtr newElementNulls =
-        AlignedBuffer::allocate<bool>(leftElementsCount, pool, bits::kNotNull);
-    BufferPtr newLengths = allocateSizes(rowCount, pool);
-    BufferPtr newOffsets = allocateOffsets(rowCount, pool);
-
-    // Pointers and cursors to the raw data.
-    auto rawNewIndices = newIndices->asMutable<vector_size_t>();
-    auto rawNewElementNulls = newElementNulls->asMutable<uint64_t>();
-    auto rawNewLengths = newLengths->asMutable<vector_size_t>();
-    auto rawNewOffsets = newOffsets->asMutable<vector_size_t>();
-
-    vector_size_t indicesCursor = 0;
-
-    // Lambda that process each row. This is detached from the code so we can
-    // apply it differently based on whether the right-hand side set is constant
-    // or not.
-    auto processRow = [&](vector_size_t row,
-                          const SetWithNull<T>& rightSet,
-                          SetWithNull<T>& outputSet) {
-      auto idx = decodedLeftArray->index(row);
-      auto size = baseLeftArray->sizeAt(idx);
-      auto offset = baseLeftArray->offsetAt(idx);
-
-      outputSet.reset();
-      rawNewOffsets[row] = indicesCursor;
-
-      // Scans the array elements on the left-hand side.
-      for (vector_size_t i = offset; i < (offset + size); ++i) {
-        if (decodedLeftElements->isNullAt(i)) {
-          // For a NULL value not added to the output row yet, insert in
-          // array_intersect if it was found on the rhs (and not found in the
-          // case of array_except).
-          if (!outputSet.hasNull) {
-            bool setNull = false;
-            if constexpr (isIntersect) {
-              setNull = rightSet.hasNull;
-            } else {
-              setNull = !rightSet.hasNull;
-            }
-            if (setNull) {
-              bits::setNull(rawNewElementNulls, indicesCursor++, true);
-              outputSet.hasNull = true;
-            }
-          }
-        } else {
-          auto val = decodedLeftElements->valueAt<T>(i);
-          // For array_intersect, add the element if it is found (not found
-          // for array_except) in the right-hand side, and wasn't added already
-          // (check outputSet).
-          bool addValue = false;
-          if constexpr (isIntersect) {
-            addValue = rightSet.set.count(val) > 0;
-          } else {
-            addValue = rightSet.set.count(val) == 0;
-          }
-          if (addValue) {
-            auto it = outputSet.set.insert(val);
-            if (it.second) {
-              rawNewIndices[indicesCursor++] = i;
-            }
-          }
-        }
-      }
-      rawNewLengths[row] = indicesCursor - rawNewOffsets[row];
-    };
-
-    SetWithNull<T> outputSet;
-
-    // Optimized case when the right-hand side array is constant.
-    if (constantSet_.has_value()) {
-      rows.applyToSelected([&](vector_size_t row) {
-        processRow(row, *constantSet_, outputSet);
-      });
-    }
-    // General case when no arrays are constant and both sets need to be
-    // computed for each row.
-    else {
-      exec::LocalDecodedVector rightHolder(context, *right, rows);
-      // Decode and acquire array elements vector.
-      exec::LocalDecodedVector rightElementsHolder(context);
-      auto decodedRightElements =
-          decodeArrayElements(rightHolder, rightElementsHolder, rows);
-      SetWithNull<T> rightSet;
-      auto rightArrayVector = rightHolder.get()->base()->as<ArrayVector>();
-      rows.applyToSelected([&](vector_size_t row) {
-        auto idx = rightHolder.get()->index(row);
-        generateSet<T>(rightArrayVector, decodedRightElements, idx, rightSet);
-        processRow(row, rightSet, outputSet);
-      });
-    }
-
-    auto newElements = BaseVector::wrapInDictionary(
-        newElementNulls, newIndices, indicesCursor, baseLeftArray->elements());
-    auto resultArray = std::make_shared<ArrayVector>(
-        pool,
-        outputType,
-        nullptr,
-        rowCount,
-        newOffsets,
-        newLengths,
-        newElements);
-    context.moveOrCopyResult(resultArray, rows, result);
-  }
-
-  // If one of the arrays is constant, this member will store a pointer to the
-  // set generated from its elements, which is calculated only once, before
-  // instantiating this object.
-  std::optional<SetWithNull<T>> constantSet_;
-}; // class ArrayIntersectExcept
 
 template <typename T>
 class ArraysOverlapFunction : public exec::VectorFunction {
@@ -322,7 +87,8 @@ class ArraysOverlapFunction : public exec::VectorFunction {
       auto baseRightArray = rightDecoder.get()->base()->as<ArrayVector>();
       rows.applyToSelected([&](vector_size_t row) {
         auto idx = rightDecoder.get()->index(row);
-        generateSet<T>(baseRightArray, decodedRightElements, idx, rightSet);
+        generateSet<T, false>(
+            baseRightArray, decodedRightElements, idx, rightSet);
         processRow(row, rightSet);
       });
     }
@@ -338,83 +104,6 @@ class ArraysOverlapFunction : public exec::VectorFunction {
   const bool isLeftConstant_{false};
 }; // class ArraysOverlapFunction
 
-void validateMatchingArrayTypes(
-    const std::vector<exec::VectorFunctionArg>& inputArgs,
-    const std::string& name,
-    vector_size_t expectedArgCount) {
-  VELOX_USER_CHECK_EQ(
-      inputArgs.size(),
-      expectedArgCount,
-      "{} requires exactly {} parameters",
-      name,
-      expectedArgCount);
-
-  auto arrayType = inputArgs.front().type;
-  VELOX_USER_CHECK_EQ(
-      arrayType->kind(),
-      TypeKind::ARRAY,
-      "{} requires arguments of type ARRAY",
-      name);
-
-  for (auto& arg : inputArgs) {
-    VELOX_USER_CHECK(
-        arrayType->kindEquals(arg.type),
-        "{} function requires all arguments of the same type: {} vs. {}",
-        name,
-        arg.type->toString(),
-        arrayType->toString());
-  }
-}
-
-template <typename T>
-SetWithNull<T> validateConstantVectorAndGenerateSet(
-    const BaseVector* baseVector) {
-  auto constantVector = baseVector->as<ConstantVector<velox::ComplexType>>();
-  auto constantArray = constantVector->as<ConstantVector<velox::ComplexType>>();
-  VELOX_CHECK_NOT_NULL(constantArray, "wrong constant type found");
-  VELOX_CHECK_NOT_NULL(constantVector, "wrong constant type found");
-  auto arrayVecPtr = constantVector->valueVector()->as<ArrayVector>();
-  VELOX_CHECK_NOT_NULL(arrayVecPtr, "wrong array literal type");
-
-  auto idx = constantArray->index();
-  auto elementBegin = arrayVecPtr->offsetAt(idx);
-  auto elementEnd = elementBegin + arrayVecPtr->sizeAt(idx);
-
-  SelectivityVector rows{elementEnd, false};
-  rows.setValidRange(elementBegin, elementEnd, true);
-  rows.updateBounds();
-
-  DecodedVector decodedElements{*arrayVecPtr->elements(), rows};
-
-  SetWithNull<T> constantSet;
-  generateSet<T>(arrayVecPtr, &decodedElements, idx, constantSet);
-  return constantSet;
-}
-
-template <bool isIntersect, TypeKind kind>
-std::shared_ptr<exec::VectorFunction> createTypedArraysIntersectExcept(
-    const std::vector<exec::VectorFunctionArg>& inputArgs) {
-  using T = typename TypeTraits<kind>::NativeType;
-
-  VELOX_CHECK_EQ(inputArgs.size(), 2);
-  BaseVector* rhs = inputArgs[1].constantValue.get();
-
-  // We don't optimize the case where lhs is a constant expression for
-  // array_intersect() because that would make this function non-deterministic.
-  // For example, a constant lhs would mean the constantSet is created based on
-  // lhs; the same data encoded as a regular column could result in the set
-  // being created based on rhs. Running this function with different sets could
-  // results in arrays in different orders.
-  //
-  // If rhs is a constant value:
-  if (rhs != nullptr) {
-    return std::make_shared<ArrayIntersectExceptFunction<isIntersect, T>>(
-        validateConstantVectorAndGenerateSet<T>(rhs));
-  } else {
-    return std::make_shared<ArrayIntersectExceptFunction<isIntersect, T>>();
-  }
-}
-
 std::shared_ptr<exec::VectorFunction> createArrayIntersect(
     const std::string& name,
     const std::vector<exec::VectorFunctionArg>& inputArgs,
@@ -426,7 +115,8 @@ std::shared_ptr<exec::VectorFunction> createArrayIntersect(
       createTypedArraysIntersectExcept,
       /* isIntersect */ true,
       elementType->kind(),
-      inputArgs);
+      inputArgs,
+      false);
 }
 
 std::shared_ptr<exec::VectorFunction> createArrayExcept(
@@ -440,22 +130,8 @@ std::shared_ptr<exec::VectorFunction> createArrayExcept(
       createTypedArraysIntersectExcept,
       /* isIntersect */ false,
       elementType->kind(),
-      inputArgs);
-}
-
-std::vector<std::shared_ptr<exec::FunctionSignature>> signatures(
-    const std::string& returnTypeTemplate) {
-  std::vector<std::shared_ptr<exec::FunctionSignature>> signatures;
-  for (const auto& type : exec::primitiveTypeNames()) {
-    signatures.push_back(
-        exec::FunctionSignatureBuilder()
-            .returnType(
-                fmt::format(fmt::runtime(returnTypeTemplate.c_str()), type))
-            .argumentType(fmt::format("array({})", type))
-            .argumentType(fmt::format("array({})", type))
-            .build());
-  }
-  return signatures;
+      inputArgs,
+      false);
 }
 
 template <TypeKind kind>
@@ -470,7 +146,7 @@ const std::shared_ptr<exec::VectorFunction> createTypedArraysOverlap(
   }
   auto isLeftConstant = (left != nullptr);
   auto baseVector = isLeftConstant ? left : right;
-  auto constantSet = validateConstantVectorAndGenerateSet<T>(baseVector);
+  auto constantSet = validateConstantVectorAndGenerateSet<T, false>(baseVector);
   return std::make_shared<ArraysOverlapFunction<T>>(
       std::move(constantSet), isLeftConstant);
 }

--- a/velox/functions/sparksql/ArrayIntersectExcept.cpp
+++ b/velox/functions/sparksql/ArrayIntersectExcept.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/lib/ArrayIntersectExceptFunction.h"
+
+namespace facebook::velox::functions::sparksql {
+namespace {
+
+std::shared_ptr<exec::VectorFunction> createArrayIntersect(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    const core::QueryConfig& /*config*/) {
+  validateMatchingArrayTypes(inputArgs, name, 2);
+  auto elementType = inputArgs.front().type->childAt(0);
+
+  return VELOX_DYNAMIC_SCALAR_TEMPLATE_TYPE_DISPATCH(
+      createTypedArraysIntersectExcept,
+      /* isIntersect */ true,
+      elementType->kind(),
+      inputArgs,
+      true);
+}
+
+std::shared_ptr<exec::VectorFunction> createArrayExcept(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    const core::QueryConfig& /*config*/) {
+  validateMatchingArrayTypes(inputArgs, name, 2);
+  auto elementType = inputArgs.front().type->childAt(0);
+
+  return VELOX_DYNAMIC_SCALAR_TEMPLATE_TYPE_DISPATCH(
+      createTypedArraysIntersectExcept,
+      /* isIntersect */ false,
+      elementType->kind(),
+      inputArgs,
+      true);
+}
+} // namespace
+
+VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
+    udf_array_intersect,
+    signatures("array({})"),
+    createArrayIntersect);
+
+VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
+    udf_array_except,
+    signatures("array({})"),
+    createArrayExcept);
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/CMakeLists.txt
+++ b/velox/functions/sparksql/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_subdirectory(specialforms)
 add_library(
   velox_functions_spark
+  ArrayIntersectExcept.cpp
   ArraySort.cpp
   Bitwise.cpp
   Comparisons.cpp

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -62,8 +62,6 @@ static void workAroundRegistrationMacro(const std::string& prefix) {
   // Complex types.
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_constructor, prefix + "array");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_contains, prefix + "array_contains");
-  VELOX_REGISTER_VECTOR_FUNCTION(
-      udf_array_intersect, prefix + "array_intersect");
   // This is the semantics of spark.sql.ansi.enabled = false.
   registerElementAtFunction(prefix + "element_at", true);
 
@@ -251,6 +249,10 @@ void registerFunctions(const std::string& prefix) {
 
   registerFunction<FindInSetFunction, int32_t, Varchar, Varchar>(
       {prefix + "find_in_set"});
+
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_except, prefix + "array_except");
+  VELOX_REGISTER_VECTOR_FUNCTION(
+      udf_array_intersect, prefix + "array_intersect");
 
   // Register array sort functions.
   exec::registerStatefulVectorFunction(

--- a/velox/functions/sparksql/tests/ArrayIntersectExceptTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayIntersectExceptTest.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <optional>
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+#include "velox/vector/tests/TestingDictionaryArrayElementsFunction.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::functions::test;
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class ArrayIntersectExceptTest : public SparkFunctionBaseTest {
+ protected:
+  void testExpr(
+      const VectorPtr& expected,
+      const std::string& expression,
+      const std::vector<VectorPtr>& input) {
+    auto result = evaluate<ArrayVector>(expression, makeRowVector(input));
+    assertEqualVectors(expected, result);
+
+    // Also test using dictionary encodings.
+    if (input.size() == 2) {
+      // Wrap first column in a dictionary: repeat each row twice. Wrap second
+      // column in the same dictionary, then flatten to prevent peeling of
+      // encodings. Wrap the expected result in the same dictionary.
+      // The expression evaluation on both dictionary inputs should result in
+      // the dictionary of the expected result vector.
+      auto newSize = input[0]->size() * 2;
+      auto indices = makeIndices(newSize, [](auto row) { return row / 2; });
+      auto firstDict = wrapInDictionary(indices, newSize, input[0]);
+      auto secondFlat = flatten(wrapInDictionary(indices, newSize, input[1]));
+
+      auto dictResult = evaluate<ArrayVector>(
+          expression, makeRowVector({firstDict, secondFlat}));
+      auto dictExpected = wrapInDictionary(indices, newSize, expected);
+      assertEqualVectors(dictExpected, dictResult);
+    }
+  }
+
+  template <typename T>
+  void testArrayExceptFloatingPoint() {
+    auto expected = makeNullableArrayVector<T>({
+        {1.0001, 3.03, std::nullopt, 4.00004},
+        {2.02, 1},
+        {8.0001, std::nullopt},
+        {std::numeric_limits<T>::max()},
+        {},
+    });
+    testExpr(expected, "array_except(C0, C1)", getInputVectors<T>());
+
+    expected = makeNullableArrayVector<T>({
+        {1.0, 4.0},
+        {2.0199, 1.000001},
+        {1.0001, -2.02, 8.00099},
+        {},
+        {},
+    });
+    testExpr(expected, "array_except(C1, C0)", getInputVectors<T>());
+  }
+
+  template <typename T>
+  void testArrayIntersectFloatingPoint() {
+    auto expected = makeNullableArrayVector<T>({
+        {-2.0},
+        {std::numeric_limits<T>::min(), -2.001},
+        {std::numeric_limits<T>::max()},
+        {9.0009, std::numeric_limits<T>::infinity()},
+        {std::numeric_limits<T>::quiet_NaN(), 9.0009},
+    });
+    testExpr(expected, "array_intersect(C0, C1)", getInputVectors<T>());
+
+    expected = makeNullableArrayVector<T>({
+        {-2.0},
+        {std::numeric_limits<T>::min(), -2.001},
+        {std::numeric_limits<T>::max()},
+        {9.0009, std::numeric_limits<T>::infinity()},
+        {9.0009, std::numeric_limits<T>::quiet_NaN()},
+    });
+    testExpr(expected, "array_intersect(C1, C0)", getInputVectors<T>());
+  }
+
+ private:
+  template <typename T>
+  std::vector<VectorPtr> getInputVectors() {
+    const auto array1 = makeNullableArrayVector<T>({
+        {1.0001, -2.0, 3.03, std::nullopt, 4.00004},
+        {std::numeric_limits<T>::min(), 2.02, -2.001, 1},
+        {std::numeric_limits<T>::max(), 8.0001, std::nullopt},
+        {9.0009,
+         std::numeric_limits<T>::infinity(),
+         std::numeric_limits<T>::max()},
+        {std::numeric_limits<T>::quiet_NaN(), 9.0009},
+    });
+    const auto array2 = makeNullableArrayVector<T>({
+        {1.0, -2.0, 4.0},
+        {std::numeric_limits<T>::min(), 2.0199, -2.001, 1.000001},
+        {1.0001, -2.02, std::numeric_limits<T>::max(), 8.00099},
+        {9.0009, std::numeric_limits<T>::infinity()},
+        {9.0009, std::numeric_limits<T>::quiet_NaN()},
+    });
+    return {array1, array2};
+  }
+};
+
+TEST_F(ArrayIntersectExceptTest, except) {
+  testArrayExceptFloatingPoint<float>();
+  testArrayExceptFloatingPoint<double>();
+}
+
+TEST_F(ArrayIntersectExceptTest, intersect) {
+  testArrayIntersectFloatingPoint<float>();
+  testArrayIntersectFloatingPoint<double>();
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_executable(
   velox_functions_spark_test
   ArithmeticTest.cpp
+  ArrayIntersectExceptTest.cpp
   ArrayMaxTest.cpp
   ArrayMinTest.cpp
   ArraySortTest.cpp


### PR DESCRIPTION
In Presto, NaNs are treated as different in array_intersect and array_except, 
but in Spark NaNs are treated as equal. This PR moves 
ArrayIntersectExceptFunction from folder `functions/prestosql` to 
`functions/lib`, and adds `equalNaN` template parameter to control different 
behaviors.
