### PR TITLE
Add overwrite flag to simple function registration API

### DIFF
--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -1394,6 +1394,15 @@ TEST_F(SimpleFunctionTest, decimals) {
   // Verify overwrite behavior. Register a different function using the same
   // name and physical signature as decimal_plus_one. Expect the new function to
   // be used for (short) -> short signature.
+  // Not overwrite function registry.
+  registerFunction<
+      DecimalPlusTwoFunction,
+      ShortDecimal<P1, S1>,
+      ShortDecimal<P1, S1>>({"decimal_plus_one"}, {}, false);
+  result = evaluate("decimal_plus_one(c1)", data);
+  assertEqualVectors(expected, result);
+
+  // Overwrite function registry.
   registerFunction<
       DecimalPlusTwoFunction,
       ShortDecimal<P1, S1>,

--- a/velox/functions/Registerer.h
+++ b/velox/functions/Registerer.h
@@ -34,8 +34,17 @@ struct TempWrapper {
 template <template <class...> typename T, typename... TArgs>
 using ParameterBinder = TempWrapper<T<exec::VectorExec, TArgs...>>;
 
+// Register a UDF with the given aliases. If an alias already
+// exists and 'overwrite' is true, the existing entry in the function
+// registry is overwritten by the current UDF. If an alias already exists and
+// 'overwrite' is false, the current UDF is not registered with this alias.
+// This method returns true if all 'aliases' are registered successfully. It
+// returns false if any alias in 'aliases' already exists in the registry and
+// is not overwritten.
 template <typename Func, typename TReturn, typename... TArgs>
-void registerFunction(const std::vector<std::string>& aliases = {}) {
+bool registerFunction(
+    const std::vector<std::string>& aliases = {},
+    bool overwrite = true) {
   using funcClass = typename Func::template udf<exec::VectorExec>;
   using holderClass = core::UDFHolder<
       funcClass,
@@ -43,7 +52,7 @@ void registerFunction(const std::vector<std::string>& aliases = {}) {
       TReturn,
       ConstantChecker<TArgs...>,
       typename UnwrapConstantType<TArgs>::type...>;
-  exec::registerSimpleFunction<holderClass>(aliases, {});
+  return exec::registerSimpleFunction<holderClass>(aliases, {}, overwrite);
 }
 
 // New registration function; mostly a copy from the function above, but taking
@@ -51,9 +60,10 @@ void registerFunction(const std::vector<std::string>& aliases = {}) {
 // a while to maintain backwards compatibility, but the idea is to remove the
 // one above eventually.
 template <template <class> typename Func, typename TReturn, typename... TArgs>
-void registerFunction(
+bool registerFunction(
     const std::vector<std::string>& aliases = {},
-    const std::vector<exec::SignatureVariable>& constraints = {}) {
+    const std::vector<exec::SignatureVariable>& constraints = {},
+    bool overwrite = true) {
   using funcClass = Func<exec::VectorExec>;
   using holderClass = core::UDFHolder<
       funcClass,
@@ -61,7 +71,8 @@ void registerFunction(
       TReturn,
       ConstantChecker<TArgs...>,
       typename UnwrapConstantType<TArgs>::type...>;
-  exec::registerSimpleFunction<holderClass>(aliases, constraints);
+  return exec::registerSimpleFunction<holderClass>(
+      aliases, constraints, overwrite);
 }
 
 } // namespace facebook::velox

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h
@@ -20,9 +20,10 @@
 namespace facebook::velox::aggregate::prestosql {
 
 /// Entery point to register aggregate functions.
-/// \param prefix : Prefix for the aggregate functions.
-/// \param withCompanionFunctions : Also register companion functions, defaults
-/// to true. \param onlyPrestoSignatures  : Register only function signatures
+/// @param prefix Prefix for the aggregate functions.
+/// @param withCompanionFunctions Also register companion functions, defaults
+/// to true.
+/// @param onlyPrestoSignatures Register only function signatures
 /// that are compatible with Presto.
 void registerAllAggregateFunctions(
     const std::string& prefix = "",
@@ -31,7 +32,7 @@ void registerAllAggregateFunctions(
     bool overwrite = true);
 
 /// Register internal aggregation functions only for testing.
-/// \param prefix : Prefix for the aggregate functions.
+/// @param prefix Prefix for the aggregate functions.
 void registerInternalAggregateFunctions(const std::string& prefix);
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/tests/CMakeLists.txt
+++ b/velox/functions/tests/CMakeLists.txt
@@ -16,4 +16,4 @@ add_executable(velox_function_registry_test FunctionRegistryTest.cpp)
 add_test(NAME velox_function_registry_test COMMAND velox_function_registry_test)
 
 target_link_libraries(velox_function_registry_test velox_function_registry
-                      gmock gtest gtest_main)
+                      velox_functions_test_lib gmock gtest gtest_main)

--- a/velox/functions/tests/FunctionRegistryTest.cpp
+++ b/velox/functions/tests/FunctionRegistryTest.cpp
@@ -24,6 +24,7 @@
 #include "velox/functions/FunctionRegistry.h"
 #include "velox/functions/Macros.h"
 #include "velox/functions/Registerer.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/type/Type.h"
 
 namespace facebook::velox {
@@ -79,9 +80,18 @@ struct FuncFour {
 
 template <typename T>
 struct FuncFive {
-  FOLLY_ALWAYS_INLINE bool call(
-      int64_t& /* result */,
-      const int64_t& /* arg1 */) {
+  FOLLY_ALWAYS_INLINE bool call(int64_t& result, const int64_t& /* arg1 */) {
+    result = 5;
+    return true;
+  }
+};
+
+// FuncSix has the same signature as FuncFive. It's used to test overwrite
+// during registration.
+template <typename T>
+struct FuncSix {
+  FOLLY_ALWAYS_INLINE bool call(int64_t& result, const int64_t& /* arg1 */) {
+    result = 6;
     return true;
   }
 };
@@ -223,7 +233,7 @@ inline void registerTestFunctions() {
 }
 } // namespace
 
-class FunctionRegistryTest : public ::testing::Test {
+class FunctionRegistryTest : public testing::Test {
  public:
   FunctionRegistryTest() {
     registerTestFunctions();
@@ -588,4 +598,25 @@ TEST_F(FunctionRegistryTest, resolveWithMetadata) {
   result = resolveFunctionWithMetadata("non-existent-function", {VARCHAR()});
   EXPECT_FALSE(result.has_value());
 }
+
+class FunctionRegistryOverwriteTest : public functions::test::FunctionBaseTest {
+ public:
+  FunctionRegistryOverwriteTest() {
+    registerTestFunctions();
+  }
+};
+
+TEST_F(FunctionRegistryOverwriteTest, overwrite) {
+  ASSERT_TRUE((registerFunction<FuncFive, int64_t, int64_t>({"foo"})));
+  ASSERT_FALSE(
+      (registerFunction<FuncSix, int64_t, int64_t>({"foo"}, {}, false)));
+  ASSERT_TRUE((evaluateOnce<int64_t, int64_t>("foo(c0)", 0) == 5));
+  ASSERT_TRUE((registerFunction<FuncSix, int64_t, int64_t>({"foo"})));
+  ASSERT_TRUE((evaluateOnce<int64_t, int64_t>("foo(c0)", 0) == 6));
+
+  auto& simpleFunctions = exec::simpleFunctions();
+  auto signatures = simpleFunctions.getFunctionSignatures("foo");
+  ASSERT_EQ(signatures.size(), 1);
+}
+
 } // namespace facebook::velox


### PR DESCRIPTION
The `SimpleFunctionRegistry::registerFunction(aliases, constraints)` 
API used to always overwrite the function registry when the function 
name and signature already exists. This diff adds an overwrite flag to 
this API to control the behavior of overwriting. The overwrite flag is 
false by default. The 
`SimpleFunctionRegistry::registerFunction(aliases, constraints, overwrite)` 
API returns a bool that is true only when all aliases are successfully 
registered.

Differential Revision: D55041377


