### PR TITLE
Fix CSE with TRY when updating sharedSubexprValues

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -955,7 +955,16 @@ void Expr::evaluateSharedSubexpr(
   context.deselectErrors(*missingRows);
 
   sharedSubexprRows->select(*missingRows);
-  context.moveOrCopyResult(sharedSubexprValues, rows, result);
+
+  if (context.errors()) {
+    LocalSelectivityVector rowsWithoutErrorsHolder(context, rows);
+    auto* rowsWithoutErrors = rowsWithoutErrorsHolder.get();
+    context.deselectErrors(*rowsWithoutErrors);
+
+    context.moveOrCopyResult(sharedSubexprValues, *rowsWithoutErrors, result);
+  } else {
+    context.moveOrCopyResult(sharedSubexprValues, rows, result);
+  }
 }
 
 SelectivityVector* singleRow(

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -3667,6 +3667,99 @@ TEST_P(ParameterizedExprTest, cseUnderTry) {
       result);
 }
 
+namespace {
+// This UDF throws an exception for any argument equal to 31, otherwise it's the
+// identity function. Important for the test, it sizes the result only large
+// enough to hold all rows that didn't throw an error.
+class TestingShrinkForErrorsFunction : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    VELOX_CHECK(args[0]->isFlatEncoding());
+
+    const auto* flatArg = args[0]->as<FlatVector<int8_t>>();
+
+    exec::LocalSelectivityVector remainingRows(context, rows);
+    context.applyToSelectedNoThrow(*remainingRows, [&](vector_size_t row) {
+      // Throw a user error (so it can be caught be try) if the argument is
+      // equal to 31.
+      VELOX_USER_CHECK_NE(flatArg->valueAt(row), 31, "Expected");
+    });
+
+    context.deselectErrors(*remainingRows);
+
+    // Create the result, importantly the size is rows.end() so may be smaller
+    // than the rows being processed after errors are deselected.
+    const auto localResult = std::make_shared<FlatVector<int8_t>>(
+        context.pool(),
+        outputType,
+        nullptr,
+        rows.end(),
+        flatArg->values(),
+        std::vector<BufferPtr>{});
+
+    context.moveOrCopyResult(localResult, *remainingRows, result);
+  }
+
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+    return {exec::FunctionSignatureBuilder()
+                .returnType("tinyint")
+                .argumentType("tinyint")
+                .build()};
+  }
+};
+} // namespace
+
+VELOX_DECLARE_VECTOR_FUNCTION(
+    udf_testing_shrink_for_errors,
+    TestingShrinkForErrorsFunction::signatures(),
+    std::make_unique<TestingShrinkForErrorsFunction>());
+
+TEST_P(ParameterizedExprTest, cseUnderTryWithIf) {
+  // This tests a particular case where shared subexpression computation can hit
+  // errors when combined with TRY. In this case a VectorFunction sizes the
+  // result based on rows.end(), can throw user exceptions, and doesn't resize
+  // the result Vector to include rows that produced exceptions. If that
+  // funciton is evaluated as part of CSE, e.g. on both sides of an if
+  // statement, and the last row produces an exception, the result Vector will
+  // be smaller than rows.size(). This test validates that in CSE we can
+  // tolerate this and does not rely on the fact the result Vector is at least
+  // rows.size() large, particularly when we're updating the result of a CSE to
+  // add new values, e.g. in the else portion of an if statement.
+  VELOX_REGISTER_VECTOR_FUNCTION(
+      udf_testing_shrink_for_errors, "testing_shrink_for_errors");
+
+  auto input = makeRowVector({
+      makeNullableFlatVector<bool>({true, false, true, false, true, false}),
+      makeNullableFlatVector<int8_t>({31, 3, 31, 31, 2, 31}),
+  });
+
+  VELOX_ASSERT_THROW(
+      evaluate(
+          "if(c0, testing_shrink_for_errors(c1), testing_shrink_for_errors(c1))",
+          input),
+      "Expected");
+
+  auto result = evaluate(
+      "try(if(c0, testing_shrink_for_errors(c1), testing_shrink_for_errors(c1)))",
+      input);
+
+  assertEqualVectors(
+      makeNullableFlatVector<int8_t>({
+          std::nullopt,
+          3,
+          std::nullopt,
+          std::nullopt,
+          2,
+          std::nullopt,
+      }),
+      result);
+}
+
 TEST_P(ParameterizedExprTest, conjunctUnderTry) {
   auto input = makeRowVector({
       makeFlatVector<StringView>({"a"_sv, "b"_sv}),


### PR DESCRIPTION
Summary:
When evaluating shared subexpressions with TRY, we only copy the values that are valid (did not encounter exceptions) into 
the sharedSubexprValues.  This means that the size of sharedSubexprValues may not have values for all the selected rows (in 
particular it may have a smaller length than rows).

We need to handle this when copying values from sharedSubexprValues into the result Vector, we should only copy values 
that did not encounter exceptions.  TRY will handle this upstream by appending nulls for the exceptions.

I encountered this in fuzzing, the map function produces a result Vector that is only large enough to hold values that did not
encounter exceptions and this causes an error in context.moveOrCopyResult because it was trying to copy more elements than exist.

Differential Revision: D55719677


