### PR TITLE
Remove unused-but-set variables in velox/common/caching/tests/SsdFileTest.cpp +16

### DIFF
--- a/velox/common/caching/tests/SsdFileTest.cpp
+++ b/velox/common/caching/tests/SsdFileTest.cpp
@@ -287,7 +287,6 @@ TEST_F(SsdFileTest, writeAndRead) {
 
   // We check howmany entries are found. The earliest writes will have been
   // evicted. We read back the found entries and check their contents.
-  int32_t numFound = 0;
   for (auto& entry : allEntries) {
     std::vector<CachePin> pins;
 
@@ -301,7 +300,6 @@ TEST_F(SsdFileTest, writeAndRead) {
       ssdPins.push_back(
           ssdFile_->find(RawFileCacheKey{fileName_.id(), entry.key.offset}));
       if (!ssdPins.back().empty()) {
-        ++numFound;
         ssdFile_->load(ssdPins, pins);
         checkContents(pins[0].entry()->data(), pins[0].entry()->size());
       }

--- a/velox/common/memory/MallocAllocator.cpp
+++ b/velox/common/memory/MallocAllocator.cpp
@@ -138,11 +138,6 @@ bool MallocAllocator::allocateContiguousImpl(
   } else {
     VELOX_CHECK_LE(numPages, maxPages);
   }
-  MachinePageCount numCollateralPages = 0;
-  if (collateral != nullptr) {
-    numCollateralPages =
-        freeNonContiguous(*collateral) / AllocationTraits::kPageSize;
-  }
   auto numContiguousCollateralPages = allocation.numPages();
   if (numContiguousCollateralPages > 0) {
     useHugePages(allocation, false);

--- a/velox/common/memory/tests/ByteStreamTest.cpp
+++ b/velox/common/memory/tests/ByteStreamTest.cpp
@@ -101,12 +101,10 @@ TEST_F(ByteStreamTest, inputStream) {
   uint8_t* const kFakeBuffer = reinterpret_cast<uint8_t*>(this);
   std::vector<ByteRange> byteRanges;
   size_t totalBytes{0};
-  size_t lastRangeEnd;
   for (int32_t i = 0; i < 32; ++i) {
     byteRanges.push_back(ByteRange{kFakeBuffer, 4096 + i, 0});
     totalBytes += 4096 + i;
   }
-  lastRangeEnd = byteRanges.back().size;
   ByteInputStream byteStream(std::move(byteRanges));
   ASSERT_EQ(byteStream.size(), totalBytes);
 }

--- a/velox/dwio/common/tests/utils/BatchMaker.cpp
+++ b/velox/dwio/common/tests/utils/BatchMaker.cpp
@@ -51,14 +51,11 @@ VectorPtr createScalar(
   BufferPtr nulls = allocateNulls(size, &pool);
   auto* nullsPtr = nulls->asMutable<uint64_t>();
 
-  size_t nullCount = 0;
   for (size_t i = 0; i < size; ++i) {
     auto notNull = isNotNull(gen, i, isNullAt);
     bits::setNull(nullsPtr, i, !notNull);
     if (notNull) {
       valuesPtr[i] = val();
-    } else {
-      nullCount++;
     }
   }
 

--- a/velox/dwio/common/tests/utils/MapBuilder.h
+++ b/velox/dwio/common/tests/utils/MapBuilder.h
@@ -56,7 +56,6 @@ class MapBuilder {
 
     BufferPtr valueNulls = allocateNulls(items, &pool);
     auto* valueNullsPtr = valueNulls->asMutable<uint64_t>();
-    size_t valueNullCount = 0;
 
     auto i = 0;
     auto offset = 0;
@@ -74,7 +73,6 @@ class MapBuilder {
             valuesPtr[offset] = *pair.second;
             bits::clearNull(valueNullsPtr, offset);
           } else {
-            valueNullCount++;
             bits::setNull(valueNullsPtr, offset);
           }
           ++offset;

--- a/velox/dwio/dwrf/test/TestDecompression.cpp
+++ b/velox/dwio/dwrf/test/TestDecompression.cpp
@@ -1154,9 +1154,6 @@ TEST_F(TestSeek, uncompressedLarge) {
     EXPECT_TRUE(false) << "Address past last header";
     return 0;
   };
-  // Start and size of last Next as offsets to content (no headers).
-  int32_t lastReadStart = 0;
-  int32_t lastReadSize = 0;
 
   for (auto& pair : ranges) {
     uint64_t target = pair.first;
@@ -1170,8 +1167,6 @@ TEST_F(TestSeek, uncompressedLarge) {
       EXPECT_EQ(result, addressForOffset(target + readSize));
       EXPECT_EQ(
           size, readSizeForAddress(reinterpret_cast<const char*>(result)));
-      lastReadStart = target + readSize;
-      lastReadSize = size;
       readSize += size;
     } while (readSize < targetSize);
   }

--- a/velox/dwio/dwrf/test/TestStatisticsBuilderUtils.cpp
+++ b/velox/dwio/dwrf/test/TestStatisticsBuilderUtils.cpp
@@ -280,10 +280,8 @@ TEST_F(TestStatisticsBuilderUtils, addBinaryValues) {
 
   std::array<char, 10> data;
   std::memset(data.data(), 'a', 10);
-  size_t total = 0;
   for (size_t i = 0; i < size; ++i) {
     valuesPtr[i] = StringView(data.data(), i + 1);
-    total += (i + 1);
   }
 
   {

--- a/velox/dwio/dwrf/test/TestStripeStream.cpp
+++ b/velox/dwio/dwrf/test/TestStripeStream.cpp
@@ -69,7 +69,6 @@ void enqueueReads(
   auto& metadataCache = readerBase.getMetadataCache();
   uint64_t offset = stripeStart;
   uint64_t length = 0;
-  uint32_t regions = 0;
   for (const auto& stream : footer.streams()) {
     length = stream.length();
     // If index cache is available, there is no need to read it
@@ -81,7 +80,6 @@ void enqueueReads(
         selector.shouldReadStream(stream.node(), stream.sequence()) &&
         !inMetaCache) {
       input.enqueue({offset, length});
-      regions++;
     }
     offset += length;
   }

--- a/velox/dwio/parquet/reader/ParquetTypeWithId.cpp
+++ b/velox/dwio/parquet/reader/ParquetTypeWithId.cpp
@@ -103,12 +103,8 @@ LevelMode ParquetTypeWithId::makeLevelInfo(LevelInfo& info) const {
   bool isMap = type()->kind() == TypeKind::MAP;
   bool hasList = false;
   if (isStruct) {
-    bool isAllLists = true;
     for (auto i = 0; i < getChildren().size(); ++i) {
       auto& child = parquetChildAt(i);
-      if (child.type()->kind() != TypeKind ::ARRAY) {
-        isAllLists = false;
-      }
       hasList |= hasList || containsList(child);
     }
   }

--- a/velox/exec/benchmarks/FilterProjectBenchmark.cpp
+++ b/velox/exec/benchmarks/FilterProjectBenchmark.cpp
@@ -253,9 +253,7 @@ class FilterProjectBenchmark : public VectorTestBase {
 
   int64_t run(std::shared_ptr<const core::PlanNode> plan) {
     auto start = getCurrentTimeMicro();
-    int32_t numRows = 0;
     auto result = exec::test::AssertQueryBuilder(plan).copyResults(pool_.get());
-    numRows += result->childAt(0)->as<FlatVector<int64_t>>()->valueAt(0);
     auto elapsedMicros = getCurrentTimeMicro() - start;
     return elapsedMicros;
   }

--- a/velox/exec/benchmarks/HashTableBenchmark.cpp
+++ b/velox/exec/benchmarks/HashTableBenchmark.cpp
@@ -321,7 +321,6 @@ class HashTableBenchmark : public VectorTestBase {
     int32_t mask = powerOfTwo - 1;
     int32_t position = 0;
     int32_t delta = 1;
-    int32_t numInserted = 0;
     auto nextOffset = rowContainer->nextOffset();
 
     // We insert values in a geometric skip order. 1, 2, 4, 7,
@@ -340,7 +339,6 @@ class HashTableBenchmark : public VectorTestBase {
         if (nextOffset) {
           *reinterpret_cast<char**>(newRow + nextOffset) = nullptr;
         }
-        ++numInserted;
         for (auto i = 0; i < batches[batchIndex]->type()->size(); ++i) {
           rowContainer->store(decoded[batchIndex][i], rowIndex, newRow, i);
         }

--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -611,12 +611,10 @@ std::vector<RowVectorPtr> PrestoQueryRunner::execute(const std::string& sql) {
   auto response = ServerResponse(startQuery(sql));
   response.throwIfFailed();
 
-  vector_size_t numResults = 0;
   std::vector<RowVectorPtr> queryResults;
   for (;;) {
     for (auto& result : response.queryResults(pool_.get())) {
       queryResults.push_back(result);
-      numResults += result->size();
     }
 
     if (response.queryCompleted()) {

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -452,16 +452,12 @@ class HashTableTest : public testing::TestWithParam<bool>,
     const auto mode = topTable_->hashMode();
     SelectivityInfo hashTime;
     SelectivityInfo probeTime;
-    int32_t numHashed = 0;
-    int32_t numProbed = 0;
-    int32_t numHit = 0;
     auto& hashers = topTable_->hashers();
     VectorHasher::ScratchMemory scratchMemory;
     for (auto batchIndex = 0; batchIndex < batches_.size(); ++batchIndex) {
       const auto& batch = batches_[batchIndex];
       lookup->reset(batch->size());
       rows.setAll();
-      numHashed += batch->size();
       {
         SelectivityTimer timer(hashTime, 0);
         for (auto i = 0; i < hashers.size(); ++i) {
@@ -496,13 +492,11 @@ class HashTableTest : public testing::TestWithParam<bool>,
         }
       } else {
         {
-          numProbed += lookup->rows.size();
           SelectivityTimer timer(probeTime, 0);
           topTable_->joinProbe(*lookup);
         }
         for (auto i = 0; i < lookup->rows.size(); ++i) {
           const auto key = lookup->rows[i];
-          numHit += lookup->hits[key] != nullptr;
           ASSERT_EQ(rowOfKey_[startOffset + key], lookup->hits[key]);
         }
       }

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -3951,9 +3951,7 @@ DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, tableFileWriteError) {
   VectorFuzzer fuzzer(options, pool());
   const int numBatches = 20;
   std::vector<RowVectorPtr> vectors;
-  int numRows{0};
   for (int i = 0; i < numBatches; ++i) {
-    numRows += batchSize;
     vectors.push_back(fuzzer.fuzzRow(rowType_));
   }
 

--- a/velox/experimental/wave/exec/tests/utils/FileFormat.cpp
+++ b/velox/experimental/wave/exec/tests/utils/FileFormat.cpp
@@ -250,10 +250,8 @@ StringView StringSet::add(StringView data) {
 
 std::unique_ptr<Column> StringSet::toColumn() {
   auto buffer = AlignedBuffer::allocate<char>(totalSize_, pool_);
-  int64_t fill = 0;
   for (auto& piece : buffers_) {
     memcpy(buffer->asMutable<char>(), piece->as<char>(), piece->size());
-    fill += piece->size();
   }
   auto column = std::make_unique<Column>();
   column->kind = TypeKind::VARCHAR;

--- a/velox/functions/prestosql/aggregates/benchmarks/TwoStringKeys.cpp
+++ b/velox/functions/prestosql/aggregates/benchmarks/TwoStringKeys.cpp
@@ -75,9 +75,8 @@ class TwoStringKeysBenchmark : public HiveConnectorTestBase {
 
     auto task = makeTask(plan);
 
-    vector_size_t numResultRows = 0;
     while (auto result = task->next()) {
-      numResultRows += result->size();
+      // no action
     }
 
     LOG(ERROR) << exec::printPlanWithStats(


### PR DESCRIPTION
Summary:
This diff removes a variable that was set, but which was not used.

LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused but set variables often indicate a programming mistake, but can also just be unnecessary cruft that harms readability and performance.

Removing this variable will not change how your code works, but the unused variable may indicate your code isn't working the way you thought it was. If you feel the diff needs changes before landing, **please commandeer** and make appropriate changes: there are hundreds of these and responding to them individually is challenging.

For questions/comments, contact r-barnes.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: meyering

Differential Revision: D57217050


