### PR TITLE
Fix segfault in TableScanBuilder

### DIFF
--- a/velox/exec/tests/PlanBuilderTest.cpp
+++ b/velox/exec/tests/PlanBuilderTest.cpp
@@ -239,4 +239,11 @@ TEST_F(PlanBuilderTest, windowFrame) {
           .planNode(),
       "Window frame of type RANGE PRECEDING or FOLLOWING requires single sorting key in ORDER BY");
 }
+
+TEST_F(PlanBuilderTest, missingOutputType) {
+  VELOX_ASSERT_THROW(
+      PlanBuilder().startTableScan().endTableScan(),
+      "outputType must be specified");
+}
+
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -135,6 +135,7 @@ PlanBuilder& PlanBuilder::tpchTableScan(
 }
 
 core::PlanNodePtr PlanBuilder::TableScanBuilder::build(core::PlanNodeId id) {
+  VELOX_CHECK_NOT_NULL(outputType_, "outputType must be specified");
   std::unordered_map<std::string, core::TypedExprPtr> typedMapping;
   bool hasAssignments = !(assignments_.empty());
   for (uint32_t i = 0; i < outputType_->size(); ++i) {

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -160,6 +160,10 @@ class PlanBuilder {
   /// Helper class to build a custom TableScanNode.
   /// Uses a planBuilder instance to get the next plan id, memory pool, and
   /// parse options.
+  ///
+  /// Uses the hive connector by default. Specify outputType, tableHandle, and
+  /// assignments for other connectors. If these three are specified, all other
+  /// builder arguments will be ignored.
   class TableScanBuilder {
    public:
     TableScanBuilder(PlanBuilder& builder) : planBuilder_(builder) {}
@@ -177,6 +181,7 @@ class PlanBuilder {
     }
 
     /// @param outputType List of column names and types to read from the table.
+    /// This property is required.
     TableScanBuilder& outputType(RowTypePtr outputType) {
       outputType_ = std::move(outputType);
       return *this;


### PR DESCRIPTION
Add a check on the outputType parameter of the TableScanBuilder so that it fails with a
meaningful exception instead of dereferencing a null pointer.