### PR TITLE
Change max wait for actual data fetching to 100ms

### DIFF
--- a/velox/exec/ExchangeClient.cpp
+++ b/velox/exec/ExchangeClient.cpp
@@ -140,10 +140,9 @@ void ExchangeClient::request(std::vector<RequestSpec>&& requestSpecs) {
   for (auto& spec : requestSpecs) {
     auto future = folly::SemiFuture<ExchangeSource::Response>::makeEmpty();
     if (spec.maxBytes == 0) {
-      future = spec.source->requestDataSizes(kDefaultMaxWaitSeconds);
+      future = spec.source->requestDataSizes(kRequestDataSizesMaxWait);
     } else {
-      // TODO: Change maxWait to 100ms once we fix the unit of wait time.
-      future = spec.source->request(spec.maxBytes, 1);
+      future = spec.source->request(spec.maxBytes, kRequestDataMaxWait);
     }
     VELOX_CHECK(future.valid());
     std::move(future)

--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -25,7 +25,8 @@ namespace facebook::velox::exec {
 class ExchangeClient : public std::enable_shared_from_this<ExchangeClient> {
  public:
   static constexpr int32_t kDefaultMaxQueuedBytes = 32 << 20; // 32 MB.
-  static constexpr int32_t kDefaultMaxWaitSeconds = 2;
+  static constexpr std::chrono::seconds kRequestDataSizesMaxWait{2};
+  static constexpr std::chrono::milliseconds kRequestDataMaxWait{100};
   static inline const std::string kBackgroundCpuTimeMs = "backgroundCpuTimeMs";
 
   ExchangeClient(

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -371,10 +371,10 @@ TEST_F(ExchangeClientTest, sourceTimeout) {
 
 #ifndef NDEBUG
   // Wait until all sources have timed out at least once.
-  constexpr int32_t kMaxIters =
-      3 * kNumSources * ExchangeClient::kDefaultMaxWaitSeconds;
-  int32_t counter = 0;
-  for (; counter < kMaxIters; ++counter) {
+  auto deadline = std::chrono::system_clock::now() +
+      3 * kNumSources *
+          std::chrono::seconds(ExchangeClient::kRequestDataSizesMaxWait);
+  while (std::chrono::system_clock::now() < deadline) {
     {
       std::lock_guard<std::mutex> l(mutex);
       if (sourcesWithTimeout.size() >= kNumSources) {
@@ -383,7 +383,7 @@ TEST_F(ExchangeClientTest, sourceTimeout) {
     }
     std::this_thread::sleep_for(std::chrono::seconds(1));
   }
-  EXPECT_LT(counter, kMaxIters);
+  EXPECT_LT(std::chrono::system_clock::now(), deadline);
 #endif
 
   const auto& queue = client->queue();


### PR DESCRIPTION
Summary:
As a follow up to the exchange protocol upgrade, we can reduce the max
wait for actual data fetching to a very small amount, to avoid long waiting in
particular happening when multiple destination buffers are sharing the same
arbitrary buffer.

Differential Revision: D54495685


