### PR TITLE
Fix use-after-move in StringIdMap

### DIFF
--- a/velox/common/caching/StringIdMap.cpp
+++ b/velox/common/caching/StringIdMap.cpp
@@ -79,8 +79,8 @@ uint64_t StringIdMap::makeId(std::string_view string) {
   entry.numInUse = 1;
   pinnedSize_ += entry.string.size();
   auto id = entry.id;
-  auto& entryInTable = idToString_[id] = std::move(entry);
-  stringToId_[entryInTable.string] = entry.id;
+  idToString_[id] = std::move(entry);
+  stringToId_[string] = id;
   return lastId_;
 }
 


### PR DESCRIPTION
Using a variable after moving it is bug-prone and is not a good 
practice. Although the move operation on basic types is equivalent 
to copying, we should still try to avoid this usage.

In the original implementation, `entry` was moved in L82((i.e. it 
should no longer be used after that), but was used again in L83. 
This PR fixes this problem.