### PR TITLE
Replace fromKindToScalerType with createScalarType

### DIFF
--- a/pyvelox/pyvelox.cpp
+++ b/pyvelox/pyvelox.cpp
@@ -37,7 +37,7 @@ static VectorPtr variantToConstantVector(
     facebook::velox::memory::MemoryPool* pool) {
   using NativeType = typename TypeTraits<T>::NativeType;
 
-  TypePtr typePtr = fromKindToScalerType(T);
+  TypePtr typePtr = createScalarType(T);
   if (!variant.hasValue()) {
     return std::make_shared<ConstantVector<NativeType>>(
         pool,

--- a/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -624,8 +624,8 @@ TEST_P(
 
   auto rowType =
       ROW({"c0", "c1"},
-          {fromKindToScalerType(GetParam().valueType),
-           fromKindToScalerType(GetParam().comparisonType)});
+          {createScalarType(GetParam().valueType),
+           createScalarType(GetParam().comparisonType)});
 
   const bool isSmallInt = GetParam().comparisonType == TypeKind::TINYINT ||
       GetParam().comparisonType == TypeKind::SMALLINT;
@@ -648,7 +648,7 @@ TEST_P(
   for (int i = 0; i < kNumBatches; ++i) {
     // Generate a non-lazy vector so that it can be written out as a duckDB
     // table.
-    auto valueVector = fuzzer.fuzz(fromKindToScalerType(GetParam().valueType));
+    auto valueVector = fuzzer.fuzz(createScalarType(GetParam().valueType));
     auto comparisonVector = buildDataVector(
         GetParam().comparisonType,
         kBatchSize,
@@ -1060,8 +1060,8 @@ TEST_P(
 
   auto rowType =
       ROW({"c0", "c1", "c2"},
-          {fromKindToScalerType(GetParam().valueType),
-           fromKindToScalerType(GetParam().comparisonType),
+          {createScalarType(GetParam().valueType),
+           createScalarType(GetParam().comparisonType),
            INTEGER()});
 
   const bool isSmallInt = GetParam().comparisonType == TypeKind::TINYINT ||
@@ -1085,7 +1085,7 @@ TEST_P(
   for (int i = 0; i < kNumBatches; ++i) {
     // Generate a non-lazy vector so that it can be written out as a duckDB
     // table.
-    auto valueVector = fuzzer.fuzz(fromKindToScalerType(GetParam().valueType));
+    auto valueVector = fuzzer.fuzz(createScalarType(GetParam().valueType));
     auto groupByVector = makeFlatVector<int32_t>(kBatchSize);
     auto comparisonVector = buildDataVector(
         GetParam().comparisonType,

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -886,37 +886,6 @@ exec::CastOperatorPtr getCustomTypeCastOperator(const std::string& name) {
   return nullptr;
 }
 
-TypePtr fromKindToScalerType(TypeKind kind) {
-  switch (kind) {
-    case TypeKind::TINYINT:
-      return TINYINT();
-    case TypeKind::BOOLEAN:
-      return BOOLEAN();
-    case TypeKind::SMALLINT:
-      return SMALLINT();
-    case TypeKind::BIGINT:
-      return BIGINT();
-    case TypeKind::INTEGER:
-      return INTEGER();
-    case TypeKind::REAL:
-      return REAL();
-    case TypeKind::VARCHAR:
-      return VARCHAR();
-    case TypeKind::VARBINARY:
-      return VARBINARY();
-    case TypeKind::TIMESTAMP:
-      return TIMESTAMP();
-    case TypeKind::DOUBLE:
-      return DOUBLE();
-    case TypeKind::UNKNOWN:
-      return UNKNOWN();
-    default:
-      VELOX_UNSUPPORTED(
-          "Kind is not a scalar type: {}", mapTypeKindToName(kind));
-      return nullptr;
-  }
-}
-
 void toTypeSql(const TypePtr& type, std::ostream& out) {
   switch (type->kind()) {
     case TypeKind::ARRAY:

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -2412,9 +2412,6 @@ struct CastTypeChecker<Row<T...>> {
   }
 };
 
-/// Return the scalar type for a given 'kind'.
-TypePtr fromKindToScalerType(TypeKind kind);
-
 /// Appends type's SQL string to 'out'. Uses DuckDB SQL.
 void toTypeSql(const TypePtr& type, std::ostream& out);
 

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -799,36 +799,6 @@ TEST(TypeTest, isVariadicType) {
   EXPECT_FALSE((isVariadicType<Map<int8_t, Date>>::value));
 }
 
-TEST(TypeTest, fromKindToScalerType) {
-  for (const TypeKind& kind :
-       {TypeKind::BOOLEAN,
-        TypeKind::TINYINT,
-        TypeKind::SMALLINT,
-        TypeKind::INTEGER,
-        TypeKind::BIGINT,
-        TypeKind::REAL,
-        TypeKind::DOUBLE,
-        TypeKind::VARCHAR,
-        TypeKind::VARBINARY,
-        TypeKind::TIMESTAMP,
-        TypeKind::UNKNOWN}) {
-    SCOPED_TRACE(mapTypeKindToName(kind));
-    auto type = fromKindToScalerType(kind);
-    ASSERT_EQ(type->kind(), kind);
-  }
-
-  for (const TypeKind& kind :
-       {TypeKind::ARRAY,
-        TypeKind::MAP,
-        TypeKind::ROW,
-        TypeKind::OPAQUE,
-        TypeKind::FUNCTION,
-        TypeKind::INVALID}) {
-    SCOPED_TRACE(mapTypeKindToName(kind));
-    EXPECT_ANY_THROW(fromKindToScalerType(kind));
-  }
-}
-
 TEST(TypeTest, rowEquvialentCheckWithChildRowsWithDifferentNames) {
   std::vector<TypePtr> types;
   std::vector<TypePtr> typesWithDifferentNames;


### PR DESCRIPTION
Summary: fromKindToScalerType is a duplicate of createScalarType that's used in a few call sites. Remove it in favor of createScalarType.

Differential Revision: D55103079


