### PR TITLE
Fix build with newer XCode

### DIFF
--- a/velox/dwio/parquet/writer/arrow/tests/BloomFilterTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/BloomFilterTest.cpp
@@ -29,8 +29,8 @@
 #include "arrow/buffer.h"
 #include "arrow/io/file.h"
 #include "arrow/status.h"
-#include "arrow/testing/gtest_util.h"
-#include "arrow/testing/random.h"
+#include "arrow/testing/gtest_util.h" // @manual=fbsource//third-party/apache-arrow:arrow_testing
+#include "arrow/testing/random.h" // @manual=fbsource//third-party/apache-arrow:arrow_testing
 
 #include "velox/dwio/parquet/writer/arrow/Exception.h"
 #include "velox/dwio/parquet/writer/arrow/Platform.h"

--- a/velox/dwio/parquet/writer/arrow/tests/ColumnWriterTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/ColumnWriterTest.cpp
@@ -22,7 +22,7 @@
 #include <gtest/gtest.h>
 
 #include "arrow/io/buffered.h"
-#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/gtest_util.h" // @manual=fbsource//third-party/apache-arrow:arrow_testing
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_builders.h"
 

--- a/velox/dwio/parquet/writer/arrow/tests/FileDeserializeTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/FileDeserializeTest.cpp
@@ -36,8 +36,7 @@
 #include "velox/dwio/parquet/writer/arrow/tests/TestUtil.h"
 
 #include "arrow/io/memory.h"
-#include "arrow/status.h"
-#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/gtest_util.h" // @manual=fbsource//third-party/apache-arrow:arrow_testing
 #include "arrow/util/compression.h"
 #include "arrow/util/crc32.h"
 

--- a/velox/dwio/parquet/writer/arrow/tests/FileSerializeTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/FileSerializeTest.cpp
@@ -19,7 +19,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "arrow/testing/gtest_compat.h"
+#include "arrow/testing/gtest_compat.h" // @manual=fbsource//third-party/apache-arrow:arrow_testing
 
 #include "velox/dwio/parquet/writer/arrow/ColumnWriter.h"
 #include "velox/dwio/parquet/writer/arrow/FileWriter.h"

--- a/velox/dwio/parquet/writer/arrow/tests/LevelConversionTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/LevelConversionTest.cpp
@@ -27,7 +27,7 @@
 #include <string>
 #include <vector>
 
-#include "arrow/testing/gtest_compat.h"
+#include "arrow/testing/gtest_compat.h" // @manual=fbsource//third-party/apache-arrow:arrow_testing
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap.h"
 #include "arrow/util/ubsan.h"

--- a/velox/dwio/parquet/writer/arrow/tests/StatisticsTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/StatisticsTest.cpp
@@ -30,8 +30,8 @@
 #include "arrow/array.h"
 #include "arrow/buffer.h"
 #include "arrow/memory_pool.h"
-#include "arrow/testing/builder.h"
-#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/builder.h" // @manual=fbsource//third-party/apache-arrow:arrow_testing
+#include "arrow/testing/gtest_util.h" // @manual=fbsource//third-party/apache-arrow:arrow_testing
 #include "arrow/type_traits.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_ops.h"

--- a/velox/dwio/parquet/writer/arrow/tests/TestUtil.h
+++ b/velox/dwio/parquet/writer/arrow/tests/TestUtil.h
@@ -29,7 +29,7 @@
 #include <gtest/gtest.h>
 
 #include "arrow/io/memory.h"
-#include "arrow/testing/util.h"
+#include "arrow/testing/util.h" // @manual=fbsource//third-party/apache-arrow:arrow_testing
 
 #include "velox/dwio/parquet/writer/arrow/ColumnPage.h"
 #include "velox/dwio/parquet/writer/arrow/ColumnWriter.h"

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -17,7 +17,7 @@
 #include <arrow/api.h>
 #include <arrow/c/abi.h>
 #include <arrow/c/bridge.h>
-#include <arrow/testing/gtest_util.h>
+#include <arrow/testing/gtest_util.h> // @manual=fbsource//third-party/apache-arrow:arrow_testing
 #include <gtest/gtest.h>
 
 #include "velox/common/base/Nulls.h"

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -16,7 +16,7 @@
 
 #include <arrow/c/abi.h>
 #include <arrow/c/bridge.h>
-#include <arrow/testing/gtest_util.h>
+#include <arrow/testing/gtest_util.h> // @manual=fbsource//third-party/apache-arrow:arrow_testing
 #include <gtest/gtest.h>
 
 #include "velox/common/base/tests/GTestUtils.h"


### PR DESCRIPTION
Summary:
## Context

D56311154 broke `arrow` (and potentially other targets) on mac/mac-arm to upgrade XCode, which is encouraged to fix forward ([post](https://fb.workplace.com/groups/XcodeRollout/permalink/1884525198642779/)). This Diff is to resolve the arrow build errors, such as:

https://www.internalfb.com/sandcastle/workflow/1896015443125640249

## Changes

- Split `arrow` into two components: `arrow` and `arrow_testing`. This separation ensures that `arrow_testing` is solely used for testing, while `arrow` remains focused on the core features.
- "Fix" ambiguous << operator calls, which I'm not super confident..

Reviewed By: fskarakas

Differential Revision: D56380166


