### PR TITLE
Parallelize local memory arbitration

### DIFF
--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -117,11 +117,18 @@ void registerVeloxMetrics() {
       kMetricArbitratorGlobalArbitrationCount,
       facebook::velox::StatType::COUNT);
 
-  // The distribution of the amount of time an arbitration request stays queued
-  // in range of [0, 600s] with 20 buckets. It is configured to report the
-  // latency at P50, P90, P99, and P100 percentiles.
+  // The number of global arbitration that reclaims used memory by slow disk
+  // spilling.
+  DEFINE_METRIC(
+      kMetricArbitratorSlowGlobalArbitrationCount,
+      facebook::velox::StatType::COUNT);
+
+  // The distribution of the amount of time an arbitration operation stays in
+  // arbitration queues and waits the arbitration r/w locks in range of [0,
+  // 600s] with 20 buckets. It is configured to report the latency at P50, P90,
+  // P99, and P100 percentiles.
   DEFINE_HISTOGRAM_METRIC(
-      kMetricArbitratorQueueTimeMs, 30'000, 0, 600'000, 50, 90, 99, 100);
+      kMetricArbitratorWaitTimeMs, 30'000, 0, 600'000, 50, 90, 99, 100);
 
   // The distribution of the amount of time it take to complete a single
   // arbitration request stays queued in range of [0, 600s] with 20

--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -76,11 +76,20 @@ constexpr folly::StringPiece kMetricArbitratorLocalArbitrationCount{
 constexpr folly::StringPiece kMetricArbitratorGlobalArbitrationCount{
     "velox.arbitrator_global_arbitration_count"};
 
-constexpr folly::StringPiece kMetricArbitratorQueueTimeMs{
-    "velox.arbitrator_queue_time_ms"};
+constexpr folly::StringPiece kMetricArbitratorSlowGlobalArbitrationCount{
+    "velox.arbitrator_slow_global_arbitration_count"};
+
+constexpr folly::StringPiece kMetricArbitratorAbortedCount{
+    "velox.arbitrator_aborted_count"};
+
+constexpr folly::StringPiece kMetricArbitratorFailuresCount{
+    "velox.arbitrator_failures_count"};
 
 constexpr folly::StringPiece kMetricArbitratorArbitrationTimeMs{
     "velox.arbitrator_arbitration_time_ms"};
+
+constexpr folly::StringPiece kMetricArbitratorWaitTimeMs{
+    "velox.arbitrator_wait_time_ms"};
 
 constexpr folly::StringPiece kMetricArbitratorFreeCapacityBytes{
     "velox.arbitrator_free_capacity_bytes"};
@@ -122,10 +131,4 @@ constexpr folly::StringPiece kMetricFileWriterEarlyFlushedRawBytes{
 
 constexpr folly::StringPiece kMetricArbitratorRequestsCount{
     "velox.arbitrator_requests_count"};
-
-constexpr folly::StringPiece kMetricArbitratorAbortedCount{
-    "velox.arbitrator_aborted_count"};
-
-constexpr folly::StringPiece kMetricArbitratorFailuresCount{
-    "velox.arbitrator_failures_count"};
 } // namespace facebook::velox

--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -65,6 +65,7 @@ std::unique_ptr<MemoryArbitrator> createArbitrator(
        .memoryPoolReservedCapacity = options.memoryPoolReservedCapacity,
        .memoryPoolTransferCapacity = options.memoryPoolTransferCapacity,
        .memoryReclaimWaitMs = options.memoryReclaimWaitMs,
+       .globalArbitrationEnabled = options.globalArbitrationEnabled,
        .arbitrationStateCheckCb = options.arbitrationStateCheckCb,
        .checkUsageLeak = options.checkUsageLeak});
 }

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -177,6 +177,10 @@ struct MemoryManagerOptions {
   /// zero, then there is no timeout. The default is 5 mins.
   uint64_t memoryReclaimWaitMs{300'000};
 
+  /// If true, it allows memory arbitrator to reclaim used memory cross query
+  /// memory pools.
+  bool globalArbitrationEnabled{false};
+
   /// Provided by the query system to validate the state after a memory pool
   /// enters arbitration if not null. For instance, Prestissimo provides
   /// callback to check if a memory arbitration request is issued from a driver

--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -330,12 +330,11 @@ MemoryArbitrator::Stats::Stats(
 
 std::string MemoryArbitrator::Stats::toString() const {
   return fmt::format(
-      "STATS[numRequests {} numSucceeded {} numAborted {} numFailures {} "
+      "STATS[numRequests {} numAborted {} numFailures {} "
       "numNonReclaimableAttempts {} numReserves {} numReleases {} "
       "queueTime {} arbitrationTime {} reclaimTime {} shrunkMemory {} "
       "reclaimedMemory {} maxCapacity {} freeCapacity {} freeReservedCapacity {}]",
       numRequests,
-      numSucceeded,
       numAborted,
       numFailures,
       numNonReclaimableAttempts,

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -75,6 +75,10 @@ class MemoryArbitrator {
     /// timeout.
     uint64_t memoryReclaimWaitMs{0};
 
+    /// If true, it allows memory arbitrator to reclaim used memory cross query
+    /// memory pools.
+    bool globalArbitrationEnabled{false};
+
     /// Provided by the query system to validate the state after a memory pool
     /// enters arbitration if not null. For instance, Prestissimo provides
     /// callback to check if a memory arbitration request is issued from a
@@ -253,6 +257,7 @@ class MemoryArbitrator {
         memoryPoolReservedCapacity_(config.memoryPoolReservedCapacity),
         memoryPoolTransferCapacity_(config.memoryPoolTransferCapacity),
         memoryReclaimWaitMs_(config.memoryReclaimWaitMs),
+        globalArbitrationEnabled_(config.globalArbitrationEnabled),
         arbitrationStateCheckCb_(config.arbitrationStateCheckCb),
         checkUsageLeak_(config.checkUsageLeak) {
     VELOX_CHECK_LE(reservedCapacity_, capacity_);
@@ -263,6 +268,7 @@ class MemoryArbitrator {
   const uint64_t memoryPoolReservedCapacity_;
   const uint64_t memoryPoolTransferCapacity_;
   const uint64_t memoryReclaimWaitMs_;
+  const bool globalArbitrationEnabled_;
   const MemoryArbitrationStateCheckCB arbitrationStateCheckCb_;
   const bool checkUsageLeak_;
 };

--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -832,8 +832,8 @@ bool MemoryPoolImpl::maybeIncrementReservation(uint64_t size) {
 
     // NOTE: we allow memory pool to overuse its memory during the memory
     // arbitration process. The memory arbitration process itself needs to
-    // ensure the the memory pool usage of the memory pool is within the
-    // capacity limit after the arbitration operation completes.
+    // ensure the memory pool usage of the memory pool is within the capacity
+    // limit after the arbitration operation completes.
     if (FOLLY_UNLIKELY(
             (reservationBytes_ + size > capacity_) &&
             !underMemoryArbitration())) {
@@ -954,7 +954,11 @@ uint64_t MemoryPoolImpl::freeBytes() const {
   if (capacity_ == kMaxMemory) {
     return 0;
   }
-  VELOX_CHECK_GE(capacity_, reservationBytes_);
+  if (capacity_ < reservationBytes_) {
+    // NOTE: the memory reservation could be temporarily larger than its
+    // capacity if this memory pool is under memory arbitration processing.
+    return 0;
+  }
   return capacity_ - reservationBytes_;
 }
 

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -18,6 +18,8 @@
 
 #include "velox/common/memory/MemoryArbitrator.h"
 
+#include "velox/common/base/Counters.h"
+#include "velox/common/base/StatsReporter.h"
 #include "velox/common/future/VeloxPromise.h"
 #include "velox/common/memory/Memory.h"
 
@@ -85,92 +87,186 @@ class SharedArbitrator : public memory::MemoryArbitrator {
       "globalArbitrationCount"};
   static inline const std::string kLocalArbitrationCount{
       "localArbitrationCount"};
+  static inline const std::string kLocalArbitrationQueueWallNanos{
+      "localArbitrationQueueWallNanos"};
+  static inline const std::string kLocalArbitrationLockWaitWallNanos{
+      "localArbitrationLockWaitWallNanos"};
+  static inline const std::string kGlobalArbitrationLockWaitWallNanos{
+      "globalArbitrationLockWaitWallNanos"};
 
  private:
   // The kind string of shared arbitrator.
   inline static const std::string kind_{"SHARED"};
 
+  // Contains the execution state of an arbitration operation.
+  struct ArbitrationOperation {
+    MemoryPool* const requestPool;
+    MemoryPool* const requestRoot;
+    const std::vector<std::shared_ptr<MemoryPool>>& candidatePools;
+    const uint64_t targetBytes;
+    // The start time of this arbitration operation.
+    const std::chrono::steady_clock::time_point startTime;
+
+    // The stats of candidate memory pools used for memory arbitration.
+    std::vector<Candidate> candidates;
+
+    // The time that waits in local arbitration queue.
+    uint64_t localArbitrationQueueTimeUs{0};
+
+    // The time that waits to acquire the local arbitration lock.
+    uint64_t localArbitrationLockWaitTimeUs{0};
+
+    // The time that waits to acquire the global arbitration lock.
+    uint64_t globalArbitrationLockWaitTimeUs{0};
+
+    ArbitrationOperation(
+        uint64_t targetBytes,
+        const std::vector<std::shared_ptr<MemoryPool>>& candidatePools)
+        : ArbitrationOperation(nullptr, targetBytes, candidatePools) {}
+
+    ArbitrationOperation(
+        MemoryPool* _requestor,
+        uint64_t _targetBytes,
+        const std::vector<std::shared_ptr<MemoryPool>>& _candidatePools)
+        : requestPool(_requestor),
+          requestRoot(_requestor == nullptr ? nullptr : _requestor->root()),
+          candidatePools(_candidatePools),
+          targetBytes(_targetBytes),
+          startTime(std::chrono::steady_clock::now()) {}
+
+    uint64_t waitTimeUs() const {
+      return localArbitrationQueueTimeUs + localArbitrationLockWaitTimeUs +
+          globalArbitrationLockWaitTimeUs;
+    }
+
+    void enterArbitration();
+    void leaveArbitration();
+  };
+
+  // Used to start and finish an arbitration operation initiated from a memory
+  // pool or memory capacity shrink request sent through shrinkPools() API.
   class ScopedArbitration {
    public:
-    // Used by arbitration request NOT initiated from memory pool, e.g. through
-    // shrinkPools() API.
-    explicit ScopedArbitration(SharedArbitrator* arbitrator);
-
-    // Used by arbitration request initiated from a memory pool.
-    explicit ScopedArbitration(
-        MemoryPool* requestor,
-        SharedArbitrator* arbitrator);
+    ScopedArbitration(SharedArbitrator* arbitrator, ArbitrationOperation* op);
 
     ~ScopedArbitration();
 
    private:
-    MemoryPool* const requestor_;
+    ArbitrationOperation* const operation_;
     SharedArbitrator* const arbitrator_;
-    const std::chrono::steady_clock::time_point startTime_;
     const ScopedMemoryArbitrationContext arbitrationCtx_;
+    const std::chrono::steady_clock::time_point startTime_;
+  };
+
+  // The arbitration running queue for arbitration requests from the same query
+  // pool.
+  struct ArbitrationQueue {
+    // Points to the current running arbitration.
+    ArbitrationOperation* current;
+
+    // The promises of the arbitration requests from the same query pool waiting
+    // for the serial execution.
+    std::vector<ContinuePromise> waitPromises;
+
+    explicit ArbitrationQueue(ArbitrationOperation* op) : current(op) {
+      VELOX_CHECK_NOT_NULL(current);
+    }
   };
 
   // Invoked to check if the memory growth will exceed the memory pool's max
   // capacity limit or the arbitrator's node capacity limit.
-  bool checkCapacityGrowth(const MemoryPool& pool, uint64_t targetBytes) const;
+  bool checkCapacityGrowth(ArbitrationOperation* op) const;
 
-  // Invoked to ensure the memory growth request won't exceed the requestor's
-  // max capacity as well as the arbitrator's node capacity. If it does, then we
-  // first need to reclaim the used memory from the requestor itself to ensure
-  // the memory growth won't exceed the capacity limit, and then proceed with
-  // the memory arbitration process. The reclaimed memory capacity returns to
-  // the arbitrator, and let the memory arbitration process to grow the
-  // requestor capacity accordingly.
-  bool ensureCapacity(MemoryPool* requestor, uint64_t targetBytes);
+  // Invoked to ensure the memory growth request won't exceed the request memory
+  // pool's max capacity as well as the arbitrator's node capacity. If it does,
+  // then we first need to reclaim the used memory from the request memory pool
+  // itself to ensure the memory growth won't exceed the capacity limit, and
+  // then proceed with the memory arbitration process across queries.
+  bool ensureCapacity(ArbitrationOperation* op);
 
-  bool arbitrateMemory(
-      MemoryPool* requestor,
-      std::vector<Candidate>& candidates,
-      uint64_t targetBytes);
+  // Invoked to reclaim the memory from the other query memory pools to grow the
+  // request memory pool's capacity.
+  bool arbitrateMemory(ArbitrationOperation* op);
 
-  // Invoked to start next memory arbitration request, and it will wait for the
-  // serialized execution if there is a running or other waiting arbitration
-  // requests.
-  void startArbitration(const std::string& contextMsg);
+  // Invoked to start next memory arbitration request, and it will wait for
+  // the serialized execution if there is a running or other waiting
+  // arbitration requests.
+  void startArbitration(ArbitrationOperation* op);
 
   // Invoked by a finished memory arbitration request to kick off the next
   // arbitration request execution if there are any ones waiting.
-  void finishArbitration();
+  void finishArbitration(ArbitrationOperation* op);
 
-  // Invoked to get the memory stats of the candidate memory pools for
-  // arbitration. If 'freeCapacityOnly' is true, then we only get free capacity
-  // stats for each candidate memory pool.
-  std::vector<SharedArbitrator::Candidate> getCandidateStats(
-      const std::vector<std::shared_ptr<MemoryPool>>& pools,
+  // Invoked to run local arbitration on the request memory pool. It first
+  // ensures the memory growth is within both memory pool and arbitrator
+  // capacity limits. This step might reclaim the used memory from the request
+  // memory pool itself. Then it tries to allocate free capacity from the
+  // arbitrator. At last, it tries to reclaim free memory from the other queries
+  // before it falls back to the global arbitration. The local arbitration run
+  // is protected by shared lock of 'arbitrationLock_' which can run in parallel
+  // for different query pools. The free memory reclamation is protected by
+  // arbitrator 'mutex_' which is an in-memory fast operation. The function
+  // returns false on failure. Otherwise, it needs to further check if
+  // 'needGlobalArbitration' is true or not. If true, needs to proceed with the
+  // global arbitration run.
+  bool runLocalArbitration(
+      ArbitrationOperation* op,
+      bool& needGlobalArbitration);
+
+  // Invoked to run global arbitration to reclaim free or used memory from the
+  // other queries. The global arbitration run is protected by the exclusive
+  // lock of 'arbitrationLock_' for serial execution. The function returns true
+  // on success, false on failure.
+  bool runGlobalArbitration(ArbitrationOperation* op);
+
+  // Gets the mim/max memory capacity growth targets for 'op'.
+  void getGrowTargets(
+      ArbitrationOperation* op,
+      uint64_t& maxGrowTarget,
+      uint64_t& minGrowTarget);
+
+  // Invoked to get or refresh the memory stats of the candidate memory pools
+  // for arbitration. If 'freeCapacityOnly' is true, then we only get free
+  // capacity stats for each candidate memory pool.
+  void getCandidateStats(
+      ArbitrationOperation* op,
       bool freeCapacityOnly = false);
 
-  // Invoked to reclaim free memory capacity from 'candidates' without actually
-  // freeing used memory.
+  // Invoked to reclaim free memory capacity from 'candidates' without
+  // actually freeing used memory.
   //
   // NOTE: the function might sort 'candidates' based on each candidate's free
   // capacity internally.
   uint64_t reclaimFreeMemoryFromCandidates(
-      std::vector<Candidate>& candidates,
-      uint64_t targetBytes);
+      ArbitrationOperation* op,
+      uint64_t reclaimTargetBytes,
+      bool isLocalArbitration);
 
   // Invoked to reclaim used memory capacity from 'candidates' by spilling.
   //
   // NOTE: the function might sort 'candidates' based on each candidate's
   // reclaimable memory internally.
   uint64_t reclaimUsedMemoryFromCandidatesBySpill(
-      MemoryPool* requestor,
-      std::vector<Candidate>& candidates,
-      uint64_t targetBytes);
+      ArbitrationOperation* op,
+      uint64_t reclaimTargetBytes);
 
   // Invoked to reclaim used memory capacity from 'candidates' by aborting the
   // top memory users' queries.
   uint64_t reclaimUsedMemoryFromCandidatesByAbort(
-      std::vector<Candidate>& candidates,
-      uint64_t targetBytes);
+      ArbitrationOperation* op,
+      uint64_t reclaimTargetBytes);
+
+  // Checks if request pool has been aborted or not.
+  void checkIfAborted(ArbitrationOperation* op);
+
+  // Checks if the request pool already has enough free capacity for the growth.
+  // This could happen if there are multiple arbitration operations from the
+  // same query. When the first served operation succeeds, it might have
+  // reserved enough capacity for the followup operations.
+  bool maybeGrowFromSelf(ArbitrationOperation* op);
 
   // Invoked to grow 'pool' capacity by 'growBytes' and commit used reservation
-  // by 'reservationBytes'. The function throws if the grow fails from memory
-  // pool.
+  // by 'reservationBytes'. The function throws if the growth fails.
   void
   checkedGrow(MemoryPool* pool, uint64_t growBytes, uint64_t reservationBytes);
 
@@ -188,20 +284,18 @@ class SharedArbitrator : public memory::MemoryArbitrator {
 
   // Invoked to handle the memory arbitration failure to abort the memory pool
   // with the largest capacity to free up memory. The function returns true on
-  // success and false if the requestor itself has been selected as the victim.
-  // We don't abort the requestor itself but just fails the arbitration to let
-  // the user decide to either proceed with the query or fail it.
-  bool handleOOM(
-      MemoryPool* requestor,
-      uint64_t targetBytes,
-      std::vector<Candidate>& candidates);
+  // success and false if the requestor itself has been selected as the
+  // victim. We don't abort the requestor itself but just fails the
+  // arbitration to let the user decide to either proceed with the query or
+  // fail it.
+  bool handleOOM(ArbitrationOperation* op);
 
   // Decrements free capacity from the arbitrator with up to
   // 'maxBytesToReserve'. The arbitrator might have less free available
-  // capacity. The function returns the actual decremented free capacity bytes.
-  // If 'minBytesToReserve' is not zero and there is less than 'minBytes'
-  // available in non-reserved capacity, then the arbitrator tries to decrement
-  // up to 'minBytes' from the reserved capacity.
+  // capacity. The function returns the actual decremented free capacity
+  // bytes. If 'minBytesToReserve' is not zero and there is less than
+  // 'minBytes' available in non-reserved capacity, then the arbitrator tries
+  // to decrement up to 'minBytes' from the reserved capacity.
   uint64_t decrementFreeCapacity(
       uint64_t maxBytesToReserve,
       uint64_t minBytesToReserve);
@@ -216,12 +310,12 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   // reserved capacity limit. 'bytes' is updated accordingly.
   void incrementFreeReservedCapacityLocked(uint64_t& bytes);
 
+  void incrementGlobalArbitrationCount();
+  void incrementLocalArbitrationCount();
+
   std::string toStringLocked() const;
 
   Stats statsLocked() const;
-
-  void incrementGlobalArbitrationCount();
-  void incrementLocalArbitrationCount();
 
   // Returns the max reclaimable capacity from 'pool' which includes both used
   // and free capacities.
@@ -231,32 +325,46 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   // shrink.
   int64_t reclaimableFreeCapacity(const MemoryPool& pool) const;
 
-  // Returns the used memory capacity that can be reclaimed from 'pool' by disk
-  // spill.
+  // Returns the used memory capacity that can be reclaimed from 'pool' by
+  // disk spill.
   int64_t reclaimableUsedCapacity(const MemoryPool& pool) const;
 
   // Returns the minimal amount of memory capacity to grow for 'pool' to have
   // the reserved capacity as specified by 'memoryPoolReservedCapacity_'.
   int64_t minGrowCapacity(const MemoryPool& pool) const;
 
+  // Returns true if 'pool' is under memory arbitration.
+  bool isUnderArbitration(MemoryPool* pool) const;
+  bool isUnderArbitrationLocked(MemoryPool* pool) const;
+
+  void updateArbitrationRequestStats();
+  void updateArbitrationFailureStats();
+
+  // Lock used to protect the arbitrator state.
   mutable std::mutex mutex_;
   tsan_atomic<uint64_t> freeReservedCapacity_{0};
   tsan_atomic<uint64_t> freeNonReservedCapacity_{0};
-  // Indicates if there is a running arbitration request or not.
-  bool running_{false};
 
-  // The promises of the arbitration requests waiting for the serialized
-  // execution.
-  std::vector<ContinuePromise> waitPromises_;
+  // Contains the arbitration running queues with one per each query memory
+  // pool.
+  std::unordered_map<MemoryPool*, std::unique_ptr<ArbitrationQueue>>
+      arbitrationQueues_;
 
-  tsan_atomic<uint64_t> numRequests_{0};
-  std::atomic<uint64_t> numSucceeded_{0};
+  // R/W lock used to control local and global arbitration runs. A local
+  // arbitration run needs to hold a shared lock while the latter needs to hold
+  // an exclusive lock. Hence, multiple local arbitration runs from different
+  // query memory pools can run in parallel but the global ones has to run with
+  // one at a time.
+  mutable std::shared_mutex arbitrationLock_;
+
+  std::atomic_uint64_t numRequests_{0};
+  std::atomic_uint32_t numPending_{0};
   tsan_atomic<uint64_t> numAborted_{0};
-  tsan_atomic<uint64_t> numFailures_{0};
-  tsan_atomic<uint64_t> queueTimeUs_{0};
+  std::atomic_uint64_t numFailures_{0};
+  std::atomic_uint64_t waitTimeUs_{0};
   tsan_atomic<uint64_t> arbitrationTimeUs_{0};
-  tsan_atomic<uint64_t> numShrunkBytes_{0};
-  tsan_atomic<uint64_t> numReclaimedBytes_{0};
+  tsan_atomic<uint64_t> reclaimedFreeBytes_{0};
+  tsan_atomic<uint64_t> reclaimedUsedBytes_{0};
   tsan_atomic<uint64_t> reclaimTimeUs_{0};
   tsan_atomic<uint64_t> numNonReclaimableAttempts_{0};
   tsan_atomic<uint64_t> numReserves_{0};

--- a/velox/common/memory/tests/MemoryArbitratorTest.cpp
+++ b/velox/common/memory/tests/MemoryArbitratorTest.cpp
@@ -62,14 +62,14 @@ TEST_F(MemoryArbitrationTest, stats) {
   stats.numNonReclaimableAttempts = 5;
   ASSERT_EQ(
       stats.toString(),
-      "STATS[numRequests 2 numSucceeded 0 numAborted 3 numFailures 100 "
+      "STATS[numRequests 2 numAborted 3 numFailures 100 "
       "numNonReclaimableAttempts 5 numReserves 0 numReleases 0 "
       "queueTime 230.00ms arbitrationTime 1.02ms reclaimTime 1.00ms "
       "shrunkMemory 95.37MB reclaimedMemory 9.77KB "
       "maxCapacity 0B freeCapacity 1.95KB freeReservedCapacity 1000B]");
   ASSERT_EQ(
       fmt::format("{}", stats),
-      "STATS[numRequests 2 numSucceeded 0 numAborted 3 numFailures 100 "
+      "STATS[numRequests 2 numAborted 3 numFailures 100 "
       "numNonReclaimableAttempts 5 numReserves 0 numReleases 0 "
       "queueTime 230.00ms arbitrationTime 1.02ms reclaimTime 1.00ms "
       "shrunkMemory 95.37MB reclaimedMemory 9.77KB "

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -106,8 +106,8 @@ TEST_F(MemoryManagerTest, ctor) {
         "pools 1\nList of root pools:\n\t__sys_root__\n"
         "Memory Allocator[MALLOC capacity 4.00GB allocated bytes 0 "
         "allocated pages 0 mapped pages 0]\n"
-        "ARBITRATOR[SHARED CAPACITY[4.00GB] RUNNING[false] QUEUING[0] "
-        "STATS[numRequests 0 numSucceeded 0 numAborted 0 numFailures 0 "
+        "ARBITRATOR[SHARED CAPACITY[4.00GB] PENDING[0] "
+        "STATS[numRequests 0 numAborted 0 numFailures 0 "
         "numNonReclaimableAttempts 0 numReserves 0 numReleases 0 queueTime 0us "
         "arbitrationTime 0us reclaimTime 0us shrunkMemory 0B "
         "reclaimedMemory 0B maxCapacity 4.00GB freeCapacity 4.00GB freeReservedCapacity 0B]]]");

--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -129,6 +129,9 @@ Memory Management
        initiate the memory arbitration request. This indicates the velox runtime doesn't have
        enough memory to run all the queries at their peak memory usage. We have to trigger
        spilling to let them run through completion.
+   * - arbitrator_slow_global_arbitration_count
+     - Count
+     - The number of global arbitration that reclaims used memory by slow disk spilling.
    * - arbitrator_aborted_count
      - Count
      - The number of times a query level memory pool is aborted as a result of
@@ -143,9 +146,10 @@ Memory Management
        the requested amount of memory.
    * - arbitrator_queue_time_ms
      - Histogram
-     - The distribution of the amount of time an arbitration request stays queued
-       in range of [0, 600s] with 20 buckets. It is configured to report the
-       latency at P50, P90, P99, and P100 percentiles.
+     - The distribution of the amount of time an arbitration request stays in
+       arbitration queues and waits the arbitration r/w locks in range of [0, 600s]
+       with 20 buckets. It is configured to report the latency at P50, P90, P99,
+       and P100 percentiles.
    * - arbitrator_arbitration_time_ms
      - Histogram
      - The distribution of the amount of time it take to complete a single

--- a/velox/docs/monitoring/stats.rst
+++ b/velox/docs/monitoring/stats.rst
@@ -52,6 +52,15 @@ These stats are reported by all operators.
      - The number of times a request for more memory hit the query memory
        limit and initiated a local arbitration attempt where memory is
        reclaimed from the requestor itself.
+   * - localArbitrationQueueWallNanos
+     -
+     - The time of an operator waiting in local arbitration queue.
+   * - localArbitrationLockWaitWallNanos
+     -
+     - The time of an operator waiting to acquire the local arbitration lock.
+   * - globalArbitrationLockWaitWallNanos
+     -
+     - The time of an operator waiting to acquire the global arbitration lock.
 
 HashBuild, HashAggregation
 --------------------------

--- a/velox/exec/tests/utils/ArbitratorTestUtil.cpp
+++ b/velox/exec/tests/utils/ArbitratorTestUtil.cpp
@@ -58,6 +58,7 @@ std::unique_ptr<memory::MemoryManager> createMemoryManager(
   options.memoryPoolTransferCapacity = memoryPoolTransferCapacity;
   options.memoryPoolReservedCapacity = 0;
   options.memoryReclaimWaitMs = maxReclaimWaitMs;
+  options.globalArbitrationEnabled = true;
   options.checkUsageLeak = true;
   options.arbitrationStateCheckCb = memoryArbitrationStateCheck;
   return std::make_unique<memory::MemoryManager>(options);

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -94,6 +94,7 @@ void OperatorTestBase::setupMemory(
   options.memoryPoolReservedCapacity = memoryPoolReservedCapacity;
   options.arbitratorKind = "SHARED";
   options.checkUsageLeak = true;
+  options.globalArbitrationEnabled = true;
   options.arbitrationStateCheckCb = memoryArbitrationStateCheck;
   memory::MemoryManager::testingSetInstance(options);
   asyncDataCache_ =


### PR DESCRIPTION
Parallelize the local memory arbitration execution. The workload flow of memory arbitration process
changes as follows:
First wait in the arbitration queue to serialize the memory arbitration request processing from the same
query pool. Adds ArbitrationQueue data structure for this which contains the wait promises of the
arbitration requests from the same query pool. The arbitration queue is protected by arbitrator lock.

Second calls runLocalArbitration to run local arbitration which acquires the reader lock of arbitration
lock (which is added by this pr for local/global arbitration execution control). Then it ensures the request
memory pool is within the capacity limit (this might trigger spill to reclaim the used memory from the
request pool itself), and tries to allocate free capacity from the arbitrator or reclaim the free memory from
the other queries which is protected by arbitrator lock.

Third if runLocalArbitration can't reclaim sufficient memory, then proceeds with runGlobalArbitration which
acquires the writer lock of arbitration lock. Then it reclaims the free capacity from the arbitrator or the other
queries. And at last reclaims the used memory from the other queries by spilling.

ArbitrationOperation is added to contains the state of arbitration request processing to simplify the code
implementation.

This PR also adds an option to disable global arbitration and only do local arbitration which can always
run in parallel. With this option, for 2hrs stress test (1000 query concurrency at coordinator) with Meta
internal production workloads replay, the averaged query execution time has been reduced by ~30% and cpu
time is kept the same. The memory arbitration wall time for query without triggering spilled is only 9 mins in
total. 
