### PR TITLE
Improve logs, runtime stats collection and task pause tests

### DIFF
--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -566,7 +566,8 @@ uint64_t SharedArbitrator::reclaim(
       << "Reclaimed from memory pool " << pool->name() << " with target of "
       << succinctBytes(targetBytes) << ", actually reclaimed "
       << succinctBytes(freedBytes) << " free memory and "
-      << succinctBytes(reclaimedBytes - freedBytes) << " used memory";
+      << succinctBytes(reclaimedBytes - freedBytes) << " used memory, spent "
+      << succinctMicros(reclaimDurationUs);
   return reclaimedBytes;
 }
 

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -828,10 +828,14 @@ void Driver::closeOperators() {
 
 void Driver::updateStats() {
   DriverStats stats;
-  stats.runtimeStats[DriverStats::kTotalPauseTime] = RuntimeMetric(
-      1'000'000 * state_.totalPauseTimeMs, RuntimeCounter::Unit::kNanos);
-  stats.runtimeStats[DriverStats::kTotalOffThreadTime] = RuntimeMetric(
-      1'000'000 * state_.totalOffThreadTimeMs, RuntimeCounter::Unit::kNanos);
+  if (state_.totalPauseTimeMs > 0) {
+    stats.runtimeStats[DriverStats::kTotalPauseTime] = RuntimeMetric(
+        1'000'000 * state_.totalPauseTimeMs, RuntimeCounter::Unit::kNanos);
+  }
+  if (state_.totalOffThreadTimeMs > 0) {
+    stats.runtimeStats[DriverStats::kTotalOffThreadTime] = RuntimeMetric(
+        1'000'000 * state_.totalOffThreadTimeMs, RuntimeCounter::Unit::kNanos);
+  }
   task()->addDriverStats(ctx_->pipelineId, std::move(stats));
 }
 

--- a/velox/exec/TaskStats.h
+++ b/velox/exec/TaskStats.h
@@ -29,18 +29,18 @@ struct OperatorStats;
 
 /// Stores execution stats per pipeline.
 struct PipelineStats {
-  // Cumulative OperatorStats for finished Drivers. The subscript is the
-  // operator id, which is the initial ordinal position of the
-  // operator in the DriverFactory.
+  /// Cumulative OperatorStats for finished Drivers. The subscript is the
+  /// operator id, which is the initial ordinal position of the operator in the
+  /// DriverFactory.
   std::vector<OperatorStats> operatorStats;
 
-  // Runtime statistics per driver.
+  /// Runtime statistics per driver.
   std::vector<DriverStats> driverStats;
 
-  // True if contains the source node for the task.
+  /// True if contains the source node for the task.
   bool inputPipeline;
 
-  // True if contains the sync node for the task.
+  /// True if contains the sync node for the task.
   bool outputPipeline;
 
   PipelineStats(bool _inputPipeline, bool _outputPipeline)


### PR DESCRIPTION
Only collect task pause time if it is not zero
Include reclaim duration in task reclamation log