### PR TITLE
Fix hash build spill partition calculation discovered by join fuzzer

### DIFF
--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -576,9 +576,9 @@ void HashBuild::computeSpillPartitions(const RowVectorPtr& input) {
   }
 
   spillPartitions_.resize(input->size());
-  for (auto i = 0; i < spillPartitions_.size(); ++i) {
-    spillPartitions_[i] = spiller_->hashBits().partition(hashes_[i]);
-  }
+  activeRows_.applyToSelected([&](int32_t row) {
+    spillPartitions_[row] = spiller_->hashBits().partition(hashes_[row]);
+  });
 }
 
 void HashBuild::spillPartition(


### PR DESCRIPTION
When hash build calculate the partition number for input, it sizes the hash vector
based on the valid size of active rows in the input but sizes the partition number
vector using the input vector size. The valid size of active rows could be smaller
than input vector size. The join fuzzer asan detects this in the new group execution
mode.
Has run join fuzzer successfully in Meta dev mode for an hour with this fix