### PR TITLE
Bump up memory capacity for ExchangeFuzzer

### DIFF
--- a/velox/exec/tests/ExchangeFuzzer.cpp
+++ b/velox/exec/tests/ExchangeFuzzer.cpp
@@ -526,7 +526,7 @@ int main(int argc, char** argv) {
   folly::Init init{&argc, &argv};
   memory::MemoryManagerOptions options;
   options.useMmapAllocator = true;
-  options.allocatorCapacity = 8UL << 30;
+  options.allocatorCapacity = 15UL << 30;
   options.useMmapArena = true;
   options.mmapArenaCapacityRatio = 1;
   memory::MemoryManager::initialize(options);


### PR DESCRIPTION
Summary:
https://github.com/facebookincubator/velox/pull/9186 increased the amount of memory the ExchangeFuzzer uses (it
changed the Values operator to copy its Vectors if it's multi-threaded to prevent concurrency issues).

Bumping up the ExchangeFuzzer's memory capacity allows it to continue to succeed.

Differential Revision: D56527484
