### PR TITLE
Optimize the shared leaf memory pool locking

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -28,6 +28,7 @@ DECLARE_int32(velox_memory_num_shared_leaf_pools);
 namespace facebook::velox::memory {
 namespace {
 constexpr std::string_view kSysRootName{"__sys_root__"};
+constexpr std::string_view kSysSharedLeafNamePrefix{"__sys_shared_leaf__"};
 
 struct SingletonState {
   ~SingletonState() {
@@ -74,6 +75,20 @@ std::unique_ptr<MemoryArbitrator> createArbitrator(
        .arbitrationStateCheckCb = options.arbitrationStateCheckCb,
        .checkUsageLeak = options.checkUsageLeak});
 }
+
+std::vector<std::shared_ptr<MemoryPool>> createSharedLeafMemoryPools(
+    MemoryPool& sysPool) {
+  VELOX_CHECK_EQ(sysPool.name(), kSysRootName);
+  std::vector<std::shared_ptr<MemoryPool>> leafPools;
+  const size_t numSharedPools =
+      std::max(1, FLAGS_velox_memory_num_shared_leaf_pools);
+  leafPools.reserve(numSharedPools);
+  for (size_t i = 0; i < numSharedPools; ++i) {
+    leafPools.emplace_back(sysPool.addLeafChild(
+        fmt::format("{}{}", kSysSharedLeafNamePrefix, i)));
+  }
+  return leafPools;
+}
 } // namespace
 
 MemoryManager::MemoryManager(const MemoryManagerOptions& options)
@@ -88,7 +103,7 @@ MemoryManager::MemoryManager(const MemoryManagerOptions& options)
       poolGrowCb_([&](MemoryPool* pool, uint64_t targetBytes) {
         return growPool(pool, targetBytes);
       }),
-      defaultRoot_{std::make_shared<MemoryPoolImpl>(
+      sysRoot_{std::make_shared<MemoryPoolImpl>(
           this,
           std::string(kSysRootName),
           MemoryPool::Kind::kAggregate,
@@ -105,25 +120,22 @@ MemoryManager::MemoryManager(const MemoryManagerOptions& options)
               .debugEnabled = options.debugEnabled,
               .coreOnAllocationFailureEnabled =
                   options.coreOnAllocationFailureEnabled})},
-      spillPool_{addLeafPool("__sys_spilling__")} {
+      spillPool_{addLeafPool("__sys_spilling__")},
+      sharedLeafPools_(createSharedLeafMemoryPools(*sysRoot_)) {
   VELOX_CHECK_NOT_NULL(allocator_);
   VELOX_CHECK_NOT_NULL(arbitrator_);
   VELOX_USER_CHECK_GE(capacity(), 0);
   VELOX_CHECK_GE(allocator_->capacity(), arbitrator_->capacity());
   MemoryAllocator::alignmentCheck(0, alignment_);
-  const bool ret = defaultRoot_->grow(defaultRoot_->maxCapacity(), 0);
+  const bool ret = sysRoot_->grow(sysRoot_->maxCapacity(), 0);
   VELOX_CHECK(
       ret,
       "Failed to set max capacity {} for {}",
-      succinctBytes(defaultRoot_->maxCapacity()),
-      defaultRoot_->name());
-  const size_t numSharedPools =
-      std::max(1, FLAGS_velox_memory_num_shared_leaf_pools);
-  sharedLeafPools_.reserve(numSharedPools);
-  for (size_t i = 0; i < numSharedPools; ++i) {
-    sharedLeafPools_.emplace_back(
-        addLeafPool(fmt::format("default_shared_leaf_pool_{}", i)));
-  }
+      succinctBytes(sysRoot_->maxCapacity()),
+      sysRoot_->name());
+  VELOX_CHECK_EQ(
+      sharedLeafPools_.size(),
+      std::max(1, FLAGS_velox_memory_num_shared_leaf_pools));
 }
 
 MemoryManager::~MemoryManager() {
@@ -245,7 +257,7 @@ std::shared_ptr<MemoryPool> MemoryManager::addLeafPool(
     static std::atomic<int64_t> poolId{0};
     poolName = fmt::format("default_leaf_{}", poolId++);
   }
-  return defaultRoot_->addLeafChild(poolName, threadSafe, nullptr);
+  return sysRoot_->addLeafChild(poolName, threadSafe, nullptr);
 }
 
 bool MemoryManager::growPool(MemoryPool* pool, uint64_t incrementBytes) {
@@ -276,7 +288,6 @@ void MemoryManager::dropPool(MemoryPool* pool) {
 
 MemoryPool& MemoryManager::deprecatedSharedLeafPool() {
   const auto idx = std::hash<std::thread::id>{}(std::this_thread::get_id());
-  std::shared_lock guard{mutex_};
   return *sharedLeafPools_.at(idx % sharedLeafPools_.size());
 }
 
@@ -285,7 +296,7 @@ int64_t MemoryManager::getTotalBytes() const {
 }
 
 size_t MemoryManager::numPools() const {
-  size_t numPools = defaultRoot_->getChildCount();
+  size_t numPools = sysRoot_->getChildCount();
   {
     std::shared_lock guard{mutex_};
     numPools += pools_.size() - sharedLeafPools_.size();
@@ -312,9 +323,9 @@ std::string MemoryManager::toString(bool detail) const {
       << "\n";
   out << "List of root pools:\n";
   if (detail) {
-    out << defaultRoot_->treeMemoryUsage(false);
+    out << sysRoot_->treeMemoryUsage(false);
   } else {
-    out << "\t" << defaultRoot_->name() << "\n";
+    out << "\t" << sysRoot_->name() << "\n";
   }
   std::vector<std::shared_ptr<MemoryPool>> pools = getAlivePools();
   for (const auto& pool : pools) {

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -283,7 +283,7 @@ class MemoryManager {
   /// Returns the memory manger's internal default root memory pool for testing
   /// purpose.
   MemoryPool& testingDefaultRoot() const {
-    return *defaultRoot_;
+    return *sysRoot_;
   }
 
   /// Returns the process wide leaf memory pool used for disk spilling.
@@ -322,10 +322,9 @@ class MemoryManager {
   // Callback invoked by the root memory pool to request memory capacity growth.
   const MemoryPoolImpl::GrowCapacityCallback poolGrowCb_;
 
-  const std::shared_ptr<MemoryPool> defaultRoot_;
+  const std::shared_ptr<MemoryPool> sysRoot_;
   const std::shared_ptr<MemoryPool> spillPool_;
-
-  std::vector<std::shared_ptr<MemoryPool>> sharedLeafPools_;
+  const std::vector<std::shared_ptr<MemoryPool>> sharedLeafPools_;
 
   mutable folly::SharedMutex mutex_;
   // All user root pools allocated from 'this'.

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -306,7 +306,7 @@ TEST_F(MemoryManagerTest, defaultMemoryManager) {
     ASSERT_THAT(
         managerA.toString(true),
         testing::HasSubstr(fmt::format(
-            "default_shared_leaf_pool_{} usage 0B reserved 0B peak 0B\n", i)));
+            "__sys_shared_leaf__{} usage 0B reserved 0B peak 0B\n", i)));
   }
 }
 
@@ -628,4 +628,20 @@ TEST_F(MemoryManagerTest, quotaEnforcement) {
   }
 }
 
+TEST_F(MemoryManagerTest, deprecatedSharedPoolAccess) {
+  MemoryManager manager{};
+  auto& pool1 = deprecatedSharedLeafPool();
+  auto& pool2 = deprecatedSharedLeafPool();
+  ASSERT_EQ(pool1.name(), pool2.name());
+  ASSERT_EQ(&pool1, &pool2);
+  auto testThread = std::thread([&] {
+    auto& pool3 = deprecatedSharedLeafPool();
+    auto& pool4 = deprecatedSharedLeafPool();
+    ASSERT_EQ(pool4.name(), pool3.name());
+    ASSERT_EQ(&pool4, &pool3);
+    ASSERT_NE(pool3.name(), pool1.name());
+    ASSERT_NE(&pool3, &pool1);
+  });
+  testThread.join();
+}
 } // namespace facebook::velox::memory


### PR DESCRIPTION
Avoid the global locking when access shared leaf memory pool:
1. remove the global lock access to the single-ton memory manager
2. remove the global lock to access shared leaf pool array

Next step is to work with Meta internal teams to deprecate such use cases with explicit
leaf memory pool lifecycle management at user side as well as explicit memory manager
initialization.