### PR TITLE
Fix build error in abfs test

### DIFF
--- a/velox/connectors/hive/storage_adapters/abfs/tests/AbfsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/tests/AbfsFileSystemTest.cpp
@@ -66,7 +66,7 @@ class AbfsFileSystemTest : public testing::Test {
     azuriteServer = std::make_shared<filesystems::test::AzuriteServer>(port);
     azuriteServer->start();
     auto tempFile = createFile();
-    azuriteServer->addFile(tempFile->path, filePath);
+    azuriteServer->addFile(tempFile->getPath(), filePath);
   }
 
   void TearDown() override {

--- a/velox/connectors/hive/storage_adapters/abfs/tests/MockBlobStorageFileClient.h
+++ b/velox/connectors/hive/storage_adapters/abfs/tests/MockBlobStorageFileClient.h
@@ -27,7 +27,7 @@ class MockBlobStorageFileClient : public IBlobStorageFileClient {
  public:
   MockBlobStorageFileClient() {
     auto tempFile = ::exec::test::TempFilePath::create();
-    filePath_ = tempFile->path;
+    filePath_ = tempFile->getPath();
   }
 
   void create() override;


### PR DESCRIPTION
Fix CI failure in [Linux Build / Linux release with adapters (pull_request)](https://github.com/facebookincubator/velox/actions/runs/8793602118/job/24131750229?pr=9478):
```
/__w/velox/velox/./velox/connectors/hive/storage_adapters/abfs/tests/MockBlobStorageFileClient.h:30:27: error: 'using element_type = class facebook::velox::exec::test::TempFilePath' {aka 'class facebook::velox::exec::test::TempFilePath'} has no member named 'path'; did you mean 'const string facebook::velox::exec::test::TempFilePath::path_'? (accessible via 'const string& facebook::velox::exec::test::TempFilePath::getPath() const')
   30 |     filePath_ = tempFile->path;
      |                           ^~~~
      |                           getPath()
  
```

```
/__w/velox/velox/velox/connectors/hive/storage_adapters/abfs/tests/AbfsFileSystemTest.cpp:69:38: error: 'using element_type = class facebook::velox::exec::test::TempFilePath' {aka 'class facebook::velox::exec::test::TempFilePath'} has no member named 'path'; did you mean 'const string facebook::velox::exec::test::TempFilePath::path_'? (accessible via 'const string& facebook::velox::exec::test::TempFilePath::getPath() const')
   69 |     azuriteServer->addFile(tempFile->path, filePath);
      |                                      ^~~~
      |                                      getPath()
```