### PR TITLE
Refactor JsonPathTokenizer

### DIFF
--- a/velox/functions/prestosql/json/JsonExtractor.cpp
+++ b/velox/functions/prestosql/json/JsonExtractor.cpp
@@ -73,7 +73,7 @@ class JsonExtractor {
 
     while (kTokenizer.hasNext()) {
       if (auto token = kTokenizer.getNext()) {
-        tokens_.push_back(token.value());
+        tokens_.emplace_back(token.value());
       } else {
         tokens_.clear();
         return false;

--- a/velox/functions/prestosql/json/JsonPathTokenizer.h
+++ b/velox/functions/prestosql/json/JsonPathTokenizer.h
@@ -16,36 +16,31 @@
 
 #pragma once
 
-#include <folly/Expected.h>
-#include <folly/Range.h>
+#include <optional>
+#include <string>
 
 namespace facebook::velox::functions {
 
-using ParseResult = folly::Expected<std::string, bool>;
-
 class JsonPathTokenizer {
  public:
-  bool reset(folly::StringPiece path);
+  bool reset(std::string_view path);
 
   bool hasNext() const;
 
-  ParseResult getNext();
+  std::optional<std::string> getNext();
 
  private:
   bool match(char expected);
-  ParseResult matchDotKey();
 
-  ParseResult matchUnquotedSubscriptKey();
+  std::optional<std::string> matchDotKey();
 
-  ParseResult matchQuotedSubscriptKey();
+  std::optional<std::string> matchUnquotedSubscriptKey();
 
-  bool isDotKeyFormat(char c);
-
-  bool isUnquotedBracketKeyFormat(char c);
+  std::optional<std::string> matchQuotedSubscriptKey();
 
  private:
   size_t index_;
-  folly::StringPiece path_;
+  std::string_view path_;
 };
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/json/SIMDJsonExtractor.cpp
+++ b/velox/functions/prestosql/json/SIMDJsonExtractor.cpp
@@ -55,7 +55,7 @@ bool SIMDJsonExtractor::tokenize(const std::string& path) {
 
   while (tokenizer.hasNext()) {
     if (auto token = tokenizer.getNext()) {
-      tokens_.push_back(token.value());
+      tokens_.emplace_back(token.value());
     } else {
       tokens_.clear();
       return false;

--- a/velox/functions/prestosql/json/tests/JsonPathTokenizerTest.cpp
+++ b/velox/functions/prestosql/json/tests/JsonPathTokenizerTest.cpp
@@ -51,16 +51,19 @@ using TokenList = std::vector<std::string>;
   }
 
 // The test is ported from Presto for compatibility
-folly::Expected<TokenList, bool> getTokens(const std::string& path) {
+std::optional<TokenList> getTokens(const std::string& path) {
   JsonPathTokenizer tokenizer;
-  tokenizer.reset(path);
+  if (!tokenizer.reset(path)) {
+    return std::nullopt;
+  }
+
   TokenList tokens;
   while (tokenizer.hasNext()) {
     if (auto token = tokenizer.getNext()) {
-      tokens.push_back(token.value());
+      tokens.emplace_back(token.value());
     } else {
       tokens.clear();
-      return folly::makeUnexpected(false);
+      return std::nullopt;
     }
   }
   return tokens;


### PR DESCRIPTION
Summary:
- Replace folly::StringPiece with std::string_view.
- Replace `folly::Expected<std::string, bool>` with `std::optional<std::string>`.
- Replace private methods isDotKeyFormat and isUnquotedBracketKeyFormat with free functions in .cpp file.

Differential Revision: D56451797


