### PR TITLE
Wave hash Table and Group By Update Variations

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Make Release Build
         env:
           MAKEFLAGS: 'NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4'
-          CUDA_ARCHITECTURES: 60
+          CUDA_ARCHITECTURES: 70
           CUDA_COMPILER: /usr/local/cuda-${CUDA_VERSION}/bin/nvcc
           # Without that, nvcc picks /usr/bin/c++ which is GCC 8
           CUDA_FLAGS: "-ccbin /opt/rh/gcc-toolset-9/root/usr/bin"

--- a/velox/experimental/wave/common/Block.cuh
+++ b/velox/experimental/wave/common/Block.cuh
@@ -16,39 +16,52 @@
 
 #pragma once
 
+#include <cub/block/block_radix_sort.cuh>
 #include <cub/block/block_reduce.cuh>
 #include <cub/block/block_scan.cuh>
+#include <cub/block/block_store.cuh>
+#include "velox/experimental/wave/common/CudaUtil.cuh"
 
 /// Utilities for  booleans and indices and thread blocks.
 
 namespace facebook::velox::wave {
 
 template <
+    typename T,
     int32_t blockSize,
+    cub::BlockScanAlgorithm Algorithm = cub::BLOCK_SCAN_RAKING>
+inline int32_t __device__ __host__ boolToIndicesSharedSize() {
+  typedef cub::BlockScan<T, blockSize, Algorithm> BlockScanT;
+
+  return sizeof(typename BlockScanT::TempStorage);
+}
+
+/// Converts an array of flags to an array of indices of set flags. The first
+/// index is given by 'start'. The number of indices is returned in 'size', i.e.
+/// this is 1 + the index of the last set flag.
+template <
+    int32_t blockSize,
+    typename T,
     cub::BlockScanAlgorithm Algorithm = cub::BLOCK_SCAN_RAKING,
     typename Getter>
-__device__ inline void boolBlockToIndices(
-    Getter getter,
-    int32_t start,
-    int32_t* indices,
-    void* shmem,
-    int32_t& size) {
-  typedef cub::BlockScan<int, blockSize, Algorithm> BlockScanT;
+__device__ inline void
+boolBlockToIndices(Getter getter, T start, T* indices, void* shmem, T& size) {
+  typedef cub::BlockScan<T, blockSize, Algorithm> BlockScanT;
 
   auto* temp = reinterpret_cast<typename BlockScanT::TempStorage*>(shmem);
-  int data[1];
+  T data[1];
   uint8_t flag = getter();
   data[0] = flag;
   __syncthreads();
-  int aggregate;
+  T aggregate;
   BlockScanT(*temp).ExclusiveSum(data, data, aggregate);
-  __syncthreads();
   if (flag) {
     indices[data[0]] = threadIdx.x + start;
   }
   if (threadIdx.x == 0) {
     size = aggregate;
   }
+  __syncthreads();
 }
 
 template <int32_t blockSize, typename T, typename Getter>
@@ -63,6 +76,166 @@ __device__ inline void blockSum(Getter getter, void* shmem, T* result) {
   if (threadIdx.x == 0) {
     result[blockIdx.x] = aggregate;
   }
+}
+
+template <
+    int32_t kBlockSize,
+    int32_t kItemsPerThread,
+    typename Key,
+    typename Value>
+using RadixSort =
+    typename cub::BlockRadixSort<Key, kBlockSize, kItemsPerThread, Value>;
+
+template <
+    int32_t kBlockSize,
+    int32_t kItemsPerThread,
+    typename Key,
+    typename Value>
+inline int32_t __host__ __device__ blockSortSharedSize() {
+  return sizeof(
+      typename RadixSort<kBlockSize, kItemsPerThread, Key, Value>::TempStorage);
+}
+
+template <
+    int32_t kBlockSize,
+    int32_t kItemsPerThread,
+    typename Key,
+    typename Value,
+    typename KeyGetter,
+    typename ValueGetter>
+void __device__ blockSort(
+    KeyGetter keyGetter,
+    ValueGetter valueGetter,
+    Key* keyOut,
+    Value* valueOut,
+    char* smem) {
+  using Sort = cub::BlockRadixSort<Key, kBlockSize, kItemsPerThread, Value>;
+
+  // Per-thread tile items
+  Key keys[kItemsPerThread];
+  Value values[kItemsPerThread];
+
+  // Our current block's offset
+  int blockOffset = 0;
+
+  // Load items into a blocked arrangement
+  for (auto i = 0; i < kItemsPerThread; ++i) {
+    int32_t idx = blockOffset + i * kBlockSize + threadIdx.x;
+    values[i] = valueGetter(idx);
+    keys[i] = keyGetter(idx);
+  }
+
+  __syncthreads();
+  auto* temp_storage = reinterpret_cast<typename Sort::TempStorage*>(smem);
+
+  Sort(*temp_storage).SortBlockedToStriped(keys, values);
+
+  // Store output in striped fashion
+  cub::StoreDirectStriped<kBlockSize>(
+      threadIdx.x, valueOut + blockOffset, values);
+  cub::StoreDirectStriped<kBlockSize>(threadIdx.x, keyOut + blockOffset, keys);
+  __syncthreads();
+}
+
+template <int kBlockSize>
+int32_t partitionRowsSharedSize(int32_t numPartitions) {
+  using Scan = cub::BlockScan<int, kBlockSize>;
+  auto scanSize = sizeof(typename Scan::TempStorage) + sizeof(int32_t);
+  int32_t counterSize = sizeof(int32_t) * numPartitions;
+  if (counterSize <= scanSize) {
+    return scanSize;
+  }
+  static_assert(
+      sizeof(typename Scan::TempStorage) >= sizeof(int32_t) * kBlockSize);
+  return scanSize + counterSize; // - kBlockSize * sizeof(int32_t);
+}
+
+/// Partitions a sequence of indices into runs where the indices
+/// belonging to the same partition are contiguous. Indices from 0 to
+/// 'numKeys-1' are partitioned into 'partitionedRows', which must
+/// have space for 'numKeys' row numbers. The 0-based partition number
+/// for row 'i' is given by 'getter(i)'.  The row numbers for
+/// partition 0 start at 0. The row numbers for partition i start at
+/// 'partitionStarts[i-1]'. There must be at least the amount of
+/// shared memory given by partitionSharedSize(numPartitions).
+/// 'ranks' is a temporary array of 'numKeys' elements.
+template <int32_t kBlockSize, typename RowNumber, typename Getter>
+void __device__ partitionRows(
+    Getter getter,
+    uint32_t numKeys,
+    uint32_t numPartitions,
+    RowNumber* ranks,
+    RowNumber* partitionStarts,
+    RowNumber* partitionedRows) {
+  using Scan = cub::BlockScan<int32_t, kBlockSize>;
+  constexpr int32_t kWarpThreads = 1 << CUB_LOG_WARP_THREADS(0);
+  auto warp = threadIdx.x / kWarpThreads;
+  auto lane = cub::LaneId();
+  extern __shared__ __align__(16) char smem[];
+  auto* counters = reinterpret_cast<uint32_t*>(
+      numPartitions <= kBlockSize ? smem
+                                  : smem +
+              sizeof(typename Scan::
+                         TempStorage) /*- kBlockSize * sizeof(uint32_t)*/);
+  for (auto i = threadIdx.x; i < numPartitions; i += kBlockSize) {
+    counters[i] = 0;
+  }
+  __syncthreads();
+  for (auto start = 0; start < numKeys; start += kBlockSize) {
+    int32_t warpStart = start + warp * kWarpThreads;
+    if (start >= numKeys) {
+      break;
+    }
+    uint32_t laneMask = warpStart + kWarpThreads <= numKeys
+        ? 0xffffffff
+        : lowMask<uint32_t>(numKeys - warpStart);
+    if (warpStart + lane < numKeys) {
+      int32_t key = getter(warpStart + lane);
+      uint32_t mask = __match_any_sync(laneMask, key);
+      int32_t leader = (kWarpThreads - 1) - __clz(mask);
+      uint32_t cnt = __popc(mask & lowMask<uint32_t>(lane + 1));
+      uint32_t base;
+      if (lane == leader) {
+        base = atomicAdd(&counters[key], cnt);
+      }
+      base = __shfl_sync(laneMask, base, leader);
+      ranks[warpStart + lane] = base + cnt - 1;
+    }
+  }
+  // Prefix sum the counts. All counters must have their final value.
+  __syncthreads();
+  auto* temp = reinterpret_cast<typename Scan::TempStorage*>(smem);
+  int32_t* aggregate = reinterpret_cast<int32_t*>(smem);
+  for (auto start = 0; start < numPartitions; start += kBlockSize) {
+    int32_t localCount[1];
+    localCount[0] =
+        threadIdx.x + start < numPartitions ? counters[start + threadIdx.x] : 0;
+    if (threadIdx.x == 0 && start > 0) {
+      // The sum of the previous round is carried over as start of this.
+      localCount[0] += *aggregate;
+    }
+    Scan(*temp).InclusiveSum(localCount, localCount);
+    if (start + threadIdx.x < numPartitions) {
+      partitionStarts[start + threadIdx.x] = localCount[0];
+    }
+    if (threadIdx.x == kBlockSize - 1 && start + kBlockSize < numPartitions) {
+      *aggregate = localCount[0];
+    }
+    __syncthreads();
+  }
+  if (threadIdx.x == 0) {
+    if (partitionStarts[numPartitions - 1] != numKeys) {
+      *(long*)0 = 0;
+    }
+  }
+  // Write the row numbers of the inputs into the rankth position in each
+  // partition.
+  for (auto i = threadIdx.x; i < numKeys; i += kBlockSize) {
+    auto key = getter(i);
+    auto keyStart = key == 0 ? 0 : partitionStarts[key - 1];
+    partitionedRows[keyStart + ranks[i]] = i;
+  }
+  __syncthreads();
 }
 
 } // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/Cuda.h
+++ b/velox/experimental/wave/common/Cuda.h
@@ -18,6 +18,8 @@
 
 #include <functional>
 #include <memory>
+#include <string>
+#include <unordered_map>
 /// Contains wrappers for common Cuda objects. Wave does not directly
 /// include Cuda headers because of interference with BitUtils.h and
 /// SimdUtils.h.
@@ -182,5 +184,24 @@ GpuAllocator::UniquePtr<T[]> GpuAllocator::allocate(size_t n) {
   T* ptr = static_cast<T*>(allocate(bytes));
   return UniquePtr<T[]>(ptr, Deleter(this, bytes));
 }
+
+/// Info on kernel occupancy limits.
+struct KernelInfo {
+  int32_t numRegs{0};
+  int32_t maxThreadsPerBlock;
+  int32_t sharedMemory{0};
+  int32_t maxOccupancy0{0};
+  int32_t maxOccupancy16{0};
+
+  std::string toString() const;
+};
+
+KernelInfo getRegisteredKernelInfo(const char* name);
+
+KernelInfo kernelInfo(const void* func);
+
+std::unordered_map<std::string, KernelInfo>& kernelRegistry();
+/// Prints summary of registered kernels.
+void printKernels();
 
 } // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/FreeSet.cuh
+++ b/velox/experimental/wave/common/FreeSet.cuh
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace facebook::velox::wave {
+
+template <typename T, int32_t kSize>
+class FreeSet {
+ public:
+  static constexpr uint32_t kEmpty = ~0;
+  static constexpr int32_t kBitSizeMask = (kSize / 64) - 1;
+  static constexpr int32_t kSizeMask = kSize - 1;
+
+  void __device__ clear() {
+    for (auto i = threadIdx.x; i < kSize; i += blockDim.x) {
+      if (i < sizeof(bits_) / sizeof(bits_[0])) {
+        bits_[i] = 0;
+      }
+      items_[i] = kEmpty;
+    }
+  }
+
+  // Adds an item. Returns true if succeededs.
+  bool __device__ put(T item) {
+    if (full_) {
+      return false;
+    }
+    auto tid = threadIdx.x + blockDim.x * blockIdx.x;
+    auto bitIdx = tid & kBitSizeMask;
+    for (auto count = 0; count <= kBitSizeMask; ++count) {
+      auto word = ~bits_[bitIdx];
+      while (word) {
+        auto bit = __ffsll(word);
+        --bit;
+        if (kEmpty == atomicCAS(&items_[bitIdx * 64 + bit], kEmpty, item)) {
+          atomicOr(&bits_[bitIdx], 1UL << bit);
+          if (empty_) {
+            atomicExch(&empty_, 0);
+          }
+          return true;
+        }
+        word &= word - 1;
+      }
+      bitIdx = bitIdx + 1 & kBitSizeMask;
+    }
+    atomicExch(&full_, 1);
+    return false;
+  }
+
+  T __device__ get() {
+    if (empty_) {
+      return kEmpty;
+    }
+
+    auto tid = threadIdx.x + blockDim.x * blockIdx.x;
+    auto bitIdx = tid & kBitSizeMask;
+    for (auto count = 0; count <= kBitSizeMask; ++count) {
+      auto word = bits_[bitIdx];
+      while (word) {
+        auto bit = __ffsll(word);
+        --bit;
+        T item = atomicExch(&items_[bitIdx * 64 + bit], kEmpty);
+        if (item != kEmpty) {
+          atomicAnd(&bits_[bitIdx], ~(1UL << bit));
+          if (full_) {
+            atomicExch(&full_, 0);
+          }
+          return item;
+        }
+        word &= word - 1;
+      }
+      bitIdx = bitIdx + 1 & kBitSizeMask;
+    }
+    atomicExch(&empty_, true);
+    return kEmpty;
+  }
+
+  int32_t full_{0};
+  int32_t empty_{1};
+  unsigned long long bits_[kBitSizeMask + 1];
+  T items_[kSize];
+};
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/GpuArena.h
+++ b/velox/experimental/wave/common/GpuArena.h
@@ -124,7 +124,7 @@ class GpuArena {
   WaveBufferPtr allocateBytes(uint64_t bytes);
 
   template <typename T>
-  WaveBufferPtr allocate(int32_t items) {
+  WaveBufferPtr allocate(uint64_t items) {
     static_assert(std::is_trivially_destructible_v<T>);
     return allocateBytes(sizeof(T) * items);
   }

--- a/velox/experimental/wave/common/Hash.h
+++ b/velox/experimental/wave/common/Hash.h
@@ -93,6 +93,17 @@ __device__ __host__ inline uint32_t twang32From64(uint64_t key) {
   return static_cast<uint32_t>(key);
 }
 
+__device__ inline uint64_t hashMix(const uint64_t upper, const uint64_t lower) {
+  // Murmur-inspired hashing.
+  const uint64_t kMul = 0x9ddfea08eb382d69ULL;
+  uint64_t a = (lower ^ upper) * kMul;
+  a ^= (a >> 47);
+  uint64_t b = (upper ^ a) * kMul;
+  b ^= (b >> 47);
+  b *= kMul;
+  return b;
+}
+
 template <typename T>
 struct IntHasher32 {
   __device__ __host__ uint32_t operator()(T val) const {

--- a/velox/experimental/wave/common/HashTable.cuh
+++ b/velox/experimental/wave/common/HashTable.cuh
@@ -1,0 +1,368 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuda/atomic>
+#include <cuda/semaphore>
+
+#include <cub/thread/thread_load.cuh>
+#include <cub/util_ptx.cuh>
+
+#include "velox/experimental/wave/common/CudaUtil.cuh"
+#include "velox/experimental/wave/common/FreeSet.cuh"
+#include "velox/experimental/wave/common/Hash.h"
+#include "velox/experimental/wave/common/HashTable.h"
+
+namespace facebook::velox::wave {
+
+#define GPF() *(long*)0 = 0
+
+template <typename T, typename U>
+inline __device__ cuda::atomic<T, cuda::thread_scope_device>* asDeviceAtomic(
+    U* ptr) {
+  return reinterpret_cast<cuda::atomic<T, cuda::thread_scope_device>*>(ptr);
+}
+
+template <typename T>
+inline bool __device__ atomicTryLock(T* lock) {
+  return 0 ==
+      asDeviceAtomic<int32_t>(lock)->exchange(1, cuda::memory_order_consume);
+}
+
+template <typename T>
+inline void __device__ atomicUnlock(T* lock) {
+  asDeviceAtomic<int32_t>(lock)->store(0, cuda::memory_order_release);
+}
+
+/// Allocator subclass that defines device member functions.
+struct RowAllocator : public HashPartitionAllocator {
+  template <typename T>
+  T* __device__ allocateRow() {
+    auto fromFree = getFromFree();
+    if (fromFree != kEmpty) {
+      ++numFromFree;
+      return reinterpret_cast<T*>(base + fromFree);
+    }
+    auto offset = atomicAdd(&rowOffset, rowSize);
+
+    if (offset + rowSize < cub::ThreadLoad<cub::LOAD_CG>(&stringOffset)) {
+      if (!inRange(base + offset)) {
+        GPF();
+      }
+      return reinterpret_cast<T*>(base + offset);
+    }
+    return nullptr;
+  }
+
+  uint32_t __device__ getFromFree() {
+    uint32_t item = reinterpret_cast<FreeSet<uint32_t, 1024>*>(freeSet)->get();
+    if (item != kEmpty) {
+      ++numFromFree;
+    }
+    return item;
+  }
+
+  void __device__ freeRow(void* row) {
+    if (!inRange(row)) {
+      GPF();
+    }
+    uint32_t offset = reinterpret_cast<uint64_t>(row) - base;
+    numFull += reinterpret_cast<FreeSet<uint32_t, 1024>*>(freeSet)->put(
+                   offset) == false;
+  }
+
+  template <typename T>
+  T* __device__ allocate(int32_t cnt) {
+    uint32_t size = sizeof(T) * cnt;
+    auto offset = atomicSub(&stringOffset, size);
+    if (offset - size > cub::ThreadLoad<cub::LOAD_CG>(&rowOffset)) {
+      if (!inRange(base + offset - size)) {
+        GPF();
+      }
+      return reinterpret_cast<T*>(base + offset - size);
+    }
+    return nullptr;
+  }
+
+  template <typename T>
+  bool __device__ inRange(T ptr) {
+    return reinterpret_cast<uint64_t>(ptr) >= base &&
+        reinterpret_cast<uint64_t>(ptr) < base + capacity;
+  }
+};
+
+inline uint8_t __device__ hashTag(uint64_t h) {
+  return 0x80 | (h >> 32);
+}
+
+struct GpuBucket : public GpuBucketMembers {
+  template <typename RowType>
+  inline RowType* __device__ load(int32_t idx) const {
+    uint64_t uptr = reinterpret_cast<const uint32_t*>(&data)[idx];
+    if (uptr == 0) {
+      return nullptr;
+    }
+    uptr |= static_cast<uint64_t>(data[idx + 8]) << 32;
+    return reinterpret_cast<RowType*>(uptr);
+  }
+
+  template <typename RowType>
+  inline RowType* __device__ loadConsume(int32_t idx) {
+    uint64_t uptr =
+        asDeviceAtomic<uint32_t>(&data)[idx].load(cuda::memory_order_consume);
+    if (uptr == 0) {
+      return nullptr;
+    }
+    uptr |= static_cast<uint64_t>(data[idx + 8]) << 32;
+    return reinterpret_cast<RowType*>(uptr);
+  }
+
+  template <typename RowType>
+  inline RowType* __device__ loadWithWait(int32_t idx) {
+    RowType* hit;
+    do {
+      // It could be somebody inserted the tag but did not fill in the
+      // pointer. The pointer is coming in a few clocks.
+      hit = loadConsume<RowType>(idx);
+    } while (!hit);
+    return hit;
+  }
+
+  inline void __device__ store(int32_t idx, void* ptr) {
+    auto uptr = reinterpret_cast<uint64_t>(ptr);
+    data[8 + idx] = uptr >> 32;
+    // The high part must be seen if the low part is seen.
+    asDeviceAtomic<uint32_t>(&data)[idx].store(
+        uptr, cuda::memory_order_release);
+  }
+
+  bool __device__ addNewTag(uint8_t tag, uint32_t oldTags, uint8_t tagShift) {
+    uint32_t newTags = oldTags | ((static_cast<uint32_t>(tag) << tagShift));
+    return (oldTags == atomicCAS(&tags, oldTags, newTags));
+  }
+};
+
+/// Shared memory state for an updating probe.
+struct ProbeShared {
+  int32_t* inputRetries;
+  int32_t* outputRetries;
+  uint32_t numKernelRetries;
+  uint32_t numHostRetries;
+  int32_t blockBase;
+  int32_t blockEnd;
+  int32_t numRounds;
+  int32_t toDo;
+  int32_t done;
+  int32_t numUpdated;
+  int32_t numTried;
+
+  /// Initializes a probe. Sets outputRetries and clears inputRetries and other
+  /// state.
+  void __device__ init(HashProbe* probe, int32_t base) {
+    inputRetries = nullptr;
+    outputRetries = probe->kernelRetries1;
+    numKernelRetries = 0;
+    numHostRetries = 0;
+    blockBase = base;
+    toDo = 0;
+    done = 0;
+    numRounds = 0;
+  }
+
+  // Resets retrry count and swaps input and output retries.
+  void __device__ nextRound(HashProbe* probe) {
+    numKernelRetries = 0;
+    if (!inputRetries) {
+      // This is after the initial round where there are no input retries.
+      inputRetries = outputRetries;
+      outputRetries = probe->kernelRetries2;
+    } else {
+      // swap input and output retries.
+      auto temp = outputRetries;
+      outputRetries = inputRetries;
+      inputRetries = temp;
+    }
+  }
+};
+
+class GpuHashTable : public GpuHashTableBase {
+ public:
+  static constexpr int32_t kExclusive = 1;
+
+  static int32_t updatingProbeSharedSize() {
+    return sizeof(ProbeShared);
+  }
+
+  template <typename RowType, typename Ops>
+  void __device__ readOnlyProbe(HashProbe* probe, Ops ops) {
+    int32_t blockBase = ops.blockBase(probe);
+    int32_t end = ops.numRowsInBlock(probe) + blockBase;
+    for (auto i = blockBase + threadIdx.x; i < end; i += blockDim.x) {
+      auto h = ops.hash(i, probe);
+      uint32_t tagWord = hashTag(h);
+      tagWord |= tagWord << 8;
+      tagWord = tagWord | tagWord << 16;
+      auto bucketIdx = h & sizeMask;
+      for (;;) {
+        GpuBucket* bucket = buckets + bucketIdx;
+        auto tags = bucket->tags;
+        auto hits = __vcmpeq4(tags, tagWord) & 0x01010101;
+        while (hits) {
+          auto hitIdx = (__ffs(hits) - 1) / 8;
+          auto* hit = bucket->load<RowType>(hitIdx);
+          if (ops.compare(this, hit, i, probe)) {
+            ops.hit(i, probe, hit);
+            goto done;
+          }
+          hits = hits & (hits - 1);
+        }
+        if (__vcmpeq4(tags, 0)) {
+          ops.miss(i, probe);
+          break;
+        }
+        bucketIdx = (bucketIdx + 1) & sizeMask;
+      }
+    done:;
+    }
+  }
+
+  template <typename RowType, typename Ops>
+  void __device__ updatingProbe(HashProbe* probe, Ops ops) {
+    extern __shared__ __align__(16) char smem[];
+    auto* sharedState = reinterpret_cast<ProbeShared*>(smem);
+    if (threadIdx.x == 0) {
+      sharedState->init(probe, ops.blockBase(probe));
+    }
+    __syncthreads();
+    auto lane = cub::LaneId();
+    constexpr int32_t kWarpThreads = 1 << CUB_LOG_WARP_THREADS(0);
+    auto warp = threadIdx.x / kWarpThreads;
+    int32_t end = ops.numRowsInBlock(probe) + sharedState->blockBase;
+    for (auto i = threadIdx.x + sharedState->blockBase; i < end;
+         i += blockDim.x) {
+      auto start = i & ~(kWarpThreads - 1);
+      uint32_t laneMask =
+          start + kWarpThreads <= end ? ~0 : lowMask<uint32_t>(end - start);
+      auto h = ops.hash(i, probe);
+      uint32_t tagWord = hashTag(h);
+      tagWord |= tagWord << 8;
+      tagWord = tagWord | tagWord << 16;
+      auto bucketIdx = h & sizeMask;
+      uint32_t misses = 0;
+      RowType* hit = nullptr;
+      RowType* toInsert = nullptr;
+      int32_t hitIdx;
+      GpuBucket* bucket;
+      uint32_t tags;
+      for (;;) {
+        bucket = buckets + bucketIdx;
+      reprobe:
+        tags = asDeviceAtomic<uint32_t>(&bucket->tags)
+                   ->load(cuda::memory_order_consume);
+        auto hits = __vcmpeq4(tags, tagWord) & 0x01010101;
+        while (hits) {
+          hitIdx = (__ffs(hits) - 1) / 8;
+          auto candidate = bucket->loadWithWait<RowType>(hitIdx);
+          if (ops.compare(this, candidate, i, probe)) {
+            if (toInsert) {
+              freeInsertable(toInsert, h);
+            }
+            hit = candidate;
+            break;
+          }
+          hits = hits & (hits - 1);
+        }
+        if (hit) {
+          break;
+        }
+        misses = __vcmpeq4(tags, 0);
+        if (misses) {
+          auto success = ops.insert(
+              this,
+              partitionIdx(h),
+              bucket,
+              misses,
+              tags,
+              tagWord,
+              i,
+              probe,
+              toInsert);
+          if (success == ProbeState::kRetry) {
+            goto reprobe;
+          }
+          if (success == ProbeState::kNeedSpace) {
+            addHostRetry(sharedState, i, probe);
+          }
+          hit = toInsert;
+          break;
+        }
+        bucketIdx = (bucketIdx + 1) & sizeMask;
+      }
+      // Every lane has a hit, or a nullptr if out of space.
+      uint32_t peers =
+          __match_any_sync(laneMask, reinterpret_cast<int64_t>(hit));
+      if (hit) {
+        int32_t leader = (kWarpThreads - 1) - __clz(peers);
+        RowType* writable = nullptr;
+        if (lane == leader) {
+          writable = ops.getExclusive(this, bucket, hit, hitIdx, warp);
+        }
+        auto toUpdate = peers;
+        ProbeState success = ProbeState::kDone;
+        while (toUpdate) {
+          auto peer = __ffs(toUpdate) - 1;
+          auto idxToUpdate = __shfl_sync(peers, i, peer);
+          if (lane == leader) {
+            if (success == ProbeState::kDone) {
+              success = ops.update(this, bucket, writable, idxToUpdate, probe);
+            }
+            if (success == ProbeState::kNeedSpace) {
+              addHostRetry(sharedState, idxToUpdate, probe);
+            }
+            if (success != ProbeState::kDone) {
+              printf("");
+            }
+          }
+          toUpdate &= toUpdate - 1;
+        }
+        if (lane == leader) {
+          ops.writeDone(writable);
+        }
+      } else {
+        printf("");
+      }
+    }
+  }
+
+  template <typename RowType>
+  void __device__ freeInsertable(RowType*& row, uint64_t h) {
+    allocators[partitionIdx(h)].freeRow(row);
+    row = nullptr;
+  }
+
+  int32_t __device__ partitionIdx(uint64_t h) const {
+    return (h & partitionMask) >> partitionShift;
+  }
+
+ private:
+  static void __device__
+  addHostRetry(ProbeShared* shared, int32_t i, HashProbe* probe) {
+    probe->hostRetries
+        [shared->blockBase + atomicAdd(&shared->numHostRetries, 1)] = i;
+  }
+};
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/HashTable.h
+++ b/velox/experimental/wave/common/HashTable.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+/// Structs for tagged GPU hash table. Can be inclued in both Velox .cpp and
+/// .cu.
+namespace facebook::velox::wave {
+
+/// A 32 byte tagged bucket with 4 tags, 4 flag bytes and 4 6-byte
+/// pointers. Fits in one 32 byte GPU cache sector.
+struct GpuBucketMembers {
+  uint32_t tags;
+  uint32_t flags;
+  uint16_t data[12];
+
+  template <typename T>
+  T* testingLoad(int32_t idx) {
+    auto uptr = static_cast<uint64_t>(data[8 + idx]) << 32;
+    uptr |= reinterpret_cast<uint32_t*>(data)[idx];
+    return reinterpret_cast<T*>(uptr);
+  }
+};
+
+template <typename T, int32_t kSize>
+class FreeSetBase {
+  int32_t full_{0};
+  int32_t empty_{1};
+  unsigned long long bits_[kSize / 64] = {};
+  T items_[kSize] = {};
+};
+
+/// A device arena for device side allocation.
+struct HashPartitionAllocator {
+  static constexpr uint32_t kEmpty = ~0;
+
+  HashPartitionAllocator(
+      char* data,
+      uint32_t size,
+      uint32_t rowSize,
+      void* freeSet)
+      : rowSize(rowSize),
+        base(reinterpret_cast<uint64_t>(data)),
+        capacity(size),
+        stringOffset(capacity),
+        freeSet(freeSet) {}
+
+  const int32_t rowSize{0};
+  const uint64_t base{0};
+  uint32_t rowOffset{0};
+  const uint32_t capacity{0};
+  uint32_t stringOffset{0};
+  void* freeSet{nullptr};
+  int32_t numFromFree{0};
+  int32_t numFull{0};
+};
+
+/// Implementation of HashPartitionAllocator, defined in .cuh.
+struct RowAllocator;
+
+enum class ProbeState : uint8_t { kDone, kMoreValues, kNeedSpace, kRetry };
+
+/// Operands for one TB of hash probe.
+struct HashProbe {
+  /// The number of input rows processed by each thread of a TB. The base index
+  /// for a block in the arrays in 'this' is 'numRowsPerThread * blockDim.x *
+  /// blockIdx.x'
+  int32_t numRowsPerThread{1};
+
+  /// Count of probe keys for each TB. Subscript is blockIdx.x.
+  int32_t* numRows;
+
+  /// Data for probe keys. To be interpreted by Ops of the probe, no
+  /// fixed format.
+  void* keys;
+
+  /// Hash numbers for probe keys.
+  uint64_t* hashes;
+
+  /// List of input rows to retry in kernel. Sized to one per row of
+  /// input. Used inside kernel, not meaningful after return. Sample
+  /// use case is another warp updating the same row.
+  int32_t* kernelRetries1;
+  int32_t* kernelRetries2;
+
+  /// List of input rows to retry after host updated state. Sized to
+  /// one per row of input. The reason for a host side retry is
+  /// needing more space. The host will decide to allocate/spill/error
+  /// out.
+  int32_t* hostRetries;
+
+  /// Count of valid items in 'hostRetries'. The subscript is blockIdx.x.
+  int32_t* numHostRetries;
+
+  /// Space in 'hits' and 'hitRows'. Should be a multiple of probe block width.
+  int32_t maxHits{0};
+
+  /// Row numbers for hits. Indices into 'hashes'.
+  int32_t* hitRows{nullptr};
+
+  // Optional payload rows hitting from a probe.
+  void** hits{nullptr};
+};
+
+struct GpuBucket;
+
+struct GpuHashTableBase {
+  /// Bucket array. Size is 'sizeMask + 1'.
+  GpuBucket* buckets{nullptr};
+
+  // Mask to extract index into 'buckets' from a hash number. a
+  // sizemask of 63 means 64 buckets, which is up to 256 entries.
+  uint32_t sizeMask;
+
+  // Translates a hash number to a partition number '(hash &
+  // partitionMask) >> partitionShift' is a partition number used as
+  // a physical partition of the table. Used as index into 'allocators'.
+  uint32_t partitionMask{0};
+  uint8_t partitionShift{0};
+
+  /// A RowAllocator for each partition.
+  RowAllocator* allocators;
+};
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/tests/BlockTest.cu
+++ b/velox/experimental/wave/common/tests/BlockTest.cu
@@ -1,6 +1,25 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "velox/experimental/wave/common/Block.cuh"
 #include "velox/experimental/wave/common/CudaUtil.cuh"
+#include "velox/experimental/wave/common/HashTable.cuh"
 #include "velox/experimental/wave/common/tests/BlockTest.h"
+#include "velox/experimental/wave/common/tests/HashTestUtil.h"
+#include "velox/experimental/wave/common/tests/Updates.cuh"
 
 namespace facebook::velox::wave {
 
@@ -41,6 +60,48 @@ void BlockTestStream::testBoolToIndices(
   CUDA_CHECK(cudaGetLastError());
 }
 
+__global__ void boolToIndicesNoShared(
+    uint8_t** bools,
+    int32_t** indices,
+    int32_t* sizes,
+    int64_t* times,
+    void* temp) {
+  int32_t idx = blockIdx.x;
+
+  // Start cycle timer
+  clock_t start = clock();
+  uint8_t* blockBools = bools[idx];
+  char* smem = reinterpret_cast<char*>(temp) +
+      blockIdx.x * sizeof(typename ScanAlgorithm::TempStorage);
+  boolBlockToIndices<256>(
+      [&]() { return blockBools[threadIdx.x]; },
+      idx * 256,
+      indices[idx],
+      smem,
+      sizes[idx]);
+  clock_t stop = clock();
+  if (threadIdx.x == 0) {
+    times[idx] = (start > stop) ? start - stop : stop - start;
+  }
+}
+
+void BlockTestStream::testBoolToIndicesNoShared(
+    int32_t numBlocks,
+    uint8_t** flags,
+    int32_t** indices,
+    int32_t* sizes,
+    int64_t* times,
+    void* temp) {
+  CUDA_CHECK(cudaGetLastError());
+  boolToIndicesNoShared<<<numBlocks, 256, 0, stream_->stream>>>(
+      flags, indices, sizes, times, temp);
+  CUDA_CHECK(cudaGetLastError());
+}
+
+int32_t BlockTestStream::boolToIndicesSize() {
+  return sizeof(typename ScanAlgorithm::TempStorage);
+}
+
 __global__ void sum64(int64_t* numbers, int64_t* results) {
   extern __shared__ char smem[];
   int32_t idx = blockIdx.x;
@@ -56,5 +117,386 @@ void BlockTestStream::testSum64(
   sum64<<<numBlocks, 256, tempBytes, stream_->stream>>>(numbers, results);
   CUDA_CHECK(cudaGetLastError());
 }
+
+/// Keys and values are n sections of 8K items. The items in each section get
+/// sorted on the key.
+void __global__ __launch_bounds__(1024)
+    testSort(uint16_t** keys, uint16_t** values) {
+  extern __shared__ __align__(16) char smem[];
+  auto keyBase = keys[blockIdx.x];
+  auto valueBase = values[blockIdx.x];
+  blockSort<256, 32>(
+      [&](auto i) { return keyBase[i]; },
+      [&](auto i) { return valueBase[i]; },
+      keys[blockIdx.x],
+      values[blockIdx.x],
+      smem);
+}
+
+void BlockTestStream::testSort16(
+    int32_t numBlocks,
+    uint16_t** keys,
+    uint16_t** values) {
+  auto tempBytes = sizeof(
+      typename cub::BlockRadixSort<uint16_t, 256, 32, uint16_t>::TempStorage);
+
+  testSort<<<numBlocks, 256, tempBytes, stream_->stream>>>(keys, values);
+}
+
+/// Calls partitionRows on each thread block of 256 threads. The parameters
+/// correspond to 'partitionRows'. Each is an array subscripted by blockIdx.x.
+void __global__ partitionShortsKernel(
+    uint16_t** keys,
+    int32_t* numKeys,
+    int32_t numPartitions,
+    int32_t** ranks,
+    int32_t** partitionStarts,
+    int32_t** partitionedRows) {
+  partitionRows<256>(
+      [&](auto i) { return keys[blockIdx.x][i]; },
+      numKeys[blockIdx.x],
+      numPartitions,
+      ranks[blockIdx.x],
+      partitionStarts[blockIdx.x],
+      partitionedRows[blockIdx.x]);
+}
+
+void BlockTestStream::partitionShorts(
+    int32_t numBlocks,
+    uint16_t** keys,
+    int32_t* numKeys,
+    int32_t numPartitions,
+    int32_t** ranks,
+    int32_t** partitionStarts,
+    int32_t** partitionedRows) {
+  constexpr int32_t kBlockSize = 256;
+  auto shared = partitionRowsSharedSize<kBlockSize>(numPartitions);
+  partitionShortsKernel<<<numBlocks, kBlockSize, shared, stream_->stream>>>(
+      keys, numKeys, numPartitions, ranks, partitionStarts, partitionedRows);
+  CUDA_CHECK(cudaGetLastError());
+}
+
+/// A mock complex accumulator update function.
+ProbeState __device__ arrayAgg64Append(
+    ArrayAgg64* accumulator,
+    int64_t arg,
+    RowAllocator* allocator) {
+  auto* last = accumulator->last;
+  if (!last || accumulator->numInLast >= sizeof(last->data) / sizeof(int64_t)) {
+    auto* next = allocator->allocate<ArrayAgg64::Run>(1);
+    if (!next) {
+      return ProbeState::kNeedSpace;
+    }
+    next->next = nullptr;
+    if (accumulator->last) {
+      accumulator->last->next = next;
+      accumulator->last = next;
+    } else {
+      accumulator->first = accumulator->last = next;
+    }
+  }
+  accumulator->last->data[accumulator->numInLast++] = arg;
+  return ProbeState::kDone;
+}
+
+/// An mock Ops parameter class to do group by.
+class MockGroupByOps {
+ public:
+  int32_t __device__ blockBase(HashProbe* probe) {
+    return probe->numRowsPerThread * blockDim.x * blockIdx.x;
+  }
+
+  int32_t __device__ numRowsInBlock(HashProbe* probe) {
+    return probe->numRows[blockIdx.x];
+  }
+
+  uint64_t __device__ hash(int32_t i, HashProbe* probe) {
+    auto key = reinterpret_cast<int64_t**>(probe->keys)[0];
+    return hashMix(1, key[i]);
+  }
+
+  bool __device__
+  compare(GpuHashTable* table, TestingRow* row, int32_t i, HashProbe* probe) {
+    return row->key == reinterpret_cast<int64_t**>(probe->keys)[0][i];
+  }
+
+  TestingRow* __device__
+  newRow(GpuHashTable* table, int32_t partition, int32_t i, HashProbe* probe) {
+    auto* allocator = &table->allocators[partition];
+    auto row = allocator->allocateRow<TestingRow>();
+    if (row) {
+      row->key = reinterpret_cast<int64_t**>(probe->keys)[0][i];
+      row->flags = 0;
+      row->count = 0;
+      new (&row->concatenation) ArrayAgg64();
+    }
+    return row;
+  }
+
+  ProbeState __device__ insert(
+      GpuHashTable* table,
+      int32_t partition,
+      GpuBucket* bucket,
+      uint32_t misses,
+      uint32_t oldTags,
+      uint32_t tagWord,
+      int32_t i,
+      HashProbe* probe,
+      TestingRow*& row) {
+    if (!row) {
+      row = newRow(table, partition, i, probe);
+      if (!row) {
+        return ProbeState::kNeedSpace;
+      }
+    }
+    auto missShift = __ffs(misses) - 1;
+    if (!bucket->addNewTag(tagWord, oldTags, missShift)) {
+      return ProbeState::kRetry;
+    }
+    bucket->store(missShift / 8, row);
+    return ProbeState::kDone;
+  }
+
+  TestingRow* __device__ getExclusive(
+      GpuHashTable* table,
+      GpuBucket* bucket,
+      TestingRow* row,
+      int32_t hitIdx,
+      int32_t warp) {
+    return row;
+    int32_t nanos = 1;
+    for (;;) {
+      if (atomicTryLock(&row->flags)) {
+        return row;
+      }
+      __nanosleep((nanos + threadIdx.x) & 31);
+      nanos += 3;
+    }
+  }
+
+  void __device__ writeDone(TestingRow* row) {
+    // atomicUnlock(&row->flags);
+  }
+
+  ProbeState __device__ update(
+      GpuHashTable* table,
+      GpuBucket* bucket,
+      TestingRow* row,
+      int32_t i,
+      HashProbe* probe) {
+    auto* keys = reinterpret_cast<int64_t**>(probe->keys);
+    atomicAdd((unsigned long long*)&row->count, (unsigned long long)keys[1][i]);
+    return ProbeState::kDone;
+    int64_t arg = keys[1][i];
+    int32_t part = table->partitionIdx(bucket - table->buckets);
+    auto* allocator = &table->allocators[part];
+    auto state = arrayAgg64Append(&row->concatenation, arg, allocator);
+    row->flags = 0;
+    __threadfence();
+    return state;
+  }
+};
+
+void __global__ __launch_bounds__(1024) hashTestKernel(
+    GpuHashTable* table,
+    HashProbe* probe,
+    BlockTestStream::HashCase mode) {
+  switch (mode) {
+    case BlockTestStream::HashCase::kGroup: {
+      table->updatingProbe<TestingRow>(probe, MockGroupByOps());
+      break;
+    }
+    case BlockTestStream::HashCase::kBuild:
+    case BlockTestStream::HashCase::kProbe:
+      *(long*)0 = 0; // Unimplemented.
+  }
+}
+
+void BlockTestStream::hashTest(
+    GpuHashTableBase* table,
+    HashRun& run,
+    HashCase mode) {
+  constexpr int32_t kBlockSize = 256;
+  int32_t shared = 0;
+  if (mode == HashCase::kGroup) {
+    shared = GpuHashTable::updatingProbeSharedSize();
+  }
+  hashTestKernel<<<run.numBlocks, run.blockSize, shared, stream_->stream>>>(
+      reinterpret_cast<GpuHashTable*>(table), run.probe, mode);
+  CUDA_CHECK(cudaGetLastError());
+}
+
+void __global__ allocatorTestKernel(
+    int32_t numAlloc,
+    int32_t numFree,
+    int32_t numStr,
+    AllocatorTestResult* allResults) {
+  auto* result = allResults + threadIdx.x + blockIdx.x * blockDim.x;
+  for (;;) {
+    int32_t maxRows = sizeof(result->rows) / sizeof(result->rows[0]);
+    int32_t maxStrings = sizeof(result->strings) / sizeof(result->strings[0]);
+    for (auto count = 0; count < numAlloc; ++count) {
+      if (result->numRows >= maxRows) {
+        return;
+      }
+      auto newRow = result->allocator->allocateRow<int64_t>();
+      if (newRow == nullptr) {
+        return;
+      }
+      if (reinterpret_cast<uint64_t>(newRow) == result->allocator->base) {
+        printf("");
+      }
+
+      result->rows[result->numRows++] = newRow;
+    }
+    for (auto count = 0; count < numFree; ++count) {
+      if (result->numRows == 0) {
+        return;
+      }
+      auto* toFree = result->rows[--result->numRows];
+      if (reinterpret_cast<uint64_t>(toFree) == result->allocator->base) {
+        printf(""); // GPF();
+      }
+      if (!result->allocator->inRange(toFree)) {
+        GPF();
+      }
+      result->allocator->freeRow(toFree);
+    }
+    for (auto count = 0; count < numStr; ++count) {
+      if (result->numStrings >= maxStrings) {
+        return;
+      }
+      auto str = result->allocator->allocate<char>(11);
+      if (!str) {
+        return;
+      }
+      result->strings[result->numStrings++] = reinterpret_cast<int64_t*>(str);
+    }
+  }
+}
+
+void __global__ initAllocatorKernel(RowAllocator* allocator) {
+  if (threadIdx.x == 0) {
+    if (allocator->freeSet) {
+      reinterpret_cast<FreeSet<uint32_t, 1024>*>(allocator->freeSet)->clear();
+    }
+  }
+}
+
+//  static
+int32_t BlockTestStream::freeSetSize() {
+  return sizeof(FreeSet<uint32_t, 1024>);
+}
+
+void BlockTestStream::initAllocator(HashPartitionAllocator* allocator) {
+  initAllocatorKernel<<<1, 1, 0, stream_->stream>>>(
+      reinterpret_cast<RowAllocator*>(allocator));
+  CUDA_CHECK(cudaGetLastError());
+}
+
+void BlockTestStream::rowAllocatorTest(
+    int32_t numBlocks,
+    int32_t numAlloc,
+    int32_t numFree,
+    int32_t numStr,
+    AllocatorTestResult* results) {
+  allocatorTestKernel<<<numBlocks, 64, 0, stream_->stream>>>(
+      numAlloc, numFree, numStr, results);
+  CUDA_CHECK(cudaGetLastError());
+}
+
+#define UPDATE_CASE(name, func, smem)                                      \
+  void __global__ name##Kernel(TestingRow* rows, HashProbe* probe) {       \
+    func(rows, probe);                                                     \
+  }                                                                        \
+                                                                           \
+  void BlockTestStream::name(TestingRow* rows, HashRun& run) {             \
+    name##Kernel<<<run.numBlocks, run.blockSize, smem, stream_->stream>>>( \
+        rows, run.probe);                                                  \
+    CUDA_CHECK(cudaGetLastError());                                        \
+  }
+
+UPDATE_CASE(updateSum1NoSync, testSumNoSync, 0);
+UPDATE_CASE(updateSum1Mtx, testSumMtx, 0);
+UPDATE_CASE(updateSum1MtxCoalesce, testSumMtxCoalesce, 0);
+UPDATE_CASE(updateSum1Atomic, testSumAtomic, 0);
+UPDATE_CASE(updateSum1AtomicCoalesce, testSumAtomicCoalesce, 0);
+UPDATE_CASE(updateSum1Exch, testSumExch, sizeof(ProbeShared));
+UPDATE_CASE(updateSum1Order, testSumOrder, 0);
+
+void __global__ __launch_bounds__(1024) update1PartitionKernel(
+    int32_t numRows,
+    int32_t numDistinct,
+    int32_t numParts,
+    int32_t blockStride,
+    HashProbe* probe,
+    int32_t* temp) {
+  auto blockStart = blockStride * blockIdx.x;
+  auto keys = reinterpret_cast<int64_t**>(probe->keys);
+  auto indices = keys[0];
+  partitionRows<256, int32_t>(
+      [&](auto i) -> int32_t { return indices[i + blockStart] % numParts; },
+      blockIdx.x == blockDim.x - 1 ? numRows - blockStart : blockStride,
+      numParts,
+      temp + blockIdx.x * blockStride,
+      probe->hostRetries + blockStride * blockIdx.x,
+      probe->kernelRetries1 + blockStride * blockIdx.x);
+}
+
+void __global__ updateSum1PartKernel(
+    TestingRow* rows,
+    int32_t numParts,
+    HashProbe* probe,
+    int32_t numGroups,
+    int32_t groupStride) {
+  testSumPart(
+      rows,
+      numParts,
+      probe,
+      probe->kernelRetries1,
+      probe->hostRetries,
+      numGroups,
+      groupStride);
+}
+
+void BlockTestStream::updateSum1Part(TestingRow* rows, HashRun& run) {
+  auto numParts = std::min<int32_t>(run.numDistinct, 8192);
+  auto groupStride = run.numRows / 32;
+  auto numGroups = run.numRows / groupStride;
+  auto partSmem = partitionRowsSharedSize<256>(numParts);
+  // We use probe->kernelRetries1 as the indices array for partitions. We use
+  // probe->hostRetries as the array of partition starts. So, if we have 10
+  // partitions, then hostRetries[x..y] is the input rows for partition 1 if x
+  // is partitionStarts[0] and y is partitionStarts[1].
+  update1PartitionKernel<<<numGroups, 256, partSmem, stream_->stream>>>(
+      run.numRows,
+      run.numDistinct,
+      numParts,
+      groupStride,
+      run.probe,
+      run.partitionTemp);
+  CUDA_CHECK(cudaGetLastError());
+
+  int32_t blockSize = roundUp(std::min<int32_t>(256, numParts), 32);
+  int32_t numBlocks = numParts / blockSize;
+  // There will be one lane per partition. The last blocks may have empty lanes.
+  if (numBlocks * blockSize < numParts) {
+    ++numBlocks;
+  }
+  updateSum1PartKernel<<<numBlocks, blockSize, 0, stream_->stream>>>(
+      rows, numParts, run.probe, numGroups, groupStride);
+  CUDA_CHECK(cudaGetLastError());
+}
+
+REGISTER_KERNEL("testSort", testSort);
+REGISTER_KERNEL("boolToIndices", boolToIndices);
+REGISTER_KERNEL("sum64", sum64);
+REGISTER_KERNEL("partitionShorts", partitionShortsKernel);
+REGISTER_KERNEL("hashTest", hashTestKernel);
+REGISTER_KERNEL("allocatorTest", allocatorTestKernel);
+REGISTER_KERNEL("sum1atm", updateSum1AtomicKernel);
+REGISTER_KERNEL("sum1Exch", updateSum1ExchKernel);
+REGISTER_KERNEL("sum1Part", updateSum1PartKernel);
+REGISTER_KERNEL("partSum", update1PartitionKernel);
 
 } // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/tests/CMakeLists.txt
+++ b/velox/experimental/wave/common/tests/CMakeLists.txt
@@ -12,8 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_wave_common_test GpuArenaTest.cpp CudaTest.cpp CudaTest.cu
-                                      BlockTest.cpp BlockTest.cu)
+add_executable(
+  velox_wave_common_test
+  GpuArenaTest.cpp
+  CudaTest.cpp
+  CudaTest.cu
+  BlockTest.cpp
+  BlockTest.cu
+  HashTableTest.cpp
+  HashTestUtil.cpp)
 
 add_test(velox_wave_common_test velox_wave_common_test)
 

--- a/velox/experimental/wave/common/tests/CpuTable.h
+++ b/velox/experimental/wave/common/tests/CpuTable.h
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#include "velox/common/base/SimdUtil.h"
+
+namespace facebook::velox::wave {
+
+class CpuBucket {
+ public:
+  using TagVector = xsimd::batch<uint8_t, xsimd::sse2>;
+
+  auto loadTags() {
+    return TagVector(_mm_loadu_si128(reinterpret_cast<__m128i const*>(&tags_)));
+  }
+
+  void setTag(int32_t idx, uint8_t tag) {
+    tags_[idx] = tag;
+  }
+
+  static inline uint16_t matchTags(TagVector tags, uint8_t tag) {
+    auto flags = TagVector::broadcast(tag) == tags;
+    return simd::toBitMask(flags);
+  }
+
+  template <typename T>
+  T* load(int32_t idx) {
+    uint64_t data = *reinterpret_cast<uint64_t*>(&data_[idx * 6]);
+    return reinterpret_cast<T*>(data & 0xffffffffffff);
+  }
+
+  void store(uint32_t idx, void* row) {
+    auto uptr = reinterpret_cast<uint64_t>(row);
+    uint64_t data = *reinterpret_cast<uint64_t*>(&data_[idx * 6]);
+    *reinterpret_cast<uint64_t*>(&data_[idx * 6]) =
+        (data & 0xffff000000000000) | uptr;
+  }
+
+ private:
+  uint8_t tags_[16];
+  uint8_t data_[128 - 16];
+};
+
+struct CpuHashTable {
+  CpuHashTable() = default;
+
+  CpuHashTable(int32_t numSlots, int32_t rowBytes) {
+    auto numBuckets = bits::nextPowerOfTwo(numSlots) / 16;
+    assert(numBuckets > 0);
+    sizeMask = numBuckets - 1;
+    bucketSpace.resize(numBuckets * sizeof(CpuBucket) + 64);
+    buckets = reinterpret_cast<CpuBucket*>(
+        bits::roundUp(reinterpret_cast<uint64_t>(bucketSpace.data()), 64));
+    rows.resize(rowBytes);
+  }
+
+  std::string bucketSpace;
+
+  CpuBucket* buckets;
+
+  int32_t sizeMask;
+
+  // Preallocated space for rows. Do not resize.
+  std::string rows;
+
+  // Number of used bytes in 'rows'.
+  int32_t spaceUsed{0};
+
+  // Number of entries.
+  int32_t size{0};
+
+  template <typename T>
+  T* newRow() {
+    auto size = sizeof(T);
+    if (spaceUsed + size > rows.size()) {
+      return nullptr;
+    }
+    auto row = reinterpret_cast<T*>(rows.data() + spaceUsed);
+    spaceUsed += size;
+    return row;
+  }
+
+  template <typename RowType, typename Ops>
+  RowType* find(int64_t key, uint64_t h, Ops ops) const {
+    uint8_t tag = 0x80 | (h >> 32);
+    int32_t bucketIdx = h & sizeMask;
+    for (;;) {
+      auto tags = buckets[bucketIdx].loadTags();
+      auto hits = CpuBucket::matchTags(tags, tag);
+      while (hits) {
+        auto idx = bits::getAndClearLastSetBit(hits);
+        auto row = buckets[bucketIdx].load<RowType>(idx);
+        if (ops.compare1(this, row, key)) {
+          return row;
+        }
+      }
+      auto misses = CpuBucket::matchTags(tags, 0);
+      if (misses) {
+        return nullptr;
+      }
+      bucketIdx = (1 + bucketIdx) & sizeMask;
+    }
+  }
+
+  template <typename RowType, typename Ops>
+  void updatingProbe(int32_t numRows, HashProbe* probe, Ops ops) {
+    for (auto i = 0; i < numRows; ++i) {
+      auto h = probe->hashes[i];
+      uint8_t tag = 0x80 | (h >> 32);
+      auto bucketIdx = h & sizeMask;
+      for (;;) {
+        auto tags = buckets[bucketIdx].loadTags();
+        auto hits = CpuBucket::matchTags(tags, tag);
+        while (hits) {
+          auto idx = bits::getAndClearLastSetBit(hits);
+          auto row = buckets[bucketIdx].load<RowType>(idx);
+          if (ops.compare(this, row, i, probe)) {
+            ops.update(this, row, i, probe);
+            goto done;
+          }
+        }
+        auto misses = CpuBucket::matchTags(tags, 0);
+        if (misses) {
+          int32_t idx = bits::getAndClearLastSetBit(misses);
+          buckets[bucketIdx].setTag(idx, tag);
+          auto* newRow = ops.newRow(this, i, probe);
+          buckets[bucketIdx].store(idx, newRow);
+          ++size;
+          ops.update(this, newRow, i, probe);
+          break;
+        }
+        bucketIdx = (bucketIdx + 1) & sizeMask;
+      }
+    done:;
+    }
+  }
+
+  void check() {
+    for (auto i = 0; i <= sizeMask; ++i) {
+      for (auto j = 0; j < 16; j++) {
+        auto row = buckets[i].load<char>(j);
+        if (!row || (row >= rows.data() && row < rows.data() + rows.size())) {
+          continue;
+        }
+        VELOX_FAIL();
+      }
+    }
+  }
+};
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/tests/CudaTest.cu
+++ b/velox/experimental/wave/common/tests/CudaTest.cu
@@ -14,30 +14,53 @@
  * limitations under the License.
  */
 
+#include "velox/experimental/wave/common/Block.cuh"
 #include "velox/experimental/wave/common/CudaUtil.cuh"
 #include "velox/experimental/wave/common/tests/CudaTest.h"
 
 namespace facebook::velox::wave {
+constexpr uint32_t kPrime32 = 1815531889;
 
 __global__ void
 addOneKernel(int32_t* numbers, int32_t size, int32_t stride, int32_t repeats) {
-  auto index = blockDim.x * blockIdx.x + threadIdx.x;
   for (auto counter = 0; counter < repeats; ++counter) {
-    for (; index < size; index += stride) {
+    for (auto index = blockDim.x * blockIdx.x + threadIdx.x; index < size;
+         index += stride) {
       ++numbers[index];
     }
     __syncthreads();
   }
 }
 
-void TestStream::addOne(int32_t* numbers, int32_t size, int32_t repeats) {
-  constexpr int32_t kWidth = 10240;
+__global__ void addOneSharedKernel(
+    int32_t* numbers,
+    int32_t size,
+    int32_t stride,
+    int32_t repeats) {
+  extern __shared__ __align__(16) char smem[];
+  int32_t* temp = reinterpret_cast<int32_t*>(smem);
+  for (auto index = blockDim.x * blockIdx.x + threadIdx.x; index < size;
+       index += stride) {
+    temp[threadIdx.x] = numbers[blockDim.x * blockIdx.x + threadIdx.x];
+    for (auto counter = 0; counter < repeats; ++counter) {
+      ++temp[index];
+    }
+    __syncthreads();
+    numbers[blockDim.x * blockIdx.x + threadIdx.x] = temp[threadIdx.x];
+  }
+}
+
+void TestStream::addOne(
+    int32_t* numbers,
+    int32_t size,
+    int32_t repeats,
+    int32_t width) {
   constexpr int32_t kBlockSize = 256;
   auto numBlocks = roundUp(size, kBlockSize) / kBlockSize;
   int32_t stride = size;
-  if (numBlocks > kWidth / kBlockSize) {
-    stride = kWidth;
-    numBlocks = kWidth / kBlockSize;
+  if (numBlocks > width / kBlockSize) {
+    stride = width;
+    numBlocks = width / kBlockSize;
   }
   addOneKernel<<<numBlocks, kBlockSize, 0, stream_->stream>>>(
       numbers, size, stride, repeats);
@@ -45,26 +68,29 @@ void TestStream::addOne(int32_t* numbers, int32_t size, int32_t repeats) {
 }
 
 __global__ void addOneWideKernel(WideParams params) {
-  auto index = blockDim.x * blockIdx.x + threadIdx.x;
   auto numbers = params.numbers;
   auto size = params.size;
   auto repeat = params.repeat;
   auto stride = params.stride;
   for (auto counter = 0; counter < repeat; ++counter) {
-    for (; index < size; index += stride) {
+    for (auto index = blockDim.x * blockIdx.x + threadIdx.x; index < size;
+         index += stride) {
       ++numbers[index];
     }
   }
 }
 
-void TestStream::addOneWide(int32_t* numbers, int32_t size, int32_t repeat) {
-  constexpr int32_t kWidth = 10240;
+void TestStream::addOneWide(
+    int32_t* numbers,
+    int32_t size,
+    int32_t repeat,
+    int32_t width) {
   constexpr int32_t kBlockSize = 256;
   auto numBlocks = roundUp(size, kBlockSize) / kBlockSize;
   int32_t stride = size;
-  if (numBlocks > kWidth / kBlockSize) {
-    stride = kWidth;
-    numBlocks = kWidth / kBlockSize;
+  if (numBlocks > width / kBlockSize) {
+    stride = width;
+    numBlocks = width / kBlockSize;
   }
   WideParams params;
   params.numbers = numbers;
@@ -75,41 +101,90 @@ void TestStream::addOneWide(int32_t* numbers, int32_t size, int32_t repeat) {
   CUDA_CHECK(cudaGetLastError());
 }
 
-__global__ void addOneRandomKernel(
+void TestStream::addOneShared(
+    int32_t* numbers,
+    int32_t size,
+    int32_t repeats,
+    int32_t width) {
+  constexpr int32_t kBlockSize = 256;
+  auto numBlocks = roundUp(size, kBlockSize) / kBlockSize;
+  int32_t stride = size;
+  if (numBlocks > width / kBlockSize) {
+    stride = width;
+    numBlocks = width / kBlockSize;
+  }
+  addOneSharedKernel<<<
+      numBlocks,
+      kBlockSize,
+      sizeof(int32_t) * kBlockSize,
+      stream_->stream>>>(numbers, size, stride, repeats);
+  CUDA_CHECK(cudaGetLastError());
+}
+
+__global__ void __launch_bounds__(1024) addOneRandomKernel(
     int32_t* numbers,
     const int32_t* lookup,
     uint32_t size,
     int32_t stride,
-    int32_t repeats) {
-  auto index = blockDim.x * blockIdx.x + threadIdx.x;
+    int32_t repeats,
+    bool emptyWarps,
+    bool emptyThreads) {
   for (uint32_t counter = 0; counter < repeats; ++counter) {
-    for (; index < size; index += stride) {
-      auto rnd = (static_cast<uint64_t>(static_cast<uint32_t>(
-                      index * (counter + 1) * 1367836089)) *
-                  size) >>
-          32;
-      numbers[index] += lookup[rnd];
+    if (emptyWarps) {
+      if (((threadIdx.x / 32) & 1) == 0) {
+        for (auto index = blockDim.x * blockIdx.x + threadIdx.x; index < size;
+             index += stride) {
+          auto rnd = deviceScale32(index * (counter + 1) * kPrime32, size);
+          numbers[index] += lookup[rnd];
+          rnd = deviceScale32((index + 32) * (counter + 1) * kPrime32, size);
+          numbers[index + 32] += lookup[rnd];
+        }
+      }
+    } else if (emptyThreads) {
+      if ((threadIdx.x & 1) == 0) {
+        for (auto index = blockDim.x * blockIdx.x + threadIdx.x; index < size;
+             index += stride) {
+          auto rnd = deviceScale32(index * (counter + 1) * kPrime32, size);
+          numbers[index] += lookup[rnd];
+          rnd = deviceScale32((index + 1) * (counter + 1) * kPrime32, size);
+          numbers[index + 1] += lookup[rnd];
+        }
+      }
+    } else {
+#pragma unroll
+      for (auto index = blockDim.x * blockIdx.x + threadIdx.x; index < size;
+           index += stride) {
+        auto rnd = deviceScale32(index * (counter + 1) * kPrime32, size);
+        numbers[index] += lookup[rnd];
+      }
     }
     __syncthreads();
   }
+  __syncthreads();
 }
 
 void TestStream::addOneRandom(
     int32_t* numbers,
     const int32_t* lookup,
     int32_t size,
-    int32_t repeats) {
-  constexpr int32_t kWidth = 10240;
+    int32_t repeats,
+    int32_t width,
+    bool emptyWarps,
+    bool emptyThreads) {
   constexpr int32_t kBlockSize = 256;
   auto numBlocks = roundUp(size, kBlockSize) / kBlockSize;
   int32_t stride = size;
-  if (numBlocks > kWidth / kBlockSize) {
-    stride = kWidth;
-    numBlocks = kWidth / kBlockSize;
+  if (numBlocks > width / kBlockSize) {
+    stride = width;
+    numBlocks = width / kBlockSize;
   }
   addOneRandomKernel<<<numBlocks, kBlockSize, 0, stream_->stream>>>(
-      numbers, lookup, size, stride, repeats);
+      numbers, lookup, size, stride, repeats, emptyWarps, emptyThreads);
   CUDA_CHECK(cudaGetLastError());
 }
+
+REGISTER_KERNEL("addOne", addOneKernel);
+REGISTER_KERNEL("addOneWide", addOneWideKernel);
+REGISTER_KERNEL("addOneRandom", addOneRandomKernel);
 
 } // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/tests/CudaTest.h
+++ b/velox/experimental/wave/common/tests/CudaTest.h
@@ -35,15 +35,51 @@ class TestStream : public Stream {
  public:
   // Queues a kernel to add 1 to numbers[0...size - 1]. The kernel repeats
   // 'repeat' times.
-  void addOne(int32_t* numbers, int size, int32_t repeat = 1);
+  void
+  addOne(int32_t* numbers, int size, int32_t repeat = 1, int32_t width = 10240);
 
-  void addOneWide(int32_t* numbers, int32_t size, int32_t repeat = 1);
+  void addOneWide(
+      int32_t* numbers,
+      int32_t size,
+      int32_t repeat = 1,
+      int32_t width = 10240);
 
+  /// Like addOne but uses shared memory for intermediates, with global
+  /// ead/write at start/end.
+  void addOneShared(
+      int32_t* numbers,
+      int32_t size,
+      int32_t repeat = 1,
+      int32_t width = 10240);
+
+  /// Increments each of 'numbers by a deterministic pseudorandom
+  /// increment from 'lookup'.  If 'emptyWarps' is true, odd warps do
+  /// no work but still sync with the other ones with __syncthreads().
+  /// If 'emptyThreads' is true, odd lanes do no work and even lanes
+  /// do their work instead.
   void addOneRandom(
       int32_t* numbers,
       const int32_t* lookup,
       int size,
-      int32_t repeat = 1);
+      int32_t repeat = 1,
+      int32_t width = 10240,
+      bool emptyWarps = false,
+      bool emptyLanes = false);
+
+  // Makes random lookup keys and increments, starting at 'startCount'
+  // columns[0] is keys. 'powerOfTwo' is the next power of two from
+  // 'keyRange'. If 'powerOfTwo' is 0 the key columns are set to
+  // zero. Otherwise the key column values are incremented by a a
+  // delta + index of column where delta for element 0 is startCount &
+  // (powerOfTwo - 1).
+  void makeInput(
+      int32_t numRows,
+      int32_t keyRange,
+      int32_t powerOfTwo,
+      int32_t startCount,
+      uint64_t* hash,
+      uint8_t numColumns,
+      int64_t** columns);
 };
 
 } // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/tests/HashTableTest.cpp
+++ b/velox/experimental/wave/common/tests/HashTableTest.cpp
@@ -1,0 +1,386 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "velox/common/time/Timer.h"
+#include "velox/experimental/wave/common/Buffer.h"
+#include "velox/experimental/wave/common/GpuArena.h"
+#include "velox/experimental/wave/common/tests/BlockTest.h"
+#include "velox/experimental/wave/common/tests/CpuTable.h"
+#include "velox/experimental/wave/common/tests/HashTestUtil.h"
+
+#include <iostream>
+
+namespace facebook::velox::wave {
+
+class CpuMockGroupByOps {
+ public:
+  bool
+  compare(CpuHashTable* table, TestingRow* row, int32_t i, HashProbe* probe) {
+    return row->key == reinterpret_cast<int64_t**>(probe->keys)[0][i];
+  }
+
+  bool compare1(const CpuHashTable* table, TestingRow* row, int64_t key) {
+    return key == row->key;
+  }
+
+  TestingRow* newRow(CpuHashTable* table, int32_t i, HashProbe* probe) {
+    auto row = table->newRow<TestingRow>();
+    row->key = reinterpret_cast<int64_t**>(probe->keys)[0][i];
+    row->flags = 0;
+    row->count = 0;
+    new (&row->concatenation) ArrayAgg64();
+    return row;
+  }
+
+  void
+  update(CpuHashTable* table, TestingRow* row, int32_t i, HashProbe* probe) {
+    auto* keys = reinterpret_cast<int64_t**>(probe->keys);
+    row->count += keys[1][i];
+
+#if 0
+      int64_t arg = keys[1][i];
+      int32_t part = table->partitionIdx(bucket - table->buckets);
+      auto* allocator = &table->allocators[part];
+      auto state = arrayAgg64Append(&row->concatenation, arg, allocator);
+#endif
+  }
+};
+
+class HashTableTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    device_ = getDevice();
+    setDevice(device_);
+    allocator_ = getAllocator(device_);
+    arena_ = std::make_unique<GpuArena>(1 << 28, allocator_);
+    streams_.push_back(std::make_unique<BlockTestStream>());
+  }
+
+  void prefetch(Stream& stream, WaveBufferPtr buffer) {
+    stream.prefetch(device_, buffer->as<char>(), buffer->capacity());
+  }
+
+  // Tests different styles of updating a group by. Results are returned in
+  // 'run'.
+  void updateTestCase(int32_t numDistinct, int32_t numRows, HashRun& run) {
+    run.numRows = numRows;
+    run.numDistinct = numDistinct;
+    run.numColumns = 2;
+    run.numRowsPerThread = 32;
+
+    initializeHashTestInput(run, arena_.get());
+    fillHashTestInput(
+        run.numRows,
+        run.numDistinct,
+        bits::nextPowerOfTwo(run.numDistinct),
+        1,
+        run.numColumns,
+        reinterpret_cast<int64_t**>(run.probe->keys));
+    std::vector<TestingRow> reference(run.numDistinct);
+    for (auto i = 0; i < run.numDistinct; ++i) {
+      reference[i].key = i;
+    }
+    gpuRowsBuffer_ = arena_->allocate<TestingRow>(run.numDistinct);
+    TestingRow* gpuRows = gpuRowsBuffer_->as<TestingRow>();
+    memcpy(gpuRows, reference.data(), sizeof(TestingRow) * run.numDistinct);
+    prefetch(*streams_[0], gpuRowsBuffer_);
+    prefetch(*streams_[0], run.gpuData);
+    streams_[0]->wait();
+    updateCpu(reference.data(), run);
+    updateGpu(gpuRows, run, reference.data());
+    std::cout << run.toString() << std::endl;
+  }
+
+  void updateCpu(TestingRow* rows, HashRun& run) {
+    uint64_t micros = 0;
+    {
+      MicrosecondTimer t(&micros);
+      switch (run.testCase) {
+        case HashTestCase::kUpdateSum1: {
+          int64_t** keys = reinterpret_cast<int64_t**>(run.probe->keys);
+          int64_t* indices = keys[0];
+          int64_t* data = keys[1];
+          auto numRows = run.numRows;
+          for (auto i = 0; i < numRows; ++i) {
+            rows[indices[i]].count += data[i];
+          }
+          break;
+        }
+        default:
+          VELOX_FAIL("Unsupported test case");
+      }
+    }
+    run.addScore("cpu1t", micros);
+  }
+
+#define UPDATE_CASE(title, func, expectCorrect, nextFlags) \
+  {                                                        \
+    std::cout << title << std::endl;                       \
+    MicrosecondTimer t(&micros);                           \
+    streams_[0]->func(rows, run);                          \
+    streams_[0]->wait();                                   \
+  }                                                        \
+  run.addScore(title, micros);                             \
+  micros = 0;                                              \
+  compareAndReset(                                         \
+      reference, rows, run.numDistinct, title, expectCorrect, nextFlags);
+
+  void updateGpu(TestingRow* rows, HashRun& run, TestingRow* reference) {
+    uint64_t micros = 0;
+    switch (run.testCase) {
+      case HashTestCase::kUpdateSum1:
+        UPDATE_CASE("sum1Atm", updateSum1Atomic, true, 0);
+        UPDATE_CASE("sum1NoSync", updateSum1NoSync, false, 0);
+        UPDATE_CASE("sum1AtmCoa", updateSum1AtomicCoalesce, true, 1);
+        UPDATE_CASE("sum1Mtx", updateSum1Mtx, true, 1);
+        UPDATE_CASE("sum1MtxCoa", updateSum1MtxCoalesce, true, 0);
+        UPDATE_CASE("sum1Part", updateSum1Part, true, 0);
+        UPDATE_CASE("sum1Order", updateSum1Order, true, 0);
+        // UPDATE_CASE("sum1Exch", updateSum1Exch, false, 0);
+
+        break;
+      default:
+        VELOX_FAIL("Unsupported test case");
+    }
+  }
+
+  void compareAndReset(
+      TestingRow* reference,
+      TestingRow* rows,
+      int32_t numRows,
+      const char* title,
+      bool expectCorrect,
+      int32_t initFlags = 0) {
+    int32_t numError = 0;
+    int64_t errorSigned = 0;
+    int64_t errorDelta = 0;
+    for (auto i = 0; i < numRows; ++i) {
+      if (rows[i].count == reference[i].count) {
+        continue;
+      }
+      if (numError == 0 && expectCorrect) {
+        std::cout << "In " << title << std::endl;
+        EXPECT_EQ(reference[i].count, rows[i].count) << " at " << i;
+      }
+      ++numError;
+      int64_t d = reference[i].count - rows[i].count;
+      errorSigned += d;
+      errorDelta += d < 0 ? -d : d;
+    }
+    if (numError) {
+      std::cout << fmt::format(
+                       "{}: numError={} errorDelta={} errorSigned={}",
+                       title,
+                       numError,
+                       errorDelta,
+                       errorSigned)
+                << std::endl;
+    }
+    for (auto i = 0; i < numRows; ++i) {
+      new (rows + i) TestingRow();
+      rows[i].key = i;
+      rows[i].flags = initFlags;
+    }
+    prefetch(*streams_[0], gpuRowsBuffer_);
+    streams_[0]->wait();
+  }
+
+  void groupTestCase(int32_t numDistinct, int32_t numRows, HashRun& run) {
+    run.numRows = numRows;
+    run.numDistinct = numDistinct;
+    if (!run.numSlots) {
+      run.numSlots = bits::nextPowerOfTwo(numDistinct);
+    }
+    run.numColumns = 2;
+    run.numRowsPerThread = 32;
+
+    initializeHashTestInput(run, arena_.get());
+    fillHashTestInput(
+        run.numRows,
+        run.numDistinct,
+        bits::nextPowerOfTwo(run.numDistinct),
+        1,
+        run.numColumns,
+        reinterpret_cast<int64_t**>(run.probe->keys));
+    CpuHashTable cpuTable(run.numSlots, sizeof(TestingRow) * run.numDistinct);
+    cpuGroupBy(cpuTable, run);
+    gpuGroupBy(cpuTable, run);
+    std::cout << run.toString() << std::endl;
+  }
+
+  void cpuGroupBy(CpuHashTable& table, HashRun& run) {
+    uint64_t time = 0;
+    {
+      MicrosecondTimer t(&time);
+      int64_t* key = reinterpret_cast<int64_t**>(run.probe->keys)[0];
+      auto* hashes = run.probe->hashes;
+      for (auto i = 0; i < run.numRows; ++i) {
+        hashes[i] = bits::hashMix(1, key[i]);
+      }
+      table.updatingProbe<TestingRow>(
+          run.numRows, run.probe, CpuMockGroupByOps());
+    }
+    run.addScore("cpu1T", time);
+  }
+
+  void gpuGroupBy(const CpuHashTable& reference, HashRun& run) {
+    WaveBufferPtr gpuTableBuffer;
+    GpuHashTableBase* gpuTable;
+    setupGpuTable(
+        run.numSlots,
+        run.numRows,
+        sizeof(TestingRow),
+        arena_.get(),
+        gpuTable,
+        gpuTableBuffer);
+    prefetch(*streams_[0], run.gpuData);
+    prefetch(*streams_[0], gpuTableBuffer);
+    streams_[0]->wait();
+    uint64_t micros = 0;
+    {
+      MicrosecondTimer t(&micros);
+      streams_[0]->hashTest(gpuTable, run, BlockTestStream::HashCase::kGroup);
+      streams_[0]->wait();
+    }
+    run.addScore("gpu", micros);
+    checkGroupBy(reference, gpuTable);
+  }
+
+  void checkGroupBy(const CpuHashTable& reference, GpuHashTableBase* table) {
+    int32_t numChecked = 0;
+    for (auto i = 0; i <= table->sizeMask; ++i) {
+      for (auto j = 0; j < 4; ++j) {
+        auto* row = reinterpret_cast<GpuBucketMembers*>(table->buckets)[i]
+                        .testingLoad<TestingRow>(j);
+        if (row == nullptr) {
+          continue;
+        }
+        ++numChecked;
+        auto referenceRow = reference.find<TestingRow>(
+            row->key, bits::hashMix(1, row->key), CpuMockGroupByOps());
+        ASSERT_TRUE(referenceRow != nullptr);
+        EXPECT_EQ(referenceRow->count, row->count);
+      }
+    }
+    EXPECT_EQ(reference.size, numChecked);
+  }
+
+  Device* device_;
+  GpuAllocator* allocator_;
+  std::unique_ptr<GpuArena> arena_;
+  std::vector<std::unique_ptr<BlockTestStream>> streams_;
+  WaveBufferPtr gpuRowsBuffer_;
+};
+
+TEST_F(HashTableTest, allocator) {
+  constexpr int32_t kNumThreads = 256;
+  constexpr int32_t kTotal = 1 << 22;
+  WaveBufferPtr data = arena_->allocate<char>(kTotal);
+  auto* allocator = data->as<HashPartitionAllocator>();
+  auto freeSetSize = BlockTestStream::freeSetSize();
+  new (allocator) HashPartitionAllocator(
+      data->as<char>() + sizeof(HashPartitionAllocator) + freeSetSize,
+      kTotal - sizeof(HashPartitionAllocator) - freeSetSize,
+      16,
+      allocator + 1);
+  memset(allocator->freeSet, 0, freeSetSize);
+  WaveBufferPtr allResults = arena_->allocate<AllocatorTestResult>(kNumThreads);
+  auto results = allResults->as<AllocatorTestResult>();
+  for (auto i = 0; i < kNumThreads; ++i) {
+    results[i].allocator = reinterpret_cast<RowAllocator*>(allocator);
+    results[i].numRows = 0;
+    results[i].numStrings = 0;
+  }
+  auto stream1 = std::make_unique<BlockTestStream>();
+  auto stream2 = std::make_unique<BlockTestStream>();
+  stream1->initAllocator(allocator);
+  stream1->wait();
+  stream1->rowAllocatorTest(2, 4, 3, 2, results);
+  stream2->rowAllocatorTest(2, 4, 3, 2, results + 128);
+
+  stream1->wait();
+  stream2->wait();
+  // Pointer to result idx, position in result;
+  std::unordered_map<int64_t*, int32_t> uniques;
+  for (auto resultIdx = 0; resultIdx < kNumThreads; ++resultIdx) {
+    auto* result = results + resultIdx;
+    for (auto i = 0; i < result->numRows; ++i) {
+      auto row = result->rows[i];
+      EXPECT_GE(reinterpret_cast<uint64_t>(row), allocator->base);
+      EXPECT_LT(
+          reinterpret_cast<uint64_t>(row),
+          allocator->base + allocator->capacity);
+      auto it = uniques.find(row);
+      EXPECT_TRUE(it == uniques.end()) << fmt::format(
+          "row {} is also at {} {}",
+          reinterpret_cast<uint64_t>(row),
+          it->second >> 24,
+          it->second & bits::lowMask(24));
+
+      uniques[row] = (resultIdx << 24) | i;
+    }
+    for (auto i = 0; i < result->numStrings; ++i) {
+      auto string = result->strings[i];
+      EXPECT_GE(reinterpret_cast<uint64_t>(string), allocator->base);
+      EXPECT_LT(
+          reinterpret_cast<uint64_t>(string),
+          allocator->base + allocator->capacity);
+      auto it = uniques.find(string);
+      EXPECT_TRUE(it == uniques.end()) << fmt::format(
+          "String {} is also at {} {}",
+          reinterpret_cast<uint64_t>(string),
+          it->second >> 24,
+          it->second & bits::lowMask(24));
+      uniques[string] = (resultIdx << 24) | i;
+    }
+  }
+}
+
+TEST_F(HashTableTest, update) {
+  {
+    HashRun run;
+    run.testCase = HashTestCase::kUpdateSum1;
+    updateTestCase(1000, 2000000, run);
+  }
+  {
+    HashRun run;
+    run.testCase = HashTestCase::kUpdateSum1;
+    updateTestCase(10000000, 2000000, run);
+  }
+  {
+    HashRun run;
+    run.testCase = HashTestCase::kUpdateSum1;
+    updateTestCase(10, 2000000, run);
+  }
+}
+
+TEST_F(HashTableTest, groupBy) {
+  {
+    HashRun run;
+    run.testCase = HashTestCase::kGroupSum1;
+    run.numSlots = 2048;
+    groupTestCase(1000, 2000000, run);
+  }
+  {
+    HashRun run;
+    run.testCase = HashTestCase::kGroupSum1;
+    run.numSlots = 8 << 20;
+    groupTestCase(5000000, 50000000, run);
+  }
+}
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/tests/HashTestUtil.cpp
+++ b/velox/experimental/wave/common/tests/HashTestUtil.cpp
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/common/tests/HashTestUtil.h"
+#include <fmt/format.h>
+#include "velox/common/base/BitUtil.h"
+#include "velox/experimental/wave/common/Buffer.h"
+#include "velox/experimental/wave/common/GpuArena.h"
+#include "velox/experimental/wave/common/HashTable.h"
+
+namespace facebook::velox::wave {
+
+constexpr uint32_t kPrime32 = 1815531889;
+inline uint32_t scale32(uint32_t n, uint32_t scale) {
+  return (static_cast<uint64_t>(static_cast<uint32_t>(n)) * scale) >> 32;
+}
+
+// Returns the byte size for a GpuProbe with numRows as first, rounded row count
+// as second.
+std::pair<int64_t, int32_t> probeSize(HashRun& run) {
+  int32_t roundedRows =
+      bits::roundUp(run.numRows, run.blockSize * run.numRowsPerThread);
+  return {
+      sizeof(HashProbe) +
+          // Column data and hash number array.
+          (1 + run.numColumns) * roundedRows * sizeof(int64_t)
+          // Pointers to column starts
+          + sizeof(int64_t*) * run.numColumns
+          // retry lists
+          + 3 * sizeof(int32_t) * roundedRows +
+          // numRows for each block.
+          sizeof(int32_t) * roundedRows /
+              (run.blockSize * run.numRowsPerThread) +
+          // Temp space for partitioning.
+          roundedRows * sizeof(int32_t) +
+          // alignment padding
+          256,
+      roundedRows};
+}
+
+void fillHashTestInput(
+    int32_t numRows,
+    int32_t keyRange,
+    int32_t powerOfTwo,
+    int64_t counter,
+    uint8_t numColumns,
+    int64_t** columns,
+    int32_t numHot,
+    int32_t hotPct) {
+  int32_t delta = counter & (powerOfTwo - 1);
+  for (auto i = 0; i < numRows; ++i) {
+    auto previous = columns[0][i];
+    auto seed = (previous + delta + i) * kPrime32;
+    if (hotPct && scale32(seed >> 32, 100) <= hotPct) {
+      int32_t nth = scale32(seed, numHot);
+      nth = std::min<int64_t>(
+          keyRange - 1, nth * (static_cast<float>(keyRange) / nth));
+      columns[0][i] = nth;
+    } else {
+      columns[0][i] = scale32(seed, keyRange);
+    }
+  }
+  counter += numRows;
+  for (auto c = 1; c < numColumns; ++c) {
+    for (auto r = 0; r < numRows; ++r) {
+      columns[c][r] = 1; // c + (r & 7);
+    }
+  }
+}
+
+void initializeHashTestInput(HashRun& run, GpuArena* arena) {
+  auto [bytes, roundedRows] = probeSize(run);
+  if (!arena) {
+    run.isCpu = true;
+    run.cpuData = std::make_unique<char[]>(bytes);
+    run.input = run.cpuData.get();
+  } else {
+    run.isCpu = false;
+    run.gpuData = arena->allocate<char>(bytes);
+    run.input = run.gpuData->as<char>();
+  }
+  auto data = run.input;
+  auto dataBegin = data;
+  HashProbe* probe = new (data) HashProbe();
+  run.probe = probe;
+  data += sizeof(HashProbe);
+  probe->numRows = reinterpret_cast<int32_t*>(data);
+  data += bits::roundUp(
+      sizeof(int32_t) * roundedRows / (run.numRowsPerThread * run.blockSize),
+      8);
+  if (!arena) {
+    probe->numRows[0] = run.numRows;
+  } else {
+    run.numBlocks = roundedRows / (run.blockSize * run.numRowsPerThread);
+    for (auto i = 0; i < run.numBlocks; ++i) {
+      if (i == run.numBlocks - 1) {
+        probe->numRows[i] =
+            run.numRows - (i * run.blockSize * run.numRowsPerThread);
+        break;
+      }
+      probe->numRows[i] = run.blockSize * run.numRowsPerThread;
+      ;
+    }
+  }
+  probe->numRowsPerThread = run.numRowsPerThread;
+  probe->hashes = reinterpret_cast<uint64_t*>(data);
+  data += sizeof(uint64_t) * roundedRows;
+  probe->keys = data;
+  data += sizeof(void*) * run.numColumns;
+  probe->kernelRetries1 = reinterpret_cast<int32_t*>(data);
+  data += sizeof(int32_t) * roundedRows;
+  probe->kernelRetries2 = reinterpret_cast<int32_t*>(data);
+  data += sizeof(int32_t) * roundedRows;
+  probe->hostRetries = reinterpret_cast<int32_t*>(data);
+  data += sizeof(int32_t) * roundedRows;
+  for (auto i = 0; i < run.numColumns; ++i) {
+    reinterpret_cast<int64_t**>(probe->keys)[i] =
+        reinterpret_cast<int64_t*>(data);
+    data += sizeof(int64_t) * roundedRows;
+  }
+  run.partitionTemp = reinterpret_cast<int32_t*>(data);
+  data += bits::roundUp(sizeof(int32_t) * roundedRows, 8);
+  VELOX_CHECK_LE(data - dataBegin, bytes);
+}
+
+void setupGpuTable(
+    int32_t numSlots,
+    int32_t maxRows,
+    int64_t rowSize,
+    GpuArena* arena,
+    GpuHashTableBase*& table,
+    WaveBufferPtr& buffer) {
+  using FreeSetType = FreeSetBase<void*, 1024>;
+  // GPU cache lines are 128 bytes divided in 4 separately loadable 32 byte
+  // sectors.
+  constexpr int32_t kAlignment = 128;
+  int32_t numBuckets = bits::nextPowerOfTwo(numSlots / 4);
+  int64_t bytes = sizeof(GpuHashTableBase) + sizeof(HashPartitionAllocator) +
+      sizeof(FreeSetType) + sizeof(GpuBucketMembers) * numBuckets +
+      maxRows * rowSize;
+  buffer = arena->allocate<char>(bytes + kAlignment);
+  table = buffer->as<GpuHashTableBase>();
+  new (table) GpuHashTableBase();
+  table->sizeMask = numBuckets - 1;
+  char* data = reinterpret_cast<char*>(table + 1);
+  table->allocators = reinterpret_cast<RowAllocator*>(data);
+  auto allocatorBase =
+      reinterpret_cast<HashPartitionAllocator*>(table->allocators);
+  data += sizeof(HashPartitionAllocator);
+  auto freeSet = reinterpret_cast<FreeSetType*>(data);
+  new (freeSet) FreeSetType();
+  data += sizeof(FreeSetType);
+  // The buckets start at aligned address.
+  data = reinterpret_cast<char*>(
+      bits::roundUp(reinterpret_cast<uint64_t>(data), kAlignment));
+  table->buckets = reinterpret_cast<GpuBucket*>(data);
+  data += sizeof(GpuBucketMembers) * numBuckets;
+  auto allocator = reinterpret_cast<HashPartitionAllocator*>(table->allocators);
+  new (allocator)
+      HashPartitionAllocator(data, maxRows * rowSize, rowSize, freeSet);
+  table->partitionMask = 0;
+  table->partitionShift = 0;
+  memset(table->buckets, 0, sizeof(GpuBucketMembers) * (table->sizeMask + 1));
+}
+
+std::string HashRun::toString() const {
+  std::stringstream out;
+  std::string opLabel = testCase == HashTestCase::kUpdateSum1 ? "update sum1"
+      : testCase == HashTestCase::kGroupSum1                  ? "groupSum1"
+                                             : "update array_agg1";
+  out << "===" << label << ":" << opLabel << " distinct=" << numDistinct
+      << " rows=" << numRows << " (" << numBlocks << "x" << blockSize << "x"
+      << numRowsPerThread << ") ";
+  if (hotPct) {
+    out << " skew " << hotPct << "% in " << numHot << " ";
+  }
+  auto sorted = scores;
+  std::sort(sorted.begin(), sorted.end(), [](auto& left, auto& right) {
+    return left.second < right.second;
+  });
+  float gb =
+      numRows * sizeof(int64_t) * numColumns / static_cast<float>(1 << 30);
+  for (auto& score : sorted) {
+    out << std::endl
+        << "  * "
+        << fmt::format(
+               " {}={:.2f} rps {:.2f} GB/s {} us {:.2f}x",
+               score.first,
+               numRows / (score.second / 1e6),
+               gb / (score.second / 1e6),
+               score.second,
+               score.second / sorted[0].second);
+  }
+  return out.str();
+}
+
+void HashRun::addScore(const char* label, uint64_t micros) {
+  scores.push_back(std::make_pair<std::string, float>(label, micros));
+}
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/tests/HashTestUtil.h
+++ b/velox/experimental/wave/common/tests/HashTestUtil.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include "velox/experimental/wave/common/Buffer.h"
+#include "velox/experimental/wave/common/HashTable.h"
+
+namespace facebook::velox::wave {
+
+/// Identifies operation being tested. A collection of representative hash table
+/// ops like aggregates probes and builds with different functions and layouts.
+enum class HashTestCase {
+  // bigint sum.  Update only, no hash table.
+  kUpdateSum1,
+  // group by with bigint sum.
+  kGroupSum1,
+  // array_agg of bigint. Update only, no hash table.
+  kUpdateArrayAgg1
+};
+
+/// Describes a hashtable benchmark case.
+struct HashRun {
+  // Label of test case. Describes what is done. The labels for different
+  // implementations come from 'scores'.
+  std::string label;
+  // the operation being measured.
+  HashTestCase testCase;
+  // CPU/GPU measurement.
+  bool isCpu;
+
+  // Number of slots in table.
+  int32_t numSlots{0};
+
+  // Number of probe rows.
+  int32_t numRows;
+
+  // Number of distinct keys.
+  int32_t numDistinct;
+
+  // Number of distinct hot keys.
+  int32_t numHot{0};
+
+  // Percentage of hot keys over total keys. e.g. with 1000 distinct and 10 hot
+  // and hotPct of 50, every second key will be one of 10 and the rest are
+  // evenly spread over the 1000.
+  int32_t hotPct{0};
+
+  // Number of keys processed by each thread of each block.
+  int32_t numRowsPerThread;
+
+  int32_t blockSize{256};
+
+  // Number of blocks of 'blockSize' threads.
+  int32_t numBlocks;
+
+  // Number of columns. Key is column 0.
+  uint8_t numColumns{1};
+
+  // Number of independent hash tables.
+  int32_t numTables{1};
+
+  // Result, labeled by implementation alternative.
+  std::vector<std::pair<std::string, float>> scores;
+
+  std::unique_ptr<char[]> cpuData;
+  WaveBufferPtr gpuData;
+
+  // Input data, either cpuData or gpuData.
+  char* input;
+
+  // Initialized probe params, contained in 'input'.
+  HashProbe* probe;
+  // One int per row, use for partitioning intermediates. Uninitialized.
+  int32_t* partitionTemp;
+
+  int32_t* partitionArgs;
+  std::string toString() const;
+  void addScore(const char* label, uint64_t micros);
+  void clearScore() {
+    scores.clear();
+  }
+};
+
+void fillHashTestInput(
+    int32_t numRows,
+    int32_t keyRange,
+    int32_t powerOfTwo,
+    int64_t counter,
+    uint8_t numColumns,
+    int64_t** columns,
+    int32_t numHot = 0,
+    int32_t hotPct = 0);
+
+void initializeHashTestInput(HashRun& run, GpuArena* arena);
+
+void setupGpuTable(
+    int32_t numSlots,
+    int32_t maxRows,
+    int64_t rowSize,
+    GpuArena* arena,
+    GpuHashTableBase*& table,
+    WaveBufferPtr& buffer);
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/tests/Updates.cuh
+++ b/velox/experimental/wave/common/tests/Updates.cuh
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/experimental/wave/common/HashTable.cuh"
+#include "velox/experimental/wave/common/tests/BlockTest.h"
+
+namespace facebook::velox::wave {
+
+using Mutex = cuda::binary_semaphore<cuda::thread_scope_device>;
+
+inline void __device__ testingLock(int32_t* mtx) {
+  reinterpret_cast<Mutex*>(mtx)->acquire();
+}
+
+inline void __device__ testingUnlock(int32_t* mtx) {
+  reinterpret_cast<Mutex*>(mtx)->release();
+}
+
+void __device__ testSumNoSync(TestingRow* rows, HashProbe* probe) {
+  auto keys = reinterpret_cast<int64_t**>(probe->keys);
+  auto indices = keys[0];
+  auto deltas = keys[1];
+  int32_t base = probe->numRowsPerThread * blockDim.x * blockIdx.x;
+  int32_t end = base + probe->numRows[blockIdx.x];
+
+  for (auto i = base + threadIdx.x; i < end; i += blockDim.x) {
+    auto* row = &rows[indices[i]];
+    row->count += deltas[i];
+  }
+}
+
+void __device__ testSumPart(
+    TestingRow* rows,
+    int32_t numParts,
+    HashProbe* probe,
+    int32_t* part,
+    int32_t* partEnd,
+    int32_t numGroups,
+    int32_t groupStride) {
+  auto keys = reinterpret_cast<int64_t**>(probe->keys);
+  auto indices = keys[0];
+  auto deltas = keys[1];
+  for (auto groupIdx = 0; groupIdx < numGroups; ++groupIdx) {
+    auto groupStart = groupIdx * groupStride;
+    int32_t linear = threadIdx.x + blockIdx.x * blockDim.x;
+    if (linear > numParts) {
+      break;
+    }
+    int32_t begin = linear == 0 ? groupStart
+                                : groupStart + partEnd[groupStart + linear - 1];
+    int32_t end = groupStart + partEnd[groupStart + linear];
+
+    for (auto i = begin; i < end; ++i) {
+      auto index = groupStart + part[i];
+      auto* row = &rows[indices[index]];
+      row->count += deltas[index];
+    }
+  }
+  __syncthreads();
+}
+
+void __device__ testSumMtx(TestingRow* rows, HashProbe* probe) {
+  auto keys = reinterpret_cast<int64_t**>(probe->keys);
+  auto indices = keys[0];
+  auto deltas = keys[1];
+  int32_t base = probe->numRowsPerThread * blockDim.x * blockIdx.x;
+  int32_t end = base + probe->numRows[blockIdx.x];
+
+  for (auto i = base + threadIdx.x; i < end; i += blockDim.x) {
+    auto* row = &rows[indices[i]];
+    testingLock(&row->flags);
+    row->count += deltas[i];
+    testingUnlock(&row->flags);
+  }
+}
+
+void __device__ testSumAtomic(TestingRow* rows, HashProbe* probe) {
+  auto keys = reinterpret_cast<int64_t**>(probe->keys);
+  auto indices = keys[0];
+  auto deltas = keys[1];
+  int32_t base = probe->numRowsPerThread * blockDim.x * blockIdx.x;
+  int32_t end = base + probe->numRows[blockIdx.x];
+
+  for (auto i = base + threadIdx.x; i < end; i += blockDim.x) {
+    auto* row = &rows[indices[i]];
+    atomicAdd((unsigned long long*)&row->count, (unsigned long long)deltas[i]);
+  }
+}
+
+void __device__ testSumAtomicCoalesce(TestingRow* rows, HashProbe* probe) {
+  constexpr int32_t kWarpThreads = 32;
+  auto keys = reinterpret_cast<int64_t**>(probe->keys);
+  auto indices = keys[0];
+  auto deltas = keys[1];
+  int32_t base = probe->numRowsPerThread * blockDim.x * blockIdx.x;
+  int32_t lane = cub::LaneId();
+  int32_t end = base + probe->numRows[blockIdx.x];
+
+  for (auto count = base; count < end; count += blockDim.x) {
+    auto i = threadIdx.x + count;
+
+    if (i < end) {
+      uint32_t laneMask = count + kWarpThreads <= end
+          ? 0xffffffff
+          : lowMask<uint32_t>(end - count);
+      auto index = indices[i];
+      auto delta = deltas[i];
+      uint32_t allPeers = __match_any_sync(laneMask, index);
+      int32_t leader = __ffs(allPeers) - 1;
+      auto peers = allPeers;
+      int64_t total = 0;
+      auto currentPeer = leader;
+      for (;;) {
+        total += __shfl_sync(allPeers, delta, currentPeer);
+        peers &= peers - 1;
+        if (peers == 0) {
+          break;
+        }
+        currentPeer = __ffs(peers) - 1;
+      }
+      if (lane == leader) {
+        auto* row = &rows[index];
+        atomicAdd((unsigned long long*)&row->count, (unsigned long long)total);
+      }
+    }
+  }
+}
+
+void __device__ testSumExch(TestingRow* rows, HashProbe* probe) {
+  int32_t base = probe->numRowsPerThread * blockDim.x * blockIdx.x;
+  int32_t end = base + probe->numRows[blockIdx.x];
+  auto keys = reinterpret_cast<int64_t**>(probe->keys);
+  auto indices = keys[0];
+  auto deltas = keys[1];
+
+  extern __shared__ __align__(16) char smem[];
+  ProbeShared* shared = reinterpret_cast<ProbeShared*>(smem);
+  if (threadIdx.x == 0) {
+    shared->init(probe, base);
+    shared->blockEnd = end;
+    shared->toDo = probe->numRows[blockIdx.x];
+    shared->numRounds = 0;
+    shared->numUpdated = 0;
+    shared->numTried = 0;
+  }
+  __syncthreads();
+  for (;;) {
+    if (shared->blockEnd <= shared->blockBase) {
+      GPF();
+    }
+    int32_t counter;
+    for (counter = base; counter < shared->blockEnd; counter += blockDim.x) {
+      auto i = counter + threadIdx.x;
+      if (i < shared->blockEnd) {
+        atomicAdd(&shared->numTried, 1);
+        if (shared->inputRetries) {
+          i = shared->inputRetries[i];
+        }
+        auto* row = &rows[indices[i]];
+        if (0 ==
+            asDeviceAtomic<int32_t>(&row->flags)
+                ->exchange(1, cuda::memory_order_consume)) {
+          atomicAdd(
+              (unsigned long long*)&row->count, (unsigned long long)deltas[i]);
+          atomicAdd(&shared->numUpdated, 1);
+          asDeviceAtomic<int32_t>(&row->flags)
+              ->store(0, cuda::memory_order_release);
+        } else {
+          shared
+              ->outputRetries[base + atomicAdd(&shared->numKernelRetries, 1)] =
+              i;
+        }
+      } else {
+        atomicAdd(&shared->numTried, 1 << 16);
+      }
+      // __syncthreads();
+    }
+    __syncthreads();
+    if (shared->numKernelRetries == 0) {
+      if ((shared->numTried & 0xffff) != shared->blockEnd - shared->blockBase) {
+        GPF();
+      }
+      if (shared->done + (shared->blockEnd - shared->blockBase) !=
+          shared->toDo) {
+        GPF();
+      }
+      // printf("%d %d //%d\n", base, end, counter);
+      return;
+    }
+
+    if (threadIdx.x == 0) {
+      shared->done +=
+          (shared->blockEnd - shared->blockBase) - shared->numKernelRetries;
+      ++shared->numRounds;
+      shared->numTried = 0;
+      shared->blockEnd = base + shared->numKernelRetries;
+      shared->nextRound(probe);
+    }
+    __syncthreads();
+  }
+}
+void __device__ testSumMtxCoalesce(TestingRow* rows, HashProbe* probe) {
+  constexpr int32_t kWarpThreads = 32;
+  auto keys = reinterpret_cast<int64_t**>(probe->keys);
+  auto indices = keys[0];
+  auto deltas = keys[1];
+  int32_t base = probe->numRowsPerThread * blockDim.x * blockIdx.x;
+  int32_t lane = cub::LaneId();
+  int32_t end = base + probe->numRows[blockIdx.x];
+
+  for (auto count = base; count < end; count += blockDim.x) {
+    auto i = threadIdx.x + count;
+
+    if (i < end) {
+      uint32_t laneMask = count + kWarpThreads <= end
+          ? 0xffffffff
+          : lowMask<uint32_t>(end - count);
+      auto index = indices[i];
+      auto delta = deltas[i];
+      uint32_t allPeers = __match_any_sync(laneMask, index);
+      int32_t leader = __ffs(allPeers) - 1;
+      auto peers = allPeers;
+      int64_t total = 0;
+      auto currentPeer = leader;
+      for (;;) {
+        total += __shfl_sync(allPeers, delta, currentPeer);
+        peers &= peers - 1;
+        if (peers == 0) {
+          break;
+        }
+        currentPeer = __ffs(peers) - 1;
+      }
+      if (lane == leader) {
+        auto* row = &rows[index];
+        testingLock(&row->flags);
+        row->count += total;
+        testingUnlock(&row->flags);
+      }
+    }
+  }
+}
+
+void __device__ testSumOrder(TestingRow* rows, HashProbe* probe) {
+  auto keys = reinterpret_cast<int64_t**>(probe->keys);
+  auto indices = keys[0];
+  auto deltas = keys[1];
+  int32_t base = probe->numRowsPerThread * blockDim.x * blockIdx.x;
+  int32_t end = base + probe->numRows[blockIdx.x];
+
+  for (auto i = base + threadIdx.x; i < end; i += blockDim.x) {
+    auto* row = &rows[indices[i]];
+    int32_t waitNano = 1;
+    auto d = deltas[i];
+    for (;;) {
+      if (0 ==
+          asDeviceAtomic<int32_t>(&row->flags)
+              ->exchange(1, cuda::memory_order_consume)) {
+        row->count += d;
+        asDeviceAtomic<int32_t>(&row->flags)
+            ->store(0, cuda::memory_order_release);
+        break;
+      } else {
+        __nanosleep(waitNano);
+        waitNano += threadIdx.x & 31;
+      }
+    }
+  }
+}
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/tests/Util.h
+++ b/velox/experimental/wave/common/tests/Util.h
@@ -16,6 +16,12 @@
 
 #pragma once
 
-#include "velox/experimental/wave/vector/Operand.h"
+#include <cstdint>
 
-namespace facebook::velox::wave {} // namespace facebook::velox::wave
+namespace facebook::velox::wave {
+
+inline uint32_t scale32(uint32_t n, uint32_t scale) {
+  return (static_cast<uint64_t>(static_cast<uint32_t>(n)) * scale) >> 32;
+}
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/AggregationInstructions.cu
+++ b/velox/experimental/wave/exec/AggregationInstructions.cu
@@ -91,7 +91,7 @@ normalize(BlockInfo* block, void* idMap, Operand* key, int32_t& result) {
   auto* typedIdMap = reinterpret_cast<IdMap<T>*>(idMap);
   auto id = typedIdMap->makeId(value<T>(key, block->base, block->shared));
   if (id == -1) {
-    return ErrorCode::kInsuffcientMemory;
+    return ErrorCode::kInsufficientMemory;
   }
   assert(typedIdMap->cardinality() <= kNormalizationRadix);
   result = kNormalizationRadix * result + id - 1;


### PR DESCRIPTION
Adds block utilities for radix sort and partitioning. Adds a template for hash tables for join and group by and a set of alternative ways of updating a group by. Adds a kernel registry for tracking register use, occupancy and shared memory.

Adds a buffer view over WaveBufferPtr.
Adds some more cases and adjustments for roundtripMatrix test.