### PR TITLE
Fix syntax error in workflow yaml

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -50,7 +50,7 @@ jobs:
   adapters:
     name: Linux release with adapters
     # prevent errors when forks ff their main branch
-    if: ${{ github.repository == "facebookincubator/velox" }}
+    if: ${{ github.repository == 'facebookincubator/velox' }}
     runs-on: 8-core
     container: ghcr.io/facebookincubator/velox-dev:adapters
     defaults:
@@ -115,7 +115,7 @@ jobs:
   ubuntu-debug:
     runs-on: 8-core
     # prevent errors when forks ff their main branch
-    if: ${{ github.repository == "facebookincubator/velox" }}
+    if: ${{ github.repository == 'facebookincubator/velox' }}
     name: "Ubuntu debug with resolve_dependency"
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -84,7 +84,7 @@ jobs:
   compile:
     name: Build
     # prevent errors when forks ff their main branch
-    if: ${{ github.repository == "facebookincubator/velox" }}
+    if: ${{ github.repository == 'facebookincubator/velox' }}
     runs-on: 16-core
     container: ghcr.io/facebookincubator/velox-dev:centos8
     timeout-minutes: 120


### PR DESCRIPTION
Within `if:`/`${{}}`only single quotes are allowed, due to the fact that broken workflows don't show up in the check suite it got overlooked in #9420 