### PR TITLE
Add nightly job to track build metrics

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,6 +22,8 @@ on:
       - 'third_party/**'
       - 'pyvelox/**'
       - '.github/workflows/benchmark.yml'
+      - 'scripts/benchmark-requirements.txt'
+
   push:
     branches: [main]
 

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -128,6 +128,6 @@ jobs:
           ./scripts/build-metrics.py upload \
             --build_type "${{ matrix.type }}" \
             --run_id "BM-${{ matrix.type }}-${{ github.run_id }}-${{ github.run_attempt }}" \
-            --pr_number "${{ github.event.number }}" \
+            --pr_number "0" \
             --sha "${{ inputs.ref || github.sha }}" \
             "/tmp/metrics"

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -120,8 +120,8 @@ jobs:
           CONBENCH_MACHINE_INFO_NAME: "GitHub-runner-${{ matrix.runner }}"
           CONBENCH_EMAIL: "${{ secrets.CONBENCH_EMAIL }}"
           CONBENCH_PASSWORD: "${{ secrets.CONBENCH_PASSWORD }}"
-          CONBENCH_PROJECT_REPOSITORY: "${{ github.repository }}"
-          CONBENCH_PROJECT_COMMIT: "${{ inputs.ref || github.sha }}"
+          # These don't actually work https://github.com/conbench/conbench/issues/1484
+          # TODO remove them here and in the benchmark job 
         run: |
           ./scripts/build-metrics.py upload \
             --build_type "${{ matrix.type }}" \

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -112,4 +112,5 @@ jobs:
             --build_type "${{ matrix.type }}" \
             --run_id "BM-${{ matrix.type }}-${{ github.run_id }}-${{ github.run_attempt }}" \
             --pr_number "${{ steps.extract.outputs.pr_number }}" \
-            --sha "${{ inputs.ref || github.sha }}"
+            --sha "${{ inputs.ref || github.sha }}" \
+            "/tmp/metrics"

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -1,0 +1,101 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Collect Build Metrics
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "ref to check"
+        required: true
+
+  schedule:
+    - cron: "5 4 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  metrics:
+    name: Linux release with adapters
+    runs-on: 8-core
+    container: ghcr.io/facebookincubator/velox-dev:adapters
+    defaults:
+      run:
+        shell: bash
+    env:
+      CCACHE_DIR: "/__w/velox/velox/.ccache"
+      VELOX_DEPENDENCY_SOURCE: SYSTEM
+      simdjson_SOURCE: BUNDLED
+      xsimd_SOURCE: BUNDLED
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Fix git permissions
+        # Usually actions/checkout does this but as we run in a container
+        # it doesn't work
+        run: git config --global --add safe.directory /__w/velox/velox
+
+      - name: Make Release Build
+        env:
+          MAKEFLAGS: 'NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4'
+        run: |
+          EXTRA_CMAKE_FLAGS=(
+            "-DVELOX_ENABLE_BENCHMARKS=ON"
+            "-DVELOX_ENABLE_ARROW=ON"
+            "-DVELOX_ENABLE_PARQUET=ON"
+            "-DVELOX_ENABLE_HDFS=ON"
+            "-DVELOX_ENABLE_S3=ON"
+            "-DVELOX_ENABLE_GCS=ON"
+            "-DVELOX_ENABLE_ABFS=ON"
+            "-DVELOX_ENABLE_SUBSTRAIT=ON"
+            "-DVELOX_ENABLE_REMOTE_FUNCTIONS=ON"
+          )
+          make release
+
+      - name: Log binary sizes
+        run: |
+          mkdir -p /tmp/metrics
+          sizes_file=/tmp/metrics/object_sizes
+          pushd _build/release
+
+          find velox -type f -name '*.so' -o -name '*.a' -exec ls -l -BB {} \; |
+            awk '{print $5, $9; total += $5} END {print total," total_lib_size"}' > $sizes_file
+
+          find velox -type f -name '*.o' -exec ls -l -BB {} \; |
+            awk '{print $5, $9; total += $5} END {print total," total_obj_size"}' >> $sizes_file
+
+          find velox -type f -name 'velox_*' -exec ls -l -BB {} \; |
+            awk '{print $5, $9; total += $5} END {print total," total_exec_size"}' >> $sizes_file
+
+      - name: Copy ninja_log
+        run: cp _build/release/.ninja_log /tmp/metrics/.ninja_log
+
+      - name: "Upload Metrics"
+        env:
+          CONBENCH_URL: "https://velox-conbench.voltrondata.run/"
+          CONBENCH_MACHINE_INFO_NAME: "GitHub-runner-8-core"
+          CONBENCH_EMAIL: "${{ secrets.CONBENCH_EMAIL }}"
+          CONBENCH_PASSWORD: "${{ secrets.CONBENCH_PASSWORD }}"
+          CONBENCH_PROJECT_REPOSITORY: "${{ github.repository }}"
+          CONBENCH_PROJECT_COMMIT: "${{ inputs.ref || github.sha }}"
+        run: |
+          ./velox/scripts/build-metrics.py upload \
+            --run_id "bm-testing-GHA-${{ github.run_id }}-${{ github.run_attempt }}" \
+            --pr_number "${{ steps.extract.outputs.pr_number }}" \
+            --sha "${{ inputs.ref || github.sha }}"

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -121,7 +121,9 @@ jobs:
           CONBENCH_EMAIL: "${{ secrets.CONBENCH_EMAIL }}"
           CONBENCH_PASSWORD: "${{ secrets.CONBENCH_PASSWORD }}"
           # These don't actually work https://github.com/conbench/conbench/issues/1484
-          # TODO remove them here and in the benchmark job 
+          # but have to be there to work regardless??
+          CONBENCH_PROJECT_REPOSITORY: "${{ github.repository }}"
+          CONBENCH_PROJECT_COMMIT: "${{ inputs.ref || github.sha }}"
         run: |
           ./scripts/build-metrics.py upload \
             --build_type "${{ matrix.type }}" \

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   metrics:
-    name: Linux release with adapters
+    name: Linux ${{ matrix.type }} with adapters
     if: ${{ github.repository == 'facebookincubator/velox' }}
     runs-on: ${{ matrix.runner }}
     container: ghcr.io/facebookincubator/velox-dev:adapters
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: "8-core" # we could use 8-core here
+          - runner: "8-core"
             type: "release"
           - runner: "16-core"
             type: "debug"
@@ -59,7 +59,7 @@ jobs:
         # it doesn't work
         run: git config --global --add safe.directory /__w/velox/velox
 
-      - name: Make Release Build
+      - name: Make ${{ matrix.type }} Build
         env:
           MAKEFLAGS: 'NUM_THREADS=4 MAX_HIGH_MEM_JOBS=2 MAX_LINK_JOBS=2'
         run: |

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -128,6 +128,6 @@ jobs:
           ./scripts/build-metrics.py upload \
             --build_type "${{ matrix.type }}" \
             --run_id "BM-${{ matrix.type }}-${{ github.run_id }}-${{ github.run_attempt }}" \
-            --pr_number "0" \
+            --pr_number "${{ github.event.number }}" \
             --sha "${{ inputs.ref || github.sha }}" \
             "/tmp/metrics"

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -31,7 +31,8 @@ permissions:
 jobs:
   metrics:
     name: Linux release with adapters
-    runs-on: 8-core
+    #if: ${{ github.repository == 'facebookincubator/velox' }}
+    runs-on: ubuntu-latest #8-core
     container: ghcr.io/facebookincubator/velox-dev:adapters
     defaults:
       run:
@@ -53,7 +54,7 @@ jobs:
 
       - name: Make Release Build
         env:
-          MAKEFLAGS: 'NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4'
+          MAKEFLAGS: 'NUM_THREADS=4 MAX_HIGH_MEM_JOBS=2 MAX_LINK_JOBS=2'
         run: |
           EXTRA_CMAKE_FLAGS=(
             "-DVELOX_ENABLE_BENCHMARKS=ON"

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -87,12 +87,8 @@ jobs:
       - name: Copy ninja_log
         run: cp _build/release/.ninja_log /tmp/metrics/.ninja_log
 
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
-
       - name: "Install dependencies"
-        run: python -m pip install -r velox/scripts/benchmark-requirements.txt
+        run: python3 -m pip install -r velox/scripts/benchmark-requirements.txt
 
       - name: "Upload Metrics"
         env:

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -88,7 +88,7 @@ jobs:
         run: cp _build/release/.ninja_log /tmp/metrics/.ninja_log
 
       - name: "Install dependencies"
-        run: python3 -m pip install -r velox/scripts/benchmark-requirements.txt
+        run: python3 -m pip install -r scripts/benchmark-requirements.txt
 
       - name: "Upload Metrics"
         env:

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -59,14 +59,7 @@ jobs:
         # it doesn't work
         run: git config --global --add safe.directory /__w/velox/velox
 
-      - uses: assignUser/stash/restore@v1
-        id: get-bm
-        with:
-          path: '/tmp/metrics'
-          key: build-metrics-${{ matrix.type }}
-
       - name: Make ${{ matrix.type }} Build
-        if: ${{ steps.get-bm.outputs.stash-hit != 'true' }}
         env:
           MAKEFLAGS: 'MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=4'
         run: |
@@ -84,7 +77,6 @@ jobs:
           make '${{ matrix.type }}'
 
       - name: Log binary sizes
-        if: ${{ steps.get-bm.outputs.stash-hit != 'true' }}
         run: |
           mkdir -p /tmp/metrics
           sizes_file=/tmp/metrics/object_sizes
@@ -100,14 +92,7 @@ jobs:
             awk '{print $5, $9; total += $5} END {print total," total_exec_size"}' >> $sizes_file
 
       - name: Copy ninja_log
-        if: ${{ steps.get-bm.outputs.stash-hit != 'true' }}
         run: cp _build/${{ matrix.type }}/.ninja_log /tmp/metrics/.ninja_log
-
-      - uses: assignUser/stash/save@v1
-        if: ${{ steps.get-bm.outputs.stash-hit != 'true' }}
-        with:
-          path: '/tmp/metrics'
-          key: build-metrics-${{ matrix.type }}
 
       - name: "Install dependencies"
         run: |

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Copy ninja_log
         if: ${{ steps.get-bm.outputs.stash-hit != 'true' }}
-        run: cp _build/release/.ninja_log /tmp/metrics/.ninja_log
+        run: cp _build/${{ matrix.type }}/.ninja_log /tmp/metrics/.ninja_log
 
       - uses: assignUser/stash/save@v1
         if: ${{ steps.get-bm.outputs.stash-hit != 'true' }}
@@ -126,6 +126,6 @@ jobs:
           ./scripts/build-metrics.py upload \
             --build_type "${{ matrix.type }}" \
             --run_id "BM-${{ matrix.type }}-${{ github.run_id }}-${{ github.run_attempt }}" \
-            --pr_number "${{ steps.extract.outputs.pr_number }}" \
+            --pr_number "${{ github.event.number }}" \
             --sha "${{ inputs.ref || github.sha }}" \
             "/tmp/metrics"

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -41,11 +41,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - runner: "8-core"
-            type: "release"
-          - runner: "16-core"
-            type: "debug"
+        - runner: "16-core"
+        - type: ["debug", "release"]
     defaults:
       run:
         shell: bash
@@ -75,7 +72,6 @@ jobs:
             "-DVELOX_ENABLE_S3=ON"
             "-DVELOX_ENABLE_GCS=ON"
             "-DVELOX_ENABLE_ABFS=ON"
-            "-DVELOX_ENABLE_SUBSTRAIT=ON"
             "-DVELOX_ENABLE_REMOTE_FUNCTIONS=ON"
           )
           make '${{ matrix.type }}'

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -87,6 +87,13 @@ jobs:
       - name: Copy ninja_log
         run: cp _build/release/.ninja_log /tmp/metrics/.ninja_log
 
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: "Install dependencies"
+        run: python -m pip install -r velox/scripts/benchmark-requirements.txt
+
       - name: "Upload Metrics"
         env:
           CONBENCH_URL: "https://velox-conbench.voltrondata.run/"

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -31,14 +31,21 @@ permissions:
 jobs:
   metrics:
     name: Linux release with adapters
-    #if: ${{ github.repository == 'facebookincubator/velox' }}
-    runs-on: ubuntu-latest #8-core
+    if: ${{ github.repository == 'facebookincubator/velox' }}
+    runs-on: ${{ matrix.runner }}
     container: ghcr.io/facebookincubator/velox-dev:adapters
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: "8-core" # we could use 8-core here
+            type: "release"
+          - runner: "16-core"
+            type: "debug"
     defaults:
       run:
         shell: bash
     env:
-      CCACHE_DIR: "/__w/velox/velox/.ccache"
       VELOX_DEPENDENCY_SOURCE: SYSTEM
       simdjson_SOURCE: BUNDLED
       xsimd_SOURCE: BUNDLED
@@ -67,7 +74,7 @@ jobs:
             "-DVELOX_ENABLE_SUBSTRAIT=ON"
             "-DVELOX_ENABLE_REMOTE_FUNCTIONS=ON"
           )
-          make release
+          make '${{ matrix.type }}'
 
       - name: Log binary sizes
         run: |
@@ -88,18 +95,21 @@ jobs:
         run: cp _build/release/.ninja_log /tmp/metrics/.ninja_log
 
       - name: "Install dependencies"
-        run: python3 -m pip install -r scripts/benchmark-requirements.txt
+        run: |
+          python3 -m pip install setuptools
+          python3 -m pip install -r scripts/benchmark-requirements.txt
 
       - name: "Upload Metrics"
         env:
           CONBENCH_URL: "https://velox-conbench.voltrondata.run/"
-          CONBENCH_MACHINE_INFO_NAME: "GitHub-runner-8-core"
+          CONBENCH_MACHINE_INFO_NAME: "GitHub-runner-${{ matrix.runner }}"
           CONBENCH_EMAIL: "${{ secrets.CONBENCH_EMAIL }}"
           CONBENCH_PASSWORD: "${{ secrets.CONBENCH_PASSWORD }}"
           CONBENCH_PROJECT_REPOSITORY: "${{ github.repository }}"
           CONBENCH_PROJECT_COMMIT: "${{ inputs.ref || github.sha }}"
         run: |
           ./scripts/build-metrics.py upload \
-            --run_id "bm-testing-GHA-${{ github.run_id }}-${{ github.run_attempt }}" \
+            --build_type "${{ matrix.type }}" \
+            --run_id "BM-${{ matrix.type }}-${{ github.run_id }}-${{ github.run_attempt }}" \
             --pr_number "${{ steps.extract.outputs.pr_number }}" \
             --sha "${{ inputs.ref || github.sha }}"

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -59,7 +59,14 @@ jobs:
         # it doesn't work
         run: git config --global --add safe.directory /__w/velox/velox
 
+      - uses: assignUser/stash/restore@v1
+        id: get-bm
+        with:
+          path: '/tmp/metrics'
+          key: build-metrics-${{ matrix.type }}
+
       - name: Make ${{ matrix.type }} Build
+        if: ${{ steps.get-bm.outputs.stash-hit != 'true' }}
         env:
           MAKEFLAGS: 'NUM_THREADS=4 MAX_HIGH_MEM_JOBS=2 MAX_LINK_JOBS=2'
         run: |
@@ -77,6 +84,7 @@ jobs:
           make '${{ matrix.type }}'
 
       - name: Log binary sizes
+        if: ${{ steps.get-bm.outputs.stash-hit != 'true' }}
         run: |
           mkdir -p /tmp/metrics
           sizes_file=/tmp/metrics/object_sizes
@@ -92,7 +100,14 @@ jobs:
             awk '{print $5, $9; total += $5} END {print total," total_exec_size"}' >> $sizes_file
 
       - name: Copy ninja_log
+        if: ${{ steps.get-bm.outputs.stash-hit != 'true' }}
         run: cp _build/release/.ninja_log /tmp/metrics/.ninja_log
+
+      - uses: assignUser/stash/save@v1
+        if: ${{ steps.get-bm.outputs.stash-hit != 'true' }}
+        with:
+          path: '/tmp/metrics'
+          key: build-metrics-${{ matrix.type }}
 
       - name: "Install dependencies"
         run: |

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -96,7 +96,7 @@ jobs:
           CONBENCH_PROJECT_REPOSITORY: "${{ github.repository }}"
           CONBENCH_PROJECT_COMMIT: "${{ inputs.ref || github.sha }}"
         run: |
-          ./velox/scripts/build-metrics.py upload \
+          ./scripts/build-metrics.py upload \
             --run_id "bm-testing-GHA-${{ github.run_id }}-${{ github.run_attempt }}" \
             --pr_number "${{ steps.extract.outputs.pr_number }}" \
             --sha "${{ inputs.ref || github.sha }}"

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -26,6 +26,7 @@ on:
         required: true
 
   schedule:
+    # Run every day at 04:05
     - cron: "5 4 * * *"
 
 permissions:

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -16,6 +16,9 @@ name: Collect Build Metrics
 
 on:
   pull_request:
+      paths:
+        - ".github/workflows/build-metrics.yml"
+
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           mkdir -p /tmp/metrics
           sizes_file=/tmp/metrics/object_sizes
-          pushd _build/release
+          pushd '_build/${{ matrix.type }}'
 
           find velox -type f -name '*.so' -o -name '*.a' -exec ls -l -BB {} \; |
             awk '{print $5, $9; total += $5} END {print total," total_lib_size"}' > $sizes_file

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Make ${{ matrix.type }} Build
         if: ${{ steps.get-bm.outputs.stash-hit != 'true' }}
         env:
-          MAKEFLAGS: 'NUM_THREADS=4 MAX_HIGH_MEM_JOBS=2 MAX_LINK_JOBS=2'
+          MAKEFLAGS: 'MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=4'
         run: |
           EXTRA_CMAKE_FLAGS=(
             "-DVELOX_ENABLE_BENCHMARKS=ON"

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -90,7 +90,6 @@ jobs:
             "-DVELOX_ENABLE_S3=ON"
             "-DVELOX_ENABLE_GCS=ON"
             "-DVELOX_ENABLE_ABFS=ON"
-            "-DVELOX_ENABLE_SUBSTRAIT=ON"
             "-DVELOX_ENABLE_REMOTE_FUNCTIONS=ON"
           )
           make release EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS[*]}"

--- a/scripts/benchmark-requirements.txt
+++ b/scripts/benchmark-requirements.txt
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-benchadapt
-benchalerts
-benchclients
+benchadapt==2024.3.20
+benchalerts==2024.1.10.1
+benchclients==2024.3.29.1

--- a/scripts/benchmark-requirements.txt
+++ b/scripts/benchmark-requirements.txt
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-benchadapt@git+https://github.com/conbench/conbench.git@44e81d1#subdirectory=benchadapt/python
-benchalerts@git+https://github.com/conbench/conbench.git@44e81d1#subdirectory=benchalerts
-benchclients@git+https://github.com/conbench/conbench.git@44e81d1#subdirectory=benchclients/python
+benchadapt
+benchalerts
+benchclients

--- a/scripts/build-metrics.py
+++ b/scripts/build-metrics.py
@@ -286,7 +286,6 @@ def parse_args():
     )
     upload_parser.add_argument(
         "base_path",
-        default="/tmp/metrics",
         help="Path in which the .ninja_log and sizes_file are found.",
     )
 

--- a/scripts/build-metrics.py
+++ b/scripts/build-metrics.py
@@ -219,7 +219,7 @@ def upload(args):
             "run_reason": run_reason,
             "github": {
                 # TODO change
-                "repository": "https://github.com/assignUser/velox",
+                "repository": "https://github.com/facebookincubator/velox",
                 "pr_number": pr_number,
                 "commit": args.sha,
             },
@@ -236,8 +236,7 @@ def upload(args):
             "run_name": run_name,
             "run_reason": run_reason,
             "github": {
-                # TODO change
-                "repository": "https://github.com/assignUser/velox",
+                "repository": "https://github.com/facebookincubator/velox",
                 "pr_number": pr_number,
                 "commit": args.sha,
             },

--- a/scripts/build-metrics.py
+++ b/scripts/build-metrics.py
@@ -1,0 +1,169 @@
+import uuid
+from os.path import splitext
+from pathlib import Path
+from typing import Any, Dict, List
+
+from benchadapt import BenchmarkResult
+from benchadapt.adapters import BenchmarkAdapter
+
+
+class BinarySizeAdapter(BenchmarkAdapter):
+    size_file: Path
+
+    def __init__(
+        self,
+        command: List[str],
+        # TODO remove default path
+        size_file: str = "/tmp/object-size",
+        result_fields_override: Dict[str, Any] = {},
+        result_fields_append: Dict[str, Any] = {},
+    ) -> None:
+        self.size_file = Path(size_file)
+        super().__init__(command, result_fields_override, result_fields_append)
+
+    def _transform_results(self) -> List[BenchmarkResult]:
+        results = []
+
+        batch_id = uuid.uuid4().hex
+        with open(self.size_file, "r") as file:
+            sizes = [line.strip() for line in file]
+
+        if not sizes:
+            raise ValueError("'size_file' is empty!")
+
+        for line in sizes:
+            size, path = line.split(maxsplit=1)
+            path = path.strip()
+            _, ext = splitext(path)
+            if ext in [".so", ".a"]:
+                suite = "library"
+            elif ext == ".o":
+                suite = "object"
+            else:
+                suite = "executable"
+
+            parsed_size = BenchmarkResult(
+                run_reason="merge",
+                # TODO remove, added via envvars
+                github={
+                    "repository": "https://github.com/facebookincubator/velox",
+                    "commit": "e29cde7b220ac507f7c55e3101f47836a67c51f1",
+                },
+                batch_id=batch_id,
+                stats={
+                    "data": [size],
+                    "unit": "B",
+                    "iterations": 1,
+                },
+                tags={"name": path, "suite": suite, "source": "build_metrics"},
+                info={},
+                context={"benchmark_language": "C++"},
+            )
+            results.append(parsed_size)
+
+        return results
+
+
+class BuildTimeAdapter(BenchmarkAdapter):
+    ninja_log: Path
+
+    def __init__(
+        self,
+        command: List[str],
+        # TODO remove default path
+        ninja_log: str = "_build/release/.ninja_log",
+        result_fields_override: Dict[str, Any] = {},
+        result_fields_append: Dict[str, Any] = {},
+    ) -> None:
+        self.ninja_log = Path(ninja_log)
+        super().__init__(command, result_fields_override, result_fields_append)
+
+    def _transform_results(self) -> List[BenchmarkResult]:
+        results = []
+
+        batch_id = uuid.uuid4().hex
+        with open(self.ninja_log, "r") as file:
+            log_lines = [line.strip() for line in file]
+
+        if not log_lines[0].startswith("# ninja log v"):
+            raise ValueError("Malformed Ninja log found!")
+        else:
+            del log_lines[0]
+
+        ms2sec = lambda x: x / 1000
+        get_epoch = lambda l: int(l.split()[2])
+        totals = {
+            "link_time": 0,
+            "compile_time": 0,
+            "total_time": 0,
+            "wall_time": get_epoch(log_lines[-1]) - get_epoch(log_lines[0]),
+        }
+
+        for line in log_lines:
+            start, end, epoch, object_path, _ = line.split()
+            start = int(start)
+            end = int(end)
+            duration = ms2sec(end - start)
+
+            # Don't track dependency times (refine check potentially?)
+            if not object_path.startswith("velox"):
+                continue
+
+            _, ext = splitext(object_path)
+            if ext in [".so", ".a"] or not ext:
+                totals["link_time"] += duration
+                suite = "linking"
+            elif ext == ".o":
+                totals["compile_time"] += duration
+                suite = "compiling"
+            else:
+                print(f"Unkown file type found: {object_path}")
+                print("Skipping...")
+                continue
+
+            time_result = BenchmarkResult(
+                run_reason="merge",
+                # TODO remove, added via envvars
+                github={
+                    "repository": "https://github.com/facebookincubator/velox",
+                    "commit": "c329af5d37547f8ab3e88129b7aa166294e9d75c",
+                },
+                batch_id=batch_id,
+                stats={
+                    "data": [duration],
+                    "unit": "s",
+                    "iterations": 1,
+                },
+                tags={"name": object_path, "suite": suite, "source": "build_metrics"},
+                info={},
+                context={"benchmark_language": "C++"},
+            )
+            results.append(time_result)
+
+        totals["total_time"] = totals["link_time"] + totals["compile_time"]
+        for total_name, total in totals.items():
+            total_result = BenchmarkResult(
+                run_reason="merge",
+                # TODO remove, added via envvars
+                github={
+                    "repository": "https://github.com/facebookincubator/velox",
+                    "commit": "c329af5d37547f8ab3e88129b7aa166294e9d75c",
+                },
+                batch_id=batch_id,
+                stats={
+                    "data": [total],
+                    "unit": "s",
+                    "iterations": 1,
+                },
+                tags={"name": total_name, "suite": "total", "source": "build_metrics"},
+                info={},
+                context={"benchmark_language": "C++"},
+            )
+            results.append(total_result)
+
+        return results
+
+
+# find velox -type f -name '*.o' -exec ls -l -BB {} \; | awk '{print $5, $9}' |  sed 's|CMakeFiles/.*dir/||g' > /tmp/object-size
+BuildTimeAdapter(command=["true"])()
+# BinarySizeAdapter(command=["true"])()

--- a/scripts/build-metrics.py
+++ b/scripts/build-metrics.py
@@ -8,13 +8,21 @@ from benchadapt.adapters import BenchmarkAdapter
 
 
 class BinarySizeAdapter(BenchmarkAdapter):
+    """
+    Adapter to track build artifact sizes in conbench.
+    Expects the `size_file` to be formatted like this:
+    <size in bytes> <path/to/binary|arbitrary_name>
+
+    Suite meta data will be library, object or executable
+    based on file ending.
+    """
+
     size_file: Path
 
     def __init__(
         self,
         command: List[str],
-        # TODO remove default path
-        size_file: str = "/tmp/object-size",
+        size_file: str,
         result_fields_override: Dict[str, Any] = {},
         result_fields_append: Dict[str, Any] = {},
     ) -> None:
@@ -44,11 +52,6 @@ class BinarySizeAdapter(BenchmarkAdapter):
 
             parsed_size = BenchmarkResult(
                 run_reason="merge",
-                # TODO remove, added via envvars
-                github={
-                    "repository": "https://github.com/facebookincubator/velox",
-                    "commit": "e29cde7b220ac507f7c55e3101f47836a67c51f1",
-                },
                 batch_id=batch_id,
                 stats={
                     "data": [size],
@@ -65,13 +68,20 @@ class BinarySizeAdapter(BenchmarkAdapter):
 
 
 class BuildTimeAdapter(BenchmarkAdapter):
+    """
+    Adapter to extract compile and link times from a .ninja_log.
+    Will calculate aggregates for total, compile, link and wall time.
+    Suite metadata will be set based on binary ending to object, library or executable.
+
+    Only files in paths beginning with velox/ will be tracked to avoid dependencies.
+    """
+
     ninja_log: Path
 
     def __init__(
         self,
         command: List[str],
-        # TODO remove default path
-        ninja_log: str = "_build/release/.ninja_log",
+        ninja_log: str,
         result_fields_override: Dict[str, Any] = {},
         result_fields_append: Dict[str, Any] = {},
     ) -> None:
@@ -123,11 +133,6 @@ class BuildTimeAdapter(BenchmarkAdapter):
 
             time_result = BenchmarkResult(
                 run_reason="merge",
-                # TODO remove, added via envvars
-                github={
-                    "repository": "https://github.com/facebookincubator/velox",
-                    "commit": "c329af5d37547f8ab3e88129b7aa166294e9d75c",
-                },
                 batch_id=batch_id,
                 stats={
                     "data": [duration],
@@ -144,11 +149,6 @@ class BuildTimeAdapter(BenchmarkAdapter):
         for total_name, total in totals.items():
             total_result = BenchmarkResult(
                 run_reason="merge",
-                # TODO remove, added via envvars
-                github={
-                    "repository": "https://github.com/facebookincubator/velox",
-                    "commit": "c329af5d37547f8ab3e88129b7aa166294e9d75c",
-                },
                 batch_id=batch_id,
                 stats={
                     "data": [total],

--- a/scripts/build-metrics.py
+++ b/scripts/build-metrics.py
@@ -218,7 +218,6 @@ def upload(args):
             "run_name": run_name,
             "run_reason": run_reason,
             "github": {
-                # TODO change
                 "repository": "https://github.com/facebookincubator/velox",
                 "pr_number": pr_number,
                 "commit": args.sha,


### PR DESCRIPTION
This PR adds a nightly job that collect build time and binary size metrics for a debug and release build and uploads the data to conbench. For example: https://velox-conbench.voltrondata.run/runs/BM-release-8665191090-1/

The adapters also add aggregate statistics, for time the `wall_time` is of course dependent on the number of cores so there will be clear differences between release and debug as debug runs on 16 cores (because the 8 cores don't have enough disk space for a debug build).