### PR TITLE
Use mutex lock to protect cache shutdown

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -647,6 +647,9 @@ void AsyncDataCache::shutdown() {
   for (auto& shard : shards_) {
     shard->shutdown();
   }
+  if (ssdCache_) {
+    ssdCache_->shutdown();
+  }
 }
 
 void CacheShard::shutdown() {

--- a/velox/common/caching/tests/SsdFileTest.cpp
+++ b/velox/common/caching/tests/SsdFileTest.cpp
@@ -48,7 +48,7 @@ class SsdFileTest : public testing::Test {
 
   void TearDown() override {
     if (ssdFile_) {
-      ssdFile_->deleteFile();
+      ssdFile_->testingDeleteFile();
     }
     if (cache_) {
       cache_->shutdown();

--- a/velox/dwio/dwrf/test/CacheInputTest.cpp
+++ b/velox/dwio/dwrf/test/CacheInputTest.cpp
@@ -62,13 +62,13 @@ class CacheTest : public testing::Test {
   }
 
   void TearDown() override {
-    executor_->join();
-    auto ssdCache = cache_->ssdCache();
-    if (ssdCache) {
-      ssdCache->testingDeleteFiles();
-    }
     if (cache_) {
       cache_->shutdown();
+    }
+    executor_->join();
+    auto* ssdCache = cache_->ssdCache();
+    if (ssdCache) {
+      ssdCache->testingDeleteFiles();
     }
   }
 


### PR DESCRIPTION
Currently, SSD cache use atomics to handle shutdown and writeInProgress counter which are used a lock to prevent concurrent writes to a SSD file. It is better to use mutex to ease the implementation and also prevent any write to SSD file if shutdown has been triggered.