### PR TITLE
Temporarily remove step to save ccache from scheduled jobs

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -171,11 +171,7 @@ jobs:
       - name: Ccache after
         run: ccache -s
 
-      - name: Save ccache
-        uses: assignUser/stash/save@v1
-        with:
-          path: "${{ env.CCACHE_DIR }}"
-          key: ccache-fuzzer-centos
+      # TODO: Add step to save ccache
 
       - name: Build PyVelox
         env:


### PR DESCRIPTION
Saving ccache is resulting in some errors finalizing the upload
which is preventing scheduled jobs from running. Removing this
step temporarily till its resolved.