### PR TITLE
Fix map_top_n to break ties by comparing keys

### DIFF
--- a/velox/docs/functions/presto/map.rst
+++ b/velox/docs/functions/presto/map.rst
@@ -96,7 +96,8 @@ Map Functions
 
 .. function:: map_top_n(map(K,V), n) -> map(K, V)
 
-    Truncates map items. Keeps only the top N elements by value.
+    Truncates map items. Keeps only the top N elements by value. Keys are used to break ties on non-NULL values. Both keys and values should be orderable.
+
     ``n`` must be a non-negative BIGINT value.::
 
         SELECT map_top_n(map(ARRAY['a', 'b', 'c'], ARRAY[2, 3, 1]), 2) --- {'b' -> 3, 'a' -> 2}

--- a/velox/docs/functions/presto/map.rst
+++ b/velox/docs/functions/presto/map.rst
@@ -96,7 +96,7 @@ Map Functions
 
 .. function:: map_top_n(map(K,V), n) -> map(K, V)
 
-    Truncates map items. Keeps only the top N elements by value. Keys are used to break ties on non-NULL values. Both keys and values should be orderable.
+    Truncates map items. Keeps only the top N elements by value. Keys are used to break ties with the max key being chosen. Both keys and values should be orderable.
 
     ``n`` must be a non-negative BIGINT value.::
 

--- a/velox/functions/prestosql/MapTopN.h
+++ b/velox/functions/prestosql/MapTopN.h
@@ -41,6 +41,9 @@ struct MapTopNFunction {
         }
 
         return comp > 0;
+      } else if (FOLLY_UNLIKELY(
+                     l->second.has_value() && r->second.has_value())) {
+        return l->first.compare(r->first, flags) > 0;
       }
 
       return l->second.has_value();

--- a/velox/functions/prestosql/MapTopN.h
+++ b/velox/functions/prestosql/MapTopN.h
@@ -34,7 +34,13 @@ struct MapTopNFunction {
           CompareFlags::NullHandlingMode::kNullAsIndeterminate};
 
       if (l->second.has_value() && r->second.has_value()) {
-        return l->second.value().compare(r->second.value(), flags) > 0;
+        auto comp = l->second.value().compare(r->second.value(), flags);
+
+        if (FOLLY_UNLIKELY(comp == 0)) {
+          return l->first.compare(r->first, flags) > 0;
+        }
+
+        return comp > 0;
       }
 
       return l->second.has_value();
@@ -42,8 +48,8 @@ struct MapTopNFunction {
   };
 
   void call(
-      out_type<Map<Generic<T1>, Orderable<T2>>>& out,
-      const arg_type<Map<Generic<T1>, Orderable<T2>>>& inputMap,
+      out_type<Map<Orderable<T1>, Orderable<T2>>>& out,
+      const arg_type<Map<Orderable<T1>, Orderable<T2>>>& inputMap,
       int64_t n) {
     VELOX_USER_CHECK_GE(n, 0, "n must be greater than or equal to 0")
 
@@ -56,7 +62,7 @@ struct MapTopNFunction {
       return;
     }
 
-    using It = typename arg_type<Map<Generic<T1>, Orderable<T2>>>::Iterator;
+    using It = typename arg_type<Map<Orderable<T1>, Orderable<T2>>>::Iterator;
 
     Compare<It> comparator;
 

--- a/velox/functions/prestosql/registration/MapFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/MapFunctionsRegistration.cpp
@@ -92,8 +92,8 @@ void registerMapFunctions(const std::string& prefix) {
 
   registerFunction<
       MapTopNFunction,
-      Map<Generic<T1>, Orderable<T2>>,
-      Map<Generic<T1>, Orderable<T2>>,
+      Map<Orderable<T1>, Orderable<T2>>,
+      Map<Orderable<T1>, Orderable<T2>>,
       int64_t>({prefix + "map_top_n"});
 
   registerMapSubset(prefix);

--- a/velox/functions/prestosql/tests/MapTopNTest.cpp
+++ b/velox/functions/prestosql/tests/MapTopNTest.cpp
@@ -66,5 +66,53 @@ TEST_F(MapTopNTest, basic) {
       "n must be greater than or equal to 0");
 }
 
+// Test to ensure we use keys to break ties if values are
+// equal.
+TEST_F(MapTopNTest, equalValues) {
+  auto data = makeRowVector({
+      makeMapVectorFromJson<int32_t, int64_t>({
+          "{6:3, 2:5, 3:1, 4:4, 5:2, 1:3}",
+          "{1:3, 2:5, 3:null, 4:4, 5:2, 6:5 }",
+          "{1:null, 2:null, 3:1, 4:4, 5:null}",
+      }),
+  });
+
+  auto result = evaluate("map_top_n(c0, 3)", data);
+
+  auto expected = makeMapVectorFromJson<int32_t, int64_t>({
+      "{2:5, 4:4, 6:3}",
+      "{6:5, 2:5, 4:4}",
+      "{4:4, 3:1, 5:null}",
+  });
+
+  assertEqualVectors(expected, result);
+
+  // Map vector with equal array's as values.
+  auto valuesVector = makeArrayVectorFromJson<int64_t>({
+      "[1, 2, 3]",
+      "[4, 5, 6]",
+      "[-1, -2, -3]",
+      "[1, 2, 3]",
+  });
+
+  auto keysVector = makeFlatVector<int32_t>({1, 2, 3, 4});
+
+  auto mapvector = makeMapVector({0, 4}, keysVector, valuesVector);
+
+  result = evaluate("map_top_n(c0, 3)", makeRowVector({mapvector}));
+
+  auto expectedValues = makeArrayVectorFromJson<int64_t>({
+      "[1, 2, 3]",
+      "[4, 5, 6]",
+      "[1, 2, 3]",
+  });
+
+  auto expectedKeys = makeFlatVector<int32_t>({1, 2, 4});
+
+  auto expectedResults = makeMapVector({0, 3}, expectedKeys, expectedValues);
+
+  assertEqualVectors(expectedResults, result);
+}
+
 } // namespace
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/MapTopNTest.cpp
+++ b/velox/functions/prestosql/tests/MapTopNTest.cpp
@@ -70,20 +70,20 @@ TEST_F(MapTopNTest, basic) {
 // equal.
 TEST_F(MapTopNTest, equalValues) {
   auto data = makeRowVector({
-      makeMapVectorFromJson<int32_t, int64_t>({
-          "{6:3, 2:5, 3:1, 4:4, 5:2, 1:3}",
-          "{1:3, 2:5, 3:null, 4:4, 5:2, 6:5 }",
-          "{1:null, 2:null, 3:1, 4:4, 5:null}",
-      }),
+      makeMapVectorFromJson<int32_t, int64_t>(
+          {"{6:3, 2:5, 3:1, 4:4, 5:2, 1:3}",
+           "{1:3, 2:5, 3:null, 4:4, 5:2, 6:5 }",
+           "{1:null, 2:null, 3:1, 4:4, 5:null}",
+           "{1:null, 2:null, 3:null, 4:null, 5:null}"}),
   });
 
   auto result = evaluate("map_top_n(c0, 3)", data);
 
-  auto expected = makeMapVectorFromJson<int32_t, int64_t>({
-      "{2:5, 4:4, 6:3}",
-      "{6:5, 2:5, 4:4}",
-      "{4:4, 3:1, 5:null}",
-  });
+  auto expected = makeMapVectorFromJson<int32_t, int64_t>(
+      {"{2:5, 4:4, 6:3}",
+       "{6:5, 2:5, 4:4}",
+       "{4:4, 3:1, 5:null}",
+       "{4:null, 3:null, 5:null}"});
 
   assertEqualVectors(expected, result);
 


### PR DESCRIPTION
Presto Java internally breaks ties between equal non-null values in map_top_n by using the one with the larger key value.
(See : 
https://github.com/prestodb/presto/blob/0edb84cc8e2f825e257c558143edca1e154f8a72/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/MapSqlFunctions.java#L57 ). This change fixes it to be equivalent to presto behavior. 