### PR TITLE
Silence 'Failed to generate SQL...Type not supported yet: VARBINARY' errors

### DIFF
--- a/velox/expression/ConstantExpr.cpp
+++ b/velox/expression/ConstantExpr.cpp
@@ -231,7 +231,9 @@ void appendSqlLiteral(
 }
 
 bool canBeExpressedInSQL(const TypePtr& type) {
-  return type->isPrimitiveType() && type != VARBINARY();
+  // Logical types cannot be expressed in SQL.
+  const bool isLogicalType = type->name() != type->kindName();
+  return type->isPrimitiveType() && type != VARBINARY() && !isLogicalType;
 }
 
 } // namespace
@@ -239,6 +241,15 @@ bool canBeExpressedInSQL(const TypePtr& type) {
 std::string ConstantExpr::toSql(
     std::vector<VectorPtr>* complexConstants) const {
   VELOX_CHECK_NOT_NULL(sharedConstantValue_);
+
+  // TODO canBeExpressedInSQL is misleading. ARRAY(INTEGER()) can be expressed
+  // in SQL, but canBeExpressedInSQL returns false for that type. we need to
+  // distinguish between types that cannot be expressed in SQL at all
+  // (VARBINARY, logic types like JSON) and types that can be expressed in
+  // SQL, but they can be large and therefore we want to provider an option to
+  // represent then using 'complex constants'. If a type cannot be expressed
+  // in SQL, we should assert that complexConstants is not null.
+
   std::ostringstream out;
   if (complexConstants && !canBeExpressedInSQL(sharedConstantValue_->type())) {
     int idx = complexConstants->size();

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1805,14 +1805,18 @@ ExprSet::~ExprSet() {
       auto exprStats = stats();
 
       std::vector<std::string> sqls;
+      std::vector<VectorPtr> complexConstants;
       for (const auto& expr : exprs()) {
         try {
-          sqls.emplace_back(expr->toSql());
+          sqls.emplace_back(expr->toSql(&complexConstants));
         } catch (const std::exception& e) {
           LOG_EVERY_N(WARNING, 100) << "Failed to generate SQL: " << e.what();
           sqls.emplace_back("<failed to generate>");
         }
       }
+
+      // TODO Enhance listener API to allow passing 'complexConstants' in
+      // addition to SQL.
 
       auto uuid = makeUuid();
       for (const auto& listener : listeners) {

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2754,6 +2754,21 @@ TEST_P(ParameterizedExprTest, constantJsonToSql) {
       << sql;
 }
 
+TEST_P(ParameterizedExprTest, lambdaToSql) {
+  auto exprSet = compileNoConstantFolding(
+      "transform(array[1, 2, 3], x -> (x + cardinality(array[10, 20, 30])))",
+      ROW({}));
+
+  std::vector<VectorPtr> complexConstants;
+  auto sql = exprSet->expr(0)->toSql(&complexConstants);
+
+  auto copy =
+      compileNoConstantFolding(sql, ROW({}), makeRowVector(complexConstants));
+  ASSERT_EQ(
+      exprSet->toString(false /*compact*/), copy->toString(false /*compact*/))
+      << sql;
+}
+
 TEST_P(ParameterizedExprTest, toSql) {
   auto rowType =
       ROW({"a", "b", "c.d", "e", "f"},

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -33,6 +33,7 @@
 #include "velox/functions/Udf.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/parse/TypeResolver.h"
@@ -56,9 +57,11 @@ class ExprTest : public testing::Test, public VectorTestBase {
 
   core::TypedExprPtr parseExpression(
       const std::string& text,
-      const RowTypePtr& rowType) {
+      const RowTypePtr& rowType,
+      const VectorPtr& complexConstants = nullptr) {
     auto untyped = parse::parseExpr(text, options_);
-    return core::Expressions::inferTypes(untyped, rowType, execCtx_->pool());
+    return core::Expressions::inferTypes(
+        untyped, rowType, execCtx_->pool(), complexConstants);
   }
 
   core::TypedExprPtr parseExpression(
@@ -93,9 +96,27 @@ class ExprTest : public testing::Test, public VectorTestBase {
   template <typename T = exec::ExprSet>
   std::unique_ptr<T> compileExpression(
       const std::string& expr,
-      const RowTypePtr& rowType) {
-    auto parsedExpression = parseExpression(expr, rowType);
+      const RowTypePtr& rowType,
+      const VectorPtr& complexConstants = nullptr) {
+    auto parsedExpression = parseExpression(expr, rowType, complexConstants);
     return compileExpression<T>(parsedExpression);
+  }
+
+  std::unique_ptr<exec::ExprSet> compileNoConstantFolding(
+      const std::string& sql,
+      const RowTypePtr& rowType,
+      const VectorPtr& complexConstants = nullptr) {
+    auto expression = parseExpression(sql, rowType, complexConstants);
+    return compileNoConstantFolding(expression);
+  }
+
+  std::unique_ptr<exec::ExprSet> compileNoConstantFolding(
+      const core::TypedExprPtr& expression) {
+    std::vector<core::TypedExprPtr> expressions = {expression};
+    return std::make_unique<exec::ExprSet>(
+        std::move(expressions),
+        execCtx_.get(),
+        false /*enableConstantFolding*/);
   }
 
   std::unique_ptr<exec::ExprSet> compileMultiple(
@@ -2713,6 +2734,24 @@ TEST_P(ParameterizedExprTest, constantToSql) {
           10,
           pool())),
       "NULL::STRUCT(a BOOLEAN, b STRUCT(c DOUBLE, d VARCHAR))");
+}
+
+TEST_P(ParameterizedExprTest, constantJsonToSql) {
+  core::TypedExprPtr expression = std::make_shared<const core::CallTypedExpr>(
+      VARCHAR(),
+      std::vector<core::TypedExprPtr>{makeConstantExpr("[1, 2, 3]", JSON())},
+      "json_format");
+
+  auto exprSet = compileNoConstantFolding(expression);
+
+  std::vector<VectorPtr> complexConstants;
+  auto sql = exprSet->expr(0)->toSql(&complexConstants);
+
+  auto copy =
+      compileNoConstantFolding(sql, ROW({}), makeRowVector(complexConstants));
+  ASSERT_EQ(
+      exprSet->toString(false /*compact*/), copy->toString(false /*compact*/))
+      << sql;
 }
 
 TEST_P(ParameterizedExprTest, toSql) {

--- a/velox/parse/Expressions.cpp
+++ b/velox/parse/Expressions.cpp
@@ -199,8 +199,15 @@ TypedExprPtr Expressions::inferTypes(
   // try rebuilding complex constant type from vector
   if (auto fun = std::dynamic_pointer_cast<const CallExpr>(expr)) {
     if (fun->getFunctionName() == "__complex_constant") {
-      VELOX_CHECK(complexConstants);
+      VELOX_CHECK_NOT_NULL(
+          complexConstants,
+          "Expression contains __complex_constant function call, but complexConstants is missing")
+
       auto ccInputRow = complexConstants->as<RowVector>();
+      VELOX_CHECK_NOT_NULL(
+          ccInputRow,
+          "Expected RowVector for complexConstants: {}",
+          complexConstants->toString());
       auto name =
           std::dynamic_pointer_cast<const FieldAccessExpr>(fun->getInputs()[0])
               ->getFieldName();

--- a/velox/parse/Expressions.cpp
+++ b/velox/parse/Expressions.cpp
@@ -185,12 +185,14 @@ TypedExprPtr Expressions::inferTypes(
   VELOX_CHECK_NOT_NULL(expr);
 
   if (auto lambdaExpr = std::dynamic_pointer_cast<const LambdaExpr>(expr)) {
-    return resolveLambdaExpr(lambdaExpr, inputRow, lambdaInputTypes, pool);
+    return resolveLambdaExpr(
+        lambdaExpr, inputRow, lambdaInputTypes, pool, complexConstants);
   }
 
   if (auto call = std::dynamic_pointer_cast<const CallExpr>(expr)) {
     if (!expr->getInputs().empty()) {
-      if (auto returnType = tryResolveCallWithLambdas(call, inputRow, pool)) {
+      if (auto returnType = tryResolveCallWithLambdas(
+              call, inputRow, pool, complexConstants)) {
         return returnType;
       }
     }
@@ -284,7 +286,8 @@ TypedExprPtr Expressions::resolveLambdaExpr(
     const std::shared_ptr<const core::LambdaExpr>& lambdaExpr,
     const TypePtr& inputRow,
     const std::vector<TypePtr>& lambdaInputTypes,
-    memory::MemoryPool* pool) {
+    memory::MemoryPool* pool,
+    const VectorPtr& complexConstants) {
   auto names = lambdaExpr->inputNames();
   auto body = lambdaExpr->body();
 
@@ -308,7 +311,7 @@ TypedExprPtr Expressions::resolveLambdaExpr(
   auto lambdaRow = ROW(std::move(names), std::move(types));
 
   return std::make_shared<LambdaTypedExpr>(
-      signature, inferTypes(body, lambdaRow, pool));
+      signature, inferTypes(body, lambdaRow, pool, complexConstants));
 }
 
 namespace {
@@ -403,7 +406,8 @@ const exec::FunctionSignature* findLambdaSignature(
 TypedExprPtr Expressions::tryResolveCallWithLambdas(
     const std::shared_ptr<const CallExpr>& callExpr,
     const TypePtr& inputRow,
-    memory::MemoryPool* pool) {
+    memory::MemoryPool* pool,
+    const VectorPtr& complexConstants) {
   auto signature = findLambdaSignature(callExpr);
 
   if (signature == nullptr) {
@@ -416,7 +420,8 @@ TypedExprPtr Expressions::tryResolveCallWithLambdas(
   std::vector<TypePtr> childTypes(numArgs);
   for (auto i = 0; i < numArgs; ++i) {
     if (!isLambdaArgument(signature->argumentTypes()[i])) {
-      children[i] = inferTypes(callExpr->getInputs()[i], inputRow, pool);
+      children[i] = inferTypes(
+          callExpr->getInputs()[i], inputRow, pool, complexConstants);
       childTypes[i] = children[i]->type();
     }
   }
@@ -436,8 +441,12 @@ TypedExprPtr Expressions::tryResolveCallWithLambdas(
         lambdaTypes.push_back(type);
       }
 
-      children[i] =
-          inferTypes(callExpr->getInputs()[i], inputRow, lambdaTypes, pool);
+      children[i] = inferTypes(
+          callExpr->getInputs()[i],
+          inputRow,
+          lambdaTypes,
+          pool,
+          complexConstants);
     }
   }
 

--- a/velox/parse/Expressions.h
+++ b/velox/parse/Expressions.h
@@ -60,12 +60,14 @@ class Expressions {
       const std::shared_ptr<const core::LambdaExpr>& lambdaExpr,
       const TypePtr& inputRow,
       const std::vector<TypePtr>& lambdaInputTypes,
-      memory::MemoryPool* pool);
+      memory::MemoryPool* pool,
+      const VectorPtr& complexConstants = nullptr);
 
   static TypedExprPtr tryResolveCallWithLambdas(
       const std::shared_ptr<const CallExpr>& expr,
       const TypePtr& input,
-      memory::MemoryPool* pool);
+      memory::MemoryPool* pool,
+      const VectorPtr& complexConstants = nullptr);
 
   static TypeResolverHook resolverHook_;
 };


### PR DESCRIPTION
Summary:
Expression Fuzzer logs are filled with "Failed to generate SQL...Type not
supported yet: VARBINARY" errors.

These come from ExprSet::~ExprSet which is trying to generate expression SQL to
pass to ExprSetListener::onCompletion. Prevent these errors by
passing 'complexConstants' vector.

https://github.com/facebookincubator/velox/actions/runs/8683096674/job/23809430272

Differential Revision: D56518625


