### PR TITLE
Fix wrong cast in DecimalUtil::divideWithRoundUp()

### DIFF
--- a/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
@@ -411,6 +411,14 @@ TEST_F(DecimalArithmeticTest, round) {
       {makeFlatVector<int128_t>(
           {DecimalUtil::kLongDecimalMax, DecimalUtil::kLongDecimalMin},
           DECIMAL(38, 1))});
+  testDecimalExpr<TypeKind::BIGINT>(
+      {makeFlatVector<int64_t>(
+          {3000000000000000, -3000000000000000}, DECIMAL(17, 0))},
+      "round(c0)",
+      {makeFlatVector<int128_t>(
+          {facebook::velox::HugeInt::parse("3000000000000000000000"),
+           facebook::velox::HugeInt::parse("-3000000000000000000000")},
+          DECIMAL(22, 6))});
 
   // Min and max short decimals.
   testDecimalExpr<TypeKind::BIGINT>(

--- a/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
@@ -416,8 +416,8 @@ TEST_F(DecimalArithmeticTest, round) {
           {3000000000000000, -3000000000000000}, DECIMAL(17, 0))},
       "round(c0)",
       {makeFlatVector<int128_t>(
-          {facebook::velox::HugeInt::parse("3000000000000000000000"),
-           facebook::velox::HugeInt::parse("-3000000000000000000000")},
+          {HugeInt::parse("3" + std::string(21, '0')),
+           HugeInt::parse("-3" + std::string(21, '0'))},
           DECIMAL(22, 6))});
 
   // Min and max short decimals.

--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -278,7 +278,9 @@ class DecimalUtil {
       uint8_t /*bRescale*/) {
     VELOX_USER_CHECK_NE(b, 0, "Division by zero");
     int resultSign = 1;
-    R unsignedDividendRescaled(a);
+    using IntermediateType =
+        std::conditional_t<std::is_same_v<A, velox::int128_t>, A, R>;
+    IntermediateType unsignedDividendRescaled(a);
     if (a < 0) {
       resultSign = -1;
       unsignedDividendRescaled *= -1;
@@ -288,9 +290,9 @@ class DecimalUtil {
       resultSign *= -1;
       unsignedDivisor *= -1;
     }
-    unsignedDividendRescaled = checkedMultiply<R>(
+    unsignedDividendRescaled = checkedMultiply<IntermediateType>(
         unsignedDividendRescaled,
-        R(DecimalUtil::kPowersOfTen[aRescale]),
+        IntermediateType(DecimalUtil::kPowersOfTen[aRescale]),
         "Decimal");
     R quotient = unsignedDividendRescaled / unsignedDivisor;
     R remainder = unsignedDividendRescaled % unsignedDivisor;


### PR DESCRIPTION
Decimal round function returns wrong results when round(long decimal) -> short decimal. The cause is that in DecimalUtil::divideWithRoundUp(), when initializing `unsignedDividendRescaled`, the int128_t type is forcibly cast to int64_t type, resulting in an incorrect value for `unsignedDividendRescaled`. We fix it in this patch.