### PR TITLE
Add execution mode enforcement

### DIFF
--- a/velox/examples/ScanAndSort.cpp
+++ b/velox/examples/ScanAndSort.cpp
@@ -130,7 +130,8 @@ int main(int argc, char** argv) {
       "my_write_task",
       writerPlanFragment,
       /*destination=*/0,
-      std::make_shared<core::QueryCtx>(executor.get()));
+      std::make_shared<core::QueryCtx>(executor.get()),
+      exec::Task::ExecutionMode::kParallel);
 
   // next() starts execution using the client thread. The loop pumps output
   // vectors out of the task (there are none in this query fragment).
@@ -159,7 +160,8 @@ int main(int argc, char** argv) {
       "my_read_task",
       readPlanFragment,
       /*destination=*/0,
-      std::make_shared<core::QueryCtx>(executor.get()));
+      std::make_shared<core::QueryCtx>(executor.get()),
+      exec::Task::ExecutionMode::kParallel);
 
   // Now that we have the query fragment and Task structure set up, we will
   // add data to it via `splits`.

--- a/velox/exec/benchmarks/ExchangeBenchmark.cpp
+++ b/velox/exec/benchmarks/ExchangeBenchmark.cpp
@@ -299,6 +299,7 @@ class ExchangeBenchmark : public VectorTestBase {
         std::move(planFragment),
         destination,
         std::move(queryCtx),
+        Task::ExecutionMode::kParallel,
         std::move(consumer));
   }
 

--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -266,6 +266,7 @@ class DriverTest : public OperatorTestBase {
         plan,
         0,
         std::make_shared<core::QueryCtx>(driverExecutor_.get()),
+        Task::ExecutionMode::kParallel,
         [](RowVectorPtr /*unused*/, ContinueFuture* /*unused*/) {
           return exec::BlockingReason::kNotBlocked;
         });
@@ -1503,6 +1504,7 @@ DEBUG_ONLY_TEST_F(DriverTest, driverCpuTimeSlicingCheck) {
         0,
         std::make_shared<core::QueryCtx>(
             driverExecutor_.get(), std::move(queryConfig)),
+        Task::ExecutionMode::kParallel,
         [](RowVectorPtr /*unused*/, ContinueFuture* /*unused*/) {
           return exec::BlockingReason::kNotBlocked;
         });
@@ -1537,6 +1539,7 @@ TEST_F(OpCallStatusTest, basic) {
       0,
       std::make_shared<core::QueryCtx>(
           driverExecutor_.get(), std::move(queryConfig)),
+      Task::ExecutionMode::kParallel,
       [](RowVectorPtr /*unused*/, ContinueFuture* /*unused*/) {
         return exec::BlockingReason::kNotBlocked;
       });

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -64,7 +64,11 @@ class ExchangeClientTest : public testing::Test,
     queryCtx->testingOverrideMemoryPool(
         memory::memoryManager()->addRootPool(queryCtx->queryId()));
     return Task::create(
-        taskId, core::PlanFragment{planNode}, 0, std::move(queryCtx));
+        taskId,
+        core::PlanFragment{planNode},
+        0,
+        std::move(queryCtx),
+        Task::ExecutionMode::kParallel);
   }
 
   int32_t enqueue(

--- a/velox/exec/tests/ExchangeFuzzer.cpp
+++ b/velox/exec/tests/ExchangeFuzzer.cpp
@@ -494,6 +494,7 @@ class ExchangeFuzzer : public VectorTestBase {
         std::move(planFragment),
         destination,
         std::move(queryCtx),
+        Task::ExecutionMode::kParallel,
         std::move(consumer));
   }
 

--- a/velox/exec/tests/GroupedExecutionTest.cpp
+++ b/velox/exec/tests/GroupedExecutionTest.cpp
@@ -120,7 +120,12 @@ TEST_F(GroupedExecutionTest, groupedExecutionErrors) {
   planFragment.groupedExecutionLeafNodeIds.clear();
   planFragment.groupedExecutionLeafNodeIds.emplace(tableScanNodeId);
   queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-  task = exec::Task::create("0", planFragment, 0, std::move(queryCtx));
+  task = exec::Task::create(
+      "0",
+      planFragment,
+      0,
+      std::move(queryCtx),
+      Task::ExecutionMode::kParallel);
   VELOX_ASSERT_THROW(
       task->start(3, 1),
       "groupedExecutionLeafNodeIds must be empty in ungrouped execution mode");
@@ -129,7 +134,12 @@ TEST_F(GroupedExecutionTest, groupedExecutionErrors) {
   planFragment.executionStrategy = core::ExecutionStrategy::kGrouped;
   planFragment.groupedExecutionLeafNodeIds.clear();
   queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-  task = exec::Task::create("0", planFragment, 0, std::move(queryCtx));
+  task = exec::Task::create(
+      "0",
+      planFragment,
+      0,
+      std::move(queryCtx),
+      Task::ExecutionMode::kParallel);
   VELOX_ASSERT_THROW(
       task->start(3, 1),
       "groupedExecutionLeafNodeIds must not be empty in "
@@ -140,7 +150,12 @@ TEST_F(GroupedExecutionTest, groupedExecutionErrors) {
   planFragment.groupedExecutionLeafNodeIds.clear();
   planFragment.groupedExecutionLeafNodeIds.emplace(projectNodeId);
   queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-  task = exec::Task::create("0", planFragment, 0, std::move(queryCtx));
+  task = exec::Task::create(
+      "0",
+      planFragment,
+      0,
+      std::move(queryCtx),
+      Task::ExecutionMode::kParallel);
   VELOX_ASSERT_THROW(
       task->start(3, 1),
       fmt::format(
@@ -153,7 +168,12 @@ TEST_F(GroupedExecutionTest, groupedExecutionErrors) {
   planFragment.groupedExecutionLeafNodeIds.emplace(tableScanNodeId);
   planFragment.groupedExecutionLeafNodeIds.emplace(projectNodeId);
   queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-  task = exec::Task::create("0", planFragment, 0, std::move(queryCtx));
+  task = exec::Task::create(
+      "0",
+      planFragment,
+      0,
+      std::move(queryCtx),
+      Task::ExecutionMode::kParallel);
   VELOX_ASSERT_THROW(
       task->start(3, 1),
       fmt::format(
@@ -166,7 +186,12 @@ TEST_F(GroupedExecutionTest, groupedExecutionErrors) {
   planFragment.groupedExecutionLeafNodeIds.clear();
   planFragment.groupedExecutionLeafNodeIds.emplace(localPartitionNodeId);
   queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-  task = exec::Task::create("0", planFragment, 0, std::move(queryCtx));
+  task = exec::Task::create(
+      "0",
+      planFragment,
+      0,
+      std::move(queryCtx),
+      Task::ExecutionMode::kParallel);
   VELOX_ASSERT_THROW(
       task->start(3, 1),
       fmt::format(
@@ -202,8 +227,12 @@ TEST_F(GroupedExecutionTest, groupedExecutionWithOutputBuffer) {
   planFragment.groupedExecutionLeafNodeIds.emplace(tableScanNodeId);
   planFragment.numSplitGroups = 10;
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-  auto task =
-      exec::Task::create("0", std::move(planFragment), 0, std::move(queryCtx));
+  auto task = exec::Task::create(
+      "0",
+      std::move(planFragment),
+      0,
+      std::move(queryCtx),
+      Task::ExecutionMode::kParallel);
   // 3 drivers max and 1 concurrent split group.
   task->start(3, 1);
 
@@ -397,7 +426,11 @@ DEBUG_ONLY_TEST_F(
         }));
 
     auto task = exec::Task::create(
-        "0", std::move(planFragment), 0, std::move(queryCtx));
+        "0",
+        std::move(planFragment),
+        0,
+        std::move(queryCtx),
+        Task::ExecutionMode::kParallel);
     const auto spillDirectory = exec::test::TempDirectoryPath::create();
     if (testData.enableSpill) {
       task->setSpillDirectory(spillDirectory->getPath());
@@ -513,7 +546,11 @@ TEST_F(GroupedExecutionTest, groupedExecutionWithHashAndNestedLoopJoin) {
     planFragment.numSplitGroups = 10;
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     auto task = exec::Task::create(
-        "0", std::move(planFragment), 0, std::move(queryCtx));
+        "0",
+        std::move(planFragment),
+        0,
+        std::move(queryCtx),
+        Task::ExecutionMode::kParallel);
     // 3 drivers max and 1 concurrent split group.
     task->start(3, 1);
 

--- a/velox/exec/tests/MemoryReclaimerTest.cpp
+++ b/velox/exec/tests/MemoryReclaimerTest.cpp
@@ -44,13 +44,16 @@ class MemoryReclaimerTest : public OperatorTestBase {
         "MemoryReclaimerTest",
         std::move(fakePlanFragment),
         0,
-        std::make_shared<core::QueryCtx>());
+        std::make_shared<core::QueryCtx>(executor_.get()),
+        Task::ExecutionMode::kParallel);
   }
 
   void SetUp() override {}
 
   void TearDown() override {}
 
+  std::shared_ptr<folly::CPUThreadPoolExecutor> executor_{
+      std::make_shared<folly::CPUThreadPoolExecutor>(4)};
   const std::shared_ptr<memory::MemoryPool> pool_;
   RowTypePtr rowType_;
   std::shared_ptr<Task> fakeTask_;

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -86,6 +86,7 @@ class MultiFragmentTest : public HiveConnectorTestBase {
         std::move(planFragment),
         destination,
         std::move(queryCtx),
+        Task::ExecutionMode::kParallel,
         std::move(consumer));
   }
 

--- a/velox/exec/tests/OperatorUtilsTest.cpp
+++ b/velox/exec/tests/OperatorUtilsTest.cpp
@@ -41,12 +41,14 @@ class OperatorUtilsTest : public OperatorTestBase {
     core::PlanFragment planFragment;
     const core::PlanNodeId id{"0"};
     planFragment.planNode = std::make_shared<core::ValuesNode>(id, values);
+    executor_ = std::make_shared<folly::CPUThreadPoolExecutor>(4);
 
     task_ = Task::create(
         "SpillOperatorGroupTest_task",
         std::move(planFragment),
         0,
-        std::make_shared<core::QueryCtx>());
+        std::make_shared<core::QueryCtx>(executor_.get()),
+        Task::ExecutionMode::kParallel);
     driver_ = Driver::testingCreate();
     driverCtx_ = std::make_unique<DriverCtx>(task_, 0, 0, 0, 0);
     driverCtx_->driver = driver_.get();
@@ -131,6 +133,7 @@ class OperatorUtilsTest : public OperatorTestBase {
     }
   }
 
+  std::shared_ptr<folly::CPUThreadPoolExecutor> executor_;
   std::shared_ptr<Task> task_;
   std::shared_ptr<Driver> driver_;
   std::unique_ptr<DriverCtx> driverCtx_;

--- a/velox/exec/tests/OutputBufferManagerTest.cpp
+++ b/velox/exec/tests/OutputBufferManagerTest.cpp
@@ -74,8 +74,12 @@ class OutputBufferManagerTest : public testing::Test {
     auto queryCtx = std::make_shared<core::QueryCtx>(
         executor_.get(), core::QueryConfig(std::move(configSettings)));
 
-    auto task =
-        Task::create(taskId, std::move(planFragment), 0, std::move(queryCtx));
+    auto task = Task::create(
+        taskId,
+        std::move(planFragment),
+        0,
+        std::move(queryCtx),
+        Task::ExecutionMode::kParallel);
 
     bufferManager_->initializeTask(task, kind, numDestinations, numDrivers);
     return task;

--- a/velox/exec/tests/PartitionedOutputTest.cpp
+++ b/velox/exec/tests/PartitionedOutputTest.cpp
@@ -116,7 +116,8 @@ TEST_F(PartitionedOutputTest, flush) {
       0,
       createQueryContext(
           {{core::QueryConfig::kMaxPartitionedOutputBufferSize,
-            std::to_string(PartitionedOutput::kMinDestinationSize * 2)}}));
+            std::to_string(PartitionedOutput::kMinDestinationSize * 2)}}),
+      Task::ExecutionMode::kParallel);
   task->start(1);
 
   const auto partition0 = getAllData(taskId, 0);

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1483,6 +1483,7 @@ DEBUG_ONLY_TEST_F(TableScanTest, tableScanSplitsAndWeights) {
       core::PlanFragment{leafPlan},
       0,
       std::move(queryCtx),
+      Task::ExecutionMode::kParallel,
       std::move(consumer));
   leafTask->start(4);
 

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -466,7 +466,11 @@ class TaskTest : public HiveConnectorTestBase {
       const std::unordered_map<std::string, std::vector<std::string>>&
           filePaths = {}) {
     auto task = Task::create(
-        "single.execution.task.0", plan, 0, std::make_shared<core::QueryCtx>());
+        "single.execution.task.0",
+        plan,
+        0,
+        std::make_shared<core::QueryCtx>(),
+        Task::ExecutionMode::kSerial);
 
     for (const auto& [nodeId, paths] : filePaths) {
       for (const auto& path : paths) {
@@ -514,7 +518,8 @@ TEST_F(TaskTest, toJson) {
       "task-1",
       std::move(plan),
       0,
-      std::make_shared<core::QueryCtx>(driverExecutor_.get()));
+      std::make_shared<core::QueryCtx>(driverExecutor_.get()),
+      Task::ExecutionMode::kParallel);
 
   ASSERT_EQ(
       task->toString(), "{Task task-1 (task-1)Plan: -- Project\n\n drivers:\n");
@@ -554,7 +559,8 @@ TEST_F(TaskTest, wrongPlanNodeForSplit) {
       "task-1",
       std::move(plan),
       0,
-      std::make_shared<core::QueryCtx>(driverExecutor_.get()));
+      std::make_shared<core::QueryCtx>(driverExecutor_.get()),
+      Task::ExecutionMode::kParallel);
 
   // Add split for the source node.
   task->addSplit("0", exec::Split(folly::copy(connectorSplit)));
@@ -609,7 +615,8 @@ TEST_F(TaskTest, wrongPlanNodeForSplit) {
       "task-2",
       std::move(plan),
       0,
-      std::make_shared<core::QueryCtx>(driverExecutor_.get()));
+      std::make_shared<core::QueryCtx>(driverExecutor_.get()),
+      Task::ExecutionMode::kParallel);
   errorMessage =
       "Splits can be associated only with leaf plan nodes which require splits. Plan node ID 0 doesn't refer to such plan node.";
   VELOX_ASSERT_THROW(
@@ -635,7 +642,8 @@ TEST_F(TaskTest, duplicatePlanNodeIds) {
           "task-1",
           std::move(plan),
           0,
-          std::make_shared<core::QueryCtx>(driverExecutor_.get())),
+          std::make_shared<core::QueryCtx>(driverExecutor_.get()),
+          Task::ExecutionMode::kParallel),
       "Plan node IDs must be unique. Found duplicate ID: 0.")
 }
 
@@ -893,7 +901,11 @@ TEST_F(TaskTest, singleThreadedExecutionExternalBlockable) {
   // First pass, we don't activate the external blocker, expect the task to run
   // without being blocked.
   auto nonBlockingTask = Task::create(
-      "single.execution.task.0", plan, 0, std::make_shared<core::QueryCtx>());
+      "single.execution.task.0",
+      plan,
+      0,
+      std::make_shared<core::QueryCtx>(),
+      Task::ExecutionMode::kSerial);
   std::vector<RowVectorPtr> results;
   for (;;) {
     auto result = nonBlockingTask->next(&continueFuture);
@@ -909,7 +921,11 @@ TEST_F(TaskTest, singleThreadedExecutionExternalBlockable) {
   continueFuture = ContinueFuture::makeEmpty();
   // Second pass, we will now use external blockers to block the task.
   auto blockingTask = Task::create(
-      "single.execution.task.1", plan, 0, std::make_shared<core::QueryCtx>());
+      "single.execution.task.1",
+      plan,
+      0,
+      std::make_shared<core::QueryCtx>(),
+      Task::ExecutionMode::kSerial);
   // Before we block, we expect `next` to get data normally.
   results.push_back(blockingTask->next(&continueFuture));
   EXPECT_TRUE(results.back() != nullptr);
@@ -941,7 +957,11 @@ TEST_F(TaskTest, supportsSingleThreadedExecution) {
                   .partitionedOutput({}, 1, std::vector<std::string>{"p0"})
                   .planFragment();
   auto task = Task::create(
-      "single.execution.task.0", plan, 0, std::make_shared<core::QueryCtx>());
+      "single.execution.task.0",
+      plan,
+      0,
+      std::make_shared<core::QueryCtx>(),
+      Task::ExecutionMode::kSerial);
 
   // PartitionedOutput does not support single threaded execution, therefore the
   // task doesn't support it either.
@@ -957,7 +977,11 @@ TEST_F(TaskTest, updateBroadCastOutputBuffers) {
   auto bufferManager = OutputBufferManager::getInstance().lock();
   {
     auto task = Task::create(
-        "t0", plan, 0, std::make_shared<core::QueryCtx>(driverExecutor_.get()));
+        "t0",
+        plan,
+        0,
+        std::make_shared<core::QueryCtx>(driverExecutor_.get()),
+        Task::ExecutionMode::kParallel);
 
     task->start(1, 1);
 
@@ -971,7 +995,11 @@ TEST_F(TaskTest, updateBroadCastOutputBuffers) {
 
   {
     auto task = Task::create(
-        "t1", plan, 0, std::make_shared<core::QueryCtx>(driverExecutor_.get()));
+        "t1",
+        plan,
+        0,
+        std::make_shared<core::QueryCtx>(driverExecutor_.get()),
+        Task::ExecutionMode::kParallel);
 
     task->start(1, 1);
 
@@ -1197,6 +1225,62 @@ TEST_F(TaskTest, outputBufferSize) {
   ASSERT_GT(outputStats.bufferedBytes, 0);
   ASSERT_EQ(outputStats.bufferedPages, outputStats.totalPagesSent);
   task->requestCancel();
+}
+
+DEBUG_ONLY_TEST_F(TaskTest, inconsistentExecutionMode) {
+  {
+    // Scenario 1: Parallel execution starts first then kicks in Serial
+    // execution.
+
+    // Let parallel execution pause a bit so that we can call serial API on Task
+    // to trigger inconsistent execution mode failure.
+    folly::EventCount getOutputWait;
+    std::atomic_bool getOutputWaitFlag{false};
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Values::getOutput",
+        std::function<void(Values*)>([&](Values* /*unused*/) {
+          getOutputWait.await([&]() { return getOutputWaitFlag.load(); });
+        }));
+    auto data = makeRowVector({
+        makeFlatVector<int64_t>(1'000, [](auto row) { return row; }),
+    });
+
+    CursorParameters params;
+    params.planNode =
+        PlanBuilder().values({data, data, data}).project({"c0"}).planNode();
+    params.queryCtx = std::make_shared<core::QueryCtx>(driverExecutor_.get());
+    params.maxDrivers = 4;
+
+    auto cursor = TaskCursor::create(params);
+    auto* task = cursor->task().get();
+
+    cursor->start();
+    VELOX_ASSERT_THROW(task->next(), "Inconsistent task execution mode.");
+    getOutputWaitFlag = true;
+    getOutputWait.notify();
+    while (cursor->hasNext()) {
+      cursor->moveNext();
+    }
+  }
+
+  {
+    // Scenario 2: Serial execution starts first then kicks in Parallel
+    // execution.
+
+    auto data = makeRowVector({
+        makeFlatVector<int64_t>(1'000, [](auto row) { return row; }),
+    });
+    auto plan =
+        PlanBuilder().values({data, data, data}).project({"c0"}).planFragment();
+    auto queryCtx = std::make_shared<core::QueryCtx>(driverExecutor_.get());
+    auto task =
+        Task::create("task.0", plan, 0, queryCtx, Task::ExecutionMode::kSerial);
+
+    task->next();
+    VELOX_ASSERT_THROW(task->start(4, 1), "Inconsistent task execution mode.");
+    while (task->next() != nullptr) {
+    }
+  }
 }
 
 DEBUG_ONLY_TEST_F(TaskTest, findPeerOperators) {
@@ -1462,12 +1546,15 @@ TEST_F(TaskTest, driverCreationMemoryAllocationCheck) {
         "driverCreationMemoryAllocationCheck",
         plan,
         0,
-        std::make_shared<core::QueryCtx>());
+        std::make_shared<core::QueryCtx>(
+            singleThreadExecution ? nullptr : driverExecutor_.get()),
+        singleThreadExecution ? Task::ExecutionMode::kSerial
+                              : Task::ExecutionMode::kParallel);
     if (singleThreadExecution) {
+      VELOX_ASSERT_THROW(badTask->next(), "Unexpected memory pool allocations");
+    } else {
       VELOX_ASSERT_THROW(
           badTask->start(1), "Unexpected memory pool allocations");
-    } else {
-      VELOX_ASSERT_THROW(badTask->next(), "Unexpected memory pool allocations");
     }
   }
 }
@@ -1599,7 +1686,8 @@ DEBUG_ONLY_TEST_F(TaskTest, resumeAfterTaskFinish) {
       "task",
       std::move(plan),
       0,
-      std::make_shared<core::QueryCtx>(driverExecutor_.get()));
+      std::make_shared<core::QueryCtx>(driverExecutor_.get()),
+      Task::ExecutionMode::kParallel);
   task->start(4, 1);
 
   // Request pause and then unblock operators to proceed.
@@ -1631,7 +1719,8 @@ DEBUG_ONLY_TEST_F(
 
   auto queryCtx = std::make_shared<core::QueryCtx>(driverExecutor_.get());
 
-  auto blockingTask = Task::create("blocking.task.0", plan, 0, queryCtx);
+  auto blockingTask = Task::create(
+      "blocking.task.0", plan, 0, queryCtx, Task::ExecutionMode::kSerial);
 
   // Before we block, we expect `next` to get data normally.
   EXPECT_NE(nullptr, blockingTask->next());
@@ -1705,7 +1794,8 @@ DEBUG_ONLY_TEST_F(TaskTest, longRunningOperatorInTaskReclaimerAbort) {
 
   auto queryCtx = std::make_shared<core::QueryCtx>(driverExecutor_.get());
 
-  auto blockingTask = Task::create("blocking.task.0", plan, 0, queryCtx);
+  auto blockingTask = Task::create(
+      "blocking.task.0", plan, 0, queryCtx, Task::ExecutionMode::kParallel);
 
   blockingTask->start(4, 1);
   const std::string abortErrorMessage("Synthetic Exception");
@@ -1766,7 +1856,12 @@ DEBUG_ONLY_TEST_F(TaskTest, taskReclaimStats) {
       nullptr,
       std::move(queryPool),
       nullptr);
-  auto task = Task::create("task", std::move(plan), 0, std::move(queryCtx));
+  auto task = Task::create(
+      "task",
+      std::move(plan),
+      0,
+      std::move(queryCtx),
+      Task::ExecutionMode::kParallel);
   task->start(4, 1);
 
   const int numReclaims{10};
@@ -1832,7 +1927,12 @@ DEBUG_ONLY_TEST_F(TaskTest, taskPauseTime) {
       nullptr,
       std::move(queryPool),
       nullptr);
-  auto task = Task::create("task", std::move(plan), 0, std::move(queryCtx));
+  auto task = Task::create(
+      "task",
+      std::move(plan),
+      0,
+      std::move(queryCtx),
+      Task::ExecutionMode::kParallel);
   task->start(4, 1);
 
   // Wait for the task driver starts to run.
@@ -1880,7 +1980,8 @@ TEST_F(TaskTest, updateStatsWhileCloseOffThreadDriver) {
       "task",
       std::move(plan),
       0,
-      std::make_shared<core::QueryCtx>(driverExecutor_.get()));
+      std::make_shared<core::QueryCtx>(driverExecutor_.get()),
+      Task::ExecutionMode::kParallel);
   task->start(4, 1);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   task->testingVisitDrivers(
@@ -1924,7 +2025,8 @@ DEBUG_ONLY_TEST_F(TaskTest, driverEnqueAfterFailedAndPausedTask) {
       "task",
       std::move(plan),
       0,
-      std::make_shared<core::QueryCtx>(driverExecutor_.get()));
+      std::make_shared<core::QueryCtx>(driverExecutor_.get()),
+      Task::ExecutionMode::kParallel);
   task->start(4, 1);
 
   // Request pause.

--- a/velox/exec/tests/ThreadDebugInfoTest.cpp
+++ b/velox/exec/tests/ThreadDebugInfoTest.cpp
@@ -99,7 +99,11 @@ DEBUG_ONLY_TEST_F(ThreadDebugInfoDeathTest, withinTheCallingThread) {
       nullptr,
       "TaskCursorQuery_0");
   auto task = exec::Task::create(
-      "single.execution.task.0", std::move(plan), 0, queryCtx);
+      "single.execution.task.0",
+      std::move(plan),
+      0,
+      queryCtx,
+      exec::Task::ExecutionMode::kSerial);
 
 #if IS_BUILDING_WITH_ASAN() == 0
   ASSERT_DEATH(

--- a/velox/exec/tests/utils/Cursor.cpp
+++ b/velox/exec/tests/utils/Cursor.cpp
@@ -226,6 +226,7 @@ class MultiThreadedTaskCursor : public TaskCursorBase {
         std::move(planFragment_),
         params.destination,
         std::move(queryCtx_),
+        Task::ExecutionMode::kParallel,
         // consumer
         [queue, copyResult = params.copyResult](
             const RowVectorPtr& vector, velox::ContinueFuture* future) {
@@ -329,7 +330,8 @@ class SingleThreadedTaskCursor : public TaskCursorBase {
         taskId_,
         std::move(planFragment_),
         params.destination,
-        std::move(queryCtx_));
+        std::move(queryCtx_),
+        Task::ExecutionMode::kSerial);
 
     if (!taskSpillDirectory_.empty()) {
       task_->setSpillDirectory(taskSpillDirectory_);

--- a/velox/functions/prestosql/aggregates/benchmarks/ReduceAgg.cpp
+++ b/velox/functions/prestosql/aggregates/benchmarks/ReduceAgg.cpp
@@ -189,7 +189,8 @@ class ReduceAggBenchmark : public HiveConnectorTestBase {
         "t",
         std::move(plan),
         0,
-        std::make_shared<core::QueryCtx>(executor_.get()));
+        std::make_shared<core::QueryCtx>(executor_.get()),
+        exec::Task::ExecutionMode::kParallel);
 
     task->addSplit(
         "0", exec::Split(makeHiveConnectorSplit(filePath_->getPath())));

--- a/velox/functions/prestosql/aggregates/benchmarks/SimpleAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/benchmarks/SimpleAggregates.cpp
@@ -165,7 +165,8 @@ class SimpleAggregatesBenchmark : public HiveConnectorTestBase {
         "t",
         std::move(plan),
         0,
-        std::make_shared<core::QueryCtx>(executor_.get()));
+        std::make_shared<core::QueryCtx>(executor_.get()),
+        exec::Task::ExecutionMode::kParallel);
   }
 
  private:

--- a/velox/functions/prestosql/aggregates/benchmarks/TwoStringKeys.cpp
+++ b/velox/functions/prestosql/aggregates/benchmarks/TwoStringKeys.cpp
@@ -113,7 +113,8 @@ class TwoStringKeysBenchmark : public HiveConnectorTestBase {
         "t",
         std::move(plan),
         0,
-        std::make_shared<core::QueryCtx>(executor_.get()));
+        std::make_shared<core::QueryCtx>(executor_.get()),
+        exec::Task::ExecutionMode::kParallel);
 
     task->addSplit(
         "0", exec::Split(makeHiveConnectorSplit((filePath_->getPath()))));


### PR DESCRIPTION
Velox task has two execution modes: one is the sequential execution mode used by streaming service and the other is the parallel execution mode used by query engine like Prestissimo. The two execution modes use different APIs but we don't have any reliable way to tell if a task is under sequential or parallel execution modes internally, such as parallel execution mode use a driver executor but sequential mode not.
This PR defines execution mode for the task/query to add sanity checks for different api calls.