### PR TITLE
Fix approx_distinct result verifier for window fuzzer

### DIFF
--- a/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
@@ -112,8 +112,7 @@ int main(int argc, char** argv) {
       std::shared_ptr<facebook::velox::exec::test::ResultVerifier>>
       customVerificationFunctions = {
           // Approx functions.
-          // https://github.com/facebookincubator/velox/issues/9347
-          {"approx_distinct", nullptr},
+          {"approx_distinct", std::make_shared<ApproxDistinctResultVerifier>()},
           {"approx_set", nullptr},
           {"approx_percentile", nullptr},
           {"approx_most_frequent", nullptr},


### PR DESCRIPTION
Summary:
The custom result verification for approx_distinct in window 
operations requires a different handling from aggregation. The reason 
is that the error bound for approx_distinc only applies to independent 
input sets, while input sets for rows in the same partition in a window 
operation are correlated. Therefore, this diff changes 
ApproxDistinctResultVerifier to only take the max error in each 
partition when verifying the error bound for results of window 
operations.

This diff fixes https://github.com/facebookincubator/velox/issues/9347.

Differential Revision: D55898634


