### PR TITLE
Remove "using namespace" dep in ubs/admin_api/policy_engine/internal/auth/UBSPolicyAclCheckerSet.h + 5

### DIFF
--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -28,6 +28,8 @@ using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::memory {
 
+using namespace facebook::velox::memory;
+
 namespace {
 
 // Returns the max capacity to grow of memory 'pool'. The calculation is based


### PR DESCRIPTION
Summary:
The files modified in this diff rely on `using namespace` in the global namespace. In this diff we break that reliance by adding appropriate namespace qualifiers.

Landing this diff helps us onboard our code to the `-Wheader-hygiene` warning flag.

D54681732 aggregates many of these files and D54681798 removes the associated headers; however, I have broken D54681732 up to make landing and rollbacks safer.

Reviewed By: palmje

Differential Revision: D54692601


