### PR TITLE
Fix MinioServer to prevent startup errors due to invalid ports

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3MultipleEndpointsTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3MultipleEndpointsTest.cpp
@@ -48,9 +48,7 @@ class S3MultipleEndpoints : public S3Test {
                 minioServer_->hiveConfig(),
                 ioExecutor_.get());
     connector::registerConnector(hiveConnector1);
-    auto port = facebook::velox::exec::test::getFreePort();
-    minioSecondServer_ =
-        std::make_unique<MinioServer>(fmt::format("127.0.0.1:{}", port));
+    minioSecondServer_ = std::make_unique<MinioServer>();
     minioSecondServer_->start();
     auto hiveConnector2 =
         connector::getConnectorFactory(

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3Test.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3Test.h
@@ -21,7 +21,6 @@
 #include "velox/connectors/hive/storage_adapters/s3fs/S3Util.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/tests/MinioServer.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
-#include "velox/exec/tests/utils/PortUtil.h"
 #include "velox/exec/tests/utils/TempFilePath.h"
 
 #include "gtest/gtest.h"
@@ -35,9 +34,7 @@ static constexpr std::string_view kDummyPath = "s3://dummy/foo.txt";
 class S3Test : public testing::Test, public ::test::VectorTestBase {
  protected:
   void SetUp() override {
-    auto port = facebook::velox::exec::test::getFreePort();
-    minioServer_ =
-        std::make_unique<MinioServer>(fmt::format("127.0.0.1:{}", port));
+    minioServer_ = std::make_unique<MinioServer>();
     minioServer_->start();
     ioExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(3);
   }


### PR DESCRIPTION
The minio server provides an API port and a console endpoint. Originally, only one free port is used 
by the tests to set the API endpoint. This can cause issues (flaky test) when the selected port
overlaps with the console default port.
This change explicitly sets the ports for the API and console to avoid any issues related to these two ports.