### PR TITLE
Speed up MemoryPool in debug mode

### DIFF
--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -1077,10 +1077,10 @@ void MemoryPoolImpl::recordAllocDbg(const void* addr, uint64_t size) {
   if (!needRecordDbg(true)) {
     return;
   }
-  const auto stackTrace = process::StackTrace().toString();
   std::lock_guard<std::mutex> l(debugAllocMutex_);
   debugAllocRecords_.emplace(
-      reinterpret_cast<uint64_t>(addr), AllocationRecord{size, stackTrace});
+      reinterpret_cast<uint64_t>(addr),
+      AllocationRecord{size, process::StackTrace()});
 }
 
 void MemoryPoolImpl::recordAllocDbg(const Allocation& allocation) {
@@ -1121,7 +1121,7 @@ void MemoryPoolImpl::recordFreeDbg(const void* addr, uint64_t size) {
         "{}\n",
         size,
         allocRecord.size,
-        allocRecord.callStack,
+        allocRecord.callStack.toString(),
         freeStackTrace));
   }
   debugAllocRecords_.erase(addrUint64);
@@ -1170,7 +1170,7 @@ void MemoryPoolImpl::leakCheckDbg() {
     const auto& allocationRecord = itr.second;
     oss << "======== Leaked memory allocation of " << allocationRecord.size
         << " bytes ========\n"
-        << allocationRecord.callStack;
+        << allocationRecord.callStack.toString();
   }
   VELOX_FAIL(buf.str());
 }

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -694,7 +694,7 @@ class MemoryPoolImpl : public MemoryPool {
   /// Structure to store allocation details in debug mode.
   struct AllocationRecord {
     uint64_t size;
-    std::string callStack;
+    process::StackTrace callStack;
   };
 
   std::unordered_map<uint64_t, AllocationRecord>& testingDebugAllocRecords() {

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -2415,7 +2415,6 @@ TEST(MemoryPoolTest, debugMode) {
          uint64_t size) {
         for (const auto& pair : records) {
           EXPECT_EQ(pair.second.size, size);
-          EXPECT_FALSE(pair.second.callStack.empty());
         }
       };
 


### PR DESCRIPTION
Summary:
The debug utilities in MemoryPoolImpl are super useful, but I noticed things were taking forever to run when I had it enabled.
Looking through the code, it looks like it's because we convert the StackTrace to a string when recording an allocation.  We
can instead store the StackTrace objects, which include the stack pointers, and convert them to strings as needed (only when
there's a failure or a leak).  This speeds up run times.

Differential Revision: D54777429


