### PR TITLE
Fix crash in ArrayVectorBase::copyRangesImpl in case target offsets or sizes is nullptr

### DIFF
--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -541,8 +541,9 @@ void ArrayVectorBase::copyRangesImpl(
 
   auto sourceArray = leafSource->asUnchecked<ArrayVectorBase>();
   auto setNotNulls = mayHaveNulls() || source->mayHaveNulls();
-  auto* mutableOffsets = offsets_->asMutable<vector_size_t>();
-  auto* mutableSizes = sizes_->asMutable<vector_size_t>();
+  auto* mutableOffsets =
+      this->mutableOffsets(length_)->asMutable<vector_size_t>();
+  auto* mutableSizes = this->mutableSizes(length_)->asMutable<vector_size_t>();
   vector_size_t childSize = targetValues->get()->size();
   if (ranges.size() == 1 && ranges.back().count == 1) {
     auto& range = ranges.back();

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -3773,5 +3773,17 @@ TEST_F(VectorTest, mapUpdateMultipleUpdates) {
   }
 }
 
+TEST_F(VectorTest, arrayCopyTargetNullOffsets) {
+  auto target = BaseVector::create(ARRAY(BIGINT()), 11, pool());
+  auto offsetsRef = target->asUnchecked<ArrayVector>()->offsets();
+  ASSERT_TRUE(offsetsRef);
+  BaseVector::prepareForReuse(target, target->size());
+  ASSERT_FALSE(target->asUnchecked<ArrayVector>()->offsets());
+  auto source = makeArrayVector<int64_t>(
+      11, [](auto) { return 1; }, [](auto i, auto) { return i; });
+  target->copy(source.get(), 0, 0, source->size());
+  test::assertEqualVectors(source, target);
+}
+
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
Summary: `offset_` or `sizes_` can be `nullptr` if it is multi-referenced and cleared during `prepareForReuse`, in that case the old code results in crash.  Reallocate them using `mutableOffsets` or `mutableSizes` in `copyRangesImpl`.

Differential Revision: D57012135


