### PR TITLE
Add Cuda rountrip meter

### DIFF
--- a/velox/experimental/wave/common/Buffer.h
+++ b/velox/experimental/wave/common/Buffer.h
@@ -16,7 +16,8 @@
 
 #pragma once
 #include <boost/intrusive_ptr.hpp>
-#include "velox/common/base/Exceptions.h"
+#include <atomic>
+#include <cstdint>
 
 namespace facebook::velox::wave {
 
@@ -45,7 +46,7 @@ class Buffer {
   }
 
   void setSize(size_t newSize) {
-    VELOX_DCHECK_LE(newSize, capacity_);
+    assert(newSize <= capacity_);
     size_ = newSize;
   }
 
@@ -54,7 +55,7 @@ class Buffer {
   }
 
   bool unpin() {
-    VELOX_DCHECK_LT(0, pinCount_);
+    assert(0 < pinCount_);
     return --pinCount_ == 0;
   }
 

--- a/velox/experimental/wave/common/CudaUtil.cuh
+++ b/velox/experimental/wave/common/CudaUtil.cuh
@@ -28,7 +28,7 @@ void cudaCheck(cudaError_t err, const char* file, int line);
 #define CUDA_CHECK(e) ::facebook::velox::wave::cudaCheck(e, __FILE__, __LINE__)
 
 template <typename T, typename U>
-constexpr inline T roundUp(T value, U factor) {
+__host__ __device__ constexpr inline T roundUp(T value, U factor) {
   return (value + (factor - 1)) / factor * factor;
 }
 

--- a/velox/experimental/wave/common/GpuArena.h
+++ b/velox/experimental/wave/common/GpuArena.h
@@ -42,7 +42,7 @@ class GpuSlab {
 
   // Returns an address for at least 'bytes' of memory inside this slab, nullptr
   // if there is no contiguous run of at least 'bytes'.
-  void* FOLLY_NULLABLE allocate(uint64_t bytes);
+  void* allocate(uint64_t bytes);
 
   /// Frees an area returned by allocate().
   void free(void* address, uint64_t bytes);

--- a/velox/experimental/wave/common/tests/BlockTest.cu
+++ b/velox/experimental/wave/common/tests/BlockTest.cu
@@ -34,6 +34,7 @@ void BlockTestStream::testBoolToIndices(
     int32_t** indices,
     int32_t* sizes,
     int64_t* times) {
+  CUDA_CHECK(cudaGetLastError());
   auto tempBytes = sizeof(typename ScanAlgorithm::TempStorage);
   boolToIndices<<<numBlocks, 256, tempBytes, stream_->stream>>>(
       flags, indices, sizes, times);

--- a/velox/experimental/wave/common/tests/CudaTest.cpp
+++ b/velox/experimental/wave/common/tests/CudaTest.cpp
@@ -67,6 +67,11 @@ DEFINE_int64(
 DEFINE_string(mode, "all", "Mode for reduce test memory transfers.");
 
 DEFINE_bool(enable_bm, false, "Enable custom and long running tests");
+
+DEFINE_string(
+    roundtrip_ops,
+    "",
+    "Custom roundtrip composition, see comments in RoundtripThread");
 using namespace facebook::velox;
 using namespace facebook::velox::wave;
 
@@ -427,6 +432,333 @@ class ProcessDeviceCoalesced : public ProcessBatchBase {
   Semaphore syncSem_{0};
 };
 
+struct RoundtripStats {
+  // id of experiment.
+  int32_t id{0};
+  bool isCpu{false};
+  // Description of round trip.
+  std::string mode;
+  // Threads in experiment.
+  int32_t numThreads{0};
+  // Number of times a thread repeats the sequence given by 'mode'.
+  int64_t numOps{0};
+  // Number of additions in the ops
+  int64_t numAdds{0};
+
+  // Bytes transferred to device.
+  int64_t toDeviceBytes{0};
+
+  // Bytes copied to host.
+  int64_t toHostBytes{0};
+
+  int64_t startMicros{0};
+
+  int64_t endMicros{0};
+
+  // Wall time of experiment.
+  float micros{0};
+  void init(
+      int32_t _id,
+      bool _isCpu,
+      int32_t _numThreads,
+      std::string _mode,
+      int32_t repeats) {
+    id = _id;
+    isCpu = _isCpu;
+    numThreads = _numThreads;
+    mode = _mode;
+    numOps = repeats;
+  }
+
+  void add(RoundtripStats& other) {
+    startMicros = std::min(startMicros, other.startMicros);
+    endMicros = std::max(endMicros, other.endMicros);
+    toHostBytes += other.toHostBytes;
+    toDeviceBytes += other.toDeviceBytes;
+    numAdds += other.numAdds;
+  }
+
+  std::string toString() const {
+    return fmt::format(
+        "{}: rps={} gips={}  mode={} threads={} micros={} avgus={} toDev={} GB/s toHost={} GB/s",
+        id,
+        (numThreads * numOps) / (micros / 1000000),
+        numAdds / (micros * 1000),
+        mode,
+        numThreads,
+        micros,
+        micros / numOps,
+        toDeviceBytes / (micros * 1000),
+        toHostBytes / (micros * 1000));
+  }
+};
+
+/// Describes one thread of execution in round trip measurement. Each thread
+/// does a sequence of data transfers, kernel calls and synchronizations. The
+/// operations are described in a string of the form:
+///
+///  dnnn - Transfer nnn KB to device.
+/// hnnn - transfer nnn KB to host.
+/// annn,xxx - Increment nnn KB of ints in a kernel xxx times. Reads and writes
+/// nnn KB sequentially over up to 10K threads in 256 thread blocks rnnn,xxx -
+/// Increment nnn KB of int32 counters by a random increment fetched from a
+/// lookup table of nnn KB. This is done xxx times. Read and write sequential,
+/// read random in up to 10K lanes in blocks of 256. wnnn,xxx Same as 'a' but
+/// invokes the kernel wit a 8KB struct. Measures difference of sending a small
+/// parameter block as kernel parameter as opposed to pre-staging it on device
+/// with a small transfer. s - Synchronize the stream. e - Synchronize the
+/// stream with record event + wait event.
+class RoundtripThread {
+ public:
+  // Up to 32 MB of ints.
+  static constexpr int32_t kNumKB = 32 << 10;
+  static constexpr int32_t kNumInts = kNumKB * 256;
+
+  RoundtripThread(int32_t device, ArenaSet* arenas) : arenas_(arenas) {
+    setDevice(getDevice(device));
+    hostBuffer_ = arenas_->host->allocate<int32_t>(kNumInts);
+    deviceBuffer_ = arenas_->device->allocate<int32_t>(kNumInts);
+    lookupBuffer_ = arenas_->device->allocate<int32_t>(kNumInts);
+
+    stream_ = std::make_unique<TestStream>();
+    event_ = std::make_unique<Event>();
+    for (auto i = 0; i < kNumInts; ++i) {
+      hostBuffer_->as<int32_t>()[i] = i;
+    }
+    stream_->hostToDeviceAsync(
+        lookupBuffer_->as<int32_t>(),
+        hostBuffer_->as<int32_t>(),
+        kNumInts * sizeof(int32_t));
+    stream_->wait();
+    hostInts_ = std::make_unique<int32_t[]>(kNumInts);
+    hostLookup_ = std::make_unique<int32_t[]>(kNumInts);
+    memcpy(
+        hostLookup_.get(),
+        hostBuffer_->as<int32_t>(),
+        kNumInts * sizeof(int32_t));
+  }
+
+  enum class OpCode {
+    kToDevice,
+    kToHost,
+    kAdd,
+    kAddRandom,
+    kWideAdd,
+    kEnd,
+    kSync,
+    kSyncEvent
+  };
+
+  struct Op {
+    OpCode opCode;
+    int32_t param1{1};
+    int32_t param2{0};
+  };
+
+  void run(RoundtripStats& stats) {
+    stats.startMicros = getCurrentTimeMicro();
+    for (auto counter = 0; counter < stats.numOps; ++counter) {
+      int32_t position = 0;
+      bool done = false;
+      for (;;) {
+        auto op = nextOp(stats.mode, position);
+        switch (op.opCode) {
+          case OpCode::kEnd:
+            done = true;
+            break;
+          case OpCode::kToDevice:
+            VELOX_CHECK_LE(op.param1, kNumKB);
+            if (stats.isCpu) {
+              memcpy(
+                  hostInts_.get(),
+                  hostBuffer_->as<int32_t>(),
+                  op.param1 * 1024);
+            } else {
+              stream_->hostToDeviceAsync(
+                  deviceBuffer_->as<int32_t>(),
+                  hostBuffer_->as<int32_t>(),
+                  op.param1 * 1024);
+            }
+            stats.toDeviceBytes += op.param1 * 1024;
+            break;
+          case OpCode::kToHost:
+            VELOX_CHECK_LE(op.param1, kNumKB);
+            if (stats.isCpu) {
+              memcpy(
+                  hostBuffer_->as<int32_t>(),
+                  hostInts_.get(),
+                  op.param1 * 1024);
+            } else {
+              stream_->deviceToHostAsync(
+                  hostBuffer_->as<int32_t>(),
+                  deviceBuffer_->as<int32_t>(),
+                  op.param1 * 1024);
+            }
+            stats.toHostBytes += op.param1 * 1024;
+            break;
+          case OpCode::kAdd:
+            VELOX_CHECK_LE(op.param1, kNumKB);
+            if (stats.isCpu) {
+              addOneCpu(op.param1 * 256, op.param2);
+            } else {
+              stream_->addOne(
+                  deviceBuffer_->as<int32_t>(), op.param1 * 256, op.param2);
+            }
+            stats.numAdds += op.param1 * op.param2 * 256;
+            break;
+          case OpCode::kWideAdd:
+            VELOX_CHECK_LE(op.param1, kNumKB);
+            if (stats.isCpu) {
+              addOneCpu(op.param1 * 256, op.param2);
+            } else {
+              stream_->addOneWide(
+                  deviceBuffer_->as<int32_t>(), op.param1 * 256, op.param2);
+            }
+            stats.numAdds += op.param1 * op.param2 * 256;
+            break;
+
+          case OpCode::kAddRandom:
+            VELOX_CHECK_LE(op.param1, kNumKB);
+            if (stats.isCpu) {
+              addOneRandomCpu(op.param1 * 256, op.param2);
+            } else {
+              stream_->addOneRandom(
+                  deviceBuffer_->as<int32_t>(),
+                  lookupBuffer_->as<int32_t>(),
+                  op.param1 * 256,
+                  op.param2);
+            }
+            stats.numAdds += op.param1 * op.param2 * 256;
+            break;
+
+          case OpCode::kSync:
+            if (!stats.isCpu) {
+              stream_->wait();
+            }
+            break;
+          case OpCode::kSyncEvent:
+            if (!stats.isCpu) {
+              event_->record(*stream_);
+              event_->wait();
+            }
+            break;
+          default:
+            VELOX_FAIL("Bad test opcode {}", static_cast<int32_t>(op.opCode));
+        }
+        if (done) {
+          break;
+        }
+      }
+    }
+    stats.endMicros = getCurrentTimeMicro();
+  }
+
+  void addOneCpu(int32_t size, int32_t repeat) {
+    int32_t* ints = hostInts_.get();
+    for (auto counter = 0; counter < repeat; ++counter) {
+      for (auto i = 0; i < size; ++i) {
+        ++ints[i];
+      }
+    }
+  }
+  void addOneRandomCpu(uint32_t size, int32_t repeat) {
+    int32_t* ints = hostInts_.get();
+    int32_t* lookup = hostLookup_.get();
+    for (uint32_t counter = 0; counter < repeat; ++counter) {
+      for (auto i = 0; i < size; ++i) {
+        auto rnd = (static_cast<uint64_t>(
+                        static_cast<uint32_t>(i * (counter + 1) * 1367836089)) *
+                    size) >>
+            32;
+        ints[i] += lookup[rnd];
+      }
+    }
+  }
+
+  Op nextOp(const std::string& str, int32_t& position) {
+    Op op;
+    for (;;) {
+      if (position >= str.size()) {
+        op.opCode = OpCode::kEnd;
+        return op;
+      }
+      switch (str[position]) {
+        case ' ':
+          ++position;
+          break;
+        case 'd':
+          op.opCode = OpCode::kToDevice;
+          ++position;
+          op.param1 = parseInt(str, position, 1);
+          return op;
+        case 'h':
+          op.opCode = OpCode::kToHost;
+          ++position;
+          op.param1 = parseInt(str, position, 1);
+          return op;
+        case 'a':
+          op.opCode = OpCode::kAdd;
+          ++position;
+          op.param1 = parseInt(str, position, 1);
+          op.param2 = parseInt(str, position, 1);
+          return op;
+        case 'w':
+          op.opCode = OpCode::kWideAdd;
+          ++position;
+          op.param1 = parseInt(str, position, 1);
+          op.param2 = parseInt(str, position, 1);
+          return op;
+
+        case 'r':
+          op.opCode = OpCode::kAddRandom;
+          ++position;
+          op.param1 = parseInt(str, position, 1);
+          op.param2 = parseInt(str, position, 1);
+          return op;
+
+        case 's':
+          op.opCode = OpCode::kSync;
+          ++position;
+          return op;
+        case 'e':
+          op.opCode = OpCode::kSyncEvent;
+          ++position;
+          return op;
+        default:
+          VELOX_FAIL("No opcode {}", str[position]);
+      }
+    }
+  }
+
+  int32_t parseInt(const std::string& str, int32_t& position, int32_t deflt) {
+    int32_t result = 0;
+    if (position >= str.size()) {
+      return deflt;
+    }
+    if (str[position] == ',') {
+      ++position;
+    } else if (!isdigit(str[position])) {
+      return deflt;
+    }
+    for (;;) {
+      result = 10 * result + str[position++] - '0';
+      if (position == str.size() || !isdigit(str[position])) {
+        break;
+      }
+    }
+    return result;
+  }
+
+  ArenaSet* const arenas_;
+  WaveBufferPtr deviceBuffer_;
+  WaveBufferPtr hostBuffer_;
+  WaveBufferPtr lookupBuffer_;
+  std::unique_ptr<int32_t[]> hostLookup_;
+  std::unique_ptr<int32_t[]> hostInts_;
+  std::unique_ptr<TestStream> stream_;
+  std::unique_ptr<Event> event_;
+};
+
 class CudaTest : public testing::Test {
  protected:
   static constexpr int64_t kArenaQuantum = 512 << 20;
@@ -439,7 +771,7 @@ class CudaTest : public testing::Test {
     hostAllocator_ = getHostAllocator(device_);
   }
 
-  void setupMemory(int64_t capacity = 16UL << 30) {
+  void setupMemory(int64_t capacity = 24UL << 30) {
     static bool inited = false;
     if (!globalSyncExecutor) {
       globalSyncExecutor = std::make_unique<folly::CPUThreadPoolExecutor>(10);
@@ -733,6 +1065,58 @@ class CudaTest : public testing::Test {
     return gbs;
   }
 
+  void roundtripTest(
+      const std::string& title,
+      const std::vector<std::string>& modeValues,
+      bool isCpu,
+      int numOps = 10000) {
+    auto arenas = getArenas();
+    std::vector<RoundtripStats> allStats;
+    std::vector<int32_t> numThreadsValues = {2, 4, 8, 16, 32};
+    int32_t ordinal = 0;
+    for (auto numThreads : numThreadsValues) {
+      std::vector<RoundtripStats> runStats;
+      for (auto& mode : modeValues) {
+        std::vector<std::thread> threads;
+        std::vector<std::unique_ptr<RoundtripThread>> runs;
+        threads.reserve(numThreads);
+        runs.reserve(numThreads);
+        std::vector<RoundtripStats> threadStats;
+        threadStats.resize(numThreads);
+
+        for (int32_t i = 0; i < numThreads; ++i) {
+          threadStats[i].init(++ordinal, isCpu, numThreads, mode, numOps);
+          runs.push_back(std::make_unique<RoundtripThread>(0, arenas.get()));
+        }
+        for (int32_t i = 0; i < numThreads; ++i) {
+          threads.push_back(std::thread(
+              [i, &runs, &threadStats]() { runs[i]->run(threadStats[i]); }));
+        }
+        for (auto i = 0; i < numThreads; ++i) {
+          threads[i].join();
+          if (i == 0) {
+            allStats.push_back(threadStats[i]);
+          } else {
+            allStats.back().add(threadStats[i]);
+          }
+        }
+        allStats.back().micros =
+            allStats.back().endMicros - allStats.back().startMicros;
+      }
+    }
+    std::sort(
+        allStats.begin(),
+        allStats.end(),
+        [](const RoundtripStats& left, const RoundtripStats& right) {
+          return left.numAdds / left.micros > right.numAdds / right.micros;
+        });
+    std::cout << std::endl << title << std::endl;
+    for (auto& stats : allStats) {
+      std::cout << stats.toString() << std::endl;
+    }
+    releaseArenas(std::move(arenas));
+  }
+
   std::unique_ptr<ArenaSet> getArenas() {
     {
       std::lock_guard<std::mutex> l(mutex_);
@@ -894,6 +1278,55 @@ TEST_F(CudaTest, reduceMatrix) {
     std::cout << stats.toString() << std::endl;
   }
   waitFinish();
+}
+
+TEST_F(CudaTest, roundtripMatrix) {
+  if (!FLAGS_roundtrip_ops.empty()) {
+    std::vector<std::string> modes = {FLAGS_roundtrip_ops};
+    roundtripTest(
+        fmt::format("{} GPU, 1000 repeats", modes[0]), modes, false, 1000);
+    roundtripTest(
+        fmt::format("{} CPU, 100 repeats", modes[0]), modes, true, 100);
+    return;
+  }
+  if (!FLAGS_enable_bm) {
+    return;
+  }
+  std::vector<std::string> syncModeValues = {
+      "dahs",
+      "dahe",
+      "dsashs",
+      "deaehe",
+      "whs",
+      "d10w10h1sw10h1sw10h1s",
+      "d10a10h1sd1a10h1sd1a10h1s"};
+  roundtripTest("Sync GPU", syncModeValues, false, 10000);
+  roundtripTest("Sync CPU", syncModeValues, true, 10000);
+
+  std::vector<std::string> seqModeValues = {
+      "d10h10h10s",
+      "d100a100h100s",
+      "d1000a1000h1000s",
+      "d1000a1000,10h1000s",
+      "d1000a1000,10h1sd1a1000,5h1s",
+      "d100a100,10h1s",
+      "d1000a1000,30h1sd1a1000,30h1s",
+      "d1000a1000,150h1sd1a1000,150h1s",
+  };
+  roundtripTest("Seq GPU", seqModeValues, false, 1024);
+  roundtripTest("Seq CPU", seqModeValues, true, 64);
+
+  std::vector<std::string> randomModeValues = {
+      "d100r100,10h1s",
+      "d100r100,10r100,10h1s",
+      "d100r100,10r100,100h1s",
+      "d100r100,1000h1s",
+      "d1000r1000,10h1s",
+      "d1000r1000,100h1s",
+      "d10000r10000,10h1s",
+      "d30000r30000,50h1s"};
+  roundtripTest("Random GPU", randomModeValues, false, 512);
+  roundtripTest("Random CPU", randomModeValues, true, 16);
 }
 
 int main(int argc, char** argv) {

--- a/velox/experimental/wave/common/tests/CudaTest.cu
+++ b/velox/experimental/wave/common/tests/CudaTest.cu
@@ -19,14 +19,18 @@
 
 namespace facebook::velox::wave {
 
-__global__ void addOneKernel(int32_t* numbers, int32_t size, int32_t stride) {
+__global__ void
+addOneKernel(int32_t* numbers, int32_t size, int32_t stride, int32_t repeats) {
   auto index = blockDim.x * blockIdx.x + threadIdx.x;
-  for (; index < size; index += stride) {
-    ++numbers[index];
+  for (auto counter = 0; counter < repeats; ++counter) {
+    for (; index < size; index += stride) {
+      ++numbers[index];
+    }
+    __syncthreads();
   }
 }
 
-void TestStream::addOne(int32_t* numbers, int32_t size) {
+void TestStream::addOne(int32_t* numbers, int32_t size, int32_t repeats) {
   constexpr int32_t kWidth = 10240;
   constexpr int32_t kBlockSize = 256;
   auto numBlocks = roundUp(size, kBlockSize) / kBlockSize;
@@ -36,7 +40,75 @@ void TestStream::addOne(int32_t* numbers, int32_t size) {
     numBlocks = kWidth / kBlockSize;
   }
   addOneKernel<<<numBlocks, kBlockSize, 0, stream_->stream>>>(
-      numbers, size, stride);
+      numbers, size, stride, repeats);
+  CUDA_CHECK(cudaGetLastError());
+}
+
+__global__ void addOneWideKernel(WideParams params) {
+  auto index = blockDim.x * blockIdx.x + threadIdx.x;
+  auto numbers = params.numbers;
+  auto size = params.size;
+  auto repeat = params.repeat;
+  auto stride = params.stride;
+  for (auto counter = 0; counter < repeat; ++counter) {
+    for (; index < size; index += stride) {
+      ++numbers[index];
+    }
+  }
+}
+
+void TestStream::addOneWide(int32_t* numbers, int32_t size, int32_t repeat) {
+  constexpr int32_t kWidth = 10240;
+  constexpr int32_t kBlockSize = 256;
+  auto numBlocks = roundUp(size, kBlockSize) / kBlockSize;
+  int32_t stride = size;
+  if (numBlocks > kWidth / kBlockSize) {
+    stride = kWidth;
+    numBlocks = kWidth / kBlockSize;
+  }
+  WideParams params;
+  params.numbers = numbers;
+  params.size = size;
+  params.stride = stride;
+  params.repeat = repeat;
+  addOneWideKernel<<<numBlocks, kBlockSize, 0, stream_->stream>>>(params);
+  CUDA_CHECK(cudaGetLastError());
+}
+
+__global__ void addOneRandomKernel(
+    int32_t* numbers,
+    const int32_t* lookup,
+    uint32_t size,
+    int32_t stride,
+    int32_t repeats) {
+  auto index = blockDim.x * blockIdx.x + threadIdx.x;
+  for (uint32_t counter = 0; counter < repeats; ++counter) {
+    for (; index < size; index += stride) {
+      auto rnd = (static_cast<uint64_t>(static_cast<uint32_t>(
+                      index * (counter + 1) * 1367836089)) *
+                  size) >>
+          32;
+      numbers[index] += lookup[rnd];
+    }
+    __syncthreads();
+  }
+}
+
+void TestStream::addOneRandom(
+    int32_t* numbers,
+    const int32_t* lookup,
+    int32_t size,
+    int32_t repeats) {
+  constexpr int32_t kWidth = 10240;
+  constexpr int32_t kBlockSize = 256;
+  auto numBlocks = roundUp(size, kBlockSize) / kBlockSize;
+  int32_t stride = size;
+  if (numBlocks > kWidth / kBlockSize) {
+    stride = kWidth;
+    numBlocks = kWidth / kBlockSize;
+  }
+  addOneRandomKernel<<<numBlocks, kBlockSize, 0, stream_->stream>>>(
+      numbers, lookup, size, stride, repeats);
   CUDA_CHECK(cudaGetLastError());
 }
 

--- a/velox/experimental/wave/common/tests/CudaTest.h
+++ b/velox/experimental/wave/common/tests/CudaTest.h
@@ -22,10 +22,28 @@
 
 namespace facebook::velox::wave {
 
+struct WideParams {
+  int32_t size;
+  int32_t* numbers;
+  int32_t stride;
+  int32_t repeat;
+  char data[4000];
+  void* result;
+};
+
 class TestStream : public Stream {
  public:
-  // Queues a kernel to add 1 to numbers[0...size - 1].
-  void addOne(int32_t* numbers, int size);
+  // Queues a kernel to add 1 to numbers[0...size - 1]. The kernel repeats
+  // 'repeat' times.
+  void addOne(int32_t* numbers, int size, int32_t repeat = 1);
+
+  void addOneWide(int32_t* numbers, int32_t size, int32_t repeat = 1);
+
+  void addOneRandom(
+      int32_t* numbers,
+      const int32_t* lookup,
+      int size,
+      int32_t repeat = 1);
 };
 
 } // namespace facebook::velox::wave


### PR DESCRIPTION
Adds a test to run Cuda programs consisting of data transfers and memory operations. See comments for the language for customizing the programs. Generates a test matrix of throughputs and latencies for different numbers of threads, data sizes and operation mixes. Measures the same for both GPU and CPU.

Makes GpuArena.h free of folly so it can be included together with Cuda headres.