### PR TITLE
Fix hash join changes for probe side spilling support

### DIFF
--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -505,18 +505,17 @@ void HashBuild::spillInput(const RowVectorPtr& input) {
   computeSpillPartitions(input);
 
   vector_size_t numSpillInputs = 0;
-  for (auto rowIdx = 0; rowIdx < numInput; ++rowIdx) {
-    const auto partition = spillPartitions_[rowIdx];
-    if (FOLLY_UNLIKELY(!activeRows_.isValid(rowIdx))) {
+  for (auto row = 0; row < numInput; ++row) {
+    const auto partition = spillPartitions_[row];
+    if (FOLLY_UNLIKELY(!activeRows_.isValid(row))) {
       continue;
     }
     if (!spiller_->isSpilled(partition)) {
       continue;
     }
-    activeRows_.setValid(rowIdx, false);
+    activeRows_.setValid(row, false);
     ++numSpillInputs;
-    rawSpillInputIndicesBuffers_[partition][numSpillInputs_[partition]++] =
-        rowIdx;
+    rawSpillInputIndicesBuffers_[partition][numSpillInputs_[partition]++] = row;
   }
   if (numSpillInputs == 0) {
     return;
@@ -734,8 +733,9 @@ bool HashBuild::finishHashBuild() {
       isInputFromSpill() ? spillConfig()->startPartitionBit
                          : BaseHashTable::kNoSpillInputStartPartitionBit);
   addRuntimeStats();
-  if (joinBridge_->setHashTable(
-          std::move(table_), std::move(spillPartitions), joinHasNullKeys_)) {
+  joinBridge_->setHashTable(
+      std::move(table_), std::move(spillPartitions), joinHasNullKeys_);
+  if (spillEnabled()) {
     intermediateStateCleared_ = true;
   }
 
@@ -1105,11 +1105,11 @@ void HashBuild::reclaim(
 }
 
 bool HashBuild::nonReclaimableState() const {
-  // Apart from being in the nonReclaimable section,
-  // its also not reclaimable if:
-  // 1) the hash table has been built by the last build thread (inidicated
-  //    by state_)
-  // 2) the last build operator has transferred ownership of 'this' operator's
+  // Apart from being in the nonReclaimable section, it's also not reclaimable
+  // if:
+  // 1) the hash table has been built by the last build thread (indicated by
+  //    state_)
+  // 2) the last build operator has transferred ownership of 'this operator's
   //    intermediate state (table_ and spiller_) to itself
   // 3) it has completed spilling before reaching either of the previous
   //    two states.

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -114,7 +114,7 @@ class HashBuild final : public Operator {
   void postHashBuildProcess();
 
   bool spillEnabled() const {
-    return spillConfig_.has_value();
+    return canReclaim();
   }
 
   void recordSpillStats();
@@ -219,8 +219,8 @@ class HashBuild final : public Operator {
   // The row type used for hash table build and disk spilling.
   RowTypePtr tableType_;
 
-  // Used to serialize access to intermediate state variables (like 'table_' and
-  // 'spiller_'). This is only required when variables are accessed
+  // Used to serialize access to internal state including 'table_' and
+  // 'spiller_'. This is only required when variables are accessed
   // concurrently, that is, when a thread tries to close the operator while
   // another thread is building the hash table. Refer to 'close()' and
   // finishHashBuild()' for more details.
@@ -263,8 +263,8 @@ class HashBuild final : public Operator {
   bool joinHasNullKeys_{false};
 
   // This can be nullptr if either spilling is not allowed or it has been
-  // trsnaferred to the last hash build operator while in kWaitForBuild state or
-  // it has been cleared to setup a new one for recursive spilling.
+  // transferred to the last hash build operator while in kWaitForBuild state or
+  // it has been cleared to set up a new one for recursive spilling.
   std::unique_ptr<Spiller> spiller_;
 
   // Used to read input from previously spilled data for restoring.

--- a/velox/exec/HashJoinBridge.cpp
+++ b/velox/exec/HashJoinBridge.cpp
@@ -29,7 +29,7 @@ void HashJoinBridge::addBuilder() {
   ++numBuilders_;
 }
 
-bool HashJoinBridge::setHashTable(
+void HashJoinBridge::setHashTable(
     std::unique_ptr<BaseHashTable> table,
     SpillPartitionSet spillPartitionSet,
     bool hasNullKeys) {
@@ -37,7 +37,6 @@ bool HashJoinBridge::setHashTable(
 
   auto spillPartitionIdSet = toSpillPartitionIdSet(spillPartitionSet);
 
-  bool hasSpillData;
   std::vector<ContinuePromise> promises;
   {
     std::lock_guard<std::mutex> l(mutex_);
@@ -64,12 +63,25 @@ bool HashJoinBridge::setHashTable(
         std::move(spillPartitionIdSet),
         hasNullKeys);
     restoringSpillPartitionId_.reset();
-
-    hasSpillData = !spillPartitionSets_.empty();
     promises = std::move(promises_);
   }
   notify(std::move(promises));
-  return hasSpillData;
+}
+
+void HashJoinBridge::setSpilledHashTable(SpillPartitionSet spillPartitionSet) {
+  VELOX_CHECK(
+      !spillPartitionSet.empty(), "Spilled table partitions can't be empty");
+  std::lock_guard<std::mutex> l(mutex_);
+  VELOX_CHECK(started_);
+  VELOX_CHECK(buildResult_.has_value());
+  VELOX_CHECK(restoringSpillShards_.empty());
+  VELOX_CHECK(!restoringSpillPartitionId_.has_value());
+
+  for (auto& partitionEntry : spillPartitionSet) {
+    const auto id = partitionEntry.first;
+    VELOX_CHECK_EQ(spillPartitionSets_.count(id), 0);
+    spillPartitionSets_.emplace(id, std::move(partitionEntry.second));
+  }
 }
 
 void HashJoinBridge::setAntiJoinHasNullKeys() {
@@ -131,10 +143,8 @@ bool HashJoinBridge::probeFinished() {
           spillPartitionSets_.begin()->second->split(numBuilders_);
       VELOX_CHECK_EQ(restoringSpillShards_.size(), numBuilders_);
       spillPartitionSets_.erase(spillPartitionSets_.begin());
-      promises = std::move(promises_);
-    } else {
-      VELOX_CHECK(promises_.empty());
     }
+    promises = std::move(promises_);
   }
   notify(std::move(promises));
   return hasSpillInput;
@@ -148,15 +158,23 @@ std::optional<HashJoinBridge::SpillInput> HashJoinBridge::spillInputOrFuture(
   VELOX_DCHECK(
       !restoringSpillPartitionId_.has_value() || !buildResult_.has_value());
 
-  if (!restoringSpillPartitionId_.has_value()) {
-    if (spillPartitionSets_.empty()) {
-      return HashJoinBridge::SpillInput{};
-    } else {
-      promises_.emplace_back("HashJoinBridge::spillInputOrFuture");
-      *future = promises_.back().getSemiFuture();
-      return std::nullopt;
-    }
+  // If 'buildResult_' is set, then the probe side is under processing. The
+  // build shall just wait.
+  if (buildResult_.has_value()) {
+    VELOX_CHECK(!restoringSpillPartitionId_.has_value());
+    promises_.emplace_back("HashJoinBridge::spillInputOrFuture");
+    *future = promises_.back().getSemiFuture();
+    return std::nullopt;
   }
+
+  // If 'restoringSpillPartitionId_' is not set after probe side is done, then
+  // the join processing is all done.
+  if (!restoringSpillPartitionId_.has_value()) {
+    VELOX_CHECK(spillPartitionSets_.empty());
+    VELOX_CHECK(restoringSpillShards_.empty());
+    return HashJoinBridge::SpillInput{};
+  }
+
   VELOX_CHECK(!restoringSpillShards_.empty());
   auto spillShard = std::move(restoringSpillShards_.back());
   restoringSpillShards_.pop_back();
@@ -175,22 +193,39 @@ uint64_t HashJoinMemoryReclaimer::reclaim(
     uint64_t targetBytes,
     uint64_t maxWaitMs,
     memory::MemoryReclaimer::Stats& stats) {
+  // The flags to track if we have reclaimed from both build and probe operators
+  // under a hash join node.
+  bool hasReclaimedFromBuild{false};
+  bool hasReclaimedFromProbe{false};
   uint64_t reclaimedBytes{0};
   pool->visitChildren([&](memory::MemoryPool* child) {
     VELOX_CHECK_EQ(child->kind(), memory::MemoryPool::Kind::kLeaf);
-    // The hash probe operator do not support memory reclaim.
-    if (!isHashBuildMemoryPool(*child)) {
-      return true;
+    const bool isBuild = isHashBuildMemoryPool(*child);
+    if (isBuild) {
+      if (!hasReclaimedFromBuild) {
+        // We just need to reclaim from any one of the hash build operator.
+        hasReclaimedFromBuild = true;
+        reclaimedBytes = child->reclaim(targetBytes, maxWaitMs, stats);
+      }
+      return !hasReclaimedFromProbe;
     }
-    // We only need to reclaim from any one of the hash build operators
-    // which will reclaim from all the peer hash build operators.
-    reclaimedBytes = child->reclaim(targetBytes, maxWaitMs, stats);
-    return false;
+
+    if (!hasReclaimedFromProbe) {
+      // The same as build operator, we only need to reclaim from any one of the
+      // hash probe operator.
+      hasReclaimedFromProbe = true;
+      reclaimedBytes = child->reclaim(targetBytes, maxWaitMs, stats);
+    }
+    return !hasReclaimedFromBuild;
   });
   return reclaimedBytes;
 }
 
 bool isHashBuildMemoryPool(const memory::MemoryPool& pool) {
   return folly::StringPiece(pool.name()).endsWith("HashBuild");
+}
+
+bool isHashProbeMemoryPool(const memory::MemoryPool& pool) {
+  return folly::StringPiece(pool.name()).endsWith("HashProbe");
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -726,11 +726,16 @@ void HashTable<ignoreNullKeys>::allocateTables(uint64_t size) {
 }
 
 template <bool ignoreNullKeys>
-void HashTable<ignoreNullKeys>::clear() {
+void HashTable<ignoreNullKeys>::clear(bool freeTable) {
   rows_->clear();
   if (table_) {
-    // All modes have 8 bytes per slot.
-    memset(table_, 0, capacity_ * sizeof(char*));
+    if (!freeTable) {
+      // All modes have 8 bytes per slot.
+      ::memset(table_, 0, capacity_ * sizeof(char*));
+    } else {
+      rows_->pool()->freeContiguous(tableAllocation_);
+      table_ = nullptr;
+    }
   }
   numDistinct_ = 0;
   numTombstones_ = 0;

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -258,9 +258,9 @@ class BaseHashTable {
   /// owned by 'this'.
   virtual int64_t allocatedBytes() const = 0;
 
-  /// Deletes any content of 'this' but does not free the memory. Can
-  /// be used for flushing a partial group by, for example.
-  virtual void clear() = 0;
+  /// Deletes any content of 'this'. If 'freeTable' is false, then hash table is
+  /// not freed which can be used for flushing a partial group by, for example.
+  virtual void clear(bool freeTable = false) = 0;
 
   /// Returns the capacity of the internal hash table which is number of rows
   /// it can stores in a group by or hash join build.
@@ -502,7 +502,7 @@ class HashTable : public BaseHashTable {
       int32_t maxRows,
       char** rows) override;
 
-  void clear() override;
+  void clear(bool freeTable = false) override;
 
   int64_t allocatedBytes() const override {
     // For each row: sizeof(char*) per table entry + memory

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1516,7 +1516,6 @@ bool Task::hasMixedExecutionGroup() const {
   if (!isGroupedExecution()) {
     return false;
   }
-  std::lock_guard<std::timed_mutex> l(mutex_);
   return numDriversUngrouped_ > 0;
 }
 

--- a/velox/exec/tests/GroupedExecutionTest.cpp
+++ b/velox/exec/tests/GroupedExecutionTest.cpp
@@ -42,8 +42,8 @@ class GroupedExecutionTest : public virtual HiveConnectorTestBase {
       int32_t count,
       int32_t rowsPerVector,
       const RowTypePtr& rowType = nullptr) {
-    auto inputs = rowType ? rowType : rowType_;
-    return HiveConnectorTestBase::makeVectors(inputs, count, rowsPerVector);
+    auto inputType = rowType ? rowType : rowType_;
+    return HiveConnectorTestBase::makeVectors(inputType, count, rowsPerVector);
   }
 
   exec::Split makeHiveSplitWithGroup(std::string path, int32_t group) {

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -5422,7 +5422,6 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringAllocation) {
         "facebook::velox::exec::Driver::runInternal::addInput",
         std::function<void(Operator*)>(([&](Operator* testOp) {
           if (testOp->operatorType() != "HashBuild") {
-            ASSERT_FALSE(testOp->canReclaim());
             return;
           }
           op = testOp;
@@ -5670,10 +5669,10 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringWaitForProbe) {
                       concat(probeType_->names(), buildType_->names()))
                   .planNode();
 
+  std::atomic_bool driverWaitFlag{true};
   folly::EventCount driverWait;
-  auto driverWaitKey = driverWait.prepareWait();
+  std::atomic_bool testWaitFlag{true};
   folly::EventCount testWait;
-  auto testWaitKey = testWait.prepareWait();
 
   Operator* op;
   std::atomic<bool> injectSpillOnce{true};
@@ -5704,7 +5703,6 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringWaitForProbe) {
         if (testOp->operatorType() != "HashProbe") {
           return;
         }
-        ASSERT_FALSE(testOp->canReclaim());
         if (!injectOnce.exchange(false)) {
           return;
         }
@@ -5714,11 +5712,12 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringWaitForProbe) {
         const bool reclaimable = op->reclaimableBytes(reclaimableBytes);
         ASSERT_TRUE(reclaimable);
         ASSERT_GT(reclaimableBytes, 0);
-        testWait.notify();
+        testWaitFlag = false;
+        testWait.notifyAll();
         auto* driver = testOp->testingOperatorCtx()->driver();
         auto task = driver->task();
         SuspendedSection suspendedSection(driver);
-        driverWait.wait(driverWaitKey);
+        driverWait.await([&]() { return !driverWaitFlag.load(); });
       })));
 
   std::thread taskThread([&]() {
@@ -5741,7 +5740,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringWaitForProbe) {
         .run();
   });
 
-  testWait.wait(testWaitKey);
+  testWait.await([&]() { return !testWaitFlag.load(); });
   ASSERT_TRUE(op != nullptr);
   auto task = op->testingOperatorCtx()->task();
   auto taskPauseWait = task->requestPause();
@@ -5764,7 +5763,8 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringWaitForProbe) {
   // No reclaim as the build operator is not in building table state.
   ASSERT_EQ(usedMemoryBytes, op->pool()->currentBytes());
 
-  driverWait.notify();
+  driverWaitFlag = false;
+  driverWait.notifyAll();
   Task::resume(task);
   task.reset();
 
@@ -7013,165 +7013,6 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringJoinTableBuild) {
   joinThread.join();
   memThread.join();
   waitForAllTasksToBeDeleted();
-}
-
-// This test is to reproduce a race condition that memory arbitrator tries to
-// reclaim from a set of hash build operators in which the last hash build
-// operator has finished.
-DEBUG_ONLY_TEST_F(HashJoinTest, raceBetweenRaclaimAndJoinFinish) {
-  std::unique_ptr<memory::MemoryManager> memoryManager = createMemoryManager();
-  const auto& arbitrator = memoryManager->arbitrator();
-  auto rowType = ROW({
-      {"c0", INTEGER()},
-      {"c1", INTEGER()},
-      {"c2", VARCHAR()},
-  });
-  // Build a large vector to trigger memory arbitration.
-  fuzzerOpts_.vectorSize = 10'000;
-  std::vector<RowVectorPtr> vectors = createVectors(2, rowType, fuzzerOpts_);
-  createDuckDbTable(vectors);
-
-  std::shared_ptr<core::QueryCtx> joinQueryCtx =
-      newQueryCtx(memoryManager, executor_, kMemoryCapacity);
-
-  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
-  core::PlanNodeId planNodeId;
-  auto plan = PlanBuilder(planNodeIdGenerator)
-                  .values(vectors, false)
-                  .project({"c0 AS t0", "c1 AS t1", "c2 AS t2"})
-                  .hashJoin(
-                      {"t0"},
-                      {"u0"},
-                      PlanBuilder(planNodeIdGenerator)
-                          .values(vectors, true)
-                          .project({"c0 AS u0", "c1 AS u1", "c2 AS u2"})
-                          .planNode(),
-                      "",
-                      {"t1"},
-                      core::JoinType::kAnti)
-                  .capturePlanNodeId(planNodeId)
-                  .planNode();
-
-  std::atomic<bool> waitForBuildFinishFlag{true};
-  folly::EventCount waitForBuildFinishEvent;
-  std::atomic<Driver*> lastBuildDriver{nullptr};
-  std::atomic<Task*> task{nullptr};
-  std::atomic<bool> isLastBuildFirstChildPool{false};
-  SCOPED_TESTVALUE_SET(
-      "facebook::velox::exec::HashBuild::finishHashBuild",
-      std::function<void(exec::HashBuild*)>([&](exec::HashBuild* buildOp) {
-        lastBuildDriver = buildOp->testingOperatorCtx()->driver();
-        // Checks if the last build memory pool is the first build pool in its
-        // parent node pool. It is used to check the test result.
-        int buildPoolIndex{0};
-        buildOp->pool()->parent()->visitChildren([&](memory::MemoryPool* pool) {
-          if (pool == buildOp->pool()) {
-            return false;
-          }
-          if (isHashBuildMemoryPool(*pool)) {
-            ++buildPoolIndex;
-          }
-          return true;
-        });
-        isLastBuildFirstChildPool = (buildPoolIndex == 0);
-        task = lastBuildDriver.load()->task().get();
-        waitForBuildFinishFlag = false;
-        waitForBuildFinishEvent.notifyAll();
-      }));
-
-  std::atomic<bool> waitForReclaimFlag{true};
-  folly::EventCount waitForReclaimEvent;
-  SCOPED_TESTVALUE_SET(
-      "facebook::velox::exec::Driver::runInternal",
-      std::function<void(Driver*)>([&](Driver* driver) {
-        auto* op = driver->findOperator(planNodeId);
-        if (op->operatorType() != "HashBuild" &&
-            op->operatorType() != "HashProbe") {
-          return;
-        }
-
-        // Suspend hash probe driver to wait for the test triggered reclaim to
-        // finish.
-        if (op->operatorType() == "HashProbe") {
-          op->pool()->reclaimer()->enterArbitration();
-          waitForReclaimEvent.await(
-              [&]() { return !waitForReclaimFlag.load(); });
-          op->pool()->reclaimer()->leaveArbitration();
-        }
-
-        // Check if we have reached to the last hash build operator or not. The
-        // testvalue callback will set the last build driver.
-        if (lastBuildDriver == nullptr) {
-          return;
-        }
-
-        // Suspend all the remaining hash build drivers until the test triggered
-        // reclaim finish.
-        op->pool()->reclaimer()->enterArbitration();
-        waitForReclaimEvent.await([&]() { return !waitForReclaimFlag.load(); });
-        op->pool()->reclaimer()->leaveArbitration();
-      }));
-
-  const int numDrivers = 4;
-  std::thread queryThread([&]() {
-    const auto spillDirectory = exec::test::TempDirectoryPath::create();
-    AssertQueryBuilder(plan, duckDbQueryRunner_)
-        .maxDrivers(numDrivers)
-        .queryCtx(joinQueryCtx)
-        .spillDirectory(spillDirectory->path)
-        .config(core::QueryConfig::kSpillEnabled, true)
-        .config(core::QueryConfig::kJoinSpillEnabled, true)
-        .assertResults(
-            "SELECT c1 FROM tmp WHERE c0 NOT IN (SELECT c0 FROM tmp)");
-  });
-
-  // Wait for the last hash build operator to start building the hash table.
-  waitForBuildFinishEvent.await([&] { return !waitForBuildFinishFlag.load(); });
-  ASSERT_TRUE(lastBuildDriver != nullptr);
-  ASSERT_TRUE(task != nullptr);
-
-  // Wait until the last build driver gets removed from the task after finishes.
-  while (task.load()->numFinishedDrivers() != 1) {
-    bool foundLastBuildDriver{false};
-    task.load()->testingVisitDrivers([&](Driver* driver) {
-      if (driver == lastBuildDriver) {
-        foundLastBuildDriver = true;
-      }
-    });
-    if (!foundLastBuildDriver) {
-      break;
-    }
-  }
-
-  // Reclaim from the task, and we can't reclaim anything as we don't support
-  // spill after hash table built.
-  memory::MemoryReclaimer::Stats stats;
-  const uint64_t oldCapacity = joinQueryCtx->pool()->capacity();
-  task.load()->pool()->shrink();
-  task.load()->pool()->reclaim(1'000, 0, stats);
-  // If the last build memory pool is first child of its parent memory pool,
-  // then memory arbitration (or join node memory pool) will reclaim from the
-  // last build operator first which simply quits as the driver has gone. If
-  // not, we expect to get numNonReclaimableAttempts from any one of the
-  // remaining hash build operator.
-  if (isLastBuildFirstChildPool) {
-    ASSERT_EQ(stats.numNonReclaimableAttempts, 0);
-  } else {
-    ASSERT_EQ(stats.numNonReclaimableAttempts, 1);
-  }
-  // Make sure we don't leak memory capacity since we reclaim from task pool
-  // directly.
-  static_cast<memory::MemoryPoolImpl*>(task.load()->pool())
-      ->testingSetCapacity(oldCapacity);
-  waitForReclaimFlag = false;
-  waitForReclaimEvent.notifyAll();
-
-  queryThread.join();
-
-  waitForAllTasksToBeDeleted();
-  ASSERT_EQ(arbitrator->stats().numFailures, 0);
-  ASSERT_EQ(arbitrator->stats().numReclaimedBytes, 0);
-  ASSERT_EQ(arbitrator->stats().numReserves, 1);
 }
 
 DEBUG_ONLY_TEST_F(HashJoinTest, joinBuildSpillError) {


### PR DESCRIPTION
This is a resubmit of [PR8926](https://github.com/facebookincubator/velox/pull/8926), On top of it, we fix a hanging issue in found under grouped
execution mode: when the first group finishes execution, the last hash probe operator doesn't send
signal to build operators so that the next group won't start as the first group has running drivers
(build drivers). This only happens under grouped execution mode with spilling config enabled (no matter
spilling has been triggered or not) with PR8926 which enforces the hash build operator to wait for
the hash probe to finish. Without the grouped execution mode, the task can finish when the output
pipeline finishes (hash probe). When spilling is disabled, the hash build operator will finish without
waiting for the hash probe to finish.
The fix is to enforce the last hash probe operator to send the completion signal to the hash build
operator and verified with unit test

Rerun on cluster with group execution and spilling enabled: 20240307_173141_00003_x4q6n
Rerun on cluster without group execution but spilling enabled: 20240307_173625_00008_x4q6n
Rerun on cluster without group execution and spilling disabled:  20240307_173759_00013_x4q6n