### PR TITLE
Prevent duplicates in writable regions

### DIFF
--- a/velox/common/caching/SsdFile.cpp
+++ b/velox/common/caching/SsdFile.cpp
@@ -583,9 +583,14 @@ bool SsdFile::removeFileEntries(
   }
   if (toFree.size() > 0) {
     clearRegionEntriesLocked(toFree);
-    writableRegions_.reserve(writableRegions_.size() + toFree.size());
+    writableRegions_.reserve(
+        std::min<size_t>(writableRegions_.size() + toFree.size(), numRegions_));
+    folly::F14FastSet<uint64_t> existingWritableRegions(
+        writableRegions_.begin(), writableRegions_.end());
     for (int32_t region : toFree) {
-      writableRegions_.push_back(region);
+      if (existingWritableRegions.count(region) == 0) {
+        writableRegions_.push_back(region);
+      }
     }
   }
 

--- a/velox/common/caching/SsdFile.h
+++ b/velox/common/caching/SsdFile.h
@@ -281,6 +281,10 @@ class SsdFile {
     return tracker_.copyScores();
   }
 
+  int32_t testingNumWritableRegions() const {
+    return writableRegions_.size();
+  }
+
  private:
   // 4 first bytes of a checkpoint file. Allows distinguishing between format
   // versions.


### PR DESCRIPTION
When TTL control ages out old cache entries and evict out the entire regions from a ssd file, it tries to add those evicted region back to the writable regions and this potentially could cause duplicate writable regions as the evicted region here might not necessarily be non-writable region.