### PR TITLE
Add API to get all the row containers from a composed hash table

### DIFF
--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -1480,6 +1480,17 @@ void HashTable<ignoreNullKeys>::decideHashMode(
 }
 
 template <bool ignoreNullKeys>
+std::vector<RowContainer*> HashTable<ignoreNullKeys>::allRows() const {
+  std::vector<RowContainer*> rowContainers;
+  rowContainers.reserve(otherTables_.size() + 1);
+  rowContainers.push_back(rows_.get());
+  for (auto& other : otherTables_) {
+    rowContainers.push_back(other->rows_.get());
+  }
+  return rowContainers;
+}
+
+template <bool ignoreNullKeys>
 std::string HashTable<ignoreNullKeys>::toString() {
   std::stringstream out;
   out << "[HashTable keys: " << hashers_.size()

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -327,8 +327,12 @@ class BaseHashTable {
     return rows_.get();
   }
 
-  // Static functions for processing internals. Public because used in
-  // structs that define probe and insert algorithms.
+  /// Returns all the row containers of a composed hash table such as for hash
+  /// join use.
+  virtual std::vector<RowContainer*> allRows() const = 0;
+
+  /// Static functions for processing internals. Public because used in
+  /// structs that define probe and insert algorithms.
 
   /// Extracts a 7 bit tag from a hash number. The high bit is always set.
   static uint8_t hashTag(uint64_t hash) {
@@ -576,6 +580,8 @@ class HashTable : public BaseHashTable {
   uint64_t rehashSize() const {
     return rehashSize(capacity_ - numTombstones_);
   }
+
+  std::vector<RowContainer*> allRows() const override;
 
   std::string toString() override;
 

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -140,7 +140,7 @@ class HashTableTest : public testing::TestWithParam<bool>,
       makeRows(size, 1, sequence, buildType, batches);
       copyVectorsToTable(batches, startOffset, table.get());
       sequence += size;
-      if (!topTable_) {
+      if (topTable_ == nullptr) {
         topTable_ = std::move(table);
         numRows += topTable_->rows()->numRows();
       } else {
@@ -159,6 +159,13 @@ class HashTableTest : public testing::TestWithParam<bool>,
         estimatedTableSize,
         topTable_->rows()->pool()->currentBytes() - usedMemoryBytes);
     ASSERT_EQ(topTable_->hashMode(), mode);
+    ASSERT_EQ(topTable_->allRows().size(), numWays);
+    uint64_t rowCount{0};
+    for (auto* rowContainer : topTable_->allRows()) {
+      rowCount += rowContainer->numRows();
+    }
+    ASSERT_EQ(rowCount, numRows);
+
     LOG(INFO) << "Made table " << describeTable();
     testProbe();
     testEraseEveryN(3);


### PR DESCRIPTION
Add API in hash table to return all the row containers so that the hash probe
can parallelize the built table spill from a composed table