### PR TITLE
Simplify the row number spill control logic

### DIFF
--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -460,17 +460,23 @@ bool underMemoryArbitration() {
   return memoryArbitrationContext() != nullptr;
 }
 
-void testingRunArbitration(uint64_t targetBytes, MemoryManager* manager) {
+void testingRunArbitration(
+    uint64_t targetBytes,
+    bool allowSpill,
+    MemoryManager* manager) {
   if (manager == nullptr) {
     manager = memory::memoryManager();
   }
-  manager->shrinkPools(targetBytes);
+  manager->shrinkPools(targetBytes, allowSpill);
 }
 
-void testingRunArbitration(MemoryPool* pool, uint64_t targetBytes) {
+void testingRunArbitration(
+    MemoryPool* pool,
+    uint64_t targetBytes,
+    bool allowSpill) {
   pool->enterArbitration();
   static_cast<MemoryPoolImpl*>(pool)->testingManager()->shrinkPools(
-      targetBytes);
+      targetBytes, allowSpill);
   pool->leaveArbitration();
 }
 } // namespace facebook::velox::memory

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -433,14 +433,20 @@ bool underMemoryArbitration();
 /// The function triggers memory arbitration by shrinking memory pools from
 /// 'manager' by invoking shrinkPools API. If 'manager' is not set, then it
 /// shrinks from the process wide memory manager. If 'targetBytes' is zero, then
-/// reclaims all the memory from 'manager' if possible.
+/// it reclaims all the memory from 'manager' if possible. If 'allowSpill' is
+/// true, then it allows to reclaim the used memory by spilling.
 class MemoryManager;
 void testingRunArbitration(
     uint64_t targetBytes = 0,
+    bool allowSpill = true,
     MemoryManager* manager = nullptr);
 
 /// The function triggers memory arbitration by shrinking memory pools from
 /// 'manager' of 'pool' by invoking its shrinkPools API. If 'targetBytes' is
-/// zero, then reclaims all the memory from 'manager' if possible.
-void testingRunArbitration(MemoryPool* pool, uint64_t targetBytes = 0);
+/// zero, then it reclaims all the memory from 'manager' if possible. If
+/// 'allowSpill' is true, then it allows to reclaim the used memory by spilling.
+void testingRunArbitration(
+    MemoryPool* pool,
+    uint64_t targetBytes = 0,
+    bool allowSpill = true);
 } // namespace facebook::velox::memory

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -422,7 +422,6 @@ void HashBuild::ensureInputFits(RowVectorPtr& input) {
   // is already sufficient reservations.
   VELOX_CHECK(spillEnabled());
 
-  Operator::ReclaimableSectionGuard guard(this);
   auto* rows = table_->rows();
   const auto numRows = rows->numRows();
 
@@ -436,6 +435,7 @@ void HashBuild::ensureInputFits(RowVectorPtr& input) {
   if (numRows != 0) {
     // Test-only spill path.
     if (testingTriggerSpill()) {
+      Operator::ReclaimableSectionGuard guard(this);
       memory::testingRunArbitration(pool());
       // NOTE: the memory arbitration should have triggered spilling on this
       // hash build operator so we return true to indicate have enough memory.
@@ -479,11 +479,16 @@ void HashBuild::ensureInputFits(RowVectorPtr& input) {
       incrementBytes * 2,
       currentUsage * spillConfig_->spillableReservationGrowthPct / 100);
 
-  if (!pool()->maybeReserve(targetIncrementBytes)) {
-    LOG(WARNING) << "Failed to reserve " << succinctBytes(targetIncrementBytes)
-                 << " for memory pool " << pool()->name()
-                 << ", usage: " << succinctBytes(pool()->currentBytes())
-                 << ", reservation: " << succinctBytes(pool()->reservedBytes());
+  {
+    Operator::ReclaimableSectionGuard guard(this);
+    if (!pool()->maybeReserve(targetIncrementBytes)) {
+      LOG(WARNING) << "Failed to reserve "
+                   << succinctBytes(targetIncrementBytes) << " for memory pool "
+                   << pool()->name()
+                   << ", usage: " << succinctBytes(pool()->currentBytes())
+                   << ", reservation: "
+                   << succinctBytes(pool()->reservedBytes());
+    }
   }
 }
 

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -296,7 +296,6 @@ void Operator::recordBlockingTime(uint64_t start, BlockingReason reason) {
 }
 
 void Operator::recordSpillStats(const common::SpillStats& spillStats) {
-  VELOX_CHECK(noMoreInput_);
   auto lockedStats = stats_.wlock();
   lockedStats->spilledInputBytes += spillStats.spilledInputBytes;
   lockedStats->spilledBytes += spillStats.spilledBytes;

--- a/velox/exec/RowNumber.h
+++ b/velox/exec/RowNumber.h
@@ -56,9 +56,7 @@ class RowNumber : public Operator {
     return spillConfig_.has_value();
   }
 
-  void setupHashTableSpiller();
-
-  void setupInputSpiller();
+  void setupInputSpiller(const SpillPartitionNumSet& spillPartitionSet);
 
   void ensureInputFits(const RowVectorPtr& input);
 
@@ -69,6 +67,8 @@ class RowNumber : public Operator {
   void addSpillInput();
 
   void restoreNextSpillPartition();
+
+  SpillPartitionNumSet spillHashTable();
 
   int64_t numRows(char* partition);
 
@@ -98,8 +98,9 @@ class RowNumber : public Operator {
 
   RowTypePtr inputType_;
 
-  // Spiller for contents of the HashTable,
-  std::unique_ptr<Spiller> hashTableSpiller_;
+  // The spill partition bits used by both hash table content spill and input
+  // data spill.
+  HashBitRange spillPartitionBits_;
 
   // Used to restore previously spilled hash table.
   std::unique_ptr<UnorderedStreamReader<BatchStream>> spillHashTableReader_;

--- a/velox/exec/tests/RowNumberTest.cpp
+++ b/velox/exec/tests/RowNumberTest.cpp
@@ -24,6 +24,11 @@ namespace facebook::velox::exec::test {
 
 class RowNumberTest : public OperatorTestBase {
  protected:
+  static void SetUpTestCase() {
+    FLAGS_velox_testing_enable_arbitration = true;
+    OperatorTestBase::SetUpTestCase();
+  }
+
   RowNumberTest() {
     filesystems::registerLocalFileSystem();
   }


### PR DESCRIPTION
Simplify the hash table spill control logic in row number by removing the noMoreInput
limit in Operator::recordSpillStats which is too strict as we have to hold a spiller until
the operator receives the no more input signal even though the spiller has already been
done like hash table spill which finishes in row number spill.