### PR TITLE
Implementing windows fuzzer k-range frames

### DIFF
--- a/velox/exec/fuzzer/AggregationFuzzerBase.cpp
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.cpp
@@ -803,11 +803,14 @@ std::unique_ptr<ReferenceQueryRunner> setupReferenceQueryRunner(
     LOG(INFO) << "Using DuckDB as the reference DB.";
     return duckQueryRunner;
   } else {
-    return std::make_unique<PrestoQueryRunner>(
+    auto prestoQueryRunner = std::make_unique<PrestoQueryRunner>(
         prestoUrl,
         runnerName,
         static_cast<std::chrono::milliseconds>(reqTimeoutMs));
+    prestoQueryRunner->queryRunnerContext_ =
+        std::make_shared<QueryRunnerContext>();
     LOG(INFO) << "Using Presto as the reference DB.";
+    return prestoQueryRunner;
   }
 }
 

--- a/velox/exec/fuzzer/AggregationFuzzerBase.h
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.h
@@ -189,7 +189,8 @@ class AggregationFuzzerBase {
   std::vector<std::string> generateSortingKeys(
       const std::string& prefix,
       std::vector<std::string>& names,
-      std::vector<TypePtr>& types);
+      std::vector<TypePtr>& types,
+      const bool isKRangeFrame = false);
 
   std::pair<CallableSignature, SignatureStats&> pickSignature();
 
@@ -206,7 +207,8 @@ class AggregationFuzzerBase {
       std::vector<std::string> names,
       std::vector<TypePtr> types,
       const std::vector<std::string>& partitionKeys,
-      const CallableSignature& signature);
+      const CallableSignature& signature,
+      std::string orderByKey);
 
   std::pair<std::optional<MaterializedRowMultiset>, ReferenceQueryErrorCode>
   computeReferenceResults(

--- a/velox/exec/fuzzer/ReferenceQueryRunner.h
+++ b/velox/exec/fuzzer/ReferenceQueryRunner.h
@@ -19,6 +19,11 @@
 
 namespace facebook::velox::exec::test {
 
+class QueryRunnerContext {
+ public:
+  std::unordered_map<core::PlanNodeId, std::vector<std::string>> windowFrames_;
+};
+
 /// Query runner that uses reference database, i.e. DuckDB, Presto, Spark.
 class ReferenceQueryRunner {
  public:
@@ -72,6 +77,7 @@ class ReferenceQueryRunner {
   virtual std::vector<velox::RowVectorPtr> execute(const std::string& sql) {
     VELOX_UNSUPPORTED();
   }
-};
 
+  std::shared_ptr<QueryRunnerContext> queryRunnerContext_;
+};
 } // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/WindowFuzzer.h
+++ b/velox/exec/fuzzer/WindowFuzzer.h
@@ -86,9 +86,42 @@ class WindowFuzzer : public AggregationFuzzerBase {
 
   void addWindowFunctionSignatures(const WindowFunctionMap& signatureMap);
 
+  std::tuple<
+      core::WindowNode::WindowType,
+      core::WindowNode::BoundType,
+      core::WindowNode::BoundType>
+  frameWindowTypeAndBoundType();
+
+  template <TypeKind TKind>
+  void addOffsetColumnsToInput(
+      std::vector<RowVectorPtr>& input,
+      core::WindowNode::BoundType startBoundType,
+      core::WindowNode::BoundType endBoundType,
+      SortingKeyAndOrder& orderByKey);
+
+  // Add offset column to input data for k-range frames. Returns the value of K
+  // as a string.
+  template <typename T>
+  void addKRangeFrameColumnToInput(
+      std::vector<RowVectorPtr>& input,
+      core::WindowNode::BoundType frameBoundType,
+      std::string& columnName,
+      SortingKeyAndOrder& orderByKey);
+
+  template <typename T>
+  T genOffsetAtIdx(
+      T* offsetCol,
+      vector_size_t idx,
+      T offsetValue,
+      core::WindowNode::BoundType frameBoundType,
+      WindowFuzzer::SortingKeyAndOrder& orderByKey);
+
   // Return a randomly generated frame clause string together with a boolean
   // flag indicating whether it is a ROWS frame.
-  std::tuple<std::string, bool> generateFrameClause();
+  std::string generateFrameClause(
+      core::WindowNode::WindowType windowType,
+      core::WindowNode::BoundType startBoundType,
+      core::WindowNode::BoundType endBoundType);
 
   std::string generateOrderByClause(
       const std::vector<SortingKeyAndOrder>& sortingKeysAndOrders);
@@ -101,7 +134,8 @@ class WindowFuzzer : public AggregationFuzzerBase {
   std::vector<SortingKeyAndOrder> generateSortingKeysAndOrders(
       const std::string& prefix,
       std::vector<std::string>& names,
-      std::vector<TypePtr>& types);
+      std::vector<TypePtr>& types,
+      const bool& isKRangeFrame = false);
 
   // Return 'true' if query plans failed.
   bool verifyWindow(

--- a/velox/exec/fuzzer/WindowFuzzer.h
+++ b/velox/exec/fuzzer/WindowFuzzer.h
@@ -102,7 +102,7 @@ class WindowFuzzer : public AggregationFuzzerBase {
   // Add offset column to input data for k-range frames. Returns the value of K
   // as a string.
   template <typename T>
-  void addKRangeFrameColumnToInput(
+  std::optional<std::string> addKRangeFrameColumnToInput(
       std::vector<RowVectorPtr>& input,
       core::WindowNode::BoundType frameBoundType,
       std::string& columnName,
@@ -121,7 +121,8 @@ class WindowFuzzer : public AggregationFuzzerBase {
   std::string generateFrameClause(
       core::WindowNode::WindowType windowType,
       core::WindowNode::BoundType startBoundType,
-      core::WindowNode::BoundType endBoundType);
+      core::WindowNode::BoundType endBoundType,
+      bool isPrestoQuery = false);
 
   std::string generateOrderByClause(
       const std::vector<SortingKeyAndOrder>& sortingKeysAndOrders);
@@ -146,7 +147,8 @@ class WindowFuzzer : public AggregationFuzzerBase {
       const std::vector<RowVectorPtr>& input,
       bool customVerification,
       const std::shared_ptr<ResultVerifier>& customVerifier,
-      bool enableWindowVerification);
+      bool enableWindowVerification,
+      std::optional<std::string> prestoFrameClause);
 
   void testAlternativePlans(
       const std::vector<std::string>& partitionKeys,
@@ -165,6 +167,11 @@ class WindowFuzzer : public AggregationFuzzerBase {
 
     void print(size_t numIterations) const;
   } stats_;
+
+  // Represents the value of frame bound for k-range frames to be used when
+  // running the query in Presto, when Presto is used as reference DB for
+  // verification.
+  std::vector<std::pair<std::string, std::string>> prestoFrames_;
 };
 
 /// Runs the window fuzzer.


### PR DESCRIPTION
Implementing this enhancement of WindowsFuzzer being able to generate k-range frames - https://github.com/facebookincubator/velox/issues/9572

Implementation is based off of WindowTestBase.cpp.

Ran the following command to run window fuzzer test:
```
_build/debug/velox/functions/prestosql/fuzzer/velox_window_fuzzer_test --enable_window_reference_verification --presto_url="http://127.0.0.1:8080" --req_timeout_ms=2000 --duration_sec=60 --logtostderr=1 --minloglevel=0 > window_fuzzer_test_range_frame_4.out 2>&1
```
```
I20240425 11:34:11.399708 6542153 AggregationFuzzerBase.cpp:402] Executing query plan: 
-- Window[partition by [p0, p1] order by [s0 ASC NULLS LAST] w0 := covar_pop(ROW["c0"],ROW["c1"]) RANGE between 6 PRECEDING and 7 PRECEDING] -> c0:DOUBLE, c1:DOUBLE, s0:ROW<f0:INTERVAL DAY TO SECOND>, p0:ARRAY<DOUBLE>, p1:INTERVAL DAY TO SECOND, row_number:BIGINT, w0:DOUBLE
  -- Values[1000 rows in 10 vectors] -> c0:DOUBLE, c1:DOUBLE, s0:ROW<f0:INTERVAL DAY TO SECOND>, p0:ARRAY<DOUBLE>, p1:INTERVAL DAY TO SECOND, row_number:BIGINT
```
```
I20240425 11:34:51.405833 6542153 WindowFuzzer.cpp:265] ==============================> Done with iteration 77
I20240425 11:34:51.413125 6542153 AggregationFuzzerBase.cpp:654] Total functions tested: 27
I20240425 11:34:51.413216 6542153 AggregationFuzzerBase.cpp:655] Total iterations requiring sorted inputs: 64 (82.05%)
I20240425 11:34:51.413239 6542153 AggregationFuzzerBase.cpp:657] Total iterations verified against reference DB: 12 (15.38%)
I20240425 11:34:51.413255 6542153 AggregationFuzzerBase.cpp:659] Total functions not verified (verification skipped / not supported by reference DB / reference DB failed): 31 (39.74%) / 21 (26.92%) / 0 (0.00%)
I20240425 11:34:51.413271 6542153 AggregationFuzzerBase.cpp:664] Total failed functions: 27 (34.62%)
I20240425 11:34:51.413286 6542153 WindowFuzzer.cpp:479] Total functions verified in reference DB: 10
[==========] Running 0 tests from 0 test suites.
[==========] 0 tests from 0 test suites ran. (0 ms total)
[  PASSED  ] 0 tests.
```