### PR TITLE
Fix potential SIGSEGV in RowContainer cleanup after OOM

### DIFF
--- a/velox/common/memory/AllocationPool.h
+++ b/velox/common/memory/AllocationPool.h
@@ -131,9 +131,10 @@ class AllocationPool {
     return bytesInRun_ - currentOffset_;
   }
 
-  // Increses the reservation in 'pool_' when 'currentOffset_' goes past
-  // current end of last large allocation.
-  void growLastAllocation();
+  // Increases the reservation in 'pool_' if 'bytesRequested' moves
+  // 'currentOffset_' goes past current end of last large allocation, otherwise
+  // simply updates 'currentOffset_'.
+  void maybeGrowLastAllocation(uint64_t bytesRequested);
 
   void newRunImpl(memory::MachinePageCount numPages);
 


### PR DESCRIPTION
Summary:
When RowContainer is destructed it iterates over all of the rows to ensure any variable width fields and aggregates are freed 
from the HashStringAllocator.

This can result in a SIGSEGV when the RowContainer is destructed after an OOM triggered while allocating a new row.

The problem comes from a bug in AllocationPool, when it grows an existing allocation it first updates currentOffset_ and then 
grows the allocation.  When an OOM is triggered growing the allocation, that means currentOffset_ now points into 
unallocated memory (the memory we tried and failed to allocate).

When RowContainer tries to iterate over the ranges in AllocationPool to iterator over the rows, it then triggers a SIGSEGV.

The fix is to ensure AllocationPool only updates currentOffset_ once it's already allocated the memory it will point into.

Differential Revision: D54762508


