### PR TITLE
Add more info when throwing certain exceptions in  DateTimeFormatter

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -1312,9 +1312,12 @@ std::optional<DateTimeResult> DateTimeFormatter::parse(
         return std::nullopt;
       }
       VELOX_USER_FAIL(
-          "Value {} for dayOfMonth must be in the range [1,{}]",
+          "Value {} for dayOfMonth must be in the range [1,{}] "
+          "for year {} and month {}.",
           date.dayOfMonthValues[i],
-          util::getMaxDayOfMonth(date.year, date.month));
+          util::getMaxDayOfMonth(date.year, date.month),
+          date.year,
+          date.month);
     }
   }
 
@@ -1325,9 +1328,12 @@ std::optional<DateTimeResult> DateTimeFormatter::parse(
         return std::nullopt;
       }
       VELOX_USER_FAIL(
-          "Value {} for dayOfMonth must be in the range [1,{}]",
+          "Value {} for dayOfMonth must be in the range [1,{}] "
+          "for year {} and month {}.",
           date.dayOfYearValues[i],
-          util::isLeapYear(date.year) ? 366 : 365);
+          util::isLeapYear(date.year) ? 366 : 365,
+          date.year,
+          date.month);
     }
   }
 

--- a/velox/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/velox/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -17,6 +17,7 @@
 #include <velox/common/base/VeloxException.h>
 #include <velox/type/StringView.h>
 #include "velox/common/base/Exceptions.h"
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/external/date/tz.h"
 #include "velox/functions/lib/DateTimeFormatterBuilder.h"
 #include "velox/type/TimestampConversion.h"
@@ -1401,6 +1402,16 @@ TEST_F(JodaDateTimeFormatterTest, formatResultSize) {
   EXPECT_EQ(buildJodaDateTimeFormatter("C")->maxResultSize(timezone), 3);
   // Needs to pad to make result contain 4 digits.
   EXPECT_EQ(buildJodaDateTimeFormatter("CCCC")->maxResultSize(timezone), 4);
+}
+
+TEST_F(JodaDateTimeFormatterTest, betterErrorMessaging) {
+  VELOX_ASSERT_THROW(
+      parseJoda("2057-02-29T14:48:14.891Z", "yyyy-MM-dd'T'HH:mm:ss.SSSZ"),
+      "Value 29 for dayOfMonth must be in the range [1,28] for year 2057 and month 2.");
+
+  VELOX_ASSERT_THROW(
+      parseJoda("2057-02-429T14:48:14.891Z", "yyyy-MM-D'T'HH:mm:ss.SSSZ"),
+      "Value 429 for dayOfMonth must be in the range [1,365] for year 2057 and month 2.");
 }
 
 class MysqlDateTimeTest : public DateTimeFormatterTest {};


### PR DESCRIPTION
Currently the error messaging in DateTimeFormatter omits the year, month when throwing an exception due to bad dates. Adding the year, month to the error message will make it easier to debug user errors/exceptions. 