### PR TITLE
Add initial table writer fuzzer

### DIFF
--- a/velox/common/file/FileSystems.cpp
+++ b/velox/common/file/FileSystems.cpp
@@ -77,7 +77,7 @@ class LocalFileSystem : public FileSystem {
     return "Local FS";
   }
 
-  inline std::string_view extractPath(std::string_view path) {
+  inline std::string_view extractPath(std::string_view path) override {
     if (path.find(kFileScheme) == 0) {
       return path.substr(kFileScheme.length());
     }

--- a/velox/common/file/FileSystems.h
+++ b/velox/common/file/FileSystems.h
@@ -57,6 +57,12 @@ class FileSystem {
   /// Returns the name of the File System
   virtual std::string name() const = 0;
 
+  /// Returns the file path without the fs scheme prefix such as "local:" prefix
+  /// for local file system.
+  virtual std::string_view extractPath(std::string_view path) {
+    VELOX_NYI();
+  }
+
   /// Returns a ReadFile handle for a given file path
   virtual std::unique_ptr<ReadFile> openFileForRead(
       std::string_view path,

--- a/velox/common/file/tests/FaultyFileSystem.cpp
+++ b/velox/common/file/tests/FaultyFileSystem.cpp
@@ -21,13 +21,6 @@
 
 namespace facebook::velox::tests::utils {
 namespace {
-// Extracts the delegated real file path by removing the faulty file system
-// scheme prefix.
-inline std::string extractPath(std::string_view path) {
-  VELOX_CHECK_EQ(path.find(FaultyFileSystem::scheme()), 0);
-  return std::string(path.substr(FaultyFileSystem::scheme().length()));
-}
-
 // Constructs the faulty file path based on the delegated read file 'path'. It
 // pre-appends the faulty file system scheme.
 inline std::string faultyPath(const std::string& path) {
@@ -63,7 +56,7 @@ fileSystemGenerator() {
 std::unique_ptr<ReadFile> FaultyFileSystem::openFileForRead(
     std::string_view path,
     const FileOptions& options) {
-  const std::string delegatedPath = extractPath(path);
+  const std::string delegatedPath = std::string(extractPath(path));
   auto delegatedFile = getFileSystem(delegatedPath, config_)
                            ->openFileForRead(delegatedPath, options);
   return std::make_unique<FaultyReadFile>(
@@ -75,7 +68,7 @@ std::unique_ptr<ReadFile> FaultyFileSystem::openFileForRead(
 std::unique_ptr<WriteFile> FaultyFileSystem::openFileForWrite(
     std::string_view path,
     const FileOptions& options) {
-  const std::string delegatedPath = extractPath(path);
+  const std::string delegatedPath = std::string(extractPath(path));
   auto delegatedFile = getFileSystem(delegatedPath, config_)
                            ->openFileForWrite(delegatedPath, options);
   return std::make_unique<FaultyWriteFile>(
@@ -85,7 +78,7 @@ std::unique_ptr<WriteFile> FaultyFileSystem::openFileForWrite(
 }
 
 void FaultyFileSystem::remove(std::string_view path) {
-  const std::string delegatedPath = extractPath(path);
+  const std::string delegatedPath = std::string(extractPath(path));
   getFileSystem(delegatedPath, config_)->remove(delegatedPath);
 }
 

--- a/velox/common/file/tests/FaultyFileSystem.h
+++ b/velox/common/file/tests/FaultyFileSystem.h
@@ -44,6 +44,14 @@ class FaultyFileSystem : public FileSystem {
     return "Faulty FS";
   }
 
+  // Extracts the delegated real file path by removing the faulty file system
+  // scheme prefix.
+  inline std::string_view extractPath(std::string_view path) override {
+    VELOX_CHECK_EQ(path.find(scheme()), 0, "");
+    const auto filePath = path.substr(scheme().length());
+    return getFileSystem(filePath, config_)->extractPath(filePath);
+  }
+
   std::unique_ptr<ReadFile> openFileForRead(
       std::string_view path,
       const FileOptions& options) override;

--- a/velox/docs/develop/testing/writer-fuzzer.rst
+++ b/velox/docs/develop/testing/writer-fuzzer.rst
@@ -1,0 +1,45 @@
+=============
+Writer Fuzzer
+=============
+
+Writer fuzzer tests table write plan with up to 5 regular columns and
+up to 3 partition keys.
+
+At each iteration, fuzzer randomly generate a table write plan with different
+table properties, as of now, only support partitioned and unpartitioned table.
+
+The fuzzer then generates inputs and runs the query plan and compares the
+results with PrestoDB.
+As of now, we compare:
+1. How many rows were written.
+2. Output directories have the same directory layout and hierarchy.
+
+How to run
+----------
+
+Use velox_writer_fuzzer_test binary to run join fuzzer:
+
+::
+
+    velox/exec/tests/velox_writer_fuzzer_test
+
+By default, the fuzzer will go through 10 interations. Use --steps
+or --duration-sec flag to run fuzzer for longer. Use --seed to
+reproduce fuzzer failures.
+
+Here is a full list of supported command line arguments.
+
+* ``–-steps``: How many iterations to run. Each iteration generates and
+  evaluates one tale writer plan. Default is 10.
+
+* ``–-duration_sec``: For how long to run in seconds. If both ``-–steps``
+  and ``-–duration_sec`` are specified, –duration_sec takes precedence.
+
+* ``–-seed``: The seed to generate random expressions and input vectors with.
+
+* ``–-batch_size``: The size of input vectors to generate. Default is 100.
+
+* ``--num_batches``: The number of input vectors of size `--batch_size` to
+  generate. Default is 5.
+
+If running from CLion IDE, add ``--logtostderr=1`` to see the full output.

--- a/velox/exec/fuzzer/CMakeLists.txt
+++ b/velox/exec/fuzzer/CMakeLists.txt
@@ -68,3 +68,15 @@ add_library(velox_join_fuzzer JoinFuzzer.cpp)
 
 target_link_libraries(velox_join_fuzzer velox_type velox_vector_fuzzer
                       velox_exec_test_lib velox_expression_test_utility)
+
+add_library(velox_writer_fuzzer WriterFuzzer.cpp)
+
+target_link_libraries(
+  velox_writer_fuzzer
+  velox_fuzzer_util
+  velox_type
+  velox_vector_fuzzer
+  velox_exec_test_lib
+  velox_expression_test_utility
+  velox_temp_path
+  velox_vector_test_lib)

--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -21,6 +21,8 @@
 #include "velox/common/base/Fs.h"
 #include "velox/common/encode/Base64.h"
 #include "velox/common/file/FileSystems.h"
+#include "velox/connectors/hive/HiveDataSink.h"
+#include "velox/connectors/hive/TableHandle.h"
 #include "velox/core/Expressions.h"
 #include "velox/dwio/common/WriterFactory.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"
@@ -34,16 +36,6 @@ using namespace facebook::velox;
 namespace facebook::velox::exec::test {
 
 namespace {
-
-template <typename T>
-T extractSingleValue(const std::vector<RowVectorPtr>& data) {
-  VELOX_CHECK_EQ(1, data.size());
-  VELOX_CHECK_EQ(1, data[0]->childrenSize());
-
-  auto simpleVector = data[0]->childAt(0)->as<SimpleVector<T>>();
-  VELOX_CHECK(!simpleVector->isNullAt(0));
-  return simpleVector->valueAt(0);
-}
 
 void writeToFile(
     const std::string& path,
@@ -177,6 +169,11 @@ std::optional<std::string> PrestoQueryRunner::toSql(
   if (const auto rowNumberNode =
           std::dynamic_pointer_cast<const core::RowNumberNode>(plan)) {
     return toSql(rowNumberNode);
+  }
+
+  if (auto tableWriteNode =
+          std::dynamic_pointer_cast<const core::TableWriteNode>(plan)) {
+    return toSql(tableWriteNode);
   }
 
   VELOX_NYI();
@@ -536,6 +533,38 @@ std::optional<std::string> PrestoQueryRunner::toSql(
   return sql.str();
 }
 
+std::optional<std::string> PrestoQueryRunner::toSql(
+    const std::shared_ptr<const core::TableWriteNode>& tableWriteNode) {
+  auto insertTableHandle =
+      std::dynamic_pointer_cast<connector::hive::HiveInsertTableHandle>(
+          tableWriteNode->insertTableHandle()->connectorInsertTableHandle());
+
+  // Returns a CTAS sql with specified table properties from TableWriteNode,
+  // example sql:
+  // CREATE TABLE tmp_write WITH (PARTITIONED_BY = ARRAY['p0'])
+  // AS SELECT * FROM tmp
+  std::stringstream sql;
+  sql << "CREATE TABLE tmp_write";
+  std::vector<std::string> partitionKeys;
+  for (auto i = 0; i < tableWriteNode->columnNames().size(); ++i) {
+    if (insertTableHandle->inputColumns()[i]->isPartitionKey()) {
+      partitionKeys.push_back(insertTableHandle->inputColumns()[i]->name());
+    }
+  }
+
+  if (insertTableHandle->isPartitioned()) {
+    sql << " WITH (PARTITIONED_BY = ARRAY[";
+    for (int i = 0; i < partitionKeys.size(); ++i) {
+      appendComma(i, sql);
+      sql << "'" << partitionKeys[i] << "'";
+    }
+    sql << "])";
+  }
+
+  sql << " AS SELECT * FROM tmp";
+  return sql.str();
+}
+
 std::multiset<std::vector<variant>> PrestoQueryRunner::execute(
     const std::string& sql,
     const std::vector<RowVectorPtr>& input,
@@ -608,6 +637,7 @@ std::vector<velox::RowVectorPtr> PrestoQueryRunner::executeVector(
 }
 
 std::vector<RowVectorPtr> PrestoQueryRunner::execute(const std::string& sql) {
+  LOG(INFO) << "Execute presto sql: " << sql;
   auto response = ServerResponse(startQuery(sql));
   response.throwIfFailed();
 

--- a/velox/exec/fuzzer/PrestoQueryRunner.h
+++ b/velox/exec/fuzzer/PrestoQueryRunner.h
@@ -23,6 +23,13 @@
 #include "velox/vector/ComplexVector.h"
 
 namespace facebook::velox::exec::test {
+template <typename T>
+T extractSingleValue(const std::vector<RowVectorPtr>& data) {
+  auto simpleVector = data[0]->childAt(0)->as<SimpleVector<T>>();
+  VELOX_CHECK(!simpleVector->isNullAt(0));
+  return simpleVector->valueAt(0);
+}
+
 class PrestoQueryRunner : public velox::exec::test::ReferenceQueryRunner {
  public:
   /// @param coordinatorUri Presto REST API endpoint, e.g. http://127.0.0.1:8080
@@ -58,7 +65,7 @@ class PrestoQueryRunner : public velox::exec::test::ReferenceQueryRunner {
 
   /// Executes Presto SQL query and returns the results. Tables referenced by
   /// the query must already exist.
-  std::vector<velox::RowVectorPtr> execute(const std::string& sql);
+  std::vector<velox::RowVectorPtr> execute(const std::string& sql) override;
 
   bool supportsVeloxVectorResults() const override;
 
@@ -88,6 +95,9 @@ class PrestoQueryRunner : public velox::exec::test::ReferenceQueryRunner {
 
   std::optional<std::string> toSql(
       const std::shared_ptr<const velox::core::RowNumberNode>& rowNumberNode);
+
+  std::optional<std::string> toSql(
+      const std::shared_ptr<const core::TableWriteNode>& tableWriteNode);
 
   std::string startQuery(const std::string& sql);
 

--- a/velox/exec/fuzzer/ReferenceQueryRunner.h
+++ b/velox/exec/fuzzer/ReferenceQueryRunner.h
@@ -50,6 +50,10 @@ class ReferenceQueryRunner {
       const RowTypePtr& resultType) {
     VELOX_UNSUPPORTED();
   }
+
+  virtual std::vector<velox::RowVectorPtr> execute(const std::string& sql) {
+    VELOX_UNSUPPORTED();
+  }
 };
 
 } // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/WriterFuzzer.cpp
+++ b/velox/exec/fuzzer/WriterFuzzer.cpp
@@ -1,0 +1,421 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/fuzzer/WriterFuzzer.h"
+
+#include <boost/random/uniform_int_distribution.hpp>
+
+#include "velox/dwio/dwrf/reader/DwrfReader.h"
+
+#include <unordered_set>
+#include "velox/common/base/Fs.h"
+#include "velox/common/encode/Base64.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/exec/fuzzer/PrestoQueryRunner.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/expression/fuzzer/FuzzerToolkit.h"
+#include "velox/vector/VectorSaver.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+DEFINE_int32(steps, 10, "Number of plans to generate and test.");
+
+DEFINE_int32(
+    duration_sec,
+    0,
+    "For how long it should run (in seconds). If zero, "
+    "it executes exactly --steps iterations and exits.");
+
+DEFINE_int32(
+    batch_size,
+    100,
+    "The number of elements on each generated vector.");
+
+DEFINE_int32(num_batches, 10, "The number of generated vectors.");
+
+DEFINE_double(
+    null_ratio,
+    0.1,
+    "Chance of adding a null value in a vector "
+    "(expressed as double from 0 to 1).");
+
+namespace facebook::velox::exec::test {
+
+namespace {
+
+class WriterFuzzer {
+ public:
+  WriterFuzzer(
+      size_t seed,
+      std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner);
+
+  void go();
+
+ private:
+  static VectorFuzzer::Options getFuzzerOptions() {
+    VectorFuzzer::Options opts;
+    opts.vectorSize = FLAGS_batch_size;
+    opts.stringLength = 10;
+    opts.nullRatio = FLAGS_null_ratio;
+    return opts;
+  }
+
+  void seed(size_t seed) {
+    currentSeed_ = seed;
+    vectorFuzzer_.reSeed(seed);
+    rng_.seed(currentSeed_);
+  }
+
+  void reSeed() {
+    seed(rng_());
+  }
+
+  // Generates at least one and up to 5 scalar columns to be used as regular
+  // columns of table write, Column names are generated using template
+  // '<prefix>N', where N is zero-based ordinal number of the column.
+  std::vector<std::string> generateColumns(
+      const std::string& prefix,
+      std::vector<std::string>& names,
+      std::vector<TypePtr>& types);
+
+  // Generates at least one and up to 3 scalar columns to be used as partition
+  // columns of table write, Column names are generated using template
+  // '<prefix>N', where N is zero-based ordinal number of the column.
+  std::vector<std::string> generatePartitionKeys(
+      const std::string& prefix,
+      std::vector<std::string>& names,
+      std::vector<TypePtr>& types);
+
+  // Generates input data for table write.
+  std::vector<RowVectorPtr> generateInputData(
+      std::vector<std::string> names,
+      std::vector<TypePtr> types,
+      size_t partitionOffset);
+
+  void verifyWriter(
+      const std::vector<RowVectorPtr>& input,
+      const std::vector<std::string>& partitionKeys,
+      const std::string& outputDirectoryPath);
+
+  // Executes velox query plan and returns the result.
+  RowVectorPtr execute(const core::PlanNodePtr& plan, int32_t maxDrivers = 2);
+
+  RowVectorPtr veloxToPrestoResult(const RowVectorPtr& result);
+
+  // Query Presto to find out table's location on disk.
+  std::string getReferenceOutputDirectoryPath(int32_t layers);
+
+  // Compares if two directories have same partitions
+  void comparePartitions(
+      const std::string& outputDirectoryPath,
+      const std::string& referenceOutputDirectoryPath);
+
+  // Returns all the partition names in tableDirectoryPath.
+  std::set<std::string> getPartitionNames(
+      const std::string& tableDirectoryPath);
+
+  FuzzerGenerator rng_;
+  size_t currentSeed_{0};
+  std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner_;
+  std::shared_ptr<memory::MemoryPool> rootPool_{
+      memory::memoryManager()->addRootPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{rootPool_->addLeafChild("leaf")};
+  VectorFuzzer vectorFuzzer_;
+};
+} // namespace
+
+void writerFuzzer(
+    size_t seed,
+    std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner) {
+  auto writerFuzzer = WriterFuzzer(seed, std::move(referenceQueryRunner));
+  writerFuzzer.go();
+}
+
+std::vector<std::string> listFolders(std::string_view path) {
+  std::vector<std::string> folders;
+  auto fileSystem = filesystems::getFileSystem("/", nullptr);
+  for (auto& p : std::filesystem::recursive_directory_iterator(
+           fileSystem->extractPath(path))) {
+    if (p.is_directory())
+      folders.push_back(p.path().string());
+  }
+  return folders;
+}
+
+namespace {
+template <typename T>
+bool isDone(size_t i, T startTime) {
+  if (FLAGS_duration_sec > 0) {
+    std::chrono::duration<double> elapsed =
+        std::chrono::system_clock::now() - startTime;
+    return elapsed.count() >= FLAGS_duration_sec;
+  }
+  return i >= FLAGS_steps;
+}
+
+WriterFuzzer::WriterFuzzer(
+    size_t initialSeed,
+    std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner)
+    : referenceQueryRunner_{std::move(referenceQueryRunner)},
+      vectorFuzzer_{getFuzzerOptions(), pool_.get()} {
+  seed(initialSeed);
+}
+
+void WriterFuzzer::go() {
+  VELOX_CHECK(
+      FLAGS_steps > 0 || FLAGS_duration_sec > 0,
+      "Either --steps or --duration_sec needs to be greater than zero.")
+
+  auto startTime = std::chrono::system_clock::now();
+  size_t iteration = 0;
+
+  while (!isDone(iteration, startTime)) {
+    LOG(INFO) << "==============================> Started iteration "
+              << iteration << " (seed: " << currentSeed_ << ")";
+
+    std::vector<std::string> names;
+    std::vector<TypePtr> types;
+    std::vector<std::string> partitionKeys;
+
+    generateColumns("c", names, types);
+    const auto partitionOffset = names.size();
+    // 50% of times test partitioned write.
+    if (vectorFuzzer_.coinToss(0.5)) {
+      partitionKeys = generatePartitionKeys("p", names, types);
+    }
+    auto input = generateInputData(names, types, partitionOffset);
+
+    auto tempDirPath = exec::test::TempDirectoryPath::create();
+    verifyWriter(input, partitionKeys, tempDirPath->getPath());
+
+    LOG(INFO) << "==============================> Done with iteration "
+              << iteration++;
+    reSeed();
+  }
+}
+
+std::vector<std::string> WriterFuzzer::generateColumns(
+    const std::string& prefix,
+    std::vector<std::string>& names,
+    std::vector<TypePtr>& types) {
+  static const std::vector<TypePtr> kNonFloatingPointTypes{
+      BOOLEAN(),
+      TINYINT(),
+      SMALLINT(),
+      INTEGER(),
+      BIGINT(),
+      VARCHAR(),
+      VARBINARY(),
+      TIMESTAMP(),
+  };
+
+  const auto numColumns =
+      boost::random::uniform_int_distribution<uint32_t>(1, 5)(rng_);
+  std::vector<std::string> columns;
+  for (auto i = 0; i < numColumns; ++i) {
+    columns.push_back(fmt::format("{}{}", prefix, i));
+
+    // Pick random, possibly complex, type.
+    types.push_back(vectorFuzzer_.randType(kNonFloatingPointTypes, 2));
+    names.push_back(columns.back());
+  }
+  return columns;
+}
+
+std::vector<std::string> WriterFuzzer::generatePartitionKeys(
+    const std::string& prefix,
+    std::vector<std::string>& names,
+    std::vector<TypePtr>& types) {
+  // Supported partition key column types
+  // According to VectorHasher::typeKindSupportsValueIds and
+  // https://github.com/prestodb/presto/blob/master/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java#L575
+  static const std::vector<TypePtr> kSupportedKeyTypes{
+      BOOLEAN(), TINYINT(), SMALLINT(), INTEGER(), BIGINT(), VARCHAR()};
+
+  const auto numKeys =
+      boost::random::uniform_int_distribution<uint32_t>(1, 3)(rng_);
+  std::vector<std::string> partitionKeys;
+  for (auto i = 0; i < numKeys; ++i) {
+    partitionKeys.push_back(fmt::format("{}{}", prefix, i));
+
+    // Pick random scalar type.
+    types.push_back(vectorFuzzer_.randType(kSupportedKeyTypes, 1));
+    names.push_back(partitionKeys.back());
+  }
+  return partitionKeys;
+}
+
+std::vector<RowVectorPtr> WriterFuzzer::generateInputData(
+    std::vector<std::string> names,
+    std::vector<TypePtr> types,
+    size_t partitionOffset) {
+  const auto size = vectorFuzzer_.getOptions().vectorSize;
+  auto inputType = ROW(std::move(names), std::move(types));
+  std::vector<RowVectorPtr> input;
+
+  // For partition keys, limit the distinct value to 4 to avoid exceeding
+  // partition number limit of 100. Since we could have up to 3 partition
+  // keys, it would generate up to 64 partitions.
+  std::vector<VectorPtr> partitionValues;
+  for (auto i = partitionOffset; i < inputType->size(); ++i) {
+    partitionValues.push_back(vectorFuzzer_.fuzz(inputType->childAt(i), 4));
+  }
+
+  for (auto i = 0; i < FLAGS_num_batches; ++i) {
+    std::vector<VectorPtr> children;
+    for (auto j = children.size(); j < inputType->size(); ++j) {
+      if (j < partitionOffset) {
+        // For regular columns.
+        children.push_back(vectorFuzzer_.fuzz(inputType->childAt(j), size));
+      } else {
+        // TODO Add other encoding support here besides DictionaryVector.
+        children.push_back(vectorFuzzer_.fuzzDictionary(
+            partitionValues.at(j - partitionOffset), size));
+      }
+    }
+    input.push_back(std::make_shared<RowVector>(
+        pool_.get(), inputType, nullptr, size, std::move(children)));
+  }
+
+  return input;
+}
+
+void WriterFuzzer::verifyWriter(
+    const std::vector<RowVectorPtr>& input,
+    const std::vector<std::string>& partitionKeys,
+    const std::string& outputDirectoryPath) {
+  const auto plan = PlanBuilder()
+                        .values(input)
+                        .tableWrite(outputDirectoryPath, partitionKeys)
+                        .planNode();
+
+  const auto maxDrivers =
+      boost::random::uniform_int_distribution<int32_t>(1, 16)(rng_);
+  const auto result = veloxToPrestoResult(execute(plan, maxDrivers));
+
+  const auto dropSql = "DROP TABLE IF EXISTS tmp_write";
+  const auto sql = referenceQueryRunner_->toSql(plan).value();
+  referenceQueryRunner_->execute(dropSql);
+  std::multiset<std::vector<variant>> expectedResult;
+  try {
+    expectedResult =
+        referenceQueryRunner_->execute(sql, input, plan->outputType());
+  } catch (...) {
+    LOG(WARNING) << "Query failed in the reference DB";
+    return;
+  }
+
+  // 1. Verifies the table writer output result: the inserted number of rows.
+  VELOX_CHECK_EQ(
+      expectedResult.size(), // Presto sql only produces one row which is how
+                             // many rows are inserted.
+      1,
+      "Query returned unexpected result in the reference DB");
+  VELOX_CHECK(
+      assertEqualResults(expectedResult, plan->outputType(), {result}),
+      "Velox and reference DB results don't match");
+
+  // 2. Verify directory layout.
+  const auto referencedOutputDirectoryPath =
+      getReferenceOutputDirectoryPath(partitionKeys.size());
+  comparePartitions(outputDirectoryPath, referencedOutputDirectoryPath);
+
+  LOG(INFO) << "Verified results against reference DB";
+}
+
+RowVectorPtr WriterFuzzer::execute(
+    const core::PlanNodePtr& plan,
+    int32_t maxDrivers) {
+  LOG(INFO) << "Executing query plan: " << std::endl
+            << plan->toString(true, true);
+  fuzzer::ResultOrError resultOrError;
+  AssertQueryBuilder builder(plan);
+  return builder.maxDrivers(maxDrivers).copyResults(pool_.get());
+}
+
+RowVectorPtr WriterFuzzer::veloxToPrestoResult(const RowVectorPtr& result) {
+  // Velox TableWrite node produces results of following layout
+  // row     fragments     context
+  // X         null          X
+  // null       X            X
+  // null       X            X
+  // Extract inserted rows from velox execution result.
+  std::vector<VectorPtr> insertedRows = {result->childAt(0)->slice(0, 1)};
+  return std::make_shared<RowVector>(
+      pool_.get(),
+      ROW({"count"}, {insertedRows[0]->type()}),
+      nullptr,
+      1,
+      insertedRows);
+}
+
+std::string WriterFuzzer::getReferenceOutputDirectoryPath(int32_t layers) {
+  auto filePath =
+      referenceQueryRunner_->execute("SELECT \"$path\" FROM tmp_write");
+  auto tableDirectoryPath =
+      fs::path(extractSingleValue<StringView>(filePath)).parent_path();
+  while (layers-- > 0) {
+    tableDirectoryPath = tableDirectoryPath.parent_path();
+  }
+  return tableDirectoryPath.string();
+}
+
+void WriterFuzzer::comparePartitions(
+    const std::string& outputDirectoryPath,
+    const std::string& referenceOutputDirectoryPath) {
+  const auto partitions = getPartitionNames(outputDirectoryPath);
+  LOG(INFO) << "Velox written partitions:" << std::endl;
+  for (const std::string& partition : partitions) {
+    LOG(INFO) << partition << std::endl;
+  }
+
+  const auto referencedPartitions =
+      getPartitionNames(referenceOutputDirectoryPath);
+  LOG(INFO) << "Presto written partitions:" << std::endl;
+  for (const std::string& partition : referencedPartitions) {
+    LOG(INFO) << partition << std::endl;
+  }
+
+  VELOX_CHECK(
+      partitions == referencedPartitions,
+      "Velox and reference DB output directory hierarchies don't match");
+}
+
+std::set<std::string> WriterFuzzer::getPartitionNames(
+    const std::string& tableDirectoryPath) {
+  auto fileSystem = filesystems::getFileSystem("/", nullptr);
+  auto directories = listFolders(tableDirectoryPath);
+  std::set<std::string> partitionNames;
+
+  for (std::string directory : directories) {
+    // Remove the path prefix to get the partition name
+    // For example: /test/tmp_write/p0=1/p1=2020
+    // partition name is /p0=1/p1=2020
+    directory.erase(0, fileSystem->extractPath(tableDirectoryPath).length());
+
+    // If it's a hidden directory, ignore
+    if (directory.find("/.") != std::string::npos) {
+      continue;
+    }
+
+    partitionNames.insert(directory);
+  }
+
+  return partitionNames;
+}
+
+} // namespace
+} // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/WriterFuzzer.h
+++ b/velox/exec/fuzzer/WriterFuzzer.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/fuzzer/ReferenceQueryRunner.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+DECLARE_bool(enable_window_reference_verification);
+
+namespace facebook::velox::exec::test {
+/// Runs the writer fuzzer.
+/// @param seed Random seed - Pass the same seed for reproducibility.
+/// @param referenceQueryRunner Reference query runner for results
+/// verification.
+void writerFuzzer(
+    size_t seed,
+    std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner);
+
+/// Returns all the folders in a local fs path recursively.
+std::vector<std::string> listFolders(std::string_view path);
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/WriterFuzzerRunner.h
+++ b/velox/exec/fuzzer/WriterFuzzerRunner.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/String.h>
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "velox/common/file/FileSystems.h"
+#include "velox/connectors/hive/HiveConnector.h"
+#include "velox/exec/fuzzer/WriterFuzzer.h"
+#include "velox/expression/fuzzer/FuzzerToolkit.h"
+#include "velox/parse/TypeResolver.h"
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+namespace facebook::velox::exec::test {
+
+static inline const std::string kHiveConnectorId = "test-hive";
+
+/// WriterFuzzerRunner leverages WriterFuzzer and VectorFuzzer to
+/// automatically generate and execute table writer tests.
+/// It works in following steps:
+///
+///  1. Pick different table write properties. Eg: partitioned.
+///  (TODO: bucketed, sorted).
+///  2. Generate corresponding table write query plan.
+///  3. Generate a random set of input data (vector).
+///  4. Execute the query plan.
+///  5. Generate corresponding sql in reference DB and execute the sql.
+///  6. Assert results from step 4 and 5 are the same.
+///  7. Rinse and repeat.
+///
+/// The common usage pattern is as following:
+///
+///  $ ./velox_writer_fuzzer_test --steps 10000
+///
+/// The important flags that control WriterFuzzer's behavior are:
+///
+///  --steps: how many iterations to run.
+///  --duration_sec: alternatively, for how many seconds it should run (takes
+///          precedence over --steps).
+///  --seed: pass a deterministic seed to reproduce the behavior (each iteration
+///          will print a seed as part of the logs).
+///  --batch_size: size of input vector batches generated.
+///
+/// e.g:
+///
+///  $ ./velox_writer_fuzzer_test \
+///         --steps 10000 \
+///         --seed 123
+
+class WriterFuzzerRunner {
+ public:
+  static int run(
+      size_t seed,
+      std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner) {
+    filesystems::registerLocalFileSystem();
+    auto hiveConnector =
+        connector::getConnectorFactory(
+            connector::hive::HiveConnectorFactory::kHiveConnectorName)
+            ->newConnector(
+                kHiveConnectorId, std::make_shared<core::MemConfig>());
+    connector::registerConnector(hiveConnector);
+    facebook::velox::exec::test::writerFuzzer(
+        seed, std::move(referenceQueryRunner));
+    // Calling gtest here so that it can be recognized as tests in CI systems.
+    return RUN_ALL_TESTS();
+  }
+};
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -83,7 +83,8 @@ add_executable(
   ValuesTest.cpp
   VectorHasherTest.cpp
   WindowFunctionRegistryTest.cpp
-  WindowTest.cpp)
+  WindowTest.cpp
+  WriterFuzzerUtilTest.cpp)
 
 add_executable(
   velox_exec_infra_test
@@ -132,6 +133,7 @@ target_link_libraries(
   velox_type
   velox_vector
   velox_vector_fuzzer
+  velox_writer_fuzzer
   velox_window
   Boost::atomic
   Boost::context

--- a/velox/exec/tests/WriterFuzzerUtilTest.cpp
+++ b/velox/exec/tests/WriterFuzzerUtilTest.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "velox/common/file/FileSystems.h"
+#include "velox/exec/fuzzer/WriterFuzzer.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec::test;
+
+TEST(WriterFuzzerUtilTest, listFolders) {
+  facebook::velox::filesystems::registerLocalFileSystem();
+  const auto tempFolder = exec::test::TempDirectoryPath::create();
+  // Directory layout:
+  // First layer:   dir1/   dir2/      dir3/    a
+  // Second layer:  b       dir2_1/
+  const auto dir1 = fmt::format("{}/dir1", tempFolder->getPath());
+  const auto dir2 = fmt::format("{}/dir2", tempFolder->getPath());
+  const auto dir2_1 = fmt::format("{}/dir2/dir2_1", tempFolder->getPath());
+  const auto dir3 = fmt::format("{}/dir3", tempFolder->getPath());
+  const auto a = fmt::format("{}/a", tempFolder->getPath());
+  const auto b = fmt::format("{}/dir1/b", tempFolder->getPath());
+
+  auto localFs = filesystems::getFileSystem(a, nullptr);
+  {
+    localFs->mkdir(dir1);
+    localFs->mkdir(dir2);
+    localFs->mkdir(dir2_1);
+    localFs->mkdir(dir3);
+    auto writeFile = localFs->openFileForWrite(a);
+    writeFile = localFs->openFileForWrite(b);
+  }
+  auto folder = listFolders(std::string_view(tempFolder->getPath()));
+  std::sort(folder.begin(), folder.end());
+  ASSERT_EQ(folder, std::vector<std::string>({dir1, dir2, dir2_1, dir3}));
+
+  localFs->remove(b);
+  localFs->remove(dir1);
+  folder = listFolders(std::string_view(tempFolder->getPath()));
+  std::sort(folder.begin(), folder.end());
+  ASSERT_EQ(folder, std::vector<std::string>({dir2, dir2_1, dir3}));
+
+  localFs->remove(dir2_1);
+  localFs->remove(dir2);
+  localFs->remove(dir3);
+  ASSERT_TRUE(listFolders(std::string_view(tempFolder->getPath())).empty());
+}

--- a/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
@@ -21,7 +21,6 @@
 
 #include "velox/exec/fuzzer/AggregationFuzzerOptions.h"
 #include "velox/exec/fuzzer/AggregationFuzzerRunner.h"
-#include "velox/exec/fuzzer/DuckQueryRunner.h"
 #include "velox/exec/fuzzer/PrestoQueryRunner.h"
 #include "velox/exec/fuzzer/TransformResultVerifier.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"

--- a/velox/functions/prestosql/fuzzer/CMakeLists.txt
+++ b/velox/functions/prestosql/fuzzer/CMakeLists.txt
@@ -37,3 +37,9 @@ target_link_libraries(
   velox_functions_prestosql
   gtest
   gtest_main)
+
+# Writer Fuzzer
+add_executable(velox_writer_fuzzer_test WriterFuzzerTest.cpp)
+
+target_link_libraries(velox_writer_fuzzer_test velox_writer_fuzzer
+                      velox_fuzzer_util gtest gtest_main)

--- a/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
@@ -19,7 +19,6 @@
 #include <gtest/gtest.h>
 #include <unordered_set>
 
-#include "velox/exec/fuzzer/DuckQueryRunner.h"
 #include "velox/exec/fuzzer/WindowFuzzerRunner.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/fuzzer/ApproxDistinctInputGenerator.h"

--- a/velox/functions/prestosql/fuzzer/WriterFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/WriterFuzzerTest.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/init/Init.h>
+#include <gflags/gflags.h>
+#include <gtest/gtest.h>
+
+#include "velox/exec/fuzzer/PrestoQueryRunner.h"
+#include "velox/exec/fuzzer/WriterFuzzerRunner.h"
+
+DEFINE_int64(
+    seed,
+    0,
+    "Initial seed for random number generator used to reproduce previous "
+    "results (0 means start with random seed).");
+
+DEFINE_string(
+    presto_url,
+    "",
+    "Presto coordinator URI along with port. If set, we use Presto "
+    "source of truth. Otherwise, use DuckDB. Example: "
+    "--presto_url=http://127.0.0.1:8080");
+
+DEFINE_uint32(
+    req_timeout_ms,
+    1000,
+    "Timeout in milliseconds for HTTP requests made to reference DB, "
+    "such as Presto. Example: --req_timeout_ms=2000");
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // Calls common init functions in the necessary order, initializing
+  // singletons, installing proper signal handlers for better debugging
+  // experience, and initialize glog and gflags.
+  folly::Init init(&argc, &argv);
+
+  facebook::velox::memory::MemoryManager::initialize({});
+
+  size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
+
+  using Runner = facebook::velox::exec::test::WriterFuzzerRunner;
+  using PrestoQueryRunner = facebook::velox::exec::test::PrestoQueryRunner;
+
+  VELOX_CHECK(
+      !FLAGS_presto_url.empty(),
+      "Table writer fuzzer only supports presto DB for now")
+  auto queryRunner = std::make_unique<PrestoQueryRunner>(
+      FLAGS_presto_url,
+      "writer_fuzzer",
+      static_cast<std::chrono::milliseconds>(FLAGS_req_timeout_ms));
+  LOG(INFO) << "Using Presto as the reference DB.";
+  return Runner::run(initialSeed, std::move(queryRunner));
+}


### PR DESCRIPTION
Table writer fuzzer randomly generates a table write plan with different table properties. 
As of now, we only support generating partitioned and unpartitioned table.

Verify the result with PrestoDB by comparing:
1. How many rows were written.
2. Output directories have the same directory layout and hierarchy.

Next steps:

- [ ] Verify the written data itself 
- [ ] Add support for more table properties: bucket and sort.
- [ ] Right now we have values as input, add table scan as the input 