### PR TITLE
Add custom argument generators for Spark decimal functions

### DIFF
--- a/velox/functions/sparksql/fuzzer/AddSubtractArgGenerator.h
+++ b/velox/functions/sparksql/fuzzer/AddSubtractArgGenerator.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/expression/fuzzer/DecimalArgGeneratorBase.h"
+#include "velox/functions/sparksql/DecimalUtil.h"
+
+namespace facebook::velox::functions::sparksql::fuzzer {
+
+class AddSubtractArgGenerator : public velox::fuzzer::DecimalArgGeneratorBase {
+ public:
+  AddSubtractArgGenerator() {
+    initialize(2);
+  }
+
+ protected:
+  std::optional<std::pair<int, int>>
+  toReturnType(int p1, int s1, int p2, int s2) override {
+    const auto precision = std::max(p1 - s1, p2 - s2) + std::max(s1, s2) + 1;
+    const auto scale = std::max(s1, s2);
+    return DecimalUtil::adjustPrecisionScale(precision, scale);
+  }
+};
+
+} // namespace facebook::velox::functions::sparksql::fuzzer

--- a/velox/functions/sparksql/fuzzer/DivideArgGenerator.h
+++ b/velox/functions/sparksql/fuzzer/DivideArgGenerator.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/expression/fuzzer/DecimalArgGeneratorBase.h"
+#include "velox/functions/sparksql/DecimalUtil.h"
+
+namespace facebook::velox::functions::sparksql::fuzzer {
+
+class DivideArgGenerator : public velox::fuzzer::DecimalArgGeneratorBase {
+ public:
+  DivideArgGenerator() {
+    initialize(2);
+  }
+
+ protected:
+  std::optional<std::pair<int, int>>
+  toReturnType(int p1, int s1, int p2, int s2) override {
+    const auto scale = std::max(6, s1 + p2 + 1);
+    const auto precision = p1 - s1 + s2 + scale;
+    return DecimalUtil::adjustPrecisionScale(precision, scale);
+  }
+};
+
+} // namespace facebook::velox::functions::sparksql::fuzzer

--- a/velox/functions/sparksql/fuzzer/MakeTimestampArgGenerator.h
+++ b/velox/functions/sparksql/fuzzer/MakeTimestampArgGenerator.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <boost/random/uniform_int_distribution.hpp>
+#include "velox/expression/fuzzer/ArgGenerator.h"
+#include "velox/functions/sparksql/DecimalUtil.h"
+
+namespace facebook::velox::functions::sparksql::fuzzer {
+
+class MakeTimestampArgGenerator : public velox::fuzzer::ArgGenerator {
+ public:
+  std::vector<TypePtr> generateArgs(
+      const exec::FunctionSignature& signature,
+      const TypePtr& returnType,
+      FuzzerGenerator& rng) override {
+    const auto s = 6;
+    const auto p = rand32(s, ShortDecimalType::kMaxPrecision, rng);
+    std::vector<TypePtr> types = {
+        INTEGER(), INTEGER(), INTEGER(), INTEGER(), INTEGER(), DECIMAL(p, s)};
+
+    if (signature.argumentTypes().size() == 6) {
+      return types;
+    }
+    types.push_back(VARCHAR());
+    return types;
+  }
+
+ private:
+  static uint32_t rand32(uint32_t min, uint32_t max, FuzzerGenerator& rng) {
+    return boost::random::uniform_int_distribution<uint32_t>(min, max)(rng);
+  }
+};
+
+} // namespace facebook::velox::functions::sparksql::fuzzer

--- a/velox/functions/sparksql/fuzzer/MultiplyArgGenerator.h
+++ b/velox/functions/sparksql/fuzzer/MultiplyArgGenerator.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/expression/fuzzer/DecimalArgGeneratorBase.h"
+#include "velox/functions/sparksql/DecimalUtil.h"
+
+namespace facebook::velox::functions::sparksql::fuzzer {
+
+class MultiplyArgGenerator : public velox::fuzzer::DecimalArgGeneratorBase {
+ public:
+  MultiplyArgGenerator() {
+    initialize(2);
+  }
+
+ protected:
+  std::optional<std::pair<int, int>>
+  toReturnType(int p1, int s1, int p2, int s2) override {
+    return DecimalUtil::adjustPrecisionScale(p1 + p2 + 1, s1 + s2);
+  }
+};
+
+} // namespace facebook::velox::functions::sparksql::fuzzer

--- a/velox/functions/sparksql/fuzzer/UnscaledValueArgGenerator.h
+++ b/velox/functions/sparksql/fuzzer/UnscaledValueArgGenerator.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <boost/random/uniform_int_distribution.hpp>
+#include "velox/expression/fuzzer/ArgGenerator.h"
+#include "velox/functions/sparksql/DecimalUtil.h"
+
+namespace facebook::velox::functions::sparksql::fuzzer {
+
+class UnscaledValueArgGenerator : public velox::fuzzer::ArgGenerator {
+ public:
+  std::vector<TypePtr> generateArgs(
+      const exec::FunctionSignature& signature,
+      const TypePtr& returnType,
+      FuzzerGenerator& rng) override {
+    const auto p = rand32(
+        ShortDecimalType::kMinPrecision, ShortDecimalType::kMaxPrecision, rng);
+    const auto s = rand32(0, p, rng);
+
+    return {DECIMAL(p, s)};
+  }
+
+ private:
+  static uint32_t rand32(uint32_t min, uint32_t max, FuzzerGenerator& rng) {
+    return boost::random::uniform_int_distribution<uint32_t>(min, max)(rng);
+  }
+};
+
+} // namespace facebook::velox::functions::sparksql::fuzzer

--- a/velox/functions/sparksql/tests/ArgGeneratorTest.cpp
+++ b/velox/functions/sparksql/tests/ArgGeneratorTest.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/expression/fuzzer/tests/ArgGeneratorTestUtils.h"
+#include "velox/functions/FunctionRegistry.h"
+#include "velox/functions/sparksql/fuzzer/AddSubtractArgGenerator.h"
+#include "velox/functions/sparksql/fuzzer/DivideArgGenerator.h"
+#include "velox/functions/sparksql/fuzzer/MakeTimestampArgGenerator.h"
+#include "velox/functions/sparksql/fuzzer/MultiplyArgGenerator.h"
+#include "velox/functions/sparksql/fuzzer/UnscaledValueArgGenerator.h"
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+using namespace facebook::velox::fuzzer::test;
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class ArgGeneratorTest : public SparkFunctionBaseTest {
+ protected:
+  // Assert that the generated argument types meet user-specified check.
+  void assertArgumentTypes(
+      std::shared_ptr<velox::fuzzer::ArgGenerator> generator,
+      const exec::FunctionSignature& signature,
+      const TypePtr& returnType,
+      std::function<void(const std::vector<TypePtr>&)> check) {
+    std::mt19937 seed{0};
+    const auto argTypes = generator->generateArgs(signature, returnType, seed);
+    check(argTypes);
+  }
+
+  // Returns the only signature with specified return type for a given function
+  // name.
+  // @param returnType The name of expected return type defined in function
+  // signature. Default is 'decimal'.
+  const exec::FunctionSignature& getOnlySignature(
+      const std::string& functionName,
+      const std::string& returnType = "decimal") {
+    const auto signatures = getSignatures(functionName, returnType);
+    VELOX_CHECK_EQ(signatures.size(), 1);
+    return *signatures[0];
+  }
+};
+
+TEST_F(ArgGeneratorTest, add) {
+  const auto& signature = getOnlySignature("add");
+  const auto generator = std::make_shared<fuzzer::AddSubtractArgGenerator>();
+
+  assertReturnType(generator, signature, DECIMAL(10, 2));
+  assertReturnType(generator, signature, DECIMAL(32, 6));
+  assertReturnType(generator, signature, DECIMAL(38, 20));
+  assertReturnType(generator, signature, DECIMAL(38, 0));
+  assertEmptyArgs(generator, signature, DECIMAL(18, 18));
+  assertEmptyArgs(generator, signature, DECIMAL(38, 38));
+}
+
+TEST_F(ArgGeneratorTest, subtract) {
+  const auto& signature = getOnlySignature("subtract");
+  const auto generator = std::make_shared<fuzzer::AddSubtractArgGenerator>();
+
+  assertReturnType(generator, signature, DECIMAL(10, 2));
+  assertReturnType(generator, signature, DECIMAL(32, 6));
+  assertReturnType(generator, signature, DECIMAL(38, 20));
+  assertReturnType(generator, signature, DECIMAL(38, 0));
+  assertEmptyArgs(generator, signature, DECIMAL(18, 18));
+  assertEmptyArgs(generator, signature, DECIMAL(38, 38));
+}
+
+TEST_F(ArgGeneratorTest, multiply) {
+  const auto& signature = getOnlySignature("multiply");
+  const auto generator = std::make_shared<fuzzer::MultiplyArgGenerator>();
+
+  assertReturnType(generator, signature, DECIMAL(10, 2));
+  assertReturnType(generator, signature, DECIMAL(32, 6));
+  assertReturnType(generator, signature, DECIMAL(38, 20));
+  assertReturnType(generator, signature, DECIMAL(38, 0));
+  assertEmptyArgs(generator, signature, DECIMAL(18, 18));
+  assertEmptyArgs(generator, signature, DECIMAL(38, 38));
+}
+
+TEST_F(ArgGeneratorTest, divide) {
+  const auto& signature = getOnlySignature("divide");
+  const auto generator = std::make_shared<fuzzer::DivideArgGenerator>();
+
+  assertReturnType(generator, signature, DECIMAL(32, 6));
+  assertReturnType(generator, signature, DECIMAL(38, 20));
+  assertReturnType(generator, signature, DECIMAL(18, 18));
+  assertReturnType(generator, signature, DECIMAL(38, 38));
+  assertEmptyArgs(generator, signature, DECIMAL(38, 0));
+  assertEmptyArgs(generator, signature, DECIMAL(10, 2));
+}
+
+TEST_F(ArgGeneratorTest, makeTimestamp) {
+  const auto signatures = getSignatures("make_timestamp", "timestamp");
+  VELOX_CHECK_EQ(signatures.size(), 2);
+  bool isSixArgs = signatures[0]->argumentTypes().size() == 6;
+  const auto generator = std::make_shared<fuzzer::MakeTimestampArgGenerator>();
+
+  std::function<void(const TypePtr&)> assertDecimalType =
+      [](const TypePtr& type) {
+        ASSERT_TRUE(type->isShortDecimal());
+        auto [precision, scale] = getDecimalPrecisionScale(*type);
+        ASSERT_EQ(scale, 6);
+      };
+
+  const auto& sixArgsSignature = isSixArgs ? *signatures[0] : *signatures[1];
+  assertReturnType(generator, sixArgsSignature, TIMESTAMP());
+  assertArgumentTypes(
+      generator,
+      sixArgsSignature,
+      TIMESTAMP(),
+      [&](const std::vector<TypePtr>& argumentTypes) {
+        EXPECT_EQ(argumentTypes.size(), 6);
+        assertDecimalType(argumentTypes[5]);
+      });
+
+  const auto& sevenArgsSignature = isSixArgs ? *signatures[1] : *signatures[0];
+  assertReturnType(generator, sevenArgsSignature, TIMESTAMP());
+  assertArgumentTypes(
+      generator,
+      sevenArgsSignature,
+      TIMESTAMP(),
+      [&](const std::vector<TypePtr>& argumentTypes) {
+        EXPECT_EQ(argumentTypes.size(), 7);
+        assertDecimalType(argumentTypes[5]);
+      });
+}
+
+TEST_F(ArgGeneratorTest, unscaledValue) {
+  const auto& signature = getOnlySignature("unscaled_value", "bigint");
+  const auto generator = std::make_shared<fuzzer::UnscaledValueArgGenerator>();
+
+  assertReturnType(generator, signature, BIGINT());
+  assertArgumentTypes(
+      generator,
+      signature,
+      BIGINT(),
+      [](const std::vector<TypePtr>& argumentTypes) {
+        EXPECT_EQ(argumentTypes.size(), 1);
+        ASSERT_TRUE(argumentTypes[0]->isShortDecimal());
+      });
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(
   ArraySizeTest.cpp
   ArraySortTest.cpp
   ArrayShuffleTest.cpp
+  ArgGeneratorTest.cpp
   BitwiseTest.cpp
   ComparisonsTest.cpp
   DateTimeFunctionsTest.cpp
@@ -58,6 +59,8 @@ target_link_libraries(
   velox_functions_spark
   velox_functions_test_lib
   velox_exec_test_lib
+  velox_expression_fuzzer_test_utility
+  velox_expression_fuzzer
   fmt::fmt
   gtest
   gtest_main


### PR DESCRIPTION
To generate argument types in the decimal fuzzer test correctly, customized 
argument type generators are required. This PR adds arg generators for the 
Spark functions add/subtract, multiply, divide, make_timestamp and
unscaled_value.