### PR TITLE
Update current_date Presto function 

### DIFF
--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -1442,14 +1442,12 @@ struct CurrentDateFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   const date::time_zone* timeZone_ = nullptr;
+  int32_t currentDate_;
 
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config) {
     timeZone_ = getTimeZoneFromConfig(config);
-  }
-
-  FOLLY_ALWAYS_INLINE void call(out_type<Date>& result) {
     auto now = Timestamp::now();
     if (timeZone_ != nullptr) {
       now.toTimezone(*timeZone_);
@@ -1457,8 +1455,13 @@ struct CurrentDateFunction {
     const std::chrono::
         time_point<std::chrono::system_clock, std::chrono::milliseconds>
             localTimepoint(std::chrono::milliseconds(now.toMillis()));
-    result = std::chrono::floor<date::days>((localTimepoint).time_since_epoch())
-                 .count();
+    currentDate_ =
+        std::chrono::floor<date::days>((localTimepoint).time_since_epoch())
+            .count();
+  }
+
+  FOLLY_ALWAYS_INLINE void call(out_type<Date>& result) {
+    result = currentDate_;
   }
 };
 


### PR DESCRIPTION
Presto's `current_date` implementation can return different result for different rows but should return the same result for all rows in a query. Updating the implementation to set the current_date in `initialize` vs `call` so that it is set once per query.

Addresses #9354 