### PR TITLE
Add current_date Spark function

### DIFF
--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -284,6 +284,8 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<FromUtcTimestampFunction, Timestamp, Timestamp, Varchar>(
       {prefix + "from_utc_timestamp"});
 
+  registerFunction<CurrentDateFunction, Date>({prefix + "current_date"});
+
   registerFunction<UnixDateFunction, int32_t, Date>({prefix + "unix_date"});
 
   registerFunction<UnixTimestampFunction, int64_t>({prefix + "unix_timestamp"});


### PR DESCRIPTION
Returns the current date at the start of query evaluation as a DateType column. All calls of current_date within the same query return the same value.

Spark docs - https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.current_date.html

Addresses #9109 