### PR TITLE
Mark 'arbitrary' Presto aggregate function order sensitive

### DIFF
--- a/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
@@ -326,7 +326,6 @@ void registerArbitraryAggregate(
                 inputType->kindName());
         }
       },
-      {false /*orderSensitive*/},
       withCompanionFunctions,
       overwrite);
 }

--- a/velox/functions/prestosql/aggregates/tests/AggregationFunctionRegTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AggregationFunctionRegTest.cpp
@@ -64,7 +64,6 @@ TEST_F(AggregationFunctionRegTest, orderSensitive) {
       "min",
       "max",
       "count",
-      "arbitrary",
       "bool_and",
       "bool_or",
       "bitwise_and_agg",
@@ -74,8 +73,7 @@ TEST_F(AggregationFunctionRegTest, orderSensitive) {
       "count_if",
       "geometric_mean",
       "histogram",
-      "reduce_agg",
-      "any_value"};
+      "reduce_agg"};
   aggregate::prestosql::registerAllAggregateFunctions();
   exec::aggregateFunctions().withRLock([&](const auto& aggrFuncMap) {
     for (const auto& entry : aggrFuncMap) {
@@ -88,7 +86,7 @@ TEST_F(AggregationFunctionRegTest, orderSensitive) {
 
   // Test some but not all order sensitive functions
   std::set<std::string> orderSensitiveFunctions = {
-      "array_agg", "map_agg", "map_union", "set_agg"};
+      "array_agg", "arbitrary", "any_value", "map_agg", "map_union", "set_agg"};
   exec::aggregateFunctions().withRLock([&](const auto& aggrFuncMap) {
     for (const auto& entry : aggrFuncMap) {
       if (entry.second.metadata.orderSensitive) {


### PR DESCRIPTION
As discussed in https://github.com/facebookincubator/velox/issues/9274#issuecomment-2044702864, mark arbitrary aggregate as order sensitive, as a prerequisite for https://github.com/facebookincubator/velox/pull/9482