### PR TITLE
Disable COW for SSD checkpoint and evictlog files

### DIFF
--- a/velox/common/caching/SsdFile.h
+++ b/velox/common/caching/SsdFile.h
@@ -350,6 +350,9 @@ class SsdFile {
   // Maximum size of the backing file in kRegionSize units.
   const int32_t maxRegions_;
 
+  // True if copy on write should be disabled.
+  const bool disableFileCow_;
+
   // Serializes access to all private data members.
   mutable std::shared_mutex mutex_;
 


### PR DESCRIPTION
Summary:
On btrfs overwriting file's blocks causes file system to allocate more
and more new blocks, eventually taking the whole disk space, while the
file is being only fraction of it.
'copy on write' is already disabled for SSD cache file to prevent the
issue. It is also needed for checkpoint files and evictlog files.

Differential Revision: D56777422
