### PR TITLE
Make default value for "max_spill_level" equal to 1.

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -534,7 +534,7 @@ class QueryConfig {
   }
 
   int32_t maxSpillLevel() const {
-    return get<int32_t>(kMaxSpillLevel, 4);
+    return get<int32_t>(kMaxSpillLevel, 1);
   }
 
   /// Returns the start partition bit which is used with

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -265,7 +265,7 @@ Spilling
        reservation grows along a series of powers of (1 + N / 100). If the memory reservation fails, it starts spilling.
    * - max_spill_level
      - integer
-     - 4
+     - 1
      - The maximum allowed spilling level with zero being the initial spilling level. Applies to hash join build
        spilling which might use recursive spilling when the build table is very large. -1 means unlimited.
        In this case an extremely large query might run out of spilling partition bits. The max spill level


### PR DESCRIPTION
Summary:
Apparently, it is the best setting atm and it makes sense
to make it default.

Differential Revision: D55932208


