### PR TITLE
Support reading Iceberg tables with equality delete files

### DIFF
--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -173,7 +173,10 @@ std::unique_ptr<SplitReader> HiveDataSource::createSplitReader() {
       ioStats_,
       fileHandleFactory_,
       executor_,
-      scanSpec_);
+      scanSpec_,
+      remainingFilterExprSet_,
+      expressionEvaluator_,
+      totalRemainingFilterTime_);
 }
 
 void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
@@ -190,8 +193,10 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
   }
 
   splitReader_ = createSplitReader();
+
   // Split reader subclasses may need to use the reader options in prepareSplit
   // so we initialize it beforehand.
+
   splitReader_->configureReaderOptions(randomSkip_);
   splitReader_->prepareSplit(metadataFilter_, runtimeStats_);
 }
@@ -391,6 +396,7 @@ std::shared_ptr<wave::WaveDataSource> HiveDataSource::toWaveDataSource() {
 void HiveDataSource::registerWaveDelegateHook(WaveDelegateHookFunction hook) {
   waveDelegateHook_ = hook;
 }
+
 std::shared_ptr<wave::WaveDataSource> toWaveDataSource();
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveDataSource.h
+++ b/velox/connectors/hive/HiveDataSource.h
@@ -146,7 +146,7 @@ class HiveDataSource : public DataSource {
   std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>
       infoColumns_;
   std::shared_ptr<common::MetadataFilter> metadataFilter_;
-  std::unique_ptr<exec::ExprSet> remainingFilterExprSet_;
+  std::shared_ptr<exec::ExprSet> remainingFilterExprSet_;
   RowVectorPtr emptyOutput_;
   dwio::common::RuntimeStatistics runtimeStats_;
   std::atomic<uint64_t> totalRemainingFilterTime_{0};

--- a/velox/connectors/hive/SplitReader.h
+++ b/velox/connectors/hive/SplitReader.h
@@ -65,7 +65,10 @@ class SplitReader {
       const std::shared_ptr<io::IoStatistics>& ioStats,
       FileHandleFactory* fileHandleFactory,
       folly::Executor* executor,
-      const std::shared_ptr<common::ScanSpec>& scanSpec);
+      const std::shared_ptr<common::ScanSpec>& scanSpec,
+      std::shared_ptr<exec::ExprSet>& remainingFilterExprSet,
+      core::ExpressionEvaluator* expressionEvaluator,
+      std::atomic<uint64_t>& totalRemainingFilterTime);
 
   SplitReader(
       const std::shared_ptr<const hive::HiveConnectorSplit>& hiveSplit,
@@ -100,6 +103,8 @@ class SplitReader {
   bool emptySplit() const;
 
   void resetSplit();
+
+  std::shared_ptr<const dwio::common::TypeWithId> baseFileSchema();
 
   int64_t estimatedRowSize() const;
 

--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 add_library(
-  velox_hive_iceberg_splitreader IcebergSplitReader.cpp IcebergSplit.cpp
-                                 PositionalDeleteFileReader.cpp)
+  velox_hive_iceberg_splitreader
+  IcebergSplitReader.cpp IcebergSplit.cpp PositionalDeleteFileReader.cpp
+  EqualityDeleteFileReader.cpp FilterUtil.cpp)
 
 target_link_libraries(velox_hive_iceberg_splitreader velox_connector
                       Folly::folly)

--- a/velox/connectors/hive/iceberg/EqualityDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/EqualityDeleteFileReader.cpp
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/EqualityDeleteFileReader.h"
+
+#include "velox/connectors/hive/HiveConnectorUtil.h"
+#include "velox/connectors/hive/iceberg/FilterUtil.h"
+#include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
+#include "velox/dwio/common/ReaderFactory.h"
+#include "velox/dwio/common/TypeUtils.h"
+
+using namespace facebook::velox::common;
+using namespace facebook::velox::core;
+using namespace facebook::velox::exec;
+
+namespace facebook::velox::connector::hive::iceberg {
+
+static constexpr const int kMaxBatchRows = 10'000;
+
+EqualityDeleteFileReader::EqualityDeleteFileReader(
+    const IcebergDeleteFile& deleteFile,
+    std::shared_ptr<const dwio::common::TypeWithId> baseFileSchema,
+    FileHandleFactory* fileHandleFactory,
+    folly::Executor* executor,
+    const ConnectorQueryCtx* connectorQueryCtx,
+    const std::shared_ptr<const HiveConfig> hiveConfig,
+    std::shared_ptr<io::IoStatistics> ioStats,
+    dwio::common::RuntimeStatistics& runtimeStats,
+    const std::string& connectorId)
+    : deleteFile_(deleteFile),
+      baseFileSchema_(baseFileSchema),
+      connectorQueryCtx_(connectorQueryCtx),
+      hiveConfig_(hiveConfig),
+      deleteSplit_(nullptr),
+      fileHandleFactory_(fileHandleFactory),
+      executor_(executor),
+      pool_(connectorQueryCtx->memoryPool()),
+      ioStats_(ioStats),
+      deleteRowReader_(nullptr) {
+  VELOX_CHECK(deleteFile_.content == FileContent::kEqualityDeletes);
+
+  if (deleteFile_.recordCount == 0) {
+    return;
+  }
+
+  std::unordered_set<int32_t> equalityFieldIds(
+      deleteFile_.equalityFieldIds.begin(), deleteFile_.equalityFieldIds.end());
+  auto deleteFieldSelector = [&equalityFieldIds](size_t index) {
+    return equalityFieldIds.find(static_cast<int32_t>(index)) !=
+        equalityFieldIds.end();
+  };
+  auto deleteFileSchema = dwio::common::typeutils::buildSelectedType(
+      baseFileSchema_, deleteFieldSelector);
+
+  rowType_ = std::static_pointer_cast<const RowType>(deleteFileSchema->type());
+
+  // TODO: push down filter if previous delete file contains this one. E.g.
+  // previous equality delete file has a=1, and this file also contains
+  // columns a, then a!=1 can be pushed as a filter when reading this delete
+  // file.
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("<root>");
+  scanSpec->addAllChildFields(rowType_->asRow());
+
+  deleteSplit_ = std::make_shared<HiveConnectorSplit>(
+      connectorId,
+      deleteFile_.filePath,
+      deleteFile_.fileFormat,
+      0,
+      deleteFile_.fileSizeInBytes);
+
+  // Create the Reader and RowReader
+
+  dwio::common::ReaderOptions deleteReaderOpts(pool_);
+  configureReaderOptions(
+      deleteReaderOpts,
+      hiveConfig_,
+      connectorQueryCtx_->sessionProperties(),
+      rowType_,
+      deleteSplit_);
+
+  auto deleteFileHandle =
+      fileHandleFactory_->generate(deleteFile_.filePath).second;
+  auto deleteFileInput = createBufferedInput(
+      *deleteFileHandle,
+      deleteReaderOpts,
+      connectorQueryCtx_,
+      ioStats_,
+      executor_);
+
+  auto deleteReader =
+      dwio::common::getReaderFactory(deleteReaderOpts.getFileFormat())
+          ->createReader(std::move(deleteFileInput), deleteReaderOpts);
+
+  dwio::common::RowReaderOptions deleteRowReaderOpts;
+  configureRowReaderOptions(
+      deleteRowReaderOpts, {}, scanSpec, nullptr, rowType_, deleteSplit_);
+
+  deleteRowReader_.reset();
+  deleteRowReader_ = deleteReader->createRowReader(deleteRowReaderOpts);
+}
+
+void EqualityDeleteFileReader::readDeleteValues(
+    SubfieldFilters& subfieldFilters,
+    std::vector<core::TypedExprPtr>& expressionInputs) {
+  VELOX_CHECK(deleteRowReader_);
+  VELOX_CHECK(deleteSplit_);
+
+  if (!deleteValuesOutput_) {
+    deleteValuesOutput_ = BaseVector::create(rowType_, 0, pool_);
+  }
+
+  // TODO:: verfiy if the field is a sub-field. Velox currently doesn't support
+  // pushing down filters to sub-fields
+  if (rowType_->size() == 1) {
+    // Construct the IN list filter that can be pushed down to the base file
+    // readers, then update the baseFileScanSpec.
+    readSingleColumnDeleteValues(subfieldFilters);
+  } else {
+    readMultipleColumnDeleteValues(expressionInputs);
+  }
+
+  deleteSplit_.reset();
+}
+
+void EqualityDeleteFileReader::readSingleColumnDeleteValues(
+    SubfieldFilters& subfieldFilters) {
+  std::unique_ptr<Filter> filter = std::make_unique<AlwaysTrue>();
+  while (deleteRowReader_->next(kMaxBatchRows, deleteValuesOutput_)) {
+    if (deleteValuesOutput_->size() == 0) {
+      continue;
+    }
+
+    deleteValuesOutput_->loadedVector();
+    auto vector =
+        std::dynamic_pointer_cast<RowVector>(deleteValuesOutput_)->childAt(0);
+    auto name = rowType_->nameOf(0);
+
+    auto typeKind = vector->type()->kind();
+    VELOX_CHECK(
+        typeKind != TypeKind::DOUBLE && typeKind != TypeKind::REAL,
+        "Iceberg does not allow DOUBLE or REAL columns as the equality delete columns: {} : {}",
+        name,
+        typeKind);
+
+    auto notExistsFilter =
+        createNotExistsFilter(vector, 0, deleteValuesOutput_->size(), typeKind);
+    filter = filter->mergeWith(notExistsFilter.get());
+  }
+
+  if (filter->kind() != FilterKind::kAlwaysTrue) {
+    if (subfieldFilters.find(common::Subfield(rowType_->nameOf(0))) !=
+        subfieldFilters.end()) {
+      subfieldFilters[common::Subfield(rowType_->nameOf(0))] =
+          subfieldFilters[common::Subfield(rowType_->nameOf(0))]->mergeWith(
+              filter.get());
+    } else {
+      subfieldFilters[common::Subfield(rowType_->nameOf(0))] =
+          std::move(filter);
+    }
+  }
+}
+
+void EqualityDeleteFileReader::readMultipleColumnDeleteValues(
+    std::vector<core::TypedExprPtr>& expressionInputs) {
+  auto numDeleteFields = rowType_->size();
+  VELOX_CHECK_GT(
+      numDeleteFields,
+      0,
+      "Iceberg equality delete file should have at least one field.");
+
+  // TODO: logical expression simplifications
+  while (deleteRowReader_->next(kMaxBatchRows, deleteValuesOutput_)) {
+    if (deleteValuesOutput_->size() == 0) {
+      continue;
+    }
+
+    deleteValuesOutput_->loadedVector();
+    auto rowVector = std::dynamic_pointer_cast<RowVector>(deleteValuesOutput_);
+    auto numDeletedValues = rowVector->childAt(0)->size();
+
+    for (int i = 0; i < numDeletedValues; i++) {
+      std::vector<core::TypedExprPtr> disconjunctInputs;
+
+      for (int j = 0; j < numDeleteFields; j++) {
+        auto type = rowType_->childAt(j);
+        auto name = rowType_->nameOf(j);
+        auto value = BaseVector::wrapInConstant(1, i, rowVector->childAt(j));
+
+        std::vector<core::TypedExprPtr> isNotEqualInputs;
+        isNotEqualInputs.push_back(
+            std::make_shared<FieldAccessTypedExpr>(type, name));
+        isNotEqualInputs.push_back(std::make_shared<ConstantTypedExpr>(value));
+        auto isNotEqualExpr =
+            std::make_shared<CallTypedExpr>(BOOLEAN(), isNotEqualInputs, "neq");
+
+        disconjunctInputs.push_back(isNotEqualExpr);
+      }
+
+      auto disconjunctNotEqualExpr =
+          std::make_shared<CallTypedExpr>(BOOLEAN(), disconjunctInputs, "or");
+      expressionInputs.push_back(disconjunctNotEqualExpr);
+    }
+  }
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/EqualityDeleteFileReader.h
+++ b/velox/connectors/hive/iceberg/EqualityDeleteFileReader.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/connectors/Connector.h"
+#include "velox/connectors/hive/FileHandle.h"
+#include "velox/connectors/hive/HiveConfig.h"
+#include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/dwio/common/Reader.h"
+#include "velox/expression/Expr.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+class IcebergDeleteFile;
+
+using SubfieldFilters =
+    std::unordered_map<common::Subfield, std::unique_ptr<common::Filter>>;
+
+class EqualityDeleteFileReader {
+ public:
+  EqualityDeleteFileReader(
+      const IcebergDeleteFile& deleteFile,
+      std::shared_ptr<const dwio::common::TypeWithId> baseFileSchema,
+      FileHandleFactory* fileHandleFactory,
+      folly::Executor* executor,
+      const ConnectorQueryCtx* connectorQueryCtx,
+      const std::shared_ptr<const HiveConfig> hiveConfig,
+      std::shared_ptr<io::IoStatistics> ioStats,
+      dwio::common::RuntimeStatistics& runtimeStats,
+      const std::string& connectorId);
+
+  void readDeleteValues(
+      SubfieldFilters& subfieldFilters,
+      std::vector<core::TypedExprPtr>& typedExpressions);
+
+ private:
+  void readSingleColumnDeleteValues(SubfieldFilters& subfieldFilters);
+
+  void readMultipleColumnDeleteValues(
+      std::vector<core::TypedExprPtr>& expressionInputs);
+
+  const IcebergDeleteFile& deleteFile_;
+  const std::shared_ptr<const dwio::common::TypeWithId> baseFileSchema_;
+  const ConnectorQueryCtx* const connectorQueryCtx_;
+  const std::shared_ptr<const HiveConfig> hiveConfig_;
+  std::shared_ptr<const HiveConnectorSplit> deleteSplit_;
+
+  FileHandleFactory* const fileHandleFactory_;
+  folly::Executor* const executor_;
+  memory::MemoryPool* const pool_;
+  const std::shared_ptr<io::IoStatistics> ioStats_;
+
+  RowTypePtr rowType_;
+  std::unique_ptr<dwio::common::RowReader> deleteRowReader_;
+  VectorPtr deleteValuesOutput_;
+};
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/FilterUtil.cpp
+++ b/velox/connectors/hive/iceberg/FilterUtil.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/connectors/hive/iceberg/FilterUtil.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+using namespace facebook::velox::exec;
+using namespace facebook::velox::core;
+
+// Read 'size' values from 'valuesVector' starting at 'offset', de-duplicate
+// remove nulls and sort. Return a list of unique non-null values sorted in
+// ascending order and a boolean indicating whether there were any null values.
+template <typename T, typename U = T>
+std::pair<std::vector<T>, bool> toValues(
+    const VectorPtr& valuesVector,
+    vector_size_t offset,
+    vector_size_t size) {
+  auto simpleValues = valuesVector->as<SimpleVector<U>>();
+
+  bool nullAllowed = false;
+  std::vector<T> values;
+  values.reserve(size);
+
+  for (auto i = offset; i < offset + size; i++) {
+    if (simpleValues->isNullAt(i)) {
+      nullAllowed = true;
+    } else {
+      if constexpr (std::is_same_v<U, Timestamp>) {
+        values.emplace_back(simpleValues->valueAt(i).toMillis());
+      } else {
+        values.emplace_back(simpleValues->valueAt(i));
+      }
+    }
+  }
+
+  // In-place sort, remove duplicates, and later std::move to save memory
+  std::sort(values.begin(), values.end());
+  auto last = std::unique(values.begin(), values.end());
+  values.resize(std::distance(values.begin(), last));
+
+  return {std::move(values), nullAllowed};
+}
+
+template <typename T>
+std::unique_ptr<common::Filter> createNegatedBigintValuesFilter(
+    const VectorPtr& valuesVector,
+    vector_size_t offset,
+    vector_size_t size) {
+  auto valuesPair = toValues<int64_t, T>(valuesVector, offset, size);
+
+  const auto& values = valuesPair.first;
+  bool hasNull = valuesPair.second;
+
+  return common::createNegatedBigintValues(values, !hasNull);
+}
+
+std::unique_ptr<common::Filter> createNotExistsFilter(
+    const VectorPtr& elements,
+    vector_size_t offset,
+    vector_size_t size,
+    const TypeKind& type) {
+  std::unique_ptr<common::Filter> filter;
+  switch (type) {
+    case TypeKind::HUGEINT:
+      // TODO: createNegatedHugeintValuesFilter is not implemented yet.
+      VELOX_NYI("createNegatedHugeintValuesFilter is not implemented yet");
+    case TypeKind::BIGINT:
+      filter = createNegatedBigintValuesFilter<int64_t>(elements, offset, size);
+      break;
+    case TypeKind::INTEGER:
+      filter = createNegatedBigintValuesFilter<int32_t>(elements, offset, size);
+      break;
+    case TypeKind::SMALLINT:
+      filter = createNegatedBigintValuesFilter<int16_t>(elements, offset, size);
+      break;
+    case TypeKind::TINYINT:
+      filter = createNegatedBigintValuesFilter<int8_t>(elements, offset, size);
+      break;
+    case TypeKind::BOOLEAN:
+      // Hack: using BIGINT filter for bool, which is essentially "int1_t".
+      filter = createNegatedBigintValuesFilter<bool>(elements, offset, size);
+      break;
+    case TypeKind::TIMESTAMP:
+      filter =
+          createNegatedBigintValuesFilter<Timestamp>(elements, offset, size);
+      break;
+    case TypeKind::VARCHAR:
+    case TypeKind::VARBINARY:
+      // TODO: createNegatedBytesValuesFilter is not implemented yet.
+      VELOX_NYI("createNegatedBytesValuesFilter is not implemented yet");
+    case TypeKind::REAL:
+    case TypeKind::DOUBLE:
+      VELOX_USER_FAIL(
+          "Iceberg equality delete column cannot be DOUBLE or FLOAT");
+    case TypeKind::UNKNOWN:
+      [[fallthrough]];
+    case TypeKind::ARRAY:
+      [[fallthrough]];
+    case TypeKind::MAP:
+      [[fallthrough]];
+    case TypeKind::ROW:
+      [[fallthrough]];
+    default:
+      VELOX_UNSUPPORTED(
+          "Unsupported in-list type {} for NOT EXIST predicate", type);
+  }
+  return filter;
+}
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/FilterUtil.h
+++ b/velox/connectors/hive/iceberg/FilterUtil.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/expression/Expr.h"
+#include "velox/type/Filter.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+std::unique_ptr<common::Filter> createNotExistsFilter(
+    const VectorPtr& elements,
+    vector_size_t offset,
+    vector_size_t size,
+    const TypeKind& type);
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -16,11 +16,13 @@
 
 #include "velox/connectors/hive/iceberg/IcebergSplitReader.h"
 
+#include "velox/connectors/hive/iceberg/EqualityDeleteFileReader.h"
 #include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/dwio/common/BufferUtil.h"
 
 using namespace facebook::velox::dwio::common;
+using namespace facebook::velox::exec;
 
 namespace facebook::velox::connector::hive::iceberg {
 
@@ -35,7 +37,10 @@ IcebergSplitReader::IcebergSplitReader(
     const std::shared_ptr<io::IoStatistics>& ioStats,
     FileHandleFactory* const fileHandleFactory,
     folly::Executor* executor,
-    const std::shared_ptr<common::ScanSpec>& scanSpec)
+    const std::shared_ptr<common::ScanSpec>& scanSpec,
+    std::shared_ptr<exec::ExprSet>& remainingFilterExprSet,
+    core::ExpressionEvaluator* expressionEvaluator,
+    std::atomic<uint64_t>& totalRemainingFilterTime)
     : SplitReader(
           hiveSplit,
           hiveTableHandle,
@@ -47,8 +52,18 @@ IcebergSplitReader::IcebergSplitReader(
           fileHandleFactory,
           executor,
           scanSpec),
+      originalScanSpec_(nullptr),
       baseReadOffset_(0),
-      splitOffset_(0) {}
+      splitOffset_(0),
+      deleteExprSet_(nullptr),
+      expressionEvaluator_(expressionEvaluator),
+      totalRemainingFilterTime_(totalRemainingFilterTime) {}
+
+IcebergSplitReader::~IcebergSplitReader() {
+  if (originalScanSpec_) {
+    *scanSpec_ = *originalScanSpec_;
+  }
+}
 
 void IcebergSplitReader::prepareSplit(
     std::shared_ptr<common::MetadataFilter> metadataFilter,
@@ -60,15 +75,63 @@ void IcebergSplitReader::prepareSplit(
     return;
   }
 
-  createRowReader(metadataFilter);
-
   std::shared_ptr<const HiveIcebergSplit> icebergSplit =
       std::dynamic_pointer_cast<const HiveIcebergSplit>(hiveSplit_);
+  const auto& deleteFiles = icebergSplit->deleteFiles;
+
+  // Process the equality delete files to update the scan spec and remaining
+  // filters. It needs to be done after creating the Reader and before creating
+  // the RowReader.
+
+  SubfieldFilters subfieldFilters;
+  std::vector<core::TypedExprPtr> conjunctInputs;
+
+  for (const auto& deleteFile : deleteFiles) {
+    if (deleteFile.content == FileContent::kEqualityDeletes &&
+        deleteFile.recordCount > 0) {
+      // TODO: build cache of <Partition, ExprSet> to avoid repeating file
+      // parsing across partitions. Within a single partition, the splits should
+      // be with the same equality delete files and only need to be parsed once.
+      auto equalityDeleteReader = std::make_unique<EqualityDeleteFileReader>(
+          deleteFile,
+          baseFileSchema(),
+          fileHandleFactory_,
+          executor_,
+          connectorQueryCtx_,
+          hiveConfig_,
+          ioStats_,
+          runtimeStats,
+          hiveSplit_->connectorId);
+      equalityDeleteReader->readDeleteValues(subfieldFilters, conjunctInputs);
+    }
+  }
+
+  if (!subfieldFilters.empty()) {
+    originalScanSpec_ = scanSpec_->clone();
+
+    for (auto iter = subfieldFilters.begin(); iter != subfieldFilters.end();
+         iter++) {
+      auto childSpec = scanSpec_->getOrCreateChild(iter->first);
+      childSpec->addFilter(*iter->second);
+      childSpec->setSubscript(scanSpec_->children().size() - 1);
+    }
+  }
+
+  if (!conjunctInputs.empty()) {
+    core::TypedExprPtr expression =
+        std::make_shared<core::CallTypedExpr>(BOOLEAN(), conjunctInputs, "and");
+    deleteExprSet_ = expressionEvaluator_->compile(expression);
+    VELOX_CHECK_EQ(deleteExprSet_->size(), 1);
+  }
+
+  createRowReader(metadataFilter);
+
   baseReadOffset_ = 0;
   splitOffset_ = baseRowReader_->nextRowNumber();
-  positionalDeleteFileReaders_.clear();
 
-  const auto& deleteFiles = icebergSplit->deleteFiles;
+  // Create the positional deletes file readers. They need to be created after
+  // the RowReader is created.
+  positionalDeleteFileReaders_.clear();
   for (const auto& deleteFile : deleteFiles) {
     if (deleteFile.content == FileContent::kPositionalDeletes) {
       if (deleteFile.recordCount > 0) {
@@ -85,8 +148,6 @@ void IcebergSplitReader::prepareSplit(
                 splitOffset_,
                 hiveSplit_->connectorId));
       }
-    } else {
-      VELOX_NYI();
     }
   }
 }
@@ -118,6 +179,29 @@ uint64_t IcebergSplitReader::next(uint64_t size, VectorPtr& output) {
   }
 
   auto rowsScanned = baseRowReader_->next(size, output, &mutation);
+
+  // Evaluate the remaining filter deleteExprSet_ for every batch and update the
+  // output vector if it reduces any rows.
+  if (deleteExprSet_) {
+    auto filterStartMicros = getCurrentTimeMicro();
+
+    filterRows_.resize(output->size());
+    auto rowVector = std::dynamic_pointer_cast<RowVector>(output);
+    expressionEvaluator_->evaluate(
+        deleteExprSet_.get(), filterRows_, *rowVector, filterResult_);
+    auto numRemainingRows = exec::processFilterResults(
+        filterResult_, filterRows_, filterEvalCtx_, pool_);
+
+    if (numRemainingRows < output->size()) {
+      output = exec::wrap(
+          numRemainingRows, filterEvalCtx_.selectedIndices, rowVector);
+    }
+
+    totalRemainingFilterTime_.fetch_add(
+        (getCurrentTimeMicro() - filterStartMicros) * 1000,
+        std::memory_order_relaxed);
+  }
+
   baseReadOffset_ += rowsScanned;
 
   return rowsScanned;

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -19,6 +19,7 @@
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/hive/SplitReader.h"
 #include "velox/connectors/hive/iceberg/PositionalDeleteFileReader.h"
+#include "velox/exec/OperatorUtils.h"
 
 namespace facebook::velox::connector::hive::iceberg {
 
@@ -37,9 +38,12 @@ class IcebergSplitReader : public SplitReader {
       const std::shared_ptr<io::IoStatistics>& ioStats,
       FileHandleFactory* fileHandleFactory,
       folly::Executor* executor,
-      const std::shared_ptr<common::ScanSpec>& scanSpec);
+      const std::shared_ptr<common::ScanSpec>& scanSpec,
+      std::shared_ptr<exec::ExprSet>& remainingFilterExprSet,
+      core::ExpressionEvaluator* expressionEvaluator,
+      std::atomic<uint64_t>& totalRemainingFilterTime);
 
-  ~IcebergSplitReader() override = default;
+  ~IcebergSplitReader() override;
 
   void prepareSplit(
       std::shared_ptr<common::MetadataFilter> metadataFilter,
@@ -48,6 +52,11 @@ class IcebergSplitReader : public SplitReader {
   uint64_t next(uint64_t size, VectorPtr& output) override;
 
  private:
+  // The ScanSpec may need to be updated for different partitions if the split
+  // comes with single column equality delete files. So we need to keep a copy
+  // of the original ScanSpec.
+  std::shared_ptr<common::ScanSpec> originalScanSpec_;
+
   // The read offset to the beginning of the split in number of rows for the
   // current batch for the base data file
   uint64_t baseReadOffset_;
@@ -58,5 +67,13 @@ class IcebergSplitReader : public SplitReader {
   std::list<std::unique_ptr<PositionalDeleteFileReader>>
       positionalDeleteFileReaders_;
   BufferPtr deleteBitmap_;
+  std::unique_ptr<exec::ExprSet> deleteExprSet_;
+  core::ExpressionEvaluator* expressionEvaluator_;
+  std::atomic<uint64_t>& totalRemainingFilterTime_;
+
+  // Reusable memory for remaining filter evaluation.
+  VectorPtr filterResult_;
+  SelectivityVector filterRows_;
+  exec::FilterEvalCtx filterEvalCtx_;
 };
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/dwio/common/ScanSpec.h
+++ b/velox/dwio/common/ScanSpec.h
@@ -56,6 +56,14 @@ class ScanSpec {
 
   explicit ScanSpec(const std::string& name) : fieldName_(name) {}
 
+  ScanSpec(const ScanSpec& other) {
+    *this = other;
+  }
+
+  ScanSpec& operator=(const ScanSpec&);
+
+  std::shared_ptr<ScanSpec> clone();
+
   // Filter to apply. If 'this' corresponds to a struct/list/map, this
   // can only be isNull or isNotNull, other filtering is given by
   // 'children'.
@@ -356,7 +364,7 @@ class ScanSpec {
   // True if a string dictionary or flat map in this field should be
   // returned as flat.
   bool makeFlat_ = false;
-  std::unique_ptr<common::Filter> filter_;
+  std::shared_ptr<common::Filter> filter_;
 
   // Filters that will be only used for row group filtering based on metadata.
   // The conjunctions among these filters are tracked in MetadataFilter, with

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1761,6 +1761,27 @@ ExprSet::ExprSet(
   }
 }
 
+ExprSet::ExprSet(
+    const std::vector<std::shared_ptr<Expr>>& sources,
+    core::ExecCtx* execCtx)
+    : execCtx_(execCtx) {
+  clear();
+  exprs_ = sources;
+  std::vector<FieldReference*> allDistinctFields;
+  for (auto& expr : exprs_) {
+    Expr::mergeFields(
+        distinctFields_, multiplyReferencedFields_, expr->distinctFields());
+  }
+}
+
+void ExprSet::operator=(const ExprSet& another) {
+  exprs_ = another.exprs_;
+  distinctFields_ = another.distinctFields_;
+  multiplyReferencedFields_ = another.multiplyReferencedFields_;
+  toReset_ = another.toReset_;
+  memoizingExprs_ = another.memoizingExprs_;
+}
+
 namespace {
 void addStats(
     const exec::Expr& expr,

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -45,7 +45,9 @@ DECLARE_string(velox_save_input_on_expression_system_failure_path);
 namespace facebook::velox::exec {
 
 class ExprSet;
+
 class FieldReference;
+
 class VectorFunction;
 
 struct ExprStats {
@@ -672,6 +674,12 @@ class ExprSet {
       const std::vector<core::TypedExprPtr>& source,
       core::ExecCtx* execCtx,
       bool enableConstantFolding = true);
+
+  ExprSet(
+      const std::vector<std::shared_ptr<Expr>>& sources,
+      core::ExecCtx* execCtx);
+
+  void operator=(const ExprSet& another);
 
   virtual ~ExprSet();
 

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -999,7 +999,7 @@ VectorPtr testVariadicArgReuse(
 
   // Create a dummy EvalCtx.
   SelectivityVector rows(inputs[0]->size());
-  exec::ExprSet exprSet({}, execCtx);
+  exec::ExprSet exprSet(std::vector<core::TypedExprPtr>{}, execCtx);
   RowVectorPtr inputRows = vectorMaker.rowVector({});
   exec::EvalCtx evalCtx(execCtx, &exprSet, inputRows.get());
 

--- a/velox/functions/prestosql/tests/ElementAtTest.cpp
+++ b/velox/functions/prestosql/tests/ElementAtTest.cpp
@@ -971,7 +971,7 @@ TEST_F(ElementAtTest, testCachingOptimzation) {
   }
 
   // Make a dummy eval context.
-  exec::ExprSet exprSet({}, &execCtx_);
+  exec::ExprSet exprSet(std::vector<core::TypedExprPtr>{}, &execCtx_);
   auto inputs = makeRowVector({});
   exec::EvalCtx evalCtx(&execCtx_, &exprSet, inputs.get());
 

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -1242,7 +1242,7 @@ void StringFunctionsTest::testReplaceInPlace(
     auto replaceFunction =
         exec::getVectorFunction("replace", {VARCHAR(), VARCHAR()}, {}, config);
     SelectivityVector rows(tests.size());
-    ExprSet exprSet({}, &execCtx_);
+    ExprSet exprSet(std::vector<core::TypedExprPtr>{}, &execCtx_);
     RowVectorPtr inputRows = makeRowVector({});
     exec::EvalCtx evalCtx(&execCtx_, &exprSet, inputRows.get());
     replaceFunction->apply(rows, functionInputs, VARCHAR(), evalCtx, resultPtr);

--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -1183,7 +1183,7 @@ std::unique_ptr<Filter> createBigintValuesFilter(
 std::unique_ptr<Filter> createBigintValues(
     const std::vector<int64_t>& values,
     bool nullAllowed) {
-  return createBigintValuesFilter(values, nullAllowed, false);
+  return common::createBigintValuesFilter(values, nullAllowed, false);
 }
 
 std::unique_ptr<Filter> createHugeintValues(
@@ -1199,7 +1199,7 @@ std::unique_ptr<Filter> createHugeintValues(
 std::unique_ptr<Filter> createNegatedBigintValues(
     const std::vector<int64_t>& values,
     bool nullAllowed) {
-  return createBigintValuesFilter(values, nullAllowed, true);
+  return common::createBigintValuesFilter(values, nullAllowed, true);
 }
 
 BigintMultiRange::BigintMultiRange(


### PR DESCRIPTION
This PR adds the support for reading Iceberg tables with equality delete files. The single column values in the equality delete files would be interpreted as domain NOT EXSITS filter and pushed to the reader, and multi-column values would be interpreted as a remaining filter.

The design doc is https://github.com/facebookincubator/velox/issues/8748