### PR TITLE
Add pool name regex in TestScopedSpillInjection

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -839,7 +839,7 @@ void GroupingSet::ensureInputFits(const RowVectorPtr& input) {
   const int64_t flatBytes = input->estimateFlatSize();
 
   // Test-only spill path.
-  if (testingTriggerSpill()) {
+  if (testingTriggerSpill(pool_.name())) {
     memory::ReclaimableSectionGuard guard(nonReclaimableSection_);
     memory::testingRunArbitration(&pool_);
     return;
@@ -905,7 +905,7 @@ void GroupingSet::ensureOutputFits() {
   }
 
   // Test-only spill path.
-  if (testingTriggerSpill()) {
+  if (testingTriggerSpill(pool_.name())) {
     memory::ReclaimableSectionGuard guard(nonReclaimableSection_);
     memory::testingRunArbitration(&pool_);
     return;

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -454,7 +454,7 @@ void HashBuild::ensureInputFits(RowVectorPtr& input) {
 
   if (numRows != 0) {
     // Test-only spill path.
-    if (testingTriggerSpill()) {
+    if (testingTriggerSpill(pool()->name())) {
       Operator::ReclaimableSectionGuard guard(this);
       memory::testingRunArbitration(pool());
       return;
@@ -772,7 +772,7 @@ void HashBuild::ensureTableFits(uint64_t numRows) {
   }
 
   // Test-only spill path.
-  if (testingTriggerSpill()) {
+  if (testingTriggerSpill(pool()->name())) {
     Operator::ReclaimableSectionGuard guard(this);
     memory::testingRunArbitration(pool());
     return;

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1523,7 +1523,7 @@ void HashProbe::ensureOutputFits() {
     return;
   }
 
-  if (testingTriggerSpill()) {
+  if (testingTriggerSpill(pool()->name())) {
     Operator::ReclaimableSectionGuard guard(this);
     memory::testingRunArbitration(pool());
   }

--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -195,7 +195,7 @@ void RowNumber::ensureInputFits(const RowVectorPtr& input) {
   const auto outOfLineBytesPerRow = outOfLineBytes / numDistinct;
 
   // Test-only spill path.
-  if (testingTriggerSpill()) {
+  if (testingTriggerSpill(pool()->name())) {
     Operator::ReclaimableSectionGuard guard(this);
     memory::testingRunArbitration(pool());
     return;

--- a/velox/exec/SortBuffer.cpp
+++ b/velox/exec/SortBuffer.cpp
@@ -194,7 +194,7 @@ void SortBuffer::ensureInputFits(const VectorPtr& input) {
   const int64_t flatInputBytes = input->estimateFlatSize();
 
   // Test-only spill path.
-  if (numRows > 0 && testingTriggerSpill()) {
+  if (numRows > 0 && testingTriggerSpill(pool_->name())) {
     spill();
     return;
   }

--- a/velox/exec/SortWindowBuild.cpp
+++ b/velox/exec/SortWindowBuild.cpp
@@ -90,7 +90,7 @@ void SortWindowBuild::ensureInputFits(const RowVectorPtr& input) {
   }
 
   // Test-only spill path.
-  if (testingTriggerSpill()) {
+  if (testingTriggerSpill(pool_->name())) {
     spill();
     return;
   }

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -18,6 +18,7 @@
 
 #include <folly/container/F14Set.h>
 
+#include <re2/re2.h>
 #include "velox/common/base/SpillConfig.h"
 #include "velox/common/base/SpillStats.h"
 #include "velox/common/compression/Compression.h"
@@ -452,14 +453,17 @@ SpillPartitionIdSet toSpillPartitionIdSet(
 /// triggered spill.
 /// 'spillPct' indicates the chance of triggering spilling. 100% means spill
 /// will always be triggered.
+/// 'pools' is a regular expression string used to define the specific memory
+/// pools targeted for injecting spilling.
 /// 'maxInjections' indicates the max number of actual triggering. e.g. when
 /// 'spillPct' is 20 and 'maxInjections' is 10, continuous calls to
-/// testingTriggerSpill() will keep rolling the dice that has a chance of 20%
-/// triggering until 10 triggers have been invoked.
+/// testingTriggerSpill(poolName) will keep rolling the dice that has a
+/// chance of 20% triggering until 10 triggers have been invoked.
 class TestScopedSpillInjection {
  public:
   explicit TestScopedSpillInjection(
       int32_t spillPct,
+      const std::string& poolRegExp = ".*",
       uint32_t maxInjections = std::numeric_limits<uint32_t>::max());
 
   ~TestScopedSpillInjection();
@@ -467,7 +471,7 @@ class TestScopedSpillInjection {
 
 /// Test utility that returns true if triggered spill is evaluated to happen,
 /// false otherwise.
-bool testingTriggerSpill();
+bool testingTriggerSpill(const std::string& poolName = "");
 
 tsan_atomic<uint32_t>& injectedSpillCount();
 

--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -674,7 +674,7 @@ void TopNRowNumber::ensureInputFits(const RowVectorPtr& input) {
   }
 
   // Test-only spill path.
-  if (testingTriggerSpill()) {
+  if (testingTriggerSpill(pool()->name())) {
     spill();
     return;
   }


### PR DESCRIPTION
Add a pool name regex in TestScopedSpillInjection to control
the spill injection for target operators.