### PR TITLE
Change JoinFuzzer iteration message to warning

### DIFF
--- a/velox/exec/tests/JoinFuzzer.cpp
+++ b/velox/exec/tests/JoinFuzzer.cpp
@@ -1221,16 +1221,16 @@ void JoinFuzzer::go() {
   size_t iteration = 0;
 
   while (!isDone(iteration, startTime)) {
-    LOG(INFO) << "==============================> Started iteration "
-              << iteration << " (seed: " << currentSeed_ << ")";
+    LOG(WARNING) << "==============================> Started iteration "
+                 << iteration << " (seed: " << currentSeed_ << ")";
 
     // Pick join type.
     const auto joinType = pickJoinType();
 
     verify(joinType);
 
-    LOG(INFO) << "==============================> Done with iteration "
-              << iteration;
+    LOG(WARNING) << "==============================> Done with iteration "
+                 << iteration;
 
     reSeed();
     ++iteration;


### PR DESCRIPTION
The CI pipeline runs the JoinFuzzer with --minloglevel=1 which excludes INFO messages. This change is to make sure that failures will have the iteration seed printed to allow an easy repro.