### PR TITLE
Update driver and operator stats when close by task

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -853,6 +853,7 @@ void Driver::closeByTask() {
   VELOX_CHECK(isOnThread());
   VELOX_CHECK(isTerminated());
   closeOperators();
+  updateStats();
   closed_ = true;
 }
 


### PR DESCRIPTION
Summary:
Currently the stats are not updated if close is issued by task.

Fix https://github.com/facebookincubator/velox/issues/9301

Differential Revision: D55601334


