### PR TITLE
Remove unused variables in velox/common/base/tests/ScratchTest.cpp

### DIFF
--- a/velox/common/base/tests/ScratchTest.cpp
+++ b/velox/common/base/tests/ScratchTest.cpp
@@ -35,7 +35,6 @@ TEST(ScratchTest, basic) {
   {
     ScratchPtr<int32_t> ints(scratch);
     ScratchPtr<int64_t> longs(scratch);
-    auto tempLongs = longs.get(2000);
     auto tempInts = ints.get(1000);
     std::fill(tempInts, tempInts + 1000, -1);
     std::fill(tempInts, tempInts + 2000, -1);

--- a/velox/common/base/tests/SimdUtilTest.cpp
+++ b/velox/common/base/tests/SimdUtilTest.cpp
@@ -157,7 +157,6 @@ TEST_F(SimdUtilTest, gather32) {
 
 TEST_F(SimdUtilTest, gather64) {
   int32_t indices4[4] = {3, 2, 1, 0};
-  int32_t indices3[4] = {3, 2, 1, 1 << 31};
   int64_t data[4] = {44, 55, 66, 77};
   constexpr int kBatchSize = xsimd::batch<int64_t>::size;
   const int32_t* indices = indices4 + (4 - kBatchSize);

--- a/velox/common/caching/tests/CachedFactoryTest.cpp
+++ b/velox/common/caching/tests/CachedFactoryTest.cpp
@@ -134,7 +134,7 @@ TEST(CachedFactoryTest, basicExceptionHandling) {
   EXPECT_EQ(getCachedValue(val1), 2);
   EXPECT_EQ(*generated, 1);
   try {
-    auto val2 = factory.generate(3);
+    [[maybe_unused]] auto val2 = factory.generate(3);
     FAIL() << "Factory generation should have failed";
   } catch (const std::invalid_argument&) {
     // Expected.

--- a/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
@@ -94,7 +94,6 @@ template <typename ColumnVisitor>
 void SelectiveByteRleColumnReader::readWithVisitor(
     RowSet rows,
     ColumnVisitor visitor) {
-  vector_size_t numRows = rows.back() + 1;
   if (boolRle_) {
     if (nullsInReadRange_) {
       boolRle_->readWithVisitor<true>(

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -846,7 +846,6 @@ void GroupingSet::ensureInputFits(const RowVectorPtr& input) {
   auto [freeRows, outOfLineFreeBytes] = rows->freeSpace();
   const auto outOfLineBytes =
       rows->stringAllocator().retainedSize() - outOfLineFreeBytes;
-  const auto outOfLineBytesPerRow = outOfLineBytes / numDistinct;
   const int64_t flatBytes = input->estimateFlatSize();
 
   // Test-only spill path.

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -444,8 +444,6 @@ void HashBuild::ensureInputFits(RowVectorPtr& input) {
   auto [freeRows, outOfLineFreeBytes] = rows->freeSpace();
   const auto outOfLineBytes =
       rows->stringAllocator().retainedSize() - outOfLineFreeBytes;
-  const auto outOfLineBytesPerRow =
-      std::max<uint64_t>(1, numRows == 0 ? 0 : outOfLineBytes / numRows);
   const auto currentUsage = pool()->currentBytes();
 
   if (numRows != 0) {

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1857,7 +1857,6 @@ void HashProbe::prepareTableSpill(
     names.emplace_back(tableInputType->nameOf(channel));
     types.emplace_back(tableInputType->childAt(channel));
   }
-  const auto numDependents = tableInputType->size() - numKeys;
   for (auto i = 0; i < tableInputType->size(); ++i) {
     if (keyChannelMap.find(i) == keyChannelMap.end()) {
       names.emplace_back(tableInputType->nameOf(i));

--- a/velox/experimental/wave/common/tests/HashTestUtil.cpp
+++ b/velox/experimental/wave/common/tests/HashTestUtil.cpp
@@ -157,8 +157,6 @@ void setupGpuTable(
   table->sizeMask = numBuckets - 1;
   char* data = reinterpret_cast<char*>(table + 1);
   table->allocators = reinterpret_cast<RowAllocator*>(data);
-  auto allocatorBase =
-      reinterpret_cast<HashPartitionAllocator*>(table->allocators);
   data += sizeof(HashPartitionAllocator);
   auto freeSet = reinterpret_cast<FreeSetType*>(data);
   new (freeSet) FreeSetType();

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -4241,7 +4241,6 @@ void PrestoVectorSerde::deserializeSingleColumn(
   VELOX_CHECK_EQ(
       prestoOptions.compressionKind,
       common::CompressionKind::CompressionKind_NONE);
-  const bool useLosslessTimestamp = prestoOptions.useLosslessTimestamp;
 
   if (*result && result->unique()) {
     VELOX_CHECK(


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: palmje

Differential Revision: D57344002


