### PR TITLE
Update aws-sdk-cpp version to 1.11.321(from 1.11.169)

### DIFF
--- a/scripts/setup-adapters.sh
+++ b/scripts/setup-adapters.sh
@@ -27,7 +27,7 @@ MACHINE=$(uname -m)
 
 function install_aws_deps {
   local AWS_REPO_NAME="aws/aws-sdk-cpp"
-  local AWS_SDK_VERSION="1.11.169"
+  local AWS_SDK_VERSION="1.11.321"
 
   github_checkout $AWS_REPO_NAME $AWS_SDK_VERSION --depth 1 --recurse-submodules
   cmake_install -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DBUILD_SHARED_LIBS:BOOL=OFF -DMINIMIZE_SIZE:BOOL=ON -DENABLE_TESTING:BOOL=OFF -DBUILD_ONLY:STRING="s3;identity-management"


### PR DESCRIPTION
`AdaptiveRetryStrategy` and `GetRetryCount()` API is not available in version 1.11.169. We need this version upgrade for `RetryStrategy` support of S3FileSytem.