### PR TITLE
Fix findPeerOperators in group execution mode

### DIFF
--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -499,6 +499,10 @@ class Operator : public BaseRuntimeStatWriter {
     return operatorCtx_->operatorId();
   }
 
+  const uint32_t splitGroupId() const {
+    return operatorCtx_->driverCtx()->splitGroupId;
+  }
+
   /// Sets operator id. Use is limited to renumbering Operators from
   /// DriverAdapter. Do not use outside of this.
   void setOperatorIdFromAdapter(int32_t id) {

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1624,12 +1624,16 @@ std::vector<Operator*> Task::findPeerOperators(
   std::vector<Operator*> peers;
   const auto operatorId = caller->operatorId();
   const auto& operatorType = caller->operatorType();
+  const auto splitGroupId = caller->splitGroupId();
   std::lock_guard<std::timed_mutex> l(mutex_);
   for (auto& driver : drivers_) {
     if (driver == nullptr) {
       continue;
     }
     if (driver->driverCtx()->pipelineId != pipelineId) {
+      continue;
+    }
+    if (driver->driverCtx()->splitGroupId != splitGroupId) {
       continue;
     }
     Operator* peer = driver->findOperator(operatorId);

--- a/velox/exec/tests/GroupedExecutionTest.cpp
+++ b/velox/exec/tests/GroupedExecutionTest.cpp
@@ -292,25 +292,34 @@ DEBUG_ONLY_TEST_F(
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, vectors);
 
+  const int numDriversPerGroup{3};
+
   struct {
     bool enableSpill;
     bool mixedExecutionMode;
+    int groupConcurrency;
     int expectedNumDrivers;
     bool expectedSpill;
 
     std::string debugString() const {
       return fmt::format(
-          "enableSpill {}, mixedExecutionMode {}, expectedNumDrivers {}, expectedSpill {}",
+          "enableSpill {}, mixedExecutionMode {}, groupConcurrency {}, expectedNumDrivers {}, expectedSpill {}",
           enableSpill,
           mixedExecutionMode,
+          groupConcurrency,
           expectedNumDrivers,
+          groupConcurrency,
           expectedSpill);
     }
   } testSettings[] = {
-      {false, false, 12, false},
-      {false, true, 9, false},
-      {true, false, 12, true},
-      {true, true, 9, false}};
+      {false, false, 1, 12, false},
+      {false, true, 1, 9, false},
+      {true, false, 1, 12, true},
+      {true, true, 1, 9, false},
+      {false, false, 2, 12, false},
+      {false, true, 2, 9, false},
+      {true, false, 2, 12, true},
+      {true, true, 2, 9, false}};
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
@@ -358,9 +367,30 @@ DEBUG_ONLY_TEST_F(
     SCOPED_TESTVALUE_SET(
         "facebook::velox::exec::Driver::runInternal::noMoreInput",
         std::function<void(Operator*)>([&](Operator* op) {
+          if (op->operatorType() == "HashProbe") {
+            ASSERT_NE(op->splitGroupId(), kUngroupedGroupId);
+            const int pipelineId =
+                op->testingOperatorCtx()->driverCtx()->pipelineId;
+            const auto peerOps =
+                op->testingOperatorCtx()->task()->findPeerOperators(
+                    pipelineId, op);
+            ASSERT_LE(peerOps.size(), numDriversPerGroup);
+          }
           if (op->operatorType() != "HashBuild") {
             return;
           }
+          if (testData.mixedExecutionMode) {
+            ASSERT_EQ(op->splitGroupId(), kUngroupedGroupId);
+          } else {
+            ASSERT_NE(op->splitGroupId(), kUngroupedGroupId);
+          }
+          const int pipelineId =
+              op->testingOperatorCtx()->driverCtx()->pipelineId;
+          const auto peerOps =
+              op->testingOperatorCtx()->task()->findPeerOperators(
+                  pipelineId, op);
+          ASSERT_LE(peerOps.size(), numDriversPerGroup);
+
           ASSERT_EQ(op->canReclaim(), testData.expectedSpill);
           if (testData.enableSpill) {
             memory::testingRunArbitration(op->pool());
@@ -374,9 +404,8 @@ DEBUG_ONLY_TEST_F(
       task->setSpillDirectory(spillDirectory->path);
     }
 
-    // 3 drivers max and 1 concurrent split group to execute one group at a
-    // time.
-    task->start(3, 1);
+    // 'numDriversPerGroup' drivers max to execute one group at a time.
+    task->start(numDriversPerGroup, testData.groupConcurrency);
     ASSERT_EQ(task->hasMixedExecutionGroup(), testData.mixedExecutionMode);
 
     // Add split(s) to the build scan.


### PR DESCRIPTION
In group execution mode, findPeerOperators need to only look for operators
within the same group