### PR TITLE
Improve error message for invalid date format %v

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -301,9 +301,9 @@ void parseFail(
     const char* end,
     const bool failOnError) {
   if (failOnError) {
-    VELOX_DCHECK(cur <= end);
+    VELOX_DCHECK_LE(cur, end);
     VELOX_USER_FAIL(
-        "Invalid format: \"{}\" is malformed at \"{}\"",
+        "Invalid date format: '{}' is malformed at '{}'",
         input,
         std::string_view(cur, end - cur));
   }
@@ -532,58 +532,56 @@ std::string formatFractionOfSecond(
 }
 
 // According to DateTimeFormatSpecifier enum class
-std::string getSpecifierName(int enumInt) {
-  switch (enumInt) {
-    case 0:
+std::string getSpecifierName(DateTimeFormatSpecifier specifier) {
+  switch (specifier) {
+    case DateTimeFormatSpecifier::ERA:
       return "ERA";
-    case 1:
+    case DateTimeFormatSpecifier::CENTURY_OF_ERA:
       return "CENTURY_OF_ERA";
-    case 2:
+    case DateTimeFormatSpecifier::YEAR_OF_ERA:
       return "YEAR_OF_ERA";
-    case 3:
+    case DateTimeFormatSpecifier::WEEK_YEAR:
       return "WEEK_YEAR";
-    case 4:
+    case DateTimeFormatSpecifier::WEEK_OF_WEEK_YEAR:
       return "WEEK_OF_WEEK_YEAR";
-    case 5:
+    case DateTimeFormatSpecifier::DAY_OF_WEEK_0_BASED:
       return "DAY_OF_WEEK_0_BASED";
-    case 6:
+    case DateTimeFormatSpecifier::DAY_OF_WEEK_1_BASED:
       return "DAY_OF_WEEK_1_BASED";
-    case 7:
+    case DateTimeFormatSpecifier::DAY_OF_WEEK_TEXT:
       return "DAY_OF_WEEK_TEXT";
-    case 8:
+    case DateTimeFormatSpecifier::YEAR:
       return "YEAR";
-    case 9:
+    case DateTimeFormatSpecifier::DAY_OF_YEAR:
       return "DAY_OF_YEAR";
-    case 10:
+    case DateTimeFormatSpecifier::MONTH_OF_YEAR:
       return "MONTH_OF_YEAR";
-    case 11:
+    case DateTimeFormatSpecifier::MONTH_OF_YEAR_TEXT:
       return "MONTH_OF_YEAR_TEXT";
-    case 12:
+    case DateTimeFormatSpecifier::DAY_OF_MONTH:
       return "DAY_OF_MONTH";
-    case 13:
+    case DateTimeFormatSpecifier::HALFDAY_OF_DAY:
       return "HALFDAY_OF_DAY";
-    case 14:
+    case DateTimeFormatSpecifier::HOUR_OF_HALFDAY:
       return "HOUR_OF_HALFDAY";
-    case 15:
+    case DateTimeFormatSpecifier::CLOCK_HOUR_OF_HALFDAY:
       return "CLOCK_HOUR_OF_HALFDAY";
-    case 16:
+    case DateTimeFormatSpecifier::HOUR_OF_DAY:
       return "HOUR_OF_DAY";
-    case 17:
+    case DateTimeFormatSpecifier::CLOCK_HOUR_OF_DAY:
       return "CLOCK_HOUR_OF_DAY";
-    case 18:
+    case DateTimeFormatSpecifier::MINUTE_OF_HOUR:
       return "MINUTE_OF_HOUR";
-    case 19:
+    case DateTimeFormatSpecifier::SECOND_OF_MINUTE:
       return "SECOND_OF_MINUTE";
-    case 20:
+    case DateTimeFormatSpecifier::FRACTION_OF_SECOND:
       return "FRACTION_OF_SECOND";
-    case 21:
+    case DateTimeFormatSpecifier::TIMEZONE:
       return "TIMEZONE";
-    case 22:
+    case DateTimeFormatSpecifier::TIMEZONE_OFFSET_ID:
       return "TIMEZONE_OFFSET_ID";
-    case 23:
+    case DateTimeFormatSpecifier::LITERAL_PERCENT:
       return "LITERAL_PERCENT";
-    default:
-      return "[Specifier not updated to conversion function yet]";
   }
 }
 
@@ -944,8 +942,7 @@ int32_t parseFromPattern(
       default:
         VELOX_NYI(
             "Numeric Joda specifier DateTimeFormatSpecifier::" +
-            getSpecifierName(static_cast<int>(curPattern.specifier)) +
-            " not implemented yet.");
+            getSpecifierName(curPattern.specifier) + " not implemented yet.");
     }
   }
   return 0;
@@ -1017,8 +1014,8 @@ uint32_t DateTimeFormatter::maxResultSize(
       case DateTimeFormatSpecifier::WEEK_OF_WEEK_YEAR:
       default:
         VELOX_UNSUPPORTED(
-            "format is not supported for specifier {}",
-            token.pattern.specifier);
+            "Date format specifier is not supported: {}",
+            getSpecifierName(token.pattern.specifier));
     }
   }
   return size;
@@ -1489,7 +1486,8 @@ std::shared_ptr<DateTimeFormatter> buildMysqlDateTimeFormatter(
         case 'V':
         case 'w':
         case 'X':
-          VELOX_UNSUPPORTED("Specifier {} is not supported.", *tokenEnd)
+          VELOX_UNSUPPORTED(
+              "Date format specifier is not supported: %{}", *tokenEnd)
         default:
           builder.appendLiteral(tokenEnd, 1);
           break;

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -2664,7 +2664,7 @@ TEST_F(DateTimeFunctionsTest, parseDatetime) {
   VELOX_ASSERT_THROW(parseDatetime("", ""), "Invalid pattern specification");
   VELOX_ASSERT_THROW(
       parseDatetime("1234", "Y Y"),
-      "Invalid format: \"1234\" is malformed at \"\"");
+      "Invalid date format: '1234' is malformed at ''");
 
   // Simple tests. More exhaustive tests are provided as part of Joda's
   // implementation.
@@ -2740,7 +2740,7 @@ TEST_F(DateTimeFunctionsTest, parseDatetime) {
 
   VELOX_ASSERT_THROW(
       parseDatetime("2024-02-25+06:00:99 PST", "yyyy-MM-dd+HH:mm:99 ZZZ"),
-      "Invalid format: \"2024-02-25+06:00:99 PST\" is malformed at \"PST\"");
+      "Invalid date format: '2024-02-25+06:00:99 PST' is malformed at 'PST'");
 }
 
 TEST_F(DateTimeFunctionsTest, formatDateTime) {
@@ -3341,31 +3341,32 @@ TEST_F(DateTimeFunctionsTest, dateFormat) {
           fromTimestampString("-2000-02-29 00:00:00.987"),
           "%Y-%m-%d %H:%i:%s.%f"));
 
-  // User format errors or unsupported errors
-  EXPECT_THROW(
-      dateFormat(fromTimestampString("-2000-02-29 00:00:00.987"), "%D"),
-      VeloxUserError);
-  EXPECT_THROW(
-      dateFormat(fromTimestampString("-2000-02-29 00:00:00.987"), "%U"),
-      VeloxUserError);
-  EXPECT_THROW(
-      dateFormat(fromTimestampString("-2000-02-29 00:00:00.987"), "%u"),
-      VeloxUserError);
-  EXPECT_THROW(
-      dateFormat(fromTimestampString("-2000-02-29 00:00:00.987"), "%V"),
-      VeloxUserError);
-  EXPECT_THROW(
-      dateFormat(fromTimestampString("-2000-02-29 00:00:00.987"), "%w"),
-      VeloxUserError);
-  EXPECT_THROW(
-      dateFormat(fromTimestampString("-2000-02-29 00:00:00.987"), "%X"),
-      VeloxUserError);
-  EXPECT_THROW(
-      dateFormat(fromTimestampString("-2000-02-29 00:00:00.987"), "%v"),
-      VeloxUserError);
-  EXPECT_THROW(
-      dateFormat(fromTimestampString("-2000-02-29 00:00:00.987"), "%x"),
-      VeloxUserError);
+  // User format errors or unsupported errors.
+  const auto timestamp = fromTimestampString("-2000-02-29 00:00:00.987");
+  VELOX_ASSERT_THROW(
+      dateFormat(timestamp, "%D"),
+      "Date format specifier is not supported: %D");
+  VELOX_ASSERT_THROW(
+      dateFormat(timestamp, "%U"),
+      "Date format specifier is not supported: %U");
+  VELOX_ASSERT_THROW(
+      dateFormat(timestamp, "%u"),
+      "Date format specifier is not supported: %u");
+  VELOX_ASSERT_THROW(
+      dateFormat(timestamp, "%V"),
+      "Date format specifier is not supported: %V");
+  VELOX_ASSERT_THROW(
+      dateFormat(timestamp, "%w"),
+      "Date format specifier is not supported: %w");
+  VELOX_ASSERT_THROW(
+      dateFormat(timestamp, "%X"),
+      "Date format specifier is not supported: %X");
+  VELOX_ASSERT_THROW(
+      dateFormat(timestamp, "%v"),
+      "Date format specifier is not supported: WEEK_OF_WEEK_YEAR");
+  VELOX_ASSERT_THROW(
+      dateFormat(timestamp, "%x"),
+      "Date format specifier is not supported: WEEK_YEAR");
 }
 
 TEST_F(DateTimeFunctionsTest, dateFormatTimestampWithTimezone) {
@@ -3467,11 +3468,12 @@ TEST_F(DateTimeFunctionsTest, dateParse) {
       Timestamp(-66600, 0), dateParse("1969-12-31+11:00", "%Y-%m-%d+%H:%i"));
 
   VELOX_ASSERT_THROW(
-      dateParse("", "%y+"), "Invalid format: \"\" is malformed at \"\"");
+      dateParse("", "%y+"), "Invalid date format: '' is malformed at ''");
   VELOX_ASSERT_THROW(
-      dateParse("1", "%y+"), "Invalid format: \"1\" is malformed at \"1\"");
+      dateParse("1", "%y+"), "Invalid date format: '1' is malformed at '1'");
   VELOX_ASSERT_THROW(
-      dateParse("116", "%y+"), "Invalid format: \"116\" is malformed at \"6\"");
+      dateParse("116", "%y+"),
+      "Invalid date format: '116' is malformed at '6'");
 }
 
 TEST_F(DateTimeFunctionsTest, dateFunctionVarchar) {


### PR DESCRIPTION
Summary:
Before this change, date_format(... %v ...) was failing with cryptic error message:

```
VeloxUserError:  format is not supported for specifier 4
```

After this change, the error message is more clear:

```
Date format specifier is not supported: WEEK_OF_WEEK_YEAR
```

Differential Revision: D56514350


