### PR TITLE
Remove row vector encoding check for ApproxPercentile's intermediate input

### DIFF
--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
@@ -647,7 +647,18 @@ class ApproxPercentileAggregate : public exec::Aggregate {
     VELOX_CHECK_EQ(args.size(), 1);
     DecodedVector decoded(*args[0], rows);
     auto rowVec = decoded.base()->as<RowVector>();
-    VELOX_CHECK(rowVec);
+    if constexpr (checkIntermediateInputs) {
+      VELOX_USER_CHECK(rowVec);
+      for (int i = kK; i <= kMaxValue; ++i) {
+        VELOX_USER_CHECK(rowVec->childAt(i)->isFlatEncoding());
+      }
+      for (int i = kItems; i <= kLevels; ++i) {
+        VELOX_USER_CHECK(
+            rowVec->childAt(i)->encoding() == VectorEncoding::Simple::ARRAY);
+      }
+    } else {
+      VELOX_CHECK(rowVec);
+    }
 
     const SelectivityVector* baseRows = &rows;
     SelectivityVector innerRows{rowVec->size(), false};

--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
@@ -647,21 +647,7 @@ class ApproxPercentileAggregate : public exec::Aggregate {
     VELOX_CHECK_EQ(args.size(), 1);
     DecodedVector decoded(*args[0], rows);
     auto rowVec = decoded.base()->as<RowVector>();
-    if constexpr (checkIntermediateInputs) {
-      VELOX_USER_CHECK(rowVec);
-      for (int i = kPercentiles; i <= kAccuracy; ++i) {
-        VELOX_USER_CHECK(rowVec->childAt(i)->isConstantEncoding());
-      }
-      for (int i = kK; i <= kMaxValue; ++i) {
-        VELOX_USER_CHECK(rowVec->childAt(i)->isFlatEncoding());
-      }
-      for (int i = kItems; i <= kLevels; ++i) {
-        VELOX_USER_CHECK(
-            rowVec->childAt(i)->encoding() == VectorEncoding::Simple::ARRAY);
-      }
-    } else {
-      VELOX_CHECK(rowVec);
-    }
+    VELOX_CHECK(rowVec);
 
     const SelectivityVector* baseRows = &rows;
     SelectivityVector innerRows{rowVec->size(), false};


### PR DESCRIPTION
The row vector's encoding for intermediate input can't be guaranteed, since for Spark (with Gluten), the partial agg's result vector maybe flattened in Gluten's Exchange Operator when doing shuffle partition split. Prestissimo may also have the same issue.  More details can be found at the discussion https://github.com/facebookincubator/velox/pull/6661#discussion_r1532300534