### PR TITLE
Split Arithmetic Functions Registration

### DIFF
--- a/velox/functions/prestosql/registration/CMakeLists.txt
+++ b/velox/functions/prestosql/registration/CMakeLists.txt
@@ -14,7 +14,6 @@
 
 add_library(
   velox_functions_prestosql
-  ArithmeticFunctionsRegistration.cpp
   ArrayConcatRegistration.cpp
   ArrayFunctionsRegistration.cpp
   ArrayNGramsRegistration.cpp
@@ -27,6 +26,9 @@ add_library(
   HyperLogFunctionsRegistration.cpp
   JsonFunctionsRegistration.cpp
   MapFunctionsRegistration.cpp
+  MathematicalFunctionsRegistration.cpp
+  MathematicalOperatorsRegistration.cpp
+  ProbabilityTrigonometricFunctionsRegistration.cpp
   RegistrationFunctions.cpp
   StringFunctionsRegistration.cpp
   URLFunctionsRegistration.cpp)

--- a/velox/functions/prestosql/registration/MathematicalFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/MathematicalFunctionsRegistration.cpp
@@ -16,49 +16,13 @@
 #include "velox/functions/Registerer.h"
 #include "velox/functions/lib/RegistrationHelpers.h"
 #include "velox/functions/prestosql/Arithmetic.h"
-#include "velox/functions/prestosql/Bitwise.h"
 #include "velox/functions/prestosql/DecimalFunctions.h"
-#include "velox/functions/prestosql/Probability.h"
 #include "velox/functions/prestosql/Rand.h"
 
 namespace facebook::velox::functions {
 
 namespace {
-void registerSimpleFunctions(const std::string& prefix) {
-  registerBinaryFloatingPoint<PlusFunction>({prefix + "plus"});
-  registerFunction<
-      PlusFunction,
-      IntervalDayTime,
-      IntervalDayTime,
-      IntervalDayTime>({prefix + "plus"});
-  registerBinaryFloatingPoint<MinusFunction>({prefix + "minus"});
-  registerFunction<
-      MinusFunction,
-      IntervalDayTime,
-      IntervalDayTime,
-      IntervalDayTime>({prefix + "minus"});
-  registerBinaryFloatingPoint<MultiplyFunction>({prefix + "multiply"});
-  registerFunction<MultiplyFunction, IntervalDayTime, IntervalDayTime, int64_t>(
-      {prefix + "multiply"});
-  registerFunction<MultiplyFunction, IntervalDayTime, int64_t, IntervalDayTime>(
-      {prefix + "multiply"});
-  registerFunction<
-      IntervalMultiplyFunction,
-      IntervalDayTime,
-      IntervalDayTime,
-      double>({prefix + "multiply"});
-  registerFunction<
-      IntervalMultiplyFunction,
-      IntervalDayTime,
-      double,
-      IntervalDayTime>({prefix + "multiply"});
-  registerBinaryFloatingPoint<DivideFunction>({prefix + "divide"});
-  registerFunction<
-      IntervalDivideFunction,
-      IntervalDayTime,
-      IntervalDayTime,
-      double>({prefix + "divide"});
-  registerBinaryFloatingPoint<ModulusFunction>({prefix + "mod"});
+void registerMathFunctions(const std::string& prefix) {
   registerUnaryNumeric<CeilFunction>({prefix + "ceil", prefix + "ceiling"});
   registerUnaryNumeric<FloorFunction>({prefix + "floor"});
 
@@ -110,15 +74,6 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerFunction<LnFunction, double, double>({prefix + "ln"});
   registerFunction<Log2Function, double, double>({prefix + "log2"});
   registerFunction<Log10Function, double, double>({prefix + "log10"});
-  registerFunction<CosFunction, double, double>({prefix + "cos"});
-  registerFunction<CoshFunction, double, double>({prefix + "cosh"});
-  registerFunction<AcosFunction, double, double>({prefix + "acos"});
-  registerFunction<SinFunction, double, double>({prefix + "sin"});
-  registerFunction<AsinFunction, double, double>({prefix + "asin"});
-  registerFunction<TanFunction, double, double>({prefix + "tan"});
-  registerFunction<TanhFunction, double, double>({prefix + "tanh"});
-  registerFunction<AtanFunction, double, double>({prefix + "atan"});
-  registerFunction<Atan2Function, double, double, double>({prefix + "atan2"});
   registerFunction<SqrtFunction, double, double>({prefix + "sqrt"});
   registerFunction<CbrtFunction, double, double>({prefix + "cbrt"});
   registerFunction<
@@ -146,61 +101,19 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerFunction<TruncateFunction, double, double>({prefix + "truncate"});
   registerFunction<TruncateFunction, double, double, int32_t>(
       {prefix + "truncate"});
-  registerFunction<BetaCDFFunction, double, double, double, double>(
-      {prefix + "beta_cdf"});
-  registerFunction<NormalCDFFunction, double, double, double, double>(
-      {prefix + "normal_cdf"});
-  registerFunction<BinomialCDFFunction, double, int64_t, double, int64_t>(
-      {prefix + "binomial_cdf"});
-  registerFunction<BinomialCDFFunction, double, int32_t, double, int32_t>(
-      {prefix + "binomial_cdf"});
-  registerFunction<CauchyCDFFunction, double, double, double, double>(
-      {prefix + "cauchy_cdf"});
-  registerFunction<ChiSquaredCDFFunction, double, double, double>(
-      {prefix + "chi_squared_cdf"});
-  registerFunction<FCDFFunction, double, double, double, double>(
-      {prefix + "f_cdf"});
-  registerFunction<InverseBetaCDFFunction, double, double, double, double>(
-      {prefix + "inverse_beta_cdf"});
-  registerFunction<PoissonCDFFunction, double, double, int64_t>(
-      {prefix + "poisson_cdf"});
-  registerFunction<PoissonCDFFunction, double, double, int32_t>(
-      {prefix + "poisson_cdf"});
-  registerFunction<GammaCDFFunction, double, double, double, double>(
-      {prefix + "gamma_cdf"});
-  registerFunction<LaplaceCDFFunction, double, double, double, double>(
-      {prefix + "laplace_cdf"});
-  registerFunction<
-      WilsonIntervalUpperFunction,
-      double,
-      int64_t,
-      int64_t,
-      double>({prefix + "wilson_interval_upper"});
-  registerFunction<
-      WilsonIntervalLowerFunction,
-      double,
-      int64_t,
-      int64_t,
-      double>({prefix + "wilson_interval_lower"});
   registerFunction<
       CosineSimilarityFunction,
       double,
       Map<Varchar, double>,
       Map<Varchar, double>>({prefix + "cosine_similarity"});
-  registerFunction<WeibullCDFFunction, double, double, double, double>(
-      {prefix + "weibull_cdf"});
 }
 
 } // namespace
 
-void registerArithmeticFunctions(const std::string& prefix = "") {
-  registerSimpleFunctions(prefix);
+void registerMathematicalFunctions(const std::string& prefix = "") {
+  registerMathFunctions(prefix);
   VELOX_REGISTER_VECTOR_FUNCTION(udf_not, prefix + "not");
 
-  registerDecimalPlus(prefix);
-  registerDecimalMinus(prefix);
-  registerDecimalMultiply(prefix);
-  registerDecimalDivide(prefix);
   registerDecimalFloor(prefix);
   registerDecimalRound(prefix);
 }

--- a/velox/functions/prestosql/registration/MathematicalOperatorsRegistration.cpp
+++ b/velox/functions/prestosql/registration/MathematicalOperatorsRegistration.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/Registerer.h"
+#include "velox/functions/lib/RegistrationHelpers.h"
+#include "velox/functions/prestosql/Arithmetic.h"
+#include "velox/functions/prestosql/DecimalFunctions.h"
+
+namespace facebook::velox::functions {
+
+namespace {
+void registerMathOperators(const std::string& prefix = "") {
+  registerBinaryFloatingPoint<PlusFunction>({prefix + "plus"});
+  registerFunction<
+      PlusFunction,
+      IntervalDayTime,
+      IntervalDayTime,
+      IntervalDayTime>({prefix + "plus"});
+  registerBinaryFloatingPoint<MinusFunction>({prefix + "minus"});
+  registerFunction<
+      MinusFunction,
+      IntervalDayTime,
+      IntervalDayTime,
+      IntervalDayTime>({prefix + "minus"});
+  registerBinaryFloatingPoint<MultiplyFunction>({prefix + "multiply"});
+  registerFunction<MultiplyFunction, IntervalDayTime, IntervalDayTime, int64_t>(
+      {prefix + "multiply"});
+  registerFunction<MultiplyFunction, IntervalDayTime, int64_t, IntervalDayTime>(
+      {prefix + "multiply"});
+  registerFunction<
+      IntervalMultiplyFunction,
+      IntervalDayTime,
+      IntervalDayTime,
+      double>({prefix + "multiply"});
+  registerFunction<
+      IntervalMultiplyFunction,
+      IntervalDayTime,
+      double,
+      IntervalDayTime>({prefix + "multiply"});
+  registerBinaryFloatingPoint<DivideFunction>({prefix + "divide"});
+  registerFunction<
+      IntervalDivideFunction,
+      IntervalDayTime,
+      IntervalDayTime,
+      double>({prefix + "divide"});
+  registerBinaryFloatingPoint<ModulusFunction>({prefix + "mod"});
+}
+
+} // namespace
+
+void registerMathematicalOperators(const std::string& prefix = "") {
+  registerMathOperators(prefix);
+
+  registerDecimalPlus(prefix);
+  registerDecimalMinus(prefix);
+  registerDecimalMultiply(prefix);
+  registerDecimalDivide(prefix);
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/ProbabilityTrigonometricFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ProbabilityTrigonometricFunctionsRegistration.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/Registerer.h"
+#include "velox/functions/lib/RegistrationHelpers.h"
+#include "velox/functions/prestosql/Arithmetic.h"
+#include "velox/functions/prestosql/Probability.h"
+
+// Register Presto Probability, Trigonometric, and Statistical functions.
+
+namespace facebook::velox::functions {
+
+namespace {
+void registerProbTrigFunctions(const std::string& prefix) {
+  registerFunction<CosFunction, double, double>({prefix + "cos"});
+  registerFunction<CoshFunction, double, double>({prefix + "cosh"});
+  registerFunction<AcosFunction, double, double>({prefix + "acos"});
+  registerFunction<SinFunction, double, double>({prefix + "sin"});
+  registerFunction<AsinFunction, double, double>({prefix + "asin"});
+  registerFunction<TanFunction, double, double>({prefix + "tan"});
+  registerFunction<TanhFunction, double, double>({prefix + "tanh"});
+  registerFunction<AtanFunction, double, double>({prefix + "atan"});
+  registerFunction<Atan2Function, double, double, double>({prefix + "atan2"});
+
+  registerFunction<BetaCDFFunction, double, double, double, double>(
+      {prefix + "beta_cdf"});
+  registerFunction<NormalCDFFunction, double, double, double, double>(
+      {prefix + "normal_cdf"});
+  registerFunction<BinomialCDFFunction, double, int64_t, double, int64_t>(
+      {prefix + "binomial_cdf"});
+  registerFunction<BinomialCDFFunction, double, int32_t, double, int32_t>(
+      {prefix + "binomial_cdf"});
+  registerFunction<CauchyCDFFunction, double, double, double, double>(
+      {prefix + "cauchy_cdf"});
+  registerFunction<ChiSquaredCDFFunction, double, double, double>(
+      {prefix + "chi_squared_cdf"});
+  registerFunction<FCDFFunction, double, double, double, double>(
+      {prefix + "f_cdf"});
+  registerFunction<InverseBetaCDFFunction, double, double, double, double>(
+      {prefix + "inverse_beta_cdf"});
+  registerFunction<PoissonCDFFunction, double, double, int64_t>(
+      {prefix + "poisson_cdf"});
+  registerFunction<PoissonCDFFunction, double, double, int32_t>(
+      {prefix + "poisson_cdf"});
+  registerFunction<GammaCDFFunction, double, double, double, double>(
+      {prefix + "gamma_cdf"});
+  registerFunction<LaplaceCDFFunction, double, double, double, double>(
+      {prefix + "laplace_cdf"});
+  registerFunction<
+      WilsonIntervalUpperFunction,
+      double,
+      int64_t,
+      int64_t,
+      double>({prefix + "wilson_interval_upper"});
+  registerFunction<
+      WilsonIntervalLowerFunction,
+      double,
+      int64_t,
+      int64_t,
+      double>({prefix + "wilson_interval_lower"});
+
+  registerFunction<WeibullCDFFunction, double, double, double, double>(
+      {prefix + "weibull_cdf"});
+}
+
+} // namespace
+
+void registerProbabilityTrigonometryFunctions(const std::string& prefix = "") {
+  registerProbTrigFunctions(prefix);
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/RegistrationFunctions.cpp
+++ b/velox/functions/prestosql/registration/RegistrationFunctions.cpp
@@ -17,7 +17,9 @@
 
 namespace facebook::velox::functions {
 
-extern void registerArithmeticFunctions(const std::string& prefix);
+extern void registerMathematicalFunctions(const std::string& prefix);
+extern void registerMathematicalOperators(const std::string& prefix);
+extern void registerProbabilityTrigonometryFunctions(const std::string& prefix);
 extern void registerArrayFunctions(const std::string& prefix);
 extern void registerBitwiseFunctions(const std::string& prefix);
 extern void registerCheckedArithmeticFunctions(const std::string& prefix);
@@ -37,7 +39,9 @@ extern void registerInternalArrayFunctions();
 
 namespace prestosql {
 void registerArithmeticFunctions(const std::string& prefix) {
-  functions::registerArithmeticFunctions(prefix);
+  functions::registerMathematicalOperators(prefix);
+  functions::registerMathematicalFunctions(prefix);
+  functions::registerProbabilityTrigonometryFunctions(prefix);
 }
 
 void registerCheckedArithmeticFunctions(const std::string& prefix) {


### PR DESCRIPTION
Compiling a single ArithmeticFunctionsRegistration.cpp consumes a lot of memory.
Split the functions into three: MathematicalFunctions, MathematicalOperators, ProbabilityTrigonometricFunctions.
These categories are inspired by the Presto documentation and split the functions equally.
I see a 1/3 memory reduction on my local setup.
