### PR TITLE
 Avoid unnecessary reclaim on non-reclaimable query

### DIFF
--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -318,16 +318,25 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   Stats statsLocked() const;
 
   // Returns the max reclaimable capacity from 'pool' which includes both used
-  // and free capacities.
-  int64_t maxReclaimableCapacity(const MemoryPool& pool) const;
+  // and free capacities. If 'isSelfReclaim' true, we reclaim memory from the
+  // request pool itself so that we can bypass the reserved free capacity
+  // reclaim restriction.
+  int64_t maxReclaimableCapacity(const MemoryPool& pool, bool isSelfReclaim)
+      const;
 
   // Returns the free memory capacity that can be reclaimed from 'pool' by
-  // shrink.
-  int64_t reclaimableFreeCapacity(const MemoryPool& pool) const;
+  // shrink. If 'isSelfReclaim' true, we reclaim memory from the request pool
+  // itself so that we can bypass the reserved free capacity reclaim
+  // restriction.
+  int64_t reclaimableFreeCapacity(const MemoryPool& pool, bool isSelfReclaim)
+      const;
 
   // Returns the used memory capacity that can be reclaimed from 'pool' by
-  // disk spill.
-  int64_t reclaimableUsedCapacity(const MemoryPool& pool) const;
+  // disk spill. If 'isSelfReclaim' true, we reclaim memory from the request
+  // pool itself so that we can bypass the reserved free capacity reclaim
+  // restriction.
+  int64_t reclaimableUsedCapacity(const MemoryPool& pool, bool isSelfReclaim)
+      const;
 
   // Returns the minimal amount of memory capacity to grow for 'pool' to have
   // the reserved capacity as specified by 'memoryPoolReservedCapacity_'.

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -834,9 +834,9 @@ TEST_F(MockSharedArbitrationTest, shrinkPools) {
         {memoryPoolInitCapacity, true, 0, memoryPoolInitCapacity, false},
         {memoryPoolInitCapacity, false, 0, memoryPoolInitCapacity, false},
         {memoryPoolInitCapacity, true, 0, memoryPoolReserveCapacity, false}},
-       14 << 20,
-       14 << 20,
-       20 << 20,
+       12 << 20,
+       12 << 20,
+       18 << 20,
        reservedMemoryCapacity,
        true,
        false},
@@ -872,9 +872,9 @@ TEST_F(MockSharedArbitrationTest, shrinkPools) {
          memoryPoolReserveCapacity,
          memoryPoolReserveCapacity,
          false}},
-       14 << 20,
-       14 << 20,
-       20 << 20,
+       12 << 20,
+       12 << 20,
+       18 << 20,
        reservedMemoryCapacity,
        true,
        false},
@@ -2204,7 +2204,8 @@ TEST_F(MockSharedArbitrationTest, arbitrateWithMemoryReclaim) {
         kReservedMemoryCapacity - reservedPoolCapacity,
         16,
         0,
-        67108864);
+        58720256,
+        8388608);
 
     verifyReclaimerStats(
         arbitrateOp->reclaimer()->stats(), 0, 1, kMemoryPoolTransferCapacity);


### PR DESCRIPTION
Avoid unnecessary reclaim on non-reclaimable query which might spent time on waiting
for query task to pause.
Also allows arbitration to reclaim reserved capacity from the request pool itself.