### PR TITLE
Add resolveFunctionWithMetadata API

### DIFF
--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -356,19 +356,9 @@ bool isDeterministic(
     return true;
   }
 
-  // Check if this is a simple function.
-  if (auto simpleFunctionEntry =
-          exec::simpleFunctions().resolveFunction(functionName, argTypes)) {
-    return simpleFunctionEntry->metadata().deterministic;
-  }
-
-  // Vector functions are a bit more complicated. We need to fetch the list of
-  // available signatures and check if any of them bind given the current
-  // input arg types. If it binds (if there's a match), we fetch the function
-  // and return the isDeterministic bool.
-  if (auto functionWithMetadata =
-          exec::resolveVectorFunctionWithMetadata(functionName, argTypes)) {
-    return functionWithMetadata->second.deterministic;
+  if (auto typeAndMetadata =
+          resolveFunctionWithMetadata(functionName, argTypes)) {
+    return typeAndMetadata->second.deterministic;
   }
 
   // functionName must be a special form.

--- a/velox/functions/FunctionRegistry.cpp
+++ b/velox/functions/FunctionRegistry.cpp
@@ -82,6 +82,19 @@ TypePtr resolveFunction(
   return resolveVectorFunction(functionName, argTypes);
 }
 
+std::optional<std::pair<TypePtr, exec::VectorFunctionMetadata>>
+resolveFunctionWithMetadata(
+    const std::string& functionName,
+    const std::vector<TypePtr>& argTypes) {
+  if (auto resolvedFunction =
+          exec::simpleFunctions().resolveFunction(functionName, argTypes)) {
+    return std::pair<TypePtr, exec::VectorFunctionMetadata>{
+        resolvedFunction->type(), resolvedFunction->metadata()};
+  }
+
+  return exec::resolveVectorFunctionWithMetadata(functionName, argTypes);
+}
+
 TypePtr resolveFunctionOrCallableSpecialForm(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes) {

--- a/velox/functions/FunctionRegistry.h
+++ b/velox/functions/FunctionRegistry.h
@@ -37,6 +37,13 @@ TypePtr resolveFunction(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes);
 
+/// Given a function name and argument types, returns a pair of return
+/// type and metadata if function exists. Otherwise, returns std::nullopt.
+std::optional<std::pair<TypePtr, exec::VectorFunctionMetadata>>
+resolveFunctionWithMetadata(
+    const std::string& functionName,
+    const std::vector<TypePtr>& argTypes);
+
 /// Given a function name and argument types, returns the return type if the
 /// function exists or is a special form that supports type resolution (see
 /// resolveCallableSpecialForm), otherwise returns nullptr.
@@ -68,6 +75,8 @@ TypePtr resolveVectorFunction(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes);
 
+/// Given name of a vector function and argument types, returns a pair of return
+/// type and metadata if function exists. Otherwise, returns std::nullopt.
 std::optional<std::pair<TypePtr, exec::VectorFunctionMetadata>>
 resolveVectorFunctionWithMetadata(
     const std::string& functionName,


### PR DESCRIPTION
Summary:
Add velox::resolveFunctionWithMetadata API to resolve return type and metadata
for a function with a given name and argument types regardless of whether the
function is implemented using simple of vector API.

Differential Revision: D55483126


