### PR TITLE
Extend join fuzzer to cover group execution mode

### DIFF
--- a/velox/core/PlanFragment.cpp
+++ b/velox/core/PlanFragment.cpp
@@ -28,4 +28,14 @@ bool PlanFragment::canSpill(const QueryConfig& queryConfig) const {
              }) != nullptr;
 }
 
+std::string executionStrategyToString(ExecutionStrategy strategy) {
+  switch (strategy) {
+    case ExecutionStrategy::kGrouped:
+      return "GROUPED";
+    case ExecutionStrategy::kUngrouped:
+      return "UNGROUPED";
+    default:
+      return fmt::format("UNKNOWN: {}", static_cast<int>(strategy));
+  }
+}
 } // namespace facebook::velox::core

--- a/velox/core/PlanFragment.h
+++ b/velox/core/PlanFragment.h
@@ -35,6 +35,8 @@ enum class ExecutionStrategy {
   kGrouped,
 };
 
+std::string executionStrategyToString(ExecutionStrategy strategy);
+
 /// Contains some information on how to execute the fragment of a plan.
 /// Used to construct Task.
 struct PlanFragment {

--- a/velox/core/tests/PlanFragmentTest.cpp
+++ b/velox/core/tests/PlanFragmentTest.cpp
@@ -322,3 +322,14 @@ TEST_F(PlanFragmentTest, hashJoin) {
         testData.expectedCanSpill);
   }
 }
+
+TEST_F(PlanFragmentTest, executionStrategyToString) {
+  ASSERT_EQ(
+      executionStrategyToString(core::ExecutionStrategy::kUngrouped),
+      "UNGROUPED");
+  ASSERT_EQ(
+      executionStrategyToString(core::ExecutionStrategy::kGrouped), "GROUPED");
+  ASSERT_EQ(
+      executionStrategyToString(static_cast<core::ExecutionStrategy>(999)),
+      "UNKNOWN: 999");
+}

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -118,7 +118,31 @@ class AssertQueryBuilder {
     return *this;
   }
 
-  // Methods to run the query and verify the results.
+  /// Methods to configure the group execution mode.
+  AssertQueryBuilder& executionStrategy(
+      core::ExecutionStrategy executionStrategy) {
+    params_.executionStrategy = executionStrategy;
+    return *this;
+  }
+
+  AssertQueryBuilder& numSplitGroups(int numSplitGroups) {
+    params_.numSplitGroups = numSplitGroups;
+    return *this;
+  }
+
+  AssertQueryBuilder& numConcurrentSplitGroups(
+      int32_t numConcurrentSplitGroups) {
+    params_.numConcurrentSplitGroups = numConcurrentSplitGroups;
+    return *this;
+  }
+
+  AssertQueryBuilder& groupedExecutionLeafNodeIds(
+      const std::unordered_set<core::PlanNodeId>& groupedExecutionLeafNodeIds) {
+    params_.groupedExecutionLeafNodeIds = groupedExecutionLeafNodeIds;
+    return *this;
+  }
+
+  /// Methods to run the query and verify the results.
 
   /// Run the query and verify results against DuckDB. Requires
   /// duckDbQueryRunner to be provided in the constructor.
@@ -158,7 +182,7 @@ class AssertQueryBuilder {
   // Used by the created task as the default driver executor.
   std::unique_ptr<folly::Executor> executor_{
       new folly::CPUThreadPoolExecutor(std::thread::hardware_concurrency())};
-  DuckDbQueryRunner* FOLLY_NULLABLE const duckDbQueryRunner_;
+  DuckDbQueryRunner* const duckDbQueryRunner_;
   CursorParameters params_;
   std::unordered_map<std::string, std::string> configs_;
   std::unordered_map<std::string, std::unordered_map<std::string, std::string>>

--- a/velox/exec/tests/utils/Cursor.h
+++ b/velox/exec/tests/utils/Cursor.h
@@ -46,15 +46,15 @@ struct CursorParameters {
 
   uint64_t bufferedBytes = 512 * 1024;
 
-  // Ungrouped (by default) or grouped (bucketed) execution.
+  /// Ungrouped (by default) or grouped (bucketed) execution.
   core::ExecutionStrategy executionStrategy{
       core::ExecutionStrategy::kUngrouped};
 
   /// Contains leaf plan nodes that need to be executed in the grouped mode.
   std::unordered_set<core::PlanNodeId> groupedExecutionLeafNodeIds;
 
-  // Number of splits groups the task will be processing. Must be 1 for
-  // ungrouped execution.
+  /// Number of splits groups the task will be processing. Must be 1 for
+  /// ungrouped execution.
   int numSplitGroups{1};
 
   /// Spilling directory, if not empty, then the task's spilling directory would


### PR DESCRIPTION
Extend join fuzzer to cover group execution mode. To do this we split the probe and 
build input by partitioning on the join keys with one partition per each group. Then we
write the split the inputs into separate files and create table scan splits from the generated
files. For each existing query plan with table scan input, we create a corresponding
grouped execution plan.
Extend AssertQueryBuilder to support group execution configuration.