### PR TITLE
Add custom argument generators for Presto decimal functions

### DIFF
--- a/velox/expression/fuzzer/tests/ArgGeneratorTestUtils.cpp
+++ b/velox/expression/fuzzer/tests/ArgGeneratorTestUtils.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/expression/fuzzer/tests/ArgGeneratorTestUtils.h"
+#include <gtest/gtest.h>
+#include "velox/expression/SignatureBinder.h"
+
+namespace facebook::velox::fuzzer::test {
+
+void assertReturnType(
+    const std::shared_ptr<ArgGenerator>& generator,
+    const exec::FunctionSignature& signature,
+    const TypePtr& returnType) {
+  std::mt19937 seed{0};
+  const auto argTypes = generator->generateArgs(signature, returnType, seed);
+
+  // Resolve return type from argument types for the given signature.
+  exec::SignatureBinder binder(signature, argTypes);
+  VELOX_CHECK(
+      binder.tryBind(),
+      "Failed to resolve {} from argument types.",
+      returnType->toString());
+  const auto actualType = binder.tryResolveReturnType();
+  EXPECT_TRUE(returnType->equivalent(*actualType))
+      << "Expected type: " << returnType->toString()
+      << ", actual type: " << actualType->toString();
+}
+
+void assertEmptyArgs(
+    std::shared_ptr<ArgGenerator> generator,
+    const exec::FunctionSignature& signature,
+    const TypePtr& returnType) {
+  std::mt19937 seed{0};
+  const auto argTypes = generator->generateArgs(signature, returnType, seed);
+  EXPECT_TRUE(argTypes.empty());
+}
+
+} // namespace facebook::velox::fuzzer::test

--- a/velox/expression/fuzzer/tests/ArgGeneratorTestUtils.h
+++ b/velox/expression/fuzzer/tests/ArgGeneratorTestUtils.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/expression/fuzzer/ArgGenerator.h"
+#include "velox/functions/FunctionRegistry.h"
+
+namespace facebook::velox::fuzzer::test {
+
+/// Assert the equivalence between the given return type and the actual type
+/// resolved from generated argument types.
+void assertReturnType(
+    const std::shared_ptr<ArgGenerator>& generator,
+    const exec::FunctionSignature& signature,
+    const TypePtr& returnType);
+
+// Assert that no argument types can be generated for the given return type.
+void assertEmptyArgs(
+    std::shared_ptr<ArgGenerator> generator,
+    const exec::FunctionSignature& signature,
+    const TypePtr& returnType);
+
+} // namespace facebook::velox::fuzzer::test

--- a/velox/expression/fuzzer/tests/CMakeLists.txt
+++ b/velox/expression/fuzzer/tests/CMakeLists.txt
@@ -12,7 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_expression_fuzzer_unit_test ArgumentTypeFuzzerTest.cpp DecimalArgGeneratorTest.cpp ExpressionFuzzerUnitTest.cpp)
+add_library(velox_expression_fuzzer_test_utility ArgGeneratorTestUtils.cpp)
+target_link_libraries(velox_expression_fuzzer_test_utility
+                      velox_expression_functions velox_function_registry gtest)
+
+add_executable(
+  velox_expression_fuzzer_unit_test
+  ArgumentTypeFuzzerTest.cpp DecimalArgGeneratorTest.cpp
+  ExpressionFuzzerUnitTest.cpp)
 
 target_link_libraries(
   velox_expression_fuzzer_unit_test
@@ -20,5 +27,6 @@ target_link_libraries(
   velox_functions_prestosql
   velox_core
   velox_expression
+  velox_expression_fuzzer_test_utility
   gtest
   gtest_main)

--- a/velox/expression/fuzzer/tests/DecimalArgGeneratorTest.cpp
+++ b/velox/expression/fuzzer/tests/DecimalArgGeneratorTest.cpp
@@ -15,8 +15,8 @@
  */
 
 #include <gtest/gtest.h>
-#include "velox/expression/SignatureBinder.h"
 #include "velox/expression/fuzzer/DecimalArgGeneratorBase.h"
+#include "velox/expression/fuzzer/tests/ArgGeneratorTestUtils.h"
 
 namespace facebook::velox::fuzzer::test {
 
@@ -50,38 +50,6 @@ class DecimalArgGeneratorTest : public testing::Test {
       return {{p, s}};
     }
   };
-
-  // Assert the equivalence between the given return type and the actual type
-  // resolved from generated argument types.
-  void assertReturnType(
-      const std::shared_ptr<DecimalArgGeneratorBase>& generator,
-      const exec::FunctionSignature& signature,
-      const TypePtr& returnType) {
-    std::mt19937 seed{0};
-    const auto argTypes = generator->generateArgs(signature, returnType, seed);
-
-    // Resolve return type from argument types for the given signature.
-    TypePtr actualType;
-    exec::SignatureBinder binder(signature, argTypes);
-    if (binder.tryBind()) {
-      actualType = binder.tryResolveReturnType();
-    } else {
-      VELOX_FAIL("Failed to resolve return type from argument types.");
-    }
-    EXPECT_TRUE(returnType->equivalent(*actualType))
-        << "Expected type: " << returnType->toString()
-        << ", actual type: " << actualType->toString();
-  }
-
-  // Assert that no argument types can be generated for the given return type.
-  void assertEmptyArgs(
-      std::shared_ptr<DecimalArgGeneratorBase> generator,
-      const exec::FunctionSignature& signature,
-      const TypePtr& returnType) {
-    std::mt19937 seed{0};
-    const auto argTypes = generator->generateArgs(signature, returnType, seed);
-    EXPECT_TRUE(argTypes.empty());
-  }
 };
 
 TEST_F(DecimalArgGeneratorTest, unary) {

--- a/velox/functions/prestosql/fuzzer/DivideArgGenerator.h
+++ b/velox/functions/prestosql/fuzzer/DivideArgGenerator.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/expression/fuzzer/DecimalArgGeneratorBase.h"
+
+namespace facebook::velox::exec::test {
+
+// An argument type generator for decimal divide Presto function.
+class DivideArgGenerator : public fuzzer::DecimalArgGeneratorBase {
+ public:
+  DivideArgGenerator() {
+    initialize(2);
+  }
+
+ protected:
+  std::optional<std::pair<int, int>>
+  toReturnType(int p1, int s1, int p2, int s2) override {
+    if (s1 + s2 > 38) {
+      return std::nullopt;
+    }
+
+    auto p = std::min(38, p1 + s2 + std::max(0, s2 - s1));
+    auto s = std::max(s1, s2);
+    return {{p, s}};
+  }
+};
+
+} // namespace facebook::velox::exec::test

--- a/velox/functions/prestosql/fuzzer/FloorAndRoundArgGenerator.h
+++ b/velox/functions/prestosql/fuzzer/FloorAndRoundArgGenerator.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <boost/random/uniform_int_distribution.hpp>
+#include "velox/expression/fuzzer/ArgGenerator.h"
+
+namespace facebook::velox::exec::test {
+
+// An argument type generator for decimal floor and round Presto functions.
+class FloorAndRoundArgGenerator : public fuzzer::ArgGenerator {
+ public:
+  std::vector<TypePtr> generateArgs(
+      const exec::FunctionSignature& signature,
+      const TypePtr& returnType,
+      FuzzerGenerator& rng) override {
+    if (signature.argumentTypes().size() == 1) {
+      return generateSingleArg(returnType, rng);
+    }
+    VELOX_CHECK_EQ(2, signature.argumentTypes().size())
+    return generateTwoArgs(returnType);
+  }
+
+ private:
+  // Generates a decimal type following below formulas:
+  // p = p1 - s1 + min(s1, 1)
+  // s = 0
+  std::vector<TypePtr> generateSingleArg(
+      const TypePtr& returnType,
+      FuzzerGenerator& rng) {
+    const auto [p, s] = getDecimalPrecisionScale(*returnType);
+    if (s != 0) {
+      return {};
+    }
+
+    const auto s1 = rand32(38 - p + 1, rng);
+    if (s1 == 0) {
+      return {DECIMAL(p, 0)};
+    }
+
+    return {DECIMAL(p - 1 + s1, s1)};
+  }
+
+  // Generates a decimal type and an integer type. Decimal type is generated
+  // following below formulas:
+  // p = p1 + 1
+  // s = s1
+  std::vector<TypePtr> generateTwoArgs(const TypePtr& returnType) {
+    auto [p, s] = getDecimalPrecisionScale(*returnType);
+    if (p == 1 || p == s) {
+      return {};
+    }
+
+    return {DECIMAL(p - 1, s), INTEGER()};
+  }
+
+  static uint32_t rand32(uint32_t max, FuzzerGenerator& rng) {
+    return boost::random::uniform_int_distribution<uint32_t>()(rng) % max;
+  }
+};
+
+} // namespace facebook::velox::exec::test

--- a/velox/functions/prestosql/fuzzer/MultiplyArgGenerator.h
+++ b/velox/functions/prestosql/fuzzer/MultiplyArgGenerator.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/expression/fuzzer/DecimalArgGeneratorBase.h"
+
+namespace facebook::velox::exec::test {
+
+// An argument type generator for decimal multiply Presto function.
+class MultiplyArgGenerator : public fuzzer::DecimalArgGeneratorBase {
+ public:
+  MultiplyArgGenerator() {
+    initialize(2);
+  }
+
+ protected:
+  std::optional<std::pair<int, int>>
+  toReturnType(int p1, int s1, int p2, int s2) override {
+    if (s1 + s2 > 38) {
+      return std::nullopt;
+    }
+
+    auto p = std::min(38, p1 + p2);
+    auto s = s1 + s2;
+    return {{p, s}};
+  }
+};
+
+} // namespace facebook::velox::exec::test

--- a/velox/functions/prestosql/fuzzer/PlusMinusArgGenerator.h
+++ b/velox/functions/prestosql/fuzzer/PlusMinusArgGenerator.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/expression/fuzzer/DecimalArgGeneratorBase.h"
+
+namespace facebook::velox::exec::test {
+
+// An argument type generator for decimal plus and minus Presto functions.
+class PlusMinusArgGenerator : public fuzzer::DecimalArgGeneratorBase {
+ public:
+  PlusMinusArgGenerator() {
+    initialize(2);
+  }
+
+ protected:
+  std::optional<std::pair<int, int>>
+  toReturnType(int p1, int s1, int p2, int s2) override {
+    auto s = std::max(s1, s2);
+    auto p = std::min(38, std::max(p1 - s1, p2 - s2) + 1 + s);
+    return {{p, s}};
+  }
+};
+
+} // namespace facebook::velox::exec::test

--- a/velox/functions/prestosql/tests/ArgGeneratorTest.cpp
+++ b/velox/functions/prestosql/tests/ArgGeneratorTest.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/expression/fuzzer/tests/ArgGeneratorTestUtils.h"
+#include "velox/functions/prestosql/fuzzer/DivideArgGenerator.h"
+#include "velox/functions/prestosql/fuzzer/FloorAndRoundArgGenerator.h"
+#include "velox/functions/prestosql/fuzzer/MultiplyArgGenerator.h"
+#include "velox/functions/prestosql/fuzzer/PlusMinusArgGenerator.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::fuzzer::test;
+namespace {
+
+class ArgGeneratorTest : public functions::test::FunctionBaseTest {
+ protected:
+  // Returns the only signature with decimal return type for a given function
+  // name.
+  const exec::FunctionSignature& getOnlySignature(
+      const std::string& functionName) {
+    const auto signatures = getSignatures(functionName, "decimal");
+    VELOX_CHECK_EQ(signatures.size(), 1);
+    return *signatures[0];
+  }
+};
+
+TEST_F(ArgGeneratorTest, plus) {
+  const auto& signature = getOnlySignature("plus");
+  const auto generator = std::make_shared<exec::test::PlusMinusArgGenerator>();
+
+  assertReturnType(generator, signature, DECIMAL(10, 2));
+  assertReturnType(generator, signature, DECIMAL(32, 6));
+  assertReturnType(generator, signature, DECIMAL(38, 20));
+  assertReturnType(generator, signature, DECIMAL(38, 38));
+  assertReturnType(generator, signature, DECIMAL(38, 0));
+  assertEmptyArgs(generator, signature, DECIMAL(18, 18));
+}
+
+TEST_F(ArgGeneratorTest, minus) {
+  const auto& signature = getOnlySignature("minus");
+  const auto generator = std::make_shared<exec::test::PlusMinusArgGenerator>();
+
+  assertReturnType(generator, signature, DECIMAL(10, 2));
+  assertReturnType(generator, signature, DECIMAL(32, 6));
+  assertReturnType(generator, signature, DECIMAL(38, 20));
+  assertReturnType(generator, signature, DECIMAL(38, 38));
+  assertReturnType(generator, signature, DECIMAL(38, 0));
+  assertEmptyArgs(generator, signature, DECIMAL(18, 18));
+}
+
+TEST_F(ArgGeneratorTest, multiply) {
+  const auto& signature = getOnlySignature("multiply");
+  const auto generator = std::make_shared<exec::test::MultiplyArgGenerator>();
+
+  assertReturnType(generator, signature, DECIMAL(10, 2));
+  assertReturnType(generator, signature, DECIMAL(18, 18));
+  assertReturnType(generator, signature, DECIMAL(32, 6));
+  assertReturnType(generator, signature, DECIMAL(38, 20));
+  assertReturnType(generator, signature, DECIMAL(38, 38));
+  assertReturnType(generator, signature, DECIMAL(38, 0));
+}
+
+TEST_F(ArgGeneratorTest, divide) {
+  const auto& signature = getOnlySignature("divide");
+  const auto generator = std::make_shared<exec::test::DivideArgGenerator>();
+
+  assertReturnType(generator, signature, DECIMAL(10, 2));
+  assertReturnType(generator, signature, DECIMAL(18, 18));
+  assertReturnType(generator, signature, DECIMAL(32, 6));
+  assertReturnType(generator, signature, DECIMAL(38, 20));
+  assertReturnType(generator, signature, DECIMAL(38, 38));
+  assertReturnType(generator, signature, DECIMAL(38, 0));
+}
+
+TEST_F(ArgGeneratorTest, floor) {
+  const auto& signature = getOnlySignature("floor");
+  const auto generator =
+      std::make_shared<exec::test::FloorAndRoundArgGenerator>();
+
+  assertReturnType(generator, signature, DECIMAL(10, 0));
+  assertReturnType(generator, signature, DECIMAL(18, 0));
+  assertReturnType(generator, signature, DECIMAL(32, 0));
+  assertReturnType(generator, signature, DECIMAL(38, 0));
+  assertEmptyArgs(generator, signature, DECIMAL(10, 2));
+}
+
+TEST_F(ArgGeneratorTest, round) {
+  const auto signatures = getSignatures("round", "decimal");
+  VELOX_CHECK_EQ(signatures.size(), 2);
+  bool isSingleArg = signatures[0]->argumentTypes().size() == 1;
+  const auto generator =
+      std::make_shared<exec::test::FloorAndRoundArgGenerator>();
+
+  const auto& singleArgSignature =
+      isSingleArg ? *signatures[0] : *signatures[1];
+  assertReturnType(generator, singleArgSignature, DECIMAL(10, 0));
+  assertReturnType(generator, singleArgSignature, DECIMAL(18, 0));
+  assertReturnType(generator, singleArgSignature, DECIMAL(32, 0));
+  assertReturnType(generator, singleArgSignature, DECIMAL(38, 0));
+  assertEmptyArgs(generator, singleArgSignature, DECIMAL(10, 2));
+
+  const auto& twoArgsSignature = isSingleArg ? *signatures[1] : *signatures[0];
+  assertReturnType(generator, twoArgsSignature, DECIMAL(10, 2));
+  assertReturnType(generator, twoArgsSignature, DECIMAL(32, 6));
+  assertReturnType(generator, twoArgsSignature, DECIMAL(38, 20));
+  assertReturnType(generator, twoArgsSignature, DECIMAL(38, 0));
+  assertEmptyArgs(generator, twoArgsSignature, DECIMAL(18, 18));
+  assertEmptyArgs(generator, twoArgsSignature, DECIMAL(38, 38));
+  assertEmptyArgs(generator, twoArgsSignature, DECIMAL(1, 0));
+}
+
+} // namespace

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(
   ArraySumTest.cpp
   ArrayTrimTest.cpp
   ArrayUnionTest.cpp
+  ArgGeneratorTest.cpp
   BinaryFunctionsTest.cpp
   BitwiseTest.cpp
   CardinalityTest.cpp
@@ -113,6 +114,8 @@ target_link_libraries(
   velox_exec_test_lib
   velox_dwio_common_test_utils
   velox_vector_fuzzer
+  velox_expression_fuzzer_test_utility
+  velox_expression_fuzzer
   gtest
   gtest_main
   gflags::gflags

--- a/velox/functions/prestosql/tests/utils/FunctionBaseTest.cpp
+++ b/velox/functions/prestosql/tests/utils/FunctionBaseTest.cpp
@@ -27,6 +27,27 @@ void FunctionBaseTest::SetUpTestCase() {
 }
 
 // static
+std::vector<const exec::FunctionSignature*> FunctionBaseTest::getSignatures(
+    const std::string& functionName,
+    const std::string& returnType) {
+  const auto allSignatures = getFunctionSignatures();
+
+  std::vector<const exec::FunctionSignature*> signatures;
+  for (const auto& signature : allSignatures.at(functionName)) {
+    const auto& typeName = signature->returnType().baseName();
+    if (exec::sanitizeName(typeName) == exec::sanitizeName(returnType)) {
+      signatures.push_back(signature);
+    }
+  }
+  VELOX_CHECK(
+      !signatures.empty(),
+      "No signature found for function {} with return type {}.",
+      functionName,
+      returnType);
+  return signatures;
+}
+
+// static
 std::unordered_set<std::string> FunctionBaseTest::getSignatureStrings(
     const std::string& functionName) {
   auto allSignatures = getFunctionSignatures();

--- a/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
@@ -318,6 +318,14 @@ class FunctionBaseTest : public testing::Test,
     return result[0];
   }
 
+  /// Returns a vector of signatures for the given function name and return
+  /// type.
+  /// @param returnType The name of expected return type defined in function
+  /// signature.
+  static std::vector<const exec::FunctionSignature*> getSignatures(
+      const std::string& functionName,
+      const std::string& returnType);
+
   /// Returns a set of signatures for a given function serialized to strings.
   static std::unordered_set<std::string> getSignatureStrings(
       const std::string& functionName);


### PR DESCRIPTION
To generate argument types in the decimal fuzzer test correctly, customized 
argument type generators are required. This PR adds arg generators for the 
Presto functions plus/minus, multiply, divide, and floor/round.
Inspired by https://github.com/facebookincubator/velox/pull/9358.