### PR TITLE
Add normalize_nan Spark function

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -152,6 +152,11 @@ Mathematical Functions
         SELECT CAST(1 as DECIMAL(20, 3)) * CAST(0 as DECIMAL(20, 3)); -- decimal 0.000000
         SELECT CAST(201e-38 as DECIMAL(38, 38)) * CAST(301e-38 as DECIMAL(38, 38)); -- decimal 0.0000000000000000000000000000000000000
 
+.. spark:function:: normalize_nan(x) -> [same as x]
+
+    Normalize different Nans.
+    Supported types are: REAL, DOUBLE.
+
 .. spark:function:: not(x) -> boolean
 
     Logical not. ::

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -154,7 +154,9 @@ Mathematical Functions
 
 .. spark:function:: normalize_nan(x) -> [same as x]
 
-    Normalize different Nans.
+    Normalize NaNs. This function ensures the generation of a single hash value 
+    for different NaNs through the hash functions. Spark utilizes this function 
+    to prevent erroneous aggregation or joining when NaN keys are involved.
     Supported types are: REAL, DOUBLE.
 
 .. spark:function:: not(x) -> boolean

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -154,9 +154,14 @@ Mathematical Functions
 
 .. spark:function:: normalize_nan(x) -> [same as x]
 
-    Normalize NaNs. This function ensures the generation of a single hash value 
-    for different NaNs through the hash functions. Spark utilizes this function 
-    to prevent erroneous aggregation or joining when NaN keys are involved.
+    In IEEE 754 any value with all bits of the exponent set and at least one 
+    bit of the fraction set represents a NaN. Therefore there can be many 
+    different NaN representations, including quiet and signaling NaNs with sign 
+    bit set or not.
+
+    If x is not a NaN, returns x unmodified. Otherwise, returns 
+    `std::numeric_limits<float>::quiet_NaN()` or `std::numeric_limits<double>::quiet_NaN()` 
+    based on type of x.
     Supported types are: REAL, DOUBLE.
 
 .. spark:function:: not(x) -> boolean

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -318,11 +318,11 @@ struct IsNanFunction {
   }
 };
 
-template <typename T>
+template <typename TExec>
 struct NormalizeNanFunction {
-  template <typename TInput>
-  FOLLY_ALWAYS_INLINE void call(TInput& result, TInput a) {
-    static constexpr TInput kNan = std::numeric_limits<TInput>::quiet_NaN();
+  template <typename T>
+  FOLLY_ALWAYS_INLINE void call(T& result, T a) {
+    static constexpr T kNan = std::numeric_limits<T>::quiet_NaN();
     if (std::isnan(a)) {
       result = kNan;
     } else {

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -319,6 +319,19 @@ struct IsNanFunction {
 };
 
 template <typename T>
+struct NormalizeNanFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE void call(TInput& result, TInput a) {
+    constexpr TInput nan = std::numeric_limits<TInput>::quiet_NaN();
+    if (std::isnan(a)) {
+      result = nan;
+    } else {
+      result = a;
+    }
+  }
+};
+
+template <typename T>
 struct ToHexVarbinaryFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -322,9 +322,9 @@ template <typename T>
 struct NormalizeNanFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE void call(TInput& result, TInput a) {
-    constexpr TInput nan = std::numeric_limits<TInput>::quiet_NaN();
+    static constexpr TInput kNan = std::numeric_limits<TInput>::quiet_NaN();
     if (std::isnan(a)) {
-      result = nan;
+      result = kNan;
     } else {
       result = a;
     }

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -89,6 +89,10 @@ void registerArithmeticFunctions(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_div, prefix + "divide");
   registerFunction<sparksql::IsNanFunction, bool, float>({prefix + "isnan"});
   registerFunction<sparksql::IsNanFunction, bool, double>({prefix + "isnan"});
+  registerFunction<sparksql::NormalizeNanFunction, float, float>(
+      {prefix + "normalize_nan"});
+  registerFunction<sparksql::NormalizeNanFunction, double, double>(
+      {prefix + "normalize_nan"});
 }
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -450,15 +450,18 @@ TEST_F(ArithmeticTest, normalizeNanFloat) {
     return f.value();
   };
 
-  EXPECT_EQ(0.0f, normalizeNan(0.0f));
-  EXPECT_EQ(0.0f, normalizeNan(-0.0f));
-  EXPECT_EQ(1.0f, normalizeNan(1.0f));
+  EXPECT_EQ(toInt64(0.0f), toInt64(normalizeNan(0.0f)));
+  EXPECT_EQ(toInt64(0.0f), toInt64(normalizeNan(-0.0f)));
+  EXPECT_EQ(toInt64(1.0f), toInt64(normalizeNan(1.0f)));
   // folly::hasher<float>()(kNan) != folly::hasher<float>()(0.0f / 0.0f)
   // toInt64(kNan) != toInt64(0.0f / 0.0f)
   EXPECT_EQ(toInt64(normalizeNan(kNan)), toInt64(normalizeNan(kNan)));
   EXPECT_EQ(toInt64(normalizeNan(kNan)), toInt64(normalizeNan(0.0f / 0.0f)));
   EXPECT_EQ(toInt64(normalizeNan(kNan)), toInt64(normalizeNan(kInf - kInf)));
 
+  EXPECT_EQ(hasher(0.0f), hasher(normalizeNan(0.0f)));
+  EXPECT_EQ(hasher(0.0f), hasher(normalizeNan(-0.0f)));
+  EXPECT_EQ(hasher(1.0f), hasher(normalizeNan(1.0f)));
   EXPECT_EQ(hasher(normalizeNan(kNan)), hasher(normalizeNan(kNan)));
   EXPECT_EQ(hasher(normalizeNan(kNan)), hasher(normalizeNan(0.0f / 0.0f)));
   EXPECT_EQ(hasher(normalizeNan(kNan)), hasher(normalizeNan(kInf - kInf)));
@@ -477,10 +480,9 @@ TEST_F(ArithmeticTest, normalizeNanDouble) {
     return f.value();
   };
 
-  EXPECT_EQ(0.0d, normalizeNan(0.0d));
-  EXPECT_EQ(0.0d, normalizeNan(-0.0d));
-  EXPECT_EQ(1.0d, normalizeNan(1.0d));
-
+  EXPECT_EQ(toInt64(0.0d), toInt64(normalizeNan(0.0d)));
+  EXPECT_EQ(toInt64(0.0d), toInt64(normalizeNan(-0.0d)));
+  EXPECT_EQ(toInt64(1.0d), toInt64(normalizeNan(1.0d)));
   EXPECT_EQ(
       toInt64(normalizeNan(kNanDouble)), toInt64(normalizeNan(kNanDouble)));
   EXPECT_EQ(
@@ -489,6 +491,9 @@ TEST_F(ArithmeticTest, normalizeNanDouble) {
       toInt64(normalizeNan(kNanDouble)),
       toInt64(normalizeNan(kInfDouble - kInfDouble)));
 
+  EXPECT_EQ(hasher(0.0d), hasher(normalizeNan(0.0d)));
+  EXPECT_EQ(hasher(0.0d), hasher(normalizeNan(-0.0d)));
+  EXPECT_EQ(hasher(1.0d), hasher(normalizeNan(1.0d)));
   EXPECT_EQ(hasher(normalizeNan(kNanDouble)), hasher(normalizeNan(kNanDouble)));
   EXPECT_EQ(
       hasher(normalizeNan(kNanDouble)), hasher(normalizeNan(0.0d / 0.0d)));

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -480,23 +480,22 @@ TEST_F(ArithmeticTest, normalizeNanDouble) {
     return f.value();
   };
 
-  EXPECT_EQ(toInt64(0.0d), toInt64(normalizeNan(0.0d)));
-  EXPECT_EQ(toInt64(0.0d), toInt64(normalizeNan(-0.0d)));
-  EXPECT_EQ(toInt64(1.0d), toInt64(normalizeNan(1.0d)));
+  EXPECT_EQ(toInt64(0.0), toInt64(normalizeNan(0.0)));
+  EXPECT_EQ(toInt64(0.0), toInt64(normalizeNan(-0.0)));
+  EXPECT_EQ(toInt64(1.0), toInt64(normalizeNan(1.0)));
   EXPECT_EQ(
       toInt64(normalizeNan(kNanDouble)), toInt64(normalizeNan(kNanDouble)));
   EXPECT_EQ(
-      toInt64(normalizeNan(kNanDouble)), toInt64(normalizeNan(0.0d / 0.0d)));
+      toInt64(normalizeNan(kNanDouble)), toInt64(normalizeNan(0.0 / 0.0)));
   EXPECT_EQ(
       toInt64(normalizeNan(kNanDouble)),
       toInt64(normalizeNan(kInfDouble - kInfDouble)));
 
-  EXPECT_EQ(hasher(0.0d), hasher(normalizeNan(0.0d)));
-  EXPECT_EQ(hasher(0.0d), hasher(normalizeNan(-0.0d)));
-  EXPECT_EQ(hasher(1.0d), hasher(normalizeNan(1.0d)));
+  EXPECT_EQ(hasher(0.0), hasher(normalizeNan(0.0)));
+  EXPECT_EQ(hasher(0.0), hasher(normalizeNan(-0.0)));
+  EXPECT_EQ(hasher(1.0), hasher(normalizeNan(1.0)));
   EXPECT_EQ(hasher(normalizeNan(kNanDouble)), hasher(normalizeNan(kNanDouble)));
-  EXPECT_EQ(
-      hasher(normalizeNan(kNanDouble)), hasher(normalizeNan(0.0d / 0.0d)));
+  EXPECT_EQ(hasher(normalizeNan(kNanDouble)), hasher(normalizeNan(0.0 / 0.0)));
   EXPECT_EQ(
       hasher(normalizeNan(kNanDouble)),
       hasher(normalizeNan(kInfDouble - kInfDouble)));

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -438,67 +438,48 @@ TEST_F(ArithmeticTest, isNanDouble) {
 }
 
 TEST_F(ArithmeticTest, normalizeNanFloat) {
-  const auto normalizeNan = [&](std::optional<float> a) {
-    return evaluateOnce<float>("normalize_nan(c0)", a);
+  const auto normalizeNan = [&](float a) {
+    return evaluateOnce<float>("normalize_nan(c0)", std::optional<float>{a})
+        .value();
   };
 
-  const auto hasher = [&](std::optional<float> f) {
-    return folly::hasher<float>()(f.value());
+  const auto toInt32 = [&](float a) {
+    uint32_t fInt;
+    std::memcpy(&fInt, &a, sizeof(a));
+    return fInt;
   };
 
-  const auto toInt64 = [&](std::optional<float> f) -> int64_t {
-    return f.value();
-  };
-
-  EXPECT_EQ(toInt64(0.0f), toInt64(normalizeNan(0.0f)));
-  EXPECT_EQ(toInt64(0.0f), toInt64(normalizeNan(-0.0f)));
-  EXPECT_EQ(toInt64(1.0f), toInt64(normalizeNan(1.0f)));
-  // folly::hasher<float>()(kNan) != folly::hasher<float>()(0.0f / 0.0f)
-  // toInt64(kNan) != toInt64(0.0f / 0.0f)
-  EXPECT_EQ(toInt64(normalizeNan(kNan)), toInt64(normalizeNan(kNan)));
-  EXPECT_EQ(toInt64(normalizeNan(kNan)), toInt64(normalizeNan(0.0f / 0.0f)));
-  EXPECT_EQ(toInt64(normalizeNan(kNan)), toInt64(normalizeNan(kInf - kInf)));
-
-  EXPECT_EQ(hasher(0.0f), hasher(normalizeNan(0.0f)));
-  EXPECT_EQ(hasher(0.0f), hasher(normalizeNan(-0.0f)));
-  EXPECT_EQ(hasher(1.0f), hasher(normalizeNan(1.0f)));
-  EXPECT_EQ(hasher(normalizeNan(kNan)), hasher(normalizeNan(kNan)));
-  EXPECT_EQ(hasher(normalizeNan(kNan)), hasher(normalizeNan(0.0f / 0.0f)));
-  EXPECT_EQ(hasher(normalizeNan(kNan)), hasher(normalizeNan(kInf - kInf)));
+  EXPECT_EQ(0.0f, normalizeNan(0.0f));
+  EXPECT_EQ(0.0f, normalizeNan(-0.0f));
+  EXPECT_EQ(1.0f, normalizeNan(1.0f));
+  EXPECT_EQ(
+      toInt32(kNan),
+      toInt32(normalizeNan(std::numeric_limits<float>::signaling_NaN())));
+  EXPECT_EQ(toInt32(kNan), toInt32(normalizeNan(std::nanf("1"))));
+  EXPECT_EQ(toInt32(kNan), toInt32(normalizeNan(std::nanf("2"))));
 }
 
 TEST_F(ArithmeticTest, normalizeNanDouble) {
-  const auto normalizeNan = [&](std::optional<double> a) {
-    return evaluateOnce<double>("normalize_nan(c0)", a);
+  const auto normalizeNan = [&](double a) {
+    return evaluateOnce<double>("normalize_nan(c0)", std::optional<double>{a})
+        .value();
   };
 
-  const auto hasher = [&](std::optional<double> f) {
-    return folly::hasher<double>()(f.value());
+  const auto toInt64 = [&](double a) {
+    uint64_t fInt;
+    std::memcpy(&fInt, &a, sizeof(a));
+    return fInt;
   };
 
-  const auto toInt64 = [&](std::optional<double> f) -> int64_t {
-    return f.value();
-  };
+  EXPECT_EQ(0.0, normalizeNan(0.0));
+  EXPECT_EQ(0.0, normalizeNan(-0.0));
+  EXPECT_EQ(1.0, normalizeNan(1.0));
 
-  EXPECT_EQ(toInt64(0.0), toInt64(normalizeNan(0.0)));
-  EXPECT_EQ(toInt64(0.0), toInt64(normalizeNan(-0.0)));
-  EXPECT_EQ(toInt64(1.0), toInt64(normalizeNan(1.0)));
   EXPECT_EQ(
-      toInt64(normalizeNan(kNanDouble)), toInt64(normalizeNan(kNanDouble)));
-  EXPECT_EQ(
-      toInt64(normalizeNan(kNanDouble)), toInt64(normalizeNan(0.0 / 0.0)));
-  EXPECT_EQ(
-      toInt64(normalizeNan(kNanDouble)),
-      toInt64(normalizeNan(kInfDouble - kInfDouble)));
-
-  EXPECT_EQ(hasher(0.0), hasher(normalizeNan(0.0)));
-  EXPECT_EQ(hasher(0.0), hasher(normalizeNan(-0.0)));
-  EXPECT_EQ(hasher(1.0), hasher(normalizeNan(1.0)));
-  EXPECT_EQ(hasher(normalizeNan(kNanDouble)), hasher(normalizeNan(kNanDouble)));
-  EXPECT_EQ(hasher(normalizeNan(kNanDouble)), hasher(normalizeNan(0.0 / 0.0)));
-  EXPECT_EQ(
-      hasher(normalizeNan(kNanDouble)),
-      hasher(normalizeNan(kInfDouble - kInfDouble)));
+      toInt64(kNanDouble),
+      toInt64(normalizeNan(std::numeric_limits<double>::signaling_NaN())));
+  EXPECT_EQ(toInt64(kNanDouble), toInt64(normalizeNan(std::nan("1"))));
+  EXPECT_EQ(toInt64(kNanDouble), toInt64(normalizeNan(std::nan("2"))));
 }
 
 TEST_F(ArithmeticTest, hexWithBigint) {


### PR DESCRIPTION
Add normalize_nan Spark function. 
In Spark's optimizer, `NormalizeNaNAndZero` are added for aggregations to 
normalize -0.0 / 0.0 and different NaN. In Velox, we don't need to handle
 0.0 & -0.0, but different NaNs can lead to improper data aggregation. Therefore, 
 we need this expression to normalize different NaNs.
 https://github.com/apache/spark/blob/5f392a219de29b0856884fb95ff3e313f1047013/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NormalizeFloatingNumbers.scala#L173