### PR TITLE
Disable sanitizer check in cpr build

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -19,6 +19,7 @@ on:
     paths:
       - ".github/workflows/scheduled.yml"
       - scripts/*
+      - CMake/*
 
   schedule:
     - cron: '0 3 * * *'

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           path: velox
           submodules: 'recursive'
-          ref: "${{ inputs.ref || 'main' }}"
+          ref: "${{ inputs.ref }}"
 
       - name: "Install dependencies"
         run: cd  velox && sudo ./scripts/setup-ubuntu.sh 
@@ -124,7 +124,7 @@ jobs:
       - name: "Checkout Repo"
         uses: actions/checkout@v3
         with:
-          ref: "${{ inputs.ref || 'main' }}"
+          ref: "${{ inputs.ref }}"
 
       - name: "Install dependencies"
         run: sudo ./scripts/setup-ubuntu.sh
@@ -172,7 +172,7 @@ jobs:
       - name: "Checkout Repo"
         uses: actions/checkout@v3
         with:
-          ref: "${{ inputs.ref || 'main' }}"
+          ref: "${{ inputs.ref }}"
 
       - name: "Install dependencies"
         run: sudo ./scripts/setup-ubuntu.sh
@@ -246,7 +246,7 @@ jobs:
       - name: "Checkout Repo"
         uses: actions/checkout@v3
         with:
-          ref: "${{ inputs.ref || 'main' }}"
+          ref: "${{ inputs.ref }}"
 
       - name: "Install dependencies"
         run: sudo ./scripts/setup-ubuntu.sh
@@ -287,7 +287,7 @@ jobs:
       - name: "Checkout Repo"
         uses: actions/checkout@v3
         with:
-          ref: "${{ inputs.ref || 'main' }}"
+          ref: "${{ inputs.ref }}"
 
       - name: "Install dependencies"
         run:  sudo ./scripts/setup-ubuntu.sh

--- a/CMake/resolve_dependency_modules/cpr.cmake
+++ b/CMake/resolve_dependency_modules/cpr.cmake
@@ -32,8 +32,9 @@ FetchContent_Declare(
   cpr
   URL ${VELOX_CPR_SOURCE_URL}
   URL_HASH ${VELOX_CPR_BUILD_SHA256_CHECKSUM}
-  PATCH_COMMAND git apply
-                ${CMAKE_CURRENT_LIST_DIR}/cpr/cpr-libcurl-compatible.patch)
+  PATCH_COMMAND
+    git apply ${CMAKE_CURRENT_LIST_DIR}/cpr/cpr-libcurl-compatible.patch && git
+    apply ${CMAKE_CURRENT_LIST_DIR}/cpr/cpr-remove-sancheck.patch)
 set(BUILD_SHARED_LIBS OFF)
 set(CPR_USE_SYSTEM_CURL OFF)
 # ZLIB has already been found by find_package(ZLIB, REQUIRED), set CURL_ZLIB=OFF

--- a/CMake/resolve_dependency_modules/cpr/cpr-libcurl-compatible.patch
+++ b/CMake/resolve_dependency_modules/cpr/cpr-libcurl-compatible.patch
@@ -39,3 +39,13 @@
      return (*progress)(dltotal, dlnow, ultotal, ulnow) ? 0 : cancel_retval;
  }
  int debugUserFunction(CURL* handle, curl_infotype type, char* data, size_t size, const DebugCallback* debug);
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -84,7 +84,6 @@ endif()
+ include(GNUInstallDirs)
+ include(FetchContent)
+ include(cmake/code_coverage.cmake)
+-include(cmake/sanitizer.cmake)
+ include(cmake/clear_variable.cmake)
+
+ # So CMake can find FindMbedTLS.cmake

--- a/CMake/resolve_dependency_modules/cpr/cpr-libcurl-compatible.patch
+++ b/CMake/resolve_dependency_modules/cpr/cpr-libcurl-compatible.patch
@@ -39,13 +39,3 @@
      return (*progress)(dltotal, dlnow, ultotal, ulnow) ? 0 : cancel_retval;
  }
  int debugUserFunction(CURL* handle, curl_infotype type, char* data, size_t size, const DebugCallback* debug);
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -84,7 +84,6 @@ endif()
- include(GNUInstallDirs)
- include(FetchContent)
- include(cmake/code_coverage.cmake)
--include(cmake/sanitizer.cmake)
- include(cmake/clear_variable.cmake)
-
- # So CMake can find FindMbedTLS.cmake

--- a/CMake/resolve_dependency_modules/cpr/cpr-remove-sancheck.patch
+++ b/CMake/resolve_dependency_modules/cpr/cpr-remove-sancheck.patch
@@ -1,0 +1,24 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This hangs on CI and is not needed #9116
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -84,7 +84,6 @@ endif()
+ include(GNUInstallDirs)
+ include(FetchContent)
+ include(cmake/code_coverage.cmake)
+-include(cmake/sanitizer.cmake)
+ include(cmake/clear_variable.cmake)
+
+ # So CMake can find FindMbedTLS.cmake


### PR DESCRIPTION
Closes #9116 

For some arcane reason I couldn't track down the sanitizer check hangs on `ubuntu-latest` and gcc. We are not running sanitizer builds there so we can just patch it out to fix the failing CI. 