### PR TITLE
Add reserved memory capacity pool in arbitrator

### DIFF
--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -135,6 +135,10 @@ void registerVeloxMetrics() {
   DEFINE_METRIC(
       kMetricArbitratorFreeCapacityBytes, facebook::velox::StatType::AVG);
 
+  DEFINE_METRIC(
+      kMetricArbitratorFreeReservedCapacityBytes,
+      facebook::velox::StatType::AVG);
+
   // Tracks the leaf memory pool usage leak in bytes.
   DEFINE_METRIC(
       kMetricMemoryPoolUsageLeakBytes, facebook::velox::StatType::SUM);

--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -94,6 +94,9 @@ constexpr folly::StringPiece kMetricArbitratorArbitrationTimeMs{
 constexpr folly::StringPiece kMetricArbitratorFreeCapacityBytes{
     "velox.arbitrator_free_capacity_bytes"};
 
+constexpr folly::StringPiece kMetricArbitratorFreeReservedCapacityBytes{
+    "velox.arbitrator_free_reserved_capacity_bytes"};
+
 constexpr folly::StringPiece kMetricDriverYieldCount{
     "velox.driver_yield_count"};
 

--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -116,6 +116,8 @@ class AsyncDataCacheTest : public testing::Test {
     memory::MemoryManagerOptions options;
     options.useMmapAllocator = true;
     options.allocatorCapacity = maxBytes;
+    options.arbitratorCapacity = maxBytes;
+    options.arbitratorReservedCapacity = 0;
     options.trackDefaultUsage = true;
     manager_ = std::make_unique<memory::MemoryManager>(options);
     allocator_ = static_cast<memory::MmapAllocator*>(manager_->allocator());

--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -61,6 +61,8 @@ std::unique_ptr<MemoryArbitrator> createArbitrator(
       {.kind = options.arbitratorKind,
        .capacity =
            std::min(options.arbitratorCapacity, options.allocatorCapacity),
+       .reservedCapacity = options.arbitratorReservedCapacity,
+       .memoryPoolReservedCapacity = options.memoryPoolReservedCapacity,
        .memoryPoolTransferCapacity = options.memoryPoolTransferCapacity,
        .memoryReclaimWaitMs = options.memoryReclaimWaitMs,
        .arbitrationStateCheckCb = options.arbitrationStateCheckCb,

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -145,18 +145,28 @@ struct MemoryManagerOptions {
   /// reservation capacity for system usage.
   int64_t arbitratorCapacity{kMaxMemory};
 
+  /// Memory capacity reserved to ensure that a query has minimal memory
+  /// capacity to run. This capacity should be less than 'arbitratorCapacity'.
+  /// A query's minimal memory capacity is defined by
+  /// 'memoryPoolReservedCapacity'.
+  int64_t arbitratorReservedCapacity{0};
+
   /// The string kind of memory arbitrator used in the memory manager.
   ///
   /// NOTE: the arbitrator will only be created if its kind is set explicitly.
   /// Otherwise MemoryArbitrator::create returns a nullptr.
   std::string arbitratorKind{};
 
-  /// The initial memory capacity to reserve for a newly created memory pool.
+  /// The initial memory capacity to reserve for a newly created query memory
+  /// pool.
   uint64_t memoryPoolInitCapacity{256 << 20};
+
+  /// The minimal memory capacity reserved for a query memory pool to run.
+  uint64_t memoryPoolReservedCapacity{0};
 
   /// The minimal memory capacity to transfer out of or into a memory pool
   /// during the memory arbitration.
-  uint64_t memoryPoolTransferCapacity{32 << 20};
+  uint64_t memoryPoolTransferCapacity{128 << 20};
 
   /// Specifies the max time to wait for memory reclaim by arbitration. The
   /// memory reclaim might fail if the max wait time has exceeded. If it is

--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -109,7 +109,7 @@ class NoopArbitrator : public MemoryArbitrator {
 
   // Noop arbitrator has no memory capacity limit so no operation needed for
   // memory pool capacity release.
-  uint64_t shrinkCapacity(MemoryPool* pool, uint64_t targetBytes) override {
+  uint64_t shrinkCapacity(MemoryPool* pool, uint64_t /*unused*/) override {
     // No-op
     return 0;
   }
@@ -307,6 +307,7 @@ MemoryArbitrator::Stats::Stats(
     uint64_t _numReclaimedBytes,
     uint64_t _maxCapacityBytes,
     uint64_t _freeCapacityBytes,
+    uint64_t _freeReservedCapacityBytes,
     uint64_t _reclaimTimeUs,
     uint64_t _numNonReclaimableAttempts,
     uint64_t _numReserves,
@@ -321,6 +322,7 @@ MemoryArbitrator::Stats::Stats(
       numReclaimedBytes(_numReclaimedBytes),
       maxCapacityBytes(_maxCapacityBytes),
       freeCapacityBytes(_freeCapacityBytes),
+      freeReservedCapacityBytes(_freeReservedCapacityBytes),
       reclaimTimeUs(_reclaimTimeUs),
       numNonReclaimableAttempts(_numNonReclaimableAttempts),
       numReserves(_numReserves),
@@ -331,7 +333,7 @@ std::string MemoryArbitrator::Stats::toString() const {
       "STATS[numRequests {} numSucceeded {} numAborted {} numFailures {} "
       "numNonReclaimableAttempts {} numReserves {} numReleases {} "
       "queueTime {} arbitrationTime {} reclaimTime {} shrunkMemory {} "
-      "reclaimedMemory {} maxCapacity {} freeCapacity {}]",
+      "reclaimedMemory {} maxCapacity {} freeCapacity {} freeReservedCapacity {}]",
       numRequests,
       numSucceeded,
       numAborted,
@@ -345,7 +347,8 @@ std::string MemoryArbitrator::Stats::toString() const {
       succinctBytes(numShrunkBytes),
       succinctBytes(numReclaimedBytes),
       succinctBytes(maxCapacityBytes),
-      succinctBytes(freeCapacityBytes));
+      succinctBytes(freeCapacityBytes),
+      succinctBytes(freeReservedCapacityBytes));
 }
 
 MemoryArbitrator::Stats MemoryArbitrator::Stats::operator-(
@@ -361,6 +364,7 @@ MemoryArbitrator::Stats MemoryArbitrator::Stats::operator-(
   result.numReclaimedBytes = numReclaimedBytes - other.numReclaimedBytes;
   result.maxCapacityBytes = maxCapacityBytes;
   result.freeCapacityBytes = freeCapacityBytes;
+  result.freeReservedCapacityBytes = freeReservedCapacityBytes;
   result.reclaimTimeUs = reclaimTimeUs - other.reclaimTimeUs;
   result.numNonReclaimableAttempts =
       numNonReclaimableAttempts - other.numNonReclaimableAttempts;
@@ -381,6 +385,7 @@ bool MemoryArbitrator::Stats::operator==(const Stats& other) const {
              numReclaimedBytes,
              maxCapacityBytes,
              freeCapacityBytes,
+             freeReservedCapacityBytes,
              reclaimTimeUs,
              numNonReclaimableAttempts,
              numReserves,
@@ -396,6 +401,7 @@ bool MemoryArbitrator::Stats::operator==(const Stats& other) const {
              other.numReclaimedBytes,
              other.maxCapacityBytes,
              other.freeCapacityBytes,
+             other.freeReservedCapacityBytes,
              other.reclaimTimeUs,
              other.numNonReclaimableAttempts,
              other.numReserves,

--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -34,7 +34,7 @@ namespace {
 
 // Returns the max capacity to grow of memory 'pool'. The calculation is based
 // on a memory pool's max capacity and its current capacity.
-uint64_t maxGrowBytes(const MemoryPool& pool) {
+uint64_t maxGrowCapacity(const MemoryPool& pool) {
   return pool.maxCapacity() - pool.capacity();
 }
 
@@ -64,24 +64,7 @@ std::string memoryPoolAbortMessage(
   return out.str();
 }
 
-std::vector<SharedArbitrator::Candidate> getCandidateStats(
-    const std::vector<std::shared_ptr<MemoryPool>>& pools) {
-  std::vector<SharedArbitrator::Candidate> candidates;
-  candidates.reserve(pools.size());
-  for (const auto& pool : pools) {
-    auto reclaimableBytesOpt = pool->reclaimableBytes();
-    const uint64_t reclaimableBytes = reclaimableBytesOpt.value_or(0);
-    candidates.push_back(
-        {reclaimableBytesOpt.has_value(),
-         reclaimableBytes,
-         pool->freeBytes(),
-         pool->currentBytes(),
-         pool.get()});
-  }
-  return candidates;
-}
-
-void sortCandidatesByFreeCapacity(
+void sortCandidatesByReclaimableFreeCapacity(
     std::vector<SharedArbitrator::Candidate>& candidates) {
   std::sort(
       candidates.begin(),
@@ -92,28 +75,22 @@ void sortCandidatesByFreeCapacity(
       });
 
   TestValue::adjust(
-      "facebook::velox::memory::SharedArbitrator::sortCandidatesByFreeCapacity",
+      "facebook::velox::memory::SharedArbitrator::sortCandidatesByReclaimableFreeCapacity",
       &candidates);
 }
 
-void sortCandidatesByReclaimableMemory(
+void sortCandidatesByReclaimableUsedMemory(
     std::vector<SharedArbitrator::Candidate>& candidates) {
   std::sort(
       candidates.begin(),
       candidates.end(),
       [](const SharedArbitrator::Candidate& lhs,
          const SharedArbitrator::Candidate& rhs) {
-        if (!lhs.reclaimable) {
-          return false;
-        }
-        if (!rhs.reclaimable) {
-          return true;
-        }
         return lhs.reclaimableBytes > rhs.reclaimableBytes;
       });
 
   TestValue::adjust(
-      "facebook::velox::memory::SharedArbitrator::sortCandidatesByReclaimableMemory",
+      "facebook::velox::memory::SharedArbitrator::sortCandidatesByReclaimableUsedMemory",
       &candidates);
 }
 
@@ -169,67 +146,157 @@ const SharedArbitrator::Candidate& findCandidateWithLargestCapacity(
 } // namespace
 
 SharedArbitrator::SharedArbitrator(const MemoryArbitrator::Config& config)
-    : MemoryArbitrator(config), freeCapacity_(capacity_) {
-  RECORD_METRIC_VALUE(kMetricArbitratorFreeCapacityBytes, freeCapacity_);
+    : MemoryArbitrator(config),
+      freeReservedCapacity_(reservedCapacity_),
+      freeNonReservedCapacity_(capacity_ - freeReservedCapacity_) {
   VELOX_CHECK_EQ(kind_, config.kind);
+  updateFreeCapacityMetrics();
 }
 
 std::string SharedArbitrator::Candidate::toString() const {
   return fmt::format(
-      "CANDIDATE[{} RECLAIMABLE[{}] RECLAIMABLE_BYTES[{}] FREE_BYTES[{}]]",
+      "CANDIDATE[{}] RECLAIMABLE_BYTES[{}] FREE_BYTES[{}]]",
       pool->root()->name(),
-      reclaimable,
       succinctBytes(reclaimableBytes),
       succinctBytes(freeBytes));
 }
 
 SharedArbitrator::~SharedArbitrator() {
-  if (freeCapacity_ != capacity_) {
+  if (freeReservedCapacity_ != reservedCapacity_) {
     const std::string errMsg = fmt::format(
-        "\"There is unexpected free capacity not given back to arbitrator "
-        "on destruction: freeCapacity_ != capacity_ ({} vs {})\\n{}\"",
-        freeCapacity_,
+        "There is unexpected free reserved capacity not given back to arbitrator "
+        "on destruction: freeReservedCapacity_{} != reservedCapacity_{}\\n{}",
+        freeReservedCapacity_,
+        reservedCapacity_,
+        toString());
+    if (checkUsageLeak_) {
+      VELOX_FAIL(errMsg);
+    } else {
+      VELOX_MEM_LOG(ERROR) << errMsg;
+    }
+  }
+  if (freeNonReservedCapacity_ + freeReservedCapacity_ != capacity_) {
+    const std::string errMsg = fmt::format(
+        "There is unexpected free capacity not given back to arbitrator "
+        "on destruction: freeNonReservedCapacity_[{}] + freeReservedCapacity_[{}] != capacity_[{}])\\n{}",
+        freeNonReservedCapacity_,
+        freeReservedCapacity_,
         capacity_,
         toString());
     if (checkUsageLeak_) {
       VELOX_FAIL(errMsg);
     } else {
-      LOG(ERROR) << errMsg;
+      VELOX_MEM_LOG(ERROR) << errMsg;
     }
   }
+}
+
+std::vector<SharedArbitrator::Candidate> SharedArbitrator::getCandidateStats(
+    const std::vector<std::shared_ptr<MemoryPool>>& pools,
+    bool freeCapacityOnly) {
+  std::vector<SharedArbitrator::Candidate> candidates;
+  candidates.reserve(pools.size());
+  for (const auto& pool : pools) {
+    candidates.push_back(
+        {freeCapacityOnly ? 0 : reclaimableUsedCapacity(*pool),
+         reclaimableFreeCapacity(*pool),
+         pool->currentBytes(),
+         pool.get()});
+  }
+  return candidates;
+}
+
+void SharedArbitrator::updateFreeCapacityMetrics() const {
+  RECORD_METRIC_VALUE(
+      kMetricArbitratorFreeCapacityBytes,
+      freeNonReservedCapacity_ + freeReservedCapacity_);
+  RECORD_METRIC_VALUE(
+      kMetricArbitratorFreeReservedCapacityBytes, freeReservedCapacity_);
+}
+
+int64_t SharedArbitrator::reclaimableCapacity(const MemoryPool& pool) const {
+  return std::max<int64_t>(0, pool.capacity() - memoryPoolReservedCapacity_);
+}
+
+int64_t SharedArbitrator::reclaimableFreeCapacity(
+    const MemoryPool& pool) const {
+  return std::min<int64_t>(pool.freeBytes(), reclaimableCapacity(pool));
+}
+
+int64_t SharedArbitrator::reclaimableUsedCapacity(
+    const MemoryPool& pool) const {
+  const auto maxReclaimableBytes = reclaimableCapacity(pool);
+  const auto reclaimableBytes = pool.reclaimableBytes();
+  return std::min<int64_t>(maxReclaimableBytes, reclaimableBytes.value_or(0));
+}
+
+int64_t SharedArbitrator::minGrowCapacity(const MemoryPool& pool) const {
+  return std::max<int64_t>(
+      0,
+      std::min<int64_t>(pool.maxCapacity(), memoryPoolReservedCapacity_) -
+          pool.capacity());
 }
 
 uint64_t SharedArbitrator::growCapacity(
     MemoryPool* pool,
     uint64_t targetBytes) {
-  const int64_t bytesToReserve =
-      std::min<int64_t>(maxGrowBytes(*pool), targetBytes);
-  uint64_t reserveBytes;
-  uint64_t freeCapacity;
+  const auto freeCapacityUpdateCb =
+      folly::makeGuard([this]() { updateFreeCapacityMetrics(); });
+
+  uint64_t reservedBytes{0};
   {
     std::lock_guard<std::mutex> l(mutex_);
     ++numReserves_;
-    reserveBytes = decrementFreeCapacityLocked(bytesToReserve);
-    pool->grow(reserveBytes);
-    freeCapacity = freeCapacity_;
+    const int64_t maxBytesToReserve =
+        std::min<int64_t>(maxGrowCapacity(*pool), targetBytes);
+    const int64_t minBytesToReserve = minGrowCapacity(*pool);
+    reservedBytes =
+        decrementFreeCapacityLocked(maxBytesToReserve, minBytesToReserve);
+    pool->grow(reservedBytes);
   }
-  RECORD_METRIC_VALUE(kMetricArbitratorFreeCapacityBytes, freeCapacity);
-  return reserveBytes;
+  return reservedBytes;
+}
+
+uint64_t SharedArbitrator::decrementFreeCapacity(
+    uint64_t maxBytes,
+    uint64_t minBytes) {
+  uint64_t reservedBytes{0};
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    reservedBytes = decrementFreeCapacityLocked(maxBytes, minBytes);
+  }
+  return reservedBytes;
+}
+
+uint64_t SharedArbitrator::decrementFreeCapacityLocked(
+    uint64_t maxBytes,
+    uint64_t minBytes) {
+  uint64_t allocatedBytes = std::min(freeNonReservedCapacity_, maxBytes);
+  VELOX_CHECK_LE(allocatedBytes, freeNonReservedCapacity_);
+  freeNonReservedCapacity_ -= allocatedBytes;
+  if (allocatedBytes < minBytes) {
+    const uint64_t reservedBytes =
+        std::min(minBytes - allocatedBytes, freeReservedCapacity_);
+    VELOX_CHECK_LE(reservedBytes, freeReservedCapacity_);
+    freeReservedCapacity_ -= reservedBytes;
+    allocatedBytes += reservedBytes;
+  }
+  return allocatedBytes;
 }
 
 uint64_t SharedArbitrator::shrinkCapacity(
     MemoryPool* pool,
     uint64_t targetBytes) {
+  const auto freeCapacityUpdateCb =
+      folly::makeGuard([this]() { updateFreeCapacityMetrics(); });
+
   uint64_t freedBytes{0};
-  uint64_t freeCapacity{0};
   {
     std::lock_guard<std::mutex> l(mutex_);
     ++numReleases_;
     freedBytes = pool->shrink(targetBytes);
     incrementFreeCapacityLocked(freedBytes);
-    freeCapacity = freeCapacity_;
   }
-  RECORD_METRIC_VALUE(kMetricArbitratorFreeCapacityBytes, freeCapacity);
   return freedBytes;
 }
 
@@ -238,6 +305,9 @@ uint64_t SharedArbitrator::shrinkCapacity(
     uint64_t targetBytes,
     bool allowSpill,
     bool allowAbort) {
+  const auto freeCapacityUpdateCb =
+      folly::makeGuard([this]() { updateFreeCapacityMetrics(); });
+
   ScopedArbitration scopedArbitration(this);
   if (targetBytes == 0) {
     targetBytes = capacity_;
@@ -261,12 +331,12 @@ uint64_t SharedArbitrator::shrinkCapacity(
     if (freedBytes >= targetBytes) {
       return freedBytes;
     }
-  }
-  if (allowAbort) {
-    if (allowSpill) {
+    if (allowAbort) {
       // Candidate stats may change after spilling.
       candidates = getCandidateStats(pools);
     }
+  }
+  if (allowAbort) {
     freedBytes += reclaimUsedMemoryFromCandidatesByAbort(
         candidates, targetBytes - freedBytes);
   }
@@ -282,15 +352,18 @@ bool SharedArbitrator::growCapacity(
     MemoryPool* pool,
     const std::vector<std::shared_ptr<MemoryPool>>& candidatePools,
     uint64_t targetBytes) {
+  const auto freeCapacityUpdateCb =
+      folly::makeGuard([this]() { updateFreeCapacityMetrics(); });
+
   ScopedArbitration scopedArbitration(pool, this);
   MemoryPool* requestor = pool->root();
-  if (FOLLY_UNLIKELY(requestor->aborted())) {
+  if (requestor->aborted()) {
     RECORD_METRIC_VALUE(kMetricArbitratorFailuresCount);
     ++numFailures_;
-    VELOX_MEM_POOL_ABORTED("The requestor has already been aborted");
+    VELOX_MEM_POOL_ABORTED("The requestor pool has been aborted");
   }
 
-  if (FOLLY_UNLIKELY(!ensureCapacity(requestor, targetBytes))) {
+  if (!ensureCapacity(requestor, targetBytes)) {
     RECORD_METRIC_VALUE(kMetricArbitratorFailuresCount);
     ++numFailures_;
     VELOX_MEM_LOG(ERROR) << "Can't grow " << requestor->name()
@@ -305,7 +378,6 @@ bool SharedArbitrator::growCapacity(
   }
 
   std::vector<Candidate> candidates;
-  candidates.reserve(candidatePools.size());
   int numRetries{0};
   for (;; ++numRetries) {
     // Get refreshed stats before the memory arbitration retry.
@@ -335,7 +407,7 @@ bool SharedArbitrator::growCapacity(
 bool SharedArbitrator::checkCapacityGrowth(
     const MemoryPool& pool,
     uint64_t targetBytes) const {
-  return (maxGrowBytes(pool) >= targetBytes) &&
+  return (maxGrowCapacity(pool) >= targetBytes) &&
       (capacityAfterGrowth(pool, targetBytes) <= capacity_);
 }
 
@@ -398,11 +470,11 @@ bool SharedArbitrator::arbitrateMemory(
     std::vector<Candidate>& candidates,
     uint64_t targetBytes) {
   VELOX_CHECK(!requestor->aborted());
-
   const uint64_t growTarget = std::min(
-      maxGrowBytes(*requestor),
+      maxGrowCapacity(*requestor),
       std::max(memoryPoolTransferCapacity_, targetBytes));
-  uint64_t freedBytes = decrementFreeCapacity(growTarget);
+  const uint64_t minGrowTarget = minGrowCapacity(*requestor);
+  uint64_t freedBytes = decrementFreeCapacity(growTarget, minGrowTarget);
   if (freedBytes >= targetBytes) {
     requestor->grow(freedBytes);
     return true;
@@ -434,7 +506,6 @@ bool SharedArbitrator::arbitrateMemory(
     ++numFailures_;
     VELOX_MEM_POOL_ABORTED("The requestor pool has been aborted.");
   }
-
   VELOX_CHECK(!requestor->aborted());
 
   if (freedBytes < targetBytes) {
@@ -455,8 +526,8 @@ bool SharedArbitrator::arbitrateMemory(
 uint64_t SharedArbitrator::reclaimFreeMemoryFromCandidates(
     std::vector<Candidate>& candidates,
     uint64_t targetBytes) {
-  // Sort candidate memory pools based on their free capacity.
-  sortCandidatesByFreeCapacity(candidates);
+  // Sort candidate memory pools based on their reclaimable free capacity.
+  sortCandidatesByReclaimableFreeCapacity(candidates);
 
   uint64_t freedBytes{0};
   for (const auto& candidate : candidates) {
@@ -473,6 +544,7 @@ uint64_t SharedArbitrator::reclaimFreeMemoryFromCandidates(
     if (freedBytes >= targetBytes) {
       break;
     }
+    VELOX_CHECK_GE(candidate.pool->capacity(), memoryPoolReservedCapacity_);
   }
   numShrunkBytes_ += freedBytes;
   return freedBytes;
@@ -482,19 +554,16 @@ uint64_t SharedArbitrator::reclaimUsedMemoryFromCandidatesBySpill(
     MemoryPool* requestor,
     std::vector<Candidate>& candidates,
     uint64_t targetBytes) {
-  // Sort candidate memory pools based on their reclaimable memory.
-  sortCandidatesByReclaimableMemory(candidates);
+  // Sort candidate memory pools based on their reclaimable used capacity.
+  sortCandidatesByReclaimableUsedMemory(candidates);
 
-  int64_t freedBytes{0};
+  uint64_t freedBytes{0};
   for (const auto& candidate : candidates) {
     VELOX_CHECK_LT(freedBytes, targetBytes);
-    if (!candidate.reclaimable || candidate.reclaimableBytes == 0) {
+    if (candidate.reclaimableBytes == 0) {
       break;
     }
-    const int64_t bytesToReclaim = std::max<int64_t>(
-        targetBytes - freedBytes, memoryPoolTransferCapacity_);
-    VELOX_CHECK_GT(bytesToReclaim, 0);
-    freedBytes += reclaim(candidate.pool, bytesToReclaim, false);
+    freedBytes += reclaim(candidate.pool, targetBytes - freedBytes, false);
     if ((freedBytes >= targetBytes) ||
         (requestor != nullptr && requestor->aborted())) {
       break;
@@ -508,10 +577,10 @@ uint64_t SharedArbitrator::reclaimUsedMemoryFromCandidatesByAbort(
     uint64_t targetBytes) {
   sortCandidatesByUsage(candidates);
 
-  int64_t freedBytes{0};
+  uint64_t freedBytes{0};
   for (const auto& candidate : candidates) {
     VELOX_CHECK_LT(freedBytes, targetBytes);
-    if (candidate.currentBytes == 0) {
+    if (candidate.pool->capacity() == 0) {
       break;
     }
     try {
@@ -536,21 +605,28 @@ uint64_t SharedArbitrator::reclaim(
     MemoryPool* pool,
     uint64_t targetBytes,
     bool isLocalArbitration) noexcept {
+  int64_t bytesToReclaim = std::min<uint64_t>(
+      std::max(targetBytes, memoryPoolTransferCapacity_),
+      reclaimableCapacity(*pool));
+  if (bytesToReclaim == 0) {
+    return 0;
+  }
   uint64_t reclaimDurationUs{0};
   uint64_t reclaimedBytes{0};
-  uint64_t freedBytes{0};
+  uint64_t reclaimedFreeBytes{0};
   MemoryReclaimer::Stats reclaimerStats;
   {
-    MicrosecondTimer reclaimTimer(&reclaimDurationUs);
     const uint64_t oldCapacity = pool->capacity();
+    MicrosecondTimer reclaimTimer(&reclaimDurationUs);
     try {
-      freedBytes = pool->shrink(targetBytes);
-      if (freedBytes < targetBytes) {
+      reclaimedFreeBytes = pool->shrink(bytesToReclaim);
+      bytesToReclaim -= reclaimedFreeBytes;
+      VELOX_CHECK_GE(bytesToReclaim, 0);
+      if (bytesToReclaim > 0) {
         if (isLocalArbitration) {
           incrementLocalArbitrationCount();
         }
-        pool->reclaim(
-            targetBytes - freedBytes, memoryReclaimWaitMs_, reclaimerStats);
+        pool->reclaim(bytesToReclaim, memoryReclaimWaitMs_, reclaimerStats);
       }
     } catch (const std::exception& e) {
       VELOX_MEM_LOG(ERROR) << "Failed to reclaim from memory pool "
@@ -564,16 +640,19 @@ uint64_t SharedArbitrator::reclaim(
     VELOX_CHECK_GE(oldCapacity, newCapacity);
     reclaimedBytes = oldCapacity - newCapacity;
   }
-  numReclaimedBytes_ += reclaimedBytes - freedBytes;
-  numShrunkBytes_ += freedBytes;
+  VELOX_CHECK_GE(reclaimedBytes, reclaimedFreeBytes);
+  numReclaimedBytes_ += reclaimedBytes - reclaimedFreeBytes;
+  numShrunkBytes_ += reclaimedFreeBytes;
   reclaimTimeUs_ += reclaimDurationUs;
   numNonReclaimableAttempts_ += reclaimerStats.numNonReclaimableAttempts;
-  VELOX_MEM_LOG_EVERY_MS(INFO, 1000)
-      << "Reclaimed from memory pool " << pool->name() << " with target of "
-      << succinctBytes(targetBytes) << ", actually reclaimed "
-      << succinctBytes(freedBytes) << " free memory and "
-      << succinctBytes(reclaimedBytes - freedBytes) << " used memory, spent "
-      << succinctMicros(reclaimDurationUs);
+  VELOX_MEM_LOG(INFO) << "Reclaimed from memory pool " << pool->name()
+                      << " with target of " << succinctBytes(targetBytes)
+                      << ", actually reclaimed "
+                      << succinctBytes(reclaimedFreeBytes)
+                      << " free memory and "
+                      << succinctBytes(reclaimedBytes - reclaimedFreeBytes)
+                      << " used memory, spent "
+                      << succinctMicros(reclaimDurationUs);
   return reclaimedBytes;
 }
 
@@ -594,44 +673,31 @@ void SharedArbitrator::abort(
   VELOX_CHECK(pool->aborted());
 }
 
-uint64_t SharedArbitrator::decrementFreeCapacity(uint64_t bytes) {
-  uint64_t reserveBytes;
-  uint64_t freeCapacity;
-  {
-    std::lock_guard<std::mutex> l(mutex_);
-    reserveBytes = decrementFreeCapacityLocked(bytes);
-    freeCapacity = freeCapacity_;
-  }
-  RECORD_METRIC_VALUE(kMetricArbitratorFreeCapacityBytes, freeCapacity);
-  return reserveBytes;
-}
-
-uint64_t SharedArbitrator::decrementFreeCapacityLocked(uint64_t bytes) {
-  const uint64_t targetBytes = std::min(freeCapacity_, bytes);
-  VELOX_CHECK_LE(targetBytes, freeCapacity_);
-  freeCapacity_ -= targetBytes;
-  return targetBytes;
-}
-
 void SharedArbitrator::incrementFreeCapacity(uint64_t bytes) {
-  uint64_t freeCapacity;
-  {
-    std::lock_guard<std::mutex> l(mutex_);
-    incrementFreeCapacityLocked(bytes);
-    freeCapacity = freeCapacity_;
-  }
-  RECORD_METRIC_VALUE(kMetricArbitratorFreeCapacityBytes, freeCapacity);
+  std::lock_guard<std::mutex> l(mutex_);
+  incrementFreeCapacityLocked(bytes);
 }
 
 void SharedArbitrator::incrementFreeCapacityLocked(uint64_t bytes) {
-  freeCapacity_ += bytes;
-  if (FOLLY_UNLIKELY(freeCapacity_ > capacity_)) {
+  incrementFreeReservedCapacityLocked(bytes);
+  freeNonReservedCapacity_ += bytes;
+  if (FOLLY_UNLIKELY(
+          freeNonReservedCapacity_ + freeReservedCapacity_ > capacity_)) {
     VELOX_FAIL(
-        "The free capacity {} is larger than the max capacity {}, {}",
-        succinctBytes(freeCapacity_),
+        "The free capacity {}/{} is larger than the max capacity {}, {}",
+        succinctBytes(freeNonReservedCapacity_),
+        succinctBytes(freeReservedCapacity_),
         succinctBytes(capacity_),
         toStringLocked());
   }
+}
+
+void SharedArbitrator::incrementFreeReservedCapacityLocked(uint64_t& bytes) {
+  VELOX_CHECK_LE(freeReservedCapacity_, reservedCapacity_);
+  const uint64_t freedBytes =
+      std::min(bytes, reservedCapacity_ - freeReservedCapacity_);
+  freeReservedCapacity_ += freedBytes;
+  bytes -= freedBytes;
 }
 
 MemoryArbitrator::Stats SharedArbitrator::stats() const {
@@ -650,7 +716,8 @@ MemoryArbitrator::Stats SharedArbitrator::statsLocked() const {
   stats.numShrunkBytes = numShrunkBytes_;
   stats.numReclaimedBytes = numReclaimedBytes_;
   stats.maxCapacityBytes = capacity_;
-  stats.freeCapacityBytes = freeCapacity_;
+  stats.freeCapacityBytes = freeNonReservedCapacity_ + freeReservedCapacity_;
+  stats.freeReservedCapacityBytes = freeReservedCapacity_;
   stats.reclaimTimeUs = reclaimTimeUs_;
   stats.numNonReclaimableAttempts = numNonReclaimableAttempts_;
   stats.numReserves = numReserves_;

--- a/velox/common/memory/tests/ByteStreamTest.cpp
+++ b/velox/common/memory/tests/ByteStreamTest.cpp
@@ -30,6 +30,8 @@ class ByteStreamTest : public testing::Test {
     MemoryManagerOptions options;
     options.useMmapAllocator = true;
     options.allocatorCapacity = kMaxMappedMemory;
+    options.arbitratorCapacity = kMaxMappedMemory;
+    options.arbitratorReservedCapacity = 0;
     memoryManager_ = std::make_unique<MemoryManager>(options);
     mmapAllocator_ = static_cast<MmapAllocator*>(memoryManager_->allocator());
     pool_ = memoryManager_->addLeafPool("ByteStreamTest");

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -48,7 +48,7 @@ struct ProcessSize {
 };
 } // namespace
 
-static constexpr uint64_t kCapacityBytes = 1024UL * 1024 * 1024;
+static constexpr uint64_t kCapacityBytes = 1ULL << 30;
 static constexpr MachinePageCount kCapacityPages =
     (kCapacityBytes / AllocationTraits::kPageSize);
 
@@ -72,6 +72,9 @@ class MemoryAllocatorTest : public testing::TestWithParam<int> {
       MemoryManagerOptions options;
       options.useMmapAllocator = true;
       options.allocatorCapacity = kCapacityBytes;
+      options.arbitratorCapacity = kCapacityBytes;
+      options.arbitratorReservedCapacity = 128 << 20;
+      options.memoryPoolReservedCapacity = 1 << 20;
       options.smallAllocationReservePct = 4;
       options.maxMallocBytes = maxMallocBytes_;
       memoryManager_ = std::make_unique<MemoryManager>(options);
@@ -84,6 +87,9 @@ class MemoryAllocatorTest : public testing::TestWithParam<int> {
     } else {
       MemoryManagerOptions options;
       options.allocatorCapacity = kCapacityBytes;
+      options.arbitratorCapacity = kCapacityBytes;
+      options.arbitratorReservedCapacity = 128 << 20;
+      options.memoryPoolReservedCapacity = 1 << 20;
       if (!enableReservation_) {
         options.allocationSizeThresholdWithReservation = 0;
       }

--- a/velox/common/memory/tests/MemoryCapExceededTest.cpp
+++ b/velox/common/memory/tests/MemoryCapExceededTest.cpp
@@ -204,7 +204,9 @@ TEST_P(MemoryCapExceededTest, allocatorCapacityExceededError) {
   for (const auto& testData : testSettings) {
     memory::MemoryManager manager(
         {.allocatorCapacity = (int64_t)testData.allocatorCapacity,
-         .useMmapAllocator = testData.useMmap});
+         .useMmapAllocator = testData.useMmap,
+         .arbitratorCapacity = (int64_t)testData.allocatorCapacity,
+         .arbitratorReservedCapacity = 0});
 
     vector_size_t size = 1'024;
     // This limit ensures that only the Aggregation Operator fails.

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -45,8 +45,10 @@ constexpr int64_t KB = 1024L;
 constexpr int64_t MB = 1024L * KB;
 
 constexpr uint64_t kMemoryCapacity = 512 * MB;
+constexpr uint64_t kReservedMemoryCapacity = 128 * MB;
 constexpr uint64_t kMemoryPoolInitCapacity = 16 * MB;
 constexpr uint64_t kMemoryPoolTransferCapacity = 8 * MB;
+constexpr uint64_t kMemoryPoolReservedCapacity = 8 * MB;
 
 class MemoryReclaimer;
 class MockMemoryOperator;
@@ -245,6 +247,9 @@ class MockMemoryOperator {
     size_t size;
     {
       std::lock_guard<std::mutex> l(mu_);
+      if (allocations_.count(buffer) != 1) {
+        LOG(ERROR) << "done";
+      }
       VELOX_CHECK_EQ(allocations_.count(buffer), 1);
       size = allocations_[buffer];
       totalBytes_ -= size;
@@ -404,22 +409,19 @@ class MockSharedArbitrationTest : public testing::Test {
   }
 
   void setupMemory(
-      int64_t memoryCapacity = 0,
-      uint64_t memoryPoolInitCapacity = kMaxMemory,
-      uint64_t memoryPoolTransferCapacity = 0,
+      int64_t memoryCapacity = kMemoryCapacity,
+      int64_t reservedMemoryCapacity = kReservedMemoryCapacity,
+      uint64_t memoryPoolInitCapacity = kMemoryPoolInitCapacity,
+      uint64_t memoryPoolReserveCapacity = kMemoryPoolReservedCapacity,
+      uint64_t memoryPoolTransferCapacity = kMemoryPoolTransferCapacity,
       std::function<void(MemoryPool&)> arbitrationStateCheckCb = nullptr) {
-    if (memoryPoolInitCapacity == kMaxMemory) {
-      memoryPoolInitCapacity = kMemoryPoolInitCapacity;
-    }
-    if (memoryPoolTransferCapacity == 0) {
-      memoryPoolTransferCapacity = kMemoryPoolTransferCapacity;
-    }
-    memoryCapacity = (memoryCapacity != 0) ? memoryCapacity : kMemoryCapacity;
     MemoryManagerOptions options;
     options.allocatorCapacity = memoryCapacity;
+    options.arbitratorReservedCapacity = reservedMemoryCapacity;
     std::string arbitratorKind = "SHARED";
     options.arbitratorKind = arbitratorKind;
     options.memoryPoolInitCapacity = memoryPoolInitCapacity;
+    options.memoryPoolReservedCapacity = memoryPoolReserveCapacity;
     options.memoryPoolTransferCapacity = memoryPoolTransferCapacity;
     options.arbitrationStateCheckCb = std::move(arbitrationStateCheckCb);
     options.checkUsageLeak = true;
@@ -472,6 +474,7 @@ void verifyArbitratorStats(
     const MemoryArbitrator::Stats& stats,
     uint64_t maxCapacityBytes,
     uint64_t freeCapacityBytes = 0,
+    uint64_t freeReservedCapacityBytes = 0,
     uint64_t numRequests = 0,
     uint64_t numSucceeded = 0,
     uint64_t numFailures = 0,
@@ -486,6 +489,7 @@ void verifyArbitratorStats(
   ASSERT_EQ(stats.numShrunkBytes, numShrunkBytes);
   ASSERT_GE(stats.arbitrationTimeUs, arbitrationTimeUs);
   ASSERT_GE(stats.queueTimeUs, queueTimeUs);
+  ASSERT_EQ(stats.freeReservedCapacityBytes, freeReservedCapacityBytes);
   ASSERT_EQ(stats.freeCapacityBytes, freeCapacityBytes);
   ASSERT_EQ(stats.maxCapacityBytes, maxCapacityBytes);
 }
@@ -504,22 +508,31 @@ void verifyReclaimerStats(
 }
 
 TEST_F(MockSharedArbitrationTest, constructor) {
+  const int reservedCapacity = arbitrator_->stats().freeReservedCapacityBytes;
+  const int nonReservedCapacity =
+      arbitrator_->stats().freeCapacityBytes - reservedCapacity;
   std::vector<std::shared_ptr<MockTask>> tasks;
+  int remainingFreeCapacity = arbitrator_->stats().freeCapacityBytes;
   for (int i = 0; i <= kMemoryCapacity / kMemoryPoolInitCapacity; ++i) {
     auto task = addTask(kMemoryCapacity);
     ASSERT_NE(task->pool()->reclaimer(), nullptr);
-    if (i < kMemoryCapacity / kMemoryPoolInitCapacity) {
+    if (i < nonReservedCapacity / kMemoryPoolInitCapacity) {
       ASSERT_EQ(task->capacity(), kMemoryPoolInitCapacity);
     } else {
-      ASSERT_EQ(task->capacity(), 0);
+      ASSERT_EQ(task->capacity(), kMemoryPoolReservedCapacity);
     }
+    remainingFreeCapacity -= task->capacity();
     tasks.push_back(std::move(task));
   }
   auto stats = arbitrator_->stats();
-  verifyArbitratorStats(stats, kMemoryCapacity);
+  ASSERT_EQ(remainingFreeCapacity, stats.freeCapacityBytes);
+  ASSERT_EQ(remainingFreeCapacity, stats.freeReservedCapacityBytes);
+  verifyArbitratorStats(
+      stats, kMemoryCapacity, remainingFreeCapacity, remainingFreeCapacity);
   tasks.clear();
   stats = arbitrator_->stats();
-  verifyArbitratorStats(stats, kMemoryCapacity, kMemoryCapacity);
+  verifyArbitratorStats(
+      stats, kMemoryCapacity, kMemoryCapacity, reservedCapacity);
 }
 
 TEST_F(MockSharedArbitrationTest, arbitrationStateCheck) {
@@ -531,7 +544,7 @@ TEST_F(MockSharedArbitrationTest, arbitrationStateCheck) {
     ASSERT_TRUE(RE2::FullMatch(pool.name(), re));
     ++checkCount;
   };
-  setupMemory(memCapacity, 0, 0, checkCountCb);
+  setupMemory(memCapacity, 0, 0, 0, 0, checkCountCb);
 
   const int numTasks{5};
   std::vector<std::shared_ptr<MockTask>> tasks;
@@ -556,7 +569,7 @@ TEST_F(MockSharedArbitrationTest, arbitrationStateCheck) {
   MemoryArbitrationStateCheckCB badCheckCb = [&](MemoryPool& /*unused*/) {
     VELOX_FAIL("bad check");
   };
-  setupMemory(memCapacity, 0, 0, badCheckCb);
+  setupMemory(memCapacity, 0, 0, 0, 0, badCheckCb);
   std::shared_ptr<MockTask> task = addTask(kMemoryCapacity);
   ASSERT_EQ(task->capacity(), 0);
   MockMemoryOperator* memOp = task->addMemoryOp();
@@ -564,24 +577,24 @@ TEST_F(MockSharedArbitrationTest, arbitrationStateCheck) {
 }
 
 TEST_F(MockSharedArbitrationTest, arbitrationFailsTask) {
-  auto nonReclaimTask = addTask(384 * MB);
-  auto nonReclaimOp = nonReclaimTask->addMemoryOp(false);
-  auto buf = nonReclaimOp->allocate(384 * MB);
+  auto nonReclaimTask = addTask(328 * MB);
+  auto* nonReclaimOp = nonReclaimTask->addMemoryOp(false);
+  auto* buf = nonReclaimOp->allocate(320 * MB);
 
   // growTask is (192 + 128) = 320MB which is less than nonReclaimTask 384MB.
-  // This makes sure nonReclaimTask gets picked as the victim during handleOOM()
-  auto growTask = addTask(192 * MB);
-  auto growOp = growTask->addMemoryOp(false);
-  auto bufGrow = growOp->allocate(128 * MB);
-  EXPECT_NO_THROW(manager_->testingGrowPool(growOp->pool(), 64 * MB));
+  // This makes sure nonReclaimTask gets picked as the victim during
+  // handleOOM().
+  auto growTask = addTask(328 * MB);
+  auto* growOp = growTask->addMemoryOp(false);
+  auto* bufGrow = growOp->allocate(64 * MB);
+  ASSERT_NO_THROW(manager_->testingGrowPool(growOp->pool(), 128 * MB));
   ASSERT_NE(nonReclaimTask->error(), nullptr);
   try {
     std::rethrow_exception(nonReclaimTask->error());
   } catch (const VeloxRuntimeError& e) {
     ASSERT_EQ(velox::error_code::kMemAborted, e.errorCode());
     ASSERT_TRUE(
-        std::string(e.what()).find(
-            "usage 384.00MB reserved 384.00MB peak 384.00MB") !=
+        std::string(e.what()).find("aborted when requestor") !=
         std::string::npos);
   } catch (...) {
     FAIL();
@@ -591,141 +604,422 @@ TEST_F(MockSharedArbitrationTest, arbitrationFailsTask) {
 }
 
 TEST_F(MockSharedArbitrationTest, shrinkPools) {
-  struct TaskTestData {
+  const int64_t memoryCapacity = 32 << 20;
+  const int64_t reservedMemoryCapacity = 8 << 20;
+  const uint64_t memoryPoolInitCapacity = 8 << 20;
+  const uint64_t memoryPoolReserveCapacity = 2 << 20;
+  const uint64_t memoryPoolTransferCapacity = 2 << 20;
+  setupMemory(
+      memoryCapacity,
+      reservedMemoryCapacity,
+      memoryPoolInitCapacity,
+      memoryPoolReserveCapacity,
+      memoryPoolTransferCapacity);
+
+  struct TestTask {
     uint64_t capacity{0};
     bool reclaimable{false};
+    uint64_t allocateBytes{0};
 
-    uint64_t expectedCapacityAfterShrink{0};
+    uint64_t expectedInitialCapacity{0};
     bool expectedAbortAfterShrink{false};
 
     std::string debugString() const {
       return fmt::format(
-          "capacity: {}, reclaimable: {}, expectedCapacityAfterShrink: {}, expectedAbortAfterShrink: {}",
+          "capacity: {}, reclaimable: {}, allocateBytes: {}, expectedInitialCapacity: {}, expectedAbortAfterShrink: {}",
           succinctBytes(capacity),
+          succinctBytes(allocateBytes),
           reclaimable,
-          succinctBytes(expectedCapacityAfterShrink),
+          succinctBytes(expectedInitialCapacity),
           expectedAbortAfterShrink);
     }
   };
 
   struct {
-    std::vector<TaskTestData> taskTestDatas;
+    std::vector<TestTask> testTasks;
     uint64_t targetBytes;
     uint64_t expectedFreedBytes;
+    uint64_t expectedFreeCapacity;
+    uint64_t expectedReservedFreeCapacity;
     bool allowSpill;
     bool allowAbort;
 
     std::string debugString() const {
       std::stringstream tasksOss;
-      for (const auto& taskTestData : taskTestDatas) {
-        tasksOss << taskTestData.debugString();
+      for (const auto& testTask : testTasks) {
+        tasksOss << testTask.debugString();
         tasksOss << ",";
       }
       return fmt::format(
-          "taskTestDatas: [{}], targetBytes: {}, expectedFreedBytes: {}, allowSpill: {}, allowAbort: {}",
+          "taskTests: [{}], targetBytes: {}, expectedFreedBytes: {}, expectedReservedFreeCapacity: {}, allowSpill: {}, allowAbort: {}",
           tasksOss.str(),
           succinctBytes(targetBytes),
           succinctBytes(expectedFreedBytes),
+          succinctBytes(expectedReservedFreeCapacity),
           allowSpill,
           allowAbort);
     }
   } testSettings[] = {
-      {{{kMemoryCapacity / 4, true, 0, false},
-        {kMemoryCapacity / 2, true, 0, false},
-        {kMemoryCapacity / 4, false, kMemoryCapacity / 4, false}},
+      {{{memoryPoolInitCapacity, true, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, true, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, false, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, false, 0, memoryPoolReserveCapacity, false}},
        0,
-       kMemoryCapacity / 4 * 3,
+       18 << 20,
+       24 << 20,
+       reservedMemoryCapacity,
        true,
        false},
-      {{{kMemoryCapacity / 4, true, 0, false},
-        {kMemoryCapacity / 2, true, 0, false},
-        {kMemoryCapacity / 4, false, 0, true}},
-       0,
-       kMemoryCapacity,
-       true,
-       true},
-      {{{kMemoryCapacity / 4, true, kMemoryCapacity / 4, false},
-        {kMemoryCapacity / 2, true, kMemoryCapacity / 2, false},
-        {kMemoryCapacity / 4, false, kMemoryCapacity / 4, false}},
-       0,
-       0,
-       false,
-       false},
-      {{{kMemoryCapacity / 4, true, 0, true},
-        {kMemoryCapacity / 2, true, 0, true},
-        {kMemoryCapacity / 4, false, 0, true}},
-       0,
-       kMemoryCapacity,
-       false,
-       true},
-      {{{kMemoryCapacity / 4, true, 0, false},
-        {kMemoryCapacity / 2, true, 0, false},
-        {kMemoryCapacity / 4, false, kMemoryCapacity / 4, false}},
-       1UL << 30,
-       kMemoryCapacity / 4 * 3,
-       true,
-       false},
-      {{{kMemoryCapacity / 4, true, 0, false},
-        {kMemoryCapacity / 2, true, 0, false},
-        {kMemoryCapacity / 4, false, 0, true}},
-       1UL << 30,
-       kMemoryCapacity,
-       true,
-       true},
-      {{{kMemoryCapacity / 4, true, kMemoryCapacity / 4, false},
-        {kMemoryCapacity / 2, true, kMemoryCapacity / 2, false},
-        {kMemoryCapacity / 4, false, kMemoryCapacity / 4, false}},
-       1UL << 30,
-       0,
-       false,
-       false},
-      {{{kMemoryCapacity / 4, true, 0, true},
-        {kMemoryCapacity / 2, true, 0, true},
-        {kMemoryCapacity / 4, false, 0, true}},
-       1UL << 30,
-       kMemoryCapacity,
-       false,
-       true},
-      {{{kMemoryCapacity / 4, true, kMemoryCapacity / 4, false},
-        {kMemoryCapacity / 2,
-         true,
-         kMemoryCapacity / 2 - kMemoryPoolTransferCapacity,
-         false},
-        {kMemoryCapacity / 4, false, kMemoryCapacity / 4, false}},
-       1,
-       kMemoryPoolTransferCapacity,
-       true,
-       false},
-      {{{kMemoryCapacity / 4, true, kMemoryCapacity / 4, false},
-        {kMemoryCapacity / 2,
-         true,
-         kMemoryCapacity / 2 - kMemoryPoolTransferCapacity,
-         false},
-        {kMemoryCapacity / 4, false, kMemoryCapacity / 4, false}},
-       1,
-       kMemoryPoolTransferCapacity,
-       true,
-       true},
-      {{{kMemoryCapacity / 4, true, kMemoryCapacity / 4, false},
-        {kMemoryCapacity / 2, true, kMemoryCapacity / 2, false},
 
-        {kMemoryCapacity / 4, false, kMemoryCapacity / 4, false}},
-       1,
+      {{{memoryPoolInitCapacity, true, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, true, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, false, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, true, 0, memoryPoolReserveCapacity, false}},
        0,
+       18 << 20,
+       24 << 20,
+       reservedMemoryCapacity,
+       true,
+       false},
+
+      {{{memoryPoolInitCapacity,
+         false,
+         memoryPoolInitCapacity,
+         memoryPoolInitCapacity,
+         false},
+        {memoryPoolInitCapacity, true, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, false, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity,
+         true,
+         memoryPoolReserveCapacity,
+         memoryPoolReserveCapacity,
+         false}},
+       0,
+       12 << 20,
+       18 << 20,
+       reservedMemoryCapacity,
+       true,
+       false},
+
+      {{{memoryPoolInitCapacity,
+         true,
+         memoryPoolInitCapacity,
+         memoryPoolInitCapacity,
+         false},
+        {memoryPoolInitCapacity, true, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, false, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity,
+         true,
+         memoryPoolReserveCapacity,
+         memoryPoolReserveCapacity,
+         false}},
+       0,
+       18 << 20,
+       24 << 20,
+       reservedMemoryCapacity,
+       true,
+       false},
+
+      {{{memoryPoolInitCapacity,
+         true,
+         memoryPoolInitCapacity,
+         memoryPoolInitCapacity,
+         false},
+        {memoryPoolInitCapacity, true, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, false, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity,
+         true,
+         memoryPoolReserveCapacity,
+         memoryPoolReserveCapacity,
+         false}},
+       0,
+       12 << 20,
+       18 << 20,
+       reservedMemoryCapacity,
        false,
        false},
-      {{{kMemoryCapacity / 4, true, kMemoryCapacity / 4, false},
-        {kMemoryCapacity / 2, true, 0, true},
-        {kMemoryCapacity / 4, false, kMemoryCapacity / 4, false}},
-       1,
-       kMemoryCapacity / 2,
+
+      {{{memoryPoolInitCapacity,
+         false,
+         memoryPoolInitCapacity,
+         memoryPoolInitCapacity,
+         false},
+        {memoryPoolInitCapacity, true, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, false, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity,
+         true,
+         memoryPoolReserveCapacity,
+         memoryPoolReserveCapacity,
+         false}},
+       0,
+       12 << 20,
+       18 << 20,
+       reservedMemoryCapacity,
+       true,
+       false},
+
+      {{{memoryPoolInitCapacity, true, 0, memoryPoolInitCapacity, true},
+        {memoryPoolInitCapacity, true, 0, memoryPoolInitCapacity, true},
+        {memoryPoolInitCapacity, false, 0, memoryPoolInitCapacity, true},
+        {memoryPoolInitCapacity, true, 0, memoryPoolReserveCapacity, true}},
+       0,
+       26 << 20,
+       memoryCapacity,
+       reservedMemoryCapacity,
        false,
-       true}};
+       true},
+
+      {{{memoryPoolInitCapacity,
+         true,
+         memoryPoolInitCapacity,
+         memoryPoolInitCapacity,
+         true},
+        {memoryPoolInitCapacity, true, 0, memoryPoolInitCapacity, true},
+        {memoryPoolInitCapacity, false, 0, memoryPoolInitCapacity, true},
+        {memoryPoolInitCapacity,
+         true,
+         memoryPoolReserveCapacity,
+         memoryPoolReserveCapacity,
+         true}},
+       0,
+       26 << 20,
+       memoryCapacity,
+       reservedMemoryCapacity,
+       true,
+       true},
+
+      {{{memoryPoolInitCapacity, true, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, true, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, false, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, true, 0, memoryPoolReserveCapacity, false}},
+       16 << 20,
+       16 << 20,
+       22 << 20,
+       reservedMemoryCapacity,
+       false,
+       false},
+
+      {{{memoryPoolInitCapacity, true, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, true, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, false, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, true, 0, memoryPoolReserveCapacity, false}},
+       16 << 20,
+       16 << 20,
+       22 << 20,
+       reservedMemoryCapacity,
+       true,
+       false},
+
+      {{{memoryPoolInitCapacity, true, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, true, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, false, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, true, 0, memoryPoolReserveCapacity, false}},
+       16 << 20,
+       16 << 20,
+       22 << 20,
+       reservedMemoryCapacity,
+       true,
+       true},
+
+      {{{memoryPoolInitCapacity, true, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, true, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, false, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, true, 0, memoryPoolReserveCapacity, false}},
+       14 << 20,
+       14 << 20,
+       20 << 20,
+       reservedMemoryCapacity,
+       false,
+       false},
+
+      {{{memoryPoolInitCapacity, true, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, true, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, false, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, true, 0, memoryPoolReserveCapacity, false}},
+       14 << 20,
+       14 << 20,
+       20 << 20,
+       reservedMemoryCapacity,
+       true,
+       false},
+
+      {{{memoryPoolInitCapacity, true, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, true, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, false, 0, memoryPoolInitCapacity, false},
+        {memoryPoolInitCapacity, true, 0, memoryPoolReserveCapacity, false}},
+       14 << 20,
+       14 << 20,
+       20 << 20,
+       reservedMemoryCapacity,
+       true,
+       true},
+
+      {{{memoryPoolInitCapacity,
+         true,
+         memoryPoolInitCapacity,
+         memoryPoolInitCapacity,
+         false},
+        {memoryPoolInitCapacity,
+         true,
+         memoryPoolInitCapacity,
+         memoryPoolInitCapacity,
+         false},
+        {memoryPoolInitCapacity,
+         false,
+         memoryPoolInitCapacity,
+         memoryPoolInitCapacity,
+         false},
+        {memoryPoolInitCapacity,
+         true,
+         memoryPoolReserveCapacity,
+         memoryPoolReserveCapacity,
+         false}},
+       14 << 20,
+       12 << 20,
+       18 << 20,
+       reservedMemoryCapacity,
+       true,
+       false},
+
+      {{{memoryPoolInitCapacity,
+         true,
+         memoryPoolInitCapacity,
+         memoryPoolInitCapacity,
+         false},
+        {memoryPoolInitCapacity,
+         true,
+         memoryPoolInitCapacity,
+         memoryPoolInitCapacity,
+         false},
+        {memoryPoolInitCapacity,
+         false,
+         memoryPoolInitCapacity,
+         memoryPoolInitCapacity,
+         false},
+        {memoryPoolInitCapacity,
+         true,
+         memoryPoolReserveCapacity,
+         memoryPoolReserveCapacity,
+         false}},
+       14 << 20,
+       0,
+       6 << 20,
+       6 << 20,
+       false,
+       false},
+
+      {{{memoryPoolInitCapacity,
+         true,
+         memoryPoolInitCapacity,
+         memoryPoolInitCapacity,
+         true},
+        {memoryPoolInitCapacity,
+         true,
+         memoryPoolInitCapacity,
+         memoryPoolInitCapacity,
+         true},
+        {memoryPoolInitCapacity,
+         false,
+         memoryPoolInitCapacity,
+         memoryPoolInitCapacity,
+         true},
+        {memoryPoolInitCapacity,
+         true,
+         memoryPoolReserveCapacity,
+         memoryPoolReserveCapacity,
+         false}},
+       24 << 20,
+       24 << 20,
+       30 << 20,
+       reservedMemoryCapacity,
+       false,
+       true},
+
+      {{{memoryPoolInitCapacity,
+         false,
+         memoryPoolInitCapacity,
+         memoryPoolInitCapacity,
+         false},
+        {memoryPoolInitCapacity,
+         false,
+         memoryPoolInitCapacity,
+         memoryPoolInitCapacity,
+         false},
+        {memoryPoolInitCapacity,
+         false,
+         memoryPoolInitCapacity,
+         memoryPoolInitCapacity,
+         false},
+        {memoryPoolInitCapacity,
+         false,
+         memoryPoolReserveCapacity,
+         memoryPoolReserveCapacity,
+         false}},
+       14 << 20,
+       0,
+       6 << 20,
+       6 << 20,
+       false,
+       false},
+
+      {{{memoryPoolInitCapacity,
+         false,
+         memoryPoolInitCapacity,
+         memoryPoolInitCapacity,
+         false},
+        {memoryPoolInitCapacity,
+         false,
+         memoryPoolInitCapacity,
+         memoryPoolInitCapacity,
+         false},
+        {memoryPoolInitCapacity,
+         false,
+         memoryPoolInitCapacity,
+         memoryPoolInitCapacity,
+         false},
+        {memoryPoolInitCapacity,
+         false,
+         memoryPoolReserveCapacity,
+         memoryPoolReserveCapacity,
+         false}},
+       14 << 20,
+       0,
+       6 << 20,
+       6 << 20,
+       true,
+       false},
+
+      {{{memoryPoolInitCapacity,
+         false,
+         memoryPoolInitCapacity,
+         memoryPoolInitCapacity,
+         false},
+        {memoryPoolInitCapacity,
+         false,
+         memoryPoolInitCapacity,
+         memoryPoolInitCapacity,
+         false},
+        {memoryPoolInitCapacity,
+         false,
+         memoryPoolInitCapacity,
+         memoryPoolInitCapacity,
+         false},
+        {memoryPoolInitCapacity,
+         true,
+         memoryPoolReserveCapacity,
+         memoryPoolReserveCapacity,
+         false}},
+       14 << 20,
+       0,
+       6 << 20,
+       6 << 20,
+       true,
+       false}};
+
   struct MockTaskContainer {
     std::shared_ptr<MockTask> task;
     MockMemoryOperator* op;
-    void* buf;
-    TaskTestData taskTestData;
+    TestTask testTask;
   };
 
   std::function<void(MockTask*, bool)> checkTaskException =
@@ -742,14 +1036,18 @@ TEST_F(MockSharedArbitrationTest, shrinkPools) {
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
+    LOG(ERROR) << testData.debugString();
 
     std::vector<MockTaskContainer> taskContainers;
-    for (const auto& taskTestData : testData.taskTestDatas) {
-      auto task = addTask(taskTestData.capacity);
-      auto* op = addMemoryOp(task, taskTestData.reclaimable);
-      auto* buf = op->allocate(taskTestData.capacity);
-      ASSERT_EQ(op->capacity(), taskTestData.capacity);
-      taskContainers.push_back({task, op, buf, taskTestData});
+    for (const auto& testTask : testData.testTasks) {
+      auto task = addTask(testTask.capacity);
+      auto* op = addMemoryOp(task, testTask.reclaimable);
+      ASSERT_EQ(op->capacity(), testTask.expectedInitialCapacity);
+      if (testTask.allocateBytes != 0) {
+        op->allocate(testTask.allocateBytes);
+      }
+      ASSERT_LE(op->capacity(), testTask.capacity);
+      taskContainers.push_back({task, op, testTask});
     }
 
     ASSERT_EQ(
@@ -758,12 +1056,9 @@ TEST_F(MockSharedArbitrationTest, shrinkPools) {
         testData.expectedFreedBytes);
 
     for (const auto& taskContainer : taskContainers) {
-      ASSERT_EQ(
-          taskContainer.task->capacity(),
-          taskContainer.taskTestData.expectedCapacityAfterShrink);
       checkTaskException(
           taskContainer.task.get(),
-          taskContainer.taskTestData.expectedAbortAfterShrink);
+          taskContainer.testTask.expectedAbortAfterShrink);
     }
 
     uint64_t totalCapacity{0};
@@ -771,89 +1066,118 @@ TEST_F(MockSharedArbitrationTest, shrinkPools) {
       totalCapacity += taskContainer.task->capacity();
     }
     ASSERT_EQ(
+        arbitrator_->stats().freeCapacityBytes, testData.expectedFreeCapacity);
+    ASSERT_EQ(
+        arbitrator_->stats().freeReservedCapacityBytes,
+        testData.expectedReservedFreeCapacity);
+    ASSERT_EQ(
         totalCapacity + arbitrator_->stats().freeCapacityBytes,
         arbitrator_->capacity());
   }
 }
 
 TEST_F(MockSharedArbitrationTest, singlePoolGrowWithoutArbitration) {
+  const int64_t memoryCapacity = 128 << 20;
+  const uint64_t memoryPoolInitCapacity = 32 << 20;
+  const uint64_t memoryPoolTransferCapacity = 8 << 20;
+  setupMemory(
+      memoryCapacity, 0, memoryPoolInitCapacity, 0, memoryPoolTransferCapacity);
+
   auto* memOp = addMemoryOp();
   const int allocateSize = 1 * MB;
-  while (memOp->capacity() < kMemoryCapacity) {
+  while (memOp->capacity() < memoryCapacity) {
     memOp->allocate(allocateSize);
   }
 
   verifyArbitratorStats(
       arbitrator_->stats(),
-      kMemoryCapacity,
+      memoryCapacity,
       0,
-      (kMemoryCapacity - kMemoryPoolInitCapacity) / kMemoryPoolTransferCapacity,
-      (kMemoryCapacity - kMemoryPoolInitCapacity) /
-          kMemoryPoolTransferCapacity);
+      0,
+      (memoryCapacity - memoryPoolInitCapacity) / memoryPoolTransferCapacity,
+      (memoryCapacity - memoryPoolInitCapacity) / memoryPoolTransferCapacity);
 
   verifyReclaimerStats(
       memOp->reclaimer()->stats(),
       0,
-      (kMemoryCapacity - kMemoryPoolInitCapacity) /
-          kMemoryPoolTransferCapacity);
+      (memoryCapacity - memoryPoolInitCapacity) / memoryPoolTransferCapacity);
 
   clearTasks();
   verifyArbitratorStats(
       arbitrator_->stats(),
-      kMemoryCapacity,
-      kMemoryCapacity,
-      (kMemoryCapacity - kMemoryPoolInitCapacity) / kMemoryPoolTransferCapacity,
-      (kMemoryCapacity - kMemoryPoolInitCapacity) /
-          kMemoryPoolTransferCapacity);
+      memoryCapacity,
+      memoryCapacity,
+      0,
+      (memoryCapacity - memoryPoolInitCapacity) / memoryPoolTransferCapacity,
+      (memoryCapacity - memoryPoolInitCapacity) / memoryPoolTransferCapacity);
 }
 
 TEST_F(MockSharedArbitrationTest, maxCapacityReserve) {
   const int memCapacity = 256 * MB;
   const int minPoolCapacity = 32 * MB;
-  setupMemory(memCapacity, minPoolCapacity);
   struct {
-    uint64_t maxCapacity;
-    uint64_t expectedInitialCapacity;
+    uint64_t memCapacity;
+    uint64_t reservedCapacity;
+    uint64_t poolInitCapacity;
+    uint64_t poolReservedCapacity;
+    uint64_t poolMaxCapacity;
+    uint64_t expectedPoolInitCapacity;
 
     std::string debugString() const {
       return fmt::format(
-          "maxCapacity {}, expectedInitialCapacity {}",
-          succinctBytes(maxCapacity),
-          succinctBytes(expectedInitialCapacity));
+          "memCapacity {}, reservedCapacity {}, poolInitCapacity {}, poolReservedCapacity {}, poolMaxCapacity {}, expectedPoolInitCapacity {}",
+          succinctBytes(memCapacity),
+          succinctBytes(reservedCapacity),
+          succinctBytes(poolInitCapacity),
+          succinctBytes(poolReservedCapacity),
+          succinctBytes(poolMaxCapacity),
+          succinctBytes(expectedPoolInitCapacity));
     }
   } testSettings[] = {
-      {minPoolCapacity, minPoolCapacity},
-      {minPoolCapacity / 2, minPoolCapacity / 2},
-      {minPoolCapacity * 2, minPoolCapacity}};
+      {256 << 20, 256 << 20, 128 << 20, 64 << 20, 256 << 20, 64 << 20},
+      {256 << 20, 0, 128 << 20, 64 << 20, 256 << 20, 128 << 20},
+      {256 << 20, 0, 512 << 20, 64 << 20, 256 << 20, 256 << 20},
+      {256 << 20, 0, 128 << 20, 64 << 20, 256 << 20, 128 << 20},
+      {256 << 20, 128 << 20, 128 << 20, 64 << 20, 256 << 20, 128 << 20},
+      {256 << 20, 128 << 20, 256 << 20, 64 << 20, 256 << 20, 128 << 20},
+      {256 << 20, 128 << 20, 256 << 20, 256 << 20, 256 << 20, 256 << 20},
+      {256 << 20, 128 << 20, 256 << 20, 256 << 20, 128 << 20, 128 << 20}};
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
-    auto task = addTask(testData.maxCapacity);
-    ASSERT_EQ(task->pool()->maxCapacity(), testData.maxCapacity);
-    ASSERT_EQ(task->pool()->capacity(), testData.expectedInitialCapacity);
+    setupMemory(
+        testData.memCapacity,
+        testData.reservedCapacity,
+        testData.poolInitCapacity,
+        testData.poolReservedCapacity);
+    auto task = addTask(testData.poolMaxCapacity);
+    ASSERT_EQ(task->pool()->maxCapacity(), testData.poolMaxCapacity);
+    ASSERT_EQ(task->pool()->capacity(), testData.expectedPoolInitCapacity);
   }
 }
 
 TEST_F(MockSharedArbitrationTest, ensureMemoryPoolMaxCapacity) {
   const int memCapacity = 256 * MB;
-  const int minPoolCapacity = 8 * MB;
+  const int poolInitCapacity = 8 * MB;
   struct {
-    uint64_t maxCapacity;
+    uint64_t poolMaxCapacity;
     bool isReclaimable;
     uint64_t allocatedBytes;
     uint64_t requestBytes;
     bool hasOtherTask;
+    uint64_t otherAllocatedBytes;
     bool expectedSuccess;
     bool expectedReclaimFromOther;
 
     std::string debugString() const {
       return fmt::format(
-          "maxCapacity {} isReclaimable {} allocatedBytes {} requestBytes {} hasOtherTask {} expectedSuccess {} expectedReclaimFromOther {}",
-          succinctBytes(maxCapacity),
+          "poolMaxCapacity {} isReclaimable {} allocatedBytes {} requestBytes {} hasOtherTask {} otherAllocatedBytes {} expectedSuccess {} expectedReclaimFromOther {}",
+          succinctBytes(poolMaxCapacity),
           isReclaimable,
           succinctBytes(allocatedBytes),
           succinctBytes(requestBytes),
           hasOtherTask,
+          succinctBytes(otherAllocatedBytes),
           expectedSuccess,
           expectedReclaimFromOther);
     }
@@ -863,6 +1187,7 @@ TEST_F(MockSharedArbitrationTest, ensureMemoryPoolMaxCapacity) {
        memCapacity / 4,
        memCapacity / 2,
        false,
+       0,
        true,
        false},
       {memCapacity / 2,
@@ -870,6 +1195,7 @@ TEST_F(MockSharedArbitrationTest, ensureMemoryPoolMaxCapacity) {
        memCapacity / 4,
        memCapacity / 8,
        false,
+       0,
        true,
        false},
       {memCapacity / 2,
@@ -877,6 +1203,7 @@ TEST_F(MockSharedArbitrationTest, ensureMemoryPoolMaxCapacity) {
        memCapacity / 4,
        memCapacity / 2,
        false,
+       0,
        true,
        false},
       {memCapacity / 2,
@@ -884,6 +1211,7 @@ TEST_F(MockSharedArbitrationTest, ensureMemoryPoolMaxCapacity) {
        memCapacity / 2,
        memCapacity / 4,
        false,
+       0,
        true,
        false},
       {memCapacity / 2,
@@ -891,6 +1219,7 @@ TEST_F(MockSharedArbitrationTest, ensureMemoryPoolMaxCapacity) {
        memCapacity / 4,
        memCapacity / 2,
        false,
+       0,
        false,
        false},
       {memCapacity / 2,
@@ -898,6 +1227,7 @@ TEST_F(MockSharedArbitrationTest, ensureMemoryPoolMaxCapacity) {
        memCapacity / 2,
        memCapacity / 4,
        false,
+       0,
        false,
        false},
       {memCapacity / 2,
@@ -905,6 +1235,7 @@ TEST_F(MockSharedArbitrationTest, ensureMemoryPoolMaxCapacity) {
        memCapacity / 4,
        memCapacity / 2,
        true,
+       memCapacity - memCapacity / 4,
        true,
        true},
       {memCapacity / 2,
@@ -912,6 +1243,7 @@ TEST_F(MockSharedArbitrationTest, ensureMemoryPoolMaxCapacity) {
        memCapacity / 4,
        memCapacity / 8,
        true,
+       memCapacity - memCapacity / 4,
        true,
        true},
       {memCapacity / 2,
@@ -919,6 +1251,7 @@ TEST_F(MockSharedArbitrationTest, ensureMemoryPoolMaxCapacity) {
        memCapacity / 4,
        memCapacity / 2,
        true,
+       memCapacity - memCapacity / 4,
        true,
        true},
       {memCapacity / 2,
@@ -926,6 +1259,7 @@ TEST_F(MockSharedArbitrationTest, ensureMemoryPoolMaxCapacity) {
        memCapacity / 2,
        memCapacity / 4,
        true,
+       memCapacity - memCapacity / 2,
        true,
        false},
       {memCapacity / 2,
@@ -933,6 +1267,7 @@ TEST_F(MockSharedArbitrationTest, ensureMemoryPoolMaxCapacity) {
        memCapacity / 4,
        memCapacity / 2,
        true,
+       memCapacity - memCapacity / 4,
        false,
        false},
       {memCapacity / 2,
@@ -940,22 +1275,22 @@ TEST_F(MockSharedArbitrationTest, ensureMemoryPoolMaxCapacity) {
        memCapacity / 2,
        memCapacity / 4,
        false,
+       memCapacity - memCapacity / 2,
        false,
        false}};
-
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
-    setupMemory(memCapacity, minPoolCapacity);
+    setupMemory(memCapacity, 0, poolInitCapacity, 0);
 
-    auto requestor = addTask(testData.maxCapacity);
-    auto requestorOp = addMemoryOp(requestor, testData.isReclaimable);
+    auto requestor = addTask(testData.poolMaxCapacity);
+    auto* requestorOp = addMemoryOp(requestor, testData.isReclaimable);
     requestorOp->allocate(testData.allocatedBytes);
     std::shared_ptr<MockTask> other;
     MockMemoryOperator* otherOp;
     if (testData.hasOtherTask) {
       other = addTask();
       otherOp = addMemoryOp(other, true);
-      otherOp->allocate(memCapacity - testData.allocatedBytes);
+      otherOp->allocate(testData.otherAllocatedBytes);
     }
     const auto numRequests = arbitrator_->stats().numRequests;
     if (testData.expectedSuccess) {
@@ -972,7 +1307,7 @@ TEST_F(MockSharedArbitrationTest, ensureMemoryPoolMaxCapacity) {
     }
     if (testData.expectedSuccess &&
         (((testData.allocatedBytes + testData.requestBytes) >
-          testData.maxCapacity) ||
+          testData.poolMaxCapacity) ||
          testData.hasOtherTask)) {
       ASSERT_GT(arbitrator_->stats().numReclaimedBytes, 0);
     } else {
@@ -1015,10 +1350,10 @@ TEST_F(MockSharedArbitrationTest, ensureNodeMaxCapacity) {
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
-    setupMemory(testData.nodeCapacity);
+    setupMemory(testData.nodeCapacity, 0, 0, 0);
 
     auto requestor = addTask(testData.poolMaxCapacity);
-    auto requestorOp = addMemoryOp(requestor, testData.isReclaimable);
+    auto* requestorOp = addMemoryOp(requestor, testData.isReclaimable);
     requestorOp->allocate(testData.allocatedBytes);
     const auto numRequests = arbitrator_->stats().numRequests;
     if (testData.expectedSuccess) {
@@ -1040,24 +1375,33 @@ TEST_F(MockSharedArbitrationTest, ensureNodeMaxCapacity) {
 TEST_F(MockSharedArbitrationTest, failedArbitration) {
   const int memCapacity = 256 * MB;
   const int minPoolCapacity = 8 * MB;
-  setupMemory(memCapacity, minPoolCapacity);
-  auto reclaimableOp = addMemoryOp();
+  setupMemory(memCapacity, 0, minPoolCapacity, 0);
+  auto* reclaimableOp = addMemoryOp();
   ASSERT_EQ(reclaimableOp->capacity(), minPoolCapacity);
-  auto nonReclaimableOp = addMemoryOp(nullptr, false);
+  auto* nonReclaimableOp = addMemoryOp(nullptr, false);
   ASSERT_EQ(nonReclaimableOp->capacity(), minPoolCapacity);
-  auto arbitrateOp = addMemoryOp();
+  auto* arbitrateOp = addMemoryOp();
   ASSERT_EQ(arbitrateOp->capacity(), minPoolCapacity);
 
   reclaimableOp->allocate(minPoolCapacity);
   ASSERT_EQ(reclaimableOp->capacity(), minPoolCapacity);
   nonReclaimableOp->allocate(minPoolCapacity);
   ASSERT_EQ(nonReclaimableOp->capacity(), minPoolCapacity);
-  ASSERT_ANY_THROW(arbitrateOp->allocate(memCapacity));
+  VELOX_ASSERT_THROW(
+      arbitrateOp->allocate(memCapacity), "Exceeded memory pool cap");
   verifyReclaimerStats(nonReclaimableOp->reclaimer()->stats());
   verifyReclaimerStats(reclaimableOp->reclaimer()->stats(), 1);
-  verifyReclaimerStats(arbitrateOp->reclaimer()->stats(), 1, 1);
+  verifyReclaimerStats(arbitrateOp->reclaimer()->stats(), 0, 1);
   verifyArbitratorStats(
-      arbitrator_->stats(), memCapacity, 260046848, 1, 0, 1, 8388608, 8388608);
+      arbitrator_->stats(),
+      memCapacity,
+      260046848,
+      0,
+      1,
+      0,
+      1,
+      8388608,
+      8388608);
   ASSERT_EQ(arbitrator_->stats().queueTimeUs, 0);
 }
 
@@ -1068,17 +1412,31 @@ TEST_F(MockSharedArbitrationTest, singlePoolGrowCapacityWithArbitration) {
     setupMemory();
     auto op = addMemoryOp(nullptr, isLeafReclaimable);
     const int allocateSize = MB;
-    while (op->pool()->currentBytes() < kMemoryCapacity) {
+    while (op->pool()->currentBytes() <
+           kMemoryCapacity - kReservedMemoryCapacity) {
       op->allocate(allocateSize);
     }
-    verifyArbitratorStats(arbitrator_->stats(), kMemoryCapacity, 0, 62, 62);
-    verifyReclaimerStats(op->reclaimer()->stats(), 0, 62);
+    verifyArbitratorStats(
+        arbitrator_->stats(),
+        kMemoryCapacity,
+        kReservedMemoryCapacity,
+        kReservedMemoryCapacity,
+        46,
+        46);
+    verifyReclaimerStats(op->reclaimer()->stats(), 0, 46);
 
     if (!isLeafReclaimable) {
-      ASSERT_ANY_THROW(op->allocate(allocateSize));
+      VELOX_ASSERT_THROW(
+          op->allocate(allocateSize), "Exceeded memory pool cap");
       verifyArbitratorStats(
-          arbitrator_->stats(), kMemoryCapacity, 0, 63, 62, 1);
-      verifyReclaimerStats(op->reclaimer()->stats(), 1, 63);
+          arbitrator_->stats(),
+          kMemoryCapacity,
+          kReservedMemoryCapacity,
+          kReservedMemoryCapacity,
+          47,
+          46,
+          1);
+      verifyReclaimerStats(op->reclaimer()->stats(), 0, 47);
       continue;
     }
 
@@ -1087,16 +1445,24 @@ TEST_F(MockSharedArbitrationTest, singlePoolGrowCapacityWithArbitration) {
       op->allocate(allocateSize);
     }
     verifyArbitratorStats(
-        arbitrator_->stats(), kMemoryCapacity, 0, 63, 63, 0, 8388608);
-    verifyReclaimerStats(op->reclaimer()->stats(), 1, 63);
+        arbitrator_->stats(),
+        kMemoryCapacity,
+        kReservedMemoryCapacity,
+        kReservedMemoryCapacity,
+        47,
+        47,
+        0,
+        8388608);
+    verifyReclaimerStats(op->reclaimer()->stats(), 1, 47);
 
     clearTasks();
     verifyArbitratorStats(
         arbitrator_->stats(),
         kMemoryCapacity,
         kMemoryCapacity,
-        63,
-        63,
+        kReservedMemoryCapacity,
+        47,
+        47,
         0,
         8388608);
   }
@@ -1129,7 +1495,7 @@ TEST_F(MockSharedArbitrationTest, arbitrateWithCapacityShrink) {
     ASSERT_EQ(arbitratorStats.numReclaimedBytes, 0);
 
     verifyReclaimerStats(reclaimedOp->reclaimer()->stats(), 0, 11);
-    verifyReclaimerStats(arbitrateOp->reclaimer()->stats(), 0, 5);
+    verifyReclaimerStats(arbitrateOp->reclaimer()->stats(), 0, 1);
 
     clearTasks();
   }
@@ -1137,34 +1503,49 @@ TEST_F(MockSharedArbitrationTest, arbitrateWithCapacityShrink) {
 
 TEST_F(MockSharedArbitrationTest, arbitrateWithMemoryReclaim) {
   const uint64_t memoryCapacity = 256 * MB;
-  const uint64_t minPoolCapacity = 8 * MB;
+  const uint64_t reservedMemoryCapacity = 128 * MB;
+  const uint64_t initPoolCapacity = 8 * MB;
+  const uint64_t reservedPoolCapacity = 8 * MB;
   const std::vector<char> isLeafReclaimables = {true, false};
   for (const auto isLeafReclaimable : isLeafReclaimables) {
     SCOPED_TRACE(fmt::format("isLeafReclaimable {}", isLeafReclaimable));
-    setupMemory(memoryCapacity, minPoolCapacity);
+    setupMemory(
+        memoryCapacity,
+        reservedMemoryCapacity,
+        initPoolCapacity,
+        reservedPoolCapacity);
     auto* reclaimedOp = addMemoryOp(nullptr, isLeafReclaimable);
     const int allocateSize = 8 * MB;
-    while (reclaimedOp->pool()->currentBytes() < memoryCapacity) {
+    while (reclaimedOp->pool()->currentBytes() <
+           memoryCapacity - reservedMemoryCapacity) {
       reclaimedOp->allocate(allocateSize);
     }
     auto* arbitrateOp = addMemoryOp();
     if (!isLeafReclaimable) {
       auto leafTask = tasks().front();
-      ASSERT_NO_THROW(arbitrateOp->allocate(allocateSize));
+      ASSERT_NO_THROW(arbitrateOp->allocate(reservedMemoryCapacity / 2));
+
       ASSERT_NE(leafTask->error(), nullptr);
       ASSERT_EQ(arbitrator_->stats().numFailures, 0);
       continue;
     }
-    arbitrateOp->allocate(allocateSize);
+    arbitrateOp->allocate(reservedMemoryCapacity / 2);
 
     verifyArbitratorStats(
-        arbitrator_->stats(), memoryCapacity, 0, 32, 32, 0, 8388608);
+        arbitrator_->stats(),
+        memoryCapacity,
+        kReservedMemoryCapacity - reservedPoolCapacity,
+        kReservedMemoryCapacity - reservedPoolCapacity,
+        16,
+        16,
+        0,
+        67108864);
 
     verifyReclaimerStats(
         arbitrateOp->reclaimer()->stats(), 0, 1, kMemoryPoolTransferCapacity);
 
     verifyReclaimerStats(
-        reclaimedOp->reclaimer()->stats(), 1, 31, kMemoryPoolTransferCapacity);
+        reclaimedOp->reclaimer()->stats(), 1, 15, kMemoryPoolTransferCapacity);
     clearTasks();
   }
 }
@@ -1174,7 +1555,10 @@ TEST_F(MockSharedArbitrationTest, arbitrateBySelfMemoryReclaim) {
   for (const auto isLeafReclaimable : isLeafReclaimables) {
     SCOPED_TRACE(fmt::format("isLeafReclaimable {}", isLeafReclaimable));
     const uint64_t memCapacity = 128 * MB;
-    setupMemory(memCapacity);
+    const uint64_t reservedCapacity = 8 * MB;
+    const uint64_t poolReservedCapacity = 4 * MB;
+    setupMemory(
+        memCapacity, reservedCapacity, reservedCapacity, poolReservedCapacity);
     std::shared_ptr<MockTask> task = addTask(kMemoryCapacity);
     auto* memOp = addMemoryOp(task, isLeafReclaimable);
     const int allocateSize = 8 * MB;
@@ -1185,12 +1569,13 @@ TEST_F(MockSharedArbitrationTest, arbitrateBySelfMemoryReclaim) {
     const int oldNumRequests = arbitrator_->stats().numRequests;
     // Allocate a large chunk of memory to trigger arbitration.
     if (!isLeafReclaimable) {
-      ASSERT_ANY_THROW(memOp->allocate(memCapacity));
+      VELOX_ASSERT_THROW(
+          memOp->allocate(memCapacity), "Exceeded memory pool cap");
       ASSERT_EQ(oldNumRequests + 1, arbitrator_->stats().numRequests);
       ASSERT_EQ(arbitrator_->stats().numFailures, 1);
       continue;
     } else {
-      memOp->allocate(memCapacity);
+      memOp->allocate(memCapacity / 2);
       ASSERT_EQ(oldNumRequests + 1, arbitrator_->stats().numRequests);
       ASSERT_EQ(arbitrator_->stats().numFailures, 0);
       ASSERT_EQ(arbitrator_->stats().numShrunkBytes, 0);
@@ -1245,7 +1630,7 @@ TEST_F(MockSharedArbitrationTest, noAbortOnRequestWhenArbitrationFails) {
 
 DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, orderedArbitration) {
   SCOPED_TESTVALUE_SET(
-      "facebook::velox::memory::SharedArbitrator::sortCandidatesByFreeCapacity",
+      "facebook::velox::memory::SharedArbitrator::sortCandidatesByReclaimableFreeCapacity",
       std::function<void(const std::vector<SharedArbitrator::Candidate>*)>(
           ([&](const std::vector<SharedArbitrator::Candidate>* candidates) {
             for (int i = 1; i < candidates->size(); ++i) {
@@ -1254,7 +1639,7 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, orderedArbitration) {
             }
           })));
   SCOPED_TESTVALUE_SET(
-      "facebook::velox::memory::SharedArbitrator::sortCandidatesByReclaimableMemory",
+      "facebook::velox::memory::SharedArbitrator::sortCandidatesByReclaimableUsedMemory",
       std::function<void(const std::vector<SharedArbitrator::Candidate>*)>(
           ([&](const std::vector<SharedArbitrator::Candidate>* candidates) {
             for (int i = 1; i < candidates->size(); ++i) {
@@ -1266,8 +1651,10 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, orderedArbitration) {
   folly::Random::DefaultGenerator rng;
   rng.seed(512);
   const uint64_t memCapacity = 512 * MB;
-  const uint64_t minPoolCapacity = 32 * MB;
-  const uint64_t minPoolCapacityTransferSize = 8 * MB;
+  const uint64_t reservedMemCapacity = 128 * MB;
+  const uint64_t initPoolCapacity = 32 * MB;
+  const uint64_t reservedPoolCapacity = 8 * MB;
+  const uint64_t poolCapacityTransferSize = 8 * MB;
   const int numTasks = 8;
   struct {
     bool freeCapacity;
@@ -1282,15 +1669,21 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, orderedArbitration) {
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
-    setupMemory(memCapacity, minPoolCapacity, minPoolCapacityTransferSize);
+
+    setupMemory(
+        memCapacity,
+        reservedMemCapacity,
+        initPoolCapacity,
+        reservedPoolCapacity,
+        poolCapacityTransferSize);
     std::vector<MockMemoryOperator*> memOps;
-    std::vector<uint64_t> memOpCapacities;
     for (int i = 0; i < numTasks; ++i) {
       auto* memOp = addMemoryOp();
+      ASSERT_GE(memOp->capacity(), reservedPoolCapacity);
       int allocationSize = testData.sameSize ? memCapacity / numTasks
-                                             : minPoolCapacity +
+                                             : poolCapacityTransferSize +
               folly::Random::rand32(rng) %
-                  ((memCapacity / numTasks) - minPoolCapacity);
+                  ((memCapacity / numTasks) - poolCapacityTransferSize);
       allocationSize = allocationSize / MB * MB;
       memOp->allocate(allocationSize);
       if (testData.freeCapacity) {
@@ -1301,9 +1694,10 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, orderedArbitration) {
     }
 
     auto* arbitrateOp = addMemoryOp();
-    arbitrateOp->allocate(memCapacity);
+    arbitrateOp->allocate(memCapacity / 2);
     for (auto* memOp : memOps) {
-      ASSERT_EQ(memOp->capacity(), 0);
+      ASSERT_GE(memOp->capacity(), reservedPoolCapacity)
+          << memOp->pool()->name();
     }
     ASSERT_EQ(arbitrator_->stats().queueTimeUs, 0);
     clearTasks();
@@ -1314,7 +1708,7 @@ TEST_F(MockSharedArbitrationTest, poolCapacityTransferWithFreeCapacity) {
   const uint64_t memCapacity = 512 * MB;
   const uint64_t minPoolCapacity = 32 * MB;
   const uint64_t minPoolCapacityTransferSize = 16 * MB;
-  setupMemory(memCapacity, minPoolCapacity, minPoolCapacityTransferSize);
+  setupMemory(memCapacity, 0, minPoolCapacity, 0, minPoolCapacityTransferSize);
   auto* memOp = addMemoryOp();
   ASSERT_EQ(memOp->capacity(), minPoolCapacity);
   memOp->allocate(minPoolCapacity);
@@ -1337,6 +1731,7 @@ TEST_F(MockSharedArbitrationTest, poolCapacityTransferWithFreeCapacity) {
       arbitrator_->stats(),
       memCapacity,
       0,
+      0,
       expectedArbitrationRequests,
       expectedArbitrationRequests);
   ASSERT_EQ(arbitrator_->stats().queueTimeUs, 0);
@@ -1347,7 +1742,7 @@ TEST_F(MockSharedArbitrationTest, poolCapacityTransferSizeWithCapacityShrunk) {
   const uint64_t minPoolCapacity = 64 * MB;
   const uint64_t minPoolCapacityTransferSize = 32 * MB;
   const uint64_t memCapacity = minPoolCapacity * numCandidateOps;
-  setupMemory(memCapacity, minPoolCapacity, minPoolCapacityTransferSize);
+  setupMemory(memCapacity, 0, minPoolCapacity, 0, minPoolCapacityTransferSize);
   const int allocationSize = 8 * MB;
   std::vector<MockMemoryOperator*> candidateOps;
   for (int i = 0; i < numCandidateOps; ++i) {
@@ -1372,7 +1767,7 @@ TEST_F(MockSharedArbitrationTest, partialPoolCapacityTransferSize) {
   const uint64_t minPoolCapacity = 64 * MB;
   const uint64_t minPoolCapacityTransferSize = 32 * MB;
   const uint64_t memCapacity = minPoolCapacity * numCandidateOps;
-  setupMemory(memCapacity, minPoolCapacity, minPoolCapacityTransferSize);
+  setupMemory(memCapacity, 0, minPoolCapacity, 0, minPoolCapacityTransferSize);
   const int allocationSize = 8 * MB;
   std::vector<MockMemoryOperator*> candidateOps;
   for (int i = 0; i < numCandidateOps; ++i) {
@@ -1396,7 +1791,7 @@ TEST_F(MockSharedArbitrationTest, poolCapacityTransferSizeWithMemoryReclaim) {
   const uint64_t memCapacity = 128 * MB;
   const uint64_t minPoolCapacity = memCapacity;
   const uint64_t minPoolCapacityTransferSize = 64 * MB;
-  setupMemory(memCapacity, minPoolCapacity, minPoolCapacityTransferSize);
+  setupMemory(memCapacity, 0, minPoolCapacity, 0, minPoolCapacityTransferSize);
   auto* reclaimedOp = addMemoryOp();
   ASSERT_EQ(reclaimedOp->capacity(), memCapacity);
   const int allocationSize = 8 * MB;
@@ -1420,9 +1815,9 @@ TEST_F(MockSharedArbitrationTest, poolCapacityTransferSizeWithMemoryReclaim) {
 
 TEST_F(MockSharedArbitrationTest, enterArbitrationException) {
   const uint64_t memCapacity = 128 * MB;
-  const uint64_t minPoolCapacity = memCapacity;
-  const uint64_t minPoolCapacityTransferSize = 64 * MB;
-  setupMemory(memCapacity, minPoolCapacity, minPoolCapacityTransferSize);
+  const uint64_t initPoolCapacity = memCapacity;
+  const uint64_t minPoolTransferCapacity = 64 * MB;
+  setupMemory(memCapacity, 0, initPoolCapacity, 0, minPoolTransferCapacity);
   auto* reclaimedOp = addMemoryOp();
   ASSERT_EQ(reclaimedOp->capacity(), memCapacity);
   const int allocationSize = 8 * MB;
@@ -1436,17 +1831,19 @@ TEST_F(MockSharedArbitrationTest, enterArbitrationException) {
     VELOX_FAIL("enterArbitrationException failed");
   });
   ASSERT_EQ(failedArbitrateOp->capacity(), 0);
-  ASSERT_ANY_THROW(failedArbitrateOp->allocate(allocationSize));
+  VELOX_ASSERT_THROW(
+      failedArbitrateOp->allocate(allocationSize),
+      "enterArbitrationException failed");
+  ASSERT_FALSE(failedArbitrateOp->pool()->aborted());
   verifyReclaimerStats(failedArbitrateOp->reclaimer()->stats());
   ASSERT_EQ(failedArbitrateOp->capacity(), 0);
   auto* arbitrateOp = addMemoryOp();
   arbitrateOp->allocate(allocationSize);
-  ASSERT_EQ(arbitrateOp->capacity(), minPoolCapacityTransferSize);
+  ASSERT_EQ(arbitrateOp->capacity(), minPoolTransferCapacity);
   verifyReclaimerStats(arbitrateOp->reclaimer()->stats(), 0, 1);
   verifyReclaimerStats(reclaimedOp->reclaimer()->stats(), 1);
   ASSERT_EQ(arbitrator_->stats().numShrunkBytes, 0);
-  ASSERT_EQ(
-      arbitrator_->stats().numReclaimedBytes, minPoolCapacityTransferSize);
+  ASSERT_EQ(arbitrator_->stats().numReclaimedBytes, minPoolTransferCapacity);
   ASSERT_EQ(arbitrator_->stats().numRequests, 1);
   ASSERT_EQ(arbitrator_->stats().numFailures, 0);
 }
@@ -1537,7 +1934,7 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, failedToReclaimFromRequestor) {
        0}};
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
-    setupMemory();
+    setupMemory(kMemoryCapacity, 0, kMemoryPoolInitCapacity, 0);
 
     std::vector<std::shared_ptr<MockTask>> otherTasks;
     std::vector<MockMemoryOperator*> otherTaskOps;
@@ -1576,12 +1973,12 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, failedToReclaimFromRequestor) {
         numFailedTaskAllocationsAfterAbort + numOtherAllocationsAfterAbort + 1);
     folly::futures::Barrier arbitrationBarrier(
         numFailedTaskAllocationsAfterAbort + numOtherAllocationsAfterAbort + 1);
-    std::atomic<int> testInjectionCount{0};
-    std::atomic<bool> arbitrationStarted{false};
+    std::atomic_int testInjectionCount{0};
+    std::atomic_bool arbitrationStarted{false};
     SCOPED_TESTVALUE_SET(
         "facebook::velox::memory::SharedArbitrator::startArbitration",
         std::function<void(const MemoryPool*)>(
-            ([&](const MemoryPool* /*unsed*/) {
+            ([&](const MemoryPool* /*unused*/) {
               if (!arbitrationStarted) {
                 return;
               }
@@ -1592,7 +1989,7 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, failedToReclaimFromRequestor) {
             })));
 
     SCOPED_TESTVALUE_SET(
-        "facebook::velox::memory::SharedArbitrator::sortCandidatesByFreeCapacity",
+        "facebook::velox::memory::SharedArbitrator::sortCandidatesByReclaimableFreeCapacity",
         std::function<void(const std::vector<SharedArbitrator::Candidate>*)>(
             ([&](const std::vector<SharedArbitrator::Candidate>* /*unused*/) {
               if (!arbitrationStarted.exchange(true)) {
@@ -1612,7 +2009,8 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, failedToReclaimFromRequestor) {
         arbitrationStartBarrier.wait().wait();
         if (i < numFailedTaskAllocationsAfterAbort) {
           VELOX_ASSERT_THROW(
-              failedTaskOp->allocate(failedTaskMemoryCapacity), "");
+              failedTaskOp->allocate(failedTaskMemoryCapacity),
+              "The requestor pool has been aborted");
         } else {
           otherTaskOps[i - numFailedTaskAllocationsAfterAbort]->allocate(
               otherTaskMemoryCapacity);
@@ -1621,7 +2019,9 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, failedToReclaimFromRequestor) {
     }
 
     // Trigger memory arbitration to reclaim from itself which throws.
-    VELOX_ASSERT_THROW(failedTaskOp->allocate(failedTaskMemoryCapacity), "");
+    VELOX_ASSERT_THROW(
+        failedTaskOp->allocate(failedTaskMemoryCapacity),
+        "The requestor pool has been aborted");
     // Wait for all the allocation threads to complete.
     for (auto& allocationThread : allocationThreadsAfterAbort) {
       allocationThread.join();
@@ -1719,7 +2119,7 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, failedToReclaimFromOtherTask) {
        nonFailTaskMemoryCapacity}};
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
-    setupMemory();
+    setupMemory(kMemoryCapacity, 0, kMemoryPoolInitCapacity, 0);
 
     std::vector<std::shared_ptr<MockTask>> nonFailedTasks;
     std::vector<MockMemoryOperator*> nonFailedTaskOps;
@@ -1779,7 +2179,7 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, failedToReclaimFromOtherTask) {
             })));
 
     SCOPED_TESTVALUE_SET(
-        "facebook::velox::memory::SharedArbitrator::sortCandidatesByFreeCapacity",
+        "facebook::velox::memory::SharedArbitrator::sortCandidatesByReclaimableFreeCapacity",
         std::function<void(const std::vector<SharedArbitrator::Candidate>*)>(
             ([&](const std::vector<SharedArbitrator::Candidate>* /*unused*/) {
               if (!arbitrationStarted.exchange(true)) {
@@ -1864,6 +2264,7 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, failedToReclaimFromOtherTask) {
 }
 
 TEST_F(MockSharedArbitrationTest, memoryPoolAbortThrow) {
+  setupMemory(kMemoryCapacity, 0, kMemoryPoolInitCapacity, 0);
   const int numTasks = 4;
   const int smallTaskMemoryCapacity = kMemoryCapacity / 8;
   const int largeTaskMemoryCapacity = kMemoryCapacity / 2;
@@ -1885,7 +2286,9 @@ TEST_F(MockSharedArbitrationTest, memoryPoolAbortThrow) {
   ASSERT_EQ(oldStats.numAborted, 0);
 
   // Trigger memory arbitration to reclaim from itself which throws.
-  VELOX_ASSERT_THROW(largeTaskOp->allocate(largeTaskMemoryCapacity), "");
+  VELOX_ASSERT_THROW(
+      largeTaskOp->allocate(largeTaskMemoryCapacity),
+      "The requestor pool has been aborted");
   const auto newStats = arbitrator_->stats();
   ASSERT_EQ(newStats.numRequests, oldStats.numRequests + 1);
   ASSERT_EQ(newStats.numAborted, 1);
@@ -1908,7 +2311,7 @@ TEST_F(MockSharedArbitrationTest, memoryPoolAbortThrow) {
 DEBUG_ONLY_TEST_F(
     MockSharedArbitrationTest,
     freeUnusedCapacityWhenReclaimMemoryPool) {
-  setupMemory(kMemoryCapacity, 0);
+  setupMemory(kMemoryCapacity, 0, 0, 0);
   const int allocationSize = kMemoryCapacity / 4;
   std::shared_ptr<MockTask> reclaimedTask = addTask();
   MockMemoryOperator* reclaimedTaskOp = addMemoryOp(reclaimedTask);
@@ -1923,7 +2326,7 @@ DEBUG_ONLY_TEST_F(
   folly::EventCount reclaimBlock;
   auto reclaimBlockKey = reclaimBlock.prepareWait();
   SCOPED_TESTVALUE_SET(
-      "facebook::velox::memory::SharedArbitrator::sortCandidatesByReclaimableMemory",
+      "facebook::velox::memory::SharedArbitrator::sortCandidatesByReclaimableUsedMemory",
       std::function<void(const MemoryPool*)>(([&](const MemoryPool* /*unsed*/) {
         reclaimWait.notify();
         reclaimBlock.wait(reclaimBlockKey);
@@ -2017,7 +2420,7 @@ TEST_F(MockSharedArbitrationTest, arbitrationFailure) {
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
 
-    setupMemory(maxCapacity, initialCapacity, minTransferCapacity);
+    setupMemory(maxCapacity, 0, initialCapacity, 0, minTransferCapacity);
     std::shared_ptr<MockTask> requestorTask = addTask();
     MockMemoryOperator* requestorOp = addMemoryOp(requestorTask, false);
     requestorOp->allocate(testData.requestorCapacity);

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -316,13 +316,14 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimToOrderBy) {
     SCOPED_TRACE(fmt::format("sameQuery {}", sameQuery));
     const auto oldStats = arbitrator_->stats();
     std::shared_ptr<core::QueryCtx> fakeMemoryQueryCtx =
-        newQueryCtx(memoryManager_, executor_, kMemoryCapacity);
+        newQueryCtx(memoryManager_.get(), executor_.get(), kMemoryCapacity);
     ++numAddedPools_;
     std::shared_ptr<core::QueryCtx> orderByQueryCtx;
     if (sameQuery) {
       orderByQueryCtx = fakeMemoryQueryCtx;
     } else {
-      orderByQueryCtx = newQueryCtx(memoryManager_, executor_, kMemoryCapacity);
+      orderByQueryCtx =
+          newQueryCtx(memoryManager_.get(), executor_.get(), kMemoryCapacity);
       ++numAddedPools_;
     }
 
@@ -416,14 +417,14 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimToAggregation) {
     SCOPED_TRACE(fmt::format("sameQuery {}", sameQuery));
     const auto oldStats = arbitrator_->stats();
     std::shared_ptr<core::QueryCtx> fakeMemoryQueryCtx =
-        newQueryCtx(memoryManager_, executor_, kMemoryCapacity);
+        newQueryCtx(memoryManager_.get(), executor_.get(), kMemoryCapacity);
     ++numAddedPools_;
     std::shared_ptr<core::QueryCtx> aggregationQueryCtx;
     if (sameQuery) {
       aggregationQueryCtx = fakeMemoryQueryCtx;
     } else {
       aggregationQueryCtx =
-          newQueryCtx(memoryManager_, executor_, kMemoryCapacity);
+          newQueryCtx(memoryManager_.get(), executor_.get(), kMemoryCapacity);
       ++numAddedPools_;
     }
 
@@ -518,13 +519,14 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimToJoinBuilder) {
     SCOPED_TRACE(fmt::format("sameQuery {}", sameQuery));
     const auto oldStats = arbitrator_->stats();
     std::shared_ptr<core::QueryCtx> fakeMemoryQueryCtx =
-        newQueryCtx(memoryManager_, executor_, kMemoryCapacity);
+        newQueryCtx(memoryManager_.get(), executor_.get(), kMemoryCapacity);
     ++numAddedPools_;
     std::shared_ptr<core::QueryCtx> joinQueryCtx;
     if (sameQuery) {
       joinQueryCtx = fakeMemoryQueryCtx;
     } else {
-      joinQueryCtx = newQueryCtx(memoryManager_, executor_, kMemoryCapacity);
+      joinQueryCtx =
+          newQueryCtx(memoryManager_.get(), executor_.get(), kMemoryCapacity);
       ++numAddedPools_;
     }
 
@@ -637,7 +639,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, driverInitTriggeredArbitration) {
   createDuckDbTable(vectors);
   setupMemory(kMemoryCapacity, 0);
   std::shared_ptr<core::QueryCtx> queryCtx =
-      newQueryCtx(memoryManager_, executor_, kMemoryCapacity);
+      newQueryCtx(memoryManager_.get(), executor_.get(), kMemoryCapacity);
   ASSERT_EQ(queryCtx->pool()->capacity(), 0);
   ASSERT_EQ(queryCtx->pool()->maxCapacity(), kMemoryCapacity);
 
@@ -667,7 +669,7 @@ DEBUG_ONLY_TEST_F(
   createDuckDbTable(vectors);
 
   std::shared_ptr<core::QueryCtx> queryCtx =
-      newQueryCtx(memoryManager_, executor_, kMemoryCapacity);
+      newQueryCtx(memoryManager_.get(), executor_.get(), kMemoryCapacity);
   ASSERT_EQ(queryCtx->pool()->capacity(), 0);
 
   // Allocate a large chunk of memory to trigger memory reclaim during the query
@@ -761,7 +763,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, asyncArbitratonFromNonDriverContext) {
   }
   createDuckDbTable(vectors);
   std::shared_ptr<core::QueryCtx> queryCtx =
-      newQueryCtx(memoryManager_, executor_, kMemoryCapacity);
+      newQueryCtx(memoryManager_.get(), executor_.get(), kMemoryCapacity);
   ASSERT_EQ(queryCtx->pool()->capacity(), 0);
 
   folly::EventCount aggregationAllocationWait;
@@ -859,7 +861,8 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, runtimeStats) {
 
   const auto spillDirectory = exec::test::TempDirectoryPath::create();
   const auto outputDirectory = TempDirectoryPath::create();
-  const auto queryCtx = newQueryCtx(memoryManager_, executor_, memoryCapacity);
+  const auto queryCtx =
+      newQueryCtx(memoryManager_.get(), executor_.get(), memoryCapacity);
   auto writerPlan =
       PlanBuilder()
           .values(vectors)
@@ -917,7 +920,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, arbitrateMemoryFromOtherOperator) {
   for (bool sameDriver : {false, true}) {
     SCOPED_TRACE(fmt::format("sameDriver {}", sameDriver));
     std::shared_ptr<core::QueryCtx> queryCtx =
-        newQueryCtx(memoryManager_, executor_, kMemoryCapacity);
+        newQueryCtx(memoryManager_.get(), executor_.get(), kMemoryCapacity);
     ASSERT_EQ(queryCtx->pool()->capacity(), 0);
 
     std::atomic<bool> injectAllocationOnce{true};
@@ -1065,7 +1068,8 @@ TEST_F(SharedArbitrationTest, concurrentArbitration) {
       queryThreads.emplace_back([&, i]() {
         std::shared_ptr<Task> task;
         try {
-          auto queryCtx = newQueryCtx(memoryManager_, executor_, queryCapacity);
+          auto queryCtx =
+              newQueryCtx(memoryManager_.get(), executor_.get(), queryCapacity);
           if (i == 0) {
             // Write task contains aggregate node, which does not support
             // multithread aggregation type resolver, so make sure it is built
@@ -1160,7 +1164,8 @@ TEST_F(SharedArbitrationTest, reserveReleaseCounters) {
           {
             std::lock_guard<std::mutex> l(mutex);
             auto oldNum = arbitrator_->stats().numReserves;
-            queries.emplace_back(newQueryCtx(memoryManager_, executor_));
+            queries.emplace_back(
+                newQueryCtx(memoryManager_.get(), executor_.get()));
             ASSERT_EQ(arbitrator_->stats().numReserves, oldNum + 1);
           }
         });

--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -156,6 +156,10 @@ Memory Management
      - Average
      - The average of total free memory capacity which is managed by the
        memory arbitrator.
+   * - arbitrator_free_reserved_capacity_bytes
+     - Average
+     - The average of free memory capacity reserved to ensure each query has
+       the minimal reuired capacity to run.
    * - memory_pool_initial_capacity_bytes
      - Histogram
      - The distribution of a root memory pool's initial capacity in range of [0 256MB]

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -3397,7 +3397,8 @@ DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, reclaimFromTableWriter) {
       SCOPED_TRACE(fmt::format("writerSpillEnabled: {}", writerSpillEnabled));
       auto memoryManager = createMemoryManager();
       auto arbitrator = memoryManager->arbitrator();
-      auto queryCtx = newQueryCtx(memoryManager, executor_, kMemoryCapacity);
+      auto queryCtx =
+          newQueryCtx(memoryManager.get(), executor_.get(), kMemoryCapacity);
       ASSERT_EQ(queryCtx->pool()->capacity(), kMemoryPoolInitCapacity);
 
       std::atomic<int> numInputs{0};
@@ -3508,7 +3509,8 @@ DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, reclaimFromSortTableWriter) {
       SCOPED_TRACE(fmt::format("writerSpillEnabled: {}", writerSpillEnabled));
       auto memoryManager = createMemoryManager();
       auto arbitrator = memoryManager->arbitrator();
-      auto queryCtx = newQueryCtx(memoryManager, executor_, kMemoryCapacity);
+      auto queryCtx =
+          newQueryCtx(memoryManager.get(), executor_.get(), kMemoryCapacity);
       ASSERT_EQ(queryCtx->pool()->capacity(), kMemoryPoolInitCapacity);
 
       const auto spillStats = common::globalSpillStats();
@@ -3605,7 +3607,8 @@ DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, writerFlushThreshold) {
       auto arbitrator = memoryManager->arbitrator();
       auto numAddedPools = 0;
       {
-        auto queryCtx = newQueryCtx(memoryManager, executor_, kMemoryCapacity);
+        auto queryCtx =
+            newQueryCtx(memoryManager.get(), executor_.get(), kMemoryCapacity);
         ++numAddedPools;
         ASSERT_EQ(queryCtx->pool()->capacity(), kMemoryPoolInitCapacity);
 
@@ -3694,7 +3697,8 @@ DEBUG_ONLY_TEST_F(
 
   auto memoryManager = createMemoryManager();
   auto arbitrator = memoryManager->arbitrator();
-  auto queryCtx = newQueryCtx(memoryManager, executor_, kMemoryCapacity);
+  auto queryCtx =
+      newQueryCtx(memoryManager.get(), executor_.get(), kMemoryCapacity);
   ASSERT_EQ(queryCtx->pool()->capacity(), kMemoryPoolInitCapacity);
 
   std::atomic<bool> injectFakeAllocationOnce{true};
@@ -3772,7 +3776,8 @@ DEBUG_ONLY_TEST_F(
   createDuckDbTable(vectors);
   auto memoryManager = createMemoryManager();
   auto arbitrator = memoryManager->arbitrator();
-  auto queryCtx = newQueryCtx(memoryManager, executor_, kMemoryCapacity);
+  auto queryCtx =
+      newQueryCtx(memoryManager.get(), executor_.get(), kMemoryCapacity);
   ASSERT_EQ(queryCtx->pool()->capacity(), kMemoryPoolInitCapacity);
 
   std::atomic<bool> writerNoMoreInput{false};
@@ -3868,7 +3873,8 @@ DEBUG_ONLY_TEST_F(
 
   auto memoryManager = createMemoryManager();
   auto arbitrator = memoryManager->arbitrator();
-  auto queryCtx = newQueryCtx(memoryManager, executor_, kMemoryCapacity);
+  auto queryCtx =
+      newQueryCtx(memoryManager.get(), executor_.get(), kMemoryCapacity);
   ASSERT_EQ(queryCtx->pool()->capacity(), kMemoryPoolInitCapacity);
 
   std::atomic<bool> injectFakeAllocationOnce{true};
@@ -3956,7 +3962,8 @@ DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, tableFileWriteError) {
   auto memoryManager =
       createMemoryManager(memoryCapacity, kMemoryPoolInitCapacity);
   auto arbitrator = memoryManager->arbitrator();
-  auto queryCtx = newQueryCtx(memoryManager, executor_, memoryCapacity);
+  auto queryCtx =
+      newQueryCtx(memoryManager.get(), executor_.get(), memoryCapacity);
   ASSERT_EQ(queryCtx->pool()->capacity(), kMemoryPoolInitCapacity);
   std::atomic<bool> injectWriterErrorOnce{true};
   SCOPED_TESTVALUE_SET(
@@ -4026,9 +4033,9 @@ DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, tableWriteSpillUseMoreMemory) {
   auto arbitrator = memoryManager->arbitrator();
 
   std::shared_ptr<core::QueryCtx> queryCtx =
-      newQueryCtx(memoryManager, executor_, memoryCapacity / 8);
+      newQueryCtx(memoryManager.get(), executor_.get(), memoryCapacity / 8);
   std::shared_ptr<core::QueryCtx> fakeQueryCtx =
-      newQueryCtx(memoryManager, executor_, memoryCapacity);
+      newQueryCtx(memoryManager.get(), executor_.get(), memoryCapacity);
   auto fakePool = fakeQueryCtx->pool()->addLeafChild(
       "fakePool", true, FakeMemoryReclaimer::create());
   TestAllocation injectedFakeAllocation{
@@ -4111,8 +4118,10 @@ DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, tableWriteReclaimOnClose) {
 
   auto memoryManager = createMemoryManager();
   auto arbitrator = memoryManager->arbitrator();
-  auto queryCtx = newQueryCtx(memoryManager, executor_, kMemoryCapacity);
-  auto fakeQueryCtx = newQueryCtx(memoryManager, executor_, kMemoryCapacity);
+  auto queryCtx =
+      newQueryCtx(memoryManager.get(), executor_.get(), kMemoryCapacity);
+  auto fakeQueryCtx =
+      newQueryCtx(memoryManager.get(), executor_.get(), kMemoryCapacity);
   auto fakePool = fakeQueryCtx->pool()->addLeafChild(
       "fakePool", true, FakeMemoryReclaimer::create());
 
@@ -4199,7 +4208,8 @@ DEBUG_ONLY_TEST_F(
 
   auto memoryManager = createMemoryManager(memoryCapacity);
   auto arbitrator = memoryManager->arbitrator();
-  auto queryCtx = newQueryCtx(memoryManager, executor_, kMemoryCapacity);
+  auto queryCtx =
+      newQueryCtx(memoryManager.get(), executor_.get(), kMemoryCapacity);
 
   std::atomic_bool writerCloseWaitFlag{true};
   folly::EventCount writerCloseWait;

--- a/velox/exec/tests/utils/ArbitratorTestUtil.cpp
+++ b/velox/exec/tests/utils/ArbitratorTestUtil.cpp
@@ -25,8 +25,8 @@ using namespace facebook::velox::memory;
 namespace facebook::velox::exec::test {
 
 std::shared_ptr<core::QueryCtx> newQueryCtx(
-    const std::unique_ptr<MemoryManager>& memoryManager,
-    const std::shared_ptr<folly::Executor>& executor,
+    MemoryManager* memoryManager,
+    folly::Executor* executor,
     int64_t memoryCapacity,
     std::unique_ptr<MemoryReclaimer>&& reclaimer) {
   std::unordered_map<std::string, std::shared_ptr<Config>> configs;
@@ -35,7 +35,7 @@ std::shared_ptr<core::QueryCtx> newQueryCtx(
       memoryCapacity,
       reclaimer != nullptr ? std::move(reclaimer) : MemoryReclaimer::create());
   auto queryCtx = std::make_shared<core::QueryCtx>(
-      executor.get(),
+      executor,
       core::QueryConfig({}),
       configs,
       cache::AsyncDataCache::getInstance(),
@@ -50,11 +50,13 @@ std::unique_ptr<memory::MemoryManager> createMemoryManager(
     uint64_t maxReclaimWaitMs) {
   memory::MemoryManagerOptions options;
   options.arbitratorCapacity = arbitratorCapacity;
+  options.arbitratorReservedCapacity = 0;
   // Avoid allocation failure in unit tests.
   options.allocatorCapacity = arbitratorCapacity * 2;
   options.arbitratorKind = "SHARED";
   options.memoryPoolInitCapacity = memoryPoolInitCapacity;
   options.memoryPoolTransferCapacity = memoryPoolTransferCapacity;
+  options.memoryPoolReservedCapacity = 0;
   options.memoryReclaimWaitMs = maxReclaimWaitMs;
   options.checkUsageLeak = true;
   options.arbitrationStateCheckCb = memoryArbitrationStateCheck;

--- a/velox/exec/tests/utils/ArbitratorTestUtil.h
+++ b/velox/exec/tests/utils/ArbitratorTestUtil.h
@@ -87,9 +87,8 @@ struct TestAllocation {
 };
 
 std::shared_ptr<core::QueryCtx> newQueryCtx(
-    const std::unique_ptr<facebook::velox::memory::MemoryManager>&
-        memoryManager,
-    const std::shared_ptr<folly::Executor>& executor,
+    facebook::velox::memory::MemoryManager* memoryManager,
+    folly::Executor* executor,
     int64_t memoryCapacity = facebook::velox::memory::kMaxMemory,
     std::unique_ptr<MemoryReclaimer>&& reclaimer = nullptr);
 

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -76,15 +76,22 @@ void OperatorTestBase::TearDownTestCase() {
   memory::SharedArbitrator::unregisterFactory();
 }
 
-void OperatorTestBase::resetMemory() {
+void OperatorTestBase::setupMemory(
+    int64_t allocatorCapacity,
+    int64_t arbitratorCapacity,
+    int64_t arbitratorReservedCapacity,
+    int64_t memoryPoolInitCapacity,
+    int64_t memoryPoolReservedCapacity) {
   if (asyncDataCache_ != nullptr) {
     asyncDataCache_->clear();
     asyncDataCache_.reset();
   }
   MemoryManagerOptions options;
-  options.allocatorCapacity = 8L << 30;
-  options.arbitratorCapacity = 6L << 30;
-  options.memoryPoolInitCapacity = 512 << 20;
+  options.allocatorCapacity = allocatorCapacity;
+  options.arbitratorCapacity = arbitratorCapacity;
+  options.arbitratorReservedCapacity = arbitratorReservedCapacity;
+  options.memoryPoolInitCapacity = memoryPoolInitCapacity;
+  options.memoryPoolReservedCapacity = memoryPoolReservedCapacity;
   options.arbitratorKind = "SHARED";
   options.checkUsageLeak = true;
   options.arbitrationStateCheckCb = memoryArbitrationStateCheck;
@@ -92,6 +99,10 @@ void OperatorTestBase::resetMemory() {
   asyncDataCache_ =
       cache::AsyncDataCache::create(memory::memoryManager()->allocator());
   cache::AsyncDataCache::setInstance(asyncDataCache_.get());
+}
+
+void OperatorTestBase::resetMemory() {
+  OperatorTestBase::setupMemory(8L << 30, 6L << 30, 0, 512 << 20, 0);
 }
 
 void OperatorTestBase::SetUp() {

--- a/velox/exec/tests/utils/OperatorTestBase.h
+++ b/velox/exec/tests/utils/OperatorTestBase.h
@@ -40,8 +40,17 @@ class OperatorTestBase : public testing::Test,
   static void SetUpTestCase();
   static void TearDownTestCase();
 
-  /// Sets up the velox memory system. A second call to this will clear the
-  /// previous memory system instances and create a new set.
+  /// Sets up the velox memory system.
+  ///
+  /// NOTE: a second call to this will clear the previous memory system
+  /// instances and create a new set.
+  static void setupMemory(
+      int64_t allocatorCapacity,
+      int64_t arbitratorCapacity,
+      int64_t arbitratorReservedCapacity,
+      int64_t memoryPoolInitCapacity,
+      int64_t memoryPoolReservedCapacity);
+
   static void resetMemory();
 
  protected:


### PR DESCRIPTION
To ensure small queries having enough memory capacity to run through without the interference
of the other large queries by slow memory arbitration. We reserve a small percentage of memory
capacity which is only used for memory reservation when we start a query execution to ensure that
each query has a minimal amount of memory capacity to run. Correspondingly, when we free unused
memory capacity from a query memory pool, we make sure the reclaimed memory pool still has the
minimal amount of capacity after the shrink.