### PR TITLE
Support parquet thrift.convertedType.ENUM with BYTE_ARRAY as schemaElement.type

### DIFF
--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -529,10 +529,19 @@ TypePtr ReaderBase::convertType(
             VELOX_FAIL(
                 "UTF8 converted type can only be set for thrift::Type::(FIXED_LEN_)BYTE_ARRAY");
         }
+
+      case thrift::ConvertedType::ENUM:
+        switch (schemaElement.type) {
+          case thrift::Type::BYTE_ARRAY:
+            return VARCHAR();
+          default:
+            VELOX_FAIL(
+                "ENUM converted type can only be set for thrift::Type::BYTE_ARRAY");
+        }
+
       case thrift::ConvertedType::MAP:
       case thrift::ConvertedType::MAP_KEY_VALUE:
       case thrift::ConvertedType::LIST:
-      case thrift::ConvertedType::ENUM:
       case thrift::ConvertedType::TIME_MILLIS:
       case thrift::ConvertedType::TIME_MICROS:
       case thrift::ConvertedType::JSON:


### PR DESCRIPTION
Velox doesn't support `ENUM` as `thrift.convertedType`. But actually the physical type is `BYTE_ARRAY` and it can support. 

<img width="261" alt="image" src="https://github.com/facebookincubator/velox/assets/11849056/f9483559-2fa5-4cfb-8996-67a3e12774cb">
