### PR TITLE
Implement TPCH Query 11 in TpchQueryBuilder

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -529,6 +529,11 @@ BENCHMARK(q10) {
   benchmark.run(planContext);
 }
 
+BENCHMARK(q11) {
+  const auto planContext = queryBuilder->getQueryPlan(11);
+  benchmark.run(planContext);
+}
+
 BENCHMARK(q12) {
   const auto planContext = queryBuilder->getQueryPlan(12);
   benchmark.run(planContext);

--- a/velox/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -195,6 +195,11 @@ TEST_F(ParquetTpchTest, Q10) {
   assertQuery(10, std::move(sortingKeys));
 }
 
+TEST_F(ParquetTpchTest, Q11) {
+  std::vector<uint32_t> sortingKeys{1};
+  assertQuery(11, std::move(sortingKeys));
+}
+
 TEST_F(ParquetTpchTest, Q12) {
   std::vector<uint32_t> sortingKeys{0};
   assertQuery(12, std::move(sortingKeys));

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -98,6 +98,7 @@ class TpchQueryBuilder {
   TpchPlan getQ8Plan() const;
   TpchPlan getQ9Plan() const;
   TpchPlan getQ10Plan() const;
+  TpchPlan getQ11Plan() const;
   TpchPlan getQ12Plan() const;
   TpchPlan getQ13Plan() const;
   TpchPlan getQ14Plan() const;


### PR DESCRIPTION
This PR introduces TPC-H Query 11 into the TpchQueryBuilder and extends the TpchBenchmark and ParquetTpchTest to include this query. Additionally, it provides a detailed performance comparison with DuckDB using the Parquet file format and includes the output of PrintPlanWithStats for detailed analysis.

## Performance Comparison

Chip: Apple M1 Pro
Total Number of Cores: 10 (8 performance and 2 efficiency)
Memory:	32 GB
 
The following table summarizes the performance comparison between Velox and DuckDB (with Parquet file format) across various numbers of threads/drivers:

```
| # Num Threads/ Drivers | Velox(ms) | DuckDB(ms) |
|:----------------------:|:---------:|:----------:|
|            1           |     18    |     68.8   |  
|            4           |     16    |     53.5   |  
|            8           |     17    |     56.4   | 
|           16           |     18    |     55.7   | 
``` 
A PowerPoint presentation of the above details is included in the link: [PowerPoint Presentation](https://ibm.box.com/s/62w6evg3ckdwtoth8s72ghp3dpdajvux).
