### PR TITLE
Set minimum boost version to 1.77.0

### DIFF
--- a/CMake/resolve_dependency_modules/README.md
+++ b/CMake/resolve_dependency_modules/README.md
@@ -23,7 +23,7 @@ by Velox. See details on bundling below.
 | zstd              | default         | No       |
 | openssl           | default         | No       |
 | protobuf          | 21 (exact)      | Yes      |
-| boost             | 1.66.0          | Yes      |
+| boost             | 1.77.0          | Yes      |
 | flex              | 2.5.13          | No       |
 | bison             | 3.0.4           | No       |
 | cmake             | 3.14            | No       |

--- a/CMake/resolve_dependency_modules/README.md
+++ b/CMake/resolve_dependency_modules/README.md
@@ -23,7 +23,7 @@ by Velox. See details on bundling below.
 | zstd              | default         | No       |
 | openssl           | default         | No       |
 | protobuf          | 21 (exact)      | Yes      |
-| boost             | 1.77.0          | Yes      |
+| boost             | 1.84.0          | Yes      |
 | flex              | 2.5.13          | No       |
 | bison             | 3.0.4           | No       |
 | cmake             | 3.14            | No       |

--- a/CMake/resolve_dependency_modules/README.md
+++ b/CMake/resolve_dependency_modules/README.md
@@ -23,7 +23,7 @@ by Velox. See details on bundling below.
 | zstd              | default         | No       |
 | openssl           | default         | No       |
 | protobuf          | 21 (exact)      | Yes      |
-| boost             | 1.84.0          | Yes      |
+| boost             | 1.77.0          | Yes      |
 | flex              | 2.5.13          | No       |
 | bison             | 3.0.4           | No       |
 | cmake             | 3.14            | No       |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,7 +374,7 @@ set(BOOST_INCLUDE_LIBRARIES
     thread)
 
 set_source(Boost)
-resolve_dependency(Boost 1.84.0 COMPONENTS ${BOOST_INCLUDE_LIBRARIES})
+resolve_dependency(Boost 1.77.0 COMPONENTS ${BOOST_INCLUDE_LIBRARIES})
 
 # Range-v3 will be enable when the codegen code actually lands keeping it here
 # for reference. find_package(range-v3)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,7 +374,7 @@ set(BOOST_INCLUDE_LIBRARIES
     thread)
 
 set_source(Boost)
-resolve_dependency(Boost 1.66.0 COMPONENTS ${BOOST_INCLUDE_LIBRARIES})
+resolve_dependency(Boost 1.77.0 COMPONENTS ${BOOST_INCLUDE_LIBRARIES})
 
 # Range-v3 will be enable when the codegen code actually lands keeping it here
 # for reference. find_package(range-v3)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,7 +374,7 @@ set(BOOST_INCLUDE_LIBRARIES
     thread)
 
 set_source(Boost)
-resolve_dependency(Boost 1.77.0 COMPONENTS ${BOOST_INCLUDE_LIBRARIES})
+resolve_dependency(Boost 1.84.0 COMPONENTS ${BOOST_INCLUDE_LIBRARIES})
 
 # Range-v3 will be enable when the codegen code actually lands keeping it here
 # for reference. find_package(range-v3)


### PR DESCRIPTION
This [commit](https://github.com/facebookincubator/velox/commit/6dba462cc226e2a61fd0de28fceb9fd07b29a5ce) introduces some code to use a boost API: `boost::uuids::to_chars`, which is available since boost 1.77.0 (see [boost commit](https://github.com/boostorg/uuid/commit/eaa4be7b96c99ad56effc351aa44d0bef04da5a3)). So I'm proposing to change the minimum version to 1.77.0.

Post related PR:
https://github.com/facebookincubator/velox/pull/8679
