### PR TITLE
Let driver go off-thread waiting for memory arbitration

### DIFF
--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -34,6 +34,10 @@
 DECLARE_bool(velox_memory_leak_check_enabled);
 DECLARE_bool(velox_memory_pool_debug_enabled);
 
+namespace facebook::velox::core {
+class QueryCtx;
+}
+
 namespace facebook::velox::memory {
 #define VELOX_MEM_POOL_CAP_EXCEEDED(errorMessage)                   \
   _VELOX_THROW(                                                     \
@@ -546,6 +550,7 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
 
   friend class TestMemoryReclaimer;
   friend class MemoryReclaimer;
+  friend class core::QueryCtx;
 };
 
 std::ostream& operator<<(std::ostream& out, MemoryPool::Kind kind);

--- a/velox/common/memory/tests/MemoryCapExceededTest.cpp
+++ b/velox/common/memory/tests/MemoryCapExceededTest.cpp
@@ -95,7 +95,7 @@ TEST_P(MemoryCapExceededTest, singleDriver) {
                   .singleAggregation({"c0"}, {"sum(p1)"})
                   .orderBy({"c0"}, false)
                   .planNode();
-  auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  auto queryCtx = core::QueryCtx::create(executor_.get());
   queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
       queryCtx->queryId(), kMaxBytes, exec::MemoryReclaimer::create()));
   CursorParameters params;
@@ -153,7 +153,7 @@ TEST_P(MemoryCapExceededTest, multipleDrivers) {
                   .values(data, true)
                   .singleAggregation({"c0"}, {"sum(c1)"})
                   .planNode();
-  auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  auto queryCtx = core::QueryCtx::create(executor_.get());
   queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
       queryCtx->queryId(), kMaxBytes, exec::MemoryReclaimer::create()));
 
@@ -229,7 +229,7 @@ TEST_P(MemoryCapExceededTest, allocatorCapacityExceededError) {
                     .singleAggregation({"c0"}, {"sum(p1)"})
                     .orderBy({"c0"}, false)
                     .planNode();
-    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+    auto queryCtx = core::QueryCtx::create(executor_.get());
     queryCtx->testingOverrideMemoryPool(
         manager.addRootPool(queryCtx->queryId(), kMaxBytes));
     CursorParameters params;

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -32,12 +32,13 @@
 #include "velox/core/PlanNode.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/exec/Driver.h"
-#include "velox/exec/HashBuild.h"
+#include "velox/exec/HashAggregation.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/TableWriter.h"
 #include "velox/exec/Values.h"
 #include "velox/exec/tests/utils/ArbitratorTestUtil.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/SumNonPODAggregate.h"
 
 DECLARE_bool(velox_memory_leak_check_enabled);
 DECLARE_bool(velox_suppress_memory_capacity_exceeding_error_message);
@@ -236,6 +237,7 @@ class SharedArbitrationTest : public exec::test::HiveConnectorTestBase {
 
   void SetUp() override {
     HiveConnectorTestBase::SetUp();
+    registerSumNonPODAggregate("sumnonpod", 64);
     fakeOperatorFactory_->setCanReclaim(true);
 
     setupMemory();
@@ -303,6 +305,132 @@ class SharedArbitrationTest : public exec::test::HiveConnectorTestBase {
   RowVectorPtr vector_;
   std::atomic_uint64_t numAddedPools_{0};
 };
+
+DEBUG_ONLY_TEST_F(SharedArbitrationTest, queryArbitrationStateCheck) {
+  const std::vector<RowVectorPtr> vectors =
+      createVectors(rowType_, 32, 32 << 20);
+  createDuckDbTable(vectors);
+  std::shared_ptr<core::QueryCtx> queryCtx =
+      newQueryCtx(memory::memoryManager(), executor_.get(), kMemoryCapacity);
+
+  std::atomic_bool queryCtxStateChecked{false};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::Task::requestPauseLocked",
+      std::function<void(Task*)>(([&](Task* /*unused*/) {
+        ASSERT_TRUE(queryCtx->testingUnderArbitration());
+        queryCtxStateChecked = true;
+      })));
+
+  const auto spillDirectory = exec::test::TempDirectoryPath::create();
+  TestScopedSpillInjection scopedSpillInjection(100);
+  core::PlanNodeId aggregationNodeId;
+  AssertQueryBuilder(duckDbQueryRunner_)
+      .queryCtx(queryCtx)
+      .spillDirectory(spillDirectory->getPath())
+      .config(core::QueryConfig::kSpillEnabled, "true")
+      .plan(PlanBuilder()
+                .values(vectors)
+                .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
+                .capturePlanNodeId(aggregationNodeId)
+                .planNode())
+      .assertResults("SELECT c0, c1, array_agg(c2) FROM tmp GROUP BY c0, c1");
+  ASSERT_TRUE(queryCtxStateChecked);
+  ASSERT_FALSE(queryCtx->testingUnderArbitration());
+  waitForAllTasksToBeDeleted();
+  ASSERT_FALSE(queryCtx->testingUnderArbitration());
+}
+
+DEBUG_ONLY_TEST_F(SharedArbitrationTest, skipNonReclaimableTaskTest) {
+  const std::vector<RowVectorPtr> vectors =
+      createVectors(rowType_, 32, 32 << 20);
+  std::shared_ptr<core::QueryCtx> queryCtx =
+      newQueryCtx(memory::memoryManager(), executor_.get(), kMemoryCapacity);
+  std::unordered_map<std::string, std::string> configs;
+  configs.emplace(core::QueryConfig::kSpillEnabled, "true");
+  queryCtx->testingOverrideConfigUnsafe(std::move(configs));
+
+  std::atomic_int blockedCount{0};
+  std::atomic_bool blockedAggregation{false};
+  std::atomic_bool blockedPartialAggregation{false};
+  folly::EventCount arbitrationWait;
+  std::atomic<bool> arbitrationWaitFlag{true};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::Driver::runInternal::addInput",
+      std::function<void(exec::Operator*)>(([&](exec::Operator* op) {
+        if (op->testingOperatorCtx()->operatorType() != "Aggregation" &&
+            op->testingOperatorCtx()->operatorType() != "PartialAggregation") {
+          return;
+        }
+        if (op->pool()->currentBytes() == 0) {
+          return;
+        }
+        if (op->testingOperatorCtx()->operatorType() == "PartialAggregation") {
+          if (blockedPartialAggregation.exchange(true)) {
+            return;
+          }
+        } else {
+          if (blockedAggregation.exchange(true)) {
+            return;
+          }
+        }
+        auto* driver = op->testingOperatorCtx()->driver();
+        SuspendedSection suspendedSection(driver);
+        arbitrationWait.await([&]() { return !arbitrationWaitFlag.load(); });
+      })));
+
+  std::atomic_int taskPausedCount{0};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::Task::requestPauseLocked",
+      std::function<void(Task*)>(([&](Task* /*unused*/) {
+        ASSERT_TRUE(queryCtx->testingUnderArbitration());
+        ++taskPausedCount;
+      })));
+
+  std::thread spillableThread([&]() {
+    const auto spillDirectory = exec::test::TempDirectoryPath::create();
+    AssertQueryBuilder(PlanBuilder()
+                           .values(vectors)
+                           .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
+                           .planNode())
+        .queryCtx(queryCtx)
+        .spillDirectory(spillDirectory->getPath())
+        .copyResults(pool());
+  });
+
+  std::thread nonSpillableThread([&]() {
+    AssertQueryBuilder(PlanBuilder()
+                           .values(vectors)
+                           .aggregation(
+                               {"c0", "c1"},
+                               {"sum(c0)", "array_agg(c2)"},
+                               {},
+                               core::AggregationNode::Step::kPartial,
+                               false)
+                           .planNode())
+        .queryCtx(queryCtx)
+        .copyResults(pool());
+  });
+
+  while (!blockedPartialAggregation || !blockedAggregation) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  testingRunArbitration();
+
+  arbitrationWaitFlag = false;
+  arbitrationWait.notifyAll();
+
+  spillableThread.join();
+  nonSpillableThread.join();
+
+  // We shall only reclaim from the reclaimable task but not non-reclaimable
+  // task.
+  ASSERT_EQ(taskPausedCount, 1);
+  ASSERT_FALSE(queryCtx->testingUnderArbitration());
+  waitForAllTasksToBeDeleted();
+  ASSERT_FALSE(queryCtx->testingUnderArbitration());
+  ASSERT_EQ(taskPausedCount, 1);
+}
 
 DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimToOrderBy) {
   const int numVectors = 32;

--- a/velox/connectors/hive/tests/HiveConnectorTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorTest.cpp
@@ -464,8 +464,8 @@ TEST_F(HiveConnectorTest, makeScanSpec_prunedMapNonNullMapKey) {
 }
 
 TEST_F(HiveConnectorTest, extractFiltersFromRemainingFilter) {
-  core::QueryCtx queryCtx;
-  exec::SimpleExpressionEvaluator evaluator(&queryCtx, pool_.get());
+  auto queryCtx = core::QueryCtx::create();
+  exec::SimpleExpressionEvaluator evaluator(queryCtx.get(), pool_.get());
   auto rowType = ROW({"c0", "c1", "c2"}, {BIGINT(), BIGINT(), DECIMAL(20, 0)});
 
   auto expr = parseExpr("not (c0 > 0 or c1 > 0)", rowType);
@@ -503,8 +503,8 @@ TEST_F(HiveConnectorTest, extractFiltersFromRemainingFilter) {
 }
 
 TEST_F(HiveConnectorTest, prestoTableSampling) {
-  core::QueryCtx queryCtx;
-  exec::SimpleExpressionEvaluator evaluator(&queryCtx, pool_.get());
+  auto queryCtx = core::QueryCtx::create();
+  exec::SimpleExpressionEvaluator evaluator(queryCtx.get(), pool_.get());
   auto rowType = ROW({"c0"}, {BIGINT()});
 
   auto expr = parseExpr("rand() < 0.5", rowType);

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -26,8 +26,42 @@
 
 namespace facebook::velox::core {
 
-class QueryCtx {
+class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
  public:
+  ~QueryCtx() {
+    VELOX_CHECK(!underArbitration_);
+  }
+
+  /// QueryCtx is used in different places. When used with `Task::start()`, it's
+  /// required that the caller supplies the executor and ensure its lifetime
+  /// outlives the tasks that use it. In contrast, when used in expression
+  /// evaluation through `ExecCtx` or 'Task::next()' for single thread execution
+  /// mode, executor is not needed. Hence, we don't require executor to always
+  /// be passed in here, but instead, ensure that executor exists when actually
+  /// being used.
+  static std::shared_ptr<QueryCtx> create(
+      folly::Executor* executor = nullptr,
+      QueryConfig&& queryConfig = QueryConfig{{}},
+      std::unordered_map<std::string, std::shared_ptr<Config>>
+          connectorConfigs = {},
+      cache::AsyncDataCache* cache = cache::AsyncDataCache::getInstance(),
+      std::shared_ptr<memory::MemoryPool> pool = nullptr,
+      folly::Executor* spillExecutor = nullptr,
+      const std::string& queryId = "");
+
+  /// Constructor to block the destruction of executor while this object is
+  /// alive.
+  ///
+  /// This constructor does not keep the ownership of executor.
+  static std::shared_ptr<QueryCtx> create(
+      folly::Executor::KeepAlive<> executorKeepalive,
+      std::unordered_map<std::string, std::string> queryConfigValues = {},
+      std::unordered_map<std::string, std::shared_ptr<Config>>
+          connectorConfigs = {},
+      cache::AsyncDataCache* cache = cache::AsyncDataCache::getInstance(),
+      std::shared_ptr<memory::MemoryPool> pool = nullptr,
+      const std::string& queryId = "");
+
   /// QueryCtx is used in different places. When used with `Task::start()`, it's
   /// required that the caller supplies the executor and ensure its lifetime
   /// outlives the tasks that use it. In contrast, when used in expression
@@ -43,15 +77,6 @@ class QueryCtx {
       cache::AsyncDataCache* cache = cache::AsyncDataCache::getInstance(),
       std::shared_ptr<memory::MemoryPool> pool = nullptr,
       folly::Executor* spillExecutor = nullptr,
-      const std::string& queryId = "");
-
-  QueryCtx(
-      folly::Executor* executor,
-      QueryConfig&& queryConfig,
-      std::unordered_map<std::string, std::shared_ptr<Config>> connectorConfigs,
-      cache::AsyncDataCache* cache,
-      std::shared_ptr<memory::MemoryPool> pool,
-      std::shared_ptr<folly::Executor> spillExecutor,
       const std::string& queryId = "");
 
   /// Constructor to block the destruction of executor while this
@@ -125,15 +150,59 @@ class QueryCtx {
     return queryId_;
   }
 
-  void testingOverrideMemoryPool(std::shared_ptr<memory::MemoryPool> pool) {
-    pool_ = std::move(pool);
-  }
+  /// Checks if the associated query is under memory arbitration or not. The
+  /// function returns true if it is and set future which is fulfilled when the
+  /// the memory arbiration finishes.
+  bool checkUnderArbitration(ContinueFuture* future);
 
   /// Updates the aggregated spill bytes of this query, and and throws if
   /// exceeds the max spill bytes limit.
   void updateSpilledBytesAndCheckLimit(uint64_t bytes);
 
+  void testingOverrideMemoryPool(std::shared_ptr<memory::MemoryPool> pool) {
+    pool_ = std::move(pool);
+  }
+
+  /// Indicates if the query is under memory arbitration or not.
+  bool testingUnderArbitration() const {
+    std::lock_guard<std::mutex> l(mutex_);
+    VELOX_CHECK(underArbitration_ || arbitrationPromises_.empty());
+    return underArbitration_;
+  }
+
  private:
+  class MemoryReclaimer : public memory::MemoryReclaimer {
+   public:
+    static std::unique_ptr<memory::MemoryReclaimer> create(
+        QueryCtx* queryCtx,
+        memory::MemoryPool* pool);
+
+    uint64_t reclaim(
+        memory::MemoryPool* pool,
+        uint64_t targetBytes,
+        uint64_t maxWaitMs,
+        memory::MemoryReclaimer::Stats& stats) override;
+
+   protected:
+    MemoryReclaimer(
+        const std::shared_ptr<QueryCtx>& queryCtx,
+        memory::MemoryPool* pool)
+        : queryCtx_(queryCtx), pool_(pool) {
+      VELOX_CHECK_NOT_NULL(pool_);
+    }
+
+    // Gets the shared pointer to the associated query ctx to ensure its
+    // liveness during the query memory reclaim operation.
+    //
+    // NOTE: an operator's memory pool can outlive its operator.
+    std::shared_ptr<QueryCtx> ensureQueryCtx() const {
+      return queryCtx_.lock();
+    }
+
+    const std::weak_ptr<QueryCtx> queryCtx_;
+    memory::MemoryPool* const pool_;
+  };
+
   static Config* getEmptyConfig() {
     static const std::unique_ptr<Config> kEmptyConfig =
         std::make_unique<MemConfig>();
@@ -143,11 +212,18 @@ class QueryCtx {
   void initPool(const std::string& queryId) {
     if (pool_ == nullptr) {
       pool_ = memory::memoryManager()->addRootPool(
-          QueryCtx::generatePoolName(queryId),
-          memory::kMaxMemory,
-          memory::MemoryReclaimer::create());
+          QueryCtx::generatePoolName(queryId), memory::kMaxMemory);
     }
   }
+
+  // Setup the memory reclaimer for arbitration if user provided memory pool
+  // hasn't set it.
+  void maybeSetReclaimer();
+
+  // Invoked to start memory arbitration on this query.
+  void startArbitration();
+  // Invoked to stop memory arbitration on this query.
+  void finishArbitration();
 
   const std::string queryId_;
   folly::Executor* const executor_{nullptr};
@@ -160,6 +236,11 @@ class QueryCtx {
   folly::Executor::KeepAlive<> executorKeepalive_;
   QueryConfig queryConfig_;
   std::atomic<uint64_t> numSpilledBytes_{0};
+
+  mutable std::mutex mutex_;
+  // Indicates if this query is under memory arbitration or not.
+  bool underArbitration_{false};
+  std::vector<ContinuePromise> arbitrationPromises_;
 };
 
 // Represents the state of one thread of query execution.

--- a/velox/core/tests/PlanFragmentTest.cpp
+++ b/velox/core/tests/PlanFragmentTest.cpp
@@ -67,7 +67,7 @@ class PlanFragmentTest : public testing::Test {
         {QueryConfig::kOrderBySpillEnabled,
          orderBySpillEnabled ? "true" : "false"},
     });
-    return std::make_shared<QueryCtx>(nullptr, std::move(configData));
+    return QueryCtx::create(nullptr, std::move(configData));
   }
 
   RowTypePtr rowType_;

--- a/velox/core/tests/QueryConfigTest.cpp
+++ b/velox/core/tests/QueryConfigTest.cpp
@@ -30,7 +30,7 @@ class QueryConfigTest : public testing::Test {
 
 TEST_F(QueryConfigTest, emptyConfig) {
   std::unordered_map<std::string, std::string> configData;
-  auto queryCtx = std::make_shared<QueryCtx>(nullptr, std::move(configData));
+  auto queryCtx = QueryCtx::create(nullptr, std::move(configData));
   const QueryConfig& config = queryCtx->queryConfig();
 
   ASSERT_FALSE(config.isLegacyCast());
@@ -40,7 +40,7 @@ TEST_F(QueryConfigTest, setConfig) {
   std::string path = "/tmp/setConfig";
   std::unordered_map<std::string, std::string> configData(
       {{QueryConfig::kLegacyCast, "true"}});
-  auto queryCtx = std::make_shared<QueryCtx>(nullptr, std::move(configData));
+  auto queryCtx = QueryCtx::create(nullptr, std::move(configData));
   const QueryConfig& config = queryCtx->queryConfig();
 
   ASSERT_TRUE(config.isLegacyCast());
@@ -50,10 +50,10 @@ TEST_F(QueryConfigTest, invalidConfig) {
   std::unordered_map<std::string, std::string> configData(
       {{QueryConfig::kSessionTimezone, "Invalid"}});
   VELOX_ASSERT_USER_THROW(
-      std::make_shared<QueryCtx>(nullptr, std::move(configData)),
+      QueryCtx::create(nullptr, std::move(configData)),
       "Unknown time zone: 'Invalid'");
 
-  auto queryCtx = std::make_shared<QueryCtx>(nullptr);
+  auto queryCtx = QueryCtx::create(nullptr);
   VELOX_ASSERT_USER_THROW(
       queryCtx->testingOverrideConfigUnsafe({
           {core::QueryConfig::kSessionTimezone, ""},
@@ -135,7 +135,7 @@ TEST_F(QueryConfigTest, taskWriterCountConfig) {
           QueryConfig::kTaskPartitionedWriterCount,
           std::to_string(testConfig.numPartitionedWriterCounter.value()));
     }
-    auto queryCtx = std::make_shared<QueryCtx>(nullptr, std::move(configData));
+    auto queryCtx = QueryCtx::create(nullptr, std::move(configData));
     const QueryConfig& config = queryCtx->queryConfig();
     ASSERT_EQ(config.taskWriterCount(), testConfig.expectedWriterCounter);
     ASSERT_EQ(
@@ -153,8 +153,7 @@ TEST_F(QueryConfigTest, enableExpressionEvaluationCacheConfig) {
     std::unordered_map<std::string, std::string> configData(
         {{core::QueryConfig::kEnableExpressionEvaluationCache,
           enableExpressionEvaluationCache ? "true" : "false"}});
-    auto queryCtx =
-        std::make_shared<core::QueryCtx>(nullptr, std::move(configData));
+    auto queryCtx = core::QueryCtx::create(nullptr, std::move(configData));
     const core::QueryConfig& config = queryCtx->queryConfig();
     ASSERT_EQ(
         config.isExpressionEvaluationCacheEnabled(),

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
@@ -500,8 +500,8 @@ void E2EFilterTestBase::testMetadataFilter() {
   test::VectorMaker vectorMaker(leafPool_.get());
   functions::prestosql::registerAllScalarFunctions();
   parse::registerTypeResolver();
-  core::QueryCtx queryCtx;
-  exec::SimpleExpressionEvaluator evaluator(&queryCtx, leafPool_.get());
+  auto queryCtx = core::QueryCtx::create();
+  exec::SimpleExpressionEvaluator evaluator(queryCtx.get(), leafPool_.get());
 
   // a: bigint, b: struct<c: bigint>
   std::vector<RowVectorPtr> batches;

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -452,7 +452,7 @@ TEST_F(ParquetTableScanTest, readAsLowerCase) {
       std::make_shared<folly::CPUThreadPoolExecutor>(
           std::thread::hardware_concurrency());
   std::shared_ptr<core::QueryCtx> queryCtx =
-      std::make_shared<core::QueryCtx>(executor.get());
+      core::QueryCtx::create(executor.get());
   std::unordered_map<std::string, std::string> session = {
       {std::string(
            connector::hive::HiveConfig::kFileColumnNamesReadAsLowerCaseSession),

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -190,7 +190,7 @@ DEBUG_ONLY_TEST_F(ParquetWriterTest, unitFromHiveConfig) {
       std::make_shared<folly::CPUThreadPoolExecutor>(
           std::thread::hardware_concurrency());
   std::shared_ptr<core::QueryCtx> queryCtx =
-      std::make_shared<core::QueryCtx>(executor.get());
+      core::QueryCtx::create(executor.get());
   std::unordered_map<std::string, std::string> session = {
       {std::string(
            connector::hive::HiveConfig::kParquetWriteTimestampUnitSession),

--- a/velox/examples/ExpressionEval.cpp
+++ b/velox/examples/ExpressionEval.cpp
@@ -58,7 +58,7 @@ int main(int argc, char** argv) {
   // QueryCtx holds the metadata and configuration associated with a
   // particular query. This is shared between all threads of execution
   // for the same query (one object per query).
-  auto queryCtx = std::make_shared<core::QueryCtx>();
+  auto queryCtx = core::QueryCtx::create();
 
   // ExecCtx holds structures associated with a single thread of execution
   // (one per thread). Each thread of execution requires a scoped memory pool,

--- a/velox/examples/OpaqueType.cpp
+++ b/velox/examples/OpaqueType.cpp
@@ -189,7 +189,7 @@ int main(int argc, char** argv) {
 
   memory::MemoryManager::initialize({});
   // Create memory pool and other query-related structures.
-  auto queryCtx = std::make_shared<core::QueryCtx>();
+  auto queryCtx = core::QueryCtx::create();
   auto pool = memory::memoryManager()->addLeafPool();
   core::ExecCtx execCtx{pool.get(), queryCtx.get()};
 

--- a/velox/examples/ScanAndSort.cpp
+++ b/velox/examples/ScanAndSort.cpp
@@ -130,7 +130,7 @@ int main(int argc, char** argv) {
       "my_write_task",
       writerPlanFragment,
       /*destination=*/0,
-      std::make_shared<core::QueryCtx>(executor.get()),
+      core::QueryCtx::create(executor.get()),
       exec::Task::ExecutionMode::kParallel);
 
   // next() starts execution using the client thread. The loop pumps output
@@ -160,7 +160,7 @@ int main(int argc, char** argv) {
       "my_read_task",
       readPlanFragment,
       /*destination=*/0,
-      std::make_shared<core::QueryCtx>(executor.get()),
+      core::QueryCtx::create(executor.get()),
       exec::Task::ExecutionMode::kParallel);
 
   // Now that we have the query fragment and Task structure set up, we will

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -211,6 +211,9 @@ enum class BlockingReason {
   /// exit them because Task requested to yield or stop or after a certain time.
   /// This is the blocking reason used in such cases.
   kYield,
+  /// Operator is blocked waiting for its associated query memory arbitration to
+  /// finish.
+  kWaitForArbitration,
 };
 
 std::string blockingReasonToString(BlockingReason reason);
@@ -388,6 +391,11 @@ class Driver : public std::enable_shared_from_this<Driver> {
   /// Returns true if this driver is running on thread and has exceeded the cpu
   /// time slice limit if set.
   bool shouldYield() const;
+
+  /// Checks if the associated query is under memory arbitration or not. The
+  /// function returns true if it is and set future which is fulfilled when the
+  /// the memory arbiration finishes.
+  bool checkUnderArbitration(ContinueFuture* future);
 
   void initializeOperatorStats(std::vector<OperatorStats>& stats);
 

--- a/velox/exec/ExchangeQueue.cpp
+++ b/velox/exec/ExchangeQueue.cpp
@@ -97,7 +97,7 @@ std::vector<std::unique_ptr<SerializedPage>> ExchangeQueue::dequeueLocked(
     uint32_t maxBytes,
     bool* atEnd,
     ContinueFuture* future) {
-  VELOX_CHECK(future);
+  VELOX_CHECK_NOT_NULL(future);
   if (!error_.empty()) {
     *atEnd = true;
     VELOX_FAIL(error_);

--- a/velox/exec/benchmarks/ExchangeBenchmark.cpp
+++ b/velox/exec/benchmarks/ExchangeBenchmark.cpp
@@ -289,7 +289,7 @@ class ExchangeBenchmark : public VectorTestBase {
       Consumer consumer = nullptr,
       int64_t maxMemory = kMaxMemory) {
     auto configCopy = configSettings_;
-    auto queryCtx = std::make_shared<core::QueryCtx>(
+    auto queryCtx = core::QueryCtx::create(
         executor_.get(), core::QueryConfig(std::move(configCopy)));
     queryCtx->testingOverrideMemoryPool(
         memory::memoryManager()->addRootPool(queryCtx->queryId(), maxMemory));

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -1111,7 +1111,7 @@ TEST_F(AggregationTest, partialAggregationMaybeReservationReleaseCheck) {
   const int64_t kMaxUserMemoryUsage = 2 * kMaxPartialMemoryUsage;
   // Make sure partial aggregation runs out of memory after first batch.
   CursorParameters params;
-  params.queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  params.queryCtx = core::QueryCtx::create(executor_.get());
   params.queryCtx->testingOverrideConfigUnsafe({
       {QueryConfig::kMaxPartialAggregationMemory,
        std::to_string(kMaxPartialMemoryUsage)},
@@ -1156,7 +1156,7 @@ TEST_F(AggregationTest, spillAll) {
   auto results = AssertQueryBuilder(plan).copyResults(pool_.get());
 
   auto tempDirectory = exec::test::TempDirectoryPath::create();
-  auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  auto queryCtx = core::QueryCtx::create(executor_.get());
   TestScopedSpillInjection scopedSpillInjection(100);
   auto task = AssertQueryBuilder(plan)
                   .spillDirectory(tempDirectory->getPath())
@@ -2014,7 +2014,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringInputProcessing) {
     SCOPED_TRACE(testData.debugString());
 
     auto tempDirectory = exec::test::TempDirectoryPath::create();
-    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+    auto queryCtx = core::QueryCtx::create(executor_.get());
     queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
         queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
     auto expectedResult =
@@ -2156,7 +2156,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringReserve) {
   }
 
   auto tempDirectory = exec::test::TempDirectoryPath::create();
-  auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  auto queryCtx = core::QueryCtx::create(executor_.get());
   queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
       queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
   auto expectedResult =
@@ -2265,7 +2265,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringAllocation) {
     SCOPED_TRACE(fmt::format("enableSpilling {}", enableSpilling));
 
     auto tempDirectory = exec::test::TempDirectoryPath::create();
-    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+    auto queryCtx = core::QueryCtx::create(executor_.get());
     queryCtx->testingOverrideMemoryPool(
         memory::memoryManager()->addRootPool(queryCtx->queryId(), kMaxBytes));
     auto expectedResult =
@@ -2391,7 +2391,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringOutputProcessing) {
     SCOPED_TRACE(fmt::format("enableSpilling {}", enableSpilling));
 
     auto tempDirectory = exec::test::TempDirectoryPath::create();
-    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+    auto queryCtx = core::QueryCtx::create(executor_.get());
     queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
         queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
     auto expectedResult =
@@ -2534,7 +2534,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringNonReclaimableSection) {
     SCOPED_TRACE(fmt::format("testData {}", testData.debugString()));
 
     auto tempDirectory = exec::test::TempDirectoryPath::create();
-    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+    auto queryCtx = core::QueryCtx::create(executor_.get());
     queryCtx->testingOverrideMemoryPool(
         memory::memoryManager()->addRootPool(queryCtx->queryId(), kMaxBytes));
     auto expectedResult =
@@ -2687,7 +2687,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimWithEmptyAggregationTable) {
     SCOPED_TRACE(fmt::format("enableSpilling {}", enableSpilling));
 
     auto tempDirectory = exec::test::TempDirectoryPath::create();
-    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+    auto queryCtx = core::QueryCtx::create(executor_.get());
     queryCtx->testingOverrideMemoryPool(
         memory::memoryManager()->addRootPool(queryCtx->queryId(), kMaxBytes));
     auto expectedResult =
@@ -3047,7 +3047,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimEmptyInput) {
       }));
 
   auto tempDirectory = exec::test::TempDirectoryPath::create();
-  auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  auto queryCtx = core::QueryCtx::create(executor_.get());
   queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
       queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
   core::PlanNodeId aggNodeId;
@@ -3116,7 +3116,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimEmptyOutput) {
       })));
 
   auto tempDirectory = exec::test::TempDirectoryPath::create();
-  auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  auto queryCtx = core::QueryCtx::create(executor_.get());
   queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
       queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
   core::PlanNodeId aggNodeId;
@@ -3166,7 +3166,7 @@ TEST_F(AggregationTest, maxSpillBytes) {
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
-    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+    auto queryCtx = core::QueryCtx::create(executor_.get());
     try {
       TestScopedSpillInjection scopedSpillInjection(100);
       AssertQueryBuilder(plan)
@@ -3290,12 +3290,12 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimFromAggregationOnNoMoreInput) {
     SCOPED_TRACE(fmt::format("sameQuery {}", sameQuery));
     const auto spillDirectory = exec::test::TempDirectoryPath::create();
     std::shared_ptr<core::QueryCtx> fakeQueryCtx =
-        std::make_shared<core::QueryCtx>(executor_.get());
+        core::QueryCtx::create(executor_.get());
     std::shared_ptr<core::QueryCtx> aggregationQueryCtx;
     if (sameQuery) {
       aggregationQueryCtx = fakeQueryCtx;
     } else {
-      aggregationQueryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+      aggregationQueryCtx = core::QueryCtx::create(executor_.get());
     }
 
     folly::EventCount arbitrationWait;
@@ -3378,12 +3378,12 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimFromAggregationDuringOutput) {
     SCOPED_TRACE(fmt::format("sameQuery {}", sameQuery));
     const auto spillDirectory = exec::test::TempDirectoryPath::create();
     std::shared_ptr<core::QueryCtx> fakeQueryCtx =
-        std::make_shared<core::QueryCtx>(executor_.get());
+        core::QueryCtx::create(executor_.get());
     std::shared_ptr<core::QueryCtx> aggregationQueryCtx;
     if (sameQuery) {
       aggregationQueryCtx = fakeQueryCtx;
     } else {
-      aggregationQueryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+      aggregationQueryCtx = core::QueryCtx::create(executor_.get());
     }
 
     folly::EventCount arbitrationWait;
@@ -3455,12 +3455,12 @@ TEST_F(AggregationTest, reclaimFromCompletedAggregation) {
     SCOPED_TRACE(fmt::format("sameQuery {}", sameQuery));
     const auto spillDirectory = exec::test::TempDirectoryPath::create();
     std::shared_ptr<core::QueryCtx> fakeQueryCtx =
-        std::make_shared<core::QueryCtx>(executor_.get());
+        core::QueryCtx::create(executor_.get());
     std::shared_ptr<core::QueryCtx> aggregationQueryCtx;
     if (sameQuery) {
       aggregationQueryCtx = fakeQueryCtx;
     } else {
-      aggregationQueryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+      aggregationQueryCtx = core::QueryCtx::create(executor_.get());
     }
 
     folly::EventCount arbitrationWait;

--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -267,7 +267,7 @@ class DriverTest : public OperatorTestBase {
         "t0",
         plan,
         0,
-        std::make_shared<core::QueryCtx>(driverExecutor_.get()),
+        core::QueryCtx::create(driverExecutor_.get()),
         Task::ExecutionMode::kParallel,
         [](RowVectorPtr /*unused*/, ContinueFuture* /*unused*/) {
           return exec::BlockingReason::kNotBlocked;
@@ -580,7 +580,7 @@ TEST_F(DriverTest, pause) {
   // Make sure CPU usage tracking is enabled.
   std::unordered_map<std::string, std::string> queryConfig{
       {core::QueryConfig::kOperatorTrackCpuUsage, "true"}};
-  params.queryCtx = std::make_shared<core::QueryCtx>(
+  params.queryCtx = core::QueryCtx::create(
       executor_.get(), core::QueryConfig(std::move(queryConfig)));
   int32_t numRead = 0;
   readResults(params, ResultOperation::kPause, 370'000'000, &numRead);
@@ -803,7 +803,7 @@ TEST_F(DriverTest, pauserNode) {
   std::vector<CursorParameters> params(kNumTasks);
   int32_t hits{0};
   for (int32_t i = 0; i < kNumTasks; ++i) {
-    params[i].queryCtx = std::make_shared<core::QueryCtx>(executor.get());
+    params[i].queryCtx = core::QueryCtx::create(executor.get());
     params[i].planNode = makeValuesFilterProject(
         rowType_,
         "m1 % 10 > 0",
@@ -1518,8 +1518,7 @@ DEBUG_ONLY_TEST_F(DriverTest, driverCpuTimeSlicingCheck) {
           "t0",
           fragment,
           0,
-          std::make_shared<core::QueryCtx>(
-              driverExecutor_.get(), std::move(queryConfig)),
+          core::QueryCtx::create(driverExecutor_.get(), std::move(queryConfig)),
           testParam.executionMode,
           [](RowVectorPtr /*unused*/, ContinueFuture* /*unused*/) {
             return exec::BlockingReason::kNotBlocked;
@@ -1530,8 +1529,7 @@ DEBUG_ONLY_TEST_F(DriverTest, driverCpuTimeSlicingCheck) {
           "t0",
           fragment,
           0,
-          std::make_shared<core::QueryCtx>(
-              driverExecutor_.get(), std::move(queryConfig)),
+          core::QueryCtx::create(driverExecutor_.get(), std::move(queryConfig)),
           testParam.executionMode);
       while (task->next() != nullptr) {
       }
@@ -1603,8 +1601,7 @@ TEST_F(OpCallStatusTest, basic) {
       "t19",
       fragment,
       0,
-      std::make_shared<core::QueryCtx>(
-          driverExecutor_.get(), std::move(queryConfig)),
+      core::QueryCtx::create(driverExecutor_.get(), std::move(queryConfig)),
       Task::ExecutionMode::kParallel,
       [](RowVectorPtr /*unused*/, ContinueFuture* /*unused*/) {
         return exec::BlockingReason::kNotBlocked;

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -60,7 +60,7 @@ class ExchangeClientTest : public testing::Test,
   std::shared_ptr<Task> makeTask(
       const std::string& taskId,
       const core::PlanNodePtr& planNode) {
-    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+    auto queryCtx = core::QueryCtx::create(executor_.get());
     queryCtx->testingOverrideMemoryPool(
         memory::memoryManager()->addRootPool(queryCtx->queryId()));
     return Task::create(

--- a/velox/exec/tests/ExchangeFuzzer.cpp
+++ b/velox/exec/tests/ExchangeFuzzer.cpp
@@ -484,7 +484,7 @@ class ExchangeFuzzer : public VectorTestBase {
       Consumer consumer = nullptr,
       int64_t maxMemory = kMaxMemory) {
     auto configCopy = configSettings_;
-    auto queryCtx = std::make_shared<core::QueryCtx>(
+    auto queryCtx = core::QueryCtx::create(
         executor_.get(), core::QueryConfig(std::move(configCopy)));
     queryCtx->testingOverrideMemoryPool(
         memory::memoryManager()->addRootPool(queryCtx->queryId(), maxMemory));

--- a/velox/exec/tests/GroupedExecutionTest.cpp
+++ b/velox/exec/tests/GroupedExecutionTest.cpp
@@ -119,7 +119,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionErrors) {
   planFragment.executionStrategy = core::ExecutionStrategy::kUngrouped;
   planFragment.groupedExecutionLeafNodeIds.clear();
   planFragment.groupedExecutionLeafNodeIds.emplace(tableScanNodeId);
-  queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  queryCtx = core::QueryCtx::create(executor_.get());
   task = exec::Task::create(
       "0",
       planFragment,
@@ -133,7 +133,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionErrors) {
   // Check grouped execution without supplied leaf node ids.
   planFragment.executionStrategy = core::ExecutionStrategy::kGrouped;
   planFragment.groupedExecutionLeafNodeIds.clear();
-  queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  queryCtx = core::QueryCtx::create(executor_.get());
   task = exec::Task::create(
       "0",
       planFragment,
@@ -149,7 +149,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionErrors) {
   planFragment.executionStrategy = core::ExecutionStrategy::kGrouped;
   planFragment.groupedExecutionLeafNodeIds.clear();
   planFragment.groupedExecutionLeafNodeIds.emplace(projectNodeId);
-  queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  queryCtx = core::QueryCtx::create(executor_.get());
   task = exec::Task::create(
       "0",
       planFragment,
@@ -167,7 +167,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionErrors) {
   planFragment.groupedExecutionLeafNodeIds.clear();
   planFragment.groupedExecutionLeafNodeIds.emplace(tableScanNodeId);
   planFragment.groupedExecutionLeafNodeIds.emplace(projectNodeId);
-  queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  queryCtx = core::QueryCtx::create(executor_.get());
   task = exec::Task::create(
       "0",
       planFragment,
@@ -185,7 +185,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionErrors) {
   planFragment.executionStrategy = core::ExecutionStrategy::kGrouped;
   planFragment.groupedExecutionLeafNodeIds.clear();
   planFragment.groupedExecutionLeafNodeIds.emplace(localPartitionNodeId);
-  queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  queryCtx = core::QueryCtx::create(executor_.get());
   task = exec::Task::create(
       "0",
       planFragment,
@@ -226,7 +226,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionWithOutputBuffer) {
   planFragment.executionStrategy = core::ExecutionStrategy::kGrouped;
   planFragment.groupedExecutionLeafNodeIds.emplace(tableScanNodeId);
   planFragment.numSplitGroups = 10;
-  auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  auto queryCtx = core::QueryCtx::create(executor_.get());
   auto task = exec::Task::create(
       "0",
       std::move(planFragment),
@@ -384,7 +384,7 @@ DEBUG_ONLY_TEST_F(
     }
     planFragment.numSplitGroups = 2;
 
-    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+    auto queryCtx = core::QueryCtx::create(executor_.get());
     if (testData.enableSpill) {
       std::unordered_map<std::string, std::string> configs;
       configs.emplace(core::QueryConfig::kSpillEnabled, "true");
@@ -544,7 +544,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionWithHashAndNestedLoopJoin) {
     planFragment.executionStrategy = core::ExecutionStrategy::kGrouped;
     planFragment.groupedExecutionLeafNodeIds.emplace(probeScanNodeId);
     planFragment.numSplitGroups = 10;
-    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+    auto queryCtx = core::QueryCtx::create(executor_.get());
     auto task = exec::Task::create(
         "0",
         std::move(planFragment),

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -604,7 +604,7 @@ class HashJoinBuilder {
         builder.splits(splitEntry.first, splitEntry.second);
       }
     }
-    auto queryCtx = std::make_shared<core::QueryCtx>(
+    auto queryCtx = core::QueryCtx::create(
         executor_,
         core::QueryConfig{{}},
         std::unordered_map<std::string, std::shared_ptr<Config>>{},
@@ -3922,7 +3922,7 @@ TEST_F(HashJoinTest, memory) {
                         .project({"t_k1 % 1000 AS k1", "u_k1 % 1000 AS k2"})
                         .singleAggregation({}, {"sum(k1)", "sum(k2)"})
                         .planNode();
-  params.queryCtx = std::make_shared<core::QueryCtx>(driverExecutor_.get());
+  params.queryCtx = core::QueryCtx::create(driverExecutor_.get());
   auto [taskCursor, rows] = readCursor(params, [](Task*) {});
   EXPECT_GT(3'500, params.queryCtx->pool()->stats().numAllocs);
   EXPECT_GT(40'000'000, params.queryCtx->pool()->stats().cumulativeBytes);
@@ -5288,7 +5288,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, buildReservationReleaseCheck) {
                             "",
                             concat(probeType_->names(), buildType_->names()))
                         .planNode();
-  params.queryCtx = std::make_shared<core::QueryCtx>(driverExecutor_.get());
+  params.queryCtx = core::QueryCtx::create(driverExecutor_.get());
   // NOTE: the spilling setup is to trigger memory reservation code path which
   // only gets executed when spilling is enabled. We don't care about if
   // spilling is really triggered in test or not.
@@ -6618,7 +6618,7 @@ TEST_F(HashJoinTest, maxSpillBytes) {
                   .planNode();
 
   auto spillDirectory = exec::test::TempDirectoryPath::create();
-  auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  auto queryCtx = core::QueryCtx::create(executor_.get());
 
   struct {
     int32_t maxSpilledBytes;
@@ -6674,7 +6674,7 @@ TEST_F(HashJoinTest, onlyHashBuildMaxSpillBytes) {
                   .planNode();
 
   auto spillDirectory = exec::test::TempDirectoryPath::create();
-  auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  auto queryCtx = core::QueryCtx::create(executor_.get());
 
   struct {
     int32_t maxSpilledBytes;

--- a/velox/exec/tests/MemoryReclaimerTest.cpp
+++ b/velox/exec/tests/MemoryReclaimerTest.cpp
@@ -44,7 +44,7 @@ class MemoryReclaimerTest : public OperatorTestBase {
         "MemoryReclaimerTest",
         std::move(fakePlanFragment),
         0,
-        std::make_shared<core::QueryCtx>(executor_.get()),
+        core::QueryCtx::create(executor_.get()),
         Task::ExecutionMode::kParallel);
   }
 

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -29,7 +29,7 @@ class MergeJoinTest : public HiveConnectorTestBase {
   CursorParameters makeCursorParameters(
       const std::shared_ptr<const core::PlanNode>& planNode,
       uint32_t preferredOutputBatchSize) {
-    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+    auto queryCtx = core::QueryCtx::create(executor_.get());
 
     CursorParameters params;
     params.planNode = planNode;

--- a/velox/exec/tests/MergeTest.cpp
+++ b/velox/exec/tests/MergeTest.cpp
@@ -177,7 +177,7 @@ TEST_F(MergeTest, offByOne) {
 
   CursorParameters params;
   params.planNode = plan;
-  params.queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  params.queryCtx = core::QueryCtx::create(executor_.get());
   params.queryCtx->testingOverrideConfigUnsafe(
       {{core::QueryConfig::kPreferredOutputBatchRows, "6"}});
   assertQueryOrdered(params, "VALUES (0), (1), (2), (3), (4), (5), (10)", {0});

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -76,7 +76,7 @@ class MultiFragmentTest : public HiveConnectorTestBase {
       Consumer consumer = nullptr,
       int64_t maxMemory = memory::kMaxMemory) {
     auto configCopy = configSettings_;
-    auto queryCtx = std::make_shared<core::QueryCtx>(
+    auto queryCtx = core::QueryCtx::create(
         executor_.get(), core::QueryConfig(std::move(configCopy)));
     queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
         queryCtx->queryId(), maxMemory, MemoryReclaimer::create()));

--- a/velox/exec/tests/OperatorUtilsTest.cpp
+++ b/velox/exec/tests/OperatorUtilsTest.cpp
@@ -47,7 +47,7 @@ class OperatorUtilsTest : public OperatorTestBase {
         "SpillOperatorGroupTest_task",
         std::move(planFragment),
         0,
-        std::make_shared<core::QueryCtx>(executor_.get()),
+        core::QueryCtx::create(executor_.get()),
         Task::ExecutionMode::kParallel);
     driver_ = Driver::testingCreate();
     driverCtx_ = std::make_unique<DriverCtx>(task_, 0, 0, 0, 0);

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -196,7 +196,7 @@ class OrderByTest : public OperatorTestBase {
     {
       SCOPED_TRACE("run with spilling");
       auto spillDirectory = exec::test::TempDirectoryPath::create();
-      auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+      auto queryCtx = core::QueryCtx::create(executor_.get());
       TestScopedSpillInjection scopedSpillInjection(100);
       queryCtx->testingOverrideConfigUnsafe({
           {core::QueryConfig::kSpillEnabled, "true"},
@@ -474,7 +474,7 @@ TEST_F(OrderByTest, outputBatchRows) {
                     .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
                     .capturePlanNodeId(orderById)
                     .planNode();
-    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+    auto queryCtx = core::QueryCtx::create(executor_.get());
     queryCtx->testingOverrideConfigUnsafe(
         {{core::QueryConfig::kPreferredOutputBatchBytes,
           std::to_string(testData.preferredOutBatchBytes)},
@@ -567,7 +567,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringInputProcessing) {
     SCOPED_TRACE(testData.debugString());
 
     auto spillDirectory = exec::test::TempDirectoryPath::create();
-    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+    auto queryCtx = core::QueryCtx::create(executor_.get());
     queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
         queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
     auto expectedResult =
@@ -706,7 +706,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringReserve) {
   }
 
   auto spillDirectory = exec::test::TempDirectoryPath::create();
-  auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  auto queryCtx = core::QueryCtx::create(executor_.get());
   queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
       queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
   auto expectedResult =
@@ -819,7 +819,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringAllocation) {
   for (const auto enableSpilling : enableSpillings) {
     SCOPED_TRACE(fmt::format("enableSpilling {}", enableSpilling));
     auto spillDirectory = exec::test::TempDirectoryPath::create();
-    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+    auto queryCtx = core::QueryCtx::create(executor_.get());
     queryCtx->testingOverrideMemoryPool(
         memory::memoryManager()->addRootPool(queryCtx->queryId(), kMaxBytes));
     auto expectedResult =
@@ -949,7 +949,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringOutputProcessing) {
   for (const auto enableSpilling : enableSpillings) {
     SCOPED_TRACE(fmt::format("enableSpilling {}", enableSpilling));
     auto spillDirectory = exec::test::TempDirectoryPath::create();
-    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+    auto queryCtx = core::QueryCtx::create(executor_.get());
     queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
         queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
     auto expectedResult =
@@ -1257,7 +1257,7 @@ TEST_F(OrderByTest, maxSpillBytes) {
           .capturePlanNodeId(orderNodeId)
           .planNode();
   auto spillDirectory = exec::test::TempDirectoryPath::create();
-  auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  auto queryCtx = core::QueryCtx::create(executor_.get());
 
   struct {
     int32_t maxSpilledBytes;

--- a/velox/exec/tests/OutputBufferManagerTest.cpp
+++ b/velox/exec/tests/OutputBufferManagerTest.cpp
@@ -71,7 +71,7 @@ class OutputBufferManagerTest : public testing::Test {
       configSettings[core::QueryConfig::kMaxPartitionedOutputBufferSize] =
           std::to_string(maxOutputBufferSize);
     }
-    auto queryCtx = std::make_shared<core::QueryCtx>(
+    auto queryCtx = core::QueryCtx::create(
         executor_.get(), core::QueryConfig(std::move(configSettings)));
 
     auto task = Task::create(

--- a/velox/exec/tests/PartitionedOutputTest.cpp
+++ b/velox/exec/tests/PartitionedOutputTest.cpp
@@ -25,7 +25,7 @@ class PartitionedOutputTest : public OperatorTestBase {
  protected:
   std::shared_ptr<core::QueryCtx> createQueryContext(
       std::unordered_map<std::string, std::string> config) {
-    return std::make_shared<core::QueryCtx>(
+    return core::QueryCtx::create(
         executor_.get(), core::QueryConfig(std::move(config)));
   }
 

--- a/velox/exec/tests/RowNumberTest.cpp
+++ b/velox/exec/tests/RowNumberTest.cpp
@@ -194,7 +194,7 @@ TEST_F(RowNumberTest, spill) {
   std::vector<RowVectorPtr> vectors = createVectors(8, rowType_, fuzzerOpts_);
   createDuckDbTable(vectors);
   const auto spillDirectory = exec::test::TempDirectoryPath::create();
-  auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  auto queryCtx = core::QueryCtx::create(executor_.get());
 
   struct {
     uint32_t spillPartitionBits;
@@ -269,7 +269,7 @@ TEST_F(RowNumberTest, maxSpillBytes) {
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     auto spillDirectory = exec::test::TempDirectoryPath::create();
-    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+    auto queryCtx = core::QueryCtx::create(executor_.get());
     try {
       TestScopedSpillInjection scopedSpillInjection(100);
       AssertQueryBuilder(plan)
@@ -308,7 +308,7 @@ TEST_F(RowNumberTest, memoryUsage) {
   int64_t peakBytesWithOutSpilling = 0;
 
   for (const auto& spillEnable : {false, true}) {
-    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+    auto queryCtx = core::QueryCtx::create(executor_.get());
     auto spillDirectory = exec::test::TempDirectoryPath::create();
     const std::string spillEnableConfig = std::to_string(spillEnable);
 

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1489,7 +1489,7 @@ DEBUG_ONLY_TEST_F(TableScanTest, tableScanSplitsAndWeights) {
                       .partitionedOutput({}, 1, {"c0", "c1", "c2"})
                       .planNode();
   std::unordered_map<std::string, std::string> config;
-  auto queryCtx = std::make_shared<core::QueryCtx>(
+  auto queryCtx = core::QueryCtx::create(
       executor_.get(), core::QueryConfig(std::move(config)));
   core::PlanFragment planFragment{leafPlan};
   Consumer consumer = nullptr;

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -470,7 +470,7 @@ class TaskTest : public HiveConnectorTestBase {
         "single.execution.task.0",
         plan,
         0,
-        std::make_shared<core::QueryCtx>(),
+        core::QueryCtx::create(),
         Task::ExecutionMode::kSerial);
 
     for (const auto& [nodeId, paths] : filePaths) {
@@ -519,7 +519,7 @@ TEST_F(TaskTest, toJson) {
       "task-1",
       std::move(plan),
       0,
-      std::make_shared<core::QueryCtx>(driverExecutor_.get()),
+      core::QueryCtx::create(driverExecutor_.get()),
       Task::ExecutionMode::kParallel);
 
   ASSERT_EQ(
@@ -565,7 +565,7 @@ TEST_F(TaskTest, wrongPlanNodeForSplit) {
       "task-1",
       std::move(plan),
       0,
-      std::make_shared<core::QueryCtx>(driverExecutor_.get()),
+      core::QueryCtx::create(driverExecutor_.get()),
       Task::ExecutionMode::kParallel);
 
   // Add split for the source node.
@@ -621,7 +621,7 @@ TEST_F(TaskTest, wrongPlanNodeForSplit) {
       "task-2",
       std::move(plan),
       0,
-      std::make_shared<core::QueryCtx>(driverExecutor_.get()),
+      core::QueryCtx::create(driverExecutor_.get()),
       Task::ExecutionMode::kParallel);
   errorMessage =
       "Splits can be associated only with leaf plan nodes which require splits. Plan node ID 0 doesn't refer to such plan node.";
@@ -648,7 +648,7 @@ TEST_F(TaskTest, duplicatePlanNodeIds) {
           "task-1",
           std::move(plan),
           0,
-          std::make_shared<core::QueryCtx>(driverExecutor_.get()),
+          core::QueryCtx::create(driverExecutor_.get()),
           Task::ExecutionMode::kParallel),
       "Plan node IDs must be unique. Found duplicate ID: 0.")
 }
@@ -921,7 +921,7 @@ TEST_F(TaskTest, singleThreadedExecutionExternalBlockable) {
       "single.execution.task.0",
       plan,
       0,
-      std::make_shared<core::QueryCtx>(),
+      core::QueryCtx::create(),
       Task::ExecutionMode::kSerial);
   std::vector<RowVectorPtr> results;
   for (;;) {
@@ -941,7 +941,7 @@ TEST_F(TaskTest, singleThreadedExecutionExternalBlockable) {
       "single.execution.task.1",
       plan,
       0,
-      std::make_shared<core::QueryCtx>(),
+      core::QueryCtx::create(),
       Task::ExecutionMode::kSerial);
   // Before we block, we expect `next` to get data normally.
   results.push_back(blockingTask->next(&continueFuture));
@@ -977,7 +977,7 @@ TEST_F(TaskTest, supportsSingleThreadedExecution) {
       "single.execution.task.0",
       plan,
       0,
-      std::make_shared<core::QueryCtx>(),
+      core::QueryCtx::create(),
       Task::ExecutionMode::kSerial);
 
   // PartitionedOutput does not support single threaded execution, therefore the
@@ -997,7 +997,7 @@ TEST_F(TaskTest, updateBroadCastOutputBuffers) {
         "t0",
         plan,
         0,
-        std::make_shared<core::QueryCtx>(driverExecutor_.get()),
+        core::QueryCtx::create(driverExecutor_.get()),
         Task::ExecutionMode::kParallel);
 
     task->start(1, 1);
@@ -1015,7 +1015,7 @@ TEST_F(TaskTest, updateBroadCastOutputBuffers) {
         "t1",
         plan,
         0,
-        std::make_shared<core::QueryCtx>(driverExecutor_.get()),
+        core::QueryCtx::create(driverExecutor_.get()),
         Task::ExecutionMode::kParallel);
 
     task->start(1, 1);
@@ -1091,7 +1091,7 @@ DEBUG_ONLY_TEST_F(TaskTest, outputDriverFinishEarly) {
 
   CursorParameters params;
   params.planNode = plan;
-  params.queryCtx = std::make_shared<core::QueryCtx>(driverExecutor_.get());
+  params.queryCtx = core::QueryCtx::create(driverExecutor_.get());
   params.queryCtx->testingOverrideConfigUnsafe(
       {{core::QueryConfig::kPreferredOutputBatchRows, "1"}});
 
@@ -1137,7 +1137,7 @@ DEBUG_ONLY_TEST_F(TaskTest, liveStats) {
 
   CursorParameters params;
   params.planNode = plan;
-  params.queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  params.queryCtx = core::QueryCtx::create(executor_.get());
   params.queryCtx->testingOverrideConfigUnsafe(
       {{core::QueryConfig::kPreferredOutputBatchRows, "1"}});
 
@@ -1216,7 +1216,7 @@ TEST_F(TaskTest, outputBufferSize) {
 
   CursorParameters params;
   params.planNode = plan;
-  params.queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  params.queryCtx = core::QueryCtx::create(executor_.get());
 
   // Produce the results to output buffer manager but not consuming them to
   // check the buffer utilization in test.
@@ -1265,7 +1265,7 @@ DEBUG_ONLY_TEST_F(TaskTest, inconsistentExecutionMode) {
     CursorParameters params;
     params.planNode =
         PlanBuilder().values({data, data, data}).project({"c0"}).planNode();
-    params.queryCtx = std::make_shared<core::QueryCtx>(driverExecutor_.get());
+    params.queryCtx = core::QueryCtx::create(driverExecutor_.get());
     params.maxDrivers = 4;
 
     auto cursor = TaskCursor::create(params);
@@ -1289,7 +1289,7 @@ DEBUG_ONLY_TEST_F(TaskTest, inconsistentExecutionMode) {
     });
     auto plan =
         PlanBuilder().values({data, data, data}).project({"c0"}).planFragment();
-    auto queryCtx = std::make_shared<core::QueryCtx>(driverExecutor_.get());
+    auto queryCtx = core::QueryCtx::create(driverExecutor_.get());
     auto task =
         Task::create("task.0", plan, 0, queryCtx, Task::ExecutionMode::kSerial);
 
@@ -1330,7 +1330,7 @@ DEBUG_ONLY_TEST_F(TaskTest, findPeerOperators) {
                               "",
                               {"t_c0", "t_c1", "u_c0"})
                           .planNode();
-    params.queryCtx = std::make_shared<core::QueryCtx>(driverExecutor_.get());
+    params.queryCtx = core::QueryCtx::create(driverExecutor_.get());
     params.maxDrivers = numDriver;
 
     auto cursor = TaskCursor::create(params);
@@ -1381,7 +1381,7 @@ DEBUG_ONLY_TEST_F(TaskTest, raceBetweenTaskPauseAndTerminate) {
   CursorParameters params;
   params.planNode =
       PlanBuilder(planNodeIdGenerator).values(values, true).planNode();
-  params.queryCtx = std::make_shared<core::QueryCtx>(driverExecutor_.get());
+  params.queryCtx = core::QueryCtx::create(driverExecutor_.get());
   params.maxDrivers = 1;
 
   auto cursor = TaskCursor::create(params);
@@ -1458,7 +1458,7 @@ DEBUG_ONLY_TEST_F(TaskTest, driverCounters) {
 
   CursorParameters params;
   params.planNode = plan.planNode;
-  params.queryCtx = std::make_shared<core::QueryCtx>(driverExecutor_.get());
+  params.queryCtx = core::QueryCtx::create(driverExecutor_.get());
   // The queue size in the executor is 3, so we will have 1 driver queued.
   params.maxDrivers = 4;
 
@@ -1563,7 +1563,7 @@ TEST_F(TaskTest, driverCreationMemoryAllocationCheck) {
         "driverCreationMemoryAllocationCheck",
         plan,
         0,
-        std::make_shared<core::QueryCtx>(
+        core::QueryCtx::create(
             singleThreadExecution ? nullptr : driverExecutor_.get()),
         singleThreadExecution ? Task::ExecutionMode::kSerial
                               : Task::ExecutionMode::kParallel);
@@ -1591,7 +1591,7 @@ TEST_F(TaskTest, spillDirectoryLifecycleManagement) {
                         .planNode();
   CursorParameters params;
   params.planNode = plan;
-  params.queryCtx = std::make_shared<core::QueryCtx>(driverExecutor_.get());
+  params.queryCtx = core::QueryCtx::create(driverExecutor_.get());
   params.queryCtx->testingOverrideConfigUnsafe(
       {{core::QueryConfig::kSpillEnabled, "true"},
        {core::QueryConfig::kAggregationSpillEnabled, "true"}});
@@ -1648,7 +1648,7 @@ TEST_F(TaskTest, spillDirNotCreated) {
                             {"t_c0", "t_c1", "u_c0"})
                         .capturePlanNodeId(hashJoinNodeId)
                         .planNode();
-  params.queryCtx = std::make_shared<core::QueryCtx>(driverExecutor_.get());
+  params.queryCtx = core::QueryCtx::create(driverExecutor_.get());
   params.queryCtx->testingOverrideConfigUnsafe(
       {{core::QueryConfig::kSpillEnabled, "true"},
        {core::QueryConfig::kJoinSpillEnabled, "true"}});
@@ -1703,7 +1703,7 @@ DEBUG_ONLY_TEST_F(TaskTest, resumeAfterTaskFinish) {
       "task",
       std::move(plan),
       0,
-      std::make_shared<core::QueryCtx>(driverExecutor_.get()),
+      core::QueryCtx::create(driverExecutor_.get()),
       Task::ExecutionMode::kParallel);
   task->start(4, 1);
 
@@ -1734,7 +1734,7 @@ DEBUG_ONLY_TEST_F(
   auto plan =
       PlanBuilder().values({data, data, data}).project({"c0"}).planFragment();
 
-  auto queryCtx = std::make_shared<core::QueryCtx>(driverExecutor_.get());
+  auto queryCtx = core::QueryCtx::create(driverExecutor_.get());
 
   auto blockingTask = Task::create(
       "blocking.task.0", plan, 0, queryCtx, Task::ExecutionMode::kSerial);
@@ -1809,7 +1809,7 @@ DEBUG_ONLY_TEST_F(TaskTest, longRunningOperatorInTaskReclaimerAbort) {
   auto plan =
       PlanBuilder().values({data, data, data}).project({"c0"}).planFragment();
 
-  auto queryCtx = std::make_shared<core::QueryCtx>(driverExecutor_.get());
+  auto queryCtx = core::QueryCtx::create(driverExecutor_.get());
 
   auto blockingTask = Task::create(
       "blocking.task.0", plan, 0, queryCtx, Task::ExecutionMode::kParallel);
@@ -1866,7 +1866,7 @@ DEBUG_ONLY_TEST_F(TaskTest, taskReclaimStats) {
 
   auto queryPool = memory::memoryManager()->addRootPool(
       "taskReclaimStats", 1UL << 30, exec::MemoryReclaimer::create());
-  auto queryCtx = std::make_shared<core::QueryCtx>(
+  auto queryCtx = core::QueryCtx::create(
       driverExecutor_.get(),
       core::QueryConfig{{}},
       std::unordered_map<std::string, std::shared_ptr<Config>>{},
@@ -1937,7 +1937,7 @@ DEBUG_ONLY_TEST_F(TaskTest, taskPauseTime) {
 
   auto queryPool = memory::memoryManager()->addRootPool(
       "taskPauseTime", 1UL << 30, exec::MemoryReclaimer::create());
-  auto queryCtx = std::make_shared<core::QueryCtx>(
+  auto queryCtx = core::QueryCtx::create(
       driverExecutor_.get(),
       core::QueryConfig{{}},
       std::unordered_map<std::string, std::shared_ptr<Config>>{},
@@ -1997,7 +1997,7 @@ TEST_F(TaskTest, updateStatsWhileCloseOffThreadDriver) {
       "task",
       std::move(plan),
       0,
-      std::make_shared<core::QueryCtx>(driverExecutor_.get()),
+      core::QueryCtx::create(driverExecutor_.get()),
       Task::ExecutionMode::kParallel);
   task->start(4, 1);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -2042,7 +2042,7 @@ DEBUG_ONLY_TEST_F(TaskTest, driverEnqueAfterFailedAndPausedTask) {
       "task",
       std::move(plan),
       0,
-      std::make_shared<core::QueryCtx>(driverExecutor_.get()),
+      core::QueryCtx::create(driverExecutor_.get()),
       Task::ExecutionMode::kParallel);
   task->start(4, 1);
 

--- a/velox/exec/tests/ThreadDebugInfoTest.cpp
+++ b/velox/exec/tests/ThreadDebugInfoTest.cpp
@@ -90,7 +90,7 @@ DEBUG_ONLY_TEST_F(ThreadDebugInfoDeathTest, withinTheCallingThread) {
   auto plan =
       PlanBuilder().values({vector}).project({"segFault(c0)"}).planFragment();
 
-  auto queryCtx = std::make_shared<core::QueryCtx>(
+  auto queryCtx = core::QueryCtx::create(
       executor_.get(),
       core::QueryConfig({}),
       std::unordered_map<std::string, std::shared_ptr<Config>>{},

--- a/velox/exec/tests/TopNRowNumberTest.cpp
+++ b/velox/exec/tests/TopNRowNumberTest.cpp
@@ -352,7 +352,7 @@ TEST_F(TopNRowNumberTest, maxSpillBytes) {
   } testSettings[] = {{1 << 30, false}, {13 << 20, true}, {0, false}};
 
   auto spillDirectory = exec::test::TempDirectoryPath::create();
-  auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  auto queryCtx = core::QueryCtx::create(executor_.get());
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());

--- a/velox/exec/tests/VeloxIn10MinDemo.cpp
+++ b/velox/exec/tests/VeloxIn10MinDemo.cpp
@@ -102,7 +102,7 @@ class VeloxIn10MinDemo : public VectorTestBase {
       std::make_shared<folly::CPUThreadPoolExecutor>(
           std::thread::hardware_concurrency())};
   std::shared_ptr<core::QueryCtx> queryCtx_{
-      std::make_shared<core::QueryCtx>(executor_.get())};
+      core::QueryCtx::create(executor_.get())};
   std::unique_ptr<core::ExecCtx> execCtx_{
       std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get())};
 };

--- a/velox/exec/tests/utils/ArbitratorTestUtil.cpp
+++ b/velox/exec/tests/utils/ArbitratorTestUtil.cpp
@@ -30,11 +30,9 @@ std::shared_ptr<core::QueryCtx> newQueryCtx(
     int64_t memoryCapacity,
     std::unique_ptr<MemoryReclaimer>&& reclaimer) {
   std::unordered_map<std::string, std::shared_ptr<Config>> configs;
-  std::shared_ptr<MemoryPool> pool = memoryManager->addRootPool(
-      "",
-      memoryCapacity,
-      reclaimer != nullptr ? std::move(reclaimer) : MemoryReclaimer::create());
-  auto queryCtx = std::make_shared<core::QueryCtx>(
+  std::shared_ptr<MemoryPool> pool =
+      memoryManager->addRootPool("", memoryCapacity);
+  auto queryCtx = core::QueryCtx::create(
       executor,
       core::QueryConfig({}),
       configs,

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -238,7 +238,7 @@ AssertQueryBuilder::readCursor() {
       // NOTE: the destructor of 'executor_' will wait for all the async task
       // activities to finish on AssertQueryBuilder dtor.
       static std::atomic<uint64_t> cursorQueryId{0};
-      params_.queryCtx = std::make_shared<core::QueryCtx>(
+      params_.queryCtx = core::QueryCtx::create(
           executor_.get(),
           core::QueryConfig({}),
           std::unordered_map<std::string, std::shared_ptr<Config>>{},

--- a/velox/exec/tests/utils/Cursor.cpp
+++ b/velox/exec/tests/utils/Cursor.cpp
@@ -151,7 +151,7 @@ class TaskCursorBase : public TaskCursor {
       // activities to finish on TaskCursor destruction.
       executor_ = executor;
       static std::atomic<uint64_t> cursorQueryId{0};
-      queryCtx_ = std::make_shared<core::QueryCtx>(
+      queryCtx_ = core::QueryCtx::create(
           executor_.get(),
           core::QueryConfig({}),
           std::unordered_map<std::string, std::shared_ptr<Config>>{},

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -170,8 +170,8 @@ core::PlanNodePtr PlanBuilder::TableScanBuilder::build(core::PlanNodeId id) {
 
   SubfieldFilters filters;
   filters.reserve(subfieldFilters_.size());
-  core::QueryCtx queryCtx;
-  exec::SimpleExpressionEvaluator evaluator(&queryCtx, planBuilder_.pool_);
+  auto queryCtx = core::QueryCtx::create();
+  exec::SimpleExpressionEvaluator evaluator(queryCtx.get(), planBuilder_.pool_);
   for (const auto& filter : subfieldFilters_) {
     auto filterExpr =
         parseExpr(filter, parseType, planBuilder_.options_, planBuilder_.pool_);

--- a/velox/expression/fuzzer/ExpressionFuzzerVerifier.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerVerifier.cpp
@@ -82,7 +82,7 @@ ExpressionFuzzerVerifier::ExpressionFuzzerVerifier(
     size_t initialSeed,
     const ExpressionFuzzerVerifier::Options& options)
     : options_(options),
-      queryCtx_(std::make_shared<core::QueryCtx>(
+      queryCtx_(core::QueryCtx::create(
           nullptr,
           core::QueryConfig(options.queryConfigs))),
       execCtx_({pool_.get(), queryCtx_.get()}),

--- a/velox/expression/tests/ExprCompilerTest.cpp
+++ b/velox/expression/tests/ExprCompilerTest.cpp
@@ -102,7 +102,7 @@ class ExprCompilerTest : public testing::Test,
         std::vector<core::TypedExprPtr>{expr}, execCtx_.get());
   }
 
-  std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
+  std::shared_ptr<core::QueryCtx> queryCtx_{velox::core::QueryCtx::create()};
   std::unique_ptr<core::ExecCtx> execCtx_{
       std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get())};
 };

--- a/velox/expression/tests/ExprEncodingsTest.cpp
+++ b/velox/expression/tests/ExprEncodingsTest.cpp
@@ -489,7 +489,7 @@ class ExprEncodingsTest
         makeLazyVector);
   }
 
-  std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
+  std::shared_ptr<core::QueryCtx> queryCtx_{velox::core::QueryCtx::create()};
   std::unique_ptr<core::ExecCtx> execCtx_{
       std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get())};
   TestData testData_;

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -401,7 +401,7 @@ class ExprTest : public testing::Test, public VectorTestBase {
     return exprSet.exprs().front()->propagatesNulls();
   }
 
-  std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
+  std::shared_ptr<core::QueryCtx> queryCtx_{velox::core::QueryCtx::create()};
   std::unique_ptr<core::ExecCtx> execCtx_{
       std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get())};
   parse::ParseOptions options_;
@@ -414,7 +414,7 @@ class ParameterizedExprTest : public ExprTest,
     std::unordered_map<std::string, std::string> configData(
         {{core::QueryConfig::kEnableExpressionEvaluationCache,
           GetParam() ? "true" : "false"}});
-    queryCtx_ = std::make_shared<core::QueryCtx>(
+    queryCtx_ = velox::core::QueryCtx::create(
         nullptr, core::QueryConfig(std::move(configData)));
     execCtx_ = std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get());
   }
@@ -4235,7 +4235,7 @@ TEST_F(ExprTest, commonSubExpressionWithPeeling) {
       // Set max_shared_subexpr_results_cached low so the
       // second result isn't cached, so expr1 is only evaluated once, but expr2
       // is evaluated twice.
-      auto queryCtx = std::make_shared<core::QueryCtx>(
+      auto queryCtx = velox::core::QueryCtx::create(
           nullptr,
           core::QueryConfig(std::unordered_map<std::string, std::string>{
               {core::QueryConfig::kMaxSharedSubexprResultsCached, "1"}}));

--- a/velox/expression/tests/ExprToSubfieldFilterTest.cpp
+++ b/velox/expression/tests/ExprToSubfieldFilterTest.cpp
@@ -68,8 +68,8 @@ class ExprToSubfieldFilterTest : public testing::Test {
  private:
   std::shared_ptr<memory::MemoryPool> pool_ =
       memory::memoryManager()->addLeafPool();
-  core::QueryCtx queryCtx_;
-  SimpleExpressionEvaluator evaluator_{&queryCtx_, pool_.get()};
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
+  SimpleExpressionEvaluator evaluator_{queryCtx_.get(), pool_.get()};
 };
 
 TEST_F(ExprToSubfieldFilterTest, eq) {

--- a/velox/expression/tests/ExpressionRunner.cpp
+++ b/velox/expression/tests/ExpressionRunner.cpp
@@ -119,7 +119,7 @@ void ExpressionRunner::run(
     bool useSeperatePoolForInput) {
   VELOX_CHECK(!sql.empty());
   auto memoryManager = memory::memoryManager();
-  std::shared_ptr<core::QueryCtx> queryCtx{std::make_shared<core::QueryCtx>()};
+  auto queryCtx = core::QueryCtx::create();
   std::shared_ptr<memory::MemoryPool> deserializerPool{
       memoryManager->addLeafPool()};
   std::shared_ptr<memory::MemoryPool> pool = useSeperatePoolForInput

--- a/velox/expression/tests/ExpressionRunnerUnitTest.cpp
+++ b/velox/expression/tests/ExpressionRunnerUnitTest.cpp
@@ -41,8 +41,8 @@ class ExpressionRunnerUnitTest : public testing::Test, public VectorTestBase {
 
   std::shared_ptr<memory::MemoryPool> pool_{
       memory::memoryManager()->addLeafPool()};
-  core::QueryCtx queryCtx_{};
-  core::ExecCtx execCtx_{pool_.get(), &queryCtx_};
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
+  core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
 };
 
 TEST_F(ExpressionRunnerUnitTest, run) {

--- a/velox/expression/tests/ExpressionVerifierUnitTest.cpp
+++ b/velox/expression/tests/ExpressionVerifierUnitTest.cpp
@@ -81,8 +81,8 @@ class ExpressionVerifierUnitTest : public testing::Test, public VectorTestBase {
 
   std::shared_ptr<memory::MemoryPool> pool_{
       memory::memoryManager()->addLeafPool()};
-  core::QueryCtx queryCtx_{};
-  core::ExecCtx execCtx_{pool_.get(), &queryCtx_};
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
+  core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
 };
 
 TEST_F(ExpressionVerifierUnitTest, persistReproInfo) {

--- a/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
@@ -1296,8 +1296,8 @@ void AggregationTestBase::testIncrementalAggregation(
     auto queryCtxConfig = config;
     auto func = createAggregateFunction(
         functionName, aggregate.rawInputTypes, allocator, config);
-    auto queryCtx = std::make_shared<core::QueryCtx>(
-        nullptr, core::QueryConfig{queryCtxConfig});
+    auto queryCtx =
+        core::QueryCtx::create(nullptr, core::QueryConfig{queryCtxConfig});
 
     std::shared_ptr<core::ExpressionEvaluator> expressionEvaluator;
     if (!lambdas.empty()) {

--- a/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
+++ b/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
@@ -94,7 +94,7 @@ class FunctionBenchmarkBase {
   }
 
  protected:
-  std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
   std::shared_ptr<memory::MemoryPool> pool_{
       memory::memoryManager()->addLeafPool()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};

--- a/velox/functions/prestosql/aggregates/benchmarks/ReduceAgg.cpp
+++ b/velox/functions/prestosql/aggregates/benchmarks/ReduceAgg.cpp
@@ -189,7 +189,7 @@ class ReduceAggBenchmark : public HiveConnectorTestBase {
         "t",
         std::move(plan),
         0,
-        std::make_shared<core::QueryCtx>(executor_.get()),
+        core::QueryCtx::create(executor_.get()),
         exec::Task::ExecutionMode::kParallel);
 
     task->addSplit(

--- a/velox/functions/prestosql/aggregates/benchmarks/SimpleAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/benchmarks/SimpleAggregates.cpp
@@ -165,7 +165,7 @@ class SimpleAggregatesBenchmark : public HiveConnectorTestBase {
         "t",
         std::move(plan),
         0,
-        std::make_shared<core::QueryCtx>(executor_.get()),
+        core::QueryCtx::create(executor_.get()),
         exec::Task::ExecutionMode::kParallel);
   }
 

--- a/velox/functions/prestosql/aggregates/benchmarks/TwoStringKeys.cpp
+++ b/velox/functions/prestosql/aggregates/benchmarks/TwoStringKeys.cpp
@@ -113,7 +113,7 @@ class TwoStringKeysBenchmark : public HiveConnectorTestBase {
         "t",
         std::move(plan),
         0,
-        std::make_shared<core::QueryCtx>(executor_.get()),
+        core::QueryCtx::create(executor_.get()),
         exec::Task::ExecutionMode::kParallel);
 
     task->addSplit(

--- a/velox/functions/prestosql/aggregates/tests/ApproxPercentileTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxPercentileTest.cpp
@@ -345,7 +345,7 @@ TEST_F(ApproxPercentileTest, largeWeightsGroupBy) {
 TEST_F(ApproxPercentileTest, partialFull) {
   // Make sure partial aggregation runs out of memory after first batch.
   CursorParameters params;
-  params.queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  params.queryCtx = velox::core::QueryCtx::create(executor_.get());
   params.queryCtx->testingOverrideConfigUnsafe({
       {core::QueryConfig::kMaxPartialAggregationMemory, "300000"},
   });

--- a/velox/functions/prestosql/tests/SimpleComparisonMatcherTest.cpp
+++ b/velox/functions/prestosql/tests/SimpleComparisonMatcherTest.cpp
@@ -47,7 +47,7 @@ class SimpleComparisonMatcherTest : public testing::Test,
     return core::Expressions::inferTypes(untyped, rowType, execCtx_->pool());
   }
 
-  std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
   std::unique_ptr<core::ExecCtx> execCtx_{
       std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get())};
   const std::string prefix_ = "tp.";

--- a/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
@@ -339,7 +339,7 @@ class FunctionBaseTest : public testing::Test,
       const VectorPtr& expected);
 
   std::shared_ptr<core::QueryCtx> queryCtx_{
-      std::make_shared<core::QueryCtx>(executor_.get())};
+      core::QueryCtx::create(executor_.get())};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
   parse::ParseOptions options_;
 

--- a/velox/functions/remote/server/RemoteFunctionService.cpp
+++ b/velox/functions/remote/server/RemoteFunctionService.cpp
@@ -94,8 +94,8 @@ void RemoteFunctionServiceHandler::invokeFunction(
   SelectivityVector rows{numRows};
 
   // Expression boilerplate.
-  core::QueryCtx queryCtx;
-  core::ExecCtx execCtx{pool_.get(), &queryCtx};
+  auto queryCtx = core::QueryCtx::create();
+  core::ExecCtx execCtx{pool_.get(), queryCtx.get()};
   exec::ExprSet exprSet{
       getExpressions(
           inputType,

--- a/velox/functions/sparksql/tests/InputFileNameTest.cpp
+++ b/velox/functions/sparksql/tests/InputFileNameTest.cpp
@@ -34,7 +34,7 @@ class InputFileNameTest : public SparkFunctionBaseTest {
         "t",
         std::move(plan),
         0,
-        std::make_shared<core::QueryCtx>(executor_.get()),
+        velox::core::QueryCtx::create(executor_.get()),
         exec::Task::ExecutionMode::kParallel);
     exec::DriverCtx driverCtx(task, 0, 0, 0, 0);
     return driverCtx;

--- a/velox/substrait/tests/FunctionTest.cpp
+++ b/velox/substrait/tests/FunctionTest.cpp
@@ -35,8 +35,7 @@ class FunctionTest : public ::testing::Test {
     memory::MemoryManager::testingSetInstance({});
   }
 
-  std::shared_ptr<core::QueryCtx> queryCtx_ =
-      std::make_shared<core::QueryCtx>();
+  std::shared_ptr<core::QueryCtx> queryCtx_ = core::QueryCtx::create();
 
   std::shared_ptr<memory::MemoryPool> pool_ =
       memory::memoryManager()->addLeafPool();

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -360,7 +360,7 @@ class ArrowBridgeArrayExportTest : public testing::Test {
 
   // Boiler plate structures required by vectorMaker.
   ArrowOptions options_;
-  std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
+  std::shared_ptr<core::QueryCtx> queryCtx_{velox::core::QueryCtx::create()};
   std::shared_ptr<memory::MemoryPool> pool_{
       memory::memoryManager()->addLeafPool()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};


### PR DESCRIPTION
This PR adds customized memory reclaimer for query execution and implements inside the
query context:
(1) let driver go-off thread wait for query memory arbitration to complete. When a query is under
memory arbitration, it is out of memory capacity and if we allow the query driver threads continue
to run, then it is very likely that they are blocked inside the memory arbitrator which is on-thread
blocking. This might indirect affects non-spilled query or query which is not under memory arbitration
as they hold the driver thread and the non-spilled query might see high driver queue latency. Also
note that a query might contain multiple tasks and we reclaim memory from one task at a time. This
PR returns driver a future if the associated query is under memory arbitration. With Meta internal logs
based shadowing, the memory arbitration wall-time from the spilled query has been reduced by half
with this optimization. It doesn't reduce the driver queue latency but run through with more large queries
with spilling with the same or reduced the execution time.
(2) customize the query reclaim procedure to skip reclaim from the task which is non-spillable and sort
the tasks for reclaim based on the reclaimable bytes instead of task memory capacity.

The next step is to (1) parallelize memory reclamation processing at the plan node level; (2) self-triggered
spill if the operator has already spilled and do spill by itself if its memory capacity reaches to % of the
previous peak memory usage; (3) skip the memory copy in http response handling to avoid triggering the
memory arbitration in http executor in Prestissimo.
