### PR TITLE
Fix reduceAgg benchmark test setting

### DIFF
--- a/velox/exec/tests/utils/OperatorTestBase.h
+++ b/velox/exec/tests/utils/OperatorTestBase.h
@@ -32,6 +32,14 @@
 namespace facebook::velox::exec::test {
 class OperatorTestBase : public testing::Test,
                          public velox::test::VectorTestBase {
+ public:
+  /// The following two methods are used by google unit test framework to do
+  /// one-time setup/teardown for all the unit tests from OperatorTestBase. We
+  /// make them public as some benchmark like ReduceAgg also call these methods
+  /// to setup/teardown benchmark test environment.
+  static void SetUpTestCase();
+  static void TearDownTestCase();
+
  protected:
   OperatorTestBase();
   ~OperatorTestBase() override;
@@ -43,10 +51,6 @@ class OperatorTestBase : public testing::Test,
   /// Allow base classes to register custom vector serde.
   /// By default, registers Presto-compatible serde.
   virtual void registerVectorSerde();
-
-  static void SetUpTestCase();
-
-  static void TearDownTestCase();
 
   void createDuckDbTable(const std::vector<RowVectorPtr>& data) {
     duckDbQueryRunner_.createTable("tmp", data);

--- a/velox/functions/prestosql/aggregates/benchmarks/ReduceAgg.cpp
+++ b/velox/functions/prestosql/aggregates/benchmarks/ReduceAgg.cpp
@@ -36,8 +36,7 @@ namespace {
 // Compare performance of sum(x) with equivalent reduce_agg(x,..).
 class ReduceAggBenchmark : public HiveConnectorTestBase {
  public:
-  explicit ReduceAggBenchmark() {
-    OperatorTestBase::SetUpTestCase();
+  ReduceAggBenchmark() {
     HiveConnectorTestBase::SetUp();
 
     inputType_ = ROW({
@@ -224,10 +223,11 @@ BENCHMARK_RELATIVE(sum_groupby) {
 int main(int argc, char** argv) {
   folly::Init init(&argc, &argv);
 
-  memory::MemoryManager::initialize({});
+  OperatorTestBase::SetUpTestCase();
   benchmark = std::make_unique<ReduceAggBenchmark>();
   benchmark->verify();
   folly::runBenchmarks();
   benchmark.reset();
+  OperatorTestBase::TearDownTestCase();
   return 0;
 }

--- a/velox/functions/prestosql/aggregates/benchmarks/SimpleAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/benchmarks/SimpleAggregates.cpp
@@ -36,7 +36,7 @@ namespace {
 
 class SimpleAggregatesBenchmark : public HiveConnectorTestBase {
  public:
-  explicit SimpleAggregatesBenchmark() {
+  SimpleAggregatesBenchmark() {
     OperatorTestBase::SetUpTestCase();
     HiveConnectorTestBase::SetUp();
 
@@ -269,9 +269,10 @@ BENCHMARK_DRAW_LINE();
 
 int main(int argc, char** argv) {
   folly::Init init{&argc, &argv};
-  memory::MemoryManager::initialize({});
+  OperatorTestBase::SetUpTestCase();
   benchmark = std::make_unique<SimpleAggregatesBenchmark>();
   folly::runBenchmarks();
   benchmark.reset();
+  OperatorTestBase::TearDownTestCase();
   return 0;
 }

--- a/velox/functions/prestosql/aggregates/benchmarks/TwoStringKeys.cpp
+++ b/velox/functions/prestosql/aggregates/benchmarks/TwoStringKeys.cpp
@@ -37,8 +37,7 @@ namespace {
 // Compare performance of sum(x) with equivalent reduce_agg(x,..).
 class TwoStringKeysBenchmark : public HiveConnectorTestBase {
  public:
-  explicit TwoStringKeysBenchmark() {
-    OperatorTestBase::SetUpTestCase();
+  TwoStringKeysBenchmark() {
     HiveConnectorTestBase::SetUp();
 
     inputType_ = ROW({
@@ -135,10 +134,10 @@ BENCHMARK(two_string_keys) {
 
 int main(int argc, char** argv) {
   folly::Init init(&argc, &argv);
-  memory::MemoryManager::initialize({});
+  OperatorTestBase::SetUpTestCase();
   benchmark = std::make_unique<TwoStringKeysBenchmark>();
   benchmark->verify();
-  //   folly::runBenchmarks();
   benchmark.reset();
+  OperatorTestBase::TearDownTestCase();
   return 0;
 }


### PR DESCRIPTION
Fix reduceAgg bencnmark test setup by calling OperatorTestBase::SetUpTestCase
in benchmark main instead of its constructor. SetUpTestCase is supposed to call
once before any unit test cases run (like OperatorTestBase constructor). Correspondingly
move SetUpTestCase/TearDownTestCase to public section to use for non-google unit
test use case such as reduceAgg benchmark which use it for benchmark testing setup