### PR TITLE
feat: Add companionFunction to function metadata

### DIFF
--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -476,6 +476,9 @@ struct AggregateFunctionMetadata {
   /// True if results of the aggregation depend on the order of inputs. For
   /// example, array_agg is order sensitive while count is not.
   bool orderSensitive{true};
+
+  /// Indicates if this is a companion function.
+  bool companionFunction{false};
 };
 /// Register an aggregate function with the specified name and signatures. If
 /// registerCompanionFunctions is true, also register companion aggregate and
@@ -513,6 +516,9 @@ std::vector<AggregateRegistrationResult> registerAggregateFunction(
     const AggregateFunctionMetadata& metadata,
     bool registerCompanionFunctions,
     bool overwrite);
+
+const AggregateFunctionMetadata& getAggregateFunctionMetadata(
+    const std::string& name);
 
 /// Returns signatures of the aggregate function with the specified name.
 /// Returns empty std::optional if function with that name is not found.

--- a/velox/exec/AggregateCompanionAdapter.h
+++ b/velox/exec/AggregateCompanionAdapter.h
@@ -178,6 +178,7 @@ class CompanionFunctionsRegistrar {
   static bool registerPartialFunction(
       const std::string& name,
       const std::vector<AggregateFunctionSignaturePtr>& signatures,
+      const AggregateFunctionMetadata& metadata,
       bool overwrite = false);
 
   // When there is already a function of the same name as the merge companion
@@ -186,6 +187,7 @@ class CompanionFunctionsRegistrar {
   static bool registerMergeFunction(
       const std::string& name,
       const std::vector<AggregateFunctionSignaturePtr>& signatures,
+      const AggregateFunctionMetadata& metadata,
       bool overwrite = false);
 
   // If there are multiple signatures of the original aggregation function
@@ -213,6 +215,7 @@ class CompanionFunctionsRegistrar {
   static bool registerMergeExtractFunction(
       const std::string& name,
       const std::vector<AggregateFunctionSignaturePtr>& signatures,
+      const AggregateFunctionMetadata& metadata,
       bool overwrite = false);
 
  private:
@@ -227,6 +230,7 @@ class CompanionFunctionsRegistrar {
   static bool registerMergeExtractFunctionWithSuffix(
       const std::string& name,
       const std::vector<AggregateFunctionSignaturePtr>& signatures,
+      const AggregateFunctionMetadata& metadata,
       bool overwrite);
 };
 

--- a/velox/expression/FunctionMetadata.h
+++ b/velox/expression/FunctionMetadata.h
@@ -40,6 +40,9 @@ struct VectorFunctionMetadata {
   /// In this case, 'rows' in VectorFunction::apply will point only to positions
   /// for which all arguments are not null.
   bool defaultNullBehavior{true};
+
+  /// Indicates if this is a companion function.
+  bool companionFunction{false};
 };
 
 class VectorFunctionMetadataBuilder {
@@ -56,6 +59,11 @@ class VectorFunctionMetadataBuilder {
 
   VectorFunctionMetadataBuilder& defaultNullBehavior(bool defaultNullBehavior) {
     metadata_.defaultNullBehavior = defaultNullBehavior;
+    return *this;
+  }
+
+  VectorFunctionMetadataBuilder& companionFunction(bool companionFunction) {
+    metadata_.companionFunction = companionFunction;
     return *this;
   }
 

--- a/velox/functions/lib/aggregates/BitwiseAggregateBase.h
+++ b/velox/functions/lib/aggregates/BitwiseAggregateBase.h
@@ -114,7 +114,7 @@ exec::AggregateRegistrationResult registerBitwise(
                 inputType->kindName());
         }
       },
-      {false /*orderSensitive*/},
+      {false /*orderSensitive*/, false /*companionFunction*/},
       withCompanionFunctions,
       overwrite);
 }

--- a/velox/functions/prestosql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/AverageAggregate.cpp
@@ -155,7 +155,7 @@ void registerAverageAggregate(
           }
         }
       },
-      {false /*orderSensitive*/},
+      {false /*orderSensitive*/, false /*companionFunction*/},
       withCompanionFunctions,
       overwrite);
 }

--- a/velox/functions/prestosql/aggregates/BoolAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/BoolAggregates.cpp
@@ -209,7 +209,7 @@ exec::AggregateRegistrationResult registerBool(
             inputType->kindName());
         return std::make_unique<T>();
       },
-      {false /*orderSensitive*/},
+      {false /*orderSensitive*/, false /*companionFunction*/},
       withCompanionFunctions,
       overwrite);
 }

--- a/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
@@ -262,7 +262,7 @@ void registerChecksumAggregate(
 
         return std::make_unique<ChecksumAggregate>(VARBINARY());
       },
-      {false /*orderSensitive*/},
+      {false /*orderSensitive*/, false /*companionFunction*/},
       withCompanionFunctions,
       overwrite);
 }

--- a/velox/functions/prestosql/aggregates/CountAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountAggregate.cpp
@@ -182,7 +182,7 @@ void registerCountAggregate(
             argTypes.size(), 1, "{} takes at most one argument", name);
         return std::make_unique<CountAggregate>();
       },
-      {false /*orderSensitive*/},
+      {false /*orderSensitive*/, false /*companionFunction*/},
       withCompanionFunctions,
       overwrite);
 }

--- a/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
@@ -206,7 +206,7 @@ void registerCountIfAggregate(
 
         return std::make_unique<CountIfAggregate>();
       },
-      {false /*orderSensitive*/},
+      {false /*orderSensitive*/, false /*companionFunction*/},
       withCompanionFunctions,
       overwrite);
 }

--- a/velox/functions/prestosql/aggregates/GeometricMeanAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/GeometricMeanAggregate.cpp
@@ -136,7 +136,7 @@ void registerGeometricMeanAggregate(
                 inputType->toString());
         }
       },
-      {false /*orderSensitive*/},
+      {false /*orderSensitive*/, false /*companionFunction*/},
       withCompanionFunctions,
       overwrite);
 }

--- a/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
@@ -632,7 +632,7 @@ void registerHistogramAggregate(
                 inputType->toString());
         }
       },
-      {false /*orderSensitive*/},
+      {false /*orderSensitive*/, false /*companionFunction*/},
       withCompanionFunctions,
       overwrite);
 }

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -514,7 +514,7 @@ exec::AggregateRegistrationResult registerMinMax(
           }
         }
       },
-      {false /*orderSensitive*/},
+      {false /*orderSensitive*/, false /*companionFunction*/},
       withCompanionFunctions,
       overwrite);
 }

--- a/velox/functions/prestosql/aggregates/ReduceAgg.cpp
+++ b/velox/functions/prestosql/aggregates/ReduceAgg.cpp
@@ -817,7 +817,7 @@ void registerReduceAgg(
           const core::QueryConfig& config) -> std::unique_ptr<exec::Aggregate> {
         return std::make_unique<ReduceAgg>(resultType);
       },
-      {false /*orderSensitive*/},
+      {false /*orderSensitive*/, false /*companionFunction*/},
       withCompanionFunctions,
       overwrite);
 }

--- a/velox/functions/prestosql/aggregates/SumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/SumAggregate.cpp
@@ -114,7 +114,7 @@ exec::AggregateRegistrationResult registerSum(
                 inputType->kindName());
         }
       },
-      {false /*orderSensitive*/},
+      {false /*orderSensitive*/, false /*companionFunction*/},
       withCompanionFunctions,
       overwrite);
 }


### PR DESCRIPTION
Adds a boolean field, `isCompanionFunction`, to `VectorFunctionMetadata`, 
`AggregateFunctionMetadata`, and `WindowFunction::Metadata`, to indicate 
whether the respective scalar, aggregate, and window functions are companion
 functions in Velox. 
This field would be used to check for and exclude companion functions from 
the function metadata returned by the `v1/functions` endpoint in the Presto 
C++ sidecar. Currently, this is being done by searching for specific suffixes in
 the registered [companion functions' names.](https://github.com/prestodb/presto/blob/8abe0c9609dd6c82a01a542499a9def0d9e81ea4/presto-native-execution/presto_cpp/main/types/FunctionMetadata.cpp#L65)
Related discussion: https://github.com/facebookincubator/velox/discussions/11011 .