### PR TITLE
Fix json_extract for non-definite paths (paths with wildcards)

### DIFF
--- a/velox/functions/prestosql/json/SIMDJsonExtractor.cpp
+++ b/velox/functions/prestosql/json/SIMDJsonExtractor.cpp
@@ -16,7 +16,11 @@
 
 #include "velox/functions/prestosql/json/SIMDJsonExtractor.h"
 
-namespace facebook::velox::functions::detail {
+namespace facebook::velox::functions {
+namespace {
+using JsonVector = std::vector<simdjson::ondemand::value>;
+}
+
 /* static */ SIMDJsonExtractor& SIMDJsonExtractor::getInstance(
     folly::StringPiece path) {
   // Cache tokenize operations in JsonExtractor across invocations in the same
@@ -94,4 +98,4 @@ simdjson::error_code extractArray(
   }
   return simdjson::SUCCESS;
 }
-} // namespace facebook::velox::functions::detail
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -618,6 +618,13 @@ TEST_F(JsonFunctionsTest, jsonExtract) {
   EXPECT_EQ("3", jsonExtract(json, "$[0][0][0].b.[2]"));
   EXPECT_EQ("3", jsonExtract(json, "$.[0].[0][0].b.[2]"));
 
+  // Definite vs. non-definite paths.
+  EXPECT_EQ("[123]", jsonExtract(R"({"a": [{"b": 123}]})", "$.a[*].b"));
+  EXPECT_EQ("123", jsonExtract(R"({"a": [{"b": 123}]})", "$.a[0].b"));
+
+  EXPECT_EQ("[]", jsonExtract(R"({"a": [{"b": 123}]})", "$.a[*].c"));
+  EXPECT_EQ(std::nullopt, jsonExtract(R"({"a": [{"b": 123}]})", "$.a[0].c"));
+
   // TODO The following paths are supported by Presto via Jayway, but do not
   // work in Velox yet. Figure out how to add support for these.
   VELOX_ASSERT_THROW(jsonExtract(kJson, "$..price"), "Invalid JSON path");


### PR DESCRIPTION
Summary:
In Presto, paths with wildcards are handled by Jayway engine. It always returns an array for such paths, even if only one entry matches.

Non-definite paths matching zero or one entry:

```
presto:di> select json_extract('{"a": [{"b": 123}]}', '$.a[*].b');
 _col0
-------
 [123]

presto:di> select json_extract('{"a": [{"b": 123}]}', '$.a[*].c');
 _col0
-------
 []
```

"Equivalent" define paths:

```
presto:di> select json_extract('{"a": [{"b": 123}]}', '$.a[0].b');
 _col0
-------
 123

presto:di> select json_extract('{"a": [{"b": 123}]}', '$.a[0].c');
 _col0
-------
 NULL
```

Differential Revision: D56529345
