### PR TITLE
Move scalar function metadata to the registry

### DIFF
--- a/velox/core/SimpleFunctionMetadata.h
+++ b/velox/core/SimpleFunctionMetadata.h
@@ -385,6 +385,7 @@ class ISimpleFunctionMetadata {
   virtual TypePtr tryResolveReturnType() const = 0;
   virtual std::string getName() const = 0;
   virtual bool isDeterministic() const = 0;
+  virtual bool defaultNullBehavior() const = 0;
   virtual uint32_t priority() const = 0;
   virtual const std::shared_ptr<exec::FunctionSignature> signature() const = 0;
   virtual const TypePtr& resultPhysicalType() const = 0;
@@ -456,6 +457,10 @@ class SimpleFunctionMetadata : public ISimpleFunctionMetadata {
     return udf_is_deterministic<Fun>();
   }
 
+  bool defaultNullBehavior() const final {
+    return defaultNullBehavior_;
+  }
+
   static constexpr bool isVariadic() {
     if constexpr (num_args == 0) {
       return false;
@@ -465,7 +470,9 @@ class SimpleFunctionMetadata : public ISimpleFunctionMetadata {
   }
 
   explicit SimpleFunctionMetadata(
-      const std::vector<exec::SignatureVariable>& constraints) {
+      bool defaultNullBehavior,
+      const std::vector<exec::SignatureVariable>& constraints)
+      : defaultNullBehavior_{defaultNullBehavior} {
     auto analysis = analyzeSignatureTypes(constraints);
 
     buildSignature(analysis);
@@ -601,6 +608,7 @@ class SimpleFunctionMetadata : public ISimpleFunctionMetadata {
     signature_ = builder.build();
   }
 
+  const bool defaultNullBehavior_;
   exec::FunctionSignaturePtr signature_;
   uint32_t priority_;
   TypePtr resultPhysicalType_;

--- a/velox/exec/AggregateCompanionAdapter.cpp
+++ b/velox/exec/AggregateCompanionAdapter.cpp
@@ -467,7 +467,9 @@ bool CompanionFunctionsRegistrar::registerExtractFunctionWithSuffix(
         CompanionSignatures::extractFunctionNameWithSuffix(originalName, type),
         extractSignatures,
         factory,
-        {},
+        exec::VectorFunctionMetadataBuilder()
+            .defaultNullBehavior(false)
+            .build(),
         overwrite);
   }
   return registered;
@@ -523,7 +525,7 @@ bool CompanionFunctionsRegistrar::registerExtractFunction(
       CompanionSignatures::extractFunctionName(originalName),
       extractSignatures,
       factory,
-      {},
+      exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
       overwrite);
 }
 

--- a/velox/exec/AggregateCompanionAdapter.h
+++ b/velox/exec/AggregateCompanionAdapter.h
@@ -134,10 +134,6 @@ struct AggregateCompanionAdapter {
     explicit ExtractFunction(std::unique_ptr<Aggregate> fn)
         : fn_{std::move(fn)} {}
 
-    bool isDefaultNullBehavior() const override {
-      return false;
-    }
-
     void apply(
         const SelectivityVector& rows,
         std::vector<VectorPtr>& args,

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -166,6 +166,7 @@ class Expr {
       TypePtr type,
       std::vector<std::shared_ptr<Expr>>&& inputs,
       std::shared_ptr<VectorFunction> vectorFunction,
+      VectorFunctionMetadata metadata,
       std::string name,
       bool trackCpuUsage);
 
@@ -364,8 +365,12 @@ class Expr {
       EvalCtx& context,
       VectorPtr& result) const;
 
-  auto& vectorFunction() const {
+  const std::shared_ptr<VectorFunction>& vectorFunction() const {
     return vectorFunction_;
+  }
+
+  const VectorFunctionMetadata& vectorFunctionMetadata() const {
+    return vectorFunctionMetadata_;
   }
 
   auto& inputValues() {
@@ -565,6 +570,7 @@ class Expr {
   const std::vector<std::shared_ptr<Expr>> inputs_;
   const std::string name_;
   const std::shared_ptr<VectorFunction> vectorFunction_;
+  const VectorFunctionMetadata vectorFunctionMetadata_;
   const bool specialForm_;
   const bool supportsFlatNoNullsFastPath_;
   const bool trackCpuUsage_;

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -412,7 +412,7 @@ ExprPtr compileRewrittenExpression(
             trackCpuUsage)) {
       result = specialForm;
     } else if (
-        auto func = getVectorFunction(
+        auto functionWithMetadata = getVectorFunctionWithMetadata(
             call->name(),
             inputTypes,
             getConstantInputs(compiledInputs),
@@ -420,7 +420,8 @@ ExprPtr compileRewrittenExpression(
       result = std::make_shared<Expr>(
           resultType,
           std::move(compiledInputs),
-          func,
+          functionWithMetadata->first,
+          functionWithMetadata->second,
           call->name(),
           trackCpuUsage);
     } else if (
@@ -434,12 +435,14 @@ ExprPtr compileRewrittenExpression(
           simpleFunctionEntry->type(),
           resultType,
           folly::join(", ", inputTypes));
+
       auto func = simpleFunctionEntry->createFunction()->createVectorFunction(
           inputTypes, getConstantInputs(compiledInputs), config);
       result = std::make_shared<Expr>(
           resultType,
           std::move(compiledInputs),
           std::move(func),
+          simpleFunctionEntry->metadata(),
           call->name(),
           trackCpuUsage);
     } else {

--- a/velox/expression/FunctionMetadata.h
+++ b/velox/expression/FunctionMetadata.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+namespace facebook::velox::exec {
+
+struct VectorFunctionMetadata {
+  /// Boolean indicating whether this function supports flattening, i.e.
+  /// converting a set of nested calls into a single call.
+  ///
+  ///     f(a, f(b, f(c, d))) => f(a, b, c, d).
+  ///
+  /// For example, concat(string,...), concat(array,...), map_concat(map,...)
+  /// Presto functions support flattening. Similarly, built-in special format
+  /// AND and OR also support flattening.
+  ///
+  /// A function that supports flattening must have a signature with variadic
+  /// arguments of the same type. The result type must be the same as input
+  /// type.
+  bool supportsFlattening{false};
+
+  /// True if the function is deterministic, e.g given same inputs always
+  /// returns same result.
+  bool deterministic{true};
+
+  /// True if null in any argument always produces null result.
+  /// In this case, 'rows' in VectorFunction::apply will point only to positions
+  /// for which all arguments are not null.
+  bool defaultNullBehavior{true};
+};
+
+class VectorFunctionMetadataBuilder {
+ public:
+  VectorFunctionMetadataBuilder& supportsFlattening(bool supportsFlattening) {
+    metadata_.supportsFlattening = supportsFlattening;
+    return *this;
+  }
+
+  VectorFunctionMetadataBuilder& deterministic(bool deterministic) {
+    metadata_.deterministic = deterministic;
+    return *this;
+  }
+
+  VectorFunctionMetadataBuilder& defaultNullBehavior(bool defaultNullBehavior) {
+    metadata_.defaultNullBehavior = defaultNullBehavior;
+    return *this;
+  }
+
+  const VectorFunctionMetadata& build() const {
+    return metadata_;
+  }
+
+ private:
+  VectorFunctionMetadata metadata_;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/expression/SimpleFunctionAdapter.h
+++ b/velox/expression/SimpleFunctionAdapter.h
@@ -421,14 +421,6 @@ class SimpleFunctionAdapter : public VectorFunction {
     return fn_->getCanonicalName();
   }
 
-  bool isDeterministic() const override {
-    return fn_->isDeterministic();
-  }
-
-  bool isDefaultNullBehavior() const override {
-    return fn_->is_default_null_behavior;
-  }
-
   bool supportsFlatNoNullsFastPath() const override {
     if (FUNC::can_produce_null_output) {
       return false;
@@ -904,6 +896,9 @@ class SimpleFunctionAdapterFactoryImpl : public SimpleFunctionAdapterFactory {
   using Metadata = typename UDFHolder::Metadata;
 
   explicit SimpleFunctionAdapterFactoryImpl() {}
+
+  static constexpr bool is_default_null_behavior =
+      UDFHolder::is_default_null_behavior;
 
   std::unique_ptr<VectorFunction> createVectorFunction(
       const std::vector<TypePtr>& inputTypes,

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -48,11 +48,6 @@ struct ErrorOnOddFunctionElseUnknown {
 class CastExprTest : public functions::test::CastBaseTest {
  protected:
   CastExprTest() {
-    exec::registerVectorFunction(
-        "testing_dictionary",
-        TestingDictionaryFunction::signatures(),
-        std::make_unique<TestingDictionaryFunction>());
-
     registerFunction<ErrorOnOddFunctionElseUnknown, UnknownValue, int32_t>(
         {"error_on_odd_else_unknown"});
   }
@@ -2383,10 +2378,6 @@ class TestingDictionaryToFewerRowsFunction : public exec::VectorFunction {
  public:
   TestingDictionaryToFewerRowsFunction() {}
 
-  bool isDefaultNullBehavior() const override {
-    return false;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -2429,7 +2420,8 @@ TEST_F(CastExprTest, dictionaryEncodedNestedInput) {
   exec::registerVectorFunction(
       "add_dict",
       TestingDictionaryToFewerRowsFunction::signatures(),
-      std::make_unique<TestingDictionaryToFewerRowsFunction>());
+      std::make_unique<TestingDictionaryToFewerRowsFunction>(),
+      exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build());
 
   auto elements = makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6});
   auto elementsInDict = BaseVector::wrapInDictionary(

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -829,10 +829,6 @@ namespace {
 // f(n) = n + rand() - non-deterministict function with a single argument
 class PlusRandomIntegerFunction : public exec::VectorFunction {
  public:
-  bool isDeterministic() const override {
-    return false;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -865,15 +861,20 @@ class PlusRandomIntegerFunction : public exec::VectorFunction {
                 .build()};
   }
 };
+
+void registerPlusRandomIntegerFunction() {
+  exec::registerVectorFunction(
+      "plus_random",
+      PlusRandomIntegerFunction::signatures(),
+      std::make_unique<PlusRandomIntegerFunction>(),
+      exec::VectorFunctionMetadataBuilder().deterministic(false).build());
+}
 } // namespace
 
 // Test evaluating single-argument non-deterministic vector function on
 // constant vector. The function must be called on each row, not just one.
 TEST_P(ParameterizedExprTest, nonDeterministicVectorFunctionOnConstantInput) {
-  exec::registerVectorFunction(
-      "plus_random",
-      PlusRandomIntegerFunction::signatures(),
-      std::make_unique<PlusRandomIntegerFunction>());
+  registerPlusRandomIntegerFunction();
 
   const vector_size_t size = 1'000;
   auto row = makeRowVector({makeConstant(10, size)});
@@ -888,10 +889,7 @@ TEST_P(ParameterizedExprTest, nonDeterministicVectorFunctionOnConstantInput) {
 
 // Verify constant folding doesn't apply to non-deterministic functions.
 TEST_P(ParameterizedExprTest, nonDeterministicConstantFolding) {
-  exec::registerVectorFunction(
-      "plus_random",
-      PlusRandomIntegerFunction::signatures(),
-      std::make_unique<PlusRandomIntegerFunction>());
+  registerPlusRandomIntegerFunction();
 
   const vector_size_t size = 1'000;
   auto emptyRow = makeRowVector(ROW({}), size);
@@ -1822,10 +1820,6 @@ namespace {
 // Returns the first value of the argument vector wrapped as a constant.
 class TestingConstantFunction : public exec::VectorFunction {
  public:
-  bool isDefaultNullBehavior() const override {
-    return false;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -1850,10 +1844,6 @@ class TestingConstantFunction : public exec::VectorFunction {
 // vector and indices from the second.
 class TestingDictionaryFunction : public exec::VectorFunction {
  public:
-  bool isDefaultNullBehavior() const override {
-    return false;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -1904,14 +1894,17 @@ class TestingSingleArgDeterministicFunction : public exec::VectorFunction {
 };
 
 } // namespace
-VELOX_DECLARE_VECTOR_FUNCTION(
+
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_testing_constant,
     TestingConstantFunction::signatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<TestingConstantFunction>());
 
-VELOX_DECLARE_VECTOR_FUNCTION(
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_testing_dictionary,
     TestingDictionaryFunction::signatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<TestingDictionaryFunction>());
 
 VELOX_DECLARE_VECTOR_FUNCTION(
@@ -2781,10 +2774,6 @@ namespace {
 // A naive function that wraps the input in a dictionary vector.
 class WrapInDictionaryFunc : public exec::VectorFunction {
  public:
-  bool isDefaultNullBehavior() const override {
-    return true;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -2810,10 +2799,6 @@ class WrapInDictionaryFunc : public exec::VectorFunction {
 
 class LastRowNullFunc : public exec::VectorFunction {
  public:
-  bool isDefaultNullBehavior() const override {
-    return false;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -2841,11 +2826,15 @@ TEST_P(ParameterizedExprTest, dictionaryResizedInAddNulls) {
   exec::registerVectorFunction(
       "dict_wrap",
       WrapInDictionaryFunc::signatures(),
-      std::make_unique<WrapInDictionaryFunc>());
+      std::make_unique<WrapInDictionaryFunc>(),
+      exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build());
+
   exec::registerVectorFunction(
       "last_row_null",
       LastRowNullFunc::signatures(),
-      std::make_unique<LastRowNullFunc>());
+      std::make_unique<LastRowNullFunc>(),
+      exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build());
+
   // This test verifies an edge case where applyFunctionWithPeeling may produce
   // a result vector which is dictionary encoded and has fewer values than
   // are rows.

--- a/velox/expression/tests/TryExprTest.cpp
+++ b/velox/expression/tests/TryExprTest.cpp
@@ -220,10 +220,6 @@ class CreateConstantAndThrow : public exec::VectorFunction {
   CreateConstantAndThrow(bool throwOnFirstRow = false)
       : throwOnFirstRow_{throwOnFirstRow} {}
 
-  bool isDefaultNullBehavior() const override {
-    return true;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& /* args */,

--- a/velox/functions/FunctionRegistry.cpp
+++ b/velox/functions/FunctionRegistry.cpp
@@ -70,7 +70,7 @@ void clearFunctionRegistry() {
       [](auto& functionMap) { functionMap.clear(); });
 }
 
-std::shared_ptr<const Type> resolveFunction(
+TypePtr resolveFunction(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes) {
   // Check if this is a simple function.
@@ -82,7 +82,7 @@ std::shared_ptr<const Type> resolveFunction(
   return resolveVectorFunction(functionName, argTypes);
 }
 
-std::shared_ptr<const Type> resolveFunctionOrCallableSpecialForm(
+TypePtr resolveFunctionOrCallableSpecialForm(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes) {
   if (auto returnType = resolveCallableSpecialForm(functionName, argTypes)) {
@@ -92,13 +92,13 @@ std::shared_ptr<const Type> resolveFunctionOrCallableSpecialForm(
   return resolveFunction(functionName, argTypes);
 }
 
-std::shared_ptr<const Type> resolveCallableSpecialForm(
+TypePtr resolveCallableSpecialForm(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes) {
   return exec::resolveTypeForSpecialForm(functionName, argTypes);
 }
 
-std::shared_ptr<const Type> resolveSimpleFunction(
+TypePtr resolveSimpleFunction(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes) {
   if (auto resolvedFunction =
@@ -109,10 +109,17 @@ std::shared_ptr<const Type> resolveSimpleFunction(
   return nullptr;
 }
 
-std::shared_ptr<const Type> resolveVectorFunction(
+TypePtr resolveVectorFunction(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes) {
   return exec::resolveVectorFunction(functionName, argTypes);
+}
+
+std::optional<std::pair<TypePtr, exec::VectorFunctionMetadata>>
+resolveVectorFunctionWithMetadata(
+    const std::string& functionName,
+    const std::vector<TypePtr>& argTypes) {
+  return exec::resolveVectorFunctionWithMetadata(functionName, argTypes);
 }
 
 } // namespace facebook::velox

--- a/velox/functions/FunctionRegistry.h
+++ b/velox/functions/FunctionRegistry.h
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 
+#include "velox/expression/FunctionMetadata.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/type/Type.h"
 
@@ -25,20 +26,21 @@ namespace facebook::velox {
 
 using FunctionSignatureMap = std::
     unordered_map<std::string, std::vector<const exec::FunctionSignature*>>;
+
 /// Returns a mapping of all Simple and Vector functions registered in Velox
 /// The mapping is function name -> list of function signatures
 FunctionSignatureMap getFunctionSignatures();
 
 /// Given a function name and argument types, returns
 /// the return type if function exists otherwise returns nullptr
-std::shared_ptr<const Type> resolveFunction(
+TypePtr resolveFunction(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes);
 
 /// Given a function name and argument types, returns the return type if the
 /// function exists or is a special form that supports type resolution (see
 /// resolveCallableSpecialForm), otherwise returns nullptr.
-std::shared_ptr<const Type> resolveFunctionOrCallableSpecialForm(
+TypePtr resolveFunctionOrCallableSpecialForm(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes);
 
@@ -50,22 +52,28 @@ std::shared_ptr<const Type> resolveFunctionOrCallableSpecialForm(
 /// or
 /// 2) their return types cannot be inferred from their argument types, e.g.
 ///    Cast.
-std::shared_ptr<const Type> resolveCallableSpecialForm(
+TypePtr resolveCallableSpecialForm(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes);
 
 /// Given name of simple function and argument types, returns
 /// the return type if function exists otherwise returns nullptr
-std::shared_ptr<const Type> resolveSimpleFunction(
+TypePtr resolveSimpleFunction(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes);
 
 /// Given name of vector function and argument types, returns
 /// the return type if function exists otherwise returns nullptr
-std::shared_ptr<const Type> resolveVectorFunction(
+TypePtr resolveVectorFunction(
+    const std::string& functionName,
+    const std::vector<TypePtr>& argTypes);
+
+std::optional<std::pair<TypePtr, exec::VectorFunctionMetadata>>
+resolveVectorFunctionWithMetadata(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes);
 
 /// Clears the function registry.
 void clearFunctionRegistry();
+
 } // namespace facebook::velox

--- a/velox/functions/lib/IsNull.cpp
+++ b/velox/functions/lib/IsNull.cpp
@@ -23,10 +23,6 @@ namespace {
 template <bool IsNotNULL>
 class IsNullFunction : public exec::VectorFunction {
  public:
-  bool isDefaultNullBehavior() const override {
-    return false;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -93,18 +89,20 @@ class IsNullFunction : public exec::VectorFunction {
 };
 } // namespace
 
-VELOX_DECLARE_VECTOR_FUNCTION(
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_is_null,
     IsNullFunction<false>::signatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<IsNullFunction</*IsNotNUll=*/false>>());
 
 void registerIsNullFunction(const std::string& name) {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_is_null, name);
 }
 
-VELOX_DECLARE_VECTOR_FUNCTION(
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_is_not_null,
     IsNullFunction<true>::signatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<IsNullFunction</*IsNotNUll=*/true>>());
 
 void registerIsNotNullFunction(const std::string& name) {

--- a/velox/functions/lib/MapConcat.cpp
+++ b/velox/functions/lib/MapConcat.cpp
@@ -25,10 +25,6 @@ namespace {
 template <bool EmptyForNull>
 class MapConcatFunction : public exec::VectorFunction {
  public:
-  bool isDefaultNullBehavior() const override {
-    return !EmptyForNull;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -183,6 +179,7 @@ void registerMapConcatEmptyNullsFunction(const std::string& name) {
   exec::registerVectorFunction(
       name,
       MapConcatFunction</*EmptyForNull=*/true>::signatures(),
-      std::make_unique<MapConcatFunction</*EmptyForNull=*/true>>());
+      std::make_unique<MapConcatFunction</*EmptyForNull=*/true>>(),
+      exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build());
 }
 } // namespace facebook::velox::functions

--- a/velox/functions/lib/Repeat.cpp
+++ b/velox/functions/lib/Repeat.cpp
@@ -28,11 +28,6 @@ class RepeatFunction : public exec::VectorFunction {
 
   static constexpr int32_t kMaxResultEntries = 10'000;
 
-  bool isDefaultNullBehavior() const override {
-    // repeat(null, n) returns an array of n nulls.
-    return false;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -197,6 +192,13 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> repeatSignatures() {
               .argumentType("T")
               .argumentType("integer")
               .build()};
+}
+
+exec::VectorFunctionMetadata repeatMetadata() {
+  // repeat(null, n) returns an array of n nulls.
+  return exec::VectorFunctionMetadataBuilder()
+      .defaultNullBehavior(false)
+      .build();
 }
 
 std::shared_ptr<exec::VectorFunction> makeRepeat(

--- a/velox/functions/lib/Repeat.h
+++ b/velox/functions/lib/Repeat.h
@@ -23,6 +23,8 @@ namespace facebook::velox::functions {
 
 std::vector<std::shared_ptr<exec::FunctionSignature>> repeatSignatures();
 
+exec::VectorFunctionMetadata repeatMetadata();
+
 // Does not allow negative count.
 std::shared_ptr<exec::VectorFunction> makeRepeat(
     const std::string& name,
@@ -34,4 +36,5 @@ std::shared_ptr<exec::VectorFunction> makeRepeatAllowNegativeCount(
     const std::string& name,
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& config);
+
 } // namespace facebook::velox::functions

--- a/velox/functions/lib/tests/RepeatTest.cpp
+++ b/velox/functions/lib/tests/RepeatTest.cpp
@@ -28,11 +28,15 @@ class RepeatTest : public functions::test::FunctionBaseTest {
   static void SetUpTestCase() {
     FunctionBaseTest::SetUpTestCase();
     exec::registerStatefulVectorFunction(
-        "repeat", functions::repeatSignatures(), functions::makeRepeat);
+        "repeat",
+        functions::repeatSignatures(),
+        functions::makeRepeat,
+        functions::repeatMetadata());
     exec::registerStatefulVectorFunction(
         "repeat_allow_negative_count",
         functions::repeatSignatures(),
-        functions::makeRepeatAllowNegativeCount);
+        functions::makeRepeatAllowNegativeCount,
+        functions::repeatMetadata());
   }
 
   void testExpression(

--- a/velox/functions/prestosql/ArrayAndMapMatch.cpp
+++ b/velox/functions/prestosql/ArrayAndMapMatch.cpp
@@ -36,16 +36,6 @@ class MatchFunction : public exec::VectorFunction {
   virtual const VectorPtr& lambdaArgument(
       const std::shared_ptr<TContainer>& flatContainer) const = 0;
 
-  bool isDefaultNullBehavior() const override {
-    // Match functions are null preserving for the array/map argument, but
-    // predicate expression may use other fields and may not preserve nulls in
-    // these.
-    //
-    // For example, all_match(array[1, 2, 3], x -> x > coalesce(a, 0)) should
-    // not return null when 'a' is null.
-    return false;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -309,44 +299,59 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> valuesSignatures() {
 
 } // namespace
 
-VELOX_DECLARE_VECTOR_FUNCTION(
+/// Match functions are null preserving for the array/map argument, but
+/// predicate expression may use other fields and may not preserve nulls in
+/// these.
+///
+/// For example, all_match(array[1, 2, 3], x -> x > coalesce(a, 0)) should
+/// not return null when 'a' is null.
+
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_all_match,
     signatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<AllMatchFunction>());
 
-VELOX_DECLARE_VECTOR_FUNCTION(
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_any_match,
     signatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<AnyMatchFunction>());
 
-VELOX_DECLARE_VECTOR_FUNCTION(
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_none_match,
     signatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<NoneMatchFunction>());
 
-VELOX_DECLARE_VECTOR_FUNCTION(
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_all_keys_match,
     keysSignatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<AllKeysMatchFunction>());
 
-VELOX_DECLARE_VECTOR_FUNCTION(
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_any_keys_match,
     keysSignatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<AnyKeysMatchFunction>());
 
-VELOX_DECLARE_VECTOR_FUNCTION(
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_no_keys_match,
     keysSignatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<NoKeysMatchFunction>());
 
-VELOX_DECLARE_VECTOR_FUNCTION(
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_any_values_match,
     valuesSignatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<AnyValuesMatchFunction>());
 
-VELOX_DECLARE_VECTOR_FUNCTION(
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_no_values_match,
     valuesSignatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<NoValuesMatchFunction>());
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/ArrayConstructor.cpp
+++ b/velox/functions/prestosql/ArrayConstructor.cpp
@@ -22,10 +22,6 @@ namespace {
 
 class ArrayConstructor : public exec::VectorFunction {
  public:
-  bool isDefaultNullBehavior() const override {
-    return false;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -147,9 +143,10 @@ class ArrayConstructor : public exec::VectorFunction {
 };
 } // namespace
 
-VELOX_DECLARE_VECTOR_FUNCTION(
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_array_constructor,
     ArrayConstructor::signatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<ArrayConstructor>());
 
 void registerArrayConstructor(const std::string& name) {

--- a/velox/functions/prestosql/ArrayShuffle.cpp
+++ b/velox/functions/prestosql/ArrayShuffle.cpp
@@ -40,10 +40,6 @@ namespace {
 //
 class ArrayShuffleFunction : public exec::VectorFunction {
  public:
-  bool isDeterministic() const override {
-    return false;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -119,8 +115,9 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
 } // namespace
 
 // Register function.
-VELOX_DECLARE_VECTOR_FUNCTION(
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_array_shuffle,
     signatures(),
+    exec::VectorFunctionMetadataBuilder().deterministic(false).build(),
     std::make_unique<ArrayShuffleFunction>());
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/FilterFunctions.cpp
+++ b/velox/functions/prestosql/FilterFunctions.cpp
@@ -24,15 +24,6 @@ namespace facebook::velox::functions {
 namespace {
 
 class FilterFunctionBase : public exec::VectorFunction {
- public:
-  bool isDefaultNullBehavior() const override {
-    // array_filter and map_filter are null preserving for the array and the
-    // map. But since an expr tree with a lambda depends on all named fields,
-    // including captures, a null in a capture does not automatically make a
-    // null result.
-    return false;
-  }
-
  protected:
   // Applies filter functions to elements of maps or arrays and returns the
   // number of elements that passed the filters. Stores the number of elements
@@ -242,14 +233,21 @@ class MapFilterFunction : public FilterFunctionBase {
 };
 } // namespace
 
-VELOX_DECLARE_VECTOR_FUNCTION(
+/// array_filter and map_filter are null preserving for the array and the
+/// map. But since an expr tree with a lambda depends on all named fields,
+/// including captures, a null in a capture does not automatically make a
+/// null result.
+
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_array_filter,
     ArrayFilterFunction::signatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<ArrayFilterFunction>());
 
-VELOX_DECLARE_VECTOR_FUNCTION(
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_map_filter,
     MapFilterFunction::signatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<MapFilterFunction>());
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/FindFirst.cpp
+++ b/velox/functions/prestosql/FindFirst.cpp
@@ -29,16 +29,6 @@ void recordInvalidStartIndex(vector_size_t row, exec::EvalCtx& context) {
 }
 
 class FindFirstFunctionBase : public exec::VectorFunction {
- public:
-  bool isDefaultNullBehavior() const override {
-    // find_first function is null preserving for the array argument, but
-    // predicate expression may use other fields and may not preserve nulls in
-    // these.
-    // For example: find_first(array[1, 2, 3], x -> x > coalesce(a, 0)) should
-    // not return null when 'a' is null.
-    return false;
-  }
-
  protected:
   ArrayVectorPtr prepareInputArray(
       const VectorPtr& input,
@@ -417,14 +407,22 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> indexSignatures() {
 
 } // namespace
 
-VELOX_DECLARE_VECTOR_FUNCTION(
+/// find_first function is null preserving for the array argument, but
+/// predicate expression may use other fields and may not preserve nulls in
+/// these.
+/// For example: find_first(array[1, 2, 3], x -> x > coalesce(a, 0)) should
+/// not return null when 'a' is null.
+
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_find_first,
     valueSignatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<FindFirstFunction>());
 
-VELOX_DECLARE_VECTOR_FUNCTION(
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_find_first_index,
     indexSignatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<FindFirstIndexFunction>());
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/MapZipWith.cpp
+++ b/velox/functions/prestosql/MapZipWith.cpp
@@ -78,14 +78,6 @@ struct MergeResults {
 // https://prestodb.io/docs/current/functions/map.html#map_zip_with
 class MapZipWithFunction : public exec::VectorFunction {
  public:
-  bool isDefaultNullBehavior() const override {
-    // map_zip_with is null preserving for the map, but since an
-    // expr tree with a lambda depends on all named fields, including
-    // captures, a null in a capture does not automatically make a
-    // null result.
-    return false;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -491,9 +483,15 @@ class MapZipWithFunction : public exec::VectorFunction {
 };
 } // namespace
 
-VELOX_DECLARE_VECTOR_FUNCTION(
+/// map_zip_with is null preserving for the map, but since an
+/// expr tree with a lambda depends on all named fields, including
+/// captures, a null in a capture does not automatically make a
+/// null result.
+
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_map_zip_with,
     MapZipWithFunction::signatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<MapZipWithFunction>());
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/Reduce.cpp
+++ b/velox/functions/prestosql/Reduce.cpp
@@ -84,14 +84,6 @@ bool toNthElementRows(
 /// https://prestodb.io/docs/current/functions/array.html#reduce
 class ReduceFunction : public exec::VectorFunction {
  public:
-  bool isDefaultNullBehavior() const override {
-    // reduce is null preserving for the array. But since an
-    // expr tree with a lambda depends on all named fields, including
-    // captures, a null in a capture does not automatically make a
-    // null result.
-    return false;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -240,9 +232,15 @@ class ReduceFunction : public exec::VectorFunction {
 };
 } // namespace
 
-VELOX_DECLARE_VECTOR_FUNCTION(
+/// reduce is null preserving for the array. But since an
+/// expr tree with a lambda depends on all named fields, including
+/// captures, a null in a capture does not automatically make a
+/// null result.
+
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_reduce,
     ReduceFunction::signatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<ReduceFunction>());
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/RowFunction.cpp
+++ b/velox/functions/prestosql/RowFunction.cpp
@@ -37,16 +37,13 @@ class RowFunction : public exec::VectorFunction {
         0 /*nullCount*/);
     context.moveOrCopyResult(row, rows, result);
   }
-
-  bool isDefaultNullBehavior() const override {
-    return false;
-  }
 };
 } // namespace
 
-VELOX_DECLARE_VECTOR_FUNCTION(
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_concat_row,
     std::vector<std::shared_ptr<exec::FunctionSignature>>{},
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<RowFunction>());
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/StringFunctions.cpp
+++ b/velox/functions/prestosql/StringFunctions.cpp
@@ -76,10 +76,6 @@ class UpperLowerTemplateFunction : public exec::VectorFunction {
   }
 
  public:
-  bool isDefaultNullBehavior() const override {
-    return true;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,

--- a/velox/functions/prestosql/Transform.cpp
+++ b/velox/functions/prestosql/Transform.cpp
@@ -25,14 +25,6 @@ namespace {
 // See documentation at https://prestodb.io/docs/current/functions/array.html
 class TransformFunction : public exec::VectorFunction {
  public:
-  bool isDefaultNullBehavior() const override {
-    // transform is null preserving for the array. But since an
-    // expr tree with a lambda depends on all named fields, including
-    // captures, a null in a capture does not automatically make a
-    // null result.
-    return false;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -105,9 +97,15 @@ class TransformFunction : public exec::VectorFunction {
 };
 } // namespace
 
-VELOX_DECLARE_VECTOR_FUNCTION(
+/// transform is null preserving for the array. But since an
+/// expr tree with a lambda depends on all named fields, including
+/// captures, a null in a capture does not automatically make a
+/// null result.
+
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_transform,
     TransformFunction::signatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<TransformFunction>());
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/TransformKeys.cpp
+++ b/velox/functions/prestosql/TransformKeys.cpp
@@ -26,14 +26,6 @@ namespace {
 // See documentation at https://prestodb.io/docs/current/functions/map.html
 class TransformKeysFunction : public exec::VectorFunction {
  public:
-  bool isDefaultNullBehavior() const override {
-    // transform_keys is null preserving for the map. But
-    // since an expr tree with a lambda depends on all named fields, including
-    // captures, a null in a capture does not automatically make a
-    // null result.
-    return false;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -139,9 +131,15 @@ class TransformKeysFunction : public exec::VectorFunction {
 };
 } // namespace
 
-VELOX_DECLARE_VECTOR_FUNCTION(
+/// transform_keys is null preserving for the map. But
+/// since an expr tree with a lambda depends on all named fields, including
+/// captures, a null in a capture does not automatically make a
+/// null result.
+
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_transform_keys,
     TransformKeysFunction::signatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<TransformKeysFunction>());
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/TransformValues.cpp
+++ b/velox/functions/prestosql/TransformValues.cpp
@@ -25,14 +25,6 @@ namespace {
 // See documentation at https://prestodb.io/docs/current/functions/map.html
 class TransformValuesFunction : public exec::VectorFunction {
  public:
-  bool isDefaultNullBehavior() const override {
-    // transform_values is null preserving for the map. But
-    // since an expr tree with a lambda depends on all named fields, including
-    // captures, a null in a capture does not automatically make a
-    // null result.
-    return false;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -107,9 +99,15 @@ class TransformValuesFunction : public exec::VectorFunction {
 };
 } // namespace
 
-VELOX_DECLARE_VECTOR_FUNCTION(
+/// transform_values is null preserving for the map. But
+/// since an expr tree with a lambda depends on all named fields, including
+/// captures, a null in a capture does not automatically make a
+/// null result.
+
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_transform_values,
     TransformValuesFunction::signatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<TransformValuesFunction>());
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/TypeOf.cpp
+++ b/velox/functions/prestosql/TypeOf.cpp
@@ -109,10 +109,6 @@ class TypeOfFunction : public exec::VectorFunction {
  public:
   TypeOfFunction(const TypePtr& type) : typeName_{typeName(type)} {}
 
-  bool isDefaultNullBehavior() const override {
-    return false;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -141,7 +137,7 @@ class TypeOfFunction : public exec::VectorFunction {
       return std::make_shared<TypeOfFunction>(inputArgs[0].type);
     } catch (...) {
       return std::make_shared<exec::AlwaysFailingVectorFunction>(
-          std::current_exception(), false /*defaultNullBehavior*/);
+          std::current_exception());
     }
   }
 
@@ -150,9 +146,10 @@ class TypeOfFunction : public exec::VectorFunction {
 };
 } // namespace
 
-VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
+VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION_WITH_METADATA(
     udf_typeof,
     TypeOfFunction::signatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     TypeOfFunction::create);
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/ZipWith.cpp
+++ b/velox/functions/prestosql/ZipWith.cpp
@@ -46,14 +46,6 @@ struct DecodedInputs {
 // https://prestodb.io/docs/current/functions/array.html#zip_with
 class ZipWithFunction : public exec::VectorFunction {
  public:
-  bool isDefaultNullBehavior() const override {
-    // zip_with is null preserving for the arrays, but since an
-    // expr tree with a lambda depends on all named fields, including
-    // captures, a null in a capture does not automatically make a
-    // null result.
-    return false;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -322,9 +314,15 @@ class ZipWithFunction : public exec::VectorFunction {
 };
 } // namespace
 
-VELOX_DECLARE_VECTOR_FUNCTION(
+/// zip_with is null preserving for the arrays, but since an
+/// expr tree with a lambda depends on all named fields, including
+/// captures, a null in a capture does not automatically make a
+/// null result.
+
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_zip_with,
     ZipWithFunction::signatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<ZipWithFunction>());
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -147,7 +147,7 @@ void registerArrayFunctions(const std::string& prefix) {
 
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_sum, prefix + "array_sum");
   exec::registerStatefulVectorFunction(
-      prefix + "repeat", repeatSignatures(), makeRepeat);
+      prefix + "repeat", repeatSignatures(), makeRepeat, repeatMetadata());
   VELOX_REGISTER_VECTOR_FUNCTION(udf_sequence, prefix + "sequence");
 
   exec::registerStatefulVectorFunction(

--- a/velox/functions/prestosql/tests/ArrayExceptTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayExceptTest.cpp
@@ -314,10 +314,7 @@ TEST_F(ArrayExceptTest, constant) {
 }
 
 TEST_F(ArrayExceptTest, dictionaryEncodedElementsInConstant) {
-  exec::registerVectorFunction(
-      "testing_dictionary_array_elements",
-      test::TestingDictionaryArrayElementsFunction::signatures(),
-      std::make_unique<test::TestingDictionaryArrayElementsFunction>());
+  TestingDictionaryArrayElementsFunction::registerFunction();
 
   auto array = makeArrayVector<int64_t>({{1, 3}, {2, 5}, {0, 6}});
   auto expected = makeArrayVector<int64_t>({{}, {5}, {6}});

--- a/velox/functions/prestosql/tests/ArraysOverlapTest.cpp
+++ b/velox/functions/prestosql/tests/ArraysOverlapTest.cpp
@@ -216,10 +216,7 @@ TEST_F(ArraysOverlapTest, constant) {
 }
 
 TEST_F(ArraysOverlapTest, dictionaryEncodedElementsInConstant) {
-  exec::registerVectorFunction(
-      "testing_dictionary_array_elements",
-      test::TestingDictionaryArrayElementsFunction::signatures(),
-      std::make_unique<test::TestingDictionaryArrayElementsFunction>());
+  TestingDictionaryArrayElementsFunction::registerFunction();
 
   auto array = makeArrayVector<int64_t>({{1, 3}, {2, 5}, {0, 6}});
   auto expected = makeNullableFlatVector<bool>({true, true, false});

--- a/velox/functions/prestosql/tests/CastBaseTest.h
+++ b/velox/functions/prestosql/tests/CastBaseTest.h
@@ -33,7 +33,10 @@ class CastBaseTest : public FunctionBaseTest {
     exec::registerVectorFunction(
         "testing_dictionary",
         test::TestingDictionaryFunction::signatures(),
-        std::make_unique<test::TestingDictionaryFunction>());
+        std::make_unique<test::TestingDictionaryFunction>(),
+        exec::VectorFunctionMetadataBuilder()
+            .defaultNullBehavior(false)
+            .build());
   }
 
   // Build an ITypedExpr for cast(fromType as toType).

--- a/velox/functions/remote/client/Remote.cpp
+++ b/velox/functions/remote/client/Remote.cpp
@@ -70,16 +70,6 @@ class RemoteFunction : public exec::VectorFunction {
     }
   }
 
-  // TODO: The values for these flags shold be obtained from the
-  // VectorFunctionMetadata object passed by clients.
-  bool isDeterministic() const override {
-    return true;
-  }
-
-  bool isDefaultNullBehavior() const override {
-    return true;
-  }
-
  private:
   void applyRemote(
       const SelectivityVector& rows,

--- a/velox/functions/sparksql/Comparisons.cpp
+++ b/velox/functions/sparksql/Comparisons.cpp
@@ -208,10 +208,6 @@ void applyTyped(
 
 class EqualtoNullSafe final : public exec::VectorFunction {
  public:
-  bool isDefaultNullBehavior() const override {
-    return false;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,

--- a/velox/functions/sparksql/Hash.cpp
+++ b/velox/functions/sparksql/Hash.cpp
@@ -183,10 +183,6 @@ class Murmur3HashFunction final : public exec::VectorFunction {
   Murmur3HashFunction() = default;
   explicit Murmur3HashFunction(int32_t seed) : seed_(seed) {}
 
-  bool isDefaultNullBehavior() const final {
-    return false;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args, // Not using const ref so we can reuse args
@@ -350,10 +346,6 @@ class XxHash64Function final : public exec::VectorFunction {
   XxHash64Function() = default;
   explicit XxHash64Function(int64_t seed) : seed_(seed) {}
 
-  bool isDefaultNullBehavior() const final {
-    return false;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args, // Not using const ref so we can reuse args
@@ -469,6 +461,12 @@ std::shared_ptr<exec::VectorFunction> makeXxHash64WithSeed(
   }
   auto seed = constantSeed->as<ConstantVector<int64_t>>()->valueAt(0);
   return std::make_shared<XxHash64Function>(seed);
+}
+
+exec::VectorFunctionMetadata hashMetadata() {
+  return exec::VectorFunctionMetadataBuilder()
+      .defaultNullBehavior(false)
+      .build();
 }
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Hash.h
+++ b/velox/functions/sparksql/Hash.h
@@ -76,4 +76,6 @@ std::shared_ptr<exec::VectorFunction> makeXxHash64WithSeed(
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& config);
 
+exec::VectorFunctionMetadata hashMetadata();
+
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/LeastGreatest.cpp
+++ b/velox/functions/sparksql/LeastGreatest.cpp
@@ -27,10 +27,6 @@ template <typename Cmp, TypeKind kind>
 class LeastGreatestFunction final : public exec::VectorFunction {
   using T = typename TypeTraits<kind>::NativeType;
 
-  bool isDefaultNullBehavior() const override {
-    return false;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,

--- a/velox/functions/sparksql/Map.cpp
+++ b/velox/functions/sparksql/Map.cpp
@@ -60,10 +60,6 @@ void setKeysAndValuesResult(
 
 class MapFunction : public exec::VectorFunction {
  public:
-  bool isDefaultNullBehavior() const override {
-    return false;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -139,8 +135,9 @@ class MapFunction : public exec::VectorFunction {
 };
 } // namespace
 
-VELOX_DECLARE_VECTOR_FUNCTION(
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_map,
     MapFunction::signatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<MapFunction>());
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -202,19 +202,29 @@ void registerFunctions(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_regexp_split, prefix + "split");
 
   exec::registerStatefulVectorFunction(
-      prefix + "least", leastSignatures(), makeLeast);
+      prefix + "least",
+      leastSignatures(),
+      makeLeast,
+      exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build());
   exec::registerStatefulVectorFunction(
-      prefix + "greatest", greatestSignatures(), makeGreatest);
+      prefix + "greatest",
+      greatestSignatures(),
+      makeGreatest,
+      exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build());
   exec::registerStatefulVectorFunction(
-      prefix + "hash", hashSignatures(), makeHash);
+      prefix + "hash", hashSignatures(), makeHash, hashMetadata());
   exec::registerStatefulVectorFunction(
-      prefix + "hash_with_seed", hashWithSeedSignatures(), makeHashWithSeed);
+      prefix + "hash_with_seed",
+      hashWithSeedSignatures(),
+      makeHashWithSeed,
+      hashMetadata());
   exec::registerStatefulVectorFunction(
-      prefix + "xxhash64", xxhash64Signatures(), makeXxHash64);
+      prefix + "xxhash64", xxhash64Signatures(), makeXxHash64, hashMetadata());
   exec::registerStatefulVectorFunction(
       prefix + "xxhash64_with_seed",
       xxhash64WithSeedSignatures(),
-      makeXxHash64WithSeed);
+      makeXxHash64WithSeed,
+      hashMetadata());
   VELOX_REGISTER_VECTOR_FUNCTION(udf_map, prefix + "map");
 
   // Register 'in' functions.
@@ -271,7 +281,8 @@ void registerFunctions(const std::string& prefix) {
   exec::registerStatefulVectorFunction(
       prefix + "array_repeat",
       repeatSignatures(),
-      makeRepeatAllowNegativeCount);
+      makeRepeatAllowNegativeCount,
+      repeatMetadata());
 
   // Register date functions.
   registerFunction<YearFunction, int32_t, Timestamp>({prefix + "year"});

--- a/velox/functions/sparksql/RegisterCompare.cpp
+++ b/velox/functions/sparksql/RegisterCompare.cpp
@@ -35,7 +35,10 @@ void registerCompareFunctions(const std::string& prefix) {
       makeGreaterThanOrEqual);
   // Compare nullsafe functions.
   exec::registerStatefulVectorFunction(
-      prefix + "equalnullsafe", comparisonSignatures(), makeEqualToNullSafe);
+      prefix + "equalnullsafe",
+      comparisonSignatures(),
+      makeEqualToNullSafe,
+      exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build());
   registerFunction<BetweenFunction, bool, int8_t, int8_t, int8_t>(
       {prefix + "between"});
   registerFunction<BetweenFunction, bool, int16_t, int16_t, int16_t>(

--- a/velox/functions/sparksql/specialforms/DecimalRound.cpp
+++ b/velox/functions/sparksql/specialforms/DecimalRound.cpp
@@ -242,6 +242,7 @@ exec::ExprPtr DecimalRoundCallToSpecialForm::constructSpecialForm(
       type,
       std::move(args),
       std::move(decimalRound),
+      exec::VectorFunctionMetadata{},
       kRoundDecimal,
       trackCpuUsage);
 }

--- a/velox/functions/sparksql/specialforms/MakeDecimal.cpp
+++ b/velox/functions/sparksql/specialforms/MakeDecimal.cpp
@@ -181,6 +181,7 @@ exec::ExprPtr MakeDecimalCallToSpecialForm::constructSpecialForm(
       type,
       std::move(args),
       createMakeDecimal(type, nullOnOverflow),
+      exec::VectorFunctionMetadata{},
       kMakeDecimal,
       trackCpuUsage);
 }

--- a/velox/functions/sparksql/tests/InTest.cpp
+++ b/velox/functions/sparksql/tests/InTest.cpp
@@ -31,10 +31,6 @@ constexpr double kNan = std::numeric_limits<double>::quiet_NaN();
 /// Wraps input in a dictionary that repeats first row.
 class TestingDictionaryFunction : public exec::VectorFunction {
  public:
-  bool isDefaultNullBehavior() const override {
-    return false;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -63,7 +59,10 @@ class InTest : public SparkFunctionBaseTest {
     exec::registerVectorFunction(
         "testing_dictionary",
         TestingDictionaryFunction::signatures(),
-        std::make_unique<TestingDictionaryFunction>());
+        std::make_unique<TestingDictionaryFunction>(),
+        exec::VectorFunctionMetadataBuilder()
+            .defaultNullBehavior(false)
+            .build());
   }
 
   template <typename T>

--- a/velox/functions/tests/FunctionRegistryTest.cpp
+++ b/velox/functions/tests/FunctionRegistryTest.cpp
@@ -171,11 +171,6 @@ class VectorFuncFour : public velox::exec::VectorFunction {
                 .argumentType("map(K,V)")
                 .build()};
   }
-
-  // Make it non-deterministic.
-  bool isDeterministic() const override {
-    return false;
-  }
 };
 
 VELOX_DECLARE_VECTOR_FUNCTION(
@@ -193,9 +188,10 @@ VELOX_DECLARE_VECTOR_FUNCTION(
     VectorFuncThree::signatures(),
     std::make_unique<VectorFuncThree>());
 
-VELOX_DECLARE_VECTOR_FUNCTION(
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_vector_func_four,
     VectorFuncFour::signatures(),
+    exec::VectorFunctionMetadataBuilder().deterministic(false).build(),
     std::make_unique<VectorFuncFour>());
 
 inline void registerTestFunctions() {

--- a/velox/vector/tests/TestingDictionaryArrayElementsFunction.h
+++ b/velox/vector/tests/TestingDictionaryArrayElementsFunction.h
@@ -26,8 +26,14 @@ class TestingDictionaryArrayElementsFunction : public exec::VectorFunction {
  public:
   TestingDictionaryArrayElementsFunction() {}
 
-  bool isDefaultNullBehavior() const override {
-    return false;
+  static void registerFunction() {
+    exec::registerVectorFunction(
+        "testing_dictionary_array_elements",
+        test::TestingDictionaryArrayElementsFunction::signatures(),
+        std::make_unique<test::TestingDictionaryArrayElementsFunction>(),
+        exec::VectorFunctionMetadataBuilder()
+            .defaultNullBehavior(false)
+            .build());
   }
 
   void apply(

--- a/velox/vector/tests/TestingDictionaryFunction.h
+++ b/velox/vector/tests/TestingDictionaryFunction.h
@@ -28,10 +28,6 @@ class TestingDictionaryFunction : public exec::VectorFunction {
   TestingDictionaryFunction(vector_size_t trailingNulls = 0)
       : trailingNulls_(trailingNulls) {}
 
-  bool isDefaultNullBehavior() const override {
-    return false;
-  }
-
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,


### PR DESCRIPTION
Move is-deterministic and default-null-behavior flags to the registry to allow
fetching these without instantiating an executable function.

Added two flags to the existing VectorFunctionMetadata struct. Removed VectorFunction::isDeterministic and VectorFunction::isDefaultNullBehavior APIs.

Extracted VectorFunctionMetadata from VectorFunction.h into FunctionMetadata.h.

Most of the changes are in non-deafult-null-behavior and non-deterministic
functions to remove isDefaultNullBehavior() and isDeterministic() methods and
update registration calls.

Material changes are in the following files:

```
velox/core/SimpleFunctionMetadata.h

velox/exec/AggregateCompanionAdapter.cpp
velox/exec/AggregateCompanionAdapter.h

velox/expression/Expr.cpp
velox/expression/Expr.h
velox/expression/ExprCompiler.cpp
velox/expression/FunctionMetadata.h
velox/expression/SimpleFunctionAdapter.h
velox/expression/SimpleFunctionRegistry.h
velox/expression/VectorFunction.cpp
velox/expression/VectorFunction.h

velox/expression/tests/ExpressionFuzzer.cpp
```