### PR TITLE
Fix broken Github Actions Macos13 build

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -58,6 +58,8 @@ jobs:
         with:
           submodules: recursive
       - name: Install Dependencies
+        env:
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "TRUE"
         run: |
           brew install \
             bison boost ccache double-conversion flex fmt gflags glog \


### PR DESCRIPTION
Automatic package updates from brew cause it to install a version of python that fails on macos13. Remove automatic package updates so that macos13 build can proceed. 

Fixes : https://github.com/facebookincubator/velox/issues/8907 

