### PR TITLE
Clear paged output stream buffers at flush time

### DIFF
--- a/velox/dwio/common/compression/PagedOutputStream.cpp
+++ b/velox/dwio/common/compression/PagedOutputStream.cpp
@@ -93,7 +93,9 @@ uint64_t PagedOutputStream::flush() {
     auto buffers = createPage();
     const auto cleanup = folly::makeGuard([this]() {
       resetBuffers();
-      // Reset input buffers.
+      // Reset input buffers. clear() forces the buffer to shrink.
+      // Not doing so lead to very high flush memory overhead.
+      buffer_.clear();
       buffer_.resize(pageHeaderSize_);
     });
     bufferHolder_.take(std::move(buffers));

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -420,11 +420,14 @@ void Writer::flushStripe(bool close) {
   });
 
   // Collects the memory increment from flushing data to output streams.
+  const auto postFlushStreamMemoryUsage =
+      context.getMemoryUsage(MemoryUsageCategory::OUTPUT_STREAM);
   const auto flushOverhead =
-      context.getMemoryUsage(MemoryUsageCategory::OUTPUT_STREAM) -
-      preFlushStreamMemoryUsage;
-  context.recordFlushOverhead(flushOverhead);
-  metrics.flushOverhead = flushOverhead;
+      postFlushStreamMemoryUsage > preFlushStreamMemoryUsage
+      ? postFlushStreamMemoryUsage - preFlushStreamMemoryUsage
+      : 0;
+  metrics.flushOverhead = static_cast<uint64_t>(flushOverhead);
+  context.recordFlushOverhead(metrics.flushOverhead);
 
   const auto postFlushMem = context.getTotalMemoryUsage();
 


### PR DESCRIPTION
Summary:
The PagedOutputStream::flush() api is only called at stripe flush time. Currently the internal head buffer of PagedOutputStream is not cleared to save future allocations. However, this causes an entire stripe size worth of flush memory overhead, making the trade off less favorable in ingestion engines.

Clearing the internal buffer explicitly reduces the peak memory significantly as well as reducing the flush overhead. This makes DWRF writers much more friendly for memory arbitration. It also makes the writer memory tighter when data shape is less even across stripes, especially for uneven distribution of keys in flat maps.

Differential Revision: D56095890


