### PR TITLE
Fix sheduled fuzzer jobs to make removal of bias files silent.

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -246,8 +246,8 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         run: |
           # Remove irrelevant artifacts
-          rm *_bias_functions
-          rm *_signatures_main.json
+          rm -f *_bias_functions
+          rm -f *_signatures_main.json
           # Rename signature files as 'main' files
           for f in *_signatures_contender.json; do
             mv "$f" "${f/_contender.json/_main.json}"


### PR DESCRIPTION
This prevents errors like so : https://github.com/facebookincubator/velox/actions/runs/8802791272/job/24159384172 . 