### PR TITLE
[BUILD] Permission denied when build velox on a new machine

### DIFF
--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -171,6 +171,7 @@ function cmake_install {
     -DCMAKE_CXX_FLAGS="$COMPILER_FLAGS" \
     -DBUILD_TESTING=OFF \
     "$@"
-  ${SUDO} ninja -C "${BINARY_DIR}" install
+  cmake --build "${BINARY_DIR}"
+  ${SUDO} cmake --install "${BINARY_DIR}"
 }
 

--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -171,6 +171,7 @@ function cmake_install {
     -DCMAKE_CXX_FLAGS="$COMPILER_FLAGS" \
     -DBUILD_TESTING=OFF \
     "$@"
+
   cmake --build "${BINARY_DIR}"
   ${SUDO} cmake --install "${BINARY_DIR}"
 }

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -143,7 +143,7 @@ function install_conda {
 
   mkdir -p conda && cd conda
   wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$ARCH.sh
-  bash Miniconda3-latest-Linux-$ARCH.sh -b -p $MINICONDA_PATH
+  ${SUDO} bash Miniconda3-latest-Linux-$ARCH.sh -b -p $MINICONDA_PATH
 }
 
 function install_duckdb {
@@ -153,6 +153,8 @@ function install_duckdb {
     (
       cd duckdb
       cmake_install -DBUILD_UNITTESTS=OFF -DENABLE_SANITIZER=OFF -DENABLE_UBSAN=OFF -DBUILD_SHELL=OFF -DEXPORT_DLL_SYMBOLS=OFF -DCMAKE_BUILD_TYPE=Release
+      # duckdb build process creates ccache dir with root ownership if dir does not exist
+      # Change ccache dir ownership to current user to avoid permission issues
       sudo chown -R $(id -u -n):$(id -g -n) $(ccache -k cache_dir)
     )
   fi

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -142,7 +142,7 @@ function install_conda {
   fi
 
   mkdir -p conda && cd conda
-  wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$ARCH.sh -O Miniconda3-latest-Linux-$ARCH.s
+  wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$ARCH.sh -O Miniconda3-latest-Linux-$ARCH.sh
   bash Miniconda3-latest-Linux-$ARCH.sh -b -p $MINICONDA_PATH
 }
 

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -130,7 +130,7 @@ function install_fbthrift {
 }
 
 function install_conda {
-  MINICONDA_PATH=/opt/miniconda-for-velox
+  MINICONDA_PATH="${HOME:-/opt}/miniconda-for-velox"
   if [ -e ${MINICONDA_PATH} ]; then
     echo "File or directory already exists: ${MINICONDA_PATH}"
     return
@@ -142,8 +142,8 @@ function install_conda {
   fi
 
   mkdir -p conda && cd conda
-  wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$ARCH.sh
-  ${SUDO} bash Miniconda3-latest-Linux-$ARCH.sh -b -p $MINICONDA_PATH
+  wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$ARCH.sh -O Miniconda3-latest-Linux-$ARCH.s
+  bash Miniconda3-latest-Linux-$ARCH.sh -b -p $MINICONDA_PATH
 }
 
 function install_duckdb {

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -153,6 +153,7 @@ function install_duckdb {
     (
       cd duckdb
       cmake_install -DBUILD_UNITTESTS=OFF -DENABLE_SANITIZER=OFF -DENABLE_UBSAN=OFF -DBUILD_SHELL=OFF -DEXPORT_DLL_SYMBOLS=OFF -DCMAKE_BUILD_TYPE=Release
+      sudo chown -R $(id -u -n):$(id -g -n) $(ccache -k cache_dir)
     )
   fi
 }

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -153,9 +153,6 @@ function install_duckdb {
     (
       cd duckdb
       cmake_install -DBUILD_UNITTESTS=OFF -DENABLE_SANITIZER=OFF -DENABLE_UBSAN=OFF -DBUILD_SHELL=OFF -DEXPORT_DLL_SYMBOLS=OFF -DCMAKE_BUILD_TYPE=Release
-      # duckdb build process creates ccache dir with root ownership if dir does not exist
-      # Change ccache dir ownership to current user to avoid permission issues
-      sudo chown -R $(id -u -n):$(id -g -n) $(ccache -k cache_dir)
     )
   fi
 }


### PR DESCRIPTION
Permission denied error occurred in 2 places:

1. `scripts/setup-ubuntu.sh` install_conda
 ```
mkdir: cannot create directory ‘/opt/miniconda-for-velox’: Permission denied
```
2. `make`
```
[193/1604] Building CXX object velox/common/base/tests/CMakeFiles/velox_base_test.dir/SpillConfigTest.cpp.o
FAILED: velox/common/base/tests/CMakeFiles/velox_base_test.dir/SpillConfigTest.cpp.o
/usr/bin/ccache /usr/bin/c++  -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_CONTEXT_DYN_LINK -DBOOST_CONTEXT_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_FILESYSTEM_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_REGEX_DYN_LINK -DBOOST_REGEX_NO_LIB -DBOOST_SYSTEM_DYN_LINK -DBOOST_SYSTEM_NO_LIB -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DFOLLY_HAVE_INT128_T=1 -DGFLAGS_IS_A_DLL=0 -I../../. -I../../velox/external/xxhash -isystem ../../velox -isystem ../../velox/external -isystem /usr/include/libdwarf -isystem /usr/include/libiberty -isystem _deps/gtest-src/googletest/include -isystem _deps/gtest-src/googletest -isystem _deps/gtest-src/googlemock/include -isystem _deps/gtest-src/googlemock -isystem _deps/gtest-src/include -isystem _deps/gtest-src -mavx2 -mfma -mavx -mf16c -mlzcnt -std=c++17 -mbmi2 -D USE_VELOX_COMMON_BASE -D HAS_UNCAUGHT_EXCEPTIONS -Wall -Wextra -Wno-unused        -Wno-unused-parameter        -Wno-sign-compare        -Wno-ignored-qualifiers        -Wno-implicit-fallthrough          -Wno-empty-body          -Wno-class-memaccess          -Wno-comment          -Wno-int-in-bool-context          -Wno-redundant-move          -Wno-array-bounds          -Wno-maybe-uninitialized          -Wno-unused-result          -Wno-format-overflow          -Wno-strict-aliasing -Werror -O3 -DNDEBUG -fPIE   -fdiagnostics-color=always -std=gnu++17 -MD -MT velox/common/base/tests/CMakeFiles/velox_base_test.dir/SpillConfigTest.cpp.o -MF velox/common/base/tests/CMakeFiles/velox_base_test.dir/SpillConfigTest.cpp.o.d -o velox/common/base/tests/CMakeFiles/velox_base_test.dir/SpillConfigTest.cpp.o -c ../../velox/common/base/tests/SpillConfigTest.cpp
ccache: error: Failed to create temporary file for /home/zhouyifan/.ccache/tmp/SpillConfi.stdout: Permission denied
```