### PR TITLE
Support unnest with outer option

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -822,12 +822,14 @@ UnnestNode::UnnestNode(
     std::vector<FieldAccessTypedExprPtr> unnestVariables,
     const std::vector<std::string>& unnestNames,
     const std::optional<std::string>& ordinalityName,
-    const PlanNodePtr& source)
+    const PlanNodePtr& source,
+    const bool outer)
     : PlanNode(id),
       replicateVariables_{std::move(replicateVariables)},
       unnestVariables_{std::move(unnestVariables)},
       withOrdinality_{ordinalityName.has_value()},
-      sources_{source} {
+      sources_{source},
+      outer_{outer} {
   // Calculate output type. First come "replicate" columns, followed by
   // "unnest" columns, followed by an optional ordinality column.
   std::vector<std::string> names;
@@ -888,6 +890,7 @@ folly::dynamic UnnestNode::serialize() const {
   if (withOrdinality_) {
     obj["ordinalityName"] = outputType()->names().back();
   }
+  obj["outer"] = outer_;
   return obj;
 }
 
@@ -909,7 +912,8 @@ PlanNodePtr UnnestNode::create(const folly::dynamic& obj, void* context) {
       std::move(unnestVariables),
       std::move(unnestNames),
       ordinalityName,
-      std::move(source));
+      std::move(source),
+      obj["outer"].asBool());
 }
 
 AbstractJoinNode::AbstractJoinNode(

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1914,13 +1914,16 @@ class UnnestNode : public PlanNode {
   /// must appear in the same order as unnestVariables.
   /// @param ordinalityName Optional name for the ordinality columns. If not
   /// present, ordinality column is not produced.
+  /// @param outer If true, produces a row for each input row even if the
+  /// unnestNames is empty. The output columns are null in this case.
   UnnestNode(
       const PlanNodeId& id,
       std::vector<FieldAccessTypedExprPtr> replicateVariables,
       std::vector<FieldAccessTypedExprPtr> unnestVariables,
       const std::vector<std::string>& unnestNames,
       const std::optional<std::string>& ordinalityName,
-      const PlanNodePtr& source);
+      const PlanNodePtr& source,
+      const bool outer = false);
 
   /// The order of columns in the output is: replicated columns (in the order
   /// specified), unnested columns (in the order specified, for maps: key comes
@@ -1945,6 +1948,10 @@ class UnnestNode : public PlanNode {
     return withOrdinality_;
   }
 
+  bool outer() const {
+    return outer_;
+  }
+
   std::string_view name() const override {
     return "Unnest";
   }
@@ -1961,6 +1968,7 @@ class UnnestNode : public PlanNode {
   const bool withOrdinality_;
   const std::vector<PlanNodePtr> sources_;
   RowTypePtr outputType_;
+  const bool outer_;
 };
 
 /// Checks that input contains at most one row. Return that row as is. If input

--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -668,6 +668,8 @@ number starting with 1.
      - Names to use for expanded columns. One name per array column. Two names per map column.
    * - ordinalityName
      - Optional name for the ordinality column.
+   * - outer
+     - when true, each input values will be output at least once, even if the unnest array/map is empty.
 
 .. _TableWriteNode:
 

--- a/velox/exec/Unnest.h
+++ b/velox/exec/Unnest.h
@@ -93,6 +93,8 @@ class Unnest : public Operator {
   // Next 'input_' row to process in getOutput().
   vector_size_t nextInputRow_{0};
 
+  // Allow the input values output at least once even the unnest cols is
+  // null/empty.
   const bool outer_;
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/Unnest.h
+++ b/velox/exec/Unnest.h
@@ -92,5 +92,7 @@ class Unnest : public Operator {
 
   // Next 'input_' row to process in getOutput().
   vector_size_t nextInputRow_{0};
+
+  const bool outer_;
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -1432,7 +1432,8 @@ PlanBuilder& PlanBuilder::nestedLoopJoin(
 PlanBuilder& PlanBuilder::unnest(
     const std::vector<std::string>& replicateColumns,
     const std::vector<std::string>& unnestColumns,
-    const std::optional<std::string>& ordinalColumn) {
+    const std::optional<std::string>& ordinalColumn,
+    bool outer) {
   VELOX_CHECK_NOT_NULL(planNode_, "Unnest cannot be the source node");
   std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>>
       replicateFields;
@@ -1468,7 +1469,8 @@ PlanBuilder& PlanBuilder::unnest(
       unnestFields,
       unnestNames,
       ordinalColumn,
-      planNode_);
+      planNode_,
+      outer);
   return *this;
 }
 

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -886,10 +886,13 @@ class PlanBuilder {
   /// @param ordinalColumn An optional name for the 'ordinal' column to produce.
   /// This column contains the index of the element of the unnested array or
   /// map. If not specified, the output will not contain this column.
+  /// @param outer If true, produces a row for each input row even if the
+  /// unnestNames' values are empty. The output columns are null in this case.
   PlanBuilder& unnest(
       const std::vector<std::string>& replicateColumns,
       const std::vector<std::string>& unnestColumns,
-      const std::optional<std::string>& ordinalColumn = std::nullopt);
+      const std::optional<std::string>& ordinalColumn = std::nullopt,
+      bool outer = false);
 
   /// Add a WindowNode to compute one or more windowFunctions.
   /// @param windowFunctions A list of one or more window function SQL like


### PR DESCRIPTION
Spark supports Generator with outer to allow the input values output at least once even the unnest array is null or empty

https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-lateral-view.html

e.g.

```sql
select 1 as a, b from lateral view outer explode(array()) as  b;

1       NULL
```

`UnnestNode` can also support this whereas gluten can support such queries