### PR TITLE
Introduce EvalCtx::captureErrorDetails flag

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -918,6 +918,8 @@ void CastExpr::evalSpecialForm(
   inTopLevel = true;
   if (nullOnFailure()) {
     ScopedVarSetter holder{context.mutableThrowOnError(), false};
+    ScopedVarSetter captureErrorDetails(
+        context.mutableCaptureErrorDetails(), false);
     apply(rows, input, context, fromType, toType, result);
   } else {
     apply(rows, input, context, fromType, toType, result);

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -192,12 +192,27 @@ class EvalCtx {
     errors_.reset();
   }
 
+  /// Boolean indicating whether exceptions that occur during expression
+  /// evaluation should be thrown directly or saved for later processing.
   bool throwOnError() const {
     return throwOnError_;
   }
 
   bool* mutableThrowOnError() {
     return &throwOnError_;
+  }
+
+  /// Boolean indicating whether to capture details when storing exceptions for
+  /// later processing (throwOnError_ == true).
+  ///
+  /// Conjunct expressions (AND, OR) require capturing error details, while TRY
+  /// and TRY_CAST expressions do not.
+  bool captureErrorDetails() const {
+    return captureErrorDetails_;
+  }
+
+  bool* mutableCaptureErrorDetails() {
+    return &captureErrorDetails_;
   }
 
   bool nullsPruned() const {
@@ -354,6 +369,8 @@ class EvalCtx {
   // behavior.
   bool nullsPruned_{false};
   bool throwOnError_{true};
+
+  bool captureErrorDetails_{true};
 
   // True if the current set of rows will not grow, e.g. not under and IF or OR.
   bool isFinalSelection_{true};

--- a/velox/expression/TryExpr.cpp
+++ b/velox/expression/TryExpr.cpp
@@ -23,6 +23,9 @@ void TryExpr::evalSpecialForm(
     EvalCtx& context,
     VectorPtr& result) {
   ScopedVarSetter throwOnError(context.mutableThrowOnError(), false);
+  ScopedVarSetter captureErrorDetails(
+      context.mutableCaptureErrorDetails(), false);
+
   // It's possible with nested TRY expressions that some rows already threw
   // exceptions in earlier expressions that haven't been handled yet. To avoid
   // incorrectly handling them here, store those errors and temporarily reset
@@ -42,6 +45,9 @@ void TryExpr::evalSpecialFormSimplified(
     EvalCtx& context,
     VectorPtr& result) {
   ScopedVarSetter throwOnError(context.mutableThrowOnError(), false);
+  ScopedVarSetter captureErrorDetails(
+      context.mutableCaptureErrorDetails(), false);
+
   // It's possible with nested TRY expressions that some rows already threw
   // exceptions in earlier expressions that haven't been handled yet. To avoid
   // incorrectly handling them here, store those errors and temporarily reset


### PR DESCRIPTION
Summary:
Introduce a flag in EvalCtx to distinguish cases where we need to capture
exception details from cases where it is sufficient to just note that an
exception occurred.

Use the new flag to optimize TRY and TRY_CAST by skipping construction of
exceptions. This optimization applies to errors reported via
EvalCtx::setStatus.

Differential Revision: D56717896
