### PR TITLE
Fix min precision of short decimal type

### DIFF
--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -664,7 +664,7 @@ class DecimalType : public ScalarType<KIND> {
  public:
   static_assert(KIND == TypeKind::BIGINT || KIND == TypeKind::HUGEINT);
   static constexpr uint8_t kMaxPrecision = KIND == TypeKind::BIGINT ? 18 : 38;
-  static constexpr uint8_t kMinPrecision = KIND == TypeKind::BIGINT ? 0 : 19;
+  static constexpr uint8_t kMinPrecision = KIND == TypeKind::BIGINT ? 1 : 19;
 
   inline bool equivalent(const Type& other) const override {
     if (!Type::hasSameTypeId(other)) {

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -228,6 +228,9 @@ TEST(TypeTest, shortDecimal) {
   EXPECT_NE(*DECIMAL(9, 5), *shortDecimal);
   EXPECT_NE(*DECIMAL(10, 4), *shortDecimal);
 
+  VELOX_ASSERT_THROW(
+      DECIMAL(0, 0), "Precision of decimal type must be at least 1");
+
   EXPECT_STREQ(shortDecimal->name(), "DECIMAL");
   EXPECT_EQ(shortDecimal->parameters().size(), 2);
   EXPECT_TRUE(


### PR DESCRIPTION
The min precision of short decimal type should be 1.