### PR TITLE
Fix allocation calls where requested size is covered by the collateral

### DIFF
--- a/velox/common/memory/MallocAllocator.cpp
+++ b/velox/common/memory/MallocAllocator.cpp
@@ -47,65 +47,36 @@ MallocAllocator::~MallocAllocator() {
 }
 
 bool MallocAllocator::allocateNonContiguousWithoutRetry(
-    MachinePageCount numPages,
-    Allocation& out,
-    ReservationCallback reservationCB,
-    MachinePageCount minSizeClass) {
-  const uint64_t freedBytes = freeNonContiguous(out);
-  if (numPages == 0) {
-    if (freedBytes != 0 && reservationCB != nullptr) {
-      reservationCB(freedBytes, false);
-    }
+    const SizeMix& sizeMix,
+    Allocation& out) {
+  freeNonContiguous(out);
+  if (sizeMix.totalPages == 0) {
     return true;
   }
-  const SizeMix mix = allocationSize(numPages, minSizeClass);
-  const auto totalBytes = AllocationTraits::pageBytes(mix.totalPages);
+  const auto totalBytes = AllocationTraits::pageBytes(sizeMix.totalPages);
   if (testingHasInjectedFailure(InjectedFailure::kCap) ||
       !incrementUsage(totalBytes)) {
-    if (freedBytes != 0 && reservationCB != nullptr) {
-      reservationCB(freedBytes, false);
-    }
     const auto errorMsg = fmt::format(
-        "Exceeded memory allocator limit when allocating {} new pages for "
-        "total allocation of {} pages, the memory allocator capacity is {}",
-        mix.totalPages,
-        numPages,
+        "Exceeded memory allocator limit when allocating {} new pages"
+        ", the memory allocator capacity is {}",
+        sizeMix.totalPages,
         succinctBytes(capacity_));
     VELOX_MEM_LOG_EVERY_MS(WARNING, 1000) << errorMsg;
     setAllocatorFailureMessage(errorMsg);
     return false;
   }
 
-  uint64_t bytesToAllocate = 0;
-  if (reservationCB != nullptr) {
-    bytesToAllocate = AllocationTraits::pageBytes(mix.totalPages) - freedBytes;
-    try {
-      reservationCB(bytesToAllocate, true);
-    } catch (std::exception&) {
-      VELOX_MEM_LOG(WARNING)
-          << "Failed to reserve " << succinctBytes(bytesToAllocate)
-          << " for non-contiguous allocation of " << numPages
-          << " pages, then release " << succinctBytes(freedBytes)
-          << " from the old allocation";
-      // If the new memory reservation fails, we need to release the memory
-      // reservation of the freed memory of previously allocation.
-      reservationCB(freedBytes, false);
-      decrementUsage(totalBytes);
-      std::rethrow_exception(std::current_exception());
-    }
-  }
-
   std::vector<void*> buffers;
-  buffers.reserve(mix.numSizes);
-  for (int32_t i = 0; i < mix.numSizes; ++i) {
+  buffers.reserve(sizeMix.numSizes);
+  for (int32_t i = 0; i < sizeMix.numSizes; ++i) {
     MachinePageCount numSizeClassPages =
-        mix.sizeCounts[i] * sizeClassSizes_[mix.sizeIndices[i]];
+        sizeMix.sizeCounts[i] * sizeClassSizes_[sizeMix.sizeIndices[i]];
     void* ptr = nullptr;
     // Trigger allocation failure by skipping malloc
     if (!testingHasInjectedFailure(InjectedFailure::kAllocate)) {
       stats_.recordAllocate(
-          AllocationTraits::pageBytes(sizeClassSizes_[mix.sizeIndices[i]]),
-          mix.sizeCounts[i],
+          AllocationTraits::pageBytes(sizeClassSizes_[sizeMix.sizeIndices[i]]),
+          sizeMix.sizeCounts[i],
           [&]() {
             ptr = ::malloc(
                 AllocationTraits::pageBytes(numSizeClassPages)); // NOLINT
@@ -117,7 +88,7 @@ bool MallocAllocator::allocateNonContiguousWithoutRetry(
           "Malloc failed to allocate {} of memory while allocating for "
           "non-contiguous allocation of {} pages",
           succinctBytes(AllocationTraits::pageBytes(numSizeClassPages)),
-          numPages);
+          sizeMix.totalPages);
       VELOX_MEM_LOG(WARNING) << errorMsg;
       setAllocatorFailureMessage(errorMsg);
       break;
@@ -126,27 +97,22 @@ bool MallocAllocator::allocateNonContiguousWithoutRetry(
     out.append(reinterpret_cast<uint8_t*>(ptr), numSizeClassPages); // NOLINT
   }
 
-  if (buffers.size() != mix.numSizes) {
+  if (buffers.size() != sizeMix.numSizes) {
     // Failed to allocate memory using malloc. Free any malloced pages and
     // return false.
     for (auto* buffer : buffers) {
       ::free(buffer);
     }
     out.clear();
-    if (reservationCB != nullptr) {
-      VELOX_MEM_LOG(WARNING)
-          << "Failed to allocate memory for non-contiguous allocation of "
-          << numPages << " pages, then release "
-          << succinctBytes(bytesToAllocate + freedBytes)
-          << " of memory reservation including the old allocation";
-      reservationCB(bytesToAllocate + freedBytes, false);
-    }
+    VELOX_MEM_LOG(WARNING)
+        << "Failed to allocate memory for non-contiguous allocation of "
+        << sizeMix.totalPages << " pages";
     decrementUsage(totalBytes);
     return false;
   }
 
   // Successfully allocated all pages.
-  numAllocated_.fetch_add(mix.totalPages);
+  numAllocated_.fetch_add(sizeMix.totalPages);
   return true;
 }
 
@@ -154,12 +120,10 @@ bool MallocAllocator::allocateContiguousWithoutRetry(
     MachinePageCount numPages,
     Allocation* collateral,
     ContiguousAllocation& allocation,
-    ReservationCallback reservationCB,
     MachinePageCount maxPages) {
   bool result;
   stats_.recordAllocate(AllocationTraits::pageBytes(numPages), 1, [&]() {
-    result = allocateContiguousImpl(
-        numPages, collateral, allocation, reservationCB, maxPages);
+    result = allocateContiguousImpl(numPages, collateral, allocation, maxPages);
   });
   return result;
 }
@@ -168,7 +132,6 @@ bool MallocAllocator::allocateContiguousImpl(
     MachinePageCount numPages,
     Allocation* collateral,
     ContiguousAllocation& allocation,
-    ReservationCallback reservationCB,
     MachinePageCount maxPages) {
   if (maxPages == 0) {
     maxPages = numPages;
@@ -192,23 +155,13 @@ bool MallocAllocator::allocateContiguousImpl(
     decrementUsage(AllocationTraits::pageBytes(numContiguousCollateralPages));
     allocation.clear();
   }
-  const auto totalCollateralPages =
-      numCollateralPages + numContiguousCollateralPages;
-  const auto totalCollateralBytes =
-      AllocationTraits::pageBytes(totalCollateralPages);
   if (numPages == 0) {
-    if (totalCollateralBytes != 0 && reservationCB != nullptr) {
-      reservationCB(totalCollateralBytes, false);
-    }
     return true;
   }
 
   const auto totalBytes = AllocationTraits::pageBytes(numPages);
   if (testingHasInjectedFailure(InjectedFailure::kCap) ||
       !incrementUsage(totalBytes)) {
-    if (totalCollateralBytes != 0 && reservationCB != nullptr) {
-      reservationCB(totalCollateralBytes, false);
-    }
     const auto errorMsg = fmt::format(
         "Exceeded memory allocator limit when allocating {} new pages, the "
         "memory allocator capacity is {}",
@@ -217,23 +170,6 @@ bool MallocAllocator::allocateContiguousImpl(
     setAllocatorFailureMessage(errorMsg);
     VELOX_MEM_LOG_EVERY_MS(WARNING, 1000) << errorMsg;
     return false;
-  }
-  const int64_t numNeededPages = numPages - totalCollateralPages;
-  if (reservationCB != nullptr) {
-    try {
-      reservationCB(AllocationTraits::pageBytes(numNeededPages), true);
-    } catch (std::exception&) {
-      // If the new memory reservation fails, we need to release the memory
-      // reservation of the freed contiguous and non-contiguous memory.
-      VELOX_MEM_LOG(WARNING)
-          << "Failed to reserve " << AllocationTraits::pageBytes(numNeededPages)
-          << " bytes for contiguous allocation of " << numPages
-          << " pages, then release " << succinctBytes(totalCollateralBytes)
-          << " from the old allocations";
-      reservationCB(totalCollateralBytes, false);
-      decrementUsage(totalBytes);
-      std::rethrow_exception(std::current_exception());
-    }
   }
   numAllocated_.fetch_add(numPages);
   numMapped_.fetch_add(numPages);
@@ -300,15 +236,7 @@ void MallocAllocator::freeContiguousImpl(ContiguousAllocation& allocation) {
 
 bool MallocAllocator::growContiguousWithoutRetry(
     MachinePageCount increment,
-    ContiguousAllocation& allocation,
-    ReservationCallback reservationCB) {
-  VELOX_CHECK_LE(
-      allocation.size() + increment * AllocationTraits::kPageSize,
-      allocation.maxSize());
-  if (reservationCB != nullptr) {
-    // May throw. If does, there is nothing to revert.
-    reservationCB(AllocationTraits::pageBytes(increment), true);
-  }
+    ContiguousAllocation& allocation) {
   if (!incrementUsage(AllocationTraits::pageBytes(increment))) {
     const auto errorMsg = fmt::format(
         "Exceeded memory allocator limit when allocating {} new pages for "
@@ -318,9 +246,6 @@ bool MallocAllocator::growContiguousWithoutRetry(
         succinctBytes(capacity_));
     setAllocatorFailureMessage(errorMsg);
     VELOX_MEM_LOG_EVERY_MS(WARNING, 1000) << errorMsg;
-    if (reservationCB != nullptr) {
-      reservationCB(AllocationTraits::pageBytes(increment), false);
-    }
     return false;
   }
   numAllocated_ += increment;

--- a/velox/common/memory/MallocAllocator.h
+++ b/velox/common/memory/MallocAllocator.h
@@ -55,8 +55,7 @@ class MallocAllocator : public MemoryAllocator {
 
   bool growContiguousWithoutRetry(
       MachinePageCount increment,
-      ContiguousAllocation& allocation,
-      ReservationCallback reservationCB = nullptr) override;
+      ContiguousAllocation& allocation) override;
 
   void freeBytes(void* p, uint64_t bytes) noexcept override;
 
@@ -84,23 +83,19 @@ class MallocAllocator : public MemoryAllocator {
 
  private:
   bool allocateNonContiguousWithoutRetry(
-      MachinePageCount numPages,
-      Allocation& out,
-      ReservationCallback reservationCB = nullptr,
-      MachinePageCount minSizeClass = 0) override;
+      const SizeMix& sizeMix,
+      Allocation& out) override;
 
   bool allocateContiguousWithoutRetry(
       MachinePageCount numPages,
       Allocation* collateral,
       ContiguousAllocation& allocation,
-      ReservationCallback reservationCB = nullptr,
       MachinePageCount maxPages = 0) override;
 
   bool allocateContiguousImpl(
       MachinePageCount numPages,
       Allocation* collateral,
       ContiguousAllocation& allocation,
-      ReservationCallback reservationCB,
       MachinePageCount maxPages);
 
   void freeContiguousImpl(ContiguousAllocation& allocation);

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -221,7 +221,7 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
   /// the same as 'this'.
   virtual void registerCache(const std::shared_ptr<Cache>& cache) = 0;
 
-  using ReservationCallback = std::function<void(int64_t, bool)>;
+  using ReservationCallback = std::function<void(uint64_t, bool)>;
 
   /// Returns the capacity of the allocator in bytes.
   virtual size_t capacity() const = 0;

--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -545,7 +545,7 @@ void MemoryPoolImpl::allocateNonContiguous(
   if (!allocator_->allocateNonContiguous(
           numPages,
           out,
-          [this](int64_t allocBytes, bool preAllocate) {
+          [this](uint64_t allocBytes, bool preAllocate) {
             if (preAllocate) {
               reserve(allocBytes);
             } else {
@@ -597,7 +597,7 @@ void MemoryPoolImpl::allocateContiguous(
           numPages,
           nullptr,
           out,
-          [this](int64_t allocBytes, bool preAlloc) {
+          [this](uint64_t allocBytes, bool preAlloc) {
             if (preAlloc) {
               reserve(allocBytes);
             } else {
@@ -632,7 +632,7 @@ void MemoryPoolImpl::growContiguous(
     MachinePageCount increment,
     ContiguousAllocation& allocation) {
   if (!allocator_->growContiguous(
-          increment, allocation, [this](int64_t allocBytes, bool preAlloc) {
+          increment, allocation, [this](uint64_t allocBytes, bool preAlloc) {
             if (preAlloc) {
               reserve(allocBytes);
             } else {

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -103,8 +103,7 @@ class MmapAllocator : public MemoryAllocator {
 
   bool growContiguousWithoutRetry(
       MachinePageCount increment,
-      ContiguousAllocation& allocation,
-      ReservationCallback reservationCB = nullptr) override;
+      ContiguousAllocation& allocation) override;
 
   void freeContiguous(ContiguousAllocation& allocation) override;
 
@@ -316,23 +315,19 @@ class MmapAllocator : public MemoryAllocator {
   };
 
   bool allocateNonContiguousWithoutRetry(
-      MachinePageCount numPages,
-      Allocation& out,
-      ReservationCallback reservationCB = nullptr,
-      MachinePageCount minSizeClass = 0) override;
+      const SizeMix& sizeMix,
+      Allocation& out) override;
 
   bool allocateContiguousWithoutRetry(
       MachinePageCount numPages,
       Allocation* collateral,
       ContiguousAllocation& allocation,
-      ReservationCallback reservationCB = nullptr,
       MachinePageCount maxPages = 0) override;
 
   bool allocateContiguousImpl(
       MachinePageCount numPages,
       Allocation* collateral,
       ContiguousAllocation& allocation,
-      ReservationCallback reservationCB,
       MachinePageCount maxPages);
 
   void freeContiguousImpl(ContiguousAllocation& allocation);


### PR DESCRIPTION
Summary:
Currently calls to allocation APIs in memory allocator, namely
allocateNonContiguous and allocateContiguous where the requested size
is covered by the provided collateral allocation is incorrectly
handeled. The issue arises when the variable tracking the number of
additional pages to be allocated becomes negative. This negative value
is then passed to the MemoryPool's reserve() call, where it is
implicitly converted into an unsigned integer. Instead of failing the
reservation due to an unusually large reservation request (as a result
of the negative int64 to uint64 conversion), the reservation remains
unchanged. This happens because when MemoryPoolImpl::reserve() uses
reservationSizeLocked(int64_t size) to check if more reservation is
needed, it returns 0. This is due to another implicit conversion from
uint64 back to int64, which is then used to calculate that no
increment to the reservation is necessary. Finally, the used and
cumulative metrics also get updated correctly because they are
signed integers and the compiler implicitly converts unit64 back to
int64. Therefore, it never manifests into an error state but the
code is fragile and can cause issues with future changes if the
implementation changes.

This change fixes this silent bug by ensuring this case is properly
handled and extra memory is released with the proper APIs.

Differential Revision: D55047654


