### PR TITLE
More C++: Remove virtual for destructor

### DIFF
--- a/velox/dwio/common/InputStream.h
+++ b/velox/dwio/common/InputStream.h
@@ -143,7 +143,7 @@ class ReadFileInputStream final : public InputStream {
       const MetricsLogPtr& metricsLog = MetricsLog::voidLog(),
       IoStatistics* FOLLY_NULLABLE stats = nullptr);
 
-  virtual ~ReadFileInputStream() {}
+  ~ReadFileInputStream() override = default;
 
   uint64_t getLength() const final override {
     return readFile_->size();


### PR DESCRIPTION
Summary: This is an anti pattern. We should not do

Differential Revision: D54756220


