### PR TITLE
Prevent driver thread running again if task reclaim failed

### DIFF
--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -227,8 +227,7 @@ Spiller::Spiller(
           memory::spillMemoryPool(),
           spillStats,
           fileCreateConfig) {
-  TestValue::adjust(
-      "facebook::velox::exec::Spiller", const_cast<HashBitRange*>(&bits_));
+  TestValue::adjust("facebook::velox::exec::Spiller", this);
 
   VELOX_CHECK(!spillProbedFlag_ || type_ == Type::kHashJoinBuild);
   VELOX_CHECK_EQ(container_ == nullptr, type_ == Type::kHashJoinProbe);

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2833,9 +2833,18 @@ uint64_t Task::MemoryReclaimer::reclaimTask(
   if (shrunkBytes >= targetBytes) {
     return shrunkBytes;
   }
-  return shrunkBytes +
-      memory::MemoryReclaimer::reclaim(
-             task->pool(), targetBytes - shrunkBytes, maxWaitMs, stats);
+  uint64_t reclaimedBytes{0};
+  try {
+    reclaimedBytes = memory::MemoryReclaimer::reclaim(
+        task->pool(), targetBytes - shrunkBytes, maxWaitMs, stats);
+  } catch (...) {
+    // Set task error before resumes the task execution as the task operator
+    // might not be in consistent state anymore. This prevents any off thread
+    // from running again.
+    task->setError(std::current_exception());
+    std::rethrow_exception(std::current_exception());
+  }
+  return shrunkBytes + reclaimedBytes;
 }
 
 void Task::MemoryReclaimer::abort(


### PR DESCRIPTION
The join fuzzer test detects such race condition in task memory reclaim:
T1 : hash probe op triggers memory arbitration
T2: memory arbitration triggers memory reclaim from hash probe query
T3: memory arbitration pauses the task execution
T4: memory arbitration fails in steps after spills the pending output from the hash probe operator
T5: memory arbitration resumes the task execution
T7: another hash probe operator (driver thread) from the same query resumes execution
      and run into check failure (or some random failure depends how spill fails) when read spilled output
      which expects the hash table for probe is not empty
T8: memory arbitration aborts the query that sets the task error, wait for task to stop and abort task
      operators.

The current mechanism can guarantee that operators which under (or wait) memory arbitration won't
execute again if the query has been aborted during the memory arbitration but it has a time window
that paused task driver get a chance to run. We shall prevent this race condition by setting task error
before resume it. This is very hard to reproduce in unit test so we rely on fuzzer signal. Add a dedicated
unit test to cover the task memory reclaim failure is handle properly on the execution path.

Join fuzzer has kept running for ~10 hours with oom injection and no failure