### PR TITLE
Remove "using namespace" dep in velox/common/memory/tests/SharedArbitratorTest.cpp + 5

### DIFF
--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -38,6 +38,7 @@ DEFINE_bool(
     "Enable to turn on arbitration for tests by default");
 
 using namespace facebook::velox::common::testutil;
+using namespace facebook::velox::memory;
 
 namespace facebook::velox::exec::test {
 
@@ -58,7 +59,7 @@ void OperatorTestBase::SetUpTestCase() {
   FLAGS_velox_enable_memory_usage_track_in_default_memory_pool = true;
   FLAGS_velox_memory_leak_check_enabled = true;
   memory::SharedArbitrator::registerFactory();
-  memory::MemoryManagerOptions options;
+  MemoryManagerOptions options;
   options.allocatorCapacity = 8L << 30;
   if (FLAGS_velox_testing_enable_arbitration) {
     options.arbitratorCapacity = 6L << 30;


### PR DESCRIPTION
Summary:
The files modified in this diff rely on `using namespace` in the global namespace. In this diff we break that reliance by adding appropriate namespace qualifiers.

Landing this diff helps us onboard our code to the `-Wheader-hygiene` warning flag.

D54681732 aggregates many of these files and D54681798 removes the associated headers; however, I have broken D54681732 up to make landing and rollbacks safer.

Reviewed By: palmje

Differential Revision: D54692599


