### PR TITLE
Add SSD cache file path to CacheInputStream::getName

### DIFF
--- a/velox/common/caching/SsdCache.h
+++ b/velox/common/caching/SsdCache.h
@@ -105,6 +105,10 @@ class SsdCache {
 
   std::string toString() const;
 
+  const std::string& filePrefix() const {
+    return filePrefix_;
+  }
+
  private:
   const std::string filePrefix_;
   const int32_t numShards_;

--- a/velox/common/caching/SsdFile.h
+++ b/velox/common/caching/SsdFile.h
@@ -272,6 +272,11 @@ class SsdFile {
   /// Returns true if copy on write is disabled for this file. Used in testing.
   bool testingIsCowDisabled() const;
 
+  /// Return the SSD file path.
+  const std::string& fileName() const {
+    return fileName_;
+  }
+
  private:
   // 4 first bytes of a checkpoint file. Allows distinguishing between format
   // versions.

--- a/velox/dwio/common/CacheInputStream.cpp
+++ b/velox/dwio/common/CacheInputStream.cpp
@@ -127,7 +127,13 @@ void CacheInputStream::seekToPosition(PositionProvider& seekPosition) {
 }
 
 std::string CacheInputStream::getName() const {
-  return fmt::format("CacheInputStream {} of {}", position_, region_.length);
+  std::string result =
+      fmt::format("CacheInputStream {} of {}", position_, region_.length);
+  auto ssdFile = ssdFileName();
+  if (!ssdFile.empty()) {
+    result += fmt::format(" ssdFile={}", ssdFile);
+  }
+  return result;
 }
 
 size_t CacheInputStream::positionSize() {
@@ -283,6 +289,14 @@ bool CacheInputStream::loadFromSsd(
   ioStats_->queryThreadIoLatency().increment(usec);
   entry.setExclusiveToShared();
   return true;
+}
+
+std::string CacheInputStream::ssdFileName() const {
+  auto ssdCache = cache_->ssdCache();
+  if (!ssdCache) {
+    return "";
+  }
+  return ssdCache->file(fileNum_).fileName();
 }
 
 void CacheInputStream::loadPosition() {

--- a/velox/dwio/common/CacheInputStream.h
+++ b/velox/dwio/common/CacheInputStream.h
@@ -109,6 +109,10 @@ class CacheInputStream : public SeekableInputStream {
       velox::common::Region region,
       cache::AsyncDataCacheEntry& entry);
 
+  // Return SSD cache file path if exists; return empty string if no SSD cache
+  // file.
+  std::string ssdFileName() const;
+
   CachedBufferedInput* const bufferedInput_;
   cache::AsyncDataCache* const cache_;
   IoStatistics* ioStats_;

--- a/velox/dwio/dwrf/test/CacheInputTest.cpp
+++ b/velox/dwio/dwrf/test/CacheInputTest.cpp
@@ -201,8 +201,15 @@ class CacheTest : public testing::Test {
               (1 << 20) - 11,
               (streamStarts_[streamIndex + 1] - streamStarts_[streamIndex]) /
                   2)};
-      data->streams.push_back(
-          data->input->enqueue(region, streamIds_[streamIndex].get()));
+      auto stream = data->input->enqueue(region, streamIds_[streamIndex].get());
+      if (cache_->ssdCache()) {
+        auto name = static_cast<const CacheInputStream&>(*stream).getName();
+        EXPECT_TRUE(
+            name.find("ssdFile=" + cache_->ssdCache()->filePrefix()) !=
+            name.npos)
+            << name;
+      }
+      data->streams.push_back(std::move(stream));
       data->regions.push_back(region);
     }
     return data;
@@ -424,6 +431,7 @@ TEST_F(CacheTest, window) {
   auto stream = input->read(begin, end - begin, LogType::TEST);
   auto cacheInput = dynamic_cast<CacheInputStream*>(stream.get());
   EXPECT_TRUE(cacheInput != nullptr);
+  ASSERT_EQ(cacheInput->getName(), "CacheInputStream 0 of 13631488");
   auto maxSize =
       allocator_->sizeClasses().back() * memory::AllocationTraits::kPageSize;
   const void* buffer;
@@ -501,8 +509,6 @@ TEST_F(CacheTest, ssd) {
   readFiles(
       "prefix1_", 0, kSsdBytes / bytesPerFile, 30, 100, 1, kStripesPerFile, 4);
 
-  LOG(INFO) << cache_->toString();
-
   waitForWrite();
   cache_->clear();
   // Read double this to get some eviction from SSD.
@@ -523,7 +529,6 @@ TEST_F(CacheTest, ssd) {
   // issued. Also, the head of each file does not get prefetched
   // because each file has its own tracker.
   EXPECT_LE(kSsdBytes / 8, ioStats_->prefetch().sum());
-  LOG(INFO) << cache_->toString();
 
   readFiles(
       "prefix1_",
@@ -534,7 +539,6 @@ TEST_F(CacheTest, ssd) {
       1,
       kStripesPerFile,
       4);
-  LOG(INFO) << cache_->toString();
 }
 
 TEST_F(CacheTest, singleFileThreads) {


### PR DESCRIPTION
Summary:
So that when SSD cache corruption happens, we can download the file and
analyze the difference between the file and remote file at that time to further
determine source of error.

Differential Revision: D56782655
