### PR TITLE
Remove error details from ExprSetListener::onError

### DIFF
--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -819,14 +819,10 @@ class ExprSetListener {
       const ExprSetCompletionEvent& event) = 0;
 
   /// Called when a batch of rows encounters errors processing one or more
-  /// rows in a try expression to provide information about these errors. This
-  /// function must neither change rows nor errors.
-  /// @param rows Rows where errors exist.
-  /// @param errors Error vector produced inside the try expression.
-  virtual void onError(
-      const SelectivityVector& rows,
-      const ErrorVector& errors,
-      const std::string& queryId) = 0;
+  /// rows in a try expression to provide information about these errors.
+  /// @param numRows Number of rows with errors.
+  /// @param queryId Query ID.
+  virtual void onError(vector_size_t numRows, const std::string& queryId) = 0;
 };
 
 /// Return the ExprSetListeners having been registered.

--- a/velox/expression/tests/ExpressionFuzzerVerifier.h
+++ b/velox/expression/tests/ExpressionFuzzerVerifier.h
@@ -139,10 +139,8 @@ class ExpressionFuzzerVerifier {
 
     // A no-op since we cannot tie errors directly to functions where they
     // occurred.
-    void onError(
-        const SelectivityVector& /*rows*/,
-        const ::facebook::velox::ErrorVector& /*errors*/,
-        const std::string& /*queryId*/) override {}
+    void onError(vector_size_t /*numRows*/, const std::string& /*queryId*/)
+        override {}
 
    private:
     std::unordered_map<std::string, ExprUsageStats>& exprNameToStats_;


### PR DESCRIPTION
Summary: Generating exceptions when evaluating under TRY is expensive. When many rows generate exceptions query performance degrades a lot.

Differential Revision: D56745982
