### PR TITLE
Disable custom result verifier of approx_distinct in window fuzzer test

### DIFF
--- a/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
@@ -112,7 +112,8 @@ int main(int argc, char** argv) {
       std::shared_ptr<facebook::velox::exec::test::ResultVerifier>>
       customVerificationFunctions = {
           // Approx functions.
-          {"approx_distinct", std::make_shared<ApproxDistinctResultVerifier>()},
+          // https://github.com/facebookincubator/velox/issues/9531
+          {"approx_distinct", nullptr},
           {"approx_set", nullptr},
           {"approx_percentile", nullptr},
           {"approx_most_frequent", nullptr},


### PR DESCRIPTION
Summary:
The custom result verification of approx_distinct fails the window fuzzer test in Velox contbuild (https://github.com/facebookincubator/velox/issues/9531). 
Disable it to unblock Velox contbuild while we investigate what happens there.

Differential Revision: D56311607


