### PR TITLE
Add bitwise_xor and bitwise_not Spark functions

### DIFF
--- a/velox/docs/functions/spark/bitwise.rst
+++ b/velox/docs/functions/spark/bitwise.rst
@@ -6,11 +6,13 @@ Bitwise Functions
 
     Returns the bitwise AND of ``x`` and ``y`` in 2's complement representation. 
     Corresponds to Spark's operator ``&``.
+    Supported types are: TINYINT, SMALLINT, INTEGER and BIGINT.
 
 .. spark:function:: bitwise_or(x, y) -> [same as input]
 
     Returns the bitwise OR of ``x`` and ``y`` in 2's complement representation.
     Corresponds to Spark's operator ``|``.
+    Supported types are: TINYINT, SMALLINT, INTEGER and BIGINT.
 
 .. spark:function:: bitwise_xor(x, y) -> [same as input]
 

--- a/velox/docs/functions/spark/bitwise.rst
+++ b/velox/docs/functions/spark/bitwise.rst
@@ -10,7 +10,19 @@ Bitwise Functions
 .. spark:function:: bitwise_or(x, y) -> [same as input]
 
     Returns the bitwise OR of ``x`` and ``y`` in 2's complement representation.
+    Corresponds to Spark's operator ``|``.
+
+.. spark:function:: bitwise_xor(x, y) -> [same as input]
+
+    Returns the bitwise exclusive OR of ``x`` and ``y`` in 2's complement representation.
     Corresponds to Spark's operator ``^``.
+    Supported types are: TINYINT, SMALLINT, INTEGER and BIGINT.
+
+.. spark:function:: bitwise_not(x) -> [same as input]
+
+    Returns the bitwise NOT of ``x`` in 2's complement representation.
+    Corresponds to Spark's operator ``~``.
+    Supported types are: TINYINT, SMALLINT, INTEGER and BIGINT.
 
 .. spark:function:: bit_count(x) -> integer
 

--- a/velox/docs/functions/spark/bitwise.rst
+++ b/velox/docs/functions/spark/bitwise.rst
@@ -8,6 +8,12 @@ Bitwise Functions
     Corresponds to Spark's operator ``&``.
     Supported types are: TINYINT, SMALLINT, INTEGER and BIGINT.
 
+.. spark:function:: bitwise_not(x) -> [same as input]
+
+    Returns the bitwise NOT of ``x`` in 2's complement representation.
+    Corresponds to Spark's operator ``~``.
+    Supported types are: TINYINT, SMALLINT, INTEGER and BIGINT.
+
 .. spark:function:: bitwise_or(x, y) -> [same as input]
 
     Returns the bitwise OR of ``x`` and ``y`` in 2's complement representation.
@@ -18,12 +24,6 @@ Bitwise Functions
 
     Returns the bitwise exclusive OR of ``x`` and ``y`` in 2's complement representation.
     Corresponds to Spark's operator ``^``.
-    Supported types are: TINYINT, SMALLINT, INTEGER and BIGINT.
-
-.. spark:function:: bitwise_not(x) -> [same as input]
-
-    Returns the bitwise NOT of ``x`` in 2's complement representation.
-    Corresponds to Spark's operator ``~``.
     Supported types are: TINYINT, SMALLINT, INTEGER and BIGINT.
 
 .. spark:function:: bit_count(x) -> integer

--- a/velox/functions/sparksql/Bitwise.cpp
+++ b/velox/functions/sparksql/Bitwise.cpp
@@ -34,6 +34,22 @@ struct BitwiseOrFunction {
 };
 
 template <typename T>
+struct BitwiseXorFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE void call(TInput& result, TInput a, TInput b) {
+    result = a ^ b;
+  }
+};
+
+template <typename T>
+struct BitwiseNotFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE void call(TInput& result, TInput a) {
+    result = ~a;
+  }
+};
+
+template <typename T>
 struct ShiftLeftFunction {
   template <typename TInput1, typename TInput2>
   FOLLY_ALWAYS_INLINE void call(TInput1& result, TInput1 a, TInput2 b) {
@@ -111,6 +127,9 @@ struct BitGetFunction {
 void registerBitwiseFunctions(const std::string& prefix) {
   registerBinaryIntegral<BitwiseAndFunction>({prefix + "bitwise_and"});
   registerBinaryIntegral<BitwiseOrFunction>({prefix + "bitwise_or"});
+  registerBinaryIntegral<BitwiseXorFunction>({prefix + "bitwise_xor"});
+
+  registerUnaryIntegral<BitwiseNotFunction>({prefix + "bitwise_not"});
 
   registerFunction<BitCountFunction, int32_t, bool>({prefix + "bit_count"});
   registerFunction<BitCountFunction, int32_t, int8_t>({prefix + "bit_count"});

--- a/velox/functions/sparksql/tests/BitwiseTest.cpp
+++ b/velox/functions/sparksql/tests/BitwiseTest.cpp
@@ -46,6 +46,16 @@ class BitwiseTest : public SparkFunctionBaseTest {
   }
 
   template <typename T>
+  std::optional<T> bitwiseXor(std::optional<T> a, std::optional<T> b) {
+    return evaluateOnce<T>("bitwise_xor(c0, c1)", a, b);
+  }
+
+  template <typename T>
+  std::optional<T> bitwiseNot(std::optional<T> a) {
+    return evaluateOnce<T>("bitwise_not(c0)", a);
+  }
+
+  template <typename T>
   std::optional<int32_t> bitCount(std::optional<T> a) {
     return evaluateOnce<int32_t>("bit_count(c0)", a);
   }
@@ -146,6 +156,68 @@ TEST_F(BitwiseTest, bitwiseOr) {
   EXPECT_EQ(bitwiseOr<int64_t>(kMax64, -1), -1);
   EXPECT_EQ(bitwiseOr<int64_t>(kMin64, 1), kMin64 + 1);
   EXPECT_EQ(bitwiseOr<int64_t>(kMin64, -1), -1);
+}
+
+TEST_F(BitwiseTest, bitwiseXor) {
+  EXPECT_EQ(bitwiseXor<int32_t>(0, -1), -1);
+  EXPECT_EQ(bitwiseXor<int32_t>(3, 8), 11);
+  EXPECT_EQ(bitwiseXor<int32_t>(-4, 12), -16);
+  EXPECT_EQ(bitwiseXor<int32_t>(60, 21), 41);
+
+  EXPECT_EQ(bitwiseXor<int8_t>(kMin8, kMax8), -1);
+  EXPECT_EQ(bitwiseXor<int8_t>(kMax8, kMax8), 0);
+  EXPECT_EQ(bitwiseXor<int8_t>(kMax8, kMin8), -1);
+  EXPECT_EQ(bitwiseXor<int8_t>(kMin8, kMin8), 0);
+  EXPECT_EQ(bitwiseXor<int8_t>(kMax8, 1), kMax8 - 1);
+  EXPECT_EQ(bitwiseXor<int8_t>(kMax8, -1), kMin8);
+  EXPECT_EQ(bitwiseXor<int8_t>(kMin8, 1), kMin8 + 1);
+  EXPECT_EQ(bitwiseXor<int8_t>(kMin8, -1), kMax8);
+
+  EXPECT_EQ(bitwiseXor<int16_t>(kMin16, kMax16), -1);
+  EXPECT_EQ(bitwiseXor<int16_t>(kMax16, kMax16), 0);
+  EXPECT_EQ(bitwiseXor<int16_t>(kMax16, kMin16), -1);
+  EXPECT_EQ(bitwiseXor<int16_t>(kMin16, kMin16), 0);
+  EXPECT_EQ(bitwiseXor<int16_t>(kMax16, 1), kMax16 - 1);
+  EXPECT_EQ(bitwiseXor<int16_t>(kMax16, -1), kMin16);
+  EXPECT_EQ(bitwiseXor<int16_t>(kMin16, 1), kMin16 + 1);
+  EXPECT_EQ(bitwiseXor<int16_t>(kMin16, -1), kMax16);
+
+  EXPECT_EQ(bitwiseXor<int32_t>(kMin32, kMax32), -1);
+  EXPECT_EQ(bitwiseXor<int32_t>(kMax32, kMax32), 0);
+  EXPECT_EQ(bitwiseXor<int32_t>(kMax32, kMin32), -1);
+  EXPECT_EQ(bitwiseXor<int32_t>(kMin32, kMin32), 0);
+  EXPECT_EQ(bitwiseXor<int32_t>(kMax32, 1), kMax32 - 1);
+  EXPECT_EQ(bitwiseXor<int32_t>(kMax32, -1), kMin32);
+  EXPECT_EQ(bitwiseXor<int32_t>(kMin32, 1), kMin32 + 1);
+  EXPECT_EQ(bitwiseXor<int32_t>(kMin32, -1), kMax32);
+
+  EXPECT_EQ(bitwiseXor<int64_t>(kMin64, kMax64), -1);
+  EXPECT_EQ(bitwiseXor<int64_t>(kMax64, kMax64), 0);
+  EXPECT_EQ(bitwiseXor<int64_t>(kMax64, kMin64), -1);
+  EXPECT_EQ(bitwiseXor<int64_t>(kMin64, kMin64), 0);
+  EXPECT_EQ(bitwiseXor<int64_t>(kMax64, 1), kMax64 - 1);
+  EXPECT_EQ(bitwiseXor<int64_t>(kMax64, -1), kMin64);
+  EXPECT_EQ(bitwiseXor<int64_t>(kMin64, 1), kMin64 + 1);
+  EXPECT_EQ(bitwiseXor<int64_t>(kMin64, -1), kMax64);
+}
+
+TEST_F(BitwiseTest, bitwiseNot) {
+  EXPECT_EQ(bitwiseNot<int32_t>(0), -1);
+  EXPECT_EQ(bitwiseNot<int32_t>(3), -4);
+  EXPECT_EQ(bitwiseNot<int32_t>(-4), 3);
+  EXPECT_EQ(bitwiseNot<int32_t>(60), -61);
+
+  EXPECT_EQ(bitwiseNot<int8_t>(kMin8), kMax8);
+  EXPECT_EQ(bitwiseNot<int8_t>(kMax8), kMin8);
+
+  EXPECT_EQ(bitwiseNot<int16_t>(kMin16), kMax16);
+  EXPECT_EQ(bitwiseNot<int16_t>(kMax16), kMin16);
+
+  EXPECT_EQ(bitwiseNot<int32_t>(kMin32), kMax32);
+  EXPECT_EQ(bitwiseNot<int32_t>(kMax32), kMin32);
+
+  EXPECT_EQ(bitwiseNot<int64_t>(kMin64), kMax64);
+  EXPECT_EQ(bitwiseNot<int64_t>(kMax64), kMin64);
 }
 
 TEST_F(BitwiseTest, bitCount) {

--- a/velox/functions/sparksql/tests/BitwiseTest.cpp
+++ b/velox/functions/sparksql/tests/BitwiseTest.cpp
@@ -41,6 +41,11 @@ class BitwiseTest : public SparkFunctionBaseTest {
   }
 
   template <typename T>
+  std::optional<T> bitwiseNot(std::optional<T> a) {
+    return evaluateOnce<T>("bitwise_not(c0)", a);
+  }
+
+  template <typename T>
   std::optional<T> bitwiseOr(std::optional<T> a, std::optional<T> b) {
     return evaluateOnce<T>("bitwise_or(c0, c1)", a, b);
   }
@@ -48,11 +53,6 @@ class BitwiseTest : public SparkFunctionBaseTest {
   template <typename T>
   std::optional<T> bitwiseXor(std::optional<T> a, std::optional<T> b) {
     return evaluateOnce<T>("bitwise_xor(c0, c1)", a, b);
-  }
-
-  template <typename T>
-  std::optional<T> bitwiseNot(std::optional<T> a) {
-    return evaluateOnce<T>("bitwise_not(c0)", a);
   }
 
   template <typename T>
@@ -123,6 +123,26 @@ TEST_F(BitwiseTest, bitwiseAnd) {
   EXPECT_EQ(bitwiseAnd<int64_t>(kMin64, 1), 0);
   EXPECT_EQ(bitwiseAnd<int64_t>(kMin64, -1), kMin64);
 }
+
+TEST_F(BitwiseTest, bitwiseNot) {
+  EXPECT_EQ(bitwiseNot<int32_t>(0), -1);
+  EXPECT_EQ(bitwiseNot<int32_t>(3), -4);
+  EXPECT_EQ(bitwiseNot<int32_t>(-4), 3);
+  EXPECT_EQ(bitwiseNot<int32_t>(60), -61);
+
+  EXPECT_EQ(bitwiseNot<int8_t>(kMin8), kMax8);
+  EXPECT_EQ(bitwiseNot<int8_t>(kMax8), kMin8);
+
+  EXPECT_EQ(bitwiseNot<int16_t>(kMin16), kMax16);
+  EXPECT_EQ(bitwiseNot<int16_t>(kMax16), kMin16);
+
+  EXPECT_EQ(bitwiseNot<int32_t>(kMin32), kMax32);
+  EXPECT_EQ(bitwiseNot<int32_t>(kMax32), kMin32);
+
+  EXPECT_EQ(bitwiseNot<int64_t>(kMin64), kMax64);
+  EXPECT_EQ(bitwiseNot<int64_t>(kMax64), kMin64);
+}
+
 
 TEST_F(BitwiseTest, bitwiseOr) {
   EXPECT_EQ(bitwiseOr<int32_t>(0, -1), -1);
@@ -199,25 +219,6 @@ TEST_F(BitwiseTest, bitwiseXor) {
   EXPECT_EQ(bitwiseXor<int64_t>(kMax64, -1), kMin64);
   EXPECT_EQ(bitwiseXor<int64_t>(kMin64, 1), kMin64 + 1);
   EXPECT_EQ(bitwiseXor<int64_t>(kMin64, -1), kMax64);
-}
-
-TEST_F(BitwiseTest, bitwiseNot) {
-  EXPECT_EQ(bitwiseNot<int32_t>(0), -1);
-  EXPECT_EQ(bitwiseNot<int32_t>(3), -4);
-  EXPECT_EQ(bitwiseNot<int32_t>(-4), 3);
-  EXPECT_EQ(bitwiseNot<int32_t>(60), -61);
-
-  EXPECT_EQ(bitwiseNot<int8_t>(kMin8), kMax8);
-  EXPECT_EQ(bitwiseNot<int8_t>(kMax8), kMin8);
-
-  EXPECT_EQ(bitwiseNot<int16_t>(kMin16), kMax16);
-  EXPECT_EQ(bitwiseNot<int16_t>(kMax16), kMin16);
-
-  EXPECT_EQ(bitwiseNot<int32_t>(kMin32), kMax32);
-  EXPECT_EQ(bitwiseNot<int32_t>(kMax32), kMin32);
-
-  EXPECT_EQ(bitwiseNot<int64_t>(kMin64), kMax64);
-  EXPECT_EQ(bitwiseNot<int64_t>(kMax64), kMin64);
 }
 
 TEST_F(BitwiseTest, bitCount) {

--- a/velox/functions/sparksql/tests/BitwiseTest.cpp
+++ b/velox/functions/sparksql/tests/BitwiseTest.cpp
@@ -143,7 +143,6 @@ TEST_F(BitwiseTest, bitwiseNot) {
   EXPECT_EQ(bitwiseNot<int64_t>(kMax64), kMin64);
 }
 
-
 TEST_F(BitwiseTest, bitwiseOr) {
   EXPECT_EQ(bitwiseOr<int32_t>(0, -1), -1);
   EXPECT_EQ(bitwiseOr<int32_t>(3, 8), 11);


### PR DESCRIPTION
Spark implementations: [`bitwise_xor` ](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitwiseExpressions.scala#L133) and [`bitwise_not`](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitwiseExpressions.scala#L178C19-L178C20).

These two functions have different return types comparing to their counterparts
in Presto.