### PR TITLE
Add test for decimal multiply when result scale exceeds the precision

### DIFF
--- a/velox/functions/prestosql/DecimalFunctions.cpp
+++ b/velox/functions/prestosql/DecimalFunctions.cpp
@@ -363,6 +363,7 @@ void registerDecimalMultiply(const std::string& prefix) {
           exec::ParameterType::kIntegerParameter),
       exec::SignatureVariable(
           S3::name(),
+          // Result type resolution fails if sum of input scales exceeds 38.
           fmt::format(
               "{a_scale} + {b_scale}",
               fmt::arg("a_scale", S1::name()),

--- a/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
@@ -291,6 +291,14 @@ TEST_F(DecimalArithmeticTest, multiply) {
                   HugeInt::build(0x08FFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF)},
               DECIMAL(38, 0))}),
       "Decimal overflow. Value '119630519620642428561342635425231011830' is not in the range of Decimal Type");
+
+  // The sum of input scales exceeds 38.
+  VELOX_ASSERT_THROW(
+      evaluate(
+          "c0 * c0",
+          makeRowVector(
+              {makeFlatVector<int128_t>({1000, 2000}, DECIMAL(38, 30))})),
+      "");
 }
 
 TEST_F(DecimalArithmeticTest, decimalDivTest) {


### PR DESCRIPTION
When the result scale of decimal multiply exceeds the precision, exception 
occurs during the decimal type creation.