### PR TITLE
Allow async source to take lambda func which capture unique_ptr

### DIFF
--- a/velox/common/base/AsyncSource.h
+++ b/velox/common/base/AsyncSource.h
@@ -40,7 +40,7 @@ template <typename Item>
 class AsyncSource {
  public:
   explicit AsyncSource(std::function<std::unique_ptr<Item>()> make)
-      : make_(make) {}
+      : make_(std::move(make)) {}
 
   // Makes an item if it is not already made. To be called on a background
   // executor.


### PR DESCRIPTION
Currently async source take a copy of working function which disallow
to pass lambda function which captures unique_ptr. Changes to move
the function in async source ctor to make it work