### PR TITLE
Fix flaky SharedArbitrationTest.driverInitTriggeredArbitration

### DIFF
--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -609,6 +609,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, driverInitTriggeredArbitration) {
                 .project({"1+1+4 as t0", "1+3+3 as t1"})
                 .planNode())
       .assertResults(expectedVector);
+  waitForAllTasksToBeDeleted();
 }
 
 DEBUG_ONLY_TEST_F(


### PR DESCRIPTION
SharedArbitrationTest.driverInitTriggeredArbitration failed with leaked empty memory pool which 
is likely caused by pending task and add a step to wait for its completion: [issue](https://github.com/facebookincubator/velox/issues/9369 )
