### PR TITLE
Remove unused lambda capture from velox/common/base/tests/AsyncSourceTest.cpp

### DIFF
--- a/velox/common/base/tests/AsyncSourceTest.cpp
+++ b/velox/common/base/tests/AsyncSourceTest.cpp
@@ -112,7 +112,7 @@ TEST(AsyncSourceTest, errorsWithThreads) {
   std::atomic<int32_t> numErrors{0};
   for (auto i = 0; i < kNumGizmos; ++i) {
     gizmos.push_back(
-        std::make_shared<AsyncSource<Gizmo>>([i]() -> std::unique_ptr<Gizmo> {
+        std::make_shared<AsyncSource<Gizmo>>([]() -> std::unique_ptr<Gizmo> {
           std::this_thread::sleep_for(std::chrono::milliseconds(1)); // NOLINT
           VELOX_USER_FAIL("Testing error");
         }));

--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -180,7 +180,7 @@ class AsyncDataCacheTest : public testing::Test {
     std::vector<std::thread> threads;
     threads.reserve(numThreads);
     for (int32_t i = 0; i < numThreads; ++i) {
-      threads.push_back(std::thread([this, i, func]() { func(i); }));
+      threads.push_back(std::thread([i, func]() { func(i); }));
     }
     for (auto& thread : threads) {
       thread.join();


### PR DESCRIPTION
Summary:
`-Wunused-lambda-capture` has identified an unused lambda capture. This diff removes it.

If the code compiles, this is safe to land.

Reviewed By: xiaoxmeng

Differential Revision: D55560320


