### PR TITLE
Fix scheduled fuzzer job being canceled prematurely

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -71,7 +71,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
A merge to main had the same concurrency group as the scheduled run and would cancel an ongoing run. This PR adds the event name to the concurrency group to prevent this.