### PR TITLE
SIMD-ize DenseHll::mergeWith

### DIFF
--- a/velox/common/hyperloglog/benchmarks/CMakeLists.txt
+++ b/velox/common/hyperloglog/benchmarks/CMakeLists.txt
@@ -11,18 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(velox_common_hyperloglog BiasCorrection.cpp DenseHll.cpp
-                                     SparseHll.cpp)
 
-target_link_libraries(
-  velox_common_hyperloglog
-  PUBLIC velox_memory
-  PRIVATE velox_exception)
+add_executable(velox_common_hyperloglog_dense_hll_bm DenseHll.cpp)
 
-if(${VELOX_BUILD_TESTING})
-  add_subdirectory(tests)
-endif()
-
-if(${VELOX_ENABLE_BENCHMARKS})
-  add_subdirectory(benchmarks)
-endif()
+target_link_libraries(velox_common_hyperloglog_dense_hll_bm
+                      velox_common_hyperloglog ${FOLLY_BENCHMARK})

--- a/velox/common/hyperloglog/benchmarks/DenseHll.cpp
+++ b/velox/common/hyperloglog/benchmarks/DenseHll.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/hyperloglog/DenseHll.h"
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include "velox/common/memory/HashStringAllocator.h"
+
+#define XXH_INLINE_ALL
+#include <xxhash.h>
+
+using namespace facebook::velox;
+
+namespace {
+
+template <typename T>
+uint64_t hashOne(T value) {
+  return XXH64(&value, sizeof(value), 0);
+}
+
+// A benchmark for DenseHll::mergeWith(serialized) API.
+//
+// Measures the time it takes to merge 2 serialized digests using different
+// values for hash bits. Larger values of hash bits corresponds to larger
+// digests that are more accurate, but slower to merge. The default number of
+// hash bits is 11, while in practice 16 is common.
+class DenseHllBenchmark {
+ public:
+  explicit DenseHllBenchmark(memory::MemoryPool* pool) : pool_(pool) {
+    for (auto hashBits : {11, 12, 16}) {
+      serializedHlls_[hashBits].push_back(makeSerializedHll(hashBits, 1));
+      serializedHlls_[hashBits].push_back(makeSerializedHll(hashBits, 2));
+    }
+  }
+
+  void run(int hashBits) {
+    folly::BenchmarkSuspender suspender;
+
+    HashStringAllocator allocator(pool_);
+    common::hll::DenseHll hll(hashBits, &allocator);
+
+    suspender.dismiss();
+
+    for (const auto& serialized : serializedHlls_.at(hashBits)) {
+      hll.mergeWith(serialized.data());
+    }
+  }
+
+ private:
+  std::string makeSerializedHll(int hashBits, int32_t step) {
+    HashStringAllocator allocator(pool_);
+    common::hll::DenseHll hll(hashBits, &allocator);
+    for (int32_t i = 0; i < 1'000'000; ++i) {
+      auto hash = hashOne(i * step);
+      hll.insertHash(hash);
+    }
+    return serialize(hll);
+  }
+
+  static std::string serialize(common::hll::DenseHll& denseHll) {
+    auto size = denseHll.serializedSize();
+    std::string serialized;
+    serialized.resize(size);
+    denseHll.serialize(serialized.data());
+    return serialized;
+  }
+
+  memory::MemoryPool* pool_;
+
+  // List of serialized HLLs to use for merging, keyed by the number of hash
+  // bits.
+  std::unordered_map<int, std::vector<std::string>> serializedHlls_;
+};
+
+} // namespace
+
+std::unique_ptr<DenseHllBenchmark> benchmark;
+
+BENCHMARK(mergeSerialized11) {
+  benchmark->run(11);
+}
+
+BENCHMARK(mergeSerialized12) {
+  benchmark->run(12);
+}
+
+BENCHMARK(mergeSerialized16) {
+  benchmark->run(16);
+}
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+
+  memory::MemoryManager::initialize({});
+  auto rootPool = memory::memoryManager()->addRootPool();
+  auto pool = rootPool->addLeafChild("bm");
+  benchmark = std::make_unique<DenseHllBenchmark>(pool.get());
+
+  folly::runBenchmarks();
+  return 0;
+}


### PR DESCRIPTION
Summary:
Logically, HLL digest represents an array of 2^n numbers. Merging two such arrays consists of computing element-wise max of the numbers. The sizes of the arrays are always the same.

Example,

```
	HLL1: [1, 2, 3, 4, 5]
	HLL2: [5, 4, 3, 2, 1]

	Combined HLL: [5,4, 3, 4, 5]
```

This should be a fairly quick operation that easily lends itself to vectorization. But there is a catch.

The numbers stored in HLL digest are 8-bit integers that represent the number of leading zeros in a 64-bit hash. These numbers are from [0, 63] range. Hence, require at most 6 bits.

The size of the HLL array is a power of 2 (2^n), where n is a function of max standard error specified in approx_distinct. Larger values of 'n' allow for higher accuracy at the expense of using more memory.

In production workloads, we often see n = 16.

Storing 2^16 8-bit numbers requires 65KB (each number uses 1 byte). However, Presto uses a compact representation of the HLL digest that requires about half the memory.

Compact representation includes:

* One 8-bit baseline number: minimum value of all the numbers in the array
* 2^n 4-bit deltas from baseline capped at 15 (maximum value representable in 4 bits): delta = min(value - baseline, 15). 
* A small list of overflow values.
  * A list of indices where overflow has occurred (value > baseline + 15)
  * A matching list of overflows: overflow = value - baseline - 15.

For example, given HLL: [10, 2, 3, 18, 5], its compact representation is

* baseline: 2
* deltas: [8, 0, 1, 15, 3]
*	overflow indices: [3]
*	overflow values: [1]

There is only one value that has an overflow: 18 = 2 (baseline) + 15 (max delta) + 1 (overflow). Hence, overflow indices and values arrays have just one entry each.

In practice, for HLL of size 2^16, we see ~20 overflows.

Compact representation helps save memory and network bandwidth (shuffle), but requires a more sophisticated and therefore expensive processing. Merging compactly represented HLLs is a lot slower.

It is possible to speed up merging of compact HLLs using SIMD instructions. The implementation here is 2-3x faster than the original scalar implementation. 

There are a few challenges in SIMD-zing HLL merge.

First, there are no instructions to operate on 4-bit integers. The smallest supported integer is 8-bit. There is also no instruction to load 4-bit integers into SIMD registers.

The approach implemented here is to process deltas in even slots separately from deltas in odd slots.

We process deltas in batches of 64. Each batch is located in a 32 byte-buffer, each byte storing 2 values. Overflows are processed separately using scalar code path.

Add microbenchmark to measure the speed of DenseHll::mergeWith(serialized) for 3 different values of the hash bits: 11 (default), 12 and 16. The benchmark run on  Intel(R) Xeon(R) CPU E5-2680 v4 @ 2.40GHz shows speed up of 4x, 2.5x, 25x respectively. However, end-to-end measurements show much smaller gains of 2-3x.

Before:

```
============================================================================
[...]n/hyperloglog/benchmarks/DenseHll.cpp     relative  time/iter   iters/s
============================================================================
mergeSerialized11                                          25.10us    39.84K
mergeSerialized12                                          54.29us    18.42K
mergeSerialized16                                         569.50us     1.76K
```

After:

```
============================================================================
[...]n/hyperloglog/benchmarks/DenseHll.cpp     relative  time/iter   iters/s
============================================================================
mergeSerialized11                                           6.33us   158.02K
mergeSerialized12                                          20.04us    49.91K
mergeSerialized16                                          22.37us    44.70K
```

Differential Revision: D55936471


