### PR TITLE
Optionally use linear heuristics to estimate stripe size

### DIFF
--- a/velox/dwio/common/FileSink.cpp
+++ b/velox/dwio/common/FileSink.cpp
@@ -186,8 +186,7 @@ MemorySink::MemorySink(size_t capacity, const Options& options)
 void MemorySink::write(std::vector<DataBuffer<char>>& buffers) {
   writeImpl(buffers, [&](auto& buffer) {
     const auto size = buffer.size();
-    DWIO_ENSURE_LE(size_ + size, data_.capacity());
-    ::memcpy(data_.data() + size_, buffer.data(), size);
+    data_.extendAppend(size_, buffer.data(), size);
     return size;
   });
 }

--- a/velox/dwio/dwrf/common/Config.cpp
+++ b/velox/dwio/dwrf/common/Config.cpp
@@ -192,6 +192,10 @@ Config::Entry<uint64_t> Config::STRIPE_SIZE(
     "hive.exec.orc.stripe.size",
     256L * 1024L * 1024L);
 
+Config::Entry<bool> Config::LINEAR_STRIPE_SIZE_HEURISTICS(
+    "hive.exec.orc.linear.stripe.size.heuristics",
+    true);
+
 Config::Entry<bool> Config::FORCE_LOW_MEMORY_MODE(
     "hive.exec.orc.low.memory",
     false);

--- a/velox/dwio/dwrf/common/Config.h
+++ b/velox/dwio/dwrf/common/Config.h
@@ -62,6 +62,7 @@ class Config : public common::ConfigBase<Config> {
   static Entry<uint32_t> MAP_FLAT_MAX_KEYS;
   static Entry<uint64_t> MAX_DICTIONARY_SIZE;
   static Entry<uint64_t> STRIPE_SIZE;
+  static Entry<bool> LINEAR_STRIPE_SIZE_HEURISTICS;
   /// With this config, we don't even try the more memory intensive encodings on
   /// writer start up.
   static Entry<bool> FORCE_LOW_MEMORY_MODE;

--- a/velox/dwio/dwrf/test/WriterExtendedTests.cpp
+++ b/velox/dwio/dwrf/test/WriterExtendedTests.cpp
@@ -108,8 +108,8 @@ void testWriterDefaultFlushPolicy(
       numStripesLower,
       numStripesUpper,
       config,
-      /* flushPolicyFactory */ nullptr,
-      /* layoutPlannerFactory */ nullptr,
+      /*flushPolicyFactory=*/nullptr,
+      /*layoutPlannerFactory=*/nullptr,
       memoryBudget,
       false);
 }
@@ -123,7 +123,7 @@ class E2EWriterTest : public testing::Test {
 
 TEST_F(E2EWriterTest, FlushPolicySimpleEncoding) {
   const size_t batchCount = 200;
-  const size_t size = 1000;
+  const size_t batchSize = 1000;
   auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
 
   HiveTypeParser parser;
@@ -138,30 +138,30 @@ TEST_F(E2EWriterTest, FlushPolicySimpleEncoding) {
 
   auto testCases = folly::make_array<FlushPolicyTestCase>(
       FlushPolicyTestCase{
-          /*stripeSize*/ 256 * kSizeKB,
-          /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 13,
-          /*numStripesUpper*/ 13,
-          /*seed*/ 1411367325},
+          /*stripeSize=*/256 * kSizeKB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/13,
+          /*numStripesUpper=*/13,
+          /*seed=*/1411367325},
       FlushPolicyTestCase{
-          /*stripeSize*/ 512 * kSizeKB,
-          /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 7,
-          /*numStripesUpper*/ 7,
-          /*seed*/ 1411367325},
+          /*stripeSize=*/512 * kSizeKB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/7,
+          /*numStripesUpper=*/7,
+          /*seed=*/1411367325},
       FlushPolicyTestCase{
-          /*stripeSize*/ 1 * kSizeMB,
-          /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 4,
-          /*numStripesUpper*/ 4,
-          /*seed*/ 1411367325});
+          /*stripeSize=*/1 * kSizeMB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/4,
+          /*numStripesUpper=*/4,
+          /*seed=*/1411367325});
 
   for (const auto& testCase : testCases) {
     auto config = std::make_shared<Config>();
     config->set(Config::DISABLE_LOW_MEMORY_MODE, true);
     config->set(Config::STRIPE_SIZE, testCase.stripeSize);
     auto batches = E2EWriterTestUtil::generateBatches(
-        type, batchCount, size, testCase.seed, *pool);
+        type, batchCount, batchSize, testCase.seed, *pool);
     testWriterDefaultFlushPolicy(
         *pool,
         type,
@@ -177,7 +177,7 @@ TEST_F(E2EWriterTest, FlushPolicySimpleEncoding) {
 // flush is delayed if we rely on stream usage to estimate stripe size.
 TEST_F(E2EWriterTest, FlushPolicyDictionaryEncoding) {
   const size_t batchCount = 500;
-  const size_t size = 1000;
+  const size_t batchSize = 1000;
   auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
 
   HiveTypeParser parser;
@@ -192,30 +192,30 @@ TEST_F(E2EWriterTest, FlushPolicyDictionaryEncoding) {
 
   auto testCases = folly::make_array<FlushPolicyTestCase>(
       FlushPolicyTestCase{
-          /*stripeSize*/ 1 * kSizeMB,
-          /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 11,
-          /*numStripesUpper*/ 11,
-          /*seed*/ 1630160118},
+          /*stripeSize=*/1 * kSizeMB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/11,
+          /*numStripesUpper=*/11,
+          /*seed=*/1630160118},
       FlushPolicyTestCase{
-          /*stripeSize*/ 1 * kSizeMB,
-          /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 11,
-          /*numStripesUpper*/ 11,
-          /*seed*/ 1630160118,
+          /*stripeSize=*/1 * kSizeMB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/11,
+          /*numStripesUpper=*/11,
+          /*seed=*/1630160118,
           11 * kSizeMB},
       FlushPolicyTestCase{
-          /*stripeSize*/ 2 * kSizeMB,
-          /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 6,
-          /*numStripesUpper*/ 6,
-          /*seed*/ 1630160118},
+          /*stripeSize=*/2 * kSizeMB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/6,
+          /*numStripesUpper=*/6,
+          /*seed=*/1630160118},
       FlushPolicyTestCase{
-          /*stripeSize*/ 2 * kSizeMB,
-          /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 6,
-          /*numStripesUpper*/ 6,
-          /*seed*/ 1630160118,
+          /*stripeSize=*/2 * kSizeMB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/6,
+          /*numStripesUpper=*/6,
+          /*seed=*/1630160118,
           13 * kSizeMB});
 
   for (const auto& testCase : testCases) {
@@ -223,7 +223,7 @@ TEST_F(E2EWriterTest, FlushPolicyDictionaryEncoding) {
     config->set(Config::DISABLE_LOW_MEMORY_MODE, true);
     config->set(Config::STRIPE_SIZE, testCase.stripeSize);
     auto batches = E2EWriterTestUtil::generateBatches(
-        type, batchCount, size, testCase.seed, *pool);
+        type, batchCount, batchSize, testCase.seed, *pool);
     testWriterDefaultFlushPolicy(
         *pool,
         type,
@@ -236,30 +236,30 @@ TEST_F(E2EWriterTest, FlushPolicyDictionaryEncoding) {
 
   auto dictionaryEncodingTestCases = folly::make_array<FlushPolicyTestCase>(
       FlushPolicyTestCase{
-          /*stripeSize*/ 256 * kSizeKB,
-          /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 42,
-          /*numStripesUpper*/ 42,
-          /*seed*/ 1630160118},
+          /*stripeSize=*/256 * kSizeKB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/42,
+          /*numStripesUpper=*/43,
+          /*seed=*/1630160118},
       FlushPolicyTestCase{
-          /*stripeSize*/ 256 * kSizeKB,
-          /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 42,
-          /*numStripesUpper*/ 42,
-          /*seed*/ 1630160118,
+          /*stripeSize=*/256 * kSizeKB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/42,
+          /*numStripesUpper=*/43,
+          /*seed=*/1630160118,
           6 * kSizeMB},
       FlushPolicyTestCase{
-          /*stripeSize*/ 512 * kSizeKB,
-          /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 22,
-          /*numStripesUpper*/ 22,
-          /*seed*/ 1630160118},
+          /*stripeSize=*/512 * kSizeKB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/22,
+          /*numStripesUpper=*/22,
+          /*seed=*/1630160118},
       FlushPolicyTestCase{
-          /*stripeSize*/ 512 * kSizeKB,
-          /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 22,
-          /*numStripesUpper*/ 22,
-          /*seed*/ 1630160118,
+          /*stripeSize=*/512 * kSizeKB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/22,
+          /*numStripesUpper=*/22,
+          /*seed=*/1630160118,
           10 * kSizeMB});
 
   for (const auto& testCase : dictionaryEncodingTestCases) {
@@ -270,7 +270,7 @@ TEST_F(E2EWriterTest, FlushPolicyDictionaryEncoding) {
     config->set(Config::DISABLE_LOW_MEMORY_MODE, true);
     config->set(Config::STRIPE_SIZE, testCase.stripeSize);
     auto batches = E2EWriterTestUtil::generateBatches(
-        type, batchCount, size, testCase.seed, *pool);
+        type, batchCount, batchSize, testCase.seed, *pool);
     testWriterDefaultFlushPolicy(
         *pool,
         type,
@@ -283,17 +283,17 @@ TEST_F(E2EWriterTest, FlushPolicyDictionaryEncoding) {
 
   auto dictionarySizeTestCases = folly::make_array<FlushPolicyTestCase>(
       FlushPolicyTestCase{
-          /*stripeSize*/ std::numeric_limits<int64_t>::max(),
-          /*dictSize*/ 20 * kSizeKB,
-          /*numStripesLower*/ 500,
-          /*numStripesUpper*/ 500,
-          /*seed*/ 1719796763},
+          /*stripeSize=*/std::numeric_limits<int64_t>::max(),
+          /*dictSize=*/20 * kSizeKB,
+          /*numStripesLower=*/500,
+          /*numStripesUpper=*/500,
+          /*seed=*/1719796763},
       FlushPolicyTestCase{
-          /*stripeSize*/ std::numeric_limits<int64_t>::max(),
-          /*dictSize*/ 40 * kSizeKB,
-          /*numStripesLower*/ 250,
-          /*numStripesUpper*/ 250,
-          /*seed*/ 1719796763});
+          /*stripeSize=*/std::numeric_limits<int64_t>::max(),
+          /*dictSize=*/40 * kSizeKB,
+          /*numStripesLower=*/250,
+          /*numStripesUpper=*/250,
+          /*seed=*/1719796763});
 
   for (const auto& testCase : dictionarySizeTestCases) {
     // Force writing with dictionary encoding.
@@ -304,7 +304,7 @@ TEST_F(E2EWriterTest, FlushPolicyDictionaryEncoding) {
 
     config->set(Config::MAX_DICTIONARY_SIZE, testCase.dictSize);
     auto batches = E2EWriterTestUtil::generateBatches(
-        type, batchCount, size, testCase.seed, *pool);
+        type, batchCount, batchSize, testCase.seed, *pool);
     testWriterDefaultFlushPolicy(
         *pool,
         type,
@@ -319,7 +319,7 @@ TEST_F(E2EWriterTest, FlushPolicyDictionaryEncoding) {
 // stream usage seems to have a delta that is close to compression block size?
 TEST_F(E2EWriterTest, FlushPolicyNestedTypes) {
   const size_t batchCount = 10;
-  const size_t size = 1000;
+  const size_t batchSize = 1000;
   auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
 
   HiveTypeParser parser;
@@ -334,30 +334,30 @@ TEST_F(E2EWriterTest, FlushPolicyNestedTypes) {
 
   auto testCases = folly::make_array<FlushPolicyTestCase>(
       FlushPolicyTestCase{
-          /*stripeSize*/ 256 * kSizeKB,
-          /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 5,
-          /*numStripesUpper*/ 5,
-          /*seed*/ 3850165650},
+          /*stripeSize=*/256 * kSizeKB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/5,
+          /*numStripesUpper=*/5,
+          /*seed=*/3850165650},
       FlushPolicyTestCase{
-          /*stripeSize*/ 256 * kSizeKB,
-          /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 5,
-          /*numStripesUpper*/ 5,
-          /*seed*/ 3850165650,
+          /*stripeSize=*/256 * kSizeKB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/5,
+          /*numStripesUpper=*/5,
+          /*seed=*/3850165650,
           8 * kSizeMB},
       FlushPolicyTestCase{
-          /*stripeSize*/ 512 * kSizeKB,
-          /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 3,
-          /*numStripesUpper*/ 3,
-          /*seed*/ 3850165650},
+          /*stripeSize=*/512 * kSizeKB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/3,
+          /*numStripesUpper=*/3,
+          /*seed=*/3850165650},
       FlushPolicyTestCase{
-          /*stripeSize*/ 512 * kSizeKB,
-          /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 3,
-          /*numStripesUpper*/ 3,
-          /*seed*/ 2969662436,
+          /*stripeSize=*/512 * kSizeKB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/3,
+          /*numStripesUpper=*/3,
+          /*seed=*/2969662436,
           8 * kSizeMB});
 
   for (const auto& testCase : testCases) {
@@ -365,7 +365,7 @@ TEST_F(E2EWriterTest, FlushPolicyNestedTypes) {
     config->set(Config::DISABLE_LOW_MEMORY_MODE, true);
     config->set(Config::STRIPE_SIZE, testCase.stripeSize);
     auto batches = E2EWriterTestUtil::generateBatches(
-        type, batchCount, size, testCase.seed, *pool);
+        type, batchCount, batchSize, testCase.seed, *pool);
     testWriterDefaultFlushPolicy(
         *pool,
         type,
@@ -380,7 +380,7 @@ TEST_F(E2EWriterTest, FlushPolicyNestedTypes) {
 // Flat map has 1.5 orders of magnitude inflated stream memory usage.
 TEST_F(E2EWriterTest, FlushPolicyFlatMap) {
   const size_t batchCount = 10;
-  const size_t size = 500;
+  const size_t batchSize = 500;
   auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
 
   HiveTypeParser parser;
@@ -396,53 +396,53 @@ TEST_F(E2EWriterTest, FlushPolicyFlatMap) {
 
   auto testCases = folly::make_array<FlatMapFlushPolicyTestCase>(
       FlatMapFlushPolicyTestCase{
-          /*stripeSize*/ 256 * kSizeKB,
-          /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 6,
-          /*numStripesUpper*/ 6,
-          /*enableDictionary*/ true,
-          /*enableDictionarySharing*/ false,
-          /*seed*/ 1321904009},
+          /*stripeSize=*/256 * kSizeKB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/6,
+          /*numStripesUpper=*/6,
+          /*enableDictionary=*/true,
+          /*enableDictionarySharing=*/false,
+          /*seed=*/1321904009},
       FlatMapFlushPolicyTestCase{
-          /*stripeSize*/ 512 * kSizeKB,
-          /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 4,
-          /*numStripesUpper*/ 4,
-          /*enableDictionary*/ true,
-          /*enableDictionarySharing*/ false,
-          /*seed*/ 1321904009},
+          /*stripeSize=*/512 * kSizeKB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/4,
+          /*numStripesUpper=*/4,
+          /*enableDictionary=*/true,
+          /*enableDictionarySharing=*/false,
+          /*seed=*/1321904009},
       FlatMapFlushPolicyTestCase{
-          /*stripeSize*/ 2 * kSizeMB,
-          /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 2,
-          /*numStripesUpper*/ 2,
-          /*enableDictionary*/ true,
-          /*enableDictionarySharing*/ true,
-          /*seed*/ 1321904009},
+          /*stripeSize=*/2 * kSizeMB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/2,
+          /*numStripesUpper=*/2,
+          /*enableDictionary=*/true,
+          /*enableDictionarySharing=*/true,
+          /*seed=*/1321904009},
       FlatMapFlushPolicyTestCase{
-          /*stripeSize*/ 256 * kSizeKB,
-          /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 6,
-          /*numStripesUpper*/ 6,
-          /*enableDictionary*/ false,
-          /*enableDictionarySharing*/ false,
-          /*seed*/ 1321904009},
+          /*stripeSize=*/256 * kSizeKB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/6,
+          /*numStripesUpper=*/6,
+          /*enableDictionary=*/false,
+          /*enableDictionarySharing=*/false,
+          /*seed=*/1321904009},
       FlatMapFlushPolicyTestCase{
-          /*stripeSize*/ 512 * kSizeKB,
-          /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 4,
-          /*numStripesUpper*/ 4,
-          /*enableDictionary*/ false,
-          /*enableDictionarySharing*/ false,
-          /*seed*/ 1321904009},
+          /*stripeSize=*/512 * kSizeKB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/4,
+          /*numStripesUpper=*/4,
+          /*enableDictionary=*/false,
+          /*enableDictionarySharing=*/false,
+          /*seed=*/1321904009},
       FlatMapFlushPolicyTestCase{
-          /*stripeSize*/ 2 * kSizeMB,
-          /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 2,
-          /*numStripesUpper*/ 2,
-          /*enableDictionary*/ false,
-          /*enableDictionarySharing*/ true,
-          /*seed*/ 1321904009});
+          /*stripeSize=*/2 * kSizeMB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/2,
+          /*numStripesUpper=*/2,
+          /*enableDictionary=*/false,
+          /*enableDictionarySharing=*/true,
+          /*seed=*/1321904009});
 
   for (const auto& testCase : testCases) {
     auto config = std::make_shared<Config>();
@@ -461,7 +461,349 @@ TEST_F(E2EWriterTest, FlushPolicyFlatMap) {
     }
     config->set(Config::MAP_FLAT_DICT_SHARE, testCase.enableDictionarySharing);
     auto batches = E2EWriterTestUtil::generateBatches(
-        type, batchCount, size, testCase.seed, *pool);
+        type, batchCount, batchSize, testCase.seed, *pool);
+
+    testWriterDefaultFlushPolicy(
+        *pool,
+        type,
+        batches,
+        testCase.numStripesLower,
+        testCase.numStripesUpper,
+        config,
+        testCase.memoryBudget);
+  }
+}
+
+TEST_F(E2EWriterTest, MemoryPoolBasedFlushPolicySimpleEncoding) {
+  const size_t batchCount = 2000;
+  const size_t batchSize = 5000;
+  auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
+
+  HiveTypeParser parser;
+  auto type = parser.parse(
+      "struct<"
+      "bool_val:boolean,"
+      "byte_val:tinyint,"
+      "float_val:float,"
+      "double_val:double,"
+      "timestamp_val:timestamp,"
+      ">");
+
+  auto testCases = folly::make_array<FlushPolicyTestCase>(
+      FlushPolicyTestCase{
+          /*stripeSize=*/2 * kSizeMB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/55,
+          /*numStripesUpper=*/55,
+          /*seed=*/1411367325},
+      FlushPolicyTestCase{
+          /*stripeSize=*/4 * kSizeMB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/23,
+          /*numStripesUpper=*/23,
+          /*seed=*/1411367325},
+      FlushPolicyTestCase{
+          /*stripeSize=*/32 * kSizeMB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/3,
+          /*numStripesUpper=*/3,
+          /*seed=*/1411367325});
+
+  for (const auto& testCase : testCases) {
+    auto config = std::make_shared<Config>();
+    config->set(Config::DISABLE_LOW_MEMORY_MODE, true);
+    config->set(Config::STRIPE_SIZE, testCase.stripeSize);
+    config->set<uint64_t>(dwrf::Config::COMPRESSION_BLOCK_SIZE_MIN, 64UL);
+    config->set(dwrf::Config::LINEAR_STRIPE_SIZE_HEURISTICS, false);
+    auto batches = E2EWriterTestUtil::generateBatches(
+        type, batchCount, batchSize, testCase.seed, *pool);
+    testWriterDefaultFlushPolicy(
+        *pool,
+        type,
+        batches,
+        testCase.numStripesLower,
+        testCase.numStripesUpper,
+        config,
+        testCase.memoryBudget);
+  }
+}
+
+// Many streams are not yet allocated prior to the first flush, hence first
+// flush is delayed if we rely on stream usage to estimate stripe size.
+TEST_F(E2EWriterTest, MemoryPoolBasedFlushPolicyDictionaryEncoding) {
+  const size_t batchCount = 1000;
+  const size_t batchSize = 2000;
+  auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
+
+  HiveTypeParser parser;
+  auto type = parser.parse(
+      "struct<"
+      "short_val:smallint,"
+      "int_val:int,"
+      "long_val:bigint,"
+      "string_val:string,"
+      "binary_val:binary,"
+      ">");
+
+  auto testCases = folly::make_array<FlushPolicyTestCase>(
+      FlushPolicyTestCase{
+          /*stripeSize=*/1 * kSizeMB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/38,
+          /*numStripesUpper=*/38,
+          /*seed=*/1630160118},
+      FlushPolicyTestCase{
+          /*stripeSize=*/2 * kSizeMB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/29,
+          /*numStripesUpper=*/29,
+          /*seed=*/1630160118},
+      FlushPolicyTestCase{
+          /*stripeSize=*/16 * kSizeMB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/2,
+          /*numStripesUpper=*/2,
+          /*seed=*/1630160118,
+          13 * kSizeMB});
+
+  for (const auto& testCase : testCases) {
+    auto config = std::make_shared<Config>();
+    config->set(Config::DISABLE_LOW_MEMORY_MODE, true);
+    config->set(Config::STRIPE_SIZE, testCase.stripeSize);
+    config->set<uint64_t>(dwrf::Config::COMPRESSION_BLOCK_SIZE_MIN, 64UL);
+    config->set(dwrf::Config::LINEAR_STRIPE_SIZE_HEURISTICS, false);
+    auto batches = E2EWriterTestUtil::generateBatches(
+        type, batchCount, batchSize, testCase.seed, *pool);
+    testWriterDefaultFlushPolicy(
+        *pool,
+        type,
+        batches,
+        testCase.numStripesLower,
+        testCase.numStripesUpper,
+        config,
+        testCase.memoryBudget);
+  }
+
+  auto dictionaryEncodingTestCases = folly::make_array<FlushPolicyTestCase>(
+      FlushPolicyTestCase{
+          /*stripeSize=*/1 * kSizeMB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/198,
+          /*numStripesUpper=*/198,
+          /*seed=*/1630160118},
+      FlushPolicyTestCase{
+          /*stripeSize=*/2 * kSizeMB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/43,
+          /*numStripesUpper=*/43,
+          /*seed=*/1630160118},
+      FlushPolicyTestCase{
+          /*stripeSize=*/16 * kSizeMB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/3,
+          /*numStripesUpper=*/3,
+          /*seed=*/1630160118});
+
+  for (const auto& testCase : dictionaryEncodingTestCases) {
+    auto config = std::make_shared<Config>();
+    config->set(Config::DICTIONARY_NUMERIC_KEY_SIZE_THRESHOLD, 1.0f);
+    config->set(Config::DICTIONARY_STRING_KEY_SIZE_THRESHOLD, 1.0f);
+    config->set(Config::ENTROPY_KEY_STRING_SIZE_THRESHOLD, 0.0f);
+    config->set(Config::DISABLE_LOW_MEMORY_MODE, true);
+    config->set(Config::STRIPE_SIZE, testCase.stripeSize);
+    config->set<uint64_t>(dwrf::Config::COMPRESSION_BLOCK_SIZE_MIN, 64UL);
+    config->set(dwrf::Config::LINEAR_STRIPE_SIZE_HEURISTICS, false);
+    auto batches = E2EWriterTestUtil::generateBatches(
+        type, batchCount, batchSize, testCase.seed, *pool);
+    testWriterDefaultFlushPolicy(
+        *pool,
+        type,
+        batches,
+        testCase.numStripesLower,
+        testCase.numStripesUpper,
+        config,
+        testCase.memoryBudget);
+  }
+
+  auto dictionarySizeTestCases = folly::make_array<FlushPolicyTestCase>(
+      FlushPolicyTestCase{
+          /*stripeSize=*/std::numeric_limits<int64_t>::max(),
+          /*dictSize=*/200 * kSizeKB,
+          /*numStripesLower=*/319,
+          /*numStripesUpper=*/319,
+          /*seed=*/1719796763},
+      FlushPolicyTestCase{
+          /*stripeSize=*/std::numeric_limits<int64_t>::max(),
+          /*dictSize=*/1 * kSizeMB,
+          /*numStripesLower=*/63,
+          /*numStripesUpper=*/63,
+          /*seed=*/1719796763});
+
+  for (const auto& testCase : dictionarySizeTestCases) {
+    // Force writing with dictionary encoding.
+    auto config = std::make_shared<Config>();
+    config->set(Config::DICTIONARY_NUMERIC_KEY_SIZE_THRESHOLD, 1.0f);
+    config->set(Config::DICTIONARY_STRING_KEY_SIZE_THRESHOLD, 1.0f);
+    config->set(Config::ENTROPY_KEY_STRING_SIZE_THRESHOLD, 0.0f);
+    config->set<uint64_t>(dwrf::Config::COMPRESSION_BLOCK_SIZE_MIN, 64UL);
+    config->set(dwrf::Config::LINEAR_STRIPE_SIZE_HEURISTICS, false);
+
+    config->set(Config::MAX_DICTIONARY_SIZE, testCase.dictSize);
+    auto batches = E2EWriterTestUtil::generateBatches(
+        type, batchCount, batchSize, testCase.seed, *pool);
+    testWriterDefaultFlushPolicy(
+        *pool,
+        type,
+        batches,
+        testCase.numStripesLower,
+        testCase.numStripesUpper,
+        config,
+        testCase.memoryBudget);
+  }
+}
+
+// stream usage seems to have a delta that is close to compression block size?
+TEST_F(E2EWriterTest, MemoryPoolBasedFlushPolicyNestedTypes) {
+  const size_t batchCount = 100;
+  const size_t batchSize = 1000;
+  auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
+
+  HiveTypeParser parser;
+  auto type = parser.parse(
+      "struct<"
+      "array_val:array<float>,"
+      "map_val:map<int,double>,"
+      "map_val1:map<bigint,double>,"
+      "map_val2:map<bigint,map<string, int>>,"
+      "struct_val:struct<a:float,b:double>"
+      ">");
+
+  auto testCases = folly::make_array<FlushPolicyTestCase>(
+      FlushPolicyTestCase{
+          /*stripeSize=*/2 * kSizeMB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/9,
+          /*numStripesUpper=*/9,
+          /*seed=*/3850165650},
+      FlushPolicyTestCase{
+          /*stripeSize=*/4 * kSizeMB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/4,
+          /*numStripesUpper=*/4,
+          /*seed=*/3850165650},
+      FlushPolicyTestCase{
+          /*stripeSize=*/16 * kSizeMB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/1,
+          /*numStripesUpper=*/1,
+          /*seed=*/2969662436});
+
+  for (const auto& testCase : testCases) {
+    auto config = std::make_shared<Config>();
+    config->set(Config::DISABLE_LOW_MEMORY_MODE, true);
+    config->set(Config::STRIPE_SIZE, testCase.stripeSize);
+    config->set<uint64_t>(dwrf::Config::COMPRESSION_BLOCK_SIZE_MIN, 64UL);
+    config->set(dwrf::Config::LINEAR_STRIPE_SIZE_HEURISTICS, false);
+    auto batches = E2EWriterTestUtil::generateBatches(
+        type, batchCount, batchSize, testCase.seed, *pool);
+    testWriterDefaultFlushPolicy(
+        *pool,
+        type,
+        batches,
+        testCase.numStripesLower,
+        testCase.numStripesUpper,
+        config,
+        testCase.memoryBudget);
+  }
+}
+
+// Flat map has 1.5 orders of magnitude inflated stream memory usage.
+TEST_F(E2EWriterTest, MemoryPoolBasedFlushPolicyFlatMap) {
+  const size_t batchCount = 500;
+  const size_t batchSize = 500;
+  auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
+
+  HiveTypeParser parser;
+  // A mixture of columns where dictionary sharing is not necessarily
+  // turned on.
+  auto type = parser.parse(
+      "struct<"
+      "map_val:map<int,int>,"
+      "dense_features:map<int,float>,"
+      "sparse_features:map<bigint,array<bigint>>,"
+      "id_score_list_features:map<bigint,map<bigint, float>>,"
+      ">");
+
+  auto testCases = folly::make_array<FlatMapFlushPolicyTestCase>(
+      FlatMapFlushPolicyTestCase{
+          /*stripeSize=*/4 * kSizeMB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/312,
+          /*numStripesUpper=*/312,
+          /*enableDictionary=*/true,
+          /*enableDictionarySharing=*/true,
+          /*seed=*/1321904009},
+      FlatMapFlushPolicyTestCase{
+          /*stripeSize=*/16 * kSizeMB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/3,
+          /*numStripesUpper=*/4,
+          /*enableDictionary=*/true,
+          /*enableDictionarySharing=*/true,
+          /*seed=*/1321904009},
+      FlatMapFlushPolicyTestCase{
+          /*stripeSize=*/128 * kSizeMB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/1,
+          /*numStripesUpper=*/1,
+          /*enableDictionary=*/true,
+          /*enableDictionarySharing=*/true,
+          /*seed=*/1321904009},
+      FlatMapFlushPolicyTestCase{
+          /*stripeSize=*/4 * kSizeMB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/308,
+          /*numStripesUpper=*/308,
+          /*enableDictionary=*/false,
+          /*enableDictionarySharing=*/true,
+          /*seed=*/1321904009},
+      FlatMapFlushPolicyTestCase{
+          /*stripeSize=*/16 * kSizeMB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/3,
+          /*numStripesUpper=*/4,
+          /*enableDictionary=*/false,
+          /*enableDictionarySharing=*/true,
+          /*seed=*/1321904009},
+      FlatMapFlushPolicyTestCase{
+          /*stripeSize=*/128 * kSizeMB,
+          /*dictSize=*/std::numeric_limits<int64_t>::max(),
+          /*numStripesLower=*/1,
+          /*numStripesUpper=*/1,
+          /*enableDictionary=*/false,
+          /*enableDictionarySharing=*/true,
+          /*seed=*/1321904009});
+
+  for (const auto& testCase : testCases) {
+    auto config = std::make_shared<Config>();
+    config->set(Config::STRIPE_SIZE, testCase.stripeSize);
+    config->set(Config::MAX_DICTIONARY_SIZE, testCase.dictSize);
+    config->set(Config::FLATTEN_MAP, true);
+    config->set(Config::MAP_FLAT_COLS, {0, 1, 2, 3});
+    config->set(Config::DISABLE_LOW_MEMORY_MODE, true);
+    config->set<uint64_t>(dwrf::Config::COMPRESSION_BLOCK_SIZE_MIN, 64UL);
+    config->set(dwrf::Config::LINEAR_STRIPE_SIZE_HEURISTICS, false);
+    config->set(
+        Config::MAP_FLAT_DISABLE_DICT_ENCODING, !testCase.enableDictionary);
+    if (testCase.enableDictionary) {
+      // Force dictionary encoding for integer columns.
+      config->set(Config::DICTIONARY_NUMERIC_KEY_SIZE_THRESHOLD, 1.0f);
+    } else {
+      config->set(Config::DICTIONARY_NUMERIC_KEY_SIZE_THRESHOLD, 0.0f);
+    }
+    config->set(Config::MAP_FLAT_DICT_SHARE, testCase.enableDictionarySharing);
+    auto batches = E2EWriterTestUtil::generateBatches(
+        type, batchCount, batchSize, testCase.seed, *pool);
 
     testWriterDefaultFlushPolicy(
         *pool,

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -39,14 +39,17 @@ dwio::common::StripeProgress getStripeProgress(const WriterContext& context) {
       .stripeIndex = context.stripeIndex(),
       .stripeRowCount = context.stripeRowCount(),
       .totalMemoryUsage = context.getTotalMemoryUsage(),
-      .stripeSizeEstimate = std::max(
-          context.getEstimatedStripeSize(context.stripeRawSize()),
-          // The stripe size estimate is only more accurate from the second
-          // stripe onward because it uses past stripe states in heuristics.
-          // We need to additionally bound it with output stream size based
-          // estimate for the first stripe.
-          context.stripeIndex() == 0 ? context.getEstimatedOutputStreamSize()
-                                     : 0)};
+      .stripeSizeEstimate = context.linearStripeSizeHeuristics()
+          ? std::max(
+                context.getEstimatedStripeSize(context.stripeRawSize()),
+                // The stripe size estimate is only more accurate from the
+                // second stripe onward because it uses past stripe states in
+                // heuristics. We need to additionally bound it with output
+                // stream size based estimate for the first stripe.
+                context.stripeIndex() == 0
+                    ? context.getEstimatedOutputStreamSize()
+                    : 0)
+          : context.getEstimatedOutputStreamSize()};
 }
 
 #define NON_RECLAIMABLE_SECTION_CHECK() \

--- a/velox/dwio/dwrf/writer/WriterContext.cpp
+++ b/velox/dwio/dwrf/writer/WriterContext.cpp
@@ -43,6 +43,8 @@ WriterContext::WriterContext(
       shareFlatMapDictionaries_{getConfig(Config::MAP_FLAT_DICT_SHARE)},
       stripeSizeFlushThreshold_{getConfig(Config::STRIPE_SIZE)},
       dictionarySizeFlushThreshold_{getConfig(Config::MAX_DICTIONARY_SIZE)},
+      linearStripeSizeHeuristics_{
+          getConfig(Config::LINEAR_STRIPE_SIZE_HEURISTICS)},
       streamSizeAboveThresholdCheckEnabled_{
           getConfig(Config::STREAM_SIZE_ABOVE_THRESHOLD_CHECK_ENABLED)},
       rawDataSizePerBatch_{getConfig(Config::RAW_DATA_SIZE_PER_BATCH)},


### PR DESCRIPTION
Summary:
Currently, the writer only use memory pool based flush signals to approximate stripe size in the first stripe and then relies on linear heuristics to approximate stripe size and determine flush timing.

While the linear heuristics can get very accurate for stable data shapes, it has edge cases when data shape shifts throughout the file, and might cause the writer to produce super big stripes. This is bad for reliability of both the storage layer and the ingestion engine. We provide a less greedy mode through disabling the linear heuristics for memory bound engines such as Prestissimo.

NOTE: the next step of this fix is to further improve the flush policy for dictionary encoded cases, which will currently undercount due to output streams not being populated until flush time.

Differential Revision: D56089542


