### PR TITLE
Update README for build on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ $ ./scripts/setup-macos.sh
 $ make
 ```
 
+With macOS 14.4 and XCode 15.3 where `m4` is missing, you can either
+1. install `m4` via `brew`:
+```shell
+$ brew install m4
+$ export PATH=/opt/homebrew/opt/m4/bin:$PATH
+```
+
+2. or use `gm4` instead:
+```shell
+$ M4=/usr/bin/gm4 make
+```
+
 You can also produce intel binaries on an M1, use `CPU_TARGET="sse"` for the above.
 
 ### Setting up on aarch64 Linux (Ubuntu 20.04 or later)

--- a/README.md
+++ b/README.md
@@ -84,18 +84,12 @@ dependencies for a given platform.
 
 ### Setting up on macOS
 
-On an Intel MacOS machine you can setup and then build like so:
+On a MacOS machine (either Intel or Apple silicon) you can setup and then build like so:
 
 ```shell
+$ export INSTALL_PREFIX=/Users/$USERNAME/velox/velox_dependency_install
 $ ./scripts/setup-macos.sh
 $ make
-```
-
-On an M1 MacOS machine you can build like so:
-
-```shell
-$ CPU_TARGET="arm64" ./scripts/setup-macos.sh
-$ CPU_TARGET="arm64" make
 ```
 
 You can also produce intel binaries on an M1, use `CPU_TARGET="sse"` for the above.


### PR DESCRIPTION
Tested on MacOS 14.4.1 w/ M1 chip.

* Per https://github.com/facebookincubator/velox/issues/1446#issuecomment-1721311629, `CPU_TARGET="arm64"` is not needed any more.
  ```
  ++ arch
  + '[' arm64 == arm64 ']'
  ```
* Add `INSTALL_PREFIX` to address dependency installation permission issues in https://github.com/facebookincubator/velox/issues/2016

CC: @majetideepak 