### PR TITLE
Update documentation for 'split_to_map'.

### DIFF
--- a/velox/docs/functions/presto/string.rst
+++ b/velox/docs/functions/presto/string.rst
@@ -155,7 +155,8 @@ String Functions
     each pair into key and value. Note that ``entryDelimiter`` and ``keyValueDelimiter`` are
     interpreted literally, i.e., as full string matches.
 
-    entryDelimiter and keyValueDelimiter must not be empty and must not be the same.
+    ``entryDelimiter`` and ``keyValueDelimiter`` must not be empty and must not be the same.
+    ``entryDelimiter`` is allowed to be the trailing character.
 
     Raises an error if there are duplicate keys.
 


### PR DESCRIPTION
Summary: Add note that entryDelimiter is allowed to be the trailing character.

Differential Revision: D54346235


