### PR TITLE
Fix flaky spill stats check in aggregation test

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -900,7 +900,8 @@ void GroupingSet::ensureOutputFits() {
   // to reserve memory for the output as we can't reclaim much memory from this
   // operator itself. The output processing can reclaim memory from the other
   // operator or query through memory arbitration.
-  if (isPartial_ || spillConfig_ == nullptr || hasSpilled()) {
+  if (isPartial_ || spillConfig_ == nullptr || hasSpilled() ||
+      table_ == nullptr || table_->numDistinct() == 0) {
     return;
   }
 

--- a/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
@@ -415,7 +415,7 @@ void AggregationTestBase::testAggregationsWithCompanion(
         toPlanStats(task->taskStats()).at(partialNodeId).inputRows;
     const auto finalInputRows =
         toPlanStats(task->taskStats()).at(finalNodeId).inputRows;
-    if (partialInputRows > 1) {
+    if (exec::injectedSpillCount() > 0) {
       EXPECT_LT(0, spilledBytes(*task))
           << "partial inputRows: " << partialInputRows
           << " final inputRows: " << finalInputRows
@@ -854,7 +854,7 @@ void AggregationTestBase::testAggregationsImpl(
         toPlanStats(task->taskStats()).at(partialNodeId).inputRows;
     const auto finalInputRows =
         toPlanStats(task->taskStats()).at(finalNodeId).inputRows;
-    if (partialInputRows > 1) {
+    if (exec::injectedSpillCount() > 0) {
       EXPECT_LT(0, spilledBytes(*task))
           << "partial inputRows: " << partialInputRows
           << " final inputRows: " << finalInputRows


### PR DESCRIPTION
The flaky is due to spill check condition is fragile which is based on whether we have received
more than one input at partial aggregation. We shall change to final aggregation and given we
have four drivers so it is not guarantee one aggregation has received more than one input row.
Since we have recorded the spill injection count, then we just rely on this to check spill stats.

This PR also restrict the case that we trigger spill for output memory reservation by checking
if table is null or empty