### PR TITLE
Fix regr_r2 failure in AggregationFuzzer

### DIFF
--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -447,7 +447,8 @@ Statistical Aggregate Functions
 .. function:: regr_r2(y, x) -> double
 
     Returns the coefficient of determination of the linear regression. ``y`` is the dependent
-    value. ``x`` is the independent value.
+    value. ``x`` is the independent value. If regr_sxx(y, x) is 0, result is null. If regr_syy(y, x) is 0
+    and regr_sxx(y, x) isn't 0, result is 1;
 
 .. function:: regr_slope(y, x) -> double
 

--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -448,7 +448,7 @@ Statistical Aggregate Functions
 
     Returns the coefficient of determination of the linear regression. ``y`` is the dependent
     value. ``x`` is the independent value. If regr_sxx(y, x) is 0, result is null. If regr_syy(y, x) is 0
-    and regr_sxx(y, x) isn't 0, result is 1;
+    and regr_sxx(y, x) isn't 0, result is 1.
 
 .. function:: regr_slope(y, x) -> double
 

--- a/velox/functions/prestosql/aggregates/CovarianceAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/CovarianceAggregates.cpp
@@ -413,10 +413,13 @@ struct RegrSxyResultAccessor {
 
 struct RegrR2ResultAccessor {
   static bool hasResult(const ExtendedRegrAccumulator& accumulator) {
-    return accumulator.m2Y() != 0 && accumulator.m2X() != 0;
+    return accumulator.m2X() != 0;
   }
 
   static double result(const ExtendedRegrAccumulator& accumulator) {
+    if (accumulator.m2X() != 0 && accumulator.m2Y() == 0) {
+      return 1;
+    }
     return std::pow(accumulator.c2(), 2) /
         (accumulator.m2X() * accumulator.m2Y());
   }

--- a/velox/functions/prestosql/aggregates/tests/CovarianceAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/CovarianceAggregationTest.cpp
@@ -163,6 +163,23 @@ TEST_P(CovarianceAggregationTest, allSameValue) {
   testDistinctGroupBy(aggName, data);
 }
 
+TEST_P(CovarianceAggregationTest, allSameYValue) {
+  vector_size_t size = 1'000;
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>(size, [](auto row) { return row % 7; }),
+      makeFlatVector<float>(size, [](auto row) { return 1; }),
+      makeFlatVector<float>(size, [](auto row) { return row * 0.2; }),
+  });
+
+  createDuckDbTable({data});
+
+  auto aggName = GetParam();
+  testGlobalAgg(aggName, data);
+  testGroupBy(aggName, data);
+  testDistinctGlobalAgg(aggName, data);
+  testDistinctGroupBy(aggName, data);
+}
+
 VELOX_INSTANTIATE_TEST_SUITE_P(
     CovarianceAggregationTest,
     CovarianceAggregationTest,

--- a/velox/functions/prestosql/aggregates/tests/CovarianceAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/CovarianceAggregationTest.cpp
@@ -167,7 +167,7 @@ TEST_P(CovarianceAggregationTest, constantY) {
   vector_size_t size = 1'000;
   auto data = makeRowVector({
       makeFlatVector<int32_t>(size, [](auto row) { return row % 7; }),
-      makeFlatVector<float>(size, [](auto row) { return 1; }),
+      makeFlatVector<float>(size, [](auto /*row*/) { return 1; }),
       makeFlatVector<float>(size, [](auto row) { return row * 0.2; }),
   });
 

--- a/velox/functions/prestosql/aggregates/tests/CovarianceAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/CovarianceAggregationTest.cpp
@@ -163,7 +163,7 @@ TEST_P(CovarianceAggregationTest, allSameValue) {
   testDistinctGroupBy(aggName, data);
 }
 
-TEST_P(CovarianceAggregationTest, allSameYValue) {
+TEST_P(CovarianceAggregationTest, constantY) {
   vector_size_t size = 1'000;
   auto data = makeRowVector({
       makeFlatVector<int32_t>(size, [](auto row) { return row % 7; }),


### PR DESCRIPTION
Fix regr_r2 for two cases:

1. m2X() = 0, then result is NULL
2. m2X() != 0 and m2Y() = 0, then result is 1.

Fixes #9089