### PR TITLE
Pass an executor to SsdFile

### DIFF
--- a/velox/common/caching/SsdCache.cpp
+++ b/velox/common/caching/SsdCache.cpp
@@ -60,7 +60,8 @@ SsdCache::SsdCache(
         i,
         fileMaxRegions,
         checkpointIntervalBytes / numShards,
-        disableFileCow));
+        disableFileCow,
+        executor_));
   }
 }
 


### PR DESCRIPTION
Checkpoint relies on the executor to schedule a potentially long
fsync of cache file on another thread. Currently it is not set.