### PR TITLE
Fix incorrect std::move in ExprCompiler.cpp

### DIFF
--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -404,13 +404,9 @@ ExprPtr compileRewrittenExpression(
           trackCpuUsage);
     }
   } else if (auto call = dynamic_cast<const core::CallTypedExpr*>(expr.get())) {
-    if (auto specialForm = getSpecialForm(
-            config,
-            call->name(),
-            resultType,
-            std::move(compiledInputs),
-            trackCpuUsage)) {
-      result = specialForm;
+    if (auto specialForm = specialFormRegistry().getSpecialForm(call->name())) {
+      result = specialForm->constructSpecialForm(
+          resultType, std::move(compiledInputs), trackCpuUsage, config);
     } else if (
         auto func = getVectorFunction(
             call->name(),


### PR DESCRIPTION
Summary: {F1473140094}

Differential Revision: D55319745


