### PR TITLE
Fix broken MacOS build. Use TYPED_TEST_SUITE

### DIFF
--- a/velox/dwio/common/tests/ResultOrActionsTests.cpp
+++ b/velox/dwio/common/tests/ResultOrActionsTests.cpp
@@ -82,7 +82,7 @@ TEST(ResultOrActionsTest, Void) {
 }
 
 using ReaderResultTypes = ::testing::Types<ReaderResult, VoidResult>;
-TYPED_TEST_CASE(ResultOrActionsTypedTest, ReaderResultTypes);
+TYPED_TEST_SUITE(ResultOrActionsTypedTest, ReaderResultTypes);
 
 TYPED_TEST(ResultOrActionsTypedTest, NoResult) {
   ReaderResult readerResult;


### PR DESCRIPTION
Summary:
```
/Users/runner/work/velox/velox/velox/dwio/common/tests/ResultOrActionsTests.cpp
/Users/runner/work/velox/velox/velox/dwio/common/tests/ResultOrActionsTests.cpp:85:1: error: 'TypedTestCaseIsDeprecated' is deprecated: TYPED_TEST_CASE is deprecated, please use TYPED_TEST_SUITE [-Werror,-Wdeprecated-declarations]
TYPED_TEST_CASE(ResultOrActionsTypedTest, ReaderResultTypes);
^
/Users/runner/work/velox/velox/_build/debug/_deps/gtest-src/googletest/include/gtest/gtest-typed-test.h:229:38: note: expanded from macro 'TYPED_TEST_CASE'
  static_assert(::testing::internal::TypedTestCaseIsDeprecated(), ""); \
                                     ^
/Users/runner/work/velox/velox/_build/debug/_deps/gtest-src/googletest/include/gtest/internal/gtest-internal.h:1306:1: note: 'TypedTestCaseIsDeprecated' has been explicitly marked deprecated here
GTEST_INTERNAL_DEPRECATED(
^
/Users/runner/work/velox/velox/_build/debug/_deps/gtest-src/googletest/include/gtest/internal/gtest-port.h:2336:59: note: expanded from macro 'GTEST_INTERNAL_DEPRECATED'
#define GTEST_INTERNAL_DEPRECATED(message) __attribute__((deprecated(message)))
                                                          ^
1 error generated.
[1444/2401] Building CXX object velox/dwio/common/tests/CMakeFiles/velox_dwio_common_test.dir/ReaderTest.cpp.o
[1445/2401] Building CXX object velox/dwio/common/tests/CMakeFiles/velox_e2e_filter_test_base.dir/E2EFilterTestBase.cpp.o
ninja: build stopped: subcommand failed.
Error: Process completed with exit code 1.
```

Differential Revision: D54568611


