### PR TITLE
make numSuspensions in ThreadState atomic

### DIFF
--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -114,7 +114,7 @@ struct ThreadState {
   /// driver thread is in a (recursive) section waiting for RPC or memory
   /// strategy decision. The thread is not supposed to access its memory, which
   /// a third party can revoke while the thread is in this state.
-  uint32_t numSuspensions{0};
+  std::atomic<uint32_t> numSuspensions{0};
   /// The start execution time on thread in milliseconds. It is reset when the
   /// driver goes off thread. This is used to track the time that a driver has
   /// continuously run on a thread for per-driver cpu time slice enforcement.


### PR DESCRIPTION
Summary:
numSuspensions was added in https://github.com/facebookincubator/velox/pull/9477

That PR made it so that memory arbitration does not wait for Table Scan Operators to stop.  In this case, the Table Scan 
Operator may itself trigger an arbitration during an already on going arbitration.  For this reason the boolean suspended was 
converted to an integer numSuspensions as multiple requests for arbitration may occur.

Naturally, the multiple requests to enter arbitration may come from different threads.  We need to make numSuspensions
atomic so that the reads/writes coming from the different threads that triggered arbitration can be handled correctly.

This issue was exposed in TSAN in the join_fuzzer, where a TableScan triggered an arbitration during an ongoing arbitration,
causing a data race with this variable.

Differential Revision: D56439014


