### PR TITLE
Fix TestScopedSpillInjection::testingSpillPoolRegExp

### DIFF
--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -306,7 +306,7 @@ tsan_atomic<uint32_t>& testingSpillPct() {
   return spillPct;
 }
 
-std::string testingSpillPoolRegExp() {
+std::string& testingSpillPoolRegExp() {
   static std::string spillPoolRegExp{".*"};
   return spillPoolRegExp;
 }


### PR DESCRIPTION
TestScopedSpillInjection::testingSpillPoolRegExp should return a reference which
is a typo from previous tsan build fix.