### PR TITLE
Change `result_of` to `invoke_result` in velox/vector/fuzzer/GeneratorSpec.h

### DIFF
--- a/velox/vector/fuzzer/GeneratorSpec.h
+++ b/velox/vector/fuzzer/GeneratorSpec.h
@@ -79,7 +79,7 @@ class ScalarGeneratorSpec : public GeneratorSpec {
       : GeneratorSpec(type, nullProbability),
         distribution_(std::forward<Distribution>(distribution)) {
     using TCpp = typename TypeTraits<KIND>::NativeType;
-    using Ret = std::result_of_t<Distribution(FuzzerGenerator&)>;
+    using Ret = std::invoke_result_t<Distribution, FuzzerGenerator&>;
     static_assert(std::is_convertible_v<Ret, TCpp>);
   }
 
@@ -143,7 +143,7 @@ class ArrayGeneratorSpec : public GeneratorSpec {
       : GeneratorSpec(type, nullProbability),
         elements_(elements),
         lengthDistribution_(std::forward<Distribution>(lengthDistribution)) {
-    using Ret = std::result_of_t<Distribution(FuzzerGenerator&)>;
+    using Ret = std::invoke_result_t<Distribution, FuzzerGenerator&>;
     static_assert(std::is_convertible_v<Ret, vector_size_t>);
   }
 
@@ -190,7 +190,7 @@ class MapGeneratorSpec : public GeneratorSpec {
         keys_(keys),
         values_(values),
         lengthDistribution_(std::forward<Distribution>(lengthDistribution)) {
-    using Ret = std::result_of_t<Distribution(FuzzerGenerator&)>;
+    using Ret = std::invoke_result_t<Distribution, FuzzerGenerator&>;
     static_assert(std::is_convertible_v<Ret, vector_size_t>);
   }
 
@@ -240,7 +240,7 @@ class EncoderSpec : public GeneratorSpec {
         base_(base),
         encoding_(std::forward<Distribution>(encodingDistribution)),
         nesting_(minNesting, maxNesting) {
-    using Ret = std::result_of_t<Distribution(FuzzerGenerator&)>;
+    using Ret = std::invoke_result_t<Distribution, FuzzerGenerator&>;
     static_assert(std::is_convertible_v<Ret, EncoderSpecCodes>);
   }
 


### PR DESCRIPTION
Summary: C++20 has [eliminated](https://en.cppreference.com/w/cpp/types/result_of) `result_of` in favour of `invoke_result`. It's mysterious that this code even still works, but, nevertheless, I'm fixing it.

Differential Revision: D56987447


