### PR TITLE
[Do not review] Add support for Presto temporary tables SPI

### DIFF
--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -42,6 +42,8 @@ class LocationHandle : public ISerializable {
     kNew,
     /// Write to an existing table.
     kExisting,
+    /// Write to a temporary table.
+    kTemporary,
   };
 
   LocationHandle(
@@ -246,6 +248,8 @@ class HiveInsertTableHandle : public ConnectorInsertTableHandle {
   const HiveBucketProperty* bucketProperty() const;
 
   bool isExistingTable() const;
+
+  bool isTemporaryTable() const;
 
   folly::dynamic serialize() const override;
 


### PR DESCRIPTION
Presto doesn't support TEMPORARY tables externally via SQL, but supports them in an SPI https://github.com/prestodb/presto/pull/12464 that is used by CTE ref https://github.com/prestodb/presto/blob/master/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PhysicalCteOptimizer.java

TEMPORARY tables are always bucketed but not partitioned. The SPI only follows a pattern of INSERT following CREATE of tables. It doesn't support CTAS. So temporary tables are always Append mode in the HiveDataSink writes.

To support such TEMPORARY table use in Velox, we need to separate this mode in the HiveDataSink LocationHandle and always use Append mode for it in DataSink writes. The Velox changes are only limited to this writing. All other special Temporary table handling is specific to the commit processing that happens in the TableFinishOperator in the co-ordinator.

Presto CTE PR where this will be used https://github.com/prestodb/presto/pull/22780.