### PR TITLE
SplitReader refactor

### DIFF
--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -450,10 +450,10 @@ std::unique_ptr<dwio::common::SerDeOptions> parseSerdeParameters(
 
 void configureReaderOptions(
     dwio::common::ReaderOptions& readerOptions,
-    const std::shared_ptr<HiveConfig>& hiveConfig,
+    const std::shared_ptr<const HiveConfig>& hiveConfig,
     const Config* sessionProperties,
-    const std::shared_ptr<HiveTableHandle>& hiveTableHandle,
-    const std::shared_ptr<HiveConnectorSplit>& hiveSplit) {
+    const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
+    const std::shared_ptr<const HiveConnectorSplit>& hiveSplit) {
   configureReaderOptions(
       readerOptions,
       hiveConfig,
@@ -465,10 +465,10 @@ void configureReaderOptions(
 
 void configureReaderOptions(
     dwio::common::ReaderOptions& readerOptions,
-    const std::shared_ptr<HiveConfig>& hiveConfig,
+    const std::shared_ptr<const HiveConfig>& hiveConfig,
     const Config* sessionProperties,
     const RowTypePtr& fileSchema,
-    const std::shared_ptr<HiveConnectorSplit>& hiveSplit,
+    const std::shared_ptr<const HiveConnectorSplit>& hiveSplit,
     const std::unordered_map<std::string, std::string>& tableParameters) {
   readerOptions.setLoadQuantum(hiveConfig->loadQuantum());
   readerOptions.setMaxCoalesceBytes(hiveConfig->maxCoalescedBytes());
@@ -502,10 +502,10 @@ void configureReaderOptions(
 void configureRowReaderOptions(
     dwio::common::RowReaderOptions& rowReaderOptions,
     const std::unordered_map<std::string, std::string>& tableParameters,
-    std::shared_ptr<common::ScanSpec> scanSpec,
-    std::shared_ptr<common::MetadataFilter> metadataFilter,
+    const std::shared_ptr<common::ScanSpec>& scanSpec,
+    const std::shared_ptr<common::MetadataFilter>& metadataFilter,
     const RowTypePtr& rowType,
-    std::shared_ptr<HiveConnectorSplit> hiveSplit) {
+    const std::shared_ptr<const HiveConnectorSplit>& hiveSplit) {
   auto skipRowsIt =
       tableParameters.find(dwio::common::TableParameter::kSkipHeaderLineCount);
   if (skipRowsIt != tableParameters.end()) {
@@ -569,8 +569,8 @@ bool applyPartitionFilter(
 } // namespace
 
 bool testFilters(
-    common::ScanSpec* scanSpec,
-    dwio::common::Reader* reader,
+    const common::ScanSpec* scanSpec,
+    const dwio::common::Reader* reader,
     const std::string& filePath,
     const std::unordered_map<std::string, std::optional<std::string>>&
         partitionKey,

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -574,8 +574,10 @@ bool testFilters(
     const std::string& filePath,
     const std::unordered_map<std::string, std::optional<std::string>>&
         partitionKey,
-    std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
+    const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
         partitionKeysHandle) {
+  VELOX_CHECK_EQ(partitionKey.size(), partitionKeysHandle.size());
+
   auto totalRows = reader->numberOfRows();
   const auto& fileTypeWithId = reader->typeWithId();
   const auto& rowType = reader->rowType();
@@ -586,8 +588,11 @@ bool testFilters(
         // If missing column is partition key.
         auto iter = partitionKey.find(name);
         if (iter != partitionKey.end() && iter->second.has_value()) {
+          auto handlesIter = partitionKeysHandle.find(name);
+          VELOX_CHECK(handlesIter != partitionKeysHandle.end());
+
           return applyPartitionFilter(
-              (*partitionKeysHandle)[name]->dataType()->kind(),
+              handlesIter->second->dataType()->kind(),
               iter->second.value(),
               child->filter());
         }

--- a/velox/connectors/hive/HiveConnectorUtil.h
+++ b/velox/connectors/hive/HiveConnectorUtil.h
@@ -88,7 +88,7 @@ bool testFilters(
     const std::string& filePath,
     const std::unordered_map<std::string, std::optional<std::string>>&
         partitionKey,
-    std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
+    const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
         partitionKeysHandle);
 
 std::unique_ptr<dwio::common::BufferedInput> createBufferedInput(

--- a/velox/connectors/hive/HiveConnectorUtil.h
+++ b/velox/connectors/hive/HiveConnectorUtil.h
@@ -61,30 +61,30 @@ std::shared_ptr<common::ScanSpec> makeScanSpec(
 
 void configureReaderOptions(
     dwio::common::ReaderOptions& readerOptions,
-    const std::shared_ptr<HiveConfig>& config,
+    const std::shared_ptr<const HiveConfig>& config,
     const Config* sessionProperties,
-    const std::shared_ptr<HiveTableHandle>& hiveTableHandle,
-    const std::shared_ptr<HiveConnectorSplit>& hiveSplit);
+    const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
+    const std::shared_ptr<const HiveConnectorSplit>& hiveSplit);
 
 void configureReaderOptions(
     dwio::common::ReaderOptions& readerOptions,
-    const std::shared_ptr<HiveConfig>& hiveConfig,
+    const std::shared_ptr<const HiveConfig>& hiveConfig,
     const Config* sessionProperties,
     const RowTypePtr& fileSchema,
-    const std::shared_ptr<HiveConnectorSplit>& hiveSplit,
+    const std::shared_ptr<const HiveConnectorSplit>& hiveSplit,
     const std::unordered_map<std::string, std::string>& tableParameters = {});
 
 void configureRowReaderOptions(
     dwio::common::RowReaderOptions& rowReaderOptions,
     const std::unordered_map<std::string, std::string>& tableParameters,
-    std::shared_ptr<common::ScanSpec> scanSpec,
-    std::shared_ptr<common::MetadataFilter> metadataFilter,
+    const std::shared_ptr<common::ScanSpec>& scanSpec,
+    const std::shared_ptr<common::MetadataFilter>& metadataFilter,
     const RowTypePtr& rowType,
-    std::shared_ptr<HiveConnectorSplit> hiveSplit);
+    const std::shared_ptr<const HiveConnectorSplit>& hiveSplit);
 
 bool testFilters(
-    common::ScanSpec* scanSpec,
-    dwio::common::Reader* reader,
+    const common::ScanSpec* scanSpec,
+    const dwio::common::Reader* reader,
     const std::string& filePath,
     const std::unordered_map<std::string, std::optional<std::string>>&
         partitionKey,

--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -167,14 +167,14 @@ std::unique_ptr<SplitReader> HiveDataSource::createSplitReader() {
   return SplitReader::create(
       split_,
       hiveTableHandle_,
-      scanSpec_,
-      readerOutputType_,
       &partitionKeys_,
-      fileHandleFactory_,
-      executor_,
       connectorQueryCtx_,
       hiveConfig_,
-      ioStats_);
+      readerOutputType_,
+      ioStats_,
+      fileHandleFactory_,
+      executor_,
+      scanSpec_);
 }
 
 void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -152,6 +152,71 @@ void SplitReader::prepareSplit(
   createRowReader(metadataFilter);
 }
 
+uint64_t SplitReader::next(uint64_t size, VectorPtr& output) {
+  if (!baseReaderOpts_.randomSkip()) {
+    return baseRowReader_->next(size, output);
+  }
+  dwio::common::Mutation mutation;
+  mutation.randomSkip = baseReaderOpts_.randomSkip().get();
+  return baseRowReader_->next(size, output, &mutation);
+}
+
+void SplitReader::resetFilterCaches() {
+  if (baseRowReader_) {
+    baseRowReader_->resetFilterCaches();
+  }
+}
+
+bool SplitReader::emptySplit() const {
+  return emptySplit_;
+}
+
+void SplitReader::resetSplit() {
+  hiveSplit_.reset();
+}
+
+int64_t SplitReader::estimatedRowSize() const {
+  if (!baseRowReader_) {
+    return DataSource::kUnknownRowSize;
+  }
+
+  auto size = baseRowReader_->estimatedRowSize();
+  if (size.has_value()) {
+    return size.value();
+  }
+  return DataSource::kUnknownRowSize;
+}
+
+void SplitReader::updateRuntimeStats(
+    dwio::common::RuntimeStatistics& stats) const {
+  if (baseRowReader_) {
+    baseRowReader_->updateRuntimeStats(stats);
+  }
+}
+
+bool SplitReader::allPrefetchIssued() const {
+  return baseRowReader_ && baseRowReader_->allPrefetchIssued();
+}
+
+std::string SplitReader::toString() const {
+  std::string partitionKeys;
+  std::for_each(
+      partitionKeys_->begin(),
+      partitionKeys_->end(),
+      [&](std::pair<
+          const std::string,
+          std::shared_ptr<facebook::velox::connector::hive::HiveColumnHandle>>
+              column) { partitionKeys += " " + column.second->toString(); });
+  return fmt::format(
+      "SplitReader: hiveSplit_{} scanSpec_{} readerOutputType_{} partitionKeys_{} reader{} rowReader{}",
+      hiveSplit_->toString(),
+      scanSpec_->toString(),
+      readerOutputType_->toString(),
+      partitionKeys,
+      static_cast<const void*>(baseReader_.get()),
+      static_cast<const void*>(baseRowReader_.get()));
+}
+
 void SplitReader::createReader() {
   VELOX_CHECK_NE(
       baseReaderOpts_.getFileFormat(), dwio::common::FileFormat::UNKNOWN);
@@ -304,49 +369,6 @@ std::vector<TypePtr> SplitReader::adaptColumns(
   return columnTypes;
 }
 
-uint64_t SplitReader::next(uint64_t size, VectorPtr& output) {
-  if (!baseReaderOpts_.randomSkip()) {
-    return baseRowReader_->next(size, output);
-  }
-  dwio::common::Mutation mutation;
-  mutation.randomSkip = baseReaderOpts_.randomSkip().get();
-  return baseRowReader_->next(size, output, &mutation);
-}
-
-void SplitReader::resetFilterCaches() {
-  if (baseRowReader_) {
-    baseRowReader_->resetFilterCaches();
-  }
-}
-
-bool SplitReader::emptySplit() const {
-  return emptySplit_;
-}
-
-void SplitReader::resetSplit() {
-  hiveSplit_.reset();
-}
-
-int64_t SplitReader::estimatedRowSize() const {
-  if (!baseRowReader_) {
-    return DataSource::kUnknownRowSize;
-  }
-
-  const auto size = baseRowReader_->estimatedRowSize();
-  return size.value_or(DataSource::kUnknownRowSize);
-}
-
-void SplitReader::updateRuntimeStats(
-    dwio::common::RuntimeStatistics& stats) const {
-  if (baseRowReader_) {
-    baseRowReader_->updateRuntimeStats(stats);
-  }
-}
-
-bool SplitReader::allPrefetchIssued() const {
-  return baseRowReader_ && baseRowReader_->allPrefetchIssued();
-}
-
 void SplitReader::setPartitionValue(
     common::ScanSpec* spec,
     const std::string& partitionKey,
@@ -365,25 +387,6 @@ void SplitReader::setPartitionValue(
       1,
       connectorQueryCtx_->memoryPool());
   spec->setConstantValue(constant);
-}
-
-std::string SplitReader::toString() const {
-  std::string partitionKeys;
-  std::for_each(
-      partitionKeys_->begin(),
-      partitionKeys_->end(),
-      [&](std::pair<
-          const std::string,
-          std::shared_ptr<facebook::velox::connector::hive::HiveColumnHandle>>
-              column) { partitionKeys += " " + column.second->toString(); });
-  return fmt::format(
-      "SplitReader: hiveSplit_{} scanSpec_{} readerOutputType_{} partitionKeys_{} reader{} rowReader{}",
-      hiveSplit_->toString(),
-      scanSpec_->toString(),
-      readerOutputType_->toString(),
-      partitionKeys,
-      static_cast<const void*>(baseReader_.get()),
-      static_cast<const void*>(baseRowReader_.get()));
 }
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -60,17 +60,16 @@ VectorPtr newConstantFromString(
 } // namespace
 
 std::unique_ptr<SplitReader> SplitReader::create(
-    const std::shared_ptr<velox::connector::hive::HiveConnectorSplit>&
-        hiveSplit,
-    const std::shared_ptr<HiveTableHandle>& hiveTableHandle,
+    const std::shared_ptr<hive::HiveConnectorSplit>& hiveSplit,
+    const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
     const std::shared_ptr<common::ScanSpec>& scanSpec,
     const RowTypePtr& readerOutputType,
-    std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
+    const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
         partitionKeys,
     FileHandleFactory* fileHandleFactory,
     folly::Executor* executor,
     const ConnectorQueryCtx* connectorQueryCtx,
-    const std::shared_ptr<HiveConfig>& hiveConfig,
+    const std::shared_ptr<const HiveConfig>& hiveConfig,
     const std::shared_ptr<io::IoStatistics>& ioStats) {
   //  Create the SplitReader based on hiveSplit->customSplitInfo["table_format"]
   if (hiveSplit->customSplitInfo.count("table_format") > 0 &&
@@ -102,17 +101,17 @@ std::unique_ptr<SplitReader> SplitReader::create(
 }
 
 SplitReader::SplitReader(
-    const std::shared_ptr<velox::connector::hive::HiveConnectorSplit>&
-        hiveSplit,
-    const std::shared_ptr<HiveTableHandle>& hiveTableHandle,
+    const std::shared_ptr<const hive::HiveConnectorSplit>& hiveSplit,
+    const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
     const std::shared_ptr<common::ScanSpec>& scanSpec,
     const RowTypePtr& readerOutputType,
-    std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
+    const std::unordered_map<
+        std::string, std::shared_ptr<HiveColumnHandle>>*
         partitionKeys,
     FileHandleFactory* fileHandleFactory,
     folly::Executor* executor,
     const ConnectorQueryCtx* connectorQueryCtx,
-    const std::shared_ptr<HiveConfig>& hiveConfig,
+    const std::shared_ptr<const HiveConfig>& hiveConfig,
     const std::shared_ptr<io::IoStatistics>& ioStats)
     : hiveSplit_(hiveSplit),
       hiveTableHandle_(hiveTableHandle),
@@ -203,9 +202,7 @@ std::string SplitReader::toString() const {
   std::for_each(
       partitionKeys_->begin(),
       partitionKeys_->end(),
-      [&](std::pair<
-          const std::string,
-          std::shared_ptr<facebook::velox::connector::hive::HiveColumnHandle>>
+      [&](std::pair<const std::string, std::shared_ptr<const HiveColumnHandle>>
               column) { partitionKeys += " " + column.second->toString(); });
   return fmt::format(
       "SplitReader: hiveSplit_{} scanSpec_{} readerOutputType_{} partitionKeys_{} reader{} rowReader{}",

--- a/velox/connectors/hive/SplitReader.h
+++ b/velox/connectors/hive/SplitReader.h
@@ -55,31 +55,31 @@ class HiveConfig;
 class SplitReader {
  public:
   static std::unique_ptr<SplitReader> create(
-      const std::shared_ptr<velox::connector::hive::HiveConnectorSplit>&
-          hiveSplit,
-      const std::shared_ptr<HiveTableHandle>& hiveTableHandle,
+      const std::shared_ptr<hive::HiveConnectorSplit>& hiveSplit,
+      const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
       const std::shared_ptr<common::ScanSpec>& scanSpec,
       const RowTypePtr& readerOutputType,
-      std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
+      const std::unordered_map<
+          std::string, std::shared_ptr<HiveColumnHandle>>*
           partitionKeys,
       FileHandleFactory* fileHandleFactory,
       folly::Executor* executor,
       const ConnectorQueryCtx* connectorQueryCtx,
-      const std::shared_ptr<HiveConfig>& hiveConfig,
+      const std::shared_ptr<const HiveConfig>& hiveConfig,
       const std::shared_ptr<io::IoStatistics>& ioStats);
 
   SplitReader(
-      const std::shared_ptr<velox::connector::hive::HiveConnectorSplit>&
-          hiveSplit,
-      const std::shared_ptr<HiveTableHandle>& hiveTableHandle,
+      const std::shared_ptr<const hive::HiveConnectorSplit>& hiveSplit,
+      const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
       const std::shared_ptr<common::ScanSpec>& scanSpec,
       const RowTypePtr& readerOutputType,
-      std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
+      const std::unordered_map<
+          std::string, std::shared_ptr<HiveColumnHandle>>*
           partitionKeys,
       FileHandleFactory* fileHandleFactory,
       folly::Executor* executor,
       const ConnectorQueryCtx* connectorQueryCtx,
-      const std::shared_ptr<HiveConfig>& hiveConfig,
+      const std::shared_ptr<const HiveConfig>& hiveConfig,
       const std::shared_ptr<io::IoStatistics>& ioStats);
 
   virtual ~SplitReader() = default;
@@ -139,20 +139,21 @@ class SplitReader {
       const std::string& partitionKey,
       const std::optional<std::string>& value) const;
 
-  std::shared_ptr<HiveConnectorSplit> hiveSplit_;
-  std::shared_ptr<HiveTableHandle> hiveTableHandle_;
+  std::shared_ptr<const HiveConnectorSplit> hiveSplit_;
+  const std::shared_ptr<const HiveTableHandle> hiveTableHandle_;
   std::shared_ptr<common::ScanSpec> scanSpec_;
   const RowTypePtr readerOutputType_;
-  const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
-      partitionKeys_;
+  const std::unordered_map<
+      std::string,
+      std::shared_ptr<HiveColumnHandle>>* const partitionKeys_;
   memory::MemoryPool* const pool_;
   std::unique_ptr<dwio::common::Reader> baseReader_;
   std::unique_ptr<dwio::common::RowReader> baseRowReader_;
   FileHandleFactory* const fileHandleFactory_;
   folly::Executor* const executor_;
   const ConnectorQueryCtx* const connectorQueryCtx_;
-  const std::shared_ptr<HiveConfig> hiveConfig_;
-  std::shared_ptr<io::IoStatistics> ioStats_;
+  const std::shared_ptr<const HiveConfig> hiveConfig_;
+  const std::shared_ptr<io::IoStatistics> ioStats_;
   dwio::common::ReaderOptions baseReaderOpts_;
   dwio::common::RowReaderOptions baseRowReaderOpts_;
   bool emptySplit_;

--- a/velox/connectors/hive/SplitReader.h
+++ b/velox/connectors/hive/SplitReader.h
@@ -57,30 +57,28 @@ class SplitReader {
   static std::unique_ptr<SplitReader> create(
       const std::shared_ptr<hive::HiveConnectorSplit>& hiveSplit,
       const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
-      const std::shared_ptr<common::ScanSpec>& scanSpec,
-      const RowTypePtr& readerOutputType,
-      const std::unordered_map<
-          std::string, std::shared_ptr<HiveColumnHandle>>*
+      const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
           partitionKeys,
-      FileHandleFactory* fileHandleFactory,
-      folly::Executor* executor,
       const ConnectorQueryCtx* connectorQueryCtx,
       const std::shared_ptr<const HiveConfig>& hiveConfig,
-      const std::shared_ptr<io::IoStatistics>& ioStats);
+      const RowTypePtr& readerOutputType,
+      const std::shared_ptr<io::IoStatistics>& ioStats,
+      FileHandleFactory* fileHandleFactory,
+      folly::Executor* executor,
+      const std::shared_ptr<common::ScanSpec>& scanSpec);
 
   SplitReader(
       const std::shared_ptr<const hive::HiveConnectorSplit>& hiveSplit,
       const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
-      const std::shared_ptr<common::ScanSpec>& scanSpec,
-      const RowTypePtr& readerOutputType,
-      const std::unordered_map<
-          std::string, std::shared_ptr<HiveColumnHandle>>*
+      const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
           partitionKeys,
-      FileHandleFactory* fileHandleFactory,
-      folly::Executor* executor,
       const ConnectorQueryCtx* connectorQueryCtx,
       const std::shared_ptr<const HiveConfig>& hiveConfig,
-      const std::shared_ptr<io::IoStatistics>& ioStats);
+      const RowTypePtr& readerOutputType,
+      const std::shared_ptr<io::IoStatistics>& ioStats,
+      FileHandleFactory* fileHandleFactory,
+      folly::Executor* executor,
+      const std::shared_ptr<common::ScanSpec>& scanSpec);
 
   virtual ~SplitReader() = default;
 
@@ -141,19 +139,21 @@ class SplitReader {
 
   std::shared_ptr<const HiveConnectorSplit> hiveSplit_;
   const std::shared_ptr<const HiveTableHandle> hiveTableHandle_;
-  std::shared_ptr<common::ScanSpec> scanSpec_;
-  const RowTypePtr readerOutputType_;
   const std::unordered_map<
       std::string,
       std::shared_ptr<HiveColumnHandle>>* const partitionKeys_;
-  memory::MemoryPool* const pool_;
-  std::unique_ptr<dwio::common::Reader> baseReader_;
-  std::unique_ptr<dwio::common::RowReader> baseRowReader_;
-  FileHandleFactory* const fileHandleFactory_;
-  folly::Executor* const executor_;
   const ConnectorQueryCtx* const connectorQueryCtx_;
   const std::shared_ptr<const HiveConfig> hiveConfig_;
+
+  const RowTypePtr readerOutputType_;
   const std::shared_ptr<io::IoStatistics> ioStats_;
+  FileHandleFactory* const fileHandleFactory_;
+  folly::Executor* const executor_;
+  memory::MemoryPool* const pool_;
+
+  std::shared_ptr<common::ScanSpec> scanSpec_;
+  std::unique_ptr<dwio::common::Reader> baseReader_;
+  std::unique_ptr<dwio::common::RowReader> baseRowReader_;
   dwio::common::ReaderOptions baseReaderOpts_;
   dwio::common::RowReaderOptions baseRowReaderOpts_;
   bool emptySplit_;

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -19,25 +19,22 @@
 #include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/dwio/common/BufferUtil.h"
-#include "velox/dwio/common/Mutation.h"
-#include "velox/dwio/common/Reader.h"
 
 using namespace facebook::velox::dwio::common;
 
 namespace facebook::velox::connector::hive::iceberg {
 
 IcebergSplitReader::IcebergSplitReader(
-    const std::shared_ptr<velox::connector::hive::HiveConnectorSplit>&
-        hiveSplit,
-    const std::shared_ptr<HiveTableHandle>& hiveTableHandle,
+    const std::shared_ptr<hive::HiveConnectorSplit>& hiveSplit,
+    const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
     const std::shared_ptr<common::ScanSpec>& scanSpec,
     const RowTypePtr& readerOutputType,
-    std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
+    const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
         partitionKeys,
     FileHandleFactory* fileHandleFactory,
     folly::Executor* executor,
     const ConnectorQueryCtx* connectorQueryCtx,
-    const std::shared_ptr<HiveConfig>& hiveConfig,
+    const std::shared_ptr<const HiveConfig>& hiveConfig,
     std::shared_ptr<io::IoStatistics> ioStats)
     : SplitReader(
           hiveSplit,
@@ -65,8 +62,8 @@ void IcebergSplitReader::prepareSplit(
 
   createRowReader(metadataFilter);
 
-  std::shared_ptr<HiveIcebergSplit> icebergSplit =
-      std::dynamic_pointer_cast<HiveIcebergSplit>(hiveSplit_);
+  std::shared_ptr<const HiveIcebergSplit> icebergSplit =
+      std::dynamic_pointer_cast<const HiveIcebergSplit>(hiveSplit_);
   baseReadOffset_ = 0;
   splitOffset_ = baseRowReader_->nextRowNumber();
   positionalDeleteFileReaders_.clear();

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -25,28 +25,28 @@ using namespace facebook::velox::dwio::common;
 namespace facebook::velox::connector::hive::iceberg {
 
 IcebergSplitReader::IcebergSplitReader(
-    const std::shared_ptr<hive::HiveConnectorSplit>& hiveSplit,
+    const std::shared_ptr<const hive::HiveConnectorSplit>& hiveSplit,
     const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
-    const std::shared_ptr<common::ScanSpec>& scanSpec,
-    const RowTypePtr& readerOutputType,
     const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
         partitionKeys,
-    FileHandleFactory* fileHandleFactory,
-    folly::Executor* executor,
     const ConnectorQueryCtx* connectorQueryCtx,
     const std::shared_ptr<const HiveConfig>& hiveConfig,
-    std::shared_ptr<io::IoStatistics> ioStats)
+    const RowTypePtr& readerOutputType,
+    const std::shared_ptr<io::IoStatistics>& ioStats,
+    FileHandleFactory* const fileHandleFactory,
+    folly::Executor* executor,
+    const std::shared_ptr<common::ScanSpec>& scanSpec)
     : SplitReader(
           hiveSplit,
           hiveTableHandle,
-          scanSpec,
-          readerOutputType,
           partitionKeys,
-          fileHandleFactory,
-          executor,
           connectorQueryCtx,
           hiveConfig,
-          ioStats),
+          readerOutputType,
+          ioStats,
+          fileHandleFactory,
+          executor,
+          scanSpec),
       baseReadOffset_(0),
       splitOffset_(0) {}
 

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -27,17 +27,16 @@ struct IcebergDeleteFile;
 class IcebergSplitReader : public SplitReader {
  public:
   IcebergSplitReader(
-      const std::shared_ptr<velox::connector::hive::HiveConnectorSplit>&
-          hiveSplit,
-      const std::shared_ptr<HiveTableHandle>& hiveTableHandle,
+      const std::shared_ptr<hive::HiveConnectorSplit>& hiveSplit,
+      const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
       const std::shared_ptr<common::ScanSpec>& scanSpec,
       const RowTypePtr& readerOutputType,
-      std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
+      const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
           partitionKeys,
       FileHandleFactory* fileHandleFactory,
       folly::Executor* executor,
       const ConnectorQueryCtx* connectorQueryCtx,
-      const std::shared_ptr<HiveConfig>& hiveConfig,
+      const std::shared_ptr<const HiveConfig>& hiveConfig,
       std::shared_ptr<io::IoStatistics> ioStats);
 
   ~IcebergSplitReader() override = default;

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -27,16 +27,17 @@ struct IcebergDeleteFile;
 class IcebergSplitReader : public SplitReader {
  public:
   IcebergSplitReader(
-      std::shared_ptr<velox::connector::hive::HiveConnectorSplit> hiveSplit,
-      std::shared_ptr<HiveTableHandle> hiveTableHandle,
-      std::shared_ptr<common::ScanSpec> scanSpec,
-      const RowTypePtr readerOutputType,
+      const std::shared_ptr<velox::connector::hive::HiveConnectorSplit>&
+          hiveSplit,
+      const std::shared_ptr<HiveTableHandle>& hiveTableHandle,
+      const std::shared_ptr<common::ScanSpec>& scanSpec,
+      const RowTypePtr& readerOutputType,
       std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
           partitionKeys,
       FileHandleFactory* fileHandleFactory,
       folly::Executor* executor,
       const ConnectorQueryCtx* connectorQueryCtx,
-      const std::shared_ptr<HiveConfig> hiveConfig,
+      const std::shared_ptr<HiveConfig>& hiveConfig,
       std::shared_ptr<io::IoStatistics> ioStats);
 
   ~IcebergSplitReader() override = default;
@@ -45,7 +46,7 @@ class IcebergSplitReader : public SplitReader {
       std::shared_ptr<common::MetadataFilter> metadataFilter,
       dwio::common::RuntimeStatistics& runtimeStats) override;
 
-  uint64_t next(int64_t size, VectorPtr& output) override;
+  uint64_t next(uint64_t size, VectorPtr& output) override;
 
  private:
   // The read offset to the beginning of the split in number of rows for the

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -27,17 +27,17 @@ struct IcebergDeleteFile;
 class IcebergSplitReader : public SplitReader {
  public:
   IcebergSplitReader(
-      const std::shared_ptr<hive::HiveConnectorSplit>& hiveSplit,
+      const std::shared_ptr<const hive::HiveConnectorSplit>& hiveSplit,
       const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
-      const std::shared_ptr<common::ScanSpec>& scanSpec,
-      const RowTypePtr& readerOutputType,
       const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
           partitionKeys,
-      FileHandleFactory* fileHandleFactory,
-      folly::Executor* executor,
       const ConnectorQueryCtx* connectorQueryCtx,
       const std::shared_ptr<const HiveConfig>& hiveConfig,
-      std::shared_ptr<io::IoStatistics> ioStats);
+      const RowTypePtr& readerOutputType,
+      const std::shared_ptr<io::IoStatistics>& ioStats,
+      FileHandleFactory* fileHandleFactory,
+      folly::Executor* executor,
+      const std::shared_ptr<common::ScanSpec>& scanSpec);
 
   ~IcebergSplitReader() override = default;
 

--- a/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
@@ -30,8 +30,8 @@ PositionalDeleteFileReader::PositionalDeleteFileReader(
     FileHandleFactory* fileHandleFactory,
     const ConnectorQueryCtx* connectorQueryCtx,
     folly::Executor* executor,
-    const std::shared_ptr<HiveConfig> hiveConfig,
-    std::shared_ptr<io::IoStatistics> ioStats,
+    const std::shared_ptr<const HiveConfig>& hiveConfig,
+    const std::shared_ptr<io::IoStatistics>& ioStats,
     dwio::common::RuntimeStatistics& runtimeStats,
     uint64_t splitOffset,
     const std::string& connectorId)

--- a/velox/connectors/hive/iceberg/PositionalDeleteFileReader.h
+++ b/velox/connectors/hive/iceberg/PositionalDeleteFileReader.h
@@ -41,8 +41,8 @@ class PositionalDeleteFileReader {
       FileHandleFactory* fileHandleFactory,
       const ConnectorQueryCtx* connectorQueryCtx,
       folly::Executor* executor,
-      const std::shared_ptr<HiveConfig> hiveConfig,
-      std::shared_ptr<io::IoStatistics> ioStats,
+      const std::shared_ptr<const HiveConfig>& hiveConfig,
+      const std::shared_ptr<io::IoStatistics>& ioStats,
       dwio::common::RuntimeStatistics& runtimeStats,
       uint64_t splitOffset,
       const std::string& connectorId);
@@ -68,8 +68,8 @@ class PositionalDeleteFileReader {
   FileHandleFactory* const fileHandleFactory_;
   folly::Executor* const executor_;
   const ConnectorQueryCtx* const connectorQueryCtx_;
-  const std::shared_ptr<HiveConfig> hiveConfig_;
-  std::shared_ptr<io::IoStatistics> ioStats_;
+  const std::shared_ptr<const HiveConfig> hiveConfig_;
+  const std::shared_ptr<io::IoStatistics> ioStats_;
   memory::MemoryPool* const pool_;
 
   std::shared_ptr<IcebergMetadataColumn> filePathColumn_;


### PR DESCRIPTION
To prepare for the upcoming equality delete file read, we need to refactor the SplitReader a bit.