### PR TITLE
UnitLoader supports initial rowsToSkip

### DIFF
--- a/velox/dwio/common/OnDemandUnitLoader.h
+++ b/velox/dwio/common/OnDemandUnitLoader.h
@@ -33,8 +33,8 @@ class OnDemandUnitLoaderFactory
   ~OnDemandUnitLoaderFactory() override = default;
 
   std::unique_ptr<velox::dwio::common::UnitLoader> create(
-      std::vector<std::unique_ptr<velox::dwio::common::LoadUnit>> loadUnits)
-      override;
+      std::vector<std::unique_ptr<velox::dwio::common::LoadUnit>> loadUnits,
+      uint64_t rowsToSkip) override;
 
  private:
   std::function<void(std::chrono::high_resolution_clock::duration)>

--- a/velox/dwio/common/UnitLoader.h
+++ b/velox/dwio/common/UnitLoader.h
@@ -62,7 +62,8 @@ class UnitLoaderFactory {
  public:
   virtual ~UnitLoaderFactory() = default;
   virtual std::unique_ptr<UnitLoader> create(
-      std::vector<std::unique_ptr<LoadUnit>> loadUnits) = 0;
+      std::vector<std::unique_ptr<LoadUnit>> loadUnits,
+      uint64_t rowsToSkip) = 0;
 };
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/tests/utils/UnitLoaderTestTools.h
+++ b/velox/dwio/common/tests/utils/UnitLoaderTestTools.h
@@ -74,7 +74,8 @@ class ReaderMock {
   ReaderMock(
       std::vector<uint64_t> rowsPerUnit,
       std::vector<uint64_t> ioSizes,
-      UnitLoaderFactory& factory);
+      UnitLoaderFactory& factory,
+      uint64_t rowsToSkip);
 
   bool read(uint64_t maxRows);
 
@@ -93,8 +94,8 @@ class ReaderMock {
   std::vector<uint64_t> ioSizes_;
   std::vector<std::atomic_bool> unitsLoaded_;
   std::unique_ptr<UnitLoader> loader_;
-  size_t currentUnit_{0};
-  size_t currentRowInUnit_{0};
+  size_t currentUnit_;
+  size_t currentRowInUnit_;
   std::optional<size_t> lastUnitLoaded_;
 };
 

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -308,7 +308,7 @@ std::unique_ptr<dwio::common::UnitLoader> DwrfRowReader::getUnitLoader() {
         std::make_shared<dwio::common::OnDemandUnitLoaderFactory>(
             options_.getBlockedOnIoCallback());
   }
-  return unitLoaderFactory->create(std::move(loadUnits));
+  return unitLoaderFactory->create(std::move(loadUnits), 0);
 }
 
 uint64_t DwrfRowReader::seekToRow(uint64_t rowNumber) {


### PR DESCRIPTION
Summary:
Modify interface to accept rowsToSkip.

Readers will soon support it.

Differential Revision: D56953541


