### PR TITLE
Support complex type 'compare' in 3-arg min_by and max_by Presto aggregates

### DIFF
--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -1844,7 +1844,7 @@ exec::AggregateRegistrationResult registerMinMaxBy(
   // V, C, bigint -> row(bigint, array(C), array(V)) -> array(V).
   signatures.push_back(exec::AggregateFunctionSignatureBuilder()
                            .typeVariable("V")
-                           .typeVariable("C")
+                           .orderableTypeVariable("C")
                            .returnType("array(V)")
                            .intermediateType("row(bigint,array(C),array(V))")
                            .argumentType("V")

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -577,12 +577,13 @@ struct MinMaxByNComplexCompareTypeAccumulator {
       vector_size_t compareIndex,
       std::optional<V> value,
       Compare& comparator) {
-    auto comparePosition = writeComplex(decodedCompare, compareIndex);
     if (base.heapValues.size() < base.n) {
+      auto comparePosition = writeComplex(decodedCompare, compareIndex);
       addToAccumulator(comparePosition, value, comparator);
     } else {
       const auto& topPair = base.heapValues.front();
       if (comparator.compare(topPair, decodedCompare, compareIndex)) {
+        auto comparePosition = writeComplex(decodedCompare, compareIndex);
         std::pop_heap(
             base.heapValues.begin(), base.heapValues.end(), comparator);
         base.heapValues.pop_back();
@@ -727,12 +728,13 @@ struct MinMaxByNStringViewValueTypeComplexCompareTypeAccumulator {
       vector_size_t compareIndex,
       std::optional<V> value,
       Compare& comparator) {
-    auto comparePosition = writeComplex(decodedCompare, compareIndex);
     if (base.heapValues.size() < base.n) {
+      auto comparePosition = writeComplex(decodedCompare, compareIndex);
       addToAccumulator(comparePosition, value, comparator);
     } else {
       const auto& topPair = base.heapValues.front();
       if (comparator.compare(topPair, decodedCompare, compareIndex)) {
+        auto comparePosition = writeComplex(decodedCompare, compareIndex);
         std::pop_heap(
             base.heapValues.begin(), base.heapValues.end(), comparator);
         base.heapValues.pop_back();
@@ -885,13 +887,16 @@ struct MinMaxByNBothComplexTypeAccumulator {
       DecodedVector& decodedValue,
       vector_size_t valueIndex,
       Compare& comparator) {
-    auto comparePosition = writeComplexCompare(decodedCompare, compareIndex);
-    auto valuePosition = writeComplexValue(decodedValue, valueIndex);
     if (base.heapValues.size() < base.n) {
+      auto comparePosition = writeComplexCompare(decodedCompare, compareIndex);
+      auto valuePosition = writeComplexValue(decodedValue, valueIndex);
       addToAccumulator(comparePosition, valuePosition, comparator);
     } else {
       const auto& topPair = base.heapValues.front();
       if (comparator.compare(topPair, decodedCompare, compareIndex)) {
+        auto comparePosition =
+            writeComplexCompare(decodedCompare, compareIndex);
+        auto valuePosition = writeComplexValue(decodedValue, valueIndex);
         std::pop_heap(
             base.heapValues.begin(), base.heapValues.end(), comparator);
         base.heapValues.pop_back();

--- a/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -2245,7 +2245,8 @@ TEST_F(MinMaxByComplexTypes, arrayTypeCompare) {
 
   // Test StringView type (both as value and comparison).
   data = makeRowVector({
-      makeFlatVector<std::string>({"a", "Abc", "bc", "Longer test string"}),
+      makeNullableFlatVector<std::string>(
+          {std::nullopt, "Abc", "bc", "Longer test string"}),
       makeArrayVector<std::string>(
           {{"a", "b", "Longer string ...."},
            {"c", "Abc", "Mountains and rivers"},
@@ -2253,16 +2254,20 @@ TEST_F(MinMaxByComplexTypes, arrayTypeCompare) {
            {"Oceans and skies"}}),
   });
 
-  expected = makeRowVector({makeArrayVector<std::string>({
-      {"Longer test string", "a"},
+  expected = makeRowVector({makeNullableArrayVector<std::string>({
+      {"Longer test string", std::nullopt},
   })});
 
   testAggregations({data}, {}, {"min_by(c0, c1, 2)"}, {expected});
 
   data = makeRowVector({
       makeFlatVector<int16_t>({1, 2, 1, 2, 1}),
-      makeFlatVector<std::string>(
-          {"a", "Abc", "bc", "Longer test string", "c"}),
+      makeNullableFlatVector<std::string>(
+          {std::nullopt,
+           "Abc",
+           std::nullopt,
+           "Longer test string",
+           std::nullopt}),
       makeArrayVector<std::string>(
           {{"a", "b", "Longer string ...."},
            {"c", "Abc", "Mountains and rivers"},
@@ -2273,8 +2278,8 @@ TEST_F(MinMaxByComplexTypes, arrayTypeCompare) {
 
   expected = makeRowVector(
       {makeFlatVector<int16_t>({1, 2}),
-       makeArrayVector<std::string>(
-           {{"c", "bc"}, {"Abc", "Longer test string"}})});
+       makeNullableArrayVector<std::string>(
+           {{std::nullopt, std::nullopt}, {"Abc", "Longer test string"}})});
 
   testAggregations({data}, {"c0"}, {"max_by(c1, c2, 2)"}, {expected});
 }


### PR DESCRIPTION
Presto's min_by and max_by with 3 args support complex type for the compare param, such as array.

Fixes #7469