### PR TITLE
Enable find static package of gflags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,12 @@ set(VELOX_DEPENDENCY_SOURCE
       STRING
       "Default source for all dependencies with source builds enabled: AUTO SYSTEM BUNDLED."
 )
-set(VELOX_GFLAGS_TYPE "shared" CACHE STRING "Specify whether to find the gflags package as a shared or static package")
+set(VELOX_GFLAGS_TYPE
+    "shared"
+    CACHE
+      STRING
+      "Specify whether to find the gflags package as a shared or static package"
+)
 option(VELOX_ENABLE_EXEC "Build exec." ON)
 option(VELOX_ENABLE_AGGREGATES "Build aggregates." ON)
 option(VELOX_ENABLE_HIVE_CONNECTOR "Build Hive connector." ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ set(VELOX_DEPENDENCY_SOURCE
       STRING
       "Default source for all dependencies with source builds enabled: AUTO SYSTEM BUNDLED."
 )
+set(VELOX_GFLAGS_TYPE "shared" CACHE STRING "Specify whether to find the gflags package as a shared or static library")
 option(VELOX_ENABLE_EXEC "Build exec." ON)
 option(VELOX_ENABLE_AGGREGATES "Build aggregates." ON)
 option(VELOX_ENABLE_HIVE_CONNECTOR "Build Hive connector." ON)
@@ -380,7 +381,7 @@ resolve_dependency(Boost 1.66.0 COMPONENTS ${BOOST_INCLUDE_LIBRARIES})
 # for reference. find_package(range-v3)
 
 set_source(gflags)
-resolve_dependency(gflags COMPONENTS shared)
+resolve_dependency(gflags COMPONENTS ${VELOX_GFLAGS_TYPE})
 if(NOT TARGET gflags::gflags)
   # This is a bit convoluted, but we want to be able to use gflags::gflags as a
   # target even when velox is built as a subproject which uses

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ set(VELOX_DEPENDENCY_SOURCE
       STRING
       "Default source for all dependencies with source builds enabled: AUTO SYSTEM BUNDLED."
 )
-set(VELOX_GFLAGS_TYPE "shared" CACHE STRING "Specify whether to find the gflags package as a shared or static library")
+set(VELOX_GFLAGS_TYPE "shared" CACHE STRING "Specify whether to find the gflags package as a shared or static package")
 option(VELOX_ENABLE_EXEC "Build exec." ON)
 option(VELOX_ENABLE_AGGREGATES "Build aggregates." ON)
 option(VELOX_ENABLE_HIVE_CONNECTOR "Build Hive connector." ON)


### PR DESCRIPTION
Fix [#8375](https://github.com/facebookincubator/velox/issues/8375)

In Velox, only the gflags package is configured to find the shared
package. However, if the operating system has the static package of
gflags pre-installed, CMake will report an error: Package gflags was
installed without the required component shared!

Add option VELOX_GFLAGS_TYPE to CMakelist.txt. When the static package
of gflags is pre-installed on the OS, setting
'-DVELOX_GFLAGS_TYPE=static' allows CMake to compile successfully.