### PR TITLE
Optimize addNullsForUnselectedRows

### DIFF
--- a/velox/functions/lib/LambdaFunctionUtil.cpp
+++ b/velox/functions/lib/LambdaFunctionUtil.cpp
@@ -158,7 +158,7 @@ BufferPtr addNullsForUnselectedRows(
     const VectorPtr& vector,
     const SelectivityVector& rows) {
   // Set nulls for rows not present in 'rows'.
-  BufferPtr nulls = allocateNulls(vector->size(), vector->pool(), bits::kNull);
+  BufferPtr nulls = allocateNulls(rows.size(), vector->pool(), bits::kNull);
 
   // bits::kNull is 0. Hence, bits::orBits() simply copies the bits from the
   // selectivity vector into the nulls buffer. We cannot use memcpy because it

--- a/velox/functions/lib/LambdaFunctionUtil.h
+++ b/velox/functions/lib/LambdaFunctionUtil.h
@@ -88,8 +88,9 @@ MapVectorPtr flattenMap(
     const VectorPtr& vector,
     DecodedVector& decodedVector);
 
-// Makes a copy of the original nulls in 'vector' and adds nulls for unselected
-// rows in 'rows'
+// Creates a nulls buffer to hold rows.size() nulls. Copies the original nulls
+// in 'vector' for positions [rows.begin(), rows.end()) and sets nulls for
+// unselected rows in 'rows'.
 BufferPtr addNullsForUnselectedRows(
     const VectorPtr& vector,
     const SelectivityVector& rows);

--- a/velox/functions/prestosql/Transform.cpp
+++ b/velox/functions/prestosql/Transform.cpp
@@ -77,7 +77,7 @@ class TransformFunction : public exec::VectorFunction {
         flatArray->pool(),
         outputType,
         std::move(newNulls),
-        flatArray->size(),
+        rows.end(),
         flatArray->offsets(),
         flatArray->sizes(),
         newElements);

--- a/velox/functions/prestosql/TransformKeys.cpp
+++ b/velox/functions/prestosql/TransformKeys.cpp
@@ -106,7 +106,7 @@ class TransformKeysFunction : public exec::VectorFunction {
         flatMap->pool(),
         outputType,
         std::move(newNulls),
-        flatMap->size(),
+        rows.end(),
         flatMap->offsets(),
         flatMap->sizes(),
         transformedKeys,

--- a/velox/functions/prestosql/TransformValues.cpp
+++ b/velox/functions/prestosql/TransformValues.cpp
@@ -77,7 +77,7 @@ class TransformValuesFunction : public exec::VectorFunction {
         flatMap->pool(),
         outputType,
         std::move(newNulls),
-        flatMap->size(),
+        rows.end(),
         flatMap->offsets(),
         flatMap->sizes(),
         flatMap->mapKeys(),


### PR DESCRIPTION
Summary: addNullsForUnselectedRows used to create nulls buffer or a size larger then necessary.

Differential Revision: D55457803


