### PR TITLE
Allow from_utc_timestamp, to_utc_timestamp to support more timezones

### DIFF
--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -321,7 +321,8 @@ struct ToUtcTimestampFunction {
         ? tzID_
         : util::getTimeZoneID(
               std::string_view(timezone.data(), timezone.size()), false);
-    VELOX_USER_CHECK(fromTimezoneID != -1, "Unknown time zone: '{}'", timezone);
+    VELOX_USER_CHECK_NE(
+        fromTimezoneID, -1, "Unknown time zone: '{}'", timezone);
     result.toGMT(*fromTimezoneID);
   }
 
@@ -353,7 +354,7 @@ struct FromUtcTimestampFunction {
         ? tzID_
         : util::getTimeZoneID(
               std::string_view(timezone.data(), timezone.size()), false);
-    VELOX_USER_CHECK(toTimezoneID != -1, "Unknown time zone: '{}'", timezone);
+    VELOX_USER_CHECK_NE(toTimezoneID, -1, "Unknown time zone: '{}'", timezone);
     result.toTimezone(*toTimezoneID);
   }
 

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -307,8 +307,8 @@ struct ToUtcTimestampFunction {
       const arg_type<Varchar>* /*input*/,
       const arg_type<Varchar>* timezone) {
     if (timezone) {
-      timezone_ = date::locate_zone(
-          std::string_view((*timezone).data(), (*timezone).size()));
+      tzID_ = util::getTimeZoneID(
+          std::string_view((*timezone).data(), (*timezone).size()), false);
     }
   }
 
@@ -317,14 +317,16 @@ struct ToUtcTimestampFunction {
       const arg_type<Timestamp>& timestamp,
       const arg_type<Varchar>& timezone) {
     result = timestamp;
-    auto fromTimezone = timezone_
-        ? timezone_
-        : date::locate_zone(std::string_view(timezone.data(), timezone.size()));
-    result.toGMT(*fromTimezone);
+    auto fromTimezoneID = tzID_
+        ? tzID_
+        : util::getTimeZoneID(
+              std::string_view(timezone.data(), timezone.size()), false);
+    VELOX_USER_CHECK(fromTimezoneID != -1, "Unknown time zone: '{}'", timezone);
+    result.toGMT(*fromTimezoneID);
   }
 
  private:
-  const date::time_zone* timezone_{nullptr};
+  std::optional<int16_t> tzID_{std::nullopt};
 };
 
 template <typename T>
@@ -337,8 +339,8 @@ struct FromUtcTimestampFunction {
       const arg_type<Varchar>* /*input*/,
       const arg_type<Varchar>* timezone) {
     if (timezone) {
-      timezone_ = date::locate_zone(
-          std::string_view((*timezone).data(), (*timezone).size()));
+      tzID_ = util::getTimeZoneID(
+          std::string_view((*timezone).data(), (*timezone).size()), false);
     }
   }
 
@@ -347,14 +349,16 @@ struct FromUtcTimestampFunction {
       const arg_type<Timestamp>& timestamp,
       const arg_type<Varchar>& timezone) {
     result = timestamp;
-    auto toTimezone = timezone_
-        ? timezone_
-        : date::locate_zone(std::string_view(timezone.data(), timezone.size()));
-    result.toTimezone(*toTimezone);
+    auto toTimezoneID = tzID_
+        ? tzID_
+        : util::getTimeZoneID(
+              std::string_view(timezone.data(), timezone.size()), false);
+    VELOX_USER_CHECK(toTimezoneID != -1, "Unknown time zone: '{}'", timezone);
+    result.toTimezone(*toTimezoneID);
   }
 
  private:
-  const date::time_zone* timezone_{nullptr};
+  std::optional<int16_t> tzID_{std::nullopt};
 };
 
 /// Converts date string to Timestmap type.

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -97,9 +97,12 @@ TEST_F(DateTimeFunctionsTest, toUtcTimestamp) {
   EXPECT_EQ(
       "2015-01-24T00:00:00.000000000",
       toUtcTimestamp("2015-01-24 05:30:00", "Asia/Kolkata"));
+  EXPECT_EQ(
+      "2015-01-23T16:00:00.000000000",
+      toUtcTimestamp("2015-01-24 00:00:00", "+08:00"));
   VELOX_ASSERT_THROW(
       toUtcTimestamp("2015-01-24 00:00:00", "Asia/Ooty"),
-      "Asia/Ooty not found in timezone database");
+      "Unknown time zone: 'Asia/Ooty'");
 }
 
 TEST_F(DateTimeFunctionsTest, fromUtcTimestamp) {
@@ -124,9 +127,12 @@ TEST_F(DateTimeFunctionsTest, fromUtcTimestamp) {
   EXPECT_EQ(
       "2015-01-24T05:30:00.000000000",
       fromUtcTimestamp("2015-01-24 00:00:00", "Asia/Kolkata"));
+  EXPECT_EQ(
+      "2015-01-24T08:00:00.000000000",
+      fromUtcTimestamp("2015-01-24 00:00:00", "+08:00"));
   VELOX_ASSERT_THROW(
       fromUtcTimestamp("2015-01-24 00:00:00", "Asia/Ooty"),
-      "Asia/Ooty not found in timezone database");
+      "Unknown time zone: 'Asia/Ooty'");
 }
 
 TEST_F(DateTimeFunctionsTest, toFromUtcTimestamp) {
@@ -153,7 +159,7 @@ TEST_F(DateTimeFunctionsTest, toFromUtcTimestamp) {
       toFromUtcTimestamp("2015-01-24 00:00:00", "Asia/Kolkata"));
   VELOX_ASSERT_THROW(
       toFromUtcTimestamp("2015-01-24 00:00:00", "Asia/Ooty"),
-      "Asia/Ooty not found in timezone database");
+      "Unknown time zone: 'Asia/Ooty'");
 }
 
 TEST_F(DateTimeFunctionsTest, year) {


### PR DESCRIPTION
A follow up for https://github.com/facebookincubator/velox/pull/8868

```bash
C++ exception with description "Exception: VeloxUserError
Error Source: USER
Error Code: INVALID_ARGUMENT
Reason: +08:00 not found in timezone database
```

Our clients requires timezones like `+08:00`, but the original pr use `toGMT(const date::time_zone& zone)`/`toTimezone(const date::time_zone& zone)` which doesn't support this, so this pr changes to pass `timeZoneID`(`toGMT(int16_t tzID)`, `toTimezone(int16_t tzID)`) to support it.