### PR TITLE
Move E2EFilterTestBase into tests/utils to be reused by Nimble

### DIFF
--- a/velox/dwio/common/ColumnSelector.h
+++ b/velox/dwio/common/ColumnSelector.h
@@ -18,6 +18,7 @@
 
 #include "velox/dwio/common/FilterNode.h"
 #include "velox/dwio/common/MetricsLog.h"
+#include "velox/dwio/common/ScanSpec.h"
 #include "velox/dwio/common/TypeWithId.h"
 
 namespace facebook::velox::dwio::common {
@@ -291,6 +292,10 @@ class ColumnSelector {
   static ColumnSelector apply(
       const std::shared_ptr<ColumnSelector>& origin,
       const std::shared_ptr<const velox::RowType>& fileSchema);
+
+  static std::shared_ptr<ColumnSelector> fromScanSpec(
+      const velox::common::ScanSpec& spec,
+      const RowTypePtr& rowType);
 
  private:
   // visit the tree with disk type

--- a/velox/dwio/common/ScanSpec.h
+++ b/velox/dwio/common/ScanSpec.h
@@ -222,9 +222,11 @@ class ScanSpec {
     valueHook_ = valueHook;
   }
 
-  // Returns true if the corresponding reader only needs to reference
-  // the nulls stream. True if filter is is-null with or without value
-  // extraction or if filter is is-not-null and no value is extracted.
+  // Returns true if the corresponding reader only needs to reference the nulls
+  // stream.  True if filter is is-null with or without value extraction or if
+  // filter is is-not-null and no value is extracted.  Note that this does not
+  // apply to Nimble format leaf nodes, because nulls are mixed in the encoding
+  // with actual values.
   bool readsNullsOnly() const {
     if (filter_) {
       if (filter_->kind() == FilterKind::kIsNull) {

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -450,6 +450,10 @@ class SelectiveColumnReader {
   void
   prepareRead(vector_size_t offset, RowSet rows, const uint64_t* incomingNulls);
 
+  virtual bool readsNullsOnly() const {
+    return scanSpec_->readsNullsOnly();
+  }
+
   void setOutputRows(RowSet rows) {
     outputRows_.resize(rows.size());
     if (!rows.size()) {

--- a/velox/dwio/common/SelectiveColumnReaderInternal.h
+++ b/velox/dwio/common/SelectiveColumnReaderInternal.h
@@ -60,7 +60,7 @@ void SelectiveColumnReader::prepareRead(
     vector_size_t offset,
     RowSet rows,
     const uint64_t* incomingNulls) {
-  const bool readsNullsOnly = scanSpec_->readsNullsOnly();
+  const bool readsNullsOnly = this->readsNullsOnly();
   seekTo(offset, readsNullsOnly);
   vector_size_t numRows = rows.back() + 1;
 

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -65,22 +65,6 @@ target_link_libraries(
   velox_dwio_common_int_decoder_benchmark velox_dwio_common_exception
   velox_exception velox_dwio_dwrf_common Folly::folly ${FOLLY_BENCHMARK})
 
-add_library(velox_e2e_filter_test_base E2EFilterTestBase.cpp)
-
-target_link_libraries(
-  velox_e2e_filter_test_base
-  velox_functions_prestosql
-  velox_parse_parser
-  velox_vector_test_lib
-  velox_link_libs
-  Folly::folly
-  fmt::fmt
-  lz4::lz4
-  lzo2::lzo2
-  zstd::zstd
-  ZLIB::ZLIB
-  ${TEST_LINK_LIBS})
-
 if(VELOX_ENABLE_ARROW AND VELOX_ENABLE_BENCHMARKS)
   add_subdirectory(Lemire/FastPFor)
   add_executable(velox_dwio_common_bitpack_decoder_benchmark

--- a/velox/dwio/common/tests/utils/CMakeLists.txt
+++ b/velox/dwio/common/tests/utils/CMakeLists.txt
@@ -12,20 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_dwio_common_test_utils BatchMaker.cpp DataFiles.cpp
-                                         DataSetBuilder.cpp FilterGenerator.cpp
-                                         UnitLoaderTestTools.cpp)
+add_library(
+  velox_dwio_common_test_utils
+  BatchMaker.cpp DataFiles.cpp DataSetBuilder.cpp FilterGenerator.cpp
+  UnitLoaderTestTools.cpp E2EFilterTestBase.cpp)
 
 target_link_libraries(
   velox_dwio_common_test_utils
   Folly::folly
+  fmt::fmt
+  glog::glog
+  gflags::gflags
+  gtest
   velox_dwio_common
   velox_dwio_common_exception
   velox_exception
+  velox_functions_prestosql
   velox_memory
+  velox_parse_parser
   velox_type
   velox_type_fbhive
-  velox_vector)
+  velox_vector
+  velox_vector_test_lib)
 
 # older versions of GCC need it to allow std::filesystem
 if(CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.h
@@ -85,6 +85,14 @@ class E2EFilterTestBase : public testing::Test {
   void SetUp() override {
     rootPool_ = memory::memoryManager()->addRootPool("E2EFilterTestBase");
     leafPool_ = rootPool_->addLeafChild("E2EFilterTestBase");
+    // Check environment variable because `buck test` does not allow pass in
+    // command line arguments.
+    if (const char* useRandomSeed = getenv("VELOX_TEST_USE_RANDOM_SEED")) {
+      if (folly::to<bool>(useRandomSeed)) {
+        seed_ = folly::Random::secureRand32();
+        LOG(INFO) << "Random seed: " << seed_;
+      }
+    }
   }
 
   static bool typeKindSupportsValueHook(TypeKind kind) {
@@ -314,7 +322,7 @@ class E2EFilterTestBase : public testing::Test {
   std::shared_ptr<memory::MemoryPool> rootPool_;
   std::shared_ptr<memory::MemoryPool> leafPool_;
   std::shared_ptr<const RowType> rowType_;
-  dwio::common::MemorySink* sinkPtr_;
+  std::string_view sinkData_;
   bool useVInts_ = true;
   dwio::common::RuntimeStatistics runtimeStats_;
   // Number of calls to flush policy between starting new stripes.
@@ -323,6 +331,8 @@ class E2EFilterTestBase : public testing::Test {
   std::vector<int32_t> readSizes_;
   int32_t batchCount_ = kBatchCount;
   int32_t batchSize_ = kBatchSize;
+  bool testRowGroupSkip_ = true;
+  uint32_t seed_ = 1;
 };
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -346,7 +346,7 @@ add_test(velox_dwrf_e2e_filter_test velox_dwrf_e2e_filter_test)
 
 target_link_libraries(
   velox_dwrf_e2e_filter_test
-  velox_e2e_filter_test_base
+  velox_dwio_common_test_utils
   velox_link_libs
   velox_test_util
   Folly::folly

--- a/velox/dwio/dwrf/test/E2EFilterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EFilterTest.cpp
@@ -16,7 +16,7 @@
 
 #include "velox/common/base/Portability.h"
 #include "velox/common/testutil/TestValue.h"
-#include "velox/dwio/common/tests/E2EFilterTestBase.h"
+#include "velox/dwio/common/tests/utils/E2EFilterTestBase.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/writer/FlushPolicy.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
@@ -79,13 +79,14 @@ class E2EFilterTest : public E2EFilterTestBase {
         200 * 1024 * 1024,
         dwio::common::FileSink::Options{.pool = leafPool_.get()});
     ASSERT_TRUE(sink->isBuffered());
-    sinkPtr_ = sink.get();
+    auto* sinkPtr = sink.get();
     options.memoryPool = rootPool_.get();
     writer_ = std::make_unique<dwrf::Writer>(std::move(sink), options);
     for (auto& batch : batches) {
       writer_->write(batch);
     }
     writer_->close();
+    sinkData_ = std::string_view(sinkPtr->data(), sinkPtr->size());
   }
 
   void setUpRowReaderOptions(

--- a/velox/dwio/parquet/tests/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/reader/CMakeLists.txt
@@ -25,7 +25,7 @@ add_executable(velox_parquet_e2e_filter_test E2EFilterTest.cpp)
 add_test(velox_parquet_e2e_filter_test velox_parquet_e2e_filter_test)
 target_link_libraries(
   velox_parquet_e2e_filter_test
-  velox_e2e_filter_test_base
+  velox_dwio_common_test_utils
   velox_dwio_parquet_writer
   velox_dwio_native_parquet_reader
   lz4::lz4


### PR DESCRIPTION
Summary:
In order to reuse this base class in nimble, we need to move it to
`tests/utils` which will be included in `VELOX_BUILD_MINIMAL_WITH_DWIO`.  Also
factor out `ColumnSelector::fromScanSpec` so that we can reuse this logic in
nimble without depending on `HiveConnectorUtil`.

Differential Revision: D57114400
