### PR TITLE
Disable approx_distinct result verifier in window fuzzer test

### DIFF
--- a/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
@@ -112,7 +112,8 @@ int main(int argc, char** argv) {
       std::shared_ptr<facebook::velox::exec::test::ResultVerifier>>
       customVerificationFunctions = {
           // Approx functions.
-          {"approx_distinct", std::make_shared<ApproxDistinctResultVerifier>()},
+          // https://github.com/facebookincubator/velox/issues/9347
+          {"approx_distinct", nullptr},
           {"approx_set", nullptr},
           {"approx_percentile", nullptr},
           {"approx_most_frequent", nullptr},


### PR DESCRIPTION
Summary: The approx_distinct result verifier for window fuzzer is giving false positive signals. It need to be fixed as described in https://github.com/facebookincubator/velox/issues/9347. Disable this result verifier until it is fixed.

Differential Revision: D55879765


