### PR TITLE
[WIP] Add BaseVector::estimateCompactSize

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -590,7 +590,7 @@ StopReason Driver::runInternal(
                 if (ctx_->queryConfig().validateOutputFromOperators()) {
                   validateOperatorResult(intermediateResult, *op);
                 }
-                resultBytes = intermediateResult->estimateFlatSize();
+                resultBytes = intermediateResult->estimateCompactSize();
                 {
                   auto lockedStats = op->stats().wlock();
                   lockedStats->addOutputVector(
@@ -699,7 +699,7 @@ StopReason Driver::runInternal(
               {
                 auto lockedStats = op->stats().wlock();
                 lockedStats->addOutputVector(
-                    result->estimateFlatSize(), result->size());
+                    result->estimateCompactSize(), result->size());
               }
 
               // This code path is used only in single-threaded execution.

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -828,6 +828,14 @@ uint64_t BaseVector::estimateFlatSize() const {
   return length_ * avgRowSize;
 }
 
+double BaseVector::estimateRowSize() const {
+  return estimateCompactSize() / length_;
+}
+
+uint64_t BaseVector::estimateCompactSize() const {
+  return estimateFlatSize();
+}
+
 namespace {
 bool isReusableEncoding(VectorEncoding::Simple encoding) {
   return encoding == VectorEncoding::Simple::FLAT ||

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -727,6 +727,17 @@ class BaseVector {
   /// hasn't been loaded yet.
   virtual uint64_t estimateFlatSize() const;
 
+  /// Returns an estimate size of each row in this vector.
+  virtual double estimateRowSize() const;
+
+  /// Returns an estimate size of the vector as if it was compacted,
+  /// ignoring any over-allocations. For example:
+  /// (1) For dictionary vector, it only counts each dictionary entry once,
+  /// rather than each time a value is referenced.
+  /// (2) For flat vector, returns its retained size.
+  /// (3) For lazy vector that hasn't been loaded, returns zero.
+  virtual uint64_t estimateCompactSize() const;
+
   /// To safely reuse a vector one needs to (1) ensure that the vector as well
   /// as all its buffers and child vectors are singly-referenced and mutable
   /// (for buffers); (2) clear append-only string buffers and child vectors

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -448,6 +448,16 @@ uint64_t RowVector::estimateFlatSize() const {
   return total;
 }
 
+uint64_t RowVector::estimateCompactSize() const {
+  uint64_t total = BaseVector::retainedSize();
+  for (const auto& child : children_) {
+    if (child) {
+      total += child->estimateCompactSize();
+    }
+  }
+  return total;
+}
+
 void RowVector::prepareForReuse() {
   BaseVector::prepareForReuse();
   for (auto& child : children_) {
@@ -979,6 +989,10 @@ uint64_t ArrayVector::estimateFlatSize() const {
       sizes_->capacity() + elements_->estimateFlatSize();
 }
 
+uint64_t ArrayVector::estimateCompactSize() const {
+  return BaseVector::retainedSize() + offsets_->capacity() + sizes_->capacity() + elements_->estimateCompactSize();
+}
+
 namespace {
 void zeroOutBuffer(BufferPtr buffer) {
   memset(buffer->asMutable<char>(), 0, buffer->size());
@@ -1281,6 +1295,10 @@ uint64_t MapVector::estimateFlatSize() const {
   return BaseVector::retainedSize() + offsets_->capacity() +
       sizes_->capacity() + keys_->estimateFlatSize() +
       values_->estimateFlatSize();
+}
+
+uint64_t MapVector::estimateCompactSize() const {
+  return BaseVector::retainedSize() + offsets_->capacity() + sizes_->capacity() + keys_->estimateCompactSize() + values_->estimateCompactSize();
 }
 
 void MapVector::prepareForReuse() {

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -180,6 +180,8 @@ class RowVector : public BaseVector {
 
   uint64_t estimateFlatSize() const override;
 
+  uint64_t estimateCompactSize() const override;
+
   using BaseVector::toString;
 
   std::string toString(vector_size_t index) const override;
@@ -457,6 +459,8 @@ class ArrayVector : public ArrayVectorBase {
 
   uint64_t estimateFlatSize() const override;
 
+  uint64_t estimateCompactSize() const override;
+
   using BaseVector::toString;
 
   std::string toString(vector_size_t index) const override;
@@ -585,6 +589,8 @@ class MapVector : public ArrayVectorBase {
   }
 
   uint64_t estimateFlatSize() const override;
+
+  uint64_t estimateCompactSize() const override;
 
   using BaseVector::toString;
 

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -205,6 +205,14 @@ class ConstantVector final : public SimpleVector<T> {
     return sizeof(T);
   }
 
+  double estimateRowSize() const override {
+    return valueVector_ ? valueVector_->estimateRowSize() : retainedSize();
+  }
+
+  uint64_t estimateCompactSize() const override {
+    return 1 * estimateRowSize();
+  }
+
   BaseVector* loadedVector() override {
     if (!valueVector_) {
       return this;

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -210,6 +210,7 @@ class ConstantVector final : public SimpleVector<T> {
   }
 
   uint64_t estimateCompactSize() const override {
+    LOG(ERROR) << "Constant Vector estimateCompactSize call. estimateRowSize():" << estimateRowSize();
     return 1 * estimateRowSize();
   }
 

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -166,6 +166,7 @@ class DictionaryVector : public SimpleVector<T> {
         used[rawIndices[i]] = true;
       }
     }
+    LOG(ERROR) << "Dictionary Vector estimateCompactSize call. uniqueIds:" << uniqueIds << ", estimateRowSize():" << estimateRowSize();
     return uniqueIds * estimateRowSize();
   }
 

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -148,6 +148,27 @@ class DictionaryVector : public SimpleVector<T> {
         indices_->capacity();
   }
 
+  double estimateRowSize() const override {
+    return 1.0 * dictionaryValues_->estimateRowSize();
+  }
+
+  uint64_t estimateCompactSize() const override {
+    if (indices() == nullptr) {
+      return 0;
+    }
+
+    int uniqueIds = 0;
+    std::vector<bool> used(dictionaryValues_->size());
+    const int32_t* rawIndices = indices_->as<int32_t>();
+    for (int i = 0; i < BaseVector::length_; i++) {
+      if (!BaseVector::isNullAt(i)) {
+        uniqueIds += used[rawIndices[i]] ? 0 : 1;
+        used[rawIndices[i]] = true;
+      }
+    }
+    return uniqueIds * estimateRowSize();
+  }
+
   bool isScalar() const override {
     return dictionaryValues_->isScalar();
   }

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -386,6 +386,17 @@ class FlatVector final : public SimpleVector<T> {
     return size;
   }
 
+  double estimateRowSize() const override {
+    if (BaseVector::length_ == 0) {
+      return 0;
+    }
+    return 1.0 * retainedSize() / BaseVector::length_;
+  }
+
+  uint64_t estimateCompactSize() const override {
+    return retainedSize();
+  }
+
   /**
    * Used for vectors of type VARCHAR and VARBINARY to hold data referenced by
    * StringView's. It is safe to share these among multiple vectors. These

--- a/velox/vector/SequenceVector.h
+++ b/velox/vector/SequenceVector.h
@@ -153,6 +153,14 @@ class SequenceVector : public SimpleVector<T> {
     return sequenceValues_->retainedSize() + sequenceLengths_->capacity();
   }
 
+  double estimateRowSize() const override {
+    return sequenceValues_->estimateRowSize();
+  }
+
+  uint64_t estimateCompactSize() const override {
+    return sequenceLengths_->size() * estimateRowSize();
+  }
+
   bool isScalar() const override {
     return sequenceValues_->isScalar();
   }

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -675,6 +675,15 @@ class VectorTestBase {
         size, 0, vectorMaker_.arrayVector<T>({data}));
   }
 
+  /// Create constant vector of type MAP from keys and values.
+  VectorPtr makeConstantMap(
+      vector_size_t size,
+      const VectorPtr& keys,
+      const VectorPtr& values) {
+    return BaseVector::wrapInConstant(
+        size, 0, vectorMaker_.mapVector({0}, keys, values));
+  }
+
   VectorPtr makeNullConstant(TypeKind typeKind, vector_size_t size) {
     return BaseVector::createNullConstant(
         createType(typeKind, {}), size, pool());


### PR DESCRIPTION
Using estimateFlatSize for reporting operator’s outputBytes could cause inflated reported data size.
Add estimateCompactSize API to return compact size and avoid any over-counting.

Issue: https://github.com/facebookincubator/velox/issues/9346