### PR TITLE
Do not fail getData for deleted buffer

### DIFF
--- a/velox/exec/OutputBuffer.cpp
+++ b/velox/exec/OutputBuffer.cpp
@@ -724,15 +724,17 @@ void OutputBuffer::getData(
 
     VELOX_CHECK_LT(destination, buffers_.size());
     auto* buffer = buffers_[destination].get();
-    VELOX_CHECK_NOT_NULL(
-        buffer,
-        "getData received after its buffer is deleted. Destination: {}, sequence: {}",
-        destination,
-        sequence);
-    freed = buffer->acknowledge(sequence, true);
-    updateAfterAcknowledgeLocked(freed, promises);
-    data = buffer->getData(
-        maxBytes, sequence, notify, activeCheck, arbitraryBuffer_.get());
+    if (buffer) {
+      freed = buffer->acknowledge(sequence, true);
+      updateAfterAcknowledgeLocked(freed, promises);
+      data = buffer->getData(
+          maxBytes, sequence, notify, activeCheck, arbitraryBuffer_.get());
+    } else {
+      data.data.emplace_back(nullptr);
+      data.immediate = true;
+      VLOG(1) << "getData received after deleteResults for destination "
+              << destination << " and sequence " << sequence;
+    }
   }
   releaseAfterAcknowledge(freed, promises);
   if (data.immediate) {

--- a/velox/exec/OutputBuffer.h
+++ b/velox/exec/OutputBuffer.h
@@ -293,9 +293,10 @@ class OutputBuffer {
 
   void acknowledge(int destination, int64_t sequence);
 
-  /// Deletes all data for 'destination'. Returns true if all destinations are
-  /// deleted, meaning that the buffer is fully consumed and the producer can be
-  /// marked finished and the buffers freed.
+  /// Deletes all buffered data and makes all subsequent getData requests
+  /// for 'destination' return empty results. Returns true if all destinations
+  /// are deleted, meaning that the buffer is fully consumed and the producer
+  /// can be marked finished and the buffers freed.
   bool deleteResults(int destination);
 
   void getData(

--- a/velox/exec/OutputBufferManager.h
+++ b/velox/exec/OutputBufferManager.h
@@ -77,15 +77,17 @@ class OutputBufferManager {
   /// The sequence number of the data must be >= 'sequence'. If there is no
   /// buffer associated with the given taskId, returns false. If there is no
   /// data, 'notify' will be registered and called when there is data or the
-  /// source is at end, the function returns true. Existing data with a sequence
-  /// number < sequence is deleted. The caller is expected to increment the
-  /// sequence number between calls by the number of items received. In this way
-  /// the next call implicitly acknowledges receipt of the results from the
-  /// previous. The acknowledge method is offered for an early ack, so that the
-  /// producer can continue before the consumer is done processing the received
-  /// data. If not null, 'activeCheck' is used to check if data consumer is
-  /// currently active or not. This only applies for arbitrary output buffer for
-  /// now.
+  /// source is at end, the function returns true. If deleteResults was
+  /// previously called for the destination, 'notify' will be called immediately
+  /// with a list of pages containing a single "end of data" marker. Existing
+  /// data with a sequence number < sequence is deleted. The caller is expected
+  /// to increment the sequence number between calls by the number of items
+  /// received. In this way the next call implicitly acknowledges receipt of the
+  /// results from the previous. The acknowledge method is offered for an early
+  /// ack, so that the producer can continue before the consumer is done
+  /// processing the received data. If not null, 'activeCheck' is used to check
+  /// if data consumer is currently active or not. This only applies for
+  /// arbitrary output buffer for now.
   bool getData(
       const std::string& taskId,
       int destination,


### PR DESCRIPTION
Sometimes requests can arrive out of order. When a `getData` arrives after a buffer is closed it may cause an unwanted failure.

Fixes https://github.com/prestodb/presto/issues/22129
