### PR TITLE
Fix bug in initializing global aggregations with initialized flag

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -413,14 +413,18 @@ void GroupingSet::initializeGlobalAggregation() {
   lookup_->reset(1);
 
   // Row layout is:
-  //  - null flags - one bit per aggregate,
+  //  - alternating null flag, intialized flag - one bit per flag, one pair per
+  //                                             aggregation,
   //  - uint32_t row size,
   //  - fixed-width accumulators - one per aggregate
   //
   // Here we always make space for a row size since we only have one row and no
   // RowContainer.  The whole row is allocated to guarantee that alignment
   // requirements of all aggregate functions are satisfied.
-  int32_t rowSizeOffset = bits::nbytes(aggregates_.size());
+
+  // Allocate space for the null and initialized flags.
+  int32_t rowSizeOffset =
+      bits::nbytes(aggregates_.size() * RowContainer::kNumAccumulatorFlags);
   int32_t offset = rowSizeOffset + sizeof(int32_t);
   int32_t accumulatorFlagsOffset = 0;
   int32_t alignment = 1;


### PR DESCRIPTION
Summary:
https://github.com/facebookincubator/velox/pull/9067 introduced an initialized flag that we include alongside the null flag
for aggregations in the rows in RowContainer.

Global aggregations do not use a RowContainer to create rows, rather a single row is constructed manually inside 
GroupingSets.  When that PR was landed this logic was not properly updated, we did not allocate enough space in the row
for the additional bits which could lead to null/initialized flags overwriting the aggregate values when there were a lot of 
them.

This change fixes it so that we allocate the correct amount of space for flags for global aggregations as an immediate fix.

Longer term it would be better to centralize the logic for creating rows in RowContainer (I'd like to get us back to a working
state before attempting such a refactor).

Differential Revision: D55823098


