### PR TITLE
Add CMakeUserPresets.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -279,6 +279,7 @@ settings.json
 
 # User's build configuration
 Makefile.config
+CMakeUserPresets.json
 
 # build, distribute, and bins (+ python proto bindings)
 build


### PR DESCRIPTION
Ensure user-specific CMake presets do not show up in git.

CMake >= 3.19 allows the use of presets to specify project settings. CMakeUserPresets.json is used to store user-specific settings which should not be checked in to git.