### PR TITLE
Fix NPE caused by testingRunArbitration

### DIFF
--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -478,5 +478,9 @@ void testingRunArbitration(
   static_cast<MemoryPoolImpl*>(pool)->testingManager()->shrinkPools(
       targetBytes, allowSpill);
   pool->leaveArbitration();
+
+  // This function is simulating an arbitration triggered by growCapacity, which
+  // would check this.
+  static_cast<MemoryPoolImpl*>(pool)->testingCheckIfAborted();
 }
 } // namespace facebook::velox::memory

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -687,6 +687,10 @@ class MemoryPoolImpl : public MemoryPool {
     return allocator_;
   }
 
+  void testingCheckIfAborted() const {
+    checkIfAborted();
+  }
+
   uint64_t testingMinReservationBytes() const {
     return minReservationBytes_;
   }


### PR DESCRIPTION
Summary:
testingRunArbitration is called from within an operator to force a call to shrinkPools to simulate what would happen if 
arbitration was triggered by a call to growCapacity.

It does not check if the pool was aborted due to an error during arbitration which leads to all sorts of memory issues as the
Task will be terminated as part of aborting the pool causing operators to get destructed.

Adding a check to simulate what already happens in growCapacity.

Differential Revision: D55038530


