### PR TITLE
GCS Set a default policy to retry failures

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -132,6 +132,15 @@ std::string HiveConfig::gcsCredentials() const {
   return config_->get<std::string>(kGCSCredentials, std::string(""));
 }
 
+std::optional<int> HiveConfig::gcsMaxRetryCount() const {
+  return static_cast<std::optional<int>>(config_->get<int>(kGCSMaxRetryCount));
+}
+
+std::optional<std::string> HiveConfig::gcsMaxRetryTime() const {
+  return static_cast<std::optional<std::string>>(
+      config_->get<std::string>(kGCSMaxRetryTime));
+}
+
 bool HiveConfig::isOrcUseColumnNames(const Config* session) const {
   return session->get<bool>(
       kOrcUseColumnNamesSession, config_->get<bool>(kOrcUseColumnNames, false));

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -106,6 +106,12 @@ class HiveConfig {
   /// The GCS service account configuration as json string
   static constexpr const char* kGCSCredentials = "hive.gcs.credentials";
 
+  /// The GCS maximum retry counter of transient errors.
+  static constexpr const char* kGCSMaxRetryCount = "hive.gcs.max-retry-count";
+
+  /// The GCS maximum time allowed to retry transient errors.
+  static constexpr const char* kGCSMaxRetryTime = "hive.gcs.max-retry-time";
+
   /// Maps table field names to file field names using names, not indices.
   // TODO: remove hive_orc_use_column_names since it doesn't exist in presto,
   // right now this is only used for testing.
@@ -241,6 +247,10 @@ class HiveConfig {
   std::string gcsScheme() const;
 
   std::string gcsCredentials() const;
+
+  std::optional<int> gcsMaxRetryCount() const;
+
+  std::optional<std::string> gcsMaxRetryTime() const;
 
   bool isOrcUseColumnNames(const Config* session) const;
 

--- a/velox/connectors/hive/storage_adapters/gcs/examples/GCSFileSystemExample.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/examples/GCSFileSystemExample.cpp
@@ -24,10 +24,19 @@
 #include <iostream>
 
 DEFINE_string(gcs_path, "", "Path of GCS bucket");
+DEFINE_string(gcs_max_retry_count, "", "Max retry count");
+DEFINE_string(gcs_max_retry_time, "", "Max retry time");
 
 auto newConfiguration() {
   using namespace facebook::velox;
   std::unordered_map<std::string, std::string> configOverride = {};
+  if (!FLAGS_gcs_max_retry_count.empty()) {
+    configOverride.emplace(
+        "hive.gcs.max-retry-count", FLAGS_gcs_max_retry_count);
+  }
+  if (!FLAGS_gcs_max_retry_time.empty()) {
+    configOverride.emplace("hive.gcs.max-retry-time", FLAGS_gcs_max_retry_time);
+  }
   return std::make_shared<const core::MemConfig>(std::move(configOverride));
 }
 
@@ -40,7 +49,7 @@ int main(int argc, char** argv) {
   }
   filesystems::GCSFileSystem gcfs(newConfiguration());
   gcfs.initializeClient();
-  std::cout << "Opening file " << FLAGS_gcs_path << std::endl;
+  std::cout << "Opening file for read " << FLAGS_gcs_path << std::endl;
   std::unique_ptr<ReadFile> file_read = gcfs.openFileForRead(FLAGS_gcs_path);
   std::size_t file_size = file_read->size();
   std::cout << "File size = " << file_size << std::endl;

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -569,6 +569,14 @@ Each query can override the config by setting corresponding query session proper
      - string
      -
      - The GCS service account configuration as json string.
+   * - hive.gcs.max-retry-count
+     - integer
+     -
+     - The GCS maximum retry counter of transient errors.
+   * - hive.gcs.max-retry-time
+     - string
+     -
+     - The GCS maximum time allowed to retry transient errors.
 
 ``Azure Blob Storage Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
GCS: Add properties to configure retry policy

GCS may encounter recoverable errors, for example, an authentification error.
By default GCS keeps retrying for up to 15 minutes,
but this default may be excessive, giving the impression that Velox has become unresponsive.
This behaviour can be configured, with options to configure the time to keep retrying or the number of times to retry.
However, the GCS connector does not allow to configure neither the retry time nor the retry count.

This change introduces two new properties:
- hive.gcs.max-retry-count: integer
  The maximum retry counter of transient errors.
- hive.gcs.max-retry-time: integer
  The maximum time allowed (seconds) to retry transient errors.

Testing was performed manually, trying to read from an unauthorized bucket.

Fixes #9264