### PR TITLE
Enable arbitrator in AggregationTest

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -886,7 +886,8 @@ void GroupingSet::ensureOutputFits() {
 
   // Test-only spill path.
   if (testingTriggerSpill()) {
-    spill(RowContainerIterator{});
+    memory::ReclaimableSectionGuard guard(nonReclaimableSection_);
+    memory::testingRunArbitration(&pool_);
     return;
   }
 

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -457,6 +457,16 @@ class TestBadMemoryTranslator : public exec::Operator::PlanNodeTranslator {
 } // namespace
 class TaskTest : public HiveConnectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    FLAGS_velox_testing_enable_arbitration = true;
+    OperatorTestBase::SetUpTestCase();
+  }
+
+  static void TearDownTestCase() {
+    FLAGS_velox_testing_enable_arbitration = false;
+    OperatorTestBase::TearDownTestCase();
+  }
+
   static std::pair<std::shared_ptr<exec::Task>, std::vector<RowVectorPtr>>
   executeSingleThreaded(
       core::PlanFragment plan,

--- a/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
@@ -79,6 +79,16 @@ void AggregationTestBase::TearDown() {
   OperatorTestBase::TearDown();
 }
 
+void AggregationTestBase::SetUpTestCase() {
+  FLAGS_velox_testing_enable_arbitration = true;
+  OperatorTestBase::SetUpTestCase();
+}
+
+void AggregationTestBase::TearDownTestCase() {
+  FLAGS_velox_testing_enable_arbitration = false;
+  OperatorTestBase::TearDownTestCase();
+}
+
 void AggregationTestBase::testAggregations(
     const std::vector<RowVectorPtr>& data,
     const std::vector<std::string>& groupingKeys,

--- a/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h
+++ b/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h
@@ -29,6 +29,8 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
  protected:
   void SetUp() override;
   void TearDown() override;
+  static void SetUpTestCase();
+  static void TearDownTestCase();
 
   std::vector<RowVectorPtr>
   makeVectors(const RowTypePtr& rowType, vector_size_t size, int numVectors);


### PR DESCRIPTION
Enables SharedArbitrator in MemoryManager in AggregationTest suites. Applies global pools shrink as injection method.