### PR TITLE
Pass input types to SimpleFunctionAdapterFactory::createVectorFunction

### DIFF
--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -434,12 +434,12 @@ ExprPtr compileRewrittenExpression(
           simpleFunctionEntry->type(),
           resultType,
           folly::join(", ", inputTypes));
-      auto func_2 = simpleFunctionEntry->createFunction()->createVectorFunction(
-          getConstantInputs(compiledInputs), config);
+      auto func = simpleFunctionEntry->createFunction()->createVectorFunction(
+          inputTypes, getConstantInputs(compiledInputs), config);
       result = std::make_shared<Expr>(
           resultType,
           std::move(compiledInputs),
-          std::move(func_2),
+          std::move(func),
           call->name(),
           trackCpuUsage);
     } else {

--- a/velox/expression/SimpleFunctionAdapter.h
+++ b/velox/expression/SimpleFunctionAdapter.h
@@ -227,7 +227,8 @@ class SimpleFunctionAdapter : public VectorFunction {
   }
 
  public:
-  explicit SimpleFunctionAdapter(
+  SimpleFunctionAdapter(
+      const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
       const std::vector<VectorPtr>& constantInputs)
       : fn_{std::make_unique<FUNC>()} {
@@ -901,10 +902,11 @@ class SimpleFunctionAdapterFactoryImpl : public SimpleFunctionAdapterFactory {
   explicit SimpleFunctionAdapterFactoryImpl() {}
 
   std::unique_ptr<VectorFunction> createVectorFunction(
+      const std::vector<TypePtr>& inputTypes,
       const std::vector<VectorPtr>& constantInputs,
       const core::QueryConfig& config) const override {
     return std::make_unique<SimpleFunctionAdapter<UDFHolder>>(
-        config, constantInputs);
+        inputTypes, config, constantInputs);
   }
 };
 

--- a/velox/expression/VectorFunction.h
+++ b/velox/expression/VectorFunction.h
@@ -182,6 +182,7 @@ class ApplyNeverCalled final : public VectorFunction {
 class SimpleFunctionAdapterFactory {
  public:
   virtual std::unique_ptr<VectorFunction> createVectorFunction(
+      const std::vector<TypePtr>& inputTypes,
       const std::vector<VectorPtr>& constantInputs,
       const core::QueryConfig& config) const = 0;
   virtual ~SimpleFunctionAdapterFactory() = default;

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -992,7 +992,7 @@ VectorPtr testVariadicArgReuse(
       exec::simpleFunctions()
           .resolveFunction(functionName, {})
           ->createFunction()
-          ->createVectorFunction({}, execCtx->queryCtx()->queryConfig());
+          ->createVectorFunction({}, {}, execCtx->queryCtx()->queryConfig());
 
   // Create a dummy EvalCtx.
   SelectivityVector rows(inputs[0]->size());


### PR DESCRIPTION
Summary:
This change is part of enabling simple functions to process inputs of decimal type. Such processing requires access to decimal type parameters (precision and scale). This change provides full type information to the function constructor. A follow-up change will pass this to simple function's 'initialize' method.

See https://github.com/facebookincubator/velox/pull/9096 for the end-to-end workflow.

Differential Revision: D55011267


