### PR TITLE
Fix compile warning by remove comparison of unsigned < 0

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -473,7 +473,7 @@ DwrfRowReader::prefetchUnits() {
 DwrfRowReader::FetchResult DwrfRowReader::fetch(uint32_t stripeIndex) {
   FetchStatus prevStatus;
   stripeLoadStatuses_.withWLock([&](auto& stripeLoadStatus) {
-    if (stripeIndex < 0 || stripeIndex >= stripeLoadStatus.size()) {
+    if (stripeIndex >= stripeLoadStatus.size()) {
       prevStatus = FetchStatus::ERROR;
     }
 


### PR DESCRIPTION
Unsigned int32 always >= 0.

Fixes: https://github.com/facebookincubator/velox/issues/9542