### PR TITLE
Add expm1 Spark function

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -98,7 +98,7 @@ Mathematical Functions
 
 .. spark:function:: expm1(x) -> double
 
-    Returns Euler's number raised to the power of ``x``, minus 1, which is "exp(x)-1" in math, while this function is more accurate than exp(num) - 1 when the num is close to zero.
+    Returns Euler's number raised to the power of ``x``, minus 1, which is ``exp(x) - 1`` in math. This function expm1(x) is more accurate than ``std::exp(x) - 1`` when ``x`` is close zero.
     If the argument is NaN, the result is NaN.
     If the argument is positive infinity, then the result is positive infinity.
     If the argument is negative infinity, then the result is -1.0.

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -96,6 +96,10 @@ Mathematical Functions
 
     Returns Euler's number raised to the power of ``x``.
 
+.. spark:function:: expm1(x) -> double
+
+    Returns Euler's number raised to the power of ``x`` minus 1 and this function is more accurate than exp(num) - 1whne the num is close to zero.
+
 .. spark:function:: floor(x) -> [same as x]
 
     Returns ``x`` rounded down to the nearest integer.

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -98,7 +98,7 @@ Mathematical Functions
 
 .. spark:function:: expm1(x) -> double
 
-    Returns Euler's number raised to the power of ``x`` minus 1 and this function is more accurate than exp(num) - 1whne the num is close to zero.
+    Returns Euler's number raised to the power of ``x`` minus 1 and this function is more accurate than exp(num) - 1when the num is close to zero.
 
 .. spark:function:: floor(x) -> [same as x]
 

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -99,6 +99,10 @@ Mathematical Functions
 .. spark:function:: expm1(x) -> double
 
     Returns Euler's number raised to the power of ``x`` minus 1 and this function is more accurate than exp(num) - 1when the num is close to zero.
+    If the argument is NaN, the result is NaN.
+    If the argument is positive infinity, then the result is positive infinity.
+    If the argument is negative infinity, then the result is -1.0.
+    If the argument is zero, then the result is a zero with the same sign as the argument.
 
 .. spark:function:: floor(x) -> [same as x]
 

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -98,7 +98,7 @@ Mathematical Functions
 
 .. spark:function:: expm1(x) -> double
 
-    Returns Euler's number raised to the power of ``x`` minus 1, which is "exp(x)-1" in math, while this function is more accurate than exp(num) - 1 when the num is close to zero.
+    Returns Euler's number raised to the power of ``x``, minus 1, which is "exp(x)-1" in math, while this function is more accurate than exp(num) - 1 when the num is close to zero.
     If the argument is NaN, the result is NaN.
     If the argument is positive infinity, then the result is positive infinity.
     If the argument is negative infinity, then the result is -1.0.

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -98,7 +98,7 @@ Mathematical Functions
 
 .. spark:function:: expm1(x) -> double
 
-    Returns Euler's number raised to the power of ``x``, minus 1, which is ``exp(x) - 1`` in math. This function expm1(x) is more accurate than ``std::exp(x) - 1`` when ``x`` is close zero.
+    Returns Euler's number raised to the power of ``x``, minus 1, which is ``exp(x) - 1`` in math. This function expm1(x) is more accurate than ``exp(x) - 1``, when ``x`` is close to zero.
     If the argument is NaN, the result is NaN.
     If the argument is positive infinity, then the result is positive infinity.
     If the argument is negative infinity, then the result is -1.0.

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -98,7 +98,7 @@ Mathematical Functions
 
 .. spark:function:: expm1(x) -> double
 
-    Returns Euler's number raised to the power of ``x`` minus 1 and this function is more accurate than exp(num) - 1when the num is close to zero.
+    Returns Euler's number raised to the power of ``x`` minus 1 and this function is more accurate than exp(num) - 1 when the num is close to zero.
     If the argument is NaN, the result is NaN.
     If the argument is positive infinity, then the result is positive infinity.
     If the argument is negative infinity, then the result is -1.0.

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -98,7 +98,7 @@ Mathematical Functions
 
 .. spark:function:: expm1(x) -> double
 
-    Returns Euler's number raised to the power of ``x`` minus 1 and this function is more accurate than exp(num) - 1 when the num is close to zero.
+    Returns Euler's number raised to the power of ``x`` minus 1, which is "exp(x)-1" in math, while this function is more accurate than exp(num) - 1 when the num is close to zero.
     If the argument is NaN, the result is NaN.
     If the argument is positive infinity, then the result is positive infinity.
     If the argument is negative infinity, then the result is -1.0.

--- a/velox/functions/prestosql/Arithmetic.h
+++ b/velox/functions/prestosql/Arithmetic.h
@@ -241,13 +241,6 @@ struct ExpFunction {
 };
 
 template <typename T>
-struct Expm1Function {
-  FOLLY_ALWAYS_INLINE void call(double& result, double a) {
-    result = std::expm1(a);
-  }
-};
-
-template <typename T>
 struct MinFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE void

--- a/velox/functions/prestosql/Arithmetic.h
+++ b/velox/functions/prestosql/Arithmetic.h
@@ -241,6 +241,13 @@ struct ExpFunction {
 };
 
 template <typename T>
+struct Expm1Function {
+  FOLLY_ALWAYS_INLINE void call(double& result, double a) {
+    result = std::expm1(a);
+  }
+};
+
+template <typename T>
 struct MinFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE void

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -262,9 +262,12 @@ struct Log1pFunction {
   }
 };
 
-template <typename T>
+
 struct Expm1Function {
   FOLLY_ALWAYS_INLINE void call(double& result, double a) {
+    //std::expm1 is more accurate than the expression std::exp(num) - 1.0 if num is close to zero.
+    //Spark use java StrickMath we need to keep it as below
+    //this is aligned with https://docs.oracle.com/javase/8/docs/api/java/lang/StrictMath.html#expm1-double-
     result = std::expm1(a);
   }
 };

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -267,7 +267,7 @@ struct Expm1Function {
   FOLLY_ALWAYS_INLINE void call(double& result, double a) {
     // The std::expm1 is more accurate than the expression std::exp(num) - 1.0 if num is close to zero.
     // Spark use java StrickMath we need to keep it as below.
-    // https://docs.oracle.com/javase/8/docs/api/java/lang/StrictMath.html#expm1-double-
+    // Ref: https://docs.oracle.com/javase/8/docs/api/java/lang/StrictMath.html#expm1-double-.
     result = std::expm1(a);
   }
 };

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -266,7 +266,7 @@ template <typename T>
 struct Expm1Function {
   FOLLY_ALWAYS_INLINE void call(double& result, double a) {
     // The std::expm1 is more accurate than the expression std::exp(num) - 1.0 if num is close to zero.
-    // Spark uses Java's StrictMath we need to keep it as below.
+    // This matches Spark's implementation that uses java.lang.StrictMath.expm1 as below.
     // Ref: https://docs.oracle.com/javase/8/docs/api/java/lang/StrictMath.html#expm1-double-.
     result = std::expm1(a);
   }

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -263,6 +263,13 @@ struct Log1pFunction {
 };
 
 template <typename T>
+struct Expm1Function {
+  FOLLY_ALWAYS_INLINE void call(double& result, double a) {
+    result = std::expm1(a);
+  }
+};
+
+template <typename T>
 struct CotFunction {
   FOLLY_ALWAYS_INLINE void call(double& result, double a) {
     result = 1 / std::tan(a);

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -265,9 +265,9 @@ struct Log1pFunction {
 
 struct Expm1Function {
   FOLLY_ALWAYS_INLINE void call(double& result, double a) {
-    //std::expm1 is more accurate than the expression std::exp(num) - 1.0 if num is close to zero.
-    //Spark use java StrickMath we need to keep it as below
-    //this is aligned with https://docs.oracle.com/javase/8/docs/api/java/lang/StrictMath.html#expm1-double-
+    // The std::expm1 is more accurate than the expression std::exp(num) - 1.0 if num is close to zero.
+    // Spark use java StrickMath we need to keep it as below.
+    // https://docs.oracle.com/javase/8/docs/api/java/lang/StrictMath.html#expm1-double-
     result = std::expm1(a);
   }
 };

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -262,7 +262,7 @@ struct Log1pFunction {
   }
 };
 
-
+template <typename T>
 struct Expm1Function {
   FOLLY_ALWAYS_INLINE void call(double& result, double a) {
     // The std::expm1 is more accurate than the expression std::exp(num) - 1.0 if num is close to zero.

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -266,7 +266,7 @@ struct Log1pFunction {
 struct Expm1Function {
   FOLLY_ALWAYS_INLINE void call(double& result, double a) {
     // The std::expm1 is more accurate than the expression std::exp(num) - 1.0 if num is close to zero.
-    // Spark use java StrickMath we need to keep it as below.
+    // Spark uses Java's StrictMath we need to keep it as below.
     // Ref: https://docs.oracle.com/javase/8/docs/api/java/lang/StrictMath.html#expm1-double-.
     result = std::expm1(a);
   }

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -57,6 +57,7 @@ void registerArithmeticFunctions(const std::string& prefix) {
   registerFunction<ToHexVarbinaryFunction, Varchar, Varbinary>(
       {prefix + "hex"});
   registerFunction<ExpFunction, double, double>({prefix + "exp"});
+  registerFunction<Expm1Function, double, double>({prefix + "expm1"});
   registerBinaryIntegral<PModIntFunction>({prefix + "pmod"});
   registerBinaryFloatingPoint<PModFloatFunction>({prefix + "pmod"});
   registerFunction<PowerFunction, double, double, double>({prefix + "power"});

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -370,7 +370,7 @@ TEST_F(ArithmeticTest, expm1) {
   EXPECT_EQ(expm1(0), 0);
   EXPECT_EQ(expm1(1), kE - 1);
   // As this is only for high accuracy of little number, we use a little number 1e-12 which can give the difference. 
-  // If you use exp - 1, the value may be 1.000009e-12, while the true value should be below 1.000000000000005e-12.
+  // If you use std::exp(x) - 1, the value may be 1.000009e-12, while the true value should be below 1.000000000000005e-12.
   EXPECT_LT(expm1(1e-12), 1.00009e-12);
 }
 

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -360,12 +360,18 @@ TEST_F(ArithmeticTest, expm1) {
 
   const double kE = std::exp(1);
 
+  //If the argument is NaN, the result is NaN.
+  //If the argument is positive infinity, then the result is positive infinity.
+  //If the argument is negative infinity, then the result is -1.0.
+  //If the argument is zero, then the result is a zero with the same sign as the argument.
+  EXPECT_TRUE(std::isnan(expm1(kNan).value_or(0)));
+  EXPECT_EQ(expm1(kInf), kInf);
+  EXPECT_EQ(expm1(-kInf), -1);
   EXPECT_EQ(expm1(0), 0);
   EXPECT_EQ(expm1(1), kE - 1);
-  // As this is only for high accuracy of little number, this is just an example
-  EXPECT_LT(expm1(1e-10), 1.00000000005e-10);
-  EXPECT_EQ(expm1(kInf), kInf);
-  EXPECT_TRUE(std::isnan(expm1(kNan).value_or(0)));
+  // As this is only for high accuracy of little number, we use a little number 1e-12 which can give the difference. 
+  // If you use exp - 1, the value may be 1.000009e-12, while the true value should be below 1.000000000000005e-12
+  EXPECT_LT(expm1(1e-12), 1.00009e-12);
 }
 
 class BinTest : public SparkFunctionBaseTest {

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -360,17 +360,17 @@ TEST_F(ArithmeticTest, expm1) {
 
   const double kE = std::exp(1);
 
-  //If the argument is NaN, the result is NaN.
-  //If the argument is positive infinity, then the result is positive infinity.
-  //If the argument is negative infinity, then the result is -1.0.
-  //If the argument is zero, then the result is a zero with the same sign as the argument.
+  // If the argument is NaN, the result is NaN.
+  // If the argument is positive infinity, then the result is positive infinity.
+  // If the argument is negative infinity, then the result is -1.0.
+  // If the argument is zero, then the result is a zero with the same sign as the argument.
   EXPECT_TRUE(std::isnan(expm1(kNan).value_or(0)));
   EXPECT_EQ(expm1(kInf), kInf);
   EXPECT_EQ(expm1(-kInf), -1);
   EXPECT_EQ(expm1(0), 0);
   EXPECT_EQ(expm1(1), kE - 1);
   // As this is only for high accuracy of little number, we use a little number 1e-12 which can give the difference. 
-  // If you use exp - 1, the value may be 1.000009e-12, while the true value should be below 1.000000000000005e-12
+  // If you use exp - 1, the value may be 1.000009e-12, while the true value should be below 1.000000000000005e-12.
   EXPECT_LT(expm1(1e-12), 1.00009e-12);
 }
 

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -353,6 +353,21 @@ TEST_F(ArithmeticTest, log1p) {
   EXPECT_TRUE(std::isnan(log1p(kNan).value_or(0)));
 }
 
+TEST_F(ArithmetricTest, expm1) {
+  static const auto expm1 = [&](std::optional<double> a) {
+    return evaluateOnce<double>("expm1(c0)", a);
+  }
+
+  const double kE = std::exp(1);
+
+  EXPECT_EQ(expm1(0), 0);
+  EXPECT_EQ(expm1(1), kE - 1);
+  // As this is only for high accuracy of little number, this is just an example
+  EXPECT_LT(expm1(1e-10), 1.00000000005e-10);
+  EXPECT_EQ(expm1(kInf), kInf);
+  EXPECT_TRUE(std::isnan(expm1(kNan).value_or(0)));
+}
+
 class BinTest : public SparkFunctionBaseTest {
  protected:
   std::optional<std::string> bin(std::optional<std::int64_t> arg) {

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -353,10 +353,10 @@ TEST_F(ArithmeticTest, log1p) {
   EXPECT_TRUE(std::isnan(log1p(kNan).value_or(0)));
 }
 
-TEST_F(ArithmetricTest, expm1) {
+TEST_F(ArithmeticTest, expm1) {
   static const auto expm1 = [&](std::optional<double> a) {
     return evaluateOnce<double>("expm1(c0)", a);
-  }
+  };
 
   const double kE = std::exp(1);
 


### PR DESCRIPTION
Use std::expm1 for the implementation.

Fixes #9716 