### PR TITLE
Fix PartitionIdGenerator's multiplier initialization for VectorHasher

### DIFF
--- a/velox/connectors/hive/PartitionIdGenerator.h
+++ b/velox/connectors/hive/PartitionIdGenerator.h
@@ -20,8 +20,7 @@
 
 namespace facebook::velox::connector::hive {
 /// Generate sequential integer IDs for distinct partition values, which could
-/// be used as vector index. Only single partition key is supported at the
-/// moment.
+/// be used as vector index.
 class PartitionIdGenerator {
  public:
   /// @param inputType RowType of the input.
@@ -83,6 +82,7 @@ class PartitionIdGenerator {
   const bool partitionPathAsLowerCase_;
 
   std::vector<std::unique_ptr<exec::VectorHasher>> hashers_;
+  bool hasMultiplierSet_ = false;
 
   // A mapping from value ID produced by VectorHashers to a partition ID.
   std::unordered_map<uint64_t, uint64_t> partitionIds_;


### PR DESCRIPTION
When having N columns, PartitionIdGenerator relies on N VectorHashers
 to generate ValueIds, with each VectorHasher’s multiplier correctly set up.

However when having multiple bool columns, it triggers a corner case that
VectorHasher’s multipliers won’t be set at all.

Add multiplierInitialized flag and properly set it to fix this corner case.