### PR TITLE
Put table scan in suspensions state when get output

### DIFF
--- a/velox/common/file/CMakeLists.txt
+++ b/velox/common/file/CMakeLists.txt
@@ -20,6 +20,6 @@ target_link_libraries(
   PUBLIC velox_exception Folly::folly
   PRIVATE velox_common_base fmt::fmt glog::glog)
 
-if(${VELOX_BUILD_TESTING})
+if(${VELOX_BUILD_TESTING} OR ${VELOX_BUILD_TEST_UTILS})
   add_subdirectory(tests)
 endif()

--- a/velox/common/file/tests/FaultyFile.cpp
+++ b/velox/common/file/tests/FaultyFile.cpp
@@ -18,6 +18,19 @@
 
 namespace facebook::velox::tests::utils {
 
+std::string FaultFileOperation::typeString(Type type) {
+  switch (type) {
+    case Type::kReadv:
+      return "READV";
+    case Type::kRead:
+      return "READ";
+    default:
+      VELOX_UNSUPPORTED(
+          "Unknown file operation type: {}", static_cast<int>(type));
+      break;
+  }
+}
+
 FaultyReadFile::FaultyReadFile(
     const std::string& path,
     std::shared_ptr<ReadFile> delegatedFile,

--- a/velox/common/file/tests/FaultyFile.h
+++ b/velox/common/file/tests/FaultyFile.h
@@ -29,6 +29,7 @@ struct FaultFileOperation {
     /// TODO: add to support fault injections for the other file operation
     /// types.
   };
+  static std::string typeString(Type type);
 
   const Type type;
 
@@ -44,6 +45,12 @@ struct FaultFileOperation {
   FaultFileOperation(Type _type, const std::string& _path)
       : type(_type), path(_path) {}
 };
+
+FOLLY_ALWAYS_INLINE std::ostream& operator<<(
+    std::ostream& o,
+    const FaultFileOperation::Type& type) {
+  return o << FaultFileOperation::typeString(type);
+}
 
 /// Fault injection parameters for file read API.
 struct FaultFileReadOperation : FaultFileOperation {

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -143,7 +143,7 @@ class FakeMemoryOperator : public Operator {
       override {
     VELOX_CHECK(canReclaim());
     auto* driver = operatorCtx_->driver();
-    VELOX_CHECK(!driver->state().isOnThread() || driver->state().isSuspended);
+    VELOX_CHECK(!driver->state().isOnThread() || driver->state().suspended());
     VELOX_CHECK(driver->task()->pauseRequested());
     VELOX_CHECK_GT(targetBytes, 0);
 

--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -49,8 +49,8 @@ HiveDataSource::HiveDataSource(
   // Column handled keyed on the column alias, the name used in the query.
   for (const auto& [canonicalizedName, columnHandle] : columnHandles) {
     auto handle = std::dynamic_pointer_cast<HiveColumnHandle>(columnHandle);
-    VELOX_CHECK(
-        handle != nullptr,
+    VELOX_CHECK_NOT_NULL(
+        handle,
         "ColumnHandle must be an instance of HiveColumnHandle for {}",
         canonicalizedName);
 
@@ -67,7 +67,7 @@ HiveDataSource::HiveDataSource(
   auto readerRowTypes = outputType_->children();
   folly::F14FastMap<std::string, std::vector<const common::Subfield*>>
       subfields;
-  for (auto& outputName : outputType_->names()) {
+  for (const auto& outputName : outputType_->names()) {
     auto it = columnHandles.find(outputName);
     VELOX_CHECK(
         it != columnHandles.end(),
@@ -86,9 +86,8 @@ HiveDataSource::HiveDataSource(
   }
 
   hiveTableHandle_ = std::dynamic_pointer_cast<HiveTableHandle>(tableHandle);
-  VELOX_CHECK(
-      hiveTableHandle_ != nullptr,
-      "TableHandle must be an instance of HiveTableHandle");
+  VELOX_CHECK_NOT_NULL(
+      hiveTableHandle_, "TableHandle must be an instance of HiveTableHandle");
   if (hiveConfig_->isFileColumnNamesReadAsLowerCase(
           connectorQueryCtx->sessionProperties())) {
     checkColumnNameLowerCase(outputType_);
@@ -97,7 +96,7 @@ HiveDataSource::HiveDataSource(
   }
 
   SubfieldFilters filters;
-  for (auto& [k, v] : hiveTableHandle_->subfieldFilters()) {
+  for (const auto& [k, v] : hiveTableHandle_->subfieldFilters()) {
     filters.emplace(k.clone(), v->clone());
   }
   double sampleRate = 1;

--- a/velox/connectors/hive/HiveDataSource.h
+++ b/velox/connectors/hive/HiveDataSource.h
@@ -140,6 +140,7 @@ class HiveDataSource : public DataSource {
 
   // The row type for the data source output, not including filter-only columns
   const RowTypePtr outputType_;
+  core::ExpressionEvaluator* const expressionEvaluator_;
 
   // Column handles for the Split info columns keyed on their column names.
   std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>
@@ -149,7 +150,6 @@ class HiveDataSource : public DataSource {
   RowVectorPtr emptyOutput_;
   dwio::common::RuntimeStatistics runtimeStats_;
   std::atomic<uint64_t> totalRemainingFilterTime_{0};
-  core::ExpressionEvaluator* expressionEvaluator_;
   uint64_t completedRows_ = 0;
 
   // Reusable memory for remaining filter evaluation.

--- a/velox/connectors/hive/TableHandle.cpp
+++ b/velox/connectors/hive/TableHandle.cpp
@@ -73,8 +73,8 @@ std::string HiveColumnHandle::toString() const {
       columnTypeName(columnType_),
       dataType_->toString());
   out << " requiredSubfields: [";
-  for (const auto& s : requiredSubfields_) {
-    out << " " << s.toString();
+  for (const auto& subfield : requiredSubfields_) {
+    out << " " << subfield.toString();
   }
   out << " ]]";
   return out.str();

--- a/velox/connectors/hive/TableHandle.h
+++ b/velox/connectors/hive/TableHandle.h
@@ -69,20 +69,20 @@ class HiveColumnHandle : public ColumnHandle {
     return hiveType_;
   }
 
-  // Applies to columns of complex types: arrays, maps and structs.  When a
-  // query uses only some of the subfields, the engine provides the complete
-  // list of required subfields and the connector is free to prune the rest.
-  //
-  // Examples:
-  //  - SELECT a[1], b['x'], x.y FROM t
-  //  - SELECT a FROM t WHERE b['y'] > 10
-  //
-  // Pruning a struct means populating some of the members with null values.
-  //
-  // Pruning a map means dropping keys not listed in the required subfields.
-  //
-  // Pruning arrays means dropping values with indices larger than maximum
-  // required index.
+  /// Applies to columns of complex types: arrays, maps and structs.  When a
+  /// query uses only some of the subfields, the engine provides the complete
+  /// list of required subfields and the connector is free to prune the rest.
+  ///
+  /// Examples:
+  ///  - SELECT a[1], b['x'], x.y FROM t
+  ///  - SELECT a FROM t WHERE b['y'] > 10
+  ///
+  /// Pruning a struct means populating some of the members with null values.
+  ///
+  /// Pruning a map means dropping keys not listed in the required subfields.
+  ///
+  /// Pruning arrays means dropping values with indices larger than maximum
+  /// required index.
   const std::vector<common::Subfield>& requiredSubfields() const {
     return requiredSubfields_;
   }

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -197,7 +197,7 @@ void BlockingState::setResume(std::shared_ptr<BlockingState> state) {
           state->operator_->recordBlockingTime(
               state->sinceMicros_, state->reason_);
         }
-        VELOX_CHECK(!driver->state().isSuspended);
+        VELOX_CHECK(!driver->state().suspended());
         VELOX_CHECK(driver->state().hasBlockingFuture);
         driver->state().hasBlockingFuture = false;
         if (task->pauseRequested()) {
@@ -1007,7 +1007,10 @@ SuspendedSection::SuspendedSection(Driver* driver) : driver_(driver) {
 
 SuspendedSection::~SuspendedSection() {
   if (driver_->task()->leaveSuspended(driver_->state()) != StopReason::kNone) {
-    VELOX_FAIL("Terminate detected when leaving suspended section");
+    LOG(WARNING)
+        << "Terminate detected when leaving suspended section for driver "
+        << driver_->driverCtx()->driverId << " from task "
+        << driver_->task()->taskId();
   }
 }
 

--- a/velox/exec/MemoryReclaimer.cpp
+++ b/velox/exec/MemoryReclaimer.cpp
@@ -70,7 +70,7 @@ void memoryArbitrationStateCheck(memory::MemoryPool& pool) {
   const auto* driverThreadCtx = driverThreadContext();
   if (driverThreadCtx != nullptr) {
     Driver* driver = driverThreadCtx->driverCtx.driver;
-    if (!driver->state().isSuspended) {
+    if (!driver->state().suspended()) {
       VELOX_FAIL(
           "Driver thread is not suspended under memory arbitration processing: {}, request memory pool: {}",
           driver->toString(),

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -624,11 +624,11 @@ uint64_t Operator::MemoryReclaimer::reclaim(
   }
   VELOX_CHECK_EQ(pool->name(), op_->pool()->name());
   VELOX_CHECK(
-      !driver->state().isOnThread() || driver->state().isSuspended ||
+      !driver->state().isOnThread() || driver->state().suspended() ||
           driver->state().isTerminated,
       "driverOnThread {}, driverSuspended {} driverTerminated {} {}",
       driver->state().isOnThread(),
-      driver->state().isSuspended,
+      driver->state().suspended(),
       driver->state().isTerminated,
       pool->name());
   VELOX_CHECK(driver->task()->pauseRequested());
@@ -670,10 +670,10 @@ void Operator::MemoryReclaimer::abort(
   }
   VELOX_CHECK_EQ(pool->name(), op_->pool()->name());
   VELOX_CHECK(
-      !driver->state().isOnThread() || driver->state().isSuspended ||
+      !driver->state().isOnThread() || driver->state().suspended() ||
       driver->state().isTerminated);
   VELOX_CHECK(driver->task()->isCancelled());
-  if (driver->state().isOnThread() && driver->state().isSuspended) {
+  if (driver->state().isOnThread() && driver->state().suspended()) {
     // We can't abort an operator if it is running on a driver thread and
     // suspended for memory arbitration. Otherwise, it might cause random crash
     // when the driver thread throws after detects the aborted query.

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -57,7 +57,28 @@ folly::dynamic TableScan::toJson() const {
   return ret;
 }
 
+bool TableScan::shouldYield(StopReason taskStopReason, size_t startTimeMs)
+    const {
+  // Checks task-level yield signal, driver-level yield signal and table scan
+  // output processing time limit.
+  //
+  // NOTE: if the task is being paused, then we shall continue execution as we
+  // won't yield the driver thread but simply spinning (with on-thread time
+  // sleep) until the task has been resumed.
+  return (taskStopReason == StopReason::kYield ||
+          driverCtx_->driver->shouldYield() ||
+          ((getOutputTimeLimitMs_ != 0) &&
+           (getCurrentTimeMs() - startTimeMs) >= getOutputTimeLimitMs_)) &&
+      !driverCtx_->task->pauseRequested();
+}
+
+bool TableScan::shouldStop(StopReason taskStopReason) const {
+  return taskStopReason != StopReason::kNone &&
+      taskStopReason != StopReason::kYield;
+}
+
 RowVectorPtr TableScan::getOutput() {
+  SuspendedSection suspendedSection(driverCtx_->driver);
   auto exitCurStatusGuard = folly::makeGuard([this]() { curStatus_ = ""; });
 
   if (noMoreSplits_) {
@@ -72,9 +93,9 @@ RowVectorPtr TableScan::getOutput() {
       // w/o producing a result. In this case we return with the Yield blocking
       // reason and an already fulfilled future.
       curStatus_ = "getOutput: task->shouldStop";
-      if ((driverCtx_->task->shouldStop() != StopReason::kNone) ||
-          ((getOutputTimeLimitMs_ != 0) &&
-           (getCurrentTimeMs() - startTimeMs) >= getOutputTimeLimitMs_)) {
+      const StopReason taskStopReason = driverCtx_->task->shouldStop();
+      if (shouldStop(taskStopReason) ||
+          shouldYield(taskStopReason, startTimeMs)) {
         blockingReason_ = BlockingReason::kYield;
         blockingFuture_ = ContinueFuture{folly::Unit{}};
         // A point for test code injection.
@@ -137,7 +158,7 @@ RowVectorPtr TableScan::getOutput() {
           connectorSplit->connectorId,
           "Got splits with different connector IDs");
 
-      if (!dataSource_) {
+      if (dataSource_ == nullptr) {
         curStatus_ = "getOutput: creating dataSource_";
         connectorQueryCtx_ = operatorCtx_->createConnectorQueryCtx(
             connectorSplit->connectorId, planNodeId(), connectorPool_);
@@ -162,7 +183,7 @@ RowVectorPtr TableScan::getOutput() {
            },
            &debugString_});
 
-      if (connectorSplit->dataSource) {
+      if (connectorSplit->dataSource != nullptr) {
         curStatus_ = "getOutput: preloaded split";
         ++numPreloadedSplits_;
         // The AsyncSource returns a unique_ptr to a shared_ptr. The unique_ptr

--- a/velox/exec/TableScan.h
+++ b/velox/exec/TableScan.h
@@ -57,6 +57,14 @@ class TableScan : public SourceOperator {
   }
 
  private:
+  // Checks if this table scan operator needs to yield before processing the
+  // next split.
+  bool shouldYield(StopReason taskStopReason, size_t startTimeMs) const;
+
+  // Checks if this table scan operator needs to stop because the task has been
+  // terminated.
+  bool shouldStop(StopReason taskStopReason) const;
+
   // Sets 'maxPreloadSplits' and 'splitPreloader' if prefetching splits is
   // appropriate. The preloader will be applied to the 'first 'maxPreloadSplits'
   // of the Task's split queue for 'this' when getting splits.

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -316,7 +316,7 @@ uint64_t TableWriter::ConnectorReclaimer::reclaim(
     return 0;
   }
   VELOX_CHECK(
-      !driver->state().isOnThread() || driver->state().isSuspended ||
+      !driver->state().isOnThread() || driver->state().suspended() ||
       driver->state().isTerminated);
   VELOX_CHECK(driver->task()->pauseRequested());
 

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -861,7 +861,7 @@ void Task::resume(std::shared_ptr<Task> self) {
     if (self->isRunningLocked()) {
       for (auto& driver : self->drivers_) {
         if (driver != nullptr) {
-          if (driver->state().isSuspended) {
+          if (driver->state().suspended()) {
             // The Driver will come on thread in its own time as long as
             // the cancel flag is reset. This check needs to be inside 'mutex_'.
             continue;
@@ -2121,7 +2121,7 @@ Task::DriverCounts Task::driverCounts() const {
     if (driver) {
       if (driver->state().isEnqueued) {
         ++ret.numQueuedDrivers;
-      } else if (driver->state().isSuspended) {
+      } else if (driver->state().suspended()) {
         ++ret.numSuspendedDrivers;
       } else if (driver->isOnThread()) {
         ++ret.numOnThreadDrivers;
@@ -2513,6 +2513,7 @@ StopReason Task::enterSuspended(ThreadState& state) {
       promise.setValue();
     }
   });
+
   std::lock_guard<std::timed_mutex> l(mutex_);
   if (state.isTerminated) {
     return StopReason::kAlreadyTerminated;
@@ -2529,10 +2530,15 @@ StopReason Task::enterSuspended(ThreadState& state) {
           reason == StopReason::kYield,
       "Unexpected stop reason on suspension: {}",
       reason);
-  state.isSuspended = true;
+  if (++state.numSuspensions > 1) {
+    // Only the first suspension request needs to update the running driver
+    // thread counter in the task.
+    return StopReason::kNone;
+  }
   if (--numThreads_ == 0) {
     threadFinishPromises = allThreadsFinishedLocked();
   }
+  VELOX_CHECK_GE(numThreads_, 0);
   return StopReason::kNone;
 }
 
@@ -2543,8 +2549,15 @@ StopReason Task::leaveSuspended(ThreadState& state) {
   for (;;) {
     {
       std::lock_guard<std::timed_mutex> l(mutex_);
-      ++numThreads_;
-      state.isSuspended = false;
+      VELOX_CHECK_GT(state.numSuspensions, 0);
+      auto leaveGuard = folly::makeGuard([&]() {
+        VELOX_CHECK_GE(numThreads_, 0);
+        if (--state.numSuspensions == 0) {
+          // Only the last suspension leave needs to update the running driver
+          // thread counter in the task
+          ++numThreads_;
+        }
+      });
       if (state.isTerminated) {
         return StopReason::kAlreadyTerminated;
       }
@@ -2552,12 +2565,14 @@ StopReason Task::leaveSuspended(ThreadState& state) {
         state.isTerminated = true;
         return StopReason::kTerminate;
       }
-      if (!pauseRequested_) {
-        // For yield or anything but pause we return here.
+      if (state.numSuspensions > 1 || !pauseRequested_) {
+        // If we have more than one suspension requests on this driver thread or
+        // the task has been resumed, then we return here.
         return StopReason::kNone;
       }
-      --numThreads_;
-      state.isSuspended = true;
+      VELOX_CHECK_GT(state.numSuspensions, 0);
+      VELOX_CHECK_GE(numThreads_, 0);
+      leaveGuard.dismiss();
     }
     // If the pause flag is on when trying to reenter, sleep a while outside of
     // the mutex and recheck. This is rare and not time critical. Can happen if

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -632,6 +632,11 @@ class Task : public std::enable_shared_from_this<Task> {
     return numDriversInPartitionedOutput_ > 0;
   }
 
+  void testingIncrementThreads() {
+    std::lock_guard l(mutex_);
+    ++numThreads_;
+  }
+
   /// Invoked to run provided 'callback' on each alive driver of the task.
   void testingVisitDrivers(const std::function<void(Driver*)>& callback);
 

--- a/velox/exec/tests/MemoryReclaimerTest.cpp
+++ b/velox/exec/tests/MemoryReclaimerTest.cpp
@@ -64,19 +64,20 @@ TEST_F(MemoryReclaimerTest, enterArbitrationTest) {
     auto reclaimer = exec::MemoryReclaimer::create();
     auto driver = Driver::testingCreate(
         std::make_unique<DriverCtx>(fakeTask_, 0, 0, 0, 0));
+    fakeTask_->testingIncrementThreads();
     if (underDriverContext) {
       driver->state().setThread();
       ScopedDriverThreadContext scopedDriverThreadCtx{*driver->driverCtx()};
       reclaimer->enterArbitration();
       ASSERT_TRUE(driver->state().isOnThread());
-      ASSERT_TRUE(driver->state().isSuspended);
+      ASSERT_TRUE(driver->state().suspended());
       reclaimer->leaveArbitration();
       ASSERT_TRUE(driver->state().isOnThread());
-      ASSERT_FALSE(driver->state().isSuspended);
+      ASSERT_FALSE(driver->state().suspended());
     } else {
       reclaimer->enterArbitration();
       ASSERT_FALSE(driver->state().isOnThread());
-      ASSERT_FALSE(driver->state().isSuspended);
+      ASSERT_FALSE(driver->state().suspended());
       reclaimer->leaveArbitration();
     }
   }

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -15,8 +15,12 @@
  */
 #include "velox/exec/TableScan.h"
 #include <atomic>
+#include "folly/experimental/EventCount.h"
 #include "velox/common/base/Fs.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/file/tests/FaultyFile.h"
+#include "velox/common/file/tests/FaultyFileSystem.h"
+#include "velox/common/memory/MemoryArbitrator.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnector.h"
@@ -29,6 +33,7 @@
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/LocalExchangeSource.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
 #include "velox/expression/ExprToSubfieldFilter.h"
 #include "velox/type/Timestamp.h"
 #include "velox/type/Type.h"
@@ -40,6 +45,7 @@ using namespace facebook::velox::core;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::common::test;
 using namespace facebook::velox::exec::test;
+using namespace facebook::velox::tests::utils;
 
 namespace {
 void verifyCacheStats(
@@ -108,6 +114,20 @@ class TableScanTest : public virtual HiveConnectorTestBase {
         .config(
             core::QueryConfig::kMaxSplitPreloadPerDriver,
             std::to_string(numPrefetchSplit))
+        .splits(makeHiveConnectorSplits(filePaths))
+        .assertResults(duckDbSql);
+  }
+
+  // Run query with spill enabled.
+  std::shared_ptr<Task> assertQuery(
+      const PlanNodePtr& plan,
+      const std::vector<std::shared_ptr<TempFilePath>>& filePaths,
+      const std::string& spillDirectory,
+      const std::string& duckDbSql) {
+    return AssertQueryBuilder(plan, duckDbQueryRunner_)
+        .spillDirectory(spillDirectory)
+        .config(core::QueryConfig::kSpillEnabled, true)
+        .config(core::QueryConfig::kAggregationSpillEnabled, true)
         .splits(makeHiveConnectorSplits(filePaths))
         .assertResults(duckDbSql);
   }
@@ -4066,4 +4086,114 @@ TEST_F(TableScanTest, partitionKeyNotMatchPartitionKeysHandle) {
                 .planNode();
 
   assertQuery(op, split, "SELECT c0 FROM tmp");
+}
+
+TEST_F(TableScanTest, memoryArbitrationWithSlowTableScan) {
+  const size_t numFiles{2};
+  std::vector<std::shared_ptr<TempFilePath>> filePaths;
+  std::vector<RowVectorPtr> vectorsForDuckDb;
+  filePaths.reserve(numFiles);
+  vectorsForDuckDb.reserve(numFiles);
+  for (auto i = 0; i < numFiles; ++i) {
+    auto vectors = makeVectors(5, 128);
+    filePaths.emplace_back(TempFilePath::create(true));
+    writeToFile(filePaths.back()->path, vectors);
+    for (const auto& vector : vectors) {
+      vectorsForDuckDb.emplace_back(vector);
+    }
+  }
+  createDuckDbTable(vectorsForDuckDb);
+
+  std::atomic_bool readWaitFlag{true};
+  folly::EventCount readWait;
+  std::atomic_bool readResumeFlag{true};
+  folly::EventCount readResume;
+
+  auto faultyFs = faultyFileSystem();
+  std::atomic_bool injectOnce{true};
+  faultyFs->setFileInjectionHook([&](FaultFileOperation* readOp) {
+    // Inject memory arbitration at the second read file so as to make sure the
+    // aggregation has accumulated state to spill.
+    if (readOp->path != filePaths.back()->getPath()) {
+      return;
+    }
+    if (!injectOnce.exchange(false)) {
+      return;
+    }
+    readWaitFlag = false;
+    readWait.notifyAll();
+    readResume.await([&]() { return !readResumeFlag.load(); });
+  });
+
+  // Get the number of values processed via aggregation pushdown into scan.
+  auto loadedToValueHook = [](const std::shared_ptr<Task> task,
+                              int operatorIndex = 0) {
+    auto stats = task->taskStats()
+                     .pipelineStats[0]
+                     .operatorStats[operatorIndex]
+                     .runtimeStats;
+    auto it = stats.find("loadedToValueHook");
+    return it != stats.end() ? it->second.sum : 0;
+  };
+
+  core::PlanNodeId aggNodeId;
+  auto op =
+      PlanBuilder()
+          .tableScan(rowType_)
+          .singleAggregation(
+              {"c5"}, {"max(c0)", "max(c1)", "max(c2)", "max(c3)", "max(c4)"})
+          .capturePlanNodeId(aggNodeId)
+          .planNode();
+
+  std::thread queryThread([&]() {
+    const auto spillDirectory = exec::test::TempDirectoryPath::create();
+    auto task = assertQuery(
+        op,
+        filePaths,
+        spillDirectory->getPath(),
+        "SELECT c5, max(c0), max(c1), max(c2), max(c3), max(c4) FROM tmp group by c5");
+    EXPECT_EQ(6400, loadedToValueHook(task, 1));
+    EXPECT_GT(toPlanStats(task->taskStats()).at(aggNodeId).spilledBytes, 0);
+  });
+
+  readWait.await([&]() { return !readWaitFlag.load(); });
+
+  memory::testingRunArbitration();
+
+  readResumeFlag = false;
+  readResume.notifyAll();
+
+  queryThread.join();
+}
+
+DEBUG_ONLY_TEST_F(TableScanTest, memoryArbitrationByTableScanAllocation) {
+  auto vectors = makeVectors(10, 1'000);
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), vectors);
+  createDuckDbTable(vectors);
+
+  std::atomic_bool injectOnce{true};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::memory::MemoryPoolImpl::reserveThreadSafe",
+      std::function<void(memory::MemoryPool*)>([&](memory::MemoryPool* pool) {
+        const std::string re(".*TableScan.*");
+        if (!RE2::FullMatch(pool->name(), re)) {
+          return;
+        }
+        if (!injectOnce.exchange(false)) {
+          return;
+        }
+        memory::memoryManager()->testingGrowPool(pool, 1 << 20);
+      }));
+
+  auto op =
+      PlanBuilder()
+          .tableScan(rowType_)
+          .singleAggregation(
+              {"c5"}, {"max(c0)", "max(c1)", "max(c2)", "max(c3)", "max(c4)"})
+          .planNode();
+  assertQuery(
+      op,
+      {filePath},
+      "SELECT c5, max(c0), max(c1), max(c2), max(c3), max(c4) FROM tmp group by c5");
 }

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(
   velox_dwio_dwrf_reader
   velox_dwio_dwrf_writer
   velox_dwio_common_test_utils
+  velox_file_test_utils
   velox_type_fbhive
   velox_hive_connector
   velox_tpch_connector

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -17,6 +17,7 @@
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 
 #include "velox/common/file/FileSystems.h"
+#include "velox/common/file/tests/FaultyFileSystem.h"
 #include "velox/connectors/hive/HiveDataSink.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
@@ -26,6 +27,7 @@ namespace facebook::velox::exec::test {
 
 HiveConnectorTestBase::HiveConnectorTestBase() {
   filesystems::registerLocalFileSystem();
+  tests::utils::registerFaultyFileSystem();
 }
 
 void HiveConnectorTestBase::SetUp() {

--- a/velox/expression/ExprToSubfieldFilter.cpp
+++ b/velox/expression/ExprToSubfieldFilter.cpp
@@ -67,11 +67,11 @@ bool toSubfield(const core::ITypedExpr* field, common::Subfield& subfield) {
       const auto& name = dereference->name();
       // When the field name is empty string, it typically means that the field
       // name was not set in the parent type.
-      if (name == "") {
+      if (name.empty()) {
         return false;
       }
       path.push_back(std::make_unique<common::Subfield::NestedField>(name));
-    } else if (!dynamic_cast<const core::InputTypedExpr*>(current)) {
+    } else if (dynamic_cast<const core::InputTypedExpr*>(current) == nullptr) {
       return false;
     } else {
       break;
@@ -84,7 +84,7 @@ bool toSubfield(const core::ITypedExpr* field, common::Subfield& subfield) {
       return false;
     }
     current = current->inputs()[0].get();
-    if (!current) {
+    if (current == nullptr) {
       return false;
     }
   }

--- a/velox/type/Subfield.h
+++ b/velox/type/Subfield.h
@@ -96,7 +96,8 @@ class Subfield {
   class NestedField final : public PathElement {
    public:
     explicit NestedField(const std::string& name) : name_(name) {
-      VELOX_USER_CHECK_NE(name, "", "NestedFields must have non-empty names.");
+      VELOX_USER_CHECK(
+          !name.empty(), "NestedFields must have non-empty names.");
     }
 
     SubfieldKind kind() const override {


### PR DESCRIPTION
When memory arbitrator reclaims from a query, the query might get stuck in a slow table scan
operation as remote storage access can be very slow. This can cause long tail in memory arbitration.
To optimize this, we could avoid waiting table scan operator to stop during the memory arbitration
as we anyway can't reclaim memory from a table scan operator.
This PR adds a suspended section at the start of get output processing, and continue table scan
process next split if the task has been paused instead of blocking the driver thread in a on-thread
sleep loop. To support this, we add recursive suspension request support as the table scan operator
itself might trigger memory arbitration and we need to make sure the driver suspension state and
the task running threads are handled properly. We should decrement the number of running driver
threads in the task on the first arbitration request and correspondingly, we shall increment or get the
driver out of the suspension state on the last suspension request.
This PR also refactor the yield logic a bit in table scan get output to ease maintenance.
Also add per-driver yield check in split processing loop. Unit test added to verify.