### PR TITLE
Add initialized bit for aggregates in RowContainer

### DIFF
--- a/velox/exec/Aggregate.cpp
+++ b/velox/exec/Aggregate.cpp
@@ -325,9 +325,13 @@ void Aggregate::setOffsetsInternal(
     int32_t offset,
     int32_t nullByte,
     uint8_t nullMask,
+    int32_t initializedByte,
+    uint8_t initializedMask,
     int32_t rowSizeOffset) {
   nullByte_ = nullByte;
   nullMask_ = nullMask;
+  initializedByte_ = initializedByte;
+  initializedMask_ = initializedMask;
   offset_ = offset;
   rowSizeOffset_ = rowSizeOffset;
 }

--- a/velox/exec/AggregateCompanionAdapter.cpp
+++ b/velox/exec/AggregateCompanionAdapter.cpp
@@ -27,8 +27,16 @@ void AggregateCompanionFunctionBase::setOffsetsInternal(
     int32_t offset,
     int32_t nullByte,
     uint8_t nullMask,
+    int32_t initializedByte,
+    uint8_t initializedMask,
     int32_t rowSizeOffset) {
-  fn_->setOffsets(offset, nullByte, nullMask, rowSizeOffset);
+  fn_->setOffsets(
+      offset,
+      nullByte,
+      nullMask,
+      initializedByte,
+      initializedMask,
+      rowSizeOffset);
 }
 
 int32_t AggregateCompanionFunctionBase::accumulatorFixedWidthSize() const {
@@ -56,11 +64,22 @@ void AggregateCompanionFunctionBase::destroy(folly::Range<char**> groups) {
   fn_->destroy(groups);
 }
 
+void AggregateCompanionFunctionBase::destroyInternal(
+    folly::Range<char**> groups) {
+  fn_->destroy(groups);
+}
+
 void AggregateCompanionFunctionBase::clearInternal() {
   fn_->clear();
 }
 
 void AggregateCompanionFunctionBase::initializeNewGroups(
+    char** groups,
+    folly::Range<const vector_size_t*> indices) {
+  fn_->initializeNewGroups(groups, indices);
+}
+
+void AggregateCompanionFunctionBase::initializeNewGroupsInternal(
     char** groups,
     folly::Range<const vector_size_t*> indices) {
   fn_->initializeNewGroups(groups, indices);
@@ -154,6 +173,8 @@ int32_t AggregateCompanionAdapter::ExtractFunction::setOffset() const {
       offset,
       RowContainer::nullByte(0),
       RowContainer::nullMask(0),
+      RowContainer::initializedByte(0),
+      RowContainer::initializedMask(0),
       rowSizeOffset);
   return offset;
 }

--- a/velox/exec/AggregateCompanionAdapter.h
+++ b/velox/exec/AggregateCompanionAdapter.h
@@ -74,11 +74,19 @@ class AggregateCompanionFunctionBase : public Aggregate {
       int32_t offset,
       int32_t nullByte,
       uint8_t nullMask,
+      int32_t initializedByte,
+      uint8_t initializedMask,
       int32_t rowSizeOffset) override final;
 
   void setAllocatorInternal(HashStringAllocator* allocator) override final;
 
   void clearInternal() override final;
+
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override final;
+
+  void destroyInternal(folly::Range<char**> groups) override final;
 
   std::unique_ptr<Aggregate> fn_;
 };

--- a/velox/exec/AggregateWindow.cpp
+++ b/velox/exec/AggregateWindow.cpp
@@ -75,8 +75,8 @@ class AggregateWindowFunction : public exec::WindowFunction {
     //
     // Here we always make space for a row size since we only have one
     // row and no RowContainer. We also have a single aggregate here, so there
-    // is only one null bit.
-    static const int32_t kNullOffset = 0;
+    // is only one null bit and one initialized bit.
+    static const int32_t kAccumulatorFlagsOffset = 0;
     static const int32_t kRowSizeOffset = bits::nbytes(1);
     singleGroupRowSize_ = kRowSizeOffset + sizeof(int32_t);
     // Accumulator offset must be aligned by their alignment size.
@@ -84,8 +84,10 @@ class AggregateWindowFunction : public exec::WindowFunction {
         singleGroupRowSize_, aggregate_->accumulatorAlignmentSize());
     aggregate_->setOffsets(
         singleGroupRowSize_,
-        exec::RowContainer::nullByte(kNullOffset),
-        exec::RowContainer::nullMask(kNullOffset),
+        exec::RowContainer::nullByte(kAccumulatorFlagsOffset),
+        exec::RowContainer::nullMask(kAccumulatorFlagsOffset),
+        exec::RowContainer::initializedByte(kAccumulatorFlagsOffset),
+        exec::RowContainer::initializedMask(kAccumulatorFlagsOffset),
         /* needed for out of line allocations */ kRowSizeOffset);
     singleGroupRowSize_ += aggregate_->accumulatorFixedWidthSize();
 

--- a/velox/exec/DistinctAggregations.cpp
+++ b/velox/exec/DistinctAggregations.cpp
@@ -56,20 +56,6 @@ class TypedDistinctAggregations : public DistinctAggregations {
         }};
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    for (auto i : indices) {
-      groups[i][nullByte_] |= nullMask_;
-      new (groups[i] + offset_) AccumulatorType(inputType_, allocator_);
-    }
-
-    for (auto i = 0; i < aggregates_.size(); ++i) {
-      const auto& aggregate = *aggregates_[i];
-      aggregate.function->initializeNewGroups(groups, indices);
-    }
-  }
-
   void addInput(
       char** groups,
       const RowVectorPtr& input,
@@ -145,6 +131,21 @@ class TypedDistinctAggregations : public DistinctAggregations {
           groups.data(),
           folly::Range<const int32_t*>(
               iota(groups.size(), temp), groups.size()));
+    }
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    for (auto i : indices) {
+      groups[i][nullByte_] |= nullMask_;
+      new (groups[i] + offset_) AccumulatorType(inputType_, allocator_);
+    }
+
+    for (auto i = 0; i < aggregates_.size(); ++i) {
+      const auto& aggregate = *aggregates_[i];
+      aggregate.function->initializeNewGroups(groups, indices);
     }
   }
 

--- a/velox/exec/DistinctAggregations.h
+++ b/velox/exec/DistinctAggregations.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <cstdint>
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/AggregateInfo.h"
 #include "velox/exec/RowContainer.h"
@@ -49,16 +50,31 @@ class DistinctAggregations {
       int32_t offset,
       int32_t nullByte,
       uint8_t nullMask,
+      int32_t initializedByte,
+      uint8_t initializedMask,
       int32_t rowSizeOffset) {
     offset_ = offset;
     nullByte_ = nullByte;
     nullMask_ = nullMask;
+    initializedByte_ = initializedByte;
+    initializedMask_ = initializedMask;
     rowSizeOffset_ = rowSizeOffset;
   }
 
-  virtual void initializeNewGroups(
+  // Initializes null flags and accumulators for newly encountered groups.  This
+  // function should be called only once for each group.
+  //
+  // @param groups Pointers to the start of the new group rows.
+  // @param indices Indices into 'groups' of the new entries.
+  void initializeNewGroups(
       char** groups,
-      folly::Range<const vector_size_t*> indices) = 0;
+      folly::Range<const vector_size_t*> indices) {
+    initializeNewGroupsInternal(groups, indices);
+
+    for (auto index : indices) {
+      groups[index][initializedByte_] |= initializedMask_;
+    }
+  }
 
   virtual void addInput(
       char** groups,
@@ -76,10 +92,21 @@ class DistinctAggregations {
       const RowVectorPtr& result) = 0;
 
  protected:
+  // Initializes null flags and accumulators for newly encountered groups.  This
+  // function should be called only once for each group.
+  //
+  // @param groups Pointers to the start of the new group rows.
+  // @param indices Indices into 'groups' of the new entries.
+  virtual void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) = 0;
+
   HashStringAllocator* allocator_;
   int32_t offset_;
   int32_t nullByte_;
   uint8_t nullMask_;
+  int32_t initializedByte_;
+  uint8_t initializedMask_;
   int32_t rowSizeOffset_;
 };
 

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -322,6 +322,8 @@ void initializeAggregates(
         rowColumn.offset(),
         rowColumn.nullByte(),
         rowColumn.nullMask(),
+        rowColumn.initializedByte(),
+        rowColumn.initializedMask(),
         rows.rowSizeOffset());
     ++i;
   }
@@ -373,6 +375,8 @@ void GroupingSet::createHashTable() {
         rowColumn.offset(),
         rowColumn.nullByte(),
         rowColumn.nullMask(),
+        rowColumn.initializedByte(),
+        rowColumn.initializedMask(),
         rows.rowSizeOffset());
 
     ++numColumns;
@@ -387,6 +391,8 @@ void GroupingSet::createHashTable() {
           rowColumn.offset(),
           rowColumn.nullByte(),
           rowColumn.nullMask(),
+          rowColumn.initializedByte(),
+          rowColumn.initializedMask(),
           rows.rowSizeOffset());
       ++numColumns;
     }
@@ -416,7 +422,7 @@ void GroupingSet::initializeGlobalAggregation() {
   // requirements of all aggregate functions are satisfied.
   int32_t rowSizeOffset = bits::nbytes(aggregates_.size());
   int32_t offset = rowSizeOffset + sizeof(int32_t);
-  int32_t nullOffset = 0;
+  int32_t accumulatorFlagsOffset = 0;
   int32_t alignment = 1;
 
   for (auto& aggregate : aggregates_) {
@@ -431,12 +437,14 @@ void GroupingSet::initializeGlobalAggregation() {
     function->setAllocator(&stringAllocator_);
     function->setOffsets(
         offset,
-        RowContainer::nullByte(nullOffset),
-        RowContainer::nullMask(nullOffset),
+        RowContainer::nullByte(accumulatorFlagsOffset),
+        RowContainer::nullMask(accumulatorFlagsOffset),
+        RowContainer::initializedByte(accumulatorFlagsOffset),
+        RowContainer::initializedMask(accumulatorFlagsOffset),
         rowSizeOffset);
 
     offset += accumulator.fixedWidthSize();
-    ++nullOffset;
+    accumulatorFlagsOffset += RowContainer::kNumAccumulatorFlags;
     alignment =
         RowContainer::combineAlignments(accumulator.alignment(), alignment);
   }
@@ -449,12 +457,14 @@ void GroupingSet::initializeGlobalAggregation() {
     sortedAggregations_->setAllocator(&stringAllocator_);
     sortedAggregations_->setOffsets(
         offset,
-        RowContainer::nullByte(nullOffset),
-        RowContainer::nullMask(nullOffset),
+        RowContainer::nullByte(accumulatorFlagsOffset),
+        RowContainer::nullMask(accumulatorFlagsOffset),
+        RowContainer::initializedByte(accumulatorFlagsOffset),
+        RowContainer::initializedMask(accumulatorFlagsOffset),
         rowSizeOffset);
 
     offset += accumulator.fixedWidthSize();
-    ++nullOffset;
+    accumulatorFlagsOffset += RowContainer::kNumAccumulatorFlags;
     alignment =
         RowContainer::combineAlignments(accumulator.alignment(), alignment);
   }
@@ -468,12 +478,14 @@ void GroupingSet::initializeGlobalAggregation() {
       aggregation->setAllocator(&stringAllocator_);
       aggregation->setOffsets(
           offset,
-          RowContainer::nullByte(nullOffset),
-          RowContainer::nullMask(nullOffset),
+          RowContainer::nullByte(accumulatorFlagsOffset),
+          RowContainer::nullMask(accumulatorFlagsOffset),
+          RowContainer::initializedByte(accumulatorFlagsOffset),
+          RowContainer::initializedMask(accumulatorFlagsOffset),
           rowSizeOffset);
 
       offset += accumulator.fixedWidthSize();
-      ++nullOffset;
+      accumulatorFlagsOffset += RowContainer::kNumAccumulatorFlags;
       alignment =
           RowContainer::combineAlignments(accumulator.alignment(), alignment);
     }

--- a/velox/exec/SortedAggregations.cpp
+++ b/velox/exec/SortedAggregations.cpp
@@ -203,6 +203,7 @@ void SortedAggregations::initializeNewGroups(
   for (auto i : indices) {
     groups[i][nullByte_] |= nullMask_;
     new (groups[i] + offset_) RowPointers();
+    groups[i][initializedByte_] |= initializedMask_;
   }
 
   for (const auto& [sortingSpec, aggregates] : aggregates_) {

--- a/velox/exec/SortedAggregations.h
+++ b/velox/exec/SortedAggregations.h
@@ -54,10 +54,14 @@ class SortedAggregations {
       int32_t offset,
       int32_t nullByte,
       uint8_t nullMask,
+      int32_t initializedByte,
+      uint8_t initializedMask,
       int32_t rowSizeOffset) {
     offset_ = offset;
     nullByte_ = nullByte;
     nullMask_ = nullMask;
+    initializedByte_ = initializedByte;
+    initializedMask_ = initializedMask;
     rowSizeOffset_ = rowSizeOffset;
   }
 
@@ -154,6 +158,8 @@ class SortedAggregations {
   int32_t offset_;
   int32_t nullByte_;
   uint8_t nullMask_;
+  int32_t initializedByte_;
+  uint8_t initializedMask_;
   int32_t rowSizeOffset_;
 };
 

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -386,6 +386,8 @@ void StreamingAggregation::initializeAggregates(uint32_t numKeys) {
         rowColumn.offset(),
         rowColumn.nullByte(),
         rowColumn.nullMask(),
+        rowColumn.initializedByte(),
+        rowColumn.initializedMask(),
         rows_->rowSizeOffset());
     columnIndex++;
   }
@@ -397,6 +399,8 @@ void StreamingAggregation::initializeAggregates(uint32_t numKeys) {
         rowColumn.offset(),
         rowColumn.nullByte(),
         rowColumn.nullMask(),
+        rowColumn.initializedByte(),
+        rowColumn.initializedMask(),
         rows_->rowSizeOffset());
     columnIndex++;
   }
@@ -410,6 +414,8 @@ void StreamingAggregation::initializeAggregates(uint32_t numKeys) {
           rowColumn.offset(),
           rowColumn.nullByte(),
           rowColumn.nullMask(),
+          rowColumn.initializedByte(),
+          rowColumn.initializedMask(),
           rows_->rowSizeOffset());
       columnIndex++;
     }

--- a/velox/exec/tests/AggregateFunctionRegistryTest.cpp
+++ b/velox/exec/tests/AggregateFunctionRegistryTest.cpp
@@ -34,10 +34,6 @@ class AggregateFunc : public Aggregate {
     return 0;
   }
 
-  void initializeNewGroups(
-      char** /*groups*/,
-      folly::Range<const vector_size_t*> /*indices*/) override {}
-
   void addRawInput(
       char** /*groups*/,
       const SelectivityVector& /*rows*/,
@@ -93,6 +89,11 @@ class AggregateFunc : public Aggregate {
     };
     return signatures;
   }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/) override {}
 };
 
 bool registerAggregateFunc(const std::string& name, bool overwrite = false) {

--- a/velox/exec/tests/DummyAggregateFunction.h
+++ b/velox/exec/tests/DummyAggregateFunction.h
@@ -28,10 +28,6 @@ class DummyDicitonaryFunction : public exec::Aggregate {
     return 0;
   }
 
-  void initializeNewGroups(
-      char** /*groups*/,
-      folly::Range<const vector_size_t*> /*indices*/) override {}
-
   void addRawInput(
       char** /*groups*/,
       const SelectivityVector& /*rows*/,
@@ -65,6 +61,11 @@ class DummyDicitonaryFunction : public exec::Aggregate {
       char** /*groups*/,
       int32_t /*numGroups*/,
       VectorPtr* /*result*/) override {}
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/) override {}
 };
 
 AggregateRegistrationResult registerDummyAggregateFunction(

--- a/velox/exec/tests/SimpleAggregateAdapterTest.cpp
+++ b/velox/exec/tests/SimpleAggregateAdapterTest.cpp
@@ -301,6 +301,8 @@ TEST_F(SimpleArrayAggAggregationTest, trackRowSize) {
         offset,
         RowContainer::nullByte(0),
         RowContainer::nullMask(0),
+        RowContainer::initializedByte(0),
+        RowContainer::initializedMask(0),
         rowSizeOffset);
 
     // Make two groups for odd and even rows.

--- a/velox/functions/lib/aggregates/AverageAggregateBase.h
+++ b/velox/functions/lib/aggregates/AverageAggregateBase.h
@@ -83,15 +83,6 @@ class AverageAggregateBase : public exec::Aggregate {
     return sizeof(SumCount<TAccumulator>);
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    setAllNulls(groups, indices);
-    for (auto i : indices) {
-      new (groups[i] + offset_) SumCount<TAccumulator>();
-    }
-  }
-
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     auto vector = (*result)->as<FlatVector<TResult>>();
@@ -382,6 +373,15 @@ class AverageAggregateBase : public exec::Aggregate {
         totalSum += baseSumDecoded.template valueAt<TAccumulator>(decodedIndex);
       });
       updateNonNullValue(group, totalCount, totalSum);
+    }
+  }
+
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      new (groups[i] + offset_) SumCount<TAccumulator>();
     }
   }
 

--- a/velox/functions/lib/aggregates/BitwiseAggregateBase.h
+++ b/velox/functions/lib/aggregates/BitwiseAggregateBase.h
@@ -33,15 +33,6 @@ class BitwiseAggregateBase : public SimpleNumericAggregate<T, T, T> {
     return sizeof(T);
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    exec::Aggregate::setAllNulls(groups, indices);
-    for (auto i : indices) {
-      *exec::Aggregate::value<T>(groups[i]) = initialValue_;
-    }
-  }
-
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     BaseAggregate::doExtractValues(groups, numGroups, result, [&](char* group) {
@@ -66,6 +57,15 @@ class BitwiseAggregateBase : public SimpleNumericAggregate<T, T, T> {
   }
 
  protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    exec::Aggregate::setAllNulls(groups, indices);
+    for (auto i : indices) {
+      *exec::Aggregate::value<T>(groups[i]) = initialValue_;
+    }
+  }
+
   const T initialValue_;
 };
 

--- a/velox/functions/lib/aggregates/CentralMomentsAggregatesBase.h
+++ b/velox/functions/lib/aggregates/CentralMomentsAggregatesBase.h
@@ -221,15 +221,6 @@ class CentralMomentsAggregatesBase : public exec::Aggregate {
     return sizeof(CentralMomentsAccumulator);
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    setAllNulls(groups, indices);
-    for (auto i : indices) {
-      new (groups[i] + offset_) CentralMomentsAccumulator();
-    }
-  }
-
   void addRawInput(
       char** groups,
       const SelectivityVector& rows,
@@ -409,6 +400,16 @@ class CentralMomentsAggregatesBase : public exec::Aggregate {
         clearNull(rawNulls, i);
         centralMomentsResult.set(i, *accumulator(group));
       }
+    }
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      new (groups[i] + offset_) CentralMomentsAccumulator();
     }
   }
 

--- a/velox/functions/lib/aggregates/DecimalAggregate.h
+++ b/velox/functions/lib/aggregates/DecimalAggregate.h
@@ -81,15 +81,6 @@ class DecimalAggregate : public exec::Aggregate {
     return static_cast<int32_t>(sizeof(int128_t));
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    setAllNulls(groups, indices);
-    for (auto i : indices) {
-      new (groups[i] + offset_) LongDecimalWithOverflowState();
-    }
-  }
-
   void addRawInput(
       char** groups,
       const SelectivityVector& rows,
@@ -324,6 +315,16 @@ class DecimalAggregate : public exec::Aggregate {
     accumulator->overflow +=
         DecimalUtil::addWithOverflow(accumulator->sum, value, accumulator->sum);
     accumulator->count += 1;
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      new (groups[i] + offset_) LongDecimalWithOverflowState();
+    }
   }
 
  private:

--- a/velox/functions/lib/aggregates/MinMaxByAggregatesBase.h
+++ b/velox/functions/lib/aggregates/MinMaxByAggregatesBase.h
@@ -105,29 +105,6 @@ class MinMaxByAggregateBase : public exec::Aggregate {
         sizeof(bool);
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    exec::Aggregate::setAllNulls(groups, indices);
-    for (const vector_size_t i : indices) {
-      auto group = groups[i];
-      valueIsNull(group) = true;
-
-      if constexpr (!isNumeric<T>()) {
-        new (group + offset_) SingleValueAccumulator();
-      } else {
-        *value(group) = ValueAccumulatorType();
-      }
-
-      if constexpr (isNumeric<U>()) {
-        *comparisonValue(group) = ComparisonAccumulatorType();
-      } else {
-        new (group + offset_ + sizeof(ValueAccumulatorType))
-            SingleValueAccumulator();
-      }
-    }
-  }
-
   void addRawInput(
       char** groups,
       const SelectivityVector& rows,
@@ -282,17 +259,6 @@ class MinMaxByAggregateBase : public exec::Aggregate {
             i,
             rawComparisonValues,
             rawBoolComparisonValues);
-      }
-    }
-  }
-
-  void destroy(folly::Range<char**> groups) override {
-    for (auto group : groups) {
-      if constexpr (!isNumeric<T>()) {
-        value(group)->destroy(allocator_);
-      }
-      if constexpr (!isNumeric<U>()) {
-        comparisonValue(group)->destroy(allocator_);
       }
     }
   }
@@ -493,6 +459,42 @@ class MinMaxByAggregateBase : public exec::Aggregate {
             decodedValue_.isNullAt(decodedIndex),
             mayUpdate);
       });
+    }
+  }
+
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    exec::Aggregate::setAllNulls(groups, indices);
+    for (const vector_size_t i : indices) {
+      auto group = groups[i];
+      valueIsNull(group) = true;
+
+      if constexpr (!isNumeric<T>()) {
+        new (group + offset_) SingleValueAccumulator();
+      } else {
+        *value(group) = ValueAccumulatorType();
+      }
+
+      if constexpr (isNumeric<U>()) {
+        *comparisonValue(group) = ComparisonAccumulatorType();
+      } else {
+        new (group + offset_ + sizeof(ValueAccumulatorType))
+            SingleValueAccumulator();
+      }
+    }
+  }
+
+  void destroyInternal(folly::Range<char**> groups) override {
+    for (auto group : groups) {
+      if (isInitialized(group)) {
+        if constexpr (!isNumeric<T>()) {
+          value(group)->destroy(allocator_);
+        }
+        if constexpr (!isNumeric<U>()) {
+          comparisonValue(group)->destroy(allocator_);
+        }
+      }
     }
   }
 

--- a/velox/functions/lib/aggregates/SumAggregateBase.h
+++ b/velox/functions/lib/aggregates/SumAggregateBase.h
@@ -43,15 +43,6 @@ class SumAggregateBase
     return 1;
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    exec::Aggregate::setAllNulls(groups, indices);
-    for (auto i : indices) {
-      *exec::Aggregate::value<TAccumulator>(groups[i]) = 0;
-    }
-  }
-
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     BaseAggregate::template doExtractValues<ResultType>(
@@ -144,6 +135,15 @@ class SumAggregateBase
     } else {
       BaseAggregate::template updateGroups<false, TData, TValue>(
           groups, rows, arg, &updateSingleValue<TData>, false);
+    }
+  }
+
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    exec::Aggregate::setAllNulls(groups, indices);
+    for (auto i : indices) {
+      *exec::Aggregate::value<TAccumulator>(groups[i]) = 0;
     }
   }
 

--- a/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
@@ -1186,7 +1186,7 @@ std::unique_ptr<exec::Aggregate> createAggregateFunction(
       finalType,
       queryConfig);
   func->setAllocator(&allocator);
-  func->setOffsets(kOffset, 0, 1, kRowSizeOffset);
+  func->setOffsets(kOffset, 0, 1, 0, 2, kRowSizeOffset);
 
   VELOX_CHECK(intermediateType->equivalent(
       *func->intermediateType(functionName, inputTypes)));

--- a/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
@@ -72,18 +72,6 @@ struct ApproxMostFrequentAggregate : exec::Aggregate {
     return sizeof(Accumulator<T>);
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    for (auto index : indices) {
-      new (groups[index] + offset_) Accumulator<T>(allocator_);
-    }
-  }
-
-  void destroy(folly::Range<char**> groups) override {
-    destroyAccumulators<Accumulator<T>>(groups);
-  }
-
   void addRawInput(
       char** groups,
       const SelectivityVector& rows,
@@ -216,6 +204,19 @@ struct ApproxMostFrequentAggregate : exec::Aggregate {
         entryCount += summary->size();
       }
     }
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    for (auto index : indices) {
+      new (groups[index] + offset_) Accumulator<T>(allocator_);
+    }
+  }
+
+  void destroyInternal(folly::Range<char**> groups) override {
+    destroyAccumulators<Accumulator<T>>(groups);
   }
 
  private:

--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
@@ -146,22 +146,6 @@ class ApproxPercentileAggregate : public exec::Aggregate {
     return false;
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    exec::Aggregate::setAllNulls(groups, indices);
-    for (auto i : indices) {
-      auto group = groups[i];
-      new (group + offset_) KllSketchAccumulator<T>(allocator_);
-    }
-  }
-
-  void destroy(folly::Range<char**> groups) override {
-    for (auto group : groups) {
-      value<KllSketchAccumulator<T>>(group)->~KllSketchAccumulator<T>();
-    }
-  }
-
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     finalize(groups, numGroups);
@@ -416,6 +400,25 @@ class ApproxPercentileAggregate : public exec::Aggregate {
       const std::vector<VectorPtr>& args,
       bool /*mayPushdown*/) override {
     addIntermediate<true>(group, rows, args);
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    exec::Aggregate::setAllNulls(groups, indices);
+    for (auto i : indices) {
+      auto group = groups[i];
+      new (group + offset_) KllSketchAccumulator<T>(allocator_);
+    }
+  }
+
+  void destroyInternal(folly::Range<char**> groups) override {
+    for (auto group : groups) {
+      if (isInitialized(group)) {
+        value<KllSketchAccumulator<T>>(group)->~KllSketchAccumulator<T>();
+      }
+    }
   }
 
  private:

--- a/velox/functions/prestosql/aggregates/BoolAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/BoolAggregates.cpp
@@ -62,7 +62,8 @@ class BoolAndOrAggregate : public SimpleNumericAggregate<bool, bool, bool> {
     extractValues(groups, numGroups, result);
   }
 
-  void initializeNewGroups(
+ protected:
+  void initializeNewGroupsInternal(
       char** groups,
       folly::Range<const vector_size_t*> indices) override {
     setAllNulls(groups, indices);
@@ -71,7 +72,6 @@ class BoolAndOrAggregate : public SimpleNumericAggregate<bool, bool, bool> {
     }
   }
 
- protected:
   const bool initialValue_;
 };
 

--- a/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
@@ -40,15 +40,6 @@ class ChecksumAggregate : public exec::Aggregate {
     return sizeof(int64_t);
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    setAllNulls(groups, indices);
-    for (auto i : indices) {
-      *value<int64_t>(groups[i]) = 0;
-    }
-  }
-
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     auto* vector = (*result)->asUnchecked<FlatVector<StringView>>();
@@ -192,6 +183,16 @@ class ChecksumAggregate : public exec::Aggregate {
       clearNull(group);
     }
     safeAdd(*value<int64_t>(group), result);
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      *value<int64_t>(groups[i]) = 0;
+    }
   }
 
  private:

--- a/velox/functions/prestosql/aggregates/CountAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountAggregate.cpp
@@ -34,15 +34,6 @@ class CountAggregate : public SimpleNumericAggregate<bool, int64_t, int64_t> {
     return sizeof(int64_t);
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    for (auto i : indices) {
-      // result of count is never null
-      *value<int64_t>(groups[i]) = (int64_t)0;
-    }
-  }
-
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     BaseAggregate::doExtractValues(groups, numGroups, result, [&](char* group) {
@@ -138,6 +129,16 @@ class CountAggregate : public SimpleNumericAggregate<bool, int64_t, int64_t> {
     }
 
     addToGroup(group, count);
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    for (auto i : indices) {
+      // result of count is never null
+      *value<int64_t>(groups[i]) = (int64_t)0;
+    }
   }
 
  private:

--- a/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
@@ -33,14 +33,6 @@ class CountIfAggregate : public exec::Aggregate {
     return sizeof(int64_t);
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    for (auto i : indices) {
-      *value<int64_t>(groups[i]) = 0;
-    }
-  }
-
   void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     extractValues(groups, numGroups, result);
@@ -160,6 +152,15 @@ class CountIfAggregate : public exec::Aggregate {
     rows.applyToSelected([&](auto row) { numTrue += arg->valueAt(row); });
 
     addToGroup(group, numTrue);
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    for (auto i : indices) {
+      *value<int64_t>(groups[i]) = 0;
+    }
   }
 
  private:

--- a/velox/functions/prestosql/aggregates/CovarianceAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/CovarianceAggregates.cpp
@@ -559,15 +559,6 @@ class CovarianceAggregate : public exec::Aggregate {
     return sizeof(TAccumulator);
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    setAllNulls(groups, indices);
-    for (auto i : indices) {
-      new (groups[i] + offset_) TAccumulator();
-    }
-  }
-
   void addRawInput(
       char** groups,
       const SelectivityVector& rows,
@@ -711,6 +702,16 @@ class CovarianceAggregate : public exec::Aggregate {
         clearNull(rawNulls, i);
         covarResult.set(i, *accumulator(group));
       }
+    }
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      new (groups[i] + offset_) TAccumulator();
     }
   }
 

--- a/velox/functions/prestosql/aggregates/EntropyAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/EntropyAggregates.cpp
@@ -85,15 +85,6 @@ class EntropyAggregate : public exec::Aggregate {
     return sizeof(EntropyAccumulator);
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    setAllNulls(groups, indices);
-    for (auto i : indices) {
-      new (groups[i] + offset_) EntropyAccumulator();
-    }
-  }
-
   void addRawInput(
       char** groups,
       const SelectivityVector& rows,
@@ -288,6 +279,15 @@ class EntropyAggregate : public exec::Aggregate {
  protected:
   inline EntropyAccumulator* accumulator(char* group) {
     return exec::Aggregate::value<EntropyAccumulator>(group);
+  }
+
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      new (groups[i] + offset_) EntropyAccumulator();
+    }
   }
 
  private:

--- a/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
@@ -168,14 +168,6 @@ class HistogramAggregate : public exec::Aggregate {
     return false;
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    for (auto index : indices) {
-      new (groups[index] + offset_) AccumulatorType{allocator_};
-    }
-  }
-
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     auto mapVector = (*result)->as<MapVector>();
@@ -321,7 +313,16 @@ class HistogramAggregate : public exec::Aggregate {
     });
   }
 
-  void destroy(folly::Range<char**> groups) override {
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    for (auto index : indices) {
+      new (groups[index] + offset_) AccumulatorType{allocator_};
+    }
+  }
+
+  void destroyInternal(folly::Range<char**> groups) override {
     destroyAccumulators<AccumulatorType>(groups);
   }
 

--- a/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
@@ -56,15 +56,6 @@ class MaxSizeForStatsAggregate
     });
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    exec::Aggregate::setAllNulls(groups, indices);
-    for (auto i : indices) {
-      *BaseAggregate ::value<int64_t>(groups[i]) = 0;
-    }
-  }
-
   void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     // Partial and final aggregations are the same.
@@ -198,6 +189,15 @@ class MaxSizeForStatsAggregate
       rows.applyToSelected([&](auto row) {
         updateOneAccumulator(group, row, elementSizes_[sizeIndex++]);
       });
+    }
+  }
+
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    exec::Aggregate::setAllNulls(groups, indices);
+    for (auto i : indices) {
+      *BaseAggregate ::value<int64_t>(groups[i]) = 0;
     }
   }
 };

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -636,16 +636,6 @@ class MinMaxByNAggregate : public exec::Aggregate {
     return sizeof(AccumulatorType);
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    exec::Aggregate::setAllNulls(groups, indices);
-    for (const vector_size_t i : indices) {
-      auto group = groups[i];
-      new (group + offset_) AccumulatorType(allocator_);
-    }
-  }
-
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     auto valuesArray = (*result)->as<ArrayVector>();
@@ -821,7 +811,18 @@ class MinMaxByNAggregate : public exec::Aggregate {
     });
   }
 
-  void destroy(folly::Range<char**> groups) override {
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    exec::Aggregate::setAllNulls(groups, indices);
+    for (const vector_size_t i : indices) {
+      auto group = groups[i];
+      new (group + offset_) AccumulatorType(allocator_);
+    }
+  }
+
+  void destroyInternal(folly::Range<char**> groups) override {
     destroyAccumulators<AccumulatorType>(groups);
   }
 

--- a/velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.cpp
@@ -48,15 +48,6 @@ class SumDataSizeForStatsAggregate
     });
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    exec::Aggregate::setAllNulls(groups, indices);
-    for (auto index : indices) {
-      *BaseAggregate ::value<int64_t>(groups[index]) = 0;
-    }
-  }
-
   void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     // Partial and final aggregations are the same.
@@ -170,6 +161,15 @@ class SumDataSizeForStatsAggregate
     rows.applyToSelected([&](auto row) {
       updateOneAccumulator(group, row, rowSizes_[sizeIndex++]);
     });
+  }
+
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    exec::Aggregate::setAllNulls(groups, indices);
+    for (auto index : indices) {
+      *BaseAggregate ::value<int64_t>(groups[index]) = 0;
+    }
   }
 
  private:

--- a/velox/functions/prestosql/aggregates/VarianceAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/VarianceAggregates.cpp
@@ -146,15 +146,6 @@ class VarianceAggregate : public exec::Aggregate {
     return sizeof(VarianceAccumulator);
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    setAllNulls(groups, indices);
-    for (auto i : indices) {
-      new (groups[i] + offset_) VarianceAccumulator();
-    }
-  }
-
   void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     auto rowVector = (*result)->as<RowVector>();
@@ -374,6 +365,15 @@ class VarianceAggregate : public exec::Aggregate {
  protected:
   inline VarianceAccumulator* accumulator(char* group) {
     return exec::Aggregate::value<VarianceAccumulator>(group);
+  }
+
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      new (groups[i] + offset_) VarianceAccumulator();
+    }
   }
 
  private:

--- a/velox/functions/prestosql/aggregates/tests/HistogramTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/HistogramTest.cpp
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/RowContainer.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
 

--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
@@ -76,15 +76,6 @@ class BloomFilterAggAggregate : public exec::Aggregate {
     return false;
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    setAllNulls(groups, indices);
-    for (auto i : indices) {
-      new (groups[i] + offset_) BloomFilterAccumulator(allocator_);
-    }
-  }
-
   static FOLLY_ALWAYS_INLINE void checkBloomFilterNotNull(
       DecodedVector& decoded,
       vector_size_t idx) {
@@ -203,6 +194,16 @@ class BloomFilterAggAggregate : public exec::Aggregate {
   void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     extractValues(groups, numGroups, result);
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      new (groups[i] + offset_) BloomFilterAccumulator(allocator_);
+    }
   }
 
  private:


### PR DESCRIPTION
Summary:
The way aggregates are used in RowContainer, the typical flow is that a group of rows are allocated in the RowContainer, then
accumulators are allocated column wise across all rows via initializeNewGroups.

This leaves a window of time where the accumulators are not null but also not non-null they simply aren't initialized while new
rows are being allocated before  initializeNewGroups has been called.  During this time if an exception occurs (e.g. an OOM
allocating a row), when the RowContainer is destructed as part of stack unwinding, it may call freeAggregates which will
attempt to destroy the accumulators that were never created leading to crashes.

We can't simply set the null bit for the accumulators because
1) Some aggregates initialize an accumulator even if the column is null, and therefore still need to destroy it.
2) Aggregates maintain a nullCount_ internally, if this is 0 null bits are ignored.  Incrementing this for each aggregate on each
row creation would have a performance cost, much like allocating the accumulator on each row would.

In order to handle this, I've added an initialized bit along side the null bit for every aggregation.  This is initially set to 0 by
RowContainer's initializeRow function.  When initializeNewGroups is called Aggregate flips this bit to 1.  It also flips it back to
0 when destroy is called.  Destroy checks this bit before destroying an accumulator to determine if it has been initialized.

To minimize the changes needed in Aggregate implementations, I've made initializeNewGroups and destroy non-virtual in
Aggregate, they call new virtual methods initializeNewGroupsInternal and destroyInternal which are drop in replacements for
the original functions in the implementations.  This way Aggregate handles flipping the initialized bit in one place.

The only other change needed was in the few existing Aggregates that destroy their accumulator on their own (rather than
through Aggregate's destroyAccumulator function) I added a check for the initialized bit.

This diff is unfortunately large because of the need to update every Aggregate function to rename the functions, and the
need to update the signature of setOffsets to add the initialized bit offset.  The key changes are in
* RowContainer.h/.cpp
* Aggregate.h/.cpp

Differential Revision: D54862289
