### PR TITLE
Fix CAST(tinyint/smallint/integer/bigint as varbinary) for Spark

### DIFF
--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -184,3 +184,22 @@ Valid example
   SELECT cast(' -3E+2' as decimal(12, 2)); -- -300.00
   SELECT cast('-3E+2 ' as decimal(12, 2)); -- -300.00
   SELECT cast('  -3E+2  ' as decimal(12, 2)); -- -300.00
+
+Cast to Varbinary
+-----------------
+
+From integral types
+^^^^^^^^^^^^^^^^^^^
+
+Casting integral value to varbinary type is allowed.
+Bytes of input value are converted into an array of bytes in little-endian order.
+Supported types are tinyint, smallint, integer and bigint.
+
+Valid example
+
+::
+
+  SELECT cast(cast(18 as tinyint) as binary); -- [12]
+  SELECT cast(cast(180 as smallint) as binary); -- [00 B4]
+  SELECT cast(cast(180000 as integer) as binary); -- [00 02 BF 20]
+  SELECT cast(cast(180000 as bigint) as binary); -- [00 00 00 00 00 02 BF 20]

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -212,6 +212,12 @@ class CastExpr : public SpecialForm {
       const TypePtr& toType,
       VectorPtr& castResult);
 
+  template <typename TInput>
+  VectorPtr applyIntToBinaryCast(
+      const SelectivityVector& rows,
+      exec::EvalCtx& context,
+      const BaseVector& input);
+
   template <typename TInput, typename TOutput>
   void applyFloatingPointToDecimalCastKernel(
       const SelectivityVector& rows,

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -57,10 +57,6 @@ int32_t PrestoCastHooks::castStringToDate(const StringView& dateString) const {
   return util::castFromDateString(dateString, util::ParseMode::kStandardCast);
 }
 
-bool PrestoCastHooks::legacy() const {
-  return legacyCast_;
-}
-
 StringView PrestoCastHooks::removeWhiteSpaces(const StringView& view) const {
   return view;
 }
@@ -68,9 +64,5 @@ StringView PrestoCastHooks::removeWhiteSpaces(const StringView& view) const {
 const TimestampToStringOptions& PrestoCastHooks::timestampToStringOptions()
     const {
   return options_;
-}
-
-bool PrestoCastHooks::truncate() const {
-  return false;
 }
 } // namespace facebook::velox::exec

--- a/velox/expression/PrestoCastHooks.h
+++ b/velox/expression/PrestoCastHooks.h
@@ -32,8 +32,9 @@ class PrestoCastHooks : public CastHooks {
   // Uses standard cast mode to cast from string to date.
   int32_t castStringToDate(const StringView& dateString) const override;
 
-  // Follows 'isLegacyCast' config.
-  bool legacy() const override;
+  bool legacy() const override {
+    return legacyCast_;
+  }
 
   // Returns the input as is.
   StringView removeWhiteSpaces(const StringView& view) const override;
@@ -41,8 +42,9 @@ class PrestoCastHooks : public CastHooks {
   // Returns cast options following 'isLegacyCast' and session timezone.
   const TimestampToStringOptions& timestampToStringOptions() const override;
 
-  // Returns false.
-  bool truncate() const override;
+  bool truncate() const override {
+    return false;
+  }
 
  private:
   const bool legacyCast_;

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -1704,6 +1704,17 @@ TEST_F(CastExprTest, decimalToDecimal) {
       "Cannot cast DECIMAL '-99999999999999999999999999999999999999' to DECIMAL(38, 1)");
 }
 
+TEST_F(CastExprTest, integerToBinary) {
+  testInvalidCast<int8_t>(
+      "varbinary", {12}, "Cannot cast TINYINT to VARBINARY.");
+  testInvalidCast<int16_t>(
+      "varbinary", {12}, "Cannot cast SMALLINT to VARBINARY.");
+  testInvalidCast<int32_t>(
+      "varbinary", {12}, "Cannot cast INTEGER to VARBINARY.");
+  testInvalidCast<int64_t>(
+      "varbinary", {12}, "Cannot cast BIGINT to VARBINARY.");
+}
+
 TEST_F(CastExprTest, integerToDecimal) {
   testIntToDecimalCasts<int8_t>();
   testIntToDecimalCasts<int16_t>();

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -40,10 +40,6 @@ int32_t SparkCastHooks::castStringToDate(const StringView& dateString) const {
       removeWhiteSpaces(dateString), util::ParseMode::kNonStandardCast);
 }
 
-bool SparkCastHooks::legacy() const {
-  return false;
-}
-
 StringView SparkCastHooks::removeWhiteSpaces(const StringView& view) const {
   StringView output;
   stringImpl::trimUnicodeWhiteSpace<true, true, StringView, StringView>(
@@ -61,9 +57,5 @@ const TimestampToStringOptions& SparkCastHooks::timestampToStringOptions()
       .dateTimeSeparator = ' ',
   };
   return options;
-}
-
-bool SparkCastHooks::truncate() const {
-  return true;
 }
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -30,8 +30,9 @@ class SparkCastHooks : public exec::CastHooks {
   /// non-standard cast mode to cast from string to date.
   int32_t castStringToDate(const StringView& dateString) const override;
 
-  // Returns false.
-  bool legacy() const override;
+  bool legacy() const override {
+    return false;
+  }
 
   /// When casting from string to integral, floating-point, decimal, date, and
   /// timestamp types, Spark hook trims all leading and trailing UTF8
@@ -43,7 +44,8 @@ class SparkCastHooks : public exec::CastHooks {
   /// positive sign at first if the year exceeds 9999.
   const TimestampToStringOptions& timestampToStringOptions() const override;
 
-  // Returns true.
-  bool truncate() const override;
+  bool truncate() const override {
+    return true;
+  }
 };
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -556,5 +556,78 @@ TEST_F(SparkCastExprTest, fromString) {
            -30000},
           DECIMAL(12, 2)));
 }
+
+TEST_F(SparkCastExprTest, tinyintToBinary) {
+  testCast<int8_t, std::string>(
+      TINYINT(),
+      VARBINARY(),
+      {18,
+       -26,
+       0,
+       110,
+       std::numeric_limits<int8_t>::max(),
+       std::numeric_limits<int8_t>::min()},
+      {std::string("\x12", 1),
+       std::string("\xE6", 1),
+       std::string("\0", 1),
+       std::string("\x6E", 1),
+       std::string("\x7F", 1),
+       std::string("\x80", 1)});
+}
+
+TEST_F(SparkCastExprTest, smallintToBinary) {
+  testCast<int16_t, std::string>(
+      SMALLINT(),
+      VARBINARY(),
+      {180,
+       -199,
+       0,
+       12300,
+       std::numeric_limits<int16_t>::max(),
+       std::numeric_limits<int16_t>::min()},
+      {std::string("\0\xB4", 2),
+       std::string("\xFF\x39", 2),
+       std::string("\0\0", 2),
+       std::string("\x30\x0C", 2),
+       std::string("\x7F\xFF", 2),
+       std::string("\x80\00", 2)});
+}
+
+TEST_F(SparkCastExprTest, integerToBinary) {
+  testCast<int32_t, std::string>(
+      INTEGER(),
+      VARBINARY(),
+      {18,
+       -26,
+       0,
+       180000,
+       std::numeric_limits<int32_t>::max(),
+       std::numeric_limits<int32_t>::min()},
+      {std::string("\0\0\0\x12", 4),
+       std::string("\xFF\xFF\xFF\xE6", 4),
+       std::string("\0\0\0\0", 4),
+       std::string("\0\x02\xBF\x20", 4),
+       std::string("\x7F\xFF\xFF\xFF", 4),
+       std::string("\x80\0\0\0", 4)});
+}
+
+TEST_F(SparkCastExprTest, bigintToBinary) {
+  testCast<int64_t, std::string>(
+      BIGINT(),
+      VARBINARY(),
+      {123456,
+       -256789,
+       0,
+       180000,
+       std::numeric_limits<int64_t>::max(),
+       std::numeric_limits<int64_t>::min()},
+      {std::string("\0\0\0\0\0\x01\xE2\x40", 8),
+       std::string("\xFF\xFF\xFF\xFF\xFF\xFC\x14\xEB", 8),
+       std::string("\0\0\0\0\0\0\0\0", 8),
+       std::string("\0\0\0\0\0\x02\xBF\x20", 8),
+       std::string("\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF", 8),
+       std::string("\x80\x00\x00\x00\x00\x00\x00\x00", 8)});
+}
+
 } // namespace
 } // namespace facebook::velox::test


### PR DESCRIPTION
Fixes https://github.com/facebookincubator/velox/issues/9820.