### PR TITLE
Fix the lock order issue caused by value operator init

### DIFF
--- a/velox/exec/Values.h
+++ b/velox/exec/Values.h
@@ -25,6 +25,8 @@ class Values : public SourceOperator {
       DriverCtx* driverCtx,
       std::shared_ptr<const core::ValuesNode> values);
 
+  void initialize() override;
+
   RowVectorPtr getOutput() override;
 
   BlockingReason isBlocked(ContinueFuture* /* unused */) override {
@@ -55,6 +57,7 @@ class Values : public SourceOperator {
   }
 
  private:
+  std::shared_ptr<const core::ValuesNode> valueNodes_;
   std::vector<RowVectorPtr> values_;
   int32_t current_ = 0;
   size_t roundsLeft_ = 1;


### PR DESCRIPTION
The lock order issue detected by tsan is as follows:
T1: task startup creates driver and constructor operators which holds the task lock
T2: value operator constructor allocates memory from memory pool for parallelized value node mode
      which triggers memory arbitration 
T3: the memory arbitration grabs arbitration lock for arbitration
T4: the memory reclaim tries to grabs the task lock for reclaim such as to pause the task execution

This forms a deadlock and we have the logic to detect the memory pool allocation from the operator
constructor in driver execution framework. However the memory pool of vectors used by value nodes
is not the query memory pool but owns by the test framework. This PR moves the memory pool allocation
from constructor to initialize() method as the other operator does.