### PR TITLE
Fix the issue that the splits cannot be skipped for some special case

### DIFF
--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -599,21 +599,28 @@ bool testFilters(
   for (const auto& child : scanSpec->children()) {
     if (child->filter()) {
       const auto& name = child->fieldName();
-      if (!rowType->containsChild(name)) {
-        // If missing column is partition key.
-        auto iter = partitionKey.find(name);
+      auto iter = partitionKey.find(name);
+      // By design, the partition key columns for Iceberg tables are included in
+      // the data files to facilitate partition transform and partition
+      // evolution, so we need to test both cases.
+      if (!rowType->containsChild(name) || iter != partitionKey.end()) {
         if (iter != partitionKey.end() && iter->second.has_value()) {
           auto handlesIter = partitionKeysHandle.find(name);
           VELOX_CHECK(handlesIter != partitionKeysHandle.end());
 
+          // This is a non-null partition key
           return applyPartitionFilter(
               handlesIter->second->dataType()->kind(),
               iter->second.value(),
               child->filter());
         }
-        // Column is missing. Most likely due to schema evolution.
+        // Column is missing, most likely due to schema evolution. Or it's a
+        // partition key but the partition value is NULL.
         if (child->filter()->isDeterministic() &&
             !child->filter()->testNull()) {
+          VLOG(1) << "Skipping " << filePath
+                  << " because the filter testNull() failed for column "
+                  << child->fieldName();
           return false;
         }
       } else {

--- a/velox/dwio/common/Statistics.h
+++ b/velox/dwio/common/Statistics.h
@@ -510,7 +510,7 @@ class Statistics {
    * @param colId id of the column
    * @return one column's statistics
    */
-  virtual const ColumnStatistics& getColumnStatistics(uint32_t colId) const = 0;
+  virtual const ColumnStatistics* getColumnStatistics(uint32_t colId) const = 0;
 
   /**
    * Get the number of columns

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -684,12 +684,13 @@ std::optional<size_t> DwrfRowReader::estimatedRowSizeHelper(
     uint32_t nodeId) const {
   DWIO_ENSURE_LT(nodeId, fileFooter.typesSize(), "Types missing in footer");
 
-  const auto& s = stats.getColumnStatistics(nodeId);
+  const auto* s = stats.getColumnStatistics(nodeId);
   const auto& t = fileFooter.types(nodeId);
-  if (!s.getNumberOfValues()) {
+  if (!s || !s->getNumberOfValues()) {
     return std::nullopt;
   }
-  auto valueCount = s.getNumberOfValues().value();
+
+  auto valueCount = s->getNumberOfValues().value();
   if (valueCount < 1) {
     return 0;
   }
@@ -720,7 +721,7 @@ std::optional<size_t> DwrfRowReader::estimatedRowSizeHelper(
     }
     case TypeKind::VARCHAR: {
       auto stringStats =
-          dynamic_cast<const dwio::common::StringColumnStatistics*>(&s);
+          dynamic_cast<const dwio::common::StringColumnStatistics*>(s);
       if (!stringStats) {
         return std::nullopt;
       }
@@ -732,7 +733,7 @@ std::optional<size_t> DwrfRowReader::estimatedRowSizeHelper(
     }
     case TypeKind::VARBINARY: {
       auto binaryStats =
-          dynamic_cast<const dwio::common::BinaryColumnStatistics*>(&s);
+          dynamic_cast<const dwio::common::BinaryColumnStatistics*>(s);
       if (!binaryStats) {
         return std::nullopt;
       }

--- a/velox/dwio/dwrf/reader/ReaderBase.cpp
+++ b/velox/dwio/dwrf/reader/ReaderBase.cpp
@@ -242,10 +242,15 @@ std::unique_ptr<Statistics> ReaderBase::getStatistics() const {
 
 std::unique_ptr<ColumnStatistics> ReaderBase::getColumnStatistics(
     uint32_t index) const {
+  if (!footer_->statisticsSize()) {
+    return nullptr;
+  }
+
   DWIO_ENSURE_LT(
       index,
       static_cast<uint32_t>(footer_->statisticsSize()),
       "column index out of range");
+
   StatsContext statsContext(getWriterVersion());
   if (!handler_->isEncrypted(index)) {
     auto& stats = footer_->statistics(index);

--- a/velox/dwio/dwrf/reader/ReaderBase.h
+++ b/velox/dwio/dwrf/reader/ReaderBase.h
@@ -48,9 +48,12 @@ class FooterStatisticsImpl : public dwio::common::Statistics {
 
   virtual ~FooterStatisticsImpl() override = default;
 
-  virtual const dwio::common::ColumnStatistics& getColumnStatistics(
+  virtual const dwio::common::ColumnStatistics* getColumnStatistics(
       uint32_t columnId) const override {
-    return *colStats_.at(columnId);
+    if (!colStats_.empty()) {
+      return colStats_.at(columnId).get();
+    }
+    return nullptr;
   }
 
   uint32_t getNumberOfColumns() const override {

--- a/velox/dwio/dwrf/test/E2EWriterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTest.cpp
@@ -1208,11 +1208,12 @@ TEST_F(E2EEncryptionTest, EncryptRoot) {
     ASSERT_FALSE(
         stats.has_intstatistics() || stats.has_doublestatistics() ||
         stats.has_stringstatistics());
-    auto& encrypted = encryptedStats->getColumnStatistics(i);
-    ASSERT_EQ(stats.hasnull(), encrypted.hasNull().value());
-    ASSERT_EQ(stats.numberofvalues(), encrypted.getNumberOfValues());
+    const auto* encrypted = encryptedStats->getColumnStatistics(i);
+    ASSERT_TRUE(encrypted);
+    ASSERT_EQ(stats.hasnull(), encrypted->hasNull().value());
+    ASSERT_EQ(stats.numberofvalues(), encrypted->getNumberOfValues());
     // stats got thru api should not be the basic one
-    ASSERT_EQ(typeid(encrypted) == typeid(const ColumnStatistics&), i == 0);
+    ASSERT_EQ(typeid(*encrypted) == typeid(const ColumnStatistics&), i == 0);
   }
 
   RowReaderOptions rowReaderOpts;
@@ -1287,13 +1288,14 @@ TEST_F(E2EEncryptionTest, EncryptSelectedFields) {
         stats.has_intstatistics() || stats.has_doublestatistics() ||
             stats.has_stringstatistics(),
         (i == 1 || i == 7 || i == 8 || i == 9));
-    auto& encrypted = encryptedStats->getColumnStatistics(i);
-    ASSERT_EQ(stats.hasnull(), encrypted.hasNull().value());
-    ASSERT_EQ(stats.numberofvalues(), encrypted.getNumberOfValues());
+    const auto* encrypted = encryptedStats->getColumnStatistics(i);
+    ASSERT_TRUE(encrypted);
+    ASSERT_EQ(stats.hasnull(), encrypted->hasNull().value());
+    ASSERT_EQ(stats.numberofvalues(), encrypted->getNumberOfValues());
     // stats got thru api should not be the basic one unless they are
     // intermediate nodes
     ASSERT_EQ(
-        typeid(encrypted) == typeid(const ColumnStatistics&),
+        typeid(*encrypted) == typeid(const ColumnStatistics&),
         (i == 0 || i == 3 || i == 6 || i == 10 || i == 11));
   }
 

--- a/velox/dwio/dwrf/test/ReaderBaseTests.cpp
+++ b/velox/dwio/dwrf/test/ReaderBaseTests.cpp
@@ -129,11 +129,12 @@ class EncryptedStatsTest : public Test {
 TEST_F(EncryptedStatsTest, getStatistics) {
   auto stats = reader_->getStatistics();
   for (size_t i = 1; i < 7; ++i) {
-    auto& stat = stats->getColumnStatistics(i);
+    const auto* stat = stats->getColumnStatistics(i);
+    ASSERT_TRUE(stat);
     if (i != 5) {
-      ASSERT_EQ(stat.getNumberOfValues(), i * 100);
+      ASSERT_EQ(stat->getNumberOfValues(), i * 100);
     } else {
-      ASSERT_EQ(stat.getNumberOfValues(), i);
+      ASSERT_EQ(stat->getNumberOfValues(), i);
     }
   }
 }
@@ -142,11 +143,11 @@ TEST_F(EncryptedStatsTest, getStatisticsKeyNotLoaded) {
   clearKey(0);
   auto stats = reader_->getStatistics();
   for (size_t i = 2; i < 7; ++i) {
-    auto& stat = stats->getColumnStatistics(i);
+    const auto* stat = stats->getColumnStatistics(i);
     if (i != 5) {
-      ASSERT_EQ(stat.getNumberOfValues(), i * 100);
+      ASSERT_EQ(stat->getNumberOfValues(), i * 100);
     } else {
-      ASSERT_EQ(stat.getNumberOfValues(), i);
+      ASSERT_EQ(stat->getNumberOfValues(), i);
     }
   }
 }

--- a/velox/dwio/dwrf/writer/Writer.h
+++ b/velox/dwio/dwrf/writer/Writer.h
@@ -38,6 +38,7 @@ struct WriterOptions {
   // If not null, used by memory arbitration to track if a file writer is under
   // memory reclaimable section or not.
   tsan_atomic<bool>* nonReclaimableSection{nullptr};
+  bool writeColumnStats{true};
   /// The default factory allows the writer to construct the default flush
   /// policy with the configs in its ctor.
   std::function<std::unique_ptr<DWRFFlushPolicy>()> flushPolicyFactory;
@@ -210,6 +211,10 @@ class Writer : public dwio::common::Writer {
   std::unique_ptr<DWRFFlushPolicy> flushPolicy_;
   std::unique_ptr<LayoutPlanner> layoutPlanner_;
   std::unique_ptr<ColumnWriter> writer_;
+  // For tests only. When writeColumnStats_ is set to true, the ColumnStatistics
+  // would NOT be written at all. Note that this is different from writing empty
+  // ColumnStatistics.
+  bool writeColumnStats_;
 };
 
 class DwrfWriterFactory : public dwio::common::WriterFactory {

--- a/velox/dwio/dwrf/writer/WriterBase.cpp
+++ b/velox/dwio/dwrf/writer/WriterBase.cpp
@@ -37,7 +37,6 @@ void WriterBase::writeFooter(const Type& type) {
   }
 
   ProtoUtils::writeType(type, footer_);
-  DWIO_ENSURE_EQ(footer_.types_size(), footer_.statistics_size());
   auto writerVersion =
       static_cast<uint32_t>(context_->getConfig(Config::WRITER_VERSION));
   writeUserMetadata(writerVersion);

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -76,6 +76,16 @@ class TableScanTest : public virtual HiveConnectorTestBase {
   std::vector<RowVectorPtr> makeVectors(
       int32_t count,
       int32_t rowsPerVector,
+      const RowTypePtr& rowType = nullptr,
+      std::function<bool(vector_size_t /*index*/)> isNullAt = nullptr) {
+    auto inputs = rowType ? rowType : rowType_;
+    return HiveConnectorTestBase::makeVectors(
+        inputs, count, rowsPerVector, isNullAt);
+  }
+
+  std::vector<RowVectorPtr> makeNullableVectors(
+      int32_t count,
+      int32_t rowsPerVector,
       const RowTypePtr& rowType = nullptr) {
     auto inputs = rowType ? rowType : rowType_;
     return HiveConnectorTestBase::makeVectors(inputs, count, rowsPerVector);
@@ -172,7 +182,8 @@ class TableScanTest : public virtual HiveConnectorTestBase {
   void testPartitionedTableImpl(
       const std::string& filePath,
       const TypePtr& partitionType,
-      const std::optional<std::string>& partitionValue) {
+      const std::optional<std::string>& partitionValue,
+      bool isPartitionColumnInFile = false) {
     auto split = HiveConnectorSplitBuilder(filePath)
                      .partitionKey("pkey", partitionValue)
                      .build();
@@ -192,8 +203,11 @@ class TableScanTest : public virtual HiveConnectorTestBase {
 
     std::string partitionValueStr =
         partitionValue.has_value() ? "'" + *partitionValue + "'" : "null";
-    assertQuery(
-        op, split, fmt::format("SELECT {}, * FROM tmp", partitionValueStr));
+
+    std::string duckdbSql = isPartitionColumnInFile
+        ? "SELECT * FROM tmp"
+        : fmt::format("SELECT {}, * FROM tmp", partitionValueStr);
+    assertQuery(op, split, duckdbSql);
 
     outputType = ROW({"c0", "pkey", "c1"}, {BIGINT(), partitionType, DOUBLE()});
     op = PlanBuilder()
@@ -231,12 +245,60 @@ class TableScanTest : public virtual HiveConnectorTestBase {
         op, split, fmt::format("SELECT {} FROM tmp", partitionValueStr));
   }
 
-  void testPartitionedTable(
+  void testPartitionedTableWithFilterOnPartitionKey(
+      const RowTypePtr& fileSchema,
       const std::string& filePath,
       const TypePtr& partitionType,
       const std::optional<std::string>& partitionValue) {
-    testPartitionedTableImpl(filePath, partitionType, partitionValue);
-    testPartitionedTableImpl(filePath, partitionType, std::nullopt);
+    // The filter on the partition key cannot eliminate the partition, therefore
+    // the split should NOT be skipped and all rows in it should be selected.
+    auto split = HiveConnectorSplitBuilder(filePath)
+                     .partitionKey("pkey", partitionValue)
+                     .build();
+    auto outputType = ROW({"c0", "c1"}, {BIGINT(), DOUBLE()});
+    ColumnHandleMap assignments = {
+        {"pkey", partitionKey("pkey", partitionType)},
+        {"c0", regularColumn("c0", BIGINT())},
+        {"c1", regularColumn("c1", DOUBLE())}};
+    std::string filter = partitionValue.has_value()
+        ? "pkey = " + partitionValue.value()
+        : "pkey IS NULL";
+    auto op = PlanBuilder()
+                  .startTableScan()
+                  .dataColumns(fileSchema)
+                  .outputType(outputType)
+                  .assignments(assignments)
+                  .subfieldFilter(filter)
+                  .endTableScan()
+                  .planNode();
+
+    assertQuery(op, split, fmt::format("SELECT c0, c1 FROM tmp"));
+
+    // The split should be skipped because the partition key does not pass
+    // the filter
+    filter = partitionValue.has_value() ? "pkey <> " + partitionValue.value()
+                                        : "pkey IS NOT NULL";
+    op = PlanBuilder()
+             .startTableScan()
+             .dataColumns(fileSchema)
+             .outputType(outputType)
+             .assignments(assignments)
+             .subfieldFilter(filter)
+             .endTableScan()
+             .planNode();
+    assertQuery(op, split, fmt::format("SELECT c0, c1 FROM tmp WHERE 1 = 0"));
+  }
+
+  void testPartitionedTable(
+      const std::string& filePath,
+      const TypePtr& partitionType,
+      const std::optional<std::string>& partitionValue,
+      const RowTypePtr& fileSchema = nullptr,
+      bool isPartitionColumnInFile = false) {
+    testPartitionedTableImpl(
+        filePath, partitionType, partitionValue, isPartitionColumnInFile);
+    testPartitionedTableImpl(
+        filePath, partitionType, std::nullopt, isPartitionColumnInFile);
   }
 
   RowTypePtr rowType_{
@@ -1752,6 +1814,27 @@ TEST_F(TableScanTest, partitionedTableDateKey) {
   writeToFile(filePath->getPath(), vectors);
   createDuckDbTable(vectors);
   testPartitionedTable(filePath->getPath(), DATE(), "2023-10-27");
+}
+
+// Partition key was written as a real column in the data file, and the value is
+// NULL. The column does not have column statistics
+TEST_F(TableScanTest, partitionedTablePartitionKeyInFile) {
+  auto fileSchema = ROW({"c0", "c1", "pkey"}, {BIGINT(), DOUBLE(), BIGINT()});
+  auto filePath = TempFilePath::create();
+  // Create values of all nulls.
+  auto vectors =
+      makeVectors(10, 1'000, fileSchema, [](vector_size_t i) { return true; });
+  //  auto vectors = makeVectors(10, 1'000, rowType);
+  writeToFile(
+      filePath->getPath(),
+      vectors,
+      std::make_shared<facebook::velox::dwrf::Config>(),
+      false);
+  createDuckDbTable(vectors);
+  testPartitionedTable(
+      filePath->getPath(), BIGINT(), std::nullopt, fileSchema, true);
+  testPartitionedTableWithFilterOnPartitionKey(
+      fileSchema, filePath->getPath(), BIGINT(), std::nullopt);
 }
 
 std::vector<StringView> toStringViews(const std::vector<std::string>& values) {

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -70,7 +70,8 @@ void HiveConnectorTestBase::writeToFile(
 void HiveConnectorTestBase::writeToFile(
     const std::string& filePath,
     const std::vector<RowVectorPtr>& vectors,
-    std::shared_ptr<dwrf::Config> config) {
+    std::shared_ptr<dwrf::Config> config,
+    bool writeColumnStats) {
   velox::dwrf::WriterOptions options;
   options.config = config;
   options.schema = vectors[0]->type();
@@ -79,6 +80,8 @@ void HiveConnectorTestBase::writeToFile(
       std::move(localWriteFile), filePath);
   auto childPool = rootPool_->addAggregateChild("HiveConnectorTestBase.Writer");
   options.memoryPool = childPool.get();
+  options.writeColumnStats = writeColumnStats;
+
   facebook::velox::dwrf::Writer writer{std::move(sink), options};
   for (size_t i = 0; i < vectors.size(); ++i) {
     writer.write(vectors[i]);

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -92,11 +92,13 @@ void HiveConnectorTestBase::writeToFile(
 std::vector<RowVectorPtr> HiveConnectorTestBase::makeVectors(
     const RowTypePtr& rowType,
     int32_t numVectors,
-    int32_t rowsPerVector) {
+    int32_t rowsPerVector,
+    std::function<bool(vector_size_t /*index*/)> isNullAt) {
   std::vector<RowVectorPtr> vectors;
   for (int32_t i = 0; i < numVectors; ++i) {
     auto vector = std::dynamic_pointer_cast<RowVector>(
-        velox::test::BatchMaker::createBatch(rowType, rowsPerVector, *pool_));
+        velox::test::BatchMaker::createBatch(
+            rowType, rowsPerVector, *pool_, isNullAt));
     vectors.push_back(vector);
   }
   return vectors;

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -47,7 +47,8 @@ class HiveConnectorTestBase : public OperatorTestBase {
       const std::string& filePath,
       const std::vector<RowVectorPtr>& vectors,
       std::shared_ptr<dwrf::Config> config =
-          std::make_shared<facebook::velox::dwrf::Config>());
+          std::make_shared<facebook::velox::dwrf::Config>(),
+      bool writeColumnStats = true);
 
   std::vector<RowVectorPtr> makeVectors(
       const RowTypePtr& rowType,

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -53,7 +53,8 @@ class HiveConnectorTestBase : public OperatorTestBase {
   std::vector<RowVectorPtr> makeVectors(
       const RowTypePtr& rowType,
       int32_t numVectors,
-      int32_t rowsPerVector);
+      int32_t rowsPerVector,
+      std::function<bool(vector_size_t /*index*/)> isNullAt = nullptr);
 
   using OperatorTestBase::assertQuery;
 


### PR DESCRIPTION
In some rare case, the tables created by other engines would put the
    partition key columns in the data file too, and fail to write ColumnStats
    for such columns. In such case, the split from a partition with NULL
    partition keys failed to be skipped, causing wrong results. This is
    because HiveConnectorUtils::testFilters() assumes the partition keys are
    not in the data file, therefore is unable to apply the filter on the
    partition key. This commit fixes this issue by also checking the partition
    key list even when the partition columns are in the data file.