### PR TITLE
Fix setup-centos8 script to use pip3.9

### DIFF
--- a/scripts/setup-centos8.sh
+++ b/scripts/setup-centos8.sh
@@ -61,7 +61,7 @@ function install_velox_deps_from_dnf {
     libdwarf-devel curl-devel libicu-devel bison flex libsodium-devel
 
   # install sphinx for doc gen
-  pip3 install sphinx sphinx-tabs breathe sphinx_rtd_theme
+  pip3.9 install sphinx sphinx-tabs breathe sphinx_rtd_theme
 }
 
 function install_conda {


### PR DESCRIPTION
Use pip3.9 to install packages since python39-pip is installed.