### PR TITLE
Wave Table Scan Infrastructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ clean:					#: Delete all build artifacts
 
 cmake:					#: Use CMake to create a Makefile build system
 	mkdir -p $(BUILD_BASE_DIR)/$(BUILD_DIR) && \
-	cmake -B \
+	cmake  -B \
 		"$(BUILD_BASE_DIR)/$(BUILD_DIR)" \
 		${CMAKE_FLAGS} \
 		$(GENERATOR) \

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -27,6 +27,9 @@
 
 #include <folly/Synchronized.h>
 
+namespace facebook::velox::wave {
+class WaveDataSource;
+}
 namespace facebook::velox::common {
 class Filter;
 }
@@ -228,6 +231,16 @@ class DataSource {
   // fully account for size of sparsely accessed columns.
   virtual int64_t estimatedRowSize() {
     return kUnknownRowSize;
+  }
+
+  /// Returns a Wave delegate that implements the Wave Operator
+  /// interface for a GPU table scan. This should be called after
+  /// construction and no other methods should be called on 'this'
+  /// after creating the delegate. Splits, dynamic filters etc.  will
+  /// be added to the WaveDataSource instead of 'this'. 'this' should
+  /// stay live until after the destruction of the delegate.
+  virtual std::shared_ptr<wave::WaveDataSource> toWaveDataSource() {
+    VELOX_UNSUPPORTED();
   }
 };
 

--- a/velox/experimental/wave/CMakeLists.txt
+++ b/velox/experimental/wave/CMakeLists.txt
@@ -15,4 +15,4 @@
 add_subdirectory(common)
 add_subdirectory(exec)
 add_subdirectory(vector)
-add_subdirectory(dwio/decode)
+add_subdirectory(dwio)

--- a/velox/experimental/wave/dwio/CMakeLists.txt
+++ b/velox/experimental/wave/dwio/CMakeLists.txt
@@ -12,34 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_wave_stream OperandSet.cpp Wave.cpp)
+add_subdirectory(decode)
 
-add_library(
-  velox_wave_exec
-  Aggregation.cpp
-  AggregationInstructions.cu
-  ExprKernel.cu
-  ToWave.cpp
-  WaveOperator.cpp
-  Vectors.cpp
-  Values.cpp
-  WaveDriver.cpp
-  Project.cpp
-  TableScan.cpp
-  WaveHiveDataSource.cpp
-  WaveSplitReader.cpp)
-
-set_target_properties(velox_wave_exec PROPERTIES CUDA_ARCHITECTURES native)
-
-target_link_libraries(
-  velox_wave_exec
-  velox_wave_vector
-  velox_wave_common
-  velox_wave_stream
-  velox_exception
-  velox_common_base
-  velox_exec)
-
-if(${VELOX_BUILD_TESTING})
-  add_subdirectory(tests)
-endif()
+add_library(velox_wave_dwio ColumnReader.cpp FormatData.cpp ReadStream.cpp
+                            StructColumnReader.cpp)

--- a/velox/experimental/wave/dwio/ColumnReader.cpp
+++ b/velox/experimental/wave/dwio/ColumnReader.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/dwio/ColumnReader.h"
+
+namespace facebook::velox::wave {
+
+void ColumnReader::makeOp(
+    ReadStream* readStream,
+    ColumnAction action,
+    int32_t offset,
+    RowSet rows,
+    ColumnOp& op) {
+  VELOX_CHECK(action == ColumnAction::kValues, "Only values supported");
+  formatData_->newBatch(readOffset_ + offset);
+  op.action = action;
+  op.reader = this;
+  op.waveVector = readStream->operandVector(operand_, requestedType_);
+  op.rows = rows;
+  readOffset_ = offset + rows.back() + 1;
+};
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/dwio/ColumnReader.h
+++ b/velox/experimental/wave/dwio/ColumnReader.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/dwio/common/TypeWithId.h"
+#include "velox/experimental/wave/dwio/FormatData.h"
+#include "velox/experimental/wave/exec/Wave.h"
+
+namespace facebook::velox::wave {
+
+class ReadStream;
+class StructColumnReader;
+
+/// dwio::SelectiveColumnReader for Wave
+class ColumnReader {
+ public:
+  ColumnReader(
+      const TypePtr& requestedType,
+      std::shared_ptr<const dwio::common::TypeWithId> fileType,
+      OperandId operand,
+      FormatParams& params,
+      velox::common::ScanSpec& scanSpec)
+      : requestedType_(requestedType),
+        fileType_(fileType),
+        operand_(operand),
+        formatData_(params.toFormatData(fileType_, scanSpec, operand)),
+        scanSpec_(&scanSpec) {}
+
+  virtual ~ColumnReader() = default;
+
+  const common::ScanSpec& scanSpec() const {
+    return *scanSpec_;
+  }
+
+  const std::vector<ColumnReader*> children() const {
+    return children_;
+  }
+
+  int32_t totalRows() const {
+    return formatData_->totalRows();
+  }
+
+  OperandId operand() const {
+    return operand_;
+  }
+
+  virtual void makeOp(
+      ReadStream* readStream,
+      ColumnAction action,
+      int32_t offset,
+      RowSet rows,
+      ColumnOp& op);
+
+  FormatData* formatData() const {
+    return formatData_.get();
+  }
+
+ protected:
+  TypePtr requestedType_;
+  std::shared_ptr<const dwio::common::TypeWithId> fileType_;
+  const OperandId operand_;
+  std::unique_ptr<FormatData> formatData_;
+  // Specification of filters, value extraction, pruning etc. The
+  // spec is assigned at construction and the contents may change at
+  // run time based on adaptation. Owned by caller.
+  velox::common::ScanSpec* scanSpec_;
+
+  std::vector<ColumnReader*> children_;
+
+  // Row number after last read row, relative to the ORC stripe or Parquet
+  // Rowgroup start.
+  vector_size_t readOffset_ = 0;
+};
+
+class ReadStream : public Executable {
+ public:
+  ReadStream(
+      StructColumnReader* columnReader,
+      vector_size_t offset,
+      RowSet rows,
+      WaveStream& waveStream,
+      const OperandSet* firstColumns = nullptr);
+
+  /// Runs a sequence of kernel invocations until all eagerly produced columns
+  /// have their last kernel in flight. Transfers ownership of 'readStream' to
+  /// its WaveStream.
+  static void launch(std::unique_ptr<ReadStream>&& readStream);
+
+  DecodePrograms& programs() {
+    return programs_;
+  }
+
+  // Prepares the next kernel launch in 'programs_'. Returns true if
+  // all non-lazy activity will be complete after the program kernel
+  // completes. Sets needSync if the next step(s) depend on the stream
+  // being synced first, i.e. a device to host transfer must have
+  // completed so that the next step can decide based on data received
+  // from device.
+  bool makePrograms(bool& needSync);
+
+ private:
+  /// Makes column dependencies.
+  void makeOps();
+
+  StructColumnReader* reader_;
+  int32_t offset_;
+  RowSet rows_;
+  std::vector<ColumnOp> ops_;
+  std::vector<std::unique_ptr<SplitStaging>> staging_;
+  SplitStaging* currentStaging_;
+
+  // Data to be copied from device, e.g. filter selectivities.
+  ResultStaging resultStaging_;
+  // Intermediate data to stay on device, e.g. selected rows.
+  ResultStaging deviceStaging_;
+  // Reusable control block for launching decode kernels.
+  DecodePrograms programs_;
+};
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/dwio/FormatData.cpp
+++ b/velox/experimental/wave/dwio/FormatData.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/dwio/FormatData.h"
+#include "velox/experimental/wave/dwio/ColumnReader.h"
+
+namespace facebook::velox::wave {
+
+BufferId SplitStaging::add(Staging& staging) {
+  VELOX_CHECK_NULL(deviceBuffer_);
+  staging_.push_back(staging);
+  offsets_.push_back(fill_);
+  fill_ += bits::roundUp(staging.size, 8);
+  return offsets_.size() - 1;
+}
+
+void SplitStaging::registerPointerInternal(BufferId id, void** ptr) {
+  VELOX_CHECK_NULL(deviceBuffer_);
+  patch_.push_back(std::make_pair(id, ptr));
+}
+
+// Starts the transfers registered with add(). 'stream' is set to a stream
+// where operations depending on the transfer may be queued.
+void SplitStaging::transfer(WaveStream& waveStream, Stream& stream) {
+  if (fill_ == 0) {
+    return;
+  }
+  deviceBuffer_ = waveStream.arena().allocate<char>(fill_);
+  auto universal = deviceBuffer_->as<char>();
+  for (auto i = 0; i < offsets_.size(); ++i) {
+    memcpy(universal + offsets_[i], staging_[i].hostData, staging_[i].size);
+  }
+  stream.prefetch(
+      getDevice(), deviceBuffer_->as<char>(), deviceBuffer_->size());
+  for (auto& pair : patch_) {
+    *reinterpret_cast<int64_t*>(pair.second) +=
+        reinterpret_cast<int64_t>(universal) + offsets_[pair.first];
+  }
+}
+
+BufferId ResultStaging::reserve(int32_t bytes) {
+  offsets_.push_back(fill_);
+  fill_ += bits::roundUp(bytes, 8);
+  return offsets_.size() - 1;
+}
+
+void ResultStaging::registerPointerInternal(BufferId id, void** pointer) {
+  patch_.push_back(std::make_pair(id, pointer));
+}
+
+void ResultStaging::setReturnBuffer(GpuArena& arena, DecodePrograms& programs) {
+  if (fill_ == 0) {
+    programs.result = nullptr;
+    programs.hostResult = nullptr;
+    return;
+  }
+  programs.result = arena.allocate<char>(fill_);
+  auto address = reinterpret_cast<int64_t>(programs.result->as<char>());
+  // Patch all the registered pointers to point to buffer at offset offset_[id]
+  // + the offset already in the registered pointer.
+  for (auto& pair : patch_) {
+    int64_t* pointer = reinterpret_cast<int64_t*>(pair.second);
+    *pointer += address + offsets_[pair.first];
+  }
+  patch_.clear();
+  offsets_.clear();
+  fill_ = 0;
+}
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/dwio/FormatData.h
+++ b/velox/experimental/wave/dwio/FormatData.h
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/dwio/common/ScanSpec.h"
+#include "velox/dwio/common/Statistics.h"
+#include "velox/dwio/common/TypeWithId.h"
+#include "velox/experimental/wave/dwio/decode/DecodeStep.h"
+#include "velox/experimental/wave/vector/WaveVector.h"
+
+#include <folly/Range.h>
+
+namespace facebook::velox::wave {
+using BufferId = int32_t;
+constexpr BufferId kNoBufferId = -1;
+
+class ReadStream;
+class WaveStream;
+
+// Describes how a column is staged on GPU, for example, copy from host RAM,
+// direct read, already on device etc.
+struct Staging {
+  // Pointer to data in pageable host memory, if applicable.
+  const void* hostData{nullptr};
+
+  //  Size in bytes.
+  size_t size;
+
+  // Add members here to describe locations in storage for GPU direct transfer.
+};
+
+/// Describes how columns to be read together are staged on device. This is
+/// anything from a set of host to device copies, GPU direct IO, or no-op if
+/// data already on device.
+class SplitStaging {
+ public:
+  /// Adds a transfer described by 'staging'. Returns an id of the
+  /// device side buffer. The id will be mapped to an actual buffer
+  /// when the transfers are queud. At this time, pointers that
+  /// are registered to the id are patched to the actual device side
+  /// address.
+  BufferId add(Staging& staging);
+
+  /// Registers '*ptr' to be patched to the device side address of the transfer
+  /// identified by 'id'. The *ptr is an offset into the buffer identified by
+  /// id, so that the actual start of the area is added to the offset at *ptr.
+  template <typename T>
+  void registerPointer(BufferId id, T pointer) {
+    registerPointerInternal(
+        id, reinterpret_cast<void**>(reinterpret_cast<uint64_t>(pointer)));
+  }
+
+  // Starts the transfers registered with add( on 'stream').
+  void transfer(WaveStream& waveStream, Stream& stream);
+
+ private:
+  void registerPointerInternal(BufferId id, void** ptr);
+
+  // Pinned host memory for transfer to device. May be nullptr if using unified
+  // memory.
+  WaveBufferPtr hostBuffer_;
+
+  // Device accessible memory (device or unified) with the data to read.
+  WaveBufferPtr deviceBuffer_;
+
+  std::vector<Staging> staging_;
+  // Offsets into device buffer for each id returned by add().
+  std::vector<int64_t> offsets_;
+
+  // List of pointers to patch to places inside deviceBuffer once this is
+  // allocated.
+  std::vector<std::pair<int32_t, void**>> patch_;
+
+  // Total device side space reserved so farr.
+  int64_t fill_{0};
+};
+
+class ResultStaging {
+ public:
+  /// Reserves 'bytes' bytes in result buffer to be brought to host after
+  /// Decodeprograms completes on device.
+  BufferId reserve(int32_t bytes);
+
+  /// Registers '*pointer' to be patched to the buffer. The starting address of
+  /// the buffer is added to *pointer, so that if *pointer was 16, *pointer will
+  /// come to point to the 16th byte in the buffer.
+  template <typename T>
+  void registerPointer(BufferId id, T pointer) {
+    registerPointerInternal(
+        id, reinterpret_cast<void**>(reinterpret_cast<uint64_t>(pointer)));
+  }
+
+  void setReturnBuffer(GpuArena& arena, DecodePrograms& programs);
+
+ private:
+  void registerPointerInternal(BufferId id, void** pointer);
+
+  // Offset of each result in either buffer.
+  std::vector<int32_t> offsets_;
+  // Patch addresses. The int64_t* is updated to point to the result buffer once
+  // it is allocated.
+  std::vector<std::pair<int32_t, void**>> patch_;
+  int32_t fill_{0};
+  WaveBufferPtr deviceBuffer_;
+  WaveBufferPtr hostBuffer_;
+};
+
+using RowSet = folly::Range<const int32_t*>;
+class ColumnReader;
+
+// Specifies an action on a column. A column is not indivisible. It
+// has parts and another column's decode may depend on one part of
+// another column but not another., e.g. a child of a nullable struct
+// needs the nulls of the struct but no other parts to decode.
+enum class ColumnAction { kNulls, kFilter, kLengths, kValues };
+
+/// A generic description of a decode step. The actual steps are
+/// provided by FormatData specializations but this captures
+/// dependences, e.g. filters before non-filters, nulls and lengths
+/// of repeated containers before decoding the values. A dependency
+/// can be device side only or may need host decision. Items that
+/// depend device side can be made into consecutive decode ops in
+/// one kernel launch or can be in consecutively queued
+/// kernels. dependences which need host require the prerequisite
+/// kernel to ship data to host, which will sync on the stream and
+/// only then may schedule the dependents in another kernel.
+struct ColumnOp {
+  static constexpr int32_t kNoPrerequisite = -1;
+  static constexpr int32_t kNoOperand = -1;
+
+  // Is the op completed after this? If so, any dependent action can be
+  // queued as soon as this is set.
+  bool isFinal{false};
+  // True if needs a result on the host before proceeding.
+  bool needsResult{false};
+  OperandId producesOperand{kNoOperand};
+  // Index of another op in column ops array in ReadStream.
+  int32_t prerequisite{kNoPrerequisite};
+  ColumnAction action;
+  // Non-owning view on rows to read.
+  RowSet rows;
+  ColumnReader* reader{nullptr};
+  // Vector completed by arrival of this. nullptr if no vector.
+  WaveVector* waveVector{nullptr};
+  // Host side result size. 0 for unconditional decoding. Can be buffer size for
+  // passing rows, length/offset array etc.
+  int32_t resultSize{0};
+
+  // Device side non-vector result, like set of passing rows, array of
+  // lengths/starts etc.
+  int32_t* deviceResult{nullptr};
+  int32_t* hostResult{nullptr};
+};
+
+/// Operations on leaf columns. This is specialized for each file format.
+class FormatData {
+ public:
+  virtual ~FormatData() = default;
+
+  virtual int32_t totalRows() const = 0;
+
+  virtual bool hasNulls() const = 0;
+
+  /// Enqueues read of 'numRows' worth of null flags.  Returns the id of the
+  /// result area allocated from 'deviceStaging'.
+  virtual BufferId readNulls(
+      int32_t numRows,
+      ResultStaging& deviceStaging,
+      SplitStaging& stageing,
+      DecodePrograms& programs) {
+    VELOX_NYI();
+  }
+
+  /// Sets how many TBs will be scheduled at a time for this column.
+  void setBlocks(int32_t numBlocks) {
+    VELOX_NYI();
+  }
+
+  /// Returns estimate of sequential instructions needed to decode one value.
+  /// Used to decide how many TBs to use for each column.
+  virtual float cost(const ColumnOp& op) {
+    return 10;
+  }
+
+  /// Prepares a new batch of reads. The batch starts at 'startRiw', which is a
+  /// row number in terms of the column of 'this'. The row number for a nested
+  /// column is in terms of the column, not in terms of top level rows.
+  virtual void newBatch(int32_t startRow) = 0;
+
+  /// Adds the next read of the column. If the column is a filter depending on
+  /// another filter, the previous filter is given on the first call. Updates
+  /// status of 'op'.
+  virtual void startOp(
+      ColumnOp& op,
+      const ColumnOp* previousFilter,
+      ResultStaging& deviceStaging,
+      ResultStaging& resultStaging,
+      SplitStaging& staging,
+      DecodePrograms& program,
+      ReadStream& stream) = 0;
+};
+
+class FormatParams {
+ public:
+  explicit FormatParams(
+      memory::MemoryPool& pool,
+      dwio::common::ColumnReaderStatistics& stats)
+      : pool_(pool), stats_(stats) {}
+
+  virtual ~FormatParams() = default;
+
+  /// Makes format-specific structures for the column given by  'type'.
+  /// 'scanSpec' is given as extra context.
+  virtual std::unique_ptr<FormatData> toFormatData(
+      const std::shared_ptr<const dwio::common::TypeWithId>& type,
+      const velox::common::ScanSpec& scanSpec,
+      OperandId operand) = 0;
+
+  memory::MemoryPool& pool() {
+    return pool_;
+  }
+
+  dwio::common::ColumnReaderStatistics& runtimeStatistics() {
+    return stats_;
+  }
+
+ private:
+  memory::MemoryPool& pool_;
+  dwio::common::ColumnReaderStatistics& stats_;
+  int32_t currentRow_{0};
+};
+
+}; // namespace facebook::velox::wave

--- a/velox/experimental/wave/dwio/ReadStream.cpp
+++ b/velox/experimental/wave/dwio/ReadStream.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/dwio/ColumnReader.h"
+#include "velox/experimental/wave/dwio/StructColumnReader.h"
+
+namespace facebook::velox::wave {
+void allOperands(const ColumnReader* reader, OperandSet& operands) {
+  auto op = reader->operand();
+  if (op != kNoOperand) {
+    operands.add(op);
+  }
+  for (auto& child : reader->children()) {
+    allOperands(child, operands);
+  }
+}
+
+ReadStream::ReadStream(
+    StructColumnReader* columnReader,
+    vector_size_t offset,
+    RowSet rows,
+    WaveStream& _waveStream,
+    const OperandSet* firstColumns)
+    : Executable(), offset_(offset), rows_(rows) {
+  waveStream = &_waveStream;
+  allOperands(columnReader, outputOperands);
+  output.resize(outputOperands.size());
+  reader_ = columnReader;
+  staging_.push_back(std::make_unique<SplitStaging>());
+  currentStaging_ = staging_[0].get();
+  makeOps();
+}
+
+void ReadStream::makeOps() {
+  auto& children = reader_->children();
+  for (auto i = 0; i < children.size(); ++i) {
+    ops_.emplace_back();
+    auto& op = ops_.back();
+    auto* child = reader_->children()[i];
+    child->makeOp(this, ColumnAction::kValues, offset_, rows_, op);
+  }
+}
+
+bool ReadStream::makePrograms(bool& needSync) {
+  bool allDone = true;
+  needSync = false;
+  programs_.clear();
+  for (auto i = 0; i < ops_.size(); ++i) {
+    auto& op = ops_[i];
+    if (op.isFinal) {
+      continue;
+    }
+    if (op.prerequisite == ColumnOp::kNoPrerequisite ||
+        ops_[op.prerequisite].isFinal) {
+      op.reader->formatData()->startOp(
+          op,
+          nullptr,
+          deviceStaging_,
+          resultStaging_,
+          *currentStaging_,
+          programs_,
+          *this);
+      if (!op.isFinal) {
+        allDone = false;
+      }
+      if (op.needsResult) {
+        needSync = true;
+      }
+    } else {
+      allDone = false;
+    }
+  }
+  resultStaging_.setReturnBuffer(waveStream->arena(), programs_);
+  return allDone;
+}
+
+// static
+void ReadStream::launch(std::unique_ptr<ReadStream>&& readStream) {
+  using UniqueExe = std::unique_ptr<Executable>;
+  readStream->waveStream->installExecutables(
+      folly::Range<UniqueExe*>(reinterpret_cast<UniqueExe*>(&readStream), 1),
+      [&](Stream* stream, folly::Range<Executable**> exes) {
+        auto* readStream = reinterpret_cast<ReadStream*>(exes[0]);
+        bool needSync = false;
+        for (;;) {
+          bool done = readStream->makePrograms(needSync);
+          readStream->currentStaging_->transfer(
+              *readStream->waveStream, *stream);
+          if (done) {
+            break;
+          }
+          WaveBufferPtr extra;
+          launchDecode(
+              readStream->programs(),
+              &readStream->waveStream->arena(),
+              extra,
+              stream);
+          readStream->staging_.push_back(std::make_unique<SplitStaging>());
+          readStream->currentStaging_ = readStream->staging_.back().get();
+          if (needSync) {
+            stream->wait();
+          }
+        }
+        WaveBufferPtr extra;
+        launchDecode(
+            readStream->programs(),
+            &readStream->waveStream->arena(),
+            extra,
+            stream);
+        readStream->waveStream->markLaunch(*stream, *readStream);
+      });
+}
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/dwio/StructColumnReader.cpp
+++ b/velox/experimental/wave/dwio/StructColumnReader.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/dwio/StructColumnReader.h"
+
+namespace facebook ::velox::wave {
+
+bool StructColumnReader::isChildConstant(
+    const velox::common::ScanSpec& childSpec) const {
+  // Returns true if the child has a constant set in the ScanSpec, or if the
+  // file doesn't have this child (in which case it will be treated as null).
+  return childSpec.isConstant() ||
+      // The below check is trying to determine if this is a missing field in a
+      // struct that should be constant null.
+      (!isRoot_ && // If we're in the root struct channel is meaningless in this
+                   // context and it will be a null constant anyway if it's
+                   // missing.
+       childSpec.channel() !=
+           velox::common::ScanSpec::kNoChannel && // This can happen if there's
+                                                  // a filter on a subfield of a
+                                                  // row type that doesn't exist
+                                                  // in the output.
+       fileType_->type()->kind() !=
+           TypeKind::MAP && // If this is the case it means this is a flat map,
+                            // so it can't have "missing" fields.
+       childSpec.channel() >= fileType_->size());
+}
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/dwio/StructColumnReader.h
+++ b/velox/experimental/wave/dwio/StructColumnReader.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/experimental/wave/dwio/ColumnReader.h"
+
+namespace facebook ::velox::wave {
+
+class StructColumnReader : public ColumnReader {
+ public:
+  StructColumnReader(
+      const TypePtr& requestedType,
+      std::shared_ptr<const dwio::common::TypeWithId> fileType,
+      OperandId operand,
+      FormatParams& params,
+      velox::common::ScanSpec& scanSpec,
+      bool isRoot)
+      : ColumnReader(requestedType, fileType, operand, params, scanSpec),
+        isRoot_(isRoot) {}
+
+  bool isChildConstant(const velox::common::ScanSpec& childSpec) const;
+
+ protected:
+  void addChild(std::unique_ptr<ColumnReader> child) {
+    children_.push_back(child.get());
+    childrenOwned_.push_back(std::move(child));
+  }
+
+  const bool isRoot_;
+  std::vector<std::unique_ptr<ColumnReader>> childrenOwned_;
+};
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/dwio/decode/DecodeStep.h
+++ b/velox/experimental/wave/dwio/decode/DecodeStep.h
@@ -209,6 +209,12 @@ struct GpuDecode {
 };
 
 struct DecodePrograms {
+  void clear() {
+    programs.clear();
+    result = nullptr;
+    hostResult = nullptr;
+  }
+
   // Set of decode programs submitted as a unit. Each vector<DecodeStep> is run
   // on its own thread block. The consecutive DecodeSteps in the same program
   // are consecutive and the next one can depend on a previous one.

--- a/velox/experimental/wave/dwio/decode/GpuDecoder-inl.cuh
+++ b/velox/experimental/wave/dwio/decode/GpuDecoder-inl.cuh
@@ -73,7 +73,7 @@ enum class ResultOp { kDict, kBaseline, kDictScatter, kBaselineScatter };
 template <typename T, ResultOp op>
 __device__ void storeResult(
     int32_t i,
-    int32_t bitfield,
+    uint64_t bitfield,
     T baseline,
     const T* dict,
     const int32_t* scatter,
@@ -110,13 +110,13 @@ __device__ void decodeDictionaryOnBitpack(GpuDecode::DictionaryOnBitpack& op) {
     uint64_t word = words[wordIndex];
     uint64_t low = word >> bit;
     if (bitWidth + bit <= 64) {
-      int32_t index = low & mask;
+      uint64_t index = low & mask;
       storeResult<T, resultOp>(i, index, baseline, dict, scatter, result);
     } else {
       uint64_t nextWord = words[wordIndex + 1];
       int32_t bitsFromNext = bitWidth - (64 - bit);
-      int32_t index =
-          low | ((nextWord & ((1 << bitsFromNext) - 1)) << (64 - bit));
+      uint64_t index =
+          low | ((nextWord & ((1LU << bitsFromNext) - 1)) << (64 - bit));
       storeResult<T, resultOp>(i, index, baseline, dict, scatter, result);
     }
   }

--- a/velox/experimental/wave/exec/Aggregation.cpp
+++ b/velox/experimental/wave/exec/Aggregation.cpp
@@ -20,19 +20,19 @@
 #include "velox/experimental/wave/exec/ToWave.h"
 #include "velox/experimental/wave/exec/Vectors.h"
 
-#define KEY_TYPE_DISPATCH(_func, _kindExpr, ...) \
-  [&]() {                                        \
-    auto _kind = (_kindExpr);                    \
-    switch (_kind) {                             \
-      case PhysicalType::kInt32:                 \
-        return _func<int32_t>(__VA_ARGS__);      \
-      case PhysicalType::kInt64:                 \
-        return _func<int64_t>(__VA_ARGS__);      \
-      case PhysicalType::kString:                \
-        return _func<StringView>(__VA_ARGS__);   \
-      default:                                   \
-        VELOX_UNSUPPORTED("{}", _kind);          \
-    };                                           \
+#define KEY_TYPE_DISPATCH(_func, _kindExpr, ...)              \
+  [&]() {                                                     \
+    auto _kind = (_kindExpr);                                 \
+    switch (_kind) {                                          \
+      case PhysicalType::kInt32:                              \
+        return _func<int32_t>(__VA_ARGS__);                   \
+      case PhysicalType::kInt64:                              \
+        return _func<int64_t>(__VA_ARGS__);                   \
+      case PhysicalType::kString:                             \
+        return _func<StringView>(__VA_ARGS__);                \
+      default:                                                \
+        VELOX_UNSUPPORTED("{}", static_cast<int32_t>(_kind)); \
+    };                                                        \
   }()
 
 namespace facebook::velox::wave {
@@ -80,10 +80,10 @@ Aggregation::Aggregation(
     const core::AggregationNode& node,
     const std::shared_ptr<aggregation::AggregateFunctionRegistry>&
         functionRegistry)
-    : WaveOperator(state, node.outputType()),
+    : WaveOperator(state, node.outputType(), node.id()),
       arena_(&state.arena()),
       functionRegistry_(functionRegistry) {
-  VELOX_CHECK_EQ(node.step(), core::AggregationNode::Step::kSingle);
+  VELOX_CHECK(node.step() == core::AggregationNode::Step::kSingle);
   VELOX_CHECK(node.preGroupedKeys().empty());
   auto& inputType = node.sources()[0]->outputType();
   container_ = arena_->allocate<aggregation::GroupsContainer>(

--- a/velox/experimental/wave/exec/OperandSet.h
+++ b/velox/experimental/wave/exec/OperandSet.h
@@ -18,9 +18,9 @@
 
 #include <vector>
 #include "velox/common/base/BitUtil.h"
+#include "velox/experimental/wave/vector/Operand.h"
 
 namespace facebook::velox::wave {
-using OperandId = int32_t;
 
 /// Set of OperandId . Uses the id() as an index into a bitmap.
 class OperandSet {

--- a/velox/experimental/wave/exec/Project.h
+++ b/velox/experimental/wave/exec/Project.h
@@ -25,7 +25,7 @@ class Project : public WaveOperator {
       RowTypePtr outputType,
       std::vector<AbstractOperand*> operands,
       std::vector<std::vector<ProgramPtr>> levels)
-      : WaveOperator(state, outputType), levels_(std::move(levels)) {}
+      : WaveOperator(state, outputType, ""), levels_(std::move(levels)) {}
 
   bool isStreaming() const override {
     return true;

--- a/velox/experimental/wave/exec/TableScan.cpp
+++ b/velox/experimental/wave/exec/TableScan.cpp
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/exec/TableScan.h"
+#include "velox/common/time/Timer.h"
+#include "velox/exec/Task.h"
+#include "velox/experimental/wave/exec/WaveDriver.h"
+#include "velox/expression/Expr.h"
+
+namespace facebook::velox::wave {
+
+std::atomic<uint64_t> TableScan::ioWaitNanos_;
+
+using exec::BlockingReason;
+
+BlockingReason TableScan::isBlocked(ContinueFuture* future) {
+  if (!dataSource_ || needNewSplit_) {
+    nextSplit(future);
+  }
+  if (blockingFuture_.valid()) {
+    *future = std::move(blockingFuture_);
+    return blockingReason_;
+  }
+  return BlockingReason::kNotBlocked;
+}
+
+BlockingReason TableScan::nextSplit(ContinueFuture* future) {
+  exec::Split split;
+  blockingReason_ = driverCtx_->task->getSplitOrFuture(
+      driverCtx_->splitGroupId,
+      planNodeId_,
+      split,
+      blockingFuture_,
+      maxPreloadedSplits_,
+      splitPreloader_);
+  if (blockingReason_ != BlockingReason::kNotBlocked) {
+    return blockingReason_;
+  }
+
+  if (!split.hasConnectorSplit()) {
+    noMoreSplits_ = true;
+    if (dataSource_) {
+      auto connectorStats = dataSource_->runtimeStats();
+      auto lockedStats = stats().wlock();
+      for (const auto& [name, counter] : connectorStats) {
+        if (name == "ioWaitNanos") {
+          ioWaitNanos_ += counter.value - lastIoWaitNanos_;
+          lastIoWaitNanos_ = counter.value;
+        }
+        if (UNLIKELY(lockedStats->runtimeStats.count(name) == 0)) {
+          lockedStats->runtimeStats.insert(
+              std::make_pair(name, RuntimeMetric(counter.unit)));
+        } else {
+          VELOX_CHECK_EQ(lockedStats->runtimeStats.at(name).unit, counter.unit);
+        }
+        lockedStats->runtimeStats.at(name).addValue(counter.value);
+      }
+    }
+    return BlockingReason::kNotBlocked;
+  }
+
+  const auto& connectorSplit = split.connectorSplit;
+  needNewSplit_ = false;
+
+  VELOX_CHECK_EQ(
+      connector_->connectorId(),
+      connectorSplit->connectorId,
+      "Got splits with different connector IDs");
+
+  if (!dataSource_) {
+    connectorQueryCtx_ = driver_->operatorCtx()->createConnectorQueryCtx(
+        connectorSplit->connectorId, planNodeId_, connectorPool_);
+    dataSource_ = connector_->createDataSource(
+        outputType_, tableHandle_, columnHandles_, connectorQueryCtx_.get());
+    waveDataSource_ = dataSource_->toWaveDataSource();
+    WithSubfieldMap subfields(driver_->subfields());
+    waveDataSource_->setOutputOperands(defines_);
+    waveDataSource_->addSplit(connectorSplit);
+  } else {
+    if (connectorSplit->dataSource) {
+      ++numPreloadedSplits_;
+      // The AsyncSource returns a unique_ptr to a shared_ptr. The
+      // unique_ptr will be nullptr if there was a cancellation.
+      numReadyPreloadedSplits_ += connectorSplit->dataSource->hasValue();
+      auto preparedDataSource = connectorSplit->dataSource->move();
+      driver_->stats().wlock()->getOutputTiming.add(
+          connectorSplit->dataSource->prepareTiming());
+      if (!preparedDataSource) {
+        // There must be a cancellation.
+        VELOX_CHECK(driver_->operatorCtx()->task()->isCancelled());
+        return BlockingReason::kNotBlocked;
+      }
+      auto preparedWaveSource = preparedDataSource->toWaveDataSource();
+      waveDataSource_->setFromDataSource(std::move(preparedWaveSource));
+    } else {
+      waveDataSource_->addSplit(connectorSplit);
+    }
+  }
+  for (const auto& entry : pendingDynamicFilters_) {
+    waveDataSource_->addDynamicFilter(entry.first, entry.second);
+  }
+  pendingDynamicFilters_.clear();
+  return BlockingReason::kNotBlocked;
+}
+
+void TableScan::preload(std::shared_ptr<connector::ConnectorSplit> split) {
+  // The AsyncSource returns a unique_ptr to the shared_ptr of the
+  // DataSource. The callback may outlive the Task, hence it captures
+  // a shared_ptr to it. This is required to keep memory pools live
+  // for the duration. The callback checks for task cancellation to
+  // avoid needless work.
+  split->dataSource = std::make_unique<AsyncSource<connector::DataSource>>(
+      [type = outputType_,
+       source = waveDataSource_,
+       table = tableHandle_,
+       columns = columnHandles_,
+       connector = connector_,
+       defines = defines_,
+       this,
+       ctx = driver_->operatorCtx()->createConnectorQueryCtx(
+           split->connectorId, planNodeId_, connectorPool_),
+       task = driver_->operatorCtx()->task(),
+       split]() -> std::unique_ptr<connector::DataSource> {
+        if (task->isCancelled()) {
+          return nullptr;
+        }
+        auto debugString =
+            fmt::format("Split {} Task {}", split->toString(), task->taskId());
+        ExceptionContextSetter exceptionContext(
+            {[](VeloxException::Type /*exceptionType*/, auto* debugString) {
+               return *static_cast<std::string*>(debugString);
+             },
+             &debugString});
+
+        auto ptr = connector->createDataSource(type, table, columns, ctx.get());
+        if (task->isCancelled()) {
+          return nullptr;
+        }
+        WithSubfieldMap subfields(driver_->subfields());
+        auto waveSource = ptr->toWaveDataSource();
+        waveSource->setOutputOperands(defines);
+        waveSource->addSplit(split);
+        return ptr;
+      });
+}
+
+void TableScan::checkPreload() {
+  auto executor = connector_->executor();
+  if (maxPreloadedSplits_ == 0 || !executor ||
+      !connector_->supportsSplitPreload()) {
+    return;
+  }
+  if (dataSource_->allPrefetchIssued()) {
+    maxPreloadedSplits_ = driverCtx_->task->numDrivers(driverCtx_->driver) *
+        maxSplitPreloadPerDriver_;
+    if (!splitPreloader_) {
+      splitPreloader_ =
+          [executor, this](std::shared_ptr<connector::ConnectorSplit> split) {
+            preload(split);
+
+            executor->add(
+                [taskHolder = driver_->operatorCtx()->task(), split]() mutable {
+                  split->dataSource->prepare();
+                  split.reset();
+                });
+          };
+    }
+  }
+}
+
+bool TableScan::isFinished() const {
+  return noMoreSplits_;
+}
+
+void TableScan::addDynamicFilter(
+    column_index_t outputChannel,
+    const std::shared_ptr<common::Filter>& filter) {
+  if (dataSource_) {
+    dataSource_->addDynamicFilter(outputChannel, filter);
+  } else {
+    pendingDynamicFilters_.emplace(outputChannel, filter);
+  }
+}
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/TableScan.h
+++ b/velox/experimental/wave/exec/TableScan.h
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/experimental/wave/exec/WaveOperator.h"
+
+#include "velox/common/time/Timer.h"
+#include "velox/exec/Task.h"
+#include "velox/experimental/wave/exec/ToWave.h"
+#include "velox/experimental/wave/exec/WaveDataSource.h"
+#include "velox/expression/Expr.h"
+
+namespace facebook::velox::wave {
+
+class TableScan : public WaveOperator {
+ public:
+  TableScan(
+      CompileState& state,
+      int32_t operatorId,
+      const core::TableScanNode& tableScanNode)
+      : WaveOperator(state, tableScanNode.outputType(), tableScanNode.id()),
+        tableHandle_(tableScanNode.tableHandle()),
+        columnHandles_(tableScanNode.assignments()),
+        driverCtx_(state.driver().driverCtx()),
+        connectorPool_(driverCtx_->task->addConnectorPoolLocked(
+            planNodeId_,
+            driverCtx_->pipelineId,
+            driverCtx_->driverId,
+            "",
+            tableHandle_->connectorId())),
+        readBatchSize_(driverCtx_->task->queryCtx()
+                           ->queryConfig()
+                           .preferredOutputBatchRows()) {
+    connector_ = connector::getConnector(tableHandle_->connectorId());
+  }
+
+  int32_t canAdvance() override {
+    if (!dataSource_) {
+      return 0;
+    }
+    return waveDataSource_->canAdvance();
+  }
+
+  void schedule(WaveStream& stream, int32_t maxRows = 0) override {
+    waveDataSource_->schedule(stream, maxRows);
+  }
+
+  vector_size_t outputSize(WaveStream& stream) const {
+    return waveDataSource_->outputSize(stream);
+  }
+
+  bool isStreaming() const override {
+    return true;
+  }
+
+  exec::BlockingReason isBlocked(ContinueFuture* future) override;
+
+  bool isFinished() const override;
+
+  bool canAddDynamicFilter() const override {
+    return true;
+  }
+
+  void addDynamicFilter(
+      column_index_t outputChannel,
+      const std::shared_ptr<common::Filter>& filter) override;
+
+  static uint64_t ioWaitNanos() {
+    return ioWaitNanos_;
+  }
+
+  std::string toString() const override {
+    return "TableScan";
+  }
+
+ private:
+  exec::BlockingReason nextSplit(ContinueFuture* future);
+
+  // Sets 'maxPreloadSplits' and 'splitPreloader' if prefetching
+  // splits is appropriate. The preloader will be applied to the
+  // 'first 'maxPreloadSplits' of the Tasks's split queue for 'this'
+  // when getting splits.
+  void checkPreload();
+
+  // Sets 'split->dataSource' to be a Asyncsource that makes a
+  // DataSource to read 'split'. This source will be prepared in the
+  // background on the executor of the connector. If the DataSource is
+  // needed before prepare is done, it will be made when needed.
+  void preload(std::shared_ptr<connector::ConnectorSplit> split);
+
+  // Process-wide IO wait time.
+  static std::atomic<uint64_t> ioWaitNanos_;
+
+  const std::shared_ptr<connector::ConnectorTableHandle> tableHandle_;
+  const std::
+      unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
+          columnHandles_;
+  exec::DriverCtx* const driverCtx_;
+  memory::MemoryPool* const connectorPool_;
+  ContinueFuture blockingFuture_{ContinueFuture::makeEmpty()};
+  exec::BlockingReason blockingReason_;
+  int64_t currentSplitWeight_{0};
+  bool needNewSplit_ = true;
+  std::shared_ptr<connector::Connector> connector_;
+  std::shared_ptr<connector::ConnectorQueryCtx> connectorQueryCtx_;
+  bool noMoreSplits_ = false;
+  // Dynamic filters to add to the data source when it gets created.
+  std::unordered_map<column_index_t, std::shared_ptr<common::Filter>>
+      pendingDynamicFilters_;
+
+  std::shared_ptr<connector::DataSource> dataSource_;
+
+  std::shared_ptr<WaveDataSource> waveDataSource_;
+
+  int32_t maxPreloadedSplits_{0};
+
+  const int32_t maxSplitPreloadPerDriver_{0};
+
+  // Callback passed to getSplitOrFuture() for triggering async
+  // preload. The callback's lifetime is the lifetime of 'this'. This
+  // callback can schedule preloads on an executor. These preloads may
+  // outlive the Task and therefore need to capture a shared_ptr to
+  // it.
+  std::function<void(const std::shared_ptr<connector::ConnectorSplit>&)>
+      splitPreloader_{nullptr};
+
+  // Count of splits that started background preload.
+  int32_t numPreloadedSplits_{0};
+
+  // Count of splits that finished preloading before being read.
+  int32_t numReadyPreloadedSplits_{0};
+
+  int32_t readBatchSize_;
+  int32_t maxReadBatchSize_;
+
+  // Exits getOutput() method after this many milliseconds.
+  // Zero means 'no limit'.
+  size_t getOutputTimeLimitMs_{0};
+
+  double maxFilteringRatio_{0};
+
+  // String shown in ExceptionContext inside DataSource and LazyVector loading.
+  std::string debugString_;
+
+  // The last value of the IO wait time of 'this' that has been added to the
+  // global static 'ioWaitNanos_'.
+  uint64_t lastIoWaitNanos_{0};
+};
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/ToWave.h
+++ b/velox/experimental/wave/exec/ToWave.h
@@ -31,6 +31,10 @@ class CompileState {
   CompileState(const exec::DriverFactory& driverFactory, exec::Driver& driver)
       : driverFactory_(driverFactory), driver_(driver) {}
 
+  exec::Driver& driver() {
+    return driver_;
+  }
+
   // Replaces sequences of Operators in the Driver given at construction with
   // Wave equivalents. Returns true if the Driver was changed.
   bool compile();

--- a/velox/experimental/wave/exec/Values.cpp
+++ b/velox/experimental/wave/exec/Values.cpp
@@ -21,7 +21,7 @@
 namespace facebook::velox::wave {
 
 Values::Values(CompileState& state, const core::ValuesNode& values)
-    : WaveOperator(state, values.outputType()),
+    : WaveOperator(state, values.outputType(), values.id()),
       values_(values.values()),
       roundsLeft_(values.repeatTimes()) {}
 

--- a/velox/experimental/wave/exec/WaveDataSource.h
+++ b/velox/experimental/wave/exec/WaveDataSource.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/time/Timer.h"
+#include "velox/connectors/Connector.h"
+#include "velox/exec/Task.h"
+#include "velox/experimental/wave/exec/WaveOperator.h"
+#include "velox/expression/Expr.h"
+
+namespace facebook::velox::wave {
+
+/// A delegate produced by a regular Velox connector::DataSource for reading its
+/// particular file format on GPU. Same methods, except that Wave schedule() and
+/// related are exposed instead of an iterator model.
+class WaveDataSource {
+ public:
+  virtual ~WaveDataSource() = default;
+
+  /// Sets the operand ids of the subfields that are projected out.
+  void setOutputOperands(const DefinesMap& defines) {
+    defines_ = &defines;
+  }
+
+  virtual void addDynamicFilter(
+      column_index_t outputChannel,
+      const std::shared_ptr<common::Filter>& filter) = 0;
+
+  virtual void addSplit(std::shared_ptr<connector::ConnectorSplit> split) = 0;
+
+  virtual int32_t canAdvance() = 0;
+
+  virtual void schedule(WaveStream& stream, int32_t maxRows = 0) = 0;
+
+  virtual vector_size_t outputSize(WaveStream& stream) const = 0;
+
+  virtual bool isFinished() = 0;
+
+  virtual uint64_t getCompletedBytes() = 0;
+
+  virtual uint64_t getCompletedRows() = 0;
+
+  virtual std::unordered_map<std::string, RuntimeCounter> runtimeStats() = 0;
+
+  virtual void setFromDataSource(std::shared_ptr<WaveDataSource> source) {
+    VELOX_UNSUPPORTED();
+  }
+
+ protected:
+  const DefinesMap* defines_{nullptr};
+};
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/WaveHiveDataSource.cpp
+++ b/velox/experimental/wave/exec/WaveHiveDataSource.cpp
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/exec/WaveHiveDataSource.h"
+
+namespace facebook::velox::wave {
+
+using namespace connector::hive;
+
+WaveHiveDataSource::WaveHiveDataSource(
+    const std::shared_ptr<HiveTableHandle>& hiveTableHandle,
+    const std::shared_ptr<common::ScanSpec>& scanSpec,
+    const RowTypePtr& readerOutputType,
+    std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
+        partitionKeys,
+    FileHandleFactory* fileHandleFactory,
+    folly::Executor* executor,
+    const connector::ConnectorQueryCtx* connectorQueryCtx,
+    const std::shared_ptr<HiveConfig>& hiveConfig,
+    const std::shared_ptr<io::IoStatistics>& ioStats,
+    const exec::ExprSet* remainingFilter,
+    std::shared_ptr<common::MetadataFilter> metadataFilter) {
+  params_.hiveTableHandle = hiveTableHandle;
+  params_.scanSpec = scanSpec;
+  params_.readerOutputType = readerOutputType;
+  params_.partitionKeys = partitionKeys;
+  params_.fileHandleFactory = fileHandleFactory;
+  params_.executor = executor;
+  params_.connectorQueryCtx = connectorQueryCtx;
+  params_.hiveConfig = hiveConfig;
+  params_.ioStats = ioStats;
+  remainingFilter_ = remainingFilter ? remainingFilter->exprs().at(0) : nullptr;
+  metadataFilter_ = metadataFilter;
+}
+
+void WaveHiveDataSource::addDynamicFilter(
+    column_index_t outputChannel,
+    const std::shared_ptr<common::Filter>& filter) {
+  VELOX_NYI();
+}
+
+void WaveHiveDataSource::setFromDataSource(
+    std::shared_ptr<WaveDataSource> sourceShared) {
+  auto source = dynamic_cast<WaveHiveDataSource*>(sourceShared.get());
+  VELOX_CHECK(source, "Bad DataSource type");
+
+  split_ = std::move(source->split_);
+  if (source->splitReader_ && source->splitReader_->emptySplit()) {
+    runtimeStats_.skippedSplits += source->runtimeStats_.skippedSplits;
+    runtimeStats_.skippedSplitBytes += source->runtimeStats_.skippedSplitBytes;
+    return;
+  }
+  source->params_.scanSpec->moveAdaptationFrom(*params_.scanSpec);
+  params_.scanSpec = std::move(source->params_.scanSpec);
+  splitReader_ = std::move(source->splitReader_);
+  // New io will be accounted on the stats of 'source'. Add the existing
+  // balance to that.
+  source->params_.ioStats->merge(*params_.ioStats);
+  params_.ioStats = std::move(source->params_.ioStats);
+}
+
+void WaveHiveDataSource::addSplit(
+    std::shared_ptr<connector::ConnectorSplit> split) {
+  VELOX_CHECK(
+      split_ == nullptr,
+      "Previous split has not been processed yet. Call next to process the split.");
+  split_ = std::dynamic_pointer_cast<HiveConnectorSplit>(split);
+  VELOX_CHECK(split_, "Wrong type of split");
+
+  VLOG(1) << "Adding split " << split_->toString();
+
+  if (splitReader_) {
+    splitReader_.reset();
+  }
+
+  splitReader_ = WaveSplitReader::create(split, params_, defines_);
+  ;
+  // Split reader subclasses may need to use the reader options in prepareSplit
+  // so we initialize it beforehand.
+  splitReader_->configureReaderOptions();
+  splitReader_->prepareSplit(metadataFilter_, runtimeStats_);
+}
+
+int32_t WaveHiveDataSource::canAdvance() {
+  return splitReader_ != nullptr ? splitReader_->canAdvance() : 0;
+}
+
+void WaveHiveDataSource::schedule(WaveStream& stream, int32_t maxRows) {
+  splitReader_->schedule(stream, maxRows);
+}
+
+vector_size_t WaveHiveDataSource::outputSize(WaveStream& stream) const {
+  return splitReader_->outputSize(stream);
+}
+
+bool WaveHiveDataSource::isFinished() {
+  if (!splitReader_) {
+    return false;
+  }
+  if (splitReader_->isFinished()) {
+    auto stats = splitReader_->runtimeStats();
+    for (const auto& [name, counter] : stats) {
+      auto it = splitReaderStats_.find(name);
+      if (it == splitReaderStats_.end()) {
+        splitReaderStats_.insert(std::make_pair(name, counter));
+      } else {
+        splitReaderStats_.insert(std::make_pair(
+            name, RuntimeCounter(it->second.value, counter.unit)));
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
+uint64_t WaveHiveDataSource::getCompletedBytes() {
+  return 0;
+}
+
+uint64_t WaveHiveDataSource::getCompletedRows() {
+  return completedRows_;
+}
+
+std::unordered_map<std::string, RuntimeCounter>
+WaveHiveDataSource::runtimeStats() {
+  auto map = runtimeStats_.toMap();
+  for (const auto& [name, counter] : splitReaderStats_) {
+    map.insert(std::make_pair(name, counter));
+  }
+  return map;
+}
+
+// static
+void WaveHiveDataSource::registerConnector() {
+  static bool registered = false;
+  if (registered) {
+    return;
+  }
+  registered = true;
+  auto config = std::make_shared<const core::MemConfig>();
+
+  // Create hive connector with config...
+  auto hiveConnector =
+      connector::getConnectorFactory(
+          connector::hive::HiveConnectorFactory::kHiveConnectorName)
+          ->newConnector("wavemock", config, nullptr);
+  connector::registerConnector(hiveConnector);
+  connector::hive::HiveDataSource::registerWaveDelegateHook(
+      [](const std::shared_ptr<HiveTableHandle>& hiveTableHandle,
+         const std::shared_ptr<common::ScanSpec>& scanSpec,
+         const RowTypePtr& readerOutputType,
+         std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
+             partitionKeys,
+         FileHandleFactory* fileHandleFactory,
+         folly::Executor* executor,
+         const connector::ConnectorQueryCtx* connectorQueryCtx,
+         const std::shared_ptr<HiveConfig>& hiveConfig,
+         const std::shared_ptr<io::IoStatistics>& ioStats,
+         const exec::ExprSet* remainingFilter,
+         std::shared_ptr<common::MetadataFilter> metadataFilter) {
+        return std::make_shared<WaveHiveDataSource>(
+            hiveTableHandle,
+            scanSpec,
+            readerOutputType,
+
+            partitionKeys,
+            fileHandleFactory,
+            executor,
+            connectorQueryCtx,
+            hiveConfig,
+            ioStats,
+            remainingFilter,
+            metadataFilter);
+      });
+}
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/WaveHiveDataSource.h
+++ b/velox/experimental/wave/exec/WaveHiveDataSource.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include "velox/connectors/hive/HiveDataSource.h"
+#include "velox/experimental/wave/exec/WaveDataSource.h"
+#include "velox/experimental/wave/exec/WaveSplitReader.h"
+
+namespace facebook::velox::wave {
+
+class WaveHiveDataSource : public WaveDataSource {
+ public:
+  WaveHiveDataSource(
+      const std::shared_ptr<connector::hive::HiveTableHandle>& hiveTableHandle,
+      const std::shared_ptr<common::ScanSpec>& scanSpec,
+      const RowTypePtr& readerOutputType,
+      std::unordered_map<
+          std::string,
+          std::shared_ptr<connector::hive::HiveColumnHandle>>* partitionKeys,
+      FileHandleFactory* fileHandleFactory,
+      folly::Executor* executor,
+      const connector::ConnectorQueryCtx* connectorQueryCtx,
+      const std::shared_ptr<connector::hive::HiveConfig>& hiveConfig,
+      const std::shared_ptr<io::IoStatistics>& ioStats,
+      const exec::ExprSet* remainingFilter,
+      std::shared_ptr<common::MetadataFilter> metadataFilter);
+
+  void addDynamicFilter(
+      column_index_t outputChannel,
+      const std::shared_ptr<common::Filter>& filter) override;
+
+  void addSplit(std::shared_ptr<connector::ConnectorSplit> split) override;
+
+  void setFromDataSource(std::shared_ptr<WaveDataSource> dataSource) override;
+
+  int32_t canAdvance() override;
+
+  void schedule(WaveStream& stream, int32_t maxRows) override;
+
+  vector_size_t outputSize(WaveStream& stream) const override;
+
+  bool isFinished() override;
+
+  uint64_t getCompletedBytes() override;
+
+  uint64_t getCompletedRows() override;
+
+  std::unordered_map<std::string, RuntimeCounter> runtimeStats() override;
+
+  static void registerConnector();
+
+ private:
+  SplitReaderParams params_;
+  std::shared_ptr<connector::ConnectorSplit> split_;
+  std::unique_ptr<WaveSplitReader> splitReader_;
+  std::shared_ptr<exec::Expr> remainingFilter_;
+  dwio::common::RuntimeStatistics runtimeStats_;
+  std::shared_ptr<common::MetadataFilter> metadataFilter_;
+  int64_t completedRows_{0};
+  int64_t completedBytes_{0};
+  std::unordered_map<std::string, RuntimeCounter> splitReaderStats_;
+};
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/WaveOperator.cpp
+++ b/velox/experimental/wave/exec/WaveOperator.cpp
@@ -16,11 +16,15 @@
 
 #include "velox/experimental/wave/exec/WaveOperator.h"
 #include "velox/experimental/wave/exec/ToWave.h"
+#include "velox/experimental/wave/exec/WaveDriver.h"
 
 namespace facebook::velox::wave {
 
-WaveOperator::WaveOperator(CompileState& state, const RowTypePtr& type)
-    : id_(state.numOperators()), outputType_(type) {
+WaveOperator::WaveOperator(
+    CompileState& state,
+    const RowTypePtr& type,
+    const std::string& planNodeId)
+    : id_(state.numOperators()), planNodeId_(planNodeId), outputType_(type) {
   definesSubfields(state, outputType_);
 }
 
@@ -51,6 +55,10 @@ void WaveOperator::definesSubfields(
       return;
     }
   }
+}
+
+folly::Synchronized<exec::OperatorStats>& WaveOperator::stats() {
+  return driver_->stats();
 }
 
 } // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/WaveSplitReader.cpp
+++ b/velox/experimental/wave/exec/WaveSplitReader.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/exec/WaveSplitReader.h"
+
+namespace facebook::velox::wave {
+std::unique_ptr<WaveSplitReader> WaveSplitReader::create(
+    const std::shared_ptr<velox::connector::ConnectorSplit>& split,
+    const SplitReaderParams& params,
+    const DefinesMap* defines) {
+  for (auto& factory : factories_) {
+    auto result = factory->create(split, params, defines);
+    if (result) {
+      return result;
+    }
+  }
+  VELOX_FAIL("No WaveSplitReader for  {}", split->toString());
+}
+
+std::vector<std::unique_ptr<WaveSplitReaderFactory>>
+    WaveSplitReader::factories_;
+
+// static
+void WaveSplitReader::registerFactory(
+    std::unique_ptr<WaveSplitReaderFactory> factory) {
+  factories_.push_back(std::move(factory));
+}
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/WaveSplitReader.h
+++ b/velox/experimental/wave/exec/WaveSplitReader.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/io/IoStatistics.h"
+#include "velox/common/time/Timer.h"
+#include "velox/connectors/hive/FileHandle.h"
+#include "velox/connectors/hive/HiveConnector.h"
+#include "velox/connectors/hive/TableHandle.h"
+#include "velox/dwio/common/ScanSpec.h"
+#include "velox/dwio/common/Statistics.h"
+#include "velox/exec/Task.h"
+#include "velox/experimental/wave/exec/WaveOperator.h"
+
+namespace facebook::velox::wave {
+
+/// Parameters for a Wave Hive SplitReaderFactory.
+struct SplitReaderParams {
+  std ::shared_ptr<connector::hive::HiveTableHandle> hiveTableHandle;
+  std::shared_ptr<common::ScanSpec> scanSpec;
+  RowTypePtr readerOutputType;
+  std::unordered_map<
+      std::string,
+      std::shared_ptr<connector::hive::HiveColumnHandle>>* partitionKeys;
+  FileHandleFactory* fileHandleFactory;
+  folly::Executor* executor;
+  const connector::ConnectorQueryCtx* connectorQueryCtx;
+  std::shared_ptr<connector::hive::HiveConfig> hiveConfig;
+  std::shared_ptr<io::IoStatistics> ioStats;
+};
+
+class WaveSplitReaderFactory;
+
+class WaveSplitReader {
+ public:
+  virtual ~WaveSplitReader() = default;
+
+  static std::unique_ptr<WaveSplitReader> create(
+      const std::shared_ptr<velox::connector::ConnectorSplit>& split,
+      const SplitReaderParams& params,
+      const DefinesMap* defines);
+
+  virtual bool emptySplit() = 0;
+
+  virtual int32_t canAdvance() = 0;
+
+  virtual void schedule(WaveStream& stream, int32_t maxRows) = 0;
+
+  virtual vector_size_t outputSize(WaveStream& stream) const = 0;
+
+  virtual bool isFinished() const = 0;
+
+  virtual uint64_t getCompletedBytes() = 0;
+
+  virtual uint64_t getCompletedRows() = 0;
+
+  virtual std::unordered_map<std::string, RuntimeCounter> runtimeStats() = 0;
+
+  virtual void configureReaderOptions() {}
+  virtual void prepareSplit(
+      std::shared_ptr<common::MetadataFilter> metadataFilter,
+      dwio::common::RuntimeStatistics& runtimeStats) {}
+
+  static void registerFactory(std::unique_ptr<WaveSplitReaderFactory> factory);
+
+  static std::vector<std::unique_ptr<WaveSplitReaderFactory>> factories_;
+};
+
+class WaveSplitReaderFactory {
+ public:
+  virtual ~WaveSplitReaderFactory() = default;
+
+  /// Returns a new split reader corresponding to 'split' if 'this' recognizes
+  /// the split, otherwise returns nullptr.
+  virtual std::unique_ptr<WaveSplitReader> create(
+      const std::shared_ptr<connector::ConnectorSplit>& split,
+      const SplitReaderParams& params,
+      const DefinesMap* defines) = 0;
+};
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/tests/CMakeLists.txt
+++ b/velox/experimental/wave/exec/tests/CMakeLists.txt
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_wave_exec_test FilterProjectTest.cpp Main.cpp)
+add_subdirectory(utils)
+
+add_executable(velox_wave_exec_test FilterProjectTest.cpp TableScanTest.cpp
+                                    Main.cpp)
 
 set_target_properties(velox_wave_exec_test PROPERTIES CUDA_ARCHITECTURES native)
 
@@ -21,6 +24,7 @@ add_test(velox_wave_exec_test velox_wave_exec_test)
 target_link_libraries(
   velox_wave_exec_test
   velox_wave_exec
+  velox_wave_mock_reader
   velox_aggregates
   velox_dwio_common
   velox_dwio_common_exception

--- a/velox/experimental/wave/exec/tests/TableScanTest.cpp
+++ b/velox/experimental/wave/exec/tests/TableScanTest.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cuda_runtime.h> // @manual
+#include "velox/exec/ExchangeSource.h"
+#include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/LocalExchangeSource.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/experimental/wave/exec/ToWave.h"
+#include "velox/experimental/wave/exec/WaveHiveDataSource.h"
+#include "velox/experimental/wave/exec/tests/utils/FileFormat.h"
+#include "velox/experimental/wave/exec/tests/utils/WaveTestSplitReader.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::core;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+
+class TableScanTest : public virtual HiveConnectorTestBase {
+ protected:
+  void SetUp() override {
+    HiveConnectorTestBase::SetUp();
+    wave::registerWave();
+    wave::WaveHiveDataSource::registerConnector();
+    wave::test::WaveTestSplitReader::registerTestSplitReader();
+    exec::ExchangeSource::factories().clear();
+    exec::ExchangeSource::registerFactory(createLocalExchangeSource);
+    fuzzer_ = std::make_unique<VectorFuzzer>(options_, pool_.get());
+  }
+
+  static void SetUpTestCase() {
+    OperatorTestBase::SetUpTestCase();
+  }
+
+  void TearDown() override {
+    wave::test::Table::dropAll();
+  }
+
+  std::vector<RowVectorPtr> makeVectors(
+      const RowTypePtr& rowType,
+      int32_t numVectors,
+      int32_t rowsPerVector) {
+    std::vector<RowVectorPtr> vectors;
+    options_.vectorSize = rowsPerVector;
+    fuzzer_->setOptions(options_);
+
+    for (int32_t i = 0; i < numVectors; ++i) {
+      auto vector = fuzzer_->fuzzInputFlatRow(rowType);
+      vectors.push_back(vector);
+    }
+    return vectors;
+  }
+
+  wave::test::SplitVector makeTable(
+      const std::string& name,
+      std::vector<RowVectorPtr>& rows) {
+    wave::test::Table::dropTable(name);
+    return wave::test::Table::defineTable(name, rows)->splits();
+  }
+
+  std::shared_ptr<Task> assertQuery(
+      const PlanNodePtr& plan,
+      const wave::test::SplitVector& splits,
+      const std::string& duckDbSql) {
+    return OperatorTestBase::assertQuery(plan, splits, duckDbSql);
+  }
+
+  std::shared_ptr<Task> assertQuery(
+      const PlanNodePtr& plan,
+      const wave::test::SplitVector& splits,
+      const std::string& duckDbSql,
+      const int32_t numPrefetchSplit) {
+    return AssertQueryBuilder(plan, duckDbQueryRunner_)
+        .config(
+            core::QueryConfig::kMaxSplitPreloadPerDriver,
+            std::to_string(numPrefetchSplit))
+        .splits(splits)
+        .assertResults(duckDbSql);
+  }
+
+  core::PlanNodePtr tableScanNode(const RowTypePtr& outputType) {
+    return PlanBuilder(pool_.get()).tableScan(outputType).planNode();
+  }
+
+  static PlanNodeStats getTableScanStats(const std::shared_ptr<Task>& task) {
+    auto planStats = toPlanStats(task->taskStats());
+    return std::move(planStats.at("0"));
+  }
+
+  static std::unordered_map<std::string, RuntimeMetric>
+  getTableScanRuntimeStats(const std::shared_ptr<Task>& task) {
+    return task->taskStats().pipelineStats[0].operatorStats[0].runtimeStats;
+  }
+
+  static int64_t getSkippedStridesStat(const std::shared_ptr<Task>& task) {
+    return getTableScanRuntimeStats(task)["skippedStrides"].sum;
+  }
+
+  static int64_t getSkippedSplitsStat(const std::shared_ptr<Task>& task) {
+    return getTableScanRuntimeStats(task)["skippedSplits"].sum;
+  }
+
+  static void waitForFinishedDrivers(
+      const std::shared_ptr<Task>& task,
+      uint32_t n) {
+    // Limit wait to 10 seconds.
+    size_t iteration{0};
+    while (task->numFinishedDrivers() < n and iteration < 100) {
+      /* sleep override */
+      usleep(100'000); // 0.1 second.
+      ++iteration;
+    }
+    ASSERT_EQ(n, task->numFinishedDrivers());
+  }
+
+  VectorFuzzer::Options options_;
+  std::unique_ptr<VectorFuzzer> fuzzer_;
+};
+
+TEST_F(TableScanTest, basic) {
+  auto type = ROW({"c0"}, {BIGINT()});
+  auto vectors = makeVectors(type, 10, 1'000);
+  auto splits = makeTable("test", vectors);
+  createDuckDbTable(vectors);
+
+  auto plan = tableScanNode(type);
+  auto task = assertQuery(plan, splits, "SELECT * FROM tmp");
+
+  // A quick sanity check for memory usage reporting. Check that peak total
+  // memory usage for the project node is > 0.
+  auto planStats = toPlanStats(task->taskStats());
+  auto scanNodeId = plan->id();
+  auto it = planStats.find(scanNodeId);
+  ASSERT_TRUE(it != planStats.end());
+}

--- a/velox/experimental/wave/exec/tests/utils/CMakeLists.txt
+++ b/velox/experimental/wave/exec/tests/utils/CMakeLists.txt
@@ -12,34 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_wave_stream OperandSet.cpp Wave.cpp)
+add_library(velox_wave_mock_file FileFormat.cpp)
+target_link_libraries(velox_wave_mock_file velox_exception velox_common_base
+                      velox_vector)
 
-add_library(
-  velox_wave_exec
-  Aggregation.cpp
-  AggregationInstructions.cu
-  ExprKernel.cu
-  ToWave.cpp
-  WaveOperator.cpp
-  Vectors.cpp
-  Values.cpp
-  WaveDriver.cpp
-  Project.cpp
-  TableScan.cpp
-  WaveHiveDataSource.cpp
-  WaveSplitReader.cpp)
-
-set_target_properties(velox_wave_exec PROPERTIES CUDA_ARCHITECTURES native)
+add_library(velox_wave_mock_reader WaveTestSplitReader.cpp TestFormatReader.cpp)
 
 target_link_libraries(
+  velox_wave_mock_reader
   velox_wave_exec
-  velox_wave_vector
-  velox_wave_common
-  velox_wave_stream
+  velox_wave_mock_file
+  velox_wave_dwio
+  velox_wave_decode
   velox_exception
   velox_common_base
-  velox_exec)
-
-if(${VELOX_BUILD_TESTING})
-  add_subdirectory(tests)
-endif()
+  velox_vector)

--- a/velox/experimental/wave/exec/tests/utils/FileFormat.cpp
+++ b/velox/experimental/wave/exec/tests/utils/FileFormat.cpp
@@ -1,0 +1,377 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/exec/tests/utils/FileFormat.h"
+
+namespace facebook::velox::wave::test {
+
+const Column* Stripe::findColumn(const dwio::common::TypeWithId& child) const {
+  for (auto i = 0; i < typeWithId->size(); ++i) {
+    if (typeWithId->childAt(i)->id() == child.id()) {
+      return columns[i].get();
+    }
+  }
+  VELOX_FAIL("No such column {}", child.id());
+}
+
+std::mutex Table::mutex_;
+std::unordered_map<std::string, std::unique_ptr<Table>> Table::allTables_;
+std::unordered_map<std::string, Stripe*> Table::allStripes_;
+
+int32_t bitWidth(uint64_t max) {
+  return 64 - __builtin_clzll(max);
+}
+
+template <typename T>
+T subtractMin(T value, T min) {
+  return value - min;
+}
+
+template <>
+StringView subtractMin(StringView value, StringView /*min*/) {
+  return value;
+}
+
+template <>
+Timestamp subtractMin(Timestamp value, Timestamp /*min*/) {
+  return value;
+}
+
+template <>
+double subtractMin(double value, double /*min*/) {
+  return value;
+}
+
+template <>
+float subtractMin(float value, float /*min*/) {
+  return value;
+}
+
+template <typename T>
+int64_t baseValue(T value) {
+  return static_cast<int64_t>(value);
+}
+
+template <>
+int64_t baseValue(StringView value) {
+  return 0;
+}
+
+template <>
+int64_t baseValue(Timestamp value) {
+  return 0;
+}
+
+template <>
+int64_t baseValue(double value) {
+  return 0;
+}
+template <>
+int64_t baseValue(float value) {
+  return 0;
+}
+
+template <typename T>
+int32_t rangeBitWidth(T max, T min) {
+  auto bits = bitWidth(baseValue(subtractMin(max, min)));
+  return bits ? bits : sizeof(T) * 8;
+}
+
+template <typename T>
+BufferPtr
+encodeInts(const std::vector<T>& ints, T min, T max, memory::MemoryPool* pool) {
+  int32_t width = rangeBitWidth(max, min);
+  int32_t size = bits::roundUp(ints.size() * width, 128) / 8;
+  auto buffer = AlignedBuffer::allocate<char>(size, pool);
+  auto destination = buffer->asMutable<uint64_t>();
+  for (auto i = 0; i < ints.size(); ++i) {
+    T sourceValue = subtractMin(ints[i], min);
+    bits::copyBits(
+        reinterpret_cast<uint64_t*>(&sourceValue),
+        0,
+        destination,
+        i * width,
+        width);
+  }
+  return buffer;
+}
+
+template <TypeKind kind>
+std::unique_ptr<EncoderBase> makeTypedEncoder(
+    memory::MemoryPool& pool,
+    const TypePtr& type) {
+  using T = typename TypeTraits<kind>::NativeType;
+  return std::make_unique<Encoder<T>>(&pool, type);
+}
+
+std::unique_ptr<EncoderBase> makeEncoder(
+    memory::MemoryPool& pool,
+    const TypePtr& type) {
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      makeTypedEncoder, type->kind(), pool, type);
+}
+
+template <typename T>
+int64_t Encoder<T>::flatSize() {
+  return count_ * rangeBitWidth(max_, min_) / 8;
+}
+
+template <>
+int64_t Encoder<StringView>::flatSize() {
+  return totalStringBytes_ + (count_ * bitWidth(maxLength_) / 8);
+}
+
+template <>
+int64_t Encoder<Timestamp>::flatSize() {
+  return direct_.size() * sizeof(Timestamp);
+}
+
+template <>
+int64_t Encoder<double>::flatSize() {
+  return direct_.size() * sizeof(double);
+}
+
+template <>
+int64_t Encoder<float>::flatSize() {
+  return direct_.size() * sizeof(float);
+}
+
+template <typename T>
+int64_t Encoder<T>::dictSize() {
+  return (rangeBitWidth(max_, min_) * distincts_.size() / 8) +
+      (bitWidth(distincts_.size() - 1) * count_ / 8);
+}
+
+template <>
+int64_t Encoder<StringView>::dictSize() {
+  return (count_ * bitWidth(distincts_.size() - 1) / 8) + dictBytes_;
+}
+
+struct StringWithId {
+  StringView string;
+  int32_t id;
+};
+
+template <typename T>
+std::unique_ptr<Column>
+directInts(std::vector<T>& ints, T min, T max, memory::MemoryPool* pool) {
+  auto column = std::make_unique<Column>();
+  column->values = encodeInts(ints, min, max, pool);
+  column->numValues = ints.size();
+  return column;
+}
+
+template <typename T>
+std::unique_ptr<Column> Encoder<T>::toColumn() {
+  auto column = std::make_unique<Column>();
+  column->kind = kind_;
+  if (distincts_.size() <= 1) {
+    VELOX_NYI("constant not supported");
+  }
+  if (!abandonDict_ && dictSize() < flatSize()) {
+    if (kind_ == TypeKind::VARCHAR) {
+      column->encoding = kDict;
+      column->values = encodeInts(
+          indices_, 0, static_cast<int32_t>(distincts_.size() - 1), pool_);
+      column->bitWidth = bitWidth(distincts_.size() - 1);
+      column->alphabet = dictStrings_.toColumn();
+      return column;
+    } else {
+      column->alphabet = directInts(dictInts_, min_, max_, pool_);
+    }
+  }
+  column->values = encodeInts(direct_, min_, max_, pool_);
+  column->numValues = count_;
+  column->bitWidth = rangeBitWidth(max_, min_);
+  column->baseline = baseValue(min_);
+  return column;
+}
+
+template <typename T>
+void Encoder<T>::add(T data) {
+  if (direct_.empty()) {
+    min_ = data;
+    max_ = data;
+  } else {
+    if (data > max_) {
+      max_ = data;
+    } else if (data < min_) {
+      min_ = data;
+    }
+  }
+  ++count_;
+  ++nonNullCount_;
+  direct_.push_back(data);
+  if (abandonDict_) {
+    return;
+  }
+  auto it = distincts_.find(data);
+  if (it != distincts_.end()) {
+    indices_.push_back(it->second);
+    return;
+  }
+  auto id = distincts_.size();
+  distincts_[data] = id;
+  dictInts_.push_back(data);
+  indices_.push_back(id);
+}
+
+StringView StringSet::add(StringView data) {
+  int32_t stringSize = data.size();
+  totalSize_ += stringSize;
+  if (stringSize > maxLength_) {
+    maxLength_ = stringSize;
+  }
+  if (buffers_.empty() ||
+      buffers_.back()->size() + stringSize > buffers_.back()->capacity()) {
+    buffers_.push_back(AlignedBuffer::allocate<char>(1 << 20, pool_));
+    buffers_.back()->setSize(0);
+  }
+  lengths_.push_back(stringSize);
+  auto& buffer = buffers_.back();
+  auto size = buffer->size();
+  memcpy(buffer->asMutable<char>() + size, data.data(), data.size());
+  buffer->setSize(size + data.size());
+  return StringView(buffer->as<char>() + size, data.size());
+};
+
+std::unique_ptr<Column> StringSet::toColumn() {
+  auto buffer = AlignedBuffer::allocate<char>(totalSize_, pool_);
+  int64_t fill = 0;
+  for (auto& piece : buffers_) {
+    memcpy(buffer->asMutable<char>(), piece->as<char>(), piece->size());
+    fill += piece->size();
+  }
+  auto column = std::make_unique<Column>();
+  column->kind = TypeKind::VARCHAR;
+  column->encoding = kFlat;
+  column->values = buffer;
+  column->lengths = directInts(lengths_, 0, maxLength_, pool_);
+  column->bitWidth = bitWidth(maxLength_);
+  return column;
+}
+
+template <>
+void Encoder<StringView>::add(StringView data) {
+  ++count_;
+  ++nonNullCount_;
+  auto size = data.size();
+  totalStringBytes_ += size;
+  if (size > maxLength_) {
+    maxLength_ = size;
+  }
+
+  if (abandonDict_) {
+    allStrings_.add(data);
+    return;
+  }
+  auto it = distincts_.find(data);
+  if (it != distincts_.end()) {
+    indices_.push_back(it->second);
+    return;
+  }
+  dictBytes_ += data.size();
+  auto copy = dictStrings_.add(data);
+  auto id = distincts_.size();
+  distincts_[copy] = id;
+  indices_.push_back(id);
+}
+
+template <typename T>
+void Encoder<T>::append(const VectorPtr& data) {
+  auto size = data->size();
+  SelectivityVector allRows(size);
+  DecodedVector decoded(*data, allRows, true);
+  for (auto i = 0; i < size; ++i) {
+    add(decoded.valueAt<T>(i));
+  }
+}
+
+void Writer::append(RowVectorPtr data) {
+  type_ = data->type();
+  if (encoders_.empty()) {
+    for (auto i = 0; i < data->type()->size(); ++i) {
+      encoders_.push_back(
+          makeEncoder(*pool_, data->type()->as<TypeKind::ROW>().childAt(i)));
+    }
+  }
+  VELOX_CHECK_EQ(encoders_.size(), data->type()->size());
+  for (auto i = 0; i < encoders_.size(); ++i) {
+    encoders_[i]->append(data->childAt(i));
+  }
+}
+
+void Writer::finishStripe() {
+  std::vector<std::unique_ptr<Column>> columns;
+  for (auto& encoder : encoders_) {
+    columns.push_back(encoder->toColumn());
+  }
+  stripes_.push_back(std::make_unique<Stripe>(
+      std::move(columns), dwio::common::TypeWithId::create(type_)));
+}
+
+Table* Writer::finalize(std::string tableName) {
+  finishStripe();
+  auto table = Table::getTable(tableName, true);
+  table->addStripes(std::move(stripes_), pool_);
+  return table;
+}
+
+void Table::addStripes(
+    std::vector<std::unique_ptr<Stripe>>&& stripes,
+    std::shared_ptr<memory::MemoryPool> pool) {
+  std::lock_guard<std::mutex> l(mutex_);
+  for (auto& s : stripes) {
+    s->name = fmt::format("wavemock://{}/{}", name_, stripes_.size());
+    allStripes_[s->name] = s.get();
+    stripes_.push_back(std::move(s));
+  }
+  pools_.push_back(pool);
+}
+
+// static
+const Table* Table::defineTable(
+    const std::string& name,
+    const std::vector<RowVectorPtr>& data) {
+  dropTable(name);
+  Writer writer(data[0]->size());
+  for (auto& vector : data) {
+    writer.append(vector);
+  }
+  return writer.finalize(name);
+}
+
+//  static
+void Table::dropTable(const std::string& name) {
+  std::lock_guard<std::mutex> l(mutex_);
+  auto it = allTables_.find(name);
+  if (it == allTables_.end()) {
+    return;
+  }
+  auto& table = it->second;
+  for (auto& stripe : table->stripes_) {
+    allStripes_.erase(stripe->name);
+  }
+  allTables_.erase(it);
+}
+// static
+void Table::dropAll() {
+  std::lock_guard<std::mutex> l(mutex_);
+  allStripes_.clear();
+  allTables_.clear();
+}
+
+} // namespace facebook::velox::wave::test

--- a/velox/experimental/wave/exec/tests/utils/FileFormat.h
+++ b/velox/experimental/wave/exec/tests/utils/FileFormat.h
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/connectors/Connector.h"
+#include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/dwio/common/TypeWithId.h"
+#include "velox/type/StringView.h"
+#include "velox/vector/ComplexVector.h"
+
+/// Sample set of composable encodings. Bit packing, direct and dictionary.
+namespace facebook::velox::wave::test {
+
+class Table;
+
+enum Encoding { kFlat, kDict };
+
+struct Column {
+  TypeKind kind;
+  Encoding encoding;
+  // Number of encoded values.
+  int32_t numValues{0};
+
+  // Distinct values in kDict.
+  std::shared_ptr<Column> alphabet;
+
+  // Encoded lengths for strings in 'data' if type is varchar and encoding is
+  // kFlat.
+  std::unique_ptr<Column> lengths;
+
+  // Width of bit packed encoding.
+  int8_t bitWidth;
+
+  BufferPtr values;
+
+  /// Frame of reference base for kFlat.
+  int64_t baseline{0};
+};
+
+struct Stripe {
+  Stripe(
+      std::vector<std::unique_ptr<Column>>&& in,
+      const std::shared_ptr<const dwio::common::TypeWithId>& type)
+      : typeWithId(type), columns(std::move(in)) {}
+
+  const Column* findColumn(const dwio::common::TypeWithId& child) const;
+
+  // Unique name assigned when associating with a Table.
+  std::string name;
+
+  std::shared_ptr<const dwio::common::TypeWithId> typeWithId;
+
+  // Top level columns.
+  std::vector<std::unique_ptr<Column>> columns;
+};
+
+class StringSet {
+ public:
+  StringSet(memory::MemoryPool* pool) : pool_(pool) {}
+
+  StringView add(StringView data);
+  std::unique_ptr<Column> toColumn();
+
+ private:
+  int64_t totalSize_{0};
+  int32_t maxLength_{0};
+  std::vector<int32_t> lengths_;
+  std::vector<BufferPtr> buffers_;
+  memory::MemoryPool* pool_;
+};
+
+class EncoderBase {
+ public:
+  virtual ~EncoderBase() = default;
+
+  virtual void append(const VectorPtr& data) = 0;
+
+  virtual std::unique_ptr<Column> toColumn() = 0;
+};
+
+template <typename T>
+class Encoder : public EncoderBase {
+ public:
+  Encoder(memory::MemoryPool* pool, const TypePtr& type)
+      : pool_(pool),
+        kind_(type->kind()),
+        dictStrings_(pool),
+        allStrings_(pool) {}
+
+  // Adds data.
+  void append(const VectorPtr& data) override;
+
+  // Retrieves the data added so far as an encoded column.
+  std::unique_ptr<Column> toColumn() override;
+
+ private:
+  void appendTyped(VectorPtr data);
+
+  void add(T data);
+
+  int64_t flatSize();
+  int64_t dictSize();
+
+  memory::MemoryPool* pool_;
+  TypeKind kind_;
+  int32_t count_{0};
+  int32_t nonNullCount_{0};
+  // Distincts for either int64_t or double.
+  folly::F14FastMap<T, int32_t> distincts_;
+  // Values as indices into dicts.
+  std::vector<int32_t> indices_;
+
+  std::vector<T> dictInts_;
+  // The fixed width values as direct.
+  std::vector<T> direct_;
+  // True if too many distinct values for dict.
+  bool abandonDict_{false};
+  T max_{};
+  T min_{};
+  // longest string, if string type.
+  int32_t maxLength_{0};
+  // Total bytes in distinct strings.
+  int64_t dictBytes_{0};
+  // Total string bytes without dict.
+  int32_t totalStringBytes_{0};
+
+  StringSet dictStrings_;
+  StringSet allStrings_;
+};
+
+template <>
+void Encoder<StringView>::add(StringView data);
+
+template <>
+int64_t Encoder<StringView>::dictSize();
+
+template <>
+int64_t Encoder<StringView>::flatSize();
+
+template <>
+int64_t Encoder<Timestamp>::flatSize();
+template <>
+int64_t Encoder<double>::flatSize();
+template <>
+int64_t Encoder<float>::flatSize();
+
+class Writer {
+ public:
+  Writer(int32_t stripeSize)
+      : stripeSize_(stripeSize),
+        pool_(memory::MemoryManager::getInstance()->addLeafPool()) {}
+
+  /// Appends a batch of data.
+  void append(RowVectorPtr data);
+
+  // Finishes encoding data, makes the table ready to read.
+  Table* finalize(std::string tableName);
+
+ private:
+  TypePtr type_;
+  void finishStripe();
+  const int32_t stripeSize_;
+  std::vector<std::unique_ptr<Stripe>> stripes_;
+  std::shared_ptr<memory::MemoryPool> pool_;
+  std::vector<std::unique_ptr<EncoderBase>> encoders_;
+};
+
+using SplitVector = std::vector<std::shared_ptr<connector::ConnectorSplit>>;
+
+class Table {
+ public:
+  Table(const std::string name) : name_(name) {}
+
+  static const Table* defineTable(
+      const std::string& name,
+      const std::vector<RowVectorPtr>& data);
+
+  static Table* getTable(const std::string& name, bool makeNew = false) {
+    std::lock_guard<std::mutex> l(mutex_);
+    auto it = allTables_.find(name);
+    if (it == allTables_.end()) {
+      if (makeNew) {
+        auto table = std::make_unique<Table>(name);
+        auto ptr = table.get();
+        allTables_[name] = std::move(table);
+        return ptr;
+      }
+      return nullptr;
+    }
+    return it->second.get();
+  }
+
+  static void dropTable(const std::string& name);
+
+  static Stripe* getStripe(const std::string& path) {
+    std::lock_guard<std::mutex> l(mutex_);
+    auto it = allStripes_.find(path);
+    VELOX_CHECK(it != allStripes_.end());
+    return it->second;
+  }
+
+  void addStripes(
+      std::vector<std::unique_ptr<Stripe>>&& stripes,
+      std::shared_ptr<memory::MemoryPool> pool);
+
+  int32_t numStripes() const {
+    return stripes_.size();
+  }
+
+  Stripe* stripeAt(int32_t index) {
+    std::lock_guard<std::mutex> l(mutex_);
+    if (index >= stripes_.size()) {
+      return nullptr;
+    }
+    return stripes_[index].get();
+  }
+
+  SplitVector splits() const {
+    SplitVector result;
+    std::lock_guard<std::mutex> l(mutex_);
+    for (auto& stripe : stripes_) {
+      result.push_back(std::make_shared<connector::hive::HiveConnectorSplit>(
+          "test-hive", stripe->name, dwio::common::FileFormat::UNKNOWN));
+    }
+    return result;
+  }
+
+  /// Drops all tables and stripes. Do this at end of test for cleanup.
+  static void dropAll();
+
+ private:
+  static std::mutex mutex_;
+  static std::unordered_map<std::string, std::unique_ptr<Table>> allTables_;
+  static std::unordered_map<std::string, Stripe*> allStripes_;
+  std::vector<std::shared_ptr<memory::MemoryPool>> pools_;
+  std::string name_;
+  std::vector<std::unique_ptr<Stripe>> stripes_;
+};
+
+} // namespace facebook::velox::wave::test

--- a/velox/experimental/wave/exec/tests/utils/TestFormatReader.cpp
+++ b/velox/experimental/wave/exec/tests/utils/TestFormatReader.cpp
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/exec/tests/utils/TestFormatReader.h"
+#include "velox/experimental/wave/dwio/StructColumnReader.h"
+
+namespace facebook::velox::wave::test {
+
+using common::Subfield;
+
+std::unique_ptr<FormatData> TestFormatParams::toFormatData(
+    const std::shared_ptr<const dwio::common::TypeWithId>& type,
+    const velox::common::ScanSpec& scanSpec,
+    OperandId operand) {
+  auto* column = type->id() == 0 ? nullptr : stripe_->findColumn(*type);
+  return std::make_unique<TestFormatData>(
+      operand, stripe_->columns[0]->numValues, column);
+}
+
+void TestFormatData::startOp(
+    ColumnOp& op,
+    const ColumnOp* previousFilter,
+    ResultStaging& deviceStaging,
+    ResultStaging& resultStaging,
+    SplitStaging& splitStaging,
+    DecodePrograms& program,
+    ReadStream& stream) {
+  VELOX_CHECK_NOT_NULL(column_);
+  BufferId id = kNoBufferId;
+  if (!staged_) {
+    staged_ = true;
+    Staging staging;
+    staging.hostData = column_->values->as<char>();
+    staging.size = column_->values->size();
+    id = splitStaging.add(staging);
+  }
+  if (!queued_) {
+    queued_ = true;
+    auto step = std::make_unique<GpuDecode>();
+    if (op.waveVector) {
+      op.waveVector->resize(op.rows.size(), false);
+    }
+    auto columnKind = static_cast<WaveTypeKind>(column_->kind);
+    if (column_->encoding == Encoding::kFlat) {
+      if (column_->baseline == 0 &&
+          (column_->bitWidth == 32 || column_->bitWidth == 64)) {
+        step->step = DecodeStep::kTrivial;
+        step->data.trivial.dataType = columnKind;
+        step->data.trivial.input = 0;
+        step->data.trivial.begin = currentRow_;
+        step->data.trivial.end = currentRow_ + op.rows.back() + 1;
+        step->data.trivial.input = nullptr;
+        if (id != kNoBufferId) {
+          splitStaging.registerPointer(id, &step->data.trivial.input);
+          splitStaging.registerPointer(id, &deviceBuffer_);
+        } else {
+          step->data.trivial.input = deviceBuffer_;
+        }
+        step->data.trivial.result = op.waveVector->values<char>();
+      } else {
+        step->step = DecodeStep::kDictionaryOnBitpack;
+        // Just bit pack, no dictionary.
+        step->data.dictionaryOnBitpack.alphabet = nullptr;
+        step->data.dictionaryOnBitpack.dataType = columnKind;
+        step->data.dictionaryOnBitpack.baseline = column_->baseline;
+        step->data.dictionaryOnBitpack.bitWidth = column_->bitWidth;
+        step->data.dictionaryOnBitpack.indices = nullptr;
+        step->data.dictionaryOnBitpack.begin = currentRow_;
+        step->data.dictionaryOnBitpack.end = currentRow_ + op.rows.back() + 1;
+        if (id != kNoBufferId) {
+          splitStaging.registerPointer(
+              id, &step->data.dictionaryOnBitpack.indices);
+          splitStaging.registerPointer(id, &deviceBuffer_);
+        } else {
+          step->data.dictionaryOnBitpack.indices =
+              reinterpret_cast<uint64_t*>(deviceBuffer_);
+        }
+        step->data.dictionaryOnBitpack.result = op.waveVector->values<char>();
+      }
+    } else {
+      VELOX_NYI("Non flat test encoding");
+    }
+    op.isFinal = true;
+    std::vector<std::unique_ptr<GpuDecode>> steps;
+    steps.push_back(std::move(step));
+    program.programs.push_back(std::move(steps));
+  }
+}
+
+class TestStructColumnReader : public StructColumnReader {
+ public:
+  TestStructColumnReader(
+      const TypePtr& requestedType,
+      const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
+      TestFormatParams& params,
+      common::ScanSpec& scanSpec,
+      std::vector<std::unique_ptr<Subfield::PathElement>>& path,
+      const DefinesMap& defines,
+      bool isRoot)
+      : StructColumnReader(
+            requestedType,
+            fileType,
+            pathToOperand(defines, path),
+            params,
+            scanSpec,
+            isRoot) {
+    // A reader tree may be constructed while the ScanSpec is being used
+    // for another read. This happens when the next stripe is being
+    // prepared while the previous one is reading.
+    auto& childSpecs = scanSpec.stableChildren();
+    for (auto i = 0; i < childSpecs.size(); ++i) {
+      auto childSpec = childSpecs[i];
+      if (isChildConstant(*childSpec)) {
+        VELOX_NYI();
+        continue;
+      }
+      auto childFileType = fileType_->childByName(childSpec->fieldName());
+      auto childRequestedType = requestedType_->as<TypeKind::ROW>().findChild(
+          folly::StringPiece(childSpec->fieldName()));
+      auto childParams = TestFormatParams(
+          params.pool(), params.runtimeStatistics(), params.stripe());
+
+      path.push_back(std::make_unique<common::Subfield::NestedField>(
+          childSpec->fieldName()));
+      addChild(TestFormatReader::build(
+          childRequestedType,
+          childFileType,
+          params,
+          *childSpec,
+          path,
+          defines));
+      path.pop_back();
+      childSpec->setSubscript(children_.size() - 1);
+    }
+  }
+};
+
+std::unique_ptr<ColumnReader> buildIntegerReader(
+    const TypePtr& requestedType,
+    const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
+    TestFormatParams& params,
+    common::ScanSpec& scanSpec,
+    std::vector<std::unique_ptr<Subfield::PathElement>>& path,
+    const DefinesMap& defines) {
+  return std::make_unique<ColumnReader>(
+      requestedType, fileType, pathToOperand(defines, path), params, scanSpec);
+}
+
+// static
+std::unique_ptr<ColumnReader> TestFormatReader::build(
+    const TypePtr& requestedType,
+    const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
+    TestFormatParams& params,
+    common::ScanSpec& scanSpec,
+    std::vector<std::unique_ptr<Subfield::PathElement>>& path,
+    const DefinesMap& defines,
+    bool isRoot) {
+  switch (fileType->type()->kind()) {
+    case TypeKind::INTEGER:
+    case TypeKind::BIGINT:
+      return buildIntegerReader(
+          requestedType, fileType, params, scanSpec, path, defines);
+
+    case TypeKind::ROW:
+      return std::make_unique<TestStructColumnReader>(
+          requestedType, fileType, params, scanSpec, path, defines, isRoot);
+    default:
+      VELOX_UNREACHABLE();
+  }
+}
+
+} // namespace facebook::velox::wave::test

--- a/velox/experimental/wave/exec/tests/utils/TestFormatReader.h
+++ b/velox/experimental/wave/exec/tests/utils/TestFormatReader.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/experimental/wave/dwio/ColumnReader.h"
+#include "velox/experimental/wave/exec/tests/utils/FileFormat.h"
+#include "velox/type/Subfield.h"
+
+namespace facebook::velox::wave::test {
+
+class TestFormatData : public wave::FormatData {
+ public:
+  TestFormatData(
+      OperandId operand,
+      int32_t totalRows,
+      const test::Column* column)
+      : operand_(operand), totalRows_(totalRows), column_(column) {}
+
+  bool hasNulls() const override {
+    return false;
+  }
+
+  int32_t totalRows() const override {
+    return totalRows_;
+  }
+
+  void newBatch(int32_t startRow) override {
+    currentRow_ = startRow;
+    queued_ = false;
+  }
+
+  void startOp(
+      ColumnOp& op,
+      const ColumnOp* previousFilter,
+      ResultStaging& deviceStaging,
+      ResultStaging& resultStaging,
+      SplitStaging& staging,
+      DecodePrograms& program,
+      ReadStream& stream) override;
+
+ private:
+  const OperandId operand_;
+  int32_t totalRows_{0};
+
+  const test::Column* column_;
+  bool staged_{false};
+  bool queued_{false};
+  int32_t numStaged_{0};
+  int32_t currentRow_{0};
+  // The device side data area start, set after the staged transfer is done.
+  void* deviceBuffer_{nullptr};
+};
+
+class TestFormatParams : public wave::FormatParams {
+ public:
+  TestFormatParams(
+      memory::MemoryPool& pool,
+      dwio::common::ColumnReaderStatistics& stats,
+      const test::Stripe* stripe)
+      : FormatParams(pool, stats), stripe_(stripe) {}
+
+  std::unique_ptr<FormatData> toFormatData(
+      const std::shared_ptr<const dwio::common::TypeWithId>& type,
+      const velox::common::ScanSpec& scanSpec,
+      OperandId operand) override;
+
+  const Stripe* stripe() const {
+    return stripe_;
+  }
+
+ private:
+  const test::Stripe* stripe_;
+};
+
+class TestFormatReader {
+ public:
+  static std::unique_ptr<ColumnReader> build(
+      const TypePtr& requestedType,
+      const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
+      TestFormatParams& params,
+      common::ScanSpec& scanSpec,
+      std::vector<std::unique_ptr<common::Subfield::PathElement>>& path,
+      const DefinesMap& defines,
+      bool isRoot = false);
+};
+
+} // namespace facebook::velox::wave::test

--- a/velox/experimental/wave/exec/tests/utils/WaveTestSplitReader.cpp
+++ b/velox/experimental/wave/exec/tests/utils/WaveTestSplitReader.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/exec/tests/utils/WaveTestSplitReader.h"
+#include "velox/experimental/wave/exec/tests/utils/TestFormatReader.h"
+
+namespace facebook::velox::wave::test {
+
+using common::Subfield;
+
+WaveTestSplitReader::WaveTestSplitReader(
+    const std::shared_ptr<connector::ConnectorSplit>& split,
+    const SplitReaderParams& params,
+    const DefinesMap* defines) {
+  auto hiveSplit =
+      dynamic_cast<connector::hive::HiveConnectorSplit*>(split.get());
+  VELOX_CHECK_NOT_NULL(hiveSplit);
+  stripe_ = test::Table::getStripe(hiveSplit->filePath);
+  VELOX_CHECK_NOT_NULL(stripe_);
+  TestFormatParams formatParams(
+      *params.connectorQueryCtx->memoryPool(), readerStats_, stripe_);
+  std::vector<std::unique_ptr<Subfield::PathElement>> empty;
+  columnReader_ = TestFormatReader::build(
+      params.readerOutputType,
+      stripe_->typeWithId,
+      formatParams,
+      *params.scanSpec,
+      empty,
+      *defines,
+      true);
+}
+
+int32_t WaveTestSplitReader::canAdvance() {
+  if (!stripe_) {
+    return 0;
+  }
+  return available();
+}
+
+void WaveTestSplitReader::schedule(WaveStream& waveStream, int32_t maxRows) {
+  auto numRows = std::min<int32_t>(maxRows, available());
+  scheduledRows_ = numRows;
+  auto rowSet = folly::Range<const int32_t*>(iota(numRows, rows_), numRows);
+  auto readStream = std::make_unique<ReadStream>(
+      reinterpret_cast<StructColumnReader*>(columnReader_.get()),
+      0,
+      rowSet,
+      waveStream);
+  ReadStream::launch(std::move(readStream));
+  nextRow_ += scheduledRows_;
+}
+
+vector_size_t WaveTestSplitReader::outputSize(WaveStream& stream) const {
+  return scheduledRows_;
+}
+
+bool WaveTestSplitReader::isFinished() const {
+  return nextRow_ >= available();
+}
+
+namespace {
+class WaveTestSplitReaderFactory : public WaveSplitReaderFactory {
+ public:
+  std::unique_ptr<WaveSplitReader> create(
+      const std::shared_ptr<connector::ConnectorSplit>& split,
+      const SplitReaderParams& params,
+      const DefinesMap* defines) override {
+    auto hiveSplit =
+        dynamic_cast<connector::hive::HiveConnectorSplit*>(split.get());
+    if (!hiveSplit) {
+      return nullptr;
+    }
+    if (hiveSplit->filePath.size() > 11 &&
+        memcmp(hiveSplit->filePath.data(), "wavemock://", 11) == 0) {
+      return std::make_unique<WaveTestSplitReader>(split, params, defines);
+    }
+    return nullptr;
+  }
+};
+} // namespace
+
+//  static
+void WaveTestSplitReader::registerTestSplitReader() {
+  WaveSplitReader::registerFactory(
+      std::make_unique<WaveTestSplitReaderFactory>());
+}
+
+} // namespace facebook::velox::wave::test

--- a/velox/experimental/wave/exec/tests/utils/WaveTestSplitReader.h
+++ b/velox/experimental/wave/exec/tests/utils/WaveTestSplitReader.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/experimental/wave/dwio/ColumnReader.h"
+#include "velox/experimental/wave/exec/WaveSplitReader.h"
+#include "velox/experimental/wave/exec/tests/utils/FileFormat.h"
+
+namespace facebook::velox::wave::test {
+
+/// A WaveSplitReader that decodes mock Wave tables.
+class WaveTestSplitReader : public WaveSplitReader {
+ public:
+  WaveTestSplitReader(
+      const std::shared_ptr<connector::ConnectorSplit>& split,
+      const SplitReaderParams& params,
+      const DefinesMap* defines);
+
+  bool emptySplit() override {
+    return !stripe_ || stripe_->columns[0]->numValues == 0;
+  }
+
+  int32_t canAdvance() override;
+
+  void schedule(WaveStream& stream, int32_t maxRows = 0) override;
+
+  vector_size_t outputSize(WaveStream& stream) const;
+
+  bool isFinished() const override;
+
+  uint64_t getCompletedBytes() override {
+    return 0;
+  }
+
+  uint64_t getCompletedRows() override {
+    return 0;
+  }
+
+  std::unordered_map<std::string, RuntimeCounter> runtimeStats() override {
+    return {};
+  }
+
+  static void registerTestSplitReader();
+
+ private:
+  int32_t available() const {
+    return stripe_->columns[0]->numValues - nextRow_;
+  }
+
+  std::shared_ptr<connector::ConnectorSplit> split_;
+  SplitReaderParams params_;
+  test::Stripe* stripe_{nullptr};
+  std::unique_ptr<ColumnReader> columnReader_;
+  // First unscheduled row.
+  int32_t nextRow_{0};
+  int32_t scheduledRows_{0};
+  dwio::common::ColumnReaderStatistics readerStats_;
+  raw_vector<int32_t> rows_;
+};
+
+} // namespace facebook::velox::wave::test


### PR DESCRIPTION
Adds a hook from Connector to Wave. Adds a Wave analog to DataSource and SplitReader. Adds a mock file format with bit packing, frame of reference and dictionary encoding.

Adds a reader tree analogous to SelectiveColumnReader.  Adds an analog of dwio::common::FormatData for Wave file format support.  Adds an Executable subclass to represent table scan as part of WaveStream. This encapsulates kernel launches for file format

operations.

Adds a minimal end to end test reading one column of data from a mock table.