### PR TITLE
[window] Optimization aggregation window by segment tree

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -354,22 +354,12 @@ class QueryConfig {
   static constexpr const char* kDriverCpuTimeSliceLimitMs =
       "driver_cpu_time_slice_limit_ms";
 
-  /// When the frame size is large than it, use segmentTree to improve window
-  /// aggregate.
-  static constexpr const char* kMinFrameSizeUseSegmentTree =
-      "min_frame_size_use_segment_tree";
-
   /// Whether enable window segment tree optimization.
   static constexpr const char* kEnableWindowSegmentTreeOpt =
       "enable_window_segment_tree_opt";
 
-  uint64_t minFrameSizeUseSegmentTree() const {
-    static constexpr uint64_t kDefault = 16;
-    return get<uint64_t>(kMinFrameSizeUseSegmentTree, kDefault);
-  }
-
   bool enableWindowSegmentTreeOpt() const {
-    return get<bool>(kEnableWindowSegmentTreeOpt, false);
+    return get<bool>(kEnableWindowSegmentTreeOpt, true);
   }
 
   uint64_t queryMaxMemoryPerNode() const {

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -363,24 +363,13 @@ class QueryConfig {
   static constexpr const char* kEnableWindowSegmentTreeOpt =
       "enable_window_segment_tree_opt";
 
-  /// Aggregate functions use segmentTree to improve window aggregate, the
-  /// format is "functionName1:orderInsensitive1,functionName2", if
-  /// orderInsensitive is not define, default values is true
-  static constexpr const char* kFunctionUseSegmentTree =
-      "function_use_segment_tree";
-
-  std::string functionUseSegmentTree() const {
-    return get<std::string>(
-        kFunctionUseSegmentTree, "min:true,max:true,sum,avg,stddev");
-  }
-
   uint64_t minFrameSizeUseSegmentTree() const {
-    static constexpr uint64_t kDefault = 0;
+    static constexpr uint64_t kDefault = 16;
     return get<uint64_t>(kMinFrameSizeUseSegmentTree, kDefault);
   }
 
   bool enableWindowSegmentTreeOpt() const {
-    return get<bool>(kEnableWindowSegmentTreeOpt, true);
+    return get<bool>(kEnableWindowSegmentTreeOpt, false);
   }
 
   uint64_t queryMaxMemoryPerNode() const {

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -354,6 +354,35 @@ class QueryConfig {
   static constexpr const char* kDriverCpuTimeSliceLimitMs =
       "driver_cpu_time_slice_limit_ms";
 
+  /// When the frame size is large than it, use segmentTree to improve window
+  /// aggregate.
+  static constexpr const char* kMinFrameSizeUseSegmentTree =
+      "min_frame_size_use_segment_tree";
+
+  /// Whether enable window segment tree optimization.
+  static constexpr const char* kEnableWindowSegmentTreeOpt =
+      "enable_window_segment_tree_opt";
+
+  /// Aggregate functions use segmentTree to improve window aggregate, the
+  /// format is "functionName1:orderInsensitive1,functionName2", if
+  /// orderInsensitive is not define, default values is true
+  static constexpr const char* kFunctionUseSegmentTree =
+      "function_use_segment_tree";
+
+  std::string functionUseSegmentTree() const {
+    return get<std::string>(
+        kFunctionUseSegmentTree, "min:true,max:true,sum,avg,stddev");
+  }
+
+  uint64_t minFrameSizeUseSegmentTree() const {
+    static constexpr uint64_t kDefault = 0;
+    return get<uint64_t>(kMinFrameSizeUseSegmentTree, kDefault);
+  }
+
+  bool enableWindowSegmentTreeOpt() const {
+    return get<bool>(kEnableWindowSegmentTreeOpt, true);
+  }
+
   uint64_t queryMaxMemoryPerNode() const {
     return toCapacity(
         get<std::string>(kQueryMaxMemoryPerNode, "0B"), CapacityUnit::BYTE);

--- a/velox/exec/AggregateWindow.cpp
+++ b/velox/exec/AggregateWindow.cpp
@@ -66,6 +66,8 @@ class AggregateWindowFunction : public exec::WindowFunction {
         resultType,
         config);
     aggregate_->setAllocator(stringAllocator_);
+    orderSensitive_ =
+        exec::getAggregateFunctionEntry(name)->metadata.orderSensitive;
 
     // Aggregate initialization.
     // Row layout is:
@@ -129,33 +131,53 @@ class AggregateWindowFunction : public exec::WindowFunction {
     }
   }
 
+  void initialize(const WindowFrame& windowFrame,
+                  vector_size_t minFrameSizeUseSegmentTree,
+                  bool enableSegmentTreeOpt) override {
+    enableSegmentTreeOpt_ = enableSegmentTreeOpt;
+    minFrameUseSegmentTree_ = minFrameSizeUseSegmentTree;
+    // Enable use segment tree when frame size >= minFrameSizeUseSegmentTree.
+    if (enableSegmentTreeOpt_ && windowFrame.start.has_value() &&
+        windowFrame.start.value().constant.has_value() &&
+        windowFrame.end.has_value() &&
+        windowFrame.end.value().constant.has_value() &&
+        windowFrame.start.value().constant.value() +
+                windowFrame.end.value().constant.value() >=
+            minFrameSizeUseSegmentTree) {
+      useSegmentTreeByConstFrame_ = true;
+    } else {
+      useSegmentTreeByConstFrame_ = false;
+    }
+  }
+
   char** allocateNodes(
       memory::AllocationPool& allocationPool,
       const vector_size_t& n) const {
-    auto* groups = (char**)allocationPool.allocateFixed(sizeof(char*) * n);
+    auto* nodes = (char**)allocationPool.allocateFixed(sizeof(char*) * n);
 
     auto alignment = aggregate_->accumulatorAlignmentSize();
     for (vector_size_t i = 0; i < n; i++) {
-      groups[i] = allocationPool.allocateFixed(singleGroupRowSize_, alignment);
+      nodes[i] = allocationPool.allocateFixed(singleGroupRowSize_, alignment);
     }
-    return groups;
+    return nodes;
   }
 
-  // Aggregate the leaf nodes for [begin, end) to targetState.
-  void extractFrame(vector_size_t begin, vector_size_t end, char* targetState) {
+  // Aggregate the leaf nodes in [begin, end) to targetNode.
+  void
+  aggregateLeafNodes(vector_size_t begin, vector_size_t end, char* targetNode) {
     rows_.setValidRange(begin, end, true);
     rows_.updateBounds(begin, end);
-
-    aggregate_->addSingleGroupRawInput(targetState, rows_, argVectors_, false);
+    aggregate_->addSingleGroupRawInput(targetNode, rows_, argVectors_, false);
     rows_.setValidRange(begin, end, false);
+    rows_.updateBounds(0, 0);
   }
 
-  // Aggregate the nodes for [begin, end) to targetState.
-  void segmentValue(
+  // Aggregate the nodes in [begin, end) to targetNode.
+  void aggregateNodes(
       vector_size_t levelIdx,
       vector_size_t begin,
       vector_size_t end,
-      char* targetState) {
+      char* targetNode) {
     if (begin == end || partition_->numRows() == 0) {
       return;
     }
@@ -163,39 +185,52 @@ class AggregateWindowFunction : public exec::WindowFunction {
     const auto count = end - begin;
     if (levelIdx == 0) {
       // Aggregate the leaf nodes.
-      extractFrame(begin, end, targetState);
+      aggregateLeafNodes(begin, end, targetNode);
     } else {
-      // Find out where the states begin.
-      auto begin_node = treeNodes_ + begin + levelsStart_[levelIdx - 1];
+      // Find out where the node begins.
+      auto beginNode = treeNodes_ + begin + levelsStart_[levelIdx - 1];
       intermediateResultVector_->resize(count);
       BaseVector::prepareForReuse(intermediateResultVector_, count);
-      // Extract the upper leaf nodes [begin, end) to intermediateResultVector_.
-      aggregate_->extractAccumulators(
-          begin_node, count, &intermediateResultVector_);
 
-      // SelectivityVector rows.
+      // Extract the upper nodes [begin, end) to intermediateResultVector_.
+      aggregate_->extractAccumulators(
+          beginNode, count, &intermediateResultVector_);
+
       if (count != selectivityForSegment_.size()) {
         selectivityForSegment_.resize(count);
       }
       selectivityForSegment_.setValidRange(0, count, true);
+      // Since we know begin and end of selectivityForSegment_ is [0, count],
+      // and we have already set it in selectivityForSegment_.resize(count)
+      // so we don't need to call updateBounds() here.
 
-      // Aggregate the upper level nodes to targetState.
+      // Aggregate the upper nodes to targetNode.
       aggregate_->addSingleGroupIntermediateResults(
-          targetState, selectivityForSegment_, {intermediateResultVector_}, false);
+          targetNode,
+          selectivityForSegment_,
+          {intermediateResultVector_},
+          false);
     }
+  }
+
+  inline vector_size_t getLevelSize(
+      vector_size_t currentLevel,
+      vector_size_t levelsOffset) {
+    return currentLevel == 0 ? partition_->numRows()
+                             : levelsOffset - levelsStart_[currentLevel - 1];
   }
 
   // Construct segment tree.
   void constructSegmentTree() {
-    vector_size_t partitionCount = partition_->numRows();
-    fillArgVectors(0, partitionCount - 1);
-    rows_.resize(partitionCount, false);
+    vector_size_t numRows = partition_->numRows();
+    fillArgVectors(0, numRows - 1);
+    rows_.resize(numRows, false);
     if (treeNodes_ != nullptr) {
       aggregate_->destroy(folly::Range(treeNodes_, treeNodeCount_));
       levelsStart_.clear();
     }
 
-    // Compute node count of segment tree.
+    // Compute node count of the segment tree.
     treeNodeCount_ = 0;
     vector_size_t levelNodes = partition_->numRows();
     do {
@@ -203,33 +238,33 @@ class AggregateWindowFunction : public exec::WindowFunction {
       treeNodeCount_ += levelNodes;
     } while (levelNodes > 1);
 
-    // Allocate treeNodeCount_ nodes for segment tree.
+    // Allocate treeNodeCount_ nodes for the segment tree.
     memory::AllocationPool allocationPool{pool_};
     treeNodes_ = allocateNodes(allocationPool, treeNodeCount_);
-
     std::vector<vector_size_t> allSelectedRange;
     for (vector_size_t i = 0; i < treeNodeCount_; i++) {
       allSelectedRange.push_back(i);
     }
     aggregate_->clear();
-    // Initialize all the nodes.
+    // Initialize all the tree nodes.
     aggregate_->initializeNewGroups(treeNodes_, allSelectedRange);
 
     // Level 0 is data itself.
     levelsStart_.push_back(0);
+
     vector_size_t levelsOffset = 0;
     vector_size_t currentLevel = 0;
     vector_size_t levelSize;
     // Iterate over the levels of the segment tree.
-    while ((levelSize =
-                (currentLevel == 0 ? partition_->numRows()
-                                   : levelsOffset -
-                         levelsStart_[currentLevel - 1])) > 1) {
+    while ((levelSize = getLevelSize(currentLevel, levelsOffset)) > 1) {
       for (vector_size_t pos = 0; pos < levelSize; pos += kTreeFanout) {
-        // Compute the aggregate for upper level node in the segment tree.
-        char* node = treeNodes_[levelsOffset];
-        segmentValue(
-            currentLevel, pos, std::min(levelSize, pos + kTreeFanout), node);
+        // Compute the aggregate for node in the segment tree.
+        char* targetNode = treeNodes_[levelsOffset];
+        aggregateNodes(
+            currentLevel,
+            pos,
+            std::min(levelSize, pos + kTreeFanout),
+            targetNode);
         levelsOffset++;
       }
 
@@ -292,10 +327,11 @@ class AggregateWindowFunction : public exec::WindowFunction {
           resultOffset,
           result);
     } else {
-
-      if (newPartition_) {
+      if (enableSegmentTreeOpt_
+          && newPartition_
+          && validRows.countSelected() > minFrameUseSegmentTree_) {
         newPartition_ = false;
-        if (useSegmentTreeBySql_) {
+        if (useSegmentTreeByConstFrame_) {
           currentPartitionUseSegmentTree_ = true;
           constructSegmentTree();
         } else {
@@ -504,60 +540,56 @@ class AggregateWindowFunction : public exec::WindowFunction {
     setEmptyFramesResult(validRows, resultOffset, emptyResult_, result);
   }
 
-  void swap(char* left, char* right) {
-    auto tmp = left;
-    left = right;
-    right = left;
-  }
-
-  // Compute the upper level nodes for leave nodes in [frameStart, frameEnd).
-  void evaluateUpperLevels(const vector_size_t& frameStart,
-                           const vector_size_t& frameEnd,
-                           const vector_size_t maxLevel,
-                           vector_size_t row_idx,
-                           char* statePtr) {
+  // Compute the upper level nodes in [frameStart, frameEnd).
+  char* evaluateUpperLevels(
+      const vector_size_t& frameStart,
+      const vector_size_t& frameEnd,
+      const vector_size_t maxLevel,
+      vector_size_t rowIdx,
+      char* statePtr) {
     auto begin = frameStart;
     auto end = frameEnd;
-    // If two record frame has a same upper level, we can reuse upper level
-    // result. For example:
-    //
-    //   level_3  0
-    //            |         \
-    //   level_2  0         1
-    //            |   \     |   \
-    //   level_1  0    1    2    3
-    //            | \  | \  | \  | \
-    //   level_0  0 1  2 3  4 5  6 7
-    //
-    // rowIdx=3, frame is [1~6), parent is [1, 3)
-    // rowIdx=4, frame is [2~7), parent is [1, 3)
-    // For rowIdx=4, the parent node is the same as rowIdx=3, we can cache the
-    // result of [1, 3) in rowIdx=3 and reuse it in rowIdx=4.
-    if (begin / kTreeFanout == prevBegin_ &&
-        end / kTreeFanout == prevEnd_) {
-      // Just return the previous top level result.
-      tempState_ = statePtr;
-      statePtr = prevState_;
-      return;
-    }
 
     vector_size_t levelIdx = 0;
-    vector_size_t right_max = 0;
+    vector_size_t rightMax = 0;
 
     for (; levelIdx < maxLevel; levelIdx++) {
-      if (orderInsensitive_ && levelIdx == 1) {
+      auto parentBegin = begin / kTreeFanout;
+      auto parentEnd = end / kTreeFanout;
+      /// If two record frame has a same upper level, we can reuse upper level
+      /// result. For example:
+      ///   level_3          0
+      ///                  /   \
+      ///                 /     \
+      ///                /       \
+      ///   level_2     0         1
+      ///              / \       / \
+      ///             /   \     /   \
+      ///   level_1   0    1    2    3
+      ///            / \  / \  / \  / \
+      ///   level_0  0 1  2 3  4 5  6 7
+      /// rowIdx=3, frame is [1~6), parent is [1, 3)
+      /// rowIdx=4, frame is [2~7), parent is [1, 3)
+      /// For rowIdx=4, the parent node is the same as rowIdx=3, we can cache the
+      /// result of [1, 3) in rowIdx=3 and reuse it in rowIdx=4.
+      if (levelIdx == 1 && parentBegin == prevBegin_ && parentEnd == prevEnd_) {
+        // Just return the previous result.
+        tempState_ = statePtr;
+        statePtr = prevState_;
+        return statePtr;
+      }
+
+      if (!orderSensitive_ && levelIdx == 1) {
         tempState_ = prevState_;
         prevState_ = statePtr;
         prevBegin_ = begin;
         prevEnd_ = end;
       }
 
-      auto parentBegin = begin / kTreeFanout;
-      auto parentEnd = end / kTreeFanout;
       if (parentBegin == parentEnd) {
         // Skip level 0, level 0 nodes compute in evaluateLeaves().
         if (levelIdx) {
-          segmentValue(levelIdx, begin, end, statePtr);
+          aggregateNodes(levelIdx, begin, end, statePtr);
         }
         break;
       }
@@ -566,7 +598,7 @@ class AggregateWindowFunction : public exec::WindowFunction {
       if (begin != groupBegin) {
         // Skip level 0, level 0 nodes compute in evaluateLeaves().
         if (levelIdx) {
-          segmentValue(levelIdx, begin, groupBegin + kTreeFanout, statePtr);
+          aggregateNodes(levelIdx, begin, groupBegin + kTreeFanout, statePtr);
         }
         parentBegin++;
       }
@@ -575,13 +607,13 @@ class AggregateWindowFunction : public exec::WindowFunction {
       if (end != groupEnd) {
         // Skip level 0, level 0 nodes compute in evaluateLeaves().
         if (levelIdx) {
-          if (orderInsensitive_) {
-            segmentValue(levelIdx, groupEnd, end, statePtr);
+          if (!orderSensitive_) {
+            aggregateNodes(levelIdx, groupEnd, end, statePtr);
           } else {
             // If order sensitive, we should compute left side before right
             // side, so here we only record the ranges in rightStack_.
             rightStack_[levelIdx] = {groupEnd, end};
-            right_max = levelIdx;
+            rightMax = levelIdx;
           }
         }
       }
@@ -591,15 +623,16 @@ class AggregateWindowFunction : public exec::WindowFunction {
 
     // For order sensitive aggregates. As we go up the tree, we can just
     // reverse scan the array and append the cached ranges.
-    for (levelIdx = right_max; levelIdx > 0; --levelIdx) {
+    for (levelIdx = rightMax; levelIdx > 0; --levelIdx) {
       auto& rightEntry = rightStack_[levelIdx];
       const auto groupEnd = rightEntry.first;
       const auto end = rightEntry.second;
       if (end) {
-        segmentValue(levelIdx, groupEnd, end, statePtr);
+        aggregateNodes(levelIdx, groupEnd, end, statePtr);
         rightEntry = {0, 0};
       }
     }
+    return statePtr;
   }
 
   // Compute the ragged leaf nodes in [begin, end), for order sensitive
@@ -608,19 +641,18 @@ class AggregateWindowFunction : public exec::WindowFunction {
   void evaluateLeaves(
       const vector_size_t& begin,
       const vector_size_t& end,
-      vector_size_t row_idx,
-      char* targetState,
+      vector_size_t rowIdx,
+      char* targetNode,
       FramePart leafPart) {
     const bool computeLeft = leafPart != FramePart::RIGHT;
     const bool computeRight = leafPart != FramePart::LEFT;
-    const bool add_curr_row = computeLeft;
 
     auto parentBegin = begin / kTreeFanout;
     auto parentEnd = end / kTreeFanout;
     if (parentBegin == parentEnd) {
       // Only compute when parentBegin == parentEnd and computeLeft.
       if (computeLeft) {
-        extractFrame(begin, end, targetState);
+        aggregateLeafNodes(begin, end, targetNode);
       }
       return;
     }
@@ -628,44 +660,35 @@ class AggregateWindowFunction : public exec::WindowFunction {
     vector_size_t groupBegin = parentBegin * kTreeFanout;
     vector_size_t groupEnd = parentEnd * kTreeFanout;
 
-    if (leafPart == FramePart::FULL && begin != groupBegin && end != groupEnd) {
-      rows_.setValidRange(begin, groupBegin + kTreeFanout, true);
-      rows_.setValidRange(groupEnd, end, true);
-      rows_.updateBounds(begin, end);
-
-      aggregate_->addSingleGroupRawInput(targetState, rows_, argVectors_, false);
-      rows_.setValidRange(begin, groupBegin + kTreeFanout, false);
-      rows_.setValidRange(groupEnd, end, false);
-      return;
-    }
-
-    // Compute ragged left side.
+    // Compute ragged left leaf nodes.
     if (begin != groupBegin && computeLeft) {
-      extractFrame(begin, groupBegin + kTreeFanout, targetState);
+      aggregateLeafNodes(begin, groupBegin + kTreeFanout, targetNode);
     }
 
-    // Compute ragged right side.
+    // Compute ragged right leaf nodes.
     if (end != groupEnd && computeRight) {
-      extractFrame(groupEnd, end, targetState);
+      aggregateLeafNodes(groupEnd, end, targetNode);
     }
   }
 
-  // Combine the sourceState to targetState.
-  void combine(char* sourceState, char* targetState, SelectivityVector& rows) {
-    aggregate_->extractAccumulators(&sourceState, 1, &intermediateResultForCombine_);
+  // Combine the sourceState to targetNode.
+  void combine(char* sourceState, char* targetNode, SelectivityVector& rows) {
+    aggregate_->extractAccumulators(
+        &sourceState, 1, &intermediateResultForCombine_);
 
-    // Aggregate the intermediateResultForCombine_ to targetState.
+    // Aggregate the intermediateResultForCombine_ to targetNode.
     aggregate_->addSingleGroupIntermediateResults(
-        targetState, rows, {intermediateResultForCombine_}, false);
+        targetNode, rows, {intermediateResultForCombine_}, false);
   }
 
-  void segmentTreeAggregation(const SelectivityVector& validRows,
-                              vector_size_t minFrame,
-                              vector_size_t maxFrame,
-                              const vector_size_t* frameStartsVector,
-                              const vector_size_t* frameEndsVector,
-                              vector_size_t resultOffset,
-                              const VectorPtr& result) {
+  void segmentTreeAggregation(
+      const SelectivityVector& validRows,
+      vector_size_t minFrame,
+      vector_size_t maxFrame,
+      const vector_size_t* frameStartsVector,
+      const vector_size_t* frameEndsVector,
+      vector_size_t resultOffset,
+      const VectorPtr& result) {
     const auto maxLevel = levelsStart_.size() + 1;
     rightStack_.resize(maxLevel, {0, 0});
     prevBegin_ = 1;
@@ -673,16 +696,16 @@ class AggregateWindowFunction : public exec::WindowFunction {
     SelectivityVector rowsForCombine;
     rowsForCombine.resizeFill(1, true);
     auto singleGroup = std::vector<vector_size_t>{0};
-    aggregate_->clear();
+    aggregate_->initializeNewGroups(&prevState_, singleGroup);
 
     validRows.applyToSelected([&](auto i) {
       aggregate_->clear();
       aggregate_->initializeNewGroups(&leftLeavesState_, singleGroup);
       aggregate_->initializeNewGroups(&upperLevelsState_, singleGroup);
 
-      if (orderInsensitive_) {
-        // Aggregate the segment tree nodes.
-        evaluateUpperLevels(
+      if (!orderSensitive_) {
+        // Aggregate the upper level nodes.
+        upperLevelsState_ = evaluateUpperLevels(
             frameStartsVector[i],
             frameEndsVector[i] + 1,
             maxLevel,
@@ -690,7 +713,7 @@ class AggregateWindowFunction : public exec::WindowFunction {
             upperLevelsState_);
 
         memcpy(leftLeavesState_, upperLevelsState_, singleGroupRowSize_);
-        // Aggregate the ragged leaves.
+        // Aggregate the ragged leaf nodes.
         evaluateLeaves(
             frameStartsVector[i],
             frameEndsVector[i] + 1,
@@ -698,7 +721,7 @@ class AggregateWindowFunction : public exec::WindowFunction {
             leftLeavesState_,
             FramePart::FULL);
       } else {
-        // Aggregate the ragged left leaves.
+        // Aggregate the ragged left leaf nodes.
         evaluateLeaves(
             frameStartsVector[i],
             frameEndsVector[i] + 1,
@@ -706,8 +729,8 @@ class AggregateWindowFunction : public exec::WindowFunction {
             leftLeavesState_,
             FramePart::LEFT);
 
-        // Aggregate the segment tree nodes.
-        evaluateUpperLevels(
+        // Aggregate the upper level nodes.
+        upperLevelsState_ = evaluateUpperLevels(
             frameStartsVector[i],
             frameEndsVector[i] + 1,
             maxLevel,
@@ -716,7 +739,7 @@ class AggregateWindowFunction : public exec::WindowFunction {
 
         combine(upperLevelsState_, leftLeavesState_, rowsForCombine);
 
-        // Aggregate the ragged right leaves.
+        // Aggregate the ragged right leaf nodes.
         evaluateLeaves(
             frameStartsVector[i],
             frameEndsVector[i] + 1,
@@ -729,8 +752,7 @@ class AggregateWindowFunction : public exec::WindowFunction {
         tempState_ = nullptr;
       }
 
-      aggregate_->extractValues(
-          &leftLeavesState_, 1, &aggregateResultVector_);
+      aggregate_->extractValues(&leftLeavesState_, 1, &aggregateResultVector_);
       result->copy(aggregateResultVector_.get(), resultOffset + i, 0, 1);
     });
 
@@ -756,49 +778,15 @@ class AggregateWindowFunction : public exec::WindowFunction {
 
   bool aggregateInitialized_{false};
 
-  // Right side nodes need to be cached and processed in reverse order.
-  using RightEntry = std::pair<vector_size_t, vector_size_t>;
+  // If the frame is constant and larger than minFrameUseSegmentTree, direct
+  // enable use segment tree, no need to compute the average frame size.
+  bool useSegmentTreeByConstFrame_{false};
 
-  // Cache of right side tree ranges for ordered aggregates
-  std::vector<RightEntry> rightStack_;
+  // Whether turn on the optimization of segment tree.
+  bool enableSegmentTreeOpt_{false};
 
-  // The actual window segment tree, an array of aggregate states that
-  // represent all the intermediate nodes.
-  char** treeNodes_;
-
-  // The total number of internal nodes of the segment tree.
-  vector_size_t treeNodeCount_{0};
-
-  // For each level, the starting location in the treeNodes_ array.
-  std::vector<vector_size_t> levelsStart_;
-
-  // kTreeFanout needs to cleanly divide STANDARD_VECTOR_SIZE
-  static constexpr vector_size_t kTreeFanout = 16;
-
-  // TypePtr intermediateType_.
-  VectorPtr intermediateResultVector_;
-  VectorPtr intermediateResultForCombine_;
-
-  BufferPtr leftBufferPtr_;
-  BufferPtr upperBufferPtr_;
-  BufferPtr prevBufferPtr;
-
-  // State for ragged left leaves.
-  char* leftLeavesState_;
-
-  // State for upper segment tree nodes.
-  char* upperLevelsState_;
-
-  // State for ragged pre upper segment tree nodes.
-  char* prevState_;
-  char* tempState_;
-  vector_size_t prevBegin_{1};
-  vector_size_t prevEnd_{0};
-  bool currentPartitionUseSegmentTree_{false};
-  bool newPartition_{false};
-
-  SelectivityVector rows_;
-  SelectivityVector selectivityForSegment_;
+  // The min average frame size can use segment tree.
+  int32_t minFrameUseSegmentTree_;
 
   // Current WindowPartition used for accessing rows in the apply method.
   const exec::WindowPartition* partition_;
@@ -830,6 +818,79 @@ class AggregateWindowFunction : public exec::WindowFunction {
   // return the default value of an aggregate (aggregation with no rows) for
   // empty frames. e.g. count for empty frames should return 0 and not null.
   VectorPtr emptyResult_;
+
+  // Right side nodes need to be cached and processed in reverse order.
+  // The first value in pair is groupEnd, the second is end：
+  // level n + 1    0   1   2
+  //               / \ / \ / \
+  // level n       1 2 3 4 5 6
+  // [frameStart, frameEnd) = [1,6), The ragged right node is
+  // [groupEnd, end) = [5, 6)
+  using RightEntry = std::pair<vector_size_t, vector_size_t>;
+
+  // Cache of right side tree ranges for ordered aggregates.
+  std::vector<RightEntry> rightStack_;
+
+  // The actual window segment tree, an array of aggregate states that
+  // represent all the intermediate nodes.
+  char** treeNodes_;
+
+  // The total number of internal nodes of the segment tree.
+  vector_size_t treeNodeCount_{0};
+
+  // For each level, the starting location in the treeNodes_ array.
+  std::vector<vector_size_t> levelsStart_;
+
+  // Fanout of the segment tree.
+  static constexpr vector_size_t kTreeFanout = 16;
+
+  // Intermediate result for construct the segment tree.
+  VectorPtr intermediateResultVector_;
+
+  // Intermediate result for combine aggregate result.
+  VectorPtr intermediateResultForCombine_;
+
+  // Left BufferPtr use for ragged left leaves.
+  BufferPtr leftBufferPtr_;
+
+  // Upper BufferPtr use for upper segment tree nodes.
+  BufferPtr upperBufferPtr_;
+
+  // BufferPtr use for prev upper segment tree nodes.
+  BufferPtr prevBufferPtr;
+
+  // State for ragged left leaves.
+  char* leftLeavesState_;
+
+  // State for upper segment tree nodes.
+  char* upperLevelsState_;
+
+  // State for prev upper segment tree nodes.
+  char* prevState_;
+
+  // Temp state.
+  char* tempState_;
+
+  // Prev begin upper node.
+  vector_size_t prevBegin_{1};
+
+  // Prev end upper node.
+  vector_size_t prevEnd_{0};
+
+  // Current partition should use segment tree for aggregate.
+  bool currentPartitionUseSegmentTree_{false};
+
+  // Whether the first time aggregate current partition.
+  bool newPartition_{false};
+
+  // Whether the aggregate function is order sensitive.
+  bool orderSensitive_;
+
+  // SelectivityVector for the partition.
+  SelectivityVector rows_;
+
+  // SelectivityVector for the upper nodes in segment three.
+  SelectivityVector selectivityForSegment_;
 };
 
 } // namespace

--- a/velox/exec/AggregateWindow.h
+++ b/velox/exec/AggregateWindow.h
@@ -20,6 +20,6 @@ namespace facebook::velox::exec {
 
 void registerAggregateWindowFunction(const std::string& name);
 
-enum FramePart : uint8_t { FULL = 0, LEFT = 1, RIGHT = 2 };
+enum class FramePart : uint8_t { FULL = 0, LEFT = 1, RIGHT = 2 };
 
 } // namespace facebook::velox::exec

--- a/velox/exec/AggregateWindow.h
+++ b/velox/exec/AggregateWindow.h
@@ -20,6 +20,4 @@ namespace facebook::velox::exec {
 
 void registerAggregateWindowFunction(const std::string& name);
 
-enum class FramePart : uint8_t { FULL = 0, LEFT = 1, RIGHT = 2 };
-
 } // namespace facebook::velox::exec

--- a/velox/exec/AggregateWindow.h
+++ b/velox/exec/AggregateWindow.h
@@ -20,4 +20,6 @@ namespace facebook::velox::exec {
 
 void registerAggregateWindowFunction(const std::string& name);
 
+enum FramePart : uint8_t { FULL = 0, LEFT = 1, RIGHT = 2 };
+
 } // namespace facebook::velox::exec

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -64,6 +64,7 @@ add_library(
   ProbeOperatorState.cpp
   RowContainer.cpp
   RowNumber.cpp
+  SegmentTreeAggregate.cpp
   SortBuffer.cpp
   SortedAggregations.cpp
   SortWindowBuild.cpp

--- a/velox/exec/SegmentTreeAggregate.cpp
+++ b/velox/exec/SegmentTreeAggregate.cpp
@@ -1,0 +1,411 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/SegmentTreeAggregate.h"
+
+namespace facebook::velox::exec {
+
+SegmentTreeAggregate::SegmentTreeAggregate(
+    const std::string& name,
+    const std::vector<TypePtr>& argTypes,
+    const vector_size_t singleGroupRowSize,
+    const std::vector<VectorPtr>& argVectors,
+    VectorPtr aggregateResultVector,
+    velox::memory::MemoryPool* pool)
+    : singleGroupRowSize_(singleGroupRowSize),
+      pool_(pool),
+      argVectors_(argVectors),
+      aggregateResultVector_(aggregateResultVector) {
+  orderSensitive_ =
+      exec::getAggregateFunctionEntry(name)->metadata.orderSensitive;
+
+  leftBufferPtr_ = AlignedBuffer::allocate<char>(singleGroupRowSize_, pool_);
+  leftLeavesState_ = leftBufferPtr_->asMutable<char>();
+  upperBufferPtr_ = AlignedBuffer::allocate<char>(singleGroupRowSize_, pool_);
+  upperLevelsState_ = upperBufferPtr_->asMutable<char>();
+  prevBufferPtr = AlignedBuffer::allocate<char>(singleGroupRowSize_, pool_);
+  prevState_ = prevBufferPtr->asMutable<char>();
+
+  intermediateResultVector_ = BaseVector::create(
+      exec::Aggregate::intermediateType(name, argTypes), kTreeFanout, pool_);
+  intermediateResultForCombine_ = BaseVector::create(
+      exec::Aggregate::intermediateType(name, argTypes), 1, pool_);
+}
+
+void SegmentTreeAggregate::destroy(
+    const std::unique_ptr<exec::Aggregate>& aggregate) {
+  if (treeNodes_ != nullptr) {
+    std::vector<char*> needDestroy = {
+        leftLeavesState_, upperLevelsState_, prevState_};
+    aggregate->destroy(folly::Range(needDestroy.data(), needDestroy.size()));
+    aggregate->destroy(folly::Range(treeNodes_, treeNodeCount_));
+  }
+}
+
+char** SegmentTreeAggregate::allocateNodes(
+    const std::unique_ptr<exec::Aggregate>& aggregate,
+    memory::AllocationPool& allocationPool,
+    const vector_size_t& n) {
+  auto* nodes = (char**)allocationPool.allocateFixed(sizeof(char*) * n);
+
+  auto alignment = aggregate->accumulatorAlignmentSize();
+  for (vector_size_t i = 0; i < n; i++) {
+    nodes[i] = allocationPool.allocateFixed(singleGroupRowSize_, alignment);
+  }
+  return nodes;
+}
+
+// Aggregate the leaf nodes in [begin, end) to targetNode.
+void SegmentTreeAggregate::aggregateLeafNodes(
+    const std::unique_ptr<exec::Aggregate>& aggregate,
+    vector_size_t begin,
+    vector_size_t end,
+    char* targetNode) {
+  rows_.setValidRange(begin, end, true);
+  rows_.updateBounds(begin, end);
+  aggregate->addSingleGroupRawInput(targetNode, rows_, argVectors_, false);
+  rows_.setValidRange(begin, end, false);
+  rows_.updateBounds(0, 0);
+}
+
+// Aggregate the nodes in [begin, end) to targetNode.
+void SegmentTreeAggregate::aggregateNodes(
+    const std::unique_ptr<exec::Aggregate>& aggregate,
+    vector_size_t levelIdx,
+    vector_size_t begin,
+    vector_size_t end,
+    char* targetNode) {
+  if (begin == end) {
+    return;
+  }
+
+  const auto count = end - begin;
+  if (levelIdx == 0) {
+    // Aggregate the leaf nodes.
+    aggregateLeafNodes(aggregate, begin, end, targetNode);
+  } else {
+    // Find out where the node begins.
+    auto beginNode = treeNodes_ + begin + levelsStart_[levelIdx - 1];
+    intermediateResultVector_->resize(count);
+    BaseVector::prepareForReuse(intermediateResultVector_, count);
+
+    // Extract the upper nodes [begin, end) to intermediateResultVector_.
+    aggregate->extractAccumulators(
+        beginNode, count, &intermediateResultVector_);
+
+    if (count != selectivityForSegment_.size()) {
+      selectivityForSegment_.resize(count);
+    }
+    selectivityForSegment_.setValidRange(0, count, true);
+    // Since we know begin and end of selectivityForSegment_ is [0, count],
+    // and we have already set it in selectivityForSegment_.resize(count)
+    // so we don't need to call updateBounds() here.
+
+    // Aggregate the upper level nodes to targetNode.
+    aggregate->addSingleGroupIntermediateResults(
+        targetNode, selectivityForSegment_, {intermediateResultVector_}, false);
+  }
+}
+
+// Construct segment tree.
+void SegmentTreeAggregate::constructSegmentTree(
+    const std::unique_ptr<exec::Aggregate>& aggregate,
+    const exec::WindowPartition* partition) {
+  vector_size_t numRows = partition->numRows();
+  if (numRows == 0) {
+    return;
+  }
+  rows_.resize(numRows, false);
+  if (treeNodes_ != nullptr) {
+    aggregate->destroy(folly::Range(treeNodes_, treeNodeCount_));
+    levelsStart_.clear();
+  }
+
+  // Compute node count of the segment tree.
+  treeNodeCount_ = 0;
+  vector_size_t levelNodes = partition->numRows();
+  do {
+    levelNodes = (levelNodes + (kTreeFanout - 1)) / kTreeFanout;
+    treeNodeCount_ += levelNodes;
+  } while (levelNodes > 1);
+
+  // Allocate treeNodeCount_ nodes for the segment tree.
+  memory::AllocationPool allocationPool{pool_};
+  treeNodes_ = allocateNodes(aggregate, allocationPool, treeNodeCount_);
+  std::vector<vector_size_t> allSelectedRange;
+  for (vector_size_t i = 0; i < treeNodeCount_; i++) {
+    allSelectedRange.push_back(i);
+  }
+  aggregate->clear();
+  // Initialize all the tree nodes.
+  aggregate->initializeNewGroups(treeNodes_, allSelectedRange);
+
+  // Level 0 is data itself.
+  levelsStart_.push_back(0);
+
+  vector_size_t levelsOffset = 0;
+  vector_size_t currentLevel = 0;
+  vector_size_t levelSize;
+  // Iterate over the levels of the segment tree.
+  while ((levelSize = getLevelSize(
+              partition->numRows(), currentLevel, levelsOffset)) > 1) {
+    for (vector_size_t pos = 0; pos < levelSize; pos += kTreeFanout) {
+      // Compute the aggregate for node in the segment tree.
+      char* targetNode = treeNodes_[levelsOffset];
+      aggregateNodes(
+          aggregate,
+          currentLevel,
+          pos,
+          std::min(levelSize, pos + kTreeFanout),
+          targetNode);
+      levelsOffset++;
+    }
+
+    levelsStart_.push_back(levelsOffset);
+    currentLevel++;
+  }
+}
+
+void SegmentTreeAggregate::segmentTreeAggregation(
+    const std::unique_ptr<exec::Aggregate>& aggregate,
+    const SelectivityVector& validRows,
+    const vector_size_t minFrame,
+    const vector_size_t maxFrame,
+    const vector_size_t* frameStartsVector,
+    const vector_size_t* frameEndsVector,
+    const vector_size_t resultOffset,
+    const VectorPtr& result) {
+  const auto maxLevel = levelsStart_.size() + 1;
+  rightStack_.resize(maxLevel, {0, 0});
+  prevBegin_ = 1;
+  prevEnd_ = 0;
+  SelectivityVector rowsForCombine;
+  rowsForCombine.resizeFill(1, true);
+  auto singleGroup = std::vector<vector_size_t>{0};
+  aggregate->initializeNewGroups(&prevState_, singleGroup);
+
+  validRows.applyToSelected([&](auto i) {
+    aggregate->clear();
+    aggregate->initializeNewGroups(&leftLeavesState_, singleGroup);
+    aggregate->initializeNewGroups(&upperLevelsState_, singleGroup);
+
+    if (!orderSensitive_) {
+      // Aggregate the upper level nodes.
+      upperLevelsState_ = evaluateUpperLevels(
+          aggregate,
+          frameStartsVector[i],
+          frameEndsVector[i] + 1,
+          maxLevel,
+          i,
+          upperLevelsState_);
+
+      memcpy(leftLeavesState_, upperLevelsState_, singleGroupRowSize_);
+      // Aggregate the ragged leaf nodes.
+      evaluateLeaves(
+          aggregate,
+          frameStartsVector[i],
+          frameEndsVector[i] + 1,
+          i,
+          leftLeavesState_,
+          FramePart::FULL);
+    } else {
+      // Aggregate the ragged left leaf nodes.
+      evaluateLeaves(
+          aggregate,
+          frameStartsVector[i],
+          frameEndsVector[i] + 1,
+          i,
+          leftLeavesState_,
+          FramePart::LEFT);
+
+      // Aggregate the upper level nodes.
+      upperLevelsState_ = evaluateUpperLevels(
+          aggregate,
+          frameStartsVector[i],
+          frameEndsVector[i] + 1,
+          maxLevel,
+          i,
+          upperLevelsState_);
+
+      combine(aggregate, upperLevelsState_, leftLeavesState_, rowsForCombine);
+
+      // Aggregate the ragged right leaf nodes.
+      evaluateLeaves(
+          aggregate,
+          frameStartsVector[i],
+          frameEndsVector[i] + 1,
+          i,
+          leftLeavesState_,
+          FramePart::RIGHT);
+    }
+    if (upperLevelsState_ == prevState_) {
+      upperLevelsState_ = tempState_;
+      tempState_ = nullptr;
+    }
+
+    aggregate->extractValues(&leftLeavesState_, 1, &aggregateResultVector_);
+    result->copy(aggregateResultVector_.get(), resultOffset + i, 0, 1);
+  });
+}
+
+// Compute the upper level nodes in [frameStart, frameEnd).
+char* SegmentTreeAggregate::evaluateUpperLevels(
+    const std::unique_ptr<exec::Aggregate>& aggregate,
+    const vector_size_t& frameStart,
+    const vector_size_t& frameEnd,
+    const vector_size_t maxLevel,
+    vector_size_t rowIdx,
+    char* statePtr) {
+  auto begin = frameStart;
+  auto end = frameEnd;
+
+  vector_size_t levelIdx = 0;
+  vector_size_t rightMax = 0;
+
+  for (; levelIdx < maxLevel; levelIdx++) {
+    auto parentBegin = begin / kTreeFanout;
+    auto parentEnd = end / kTreeFanout;
+    /// If two record frame has a same upper level, we can reuse upper level
+    /// result. For example:
+    ///   level_3          0
+    ///                  /   \
+      ///                 /     \
+      ///                /       \
+      ///   level_2     0         1
+    ///              / \       / \
+      ///             /   \     /   \
+      ///   level_1   0    1    2    3
+    ///            / \  / \  / \  / \
+      ///   level_0  0 1  2 3  4 5  6 7
+    /// rowIdx=3, frame is [1~6), parent is [1, 3)
+    /// rowIdx=4, frame is [2~7), parent is [1, 3)
+    /// For rowIdx=4, the parent node is the same as rowIdx=3, we can cache the result of [1, 3) in rowIdx=3 and reuse it in rowIdx=4.
+    if (levelIdx == 1 && parentBegin == prevBegin_ && parentEnd == prevEnd_) {
+      // Just return the previous result.
+      tempState_ = statePtr;
+      statePtr = prevState_;
+      return statePtr;
+    }
+
+    if (!orderSensitive_ && levelIdx == 1) {
+      tempState_ = prevState_;
+      prevState_ = statePtr;
+      prevBegin_ = begin;
+      prevEnd_ = end;
+    }
+
+    if (parentBegin == parentEnd) {
+      // Skip level 0, level 0 nodes compute in evaluateLeaves().
+      if (levelIdx) {
+        aggregateNodes(aggregate, levelIdx, begin, end, statePtr);
+      }
+      break;
+    }
+
+    vector_size_t groupBegin = parentBegin * kTreeFanout;
+    if (begin != groupBegin) {
+      // Skip level 0, level 0 nodes compute in evaluateLeaves().
+      if (levelIdx) {
+        aggregateNodes(
+            aggregate, levelIdx, begin, groupBegin + kTreeFanout, statePtr);
+      }
+      parentBegin++;
+    }
+
+    vector_size_t groupEnd = parentEnd * kTreeFanout;
+    if (end != groupEnd) {
+      // Skip level 0, level 0 nodes compute in evaluateLeaves().
+      if (levelIdx) {
+        if (!orderSensitive_) {
+          aggregateNodes(aggregate, levelIdx, groupEnd, end, statePtr);
+        } else {
+          // If order sensitive, we should compute left side before right
+          // side, so here we only record the ranges in rightStack_.
+          rightStack_[levelIdx] = {groupEnd, end};
+          rightMax = levelIdx;
+        }
+      }
+    }
+    begin = parentBegin;
+    end = parentEnd;
+  }
+
+  // For order sensitive aggregates. As we go up the tree, we can just
+  // reverse scan the array and append the cached ranges.
+  for (levelIdx = rightMax; levelIdx > 0; --levelIdx) {
+    auto& rightEntry = rightStack_[levelIdx];
+    const auto groupEnd = rightEntry.first;
+    const auto end = rightEntry.second;
+    if (end) {
+      aggregateNodes(aggregate, levelIdx, groupEnd, end, statePtr);
+      rightEntry = {0, 0};
+    }
+  }
+  return statePtr;
+}
+
+// Compute the ragged leaf nodes in [begin, end), for order sensitive
+// aggregates, we should firstly compute the ragged left side, the upper
+// level nodes, finally compute the ragged right side.
+void SegmentTreeAggregate::evaluateLeaves(
+    const std::unique_ptr<exec::Aggregate>& aggregate,
+    const vector_size_t& begin,
+    const vector_size_t& end,
+    vector_size_t rowIdx,
+    char* targetNode,
+    FramePart leafPart) {
+  const bool computeLeft = leafPart != FramePart::RIGHT;
+  const bool computeRight = leafPart != FramePart::LEFT;
+
+  auto parentBegin = begin / kTreeFanout;
+  auto parentEnd = end / kTreeFanout;
+  if (parentBegin == parentEnd) {
+    // Only compute when parentBegin == parentEnd and computeLeft.
+    if (computeLeft) {
+      aggregateLeafNodes(aggregate, begin, end, targetNode);
+    }
+    return;
+  }
+
+  vector_size_t groupBegin = parentBegin * kTreeFanout;
+  vector_size_t groupEnd = parentEnd * kTreeFanout;
+
+  // Compute ragged left leaf nodes.
+  if (begin != groupBegin && computeLeft) {
+    aggregateLeafNodes(aggregate, begin, groupBegin + kTreeFanout, targetNode);
+  }
+
+  // Compute ragged right leaf nodes.
+  if (end != groupEnd && computeRight) {
+    aggregateLeafNodes(aggregate, groupEnd, end, targetNode);
+  }
+}
+
+// Combine the sourceState to targetNode.
+void SegmentTreeAggregate::combine(
+    const std::unique_ptr<exec::Aggregate>& aggregate,
+    char* sourceState,
+    char* targetNode,
+    SelectivityVector& rows) {
+  aggregate->extractAccumulators(
+      &sourceState, 1, &intermediateResultForCombine_);
+
+  // Aggregate the intermediateResultForCombine_ to targetNode.
+  aggregate->addSingleGroupIntermediateResults(
+      targetNode, rows, {intermediateResultForCombine_}, false);
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/SegmentTreeAggregate.h
+++ b/velox/exec/SegmentTreeAggregate.h
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/WindowFunction.h"
+
+namespace facebook::velox::exec {
+
+/// When the window frame size is relatively large, simple aggregation will have
+/// a large number of repeated calculations. The optimization idea based on
+/// segment trees to reduce the repeated calculation of aggregate functions and
+/// reduce the time complexity of calculating a record from O(n) to O(log n)
+/// when the window frame size changes arbitrarily.
+class SegmentTreeAggregate {
+ public:
+  enum class FramePart : uint8_t { FULL = 0, LEFT = 1, RIGHT = 2 };
+
+  SegmentTreeAggregate(
+      const std::string& name,
+      const std::vector<TypePtr>& argTypes,
+      const vector_size_t singleGroupRowSize,
+      const std::vector<VectorPtr>& argVectors,
+      VectorPtr aggregateResultVector,
+      velox::memory::MemoryPool* pool);
+
+  /// Destroy any storage for the accumulator in the group row.
+  void destroy(const std::unique_ptr<exec::Aggregate>& aggregate);
+
+  /// Allocate n nodes, each size is singleGroupRowSize_.
+  char** allocateNodes(
+      const std::unique_ptr<exec::Aggregate>& aggregate,
+      memory::AllocationPool& allocationPool,
+      const vector_size_t& n);
+
+  /// Get level size in the segmentTree.
+  inline vector_size_t getLevelSize(
+      vector_size_t partitionCount,
+      vector_size_t currentLevel,
+      vector_size_t levelsOffset) {
+    return currentLevel == 0 ? partitionCount
+                             : levelsOffset - levelsStart_[currentLevel - 1];
+  }
+
+  /// Aggregate the leaf nodes in segmentTree [begin, end) to targetNode.
+  void aggregateLeafNodes(
+      const std::unique_ptr<exec::Aggregate>& aggregate,
+      vector_size_t begin,
+      vector_size_t end,
+      char* targetNode);
+
+  /// Aggregate the nodes in segmentTree [begin, end) to targetNode. It can be
+  /// leaf nodes or upper level nodes in the segmentTree.
+  void aggregateNodes(
+      const std::unique_ptr<exec::Aggregate>& aggregate,
+      vector_size_t levelIdx,
+      vector_size_t begin,
+      vector_size_t end,
+      char* targetNode);
+
+  /// Construct a segmentTree. Compute node count, allocate nodes and
+  /// initialize, Then iterate over the levels of the segment tree, for each
+  /// upper level nodes, fill it with aggregate intermediate result.
+  void constructSegmentTree(
+      const std::unique_ptr<exec::Aggregate>& aggregate,
+      const exec::WindowPartition* partition);
+
+  /// For each row, aggregate the frameStart to frameEnd by the intermediate
+  /// result in the segmentTree.
+  void segmentTreeAggregation(
+      const std::unique_ptr<exec::Aggregate>& aggregate,
+      const SelectivityVector& validRows,
+      vector_size_t minFrame,
+      vector_size_t maxFrame,
+      const vector_size_t* frameStartsVector,
+      const vector_size_t* frameEndsVector,
+      vector_size_t resultOffset,
+      const VectorPtr& result);
+
+  /// Aggregate the leaf nodes in segmentTree [begin, end) to targetNode.
+  void evaluateLeaves(
+      const std::unique_ptr<exec::Aggregate>& aggregate,
+      const vector_size_t& begin,
+      const vector_size_t& end,
+      vector_size_t rowIdx,
+      char* targetNode,
+      FramePart leafPart);
+
+  /// Aggregate the upper level nodes in segmentTree [begin, end) to targetNode.
+  char* evaluateUpperLevels(
+      const std::unique_ptr<exec::Aggregate>& aggregate,
+      const vector_size_t& frameStart,
+      const vector_size_t& frameEnd,
+      const vector_size_t maxLevel,
+      vector_size_t rowIdx,
+      char* statePtr);
+
+  /// Combine the intermediate source state into targetNode.
+  void combine(
+      const std::unique_ptr<exec::Aggregate>& aggregate,
+      char* sourceState,
+      char* targetNode,
+      SelectivityVector& rows);
+
+ private:
+  memory::MemoryPool* pool_;
+
+  // ConstantVector value from the Window operator is saved in argVectors_
+  std::vector<VectorPtr> argVectors_;
+
+  // This is a single aggregate row needed by the aggregate function for its
+  // computation. These values are for the row and its various components.
+  vector_size_t singleGroupRowSize_;
+
+  // This vector is used to copy from the aggregate to the result.
+  VectorPtr aggregateResultVector_;
+
+  // Right side nodes need to be cached and processed in reverse order.
+  // The first value in pair is groupEnd, the second is end：
+  // level n + 1    0   1   2
+  //               / \ / \ / \
+  // level n       1 2 3 4 5 6
+  // [frameStart, frameEnd) = [1,6), The ragged right node is
+  // [groupEnd, end) = [5, 6)
+  using RightEntry = std::pair<vector_size_t, vector_size_t>;
+
+  // Cache of right side tree ranges for ordered aggregates.
+  std::vector<RightEntry> rightStack_;
+
+  // The actual window segment tree, an array of aggregate states that
+  // represent all the intermediate nodes.
+  char** treeNodes_;
+
+  // The total number of internal nodes of the segment tree.
+  vector_size_t treeNodeCount_{0};
+
+  // For each level, the starting location in the treeNodes_ array.
+  std::vector<vector_size_t> levelsStart_;
+
+  // Fanout of the segment tree.
+  static constexpr vector_size_t kTreeFanout = 16;
+
+  // Intermediate result for construct the segment tree.
+  VectorPtr intermediateResultVector_;
+
+  // Intermediate result for combine aggregate result.
+  VectorPtr intermediateResultForCombine_;
+
+  // Left BufferPtr use for ragged left leaves.
+  BufferPtr leftBufferPtr_;
+
+  // Upper BufferPtr use for upper segment tree nodes.
+  BufferPtr upperBufferPtr_;
+
+  // BufferPtr use for prev upper segment tree nodes.
+  BufferPtr prevBufferPtr;
+
+  // State for ragged left leaves.
+  char* leftLeavesState_;
+
+  // State for upper segment tree nodes.
+  char* upperLevelsState_;
+
+  // State for prev upper segment tree nodes.
+  char* prevState_;
+
+  // Temp state.
+  char* tempState_;
+
+  // Prev begin upper node.
+  vector_size_t prevBegin_{1};
+
+  // Prev end upper node.
+  vector_size_t prevEnd_{0};
+
+  // Whether the aggregate function is order sensitive.
+  bool orderSensitive_;
+
+  // SelectivityVector for the partition.
+  SelectivityVector rows_;
+
+  // SelectivityVector for the upper nodes in segment three.
+  SelectivityVector selectivityForSegment_;
+};
+
+} // namespace facebook::velox::exec
+
+

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -37,8 +37,6 @@ Window::Window(
       numInputColumns_(windowNode->inputType()->size()),
       windowNode_(windowNode),
       currentPartition_(nullptr),
-      minFrameSizeUseSegmentTree_(
-          driverCtx->queryConfig().minFrameSizeUseSegmentTree()),
       enableSegmentTreeOpt_(
           driverCtx->queryConfig().enableWindowSegmentTreeOpt()),
       stringAllocator_(pool()) {
@@ -190,7 +188,6 @@ void Window::createWindowFunctions() {
         createWindowFrame(windowNode_, windowNodeFunction.frame, inputType));
 
     windowFunctions_.back()->initialize(windowFrames_.back(),
-                                       minFrameSizeUseSegmentTree_,
                                        enableSegmentTreeOpt_);
   }
 }

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -37,6 +37,8 @@ Window::Window(
       numInputColumns_(windowNode->inputType()->size()),
       windowNode_(windowNode),
       currentPartition_(nullptr),
+      minFrameSizeUseSegmentTree_(driverCtx->queryConfig().minFrameSizeUseSegmentTree()),
+      enableSegmentTreeOpt_(driverCtx->queryConfig().enableWindowSegmentTreeOpt()),
       stringAllocator_(pool()) {
   auto* spillConfig =
       spillConfig_.has_value() ? &spillConfig_.value() : nullptr;
@@ -47,6 +49,8 @@ Window::Window(
     windowBuild_ = std::make_unique<SortWindowBuild>(
         windowNode, pool(), spillConfig, &nonReclaimableSection_, &spillStats_);
   }
+
+  functionUseSegmentTree_ = Window::splitNames(driverCtx->queryConfig().functionUseSegmentTree());
 }
 
 void Window::initialize() {
@@ -184,6 +188,35 @@ void Window::createWindowFunctions() {
 
     windowFrames_.push_back(
         createWindowFrame(windowNode_, windowNodeFunction.frame, inputType));
+  }
+
+  vector_size_t numFuncs = windowFunctions_.size();
+  for (auto i = 0; i < numFuncs; i++) {
+    const auto& windowFrame = windowFrames_[i];
+    windowFunctions_[i]->setUseSegmentTree(
+        false, true, minFrameSizeUseSegmentTree_);
+    auto function = functionUseSegmentTree_.find(
+        windowNode_->windowFunctions()[i].functionCall->name());
+    // Enable use segment tree when:
+    // 1 Frame must be kPreceding and kFollowing.
+    // 2 Frame size must >= minFrameSizeUseSegmentTree_.
+    // 3 Aggregation function must in functionUseSegmentTree_.
+    if (enableSegmentTreeOpt_ && function != functionUseSegmentTree_.end() &&
+        windowFrame.startType == core::WindowNode::BoundType::kPreceding &&
+        windowFrame.endType == core::WindowNode::BoundType::kFollowing &&
+        windowFrame.start.has_value() &&
+        windowFrame.start.value().constant.has_value() &&
+        windowFrame.end.has_value() &&
+        windowFrame.end.value().constant.has_value() &&
+        windowFrame.start.value().constant.value() +
+                windowFrame.end.value().constant.value() >=
+            minFrameSizeUseSegmentTree_) {
+      windowFunctions_[i]->setUseSegmentTree(
+          true, function->second, minFrameSizeUseSegmentTree_);
+    } else {
+      windowFunctions_[i]->setUseSegmentTree(
+          false, function->second, minFrameSizeUseSegmentTree_);
+    }
   }
 }
 

--- a/velox/exec/Window.h
+++ b/velox/exec/Window.h
@@ -147,9 +147,6 @@ class Window : public Operator {
   // operator and functions. This structure is owned by the WindowBuild.
   std::unique_ptr<WindowPartition> currentPartition_;
 
-  // The min average frame size can use segment tree.
-  int32_t minFrameSizeUseSegmentTree_;
-
   // Whether turn on the optimization of segment tree.
   bool enableSegmentTreeOpt_;
 

--- a/velox/exec/WindowFunction.h
+++ b/velox/exec/WindowFunction.h
@@ -55,6 +55,14 @@ class WindowFunction {
     return pool_;
   }
 
+  void setUseSegmentTree(bool useSegmentTreeBySql,
+                         bool orderInsensitive,
+                         int32_t minFrameUseSegmentTree) {
+    useSegmentTreeBySql_ = useSegmentTreeBySql;
+    orderInsensitive_ = orderInsensitive;
+    minFrameUseSegmentTree_ = minFrameUseSegmentTree;
+  }
+
   const HashStringAllocator* stringAllocator() const {
     return stringAllocator_;
   }
@@ -127,6 +135,13 @@ class WindowFunction {
 
   // Used for setting null for empty frames.
   SelectivityVector invalidRows_;
+
+  // Whether this function use segment tree optimization.
+  bool useSegmentTreeBySql_{false};
+  // The min average frame size will use segmentTree.
+  int32_t minFrameUseSegmentTree_{64};
+  // Whether the aggregate is order insensitive.
+  bool orderInsensitive_{true};
 };
 
 /// Information from the Window operator that is useful for the function logic.

--- a/velox/exec/WindowFunction.h
+++ b/velox/exec/WindowFunction.h
@@ -82,7 +82,6 @@ class WindowFunction {
   /// This function is invoked when the WindowFunction was created.
   virtual void initialize(
       const WindowFrame& windowFrame,
-      vector_size_t minFrameSizeUseSegmentTree,
       bool enableSegmentTreeOpt) {};
 
   /// This function is invoked by the Window operator when it

--- a/velox/functions/lib/window/tests/WindowTestBase.cpp
+++ b/velox/functions/lib/window/tests/WindowTestBase.cpp
@@ -197,8 +197,8 @@ void WindowTestBase::rangeFrameTestImpl(
     const std::string& function,
     const RangeFrameBound& startBound,
     const RangeFrameBound& endBound,
-    bool unorderedColumns) {
-  auto size = 25;
+    bool unorderedColumns,
+    const int32_t size) {
   // For frames with k RANGE PRECEDING/FOLLOWING, Velox requires the application
   // to add columns with the range frame boundary value computed according
   // to the frame type.
@@ -304,9 +304,13 @@ void WindowTestBase::rangeFrameTest(
     bool ascending,
     const std::string& function,
     const RangeFrameBound& startBound,
-    const RangeFrameBound& endBound) {
-  rangeFrameTestImpl(ascending, function, startBound, endBound, false);
-  rangeFrameTestImpl(ascending, function, startBound, endBound, true);
+    const RangeFrameBound& endBound,
+    const int32_t size
+) {
+  rangeFrameTestImpl(ascending, function, startBound, endBound, false, size);
+  rangeFrameTestImpl(ascending, function, startBound, endBound, true, size);
+}
+
 void WindowTestBase::testSegmentTreeFrames(const std::string& function) {
   int64_t rowCount = 500;
   int64_t frame = 65;

--- a/velox/functions/lib/window/tests/WindowTestBase.cpp
+++ b/velox/functions/lib/window/tests/WindowTestBase.cpp
@@ -307,6 +307,65 @@ void WindowTestBase::rangeFrameTest(
     const RangeFrameBound& endBound) {
   rangeFrameTestImpl(ascending, function, startBound, endBound, false);
   rangeFrameTestImpl(ascending, function, startBound, endBound, true);
+void WindowTestBase::testSegmentTreeFrames(const std::string& function) {
+  int64_t rowCount = 500;
+  int64_t frame = 65;
+  // RANGE BETWEEN frame/2 PRECEDING AND frame/2 FOLLOWING.
+  rangeFrameTest(
+      true,
+      function,
+      {frame / 2, BoundType::kPreceding},
+      {frame / 2, BoundType::kFollowing},
+      rowCount);
+  rangeFrameTest(
+      false,
+      function,
+      {frame / 2, BoundType::kPreceding},
+      {frame / 2, BoundType::kFollowing},
+      rowCount);
+
+  // RANGE BETWEEN frame PRECEDING AND CURRENT ROW.
+  rangeFrameTest(
+      true,
+      function,
+      {frame, BoundType::kPreceding},
+      {std::nullopt, BoundType::kCurrentRow},
+      rowCount);
+  rangeFrameTest(
+      false,
+      function,
+      {frame, BoundType::kPreceding},
+      {std::nullopt, BoundType::kCurrentRow},
+      rowCount);
+
+  // RANGE BETWEEN frame PRECEDING AND 2 PRECEDING. There are no rows in that
+  // range. So this tests empty frames.
+  rangeFrameTest(
+      true,
+      function,
+      {frame, BoundType::kPreceding},
+      {2, BoundType::kPreceding},
+      rowCount);
+  rangeFrameTest(
+      false,
+      function,
+      {frame, BoundType::kPreceding},
+      {2, BoundType::kPreceding},
+      rowCount);
+
+  // RANGE BETWEEN CURRENT ROW AND frame FOLLOWING.
+  rangeFrameTest(
+      true,
+      function,
+      {std::nullopt, BoundType::kCurrentRow},
+      {frame, BoundType::kFollowing},
+      rowCount);
+  rangeFrameTest(
+      false,
+      function,
+      {std::nullopt, BoundType::kCurrentRow},
+      {frame, BoundType::kFollowing},
+      rowCount);
 }
 
 void WindowTestBase::testKRangeFrames(const std::string& function) {

--- a/velox/functions/lib/window/tests/WindowTestBase.h
+++ b/velox/functions/lib/window/tests/WindowTestBase.h
@@ -189,6 +189,8 @@ class WindowTestBase : public exec::test::OperatorTestBase {
   /// These are special as they require generating frame bound value columns.
   void testKRangeFrames(const std::string& function);
 
+  void testSegmentTreeFrames(const std::string& function);
+
   /// ParseOptions for the DuckDB Parser. nth_value in Spark expects to parse
   /// integer as int vs bigint in Presto. The default is to parse integer
   /// as bigint (Presto behavior).

--- a/velox/functions/lib/window/tests/WindowTestBase.h
+++ b/velox/functions/lib/window/tests/WindowTestBase.h
@@ -212,13 +212,15 @@ class WindowTestBase : public exec::test::OperatorTestBase {
       bool ascending,
       const std::string& function,
       const RangeFrameBound& startBound,
-      const RangeFrameBound& endBound);
+      const RangeFrameBound& endBound,
+      const int32_t size = 25);
 
   void rangeFrameTestImpl(
       bool ascending,
       const std::string& function,
       const RangeFrameBound& startBound,
       const RangeFrameBound& endBound,
-      bool unorderedColumns);
+      bool unorderedColumns,
+      const int32_t size = 25);
 };
 } // namespace facebook::velox::window::test

--- a/velox/functions/prestosql/window/CMakeLists.txt
+++ b/velox/functions/prestosql/window/CMakeLists.txt
@@ -15,7 +15,9 @@ if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)
 endif()
 
-add_library(velox_window CumeDist.cpp FirstLastValue.cpp LeadLag.cpp
+add_subdirectory(benchmark)
+
+add_library(velox_window CumeDist.cpp FirstLastValue.cpp LeadLag.cpp Ntile.cpp
                          WindowFunctionsRegistration.cpp)
 
 target_link_libraries(velox_window velox_buffer velox_exec

--- a/velox/functions/prestosql/window/CMakeLists.txt
+++ b/velox/functions/prestosql/window/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 
 add_subdirectory(benchmark)
 
-add_library(velox_window CumeDist.cpp FirstLastValue.cpp LeadLag.cpp Ntile.cpp
+add_library(velox_window CumeDist.cpp FirstLastValue.cpp LeadLag.cpp
                          WindowFunctionsRegistration.cpp)
 
 target_link_libraries(velox_window velox_buffer velox_exec

--- a/velox/functions/prestosql/window/CMakeLists.txt
+++ b/velox/functions/prestosql/window/CMakeLists.txt
@@ -15,7 +15,9 @@ if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)
 endif()
 
-add_subdirectory(benchmark)
+if(${VELOX_ENABLE_BENCHMARKS})
+  add_subdirectory(benchmark)
+endif()
 
 add_library(velox_window CumeDist.cpp FirstLastValue.cpp LeadLag.cpp
                          WindowFunctionsRegistration.cpp)

--- a/velox/functions/prestosql/window/benchmark/CMakeLists.txt
+++ b/velox/functions/prestosql/window/benchmark/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(BENCHMARK_DEPENDENCIES_NO_FUNC
+        fmt::fmt
+        velox_functions_test_lib
+        velox_exec
+        velox_exec_test_lib
+        velox_vector_test_lib
+        gflags::gflags
+        Folly::folly
+        ${FOLLY_BENCHMARK})
+
+set(BENCHMARK_DEPENDENCIES
+        velox_window
+        velox_aggregates
+        velox_hive_connector
+        velox_functions_prestosql
+        velox_functions_lib
+        velox_vector_fuzzer
+        ${BENCHMARK_DEPENDENCIES_NO_FUNC})
+
+add_executable(velox_windows_benchmarks WindowBenchmark.cpp)
+
+target_link_libraries(velox_windows_benchmarks ${BENCHMARK_DEPENDENCIES})

--- a/velox/functions/prestosql/window/benchmark/CMakeLists.txt
+++ b/velox/functions/prestosql/window/benchmark/CMakeLists.txt
@@ -13,23 +13,23 @@
 # limitations under the License.
 
 set(BENCHMARK_DEPENDENCIES_NO_FUNC
-        fmt::fmt
-        velox_functions_test_lib
-        velox_exec
-        velox_exec_test_lib
-        velox_vector_test_lib
-        gflags::gflags
-        Folly::folly
-        ${FOLLY_BENCHMARK})
+    fmt::fmt
+    velox_functions_test_lib
+    velox_exec
+    velox_exec_test_lib
+    velox_vector_test_lib
+    gflags::gflags
+    Folly::folly
+    ${FOLLY_BENCHMARK})
 
 set(BENCHMARK_DEPENDENCIES
-        velox_window
-        velox_aggregates
-        velox_hive_connector
-        velox_functions_prestosql
-        velox_functions_lib
-        velox_vector_fuzzer
-        ${BENCHMARK_DEPENDENCIES_NO_FUNC})
+    velox_window
+    velox_aggregates
+    velox_hive_connector
+    velox_functions_prestosql
+    velox_functions_lib
+    velox_vector_fuzzer
+    ${BENCHMARK_DEPENDENCIES_NO_FUNC})
 
 add_executable(velox_windows_benchmarks WindowBenchmark.cpp)
 

--- a/velox/functions/prestosql/window/benchmark/WindowBenchmark.cpp
+++ b/velox/functions/prestosql/window/benchmark/WindowBenchmark.cpp
@@ -1,0 +1,301 @@
+/*
+* Copyright (c) Facebook, Inc. and its affiliates.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include <fmt/format.h>
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <string>
+
+#include "velox/exec/tests/utils/Cursor.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/functions/prestosql/window/WindowFunctionsRegistration.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+DEFINE_int64(fuzzer_seed, 99887766, "Seed for random input dataset generator");
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+
+static constexpr int32_t kNumVectors = 10;
+static constexpr int32_t kRowsPerVector = 30'000;
+
+namespace {
+
+class WindowBenchmark : public HiveConnectorTestBase {
+public:
+ explicit WindowBenchmark() {
+   HiveConnectorTestBase::SetUp();
+   aggregate::prestosql::registerAllAggregateFunctions();
+   window::prestosql::registerAllWindowFunctions();
+
+   inputType_ = ROW({
+       {"k_array", INTEGER()},
+       {"k_norm", INTEGER()},
+       {"k_hash", INTEGER()},
+       {"k_sort", INTEGER()},
+       {"i32", INTEGER()},
+       {"i64", BIGINT()},
+       {"f32", REAL()},
+       {"f64", DOUBLE()},
+       {"i32_halfnull", INTEGER()},
+       {"i64_halfnull", BIGINT()},
+       {"f32_halfnull", REAL()},
+       {"f64_halfnull", DOUBLE()},
+   });
+
+   VectorFuzzer::Options opts;
+   opts.vectorSize = kRowsPerVector;
+   opts.nullRatio = 0;
+   VectorFuzzer fuzzer(opts, pool_.get(), FLAGS_fuzzer_seed);
+
+   std::vector<RowVectorPtr> vectors;
+   for (auto i = 0; i < kNumVectors; ++i) {
+     std::vector<VectorPtr> children;
+
+     // Generate key with a small number of unique values from a small range
+     // (0-16).
+     children.emplace_back(makeFlatVector<int32_t>(
+         kRowsPerVector, [](auto row) { return row % 4; }));
+
+     // Generate key with a small number of unique values from a large range
+     // (300 total values).
+     children.emplace_back(
+         makeFlatVector<int32_t>(kRowsPerVector, [](auto row) {
+           if (row % 3 == 0) {
+             return std::numeric_limits<int32_t>::max() - row % 100;
+           } else if (row % 3 == 1) {
+             return row % 100;
+           } else {
+             return std::numeric_limits<int32_t>::min() + row % 100;
+           }
+         }));
+
+     // Generate key with many unique values from a large range (500K total
+     // values).
+     children.emplace_back(fuzzer.fuzzFlat(INTEGER()));
+
+     // Generate a column with increasing values to get a deterministic sort
+     // order.
+     children.emplace_back(makeFlatVector<int32_t>(
+         kRowsPerVector, [](auto row) { return row; }));
+
+     // Generate random values without nulls.
+     children.emplace_back(fuzzer.fuzzFlat(INTEGER()));
+     children.emplace_back(fuzzer.fuzzFlat(BIGINT()));
+     children.emplace_back(fuzzer.fuzzFlat(REAL()));
+     children.emplace_back(fuzzer.fuzzFlat(DOUBLE()));
+
+     // Generate random values with nulls.
+
+     opts.nullRatio = 0.5; // 50%
+     fuzzer.setOptions(opts);
+
+     children.emplace_back(fuzzer.fuzzFlat(INTEGER()));
+     children.emplace_back(fuzzer.fuzzFlat(BIGINT()));
+     children.emplace_back(fuzzer.fuzzFlat(REAL()));
+     children.emplace_back(fuzzer.fuzzFlat(DOUBLE()));
+
+     vectors.emplace_back(makeRowVector(inputType_->names(), children));
+   }
+   filePath_ = TempFilePath::create();
+   writeToFile(filePath_->path, vectors);
+ }
+
+ ~WindowBenchmark() override {
+   HiveConnectorTestBase::TearDown();
+ }
+
+ void TestBody() override {}
+
+ // Enhance this function to include a frame clause.
+ void run(
+     const std::string& key,
+     const std::string& aggregate,
+     const std::string& frameType,
+     const uint32_t frameSize,
+     bool enableSegmentTree) {
+   folly::BenchmarkSuspender suspender;
+
+   std::string functionSql = fmt::format(
+       "{} over (partition by {} order by k_sort {} between {} PRECEDING and {} FOLLOWING)",
+       aggregate,
+       key,
+       frameType,
+       frameSize / 2,
+       frameSize / 2);
+   core::PlanFragment plan;
+
+   plan =
+       PlanBuilder().tableScan(inputType_).window({functionSql}).planFragment();
+
+   vector_size_t numResultRows = 0;
+   auto task = makeTask(plan, numResultRows, enableSegmentTree);
+
+   task->addSplit("0", exec::Split(makeHiveConnectorSplit(filePath_->path)));
+   task->noMoreSplits("0");
+
+   suspender.dismiss();
+
+   task->start(1);
+   auto& executor = folly::QueuedImmediateExecutor::instance();
+   auto future = task->stateChangeFuture(60'000'000).via(&executor);
+   future.wait();
+
+   folly::doNotOptimizeAway(numResultRows);
+ }
+
+ std::shared_ptr<exec::Task> makeTask(
+     core::PlanFragment plan,
+     vector_size_t& numResultRows,
+     bool enableSegmentTree) {
+   int32_t minFrameSizeUseSegmentTree = 0;
+   if (!enableSegmentTree) {
+     minFrameSizeUseSegmentTree = std::numeric_limits<int32_t>::max();
+   }
+
+   std::unordered_map<std::string, std::string> queryConfig{
+       {core::QueryConfig::kMinFrameSizeUseSegmentTree,
+        fmt::format("{}", minFrameSizeUseSegmentTree)}};
+
+   return exec::Task::create(
+       "t",
+       std::move(plan),
+       0,
+       std::make_shared<core::QueryCtx>(
+           executor_.get(),
+           core::QueryConfig(std::move(queryConfig))),
+       [&](auto vector, auto* /*future*/) {
+         if (vector) {
+           numResultRows += vector->size();
+         }
+         return exec::BlockingReason::kNotBlocked;
+       });
+ }
+
+private:
+ RowTypePtr inputType_;
+
+ std::shared_ptr<TempFilePath> filePath_;
+};
+
+std::unique_ptr<WindowBenchmark> benchmark;
+
+void rawRowFrame(uint32_t, const std::string& key, const std::string& aggregate, uint32_t frameSize) {
+  benchmark->run(key, aggregate, "rows", frameSize, false);
+}
+
+void segmentOptRowFrame(uint32_t, const std::string& key, const std::string& aggregate, uint32_t frameSize) {
+ benchmark->run(key, aggregate, "rows", frameSize, true);
+}
+
+#define WINDOW_AGG_BENCHMARKS(_name_, _key_)       \
+ BENCHMARK_NAMED_PARAM(                            \
+     rawRowFrame,                                  \
+     _name_##_frame_16_##_key_,                    \
+     #_key_,                                       \
+     fmt::format("{}(i32)", (#_name_)),            \
+      16);                                         \
+ BENCHMARK_NAMED_PARAM(                            \
+     segmentOptRowFrame,                           \
+     _name_##_frame_16_##_key_,                    \
+     #_key_,                                       \
+     fmt::format("{}(i32)", (#_name_)),            \
+      16);                                         \
+  BENCHMARK_NAMED_PARAM(                           \
+     rawRowFrame,                                  \
+     _name_##_frame_64_##_key_,                    \
+     #_key_,                                       \
+     fmt::format("{}(i32)", (#_name_)),            \
+      64);                                         \
+ BENCHMARK_NAMED_PARAM(                            \
+     segmentOptRowFrame,                           \
+     _name_##_frame_64_##_key_,                    \
+     #_key_,                                       \
+     fmt::format("{}(i32)", (#_name_)),            \
+      64);                                         \
+  BENCHMARK_NAMED_PARAM(                           \
+      rawRowFrame,                                 \
+      _name_##_frame_256_##_key_,                  \
+      #_key_,                                      \
+      fmt::format("{}(i32)", (#_name_)),           \
+       256);                                       \
+  BENCHMARK_NAMED_PARAM(                           \
+      segmentOptRowFrame,                          \
+      _name_##_frame_256_##_key_,                  \
+      #_key_,                                      \
+      fmt::format("{}(i32)", (#_name_)),           \
+       256);                                       \
+   BENCHMARK_NAMED_PARAM(                          \
+      rawRowFrame,                                 \
+      _name_##_frame_512_##_key_,                  \
+      #_key_,                                      \
+      fmt::format("{}(i32)", (#_name_)),           \
+       512);                                       \
+  BENCHMARK_NAMED_PARAM(                           \
+      segmentOptRowFrame,                          \
+      _name_##_frame_512_##_key_,                  \
+      #_key_,                                      \
+      fmt::format("{}(i32)", (#_name_)),           \
+       512);                                       \
+  BENCHMARK_NAMED_PARAM(                           \
+     rawRowFrame,                                  \
+     _name_##_frame_2048_##_key_,                  \
+     #_key_,                                       \
+     fmt::format("{}(i32)", (#_name_)),            \
+      2048);                                       \
+ BENCHMARK_NAMED_PARAM(                            \
+     segmentOptRowFrame,                           \
+     _name_##_frame_2048_##_key_,                  \
+     #_key_,                                       \
+     fmt::format("{}(i32)", (#_name_)),            \
+      2048);                                       \
+ BENCHMARK_DRAW_LINE();
+
+// Sum aggregate.
+WINDOW_AGG_BENCHMARKS(sum, k_array)
+BENCHMARK_DRAW_LINE();
+
+// Avg aggregate.
+WINDOW_AGG_BENCHMARKS(avg, k_array)
+BENCHMARK_DRAW_LINE();
+
+// Min aggregate.
+WINDOW_AGG_BENCHMARKS(min, k_array)
+BENCHMARK_DRAW_LINE();
+
+// Max aggregate.
+WINDOW_AGG_BENCHMARKS(max, k_array)
+BENCHMARK_DRAW_LINE();
+
+// Stddev aggregate.
+WINDOW_AGG_BENCHMARKS(stddev, k_array)
+BENCHMARK_DRAW_LINE();
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+  facebook::velox::memory::MemoryManager::initialize({});
+
+  benchmark = std::make_unique<WindowBenchmark>();
+  folly::runBenchmarks();
+  benchmark.reset();
+  return 0;
+}

--- a/velox/functions/prestosql/window/benchmark/WindowBenchmark.cpp
+++ b/velox/functions/prestosql/window/benchmark/WindowBenchmark.cpp
@@ -33,8 +33,8 @@ using namespace facebook::velox::test;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
 
-static constexpr int32_t kNumVectors = 10;
-static constexpr int32_t kRowsPerVector = 30'000;
+static constexpr int32_t kNumVectors = 30;
+static constexpr int32_t kRowsPerVector = 10'000;
 
 namespace {
 
@@ -202,7 +202,7 @@ void rawRowFrame(uint32_t, const std::string& key, const std::string& aggregate,
 }
 
 void segmentOptRowFrame(uint32_t, const std::string& key, const std::string& aggregate, uint32_t frameSize) {
- benchmark->run(key, aggregate, "rows", frameSize, true);
+  benchmark->run(key, aggregate, "rows", frameSize, true);
 }
 
 #define WINDOW_AGG_BENCHMARKS(_name_, _key_)       \
@@ -268,6 +268,10 @@ void segmentOptRowFrame(uint32_t, const std::string& key, const std::string& agg
       2048);                                       \
  BENCHMARK_DRAW_LINE();
 
+// Count aggregate.
+WINDOW_AGG_BENCHMARKS(count, k_array)
+BENCHMARK_DRAW_LINE();
+
 // Sum aggregate.
 WINDOW_AGG_BENCHMARKS(sum, k_array)
 BENCHMARK_DRAW_LINE();
@@ -291,7 +295,7 @@ BENCHMARK_DRAW_LINE();
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init init{&argc, &argv};
   facebook::velox::memory::MemoryManager::initialize({});
 
   benchmark = std::make_unique<WindowBenchmark>();

--- a/velox/functions/prestosql/window/tests/AggregateWindowTest.cpp
+++ b/velox/functions/prestosql/window/tests/AggregateWindowTest.cpp
@@ -141,6 +141,18 @@ TEST_F(AggregateWindowTest, rangeFrames) {
   }
 }
 
+// Tests window aggregate function with segmentTree.
+TEST_F(AggregateWindowTest, segmentTreeFrames) {
+  for (const auto& function : kAggregateFunctions) {
+    // count function is skipped as DuckDB returns inconsistent results
+    // with Velox for rows with empty frames. Velox expects empty frames to
+    // return 0, but DuckDB returns null.
+    if (function != "count(c2)") {
+      testSegmentTreeFrames(function);
+    }
+  }
+}
+
 // Test for aggregates that return NULL as the default value for empty frames
 // against DuckDb.
 TEST_F(AggregateWindowTest, nullEmptyResult) {

--- a/velox/vector/SelectivityVector.h
+++ b/velox/vector/SelectivityVector.h
@@ -286,6 +286,12 @@ class SelectivityVector {
     allSelected_.reset();
   }
 
+  /**
+   * This method is an optimization of updateBounds(). It can only be called if
+   * you exactly know the begin and end position. It's no need to call
+   * bits::findFirstBit and bits::findLastBit to determine the begin and end
+   * position.
+   */
   void updateBounds(vector_size_t begin, vector_size_t end) {
     begin_ = begin;
     end_ = end;

--- a/velox/vector/SelectivityVector.h
+++ b/velox/vector/SelectivityVector.h
@@ -286,6 +286,11 @@ class SelectivityVector {
     allSelected_.reset();
   }
 
+  void updateBounds(vector_size_t begin, vector_size_t end) {
+    begin_ = begin;
+    end_ = end;
+  }
+
   bool isAllSelected() const {
     if (allSelected_.has_value()) {
       return allSelected_.value();


### PR DESCRIPTION
This optimization is based on https://www.vldb.org/pvldb/vol8/p1058-leis.pdf paper and is similar to https://duckdb.org/2021/10/13/windowing.html

1. Description
* When the window frame size is relatively large, such as window frame size >= 16, simple aggregation (each record aggregates its window data) will have a large number of repeated calculations.
* When the window is not incremental, for example the window frame start and frame end can be changed, or the aggregation function is difficult to remove records, incrementalAggregation cannot be used for optimization. Only simple aggregations can be used.

2. The optimization idea based on segment trees to reduce the repeated calculation of aggregate functions and reduce the time complexity of calculating a record from O(n) to O(log n) when the window frame size changes arbitrarily.

3. Optimize scenarios
* There are window aggregate functions.
* Window frame size >= 16 (meaning that the row size in one partition should to be at least 16), and as the window frame size becomes larger, the optimization becomes better.

4. The following are the benchmark results. The results show that as the window window frame size becomes larger, the optimization becomes more obvious. When the window frame size is 2048, the optimization is more than 10 times.

```
============================================================================
[...]/window/benchmark/WindowBenchmark.cpp     relative  time/iter   iters/s
============================================================================
rawRowFrame(count_frame_16_k_array)                       330.49ms      3.03
segmentOptRowFrame(count_frame_16_k_array)                313.07ms      3.19
rawRowFrame(count_frame_64_k_array)                       369.08ms      2.71
segmentOptRowFrame(count_frame_64_k_array)                292.25ms      3.42
rawRowFrame(count_frame_256_k_array)                      381.35ms      2.62
segmentOptRowFrame(count_frame_256_k_array)               301.02ms      3.32
rawRowFrame(count_frame_512_k_array)                      449.17ms      2.23
segmentOptRowFrame(count_frame_512_k_array)               353.11ms      2.83
rawRowFrame(count_frame_2048_k_array)                        1.45s   688.97m
segmentOptRowFrame(count_frame_2048_k_array)              298.44ms      3.35
rawRowFrame(sum_frame_16_k_array)                         309.85ms      3.23
segmentOptRowFrame(sum_frame_16_k_array)                  311.58ms      3.21
rawRowFrame(sum_frame_64_k_array)                         361.58ms      2.77
segmentOptRowFrame(sum_frame_64_k_array)                  316.90ms      3.16
rawRowFrame(sum_frame_256_k_array)                        602.75ms      1.66
segmentOptRowFrame(sum_frame_256_k_array)                 410.00ms      2.44
rawRowFrame(sum_frame_512_k_array)                           1.08s   926.15m
segmentOptRowFrame(sum_frame_512_k_array)                 429.23ms      2.33
rawRowFrame(sum_frame_2048_k_array)                          5.49s   181.99m
segmentOptRowFrame(sum_frame_2048_k_array)                414.17ms      2.41
rawRowFrame(avg_frame_16_k_array)                         398.75ms      2.51
segmentOptRowFrame(avg_frame_16_k_array)                  355.38ms      2.81
rawRowFrame(avg_frame_64_k_array)                         365.24ms      2.74
segmentOptRowFrame(avg_frame_64_k_array)                  350.43ms      2.85
rawRowFrame(avg_frame_256_k_array)                        580.88ms      1.72
segmentOptRowFrame(avg_frame_256_k_array)                 337.23ms      2.97
rawRowFrame(avg_frame_512_k_array)                        938.85ms      1.07
segmentOptRowFrame(avg_frame_512_k_array)                 373.71ms      2.68
rawRowFrame(avg_frame_2048_k_array)                          4.25s   235.56m
segmentOptRowFrame(avg_frame_2048_k_array)                381.15ms      2.62
rawRowFrame(min_frame_16_k_array)                         320.73ms      3.12
segmentOptRowFrame(min_frame_16_k_array)                  312.86ms      3.20
rawRowFrame(min_frame_64_k_array)                         358.26ms      2.79
segmentOptRowFrame(min_frame_64_k_array)                  308.58ms      3.24
rawRowFrame(min_frame_256_k_array)                        467.94ms      2.14
segmentOptRowFrame(min_frame_256_k_array)                 309.83ms      3.23
rawRowFrame(min_frame_512_k_array)                        665.46ms      1.50
segmentOptRowFrame(min_frame_512_k_array)                 322.60ms      3.10
rawRowFrame(min_frame_2048_k_array)                          2.31s   432.04m
segmentOptRowFrame(min_frame_2048_k_array)                358.51ms      2.79
rawRowFrame(max_frame_16_k_array)                         327.33ms      3.05
segmentOptRowFrame(max_frame_16_k_array)                  334.73ms      2.99
rawRowFrame(max_frame_64_k_array)                         342.32ms      2.92
segmentOptRowFrame(max_frame_64_k_array)                  402.26ms      2.49
rawRowFrame(max_frame_256_k_array)                        552.13ms      1.81
segmentOptRowFrame(max_frame_256_k_array)                 298.60ms      3.35
rawRowFrame(max_frame_512_k_array)                        590.44ms      1.69
segmentOptRowFrame(max_frame_512_k_array)                 302.45ms      3.31
rawRowFrame(max_frame_2048_k_array)                          2.20s   455.02m
segmentOptRowFrame(max_frame_2048_k_array)                385.36ms      2.59
rawRowFrame(stddev_frame_16_k_array)                      319.41ms      3.13
segmentOptRowFrame(stddev_frame_16_k_array)               434.15ms      2.30
rawRowFrame(stddev_frame_64_k_array)                      378.43ms      2.64
segmentOptRowFrame(stddev_frame_64_k_array)               552.84ms      1.81
rawRowFrame(stddev_frame_256_k_array)                        1.08s   927.33m
segmentOptRowFrame(stddev_frame_256_k_array)              679.89ms      1.47
rawRowFrame(stddev_frame_512_k_array)                        1.07s   931.61m
segmentOptRowFrame(stddev_frame_512_k_array)              787.58ms      1.27
rawRowFrame(stddev_frame_2048_k_array)                       3.77s   265.07m
segmentOptRowFrame(stddev_frame_2048_k_array)             849.46ms      1.18
```

