### PR TITLE
Disable the driver suspension optimization for table scan

### DIFF
--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -4127,7 +4127,9 @@ TEST_F(TableScanTest, partitionKeyNotMatchPartitionKeysHandle) {
   assertQuery(op, split, "SELECT c0 FROM tmp");
 }
 
-TEST_F(TableScanTest, memoryArbitrationWithSlowTableScan) {
+// TODO: re-enable this test once we add back driver suspension support for
+// table scan.
+TEST_F(TableScanTest, DISABLED_memoryArbitrationWithSlowTableScan) {
   const size_t numFiles{2};
   std::vector<std::shared_ptr<TempFilePath>> filePaths;
   std::vector<RowVectorPtr> vectorsForDuckDb;
@@ -4205,7 +4207,11 @@ TEST_F(TableScanTest, memoryArbitrationWithSlowTableScan) {
   queryThread.join();
 }
 
-DEBUG_ONLY_TEST_F(TableScanTest, memoryArbitrationByTableScanAllocation) {
+// TODO: re-enable this test once we add back driver suspension support for
+// table scan.
+DEBUG_ONLY_TEST_F(
+    TableScanTest,
+    DISABLED_memoryArbitrationByTableScanAllocation) {
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->getPath(), vectors);


### PR DESCRIPTION
In Meta internal shadow testing, we found driver suspension in table scan get output could
cause high driver queue latency which slow down the query as the suspension leave does
on-thread sleep. We might need to extend it to support yield from leave if driver is pauses so
that we do off-thread sleep. Also the suspension leave needs to take care of task terminate 
and throws after that, otherwise the driver might proceed to the next op which might cause
random failure if the task has been terminated as discovered by join fuzzer.
As for now, we disable this optimization and re-enable this after we have the fixes for the above
two issues later.