### PR TITLE
Make SpillConfig callback return string_view

### DIFF
--- a/velox/common/base/SpillConfig.h
+++ b/velox/common/base/SpillConfig.h
@@ -35,7 +35,7 @@ namespace facebook::velox::common {
 
 /// Defining type for a callback function that returns the spill directory path.
 /// Implementations can use it to ensure the path exists before returning.
-using GetSpillDirectoryPathCB = std::function<const std::string&()>;
+using GetSpillDirectoryPathCB = std::function<std::string_view()>;
 
 /// The callback used to update the aggregated spill bytes of a query. If the
 /// query spill limit is set, the callback throws if the aggregated spilled

--- a/velox/common/base/tests/SpillConfigTest.cpp
+++ b/velox/common/base/tests/SpillConfigTest.cpp
@@ -26,7 +26,7 @@ TEST(SpillConfig, spillLevel) {
   const uint8_t kInitialBitOffset = 16;
   const uint8_t kNumPartitionsBits = 3;
   const SpillConfig config(
-      []() { return ""; },
+      []() -> std::string_view { return ""; },
       [&](uint64_t) {},
       "fakeSpillPath",
       0,
@@ -110,7 +110,7 @@ TEST(SpillConfig, spillLevelLimit) {
     const HashBitRange partitionBits(
         testData.startBitOffset, testData.startBitOffset + testData.numBits);
     const SpillConfig config(
-        []() { return ""; },
+        []() -> std::string_view { return ""; },
         [&](uint64_t) {},
         "fakeSpillPath",
         0,
@@ -150,13 +150,12 @@ TEST(SpillConfig, spillableReservationPercentages) {
       {50, 100, true},
       {1, 50, true},
       {1, 1, false}};
-  const std::string emptySpillFolder = "";
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
 
     auto createConfigFn = [&]() {
       const SpillConfig config(
-          [&]() -> const std::string& { return emptySpillFolder; },
+          [&]() -> std::string_view { return ""; },
           [&](uint64_t) {},
           "spillableReservationPercentages",
           0,

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -146,7 +146,7 @@ std::optional<common::SpillConfig> DriverCtx::makeSpillConfig(
     return std::nullopt;
   }
   common::GetSpillDirectoryPathCB getSpillDirPathCb =
-      [this]() -> const std::string& {
+      [this]() -> std::string_view {
     return task->getOrCreateSpillDirectory();
   };
   const auto& spillFilePrefix =

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -117,7 +117,7 @@ uint64_t SpillState::appendToPartition(
 
   VELOX_CHECK_NOT_NULL(
       getSpillDirPathCb_, "Spill directory callback not specified.");
-  const std::string& spillDir = getSpillDirPathCb_();
+  auto spillDir = getSpillDirPathCb_();
   VELOX_CHECK(!spillDir.empty(), "Spill directory does not exist");
   // Ensure that partition exist before writing.
   if (partitionWriters_.at(partition) == nullptr) {

--- a/velox/exec/tests/AggregateSpillBenchmarkBase.cpp
+++ b/velox/exec/tests/AggregateSpillBenchmarkBase.cpp
@@ -126,7 +126,7 @@ void AggregateSpillBenchmarkBase::writeSpillData() {
 
 std::unique_ptr<Spiller> AggregateSpillBenchmarkBase::makeSpiller() {
   common::SpillConfig spillConfig;
-  spillConfig.getSpillDirPathCb = [&]() -> const std::string& {
+  spillConfig.getSpillDirPathCb = [&]() -> std::string_view {
     return spillDir_;
   };
   spillConfig.updateAndCheckSpillLimitCb = [&](uint64_t) {};

--- a/velox/exec/tests/JoinSpillInputBenchmarkBase.cpp
+++ b/velox/exec/tests/JoinSpillInputBenchmarkBase.cpp
@@ -32,7 +32,7 @@ const int numSampleVectors = 100;
 void JoinSpillInputBenchmarkBase::setUp() {
   SpillerBenchmarkBase::setUp();
   common::SpillConfig spillConfig;
-  spillConfig.getSpillDirPathCb = [&]() -> const std::string& {
+  spillConfig.getSpillDirPathCb = [&]() -> std::string_view {
     return spillDir_;
   };
   spillConfig.updateAndCheckSpillLimitCb = [&](uint64_t) {};

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -520,10 +520,12 @@ class SpillerTest : public exec::test::RowContainerTestBase {
       bool makeError,
       uint64_t maxSpillRunRows = 0) {
     static const std::string kBadSpillDirPath = "/bad/path";
-    common::GetSpillDirectoryPathCB badSpillDirCb =
-        [&]() -> const std::string& { return kBadSpillDirPath; };
-    common::GetSpillDirectoryPathCB tempSpillDirCb =
-        [&]() -> const std::string& { return tempDirPath_->getPath(); };
+    common::GetSpillDirectoryPathCB badSpillDirCb = [&]() -> std::string_view {
+      return kBadSpillDirPath;
+    };
+    common::GetSpillDirectoryPathCB tempSpillDirCb = [&]() -> std::string_view {
+      return tempDirPath_->getPath();
+    };
     stats_.clear();
     spillStats_ = folly::Synchronized<common::SpillStats>();
 


### PR DESCRIPTION
Summary:
Previously spill config's callback returned a const reference to a
std::string. While this works if you have an std::string built on the
stack, implicit conversions like a callback returning "" is unsafe as they get
implicitly converted to a temporary std::string, thus returning a reference to
a temporary. Newer gcc flagged this issue.

Differential Revision: D56449182


