### PR TITLE
Initialize FileOptions::fileSize in S3FileSystem::openFileForWrite

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.cpp
@@ -77,7 +77,7 @@ std::unique_ptr<velox::dwio::common::FileSink> s3WriteFileSinkGenerator(
     auto fileSystem =
         filesystems::getFileSystem(fileURI, options.connectorProperties);
     return std::make_unique<dwio::common::WriteFileSink>(
-        fileSystem->openFileForWrite(fileURI, {{}, options.pool}),
+        fileSystem->openFileForWrite(fileURI, {{}, options.pool, std::nullopt}),
         fileURI,
         options.metricLogger,
         options.stats);

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
@@ -190,7 +190,8 @@ TEST_F(S3FileSystemTest, writeFileAndRead) {
   auto hiveConfig = minioServer_->hiveConfig();
   filesystems::S3FileSystem s3fs(hiveConfig);
   auto pool = memory::memoryManager()->addLeafPool("S3FileSystemTest");
-  auto writeFile = s3fs.openFileForWrite(s3File, {{}, pool.get(), std::nullopt});
+  auto writeFile =
+      s3fs.openFileForWrite(s3File, {{}, pool.get(), std::nullopt});
   auto s3WriteFile = dynamic_cast<filesystems::S3WriteFile*>(writeFile.get());
   std::string dataContent =
       "Dance me to your beauty with a burning violin"

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
@@ -190,7 +190,7 @@ TEST_F(S3FileSystemTest, writeFileAndRead) {
   auto hiveConfig = minioServer_->hiveConfig();
   filesystems::S3FileSystem s3fs(hiveConfig);
   auto pool = memory::memoryManager()->addLeafPool("S3FileSystemTest");
-  auto writeFile = s3fs.openFileForWrite(s3File, {{}, pool.get()});
+  auto writeFile = s3fs.openFileForWrite(s3File, {{}, pool.get(), std::nullopt});
   auto s3WriteFile = dynamic_cast<filesystems::S3WriteFile*>(writeFile.get());
   std::string dataContent =
       "Dance me to your beauty with a burning violin"


### PR DESCRIPTION
Initialize `FileOptions::fileSize` to `nullopt` to fix build with adapters that is failing with missing initializer for field.