### PR TITLE
Table sampling push down

### DIFF
--- a/velox/common/base/RandomUtil.cpp
+++ b/velox/common/base/RandomUtil.cpp
@@ -16,10 +16,6 @@
 
 #include "velox/common/base/RandomUtil.h"
 
-#include <optional>
-
-#include <folly/Random.h>
-
 namespace facebook::velox::random {
 
 namespace {
@@ -34,6 +30,15 @@ void setSeed(uint32_t value) {
 
 uint32_t getSeed() {
   return customSeed ? *customSeed : folly::Random::rand32();
+}
+
+RandomSkipTracker::RandomSkipTracker(double sampleRate)
+    : sampleRate_(sampleRate) {
+  VELOX_CHECK(0 <= sampleRate && sampleRate < 1);
+  if (sampleRate > 0) {
+    dist_ = std::geometric_distribution<uint64_t>(sampleRate);
+    rng_.seed(getSeed());
+  }
 }
 
 } // namespace facebook::velox::random

--- a/velox/common/base/RandomUtil.h
+++ b/velox/common/base/RandomUtil.h
@@ -16,7 +16,13 @@
 
 #pragma once
 
+#include "velox/common/base/Exceptions.h"
+
+#include <folly/Random.h>
+
 #include <cstdint>
+#include <optional>
+#include <random>
 
 namespace facebook::velox::random {
 
@@ -26,5 +32,67 @@ void setSeed(uint32_t);
 
 // Return a true random seed unless setSeed() is called before.
 uint32_t getSeed();
+
+/// Utility class to accelerate random sampling based on Bernoulli trials.
+/// Internally this keeps the number of skips for next hit.  User can consume a
+/// bulk of trials calling the `nextSkip' then `consume', or call `testOne` to
+/// do the trials one by one.
+class RandomSkipTracker {
+ public:
+  explicit RandomSkipTracker(double sampleRate);
+
+  RandomSkipTracker(const RandomSkipTracker&) = delete;
+  RandomSkipTracker& operator=(const RandomSkipTracker&) = delete;
+
+  /// Return the number of skips need to get a hit.  Must be called before
+  /// calling `consume'.
+  uint64_t nextSkip() {
+    if (sampleRate_ == 0) {
+      return std::numeric_limits<uint64_t>::max();
+    }
+    if (skip_.has_value()) {
+      return *skip_;
+    }
+    skip_ = dist_(rng_);
+    return *skip_;
+  }
+
+  /// Consume the remaining skips followed by at most one hit.
+  void consume(uint64_t numElements) {
+    if (sampleRate_ == 0) {
+      return;
+    }
+    VELOX_DCHECK(skip_.has_value());
+    if (*skip_ >= numElements) {
+      *skip_ -= numElements;
+    } else {
+      VELOX_DCHECK_EQ(numElements - *skip_, 1);
+      skip_.reset();
+    }
+  }
+
+  /// Consume one trial and return the result.
+  bool testOne() {
+    if (sampleRate_ == 0) {
+      return false;
+    }
+    if (nextSkip() == 0) {
+      skip_.reset();
+      return true;
+    }
+    --*skip_;
+    return false;
+  }
+
+  double sampleRate() const {
+    return sampleRate_;
+  }
+
+ private:
+  const double sampleRate_;
+  std::geometric_distribution<uint64_t> dist_;
+  folly::Random::DefaultGenerator rng_;
+  std::optional<uint64_t> skip_;
+};
 
 } // namespace facebook::velox::random

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -24,6 +24,8 @@
 #include "velox/dwio/common/CachedBufferedInput.h"
 #include "velox/dwio/common/DirectBufferedInput.h"
 #include "velox/dwio/common/Reader.h"
+#include "velox/expression/Expr.h"
+#include "velox/expression/ExprToSubfieldFilter.h"
 
 namespace facebook::velox::connector::hive {
 
@@ -505,6 +507,8 @@ void configureRowReaderOptions(
   rowReaderOptions.select(cs).range(hiveSplit->start, hiveSplit->length);
 }
 
+namespace {
+
 bool applyPartitionFilter(
     TypeKind kind,
     const std::string& partitionValue,
@@ -530,6 +534,8 @@ bool applyPartitionFilter(
       VELOX_FAIL("Bad type {} for partition value: {}", kind, partitionValue);
   }
 }
+
+} // namespace
 
 bool testFilters(
     common::ScanSpec* scanSpec,
@@ -609,6 +615,133 @@ std::unique_ptr<dwio::common::BufferedInput> createBufferedInput(
       ioStats,
       executor,
       readerOpts);
+}
+
+namespace {
+
+core::CallTypedExprPtr replaceInputs(
+    const core::CallTypedExpr* call,
+    std::vector<core::TypedExprPtr>&& inputs) {
+  return std::make_shared<core::CallTypedExpr>(
+      call->type(), std::move(inputs), call->name());
+}
+
+bool endWith(const std::string& str, const char* suffix) {
+  int len = strlen(suffix);
+  if (str.size() < len) {
+    return false;
+  }
+  for (int i = 0, j = str.size() - len; i < len; ++i, ++j) {
+    if (str[j] != suffix[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool isNotExpr(
+    const core::TypedExprPtr& expr,
+    const core::CallTypedExpr* call,
+    core::ExpressionEvaluator* evaluator) {
+  if (!endWith(call->name(), "not")) {
+    return false;
+  }
+  auto exprs = evaluator->compile(expr);
+  VELOX_CHECK_EQ(exprs->size(), 1);
+  auto& compiled = exprs->expr(0);
+  return compiled->vectorFunction() &&
+      compiled->vectorFunction()->getCanonicalName() ==
+      exec::FunctionCanonicalName::kNot;
+}
+
+double getPrestoSampleRate(
+    const core::TypedExprPtr& expr,
+    const core::CallTypedExpr* call,
+    core::ExpressionEvaluator* evaluator) {
+  if (!endWith(call->name(), "lt")) {
+    return -1;
+  }
+  VELOX_CHECK_EQ(call->inputs().size(), 2);
+  auto exprs = evaluator->compile(expr);
+  VELOX_CHECK_EQ(exprs->size(), 1);
+  auto& lt = exprs->expr(0);
+  if (!(lt->vectorFunction() &&
+        lt->vectorFunction()->getCanonicalName() ==
+            exec::FunctionCanonicalName::kLt)) {
+    return -1;
+  }
+  auto& rand = lt->inputs()[0];
+  if (!(rand->inputs().empty() && rand->vectorFunction() &&
+        rand->vectorFunction()->getCanonicalName() ==
+            exec::FunctionCanonicalName::kRand)) {
+    return -1;
+  }
+  auto* rate =
+      dynamic_cast<const core::ConstantTypedExpr*>(call->inputs()[1].get());
+  if (!(rate && rate->type()->kind() == TypeKind::DOUBLE)) {
+    return -1;
+  }
+  return std::max(0.0, std::min(1.0, rate->value().value<double>()));
+}
+
+} // namespace
+
+core::TypedExprPtr extractFiltersFromRemainingFilter(
+    const core::TypedExprPtr& expr,
+    core::ExpressionEvaluator* evaluator,
+    bool negated,
+    SubfieldFilters& filters,
+    double& sampleRate) {
+  auto* call = dynamic_cast<const core::CallTypedExpr*>(expr.get());
+  if (!call) {
+    return expr;
+  }
+  common::Filter* oldFilter = nullptr;
+  try {
+    common::Subfield subfield;
+    if (auto filter = exec::leafCallToSubfieldFilter(
+            *call, subfield, evaluator, negated)) {
+      if (auto it = filters.find(subfield); it != filters.end()) {
+        oldFilter = it->second.get();
+        filter = filter->mergeWith(oldFilter);
+      }
+      filters.insert_or_assign(std::move(subfield), std::move(filter));
+      return nullptr;
+    }
+  } catch (const VeloxException&) {
+    LOG(WARNING) << "Unexpected failure when extracting filter for: "
+                 << expr->toString();
+    if (oldFilter) {
+      LOG(WARNING) << "Merging with " << oldFilter->toString();
+    }
+  }
+  if (isNotExpr(expr, call, evaluator)) {
+    auto inner = extractFiltersFromRemainingFilter(
+        call->inputs()[0], evaluator, !negated, filters, sampleRate);
+    return inner ? replaceInputs(call, {inner}) : nullptr;
+  }
+  if ((call->name() == "and" && !negated) ||
+      (call->name() == "or" && negated)) {
+    auto lhs = extractFiltersFromRemainingFilter(
+        call->inputs()[0], evaluator, negated, filters, sampleRate);
+    auto rhs = extractFiltersFromRemainingFilter(
+        call->inputs()[1], evaluator, negated, filters, sampleRate);
+    if (!lhs) {
+      return rhs;
+    }
+    if (!rhs) {
+      return lhs;
+    }
+    return replaceInputs(call, {lhs, rhs});
+  }
+  if (!negated) {
+    double rate = getPrestoSampleRate(expr, call, evaluator);
+    if (rate != -1) {
+      sampleRate *= rate;
+      return nullptr;
+    }
+  }
+  return expr;
 }
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConnectorUtil.h
+++ b/velox/connectors/hive/HiveConnectorUtil.h
@@ -77,11 +77,6 @@ void configureRowReaderOptions(
     const RowTypePtr& rowType,
     std::shared_ptr<HiveConnectorSplit> hiveSplit);
 
-bool applyPartitionFilter(
-    TypeKind kind,
-    const std::string& partitionValue,
-    common::Filter* filter);
-
 bool testFilters(
     common::ScanSpec* scanSpec,
     dwio::common::Reader* reader,
@@ -97,5 +92,12 @@ std::unique_ptr<dwio::common::BufferedInput> createBufferedInput(
     const ConnectorQueryCtx* connectorQueryCtx,
     std::shared_ptr<io::IoStatistics> ioStats,
     folly::Executor* executor);
+
+core::TypedExprPtr extractFiltersFromRemainingFilter(
+    const core::TypedExprPtr& expr,
+    core::ExpressionEvaluator* evaluator,
+    bool negated,
+    SubfieldFilters& filters,
+    double& sampleRate);
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveDataSource.h
+++ b/velox/connectors/hive/HiveDataSource.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/common/base/RandomUtil.h"
 #include "velox/common/io/IoStatistics.h"
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/hive/FileHandle.h"
@@ -71,14 +72,6 @@ class HiveDataSource : public DataSource {
   void setFromDataSource(std::unique_ptr<DataSource> sourceUnique) override;
 
   int64_t estimatedRowSize() override;
-
-  // Internal API, made public to be accessible in unit tests.  Do not use in
-  // other places.
-  static core::TypedExprPtr extractFiltersFromRemainingFilter(
-      const core::TypedExprPtr& expr,
-      core::ExpressionEvaluator* evaluator,
-      bool negated,
-      SubfieldFilters& filters);
 
  protected:
   virtual std::unique_ptr<SplitReader> createSplitReader();
@@ -138,6 +131,8 @@ class HiveDataSource : public DataSource {
   VectorPtr filterResult_;
   SelectivityVector filterRows_;
   exec::FilterEvalCtx filterEvalCtx_;
+
+  std::shared_ptr<random::RandomSkipTracker> randomSkip_;
 };
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -95,13 +95,15 @@ SplitReader::SplitReader(
       ioStats_(ioStats),
       baseReaderOpts_(connectorQueryCtx->memoryPool()) {}
 
-void SplitReader::configureReaderOptions() {
+void SplitReader::configureReaderOptions(
+    std::shared_ptr<random::RandomSkipTracker> randomSkip) {
   hive::configureReaderOptions(
       baseReaderOpts_,
       hiveConfig_,
       connectorQueryCtx_->sessionProperties(),
       hiveTableHandle_,
       hiveSplit_);
+  baseReaderOpts_.setRandomSkip(std::move(randomSkip));
 }
 
 void SplitReader::prepareSplit(
@@ -113,8 +115,8 @@ void SplitReader::prepareSplit(
   std::shared_ptr<FileHandle> fileHandle;
   try {
     fileHandle = fileHandleFactory_->generate(hiveSplit_->filePath).second;
-  } catch (VeloxRuntimeError& e) {
-    if (e.errorCode() == error_code::kFileNotFound.c_str() &&
+  } catch (const VeloxRuntimeError& e) {
+    if (e.errorCode() == error_code::kFileNotFound &&
         hiveConfig_->ignoreMissingFiles(
             connectorQueryCtx_->sessionProperties())) {
       emptySplit_ = true;
@@ -223,7 +225,12 @@ std::vector<TypePtr> SplitReader::adaptColumns(
 }
 
 uint64_t SplitReader::next(int64_t size, VectorPtr& output) {
-  return baseRowReader_->next(size, output);
+  if (!baseReaderOpts_.randomSkip()) {
+    return baseRowReader_->next(size, output);
+  }
+  dwio::common::Mutation mutation;
+  mutation.randomSkip = baseReaderOpts_.randomSkip().get();
+  return baseRowReader_->next(size, output, &mutation);
 }
 
 void SplitReader::resetFilterCaches() {

--- a/velox/connectors/hive/SplitReader.h
+++ b/velox/connectors/hive/SplitReader.h
@@ -83,7 +83,8 @@ class SplitReader {
 
   virtual ~SplitReader() = default;
 
-  void configureReaderOptions();
+  void configureReaderOptions(
+      std::shared_ptr<random::RandomSkipTracker> randomSkip);
 
   /// This function is used by different table formats like Iceberg and Hudi to
   /// do additional preparations before reading the split, e.g. Open delete

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -82,6 +82,7 @@ void IcebergSplitReader::prepareSplit(
 
 uint64_t IcebergSplitReader::next(int64_t size, VectorPtr& output) {
   Mutation mutation;
+  mutation.randomSkip = baseReaderOpts_.randomSkip().get();
   mutation.deletedRows = nullptr;
 
   if (!positionalDeleteFileReaders_.empty()) {

--- a/velox/core/SimpleFunctionMetadata.h
+++ b/velox/core/SimpleFunctionMetadata.h
@@ -66,6 +66,20 @@ struct udf_help<T, util::detail::void_t<decltype(T::help)>> {
   }
 };
 
+// Canonical name of the function.
+template <class T, class = void>
+struct udf_canonical_name {
+  static constexpr exec::FunctionCanonicalName value =
+      exec::FunctionCanonicalName::kUnknown;
+};
+
+template <class T>
+struct udf_canonical_name<
+    T,
+    util::detail::void_t<decltype(T::canonical_name)>> {
+  static constexpr exec::FunctionCanonicalName value = T::canonical_name;
+};
+
 // Has the value true, unless a Variadic Type appears anywhere but at the end
 // of the parameters.
 template <typename... TArgs>
@@ -311,6 +325,7 @@ class ISimpleFunctionMetadata {
   // types, otherwise return null.
   virtual TypePtr tryResolveReturnType() const = 0;
   virtual std::string getName() const = 0;
+  virtual exec::FunctionCanonicalName getCanonicalName() const = 0;
   virtual bool isDeterministic() const = 0;
   virtual uint32_t priority() const = 0;
   virtual const std::shared_ptr<exec::FunctionSignature> signature() const = 0;
@@ -374,6 +389,10 @@ class SimpleFunctionMetadata : public ISimpleFunctionMetadata {
           "member in the function class, or specify a function alias at "
           "registration time.");
     }
+  }
+
+  exec::FunctionCanonicalName getCanonicalName() const final {
+    return udf_canonical_name<Fun>::value;
   }
 
   bool isDeterministic() const final {

--- a/velox/dwio/common/Mutation.h
+++ b/velox/dwio/common/Mutation.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include "velox/common/base/RandomUtil.h"
+
 #include <cstdint>
 
 namespace facebook::velox::dwio::common {
@@ -23,6 +25,8 @@ namespace facebook::velox::dwio::common {
 struct Mutation {
   /// Bit masks for row numbers to be deleted.
   const uint64_t* deletedRows = nullptr;
+
+  random::RandomSkipTracker* randomSkip = nullptr;
 };
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -20,6 +20,7 @@
 #include <unordered_set>
 
 #include <folly/Executor.h>
+#include "velox/common/base/RandomUtil.h"
 #include "velox/common/base/SpillConfig.h"
 #include "velox/common/compression/Compression.h"
 #include "velox/common/io/Options.h"
@@ -408,6 +409,7 @@ class ReaderOptions : public io::ReaderOptions {
   bool fileColumnNamesReadAsLowerCase{false};
   bool useColumnNamesForColumnMapping_{false};
   std::shared_ptr<folly::Executor> ioExecutor_;
+  std::shared_ptr<random::RandomSkipTracker> randomSkip_;
 
  public:
   static constexpr uint64_t kDefaultFooterEstimatedSize = 1024 * 1024; // 1MB
@@ -571,6 +573,14 @@ class ReaderOptions : public io::ReaderOptions {
 
   bool isUseColumnNamesForColumnMapping() const {
     return useColumnNamesForColumnMapping_;
+  }
+
+  const std::shared_ptr<random::RandomSkipTracker>& randomSkip() const {
+    return randomSkip_;
+  }
+
+  void setRandomSkip(std::shared_ptr<random::RandomSkipTracker> randomSkip) {
+    randomSkip_ = randomSkip;
   }
 };
 

--- a/velox/dwio/common/Reader.h
+++ b/velox/dwio/common/Reader.h
@@ -140,11 +140,12 @@ class RowReader {
 
   /**
    * Helper function used by non-selective reader to project top level columns
-   * according to the scan spec.
+   * according to the scan spec and mutations.
    */
   static VectorPtr projectColumns(
       const VectorPtr& input,
-      const velox::common::ScanSpec&);
+      const velox::common::ScanSpec& spec,
+      const Mutation* mutation);
 };
 
 /**

--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -59,8 +59,13 @@ void SelectiveStructColumnReaderBase::next(
     const Mutation* mutation) {
   process::TraceContext trace("SelectiveStructColumnReaderBase::next");
   if (children_.empty()) {
-    if (mutation && mutation->deletedRows) {
-      numValues -= bits::countBits(mutation->deletedRows, 0, numValues);
+    if (mutation) {
+      if (mutation->deletedRows) {
+        numValues -= bits::countBits(mutation->deletedRows, 0, numValues);
+      }
+      if (mutation->randomSkip) {
+        numValues *= mutation->randomSkip->sampleRate();
+      }
     }
 
     // no readers
@@ -87,7 +92,7 @@ void SelectiveStructColumnReaderBase::next(
     std::iota(&rows_[oldSize], &rows_[rows_.size()], oldSize);
   }
   mutation_ = mutation;
-  hasMutation_ = mutation && mutation->deletedRows;
+  hasMutation_ = mutation && (mutation->deletedRows || mutation->randomSkip);
   read(readOffset_, rows_, nullptr);
   getValues(outputRows(), &result);
 }
@@ -105,10 +110,27 @@ void SelectiveStructColumnReaderBase::read(
     VELOX_DCHECK(!nullsInReadRange_, "Only top level can have mutation");
     VELOX_DCHECK_EQ(
         rows.back(), rows.size() - 1, "Top level should have a dense row set");
-    bits::forEachUnsetBit(
-        mutation_->deletedRows, 0, rows.back() + 1, [&](auto i) {
-          addOutputRow(i);
-        });
+    if (mutation_->deletedRows) {
+      bits::forEachUnsetBit(
+          mutation_->deletedRows, 0, rows.back() + 1, [&](auto i) {
+            if (!mutation_->randomSkip || mutation_->randomSkip->testOne()) {
+              addOutputRow(i);
+            }
+          });
+    } else {
+      VELOX_CHECK(mutation_->randomSkip);
+      vector_size_t i = 0;
+      while (i <= rows.back()) {
+        auto skip = mutation_->randomSkip->nextSkip();
+        if (skip > rows.back() - i) {
+          mutation_->randomSkip->consume(rows.back() - i + 1);
+          break;
+        }
+        i += skip;
+        addOutputRow(i++);
+        mutation_->randomSkip->consume(skip + 1);
+      }
+    }
     if (outputRows_.empty()) {
       readOffset_ = offset + rows.back() + 1;
       return;

--- a/velox/dwio/common/tests/ReaderTest.cpp
+++ b/velox/dwio/common/tests/ReaderTest.cpp
@@ -43,7 +43,7 @@ TEST_F(ReaderTest, projectColumnsFilterStruct) {
   spec.addField("c0", 0);
   spec.getOrCreateChild(common::Subfield("c1.c0"))
       ->setFilter(common::createBigintValues({2, 4, 6}, false));
-  auto actual = RowReader::projectColumns(input, spec);
+  auto actual = RowReader::projectColumns(input, spec, nullptr);
   auto expected = makeRowVector({
       makeFlatVector<int64_t>({2, 4, 6}),
   });
@@ -66,7 +66,7 @@ TEST_F(ReaderTest, projectColumnsFilterArray) {
   {
     SCOPED_TRACE("IS NULL");
     c1->setFilter(std::make_unique<common::IsNull>());
-    auto actual = RowReader::projectColumns(input, spec);
+    auto actual = RowReader::projectColumns(input, spec, nullptr);
     auto expected = makeRowVector({
         makeFlatVector<int64_t>({1, 3, 5, 7, 9}),
     });
@@ -75,12 +75,36 @@ TEST_F(ReaderTest, projectColumnsFilterArray) {
   {
     SCOPED_TRACE("IS NOT NULL");
     c1->setFilter(std::make_unique<common::IsNotNull>());
-    auto actual = RowReader::projectColumns(input, spec);
+    auto actual = RowReader::projectColumns(input, spec, nullptr);
     auto expected = makeRowVector({
         makeFlatVector<int64_t>({0, 2, 4, 6, 8}),
     });
     test::assertEqualVectors(expected, actual);
   }
+}
+
+TEST_F(ReaderTest, projectColumnsMutation) {
+  constexpr int kSize = 10;
+  auto input = makeRowVector({makeFlatVector<int64_t>(kSize, folly::identity)});
+  common::ScanSpec spec("<root>");
+  spec.addAllChildFields(*input->type());
+  std::vector<uint64_t> deleted(bits::nwords(kSize));
+  bits::setBit(deleted.data(), 2);
+  Mutation mutation;
+  mutation.deletedRows = deleted.data();
+  auto actual = RowReader::projectColumns(input, spec, &mutation);
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({0, 1, 3, 4, 5, 6, 7, 8, 9}),
+  });
+  test::assertEqualVectors(expected, actual);
+  random::setSeed(42);
+  random::RandomSkipTracker randomSkip(0.5);
+  mutation.randomSkip = &randomSkip;
+  actual = RowReader::projectColumns(input, spec, &mutation);
+  expected = makeRowVector({
+      makeFlatVector<int64_t>({0, 1, 3, 5, 6, 8}),
+  });
+  test::assertEqualVectors(expected, actual);
 }
 
 } // namespace

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -198,6 +198,8 @@ class DwrfRowReader : public StrideIndexProvider,
 
   dwio::common::ColumnReaderStatistics columnReaderStatistics_;
 
+  bool atEnd_{false};
+
   // internal methods
 
   std::optional<size_t> estimatedRowSizeHelper(

--- a/velox/dwio/dwrf/reader/ReaderBase.cpp
+++ b/velox/dwio/dwrf/reader/ReaderBase.cpp
@@ -19,6 +19,7 @@
 #include <fmt/format.h>
 
 #include "velox/common/process/TraceContext.h"
+#include "velox/dwio/common/Mutation.h"
 #include "velox/dwio/common/exception/Exception.h"
 
 namespace facebook::velox::dwrf {
@@ -94,13 +95,15 @@ ReaderBase::ReaderBase(
     uint64_t footerEstimatedSize,
     uint64_t filePreloadThreshold,
     FileFormat fileFormat,
-    bool fileColumnNamesReadAsLowerCase)
+    bool fileColumnNamesReadAsLowerCase,
+    std::shared_ptr<random::RandomSkipTracker> randomSkip)
     : pool_{pool},
       arena_(std::make_unique<google::protobuf::Arena>()),
       decryptorFactory_(decryptorFactory),
       footerEstimatedSize_(footerEstimatedSize),
       filePreloadThreshold_(filePreloadThreshold),
-      input_(std::move(input)) {
+      input_(std::move(input)),
+      randomSkip_(std::move(randomSkip)) {
   process::TraceContext trace("ReaderBase::ReaderBase");
   // read last bytes into buffer to get PostScript
   // If file is small, load the entire file.

--- a/velox/dwio/dwrf/reader/ReaderBase.h
+++ b/velox/dwio/dwrf/reader/ReaderBase.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "velox/common/base/RandomUtil.h"
 #include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/SeekableInputStream.h"
@@ -70,7 +71,8 @@ class ReaderBase {
       uint64_t filePreloadThreshold =
           dwio::common::ReaderOptions::kDefaultFilePreloadThreshold,
       dwio::common::FileFormat fileFormat = dwio::common::FileFormat::DWRF,
-      bool fileColumnNamesReadAsLowerCase = false);
+      bool fileColumnNamesReadAsLowerCase = false,
+      std::shared_ptr<random::RandomSkipTracker> randomSkip = nullptr);
 
   ReaderBase(
       memory::MemoryPool& pool,
@@ -231,6 +233,10 @@ class ReaderBase {
     return postScript_->format();
   }
 
+  const std::shared_ptr<random::RandomSkipTracker>& randomSkip() const {
+    return randomSkip_;
+  }
+
  private:
   static std::shared_ptr<const Type> convertType(
       const FooterWrapper& footer,
@@ -251,6 +257,7 @@ class ReaderBase {
       dwio::common::ReaderOptions::kDefaultFilePreloadThreshold};
 
   std::unique_ptr<dwio::common::BufferedInput> input_;
+  const std::shared_ptr<random::RandomSkipTracker> randomSkip_;
   RowTypePtr schema_;
   // Lazily populated
   mutable std::shared_ptr<const dwio::common::TypeWithId> schemaWithId_;

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -543,7 +543,7 @@ void Writer::flushStripe(bool close) {
   metrics.groupSize = 0;
   metrics.close = close;
 
-  LOG(INFO) << fmt::format(
+  VLOG(1) << fmt::format(
       "Stripe {}: Flush overhead = {}, data length = {}, pre flush mem = {}, post flush mem = {}. Closing = {}",
       metrics.stripeIndex,
       metrics.flushOverhead,

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -36,6 +36,14 @@ const std::vector<std::string> primitiveTypeNames();
 
 enum class ParameterType : int8_t { kTypeParameter, kIntegerParameter };
 
+/// Canonical names for functions that have special treatments in pushdowns.
+enum class FunctionCanonicalName {
+  kUnknown,
+  kLt,
+  kNot,
+  kRand,
+};
+
 /// SignatureVariable holds both, type parameters (e.g. K or V in map(K,
 /// V)), and integer parameters with optional constraints (e.g. "r_precision =
 /// a_precision + b_precision" in decimals).

--- a/velox/expression/SimpleFunctionAdapter.h
+++ b/velox/expression/SimpleFunctionAdapter.h
@@ -412,6 +412,10 @@ class SimpleFunctionAdapter : public VectorFunction {
     }
   }
 
+  FunctionCanonicalName getCanonicalName() const final {
+    return fn_->getCanonicalName();
+  }
+
   bool isDeterministic() const override {
     return fn_->isDeterministic();
   }

--- a/velox/expression/VectorFunction.h
+++ b/velox/expression/VectorFunction.h
@@ -127,6 +127,10 @@ class VectorFunction {
       const {
     return std::nullopt;
   }
+
+  virtual FunctionCanonicalName getCanonicalName() const {
+    return FunctionCanonicalName::kUnknown;
+  }
 };
 
 /// Vector function that generates the specified error for every row. Use this

--- a/velox/functions/prestosql/Comparisons.cpp
+++ b/velox/functions/prestosql/Comparisons.cpp
@@ -231,6 +231,12 @@ class ComparisonSimdFunction : public exec::VectorFunction {
   bool supportsFlatNoNullsFastPath() const override {
     return true;
   }
+
+  exec::FunctionCanonicalName getCanonicalName() const override {
+    return std::is_same_v<ComparisonOp, std::less<>>
+        ? exec::FunctionCanonicalName::kLt
+        : exec::FunctionCanonicalName::kUnknown;
+  }
 };
 
 } // namespace

--- a/velox/functions/prestosql/Not.cpp
+++ b/velox/functions/prestosql/Not.cpp
@@ -61,6 +61,10 @@ class NotFunction : public exec::VectorFunction {
     context.moveOrCopyResult(localResult, rows, result);
   }
 
+  exec::FunctionCanonicalName getCanonicalName() const override {
+    return exec::FunctionCanonicalName::kNot;
+  }
+
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
     // boolean -> boolean
     return {exec::FunctionSignatureBuilder()

--- a/velox/functions/prestosql/Rand.h
+++ b/velox/functions/prestosql/Rand.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "folly/Random.h"
+#include "velox/expression/FunctionSignature.h"
 #include "velox/functions/Macros.h"
 
 namespace facebook::velox::functions {
@@ -23,6 +24,7 @@ namespace facebook::velox::functions {
 template <typename T>
 struct RandFunction {
   static constexpr bool is_deterministic = false;
+  static constexpr auto canonical_name = exec::FunctionCanonicalName::kRand;
 
   FOLLY_ALWAYS_INLINE void call(double& result) {
     result = folly::Random::randDouble01();


### PR DESCRIPTION
Summary:
Pushdown of random sampling into file readers.  Changes include:
1. Recognize random sampling from remaining filter and extract sample rate from it.
2. Construct the stateful `RandomSkipTracker` that converts Bernoulli distribution into geometric distribution.
3. For DWRF, we add extra stripe level skipping, to avoid loading huge stripe level metadata with flat map columns.
4. In struct column reader, we generate the row numbers from geometric distribution directly, instead of doing Bernoulli trial for every row.

The majority of the benefit so far comes from (avoid) reading flat map columns.  For a query that was using more then 33.85 CPU days (then time out), we can now finish it using 6.49 CPU days (Presto Java is using 15.96 days).

Differential Revision: D54331932


