### PR TITLE
Extend tests for transformXxx Presto lambda functions

### DIFF
--- a/velox/functions/lib/LambdaFunctionUtil.cpp
+++ b/velox/functions/lib/LambdaFunctionUtil.cpp
@@ -158,7 +158,7 @@ BufferPtr addNullsForUnselectedRows(
     const VectorPtr& vector,
     const SelectivityVector& rows) {
   // Set nulls for rows not present in 'rows'.
-  BufferPtr nulls = allocateNulls(vector->size(), vector->pool(), bits::kNull);
+  BufferPtr nulls = allocateNulls(rows.size(), vector->pool(), bits::kNull);
 
   // bits::kNull is 0. Hence, bits::orBits() simply copies the bits from the
   // selectivity vector into the nulls buffer. We cannot use memcpy because it

--- a/velox/functions/lib/LambdaFunctionUtil.h
+++ b/velox/functions/lib/LambdaFunctionUtil.h
@@ -88,8 +88,9 @@ MapVectorPtr flattenMap(
     const VectorPtr& vector,
     DecodedVector& decodedVector);
 
-// Makes a copy of the original nulls in 'vector' and adds nulls for unselected
-// rows in 'rows'
+// Creates a nulls buffer to hold rows.size() nulls. Copies the original nulls
+// in 'vector' for positions [rows.begin(), rows.end()) and sets nulls for
+// unselected rows in 'rows'.
 BufferPtr addNullsForUnselectedRows(
     const VectorPtr& vector,
     const SelectivityVector& rows);

--- a/velox/functions/prestosql/Transform.cpp
+++ b/velox/functions/prestosql/Transform.cpp
@@ -77,7 +77,7 @@ class TransformFunction : public exec::VectorFunction {
         flatArray->pool(),
         outputType,
         std::move(newNulls),
-        flatArray->size(),
+        rows.end(),
         flatArray->offsets(),
         flatArray->sizes(),
         newElements);

--- a/velox/functions/prestosql/TransformKeys.cpp
+++ b/velox/functions/prestosql/TransformKeys.cpp
@@ -106,7 +106,7 @@ class TransformKeysFunction : public exec::VectorFunction {
         flatMap->pool(),
         outputType,
         std::move(newNulls),
-        flatMap->size(),
+        rows.end(),
         flatMap->offsets(),
         flatMap->sizes(),
         transformedKeys,

--- a/velox/functions/prestosql/TransformValues.cpp
+++ b/velox/functions/prestosql/TransformValues.cpp
@@ -77,7 +77,7 @@ class TransformValuesFunction : public exec::VectorFunction {
         flatMap->pool(),
         outputType,
         std::move(newNulls),
-        flatMap->size(),
+        rows.end(),
         flatMap->offsets(),
         flatMap->sizes(),
         flatMap->mapKeys(),

--- a/velox/functions/prestosql/tests/TransformValuesTest.cpp
+++ b/velox/functions/prestosql/tests/TransformValuesTest.cpp
@@ -69,19 +69,33 @@ TEST_F(TransformValuesTest, evaluateSubsetOfRows) {
           nullEvery(13)),
   });
 
-  SelectivityVector inputRows(size, false);
-  inputRows.setValidRange(0, size / 3, true);
-  inputRows.updateBounds();
-
-  auto result = evaluate<MapVector>(
-      "transform_values(c0, (k, v) -> v + 5)", input, inputRows);
+  // Test using 2 selectivity vectors. One of size 100 with 33 first rows
+  // selected. Another of size 33 with all rows selected. Both should produce
+  // the same result.
   auto expectedResult = makeMapVector<int32_t, int64_t>(
       size / 3,
       [](auto row) { return row % 5; },
       [](auto row) { return row % 7; },
       [](auto row) { return row % 11 + 5; },
       nullEvery(13));
-  assertEqualVectors(expectedResult, result, inputRows);
+
+  {
+    SelectivityVector inputRows(size, false);
+    inputRows.setValidRange(0, size / 3, true);
+    inputRows.updateBounds();
+
+    auto result = evaluate<MapVector>(
+        "transform_values(c0, (k, v) -> v + 5)", input, inputRows);
+    assertEqualVectors(expectedResult, result, inputRows);
+  }
+
+  {
+    SelectivityVector inputRows(size / 3);
+
+    auto result = evaluate<MapVector>(
+        "transform_values(c0, (k, v) -> v + 5)", input, inputRows);
+    assertEqualVectors(expectedResult, result, inputRows);
+  }
 }
 
 TEST_F(TransformValuesTest, differentResultType) {


### PR DESCRIPTION
Summary:
Extend tests for transform, transform_keys and transform_values lambda functions
to cover scenario described in
https://github.com/facebookincubator/velox/issues/9288

Differential Revision: D55474277


