### PR TITLE
Deshim //folly:dynamic to //folly/json:dynamic in velox

### DIFF
--- a/pyvelox/pyvelox.h
+++ b/pyvelox/pyvelox.h
@@ -33,7 +33,7 @@
 #include <velox/vector/ComplexVector.h>
 #include <velox/vector/DictionaryVector.h>
 #include <velox/vector/FlatVector.h>
-#include "folly/json.h"
+#include "folly/json/json.h"
 #include "velox/vector/VariantToVector.h"
 
 #include "context.h"

--- a/velox/common/io/IoStatistics.h
+++ b/velox/common/io/IoStatistics.h
@@ -22,7 +22,7 @@
 #include <string>
 #include <unordered_map>
 
-#include <folly/dynamic.h>
+#include <folly/json/dynamic.h>
 
 namespace facebook::velox::io {
 

--- a/velox/common/serialization/DeserializationRegistry.h
+++ b/velox/common/serialization/DeserializationRegistry.h
@@ -18,8 +18,8 @@
 #include <string>
 #include <type_traits>
 #include "Registry.h"
-#include "folly/dynamic.h"
 #include "folly/hash/Hash.h"
+#include "folly/json/dynamic.h"
 
 namespace facebook {
 namespace velox {

--- a/velox/common/serialization/Serializable.h
+++ b/velox/common/serialization/Serializable.h
@@ -18,7 +18,7 @@
 
 #include <type_traits>
 #include "folly/Optional.h"
-#include "folly/json.h"
+#include "folly/json/json.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/serialization/DeserializationRegistry.h"
 

--- a/velox/common/serialization/tests/SerializableTest.cpp
+++ b/velox/common/serialization/tests/SerializableTest.cpp
@@ -16,7 +16,7 @@
 
 #include "velox/common/serialization/Serializable.h"
 #include <gtest/gtest.h>
-#include "folly/json.h"
+#include "folly/json/json.h"
 
 using namespace ::facebook::velox;
 

--- a/velox/dwio/dwrf/common/Config.cpp
+++ b/velox/dwio/dwrf/common/Config.cpp
@@ -17,7 +17,7 @@
 #include "velox/dwio/dwrf/common/Config.h"
 
 #include "folly/String.h"
-#include "folly/dynamic.h"
+#include "folly/json/dynamic.h"
 
 namespace facebook::velox::dwrf {
 

--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
@@ -17,7 +17,7 @@
 #include "velox/dwio/dwrf/reader/FlatMapColumnReader.h"
 #include <folly/Conv.h>
 #include <folly/container/F14Set.h>
-#include <folly/json.h>
+#include <folly/json/json.h>
 
 #include "velox/common/base/BitUtil.h"
 #include "velox/dwio/common/FlatMapHelper.h"

--- a/velox/exec/PlanNodeStats.h
+++ b/velox/exec/PlanNodeStats.h
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include <folly/dynamic.h>
+#include <folly/json/dynamic.h>
 #include "velox/common/time/CpuWallTimer.h"
 #include "velox/exec/Operator.h"
 

--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -16,7 +16,7 @@
 
 #include "velox/exec/fuzzer/PrestoQueryRunner.h"
 #include <cpr/cpr.h> // @manual
-#include <folly/json.h>
+#include <folly/json/json.h>
 #include <iostream>
 #include "velox/common/base/Fs.h"
 #include "velox/common/encode/Base64.h"

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "folly/dynamic.h"
+#include "folly/json/dynamic.h"
 #include "velox/common/base/Fs.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/hyperloglog/SparseHll.h"

--- a/velox/functions/prestosql/json/JsonExtractor.cpp
+++ b/velox/functions/prestosql/json/JsonExtractor.cpp
@@ -22,7 +22,7 @@
 
 #include "boost/algorithm/string/trim.hpp"
 #include "folly/String.h"
-#include "folly/json.h"
+#include "folly/json/json.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/functions/prestosql/json/JsonPathTokenizer.h"
 

--- a/velox/functions/prestosql/json/JsonExtractor.h
+++ b/velox/functions/prestosql/json/JsonExtractor.h
@@ -19,7 +19,7 @@
 #include <string>
 
 #include "folly/Range.h"
-#include "folly/dynamic.h"
+#include "folly/json/dynamic.h"
 
 namespace facebook::velox::functions {
 

--- a/velox/functions/prestosql/json/SIMDJsonExtractor.h
+++ b/velox/functions/prestosql/json/SIMDJsonExtractor.h
@@ -19,7 +19,7 @@
 #include <string>
 
 #include "folly/Range.h"
-#include "folly/dynamic.h"
+#include "folly/json/dynamic.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/functions/prestosql/json/JsonPathTokenizer.h"
 #include "velox/functions/prestosql/json/SIMDJsonUtil.h"

--- a/velox/functions/prestosql/json/tests/JsonExtractorTest.cpp
+++ b/velox/functions/prestosql/json/tests/JsonExtractorTest.cpp
@@ -16,7 +16,7 @@
 
 #include "velox/functions/prestosql/json/JsonExtractor.h"
 
-#include "folly/json.h"
+#include "folly/json/json.h"
 #include "gtest/gtest.h"
 #include "velox/common/base/VeloxException.h"
 

--- a/velox/functions/prestosql/json/tests/SIMDJsonExtractorTest.cpp
+++ b/velox/functions/prestosql/json/tests/SIMDJsonExtractorTest.cpp
@@ -18,7 +18,7 @@
 #include <optional>
 #include <string>
 
-#include "folly/json.h"
+#include "folly/json/json.h"
 #include "gtest/gtest.h"
 #include "velox/common/base/VeloxException.h"
 

--- a/velox/functions/prestosql/types/JsonType.cpp
+++ b/velox/functions/prestosql/types/JsonType.cpp
@@ -22,7 +22,7 @@
 
 #include "folly/CPortability.h"
 #include "folly/Conv.h"
-#include "folly/json.h"
+#include "folly/json/json.h"
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/expression/EvalCtx.h"

--- a/velox/type/HugeInt.h
+++ b/velox/type/HugeInt.h
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <folly/dynamic.h>
+#include <folly/json/dynamic.h>
 #include <sstream>
 #include <string>
 #include "velox/common/base/BitUtil.h"

--- a/velox/type/StringView.h
+++ b/velox/type/StringView.h
@@ -23,7 +23,7 @@
 #include <folly/FBString.h>
 #include <folly/Format.h>
 #include <folly/Range.h>
-#include <folly/dynamic.h>
+#include <folly/json/dynamic.h>
 
 #include <fmt/format.h>
 

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -19,7 +19,7 @@
 #include <sstream>
 #include <string>
 
-#include <folly/dynamic.h>
+#include <folly/json/dynamic.h>
 
 #include "velox/common/base/CheckedArithmetic.h"
 #include "velox/type/StringView.h"

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -20,7 +20,7 @@
 #include <folly/Format.h>
 #include <folly/Range.h>
 #include <folly/String.h>
-#include <folly/json.h>
+#include <folly/json/json.h>
 #include <cstdint>
 #include <cstring>
 #include <ctime>

--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -16,7 +16,7 @@
 
 #include "velox/type/Variant.h"
 #include <cfloat>
-#include "folly/json.h"
+#include "folly/json/json.h"
 #include "velox/common/encode/Base64.h"
 #include "velox/type/DecimalUtil.h"
 #include "velox/type/HugeInt.h"

--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -20,7 +20,7 @@
 
 #include <fmt/format.h>
 
-#include "folly/dynamic.h"
+#include "folly/json/dynamic.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/VeloxException.h"
 #include "velox/type/Conversions.h"

--- a/velox/vector/BiasVector.h
+++ b/velox/vector/BiasVector.h
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include <folly/dynamic.h>
+#include <folly/json/dynamic.h>
 
 #include "velox/common/base/SimdUtil.h"
 #include "velox/common/base/VeloxException.h"

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -17,7 +17,7 @@
 
 #include <folly/container/F14Map.h>
 #include <folly/container/F14Set.h>
-#include <folly/dynamic.h>
+#include <folly/json/dynamic.h>
 #include <gflags/gflags_declare.h>
 
 #include "velox/common/base/SimdUtil.h"

--- a/velox/vector/tests/SimpleVectorTest.cpp
+++ b/velox/vector/tests/SimpleVectorTest.cpp
@@ -22,7 +22,7 @@
 
 #include <folly/Demangle.h>
 #include <folly/FileUtil.h>
-#include <folly/dynamic.h>
+#include <folly/json/dynamic.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/vector/BuilderTypeUtils.h"


### PR DESCRIPTION
Summary:
The following headers were shimmed in //folly:dynamic and were modded:
  - folly/DynamicConverter.h -> folly/json/DynamicConverter.h
  - folly/dynamic.h -> folly/json/dynamic.h
  - folly/dynamic-inl.h -> folly/json/dynamic-inl.h
  - folly/json.h -> folly/json/json.h

`arc lint` was applied

Reviewed By: yfeldblum

Differential Revision: D53837586


