### PR TITLE
Fix unhex Spark function with inputs of odd length

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -240,7 +240,7 @@ Mathematical Functions
     If ``x`` contains non-hexadecimal character, the function returns NULL.
     When ``x`` contains even number of characters, each pair is converted to a single byte. The number of bytes in the result is half the number of bytes in the input.
     When ``x`` contains a single character, the result contains a single byte whose value matches the hexadecimal character.
-    When ``x`` contains an odd number characters greater than 2, the first character is decoded and put at index 0 of the output, the remaining pairs of characters are converted to bytes, and put start from index 1 of the output. ::
+    When ``x`` contains an odd number characters greater than 2, the first character is decoded to one byte and put at index 0 of the output, the remaining pairs of characters are converted to bytes, and put start from index 1 of the output. ::
 
         SELECT unhex("23"); -- #
         SELECT unhex("f"); -- \x0F

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -240,10 +240,10 @@ Mathematical Functions
     If ``x`` contains non-hexadecimal character, the function returns NULL.
     When ``x`` contains even number of characters, each pair is converted to a single byte. The number of bytes in the result is half the number of bytes in the input.
     When ``x`` contains a single character, the result contains a single byte whose value matches the hexadecimal character.
-    When ``x`` contains an odd number characters greater than 2, the first character is ignored, the remaining pairs of characters are converted to bytes, then zero byte is added at the end of the output. ::
+    When ``x`` contains an odd number characters greater than 2, the first character is decoded and put at index 0 of the output, the remaining pairs of characters are converted to bytes, and put start from index 1 of the output. ::
 
         SELECT unhex("23"); -- #
         SELECT unhex("f"); -- \x0F
-        SELECT unhex("b2323"); -- ##\0
+        SELECT unhex("b2323"); -- \x0B##
         SELECT unhex("G"); -- NULL
         SELECT unhex("G23"); -- NULL

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -240,7 +240,7 @@ Mathematical Functions
     If ``x`` contains non-hexadecimal character, the function returns NULL.
     When ``x`` contains even number of characters, each pair is converted to a single byte. The number of bytes in the result is half the number of bytes in the input.
     When ``x`` contains a single character, the result contains a single byte whose value matches the hexadecimal character.
-    When ``x`` contains an odd number characters greater than 2, the first character is decoded into the first byte of the result and the remaining pairs of characters are decoded into subsequent bytes, this matches Spark since 3.3.2, but not earlier ::
+    When ``x`` contains an odd number characters greater than 2, the first character is decoded into the first byte of the result and the remaining pairs of characters are decoded into subsequent bytes. This behavior matches Spark 3.3.2 and newer. ::
 
         SELECT unhex("23"); -- #
         SELECT unhex("f"); -- \x0F

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -238,9 +238,8 @@ Mathematical Functions
     Converts hexadecimal varchar ``x`` to varbinary.
     ``x`` is considered case insensitive and expected to contain only hexadecimal characters 0-9 and A-F.
     If ``x`` contains non-hexadecimal character, the function returns NULL.
-    When ``x`` contains even number of characters, each pair is converted to a single byte. The number of bytes in the result is half the number of bytes in the input.
-    When ``x`` contains a single character, the result contains a single byte whose value matches the hexadecimal character.
-    When ``x`` contains an odd number characters greater than 2, the first character is decoded into the first byte of the result and the remaining pairs of characters are decoded into subsequent bytes. This behavior matches Spark 3.3.2 and newer. ::
+    When ``x`` contains an even number of characters, each pair is converted to a single byte. The number of bytes in the result is half the number of bytes in the input.
+    When ``x`` contains an odd number of characters, the first character is decoded into the first byte of the result and the remaining pairs of characters are decoded into subsequent bytes. This behavior matches Spark 3.3.2 and newer. ::
 
         SELECT unhex("23"); -- #
         SELECT unhex("f"); -- \x0F

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -240,7 +240,7 @@ Mathematical Functions
     If ``x`` contains non-hexadecimal character, the function returns NULL.
     When ``x`` contains even number of characters, each pair is converted to a single byte. The number of bytes in the result is half the number of bytes in the input.
     When ``x`` contains a single character, the result contains a single byte whose value matches the hexadecimal character.
-    When ``x`` contains an odd number characters greater than 2, the first character is decoded to one byte and put at index 0 of the output, the remaining pairs of characters are converted to bytes, and put start from index 1 of the output. ::
+    When ``x`` contains an odd number characters greater than 2, the first character is decoded into the first byte of the result and the remaining pairs of characters are decoded into subsequent bytes, this matches Spark since 3.3.2, but not earlier ::
 
         SELECT unhex("23"); -- #
         SELECT unhex("f"); -- \x0F

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -381,16 +381,15 @@ struct UnHexFunction {
     char* resultBuffer = result.data();
 
     int32_t i = 0;
+    int32_t oddShift = 0;
     if ((input.size() & 0x01) != 0) {
       const auto v = detail::fromHex(inputBuffer[0]);
       if (v == -1) {
         return false;
       }
-      // out_type<Varbinary> resize does not guarantee all chars initialized
-      // with 0, filling last char with 0 to align with Spark.
-      resultBuffer[resultSize - 1] = 0;
       resultBuffer[0] = v;
       i += 1;
+      oddShift = 1;
     }
 
     while (i < input.size()) {
@@ -399,7 +398,7 @@ struct UnHexFunction {
       if (first == -1 || second == -1) {
         return false;
       }
-      resultBuffer[i / 2] = (first << 4) | second;
+      resultBuffer[i / 2 + oddShift] = (first << 4) | second;
       i += 2;
     }
     return true;

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -381,7 +381,6 @@ struct UnHexFunction {
     char* resultBuffer = result.data();
 
     int32_t i = 0;
-    int32_t oddShift = 0;
     if ((input.size() & 0x01) != 0) {
       const auto v = detail::fromHex(inputBuffer[0]);
       if (v == -1) {
@@ -389,7 +388,6 @@ struct UnHexFunction {
       }
       resultBuffer[0] = v;
       i += 1;
-      oddShift = 1;
     }
 
     while (i < input.size()) {
@@ -398,7 +396,7 @@ struct UnHexFunction {
       if (first == -1 || second == -1) {
         return false;
       }
-      resultBuffer[i / 2 + oddShift] = (first << 4) | second;
+      resultBuffer[(i + 1) / 2] = (first << 4) | second;
       i += 2;
     }
     return true;

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -276,11 +276,9 @@ TEST_F(ArithmeticTest, unhex) {
   EXPECT_EQ(unhex("737472696E67"), "string");
   EXPECT_EQ(unhex(""), "");
   EXPECT_EQ(unhex("23"), "#");
-  std::string b("#\0", 2);
-  EXPECT_EQ(unhex("123"), b);
-  EXPECT_EQ(unhex("b23"), b);
-  b = std::string("##\0", 3);
-  EXPECT_EQ(unhex("b2323"), b);
+  EXPECT_EQ(unhex("123"), "\x01#");
+  EXPECT_EQ(unhex("b23"), "\x0B#");
+  EXPECT_EQ(unhex("b2323"), "\x0B##");
   EXPECT_EQ(unhex("F"), "\x0F");
   EXPECT_EQ(unhex("ff"), "\xFF");
   EXPECT_EQ(unhex("G"), std::nullopt);


### PR DESCRIPTION
https://github.com/apache/spark/pull/38416 fixed unhex function when input string has an odd number of characters.