### PR TITLE
Fix build error in ArrowBridgeArrayTest

### DIFF
--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -1224,7 +1224,7 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
     testArrowImport<double>("g", {-99.9, 4.3, 31.1, 129.11, -12});
     testArrowImport<float>("f", {-99.9, 4.3, 31.1, 129.11, -12});
 
-    for (const auto& tsString : {"tss:", "tsm:", "tsu:", "tsn:"}) {
+    for (const auto tsString : {"tss:", "tsm:", "tsu:", "tsn:"}) {
       testArrowImport<Timestamp, int64_t>(
           tsString, {0, std::nullopt, Timestamp::kMaxSeconds});
     }


### PR DESCRIPTION
Summary: A simple bug, the strings are temporaries so they can't be assigned to a reference.

Differential Revision: D55333060


