### PR TITLE
Handle ssd cache region score overflow

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -401,14 +401,14 @@ class TpchBenchmark {
 #endif
 
         if (cache_) {
-          cache_->clear();
+          cache_->testingClear();
         }
       }
       if (FLAGS_clear_ssd_cache) {
         if (cache_) {
           auto ssdCache = cache_->ssdCache();
           if (ssdCache) {
-            ssdCache->clear();
+            ssdCache->testingClear();
           }
         }
       }

--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -875,7 +875,7 @@ CacheStats AsyncDataCache::refreshStats() const {
   return stats;
 }
 
-void AsyncDataCache::clear() {
+void AsyncDataCache::testingClear() {
   for (auto& shard : shards_) {
     memory::Allocation unused;
     shard->evict(std::numeric_limits<uint64_t>::max(), true, 0, unused);

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -777,7 +777,7 @@ class AsyncDataCache : public memory::Cache {
   }
 
   // Drops all unpinned entries. Pins stay valid.
-  void clear();
+  void testingClear();
 
   // Saves all entries with 'ssdSaveable_' to 'ssdCache_'.
   void saveToSsd();

--- a/velox/common/caching/SsdCache.cpp
+++ b/velox/common/caching/SsdCache.cpp
@@ -171,9 +171,9 @@ SsdCacheStats SsdCache::stats() const {
   return stats;
 }
 
-void SsdCache::clear() {
+void SsdCache::testingClear() {
   for (auto& file : files_) {
-    file->clear();
+    file->testingClear();
   }
 }
 

--- a/velox/common/caching/SsdCache.h
+++ b/velox/common/caching/SsdCache.h
@@ -90,7 +90,7 @@ class SsdCache {
   /// Drops all entries. Outstanding pins become invalid but reading them will
   /// mostly succeed since the files will not be rewritten until new content is
   /// stored.
-  void clear();
+  void testingClear();
 
   /// Deletes backing files. Used in testing.
   void testingDeleteFiles();

--- a/velox/common/caching/SsdFile.cpp
+++ b/velox/common/caching/SsdFile.cpp
@@ -510,13 +510,14 @@ void SsdFile::updateStats(SsdCacheStats& stats) const {
   stats.readCheckpointErrors += stats_.readCheckpointErrors;
 }
 
-void SsdFile::clear() {
+void SsdFile::testingClear() {
   std::lock_guard<std::shared_mutex> l(mutex_);
   entries_.clear();
   std::fill(regionSizes_.begin(), regionSizes_.end(), 0);
   std::fill(erasedRegionSizes_.begin(), erasedRegionSizes_.end(), 0);
   writableRegions_.resize(numRegions_);
   std::iota(writableRegions_.begin(), writableRegions_.end(), 0);
+  tracker_.testingClear();
 }
 
 void SsdFile::deleteFile() {
@@ -863,8 +864,8 @@ void SsdFile::readCheckpoint(std::ifstream& state) {
       maxRegions_,
       "Trying to start from checkpoint with a different capacity");
   numRegions_ = readNumber<int32_t>(state);
-  std::vector<int64_t> scores(maxRegions);
-  state.read(asChar(scores.data()), maxRegions_ * sizeof(uint64_t));
+  std::vector<double> scores(maxRegions);
+  state.read(asChar(scores.data()), maxRegions_ * sizeof(double));
   std::unordered_map<uint64_t, StringIdLease> idMap;
   for (;;) {
     const auto id = readNumber<uint64_t>(state);

--- a/velox/common/caching/SsdFile.h
+++ b/velox/common/caching/SsdFile.h
@@ -250,7 +250,7 @@ class SsdFile {
   void updateStats(SsdCacheStats& stats) const;
 
   /// Resets this' to a post-construction empty state. See SsdCache::clear().
-  void clear();
+  void testingClear();
 
   // Deletes the backing file. Used in testing.
   void deleteFile();
@@ -275,6 +275,10 @@ class SsdFile {
   /// Return the SSD file path.
   const std::string& fileName() const {
     return fileName_;
+  }
+
+  std::vector<double> testingCopyScores() {
+    return tracker_.copyScores();
   }
 
  private:

--- a/velox/common/caching/SsdFileTracker.cpp
+++ b/velox/common/caching/SsdFileTracker.cpp
@@ -30,9 +30,9 @@ void SsdFileTracker::fileTouched(int32_t totalEntries) {
 }
 
 void SsdFileTracker::regionFilled(int32_t region) {
-  const uint64_t best =
+  const double best =
       *std::max_element(regionScores_.begin(), regionScores_.end());
-  regionScores_[region] = std::max<int64_t>(regionScores_[region], best * 1.1);
+  regionScores_[region] = std::max<double>(regionScores_[region], best * 1.1);
 }
 
 std::vector<int32_t> SsdFileTracker::findEvictionCandidates(
@@ -42,7 +42,7 @@ std::vector<int32_t> SsdFileTracker::findEvictionCandidates(
   // Calculates average score of regions with no pins. Returns up to
   // 'numCandidates' unpinned regions with score <= average, lowest scoring
   // region first.
-  int64_t scoreSum = 0;
+  double scoreSum = 0;
   int32_t numUnpinned = 0;
   for (int i = 0; i < numRegions; ++i) {
     if (regionPins[i] > 0) {

--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -637,7 +637,7 @@ TEST_F(AsyncDataCacheTest, pin) {
   EXPECT_EQ(0, stats.numShared);
   EXPECT_EQ(0, stats.numExclusive);
 
-  cache_->clear();
+  cache_->testingClear();
   stats = cache_->refreshStats();
   EXPECT_EQ(0, stats.largeSize);
   EXPECT_EQ(0, stats.numEntries);
@@ -816,7 +816,7 @@ TEST_F(AsyncDataCacheTest, DISABLED_ssd) {
   ASSERT_EQ(ramStats.numShared, 0);
   ASSERT_EQ(ramStats.numExclusive, 0);
 
-  cache_->ssdCache()->clear();
+  cache_->ssdCache()->testingClear();
   // We cut the tail off one of the cache shards.
   corruptFile(fmt::format("{}/cache0.cpt", tempDirectory_->getPath()));
   // We open the cache from checkpoint. Reading checks the data integrity, here

--- a/velox/dwio/dwrf/test/CacheInputTest.cpp
+++ b/velox/dwio/dwrf/test/CacheInputTest.cpp
@@ -495,7 +495,7 @@ TEST_F(CacheTest, ssd) {
   EXPECT_LT(0, ioStats_->rawOverreadBytes());
   auto fullStripeBytes = ioStats_->rawBytesRead();
   auto bytes = ioStats_->rawBytesRead();
-  cache_->clear();
+  cache_->testingClear();
   // We read 10 stripes with some columns sparsely accessed.
   readLoop("testfile", 30, 70, 10, 10, 1, ioStats_);
   auto sparseStripeBytes = (ioStats_->rawBytesRead() - bytes) / 10;
@@ -510,7 +510,7 @@ TEST_F(CacheTest, ssd) {
       "prefix1_", 0, kSsdBytes / bytesPerFile, 30, 100, 1, kStripesPerFile, 4);
 
   waitForWrite();
-  cache_->clear();
+  cache_->testingClear();
   // Read double this to get some eviction from SSD.
   readFiles(
       "prefix1_",

--- a/velox/exec/tests/PrintPlanWithStatsTest.cpp
+++ b/velox/exec/tests/PrintPlanWithStatsTest.cpp
@@ -235,7 +235,7 @@ TEST_F(PrintPlanWithStatsTest, partialAggregateWithTableScan) {
   const std::vector<int32_t> numPrefetchSplits = {0, 2};
   for (const auto& numPrefetchSplit : numPrefetchSplits) {
     SCOPED_TRACE(fmt::format("numPrefetchSplit {}", numPrefetchSplit));
-    asyncDataCache_->clear();
+    asyncDataCache_->testingClear();
     auto filePath = TempFilePath::create();
     writeToFile(filePath->getPath(), vectors);
 

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -83,7 +83,7 @@ void OperatorTestBase::setupMemory(
     int64_t memoryPoolInitCapacity,
     int64_t memoryPoolReservedCapacity) {
   if (asyncDataCache_ != nullptr) {
-    asyncDataCache_->clear();
+    asyncDataCache_->testingClear();
     asyncDataCache_.reset();
   }
   MemoryManagerOptions options;


### PR DESCRIPTION
When SsdFileTracker looks for regions to evict, it calculates average
score of all regions and picks regions with no pins and whose scores no
larger than the average as candidates. It first adds up all the scores
then divided it by the number of regions to calculate the average.
However, if the scores are large, the sum can overflow to a small
integer, leading to a scenario where none of the individual region
scores is less or equal to the average. When this happens, even when
all regions are unpinned, the ssd cache file will not be able to find
any candidates, blocking all cache writes.
Therefore, overflow needs to be handled properly.