### PR TITLE
Prototype of simple UDAF interface with function-level variables

### DIFF
--- a/velox/exec/Aggregate.cpp
+++ b/velox/exec/Aggregate.cpp
@@ -273,11 +273,12 @@ std::unique_ptr<Aggregate> Aggregate::create(
     const std::string& name,
     core::AggregationNode::Step step,
     const std::vector<TypePtr>& argTypes,
+    const std::vector<VectorPtr>& constantInputs,
     const TypePtr& resultType,
     const core::QueryConfig& config) {
   // Lookup the function in the new registry first.
   if (auto func = getAggregateFunctionEntry(name)) {
-    return func->factory(step, argTypes, resultType, config);
+    return func->factory(step, argTypes, constantInputs, resultType, config);
   }
 
   VELOX_USER_FAIL("Aggregate function not registered: {}", name);

--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -302,6 +302,7 @@ class Aggregate {
       const std::string& name,
       core::AggregationNode::Step step,
       const std::vector<TypePtr>& argTypes,
+      const std::vector<VectorPtr>& constantInputs,
       const TypePtr& resultType,
       const core::QueryConfig& config);
 
@@ -469,6 +470,7 @@ class Aggregate {
 using AggregateFunctionFactory = std::function<std::unique_ptr<Aggregate>(
     core::AggregationNode::Step step,
     const std::vector<TypePtr>& argTypes,
+    const std::vector<VectorPtr>& constantInputs,
     const TypePtr& resultType,
     const core::QueryConfig& config)>;
 

--- a/velox/exec/AggregateInfo.cpp
+++ b/velox/exec/AggregateInfo.cpp
@@ -100,6 +100,7 @@ std::vector<AggregateInfo> toAggregateInfo(
         isPartialOutput(step) ? core::AggregationNode::Step::kPartial
                               : core::AggregationNode::Step::kSingle,
         aggregate.rawInputTypes,
+        info.constantInputs,
         aggResultType,
         operatorCtx.driverCtx()->queryConfig());
 

--- a/velox/exec/AggregateWindow.cpp
+++ b/velox/exec/AggregateWindow.cpp
@@ -45,15 +45,18 @@ class AggregateWindowFunction : public exec::WindowFunction {
     argTypes_.reserve(args.size());
     argIndices_.reserve(args.size());
     argVectors_.reserve(args.size());
+    std::vector<VectorPtr> constants;
     for (const auto& arg : args) {
       argTypes_.push_back(arg.type);
       if (arg.constantValue) {
         argIndices_.push_back(kConstantChannel);
         argVectors_.push_back(arg.constantValue);
+        constants.push_back(arg.constantValue);
       } else {
         VELOX_CHECK(arg.index.has_value());
         argIndices_.push_back(arg.index.value());
         argVectors_.push_back(BaseVector::create(arg.type, 0, pool_));
+        constants.push_back(nullptr);
       }
     }
     // Create an Aggregate function object to do result computation. Window
@@ -63,6 +66,7 @@ class AggregateWindowFunction : public exec::WindowFunction {
         name,
         core::AggregationNode::Step::kSingle,
         argTypes_,
+        constants,
         resultType,
         config);
     aggregate_->setAllocator(stringAllocator_);

--- a/velox/exec/SimpleAggregateAdapterExperiment.h
+++ b/velox/exec/SimpleAggregateAdapterExperiment.h
@@ -1,0 +1,585 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/Aggregate.h"
+#include "velox/expression/VectorReaders.h"
+#include "velox/expression/VectorWriters.h"
+
+namespace facebook::velox::exec {
+
+// The writer type of T used in simple UDAF interface. An instance of
+// out_type allows writing one row into the output vector.
+template <typename T>
+using out_type = typename VectorExec::template resolver<T>::out_type;
+
+// The reader type of T used in simple UDAF interface. An instance of
+// arg_type allows reading one row from the input vector. This is used for UDAFs
+// that have the default null behavior.
+template <typename T>
+using arg_type = typename VectorExec::template resolver<T>::in_type;
+
+// The reader type of T used in simple UDAF interface. An instance of
+// arg_type allows reading one row from the input vector. This is used for UDAFs
+// that have non-default null behavior.
+template <typename T>
+using optional_arg_type = OptionalAccessor<T>;
+
+template <typename FUNC>
+class SimpleAggregateAdapterExperiment : public Aggregate {
+ public:
+  explicit SimpleAggregateAdapterExperiment(
+      core::AggregationNode::Step step,
+      const std::vector<TypePtr>& rawInputTypes,
+      const std::vector<VectorPtr>& constantInputs,
+      const TypePtr& resultType)
+      : Aggregate(std::move(resultType)), fn_{std::make_unique<FUNC>()} {
+    fn_->initialize(step, rawInputTypes, constantInputs, resultType);
+  }
+
+  // Assume most aggregate functions have fixed-size accumulators. Functions
+  // that
+  // have non-fixed-size accumulators should overwrite `is_fixed_size_` in their
+  // accumulator structs.
+  template <typename T, typename = void>
+  struct accumulator_is_fixed_size : std::true_type {};
+
+  template <typename T>
+  struct accumulator_is_fixed_size<T, std::void_t<decltype(T::is_fixed_size_)>>
+      : std::integral_constant<bool, T::is_fixed_size_> {};
+
+  // Assume most aggregate functions have default null behavior, i.e., ignoring
+  // rows that have null values in raw input and intermediate results, and
+  // returning null for groups of no input rows or only null rows.
+  // For example: select sum(col0)
+  //              from (values (1, 10), (2, 20), (3, 30)) as t(col0, col1)
+  //              where col0 > 10; -- NULL
+  // Functions that have non-default null behavior should overwrite
+  // `default_null_behavior_`.
+  // All accumulators are initialized to NULL before the aggregation starts.
+  // However, for functions that have default and non-default null behaviors,
+  // there are a couple of differences in their implementations.
+  // 1. When default_null_behavior_ is true, authors define
+  //     void AccumulatorType::addInput(HashStringAllocator* allocator,
+  //                                    exec::arg_type<T1> arg1, ...)
+  //     void AccumulatorType::combine(HashStringAllocator* allocator,
+  //                                   exec::arg_type<IntermediateType> arg)
+  // These functions only receive non-null input values. Input rows that contain
+  // at least one NULL argument are ignored. The accumulator of a group is set
+  // to non-null if at least one input is added to this group through addInput()
+  // or combine(). Similarly, authors define
+  //     bool AccumulatorType::writeIntermediateResult(
+  //         exec::out_type<IntermediateType>&out)
+  //     bool AccumulatorType::writeFinalResult(exec::out_type<OutputType>&out)
+  // These functions are only called on groups of non-null accumulators. Groups
+  // that have NULL accumulators automatically become NULL in the result vector.
+  // These functions also return a bool indicating whether the current group
+  // should be a NULL in the result vector.
+  //
+  // 2. When default_null_behavior_ is false, authors define
+  //     bool AccumulatorType::addInput(HashStringAllocator* allocator,
+  //                                    exec::optional_arg_type<T1> arg1, ...)
+  //     bool AccumulatorType::combine(
+  //         HashStringAllocator* allocator,
+  //         exec::optional_arg_type<IntermediateType> arg)
+  // These functions receive both non-null and null inputs. They return a bool
+  // indicating whether to set the current group's accumulator to non-null. If
+  // the accumulator of a group is already non-NULL, returning false from
+  // addInput() or combine() doesn't change this group's nullness. Authors also
+  // define
+  //     bool AccumulatorType::writeIntermediateResult(
+  //         bool nonNullGroup,
+  //         exec::out_type<IntermediateType>& out)
+  //     bool AccumulatorType::writeFinalResult(
+  //         bool nonNullGroup,
+  //         exec::out_type<OutputType>& out)
+  // These functions are called on groups of both non-null and null
+  // accumulators. These functions also return a bool indicating whether the
+  // current group should be a NULL in the result vector.
+  template <typename T, typename = void>
+  struct aggregate_default_null_behavior : std::true_type {};
+
+  template <typename T>
+  struct aggregate_default_null_behavior<
+      T,
+      std::void_t<decltype(T::default_null_behavior_)>>
+      : std::integral_constant<bool, T::default_null_behavior_> {};
+
+  // Assume most aggregate functions do not use external memory. Functions that
+  // use external memory should overwrite `use_external_memory_` in their
+  // accumulator structs.
+  template <typename T, typename = void>
+  struct accumulator_use_external_memory : std::false_type {};
+
+  template <typename T>
+  struct accumulator_use_external_memory<
+      T,
+      std::void_t<decltype(T::use_external_memory_)>>
+      : std::integral_constant<bool, T::use_external_memory_> {};
+
+  // Whether the accumulator type defines its destroy() method or not. If it is
+  // defined, we call the accumulator's destroy() in
+  // SimpleAggregateAdapter::destroy().
+  template <typename T, typename = void>
+  struct accumulator_custom_destroy : std::false_type {};
+
+  template <typename T>
+  struct accumulator_custom_destroy<T, std::void_t<decltype(&T::destroy)>>
+      : std::true_type {};
+
+  // Whether the function defines its toIntermediate() method or not. If it is
+  // defined, SimpleAggregateAdapter::supportToIntermediate() returns true.
+  // Otherwise, SimpleAggregateAdapter::supportToIntermediate() returns false
+  // and SimpleAggregateAdapter::toIntermediate() is empty.
+  template <typename T, typename = void>
+  struct support_to_intermediate : std::false_type {};
+
+  template <typename T>
+  struct support_to_intermediate<T, std::void_t<decltype(&T::toIntermediate)>>
+      : std::true_type {};
+
+  // Whether the accumulator requires aligned access. If it is defined,
+  // SimpleAggregateAdapter::accumulatorAlignmentSize() returns
+  // alignof(typename FUNC::AccumulatorType).
+  // Otherwise, SimpleAggregateAdapter::accumulatorAlignmentSize() returns
+  // Aggregate::accumulatorAlignmentSize(), with a default value of 1.
+  template <typename T, typename = void>
+  struct accumulator_is_aligned : std::false_type {};
+
+  template <typename T>
+  struct accumulator_is_aligned<T, std::void_t<decltype(T::is_aligned_)>>
+      : std::integral_constant<bool, T::is_aligned_> {};
+
+  static constexpr bool aggregate_default_null_behavior_ =
+      aggregate_default_null_behavior<FUNC>::value;
+
+  static constexpr bool accumulator_is_fixed_size_ =
+      accumulator_is_fixed_size<typename FUNC::AccumulatorType>::value;
+
+  static constexpr bool accumulator_use_external_memory_ =
+      accumulator_use_external_memory<typename FUNC::AccumulatorType>::value;
+
+  static constexpr bool accumulator_custom_destroy_ =
+      accumulator_custom_destroy<typename FUNC::AccumulatorType>::value;
+
+  static constexpr bool support_to_intermediate_ =
+      support_to_intermediate<FUNC>::value;
+
+  static constexpr bool accumulator_is_aligned_ =
+      accumulator_is_aligned<typename FUNC::AccumulatorType>::value;
+
+  bool isFixedSize() const override {
+    return accumulator_is_fixed_size_;
+  }
+
+  bool accumulatorUsesExternalMemory() const override {
+    return accumulator_use_external_memory_;
+  }
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return sizeof(typename FUNC::AccumulatorType);
+  }
+
+  int32_t accumulatorAlignmentSize() const override {
+    if constexpr (accumulator_is_aligned_) {
+      return alignof(typename FUNC::AccumulatorType);
+    }
+    return Aggregate::accumulatorAlignmentSize();
+  }
+
+  // Add raw input to accumulators. If the simple aggregation function has
+  // default null behavior, input rows that has nulls are skipped. Otherwise,
+  // the accumulator type's addInput() method handles null inputs.
+  void addRawInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    if (inputDecoded_.size() < args.size()) {
+      inputDecoded_.resize(args.size());
+    }
+
+    for (column_index_t i = 0; i < args.size(); ++i) {
+      inputDecoded_[i].decode(*args[i], rows);
+    }
+
+    addRawInputImpl(
+        groups, rows, std::make_index_sequence<FUNC::InputType::size_>{});
+  }
+
+  // Similar to addRawInput, but add inputs to one single accumulator.
+  void addSingleGroupRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    if (inputDecoded_.size() < args.size()) {
+      inputDecoded_.resize(args.size());
+    }
+
+    for (column_index_t i = 0; i < args.size(); ++i) {
+      inputDecoded_[i].decode(*args[i], rows);
+    }
+
+    addSingleGroupRawInputImpl(
+        group, rows, std::make_index_sequence<FUNC::InputType::size_>{});
+  }
+
+  bool supportsToIntermediate() const override {
+    return support_to_intermediate_;
+  }
+
+  void toIntermediate(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      VectorPtr& result) const override {
+    if constexpr (support_to_intermediate_) {
+      std::vector<DecodedVector> inputDecoded{args.size()};
+      for (column_index_t i = 0; i < args.size(); ++i) {
+        inputDecoded[i].decode(*args[i], rows);
+      }
+
+      toIntermediateImpl(
+          inputDecoded,
+          rows,
+          result,
+          std::make_index_sequence<FUNC::InputType::size_>{});
+    } else {
+      VELOX_UNREACHABLE(
+          "toIntermediate should only be called when support_to_intermediate_ is true.");
+    }
+  }
+
+  // Add intermediate results to accumulators. If the simple aggregation
+  // function has default null behavior, intermediate result rows that has nulls
+  // are skipped. Otherwise, the accumulator type's combine() method handles
+  // nulls.
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    intermediateDecoded_.decode(*args[0], rows);
+
+    addIntermediateResultsImpl(groups, rows);
+  }
+
+  // Similar to addIntermediateResults, but add intermediate results to one
+  // single accumulator.
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /* mayPushdown */) override {
+    intermediateDecoded_.decode(*args[0], rows);
+
+    addSingleGroupIntermediateResultsImpl(group, rows);
+  }
+
+  // Extract intermediate results to a vector.
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    VectorWriter<typename FUNC::IntermediateType> writer;
+    auto vector = (*result)
+                      ->as<typename TypeToFlatVector<
+                          typename FUNC::IntermediateType>::type>();
+    vector->resize(numGroups);
+    writer.init(*vector);
+
+    for (auto i = 0; i < numGroups; ++i) {
+      writer.setOffset(i);
+      auto group = value<typename FUNC::AccumulatorType>(groups[i]);
+
+      if constexpr (aggregate_default_null_behavior_) {
+        if (isNull(groups[i])) {
+          writer.commitNull();
+        } else {
+          bool nonNull = group->writeIntermediateResult(writer.current());
+          writer.commit(nonNull);
+        }
+      } else {
+        bool nonNull = group->writeIntermediateResult(
+            !isNull(groups[i]), writer.current());
+        writer.commit(nonNull);
+      }
+    }
+    writer.finish();
+  }
+
+  // Extract final results to a vector.
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    auto flatResult =
+        (*result)
+            ->as<typename TypeToFlatVector<typename FUNC::OutputType>::type>();
+    flatResult->resize(numGroups);
+
+    VectorWriter<typename FUNC::OutputType> writer;
+    writer.init(*flatResult);
+
+    for (auto i = 0; i < numGroups; ++i) {
+      writer.setOffset(i);
+      auto group = value<typename FUNC::AccumulatorType>(groups[i]);
+
+      if constexpr (aggregate_default_null_behavior_) {
+        if (isNull(groups[i])) {
+          writer.commitNull();
+        } else {
+          bool nonNull = group->writeFinalResult(writer.current());
+          writer.commit(nonNull);
+        }
+      } else {
+        bool nonNull =
+            group->writeFinalResult(!isNull(groups[i]), writer.current());
+        writer.commit(nonNull);
+      }
+    }
+    writer.finish();
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      new (groups[i] + offset_)
+          typename FUNC::AccumulatorType(allocator_, fn_.get());
+    }
+  }
+
+  void destroyInternal(folly::Range<char**> groups) override {
+    if constexpr (accumulator_custom_destroy_) {
+      for (auto group : groups) {
+        auto accumulator = value<typename FUNC::AccumulatorType>(group);
+        if (isInitialized(group) && !isNull(group)) {
+          accumulator->destroy(allocator_);
+        }
+      }
+    } else {
+      destroyAccumulators<typename FUNC::AccumulatorType>(groups);
+    }
+  }
+
+ private:
+  template <std::size_t... Is>
+  void addRawInputImpl(
+      char** groups,
+      const SelectivityVector& rows,
+      std::index_sequence<Is...>) {
+    std::tuple<VectorReader<typename FUNC::InputType::template type_at<Is>>...>
+        readers{&inputDecoded_[Is]...};
+
+    if constexpr (aggregate_default_null_behavior_) {
+      rows.applyToSelected([&](auto row) {
+        // If any input is null, we ignore the whole row.
+        if (!(std::get<Is>(readers).isSet(row) && ...)) {
+          return;
+        }
+        std::optional<RowSizeTracker<char, uint32_t>> tracker;
+        if constexpr (!accumulator_is_fixed_size_) {
+          tracker.emplace(groups[row][rowSizeOffset_], *allocator_);
+        }
+        auto group = value<typename FUNC::AccumulatorType>(groups[row]);
+        group->addInput(allocator_, std::get<Is>(readers)[row]...);
+        clearNull(groups[row]);
+      });
+    } else {
+      rows.applyToSelected([&](auto row) {
+        std::optional<RowSizeTracker<char, uint32_t>> tracker;
+        if constexpr (!accumulator_is_fixed_size_) {
+          tracker.emplace(groups[row][rowSizeOffset_], *allocator_);
+        }
+        auto group = value<typename FUNC::AccumulatorType>(groups[row]);
+        bool nonNull = group->addInput(
+            allocator_,
+            OptionalAccessor<typename FUNC::InputType::template type_at<Is>>{
+                &std::get<Is>(readers), (int64_t)row}...);
+        if (nonNull) {
+          clearNull(groups[row]);
+        }
+      });
+    }
+  }
+
+  template <std::size_t... Is>
+  void addSingleGroupRawInputImpl(
+      char* group,
+      const SelectivityVector& rows,
+      std::index_sequence<Is...>) {
+    std::tuple<VectorReader<typename FUNC::InputType::template type_at<Is>>...>
+        readers{&inputDecoded_[Is]...};
+    auto accumulator = value<typename FUNC::AccumulatorType>(group);
+
+    if constexpr (aggregate_default_null_behavior_) {
+      rows.applyToSelected([&](auto row) {
+        // If any input is null, we ignore the whole row.
+        if (!(std::get<Is>(readers).isSet(row) && ...)) {
+          return;
+        }
+        std::optional<RowSizeTracker<char, uint32_t>> tracker;
+        if constexpr (!accumulator_is_fixed_size_) {
+          tracker.emplace(group[rowSizeOffset_], *allocator_);
+        }
+        accumulator->addInput(allocator_, std::get<Is>(readers)[row]...);
+        clearNull(group);
+      });
+    } else {
+      rows.applyToSelected([&](auto row) {
+        std::optional<RowSizeTracker<char, uint32_t>> tracker;
+        if constexpr (!accumulator_is_fixed_size_) {
+          tracker.emplace(group[rowSizeOffset_], *allocator_);
+        }
+        bool nonNull = accumulator->addInput(
+            allocator_,
+            OptionalAccessor<typename FUNC::InputType::template type_at<Is>>{
+                &std::get<Is>(readers), (int64_t)row}...);
+        if (nonNull) {
+          clearNull(group);
+        }
+      });
+    }
+  }
+
+  template <std::size_t... Is>
+  void toIntermediateImpl(
+      const std::vector<DecodedVector>& inputDecoded,
+      const SelectivityVector& rows,
+      VectorPtr& result,
+      std::index_sequence<Is...>) const {
+    std::tuple<VectorReader<typename FUNC::InputType::template type_at<Is>>...>
+        readers{&inputDecoded[Is]...};
+
+    VELOX_CHECK(result);
+    result->ensureWritable(rows);
+    auto* rawNulls = result->mutableRawNulls();
+    bits::fillBits(rawNulls, 0, result->size(), bits::kNull);
+
+    constexpr auto intermediateKind =
+        SimpleTypeTrait<typename FUNC::IntermediateType>::typeKind;
+    auto* flatResult =
+        result->as<typename KindToFlatVector<intermediateKind>::type>();
+    exec::VectorWriter<typename FUNC::IntermediateType> writer;
+    writer.init(*flatResult);
+
+    if constexpr (aggregate_default_null_behavior_) {
+      rows.applyToSelected([&](auto row) {
+        writer.setOffset(row);
+        // If any input is null, we ignore the whole row.
+        if (!(std::get<Is>(readers).isSet(row) && ...)) {
+          writer.commitNull();
+          return;
+        }
+        bool nonNull = FUNC::toIntermediate(
+            writer.current(), std::get<Is>(readers)[row]...);
+        writer.commit(nonNull);
+      });
+      writer.finish();
+    } else {
+      rows.applyToSelected([&](auto row) {
+        writer.setOffset(row);
+        bool nonNull = FUNC::toIntermediate(
+            writer.current(),
+            OptionalAccessor<typename FUNC::InputType::template type_at<Is>>{
+                &std::get<Is>(readers), (int64_t)row}...);
+        writer.commit(nonNull);
+      });
+      writer.finish();
+    }
+  }
+
+  // Implementation of addIntermediateResults when the intermediate type is not
+  // a Row type.
+  void addIntermediateResultsImpl(
+      char** groups,
+      const SelectivityVector& rows) {
+    VectorReader<typename FUNC::IntermediateType> reader(&intermediateDecoded_);
+
+    if constexpr (aggregate_default_null_behavior_) {
+      rows.applyToSelected([&](auto row) {
+        if (!reader.isSet(row)) {
+          return;
+        }
+        std::optional<RowSizeTracker<char, uint32_t>> tracker;
+        if constexpr (!accumulator_is_fixed_size_) {
+          tracker.emplace(groups[row][rowSizeOffset_], *allocator_);
+        }
+        auto group = value<typename FUNC::AccumulatorType>(groups[row]);
+        group->combine(allocator_, reader[row]);
+        clearNull(groups[row]);
+      });
+    } else {
+      rows.applyToSelected([&](auto row) {
+        std::optional<RowSizeTracker<char, uint32_t>> tracker;
+        if constexpr (!accumulator_is_fixed_size_) {
+          tracker.emplace(groups[row][rowSizeOffset_], *allocator_);
+        }
+        auto group = value<typename FUNC::AccumulatorType>(groups[row]);
+        bool nonNull = group->combine(
+            allocator_,
+            OptionalAccessor<typename FUNC::IntermediateType>{
+                &reader, (int64_t)row});
+        if (nonNull) {
+          clearNull(groups[row]);
+        }
+      });
+    }
+  }
+
+  // Implementation of addSingleGroupIntermediateResults when the intermediate
+  // type is not a Row type.
+  void addSingleGroupIntermediateResultsImpl(
+      char* group,
+      const SelectivityVector& rows) {
+    VectorReader<typename FUNC::IntermediateType> reader(&intermediateDecoded_);
+    auto accumulator = value<typename FUNC::AccumulatorType>(group);
+
+    if constexpr (aggregate_default_null_behavior_) {
+      rows.applyToSelected([&](auto row) {
+        if (!reader.isSet(row)) {
+          return;
+        }
+        std::optional<RowSizeTracker<char, uint32_t>> tracker;
+        if constexpr (!accumulator_is_fixed_size_) {
+          tracker.emplace(group[rowSizeOffset_], *allocator_);
+        }
+        accumulator->combine(allocator_, reader[row]);
+        clearNull(group);
+      });
+    } else {
+      rows.applyToSelected([&](auto row) {
+        std::optional<RowSizeTracker<char, uint32_t>> tracker;
+        if constexpr (!accumulator_is_fixed_size_) {
+          tracker.emplace(group[rowSizeOffset_], *allocator_);
+        }
+        bool nonNull = accumulator->combine(
+            allocator_,
+            OptionalAccessor<typename FUNC::IntermediateType>{
+                &reader, (int64_t)row});
+        if (nonNull) {
+          clearNull(group);
+        }
+      });
+    }
+  }
+
+  std::vector<DecodedVector> inputDecoded_;
+  DecodedVector intermediateDecoded_;
+
+  std::unique_ptr<FUNC> fn_;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -241,7 +241,8 @@ target_link_libraries(
   gtest_main)
 
 add_library(velox_simple_aggregate SimpleAverageAggregate.cpp
-                                   SimpleArrayAggAggregate.cpp)
+                                   SimpleArrayAggAggregate.cpp
+                                   SimpleSumAggregate.cpp)
 
 target_link_libraries(velox_simple_aggregate velox_exec velox_expression
                       velox_expression_functions velox_aggregates)
@@ -251,6 +252,15 @@ add_executable(velox_simple_aggregate_test SimpleAggregateAdapterTest.cpp
 
 target_link_libraries(
   velox_simple_aggregate_test velox_simple_aggregate velox_exec
+  velox_functions_aggregates_test_lib gtest gtest_main)
+
+add_executable(
+  velox_simple_aggregate_experiment_test
+  SimpleAggregateAdapterExperimentTest.cpp
+  Main.cpp)
+
+target_link_libraries(
+  velox_simple_aggregate_experiment_test velox_simple_aggregate velox_exec
   velox_functions_aggregates_test_lib gtest gtest_main)
 
 add_library(velox_spiller_join_benchmark_base JoinSpillInputBenchmarkBase.cpp

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -634,6 +634,7 @@ TEST_P(HashTableTest, clear) {
       "sum",
       core::AggregationNode::Step::kPartial,
       std::vector<TypePtr>{BIGINT()},
+      std::vector<VectorPtr>{nullptr},
       BIGINT(),
       config);
 

--- a/velox/exec/tests/SimpleAggregateAdapterExperimentTest.cpp
+++ b/velox/exec/tests/SimpleAggregateAdapterExperimentTest.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/tests/SimpleAggregateFunctionsRegistration.h"
+#include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+using facebook::velox::functions::aggregate::test::AggregationTestBase;
+
+namespace facebook::velox::aggregate::test {
+namespace {
+
+class SimpleSumAggregationTest : public AggregationTestBase {
+ protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+    allowInputShuffle();
+
+    registerSimpleSumAggregate("simple_sum");
+  }
+};
+
+TEST_F(SimpleSumAggregationTest, basic) {
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3, 4}),
+      makeFlatVector<bool>({true, true, false, false}),
+  });
+  auto expected = makeRowVector(
+      {makeFlatVector<bool>({false, true}), makeFlatVector<int64_t>({-7, -3})});
+  testAggregations({data}, {"c1"}, {"simple_sum(c0)"}, {expected});
+}
+
+} // namespace
+} // namespace facebook::velox::aggregate::test

--- a/velox/exec/tests/SimpleAggregateFunctionsRegistration.h
+++ b/velox/exec/tests/SimpleAggregateFunctionsRegistration.h
@@ -28,4 +28,7 @@ exec::AggregateRegistrationResult registerSimpleAverageAggregate(
 exec::AggregateRegistrationResult registerSimpleArrayAggAggregate(
     const std::string& name);
 
+exec::AggregateRegistrationResult registerSimpleSumAggregate(
+    const std::string& name);
+
 } // namespace facebook::velox::aggregate

--- a/velox/exec/tests/SimpleArrayAggAggregate.cpp
+++ b/velox/exec/tests/SimpleArrayAggAggregate.cpp
@@ -129,6 +129,7 @@ exec::AggregateRegistrationResult registerSimpleArrayAggAggregate(
       [name](
           core::AggregationNode::Step /*step*/,
           const std::vector<TypePtr>& argTypes,
+          const std::vector<VectorPtr>& constantInputs,
           const TypePtr& resultType,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {

--- a/velox/exec/tests/SimpleAverageAggregate.cpp
+++ b/velox/exec/tests/SimpleAverageAggregate.cpp
@@ -119,6 +119,7 @@ exec::AggregateRegistrationResult registerSimpleAverageAggregate(
       [name](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
+          const std::vector<VectorPtr>& constantInputs,
           const TypePtr& resultType,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {

--- a/velox/exec/tests/SimpleSumAggregate.cpp
+++ b/velox/exec/tests/SimpleSumAggregate.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/SimpleAggregateAdapterExperiment.h"
+#include "velox/expression/FunctionSignature.h"
+#include "velox/expression/VectorWriters.h"
+
+using namespace facebook::velox::exec;
+
+namespace facebook::velox::aggregate {
+
+namespace {
+
+// Returns negative sum of input values.
+class SumAggregate {
+ public:
+  // Type(s) of input vector(s) wrapped in Row.
+  using InputType = Row<int64_t>;
+
+  // Type of intermediate result vector wrapped in Row.
+  using IntermediateType = int64_t;
+
+  // Type of output vector.
+  using OutputType = int64_t;
+
+  bool flag_{false};
+
+  void initialize(
+      core::AggregationNode::Step step,
+      const std::vector<TypePtr>& rawInputTypes,
+      const std::vector<VectorPtr>& constantInputs,
+      const TypePtr& resultType) {
+    flag_ = true;
+  }
+
+  struct AccumulatorType {
+    int64_t sum_;
+    SumAggregate* fn_;
+
+    AccumulatorType() = delete;
+
+    // Constructor used in initializeNewGroups().
+    explicit AccumulatorType(
+        HashStringAllocator* /*allocator*/,
+        SumAggregate* fn) {
+      sum_ = 0;
+      fn_ = fn;
+    }
+
+    void addInput(HashStringAllocator* /*allocator*/, int64_t data) {
+      sum_ += data;
+    }
+
+    void combine(HashStringAllocator* /*allocator*/, int64_t other) {
+      sum_ += other;
+    }
+
+    bool writeFinalResult(int64_t& out) {
+      out = fn_->flag_ ? -sum_ : sum_;
+      return true;
+    }
+
+    bool writeIntermediateResult(int64_t& out) {
+      out = sum_;
+      return true;
+    }
+  };
+};
+
+} // namespace
+
+exec::AggregateRegistrationResult registerSimpleSumAggregate(
+    const std::string& name) {
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
+  signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                           .returnType("bigint")
+                           .intermediateType("bigint")
+                           .argumentType("bigint")
+                           .build());
+
+  return exec::registerAggregateFunction(
+      name,
+      std::move(signatures),
+      [name](
+          core::AggregationNode::Step step,
+          const std::vector<TypePtr>& rawInputTypes,
+          const std::vector<VectorPtr>& constantInputs,
+          const TypePtr& resultType,
+          const core::QueryConfig& /*config*/)
+          -> std::unique_ptr<exec::Aggregate> {
+        return std::make_unique<SimpleAggregateAdapterExperiment<SumAggregate>>(
+            step, rawInputTypes, constantInputs, resultType);
+      },
+      true,
+      true);
+}
+
+} // namespace facebook::velox::aggregate

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -26,7 +26,6 @@ add_library(
   OperatorTestBase.cpp
   PlanBuilder.cpp
   QueryAssertions.cpp
-  SumNonPODAggregate.cpp
   TpchQueryBuilder.cpp
   VectorTestUtil.cpp
   PortUtil.cpp)

--- a/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
@@ -1192,10 +1192,13 @@ std::unique_ptr<exec::Aggregate> createAggregateFunction(
     const std::unordered_map<std::string, std::string>& config) {
   auto [intermediateType, finalType] = getResultTypes(functionName, inputTypes);
   core::QueryConfig queryConfig({config});
+  // TODO: get the correct constantInputs.
+  std::vector<VectorPtr> constantInputs{inputTypes.size(), nullptr};
   auto func = exec::Aggregate::create(
       functionName,
       core::AggregationNode::Step::kSingle,
       inputTypes,
+      constantInputs,
       finalType,
       queryConfig);
   func->setAllocator(&allocator);

--- a/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
@@ -258,6 +258,7 @@ void registerArrayAggAggregate(
       [name](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
+          const std::vector<VectorPtr>& constantInputs,
           const TypePtr& resultType,
           const core::QueryConfig& config) -> std::unique_ptr<exec::Aggregate> {
         VELOX_CHECK_EQ(

--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -14,38 +14,8 @@
 
 add_library(
   velox_aggregates
-  ApproxDistinctAggregate.cpp
-  ApproxMostFrequentAggregate.cpp
-  ApproxPercentileAggregate.cpp
-  ArbitraryAggregate.cpp
   ArrayAggAggregate.cpp
-  AverageAggregate.cpp
-  BitwiseAggregates.cpp
-  BitwiseXorAggregate.cpp
-  BoolAggregates.cpp
-  CentralMomentsAggregates.cpp
-  Compare.cpp
-  CountAggregate.cpp
-  CountIfAggregate.cpp
-  CovarianceAggregates.cpp
-  ChecksumAggregate.cpp
-  EntropyAggregates.cpp
-  GeometricMeanAggregate.cpp
-  HistogramAggregate.cpp
-  MapAggAggregate.cpp
-  MapUnionAggregate.cpp
-  MapUnionSumAggregate.cpp
-  MaxSizeForStatsAggregate.cpp
-  MinMaxAggregates.cpp
-  MinMaxByAggregates.cpp
-  MultiMapAggAggregate.cpp
-  PrestoHasher.cpp
-  ReduceAgg.cpp
-  RegisterAggregateFunctions.cpp
-  SetAggregates.cpp
-  SumAggregate.cpp
-  SumDataSizeForStatsAggregate.cpp
-  VarianceAggregates.cpp)
+  RegisterAggregateFunctions.cpp)
 
 target_link_libraries(
   velox_aggregates

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -18,126 +18,7 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-extern void registerApproxMostFrequentAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerApproxPercentileAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerArbitraryAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
 extern void registerArrayAggAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerAverageAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerBitwiseXorAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool onlyPrestoSignatures,
-    bool overwrite);
-extern void registerChecksumAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerCountAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerCountIfAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerEntropyAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerGeometricMeanAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerHistogramAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerMapAggAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerMapUnionAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerMapUnionSumAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerMaxDataSizeForStatsAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerMultiMapAggAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerSumDataSizeForStatsAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerReduceAgg(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerSetAggAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerSetUnionAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-
-extern void registerApproxDistinctAggregates(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerBitwiseAggregates(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool onlyPrestoSignatures,
-    bool overwrite);
-extern void registerBoolAggregates(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerCentralMomentsAggregates(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerCovarianceAggregates(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerMinMaxAggregates(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerMinMaxByAggregates(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerSumAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerVarianceAggregates(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
@@ -147,47 +28,11 @@ void registerAllAggregateFunctions(
     bool withCompanionFunctions,
     bool onlyPrestoSignatures,
     bool overwrite) {
-  registerApproxDistinctAggregates(prefix, withCompanionFunctions, overwrite);
-  registerApproxMostFrequentAggregate(
-      prefix, withCompanionFunctions, overwrite);
-  registerApproxPercentileAggregate(prefix, withCompanionFunctions, overwrite);
-  registerArbitraryAggregate(prefix, withCompanionFunctions, overwrite);
   registerArrayAggAggregate(prefix, withCompanionFunctions, overwrite);
-  registerAverageAggregate(prefix, withCompanionFunctions, overwrite);
-  registerBitwiseAggregates(
-      prefix, withCompanionFunctions, onlyPrestoSignatures, overwrite);
-  registerBitwiseXorAggregate(
-      prefix, withCompanionFunctions, onlyPrestoSignatures, overwrite);
-  registerBoolAggregates(prefix, withCompanionFunctions, overwrite);
-  registerCentralMomentsAggregates(prefix, withCompanionFunctions, overwrite);
-  registerChecksumAggregate(prefix, withCompanionFunctions, overwrite);
-  registerCountAggregate(prefix, withCompanionFunctions, overwrite);
-  registerCountIfAggregate(prefix, withCompanionFunctions, overwrite);
-  registerCovarianceAggregates(prefix, withCompanionFunctions, overwrite);
-  registerEntropyAggregate(prefix, withCompanionFunctions, overwrite);
-  registerGeometricMeanAggregate(prefix, withCompanionFunctions, overwrite);
-  registerHistogramAggregate(prefix, withCompanionFunctions, overwrite);
-  registerMapAggAggregate(prefix, withCompanionFunctions, overwrite);
-  registerMapUnionAggregate(prefix, withCompanionFunctions, overwrite);
-  registerMapUnionSumAggregate(prefix, withCompanionFunctions, overwrite);
-  registerMaxDataSizeForStatsAggregate(
-      prefix, withCompanionFunctions, overwrite);
-  registerMultiMapAggAggregate(prefix, withCompanionFunctions, overwrite);
-  registerSumDataSizeForStatsAggregate(
-      prefix, withCompanionFunctions, overwrite);
-  registerMinMaxAggregates(prefix, withCompanionFunctions, overwrite);
-  registerMinMaxByAggregates(prefix, withCompanionFunctions, overwrite);
-  registerReduceAgg(prefix, withCompanionFunctions, overwrite);
-  registerSetAggAggregate(prefix, withCompanionFunctions, overwrite);
-  registerSetUnionAggregate(prefix, withCompanionFunctions, overwrite);
-  registerSumAggregate(prefix, withCompanionFunctions, overwrite);
-  registerVarianceAggregates(prefix, withCompanionFunctions, overwrite);
 }
 
-extern void registerCountDistinctAggregate(const std::string& prefix);
-
 void registerInternalAggregateFunctions(const std::string& prefix) {
-  registerCountDistinctAggregate(prefix);
+  // registerCountDistinctAggregate(prefix);
 }
 
 } // namespace facebook::velox::aggregate::prestosql


### PR DESCRIPTION
Summary:
DO NOT REVIEW. This is a prototype.

The second prototype of simple UDAF interface with function-level 
variables.  Function-level variables are data members of the UDAF class 
that are assigned at function creation time via a user-defined initialize() 
method.

Some files are deleted from the CMakeList files just to make 
velox_simple_aggregate_experiment_test compilable for this prototype.  
When making a formal change, those files need to be updated.

Differential Revision: D57241734


