### PR TITLE
Remove testWithTableScan flag in testAggregations

### DIFF
--- a/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h
+++ b/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h
@@ -68,8 +68,7 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
       const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates,
       const std::string& duckDbSql,
-      const std::unordered_map<std::string, std::string>& config = {},
-      bool testWithTableScan = true);
+      const std::unordered_map<std::string, std::string>& config = {});
 
   /// Same as above, but allows to specify a set of projections to apply after
   /// the aggregation.
@@ -80,8 +79,7 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
       const std::vector<std::string>& postAggregationProjections,
       std::function<std::shared_ptr<exec::Task>(
           exec::test::AssertQueryBuilder& builder)> assertResults,
-      const std::unordered_map<std::string, std::string>& config = {},
-      bool testWithTableScan = true);
+      const std::unordered_map<std::string, std::string>& config = {});
 
   /// Convenience version that allows to specify input data instead of a
   /// function to build Values plan node.
@@ -90,8 +88,7 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
       const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates,
       const std::string& duckDbSql,
-      const std::unordered_map<std::string, std::string>& config = {},
-      bool testWithTableScan = true);
+      const std::unordered_map<std::string, std::string>& config = {});
 
   /// Convenience version that allows to specify input data instead of a
   /// function to build Values plan node.
@@ -101,8 +98,7 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
       const std::vector<std::string>& aggregates,
       const std::vector<std::string>& postAggregationProjections,
       const std::string& duckDbSql,
-      const std::unordered_map<std::string, std::string>& config = {},
-      bool testWithTableScan = true);
+      const std::unordered_map<std::string, std::string>& config = {});
 
   /// Convenience version that allows to specify input data instead of a
   /// function to build Values plan node, and the expected result instead of a
@@ -112,8 +108,7 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
       const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates,
       const std::vector<RowVectorPtr>& expectedResult,
-      const std::unordered_map<std::string, std::string>& config = {},
-      bool testWithTableScan = true);
+      const std::unordered_map<std::string, std::string>& config = {});
 
   /// Convenience version that allows to specify input data instead of a
   /// function to build Values plan node, and the expected result instead of a
@@ -124,8 +119,7 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
       const std::vector<std::string>& aggregates,
       const std::vector<std::string>& postAggregationProjections,
       const std::vector<RowVectorPtr>& expectedResult,
-      const std::unordered_map<std::string, std::string>& config = {},
-      bool testWithTableScan = true);
+      const std::unordered_map<std::string, std::string>& config = {});
 
   /// Ensure the function is working in streaming use case.  Create a first
   /// aggregation function, add the rawInput1, then extract the accumulator,

--- a/velox/functions/prestosql/aggregates/tests/ApproxDistinctTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxDistinctTest.cpp
@@ -42,9 +42,7 @@ class ApproxDistinctTest : public AggregationTestBase {
         {vectors},
         {},
         {fmt::format("approx_distinct(c0, {})", maxStandardError)},
-        {expected},
-        {},
-        testWithTableScan);
+        {expected});
     testAggregationsWithCompanion(
         {vectors},
         [](auto& /*builder*/) {},
@@ -59,9 +57,7 @@ class ApproxDistinctTest : public AggregationTestBase {
         {},
         {fmt::format("approx_set(c0, {})", maxStandardError)},
         {"cardinality(a0)"},
-        {expected},
-        {},
-        testWithTableScan);
+        {expected});
   }
 
   void testGlobalAgg(
@@ -72,13 +68,7 @@ class ApproxDistinctTest : public AggregationTestBase {
     auto expected =
         makeRowVector({makeNullableFlatVector<int64_t>({expectedResult})});
 
-    testAggregations(
-        {vectors},
-        {},
-        {"approx_distinct(c0)"},
-        {expected},
-        {},
-        testWithTableScan);
+    testAggregations({vectors}, {}, {"approx_distinct(c0)"}, {expected});
     testAggregationsWithCompanion(
         {vectors},
         [](auto& /*builder*/) {},
@@ -89,13 +79,7 @@ class ApproxDistinctTest : public AggregationTestBase {
         {expected});
 
     testAggregations(
-        {vectors},
-        {},
-        {"approx_set(c0)"},
-        {"cardinality(a0)"},
-        {expected},
-        {},
-        testWithTableScan);
+        {vectors}, {}, {"approx_set(c0)"}, {"cardinality(a0)"}, {expected});
   }
 
   template <typename T, typename U>

--- a/velox/functions/prestosql/aggregates/tests/ArbitraryTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ArbitraryTest.cpp
@@ -57,9 +57,7 @@ TEST_F(ArbitraryTest, noNulls) {
       vectors,
       {},
       aggregates,
-      "SELECT first(c1), first(c2), first(c3), first(c4), first(c5), first(c6) FROM tmp",
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      "SELECT first(c1), first(c2), first(c3), first(c4), first(c5), first(c6) FROM tmp");
 
   // Group by aggregation.
   testAggregations(
@@ -69,9 +67,7 @@ TEST_F(ArbitraryTest, noNulls) {
       },
       {"p0"},
       aggregates,
-      "SELECT c0 % 10, first(c1), first(c2), first(c3), first(c4), first(c5), first(c6) FROM tmp GROUP BY 1",
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      "SELECT c0 % 10, first(c1), first(c2), first(c3), first(c4), first(c5), first(c6) FROM tmp GROUP BY 1");
 
   // encodings: use filter to wrap aggregation inputs in a dictionary.
   testAggregations(
@@ -82,9 +78,7 @@ TEST_F(ArbitraryTest, noNulls) {
       },
       {"p0"},
       aggregates,
-      "SELECT c0 % 10, first(c1), first(c2), first(c3), first(c4), first(c5), first(c6) FROM tmp WHERE c0 % 2 = 0 GROUP BY 1",
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      "SELECT c0 % 10, first(c1), first(c2), first(c3), first(c4), first(c5), first(c6) FROM tmp WHERE c0 % 2 = 0 GROUP BY 1");
 
   testAggregations(
       [&](PlanBuilder& builder) {
@@ -92,9 +86,7 @@ TEST_F(ArbitraryTest, noNulls) {
       },
       {},
       aggregates,
-      "SELECT first(c1), first(c2), first(c3), first(c4), first(c5), first(c6) FROM tmp WHERE c0 % 2 = 0",
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      "SELECT first(c1), first(c2), first(c3), first(c4), first(c5), first(c6) FROM tmp WHERE c0 % 2 = 0");
 }
 
 TEST_F(ArbitraryTest, nulls) {
@@ -121,18 +113,14 @@ TEST_F(ArbitraryTest, nulls) {
       vectors,
       {},
       {"arbitrary(c1)", "arbitrary(c2)", "arbitrary(c3)"},
-      "SELECT * FROM( VALUES (4, 0.50, NULL)) AS t",
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      "SELECT * FROM( VALUES (4, 0.50, NULL)) AS t");
 
   // Group by aggregation.
   testAggregations(
       vectors,
       {"c0"},
       {"arbitrary(c1)", "arbitrary(c2)", "arbitrary(c3)"},
-      "SELECT * FROM(VALUES (1, NULL, 0.50, NULL), (2, 4, NULL, NULL), (3, 5, 0.25, NULL)) AS t",
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      "SELECT * FROM(VALUES (1, NULL, 0.50, NULL), (2, 4, NULL, NULL), (3, 5, 0.25, NULL)) AS t");
 }
 
 TEST_F(ArbitraryTest, varchar) {
@@ -148,17 +136,13 @@ TEST_F(ArbitraryTest, varchar) {
       },
       {"p0"},
       {"arbitrary(c1)"},
-      "SELECT c0 % 11, first(c1) FROM tmp WHERE c1 IS NOT NULL GROUP BY 1",
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      "SELECT c0 % 11, first(c1) FROM tmp WHERE c1 IS NOT NULL GROUP BY 1");
 
   testAggregations(
       vectors,
       {},
       {"arbitrary(c1)"},
-      "SELECT first(c1) FROM tmp WHERE c1 IS NOT NULL",
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      "SELECT first(c1) FROM tmp WHERE c1 IS NOT NULL");
 
   // encodings: use filter to wrap aggregation inputs in a dictionary.
   testAggregations(
@@ -167,9 +151,7 @@ TEST_F(ArbitraryTest, varchar) {
       },
       {"p0"},
       {"arbitrary(c1)"},
-      "SELECT c0 % 11, first(c1) FROM tmp WHERE c0 % 2 = 0 AND c1 IS NOT NULL GROUP BY 1",
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      "SELECT c0 % 11, first(c1) FROM tmp WHERE c0 % 2 = 0 AND c1 IS NOT NULL GROUP BY 1");
 
   testAggregations(
       [&](PlanBuilder& builder) {
@@ -177,9 +159,7 @@ TEST_F(ArbitraryTest, varchar) {
       },
       {},
       {"arbitrary(c1)"},
-      "SELECT first(c1) FROM tmp WHERE c0 % 2 = 0 AND c1 IS NOT NULL",
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      "SELECT first(c1) FROM tmp WHERE c0 % 2 = 0 AND c1 IS NOT NULL");
 }
 
 TEST_F(ArbitraryTest, varcharConstAndNulls) {

--- a/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
@@ -456,9 +456,7 @@ TEST_F(AverageAggregationTest, avgDecimal) {
       {"avg(c0)"},
       {},
       {makeRowVector(
-          {makeNullableFlatVector<int64_t>({3'000}, DECIMAL(10, 1))})},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+          {makeNullableFlatVector<int64_t>({3'000}, DECIMAL(10, 1))})});
 
   // Long decimal aggregation
   testAggregations(
@@ -474,9 +472,7 @@ TEST_F(AverageAggregationTest, avgDecimal) {
       {"avg(c0)"},
       {},
       {makeRowVector({makeFlatVector(
-          std::vector<int128_t>{HugeInt::build(10, 300)}, DECIMAL(23, 4))})},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+          std::vector<int128_t>{HugeInt::build(10, 300)}, DECIMAL(23, 4))})});
   // Round-up average.
   testAggregations(
       {makeRowVector(
@@ -485,9 +481,7 @@ TEST_F(AverageAggregationTest, avgDecimal) {
       {"avg(c0)"},
       {},
       {makeRowVector(
-          {makeFlatVector(std::vector<int64_t>{337}, DECIMAL(3, 2))})},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+          {makeFlatVector(std::vector<int64_t>{337}, DECIMAL(3, 2))})});
 
   // The total sum overflows the max int128_t limit.
   std::vector<int128_t> rawVector;
@@ -501,9 +495,7 @@ TEST_F(AverageAggregationTest, avgDecimal) {
       {},
       {makeRowVector({makeFlatVector(
           std::vector<int128_t>{DecimalUtil::kLongDecimalMax},
-          DECIMAL(38, 0))})},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+          DECIMAL(38, 0))})});
   // The total sum underflows the min int128_t limit.
   rawVector.clear();
   auto underFlowTestResult = makeFlatVector(
@@ -516,9 +508,7 @@ TEST_F(AverageAggregationTest, avgDecimal) {
       {},
       {"avg(c0)"},
       {},
-      {makeRowVector({underFlowTestResult})},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      {makeRowVector({underFlowTestResult})});
 
   // Add more rows to show that average result is still accurate.
   for (int i = 0; i < 10; ++i) {
@@ -538,9 +528,7 @@ TEST_F(AverageAggregationTest, avgDecimal) {
       {"avg(c0)"},
       {},
       {makeRowVector(
-          {makeFlatVector(std::vector<int64_t>{100}, DECIMAL(3, 2))})},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+          {makeFlatVector(std::vector<int64_t>{100}, DECIMAL(3, 2))})});
 
   auto newSize = shortDecimal->size() * 2;
   auto indices = makeIndices(newSize, [&](int row) { return row / 2; });
@@ -553,9 +541,7 @@ TEST_F(AverageAggregationTest, avgDecimal) {
       {"avg(c0)"},
       {},
       {makeRowVector(
-          {makeFlatVector(std::vector<int64_t>{3'000}, DECIMAL(10, 1))})},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+          {makeFlatVector(std::vector<int64_t>{3'000}, DECIMAL(10, 1))})});
 
   // Decimal average aggregation with multiple groups.
   auto inputRows = {
@@ -587,13 +573,7 @@ TEST_F(AverageAggregationTest, avgDecimal) {
           {makeNullableFlatVector<int32_t>({3}),
            makeFlatVector(std::vector<int64_t>{-2498}, DECIMAL(5, 2))})};
 
-  testAggregations(
-      inputRows,
-      {"c0"},
-      {"avg(c1)"},
-      expectedResult,
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+  testAggregations(inputRows, {"c0"}, {"avg(c1)"}, expectedResult);
 
   AggregationTestBase::enableTestIncremental();
 }
@@ -610,13 +590,7 @@ TEST_F(AverageAggregationTest, avgDecimalWithMultipleRowVectors) {
   auto expectedResult = {makeRowVector(
       {makeFlatVector(std::vector<int64_t>{350}, DECIMAL(5, 2))})};
 
-  testAggregations(
-      inputRows,
-      {},
-      {"avg(c0)"},
-      expectedResult,
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+  testAggregations(inputRows, {}, {"avg(c0)"}, expectedResult);
 
   AggregationTestBase::enableTestIncremental();
 }

--- a/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
@@ -56,13 +56,7 @@ class ChecksumAggregateTest : public AggregationTestBase {
         fmt::format("VALUES (CAST(\'{}\' AS VARCHAR))", expectedChecksum);
 
     testAggregations(
-        rowVectors,
-        {},
-        {"checksum(c0)"},
-        {"to_base64(a0)"},
-        expectedDuckDbSql,
-        /*config*/ {},
-        testWithTableScan);
+        rowVectors, {}, {"checksum(c0)"}, {"to_base64(a0)"}, expectedDuckDbSql);
   }
 
   template <typename G, typename T>

--- a/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
@@ -28,7 +28,6 @@ class MapAggTest : public AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    allowInputShuffle();
   }
 };
 

--- a/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
@@ -150,13 +150,7 @@ TEST_F(MapAggTest, groupByWithDuplicates) {
 
   // We don't test with TableScan because when there are duplicate keys in
   // different splits, the result is non-deterministic.
-  testAggregations(
-      vectors,
-      {"c0"},
-      {"map_agg(c1, c2)"},
-      {expectedResult},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+  testAggregations(vectors, {"c0"}, {"map_agg(c1, c2)"}, {expectedResult});
 }
 
 TEST_F(MapAggTest, groupByNoData) {
@@ -310,13 +304,7 @@ TEST_F(MapAggTest, globalDuplicateKeys) {
 
   // We don't test with TableScan because when there are duplicate keys in
   // different splits, the result is non-deterministic.
-  testAggregations(
-      vectors,
-      {},
-      {"map_agg(c0, c1)"},
-      {expectedResult},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+  testAggregations(vectors, {}, {"map_agg(c0, c1)"}, {expectedResult});
 }
 
 /// Reproduces the bug reported in
@@ -373,20 +361,9 @@ TEST_F(MapAggTest, unknownKey) {
   });
 
   testAggregations(
-      {data},
-      {"c0"},
-      {"map_agg(c1, c2)"},
-      "VALUES (1, NULL), (2, NULL)",
-      {},
-      false /*testWithTableScan*/);
+      {data}, {"c0"}, {"map_agg(c1, c2)"}, "VALUES (1, NULL), (2, NULL)");
 
-  testAggregations(
-      {data},
-      {},
-      {"map_agg(c1, c2)"},
-      "VALUES (NULL)",
-      {},
-      false /*testWithTableScan*/);
+  testAggregations({data}, {}, {"map_agg(c1, c2)"}, "VALUES (NULL)");
 }
 
 TEST_F(MapAggTest, stringLifeCycle) {

--- a/velox/functions/prestosql/aggregates/tests/MapUnionAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MapUnionAggregationTest.cpp
@@ -278,20 +278,8 @@ TEST_F(MapUnionTest, unknownKeysAndValues) {
       makeMapVector<UnknownValue, UnknownValue>({{}, {}}),
   });
 
-  testAggregations(
-      {data},
-      {},
-      {"map_union(c1)"},
-      {expectedGlobalResult},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
-  testAggregations(
-      {data},
-      {"c0"},
-      {"map_union(c1)"},
-      {expectedGroupByResult},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+  testAggregations({data}, {}, {"map_union(c1)"}, {expectedGlobalResult});
+  testAggregations({data}, {"c0"}, {"map_union(c1)"}, {expectedGroupByResult});
 
   // map_union over non-empty map(T, unknown) where T is not unknown is allowed.
   data = makeRowVector({
@@ -329,20 +317,8 @@ TEST_F(MapUnionTest, unknownKeysAndValues) {
       }),
   });
 
-  testAggregations(
-      {data},
-      {},
-      {"map_union(c1)"},
-      {expectedGlobalResult},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
-  testAggregations(
-      {data},
-      {"c0"},
-      {"map_union(c1)"},
-      {expectedGroupByResult},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+  testAggregations({data}, {}, {"map_union(c1)"}, {expectedGlobalResult});
+  testAggregations({data}, {"c0"}, {"map_union(c1)"}, {expectedGroupByResult});
 
   // map_union over non-emtpy map(unknown, T) is not allowed.
   data = makeRowVector({

--- a/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -468,9 +468,7 @@ class MinMaxByGlobalByAggregationTest
           {},
           {"min_by(c0, c1)"},
           {},
-          testData.verifyDuckDbSql,
-          /*config*/ {},
-          /*testWithTableScan*/ false);
+          testData.verifyDuckDbSql);
     }
   }
 
@@ -566,9 +564,7 @@ class MinMaxByGlobalByAggregationTest
           {},
           {"max_by(c0, c1)"},
           {},
-          testData.verifyDuckDbSql,
-          /*config*/ {},
-          /*testWithTableScan*/ false);
+          testData.verifyDuckDbSql);
     }
   }
 };
@@ -858,9 +854,7 @@ class MinMaxByGroupByAggregationTest
           {"c2"},
           {"min_by(c0, c1)"},
           {},
-          testData.verifyDuckDbSql,
-          /*config*/ {},
-          /*testWithTableScan*/ false);
+          testData.verifyDuckDbSql);
     }
   }
 
@@ -1011,9 +1005,7 @@ class MinMaxByGroupByAggregationTest
           {"c2"},
           {"max_by(c0, c1)"},
           {},
-          testData.verifyDuckDbSql,
-          /*config*/ {},
-          /*testWithTableScan*/ false);
+          testData.verifyDuckDbSql);
     }
   }
 };

--- a/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
@@ -62,12 +62,7 @@ class MinMaxTest : public functions::aggregate::test::AggregationTestBase {
 
     // Global aggregation.
     testAggregations(
-        vectors,
-        {},
-        {agg(c1)},
-        fmt::format("SELECT {} FROM tmp", agg(c1)),
-        /*config*/ {},
-        testWithTableScan);
+        vectors, {}, {agg(c1)}, fmt::format("SELECT {} FROM tmp", agg(c1)));
 
     // Group by aggregation.
     testAggregations(
@@ -76,19 +71,12 @@ class MinMaxTest : public functions::aggregate::test::AggregationTestBase {
         },
         {"p0"},
         {agg(c1)},
-        fmt::format("SELECT c0 % 10, {} FROM tmp GROUP BY 1", agg(c1)),
-        /*config*/ {},
-        testWithTableScan);
+        fmt::format("SELECT c0 % 10, {} FROM tmp GROUP BY 1", agg(c1)));
 
     // Masked aggregations.
     auto maskedAgg = agg(c1) + " filter (where mask)";
     testAggregations(
-        vectors,
-        {},
-        {maskedAgg},
-        fmt::format("SELECT {} FROM tmp", maskedAgg),
-        /*config*/ {},
-        testWithTableScan);
+        vectors, {}, {maskedAgg}, fmt::format("SELECT {} FROM tmp", maskedAgg));
 
     testAggregations(
         [&](auto& builder) {
@@ -96,9 +84,7 @@ class MinMaxTest : public functions::aggregate::test::AggregationTestBase {
         },
         {"p0"},
         {maskedAgg},
-        fmt::format("SELECT c0 % 10, {} FROM tmp GROUP BY 1", maskedAgg),
-        /*config*/ {},
-        testWithTableScan);
+        fmt::format("SELECT c0 % 10, {} FROM tmp GROUP BY 1", maskedAgg));
 
     // Encodings: use filter to wrap aggregation inputs in a dictionary.
     testAggregations(
@@ -110,17 +96,14 @@ class MinMaxTest : public functions::aggregate::test::AggregationTestBase {
         {"p0"},
         {agg(c1)},
         fmt::format(
-            "SELECT c0 % 11, {} FROM tmp WHERE c0 % 2 = 0 GROUP BY 1", agg(c1)),
-        /*config*/ {},
-        testWithTableScan);
+            "SELECT c0 % 11, {} FROM tmp WHERE c0 % 2 = 0 GROUP BY 1",
+            agg(c1)));
 
     testAggregations(
         [&](auto& builder) { builder.values(vectors).filter("c0 % 2 = 0"); },
         {},
         {agg(c1)},
-        fmt::format("SELECT {} FROM tmp WHERE c0 % 2 = 0", agg(c1)),
-        /*config*/ {},
-        testWithTableScan);
+        fmt::format("SELECT {} FROM tmp WHERE c0 % 2 = 0", agg(c1)));
   }
 };
 

--- a/velox/functions/prestosql/aggregates/tests/SetAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SetAggTest.cpp
@@ -279,8 +279,7 @@ TEST_F(SetAggTest, longDecimal) {
           type),
   });
 
-  testAggregations(
-      {data}, {}, {"set_agg(c0)"}, {"array_sort(a0)"}, {expected}, {}, false);
+  testAggregations({data}, {}, {"set_agg(c0)"}, {"array_sort(a0)"}, {expected});
 
   // Test with some NULL inputs (long decimals)
   data = makeRowVector({
@@ -317,8 +316,7 @@ TEST_F(SetAggTest, longDecimal) {
           ARRAY(type)),
   });
 
-  testAggregations(
-      {data}, {}, {"set_agg(c0)"}, {"array_sort(a0)"}, {expected}, {}, false);
+  testAggregations({data}, {}, {"set_agg(c0)"}, {"array_sort(a0)"}, {expected});
 
   // Test with all NULL inputs (long decimals)
   data = makeRowVector({
@@ -337,8 +335,7 @@ TEST_F(SetAggTest, longDecimal) {
           ARRAY(type)),
   });
 
-  testAggregations(
-      {data}, {}, {"set_agg(c0)"}, {"array_sort(a0)"}, {expected}, {}, false);
+  testAggregations({data}, {}, {"set_agg(c0)"}, {"array_sort(a0)"}, {expected});
 }
 
 std::vector<std::optional<std::string>> generateStrings(

--- a/velox/functions/prestosql/aggregates/tests/SetUnionTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SetUnionTest.cpp
@@ -454,7 +454,7 @@ TEST_F(SetUnionTest, longDecimal) {
   });
 
   testAggregations(
-      {data}, {}, {"set_union(c0)"}, {"array_sort(a0)"}, {expected}, {}, false);
+      {data}, {}, {"set_union(c0)"}, {"array_sort(a0)"}, {expected});
 
   // Test with some NULL inputs (long decimals).
   data = makeRowVector({
@@ -487,7 +487,7 @@ TEST_F(SetUnionTest, longDecimal) {
   });
 
   testAggregations(
-      {data}, {}, {"set_union(c0)"}, {"array_sort(a0)"}, {expected}, {}, false);
+      {data}, {}, {"set_union(c0)"}, {"array_sort(a0)"}, {expected});
 
   // Test with all NULL inputs (long decimals).
   data = makeRowVector({
@@ -499,7 +499,7 @@ TEST_F(SetUnionTest, longDecimal) {
   });
 
   testAggregations(
-      {data}, {}, {"set_union(c0)"}, {"array_sort(a0)"}, {expected}, {}, false);
+      {data}, {}, {"set_union(c0)"}, {"array_sort(a0)"}, {expected});
 }
 } // namespace
 } // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/SumTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SumTest.cpp
@@ -130,12 +130,7 @@ TEST_F(SumTest, sumDecimal) {
        makeNullableFlatVector<int128_t>(longDecimalRawVector, DECIMAL(23, 4))});
   createDuckDbTable({input});
   testAggregations(
-      {input},
-      {},
-      {"sum(c0)", "sum(c1)"},
-      "SELECT sum(c0), sum(c1) FROM tmp",
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      {input}, {}, {"sum(c0)", "sum(c1)"}, "SELECT sum(c0), sum(c1) FROM tmp");
 
   // Decimal sum aggregation with multiple groups.
   auto inputRows = {
@@ -170,13 +165,7 @@ TEST_F(SumTest, sumDecimal) {
            makeFlatVector<int128_t>(
                std::vector<int128_t>{-7493}, DECIMAL(38, 2))})};
 
-  testAggregations(
-      inputRows,
-      {"c0"},
-      {"sum(c1)"},
-      expectedResult,
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+  testAggregations(inputRows, {"c0"}, {"sum(c1)"}, expectedResult);
 
   AggregationTestBase::enableTestIncremental();
 }
@@ -192,13 +181,7 @@ TEST_F(SumTest, sumDecimalOverflow) {
   auto input = makeRowVector(
       {makeFlatVector<int64_t>(shortDecimalInput, DECIMAL(17, 5))});
   createDuckDbTable({input});
-  testAggregations(
-      {input},
-      {},
-      {"sum(c0)"},
-      "SELECT sum(c0) FROM tmp",
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+  testAggregations({input}, {}, {"sum(c0)"}, "SELECT sum(c0) FROM tmp");
 
   auto decimalSumOverflow = [this](
                                 const std::vector<int128_t>& input,

--- a/velox/functions/sparksql/aggregates/tests/FirstAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/FirstAggregateTest.cpp
@@ -59,9 +59,7 @@ class FirstAggregateTest : public AggregationTestBase {
             vectors,
             {"c0"},
             {"spark_first_ignore_null(c1)"},
-            "SELECT c0, first(c1 ORDER BY c1 NULLS LAST) FROM tmp GROUP BY c0",
-            /*config*/ {},
-            /*testWithTableScan*/ false);
+            "SELECT c0, first(c1 ORDER BY c1 NULLS LAST) FROM tmp GROUP BY c0");
       }
       {
         // Expected result should have first 7 rows including nulls.
@@ -73,13 +71,7 @@ class FirstAggregateTest : public AggregationTestBase {
                 [](auto row) { return row; }, // valueAt
                 [](auto row) { return row % 3 == 0; }), // nullAt
         })};
-        testAggregations(
-            vectors,
-            {"c0"},
-            {"spark_first(c1)"},
-            expected,
-            /*config*/ {},
-            /*testWithTableScan*/ false);
+        testAggregations(vectors, {"c0"}, {"spark_first(c1)"}, expected);
       }
     }
 
@@ -92,24 +84,13 @@ class FirstAggregateTest : public AggregationTestBase {
         SCOPED_TRACE("ignore null + global");
         auto expectedTrue = {makeRowVector({makeNullableFlatVector<T>({1})})};
         testAggregations(
-            vectors,
-            {},
-            {"spark_first_ignore_null(c0)"},
-            expectedTrue,
-            /*config*/ {},
-            /*testWithTableScan*/ false);
+            vectors, {}, {"spark_first_ignore_null(c0)"}, expectedTrue);
       }
       {
         SCOPED_TRACE("not ignore null + global");
         auto expectedFalse = {
             makeRowVector({makeNullableFlatVector<T>({std::nullopt})})};
-        testAggregations(
-            vectors,
-            {},
-            {"spark_first(c0)"},
-            expectedFalse,
-            /*config*/ {},
-            /*testWithTableScan*/ false);
+        testAggregations(vectors, {}, {"spark_first(c0)"}, expectedFalse);
       }
     }
   }
@@ -121,23 +102,12 @@ class FirstAggregateTest : public AggregationTestBase {
     {
       SCOPED_TRACE("ignore null + group by");
       testAggregations(
-          data,
-          {"c0"},
-          {"spark_first_ignore_null(c1)"},
-          ignoreNullData,
-          /*config*/ {},
-          /*testWithTableScan*/ false);
+          data, {"c0"}, {"spark_first_ignore_null(c1)"}, ignoreNullData);
     }
 
     {
       SCOPED_TRACE("not ignore null + group by");
-      testAggregations(
-          data,
-          {"c0"},
-          {"spark_first(c1)"},
-          hasNullData,
-          /*config*/ {},
-          /*testWithTableScan*/ false);
+      testAggregations(data, {"c0"}, {"spark_first(c1)"}, hasNullData);
     }
   }
 
@@ -148,23 +118,12 @@ class FirstAggregateTest : public AggregationTestBase {
     {
       SCOPED_TRACE("ignore null + global");
       testAggregations(
-          data,
-          {},
-          {"spark_first_ignore_null(c0)"},
-          ignoreNullData,
-          /*config*/ {},
-          /*testWithTableScan*/ false);
+          data, {}, {"spark_first_ignore_null(c0)"}, ignoreNullData);
     }
 
     {
       SCOPED_TRACE("not ignore null + global");
-      testAggregations(
-          data,
-          {},
-          {"spark_first(c0)"},
-          hasNullData,
-          /*config*/ {},
-          /*testWithTableScan*/ false);
+      testAggregations(data, {}, {"spark_first(c0)"}, hasNullData);
     }
   }
 };
@@ -429,9 +388,7 @@ TEST_F(FirstAggregateTest, varcharGroupBy) {
         vectors,
         {"c0"},
         {"spark_first_ignore_null(c1)"},
-        "SELECT c0, first(c1) FROM tmp WHERE c1 IS NOT NULL GROUP BY c0",
-        /*config*/ {},
-        /*testWithTableScan*/ false);
+        "SELECT c0, first(c1) FROM tmp WHERE c1 IS NOT NULL GROUP BY c0");
   }
 
   {
@@ -443,13 +400,7 @@ TEST_F(FirstAggregateTest, varcharGroupBy) {
             [&data](auto row) { return StringView(data[row]); }, // valueAt
             nullEvery(3)),
     })};
-    testAggregations(
-        vectors,
-        {"c0"},
-        {"spark_first(c1)"},
-        expected,
-        /*config*/ {},
-        /*testWithTableScan*/ false);
+    testAggregations(vectors, {"c0"}, {"spark_first(c1)"}, expected);
   }
 }
 
@@ -540,13 +491,7 @@ TEST_F(FirstAggregateTest, mapGroupBy) {
           [](auto idx) { return idx * 0.1; }), // valueAt
   })};
 
-  testAggregations(
-      vectors,
-      {"c0"},
-      {"spark_first(c1)"},
-      expected,
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+  testAggregations(vectors, {"c0"}, {"spark_first(c1)"}, expected);
 }
 
 TEST_F(FirstAggregateTest, mapGlobal) {

--- a/velox/functions/sparksql/aggregates/tests/LastAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/LastAggregateTest.cpp
@@ -53,9 +53,7 @@ class LastAggregateTest : public aggregate::test::AggregationTestBase {
             vectors,
             {"c0"},
             {"spark_last_ignore_null(c1)"},
-            "SELECT c0, last(c1 ORDER BY c1 NULLS FIRST) FROM tmp GROUP BY c0",
-            /*config*/ {},
-            /*testWithTableScan*/ false);
+            "SELECT c0, last(c1 ORDER BY c1 NULLS FIRST) FROM tmp GROUP BY c0");
       }
       {
         // Expected result should have first 7 rows including nulls.
@@ -67,13 +65,7 @@ class LastAggregateTest : public aggregate::test::AggregationTestBase {
                 [](auto row) { return 91 + row; }, // valueAt
                 [](auto row) { return (91 + row) % 3 == 0; }), // nullAt
         })};
-        testAggregations(
-            vectors,
-            {"c0"},
-            {"spark_last(c1)"},
-            expected,
-            /*config*/ {},
-            /*testWithTableScan*/ false);
+        testAggregations(vectors, {"c0"}, {"spark_last(c1)"}, expected);
       }
     }
 
@@ -86,24 +78,13 @@ class LastAggregateTest : public aggregate::test::AggregationTestBase {
         SCOPED_TRACE("ignore null + global");
         auto expectedTrue = {makeRowVector({makeNullableFlatVector<T>({2})})};
         testAggregations(
-            vectors,
-            {},
-            {"spark_last_ignore_null(c0)"},
-            expectedTrue,
-            /*config*/ {},
-            /*testWithTableScan*/ false);
+            vectors, {}, {"spark_last_ignore_null(c0)"}, expectedTrue);
       }
       {
         SCOPED_TRACE("not ignore null + global");
         auto expectedFalse = {
             makeRowVector({makeNullableFlatVector<T>({std::nullopt})})};
-        testAggregations(
-            vectors,
-            {},
-            {"spark_last(c0)"},
-            expectedFalse,
-            /*config*/ {},
-            /*testWithTableScan*/ false);
+        testAggregations(vectors, {}, {"spark_last(c0)"}, expectedFalse);
       }
     }
   }
@@ -115,23 +96,12 @@ class LastAggregateTest : public aggregate::test::AggregationTestBase {
     {
       SCOPED_TRACE("ignore null + group by");
       testAggregations(
-          data,
-          {"c0"},
-          {"spark_last_ignore_null(c1)"},
-          ignoreNullData,
-          /*config*/ {},
-          /*testWithTableScan*/ false);
+          data, {"c0"}, {"spark_last_ignore_null(c1)"}, ignoreNullData);
     }
 
     {
       SCOPED_TRACE("not ignore null + group by");
-      testAggregations(
-          data,
-          {"c0"},
-          {"spark_last(c1)"},
-          hasNullData,
-          /*config*/ {},
-          /*testWithTableScan*/ false);
+      testAggregations(data, {"c0"}, {"spark_last(c1)"}, hasNullData);
     }
   }
 
@@ -142,23 +112,12 @@ class LastAggregateTest : public aggregate::test::AggregationTestBase {
     {
       SCOPED_TRACE("ignore null + global");
       testAggregations(
-          data,
-          {},
-          {"spark_last_ignore_null(c0)"},
-          ignoreNullData,
-          /*config*/ {},
-          /*testWithTableScan*/ false);
+          data, {}, {"spark_last_ignore_null(c0)"}, ignoreNullData);
     }
 
     {
       SCOPED_TRACE("not ignore null + global");
-      testAggregations(
-          data,
-          {},
-          {"spark_last(c0)"},
-          hasNullData,
-          /*config*/ {},
-          /*testWithTableScan*/ false);
+      testAggregations(data, {}, {"spark_last(c0)"}, hasNullData);
     }
   }
 };
@@ -424,9 +383,7 @@ TEST_F(LastAggregateTest, varcharGroupBy) {
       vectors,
       {"c0"},
       {"spark_last_ignore_null(c1)"},
-      "SELECT c0, last(c1) FROM tmp WHERE c1 IS NOT NULL GROUP BY c0",
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      "SELECT c0, last(c1) FROM tmp WHERE c1 IS NOT NULL GROUP BY c0");
 
   // Verify when ignoreNull is false.
   // Expected result should have last 7 rows [91..98) including nulls.
@@ -437,13 +394,7 @@ TEST_F(LastAggregateTest, varcharGroupBy) {
           [&data](auto row) { return StringView(data[91 + row]); }, // valueAt
           [](auto row) { return (91 + row) % 3 == 0; }), // nullAt
   })};
-  testAggregations(
-      vectors,
-      {"c0"},
-      {"spark_last(c1)"},
-      expected,
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+  testAggregations(vectors, {"c0"}, {"spark_last(c1)"}, expected);
 }
 
 TEST_F(LastAggregateTest, varcharGlobal) {
@@ -536,13 +487,7 @@ TEST_F(LastAggregateTest, mapGroupBy) {
           [](auto idx) { return (92 + idx) * 0.1; }), // valueAt
   })};
 
-  testAggregations(
-      vectors,
-      {"c0"},
-      {"spark_last(c1)"},
-      expected,
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+  testAggregations(vectors, {"c0"}, {"spark_last(c1)"}, expected);
 }
 
 TEST_F(LastAggregateTest, mapGlobal) {

--- a/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
@@ -42,13 +42,7 @@ class SumAggregationTest : public SumTestBase {
     auto in = makeRowVector({makeNullableFlatVector<int128_t>({input}, type)});
     auto expected =
         makeRowVector({makeNullableFlatVector<int128_t>({output}, type)});
-    testAggregations(
-        {in},
-        {},
-        {"spark_sum(c0)"},
-        {expected},
-        /*config*/ {},
-        /*testWithTableScan*/ false);
+    testAggregations({in}, {}, {"spark_sum(c0)"}, {expected});
     testAggregationsWithCompanion(
         {in},
         [](auto& /*builder*/) {},
@@ -71,13 +65,7 @@ class SumAggregationTest : public SumTestBase {
         {makeFlatVector<int32_t>(10, [](auto row) { return row; }),
          makeNullableFlatVector<int128_t>(
              std::vector<std::optional<int128_t>>(10, std::nullopt), type)});
-    testAggregations(
-        {in},
-        {"c0"},
-        {"spark_sum(c1)"},
-        {expected},
-        /*config*/ {},
-        /*testWithTableScan*/ false);
+    testAggregations({in}, {"c0"}, {"spark_sum(c1)"}, {expected});
     testAggregationsWithCompanion(
         {in},
         [](auto& /*builder*/) {},
@@ -109,13 +97,7 @@ class SumAggregationTest : public SumTestBase {
     auto expected = makeRowVector(
         {makeFlatVector<int32_t>(std::vector<int32_t>{0, 1, 2, 3}),
          outputDecimalVector});
-    testAggregations(
-        {vectors},
-        {"c0"},
-        {"spark_sum(c1)"},
-        {expected},
-        /*config*/ {},
-        /*testWithTableScan*/ false);
+    testAggregations({vectors}, {"c0"}, {"spark_sum(c1)"}, {expected});
     testAggregationsWithCompanion(
         {vectors},
         [](auto& /*builder*/) {},
@@ -191,9 +173,7 @@ TEST_F(SumAggregationTest, decimalSum) {
       {input},
       {},
       {"spark_sum(c0)", "spark_sum(c1)"},
-      "SELECT sum(c0), sum(c1) FROM tmp",
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      "SELECT sum(c0), sum(c1) FROM tmp");
   testAggregationsWithCompanion(
       {input},
       [](auto& /*builder*/) {},
@@ -246,9 +226,7 @@ TEST_F(SumAggregationTest, decimalSum) {
       inputShortDecimalRows,
       {"c0"},
       {"spark_sum(c1)"},
-      expectedShortDecimalResult,
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      expectedShortDecimalResult);
   testAggregationsWithCompanion(
       {inputShortDecimalRows},
       [](auto& /*builder*/) {},
@@ -309,9 +287,7 @@ TEST_F(SumAggregationTest, decimalSum) {
       inputLongDecimalRows,
       {"c0"},
       {"spark_sum(c1)"},
-      expectedLongDecimalResult,
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      expectedLongDecimalResult);
   testAggregationsWithCompanion(
       {inputShortDecimalRows},
       [](auto& /*builder*/) {},
@@ -400,13 +376,7 @@ TEST_F(SumAggregationTest, decimalAllNullValues) {
   std::vector<std::optional<int128_t>> result = {std::nullopt};
   auto expected =
       makeRowVector({makeNullableFlatVector<int128_t>(result, DECIMAL(30, 2))});
-  testAggregations(
-      {input},
-      {},
-      {"spark_sum(c0)"},
-      {expected},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+  testAggregations({input}, {}, {"spark_sum(c0)"}, {expected});
   testAggregationsWithCompanion(
       {input},
       [](auto& /*builder*/) {},
@@ -468,12 +438,7 @@ TEST_F(SumAggregationTest, decimalRangeOverflow) {
   auto expected = makeRowVector(
       {makeNullableFlatVector<int128_t>(result, DECIMAL(38, 18))});
   testAggregations(
-      {firstInput, secondInput},
-      {},
-      {"spark_sum(c0)"},
-      {expected},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      {firstInput, secondInput}, {}, {"spark_sum(c0)"}, {expected});
   testAggregationsWithCompanion(
       {firstInput, secondInput},
       [](auto& /*builder*/) {},


### PR DESCRIPTION
TableScan doesn't change the order of inputs, so it shouldn't really
matter whether data comes from Values or TableScan, it is nice to
remove this flag.

However, `AggregationTestBase::testReadFromFiles`
method splits and writes the input vectors into two files. This process,
to some extent, involves shuffling of the inputs. Consequently, it causes
certain aggregate function tests, such as `ArbitraryTest`, to fail.

We can utilize the allowInputShuffle_ flag. When set to true, we can avoid
splitting the inputs and instead write them into a single file. Also, we need
to disable TableScan testing when input contains timestamps type, to avoid
the issue described in #8127.

