### PR TITLE
Add order-sensitive metadata for aggregate functions

### DIFF
--- a/velox/exec/Aggregate.cpp
+++ b/velox/exec/Aggregate.cpp
@@ -53,10 +53,11 @@ getAggregateFunctionEntry(const std::string& name) {
       });
 }
 
-AggregateRegistrationResult registerAggregateFunction(
+AggregateRegistrationResult registerAggregateFunctionWithMetadata(
     const std::string& name,
     const std::vector<std::shared_ptr<AggregateFunctionSignature>>& signatures,
     const AggregateFunctionFactory& factory,
+    const AggregateFunctionMetadata& metadata,
     bool registerCompanionFunctions,
     bool overwrite) {
   auto sanitizedName = sanitizeName(name);
@@ -64,14 +65,15 @@ AggregateRegistrationResult registerAggregateFunction(
 
   if (overwrite) {
     aggregateFunctions().withWLock([&](auto& aggregationFunctionMap) {
-      aggregationFunctionMap[sanitizedName] = {signatures, std::move(factory)};
+      aggregationFunctionMap[sanitizedName] = {
+          signatures, std::move(factory), std::move(metadata)};
     });
     registered.mainFunction = true;
   } else {
     auto inserted =
         aggregateFunctions().withWLock([&](auto& aggregationFunctionMap) {
           auto [_, inserted_2] = aggregationFunctionMap.insert(
-              {sanitizedName, {signatures, factory}});
+              {sanitizedName, {signatures, factory, metadata}});
           return inserted_2;
         });
     registered.mainFunction = inserted;
@@ -98,17 +100,54 @@ AggregateRegistrationResult registerAggregateFunction(
   return registered;
 }
 
+AggregateRegistrationResult registerAggregateFunction(
+    const std::string& name,
+    const std::vector<std::shared_ptr<AggregateFunctionSignature>>& signatures,
+    const AggregateFunctionFactory& factory,
+    bool registerCompanionFunctions,
+    bool overwrite) {
+  return registerAggregateFunctionWithMetadata(
+      name,
+      signatures,
+      factory,
+      {},
+      registerCompanionFunctions,
+      overwrite);
+}
+
 std::vector<AggregateRegistrationResult> registerAggregateFunction(
     const std::vector<std::string>& names,
     const std::vector<std::shared_ptr<AggregateFunctionSignature>>& signatures,
     const AggregateFunctionFactory& factory,
     bool registerCompanionFunctions,
+    bool overwrite
+    ) {
+  return registerAggregateFunctionWithMetadata(
+      names,
+      signatures,
+      factory,
+      {},
+      registerCompanionFunctions,
+      overwrite);
+}
+
+std::vector<AggregateRegistrationResult> registerAggregateFunctionWithMetadata(
+    const std::vector<std::string>& names,
+    const std::vector<std::shared_ptr<AggregateFunctionSignature>>& signatures,
+    const AggregateFunctionFactory& factory,
+    const AggregateFunctionMetadata& metadata,
+    bool registerCompanionFunctions,
     bool overwrite) {
   auto size = names.size();
   std::vector<AggregateRegistrationResult> registrationResults{size};
   for (int i = 0; i < size; ++i) {
-    registrationResults[i] = registerAggregateFunction(
-        names[i], signatures, factory, registerCompanionFunctions, overwrite);
+    registrationResults[i] = registerAggregateFunctionWithMetadata(
+        names[i],
+        signatures,
+        factory,
+        metadata,
+        registerCompanionFunctions,
+        overwrite);
   }
   return registrationResults;
 }

--- a/velox/exec/Aggregate.cpp
+++ b/velox/exec/Aggregate.cpp
@@ -53,7 +53,7 @@ getAggregateFunctionEntry(const std::string& name) {
       });
 }
 
-AggregateRegistrationResult registerAggregateFunctionWithMetadata(
+AggregateRegistrationResult registerAggregateFunction(
     const std::string& name,
     const std::vector<std::shared_ptr<AggregateFunctionSignature>>& signatures,
     const AggregateFunctionFactory& factory,
@@ -66,7 +66,7 @@ AggregateRegistrationResult registerAggregateFunctionWithMetadata(
   if (overwrite) {
     aggregateFunctions().withWLock([&](auto& aggregationFunctionMap) {
       aggregationFunctionMap[sanitizedName] = {
-          signatures, std::move(factory), std::move(metadata)};
+          signatures, std::move(factory), metadata};
     });
     registered.mainFunction = true;
   } else {
@@ -106,13 +106,8 @@ AggregateRegistrationResult registerAggregateFunction(
     const AggregateFunctionFactory& factory,
     bool registerCompanionFunctions,
     bool overwrite) {
-  return registerAggregateFunctionWithMetadata(
-      name,
-      signatures,
-      factory,
-      {},
-      registerCompanionFunctions,
-      overwrite);
+  return registerAggregateFunction(
+      name, signatures, factory, {}, registerCompanionFunctions, overwrite);
 }
 
 std::vector<AggregateRegistrationResult> registerAggregateFunction(
@@ -120,18 +115,12 @@ std::vector<AggregateRegistrationResult> registerAggregateFunction(
     const std::vector<std::shared_ptr<AggregateFunctionSignature>>& signatures,
     const AggregateFunctionFactory& factory,
     bool registerCompanionFunctions,
-    bool overwrite
-    ) {
-  return registerAggregateFunctionWithMetadata(
-      names,
-      signatures,
-      factory,
-      {},
-      registerCompanionFunctions,
-      overwrite);
+    bool overwrite) {
+  return registerAggregateFunction(
+      names, signatures, factory, {}, registerCompanionFunctions, overwrite);
 }
 
-std::vector<AggregateRegistrationResult> registerAggregateFunctionWithMetadata(
+std::vector<AggregateRegistrationResult> registerAggregateFunction(
     const std::vector<std::string>& names,
     const std::vector<std::shared_ptr<AggregateFunctionSignature>>& signatures,
     const AggregateFunctionFactory& factory,
@@ -141,7 +130,7 @@ std::vector<AggregateRegistrationResult> registerAggregateFunctionWithMetadata(
   auto size = names.size();
   std::vector<AggregateRegistrationResult> registrationResults{size};
   for (int i = 0; i < size; ++i) {
-    registrationResults[i] = registerAggregateFunctionWithMetadata(
+    registrationResults[i] = registerAggregateFunction(
         names[i],
         signatures,
         factory,

--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -417,6 +417,11 @@ using AggregateFunctionFactory = std::function<std::unique_ptr<Aggregate>(
     const TypePtr& resultType,
     const core::QueryConfig& config)>;
 
+struct AggregateFunctionMetadata {
+  /// True if results of the aggregation depend on the order of inputs. For
+  /// example, array_agg is order sensitive while count is not.
+  bool orderSensitive{true};
+};
 /// Register an aggregate function with the specified name and signatures. If
 /// registerCompanionFunctions is true, also register companion aggregate and
 /// scalar functions with it. When functions with `name` already exist, if
@@ -429,12 +434,28 @@ AggregateRegistrationResult registerAggregateFunction(
     bool registerCompanionFunctions,
     bool overwrite);
 
+AggregateRegistrationResult registerAggregateFunctionWithMetadata(
+    const std::string& name,
+    const std::vector<std::shared_ptr<AggregateFunctionSignature>>& signatures,
+    const AggregateFunctionFactory& factory,
+    const AggregateFunctionMetadata& metadata,
+    bool registerCompanionFunctions,
+    bool overwrite);
+
 // Register an aggregation function with multiple names. Returns a vector of
 // AggregateRegistrationResult, one for each name at the corresponding index.
 std::vector<AggregateRegistrationResult> registerAggregateFunction(
     const std::vector<std::string>& names,
     const std::vector<std::shared_ptr<AggregateFunctionSignature>>& signatures,
     const AggregateFunctionFactory& factory,
+    bool registerCompanionFunctions,
+    bool overwrite);
+
+std::vector<AggregateRegistrationResult> registerAggregateFunctionWithMetadata(
+    const std::vector<std::string>& names,
+    const std::vector<std::shared_ptr<AggregateFunctionSignature>>& signatures,
+    const AggregateFunctionFactory& factory,
+    const AggregateFunctionMetadata& metadata,
     bool registerCompanionFunctions,
     bool overwrite);
 
@@ -453,6 +474,7 @@ AggregateFunctionSignatureMap getAggregateFunctionSignatures();
 struct AggregateFunctionEntry {
   std::vector<AggregateFunctionSignaturePtr> signatures;
   AggregateFunctionFactory factory;
+  AggregateFunctionMetadata metadata;
 };
 
 using AggregateFunctionMap = folly::Synchronized<

--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -434,7 +434,7 @@ AggregateRegistrationResult registerAggregateFunction(
     bool registerCompanionFunctions,
     bool overwrite);
 
-AggregateRegistrationResult registerAggregateFunctionWithMetadata(
+AggregateRegistrationResult registerAggregateFunction(
     const std::string& name,
     const std::vector<std::shared_ptr<AggregateFunctionSignature>>& signatures,
     const AggregateFunctionFactory& factory,
@@ -451,7 +451,7 @@ std::vector<AggregateRegistrationResult> registerAggregateFunction(
     bool registerCompanionFunctions,
     bool overwrite);
 
-std::vector<AggregateRegistrationResult> registerAggregateFunctionWithMetadata(
+std::vector<AggregateRegistrationResult> registerAggregateFunction(
     const std::vector<std::string>& names,
     const std::vector<std::shared_ptr<AggregateFunctionSignature>>& signatures,
     const AggregateFunctionFactory& factory,

--- a/velox/exec/AggregateInfo.h
+++ b/velox/exec/AggregateInfo.h
@@ -58,7 +58,9 @@ struct AggregateInfo {
 class OperatorCtx;
 
 /// Translate an AggregationNode to a list of AggregationInfo, which could be
-/// a hash aggregation plan node or a streaming aggregation plan node.
+/// a hash aggregation plan node or a streaming aggregation plan node. Ignore
+/// sorting properties if aggregate function is not sensitive to the order of
+/// inputs.
 ///
 /// @param aggregationNode Plan node of this aggregation.
 /// @param operatorCtx Operator context.

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -3693,7 +3693,6 @@ TEST_F(AggregationTest, ignoreOrderBy) {
           .planNode();
 
   AssertQueryBuilder(plan, duckDbQueryRunner_)
-      .assertResults(
-          "SELECT c0, sum(c1), avg(c1) FROM tmp GROUP BY 1");
+      .assertResults("SELECT c0, sum(c1), avg(c1) FROM tmp GROUP BY 1");
 }
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -3671,4 +3671,29 @@ TEST_F(AggregationTest, ignoreNullKeys) {
   AssertQueryBuilder(makePlan(true)).assertEmptyResults();
 }
 
+// Verify that ORDER BY clause is ignored for aggregates that are not order
+// sensitive.
+TEST_F(AggregationTest, ignoreOrderBy) {
+  auto data = makeRowVector({
+      makeFlatVector<int16_t>({1, 1, 2, 2, 1, 2, 1}),
+      makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 7}),
+      makeFlatVector<int64_t>({10, 20, 30, 40, 50, 60, 70}),
+      makeFlatVector<int32_t>({11, 44, 22, 55, 33, 66, 77}),
+  });
+
+  createDuckDbTable({data});
+
+  // Sorted aggregations over same inputs.
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .partialAggregation(
+              {"c0"}, {"sum(c1 ORDER BY c2 DESC)", "avg(c1 ORDER BY c3)"})
+          .finalAggregation()
+          .planNode();
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .assertResults(
+          "SELECT c0, sum(c1), avg(c1) FROM tmp GROUP BY 1");
+}
 } // namespace facebook::velox::exec::test

--- a/velox/functions/lib/aggregates/BitwiseAggregateBase.h
+++ b/velox/functions/lib/aggregates/BitwiseAggregateBase.h
@@ -88,7 +88,7 @@ exec::AggregateRegistrationResult registerBitwise(
                              .build());
   }
 
-  return exec::registerAggregateFunction(
+  return exec::registerAggregateFunctionWithMetadata(
       name,
       std::move(signatures),
       [name](
@@ -115,6 +115,7 @@ exec::AggregateRegistrationResult registerBitwise(
                 inputType->kindName());
         }
       },
+      {false /*orderSensitive*/},
       withCompanionFunctions,
       overwrite);
 }

--- a/velox/functions/lib/aggregates/BitwiseAggregateBase.h
+++ b/velox/functions/lib/aggregates/BitwiseAggregateBase.h
@@ -88,7 +88,7 @@ exec::AggregateRegistrationResult registerBitwise(
                              .build());
   }
 
-  return exec::registerAggregateFunctionWithMetadata(
+  return exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
@@ -275,7 +275,7 @@ void registerArbitraryAggregate(
           .build()};
 
   std::vector<std::string> names = {prefix + kArbitrary, prefix + kAnyValue};
-  exec::registerAggregateFunction(
+  exec::registerAggregateFunctionWithMetadata(
       names,
       std::move(signatures),
       [name = names.front()](
@@ -322,6 +322,7 @@ void registerArbitraryAggregate(
                 inputType->kindName());
         }
       },
+      {false /*orderSensitive*/},
       withCompanionFunctions,
       overwrite);
 }

--- a/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
@@ -275,7 +275,7 @@ void registerArbitraryAggregate(
           .build()};
 
   std::vector<std::string> names = {prefix + kArbitrary, prefix + kAnyValue};
-  exec::registerAggregateFunctionWithMetadata(
+  exec::registerAggregateFunction(
       names,
       std::move(signatures),
       [name = names.front()](

--- a/velox/functions/prestosql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/AverageAggregate.cpp
@@ -58,7 +58,7 @@ void registerAverageAggregate(
                            .build());
 
   auto name = prefix + kAvg;
-  exec::registerAggregateFunction(
+  exec::registerAggregateFunctionWithMetadata(
       name,
       std::move(signatures),
       [name](
@@ -142,6 +142,7 @@ void registerAverageAggregate(
           }
         }
       },
+      {false /*orderSensitive*/},
       withCompanionFunctions,
       overwrite);
 }

--- a/velox/functions/prestosql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/AverageAggregate.cpp
@@ -58,7 +58,7 @@ void registerAverageAggregate(
                            .build());
 
   auto name = prefix + kAvg;
-  exec::registerAggregateFunctionWithMetadata(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/BoolAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/BoolAggregates.cpp
@@ -190,7 +190,7 @@ exec::AggregateRegistrationResult registerBool(
           .argumentType("boolean")
           .build()};
 
-  return exec::registerAggregateFunction(
+  return exec::registerAggregateFunctionWithMetadata(
       name,
       std::move(signatures),
       [name](
@@ -209,6 +209,7 @@ exec::AggregateRegistrationResult registerBool(
             inputType->kindName());
         return std::make_unique<T>();
       },
+      {false /*orderSensitive*/},
       withCompanionFunctions,
       overwrite);
 }

--- a/velox/functions/prestosql/aggregates/BoolAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/BoolAggregates.cpp
@@ -190,7 +190,7 @@ exec::AggregateRegistrationResult registerBool(
           .argumentType("boolean")
           .build()};
 
-  return exec::registerAggregateFunctionWithMetadata(
+  return exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
@@ -244,7 +244,7 @@ void registerChecksumAggregate(
   };
 
   auto name = prefix + kChecksum;
-  exec::registerAggregateFunctionWithMetadata(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [&name](

--- a/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
@@ -244,7 +244,7 @@ void registerChecksumAggregate(
   };
 
   auto name = prefix + kChecksum;
-  exec::registerAggregateFunction(
+  exec::registerAggregateFunctionWithMetadata(
       name,
       std::move(signatures),
       [&name](
@@ -261,6 +261,7 @@ void registerChecksumAggregate(
 
         return std::make_unique<ChecksumAggregate>(VARBINARY());
       },
+      {false /*orderSensitive*/},
       withCompanionFunctions,
       overwrite);
 }

--- a/velox/functions/prestosql/aggregates/CountAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountAggregate.cpp
@@ -168,7 +168,7 @@ void registerCountAggregate(
   };
 
   auto name = prefix + kCount;
-  exec::registerAggregateFunction(
+  exec::registerAggregateFunctionWithMetadata(
       name,
       std::move(signatures),
       [name](
@@ -181,6 +181,7 @@ void registerCountAggregate(
             argTypes.size(), 1, "{} takes at most one argument", name);
         return std::make_unique<CountAggregate>();
       },
+      {false /*orderSensitive*/},
       withCompanionFunctions,
       overwrite);
 }

--- a/velox/functions/prestosql/aggregates/CountAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountAggregate.cpp
@@ -168,7 +168,7 @@ void registerCountAggregate(
   };
 
   auto name = prefix + kCount;
-  exec::registerAggregateFunctionWithMetadata(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
@@ -183,7 +183,7 @@ void registerCountIfAggregate(
   };
 
   auto name = prefix + kCountIf;
-  exec::registerAggregateFunction(
+  exec::registerAggregateFunctionWithMetadata(
       name,
       std::move(signatures),
       [name](
@@ -205,6 +205,7 @@ void registerCountIfAggregate(
 
         return std::make_unique<CountIfAggregate>();
       },
+      {false /*orderSensitive*/},
       withCompanionFunctions,
       overwrite);
 }

--- a/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
@@ -183,7 +183,7 @@ void registerCountIfAggregate(
   };
 
   auto name = prefix + kCountIf;
-  exec::registerAggregateFunctionWithMetadata(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/GeometricMeanAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/GeometricMeanAggregate.cpp
@@ -105,7 +105,7 @@ void registerGeometricMeanAggregate(
                            .argumentType("real")
                            .build());
 
-  exec::registerAggregateFunction(
+  exec::registerAggregateFunctionWithMetadata(
       name,
       std::move(signatures),
       [name](
@@ -136,6 +136,7 @@ void registerGeometricMeanAggregate(
                 inputType->toString());
         }
       },
+      {false /*orderSensitive*/},
       withCompanionFunctions,
       overwrite);
 }

--- a/velox/functions/prestosql/aggregates/GeometricMeanAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/GeometricMeanAggregate.cpp
@@ -105,7 +105,7 @@ void registerGeometricMeanAggregate(
                            .argumentType("real")
                            .build());
 
-  exec::registerAggregateFunctionWithMetadata(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
@@ -366,7 +366,7 @@ void registerHistogramAggregate(
   }
 
   auto name = prefix + kHistogram;
-  exec::registerAggregateFunctionWithMetadata(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
@@ -366,7 +366,7 @@ void registerHistogramAggregate(
   }
 
   auto name = prefix + kHistogram;
-  exec::registerAggregateFunction(
+  exec::registerAggregateFunctionWithMetadata(
       name,
       std::move(signatures),
       [name](
@@ -409,6 +409,7 @@ void registerHistogramAggregate(
                 inputType->kindName());
         }
       },
+      {false /*orderSensitive*/},
       withCompanionFunctions,
       overwrite);
 }

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -929,7 +929,7 @@ exec::AggregateRegistrationResult registerMinMax(
             .build());
   }
 
-  return exec::registerAggregateFunctionWithMetadata(
+  return exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -929,7 +929,7 @@ exec::AggregateRegistrationResult registerMinMax(
             .build());
   }
 
-  return exec::registerAggregateFunction(
+  return exec::registerAggregateFunctionWithMetadata(
       name,
       std::move(signatures),
       [name](
@@ -1014,6 +1014,7 @@ exec::AggregateRegistrationResult registerMinMax(
           }
         }
       },
+      {false /*orderSensitive*/},
       withCompanionFunctions,
       overwrite);
 }

--- a/velox/functions/prestosql/aggregates/ReduceAgg.cpp
+++ b/velox/functions/prestosql/aggregates/ReduceAgg.cpp
@@ -804,7 +804,7 @@ void registerReduceAgg(
 
   const std::string name = prefix + kReduceAgg;
 
-  exec::registerAggregateFunction(
+  exec::registerAggregateFunctionWithMetadata(
       name,
       std::move(signatures),
       [name](
@@ -814,6 +814,7 @@ void registerReduceAgg(
           const core::QueryConfig& config) -> std::unique_ptr<exec::Aggregate> {
         return std::make_unique<ReduceAgg>(resultType);
       },
+      {false /*orderSensitive*/},
       withCompanionFunctions,
       overwrite);
 }

--- a/velox/functions/prestosql/aggregates/ReduceAgg.cpp
+++ b/velox/functions/prestosql/aggregates/ReduceAgg.cpp
@@ -804,7 +804,7 @@ void registerReduceAgg(
 
   const std::string name = prefix + kReduceAgg;
 
-  exec::registerAggregateFunctionWithMetadata(
+  exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/SumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/SumAggregate.cpp
@@ -56,7 +56,7 @@ exec::AggregateRegistrationResult registerSum(
                              .build());
   }
 
-  return exec::registerAggregateFunctionWithMetadata(
+  return exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/SumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/SumAggregate.cpp
@@ -56,7 +56,7 @@ exec::AggregateRegistrationResult registerSum(
                              .build());
   }
 
-  return exec::registerAggregateFunction(
+  return exec::registerAggregateFunctionWithMetadata(
       name,
       std::move(signatures),
       [name](
@@ -111,6 +111,7 @@ exec::AggregateRegistrationResult registerSum(
                 inputType->kindName());
         }
       },
+      {false /*orderSensitive*/},
       withCompanionFunctions,
       overwrite);
 }

--- a/velox/functions/prestosql/aggregates/tests/AggregationFunctionRegTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AggregationFunctionRegTest.cpp
@@ -54,6 +54,54 @@ TEST_F(AggregationFunctionRegTest, prefix) {
   });
 }
 
+TEST_F(AggregationFunctionRegTest, orderSensitive) {
+  // Remove all functions and check for no entries.
+  clearAndCheckRegistry();
+
+  std::set<std::string> nonOrderSensitiveFunctions = {
+      "sum",
+      "avg",
+      "min",
+      "max",
+      "count",
+      "arbitrary",
+      "bool_and",
+      "bool_or",
+      "bitwise_and_agg",
+      "bitwise_or_agg",
+      "every",
+      "checksum",
+      "count_if",
+      "geometric_mean",
+      "histogram",
+      "reduce_agg",
+      "any_value"};
+  aggregate::prestosql::registerAllAggregateFunctions();
+  exec::aggregateFunctions().withRLock([&](const auto& aggrFuncMap) {
+    for (const auto& entry : aggrFuncMap) {
+      if (!entry.second.metadata.orderSensitive) {
+        EXPECT_EQ(1, nonOrderSensitiveFunctions.erase(entry.first));
+      }
+    }
+  });
+  EXPECT_EQ(0, nonOrderSensitiveFunctions.size());
+
+  // Test some but not all order sensitive functions
+  std::set<std::string> orderSensitiveFunctions = {
+      "array_agg",
+      "map_agg",
+      "map_union",
+      "set_agg"};
+  exec::aggregateFunctions().withRLock([&](const auto& aggrFuncMap) {
+    for (const auto& entry : aggrFuncMap) {
+      if (entry.second.metadata.orderSensitive) {
+        orderSensitiveFunctions.erase(entry.first);
+      }
+    }
+  });
+  EXPECT_EQ(0, orderSensitiveFunctions.size());
+}
+
 TEST_F(AggregationFunctionRegTest, prestoSupportedSignatures) {
   // Remove all functions and check for no entries.
   clearAndCheckRegistry();

--- a/velox/functions/prestosql/aggregates/tests/AggregationFunctionRegTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AggregationFunctionRegTest.cpp
@@ -88,10 +88,7 @@ TEST_F(AggregationFunctionRegTest, orderSensitive) {
 
   // Test some but not all order sensitive functions
   std::set<std::string> orderSensitiveFunctions = {
-      "array_agg",
-      "map_agg",
-      "map_union",
-      "set_agg"};
+      "array_agg", "map_agg", "map_union", "set_agg"};
   exec::aggregateFunctions().withRLock([&](const auto& aggrFuncMap) {
     for (const auto& entry : aggrFuncMap) {
       if (entry.second.metadata.orderSensitive) {


### PR DESCRIPTION
Extend aggregate function registry to add order-sensitive flag per function.

Update HashAggregation operator to ignore sorting inputs when computing
functions are not order sensitive. This is equivalent to rewriting sum(x ORDER
BY y) into sum(x).

Mark the following Presto functions as not order-sensitive:

avg
bitwise_xxx
bool_xxx
checksum
count
count_if
geometric_mean
histogram
min
max
reduce_agg
sum