### PR TITLE
Disable allocator stats collection by default

### DIFF
--- a/velox/common/memory/MemoryAllocator.cpp
+++ b/velox/common/memory/MemoryAllocator.cpp
@@ -364,15 +364,18 @@ std::string Stats::toString() const {
   std::stringstream out;
   int64_t totalClocks = 0;
   int64_t totalBytes = 0;
+  int64_t totalAllocations = 0;
   for (auto i = 0; i < sizes.size(); ++i) {
     totalClocks += sizes[i].clocks();
     totalBytes += sizes[i].totalBytes;
+    totalAllocations += sizes[i].numAllocations;
   }
   out << fmt::format(
-      "Alloc: {}MB {} Gigaclocks, {}MB advised\n",
+      "Alloc: {}MB {} Gigaclocks {} Allocations, {}MB advised\n",
       totalBytes >> 20,
       totalClocks >> 30,
-      numAdvise >> 8);
+      numAdvise >> 8,
+      totalAllocations);
 
   // Sort the size classes by decreasing clocks.
   std::vector<int32_t> indices(sizes.size());
@@ -386,10 +389,11 @@ std::string Stats::toString() const {
       break;
     }
     out << fmt::format(
-        "Size {}K: {}MB {} Megaclocks\n",
+        "Size {}K: {}MB {} Megaclocks {} Allocations\n",
         sizes[i].size * 4,
         sizes[i].totalBytes >> 20,
-        sizes[i].clocks() >> 20);
+        sizes[i].clocks() >> 20,
+        sizes[i].numAllocations);
   }
   return out.str();
 }

--- a/velox/flag_definitions/flags.cpp
+++ b/velox/flag_definitions/flags.cpp
@@ -30,7 +30,7 @@ DEFINE_int32(
 
 DEFINE_bool(
     velox_time_allocations,
-    true,
+    false,
     "Record time and volume for large allocation/free");
 
 // Used in common/base/VeloxException.cpp


### PR DESCRIPTION
Summary:
Allocator stats collection was designed to be a debugging tool and
can be expensive as allocation happens on the hotpath and stats
collection can add a non-trivial amount to it. Therefore we are
disabling it by default.

Additionally this change improves the toString() API for the struct
that accounts for these stats but adding the number of allocations
to it.

Differential Revision: D56658835
