### PR TITLE
Fix Unaligned Memory Access for Footer Length in Parquet Reader

### DIFF
--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -161,8 +161,8 @@ void ReaderBase::loadFileMetaData() {
       strncmp(copy.data() + readSize - 4, "PAR1", 4) == 0,
       "No magic bytes found at end of the Parquet file");
 
-  uint32_t footerLength =
-      *(reinterpret_cast<const uint32_t*>(copy.data() + readSize - 8));
+  uint32_t footerLength;
+  std::memcpy(&footerLength, copy.data() + readSize - 8, sizeof(uint32_t));
   VELOX_CHECK_LE(footerLength + 12, fileLength_);
   int32_t footerOffsetInBuffer = readSize - 8 - footerLength;
   if (footerLength > readSize - 8) {


### PR DESCRIPTION
```
/home/user/presto-native/presto-native-execution/velox/velox/dwio/parquet/reader/ParquetReader.cpp:165:7: runtime error: load of misaligned address 0x7f4c5f982402 for type 'const uint32_t', which requires 4 byte alignment
0x7f4c5f982402: note: pointer points here
 81 95  f8 5c 4a ce 06 00 50 41  52 31 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00
```
Got an error on running a unit test with ubsan. On further inspection seems like if the address to be set is not a multiple of 4 it can cause issues and undefined behavior. Using memcpy which is safe