### PR TITLE
DwrfReader Refactor: Remove getCurrentStripeMetadata() method

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -124,10 +124,6 @@ class DwrfRowReader : public StrideIndexProvider,
 
   int64_t nextReadSize(uint64_t size) override;
 
-  std::unique_ptr<const StripeMetadata>& getCurrentStripeMetadata() {
-    return stripeMetadata_;
-  }
-
  private:
   // Represents the status of a stripe being fetched.
   enum class FetchStatus { NOT_STARTED, IN_PROGRESS, FINISHED, ERROR };


### PR DESCRIPTION
Summary: It was an ugly hack and isn't necessary anymore.

Differential Revision: D56195703


