### PR TITLE
Add support in AggregationFuzzer to compare against reference DB for non deterministic functions on unsorted inputs 

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -147,7 +147,7 @@ jobs:
           ls -lR $PRESTO_HOME/etc
           /opt/start-prestojava.sh > /tmp/server.log 2>&1 &
           # Sleep for 60 seconds to allow Presto server to start.
-          sleep 60          
+          sleep 60
           /opt/presto-cli --server 127.0.0.1:8080 --execute 'CREATE SCHEMA hive.tpch;'
           mkdir -p /tmp/aggregate_fuzzer_repro/
           rm -rfv /tmp/aggregate_fuzzer_repro/*

--- a/velox/exec/fuzzer/AggregationFuzzerBase.cpp
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.cpp
@@ -87,6 +87,20 @@ DEFINE_bool(
 
 namespace facebook::velox::exec::test {
 
+bool AggregationFuzzerBase::isSupportedType(const TypePtr& type) const {
+  if (type->isDate() || type->isIntervalDayTime() || type->isUnKnown()) {
+    return false;
+  }
+
+  for (auto i = 0; i < type->size(); ++i) {
+    if (!isSupportedType(type->childAt(i))) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 bool AggregationFuzzerBase::addSignature(
     const std::string& name,
     const FunctionSignaturePtr& signature) {
@@ -460,6 +474,34 @@ AggregationFuzzerBase::computeReferenceResults(
       std::nullopt, ReferenceQueryErrorCode::kReferenceQueryUnsupported);
 }
 
+std::pair<
+    std::optional<std::vector<RowVectorPtr>>,
+    AggregationFuzzerBase::ReferenceQueryErrorCode>
+AggregationFuzzerBase::computeReferenceResultsAsVector(
+    const core::PlanNodePtr& plan,
+    const std::vector<RowVectorPtr>& input) {
+  VELOX_CHECK(referenceQueryRunner_->supportsVeloxVectorResults());
+
+  if (auto sql = referenceQueryRunner_->toSql(plan)) {
+    try {
+      return std::make_pair(
+          referenceQueryRunner_->executeVector(
+              sql.value(), input, plan->outputType()),
+          ReferenceQueryErrorCode::kSuccess);
+    } catch (std::exception& e) {
+      // ++stats_.numReferenceQueryFailed;
+      LOG(WARNING) << "Query failed in the reference DB";
+      return std::make_pair(
+          std::nullopt, ReferenceQueryErrorCode::kReferenceQueryFail);
+    }
+  } else {
+    LOG(INFO) << "Query not supported by the reference DB";
+  }
+
+  return std::make_pair(
+      std::nullopt, ReferenceQueryErrorCode::kReferenceQueryUnsupported);
+}
+
 void AggregationFuzzerBase::testPlan(
     const PlanWithSplits& planWithSplits,
     bool injectSpill,
@@ -474,7 +516,15 @@ void AggregationFuzzerBase::testPlan(
       injectSpill,
       abandonPartial,
       maxDrivers);
+  compare(actual, customVerification, customVerifiers, expected);
+}
 
+void AggregationFuzzerBase::compare(
+    const velox::test::ResultOrError& actual,
+    bool customVerification,
+    const std::vector<std::shared_ptr<ResultVerifier>>& customVerifiers,
+    const velox::test::ResultOrError& expected) {
+  // Compare results or exceptions (if any). Fail is anything is different.
   if (FLAGS_enable_oom_injection) {
     // If OOM injection is enabled and we've made it this far and the test
     // is considered a success.  We don't bother checking the results.
@@ -494,6 +544,9 @@ void AggregationFuzzerBase::testPlan(
         "Logically equivalent plans produced different results");
     return;
   }
+
+  VELOX_CHECK_NOT_NULL(expected.result);
+  VELOX_CHECK_NOT_NULL(actual.result);
 
   VELOX_CHECK_EQ(
       expected.result->size(),

--- a/velox/exec/fuzzer/AggregationFuzzerBase.cpp
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.cpp
@@ -88,6 +88,7 @@ DEFINE_bool(
 namespace facebook::velox::exec::test {
 
 bool AggregationFuzzerBase::isSupportedType(const TypePtr& type) const {
+  // Date / IntervalDayTime/ Unknown are not currently supported by DWRF.
   if (type->isDate() || type->isIntervalDayTime() || type->isUnKnown()) {
     return false;
   }
@@ -459,17 +460,14 @@ AggregationFuzzerBase::computeReferenceResults(
           referenceQueryRunner_->execute(
               sql.value(), input, plan->outputType()),
           ReferenceQueryErrorCode::kSuccess);
-    } catch (std::exception& e) {
-      // ++stats_.numReferenceQueryFailed;
+    } catch (...) {
       LOG(WARNING) << "Query failed in the reference DB";
       return std::make_pair(
           std::nullopt, ReferenceQueryErrorCode::kReferenceQueryFail);
     }
-  } else {
-    LOG(INFO) << "Query not supported by the reference DB";
-    // ++stats_.numVerificationNotSupported;
   }
 
+  LOG(INFO) << "Query not supported by the reference DB";
   return std::make_pair(
       std::nullopt, ReferenceQueryErrorCode::kReferenceQueryUnsupported);
 }
@@ -488,8 +486,7 @@ AggregationFuzzerBase::computeReferenceResultsAsVector(
           referenceQueryRunner_->executeVector(
               sql.value(), input, plan->outputType()),
           ReferenceQueryErrorCode::kSuccess);
-    } catch (std::exception& e) {
-      // ++stats_.numReferenceQueryFailed;
+    } catch (...) {
       LOG(WARNING) << "Query failed in the reference DB";
       return std::make_pair(
           std::nullopt, ReferenceQueryErrorCode::kReferenceQueryFail);

--- a/velox/exec/fuzzer/AggregationFuzzerBase.h
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.h
@@ -239,6 +239,10 @@ class AggregationFuzzerBase {
       const std::vector<std::shared_ptr<ResultVerifier>>& customVerifiers,
       const velox::test::ResultOrError& expected);
 
+  /// Returns false if the type or its children are unsupported.
+  /// Currently returns false if type is Date,IntervalDayTime or Unknown.
+  /// @param type
+  /// @return bool
   bool isSupportedType(const TypePtr& type) const;
 
   // @param customVerification If false, results are compared as is. Otherwise,

--- a/velox/exec/fuzzer/AggregationFuzzerBase.h
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.h
@@ -224,6 +224,23 @@ class AggregationFuzzerBase {
       bool abandonPartial = false,
       int32_t maxDrivers = 2);
 
+  // Will throw if referenceQueryRunner doesn't support
+  // returning results as a vector.
+  std::pair<
+      std::optional<std::vector<RowVectorPtr>>,
+      AggregationFuzzerBase::ReferenceQueryErrorCode>
+  computeReferenceResultsAsVector(
+      const core::PlanNodePtr& plan,
+      const std::vector<RowVectorPtr>& input);
+
+  void compare(
+      const velox::test::ResultOrError& actual,
+      bool customVerification,
+      const std::vector<std::shared_ptr<ResultVerifier>>& customVerifiers,
+      const velox::test::ResultOrError& expected);
+
+  bool isSupportedType(const TypePtr& type) const;
+
   // @param customVerification If false, results are compared as is. Otherwise,
   // only row counts are compared.
   // @param customVerifiers Custom verifier for each aggregate function. These

--- a/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
@@ -106,7 +106,13 @@ int main(int argc, char** argv) {
       "stddev_pop",
       // Lambda functions are not supported yet.
       "reduce_agg",
-  };
+      "arbitrary", // change sortedinput
+      "max_data_size_for_stats",
+      "map_union_sum", // presto real error
+      "approx_set", // presto: Doesnt support timestamps
+      "min_by", // need custom verifier
+      "max_by", // same as above
+      "any_value"};
 
   using facebook::velox::exec::test::ApproxDistinctResultVerifier;
   using facebook::velox::exec::test::ApproxPercentileResultVerifier;

--- a/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
@@ -106,12 +106,11 @@ int main(int argc, char** argv) {
       "stddev_pop",
       // Lambda functions are not supported yet.
       "reduce_agg",
-      "arbitrary", // change sortedinput
       "max_data_size_for_stats",
-      "map_union_sum", // presto real error
-      "approx_set", // presto: Doesnt support timestamps
-      "min_by", // need custom verifier
-      "max_by", // same as above
+      "map_union_sum",
+      "approx_set",
+      "min_by",
+      "max_by",
       "any_value"};
 
   using facebook::velox::exec::test::ApproxDistinctResultVerifier;


### PR DESCRIPTION
**Why**
 Currently for aggregate functions with custom verifiers, we do not verify plans against the reference db. This is because for these functions the reference db results differ and require us to use custom verifiers - typically the ResultVerifier::compare api. The compare api requires VeloxVectors and previously the results of the reference query runner were in materialized row format and thus couldnt be called. Recently support was added to return the reference db results as velox vectors (#8880). With this we can now validate functions which require custom verifiers.

**What**
We add support in the AggregationFuzzer to use the new 'executeVector' api if supported by the refrence query runner, and use that to validate non deterministic functions that require a custom verifier. 

**Results**
Currently with this change we have increased the number of plans being verified against reference db from 40 % to 80+%. 

```
 Total masked aggregations: 78 (14.58%)
Total global aggregations: 41 (7.66%)
Total group-by aggregations: 392 (73.27%)
Total distinct aggregations: 49 (9.16%)
 Total aggregations over distinct inputs: 40 (7.48%)
Total window expressions: 53 (9.91%)
 Total functions tested: 38
 Total iterations requiring sorted inputs: 43 (8.04%)
Total iterations verified against reference DB: 448 (83.74%)
 Total functions not verified (verification skipped / not supported by reference DB / reference DB failed): 53 (9.91%) / 6 (1.12%) / 3 (0.56%)
 Total failed functions: 27 (5.05%)
```

Experimental runs : 
https://github.com/facebookincubator/velox/actions/runs/8199583642/job/22443872635 
 https://github.com/facebookincubator/velox/actions/runs/8199583642/job/22424917125
 
 **Notes**
 Certain functions have been skiplisted for following reasons: 
 1. map_union_sum : This requires us to use the lates presto due to a bug on Presto end in version .284 not supporting reals. 
 2. approx_set: Signatures supported by Velox are more than supported by Presto
 3. min_by, max_by: Requires custom verifiers (order by not supported by Presto)
 4. any_value: alias for arbitrary but this alias isnt present in Presto.
 

