### PR TITLE
Fix stemmer library when cmake < 3.18 is used

### DIFF
--- a/CMake/resolve_dependency_modules/stemmer.cmake
+++ b/CMake/resolve_dependency_modules/stemmer.cmake
@@ -44,7 +44,7 @@ ExternalProject_Add(
     ${STEMMER_PREFIX}/src/libstemmer/${CMAKE_STATIC_LIBRARY_PREFIX}stemmer${CMAKE_STATIC_LIBRARY_SUFFIX}
 )
 
-add_library(stemmer STATIC IMPORTED)
+add_library(stemmer STATIC IMPORTED GLOBAL)
 add_library(stemmer::stemmer ALIAS stemmer)
 file(MAKE_DIRECTORY ${STEMMER_INCLUDE_PATH})
 set_target_properties(


### PR DESCRIPTION
When cmake 3.16 is used, build velox fails with the below error.

``` 
CMake Error at CMake/resolve_dependency_modules/stemmer.cmake:48 (add_library):
  add_library cannot create ALIAS target "stemmer::stemmer" because target
  "stemmer" is imported but not globally visible.
Call Stack (most recent call first):
  CMake/ResolveDependency.cmake:43 (include)
  CMake/ResolveDependency.cmake:81 (build_dependency)
  CMakeLists.txt:557 (resolve_dependency)
```

I note [cmake doc](https://cmake.org/cmake/help/latest/command/add_library.html#alias-libraries) says, "New in version 3.18: An ALIAS can target a non-GLOBAL Imported Target".
So to allow using cmake before version 3.18, this pr proposes to explicitly set GLOBAL for the imported
stemmer target.