### PR TITLE
Add year_of_week Spark function

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -282,3 +282,10 @@ These functions support TIMESTAMP and DATE input types.
 .. spark:function:: year(x) -> integer
 
     Returns the year from ``x``.
+
+.. spark:function:: year_of_week(x) -> integer
+
+    Returns the ISO week-numbering year that ``x`` falls in. For example, 2005-01-02 is
+    part of the 53rd week of year 2004, so the result is 2004. Only supports DATE type.
+
+        SELECT year_of_week('2005-01-02'); -- 2004

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -99,6 +99,36 @@ struct WeekFunction : public InitSessionTimezone<T> {
 };
 
 template <typename T>
+struct YearOfWeekSparkFunction : public InitSessionTimezone<T> {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE int32_t computeYearOfWeek(const std::tm& dateTime) {
+    int isoWeekDay = dateTime.tm_wday == 0 ? 7 : dateTime.tm_wday;
+    // The last few days in December may belong to the next year if they are
+    // in the same week as the next January 1 and this January 1 is a Thursday
+    // or before.
+    if (UNLIKELY(
+            dateTime.tm_mon == 11 && dateTime.tm_mday >= 29 &&
+            dateTime.tm_mday - isoWeekDay >= 31 - 3)) {
+      return 1900 + dateTime.tm_year + 1;
+    }
+    // The first few days in January may belong to the last year if they are
+    // in the same week as January 1 and January 1 is a Friday or after.
+    else if (UNLIKELY(
+                 dateTime.tm_mon == 0 && dateTime.tm_mday <= 3 &&
+                 isoWeekDay - (dateTime.tm_mday - 1) >= 5)) {
+      return 1900 + dateTime.tm_year - 1;
+    } else {
+      return 1900 + dateTime.tm_year;
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE void call(int32_t& result, const arg_type<Date>& date) {
+    result = computeYearOfWeek(getDateTime(date));
+  }
+};
+
+template <typename T>
 struct UnixDateFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -99,7 +99,7 @@ struct WeekFunction : public InitSessionTimezone<T> {
 };
 
 template <typename T>
-struct YearOfWeekSparkFunction : public InitSessionTimezone<T> {
+struct YearOfWeekFunction : public InitSessionTimezone<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE int32_t computeYearOfWeek(const std::tm& dateTime) {

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -114,13 +114,12 @@ struct YearOfWeekSparkFunction : public InitSessionTimezone<T> {
     }
     // The first few days in January may belong to the last year if they are
     // in the same week as January 1 and January 1 is a Friday or after.
-    else if (UNLIKELY(
-                 dateTime.tm_mon == 0 && dateTime.tm_mday <= 3 &&
-                 isoWeekDay - (dateTime.tm_mday - 1) >= 5)) {
+    if (UNLIKELY(
+            dateTime.tm_mon == 0 && dateTime.tm_mday <= 3 &&
+            isoWeekDay - (dateTime.tm_mday - 1) >= 5)) {
       return 1900 + dateTime.tm_year - 1;
-    } else {
-      return 1900 + dateTime.tm_year;
     }
+    return 1900 + dateTime.tm_year;
   }
 
   FOLLY_ALWAYS_INLINE void call(int32_t& result, const arg_type<Date>& date) {

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -102,7 +102,9 @@ template <typename T>
 struct YearOfWeekFunction : public InitSessionTimezone<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE int32_t computeYearOfWeek(const std::tm& dateTime) {
+  FOLLY_ALWAYS_INLINE void call(int32_t& result, const arg_type<Date>& date) {
+    const auto dateTime = getDateTime(date);
+
     int isoWeekDay = dateTime.tm_wday == 0 ? 7 : dateTime.tm_wday;
     // The last few days in December may belong to the next year if they are
     // in the same week as the next January 1 and this January 1 is a Thursday
@@ -110,20 +112,18 @@ struct YearOfWeekFunction : public InitSessionTimezone<T> {
     if (UNLIKELY(
             dateTime.tm_mon == 11 && dateTime.tm_mday >= 29 &&
             dateTime.tm_mday - isoWeekDay >= 31 - 3)) {
-      return 1900 + dateTime.tm_year + 1;
+      result = 1900 + dateTime.tm_year + 1;
+      return;
     }
     // The first few days in January may belong to the last year if they are
     // in the same week as January 1 and January 1 is a Friday or after.
     if (UNLIKELY(
             dateTime.tm_mon == 0 && dateTime.tm_mday <= 3 &&
             isoWeekDay - (dateTime.tm_mday - 1) >= 5)) {
-      return 1900 + dateTime.tm_year - 1;
+      result = 1900 + dateTime.tm_year - 1;
+      return;
     }
-    return 1900 + dateTime.tm_year;
-  }
-
-  FOLLY_ALWAYS_INLINE void call(int32_t& result, const arg_type<Date>& date) {
-    result = computeYearOfWeek(getDateTime(date));
+    result = 1900 + dateTime.tm_year;
   }
 };
 

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -317,7 +317,7 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<YearFunction, int32_t, Date>({prefix + "year"});
   registerFunction<WeekFunction, int32_t, Timestamp>({prefix + "week_of_year"});
   registerFunction<WeekFunction, int32_t, Date>({prefix + "week_of_year"});
-  registerFunction<YearOfWeekSparkFunction, int32_t, Date>(
+  registerFunction<YearOfWeekFunction, int32_t, Date>(
       {prefix + "year_of_week"});
 
   registerFunction<ToUtcTimestampFunction, Timestamp, Timestamp, Varchar>(

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -317,6 +317,8 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<YearFunction, int32_t, Date>({prefix + "year"});
   registerFunction<WeekFunction, int32_t, Timestamp>({prefix + "week_of_year"});
   registerFunction<WeekFunction, int32_t, Date>({prefix + "week_of_year"});
+  registerFunction<YearOfWeekSparkFunction, int32_t, Date>(
+      {prefix + "year_of_week"});
 
   registerFunction<ToUtcTimestampFunction, Timestamp, Timestamp, Varchar>(
       {prefix + "to_utc_timestamp"});

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -968,5 +968,21 @@ TEST_F(DateTimeFunctionsTest, makeYMInterval) {
       fromYear(-178956971), "Integer overflow in make_ym_interval(-178956971)");
 }
 
+TEST_F(DateTimeFunctionsTest, yearOfWeek) {
+  const auto yearOfWeek = [&](std::optional<int32_t> date) {
+    return evaluateOnce<int64_t, int32_t>("year_of_week(c0)", {date}, {DATE()});
+  };
+  EXPECT_EQ(std::nullopt, yearOfWeek(std::nullopt));
+  EXPECT_EQ(1970, yearOfWeek(0));
+  EXPECT_EQ(1970, yearOfWeek(-1));
+  EXPECT_EQ(1969, yearOfWeek(-4));
+  EXPECT_EQ(1970, yearOfWeek(-3));
+  EXPECT_EQ(1970, yearOfWeek(365));
+  EXPECT_EQ(1970, yearOfWeek(367));
+  EXPECT_EQ(1971, yearOfWeek(368));
+  EXPECT_EQ(2005, yearOfWeek(parseDate("2006-01-01")));
+  EXPECT_EQ(2006, yearOfWeek(parseDate("2006-01-02")));
+}
+
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -970,7 +970,7 @@ TEST_F(DateTimeFunctionsTest, makeYMInterval) {
 
 TEST_F(DateTimeFunctionsTest, yearOfWeek) {
   const auto yearOfWeek = [&](std::optional<int32_t> date) {
-    return evaluateOnce<int64_t, int32_t>("year_of_week(c0)", {date}, {DATE()});
+    return evaluateOnce<int32_t, int32_t>("year_of_week(c0)", {date}, {DATE()});
   };
   EXPECT_EQ(std::nullopt, yearOfWeek(std::nullopt));
   EXPECT_EQ(1970, yearOfWeek(0));

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -972,7 +972,6 @@ TEST_F(DateTimeFunctionsTest, yearOfWeek) {
   const auto yearOfWeek = [&](std::optional<int32_t> date) {
     return evaluateOnce<int32_t, int32_t>("year_of_week(c0)", {date}, {DATE()});
   };
-  EXPECT_EQ(std::nullopt, yearOfWeek(std::nullopt));
   EXPECT_EQ(1970, yearOfWeek(0));
   EXPECT_EQ(1970, yearOfWeek(-1));
   EXPECT_EQ(1969, yearOfWeek(-4));


### PR DESCRIPTION
This is mostly copied from presto [YearOfWeek function](https://github.com/facebookincubator/velox/blob/main/velox/functions/prestosql/DateTimeFunctions.h#L594). The differences are:
1) Spark only supports Date type input.
2) The result type is int64_t for Presto, but int32_t for Spark.

See doc: https://docs.databricks.com/en/sql/language-manual/functions/extract.html