### PR TITLE
Add levenshtein Spark function

### DIFF
--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -91,10 +91,11 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 
 .. spark:function:: levenshtein(string, string[, threshold]) -> integer
 
-    Returns the Levenshtein distance between the two given strings. If
+    Returns the `Levenshtein distance <https://en.wikipedia.org/wiki/Levenshtein_distance>`_ between the two given strings. If
     ``threshold`` is set and distance more than it, return -1. ::
 
         SELECT levenshtein('kitten', 'sitting'); -- 3
+        SELECT levenshtein('kitten', 'sitting', 10); -- 3
         SELECT levenshtein('kitten', 'sitting', 2); -- -1
 
 .. spark:function:: lower(string) -> string

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -89,11 +89,10 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 
     Returns the length of ``string`` in characters.
 
-.. spark:function:: levenshtein(string, string[, threshold]) -> integer
+.. spark:function:: levenshtein(string1, string2[, threshold]) -> integer
 
-    Returns the `Levenshtein distance <https://en.wikipedia.org/wiki/Levenshtein_distance>`_ between the two given strings. If
-    ``threshold`` is set and the levenshtein distance exceeds it, return -1.
-    Negative threshold is allowed, return -1. ::
+    Returns the `Levenshtein distance <https://en.wikipedia.org/wiki/Levenshtein_distance>`_ between the two given strings.
+    If the provided ``threshold`` is negative, or the levenshtein distance exceeds ``threshold``, returns -1. ::
 
         SELECT levenshtein('kitten', 'sitting'); -- 3
         SELECT levenshtein('kitten', 'sitting', 10); -- 3

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -89,6 +89,14 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 
     Returns the length of ``string`` in characters.
 
+.. spark:function:: levenshtein(string, string[, threshold]) -> integer
+
+    Returns the Levenshtein distance between the two given strings. If
+    ``threshold`` is set and distance more than it, return -1. ::
+
+        SELECT levenshtein('kitten', 'sitting'); -- 3
+        SELECT levenshtein('kitten', 'sitting', 2); -- -1
+
 .. spark:function:: lower(string) -> string
 
     Returns string with all characters changed to lowercase. ::

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -92,7 +92,8 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 .. spark:function:: levenshtein(string, string[, threshold]) -> integer
 
     Returns the `Levenshtein distance <https://en.wikipedia.org/wiki/Levenshtein_distance>`_ between the two given strings. If
-    ``threshold`` is set and distance more than it, return -1. ::
+    ``threshold`` is set and the levenshtein distance exceeds it, return -1.
+    Negative threshold is allowed, return -1. ::
 
         SELECT levenshtein('kitten', 'sitting'); -- 3
         SELECT levenshtein('kitten', 'sitting', 10); -- 3

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -465,6 +465,15 @@ void registerFunctions(const std::string& prefix) {
 
   registerFunction<RaiseErrorFunction, UnknownValue, Varchar>(
       {prefix + "raise_error"});
+
+  registerFunction<
+      LevenshteinDistanceFunction,
+      int32_t,
+      Varchar,
+      Varchar,
+      int32_t>({prefix + "levenshtein"});
+  registerFunction<LevenshteinDistanceFunction, int32_t, Varchar, Varchar>(
+      {prefix + "levenshtein"});
 }
 
 } // namespace sparksql

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -1294,9 +1294,9 @@ struct LevenshteinDistanceFunction {
   // O(leftCodePointsSize * rightCodePointsSize) to
   // O(k * rightCodePointsSize) by only computing a diagonal stripe of at most
   // width 2k + 1 of the cost table.
-  // One example: suppose s is of length 5, t is of length 7, and threshold is
-  // 1. In this case we're going to walk through a stripe of length 3. The
-  // matrix would look like so:
+  // One example: suppose the two gives strings are of length 5 and 7, and
+  // threshold is 1. In this case we're going to walk through a stripe of
+  // length 3. The matrix would look like so:
   //
   // <pre>
   //    0 1 2 3 4

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -1241,7 +1241,7 @@ template <typename T>
 struct LevenshteinDistanceFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  void call(
+  FOLLY_ALWAYS_INLINE void call(
       out_type<int32_t>& result,
       const arg_type<Varchar>& left,
       const arg_type<Varchar>& right,
@@ -1257,7 +1257,7 @@ struct LevenshteinDistanceFunction {
         threshold);
   }
 
-  void callAscii(
+  FOLLY_ALWAYS_INLINE void callAscii(
       out_type<int32_t>& result,
       const arg_type<Varchar>& left,
       const arg_type<Varchar>& right,
@@ -1273,14 +1273,14 @@ struct LevenshteinDistanceFunction {
         threshold);
   }
 
-  void call(
+  FOLLY_ALWAYS_INLINE void call(
       out_type<int32_t>& result,
       const arg_type<Varchar>& left,
       const arg_type<Varchar>& right) {
     call(result, left, right, INT32_MAX);
   }
 
-  void callAscii(
+  FOLLY_ALWAYS_INLINE void callAscii(
       out_type<int32_t>& result,
       const arg_type<Varchar>& left,
       const arg_type<Varchar>& right) {

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -1235,7 +1235,8 @@ struct SoundexFunction {
 };
 
 /// Implementation adopted from
-/// org.apache.commons.text.similarity.LevenshteinDistance.limitedCompare.
+/// org.apache.commons.text.similarity.LevenshteinDistance.limitedCompare and
+/// Velox Presto LevenshteinDistanceFunction.
 template <typename T>
 struct LevenshteinDistanceFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
@@ -1288,12 +1289,14 @@ struct LevenshteinDistanceFunction {
 
  private:
   // This implementation only computes the distance if it's less than or equal
-  // to the threshold value, setting result as -1 if it's greater.
-  // Threshold k allows us to reduce it to O(km) time by only computing a
-  // diagonal stripe of at most width 2k + 1 of the cost table.
-  // One example: suppose s is of length 5, t is of length 7,
-  // and our threshold is 1. In this case we're going to walk a stripe of
-  // length 3. The matrix would look like so:
+  // to the threshold value, setting result as -1 if it's greater. Threshold k
+  // allows us to reduce the time complexity from
+  // O(leftCodePointsSize * rightCodePointsSize) to
+  // O(k * rightCodePointsSize) by only computing a diagonal stripe of at most
+  // width 2k + 1 of the cost table.
+  // One example: suppose s is of length 5, t is of length 7, and threshold is
+  // 1. In this case we're going to walk through a stripe of length 3. The
+  // matrix would look like so:
   //
   // <pre>
   //    0 1 2 3 4
@@ -1373,7 +1376,7 @@ struct LevenshteinDistanceFunction {
         lower = 1;
       } else {
         leftUpDistance = distances[lower - 1];
-        // Ignore entry left of leftmost.
+        // Set this as Max value to ignore entry left of leftmost.
         distances[lower - 1] = INT32_MAX;
       }
       for (int j = lower; j < upper; j++) {

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -243,6 +243,8 @@ TEST_F(StringTest, levenshtein) {
   levenshteinTest(std::string(100000, 'l'), "hello", 99997, 99998, -1);
   levenshteinTest(std::string(1000001, 'h'), "", 1000000, 1000001, -1);
   levenshteinTest("", std::string(1000001, 'h'), 1000000, 1000001, -1);
+
+  levenshteinTest("kitten", "sitting", -1, 3, -1);
 }
 
 TEST_F(StringTest, endsWith) {

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -204,58 +204,57 @@ TEST_F(StringTest, levenshtein) {
 }
 
 TEST_F(StringTest, levenshteinWithThreshold) {
-  const auto levenshteinWithThreshold =
-      [&](const std::optional<std::string>& left,
-          const std::optional<std::string>& right,
-          const std::optional<int32_t>& threshold) {
-        return evaluateOnce<int32_t>(
-            "levenshtein(c0, c1, c2)", left, right, threshold);
-      };
+  const auto levenshtein = [&](const std::optional<std::string>& left,
+                               const std::optional<std::string>& right,
+                               const std::optional<int32_t>& threshold) {
+    return evaluateOnce<int32_t>(
+        "levenshtein(c0, c1, c2)", left, right, threshold);
+  };
 
-  EXPECT_EQ(levenshteinWithThreshold("kitten", "sitting", 2), -1);
+  EXPECT_EQ(levenshtein("kitten", "sitting", 2), -1);
 
-  EXPECT_EQ(levenshteinWithThreshold("", "", 0), 0);
+  EXPECT_EQ(levenshtein("", "", 0), 0);
 
-  EXPECT_EQ(levenshteinWithThreshold("aaapppp", "", 8), 7);
-  EXPECT_EQ(levenshteinWithThreshold("aaapppp", "", 7), 7);
-  EXPECT_EQ(levenshteinWithThreshold("aaapppp", "", 6), -1);
+  EXPECT_EQ(levenshtein("aaapppp", "", 8), 7);
+  EXPECT_EQ(levenshtein("aaapppp", "", 7), 7);
+  EXPECT_EQ(levenshtein("aaapppp", "", 6), -1);
 
-  EXPECT_EQ(levenshteinWithThreshold("elephant", "hippo", 7), 7);
-  EXPECT_EQ(levenshteinWithThreshold("elephant", "hippo", 6), -1);
-  EXPECT_EQ(levenshteinWithThreshold("hippo", "elephant", 7), 7);
-  EXPECT_EQ(levenshteinWithThreshold("hippo", "elephant", 6), -1);
+  EXPECT_EQ(levenshtein("elephant", "hippo", 7), 7);
+  EXPECT_EQ(levenshtein("elephant", "hippo", 6), -1);
+  EXPECT_EQ(levenshtein("hippo", "elephant", 7), 7);
+  EXPECT_EQ(levenshtein("hippo", "elephant", 6), -1);
 
-  EXPECT_EQ(levenshteinWithThreshold("b", "a", 0), -1);
-  EXPECT_EQ(levenshteinWithThreshold("a", "b", 0), -1);
+  EXPECT_EQ(levenshtein("b", "a", 0), -1);
+  EXPECT_EQ(levenshtein("a", "b", 0), -1);
 
-  EXPECT_EQ(levenshteinWithThreshold("aa", "aa", 0), 0);
-  EXPECT_EQ(levenshteinWithThreshold("aa", "aa", 2), 0);
+  EXPECT_EQ(levenshtein("aa", "aa", 0), 0);
+  EXPECT_EQ(levenshtein("aa", "aa", 2), 0);
 
-  EXPECT_EQ(levenshteinWithThreshold("aaa", "bbb", 2), -1);
-  EXPECT_EQ(levenshteinWithThreshold("aaa", "bbb", 3), 3);
+  EXPECT_EQ(levenshtein("aaa", "bbb", 2), -1);
+  EXPECT_EQ(levenshtein("aaa", "bbb", 3), 3);
 
-  EXPECT_EQ(levenshteinWithThreshold("aaaaaa", "b", 10), 6);
+  EXPECT_EQ(levenshtein("aaaaaa", "b", 10), 6);
 
-  EXPECT_EQ(levenshteinWithThreshold("aaapppp", "b", 8), 7);
-  EXPECT_EQ(levenshteinWithThreshold("a", "bbb", 4), 3);
+  EXPECT_EQ(levenshtein("aaapppp", "b", 8), 7);
+  EXPECT_EQ(levenshtein("a", "bbb", 4), 3);
 
-  EXPECT_EQ(levenshteinWithThreshold("aaapppp", "b", 7), 7);
-  EXPECT_EQ(levenshteinWithThreshold("a", "bbb", 3), 3);
+  EXPECT_EQ(levenshtein("aaapppp", "b", 7), 7);
+  EXPECT_EQ(levenshtein("a", "bbb", 3), 3);
 
-  EXPECT_EQ(levenshteinWithThreshold("a", "bbb", 2), -1);
-  EXPECT_EQ(levenshteinWithThreshold("bbb", "a", 2), -1);
-  EXPECT_EQ(levenshteinWithThreshold("aaapppp", "b", 6), -1);
+  EXPECT_EQ(levenshtein("a", "bbb", 2), -1);
+  EXPECT_EQ(levenshtein("bbb", "a", 2), -1);
+  EXPECT_EQ(levenshtein("aaapppp", "b", 6), -1);
 
-  EXPECT_EQ(levenshteinWithThreshold("a", "bbb", 1), -1);
-  EXPECT_EQ(levenshteinWithThreshold("bbb", "a", 1), -1);
+  EXPECT_EQ(levenshtein("a", "bbb", 1), -1);
+  EXPECT_EQ(levenshtein("bbb", "a", 1), -1);
 
-  EXPECT_EQ(levenshteinWithThreshold("12345", "1234567", 1), -1);
-  EXPECT_EQ(levenshteinWithThreshold("1234567", "12345", 1), -1);
+  EXPECT_EQ(levenshtein("12345", "1234567", 1), -1);
+  EXPECT_EQ(levenshtein("1234567", "12345", 1), -1);
 
-  EXPECT_EQ(levenshteinWithThreshold("千世", "fog", 3), 3);
-  EXPECT_EQ(levenshteinWithThreshold("千世", "fog", 2), -1);
-  EXPECT_EQ(levenshteinWithThreshold("世界千世", "大a界b", 4), 4);
-  EXPECT_EQ(levenshteinWithThreshold("世界千世", "大a界b", 3), -1);
+  EXPECT_EQ(levenshtein("千世", "fog", 3), 3);
+  EXPECT_EQ(levenshtein("千世", "fog", 2), -1);
+  EXPECT_EQ(levenshtein("世界千世", "大a界b", 4), 4);
+  EXPECT_EQ(levenshtein("世界千世", "大a界b", 3), -1);
 }
 
 TEST_F(StringTest, endsWith) {

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -171,6 +171,93 @@ TEST_F(StringTest, conv) {
   EXPECT_EQ(conv("", 10, std::nullopt), std::nullopt);
 }
 
+TEST_F(StringTest, levenshtein) {
+  const auto levenshtein = [&](const std::optional<std::string>& left,
+                               const std::optional<std::string>& right) {
+    return evaluateOnce<int32_t>("levenshtein(c0, c1)", left, right);
+  };
+
+  EXPECT_EQ(levenshtein("abc", "abc"), 0);
+  EXPECT_EQ(levenshtein("kitten", "sitting"), 3);
+  EXPECT_EQ(levenshtein("frog", "fog"), 1);
+
+  EXPECT_EQ(levenshtein("", "hello"), 5);
+  EXPECT_EQ(levenshtein("hello", ""), 5);
+  EXPECT_EQ(levenshtein("hello", "hello"), 0);
+  EXPECT_EQ(levenshtein("hello", "olleh"), 4);
+
+  EXPECT_EQ(levenshtein("hello world", "hello"), 6);
+  EXPECT_EQ(levenshtein("hello", "hello world"), 6);
+  EXPECT_EQ(levenshtein("hello world", "hel wold"), 3);
+  EXPECT_EQ(levenshtein("hello world", "hellq wodld"), 2);
+  EXPECT_EQ(levenshtein("hello word", "dello world"), 2);
+
+  EXPECT_EQ(levenshtein("  facebook  ", "  facebook  "), 0);
+
+  EXPECT_EQ(levenshtein("hello", std::string(100000, 'h')), 99999);
+  EXPECT_EQ(levenshtein(std::string(100000, 'l'), "hello"), 99998);
+  EXPECT_EQ(levenshtein(std::string(1000001, 'h'), ""), 1000001);
+  EXPECT_EQ(levenshtein("", std::string(1000001, 'h')), 1000001);
+
+  EXPECT_EQ(levenshtein("千世", "fog"), 3);
+  EXPECT_EQ(levenshtein("世界千世", "大a界b"), 4);
+}
+
+TEST_F(StringTest, levenshteinWithThreshold) {
+  const auto levenshteinWithThreshold =
+      [&](const std::optional<std::string>& left,
+          const std::optional<std::string>& right,
+          const std::optional<int32_t>& threshold) {
+        return evaluateOnce<int32_t>(
+            "levenshtein(c0, c1, c2)", left, right, threshold);
+      };
+
+  EXPECT_EQ(levenshteinWithThreshold("kitten", "sitting", 2), -1);
+
+  EXPECT_EQ(levenshteinWithThreshold("", "", 0), 0);
+
+  EXPECT_EQ(levenshteinWithThreshold("aaapppp", "", 8), 7);
+  EXPECT_EQ(levenshteinWithThreshold("aaapppp", "", 7), 7);
+  EXPECT_EQ(levenshteinWithThreshold("aaapppp", "", 6), -1);
+
+  EXPECT_EQ(levenshteinWithThreshold("elephant", "hippo", 7), 7);
+  EXPECT_EQ(levenshteinWithThreshold("elephant", "hippo", 6), -1);
+  EXPECT_EQ(levenshteinWithThreshold("hippo", "elephant", 7), 7);
+  EXPECT_EQ(levenshteinWithThreshold("hippo", "elephant", 6), -1);
+
+  EXPECT_EQ(levenshteinWithThreshold("b", "a", 0), -1);
+  EXPECT_EQ(levenshteinWithThreshold("a", "b", 0), -1);
+
+  EXPECT_EQ(levenshteinWithThreshold("aa", "aa", 0), 0);
+  EXPECT_EQ(levenshteinWithThreshold("aa", "aa", 2), 0);
+
+  EXPECT_EQ(levenshteinWithThreshold("aaa", "bbb", 2), -1);
+  EXPECT_EQ(levenshteinWithThreshold("aaa", "bbb", 3), 3);
+
+  EXPECT_EQ(levenshteinWithThreshold("aaaaaa", "b", 10), 6);
+
+  EXPECT_EQ(levenshteinWithThreshold("aaapppp", "b", 8), 7);
+  EXPECT_EQ(levenshteinWithThreshold("a", "bbb", 4), 3);
+
+  EXPECT_EQ(levenshteinWithThreshold("aaapppp", "b", 7), 7);
+  EXPECT_EQ(levenshteinWithThreshold("a", "bbb", 3), 3);
+
+  EXPECT_EQ(levenshteinWithThreshold("a", "bbb", 2), -1);
+  EXPECT_EQ(levenshteinWithThreshold("bbb", "a", 2), -1);
+  EXPECT_EQ(levenshteinWithThreshold("aaapppp", "b", 6), -1);
+
+  EXPECT_EQ(levenshteinWithThreshold("a", "bbb", 1), -1);
+  EXPECT_EQ(levenshteinWithThreshold("bbb", "a", 1), -1);
+
+  EXPECT_EQ(levenshteinWithThreshold("12345", "1234567", 1), -1);
+  EXPECT_EQ(levenshteinWithThreshold("1234567", "12345", 1), -1);
+
+  EXPECT_EQ(levenshteinWithThreshold("千世", "fog", 3), 3);
+  EXPECT_EQ(levenshteinWithThreshold("千世", "fog", 2), -1);
+  EXPECT_EQ(levenshteinWithThreshold("世界千世", "大a界b", 4), 4);
+  EXPECT_EQ(levenshteinWithThreshold("世界千世", "大a界b", 3), -1);
+}
+
 TEST_F(StringTest, endsWith) {
   const auto endsWith = [&](const std::optional<std::string>& str,
                             const std::optional<std::string>& pattern) {

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -172,89 +172,77 @@ TEST_F(StringTest, conv) {
 }
 
 TEST_F(StringTest, levenshtein) {
-  const auto levenshtein = [&](const std::optional<std::string>& left,
-                               const std::optional<std::string>& right) {
-    return evaluateOnce<int32_t>("levenshtein(c0, c1)", left, right);
+  const auto levenshteinTest = [&](const std::optional<std::string>& left,
+                                   const std::optional<std::string>& right,
+                                   const std::optional<int32_t>& threshold,
+                                   int32_t levenshteinExpected,
+                                   int32_t levenshteinWithThresholdExpected) {
+    EXPECT_EQ(
+        evaluateOnce<int32_t>("levenshtein(c0, c1)", left, right),
+        levenshteinExpected);
+    EXPECT_EQ(
+        evaluateOnce<int32_t>(
+            "levenshtein(c0, c1, c2)", left, right, threshold),
+        levenshteinWithThresholdExpected);
   };
 
-  EXPECT_EQ(levenshtein("abc", "abc"), 0);
-  EXPECT_EQ(levenshtein("kitten", "sitting"), 3);
-  EXPECT_EQ(levenshtein("frog", "fog"), 1);
+  levenshteinTest("kitten", "sitting", 2, 3, -1);
 
-  EXPECT_EQ(levenshtein("", "hello"), 5);
-  EXPECT_EQ(levenshtein("hello", ""), 5);
-  EXPECT_EQ(levenshtein("hello", "hello"), 0);
-  EXPECT_EQ(levenshtein("hello", "olleh"), 4);
+  levenshteinTest("", "", 0, 0, 0);
 
-  EXPECT_EQ(levenshtein("hello world", "hello"), 6);
-  EXPECT_EQ(levenshtein("hello", "hello world"), 6);
-  EXPECT_EQ(levenshtein("hello world", "hel wold"), 3);
-  EXPECT_EQ(levenshtein("hello world", "hellq wodld"), 2);
-  EXPECT_EQ(levenshtein("hello word", "dello world"), 2);
+  levenshteinTest("aaapppp", "", 8, 7, 7);
+  levenshteinTest("aaapppp", "", 7, 7, 7);
+  levenshteinTest("aaapppp", "", 6, 7, -1);
 
-  EXPECT_EQ(levenshtein("  facebook  ", "  facebook  "), 0);
+  levenshteinTest("elephant", "hippo", 7, 7, 7);
+  levenshteinTest("elephant", "hippo", 6, 7, -1);
+  levenshteinTest("hippo", "elephant", 7, 7, 7);
+  levenshteinTest("hippo", "elephant", 6, 7, -1);
 
-  EXPECT_EQ(levenshtein("hello", std::string(100000, 'h')), 99999);
-  EXPECT_EQ(levenshtein(std::string(100000, 'l'), "hello"), 99998);
-  EXPECT_EQ(levenshtein(std::string(1000001, 'h'), ""), 1000001);
-  EXPECT_EQ(levenshtein("", std::string(1000001, 'h')), 1000001);
+  levenshteinTest("b", "a", 0, 1, -1);
+  levenshteinTest("a", "b", 0, 1, -1);
 
-  EXPECT_EQ(levenshtein("千世", "fog"), 3);
-  EXPECT_EQ(levenshtein("世界千世", "大a界b"), 4);
-}
+  levenshteinTest("aa", "aa", 0, 0, 0);
+  levenshteinTest("aa", "aa", 2, 0, 0);
 
-TEST_F(StringTest, levenshteinWithThreshold) {
-  const auto levenshtein = [&](const std::optional<std::string>& left,
-                               const std::optional<std::string>& right,
-                               const std::optional<int32_t>& threshold) {
-    return evaluateOnce<int32_t>(
-        "levenshtein(c0, c1, c2)", left, right, threshold);
-  };
+  levenshteinTest("aaa", "bbb", 2, 3, -1);
+  levenshteinTest("aaa", "bbb", 3, 3, 3);
 
-  EXPECT_EQ(levenshtein("kitten", "sitting", 2), -1);
+  levenshteinTest("aaaaaa", "b", 10, 6, 6);
 
-  EXPECT_EQ(levenshtein("", "", 0), 0);
+  levenshteinTest("aaapppp", "b", 8, 7, 7);
+  levenshteinTest("a", "bbb", 4, 3, 3);
 
-  EXPECT_EQ(levenshtein("aaapppp", "", 8), 7);
-  EXPECT_EQ(levenshtein("aaapppp", "", 7), 7);
-  EXPECT_EQ(levenshtein("aaapppp", "", 6), -1);
+  levenshteinTest("aaapppp", "b", 7, 7, 7);
+  levenshteinTest("a", "bbb", 3, 3, 3);
 
-  EXPECT_EQ(levenshtein("elephant", "hippo", 7), 7);
-  EXPECT_EQ(levenshtein("elephant", "hippo", 6), -1);
-  EXPECT_EQ(levenshtein("hippo", "elephant", 7), 7);
-  EXPECT_EQ(levenshtein("hippo", "elephant", 6), -1);
+  levenshteinTest("a", "bbb", 2, 3, -1);
+  levenshteinTest("bbb", "a", 2, 3, -1);
+  levenshteinTest("aaapppp", "b", 6, 7, -1);
 
-  EXPECT_EQ(levenshtein("b", "a", 0), -1);
-  EXPECT_EQ(levenshtein("a", "b", 0), -1);
+  levenshteinTest("a", "bbb", 1, 3, -1);
+  levenshteinTest("bbb", "a", 1, 3, -1);
 
-  EXPECT_EQ(levenshtein("aa", "aa", 0), 0);
-  EXPECT_EQ(levenshtein("aa", "aa", 2), 0);
+  levenshteinTest("12345", "1234567", 1, 2, -1);
+  levenshteinTest("1234567", "12345", 1, 2, -1);
 
-  EXPECT_EQ(levenshtein("aaa", "bbb", 2), -1);
-  EXPECT_EQ(levenshtein("aaa", "bbb", 3), 3);
+  levenshteinTest("千世", "fog", 3, 3, 3);
+  levenshteinTest("千世", "fog", 2, 3, -1);
+  levenshteinTest("世界千世", "大a界b", 4, 4, 4);
+  levenshteinTest("世界千世", "大a界b", 3, 4, -1);
 
-  EXPECT_EQ(levenshtein("aaaaaa", "b", 10), 6);
+  levenshteinTest("hello world", "hello", 5, 6, -1);
+  levenshteinTest("hello", "hello world", 5, 6, -1);
+  levenshteinTest("hello world", "hel wold", 2, 3, -1);
+  levenshteinTest("hello world", "hellq wodld", 2, 2, 2);
+  levenshteinTest("hello word", "dello world", 2, 2, 2);
 
-  EXPECT_EQ(levenshtein("aaapppp", "b", 8), 7);
-  EXPECT_EQ(levenshtein("a", "bbb", 4), 3);
+  levenshteinTest("  facebook  ", "  facebook  ", 0, 0, 0);
 
-  EXPECT_EQ(levenshtein("aaapppp", "b", 7), 7);
-  EXPECT_EQ(levenshtein("a", "bbb", 3), 3);
-
-  EXPECT_EQ(levenshtein("a", "bbb", 2), -1);
-  EXPECT_EQ(levenshtein("bbb", "a", 2), -1);
-  EXPECT_EQ(levenshtein("aaapppp", "b", 6), -1);
-
-  EXPECT_EQ(levenshtein("a", "bbb", 1), -1);
-  EXPECT_EQ(levenshtein("bbb", "a", 1), -1);
-
-  EXPECT_EQ(levenshtein("12345", "1234567", 1), -1);
-  EXPECT_EQ(levenshtein("1234567", "12345", 1), -1);
-
-  EXPECT_EQ(levenshtein("千世", "fog", 3), 3);
-  EXPECT_EQ(levenshtein("千世", "fog", 2), -1);
-  EXPECT_EQ(levenshtein("世界千世", "大a界b", 4), 4);
-  EXPECT_EQ(levenshtein("世界千世", "大a界b", 3), -1);
+  levenshteinTest("hello", std::string(100000, 'h'), 99999, 99999, 99999);
+  levenshteinTest(std::string(100000, 'l'), "hello", 99997, 99998, -1);
+  levenshteinTest(std::string(1000001, 'h'), "", 1000000, 1000001, -1);
+  levenshteinTest("", std::string(1000001, 'h'), 1000000, 1000001, -1);
 }
 
 TEST_F(StringTest, endsWith) {


### PR DESCRIPTION
Doc: https://spark.apache.org/docs/latest/api/sql/index.html#levenshtein
Code:https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala#L2220C12-L2220C23

https://github.com/apache/spark/blob/d0385c4a99c172fa3e1ba2d72a65c8632b5c72a9/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java#L1694C5-L1694C77

There are two differences between Spark implementation and Presto's implementation:
one is that Spark's return type is `int32_t`, and the other is that it accepts 
a `threshold` parameter.