### PR TITLE
Add checksum for ssd cache

### DIFF
--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -229,6 +229,9 @@ void registerVeloxMetrics() {
   // Total number of errors while reading from SSD cache files.
   DEFINE_METRIC(kMetricSsdCacheReadSsdErrors, facebook::velox::StatType::SUM);
 
+  // Total number of corrupted SSD data read detected by checksum.
+  DEFINE_METRIC(kMetricSsdCacheReadCorruptions, facebook::velox::StatType::SUM);
+
   // Total number of errors while reading from SSD checkpoint files.
   DEFINE_METRIC(
       kMetricSsdCacheReadCheckpointErrors, facebook::velox::StatType::SUM);

--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -269,6 +269,9 @@ constexpr folly::StringPiece kMetricSsdCacheWriteSsdDropped{
 constexpr folly::StringPiece kMetricSsdCacheWriteCheckpointErrors{
     "velox.ssd_cache_write_checkpoint_errors"};
 
+constexpr folly::StringPiece kMetricSsdCacheReadCorruptions{
+    "velox.ssd_cache_read_corruptions"};
+
 constexpr folly::StringPiece kMetricSsdCacheReadSsdErrors{
     "velox.ssd_cache_read_ssd_errors"};
 

--- a/velox/common/base/PeriodicStatsReporter.cpp
+++ b/velox/common/base/PeriodicStatsReporter.cpp
@@ -210,6 +210,8 @@ void PeriodicStatsReporter::reportCacheStats() {
     REPORT_IF_NOT_ZERO(
         kMetricSsdCacheReadSsdErrors, deltaSsdStats.readSsdErrors);
     REPORT_IF_NOT_ZERO(
+        kMetricSsdCacheReadCorruptions, deltaSsdStats.readSsdCorruptions);
+    REPORT_IF_NOT_ZERO(
         kMetricSsdCacheReadCheckpointErrors,
         deltaSsdStats.readCheckpointErrors);
     REPORT_IF_NOT_ZERO(

--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -473,6 +473,7 @@ TEST_F(PeriodicStatsReporterTest, basic) {
     ASSERT_EQ(counterMap.count(kMetricSsdCacheWriteSsdDropped.str()), 0);
     ASSERT_EQ(counterMap.count(kMetricSsdCacheWriteCheckpointErrors.str()), 0);
     ASSERT_EQ(counterMap.count(kMetricSsdCacheReadSsdErrors.str()), 0);
+    ASSERT_EQ(counterMap.count(kMetricSsdCacheReadCorruptions.str()), 0);
     ASSERT_EQ(counterMap.count(kMetricSsdCacheReadCheckpointErrors.str()), 0);
     ASSERT_EQ(counterMap.count(kMetricSsdCacheCheckpointsRead.str()), 0);
     ASSERT_EQ(counterMap.count(kMetricSsdCacheCheckpointsWritten.str()), 0);
@@ -503,6 +504,7 @@ TEST_F(PeriodicStatsReporterTest, basic) {
   newSsdStats->writeSsdDropped = 10;
   newSsdStats->writeCheckpointErrors = 10;
   newSsdStats->readSsdErrors = 10;
+  newSsdStats->readSsdCorruptions = 10;
   newSsdStats->readCheckpointErrors = 10;
   cache.updateStats(
       {.numHit = 10,
@@ -548,13 +550,14 @@ TEST_F(PeriodicStatsReporterTest, basic) {
     ASSERT_EQ(counterMap.count(kMetricSsdCacheWriteSsdDropped.str()), 1);
     ASSERT_EQ(counterMap.count(kMetricSsdCacheWriteCheckpointErrors.str()), 1);
     ASSERT_EQ(counterMap.count(kMetricSsdCacheReadSsdErrors.str()), 1);
+    ASSERT_EQ(counterMap.count(kMetricSsdCacheReadCorruptions.str()), 1);
     ASSERT_EQ(counterMap.count(kMetricSsdCacheReadCheckpointErrors.str()), 1);
     ASSERT_EQ(counterMap.count(kMetricSsdCacheCheckpointsRead.str()), 1);
     ASSERT_EQ(counterMap.count(kMetricSsdCacheCheckpointsWritten.str()), 1);
     ASSERT_EQ(counterMap.count(kMetricSsdCacheRegionsEvicted.str()), 1);
     ASSERT_EQ(counterMap.count(kMetricSsdCacheAgedOutEntries.str()), 1);
     ASSERT_EQ(counterMap.count(kMetricSsdCacheAgedOutRegions.str()), 1);
-    ASSERT_EQ(counterMap.size(), 50);
+    ASSERT_EQ(counterMap.size(), 51);
   }
 }
 

--- a/velox/common/caching/CacheTTLController.h
+++ b/velox/common/caching/CacheTTLController.h
@@ -61,6 +61,10 @@ class CacheTTLController {
     return instance_.get();
   }
 
+  static void testingClear() {
+    instance_ = nullptr;
+  }
+
   /// Add file opening info for a file identified by fileNum. Return true if a
   /// new file entry is inserted, or if the existing file entry is updated
   /// while cache deletion for the file is in progress. Return false otherwise

--- a/velox/common/caching/SsdCache.h
+++ b/velox/common/caching/SsdCache.h
@@ -45,7 +45,9 @@ class SsdCache {
       int32_t numShards,
       folly::Executor* executor,
       int64_t checkpointIntervalBytes = 0,
-      bool disableFileCow = false);
+      bool disableFileCow = false,
+      bool checksumWriteEnabled = false,
+      bool checksumReadVerificationEnabled = false);
 
   /// Returns the shard corresponding to 'fileId'. 'fileId' is a file id from
   /// e.g. FileCacheKey.

--- a/velox/common/caching/StringIdMap.h
+++ b/velox/common/caching/StringIdMap.h
@@ -63,6 +63,15 @@ class StringIdMap {
     return it == idToEntry_.end() ? "" : it->second.string;
   }
 
+  // Resets StringIdMap.
+  void testingReset() {
+    std::lock_guard<std::mutex> l(mutex_);
+    stringToId_.clear();
+    idToEntry_.clear();
+    lastId_ = 0;
+    pinnedSize_ = 0;
+  }
+
  private:
   struct Entry {
     std::string string;

--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -357,6 +357,9 @@ Cache
    * - ssd_cache_write_checkpoint_errors
      - Sum
      - Total number of errors while writing SSD checkpoint file.
+   * - ssd_cache_read_corruptions
+     - Sum
+     - Total number of corrupted SSD data read detected by checksum.
    * - ssd_cache_read_ssd_errors
      - Sum
      - Total number of errors while reading from SSD cache files.


### PR DESCRIPTION
This PR introduces an optional checksum feature for the SSD cache. When
enabled, a CRC-based checksum is calculated for each cache entry and
stored in the checkpoint file. Additionally, if read verification is
activated, the checksum is recalculated and verified against the stored
value when cache data is recovered from the checkpoint or loaded from
the SSD.
A new counter, `ssd_cache_read_corruptions`, is added to track the
number of corruptions detected due to checksum mismatches.
