### PR TITLE
Fix potential error freeing StringView after failed store in RowContainer

### DIFF
--- a/velox/common/memory/tests/HashStringAllocatorTest.cpp
+++ b/velox/common/memory/tests/HashStringAllocatorTest.cpp
@@ -578,7 +578,7 @@ TEST_F(HashStringAllocatorTest, strings) {
     }
     strings.push_back(str);
     views.push_back(StringView(str.data(), str.size()));
-    allocator_->copyMultipart(reinterpret_cast<char*>(&views[i]), 0);
+    allocator_->copyMultipart(views[i], reinterpret_cast<char*>(&views[i]), 0);
     if (i % 10 == 0) {
       allocator_->checkConsistency();
     }
@@ -664,7 +664,7 @@ TEST_F(HashStringAllocatorTest, storeStringFast) {
   allocator_->allocate(HashStringAllocator::kMinAlloc);
   std::string s(allocator_->freeSpace() + sizeof(void*), 'x');
   StringView sv(s);
-  allocator_->copyMultipart(reinterpret_cast<char*>(&sv), 0);
+  allocator_->copyMultipart(sv, reinterpret_cast<char*>(&sv), 0);
   ASSERT_NE(sv.data(), s.data());
   ASSERT_EQ(sv, StringView(s));
   allocator_->checkConsistency();

--- a/velox/exec/Aggregate.cpp
+++ b/velox/exec/Aggregate.cpp
@@ -297,9 +297,13 @@ void Aggregate::setOffsetsInternal(
     int32_t offset,
     int32_t nullByte,
     uint8_t nullMask,
+    int32_t initializedByte,
+    uint8_t initializedMask,
     int32_t rowSizeOffset) {
   nullByte_ = nullByte;
   nullMask_ = nullMask;
+  initializedByte_ = initializedByte;
+  initializedMask_ = initializedMask;
   offset_ = offset;
   rowSizeOffset_ = rowSizeOffset;
 }

--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -105,6 +105,10 @@ class Aggregate {
   // @param offset Offset in bytes from the start of the row of the accumulator
   // @param nullByte Offset in bytes from the start of the row of the null flag
   // @param nullMask The specific bit in the nullByte that stores the null flag
+  // @param initializedByte Offset in bytes from the start of the row of the
+  // initialized flag
+  // @param initializedMask The specific bit in the initializedByte that stores
+  // the initialized flag
   // @param rowSizeOffset The offset of a uint32_t row size from the start of
   // the row. Only applies to accumulators that store variable size data out of
   // line. Fixed length accumulators do not use this. 0 if the row does not have
@@ -113,8 +117,16 @@ class Aggregate {
       int32_t offset,
       int32_t nullByte,
       uint8_t nullMask,
+      int32_t initializedByte,
+      int8_t initializedMask,
       int32_t rowSizeOffset) {
-    setOffsetsInternal(offset, nullByte, nullMask, rowSizeOffset);
+    setOffsetsInternal(
+        offset,
+        nullByte,
+        nullMask,
+        initializedByte,
+        initializedMask,
+        rowSizeOffset);
   }
 
   // Initializes null flags and accumulators for newly encountered groups.  This
@@ -124,7 +136,13 @@ class Aggregate {
   // @param indices Indices into 'groups' of the new entries.
   virtual void initializeNewGroups(
       char** groups,
-      folly::Range<const vector_size_t*> indices) = 0;
+      folly::Range<const vector_size_t*> indices) {
+    initializeNewGroupsInternal(groups, indices);
+
+    for (auto index : indices) {
+      groups[index][initializedByte_] |= initializedMask_;
+    }
+  }
 
   // Single Aggregate instance is able to take both raw data and
   // intermediate result as input based on the assumption that Partial
@@ -242,8 +260,14 @@ class Aggregate {
   }
 
   // Frees any out of line storage for the accumulator in
-  // 'groups'. No-op for fixed length accumulators.
-  virtual void destroy(folly::Range<char**> /*groups*/) {}
+  // 'groups' and marks the aggregate as uninitialized.
+  virtual void destroy(folly::Range<char**> groups) {
+    destroyInternal(groups);
+
+    for (auto* group : groups) {
+      group[initializedByte_] &= ~initializedMask_;
+    }
+  }
 
   // Clears state between reuses, e.g. this is called before reusing
   // the aggregation operator's state after flushing a partial
@@ -294,9 +318,24 @@ class Aggregate {
       int32_t offset,
       int32_t nullByte,
       uint8_t nullMask,
+      int32_t initializedByte,
+      uint8_t initializedMask,
       int32_t rowSizeOffset);
 
   virtual void clearInternal();
+
+  // Initializes null flags and accumulators for newly encountered groups.  This
+  // function should be called only once for each group.
+  //
+  // @param groups Pointers to the start of the new group rows.
+  // @param indices Indices into 'groups' of the new entries.
+  virtual void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) = 0;
+
+  // Frees any out of line storage for the accumulator in
+  // 'groups'. No-op for fixed length accumulators.
+  virtual void destroyInternal(folly::Range<char**> groups) {}
 
   // Shorthand for maintaining accumulator variable length size in
   // accumulator update methods. Use like: { auto tracker =
@@ -308,6 +347,10 @@ class Aggregate {
 
   bool isNull(char* group) const {
     return numNulls_ && (group[nullByte_] & nullMask_);
+  }
+
+  bool isInitialized(char* group) const {
+    return group[initializedByte_] & initializedMask_;
   }
 
   // Sets null flag for all specified groups to true.
@@ -351,9 +394,11 @@ class Aggregate {
 
   template <typename T>
   void destroyAccumulator(char* group) const {
-    auto accumulator = value<T>(group);
-    std::destroy_at(accumulator);
-    memset(accumulator, 0, sizeof(T));
+    if (isInitialized(group)) {
+      auto accumulator = value<T>(group);
+      std::destroy_at(accumulator);
+      memset(accumulator, 0, sizeof(T));
+    }
   }
 
   template <typename T>
@@ -384,6 +429,9 @@ class Aggregate {
   // Byte position of null flag in group row.
   int32_t nullByte_;
   uint8_t nullMask_;
+  // Byte position of the initialized flag in group row.
+  int32_t initializedByte_;
+  uint8_t initializedMask_;
   // Offset of fixed length accumulator state in group row.
   int32_t offset_;
 

--- a/velox/exec/AggregateCompanionAdapter.cpp
+++ b/velox/exec/AggregateCompanionAdapter.cpp
@@ -27,8 +27,16 @@ void AggregateCompanionFunctionBase::setOffsetsInternal(
     int32_t offset,
     int32_t nullByte,
     uint8_t nullMask,
+    int32_t initializedByte,
+    uint8_t initializedMask,
     int32_t rowSizeOffset) {
-  fn_->setOffsets(offset, nullByte, nullMask, rowSizeOffset);
+  fn_->setOffsets(
+      offset,
+      nullByte,
+      nullMask,
+      initializedByte,
+      initializedMask,
+      rowSizeOffset);
 }
 
 int32_t AggregateCompanionFunctionBase::accumulatorFixedWidthSize() const {
@@ -56,11 +64,22 @@ void AggregateCompanionFunctionBase::destroy(folly::Range<char**> groups) {
   fn_->destroy(groups);
 }
 
+void AggregateCompanionFunctionBase::destroyInternal(
+    folly::Range<char**> groups) {
+  fn_->destroy(groups);
+}
+
 void AggregateCompanionFunctionBase::clearInternal() {
   fn_->clear();
 }
 
 void AggregateCompanionFunctionBase::initializeNewGroups(
+    char** groups,
+    folly::Range<const vector_size_t*> indices) {
+  fn_->initializeNewGroups(groups, indices);
+}
+
+void AggregateCompanionFunctionBase::initializeNewGroupsInternal(
     char** groups,
     folly::Range<const vector_size_t*> indices) {
   fn_->initializeNewGroups(groups, indices);
@@ -154,6 +173,8 @@ int32_t AggregateCompanionAdapter::ExtractFunction::setOffset() const {
       offset,
       RowContainer::nullByte(0),
       RowContainer::nullMask(0),
+      RowContainer::initializedByte(0),
+      RowContainer::initializedMask(0),
       rowSizeOffset);
   return offset;
 }

--- a/velox/exec/AggregateCompanionAdapter.h
+++ b/velox/exec/AggregateCompanionAdapter.h
@@ -74,11 +74,19 @@ class AggregateCompanionFunctionBase : public Aggregate {
       int32_t offset,
       int32_t nullByte,
       uint8_t nullMask,
+      int32_t initializedByte,
+      uint8_t initializedMask,
       int32_t rowSizeOffset) override final;
 
   void setAllocatorInternal(HashStringAllocator* allocator) override final;
 
   void clearInternal() override final;
+
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override final;
+
+  void destroyInternal(folly::Range<char**> groups) override final;
 
   std::unique_ptr<Aggregate> fn_;
 };

--- a/velox/exec/AggregateWindow.cpp
+++ b/velox/exec/AggregateWindow.cpp
@@ -86,6 +86,8 @@ class AggregateWindowFunction : public exec::WindowFunction {
         singleGroupRowSize_,
         exec::RowContainer::nullByte(kNullOffset),
         exec::RowContainer::nullMask(kNullOffset),
+        exec::RowContainer::initializedByte(kNullOffset),
+        exec::RowContainer::initializedMask(kNullOffset),
         /* needed for out of line allocations */ kRowSizeOffset);
     singleGroupRowSize_ += aggregate_->accumulatorFixedWidthSize();
 

--- a/velox/exec/DistinctAggregations.cpp
+++ b/velox/exec/DistinctAggregations.cpp
@@ -56,20 +56,6 @@ class TypedDistinctAggregations : public DistinctAggregations {
         }};
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    for (auto i : indices) {
-      groups[i][nullByte_] |= nullMask_;
-      new (groups[i] + offset_) AccumulatorType(inputType_, allocator_);
-    }
-
-    for (auto i = 0; i < aggregates_.size(); ++i) {
-      const auto& aggregate = *aggregates_[i];
-      aggregate.function->initializeNewGroups(groups, indices);
-    }
-  }
-
   void addInput(
       char** groups,
       const RowVectorPtr& input,
@@ -145,6 +131,21 @@ class TypedDistinctAggregations : public DistinctAggregations {
           groups.data(),
           folly::Range<const int32_t*>(
               iota(groups.size(), temp), groups.size()));
+    }
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    for (auto i : indices) {
+      groups[i][nullByte_] |= nullMask_;
+      new (groups[i] + offset_) AccumulatorType(inputType_, allocator_);
+    }
+
+    for (auto i = 0; i < aggregates_.size(); ++i) {
+      const auto& aggregate = *aggregates_[i];
+      aggregate.function->initializeNewGroups(groups, indices);
     }
   }
 

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -319,6 +319,8 @@ void initializeAggregates(
         rowColumn.offset(),
         rowColumn.nullByte(),
         rowColumn.nullMask(),
+        rowColumn.initializedByte(),
+        rowColumn.initializedMask(),
         rows.rowSizeOffset());
     ++i;
   }
@@ -370,6 +372,8 @@ void GroupingSet::createHashTable() {
         rowColumn.offset(),
         rowColumn.nullByte(),
         rowColumn.nullMask(),
+        rowColumn.initializedByte(),
+        rowColumn.initializedMask(),
         rows.rowSizeOffset());
 
     ++numColumns;
@@ -384,6 +388,8 @@ void GroupingSet::createHashTable() {
           rowColumn.offset(),
           rowColumn.nullByte(),
           rowColumn.nullMask(),
+          rowColumn.initializedByte(),
+          rowColumn.initializedMask(),
           rows.rowSizeOffset());
       ++numColumns;
     }
@@ -430,6 +436,8 @@ void GroupingSet::initializeGlobalAggregation() {
         offset,
         RowContainer::nullByte(nullOffset),
         RowContainer::nullMask(nullOffset),
+        RowContainer::initializedByte(nullOffset),
+        RowContainer::initializedMask(nullOffset),
         rowSizeOffset);
 
     offset += accumulator.fixedWidthSize();
@@ -448,6 +456,8 @@ void GroupingSet::initializeGlobalAggregation() {
         offset,
         RowContainer::nullByte(nullOffset),
         RowContainer::nullMask(nullOffset),
+        RowContainer::initializedByte(nullOffset),
+        RowContainer::initializedMask(nullOffset),
         rowSizeOffset);
 
     offset += accumulator.fixedWidthSize();
@@ -467,6 +477,8 @@ void GroupingSet::initializeGlobalAggregation() {
           offset,
           RowContainer::nullByte(nullOffset),
           RowContainer::nullMask(nullOffset),
+          RowContainer::initializedByte(nullOffset),
+          RowContainer::initializedMask(nullOffset),
           rowSizeOffset);
 
       offset += accumulator.fixedWidthSize();

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -298,7 +298,7 @@ char* RowContainer::initializeRow(char* row, bool reuse) {
     auto rows = folly::Range<char**>(&row, 1);
     freeVariableWidthFields(rows);
     freeAggregates(rows);
-  } else if (rowSizeOffset_ != 0 && checkFree_) {
+  } else if (rowSizeOffset_ != 0) {
     // zero out string views so that clear() will not hit uninited data. The
     // fastest way is to set the whole row to 0.
     ::memset(row, 0, fixedRowSize_);
@@ -533,9 +533,11 @@ int32_t RowContainer::storeVariableSizeAt(
   const auto size = *reinterpret_cast<const int32_t*>(data);
 
   if (typeKind == TypeKind::VARCHAR || typeKind == TypeKind::VARBINARY) {
-    valueAt<StringView>(row, rowColumn.offset()) = StringView(data + 4, size);
     if (size > 0) {
-      stringAllocator_->copyMultipart(row, rowColumn.offset());
+      stringAllocator_->copyMultipart(
+          StringView(data + 4, size), row, rowColumn.offset());
+    } else {
+      valueAt<StringView>(row, rowColumn.offset()) = StringView();
     }
   } else {
     if (size > 0) {

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -182,7 +182,17 @@ RowContainer::RowContainer(
   // free list next pointer below the bit at 'freeFlagOffset_'.
   offset = std::max<int32_t>(offset, sizeof(void*));
   const int32_t firstAggregateOffset = offset;
+  if (!accumulators.empty()) {
+    // This moves nullOffset to the start of the next byte.
+    // This is to guarantee the null and initialized bits for an aggregate
+    // always appear in the same byte.
+    nullOffset = (nullOffset + 7) & -8;
+  }
   for (const auto& accumulator : accumulators) {
+    // Initialized bit.  Set when the accumulator is initialized.
+    nullOffsets_.push_back(nullOffset);
+    ++nullOffset;
+    // Null bit.
     nullOffsets_.push_back(nullOffset);
     ++nullOffset;
     isVariableWidth |= !accumulator.isFixedSize();
@@ -205,12 +215,13 @@ RowContainer::RowContainer(
   nullOffsets_.push_back(nullOffset);
   freeFlagOffset_ = nullOffset + firstAggregateOffset * 8;
   ++nullOffset;
+  // Add 1 to the last null offset to get the number of bits.
+  flagBytes_ = bits::nbytes(nullOffsets_.back() + 1);
   // Fixup 'nullOffsets_' to be the bit number from the start of the row.
   for (int32_t i = 0; i < nullOffsets_.size(); ++i) {
     nullOffsets_[i] += firstAggregateOffset * 8;
   }
-  const int32_t nullBytes = bits::nbytes(nullOffsets_.size());
-  offset += nullBytes;
+  offset += flagBytes_;
   for (const auto& accumulator : accumulators) {
     // Accumulator offset must be aligned by their alignment size.
     offset = bits::roundUp(offset, accumulator.alignment());
@@ -234,23 +245,28 @@ RowContainer::RowContainer(
   // no nulls, it may be that there are no null flags.
   if (!nullOffsets_.empty()) {
     // All flags like free and probed flags and null flags for keys and non-keys
-    // start as 0.
-    initialNulls_.resize(nullBytes, 0x0);
-    // Aggregates are null on a new row.
-    const auto aggregateNullOffset = nullableKeys ? keyTypes.size() : 0;
-    for (int32_t i = 0; i < accumulators_.size(); ++i) {
-      bits::setBit(initialNulls_.data(), i + aggregateNullOffset);
-    }
+    // start as 0. This is also used to mark aggregates as uninitialized on row
+    // creation.
+    initialNulls_.resize(flagBytes_, 0x0);
   }
   originalNormalizedKeySize_ = hasNormalizedKeys_
       ? bits::roundUp(sizeof(normalized_key_t), alignment_)
       : 0;
   normalizedKeySize_ = originalNormalizedKeySize_;
+  size_t nullOffsetsPos = 0;
   for (auto i = 0; i < offsets_.size(); ++i) {
     rowColumns_.emplace_back(
         offsets_[i],
-        (nullableKeys_ || i >= keyTypes_.size()) ? nullOffsets_[i]
+        (nullableKeys_ || i >= keyTypes_.size()) ? nullOffsets_[nullOffsetsPos]
                                                  : RowColumn::kNotNullOffset);
+
+    if (!accumulators.empty() && i >= keyTypes_.size() &&
+        i < keyTypes_.size() + accumulators.size()) {
+      // Aggregates have two bits, one for null and one for initialized.
+      nullOffsetsPos += 2;
+    } else {
+      nullOffsetsPos++;
+    }
   }
 }
 
@@ -545,8 +561,6 @@ void RowContainer::extractSerializedRows(
   // bytes (see typeKindSize). Variable-width columns are serialized as 4 bytes
   // of size followed by that many bytes.
 
-  const int32_t nullBytes = bits::nbytes(nullOffsets_.size());
-
   // First, calculate total number of bytes needed to serialize all rows.
 
   size_t fixedWidthRowSize = 0;
@@ -560,7 +574,8 @@ void RowContainer::extractSerializedRows(
     }
   }
 
-  size_t totalBytes = nullBytes * rows.size() + fixedWidthRowSize * rows.size();
+  size_t totalBytes =
+      flagBytes_ * rows.size() + fixedWidthRowSize * rows.size();
   if (hasVariableWidth) {
     for (const char* row : rows) {
       for (auto i = 0; i < types_.size(); ++i) {
@@ -585,8 +600,8 @@ void RowContainer::extractSerializedRows(
     size_t offset = 0;
 
     // Copy nulls.
-    memcpy(rawBuffer + offset, row + rowColumns_[0].nullByte(), nullBytes);
-    offset += nullBytes;
+    memcpy(rawBuffer + offset, row + rowColumns_[0].nullByte(), flagBytes_);
+    offset += flagBytes_;
 
     // Copy values.
     for (auto j = 0; j < types_.size(); ++j) {
@@ -617,9 +632,8 @@ void RowContainer::storeSerializedRow(
   auto serialized = vector.valueAt(index);
   size_t offset = 0;
 
-  const int32_t nullBytes = bits::nbytes(nullOffsets_.size());
-  memcpy(row + rowColumns_[0].nullByte(), serialized.data(), nullBytes);
-  offset += nullBytes;
+  memcpy(row + rowColumns_[0].nullByte(), serialized.data(), flagBytes_);
+  offset += flagBytes_;
 
   RowSizeTracker tracker(row[rowSizeOffset_], *stringAllocator_);
   for (auto i = 0; i < types_.size(); ++i) {

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -855,10 +855,11 @@ class RowContainer {
       *reinterpret_cast<T*>(row + offset) = T();
       return;
     }
-    *reinterpret_cast<T*>(row + offset) = decoded.valueAt<T>(index);
     if constexpr (std::is_same_v<T, StringView>) {
       RowSizeTracker tracker(row[rowSizeOffset_], *stringAllocator_);
-      stringAllocator_->copyMultipart(row, offset);
+      stringAllocator_->copyMultipart(decoded.valueAt<T>(index), row, offset);
+    } else {
+      *reinterpret_cast<T*>(row + offset) = decoded.valueAt<T>(index);
     }
   }
 
@@ -870,10 +871,11 @@ class RowContainer {
       char* group,
       int32_t offset) {
     using T = typename TypeTraits<Kind>::NativeType;
-    *reinterpret_cast<T*>(group + offset) = decoded.valueAt<T>(index);
     if constexpr (std::is_same_v<T, StringView>) {
       RowSizeTracker tracker(group[rowSizeOffset_], *stringAllocator_);
-      stringAllocator_->copyMultipart(group, offset);
+      stringAllocator_->copyMultipart(decoded.valueAt<T>(index), group, offset);
+    } else {
+      *reinterpret_cast<T*>(group + offset) = decoded.valueAt<T>(index);
     }
   }
 

--- a/velox/exec/SimpleAggregateAdapter.h
+++ b/velox/exec/SimpleAggregateAdapter.h
@@ -193,15 +193,6 @@ class SimpleAggregateAdapter : public Aggregate {
     return Aggregate::accumulatorAlignmentSize();
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    setAllNulls(groups, indices);
-    for (auto i : indices) {
-      new (groups[i] + offset_) typename FUNC::AccumulatorType(allocator_);
-    }
-  }
-
   // Add raw input to accumulators. If the simple aggregation function has
   // default null behavior, input rows that has nulls are skipped. Otherwise,
   // the accumulator type's addInput() method handles null inputs.
@@ -352,16 +343,27 @@ class SimpleAggregateAdapter : public Aggregate {
     writer.finish();
   }
 
-  void destroy(folly::Range<char**> groups) override {
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      new (groups[i] + offset_) typename FUNC::AccumulatorType(allocator_);
+    }
+  }
+
+  void destroyInternal(folly::Range<char**> groups) override {
     if constexpr (accumulator_custom_destroy_) {
       for (auto group : groups) {
         auto accumulator = value<typename FUNC::AccumulatorType>(group);
-        if (!isNull(group)) {
+        if (isInitialized(group) && !isNull(group)) {
           accumulator->destroy(allocator_);
         }
       }
+    } else {
+      destroyAccumulators<typename FUNC::AccumulatorType>(groups);
     }
-    destroyAccumulators<typename FUNC::AccumulatorType>(groups);
   }
 
  private:

--- a/velox/exec/SortedAggregations.cpp
+++ b/velox/exec/SortedAggregations.cpp
@@ -203,6 +203,7 @@ void SortedAggregations::initializeNewGroups(
   for (auto i : indices) {
     groups[i][nullByte_] |= nullMask_;
     new (groups[i] + offset_) RowPointers();
+    groups[i][initializedByte_] |= initializedMask_;
   }
 
   for (const auto& [sortingSpec, aggregates] : aggregates_) {

--- a/velox/exec/SortedAggregations.h
+++ b/velox/exec/SortedAggregations.h
@@ -54,10 +54,14 @@ class SortedAggregations {
       int32_t offset,
       int32_t nullByte,
       uint8_t nullMask,
+      int32_t initializedByte,
+      uint8_t initializedMask,
       int32_t rowSizeOffset) {
     offset_ = offset;
     nullByte_ = nullByte;
     nullMask_ = nullMask;
+    initializedByte_ = initializedByte;
+    initializedMask_ = initializedMask;
     rowSizeOffset_ = rowSizeOffset;
   }
 
@@ -154,6 +158,8 @@ class SortedAggregations {
   int32_t offset_;
   int32_t nullByte_;
   uint8_t nullMask_;
+  int32_t initializedByte_;
+  uint8_t initializedMask_;
   int32_t rowSizeOffset_;
 };
 

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -386,6 +386,8 @@ void StreamingAggregation::initializeAggregates(uint32_t numKeys) {
         rowColumn.offset(),
         rowColumn.nullByte(),
         rowColumn.nullMask(),
+        rowColumn.initializedByte(),
+        rowColumn.initializedMask(),
         rows_->rowSizeOffset());
     columnIndex++;
   }
@@ -397,6 +399,8 @@ void StreamingAggregation::initializeAggregates(uint32_t numKeys) {
         rowColumn.offset(),
         rowColumn.nullByte(),
         rowColumn.nullMask(),
+        rowColumn.initializedByte(),
+        rowColumn.initializedMask(),
         rows_->rowSizeOffset());
     columnIndex++;
   }
@@ -410,6 +414,8 @@ void StreamingAggregation::initializeAggregates(uint32_t numKeys) {
           rowColumn.offset(),
           rowColumn.nullByte(),
           rowColumn.nullMask(),
+          rowColumn.initializedByte(),
+          rowColumn.initializedMask(),
           rows_->rowSizeOffset());
       columnIndex++;
     }

--- a/velox/exec/tests/AggregateFunctionRegistryTest.cpp
+++ b/velox/exec/tests/AggregateFunctionRegistryTest.cpp
@@ -34,10 +34,6 @@ class AggregateFunc : public Aggregate {
     return 0;
   }
 
-  void initializeNewGroups(
-      char** /*groups*/,
-      folly::Range<const vector_size_t*> /*indices*/) override {}
-
   void addRawInput(
       char** /*groups*/,
       const SelectivityVector& /*rows*/,
@@ -93,6 +89,11 @@ class AggregateFunc : public Aggregate {
     };
     return signatures;
   }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/) override {}
 };
 
 bool registerAggregateFunc(const std::string& name, bool overwrite = false) {

--- a/velox/exec/tests/DummyAggregateFunction.h
+++ b/velox/exec/tests/DummyAggregateFunction.h
@@ -28,10 +28,6 @@ class DummyDicitonaryFunction : public exec::Aggregate {
     return 0;
   }
 
-  void initializeNewGroups(
-      char** /*groups*/,
-      folly::Range<const vector_size_t*> /*indices*/) override {}
-
   void addRawInput(
       char** /*groups*/,
       const SelectivityVector& /*rows*/,
@@ -65,6 +61,11 @@ class DummyDicitonaryFunction : public exec::Aggregate {
       char** /*groups*/,
       int32_t /*numGroups*/,
       VectorPtr* /*result*/) override {}
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/) override {}
 };
 
 AggregateRegistrationResult registerDummyAggregateFunction(

--- a/velox/exec/tests/SimpleAggregateAdapterTest.cpp
+++ b/velox/exec/tests/SimpleAggregateAdapterTest.cpp
@@ -301,6 +301,8 @@ TEST_F(SimpleArrayAggAggregationTest, trackRowSize) {
         offset,
         RowContainer::nullByte(0),
         RowContainer::nullMask(0),
+        RowContainer::initializedByte(0),
+        RowContainer::initializedMask(0),
         rowSizeOffset);
 
     // Make two groups for odd and even rows.

--- a/velox/functions/lib/aggregates/AverageAggregateBase.h
+++ b/velox/functions/lib/aggregates/AverageAggregateBase.h
@@ -83,15 +83,6 @@ class AverageAggregateBase : public exec::Aggregate {
     return sizeof(SumCount<TAccumulator>);
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    setAllNulls(groups, indices);
-    for (auto i : indices) {
-      new (groups[i] + offset_) SumCount<TAccumulator>();
-    }
-  }
-
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     auto vector = (*result)->as<FlatVector<TResult>>();
@@ -382,6 +373,15 @@ class AverageAggregateBase : public exec::Aggregate {
         totalSum += baseSumDecoded.template valueAt<TAccumulator>(decodedIndex);
       });
       updateNonNullValue(group, totalCount, totalSum);
+    }
+  }
+
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      new (groups[i] + offset_) SumCount<TAccumulator>();
     }
   }
 

--- a/velox/functions/lib/aggregates/BitwiseAggregateBase.h
+++ b/velox/functions/lib/aggregates/BitwiseAggregateBase.h
@@ -33,15 +33,6 @@ class BitwiseAggregateBase : public SimpleNumericAggregate<T, T, T> {
     return sizeof(T);
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    exec::Aggregate::setAllNulls(groups, indices);
-    for (auto i : indices) {
-      *exec::Aggregate::value<T>(groups[i]) = initialValue_;
-    }
-  }
-
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     BaseAggregate::doExtractValues(groups, numGroups, result, [&](char* group) {
@@ -66,6 +57,15 @@ class BitwiseAggregateBase : public SimpleNumericAggregate<T, T, T> {
   }
 
  protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    exec::Aggregate::setAllNulls(groups, indices);
+    for (auto i : indices) {
+      *exec::Aggregate::value<T>(groups[i]) = initialValue_;
+    }
+  }
+
   const T initialValue_;
 };
 

--- a/velox/functions/lib/aggregates/CentralMomentsAggregatesBase.h
+++ b/velox/functions/lib/aggregates/CentralMomentsAggregatesBase.h
@@ -221,15 +221,6 @@ class CentralMomentsAggregatesBase : public exec::Aggregate {
     return sizeof(CentralMomentsAccumulator);
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    setAllNulls(groups, indices);
-    for (auto i : indices) {
-      new (groups[i] + offset_) CentralMomentsAccumulator();
-    }
-  }
-
   void addRawInput(
       char** groups,
       const SelectivityVector& rows,
@@ -409,6 +400,16 @@ class CentralMomentsAggregatesBase : public exec::Aggregate {
         clearNull(rawNulls, i);
         centralMomentsResult.set(i, *accumulator(group));
       }
+    }
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      new (groups[i] + offset_) CentralMomentsAccumulator();
     }
   }
 

--- a/velox/functions/lib/aggregates/DecimalAggregate.h
+++ b/velox/functions/lib/aggregates/DecimalAggregate.h
@@ -81,15 +81,6 @@ class DecimalAggregate : public exec::Aggregate {
     return static_cast<int32_t>(sizeof(int128_t));
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    setAllNulls(groups, indices);
-    for (auto i : indices) {
-      new (groups[i] + offset_) LongDecimalWithOverflowState();
-    }
-  }
-
   void addRawInput(
       char** groups,
       const SelectivityVector& rows,
@@ -324,6 +315,16 @@ class DecimalAggregate : public exec::Aggregate {
     accumulator->overflow +=
         DecimalUtil::addWithOverflow(accumulator->sum, value, accumulator->sum);
     accumulator->count += 1;
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      new (groups[i] + offset_) LongDecimalWithOverflowState();
+    }
   }
 
  private:

--- a/velox/functions/lib/aggregates/SumAggregateBase.h
+++ b/velox/functions/lib/aggregates/SumAggregateBase.h
@@ -43,15 +43,6 @@ class SumAggregateBase
     return 1;
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    exec::Aggregate::setAllNulls(groups, indices);
-    for (auto i : indices) {
-      *exec::Aggregate::value<TAccumulator>(groups[i]) = 0;
-    }
-  }
-
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     BaseAggregate::template doExtractValues<ResultType>(
@@ -144,6 +135,15 @@ class SumAggregateBase
     } else {
       BaseAggregate::template updateGroups<false, TData, TValue>(
           groups, rows, arg, &updateSingleValue<TData>, false);
+    }
+  }
+
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    exec::Aggregate::setAllNulls(groups, indices);
+    for (auto i : indices) {
+      *exec::Aggregate::value<TAccumulator>(groups[i]) = 0;
     }
   }
 

--- a/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
@@ -1130,7 +1130,7 @@ std::unique_ptr<exec::Aggregate> createAggregateFunction(
       finalType,
       queryConfig);
   func->setAllocator(&allocator);
-  func->setOffsets(kOffset, 0, 1, kRowSizeOffset);
+  func->setOffsets(kOffset, 0, 1, 0, 2, kRowSizeOffset);
 
   VELOX_CHECK(intermediateType->equivalent(
       *func->intermediateType(functionName, inputTypes)));

--- a/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
@@ -72,18 +72,6 @@ struct ApproxMostFrequentAggregate : exec::Aggregate {
     return sizeof(Accumulator<T>);
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    for (auto index : indices) {
-      new (groups[index] + offset_) Accumulator<T>(allocator_);
-    }
-  }
-
-  void destroy(folly::Range<char**> groups) override {
-    destroyAccumulators<Accumulator<T>>(groups);
-  }
-
   void addRawInput(
       char** groups,
       const SelectivityVector& rows,
@@ -216,6 +204,19 @@ struct ApproxMostFrequentAggregate : exec::Aggregate {
         entryCount += summary->size();
       }
     }
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    for (auto index : indices) {
+      new (groups[index] + offset_) Accumulator<T>(allocator_);
+    }
+  }
+
+  void destroyInternal(folly::Range<char**> groups) override {
+    destroyAccumulators<Accumulator<T>>(groups);
   }
 
  private:

--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
@@ -146,22 +146,6 @@ class ApproxPercentileAggregate : public exec::Aggregate {
     return false;
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    exec::Aggregate::setAllNulls(groups, indices);
-    for (auto i : indices) {
-      auto group = groups[i];
-      new (group + offset_) KllSketchAccumulator<T>(allocator_);
-    }
-  }
-
-  void destroy(folly::Range<char**> groups) override {
-    for (auto group : groups) {
-      value<KllSketchAccumulator<T>>(group)->~KllSketchAccumulator<T>();
-    }
-  }
-
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     finalize(groups, numGroups);
@@ -416,6 +400,25 @@ class ApproxPercentileAggregate : public exec::Aggregate {
       const std::vector<VectorPtr>& args,
       bool /*mayPushdown*/) override {
     addIntermediate<true>(group, rows, args);
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    exec::Aggregate::setAllNulls(groups, indices);
+    for (auto i : indices) {
+      auto group = groups[i];
+      new (group + offset_) KllSketchAccumulator<T>(allocator_);
+    }
+  }
+
+  void destroyInternal(folly::Range<char**> groups) override {
+    for (auto group : groups) {
+      if (isInitialized(group)) {
+        value<KllSketchAccumulator<T>>(group)->~KllSketchAccumulator<T>();
+      }
+    }
   }
 
  private:

--- a/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
@@ -92,14 +92,6 @@ class ArrayAggAggregate : public exec::Aggregate {
         loadedElements);
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    for (auto index : indices) {
-      new (groups[index] + offset_) ArrayAccumulator();
-    }
-  }
-
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     auto vector = (*result)->as<ArrayVector>();
@@ -213,9 +205,20 @@ class ArrayAggAggregate : public exec::Aggregate {
     });
   }
 
-  void destroy(folly::Range<char**> groups) override {
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    for (auto index : indices) {
+      new (groups[index] + offset_) ArrayAccumulator();
+    }
+  }
+
+  void destroyInternal(folly::Range<char**> groups) override {
     for (auto group : groups) {
-      value<ArrayAccumulator>(group)->elements.free(allocator_);
+      if (isInitialized(group)) {
+        value<ArrayAccumulator>(group)->elements.free(allocator_);
+      }
     }
   }
 

--- a/velox/functions/prestosql/aggregates/BoolAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/BoolAggregates.cpp
@@ -62,7 +62,8 @@ class BoolAndOrAggregate : public SimpleNumericAggregate<bool, bool, bool> {
     extractValues(groups, numGroups, result);
   }
 
-  void initializeNewGroups(
+ protected:
+  void initializeNewGroupsInternal(
       char** groups,
       folly::Range<const vector_size_t*> indices) override {
     setAllNulls(groups, indices);
@@ -71,7 +72,6 @@ class BoolAndOrAggregate : public SimpleNumericAggregate<bool, bool, bool> {
     }
   }
 
- protected:
   const bool initialValue_;
 };
 

--- a/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
@@ -40,15 +40,6 @@ class ChecksumAggregate : public exec::Aggregate {
     return sizeof(int64_t);
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    setAllNulls(groups, indices);
-    for (auto i : indices) {
-      *value<int64_t>(groups[i]) = 0;
-    }
-  }
-
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     auto* vector = (*result)->asUnchecked<FlatVector<StringView>>();
@@ -192,6 +183,16 @@ class ChecksumAggregate : public exec::Aggregate {
       clearNull(group);
     }
     safeAdd(*value<int64_t>(group), result);
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      *value<int64_t>(groups[i]) = 0;
+    }
   }
 
  private:

--- a/velox/functions/prestosql/aggregates/CountAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountAggregate.cpp
@@ -34,15 +34,6 @@ class CountAggregate : public SimpleNumericAggregate<bool, int64_t, int64_t> {
     return sizeof(int64_t);
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    for (auto i : indices) {
-      // result of count is never null
-      *value<int64_t>(groups[i]) = (int64_t)0;
-    }
-  }
-
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     BaseAggregate::doExtractValues(groups, numGroups, result, [&](char* group) {
@@ -138,6 +129,16 @@ class CountAggregate : public SimpleNumericAggregate<bool, int64_t, int64_t> {
     }
 
     addToGroup(group, count);
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    for (auto i : indices) {
+      // result of count is never null
+      *value<int64_t>(groups[i]) = (int64_t)0;
+    }
   }
 
  private:

--- a/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
@@ -33,14 +33,6 @@ class CountIfAggregate : public exec::Aggregate {
     return sizeof(int64_t);
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    for (auto i : indices) {
-      *value<int64_t>(groups[i]) = 0;
-    }
-  }
-
   void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     extractValues(groups, numGroups, result);
@@ -160,6 +152,15 @@ class CountIfAggregate : public exec::Aggregate {
     rows.applyToSelected([&](auto row) { numTrue += arg->valueAt(row); });
 
     addToGroup(group, numTrue);
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    for (auto i : indices) {
+      *value<int64_t>(groups[i]) = 0;
+    }
   }
 
  private:

--- a/velox/functions/prestosql/aggregates/CovarianceAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/CovarianceAggregates.cpp
@@ -556,15 +556,6 @@ class CovarianceAggregate : public exec::Aggregate {
     return sizeof(TAccumulator);
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    setAllNulls(groups, indices);
-    for (auto i : indices) {
-      new (groups[i] + offset_) TAccumulator();
-    }
-  }
-
   void addRawInput(
       char** groups,
       const SelectivityVector& rows,
@@ -708,6 +699,16 @@ class CovarianceAggregate : public exec::Aggregate {
         clearNull(rawNulls, i);
         covarResult.set(i, *accumulator(group));
       }
+    }
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      new (groups[i] + offset_) TAccumulator();
     }
   }
 

--- a/velox/functions/prestosql/aggregates/EntropyAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/EntropyAggregates.cpp
@@ -85,15 +85,6 @@ class EntropyAggregate : public exec::Aggregate {
     return sizeof(EntropyAccumulator);
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    setAllNulls(groups, indices);
-    for (auto i : indices) {
-      new (groups[i] + offset_) EntropyAccumulator();
-    }
-  }
-
   void addRawInput(
       char** groups,
       const SelectivityVector& rows,
@@ -285,6 +276,15 @@ class EntropyAggregate : public exec::Aggregate {
  protected:
   inline EntropyAccumulator* accumulator(char* group) {
     return exec::Aggregate::value<EntropyAccumulator>(group);
+  }
+
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      new (groups[i] + offset_) EntropyAccumulator();
+    }
   }
 
  private:

--- a/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
@@ -168,14 +168,6 @@ class HistogramAggregate : public exec::Aggregate {
     return false;
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    for (auto index : indices) {
-      new (groups[index] + offset_) AccumulatorType{allocator_};
-    }
-  }
-
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     auto mapVector = (*result)->as<MapVector>();
@@ -321,7 +313,16 @@ class HistogramAggregate : public exec::Aggregate {
     });
   }
 
-  void destroy(folly::Range<char**> groups) override {
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    for (auto index : indices) {
+      new (groups[index] + offset_) AccumulatorType{allocator_};
+    }
+  }
+
+  void destroyInternal(folly::Range<char**> groups) override {
     destroyAccumulators<AccumulatorType>(groups);
   }
 

--- a/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
@@ -56,15 +56,6 @@ class MaxSizeForStatsAggregate
     });
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    exec::Aggregate::setAllNulls(groups, indices);
-    for (auto i : indices) {
-      *BaseAggregate ::value<int64_t>(groups[i]) = 0;
-    }
-  }
-
   void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     // Partial and final aggregations are the same.
@@ -198,6 +189,15 @@ class MaxSizeForStatsAggregate
       rows.applyToSelected([&](auto row) {
         updateOneAccumulator(group, row, elementSizes_[sizeIndex++]);
       });
+    }
+  }
+
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    exec::Aggregate::setAllNulls(groups, indices);
+    for (auto i : indices) {
+      *BaseAggregate ::value<int64_t>(groups[i]) = 0;
     }
   }
 };

--- a/velox/functions/prestosql/aggregates/SetAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/SetAggregates.cpp
@@ -38,16 +38,6 @@ class SetBaseAggregate : public exec::Aggregate {
     return false;
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    const auto& type = resultType()->childAt(0);
-    exec::Aggregate::setAllNulls(groups, indices);
-    for (auto i : indices) {
-      new (groups[i] + offset_) AccumulatorType(type, allocator_);
-    }
-  }
-
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     auto arrayVector = (*result)->as<ArrayVector>();
@@ -120,14 +110,6 @@ class SetBaseAggregate : public exec::Aggregate {
     addSingleGroupIntermediateResultsInt(group, rows, args, false);
   }
 
-  void destroy(folly::Range<char**> groups) override {
-    for (auto* group : groups) {
-      if (!isNull(group)) {
-        value(group)->free(*allocator_);
-      }
-    }
-  }
-
  protected:
   inline AccumulatorType* value(char* group) {
     return reinterpret_cast<AccumulatorType*>(group + Aggregate::offset_);
@@ -190,6 +172,24 @@ class SetBaseAggregate : public exec::Aggregate {
       accumulator->addValues(
           *baseArray, decodedIndex, decodedElements_, allocator_);
     });
+  }
+
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    const auto& type = resultType()->childAt(0);
+    exec::Aggregate::setAllNulls(groups, indices);
+    for (auto i : indices) {
+      new (groups[i] + offset_) AccumulatorType(type, allocator_);
+    }
+  }
+
+  void destroyInternal(folly::Range<char**> groups) override {
+    for (auto* group : groups) {
+      if (isInitialized(group) && !isNull(group)) {
+        value(group)->free(*allocator_);
+      }
+    }
   }
 
   DecodedVector decoded_;

--- a/velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.cpp
@@ -48,15 +48,6 @@ class SumDataSizeForStatsAggregate
     });
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    exec::Aggregate::setAllNulls(groups, indices);
-    for (auto index : indices) {
-      *BaseAggregate ::value<int64_t>(groups[index]) = 0;
-    }
-  }
-
   void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     // Partial and final aggregations are the same.
@@ -170,6 +161,15 @@ class SumDataSizeForStatsAggregate
     rows.applyToSelected([&](auto row) {
       updateOneAccumulator(group, row, rowSizes_[sizeIndex++]);
     });
+  }
+
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    exec::Aggregate::setAllNulls(groups, indices);
+    for (auto index : indices) {
+      *BaseAggregate ::value<int64_t>(groups[index]) = 0;
+    }
   }
 
  private:

--- a/velox/functions/prestosql/aggregates/VarianceAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/VarianceAggregates.cpp
@@ -146,15 +146,6 @@ class VarianceAggregate : public exec::Aggregate {
     return sizeof(VarianceAccumulator);
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    setAllNulls(groups, indices);
-    for (auto i : indices) {
-      new (groups[i] + offset_) VarianceAccumulator();
-    }
-  }
-
   void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     auto rowVector = (*result)->as<RowVector>();
@@ -374,6 +365,15 @@ class VarianceAggregate : public exec::Aggregate {
  protected:
   inline VarianceAccumulator* accumulator(char* group) {
     return exec::Aggregate::value<VarianceAccumulator>(group);
+  }
+
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      new (groups[i] + offset_) VarianceAccumulator();
+    }
   }
 
  private:

--- a/velox/functions/prestosql/aggregates/tests/HistogramTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/HistogramTest.cpp
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/RowContainer.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
 

--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
@@ -76,15 +76,6 @@ class BloomFilterAggAggregate : public exec::Aggregate {
     return false;
   }
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    setAllNulls(groups, indices);
-    for (auto i : indices) {
-      new (groups[i] + offset_) BloomFilterAccumulator(allocator_);
-    }
-  }
-
   static FOLLY_ALWAYS_INLINE void checkBloomFilterNotNull(
       DecodedVector& decoded,
       vector_size_t idx) {
@@ -203,6 +194,16 @@ class BloomFilterAggAggregate : public exec::Aggregate {
   void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     extractValues(groups, numGroups, result);
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      new (groups[i] + offset_) BloomFilterAccumulator(allocator_);
+    }
   }
 
  private:


### PR DESCRIPTION
Summary:
When a string is written to the RowContainer, its contents are copied into a buffer owned by the container's 
HashStringAllocator (if it's not inlined).

The way copyMultipart in HashStringAllocator works today, we have to first copy the StringView into the row, then copy the
contents into memory owned by the allocator, and then update the row's StringView in place to refer to the new memory.

If allocating memory in the allocator fails, we then have StringView in the row that refers to memory outside that owned by
the HashStringAllocator.  When the RowContainer is destructed, if it has to call eraseRows as part of clear, it will then try to
free the memory pointed to by the StringView from the HashStringAllocator, which leads to a SIGSEGV.

The fix is to pass the StringView we plan to write to the row into copyMultipart, and then construct the new StringView in
place inside the row pointing to the new memory allocated by the HashStringAllocator once it's already been allocated.  This
way the row is never in an inconsistent state.

I also deleted the copy function from HashStringAllocator since it's never used (otherwise I'd need to update it).

I also changed initializeRow in RowContainer to always 0 out the memory in the row.  Otherwise we could end up with an
uninitialized non-empty StringView in the row in the case I described above and still hit a SIGSEGV (I encountered this in the
unit test I wrote).

Differential Revision: D54872223


