### PR TITLE
Fix behavior of VELOX_BUILD_MINIMAL_WITH_DWIO flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,7 @@ option(
 option(VELOX_FORCE_COLORED_OUTPUT
        "Always produce ANSI-colored output (GNU/Clang only)." OFF)
 
-if(${VELOX_BUILD_MINIMAL})
+if(${VELOX_BUILD_MINIMAL} OR ${VELOX_BUILD_MINIMAL_WITH_DWIO})
   # Enable and disable components for velox base build
   set(VELOX_BUILD_TESTING OFF)
   set(VELOX_ENABLE_PRESTO_FUNCTIONS ON)


### PR DESCRIPTION
Summary:
Fixing the intended behavior of the open source compilation flag
VELOX_BUILD_MINIMAL_WITH_DWIO, which is to compile VELOX_BUILD_MINIMAL, plus
dwio.

Differential Revision: D56453924


