### PR TITLE
Grow initial capacity without checking memory arbitration

### DIFF
--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -209,12 +209,6 @@ uint64_t SharedArbitrator::growCapacity(
   {
     std::lock_guard<std::mutex> l(mutex_);
     ++numReserves_;
-    if (running_) {
-      // NOTE: if there is a running memory arbitration, then we shall skip
-      // reserving the free memory for the newly created memory pool but let it
-      // grow its capacity on-demand later through the memory arbitration.
-      return 0;
-    }
     reserveBytes = decrementFreeCapacityLocked(bytesToReserve);
     pool->grow(reserveBytes);
     freeCapacity = freeCapacity_;

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -1978,11 +1978,11 @@ DEBUG_ONLY_TEST_F(
 
   arbitrationRun.wait(arbitrationRunKey);
 
-  // Allocate a new root memory pool and check its initial memory reservation is
-  // zero.
+  // Allocate a new root memory pool and check it has its initial capacity
+  // allocated.
   std::shared_ptr<MockTask> skipTask = addTask(kMemoryCapacity);
   MockMemoryOperator* skipTaskOp = addMemoryOp(skipTask);
-  ASSERT_EQ(skipTaskOp->pool()->capacity(), 0);
+  ASSERT_EQ(skipTaskOp->pool()->capacity(), kMemoryPoolInitCapacity);
 
   arbitrationBlock.notify();
   allocThread.join();


### PR DESCRIPTION
Some slow queries spent a lot of time waiting for memory arbitration even through it only needs
a small amount of memory for execution. This is probably blocked behind some long running
memory arbitration. If the system has free capacity, then we shouldn't block this and let it proceed.

The followup is to parallelize the local memory arbitration execution, and we only expect the query
slowdown caused by the other queries when the system is busy with global memory arbitration which
indicates we are over-provisioning memory and needs operations.