### PR TITLE
Fix verification of histogram over interval queries in DuckDB

### DIFF
--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -120,8 +120,12 @@ template <>
   }
 
   if (type->isIntervalDayTime()) {
-    return ::duckdb::Value::INTERVAL(
-        0, 0, vector->as<SimpleVector<int64_t>>()->valueAt(index));
+    static constexpr int64_t kMicrosecondsInDay =
+        1000L * 1000L * 60L * 60L * 24L;
+    const auto interval = vector->as<SimpleVector<int64_t>>()->valueAt(index);
+    const int64_t microseconds = interval % kMicrosecondsInDay;
+    const int64_t days = interval / kMicrosecondsInDay;
+    return ::duckdb::Value::INTERVAL(0, days, microseconds);
   }
 
   return ::duckdb::Value(vector->as<SimpleVector<T>>()->valueAt(index));


### PR DESCRIPTION
Summary:
There's a bug in DuckDB that prevents us from verifying queries using histogram aggregates over time intervals.

The way the aggregate is written it converts the interval to a string and then tries to parse it back later.

The way we create intervals when setting up the DuckDB table, we only set microseconds and not days/months.  When 
writing out to a string DuckDB converts microseconds to hours/minutes/seconds/microseconds.  The parser seems to break 
trying to read that large number of hours.

By setting days and microseconds this seems to fix the parsing issue.

(This may be fixed in a later release of DuckDB but this is an easy fix on our side)

There's another bug that results in a memory leak in DuckDB when this fails that causes fuzzer to fail when run with ASAN.  
This works around that issue.

Differential Revision: D56487904


