### PR TITLE
Disable map_top_n from fuzz testing

### DIFF
--- a/velox/expression/tests/ExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerTest.cpp
@@ -64,6 +64,7 @@ int main(int argc, char** argv) {
       "regexp_extract",
       "regexp_extract_all",
       "regexp_like",
+      "map_top_n", // https://github.com/facebookincubator/velox/issues/9497
   };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
   return FuzzerRunner::run(initialSeed, skipFunctions, {{}});


### PR DESCRIPTION
Summary:
This function is newly introduced and is currently failing fuzzer.
Disabling it to unblock fuzz testing while we work on a fix.

Differential Revision: D56195119


