### PR TITLE
Add nightly runs of Aggregation fuzzer using Presto as source of truth.

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -145,7 +145,7 @@ jobs:
           cd  velox
           cp ./scripts/etc/hive.properties $PRESTO_HOME/etc/catalog
           ls -lR $PRESTO_HOME/etc
-          /opt/start-prestojava.sh > /tmp/server.log 2>&1 &
+          $PRESTO_HOME/bin/launcher run -v > /tmp/server.log 2>&1 &
           # Sleep for 60 seconds to allow Presto server to start.
           sleep 60
           /opt/presto-cli --server 127.0.0.1:8080 --execute 'CREATE SCHEMA hive.tpch;'

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -25,6 +25,7 @@ on:
       - "scripts/setup-ubuntu.sh"
       - "scripts/setup-helper-functions.sh"
       - ".github/workflows/linux-build.yml"
+      - ".github/workflows/scheduled.yml"
 
   schedule:
     - cron: '0 3 * * *'
@@ -449,10 +450,11 @@ jobs:
 
 
   presto-java-aggregation-fuzzer-run:
+    name: Aggregation Fuzzer with Presto as source of truth
     runs-on: 8-core
     container: ghcr.io/facebookincubator/velox-dev:presto-java
     timeout-minutes: 120
-    if: "$${{ github.event_name != 'pull_request' }}"
+    if: ${{ github.event_name != 'pull_request' }}
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"
       CCACHE_BASEDIR: "${{ github.workspace }}"
@@ -463,7 +465,7 @@ jobs:
         uses: assignUser/stash/restore@v1
         with:
           path: "${{ env.CCACHE_DIR }}"
-          key: ccache-fuzzer
+          key: ccache-presto-java-fuzzer
 
       - name: "Checkout Repo"
         uses: actions/checkout@v4
@@ -472,18 +474,28 @@ jobs:
           submodules: 'recursive'
           ref: "${{ inputs.ref }}"
 
-      - name: "Install dependencies"
-        run: |
-          cd  velox
-          source ./scripts/setup-ubuntu.sh
-          ccache -vsz
+      - name: Fix git permissions
+          # Usually actions/checkout does this but as we run in a container
+          # it doesn't work
+        run: git config --global --add safe.directory /__w/velox/velox/velox
+
+      - name: Zero Ccache Statistics
+        run: ccache -sz
+
 
       - name: "Build"
+        env:
+          EXTRA_CMAKE_FLAGS: "-DVELOX_ENABLE_ARROW=ON ${{ inputs.extraCMakeFlags }}"
         run: |
           cd velox
-          source /opt/rh/gcc-toolset-9/enable
           make debug NUM_THREADS="${{ inputs.numThreads || 8 }}" MAX_HIGH_MEM_JOBS="${{ inputs.maxHighMemJobs || 8 }}" MAX_LINK_JOBS="${{ inputs.maxLinkJobs || 4 }}" EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON ${{ inputs.extraCMakeFlags }}"
           ccache -s
+
+      - name: "Save ccache"
+        uses: assignUser/stash/save@v1
+        with:
+          path: "${{ env.CCACHE_DIR }}"
+          key: ccache-presto-java-fuzzer
 
       - name: "Run Aggregate Fuzzer"
         run: |

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -446,3 +446,70 @@ jobs:
             name: exchange-fuzzer-failure-artifacts
             path: |
               /tmp/exchange_fuzzer_repro
+
+
+  presto-java-aggregation-fuzzer-run:
+    runs-on: 8-core
+    container: ghcr.io/facebookincubator/velox-dev:presto-java
+    timeout-minutes: 120
+    env:
+      CCACHE_DIR: "${{ github.workspace }}/.ccache/"
+      CCACHE_BASEDIR: "${{ github.workspace }}"
+      LINUX_DISTRO: "centos"
+    steps:
+
+      - name: "Restore ccache"
+        uses: actions/cache@v3
+        with:
+          path: "${{ env.CCACHE_DIR }}"
+          # We are using the benchmark ccache as it has all
+          # required features enabled, so no need to create a new one
+          key: ccache-presto-${{ github.sha }}
+          restore-keys: |
+            ccache-presto-
+
+      - name: "Checkout Repo"
+        uses: actions/checkout@v3
+        with:
+          path: velox
+          submodules: 'recursive'
+          ref: "${{ inputs.ref || 'main' }}"
+
+
+      - name: "Build"
+        run: |
+          cd velox
+          source /opt/rh/gcc-toolset-9/enable
+          make debug NUM_THREADS="${{ inputs.numThreads || 8 }}" MAX_HIGH_MEM_JOBS="${{ inputs.maxHighMemJobs || 8 }}" MAX_LINK_JOBS="${{ inputs.maxLinkJobs || 4 }}" EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON ${{ inputs.extraCMakeFlags }}"
+          ccache -s
+
+      - name: "Run Aggregate Fuzzer"
+        run: |
+          cd  velox
+          cp ./scripts/etc/hive.properties $PRESTO_HOME/etc/catalog
+          ls -lR $PRESTO_HOME/etc
+          $PRESTO_HOME/bin/launcher run -v > /tmp/server.log 2>&1 &
+          # Sleep for 60 seconds to allow Presto server to start.
+          sleep 60          
+          /opt/presto-cli --server 127.0.0.1:8080 --execute 'CREATE SCHEMA hive.tpch;'
+          mkdir -p /tmp/aggregate_fuzzer_repro/
+          rm -rfv /tmp/aggregate_fuzzer_repro/*
+          chmod -R 777 /tmp/aggregate_fuzzer_repro
+          _build/debug/velox/functions/prestosql/fuzzer/velox_aggregation_fuzzer_test \
+                --seed ${RANDOM} \
+                --duration_sec 3600 \
+                --logtostderr=1 \
+                --minloglevel=0 \
+                --repro_persist_path=/tmp/aggregate_fuzzer_repro \
+                --enable_sorted_aggregations=true \
+                --presto_url=http://127.0.0.1:8080 \
+          && echo -e "\n\nAggregation fuzzer run finished successfully."
+
+      - name: Archive aggregate production artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: aggregate-fuzzer-failure-artifacts
+          path: |
+            /tmp/aggregate_fuzzer_repro
+            /tmp/server.log

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -452,6 +452,7 @@ jobs:
     runs-on: 8-core
     container: ghcr.io/facebookincubator/velox-dev:presto-java
     timeout-minutes: 120
+    if: "$${{ github.event_name != 'pull_request' }}"
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"
       CCACHE_BASEDIR: "${{ github.workspace }}"
@@ -459,22 +460,23 @@ jobs:
     steps:
 
       - name: "Restore ccache"
-        uses: actions/cache@v3
+        uses: assignUser/stash/restore@v1
         with:
           path: "${{ env.CCACHE_DIR }}"
-          # We are using the benchmark ccache as it has all
-          # required features enabled, so no need to create a new one
-          key: ccache-presto-${{ github.sha }}
-          restore-keys: |
-            ccache-presto-
+          key: ccache-fuzzer
 
       - name: "Checkout Repo"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: velox
           submodules: 'recursive'
-          ref: "${{ inputs.ref || 'main' }}"
+          ref: "${{ inputs.ref }}"
 
+      - name: "Install dependencies"
+        run: |
+          cd  velox
+          source ./scripts/setup-ubuntu.sh
+          ccache -vsz
 
       - name: "Build"
         run: |
@@ -497,7 +499,7 @@ jobs:
           chmod -R 777 /tmp/aggregate_fuzzer_repro
           _build/debug/velox/functions/prestosql/fuzzer/velox_aggregation_fuzzer_test \
                 --seed ${RANDOM} \
-                --duration_sec 3600 \
+                --duration_sec $DURATION \
                 --logtostderr=1 \
                 --minloglevel=0 \
                 --repro_persist_path=/tmp/aggregate_fuzzer_repro \
@@ -506,10 +508,10 @@ jobs:
           && echo -e "\n\nAggregation fuzzer run finished successfully."
 
       - name: Archive aggregate production artifacts
-        if: always()
-        uses: actions/upload-artifact@v3
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
         with:
-          name: aggregate-fuzzer-failure-artifacts
+          name: presto-sot-aggregate-fuzzer-failure-artifacts
           path: |
             /tmp/aggregate_fuzzer_repro
             /tmp/server.log


### PR DESCRIPTION
**What**
This PR adds a scheduled job to run nightly which will run the AggregationFuzzer using Presto as source of truth. 

**Why**
By default the AggregationFuzzer uses DuckDB, but this job switches the reference DB to use Presto and validates the results by comparing them to Presto's results.  I have run this locally and on experimental runs and not noticed any recent failures. 

**Results**
You can see a few succesful experimental results here : 
https://github.com/facebookincubator/velox/actions/runs/8199583642/job/22443872635 
 https://github.com/facebookincubator/velox/actions/runs/8199583642/job/22424917125