### PR TITLE
Fix BaseVector::flattenVector for Lazy input

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -864,7 +864,7 @@ void BaseVector::flattenVector(VectorPtr& vector) {
       return;
     }
     case VectorEncoding::Simple::LAZY: {
-      auto loadedVector =
+      auto& loadedVector =
           vector->asUnchecked<LazyVector>()->loadedVectorShared();
       BaseVector::flattenVector(loadedVector);
       return;

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -2754,6 +2754,12 @@ TEST_F(VectorTest, flattenVector) {
   test(dictionary, false);
   EXPECT_TRUE(dictionary->isFlatEncoding());
 
+  VectorPtr lazyDictionary =
+      wrapInLazyDictionary(makeFlatVector<int32_t>({1, 2, 3}));
+  test(lazyDictionary, true);
+  EXPECT_TRUE(lazyDictionary->isLazy());
+  EXPECT_TRUE(lazyDictionary->loadedVector()->isFlatEncoding());
+
   // Array with constant elements.
   auto* arrayVector = array->as<ArrayVector>();
   arrayVector->elements() = BaseVector::wrapInConstant(100, 1, flat);


### PR DESCRIPTION
The current implementation in `flattenVector` doesn't modify the loaded vector in `LazyVector`. Because the `loadedVector` is not a reference, the flattening doesn't take effect.

https://github.com/facebookincubator/velox/blob/0c86a0aedb90bfa966087def7551a40fc3571a01/velox/vector/BaseVector.cpp#L866-L871

Fixes #8697 