### PR TITLE
Parallelize the memory reclaim at plan node level

### DIFF
--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -278,10 +278,15 @@ void registerVeloxMetrics() {
   DEFINE_METRIC(
       kMetricTaskMemoryReclaimCount, facebook::velox::StatType::COUNT);
 
-  // Tracks memory reclaim task wait time in range of [0, 60s] with 10 buckets
+  // Tracks memory reclaim task wait time in range of [0, 60s] with 60 buckets
   // and reports P50, P90, P99, and P100.
   DEFINE_HISTOGRAM_METRIC(
-      kMetricTaskMemoryReclaimWaitTimeMs, 6'000, 0, 60'000, 50, 90, 99, 100);
+      kMetricTaskMemoryReclaimWaitTimeMs, 1'000, 0, 60'000, 50, 90, 99, 100);
+
+  // Tracks memory reclaim task wait time in range of [0, 240s] with 60 buckets
+  // and reports P50, P90, P99, and P100.
+  DEFINE_HISTOGRAM_METRIC(
+      kMetricTaskMemoryReclaimExecTimeMs, 4'000, 0, 240'000, 50, 90, 99, 100);
 
   // Tracks the number of times that the task memory reclaim wait timeouts.
   DEFINE_METRIC(
@@ -327,7 +332,7 @@ void registerVeloxMetrics() {
   DEFINE_HISTOGRAM_METRIC(
       kMetricArbitratorWaitTimeMs, 30'000, 0, 600'000, 50, 90, 99, 100);
 
-  // The distribution of the amount of time it take to complete a single
+  // The distribution of the amount of time it takes to complete a single
   // arbitration request stays queued in range of [0, 600s] with 20
   // buckets. It is configured to report the latency at P50, P90, P99,
   // and P100 percentiles.

--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -49,6 +49,9 @@ constexpr folly::StringPiece kMetricTaskMemoryReclaimCount{
 constexpr folly::StringPiece kMetricTaskMemoryReclaimWaitTimeMs{
     "velox.task_memory_reclaim_wait_ms"};
 
+constexpr folly::StringPiece kMetricTaskMemoryReclaimExecTimeMs{
+    "velox.task_memory_reclaim_exec_ms"};
+
 constexpr folly::StringPiece kMetricTaskMemoryReclaimWaitTimeoutCount{
     "velox.task_memory_reclaim_wait_timeout_count"};
 

--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -180,7 +180,7 @@ uint64_t MemoryReclaimer::run(
   RECORD_HISTOGRAM_METRIC_VALUE(
       kMetricMemoryReclaimExecTimeMs, execTimeUs / 1'000);
   RECORD_METRIC_VALUE(kMetricMemoryReclaimedBytes, reclaimedBytes);
-  RECORD_METRIC_VALUE(kMetricMemoryReclaimCount, 1);
+  RECORD_METRIC_VALUE(kMetricMemoryReclaimCount);
   addThreadLocalRuntimeStat(
       "memoryReclaimWallNanos",
       RuntimeCounter(execTimeUs * 1'000, RuntimeCounter::Unit::kNanos));
@@ -223,7 +223,7 @@ uint64_t MemoryReclaimer::reclaim(
   // child pool with most reservation first.
   struct Candidate {
     std::shared_ptr<memory::MemoryPool> pool;
-    int64_t reservedBytes;
+    int64_t reclaimableBytes;
   };
   std::vector<Candidate> candidates;
   {
@@ -232,8 +232,8 @@ uint64_t MemoryReclaimer::reclaim(
     for (auto& entry : pool->children_) {
       auto child = entry.second.lock();
       if (child != nullptr) {
-        const int64_t reservedBytes = child->reservedBytes();
-        candidates.push_back(Candidate{std::move(child), reservedBytes});
+        const int64_t reclaimableBytes = child->reclaimableBytes().value_or(0);
+        candidates.push_back(Candidate{std::move(child), reclaimableBytes});
       }
     }
   }
@@ -242,11 +242,14 @@ uint64_t MemoryReclaimer::reclaim(
       candidates.begin(),
       candidates.end(),
       [](const auto& lhs, const auto& rhs) {
-        return lhs.reservedBytes > rhs.reservedBytes;
+        return lhs.reclaimableBytes > rhs.reclaimableBytes;
       });
 
   uint64_t reclaimedBytes{0};
   for (const auto& candidate : candidates) {
+    if (candidate.reclaimableBytes == 0) {
+      break;
+    }
     const auto bytes = candidate.pool->reclaim(targetBytes, maxWaitMs, stats);
     reclaimedBytes += bytes;
     if (targetBytes != 0) {
@@ -294,6 +297,15 @@ bool MemoryReclaimer::Stats::operator==(
 bool MemoryReclaimer::Stats::operator!=(
     const MemoryReclaimer::Stats& other) const {
   return !(*this == other);
+}
+
+MemoryReclaimer::Stats& MemoryReclaimer::Stats::operator+=(
+    const MemoryReclaimer::Stats& other) {
+  numNonReclaimableAttempts += other.numNonReclaimableAttempts;
+  reclaimExecTimeUs += other.reclaimExecTimeUs;
+  reclaimedBytes += other.reclaimedBytes;
+  reclaimWaitTimeUs += other.reclaimWaitTimeUs;
+  return *this;
 }
 
 MemoryArbitrator::Stats::Stats(

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -324,6 +324,7 @@ class MemoryReclaimer {
 
     bool operator==(const Stats& other) const;
     bool operator!=(const Stats& other) const;
+    Stats& operator+=(const Stats& other);
   };
 
   virtual ~MemoryReclaimer() = default;

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -34,8 +34,8 @@
 DECLARE_bool(velox_memory_leak_check_enabled);
 DECLARE_bool(velox_memory_pool_debug_enabled);
 
-namespace facebook::velox::core {
-class QueryCtx;
+namespace facebook::velox::exec {
+class ParallelMemoryReclaimer;
 }
 
 namespace facebook::velox::memory {
@@ -548,9 +548,8 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   mutable folly::SharedMutex poolMutex_;
   std::unordered_map<std::string, std::weak_ptr<MemoryPool>> children_;
 
-  friend class TestMemoryReclaimer;
   friend class MemoryReclaimer;
-  friend class core::QueryCtx;
+  friend class velox::exec::ParallelMemoryReclaimer;
 };
 
 std::ostream& operator<<(std::ostream& out, MemoryPool::Kind kind);

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -627,21 +627,4 @@ TEST_F(MemoryManagerTest, quotaEnforcement) {
     }
   }
 }
-
-TEST_F(MemoryManagerTest, deprecatedSharedPoolAccess) {
-  MemoryManager manager{};
-  auto& pool1 = deprecatedSharedLeafPool();
-  auto& pool2 = deprecatedSharedLeafPool();
-  ASSERT_EQ(pool1.name(), pool2.name());
-  ASSERT_EQ(&pool1, &pool2);
-  auto testThread = std::thread([&] {
-    auto& pool3 = deprecatedSharedLeafPool();
-    auto& pool4 = deprecatedSharedLeafPool();
-    ASSERT_EQ(pool4.name(), pool3.name());
-    ASSERT_EQ(&pool4, &pool3);
-    ASSERT_NE(pool3.name(), pool1.name());
-    ASSERT_NE(&pool3, &pool1);
-  });
-  testThread.join();
-}
 } // namespace facebook::velox::memory

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -838,11 +838,7 @@ TEST_F(HiveDataSinkTest, memoryReclaimAfterClose) {
     ASSERT_EQ(stats.reclaimExecTimeUs, 0);
     ASSERT_EQ(stats.reclaimedBytes, 0);
     if (testData.expectedWriterReclaimEnabled) {
-      if (testData.sortWriter) {
-        ASSERT_GE(stats.numNonReclaimableAttempts, 1);
-      } else {
-        ASSERT_EQ(stats.numNonReclaimableAttempts, 1);
-      }
+      ASSERT_GE(stats.numNonReclaimableAttempts, 0);
     } else {
       ASSERT_EQ(stats.numNonReclaimableAttempts, 0);
     }

--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -110,7 +110,12 @@ Memory Management
    * - task_memory_reclaim_wait_ms
      - Histogram
      - The distribution of task memory reclaim wait time in range of [0, 60s]
-       with 10 buckets. It is configured to report latency at P50, P90, P99,
+       with 60 buckets. It is configured to report latency at P50, P90, P99,
+       and P100 percentiles.
+   * - task_memory_reclaim_exec_ms
+     - Histogram
+     - The distribution of task memory execution time in range of [0, 240s]
+       with 60 buckets. It is configured to report latency at P50, P90, P99,
        and P100 percentiles.
    * - task_memory_reclaim_wait_timeout_count
      - Count
@@ -154,7 +159,7 @@ Memory Management
        its request, the arbitration request would surpass the maximum allowed
        capacity for the requester, or the arbitration process couldn't release
        the requested amount of memory.
-   * - arbitrator_queue_time_ms
+   * - arbitrator_wait_time_ms
      - Histogram
      - The distribution of the amount of time an arbitration request stays in
        arbitration queues and waits the arbitration r/w locks in range of [0, 600s]
@@ -173,7 +178,7 @@ Memory Management
    * - arbitrator_free_reserved_capacity_bytes
      - Average
      - The average of free memory capacity reserved to ensure each query has
-       the minimal reuired capacity to run.
+       the minimal required capacity to run.
    * - memory_pool_initial_capacity_bytes
      - Histogram
      - The distribution of a root memory pool's initial capacity in range of [0 256MB]

--- a/velox/exec/MemoryReclaimer.cpp
+++ b/velox/exec/MemoryReclaimer.cpp
@@ -66,6 +66,106 @@ void MemoryReclaimer::abort(
   });
 }
 
+/*static*/ std::unique_ptr<memory::MemoryReclaimer>
+ParallelMemoryReclaimer::create(folly::Executor* executor) {
+  return std::unique_ptr<memory::MemoryReclaimer>(
+      new ParallelMemoryReclaimer(executor));
+}
+
+ParallelMemoryReclaimer::ParallelMemoryReclaimer(folly::Executor* executor)
+    : executor_(executor) {}
+
+uint64_t ParallelMemoryReclaimer::reclaim(
+    memory::MemoryPool* pool,
+    uint64_t targetBytes,
+    uint64_t maxWaitMs,
+    Stats& stats) {
+  if (executor_ == nullptr) {
+    return memory::MemoryReclaimer::reclaim(
+        pool, targetBytes, maxWaitMs, stats);
+  }
+
+  // Sort the child pools based on their reserved memory and reclaim from the
+  // child pool with most reservation first.
+  struct Candidate {
+    std::shared_ptr<memory::MemoryPool> pool;
+    int64_t reclaimableBytes;
+  };
+  std::vector<Candidate> candidates;
+  {
+    std::shared_lock guard{pool->poolMutex_};
+    candidates.reserve(pool->children_.size());
+    for (auto& entry : pool->children_) {
+      auto child = entry.second.lock();
+      if (child != nullptr) {
+        const int64_t reclaimableBytes = child->reclaimableBytes().value_or(0);
+        candidates.push_back(Candidate{std::move(child), reclaimableBytes});
+      }
+    }
+  }
+  struct ReclaimResult {
+    const uint64_t reclaimedBytes{0};
+    const Stats stats;
+    const std::exception_ptr error{nullptr};
+
+    explicit ReclaimResult(std::exception_ptr _error)
+        : reclaimedBytes(0), error(std::move(_error)) {}
+
+    ReclaimResult(uint64_t _reclaimedBytes, Stats&& _stats)
+        : reclaimedBytes(_reclaimedBytes),
+          stats(std::move(_stats)),
+          error(nullptr) {}
+  };
+
+  std::vector<std::shared_ptr<AsyncSource<ReclaimResult>>> reclaimTasks;
+  for (const auto& candidate : candidates) {
+    if (candidate.reclaimableBytes == 0) {
+      continue;
+    }
+    reclaimTasks.push_back(memory::createAsyncMemoryReclaimTask<ReclaimResult>(
+        [&, reclaimPool = candidate.pool]() {
+          try {
+            Stats reclaimStats;
+            const auto bytes =
+                reclaimPool->reclaim(targetBytes, maxWaitMs, reclaimStats);
+            return std::make_unique<ReclaimResult>(
+                bytes, std::move(reclaimStats));
+          } catch (const std::exception& e) {
+            VELOX_MEM_LOG(ERROR) << "Reclaim from memory pool " << pool->name()
+                                 << " failed: " << e.what();
+            // The exception is captured and thrown by the caller.
+            return std::make_unique<ReclaimResult>(std::current_exception());
+          }
+        }));
+    if (reclaimTasks.size() > 1) {
+      executor_->add([source = reclaimTasks.back()]() { source->prepare(); });
+    }
+  }
+
+  auto syncGuard = folly::makeGuard([&]() {
+    for (auto& reclaimTask : reclaimTasks) {
+      // We consume the result for the pending tasks. This is a cleanup in the
+      // guard and must not throw. The first error is already captured before
+      // this runs.
+      try {
+        reclaimTask->move();
+      } catch (const std::exception&) {
+      }
+    }
+  });
+
+  uint64_t reclaimedBytes{0};
+  for (auto& reclaimTask : reclaimTasks) {
+    const auto result = reclaimTask->move();
+    if (result->error) {
+      std::rethrow_exception(result->error);
+    }
+    stats += result->stats;
+    reclaimedBytes += result->reclaimedBytes;
+  }
+  return reclaimedBytes;
+}
+
 void memoryArbitrationStateCheck(memory::MemoryPool& pool) {
   const auto* driverThreadCtx = driverThreadContext();
   if (driverThreadCtx != nullptr) {

--- a/velox/exec/MemoryReclaimer.h
+++ b/velox/exec/MemoryReclaimer.h
@@ -19,7 +19,7 @@
 #include "velox/common/memory/MemoryArbitrator.h"
 
 namespace facebook::velox::exec {
-/// Provides the default memory reclaimer implementation for velox task
+/// Provides the default leaf memory reclaimer implementation for velox task
 /// execution.
 class MemoryReclaimer : public memory::MemoryReclaimer {
  public:
@@ -36,6 +36,28 @@ class MemoryReclaimer : public memory::MemoryReclaimer {
 
  protected:
   MemoryReclaimer() = default;
+};
+
+/// Provides the parallel memory reclaimer implementation for velox task
+/// execution. It parallelize the memory reclamation from all its child memory
+/// pools.
+class ParallelMemoryReclaimer : public memory::MemoryReclaimer {
+ public:
+  virtual ~ParallelMemoryReclaimer() = default;
+
+  static std::unique_ptr<memory::MemoryReclaimer> create(
+      folly::Executor* executor);
+
+  uint64_t reclaim(
+      memory::MemoryPool* pool,
+      uint64_t targetBytes,
+      uint64_t maxWaitMs,
+      Stats& stats) override;
+
+ protected:
+  explicit ParallelMemoryReclaimer(folly::Executor* executor);
+
+  folly::Executor* const executor_{nullptr};
 };
 
 /// Callback used by memory arbitration to check if a driver thread under memory

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -366,7 +366,9 @@ void Operator::recordSpillStats() {
   if (lockedSpillStats->spillReadBytes != 0) {
     lockedStats->addRuntimeStat(
         kSpillReadBytes,
-        RuntimeCounter{static_cast<int64_t>(lockedSpillStats->spillReadBytes)});
+        RuntimeCounter{
+            static_cast<int64_t>(lockedSpillStats->spillReadBytes),
+            RuntimeCounter::Unit::kBytes});
   }
 
   if (lockedSpillStats->spillReads != 0) {

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -444,7 +444,7 @@ void Spiller::runSpill(bool lastRun) {
     }
     writes.push_back(std::make_shared<AsyncSource<SpillStatus>>(
         [partition, this]() { return writeSpill(partition); }));
-    if (executor_) {
+    if ((writes.size() > 1) && executor_ != nullptr) {
       executor_->add([source = writes.back()]() { source->prepare(); });
     }
   }

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -3040,7 +3040,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimEmptyInput) {
           SuspendedSection suspendedSection(driver);
           task->pool()->reclaim(kMaxBytes, 0, stats);
           ASSERT_EQ(stats.numNonReclaimableAttempts, 0);
-          ASSERT_GT(stats.reclaimExecTimeUs, 0);
+          ASSERT_GE(stats.reclaimExecTimeUs, 0);
           ASSERT_EQ(stats.reclaimedBytes, 0);
           ASSERT_GT(stats.reclaimWaitTimeUs, 0);
         }

--- a/velox/exec/tests/MemoryReclaimerTest.cpp
+++ b/velox/exec/tests/MemoryReclaimerTest.cpp
@@ -166,3 +166,98 @@ TEST(ReclaimableSectionGuard, basic) {
   }
   ASSERT_TRUE(nonReclaimableSection);
 }
+
+TEST_F(MemoryReclaimerTest, parallelMemoryReclaimer) {
+  class MockMemoryReclaimer : public memory::MemoryReclaimer {
+   public:
+    static std::unique_ptr<MemoryReclaimer> create(
+        bool reclaimable,
+        uint64_t memoryBytes) {
+      return std::unique_ptr<MemoryReclaimer>(
+          new MockMemoryReclaimer(reclaimable, memoryBytes));
+    }
+
+    bool reclaimableBytes(const MemoryPool& pool, uint64_t& reclaimableBytes)
+        const override {
+      reclaimableBytes = 0;
+      if (!reclaimable_) {
+        return false;
+      }
+      reclaimableBytes = memoryBytes_;
+      return true;
+    }
+
+    uint64_t reclaim(
+        MemoryPool* pool,
+        uint64_t targetBytes,
+        uint64_t maxWaitMs,
+        Stats& stats) override {
+      VELOX_CHECK(reclaimable_);
+      const uint64_t reclaimedBytes = memoryBytes_;
+      memoryBytes_ = 0;
+      return reclaimedBytes;
+    }
+
+    uint64_t memoryBytes() const {
+      return memoryBytes_;
+    }
+
+   private:
+    MockMemoryReclaimer(bool reclaimable, uint64_t memoryBytes)
+        : reclaimable_(reclaimable), memoryBytes_(memoryBytes) {}
+
+    bool reclaimable_{false};
+    int reclaimCount_{0};
+    uint64_t memoryBytes_{0};
+  };
+
+  struct TestReclaimer {
+    bool reclaimable;
+    uint64_t memoryBytes;
+    uint64_t expectedMemoryBytesAfterReclaim;
+  };
+
+  struct {
+    bool hasExecutor;
+    uint64_t bytesToReclaim;
+    std::vector<TestReclaimer> testReclaimers;
+  } testSettings[] = {
+      {false, 100, {{true, 100, 0}, {true, 90, 90}, {false, 200, 200}}},
+      {true, 100, {{true, 100, 0}, {true, 90, 0}, {false, 200, 200}}},
+      {false, 110, {{true, 100, 0}, {true, 90, 0}, {false, 200, 200}}},
+      {true, 110, {{true, 100, 0}, {true, 90, 0}, {false, 200, 200}}},
+      {false, 100, {{true, 100, 100}, {true, 90, 90}, {true, 200, 0}}},
+      {true, 100, {{true, 100, 0}, {true, 90, 0}, {true, 200, 0}}},
+      {false, 80, {{true, 100, 100}, {true, 90, 90}, {true, 200, 0}}},
+      {true, 80, {{true, 100, 0}, {true, 90, 0}, {true, 200, 0}}}};
+
+  for (const auto& testData : testSettings) {
+    auto rootPool = memory::memoryManager()->addRootPool(
+        "parallelMemoryReclaimer",
+        kMaxMemory,
+        exec::ParallelMemoryReclaimer::create(
+            testData.hasExecutor ? executor_.get() : nullptr));
+    std::vector<MockMemoryReclaimer*> memoryReclaimers;
+    std::vector<std::shared_ptr<MemoryPool>> leafPools;
+    int reclaimerIdx{0};
+    for (const auto& testReclaimer : testData.testReclaimers) {
+      auto reclaimer = MockMemoryReclaimer::create(
+          testReclaimer.reclaimable, testReclaimer.memoryBytes);
+      leafPools.push_back(rootPool->addLeafChild(
+          std::to_string(reclaimerIdx++), true, std::move(reclaimer)));
+      memoryReclaimers.push_back(
+          static_cast<MockMemoryReclaimer*>(leafPools.back()->reclaimer()));
+    }
+
+    ScopedMemoryArbitrationContext context(rootPool.get());
+    memory::MemoryReclaimer::Stats stats;
+    rootPool->reclaim(testData.bytesToReclaim, 0, stats);
+    for (int i = 0; i < memoryReclaimers.size(); ++i) {
+      auto* memoryReclaimer = memoryReclaimers[i];
+      ASSERT_EQ(
+          memoryReclaimer->memoryBytes(),
+          testData.testReclaimers[i].expectedMemoryBytesAfterReclaim)
+          << i;
+    }
+  }
+}

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -812,6 +812,9 @@ class VectorTestBase {
   std::shared_ptr<folly::Executor> executor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
           std::thread::hardware_concurrency())};
+  std::shared_ptr<folly::Executor> spillExecutor_{
+      std::make_shared<folly::CPUThreadPoolExecutor>(
+          std::thread::hardware_concurrency())};
 };
 
 } // namespace facebook::velox::test


### PR DESCRIPTION
This PR parallelizes the memory reclamation execution at node level. It also adds
metrics to track the task memory reclamation execution time distribution:
task_memory_reclaim_exec_ms
For unit tests with 6 driver threads, we can almost achieve linear speedup for spill
write path.
For production query,
For a sampled small query
HEAD: 20240517_161638_00001_7q8zr
OPT: 20240517_155605_00004_6zfke
The query execution time has been reduced from 1.3min to 0.9min (1.4x), arbitration time
reduced from 9.9hrs to 2.5hrs (3.8x),  arbitration count reduced from 15,240 to 9,362 (1.6x)

For a sampled medium size qurery
HEAD: 20240517_171503_00001_5tq45
OPT: 20240517_163352_00004_7q8zr
The query execution time has been reduced from 12.4min to 7.8min (1.6x), arbitration time
reduced from 388hrs to 94hrs (4x),  arbitration count reduced from 517,570 to 194,999 (2.6x)

Task level memory reclamation count drops by half: https://fburl.com/ods/8pq6b81o

This PR also fixes some memory related flaky tests.