### PR TITLE
Allow empty seconds when parsing timestamps strings

### DIFF
--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -120,7 +120,7 @@ int64_t
 fromTime(int32_t hour, int32_t minute, int32_t second, int32_t microseconds);
 
 /// Parses the input string and returns the number of cumulative microseconds,
-/// following the "HH:MM:SS[.MS]" format (ISO 8601).
+/// following the "HH:MM[:SS[.MS]]" format (ISO 8601).
 //
 /// Throws VeloxUserError if the format or time is invalid.
 int64_t fromTimeString(const char* buf, size_t len);
@@ -132,7 +132,7 @@ inline int64_t fromTimeString(const StringView& str) {
 // Timestamp conversion
 
 /// Parses a full ISO 8601 timestamp string, following the format
-/// "YYYY-MM-DD HH:MM:SS[.MS] +00:00"
+/// "YYYY-MM-DD HH:MM[:SS[.MS]] +00:00"
 Timestamp fromTimestampString(const char* buf, size_t len);
 
 inline Timestamp fromTimestampString(const StringView& str) {

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -229,17 +229,22 @@ TEST(DateTimeUtilTest, fromTimeString) {
 }
 
 TEST(DateTimeUtilTest, fromTimeStrInvalid) {
-  EXPECT_THROW(fromTimeString(""), VeloxUserError);
-  EXPECT_THROW(fromTimeString("00"), VeloxUserError);
-  EXPECT_THROW(fromTimeString("00:00"), VeloxUserError);
+  const std::string errorMsg = "Unable to parse time value: ";
+  VELOX_ASSERT_THROW(fromTimeString(""), errorMsg);
+  VELOX_ASSERT_THROW(fromTimeString("00"), errorMsg);
+  VELOX_ASSERT_THROW(fromTimeString("00:"), errorMsg);
+  VELOX_ASSERT_THROW(fromTimeString("00:00:"), errorMsg);
+  VELOX_ASSERT_THROW(fromTimeString("00:00:00."), errorMsg);
+  VELOX_ASSERT_THROW(fromTimeString("00:00-00"), errorMsg);
+  VELOX_ASSERT_THROW(fromTimeString("00/00:00"), errorMsg);
 
   // Invalid hour, minutes and seconds.
-  EXPECT_THROW(fromTimeString("24:00:00"), VeloxUserError);
-  EXPECT_THROW(fromTimeString("00:61:00"), VeloxUserError);
-  EXPECT_THROW(fromTimeString("00:00:61"), VeloxUserError);
+  VELOX_ASSERT_THROW(fromTimeString("24:00:00"), errorMsg);
+  VELOX_ASSERT_THROW(fromTimeString("00:61:00"), errorMsg);
+  VELOX_ASSERT_THROW(fromTimeString("00:00:61"), errorMsg);
 
   // Trailing characters.
-  EXPECT_THROW(fromTimeString("00:00:00   12"), VeloxUserError);
+  VELOX_ASSERT_THROW(fromTimeString("00:00:00   12"), errorMsg);
 }
 
 // bash command to verify:
@@ -249,7 +254,9 @@ TEST(DateTimeUtilTest, fromTimestampString) {
   EXPECT_EQ(Timestamp(0, 0), fromTimestampString("1970-01-01"));
   EXPECT_EQ(Timestamp(946684800, 0), fromTimestampString("2000-01-01"));
 
+  EXPECT_EQ(Timestamp(0, 0), fromTimestampString("1970-01-01 00:00"));
   EXPECT_EQ(Timestamp(0, 0), fromTimestampString("1970-01-01 00:00:00"));
+
   EXPECT_EQ(
       Timestamp(946729316, 0), fromTimestampString("2000-01-01 12:21:56"));
   EXPECT_EQ(


### PR DESCRIPTION
Summary:
Following Presto semantics, seconds are allowed to be empty when
parsing timestamp strings. For example, both formats should be allowed:

> 2024-01-01 00:00:00
> 2024-01-01 00:00

It is an open question whether we want to change it only for Presto string to
timestamp casts, or across the board. This PR changes for all conversions since
this seems pretty harmless (and intuitive).

Also fixing a small bug: "00:00:00." shouldn't be allowed.

Fixes: #9382

Differential Revision: D55831722


