### PR TITLE
Optimize copying null bits in FlatVector::copyValuesAndNulls

### DIFF
--- a/velox/vector/SelectivityVector.h
+++ b/velox/vector/SelectivityVector.h
@@ -248,6 +248,14 @@ class SelectivityVector {
         nulls->asMutable<uint64_t>(), bits_.data(), begin_, end_);
   }
 
+  void setNulls(uint64_t* rawNulls) const {
+    VELOX_CHECK_NOT_NULL(rawNulls);
+    bits::andWithNegatedBits(rawNulls, bits_.data(), begin_, end_);
+  }
+
+  /// Copy null bits from 'src' to 'dest' for active rows.
+  void copyNulls(uint64_t* dest, const uint64_t* src) const;
+
   /// Merges the valid vector of another SelectivityVector by or'ing
   /// them together. This is used to support memoization where a state
   /// may acquire new values over time. Grows 'this' if size of 'other' exceeds

--- a/velox/vector/tests/SelectivityVectorTest.cpp
+++ b/velox/vector/tests/SelectivityVectorTest.cpp
@@ -18,9 +18,9 @@
 
 #include <gtest/gtest.h>
 
-namespace facebook {
-namespace velox {
-namespace test {
+#include "velox/common/base/Nulls.h"
+
+namespace facebook::velox {
 namespace {
 
 void assertState(
@@ -531,6 +531,92 @@ TEST(SelectivityVectorTest, toString) {
       "147 out of 1024 rows selected between 0 and 1023: 0, 7, 14, 21, 28, 35, 42, 49, 56, 63, 70, 77, 84, 91, 98, 105, 112, 119, 126, 133, 140, 147, 154, 161, 168, 175, 182, 189, 196, 203, 210, 217, 224, 231, 238, 245, 252, 259, 266, 273, 280, 287, 294, 301, 308, 315, 322, 329, 336, 343, 350, 357, 364, 371, 378, 385, 392, 399, 406, 413, 420, 427, 434, 441, 448, 455, 462, 469, 476, 483, 490, 497, 504, 511, 518, 525, 532, 539, 546, 553, 560, 567, 574, 581, 588, 595, 602, 609, 616, 623, 630, 637, 644, 651, 658, 665, 672, 679, 686, 693, 700, 707, 714, 721, 728, 735, 742, 749, 756, 763, 770, 777, 784, 791, 798, 805, 812, 819, 826, 833, 840, 847, 854, 861, 868, 875, 882, 889, 896, 903, 910, 917, 924, 931, 938, 945, 952, 959, 966, 973, 980, 987, 994, 1001, 1008, 1015, 1022");
 }
 
-} // namespace test
-} // namespace velox
-} // namespace facebook
+TEST(SelectivityVectorTest, copyNulls) {
+  // nnnnn.....nnnnn.....
+  std::vector<uint64_t> dest(bits::nwords(1024));
+  for (auto i = 0; i < 1024; ++i) {
+    bits::setNull(dest.data(), i, i % 10 < 5);
+  }
+
+  // ..nn..nn..nn..nn..nn
+  std::vector<uint64_t> src(bits::nwords(512));
+  for (auto i = 0; i < 512; ++i) {
+    bits::setNull(src.data(), i, i % 4 >= 2);
+  }
+
+  // Copy even rows. Skip some at the start and end.
+  {
+    SelectivityVector rows(512);
+    for (auto i = 0; i < rows.size(); ++i) {
+      rows.setValid(i, i % 2 == 0);
+    }
+    rows.setValidRange(0, 7, false);
+    rows.setValidRange(501, 512, false);
+    rows.updateBounds();
+
+    auto test = dest;
+    rows.copyNulls(test.data(), src.data());
+
+    for (auto i = 0; i < rows.size(); ++i) {
+      const auto isNull = bits::isBitNull(test.data(), i);
+      if (rows.isValid(i)) {
+        ASSERT_EQ(bits::isBitNull(src.data(), i), isNull);
+      } else {
+        ASSERT_EQ(bits::isBitNull(dest.data(), i), isNull);
+      }
+    }
+
+    for (auto i = rows.size(); i < 1024; ++i) {
+      const auto isNull = bits::isBitNull(test.data(), i);
+      ASSERT_EQ(bits::isBitNull(dest.data(), i), isNull);
+    }
+  }
+
+  // Copy odd rows.
+  {
+    SelectivityVector rows(512);
+    for (auto i = 0; i < rows.size(); ++i) {
+      rows.setValid(i, i % 2 != 0);
+    }
+    rows.setValidRange(0, 7, false);
+    rows.setValidRange(501, 512, false);
+    rows.updateBounds();
+
+    auto test = dest;
+    rows.copyNulls(test.data(), src.data());
+
+    for (auto i = 0; i < rows.size(); ++i) {
+      const auto isNull = bits::isBitNull(test.data(), i);
+      if (rows.isValid(i)) {
+        ASSERT_EQ(bits::isBitNull(src.data(), i), isNull);
+      } else {
+        ASSERT_EQ(bits::isBitNull(dest.data(), i), isNull);
+      }
+    }
+
+    for (auto i = rows.size(); i < 1024; ++i) {
+      const auto isNull = bits::isBitNull(test.data(), i);
+      ASSERT_EQ(bits::isBitNull(dest.data(), i), isNull);
+    }
+  }
+
+  // Copy all rows.
+  {
+    SelectivityVector rows(478);
+
+    auto test = dest;
+    rows.copyNulls(test.data(), src.data());
+
+    for (auto i = 0; i < rows.size(); ++i) {
+      const auto isNull = bits::isBitNull(test.data(), i);
+      EXPECT_EQ(bits::isBitNull(src.data(), i), isNull) << i;
+    }
+
+    for (auto i = rows.size(); i < 1024; ++i) {
+      const auto isNull = bits::isBitNull(test.data(), i);
+      ASSERT_EQ(bits::isBitNull(dest.data(), i), isNull);
+    }
+  }
+}
+
+} // namespace facebook::velox


### PR DESCRIPTION
Summary:
Copying of null bits in FlatVector::copyValuesAndNulls showed up at 40% of the
profile in a query that's computing a dozen or so coalesce(a, b) expressions.

Optimize by copying null bits in whole words.

After the optimization, the affected query uses 2-3x less CPU time and ~half wall time.

Differential Revision: D56571917
