### PR TITLE
Add session timezone getter

### DIFF
--- a/velox/core/Config.cpp
+++ b/velox/core/Config.cpp
@@ -32,6 +32,14 @@ bool MemConfig::isValueExists(const std::string& key) const {
   return values_.find(key) != values_.end();
 }
 
+void MemConfig::initialize() {
+  if (auto it = values_.find(QueryConfig::kSessionTimezone);
+      it != values_.end()) {
+    // Exception is thrown if the timezone cannot be recognized.
+    timezoneID_ = util::getTimeZoneID(it->second);
+  }
+}
+
 folly::Optional<std::string> MemConfigMutable::get(
     const std::string& key) const {
   auto lockedValues = values_.rlock();
@@ -46,13 +54,6 @@ folly::Optional<std::string> MemConfigMutable::get(
 bool MemConfigMutable::isValueExists(const std::string& key) const {
   auto lockedValues = values_.rlock();
   return lockedValues->find(key) != lockedValues->end();
-}
-
-void MemConfig::validateConfig() {
-  // Validate if timezone name can be recognized.
-  if (isValueExists(QueryConfig::kSessionTimezone)) {
-    util::getTimeZoneID(values_[QueryConfig::kSessionTimezone]);
-  }
 }
 
 } // namespace facebook::velox::core

--- a/velox/core/Config.h
+++ b/velox/core/Config.h
@@ -54,6 +54,11 @@ class Config {
     }
   }
 
+  virtual int64_t sessionTimezoneId() const {
+    VELOX_UNSUPPORTED(
+        "method sessionTimezoneId() is not supported by this config");
+  };
+
   virtual bool isValueExists(const std::string& key) const = 0;
 
   virtual const std::unordered_map<std::string, std::string>& values() const {
@@ -71,14 +76,14 @@ class MemConfig : public Config {
  public:
   explicit MemConfig(const std::unordered_map<std::string, std::string>& values)
       : values_(values) {
-    validateConfig();
+    initialize();
   }
 
   explicit MemConfig() : values_{} {}
 
   explicit MemConfig(std::unordered_map<std::string, std::string>&& values)
       : values_(std::move(values)) {
-    validateConfig();
+    initialize();
   }
 
   folly::Optional<std::string> get(const std::string& key) const override;
@@ -93,10 +98,18 @@ class MemConfig : public Config {
     return values_;
   }
 
- private:
-  // Validate if configurations are valid.
-  void validateConfig();
+  // Returns session timezone ID. Returns -1 if session timezone is not set.
+  int64_t sessionTimezoneId() const override {
+    return timezoneID_;
+  }
 
+ private:
+  // Initializes configurations. Throws exception if invalid configuration is
+  // provided.
+  void initialize();
+
+  // Session timezone ID.
+  int64_t timezoneID_ = -1;
   std::unordered_map<std::string, std::string> values_;
 };
 

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -482,6 +482,10 @@ class QueryConfig {
     return get<std::string>(kSessionTimezone, "");
   }
 
+  int64_t sessionTimezoneID() const {
+    return config_->sessionTimezoneId();
+  }
+
   bool exprEvalSimplified() const {
     return get<bool>(kExprEvalSimplified, false);
   }

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -1287,9 +1287,9 @@ struct DateParseFunction {
       isConstFormat_ = true;
     }
 
-    auto sessionTzName = config.sessionTimezone();
-    if (!sessionTzName.empty()) {
-      sessionTzID_ = util::getTimeZoneID(sessionTzName);
+    auto sessionTzID = config.sessionTimezoneID();
+    if (sessionTzID != -1) {
+      sessionTzID_ = sessionTzID;
     }
   }
 
@@ -1402,9 +1402,9 @@ struct ParseDateTimeFunction {
       isConstFormat_ = true;
     }
 
-    auto sessionTzName = config.sessionTimezone();
-    if (!sessionTzName.empty()) {
-      sessionTzID_ = util::getTimeZoneID(sessionTzName);
+    auto sessionTzID = config.sessionTimezoneID();
+    if (sessionTzID != -1) {
+      sessionTzID_ = sessionTzID;
     }
   }
 

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.cpp
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.cpp
@@ -25,10 +25,9 @@ void castFromTimestamp(
     const SelectivityVector& rows,
     VectorPtr& result) {
   const auto& config = context.execCtx()->queryCtx()->queryConfig();
-  const auto& sessionTzName = config.sessionTimezone();
   int64_t sessionTzID = 0;
-  if (!sessionTzName.empty()) {
-    sessionTzID = util::getTimeZoneID(sessionTzName);
+  if (config.sessionTimezoneID() != -1) {
+    sessionTzID = config.sessionTimezoneID();
   }
   const auto adjustTimestampToTimezone = config.adjustTimestampToTimezone();
 

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -176,9 +176,8 @@ struct UnixTimestampParseFunction {
 
  protected:
   void setTimezone(const core::QueryConfig& config) {
-    auto sessionTzName = config.sessionTimezone();
-    if (!sessionTzName.empty()) {
-      sessionTzID_ = util::getTimeZoneID(sessionTzName);
+    if (config.sessionTimezoneID() != -1) {
+      sessionTzID_ = config.sessionTimezoneID();
     }
   }
 
@@ -367,9 +366,8 @@ struct GetTimestampFunction {
       const core::QueryConfig& config,
       const arg_type<Varchar>* /*input*/,
       const arg_type<Varchar>* format) {
-    auto sessionTimezoneName = config.sessionTimezone();
-    if (!sessionTimezoneName.empty()) {
-      sessionTimezoneId_ = util::getTimeZoneID(sessionTimezoneName);
+    if (config.sessionTimezoneID() != -1) {
+      sessionTimezoneId_ = config.sessionTimezoneID();
     }
     if (format != nullptr) {
       formatter_ = buildJodaDateTimeFormatter(

--- a/velox/functions/sparksql/MakeTimestamp.cpp
+++ b/velox/functions/sparksql/MakeTimestamp.cpp
@@ -186,11 +186,9 @@ std::shared_ptr<exec::VectorFunction> createMakeTimestampFunction(
     const std::string& /* name */,
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& config) {
-  const auto sessionTzName = config.sessionTimezone();
-  VELOX_USER_CHECK(
-      !sessionTzName.empty(),
-      "make_timestamp requires session time zone to be set.")
-  const auto sessionTzID = util::getTimeZoneID(sessionTzName);
+  const auto sessionTzID = config.sessionTimezoneID();
+  VELOX_USER_CHECK_NE(
+      sessionTzID, -1, "make_timestamp requires session time zone to be set.")
 
   const auto& secondsType = inputArgs[5].type;
   VELOX_USER_CHECK(


### PR DESCRIPTION
Initializes a member variable when session timezone is set once and returns the 
integer with a getter.