### PR TITLE
Change TypeWithId to take exclusive ownership on children to avoid confusion

### DIFF
--- a/velox/dwio/common/TypeWithId.cpp
+++ b/velox/dwio/common/TypeWithId.cpp
@@ -22,9 +22,21 @@ namespace facebook::velox::dwio::common {
 using velox::Type;
 using velox::TypeKind;
 
+namespace {
+std::vector<std::shared_ptr<const TypeWithId>> toShared(
+    std::vector<std::unique_ptr<TypeWithId>> nodes) {
+  std::vector<std::shared_ptr<const TypeWithId>> result;
+  result.reserve(nodes.size());
+  for (auto&& node : nodes) {
+    result.emplace_back(std::move(node));
+  }
+  return result;
+}
+} // namespace
+
 TypeWithId::TypeWithId(
     std::shared_ptr<const Type> type,
-    std::vector<std::shared_ptr<const TypeWithId>>&& children,
+    std::vector<std::unique_ptr<TypeWithId>>&& children,
     uint32_t id,
     uint32_t maxId,
     uint32_t column)
@@ -33,13 +45,13 @@ TypeWithId::TypeWithId(
       id_{id},
       maxId_{maxId},
       column_{column},
-      children_{std::move(children)} {
+      children_{toShared(std::move(children))} {
   for (auto& child : children_) {
     const_cast<const TypeWithId*&>(child->parent_) = this;
   }
 }
 
-std::shared_ptr<const TypeWithId> TypeWithId::create(
+std::unique_ptr<TypeWithId> TypeWithId::create(
     const std::shared_ptr<const Type>& root,
     uint32_t next) {
   return create(root, next, 0);
@@ -54,13 +66,13 @@ const std::shared_ptr<const TypeWithId>& TypeWithId::childAt(
   return children_.at(idx);
 }
 
-std::shared_ptr<const TypeWithId> TypeWithId::create(
+std::unique_ptr<TypeWithId> TypeWithId::create(
     const std::shared_ptr<const Type>& type,
     uint32_t& next,
     uint32_t column) {
   DWIO_ENSURE_NOT_NULL(type);
   const uint32_t myId = next++;
-  std::vector<std::shared_ptr<const TypeWithId>> children{};
+  std::vector<std::unique_ptr<TypeWithId>> children;
   children.reserve(type->size());
   auto offset = 0;
   for (const auto& child : *type) {
@@ -70,7 +82,7 @@ std::shared_ptr<const TypeWithId> TypeWithId::create(
         (myId == 0 && type->kind() == TypeKind::ROW) ? offset++ : column));
   }
   const uint32_t maxId = next - 1;
-  return std::make_shared<const TypeWithId>(
+  return std::make_unique<TypeWithId>(
       type, std::move(children), myId, maxId, column);
 }
 

--- a/velox/dwio/common/TypeWithId.h
+++ b/velox/dwio/common/TypeWithId.h
@@ -24,14 +24,18 @@ namespace facebook::velox::dwio::common {
 
 class TypeWithId : public velox::Tree<std::shared_ptr<const TypeWithId>> {
  public:
+  /// NOTE: This constructor will re-parent the children.
   TypeWithId(
       std::shared_ptr<const velox::Type> type,
-      std::vector<std::shared_ptr<const TypeWithId>>&& children,
+      std::vector<std::unique_ptr<TypeWithId>>&& children,
       uint32_t id,
       uint32_t maxId,
       uint32_t column);
 
-  static std::shared_ptr<const TypeWithId> create(
+  TypeWithId(const TypeWithId&) = delete;
+  TypeWithId& operator=(const TypeWithId&) = delete;
+
+  static std::unique_ptr<TypeWithId> create(
       const std::shared_ptr<const velox::Type>& root,
       uint32_t next = 0);
 
@@ -70,7 +74,7 @@ class TypeWithId : public velox::Tree<std::shared_ptr<const TypeWithId>> {
   }
 
  private:
-  static std::shared_ptr<const TypeWithId> create(
+  static std::unique_ptr<TypeWithId> create(
       const std::shared_ptr<const velox::Type>& type,
       uint32_t& next,
       uint32_t column);

--- a/velox/dwio/common/tests/TypeTests.cpp
+++ b/velox/dwio/common/tests/TypeTests.cpp
@@ -39,7 +39,7 @@ TEST(TestType, selectedType) {
       "col3:map<float,double>,col4:float,"
       "col5:int,col6:bigint,col7:string>",
       HiveTypeSerializer::serialize(type).c_str());
-  auto typeWithId = TypeWithId::create(type);
+  std::shared_ptr<const TypeWithId> typeWithId = TypeWithId::create(type);
   EXPECT_EQ(0, typeWithId->id());
   EXPECT_EQ(11, typeWithId->maxId());
 

--- a/velox/dwio/dwrf/test/ColumnWriterTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTest.cpp
@@ -4239,7 +4239,7 @@ TEST_F(ColumnWriterTest, ColumnIdInStream) {
   const uint32_t kColumnId = 2;
   auto typeWithId = std::make_shared<const TypeWithId>(
       type,
-      std::vector<std::shared_ptr<const TypeWithId>>{},
+      std::vector<std::unique_ptr<TypeWithId>>{},
       /* id */ kNodeId,
       /* maxId */ kNodeId,
       /* column */ kColumnId);

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -133,7 +133,7 @@ class ColumnReaderTestBase {
     EXPECT_CALL(streams_, getRowReaderOptionsProxy())
         .WillRepeatedly(testing::Return(&options));
 
-    auto fileTypeWithId =
+    std::shared_ptr<const TypeWithId> fileTypeWithId =
         TypeWithId::create(fileType ? fileType : requestedType);
 
     if (useSelectiveReader()) {

--- a/velox/dwio/parquet/reader/ParquetTypeWithId.h
+++ b/velox/dwio/parquet/reader/ParquetTypeWithId.h
@@ -36,7 +36,7 @@ class ParquetTypeWithId : public dwio::common::TypeWithId {
 
   ParquetTypeWithId(
       TypePtr type,
-      std::vector<std::shared_ptr<const TypeWithId>>&& children,
+      std::vector<std::unique_ptr<TypeWithId>>&& children,
       uint32_t id,
       uint32_t maxId,
       uint32_t column,
@@ -73,6 +73,8 @@ class ParquetTypeWithId : public dwio::common::TypeWithId {
 
   /// Fills 'info' and returns the mode for interpreting levels.
   LevelMode makeLevelInfo(arrow::LevelInfo& info) const;
+
+  std::vector<std::unique_ptr<ParquetTypeWithId::TypeWithId>> moveChildren() &&;
 
   const std::string name_;
   const std::optional<thrift::Type::type> parquetType_;


### PR DESCRIPTION
Summary: Because the constructor is reparenting the children, taking shared ownership on children is misleading, especially when they are `const` qualified.

Differential Revision: D55318609


