### PR TITLE
Fix the build error with std::random_shuffle

### DIFF
--- a/velox/exec/benchmarks/HashJoinListResultBenchmark.cpp
+++ b/velox/exec/benchmarks/HashJoinListResultBenchmark.cpp
@@ -197,6 +197,9 @@ struct HashTableBenchmarkResult {
 
 class HashTableListJoinResultBenchmark : public VectorTestBase {
  public:
+  HashTableListJoinResultBenchmark()
+      : randomEngine_((std::random_device{}())) {}
+
   HashTableBenchmarkResult run(HashTableBenchmarkParams params) {
     params_ = params;
     HashTableBenchmarkResult result;
@@ -260,7 +263,8 @@ class HashTableListJoinResultBenchmark : public VectorTestBase {
     if (addExtraValue) {
       data[0] = params_.extraValue;
     }
-    std::random_shuffle(data.begin(), data.end());
+
+    std::shuffle(data.begin(), data.end(), randomEngine_);
     std::vector<VectorPtr> children;
     children.push_back(makeFlatVector<int64_t>(data));
     for (int32_t i = 0; i < params_.numDependentFields; ++i) {
@@ -462,6 +466,7 @@ class HashTableListJoinResultBenchmark : public VectorTestBase {
     eraseTime_ += eraseClock.timeToDropValue();
   }
 
+  std::default_random_engine randomEngine_;
   std::unique_ptr<HashTable<true>> topTable_;
   HashTableBenchmarkParams params_;
 


### PR DESCRIPTION
HashJoinListResultBenchmark uses std::random_shuffle() to generate test data. However since std::random_shuffle() was deprecated in C++14 and removed in C++17, the CLion build fails with the error "'random_shuffle' is not a member of 'std'". This commit fixes it by using std::shuffle(), which was in place since c++11 and still up to date.

fixes https://github.com/facebookincubator/velox/pull/9538