### PR TITLE
Fix nullptr dereference in SubscriptUtil

### DIFF
--- a/velox/functions/lib/SubscriptUtil.h
+++ b/velox/functions/lib/SubscriptUtil.h
@@ -41,8 +41,8 @@ class LookupTable;
 class LookupTableBase {
  public:
   template <TypeKind kind>
-  LookupTable<kind>& typedTable() {
-    return *static_cast<LookupTable<kind>*>(this);
+  LookupTable<kind>* typedTable() {
+    return static_cast<LookupTable<kind>*>(this);
   }
   virtual ~LookupTableBase() {}
 };


### PR DESCRIPTION
Summary:
If caching is not enabled in applyMapTyped in SubscriptUtil we don't initialize the cachedLookupTablePtr so it's a nullptr.

We then dereference the pointer casting it to the appropriate type whether or not it was initialized.  We don't use the resulting
reference unless caching is enabled (in which case it wasn't a nullptr), so it doesn't cause any problems at execution time.

It does cause UBSan to throw though.  This change cleans it up so we only deference the pointer where we use it.

Differential Revision: D55255553


