### PR TITLE
Fix build failure in DateTimeFormatter.cpp

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -582,6 +582,10 @@ std::string getSpecifierName(DateTimeFormatSpecifier specifier) {
       return "TIMEZONE_OFFSET_ID";
     case DateTimeFormatSpecifier::LITERAL_PERCENT:
       return "LITERAL_PERCENT";
+    default: {
+      VELOX_UNREACHABLE("[Unexpected date format specifier]");
+      return ""; // Make compiler happy.
+    }
   }
 }
 


### PR DESCRIPTION
Summary:
Fix build failure:

```
{anonymous}::getSpecifierName(facebook::velox::functions::DateTimeFormatSpecifier)':
/__w/velox/velox/velox/functions/lib/DateTimeFormatter.cpp:586:1: error: control reaches end of non-void function [-Werror=return-type]
```

Differential Revision: D56527589
