### PR TITLE
Fix hashing in approx_distinct to match Presto

### DIFF
--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -2758,7 +2758,7 @@ TEST_P(AllTableWriterTest, columnStatsDataTypes) {
   HashStringAllocator allocator{pool_.get()};
   DenseHll denseHll{
       std::string(distinctCountStatsVector->valueAt(0)).c_str(), &allocator};
-  ASSERT_EQ(denseHll.cardinality(), 1000);
+  ASSERT_EQ(denseHll.cardinality(), 1010);
   const auto maxDataSizeStatsVector =
       result->childAt(nextColumnStatsIndex++)->asFlatVector<int64_t>();
   ASSERT_EQ(maxDataSizeStatsVector->valueAt(0), 7);


### PR DESCRIPTION
Summary:
approx_distinct returns different results from Presto on some inputs. This 
is because approx_distinct uses a hash-based algorithm and the hash 
values got in Velox is different from the hash values got in Presto. Presto 
always passes sizeof(long) as `length` to the hash function for integral 
and floating-point types, while Velox passes sizeof(T) for different input 
types T. This `length` participates the calculation of the hash and hence 
causes different hash values between Velox and Presto. In addition, Presto 
collapse all NaN values to a single canonical NaN, which is also missing in 
Velox. This diff fixes the hashing in Velox to match Presto.

This diff fixes https://github.com/facebookincubator/velox/issues/9761.

Differential Revision: D57232182


