### PR TITLE
Adding backward compat format conversion

### DIFF
--- a/velox/dwio/common/Options.cpp
+++ b/velox/dwio/common/Options.cpp
@@ -36,7 +36,7 @@ FileFormat toFileFormat(std::string s) {
     return FileFormat::JSON;
   } else if (s == "parquet") {
     return FileFormat::PARQUET;
-  } else if (s == "nimble") {
+  } else if (s == "nimble" || s == "alpha") {
     return FileFormat::NIMBLE;
   } else if (s == "orc") {
     return FileFormat::ORC;


### PR DESCRIPTION
Summary:
Some tools, like validation service, still send file format "Alpha", which now fails because of recent rename.
Adding previous string for backward compat, until we clean up all callsites.

Reviewed By: zzhao0

Differential Revision: D56580198
