### PR TITLE
Fix bug in DwrfReader onRead

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -648,7 +648,8 @@ uint64_t DwrfRowReader::next(
   // reading of the data.
   auto strideSize = getReader().getFooter().rowIndexStride();
   strideIndex_ = strideSize > 0 ? currentRowInStripe_ / strideSize : 0;
-  unitLoader_->onRead(currentStripe_, currentRowInStripe_, rowsToRead);
+  const auto loadUnitIdx = currentStripe_ - firstStripe_;
+  unitLoader_->onRead(loadUnitIdx, currentRowInStripe_, rowsToRead);
   readNext(rowsToRead, mutation, result);
   currentRowInStripe_ += rowsToRead;
   return rowsToRead;


### PR DESCRIPTION
Summary: We weren't translating to loadUnitIdx.

Reviewed By: Sullivan-Patrick

Differential Revision: D56658575
