### PR TITLE
Support offset-based timezone

### DIFF
--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -22,6 +22,7 @@
 #include "velox/core/CoreTypeSystem.h"
 #include "velox/expression/StringWriter.h"
 #include "velox/external/date/tz.h"
+#include "velox/functions/lib/TimeUtils.h"
 #include "velox/type/Type.h"
 #include "velox/vector/SelectivityVector.h"
 

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/expression/PrestoCastHooks.h"
 #include "velox/external/date/tz.h"
+#include "velox/functions/lib/TimeUtils.h"
 #include "velox/type/TimestampConversion.h"
 
 namespace facebook::velox::exec {
@@ -25,10 +26,7 @@ PrestoCastHooks::PrestoCastHooks(const core::QueryConfig& config)
   if (!legacyCast_) {
     options_.zeroPaddingYear = true;
     options_.dateTimeSeparator = ' ';
-    const auto sessionTzName = config.sessionTimezone();
-    if (config.adjustTimestampToTimezone() && !sessionTzName.empty()) {
-      options_.timeZone = date::locate_zone(sessionTzName);
-    }
+    options_.timeZone = functions::getTimeZoneFromConfig(config);
   }
 }
 

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -609,6 +609,26 @@ TEST_F(CastExprTest, stringToTimestamp) {
       Timestamp(946729316, 0),
   };
   testCast<std::string, Timestamp>("timestamp", input, expected);
+
+  setTimezone("GMT+8");
+  testCast<std::string, Timestamp>(
+      "timestamp",
+      {
+          "1970-01-01",
+          "1970-01-01 08:00:00",
+          "1970-01-01 00:00:00",
+          "1970-01-01 08:00:11",
+          "1970-01-01 09:00:00",
+          std::nullopt,
+      },
+      {
+          Timestamp(-28800, 0),
+          Timestamp(0, 0),
+          Timestamp(-28800, 0),
+          Timestamp(11, 0),
+          Timestamp(3600, 0),
+          std::nullopt,
+      });
 }
 
 TEST_F(CastExprTest, timestampToString) {
@@ -2397,8 +2417,8 @@ class TestingDictionaryToFewerRowsFunction : public exec::VectorFunction {
       exec::EvalCtx& context,
       VectorPtr& result) const override {
     const auto size = rows.size();
-    auto indices =
-        makeIndices(size, [](auto /*row*/) { return 0; }, context.pool());
+    auto indices = makeIndices(
+        size, [](auto /*row*/) { return 0; }, context.pool());
 
     result = BaseVector::wrapInDictionary(nullptr, indices, size, args[0]);
   }

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -3341,6 +3341,25 @@ TEST_F(DateTimeFunctionsTest, dateFormat) {
           fromTimestampString("-2000-02-29 00:00:00.987"),
           "%Y-%m-%d %H:%i:%s.%f"));
 
+  setQueryTimeZone("GMT-8");
+
+  EXPECT_EQ(
+      "1969-12-31", dateFormat(fromTimestampString("1970-01-01"), "%Y-%m-%d"));
+  EXPECT_EQ(
+      "2000-02-28 04:00:00 PM",
+      dateFormat(
+          fromTimestampString("2000-02-29 00:00:00.987"), "%Y-%m-%d %r"));
+  EXPECT_EQ(
+      "2000-02-28 16:00:00.987000",
+      dateFormat(
+          fromTimestampString("2000-02-29 00:00:00.987"),
+          "%Y-%m-%d %H:%i:%s.%f"));
+  EXPECT_EQ(
+      "-2000-02-28 16:00:00.987000",
+      dateFormat(
+          fromTimestampString("-2000-02-29 00:00:00.987"),
+          "%Y-%m-%d %H:%i:%s.%f"));
+
   // User format errors or unsupported errors.
   const auto timestamp = fromTimestampString("-2000-02-29 00:00:00.987");
   VELOX_ASSERT_THROW(


### PR DESCRIPTION
The external date lib cannot recognize timezone like "GMT+8",
but it can recognize "Etc/GMT-8". Actually they are equivalent.
So we can do a conversion to support such timezone pattern.
See a discussion in that community: https://github.com/HowardHinnant/date/issues/823.