### PR TITLE
Fix TARGET for writer extended tests to run longer in sandcastle

### DIFF
--- a/velox/dwio/dwrf/test/WriterExtendedTests.cpp
+++ b/velox/dwio/dwrf/test/WriterExtendedTests.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <cstdint>
 #include "folly/CPortability.h"
 
 #include "folly/Random.h"
@@ -136,25 +137,27 @@ TEST_F(E2EWriterTest, FlushPolicySimpleEncoding) {
       "timestamp_val:timestamp,"
       ">");
 
+  // Final file size ~3.5MB
+  const uint32_t seed = 1411367325;
   auto testCases = folly::make_array<FlushPolicyTestCase>(
       FlushPolicyTestCase{
           /*stripeSize=*/256 * kSizeKB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
           /*numStripesLower=*/13,
           /*numStripesUpper=*/13,
-          /*seed=*/1411367325},
+          seed},
       FlushPolicyTestCase{
           /*stripeSize=*/512 * kSizeKB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
           /*numStripesLower=*/7,
           /*numStripesUpper=*/7,
-          /*seed=*/1411367325},
+          seed},
       FlushPolicyTestCase{
           /*stripeSize=*/1 * kSizeMB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
           /*numStripesLower=*/4,
           /*numStripesUpper=*/4,
-          /*seed=*/1411367325});
+          seed});
 
   for (const auto& testCase : testCases) {
     auto config = std::make_shared<Config>();
@@ -190,33 +193,21 @@ TEST_F(E2EWriterTest, FlushPolicyDictionaryEncoding) {
       "binary_val:binary,"
       ">");
 
+  // Final file size ~10.7MB
+  const uint32_t seed = 1630160118;
   auto testCases = folly::make_array<FlushPolicyTestCase>(
       FlushPolicyTestCase{
           /*stripeSize=*/1 * kSizeMB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
           /*numStripesLower=*/11,
           /*numStripesUpper=*/11,
-          /*seed=*/1630160118},
-      FlushPolicyTestCase{
-          /*stripeSize=*/1 * kSizeMB,
-          /*dictSize=*/std::numeric_limits<int64_t>::max(),
-          /*numStripesLower=*/11,
-          /*numStripesUpper=*/11,
-          /*seed=*/1630160118,
-          11 * kSizeMB},
+          seed},
       FlushPolicyTestCase{
           /*stripeSize=*/2 * kSizeMB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
           /*numStripesLower=*/6,
           /*numStripesUpper=*/6,
-          /*seed=*/1630160118},
-      FlushPolicyTestCase{
-          /*stripeSize=*/2 * kSizeMB,
-          /*dictSize=*/std::numeric_limits<int64_t>::max(),
-          /*numStripesLower=*/6,
-          /*numStripesUpper=*/6,
-          /*seed=*/1630160118,
-          13 * kSizeMB});
+          seed});
 
   for (const auto& testCase : testCases) {
     auto config = std::make_shared<Config>();
@@ -234,33 +225,26 @@ TEST_F(E2EWriterTest, FlushPolicyDictionaryEncoding) {
         testCase.memoryBudget);
   }
 
+  // Final file size ~11MB
   auto dictionaryEncodingTestCases = folly::make_array<FlushPolicyTestCase>(
       FlushPolicyTestCase{
           /*stripeSize=*/256 * kSizeKB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
           /*numStripesLower=*/42,
           /*numStripesUpper=*/43,
-          /*seed=*/1630160118},
-      FlushPolicyTestCase{
-          /*stripeSize=*/256 * kSizeKB,
-          /*dictSize=*/std::numeric_limits<int64_t>::max(),
-          /*numStripesLower=*/42,
-          /*numStripesUpper=*/43,
-          /*seed=*/1630160118,
-          6 * kSizeMB},
+          seed},
       FlushPolicyTestCase{
           /*stripeSize=*/512 * kSizeKB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
           /*numStripesLower=*/22,
           /*numStripesUpper=*/22,
-          /*seed=*/1630160118},
+          seed},
       FlushPolicyTestCase{
-          /*stripeSize=*/512 * kSizeKB,
+          /*stripeSize=*/4 * kSizeMB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
-          /*numStripesLower=*/22,
-          /*numStripesUpper=*/22,
-          /*seed=*/1630160118,
-          10 * kSizeMB});
+          /*numStripesLower=*/3,
+          /*numStripesUpper=*/3,
+          seed});
 
   for (const auto& testCase : dictionaryEncodingTestCases) {
     auto config = std::make_shared<Config>();
@@ -281,19 +265,21 @@ TEST_F(E2EWriterTest, FlushPolicyDictionaryEncoding) {
         testCase.memoryBudget);
   }
 
+  // Final file size ~11MB
+  const uint32_t dictionaryFlushSeed = 1719796763;
   auto dictionarySizeTestCases = folly::make_array<FlushPolicyTestCase>(
       FlushPolicyTestCase{
           /*stripeSize=*/std::numeric_limits<int64_t>::max(),
           /*dictSize=*/20 * kSizeKB,
           /*numStripesLower=*/500,
           /*numStripesUpper=*/500,
-          /*seed=*/1719796763},
+          dictionaryFlushSeed},
       FlushPolicyTestCase{
           /*stripeSize=*/std::numeric_limits<int64_t>::max(),
           /*dictSize=*/40 * kSizeKB,
           /*numStripesLower=*/250,
           /*numStripesUpper=*/250,
-          /*seed=*/1719796763});
+          dictionaryFlushSeed});
 
   for (const auto& testCase : dictionarySizeTestCases) {
     // Force writing with dictionary encoding.
@@ -332,33 +318,34 @@ TEST_F(E2EWriterTest, FlushPolicyNestedTypes) {
       "struct_val:struct<a:float,b:double>"
       ">");
 
+  // Final file size ~1.4MB
+  const uint32_t seed = 3850165650;
   auto testCases = folly::make_array<FlushPolicyTestCase>(
       FlushPolicyTestCase{
           /*stripeSize=*/256 * kSizeKB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
           /*numStripesLower=*/5,
           /*numStripesUpper=*/5,
-          /*seed=*/3850165650},
+          seed},
       FlushPolicyTestCase{
           /*stripeSize=*/256 * kSizeKB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
           /*numStripesLower=*/5,
           /*numStripesUpper=*/5,
-          /*seed=*/3850165650,
+          seed,
           8 * kSizeMB},
       FlushPolicyTestCase{
           /*stripeSize=*/512 * kSizeKB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
           /*numStripesLower=*/3,
           /*numStripesUpper=*/3,
-          /*seed=*/3850165650},
+          seed},
       FlushPolicyTestCase{
           /*stripeSize=*/512 * kSizeKB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
           /*numStripesLower=*/3,
           /*numStripesUpper=*/3,
-          /*seed=*/2969662436,
-          8 * kSizeMB});
+          seed});
 
   for (const auto& testCase : testCases) {
     auto config = std::make_shared<Config>();
@@ -394,6 +381,7 @@ TEST_F(E2EWriterTest, FlushPolicyFlatMap) {
       "id_score_list_features:map<bigint,map<bigint, float>>,"
       ">");
 
+  const uint32_t seed = 1321904009;
   auto testCases = folly::make_array<FlatMapFlushPolicyTestCase>(
       FlatMapFlushPolicyTestCase{
           /*stripeSize=*/256 * kSizeKB,
@@ -402,7 +390,7 @@ TEST_F(E2EWriterTest, FlushPolicyFlatMap) {
           /*numStripesUpper=*/6,
           /*enableDictionary=*/true,
           /*enableDictionarySharing=*/false,
-          /*seed=*/1321904009},
+          seed},
       FlatMapFlushPolicyTestCase{
           /*stripeSize=*/512 * kSizeKB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
@@ -410,15 +398,15 @@ TEST_F(E2EWriterTest, FlushPolicyFlatMap) {
           /*numStripesUpper=*/4,
           /*enableDictionary=*/true,
           /*enableDictionarySharing=*/false,
-          /*seed=*/1321904009},
+          seed},
       FlatMapFlushPolicyTestCase{
           /*stripeSize=*/2 * kSizeMB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
           /*numStripesLower=*/2,
           /*numStripesUpper=*/2,
           /*enableDictionary=*/true,
-          /*enableDictionarySharing=*/true,
-          /*seed=*/1321904009},
+          /*enableDictionarySharing=*/false,
+          seed},
       FlatMapFlushPolicyTestCase{
           /*stripeSize=*/256 * kSizeKB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
@@ -426,7 +414,7 @@ TEST_F(E2EWriterTest, FlushPolicyFlatMap) {
           /*numStripesUpper=*/6,
           /*enableDictionary=*/false,
           /*enableDictionarySharing=*/false,
-          /*seed=*/1321904009},
+          seed},
       FlatMapFlushPolicyTestCase{
           /*stripeSize=*/512 * kSizeKB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
@@ -434,15 +422,15 @@ TEST_F(E2EWriterTest, FlushPolicyFlatMap) {
           /*numStripesUpper=*/4,
           /*enableDictionary=*/false,
           /*enableDictionarySharing=*/false,
-          /*seed=*/1321904009},
+          seed},
       FlatMapFlushPolicyTestCase{
           /*stripeSize=*/2 * kSizeMB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
           /*numStripesLower=*/2,
           /*numStripesUpper=*/2,
           /*enableDictionary=*/false,
-          /*enableDictionarySharing=*/true,
-          /*seed=*/1321904009});
+          /*enableDictionarySharing=*/false,
+          seed});
 
   for (const auto& testCase : testCases) {
     auto config = std::make_shared<Config>();
@@ -489,25 +477,27 @@ TEST_F(E2EWriterTest, MemoryPoolBasedFlushPolicySimpleEncoding) {
       "timestamp_val:timestamp,"
       ">");
 
+  // Final file size ~175MB
+  const uint32_t seed = 1411367325;
   auto testCases = folly::make_array<FlushPolicyTestCase>(
       FlushPolicyTestCase{
           /*stripeSize=*/2 * kSizeMB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
           /*numStripesLower=*/55,
           /*numStripesUpper=*/55,
-          /*seed=*/1411367325},
+          seed},
       FlushPolicyTestCase{
           /*stripeSize=*/4 * kSizeMB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
           /*numStripesLower=*/23,
           /*numStripesUpper=*/23,
-          /*seed=*/1411367325},
+          seed},
       FlushPolicyTestCase{
           /*stripeSize=*/32 * kSizeMB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
           /*numStripesLower=*/3,
           /*numStripesUpper=*/3,
-          /*seed=*/1411367325});
+          seed});
 
   for (const auto& testCase : testCases) {
     auto config = std::make_shared<Config>();
@@ -545,26 +535,27 @@ TEST_F(E2EWriterTest, MemoryPoolBasedFlushPolicyDictionaryEncoding) {
       "binary_val:binary,"
       ">");
 
+  // Final file size 43MB-46MB
+  const uint32_t seed = 1630160118;
   auto testCases = folly::make_array<FlushPolicyTestCase>(
       FlushPolicyTestCase{
           /*stripeSize=*/1 * kSizeMB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
           /*numStripesLower=*/38,
           /*numStripesUpper=*/38,
-          /*seed=*/1630160118},
+          seed},
       FlushPolicyTestCase{
           /*stripeSize=*/2 * kSizeMB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
-          /*numStripesLower=*/29,
-          /*numStripesUpper=*/29,
-          /*seed=*/1630160118},
+          /*numStripesLower=*/18,
+          /*numStripesUpper=*/18,
+          seed},
       FlushPolicyTestCase{
           /*stripeSize=*/16 * kSizeMB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
           /*numStripesLower=*/2,
           /*numStripesUpper=*/2,
-          /*seed=*/1630160118,
-          13 * kSizeMB});
+          seed});
 
   for (const auto& testCase : testCases) {
     auto config = std::make_shared<Config>();
@@ -584,25 +575,26 @@ TEST_F(E2EWriterTest, MemoryPoolBasedFlushPolicyDictionaryEncoding) {
         testCase.memoryBudget);
   }
 
+  // Final file size 43MB-46MB
   auto dictionaryEncodingTestCases = folly::make_array<FlushPolicyTestCase>(
       FlushPolicyTestCase{
           /*stripeSize=*/1 * kSizeMB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
-          /*numStripesLower=*/198,
-          /*numStripesUpper=*/198,
-          /*seed=*/1630160118},
+          /*numStripesLower=*/63,
+          /*numStripesUpper=*/63,
+          seed},
       FlushPolicyTestCase{
           /*stripeSize=*/2 * kSizeMB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
-          /*numStripesLower=*/43,
-          /*numStripesUpper=*/43,
-          /*seed=*/1630160118},
+          /*numStripesLower=*/29,
+          /*numStripesUpper=*/29,
+          seed},
       FlushPolicyTestCase{
           /*stripeSize=*/16 * kSizeMB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
           /*numStripesLower=*/3,
           /*numStripesUpper=*/3,
-          /*seed=*/1630160118});
+          seed});
 
   for (const auto& testCase : dictionaryEncodingTestCases) {
     auto config = std::make_shared<Config>();
@@ -625,19 +617,21 @@ TEST_F(E2EWriterTest, MemoryPoolBasedFlushPolicyDictionaryEncoding) {
         testCase.memoryBudget);
   }
 
+  // Final file size 43MB-46MB
+  const uint32_t dictionaryFlushSeed = 1719796763;
   auto dictionarySizeTestCases = folly::make_array<FlushPolicyTestCase>(
       FlushPolicyTestCase{
           /*stripeSize=*/std::numeric_limits<int64_t>::max(),
           /*dictSize=*/200 * kSizeKB,
           /*numStripesLower=*/319,
           /*numStripesUpper=*/319,
-          /*seed=*/1719796763},
+          dictionaryFlushSeed},
       FlushPolicyTestCase{
           /*stripeSize=*/std::numeric_limits<int64_t>::max(),
           /*dictSize=*/1 * kSizeMB,
           /*numStripesLower=*/63,
           /*numStripesUpper=*/63,
-          /*seed=*/1719796763});
+          dictionaryFlushSeed});
 
   for (const auto& testCase : dictionarySizeTestCases) {
     // Force writing with dictionary encoding.
@@ -678,25 +672,27 @@ TEST_F(E2EWriterTest, MemoryPoolBasedFlushPolicyNestedTypes) {
       "struct_val:struct<a:float,b:double>"
       ">");
 
+  // Final file size 14MB
+  const uint32_t seed = 3850165650;
   auto testCases = folly::make_array<FlushPolicyTestCase>(
       FlushPolicyTestCase{
           /*stripeSize=*/2 * kSizeMB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
-          /*numStripesLower=*/9,
-          /*numStripesUpper=*/9,
-          /*seed=*/3850165650},
+          /*numStripesLower=*/7,
+          /*numStripesUpper=*/7,
+          seed},
       FlushPolicyTestCase{
           /*stripeSize=*/4 * kSizeMB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
-          /*numStripesLower=*/4,
-          /*numStripesUpper=*/4,
-          /*seed=*/3850165650},
+          /*numStripesLower=*/3,
+          /*numStripesUpper=*/3,
+          seed},
       FlushPolicyTestCase{
           /*stripeSize=*/16 * kSizeMB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
           /*numStripesLower=*/1,
           /*numStripesUpper=*/1,
-          /*seed=*/2969662436});
+          seed});
 
   for (const auto& testCase : testCases) {
     auto config = std::make_shared<Config>();
@@ -734,15 +730,16 @@ TEST_F(E2EWriterTest, MemoryPoolBasedFlushPolicyFlatMap) {
       "id_score_list_features:map<bigint,map<bigint, float>>,"
       ">");
 
+  const uint32_t seed = 1321904009;
   auto testCases = folly::make_array<FlatMapFlushPolicyTestCase>(
       FlatMapFlushPolicyTestCase{
           /*stripeSize=*/4 * kSizeMB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
-          /*numStripesLower=*/312,
-          /*numStripesUpper=*/312,
+          /*numStripesLower=*/310,
+          /*numStripesUpper=*/310,
           /*enableDictionary=*/true,
           /*enableDictionarySharing=*/true,
-          /*seed=*/1321904009},
+          seed},
       FlatMapFlushPolicyTestCase{
           /*stripeSize=*/16 * kSizeMB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
@@ -750,7 +747,7 @@ TEST_F(E2EWriterTest, MemoryPoolBasedFlushPolicyFlatMap) {
           /*numStripesUpper=*/4,
           /*enableDictionary=*/true,
           /*enableDictionarySharing=*/true,
-          /*seed=*/1321904009},
+          seed},
       FlatMapFlushPolicyTestCase{
           /*stripeSize=*/128 * kSizeMB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
@@ -758,7 +755,7 @@ TEST_F(E2EWriterTest, MemoryPoolBasedFlushPolicyFlatMap) {
           /*numStripesUpper=*/1,
           /*enableDictionary=*/true,
           /*enableDictionarySharing=*/true,
-          /*seed=*/1321904009},
+          seed},
       FlatMapFlushPolicyTestCase{
           /*stripeSize=*/4 * kSizeMB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
@@ -766,7 +763,7 @@ TEST_F(E2EWriterTest, MemoryPoolBasedFlushPolicyFlatMap) {
           /*numStripesUpper=*/308,
           /*enableDictionary=*/false,
           /*enableDictionarySharing=*/true,
-          /*seed=*/1321904009},
+          seed},
       FlatMapFlushPolicyTestCase{
           /*stripeSize=*/16 * kSizeMB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
@@ -774,7 +771,7 @@ TEST_F(E2EWriterTest, MemoryPoolBasedFlushPolicyFlatMap) {
           /*numStripesUpper=*/4,
           /*enableDictionary=*/false,
           /*enableDictionarySharing=*/true,
-          /*seed=*/1321904009},
+          seed},
       FlatMapFlushPolicyTestCase{
           /*stripeSize=*/128 * kSizeMB,
           /*dictSize=*/std::numeric_limits<int64_t>::max(),
@@ -782,7 +779,7 @@ TEST_F(E2EWriterTest, MemoryPoolBasedFlushPolicyFlatMap) {
           /*numStripesUpper=*/1,
           /*enableDictionary=*/false,
           /*enableDictionarySharing=*/true,
-          /*seed=*/1321904009});
+          seed});
 
   for (const auto& testCase : testCases) {
     auto config = std::make_shared<Config>();


### PR DESCRIPTION
Summary:
Forgot to fix the extended tests after D56095890. Also found out a way to let sandcastle give the test more time to run. 

Though generally speaking, we should only look at the test signals for opt run mode.

Differential Revision: D56377635


