### PR TITLE
Fix build failure by properly forward declaring IcebergDeleteFile.

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergSplit.h
+++ b/velox/connectors/hive/iceberg/IcebergSplit.h
@@ -21,7 +21,7 @@
 
 namespace facebook::velox::connector::hive::iceberg {
 
-class IcebergDeleteFile;
+struct IcebergDeleteFile;
 
 struct HiveIcebergSplit : public connector::hive::HiveConnectorSplit {
   std::vector<IcebergDeleteFile> deleteFiles;


### PR DESCRIPTION
Summary:
In `velox/connectors/hive/iceberg/IcebergDeleteFile.h` IcebergDeleteFile is declared as a struct, however in `velox/connectors/hive/iceberg/IcebergSplit.h` its forward declared as a class - which causes build failure in Meta internal system with following error

```
In file included from .../presto-trunk/presto-native-execution/presto_cpp/main/types/PrestoToVeloxSplit.cpp:18:                                                    
.../velox/connectors/hive/__velox_hive_connector__/buck-headers/velox/connectors/hive/iceberg/IcebergSplit.h:24:1: error: class 'IcebergD
eleteFile' was previously declared as a struct; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Werror,-Wmismatched-tags]                       
class IcebergDeleteFile;                                                                                                                                                     
^                                                                                                                                                                            
.../velox/connectors/hive/__velox_hive_connector__/buck-headers/velox/connectors/hive/iceberg/IcebergDeleteFile.h:32:8: note: previous us
e is here                                                                                                                                                                    
struct IcebergDeleteFile {                                                                                                                                                   
       ^                                                                                                                                                                     
buck-out/v2/gen/fbcode/0155eabfa767915a/velox/connectors/hive/__velox_hive_connector__/buck-headers/velox/connectors/hive/iceberg/IcebergSplit.h:24:1: note: did you mean str
uct here?                                                                                                                                                                    
class IcebergDeleteFile;                                                                                                                                                     
^~~~~                                                                                                                                                                        
struct
```

Fixing the forward declaration here.

Reviewed By: xiaoxmeng

Differential Revision: D54453203


