### PR TITLE
Fix race condition in MultiThreadedTaskCursor

### DIFF
--- a/velox/exec/tests/utils/Cursor.cpp
+++ b/velox/exec/tests/utils/Cursor.cpp
@@ -258,6 +258,10 @@ class MultiThreadedTaskCursor : public TaskCursorBase {
     start();
     current_ = queue_->dequeue();
     if (task_->error()) {
+      // Wait for the task to finish (there's' a small period of time between
+      // when the error is set on the Task and terminate is called).
+      task_->taskCompletionFuture(1'000'000);
+
       // Wait for all task drivers to finish to avoid destroying the executor_
       // before task_ finished using it and causing a crash.
       waitForTaskDriversToFinish(task_.get());


### PR DESCRIPTION
Summary:
In MultiThreadedTaskCursor::moveNext(), if task_ has an error we call waitForTaskDriversToFinish which expects the Task to
no longer be running.

In Task's setError method there's a brief period of time after the error is set before the Task is terminated.  If the Cursor calls
waitForTaskDriversToFinish in this window it will fail because the Task is still running.

Adding a wait for the Task to complete before calling waitForTaskDriversToFinish fixes the issue.

Differential Revision: D54961848


