### PR TITLE
Add configuration 'spark.partition_id' and refactor rand(seed) function

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -304,6 +304,9 @@ class QueryConfig {
   static constexpr const char* kSparkBloomFilterMaxNumBits =
       "spark.bloom_filter.max_num_bits";
 
+  /// The current spark partition id.
+  static constexpr const char* kSparkPartitionId = "spark.partition_id";
+
   /// The number of local parallel table writer operators per task.
   static constexpr const char* kTaskWriterCount = "task_writer_count";
 
@@ -663,6 +666,14 @@ class QueryConfig {
         kDefault,
         "{} cannot exceed the default value",
         kSparkBloomFilterMaxNumBits);
+    return value;
+  }
+
+  int32_t sparkPartitionId() const {
+    auto id = get<int32_t>(kSparkPartitionId);
+    VELOX_CHECK(id.has_value(), "Spark partition id is not set.");
+    auto value = id.value();
+    VELOX_CHECK_GE(value, 0, "Invalid Spark partition id.");
     return value;
   }
 

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -620,3 +620,6 @@ Spark-specific Configuration
      - 4194304
      - The maximum number of bits to use for the bloom filter in :spark:func:`bloom_filter_agg` function,
        the value of this config can not exceed the default value.
+   * - spark.partition_id
+     - integer
+     - The current task's Spark partition ID. It's set by the query engine (Spark) prior to task execution.

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -175,14 +175,13 @@ Mathematical Functions
 
         SELECT rand(); -- 0.9629742951434543
 
-.. spark:function:: rand(seed, partitionIndex) -> double
+.. spark:function:: rand(seed) -> double
 
     Returns a random value with uniformly distributed values in [0, 1) using a seed formed
-    by combining user-specified ``seed`` and framework provided ``partitionIndex``. The
+    by combining user-specified ``seed`` and the configuration `spark.partition_id`. The
     framework is responsible for deterministic partitioning of the data and assigning unique
-    ``partitionIndex`` to each thread (in a deterministic way).
-    ``seed`` must be constant. NULL ``seed`` is identical to zero ``seed``. ``partitionIndex``
-    cannot be NULL. ::
+    `spark.partition_id` to each thread (in a deterministic way) .
+    ``seed`` must be constant. NULL ``seed`` is identical to zero ``seed``. ::
 
         SELECT rand(0);    -- 0.5488135024422883
         SELECT rand(NULL); -- 0.5488135024422883
@@ -191,9 +190,9 @@ Mathematical Functions
 
     An alias for ``rand()``.
 
-.. spark:function:: random(seed, partitionIndex) -> double
+.. spark:function:: random(seed) -> double
 
-    An alias for ``rand(seed, partitionIndex)``.
+    An alias for ``rand(seed)``.
 
 .. spark:function:: remainder(n, m) -> [same as n]
 

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -24,24 +24,10 @@ namespace facebook::velox::functions::sparksql {
 
 void registerRandFunctions(const std::string& prefix) {
   registerFunction<RandFunction, double>({prefix + "rand", prefix + "random"});
-  // Has seed & partition index as input.
-  registerFunction<
-      RandFunction,
-      double,
-      int32_t /*seed*/,
-      int32_t /*partition index*/>({prefix + "rand", prefix + "random"});
-  // Has seed & partition index as input.
-  registerFunction<
-      RandFunction,
-      double,
-      int64_t /*seed*/,
-      int32_t /*partition index*/>({prefix + "rand", prefix + "random"});
-  // NULL constant as seed of unknown type.
-  registerFunction<
-      RandFunction,
-      double,
-      UnknownValue /*seed*/,
-      int32_t /*partition index*/>({prefix + "rand", prefix + "random"});
+  registerFunction<RandFunction, double, Constant<int32_t>>(
+      {prefix + "rand", prefix + "random"});
+  registerFunction<RandFunction, double, Constant<int64_t>>(
+      {prefix + "rand", prefix + "random"});
 }
 
 void registerArithmeticFunctions(const std::string& prefix) {


### PR DESCRIPTION
Add configuration 'spark.partition_id' and refactor fucntion rand(seed) to 
consume it.

Spark partition index is required for various Spark functions such as 
`rand(seed)` and `spark_partition_id`. However, when Gluten constructs
Substrait plans on the Spark driver side, the Spark partition index is
unavailable. Passing it as a function parameter becomes challenging.
Therefore, we need to specify it as a configuration to be passed to Velox
functions.