### PR TITLE
Remove unused lambda capture from velox/common/caching/tests/AsyncDataCacheTest.cpp

### DIFF
--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -180,7 +180,7 @@ class AsyncDataCacheTest : public testing::Test {
     std::vector<std::thread> threads;
     threads.reserve(numThreads);
     for (int32_t i = 0; i < numThreads; ++i) {
-      threads.push_back(std::thread([this, i, func]() { func(i); }));
+      threads.push_back(std::thread([i, func]() { func(i); }));
     }
     for (auto& thread : threads) {
       thread.join();


### PR DESCRIPTION
Summary:
`-Wunused-lambda-capture` has identified an unused lambda capture. This diff removes it.

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D55092498


