### PR TITLE
Allow invalid UTF-8 in cast(varchar as json)

### DIFF
--- a/velox/functions/prestosql/tests/JsonCastTest.cpp
+++ b/velox/functions/prestosql/tests/JsonCastTest.cpp
@@ -234,6 +234,24 @@ TEST_F(JsonCastTest, fromInteger) {
       {std::nullopt, std::nullopt, std::nullopt, std::nullopt});
 }
 
+TEST_F(JsonCastTest, fromInvalidUtf8) {
+  auto fromBytes = [&](const std::vector<unsigned char>& bytes) {
+    std::string s;
+    s.resize(bytes.size());
+    memcpy(s.data(), bytes.data(), bytes.size());
+    return s;
+  };
+
+  auto invalidString = fromBytes({0xBF});
+
+  testCastToJson<StringView>(
+      VARCHAR(), {StringView(invalidString)}, {"\"\\ufffd\""});
+
+  invalidString = fmt::format("head_{}_tail", fromBytes({0xBF}));
+  testCastToJson<StringView>(
+      VARCHAR(), {StringView(invalidString)}, {"\"head_\\ufffd_tail\""});
+}
+
 TEST_F(JsonCastTest, fromVarchar) {
   testCastToJson<StringView>(VARCHAR(), {"\U0001F64F"}, {"\"\\ud83d\\ude4f\""});
   testCastToJson<StringView>(

--- a/velox/functions/prestosql/types/JsonType.cpp
+++ b/velox/functions/prestosql/types/JsonType.cpp
@@ -54,6 +54,9 @@ void generateJsonTyped(
     // Figure out how to produce uppercase digits.
     folly::json::serialization_opts opts;
     opts.encode_non_ascii = true;
+    // Replace invalid UTF-8 bytes with U+FFFD.
+    opts.skip_invalid_utf8 = true;
+
     folly::json::escapeString(value, result, opts);
   } else if constexpr (std::is_same_v<T, UnknownValue>) {
     VELOX_FAIL(


### PR DESCRIPTION
Summary:
In Presto, cast(varchar as json) allows invalid UTF-8 characters and replaced
them with U+FFFD. We need to do the same.

Without this change, queries fails with

```
VeloxUserError:  folly::utf8ToCodePoint i=2 tmp=22 cast((array_agg) as JSON)
```

Differential Revision: D56546383
