### PR TITLE
Reset nulls when reusing LazyVector

### DIFF
--- a/velox/vector/LazyVector.h
+++ b/velox/vector/LazyVector.h
@@ -148,6 +148,7 @@ class LazyVector : public BaseVector {
     loader_ = std::move(loader);
     allLoaded_ = false;
     containsLazyAndIsWrapped_ = false;
+    resetNulls();
   }
 
   inline bool isLoaded() const {

--- a/velox/vector/tests/LazyVectorTest.cpp
+++ b/velox/vector/tests/LazyVectorTest.cpp
@@ -607,3 +607,19 @@ TEST_F(LazyVectorTest, lazyWithDictionaryInConstant) {
     EXPECT_EQ(constant->as<SimpleVector<int32_t>>()->valueAt(i), 7);
   }
 }
+
+TEST_F(LazyVectorTest, reset) {
+  static constexpr int32_t kVectorSize = 10;
+  auto loader = [&](RowSet rows) {
+    return makeFlatVector<int32_t>(
+        rows.back() + 1, [](auto row) { return row; });
+  };
+  LazyVector lazy(
+      pool_.get(),
+      INTEGER(),
+      kVectorSize,
+      std::make_unique<test::SimpleVectorLoader>(loader));
+  lazy.setNull(0, true);
+  lazy.reset(std::make_unique<test::SimpleVectorLoader>(loader), kVectorSize);
+  ASSERT_EQ(lazy.nulls(), nullptr);
+}


### PR DESCRIPTION
Summary:
When we reuse `LazyVector`, sometimes we have nulls left over on it,
this would cause crash when we try to translate the selectivity in
`LazyVector::ensureLoadedRowsImpl` because these old nulls do not match with the
new length.

Differential Revision: D57350093


