### PR TITLE
Force disable fetch zlib when compiling cpr

### DIFF
--- a/CMake/resolve_dependency_modules/cpr.cmake
+++ b/CMake/resolve_dependency_modules/cpr.cmake
@@ -36,7 +36,7 @@ FetchContent_Declare(
     git apply ${CMAKE_CURRENT_LIST_DIR}/cpr/cpr-libcurl-compatible.patch && git
     apply ${CMAKE_CURRENT_LIST_DIR}/cpr/cpr-remove-sancheck.patch)
 set(BUILD_SHARED_LIBS OFF)
-set(CPR_USE_SYSTEM_CURL ON)
+set(CPR_USE_SYSTEM_CURL OFF)
 # ZLIB has already been found by find_package(ZLIB, REQUIRED), set CURL_ZLIB=OFF
 # to save compile time.
 SET(CURL_ZLIB OFF CACHE STRING "" FORCE)

--- a/CMake/resolve_dependency_modules/cpr.cmake
+++ b/CMake/resolve_dependency_modules/cpr.cmake
@@ -36,10 +36,10 @@ FetchContent_Declare(
     git apply ${CMAKE_CURRENT_LIST_DIR}/cpr/cpr-libcurl-compatible.patch && git
     apply ${CMAKE_CURRENT_LIST_DIR}/cpr/cpr-remove-sancheck.patch)
 set(BUILD_SHARED_LIBS OFF)
-set(CPR_USE_SYSTEM_CURL OFF)
+set(CPR_USE_SYSTEM_CURL ON)
 # ZLIB has already been found by find_package(ZLIB, REQUIRED), set CURL_ZLIB=OFF
 # to save compile time.
-set(CURL_ZLIB OFF)
+SET(CURL_ZLIB OFF CACHE STRING "" FORCE)
 FetchContent_MakeAvailable(cpr)
 # libcpr in its CMakeLists.txt file disables the BUILD_TESTING globally when
 # CPR_USE_SYSTEM_CURL=OFF. unset BUILD_TESTING here.

--- a/CMake/resolve_dependency_modules/cpr.cmake
+++ b/CMake/resolve_dependency_modules/cpr.cmake
@@ -39,7 +39,7 @@ set(BUILD_SHARED_LIBS OFF)
 set(CPR_USE_SYSTEM_CURL OFF)
 # ZLIB has already been found by find_package(ZLIB, REQUIRED), set CURL_ZLIB=OFF
 # to save compile time.
-SET(CURL_ZLIB OFF CACHE STRING "" FORCE)
+set(CURL_ZLIB OFF CACHE STRING "" FORCE)
 FetchContent_MakeAvailable(cpr)
 # libcpr in its CMakeLists.txt file disables the BUILD_TESTING globally when
 # CPR_USE_SYSTEM_CURL=OFF. unset BUILD_TESTING here.


### PR DESCRIPTION
The suggestions of disable fetching zlib from cpr master branch has a little bit difference compared with cpr 1.10.5 branch, which leads to situations that zlib still be fetched.

After checking original PR, 1.10.5 branch is right, let's fix it and saving compile time.
cpr master branch: https://github.com/libcpr/cpr/blob/1ad1cd2daf138aefdcdb1c35d99608387d230ec1/CMakeLists.txt#L202-L209
cpr 1.10.5 branch: https://github.com/libcpr/cpr/blob/3b15fa82ea74739b574d705fea44959b58142eb8/CMakeLists.txt#L207-L215