### PR TITLE
Remove unused variables in velox/connectors/hive/tests/HiveDataSinkTest.cpp

### DIFF
--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -35,8 +35,6 @@ using namespace facebook::velox::common;
 using namespace facebook::velox::exec::test;
 using namespace facebook::velox::common::testutil;
 
-constexpr const char* kHiveConnectorId = "test-hive";
-
 class HiveDataSinkTest : public exec::test::HiveConnectorTestBase {
  protected:
   void SetUp() override {

--- a/velox/exec/prefixsort/tests/PrefixEncoderTest.cpp
+++ b/velox/exec/prefixsort/tests/PrefixEncoderTest.cpp
@@ -53,7 +53,6 @@ struct TypeLimits {
 template <>
 struct TypeLimits<Timestamp> {
   static const bool isFloat = false;
-  static const bool isSigned = true;
   static FOLLY_ALWAYS_INLINE Timestamp min() {
     return std::numeric_limits<Timestamp>::min();
   }

--- a/velox/functions/prestosql/tests/JsonCastTest.cpp
+++ b/velox/functions/prestosql/tests/JsonCastTest.cpp
@@ -21,9 +21,6 @@ using namespace facebook::velox;
 
 namespace {
 
-constexpr double kInf = std::numeric_limits<double>::infinity();
-constexpr double kNan = std::numeric_limits<double>::quiet_NaN();
-
 template <typename T>
 using TwoDimVector = std::vector<std::vector<std::optional<T>>>;
 

--- a/velox/functions/prestosql/tests/ProbabilityTest.cpp
+++ b/velox/functions/prestosql/tests/ProbabilityTest.cpp
@@ -28,8 +28,6 @@ constexpr double kDoubleMax = std::numeric_limits<double>::max();
 constexpr double kDoubleMin = std::numeric_limits<double>::min();
 constexpr int64_t kBigIntMax = std::numeric_limits<int64_t>::max();
 constexpr int64_t kBigIntMin = std::numeric_limits<int64_t>::min();
-constexpr int32_t kIntMax = std::numeric_limits<int32_t>::max();
-constexpr int32_t kIntMin = std::numeric_limits<int32_t>::min();
 
 MATCHER(IsNan, "is NaN") {
   return arg && std::isnan(*arg);

--- a/velox/functions/sparksql/tests/BitwiseTest.cpp
+++ b/velox/functions/sparksql/tests/BitwiseTest.cpp
@@ -32,7 +32,6 @@ static constexpr auto kMin32 = std::numeric_limits<int32_t>::min();
 static constexpr auto kMax32 = std::numeric_limits<int32_t>::max();
 static constexpr auto kMin64 = std::numeric_limits<int64_t>::min();
 static constexpr auto kMax64 = std::numeric_limits<int64_t>::max();
-static constexpr int kMaxBits = std::numeric_limits<uint64_t>::digits;
 
 class BitwiseTest : public SparkFunctionBaseTest {
  protected:


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: palmje

Differential Revision: D55099933


