### PR TITLE
Fix nulls ordering for Range frames

### DIFF
--- a/velox/exec/WindowPartition.h
+++ b/velox/exec/WindowPartition.h
@@ -133,29 +133,29 @@ class WindowPartition {
   // Searches for 'currentRow[frameColumn]' in 'orderByColumn' of rows between
   // 'start' and 'end' in the partition. 'firstMatch' specifies if first or last
   // row is matched.
-  template <bool isAscending>
   vector_size_t searchFrameValue(
       bool firstMatch,
       vector_size_t start,
       vector_size_t end,
       vector_size_t currentRow,
       column_index_t orderByColumn,
-      column_index_t frameColumn) const;
+      column_index_t frameColumn,
+      const CompareFlags& flags) const;
 
-  template <bool isAscending>
   vector_size_t linearSearchFrameValue(
       bool firstMatch,
       vector_size_t start,
       vector_size_t end,
       vector_size_t currentRow,
       column_index_t orderByColumn,
-      column_index_t frameColumn) const;
+      column_index_t frameColumn,
+      const CompareFlags& flags) const;
 
   // Iterates over 'numBlockRows' and searches frame value for each row.
-  template <bool isAscending>
   void updateKRangeFrameBounds(
       bool firstMatch,
       bool isPreceding,
+      const CompareFlags& flags,
       vector_size_t startRow,
       vector_size_t numRows,
       column_index_t frameColumn,

--- a/velox/functions/prestosql/window/tests/AggregateWindowTest.cpp
+++ b/velox/functions/prestosql/window/tests/AggregateWindowTest.cpp
@@ -131,7 +131,9 @@ TEST_F(AggregateWindowTest, variableWidthAggregate) {
 
 // Tests function with k RANGE PRECEDING (FOLLOWING) frames.
 TEST_F(AggregateWindowTest, rangeFrames) {
-  for (const auto& function : kAggregateFunctions) {
+  auto aggregateFunctions = kAggregateFunctions;
+  aggregateFunctions.push_back("array_agg(c2)");
+  for (const auto& function : aggregateFunctions) {
     // count function is skipped as DuckDB returns inconsistent results
     // with Velox for rows with empty frames. Velox expects empty frames to
     // return 0, but DuckDB returns null.
@@ -139,6 +141,38 @@ TEST_F(AggregateWindowTest, rangeFrames) {
       testKRangeFrames(function);
     }
   }
+}
+
+TEST_F(AggregateWindowTest, rangeNullsOrder) {
+  auto c0 = makeNullableFlatVector<int64_t>({1, 2, 1, std::nullopt});
+  auto input = makeRowVector({c0});
+
+  std::string overClause = "order by c0 asc nulls last";
+  // This frame corresponds to range between 0 preceding and 0 following
+  // (since c0 is used for both the ORDER BY and range frame column).
+  // So for each row the frame corresponds to all rows with the same value.
+
+  // This test validates that the null value doesn't mix in the range of
+  // adjacent rows.
+  std::string frameClause = "range between c0 preceding and c0 following";
+  auto arr =
+      makeNullableArrayVector<int64_t>({{1, 1}, {2}, {1, 1}, {std::nullopt}});
+  auto expected = makeRowVector({c0, arr});
+
+  WindowTestBase::testWindowFunction(
+      {input}, "array_agg(c0)", overClause, frameClause, expected);
+
+  overClause = "order by c0 asc nulls first";
+  WindowTestBase::testWindowFunction(
+      {input}, "array_agg(c0)", overClause, frameClause, expected);
+
+  overClause = "order by c0 desc nulls last";
+  WindowTestBase::testWindowFunction(
+      {input}, "array_agg(c0)", overClause, frameClause, expected);
+
+  overClause = "order by c0 desc nulls first";
+  WindowTestBase::testWindowFunction(
+      {input}, "array_agg(c0)", overClause, frameClause, expected);
 }
 
 // Test for aggregates that return NULL as the default value for empty frames


### PR DESCRIPTION
The nullsFirst flag weren't correctly passed in column comparisons for range frames. This caused range values for nulls to match those of adjacent rows for desc nulls last and asc nulls first order clauses. 

Setting the CompareFlags also made me realize an improvement to simplify the code.

Fixes https://github.com/prestodb/presto/issues/21889