### PR TITLE
Fix crash when map subfield is pruned but we still want to add non-null filter on its keys

### DIFF
--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -323,9 +323,10 @@ namespace {
 
 void filterOutNullMapKeys(const Type& rootType, common::ScanSpec& rootSpec) {
   rootSpec.visit(rootType, [](const Type& type, common::ScanSpec& spec) {
-    if (type.isMap()) {
-      spec.childByName(common::ScanSpec::kMapKeysFieldName)
-          ->addFilter(common::IsNotNull());
+    if (type.isMap() && !spec.isConstant()) {
+      auto* keys = spec.childByName(common::ScanSpec::kMapKeysFieldName);
+      VELOX_CHECK_NOT_NULL(keys);
+      keys->addFilter(common::IsNotNull());
     }
   });
 }

--- a/velox/dwio/common/ScanSpec.h
+++ b/velox/dwio/common/ScanSpec.h
@@ -410,6 +410,10 @@ class ScanSpec {
 template <typename F>
 void ScanSpec::visit(const Type& type, F&& f) {
   f(type, *this);
+  if (isConstant()) {
+    // Child specs are not populated in this case.
+    return;
+  }
   switch (type.kind()) {
     case TypeKind::ROW:
       for (auto& child : children_) {


### PR DESCRIPTION
Differential Revision: D56642855
