### PR TITLE
Fix CI build failure issue

### DIFF
--- a/velox/connectors/hive/storage_adapters/abfs/tests/AbfsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/tests/AbfsFileSystemTest.cpp
@@ -66,7 +66,7 @@ class AbfsFileSystemTest : public testing::Test {
     azuriteServer = std::make_shared<filesystems::test::AzuriteServer>(port);
     azuriteServer->start();
     auto tempFile = createFile();
-    azuriteServer->addFile(tempFile->path, filePath);
+    azuriteServer->addFile(tempFile->getPath(), filePath);
   }
 
   void TearDown() override {

--- a/velox/connectors/hive/storage_adapters/abfs/tests/MockBlobStorageFileClient.h
+++ b/velox/connectors/hive/storage_adapters/abfs/tests/MockBlobStorageFileClient.h
@@ -27,7 +27,7 @@ class MockBlobStorageFileClient : public IBlobStorageFileClient {
  public:
   MockBlobStorageFileClient() {
     auto tempFile = ::exec::test::TempFilePath::create();
-    filePath_ = tempFile->path;
+    filePath_ = tempFile->getPath();
   }
 
   void create() override;


### PR DESCRIPTION
The CI fail with below error due to this PR change https://github.com/facebookincubator/velox/pull/9457

![image](https://github.com/facebookincubator/velox/assets/9858245/8a9939e2-2fcb-4818-9f83-7195984918f7)

Not sure why the above PR been merged since it would fail the CI build
