### PR TITLE
Fix memory leak in Spill

### DIFF
--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -131,9 +131,10 @@ class FileSpillMergeStream : public SpillMergeStream {
  public:
   static std::unique_ptr<SpillMergeStream> create(
       std::unique_ptr<SpillReadFile> spillFile) {
-    auto* spillStream = new FileSpillMergeStream(std::move(spillFile));
-    spillStream->nextBatch();
-    return std::unique_ptr<SpillMergeStream>(spillStream);
+    auto spillStream = std::unique_ptr<SpillMergeStream>(
+        new FileSpillMergeStream(std::move(spillFile)));
+    static_cast<FileSpillMergeStream*>(spillStream.get())->nextBatch();
+    return spillStream;
   }
 
   uint32_t id() const override;


### PR DESCRIPTION
Summary:
In FileSpillMergeStream::create we allocate a FileSpillMergeStream on the heap using new, we call nextBatch, then we convert 
it to a unique_ptr.

This leaves an opportunity for the raw pointer to be leaked if nextBatch fails (e.g. due to an OOM).  Constructing the
unique_ptr directly ensures the memory will be cleaned up.

Differential Revision: D54775852


