### PR TITLE
Consolidate SpillStats

### DIFF
--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -355,7 +355,7 @@ struct HiveWriterInfo {
       std::shared_ptr<memory::MemoryPool> _sortPool)
       : writerParameters(std::move(parameters)),
         nonReclaimableSectionHolder(new tsan_atomic<bool>(false)),
-        spillStats(new common::SpillStats()),
+        spillStats(std::make_unique<folly::Synchronized<common::SpillStats>>()),
         writerPool(std::move(_writerPool)),
         sinkPool(std::move(_sinkPool)),
         sortPool(std::move(_sortPool)) {}
@@ -364,7 +364,7 @@ struct HiveWriterInfo {
   const std::unique_ptr<tsan_atomic<bool>> nonReclaimableSectionHolder;
   /// Collects the spill stats from sort writer if the spilling has been
   /// triggered.
-  const std::unique_ptr<common::SpillStats> spillStats;
+  const std::unique_ptr<folly::Synchronized<common::SpillStats>> spillStats;
   const std::shared_ptr<memory::MemoryPool> writerPool;
   const std::shared_ptr<memory::MemoryPool> sinkPool;
   const std::shared_ptr<memory::MemoryPool> sortPool;

--- a/velox/dwio/common/SortingWriter.h
+++ b/velox/dwio/common/SortingWriter.h
@@ -29,8 +29,7 @@ class SortingWriter : public Writer {
       std::unique_ptr<Writer> writer,
       std::unique_ptr<exec::SortBuffer> sortBuffer,
       uint32_t maxOutputRowsConfig,
-      uint64_t maxOutputBytesConfig,
-      velox::common::SpillStats* spillStats);
+      uint64_t maxOutputBytesConfig);
 
   ~SortingWriter() override;
 
@@ -81,7 +80,6 @@ class SortingWriter : public Writer {
   const uint64_t maxOutputBytesConfig_;
   memory::MemoryPool* const sortPool_;
   const bool canReclaim_;
-  velox::common::SpillStats* const spillStats_;
 
   std::unique_ptr<exec::SortBuffer> sortBuffer_;
 };

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -40,7 +40,8 @@ class GroupingSet {
       const std::optional<column_index_t>& groupIdChannel,
       const common::SpillConfig* spillConfig,
       tsan_atomic<bool>* nonReclaimableSection,
-      OperatorCtx* operatorCtx);
+      OperatorCtx* operatorCtx,
+      folly::Synchronized<common::SpillStats>* spillStats);
 
   ~GroupingSet();
 
@@ -359,6 +360,8 @@ class GroupingSet {
   // Temporary for case where an aggregate in toIntermediate() outputs post-init
   // state of aggregate for all rows.
   std::vector<char*> firstGroup_;
+
+  folly::Synchronized<common::SpillStats>* const spillStats_;
 };
 
 } // namespace facebook::velox::exec

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -72,10 +72,6 @@ class HashAggregation : public Operator {
 
   RowVectorPtr getDistinctOutput();
 
-  // Invoked to record the spilling stats in operator stats after processing all
-  // the inputs.
-  void recordSpillStats();
-
   void updateEstimatedOutputRowSize();
 
   std::shared_ptr<const core::AggregationNode> aggregationNode_;

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -117,9 +117,6 @@ class HashBuild final : public Operator {
     return canReclaim();
   }
 
-  void recordSpillStats();
-  void recordSpillStats(Spiller* spiller);
-
   // Indicates if the input is read from spill data or not.
   bool isInputFromSpill() const;
 

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -220,8 +220,6 @@ class HashProbe : public Operator {
   // next hash table from the spilled data.
   void noMoreInputInternal();
 
-  void recordSpillStats();
-
   // Returns the index of the 'match' column in the output for semi project
   // joins.
   VectorPtr& matchColumn() const {

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -420,6 +420,7 @@ class Operator : public BaseRuntimeStatWriter {
   virtual void close() {
     input_ = nullptr;
     results_.clear();
+    recordSpillStats();
     // Release the unused memory reservation on close.
     operatorCtx_->pool()->release();
   }
@@ -690,7 +691,7 @@ class Operator : public BaseRuntimeStatWriter {
       std::optional<uint64_t> averageRowSize = std::nullopt) const;
 
   /// Invoked to record spill stats in operator stats.
-  void recordSpillStats(const common::SpillStats& spillStats);
+  virtual void recordSpillStats();
 
   const std::unique_ptr<OperatorCtx> operatorCtx_;
   const RowTypePtr outputType_;
@@ -701,6 +702,7 @@ class Operator : public BaseRuntimeStatWriter {
   bool initialized_{false};
 
   folly::Synchronized<OperatorStats> stats_;
+  folly::Synchronized<common::SpillStats> spillStats_;
 
   /// Indicates if an operator is under a non-reclaimable execution section.
   /// This prevents the memory arbitrator from reclaiming memory from this

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -65,7 +65,8 @@ OrderBy::OrderBy(
       sortCompareFlags,
       pool(),
       &nonReclaimableSection_,
-      spillConfig_.has_value() ? &(spillConfig_.value()) : nullptr);
+      spillConfig_.has_value() ? &(spillConfig_.value()) : nullptr,
+      &spillStats_);
 }
 
 void OrderBy::addInput(RowVectorPtr input) {
@@ -90,7 +91,6 @@ void OrderBy::noMoreInput() {
   Operator::noMoreInput();
   sortBuffer_->noMoreInput();
   maxOutputRows_ = outputBatchRows(sortBuffer_->estimateOutputRowSize());
-  recordSpillStats();
 }
 
 RowVectorPtr OrderBy::getOutput() {
@@ -106,13 +106,5 @@ RowVectorPtr OrderBy::getOutput() {
 void OrderBy::close() {
   Operator::close();
   sortBuffer_.reset();
-}
-
-void OrderBy::recordSpillStats() {
-  VELOX_CHECK_NOT_NULL(sortBuffer_);
-  auto spillStats = sortBuffer_->spilledStats();
-  if (spillStats.has_value()) {
-    Operator::recordSpillStats(spillStats.value());
-  }
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/OrderBy.h
+++ b/velox/exec/OrderBy.h
@@ -63,10 +63,6 @@ class OrderBy : public Operator {
   void close() override;
 
  private:
-  // Invoked to record the spilling stats in operator stats after processing all
-  // the inputs.
-  void recordSpillStats();
-
   std::unique_ptr<SortBuffer> sortBuffer_;
   bool finished_ = false;
   uint32_t maxOutputRows_;

--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -116,7 +116,6 @@ void RowNumber::noMoreInput() {
 
   if (inputSpiller_ != nullptr) {
     inputSpiller_->finishSpill(spillInputPartitionSet_);
-    recordSpillStats(inputSpiller_->stats());
     removeEmptyPartitions(spillInputPartitionSet_);
     restoreNextSpillPartition();
   }
@@ -390,11 +389,11 @@ SpillPartitionNumSet RowNumber::spillHashTable() {
       table_->rows(),
       tableType,
       spillPartitionBits_,
-      &spillConfig);
+      &spillConfig,
+      &spillStats_);
 
   hashTableSpiller->spill();
   hashTableSpiller->finishSpill(spillHashTablePartitionSet_);
-  recordSpillStats(hashTableSpiller->stats());
 
   table_->clear();
   pool()->release();
@@ -412,7 +411,8 @@ void RowNumber::setupInputSpiller(
       Spiller::Type::kHashJoinProbe,
       inputType_,
       spillPartitionBits_,
-      &spillConfig);
+      &spillConfig,
+      &spillStats_);
   inputSpiller_->setPartitionsSpilled(spillPartitionSet);
 
   const auto& hashers = table_->hashers();

--- a/velox/exec/SortBuffer.h
+++ b/velox/exec/SortBuffer.h
@@ -36,7 +36,8 @@ class SortBuffer {
       const std::vector<CompareFlags>& sortCompareFlags,
       velox::memory::MemoryPool* pool,
       tsan_atomic<bool>* nonReclaimableSection,
-      const common::SpillConfig* spillConfig = nullptr);
+      const common::SpillConfig* spillConfig = nullptr,
+      folly::Synchronized<velox::common::SpillStats>* spillStats = nullptr);
 
   void addInput(const VectorPtr& input);
 
@@ -59,14 +60,6 @@ class SortBuffer {
 
   memory::MemoryPool* pool() const {
     return pool_;
-  }
-
-  /// Returns the spiller stats including total bytes and rows spilled so far.
-  std::optional<common::SpillStats> spilledStats() const {
-    if (spiller_ == nullptr) {
-      return std::nullopt;
-    }
-    return spiller_->stats();
   }
 
   std::optional<uint64_t> estimateOutputRowSize() const;
@@ -95,6 +88,7 @@ class SortBuffer {
   // execution section or not.
   tsan_atomic<bool>* const nonReclaimableSection_;
   const common::SpillConfig* const spillConfig_;
+  folly::Synchronized<common::SpillStats>* const spillStats_;
 
   // The column projection map between 'input_' and 'spillerStoreType_' as sort
   // buffer stores the sort columns first in 'data_'.

--- a/velox/exec/SortWindowBuild.h
+++ b/velox/exec/SortWindowBuild.h
@@ -30,7 +30,8 @@ class SortWindowBuild : public WindowBuild {
       const std::shared_ptr<const core::WindowNode>& node,
       velox::memory::MemoryPool* pool,
       const common::SpillConfig* spillConfig,
-      tsan_atomic<bool>* nonReclaimableSection);
+      tsan_atomic<bool>* nonReclaimableSection,
+      folly::Synchronized<common::SpillStats>* spillStats);
 
   bool needsInput() override {
     // No partitions are available yet, so can consume input rows.
@@ -85,6 +86,7 @@ class SortWindowBuild : public WindowBuild {
   const std::vector<CompareFlags> spillCompareFlags_;
 
   memory::MemoryPool* const pool_;
+  folly::Synchronized<common::SpillStats>* const spillStats_;
 
   // allKeyInfo_ is a combination of (partitionKeyInfo_ and sortKeyInfo_).
   // It is used to perform a full sorting of the input rows to be able to

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -59,21 +59,24 @@ class Spiller {
       RowTypePtr rowType,
       int32_t numSortingKeys,
       const std::vector<CompareFlags>& sortCompareFlags,
-      const common::SpillConfig* spillConfig);
+      const common::SpillConfig* spillConfig,
+      folly::Synchronized<common::SpillStats>* spillStats);
 
   /// type == Type::kAggregateOutput || type == Type::kOrderByOutput
   Spiller(
       Type type,
       RowContainer* container,
       RowTypePtr rowType,
-      const common::SpillConfig* spillConfig);
+      const common::SpillConfig* spillConfig,
+      folly::Synchronized<common::SpillStats>* spillStats);
 
   /// type == Type::kHashJoinProbe
   Spiller(
       Type type,
       RowTypePtr rowType,
       HashBitRange bits,
-      const common::SpillConfig* spillConfig);
+      const common::SpillConfig* spillConfig,
+      folly::Synchronized<common::SpillStats>* spillStats);
 
   /// type == Type::kHashJoinBuild
   Spiller(
@@ -82,7 +85,8 @@ class Spiller {
       RowContainer* container,
       RowTypePtr rowType,
       HashBitRange bits,
-      const common::SpillConfig* spillConfig);
+      const common::SpillConfig* spillConfig,
+      folly::Synchronized<common::SpillStats>* spillStats);
 
   /// type == Type::kRowNumber
   Spiller(
@@ -90,7 +94,8 @@ class Spiller {
       RowContainer* container,
       RowTypePtr rowType,
       HashBitRange bits,
-      const common::SpillConfig* spillConfig);
+      const common::SpillConfig* spillConfig,
+      folly::Synchronized<common::SpillStats>* spillStats);
 
   Type type() const {
     return type_;
@@ -204,7 +209,8 @@ class Spiller {
       common::CompressionKind compressionKind,
       folly::Executor* executor,
       uint64_t maxSpillRunRows,
-      const std::string& fileCreateConfig);
+      const std::string& fileCreateConfig,
+      folly::Synchronized<common::SpillStats>* spillStats);
 
   // Invoked to spill. If 'startRowIter' is not null, then we only spill rows
   // from row container starting at the offset pointed by 'startRowIter'.
@@ -316,13 +322,14 @@ class Spiller {
   const bool spillProbedFlag_;
   const uint64_t maxSpillRunRows_;
 
+  folly::Synchronized<common::SpillStats>* const spillStats_;
+
   // True if all rows of spilling partitions are in 'spillRuns_', so
   // that one can start reading these back. This means that the rows
   // that are not written out and deleted will be captured by
   // spillMergeStreamOverRows().
   bool finalized_{false};
 
-  folly::Synchronized<common::SpillStats> stats_;
   SpillState state_;
 
   // Collects the rows to spill for each partition.

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -255,11 +255,12 @@ void TableWriter::updateStats(const connector::DataSink::Stats& stats) {
         "numWrittenFiles", RuntimeCounter(stats.numWrittenFiles));
   }
   if (!stats.spillStats.empty()) {
-    recordSpillStats(stats.spillStats);
+    *spillStats_.wlock() += stats.spillStats;
   }
 }
 
 void TableWriter::close() {
+  Operator::close();
   if (!closed_) {
     // Abort the data sink if the query has already failed and no need for
     // regular close.

--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -288,7 +288,6 @@ void TopNRowNumber::noMoreInput() {
     VELOX_CHECK_NULL(merge_);
     auto spillPartition = spiller_->finishSpill();
     merge_ = spillPartition.createOrderedReader(pool());
-    recordSpillStats(spiller_->stats());
   } else {
     outputRows_.resize(outputBatchSize_);
   }
@@ -748,6 +747,7 @@ void TopNRowNumber::setupSpiller() {
       inputType_,
       spillCompareFlags_.size(),
       spillCompareFlags_,
-      &spillConfig_.value());
+      &spillConfig_.value(),
+      &spillStats_);
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -45,7 +45,7 @@ Window::Window(
         windowNode, pool(), spillConfig, &nonReclaimableSection_);
   } else {
     windowBuild_ = std::make_unique<SortWindowBuild>(
-        windowNode, pool(), spillConfig, &nonReclaimableSection_);
+        windowNode, pool(), spillConfig, &nonReclaimableSection_, &spillStats_);
   }
 }
 
@@ -241,10 +241,6 @@ void Window::createPeerAndFrameBuffers() {
 void Window::noMoreInput() {
   Operator::noMoreInput();
   windowBuild_->noMoreInput();
-
-  if (auto spillStats = windowBuild_->spilledStats()) {
-    recordSpillStats(spillStats.value());
-  }
 }
 
 void Window::callResetPartition() {

--- a/velox/exec/tests/AggregateSpillBenchmarkBase.cpp
+++ b/velox/exec/tests/AggregateSpillBenchmarkBase.cpp
@@ -124,7 +124,7 @@ void AggregateSpillBenchmarkBase::writeSpillData() {
   }
 }
 
-std::unique_ptr<Spiller> AggregateSpillBenchmarkBase::makeSpiller() const {
+std::unique_ptr<Spiller> AggregateSpillBenchmarkBase::makeSpiller() {
   common::SpillConfig spillConfig;
   spillConfig.getSpillDirPathCb = [&]() -> const std::string& {
     return spillDir_;
@@ -145,11 +145,16 @@ std::unique_ptr<Spiller> AggregateSpillBenchmarkBase::makeSpiller() const {
         rowType_,
         rowContainer_->keyTypes().size(),
         std::vector<CompareFlags>{},
-        &spillConfig);
+        &spillConfig,
+        &spillStats_);
   } else {
     // TODO: Add config flag to control the max spill rows.
     return std::make_unique<Spiller>(
-        spillerType_, rowContainer_.get(), rowType_, &spillConfig);
+        spillerType_,
+        rowContainer_.get(),
+        rowType_,
+        &spillConfig,
+        &spillStats_);
   }
 }
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/AggregateSpillBenchmarkBase.h
+++ b/velox/exec/tests/AggregateSpillBenchmarkBase.h
@@ -32,7 +32,7 @@ class AggregateSpillBenchmarkBase : public SpillerBenchmarkBase {
 
  private:
   void writeSpillData();
-  std::unique_ptr<Spiller> makeSpiller() const;
+  std::unique_ptr<Spiller> makeSpiller();
 
   const Spiller::Type spillerType_;
   std::unique_ptr<RowContainer> rowContainer_;

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -6309,7 +6309,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, exceededMaxSpillLevel) {
                              .operatorStats.back()
                              .runtimeStats;
         ASSERT_EQ(joinStats["exceededMaxSpillLevel"].sum, 8);
-        ASSERT_EQ(joinStats["exceededMaxSpillLevel"].count, 8);
+        ASSERT_EQ(joinStats["exceededMaxSpillLevel"].count, 1);
       })
       .run();
   ASSERT_EQ(

--- a/velox/exec/tests/JoinSpillInputBenchmarkBase.cpp
+++ b/velox/exec/tests/JoinSpillInputBenchmarkBase.cpp
@@ -49,7 +49,8 @@ void JoinSpillInputBenchmarkBase::setUp() {
       exec::Spiller::Type::kHashJoinProbe,
       rowType_,
       HashBitRange{29, 29},
-      &spillConfig);
+      &spillConfig,
+      &spillStats_);
   spiller_->setPartitionsSpilled({0});
 }
 

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -1034,8 +1034,9 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringOutputProcessing) {
     taskThread.join();
 
     auto stats = task->taskStats().pipelineStats;
-    ASSERT_EQ(stats[0].operatorStats[1].spilledBytes, 0);
-    ASSERT_EQ(stats[0].operatorStats[1].spilledPartitions, 0);
+    ASSERT_TRUE(!enableSpilling || stats[0].operatorStats[1].spilledBytes > 0);
+    ASSERT_TRUE(
+        !enableSpilling || stats[0].operatorStats[1].spilledPartitions > 0);
     OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
   }
   ASSERT_EQ(reclaimerStats_.numNonReclaimableAttempts, 0);

--- a/velox/exec/tests/SpillerBenchmarkBase.h
+++ b/velox/exec/tests/SpillerBenchmarkBase.h
@@ -71,5 +71,6 @@ class SpillerBenchmarkBase {
   std::unique_ptr<Spiller> spiller_;
   // Stats.
   uint64_t executionTimeUs_{0};
+  folly::Synchronized<common::SpillStats> spillStats_;
 };
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
Decouple spill stats from the spiller as row number and hash probe spilling might
use more than one and different spillers. Consolidate to use one spill stats to collect
the spill stats to streamline implementation. This PR introduces a synchronized spill
stats within the operator to gather these stats and later on we could separate them
for different types of spiller if offline analysis needs.