### PR TITLE
Fix the problem where buildSelectedType() makes the input type invalid

### DIFF
--- a/velox/dwio/common/TypeUtils.cpp
+++ b/velox/dwio/common/TypeUtils.cpp
@@ -52,7 +52,7 @@ std::unique_ptr<TypeWithId> visit(
   }
   if (typeWithId->type()->isRow()) {
     std::vector<std::string> names;
-    std::vector<std::unique_ptr<TypeWithId>> children;
+    std::vector<std::unique_ptr<TypeWithId>> selectedChildren;
     std::vector<std::shared_ptr<const Type>> types;
     auto& row = typeWithId->type()->asRow();
     for (auto i = 0; i < typeWithId->size(); ++i) {
@@ -61,31 +61,31 @@ std::unique_ptr<TypeWithId> visit(
         names.push_back(row.nameOf(i));
         auto newChild = visit(child, selector);
         types.push_back(newChild->type());
-        children.push_back(std::move(newChild));
+        selectedChildren.push_back(std::move(newChild));
       }
     }
     VELOX_USER_CHECK(
         !types.empty(), "selected nothing from row: " + row.toString());
     return std::make_unique<TypeWithId>(
         ROW(std::move(names), std::move(types)),
-        std::move(children),
+        std::move(selectedChildren),
         typeWithId->id(),
         typeWithId->maxId(),
         typeWithId->column());
   } else {
     checkChildrenSelected(typeWithId, selector);
-    std::vector<std::unique_ptr<TypeWithId>> children;
+    std::vector<std::unique_ptr<TypeWithId>> selectedChildren;
     std::vector<std::shared_ptr<const Type>> types;
     for (auto i = 0; i < typeWithId->size(); ++i) {
       auto& child = typeWithId->childAt(i);
       auto newChild = visit(child, selector);
       types.push_back(newChild->type());
-      children.push_back(std::move(newChild));
+      selectedChildren.push_back(std::move(newChild));
     }
     auto type = createType(typeWithId->type()->kind(), std::move(types));
     return std::make_unique<TypeWithId>(
         type,
-        std::move(children),
+        std::move(selectedChildren),
         typeWithId->id(),
         typeWithId->maxId(),
         typeWithId->column());


### PR DESCRIPTION
`buildSelectedType()` takes a constant typeWithId type tree and applies the selector on it to return a selected new type tree. However, it modifies the input typeWithId unexpectedly because it duplicates the internal type nodes, but not the leaves(primitive types). The leaf nodes were directly moved to the result instead of copied, thus making in the original input typeWithId incomplete.
```
std::shared_ptr<const TypeWithId> typeutils::buildSelectedType(
const std::shared_ptr<const TypeWithId>& typeWithId,
const std::function<bool(size_t)>& selector)  {
  return visit(typeWithId, selector);
}
```
```
std::shared_ptr<const TypeWithId> visit(
    const std::shared_ptr<const TypeWithId>& typeWithId,
    const std::function<bool(size_t)>& selector) {
  if (typeWithId->type()->isPrimitiveType()) {
    return typeWithId;   // directly returned
  }
  if (typeWithId->type()->isRow()) {
    std::vector<std::string> names;
    std::vector<std::shared_ptr<const TypeWithId>> typesWithId;  // constructing a new children vector
    std::vector<std::shared_ptr<const Type>> types;
    auto& row = typeWithId->type()->asRow();
    for (auto i = 0; i < typeWithId->size(); ++i) {
      auto& child = typeWithId->childAt(i);
      if (selector(child->id())) {
        names.push_back(row.nameOf(i));
        std::shared_ptr<const TypeWithId> twid;
        twid = visit(child, selector);   // twid was pointing to the original typeWithId leaf
        typesWithId.push_back(twid);   // twid pushed to the new vector typesWithId
        types.push_back(twid->type());
      }
    }
    VELOX_USER_CHECK(
        !types.empty(), "selected nothing from row: " + row.toString());
    return std::make_shared<TypeWithId>(.   // Creating a new type node
        ROW(std::move(names), std::move(types)),
        std::move(typesWithId),      // But with the children vector that contains the original leaves. And the original ones are now nullptr.
        typeWithId->id(),
        typeWithId->maxId(),
        typeWithId->column());
```

This PR fixes the problem by making a copy of the leaf nodes as well. After this change, the original input typeWithId would still be valid.