### PR TITLE
Fix return type for sum(REAL) Spark aggregate

### DIFF
--- a/velox/functions/sparksql/aggregates/SumAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/SumAggregate.cpp
@@ -49,7 +49,7 @@ exec::AggregateRegistrationResult registerSum(
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
-          .returnType("real")
+          .returnType("double")
           .intermediateType("double")
           .argumentType("real")
           .build(),

--- a/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
@@ -451,7 +451,8 @@ TEST_F(SumAggregationTest, decimalRangeOverflow) {
 }
 
 TEST_F(SumAggregationTest, sumFloat) {
-  auto data = makeRowVector({makeFlatVector<float>({2.00, 1.00})});
+  auto data =
+      makeRowVector({makeFlatVector<float>({3.4028235E38, 3.4028235E38})});
   createDuckDbTable({data});
 
   testAggregations(

--- a/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
@@ -449,5 +449,16 @@ TEST_F(SumAggregationTest, decimalRangeOverflow) {
       {expected},
       {});
 }
+
+TEST_F(SumAggregationTest, sumFloat) {
+  auto data = makeRowVector({makeFlatVector<float>({2.00, 1.00})});
+  createDuckDbTable({data});
+
+  testAggregations(
+      [&](auto& builder) { builder.values({data}); },
+      {},
+      {"spark_sum(c0)"},
+      "SELECT sum(c0) FROM tmp");
+}
 } // namespace
 } // namespace facebook::velox::functions::aggregate::sparksql::test


### PR DESCRIPTION
The return type of `sum(real)`  in spark sql should be `double`, not `real`https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala#L81. 