### PR TITLE
Relax ApproxDistinctResultVerifier for small number of groups with large error bound

### DIFF
--- a/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
@@ -123,8 +123,7 @@ int main(int argc, char** argv) {
       std::shared_ptr<facebook::velox::exec::test::ResultVerifier>>
       customVerificationFunctions = {
           // Approx functions.
-          // https://github.com/facebookincubator/velox/issues/9531
-          {"approx_distinct", nullptr},
+          {"approx_distinct", std::make_shared<ApproxDistinctResultVerifier>()},
           {"approx_set", nullptr},
           {"approx_percentile", nullptr},
           {"approx_most_frequent", nullptr},


### PR DESCRIPTION
Summary:
When the number of groups is small, approx_distinct doesn't 
guarantee the standard error. And when the input error bound is 
large, the standard error is more likely to exceed the error bound. This 
diff relaxes ApproxDistinctResultVerifier to not check the standard 
error when the number of groups is below 50 and the error bound is 
larger than the default 2.3%.

Differential Revision: D57115412


