### PR TITLE
Fix GCC 11 warns that writing 1 byte into a region of size 0 [-Wstringop-overflow=]

### DIFF
--- a/velox/vector/SelectivityVector.h
+++ b/velox/vector/SelectivityVector.h
@@ -156,7 +156,7 @@ class SelectivityVector {
     bits::fillBits(bits_.data(), 0, size_, false);
     begin_ = 0;
     end_ = 0;
-    allSelected_ = false;
+    allSelected_.reset();
   }
 
   /**
@@ -279,7 +279,7 @@ class SelectivityVector {
     if (begin_ == -1) {
       begin_ = 0;
       end_ = 0;
-      allSelected_ = false;
+      allSelected_.reset();
       return;
     }
     end_ = bits::findLastBit(bits_.data(), begin_, size_) + 1;


### PR DESCRIPTION
This PR fixes following error popped during compilation using GCC 11:

```
..../Parquet_Read_Fuzz/ep/build-velox/build/velox_ep/./velox/vector/SelectivityVector.h:160:20: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
  160 |       allSelected_ = false;
      |       ~~~~~~~~~~~~~^~~~~~~
```