### PR TITLE
Fix the Window operator with overflowed empty k-rows frames

### DIFF
--- a/velox/functions/prestosql/window/tests/AggregateWindowTest.cpp
+++ b/velox/functions/prestosql/window/tests/AggregateWindowTest.cpp
@@ -349,6 +349,43 @@ TEST_F(AggregateWindowTest, integerOverflowRowsFrame) {
        makeFlatVector<int64_t>({6, 6, 6, 6, 6, 6, 4, 4, 4, 4})});
   WindowTestBase::testWindowFunction(
       {input}, "count(c1)", overClause, frameClause, expected);
+
+  // Empty frame with overflowed frame end.
+  input = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3, 4}),
+      makeConstant<int64_t>(30000000000, 4),
+  });
+  expected = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3, 4}),
+      makeConstant<int64_t>(30000000000, 4),
+      makeNullConstant(TypeKind::BIGINT, 4),
+  });
+  WindowTestBase::testWindowFunction(
+      {input},
+      "sum(c0)",
+      "",
+      "rows between unbounded preceding and 30000000000 preceding",
+      expected);
+  WindowTestBase::testWindowFunction(
+      {input},
+      "sum(c0)",
+      "",
+      "rows between unbounded preceding and c1 preceding",
+      expected);
+
+  // Empty frame with overflowed frame start.
+  WindowTestBase::testWindowFunction(
+      {input},
+      "sum(c0)",
+      "",
+      "rows between 30000000000 following and unbounded following",
+      expected);
+  WindowTestBase::testWindowFunction(
+      {input},
+      "sum(c0)",
+      "",
+      "rows between c1 following and unbounded following",
+      expected);
 }
 
 }; // namespace


### PR DESCRIPTION
Summary:
The boundaries of Window frames are int32 integers. When the frame 
boundaries given in the query exceed int32 limit, the Window 
operator needs to adjust the frame bounds. However, the current 
code has a bug that when the frame end is below INT32_MIN, it 
adjust the frame end to 0. This is wrong because the original frame is 
empty, but after the adjustment, it always include row 0. This diff fixes 
this bug by setting the frame bound to -1 when the frame bound 
belows INT32_MIN. A subsequent call to computeValidFrames will 
check whether this frame is empty and mark it properly.

This diff fixes https://github.com/facebookincubator/velox/issues/9375.

Differential Revision: D56085211


