### PR TITLE
Make copies of Vectors in Values Operator if it is parallelizable

### DIFF
--- a/velox/exec/Values.cpp
+++ b/velox/exec/Values.cpp
@@ -36,7 +36,15 @@ Values::Values(
   values_.reserve(values->values().size());
   for (auto& vector : values->values()) {
     if (vector->size() > 0) {
-      values_.emplace_back(vector);
+      if (values->isParallelizable()) {
+        // If this is parallelizable, copy the values to prevent Vectors from
+        // being shared across threads.  Note that the contract in ValuesNode is
+        // that this should only be enabled for testing.
+        values_.emplace_back(std::static_pointer_cast<RowVector>(
+            vector->copyPreserveEncodings()));
+      } else {
+        values_.emplace_back(vector);
+      }
     }
   }
 }

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -496,7 +496,11 @@ class BaseVector {
     VELOX_UNSUPPORTED("Can only copy into flat or complex vectors");
   }
 
-  /// Construct a zero-copy slice of the vector with the indicated offset and
+  /// This makes a deep copy of the Vector allocating new child Vectors and
+  // Buffers recursively.  Unlike copy, this preserves encodings recursively.
+  virtual VectorPtr copyPreserveEncodings() const = 0;
+
+  // Construct a zero-copy slice of the vector with the indicated offset and
   /// length.
   virtual VectorPtr slice(vector_size_t offset, vector_size_t length) const = 0;
 

--- a/velox/vector/BiasVector.h
+++ b/velox/vector/BiasVector.h
@@ -163,6 +163,22 @@ class BiasVector : public SimpleVector<T> {
     VELOX_NYI();
   }
 
+  VectorPtr copyPreserveEncodings() const override {
+    return std::make_shared<BiasVector<T>>(
+        BaseVector::pool_,
+        AlignedBuffer::copy(BaseVector::pool_, BaseVector::nulls_),
+        BaseVector::length_,
+        valueType_,
+        AlignedBuffer::copy(BaseVector::pool_, values_),
+        bias_,
+        SimpleVector<T>::stats_,
+        BaseVector::distinctValueCount_,
+        BaseVector::nullCount_,
+        SimpleVector<T>::isSorted_,
+        BaseVector::representedByteCount_,
+        BaseVector::storageByteCount_);
+  }
+
  private:
   template <typename U>
   inline xsimd::batch<T> loadSIMDInternal(size_t byteOffset) const {

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -356,6 +356,27 @@ class ConstantVector final : public SimpleVector<T> {
     }
   }
 
+  VectorPtr copyPreserveEncodings() const override {
+    if (valueVector_) {
+      return std::make_shared<ConstantVector<T>>(
+          BaseVector::pool_,
+          BaseVector::length_,
+          index_,
+          valueVector_->copyPreserveEncodings(),
+          SimpleVector<T>::stats_);
+    }
+
+    return std::make_shared<ConstantVector<T>>(
+        BaseVector::pool_,
+        BaseVector::length_,
+        isNull_,
+        BaseVector::type_,
+        T(value_),
+        SimpleVector<T>::stats_,
+        BaseVector::representedByteCount_,
+        BaseVector::storageByteCount_);
+  }
+
  protected:
   std::string toSummaryString() const override {
     std::stringstream out;

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -224,6 +224,21 @@ class DictionaryVector : public SimpleVector<T> {
 
   void validate(const VectorValidateOptions& options) const override;
 
+  VectorPtr copyPreserveEncodings() const override {
+    return std::make_shared<DictionaryVector<T>>(
+        BaseVector::pool_,
+        AlignedBuffer::copy(BaseVector::pool_, BaseVector::nulls_),
+        BaseVector::length_,
+        dictionaryValues_->copyPreserveEncodings(),
+        AlignedBuffer::copy(BaseVector::pool_, indices_),
+        SimpleVector<T>::stats_,
+        BaseVector::distinctValueCount_,
+        BaseVector::nullCount_,
+        SimpleVector<T>::isSorted_,
+        BaseVector::representedByteCount_,
+        BaseVector::storageByteCount_);
+  }
+
  private:
   // return the dictionary index for the specified vector index.
   inline vector_size_t getDictionaryIndex(vector_size_t idx) const {

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -274,6 +274,22 @@ class FlatVector final : public SimpleVector<T> {
       const BaseVector* source,
       const folly::Range<const BaseVector::CopyRange*>& ranges) override;
 
+  VectorPtr copyPreserveEncodings() const override {
+    return std::make_shared<FlatVector<T>>(
+        BaseVector::pool_,
+        BaseVector::type_,
+        AlignedBuffer::copy(BaseVector::pool_, BaseVector::nulls_),
+        BaseVector::length_,
+        AlignedBuffer::copy(BaseVector::pool_, values_),
+        std::vector<BufferPtr>(stringBuffers_),
+        SimpleVector<T>::stats_,
+        BaseVector::distinctValueCount_,
+        BaseVector::nullCount_,
+        SimpleVector<T>::isSorted_,
+        BaseVector::representedByteCount_,
+        BaseVector::storageByteCount_);
+  }
+
   void resize(vector_size_t newSize, bool setNotNull = true) override;
 
   VectorPtr slice(vector_size_t offset, vector_size_t length) const override;

--- a/velox/vector/FunctionVector.h
+++ b/velox/vector/FunctionVector.h
@@ -193,6 +193,10 @@ class FunctionVector : public BaseVector {
     VELOX_NYI();
   }
 
+  VectorPtr copyPreserveEncodings() const override {
+    VELOX_UNSUPPORTED("copyPreserveEncodings not defined for FunctionVector");
+  }
+
  private:
   std::vector<std::shared_ptr<Callable>> functions_;
   std::vector<SelectivityVector> rowSets_;

--- a/velox/vector/LazyVector.h
+++ b/velox/vector/LazyVector.h
@@ -264,6 +264,10 @@ class LazyVector : public BaseVector {
 
   void validate(const VectorValidateOptions& options) const override;
 
+  VectorPtr copyPreserveEncodings() const override {
+    VELOX_UNSUPPORTED("copyPreserveEncodings not defined for LazyVector");
+  }
+
  private:
   static void ensureLoadedRowsImpl(
       const VectorPtr& vector,

--- a/velox/vector/SequenceVector.h
+++ b/velox/vector/SequenceVector.h
@@ -198,6 +198,20 @@ class SequenceVector : public SimpleVector<T> {
     return false;
   }
 
+  VectorPtr copyPreserveEncodings() const override {
+    return std::make_shared<SequenceVector<T>>(
+        BaseVector::pool_,
+        BaseVector::length_,
+        sequenceValues_->copyPreserveEncodings(),
+        AlignedBuffer::copy(BaseVector::pool_, sequenceLengths_),
+        SimpleVector<T>::stats_,
+        BaseVector::distinctValueCount_,
+        BaseVector::nullCount_,
+        SimpleVector<T>::isSorted_,
+        BaseVector::representedByteCount_,
+        BaseVector::storageByteCount_);
+  }
+
  private:
   // Prepares for use after construction.
   void setInternalState();

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_subdirectory(utils)
 
 add_executable(
   velox_vector_test
+  CopyPreserveEncodingsTest.cpp
   DecodedVectorTest.cpp
   EncodingTest.cpp
   EnsureWritableVectorTest.cpp

--- a/velox/vector/tests/CopyPreserveEncodingsTest.cpp
+++ b/velox/vector/tests/CopyPreserveEncodingsTest.cpp
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::test {
+
+class CopyPreserveEncodingsTest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_{
+      memory::memoryManager()->addLeafPool()};
+  VectorMaker vectorMaker_{pool_.get()};
+
+  enum class TestOptions {
+    WITH_NULLS,
+  };
+
+  std::vector<std::optional<int32_t>> generateIntInput() {
+    return generateIntInput(false);
+  }
+
+  std::vector<std::optional<int32_t>> generateIntInputWithNulls() {
+    return generateIntInput(true);
+  }
+
+  ArrayVectorPtr generateArrayVector(
+      const std::unordered_set<TestOptions>& testOptions = {}) {
+    std::function<bool(vector_size_t)> noNulls = nullptr;
+
+    return vectorMaker_.arrayVector<int32_t>(
+        10,
+        [](vector_size_t row) { return row; },
+        [](vector_size_t idx) { return idx; },
+        testOptions.count(TestOptions::WITH_NULLS) > 0
+            ? [](vector_size_t row) { return row % 5 == 0; }
+            : noNulls,
+        testOptions.count(TestOptions::WITH_NULLS) > 0
+            ? [](vector_size_t idx) { return idx % 7 == 0; }
+            : noNulls);
+  }
+
+  MapVectorPtr generateMapVector(
+      const std::unordered_set<TestOptions>& testOptions = {}) {
+    std::function<bool(vector_size_t)> noNulls = nullptr;
+
+    return vectorMaker_.mapVector<int32_t, int32_t>(
+        10,
+        [](vector_size_t row) { return row; },
+        [](vector_size_t idx) { return idx; },
+        [](vector_size_t idx) { return idx % 10; },
+        testOptions.count(TestOptions::WITH_NULLS) > 0
+            ? [&](vector_size_t row) { return row % 5 == 0; }
+            : noNulls,
+        testOptions.count(TestOptions::WITH_NULLS) > 0
+            ? [&](vector_size_t row) { return row % 7 == 0; }
+            : noNulls);
+  }
+
+  template <TypeKind kind>
+  void validateCopyPreserveEncodingsSimpleVector(
+      const VectorPtr& base,
+      const VectorPtr& copy) {
+    using T = typename TypeTraits<kind>::NativeType;
+
+    switch (base->encoding()) {
+      case VectorEncoding::Simple::BIASED: {
+        auto* baseBiased = base->as<BiasVector<T>>();
+        auto* copyBiased = copy->as<BiasVector<T>>();
+        ASSERT_NE(baseBiased->values(), copyBiased->values());
+        break;
+      }
+      case VectorEncoding::Simple::CONSTANT: {
+        auto* baseConstant = base->as<ConstantVector<T>>();
+        auto* copyConstant = copy->as<ConstantVector<T>>();
+        if (baseConstant->valueVector() != nullptr) {
+          validateCopyPreserveEncodings(
+              baseConstant->valueVector(), copyConstant->valueVector());
+        }
+        break;
+      }
+      case VectorEncoding::Simple::DICTIONARY: {
+        auto* baseDictionary = base->as<DictionaryVector<T>>();
+        auto* copyDictionary = copy->as<DictionaryVector<T>>();
+        validateCopyPreserveEncodings(
+            baseDictionary->valueVector(), copyDictionary->valueVector());
+        ASSERT_NE(baseDictionary->indices(), copyDictionary->indices());
+        break;
+      }
+      case VectorEncoding::Simple::FLAT: {
+        auto* baseFlat = base->as<FlatVector<T>>();
+        auto* copyFlat = copy->as<FlatVector<T>>();
+        ASSERT_NE(baseFlat->values(), copyFlat->values());
+        break;
+      }
+      case VectorEncoding::Simple::SEQUENCE: {
+        auto* baseSequence = base->as<SequenceVector<T>>();
+        auto* copySequence = copy->as<SequenceVector<T>>();
+        validateCopyPreserveEncodings(
+            baseSequence->valueVector(), copySequence->valueVector());
+        ASSERT_NE(
+            baseSequence->getSequenceLengths(),
+            copySequence->getSequenceLengths());
+        break;
+      }
+      default:
+        VELOX_FAIL(
+            "{} is not a supported SimpleVector encoding", base->encoding());
+    }
+  }
+
+  void validateCopyPreserveEncodings(
+      const VectorPtr& base,
+      const VectorPtr& copy) {
+    ASSERT_NE(base, copy);
+    ASSERT_EQ(base->encoding(), copy->encoding());
+
+    if (base->nulls() == nullptr) {
+      ASSERT_EQ(copy->nulls(), nullptr);
+    } else {
+      ASSERT_NE(base->nulls(), copy->nulls());
+    }
+
+    switch (base->encoding()) {
+      case VectorEncoding::Simple::ARRAY: {
+        auto* baseArray = base->as<ArrayVector>();
+        auto* copyArray = copy->as<ArrayVector>();
+        ASSERT_NE(baseArray->offsets(), copyArray->offsets());
+        ASSERT_NE(baseArray->sizes(), copyArray->sizes());
+        validateCopyPreserveEncodings(
+            baseArray->elements(), copyArray->elements());
+        break;
+      }
+      case VectorEncoding::Simple::ROW: {
+        auto* baseRow = base->as<RowVector>();
+        auto* copyRow = copy->as<RowVector>();
+        ASSERT_EQ(baseRow->childrenSize(), copyRow->childrenSize());
+        for (int i = 0; i < baseRow->childrenSize(); i++) {
+          validateCopyPreserveEncodings(
+              baseRow->childAt(i), copyRow->childAt(i));
+        }
+        break;
+      }
+      case VectorEncoding::Simple::MAP: {
+        auto* baseMap = base->as<MapVector>();
+        auto* copyMap = copy->as<MapVector>();
+        ASSERT_NE(baseMap->offsets(), copyMap->offsets());
+        ASSERT_NE(baseMap->sizes(), copyMap->sizes());
+        validateCopyPreserveEncodings(baseMap->mapKeys(), copyMap->mapKeys());
+        validateCopyPreserveEncodings(
+            baseMap->mapValues(), copyMap->mapValues());
+        break;
+      }
+      case VectorEncoding::Simple::BIASED:
+      case VectorEncoding::Simple::CONSTANT:
+      case VectorEncoding::Simple::DICTIONARY:
+      case VectorEncoding::Simple::FLAT:
+      case VectorEncoding::Simple::SEQUENCE:
+        VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+            validateCopyPreserveEncodingsSimpleVector,
+            base->typeKind(),
+            base,
+            copy);
+        break;
+      default:
+        VELOX_FAIL("{} is not a supported encoding", base->encoding());
+    }
+  }
+
+ private:
+  std::vector<std::optional<int32_t>> generateIntInput(bool withNulls) {
+    std::vector<std::optional<int32_t>> input;
+    for (int32_t i = 0; i < 10; ++i) {
+      if (withNulls && i % 5 == 0) {
+        input.push_back(std::nullopt);
+      } else {
+        input.push_back(i);
+      }
+    }
+
+    return input;
+  }
+};
+
+TEST_F(CopyPreserveEncodingsTest, biasHasNulls) {
+  auto biasVector = vectorMaker_.biasVector(generateIntInputWithNulls());
+  auto copy = biasVector->copyPreserveEncodings();
+
+  assertEqualVectors(biasVector, copy);
+  validateCopyPreserveEncodings(biasVector, copy);
+}
+
+TEST_F(CopyPreserveEncodingsTest, biasNoNulls) {
+  auto biasVector = vectorMaker_.biasVector(generateIntInput());
+  auto copy = biasVector->copyPreserveEncodings();
+
+  assertEqualVectors(biasVector, copy);
+  validateCopyPreserveEncodings(biasVector, copy);
+}
+
+TEST_F(CopyPreserveEncodingsTest, arrayHasNulls) {
+  auto arrayVector = generateArrayVector({TestOptions::WITH_NULLS});
+  auto copy = arrayVector->copyPreserveEncodings();
+
+  assertEqualVectors(arrayVector, copy);
+  validateCopyPreserveEncodings(arrayVector, copy);
+}
+
+TEST_F(CopyPreserveEncodingsTest, arrayNoNulls) {
+  auto arrayVector = generateArrayVector();
+  auto copy = arrayVector->copyPreserveEncodings();
+
+  assertEqualVectors(arrayVector, copy);
+  validateCopyPreserveEncodings(arrayVector, copy);
+}
+
+TEST_F(CopyPreserveEncodingsTest, mapHasNulls) {
+  auto mapVector = generateMapVector({TestOptions::WITH_NULLS});
+  auto copy = mapVector->copyPreserveEncodings();
+
+  assertEqualVectors(mapVector, copy);
+  validateCopyPreserveEncodings(mapVector, copy);
+}
+
+TEST_F(CopyPreserveEncodingsTest, mapNoNulls) {
+  auto mapVector = generateMapVector();
+  auto copy = mapVector->copyPreserveEncodings();
+
+  assertEqualVectors(mapVector, copy);
+  validateCopyPreserveEncodings(mapVector, copy);
+}
+
+TEST_F(CopyPreserveEncodingsTest, rowHasNulls) {
+  auto rowVector = vectorMaker_.rowVector(
+      {vectorMaker_.flatVectorNullable(generateIntInput()),
+       generateArrayVector(),
+       generateMapVector()});
+
+  rowVector->setNull(3, true);
+  auto copy = rowVector->copyPreserveEncodings();
+
+  assertEqualVectors(rowVector, copy);
+  validateCopyPreserveEncodings(rowVector, copy);
+}
+
+TEST_F(CopyPreserveEncodingsTest, rowNoNulls) {
+  auto rowVector = vectorMaker_.rowVector(
+      {vectorMaker_.flatVectorNullable(generateIntInput()),
+       generateArrayVector(),
+       generateMapVector()});
+  auto copy = rowVector->copyPreserveEncodings();
+
+  assertEqualVectors(rowVector, copy);
+  validateCopyPreserveEncodings(rowVector, copy);
+}
+
+TEST_F(CopyPreserveEncodingsTest, constantNull) {
+  auto constantVector = vectorMaker_.constantVector<int32_t>({std::nullopt});
+  auto copy = constantVector->copyPreserveEncodings();
+
+  assertEqualVectors(constantVector, copy);
+  validateCopyPreserveEncodings(constantVector, copy);
+}
+
+TEST_F(CopyPreserveEncodingsTest, constantNoNulls) {
+  auto constantVector = vectorMaker_.constantVector<int32_t>({1});
+  auto copy = constantVector->copyPreserveEncodings();
+
+  assertEqualVectors(constantVector, copy);
+  validateCopyPreserveEncodings(constantVector, copy);
+}
+
+TEST_F(CopyPreserveEncodingsTest, dictionaryHasNulls) {
+  auto dictionaryVector =
+      vectorMaker_.dictionaryVector(generateIntInputWithNulls());
+  auto copy = dictionaryVector->copyPreserveEncodings();
+
+  assertEqualVectors(dictionaryVector, copy);
+  validateCopyPreserveEncodings(dictionaryVector, copy);
+}
+
+TEST_F(CopyPreserveEncodingsTest, dictionaryNoNulls) {
+  auto dictionaryVector = vectorMaker_.dictionaryVector(generateIntInput());
+  auto copy = dictionaryVector->copyPreserveEncodings();
+
+  assertEqualVectors(dictionaryVector, copy);
+  validateCopyPreserveEncodings(dictionaryVector, copy);
+}
+
+TEST_F(CopyPreserveEncodingsTest, flatHasNulls) {
+  auto flatVector =
+      vectorMaker_.flatVectorNullable(generateIntInputWithNulls());
+  auto copy = flatVector->copyPreserveEncodings();
+
+  assertEqualVectors(flatVector, copy);
+  validateCopyPreserveEncodings(flatVector, copy);
+}
+
+TEST_F(CopyPreserveEncodingsTest, flatNoNulls) {
+  auto flatVector = vectorMaker_.flatVectorNullable(generateIntInput());
+  auto copy = flatVector->copyPreserveEncodings();
+
+  assertEqualVectors(flatVector, copy);
+  validateCopyPreserveEncodings(flatVector, copy);
+}
+
+TEST_F(CopyPreserveEncodingsTest, lazyNoNulls) {
+  auto lazyVector = vectorMaker_.lazyFlatVector<int32_t>(
+      10, [](vector_size_t row) { return row; });
+
+  VELOX_ASSERT_THROW(
+      lazyVector->copyPreserveEncodings(),
+      "copyPreserveEncodings not defined for LazyVector");
+}
+
+TEST_F(CopyPreserveEncodingsTest, sequenceHasNulls) {
+  auto sequenceVector =
+      vectorMaker_.sequenceVector(generateIntInputWithNulls());
+  auto copy = sequenceVector->copyPreserveEncodings();
+
+  assertEqualVectors(sequenceVector, copy);
+  validateCopyPreserveEncodings(sequenceVector, copy);
+}
+
+TEST_F(CopyPreserveEncodingsTest, sequenceNoNulls) {
+  auto sequenceVector = vectorMaker_.sequenceVector(generateIntInput());
+  auto copy = sequenceVector->copyPreserveEncodings();
+
+  assertEqualVectors(sequenceVector, copy);
+  validateCopyPreserveEncodings(sequenceVector, copy);
+}
+} // namespace facebook::velox::test


### PR DESCRIPTION
Summary:
The Values Operator takes a std::vector of RowVectors and simply returns them, it's usually used as a source in test queries.

The std::vector of RowVectors comes from the Plan.  In tests where parallelizable is enabled (it's a test-only feature), there's 
a risk of concurrency issues because the std::vector is shared across Drivers running on multiple threads.

This change fixes the issue by making a deep copy of the RowVectors so that each thread so a unique copy.

I introduced a function copyPreserveEncodings() to BaseVector to do the copy to ensure that the encodings of the 
RowVectors' children are preserved during the copy.  This is to ensure the intentions of test authors are not violated by
silently flattening the Vectors.

This fixes several tests that are currently broken/flaky when run with TSAN, including:
* CovarianceAggregationTest/CovarianceAggregationTest.floatSomeNulls/9
* AssertQueryBuilderTest.concurrency
* ValuesTest.valuesWithRepeatAndParallelism

Differential Revision: D55147065


