### PR TITLE
Refactor `toSerializedPage` function

### DIFF
--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -20,6 +20,7 @@
 #include "velox/exec/Task.h"
 #include "velox/exec/tests/utils/LocalExchangeSource.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/SerializedPageUtil.h"
 #include "velox/serializers/PrestoSerializer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -45,18 +46,6 @@ class ExchangeClientTest : public testing::Test,
     bufferManager_ = OutputBufferManager::getInstance().lock();
   }
 
-  std::unique_ptr<SerializedPage> toSerializedPage(const RowVectorPtr& vector) {
-    auto data = std::make_unique<VectorStreamGroup>(pool());
-    auto size = vector->size();
-    auto range = IndexRange{0, size};
-    data->createStreamTree(asRowType(vector->type()), size);
-    data->append(vector, folly::Range(&range, 1));
-    auto listener = bufferManager_->newListener();
-    IOBufOutputStream stream(*pool(), listener.get(), data->size());
-    data->flush(&stream);
-    return std::make_unique<SerializedPage>(stream.getIOBuf(), nullptr, size);
-  }
-
   std::shared_ptr<Task> makeTask(
       const std::string& taskId,
       const core::PlanNodePtr& planNode) {
@@ -71,7 +60,7 @@ class ExchangeClientTest : public testing::Test,
       const std::string& taskId,
       int32_t destination,
       const RowVectorPtr& data) {
-    auto page = toSerializedPage(data);
+    auto page = test::toSerializedPage(data, pool(), bufferManager_);
     const auto pageSize = page->size();
     ContinueFuture unused;
     auto blocked =
@@ -208,7 +197,7 @@ TEST_F(ExchangeClientTest, flowControl) {
       makeFlatVector<int64_t>(10'000, [](auto row) { return row; }),
   });
 
-  auto page = toSerializedPage(data);
+  auto page = test::toSerializedPage(data, pool(), bufferManager_);
 
   // Set limit at 3.5 pages.
   auto client = std::make_shared<ExchangeClient>(

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -28,6 +28,7 @@
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/LocalExchangeSource.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/SerializedPageUtil.h"
 
 using namespace facebook::velox::exec::test;
 
@@ -147,23 +148,11 @@ class MultiFragmentTest : public HiveConnectorTestBase {
     createDuckDbTable(vectors_);
   }
 
-  std::unique_ptr<SerializedPage> toSerializedPage(const RowVectorPtr& vector) {
-    auto data = std::make_unique<VectorStreamGroup>(pool());
-    auto size = vector->size();
-    auto range = IndexRange{0, size};
-    data->createStreamTree(asRowType(vector->type()), size);
-    data->append(vector, folly::Range(&range, 1));
-    auto listener = bufferManager_->newListener();
-    IOBufOutputStream stream(*pool(), listener.get(), data->size());
-    data->flush(&stream);
-    return std::make_unique<SerializedPage>(stream.getIOBuf(), nullptr, size);
-  }
-
   int32_t enqueue(
       const std::string& taskId,
       int32_t destination,
       const RowVectorPtr& data) {
-    auto page = toSerializedPage(data);
+    auto page = toSerializedPage(data, pool(), bufferManager_);
     const auto pageSize = page->size();
 
     ContinueFuture unused;

--- a/velox/exec/tests/OutputBufferManagerTest.cpp
+++ b/velox/exec/tests/OutputBufferManagerTest.cpp
@@ -20,6 +20,7 @@
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/exec/Task.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/SerializedPageUtil.h"
 #include "velox/serializers/PrestoSerializer.h"
 
 using namespace facebook::velox;
@@ -86,21 +87,7 @@ class OutputBufferManagerTest : public testing::Test {
       vector_size_t size) {
     auto vector = std::dynamic_pointer_cast<RowVector>(
         BatchMaker::createBatch(rowType, size, *pool_));
-    return toSerializedPage(vector);
-  }
-
-  std::unique_ptr<SerializedPage> toSerializedPage(VectorPtr vector) {
-    auto data = std::make_unique<VectorStreamGroup>(pool_.get());
-    auto size = vector->size();
-    auto range = IndexRange{0, size};
-    data->createStreamTree(
-        std::dynamic_pointer_cast<const RowType>(vector->type()), size);
-    data->append(
-        std::dynamic_pointer_cast<RowVector>(vector), folly::Range(&range, 1));
-    auto listener = bufferManager_->newListener();
-    IOBufOutputStream stream(*pool_, listener.get(), data->size());
-    data->flush(&stream);
-    return std::make_unique<SerializedPage>(stream.getIOBuf(), nullptr, size);
+    return exec::test::toSerializedPage(vector, pool_.get(), bufferManager_);
   }
 
   void enqueue(

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -29,7 +29,8 @@ add_library(
   SumNonPODAggregate.cpp
   TpchQueryBuilder.cpp
   VectorTestUtil.cpp
-  PortUtil.cpp)
+  PortUtil.cpp
+  SerializedPageUtil.cpp)
 
 target_link_libraries(
   velox_exec_test_lib

--- a/velox/exec/tests/utils/SerializedPageUtil.cpp
+++ b/velox/exec/tests/utils/SerializedPageUtil.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/tests/utils/SerializedPageUtil.h"
+
+using namespace facebook::velox;
+
+namespace facebook::velox::exec::test {
+
+std::unique_ptr<SerializedPage> toSerializedPage(
+    const RowVectorPtr& vector,
+    memory::MemoryPool* pool,
+    std::shared_ptr<OutputBufferManager> bufferManager) {
+  auto data = std::make_unique<VectorStreamGroup>(pool);
+  auto size = vector->size();
+  auto range = IndexRange{0, size};
+  data->createStreamTree(asRowType(vector->type()), size);
+  data->append(vector, folly::Range(&range, 1));
+  auto listener = bufferManager->newListener();
+  IOBufOutputStream stream(*pool, listener.get(), data->size());
+  data->flush(&stream);
+  return std::make_unique<SerializedPage>(stream.getIOBuf(), nullptr, size);
+}
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/SerializedPageUtil.h
+++ b/velox/exec/tests/utils/SerializedPageUtil.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/ExchangeQueue.h"
+#include "velox/exec/OutputBufferManager.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/VectorStream.h"
+
+namespace facebook::velox::exec::test {
+
+// Helper function for serializing RowVector to PrestoPage format.
+std::unique_ptr<SerializedPage> toSerializedPage(
+    const RowVectorPtr& vector,
+    memory::MemoryPool* pool,
+    std::shared_ptr<OutputBufferManager> bufferManager);
+
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
Refactors `toSerializedPage` function to add a common helper function for serializing 
`RowVector` to `PrestoPage` format, in file `SerializedPageUtil.cpp`.