### PR TITLE
Fix window operation with kRange frames with column boundary

### DIFF
--- a/velox/exec/SortWindowBuild.cpp
+++ b/velox/exec/SortWindowBuild.cpp
@@ -296,7 +296,7 @@ std::unique_ptr<WindowPartition> SortWindowBuild::nextPartition() {
     VELOX_CHECK(!sortedRows_.empty(), "No window partitions available")
     auto partition = folly::Range(sortedRows_.data(), sortedRows_.size());
     return std::make_unique<WindowPartition>(
-        data_.get(), partition, inputColumns_, sortKeyInfo_);
+        data_.get(), partition, inversedInputChannels_, sortKeyInfo_);
   }
 
   VELOX_CHECK(!partitionStartRows_.empty(), "No window partitions available")
@@ -314,7 +314,7 @@ std::unique_ptr<WindowPartition> SortWindowBuild::nextPartition() {
       sortedRows_.data() + partitionStartRows_[currentPartition_],
       partitionSize);
   return std::make_unique<WindowPartition>(
-      data_.get(), partition, inputColumns_, sortKeyInfo_);
+      data_.get(), partition, inversedInputChannels_, sortKeyInfo_);
 }
 
 bool SortWindowBuild::hasNextPartition() {

--- a/velox/exec/StreamingWindowBuild.cpp
+++ b/velox/exec/StreamingWindowBuild.cpp
@@ -90,7 +90,7 @@ std::unique_ptr<WindowPartition> StreamingWindowBuild::nextPartition() {
       partitionSize);
 
   return std::make_unique<WindowPartition>(
-      data_.get(), partition, inputColumns_, sortKeyInfo_);
+      data_.get(), partition, inversedInputChannels_, sortKeyInfo_);
 }
 
 bool StreamingWindowBuild::hasNextPartition() {

--- a/velox/exec/WindowBuild.cpp
+++ b/velox/exec/WindowBuild.cpp
@@ -21,55 +21,53 @@
 namespace facebook::velox::exec {
 
 namespace {
-std::vector<column_index_t> reorderInputChannels(
+std::tuple<std::vector<column_index_t>, std::vector<column_index_t>, RowTypePtr>
+reorderInputChannels(
     const RowTypePtr& inputType,
     const std::vector<core::FieldAccessTypedExprPtr>& partitionKeys,
     const std::vector<core::FieldAccessTypedExprPtr>& sortingKeys) {
   const auto size = inputType->size();
 
   std::vector<column_index_t> channels;
+  std::vector<column_index_t> inversedChannels;
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
   channels.reserve(size);
+  inversedChannels.resize(size);
+  names.reserve(size);
+  types.reserve(size);
 
   std::unordered_set<std::string> keyNames;
 
+  auto appendChannel =
+      [&inputType, &channels, &inversedChannels, &names, &types](
+          column_index_t channel) {
+        channels.push_back(channel);
+        inversedChannels[channel] = channels.size() - 1;
+        names.push_back(inputType->nameOf(channel));
+        types.push_back(inputType->childAt(channel));
+      };
+
   for (const auto& key : partitionKeys) {
-    channels.push_back(exprToChannel(key.get(), inputType));
+    auto channel = exprToChannel(key.get(), inputType);
+    appendChannel(channel);
     keyNames.insert(key->name());
   }
 
   for (const auto& key : sortingKeys) {
-    channels.push_back(exprToChannel(key.get(), inputType));
+    auto channel = exprToChannel(key.get(), inputType);
+    appendChannel(channel);
     keyNames.insert(key->name());
   }
 
   for (auto i = 0; i < size; ++i) {
     if (keyNames.count(inputType->nameOf(i)) == 0) {
-      channels.push_back(i);
+      appendChannel(i);
     }
   }
 
-  return channels;
-}
-
-RowTypePtr reorderInputType(
-    const RowTypePtr& inputType,
-    const std::vector<column_index_t>& channels) {
-  const auto size = inputType->size();
-
-  VELOX_CHECK_EQ(size, channels.size());
-
-  std::vector<std::string> names;
-  names.reserve(size);
-
-  std::vector<TypePtr> types;
-  types.reserve(size);
-
-  for (auto channel : channels) {
-    names.push_back(inputType->nameOf(channel));
-    types.push_back(inputType->childAt(channel));
-  }
-
-  return ROW(std::move(names), std::move(types));
+  return std::make_tuple(
+      channels, inversedChannels, ROW(std::move(names), std::move(types)));
 }
 
 // Returns a [start, end) slice of the 'types' vector.
@@ -82,6 +80,7 @@ slice(const std::vector<TypePtr>& types, int32_t start, int32_t end) {
   }
   return result;
 }
+
 } // namespace
 
 WindowBuild::WindowBuild(
@@ -89,14 +88,15 @@ WindowBuild::WindowBuild(
     velox::memory::MemoryPool* pool,
     const common::SpillConfig* spillConfig,
     tsan_atomic<bool>* nonReclaimableSection)
-    : inputChannels_{reorderInputChannels(
+    : spillConfig_{spillConfig},
+      nonReclaimableSection_{nonReclaimableSection},
+      decodedInputVectors_(windowNode->inputType()->size()) {
+  std::tie(inputChannels_, inversedInputChannels_, inputType_) =
+      reorderInputChannels(
           windowNode->inputType(),
           windowNode->partitionKeys(),
-          windowNode->sortingKeys())},
-      inputType_{reorderInputType(windowNode->inputType(), inputChannels_)},
-      spillConfig_{spillConfig},
-      nonReclaimableSection_{nonReclaimableSection},
-      decodedInputVectors_(inputType_->size()) {
+          windowNode->sortingKeys());
+
   const auto numPartitionKeys = windowNode->partitionKeys().size();
   const auto numSortingKeys = windowNode->sortingKeys().size();
   const auto numKeys = numPartitionKeys + numSortingKeys;
@@ -104,12 +104,6 @@ WindowBuild::WindowBuild(
       slice(inputType_->children(), 0, numKeys),
       slice(inputType_->children(), numKeys, inputType_->size()),
       pool);
-
-  const auto& inputType = windowNode->inputType();
-  for (int i = 0; i < inputType->size(); i++) {
-    const auto index = inputType_->getChildIdx(inputType->nameOf(i));
-    inputColumns_.emplace_back(data_->columnAt(index));
-  }
 
   for (auto i = 0; i < numPartitionKeys; ++i) {
     partitionKeyInfo_.push_back(std::make_pair(i, core::SortOrder{true, true}));

--- a/velox/exec/WindowBuild.h
+++ b/velox/exec/WindowBuild.h
@@ -91,23 +91,25 @@ class WindowBuild {
   std::vector<std::pair<column_index_t, core::SortOrder>> sortKeyInfo_;
 
   // Input columns in the order of: partition keys, sorting keys, the rest.
-  const std::vector<column_index_t> inputChannels_;
+  std::vector<column_index_t> inputChannels_;
+
+  // The mapping from original input column index to the index after column
+  // reordering. This is the inversed mapping of inputChannels_.
+  std::vector<column_index_t> inversedInputChannels_;
 
   // Input column types in 'inputChannels_' order.
-  const RowTypePtr inputType_;
+  RowTypePtr inputType_;
 
   const common::SpillConfig* const spillConfig_;
   tsan_atomic<bool>* const nonReclaimableSection_;
 
-  // The RowContainer holds all the input rows in WindowBuild.
+  // The RowContainer holds all the input rows in WindowBuild. Columns are
+  // already reordered according to inputChannels_.
   std::unique_ptr<RowContainer> data_;
 
   // The decodedInputVectors_ are reused across addInput() calls to decode
   // the partition and sort keys for the above RowContainer.
   std::vector<DecodedVector> decodedInputVectors_;
-
-  // RowColumns for window build used to construct WindowPartition.
-  std::vector<exec::RowColumn> inputColumns_;
 
   // Number of input rows.
   vector_size_t numRows_ = 0;

--- a/velox/exec/WindowPartition.h
+++ b/velox/exec/WindowPartition.h
@@ -30,13 +30,15 @@ class WindowPartition {
   /// The WindowPartition is constructed by WindowBuild from the input data.
   /// 'data' : Underlying RowContainer of the WindowBuild.
   /// 'rows' : Pointers to rows in the RowContainer belonging to this partition.
-  /// 'columns' : Input rows of 'data' used for accessing column data from it.
+  /// 'inputMapping' : Mapping from Window input column to the column position
+  /// in 'data' for it. This is required because the WindowBuild re-orders
+  /// the columns in 'data' for use with the spiller.
   /// 'sortKeyInfo' : Order by columns used by the the Window operator. Used to
   /// get peer rows from the input partition.
   WindowPartition(
       RowContainer* data,
       const folly::Range<char**>& rows,
-      const std::vector<exec::RowColumn>& columns,
+      const std::vector<column_index_t>& inputMapping,
       const std::vector<std::pair<column_index_t, core::SortOrder>>&
           sortKeyInfo);
 
@@ -170,6 +172,15 @@ class WindowPartition {
   // of WindowPartition.
   folly::Range<char**> partition_;
 
+  // Mapping from window input column -> index in data_. This is required
+  // because the WindowBuild reorders data_ to place partition and sort keys
+  // before other columns in data_. But the Window Operator and Function code
+  // accesses WindowPartition using the indexes of Window input type.
+  const std::vector<column_index_t> inputMapping_;
+
+  // ORDER BY column info for this partition.
+  const std::vector<std::pair<column_index_t, core::SortOrder>> sortKeyInfo_;
+
   // Copy of the input RowColumn objects that are used for
   // accessing the partition row columns. These RowColumn objects
   // index into RowContainer data_ above and can retrieve the column values.
@@ -178,8 +189,5 @@ class WindowPartition {
   // corresponding indexes of their input arguments into this vector.
   // They will request for column vector values at the respective index.
   std::vector<exec::RowColumn> columns_;
-
-  // ORDER BY column info for this partition.
-  const std::vector<std::pair<column_index_t, core::SortOrder>> sortKeyInfo_;
 };
 } // namespace facebook::velox::exec

--- a/velox/functions/lib/window/tests/WindowTestBase.h
+++ b/velox/functions/lib/window/tests/WindowTestBase.h
@@ -211,5 +211,12 @@ class WindowTestBase : public exec::test::OperatorTestBase {
       const std::string& function,
       const RangeFrameBound& startBound,
       const RangeFrameBound& endBound);
+
+  void rangeFrameTestImpl(
+      bool ascending,
+      const std::string& function,
+      const RangeFrameBound& startBound,
+      const RangeFrameBound& endBound,
+      bool unorderedColumns);
 };
 } // namespace facebook::velox::window::test


### PR DESCRIPTION
Summary:
When Window operator is initialized, WindowBuild reorders the input columns to 
place partition keys and sorting keys first before adding input rows to 
RowContainer. However, for window operations that use kRange frame with 
column boundary, e.g., range between c1 preceding and current row, the original 
column index of the frame column before reordering is passed to 
computeKRangeFrameBounds(), which leads to incorrect result. This diff fixes 
this bug by passing the actual index of the frame column after the reordering to 
computeKRangeFrameBounds().

This diff fixes https://github.com/facebookincubator/velox/issues/9229.

Differential Revision: D55351848


