### PR TITLE
Add spark regr_replacement aggregate function

### DIFF
--- a/velox/docs/functions/spark/aggregate.rst
+++ b/velox/docs/functions/spark/aggregate.rst
@@ -114,6 +114,10 @@ General Aggregate Functions
 
     Returns b
 
+.. spark:function:: regr_replacement(x) -> double
+
+    Returns the `m2` (the sum of the second central moment) of input values.
+
 .. spark:function:: skewness(x) -> double
 
     Returns the skewness of all input values. When the count of `x` is greater than or equal to 1,

--- a/velox/functions/sparksql/aggregates/CMakeLists.txt
+++ b/velox/functions/sparksql/aggregates/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(
   FirstLastAggregate.cpp
   MinMaxByAggregate.cpp
   Register.cpp
+  RegrReplacementAggregate.cpp
   SumAggregate.cpp)
 
 target_link_libraries(velox_functions_spark_aggregates fmt::fmt velox_exec

--- a/velox/functions/sparksql/aggregates/Register.cpp
+++ b/velox/functions/sparksql/aggregates/Register.cpp
@@ -21,6 +21,7 @@
 #include "velox/functions/sparksql/aggregates/BloomFilterAggAggregate.h"
 #include "velox/functions/sparksql/aggregates/CentralMomentsAggregate.h"
 #include "velox/functions/sparksql/aggregates/CollectListAggregate.h"
+#include "velox/functions/sparksql/aggregates/RegrReplacementAggregate.h"
 #include "velox/functions/sparksql/aggregates/SumAggregate.h"
 
 namespace facebook::velox::functions::aggregate::sparksql {
@@ -47,5 +48,6 @@ void registerAggregateFunctions(
   registerSum(prefix + "sum", withCompanionFunctions, overwrite);
   registerCentralMomentsAggregate(prefix, withCompanionFunctions, overwrite);
   registerCollectListAggregate(prefix, withCompanionFunctions, overwrite);
+  registerRegrReplacementAggregate(prefix, withCompanionFunctions, overwrite);
 }
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/RegrReplacementAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/RegrReplacementAggregate.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/sparksql/aggregates/RegrReplacementAggregate.h"
+
+#include "velox/exec/SimpleAggregateAdapter.h"
+
+namespace facebook::velox::functions::aggregate::sparksql {
+namespace {
+class RegrReplacementAggregate {
+ public:
+  using InputType = Row<double>;
+  using IntermediateType =
+      Row</*n*/ double,
+          /*avg*/ double,
+          /*m2*/ double>;
+  using OutputType = double;
+
+  static bool toIntermediate(
+      exec::out_type<Row<double, double, double>>& out,
+      exec::arg_type<double> in) {
+    out.copy_from(std::make_tuple(1.0, in, 0.0));
+    return true;
+  }
+
+  struct AccumulatorType {
+    double n{0.0};
+    double avg{0.0};
+    double m2{0.0};
+
+    explicit AccumulatorType(HashStringAllocator* /*allocator*/) {}
+
+    void addInput(
+        HashStringAllocator* /*allocator*/,
+        exec::arg_type<double> data) {
+      n += 1.0;
+      double delta = data - avg;
+      double deltaN = delta / n;
+      avg += deltaN;
+      m2 += delta * (delta - deltaN);
+    }
+
+    void combine(
+        HashStringAllocator* /*allocator*/,
+        exec::arg_type<Row<double, double, double>> other) {
+      VELOX_CHECK(other.at<0>().has_value());
+      VELOX_CHECK(other.at<1>().has_value());
+      VELOX_CHECK(other.at<2>().has_value());
+
+      double otherN = other.at<0>().value();
+      double otherAvg = other.at<1>().value();
+      double otherM2 = other.at<2>().value();
+
+      double originN = n;
+      n += otherN;
+      double delta = otherAvg - avg;
+      double deltaN = n == 0.0 ? 0.0 : delta / n;
+      avg += deltaN * otherN;
+      m2 += otherM2 + delta * deltaN * originN * otherN;
+    }
+
+    bool writeIntermediateResult(exec::out_type<IntermediateType>& out) {
+      out = std::make_tuple(n, avg, m2);
+      return true;
+    }
+
+    bool writeFinalResult(exec::out_type<OutputType>& out) {
+      if (n == 0.0) {
+        return false;
+      }
+      out = m2;
+      return true;
+    }
+  };
+};
+
+exec::AggregateRegistrationResult registerRegrReplacement(
+    const std::string& name,
+    bool withCompanionFunctions,
+    bool overwrite) {
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
+      exec::AggregateFunctionSignatureBuilder()
+          .returnType("double")
+          .intermediateType("row(double, double, double)")
+          .argumentType("double")
+          .build()};
+  return exec::registerAggregateFunction(
+      name,
+      std::move(signatures),
+      [name](
+          core::AggregationNode::Step /*step*/,
+          const std::vector<TypePtr>& argTypes,
+          const TypePtr& resultType,
+          const core::QueryConfig& /*config*/)
+          -> std::unique_ptr<exec::Aggregate> {
+        VELOX_CHECK_EQ(
+            argTypes.size(), 1, "{} takes at most one argument", name);
+        return std::make_unique<
+            exec::SimpleAggregateAdapter<RegrReplacementAggregate>>(resultType);
+      },
+      withCompanionFunctions,
+      overwrite);
+}
+} // namespace
+
+void registerRegrReplacementAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite) {
+  registerRegrReplacement(
+      prefix + "regr_replacement", withCompanionFunctions, overwrite);
+}
+} // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/RegrReplacementAggregate.h
+++ b/velox/functions/sparksql/aggregates/RegrReplacementAggregate.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace facebook::velox::functions::aggregate::sparksql {
+
+void registerRegrReplacementAggregate(
+    const std::string& name,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+} // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/aggregates/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(
   LastAggregateTest.cpp
   Main.cpp
   MinMaxByAggregationTest.cpp
+  RegrReplacementAggregationTest.cpp
   SumAggregationTest.cpp)
 
 add_test(velox_functions_spark_aggregates_test

--- a/velox/functions/sparksql/aggregates/tests/RegrReplacementAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/RegrReplacementAggregationTest.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+#include "velox/functions/sparksql/aggregates/Register.h"
+
+using namespace facebook::velox::functions::aggregate::test;
+
+namespace facebook::velox::functions::aggregate::sparksql::test {
+
+namespace {
+class RegrReplacementAggregationTest : public AggregationTestBase {
+ protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+    registerAggregateFunctions("spark_");
+  }
+};
+
+TEST_F(RegrReplacementAggregationTest, groupBy) {
+  vector_size_t size = 1'000;
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>(size, [](auto row) { return row % 10; }),
+      makeFlatVector<double>(size, [](auto row) { return row * 0.1; }),
+  });
+
+  createDuckDbTable({data});
+  // m2 is equal to the population variance divided by the size of the group.
+  testAggregations(
+      {data},
+      {"c0"},
+      {"spark_regr_replacement(c1)"},
+      {"c0", "a0 / 100.0"},
+      "select c0, var_pop(c1) from tmp group by c0");
+  testAggregationsWithCompanion(
+      {data},
+      [](auto& /*builder*/) {},
+      {"c0"},
+      {"spark_regr_replacement(c1)"},
+      {{DOUBLE()}},
+      {"c0", "a0 / 100.0"},
+      "select c0, var_pop(c1) from tmp group by c0");
+}
+
+TEST_F(RegrReplacementAggregationTest, global) {
+  vector_size_t size = 1'000;
+  auto data = makeRowVector({
+      makeFlatVector<double>(size, [](auto row) { return row * 0.3; }),
+  });
+
+  createDuckDbTable({data});
+  // m2 is equal to the population variance divided by the size of the group.
+  testAggregations(
+      {data},
+      {},
+      {"spark_regr_replacement(c0)"},
+      {"a0 / 1000.0"},
+      "select var_pop(c0) from tmp");
+  testAggregationsWithCompanion(
+      {data},
+      [](auto& /*builder*/) {},
+      {},
+      {"spark_regr_replacement(c0)"},
+      {{DOUBLE()}},
+      {"a0 / 1000.0"},
+      "select var_pop(c0) from tmp");
+}
+
+} // namespace
+} // namespace facebook::velox::functions::aggregate::sparksql::test


### PR DESCRIPTION
Spark and Presto use different accumulator to calculate `regr_sxx` and `regr_syy` aggregate functions, although the final calculation results are consistent, it is difficult to match them up due to inconsistent intermediate data.

Spark uses an accumulator same as the variance to store n (count), avg, and m2. However, unlike the variance, it does not calculate the expected value of m2, but returns m2 directly. It is called [RegrReplacement](https://github.com/apache/spark/blob/f6999df0c7f0bb18778b29ebdbe9f7d40899808a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CentralMomentAgg.scala#L274-L276) in Spark.

This PR implemented the `regr_replacement` aggregate function in Velox, making it easier for Spark's `regr_sxx` and `regr_syy` to perform calculations based on this aggregate function.