### PR TITLE
Add support for UNKNOWN input to checksum Presto function

### DIFF
--- a/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
@@ -91,6 +91,17 @@ class ChecksumAggregate : public exec::Aggregate {
       const std::vector<VectorPtr>& args,
       bool /*mayPushDown*/) override {
     const auto& arg = args[0];
+
+    if (arg->type()->isUnKnown()) {
+      rows.applyToSelected([&](auto row) {
+        auto group = groups[row];
+        clearNull(group);
+        computeHashForNull(group);
+      });
+
+      return;
+    }
+
     auto hasher = getPrestoHasher(arg->type());
     auto hashes = getHashBuffer(rows.end(), arg->pool());
     hasher->hash(arg, rows, hashes);
@@ -137,6 +148,16 @@ class ChecksumAggregate : public exec::Aggregate {
       const std::vector<VectorPtr>& args,
       bool /*mayPushDown*/) override {
     const auto& arg = args[0];
+
+    if (arg->type()->isUnKnown()) {
+      rows.applyToSelected([&](auto row) {
+        clearNull(group);
+        computeHashForNull(group);
+      });
+
+      return;
+    }
+
     auto hasher = getPrestoHasher(arg->type());
     auto hashes = getHashBuffer(rows.end(), arg->pool());
     hasher->hash(arg, rows, hashes);

--- a/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
@@ -383,4 +383,10 @@ TEST_F(ChecksumAggregateTest, timestampWithTimezone) {
 
   assertChecksum(timestampWithTimezone, "jwqENA0VLZY=");
 }
+
+TEST_F(ChecksumAggregateTest, unknown) {
+  auto data = makeAllNullFlatVector<UnknownValue>(100);
+  assertChecksum(data, "vBwbUFiJq80=");
+}
+
 } // namespace facebook::velox::aggregate::test


### PR DESCRIPTION
Summary:
checksum(UNKNOWN) used to fail with 

`VeloxRuntimeError:  not a known type kind: UNKNOWN`

Differential Revision: D54342941


