### PR TITLE
Fix setup-ubuntu.sh to explicitly install package manager dependencies when sourcing

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: "Install dependencies"
         if: ${{ github.event_name == 'pull_request' }}
-        run: source velox/scripts/setup-ubuntu.sh
+        run: source velox/scripts/setup-ubuntu.sh && install_apt_deps
 
       - name: Build Baseline Benchmarks
         if: ${{ github.event_name == 'pull_request' }}
@@ -115,7 +115,7 @@ jobs:
           submodules: 'recursive'
 
       - name: "Install dependencies"
-        run: source velox/scripts/setup-ubuntu.sh
+        run: source velox/scripts/setup-ubuntu.sh && install_apt_deps
 
       - name: Build Contender Benchmarks
         working-directory: velox

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -71,7 +71,7 @@ jobs:
           ref: "${{ inputs.ref || 'main' }}"
 
       - name: "Install dependencies"
-        run: cd  velox && source ./scripts/setup-ubuntu.sh
+        run: cd  velox && source ./scripts/setup-ubuntu.sh && install_apt_deps
 
       - name: "Build"
         run: |
@@ -181,7 +181,7 @@ jobs:
           ref: "${{ inputs.ref || 'main' }}"
 
       - name: "Install dependencies"
-        run: source ./scripts/setup-ubuntu.sh
+        run: source ./scripts/setup-ubuntu.sh && install_apt_deps
 
       - name: Download spark aggregation fuzzer
         uses: actions/download-artifact@v3
@@ -222,7 +222,7 @@ jobs:
           ref: "${{ inputs.ref || 'main' }}"
 
       - name: "Install dependencies"
-        run: source ./scripts/setup-ubuntu.sh
+        run: source ./scripts/setup-ubuntu.sh && install_apt_deps
 
       - name: Download join fuzzer
         uses: actions/download-artifact@v3

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          source scripts/setup-ubuntu.sh
+          source scripts/setup-ubuntu.sh && install_apt_deps
 
       - name: Clear CCache Statistics
         run: |

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -159,8 +159,7 @@ function install_apt_deps {
   install_velox_deps_from_apt
 }
 
-# For backward compatibility, invoke install_apt_deps
-(return 2> /dev/null) && install_apt_deps && return # If script was sourced, don't run commands.
+(return 2> /dev/null) && return # If script was sourced, don't run commands.
 
 (
   if [[ $# -ne 0 ]]; then


### PR DESCRIPTION
We currently always install the package manager dependencies when we source setup-ubuntu.sh.
However, this is not always desired when a user wants to install a specific package.