### PR TITLE
Add early flushed bytes runtime metrics

### DIFF
--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -196,5 +196,10 @@ void registerVeloxMetrics() {
   // Tracks the number of times that we hit the max spill level limit.
   DEFINE_METRIC(
       kMetricMaxSpillLevelExceededCount, facebook::velox::StatType::COUNT);
+
+  // Tracks the total number of bytes in file writers that's pre-maturely
+  // flushed due to memory reclaiming.
+  DEFINE_METRIC(
+      kMetricFileWriterEarlyFlushedRawBytes, facebook::velox::StatType::SUM);
 }
 } // namespace facebook::velox

--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -113,4 +113,7 @@ constexpr folly::StringPiece kMetricSpillFlushTimeMs{
 
 constexpr folly::StringPiece kMetricSpillWriteTimeMs{
     "velox.spill_write_time_ms"};
+
+constexpr folly::StringPiece kMetricFileWriterEarlyFlushedRawBytes{
+    "velox.file_writer_early_flushed_raw_bytes"};
 } // namespace facebook::velox

--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -222,6 +222,9 @@ Spilling
      - The distribution of the amount of time spent on writing spilled rows to
        disk in range of [0, 600s] with 20 buckets. It is configured to report the
        latency at P50, P90, P99, and P100 percentiles.
+   * - file_writer_early_flushed_raw_bytes
+     - Sum
+     - Number of bytes pre-maturely flushed from file writers because of memory reclaiming.
 
 Hive Connector
 --------------

--- a/velox/docs/monitoring/stats.rst
+++ b/velox/docs/monitoring/stats.rst
@@ -70,6 +70,21 @@ These stats are reported only by HashBuild and HashAggregation operators.
      - Time spent on building the hash table from rows collected by all the
        hash build operators. This stat is only reported by the HashBuild operator.
 
+TableWriter
+-----------
+These stats are reported only by TableWriter operator
+
+.. list-table::
+   :widths: 50 25 50
+   :header-rows: 1
+
+   * - Stats
+     - Unit
+     - Description
+   * - earlyFlushedRawBytes
+     - bytes
+     - Number of bytes pre-maturely flushed from file writers because of memory reclaiming.
+
 Spilling
 --------
 These stats are reported by operators that support spilling.


### PR DESCRIPTION
Add early flushed bytes in writer that is due to memory reclaiming.