### PR TITLE
Log eviction when regions age out

### DIFF
--- a/velox/common/caching/SsdFile.h
+++ b/velox/common/caching/SsdFile.h
@@ -319,6 +319,10 @@ class SsdFile {
     return writableRegions_.size();
   }
 
+  SsdCacheStats testingStats() const {
+    return stats_;
+  }
+
  private:
   // 4 first bytes of a checkpoint file. Allows distinguishing between format
   // versions.


### PR DESCRIPTION
When TTL control ages out old cache entries and evict out the entire regions from a ssd file, it doesn't update log eviction log. So when server recover from checkpoint file, it might see data correctness problem as it might read evicted cache entries on disk which might contain the overwritten data.