### PR TITLE
Add GenericView::toString() API for debugging

### DIFF
--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -1115,6 +1115,10 @@ class GenericView {
     return decoded_.base()->type();
   }
 
+  std::string toString() const {
+    return decoded_.toString(index_);
+  }
+
   // If conversion is invalid, behavior is undefined. However, debug time
   // checks will throw an exception.
   template <typename ToType>

--- a/velox/expression/tests/GenericViewTest.cpp
+++ b/velox/expression/tests/GenericViewTest.cpp
@@ -202,6 +202,43 @@ TEST_F(GenericViewTest, arrayOfGeneric) {
   }
 }
 
+TEST_F(GenericViewTest, toString) {
+  {
+    auto data = makeArrayVectorFromJson<int32_t>({
+        "[1, 2, 3]",
+    });
+
+    DecodedVector decoded(*data);
+    exec::VectorReader<Array<Any>> reader(&decoded);
+
+    auto arrayView = reader[0];
+    EXPECT_EQ("1", arrayView[0].value().toString());
+    EXPECT_EQ("2", arrayView[1].value().toString());
+    EXPECT_EQ("3", arrayView[2].value().toString());
+  }
+
+  {
+    auto data = makeMapVectorFromJson<int32_t, int64_t>({
+        "{1: 10, 2: null, 3: 30}",
+    });
+
+    DecodedVector decoded(*data);
+    exec::VectorReader<Map<Any, Any>> reader(&decoded);
+
+    auto mapView = reader[0];
+    auto it = mapView.begin();
+    EXPECT_EQ("3", it->first.toString());
+    EXPECT_EQ("30", it->second.value().toString());
+
+    ++it;
+    EXPECT_EQ("2", it->first.toString());
+
+    ++it;
+    EXPECT_EQ("1", it->first.toString());
+    EXPECT_EQ("10", it->second.value().toString());
+  }
+}
+
 template <typename T>
 struct CompareFunc {
   VELOX_DEFINE_FUNCTION_TYPES(T);

--- a/velox/vector/DecodedVector.cpp
+++ b/velox/vector/DecodedVector.cpp
@@ -465,4 +465,12 @@ void DecodedVector::applyToRows(const SelectivityVector* rows, Func&& func)
     }
   }
 }
+
+std::string DecodedVector::toString(vector_size_t idx) const {
+  if (isNullAt(idx)) {
+    return "null";
+  }
+
+  return baseVector_->toString(index(idx));
+}
 } // namespace facebook::velox

--- a/velox/vector/DecodedVector.h
+++ b/velox/vector/DecodedVector.h
@@ -230,6 +230,9 @@ class DecodedVector {
     return isConstantMapping_;
   }
 
+  /// Returns string representation of the value in the specified row.
+  std::string toString(vector_size_t idx) const;
+
   /////////////////////////////////////////////////////////////////
   /// BEGIN: Members that must only be used by PeeledEncoding class.
   /// See class comment for more details.

--- a/velox/vector/tests/DecodedVectorTest.cpp
+++ b/velox/vector/tests/DecodedVectorTest.cpp
@@ -1439,4 +1439,51 @@ TEST_F(DecodedVectorTest, previousIndicesInReUsedDecodedVector) {
   EXPECT_EQ(rawIndices[0], 0);
 }
 
+TEST_F(DecodedVectorTest, toString) {
+  auto vector = makeNullableFlatVector<int32_t>({1, std::nullopt, 3});
+  {
+    DecodedVector decoded(*vector);
+    EXPECT_EQ("1", decoded.toString(0));
+    EXPECT_EQ("null", decoded.toString(1));
+    EXPECT_EQ("3", decoded.toString(2));
+  }
+
+  auto dict = wrapInDictionary(makeIndicesInReverse(3), vector);
+  {
+    DecodedVector decoded(*dict);
+    EXPECT_EQ("3", decoded.toString(0));
+    EXPECT_EQ("null", decoded.toString(1));
+    EXPECT_EQ("1", decoded.toString(2));
+  }
+
+  auto constant = makeConstant<int32_t>(123, 10);
+  {
+    DecodedVector decoded(*constant);
+    EXPECT_EQ("123", decoded.toString(0));
+    EXPECT_EQ("123", decoded.toString(1));
+    EXPECT_EQ("123", decoded.toString(2));
+  }
+
+  constant = makeNullConstant(TypeKind::INTEGER, 5);
+  {
+    DecodedVector decoded(*constant);
+    EXPECT_EQ("null", decoded.toString(0));
+    EXPECT_EQ("null", decoded.toString(1));
+    EXPECT_EQ("null", decoded.toString(2));
+  }
+
+  dict = BaseVector::wrapInDictionary(
+      makeNulls(10, nullEvery(2)),
+      makeIndices(10, [](auto row) { return row % 3; }),
+      10,
+      makeFlatVector<int32_t>({1, 2, 3}));
+  {
+    DecodedVector decoded(*dict);
+    EXPECT_EQ("null", decoded.toString(0));
+    EXPECT_EQ("2", decoded.toString(1));
+    EXPECT_EQ("null", decoded.toString(2));
+    EXPECT_EQ("1", decoded.toString(3));
+  }
+}
+
 } // namespace facebook::velox::test


### PR DESCRIPTION
Summary:
This API is helpful for debugging scalar functions written using Simple
FunctionAPI and operating on generic maps and arrays.

Differential Revision: D54883392


