### PR TITLE
Create UnitLoader

### DIFF
--- a/velox/dwio/common/UnitLoader.h
+++ b/velox/dwio/common/UnitLoader.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace facebook::velox::dwio::common {
+
+class LoadUnit {
+ public:
+  virtual ~LoadUnit() = default;
+
+  // Perform the IO (read)
+  virtual void load() = 0;
+
+  // If memory pressure is to high, we may want to unload the unit
+  virtual void unload() = 0;
+
+  // Number of rows in the unit
+  virtual uint64_t getNumRows() = 0;
+
+  // Number of bytes that the IO will read
+  virtual uint64_t getIoSize() = 0;
+};
+
+class UnitLoader {
+ public:
+  virtual ~UnitLoader() = default;
+
+  // Must block until the unit is loaded. Must return the unit loaded.
+  virtual std::unique_ptr<LoadUnit> loadUnit(uint32_t unit) = 0;
+
+  // Reader reports progress calling this method
+  virtual void
+  onRead(uint32_t unit, uint64_t rowOffsetInUnit, uint64_t rowCount) = 0;
+};
+
+class UnitLoaderFactory {
+ public:
+  virtual ~UnitLoaderFactory() = default;
+  virtual std::unique_ptr<UnitLoader> create(
+      std::vector<std::unique_ptr<LoadUnit>> loadUnits) = 0;
+};
+
+} // namespace facebook::velox::dwio::common


### PR DESCRIPTION
Summary:
Add capability to add prefetch policies to readers through UnitLoaders.

## Usage and responsibilities
```
class LoadStripe : public LoadUnit{/* ... */};

class MyLoadPolicy : public IUnitLoader{/* ... */};

class MyLoadPolicyFactory : IUnitLoaderFactory {
 public:
  virtual std::unique_ptr<IUnitLoader> create(
      std::vector<std::unique_ptr<LoadUnit>> readPlan) {
    return std::make_unique<MyLoadPolicy>(readPlan);
  }
};

class Reader {
 public:
  Reader(IUnitLoaderFactory& factory) {
    // Read footer and figure out stripe metrics
    // auto readPlan = ...
    unitLoader_ = factory.create(readPlan);
  }

  bool read(Batch& batch) {
    if (currentRowInStripe_ > rowsInStripe(currentStripe_)) {
      if (++currentStripe_ > stripeCount_) {
        return false;
      }
      currentRowInStripe_ = 0;

      // Ask for loaded units
      auto loadUnit = unitLoader_->loadUnit(currentStripe_);
      auto loadedStripe = dynamic_cast<LoadStripe&>(*loadUnit);
      data_ = loadedStripe->getMyData();
    }
    uint64_t rowCountToRead = // ...

    // Report progress
    unitLoader_->onRead(currentStripe_, currentRowInStripe_, rowCountToRead);
    return data_->read(batch);
  }

 private:
  std::unique_ptr<IUnitLoader> unitLoader_;
  uint64_t currentStripe_;
  uint64_t currentRowInStripe_;
};

Reviewed By: helfman

Differential Revision: D54837547


