### PR TITLE
Add missing boost library for fuzzer runs

### DIFF
--- a/.circleci/dist_compile.yml
+++ b/.circleci/dist_compile.yml
@@ -352,6 +352,7 @@ jobs:
       simdjson_SOURCE: BUNDLED
       xsimd_SOURCE: BUNDLED
       DuckDB_SOURCE: BUNDLED
+      Boost_SOURCE: BUNDLED
     steps:
       - fuzzer-run:
           fuzzer_output: "/tmp/fuzzer.log"
@@ -374,6 +375,7 @@ jobs:
     environment:
       VELOX_DEPENDENCY_SOURCE: SYSTEM
       simdjson_SOURCE: BUNDLED
+      Boost_SOURCE: BUNDLED
     steps:
       - fuzzer-run:
           fuzzer_output: "/tmp/spark_fuzzer.log"
@@ -403,6 +405,7 @@ jobs:
     environment:
       VELOX_DEPENDENCY_SOURCE: SYSTEM
       simdjson_SOURCE: BUNDLED
+      Boost_SOURCE: BUNDLED
     steps:
       - fuzzer-run:
           fuzzer_output: "/tmp/aggregate_fuzzer.log"
@@ -417,6 +420,7 @@ jobs:
     environment:
       VELOX_DEPENDENCY_SOURCE: SYSTEM
       simdjson_SOURCE: BUNDLED
+      Boost_SOURCE: BUNDLED
     steps:
       - fuzzer-run:
           fuzzer_output: "/tmp/join_fuzzer.log"


### PR DESCRIPTION
When Boost was upgraded to the 1.84.0 version the
system dependency moved from the ubuntu package manager to the setup-ubuntu.sh script which now requires a source build.
This build does not occur when the container is readied for fuzzer runs.
Therefore, the executables must link in Boost statically to have it present rather than as shared library loaded from the system.