### PR TITLE
Create Budget utility class

### DIFF
--- a/velox/dwio/common/Budget.h
+++ b/velox/dwio/common/Budget.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <condition_variable>
+#include <functional>
+#include <limits>
+#include <mutex>
+#include "velox/common/base/Exceptions.h"
+#include "velox/dwio/common/MeasureTime.h"
+#include "velox/dwio/common/UnitLoaderTools.h"
+
+namespace facebook::velox::dwio::common {
+
+// This class allows threads to block until enough memory budget for their
+// request is available.
+class Budget {
+ public:
+  explicit Budget(std::function<uint64_t()> budgetCallback)
+      : budget_{budgetCallback()},
+        availableBudget_{asSigned(budget_)},
+        budgetCallback_{std::move(budgetCallback)} {}
+
+  std::optional<std::chrono::high_resolution_clock::duration> waitForBudget(
+      uint64_t requiredBudget) {
+    const auto reqBudget = asSigned(requiredBudget);
+    auto lock = std::unique_lock(mutex_);
+    if (hasBudget(reqBudget)) {
+      useBudget(reqBudget);
+      return std::nullopt;
+    }
+    const std::chrono::time_point<std::chrono::high_resolution_clock>
+        startTime = std::chrono::high_resolution_clock::now();
+    // Wait until budget is available because another thread released it. Also
+    // check every second if the total budget didn't change (so there may be
+    // budget available).
+    while (!hasBudget(reqBudget)) {
+      cv_.wait_for(lock, std::chrono::seconds(1));
+    }
+    useBudget(reqBudget);
+    return std::chrono::high_resolution_clock::now() - startTime;
+  }
+
+  void releaseBudget(uint64_t releasedBudget) {
+    const auto relBudget = asSigned(releasedBudget);
+    auto lock = std::unique_lock(mutex_);
+    availableBudget_ += relBudget;
+    cv_.notify_all();
+  }
+
+ private:
+  int64_t asSigned(uint64_t value) const {
+    VELOX_CHECK(value <= std::numeric_limits<int64_t>::max());
+    return static_cast<int64_t>(value);
+  }
+
+  void useBudget(int64_t requiredBudget) {
+    availableBudget_ -= requiredBudget;
+  }
+
+  bool hasBudget(int64_t requiredBudget) {
+    return updateBudget() >= requiredBudget;
+  }
+
+  int64_t updateBudget() {
+    const auto newBudget = asSigned(budgetCallback_());
+    if (newBudget != budget_) {
+      availableBudget_ += newBudget - budget_;
+      budget_ = newBudget;
+    }
+    return availableBudget_;
+  }
+
+  // The budget can only be > 0, but when we set a new budget, availableBudget_
+  // can go negative, if the budget is already being used and there isn't enough
+  // left.
+  uint64_t budget_;
+  int64_t availableBudget_;
+  std::function<uint64_t()> budgetCallback_;
+  std::condition_variable cv_;
+  std::mutex mutex_;
+  std::chrono::high_resolution_clock::duration lastDuration_;
+};
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/MeasureTime.h
+++ b/velox/dwio/common/MeasureTime.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <functional>
+#include <optional>
+
+namespace facebook {
+namespace velox {
+namespace dwio {
+namespace common {
+
+class MeasureTime {
+ public:
+  explicit MeasureTime(
+      const std::function<void(std::chrono::high_resolution_clock::duration)>&
+          callback)
+      : callback_{callback},
+        startTime_{std::chrono::high_resolution_clock::now()} {}
+
+  MeasureTime(const MeasureTime&) = delete;
+  MeasureTime(MeasureTime&&) = delete;
+  MeasureTime& operator=(const MeasureTime&) = delete;
+  MeasureTime& operator=(MeasureTime&& other) = delete;
+
+  ~MeasureTime() {
+    callback_(std::chrono::high_resolution_clock::now() - startTime_);
+  }
+
+ private:
+  const std::function<void(std::chrono::high_resolution_clock::duration)>&
+      callback_;
+  const std::chrono::time_point<std::chrono::high_resolution_clock> startTime_;
+};
+
+// Make sure you don't pass a lambda to this function, because that will cause a
+// std::function to be created on the fly (implicitly), and when we return from
+// this function that std::function won't exist anymore. So when MeasureTime is
+// destroyed, it will try to access a non-existing std::function.
+inline std::optional<MeasureTime> measureTimeIfCallback(
+    const std::function<void(std::chrono::high_resolution_clock::duration)>&
+        callback) {
+  if (callback) {
+    return std::make_optional<MeasureTime>(callback);
+  }
+  return std::nullopt;
+}
+
+} // namespace common
+} // namespace dwio
+} // namespace velox
+} // namespace facebook

--- a/velox/dwio/common/OnDemandUnitLoader.cpp
+++ b/velox/dwio/common/OnDemandUnitLoader.cpp
@@ -19,7 +19,7 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/dwio/common/UnitLoaderTools.h"
 
-using facebook::velox::dwio::common::unit_loader_tools::measureBlockedOnIo;
+using facebook::velox::dwio::common::unit_loader_tools::measureWithCallback;
 
 namespace facebook::velox::dwio::common {
 
@@ -29,9 +29,10 @@ class OnDemandUnitLoader : public UnitLoader {
  public:
   OnDemandUnitLoader(
       std::vector<std::unique_ptr<LoadUnit>> loadUnits,
-      std::function<void(uint64_t)> blockedOnIoMsCallback)
+      std::function<void(std::chrono::high_resolution_clock::duration)>
+          blockedOnIoCallback)
       : loadUnits_{std::move(loadUnits)},
-        blockedOnIoMsCallback_{std::move(blockedOnIoMsCallback)} {}
+        blockedOnIoCallback_{std::move(blockedOnIoCallback)} {}
 
   ~OnDemandUnitLoader() override = default;
 
@@ -48,7 +49,7 @@ class OnDemandUnitLoader : public UnitLoader {
     }
 
     {
-      auto measure = measureBlockedOnIo(blockedOnIoMsCallback_);
+      auto measure = measureWithCallback(blockedOnIoCallback_);
       loadUnits_[unit]->load();
     }
     loadedUnit_ = unit;
@@ -63,7 +64,8 @@ class OnDemandUnitLoader : public UnitLoader {
 
  private:
   std::vector<std::unique_ptr<LoadUnit>> loadUnits_;
-  std::function<void(uint64_t)> blockedOnIoMsCallback_;
+  std::function<void(std::chrono::high_resolution_clock::duration)>
+      blockedOnIoCallback_;
   std::optional<uint32_t> loadedUnit_;
 };
 
@@ -72,7 +74,7 @@ class OnDemandUnitLoader : public UnitLoader {
 std::unique_ptr<UnitLoader> OnDemandUnitLoaderFactory::create(
     std::vector<std::unique_ptr<LoadUnit>> loadUnits) {
   return std::make_unique<OnDemandUnitLoader>(
-      std::move(loadUnits), blockedOnIoMsCallback_);
+      std::move(loadUnits), blockedOnIoCallback_);
 }
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/OnDemandUnitLoader.cpp
+++ b/velox/dwio/common/OnDemandUnitLoader.cpp
@@ -17,9 +17,10 @@
 #include "velox/dwio/common/OnDemandUnitLoader.h"
 
 #include "velox/common/base/Exceptions.h"
+#include "velox/dwio/common/MeasureTime.h"
 #include "velox/dwio/common/UnitLoaderTools.h"
 
-using facebook::velox::dwio::common::unit_loader_tools::measureWithCallback;
+using facebook::velox::dwio::common::measureTimeIfCallback;
 
 namespace facebook::velox::dwio::common {
 
@@ -49,7 +50,7 @@ class OnDemandUnitLoader : public UnitLoader {
     }
 
     {
-      auto measure = measureWithCallback(blockedOnIoCallback_);
+      auto measure = measureTimeIfCallback(blockedOnIoCallback_);
       loadUnits_[unit]->load();
     }
     loadedUnit_ = unit;

--- a/velox/dwio/common/OnDemandUnitLoader.h
+++ b/velox/dwio/common/OnDemandUnitLoader.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <functional>
 
 #include "velox/dwio/common/UnitLoader.h"
@@ -26,8 +27,9 @@ class OnDemandUnitLoaderFactory
     : public velox::dwio::common::UnitLoaderFactory {
  public:
   explicit OnDemandUnitLoaderFactory(
-      std::function<void(uint64_t)> blockedOnIoMsCallback)
-      : blockedOnIoMsCallback_{std::move(blockedOnIoMsCallback)} {}
+      std::function<void(std::chrono::high_resolution_clock::duration)>
+          blockedOnIoCallback)
+      : blockedOnIoCallback_{std::move(blockedOnIoCallback)} {}
   ~OnDemandUnitLoaderFactory() override = default;
 
   std::unique_ptr<velox::dwio::common::UnitLoader> create(
@@ -35,7 +37,8 @@ class OnDemandUnitLoaderFactory
       override;
 
  private:
-  std::function<void(uint64_t)> blockedOnIoMsCallback_;
+  std::function<void(std::chrono::high_resolution_clock::duration)>
+      blockedOnIoCallback_;
 };
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -141,8 +141,10 @@ class RowReaderOptions {
   // Function to track how much time we spend waiting on IO before reading rows
   // (in dwrf row reader). todo: encapsulate this and keySelectionCallBack_ in a
   // struct
-  std::function<void(uint64_t)> blockedOnIoCallback_;
-  std::function<void(uint64_t)> decodingTimeUsCallback_;
+  std::function<void(std::chrono::high_resolution_clock::duration)>
+      blockedOnIoCallback_;
+  std::function<void(std::chrono::high_resolution_clock::duration)>
+      decodingTimeCallback_;
   std::function<void(uint16_t)> stripeCountCallback_;
   bool eagerFirstStripeLoad = true;
   uint64_t skipRows_ = 0;
@@ -354,20 +356,25 @@ class RowReaderOptions {
   }
 
   void setBlockedOnIoCallback(
-      std::function<void(int64_t)> blockedOnIoCallback) {
+      std::function<void(std::chrono::high_resolution_clock::duration)>
+          blockedOnIoCallback) {
     blockedOnIoCallback_ = std::move(blockedOnIoCallback);
   }
 
-  const std::function<void(int64_t)> getBlockedOnIoCallback() const {
+  const std::function<void(std::chrono::high_resolution_clock::duration)>
+  getBlockedOnIoCallback() const {
     return blockedOnIoCallback_;
   }
 
-  void setDecodingTimeUsCallback(std::function<void(int64_t)> decodingTimeUs) {
-    decodingTimeUsCallback_ = std::move(decodingTimeUs);
+  void setDecodingTimeCallback(
+      std::function<void(std::chrono::high_resolution_clock::duration)>
+          decodingTime) {
+    decodingTimeCallback_ = std::move(decodingTime);
   }
 
-  std::function<void(int64_t)> getDecodingTimeUsCallback() const {
-    return decodingTimeUsCallback_;
+  std::function<void(std::chrono::high_resolution_clock::duration)>
+  getDecodingTimeCallback() const {
+    return decodingTimeCallback_;
   }
 
   void setStripeCountCallback(

--- a/velox/dwio/common/UnitLoaderTools.h
+++ b/velox/dwio/common/UnitLoaderTools.h
@@ -28,38 +28,6 @@
 
 namespace facebook::velox::dwio::common::unit_loader_tools {
 
-class Measure {
- public:
-  explicit Measure(
-      const std::function<void(std::chrono::high_resolution_clock::duration)>&
-          callback)
-      : callback_{callback},
-        startTime_{std::chrono::high_resolution_clock::now()} {}
-
-  Measure(const Measure&) = delete;
-  Measure(Measure&&) = delete;
-  Measure& operator=(const Measure&) = delete;
-  Measure& operator=(Measure&& other) = delete;
-
-  ~Measure() {
-    callback_(std::chrono::high_resolution_clock::now() - startTime_);
-  }
-
- private:
-  const std::function<void(std::chrono::high_resolution_clock::duration)>&
-      callback_;
-  const std::chrono::time_point<std::chrono::high_resolution_clock> startTime_;
-};
-
-inline std::optional<Measure> measureWithCallback(
-    const std::function<void(std::chrono::high_resolution_clock::duration)>&
-        callback) {
-  if (callback) {
-    return std::make_optional<Measure>(callback);
-  }
-  return std::nullopt;
-}
-
 // This class can create many callbacks that can be distributed to unit loader
 // factories. Only when the last created callback is activated, this class will
 // emit the original callback.

--- a/velox/dwio/common/tests/BudgetTests.cpp
+++ b/velox/dwio/common/tests/BudgetTests.cpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <mutex>
+
+#include "folly/Synchronized.h"
+#include "folly/executors/CPUThreadPoolExecutor.h"
+#include "velox/dwio/common/Budget.h"
+#include "velox/dwio/common/ExecutorBarrier.h"
+
+using namespace ::testing;
+using namespace ::facebook::velox::dwio::common;
+
+TEST(BudgetTests, CanUseZero) {
+  Budget budget([&]() { return 0; });
+  EXPECT_FALSE(budget.waitForBudget(0).has_value());
+}
+
+TEST(BudgetTests, CanUseHalf) {
+  Budget budget([&]() { return 10; });
+  EXPECT_FALSE(budget.waitForBudget(5).has_value());
+}
+
+TEST(BudgetTests, CanUseAll) {
+  Budget budget([&]() { return 10; });
+  EXPECT_FALSE(budget.waitForBudget(10).has_value());
+}
+
+TEST(BudgetTests, TwoCanUse) {
+  Budget budget([&]() { return 10; });
+  EXPECT_FALSE(budget.waitForBudget(1).has_value());
+  EXPECT_FALSE(budget.waitForBudget(1).has_value());
+}
+
+TEST(BudgetTests, TwoCanUseAll) {
+  Budget budget([&]() { return 10; });
+  EXPECT_FALSE(budget.waitForBudget(5).has_value());
+  EXPECT_FALSE(budget.waitForBudget(5).has_value());
+}
+
+TEST(BudgetTests, WillRefresh) {
+  uint64_t budgetVar = 0;
+  Budget budget([&]() { return budgetVar; });
+  budgetVar = 1;
+  EXPECT_FALSE(budget.waitForBudget(1).has_value());
+  budgetVar += 1;
+  EXPECT_FALSE(budget.waitForBudget(1).has_value());
+  budgetVar += 1;
+  EXPECT_FALSE(budget.waitForBudget(1).has_value());
+  budgetVar += 1;
+  EXPECT_FALSE(budget.waitForBudget(1).has_value());
+  budgetVar += 1;
+  EXPECT_FALSE(budget.waitForBudget(1).has_value());
+  budgetVar += 1;
+  EXPECT_FALSE(budget.waitForBudget(1).has_value());
+  budget.releaseBudget(6);
+  EXPECT_FALSE(budget.waitForBudget(6).has_value());
+}
+
+TEST(BudgetTests, WillUnblock) {
+  folly::CPUThreadPoolExecutor executor(1);
+  ExecutorBarrier barrier(executor);
+  std::atomic_uint64_t budgetVar = 0;
+  Budget budget([&]() { return budgetVar.load(); });
+  barrier.add([&]() { EXPECT_TRUE(budget.waitForBudget(1).has_value()); });
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  budgetVar = 1;
+  barrier.waitAll();
+}
+
+TEST(BudgetTests, OutOfLimits) {
+  uint64_t budgetVar = std::numeric_limits<uint64_t>::max() - 1;
+  auto budgetBig = [&]() { return budgetVar; };
+  EXPECT_THAT(
+      [&]() { Budget budget(budgetBig); },
+      Throws<facebook::velox::VeloxRuntimeError>(Property(
+          &facebook::velox::VeloxRuntimeError::failingExpression,
+          HasSubstr("value <= std::numeric_limits<int64_t>::max()"))));
+
+  budgetVar = 1;
+  Budget budget(budgetBig);
+  budgetVar = std::numeric_limits<uint64_t>::max() - 1;
+  EXPECT_THAT(
+      [&]() { budget.waitForBudget(1); },
+      Throws<facebook::velox::VeloxRuntimeError>(Property(
+          &facebook::velox::VeloxRuntimeError::failingExpression,
+          HasSubstr("value <= std::numeric_limits<int64_t>::max()"))));
+}
+
+TEST(BudgetTests, ContentionForBudget) {
+  std::atomic_uint64_t simultaneous = 0;
+  std::atomic_uint64_t maxSimultaneous = 0;
+  std::atomic_uint64_t timesDidntWaitForBudget = 0;
+  folly::CPUThreadPoolExecutor executor(3);
+  ExecutorBarrier barrier(executor);
+  Budget budget([]() { return 2; });
+  folly::Synchronized<std::chrono::high_resolution_clock::duration>
+      timeWaitingForBudget;
+  // I tested with i = [0 1] and it already achieved maxSimultaneous = 2. So
+  // setting 100 should be enough for this test not to be flaky, and to try to
+  // run 3 simultaneously if it were possible (if there's a bug in the budget).
+  for (int i = 0; i < 100; ++i) {
+    barrier.add([&]() {
+      auto timeWaiting = budget.waitForBudget(1);
+      ++simultaneous;
+      if (timeWaiting.has_value()) {
+        timeWaitingForBudget.withWLock([&](auto& timeWaitingForBudget) {
+          timeWaitingForBudget += timeWaiting.value();
+        });
+      } else {
+        timesDidntWaitForBudget += 1;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      maxSimultaneous = std::max(maxSimultaneous.load(), simultaneous.load());
+      --simultaneous;
+      budget.releaseBudget(1);
+    });
+  }
+  barrier.waitAll();
+  EXPECT_EQ(maxSimultaneous.load(), 2);
+  EXPECT_GT(
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          *timeWaitingForBudget.rlock())
+          .count(),
+      0);
+  EXPECT_GT(timesDidntWaitForBudget.load(), 0);
+}

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(
   velox_dwio_common_test
   BitConcatenationTest.cpp
   BitPackDecoderTest.cpp
+  BudgetTests.cpp
   ChainedBufferTests.cpp
   ColumnSelectorTests.cpp
   DataBufferTests.cpp

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(
   LocalFileSinkTest.cpp
   MemorySinkTest.cpp
   LoggedExceptionTest.cpp
+  MeasureTimeTests.cpp
   ParallelForTest.cpp
   RangeTests.cpp
   ReadFileInputStreamTests.cpp

--- a/velox/dwio/common/tests/MeasureTimeTests.cpp
+++ b/velox/dwio/common/tests/MeasureTimeTests.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/dwio/common/MeasureTime.h"
+
+using namespace ::testing;
+using namespace ::facebook::velox::dwio::common;
+
+TEST(MeasureTimeTests, DoesntCreateMeasureIfNoCallback) {
+  EXPECT_FALSE(measureTimeIfCallback(nullptr).has_value());
+}
+
+TEST(MeasureTimeTests, CreatesMeasureIfCallback) {
+  auto callback =
+      std::function<void(std::chrono::high_resolution_clock::duration)>(
+          [](const auto&) {});
+  EXPECT_TRUE(measureTimeIfCallback(callback).has_value());
+}
+
+TEST(MeasureTimeTests, MeasuresTime) {
+  bool measured{false};
+  {
+    auto callback =
+        std::function<void(std::chrono::high_resolution_clock::duration)>(
+            [&measured](const auto&) { measured = true; });
+    auto measure = measureTimeIfCallback(callback);
+    EXPECT_TRUE(measure.has_value());
+    EXPECT_FALSE(measured);
+  }
+  EXPECT_TRUE(measured);
+}

--- a/velox/dwio/common/tests/OnDemandUnitLoaderTests.cpp
+++ b/velox/dwio/common/tests/OnDemandUnitLoaderTests.cpp
@@ -32,7 +32,7 @@ using facebook::velox::dwio::common::test::ReaderMock;
 
 TEST(OnDemandUnitLoaderTests, LoadsCorrectlyWithReader) {
   size_t blockedOnIoCount = 0;
-  OnDemandUnitLoaderFactory factory([&](uint64_t) { ++blockedOnIoCount; });
+  OnDemandUnitLoaderFactory factory([&](auto) { ++blockedOnIoCount; });
   ReaderMock readerMock{{10, 20, 30}, {0, 0, 0}, factory};
   EXPECT_EQ(readerMock.unitsLoaded(), std::vector<bool>({false, false, false}));
   EXPECT_EQ(blockedOnIoCount, 0);

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -210,7 +210,7 @@ DwrfRowReader::DwrfRowReader(
     : StripeReaderBase(reader),
       strideIndex_{0},
       options_(opts),
-      decodingTimeUsCallback_{options_.getDecodingTimeUsCallback()},
+      decodingTimeCallback_{options_.getDecodingTimeCallback()},
       columnSelector_{std::make_shared<ColumnSelector>(
           ColumnSelector::apply(opts.getSelector(), reader->getSchema()))},
       currentUnit_{nullptr} {
@@ -480,7 +480,7 @@ void DwrfRowReader::readNext(
     VectorPtr& result) {
   if (!getSelectiveColumnReader()) {
     std::optional<std::chrono::steady_clock::time_point> startTime;
-    if (decodingTimeUsCallback_) {
+    if (decodingTimeCallback_) {
       // We'll use wall time since we have parallel decoding.
       // If we move to sequential decoding only, we can use CPU time.
       startTime.emplace(std::chrono::steady_clock::now());
@@ -492,10 +492,8 @@ void DwrfRowReader::readNext(
         "Mutation pushdown is only supported in selective reader");
     getColumnReader()->next(rowsToRead, result);
     if (startTime.has_value()) {
-      decodingTimeUsCallback_(
-          std::chrono::duration_cast<std::chrono::microseconds>(
-              std::chrono::steady_clock::now() - startTime.value())
-              .count());
+      decodingTimeCallback_(
+          std::chrono::steady_clock::now() - startTime.value());
     }
     return;
   }

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -140,7 +140,8 @@ class DwrfRowReader : public StrideIndexProvider,
   uint64_t rowsInCurrentStripe_;
   uint64_t strideIndex_;
   dwio::common::RowReaderOptions options_;
-  std::function<void(uint64_t)> decodingTimeUsCallback_;
+  std::function<void(std::chrono::high_resolution_clock::duration)>
+      decodingTimeCallback_;
 
   // column selector
   std::shared_ptr<dwio::common::ColumnSelector> columnSelector_;

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -682,7 +682,11 @@ TEST_F(TestReader, testBlockedIoCallbackFiredBlocking) {
   std::optional<uint64_t> metricToIncrement;
 
   rowReaderOpts.setBlockedOnIoCallback(
-      [&metricToIncrement](uint64_t blockedTimeMs) {
+      [&metricToIncrement](
+          std::chrono::high_resolution_clock::duration blockedTime) {
+        const auto blockedTimeMs =
+            std::chrono::duration_cast<std::chrono::milliseconds>(blockedTime)
+                .count();
         if (metricToIncrement) {
           *metricToIncrement += blockedTimeMs;
         } else {
@@ -722,7 +726,11 @@ TEST_F(TestReader, DISABLED_testBlockedIoCallbackFiredNonBlocking) {
   std::optional<uint64_t> metricToIncrement;
 
   rowReaderOpts.setBlockedOnIoCallback(
-      [&metricToIncrement](uint64_t blockedTimeMs) {
+      [&metricToIncrement](
+          std::chrono::high_resolution_clock::duration blockedTime) {
+        const auto blockedTimeMs =
+            std::chrono::duration_cast<std::chrono::milliseconds>(blockedTime)
+                .count();
         if (metricToIncrement) {
           *metricToIncrement += blockedTimeMs;
         } else {
@@ -766,7 +774,11 @@ TEST_F(TestReader, DISABLED_testBlockedIoCallbackFiredWithFirstStripeLoad) {
   std::optional<uint64_t> metricToIncrement;
 
   rowReaderOpts.setBlockedOnIoCallback(
-      [&metricToIncrement](uint64_t blockedTimeMs) {
+      [&metricToIncrement](
+          std::chrono::high_resolution_clock::duration blockedTime) {
+        const auto blockedTimeMs =
+            std::chrono::duration_cast<std::chrono::milliseconds>(blockedTime)
+                .count();
         if (metricToIncrement) {
           *metricToIncrement += blockedTimeMs;
         } else {


### PR DESCRIPTION
Summary:
Create a Budget class to allow threads to block until there's budget available.

This is though to be used as memory budget, but could be any kind of budget.

Differential Revision: D56379447


