### PR TITLE
Enable `-Wmismatched-tags` in velox/PACKAGE

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -22,7 +22,7 @@
 
 namespace facebook::velox::connector::hive::iceberg {
 
-class IcebergDeleteFile;
+struct IcebergDeleteFile;
 
 class IcebergSplitReader : public SplitReader {
  public:

--- a/velox/connectors/hive/iceberg/PositionalDeleteFileReader.h
+++ b/velox/connectors/hive/iceberg/PositionalDeleteFileReader.h
@@ -27,8 +27,8 @@
 
 namespace facebook::velox::connector::hive::iceberg {
 
-class IcebergDeleteFile;
-class IcebergMetadataColumn;
+struct IcebergDeleteFile;
+struct IcebergMetadataColumn;
 
 using SubfieldFilters =
     std::unordered_map<common::Subfield, std::unique_ptr<common::Filter>>;


### PR DESCRIPTION
Summary:
This diff enables the titular warning flag for the directory in question. Further details are in [this workplace post](https://fb.workplace.com/permalink.php?story_fbid=pfbid02XaWNiCVk69r1ghfvDVpujB8Hr9Y61uDvNakxiZFa2jwiPHscVdEQwCBHrmWZSyMRl&id=100051201402394).

This is a low-risk diff. There are **no run-time effects** and the diff has already been observed to compile locally. **If the code compiles, it works; test errors are spurious.**

If the diff does not pass, it will be closed automatically.

Reviewed By: dmm-fb

Differential Revision: D53546578


