### PR TITLE
Extend the simple UDAF interface with function-level states

### DIFF
--- a/velox/docs/develop/aggregate-functions.rst
+++ b/velox/docs/develop/aggregate-functions.rst
@@ -161,6 +161,7 @@ A simple aggregation function is implemented as a class as the following.
 
     // Optional. Used only when the UDAF needs to use FunctionState.
     static void initialize(
+        core::AggregationNode::Step step,
         FunctionState& state,
         const std::vector<TypePtr>& rawInputTypes,
         const TypePtr& resultType,

--- a/velox/docs/develop/aggregate-functions.rst
+++ b/velox/docs/develop/aggregate-functions.rst
@@ -152,14 +152,16 @@ A simple aggregation function is implemented as a class as the following.
     using IntermediateType = Array<Generic<T1>>;
     using OutputType = Array<Generic<T1>>;
 
-    // If UDAF does not require the use of FunctionState, it is necessary
-    // to declare an empty FunctionState struct.
+    // Define a struct for function-level states. Even if the aggregation function
+    // doesn't use function-level states, it is still necessary to define an empty
+    // FunctionState struct.
     struct FunctionState {
       // Optional.
       TypePtr resultType;
     };
 
-    // Optional. Used only when the UDAF needs to use FunctionState.
+    // Optional. Defined only when the aggregation function needs to use function-level states.
+    // This method is called once when the aggregation function is created.
     static void initialize(
         core::AggregationNode::Step step,
         FunctionState& state,
@@ -188,13 +190,13 @@ one argument. This is needed for the SimpleAggregateAdapter to parse input
 types for arbitrary aggregation functions properly.
 
 A FunctionState struct needs to be declared in the simple aggregation function
-class, it is used to hold the function-level variables that are typically
-computed once and used at every row when adding inputs to accumulators or
-extracting values from accumulators. For example, if the UDAF needs to get the
-result type or the raw input type of the aggregaiton function, the author can
-hold them in the FunctionState struct, and initialize them in the initialize()
-method. If the UDAF does not require the use ofFunctionState, it is necessary
-to declare an empty FunctionState struct.
+class. FunctionState is initialized once when the aggregation function is
+created and used at every row when adding inputs to accumulators or extracting
+values from accumulators. For example, if the aggregation function needs to get
+the result type or the raw input type of the aggregaiton function, the author
+can hold them in the FunctionState struct, and initialize them in the
+initialize() method. If the aggregation function does not require the use of
+FunctionState, it is necessary to declare an empty FunctionState struct.
 
 The author can define an optional flag `default_null_behavior_` indicating
 whether the aggregation function has default-null behavior. This flag is true

--- a/velox/docs/develop/aggregate-functions.rst
+++ b/velox/docs/develop/aggregate-functions.rst
@@ -165,7 +165,8 @@ A simple aggregation function is implemented as a class as the following.
         FunctionState& state,
         const std::vector<TypePtr>& rawInputTypes,
         const TypePtr& resultType,
-        const std::vector<VectorPtr>& constantInputs) {
+        const std::vector<VectorPtr>& constantInputs,
+        std::optional<core::AggregationNode::Step> companionStep) {
       state.resultType = resultType;
     }
 

--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -133,8 +133,15 @@ class Aggregate {
   // UDAF.
   // @param step The aggregation step.
   // @param rawInputType The raw input type of the UDAF.
-  // @param resultType The result type of the UDAF.
-  // @param constantInputs Optional constant inputs.
+  // @param resultType The result type of the current aggregation step.
+  // @param constantInputs Optional constant input values for aggregate
+  // function. constantInputs should be empty if there are no constant inputs,
+  // aligned with inputTypes if there is at least one constant input, with
+  // non-constant inputs represented as nullptr, and must be instances of
+  // ConstantVector.
+  // @param companionStep The step used to register aggregate companion
+  // functions. kPartial for partial companion function, kIntermediate for merge
+  // and merge extract companion function.
   virtual void initialize(
       core::AggregationNode::Step step,
       const std::vector<TypePtr>& rawInputType,

--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -131,10 +131,12 @@ class Aggregate {
 
   // Initialize the function-level state of the simple function interface for
   // UDAF.
+  // @param step The aggregation step.
   // @param rawInputType The raw input type of the UDAF.
   // @param resultType The result type of the UDAF.
   // @param constantInputs Optional constant inputs.
   virtual void initialize(
+      core::AggregationNode::Step step,
       const std::vector<TypePtr>& rawInputType,
       const TypePtr& resultType,
       const std::vector<VectorPtr>& constantInputs) {}

--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -139,7 +139,9 @@ class Aggregate {
       core::AggregationNode::Step step,
       const std::vector<TypePtr>& rawInputType,
       const TypePtr& resultType,
-      const std::vector<VectorPtr>& constantInputs) {}
+      const std::vector<VectorPtr>& constantInputs,
+      std::optional<core::AggregationNode::Step> companionStep = std::nullopt) {
+  }
 
   // Initializes null flags and accumulators for newly encountered groups.  This
   // function should be called only once for each group.

--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -129,6 +129,16 @@ class Aggregate {
         rowSizeOffset);
   }
 
+  // Initialize the function-level state of the simple function interface for
+  // UDAF.
+  // @param rawInputType The raw input type of the UDAF.
+  // @param resultType The result type of the UDAF.
+  // @param constantInputs Optional constant inputs.
+  virtual void initialize(
+      const std::vector<TypePtr>& rawInputType,
+      const TypePtr& resultType,
+      const std::vector<VectorPtr>& constantInputs) {}
+
   // Initializes null flags and accumulators for newly encountered groups.  This
   // function should be called only once for each group.
   //

--- a/velox/exec/AggregateCompanionAdapter.cpp
+++ b/velox/exec/AggregateCompanionAdapter.cpp
@@ -184,6 +184,20 @@ void AggregateCompanionAdapter::MergeFunction::extractValues(
   fn_->extractAccumulators(groups, numGroups, result);
 }
 
+void AggregateCompanionAdapter::MergeExtractFunction::initialize(
+    core::AggregationNode::Step step,
+    const std::vector<TypePtr>& rawInputType,
+    const facebook::velox::TypePtr& resultType,
+    const std::vector<VectorPtr>& constantInputs,
+    std::optional<core::AggregationNode::Step> /*companionStep*/) {
+  fn_->initialize(
+      step,
+      rawInputType,
+      resultType,
+      constantInputs,
+      core::AggregationNode::Step::kFinal);
+}
+
 void AggregateCompanionAdapter::MergeExtractFunction::extractValues(
     char** groups,
     int32_t numGroups,
@@ -275,7 +289,7 @@ void AggregateCompanionAdapter::ExtractFunction::apply(
       rawInputTypes,
       outputType,
       constantInputs,
-      core::AggregationNode::Step::kIntermediate);
+      core::AggregationNode::Step::kFinal);
   fn_->initializeNewGroups(groups, allSelectedRange);
   fn_->enableValidateIntermediateInputs();
   fn_->addIntermediateResults(groups, rows, args, false);

--- a/velox/exec/AggregateCompanionAdapter.cpp
+++ b/velox/exec/AggregateCompanionAdapter.cpp
@@ -73,14 +73,6 @@ void AggregateCompanionFunctionBase::clearInternal() {
   fn_->clear();
 }
 
-void AggregateCompanionFunctionBase::initialize(
-    core::AggregationNode::Step step,
-    const std::vector<TypePtr>& rawInputType,
-    const facebook::velox::TypePtr& resultType,
-    const std::vector<VectorPtr>& constantInputs) {
-  fn_->initialize(step, rawInputType, resultType, constantInputs);
-}
-
 void AggregateCompanionFunctionBase::initializeNewGroups(
     char** groups,
     folly::Range<const vector_size_t*> indices) {
@@ -132,11 +124,35 @@ void AggregateCompanionFunctionBase::extractAccumulators(
   fn_->extractAccumulators(groups, numGroups, result);
 }
 
+void AggregateCompanionAdapter::PartialFunction::initialize(
+    core::AggregationNode::Step /*step*/,
+    const std::vector<TypePtr>& rawInputType,
+    const facebook::velox::TypePtr& resultType,
+    const std::vector<VectorPtr>& constantInputs) {
+  fn_->initialize(
+      core::AggregationNode::Step::kPartial,
+      rawInputType,
+      resultType,
+      constantInputs);
+}
+
 void AggregateCompanionAdapter::PartialFunction::extractValues(
     char** groups,
     int32_t numGroups,
     VectorPtr* result) {
   fn_->extractAccumulators(groups, numGroups, result);
+}
+
+void AggregateCompanionAdapter::MergeFunction::initialize(
+    core::AggregationNode::Step /*step*/,
+    const std::vector<TypePtr>& rawInputType,
+    const facebook::velox::TypePtr& resultType,
+    const std::vector<VectorPtr>& constantInputs) {
+  fn_->initialize(
+      core::AggregationNode::Step::kIntermediate,
+      rawInputType,
+      resultType,
+      constantInputs);
 }
 
 void AggregateCompanionAdapter::MergeFunction::addRawInput(

--- a/velox/exec/AggregateCompanionAdapter.cpp
+++ b/velox/exec/AggregateCompanionAdapter.cpp
@@ -125,15 +125,17 @@ void AggregateCompanionFunctionBase::extractAccumulators(
 }
 
 void AggregateCompanionAdapter::PartialFunction::initialize(
-    core::AggregationNode::Step /*step*/,
+    core::AggregationNode::Step step,
     const std::vector<TypePtr>& rawInputType,
     const facebook::velox::TypePtr& resultType,
-    const std::vector<VectorPtr>& constantInputs) {
+    const std::vector<VectorPtr>& constantInputs,
+    std::optional<core::AggregationNode::Step> /*companionStep*/) {
   fn_->initialize(
-      core::AggregationNode::Step::kPartial,
+      step,
       rawInputType,
       resultType,
-      constantInputs);
+      constantInputs,
+      core::AggregationNode::Step::kPartial);
 }
 
 void AggregateCompanionAdapter::PartialFunction::extractValues(
@@ -144,15 +146,17 @@ void AggregateCompanionAdapter::PartialFunction::extractValues(
 }
 
 void AggregateCompanionAdapter::MergeFunction::initialize(
-    core::AggregationNode::Step /*step*/,
+    core::AggregationNode::Step step,
     const std::vector<TypePtr>& rawInputType,
     const facebook::velox::TypePtr& resultType,
-    const std::vector<VectorPtr>& constantInputs) {
+    const std::vector<VectorPtr>& constantInputs,
+    std::optional<core::AggregationNode::Step> /*companionStep*/) {
   fn_->initialize(
-      core::AggregationNode::Step::kIntermediate,
+      step,
       rawInputType,
       resultType,
-      constantInputs);
+      constantInputs,
+      core::AggregationNode::Step::kIntermediate);
 }
 
 void AggregateCompanionAdapter::MergeFunction::addRawInput(
@@ -270,7 +274,8 @@ void AggregateCompanionAdapter::ExtractFunction::apply(
       core::AggregationNode::Step::kFinal,
       rawInputTypes,
       outputType,
-      constantInputs);
+      constantInputs,
+      core::AggregationNode::Step::kIntermediate);
   fn_->initializeNewGroups(groups, allSelectedRange);
   fn_->enableValidateIntermediateInputs();
   fn_->addIntermediateResults(groups, rows, args, false);

--- a/velox/exec/AggregateCompanionAdapter.cpp
+++ b/velox/exec/AggregateCompanionAdapter.cpp
@@ -256,14 +256,21 @@ void AggregateCompanionAdapter::ExtractFunction::apply(
 
   // Get the raw input types.
   std::vector<TypePtr> rawInputTypes{args.size()};
-  std::transform(
-      args.begin(),
-      args.end(),
-      rawInputTypes.begin(),
-      [](const VectorPtr& arg) { return arg->type(); });
+  std::vector<VectorPtr> constantInputs{args.size()};
+  for (auto i = 0; i < args.size(); i++) {
+    rawInputTypes[i] = args[i]->type();
+    if (args[i]->isConstantEncoding()) {
+      constantInputs[i] = args[i];
+    } else {
+      constantInputs[i] = nullptr;
+    }
+  }
 
   fn_->initialize(
-      core::AggregationNode::Step::kFinal, rawInputTypes, outputType, {});
+      core::AggregationNode::Step::kFinal,
+      rawInputTypes,
+      outputType,
+      constantInputs);
   fn_->initializeNewGroups(groups, allSelectedRange);
   fn_->enableValidateIntermediateInputs();
   fn_->addIntermediateResults(groups, rows, args, false);

--- a/velox/exec/AggregateCompanionAdapter.h
+++ b/velox/exec/AggregateCompanionAdapter.h
@@ -39,6 +39,7 @@ class AggregateCompanionFunctionBase : public Aggregate {
   void destroy(folly::Range<char**> groups) override final;
 
   void initialize(
+      core::AggregationNode::Step step,
       const std::vector<TypePtr>& rawInputType,
       const TypePtr& resultType,
       const std::vector<VectorPtr>& constantInputs) override;

--- a/velox/exec/AggregateCompanionAdapter.h
+++ b/velox/exec/AggregateCompanionAdapter.h
@@ -147,6 +147,13 @@ struct AggregateCompanionAdapter {
         const TypePtr& resultType)
         : MergeFunction{std::move(fn), resultType} {}
 
+    void initialize(
+        core::AggregationNode::Step step,
+        const std::vector<TypePtr>& rawInputType,
+        const TypePtr& resultType,
+        const std::vector<VectorPtr>& constantInputs,
+        std::optional<core::AggregationNode::Step> companionStep) override;
+
     void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
         override;
   };

--- a/velox/exec/AggregateCompanionAdapter.h
+++ b/velox/exec/AggregateCompanionAdapter.h
@@ -38,6 +38,11 @@ class AggregateCompanionFunctionBase : public Aggregate {
 
   void destroy(folly::Range<char**> groups) override final;
 
+  void initialize(
+      const std::vector<TypePtr>& rawInputType,
+      const TypePtr& resultType,
+      const std::vector<VectorPtr>& constantInputs) override;
+
   void initializeNewGroups(
       char** groups,
       folly::Range<const vector_size_t*> indices) override final;

--- a/velox/exec/AggregateCompanionAdapter.h
+++ b/velox/exec/AggregateCompanionAdapter.h
@@ -103,7 +103,8 @@ struct AggregateCompanionAdapter {
         core::AggregationNode::Step step,
         const std::vector<TypePtr>& rawInputType,
         const TypePtr& resultType,
-        const std::vector<VectorPtr>& constantInputs) override;
+        const std::vector<VectorPtr>& constantInputs,
+        std::optional<core::AggregationNode::Step> companionStep) override;
 
     void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
         override;
@@ -120,7 +121,8 @@ struct AggregateCompanionAdapter {
         core::AggregationNode::Step step,
         const std::vector<TypePtr>& rawInputType,
         const TypePtr& resultType,
-        const std::vector<VectorPtr>& constantInputs) override;
+        const std::vector<VectorPtr>& constantInputs,
+        std::optional<core::AggregationNode::Step> companionStep) override;
 
     void addRawInput(
         char** groups,

--- a/velox/exec/AggregateCompanionAdapter.h
+++ b/velox/exec/AggregateCompanionAdapter.h
@@ -38,12 +38,6 @@ class AggregateCompanionFunctionBase : public Aggregate {
 
   void destroy(folly::Range<char**> groups) override final;
 
-  void initialize(
-      core::AggregationNode::Step step,
-      const std::vector<TypePtr>& rawInputType,
-      const TypePtr& resultType,
-      const std::vector<VectorPtr>& constantInputs) override;
-
   void initializeNewGroups(
       char** groups,
       folly::Range<const vector_size_t*> indices) override final;
@@ -105,6 +99,12 @@ struct AggregateCompanionAdapter {
         const TypePtr& resultType)
         : AggregateCompanionFunctionBase{std::move(fn), resultType} {}
 
+    void initialize(
+        core::AggregationNode::Step step,
+        const std::vector<TypePtr>& rawInputType,
+        const TypePtr& resultType,
+        const std::vector<VectorPtr>& constantInputs) override;
+
     void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
         override;
   };
@@ -115,6 +115,12 @@ struct AggregateCompanionAdapter {
         std::unique_ptr<Aggregate> fn,
         const TypePtr& resultType)
         : AggregateCompanionFunctionBase{std::move(fn), resultType} {}
+
+    void initialize(
+        core::AggregationNode::Step step,
+        const std::vector<TypePtr>& rawInputType,
+        const TypePtr& resultType,
+        const std::vector<VectorPtr>& constantInputs) override;
 
     void addRawInput(
         char** groups,

--- a/velox/exec/AggregateInfo.cpp
+++ b/velox/exec/AggregateInfo.cpp
@@ -104,7 +104,7 @@ std::vector<AggregateInfo> toAggregateInfo(
         operatorCtx.driverCtx()->queryConfig());
 
     info.function->initialize(
-        aggregate.rawInputTypes, aggResultType, info.constantInputs);
+        step, aggregate.rawInputTypes, aggResultType, info.constantInputs);
     auto lambdas = extractLambdaInputs(aggregate);
     if (!lambdas.empty()) {
       if (expressionEvaluator == nullptr) {

--- a/velox/exec/AggregateInfo.cpp
+++ b/velox/exec/AggregateInfo.cpp
@@ -103,6 +103,8 @@ std::vector<AggregateInfo> toAggregateInfo(
         aggResultType,
         operatorCtx.driverCtx()->queryConfig());
 
+    info.function->initialize(
+        aggregate.rawInputTypes, aggResultType, info.constantInputs);
     auto lambdas = extractLambdaInputs(aggregate);
     if (!lambdas.empty()) {
       if (expressionEvaluator == nullptr) {

--- a/velox/exec/AggregateWindow.cpp
+++ b/velox/exec/AggregateWindow.cpp
@@ -151,6 +151,7 @@ class AggregateWindowFunction : public exec::WindowFunction {
         // aggregate_ function object should be initialized.
         auto singleGroup = std::vector<vector_size_t>{0};
         aggregate_->clear();
+        aggregate_->initialize(argTypes_, resultType_, argVectors_);
         aggregate_->initializeNewGroups(&rawSingleGroupRow_, singleGroup);
         aggregateInitialized_ = true;
       }
@@ -332,6 +333,7 @@ class AggregateWindowFunction : public exec::WindowFunction {
       // the aggregation based on the frame changes with each row. This would
       // require adding new APIs to the Aggregate framework.
       aggregate_->clear();
+      aggregate_->initialize(argTypes_, resultType_, argVectors_);
       aggregate_->initializeNewGroups(&rawSingleGroupRow_, kSingleGroup);
       aggregateInitialized_ = true;
 
@@ -349,6 +351,7 @@ class AggregateWindowFunction : public exec::WindowFunction {
   // This value is returned for rows with empty frames.
   void computeDefaultAggregateValue(const TypePtr& resultType) {
     aggregate_->clear();
+    aggregate_->initialize(argTypes_, resultType, argVectors_);
     aggregate_->initializeNewGroups(
         &rawSingleGroupRow_, std::vector<vector_size_t>{0});
     aggregateInitialized_ = true;

--- a/velox/exec/AggregateWindow.cpp
+++ b/velox/exec/AggregateWindow.cpp
@@ -391,6 +391,10 @@ class AggregateWindowFunction : public exec::WindowFunction {
   std::vector<TypePtr> argTypes_;
   std::vector<column_index_t> argIndices_;
   std::vector<VectorPtr> argVectors_;
+  // Constant input values for aggregate function. it should be empty if there
+  // are no constant inputs, aligned with inputTypes if there is at least one
+  // constant input, with non-constant inputs represented as nullptr, and must
+  // be instances of ConstantVector.
   std::vector<VectorPtr> constantInputs_;
 
   // This is a single aggregate row needed by the aggregate function for its

--- a/velox/exec/SimpleAggregateAdapter.h
+++ b/velox/exec/SimpleAggregateAdapter.h
@@ -55,7 +55,7 @@ class SimpleAggregateAdapter : public Aggregate {
       const TypePtr& resultType,
       const std::vector<VectorPtr>& constantInputs) override {
     if constexpr (support_initialize_function_state_) {
-      FUNC::initialize(state_, rawInputTypes, resultType, constantInputs);
+      FUNC::initialize(state_, step, rawInputTypes, resultType, constantInputs);
     }
   }
 

--- a/velox/exec/SimpleAggregateAdapter.h
+++ b/velox/exec/SimpleAggregateAdapter.h
@@ -53,9 +53,16 @@ class SimpleAggregateAdapter : public Aggregate {
       core::AggregationNode::Step step,
       const std::vector<TypePtr>& rawInputTypes,
       const TypePtr& resultType,
-      const std::vector<VectorPtr>& constantInputs) override {
+      const std::vector<VectorPtr>& constantInputs,
+      std::optional<core::AggregationNode::Step> companionStep) override {
     if constexpr (support_initialize_function_state_) {
-      FUNC::initialize(state_, step, rawInputTypes, resultType, constantInputs);
+      FUNC::initialize(
+          state_,
+          step,
+          rawInputTypes,
+          resultType,
+          constantInputs,
+          companionStep);
     }
   }
 

--- a/velox/exec/SimpleAggregateAdapter.h
+++ b/velox/exec/SimpleAggregateAdapter.h
@@ -45,11 +45,12 @@ class SimpleAggregateAdapter : public Aggregate {
       : Aggregate(std::move(resultType)) {}
 
   // Function-level states are variables hold by a UDAF instance that are
-  // typically computed once and used at every row when adding inputs to
-  // accumulators or extracting values from accumulators.
+  // computed once and used at every row when adding inputs to accumulators or
+  // extracting values from accumulators.
   typename FUNC::FunctionState state_;
 
   void initialize(
+      core::AggregationNode::Step step,
       const std::vector<TypePtr>& rawInputTypes,
       const TypePtr& resultType,
       const std::vector<VectorPtr>& constantInputs) override {

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -244,8 +244,13 @@ add_executable(velox_simple_aggregate_test SimpleAggregateAdapterTest.cpp
                                            Main.cpp)
 
 target_link_libraries(
-  velox_simple_aggregate_test velox_simple_aggregate velox_exec
-  velox_functions_aggregates_test_lib gtest gtest_main)
+  velox_simple_aggregate_test
+  velox_simple_aggregate
+  velox_exec
+  velox_functions_aggregates_test_lib
+  velox_functions_window_test_lib
+  gtest
+  gtest_main)
 
 add_library(velox_spiller_join_benchmark_base JoinSpillInputBenchmarkBase.cpp
                                               SpillerBenchmarkBase.cpp)

--- a/velox/exec/tests/SimpleAggregateAdapterTest.cpp
+++ b/velox/exec/tests/SimpleAggregateAdapterTest.cpp
@@ -357,6 +357,8 @@ class CountNullsAggregate {
   using IntermediateType = int64_t; // Intermediate result type.
   using OutputType = int64_t; // Output vector type.
 
+  struct FunctionState {};
+
   static constexpr bool default_null_behavior_ = false;
 
   struct Accumulator {
@@ -364,13 +366,16 @@ class CountNullsAggregate {
 
     Accumulator() = delete;
 
-    explicit Accumulator(HashStringAllocator* /*allocator*/) {
+    explicit Accumulator(
+        HashStringAllocator* /*allocator*/,
+        const FunctionState& /*state*/) {
       nullsCount_ = 0;
     }
 
     bool addInput(
         HashStringAllocator* /*allocator*/,
-        exec::optional_arg_type<double> data) {
+        exec::optional_arg_type<double> data,
+        const FunctionState& /*state*/) {
       if (!data.has_value()) {
         nullsCount_++;
         return true;
@@ -380,7 +385,8 @@ class CountNullsAggregate {
 
     bool combine(
         HashStringAllocator* /*allocator*/,
-        exec::optional_arg_type<int64_t> nullsCount) {
+        exec::optional_arg_type<int64_t> nullsCount,
+        const FunctionState& /*state*/) {
       if (nullsCount.has_value()) {
         nullsCount_ += nullsCount.value();
         return true;
@@ -388,13 +394,17 @@ class CountNullsAggregate {
       return false;
     }
 
-    bool writeFinalResult(bool nonNull, exec::out_type<OutputType>& out) {
+    bool writeFinalResult(
+        bool nonNull,
+        exec::out_type<OutputType>& out,
+        const FunctionState& /*state*/) {
       return writeResult<OutputType>(nonNull, out);
     }
 
     bool writeIntermediateResult(
         bool nonNull,
-        exec::out_type<IntermediateType>& out) {
+        exec::out_type<IntermediateType>& out,
+        const FunctionState& /*state*/) {
       return writeResult<IntermediateType>(nonNull, out);
     }
 

--- a/velox/exec/tests/SimpleArrayAggAggregate.cpp
+++ b/velox/exec/tests/SimpleArrayAggAggregate.cpp
@@ -36,6 +36,8 @@ class ArrayAggAggregate {
   // Type of output vector.
   using OutputType = Array<Generic<T1>>;
 
+  struct FunctionState {};
+
   static constexpr bool default_null_behavior_ = false;
 
   static bool toIntermediate(
@@ -55,7 +57,9 @@ class ArrayAggAggregate {
     AccumulatorType() = delete;
 
     // Constructor used in initializeNewGroups().
-    explicit AccumulatorType(HashStringAllocator* /*allocator*/)
+    explicit AccumulatorType(
+        HashStringAllocator* /*allocator*/,
+        const FunctionState& /*state*/)
         : elements_{} {}
 
     static constexpr bool is_fixed_size_ = false;
@@ -64,7 +68,8 @@ class ArrayAggAggregate {
     // child-type T wrapped in InputType.
     bool addInput(
         HashStringAllocator* allocator,
-        exec::optional_arg_type<Generic<T1>> data) {
+        exec::optional_arg_type<Generic<T1>> data,
+        const FunctionState& /*state*/) {
       elements_.appendValue(data, allocator);
       return true;
     }
@@ -73,7 +78,8 @@ class ArrayAggAggregate {
     // exec::optional_arg_type<IntermediateType>.
     bool combine(
         HashStringAllocator* allocator,
-        exec::optional_arg_type<Array<Generic<T1>>> other) {
+        exec::optional_arg_type<Array<Generic<T1>>> other,
+        const FunctionState& /*state*/) {
       if (!other.has_value()) {
         return false;
       }
@@ -85,7 +91,8 @@ class ArrayAggAggregate {
 
     bool writeFinalResult(
         bool nonNullGroup,
-        exec::out_type<Array<Generic<T1>>>& out) {
+        exec::out_type<Array<Generic<T1>>>& out,
+        const FunctionState& /*state*/) {
       if (!nonNullGroup) {
         return false;
       }
@@ -95,7 +102,8 @@ class ArrayAggAggregate {
 
     bool writeIntermediateResult(
         bool nonNullGroup,
-        exec::out_type<Array<Generic<T1>>>& out) {
+        exec::out_type<Array<Generic<T1>>>& out,
+        const FunctionState& /*state*/) {
       // If the group's accumulator is null, the corresponding intermediate
       // result is null too.
       if (!nonNullGroup) {

--- a/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
@@ -1256,6 +1256,11 @@ void AggregationTestBase::testIncrementalAggregation(
     std::vector<char> group(kOffset + func->accumulatorFixedWidthSize());
     std::vector<char*> groups(inputSize, group.data());
     std::vector<vector_size_t> indices(1, 0);
+    func->initialize(
+        aggregationNode.step(),
+        aggregate.rawInputTypes,
+        func->resultType(),
+        {});
     func->initializeNewGroups(groups.data(), indices);
     func->addSingleGroupRawInput(
         group.data(), SelectivityVector(inputSize), input, false);
@@ -1308,6 +1313,11 @@ VectorPtr AggregationTestBase::testStreaming(
   std::vector<char> group(kOffset + func->accumulatorFixedWidthSize());
   std::vector<char*> groups(maxRowCount, group.data());
   std::vector<vector_size_t> indices(maxRowCount, 0);
+  func->initialize(
+      core::AggregationNode::Step::kSingle,
+      rawInputTypes,
+      func->resultType(),
+      {});
   func->initializeNewGroups(groups.data(), indices);
   if (testGlobal) {
     func->addSingleGroupRawInput(
@@ -1327,6 +1337,11 @@ VectorPtr AggregationTestBase::testStreaming(
   // Create a new function picking up the intermediate result.
   auto func2 =
       createAggregateFunction(functionName, rawInputTypes, allocator, config);
+  func2->initialize(
+      core::AggregationNode::Step::kSingle,
+      rawInputTypes,
+      func2->resultType(),
+      {});
   func2->initializeNewGroups(groups.data(), indices);
   if (testGlobal) {
     func2->addSingleGroupIntermediateResults(

--- a/velox/functions/prestosql/aggregates/BitwiseXorAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/BitwiseXorAggregate.cpp
@@ -32,6 +32,8 @@ class BitwiseXorAggregate {
 
   using OutputType = T;
 
+  struct FunctionState {};
+
   static bool toIntermediate(exec::out_type<T>& out, exec::arg_type<T> in) {
     out = in;
     return true;
@@ -42,22 +44,34 @@ class BitwiseXorAggregate {
 
     AccumulatorType() = delete;
 
-    explicit AccumulatorType(HashStringAllocator* /*allocator*/) {}
+    explicit AccumulatorType(
+        HashStringAllocator* /*allocator*/,
+        const FunctionState& /*state*/) {}
 
-    void addInput(HashStringAllocator* /*allocator*/, exec::arg_type<T> data) {
+    void addInput(
+        HashStringAllocator* /*allocator*/,
+        exec::arg_type<T> data,
+        const FunctionState& /*state*/) {
       xor_ ^= data;
     }
 
-    void combine(HashStringAllocator* /*allocator*/, exec::arg_type<T> other) {
+    void combine(
+        HashStringAllocator* /*allocator*/,
+        exec::arg_type<T> other,
+        const FunctionState& /*state*/) {
       xor_ ^= other;
     }
 
-    bool writeFinalResult(exec::out_type<OutputType>& out) {
+    bool writeFinalResult(
+        exec::out_type<OutputType>& out,
+        const FunctionState& /*state*/) {
       out = xor_;
       return true;
     }
 
-    bool writeIntermediateResult(exec::out_type<IntermediateType>& out) {
+    bool writeIntermediateResult(
+        exec::out_type<IntermediateType>& out,
+        const FunctionState& /*state*/) {
       out = xor_;
       return true;
     }

--- a/velox/functions/prestosql/aggregates/GeometricMeanAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/GeometricMeanAggregate.cpp
@@ -35,6 +35,8 @@ class GeometricMeanAggregate {
 
   using OutputType = TResult;
 
+  struct FunctionState {};
+
   static bool toIntermediate(
       exec::out_type<Row<double, int64_t>>& out,
       exec::arg_type<TInput> in) {
@@ -50,30 +52,38 @@ class GeometricMeanAggregate {
 
     AccumulatorType() = delete;
 
-    explicit AccumulatorType(HashStringAllocator* /*allocator*/) {}
+    explicit AccumulatorType(
+        HashStringAllocator* /*allocator*/,
+        const FunctionState& /*state*/) {}
 
     void addInput(
         HashStringAllocator* /*allocator*/,
-        exec::arg_type<TInput> data) {
+        exec::arg_type<TInput> data,
+        const FunctionState& /*state*/) {
       logSum_ += std::log(data);
       count_ = checkedPlus<int64_t>(count_, 1);
     }
 
     void combine(
         HashStringAllocator* /*allocator*/,
-        exec::arg_type<Row<double, int64_t>> other) {
+        exec::arg_type<Row<double, int64_t>> other,
+        const FunctionState& /*state*/) {
       VELOX_CHECK(other.at<0>().has_value());
       VELOX_CHECK(other.at<1>().has_value());
       logSum_ += other.at<0>().value();
       count_ = checkedPlus<int64_t>(count_, other.at<1>().value());
     }
 
-    bool writeFinalResult(exec::out_type<OutputType>& out) {
+    bool writeFinalResult(
+        exec::out_type<OutputType>& out,
+        const FunctionState& /*state*/) {
       out = std::exp(logSum_ / count_);
       return true;
     }
 
-    bool writeIntermediateResult(exec::out_type<IntermediateType>& out) {
+    bool writeIntermediateResult(
+        exec::out_type<IntermediateType>& out,
+        const FunctionState& /*state*/) {
       out = std::make_tuple(logSum_, count_);
       return true;
     }


### PR DESCRIPTION
The simple function interface for UDAFs currently doesn't allow function-level
states. Function-level states are variables hold by a UDAF instance that are
typically computed once and used at every row when adding inputs to accumulators
or extracting values from accumulators. With the traditional vector function
interface, UDAF authors use function-level states by simply defining them as
data members of the function class. On the contrary, the simple function
interface doesn’t expose any data member of the function class to the
author-defined accumulator logics.

Below are a few examples where function-level states are necessary and useful.

Decimal functions usually need to know the precision and scale of the result
Decimal type when extract values from accumulators. The result type is currently
not exposed to author-defined accumulator type in the simple function interface.
Some functions perform heavy computation on a constant argument before
processing all input rows, such as approx_most_frequent, and store the
computation result in a function-level state. With the current simple function
interface, the UDAF author would have to do the computation on the constant
argument at every row. To enable function-level states, we can extend
SimpleAggregateAdapter to allow the UDAF author to define a FunctionState struct
in the function class and let SimpleAggregateAdapter hold an instance of
FunctionState. The author then implement a void initialize(FunctionState& state,
const TypePtr& resultType, const std::vector<VectorPtr>& constantInputs) in
their function class that assign values to the FunctionState instance. This
initialize() function will be called only once when the aggregation function
instance is created. Finally, all methods in the author-defined accumulator type
receive this FunctionState instance as a const argument.