### PR TITLE
Remove unused exception parameter from velox/common/base/tests/AsyncSourceTest.cpp

### DIFF
--- a/velox/common/base/tests/AsyncSourceTest.cpp
+++ b/velox/common/base/tests/AsyncSourceTest.cpp
@@ -137,7 +137,7 @@ TEST(AsyncSourceTest, errorsWithThreads) {
             auto gizmo =
                 gizmos[folly::Random::rand32(rng) % gizmos.size()]->move();
             EXPECT_EQ(nullptr, gizmo);
-          } catch (std::exception& e) {
+          } catch (std::exception&) {
             ++numErrors;
           }
         }

--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -225,7 +225,7 @@ class AsyncDataCacheTest : public testing::Test {
       EXPECT_TRUE(pin.entry()->isExclusive());
       pin.entry()->setPrefetch();
       return pin;
-    } catch (const VeloxException& e) {
+    } catch (const VeloxException&) {
       return CachePin();
     };
   }
@@ -333,12 +333,12 @@ class TestingCoalescedSsdLoad : public TestingCoalescedLoad {
     try {
       file.load(toLoad, pins);
       VELOX_CHECK(!injectError_, "Testing error");
-    } catch (std::exception& e) {
+    } catch (std::exception&) {
       try {
         for (const auto& ssdPin : toLoad) {
           file.erase(RawFileCacheKey{fileNum, ssdPin.run().offset()});
         }
-      } catch (const std::exception& e2) {
+      } catch (const std::exception&) {
         // Ignore error.
       }
       throw;
@@ -444,7 +444,7 @@ void AsyncDataCacheTest::loadBatch(
     executor()->add([load, semaphore]() {
       try {
         load->loadOrFuture(nullptr);
-      } catch (const std::exception& e) {
+      } catch (const std::exception&) {
         // Expecting error, ignore.
       };
       if (semaphore) {
@@ -473,7 +473,7 @@ void AsyncDataCacheTest::loadBatch(
     executor()->add([load, semaphore]() {
       try {
         load->loadOrFuture(nullptr);
-      } catch (const std::exception& e) {
+      } catch (const std::exception&) {
         // Expecting error, ignore.
       };
       if (semaphore) {
@@ -564,7 +564,7 @@ void AsyncDataCacheTest::loadLoop(
           loadBatch(fileNum, batch, injectError);
           try {
             checkBatch(fileNum, batch, injectError);
-          } catch (std::exception& e) {
+          } catch (std::exception&) {
             continue;
           }
           batch.clear();

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -115,7 +115,7 @@ class MemoryAllocatorTest : public testing::TestWithParam<int> {
         EXPECT_TRUE(result.empty());
         return false;
       }
-    } catch (const VeloxException& e) {
+    } catch (const VeloxException&) {
       EXPECT_TRUE(result.empty());
       return false;
     }

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -365,7 +365,7 @@ void Driver::enqueueInternal() {
     auto stopGuard = folly::makeGuard([&]() { opCallStatus_.stop(); });    \
     call;                                                                  \
     recordSilentThrows(*operatorPtr);                                      \
-  } catch (const VeloxException& e) {                                      \
+  } catch (const VeloxException&) {                                        \
     throw;                                                                 \
   } catch (const std::exception& e) {                                      \
     VELOX_FAIL(                                                            \

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -1917,7 +1917,7 @@ TEST_F(MultiFragmentTest, earlyTaskFailure) {
     if (internalFailure) {
       try {
         VELOX_FAIL("memoryAbortTest");
-      } catch (const VeloxRuntimeError& e) {
+      } catch (const VeloxRuntimeError&) {
         finalSortTask->pool()->abort(std::current_exception());
       }
     } else {

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -1374,7 +1374,7 @@ DEBUG_ONLY_TEST_F(TaskTest, driverCounters) {
     try {
       while (cursor->moveNext()) {
       };
-    } catch (VeloxRuntimeError& ex) {
+    } catch (VeloxRuntimeError&) {
     }
   });
 

--- a/velox/expression/tests/ExpressionFuzzerVerifier.cpp
+++ b/velox/expression/tests/ExpressionFuzzerVerifier.cpp
@@ -250,7 +250,7 @@ void ExpressionFuzzerVerifier::retryWithTry(
                 false, // canThrow
                 columnsToWrapInLazy)
             .result;
-  } catch (const std::exception& e) {
+  } catch (const std::exception&) {
     if (options_.findMinimalSubexpression) {
       computeMinimumSubExpression(
           {&execCtx_, {false, ""}},
@@ -281,7 +281,7 @@ void ExpressionFuzzerVerifier::retryWithTry(
                        : nullptr,
           false, // canThrow
           columnsToWrapInLazy);
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
       if (options_.findMinimalSubexpression) {
         computeMinimumSubExpression(
             {&execCtx_, {false, ""}},
@@ -339,7 +339,7 @@ void ExpressionFuzzerVerifier::go() {
           resultVectors ? BaseVector::copy(*resultVectors) : nullptr,
           true, // canThrow
           columnsToWrapInLazy);
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
       if (options_.findMinimalSubexpression) {
         computeMinimumSubExpression(
             {&execCtx_, {false, ""}},

--- a/velox/expression/tests/ExpressionVerifier.cpp
+++ b/velox/expression/tests/ExpressionVerifier.cpp
@@ -431,7 +431,7 @@ class MinimalSubExpressionFinder {
           results ? BaseVector::copy(*results) : nullptr,
           true, // canThrow
           columnsToWrapInLazy);
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
       success = false;
     }
     FLAGS_minloglevel = 0;

--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -217,7 +217,7 @@ class Re2MatchConstantPattern final : public exec::VectorFunction {
     exec::LocalDecodedVector toSearch(context, *args[0], rows);
     try {
       checkForBadPattern(re_);
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
       context.setErrors(rows, std::current_exception());
       return;
     }
@@ -312,7 +312,7 @@ class Re2SearchAndExtractConstantPattern final : public exec::VectorFunction {
     if (const auto groupId = getIfConstant<T>(*args[2])) {
       try {
         checkForBadGroupId(*groupId, re_);
-      } catch (const std::exception& e) {
+      } catch (const std::exception&) {
         context.setErrors(rows, std::current_exception());
         return;
       }
@@ -834,7 +834,7 @@ class LikeWithRe2 final : public exec::VectorFunction {
     // apply() will not be invoked if the selection is empty.
     try {
       checkForBadPattern(*re_);
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
       context.setErrors(rows, std::current_exception());
       return;
     }
@@ -1067,7 +1067,7 @@ class Re2ExtractAllConstantPattern final : public exec::VectorFunction {
     VELOX_CHECK(args.size() == 2 || args.size() == 3);
     try {
       checkForBadPattern(re_);
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
       context.setErrors(rows, std::current_exception());
       return;
     }
@@ -1092,7 +1092,7 @@ class Re2ExtractAllConstantPattern final : public exec::VectorFunction {
       //
       try {
         checkForBadGroupId(*_groupId, re_);
-      } catch (const std::exception& e) {
+      } catch (const std::exception&) {
         context.setErrors(rows, std::current_exception());
         return;
       }

--- a/velox/functions/prestosql/benchmarks/URLBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/URLBenchmark.cpp
@@ -127,7 +127,7 @@ struct FollyUrlExtractPortFunction {
       result = parsedUrl.port();
     } catch (const folly::ConversionError&) {
       return false;
-    } catch (const std::invalid_argument& e) {
+    } catch (const std::invalid_argument&) {
       return false;
     }
     return true;
@@ -154,7 +154,7 @@ struct FollyUrlExtractParameterFunction {
           strncpy(result.data(), pair.second.c_str(), pair.second.length());
         }
       }
-    } catch (const std::invalid_argument& e) {
+    } catch (const std::invalid_argument&) {
       return false;
     }
     return false;


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: xiaoxmeng

Differential Revision: D55548533


