### PR TITLE
Support std::stable_sort in Orderby operator

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -201,6 +201,10 @@ class QueryConfig {
   /// OrderBy spilling flag, only applies if "spill_enabled" flag is set.
   static constexpr const char* kOrderBySpillEnabled = "order_by_spill_enabled";
 
+  /// OrderBy stable sort flag.
+  static constexpr const char* kOrderByStableSortEnabled =
+      "order_by_stable_sort_enabled";
+
   /// Window spilling flag, only applies if "spill_enabled" flag is set.
   static constexpr const char* kWindowSpillEnabled = "window_spill_enabled";
 
@@ -507,6 +511,11 @@ class QueryConfig {
   /// spillEnabled()!
   bool orderBySpillEnabled() const {
     return get<bool>(kOrderBySpillEnabled, true);
+  }
+
+  // Returns 'is orderby stable sort enabled' flag.
+  bool orderByStableSortEnabled() const {
+    return get<bool>(kOrderByStableSortEnabled, false);
   }
 
   /// Returns true if spilling is enabled for Window operator. Must also

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -66,7 +66,8 @@ OrderBy::OrderBy(
       pool(),
       &nonReclaimableSection_,
       spillConfig_.has_value() ? &(spillConfig_.value()) : nullptr,
-      &spillStats_);
+      &spillStats_,
+      driverCtx->queryConfig().orderByStableSortEnabled());
 }
 
 void OrderBy::addInput(RowVectorPtr input) {

--- a/velox/exec/SortBuffer.cpp
+++ b/velox/exec/SortBuffer.cpp
@@ -26,13 +26,15 @@ SortBuffer::SortBuffer(
     velox::memory::MemoryPool* pool,
     tsan_atomic<bool>* nonReclaimableSection,
     const common::SpillConfig* spillConfig,
-    folly::Synchronized<velox::common::SpillStats>* spillStats)
+    folly::Synchronized<velox::common::SpillStats>* spillStats,
+    bool enableStableSort)
     : input_(input),
       sortCompareFlags_(sortCompareFlags),
       pool_(pool),
       nonReclaimableSection_(nonReclaimableSection),
       spillConfig_(spillConfig),
-      spillStats_(spillStats) {
+      spillStats_(spillStats),
+      enableStableSort_(enableStableSort) {
   VELOX_CHECK_GE(input_->size(), sortCompareFlags_.size());
   VELOX_CHECK_GT(sortCompareFlags_.size(), 0);
   VELOX_CHECK_EQ(sortColumnIndices.size(), sortCompareFlags_.size());
@@ -112,19 +114,36 @@ void SortBuffer::noMoreInput() {
     sortedRows_.resize(numInputRows_);
     RowContainerIterator iter;
     data_->listRows(&iter, numInputRows_, sortedRows_.data());
-    std::sort(
-        sortedRows_.begin(),
-        sortedRows_.end(),
-        [this](const char* leftRow, const char* rightRow) {
-          for (vector_size_t index = 0; index < sortCompareFlags_.size();
-               ++index) {
-            if (auto result = data_->compare(
-                    leftRow, rightRow, index, sortCompareFlags_[index])) {
-              return result < 0;
+    if (enableStableSort_) {
+      std::stable_sort(
+          sortedRows_.begin(),
+          sortedRows_.end(),
+          [this](const char* leftRow, const char* rightRow) {
+            for (vector_size_t index = 0; index < sortCompareFlags_.size();
+                 ++index) {
+              if (auto result = data_->compare(
+                      leftRow, rightRow, index, sortCompareFlags_[index])) {
+                return result < 0;
+              }
             }
-          }
-          return false;
-        });
+            return false;
+          });
+
+    } else {
+      std::sort(
+          sortedRows_.begin(),
+          sortedRows_.end(),
+          [this](const char* leftRow, const char* rightRow) {
+            for (vector_size_t index = 0; index < sortCompareFlags_.size();
+                 ++index) {
+              if (auto result = data_->compare(
+                      leftRow, rightRow, index, sortCompareFlags_[index])) {
+                return result < 0;
+              }
+            }
+            return false;
+          });
+    }
   } else {
     // Spill the remaining in-memory state to disk if spilling has been
     // triggered on this sort buffer. This is to simplify query OOM prevention

--- a/velox/exec/SortBuffer.h
+++ b/velox/exec/SortBuffer.h
@@ -37,7 +37,8 @@ class SortBuffer {
       velox::memory::MemoryPool* pool,
       tsan_atomic<bool>* nonReclaimableSection,
       const common::SpillConfig* spillConfig = nullptr,
-      folly::Synchronized<velox::common::SpillStats>* spillStats = nullptr);
+      folly::Synchronized<velox::common::SpillStats>* spillStats = nullptr,
+      bool enableStableSort = false);
 
   void addInput(const VectorPtr& input);
 
@@ -120,6 +121,8 @@ class SortBuffer {
   std::optional<uint64_t> estimatedOutputRowSize_{};
   // The number of rows that has been returned.
   size_t numOutputRows_{0};
+
+  bool enableStableSort_ = false;
 };
 
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -1453,4 +1453,75 @@ TEST_F(OrderByTest, reclaimFromCompletedOrderBy) {
   }
 }
 
+TEST_F(OrderByTest, stableSort) {
+  // the data already sorted by department and salary desc.
+  auto data = makeRowVector(
+      {"employee_name", "department", "salary"},
+      {
+          makeFlatVector<std::string>(std::vector<std::string>{
+              "Gerard Bondur",
+              "Mary Patterson",
+              "Jeff Firrelli",
+              "William Patterson",
+              "Diane Murphy",
+              "Anthony Bow",
+              "Leslie Jennings",
+              "Leslie Thompson",
+              "Larry Bott",
+              "Pamela Castillo",
+              "Barry Jones",
+              "Loui Bondur",
+              "Gerard Hernandez",
+              "George Vanauf",
+              "Steve Patterson",
+              "Julie Firrelli",
+              "Foon Yue Tseng"}),
+          makeFlatVector<std::string>(std::vector<std::string>{
+              "Accounting",
+              "Accounting",
+              "Accounting",
+              "Accounting",
+              "Accounting",
+              "Accounting",
+              "IT",
+              "IT",
+              "Sales",
+              "Sales",
+              "Sales",
+              "Sales",
+              "SCM",
+              "SCM",
+              "SCM",
+              "SCM",
+              "SCM"}),
+          makeFlatVector<int32_t>(std::vector<int32_t>{
+              11472,
+              9998,
+              8992,
+              8870,
+              8435,
+              6627,
+              8113,
+              5186,
+              11798,
+              11303,
+              10586,
+              10449,
+              6949,
+              10563,
+              9441,
+              9181,
+              6660}),
+
+      });
+
+  createDuckDbTable({data});
+
+  auto plan =
+      PlanBuilder().values({data}).orderBy({"department"}, false).planNode();
+  auto task = AssertQueryBuilder(plan, duckDbQueryRunner_)
+                  .config(core::QueryConfig::kOrderByStableSortEnabled, true)
+                  .assertResults(data);
+}
+
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
When running Spark [unit tests](https://github.com/apache/spark/blob/master/sql/core/src/test/resources/sql-tests/inputs/window.sql#L290), we noticed that the results from Gluten are inconsistent with those from Vanilla Spark. The input data contains three fields: `employee_name`, `department`, and `salary`.

The query statement is as follows:

```
SELECT employee_name, department, salary, FIRST_VALUE(employee_name) OVER w AS highest_salary
FROM basic_pays
WINDOW w AS (
  PARTITION BY department
  ORDER BY salary DESC
  RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
)
ORDER BY department
```
This query first uses a window function to partition the data by the department field and sorts it in descending order by the salary field. The data output from the window function is already sorted by the department and salary fields. After the window operation, there is an additional ORDER BY sorting based on the department field.

In Spark, the final ORDER BY sorting is stable, which means that the salary field will also maintain a descending order in the final results. However, in Velox, because std::sort is used for sorting, the stability of the final sorting result cannot be guaranteed.

This PR  aims to add an option to the ORDER BY sorting to control whether stable sorting is enabled.