### PR TITLE
Enable no-throw behavior for simple functions

### DIFF
--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -172,6 +172,26 @@ auto throwError(const std::exception_ptr& exceptionPtr) {
 }
 } // namespace
 
+void EvalCtx::setStatus(vector_size_t index, Status status) {
+  VELOX_CHECK(!status.ok(), "Status must be an error");
+
+  if (status.isUserError()) {
+    setVeloxExceptionError(
+        index,
+        std::make_exception_ptr(VeloxUserError(
+            __FILE__,
+            __LINE__,
+            __FUNCTION__,
+            "",
+            status.message(),
+            error_source::kErrorSourceUser,
+            error_code::kInvalidArgument,
+            false /*retriable*/)));
+  } else {
+    VELOX_FAIL(status.message());
+  }
+}
+
 void EvalCtx::setError(
     vector_size_t index,
     const std::exception_ptr& exceptionPtr) {

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -78,6 +78,9 @@ class EvalCtx {
 
   void restore(ContextSaver& saver);
 
+  // @param status Must indicate an error. Cannot be "ok".
+  void setStatus(vector_size_t index, Status status);
+
   // If exceptionPtr is known to be a VeloxException use setVeloxExceptionError
   // instead.
   void setError(vector_size_t index, const std::exception_ptr& exceptionPtr);

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -3467,13 +3467,9 @@ TEST_F(DateTimeFunctionsTest, dateParse) {
   EXPECT_EQ(
       Timestamp(-66600, 0), dateParse("1969-12-31+11:00", "%Y-%m-%d+%H:%i"));
 
-  VELOX_ASSERT_THROW(
-      dateParse("", "%y+"), "Invalid date format: '' is malformed at ''");
-  VELOX_ASSERT_THROW(
-      dateParse("1", "%y+"), "Invalid date format: '1' is malformed at '1'");
-  VELOX_ASSERT_THROW(
-      dateParse("116", "%y+"),
-      "Invalid date format: '116' is malformed at '6'");
+  VELOX_ASSERT_THROW(dateParse("", "%y+"), "Invalid date format: ''");
+  VELOX_ASSERT_THROW(dateParse("1", "%y+"), "Invalid date format: '1'");
+  VELOX_ASSERT_THROW(dateParse("116", "%y+"), "Invalid date format: '116'");
 }
 
 TEST_F(DateTimeFunctionsTest, dateFunctionVarchar) {


### PR DESCRIPTION
Summary:
Throwing exceptions is expensive. When many rows throw exceptions that are being suppressed by TRY, query performance degrades a lot.

Vector functions may avoid throwing exceptions by calling EvalCtx::setError, but Simple functions can only throw.

This change introduces new 'call' method to be used by Simple function to avoid throwing:

```
Status call(result, arg1, arg2,...);
```

This method can report errors via Status without throwing.

This change allows default-null-behavior functions to avoid throwing. More changes are needed to allow all simple functions to avoid throwing.

Differential Revision: D56705407
