### PR TITLE
Fix memory regression of 3-arg min_by/max_by

### DIFF
--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -253,6 +253,7 @@ struct MinMaxByNStringViewAccumulator {
       if (comparator.compare(comparison, topPair)) {
         std::pop_heap(
             base.heapValues.begin(), base.heapValues.end(), comparator);
+        freePair(base.heapValues.back());
         base.heapValues.pop_back();
         addToAccumulator(comparison, value, comparator);
       }
@@ -423,6 +424,7 @@ struct MinMaxByNComplexTypeAccumulator {
         std::pop_heap(
             base.heapValues.begin(), base.heapValues.end(), comparator);
         auto position = writeComplex(decoded, index);
+        freePair(base.heapValues.back());
         base.heapValues.pop_back();
         addToAccumulator(comparison, position, comparator);
       }


### PR DESCRIPTION
Summary: 
The previous fix of 3-arg min_by/max_by, https://github.com/facebookincubator/velox/pull/8566, introduced a memory 
usage regression. Before this change, every time a pair of (compare, value) 
is popped out of the heap, the allocated memory associated with compare 
and/or value is freed immediately. After this change, the allocated memory 
is not freed immediately after a pop from the heap, leading to a growth of 
peak memory usage. This diff fixes this memory regression by releasing the 
memory associated with (compare, value) once this pair is popped out of 
the heap. The added unit test took peak memory of 2.32MB before the fix, 
and 131.5KB after the fix.

This diff fixes https://github.com/facebookincubator/velox/issues/9254.

Differential Revision: D55533398


