### PR TITLE
Fix broken link to design philosophy document

### DIFF
--- a/website/docs/community/index.md
+++ b/website/docs/community/index.md
@@ -10,4 +10,4 @@ Today, Velox is developed and maintained by a community of 200+ individuals from
 20+ different organizations. This page contains more information about Velox's
 open source community.
 
-* [Velox Design Philosophy, Principles, and Values.](./docs/community/design-philosophy)
+* [Velox Design Philosophy, Principles, and Values.](./design-philosophy.md)


### PR DESCRIPTION
<img width="1721" alt="image" src="https://github.com/facebookincubator/velox/assets/12885505/07997adc-64f2-4f72-b294-0872cce0c56e">



The `Velox Design Philosophy, Principles, and Values` document link has an extra `/docs/community/` in the link. It is giving 404 when clicked. I have updated the link to `./design-philosophy.md.`

It is a minor document fix, so I did not open an issue. Please let me know if you need one. Thank you!