### PR TITLE
Store duplicate row address in vector for join probe

### DIFF
--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -804,14 +804,7 @@ void HashBuild::ensureTableFits(uint64_t numRows) {
 void HashBuild::ensureNextRowVectorFits(
     uint64_t numRows,
     const std::vector<HashBuild*>& otherBuilds) {
-  if (!spillEnabled() || spiller_ == nullptr || spiller_->isAllSpilled()) {
-    return;
-  }
-
-  // Test-only spill path.
-  if (testingTriggerSpill()) {
-    Operator::ReclaimableSectionGuard guard(this);
-    memory::testingRunArbitration(pool());
+  if (!spillEnabled()) {
     return;
   }
 

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -399,7 +399,6 @@ void HashBuild::addInput(RowVectorPtr input) {
     }
   }
   auto rows = table_->rows();
-  auto nextOffset = rows->nextOffset();
   FlatVector<bool>* spillProbedFlagVector{nullptr};
   if (isInputFromSpill() && needProbedFlagSpill_) {
     spillProbedFlagVector =
@@ -408,9 +407,6 @@ void HashBuild::addInput(RowVectorPtr input) {
 
   activeRows_.applyToSelected([&](auto rowIndex) {
     char* newRow = rows->newRow();
-    if (nextOffset) {
-      *reinterpret_cast<char**>(newRow + nextOffset) = nullptr;
-    }
     // Store the columns for each row in sequence. At probe time
     // strings of the row will probably be in consecutive places, so
     // reading one will prime the cache for the next.

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -146,6 +146,13 @@ class HashBuild final : public Operator {
   // the query if the memory reservation fails.
   void ensureTableFits(uint64_t numRows);
 
+  // Invoked to ensure there is sufficient memory to build the next-row-vectors
+  // with the specified 'numRows' if spilling is enabled. The function throws to
+  // fail the query if the memory reservation fails.
+  void ensureNextRowVectorFits(
+      uint64_t numRows,
+      const std::vector<HashBuild*>& otherBuilds);
+
   // Invoked to compute spill partitions numbers for each row 'input' and spill
   // rows to spiller directly if the associated partition(s) is spilling. The
   // function will skip processing if disk spilling is not enabled or there is

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -727,6 +727,12 @@ void HashTable<ignoreNullKeys>::allocateTables(uint64_t size) {
 
 template <bool ignoreNullKeys>
 void HashTable<ignoreNullKeys>::clear(bool freeTable) {
+  if (otherTables_.size() > 0) {
+    rows_->clearNextRowVectors();
+    for (auto i = 0; i < otherTables_.size(); ++i) {
+      otherTables_[i]->rows()->clearNextRowVectors();
+    }
+  }
   for (auto* rowContainer : allRows()) {
     rowContainer->clear();
   }

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -962,8 +962,14 @@ void HashTable<ignoreNullKeys>::parallelJoinBuild() {
         folly::Range<char**>(overflows.data(), overflows.size()),
         false,
         hashes);
-    insertForJoin(overflows.data(), hashes.data(), overflows.size(), nullptr);
     auto table = i == 0 ? this : otherTables_[i - 1].get();
+    insertForJoin(
+        table->rows(),
+        overflows.data(),
+        hashes.data(),
+        overflows.size(),
+        nullptr);
+
     VELOX_CHECK_EQ(table->rows()->numRows(), table->numParallelBuildRows_);
   }
 }
@@ -1030,13 +1036,16 @@ void HashTable<ignoreNullKeys>::buildJoinPartition(
       buildPartitionBounds_[partition],
       buildPartitionBounds_[partition + 1],
       overflow};
+  auto rowContainer =
+      (partition == 0 ? this : otherTables_[partition - 1].get())->rows();
   for (auto i = 0; i < numPartitions; ++i) {
     auto* table = i == 0 ? this : otherTables_[i - 1].get();
     RowContainerIterator iter;
     while (const auto numRows = table->rows_->listPartitionRows(
                iter, partition, kBatch, *rowPartitions[i], rows.data())) {
       hashRows(folly::Range(rows.data(), numRows), false, hashes);
-      insertForJoin(rows.data(), hashes.data(), numRows, &partitionInfo);
+      insertForJoin(
+          rowContainer, rows.data(), hashes.data(), numRows, &partitionInfo);
       table->numParallelBuildRows_ += numRows;
     }
   }
@@ -1052,7 +1061,7 @@ bool HashTable<ignoreNullKeys>::insertBatch(
     return false;
   }
   if (isJoinBuild_) {
-    insertForJoin(groups, hashes.data(), numGroups);
+    insertForJoin(rows(), groups, hashes.data(), numGroups);
   } else {
     insertForGroupBy(groups, hashes.data(), numGroups);
   }
@@ -1114,13 +1123,11 @@ void HashTable<ignoreNullKeys>::insertForGroupBy(
 template <bool ignoreNullKeys>
 bool HashTable<ignoreNullKeys>::arrayPushRow(char* row, int32_t index) {
   auto existing = table_[index];
-  if (nextOffset_) {
-    nextRow(row) = existing;
-    if (existing) {
+  if (existing) {
+    if (nextOffset_) {
       hasDuplicates_ = true;
+      rows_->appendNextRow(existing, row);
     }
-  } else if (existing) {
-    // Semijoin or a known unique build side ignores a repeat of a key.
     return false;
   }
   table_[index] = row;
@@ -1128,17 +1135,19 @@ bool HashTable<ignoreNullKeys>::arrayPushRow(char* row, int32_t index) {
 }
 
 template <bool ignoreNullKeys>
-void HashTable<ignoreNullKeys>::pushNext(char* row, char* next) {
+void HashTable<ignoreNullKeys>::pushNext(
+    RowContainer* rows,
+    char* row,
+    char* next) {
   if (nextOffset_ > 0) {
     hasDuplicates_ = true;
-    auto previousNext = nextRow(row);
-    nextRow(row) = next;
-    nextRow(next) = previousNext;
+    rows->appendNextRow(row, next);
   }
 }
 
 template <bool ignoreNullKeys>
 FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::buildFullProbe(
+    RowContainer* rows,
     ProbeState& state,
     uint64_t hash,
     char* inserted,
@@ -1161,7 +1170,7 @@ FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::buildFullProbe(
           if (RowContainer::normalizedKey(group) ==
               RowContainer::normalizedKey(inserted)) {
             if (nextOffset_) {
-              pushNext(group, inserted);
+              pushNext(rows, group, inserted);
             }
             return true;
           }
@@ -1178,7 +1187,7 @@ FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::buildFullProbe(
         [&](char* group, int32_t /*row*/) {
           if (compareKeys(group, inserted)) {
             if (nextOffset_ > 0) {
-              pushNext(group, inserted);
+              pushNext(rows, group, inserted);
             }
             return true;
           }
@@ -1193,6 +1202,7 @@ FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::buildFullProbe(
 
 template <bool ignoreNullKeys>
 void HashTable<ignoreNullKeys>::insertForJoin(
+    RowContainer* rows,
     char** groups,
     uint64_t* hashes,
     int32_t numGroups,
@@ -1213,7 +1223,7 @@ void HashTable<ignoreNullKeys>::insertForJoin(
     state.preProbe(*this, hashes[i], i);
     state.firstProbe(*this, 0);
 
-    buildFullProbe(state, hashes[i], groups[i], i, partitionInfo);
+    buildFullProbe(rows, state, hashes[i], groups[i], i, partitionInfo);
   }
 }
 
@@ -1681,44 +1691,48 @@ int32_t HashTable<ignoreNullKeys>::listJoinResults(
   if (!hasDuplicates_) {
     return listJoinResultsNoDuplicates(iter, includeMisses, inputRows, hits);
   }
-  int numOut = 0;
+  size_t numOut = 0;
   auto maxOut = inputRows.size();
   while (iter.lastRowIndex < iter.rows->size()) {
-    if (!iter.nextHit) {
-      auto row = (*iter.rows)[iter.lastRowIndex];
-      iter.nextHit = (*iter.hits)[row]; // NOLINT
-      if (!iter.nextHit) {
-        ++iter.lastRowIndex;
-
-        if (includeMisses) {
-          inputRows[numOut] = row; // NOLINT
-          hits[numOut] = nullptr;
-          ++numOut;
-          if (numOut >= maxOut) {
-            return numOut;
-          }
+    auto row = (*iter.rows)[iter.lastRowIndex];
+    auto hit = (*iter.hits)[row]; // NOLINT
+    if (!hit) {
+      ++iter.lastRowIndex;
+      if (includeMisses) {
+        inputRows[numOut] = row; // NOLINT
+        hits[numOut] = nullptr;
+        ++numOut;
+        if (numOut >= maxOut) {
+          return numOut;
         }
-        continue;
+      }
+      continue;
+    }
+
+    auto rows = rows_->getNextRowVector(hit);
+    if (!rows) {
+      inputRows[numOut] = row; // NOLINT
+      hits[numOut] = hit;
+      numOut++;
+      iter.lastRowIndex++;
+    } else {
+      auto numRows = rows->size();
+      auto num =
+          std::min(numRows - iter.lastDuplicateRowIndex, maxOut - numOut);
+      std::fill_n(inputRows.begin() + numOut, num, row);
+      std::memcpy(
+          hits.data() + numOut,
+          rows->data() + iter.lastDuplicateRowIndex,
+          num * sizeof(char*));
+      iter.lastDuplicateRowIndex += num;
+      numOut += num;
+      if (iter.lastDuplicateRowIndex >= numRows) {
+        iter.lastDuplicateRowIndex = 0;
+        iter.lastRowIndex++;
       }
     }
-    while (iter.nextHit) {
-      char* next = nullptr;
-      if (nextOffset_) {
-        next = nextRow(iter.nextHit);
-        if (next) {
-          __builtin_prefetch(reinterpret_cast<char*>(next) + nextOffset_);
-        }
-      }
-      inputRows[numOut] = (*iter.rows)[iter.lastRowIndex]; // NOLINT
-      hits[numOut] = iter.nextHit;
-      ++numOut;
-      iter.nextHit = next;
-      if (!iter.nextHit) {
-        ++iter.lastRowIndex;
-      }
-      if (numOut >= maxOut) {
-        return numOut;
-      }
+    if (numOut >= maxOut) {
+      return numOut;
     }
   }
   return numOut;
@@ -1860,13 +1874,28 @@ int32_t HashTable<false>::listNullKeyRows(
     iter->nextHit = lookup.hits[0];
     iter->initialized = true;
   }
-  int32_t numRows = 0;
-  char* hit = iter->nextHit;
-  while (numRows < maxRows && hit) {
-    rows[numRows++] = hit;
-    hit = nextRow(hit);
+  size_t numRows = 0;
+  if (numRows < maxRows && iter->nextHit) {
+    auto nextRows = rows_->getNextRowVector(iter->nextHit);
+    if (nextRows) {
+      auto num = std::min(
+          nextRows->size() - iter->lastDuplicateRowIndex, maxRows - numRows);
+      std::memcpy(
+          rows + numRows,
+          nextRows->data() + iter->lastDuplicateRowIndex,
+          num * sizeof(char*));
+      iter->lastDuplicateRowIndex += num;
+      numRows += num;
+      if (iter->lastDuplicateRowIndex >= nextRows->size()) {
+        iter->nextHit = nullptr;
+        iter->lastDuplicateRowIndex = 0;
+      }
+    } else {
+      rows[numRows++] = iter->nextHit;
+      iter->nextHit = nullptr;
+    }
   }
-  iter->nextHit = hit;
+
   return numRows;
 }
 

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -446,7 +446,7 @@ class HashTable : public BaseHashTable {
       memory::MemoryPool* pool,
       const std::shared_ptr<velox::HashStringAllocator>& stringArena = nullptr);
 
-  ~HashTable() {
+  ~HashTable() override {
     if (otherTables_.size() > 0) {
       rows_->clearNextRowVectors();
       for (auto i = 0; i < otherTables_.size(); ++i) {

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -446,6 +446,15 @@ class HashTable : public BaseHashTable {
       memory::MemoryPool* pool,
       const std::shared_ptr<velox::HashStringAllocator>& stringArena = nullptr);
 
+  ~HashTable() {
+    if (otherTables_.size() > 0) {
+      rows_->clearNextRowVectors();
+      for (auto i = 0; i < otherTables_.size(); ++i) {
+        otherTables_[i]->rows()->clearNextRowVectors();
+      }
+    }
+  }
+
   static std::unique_ptr<HashTable> createForAggregation(
       std::vector<std::unique_ptr<VectorHasher>>&& hashers,
       const std::vector<Accumulator>& accumulators,

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -144,8 +144,8 @@ class BaseHashTable {
     void reset(const HashLookup& lookup) {
       rows = &lookup.rows;
       hits = &lookup.hits;
-      nextHit = nullptr;
       lastRowIndex = 0;
+      lastDuplicateRowIndex = 0;
     }
 
     bool atEnd() const {
@@ -154,8 +154,8 @@ class BaseHashTable {
 
     const raw_vector<vector_size_t>* rows{nullptr};
     const raw_vector<char*>* hits{nullptr};
-    char* nextHit{nullptr};
     vector_size_t lastRowIndex{0};
+    vector_size_t lastDuplicateRowIndex{0};
   };
 
   struct RowsIterator {
@@ -172,6 +172,7 @@ class BaseHashTable {
   struct NullKeyRowsIterator {
     bool initialized = false;
     char* nextHit;
+    vector_size_t lastDuplicateRowIndex{0};
   };
 
   /// Takes ownership of 'hashers'. These are used to keep key-level
@@ -324,7 +325,7 @@ class BaseHashTable {
       int32_t numNew,
       bool disableRangeArrayHash = false) = 0;
 
-  // Removes 'rows'  from the hash table and its RowContainer. 'rows' must exist
+  // Removes 'rows' from the hash table and its RowContainer. 'rows' must exist
   // and be unique.
   virtual void erase(folly::Range<char**> rows) = 0;
 
@@ -694,10 +695,6 @@ class HashTable : public BaseHashTable {
   int32_t
   listRows(RowsIterator* iter, int32_t maxRows, uint64_t maxBytes, char** rows);
 
-  char*& nextRow(char* row) {
-    return *reinterpret_cast<char**>(row + nextOffset_);
-  }
-
   void arrayGroupProbe(HashLookup& lookup);
 
   void setHashMode(HashMode mode, int32_t numNew) override;
@@ -760,6 +757,7 @@ class HashTable : public BaseHashTable {
   /// can't be inserted within this range, it is not inserted but rather added
   /// to the end of 'overflows' in 'partitionInfo'.
   void insertForJoin(
+      RowContainer* rows,
       char** groups,
       uint64_t* hashes,
       int32_t numGroups,
@@ -841,12 +839,15 @@ class HashTable : public BaseHashTable {
 
   // Adds a row to a hash join build side entry with multiple rows
   // with the same key.
-  void pushNext(char* row, char* next);
+  // 'rows' should be the same as the one in hash table except for
+  // 'parallelJoinBuild'.
+  void pushNext(RowContainer* rows, char* row, char* next);
 
   // Finishes inserting an entry into a join hash table. If 'partitionInfo' is
   // not null and the insert falls out-side of the partition range, then insert
   // is not made but row is instead added to 'overflow' in 'partitionInfo'
   void buildFullProbe(
+      RowContainer* rows,
       ProbeState& state,
       uint64_t hash,
       char* row,

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -914,6 +914,18 @@ void RowContainer::clear() {
   firstFreeRow_ = nullptr;
 }
 
+void RowContainer::clearNextRowVectors() {
+  if (hasDuplicateRows_) {
+    constexpr int32_t kBatch = 1000;
+    std::vector<char*> rows(kBatch);
+    RowContainerIterator iter;
+    while (auto numRows = listRows(&iter, kBatch, rows.data())) {
+      freeNextRowVectors(folly::Range<char**>(rows.data(), numRows), true);
+    }
+    hasDuplicateRows_ = false;
+  }
+}
+
 void RowContainer::setProbedFlag(char** rows, int32_t numRows) {
   for (auto i = 0; i < numRows; i++) {
     // Row may be null in case of a FULL join.

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -468,6 +468,9 @@ void RowContainer::freeNextRowVectors(folly::Range<char**> rows, bool clear) {
         for (auto& next : *vector) {
           getNextRowVector(next) = nullptr;
         }
+        // Because of 'parallelJoinBuild', the memory for the next row vector
+        // may not be allocated from the RowContainer to which the row belongs,
+        // hence we need to release memory through the vector's allocator.
         auto allocator = vector->get_allocator().allocator();
         std::destroy_at(vector);
         allocator->free(HashStringAllocator::headerOf(vector));

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -393,7 +393,7 @@ void RowContainer::appendNextRow(char* current, char* nextRow) {
   NextRowVector*& nextRowArrayPtr = getNextRowVector(current);
   if (!nextRowArrayPtr) {
     nextRowArrayPtr =
-        new (stringAllocator_->allocateFromPool(kNextRowVectorSize))
+        new (stringAllocator_->allocate(kNextRowVectorSize)->begin())
             NextRowVector(StlAllocator<char*>(stringAllocator_.get()));
     hasDuplicateRows_ = true;
     nextRowArrayPtr->emplace_back(current);
@@ -470,7 +470,7 @@ void RowContainer::freeNextRowVectors(folly::Range<char**> rows, bool clear) {
         }
         auto allocator = vector->get_allocator().allocator();
         vector->~vector();
-        allocator->freeToPool(vector, kNextRowVectorSize);
+        allocator->free(HashStringAllocator::headerOf(vector));
       }
     }
     return;
@@ -489,7 +489,7 @@ void RowContainer::freeNextRowVectors(folly::Range<char**> rows, bool clear) {
       }
       auto allocator = vector->get_allocator().allocator();
       vector->~vector();
-      allocator->freeToPool(vector, kNextRowVectorSize);
+      allocator->free(HashStringAllocator::headerOf(vector));
     }
   }
 }

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -458,7 +458,7 @@ void RowContainer::freeNextRowVectors(folly::Range<char**> rows, bool clear) {
 
   if (clear) {
     for (auto row : rows) {
-      auto& vector = getNextRowVector(row);
+      auto vector = getNextRowVector(row);
       if (vector) {
         // Clear all rows, we can clear the nextOffset_ slots and delete the
         // next-row-vector.
@@ -472,7 +472,7 @@ void RowContainer::freeNextRowVectors(folly::Range<char**> rows, bool clear) {
   }
 
   for (auto row : rows) {
-    auto& vector = getNextRowVector(row);
+    auto vector = getNextRowVector(row);
     if (vector) {
       // If 'clear' is false, the caller must ensure that all rows with same
       // keys appear in the 'rows'.
@@ -891,7 +891,8 @@ void RowContainer::hash(
 
 void RowContainer::clear() {
   const bool sharedStringAllocator = !stringAllocator_.unique();
-  if (checkFree_ || sharedStringAllocator || usesExternalMemory_) {
+  if (checkFree_ || sharedStringAllocator || usesExternalMemory_ ||
+      hasDuplicateRows_) {
     constexpr int32_t kBatch = 1000;
     std::vector<char*> rows(kBatch);
     RowContainerIterator iter;

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -469,7 +469,7 @@ void RowContainer::freeNextRowVectors(folly::Range<char**> rows, bool clear) {
           getNextRowVector(next) = nullptr;
         }
         auto allocator = vector->get_allocator().allocator();
-        vector->~vector();
+        std::destroy_at(vector);
         allocator->free(HashStringAllocator::headerOf(vector));
       }
     }
@@ -488,7 +488,7 @@ void RowContainer::freeNextRowVectors(folly::Range<char**> rows, bool clear) {
         getNextRowVector(next) = nullptr;
       }
       auto allocator = vector->get_allocator().allocator();
-      vector->~vector();
+      std::destroy_at(vector);
       allocator->free(HashStringAllocator::headerOf(vector));
     }
   }

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -25,6 +25,8 @@
 
 namespace facebook::velox::exec {
 
+using NextRowVector = std::vector<char*, StlAllocator<char*>>;
+
 class Aggregate;
 
 class Accumulator {
@@ -637,6 +639,15 @@ class RowContainer {
     return nextOffset_;
   }
 
+  // Create a next-row-vector if it doesn't exist. Append the row address to
+  // the next-row-vector, and store the address of the next-row-vector in the
+  // nextOffset_ slot for all duplicate rows.
+  void appendNextRow(char* current, char* nextRow);
+
+  NextRowVector*& getNextRowVector(char* row) const {
+    return *reinterpret_cast<NextRowVector**>(row + nextOffset_);
+  }
+
   /// Hashes the values of 'columnIndex' for 'rows'.  If 'mix' is true, mixes
   /// the hash with the existing value in 'result'.
   void hash(
@@ -1215,6 +1226,11 @@ class RowContainer {
   // Free any aggregates associated with the 'rows'.
   void freeAggregates(folly::Range<char**> rows);
 
+  // Free next row vectors associated with the 'rows'.
+  void freeNextRowVectors(folly::Range<char**> rows, bool clear);
+
+  void freeRowsExtraMemory(folly::Range<char**> rows, bool clear);
+
   const bool checkFree_ = false;
 
   const std::vector<TypePtr> keyTypes_;
@@ -1234,6 +1250,7 @@ class RowContainer {
   std::vector<TypePtr> types_;
   std::vector<TypeKind> typeKinds_;
   int32_t nextOffset_ = 0;
+  bool hasDuplicateRows_{false};
   // Bit position of null bit  in the row. 0 if no null flag. Order is keys,
   // accumulators, dependent.
   std::vector<int32_t> nullOffsets_;

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -680,6 +680,9 @@ class RowContainer {
   /// Resets the state to be as after construction. Frees memory for payload.
   void clear();
 
+  /// Frees memory for next row vectors.
+  void clearNextRowVectors();
+
   int32_t compareRows(
       const char* left,
       const char* right,

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -59,11 +59,12 @@ class HashTableTestHelper {
   }
 
   void insertForJoin(
+      RowContainer* rows,
       char** groups,
       uint64_t* hashes,
       int32_t numGroups,
       TableInsertPartitionInfo* partitionInfo) {
-    table_->insertForJoin(groups, hashes, numGroups, partitionInfo);
+    table_->insertForJoin(rows, groups, hashes, numGroups, partitionInfo);
   }
 
   void setHashMode(BaseHashTable::HashMode mode, int32_t numNew) {


### PR DESCRIPTION
Problem
When there are a large number of rows with the same key in the build side, 
the `listJoinResults` function becomes very time-consuming.

Design
`appendNextRow`
Create a next-row-vector if it doesn't exist. Append the row address to
the next-row-vector, and store the address of the next-row-vector in the
`nextOffset_` slot for all duplicate rows.

`listJoinResults`
To retrieve the addresses of all rows with the same keys, we first obtain the 
address of the first row using the hash function, then, by the `nextOffset_`, 
we retrieve the address of the next-row-vector. Then, we iterate through the 
next-row-vector to obtain the addresses of the remaining rows. We can utilize 
SIMD instructions to accelerate the next-row-vector access. 

When a row needs to be erased, if value in `nextOffset_` slot is not null, then it
will be removed from corresponding next-row-vector and set it's `nextOffset_` 
slot as null.

The current design is applicable to all hash modes.

Benchmark
The results indicate that this PR can accelerate the `listJoinResults` function,
with the acceleration effect becoming more pronounced as the proportion of 
rows with the same key increases.

Fixes #9078