### PR TITLE
Reduce number of explicit OutputBuffer#acknowledge calls

### DIFF
--- a/velox/exec/ExchangeSource.h
+++ b/velox/exec/ExchangeSource.h
@@ -88,6 +88,12 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
   virtual folly::SemiFuture<Response> requestDataSizes(
       std::chrono::microseconds maxWait) = 0;
 
+  /// Notifies that the engine needs some time to process already received data
+  /// and may not request more for a while. The implementation may choose to
+  /// release temporary buffers or pause fetching any new data until any of
+  /// the 'request' or 'requestDataSizes' methods are called.
+  virtual void pause() {};
+
   /// Close the exchange source. May be called before all data
   /// has been received and processed. This can happen in case
   /// of an error or an operator like Limit aborting the query

--- a/velox/exec/OutputBuffer.cpp
+++ b/velox/exec/OutputBuffer.cpp
@@ -474,7 +474,7 @@ bool OutputBuffer::enqueue(
         VELOX_UNREACHABLE(PartitionedOutputNode::kindString(kind_));
     }
 
-    if (bufferedBytes_ > maxSize_ && future) {
+    if (bufferedBytes_ >= maxSize_ && future) {
       promises_.emplace_back("OutputBuffer::enqueue");
       *future = promises_.back().getSemiFuture();
       blocked = true;


### PR DESCRIPTION
Unnecessary acknowledge calls may cause additional RPC overhead. The idea is to avoid sending an explicit acknowledge when not necessary (for example if a subsequent getData request is expected to be sent right away).