### PR TITLE
Fix possible mod zero in fuzzConstant

### DIFF
--- a/velox/exec/fuzzer/AggregationFuzzerBase.cpp
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.cpp
@@ -270,7 +270,11 @@ std::vector<RowVectorPtr> AggregationFuzzerBase::generateInputData(
     generator = findInputGenerator(signature.value());
   }
 
-  const auto size = vectorFuzzer_.getOptions().vectorSize;
+  auto size = vectorFuzzer_.getOptions().vectorSize;
+  // 40% of times test aggregation fuzzer on empty input vectors.
+  if (vectorFuzzer_.coinToss(0.4)) {
+    size = 0;
+  }
 
   auto inputType = ROW(std::move(names), std::move(types));
   std::vector<RowVectorPtr> input;

--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -430,8 +430,9 @@ VectorPtr VectorFuzzer::fuzzConstant(const TypePtr& type, vector_size_t size) {
   // return a null constant if the element being wrapped is null in the
   // generated inner vector.
 
-  // Inner vector size can't be zero.
-  auto innerVectorSize = rand<uint32_t>(rng_) % opts_.vectorSize + 1;
+  // Inner vector size can't be zero. opts_.vectorSize could be 0, so 1 is added
+  // to avoid mod 0.
+  auto innerVectorSize = rand<uint32_t>(rng_) % (opts_.vectorSize + 1) + 1;
   auto constantIndex = rand<vector_size_t>(rng_) % innerVectorSize;
 
   ScopedOptions restorer(this);


### PR DESCRIPTION
When aggregation fuzzer is run with a `batch_size` of 0, the inner vector size calculation
in `fuzzConstant` results in mod zero:
```
auto innerVectorSize = rand<uint32_t>(rng_) % opts_.vectorSize + 1;
```

This can be reproduced by running
```
velox_aggregation_fuzzer_test --seed 1077100643 --batch_size=0 --duration_sec=60 --logtostderr=1 --minloglevel=0
```

Aggregate fuzzer is also extended to test with empty input vectors, to resolve https://github.com/facebookincubator/velox/issues/7029.