### PR TITLE
Add support for custom types to DuckParser

### DIFF
--- a/velox/duckdb/conversion/DuckConversion.cpp
+++ b/velox/duckdb/conversion/DuckConversion.cpp
@@ -175,6 +175,13 @@ TypePtr toVeloxType(LogicalType type, bool fileColumnNamesReadAsLowerCase) {
       }
       return ROW(std::move(names), std::move(types));
     }
+    case LogicalTypeId::USER: {
+      const auto name = ::duckdb::UserType::GetTypeName(type);
+      if (auto customType = getCustomType(name)) {
+        return customType;
+      }
+      [[fallthrough]];
+    }
     default:
       throw std::runtime_error(
           "unsupported type for duckdb -> velox conversion: " +

--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -16,6 +16,7 @@
 #include "velox/duckdb/conversion/DuckParser.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/core/PlanNode.h"
+#include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/parse/Expressions.h"
 
 using namespace facebook::velox;
@@ -365,6 +366,12 @@ TEST(DuckParserTest, cast) {
   EXPECT_EQ(
       "cast(\"c0\", ROW<a:BIGINT,b:REAL,c:VARCHAR>)",
       parseExpr("cast(c0 as struct(a bigint, b real, c varchar))")->toString());
+}
+
+TEST(DuckParserTest, castToJson) {
+  registerJsonType();
+  EXPECT_EQ("cast(\"c0\", JSON)", parseExpr("cast(c0 as json)")->toString());
+  EXPECT_EQ("cast(\"c0\", JSON)", parseExpr("cast(c0 as JSON)")->toString());
 }
 
 TEST(DuckParserTest, ifCase) {


### PR DESCRIPTION
Summary: Enable parsing of expressions like "cast x as json".

Differential Revision: D56544676
