### PR TITLE
Remove duplicate registration of split_part Presto function

### DIFF
--- a/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -78,8 +78,6 @@ void registerSimpleFunctions(const std::string& prefix) {
   exec::registerStatefulVectorFunction(
       prefix + "like", likeSignatures(), makeLike);
 
-  registerFunction<SplitPart, Varchar, Varchar, Varchar, int64_t>(
-      {prefix + "split_part"});
   registerFunction<Re2RegexpReplacePresto, Varchar, Varchar, Constant<Varchar>>(
       {prefix + "regexp_replace"});
   registerFunction<


### PR DESCRIPTION
Summary: split_part function was registered twice in StringFunctionsRegistration.cpp: L61 and L81.

Differential Revision: D54961647


