### PR TITLE
Avoid crashes in rowGroupUncompressedSize due to column index being o…

### DIFF
--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -418,7 +418,7 @@ std::shared_ptr<const ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
           std::move(children),
           curSchemaIdx,
           maxSchemaElementIdx,
-          columnIdx++,
+          columnIdx - 1, // was already incremented for leafTypePtr
           std::move(name),
           std::nullopt,
           std::nullopt,
@@ -612,6 +612,8 @@ int64_t ReaderBase::rowGroupUncompressedSize(
     int32_t rowGroupIndex,
     const dwio::common::TypeWithId& type) const {
   if (type.column() != ParquetTypeWithId::kNonLeaf) {
+    VELOX_CHECK_LT(rowGroupIndex, fileMetaData_->row_groups.size());
+    VELOX_CHECK_LT(type.column(), fileMetaData_->row_groups[rowGroupIndex].columns.size());
     return fileMetaData_->row_groups[rowGroupIndex]
         .columns[type.column()]
         .meta_data.total_uncompressed_size;


### PR DESCRIPTION
fixes #9222 

Turns out that in the `getParquetColumnInfo` function, the column was incremented twice for array types, which would result in out-of-bounds vector access down the road. We could confirm it in Uber by deploying the `VELOX_CHECK_LT` statements in the code, where we started seeing tons of logs like:

```
VeloxRuntimeError: type.column() < fileMetaData_->row_groups[rowGroupIndex].columns.size() (228 vs. 228) type column: 228, columns.size(): 228 Split [Hive: gs://....parquet 671088640 - 134217728] Task 20240308_025912_03027_rt9ch.1.0.32.0
```
The crash was not happening frequently because the `[]` operator on vector does not do out-of-bounds check and would result in an undefined behavior in case if the code tries to access an element at wrong index. Undefined behavior does not necessarily mean you'll get an error: you might, but you might instead get some result that doesn't make much sense.
