### PR TITLE
Propagate additional dwrf writer options

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -191,6 +191,19 @@ uint64_t HiveConfig::orcWriterMaxDictionaryMemory(const Config* session) const {
       core::CapacityUnit::BYTE);
 }
 
+bool HiveConfig::orcWriterLinearStripeSizeHeuristics(
+    const Config* session) const {
+  return session->get<bool>(
+      kOrcWriterLinearStripeSizeHeuristicsSession,
+      config_->get<bool>(kOrcWriterLinearStripeSizeHeuristics, true));
+}
+
+uint64_t HiveConfig::orcWriterMinCompressionSize(const Config* session) const {
+  return session->get<uint64_t>(
+      kOrcWriterMinCompressionSizeSession,
+      config_->get<uint64_t>(kOrcWriterMinCompressionSize, 1024));
+}
+
 std::string HiveConfig::writeFileCreateConfig() const {
   return config_->get<std::string>(kWriteFileCreateConfig, "");
 }

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -166,6 +166,18 @@ class HiveConfig {
   static constexpr const char* kOrcWriterMaxDictionaryMemorySession =
       "orc_optimized_writer_max_dictionary_memory";
 
+  /// Enables historical based stripe size estimation after compression.
+  static constexpr const char* kOrcWriterLinearStripeSizeHeuristics =
+      "hive.orc.writer.linear-stripe-size-heuristics";
+  static constexpr const char* kOrcWriterLinearStripeSizeHeuristicsSession =
+      "orc_writer_linear_stripe_size_heuristics";
+
+  /// Minimal number of items in an encoded stream.
+  static constexpr const char* kOrcWriterMinCompressionSize =
+      "hive.orc.writer.min-compression-size";
+  static constexpr const char* kOrcWriterMinCompressionSizeSession =
+      "orc_writer_min_compression_size";
+
   /// Config used to create write files. This config is provided to underlying
   /// file system through hive connector and data sink. The config is free form.
   /// The form should be defined by the underlying file system.
@@ -255,6 +267,10 @@ class HiveConfig {
   uint64_t orcWriterMaxStripeSize(const Config* session) const;
 
   uint64_t orcWriterMaxDictionaryMemory(const Config* session) const;
+
+  bool orcWriterLinearStripeSizeHeuristics(const Config* session) const;
+
+  uint64_t orcWriterMinCompressionSize(const Config* session) const;
 
   std::string writeFileCreateConfig() const;
 

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -681,6 +681,11 @@ uint32_t HiveDataSink::appendWriter(const HiveWriterId& id) {
       hiveConfig_->orcWriterMaxDictionaryMemory(connectorSessionProperties));
   options.parquetWriteTimestampUnit =
       hiveConfig_->parquetWriteTimestampUnit(connectorSessionProperties);
+  options.orcMinCompressionSize = std::optional(
+      hiveConfig_->orcWriterMinCompressionSize(connectorSessionProperties));
+  options.orcLinearStripeSizeHeuristics =
+      std::optional(hiveConfig_->orcWriterLinearStripeSizeHeuristics(
+          connectorSessionProperties));
   options.serdeParameters = std::map<std::string, std::string>(
       insertTableHandle_->serdeParameters().begin(),
       insertTableHandle_->serdeParameters().end());

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -61,6 +61,10 @@ TEST(HiveConfigTest, defaultConfig) {
   ASSERT_EQ(
       hiveConfig->sortWriterMaxOutputBytes(emptySession.get()), 10UL << 20);
   ASSERT_EQ(hiveConfig->isPartitionPathAsLowerCase(emptySession.get()), true);
+  ASSERT_EQ(hiveConfig->orcWriterMinCompressionSize(emptySession.get()), 1024);
+  ASSERT_EQ(
+      hiveConfig->orcWriterLinearStripeSizeHeuristics(emptySession.get()),
+      true);
 }
 
 TEST(HiveConfigTest, overrideConfig) {
@@ -89,7 +93,9 @@ TEST(HiveConfigTest, overrideConfig) {
       {HiveConfig::kOrcWriterMaxStripeSize, "100MB"},
       {HiveConfig::kOrcWriterMaxDictionaryMemory, "100MB"},
       {HiveConfig::kSortWriterMaxOutputRows, "100"},
-      {HiveConfig::kSortWriterMaxOutputBytes, "100MB"}};
+      {HiveConfig::kSortWriterMaxOutputBytes, "100MB"},
+      {HiveConfig::kOrcWriterLinearStripeSizeHeuristics, "false"},
+      {HiveConfig::kOrcWriterMinCompressionSize, "512"}};
   HiveConfig* hiveConfig =
       new HiveConfig(std::make_shared<MemConfig>(configFromFile));
   auto emptySession = std::make_unique<MemConfig>();
@@ -127,6 +133,10 @@ TEST(HiveConfigTest, overrideConfig) {
   ASSERT_EQ(hiveConfig->sortWriterMaxOutputRows(emptySession.get()), 100);
   ASSERT_EQ(
       hiveConfig->sortWriterMaxOutputBytes(emptySession.get()), 100UL << 20);
+  ASSERT_EQ(hiveConfig->orcWriterMinCompressionSize(emptySession.get()), 512);
+  ASSERT_EQ(
+      hiveConfig->orcWriterLinearStripeSizeHeuristics(emptySession.get()),
+      false);
 }
 
 TEST(HiveConfigTest, overrideSession) {
@@ -140,7 +150,9 @@ TEST(HiveConfigTest, overrideSession) {
       {HiveConfig::kSortWriterMaxOutputRowsSession, "20"},
       {HiveConfig::kSortWriterMaxOutputBytesSession, "20MB"},
       {HiveConfig::kPartitionPathAsLowerCaseSession, "false"},
-      {HiveConfig::kIgnoreMissingFilesSession, "true"}};
+      {HiveConfig::kIgnoreMissingFilesSession, "true"},
+      {HiveConfig::kOrcWriterMinCompressionSizeSession, "512"},
+      {HiveConfig::kOrcWriterLinearStripeSizeHeuristicsSession, "false"}};
   const auto session = std::make_unique<MemConfig>(sessionOverride);
   ASSERT_EQ(
       hiveConfig->insertExistingPartitionsBehavior(session.get()),
@@ -176,4 +188,7 @@ TEST(HiveConfigTest, overrideSession) {
   ASSERT_EQ(hiveConfig->sortWriterMaxOutputBytes(session.get()), 20UL << 20);
   ASSERT_EQ(hiveConfig->isPartitionPathAsLowerCase(session.get()), false);
   ASSERT_EQ(hiveConfig->ignoreMissingFiles(session.get()), true);
+  ASSERT_EQ(
+      hiveConfig->orcWriterLinearStripeSizeHeuristics(session.get()), false);
+  ASSERT_EQ(hiveConfig->orcWriterMinCompressionSize(session.get()), 512);
 }

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -471,6 +471,16 @@ Each query can override the config by setting corresponding query session proper
      - 9
      - Timestamp unit used when writing timestamps into Parquet through Arrow bridge.
        Valid values are 0 (second), 3 (millisecond), 6 (microsecond), 9 (nanosecond).
+   * - hive.orc.writer.linear-stripe-size-heuristics
+     - orc_writer_linear_stripe_size_heuristics
+     - bool
+     - true
+     - Enables historical based stripe size estimation after compression.
+   * - hive.orc.writer.min-compression-size
+     - orc_writer_min_compression_size
+     - integer
+     - 1024
+     - Minimal number of items in an encoded stream.
 
 ``Amazon S3 Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -609,7 +609,9 @@ struct WriterOptions {
   const velox::common::SpillConfig* spillConfig{nullptr};
   tsan_atomic<bool>* nonReclaimableSection{nullptr};
   std::optional<velox::common::CompressionKind> compressionKind;
+  std::optional<uint64_t> orcMinCompressionSize{std::nullopt};
   std::optional<uint64_t> maxStripeSize{std::nullopt};
+  std::optional<bool> orcLinearStripeSizeHeuristics{std::nullopt};
   std::optional<uint64_t> maxDictionaryMemory{std::nullopt};
   std::map<std::string, std::string> serdeParameters;
   std::optional<uint8_t> parquetWriteTimestampUnit;

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -775,17 +775,27 @@ dwrf::WriterOptions getDwrfOptions(const dwio::common::WriterOptions& options) {
         Config::COMPRESSION.configKey(),
         std::to_string(options.compressionKind.value()));
   }
-
+  if (options.orcMinCompressionSize.has_value()) {
+    configs.emplace(
+        Config::COMPRESSION_BLOCK_SIZE_MIN.configKey(),
+        std::to_string(options.orcMinCompressionSize.value()));
+  }
   if (options.maxStripeSize.has_value()) {
     configs.emplace(
         Config::STRIPE_SIZE.configKey(),
         std::to_string(options.maxStripeSize.value()));
+  }
+  if (options.orcLinearStripeSizeHeuristics.has_value()) {
+    configs.emplace(
+        Config::LINEAR_STRIPE_SIZE_HEURISTICS.configKey(),
+        std::to_string(options.orcLinearStripeSizeHeuristics.value()));
   }
   if (options.maxDictionaryMemory.has_value()) {
     configs.emplace(
         Config::MAX_DICTIONARY_SIZE.configKey(),
         std::to_string(options.maxDictionaryMemory.value()));
   }
+
   dwrf::WriterOptions dwrfOptions;
   dwrfOptions.config = Config::fromMap(configs);
   dwrfOptions.schema = options.schema;


### PR DESCRIPTION
In order to tune writer memory usage pattern, we need additional 2 options for writer
hive.exec.orc.compress.size.min
hive.exec.orc.linear.stripe.size.heuristics