### PR TITLE
Remove global -Wno-stringop-overflow, -Wno-stringop-overread compiler options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,8 +335,7 @@ if("${ENABLE_ALL_WARNINGS}")
          -Wno-format-overflow \
          -Wno-strict-aliasing \
          -Wno-type-limits \
-         -Wno-stringop-overflow \
-         -Wno-stringop-overread")
+         -Wno-stringop-overflow")
   endif()
 
   set(KNOWN_WARNINGS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,8 +334,7 @@ if("${ENABLE_ALL_WARNINGS}")
          -Wno-unused-result \
          -Wno-format-overflow \
          -Wno-strict-aliasing \
-         -Wno-type-limits \
-         -Wno-stringop-overflow")
+         -Wno-type-limits")
   endif()
 
   set(KNOWN_WARNINGS


### PR DESCRIPTION
This PR makes a change to remove the globally applied `-Wno-stringop-overflow` and `-Wno-stringop-overread` compiler options for GNU to warn for buffer overflows and undefined behaviour from reading past the end of the source buffer. PR https://github.com/facebookincubator/velox/pull/4618 originally disabled it.

Meant to address https://github.com/facebookincubator/velox/discussions/9469