### PR TITLE
Optimize cast(string as double/float) by switching to fast_float library

### DIFF
--- a/.circleci/dist_compile.yml
+++ b/.circleci/dist_compile.yml
@@ -297,6 +297,7 @@ jobs:
       simdjson_SOURCE: BUNDLED
       xsimd_SOURCE: BUNDLED
       DuckDB_SOURCE: SYSTEM
+      fast_float_SOURCE: BUNDLED
     steps:
       - pre-steps
       - run:
@@ -352,6 +353,7 @@ jobs:
       simdjson_SOURCE: BUNDLED
       xsimd_SOURCE: BUNDLED
       DuckDB_SOURCE: BUNDLED
+      fast_float_SOURCE: BUNDLED
     steps:
       - fuzzer-run:
           fuzzer_output: "/tmp/fuzzer.log"

--- a/CMake/resolve_dependency_modules/README.md
+++ b/CMake/resolve_dependency_modules/README.md
@@ -24,6 +24,7 @@ by Velox. See details on bundling below.
 | openssl           | default         | No       |
 | protobuf          | 21 (exact)      | Yes      |
 | boost             | 1.66.0          | Yes      |
+| fast_float        | 5.3.0           | Yes      |
 | flex              | 2.5.13          | No       |
 | bison             | 3.0.4           | No       |
 | cmake             | 3.14            | No       |

--- a/CMake/resolve_dependency_modules/fast_float.cmake
+++ b/CMake/resolve_dependency_modules/fast_float.cmake
@@ -1,0 +1,31 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+include_guard(GLOBAL)
+
+set(VELOX_FAST_FLOAT_VERSION 5.3.0)
+set(VELOX_FAST_FLOAT_BUILD_SHA256_CHECKSUM
+    2f3bc50670455534dcaedc9dcd0517b71152f319d0cec8625f21c51d23eaf4b9)
+set(VELOX_FAST_FLOAT_SOURCE_URL
+    "https://github.com/fastfloat/fast_float/archive/refs/tags/v${VELOX_FAST_FLOAT_VERSION}.tar.gz"
+)
+
+resolve_dependency_url(FAST_FLOAT)
+
+message(STATUS "Building fast_float from source")
+FetchContent_Declare(
+  fast_float
+  URL ${VELOX_FAST_FLOAT_SOURCE_URL}
+  URL_HASH ${VELOX_FAST_FLOAT_BUILD_SHA256_CHECKSUM})
+
+FetchContent_MakeAvailable(fast_float)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -561,6 +561,9 @@ endif()
 set_source(xsimd)
 resolve_dependency(xsimd 10.0.0)
 
+set_source(fast_float)
+resolve_dependency(fast_float 5.3.0)
+
 if(VELOX_BUILD_TESTING)
   set(BUILD_TESTING ON)
   include(CTest) # include after project() but before add_subdirectory()

--- a/velox/type/CMakeLists.txt
+++ b/velox/type/CMakeLists.txt
@@ -22,6 +22,7 @@ add_subdirectory(fbhive)
 add_library(
   velox_type
   Conversions.cpp
+  StringToFloatParser.cpp
   DecimalUtil.cpp
   DoubleUtil.cpp
   Filter.cpp
@@ -46,4 +47,5 @@ target_link_libraries(
   velox_status
   Boost::headers
   Folly::folly
-  re2::re2)
+  re2::re2
+  fast_float)

--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <type_traits>
 #include "velox/common/base/Exceptions.h"
+#include "velox/type/StringToFloatParser.h"
 #include "velox/type/TimestampConversion.h"
 #include "velox/type/Type.h"
 
@@ -384,16 +385,27 @@ struct Converter<
     return folly::to<T>(v);
   }
 
+  static T stringToFloat(const std::string_view& v) {
+    T output;
+    const auto status = StringToFloatParser::parse<T>(v, output);
+
+    if (status.ok()) {
+      return output;
+    }
+
+    throw std::invalid_argument(status.message());
+  }
+
   static T cast(folly::StringPiece v) {
-    return cast<folly::StringPiece>(v);
+    return stringToFloat(v);
   }
 
   static T cast(const StringView& v) {
-    return cast<folly::StringPiece>(folly::StringPiece(v));
+    return stringToFloat(static_cast<std::string_view>(v));
   }
 
   static T cast(const std::string& v) {
-    return cast<std::string>(v);
+    return stringToFloat(v);
   }
 
   static T cast(const bool& v) {

--- a/velox/type/StringToFloatParser.cpp
+++ b/velox/type/StringToFloatParser.cpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fast_float/fast_float.h>
+#include <folly/Likely.h>
+#include <cmath>
+
+#include "velox/type/StringToFloatParser.h"
+
+namespace facebook::velox {
+
+static inline bool characterIsSpace(char c) {
+  return c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '\f' ||
+      c == '\r';
+}
+
+static inline bool isEither(const char currentChar, char lower, char upper) {
+  return currentChar == lower || currentChar == upper;
+}
+
+static inline bool isInfinityString(const char* str, size_t length) {
+  // length = 3: inf/INF
+  // length = 8: infinity
+  if (length != 3 && length != 8) {
+    return false;
+  }
+
+  if (isEither(str[0], 'i', 'I') && isEither(str[1], 'n', 'N') &&
+      isEither(str[2], 'f', 'F')) {
+    if (length == 3) {
+      return true;
+    }
+
+    return isEither(str[3], 'i', 'I') && isEither(str[4], 'n', 'N') &&
+        isEither(str[5], 'i', 'I') && isEither(str[6], 't', 'T') &&
+        isEither(str[7], 'y', 'Y');
+  }
+
+  return false;
+}
+
+static inline bool isNanString(const char* str, size_t length) {
+  if (length != 3) {
+    return false;
+  }
+
+  return isEither(str[0], 'n', 'N') && isEither(str[1], 'a', 'A') &&
+      isEither(str[2], 'n', 'N');
+}
+
+template <typename T>
+Status StringToFloatParser::parse(const std::string_view& str, T& out) {
+  auto length = str.length();
+  if (UNLIKELY(length <= 0)) {
+    return Status::Invalid("empty string");
+  }
+  auto i = 0;
+  // Skip leading spaces.
+  for (; i < length; ++i) {
+    if (!characterIsSpace(str[i])) {
+      break;
+    }
+  }
+
+  // Skip trailing spaces.
+  auto j = length - 1;
+  for (; j >= i; j--) {
+    if (!characterIsSpace(str[j])) {
+      break;
+    }
+  }
+
+  auto negative = false;
+  // Skip leading +/-.
+  switch (str[i]) {
+    case '-':
+      negative = true;
+      i++;
+      break;
+    case '+':
+      i++;
+  }
+
+  // Check INF/INFINITY/NAN, ignoring case.
+  if (isInfinityString(str.data() + i, j - i + 1)) {
+    out = negative ? -INFINITY : INFINITY;
+    return Status::OK();
+  } else if (isNanString(str.data() + i, j - i + 1)) {
+    out = negative ? -NAN : NAN;
+    return Status::OK();
+  }
+
+  // Check invalid char.
+  auto exponential = false;
+  auto point = false;
+  auto invalid = false;
+  for (auto k = i; k <= j; ++k) {
+    if (str[k] >= '0' && str[k] <= '9') {
+      continue;
+    } else if (str[k] == '.') {
+      if (LIKELY(!point)) {
+        point = true;
+      } else {
+        invalid = true;
+        break;
+      }
+    } else if (str[k] == 'e' || str[k] == 'E') {
+      if (LIKELY(!exponential)) {
+        exponential = true;
+      } else {
+        invalid = true;
+        break;
+      }
+    } else if (str[k] == '-' || str[k] == '+') {
+      if (LIKELY(k > i && (str[k - 1] == 'e' || str[k - 1] == 'E'))) {
+        continue;
+      } else {
+        invalid = true;
+        break;
+      }
+    } else {
+      invalid = true;
+      break;
+    }
+  }
+
+  if (invalid) {
+    return Status::Invalid(
+        "Non-whitespace character found after end of conversion");
+  }
+
+  double val;
+  auto res = fast_float::from_chars(str.data() + i, str.data() + j + 1, val);
+
+  if (LIKELY(res.ec == std::errc())) {
+    if (UNLIKELY(val == std::numeric_limits<T>::infinity())) {
+      return Status::UserError("Result overflows.");
+    }
+
+    out = negative ? (T)-val : (T)val;
+    return Status::OK();
+  }
+
+  return Status::Invalid("Invalid input string: {}", str);
+}
+
+template Status StringToFloatParser::parse<float>(
+    const std::string_view& str,
+    float& out);
+template Status StringToFloatParser::parse<double>(
+    const std::string_view& str,
+    double& out);
+} // namespace facebook::velox

--- a/velox/type/StringToFloatParser.h
+++ b/velox/type/StringToFloatParser.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/base/Status.h"
+
+namespace facebook::velox {
+class StringToFloatParser {
+ public:
+  /// Converts a string to a double/float precision floating point value.
+  /// Returns UserError/Invalid status if the data is invalid.
+  ///
+  /// Leading and trailing whitespace characters in str are ignored.
+  /// Whitespace is removed as if by the java's String#trim method.
+  /// that is, both ASCII space and control characters are removed.
+  ///
+  /// The supported string formats is:
+  /// ([\\x00-\\x20]*                 - Optional leading whitespace.
+  /// [+-]?(                          - Optional sign character.
+  /// NaN|"                           - "NaN" string, ignoring case.
+  /// Infinity|                       - "Infinity" string, ignoring case.
+  /// (((Digits(\\.)?(Digits?)(Exp)?)|
+  /// (\\.(Digits)(Exp)?)))
+  /// [\\x00-\\x20]*)                 - Optional trailing whitespace.
+  ///
+  /// @tparam T Either float or double.
+  /// @param str A string to convert.
+  /// @param out The double/float precision value to be output.
+  template <typename T>
+  static Status parse(const std::string_view& str, T& out);
+};
+} // namespace facebook::velox


### PR DESCRIPTION
Fixes: https://github.com/facebookincubator/velox/issues/9119

CastBenchmark(Benchmark running in RELEASE mode):

BEFORE:
```
/Users/wypb/data/code/apache/velox/_build/release/velox/benchmarks/basic/velox_cast_benchmark
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
cast##cast_string_as_double                                36.49ms     27.40
cast##cast_string_as_float                                 31.05ms     32.20
```
AFTER:
```
/Users/wypb/data/code/apache/velox/_build/release/velox/benchmarks/basic/velox_cast_benchmark
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
cast##cast_string_as_double                                 3.66ms    272.90
cast##cast_string_as_float                                  3.70ms    270.01

```

CC: @mbasmanova 
