### PR TITLE
Restrict CAST of string to boolean

### DIFF
--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -367,7 +367,8 @@ Valid examples
 From VARCHAR
 ^^^^^^^^^^^^
 
-There is a set of strings allowed to be casted to boolean. Casting from other strings to boolean throws.
+There is a set of strings allowed to be casted to boolean. These strings are `t, f, 1, 0, true, false` and their upper case equivalents.
+Casting from other strings to boolean throws.
 
 Valid examples
 
@@ -379,6 +380,8 @@ Valid examples
   SELECT cast('true' as boolean); -- true (case insensitive)
   SELECT cast('f' as boolean); -- false (case insensitive)
   SELECT cast('false' as boolean); -- false (case insensitive)
+  SELECT cast('F' as boolean); -- false (case insensitive)
+  SELECT cast('T' as boolean); -- true (case insensitive)
 
 Invalid examples
 
@@ -391,6 +394,7 @@ Invalid examples
   SELECT cast('-1' as boolean); -- Invalid argument
   SELECT cast('tr' as boolean); -- Invalid argument
   SELECT cast('tru' as boolean); -- Invalid argument
+  SELECT cast('No' as boolean); -- Invalid argument
 
 Cast to Floating-Point Types
 ----------------------------

--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -367,7 +367,7 @@ Valid examples
 From VARCHAR
 ^^^^^^^^^^^^
 
-There is a set of strings allowed to be casted to boolean. These strings are `t, f, 1, 0, true, false` and their upper case equivalents.
+The strings `t, f, 1, 0, true, false` and their upper case equivalents are allowed to be casted to boolean.
 Casting from other strings to boolean throws.
 
 Valid examples

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -1033,28 +1033,19 @@ TEST_F(CastExprTest, primitiveInvalidCornerCases) {
   // To boolean.
   {
     testInvalidCast<std::string>(
-        "boolean",
-        {"1.7E308"},
-        "Non-whitespace character found after end of conversion");
+        "boolean", {"1.7E308"}, "Cannot cast VARCHAR '1.7E308' to BOOLEAN");
     testInvalidCast<std::string>(
-        "boolean",
-        {"nan"},
-        "Non-whitespace character found after end of conversion");
+        "boolean", {"nan"}, "Cannot cast VARCHAR 'nan' to BOOLEAN");
     testInvalidCast<std::string>(
-        "boolean", {"infinity"}, "Invalid value for bool");
+        "boolean", {"infinity"}, "Cannot cast VARCHAR 'infinity' to BOOLEAN");
     testInvalidCast<std::string>(
-        "boolean",
-        {"12"},
-        "Integer overflow when parsing bool (must be 0 or 1)");
-    testInvalidCast<std::string>("boolean", {"-1"}, "Invalid value for bool");
+        "boolean", {"12"}, "Cannot cast VARCHAR '12' to BOOLEAN");
     testInvalidCast<std::string>(
-        "boolean",
-        {"tr"},
-        "Non-whitespace character found after end of conversion");
+        "boolean", {"-1"}, "Cannot cast VARCHAR '-1' to BOOLEAN");
     testInvalidCast<std::string>(
-        "boolean",
-        {"tru"},
-        "Non-whitespace character found after end of conversion");
+        "boolean", {"tr"}, "Cannot cast VARCHAR 'tr' to BOOLEAN");
+    testInvalidCast<std::string>(
+        "boolean", {"tru"}, "Cannot cast VARCHAR 'tru' to BOOLEAN");
   }
 }
 
@@ -1100,6 +1091,14 @@ TEST_F(CastExprTest, primitiveValidCornerCases) {
     testCast<std::string, bool>("boolean", {"0"}, {false});
     testCast<std::string, bool>("boolean", {"t"}, {true});
     testCast<std::string, bool>("boolean", {"true"}, {true});
+    testCast<std::string, bool>("boolean", {"false"}, {false});
+    testCast<std::string, bool>("boolean", {"f"}, {false});
+
+    testInvalidCast<std::string>(
+        "boolean", {"NO"}, "Cannot cast NO to BOOLEAN");
+
+    testInvalidCast<std::string>(
+        "boolean", {"off"}, "Cannot cast off to BOOLEAN");
   }
 
   // To string.

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -267,19 +267,26 @@ TEST_F(SparkCastExprTest, primitiveInvalidCornerCases) {
   // To boolean.
   {
     testInvalidCast<std::string>(
-        "boolean", {"1.7E308"}, "Cannot cast VARCHAR '1.7E308' to BOOLEAN");
+        "boolean",
+        {"1.7E308"},
+        "Non-whitespace character found after end of conversion");
     testInvalidCast<std::string>(
-        "boolean", {"nan"}, "Cannot cast VARCHAR 'nan' to BOOLEAN");
+        "boolean",
+        {"nan"},
+        "Non-whitespace character found after end of conversion");
     testInvalidCast<std::string>(
-        "boolean", {"infinity"}, "Cannot cast VARCHAR 'infinity' to BOOLEAN");
+        "boolean", {"infinity"}, "Invalid value for bool");
     testInvalidCast<std::string>(
-        "boolean", {"12"}, "Cannot cast VARCHAR '12' to BOOLEAN");
+        "boolean", {"12"}, "Integer overflow when parsing bool");
+    testInvalidCast<std::string>("boolean", {"-1"}, "Invalid value for bool");
     testInvalidCast<std::string>(
-        "boolean", {"-1"}, "Cannot cast VARCHAR '-1' to BOOLEAN");
+        "boolean",
+        {"tr"},
+        "Non-whitespace character found after end of conversion");
     testInvalidCast<std::string>(
-        "boolean", {"tr"}, "Cannot cast VARCHAR 'tr' to BOOLEAN");
-    testInvalidCast<std::string>(
-        "boolean", {"tru"}, "Cannot cast VARCHAR 'tru' to BOOLEAN");
+        "boolean",
+        {"tru"},
+        "Non-whitespace character found after end of conversion");
   }
 }
 

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -267,26 +267,19 @@ TEST_F(SparkCastExprTest, primitiveInvalidCornerCases) {
   // To boolean.
   {
     testInvalidCast<std::string>(
-        "boolean",
-        {"1.7E308"},
-        "Non-whitespace character found after end of conversion");
+        "boolean", {"1.7E308"}, "Cannot cast VARCHAR '1.7E308' to BOOLEAN");
     testInvalidCast<std::string>(
-        "boolean",
-        {"nan"},
-        "Non-whitespace character found after end of conversion");
+        "boolean", {"nan"}, "Cannot cast VARCHAR 'nan' to BOOLEAN");
     testInvalidCast<std::string>(
-        "boolean", {"infinity"}, "Invalid value for bool");
+        "boolean", {"infinity"}, "Cannot cast VARCHAR 'infinity' to BOOLEAN");
     testInvalidCast<std::string>(
-        "boolean", {"12"}, "Integer overflow when parsing bool");
-    testInvalidCast<std::string>("boolean", {"-1"}, "Invalid value for bool");
+        "boolean", {"12"}, "Cannot cast VARCHAR '12' to BOOLEAN");
     testInvalidCast<std::string>(
-        "boolean",
-        {"tr"},
-        "Non-whitespace character found after end of conversion");
+        "boolean", {"-1"}, "Cannot cast VARCHAR '-1' to BOOLEAN");
     testInvalidCast<std::string>(
-        "boolean",
-        {"tru"},
-        "Non-whitespace character found after end of conversion");
+        "boolean", {"tr"}, "Cannot cast VARCHAR 'tr' to BOOLEAN");
+    testInvalidCast<std::string>(
+        "boolean", {"tru"}, "Cannot cast VARCHAR 'tru' to BOOLEAN");
   }
 }
 

--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -59,33 +59,11 @@ struct Converter {
   }
 };
 
-// This is based on Presto java's castToBoolean method.
-static Expected<bool> castToBoolean(const char* data, size_t len) {
-  const auto& TU = static_cast<int (*)(int)>(std::toupper);
-
-  if (len == 1) {
-    auto character = TU(data[0]);
-    if (character == 'T' || character == '1') {
-      return true;
-    }
-    if (character == 'F' || character == '0') {
-      return false;
-    }
-  }
-
-  if ((len == 4) && (TU(data[0]) == 'T') && (TU(data[1]) == 'R') &&
-      (TU(data[2]) == 'U') && (TU(data[3]) == 'E')) {
-    return true;
-  }
-
-  if ((len == 5) && (TU(data[0]) == 'F') && (TU(data[1]) == 'A') &&
-      (TU(data[2]) == 'L') && (TU(data[3]) == 'S') && (TU(data[4]) == 'E')) {
-    return false;
-  }
-
-  return folly::makeUnexpected(
-      Status::UserError("Cannot cast {} to BOOLEAN", StringView(data, len)));
-}
+/// Presto compatible cast of strings to boolean. There is a set of strings
+/// allowed to be casted to boolean. These strings are `t, f, 1, 0, true, false`
+/// and their upper case equivalents. Casting from other strings to boolean
+/// throws.
+Expected<bool> castToBoolean(const char* data, size_t len);
 
 namespace detail {
 


### PR DESCRIPTION
Currently Velox is much more permissive than Presto java in casting string's to booleans. Presto only allows the strings - 1, 0, t, f, true, false and their uppercase equivalents. This PR restricts the strings that can be converted to boolean to these strings. Strings apart from these will throw.

Also a new policy SparkCastPolicy has been added so that cast behavior can still confirm to current spark behavior. 

This PR breaks current spark behavior. cc: @PHILO-HE , @rui-mo . 