### PR TITLE
Correct typo in Velox documentation

### DIFF
--- a/velox/docs/develop/aggregate-functions.rst
+++ b/velox/docs/develop/aggregate-functions.rst
@@ -221,7 +221,7 @@ is `std::optional<T>`.
 
 When `T` is Varchar, Varbinary, or a complex type, `exec::arg_type<T>`,
 `exec::optional_arg_type<T>`, and `exec::out_type<T>` are the corresponding
-view and writer types of `T`. A datailed explanaion can be found in :doc:`view-and-writer-types`.
+view and writer types of `T`. A detailed explanation can be found in :doc:`view-and-writer-types`.
 
 .. list-table::
    :widths: 25 25


### PR DESCRIPTION
Fixed a minor typo in the Velox documentation.
The words "datailed explanaion" has been changed to "detailed explanation".
This correction enhances the readability of the document.

Affected file: [velox/docs/develop/aggregate-functions.rst]
Line number: [224]