### PR TITLE
Add hash build wall time stats

### DIFF
--- a/velox/docs/monitoring/stats.rst
+++ b/velox/docs/monitoring/stats.rst
@@ -65,3 +65,7 @@ These stats are reported only by HashBuild and HashAggregation operators.
    * - hashtable.numTombstones
      -
      - Number of tombstone slots in the hash table.
+   * - hashtable.buildWallNanos
+     - nanos
+     - Time spent on building the hash table from rows collected by all the
+       hash build operators. This stat is only reported by the HashBuild operator.

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -130,6 +130,9 @@ class BaseHashTable {
   static inline const std::string kNumDistinct{"hashtable.numDistinct"};
   static inline const std::string kNumTombstones{"hashtable.numTombstones"};
 
+  /// The same as above but only reported by the HashBuild operator.
+  static inline const std::string kBuildWallNanos{"hashtable.buildWallNanos"};
+
   /// Returns the string of the given 'mode'.
   static std::string modeString(HashMode mode);
 

--- a/velox/exec/tests/PrintPlanWithStatsTest.cpp
+++ b/velox/exec/tests/PrintPlanWithStatsTest.cpp
@@ -160,6 +160,7 @@ TEST_F(PrintPlanWithStatsTest, innerJoinWithTableScan) {
        {"     Output: 2000 rows \\(.+\\), Cpu time: .+, Blocked wall time: .+, Peak memory: .+, Memory allocations: .+"},
        {"     HashBuild: Input: 100 rows \\(.+\\), Output: 0 rows \\(.+\\), Cpu time: .+, Blocked wall time: .+, Peak memory: .+, Memory allocations: .+, Threads: 1"},
        {"        distinctKey0\\s+sum: 101, count: 1, min: 101, max: 101"},
+       {"        hashtable.buildWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
        {"        hashtable.capacity\\s+sum: 200, count: 1, min: 200, max: 200"},
        {"        hashtable.numDistinct\\s+sum: 100, count: 1, min: 100, max: 100"},
        {"        hashtable.numRehashes\\s+sum: 1, count: 1, min: 1, max: 1"},


### PR DESCRIPTION
For the parallel join build, multiple hash build operators are involved.
The last hash build operator constructs the hash table using rows
gathered from all operators. It would be beneficial to introduce a runtime
metric (per query) to track the time spent on the 'merge' process of the hash tables.