### PR TITLE
Add to spill probe flag to support hash probe spill

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1357,16 +1357,16 @@ FOLLY_ALWAYS_INLINE std::ostream& operator<<(
 enum class JoinType {
   // For each row on the left, find all matching rows on the right and return
   // all combinations.
-  kInner,
+  kInner = 0,
   // For each row on the left, find all matching rows on the right and return
   // all combinations. In addition, return all rows from the left that have no
   // match on the right with right-side columns filled with nulls.
-  kLeft,
+  kLeft = 1,
   // Opposite of kLeft. For each row on the right, find all matching rows on the
   // left and return all combinations. In addition, return all rows from the
   // right that have no match on the left with left-side columns filled with
   // nulls.
-  kRight,
+  kRight = 2,
   // A "union" of kLeft and kRight. For each row on the left, find all matching
   // rows on the right and return all combinations. In addition, return all rows
   // from the left that have no
@@ -1374,11 +1374,11 @@ enum class JoinType {
   // all rows from the
   // right that have no match on the left with left-side columns filled with
   // nulls.
-  kFull,
+  kFull = 3,
   // Return a subset of rows from the left side which have a match on the right
   // side. For this join type, cardinality of the output is less than or equal
   // to the cardinality of the left side.
-  kLeftSemiFilter,
+  kLeftSemiFilter = 4,
   // Return each row from the left side with a boolean flag indicating whether
   // there exists a match on the right side. For this join type, cardinality of
   // the output equals the cardinality of the left side.
@@ -1387,11 +1387,11 @@ enum class JoinType {
   // 'nullAware' boolean specified separately.
   //
   // Null-aware join follows IN semantic. Regular join follows EXISTS semantic.
-  kLeftSemiProject,
+  kLeftSemiProject = 5,
   // Opposite of kLeftSemiFilter. Return a subset of rows from the right side
   // which have a match on the left side. For this join type, cardinality of the
   // output is less than or equal to the cardinality of the right side.
-  kRightSemiFilter,
+  kRightSemiFilter = 6,
   // Opposite of kLeftSemiProject. Return each row from the right side with a
   // boolean flag indicating whether there exists a match on the left side. For
   // this join type, cardinality of the output equals the cardinality of the
@@ -1401,7 +1401,7 @@ enum class JoinType {
   // 'nullAware' boolean specified separately.
   //
   // Null-aware join follows IN semantic. Regular join follows EXISTS semantic.
-  kRightSemiProject,
+  kRightSemiProject = 7,
   // Return each row from the left side which has no match on the right side.
   // The handling of the rows with nulls in the join key depends on the
   // 'nullAware' boolean specified separately.
@@ -1415,7 +1415,8 @@ enum class JoinType {
   // Regular anti join follows NOT EXISTS semantic:
   // (1) ignore right-side rows with nulls in the join keys;
   // (2) unconditionally return left side rows with nulls in the join keys.
-  kAnti,
+  kAnti = 8,
+  kNumJoinTypes = 9,
 };
 
 const char* joinTypeName(JoinType joinType);

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -63,6 +63,7 @@ HashBuild::HashBuild(
       joinNode_(std::move(joinNode)),
       joinType_{joinNode_->joinType()},
       nullAware_{joinNode_->isNullAware()},
+      needProbedFlagSpill_{needRightSideJoin(joinType_)},
       joinBridge_(operatorCtx_->task()->getHashJoinBridgeLocked(
           operatorCtx_->driverCtx()->splitGroupId,
           planNodeId())),
@@ -196,6 +197,17 @@ void HashBuild::setupSpiller(SpillPartition* spillPartition) {
   if (!spillEnabled()) {
     return;
   }
+  if (spillType_ == nullptr) {
+    spillType_ = hashJoinTableSpillType(tableType_, joinType_);
+    if (needProbedFlagSpill_) {
+      spillProbedFlagChannel_ = spillType_->size() - 1;
+      VELOX_CHECK_NULL(spillProbedFlagVector_);
+      // Creates a constant probed flag vector with all values false for build
+      // side table spilling.
+      spillProbedFlagVector_ = std::make_shared<ConstantVector<bool>>(
+          pool(), 0, /*isNull=*/false, BOOLEAN(), false);
+    }
+  }
 
   const auto& spillConfig = spillConfig_.value();
   HashBitRange hashBits(
@@ -227,8 +239,9 @@ void HashBuild::setupSpiller(SpillPartition* spillPartition) {
 
   spiller_ = std::make_unique<Spiller>(
       Spiller::Type::kHashJoinBuild,
+      joinType_,
       table_->rows(),
-      tableType_,
+      spillType_,
       std::move(hashBits),
       &spillConfig);
 
@@ -236,7 +249,7 @@ void HashBuild::setupSpiller(SpillPartition* spillPartition) {
   spillInputIndicesBuffers_.resize(numPartitions);
   rawSpillInputIndicesBuffers_.resize(numPartitions);
   numSpillInputs_.resize(numPartitions, 0);
-  spillChildVectors_.resize(tableType_->size());
+  spillChildVectors_.resize(spillType_->size());
 }
 
 bool HashBuild::isInputFromSpill() const {
@@ -392,6 +405,12 @@ void HashBuild::addInput(RowVectorPtr input) {
   }
   auto rows = table_->rows();
   auto nextOffset = rows->nextOffset();
+  FlatVector<bool>* spillProbedFlagVector{nullptr};
+  if (isInputFromSpill() && needProbedFlagSpill_) {
+    spillProbedFlagVector =
+        input->childAt(spillProbedFlagChannel_)->asFlatVector<bool>();
+  }
+
   activeRows_.applyToSelected([&](auto rowIndex) {
     char* newRow = rows->newRow();
     if (nextOffset) {
@@ -405,6 +424,12 @@ void HashBuild::addInput(RowVectorPtr input) {
     }
     for (auto i = 0; i < dependentChannels_.size(); ++i) {
       rows->store(*decoders_[i], rowIndex, newRow, i + hashers.size());
+    }
+    if (spillProbedFlagVector != nullptr) {
+      VELOX_CHECK(!spillProbedFlagVector->isNullAt(rowIndex));
+      if (spillProbedFlagVector->valueAt(rowIndex)) {
+        rows->setProbedFlag(&newRow, 1);
+      }
     }
   });
 }
@@ -547,6 +572,11 @@ void HashBuild::maybeSetupSpillChildVectors(const RowVectorPtr& input) {
   for (const auto& channel : dependentChannels_) {
     spillChildVectors_[spillChannel++] = input->childAt(channel);
   }
+  if (needProbedFlagSpill_) {
+    VELOX_CHECK_NOT_NULL(spillProbedFlagVector_);
+    spillProbedFlagVector_->resize(input->size());
+    spillChildVectors_[spillChannel] = spillProbedFlagVector_;
+  }
 }
 
 void HashBuild::prepareInputIndicesBuffers(
@@ -597,7 +627,7 @@ void HashBuild::spillPartition(
   } else {
     spiller_->spill(
         partition,
-        wrap(size, indices, tableType_, spillChildVectors_, input->pool()));
+        wrap(size, indices, spillType_, spillChildVectors_, input->pool()));
   }
 }
 
@@ -835,8 +865,8 @@ void HashBuild::setupSpillInput(HashJoinBridge::SpillInput spillInput) {
 void HashBuild::processSpillInput() {
   checkRunning();
 
-  while (spillInputReader_->nextBatch(input_)) {
-    addInput(std::move(input_));
+  while (spillInputReader_->nextBatch(spillInput_)) {
+    addInput(std::move(spillInput_));
     if (!isRunning()) {
       return;
     }

--- a/velox/exec/HashJoinBridge.h
+++ b/velox/exec/HashJoinBridge.h
@@ -169,4 +169,20 @@ bool isHashBuildMemoryPool(const memory::MemoryPool& pool);
 /// Returns true if 'pool' is a hash probe operator's memory pool. The check is
 /// currently based on the pool name.
 bool isHashProbeMemoryPool(const memory::MemoryPool& pool);
+
+bool needRightSideJoin(core::JoinType joinType);
+
+/// Returns the type used to spill a given hash table type. The function
+/// might attach a boolean column at the end of 'tableType' if 'joinType' needs
+/// right side join processing. It is used by the hash join table spilling
+/// triggered at the probe side to record if each row has been probed or not.
+RowTypePtr hashJoinTableSpillType(
+    const RowTypePtr& tableType,
+    core::JoinType joinType);
+
+/// Checks if a given type is a hash table spill type or not based on
+/// 'joinType'.
+bool isHashJoinTableSpillType(
+    const RowTypePtr& spillType,
+    core::JoinType joinType);
 } // namespace facebook::velox::exec

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -786,9 +786,7 @@ void HashProbe::clearIdentityProjectedOutput() {
 }
 
 bool HashProbe::needLastProbe() const {
-  return !skipInput_ &&
-      (isRightJoin(joinType_) || isFullJoin(joinType_) ||
-       isRightSemiFilterJoin(joinType_) || isRightSemiProjectJoin(joinType_));
+  return !skipInput_ && needRightSideJoin(joinType_);
 }
 
 bool HashProbe::skipProbeOnEmptyBuild() const {

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -211,7 +211,7 @@ class BaseHashTable {
 
   /// Fills 'hits' with consecutive hash join results. The corresponding element
   /// of 'inputRows' is set to the corresponding row number in probe keys.
-  /// Returns the number of hits produced. If this s less than hits.size() then
+  /// Returns the number of hits produced. If this is less than hits.size() then
   /// all the hits have been produced.
   /// Adds input rows without a match to 'inputRows' with corresponding hit
   /// set to nullptr if 'includeMisses' is true. Otherwise, skips input rows

--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -397,7 +397,7 @@ SpillPartitionNumSet RowNumber::spillHashTable() {
   auto tableType = ROW(std::move(columnTypes));
 
   auto hashTableSpiller = std::make_unique<Spiller>(
-      Spiller::Type::kHashJoinBuild,
+      Spiller::Type::kRowNumber,
       table_->rows(),
       tableType,
       spillPartitionBits_,

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -39,8 +39,10 @@ class Spiller {
     kOrderByInput = 4,
     // Used for order by output processing stage.
     kOrderByOutput = 5,
+    // Used for row number.
+    kRowNumber = 6,
     // Number of spiller types.
-    kNumTypes = 6,
+    kNumTypes = 7,
   };
 
   static std::string typeName(Type);
@@ -74,6 +76,15 @@ class Spiller {
       const common::SpillConfig* spillConfig);
 
   /// type == Type::kHashJoinBuild
+  Spiller(
+      Type type,
+      core::JoinType joinType,
+      RowContainer* container,
+      RowTypePtr rowType,
+      HashBitRange bits,
+      const common::SpillConfig* spillConfig);
+
+  /// type == Type::kRowNumber
   Spiller(
       Type type,
       RowContainer* container,
@@ -184,6 +195,7 @@ class Spiller {
       HashBitRange bits,
       int32_t numSortingKeys,
       const std::vector<CompareFlags>& sortCompareFlags,
+      bool spillProbedFlag,
       const common::GetSpillDirectoryPathCB& getSpillDirPathCb,
       const common::UpdateAndCheckSpillLimitCB& updateAndCheckSpillLimitCb,
       const std::string& fileNamePrefix,
@@ -301,6 +313,7 @@ class Spiller {
   folly::Executor* const executor_;
   const HashBitRange bits_;
   const RowTypePtr rowType_;
+  const bool spillProbedFlag_;
   const uint64_t maxSpillRunRows_;
 
   // True if all rows of spilling partitions are in 'spillRuns_', so


### PR DESCRIPTION
Adds probed flag recording to support probe side spilling. When probe side triggers
hash join table spilling, it needs to records the probed flag of the spilled table for join
type like right join to produce the output. To support this:
(1) spiller for hash join build needs to extract the probed flag from the row container
of the hash join table and spill to disk along with the user table columns. To be specific,
we attach a boolean column at the end of table columns.
(2) hash build side needs the logic to restore the probed flag in the row container of the
rebuilt the hash table based on the value of the attached boolean column read from the
spilled table file.