### PR TITLE
Remove allowInputShuffle_ flag in AggregationTestBase::testReadFromFiles

### DIFF
--- a/velox/docs/develop/aggregate-functions.rst
+++ b/velox/docs/develop/aggregate-functions.rst
@@ -976,8 +976,7 @@ The following query plans are being tested.
   final aggregation with forced spilling. Query runs using 4 threads.
 
 Query run with forced spilling is enabled only for group-by aggregations and
-only if `allowInputShuffle_` flag is enabled by calling allowInputShuffle
-() method from the SetUp(). Spill testing requires multiple batches of input.
+only if aggregate functions are not order-sensitive. Spill testing requires multiple batches of input.
 To split input data into multiple batches we add local exchange with
 round-robin repartitioning before the partial aggregation. This changes the order
 in which aggregation inputs are processed, hence, query results with spilling

--- a/velox/exec/tests/SimpleAggregateAdapterTest.cpp
+++ b/velox/exec/tests/SimpleAggregateAdapterTest.cpp
@@ -34,7 +34,6 @@ class SimpleAverageAggregationTest : public AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    allowInputShuffle();
 
     registerSimpleAverageAggregate(kSimpleAvg);
   }
@@ -114,7 +113,6 @@ class SimpleArrayAggAggregationTest : public AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    disallowInputShuffle();
 
     registerSimpleArrayAggAggregate(kSimpleArrayAgg);
   }

--- a/velox/functions/lib/aggregates/tests/SumTestBase.h
+++ b/velox/functions/lib/aggregates/tests/SumTestBase.h
@@ -67,7 +67,6 @@ class SumTestBase : public AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    allowInputShuffle();
   }
 
   template <

--- a/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h
+++ b/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h
@@ -220,17 +220,6 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
       const std::string& expectedMessage,
       const std::unordered_map<std::string, std::string>& config = {});
 
-  /// Specifies that aggregate functions used in this test are not sensitive
-  /// to the order of inputs.
-  void allowInputShuffle() {
-    allowInputShuffle_ = true;
-  }
-  /// Specifies that aggregate functions used in this test are sensitive
-  /// to the order of inputs.
-  void disallowInputShuffle() {
-    allowInputShuffle_ = false;
-  }
-
   void disableTestStreaming() {
     testStreaming_ = false;
   }
@@ -296,8 +285,6 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
       std::function<std::shared_ptr<exec::Task>(
           exec::test::AssertQueryBuilder&)> assertResults,
       const std::unordered_map<std::string, std::string>& config);
-
-  bool allowInputShuffle_{false};
 };
 
 } // namespace facebook::velox::functions::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/ApproxMostFrequentTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxMostFrequentTest.cpp
@@ -27,7 +27,6 @@ struct ApproxMostFrequentTest : AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    allowInputShuffle();
   }
 
   std::shared_ptr<FlatVector<int>> makeGroupKeys() {

--- a/velox/functions/prestosql/aggregates/tests/ApproxPercentileTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxPercentileTest.cpp
@@ -87,7 +87,6 @@ class ApproxPercentileTest : public AggregationTestBase {
   void SetUp() override {
     AggregationTestBase::SetUp();
     random::setSeed(0);
-    allowInputShuffle();
   }
 
   template <typename T>

--- a/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
@@ -33,7 +33,6 @@ class AverageAggregationTest : public AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    allowInputShuffle();
 
     registerSimpleAverageAggregate("simple_avg");
   }

--- a/velox/functions/prestosql/aggregates/tests/BitwiseAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/BitwiseAggregationTest.cpp
@@ -27,7 +27,6 @@ class BitwiseAggregationTest : public AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    allowInputShuffle();
   }
 
   RowTypePtr rowType_{

--- a/velox/functions/prestosql/aggregates/tests/BoolAndOrTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/BoolAndOrTest.cpp
@@ -38,7 +38,6 @@ class BoolAndOrTest : public virtual AggregationTestBase,
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    allowInputShuffle();
   }
 };
 

--- a/velox/functions/prestosql/aggregates/tests/CentralMomentsAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/CentralMomentsAggregationTest.cpp
@@ -29,7 +29,6 @@ class CentralMomentsAggregationTest
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    allowInputShuffle();
   }
 
   void testGroupBy(

--- a/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
@@ -31,7 +31,6 @@ class ChecksumAggregateTest : public AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    allowInputShuffle();
   }
 
   template <typename T>

--- a/velox/functions/prestosql/aggregates/tests/CountAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/CountAggregationTest.cpp
@@ -29,7 +29,6 @@ class CountAggregationTest : public AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    allowInputShuffle();
   }
 
   RowTypePtr rowType_{

--- a/velox/functions/prestosql/aggregates/tests/CountDistinctTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/CountDistinctTest.cpp
@@ -31,7 +31,6 @@ class CountDistinctTest : public AggregationTestBase {
   void SetUp() override {
     prestosql::registerInternalAggregateFunctions("");
     AggregationTestBase::SetUp();
-    allowInputShuffle();
   }
 };
 

--- a/velox/functions/prestosql/aggregates/tests/CountIfAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/CountIfAggregationTest.cpp
@@ -26,7 +26,6 @@ class CountIfAggregationTest : public AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    allowInputShuffle();
   }
 
   RowTypePtr rowType_{

--- a/velox/functions/prestosql/aggregates/tests/CovarianceAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/CovarianceAggregationTest.cpp
@@ -28,7 +28,6 @@ class CovarianceAggregationTest
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    allowInputShuffle();
   }
 
   void testGroupBy(const std::string& aggName, const RowVectorPtr& data) {

--- a/velox/functions/prestosql/aggregates/tests/EntropyAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/EntropyAggregationTest.cpp
@@ -29,7 +29,6 @@ class EntropyAggregationTest : public AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    allowInputShuffle();
   }
 
   void testGroupByAgg(

--- a/velox/functions/prestosql/aggregates/tests/GeometricMeanTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/GeometricMeanTest.cpp
@@ -30,7 +30,6 @@ class GeometricMeanTest : public AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    allowInputShuffle();
   }
 };
 

--- a/velox/functions/prestosql/aggregates/tests/HistogramTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/HistogramTest.cpp
@@ -31,7 +31,6 @@ class HistogramTest : public AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    allowInputShuffle();
   }
 
   void testHistogramWithDuck(

--- a/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
@@ -125,8 +125,6 @@ TEST_F(MapAggTest, groupByWithNullValues) {
 }
 
 TEST_F(MapAggTest, groupByWithDuplicates) {
-  disallowInputShuffle();
-
   auto data = makeRowVector({
       makeFlatVector<int32_t>({0, 0, 1, 1, 2, 2, 3, 3, 4, 4}),
       makeFlatVector<int32_t>({0, 0, 1, 1, 2, 2, 3, 3, 4, 4}),

--- a/velox/functions/prestosql/aggregates/tests/MaxSizeForStatsTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MaxSizeForStatsTest.cpp
@@ -27,7 +27,6 @@ class MaxSizeForStatsTest : public AggregationTestBase {
  public:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    allowInputShuffle();
   }
 };
 

--- a/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -325,7 +325,6 @@ std::string asSql(bool value) {
 
 void MinMaxByAggregationTestBase::SetUp() {
   AggregationTestBase::SetUp();
-  AggregationTestBase::disallowInputShuffle();
   std::vector<TypePtr> supportedTypes;
   std::vector<std::string> columnNames;
   int columnId = 0;
@@ -647,8 +646,6 @@ TEST_P(
   }
 
   // Enable disk spilling test with distinct comparison values.
-  AggregationTestBase::allowInputShuffle();
-
   auto rowType =
       ROW({"c0", "c1"},
           {createScalarType(GetParam().valueType),
@@ -1083,8 +1080,6 @@ TEST_P(
   }
 
   // Enable disk spilling test with distinct comparison values.
-  AggregationTestBase::allowInputShuffle();
-
   auto rowType =
       ROW({"c0", "c1", "c2"},
           {createScalarType(GetParam().valueType),
@@ -1387,7 +1382,6 @@ class MinMaxByNTest : public AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    AggregationTestBase::allowInputShuffle();
     AggregationTestBase::enableTestStreaming();
   }
 };

--- a/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
@@ -34,7 +34,6 @@ class MinMaxTest : public functions::aggregate::test::AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    allowInputShuffle();
   }
 
   std::vector<RowVectorPtr> fuzzData(const RowTypePtr& rowType) {
@@ -474,7 +473,6 @@ class MinMaxNTest : public functions::aggregate::test::AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    allowInputShuffle();
   }
 
   template <typename T>

--- a/velox/functions/prestosql/aggregates/tests/MultiMapAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MultiMapAggTest.cpp
@@ -23,7 +23,6 @@ class MultiMapAggTest : public functions::aggregate::test::AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    allowInputShuffle();
   }
 };
 

--- a/velox/functions/prestosql/aggregates/tests/ReduceAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ReduceAggTest.cpp
@@ -28,7 +28,6 @@ class ReduceAggTest : public functions::aggregate::test::AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    allowInputShuffle();
     disableTestStreaming();
   }
 

--- a/velox/functions/prestosql/aggregates/tests/SetAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SetAggTest.cpp
@@ -35,7 +35,6 @@ class SetAggTest : public AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    allowInputShuffle();
   }
 };
 

--- a/velox/functions/prestosql/aggregates/tests/SetUnionTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SetUnionTest.cpp
@@ -33,7 +33,6 @@ class SetUnionTest : public AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    allowInputShuffle();
   }
 };
 

--- a/velox/functions/prestosql/aggregates/tests/SumDataSizeForStatsTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SumDataSizeForStatsTest.cpp
@@ -27,7 +27,6 @@ class SumDataSizeForStatsTest : public AggregationTestBase {
  public:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    allowInputShuffle();
   }
 };
 

--- a/velox/functions/prestosql/aggregates/tests/VarianceAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/VarianceAggregationTest.cpp
@@ -41,7 +41,6 @@ class VarianceAggregationTest : public AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    allowInputShuffle();
   }
 
   RowTypePtr rowType_{
@@ -159,8 +158,7 @@ TEST_F(VarianceAggregationTest, varianceNulls) {
 // when inputs are very large integers (> 15 digits long). Unfortunately
 // makeVectors() generates data that contains a lot of very large integers.
 // Replace makeVectors() with a dataset that doesn't contain very large
-// integers and enable more testing by calling allowInputShuffle() from
-// Setup().
+// integers and enable more testing.
 TEST_F(VarianceAggregationTest, varianceWithGlobalAggregation) {
   auto vectors = makeVectors(rowType_, 10, 20);
   createDuckDbTable(vectors);

--- a/velox/functions/sparksql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/AverageAggregationTest.cpp
@@ -30,7 +30,6 @@ class AverageAggregationTest : public AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    allowInputShuffle();
     registerAggregateFunctions("spark_");
   }
 };

--- a/velox/functions/sparksql/aggregates/tests/BitwiseXorAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/BitwiseXorAggregationTest.cpp
@@ -25,7 +25,6 @@ class BitwiseXorAggregationTest : public aggregate::test::AggregationTestBase {
   void SetUp() override {
     AggregationTestBase::SetUp();
     registerAggregateFunctions("");
-    allowInputShuffle();
   }
 
   RowTypePtr rowType_{

--- a/velox/functions/sparksql/aggregates/tests/BloomFilterAggAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/BloomFilterAggAggregateTest.cpp
@@ -29,7 +29,6 @@ class BloomFilterAggAggregateTest
   void SetUp() override {
     AggregationTestBase::SetUp();
     registerAggregateFunctions("");
-    allowInputShuffle();
   }
 
   VectorPtr getSerializedBloomFilter(int32_t capacity) {

--- a/velox/functions/sparksql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -28,7 +28,6 @@ class MinMaxByAggregateTest : public AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    AggregationTestBase::disallowInputShuffle();
     registerAggregateFunctions("spark_");
   }
 };


### PR DESCRIPTION
Simplify the AggregationTestBase by automatically determining if the
aggregate function is order-sensitive, which would disallow input shuffling.
If the orderSensitive flag is set to true for any of the test aggregates,
disable the test from files.

Fixes #9274 