### PR TITLE
Fix GTest includes in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -540,7 +540,7 @@ include_directories(SYSTEM velox/external)
 if(NOT VELOX_DISABLE_GOOGLETEST)
   set(gtest_SOURCE AUTO)
   resolve_dependency(gtest)
-  set(VELOX_GTEST_INCUDE_DIR
+  set(VELOX_GTEST_INCLUDE_DIR
       "${gtest_SOURCE_DIR}/googletest/include"
       PARENT_SCOPE)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -541,8 +541,7 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
   set(gtest_SOURCE AUTO)
   resolve_dependency(gtest)
   set(VELOX_GTEST_INCLUDE_DIR
-      "${gtest_SOURCE_DIR}/googletest/include"
-      PARENT_SCOPE)
+      "${gtest_SOURCE_DIR}/googletest/include")
 endif()
 
 set_source(xsimd)


### PR DESCRIPTION
Hello! I am filing a PR to fix a typo that broke `VELOX_GTEST_INCLUDE_DIR`.

This PR also removes `PARENT_SCOPE` because the variable is being set in a top-level `CMakeLists.txt` where no parent scope exists.