### PR TITLE
Add RetryStrategy for S3 file system

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -120,9 +120,9 @@ std::optional<uint32_t> HiveConfig::s3MaxConnections() const {
       config_->get<uint32_t>(kS3MaxConnections));
 }
 
-std::optional<uint32_t> HiveConfig::s3MaxAttempts() const {
-  return static_cast<std::optional<std::uint32_t>>(
-      config_->get<uint32_t>(kS3MaxAttempts));
+std::optional<int32_t> HiveConfig::s3MaxAttempts() const {
+  return static_cast<std::optional<std::int32_t>>(
+      config_->get<int32_t>(kS3MaxAttempts));
 }
 
 std::optional<std::string> HiveConfig::s3RetryMode() const {

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -120,6 +120,16 @@ std::optional<uint32_t> HiveConfig::s3MaxConnections() const {
       config_->get<uint32_t>(kS3MaxConnections));
 }
 
+std::optional<uint32_t> HiveConfig::s3MaxAttempts() const {
+  return static_cast<std::optional<std::uint32_t>>(
+      config_->get<uint32_t>(kS3MaxAttempts));
+}
+
+std::optional<std::string> HiveConfig::s3RetryMode() const {
+  return static_cast<std::optional<std::string>>(
+      config_->get<std::string>(kS3RetryMode));
+}
+
 std::string HiveConfig::gcsEndpoint() const {
   return config_->get<std::string>(kGCSEndpoint, std::string(""));
 }

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -98,6 +98,12 @@ class HiveConfig {
   /// Maximum concurrent TCP connections for a single http client.
   static constexpr const char* kS3MaxConnections = "hive.s3.max-connections";
 
+  /// Maximum retry attempts for a single http client.
+  static constexpr const char* kS3MaxAttempts = "hive.s3.max-attempts";
+
+  /// Retry mode for a single http client.
+  static constexpr const char* kS3RetryMode = "hive.s3.retry-mode";
+
   /// The GCS storage endpoint server.
   static constexpr const char* kGCSEndpoint = "hive.gcs.endpoint";
 
@@ -245,6 +251,10 @@ class HiveConfig {
   std::optional<std::string> s3SocketTimeout() const;
 
   std::optional<uint32_t> s3MaxConnections() const;
+
+  std::optional<uint32_t> s3MaxAttempts() const;
+
+  std::optional<std::string> s3RetryMode() const;
 
   std::string gcsEndpoint() const;
 

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -252,7 +252,7 @@ class HiveConfig {
 
   std::optional<uint32_t> s3MaxConnections() const;
 
-  std::optional<uint32_t> s3MaxAttempts() const;
+  std::optional<int32_t> s3MaxAttempts() const;
 
   std::optional<std::string> s3RetryMode() const;
 

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -656,7 +656,7 @@ class S3FileSystem::Impl {
         if (maxAttempts.has_value()) {
           VELOX_USER_CHECK(
               (maxAttempts.value() > 0),
-              "Invalid configuration: specify 'max-attempts' > 0.");
+              "Invalid configuration: specify 'hive.s3.max-attempts' > 0.");
           return std::make_shared<Aws::Client::StandardRetryStrategy>(
               maxAttempts.value());
         } else {
@@ -667,7 +667,7 @@ class S3FileSystem::Impl {
         if (maxAttempts.has_value()) {
           VELOX_USER_CHECK(
               (maxAttempts.value() > 0),
-              "Invalid configuration: specify 'max-attempts' > 0.");
+              "Invalid configuration: specify 'hive.s3.max-attempts' > 0.");
           return std::make_shared<Aws::Client::AdaptiveRetryStrategy>(
               maxAttempts.value());
         } else {
@@ -678,7 +678,7 @@ class S3FileSystem::Impl {
         if (maxAttempts.has_value()) {
           VELOX_USER_CHECK(
               (maxAttempts.value() > 0),
-              "Invalid configuration: specify 'max-attempts' > 0.");
+              "Invalid configuration: specify 'hive.s3.max-attempts' > 0.");
           return std::make_shared<Aws::Client::DefaultRetryStrategy>(
               maxAttempts.value());
         } else {

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -654,9 +654,11 @@ class S3FileSystem::Impl {
     if (retryMode.has_value()) {
       if (retryMode.value() == "standard") {
         if (maxAttempts.has_value()) {
-          VELOX_USER_CHECK(
-              (maxAttempts.value() > 0),
-              "Invalid configuration: specify 'hive.s3.max-attempts' > 0.");
+          VELOX_USER_CHECK_GE(
+              maxAttempts.value(),
+              0,
+              "Invalid configuration: specified 'hive.s3.max-attempts' value {} is < 0.",
+              maxAttempts.value());
           return std::make_shared<Aws::Client::StandardRetryStrategy>(
               maxAttempts.value());
         } else {
@@ -665,9 +667,11 @@ class S3FileSystem::Impl {
         }
       } else if (retryMode.value() == "adaptive") {
         if (maxAttempts.has_value()) {
-          VELOX_USER_CHECK(
-              (maxAttempts.value() > 0),
-              "Invalid configuration: specify 'hive.s3.max-attempts' > 0.");
+          VELOX_USER_CHECK_GE(
+              maxAttempts.value(),
+              0,
+              "Invalid configuration: specified 'hive.s3.max-attempts' value {} is < 0.",
+              maxAttempts.value());
           return std::make_shared<Aws::Client::AdaptiveRetryStrategy>(
               maxAttempts.value());
         } else {
@@ -676,9 +680,11 @@ class S3FileSystem::Impl {
         }
       } else if (retryMode.value() == "legacy") {
         if (maxAttempts.has_value()) {
-          VELOX_USER_CHECK(
-              (maxAttempts.value() > 0),
-              "Invalid configuration: specify 'hive.s3.max-attempts' > 0.");
+          VELOX_USER_CHECK_GE(
+              maxAttempts.value(),
+              0,
+              "Invalid configuration: specified 'hive.s3.max-attempts' value {} is < 0.",
+              maxAttempts.value());
           return std::make_shared<Aws::Client::DefaultRetryStrategy>(
               maxAttempts.value());
         } else {

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
@@ -157,25 +157,31 @@ inline std::string getRequestID(
 } // namespace
 
 /// Only Amazon (amz) and Alibaba (oss) request IDs are supported.
-#define VELOX_CHECK_AWS_OUTCOME(outcome, errorMsgPrefix, bucket, key)                                                          \
-  {                                                                                                                            \
-    if (!outcome.IsSuccess()) {                                                                                                \
-      auto error = outcome.GetError();                                                                                         \
-      auto errMsg = fmt::format(                                                                                               \
-          "{} due to: '{}'. Path:'{}', SDK Error Type:{}, HTTP Status Code:{}, S3 Service:'{}', Message:'{}', RequestID:'{}'", \
-          errorMsgPrefix,                                                                                                      \
-          getErrorStringFromS3Error(error),                                                                                    \
-          s3URI(bucket, key),                                                                                                  \
-          static_cast<int>(error.GetErrorType()),                                                                              \
-          error.GetResponseCode(),                                                                                             \
-          getS3BackendService(error.GetResponseHeaders()),                                                                     \
-          error.GetMessage(),                                                                                                  \
-          getRequestID(error.GetResponseHeaders()));                                                                           \
-      if (error.GetResponseCode() == Aws::Http::HttpResponseCode::NOT_FOUND) {                                                 \
-        VELOX_FILE_NOT_FOUND_ERROR(errMsg);                                                                                    \
-      }                                                                                                                        \
-      VELOX_FAIL(errMsg)                                                                                                       \
-    }                                                                                                                          \
+#define VELOX_CHECK_AWS_OUTCOME(outcome, errorMsgPrefix, bucket, key)                                                           \
+  {                                                                                                                             \
+    if (!outcome.IsSuccess()) {                                                                                                 \
+      auto error = outcome.GetError();                                                                                          \
+      auto errMsg = fmt::format(                                                                                                \
+          "{} due to: '{}'. Path:'{}', SDK Error Type:{}, HTTP Status Code:{}, S3 Service:'{}', Message:'{}', RequestID:'{}'.", \
+          errorMsgPrefix,                                                                                                       \
+          getErrorStringFromS3Error(error),                                                                                     \
+          s3URI(bucket, key),                                                                                                   \
+          static_cast<int>(error.GetErrorType()),                                                                               \
+          error.GetResponseCode(),                                                                                              \
+          getS3BackendService(error.GetResponseHeaders()),                                                                      \
+          error.GetMessage(),                                                                                                   \
+          getRequestID(error.GetResponseHeaders()));                                                                            \
+      if (IsRetryableHttpResponseCode(error.GetResponseCode())) {                                                               \
+        auto retryHint = fmt::format(                                                                                           \
+            " This request gets retriable response and has retried {} times, you may increase 'hive.s3.max-attempts'.",         \
+            outcome.GetRetryCount());                                                                                           \
+        errMsg.append(retryHint);                                                                                               \
+      }                                                                                                                         \
+      if (error.GetResponseCode() == Aws::Http::HttpResponseCode::NOT_FOUND) {                                                  \
+        VELOX_FILE_NOT_FOUND_ERROR(errMsg);                                                                                     \
+      }                                                                                                                         \
+      VELOX_FAIL(errMsg)                                                                                                        \
+    }                                                                                                                           \
   }
 
 bool isHostExcludedFromProxy(

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
@@ -173,7 +173,7 @@ inline std::string getRequestID(
           getRequestID(error.GetResponseHeaders()));                                                                            \
       if (IsRetryableHttpResponseCode(error.GetResponseCode())) {                                                               \
         auto retryHint = fmt::format(                                                                                           \
-            " This request gets retriable response and has retried {} times, you may increase 'hive.s3.max-attempts'.",         \
+            " Request failed after retrying {} times. Try increasing the value of 'hive.s3.max-attempts'.",                     \
             outcome.GetRetryCount());                                                                                           \
         errMsg.append(retryHint);                                                                                               \
       }                                                                                                                         \

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -559,7 +559,14 @@ Each query can override the config by setting corresponding query session proper
      - integer
      -
      - Maximum concurrent TCP connections for a single http client.
-
+   * - hive.s3.max-attempts
+     - integer
+     -
+     - Maximum attempts for connections to a single http client.
+   * - hive.s3.retry-mode
+     - string
+     -
+     - 'standard' or 'adaptive', use DefaultRetryStrategy if it's empty.
 ``Google Cloud Storage Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. list-table::

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -567,7 +567,8 @@ Each query can override the config by setting corresponding query session proper
    * - hive.s3.retry-mode
      - string
      -
-     - **Allowed values:** "standard", "adaptive", "legacy". By default use legacy mode, which only enables throttled retry for transient errors.
+     - **Allowed values:** "standard", "adaptive", "legacy". By default it's empty, S3 client will be created with RetryStrategy.
+       Legacy mode only enables throttled retry for transient errors.
        Standard mode is built on top of legacy mode and has throttled retry enabled for throttling errors apart from transient errors.
        Adaptive retry mode dynamically limits the rate of AWS requests to maximize success rate. 
 ``Google Cloud Storage Configuration``

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -562,11 +562,14 @@ Each query can override the config by setting corresponding query session proper
    * - hive.s3.max-attempts
      - integer
      -
-     - Maximum attempts for connections to a single http client.
+     - Maximum attempts for connections to a single http client, work together with retry-mode. By default, it's 3 for standard/adaptive mode
+       and 10 for legacy mode.
    * - hive.s3.retry-mode
      - string
      -
-     - 'standard' or 'adaptive', use DefaultRetryStrategy if it's empty.
+     - **Allowed values:** "standard", "adaptive", "legacy". By default use legacy mode, which only enables throttled retry for transient errors.
+       Standard mode is built on top of legacy mode and has throttled retry enabled for throttling errors apart from transient errors.
+       Adaptive retry mode dynamically limits the rate of AWS requests to maximize success rate. 
 ``Google Cloud Storage Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. list-table::


### PR DESCRIPTION
This PR add `RetryStrategy` support for s3 file system, thus it will retry when connection fails. It also upgrade aws sdk to `1.11.321` which  supports `AdaptiveRetryStrategy` which user may choose to use.

For `RetryStrategy`, 2 configs are added:

`hive.s3.max-attempts`: Maximum attempts for connections to a single http client.
`hive.s3.retry-mode`: 'standard'， 'adaptive' or `legacy`, client will be created w/o retrystrategy if it's empty.