### PR TITLE
Fix the issues that vectors fail to cast to correct types in SimpleAggregateAdapter

### DIFF
--- a/velox/exec/SimpleAggregateAdapter.h
+++ b/velox/exec/SimpleAggregateAdapter.h
@@ -288,8 +288,8 @@ class SimpleAggregateAdapter : public Aggregate {
       override {
     VectorWriter<typename FUNC::IntermediateType> writer;
     auto vector = (*result)
-                      ->as<typename TypeToFlatVector<
-                          typename FUNC::IntermediateType>::type>();
+                      ->as<typename VectorWriter<
+                          typename FUNC::IntermediateType>::vector_t>();
     vector->resize(numGroups);
     writer.init(*vector);
 
@@ -318,7 +318,7 @@ class SimpleAggregateAdapter : public Aggregate {
       override {
     auto flatResult =
         (*result)
-            ->as<typename TypeToFlatVector<typename FUNC::OutputType>::type>();
+            ->as<typename VectorWriter<typename FUNC::OutputType>::vector_t>();
     flatResult->resize(numGroups);
 
     VectorWriter<typename FUNC::OutputType> writer;
@@ -461,10 +461,8 @@ class SimpleAggregateAdapter : public Aggregate {
     auto* rawNulls = result->mutableRawNulls();
     bits::fillBits(rawNulls, 0, result->size(), bits::kNull);
 
-    constexpr auto intermediateKind =
-        SimpleTypeTrait<typename FUNC::IntermediateType>::typeKind;
-    auto* flatResult =
-        result->as<typename KindToFlatVector<intermediateKind>::type>();
+    auto* flatResult = result->as<
+        typename VectorWriter<typename FUNC::IntermediateType>::vector_t>();
     exec::VectorWriter<typename FUNC::IntermediateType> writer;
     writer.init(*flatResult);
 


### PR DESCRIPTION
Part of https://github.com/facebookincubator/velox/pull/9498

Fix the bugs when the OutputType and IntermediateType is Generic, typename TypeToFlatVector::type will be unknown. Then, the dynamic cast will be result in nullptr, which will cause segmentation fault later on.

@kgpai could you help review? Thanks!