### PR TITLE
Fix CUBE aggregation over distinct inputs when input is empty

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -565,10 +565,11 @@ bool GroupingSet::getGlobalAggregationOutput(
     }
 
     auto& function = aggregates_[i].function;
+    auto& resultVector = result->childAt(aggregates_[i].output);
     if (isPartial_) {
-      function->extractAccumulators(groups, 1, &result->childAt(i));
+      function->extractAccumulators(groups, 1, &resultVector);
     } else {
-      function->extractValues(groups, 1, &result->childAt(i));
+      function->extractValues(groups, 1, &resultVector);
     }
   }
 
@@ -594,24 +595,9 @@ bool GroupingSet::getDefaultGlobalGroupingSetOutput(
   if (iterator.allocationIndex != 0) {
     return false;
   }
-  // Global aggregates don't have grouping keys. But global grouping sets
-  // have null values in grouping keys and a groupId column as well. These
-  // key fields precede the aggregate columns in the result.
-  // This logic builds a row with just aggregate fields to reuse the global
-  // aggregate computation from the regular GroupingSet code-path.
-  auto outputType = asRowType(result->type());
-  auto firstAggregateCol = outputType->size() - aggregates_.size();
-  std::vector<std::string> names;
-  std::vector<TypePtr> types;
-  names.reserve(aggregates_.size());
-  types.reserve(aggregates_.size());
-  for (auto i = firstAggregateCol; i < outputType->size(); i++) {
-    names.push_back(outputType->nameOf(i));
-    types.push_back(outputType->childAt(i));
-  }
-  auto aggregatesType = ROW(std::move(names), std::move(types));
+
   auto globalAggregatesRow =
-      BaseVector::create<RowVector>(aggregatesType, 1, &pool_);
+      BaseVector::create<RowVector>(result->type(), 1, &pool_);
 
   VELOX_CHECK(getGlobalAggregationOutput(iterator, globalAggregatesRow));
 
@@ -619,10 +605,17 @@ bool GroupingSet::getDefaultGlobalGroupingSetOutput(
   const auto numGroupingSets = globalGroupingSets_.size();
   result->resize(numGroupingSets);
   VELOX_CHECK(groupIdChannel_.has_value());
-  // These first columns are for grouping keys (which could include the
+
+  // First columns in 'result' are for grouping keys (which could include the
   // GroupId column). For a global grouping set row :
   // i) Non-groupId grouping keys are null.
   // ii) GroupId column is populated with the global grouping set number.
+
+  column_index_t firstAggregateCol = result->type()->size();
+  for (const auto& aggregate : aggregates_) {
+    firstAggregateCol = std::min(firstAggregateCol, aggregate.output);
+  }
+
   for (auto i = 0; i < firstAggregateCol; i++) {
     auto column = result->childAt(i);
     if (i == groupIdChannel_.value()) {
@@ -641,13 +634,12 @@ bool GroupingSet::getDefaultGlobalGroupingSetOutput(
 
   // The remaining aggregate columns are filled from the computed global
   // aggregates.
-  for (auto i = firstAggregateCol; i < outputType->size(); i++) {
-    auto resultAggregateColumn = result->childAt(i);
+  for (const auto& aggregate : aggregates_) {
+    auto resultAggregateColumn = result->childAt(aggregate.output);
     resultAggregateColumn->resize(numGroupingSets);
-    auto sourceAggregateColumn =
-        globalAggregatesRow->childAt(i - firstAggregateCol);
-    for (auto j = 0; j < numGroupingSets; j++) {
-      resultAggregateColumn->copy(sourceAggregateColumn.get(), j, 0, 1);
+    auto sourceAggregateColumn = globalAggregatesRow->childAt(aggregate.output);
+    for (auto i = 0; i < numGroupingSets; i++) {
+      resultAggregateColumn->copy(sourceAggregateColumn.get(), i, 0, 1);
     }
   }
 
@@ -660,9 +652,8 @@ void GroupingSet::destroyGlobalAggregations() {
   }
   for (int32_t i = 0; i < aggregates_.size(); ++i) {
     auto& function = aggregates_[i].function;
-    auto groups = lookup_->hits.data();
     if (function->accumulatorUsesExternalMemory()) {
-      auto groups = lookup_->hits.data();
+      auto* groups = lookup_->hits.data();
       function->destroy(folly::Range(groups, 1));
     }
   }

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -1500,9 +1500,29 @@ TEST_F(AggregationTest, groupingSetsEmptyInput) {
 
   assertQuery(
       plan,
-      makeRowVector(
-          {makeNullableFlatVector<int64_t>({std::nullopt, std::nullopt}),
-           makeFlatVector<int64_t>({0, 1})}));
+      makeRowVector({
+          makeAllNullFlatVector<int64_t>(2),
+          makeFlatVector<int64_t>({0, 1}),
+      }));
+
+  // Aggregations over distinct inputs over empty input with global grouping
+  // sets.
+  plan = PlanBuilder()
+             .values({data})
+             .filter("c1 < 0")
+             .groupId({"c1"}, {{}, {}}, {"c2"})
+             .singleAggregation(
+                 {"c1", "group_id"}, {"count(distinct c2)", "min(distinct c2)"})
+             .planNode();
+
+  assertQuery(
+      plan,
+      makeRowVector({
+          makeAllNullFlatVector<int64_t>(2),
+          makeFlatVector<int64_t>({0, 1}),
+          makeFlatVector<int64_t>({0, 0}),
+          makeAllNullFlatVector<std::string>(2),
+      }));
 }
 
 TEST_F(AggregationTest, outputBatchSizeCheckWithSpill) {


### PR DESCRIPTION
Summary:
Aggregations over distinct inputs were failing when input was empty and grouping sets included global grouping sets.

For example, 

```
SELECT count(DISTINCT a) 
FROM t 
WHERE c % 2 > 10 -- always false
GROUP BY CUBE(b)
```

was failing with 

```
VeloxRuntimeError: index < childrenSize_ (2 vs. 1) Trying to access non-existing child in RowVector: [ROW ROW<count:BIGINT>: 1 elements, no nulls]
```

Aggregation over empty set of rows for a 'global grouping set' must produce
a single row with "default" value for the aggregation (e.g. 0 for count, NULL for min). 

This logic to compute "default" value resides in
GroupingSet::getDefaultGlobalGroupingSetOutput which re-uses
GroupingSet::getGlobalAggregationOutput.

getGlobalAggregationOutput is designed to be used for global aggregations
(when there are no grouping keys), but when called from
getDefaultGlobalGroupingSetOutput there are grouping keys.
getDefaultGlobalGroupingSetOutput used to "pretend" there are no grouping keys,
but modifying the 'result' vector to remove grouping keys, but that caused
failures when passing modified 'result' to TypedDistinctAggregations. The fix
is to avoid modifying 'result' vector and instead rely on AggregationInfo
struct that provides a mapping from an aggregation to a column in result
vector.

Differential Revision: D54330514

Fixes https://github.com/facebookincubator/velox/issues/8900