### PR TITLE
Fix the CMakeLists.txt to sort the cpp files in alphabetical order

### DIFF
--- a/velox/common/caching/CMakeLists.txt
+++ b/velox/common/caching/CMakeLists.txt
@@ -14,14 +14,14 @@
 
 add_library(
   velox_caching
+  AsyncDataCache.cpp
   CacheTTLController.cpp
   FileIds.cpp
-  StringIdMap.cpp
-  AsyncDataCache.cpp
   ScanTracker.cpp
   SsdCache.cpp
   SsdFile.cpp
-  SsdFileTracker.cpp)
+  SsdFileTracker.cpp
+  StringIdMap.cpp)
 target_link_libraries(
   velox_caching
   PUBLIC velox_common_base

--- a/velox/common/memory/tests/CMakeLists.txt
+++ b/velox/common/memory/tests/CMakeLists.txt
@@ -15,11 +15,11 @@ include(GoogleTest)
 
 add_executable(
   velox_memory_test
+  AllocationPoolTest.cpp
   AllocationTest.cpp
   ByteStreamTest.cpp
   CompactDoubleListTest.cpp
   HashStringAllocatorTest.cpp
-  AllocationPoolTest.cpp
   MemoryAllocatorTest.cpp
   MemoryArbitratorTest.cpp
   MemoryCapExceededTest.cpp

--- a/velox/common/process/CMakeLists.txt
+++ b/velox/common/process/CMakeLists.txt
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_process ProcessBase.cpp StackTrace.cpp ThreadDebugInfo.cpp
-                          Profiler.cpp TraceContext.cpp TraceHistory.cpp)
+add_library(velox_process ProcessBase.cpp Profiler.cpp StackTrace.cpp
+                          ThreadDebugInfo.cpp TraceContext.cpp TraceHistory.cpp)
 
 target_link_libraries(
   velox_process

--- a/velox/common/process/tests/CMakeLists.txt
+++ b/velox/common/process/tests/CMakeLists.txt
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(
-  velox_process_test TraceContextTest.cpp ThreadLocalRegistryTest.cpp
-                     TraceHistoryTest.cpp ProfilerTest.cpp)
+add_executable(velox_process_test ProfilerTest.cpp ThreadLocalRegistryTest.cpp
+                                  TraceContextTest.cpp TraceHistoryTest.cpp)
 
 add_test(velox_process_test velox_process_test)
 

--- a/velox/common/time/CMakeLists.txt
+++ b/velox/common/time/CMakeLists.txt
@@ -15,6 +15,6 @@ if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)
 endif()
 
-add_library(velox_time Timer.cpp CpuWallTimer.cpp)
+add_library(velox_time CpuWallTimer.cpp Timer.cpp)
 target_link_libraries(velox_time PUBLIC velox_process velox_test_util
                                         Folly::folly fmt::fmt)

--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -22,13 +22,13 @@ add_library(
   FileHandle.cpp
   HiveConfig.cpp
   HiveConnector.cpp
+  HiveConnectorUtil.cpp
   HiveDataSink.cpp
   HiveDataSource.cpp
   HivePartitionUtil.cpp
   PartitionIdGenerator.cpp
   SplitReader.cpp
-  TableHandle.cpp
-  HiveConnectorUtil.cpp)
+  TableHandle.cpp)
 
 target_link_libraries(
   velox_hive_connector

--- a/velox/connectors/hive/storage_adapters/abfs/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/abfs/CMakeLists.txt
@@ -17,8 +17,8 @@
 add_library(velox_abfs RegisterAbfsFileSystem.cpp)
 
 if(VELOX_ENABLE_ABFS)
-  target_sources(velox_abfs PRIVATE AbfsFileSystem.cpp AbfsWriteFile.cpp
-                                    AbfsUtils.cpp)
+  target_sources(velox_abfs PRIVATE AbfsFileSystem.cpp AbfsUtils.cpp
+                                    AbfsWriteFile.cpp)
   target_link_libraries(
     velox_abfs
     PUBLIC velox_file

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_s3file_test S3UtilTest.cpp S3FileSystemTest.cpp)
+add_executable(velox_s3file_test S3FileSystemTest.cpp S3UtilTest.cpp)
 add_test(velox_s3file_test velox_s3file_test)
 target_link_libraries(
   velox_s3file_test

--- a/velox/connectors/hive/tests/CMakeLists.txt
+++ b/velox/connectors/hive/tests/CMakeLists.txt
@@ -13,16 +13,16 @@
 # limitations under the License.
 add_executable(
   velox_hive_connector_test
-  HiveDataSinkTest.cpp
-  HivePartitionFunctionTest.cpp
   FileHandleTest.cpp
-  HivePartitionUtilTest.cpp
+  HiveConfigTest.cpp
+  HiveDataSinkTest.cpp
   HiveConnectorTest.cpp
   HiveConnectorUtilTest.cpp
   HiveConnectorSerDeTest.cpp
+  HivePartitionFunctionTest.cpp
+  HivePartitionUtilTest.cpp
   PartitionIdGeneratorTest.cpp
-  TableHandleTest.cpp
-  HiveConfigTest.cpp)
+  TableHandleTest.cpp)
 add_test(velox_hive_connector_test velox_hive_connector_test)
 
 target_link_libraries(

--- a/velox/dwio/common/tests/utils/CMakeLists.txt
+++ b/velox/dwio/common/tests/utils/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 add_library(velox_dwio_common_test_utils BatchMaker.cpp DataFiles.cpp
-                                         FilterGenerator.cpp DataSetBuilder.cpp)
+                                         DataSetBuilder.cpp FilterGenerator.cpp)
 
 target_link_libraries(
   velox_dwio_common_test_utils

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(
   AggregationMasks.cpp
   AggregateWindow.cpp
   ArrowStream.cpp
+  AssignUniqueId.cpp
   ContainerRowSerde.cpp
   DistinctAggregations.cpp
   Driver.cpp
@@ -53,12 +54,13 @@ add_library(
   NestedLoopJoinProbe.cpp
   Operator.cpp
   OperatorUtils.cpp
-  PrefixSort.cpp
   OrderBy.cpp
-  PartitionedOutput.cpp
   OutputBuffer.cpp
   OutputBufferManager.cpp
+  PartitionedOutput.cpp
+  PartitionFunction.cpp
   PlanNodeStats.cpp
+  PrefixSort.cpp
   ProbeOperatorState.cpp
   RowContainer.cpp
   RowNumber.cpp
@@ -83,9 +85,7 @@ add_library(
   Window.cpp
   WindowBuild.cpp
   WindowFunction.cpp
-  WindowPartition.cpp
-  AssignUniqueId.cpp
-  PartitionFunction.cpp)
+  WindowPartition.cpp)
 
 target_link_libraries(
   velox_exec

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -41,14 +41,15 @@ add_executable(
   ExpandTest.cpp
   FilterProjectTest.cpp
   FunctionResolutionTest.cpp
+  HashBitRangeTest.cpp
   HashJoinBridgeTest.cpp
   HashJoinTest.cpp
-  HashBitRangeTest.cpp
   HashPartitionFunctionTest.cpp
   HashTableTest.cpp
   LimitTest.cpp
   LocalPartitionTest.cpp
   Main.cpp
+  MarkDistinctTest.cpp
   MemoryReclaimerTest.cpp
   MergeJoinTest.cpp
   MergeTest.cpp
@@ -58,14 +59,15 @@ add_executable(
   OutputBufferManagerTest.cpp
   PlanNodeSerdeTest.cpp
   PlanNodeToStringTest.cpp
+  PrefixSortTest.cpp
   PrintPlanWithStatsTest.cpp
   ProbeOperatorStateTest.cpp
   RoundRobinPartitionFunctionTest.cpp
   RowContainerTest.cpp
   RowNumberTest.cpp
-  MarkDistinctTest.cpp
-  SpillTest.cpp
+  SortBufferTest.cpp
   SpillerTest.cpp
+  SpillTest.cpp
   SplitToStringTest.cpp
   SqlTest.cpp
   StreamingAggregationTest.cpp
@@ -73,16 +75,14 @@ add_executable(
   TableWriteTest.cpp
   TaskListenerTest.cpp
   ThreadDebugInfoTest.cpp
-  TopNTest.cpp
   TopNRowNumberTest.cpp
-  UnorderedStreamReaderTest.cpp
+  TopNTest.cpp
   UnnestTest.cpp
-  VectorHasherTest.cpp
+  UnorderedStreamReaderTest.cpp
   ValuesTest.cpp
+  VectorHasherTest.cpp
   WindowFunctionRegistryTest.cpp
-  WindowTest.cpp
-  SortBufferTest.cpp
-  PrefixSortTest.cpp)
+  WindowTest.cpp)
 
 add_executable(
   velox_exec_infra_test
@@ -93,10 +93,10 @@ add_executable(
   Main.cpp
   OperatorUtilsTest.cpp
   PlanBuilderTest.cpp
+  PrestoQueryRunnerTest.cpp
   QueryAssertionsTest.cpp
   TaskTest.cpp
-  TreeOfLosersTest.cpp
-  PrestoQueryRunnerTest.cpp)
+  TreeOfLosersTest.cpp)
 
 add_test(
   NAME velox_exec_test

--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -28,7 +28,6 @@ add_library(
   velox_expression
   BooleanMix.cpp
   CastExpr.cpp
-  PrestoCastHooks.cpp
   CoalesceExpr.cpp
   ConjunctExpr.cpp
   ConstantExpr.cpp
@@ -38,16 +37,17 @@ add_library(
   ExprToSubfieldFilter.cpp
   FieldReference.cpp
   FunctionCallToSpecialForm.cpp
+  GenericWriter.cpp
   LambdaExpr.cpp
-  VectorFunction.cpp
+  PeeledEncoding.cpp
+  PrestoCastHooks.cpp
   RegisterSpecialForm.cpp
   RowConstructor.cpp
   SimpleFunctionRegistry.cpp
   SpecialFormRegistry.cpp
   SwitchExpr.cpp
   TryExpr.cpp
-  GenericWriter.cpp
-  PeeledEncoding.cpp)
+  VectorFunction.cpp)
 
 target_link_libraries(
   velox_expression velox_core velox_vector velox_common_base

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -17,40 +17,40 @@ add_subdirectory(utils)
 add_executable(
   velox_expression_test
   ArgumentTypeFuzzerTest.cpp
-  CustomTypeTest.cpp
-  ExprEncodingsTest.cpp
-  ExprTest.cpp
-  ExprToSubfieldFilterTest.cpp
-  ExprCompilerTest.cpp
-  EvalCtxTest.cpp
-  ExprStatsTest.cpp
+  ArrayViewTest.cpp
+  ArrayWriterTest.cpp
   CastExprTest.cpp
   CoalesceTest.cpp
   ConjunctTest.cpp
   ConstantFlatVectorReaderTest.cpp
-  Main.cpp
-  MapWriterTest.cpp
-  ReverseSignatureBinderTest.cpp
-  RowWriterTest.cpp
+  CustomTypeTest.cpp
+  ExprCompilerTest.cpp
+  ExprEncodingsTest.cpp
+  ExprStatsTest.cpp
+  ExprTest.cpp
+  ExprToSubfieldFilterTest.cpp
+  EvalCtxTest.cpp
   EvalSimplifiedTest.cpp
   FunctionCallToSpecialFormTest.cpp
-  SignatureBinderTest.cpp
-  SimpleFunctionTest.cpp
-  SimpleFunctionInitTest.cpp
-  SimpleFunctionCallNullFreeTest.cpp
-  SimpleFunctionPresetNullsTest.cpp
-  ArrayViewTest.cpp
-  StringWriterTest.cpp
-  ArrayWriterTest.cpp
-  StringWriterTest.cpp
-  MapViewTest.cpp
-  RowViewTest.cpp
   GenericViewTest.cpp
+  GenericWriterTest.cpp
+  Main.cpp
+  MapViewTest.cpp
+  MapWriterTest.cpp
+  PeeledEncodingTest.cpp
+  ReverseSignatureBinderTest.cpp
+  RowViewTest.cpp
+  RowWriterTest.cpp
+  SignatureBinderTest.cpp
+  SimpleFunctionCallNullFreeTest.cpp
+  SimpleFunctionInitTest.cpp
+  SimpleFunctionPresetNullsTest.cpp
+  SimpleFunctionTest.cpp
+  StringWriterTest.cpp
+  StringWriterTest.cpp
   TryExprTest.cpp
   VariadicViewTest.cpp
-  VectorReaderTest.cpp
-  GenericWriterTest.cpp
-  PeeledEncodingTest.cpp)
+  VectorReaderTest.cpp)
 
 add_test(
   NAME velox_expression_test

--- a/velox/functions/lib/CMakeLists.txt
+++ b/velox/functions/lib/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(velox_functions_util velox_vector velox_common_base)
 add_library(
   velox_functions_lib
   CheckDuplicateKeys.cpp
+  CheckNestedNulls.cpp
   DateTimeFormatter.cpp
   DateTimeFormatterBuilder.cpp
   KllSketch.cpp
@@ -31,7 +32,6 @@ add_library(
   Repeat.cpp
   StringEncodingUtils.cpp
   SubscriptUtil.cpp
-  CheckNestedNulls.cpp
   TimeUtils.cpp)
 
 target_link_libraries(velox_functions_lib velox_functions_util velox_vector

--- a/velox/functions/lib/tests/CMakeLists.txt
+++ b/velox/functions/lib/tests/CMakeLists.txt
@@ -14,6 +14,7 @@
 add_executable(
   velox_functions_lib_test
   ApproxMostFrequentStreamSummaryTest.cpp
+  CheckNestedNullsTest.cpp
   DateTimeFormatterTest.cpp
   IsNullTest.cpp
   IsNotNullTest.cpp
@@ -21,8 +22,7 @@ add_executable(
   MapConcatTest.cpp
   Re2FunctionsTest.cpp
   RepeatTest.cpp
-  ZetaDistributionTest.cpp
-  CheckNestedNullsTest.cpp)
+  ZetaDistributionTest.cpp)
 
 add_test(
   NAME velox_functions_lib_test

--- a/velox/functions/lib/window/CMakeLists.txt
+++ b/velox/functions/lib/window/CMakeLists.txt
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_functions_window NthValue.cpp Rank.cpp RowNumber.cpp
-                                   Ntile.cpp)
+add_library(velox_functions_window NthValue.cpp Ntile.cpp Rank.cpp
+                                   RowNumber.cpp)
 
 target_link_libraries(velox_functions_window velox_buffer velox_exec
                       Folly::folly)

--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(
   BoolAggregates.cpp
   CentralMomentsAggregates.cpp
   Compare.cpp
+  CountAggregate.cpp
   CountIfAggregate.cpp
   CovarianceAggregates.cpp
   ChecksumAggregate.cpp
@@ -34,19 +35,18 @@ add_library(
   MapAggAggregate.cpp
   MapUnionAggregate.cpp
   MapUnionSumAggregate.cpp
+  MaxSizeForStatsAggregate.cpp
   MinMaxAggregates.cpp
   MinMaxByAggregates.cpp
   MultiMapAggAggregate.cpp
-  CountAggregate.cpp
   PrestoHasher.cpp
   ReduceAgg.cpp
+  RegisterAggregateFunctions.cpp
   SetAggregates.cpp
   SumAggregate.cpp
-  ValueList.cpp
-  VarianceAggregates.cpp
-  MaxSizeForStatsAggregate.cpp
   SumDataSizeForStatsAggregate.cpp
-  RegisterAggregateFunctions.cpp)
+  ValueList.cpp
+  VarianceAggregates.cpp)
 
 target_link_libraries(
   velox_aggregates

--- a/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -34,21 +34,21 @@ add_executable(
   HistogramTest.cpp
   Main.cpp
   MapAccumulatorTest.cpp
+  MapAggTest.cpp
+  MapUnionAggregationTest.cpp
+  MapUnionSumTest.cpp
+  MaxSizeForStatsTest.cpp
   MinMaxByAggregationTest.cpp
   MinMaxTest.cpp
   MultiMapAggTest.cpp
   PrestoHasherTest.cpp
+  ReduceAggTest.cpp
   SetAggTest.cpp
   SetUnionTest.cpp
+  SumDataSizeForStatsTest.cpp
   SumTest.cpp
-  MapAggTest.cpp
-  MapUnionAggregationTest.cpp
-  MapUnionSumTest.cpp
-  ReduceAggTest.cpp
   ValueListTest.cpp
-  VarianceAggregationTest.cpp
-  MaxSizeForStatsTest.cpp
-  SumDataSizeForStatsTest.cpp)
+  VarianceAggregationTest.cpp)
 
 add_test(
   NAME velox_aggregates_test

--- a/velox/functions/prestosql/registration/CMakeLists.txt
+++ b/velox/functions/prestosql/registration/CMakeLists.txt
@@ -15,8 +15,11 @@
 add_library(
   velox_functions_prestosql
   ArithmeticFunctionsRegistration.cpp
+  ArrayConcatRegistration.cpp
   ArrayFunctionsRegistration.cpp
+  ArrayNGramsRegistration.cpp
   BinaryFunctionsRegistration.cpp
+  BitwiseFunctionsRegistration.cpp
   CheckedArithmeticRegistration.cpp
   ComparisonFunctionsRegistration.cpp
   DateTimeFunctionsRegistration.cpp
@@ -24,12 +27,9 @@ add_library(
   HyperLogFunctionsRegistration.cpp
   JsonFunctionsRegistration.cpp
   MapFunctionsRegistration.cpp
-  StringFunctionsRegistration.cpp
-  BitwiseFunctionsRegistration.cpp
-  URLFunctionsRegistration.cpp
   RegistrationFunctions.cpp
-  ArrayConcatRegistration.cpp
-  ArrayNGramsRegistration.cpp)
+  StringFunctionsRegistration.cpp
+  URLFunctionsRegistration.cpp)
 
 # GCC 12 has a bug where it does not respect "pragma ignore" directives and ends
 # up failing compilation in an openssl header included by a hash-related

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -30,19 +30,19 @@ add_executable(
   ArrayFilterTest.cpp
   ArrayFrequencyTest.cpp
   ArrayFlattenTest.cpp
-  ArrayJoinTest.cpp
   ArrayHasDuplicatesTest.cpp
   ArrayIntersectTest.cpp
+  ArrayJoinTest.cpp
   ArrayMaxTest.cpp
   ArrayMinTest.cpp
   ArrayNGramsTest.cpp
   ArrayNoneMatchTest.cpp
   ArrayNormalizeTest.cpp
   ArrayPositionTest.cpp
-  ArrayRemoveTest.cpp
   ArrayRemoveNullsTest.cpp
-  ArraySortTest.cpp
+  ArrayRemoveTest.cpp
   ArrayShuffleTest.cpp
+  ArraySortTest.cpp
   ArraysOverlapTest.cpp
   ArraySumTest.cpp
   ArrayTrimTest.cpp
@@ -57,6 +57,7 @@ add_executable(
   ElementAtTest.cpp
   FindFirstTest.cpp
   FromUtf8Test.cpp
+  GreatestLeastTest.cpp
   HyperLogLogCastTest.cpp
   HyperLogLogFunctionsTest.cpp
   InPredicateTest.cpp
@@ -68,11 +69,11 @@ add_executable(
   MapFromEntriesTest.cpp
   MapNormalizeTest.cpp
   MapTopNTest.cpp
-  MultimapFromEntriesTest.cpp
   MapKeysAndValuesTest.cpp
   MapMatchTest.cpp
   MapTest.cpp
   MapZipWithTest.cpp
+  MultimapFromEntriesTest.cpp
   NotTest.cpp
   ProbabilityTest.cpp
   RandTest.cpp
@@ -81,22 +82,21 @@ add_executable(
   ReverseTest.cpp
   RoundTest.cpp
   ScalarFunctionRegTest.cpp
+  SequenceTest.cpp
   SimpleComparisonMatcherTest.cpp
   SliceTest.cpp
-  SequenceTest.cpp
   SplitTest.cpp
   SplitToMapTest.cpp
   StringFunctionsTest.cpp
   TimestampWithTimeZoneCastTest.cpp
-  TransformTest.cpp
   TransformKeysTest.cpp
+  TransformTest.cpp
   TransformValuesTest.cpp
   TrimFunctionsTest.cpp
   TypeOfTest.cpp
   URLFunctionsTest.cpp
   Utf8Test.cpp
   WidthBucketArrayTest.cpp
-  GreatestLeastTest.cpp
   ZipTest.cpp
   ZipWithTest.cpp)
 

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -25,12 +25,12 @@ add_executable(
   DecimalCompareTest.cpp
   DecimalRoundTest.cpp
   DecimalUtilTest.cpp
-  MakeDecimalTest.cpp
-  MakeTimestampTest.cpp
   ElementAtTest.cpp
   HashTest.cpp
   InTest.cpp
   LeastGreatestTest.cpp
+  MakeDecimalTest.cpp
+  MakeTimestampTest.cpp
   MapTest.cpp
   MightContainTest.cpp
   MonotonicallyIncreasingIdTest.cpp

--- a/velox/row/CMakeLists.txt
+++ b/velox/row/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_row_fast UnsafeRowFast.cpp CompactRow.cpp)
+add_library(velox_row_fast CompactRow.cpp UnsafeRowFast.cpp)
 
 target_link_libraries(velox_row_fast PUBLIC velox_vector)
 

--- a/velox/row/tests/CMakeLists.txt
+++ b/velox/row/tests/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_row_test UnsafeRowFuzzTest.cpp CompactRowTest.cpp)
+add_executable(velox_row_test CompactRowTest.cpp UnsafeRowFuzzTest.cpp)
 
 add_test(velox_row_test velox_row_test)
 

--- a/velox/serializers/CMakeLists.txt
+++ b/velox/serializers/CMakeLists.txt
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 add_library(
-  velox_presto_serializer PrestoSerializer.cpp UnsafeRowSerializer.cpp
-                          CompactRowSerializer.cpp)
+  velox_presto_serializer CompactRowSerializer.cpp PrestoSerializer.cpp
+                          UnsafeRowSerializer.cpp)
 
 target_link_libraries(velox_presto_serializer velox_vector velox_row_fast)
 

--- a/velox/serializers/tests/CMakeLists.txt
+++ b/velox/serializers/tests/CMakeLists.txt
@@ -13,8 +13,8 @@
 # limitations under the License.
 add_executable(
   velox_serializer_test
-  PrestoOutputStreamListenerTest.cpp PrestoSerializerTest.cpp
-  UnsafeRowSerializerTest.cpp CompactRowSerializerTest.cpp)
+  CompactRowSerializerTest.cpp PrestoOutputStreamListenerTest.cpp
+  PrestoSerializerTest.cpp UnsafeRowSerializerTest.cpp)
 
 add_test(velox_serializer_test velox_serializer_test)
 

--- a/velox/substrait/CMakeLists.txt
+++ b/velox/substrait/CMakeLists.txt
@@ -45,15 +45,15 @@ add_dependencies(substrait_proto protobuf::libprotobuf)
 
 set(SRCS
     ${PROTO_SRCS}
+    SubstraitExtensionCollector.cpp
     SubstraitParser.cpp
     SubstraitToVeloxExpr.cpp
     SubstraitToVeloxPlan.cpp
     TypeUtils.cpp
-    SubstraitExtensionCollector.cpp
+    VeloxSubstraitSignature.cpp
     VeloxToSubstraitExpr.cpp
     VeloxToSubstraitPlan.cpp
     VeloxToSubstraitType.cpp
-    VeloxSubstraitSignature.cpp
     VariantToVectorConverter.cpp)
 
 add_library(velox_substrait_plan_converter ${SRCS})

--- a/velox/substrait/tests/CMakeLists.txt
+++ b/velox/substrait/tests/CMakeLists.txt
@@ -14,14 +14,14 @@
 
 add_executable(
   velox_plan_conversion_test
-  Substrait2VeloxPlanConversionTest.cpp
-  Substrait2VeloxValuesNodeConversionTest.cpp
   FunctionTest.cpp
   JsonToProtoConverter.cpp
+  Substrait2VeloxPlanConversionTest.cpp
+  Substrait2VeloxValuesNodeConversionTest.cpp
+  SubstraitExtensionCollectorTest.cpp
   VeloxSubstraitRoundTripTest.cpp
   VeloxToSubstraitTypeTest.cpp
-  VeloxSubstraitSignatureTest.cpp
-  SubstraitExtensionCollectorTest.cpp)
+  VeloxSubstraitSignatureTest.cpp)
 
 add_dependencies(velox_plan_conversion_test velox_substrait_plan_converter)
 

--- a/velox/tpch/gen/CMakeLists.txt
+++ b/velox/tpch/gen/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 add_subdirectory(dbgen)
 
-add_library(velox_tpch_gen TpchGen.cpp DBGenIterator.cpp)
+add_library(velox_tpch_gen DBGenIterator.cpp TpchGen.cpp)
 
 target_include_directories(velox_tpch_gen PRIVATE dbgen/include)
 

--- a/velox/type/tests/CMakeLists.txt
+++ b/velox/type/tests/CMakeLists.txt
@@ -13,17 +13,17 @@
 # limitations under the License.
 add_executable(
   velox_type_test
-  StringViewTest.cpp
-  TypeTest.cpp
+  ConversionsTest.cpp
   DecimalTest.cpp
   FilterTest.cpp
   FilterSerDeTest.cpp
   HugeIntTest.cpp
+  StringViewTest.cpp
   SubfieldTest.cpp
   TimestampConversionTest.cpp
-  VariantTest.cpp
   TimestampTest.cpp
-  ConversionsTest.cpp)
+  TypeTest.cpp
+  VariantTest.cpp)
 
 add_test(velox_type_test velox_type_test)
 

--- a/velox/vector/CMakeLists.txt
+++ b/velox/vector/CMakeLists.txt
@@ -22,13 +22,13 @@ add_library(
   SelectivityVector.cpp
   SequenceVector.cpp
   SimpleVector.cpp
-  VectorSaver.cpp
+  VariantToVector.cpp
   VectorEncoding.cpp
+  VectorMap.cpp
   VectorPool.cpp
   VectorPrinter.cpp
-  VectorStream.cpp
-  VariantToVector.cpp
-  VectorMap.cpp)
+  VectorSaver.cpp
+  VectorStream.cpp)
 
 target_link_libraries(velox_vector velox_encode velox_memory velox_time
                       velox_type velox_buffer)

--- a/velox/vector/fuzzer/CMakeLists.txt
+++ b/velox/vector/fuzzer/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_vector_fuzzer VectorFuzzer.cpp GeneratorSpec.cpp Utils.cpp)
+add_library(velox_vector_fuzzer GeneratorSpec.cpp Utils.cpp VectorFuzzer.cpp)
 
 target_link_libraries(velox_vector_fuzzer velox_type velox_vector)
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -15,25 +15,25 @@ add_subdirectory(utils)
 
 add_executable(
   velox_vector_test
-  VectorCompareTest.cpp
-  VectorSaverTest.cpp
-  VectorMakerTest.cpp
-  VectorPoolTest.cpp
-  VectorPrinterTest.cpp
-  VectorTest.cpp
-  VectorStreamTest.cpp
-  VectorToStringTest.cpp
-  VectorEstimateFlatSizeTest.cpp
-  VectorPrepareForReuseTest.cpp
   DecodedVectorTest.cpp
-  SelectivityVectorTest.cpp
+  EncodingTest.cpp
   EnsureWritableVectorTest.cpp
   IsWritableVectorTest.cpp
   LazyVectorTest.cpp
   MayHaveNullsRecursiveTest.cpp
+  SelectivityVectorTest.cpp
   VariantToVectorTest.cpp
-  EncodingTest.cpp
-  VectorTestUtils.cpp)
+  VectorCompareTest.cpp
+  VectorEstimateFlatSizeTest.cpp
+  VectorMakerTest.cpp
+  VectorPoolTest.cpp
+  VectorPrepareForReuseTest.cpp
+  VectorPrinterTest.cpp
+  VectorSaverTest.cpp
+  VectorStreamTest.cpp
+  VectorTest.cpp
+  VectorTestUtils.cpp
+  VectorToStringTest.cpp)
 
 add_test(velox_vector_test velox_vector_test)
 


### PR DESCRIPTION
Sorting the .cpp files alphabetically can improve readability and maintainability of the CMake configuration.

