### PR TITLE
Fix integer overflow in Entropy aggregate when argument is constant

### DIFF
--- a/velox/functions/prestosql/aggregates/EntropyAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/EntropyAggregates.cpp
@@ -131,8 +131,11 @@ class EntropyAggregate : public exec::Aggregate {
       if (!decodedRaw_.isNullAt(0)) {
         const T value = decodedRaw_.valueAt<T>(0);
         const auto numRows = rows.countSelected();
-        EntropyAccumulator accData(
-            numRows * value, numRows * value * std::log(value));
+        // The "sum" is the constant value times the number of rows.
+        // Use double to prevent overflows (this is the same as what is done in
+        // updateNonNullValue).
+        const auto sum = (double)numRows * (double)value;
+        EntropyAccumulator accData(sum, sum * std::log(value));
         updateNonNullValue(group, accData);
       }
     } else if (decodedRaw_.mayHaveNulls()) {

--- a/velox/functions/prestosql/aggregates/tests/EntropyAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/EntropyAggregationTest.cpp
@@ -185,5 +185,21 @@ TEST_F(EntropyAggregationTest, allNulls) {
   testAggregations({data}, {"c0"}, {"entropy(c1)"}, {"a0"}, {expectedResult});
 }
 
+TEST_F(EntropyAggregationTest, largeConstant) {
+  auto data =
+      makeRowVector({makeConstant(std::numeric_limits<int64_t>::max(), 10)});
+
+  auto expectedResult = makeRowVector(
+      {makeFlatVector<double>(std::vector<double>{3.3219280948873693})});
+  testAggregations({data}, {}, {"entropy(c0)"}, {expectedResult});
+
+  data = makeRowVector(
+      {makeFlatVector<int32_t>({1, 1, 1, 2, 2, 2}),
+       makeConstant(std::numeric_limits<int64_t>::max(), 10)});
+  expectedResult = makeRowVector(
+      {makeFlatVector<double>({1.5849625007211632, 1.5849625007211632})});
+  testAggregations({data}, {"c0"}, {"entropy(c1)"}, {"a0"}, {expectedResult});
+}
+
 } // namespace
 } // namespace facebook::velox::aggregate::test


### PR DESCRIPTION
Summary:
When the argument to Entropy is constant and we have a single group, the constant value is multiplied the number of
selected rows and then this product is added to the accumulator's "sum".  It's possible this multiplication can encounter an
integer overflow.

In other cases we add values one by one to the accumulator, first casting them to double which avoids the integer overflow.
Casting the constant value to a double when multiplying achieves the same semantics.

Differential Revision: D55614963


