### PR TITLE
Add near zero-copy Import & Export for Arrow BinaryView/Utf8View formats

### DIFF
--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -39,9 +39,20 @@ static constexpr size_t kMaxBuffers{3};
 class VeloxToArrowBridgeHolder {
  public:
   VeloxToArrowBridgeHolder() {
-    for (size_t i = 0; i < kMaxBuffers; ++i) {
+    buffers_.resize(num_buffers_);
+    bufferPtrs_.resize(num_buffers_);
+    for (size_t i = 0; i < num_buffers_; ++i) {
       buffers_[i] = nullptr;
     }
+  }
+
+  void resizeBuffers(size_t buffer_count) {
+    buffers_.resize(buffer_count);
+    bufferPtrs_.resize(buffer_count);
+    for (size_t i = num_buffers_; i < buffer_count; i++) {
+      buffers_[i] = nullptr;
+    }
+    num_buffers_ = buffer_count;
   }
 
   // Acquires a buffer at index `idx`.
@@ -58,7 +69,7 @@ class VeloxToArrowBridgeHolder {
   }
 
   const void** getArrowBuffers() {
-    return buffers_;
+    return (const void**)&(buffers_[0]);
   }
 
   // Allocates space for `numChildren` ArrowArray pointers.
@@ -88,12 +99,15 @@ class VeloxToArrowBridgeHolder {
   }
 
  private:
+  // Holds the count of total buffers
+  size_t num_buffers_ = kMaxBuffers;
+
   // Holds the pointers to the arrow buffers.
-  const void* buffers_[kMaxBuffers];
+  std::vector<const void*> buffers_;
 
   // Holds ownership over the Buffers being referenced by the buffers vector
   // above.
-  BufferPtr bufferPtrs_[kMaxBuffers];
+  std::vector<BufferPtr> bufferPtrs_;
 
   // Auxiliary buffers to hold ownership over ArrowArray children structures.
   std::vector<std::unique_ptr<ArrowArray>> childrenPtrs_;
@@ -277,8 +291,12 @@ const char* exportArrowFormatStr(
     // We always map VARCHAR and VARBINARY to the "small" version (lower case
     // format string), which uses 32 bit offsets.
     case TypeKind::VARCHAR:
+      if (options.exportToView)
+        return "vu";
       return "u"; // utf-8 string
     case TypeKind::VARBINARY:
+      if (options.exportToView)
+        return "vz";
       return "z"; // binary
     case TypeKind::UNKNOWN:
       return "n"; // NullType
@@ -528,6 +546,54 @@ VectorPtr createFlatVector(
 using WrapInBufferViewFunc =
     std::function<BufferPtr(const void* buffer, size_t length)>;
 
+VectorPtr createStringFlatVectorFromUtf8View(
+    memory::MemoryPool* pool,
+    const TypePtr& type,
+    BufferPtr nulls,
+    const ArrowArray& arrowArray,
+    WrapInBufferViewFunc wrapInBufferView) {
+  int num_buffers = arrowArray.n_buffers;
+
+  // The last C data buffer stores buffer sizes
+  auto* bufferSizes = (uint64_t*)arrowArray.buffers[num_buffers - 1];
+  std::vector<BufferPtr> stringViewBuffers(num_buffers - 3);
+
+  for (int32_t buffer_id = 2; buffer_id < num_buffers - 1; ++buffer_id) {
+    stringViewBuffers[buffer_id - 2] = wrapInBufferView(
+        arrowArray.buffers[buffer_id], bufferSizes[buffer_id - 2]);
+  }
+
+  BufferPtr stringViews =
+      AlignedBuffer::allocate<StringView>(arrowArray.length, pool);
+  auto* rawStringViews = stringViews->asMutable<uint64_t>();
+  auto* rawNulls = nulls->as<uint64_t>();
+
+  // Full copy for inline strings (length <= 12). For non-inline strings ,
+  // convert 16-byte Arrow Utf8View [4-byte length, 4-byte prefix, 4-byte
+  // buffer-index, 4-byte buffer-offset] to 16-byte Velox StringView [4-byte
+  // length, 4-byte prefix, 8-byte buffer-ptr]
+  for (int32_t idx_64 = 0; idx_64 < arrowArray.length; ++idx_64) {
+    auto* view = (uint32_t*)(&((uint64_t*)arrowArray.buffers[1])[2 * idx_64]);
+    rawStringViews[2 * idx_64] = *(uint64_t*)view;
+    if (view[0] > 12)
+      rawStringViews[2 * idx_64 + 1] =
+          (uint64_t)arrowArray.buffers[2 + view[2]] + view[3];
+    else
+      rawStringViews[2 * idx_64 + 1] = *(uint64_t*)&view[2];
+  }
+
+  return std::make_shared<FlatVector<StringView>>(
+      pool,
+      type,
+      nulls,
+      arrowArray.length,
+      std::move(stringViews),
+      std::move(stringViewBuffers),
+      SimpleVectorStats<StringView>{},
+      std::nullopt,
+      optionalNullCount(arrowArray.null_count));
+}
+
 template <typename TOffset>
 VectorPtr createStringFlatVector(
     memory::MemoryPool* pool,
@@ -648,6 +714,71 @@ void exportValues(
   holder.setBuffer(1, values);
 }
 
+void exportViews(
+    const FlatVector<StringView>& vec,
+    const Selection& rows,
+    ArrowArray& out,
+    memory::MemoryPool* pool,
+    VeloxToArrowBridgeHolder& holder) {
+  auto stringBuffers = vec.stringBuffers();
+  size_t numStringBuffers = stringBuffers.size();
+  size_t numBuffers = 3 +
+      numStringBuffers; // nulls, values, stringBuffers, variadic_buffer_sizes
+
+  // resize and reassign holder buffers
+  holder.resizeBuffers(numBuffers);
+  out.buffers = holder.getArrowBuffers();
+  // cache for fast [buffer-idx, buffer-offset] calculation
+  std::vector<int32_t> stringBufferVec(numStringBuffers);
+
+  BufferPtr variadicBufferSizes =
+      AlignedBuffer::allocate<size_t>(numStringBuffers, pool);
+  auto rawVariadicBufferSizes = variadicBufferSizes->asMutable<uint64_t>();
+  for (int32_t idx = 0; idx < numStringBuffers; ++idx) {
+    rawVariadicBufferSizes[idx] = stringBuffers[idx]->size();
+    holder.setBuffer(2 + idx, stringBuffers[idx]);
+    stringBufferVec[idx] = idx;
+  }
+  holder.setBuffer(numBuffers - 1, variadicBufferSizes);
+  out.n_buffers = numBuffers;
+
+  // Sorting cache for fast binary search of [4-byte buffer-idx, 4-byte
+  // buffer-offset] from stringBufferVec with key [8-byte buffer-ptr]
+  std::stable_sort(
+      stringBufferVec.begin(),
+      stringBufferVec.end(),
+      [&out](const auto& lhs, const auto& rhs) {
+        return ((uint64_t*)&out.buffers[2])[lhs] <
+            ((uint64_t*)&out.buffers[2])[rhs];
+      });
+
+  auto utf8Views = (uint64_t*)out.buffers[1];
+  int32_t bufferIdxCache = 0;
+  uint64_t bufferAddrCache = 0;
+
+  rows.apply([&](vector_size_t i) {
+    auto view = (uint32_t*)&utf8Views[2 * i];
+    if (!vec.isNullAt(i) && view[0] > 12) {
+      uint64_t currAddr = *(uint64_t*)&view[2];
+      if (i == 0 ||
+          (currAddr - bufferAddrCache) >
+              rawVariadicBufferSizes[bufferIdxCache]) {
+        auto it = std::prev(std::upper_bound(
+            stringBufferVec.begin(),
+            stringBufferVec.end(),
+            currAddr,
+            [&out](const auto& lhs, const auto& rhs) {
+              return lhs < ((uint64_t*)&out.buffers[2])[rhs];
+            }));
+        bufferAddrCache = ((uint64_t*)&out.buffers[2])[*it];
+        bufferIdxCache = *it;
+      }
+      view[2] = bufferIdxCache;
+      view[3] = currAddr - bufferAddrCache;
+    }
+  });
+}
+
 void exportStrings(
     const FlatVector<StringView>& vec,
     const Selection& rows,
@@ -705,8 +836,21 @@ void exportFlat(
       break;
     case TypeKind::VARCHAR:
     case TypeKind::VARBINARY:
-      exportStrings(
-          *vec.asUnchecked<FlatVector<StringView>>(), rows, out, pool, holder);
+      if (options.exportToView) {
+        exportValues(vec, rows, options, out, pool, holder);
+        exportViews(
+            *vec.asUnchecked<FlatVector<StringView>>(),
+            rows,
+            out,
+            pool,
+            holder);
+      } else
+        exportStrings(
+            *vec.asUnchecked<FlatVector<StringView>>(),
+            rows,
+            out,
+            pool,
+            holder);
       break;
     default:
       VELOX_NYI(
@@ -1102,6 +1246,15 @@ TypePtr importFromArrowImpl(
     case 'z':
     case 'Z':
       return VARBINARY();
+
+    case 'v':
+      if (format[1] == 'u') {
+        return VARCHAR();
+      }
+      if (format[1] == 'z') {
+        return VARBINARY();
+      }
+      break;
 
     case 't': // temporal types.
       if (format[1] == 's') {
@@ -1734,6 +1887,18 @@ VectorPtr importFromArrowImpl(
 
   // String data types (VARCHAR and VARBINARY).
   if (type->isVarchar() || type->isVarbinary()) {
+    // Import StringView from Utf8View/BinaryView (Zero-copy)
+    if (arrowSchema.format[0] == 'v') {
+      VELOX_USER_CHECK_GE(
+          arrowArray.n_buffers,
+          3,
+          "Expecting three or more buffers as input for string view types.");
+
+      return createStringFlatVectorFromUtf8View(
+          pool, type, nulls, arrowArray, wrapInBufferView);
+    }
+
+    // Import StringView from Utf8/Binary
     VELOX_USER_CHECK_EQ(
         arrowArray.n_buffers,
         3,

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -40,9 +40,12 @@ class VeloxToArrowBridgeHolder {
  public:
   VeloxToArrowBridgeHolder() = default;
 
+  // Call to this method may require a call to `getArrowBuffers()` in order to
+  // re-acquire the underlying buffer
   void resizeBuffers(size_t bufferCount) {
-    if (bufferCount <= numBuffers_)
+    if (bufferCount <= numBuffers_) {
       return;
+    }
     buffers_.resize(bufferCount);
     bufferPtrs_.resize(bufferCount);
     for (size_t i = numBuffers_; i < bufferCount; i++) {
@@ -287,12 +290,14 @@ const char* exportArrowFormatStr(
     // We always map VARCHAR and VARBINARY to the "small" version (lower case
     // format string), which uses 32 bit offsets.
     case TypeKind::VARCHAR:
-      if (options.exportToStringView)
+      if (options.exportToStringView) {
         return "vu";
+      }
       return "u"; // utf-8 string
     case TypeKind::VARBINARY:
-      if (options.exportToStringView)
+      if (options.exportToStringView) {
         return "vz";
+      }
       return "z"; // binary
     case TypeKind::UNKNOWN:
       return "n"; // NullType
@@ -548,7 +553,7 @@ VectorPtr createStringFlatVectorFromUtf8View(
     BufferPtr nulls,
     const ArrowArray& arrowArray,
     WrapInBufferViewFunc wrapInBufferView) {
-  int num_buffers = arrowArray.n_buffers;
+  int64_t num_buffers = arrowArray.n_buffers;
   VELOX_USER_CHECK_GE(
       num_buffers,
       3,

--- a/velox/vector/arrow/Bridge.h
+++ b/velox/vector/arrow/Bridge.h
@@ -37,6 +37,7 @@ struct ArrowOptions {
   bool flattenConstant{false};
   TimestampUnit timestampUnit = TimestampUnit::kNano;
   std::optional<std::string> timestampTimeZone{std::nullopt};
+  bool exportToView = false;
 };
 
 namespace facebook::velox {

--- a/velox/vector/arrow/Bridge.h
+++ b/velox/vector/arrow/Bridge.h
@@ -37,7 +37,7 @@ struct ArrowOptions {
   bool flattenConstant{false};
   TimestampUnit timestampUnit = TimestampUnit::kNano;
   std::optional<std::string> timestampTimeZone{std::nullopt};
-  bool exportToView = false;
+  bool exportToStringView = false;
 };
 
 namespace facebook::velox {

--- a/velox/vector/arrow/Bridge.h
+++ b/velox/vector/arrow/Bridge.h
@@ -37,6 +37,7 @@ struct ArrowOptions {
   bool flattenConstant{false};
   TimestampUnit timestampUnit = TimestampUnit::kNano;
   std::optional<std::string> timestampTimeZone{std::nullopt};
+  // Export VARCHAR and VARBINARY to Arrow 15 StringView format
   bool exportToStringView = false;
 };
 

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -1618,7 +1618,7 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
           ASSERT_EQ(*vec.type(), *VARCHAR());
           EXPECT_EQ(vec.size(), 12);
         },
-        ArrowOptions{.exportToView = true});
+        ArrowOptions{.exportToStringView = true});
   }
 
   void testImportREE() {
@@ -1797,7 +1797,6 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
     EXPECT_NO_THROW(importFromArrow(arrowSchema, arrowArray, pool_.get()));
   }
 
-  ArrowOptions options_;
   std::shared_ptr<memory::MemoryPool> pool_{
       memory::memoryManager()->addLeafPool()};
 };

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -1511,15 +1511,18 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
   }
 
   template <typename F>
-  void testArrowRoundTrip(const arrow::Array& array, F validateVector) {
+  void testArrowRoundTrip(
+      const arrow::Array& array,
+      F validateVector,
+      const ArrowOptions& options = ArrowOptions{}) {
     VectorPtr vec;
     toVeloxVector(array, vec);
     validateVector(*vec);
 
     ArrowSchema schema;
     ArrowArray data;
-    velox::exportToArrow(vec, schema, options_);
-    velox::exportToArrow(vec, data, pool_.get(), options_);
+    velox::exportToArrow(vec, schema, options);
+    velox::exportToArrow(vec, data, pool_.get(), options);
     ASSERT_OK_AND_ASSIGN(auto arrowType, arrow::ImportType(&schema));
     ASSERT_OK_AND_ASSIGN(auto array2, arrow::ImportArray(&data, arrowType));
     ASSERT_OK(array2->ValidateFull());
@@ -1580,6 +1583,42 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
       EXPECT_EQ(vec.encoding(), VectorEncoding::Simple::DICTIONARY);
       EXPECT_EQ(vec.size(), 60);
     });
+  }
+
+  void testImportStringView() {
+    arrow::StringViewBuilder sb(arrow::default_memory_pool());
+    ASSERT_OK(sb.Append("hello world", 11));
+    ASSERT_OK(sb.Append("larger string which should not be inlined...", 44));
+    ASSERT_OK(sb.AppendNull());
+    ASSERT_OK(sb.Append("hello", 5));
+    ASSERT_OK(sb.Append("", 0));
+    ASSERT_OK(sb.Append("my string", 9));
+    ASSERT_OK(sb.Append("another slightly longer string", 30));
+    ASSERT_OK(sb.AppendNull());
+    ASSERT_OK(sb.Append("a", 1));
+    ASSERT_OK(sb.Append(
+        "another even longer string to ensure it's for sure not stored inline!!!",
+        71));
+    ASSERT_OK(sb.AppendNull());
+    ASSERT_OK(sb.AppendNull());
+    ASSERT_OK_AND_ASSIGN(auto array, sb.Finish());
+    const void* stringBuffers = array->data()->buffers[2]->data();
+
+    testArrowRoundTrip(
+        *array,
+        [stringBuffers](const BaseVector& vec) {
+          // assert zero-copy import to velox for stringBuffers
+          ASSERT_EQ(
+              vec.asFlatVector<StringView>()
+                  ->stringBuffers()
+                  .data()
+                  ->get()
+                  ->as<void*>(),
+              stringBuffers);
+          ASSERT_EQ(*vec.type(), *VARCHAR());
+          EXPECT_EQ(vec.size(), 12);
+        },
+        ArrowOptions{.exportToView = true});
   }
 
   void testImportREE() {
@@ -1791,6 +1830,10 @@ TEST_F(ArrowBridgeArrayImportAsViewerTest, string) {
   testImportString();
 }
 
+TEST_F(ArrowBridgeArrayImportAsViewerTest, stringview) {
+  testImportStringView();
+}
+
 TEST_F(ArrowBridgeArrayImportAsViewerTest, row) {
   testImportRow();
 }
@@ -1842,6 +1885,10 @@ TEST_F(ArrowBridgeArrayImportAsOwnerTest, without_nulls_buffer) {
 
 TEST_F(ArrowBridgeArrayImportAsOwnerTest, string) {
   testImportString();
+}
+
+TEST_F(ArrowBridgeArrayImportAsOwnerTest, stringview) {
+  testImportStringView();
 }
 
 TEST_F(ArrowBridgeArrayImportAsOwnerTest, row) {

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -33,9 +33,12 @@ class ArrowBridgeSchemaExportTest : public testing::Test {
     memory::MemoryManager::testingSetInstance({});
   }
 
-  void testScalarType(const TypePtr& type, const char* arrowFormat) {
+  void testScalarType(
+      const TypePtr& type,
+      const char* arrowFormat,
+      const ArrowOptions& options = ArrowOptions{}) {
     ArrowSchema arrowSchema;
-    exportToArrow(type, arrowSchema);
+    exportToArrow(type, arrowSchema, options);
 
     verifyScalarType(arrowSchema, arrowFormat);
 
@@ -105,7 +108,10 @@ class ArrowBridgeSchemaExportTest : public testing::Test {
     }
   }
 
-  void testConstant(const TypePtr& type, const char* arrowFormat) {
+  void testConstant(
+      const TypePtr& type,
+      const char* arrowFormat,
+      const ArrowOptions& options = ArrowOptions{}) {
     ArrowSchema arrowSchema;
     const bool isScalar = (type->size() == 0);
     const bool constantSize = 100;
@@ -120,7 +126,7 @@ class ArrowBridgeSchemaExportTest : public testing::Test {
               3, // index to use for the constant
               BaseVector::create(type, 100, pool_.get()));
 
-    velox::exportToArrow(constantVector, arrowSchema, options_);
+    velox::exportToArrow(constantVector, arrowSchema, options);
 
     EXPECT_STREQ("+r", arrowSchema.format);
     EXPECT_EQ(nullptr, arrowSchema.name);
@@ -154,9 +160,12 @@ class ArrowBridgeSchemaExportTest : public testing::Test {
     EXPECT_EQ(nullptr, arrowSchema.private_data);
   }
 
-  void exportToArrow(const TypePtr& type, ArrowSchema& out) {
+  void exportToArrow(
+      const TypePtr& type,
+      ArrowSchema& out,
+      const ArrowOptions& options = ArrowOptions{}) {
     velox::exportToArrow(
-        BaseVector::create(type, 0, pool_.get()), out, options_);
+        BaseVector::create(type, 0, pool_.get()), out, options);
   }
 
   ArrowSchema makeArrowSchema(const char* format) {
@@ -173,7 +182,6 @@ class ArrowBridgeSchemaExportTest : public testing::Test {
     };
   }
 
-  ArrowOptions options_;
   std::shared_ptr<memory::MemoryPool> pool_{
       memory::memoryManager()->addLeafPool()};
 };
@@ -201,6 +209,9 @@ TEST_F(ArrowBridgeSchemaExportTest, scalar) {
   testScalarType(TIMESTAMP(), "tsu:");
   options_.timestampUnit = TimestampUnit::kNano;
   testScalarType(TIMESTAMP(), "tsn:");
+
+  testScalarType(VARCHAR(), "vu", {.exportToStringView = true});
+  testScalarType(VARBINARY(), "vz", {.exportToStringView = true});
 
   // Test specific timezone
   options_.timestampTimeZone = "+01:0";
@@ -262,6 +273,7 @@ TEST_F(ArrowBridgeSchemaExportTest, constant) {
   testConstant(BOOLEAN(), "b");
   testConstant(DOUBLE(), "g");
   testConstant(VARCHAR(), "u");
+  testConstant(VARCHAR(), "vu", {.exportToStringView = true});
   testConstant(DATE(), "tdD");
   testConstant(INTERVAL_YEAR_MONTH(), "tiM");
   testConstant(UNKNOWN(), "n");
@@ -383,6 +395,9 @@ TEST_F(ArrowBridgeSchemaImportTest, scalar) {
   EXPECT_EQ(*VARBINARY(), *testSchemaImport("z"));
   EXPECT_EQ(*VARBINARY(), *testSchemaImport("Z"));
 
+  EXPECT_EQ(*VARCHAR(), *testSchemaImport("vu"));
+  EXPECT_EQ(*VARBINARY(), *testSchemaImport("vz"));
+
   // Temporal.
   EXPECT_EQ(*TIMESTAMP(), *testSchemaImport("tsn:"));
   EXPECT_EQ(*DATE(), *testSchemaImport("tdD"));
@@ -471,20 +486,24 @@ class ArrowBridgeSchemaTest : public testing::Test {
     memory::MemoryManager::testingSetInstance({});
   }
 
-  void roundtripTest(const TypePtr& inputType) {
+  void roundtripTest(
+      const TypePtr& inputType,
+      const ArrowOptions& options = ArrowOptions{}) {
     ArrowSchema arrowSchema;
-    exportToArrow(inputType, arrowSchema);
+    exportToArrow(inputType, arrowSchema, options);
     auto outputType = importFromArrow(arrowSchema);
     arrowSchema.release(&arrowSchema);
     EXPECT_EQ(*inputType, *outputType);
   }
 
-  void exportToArrow(const TypePtr& type, ArrowSchema& out) {
+  void exportToArrow(
+      const TypePtr& type,
+      ArrowSchema& out,
+      const ArrowOptions& options = ArrowOptions{}) {
     velox::exportToArrow(
-        BaseVector::create(type, 0, pool_.get()), out, options_);
+        BaseVector::create(type, 0, pool_.get()), out, options);
   }
 
-  ArrowOptions options_;
   std::shared_ptr<memory::MemoryPool> pool_{
       memory::memoryManager()->addLeafPool()};
 };
@@ -492,6 +511,7 @@ class ArrowBridgeSchemaTest : public testing::Test {
 TEST_F(ArrowBridgeSchemaTest, roundtrip) {
   roundtripTest(BOOLEAN());
   roundtripTest(VARCHAR());
+  roundtripTest(VARCHAR(), {.exportToStringView = true});
   roundtripTest(REAL());
   roundtripTest(ARRAY(DOUBLE()));
   roundtripTest(ARRAY(ARRAY(ARRAY(ARRAY(VARBINARY())))));
@@ -512,6 +532,7 @@ TEST_F(ArrowBridgeSchemaTest, validateInArrow) {
   const std::pair<TypePtr, std::shared_ptr<arrow::DataType>> kTypes[] = {
       {BOOLEAN(), arrow::boolean()},
       {VARCHAR(), arrow::utf8()},
+      {VARCHAR(), arrow::utf8_view()},
       {DECIMAL(10, 4), arrow::decimal(10, 4)},
       {DECIMAL(20, 15), arrow::decimal(20, 15)},
       {ARRAY(DOUBLE()), arrow::list(arrow::float64())},
@@ -526,7 +547,9 @@ TEST_F(ArrowBridgeSchemaTest, validateInArrow) {
     VLOG(1) << "Validating conversion between " << tv->toString() << " and "
             << ta->ToString();
     ArrowSchema schema;
-    exportToArrow(tv, schema);
+    ta == arrow::utf8_view()
+        ? exportToArrow(tv, schema, {.exportToStringView = true})
+        : exportToArrow(tv, schema);
     ASSERT_OK_AND_ASSIGN(auto actual, arrow::ImportType(&schema));
     ASSERT_FALSE(schema.release);
     EXPECT_EQ(*actual, *ta);

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -201,28 +201,32 @@ TEST_F(ArrowBridgeSchemaExportTest, scalar) {
   testScalarType(VARBINARY(), "z");
 
   // Test default timezone
-  options_.timestampUnit = TimestampUnit::kSecond;
-  testScalarType(TIMESTAMP(), "tss:");
-  options_.timestampUnit = TimestampUnit::kMilli;
-  testScalarType(TIMESTAMP(), "tsm:");
-  options_.timestampUnit = TimestampUnit::kMicro;
-  testScalarType(TIMESTAMP(), "tsu:");
-  options_.timestampUnit = TimestampUnit::kNano;
-  testScalarType(TIMESTAMP(), "tsn:");
+  testScalarType(
+      TIMESTAMP(), "tss:", {.timestampUnit = TimestampUnit::kSecond});
+  testScalarType(TIMESTAMP(), "tsm:", {.timestampUnit = TimestampUnit::kMilli});
+  testScalarType(TIMESTAMP(), "tsu:", {.timestampUnit = TimestampUnit::kMicro});
+  testScalarType(TIMESTAMP(), "tsn:", {.timestampUnit = TimestampUnit::kNano});
 
   testScalarType(VARCHAR(), "vu", {.exportToStringView = true});
   testScalarType(VARBINARY(), "vz", {.exportToStringView = true});
 
   // Test specific timezone
-  options_.timestampTimeZone = "+01:0";
-  options_.timestampUnit = TimestampUnit::kSecond;
-  testScalarType(TIMESTAMP(), "tss:+01:0");
-  options_.timestampUnit = TimestampUnit::kMilli;
-  testScalarType(TIMESTAMP(), "tsm:+01:0");
-  options_.timestampUnit = TimestampUnit::kMicro;
-  testScalarType(TIMESTAMP(), "tsu:+01:0");
-  options_.timestampUnit = TimestampUnit::kNano;
-  testScalarType(TIMESTAMP(), "tsn:+01:0");
+  testScalarType(
+      TIMESTAMP(),
+      "tss:+01:0",
+      {.timestampUnit = TimestampUnit::kSecond, .timestampTimeZone = "+01:0"});
+  testScalarType(
+      TIMESTAMP(),
+      "tsm:+01:0",
+      {.timestampUnit = TimestampUnit::kMilli, .timestampTimeZone = "+01:0"});
+  testScalarType(
+      TIMESTAMP(),
+      "tsu:+01:0",
+      {.timestampUnit = TimestampUnit::kMicro, .timestampTimeZone = "+01:0"});
+  testScalarType(
+      TIMESTAMP(),
+      "tsn:+01:0",
+      {.timestampUnit = TimestampUnit::kNano, .timestampTimeZone = "+01:0"});
 
   testScalarType(DATE(), "tdD");
   testScalarType(INTERVAL_YEAR_MONTH(), "tiM");


### PR DESCRIPTION
This change adds support for import/export of BinaryView and StringView from/to Arrow significantly boosting the performance of import and export of strings through the Arrow bridge.

Benchmark results show a gain of 4.3x (non-inline strings) - 18x (inline strings) faster for export and 2.2x (non-inline strings) - 7x (inline strings) faster for import of utf8view strings as compared to utf8 strings.