### PR TITLE
Add nightly build on GPU-enabled workers

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -62,7 +62,7 @@ jobs:
       simdjson_SOURCE: BUNDLED
       xsimd_SOURCE: BUNDLED
       CUDA_VERSION: "11.8"
-      CUDA_ARCHITECTURES: 75
+      CUDA_ARCHITECTURES: 60
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -77,7 +77,7 @@ jobs:
           # docker container before. It simplifies testing new/different versions
           if ! yum list installed cuda-nvcc-$(echo ${CUDA_VERSION} | tr '.' '-') 1>/dev/null; then
             source scripts/setup-centos8.sh
-            install_cuda_runtime ${CUDA_VERSION}
+            install_cuda ${CUDA_VERSION}
           fi
 
       - uses: assignUser/stash/restore@v1

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -61,6 +61,8 @@ jobs:
       VELOX_DEPENDENCY_SOURCE: SYSTEM
       simdjson_SOURCE: BUNDLED
       xsimd_SOURCE: BUNDLED
+      CUDA_VERSION: "11.8"
+      CUDA_ARCHITECTURES: 75
     steps:
       - uses: actions/checkout@v4
 
@@ -90,8 +92,6 @@ jobs:
       - name: Make Release Build
         env:
           MAKEFLAGS: 'NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4'
-          CUDA_VERSION: "11.8"
-          CUDA_ARCHITECTURES: 75
           CUDA_COMPILER: /usr/local/cuda-${CUDA_VERSION}/bin/nvcc
           # Without that, nvcc picks /usr/bin/c++ which is GCC 8
           CUDA_FLAGS: "-ccbin /opt/rh/gcc-toolset-9/root/usr/bin"

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -77,7 +77,7 @@ jobs:
           # docker container before. It simplifies testing new/different versions
           if ! yum list installed cuda-nvcc-$(echo ${CUDA_VERSION} | tr '.' '-') 1>/dev/null; then
             source scripts/setup-centos8.sh
-            install_cuda ${CUDA_VERSION}
+            install_cuda_runtime ${CUDA_VERSION}
           fi
 
       - uses: assignUser/stash/restore@v1

--- a/.github/workflows/linux-nightly-build.yml
+++ b/.github/workflows/linux-nightly-build.yml
@@ -70,7 +70,7 @@ jobs:
           # docker container before. It simplifies testing new/different versions
           if ! yum list installed cuda-nvcc-$(echo ${CUDA_VERSION} | tr '.' '-') 1>/dev/null; then
             source scripts/setup-centos8.sh
-            install_cuda ${CUDA_VERSION}
+            install_cuda_toolkit ${CUDA_VERSION}
           fi
 
       - uses: assignUser/stash/restore@v1

--- a/.github/workflows/linux-nightly-build.yml
+++ b/.github/workflows/linux-nightly-build.yml
@@ -60,12 +60,7 @@ jobs:
       - name: Install Dependencies
         run: |
           source scripts/setup-centos8.sh
-          install_cuda_runtime ${CUDA_VERSION}
-          # install_cuda_driver
-
-      # - name: Print CUDA version
-      #   run: |
-      #     nvidia-smi
+          install_cuda ${CUDA_VERSION}
 
       - uses: assignUser/stash/restore@v1
         with:

--- a/.github/workflows/linux-nightly-build.yml
+++ b/.github/workflows/linux-nightly-build.yml
@@ -36,10 +36,6 @@ jobs:
     if: ${{ github.repository == 'facebookincubator/velox' }}
     runs-on: 4-core-ubuntu-gpu-t4
     steps:
-      - name: Print CUDA version
-        run: |
-          nvidia-smi
-
   adapters:
     name: Linux release with adapters
     # prevent errors when forks ff their main branch
@@ -66,12 +62,13 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          # Allows to install arbitrary cuda-version whithout needing to update
-          # docker container before. It simplifies testing new/different versions
-          if ! yum list installed cuda-nvcc-$(echo ${CUDA_VERSION} | tr '.' '-') 1>/dev/null; then
-            source scripts/setup-centos8.sh
-            install_cuda_toolkit ${CUDA_VERSION}
-          fi
+          source scripts/setup-centos8.sh
+          install_cuda_runtime ${CUDA_VERSION}
+          install_cuda_driver
+
+      - name: Print CUDA version
+        run: |
+          nvidia-smi
 
       - uses: assignUser/stash/restore@v1
         with:

--- a/.github/workflows/linux-nightly-build.yml
+++ b/.github/workflows/linux-nightly-build.yml
@@ -15,9 +15,7 @@
 name: Linux Nightly Build
 
 on:
-  push:
-    branches:
-      - "gha-add-cuda"
+  pull_request:
 
   schedule:
     - cron: '0 3 * * *'

--- a/.github/workflows/linux-nightly-build.yml
+++ b/.github/workflows/linux-nightly-build.yml
@@ -30,6 +30,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  version-check:
+    name: Print CUDA version
+    # prevent errors when forks ff their main branch
+    if: ${{ github.repository == 'facebookincubator/velox' }}
+    runs-on: 4-core-ubuntu-gpu-t4
+    steps:
+      - name: Print CUDA version
+        run: |
+          nvidia-smi
+
   adapters:
     name: Linux release with adapters
     # prevent errors when forks ff their main branch

--- a/.github/workflows/linux-nightly-build.yml
+++ b/.github/workflows/linux-nightly-build.yml
@@ -44,7 +44,7 @@ jobs:
       VELOX_DEPENDENCY_SOURCE: SYSTEM
       simdjson_SOURCE: BUNDLED
       xsimd_SOURCE: BUNDLED
-      CUDA_VERSION: "11.8"
+      CUDA_VERSION: "12.4"
       CUDA_ARCHITECTURES: 75
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linux-nightly-build.yml
+++ b/.github/workflows/linux-nightly-build.yml
@@ -118,4 +118,4 @@ jobs:
           LIBHDFS3_CONF: "/__w/velox/velox/scripts/hdfs-client.xml"
         working-directory: _build/release
         run: |
-          ctest -j 8 --output-on-failure --no-tests=error
+          ctest -j 8 --output-on-failure --no-tests=error --verbose

--- a/.github/workflows/linux-nightly-build.yml
+++ b/.github/workflows/linux-nightly-build.yml
@@ -35,7 +35,10 @@ jobs:
     # prevent errors when forks ff their main branch
     if: ${{ github.repository == 'facebookincubator/velox' }}
     runs-on: 4-core-ubuntu-gpu-t4
-    container: ghcr.io/facebookincubator/velox-dev:adapters
+    container:
+      image: ghcr.io/facebookincubator/velox-dev:adapters
+      options: >
+        --gpus all
     defaults:
       run:
         shell: bash

--- a/.github/workflows/linux-nightly-build.yml
+++ b/.github/workflows/linux-nightly-build.yml
@@ -44,6 +44,8 @@ jobs:
       VELOX_DEPENDENCY_SOURCE: SYSTEM
       simdjson_SOURCE: BUNDLED
       xsimd_SOURCE: BUNDLED
+      CUDA_VERSION: "11.8"
+      CUDA_ARCHITECTURES: 75
     steps:
       - uses: actions/checkout@v4
 
@@ -72,9 +74,7 @@ jobs:
 
       - name: Make Release Build
         env:
-          MAKEFLAGS: 'NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4'
-          CUDA_VERSION: "11.8"
-          CUDA_ARCHITECTURES: 75
+          MAKEFLAGS: 'NUM_THREADS=4 MAX_HIGH_MEM_JOBS=2 MAX_LINK_JOBS=2'
           CUDA_COMPILER: /usr/local/cuda-${CUDA_VERSION}/bin/nvcc
           # Without that, nvcc picks /usr/bin/c++ which is GCC 8
           CUDA_FLAGS: "-ccbin /opt/rh/gcc-toolset-9/root/usr/bin"

--- a/.github/workflows/linux-nightly-build.yml
+++ b/.github/workflows/linux-nightly-build.yml
@@ -55,7 +55,7 @@ jobs:
       simdjson_SOURCE: BUNDLED
       xsimd_SOURCE: BUNDLED
       CUDA_VERSION: "12.2" # matches the version installed on 4-core-ubuntu-gpu-t4
-      CUDA_ARCHITECTURES: 75
+      CUDA_ARCHITECTURES: native
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/linux-nightly-build.yml
+++ b/.github/workflows/linux-nightly-build.yml
@@ -61,11 +61,11 @@ jobs:
         run: |
           source scripts/setup-centos8.sh
           install_cuda_runtime ${CUDA_VERSION}
-          install_cuda_driver
+          # install_cuda_driver
 
-      - name: Print CUDA version
-        run: |
-          nvidia-smi
+      # - name: Print CUDA version
+      #   run: |
+      #     nvidia-smi
 
       - uses: assignUser/stash/restore@v1
         with:

--- a/.github/workflows/linux-nightly-build.yml
+++ b/.github/workflows/linux-nightly-build.yml
@@ -107,4 +107,4 @@ jobs:
           LIBHDFS3_CONF: "/__w/velox/velox/scripts/hdfs-client.xml"
         working-directory: _build/release
         run: |
-          ctest -j 8 --output-on-failure --no-tests=error --verbose
+          ctest -j 8 --output-on-failure --no-tests=error

--- a/.github/workflows/linux-nightly-build.yml
+++ b/.github/workflows/linux-nightly-build.yml
@@ -12,32 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Linux Build
+name: Linux Nightly Build
 
 on:
-  push:
-    branches:
-      - "main"
-    paths:
-      - "velox/**"
-      - "!velox/docs/**"
-      - "CMakeLists.txt"
-      - "CMake/**"
-      - "third_party/**"
-      - "scripts/setup-ubuntu.sh"
-      - "scripts/setup-helper-functions.sh"
-      - ".github/workflows/linux-build.yml"
+  schedule:
+    - cron: '0 3 * * *'
 
-  pull_request:
-    paths:
-      - "velox/**"
-      - "!velox/docs/**"
-      - "CMakeLists.txt"
-      - "CMake/**"
-      - "third_party/**"
-      - "scripts/setup-ubuntu.sh"
-      - "scripts/setup-helper-functions.sh"
-      - ".github/workflows/linux-build.yml"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -51,7 +32,7 @@ jobs:
     name: Linux release with adapters
     # prevent errors when forks ff their main branch
     if: ${{ github.repository == 'facebookincubator/velox' }}
-    runs-on: 8-core
+    runs-on: 4-core-ubuntu-gpu-t4
     container: ghcr.io/facebookincubator/velox-dev:adapters
     defaults:
       run:
@@ -126,60 +107,3 @@ jobs:
         working-directory: _build/release
         run: |
           ctest -j 8 --output-on-failure --no-tests=error
-
-  ubuntu-debug:
-    runs-on: 8-core
-    # prevent errors when forks ff their main branch
-    if: ${{ github.repository == 'facebookincubator/velox' }}
-    name: "Ubuntu debug with resolve_dependency"
-    env:
-      CCACHE_DIR: "${{ github.workspace }}/.ccache"
-    defaults:
-      run:
-        shell: bash
-        working-directory: velox
-    steps:
-
-      - name: Get Ccache Stash
-        uses: assignUser/stash/restore@v1
-        with:
-          path: '${{ env.CCACHE_DIR }}'
-          key: ccache-ubuntu-debug-default
-
-      - name: Ensure Stash Dirs Exists
-        working-directory: ${{ github.workspace }}
-        run: |
-          mkdir -p '${{ env.CCACHE_DIR }}'
-
-      - uses: actions/checkout@v4
-        with:
-          path: velox
-
-      - name: Install Dependencies
-        run: |
-          source scripts/setup-ubuntu.sh && install_apt_deps
-
-      - name: Clear CCache Statistics
-        run: |
-          ccache -sz
-
-      - name: Make Debug Build
-        env:
-          VELOX_DEPENDENCY_SOURCE: BUNDLED
-          MAKEFLAGS: "NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4"
-          EXTRA_CMAKE_FLAGS: "-DVELOX_ENABLE_ARROW=ON"
-        run: |
-          make debug 
-
-      - name: CCache after
-        run: |
-          ccache -vs
-
-      - uses: assignUser/stash/save@v1
-        with:
-          path: '${{ env.CCACHE_DIR }}'
-          key: ccache-ubuntu-debug-default
-
-      - name: Run Tests
-        run: |
-          cd _build/debug && ctest -j 8 --output-on-failure --no-tests=error

--- a/.github/workflows/linux-nightly-build.yml
+++ b/.github/workflows/linux-nightly-build.yml
@@ -15,6 +15,10 @@
 name: Linux Nightly Build
 
 on:
+  push:
+    branches:
+      - "gha-add-cuda"
+
   schedule:
     - cron: '0 3 * * *'
 

--- a/.github/workflows/linux-nightly-build.yml
+++ b/.github/workflows/linux-nightly-build.yml
@@ -30,12 +30,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  version-check:
-    name: Print CUDA version
-    # prevent errors when forks ff their main branch
-    if: ${{ github.repository == 'facebookincubator/velox' }}
-    runs-on: 4-core-ubuntu-gpu-t4
-    steps:
   adapters:
     name: Linux release with adapters
     # prevent errors when forks ff their main branch

--- a/.github/workflows/linux-nightly-build.yml
+++ b/.github/workflows/linux-nightly-build.yml
@@ -54,7 +54,7 @@ jobs:
       VELOX_DEPENDENCY_SOURCE: SYSTEM
       simdjson_SOURCE: BUNDLED
       xsimd_SOURCE: BUNDLED
-      CUDA_VERSION: "12.4"
+      CUDA_VERSION: "12.2" # matches the version installed on 4-core-ubuntu-gpu-t4
       CUDA_ARCHITECTURES: 75
     steps:
       - uses: actions/checkout@v4

--- a/scripts/setup-centos8.sh
+++ b/scripts/setup-centos8.sh
@@ -185,16 +185,10 @@ function install_duckdb {
   fi
 }
 
-function install_cuda_runtime {
+function install_cuda {
   # See https://developer.nvidia.com/cuda-downloads
   dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
   yum install -y cuda-nvcc-$(echo $1 | tr '.' '-') cuda-cudart-devel-$(echo $1 | tr '.' '-')
-}
-
-function install_cuda_driver {
-  # See https://developer.nvidia.com/cuda-downloads
-  dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
-  yum install -y nvidia-driver-cuda
 }
 
 function install_velox_deps {

--- a/scripts/setup-centos8.sh
+++ b/scripts/setup-centos8.sh
@@ -185,16 +185,16 @@ function install_duckdb {
   fi
 }
 
-function install_cuda {
+function install_cuda_runtime {
   # See https://developer.nvidia.com/cuda-downloads
   dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
   yum install -y cuda-nvcc-$(echo $1 | tr '.' '-') cuda-cudart-devel-$(echo $1 | tr '.' '-')
 }
 
-function install_cuda_toolkit {
+function install_cuda_driver {
   # See https://developer.nvidia.com/cuda-downloads
   dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
-  yum install -y cuda-toolkit-$(echo $1 | tr '.' '-')
+  yum install -y nvidia-driver-cuda
 }
 
 function install_velox_deps {

--- a/scripts/setup-centos8.sh
+++ b/scripts/setup-centos8.sh
@@ -191,6 +191,12 @@ function install_cuda {
   yum install -y cuda-nvcc-$(echo $1 | tr '.' '-') cuda-cudart-devel-$(echo $1 | tr '.' '-')
 }
 
+function install_cuda_toolkit {
+  # See https://developer.nvidia.com/cuda-downloads
+  dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
+  yum install -y cuda-toolkit-$(echo $1 | tr '.' '-')
+}
+
 function install_velox_deps {
   run_and_time install_velox_deps_from_dnf
   run_and_time install_conda

--- a/velox/experimental/wave/dwio/decode/tests/GpuDecoderTest.cu
+++ b/velox/experimental/wave/dwio/decode/tests/GpuDecoderTest.cu
@@ -131,8 +131,10 @@ void makeBitpackDict(
 class GpuDecoderTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    if (int device; cudaGetDevice(&device) != cudaSuccess) {
-      GTEST_SKIP() << "No CUDA detected, skipping all tests";
+    cudaError_t error;
+    if (int device; (error = cudaGetDevice(&device)) != cudaSuccess) {
+      GTEST_SKIP() << "No CUDA detected, skipping all tests."
+                   << " Error: (" << error << ") " << cudaGetErrorString(error);
     }
 
     CUDA_CHECK_FATAL(cudaEventCreate(&startEvent_));
@@ -618,8 +620,10 @@ int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   folly::Init init{&argc, &argv};
 
-  if (int device; cudaGetDevice(&device) != cudaSuccess) {
-    std::cerr << "No CUDA detected, skipping all tests" << std::endl;
+  cudaError_t error;
+  if (int device; (error = cudaGetDevice(&device)) != cudaSuccess) {
+    std::cerr << "No CUDA detected, skipping all tests."
+              << " Error: (" << error << ") " << cudaGetErrorString(error) << std::endl;
     return 0;
   }
 

--- a/velox/experimental/wave/exec/tests/AggregationTest.cpp
+++ b/velox/experimental/wave/exec/tests/AggregationTest.cpp
@@ -49,8 +49,10 @@ class AggregationTest : public OperatorTestBase {
   }
 
   void SetUp() override {
-    if (int device; cudaGetDevice(&device) != cudaSuccess) {
-      GTEST_SKIP() << "No CUDA detected, skipping all tests";
+    cudaError_t error;
+    if (int device; (error = cudaGetDevice(&device)) != cudaSuccess) {
+      GTEST_SKIP() << "No CUDA detected, skipping all tests."
+                   << " Error: (" << error << ") " << cudaGetErrorString(error);
     }
   }
 };

--- a/velox/experimental/wave/exec/tests/FilterProjectTest.cpp
+++ b/velox/experimental/wave/exec/tests/FilterProjectTest.cpp
@@ -30,8 +30,10 @@ using facebook::velox::test::BatchMaker;
 class FilterProjectTest : public OperatorTestBase {
  protected:
   void SetUp() override {
-    if (int device; cudaGetDevice(&device) != cudaSuccess) {
-      GTEST_SKIP() << "No CUDA detected, skipping all tests";
+    cudaError_t error;
+    if (int device; (error = cudaGetDevice(&device)) != cudaSuccess) {
+      GTEST_SKIP() << "No CUDA detected, skipping all tests."
+                   << " Error: (" << error << ") " << cudaGetErrorString(error);
     }
     wave::registerWave();
   }

--- a/velox/experimental/wave/exec/tests/TableScanTest.cpp
+++ b/velox/experimental/wave/exec/tests/TableScanTest.cpp
@@ -34,8 +34,10 @@ using namespace facebook::velox::exec::test;
 class TableScanTest : public virtual HiveConnectorTestBase {
  protected:
   void SetUp() override {
-    if (int device; cudaGetDevice(&device) != cudaSuccess) {
-      GTEST_SKIP() << "No CUDA detected, skipping all tests";
+    cudaError_t error;
+    if (int device; (error = cudaGetDevice(&device)) != cudaSuccess) {
+      GTEST_SKIP() << "No CUDA detected, skipping all tests."
+                   << " Error: (" << error << ") " << cudaGetErrorString(error);
     }
     HiveConnectorTestBase::SetUp();
     wave::registerWave();


### PR DESCRIPTION
It would be too constraining to build and run on GPU-enabled workers for all pull request and branch pushes. We still want to build the GPU code on all pull requests to reduce the chances of regressions.