### PR TITLE
Remove -Wno-maybe-uninitialized compiler option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,7 +336,6 @@ if("${ENABLE_ALL_WARNINGS}")
          -Wno-int-in-bool-context \
          -Wno-redundant-move \
          -Wno-array-bounds \
-         -Wno-maybe-uninitialized \
          -Wno-unused-result \
          -Wno-format-overflow \
          -Wno-strict-aliasing \

--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -722,7 +722,15 @@ void MmapAllocator::SizeClass::allocateFromMappedFree(
     const auto endWord = startWord + kWordsPerGroup;
     bool anyFound = false;
     for (auto word = startWord; word < endWord; word += kWidth) {
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
       const auto bits = mappedFreeBits(word);
+#if defined(__GNUC__)
+#pragma clang diagnostic pop
+#endif
       uint16_t wordMask = simd::allSetBitMask<int64_t>() ^
           simd::toBitMask(bits == xsimd::broadcast<uint64_t>(0));
       if (wordMask == 0) {

--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -729,7 +729,7 @@ void MmapAllocator::SizeClass::allocateFromMappedFree(
 #endif
       const auto bits = mappedFreeBits(word);
 #if defined(__GNUC__)
-#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 #endif
       uint16_t wordMask = simd::allSetBitMask<int64_t>() ^
           simd::toBitMask(bits == xsimd::broadcast<uint64_t>(0));

--- a/velox/common/memory/tests/MemoryArbitratorTest.cpp
+++ b/velox/common/memory/tests/MemoryArbitratorTest.cpp
@@ -105,7 +105,7 @@ TEST_F(MemoryArbitrationTest, queryMemoryCapacity) {
     MemoryManager manager(options);
     auto rootPool = manager.addRootPool("root-1", 8L << 20);
     auto leafPool = rootPool->addLeafChild("leaf-1.0");
-    void* buffer;
+    void* buffer = nullptr;
     ASSERT_NO_THROW({
       buffer = leafPool->allocate(7L << 20);
       leafPool->free(buffer, 7L << 20);

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -951,7 +951,7 @@ TEST_F(MockSharedArbitrationTest, ensureMemoryPoolMaxCapacity) {
     auto requestorOp = addMemoryOp(requestor, testData.isReclaimable);
     requestorOp->allocate(testData.allocatedBytes);
     std::shared_ptr<MockTask> other;
-    MockMemoryOperator* otherOp;
+    MockMemoryOperator* otherOp = nullptr;
     if (testData.hasOtherTask) {
       other = addTask();
       otherOp = addMemoryOp(other, true);

--- a/velox/dwio/common/tests/utils/FilterGenerator.h
+++ b/velox/dwio/common/tests/utils/FilterGenerator.h
@@ -278,8 +278,8 @@ class ColumnStats : public AbstractColumnStats {
         return std::make_unique<velox::common::BigintRange>(0, 0, false);
       }
     }
-    int32_t lowerIndex;
-    int32_t upperIndex;
+    int32_t lowerIndex = 0;
+    int32_t upperIndex = 0;
     T lower = valueAtPct(filterSpec.startPct, &lowerIndex);
     T upper =
         valueAtPct(filterSpec.startPct + filterSpec.selectPct, &upperIndex);
@@ -314,7 +314,7 @@ class ColumnStats : public AbstractColumnStats {
   std::unique_ptr<Filter> makeRowGroupSkipRangeFilter(
       const std::vector<RowVectorPtr>& batches,
       const Subfield& subfield) {
-    T max;
+    T max = {};
     bool hasMax = false;
     for (auto batch : batches) {
       auto values = getChildBySubfield(batch.get(), subfield, rootType_)

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -394,7 +394,8 @@ void CastExpr::applyDecimalCastKernel(
       castResult->asUnchecked<FlatVector<TOutput>>()->mutableRawValues();
   const auto& fromPrecisionScale = getDecimalPrecisionScale(*fromType);
   const auto& toPrecisionScale = getDecimalPrecisionScale(*toType);
-
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
   applyToSelectedNoThrowLocal(
       context, rows, castResult, [&](vector_size_t row) {
         TOutput rescaledValue;
@@ -418,6 +419,7 @@ void CastExpr::applyDecimalCastKernel(
           }
         }
       });
+#pragma GCC diagnostic pop
 }
 
 template <typename TInput, typename TOutput>

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -458,7 +458,7 @@ void CastExpr::applyFloatingPointToDecimalCastKernel(
   const auto toPrecisionScale = getDecimalPrecisionScale(*toType);
 
   applyToSelectedNoThrowLocal(context, rows, result, [&](vector_size_t row) {
-    TOutput output;
+    TOutput output = {};
     const auto status = DecimalUtil::rescaleFloatingPoint<TInput, TOutput>(
         floatingInput->valueAt(row),
         toPrecisionScale.first,

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -394,11 +394,10 @@ void CastExpr::applyDecimalCastKernel(
       castResult->asUnchecked<FlatVector<TOutput>>()->mutableRawValues();
   const auto& fromPrecisionScale = getDecimalPrecisionScale(*fromType);
   const auto& toPrecisionScale = getDecimalPrecisionScale(*toType);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+
   applyToSelectedNoThrowLocal(
       context, rows, castResult, [&](vector_size_t row) {
-        TOutput rescaledValue;
+        TOutput rescaledValue = {};
         const auto status = DecimalUtil::rescaleWithRoundUp<TInput, TOutput>(
             sourceVector->valueAt(row),
             fromPrecisionScale.first,
@@ -419,7 +418,6 @@ void CastExpr::applyDecimalCastKernel(
           }
         }
       });
-#pragma GCC diagnostic pop
 }
 
 template <typename TInput, typename TOutput>

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -4475,7 +4475,7 @@ class PrestoVectorLexer {
     VELOX_RETURN_IF(
         numRows < 0, Status::Invalid("Negative num rows: {}", numRows));
 
-    int8_t hasNulls;
+    int8_t hasNulls = 0;
     VELOX_RETURN_NOT_OK(lexInt(TokenType::NULLS, &hasNulls));
     if (hasNulls != 0) {
       const auto numBytes = bits::nbytes(numRows);

--- a/velox/vector/tests/utils/VectorMaker.cpp
+++ b/velox/vector/tests/utils/VectorMaker.cpp
@@ -71,7 +71,7 @@ vector_size_t VectorMaker::createOffsetsAndSizes(
   auto rawOffsets = (*offsets)->asMutable<vector_size_t>();
   auto rawSizes = (*sizes)->asMutable<vector_size_t>();
 
-  uint64_t* rawNulls;
+  uint64_t* rawNulls = nullptr;
   if (isNullAt) {
     *nulls = AlignedBuffer::allocate<bool>(size, pool_);
     rawNulls = (*nulls)->asMutable<uint64_t>();


### PR DESCRIPTION
Remove -Wno-maybe-uninitialized compiler option which disables warnings about variables that may be used without being initialized which is undefined behavior in C++. 

Meant to address https://github.com/facebookincubator/velox/discussions/9469