### PR TITLE
Fix probe spill check failure

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1045,7 +1045,7 @@ bool HashProbe::maybeReadSpillOutput() {
   VELOX_DCHECK_EQ(table_->numDistinct(), 0);
 
   if (!spillOutputReader_->nextBatch(output_)) {
-    spillInputReader_.reset();
+    spillOutputReader_.reset();
     return false;
   }
   return true;

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -68,6 +68,10 @@ class HashProbe : public Operator {
 
   bool canReclaim() const override;
 
+  bool testingHasInputSpiller() const {
+    return inputSpiller_ != nullptr;
+  }
+
  private:
   void setState(ProbeOperatorState state);
   void checkStateTransition(ProbeOperatorState state);

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -632,6 +632,10 @@ class Operator : public BaseRuntimeStatWriter {
     return nonReclaimableSection_;
   }
 
+  bool testingHasInput() const {
+    return input_ != nullptr;
+  }
+
  protected:
   static std::vector<std::unique_ptr<PlanNodeTranslator>>& translators();
   friend class NonReclaimableSection;

--- a/velox/exec/tests/JoinFuzzer.cpp
+++ b/velox/exec/tests/JoinFuzzer.cpp
@@ -434,7 +434,7 @@ RowVectorPtr JoinFuzzer::execute(const PlanWithSplits& plan, bool injectSpill) {
     builder.config(core::QueryConfig::kSpillEnabled, "true")
         .config(core::QueryConfig::kAggregationSpillEnabled, "true")
         .spillDirectory(spillDirectory->path);
-    spillPct = 100;
+    spillPct = 10;
   }
 
   ScopedOOMInjector oomInjector(

--- a/velox/exec/tests/utils/OperatorTestBase.h
+++ b/velox/exec/tests/utils/OperatorTestBase.h
@@ -21,6 +21,7 @@
 #include "velox/common/caching/SsdCache.h"
 #include "velox/core/Expressions.h"
 #include "velox/core/PlanNode.h"
+#include "velox/exec/HashProbe.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/type/Variant.h"


### PR DESCRIPTION
The maybeReadSpillOutput has a bug that reset spillInputReader_ but not spillOutputReader_ during
spill output processing which caused the wrong probe finish condition to be detected. The hash probe
operator finishes early and tries to restore the same spill partition that run into spill partition restore 
check failure.
Add unit test to reproduce and verify the fix.

@zhztheplayer also helped verify the fix on Gluten CI.