### PR TITLE
Do not return dictionaries with large alphabet from Unnest

### DIFF
--- a/velox/exec/Unnest.h
+++ b/velox/exec/Unnest.h
@@ -61,6 +61,8 @@ class Unnest : public Operator {
     BufferPtr indices;
     BufferPtr nulls;
     bool identityMapping;
+
+    VectorPtr wrap(const VectorPtr& base, vector_size_t wrapSize) const;
   };
 
   // Invoked by generateOutput above to generate the encoding for the unnested
@@ -80,7 +82,6 @@ class Unnest : public Operator {
   const bool withOrdinality_;
   std::vector<column_index_t> unnestChannels_;
 
-  SelectivityVector inputRows_;
   std::vector<DecodedVector> unnestDecoded_;
 
   BufferPtr maxSizes_;


### PR DESCRIPTION
Unnest applied to large arrays (100s of elements each) produces dictionary
vectors that are inefficient to process.

Consider a batch of 1000 rows where each array has 500 elements. The elements
vector of the ArrayVector has 500 * 1000 = 500K rows, hence, the total output
of Unnest contains 500K rows. 

Unnest produces output in batches of 1000 rows, i.e. every 2 input rows produce
an output batch. An input batch of 1000 rows generates 500 batches of output.

First batch produces a dictionary vector with indices [0...999]. 2nd batch -
[1000...1999]. 251th batch produces a dictionary vector with indices
[250000...250999].

When evaluating an expression over such dictionary vector, say cast(c as
varchar), expression evaluation engine peels off dictionary and evaluates the
expression on a subset of a 1000 rows of the base vector of size 500K. To
produce a result, the expression needs to allocate a vector of size
<max-row-number + 1> and populate 1000 values. Allocating such a large vector
is slow, especially, when vector type is VARCHAR and its 'values' buffer needs
to be zeroed out.

One fix could be to optimize expression evaluation to avoid peeling dictionaries
with large alphabets. Another option is to avoid producing such dictionary
vectors in Unnest.

Changing expression evaluation is challenging because the code is rather complex
and it is hard to reason about all the cases that need to be updated and
tested. Hence, this diff is changing Unnest.

Differential Revision: D57439691


