### PR TITLE
Upgrade simdjson lib to 3.7.0 (from 3.2.0)

### DIFF
--- a/CMake/resolve_dependency_modules/README.md
+++ b/CMake/resolve_dependency_modules/README.md
@@ -31,7 +31,7 @@ by Velox. See details on bundling below.
 | xsimd             | 10.0.0          | Yes      |
 | re2               | 2021-04-01      | Yes      |
 | fmt               | 10.1.1          | Yes      |
-| simdjson          | 3.2.0           | Yes      |
+| simdjson          | 3.7.0           | Yes      |
 | folly             | v2024.04.01.00  | Yes      |
 | fizz              | v2024.04.01.00  | No       |
 | wangle            | v2024.04.01.00  | No       |

--- a/CMake/resolve_dependency_modules/simdjson.cmake
+++ b/CMake/resolve_dependency_modules/simdjson.cmake
@@ -13,9 +13,9 @@
 # limitations under the License.
 include_guard(GLOBAL)
 
-set(VELOX_SIMDJSON_VERSION 3.2.0)
+set(VELOX_SIMDJSON_VERSION 3.7.0)
 set(VELOX_SIMDJSON_BUILD_SHA256_CHECKSUM
-    75a684dbbe38cf72b8b3bdbdc430764813f3615899a6029931c26ddd89812da4)
+    27315c4861893b3e036c1f672b1c238ee86be6edb84c0824d1ed20dea5999777)
 set(VELOX_SIMDJSON_SOURCE_URL
     "https://github.com/simdjson/simdjson/archive/refs/tags/v${VELOX_SIMDJSON_VERSION}.tar.gz"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,7 +438,7 @@ if(${VELOX_BUILD_PYTHON_PACKAGE})
 endif()
 
 set_source(simdjson)
-resolve_dependency(simdjson 3.2.0)
+resolve_dependency(simdjson 3.7.0)
 
 # Locate or build folly.
 add_compile_definitions(FOLLY_HAVE_INT128_T=1)


### PR DESCRIPTION
Recently, we are proposing a patch to support a Spark JSON function based on simdjson lib. It requires to use json path API which is only available since 3.7.0. So we are trying to upgrade the lib.

Background:
1. See the discussion with @mbasmanova:
https://github.com/facebookincubator/velox/pull/5179#issuecomment-1988431563 (3.7.0 is enough)
2. I also note Masha's discussion with simdjson community to request supporting json path:
https://github.com/simdjson/simdjson/issues/2070