### PR TITLE
Remove backward compatibility option for nimble renaming

### DIFF
--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -45,11 +45,7 @@ enum class FileFormat {
   TEXT = 5,
   JSON = 6,
   PARQUET = 7,
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  ALPHA = 8,
-#else
   NIMBLE = 8,
-#endif
   ORC = 9,
 };
 


### PR DESCRIPTION
Summary:
Presto has adopted the new name NIMBLE in the code base, which is
causing test failures as NIMBLE cannot be found, when the flag
VELOX_ENABLE_BACKWARD_COMPATIBILITY is set to true.

Differential Revision: D56803216
