### PR TITLE
Mask compilation warning from gtest in clang16

### DIFF
--- a/CMake/resolve_dependency_modules/gtest.cmake
+++ b/CMake/resolve_dependency_modules/gtest.cmake
@@ -29,3 +29,6 @@ FetchContent_Declare(
   URL_HASH ${VELOX_GTEST_BUILD_SHA256_CHECKSUM})
 
 FetchContent_MakeAvailable(gtest)
+
+# Mask compilation warning in clang 16.
+target_compile_options(gtest PRIVATE -Wno-implicit-int-float-conversion)


### PR DESCRIPTION
Clang 16 prints this annoying warning every time it has to compile our bundled gtest:

```
In file included from /home/pedroerp/Github/nimble/_build/release/_deps/gtest-src/googletest/include/gtest/gtest-matchers.h:48:
/home/pedroerp/Github/nimble/_build/release/_deps/gtest-src/googletest/include/gtest/gtest-printers.h:532:9: warning: implicit conversion from 'int32_t' (aka 'int') to 'float' may lose precision [-Wimplicit-int-float-conversion]
    if (static_cast<int32_t>(val * mulfor6 + 0.5) / mulfor6 == val) return 6;
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~
/home/pedroerp/Github/nimble/_build/release/_deps/gtest-src/googletest/include/gtest/gtest-printers.h:551:17: note: in instantiation of function template specialization 'testing::internal::AppropriateResolution<float>' requested here
  os->precision(AppropriateResolution(f));
                ^
/home/pedroerp/Github/nimble/_build/release/_deps/gtest-src/googletest/include/gtest/gtest-printers.h:544:9: warning: implicit conversion from 'int32_t' (aka 'int') to 'float' may lose precision [-Wimplicit-int-float-conversion]
    if (static_cast<int32_t>(val / divfor6 + 0.5) * divfor6 == val) return 6;
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~
2 warnings generated.
```