### PR TITLE
Minimize memory of unused chain buffers

### DIFF
--- a/velox/dwio/dwrf/writer/ColumnWriter.cpp
+++ b/velox/dwio/dwrf/writer/ColumnWriter.cpp
@@ -205,7 +205,9 @@ class IntegerColumnWriter : public BaseColumnWriter {
                 context.shareFlatMapDictionaries() ? 0 : sequence},
             getMemoryPool(MemoryUsageCategory::DICTIONARY),
             getMemoryPool(MemoryUsageCategory::GENERAL))},
-        rows_{getMemoryPool(MemoryUsageCategory::GENERAL)},
+        rows_{
+            getMemoryPool(MemoryUsageCategory::GENERAL),
+            /*initialCapacity=*/16},
         dictionaryKeySizeThreshold_{
             getConfig(Config::DICTIONARY_NUMERIC_KEY_SIZE_THRESHOLD)},
         sort_{getConfig(Config::DICTIONARY_SORT_KEYS)},
@@ -795,7 +797,9 @@ class StringColumnWriter : public BaseColumnWriter {
         dictEncoder_{
             getMemoryPool(MemoryUsageCategory::DICTIONARY),
             getMemoryPool(MemoryUsageCategory::GENERAL)},
-        rows_{getMemoryPool(MemoryUsageCategory::GENERAL)},
+        rows_{
+            getMemoryPool(MemoryUsageCategory::GENERAL),
+            /*initialCapacity=*/16},
         encodingSelector_{
             getMemoryPool(MemoryUsageCategory::GENERAL),
             getConfig(Config::DICTIONARY_STRING_KEY_SIZE_THRESHOLD),


### PR DESCRIPTION
Summary:
Currently, all potentially dictionary encodable types carry a chain buffer used for dictionary encoding writes. The chain buffer should ideally be lazily initialized, but currently it eagerly initialize to the default capacity 1024 items. This is less beneficial now in workloads as the memory reallocation cost for small allocations are optimized by the velox memory allocator and jemalloc. 

The wasted capacity really stacks up especially for flat map columns - by default we don't enable dictionary encoding on them but still allocates the 1024 uint32_t items per key, of which a single map may have ~20k-30k. This materializes in 80MB-120MB wasted memory footprint per flat map column.

This diff minimizes this footprint. A more proper change can be made later to give chain buffers lazy semantics.

Differential Revision: D56056774


