### PR TITLE
Fix window fuzzer test

### DIFF
--- a/velox/exec/fuzzer/WindowFuzzer.cpp
+++ b/velox/exec/fuzzer/WindowFuzzer.cpp
@@ -68,7 +68,7 @@ void WindowFuzzer::addWindowFunctionSignatures(
   }
 }
 
-const std::string WindowFuzzer::generateFrameClause() {
+std::tuple<std::string, bool> WindowFuzzer::generateFrameClause() {
   auto frameType = [](int value) -> const std::string {
     switch (value) {
       case 0:
@@ -152,10 +152,12 @@ const std::string WindowFuzzer::generateFrameClause() {
   auto frameStart = frameBound(startBoundOptions[startBoundIndex]);
   auto frameEnd = frameBound(endBoundOptions[endBoundIndex]);
 
-  return frameTypeString + " BETWEEN " + frameStart + " AND " + frameEnd;
+  return std::make_tuple(
+      frameTypeString + " BETWEEN " + frameStart + " AND " + frameEnd,
+      isRowsFrame);
 }
 
-const std::string WindowFuzzer::generateOrderByClause(
+std::string WindowFuzzer::generateOrderByClause(
     const std::vector<SortingKeyAndOrder>& sortingKeysAndOrders) {
   std::stringstream frame;
   frame << " order by ";
@@ -215,7 +217,7 @@ void WindowFuzzer::go() {
     auto signatureWithStats = pickSignature();
     signatureWithStats.second.numRuns++;
 
-    auto signature = signatureWithStats.first;
+    const auto signature = signatureWithStats.first;
     stats_.functionNames.insert(signature.name);
 
     const bool customVerification =
@@ -230,9 +232,9 @@ void WindowFuzzer::go() {
     std::vector<TypePtr> argTypes = signature.args;
     std::vector<std::string> argNames = makeNames(argTypes.size());
 
-    bool ignoreNulls =
+    const bool ignoreNulls =
         supportIgnoreNulls(signature.name) && vectorFuzzer_.coinToss(0.5);
-    auto call =
+    const auto call =
         makeFunctionCall(signature.name, argNames, false, false, ignoreNulls);
 
     std::vector<SortingKeyAndOrder> sortingKeysAndOrders;
@@ -241,12 +243,13 @@ void WindowFuzzer::go() {
       sortingKeysAndOrders =
           generateSortingKeysAndOrders("s", argNames, argTypes);
     }
-    auto partitionKeys = generateSortingKeys("p", argNames, argTypes);
-    auto frameClause = generateFrameClause();
-    auto input = generateInputDataWithRowNumber(argNames, argTypes, signature);
-    // If the function is order-dependent, sort all input rows by row_number
-    // additionally.
-    if (requireSortedInput) {
+    const auto partitionKeys = generateSortingKeys("p", argNames, argTypes);
+    const auto [frameClause, isRowsFrame] = generateFrameClause();
+    const auto input =
+        generateInputDataWithRowNumber(argNames, argTypes, signature);
+    // If the function is order-dependent or uses "rows" frame, sort all input
+    // rows by row_number additionally.
+    if (requireSortedInput || isRowsFrame) {
       sortingKeysAndOrders.push_back(
           SortingKeyAndOrder("row_number", "asc", "nulls last"));
       ++stats_.numSortedInputs;

--- a/velox/exec/fuzzer/WindowFuzzer.h
+++ b/velox/exec/fuzzer/WindowFuzzer.h
@@ -95,9 +95,11 @@ class WindowFuzzer : public AggregationFuzzerBase {
 
   void addWindowFunctionSignatures(const WindowFunctionMap& signatureMap);
 
-  const std::string generateFrameClause();
+  // Return a randomly generated frame clause string together with a boolean
+  // flag indicating whether it is a ROWS frame.
+  std::tuple<std::string, bool> generateFrameClause();
 
-  const std::string generateOrderByClause(
+  std::string generateOrderByClause(
       const std::vector<SortingKeyAndOrder>& sortingKeysAndOrders);
 
   std::string getFrame(


### PR DESCRIPTION
Summary:
When the window frame uses the ROWS mode, frame start and frame end define the
specific number of rows before or after the current row. Therefore, input order affects the
result of window operations using the ROWS frame. This diff makes WindowFuzzer to
always provide fully ordered inputs without ties to such operations, so that the results
are deterministic and can be compared with the reference DB and across logically equivalent
plans.

Differential Revision: D55082651


