### PR TITLE
Fix data race when resetting lazy vector's consistency check

### DIFF
--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -795,7 +795,9 @@ class BaseVector {
   }
 
   void clearContainingLazyAndWrapped() {
-    containsLazyAndIsWrapped_ = false;
+    if (containsLazyAndIsWrapped_) {
+      containsLazyAndIsWrapped_ = false;
+    }
   }
 
   bool memoDisabled() const {
@@ -919,7 +921,7 @@ class BaseVector {
   // unloaded lazy vector should not be wrapped by two separate top level
   // vectors. This would ensure we avoid it being loaded for two separate set
   // of rows.
-  bool containsLazyAndIsWrapped_{false};
+  std::atomic_bool containsLazyAndIsWrapped_{false};
 
   // Whether we should use Expr::evalWithMemo to cache the result of evaluation
   // on dictionary values (this vector).  Set to false when the dictionary


### PR DESCRIPTION
Summary:
Lazy vector's consistency check is implemented using a member variable
`containsLazyAndIsWrapped_`. A recent change ensured that it is
reset whenever the encoding layer wrapping it is destroyed which
allows it to be wrapped again with another layer. This however
showed up as a data race under TSAN because a non-lazy vector can be
wrapped by multiple encoding layers at the same level and can
therefore be potentially  cleared concurrently when they are
destroyed. This change fixes that data race.

Differential Revision: D56942275


