### PR TITLE
Add "get" Spark function

### DIFF
--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -102,9 +102,9 @@ Array Functions
         SELECT array_repeat(100, -1); -- []
 
 .. spark:function:: array_size(array(E)) -> integer
-    
+
         Returns the size of the array. ::
-    
+
             SELECT array_size(array(1, 2, 3)); -- 3
 
 .. spark:function:: array_sort(array(E)) -> array(E)
@@ -140,6 +140,17 @@ Array Functions
         SELECT flatten(array(array(1, 2), array(3, 4))); -- [1, 2, 3, 4]
         SELECT flatten(array(array(1, 2), array(3, NULL))); -- [1, 2, 3, NULL]
         SELECT flatten(array(array(1, 2), NULL, array(3, 4))); -- NULL
+
+.. spark:function:: get(array(E), index) -> E
+
+    Returns an element of the array at the specified 0-based index.
+    Returns NULL if index points outside of the array boundaries. ::
+
+        SELECT get(array(1, 2, 3), 0); -- 1
+        SELECT get(array(1, 2, 3), 3); -- NULL
+        SELECT get(array(1, 2, 3), -1); -- NULL
+        SELECT get(array(1, 2, 3), NULL); -- NULL
+        SELECT get(array(1, 2, NULL), 2); -- NULL
 
 .. spark:function:: in(value, array(E)) -> boolean
 

--- a/velox/functions/sparksql/ArrayGetFunction.cpp
+++ b/velox/functions/sparksql/ArrayGetFunction.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/lib/SubscriptUtil.h"
+
+namespace facebook::velox::functions::sparksql {
+
+namespace {
+
+// get(array, index) -> array[index]
+//
+// - allows negative indices for arrays (returns NULL if index < 0).
+// - allows out of bounds accesses for arrays (returns NULL if out of
+//    bounds).
+// - index starts at 0 for arrays.
+class ArrayGetFunction : public SubscriptImpl<
+                             /* allowNegativeIndices */ true,
+                             /* nullOnNegativeIndices */ true,
+                             /* allowOutOfBound */ true,
+                             /* indexStartsAtOne */ false> {
+ public:
+  explicit ArrayGetFunction() : SubscriptImpl(false) {}
+
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+    return {// array(T), integer -> T
+            exec::FunctionSignatureBuilder()
+                .typeVariable("T")
+                .returnType("T")
+                .argumentType("array(T)")
+                .argumentType("integer")
+                .build()};
+  }
+};
+} // namespace
+
+VELOX_DECLARE_VECTOR_FUNCTION(
+    udf_array_get,
+    ArrayGetFunction::signatures(),
+    std::make_unique<ArrayGetFunction>());
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/CMakeLists.txt
+++ b/velox/functions/sparksql/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_subdirectory(specialforms)
 add_library(
   velox_functions_spark
+  ArrayGetFunction.cpp
   ArraySort.cpp
   Bitwise.cpp
   Comparisons.cpp

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -342,6 +342,8 @@ void registerFunctions(const std::string& prefix) {
       makeArrayShuffleWithCustomSeed,
       getMetadataForArrayShuffle());
 
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_get, prefix + "get");
+
   // Register date functions.
   registerFunction<YearFunction, int32_t, Timestamp>({prefix + "year"});
   registerFunction<YearFunction, int32_t, Date>({prefix + "year"});

--- a/velox/functions/sparksql/tests/ArrayGetTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayGetTest.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <optional>
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::functions::test;
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class ArrayGetTest : public SparkFunctionBaseTest {
+ protected:
+  template <typename T>
+  std::optional<T> arrayGet(
+      const ArrayVectorPtr& arrayVector,
+      const std::optional<int32_t>& index) {
+    auto input =
+        makeRowVector({arrayVector, makeConstant(index, arrayVector->size())});
+    return evaluateOnce<T>("get(c0, c1)", input);
+  }
+};
+
+TEST_F(ArrayGetTest, basic) {
+  auto arrayVector = makeNullableArrayVector<int32_t>({{1, 2, std::nullopt}});
+  EXPECT_EQ(arrayGet<int32_t>(arrayVector, -1), std::nullopt);
+  EXPECT_EQ(arrayGet<int32_t>(arrayVector, 0), 1);
+  EXPECT_EQ(arrayGet<int32_t>(arrayVector, 1), 2);
+  EXPECT_EQ(arrayGet<int32_t>(arrayVector, 2), std::nullopt);
+  EXPECT_EQ(arrayGet<int32_t>(arrayVector, 3), std::nullopt);
+  EXPECT_EQ(arrayGet<int32_t>(arrayVector, std::nullopt), std::nullopt);
+}
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
   velox_functions_spark_test
   ArithmeticTest.cpp
   ArrayFlattenTest.cpp
+  ArrayGetTest.cpp
   ArrayMaxTest.cpp
   ArrayMinTest.cpp
   ArraySizeTest.cpp


### PR DESCRIPTION
Spark support `get` function since v3.4.0, the main difference compared with `element_at` is `get` is 0-based index and return null when index out of bounds.

Spark ref: https://spark.apache.org/docs/latest/api/sql/index.html#get