### PR TITLE
Update Presto functions coverage map

### DIFF
--- a/velox/docs/functions.rst
+++ b/velox/docs/functions.rst
@@ -62,17 +62,17 @@ for :doc:`all <functions/presto/coverage>` and :doc:`most used
     ======================================  ======================================  ======================================  ==  ======================================  ==  ======================================
     Scalar Functions                                                                                                            Aggregate Functions                         Window Functions
     ======================================================================================================================  ==  ======================================  ==  ======================================
-    :func:`abs`                             :func:`find_first`                      :func:`plus`                                :func:`any_value`                           :func:`cume_dist`
-    :func:`acos`                            :func:`find_first_index`                :func:`poisson_cdf`                         :func:`approx_distinct`                     :func:`dense_rank`
-    :func:`all_keys_match`                  :func:`flatten`                         :func:`pow`                                 :func:`approx_most_frequent`                :func:`first_value`
-    :func:`all_match`                       :func:`floor`                           :func:`power`                               :func:`approx_percentile`                   :func:`lag`
-    :func:`any_keys_match`                  :func:`format_datetime`                 :func:`quarter`                             :func:`approx_set`                          :func:`last_value`
-    :func:`any_match`                       :func:`from_base`                       :func:`radians`                             :func:`arbitrary`                           :func:`lead`
-    :func:`any_values_match`                :func:`from_base64`                     :func:`rand`                                :func:`array_agg`                           :func:`nth_value`
-    :func:`array_average`                   :func:`from_base64url`                  :func:`random`                              :func:`avg`                                 :func:`ntile`
-    :func:`array_constructor`               :func:`from_big_endian_32`              :func:`reduce`                              :func:`bitwise_and_agg`                     :func:`percent_rank`
-    :func:`array_distinct`                  :func:`from_big_endian_64`              :func:`regexp_extract`                      :func:`bitwise_or_agg`                      :func:`rank`
-    :func:`array_duplicates`                :func:`from_hex`                        :func:`regexp_extract_all`                  :func:`bitwise_xor_agg`                     :func:`row_number`
+    :func:`abs`                             :func:`find_first_index`                :func:`plus`                                :func:`any_value`                           :func:`cume_dist`
+    :func:`acos`                            :func:`flatten`                         :func:`poisson_cdf`                         :func:`approx_distinct`                     :func:`dense_rank`
+    :func:`all_keys_match`                  :func:`floor`                           :func:`pow`                                 :func:`approx_most_frequent`                :func:`first_value`
+    :func:`all_match`                       :func:`format_datetime`                 :func:`power`                               :func:`approx_percentile`                   :func:`lag`
+    :func:`any_keys_match`                  :func:`from_base`                       :func:`quarter`                             :func:`approx_set`                          :func:`last_value`
+    :func:`any_match`                       :func:`from_base64`                     :func:`radians`                             :func:`arbitrary`                           :func:`lead`
+    :func:`any_values_match`                :func:`from_base64url`                  :func:`rand`                                :func:`array_agg`                           :func:`nth_value`
+    :func:`array_average`                   :func:`from_big_endian_32`              :func:`random`                              :func:`avg`                                 :func:`ntile`
+    :func:`array_constructor`               :func:`from_big_endian_64`              :func:`reduce`                              :func:`bitwise_and_agg`                     :func:`percent_rank`
+    :func:`array_distinct`                  :func:`from_hex`                        :func:`regexp_extract`                      :func:`bitwise_or_agg`                      :func:`rank`
+    :func:`array_duplicates`                :func:`from_ieee754_32`                 :func:`regexp_extract_all`                  :func:`bitwise_xor_agg`                     :func:`row_number`
     :func:`array_except`                    :func:`from_ieee754_64`                 :func:`regexp_like`                         :func:`bool_and`
     :func:`array_frequency`                 :func:`from_iso8601_date`               :func:`regexp_replace`                      :func:`bool_or`
     :func:`array_has_duplicates`            :func:`from_unixtime`                   :func:`remove_nulls`                        :func:`checksum`
@@ -81,68 +81,69 @@ for :doc:`all <functions/presto/coverage>` and :doc:`most used
     :func:`array_max`                       :func:`greatest`                        :func:`reverse`                             :func:`count_if`
     :func:`array_min`                       :func:`gt`                              :func:`round`                               :func:`covar_pop`
     :func:`array_normalize`                 :func:`gte`                             :func:`rpad`                                :func:`covar_samp`
-    :func:`array_position`                  :func:`hmac_md5`                        :func:`rtrim`                               :func:`entropy`
-    :func:`array_remove`                    :func:`hmac_sha1`                       :func:`second`                              :func:`every`
-    :func:`array_sort`                      :func:`hmac_sha256`                     :func:`sequence`                            :func:`geometric_mean`
-    :func:`array_sort_desc`                 :func:`hmac_sha512`                     :func:`sha1`                                :func:`histogram`
-    :func:`array_sum`                       :func:`hour`                            :func:`sha256`                              :func:`kurtosis`
-    :func:`array_union`                     in                                      :func:`sha512`                              :func:`map_agg`
-    :func:`arrays_overlap`                  :func:`infinity`                        :func:`shuffle`                             :func:`map_union`
-    :func:`asin`                            :func:`inverse_beta_cdf`                :func:`sign`                                :func:`map_union_sum`
-    :func:`atan`                            :func:`is_finite`                       :func:`sin`                                 :func:`max`
-    :func:`atan2`                           :func:`is_infinite`                     :func:`slice`                               :func:`max_by`
-    :func:`beta_cdf`                        :func:`is_json_scalar`                  :func:`split`                               :func:`max_data_size_for_stats`
-    :func:`between`                         :func:`is_nan`                          :func:`split_part`                          :func:`merge`
-    :func:`binomial_cdf`                    :func:`is_null`                         :func:`split_to_map`                        :func:`min`
-    :func:`bit_count`                       :func:`json_array_contains`             :func:`spooky_hash_v2_32`                   :func:`min_by`
-    :func:`bitwise_and`                     :func:`json_array_length`               :func:`spooky_hash_v2_64`                   :func:`multimap_agg`
-    :func:`bitwise_arithmetic_shift_right`  :func:`json_extract`                    :func:`sqrt`                                :func:`reduce_agg`
-    :func:`bitwise_left_shift`              :func:`json_extract_scalar`             :func:`starts_with`                         :func:`regr_avgx`
-    :func:`bitwise_logical_shift_right`     :func:`json_format`                     :func:`strpos`                              :func:`regr_avgy`
-    :func:`bitwise_not`                     :func:`json_parse`                      :func:`strrpos`                             :func:`regr_count`
-    :func:`bitwise_or`                      :func:`json_size`                       :func:`subscript`                           :func:`regr_intercept`
-    :func:`bitwise_right_shift`             :func:`laplace_cdf`                     :func:`substr`                              :func:`regr_r2`
-    :func:`bitwise_right_shift_arithmetic`  :func:`last_day_of_month`               :func:`tan`                                 :func:`regr_slope`
-    :func:`bitwise_shift_left`              :func:`least`                           :func:`tanh`                                :func:`regr_sxx`
-    :func:`bitwise_xor`                     :func:`length`                          :func:`timezone_hour`                       :func:`regr_sxy`
-    :func:`cardinality`                     :func:`levenshtein_distance`            :func:`timezone_minute`                     :func:`regr_syy`
-    :func:`cauchy_cdf`                      :func:`like`                            :func:`to_base`                             :func:`set_agg`
-    :func:`cbrt`                            :func:`ln`                              :func:`to_base64`                           :func:`set_union`
-    :func:`ceil`                            :func:`log10`                           :func:`to_base64url`                        :func:`skewness`
-    :func:`ceiling`                         :func:`log2`                            :func:`to_big_endian_32`                    :func:`stddev`
-    :func:`chi_squared_cdf`                 :func:`lower`                           :func:`to_big_endian_64`                    :func:`stddev_pop`
-    :func:`chr`                             :func:`lpad`                            :func:`to_hex`                              :func:`stddev_samp`
-    :func:`clamp`                           :func:`lt`                              :func:`to_ieee754_32`                       :func:`sum`
-    :func:`codepoint`                       :func:`lte`                             :func:`to_ieee754_64`                       :func:`sum_data_size_for_stats`
-    :func:`combinations`                    :func:`ltrim`                           :func:`to_unixtime`                         :func:`var_pop`
-    :func:`concat`                          :func:`map`                             :func:`to_utf8`                             :func:`var_samp`
-    :func:`contains`                        :func:`map_concat`                      :func:`transform`                           :func:`variance`
-    :func:`cos`                             :func:`map_entries`                     :func:`transform_keys`
-    :func:`cosh`                            :func:`map_filter`                      :func:`transform_values`
-    :func:`cosine_similarity`               :func:`map_from_entries`                :func:`trim`
-    :func:`crc32`                           :func:`map_keys`                        :func:`trim_array`
-    :func:`current_date`                    :func:`map_normalize`                   :func:`truncate`
-    :func:`date`                            :func:`map_subset`                      :func:`typeof`
-    :func:`date_add`                        :func:`map_top_n`                       :func:`upper`
-    :func:`date_diff`                       :func:`map_values`                      :func:`url_decode`
-    :func:`date_format`                     :func:`map_zip_with`                    :func:`url_encode`
-    :func:`date_parse`                      :func:`md5`                             :func:`url_extract_fragment`
-    :func:`date_trunc`                      :func:`millisecond`                     :func:`url_extract_host`
-    :func:`day`                             :func:`minus`                           :func:`url_extract_parameter`
-    :func:`day_of_month`                    :func:`minute`                          :func:`url_extract_path`
-    :func:`day_of_week`                     :func:`mod`                             :func:`url_extract_port`
-    :func:`day_of_year`                     :func:`month`                           :func:`url_extract_protocol`
-    :func:`degrees`                         :func:`multimap_from_entries`           :func:`url_extract_query`
-    :func:`distinct_from`                   :func:`multiply`                        :func:`week`
-    :func:`divide`                          :func:`nan`                             :func:`week_of_year`
-    :func:`dow`                             :func:`negate`                          :func:`weibull_cdf`
-    :func:`doy`                             :func:`neq`                             :func:`width_bucket`
-    :func:`e`                               :func:`ngrams`                          :func:`wilson_interval_lower`
-    :func:`element_at`                      :func:`no_keys_match`                   :func:`wilson_interval_upper`
-    :func:`empty_approx_set`                :func:`no_values_match`                 :func:`xxhash64`
-    :func:`ends_with`                       :func:`none_match`                      :func:`year`
-    :func:`eq`                              :func:`normal_cdf`                      :func:`year_of_week`
-    :func:`exp`                             not                                     :func:`yow`
-    :func:`f_cdf`                           :func:`parse_datetime`                  :func:`zip`
-    :func:`filter`                          :func:`pi`                              :func:`zip_with`
+    :func:`array_position`                  :func:`hamming_distance`                :func:`rtrim`                               :func:`entropy`
+    :func:`array_remove`                    :func:`hmac_md5`                        :func:`second`                              :func:`every`
+    :func:`array_sort`                      :func:`hmac_sha1`                       :func:`sequence`                            :func:`geometric_mean`
+    :func:`array_sort_desc`                 :func:`hmac_sha256`                     :func:`sha1`                                :func:`histogram`
+    :func:`array_sum`                       :func:`hmac_sha512`                     :func:`sha256`                              :func:`kurtosis`
+    :func:`array_union`                     :func:`hour`                            :func:`sha512`                              :func:`map_agg`
+    :func:`arrays_overlap`                  in                                      :func:`shuffle`                             :func:`map_union`
+    :func:`asin`                            :func:`infinity`                        :func:`sign`                                :func:`map_union_sum`
+    :func:`atan`                            :func:`inverse_beta_cdf`                :func:`sin`                                 :func:`max`
+    :func:`atan2`                           :func:`is_finite`                       :func:`slice`                               :func:`max_by`
+    :func:`beta_cdf`                        :func:`is_infinite`                     :func:`split`                               :func:`max_data_size_for_stats`
+    :func:`between`                         :func:`is_json_scalar`                  :func:`split_part`                          :func:`merge`
+    :func:`binomial_cdf`                    :func:`is_nan`                          :func:`split_to_map`                        :func:`min`
+    :func:`bit_count`                       :func:`is_null`                         :func:`spooky_hash_v2_32`                   :func:`min_by`
+    :func:`bitwise_and`                     :func:`json_array_contains`             :func:`spooky_hash_v2_64`                   :func:`multimap_agg`
+    :func:`bitwise_arithmetic_shift_right`  :func:`json_array_length`               :func:`sqrt`                                :func:`reduce_agg`
+    :func:`bitwise_left_shift`              :func:`json_extract`                    :func:`starts_with`                         :func:`regr_avgx`
+    :func:`bitwise_logical_shift_right`     :func:`json_extract_scalar`             :func:`strpos`                              :func:`regr_avgy`
+    :func:`bitwise_not`                     :func:`json_format`                     :func:`strrpos`                             :func:`regr_count`
+    :func:`bitwise_or`                      :func:`json_parse`                      :func:`subscript`                           :func:`regr_intercept`
+    :func:`bitwise_right_shift`             :func:`json_size`                       :func:`substr`                              :func:`regr_r2`
+    :func:`bitwise_right_shift_arithmetic`  :func:`laplace_cdf`                     :func:`tan`                                 :func:`regr_slope`
+    :func:`bitwise_shift_left`              :func:`last_day_of_month`               :func:`tanh`                                :func:`regr_sxx`
+    :func:`bitwise_xor`                     :func:`least`                           :func:`timezone_hour`                       :func:`regr_sxy`
+    :func:`cardinality`                     :func:`length`                          :func:`timezone_minute`                     :func:`regr_syy`
+    :func:`cauchy_cdf`                      :func:`levenshtein_distance`            :func:`to_base`                             :func:`set_agg`
+    :func:`cbrt`                            :func:`like`                            :func:`to_base64`                           :func:`set_union`
+    :func:`ceil`                            :func:`ln`                              :func:`to_base64url`                        :func:`skewness`
+    :func:`ceiling`                         :func:`log10`                           :func:`to_big_endian_32`                    :func:`stddev`
+    :func:`chi_squared_cdf`                 :func:`log2`                            :func:`to_big_endian_64`                    :func:`stddev_pop`
+    :func:`chr`                             :func:`lower`                           :func:`to_hex`                              :func:`stddev_samp`
+    :func:`clamp`                           :func:`lpad`                            :func:`to_ieee754_32`                       :func:`sum`
+    :func:`codepoint`                       :func:`lt`                              :func:`to_ieee754_64`                       :func:`sum_data_size_for_stats`
+    :func:`combinations`                    :func:`lte`                             :func:`to_unixtime`                         :func:`var_pop`
+    :func:`concat`                          :func:`ltrim`                           :func:`to_utf8`                             :func:`var_samp`
+    :func:`contains`                        :func:`map`                             :func:`transform`                           :func:`variance`
+    :func:`cos`                             :func:`map_concat`                      :func:`transform_keys`
+    :func:`cosh`                            :func:`map_entries`                     :func:`transform_values`
+    :func:`cosine_similarity`               :func:`map_filter`                      :func:`trim`
+    :func:`crc32`                           :func:`map_from_entries`                :func:`trim_array`
+    :func:`current_date`                    :func:`map_keys`                        :func:`truncate`
+    :func:`date`                            :func:`map_normalize`                   :func:`typeof`
+    :func:`date_add`                        :func:`map_subset`                      :func:`upper`
+    :func:`date_diff`                       :func:`map_top_n`                       :func:`url_decode`
+    :func:`date_format`                     :func:`map_values`                      :func:`url_encode`
+    :func:`date_parse`                      :func:`map_zip_with`                    :func:`url_extract_fragment`
+    :func:`date_trunc`                      :func:`md5`                             :func:`url_extract_host`
+    :func:`day`                             :func:`millisecond`                     :func:`url_extract_parameter`
+    :func:`day_of_month`                    :func:`minus`                           :func:`url_extract_path`
+    :func:`day_of_week`                     :func:`minute`                          :func:`url_extract_port`
+    :func:`day_of_year`                     :func:`mod`                             :func:`url_extract_protocol`
+    :func:`degrees`                         :func:`month`                           :func:`url_extract_query`
+    :func:`distinct_from`                   :func:`multimap_from_entries`           :func:`week`
+    :func:`divide`                          :func:`multiply`                        :func:`week_of_year`
+    :func:`dow`                             :func:`nan`                             :func:`weibull_cdf`
+    :func:`doy`                             :func:`negate`                          :func:`width_bucket`
+    :func:`e`                               :func:`neq`                             :func:`wilson_interval_lower`
+    :func:`element_at`                      :func:`ngrams`                          :func:`wilson_interval_upper`
+    :func:`empty_approx_set`                :func:`no_keys_match`                   :func:`xxhash64`
+    :func:`ends_with`                       :func:`no_values_match`                 :func:`year`
+    :func:`eq`                              :func:`none_match`                      :func:`year_of_week`
+    :func:`exp`                             :func:`normal_cdf`                      :func:`yow`
+    :func:`f_cdf`                           not                                     :func:`zip`
+    :func:`filter`                          :func:`parse_datetime`                  :func:`zip_with`
+    :func:`find_first`                      :func:`pi`
     ======================================  ======================================  ======================================  ==  ======================================  ==  ======================================

--- a/velox/docs/functions/presto/coverage.rst
+++ b/velox/docs/functions/presto/coverage.rst
@@ -72,40 +72,36 @@ Here is a list of all scalar and aggregate Presto functions with functions that 
     table.coverage tr:nth-child(12) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(12) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(12) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(12) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(12) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(13) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(13) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(13) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(13) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(14) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(14) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(14) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(14) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(15) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(15) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(15) td:nth-child(4) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(16) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(16) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(16) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(16) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(17) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(17) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(17) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(17) td:nth-child(5) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(18) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(18) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(17) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(18) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(18) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(18) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(19) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(19) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(19) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(7) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(20) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(20) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(20) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(20) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(20) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(20) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(21) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(21) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(21) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(21) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(21) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(22) td:nth-child(1) {background-color: #6BA81E;}
@@ -117,79 +113,78 @@ Here is a list of all scalar and aggregate Presto functions with functions that 
     table.coverage tr:nth-child(23) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(23) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(23) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(23) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(23) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(24) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(24) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(24) td:nth-child(4) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(24) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(25) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(25) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(25) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(25) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(25) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(26) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(26) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(26) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(26) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(26) td:nth-child(5) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(27) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(27) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(28) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(28) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(28) td:nth-child(4) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(28) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(28) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(29) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(29) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(29) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(29) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(30) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(30) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(30) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(30) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(30) td:nth-child(7) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(31) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(31) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(31) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(31) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(31) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(32) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(32) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(32) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(32) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(32) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(32) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(33) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(33) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(33) td:nth-child(5) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(34) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(33) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(34) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(34) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(34) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(34) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(35) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(35) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(35) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(35) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(36) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(36) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(36) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(36) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(37) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(37) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(37) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(38) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(38) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(38) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(38) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(38) td:nth-child(7) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(39) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(39) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(39) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(39) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(40) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(40) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(40) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(40) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(41) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(41) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(41) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(41) td:nth-child(7) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(42) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(42) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(42) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(42) td:nth-child(7) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(43) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(43) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(43) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(43) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(43) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(44) td:nth-child(1) {background-color: #6BA81E;}
@@ -202,106 +197,113 @@ Here is a list of all scalar and aggregate Presto functions with functions that 
     table.coverage tr:nth-child(45) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(45) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(46) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(46) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(46) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(46) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(46) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(47) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(47) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(47) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(48) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(48) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(48) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(49) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(49) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(49) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(50) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(50) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(50) td:nth-child(5) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(50) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(51) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(51) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(51) td:nth-child(5) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(51) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(52) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(52) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(52) td:nth-child(5) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(52) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(53) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(53) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(53) td:nth-child(5) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(53) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(54) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(54) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(54) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(54) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(55) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(55) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(55) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(55) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(56) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(56) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(56) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(56) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(56) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(57) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(57) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(57) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(57) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(57) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(58) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(59) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(59) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(59) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(59) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(59) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(60) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(61) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(61) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(61) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(61) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(61) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(62) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(62) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(62) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(62) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(62) td:nth-child(7) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(63) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(63) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(63) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(64) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(64) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(64) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(64) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(64) td:nth-child(7) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(65) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(65) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(65) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(65) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(65) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(66) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(66) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(66) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(67) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(67) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(67) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(67) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(68) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(68) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(68) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(68) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(69) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(69) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(69) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(69) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(70) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(70) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(70) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(70) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(71) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(71) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(71) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(71) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(72) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(72) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(72) td:nth-child(5) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(73) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(73) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(73) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(73) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(74) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(75) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(74) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(74) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(75) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(76) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(75) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(75) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(76) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(76) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(77) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(77) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(78) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(78) td:nth-child(3) {background-color: #6BA81E;}
     </style>
 
 .. table::
@@ -311,81 +313,82 @@ Here is a list of all scalar and aggregate Presto functions with functions that 
     ========================================  ========================================  ========================================  ========================================  ========================================  ==  ========================================  ==  ========================================
     Scalar Functions                                                                                                                                                                                                      Aggregate Functions                           Window Functions
     ================================================================================================================================================================================================================  ==  ========================================  ==  ========================================
-    :func:`abs`                               :func:`date_format`                       :func:`is_finite`                         :func:`regexp_extract`                    st_point                                      :func:`approx_distinct`                       :func:`cume_dist`
-    :func:`acos`                              :func:`date_parse`                        :func:`is_infinite`                       :func:`regexp_extract_all`                st_pointn                                     :func:`approx_most_frequent`                  :func:`dense_rank`
-    :func:`all_match`                         :func:`date_trunc`                        :func:`is_json_scalar`                    :func:`regexp_like`                       st_points                                     :func:`approx_percentile`                     :func:`first_value`
-    :func:`any_keys_match`                    :func:`day`                               :func:`is_nan`                            :func:`regexp_replace`                    st_polygon                                    :func:`approx_set`                            :func:`lag`
-    :func:`any_match`                         :func:`day_of_month`                      is_subnet_of                              regexp_split                              st_relate                                     :func:`arbitrary`                             :func:`last_value`
-    :func:`any_values_match`                  :func:`day_of_week`                       jaccard_index                             regress                                   st_startpoint                                 :func:`array_agg`                             :func:`lead`
-    :func:`array_average`                     :func:`day_of_year`                       :func:`json_array_contains`               reidentification_potential                st_symdifference                              :func:`avg`                                   :func:`nth_value`
-    array_cum_sum                             :func:`degrees`                           json_array_get                            :func:`remove_nulls`                      st_touches                                    :func:`bitwise_and_agg`                       :func:`ntile`
-    :func:`array_distinct`                    :func:`dow`                               :func:`json_array_length`                 render                                    st_union                                      :func:`bitwise_or_agg`                        :func:`percent_rank`
-    :func:`array_duplicates`                  :func:`doy`                               :func:`json_extract`                      :func:`repeat`                            st_within                                     :func:`bool_and`                              :func:`rank`
-    :func:`array_except`                      :func:`e`                                 :func:`json_extract_scalar`               :func:`replace`                           st_x                                          :func:`bool_or`                               :func:`row_number`
-    :func:`array_frequency`                   :func:`element_at`                        :func:`json_format`                       :func:`reverse`                           st_xmax                                       :func:`checksum`
-    :func:`array_has_duplicates`              :func:`empty_approx_set`                  :func:`json_parse`                        rgb                                       st_xmin                                       classification_fall_out
-    :func:`array_intersect`                   :func:`ends_with`                         :func:`json_size`                         :func:`round`                             st_y                                          classification_miss_rate
-    :func:`array_join`                        enum_key                                  key_sampling_percent                      :func:`rpad`                              st_ymax                                       classification_precision
-    :func:`array_max`                         :func:`exp`                               :func:`laplace_cdf`                       :func:`rtrim`                             st_ymin                                       classification_recall
-    array_max_by                              expand_envelope                           :func:`last_day_of_month`                 scale_qdigest                             :func:`starts_with`                           classification_thresholds
-    :func:`array_min`                         :func:`f_cdf`                             :func:`least`                             :func:`second`                            :func:`strpos`                                convex_hull_agg
-    array_min_by                              features                                  :func:`length`                            secure_random                             :func:`strrpos`                               :func:`corr`
-    :func:`array_normalize`                   :func:`filter`                            :func:`levenshtein_distance`              :func:`sequence`                          :func:`substr`                                :func:`count`
-    :func:`array_position`                    :func:`filter`                            line_interpolate_point                    :func:`sha1`                              :func:`tan`                                   :func:`count_if`
-    :func:`array_remove`                      :func:`find_first`                        line_locate_point                         :func:`sha256`                            :func:`tanh`                                  :func:`covar_pop`
-    :func:`array_sort`                        :func:`find_first_index`                  :func:`ln`                                :func:`sha512`                            tdigest_agg                                   :func:`covar_samp`
-    :func:`array_sort_desc`                   :func:`flatten`                           localtime                                 :func:`shuffle`                           :func:`timezone_hour`                         differential_entropy
-    :func:`array_sum`                         flatten_geometry_collections              localtimestamp                            :func:`sign`                              :func:`timezone_minute`                       :func:`entropy`
-    :func:`array_union`                       :func:`floor`                             :func:`log10`                             simplify_geometry                         :func:`to_base`                               evaluate_classifier_predictions
-    :func:`arrays_overlap`                    fnv1_32                                   :func:`log2`                              :func:`sin`                               :func:`to_base64`                             :func:`every`
-    :func:`asin`                              fnv1_64                                   :func:`lower`                             :func:`slice`                             :func:`to_base64url`                          :func:`geometric_mean`
-    :func:`atan`                              fnv1a_32                                  :func:`lpad`                              spatial_partitions                        :func:`to_big_endian_32`                      geometry_union_agg
-    :func:`atan2`                             fnv1a_64                                  :func:`ltrim`                             :func:`split`                             :func:`to_big_endian_64`                      :func:`histogram`
-    bar                                       :func:`format_datetime`                   :func:`map`                               :func:`split_part`                        to_geometry                                   khyperloglog_agg
-    :func:`beta_cdf`                          :func:`from_base`                         :func:`map_concat`                        :func:`split_to_map`                      :func:`to_hex`                                :func:`kurtosis`
-    bing_tile                                 from_base32                               :func:`map_entries`                       split_to_multimap                         :func:`to_ieee754_32`                         learn_classifier
-    bing_tile_at                              :func:`from_base64`                       :func:`map_filter`                        :func:`spooky_hash_v2_32`                 :func:`to_ieee754_64`                         learn_libsvm_classifier
-    bing_tile_children                        :func:`from_base64url`                    :func:`map_from_entries`                  :func:`spooky_hash_v2_64`                 to_iso8601                                    learn_libsvm_regressor
-    bing_tile_coordinates                     :func:`from_big_endian_32`                :func:`map_keys`                          :func:`sqrt`                              to_milliseconds                               learn_regressor
-    bing_tile_parent                          :func:`from_big_endian_64`                :func:`map_normalize`                     st_area                                   to_spherical_geography                        make_set_digest
-    bing_tile_polygon                         :func:`from_hex`                          map_remove_null_values                    st_asbinary                               :func:`to_unixtime`                           :func:`map_agg`
-    bing_tile_quadkey                         from_ieee754_32                           :func:`map_subset`                        st_astext                                 :func:`to_utf8`                               :func:`map_union`
-    bing_tile_zoom_level                      :func:`from_ieee754_64`                   :func:`map_top_n`                         st_boundary                               :func:`transform`                             :func:`map_union_sum`
-    bing_tiles_around                         :func:`from_iso8601_date`                 map_top_n_keys                            st_buffer                                 :func:`transform_keys`                        :func:`max`
-    :func:`binomial_cdf`                      from_iso8601_timestamp                    map_top_n_values                          st_centroid                               :func:`transform_values`                      :func:`max_by`
-    :func:`bit_count`                         :func:`from_unixtime`                     :func:`map_values`                        st_contains                               :func:`trim`                                  :func:`merge`
-    :func:`bitwise_and`                       :func:`from_utf8`                         :func:`map_zip_with`                      st_convexhull                             :func:`trim_array`                            merge_set_digest
-    :func:`bitwise_arithmetic_shift_right`    :func:`gamma_cdf`                         :func:`md5`                               st_coorddim                               :func:`truncate`                              :func:`min`
-    :func:`bitwise_left_shift`                geometry_as_geojson                       merge_hll                                 st_crosses                                :func:`typeof`                                :func:`min_by`
-    :func:`bitwise_logical_shift_right`       geometry_from_geojson                     merge_khll                                st_difference                             uniqueness_distribution                       :func:`multimap_agg`
-    :func:`bitwise_not`                       geometry_invalid_reason                   :func:`millisecond`                       st_dimension                              :func:`upper`                                 numeric_histogram
-    :func:`bitwise_or`                        geometry_nearest_points                   :func:`minute`                            st_disjoint                               :func:`url_decode`                            qdigest_agg
-    :func:`bitwise_right_shift`               geometry_to_bing_tiles                    :func:`mod`                               st_distance                               :func:`url_encode`                            :func:`reduce_agg`
-    :func:`bitwise_right_shift_arithmetic`    geometry_to_dissolved_bing_tiles          :func:`month`                             st_endpoint                               :func:`url_extract_fragment`                  :func:`regr_avgx`
-    :func:`bitwise_shift_left`                geometry_union                            :func:`multimap_from_entries`             st_envelope                               :func:`url_extract_host`                      :func:`regr_avgy`
-    :func:`bitwise_xor`                       great_circle_distance                     murmur3_x64_128                           st_envelopeaspts                          :func:`url_extract_parameter`                 :func:`regr_count`
-    :func:`cardinality`                       :func:`greatest`                          myanmar_font_encoding                     st_equals                                 :func:`url_extract_path`                      :func:`regr_intercept`
-    :func:`cauchy_cdf`                        hamming_distance                          myanmar_normalize_unicode                 st_exteriorring                           :func:`url_extract_port`                      :func:`regr_r2`
-    :func:`cbrt`                              hash_counts                               :func:`nan`                               st_geometries                             :func:`url_extract_protocol`                  :func:`regr_slope`
-    :func:`ceil`                              :func:`hmac_md5`                          :func:`ngrams`                            st_geometryfromtext                       :func:`url_extract_query`                     :func:`regr_sxx`
-    :func:`ceiling`                           :func:`hmac_sha1`                         :func:`no_keys_match`                     st_geometryn                              uuid                                          :func:`regr_sxy`
-    :func:`chi_squared_cdf`                   :func:`hmac_sha256`                       :func:`no_values_match`                   st_geometrytype                           value_at_quantile                             :func:`regr_syy`
-    :func:`chr`                               :func:`hmac_sha512`                       :func:`none_match`                        st_geomfrombinary                         values_at_quantiles                           :func:`set_agg`
-    classify                                  :func:`hour`                              :func:`normal_cdf`                        st_interiorringn                          :func:`week`                                  :func:`set_union`
-    :func:`codepoint`                         :func:`infinity`                          normalize                                 st_interiorrings                          :func:`week_of_year`                          :func:`skewness`
-    color                                     intersection_cardinality                  now                                       st_intersection                           :func:`weibull_cdf`                           spatial_partitioning
-    :func:`combinations`                      :func:`inverse_beta_cdf`                  :func:`parse_datetime`                    st_intersects                             :func:`width_bucket`                          :func:`stddev`
-    :func:`concat`                            inverse_binomial_cdf                      parse_duration                            st_isclosed                               :func:`wilson_interval_lower`                 :func:`stddev_pop`
-    :func:`contains`                          inverse_cauchy_cdf                        parse_presto_data_size                    st_isempty                                :func:`wilson_interval_upper`                 :func:`stddev_samp`
-    :func:`cos`                               inverse_chi_squared_cdf                   :func:`pi`                                st_isring                                 word_stem                                     :func:`sum`
-    :func:`cosh`                              inverse_f_cdf                             pinot_binary_decimal_to_double            st_issimple                               :func:`xxhash64`                              tdigest_agg
-    :func:`cosine_similarity`                 inverse_gamma_cdf                         :func:`poisson_cdf`                       st_isvalid                                :func:`year`                                  :func:`var_pop`
-    :func:`crc32`                             inverse_laplace_cdf                       :func:`pow`                               st_length                                 :func:`year_of_week`                          :func:`var_samp`
-    :func:`current_date`                      inverse_normal_cdf                        :func:`power`                             st_linefromtext                           :func:`yow`                                   :func:`variance`
-    current_time                              inverse_poisson_cdf                       quantile_at_value                         st_linestring                             :func:`zip`
-    current_timestamp                         inverse_weibull_cdf                       :func:`quarter`                           st_multipoint                             :func:`zip_with`
-    current_timezone                          ip_prefix                                 :func:`radians`                           st_numgeometries
-    :func:`date`                              ip_subnet_max                             :func:`rand`                              st_numinteriorring
-    :func:`date_add`                          ip_subnet_min                             :func:`random`                            st_numpoints
-    :func:`date_diff`                         ip_subnet_range                           :func:`reduce`                            st_overlaps
+    :func:`abs`                               :func:`date_diff`                         :func:`is_finite`                         :func:`regexp_extract`                    st_overlaps                                   :func:`approx_distinct`                       :func:`cume_dist`
+    :func:`acos`                              :func:`date_format`                       :func:`is_infinite`                       :func:`regexp_extract_all`                st_point                                      :func:`approx_most_frequent`                  :func:`dense_rank`
+    :func:`all_match`                         :func:`date_parse`                        :func:`is_json_scalar`                    :func:`regexp_like`                       st_pointn                                     :func:`approx_percentile`                     :func:`first_value`
+    :func:`any_keys_match`                    :func:`date_trunc`                        :func:`is_nan`                            :func:`regexp_replace`                    st_points                                     :func:`approx_set`                            :func:`lag`
+    :func:`any_match`                         :func:`day`                               is_subnet_of                              regexp_split                              st_polygon                                    :func:`arbitrary`                             :func:`last_value`
+    :func:`any_values_match`                  :func:`day_of_month`                      jaccard_index                             regress                                   st_relate                                     :func:`array_agg`                             :func:`lead`
+    :func:`array_average`                     :func:`day_of_week`                       :func:`json_array_contains`               reidentification_potential                st_startpoint                                 :func:`avg`                                   :func:`nth_value`
+    array_cum_sum                             :func:`day_of_year`                       json_array_get                            :func:`remove_nulls`                      st_symdifference                              :func:`bitwise_and_agg`                       :func:`ntile`
+    :func:`array_distinct`                    :func:`degrees`                           :func:`json_array_length`                 render                                    st_touches                                    :func:`bitwise_or_agg`                        :func:`percent_rank`
+    :func:`array_duplicates`                  :func:`dow`                               :func:`json_extract`                      :func:`repeat`                            st_union                                      :func:`bool_and`                              :func:`rank`
+    :func:`array_except`                      :func:`doy`                               :func:`json_extract_scalar`               :func:`replace`                           st_within                                     :func:`bool_or`                               :func:`row_number`
+    :func:`array_frequency`                   :func:`e`                                 :func:`json_format`                       replace_first                             st_x                                          :func:`checksum`
+    :func:`array_has_duplicates`              :func:`element_at`                        :func:`json_parse`                        :func:`reverse`                           st_xmax                                       classification_fall_out
+    :func:`array_intersect`                   :func:`empty_approx_set`                  :func:`json_size`                         rgb                                       st_xmin                                       classification_miss_rate
+    :func:`array_join`                        :func:`ends_with`                         key_sampling_percent                      :func:`round`                             st_y                                          classification_precision
+    array_least_frequent                      enum_key                                  :func:`laplace_cdf`                       :func:`rpad`                              st_ymax                                       classification_recall
+    :func:`array_max`                         :func:`exp`                               :func:`last_day_of_month`                 :func:`rtrim`                             st_ymin                                       classification_thresholds
+    array_max_by                              expand_envelope                           :func:`least`                             scale_qdigest                             :func:`starts_with`                           convex_hull_agg
+    :func:`array_min`                         :func:`f_cdf`                             :func:`length`                            :func:`second`                            :func:`strpos`                                :func:`corr`
+    array_min_by                              features                                  :func:`levenshtein_distance`              secure_rand                               :func:`strrpos`                               :func:`count`
+    :func:`array_normalize`                   :func:`filter`                            line_interpolate_point                    secure_random                             :func:`substr`                                :func:`count_if`
+    :func:`array_position`                    :func:`filter`                            line_locate_point                         :func:`sequence`                          :func:`tan`                                   :func:`covar_pop`
+    :func:`array_remove`                      :func:`find_first`                        :func:`ln`                                :func:`sha1`                              :func:`tanh`                                  :func:`covar_samp`
+    :func:`array_sort`                        :func:`find_first_index`                  localtime                                 :func:`sha256`                            tdigest_agg                                   differential_entropy
+    :func:`array_sort_desc`                   :func:`flatten`                           localtimestamp                            :func:`sha512`                            :func:`timezone_hour`                         :func:`entropy`
+    :func:`array_sum`                         flatten_geometry_collections              :func:`log10`                             :func:`shuffle`                           :func:`timezone_minute`                       evaluate_classifier_predictions
+    array_top_n                               :func:`floor`                             :func:`log2`                              :func:`sign`                              :func:`to_base`                               :func:`every`
+    :func:`array_union`                       fnv1_32                                   :func:`lower`                             simplify_geometry                         to_base32                                     :func:`geometric_mean`
+    :func:`arrays_overlap`                    fnv1_64                                   :func:`lpad`                              :func:`sin`                               :func:`to_base64`                             geometry_union_agg
+    :func:`asin`                              fnv1a_32                                  :func:`ltrim`                             :func:`slice`                             :func:`to_base64url`                          :func:`histogram`
+    :func:`atan`                              fnv1a_64                                  :func:`map`                               spatial_partitions                        :func:`to_big_endian_32`                      khyperloglog_agg
+    :func:`atan2`                             :func:`format_datetime`                   :func:`map_concat`                        :func:`split`                             :func:`to_big_endian_64`                      :func:`kurtosis`
+    bar                                       :func:`from_base`                         :func:`map_entries`                       :func:`split_part`                        to_geometry                                   learn_classifier
+    :func:`beta_cdf`                          from_base32                               :func:`map_filter`                        :func:`split_to_map`                      :func:`to_hex`                                learn_libsvm_classifier
+    bing_tile                                 :func:`from_base64`                       :func:`map_from_entries`                  split_to_multimap                         :func:`to_ieee754_32`                         learn_libsvm_regressor
+    bing_tile_at                              :func:`from_base64url`                    :func:`map_keys`                          :func:`spooky_hash_v2_32`                 :func:`to_ieee754_64`                         learn_regressor
+    bing_tile_children                        :func:`from_big_endian_32`                map_keys_by_top_n_values                  :func:`spooky_hash_v2_64`                 to_iso8601                                    make_set_digest
+    bing_tile_coordinates                     :func:`from_big_endian_64`                :func:`map_normalize`                     :func:`sqrt`                              to_milliseconds                               :func:`map_agg`
+    bing_tile_parent                          :func:`from_hex`                          map_remove_null_values                    st_area                                   to_spherical_geography                        :func:`map_union`
+    bing_tile_polygon                         :func:`from_ieee754_32`                   :func:`map_subset`                        st_asbinary                               :func:`to_unixtime`                           :func:`map_union_sum`
+    bing_tile_quadkey                         :func:`from_ieee754_64`                   :func:`map_top_n`                         st_astext                                 :func:`to_utf8`                               :func:`max`
+    bing_tile_zoom_level                      :func:`from_iso8601_date`                 map_top_n_keys                            st_boundary                               trail                                         :func:`max_by`
+    bing_tiles_around                         from_iso8601_timestamp                    map_top_n_values                          st_buffer                                 :func:`transform`                             :func:`merge`
+    :func:`binomial_cdf`                      :func:`from_unixtime`                     :func:`map_values`                        st_centroid                               :func:`transform_keys`                        merge_set_digest
+    :func:`bit_count`                         :func:`from_utf8`                         :func:`map_zip_with`                      st_contains                               :func:`transform_values`                      :func:`min`
+    :func:`bitwise_and`                       :func:`gamma_cdf`                         :func:`md5`                               st_convexhull                             :func:`trim`                                  :func:`min_by`
+    :func:`bitwise_arithmetic_shift_right`    geometry_as_geojson                       merge_hll                                 st_coorddim                               :func:`trim_array`                            :func:`multimap_agg`
+    :func:`bitwise_left_shift`                geometry_from_geojson                     merge_khll                                st_crosses                                :func:`truncate`                              noisy_avg_gaussian
+    :func:`bitwise_logical_shift_right`       geometry_invalid_reason                   :func:`millisecond`                       st_difference                             :func:`typeof`                                noisy_count_gaussian
+    :func:`bitwise_not`                       geometry_nearest_points                   :func:`minute`                            st_dimension                              uniqueness_distribution                       noisy_count_if_gaussian
+    :func:`bitwise_or`                        geometry_to_bing_tiles                    :func:`mod`                               st_disjoint                               :func:`upper`                                 noisy_sum_gaussian
+    :func:`bitwise_right_shift`               geometry_to_dissolved_bing_tiles          :func:`month`                             st_distance                               :func:`url_decode`                            numeric_histogram
+    :func:`bitwise_right_shift_arithmetic`    geometry_union                            :func:`multimap_from_entries`             st_endpoint                               :func:`url_encode`                            qdigest_agg
+    :func:`bitwise_shift_left`                great_circle_distance                     murmur3_x64_128                           st_envelope                               :func:`url_extract_fragment`                  :func:`reduce_agg`
+    :func:`bitwise_xor`                       :func:`greatest`                          myanmar_font_encoding                     st_envelopeaspts                          :func:`url_extract_host`                      :func:`regr_avgx`
+    :func:`cardinality`                       :func:`hamming_distance`                  myanmar_normalize_unicode                 st_equals                                 :func:`url_extract_parameter`                 :func:`regr_avgy`
+    :func:`cauchy_cdf`                        hash_counts                               :func:`nan`                               st_exteriorring                           :func:`url_extract_path`                      :func:`regr_count`
+    :func:`cbrt`                              :func:`hmac_md5`                          :func:`ngrams`                            st_geometries                             :func:`url_extract_port`                      :func:`regr_intercept`
+    :func:`ceil`                              :func:`hmac_sha1`                         :func:`no_keys_match`                     st_geometryfromtext                       :func:`url_extract_protocol`                  :func:`regr_r2`
+    :func:`ceiling`                           :func:`hmac_sha256`                       :func:`no_values_match`                   st_geometryn                              :func:`url_extract_query`                     :func:`regr_slope`
+    :func:`chi_squared_cdf`                   :func:`hmac_sha512`                       :func:`none_match`                        st_geometrytype                           uuid                                          :func:`regr_sxx`
+    :func:`chr`                               :func:`hour`                              :func:`normal_cdf`                        st_geomfrombinary                         value_at_quantile                             :func:`regr_sxy`
+    classify                                  :func:`infinity`                          normalize                                 st_interiorringn                          values_at_quantiles                           :func:`regr_syy`
+    :func:`codepoint`                         intersection_cardinality                  now                                       st_interiorrings                          :func:`week`                                  :func:`set_agg`
+    color                                     :func:`inverse_beta_cdf`                  :func:`parse_datetime`                    st_intersection                           :func:`week_of_year`                          :func:`set_union`
+    :func:`combinations`                      inverse_binomial_cdf                      parse_duration                            st_intersects                             :func:`weibull_cdf`                           :func:`skewness`
+    :func:`concat`                            inverse_cauchy_cdf                        parse_presto_data_size                    st_isclosed                               :func:`width_bucket`                          spatial_partitioning
+    :func:`contains`                          inverse_chi_squared_cdf                   :func:`pi`                                st_isempty                                :func:`wilson_interval_lower`                 :func:`stddev`
+    :func:`cos`                               inverse_f_cdf                             pinot_binary_decimal_to_double            st_isring                                 :func:`wilson_interval_upper`                 :func:`stddev_pop`
+    :func:`cosh`                              inverse_gamma_cdf                         :func:`poisson_cdf`                       st_issimple                               word_stem                                     :func:`stddev_samp`
+    :func:`cosine_similarity`                 inverse_laplace_cdf                       :func:`pow`                               st_isvalid                                :func:`xxhash64`                              :func:`sum`
+    :func:`crc32`                             inverse_normal_cdf                        :func:`power`                             st_length                                 :func:`year`                                  tdigest_agg
+    :func:`current_date`                      inverse_poisson_cdf                       quantile_at_value                         st_linefromtext                           :func:`year_of_week`                          :func:`var_pop`
+    current_time                              inverse_weibull_cdf                       :func:`quarter`                           st_linestring                             :func:`yow`                                   :func:`var_samp`
+    current_timestamp                         ip_prefix                                 :func:`radians`                           st_multipoint                             :func:`zip`                                   :func:`variance`
+    current_timezone                          ip_subnet_max                             :func:`rand`                              st_numgeometries                          :func:`zip_with`
+    :func:`date`                              ip_subnet_min                             :func:`random`                            st_numinteriorring
+    :func:`date_add`                          ip_subnet_range                           :func:`reduce`                            st_numpoints
     ========================================  ========================================  ========================================  ========================================  ========================================  ==  ========================================  ==  ========================================

--- a/velox/functions/prestosql/coverage/data/all_aggregate_functions.txt
+++ b/velox/functions/prestosql/coverage/data/all_aggregate_functions.txt
@@ -45,6 +45,10 @@ merge_set_digest
 min
 min_by
 multimap_agg
+noisy_avg_gaussian
+noisy_count_gaussian
+noisy_count_if_gaussian
+noisy_sum_gaussian
 numeric_histogram
 qdigest_agg
 reduce_agg

--- a/velox/functions/prestosql/coverage/data/all_scalar_functions.txt
+++ b/velox/functions/prestosql/coverage/data/all_scalar_functions.txt
@@ -13,6 +13,7 @@ array_frequency
 array_has_duplicates
 array_intersect
 array_join
+array_least_frequent
 array_max
 array_max_by
 array_min
@@ -23,6 +24,7 @@ array_remove
 array_sort
 array_sort_desc
 array_sum
+array_top_n
 array_union
 arrays_overlap
 asin
@@ -188,6 +190,7 @@ map_entries
 map_filter
 map_from_entries
 map_keys
+map_keys_by_top_n_values
 map_normalize
 map_remove_null_values
 map_subset
@@ -240,6 +243,7 @@ remove_nulls
 render
 repeat
 replace
+replace_first
 reverse
 rgb
 round
@@ -247,6 +251,7 @@ rpad
 rtrim
 scale_qdigest
 second
+secure_rand
 secure_random
 sequence
 sha1
@@ -332,6 +337,7 @@ tdigest_agg
 timezone_hour
 timezone_minute
 to_base
+to_base32
 to_base64
 to_base64url
 to_big_endian_32
@@ -345,6 +351,7 @@ to_milliseconds
 to_spherical_geography
 to_unixtime
 to_utf8
+trail
 transform
 transform_keys
 transform_values


### PR DESCRIPTION
Updated the complete list of Presto scalar functions using output from `SHOW FUNCTIONS` command.

Re-generated coverage maps using instructions from
`velox/functions/prestosql/coverage/README.md`.