### PR TITLE
Extend ApproxDistinctResultVerifier for WindowFuzzer

### DIFF
--- a/velox/exec/fuzzer/ResultVerifier.h
+++ b/velox/exec/fuzzer/ResultVerifier.h
@@ -54,6 +54,19 @@ class ResultVerifier {
       const core::AggregationNode::Aggregate& aggregate,
       const std::string& aggregateName) = 0;
 
+  /// Called once on a window operation before possibly multiple calls to the
+  /// 'compare' or 'verify' APIs. to specify the input data, window partition-by
+  /// keys, the window function, the window frame, and the name of the column
+  /// that will store the window function results.
+  virtual void initializeWindow(
+      const std::vector<RowVectorPtr>& /*input*/,
+      const std::vector<std::string>& /*partitionByKeys*/,
+      const core::WindowNode::Function& /*function*/,
+      const std::string& /*frame*/,
+      const std::string& /*windowName*/) {
+    VELOX_NYI();
+  }
+
   /// Compares results of two logically equivalent Velox plans or a Velox plan
   /// and a reference DB query.
   ///

--- a/velox/exec/fuzzer/WindowFuzzer.cpp
+++ b/velox/exec/fuzzer/WindowFuzzer.cpp
@@ -137,6 +137,10 @@ void WindowFuzzer::go() {
 
     const bool customVerification =
         customVerificationFunctions_.count(signature.name) != 0;
+    std::shared_ptr<ResultVerifier> customVerifier = nullptr;
+    if (customVerification) {
+      customVerifier = customVerificationFunctions_.at(signature.name);
+    }
     const bool requireSortedInput =
         orderDependentFunctions_.count(signature.name) != 0;
 
@@ -174,6 +178,7 @@ void WindowFuzzer::go() {
         call,
         input,
         customVerification,
+        customVerifier,
         FLAGS_enable_window_reference_verification);
     if (failed) {
       signatureWithStats.second.numFailed++;
@@ -209,6 +214,7 @@ void WindowFuzzer::testAlternativePlans(
     const std::string& functionCall,
     const std::vector<RowVectorPtr>& input,
     bool customVerification,
+    const std::shared_ptr<ResultVerifier>& customVerifier,
     const velox::test::ResultOrError& expected) {
   std::vector<AggregationFuzzerBase::PlanWithSplits> plans;
 
@@ -265,14 +271,23 @@ void WindowFuzzer::testAlternativePlans(
 
   for (const auto& plan : plans) {
     testPlan(
-        plan,
-        false,
-        false,
-        customVerification,
-        /*customVerifiers*/ {},
-        expected);
+        plan, false, false, customVerification, {customVerifier}, expected);
   }
 }
+
+namespace {
+void initializeVerifier(
+    const core::PlanNodePtr& plan,
+    const std::shared_ptr<ResultVerifier>& customVerifier,
+    const std::vector<RowVectorPtr>& input,
+    const std::vector<std::string>& partitionKeys,
+    const std::string& frame) {
+  const auto& windowNode =
+      std::dynamic_pointer_cast<const core::WindowNode>(plan);
+  customVerifier->initializeWindow(
+      input, partitionKeys, windowNode->windowFunctions()[0], frame, "w0");
+}
+} // namespace
 
 bool WindowFuzzer::verifyWindow(
     const std::vector<std::string>& partitionKeys,
@@ -281,12 +296,22 @@ bool WindowFuzzer::verifyWindow(
     const std::string& functionCall,
     const std::vector<RowVectorPtr>& input,
     bool customVerification,
+    const std::shared_ptr<ResultVerifier>& customVerifier,
     bool enableWindowVerification) {
   auto frame = getFrame(partitionKeys, sortingKeysAndOrders, frameClause);
   auto plan = PlanBuilder()
                   .values(input)
                   .window({fmt::format("{} over ({})", functionCall, frame)})
                   .planNode();
+  if (customVerifier) {
+    initializeVerifier(plan, customVerifier, input, partitionKeys, frame);
+  }
+  SCOPE_EXIT {
+    if (customVerifier) {
+      customVerifier->reset();
+    }
+  };
+
   if (persistAndRunOnce_) {
     persistReproInfo({{plan, {}}}, reproPersistPath_);
   }
@@ -298,8 +323,8 @@ bool WindowFuzzer::verifyWindow(
       ++stats_.numFailed;
     }
 
-    if (!customVerification && enableWindowVerification) {
-      if (resultOrError.result) {
+    if (!customVerification) {
+      if (resultOrError.result && enableWindowVerification) {
         auto referenceResult = computeReferenceResults(plan, input);
         stats_.updateReferenceQueryStats(referenceResult.second);
         if (auto expectedResult = referenceResult.first) {
@@ -316,9 +341,15 @@ bool WindowFuzzer::verifyWindow(
         }
       }
     } else {
-      // TODO: support custom verification.
-      LOG(INFO) << "Verification skipped";
+      LOG(INFO) << "Verification through custom verifier";
       ++stats_.numVerificationSkipped;
+
+      if (customVerifier && resultOrError.result) {
+        VELOX_CHECK(
+            customVerifier->supportsVerify(),
+            "Window fuzzer only uses custom verify() methods.");
+        customVerifier->verify(resultOrError.result);
+      }
     }
 
     testAlternativePlans(
@@ -328,6 +359,7 @@ bool WindowFuzzer::verifyWindow(
         functionCall,
         input,
         customVerification,
+        customVerifier,
         resultOrError);
 
     return resultOrError.exceptionPtr != nullptr;

--- a/velox/exec/fuzzer/WindowFuzzer.h
+++ b/velox/exec/fuzzer/WindowFuzzer.h
@@ -118,6 +118,7 @@ class WindowFuzzer : public AggregationFuzzerBase {
       const std::string& functionCall,
       const std::vector<RowVectorPtr>& input,
       bool customVerification,
+      const std::shared_ptr<ResultVerifier>& customVerifier,
       bool enableWindowVerification);
 
   void testAlternativePlans(
@@ -127,6 +128,7 @@ class WindowFuzzer : public AggregationFuzzerBase {
       const std::string& functionCall,
       const std::vector<RowVectorPtr>& input,
       bool customVerification,
+      const std::shared_ptr<ResultVerifier>& customVerifier,
       const velox::test::ResultOrError& expected);
 
   const std::unordered_set<std::string> orderDependentFunctions_;

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -184,4 +184,10 @@ void registerAllAggregateFunctions(
   registerVarianceAggregates(prefix, withCompanionFunctions, overwrite);
 }
 
+extern void registerCountDistinctAggregate(const std::string& prefix);
+
+void registerInternalAggregateFunctions(const std::string& prefix) {
+  registerCountDistinctAggregate(prefix);
+}
+
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h
@@ -30,4 +30,8 @@ void registerAllAggregateFunctions(
     bool onlyPrestoSignatures = false,
     bool overwrite = true);
 
+/// Register internal aggregation functions only for testing.
+/// \param prefix : Prefix for the aggregate functions.
+void registerInternalAggregateFunctions(const std::string& prefix);
+
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(
   CentralMomentsAggregationTest.cpp
   ChecksumAggregateTest.cpp
   CountAggregationTest.cpp
+  CountDistinctTest.cpp
   CountIfAggregationTest.cpp
   CovarianceAggregationTest.cpp
   EntropyAggregationTest.cpp

--- a/velox/functions/prestosql/aggregates/tests/CountDistinctTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/CountDistinctTest.cpp
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+
+using namespace facebook::velox::exec;
+using namespace facebook::velox::functions::aggregate::test;
+using namespace facebook::velox::exec::test;
+
+namespace facebook::velox::aggregate::test {
+
+namespace {
+
+class CountDistinctTest : public AggregationTestBase {
+ protected:
+  void SetUp() override {
+    prestosql::registerInternalAggregateFunctions("");
+    AggregationTestBase::SetUp();
+    allowInputShuffle();
+  }
+};
+
+TEST_F(CountDistinctTest, global) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3, 4, 5, 3, 4, 2, 6, 7}),
+      makeFlatVector<StringView>(
+          {"1", "2", "3", "4", "5", "3", "4", "2", "6", "7"}),
+  });
+
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>(std::vector<int64_t>{7}),
+  });
+
+  testAggregations(
+      {data}, {}, {"\"$internal$count_distinct\"(c0)"}, {expected});
+  testAggregations(
+      {data}, {}, {"\"$internal$count_distinct\"(c1)"}, {expected});
+
+  // Null inputs.
+  data = makeRowVector({
+      makeNullableFlatVector<int32_t>(
+          {1, 2, std::nullopt, 4, 5, std::nullopt, 4, 2, 6, 7}),
+      makeNullableFlatVector<StringView>(
+          {"1", "2", std::nullopt, "4", "5", std::nullopt, "4", "2", "6", "7"}),
+  });
+
+  expected = makeRowVector({
+      makeFlatVector<int64_t>(std::vector<int64_t>{6}),
+  });
+
+  testAggregations(
+      {data}, {}, {"\"$internal$count_distinct\"(c0)"}, {expected});
+  testAggregations(
+      {data}, {}, {"\"$internal$count_distinct\"(c1)"}, {expected});
+
+  // All inputs are null.
+  data = makeRowVector({
+      makeAllNullFlatVector<int32_t>(1'000),
+      makeAllNullFlatVector<StringView>(1'000),
+  });
+
+  expected = makeRowVector({
+      makeFlatVector<int64_t>(std::vector<int64_t>{0}),
+  });
+
+  testAggregations(
+      {data}, {}, {"\"$internal$count_distinct\"(c0)"}, {expected});
+  testAggregations(
+      {data}, {}, {"\"$internal$count_distinct\"(c1)"}, {expected});
+}
+
+TEST_F(CountDistinctTest, groupBy) {
+  auto data = makeRowVector({
+      makeFlatVector<int16_t>({1, 1, 2, 2, 2, 1, 2, 1, 2, 1}),
+      makeFlatVector<int32_t>({1, 2, 3, 4, 5, 3, 4, 2, 6, 7}),
+      makeFlatVector<StringView>(
+          {"1", "2", "3", "4", "5", "3", "4", "2", "6", "7"}),
+  });
+
+  auto expected = makeRowVector({
+      makeFlatVector<int16_t>({1, 2}),
+      makeFlatVector<int64_t>({4, 4}),
+  });
+
+  testAggregations(
+      {data, data, data},
+      {"c0"},
+      {"\"$internal$count_distinct\"(c1)"},
+      {expected});
+  testAggregations(
+      {data, data, data},
+      {"c0"},
+      {"\"$internal$count_distinct\"(c2)"},
+      {expected});
+
+  // Null inputs.
+  data = makeRowVector({
+      makeFlatVector<int16_t>({1, 1, 2, 2, 2, 1, 2, 1, 2, 1}),
+      makeNullableFlatVector<int32_t>(
+          {1,
+           std::nullopt,
+           3,
+           std::nullopt,
+           5,
+           std::nullopt,
+           3,
+           std::nullopt,
+           6,
+           1}),
+      makeNullableFlatVector<StringView>(
+          {"1",
+           std::nullopt,
+           "3",
+           std::nullopt,
+           "5",
+           std::nullopt,
+           "3",
+           std::nullopt,
+           "6",
+           "1"}),
+  });
+
+  expected = makeRowVector({
+      makeFlatVector<int16_t>({1, 2}),
+      makeFlatVector<int64_t>({1, 3}),
+  });
+
+  testAggregations(
+      {data, data, data},
+      {"c0"},
+      {"\"$internal$count_distinct\"(c1)"},
+      {expected});
+  testAggregations(
+      {data, data, data},
+      {"c0"},
+      {"\"$internal$count_distinct\"(c2)"},
+      {expected});
+
+  // All inputs are null for a group.
+  data = makeRowVector({
+      makeFlatVector<int16_t>({1, 1, 2, 2, 2, 1, 2, 1, 2, 1}),
+      makeNullableFlatVector<int32_t>(
+          {1,
+           std::nullopt,
+           std::nullopt,
+           std::nullopt,
+           std::nullopt,
+           std::nullopt,
+           std::nullopt,
+           std::nullopt,
+           std::nullopt,
+           1}),
+      makeNullableFlatVector<StringView>(
+          {"1",
+           std::nullopt,
+           std::nullopt,
+           std::nullopt,
+           std::nullopt,
+           std::nullopt,
+           std::nullopt,
+           std::nullopt,
+           std::nullopt,
+           "1"}),
+  });
+
+  expected = makeRowVector({
+      makeFlatVector<int16_t>({1, 2}),
+      makeFlatVector<int64_t>({1, 0}),
+  });
+
+  testAggregations(
+      {data, data, data},
+      {"c0"},
+      {"\"$internal$count_distinct\"(c1)"},
+      {expected});
+  testAggregations(
+      {data, data, data},
+      {"c0"},
+      {"\"$internal$count_distinct\"(c2)"},
+      {expected});
+}
+
+TEST_F(CountDistinctTest, globalArray) {
+  auto data = makeRowVector({
+      makeArrayVector<int32_t>({
+          {1, 2, 3},
+          {4, 5},
+          {1, 2, 3},
+          {3, 4, 2, 6, 7},
+          {1, 2, 3},
+          {4, 5},
+      }),
+  });
+
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>(std::vector<int64_t>{3}),
+  });
+
+  testAggregations(
+      {data}, {}, {"\"$internal$count_distinct\"(c0)"}, {expected});
+}
+
+TEST_F(CountDistinctTest, groupByArray) {
+  auto data = makeRowVector({
+      makeFlatVector<int16_t>({1, 1, 1, 2, 2, 1}),
+      makeArrayVector<int32_t>({
+          {1, 2, 3},
+          {4, 5},
+          {1, 2, 3},
+          {3, 4, 2, 6, 7},
+          {1, 2, 3},
+          {4, 5},
+      }),
+  });
+
+  auto expected = makeRowVector({
+      makeFlatVector<int16_t>({1, 2}),
+      makeFlatVector<int64_t>({2, 2}),
+  });
+
+  testAggregations(
+      {data, data, data},
+      {"c0"},
+      {"\"$internal$count_distinct\"(c1)"},
+      {expected});
+}
+
+} // namespace
+} // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/fuzzer/CMakeLists.txt
+++ b/velox/functions/prestosql/fuzzer/CMakeLists.txt
@@ -34,5 +34,6 @@ target_link_libraries(
   velox_aggregates
   velox_window
   velox_expression_test_utility
+  velox_functions_prestosql
   gtest
   gtest_main)


### PR DESCRIPTION
Summary:
Extend ApproxDistinctResultVerifier to verify approx_distinct in window operations. This
diff adds an internal aggregation function `$internal$count_distinct` to be used in
ApproxDistinctResultVerifier for window fuzzer.

Differential Revision: D54497464


