### PR TITLE
Fix out-of-index problem in SubstraitVeloxExprConverter::toVeloxExpr

### DIFF
--- a/velox/substrait/SubstraitToVeloxExpr.cpp
+++ b/velox/substrait/SubstraitToVeloxExpr.cpp
@@ -168,7 +168,7 @@ SubstraitVeloxExprConverter::toVeloxExpr(
       int32_t colIdx = substraitParser_.parseReferenceSegment(directRef);
       const auto& inputNames = inputType->names();
       const int64_t inputSize = inputNames.size();
-      if (colIdx <= inputSize) {
+      if (colIdx < inputSize) {
         const auto& inputTypes = inputType->children();
         // Convert type to row.
         return std::make_shared<core::FieldAccessTypedExpr>(


### PR DESCRIPTION
Fix out-of-index bug in `SubstraitVeloxExprConverter::toVeloxExpr(
    const ::substrait::Expression::FieldReference& substraitField,
    const RowTypePtr& inputType)`