### PR TITLE
Optimize MergedFlatMapFieldReader 3 times faster

### DIFF
--- a/velox/dwio/common/FlatMapHelper.cpp
+++ b/velox/dwio/common/FlatMapHelper.cpp
@@ -43,6 +43,7 @@ void reset(VectorPtr& vector, vector_size_t size, bool hasNulls) {
 
 void initializeStringVector(
     VectorPtr& vector,
+    const TypePtr& type,
     memory::MemoryPool& pool,
     const std::vector<const BaseVector*>& vectors) {
   vector_size_t size = 0;
@@ -64,7 +65,7 @@ void initializeStringVector(
     }
   }
   initializeFlatVector<StringView>(
-      vector, pool, VARCHAR(), size, hasNulls, std::move(buffers));
+      vector, pool, type, size, hasNulls, std::move(buffers));
 }
 
 } // namespace detail
@@ -103,19 +104,19 @@ void initializeVectorImpl(
 template <>
 void initializeVectorImpl<TypeKind::VARCHAR>(
     VectorPtr& vector,
-    const TypePtr& /* type */,
+    const TypePtr& type,
     memory::MemoryPool& pool,
     const std::vector<const BaseVector*>& vectors) {
-  detail::initializeStringVector(vector, pool, vectors);
+  detail::initializeStringVector(vector, type, pool, vectors);
 }
 
 template <>
 void initializeVectorImpl<TypeKind::VARBINARY>(
     VectorPtr& vector,
-    const TypePtr& /* type */,
+    const TypePtr& type,
     memory::MemoryPool& pool,
     const std::vector<const BaseVector*>& vectors) {
-  detail::initializeStringVector(vector, pool, vectors);
+  detail::initializeStringVector(vector, type, pool, vectors);
 }
 
 namespace {

--- a/velox/dwio/common/FlatMapHelper.h
+++ b/velox/dwio/common/FlatMapHelper.h
@@ -37,14 +37,6 @@ void resetIfNotWritable(VectorPtr& vector, const T&... buffer) {
   FOLLY_POP_WARNING
 }
 
-// Initialize string vector.
-void initializeStringVector(
-    VectorPtr& vector,
-    memory::MemoryPool& pool,
-    vector_size_t size,
-    bool hasNulls,
-    std::vector<BufferPtr>&& stringBuffers);
-
 } // namespace detail
 
 // Struct for keeping track flatmap key stream metrics.


### PR DESCRIPTION
Summary:
1. Copy map values in batch instead of row by row
2. Optimize CPU cache access pattern to avoid thrashing

Reviewed By: xiaoxmeng

Differential Revision: D54959863


