### PR TITLE
Reuse result vector in Alpha reader

### DIFF
--- a/velox/dwio/common/Reader.cpp
+++ b/velox/dwio/common/Reader.cpp
@@ -139,6 +139,7 @@ VectorPtr RowReader::projectColumns(
     bits::forEachSetBit(
         passed.data(), 0, input->size(), [&](auto i) { rawIndices[j++] = i; });
     for (auto& child : children) {
+      child->disableMemo();
       child = BaseVector::wrapInDictionary(
           nullptr, indices, size, std::move(child));
     }

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -227,6 +227,10 @@ class RowVector : public BaseVector {
   /// Note : If the child is null, then it will stay null after the resize.
   void resize(vector_size_t newSize, bool setNotNull = true) override;
 
+  VectorPtr& rawVectorForBatchReader() {
+    return rawVectorForBatchReader_;
+  }
+
  private:
   vector_size_t childSize() const {
     bool allConstant = false;
@@ -270,6 +274,10 @@ class RowVector : public BaseVector {
   // loadedVector is called, and reset to false when updateContainsLazyNotLoaded
   // is called (i.e. some children are likely updated to lazy).
   mutable bool childrenLoaded_ = false;
+
+  // For some non-selective reader, we need to keep the original vector that is
+  // unprojected and unfilterd, and reuse its memory.
+  VectorPtr rawVectorForBatchReader_;
 };
 
 // Common parent class for ARRAY and MAP vectors.  Contains 'offsets' and


### PR DESCRIPTION
Summary:
Optimize both CPU and memory utilization by reusing result and
intermediate vector memory.

Differential Revision: D55219745


