### PR TITLE
Add support for DECIMAL types to ArgumentTypeFuzzer

### DIFF
--- a/velox/expression/ReverseSignatureBinder.cpp
+++ b/velox/expression/ReverseSignatureBinder.cpp
@@ -39,7 +39,9 @@ bool ReverseSignatureBinder::tryBind() {
   if (hasConstrainedIntegerVariable(signature_.returnType())) {
     return false;
   }
-  return SignatureBinderBase::tryBind(signature_.returnType(), returnType_);
+  tryBindSucceeded_ =
+      SignatureBinderBase::tryBind(signature_.returnType(), returnType_);
+  return tryBindSucceeded_;
 }
 
 } // namespace facebook::velox::exec

--- a/velox/expression/ReverseSignatureBinder.h
+++ b/velox/expression/ReverseSignatureBinder.h
@@ -40,15 +40,28 @@ class ReverseSignatureBinder : private SignatureBinderBase {
   /// tryBind() and only if tryBind() returns true. If a type variable is not
   /// determined by tryBind(), it maps to a nullptr.
   const std::unordered_map<std::string, TypePtr>& bindings() const {
+    VELOX_CHECK(
+        tryBindSucceeded_, "tryBind() must be called first and succeed");
     return typeVariablesBindings_;
   }
 
+  /// Return the integer bindings produced by 'tryBind'. This function should be
+  /// called after 'tryBind' and only if 'tryBind' returns true.
+  const std::unordered_map<std::string, int>& integerBindings() const {
+    VELOX_CHECK(
+        tryBindSucceeded_, "tryBind() must be called first and succeed");
+    return integerVariablesBindings_;
+  }
+
  private:
-  /// Return whether there is a constraint on an integer variable in type
-  /// signature.
+  // Return whether there is a constraint on an integer variable in type
+  // signature.
   bool hasConstrainedIntegerVariable(const TypeSignature& type) const;
 
   const TypePtr returnType_;
+
+  // True if 'tryBind' has been called and succeeded. False otherwise.
+  bool tryBindSucceeded_{false};
 };
 
 } // namespace facebook::velox::exec

--- a/velox/expression/tests/utils/ArgumentTypeFuzzer.cpp
+++ b/velox/expression/tests/utils/ArgumentTypeFuzzer.cpp
@@ -27,12 +27,101 @@
 namespace facebook::velox::test {
 
 std::string typeToBaseName(const TypePtr& type) {
+  if (type->isDecimal()) {
+    return "decimal";
+  }
   return boost::algorithm::to_lower_copy(std::string{type->kindName()});
 }
 
 std::optional<TypeKind> baseNameToTypeKind(const std::string& typeName) {
   auto kindName = boost::algorithm::to_upper_copy(typeName);
   return tryMapNameToTypeKind(kindName);
+}
+
+namespace {
+
+bool isDecimalBaseName(const std::string& typeName) {
+  auto normalized = boost::algorithm::to_lower_copy(typeName);
+
+  return normalized == "decimal";
+}
+
+/// Returns true only if 'str' contains digits.
+bool isPositiveInteger(const std::string& str) {
+  return !str.empty() &&
+      std::find_if(str.begin(), str.end(), [](unsigned char c) {
+        return !std::isdigit(c);
+      }) == str.end();
+}
+
+} // namespace
+
+void ArgumentTypeFuzzer::determineUnboundedIntegerVariables(
+    const exec::TypeSignature& type) {
+  if (!isDecimalBaseName(type.baseName())) {
+    return;
+  }
+
+  VELOX_CHECK_EQ(2, type.parameters().size())
+
+  const auto& precision = type.parameters()[0].baseName();
+  const auto& scale = type.parameters()[1].baseName();
+
+  // Bind 'name' variable, if not already bound, using 'constant' constraint
+  // ('name'='123'). Return bound value if 'name' is already bound or was
+  // successfully bound to a constant value. Return std::nullopt otherwise.
+  auto tryFixedBinding = [&](const auto& name) -> std::optional<int> {
+    auto it = variables().find(name);
+    if (it == variables().end()) {
+      VELOX_CHECK(
+          isPositiveInteger(name),
+          "Precision and scale of a decimal type must refer to a variable "
+          "or specify a position integer constant: {}",
+          name)
+      return std::stoi(name);
+    }
+
+    if (integerBindings_.count(name) > 0) {
+      return integerBindings_[name];
+    }
+
+    if (isPositiveInteger(it->second.constraint())) {
+      const auto value = std::stoi(it->second.constraint());
+      integerBindings_[name] = value;
+      return value;
+    }
+
+    return std::nullopt;
+  };
+
+  std::optional<int> p = tryFixedBinding(precision);
+  std::optional<int> s = tryFixedBinding(scale);
+
+  if (p.has_value() && s.has_value()) {
+    return;
+  }
+
+  if (s.has_value()) {
+    p = std::max<int>(ShortDecimalType::kMinPrecision, s.value());
+    if (p < LongDecimalType::kMaxPrecision) {
+      p = p.value() + rand32(0, LongDecimalType::kMaxPrecision - p.value());
+    }
+
+    integerBindings_[precision] = p.value();
+    return;
+  }
+
+  if (p.has_value()) {
+    s = rand32(0, p.value());
+    integerBindings_[scale] = s.value();
+    return;
+  }
+
+  p = rand32(1, LongDecimalType::kMaxPrecision);
+  s = rand32(0, p.value());
+
+  integerBindings_[precision] = p.value();
+  integerBindings_[scale] = s.value();
 }
 
 void ArgumentTypeFuzzer::determineUnboundedTypeVariables() {
@@ -74,6 +163,7 @@ bool ArgumentTypeFuzzer::fuzzArgumentTypes(uint32_t maxVariadicArgs) {
       return false;
     }
     bindings_ = binder.bindings();
+    integerBindings_ = binder.integerBindings();
   } else {
     for (const auto& [name, _] : signature_.variables()) {
       bindings_.insert({name, nullptr});
@@ -81,13 +171,16 @@ bool ArgumentTypeFuzzer::fuzzArgumentTypes(uint32_t maxVariadicArgs) {
   }
 
   determineUnboundedTypeVariables();
+  for (const auto& argType : signature_.argumentTypes()) {
+    determineUnboundedIntegerVariables(argType);
+  }
   for (auto i = 0; i < formalArgsCnt; i++) {
     TypePtr actualArg;
     if (formalArgs[i].baseName() == "any") {
       actualArg = randType();
     } else {
       actualArg = exec::SignatureBinder::tryResolveType(
-          formalArgs[i], variables(), bindings_);
+          formalArgs[i], variables(), bindings_, integerBindings_);
       VELOX_CHECK(actualArg != nullptr);
     }
     argumentTypes_.push_back(actualArg);
@@ -114,15 +207,23 @@ TypePtr ArgumentTypeFuzzer::fuzzReturnType() {
       "Only fuzzing uninitialized return type is allowed.");
 
   determineUnboundedTypeVariables();
-  if (signature_.returnType().baseName() == "any") {
+  determineUnboundedIntegerVariables(signature_.returnType());
+
+  const auto& returnType = signature_.returnType();
+
+  if (returnType.baseName() == "any") {
     returnType_ = randType();
-    return returnType_;
   } else {
     returnType_ = exec::SignatureBinder::tryResolveType(
-        signature_.returnType(), variables(), bindings_);
-    VELOX_CHECK_NE(returnType_, nullptr);
-    return returnType_;
+        returnType, variables(), bindings_, integerBindings_);
   }
+
+  VELOX_CHECK_NOT_NULL(returnType_);
+  return returnType_;
+}
+
+int32_t ArgumentTypeFuzzer::rand32(int32_t min, int32_t max) {
+  return boost::random::uniform_int_distribution<uint32_t>(min, max)(rng_);
 }
 
 } // namespace facebook::velox::test

--- a/velox/expression/tests/utils/ArgumentTypeFuzzer.h
+++ b/velox/expression/tests/utils/ArgumentTypeFuzzer.h
@@ -65,9 +65,17 @@ class ArgumentTypeFuzzer {
     return signature_.variables();
   }
 
-  /// Bind each type variable that is not determined by the return type to a
-  /// randomly generated type.
+  // Returns random integer between min and max inclusive.
+  int32_t rand32(int32_t min, int32_t max);
+
+  // Bind each type variable that is not determined by the return type to a
+  // randomly generated type.
   void determineUnboundedTypeVariables();
+
+  // Bind integer variables used in specified decimal(p,s) type signature to
+  // randomly generated values if not already bound.
+  // Noop if 'type' is not a decimal type signature.
+  void determineUnboundedIntegerVariables(const exec::TypeSignature& type);
 
   TypePtr randType();
 
@@ -82,6 +90,8 @@ class ArgumentTypeFuzzer {
 
   /// Bindings between type variables and their actual types.
   std::unordered_map<std::string, TypePtr> bindings_;
+
+  std::unordered_map<std::string, int> integerBindings_;
 
   /// RNG to generate random types for unbounded type variables when necessary.
   std::mt19937& rng_;


### PR DESCRIPTION
Summary:
ArgumentTypeFuzzer serves two purposes.

Given a generic function signature, generate a random valid return type.
Given a generic function signature and a concrete return type, generate a list of valid argument types.

Consider a signature of the map_keys function: 

```
map(K, V) -> array(K). 
```

This signature has 2 type variables: K and V. This signature doesn’t fully specify the return type, just that it must be an array. There are many possible valid return types, but all should be of the form array(K). When asked to generate a valid return type for this signature ArgumentTypeFuzzer may return array(bigint) or array(row(...)), but it should not return ‘varchar’.

Now, if we fix the return type to array(bigint) and ask ArgumentTypeFuzzer to generate valid argument types, we may get back a map(bigint, varchar) or a map(bigint, double), but we do not expect a ‘varchar’ or a map(integer, float). By specifying the return type as array(bigint) we effectively bind the type variable: K = bigint. At the same time we leave V unspecified and ArgumentTypeFuzzer is free to choose any type for it.

To generate a return type, create an ArgumentTypeFuzzer by specifying a function signature and a random number generator, then call fuzzReturnType() method.

```
ArgumentTypeFuzzer fuzzer(signature, rng)
auto returnType = fuzzer.fuzzReturnType()
```

To generate argument types for a given return type, create an ArgumentTypeFuzzer by specifying a function signature, a return type and a random number generator, then call fuzzArgumentTypes() method.

```
ArgumentTypeFuzzer fuzzer(signature, returnType, rng)
If (fuzzer.fuzzArgumentTypes()) {
  auto argumentTypes = fuzzer.argumentTypes();
}
```

This change extends ArgumentTypeFuzzer to support signatures that use generic decimal types.

Consider a signature of least function:

```
(decimal(p, s),...) -> decimal(p, s)
```

This signature has 2 integer variables: p and s. The return type is not fully specified. It can be any valid decimal type. ArgumentTypeFuzzer::fuzzReturnType needs to generate values for ‘p’ and ‘s’ and return a decimal(p, s) type. If return type is fixed, say decimal(10, 7), ArgumentTypeFuzzer::fuzzArgumentTypes() needs to figure out that p=10 and s=7 and return a random number of argument types all of which are decimal(10, 7).

Consider slightly different function: between

```
(decimal(p, s), decimal(p, s)) -> boolean
```

This signature also has 2 integer variables: p and s. The return type is fully specified though. Hence, ArgumentTypeFuzzer::fuzzReturnType should always return ‘boolean’. However, when return type is fixed to the only possible value, ‘boolean’, ArgumentTypeFuzzer::fuzzArgumentTypes() may generate any valid values for p and s and return any decimal type for the arguments as long as both argument types are the same. A pair of {decimal(10, 7), decimal(10, 7)} is a valid response, as well as {decimal(18, 15), decimal(18, 15)}. 

Let’s also look at a the signature of the ‘floor’ function:

```
(decimal(p, s)) -> decimal(rp, 0)
```

This function has 3 integer variables: p, s, and rp. The ‘rp’ variable has a constraint:

```
rp  = min(38, p - s + min(s, 1))
```

The return type can be any decimal with scale 0. ArgumentTypeFuzzer::fuzzReturnType may return decimal(10, 0) or decimal(7, 0), but it should not return decimal(5, 2). 

If we fix return type and ask ArgumentTypeFuzzer to generate valid argument types, it will need to figure out how to generate values p and s such that rp = min(38, p - s + min(s, 1)). This is a pretty challenging task. Hence, ArgumentTypeFuzzer::fuzzArgumentTypes() doesn’t support signatures with constraints on integer variables.

It should be noted that ArgumentTypeFuzzer::fuzzReturnType() may also need to make sure that generated ‘rp’ is such that there exist ‘p’ and ‘s’ for which the formula above is true. For this particular formula this is easy because a solution exists for any rp: p = rp, s = 0. However, this is not true in general. It might be better to not support ArgumentTypeFuzzer::fuzzReturnType() for signatures with constraints on integer variables.

To fuzz argument or return types, ArgumentTypeFuzzer needs to generate valid values for integer variables. Unlike type variables, integer variables have implicit constraints. A variable that represents a precision must have a value in [1, 38] range. A variable that represents scale must have a value in [1, precision] range. The fuzzer needs a way to determine which variable represents precision, which represents scale and for scale variables it needs to figure out what is the corresponding precision. The fuzzer infers these properties from the way variables are used. It examines the types of arguments and return type to figure out what each variable represents. When encountering decimal(p, s) type, the fuzzer determines that p is precision and s is scale. When encountering decimal(p, 5) type, the fuzzer determines that p is precision that must be >= 5. When encountering decimal(10, s), the fuzzer determines that s is scale that must be in [0, 5] range.

This logic is implemented in the ArgumentTypeFuzzer::determineUnboundedIntegerVariables method.

Differential Revision: D55772808


