### PR TITLE
"Move constructible" test to compile time from run time

### DIFF
--- a/velox/dwio/common/BufferedInput.cpp
+++ b/velox/dwio/common/BufferedInput.cpp
@@ -25,6 +25,8 @@ using ::facebook::velox::common::Region;
 
 namespace facebook::velox::dwio::common {
 
+static_assert(std::is_move_constructible<BufferedInput>());
+
 void BufferedInput::load(const LogType logType) {
   // no regions to load
   if (regions_.size() == 0) {

--- a/velox/dwio/common/BufferedInput.h
+++ b/velox/dwio/common/BufferedInput.h
@@ -50,8 +50,8 @@ class BufferedInput {
       memory::MemoryPool& pool,
       uint64_t maxMergeDistance = kMaxMergeDistance,
       std::optional<bool> wsVRLoad = std::nullopt)
-      : input_(std::move(input)),
-        pool_(pool),
+      : input_{std::move(input)},
+        pool_{pool},
         maxMergeDistance_{maxMergeDistance},
         wsVRLoad_{wsVRLoad},
         allocPool_{std::make_unique<memory::AllocationPool>(&pool)} {}

--- a/velox/dwio/common/BufferedInput.h
+++ b/velox/dwio/common/BufferedInput.h
@@ -36,14 +36,14 @@ class BufferedInput {
       IoStatistics* FOLLY_NULLABLE stats = nullptr,
       uint64_t maxMergeDistance = kMaxMergeDistance,
       std::optional<bool> wsVRLoad = std::nullopt)
-      : input_{std::make_shared<ReadFileInputStream>(
-            std::move(readFile),
-            metricsLog,
-            stats)},
-        pool_{pool},
-        maxMergeDistance_{maxMergeDistance},
-        wsVRLoad_{wsVRLoad},
-        allocPool_{std::make_unique<memory::AllocationPool>(&pool)} {}
+      : BufferedInput(
+            std::make_shared<ReadFileInputStream>(
+                std::move(readFile),
+                metricsLog,
+                stats),
+            pool,
+            maxMergeDistance,
+            wsVRLoad) {}
 
   BufferedInput(
       std::shared_ptr<ReadFileInputStream> input,

--- a/velox/dwio/common/InputStream.cpp
+++ b/velox/dwio/common/InputStream.cpp
@@ -39,6 +39,16 @@ using ::facebook::velox::common::Region;
 
 namespace facebook::velox::dwio::common {
 
+namespace {
+int64_t totalBufferSize(const std::vector<folly::Range<char*>>& buffers) {
+  int64_t bufferSize = 0;
+  for (auto& buffer : buffers) {
+    bufferSize += buffer.size();
+  }
+  return bufferSize;
+}
+} // namespace
+
 folly::SemiFuture<uint64_t> InputStream::readAsync(
     const std::vector<folly::Range<char*>>& buffers,
     uint64_t offset,
@@ -95,10 +105,7 @@ void ReadFileInputStream::read(
     const std::vector<folly::Range<char*>>& buffers,
     uint64_t offset,
     LogType logType) {
-  int64_t bufferSize = 0;
-  for (auto& buffer : buffers) {
-    bufferSize += buffer.size();
-  }
+  const int64_t bufferSize = totalBufferSize(buffers);
   logRead(offset, bufferSize, logType);
   auto size = readFile_->preadv(offset, buffers);
   DWIO_ENSURE_EQ(
@@ -118,10 +125,7 @@ folly::SemiFuture<uint64_t> ReadFileInputStream::readAsync(
     const std::vector<folly::Range<char*>>& buffers,
     uint64_t offset,
     LogType logType) {
-  int64_t bufferSize = 0;
-  for (auto& buffer : buffers) {
-    bufferSize += buffer.size();
-  }
+  const int64_t bufferSize = totalBufferSize(buffers);
   logRead(offset, bufferSize, logType);
   return readFile_->preadvAsync(offset, buffers);
 }

--- a/velox/dwio/common/InputStream.h
+++ b/velox/dwio/common/InputStream.h
@@ -124,9 +124,6 @@ class InputStream {
       folly::Range<folly::IOBuf*> iobufs,
       const LogType purpose) = 0;
 
-  // case insensitive find
-  static uint32_t ifind(const std::string& src, const std::string& target);
-
   const std::string& getName() const;
 
   virtual void logRead(uint64_t offset, uint64_t length, LogType purpose);

--- a/velox/dwio/common/tests/TestBufferedInput.cpp
+++ b/velox/dwio/common/tests/TestBufferedInput.cpp
@@ -117,12 +117,6 @@ class TestBufferedInput : public testing::Test {
 };
 } // namespace
 
-TEST_F(TestBufferedInput, AllowMoveConstructor) {
-  auto readFileMock = std::make_shared<ReadFileMock>();
-  BufferedInput a(readFileMock, *pool_);
-  BufferedInput b(std::move(a));
-}
-
 TEST_F(TestBufferedInput, ZeroLengthStream) {
   auto readFile =
       std::make_shared<facebook::velox::InMemoryReadFile>(std::string());


### PR DESCRIPTION
Summary:
# Rationale
What can runtime test for "Is movable?" do more than compile time test?

Differential Revision: D54608363


