### PR TITLE
Upgrade boost minimum version to v1.84.0 in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -385,7 +385,7 @@ set(BOOST_INCLUDE_LIBRARIES
     thread)
 
 set_source(Boost)
-resolve_dependency(Boost 1.66.0 COMPONENTS ${BOOST_INCLUDE_LIBRARIES})
+resolve_dependency(Boost 1.84.0 COMPONENTS ${BOOST_INCLUDE_LIBRARIES})
 
 # Range-v3 will be enable when the codegen code actually lands keeping it here
 # for reference. find_package(range-v3)


### PR DESCRIPTION
Addresses #9263 

#8679 upgraded boost but missed the minimum required version in CMakeLists.txt, allowing a version incompatible with the new version of folly introduced in #8950 to be used in the build process. 