### PR TITLE
Add more test method in Filter::AlwaysFalse class

### DIFF
--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -312,6 +312,10 @@ class AlwaysFalse final : public Filter {
     return false;
   }
 
+  bool testNull() const final {
+    return false;
+  }
+
   bool testInt64(int64_t /* unused */) const final {
     return false;
   }
@@ -321,7 +325,16 @@ class AlwaysFalse final : public Filter {
     return false;
   }
 
+  bool testInt128(int128_t /* unused */) const final {
+    return false;
+  }
+
   bool testDouble(double /* unused */) const final {
+    return false;
+  }
+
+  bool testDoubleRange(double /*min*/, double /*max*/, bool /*hasNull*/)
+      const final {
     return false;
   }
 


### PR DESCRIPTION
We now use alwaysFalse of Filter.h and some method not implemented causing runtime error. So, we'd like to implment some alwaysFalse method to avoid the error.