### PR TITLE
Remove unused headers in Type.h

### DIFF
--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-#include "velox/type/Type.h"
+#include <velox/type/Type.h>
+
 #include <boost/algorithm/string.hpp>
+#include <fmt/format.h>
 #include <folly/Demangle.h>
 #include <re2/re2.h>
+
 #include <sstream>
 #include <typeindex>
+
 #include "velox/type/TimestampConversion.h"
 
 namespace std {

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -15,12 +15,10 @@
  */
 #pragma once
 
-#include <fmt/core.h>
-#include <fmt/format.h>
-#include <folly/Format.h>
+#include <folly/CPortability.h>
+#include <folly/dynamic.h>
 #include <folly/Range.h>
-#include <folly/String.h>
-#include <folly/json.h>
+
 #include <cstdint>
 #include <cstring>
 #include <ctime>
@@ -33,7 +31,6 @@
 #include <typeindex>
 #include <vector>
 
-#include "folly/CPortability.h"
 #include "velox/common/base/ClassName.h"
 #include "velox/common/serialization/Serializable.h"
 #include "velox/type/HugeInt.h"

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -16,8 +16,8 @@
 #pragma once
 
 #include <folly/CPortability.h>
-#include <folly/dynamic.h>
 #include <folly/Range.h>
+#include <folly/dynamic.h>
 
 #include <cstdint>
 #include <cstring>


### PR DESCRIPTION
We need to keep the core headers as clean as possible to help improve build timing.