### PR TITLE
Fix the race conditions in join fuzzer caused by arbitration test utility

### DIFF
--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -485,12 +485,19 @@ void testingRunArbitration(
     uint64_t targetBytes,
     bool allowSpill) {
   pool->enterArbitration();
-  static_cast<MemoryPoolImpl*>(pool)->testingManager()->shrinkPools(
-      targetBytes, allowSpill);
-  pool->leaveArbitration();
-
-  // This function is simulating an arbitration triggered by growCapacity, which
-  // would check this.
+  // Seraliazes the testing arbitration injection to make sure that the previous
+  // op has left arbitration section before starting the next one. This is
+  // guaranteed by the production code for operation triggered arbitration.
+  static std::mutex lock;
+  {
+    std::lock_guard<std::mutex> l(lock);
+    static_cast<MemoryPoolImpl*>(pool)->testingManager()->shrinkPools(
+        targetBytes, allowSpill);
+    pool->leaveArbitration();
+  }
+  // This function is simulating an operator triggered arbitration which
+  // would check if the query has been aborted after finish arbitration by the
+  // memory pool capacity grow path.
   static_cast<MemoryPoolImpl*>(pool)->testingCheckIfAborted();
 }
 } // namespace facebook::velox::memory


### PR DESCRIPTION
The current testingRunArbitration utility with memory pool is to simulate an operator triggered arbitration.
It exposes two race conditions which won't happen in production but could cause noise in fuzzer test.
The first race condition:
T1: OP1 injects test arbitration and succeeds, and prepare to leave but not hasn't leave the arbitration section yet
T2: another memory arbitration is triggered no matter it is by test utility or by production code. And the memory
allocation by spilling triggers oom injection that fails this disk spilling and the task memory reclaim
T3: the failed memory reclaim resumes the task execution, and then OP1 is ready to run after leave arbitration section
(Note: there is only one query run at a time in join fuzzer test)
T4: the memory arbitrator abort the query when memory reclaim fails
T5: the query abort sets the error in task
T6: the query abort waits the task threads to finish. Note at this time OP1 is not counted as running
thread as it is still in arbitration section
T7: OP1 now leaves arbitration and the memory allocation succeeds, and it didn't notice failure (task error or query aborted)
T8: the query aborts each individual operators by close the operator which release its hold memory resource
by resetting the operator class members directly
T9: OP1 hits segment fault or memory sanity check by asan when it proceeds after it has been aborted.

The second race condition:
T1: OP1 injects memory arbitration, succeeds and about to leave arbitration section
T2: OP2 injects memory arbitration which pauses the task execution, and the driver thread running OP1 is considered
as not running as it is still suspended now
T3: OP1 leave arbitration section and clears the suspension flag
T4: OP2 starts to reclaim from OP1 and hit the sanity check failure as it has seen a non-suspended driver thread
running
By adding more logs in check failure message, sometime the suspension flag has been set in test which is because
OP1 might trigger arbitration again

Note these race conditions never happens in production as the memory arbitration is sequentially executed with
one at a time, and it only starts the next next arbitration after the previously arbitration operator leaves
its arbitration section.

This fix is to serialize the test injected arbitration with a global lock to ensure that the next arbitration
starts after the previous operator has left arbitration section

