### PR TITLE
Fix iceberg reader to avoid skipping delete files

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -90,13 +90,14 @@ uint64_t IcebergSplitReader::next(int64_t size, VectorPtr& output) {
         deleteBitmap_, numBytes, connectorQueryCtx_->memoryPool());
     std::memset((void*)deleteBitmap_->as<int8_t>(), 0L, numBytes);
 
-    for (auto iter = positionalDeleteFileReaders_.begin();
-         iter != positionalDeleteFileReaders_.end();
-         iter++) {
+    auto iter = positionalDeleteFileReaders_.begin();
+    while (iter != positionalDeleteFileReaders_.end()) {
       (*iter)->readDeletePositions(
           baseReadOffset_, size, deleteBitmap_->asMutable<int8_t>());
       if ((*iter)->endOfFile()) {
         iter = positionalDeleteFileReaders_.erase(iter);
+      } else {
+        iter++;
       }
     }
 


### PR DESCRIPTION
Add read test for Iceberg in the case of multiple delete files

In the current implementation, some of the delete files were skipped while reading the
delete files from the IcebergSplitReader. When we reached EOF for a delete file it gets erased from the list
which increments the iterator to the next delete file. Since we were using a for loop it was incrementing
the iterator again thus skipping some delete files.