### PR TITLE
Remove unnecessary include of boost/locale.hpp

### DIFF
--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -17,7 +17,6 @@
 
 #include "folly/ssl/OpenSSLHash.h"
 
-#include <boost/locale.hpp>
 #include <codecvt>
 #include <string>
 #include "velox/expression/VectorFunction.h"


### PR DESCRIPTION
Upgrading boost to 1.84 required a change for Ubuntu to move from a package manager provided version of boost to one that is build in the setup-ubuntu script or, if not found uses the bundled version. 

This caused a failure in the benchmark runs, for example,
https://github.com/facebookincubator/velox/actions/runs/8119444457/job/22195340396?pr=8934

```
In file included from /home/runner/work/velox/velox/velox/velox/functions/sparksql/Register.cpp:40:
/home/runner/work/velox/velox/velox/./velox/functions/sparksql/String.h:20:10: fatal error: boost/locale.hpp: No such file or directory
   20 | #include <boost/locale.hpp>
```

There are two (apparent) problems:

- Observation 1:  is the setup-ubuntu script not running the various install functions (for folly, fmt, boost etc). This would install boost into the system (and make the header available through the system include path). I only see the package manager being executed but none of the other libraries are downloaded and built.

- Observation 2: When boost is built from the bundle the dependency to boost is not declared for the sparksql function library. Therefore it won't find the header from the bundled location.

It turns out that on further inspection the header file is not necessary aka not used. Therefore, it can be removed which resolves the build issue.

