### PR TITLE
Add RowsStreamingWindowBuild to avoid OOM in Window operator

### DIFF
--- a/velox/exec/AggregateWindow.cpp
+++ b/velox/exec/AggregateWindow.cpp
@@ -410,6 +410,7 @@ void registerAggregateWindowFunction(const std::string& name) {
     exec::registerWindowFunction(
         name,
         std::move(signatures),
+        {exec::WindowFunction::ProcessMode::kRows, true},
         [name](
             const std::vector<exec::WindowFunctionArg>& args,
             const TypePtr& resultType,

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -59,9 +59,11 @@ velox_add_library(
   OutputBufferManager.cpp
   PartitionedOutput.cpp
   PartitionFunction.cpp
+  PartitionStreamingWindowBuild.cpp
   PlanNodeStats.cpp
   PrefixSort.cpp
   ProbeOperatorState.cpp
+  RowsStreamingWindowBuild.cpp
   RowContainer.cpp
   RowNumber.cpp
   SortBuffer.cpp
@@ -71,7 +73,6 @@ velox_add_library(
   SpillFile.cpp
   Spiller.cpp
   StreamingAggregation.cpp
-  StreamingWindowBuild.cpp
   Strings.cpp
   TableScan.cpp
   TableWriteMerge.cpp

--- a/velox/exec/PartitionStreamingWindowBuild.cpp
+++ b/velox/exec/PartitionStreamingWindowBuild.cpp
@@ -14,24 +14,24 @@
  * limitations under the License.
  */
 
-#include "velox/exec/StreamingWindowBuild.h"
+#include "velox/exec/PartitionStreamingWindowBuild.h"
 
 namespace facebook::velox::exec {
 
-StreamingWindowBuild::StreamingWindowBuild(
+PartitionStreamingWindowBuild::PartitionStreamingWindowBuild(
     const std::shared_ptr<const core::WindowNode>& windowNode,
     velox::memory::MemoryPool* pool,
     const common::SpillConfig* spillConfig,
     tsan_atomic<bool>* nonReclaimableSection)
     : WindowBuild(windowNode, pool, spillConfig, nonReclaimableSection) {}
 
-void StreamingWindowBuild::buildNextPartition() {
+void PartitionStreamingWindowBuild::buildNextPartition() {
   partitionStartRows_.push_back(sortedRows_.size());
   sortedRows_.insert(sortedRows_.end(), inputRows_.begin(), inputRows_.end());
   inputRows_.clear();
 }
 
-void StreamingWindowBuild::addInput(RowVectorPtr input) {
+void PartitionStreamingWindowBuild::addInput(RowVectorPtr input) {
   for (auto i = 0; i < inputChannels_.size(); ++i) {
     decodedInputVectors_[i].decode(*input->childAt(inputChannels_[i]));
   }
@@ -53,14 +53,15 @@ void StreamingWindowBuild::addInput(RowVectorPtr input) {
   }
 }
 
-void StreamingWindowBuild::noMoreInput() {
+void PartitionStreamingWindowBuild::noMoreInput() {
   buildNextPartition();
 
   // Help for last partition related calculations.
   partitionStartRows_.push_back(sortedRows_.size());
 }
 
-std::unique_ptr<WindowPartition> StreamingWindowBuild::nextPartition() {
+std::shared_ptr<WindowPartition>
+PartitionStreamingWindowBuild::nextPartition() {
   VELOX_CHECK_GT(
       partitionStartRows_.size(), 0, "No window partitions available")
 
@@ -91,11 +92,11 @@ std::unique_ptr<WindowPartition> StreamingWindowBuild::nextPartition() {
       sortedRows_.data() + partitionStartRows_[currentPartition_],
       partitionSize);
 
-  return std::make_unique<WindowPartition>(
+  return std::make_shared<WindowPartition>(
       data_.get(), partition, inversedInputChannels_, sortKeyInfo_);
 }
 
-bool StreamingWindowBuild::hasNextPartition() {
+bool PartitionStreamingWindowBuild::hasNextPartition() {
   return partitionStartRows_.size() > 0 &&
       currentPartition_ < int(partitionStartRows_.size() - 2);
 }

--- a/velox/exec/PartitionStreamingWindowBuild.h
+++ b/velox/exec/PartitionStreamingWindowBuild.h
@@ -20,13 +20,13 @@
 
 namespace facebook::velox::exec {
 
-/// The StreamingWindowBuild is used when the input data is already sorted by
-/// {partition keys + order by keys}. The logic identifies partition changes
-/// when receiving input rows and splits out WindowPartitions for the Window
-/// operator to process.
-class StreamingWindowBuild : public WindowBuild {
+/// The PartitionStreamingWindowBuild is used when the input data is already
+/// sorted by {partition keys + order by keys}. The logic identifies partition
+/// changes when receiving input rows and splits out WindowPartitions for the
+/// Window operator to process.
+class PartitionStreamingWindowBuild : public WindowBuild {
  public:
-  StreamingWindowBuild(
+  PartitionStreamingWindowBuild(
       const std::shared_ptr<const core::WindowNode>& windowNode,
       velox::memory::MemoryPool* pool,
       const common::SpillConfig* spillConfig,
@@ -46,7 +46,7 @@ class StreamingWindowBuild : public WindowBuild {
 
   bool hasNextPartition() override;
 
-  std::unique_ptr<WindowPartition> nextPartition() override;
+  std::shared_ptr<WindowPartition> nextPartition() override;
 
   bool needsInput() override {
     // No partitions are available or the currentPartition is the last available

--- a/velox/exec/RowsStreamingWindowBuild.cpp
+++ b/velox/exec/RowsStreamingWindowBuild.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/RowsStreamingWindowBuild.h"
+#include "velox/common/testutil/TestValue.h"
+
+namespace facebook::velox::exec {
+
+RowsStreamingWindowBuild::RowsStreamingWindowBuild(
+    const std::shared_ptr<const core::WindowNode>& windowNode,
+    velox::memory::MemoryPool* pool,
+    const common::SpillConfig* spillConfig,
+    tsan_atomic<bool>* nonReclaimableSection)
+    : WindowBuild(windowNode, pool, spillConfig, nonReclaimableSection) {
+  velox::common::testutil::TestValue::adjust(
+      "facebook::velox::exec::RowsStreamingWindowBuild::RowsStreamingWindowBuild",
+      this);
+}
+
+void RowsStreamingWindowBuild::addPartitionInputs(bool finished) {
+  if (inputRows_.empty()) {
+    return;
+  }
+
+  if (windowPartitions_.size() <= inputPartition_) {
+    windowPartitions_.push_back(std::make_shared<WindowPartition>(
+        data_.get(), inversedInputChannels_, sortKeyInfo_));
+  }
+
+  windowPartitions_[inputPartition_]->addRows(inputRows_);
+
+  if (finished) {
+    windowPartitions_[inputPartition_]->setComplete();
+    ++inputPartition_;
+  }
+
+  inputRows_.clear();
+}
+
+void RowsStreamingWindowBuild::addInput(RowVectorPtr input) {
+  for (auto i = 0; i < inputChannels_.size(); ++i) {
+    decodedInputVectors_[i].decode(*input->childAt(inputChannels_[i]));
+  }
+
+  for (auto row = 0; row < input->size(); ++row) {
+    char* newRow = data_->newRow();
+
+    for (auto col = 0; col < input->childrenSize(); ++col) {
+      data_->store(decodedInputVectors_[col], row, newRow, col);
+    }
+
+    if (previousRow_ != nullptr &&
+        compareRowsWithKeys(previousRow_, newRow, partitionKeyInfo_)) {
+      addPartitionInputs(true);
+    }
+
+    if (previousRow_ != nullptr && inputRows_.size() >= numRowsPerOutput_) {
+      addPartitionInputs(false);
+    }
+
+    inputRows_.push_back(newRow);
+    previousRow_ = newRow;
+  }
+}
+
+void RowsStreamingWindowBuild::noMoreInput() {
+  addPartitionInputs(true);
+}
+
+std::shared_ptr<WindowPartition> RowsStreamingWindowBuild::nextPartition() {
+  VELOX_CHECK(hasNextPartition());
+  return windowPartitions_[++outputPartition_];
+}
+
+bool RowsStreamingWindowBuild::hasNextPartition() {
+  return !windowPartitions_.empty() &&
+      outputPartition_ + 2 <= windowPartitions_.size();
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/RowsStreamingWindowBuild.h
+++ b/velox/exec/RowsStreamingWindowBuild.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/exec/WindowBuild.h"
+
+namespace facebook::velox::exec {
+
+/// Unlike PartitionStreamingWindowBuild, RowsStreamingWindowBuild is capable of
+/// processing window functions as rows arrive within a single partition,
+/// without the need to wait for the entirewindow partition to be ready. This
+/// approach can significantly reduce memory usage, especially when a single
+/// partition contains a large amount of data. It is particularly suited for
+/// optimizing rank, dense_rank and row_number functions, as well as aggregate
+/// window functions with a default frame.
+class RowsStreamingWindowBuild : public WindowBuild {
+ public:
+  RowsStreamingWindowBuild(
+      const std::shared_ptr<const core::WindowNode>& windowNode,
+      velox::memory::MemoryPool* pool,
+      const common::SpillConfig* spillConfig,
+      tsan_atomic<bool>* nonReclaimableSection);
+
+  void addInput(RowVectorPtr input) override;
+
+  void spill() override {
+    VELOX_UNREACHABLE();
+  }
+
+  std::optional<common::SpillStats> spilledStats() const override {
+    return std::nullopt;
+  }
+
+  void noMoreInput() override;
+
+  bool hasNextPartition() override;
+
+  std::shared_ptr<WindowPartition> nextPartition() override;
+
+  bool needsInput() override {
+    // No partitions are available or the currentPartition is the last available
+    // one, so can consume input rows.
+    return windowPartitions_.empty() ||
+        outputPartition_ == windowPartitions_.size() - 1;
+  }
+
+ private:
+  // Adds input rows to the current partition, or creates a new partition if it
+  // does not exist.
+  void addPartitionInputs(bool finished);
+
+  // Points to the input rows in the current partition.
+  std::vector<char*> inputRows_;
+
+  // Used to compare rows based on partitionKeys.
+  char* previousRow_ = nullptr;
+
+  // Point to the current output partition if not -1.
+  vector_size_t outputPartition_ = -1;
+
+  // Current input partition that receives inputs.
+  vector_size_t inputPartition_ = 0;
+
+  // Holds all the built window partitions.
+  std::vector<std::shared_ptr<WindowPartition>> windowPartitions_;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/SortWindowBuild.cpp
+++ b/velox/exec/SortWindowBuild.cpp
@@ -294,11 +294,11 @@ void SortWindowBuild::loadNextPartitionFromSpill() {
   }
 }
 
-std::unique_ptr<WindowPartition> SortWindowBuild::nextPartition() {
+std::shared_ptr<WindowPartition> SortWindowBuild::nextPartition() {
   if (merge_ != nullptr) {
     VELOX_CHECK(!sortedRows_.empty(), "No window partitions available")
     auto partition = folly::Range(sortedRows_.data(), sortedRows_.size());
-    return std::make_unique<WindowPartition>(
+    return std::make_shared<WindowPartition>(
         data_.get(), partition, inversedInputChannels_, sortKeyInfo_);
   }
 
@@ -316,7 +316,7 @@ std::unique_ptr<WindowPartition> SortWindowBuild::nextPartition() {
   auto partition = folly::Range(
       sortedRows_.data() + partitionStartRows_[currentPartition_],
       partitionSize);
-  return std::make_unique<WindowPartition>(
+  return std::make_shared<WindowPartition>(
       data_.get(), partition, inversedInputChannels_, sortKeyInfo_);
 }
 

--- a/velox/exec/SortWindowBuild.h
+++ b/velox/exec/SortWindowBuild.h
@@ -53,7 +53,7 @@ class SortWindowBuild : public WindowBuild {
 
   bool hasNextPartition() override;
 
-  std::unique_ptr<WindowPartition> nextPartition() override;
+  std::shared_ptr<WindowPartition> nextPartition() override;
 
  private:
   void ensureInputFits(const RowVectorPtr& input);

--- a/velox/exec/Window.h
+++ b/velox/exec/Window.h
@@ -88,6 +88,11 @@ class Window : public Operator {
     const std::optional<FrameChannelArg> end;
   };
 
+  // Returns if a window operator support rows-wise streaming processing or not.
+  // Currently we supports 'rank', 'dense_rank' and 'row_number' functions with
+  // any frame type. Also supports the agg window function with default frame.
+  bool supportRowsStreaming();
+
   // Creates WindowFunction and frame objects for this operator.
   void createWindowFunctions();
 
@@ -165,7 +170,7 @@ class Window : public Operator {
 
   // Used to access window partition rows and columns by the window
   // operator and functions. This structure is owned by the WindowBuild.
-  std::unique_ptr<WindowPartition> currentPartition_;
+  std::shared_ptr<WindowPartition> currentPartition_;
 
   // HashStringAllocator required by functions that allocate out of line
   // buffers.

--- a/velox/exec/WindowBuild.h
+++ b/velox/exec/WindowBuild.h
@@ -66,12 +66,16 @@ class WindowBuild {
   /// access the underlying columns of Window partition data. Check
   /// hasNextPartition() before invoking this function. This function fails if
   /// called when no partition is available.
-  virtual std::unique_ptr<WindowPartition> nextPartition() = 0;
+  virtual std::shared_ptr<WindowPartition> nextPartition() = 0;
 
   /// Returns the average size of input rows in bytes stored in the data
   /// container of the WindowBuild.
   std::optional<int64_t> estimateRowSize() {
     return data_->estimateRowSize();
+  }
+
+  void setNumRowsPerOutput(vector_size_t numRowsPerOutput) {
+    numRowsPerOutput_ = numRowsPerOutput;
   }
 
  protected:
@@ -111,6 +115,9 @@ class WindowBuild {
 
   /// Number of input rows.
   vector_size_t numRows_ = 0;
+
+  // The maximum number of rows that can fit into an output block.
+  vector_size_t numRowsPerOutput_;
 };
 
 } // namespace facebook::velox::exec

--- a/velox/exec/WindowFunction.cpp
+++ b/velox/exec/WindowFunction.cpp
@@ -41,11 +41,22 @@ std::optional<const WindowFunctionEntry*> getWindowFunctionEntry(
 bool registerWindowFunction(
     const std::string& name,
     std::vector<FunctionSignaturePtr> signatures,
+    WindowFunction::Metadata metadata,
     WindowFunctionFactory factory) {
   auto sanitizedName = sanitizeName(name);
   windowFunctions()[sanitizedName] = {
-      std::move(signatures), std::move(factory)};
+      std::move(signatures), std::move(factory), std::move(metadata)};
   return true;
+}
+
+WindowFunction::Metadata getWindowFunctionMetadata(const std::string& name) {
+  const auto sanitizedName = sanitizeName(name);
+  if (auto func = getWindowFunctionEntry(sanitizedName)) {
+    return func.value()->metadata;
+  } else {
+    VELOX_USER_FAIL(
+        "Window function metadata not found for function: {}", name);
+  }
 }
 
 std::optional<std::vector<FunctionSignaturePtr>> getWindowFunctionSignatures(

--- a/velox/exec/WindowPartition.cpp
+++ b/velox/exec/WindowPartition.cpp
@@ -21,13 +21,70 @@ WindowPartition::WindowPartition(
     RowContainer* data,
     const folly::Range<char**>& rows,
     const std::vector<column_index_t>& inputMapping,
-    const std::vector<std::pair<column_index_t, core::SortOrder>>& sortKeyInfo)
-    : data_(data),
+    const std::vector<std::pair<column_index_t, core::SortOrder>>& sortKeyInfo,
+    bool partial,
+    bool complete)
+    : partial_(partial),
+      data_(data),
       partition_(rows),
+      complete_(complete),
       inputMapping_(inputMapping),
       sortKeyInfo_(sortKeyInfo) {
-  for (int i = 0; i < inputMapping_.size(); i++) {
-    columns_.emplace_back(data_->columnAt(inputMapping_[i]));
+  VELOX_CHECK_NE(partial_, complete_);
+  VELOX_CHECK_NE(complete_, partition_.empty());
+
+  for (auto index : inputMapping_) {
+    columns_.emplace_back(data_->columnAt(index));
+  }
+}
+
+WindowPartition::WindowPartition(
+    RowContainer* data,
+    const folly::Range<char**>& rows,
+    const std::vector<column_index_t>& inputMapping,
+    const std::vector<std::pair<column_index_t, core::SortOrder>>& sortKeyInfo)
+    : WindowPartition(data, rows, inputMapping, sortKeyInfo, false, true) {}
+
+WindowPartition::WindowPartition(
+    RowContainer* data,
+    const std::vector<column_index_t>& inputMapping,
+    const std::vector<std::pair<column_index_t, core::SortOrder>>& sortKeyInfo)
+    : WindowPartition(data, {}, inputMapping, sortKeyInfo, true, false) {}
+
+void WindowPartition::addRows(const std::vector<char*>& rows) {
+  checkPartial();
+  rows_.insert(rows_.end(), rows.begin(), rows.end());
+  partition_ = folly::Range(rows_.data(), rows_.size());
+}
+
+void WindowPartition::eraseRows(vector_size_t numRows) {
+  checkPartial();
+  VELOX_CHECK_GE(data_->numRows(), numRows);
+  data_->eraseRows(folly::Range<char**>(rows_.data(), numRows));
+}
+
+void WindowPartition::removeProcessedRows(vector_size_t numRows) {
+  checkPartial();
+
+  VELOX_CHECK_NULL(previousRow_);
+  if (complete_ && rows_.size() == numRows) {
+    eraseRows(numRows);
+  } else {
+    eraseRows(numRows - 1);
+    previousRow_ = rows_[numRows - 1];
+  }
+
+  rows_.erase(rows_.begin(), rows_.begin() + numRows);
+  partition_ = folly::Range(rows_.data(), rows_.size());
+  startRow_ += numRows;
+}
+
+vector_size_t WindowPartition::numRowsForProcessing(
+    vector_size_t partitionOffset) const {
+  if (partial_) {
+    return partition_.size();
+  } else {
+    return partition_.size() - partitionOffset;
   }
 }
 
@@ -50,8 +107,9 @@ void WindowPartition::extractColumn(
     vector_size_t numRows,
     vector_size_t resultOffset,
     const VectorPtr& result) const {
+  VELOX_CHECK_GE(partitionOffset, startRow_);
   RowContainer::extractColumn(
-      partition_.data() + partitionOffset,
+      partition_.data() + partitionOffset - startRow_,
       numRows,
       columns_[columnIndex],
       resultOffset,
@@ -130,23 +188,65 @@ bool WindowPartition::compareRowsWithSortKeys(const char* lhs, const char* rhs)
   return false;
 }
 
+vector_size_t WindowPartition::findPeerRowEndIndex(
+    vector_size_t startRow,
+    vector_size_t lastRow,
+    const std::function<bool(const char*, const char*)>& peerCompare) {
+  auto peerEnd = startRow;
+  while (peerEnd <= lastRow) {
+    if (peerCompare(
+            partition_[startRow - startRow_],
+            partition_[peerEnd - startRow_])) {
+      break;
+    }
+    ++peerEnd;
+  }
+  return peerEnd;
+}
+
+void WindowPartition::removePreviousRow() {
+  VELOX_CHECK_NOT_NULL(previousRow_);
+  data_->eraseRows(folly::Range<char**>(&previousRow_, 1));
+  previousRow_ = nullptr;
+}
+
 std::pair<vector_size_t, vector_size_t> WindowPartition::computePeerBuffers(
     vector_size_t start,
     vector_size_t end,
     vector_size_t prevPeerStart,
     vector_size_t prevPeerEnd,
     vector_size_t* rawPeerStarts,
-    vector_size_t* rawPeerEnds) const {
+    vector_size_t* rawPeerEnds) {
   const auto peerCompare = [&](const char* lhs, const char* rhs) -> bool {
     return compareRowsWithSortKeys(lhs, rhs);
   };
 
-  VELOX_CHECK_LE(end, numRows());
+  VELOX_CHECK_LE(end, numRows() + startRow_);
 
-  const auto lastPartitionRow = numRows() - 1;
+  auto lastPartitionRow = numRows() + startRow_ - 1;
   auto peerStart = prevPeerStart;
   auto peerEnd = prevPeerEnd;
-  for (auto i = start, j = 0; i < end; ++i, ++j) {
+
+  size_t next = start;
+  size_t index{0};
+  if (partial_ && start > 0) {
+    const auto peerGroup = peerCompare(previousRow_, partition_[0]);
+
+    // The first row is the last row in previous batch so delete it after used
+    // for the first peer group detection.
+    removePreviousRow();
+
+    if (!peerGroup) {
+      peerEnd = findPeerRowEndIndex(start, lastPartitionRow, peerCompare);
+
+      for (; next < std::min(end, peerEnd); ++next, ++index) {
+        rawPeerStarts[index] = peerStart;
+        rawPeerEnds[index] = peerEnd - 1;
+      }
+    }
+  }
+
+  for (; next < end; ++next, ++index) {
     // When traversing input partition rows, the peers are the rows with the
     // same values for the ORDER BY clause. These rows are equal in some ways
     // and affect the results of ranking functions. This logic exploits the fact
@@ -155,22 +255,17 @@ std::pair<vector_size_t, vector_size_t> WindowPartition::computePeerBuffers(
     // across the rows in that peer interval. Note: peerStart and peerEnd can be
     // maintained across getOutput calls. Hence, they are returned to the
     // caller.
-    if (i == 0 || i >= peerEnd) {
+    if (next == 0 || next >= peerEnd) {
       // Compute peerStart and peerEnd rows for the first row of the partition
       // or when past the previous peerGroup.
-      peerStart = i;
-      peerEnd = i;
-      while (peerEnd <= lastPartitionRow) {
-        if (peerCompare(partition_[peerStart], partition_[peerEnd])) {
-          break;
-        }
-        ++peerEnd;
-      }
+      peerStart = next;
+      peerEnd = findPeerRowEndIndex(peerStart, lastPartitionRow, peerCompare);
     }
 
-    rawPeerStarts[j] = peerStart;
-    rawPeerEnds[j] = peerEnd - 1;
+    rawPeerStarts[index] = peerStart;
+    rawPeerEnds[index] = peerEnd - 1;
   }
+  VELOX_CHECK_EQ(index, end - start);
   return {peerStart, peerEnd};
 }
 

--- a/velox/exec/WindowPartition.h
+++ b/velox/exec/WindowPartition.h
@@ -20,9 +20,14 @@
 
 /// Simple WindowPartition that builds over the RowContainer used for storing
 /// the input rows in the Window Operator. This works completely in-memory.
+/// WindowPartition supports partial window partitioning to facilitate
+/// RowsStreamingWindowBuild which can start data processing with a portion set
+/// of rows without having to wait until an entire partition of rows are ready.
+
 /// TODO: This implementation will be revised for Spill to disk semantics.
 
 namespace facebook::velox::exec {
+
 class WindowPartition {
  public:
   /// The WindowPartition is used by the Window operator and WindowFunction
@@ -42,9 +47,44 @@ class WindowPartition {
       const std::vector<std::pair<column_index_t, core::SortOrder>>&
           sortKeyInfo);
 
+  /// The WindowPartition is used for RowStreamingWindowBuild which allows to
+  /// start data processing with a subset of partition rows. 'partial_' flag is
+  /// set for the constructed window partition.
+  WindowPartition(
+      RowContainer* data,
+      const std::vector<column_index_t>& inputMapping,
+      const std::vector<std::pair<column_index_t, core::SortOrder>>&
+          sortKeyInfo);
+
+  /// Adds remaining input 'rows' for a partial window partition.
+  void addRows(const std::vector<char*>& rows);
+
+  /// Removes the first 'numRows' in 'rows_' from a partial window partition
+  /// after been processed.
+  void removeProcessedRows(vector_size_t numRows);
+
   /// Returns the number of rows in the current WindowPartition.
   vector_size_t numRows() const {
     return partition_.size();
+  }
+
+  /// Returns the number of rows in a window partition remaining for data
+  /// processing.
+  vector_size_t numRowsForProcessing(vector_size_t partitionOffset) const;
+
+  bool complete() const {
+    return complete_;
+  }
+
+  bool partial() const {
+    return partial_;
+  }
+
+  void setComplete() {
+    VELOX_CHECK(!complete_);
+    checkPartial();
+
+    complete_ = true;
   }
 
   /// Copies the values at 'columnIndex' into 'result' (starting at
@@ -107,7 +147,7 @@ class WindowPartition {
       vector_size_t prevPeerStart,
       vector_size_t prevPeerEnd,
       vector_size_t* rawPeerStarts,
-      vector_size_t* rawPeerEnds) const;
+      vector_size_t* rawPeerEnds);
 
   /// Sets in 'rawFrameBounds' the frame boundary for the k range
   /// preceding/following frame.
@@ -128,7 +168,32 @@ class WindowPartition {
       vector_size_t* rawFrameBounds) const;
 
  private:
+  WindowPartition(
+      RowContainer* data,
+      const folly::Range<char**>& rows,
+      const std::vector<column_index_t>& inputMapping,
+      const std::vector<std::pair<column_index_t, core::SortOrder>>&
+          sortKeyInfo,
+      bool partial,
+      bool complete);
+
   bool compareRowsWithSortKeys(const char* lhs, const char* rhs) const;
+
+  // Finds the index of the last peer row in range of ['startRow', 'lastRow'].
+  vector_size_t findPeerRowEndIndex(
+      vector_size_t startRow,
+      vector_size_t lastRow,
+      const std::function<bool(const char*, const char*)>& peerCompare);
+
+  // Removes 'numRows' from 'data_' and 'rows_'.
+  void eraseRows(vector_size_t numRows);
+
+  void checkPartial() const {
+    VELOX_CHECK(partial_, "WindowPartition should be partial");
+  }
+
+  // Removes the previous row from 'data_'.
+  void removePreviousRow();
 
   // Searches for 'currentRow[frameColumn]' in 'orderByColumn' of rows between
   // 'start' and 'end' in the partition. 'firstMatch' specifies if first or last
@@ -162,15 +227,26 @@ class WindowPartition {
       const vector_size_t* rawPeerBounds,
       vector_size_t* rawFrameBounds) const;
 
+  // Indicates if this is a partial partition for RowStreamWindowBuild
+  // processing.
+  const bool partial_;
+
   // The RowContainer associated with the partition.
   // It is owned by the WindowBuild that creates the partition.
-  RowContainer* data_;
+  RowContainer* const data_;
+
+  // Points to the input rows for partial partition.
+  std::vector<char*> rows_;
 
   // folly::Range is for the partition rows iterator provided by the
   // Window operator. The pointers are to rows from a RowContainer owned
   // by the operator. We can assume these are valid values for the lifetime
   // of WindowPartition.
   folly::Range<char**> partition_;
+
+  // Indicates if a partial partition has received all the input rows. For a
+  // non-partial partition, this is always true.
+  bool complete_ = true;
 
   // Mapping from window input column -> index in data_. This is required
   // because the WindowBuild reorders data_ to place partition and sort keys
@@ -189,5 +265,15 @@ class WindowPartition {
   // corresponding indexes of their input arguments into this vector.
   // They will request for column vector values at the respective index.
   std::vector<exec::RowColumn> columns_;
+
+  // The partition offset of the first row in 'rows_'. It is updated for
+  // partial partition during the data processing but always zero for
+  // non-partial partition.
+  vector_size_t startRow_{0};
+
+  // Points to the last row from the previous processed peer group if not null.
+  // This is only set for a partial window partition and always null for a
+  // non-partial one.
+  char* previousRow_{nullptr};
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/PlanBuilderTest.cpp
+++ b/velox/exec/tests/PlanBuilderTest.cpp
@@ -98,7 +98,11 @@ void registerWindowFunction() {
           .returnType("BIGINT")
           .build(),
   };
-  exec::registerWindowFunction("window1", std::move(signatures), nullptr);
+  exec::registerWindowFunction(
+      "window1",
+      std::move(signatures),
+      exec::WindowFunction::Metadata::defaultMetadata(),
+      nullptr);
 }
 } // namespace
 

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -729,7 +729,11 @@ TEST_F(PlanNodeToStringTest, window) {
           .returnType("BIGINT")
           .build(),
   };
-  exec::registerWindowFunction("window1", std::move(signatures), nullptr);
+  exec::registerWindowFunction(
+      "window1",
+      std::move(signatures),
+      exec::WindowFunction::Metadata::defaultMetadata(),
+      nullptr);
 
   auto plan =
       PlanBuilder()

--- a/velox/exec/tests/WindowFunctionRegistryTest.cpp
+++ b/velox/exec/tests/WindowFunctionRegistryTest.cpp
@@ -37,7 +37,11 @@ void registerWindowFunction(const std::string& name) {
           .build(),
       exec::FunctionSignatureBuilder().returnType("date").build(),
   };
-  exec::registerWindowFunction(name, std::move(signatures), nullptr);
+  exec::registerWindowFunction(
+      name,
+      std::move(signatures),
+      exec::WindowFunction::Metadata::defaultMetadata(),
+      nullptr);
 }
 } // namespace
 

--- a/velox/exec/tests/WindowTest.cpp
+++ b/velox/exec/tests/WindowTest.cpp
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/common/base/Exceptions.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/RowsStreamingWindowBuild.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -77,6 +79,262 @@ TEST_F(WindowTest, spill) {
   ASSERT_GT(stats.spilledRows, 0);
   ASSERT_GT(stats.spilledFiles, 0);
   ASSERT_GT(stats.spilledPartitions, 0);
+}
+
+TEST_F(WindowTest, rowBasedStreamingWindowOOM) {
+  const vector_size_t size = 1'000'000;
+  auto data = makeRowVector(
+      {"d", "p", "s"},
+      {
+          // Payload.
+          makeFlatVector<int64_t>(size, [](auto row) { return row; }),
+          // Partition key.
+          makeFlatVector<int16_t>(size, [](auto row) { return row; }),
+          // Sorting key.
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+      });
+
+  createDuckDbTable({data});
+
+  // Abstract the common values vector split.
+  auto valuesSplit = split(data, 10);
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  CursorParameters params;
+  auto queryCtx = core::QueryCtx::create(executor_.get());
+  queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
+      queryCtx->queryId(),
+      8'388'608 /* 8MB */,
+      exec::MemoryReclaimer::create()));
+
+  params.queryCtx = queryCtx;
+
+  auto testWindowBuild = [&](bool useStreamingWindow) {
+    if (useStreamingWindow) {
+      params.planNode =
+          PlanBuilder(planNodeIdGenerator)
+              .values(valuesSplit)
+              .streamingWindow(
+                  {"row_number() over (partition by p order by s)"})
+              .project({"d"})
+              .singleAggregation({}, {"sum(d)"})
+              .planNode();
+
+      readCursor(params, [](Task*) {});
+    } else {
+      params.planNode =
+          PlanBuilder(planNodeIdGenerator)
+              .values(valuesSplit)
+              .window({"row_number() over (partition by p order by s)"})
+              .project({"d"})
+              .singleAggregation({}, {"sum(d)"})
+              .planNode();
+
+      VELOX_ASSERT_THROW(
+          readCursor(params, [](Task*) {}),
+          "Exceeded memory pool capacity after attempt to grow capacity through arbitration.");
+    }
+  };
+  // RowStreamingWindow will not OOM.
+  testWindowBuild(true);
+  // SortBasedWindow will OOM.
+  testWindowBuild(false);
+}
+
+TEST_F(WindowTest, rowBasedStreamingWindowMemoryUsage) {
+  auto memoryUsage = [&](bool useStreamingWindow, vector_size_t size) {
+    auto data = makeRowVector(
+        {"d", "p", "s"},
+        {
+            // Payload.
+            makeFlatVector<int64_t>(size, [](auto row) { return row; }),
+            // Partition key.
+            makeFlatVector<int16_t>(size, [](auto row) { return row % 11; }),
+            // Sorting key.
+            makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+        });
+
+    createDuckDbTable({data});
+
+    // Abstract the common values vector split.
+    auto valuesSplit = split(data, 10);
+    core::PlanNodeId windowId;
+    auto builder = PlanBuilder().values(valuesSplit);
+    if (useStreamingWindow) {
+      builder.orderBy({"p", "s"}, false)
+          .streamingWindow({"row_number() over (partition by p order by s)"});
+    } else {
+      builder.window({"row_number() over (partition by p order by s)"});
+    }
+    auto plan = builder.capturePlanNodeId(windowId).planNode();
+    auto task =
+        AssertQueryBuilder(plan, duckDbQueryRunner_)
+            .config(core::QueryConfig::kPreferredOutputBatchBytes, "1024")
+            .assertResults(
+                "SELECT *, row_number() over (partition by p order by s) FROM tmp");
+
+    return exec::toPlanStats(task->taskStats()).at(windowId).peakMemoryBytes;
+  };
+
+  const vector_size_t smallSize = 100'000;
+  const vector_size_t largeSize = 1'000'000;
+  // As the volume of data increases, the peak memory usage of the sort-based
+  // window will increase (2418624 vs 17098688). Since the peak memory usage of
+  // the RowBased Window represents the one batch data in a single partition,
+  // the peak memory usage will not increase as the volume of data grows.
+  auto sortWindowSmallUsage = memoryUsage(false, smallSize);
+  auto sortWindowLargeUsage = memoryUsage(false, largeSize);
+  ASSERT_GT(sortWindowLargeUsage, sortWindowSmallUsage);
+
+  auto rowWindowSmallUsage = memoryUsage(true, smallSize);
+  auto rowWindowLargeUsage = memoryUsage(true, largeSize);
+  ASSERT_EQ(rowWindowSmallUsage, rowWindowLargeUsage);
+}
+
+DEBUG_ONLY_TEST_F(WindowTest, rankRowStreamingWindowBuild) {
+  auto data = makeRowVector(
+      {"c1"},
+      {makeFlatVector<int64_t>(std::vector<int64_t>{1, 1, 1, 1, 1, 2, 2})});
+
+  createDuckDbTable({data});
+
+  const std::vector<std::string> kClauses = {
+      "rank() over (order by c1 rows unbounded preceding)"};
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .orderBy({"c1"}, false)
+                  .streamingWindow(kClauses)
+                  .planNode();
+
+  std::atomic_bool isStreamCreated{false};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::RowsStreamingWindowBuild::RowsStreamingWindowBuild",
+      std::function<void(RowsStreamingWindowBuild*)>(
+          [&](RowsStreamingWindowBuild* windowBuild) {
+            isStreamCreated.store(true);
+          }));
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .config(core::QueryConfig::kPreferredOutputBatchBytes, "1024")
+      .config(core::QueryConfig::kPreferredOutputBatchRows, "2")
+      .config(core::QueryConfig::kMaxOutputBatchRows, "2")
+      .assertResults(
+          "SELECT *, rank() over (order by c1 rows unbounded preceding) FROM tmp");
+
+  ASSERT_TRUE(isStreamCreated.load());
+}
+
+DEBUG_ONLY_TEST_F(WindowTest, valuesRowsStreamingWindowBuild) {
+  const vector_size_t size = 1'00;
+
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>(size, [](auto row) { return row % 5; }),
+       makeFlatVector<int32_t>(size, [](auto row) { return row % 50; }),
+       makeFlatVector<int64_t>(
+           size, [](auto row) { return row % 3 + 1; }, nullEvery(5)),
+       makeFlatVector<int32_t>(size, [](auto row) { return row % 40; }),
+       makeFlatVector<int32_t>(size, [](auto row) { return row; })});
+
+  createDuckDbTable({data});
+
+  const std::vector<std::string> kClauses = {
+      "rank() over (partition by c0, c2 order by c1, c3)",
+      "dense_rank() over (partition by c0, c2 order by c1, c3)",
+      "row_number() over (partition by c0, c2 order by c1, c3)",
+      "sum(c4) over (partition by c0, c2 order by c1, c3)"};
+
+  auto plan = PlanBuilder()
+                  .values({split(data, 10)})
+                  .orderBy({"c0", "c2", "c1", "c3"}, false)
+                  .streamingWindow(kClauses)
+                  .planNode();
+
+  std::atomic_bool isStreamCreated{false};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::RowsStreamingWindowBuild::RowsStreamingWindowBuild",
+      std::function<void(RowsStreamingWindowBuild*)>(
+          [&](RowsStreamingWindowBuild* windowBuild) {
+            isStreamCreated.store(true);
+          }));
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .config(core::QueryConfig::kPreferredOutputBatchBytes, "1024")
+      .assertResults(
+          "SELECT *, rank() over (partition by c0, c2 order by c1, c3), dense_rank() over (partition by c0, c2 order by c1, c3), row_number() over (partition by c0, c2 order by c1, c3), sum(c4) over (partition by c0, c2 order by c1, c3) FROM tmp");
+  ASSERT_TRUE(isStreamCreated.load());
+}
+
+DEBUG_ONLY_TEST_F(WindowTest, aggregationWithNonDefaultFrame) {
+  const vector_size_t size = 1'00;
+
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>(size, [](auto row) { return row % 5; }),
+       makeFlatVector<int32_t>(size, [](auto row) { return row % 50; }),
+       makeFlatVector<int64_t>(
+           size, [](auto row) { return row % 3 + 1; }, nullEvery(5)),
+       makeFlatVector<int32_t>(size, [](auto row) { return row % 40; }),
+       makeFlatVector<int32_t>(size, [](auto row) { return row; })});
+
+  createDuckDbTable({data});
+
+  const std::vector<std::string> kClauses = {
+      "sum(c4) over (partition by c0, c2 order by c1, c3 range between unbounded preceding and unbounded following)"};
+
+  auto plan = PlanBuilder()
+                  .values({split(data, 10)})
+                  .orderBy({"c0", "c2", "c1", "c3"}, false)
+                  .streamingWindow(kClauses)
+                  .planNode();
+
+  std::atomic_bool isStreamCreated{false};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::RowsStreamingWindowBuild::RowsStreamingWindowBuild",
+      std::function<void(RowsStreamingWindowBuild*)>(
+          [&](RowsStreamingWindowBuild* windowBuild) {
+            isStreamCreated.store(true);
+          }));
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .config(core::QueryConfig::kPreferredOutputBatchBytes, "1024")
+      .assertResults(
+          "SELECT *, sum(c4) over (partition by c0, c2 order by c1, c3 range between unbounded preceding and unbounded following) FROM tmp");
+
+  ASSERT_FALSE(isStreamCreated.load());
+}
+
+DEBUG_ONLY_TEST_F(WindowTest, nonRowsStreamingWindow) {
+  auto data = makeRowVector(
+      {"c1"},
+      {makeFlatVector<int64_t>(std::vector<int64_t>{1, 1, 1, 1, 1, 2, 2})});
+
+  createDuckDbTable({data});
+
+  const std::vector<std::string> kClauses = {
+      "first_value(c1) over (order by c1 rows unbounded preceding)",
+      "nth_value(c1, 1) over (order by c1 rows unbounded preceding)"};
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .orderBy({"c1"}, false)
+                  .streamingWindow(kClauses)
+                  .planNode();
+
+  std::atomic_bool isStreamCreated{false};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::RowsStreamingWindowBuild::RowsStreamingWindowBuild",
+      std::function<void(RowsStreamingWindowBuild*)>(
+          [&](RowsStreamingWindowBuild* windowBuild) {
+            isStreamCreated.store(true);
+          }));
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .config(core::QueryConfig::kPreferredOutputBatchBytes, "1024")
+      .config(core::QueryConfig::kPreferredOutputBatchRows, "2")
+      .config(core::QueryConfig::kMaxOutputBatchRows, "2")
+      .assertResults(
+          "SELECT *, first_value(c1) over (order by c1 rows unbounded preceding), nth_value(c1, 1) over (order by c1 rows unbounded preceding) FROM tmp");
+  ASSERT_FALSE(isStreamCreated.load());
 }
 
 TEST_F(WindowTest, missingFunctionSignature) {

--- a/velox/functions/lib/window/NthValue.cpp
+++ b/velox/functions/lib/window/NthValue.cpp
@@ -319,6 +319,7 @@ void registerNthValue(const std::string& name, TypeKind offsetTypeKind) {
   exec::registerWindowFunction(
       name,
       std::move(signatures),
+      exec::WindowFunction::Metadata::defaultMetadata(),
       [name](
           const std::vector<exec::WindowFunctionArg>& args,
           const TypePtr& resultType,

--- a/velox/functions/lib/window/Ntile.cpp
+++ b/velox/functions/lib/window/Ntile.cpp
@@ -241,6 +241,7 @@ void registerNtile(const std::string& name, const std::string& type) {
   exec::registerWindowFunction(
       name,
       std::move(signatures),
+      exec::WindowFunction::Metadata::defaultMetadata(),
       [name](
           const std::vector<exec::WindowFunctionArg>& args,
           const TypePtr& resultType,

--- a/velox/functions/lib/window/RowNumber.cpp
+++ b/velox/functions/lib/window/RowNumber.cpp
@@ -75,6 +75,7 @@ void registerRowNumber(const std::string& name, TypeKind resultTypeKind) {
   exec::registerWindowFunction(
       name,
       std::move(signatures),
+      {exec::WindowFunction::ProcessMode::kRows, false},
       [name](
           const std::vector<exec::WindowFunctionArg>& /*args*/,
           const TypePtr& resultType,

--- a/velox/functions/prestosql/window/CumeDist.cpp
+++ b/velox/functions/prestosql/window/CumeDist.cpp
@@ -74,6 +74,7 @@ void registerCumeDist(const std::string& name) {
   exec::registerWindowFunction(
       name,
       std::move(signatures),
+      exec::WindowFunction::Metadata::defaultMetadata(),
       [name](
           const std::vector<exec::WindowFunctionArg>& /*args*/,
           const TypePtr& /*resultType*/,

--- a/velox/functions/prestosql/window/FirstLastValue.cpp
+++ b/velox/functions/prestosql/window/FirstLastValue.cpp
@@ -175,6 +175,7 @@ void registerFirstLastInternal(const std::string& name) {
   exec::registerWindowFunction(
       name,
       std::move(signatures),
+      exec::WindowFunction::Metadata::defaultMetadata(),
       [](const std::vector<exec::WindowFunctionArg>& args,
          const TypePtr& resultType,
          bool ignoreNulls,

--- a/velox/functions/prestosql/window/LeadLag.cpp
+++ b/velox/functions/prestosql/window/LeadLag.cpp
@@ -424,6 +424,7 @@ void registerLag(const std::string& name) {
   exec::registerWindowFunction(
       name,
       signatures(),
+      exec::WindowFunction::Metadata::defaultMetadata(),
       [name](
           const std::vector<exec::WindowFunctionArg>& args,
           const TypePtr& resultType,
@@ -441,6 +442,7 @@ void registerLead(const std::string& name) {
   exec::registerWindowFunction(
       name,
       signatures(),
+      exec::WindowFunction::Metadata::defaultMetadata(),
       [name](
           const std::vector<exec::WindowFunctionArg>& args,
           const TypePtr& resultType,


### PR DESCRIPTION
Unlike `StreamingWindowBuild`, `RowLevelStreamingWindowBuild ` in this PR is capable of processing window functions as rows arrive within a single partition, without the need to wait for the entire partition to be ready. This approach can significantly reduce memory usage, especially when a single partition contains a large amount of data. It is particularly suited for optimizing `rank `and `row_number `functions, as well as aggregate window functions with a default frame.  

The detailed discussions is [here](https://github.com/facebookincubator/velox/discussions/8975). The design doc is [here](https://docs.google.com/document/d/17ONSJHK8XP5Lixm8XBl01RMNl4ntpixiVFe693ahw6k/edit?usp=sharing).