### PR TITLE
Disable signature related functions in scheduled fuzzer runs

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -16,6 +16,8 @@ name: Linux Build
 
 on:
   push:
+    branches:
+      - "main"
     paths:
       - "velox/**"
       - "!velox/docs/**"
@@ -47,6 +49,8 @@ concurrency:
 jobs:
   adapters:
     name: Linux release with adapters
+    # prevent errors when forks ff their main branch
+    if: ${{ github.repository == "facebookincubator/velox" }}
     runs-on: 8-core
     container: ghcr.io/facebookincubator/velox-dev:adapters
     defaults:
@@ -110,6 +114,8 @@ jobs:
 
   ubuntu-debug:
     runs-on: 8-core
+    # prevent errors when forks ff their main branch
+    if: ${{ github.repository == "facebookincubator/velox" }}
     name: "Ubuntu debug with resolve_dependency"
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -71,7 +71,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.sha }}
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -150,8 +150,7 @@ jobs:
         if: ${{ github.even_name != 'schedule' && steps.get-sig.outputs.stash-hit != 'true' }}
         uses: actions/checkout@v4
         with:
-          # hardcode ref without broken pr
-          ref: 'main'
+          ref: ${{ steps.get-head.outputs.head_main || 'main' }}
           path: velox_main
 
       - name: Build PyVelox

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -105,12 +105,26 @@ jobs:
 
     steps:
 
+      - name: Get latest commit from main
+        if: ${{ github.event_name != 'schedule' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        id: get-head
+        run: |
+          if [ '${{ github.event_name = 'push' }}' == "true" ]; then
+            # get the parent commit of the current one to get the relevant function signatures
+            head_main=$(gh api -q '.parents.[0].sha' '/repos/facebookincubator/velox/commits/${{ github.sha }}')
+          else
+            head_main=$(gh api -H "Accept: application/vnd.github.sha" /repos/facebookincubator/velox/commits/heads/main)
+          fi
+          echo "head_main=$head_main" >> $GITHUB_OUTPUT
+
       - name: Get Function Signature Stash
         uses: assignUser/stash/restore@v1
         id: get-sig
         with:
           path: /tmp/signatures
-          key: function-signatures
+          key: function-signatures-${{ steps.get-head.outputs.head_main || github.sha }}
 
       - name: Restore ccache
         uses: assignUser/stash/restore@v1
@@ -159,11 +173,11 @@ jobs:
           python3 scripts/signature.py export --presto /tmp/signatures/presto_signatures_main.json
 
       - name: Save Function Signature Stash
-        if: ${{ github.even_name != 'schedule' && steps.get-sig.outputs.stash-hit != 'true' }}
+        if: ${{ github.even_name == 'pull_request' && steps.get-sig.outputs.stash-hit != 'true' }}
         uses: assignUser/stash/save@v1
         with:
           path: /tmp/signatures
-          key: function-signatures
+          key: function-signatures-${{ steps.get-head.outputs.head_main }}
 
       - name: Checkout Contender
         uses: actions/checkout@v4
@@ -219,6 +233,25 @@ jobs:
           name: signatures
           path: /tmp/signatures
           retention-days: "${{ env.RETENTION }}"
+
+      - name: Prepare signatures
+        working-directory: /tmp/signatures
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          # Remove irrelevant artifacts
+          rm *_bias_functions
+          rm *_signatures_main.json
+          # Rename signature files as 'main' files
+          for f in *_signatures_contender.json; do
+            mv "$f" "${f/_contender.json/_main.json}"
+          done
+
+      - name: Save Function Signature Stash
+        if: ${{ github.even_name == 'push' }}
+        uses: assignUser/stash/save@v1
+        with:
+          path: /tmp/signatures
+          key: function-signatures-${{ github.sha }}
 
       - name: Upload presto fuzzer
         uses: actions/upload-artifact@v4

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -118,7 +118,7 @@ jobs:
           mkdir -p /tmp/signatures
 
       - name: Checkout Main
-        if: ${{ steps.get-sig.outputs.stash-hit != 'true' }}
+        if: ${{ github.even_name != 'schedule' && steps.get-sig.outputs.stash-hit != 'true' }}
         uses: actions/checkout@v4
         with:
           # hardcode ref without broken pr
@@ -126,7 +126,7 @@ jobs:
           path: velox_main
 
       - name: Build PyVelox
-        if: ${{ steps.get-sig.outputs.stash-hit != 'true' }}
+        if: ${{ github.even_name != 'schedule' && steps.get-sig.outputs.stash-hit != 'true' }}
         working-directory: velox_main
         run: |
           python3 -m venv .venv
@@ -135,7 +135,7 @@ jobs:
           make python-build
 
       - name: Create Baseline Signatures
-        if: ${{ steps.get-sig.outputs.stash-hit != 'true' }}
+        if: ${{ github.even_name != 'schedule' && steps.get-sig.outputs.stash-hit != 'true' }}
         working-directory: velox_main
         run: |
           source .venv/bin/activate
@@ -144,7 +144,7 @@ jobs:
           python3 scripts/signature.py export --presto /tmp/signatures/presto_signatures_main.json
 
       - name: Save Function Signature Stash
-        if: ${{ steps.get-sig.outputs.stash-hit != 'true' }}
+        if: ${{ github.even_name != 'schedule' && steps.get-sig.outputs.stash-hit != 'true' }}
         uses: assignUser/stash/save@v1
         with:
           path: /tmp/signatures
@@ -171,9 +171,16 @@ jobs:
       - name: Ccache after
         run: ccache -s
 
-      # TODO: Add step to save ccache
+      - name: Save ccache
+        # see https://github.com/actions/upload-artifact/issues/543
+        continue-on-error: true
+        uses: assignUser/stash/save@v1
+        with:
+          path: "${{ env.CCACHE_DIR }}"
+          key: ccache-fuzzer-centos
 
       - name: Build PyVelox
+        if: ${{ github.even_name != 'schedule' }}
         env:
           VELOX_BUILD_DIR: "_build/debug"
         run: |
@@ -190,6 +197,7 @@ jobs:
           python3 scripts/signature.py gh_bias_check presto spark
 
       - name: Upload Signature Artifacts
+        if: ${{ github.even_name != 'schedule' }}
         uses: actions/upload-artifact@v4
         with:
           name: signatures

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -182,6 +182,7 @@ jobs:
           python3 -m pip install -e .
 
       - name: Create and test new function signatures
+        if: ${{ github.even_name != 'schedule' }}
         id: sig-check
         run: |
           source .venv/bin/activate
@@ -649,6 +650,7 @@ jobs:
 
   surface-signature-errors:
     name: Signature Changes
+    if: ${{ github.event_name != 'schedule' }}
     needs: compile
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -174,6 +174,7 @@ jobs:
       - name: Save ccache
         # see https://github.com/actions/upload-artifact/issues/543
         continue-on-error: true
+        if: ${{ github.even_name != 'schedule' }}
         uses: assignUser/stash/save@v1
         with:
           path: "${{ env.CCACHE_DIR }}"
@@ -673,4 +674,3 @@ jobs:
         run: |
           cat /tmp/signatures/presto_errors
           exit 1
-

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -26,6 +26,19 @@ on:
       - "scripts/setup-helper-functions.sh"
       - ".github/workflows/scheduled.yml"
 
+  push:
+    branches:
+      - "main"
+    paths:
+      - "velox/**"
+      - "!velox/docs/**"
+      - "CMakeLists.txt"
+      - "CMake/**"
+      - "third_party/**"
+      - "scripts/setup-ubuntu.sh"
+      - "scripts/setup-helper-functions.sh"
+      - ".github/workflows/scheduled.yml"
+
   schedule:
     - cron: '0 3 * * *'
 
@@ -70,6 +83,8 @@ env:
 jobs:
   compile:
     name: Build
+    # prevent errors when forks ff their main branch
+    if: ${{ github.repository == "facebookincubator/velox" }}
     runs-on: 16-core
     container: ghcr.io/facebookincubator/velox-dev:centos8
     timeout-minutes: 120

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -76,7 +76,7 @@ concurrency:
 
 env:
   # Run for 15 minute on PRs
-  DURATION: "${{ inputs.duration || ( github.event_name == 'pull_request' && 900 || 1800 )}}"
+  DURATION: "${{ inputs.duration || ( github.event_name != 'schedule' && 900 || 1800 )}}"
   # minimize artifact duration for PRs, keep them a bit longer for nightly runs
   RETENTION: "${{ github.event_name == 'pull_request' && 1 || 3 }}"
 
@@ -321,7 +321,7 @@ jobs:
           # Run for 30 minutes instead of 15, when files relevant to presto are touched
           pr_duration: "${{ steps.changes.outputs.presto == 'true' && 1800 || 900 }}"
           # Run for 60 minutes if its a scheduled run
-          other_duration: "${{ inputs.duration || 3600 }}"
+          other_duration: "${{ inputs.duration || (github.event_name == 'push' && 1800 || 3600) }}"
           is_pr: "${{ github.event_name == 'pull_request' }}"
         run: |
 


### PR DESCRIPTION
For the scheduled runs it doesn't make sense to run the signature related steps, specifically generating the signature cache might clobber (through a newer date,  not by overwriting) newer stashes on main leading to false positives.

This PR also fixes issues with the generation of the baseline signature stash only happening in the scheduled jobs. The fuzzer is now  also run on merge (against the parent commit on main) and will stash the signatures afterwards for use in PRs. The signatures stash key was amended with the sha so that we can ensure that the signatures match the merge base of the PR or generate them if they are (not) yet available. 