### PR TITLE
Selective Nimble reader skeleton

### DIFF
--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
@@ -110,7 +110,9 @@ void E2EFilterTestBase::readWithoutFilter(
     bool hasData;
     {
       MicrosecondTimer timer(&time);
-      hasData = rowReader->next(1000, resultBatch);
+      auto rowsScanned = rowReader->next(1000, resultBatch);
+      VLOG(1) << "rowsScanned=" << rowsScanned;
+      hasData = rowsScanned > 0;
     }
     if (!hasData) {
       break;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/51

The first diff for Nimble selective reader.  Contains:
- Reader class and factory implementation
- All primitive type column readers (no dictionary output) and struct column reader
- `ChuckedDecoder` to accept visitor and apply it on multiple chunks
- Basic simple implementation of `readWithVisitor` for all testable encodings
- Unit tests and randomized unit tests covering all primitive types and struct

bypass-github-export-checks

Reviewed By: oerling

Differential Revision: D57162138


