### PR TITLE
Extend expression fuzzer test to support decimal

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,11 +206,11 @@ with a benchmark.
    ```
    # Test the new function in isolation. Use --only flag to restrict the set of functions
    # and run for 60 seconds or longer.
-   velox_expression_fuzzer_test --only <my-new-function-name> --duration_sec 60 --logtostderr=1 --enable_variadic_signatures --velox_fuzzer_enable_complex_types --lazy_vector_generation_ratio 0.2 --velox_fuzzer_enable_column_reuse --velox_fuzzer_enable_expression_reuse
+   velox_expression_fuzzer_test --only <my-new-function-name> --duration_sec 60 --logtostderr=1 --enable_variadic_signatures --velox_fuzzer_enable_complex_types --velox_fuzzer_enable_decimal_type --lazy_vector_generation_ratio 0.2 --velox_fuzzer_enable_column_reuse --velox_fuzzer_enable_expression_reuse
 
    # Test the new function in combination with other functions. Do not restrict the set
    # of functions and run for 10 minutes (600 seconds) or longer.
-   velox_expression_fuzzer_test --duration_sec 600 --logtostderr=1 --enable_variadic_signatures --velox_fuzzer_enable_complex_types --lazy_vector_generation_ratio 0.2 --velox_fuzzer_enable_column_reuse --velox_fuzzer_enable_expression_reuse
+   velox_expression_fuzzer_test --duration_sec 600 --logtostderr=1 --enable_variadic_signatures --velox_fuzzer_enable_complex_types --velox_fuzzer_enable_decimal_type --lazy_vector_generation_ratio 0.2 --velox_fuzzer_enable_column_reuse --velox_fuzzer_enable_expression_reuse
    ```
 
 Here are example PRs:

--- a/velox/docs/develop/testing/fuzzer.rst
+++ b/velox/docs/develop/testing/fuzzer.rst
@@ -228,6 +228,8 @@ Below are arguments that toggle certain fuzzer features in Expression Fuzzer:
 
 * ``--velox_fuzzer_enable_complex_types``: Enable testing of function signatures with complex argument or return types. Default is false.
 
+* ``--velox_fuzzer_enable_decimal_type``: Enable testing of function signatures with decimal argument or return type. Default is false.
+
 * ``--lazy_vector_generation_ratio``: Specifies the probability with which columns in the input row vector will be selected to be wrapped in lazy encoding (expressed as double from 0 to 1). Default is 0.0.
 
 * ``--velox_fuzzer_enable_column_reuse``: Enable generation of expressions where one input column can be used by multiple subexpressions. Default is false.

--- a/velox/expression/ReverseSignatureBinder.cpp
+++ b/velox/expression/ReverseSignatureBinder.cpp
@@ -18,27 +18,7 @@
 
 namespace facebook::velox::exec {
 
-bool ReverseSignatureBinder::hasConstrainedIntegerVariable(
-    const TypeSignature& type) const {
-  if (type.parameters().empty()) {
-    auto it = variables().find(type.baseName());
-    return it != variables().end() && it->second.isIntegerParameter() &&
-        it->second.constraint() != "";
-  }
-
-  const auto& parameters = type.parameters();
-  for (const auto& parameter : parameters) {
-    if (hasConstrainedIntegerVariable(parameter)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 bool ReverseSignatureBinder::tryBind() {
-  if (hasConstrainedIntegerVariable(signature_.returnType())) {
-    return false;
-  }
   tryBindSucceeded_ =
       SignatureBinderBase::tryBind(signature_.returnType(), returnType_);
   return tryBindSucceeded_;

--- a/velox/expression/ReverseSignatureBinder.h
+++ b/velox/expression/ReverseSignatureBinder.h
@@ -54,10 +54,6 @@ class ReverseSignatureBinder : private SignatureBinderBase {
   }
 
  private:
-  // Return whether there is a constraint on an integer variable in type
-  // signature.
-  bool hasConstrainedIntegerVariable(const TypeSignature& type) const;
-
   const TypePtr returnType_;
 
   // True if 'tryBind' has been called and succeeded. False otherwise.

--- a/velox/expression/fuzzer/ArgumentTypeFuzzer.h
+++ b/velox/expression/fuzzer/ArgumentTypeFuzzer.h
@@ -82,6 +82,22 @@ class ArgumentTypeFuzzer {
   /// Generates an orderable random type, including structs, and arrays.
   TypePtr randOrderableType();
 
+  // Bind 'name' variable, if not already bound, using 'constant' constraint
+  // ('name'='123'). Return bound value if 'name' is already bound or was
+  // successfully bound to a constant value. Return std::nullopt otherwise.
+  std::optional<int> tryFixedBinding(const std::string& name);
+
+  // Bind the precision and scale variables in a decimal type signature to
+  // constant values. Return std::nullopt if the variable cannot be bound to a
+  // constant value.
+  std::pair<std::optional<int>, std::optional<int>> tryBindFixedPrecisionScale(
+      const exec::TypeSignature& type);
+
+  // Find all the nested decimal type signatures recursively.
+  void findDecimalTypes(
+      const exec::TypeSignature& type,
+      std::vector<exec::TypeSignature>& decimalTypes) const;
+
   const exec::FunctionSignature& signature_;
 
   TypePtr returnType_;

--- a/velox/expression/fuzzer/ExpressionFuzzer.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzer.cpp
@@ -440,16 +440,20 @@ bool useTypeName(
 
 bool isSupportedSignature(
     const exec::FunctionSignature& signature,
-    bool enableComplexType) {
-  // Not supporting lambda functions, or functions using decimal and
-  // timestamp with time zone types.
+    bool enableComplexType,
+    bool enableDecimalType) {
+  // When enableComplexType is disabled, not supporting complex functions.
+  const bool useComplexType = useTypeName(signature, "array") ||
+      useTypeName(signature, "map") || useTypeName(signature, "row");
+  // When enableDecimalType is disabled, not supporting decimal functions. Not
+  // supporting functions using custom types, timestamp with time zone types and
+  // interval day to second types.
   return !(
       useTypeName(signature, "opaque") ||
-      useTypeName(signature, "long_decimal") ||
-      useTypeName(signature, "short_decimal") ||
-      useTypeName(signature, "decimal") ||
       useTypeName(signature, "timestamp with time zone") ||
       useTypeName(signature, "interval day to second") ||
+      (!enableDecimalType && useTypeName(signature, "decimal")) ||
+      (!enableComplexType && useComplexType) ||
       (enableComplexType && useTypeName(signature, "unknown")));
 }
 
@@ -531,10 +535,13 @@ ExpressionFuzzer::ExpressionFuzzer(
     FunctionSignatureMap signatureMap,
     size_t initialSeed,
     const std::shared_ptr<VectorFuzzer>& vectorFuzzer,
-    const std::optional<ExpressionFuzzer::Options>& options)
+    const std::optional<ExpressionFuzzer::Options>& options,
+    const std::unordered_map<std::string, std::shared_ptr<ArgGenerator>>&
+        argGenerators)
     : options_(options.value_or(Options())),
       vectorFuzzer_(vectorFuzzer),
-      state{rng_, std::max(1, options_.maxLevelOfNesting)} {
+      state{rng_, std::max(1, options_.maxLevelOfNesting)},
+      argGenerators_(argGenerators) {
   VELOX_CHECK(vectorFuzzer, "Vector fuzzer must be provided");
   seed(initialSeed);
 
@@ -558,10 +565,14 @@ ExpressionFuzzer::ExpressionFuzzer(
     for (const auto& signature : function.second) {
       ++totalFunctionSignatures;
 
-      if (!isSupportedSignature(*signature, options_.enableComplexTypes)) {
+      if (!isSupportedSignature(
+              *signature,
+              options_.enableComplexTypes,
+              options_.enableDecimalType)) {
         continue;
       }
-      if (!(signature->variables().empty() || options_.enableComplexTypes)) {
+      if (!(signature->variables().empty() || options_.enableComplexTypes ||
+            options_.enableDecimalType)) {
         LOG(WARNING) << "Skipping unsupported signature: " << function.first
                      << signature->toString();
         continue;
@@ -669,8 +680,10 @@ ExpressionFuzzer::ExpressionFuzzer(
   sortSignatureTemplates(signatureTemplates_);
 
   for (const auto& it : signatureTemplates_) {
-    auto& returnType = it.signature->returnType().baseName();
-    auto* returnTypeKey = &returnType;
+    const auto returnType =
+        exec::sanitizeName(it.signature->returnType().baseName());
+    const auto* returnTypeKey = &returnType;
+
     if (it.typeVariables.find(returnType) != it.typeVariables.end()) {
       // Return type is a template variable.
       returnTypeKey = &kTypeParameterName;
@@ -744,7 +757,7 @@ void ExpressionFuzzer::addToTypeToExpressionListByTicketTimes(
     const std::string& funcName) {
   int tickets = getTickets(funcName);
   for (int i = 0; i < tickets; i++) {
-    typeToExpressionList_[type].push_back(funcName);
+    typeToExpressionList_[exec::sanitizeName(type)].push_back(funcName);
   }
 }
 
@@ -1018,7 +1031,8 @@ core::TypedExprPtr ExpressionFuzzer::generateExpression(
     } else {
       expression = generateExpressionFromConcreteSignatures(
           returnType, chosenFunctionName);
-      if (!expression && options_.enableComplexTypes) {
+      if (!expression &&
+          (options_.enableComplexTypes || options_.enableDecimalType)) {
         expression = generateExpressionFromSignatureTemplate(
             returnType, chosenFunctionName);
       }
@@ -1213,8 +1227,26 @@ core::TypedExprPtr ExpressionFuzzer::generateExpressionFromSignatureTemplate(
 
   auto chosenSignature = *chosen->signature;
   ArgumentTypeFuzzer fuzzer{chosenSignature, returnType, rng_};
-  VELOX_CHECK_EQ(fuzzer.fuzzArgumentTypes(options_.maxNumVarArgs), true);
-  auto& argumentTypes = fuzzer.argumentTypes();
+
+  std::vector<TypePtr> argumentTypes;
+  if (fuzzer.fuzzArgumentTypes(options_.maxNumVarArgs)) {
+    // Use the argument fuzzer to generate argument types.
+    argumentTypes = fuzzer.argumentTypes();
+  } else {
+    auto it = argGenerators_.find(functionName);
+    // Since the argument type fuzzer cannot produce argument types, argument
+    // generators should be provided.
+    VELOX_CHECK(
+        it != argGenerators_.end(),
+        "Cannot generate argument types for {} with return type {}.",
+        functionName,
+        returnType->toString());
+    argumentTypes = it->second->generateArgs(chosenSignature, returnType, rng_);
+    if (argumentTypes.empty()) {
+      return nullptr;
+    }
+  }
+
   auto constantArguments = chosenSignature.constantArguments();
 
   // ArgumentFuzzer may generate duplicate arguments if the signature's

--- a/velox/expression/fuzzer/ExpressionFuzzer.h
+++ b/velox/expression/fuzzer/ExpressionFuzzer.h
@@ -19,6 +19,7 @@
 #include "velox/core/ITypedExpr.h"
 #include "velox/core/QueryCtx.h"
 #include "velox/expression/Expr.h"
+#include "velox/expression/fuzzer/ArgGenerator.h"
 #include "velox/expression/fuzzer/FuzzerToolkit.h"
 #include "velox/expression/tests/ExpressionVerifier.h"
 #include "velox/functions/FunctionRegistry.h"
@@ -47,6 +48,10 @@ class ExpressionFuzzer {
     // Enable testing of function signatures with complex argument or return
     // types.
     bool enableComplexTypes = false;
+
+    // Enable testing of function signatures with decimal argument or return
+    // types.
+    bool enableDecimalType = false;
 
     // Enable generation of expressions where one input column can be used by
     // multiple subexpressions.
@@ -103,7 +108,9 @@ class ExpressionFuzzer {
       FunctionSignatureMap signatureMap,
       size_t initialSeed,
       const std::shared_ptr<VectorFuzzer>& vectorFuzzer,
-      const std::optional<ExpressionFuzzer::Options>& options = std::nullopt);
+      const std::optional<ExpressionFuzzer::Options>& options = std::nullopt,
+      const std::unordered_map<std::string, std::shared_ptr<ArgGenerator>>&
+          argGenerators = {});
 
   template <typename TFunc>
   void registerFuncOverride(TFunc func, const std::string& name);
@@ -416,6 +423,9 @@ class ExpressionFuzzer {
 
   } state;
   friend class ExpressionFuzzerUnitTest;
+
+  // Maps from function name to a specific generator of argument types.
+  std::unordered_map<std::string, std::shared_ptr<ArgGenerator>> argGenerators_;
 };
 
 } // namespace facebook::velox::fuzzer

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -18,7 +18,14 @@
 #include <gtest/gtest.h>
 #include <unordered_set>
 
+#include "velox/expression/fuzzer/ArgGenerator.h"
 #include "velox/expression/fuzzer/FuzzerRunner.h"
+#include "velox/functions/prestosql/fuzzer/DivideArgGenerator.h"
+#include "velox/functions/prestosql/fuzzer/FloorAndRoundArgGenerator.h"
+#include "velox/functions/prestosql/fuzzer/ModulusArgGenerator.h"
+#include "velox/functions/prestosql/fuzzer/MultiplyArgGenerator.h"
+#include "velox/functions/prestosql/fuzzer/PlusMinusArgGenerator.h"
+#include "velox/functions/prestosql/fuzzer/TruncateArgGenerator.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 
 DEFINE_int64(
@@ -27,6 +34,8 @@ DEFINE_int64(
     "Initial seed for random number generator used to reproduce previous "
     "results (0 means start with random seed).");
 
+using namespace facebook::velox::exec::test;
+using facebook::velox::fuzzer::ArgGenerator;
 using facebook::velox::fuzzer::FuzzerRunner;
 
 int main(int argc, char** argv) {
@@ -69,5 +78,16 @@ int main(int argc, char** argv) {
       "regexp_split",
   };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
-  return FuzzerRunner::run(initialSeed, skipFunctions, {{}});
+
+  std::unordered_map<std::string, std::shared_ptr<ArgGenerator>> argGenerators =
+      {{"plus", std::make_shared<PlusMinusArgGenerator>()},
+       {"minus", std::make_shared<PlusMinusArgGenerator>()},
+       {"multiply", std::make_shared<MultiplyArgGenerator>()},
+       {"divide", std::make_shared<DivideArgGenerator>()},
+       {"floor", std::make_shared<FloorAndRoundArgGenerator>()},
+       {"round", std::make_shared<FloorAndRoundArgGenerator>()},
+       {"mod", std::make_shared<ModulusArgGenerator>()},
+       {"truncate", std::make_shared<TruncateArgGenerator>()}};
+
+  return FuzzerRunner::run(initialSeed, skipFunctions, {{}}, argGenerators);
 }

--- a/velox/expression/fuzzer/ExpressionFuzzerVerifier.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerVerifier.cpp
@@ -80,7 +80,9 @@ RowVectorPtr wrapChildren(
 ExpressionFuzzerVerifier::ExpressionFuzzerVerifier(
     const FunctionSignatureMap& signatureMap,
     size_t initialSeed,
-    const ExpressionFuzzerVerifier::Options& options)
+    const ExpressionFuzzerVerifier::Options& options,
+    const std::unordered_map<std::string, std::shared_ptr<ArgGenerator>>&
+        argGenerators)
     : options_(options),
       queryCtx_(core::QueryCtx::create(
           nullptr,
@@ -98,7 +100,8 @@ ExpressionFuzzerVerifier::ExpressionFuzzerVerifier(
           signatureMap,
           initialSeed,
           vectorFuzzer_,
-          options.expressionFuzzerOptions) {
+          options.expressionFuzzerOptions,
+          argGenerators) {
   seed(initialSeed);
 
   // Init stats and register listener.

--- a/velox/expression/fuzzer/ExpressionFuzzerVerifier.h
+++ b/velox/expression/fuzzer/ExpressionFuzzerVerifier.h
@@ -51,7 +51,9 @@ class ExpressionFuzzerVerifier {
   ExpressionFuzzerVerifier(
       const FunctionSignatureMap& signatureMap,
       size_t initialSeed,
-      const Options& options);
+      const Options& options,
+      const std::unordered_map<std::string, std::shared_ptr<ArgGenerator>>&
+          argGenerators);
 
   // This function starts the test that is performed by the
   // ExpressionFuzzerVerifier which is generating random expressions and

--- a/velox/expression/fuzzer/FuzzerRunner.cpp
+++ b/velox/expression/fuzzer/FuzzerRunner.cpp
@@ -122,6 +122,11 @@ DEFINE_bool(
     "Enable testing of function signatures with complex argument or return types.");
 
 DEFINE_bool(
+    velox_fuzzer_enable_decimal_type,
+    false,
+    "Enable testing of function signatures with decimal argument or return types.");
+
+DEFINE_bool(
     velox_fuzzer_enable_column_reuse,
     false,
     "Enable generation of expressions where one input column can be "
@@ -168,6 +173,7 @@ ExpressionFuzzer::Options getExpressionFuzzerOptions(
   opts.enableVariadicSignatures = FLAGS_enable_variadic_signatures;
   opts.enableDereference = FLAGS_enable_dereference;
   opts.enableComplexTypes = FLAGS_velox_fuzzer_enable_complex_types;
+  opts.enableDecimalType = FLAGS_velox_fuzzer_enable_decimal_type;
   opts.enableColumnReuse = FLAGS_velox_fuzzer_enable_column_reuse;
   opts.enableExpressionReuse = FLAGS_velox_fuzzer_enable_expression_reuse;
   opts.functionTickets = FLAGS_assign_function_tickets;
@@ -204,8 +210,10 @@ ExpressionFuzzerVerifier::Options getExpressionFuzzerVerifierOptions(
 int FuzzerRunner::run(
     size_t seed,
     const std::unordered_set<std::string>& skipFunctions,
-    const std::unordered_map<std::string, std::string>& queryConfigs) {
-  runFromGtest(seed, skipFunctions, queryConfigs);
+    const std::unordered_map<std::string, std::string>& queryConfigs,
+    const std::unordered_map<std::string, std::shared_ptr<ArgGenerator>>&
+        argGenerators) {
+  runFromGtest(seed, skipFunctions, queryConfigs, argGenerators);
   return RUN_ALL_TESTS();
 }
 
@@ -213,13 +221,16 @@ int FuzzerRunner::run(
 void FuzzerRunner::runFromGtest(
     size_t seed,
     const std::unordered_set<std::string>& skipFunctions,
-    const std::unordered_map<std::string, std::string>& queryConfigs) {
+    const std::unordered_map<std::string, std::string>& queryConfigs,
+    const std::unordered_map<std::string, std::shared_ptr<ArgGenerator>>&
+        argGenerators) {
   memory::MemoryManager::testingSetInstance({});
   auto signatures = facebook::velox::getFunctionSignatures();
   ExpressionFuzzerVerifier(
       signatures,
       seed,
-      getExpressionFuzzerVerifierOptions(skipFunctions, queryConfigs))
+      getExpressionFuzzerVerifierOptions(skipFunctions, queryConfigs),
+      argGenerators)
       .go();
 }
 } // namespace facebook::velox::fuzzer

--- a/velox/expression/fuzzer/FuzzerRunner.h
+++ b/velox/expression/fuzzer/FuzzerRunner.h
@@ -33,12 +33,16 @@ class FuzzerRunner {
   static int run(
       size_t seed,
       const std::unordered_set<std::string>& skipFunctions,
-      const std::unordered_map<std::string, std::string>& queryConfigs);
+      const std::unordered_map<std::string, std::string>& queryConfigs,
+      const std::unordered_map<std::string, std::shared_ptr<ArgGenerator>>&
+          argGenerators);
 
   static void runFromGtest(
       size_t seed,
       const std::unordered_set<std::string>& skipFunctions,
-      const std::unordered_map<std::string, std::string>& queryConfigs);
+      const std::unordered_map<std::string, std::string>& queryConfigs,
+      const std::unordered_map<std::string, std::shared_ptr<ArgGenerator>>&
+          argGenerators);
 };
 
 } // namespace facebook::velox::fuzzer

--- a/velox/expression/fuzzer/SparkExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/SparkExpressionFuzzerTest.cpp
@@ -24,6 +24,14 @@
 
 #include "velox/expression/fuzzer/FuzzerRunner.h"
 #include "velox/functions/sparksql/Register.h"
+#include "velox/functions/sparksql/fuzzer/AddSubtractArgGenerator.h"
+#include "velox/functions/sparksql/fuzzer/DivideArgGenerator.h"
+#include "velox/functions/sparksql/fuzzer/MakeTimestampArgGenerator.h"
+#include "velox/functions/sparksql/fuzzer/MultiplyArgGenerator.h"
+#include "velox/functions/sparksql/fuzzer/UnscaledValueArgGenerator.h"
+
+using namespace facebook::velox::functions::sparksql::fuzzer;
+using facebook::velox::fuzzer::ArgGenerator;
 
 DEFINE_int64(
     seed,
@@ -58,7 +66,18 @@ int main(int argc, char** argv) {
 
   // Required by spark_partition_id function.
   std::unordered_map<std::string, std::string> queryConfigs = {
-      {facebook::velox::core::QueryConfig::kSparkPartitionId, "123"}};
+      {facebook::velox::core::QueryConfig::kSparkPartitionId, "123"},
+      {facebook::velox::core::QueryConfig::kSessionTimezone,
+       "America/Los_Angeles"}};
 
-  return FuzzerRunner::run(FLAGS_seed, skipFunctions, queryConfigs);
+  std::unordered_map<std::string, std::shared_ptr<ArgGenerator>> argGenerators =
+      {{"add", std::make_shared<AddSubtractArgGenerator>()},
+       {"subtract", std::make_shared<AddSubtractArgGenerator>()},
+       {"multiply", std::make_shared<MultiplyArgGenerator>()},
+       {"divide", std::make_shared<DivideArgGenerator>()},
+       {"unscaled_value", std::make_shared<UnscaledValueArgGenerator>()},
+       {"make_timestamp", std::make_shared<MakeTimestampArgGenerator>()}};
+
+  return FuzzerRunner::run(
+      FLAGS_seed, skipFunctions, queryConfigs, argGenerators);
 }

--- a/velox/expression/fuzzer/tests/ArgumentTypeFuzzerTest.cpp
+++ b/velox/expression/fuzzer/tests/ArgumentTypeFuzzerTest.cpp
@@ -239,6 +239,21 @@ TEST_F(ArgumentTypeFuzzerTest, unsupported) {
           .argumentType("decimal(b_precision, b_scale)")
           .build();
 
+  testFuzzingFailure(signature, ROW({ARRAY(DECIMAL(13, 6))}));
+
+  // Constraints on the argument types are not supported.
+  signature = exec::FunctionSignatureBuilder()
+                  .integerVariable("a_scale")
+                  .integerVariable("b_scale")
+                  .integerVariable("a_precision", "a_scale + 1")
+                  .integerVariable("b_precision")
+                  .integerVariable("r_precision")
+                  .integerVariable("r_scale")
+                  .returnType("decimal(r_precision, r_scale)")
+                  .argumentType("decimal(a_precision, a_scale)")
+                  .argumentType("decimal(b_precision, b_scale)")
+                  .build();
+
   testFuzzingFailure(signature, DECIMAL(13, 6));
 }
 
@@ -557,6 +572,29 @@ TEST_F(ArgumentTypeFuzzerTest, fuzzDecimalArgumentTypes) {
   EXPECT_TRUE(argTypes[1]->isDecimal());
   EXPECT_EQ(argTypes[0]->toString(), argTypes[2]->toString());
   EXPECT_EQ(argTypes[1]->toString(), argTypes[3]->toString());
+
+  // Decimal argument types are nested in complex types.
+  signature = exec::FunctionSignatureBuilder()
+                  .integerVariable("a_scale")
+                  .integerVariable("b_scale")
+                  .integerVariable("a_precision")
+                  .integerVariable("b_precision")
+                  .integerVariable("r_precision")
+                  .integerVariable("r_scale")
+                  .returnType("decimal(r_precision, r_scale)")
+                  .argumentType("row(array(decimal(a_precision, a_scale)))")
+                  .argumentType("row(array(decimal(b_precision, b_scale)))")
+                  .build();
+  argTypes = fuzzArgumentTypes(*signature, DECIMAL(10, 7));
+  ASSERT_EQ(2, argTypes.size());
+  EXPECT_TRUE(argTypes[0]->isRow());
+  EXPECT_TRUE(argTypes[0]->asRow().childAt(0)->isArray());
+  EXPECT_TRUE(
+      argTypes[0]->asRow().childAt(0)->asArray().elementType()->isDecimal());
+  EXPECT_TRUE(argTypes[1]->isRow());
+  EXPECT_TRUE(argTypes[1]->asRow().childAt(0)->isArray());
+  EXPECT_TRUE(
+      argTypes[1]->asRow().childAt(0)->asArray().elementType()->isDecimal());
 }
 
 TEST_F(ArgumentTypeFuzzerTest, fuzzDecimalReturnType) {
@@ -647,6 +685,27 @@ TEST_F(ArgumentTypeFuzzerTest, fuzzDecimalReturnType) {
 
   returnType = fuzzReturnType(*signature);
   EXPECT_EQ(DECIMAL(10, 7)->toString(), returnType->toString());
+
+  // Decimal return type is nested in complex types.
+  signature =
+      exec::FunctionSignatureBuilder()
+          .integerVariable("a_scale")
+          .integerVariable("b_scale")
+          .integerVariable("a_precision")
+          .integerVariable("b_precision")
+          .returnType(
+              "row(array(decimal(a_precision, a_scale)), array(decimal(b_precision, b_scale)))")
+          .argumentType("decimal(a_precision, a_scale)")
+          .argumentType("decimal(b_precision, b_scale)")
+          .build();
+  returnType = fuzzReturnType(*signature);
+  EXPECT_TRUE(returnType->isRow());
+  EXPECT_TRUE(returnType->asRow().childAt(0)->isArray());
+  EXPECT_TRUE(returnType->asRow().childAt(1)->isArray());
+  EXPECT_TRUE(
+      returnType->asRow().childAt(0)->asArray().elementType()->isDecimal());
+  EXPECT_TRUE(
+      returnType->asRow().childAt(1)->asArray().elementType()->isDecimal());
 }
 
 } // namespace facebook::velox::fuzzer::test

--- a/velox/functions/sparksql/MakeTimestamp.cpp
+++ b/velox/functions/sparksql/MakeTimestamp.cpp
@@ -157,7 +157,8 @@ class MakeTimestampFunction : public exec::VectorFunction {
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
     return {
         exec::FunctionSignatureBuilder()
-            .integerVariable("precision")
+            // precision <= 18.
+            .integerVariable("precision", "min(precision, 18)")
             .returnType("timestamp")
             .argumentType("integer")
             .argumentType("integer")
@@ -167,7 +168,8 @@ class MakeTimestampFunction : public exec::VectorFunction {
             .argumentType("decimal(precision, 6)")
             .build(),
         exec::FunctionSignatureBuilder()
-            .integerVariable("precision")
+            // precision <= 18.
+            .integerVariable("precision", "min(precision, 18)")
             .returnType("timestamp")
             .argumentType("integer")
             .argumentType("integer")

--- a/velox/functions/sparksql/UnscaledValueFunction.cpp
+++ b/velox/functions/sparksql/UnscaledValueFunction.cpp
@@ -49,7 +49,8 @@ class UnscaledValueFunction final : public exec::VectorFunction {
 std::vector<std::shared_ptr<exec::FunctionSignature>>
 unscaledValueSignatures() {
   return {exec::FunctionSignatureBuilder()
-              .integerVariable("precision")
+              // precision <= 18.
+              .integerVariable("precision", "min(precision, 18)")
               .integerVariable("scale")
               .returnType("bigint")
               .argumentType("DECIMAL(precision, scale)")


### PR DESCRIPTION
ArgumentTypeFuzzer could be used to generate argument types when constructing a 
decimal expression in the fuzzer test. However, given a result type, it is 
unable to produce argument types that satisfy the necessary constraints. To 
address this limitation, argument type generators for Presto and Spark decimal 
functions have been added. In this PR, ExpressionFuzzer takes a map from 
function name to an instance of the argument generator. Custom generators 
provided by Presto and Spark are used in the expression fuzzer test to generate 
argument types. Experimental fuzzer tests with decimal type enabled will be 
added in a follow-up PR.

https://github.com/facebookincubator/velox/issues/1968