### PR TITLE
Unregister the UDTs after use in ArrayViewTest and ArrayWriterTest

### DIFF
--- a/velox/expression/tests/ArrayViewTest.cpp
+++ b/velox/expression/tests/ArrayViewTest.cpp
@@ -575,6 +575,7 @@ TEST_F(NullableArrayViewTest, materializeArrayOfCustomTypes) {
           MaterializeType<Array<UDTTypeRegistrar::SimpleType>>::nullable_t,
           std::vector<std::optional<UDT>>>);
   UDTTypeRegistrar::registerType();
+  auto guard = folly::makeGuard([&] { UDTTypeRegistrar::unregisterType(); });
   registerFunction<MakeUDTFunc, UDTTypeRegistrar::SimpleType>({"make_udt"});
 
   auto result = evaluate(
@@ -597,6 +598,7 @@ TEST_F(NullFreeArrayViewTest, materializeArrayOfCustomTypes) {
           MaterializeType<Array<UDTTypeRegistrar::SimpleType>>::null_free_t,
           std::vector<UDT>>);
   UDTTypeRegistrar::registerType();
+  auto guard = folly::makeGuard([&] { UDTTypeRegistrar::unregisterType(); });
   registerFunction<MakeUDTFunc, UDTTypeRegistrar::SimpleType>({"make_udt"});
 
   auto result = evaluate(

--- a/velox/expression/tests/ArrayWriterTest.cpp
+++ b/velox/expression/tests/ArrayWriterTest.cpp
@@ -973,6 +973,7 @@ using UDT2TypeRegistrar = OpaqueCustomTypeRegister<UDT2, kName>;
 
 TEST_F(ArrayWriterTest, copyFromArrayOfOpaqueUDT) {
   UDT2TypeRegistrar::registerType();
+  auto guard = folly::makeGuard([&] { UDT2TypeRegistrar::unregisterType(); });
 
   using out_t = Array<UDT2TypeRegistrar::SimpleType>;
 
@@ -1020,6 +1021,7 @@ struct CopyFromArrayOfUDTFunc {
 
 TEST_F(ArrayWriterTest, copyFromNestedArrayOfOpaqueUDT) {
   UDT2TypeRegistrar::registerType();
+  auto guard = folly::makeGuard([&] { UDT2TypeRegistrar::unregisterType(); });
   registerFunction<CopyFromArrayOfUDTFunc, copy_from_udt_t>(
       {"copy_udt2_array"});
 

--- a/velox/type/OpaqueCustomTypes.h
+++ b/velox/type/OpaqueCustomTypes.h
@@ -38,6 +38,10 @@ class OpaqueCustomTypeRegister {
         customTypeName, std::make_unique<const TypeFactory>());
   }
 
+  static bool unregisterType() {
+    return facebook::velox::unregisterCustomType(customTypeName);
+  }
+
   // Type used in the simple function interface as CustomType<TypeT>.
   struct TypeT {
     using type = std::shared_ptr<T>;


### PR DESCRIPTION
ArrayViewTest and ArrayWriterTest register UDTs, which should be unregistered
after use to avoid causing instability in the test results of
CustomTypeTest.getCustomTypeNames.

Fixes #9169