### PR TITLE
Build boost without python in setup script

### DIFF
--- a/scripts/setup-centos8.sh
+++ b/scripts/setup-centos8.sh
@@ -101,7 +101,7 @@ function install_boost {
   (
    cd boost
    ./bootstrap.sh --prefix=/usr/local
-   ./b2 "-j$(nproc)" -d0 install threading=multi
+   ./b2 "-j$(nproc)" -d0 install threading=multi --without-python
   )
 }
 

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -96,7 +96,7 @@ function install_fmt {
 function install_boost {
   github_checkout boostorg/boost "${BOOST_VERSION}" --recursive
   ./bootstrap.sh --prefix=/usr/local
-  ${SUDO} ./b2 "-j$(nproc)" -d0 install threading=multi
+  ${SUDO} ./b2 "-j$(nproc)" -d0 install threading=multi --without-python
 }
 
 function install_folly {


### PR DESCRIPTION
Velox does not require the boost-python module. Adding the `--without-python` parameter can reduce the compilation time for Boost and also avoid some Python compatibility issues.