### PR TITLE
Remove unused exception parameter from velox/exec/Driver.cpp

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -366,7 +366,7 @@ void Driver::enqueueInternal() {
     auto stopGuard = folly::makeGuard([&]() { opCallStatus_.stop(); });    \
     call;                                                                  \
     recordSilentThrows(*operatorPtr);                                      \
-  } catch (const VeloxException& e) {                                      \
+  } catch (const VeloxException&) {                                        \
     throw;                                                                 \
   } catch (const std::exception& e) {                                      \
     VELOX_FAIL(                                                            \

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -1108,7 +1108,7 @@ void HashBuild::reclaim(
       // this runs.
       try {
         spillTask->move();
-      } catch (const std::exception& e) {
+      } catch (const std::exception&) {
       }
     }
   });

--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -217,7 +217,7 @@ class Re2MatchConstantPattern final : public exec::VectorFunction {
     exec::LocalDecodedVector toSearch(context, *args[0], rows);
     try {
       checkForBadPattern(re_);
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
       context.setErrors(rows, std::current_exception());
       return;
     }
@@ -288,7 +288,7 @@ class Re2SearchAndExtractConstantPattern final : public exec::VectorFunction {
     // apply() will not be invoked if the selection is empty.
     try {
       checkForBadPattern(re_);
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
       context.setErrors(rows, std::current_exception());
       return;
     }
@@ -312,7 +312,7 @@ class Re2SearchAndExtractConstantPattern final : public exec::VectorFunction {
     if (const auto groupId = getIfConstant<T>(*args[2])) {
       try {
         checkForBadGroupId(*groupId, re_);
-      } catch (const std::exception& e) {
+      } catch (const std::exception&) {
         context.setErrors(rows, std::current_exception());
         return;
       }
@@ -834,7 +834,7 @@ class LikeWithRe2 final : public exec::VectorFunction {
     // apply() will not be invoked if the selection is empty.
     try {
       checkForBadPattern(*re_);
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
       context.setErrors(rows, std::current_exception());
       return;
     }
@@ -1067,7 +1067,7 @@ class Re2ExtractAllConstantPattern final : public exec::VectorFunction {
     VELOX_CHECK(args.size() == 2 || args.size() == 3);
     try {
       checkForBadPattern(re_);
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
       context.setErrors(rows, std::current_exception());
       return;
     }
@@ -1092,7 +1092,7 @@ class Re2ExtractAllConstantPattern final : public exec::VectorFunction {
       //
       try {
         checkForBadGroupId(*_groupId, re_);
-      } catch (const std::exception& e) {
+      } catch (const std::exception&) {
         context.setErrors(rows, std::current_exception());
         return;
       }


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Differential Revision: D54835982


