### PR TITLE
Re-enable map_top_n for fuzz testing

### DIFF
--- a/velox/expression/tests/ExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerTest.cpp
@@ -64,7 +64,6 @@ int main(int argc, char** argv) {
       "regexp_extract",
       "regexp_extract_all",
       "regexp_like",
-      "map_top_n", // https://github.com/facebookincubator/velox/issues/9497
   };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
   return FuzzerRunner::run(initialSeed, skipFunctions, {{}});


### PR DESCRIPTION
Summary: https://github.com/facebookincubator/velox/issues/9497 was fixed.

Differential Revision: D56820158
