### PR TITLE
Make leading '$.' optional in JSON paths accepted by json_extract[_scalar] Presto functions

### DIFF
--- a/velox/functions/prestosql/json/JsonPathTokenizer.h
+++ b/velox/functions/prestosql/json/JsonPathTokenizer.h
@@ -21,12 +21,40 @@
 
 namespace facebook::velox::functions {
 
+/// Splits a JSON path into individual tokens.
+///
+/// Supports a subset of JSONPath syntax:
+/// https://goessner.net/articles/JsonPath/
+///
+///   $ - the root element
+///   . or [] - child operator
+///   * - wildcard (all objects/elements regardless their names)
+///
+/// Supports quoted keys.
+///
+/// Notably, doesn't support deep scan, e.g. $..author.
+///
+/// The leading '$.' is optional. Paths '$.foo.bar' and 'foo.bar' are
+/// equivalent. This is not part of JSONPath syntax, but this is the behavior of
+/// Jayway implementation used by Presto.
+///
+/// Examples:
+///   "$.store.book[0].author"
+///   "store.book[0].author"
 class JsonPathTokenizer {
  public:
+  /// Resets the tokenizer to a new path. This method must be called and return
+  /// true before calling hasNext or getNext.
+  ///
+  /// @return true if path is not empty and first character suggests a possibly
+  /// valid path.
   bool reset(std::string_view path);
 
+  /// Returns true if there are more tokens to be extracted.
   bool hasNext() const;
 
+  /// Returns the next token or std::nullopt if there are no more tokens left or
+  /// the remaining path is invalid.
   std::optional<std::string> getNext();
 
  private:
@@ -38,8 +66,12 @@ class JsonPathTokenizer {
 
   std::optional<std::string> matchQuotedSubscriptKey();
 
- private:
+  // The index of the next character to process. This is at least one for
+  // standard paths that start with '$'. This can be zero if 'reset' was called
+  // with a non-standard path that doesn't have a leading '$'.
   size_t index_;
+
+  // The path specified in 'reset'.
   std::string_view path_;
 };
 

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -601,6 +601,15 @@ TEST_F(JsonFunctionsTest, jsonExtract) {
       jsonExtract(kJson, "$.store.book[*].isbn"));
   EXPECT_EQ("\"Evelyn Waugh\"", jsonExtract(kJson, "$.store.book[1].author"));
 
+  // Paths without leading '$'.
+  auto json = R"({"x": {"a": 1, "b": [10, 11, 12]} })";
+  EXPECT_EQ(R"({"a": 1, "b": [10, 11, 12]})", jsonExtract(json, "x"));
+  EXPECT_EQ("1", jsonExtract(json, "x.a"));
+  EXPECT_EQ("[10, 11, 12]", jsonExtract(json, "x.b"));
+  EXPECT_EQ("12", jsonExtract(json, "x.b[2]"));
+  EXPECT_EQ(std::nullopt, jsonExtract(json, "x.c"));
+  EXPECT_EQ(std::nullopt, jsonExtract(json, "x.b[20]"));
+
   // TODO The following paths are supported by Presto via Jayway, but do not
   // work in Velox yet. Figure out how to add support for these.
   VELOX_ASSERT_THROW(jsonExtract(kJson, "$..price"), "Invalid JSON path");


### PR DESCRIPTION
Summary:
json_extract_scalar and json_extract Presto function allow paths like 'foo'
and 'foo.bar'. These paths are non-standard. They are enabled via use of Jayway
engine, which handles paths without leading '$' by prepending the path
with '$.'. Path 'foo' becomes '$.foo'. However, this logic has some unexpected
side effects. Path '.foo' becomes '$..foo', which uses deep scan operator '..'
and matches 'foo' keys anywhere in the document, rather then just at the top
level.

This change allows Velox to support paths like 'foo' and 'foo.bar[2].bar', but
not '.foo' or '[10]'. These paths are handled as if they contained leading '$.' characters.

See https://github.com/prestodb/presto/issues/22589

Part of https://github.com/facebookincubator/velox/issues/7049

Differential Revision: D56465662


