### PR TITLE
Handle ShortDecimal correctly inside `importFromArrow`

### DIFF
--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -1067,11 +1067,11 @@ TypePtr importFromArrowImpl(
         // Handle bitwidth.
         if (format[idx + sz] == ',') {
           int bitWidth = std::stoi(&format[idx + sz + 1], &sz);
-          if (bitWidth != 128) {
-            VELOX_USER_FAIL(
-                "Conversion failed for '{}'. Velox decimal does not support custom bitwidth.",
-                format);
-          }
+          VELOX_USER_CHECK_EQ(
+              bitWidth,
+              128,
+              "Conversion failed for '{}'. Velox decimal does not support custom bitwidth.",
+              format);
         }
         return DECIMAL(precision, scale);
       } catch (std::invalid_argument&) {

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -1064,7 +1064,7 @@ TypePtr importFromArrowImpl(
         // Parse ",".
         int idx = 2 + sz + 1;
         int scale = std::stoi(&format[idx], &sz);
-        // Handle bitwidth.
+        // If bitwidth is provided, check if it is equal to 128.
         if (format[idx + sz] == ',') {
           int bitWidth = std::stoi(&format[idx + sz + 1], &sz);
           VELOX_USER_CHECK_EQ(

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -1191,6 +1191,21 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
     }
   }
 
+  void testShortDecimalImport() {
+    auto arrowSchema = makeArrowSchema("d:5,2");
+    ArrowContextHolder holder;
+    auto arrowArray = fillArrowArray(
+        std::vector<std::optional<int128_t>>{
+            1, -1, 0, 12345, -12345, std::nullopt},
+        holder);
+    auto output = importFromArrow(arrowSchema, arrowArray, pool_.get());
+    assertVectorContent(
+        std::vector<std::optional<int64_t>>{
+            1, -1, 0, 12345, -12345, std::nullopt},
+        output,
+        1);
+  }
+
   void testImportScalar() {
     testArrowImport<bool>("b", {});
     testArrowImport<bool>("b", {true});

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -1129,10 +1129,8 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
   // Vector (using vector maker). Then converts ArrowArray into Velox vector and
   // assert that both Velox vectors are semantically the same.
   template <typename TOutput, typename TInput = TOutput>
-  template <typename TOutput, typename TInput = TOutput>
   void testArrowImport(
       const char* format,
-      const std::vector<std::optional<TInput>>& inputValues) {
       const std::vector<std::optional<TInput>>& inputValues) {
     ArrowContextHolder holder;
     auto arrowArray = fillArrowArray(inputValues, holder);
@@ -1154,7 +1152,6 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
     // Buffer views are not reusable. Strings might need to create an additional
     // buffer, depending on the string sizes, in which case the buffers could be
     // reusable. So we don't check them in here.
-    if constexpr (!std::is_same_v<TInput, std::string>) {
     if constexpr (!std::is_same_v<TInput, std::string>) {
       EXPECT_FALSE(BaseVector::isVectorWritable(output));
     } else {
@@ -1232,7 +1229,7 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
           tsString.data(), {0, std::nullopt, Timestamp::kMaxSeconds});
     }
 
-        testArrowImport<int64_t, int128_t>(
+    testArrowImport<int64_t, int128_t>(
         "d:5,2", {1, -1, 0, 12345, -12345, std::nullopt});
   }
 

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -1314,6 +1314,8 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
   }
 
  private:
+  // Creates short decimals from int128 and asserts the content of actual vector
+  // with the expected values.
   void assertShortDecimalVectorContent(
       const std::vector<std::optional<int128_t>>& expectedValues,
       const VectorPtr& actual,

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -385,6 +385,9 @@ TEST_F(ArrowBridgeSchemaImportTest, scalar) {
   VELOX_ASSERT_THROW(
       *testSchemaImport("d:10,4,256"),
       "Conversion failed for 'd:10,4,256'. Velox decimal does not support custom bitwidth.");
+  VELOX_ASSERT_THROW(
+      *testSchemaImport("d:10,4,"),
+      "Unable to convert 'd:10,4,' ArrowSchema decimal format to Velox decimal");
 }
 
 TEST_F(ArrowBridgeSchemaImportTest, complexTypes) {

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -388,6 +388,15 @@ TEST_F(ArrowBridgeSchemaImportTest, scalar) {
   VELOX_ASSERT_THROW(
       *testSchemaImport("d:10,4,"),
       "Unable to convert 'd:10,4,' ArrowSchema decimal format to Velox decimal");
+  VELOX_ASSERT_THROW(
+      *testSchemaImport("d:10"),
+      "Unable to convert 'd:10' ArrowSchema decimal format to Velox decimal");
+  VELOX_ASSERT_THROW(
+      *testSchemaImport("d:"),
+      "Unable to convert 'd:' ArrowSchema decimal format to Velox decimal");
+  VELOX_ASSERT_THROW(
+      *testSchemaImport("d:10,"),
+      "Unable to convert 'd:10,' ArrowSchema decimal format to Velox decimal");
 }
 
 TEST_F(ArrowBridgeSchemaImportTest, complexTypes) {

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -381,6 +381,10 @@ TEST_F(ArrowBridgeSchemaImportTest, scalar) {
   VELOX_ASSERT_THROW(
       *testSchemaImport("d2,15"),
       "Unable to convert 'd2,15' ArrowSchema decimal format to Velox decimal");
+  EXPECT_EQ(*DECIMAL(10, 4), *testSchemaImport("d:10,4,128"));
+  VELOX_ASSERT_THROW(
+      *testSchemaImport("d:10,4,256"),
+      "Conversion failed for 'd:10,4,256'. Velox decimal does not support custom bitwidth.");
 }
 
 TEST_F(ArrowBridgeSchemaImportTest, complexTypes) {


### PR DESCRIPTION
Arrow uses `int128_t` to store ShortDecimal values, while inside velox we use `int64_t`.

`ExportToArrow` already handle it specifically, but `ImportFromArrow` misses this.

This pr tries to fix it.