### PR TITLE
Throw user error for invalid time zone in make_timestamp Spark function

### DIFF
--- a/velox/type/tz/TimeZoneMap.cpp
+++ b/velox/type/tz/TimeZoneMap.cpp
@@ -135,7 +135,7 @@ int64_t getTimeZoneID(std::string_view timeZone, bool failOnError) {
     return it->second;
   }
   if (failOnError) {
-    VELOX_FAIL("Unknown time zone: '{}'", timeZone);
+    VELOX_USER_FAIL("Unknown time zone: '{}'", timeZone);
   }
   return -1;
 }


### PR DESCRIPTION
getTimeZoneID fails with VELOX_FAIL on unknown time zone, which causes 
unexpected failure in the fuzzer test. This PR changes getTimeZoneID to
throw user error.