### PR TITLE
Spill test improvement and some cleanup

### DIFF
--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -358,6 +358,20 @@ void MemoryPool::dropChild(const MemoryPool* child) {
       toString());
 }
 
+bool MemoryPool::aborted() const {
+  if (parent_ != nullptr) {
+    return parent_->aborted();
+  }
+  return aborted_;
+}
+
+std::exception_ptr MemoryPool::abortError() const {
+  if (parent_ != nullptr) {
+    return parent_->abortError();
+  }
+  return abortError_;
+}
+
 size_t MemoryPool::preferredSize(size_t size) {
   if (size < 8) {
     return 8;
@@ -1021,13 +1035,6 @@ uint64_t MemoryPoolImpl::grow(uint64_t bytes) noexcept {
   return capacity_;
 }
 
-bool MemoryPoolImpl::aborted() const {
-  if (parent_ != nullptr) {
-    return parent_->aborted();
-  }
-  return aborted_;
-}
-
 void MemoryPoolImpl::abort(const std::exception_ptr& error) {
   VELOX_CHECK_NOT_NULL(error);
   if (parent_ != nullptr) {
@@ -1051,8 +1058,8 @@ void MemoryPoolImpl::setAbortError(const std::exception_ptr& error) {
 
 void MemoryPoolImpl::checkIfAborted() const {
   if (FOLLY_UNLIKELY(aborted())) {
-    VELOX_CHECK_NOT_NULL(abortError_);
-    std::rethrow_exception(abortError_);
+    VELOX_CHECK_NOT_NULL(abortError());
+    std::rethrow_exception(abortError());
   }
 }
 

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -414,7 +414,7 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   virtual void abort(const std::exception_ptr& error) = 0;
 
   /// Returns true if this memory pool has been aborted.
-  virtual bool aborted() const = 0;
+  virtual bool aborted() const;
 
   /// The memory pool's execution stats.
   struct Stats {
@@ -506,6 +506,8 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
       Kind kind,
       bool threadSafe,
       std::unique_ptr<MemoryReclaimer> reclaimer) = 0;
+
+  virtual std::exception_ptr abortError() const;
 
   /// Invoked only on destruction to remove this memory pool from its parent's
   /// child memory pool tracking.
@@ -642,8 +644,6 @@ class MemoryPoolImpl : public MemoryPool {
   uint64_t grow(uint64_t bytes) noexcept override;
 
   void abort(const std::exception_ptr& error) override;
-
-  bool aborted() const override;
 
   std::string toString() const override {
     std::lock_guard<std::mutex> l(mutex_);

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -241,15 +241,6 @@ class QueryConfig {
   /// The max allowed spill file size. If it is zero, then there is no limit.
   static constexpr const char* kMaxSpillFileSize = "max_spill_file_size";
 
-  /// The min spill run size limit used to select partitions for spilling. The
-  /// spiller tries to spill a previously spilled partitions if its data size
-  /// exceeds this limit, otherwise it spills the partition with most data.
-  /// If the limit is zero, then the spiller always spill a previously spilled
-  /// partition if it has any data. This is to avoid spill from a partition with
-  /// a small amount of data which might result in generating too many small
-  /// spilled files.
-  static constexpr const char* kMinSpillRunSize = "min_spill_run_size";
-
   static constexpr const char* kSpillCompressionKind =
       "spill_compression_codec";
 
@@ -586,11 +577,6 @@ class QueryConfig {
   uint64_t maxSpillFileSize() const {
     constexpr uint64_t kDefaultMaxFileSize = 0;
     return get<uint64_t>(kMaxSpillFileSize, kDefaultMaxFileSize);
-  }
-
-  uint64_t minSpillRunSize() const {
-    constexpr uint64_t kDefaultMinSpillRunSize = 256 << 20; // 256MB.
-    return get<uint64_t>(kMinSpillRunSize, kDefaultMinSpillRunSize);
   }
 
   std::string spillCompressionKind() const {

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -824,7 +824,8 @@ void GroupingSet::ensureInputFits(const RowVectorPtr& input) {
 
   // Test-only spill path.
   if (testingTriggerSpill()) {
-    spill();
+    memory::ReclaimableSectionGuard guard(nonReclaimableSection_);
+    memory::testingRunArbitration(&pool_);
     return;
   }
 

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -222,7 +222,7 @@ class HashProbe : public Operator {
 
   // Produces and spills outputs from operator which has pending input to
   // process in probe 'operators'.
-  void spillOutput(const std::vector<Operator*>& operators);
+  void spillOutput(const std::vector<HashProbe*>& operators);
   // Produces and spills output from this probe operator.
   void spillOutput();
 
@@ -278,8 +278,11 @@ class HashProbe : public Operator {
         spillInputPartitionIds_.empty();
   }
 
+  // Find the peer hash probe operators in the same pipeline.
+  std::vector<HashProbe*> findPeerOperators();
+
   // Wake up the peer hash probe operators when last probe operator finishes.
-  void wakeupPeers();
+  void wakeupPeerOperators();
 
   //  std::vector<Operator*> findPeerOperators();
 

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -599,7 +599,12 @@ uint64_t Operator::MemoryReclaimer::reclaim(
   VELOX_CHECK_EQ(pool->name(), op_->pool()->name());
   VELOX_CHECK(
       !driver->state().isOnThread() || driver->state().isSuspended ||
-      driver->state().isTerminated);
+          driver->state().isTerminated,
+      "driverOnThread {}, driverSuspended {} driverTerminated {} {}",
+      driver->state().isOnThread(),
+      driver->state().isSuspended,
+      driver->state().isTerminated,
+      pool->name());
   VELOX_CHECK(driver->task()->pauseRequested());
 
   TestValue::adjust(

--- a/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
@@ -125,8 +125,43 @@ int64_t spilledBytes(const exec::Task& task) {
       spilledBytes += op.spilledBytes;
     }
   }
-
   return spilledBytes;
+}
+
+// Returns total spilled rows inside 'task'.
+int64_t spilledRows(const exec::Task& task) {
+  auto stats = task.taskStats();
+  int64_t spilledRows = 0;
+  for (auto& pipeline : stats.pipelineStats) {
+    for (auto op : pipeline.operatorStats) {
+      spilledRows += op.spilledRows;
+    }
+  }
+  return spilledRows;
+}
+
+// Returns total spilled input bytes inside 'task'.
+int64_t spilledInputBytes(const exec::Task& task) {
+  auto stats = task.taskStats();
+  int64_t spilledInputBytes = 0;
+  for (auto& pipeline : stats.pipelineStats) {
+    for (auto op : pipeline.operatorStats) {
+      spilledInputBytes += op.spilledInputBytes;
+    }
+  }
+  return spilledInputBytes;
+}
+
+// Returns total spilled files inside 'task'.
+int64_t spilledFiles(const exec::Task& task) {
+  auto stats = task.taskStats();
+  int64_t spilledFiles = 0;
+  for (auto& pipeline : stats.pipelineStats) {
+    for (auto op : pipeline.operatorStats) {
+      spilledFiles += op.spilledFiles;
+    }
+  }
+  return spilledFiles;
 }
 
 // Add a BIGINT column of 4 distinct values to data.
@@ -374,11 +409,22 @@ void AggregationTestBase::testAggregationsWithCompanion(
     auto task = assertResults(queryBuilder);
 
     // Expect > 0 spilled bytes unless there was no input.
-    auto inputRows = toPlanStats(task->taskStats()).at(partialNodeId).inputRows;
+    const auto inputRows =
+        toPlanStats(task->taskStats()).at(partialNodeId).inputRows;
     if (inputRows > 1) {
-      EXPECT_LT(0, spilledBytes(*task));
+      EXPECT_LT(0, spilledBytes(*task))
+          << "inputRows: " << inputRows
+          << " spilledRows: " << spilledRows(*task)
+          << " spilledInputBytes: " << spilledInputBytes(*task)
+          << " spilledFiles: " << spilledFiles(*task)
+          << " injectedSpills: " << exec::injectedSpillCount();
     } else {
-      EXPECT_EQ(0, spilledBytes(*task));
+      EXPECT_EQ(0, spilledBytes(*task))
+          << "inputRows: " << inputRows
+          << " spilledRows: " << spilledRows(*task)
+          << " spilledInputBytes: " << spilledInputBytes(*task)
+          << " spilledFiles: " << spilledFiles(*task)
+          << " injectedSpills: " << exec::injectedSpillCount();
     }
   }
 
@@ -798,13 +844,23 @@ void AggregationTestBase::testAggregationsImpl(
     // Expect > 0 spilled bytes unless there was no input.
     auto inputRows = toPlanStats(task->taskStats()).at(partialNodeId).inputRows;
     if (inputRows > 1) {
-      EXPECT_LT(0, spilledBytes(*task));
+      EXPECT_LT(0, spilledBytes(*task))
+          << "inputRows: " << inputRows
+          << " spilledRows: " << spilledRows(*task)
+          << " spilledInputBytes: " << spilledInputBytes(*task)
+          << " spilledFiles: " << spilledFiles(*task)
+          << " injectedSpills: " << exec::injectedSpillCount();
       ASSERT_EQ(memory::spillMemoryPool()->stats().currentBytes, 0);
       ASSERT_GT(memory::spillMemoryPool()->stats().peakBytes, 0);
       ASSERT_GE(
           memory::spillMemoryPool()->stats().peakBytes, peakSpillMemoryUsage);
     } else {
-      EXPECT_EQ(0, spilledBytes(*task));
+      EXPECT_EQ(0, spilledBytes(*task))
+          << "inputRows: " << inputRows
+          << " spilledRows: " << spilledRows(*task)
+          << " spilledInputBytes: " << spilledInputBytes(*task)
+          << " spilledFiles: " << spilledFiles(*task)
+          << " injectedSpills: " << exec::injectedSpillCount();
     }
   }
 


### PR DESCRIPTION
Add to cover spill injection on hash table build stage.
Replace spill() with testingRunArbitration() for spill injection
Fix some spilling and memory tests
Remove the deprecated spill query config