### PR TITLE
Remove incorrect check from MapWriter::initialize

### DIFF
--- a/velox/expression/ComplexWriterTypes.h
+++ b/velox/expression/ComplexWriterTypes.h
@@ -765,7 +765,7 @@ class MapWriter {
     keysVector_ = &keysWriter_->vector();
     valuesVector_ = &valuesWriter_->vector();
 
-    innerOffset_ = std::max(keysVector_->size(), valuesVector_->size());
+    innerOffset_ = std::min(keysVector_->size(), valuesVector_->size());
 
     // Keys can never be null.
     keysVector_->resetNulls();
@@ -773,10 +773,7 @@ class MapWriter {
     keysWriter_->ensureSize(1);
     valuesWriter_->ensureSize(1);
 
-    VELOX_DCHECK(
-        keysVector_->size() == valuesVector_->size(),
-        "expect map keys and value vector sized to be synchronized");
-    capacity_ = keysVector_->size();
+    capacity_ = std::min(keysVector_->size(), valuesVector_->size());
   }
 
   key_element_t& lastKeyWriter() {


### PR DESCRIPTION
Summary:
MapWriter::initialize incorrectly assumes that the sizes of the keys and values vectors in a MapVector must be the same. 

Fixes https://github.com/facebookincubator/velox/issues/9497

Differential Revision: D56515546


