### PR TITLE
Fix hash probe spill issues

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -355,8 +355,8 @@ class Connector {
     VELOX_NYI("connectorConfig is not supported yet");
   }
 
-  // Returns true if this connector would accept a filter dynamically generated
-  // during query execution.
+  /// Returns true if this connector would accept a filter dynamically generated
+  /// during query execution.
   virtual bool canAddDynamicFilter() const {
     return false;
   }

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1588,7 +1588,7 @@ class HashJoinNode : public AbstractJoinNode {
     if (nullAware) {
       VELOX_USER_CHECK(
           isNullAwareSupported(joinType),
-          "Null-aware flag is supported only for semi and anti joins");
+          "Null-aware flag is supported only for semi project and anti joins");
       VELOX_USER_CHECK_EQ(
           1, leftKeys_.size(), "Null-aware joins allow only one join key");
 

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -308,7 +308,8 @@ void Driver::pushdownFilters(int operatorIndex) {
       }
 
       const auto& identityProjections = prevOp->identityProjections();
-      auto inputChannel = getIdentityProjection(identityProjections, channel);
+      const auto inputChannel =
+          getIdentityProjection(identityProjections, channel);
       if (!inputChannel.has_value()) {
         // Filter channel is not an identity projection.
         VELOX_CHECK(
@@ -897,7 +898,7 @@ std::unordered_set<column_index_t> Driver::canPushdownFilters(
   for (auto i = 0; i < channels.size(); ++i) {
     auto channel = channels[i];
     for (auto j = filterSourceIndex - 1; j >= 0; --j) {
-      auto prevOp = operators_[j].get();
+      auto* prevOp = operators_[j].get();
 
       if (j == 0) {
         // Source operator.
@@ -908,7 +909,8 @@ std::unordered_set<column_index_t> Driver::canPushdownFilters(
       }
 
       const auto& identityProjections = prevOp->identityProjections();
-      auto inputChannel = getIdentityProjection(identityProjections, channel);
+      const auto inputChannel =
+          getIdentityProjection(identityProjections, channel);
       if (!inputChannel.has_value()) {
         // Filter channel is not an identity projection.
         if (prevOp->canAddDynamicFilter()) {

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -44,9 +44,9 @@ class HashProbe : public Operator {
     }
     // NOTE: if we can't apply dynamic filtering, then we can start early to
     // read input even before the hash table has been built.
-    const auto channels = operatorCtx_->driverCtx()->driver->canPushdownFilters(
-        this, keyChannels_);
-    return channels.empty();
+    return operatorCtx_->driverCtx()
+        ->driver->canPushdownFilters(this, keyChannels_)
+        .empty();
   }
 
   void addInput(RowVectorPtr input) override;
@@ -334,6 +334,12 @@ class HashProbe : public Operator {
 
   // Channel of probe keys in 'input_'.
   std::vector<column_index_t> keyChannels_;
+
+  // True if we have generated dynamic filters from the hash build join keys.
+  //
+  // NOTE: 'dynamicFilters_' might have been cleared once they have been pushed
+  // down to the upstream operators.
+  tsan_atomic<bool> hasGeneratedDynamicFilters_{false};
 
   // True if the join can become a no-op starting with the next batch of input.
   bool canReplaceWithDynamicFilter_{false};

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -257,24 +257,24 @@ class OperatorCtx {
   mutable std::unique_ptr<core::ExecCtx> execCtx_;
 };
 
-// Query operator
+/// Query operator
 class Operator : public BaseRuntimeStatWriter {
  public:
-  // Factory class for mapping a user-registered PlanNode into the corresponding
-  // Operator.
+  /// Factory class for mapping a user-registered PlanNode into the
+  /// corresponding Operator.
   class PlanNodeTranslator {
    public:
     virtual ~PlanNodeTranslator() = default;
 
-    // Translates plan node to operator. Returns nullptr if the plan node cannot
-    // be handled by this factory.
+    /// Translates plan node to operator. Returns nullptr if the plan node
+    /// cannot be handled by this factory.
     virtual std::unique_ptr<Operator>
     toOperator(DriverCtx* ctx, int32_t id, const core::PlanNodePtr& node) {
       return nullptr;
     }
 
-    // An overloaded method that should be called when the operator needs an
-    // ExchangeClient.
+    /// An overloaded method that should be called when the operator needs an
+    /// ExchangeClient.
     virtual std::unique_ptr<Operator> toOperator(
         DriverCtx* ctx,
         int32_t id,
@@ -283,22 +283,22 @@ class Operator : public BaseRuntimeStatWriter {
       return nullptr;
     }
 
-    // Translates plan node to join bridge. Returns nullptr if the plan node
-    // cannot be handled by this factory.
+    /// Translates plan node to join bridge. Returns nullptr if the plan node
+    /// cannot be handled by this factory.
     virtual std::unique_ptr<JoinBridge> toJoinBridge(
         const core::PlanNodePtr& /* node */) {
       return nullptr;
     }
 
-    // Translates plan node to operator supplier. Returns nullptr if the plan
-    // node cannot be handled by this factory.
+    /// Translates plan node to operator supplier. Returns nullptr if the plan
+    /// node cannot be handled by this factory.
     virtual OperatorSupplier toOperatorSupplier(
         const core::PlanNodePtr& /* node */) {
       return nullptr;
     }
 
-    // Returns max driver count for the plan node. Returns std::nullopt if the
-    // plan node cannot be handled by this factory.
+    /// Returns max driver count for the plan node. Returns std::nullopt if the
+    /// plan node cannot be handled by this factory.
     virtual std::optional<uint32_t> maxDrivers(
         const core::PlanNodePtr& /* node */) {
       return std::nullopt;

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -7428,4 +7428,178 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashProbeSpillUnderNonReclaimableSection) {
       })
       .run();
 }
+
+// This test case is to cover the case that hash probe trigger spill for right
+// semi join types and the pending input needs to be processed in multiple
+// steps.
+DEBUG_ONLY_TEST_F(HashJoinTest, spillOutputWithRightSemiJoins) {
+  for (const auto joinType :
+       {core::JoinType::kRightSemiFilter, core::JoinType::kRightSemiProject}) {
+    std::atomic_bool injectOnce{true};
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Driver::runInternal::getOutput",
+        std::function<void(Operator*)>([&](Operator* op) {
+          if (op->testingOperatorCtx()->operatorType() != "HashProbe") {
+            return;
+          }
+          if (!op->testingHasInput()) {
+            return;
+          }
+          if (!injectOnce.exchange(false)) {
+            return;
+          }
+          testingRunArbitration(op->pool());
+        }));
+
+    std::string duckDbSqlReference;
+    std::vector<std::string> joinOutputLayout;
+    bool nullAware{false};
+    if (joinType == core::JoinType::kRightSemiProject) {
+      duckDbSqlReference = "SELECT u_k2, u_k1 IN (SELECT t_k1 FROM t) FROM u";
+      joinOutputLayout = {"u_k2", "match"};
+      // Null aware is only supported for semi projection join type.
+      nullAware = true;
+    } else {
+      duckDbSqlReference =
+          "SELECT u_k2 FROM u WHERE u_k1 IN (SELECT t_k1 FROM t)";
+      joinOutputLayout = {"u_k2"};
+    }
+
+    const auto spillDirectory = exec::test::TempDirectoryPath::create();
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+        .numDrivers(1)
+        .spillDirectory(spillDirectory->path)
+        .probeType(probeType_)
+        .probeVectors(128, 3)
+        .probeKeys({"t_k1"})
+        .buildType(buildType_)
+        .buildVectors(128, 4)
+        .buildKeys({"u_k1"})
+        .joinType(joinType)
+        // Set a small number of output rows to process the input in multiple
+        // steps.
+        .config(
+            core::QueryConfig::kPreferredOutputBatchRows, std::to_string(10))
+        .injectSpill(false)
+        .joinOutputLayout(std::move(joinOutputLayout))
+        .nullAware(nullAware)
+        .referenceQuery(duckDbSqlReference)
+        .run();
+  }
+}
+
+DEBUG_ONLY_TEST_F(HashJoinTest, spillCheckOnLeftSemiFilterWithDynamicFilters) {
+  const int32_t numSplits = 10;
+  const int32_t numRowsProbe = 333;
+  const int32_t numRowsBuild = 100;
+
+  std::vector<RowVectorPtr> probeVectors;
+  probeVectors.reserve(numSplits);
+
+  std::vector<std::shared_ptr<TempFilePath>> tempFiles;
+  for (int32_t i = 0; i < numSplits; ++i) {
+    auto rowVector = makeRowVector({
+        makeFlatVector<int32_t>(
+            numRowsProbe, [&](auto row) { return row - i * 10; }),
+        makeFlatVector<int64_t>(numRowsProbe, [](auto row) { return row; }),
+    });
+    probeVectors.push_back(rowVector);
+    tempFiles.push_back(TempFilePath::create());
+    writeToFile(tempFiles.back()->path, rowVector);
+  }
+  auto makeInputSplits = [&](const core::PlanNodeId& nodeId) {
+    return [&] {
+      std::vector<exec::Split> probeSplits;
+      for (auto& file : tempFiles) {
+        probeSplits.push_back(exec::Split(makeHiveConnectorSplit(file->path)));
+      }
+      SplitInput splits;
+      splits.emplace(nodeId, probeSplits);
+      return splits;
+    };
+  };
+
+  // 100 key values in [35, 233] range.
+  std::vector<RowVectorPtr> buildVectors;
+  for (int i = 0; i < 5; ++i) {
+    buildVectors.push_back(makeRowVector({
+        makeFlatVector<int32_t>(
+            numRowsBuild / 5,
+            [i](auto row) { return 35 + 2 * (row + i * numRowsBuild / 5); }),
+        makeFlatVector<int64_t>(numRowsBuild / 5, [](auto row) { return row; }),
+    }));
+  }
+  std::vector<RowVectorPtr> keyOnlyBuildVectors;
+  for (int i = 0; i < 5; ++i) {
+    keyOnlyBuildVectors.push_back(
+        makeRowVector({makeFlatVector<int32_t>(numRowsBuild / 5, [i](auto row) {
+          return 35 + 2 * (row + i * numRowsBuild / 5);
+        })}));
+  }
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  auto probeType = ROW({"c0", "c1"}, {INTEGER(), BIGINT()});
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+
+  auto buildSide = PlanBuilder(planNodeIdGenerator, pool_.get())
+                       .values(buildVectors)
+                       .project({"c0 AS u_c0", "c1 AS u_c1"})
+                       .planNode();
+  auto keyOnlyBuildSide = PlanBuilder(planNodeIdGenerator, pool_.get())
+                              .values(keyOnlyBuildVectors)
+                              .project({"c0 AS u_c0"})
+                              .planNode();
+
+  // Left semi join.
+  core::PlanNodeId probeScanId;
+  core::PlanNodeId joinNodeId;
+  const auto op = PlanBuilder(planNodeIdGenerator, pool_.get())
+                      .tableScan(probeType)
+                      .capturePlanNodeId(probeScanId)
+                      .hashJoin(
+                          {"c0"},
+                          {"u_c0"},
+                          buildSide,
+                          "",
+                          {"c0", "c1"},
+                          core::JoinType::kLeftSemiFilter)
+                      .capturePlanNodeId(joinNodeId)
+                      .project({"c0", "c1 + 1"})
+                      .planNode();
+
+  std::atomic_bool injectOnce{true};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::Driver::runInternal::getOutput",
+      std::function<void(Operator*)>([&](Operator* op) {
+        if (op->testingOperatorCtx()->operatorType() != "HashProbe") {
+          return;
+        }
+        if (!op->testingHasInput()) {
+          return;
+        }
+        if (!injectOnce.exchange(false)) {
+          return;
+        }
+        testingRunArbitration(op->pool());
+      }));
+
+  auto spillDirectory = exec::test::TempDirectoryPath::create();
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .planNode(std::move(op))
+      .makeInputSplits(makeInputSplits(probeScanId))
+      .spillDirectory(spillDirectory->path)
+      .injectSpill(false)
+      .referenceQuery(
+          "SELECT t.c0, t.c1 + 1 FROM t WHERE t.c0 IN (SELECT c0 FROM u)")
+      .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
+        // Verify spill hasn't triggered.
+        auto taskStats = exec::toPlanStats(task->taskStats());
+        auto& planStats = taskStats.at(joinNodeId);
+        ASSERT_EQ(planStats.spilledBytes, 0);
+      })
+      .run();
+}
 } // namespace


### PR DESCRIPTION
1. Fix hash probe spill hang for right semi join types
For right semi join (project and filter), it produce output from the probed rows in hash table
after processing all the probe inputs. A probe input vector (set in Operator::input_) might be
processed in multiple output calls until all the input rows have been processed. The probe side
spill needs to spill output from the current probe input vector before clear the hash table and
the current logic wait until the output is null. This is not correct for right semi joins as it always
return null, and instead we shall check on if input_ has been reset.
Add unit test to verify the fix plus join fuzzer run.

2. Disable hash probe spill if dynamic filters have been generated
Hash probe might generate dynamic filters based on the hash join key ranges from build side and
pushdown to upstream operators. If this has been triggered, then we can't spill from hash probe
side as it might produce the incorrect result as detected by join fuzzer test. The fix is to disable
hash probe spill if dynamic filters have been generated.
Add unit test to verif the fix plus join fuzzer run.
