### PR TITLE
Fix broken build in UnitLoaderTools.h

### DIFF
--- a/velox/dwio/common/UnitLoaderTools.h
+++ b/velox/dwio/common/UnitLoaderTools.h
@@ -45,7 +45,7 @@ class Measure {
 
  private:
   const std::function<void(uint64_t)>& blockedOnIoMsCallback_;
-  const std::chrono::system_clock::time_point startTime_;
+  const std::chrono::time_point<std::chrono::high_resolution_clock> startTime_;
 };
 
 inline std::optional<Measure> measureBlockedOnIo(


### PR DESCRIPTION
Summary:
UnitLoaderTools.h fails to build on MacOS:
```
FAILED: velox/dwio/common/CMakeFiles/velox_dwio_common.dir/OnDemandUnitLoader.cpp.o
/usr/local/bin/ccache /Applications/Xcode_15.0.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_CONTEXT_DYN_LINK -DBOOST_CONTEXT_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_FILESYSTEM_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_REGEX_DYN_LINK -DBOOST_REGEX_NO_LIB -DBOOST_SYSTEM_DYN_LINK -DBOOST_SYSTEM_NO_LIB -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DFMT_SHARED -DFOLLY_HAVE_INT128_T=1 -DGFLAGS_IS_A_DLL=0 -DVELOX_ENABLE_PARQUET -I/Users/runner/work/velox/velox/_build/debug/_deps/protobuf-src/src -I/Users/runner/work/velox/velox/. -I/Users/runner/work/velox/velox/velox/external/xxhash -I/Users/runner/work/velox/velox/_build/debug/_deps/xsimd-src/include -I/Users/runner/work/velox/velox/_build/debug/_deps/re2-src -isystem /Users/runner/work/velox/velox/velox -isystem /Users/runner/work/velox/velox/velox/external -isystem /Users/runner/work/velox/velox/_build/debug/_deps/folly-src -isystem /Users/runner/work/velox/velox/_build/debug/_deps/folly-build -isystem /usr/local/include -isystem /usr/local/opt/openssl/include -mavx2 -mfma -mavx -mf16c -mlzcnt -std=c++17 -mbmi2 -fvisibility=hidden -fvisibility-inlines-hidden -D USE_VELOX_COMMON_BASE -D HAS_UNCAUGHT_EXCEPTIONS -Wall -Wextra -Wno-unused        -Wno-unused-parameter        -Wno-sign-compare        -Wno-ignored-qualifiers        -Wno-range-loop-analysis          -Wno-mismatched-tags          -Wno-nullability-completeness -Werror -g -std=gnu++17 -isysroot /Applications/Xcode_15.0.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk -mmacosx-version-min=13.6 -fPIC -MD -MT velox/dwio/common/CMakeFiles/velox_dwio_common.dir/OnDemandUnitLoader.cpp.o -MF velox/dwio/common/CMakeFiles/velox_dwio_common.dir/OnDemandUnitLoader.cpp.o.d -o velox/dwio/common/CMakeFiles/velox_dwio_common.dir/OnDemandUnitLoader.cpp.o -c /Users/runner/work/velox/velox/velox/dwio/common/OnDemandUnitLoader.cpp
In file included from /Users/runner/work/velox/velox/velox/dwio/common/OnDemandUnitLoader.cpp:20:
/Users/runner/work/velox/velox/./velox/dwio/common/UnitLoaderTools.h:32:9: error: no matching constructor for initialization of 'const std::chrono::system_clock::time_point' (aka 'const time_point<system_clock>')
        startTime_{std::chrono::high_resolution_clock::now()} {}
        ^         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode_15.0.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/usr/include/c++/v1/__chrono/time_point.h:33:28: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'time_point<steady_clock, duration<[...], ratio<[...], 1000000000>>>' to 'const time_point<std::chrono::system_clock, duration<[...], ratio<[...], 1000000>>>' for 1st argument
class _LIBCPP_TEMPLATE_VIS time_point
                           ^
/Applications/Xcode_15.0.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/usr/include/c++/v1/__chrono/time_point.h:33:28: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'time_point<steady_clock, duration<[...], ratio<[...], 1000000000>>>' to 'time_point<std::chrono::system_clock, duration<[...], ratio<[...], 1000000>>>' for 1st argument
/Applications/Xcode_15.0.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/usr/include/c++/v1/__chrono/time_point.h:47:70: note: candidate constructor not viable: no known conversion from 'time_point' (aka 'time_point<std::chrono::steady_clock, duration<long long, ratio<1LL, 1000000000LL>>>') to 'const duration' (aka 'const std::chrono::duration<long long, std::ratio<1, 1000000>>') for 1st argument
    _LIBCPP_INLINE_VISIBILITY _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit time_point(const duration& __d) : __d_(__d) {}
                                                                     ^
/Applications/Xcode_15.0.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/usr/include/c++/v1/__chrono/time_point.h:52:5: note: candidate template ignored: could not match 'std::chrono::system_clock' against 'std::chrono::steady_clock'
    time_point(const time_point<clock, _Duration2>& __t,
    ^
/Applications/Xcode_15.0.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/usr/include/c++/v1/__chrono/time_point.h:46:61: note: candidate constructor not viable: requires 0 arguments, but 1 was provided
    _LIBCPP_INLINE_VISIBILITY _LIBCPP_CONSTEXPR_SINCE_CXX14 time_point() : __d_(duration::zero()) {}
                                                            ^
In file included from /Users/runner/work/velox/velox/velox/dwio/common/OnDemandUnitLoader.cpp:20:
/Users/runner/work/velox/velox/./velox/dwio/common/UnitLoaderTools.h:42:55: error: invalid operands to binary expression ('time_point' (aka 'time_point<std::chrono::steady_clock, duration<long long, ratio<1LL, 1000000000LL>>>') and 'const std::chrono::system_clock::time_point' (aka 'const time_point<system_clock>'))
            std::chrono::high_resolution_clock::now() - startTime_);
```

Differential Revision: D55525804


Fixes #9304