### PR TITLE
Allow entry delimiter to be last in the input of SplitToMap().

### DIFF
--- a/velox/functions/prestosql/SplitToMap.h
+++ b/velox/functions/prestosql/SplitToMap.h
@@ -76,11 +76,15 @@ struct SplitToMapFunction {
       nextEntryPos = input.find(entryDelimiter, pos);
     }
 
-    processEntry(
-        out,
-        std::string_view(input.data() + pos, input.size() - pos),
-        keyValueDelimiter,
-        keys);
+    // Entry delimiter can be the last character in the input. In this case
+    // there is no last entry to process.
+    if (pos < input.size()) {
+      processEntry(
+          out,
+          std::string_view(input.data() + pos, input.size() - pos),
+          keyValueDelimiter,
+          keys);
+    }
   }
 
   void processEntry(


### PR DESCRIPTION
Summary:
We detected inconsitency of SplitToMap function compared to Presto.
Presto can handle input string with the entry delimiter being the last
character, assuming the previous chars were parsed all right.
Velox throws in such cases.
Examples: 'ds=2024/' and '=', where '/' is the entry delimiter and '=' is
the key-value delimiter.

So, in this change we bring Velox to behave like Presto.

Differential Revision: D54315225


