### PR TITLE
Add per-test memory sanity check in OperatorTestBase

### DIFF
--- a/velox/common/memory/tests/MemoryCapExceededTest.cpp
+++ b/velox/common/memory/tests/MemoryCapExceededTest.cpp
@@ -37,6 +37,7 @@ class MemoryCapExceededTest : public OperatorTestBase,
   }
 
   void TearDown() override {
+    waitForAllTasksToBeDeleted();
     OperatorTestBase::TearDown();
     FLAGS_velox_suppress_memory_capacity_exceeding_error_message = false;
   }

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -258,6 +258,7 @@ class SharedArbitrationTest : public exec::test::HiveConnectorTestBase {
   }
 
   void TearDown() override {
+    vector_.reset();
     HiveConnectorTestBase::TearDown();
   }
 

--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -100,6 +100,7 @@ class DriverTest : public OperatorTestBase {
     // NOTE: destroy the tasks first to release all the allocated memory held
     // by the plan nodes (Values) in tasks.
     tasks_.clear();
+    waitForAllTasksToBeDeleted();
 
     if (wakeupInitialized_) {
       wakeupCancelled_ = true;
@@ -1480,4 +1481,6 @@ TEST_F(OpCallStatusTest, basic) {
 
   task->start(1, 1);
   ASSERT_TRUE(waitForTaskCompletion(task.get(), 600'000'000));
+  task.reset();
+  waitForAllTasksToBeDeleted();
 };

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -46,6 +46,17 @@ class MultiFragmentTest : public HiveConnectorTestBase {
     exec::ExchangeSource::registerFactory(createLocalExchangeSource);
   }
 
+  void TearDown() override {
+    waitForAllTasksToBeDeleted();
+
+    // There might be lingering exchange source on executor even after all tasks
+    // are deleted. This can cause memory leak because exchange source holds
+    // reference to memory pool. We need to make sure they are properly cleaned.
+    testingShutdownLocalExchangeSource();
+    vectors_.clear();
+    HiveConnectorTestBase::TearDown();
+  }
+
   static std::string makeTaskId(const std::string& prefix, int num) {
     return fmt::format("local://{}-{}", prefix, num);
   }

--- a/velox/exec/tests/OperatorUtilsTest.cpp
+++ b/velox/exec/tests/OperatorUtilsTest.cpp
@@ -23,10 +23,18 @@
 using namespace facebook::velox;
 using namespace facebook::velox::test;
 using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
 
-class OperatorUtilsTest
-    : public ::facebook::velox::exec::test::OperatorTestBase {
+class OperatorUtilsTest : public OperatorTestBase {
  protected:
+  void TearDown() override {
+    driverCtx_.reset();
+    driver_.reset();
+    task_.reset();
+    waitForAllTasksToBeDeleted();
+    OperatorTestBase::TearDown();
+  }
+
   OperatorUtilsTest() {
     VectorMaker vectorMaker{pool_.get()};
     std::vector<RowVectorPtr> values = {vectorMaker.rowVector(
@@ -124,8 +132,6 @@ class OperatorUtilsTest
     }
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{
-      memory::memoryManager()->addLeafPool()};
   std::shared_ptr<Task> task_;
   std::shared_ptr<Driver> driver_;
   std::unique_ptr<DriverCtx> driverCtx_;

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -42,6 +42,12 @@ class SortBufferTest : public OperatorTestBase {
     rng_.seed(123);
   }
 
+  void TearDown() override {
+    pool_.reset();
+    rootPool_.reset();
+    OperatorTestBase::TearDown();
+  }
+
   common::SpillConfig getSpillConfig(const std::string& spillDir) const {
     return common::SpillConfig(
         [&]() -> const std::string& { return spillDir; },
@@ -73,11 +79,6 @@ class SortBufferTest : public OperatorTestBase {
       {true, true, false, CompareFlags::NullHandlingMode::kNullAsValue},
       {true, true, false, CompareFlags::NullHandlingMode::kNullAsValue}};
 
-  const int64_t maxBytes_ = 20LL << 20; // 20 MB
-  const std::shared_ptr<memory::MemoryPool> rootPool_{
-      memory::memoryManager()->addRootPool("SortBufferTest", maxBytes_)};
-  const std::shared_ptr<memory::MemoryPool> pool_{
-      rootPool_->addLeafChild("SortBufferTest", maxBytes_)};
   const std::shared_ptr<folly::Executor> executor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
           std::thread::hardware_concurrency())};

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -248,6 +248,7 @@ class TableWriteTest : public HiveConnectorTestBase {
   }
 
   void TearDown() override {
+    waitForAllTasksToBeDeleted();
     HiveConnectorTestBase::TearDown();
   }
 

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -457,8 +457,14 @@ class TestBadMemoryTranslator : public exec::Operator::PlanNodeTranslator {
   }
 };
 } // namespace
+
 class TaskTest : public HiveConnectorTestBase {
  protected:
+  void TearDown() override {
+    waitForAllTasksToBeDeleted();
+    HiveConnectorTestBase::TearDown();
+  }
+
   static std::pair<std::shared_ptr<exec::Task>, std::vector<RowVectorPtr>>
   executeSingleThreaded(
       core::PlanFragment plan,

--- a/velox/exec/tests/ValuesTest.cpp
+++ b/velox/exec/tests/ValuesTest.cpp
@@ -25,6 +25,13 @@ namespace facebook::velox::exec::test {
 
 class ValuesTest : public OperatorTestBase {
  protected:
+  void TearDown() override {
+    waitForAllTasksToBeDeleted();
+    input_.reset();
+    input2_.reset();
+    OperatorTestBase::TearDown();
+  }
+
   // Sample row vectors.
   RowVectorPtr input_{makeRowVector({
       makeFlatVector<int32_t>({0, 1, 2, 3, 5}),

--- a/velox/exec/tests/utils/OperatorTestBase.h
+++ b/velox/exec/tests/utils/OperatorTestBase.h
@@ -33,12 +33,16 @@ namespace facebook::velox::exec::test {
 class OperatorTestBase : public testing::Test,
                          public velox::test::VectorTestBase {
  public:
-  /// The following two methods are used by google unit test framework to do
+  /// The following methods are used by google unit test framework to do
   /// one-time setup/teardown for all the unit tests from OperatorTestBase. We
   /// make them public as some benchmark like ReduceAgg also call these methods
   /// to setup/teardown benchmark test environment.
   static void SetUpTestCase();
   static void TearDownTestCase();
+
+  /// Sets up the velox memory system. A second call to this will clear the
+  /// previous memory system instances and create a new set.
+  static void resetMemory();
 
  protected:
   OperatorTestBase();

--- a/velox/functions/prestosql/aggregates/tests/ApproxPercentileTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxPercentileTest.cpp
@@ -379,6 +379,7 @@ TEST_F(ApproxPercentileTest, partialFull) {
       makeFlatVector<int32_t>(117, [](auto row) { return row < 7 ? 20 : 10; }),
   });
   exec::test::assertQuery(params, {expected});
+  waitForAllTasksToBeDeleted();
 }
 
 TEST_F(ApproxPercentileTest, finalAggregateAccuracy) {

--- a/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -144,6 +144,12 @@ class MinMaxByAggregationTestBase : public AggregationTestBase {
 
   void SetUp() override;
 
+  void TearDown() override {
+    dataVectorsByType_.clear();
+    rowVectors_.clear();
+    AggregationTestBase::TearDown();
+  }
+
   // Build a flat vector with numeric native type of T. The value in the
   // returned flat vector is in ascending order.
   template <typename T>


### PR DESCRIPTION
This per test sanity check allows test to reveal failures on test level instead of on the entire suite level. This will greatly reduce the time engineers spent in locating failed tests due to memory leak. 