### PR TITLE
Add s3 client no_proxy CIDR expression support

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
@@ -133,6 +133,8 @@ TEST(S3UtilTest, isIpExcludedFromProxy) {
 
   std::vector<std::pair<std::string, bool>> tests = {
       {"localhost,127.0.0.1,.foobar.com", true},
+      {"localhost,127.0.0.0/24,.foobar.com", true},
+      {"localhost,foobar.com,127.0.0.0/16,.1,.com", true},
       {"localhost,foobar.com,.1,.com", true},
       {"localhost,test.foobar.com", false},
       {"localhost,foobar.com,*.1,*.com", true},

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -447,13 +447,13 @@ Each query can override the config by setting corresponding query session proper
      -
      - integer
      - 8MB
-     - Usually Velox fetches the meta data firstly then fetch the rest of file. But if the file is very small, Velox can fetch the whole file directly to avoid multiple IO requests. 
-       The parameter controls the threshold when whole file is fetched. 
+     - Usually Velox fetches the meta data firstly then fetch the rest of file. But if the file is very small, Velox can fetch the whole file directly to avoid multiple IO requests.
+       The parameter controls the threshold when whole file is fetched.
    * - footer-estimated-size
      -
      - integer
      - 1MB
-     - Define the estimation of footer size in ORC and Parquet format. The footer data includes version, schema, and meta data for every columns which may or may not need to be fetched later. 
+     - Define the estimation of footer size in ORC and Parquet format. The footer data includes version, schema, and meta data for every columns which may or may not need to be fetched later.
        The parameter controls the size when footer is fetched each time. Bigger value can decrease the IO requests but may fetch more useless meta data.
    * - hive.orc.writer.stripe-max-size
      - orc_optimized_writer_max_stripe_size
@@ -520,6 +520,10 @@ Each query can override the config by setting corresponding query session proper
      - string
      - velox-session
      - Session name associated with the IAM role.
+   * - hive.s3.use-proxy-from-env
+     - bool
+     - false
+     - Utilize the configuration of the environment variables http_proxy, https_proxy, and no_proxy for use with the S3 API.
 
 ``Google Cloud Storage Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/velox/docs/develop/connectors.rst
+++ b/velox/docs/develop/connectors.rst
@@ -117,8 +117,7 @@ This is the behavior when the proxy settings are enabled:
    environment variables are read. If lower case and upper case variables are set
    lower case variables take precendence.
 2. The no_proxy/NO_PROXY content is scanned for exact and suffix matches.
-3. CIDR expressions provided in no_proxy/NO_PROXY are not supported for matching.
-4. IP addresses or domains can be specified.
-5. The no_proxy/NO_PROXY list is comma separated.
-6. Use . or \*. to indicate domain suffix matching, e.g. `.foobar.com` will
+3. IP addresses, domains, subdomains, or IP ranges (CIDR) can be specified in no_proxy/NO_PROXY.
+4. The no_proxy/NO_PROXY list is comma separated.
+5. Use . or \*. to indicate domain suffix matching, e.g. `.foobar.com` will
    match `test.foobar.com` or `foo.foobar.com`.


### PR DESCRIPTION
In the first iteration CIDR expressions were not supported for identifying IP ranges for which the proxy usage is not applicable.
This PR adds handling CIDR expressions when used in the no_proxy/NO_PROXY environment variable to identify if an IP address used for the S3 backend should be excluded from the proxy.