### PR TITLE
Fix macOS build failure

### DIFF
--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -333,9 +333,8 @@ TEST(DateTimeUtilTest, fromTimestampStringInvalid) {
 
 TEST(DateTimeUtilTest, fromTimestampWithTimezoneString) {
   // -1 means no timezone information.
-  EXPECT_EQ(
-      fromTimestampWithTimezoneString("1970-01-01 00:00:00"),
-      std::make_pair(Timestamp(0, 0), -1L));
+  auto expected = std::make_pair<Timestamp, int64_t>(Timestamp(0, 0), -1);
+  EXPECT_EQ(fromTimestampWithTimezoneString("1970-01-01 00:00:00"), expected);
 
   // Test timezone offsets.
   EXPECT_EQ(


### PR DESCRIPTION
Summary:
For some reason compilation on macOS is inferring a tuple with long
instead of the long long expected and failing. Explicitly instantiating the
right tuple type to fix it.

Reviewed By: bikramSingh91

Differential Revision: D56551487
