### PR TITLE
Fix aggregate flags in initializeGlobalAggregation 

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -423,7 +423,7 @@ void GroupingSet::initializeGlobalAggregation() {
   // requirements of all aggregate functions are satisfied.
 
   // Allocate space for the null and initialized flags.
-  int32_t numAggregates = aggregates_.size();
+  size_t numAggregates = aggregates_.size();
   if (sortedAggregations_) {
     numAggregates++;
   }

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -425,11 +425,11 @@ void GroupingSet::initializeGlobalAggregation() {
   // Allocate space for the null and initialized flags.
   int32_t numAggregates = aggregates_.size();
   if (sortedAggregations_) {
-    numAggregates += 1;
+    numAggregates++;
   }
   for (const auto& aggregation : distinctAggregations_) {
     if (aggregation != nullptr) {
-      numAggregates += 1;
+      numAggregates++;
     }
   }
   int32_t rowSizeOffset =
@@ -468,6 +468,7 @@ void GroupingSet::initializeGlobalAggregation() {
     offset = bits::roundUp(offset, accumulator.alignment());
 
     sortedAggregations_->setAllocator(&stringAllocator_);
+    DCHECK(RowContainer::nullByte(accumulatorFlagsOffset) < rowSizeOffset);
     sortedAggregations_->setOffsets(
         offset,
         RowContainer::nullByte(accumulatorFlagsOffset),

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -423,8 +423,17 @@ void GroupingSet::initializeGlobalAggregation() {
   // requirements of all aggregate functions are satisfied.
 
   // Allocate space for the null and initialized flags.
+  int32_t numAggregates = aggregates_.size();
+  if (sortedAggregations_) {
+    numAggregates += 1;
+  }
+  for (const auto& aggregation : distinctAggregations_) {
+    if (aggregation != nullptr) {
+      numAggregates += 1;
+    }
+  }
   int32_t rowSizeOffset =
-      bits::nbytes(aggregates_.size() * RowContainer::kNumAccumulatorFlags);
+      bits::nbytes(numAggregates * RowContainer::kNumAccumulatorFlags);
   int32_t offset = rowSizeOffset + sizeof(int32_t);
   int32_t accumulatorFlagsOffset = 0;
   int32_t alignment = 1;

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -468,7 +468,8 @@ void GroupingSet::initializeGlobalAggregation() {
     offset = bits::roundUp(offset, accumulator.alignment());
 
     sortedAggregations_->setAllocator(&stringAllocator_);
-    DCHECK(RowContainer::nullByte(accumulatorFlagsOffset) < rowSizeOffset);
+    VELOX_DCHECK_LT(
+        RowContainer::nullByte(accumulatorFlagsOffset), rowSizeOffset);
     sortedAggregations_->setOffsets(
         offset,
         RowContainer::nullByte(accumulatorFlagsOffset),

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -427,58 +427,39 @@ void GroupingSet::initializeGlobalAggregation() {
   if (sortedAggregations_) {
     numAggregates += 1;
   }
+  for (const auto& aggregation : distinctAggregations_) {
+    if (aggregation != nullptr) {
+      numAggregates += 1;
+    }
+  }
   int32_t rowSizeOffset =
       bits::nbytes(numAggregates * RowContainer::kNumAccumulatorFlags);
   int32_t offset = rowSizeOffset + sizeof(int32_t);
   int32_t accumulatorFlagsOffset = 0;
   int32_t alignment = 1;
 
-  for (int32_t i = 0; i < aggregates_.size(); i++) {
-    auto& aggregate = aggregates_[i];
-    if (!aggregate.distinct) {
-      auto& function = aggregate.function;
+  for (auto& aggregate : aggregates_) {
+    auto& function = aggregate.function;
 
-      Accumulator accumulator{
-          aggregate.function.get(), aggregate.intermediateType};
+    Accumulator accumulator{
+        aggregate.function.get(), aggregate.intermediateType};
 
-      // Accumulator offset must be aligned by their alignment size.
-      offset = bits::roundUp(offset, accumulator.alignment());
+    // Accumulator offset must be aligned by their alignment size.
+    offset = bits::roundUp(offset, accumulator.alignment());
 
-      function->setAllocator(&stringAllocator_);
-      function->setOffsets(
-          offset,
-          RowContainer::nullByte(accumulatorFlagsOffset),
-          RowContainer::nullMask(accumulatorFlagsOffset),
-          RowContainer::initializedByte(accumulatorFlagsOffset),
-          RowContainer::initializedMask(accumulatorFlagsOffset),
-          rowSizeOffset);
+    function->setAllocator(&stringAllocator_);
+    function->setOffsets(
+        offset,
+        RowContainer::nullByte(accumulatorFlagsOffset),
+        RowContainer::nullMask(accumulatorFlagsOffset),
+        RowContainer::initializedByte(accumulatorFlagsOffset),
+        RowContainer::initializedMask(accumulatorFlagsOffset),
+        rowSizeOffset);
 
-      offset += accumulator.fixedWidthSize();
-      accumulatorFlagsOffset += RowContainer::kNumAccumulatorFlags;
-      alignment =
-          RowContainer::combineAlignments(accumulator.alignment(), alignment);
-    } else {
-      auto& aggregation = distinctAggregations_[i];
-      if (aggregation != nullptr) {
-        auto accumulator = aggregation->accumulator();
-
-        offset = bits::roundUp(offset, accumulator.alignment());
-
-        aggregation->setAllocator(&stringAllocator_);
-        aggregation->setOffsets(
-            offset,
-            RowContainer::nullByte(accumulatorFlagsOffset),
-            RowContainer::nullMask(accumulatorFlagsOffset),
-            RowContainer::initializedByte(accumulatorFlagsOffset),
-            RowContainer::initializedMask(accumulatorFlagsOffset),
-            rowSizeOffset);
-
-        offset += accumulator.fixedWidthSize();
-        accumulatorFlagsOffset += RowContainer::kNumAccumulatorFlags;
-        alignment =
-            RowContainer::combineAlignments(accumulator.alignment(), alignment);
-      }
-    }
+    offset += accumulator.fixedWidthSize();
+    accumulatorFlagsOffset += RowContainer::kNumAccumulatorFlags;
+    alignment =
+        RowContainer::combineAlignments(accumulator.alignment(), alignment);
   }
 
   if (sortedAggregations_) {
@@ -499,6 +480,28 @@ void GroupingSet::initializeGlobalAggregation() {
     accumulatorFlagsOffset += RowContainer::kNumAccumulatorFlags;
     alignment =
         RowContainer::combineAlignments(accumulator.alignment(), alignment);
+  }
+
+  for (const auto& aggregation : distinctAggregations_) {
+    if (aggregation != nullptr) {
+      auto accumulator = aggregation->accumulator();
+
+      offset = bits::roundUp(offset, accumulator.alignment());
+
+      aggregation->setAllocator(&stringAllocator_);
+      aggregation->setOffsets(
+          offset,
+          RowContainer::nullByte(accumulatorFlagsOffset),
+          RowContainer::nullMask(accumulatorFlagsOffset),
+          RowContainer::initializedByte(accumulatorFlagsOffset),
+          RowContainer::initializedMask(accumulatorFlagsOffset),
+          rowSizeOffset);
+
+      offset += accumulator.fixedWidthSize();
+      accumulatorFlagsOffset += RowContainer::kNumAccumulatorFlags;
+      alignment =
+          RowContainer::combineAlignments(accumulator.alignment(), alignment);
+    }
   }
 
   lookup_->hits[0] = rows_.allocateFixed(offset, alignment);
@@ -582,7 +585,7 @@ bool GroupingSet::getGlobalAggregationOutput(
 
   auto groups = lookup_->hits.data();
   for (int32_t i = 0; i < aggregates_.size(); ++i) {
-    if (!aggregates_[i].sortingKeys.empty() || aggregates_[i].distinct) {
+    if (!aggregates_[i].sortingKeys.empty()) {
       continue;
     }
 

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -626,6 +626,23 @@ TEST_F(AggregationTest, manyGlobalAggregations) {
 
   assertQuery(op, "SELECT " + folly::join(", ", aggregates) + " FROM tmp");
 
+  rowType =
+      velox::test::VectorMaker::rowType(std::vector<TypePtr>(32, SMALLINT()));
+  vectors = makeVectors(rowType, 10, 32);
+  createDuckDbTable(vectors);
+  aggregates.clear();
+  for (int i = 0; i < rowType->size(); i++) {
+    aggregates.push_back(fmt::format(
+        "array_agg({} ORDER BY {})", rowType->nameOf(i), rowType->nameOf(i)));
+  }
+
+  op = PlanBuilder()
+           .values(vectors)
+           .singleAggregation({}, aggregates)
+           .planNode();
+
+  assertQuery(op, "SELECT " + folly::join(", ", aggregates) + " FROM tmp");
+
   EXPECT_EQ(NonPODInt64::constructed, NonPODInt64::destructed);
 }
 

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -614,6 +614,18 @@ TEST_F(AggregationTest, manyGlobalAggregations) {
 
   assertQuery(op, "SELECT " + folly::join(", ", aggregates) + " FROM tmp");
 
+  aggregates.clear();
+  for (int i = 0; i < rowType->size(); i++) {
+    aggregates.push_back(fmt::format("sum(distinct {})", rowType->nameOf(i)));
+  }
+
+  op = PlanBuilder()
+           .values(vectors)
+           .singleAggregation({}, aggregates)
+           .planNode();
+
+  assertQuery(op, "SELECT " + folly::join(", ", aggregates) + " FROM tmp");
+
   EXPECT_EQ(NonPODInt64::constructed, NonPODInt64::destructed);
 }
 


### PR DESCRIPTION
`GroupingSet::initializeGlobalAggregation` updates `accumulatorFlagsOffset` for each valid aggregate in `aggregates_`, `sortedAggregations_` and `distinctAggregations_`, but the calculation of bytes of the flags only considers `aggregates_`, which leads to failure of the following added UT:

```
 for (int i = 0; i < rowType->size(); i++) {
    aggregates.push_back(fmt::format("sum(distinct {})", rowType->nameOf(i)));
  }

  op = PlanBuilder()
                .values(vectors)
                .singleAggregation({}, aggregates)
                .planNode();

  assertQuery(op, "SELECT " + folly::join(", ", aggregates) + " FROM tmp");
```