### PR TITLE
More Cuda Metrics

### DIFF
--- a/velox/experimental/wave/common/Block.cuh
+++ b/velox/experimental/wave/common/Block.cuh
@@ -26,6 +26,7 @@
 
 namespace facebook::velox::wave {
 
+  /// Converts an array of flags to an array of indices of set flags. The first index is given by 'start'. The number of indices is returned in 'size', i.e. this is 1 + the index of the last set flag.
 template <
     typename T,
     int32_t blockSize,
@@ -56,7 +57,7 @@ boolBlockToIndices(Getter getter, T start, T* indices, void* shmem, T& size) {
   T aggregate;
   BlockScanT(*temp).ExclusiveSum(data, data, aggregate);
   if (flag) {
-    indices[data[0]] = threadIdx.x + start;
+    indices[data[0]] = threadIdx.x + start; 
   }
   if (threadIdx.x == 0) {
     size = aggregate;
@@ -64,6 +65,50 @@ boolBlockToIndices(Getter getter, T start, T* indices, void* shmem, T& size) {
   __syncthreads();
 }
 
+  inline int32_t __device__ __host__ bool256ToIndicesSize() {
+  return sizeof(typename cub::WarpScan<uint16_t>::TempStorage) + 33 * sizeof(uint16_t);
+}
+
+  /// Returns indices of set bits for 256 one byte flags. 'getter8' is
+  /// invoked for 8 flags at a time, with the ordinal of the 8 byte
+  /// flags word as argument, so that an index of 1 means flags
+  /// 8..15. The indices start at 'start' and last index + 1 is
+  /// returned in 'size'.
+template <
+    typename T,
+  typename Getter8>
+__device__ inline void
+bool256ToIndices(Getter8 getter8, T start, T* indices, T& size,
+		 char* smem) {
+  using Scan = cub::WarpScan<uint16_t>;
+  auto* smem16 = reinterpret_cast<uint16_t*>(smem);
+  int32_t group = threadIdx.x / 8;
+  uint64_t bits = getter8(group) & 0x0101010101010101;
+  if ((threadIdx.x & 7) == 0) {
+    smem16[group] = __popcll(bits);
+    if (threadIdx.x == blockDim.x - 8) {
+      smem16[32] = smem16[31];
+    }
+  }
+  __syncthreads();
+  if (threadIdx.x < 32) {
+    auto* temp = reinterpret_cast<typename Scan::TempStorage*>((smem + 72));
+    uint16_t data = smem16[threadIdx.x];
+    Scan(*temp).ExclusiveSum(data, data);
+    smem16[threadIdx.x] = data;
+  }
+  __syncthreads();
+  int32_t tidInGroup = threadIdx.x & 7;
+  if (bits & (1UL << (tidInGroup * 8))) {
+    int32_t base = smem16[group]  + __popcll(bits & lowMask<uint64_t>(tidInGroup * 8));
+    indices[base] = threadIdx.x + start; 
+  }
+  if (threadIdx.x == 0) {
+    size = smem16[31] + smem16[32];
+  }
+  __syncthreads();
+}
+  
 template <int32_t blockSize, typename T, typename Getter>
 __device__ inline void blockSum(Getter getter, void* shmem, T* result) {
   typedef cub::BlockReduce<T, blockSize> BlockReduceT;

--- a/velox/experimental/wave/common/tests/BlockTest.cpp
+++ b/velox/experimental/wave/common/tests/BlockTest.cpp
@@ -48,6 +48,117 @@ class BlockTest : public testing::Test {
   void prefetch(Stream& stream, WaveBufferPtr buffer) {
     stream.prefetch(device_, buffer->as<char>(), buffer->capacity());
   }
+  void testBoolToIndices(bool use256) {
+    /// We make a set of 256 flags and corresponding 256 indices of true flags.
+    constexpr int32_t kNumBlocks = 20480;
+    constexpr int32_t kBlockSize = 256;
+    constexpr int32_t kNumFlags = kBlockSize * kNumBlocks;
+    auto flagsBuffer = arena_->allocate<uint8_t>(kNumFlags);
+    auto indicesBuffer = arena_->allocate<int32_t>(kNumFlags);
+    auto sizesBuffer = arena_->allocate<int32_t>(kNumBlocks);
+    BlockTestStream stream;
+
+    std::vector<int32_t> referenceIndices(kNumFlags);
+    std::vector<int32_t> referenceSizes(kNumBlocks);
+    uint8_t* flags = flagsBuffer->as<uint8_t>();
+    for (auto i = 0ul; i < kNumFlags; ++i) {
+      if ((i >> 8) % 17 == 0) {
+        flags[i] = 0;
+      } else if ((i >> 8) % 23 == 0) {
+        flags[i] = 1;
+      } else {
+        flags[i] = (i * 1121) % 73 > 50;
+      }
+    }
+    for (auto b = 0; b < kNumBlocks; ++b) {
+      auto start = b * kBlockSize;
+      int32_t counter = start;
+      for (auto i = 0; i < kBlockSize; ++i) {
+        if (flags[start + i]) {
+          referenceIndices[counter++] = start + i;
+        }
+      }
+      referenceSizes[b] = counter - start;
+    }
+
+    prefetch(stream, flagsBuffer);
+    prefetch(stream, indicesBuffer);
+    prefetch(stream, sizesBuffer);
+    stream.wait();
+    auto indicesPointers = arena_->allocate<void*>(kNumBlocks);
+    auto flagsPointers = arena_->allocate<void*>(kNumBlocks);
+    for (auto i = 0; i < kNumBlocks; ++i) {
+      flagsPointers->as<uint8_t*>()[i] = flags + (i * kBlockSize);
+      indicesPointers->as<int32_t*>()[i] =
+          indicesBuffer->as<int32_t>() + (i * kBlockSize);
+    }
+
+    prefetch(stream, flagsBuffer);
+    prefetch(stream, indicesBuffer);
+    prefetch(stream, sizesBuffer);
+    stream.wait();
+    auto startMicros = getCurrentTimeMicro();
+    if (use256) {
+      stream.testBool256ToIndices(
+          kNumBlocks,
+          flagsPointers->as<uint8_t*>(),
+          indicesPointers->as<int32_t*>(),
+          sizesBuffer->as<int32_t>());
+
+    } else {
+      stream.testBoolToIndices(
+          kNumBlocks,
+          flagsPointers->as<uint8_t*>(),
+          indicesPointers->as<int32_t*>(),
+          sizesBuffer->as<int32_t>());
+    }
+    stream.wait();
+    auto elapsed = getCurrentTimeMicro() - startMicros;
+    for (auto b = 0; b < kNumBlocks; ++b) {
+      auto* reference = referenceIndices.data() + b * kBlockSize;
+      auto* actual = indicesBuffer->as<int32_t>() + b * kBlockSize;
+      auto* referenceSizesData = referenceSizes.data();
+      auto* actualSizes = sizesBuffer->as<int32_t>();
+      ASSERT_EQ(
+          0, ::memcmp(reference, actual, referenceSizes[b] * sizeof(int32_t)));
+      ASSERT_EQ(referenceSizesData[b], actualSizes[b]);
+    }
+    std::cout << "Flags " << (use256 ? "256" : "") << " to indices: " << elapsed
+              << "us, " << kNumFlags / static_cast<float>(elapsed) << " Mrows/s"
+              << std::endl;
+
+    auto temp = arena_->allocate<char>(
+        BlockTestStream::boolToIndicesSize() * kNumBlocks);
+    prefetch(stream, temp);
+    prefetch(stream, flagsBuffer);
+    prefetch(stream, indicesBuffer);
+    prefetch(stream, sizesBuffer);
+    stream.wait();
+
+    startMicros = getCurrentTimeMicro();
+    if (use256) {
+      stream.testBool256ToIndicesNoShared(
+          kNumBlocks,
+          flagsPointers->as<uint8_t*>(),
+          indicesPointers->as<int32_t*>(),
+          sizesBuffer->as<int32_t>(),
+          temp->as<char>());
+    } else {
+      stream.testBoolToIndicesNoShared(
+          kNumBlocks,
+          flagsPointers->as<uint8_t*>(),
+          indicesPointers->as<int32_t*>(),
+          sizesBuffer->as<int32_t>(),
+          temp->as<char>());
+    }
+    stream.wait();
+    elapsed = getCurrentTimeMicro() - startMicros;
+    std::cout << "Flags " << (use256 ? "256" : "") << " to indices: "
+              << " to indices no smem: " << elapsed << "us, "
+              << kNumFlags / static_cast<float>(elapsed) << " Mrows/s"
+              << std::endl;
+  }
+
   void makePartitionRun(
       int32_t numRows,
       int32_t numPartitions,
@@ -108,88 +219,8 @@ class BlockTest : public testing::Test {
 };
 
 TEST_F(BlockTest, boolToIndices) {
-  /// We make a set of 256 flags and corresponding 256 indices of true flags.
-  constexpr int32_t kNumBlocks = 20480;
-  constexpr int32_t kBlockSize = 256;
-  constexpr int32_t kNumFlags = kBlockSize * kNumBlocks;
-  auto flagsBuffer = arena_->allocate<uint8_t>(kNumFlags);
-  auto indicesBuffer = arena_->allocate<int32_t>(kNumFlags);
-  auto sizesBuffer = arena_->allocate<int32_t>(kNumBlocks);
-  auto timesBuffer = arena_->allocate<int64_t>(kNumBlocks);
-  BlockTestStream stream;
-
-  std::vector<int32_t> referenceIndices(kNumFlags);
-  std::vector<int32_t> referenceSizes(kNumBlocks);
-  uint8_t* flags = flagsBuffer->as<uint8_t>();
-  for (auto i = 0ul; i < kNumFlags; ++i) {
-    if ((i >> 8) % 17 == 0) {
-      flags[i] = 0;
-    } else if ((i >> 8) % 23 == 0) {
-      flags[i] = 1;
-    } else {
-      flags[i] = (i * 1121) % 73 > 50;
-    }
-  }
-  for (auto b = 0; b < kNumBlocks; ++b) {
-    auto start = b * kBlockSize;
-    int32_t counter = start;
-    for (auto i = 0; i < kBlockSize; ++i) {
-      if (flags[start + i]) {
-        referenceIndices[counter++] = start + i;
-      }
-    }
-    referenceSizes[b] = counter - start;
-  }
-
-  prefetch(stream, flagsBuffer);
-  prefetch(stream, indicesBuffer);
-  prefetch(stream, sizesBuffer);
-
-  auto indicesPointers = arena_->allocate<void*>(kNumBlocks);
-  auto flagsPointers = arena_->allocate<void*>(kNumBlocks);
-  for (auto i = 0; i < kNumBlocks; ++i) {
-    flagsPointers->as<uint8_t*>()[i] = flags + (i * kBlockSize);
-    indicesPointers->as<int32_t*>()[i] =
-        indicesBuffer->as<int32_t>() + (i * kBlockSize);
-  }
-
-  auto startMicros = getCurrentTimeMicro();
-  stream.testBoolToIndices(
-      kNumBlocks,
-      flagsPointers->as<uint8_t*>(),
-      indicesPointers->as<int32_t*>(),
-      sizesBuffer->as<int32_t>(),
-      timesBuffer->as<int64_t>());
-  stream.wait();
-  auto elapsed = getCurrentTimeMicro() - startMicros;
-  for (auto b = 0; b < kNumBlocks; ++b) {
-    ASSERT_EQ(
-        0,
-        ::memcmp(
-            referenceIndices.data() + b * kBlockSize,
-            indicesBuffer->as<int32_t>() + b * kBlockSize,
-            referenceSizes[b] * sizeof(int32_t)));
-    ASSERT_EQ(referenceSizes[b], sizesBuffer->as<int32_t>()[b]);
-  }
-  std::cout << "Flags to indices: " << elapsed << "us, "
-            << kNumFlags / static_cast<float>(elapsed) << " Mrows/s"
-            << std::endl;
-
-  auto temp =
-      arena_->allocate<char>(BlockTestStream::boolToIndicesSize() * kNumBlocks);
-  startMicros = getCurrentTimeMicro();
-  stream.testBoolToIndicesNoShared(
-      kNumBlocks,
-      flagsPointers->as<uint8_t*>(),
-      indicesPointers->as<int32_t*>(),
-      sizesBuffer->as<int32_t>(),
-      timesBuffer->as<int64_t>(),
-      temp->as<char>());
-  stream.wait();
-  elapsed = getCurrentTimeMicro() - startMicros;
-  std::cout << "Flags to indices no smem: " << elapsed << "us, "
-            << kNumFlags / static_cast<float>(elapsed) << " Mrows/s"
-            << std::endl;
+  testBoolToIndices(false);
+  testBoolToIndices(true);
 }
 
 TEST_F(BlockTest, shortRadixSort) {
@@ -201,7 +232,6 @@ TEST_F(BlockTest, shortRadixSort) {
   constexpr int32_t kNumValues = kBlockSize * kNumBlocks * kValuesPerThread;
   auto keysBuffer = arena_->allocate<uint16_t>(kNumValues);
   auto valuesBuffer = arena_->allocate<int16_t>(kNumValues);
-  auto timesBuffer = arena_->allocate<int64_t>(kNumBlocks);
   BlockTestStream stream;
 
   std::vector<uint16_t> referenceKeys(kNumValues);
@@ -237,7 +267,9 @@ TEST_F(BlockTest, shortRadixSort) {
   }
   auto keySegments = keysPointers->as<uint16_t*>();
   auto valueSegments = valuesPointers->as<uint16_t*>();
-
+  prefetch(stream, keysPointers);
+  prefetch(stream, valuesPointers);
+  stream.wait();
   auto startMicros = getCurrentTimeMicro();
   stream.testSort16(kNumBlocks, keySegments, valueSegments);
   stream.wait();
@@ -251,6 +283,28 @@ TEST_F(BlockTest, shortRadixSort) {
             kValuesPerBlock * sizeof(uint16_t)));
   }
   std::cout << "sort16: " << elapsed << "us, "
+            << kNumValues / static_cast<float>(elapsed) << " Mrows/s"
+            << std::endl;
+
+  // Reset the test values for second test.
+  for (auto i = 0; i < kNumValues; ++i) {
+    keys[i] = i * 2017;
+    values[i] = i;
+  }
+  auto temp =
+      arena_->allocate<char>(kNumBlocks * BlockTestStream::sort16SharedSize());
+  prefetch(stream, temp);
+  prefetch(stream, valuesBuffer);
+  prefetch(stream, keysBuffer);
+  prefetch(stream, keysPointers);
+  prefetch(stream, valuesPointers);
+  stream.wait();
+  startMicros = getCurrentTimeMicro();
+  stream.testSort16NoShared(
+      kNumBlocks, keySegments, valueSegments, temp->as<char>());
+  stream.wait();
+  elapsed = getCurrentTimeMicro() - startMicros;
+  std::cout << "sort16 no shared: " << elapsed << "us, "
             << kNumValues / static_cast<float>(elapsed) << " Mrows/s"
             << std::endl;
 }

--- a/velox/experimental/wave/common/tests/BlockTest.h
+++ b/velox/experimental/wave/common/tests/BlockTest.h
@@ -76,24 +76,45 @@ class BlockTestStream : public Stream {
       int32_t numBlocks,
       uint8_t** flags,
       int32_t** indices,
-      int32_t* sizes,
-      int64_t* times);
+      int32_t* sizes);
   void testBoolToIndicesNoShared(
       int32_t numBlocks,
       uint8_t** flags,
       int32_t** indices,
       int32_t* sizes,
-      int64_t* times,
       void*);
 
   // Returns the smem size for block size 256 of boolToIndices().
   static int32_t boolToIndicesSize();
 
+  void testBool256ToIndices(
+      int32_t numBlocks,
+      uint8_t** flags,
+      int32_t** indices,
+      int32_t* sizes);
+
+  void testBool256ToIndicesNoShared(
+      int32_t numBlocks,
+      uint8_t** flags,
+      int32_t** indices,
+      int32_t* sizes,
+      void*);
+
+  // Returns the smem size for bool256ToIndices().
+  static int32_t bool256ToIndicesSize();
+
   // calculates the sum over blocks of 256 int64s and returns the result for
   // numbers[i * 256] ... numbers[(i + 1) * 256 - 1] inclusive  in results[i].
   void testSum64(int32_t numBlocks, int64_t* numbers, int64_t* results);
 
+  static int32_t sort16SharedSize();
+
   void testSort16(int32_t numBlocks, uint16_t** keys, uint16_t** values);
+  void testSort16NoShared(
+      int32_t numBlocks,
+      uint16_t** keys,
+      uint16_t** values,
+      char* temp);
 
   void partitionShorts(
       int32_t numBlocks,

--- a/velox/experimental/wave/common/tests/CudaTest.h
+++ b/velox/experimental/wave/common/tests/CudaTest.h
@@ -36,6 +36,10 @@ class TestStream : public Stream {
   // Queues a kernel to add 1 to numbers[0...size - 1]. The kernel repeats
   // 'repeat' times.
   void
+  incOne(int32_t* numbers, int size, int32_t repeat = 1, int32_t width = 10240);
+
+  /// Like incOne but adds idx & 31 to numbers[idx].
+  void
   addOne(int32_t* numbers, int size, int32_t repeat = 1, int32_t width = 10240);
 
   void addOneWide(
@@ -52,17 +56,28 @@ class TestStream : public Stream {
       int32_t repeat = 1,
       int32_t width = 10240);
 
+  /// Like addOne but uses registers for intermediates.
+  void addOneReg(
+      int32_t* numbers,
+      int32_t size,
+      int32_t repeat = 1,
+      int32_t width = 10240);
+
   /// Increments each of 'numbers by a deterministic pseudorandom
-  /// increment from 'lookup'.  If 'emptyWarps' is true, odd warps do
-  /// no work but still sync with the other ones with __syncthreads().
-  /// If 'emptyThreads' is true, odd lanes do no work and even lanes
-  /// do their work instead.
+  /// increment from 'lookup'. If 'numLocal is non-0, also accesses
+  /// 'numLocal' adjacent positions in 'lookup' with a stride of
+  /// 'localStride'.  If 'emptyWarps' is true, odd warps do no work
+  /// but still sync with the other ones with __syncthreads().  If
+  /// 'emptyThreads' is true, odd lanes do no work and even lanes do
+  /// their work instead.
   void addOneRandom(
       int32_t* numbers,
       const int32_t* lookup,
       int size,
       int32_t repeat = 1,
       int32_t width = 10240,
+      int32_t numLocal = 0,
+      int32_t localStride = 0,
       bool emptyWarps = false,
       bool emptyLanes = false);
 

--- a/velox/experimental/wave/exec/tests/Main.cpp
+++ b/velox/experimental/wave/exec/tests/Main.cpp
@@ -17,7 +17,11 @@
 
 #include <folly/Unit.h>
 #include <folly/init/Init.h>
+#include <gflags/gflags.h>
 #include <gtest/gtest.h>
+#include "velox/experimental/wave/common/Cuda.h"
+
+DEFINE_bool(list_kernels, false, "Print register use of kernels");
 
 // This main is needed for some tests on linux.
 int main(int argc, char** argv) {
@@ -25,5 +29,8 @@ int main(int argc, char** argv) {
   // Signal handler required for ThreadDebugInfoTest
   facebook::velox::process::addDefaultFatalSignalHandler();
   folly::Init init{&argc, &argv, false};
+  if (FLAGS_list_kernels) {
+    facebook::velox::wave::printKernels();
+  }
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
- Faster boolToIndices without shared memory.

- Variations of add one and add random with adjustable count and stride of loads for random access and shared memory and register intermediates for add loop.

- Test bool to indices and radix sort with and without shared memory.