### PR TITLE
Enhance hierarchical addition on exception context

### DIFF
--- a/velox/common/base/VeloxException.h
+++ b/velox/common/base/VeloxException.h
@@ -207,8 +207,8 @@ class VeloxException : public std::exception {
     return state_->context;
   }
 
-  const std::string& topLevelContext() const {
-    return state_->topLevelContext;
+  const std::string& additionalContext() const {
+    return state_->additionalContext;
   }
 
   const std::exception_ptr& wrappedException() const {
@@ -230,7 +230,7 @@ class VeloxException : public std::exception {
     // The current exception context.
     std::string context;
     // The top-level ancestor of the current exception context.
-    std::string topLevelContext;
+    std::string additionalContext;
     bool isRetriable;
     // The original std::exception.
     std::exception_ptr wrappedException;
@@ -352,6 +352,10 @@ struct ExceptionContext {
 
   /// Value to pass to `messageFunc`. Can be null.
   void* arg{nullptr};
+
+  /// If true, then the addition context in 'this' is always included when there
+  /// are hierarchical exception contexts.
+  bool isEssential{false};
 
   /// Pointer to the parent context when there are hierarchical exception
   /// contexts.

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -395,9 +395,10 @@ std::string Operator::toString() const {
   std::stringstream out;
   if (auto task = operatorCtx_->task()) {
     auto driverCtx = operatorCtx_->driverCtx();
-    out << operatorType() << "(" << operatorId() << ")<" << task->taskId()
-        << ":" << driverCtx->pipelineId << "." << driverCtx->driverId << " "
-        << this;
+    out << operatorType() << "(" << operatorId() << ")"
+        << " PlanNodeId: " << planNodeId() << " TaskId: " << task->taskId()
+        << " PipelineId: " << driverCtx->pipelineId
+        << " DriverId: " << driverCtx->driverId << " OperatorAddress: " << this;
   } else {
     out << "<Terminated, no task>";
   }

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -272,7 +272,7 @@ TEST_F(JsonFunctionsTest, jsonParse) {
     jsonParse(R"({"k1":})");
     FAIL() << "Error expected";
   } catch (const VeloxUserError& e) {
-    ASSERT_EQ(e.context(), "json_parse(c0)");
+    ASSERT_EQ(e.context(), "Top-level Expression: json_parse(c0)");
   }
 }
 


### PR DESCRIPTION
Summary:
Currently, VeloxExceptions have the ability to add additional context
from the top most level Exception context. This is useful for
debugging exceptions thrown during expression evaluation where we
want to know the current expression that threw it and the top level
one that contains it.
With this change, the "Top-level Context" concept is replaced by
"Additional Context", and a new field called "isEssential" is added
to the ExceptionContext to specify whether the context should always
be part of the exception when traversing the hierarchy. This
modification enables adding context at various levels within the
hierarchy.
Moreover, using this new method, extra details about the operator
and relevant metadata are now included in the exception to
facilitate debugging when queries fail due to runtime exceptions.

As an example, the exception thrown while executing an operator
will look like this:
```
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: Throwing exception
Retriable: False
Expression: false
Context: throwexception(c0)
Additional Context: Top-level Expression: plus(c0, throwexception(c0)) Operator: FilterProject(1) PlanNodeId: 1 TaskId: test_cursor 1 PipelineId: 0 DriverId: 0 OperatorAddress: 0x61a000003c80 
Function: call
File: fbcode/velox/exec/tests/DriverTest.cpp
Line: 1529
Stack trace:
```

Differential Revision: D56913321


