### PR TITLE
Remove unused exception parameter from velox/common/base/tests/StatusTest.cpp

### DIFF
--- a/velox/common/base/tests/StatusTest.cpp
+++ b/velox/common/base/tests/StatusTest.cpp
@@ -122,7 +122,7 @@ TEST(StatusTest, macros) {
   bool didThrow = false;
   try {
     VELOX_CHECK_OK(Status::Invalid("invalid"));
-  } catch (const VeloxRuntimeError& e) {
+  } catch (const VeloxRuntimeError&) {
     didThrow = true;
   }
   ASSERT_TRUE(didThrow) << "VELOX_CHECK_OK did not throw";

--- a/velox/common/caching/tests/CachedFactoryTest.cpp
+++ b/velox/common/caching/tests/CachedFactoryTest.cpp
@@ -136,7 +136,7 @@ TEST(CachedFactoryTest, basicExceptionHandling) {
   try {
     auto val2 = factory.generate(3);
     FAIL() << "Factory generation should have failed";
-  } catch (const std::invalid_argument& e) {
+  } catch (const std::invalid_argument&) {
     // Expected.
   }
   val1 = factory.generate(4);

--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -523,7 +523,7 @@ uint64_t SharedArbitrator::reclaimUsedMemoryFromCandidatesByAbort(
       VELOX_MEM_POOL_ABORTED(fmt::format(
           "Memory pool aborted to reclaim used memory, current usage {}",
           succinctBytes(candidate.currentBytes)));
-    } catch (VeloxRuntimeError& ex) {
+    } catch (VeloxRuntimeError&) {
       abort(candidate.pool, std::current_exception());
     }
     freedBytes += candidate.pool->shrink();

--- a/velox/common/process/Profiler.cpp
+++ b/velox/common/process/Profiler.cpp
@@ -144,7 +144,7 @@ void Profiler::copyToResult(const std::string* data) {
   try {
     try {
       fileSystem_->remove(target);
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
       // ignore
     }
     auto out = fileSystem_->openFileForWrite(target);
@@ -220,7 +220,7 @@ bool Profiler::interruptibleSleep(int32_t seconds) {
       std::move(sleepFuture)
           .via(&executor)
           .wait((std::chrono::seconds(seconds)));
-    } catch (std::exception& e) {
+    } catch (std::exception&) {
     }
   }
   {

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -1108,7 +1108,7 @@ void HashBuild::reclaim(
       // this runs.
       try {
         spillTask->move();
-      } catch (const std::exception& e) {
+      } catch (const std::exception&) {
       }
     }
   });

--- a/velox/exec/fuzzer/AggregationFuzzerBase.cpp
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.cpp
@@ -428,7 +428,7 @@ velox::test::ResultOrError AggregationFuzzerBase::execute(
     TestScopedSpillInjection scopedSpillInjection(spillPct);
     resultOrError.result =
         builder.maxDrivers(maxDrivers).copyResults(pool_.get());
-  } catch (VeloxUserError& e) {
+  } catch (VeloxUserError&) {
     // NOTE: velox user exception is accepted as it is caused by the invalid
     // fuzzer test inputs.
     resultOrError.exceptionPtr = std::current_exception();

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -2745,7 +2745,7 @@ namespace {
 void abortPool(memory::MemoryPool* pool) {
   try {
     VELOX_FAIL("Memory pool manually aborted");
-  } catch (const VeloxException& e) {
+  } catch (const VeloxException&) {
     pool->abort(std::current_exception());
   }
 }

--- a/velox/exec/tests/LocalPartitionTest.cpp
+++ b/velox/exec/tests/LocalPartitionTest.cpp
@@ -520,7 +520,7 @@ TEST_F(LocalPartitionTest, earlyCancelation) {
       ;
       FAIL() << "Expected a throw due to cancellation";
     }
-  } catch (const std::exception& e) {
+  } catch (const std::exception&) {
   }
 
   // Wait for task to transition to final state.

--- a/velox/exec/tests/MemoryReclaimerTest.cpp
+++ b/velox/exec/tests/MemoryReclaimerTest.cpp
@@ -94,7 +94,7 @@ TEST_F(MemoryReclaimerTest, abortTest) {
           "leafAbortTest", true, exec::MemoryReclaimer::create());
       try {
         VELOX_FAIL("abortTest error");
-      } catch (const VeloxRuntimeError& e) {
+      } catch (const VeloxRuntimeError&) {
         leafPool->abort(std::current_exception());
       }
       ASSERT_TRUE(rootPool->aborted());
@@ -104,7 +104,7 @@ TEST_F(MemoryReclaimerTest, abortTest) {
           "nonLeafAbortTest", exec::MemoryReclaimer::create());
       try {
         VELOX_FAIL("abortTest error");
-      } catch (const VeloxRuntimeError& e) {
+      } catch (const VeloxRuntimeError&) {
         aggregatePool->abort(std::current_exception());
       }
       ASSERT_TRUE(rootPool->aborted());

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -58,7 +58,7 @@ common::SpillStats spilledStats(const exec::Task& task) {
 void abortPool(memory::MemoryPool* pool) {
   try {
     VELOX_FAIL("Manual MemoryPool Abortion");
-  } catch (const VeloxException& error) {
+  } catch (const VeloxException&) {
     pool->abort(std::current_exception());
   }
 }

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -575,7 +575,7 @@ class SpillerTest : public exec::test::RowContainerTestBase {
       }
       rowContainer_->clear();
       ASSERT_FALSE(expectedError);
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
       ASSERT_TRUE(expectedError);
     }
   }

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -1312,7 +1312,7 @@ DEBUG_ONLY_TEST_F(TaskTest, raceBetweenTaskPauseAndTerminate) {
     try {
       while (cursor->moveNext()) {
       };
-    } catch (VeloxRuntimeError& ex) {
+    } catch (VeloxRuntimeError&) {
     }
   });
 

--- a/velox/expression/tests/EvalSimplifiedTest.cpp
+++ b/velox/expression/tests/EvalSimplifiedTest.cpp
@@ -86,13 +86,13 @@ class EvalSimplifiedTest : public FunctionBaseTest {
 
     try {
       exprSetCommon.eval(rows, evalCtxCommon, commonEvalResult);
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
       exceptionCommonPtr = std::current_exception();
     }
 
     try {
       exprSetSimplified.eval(rows, evalCtxSimplified, simplifiedEvalResult);
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
       exceptionSimplifiedPtr = std::current_exception();
     }
 

--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -386,7 +386,7 @@ bool isDeterministic(
   // deterministic so they are picked for Fuzz testing. Once we make the
   // isDeterministic() flag static (and hence we won't need to build the
   // function object in here) we can clean up this code.
-  catch (const std::exception& e) {
+  catch (const std::exception&) {
     LOG(WARNING) << "Unable to determine if '" << functionName
                  << "' is deterministic or not. Assuming it is.";
     return true;

--- a/velox/expression/tests/ExpressionRunner.cpp
+++ b/velox/expression/tests/ExpressionRunner.cpp
@@ -198,7 +198,7 @@ void ExpressionRunner::run(
           std::move(resultVector),
           true,
           columnsToWrapInLazy);
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
       if (findMinimalSubExpression) {
         VectorFuzzer::Options options;
         VectorFuzzer fuzzer(options, pool.get());


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D55092139


