### PR TITLE
Add float/double types support for Spark mod function

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -246,6 +246,7 @@ Mathematical Functions
 .. spark:function:: remainder(n, m) -> [same as n]
 
     Returns the modulus (remainder) of ``n`` divided by ``m``. Corresponds to Spark's operator ``%``.
+    Supported types are: TINYINT, SMALLINT, INTEGER, BIGINT, REAL and DOUBLE.
 
 .. spark:function:: rint(x) -> double
 

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -46,7 +46,7 @@ struct RemainderFunction {
 
  private:
   template <typename TInput>
-  inline void handle_floating_point(TInput& result, const TInput& a, const TInput& n) {
+  void handle_floating_point(TInput& result, const TInput& a, const TInput& n) {
     if (std::isnan(a) || std::isnan(n) || std::isinf(a)) {
       result = std::numeric_limits<TInput>::quiet_NaN();
     } else if (std::isinf(n)) {
@@ -57,8 +57,11 @@ struct RemainderFunction {
   }
 
   template <typename TInput>
-  inline void handle_integral(TInput& result, const TInput& a, const TInput& n) {
-    if (n == 1 || n == -1) {
+  void handle_integral(TInput& result, const TInput& a, const TInput& n) {
+    // std::numeric_limits<int64_t>::min() % -1 could crash the program since
+    // abs(std::numeric_limits<int64_t>::min()) can not be represented in
+    // int64_t.
+    if (UNLIKELY(n == 1 || n == -1)) {
       result = 0;
     } else {
       result = a % n;

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -45,19 +45,15 @@ struct RemainderFunction {
   }
 
  private:
-  /**
-     * Handles the floating-point remainder operation, addressing special cases.
-     *
-     * Cases handled:
-     * 1. If 'a' or 'n' is NaN, or if 'a' is infinity, the result is set to NaN.
-     * 2. If 'n' is infinity, the result is set to 'a'.
-     * 3. Otherwise, the result is the remainder of 'a' divided by 'n' using std::fmod.
-     */
   template <typename TInput>
   void handleFloatingPoint(TInput& result, const TInput a, const TInput n) {
+    // If either the dividend or the divisor is NaN, or if the dividend is
+    // infinity, the result is set to NaN.
     if (UNLIKELY(std::isnan(a) || std::isnan(n) || std::isinf(a))) {
       result = std::numeric_limits<TInput>::quiet_NaN();
-    } else if (UNLIKELY(std::isinf(n))) {
+    }
+    // If the divisor is infinity, the result is equal as the dividend.
+    else if (UNLIKELY(std::isinf(n))) {
       result = a;
     } else {
       result = std::fmod(a, n);

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -42,7 +42,11 @@ struct RemainderFunction {
     if (UNLIKELY(n == 1 || n == -1)) {
       result = 0;
     } else if constexpr (std::is_same_v<TInput, float> || std::is_same_v<TInput, double>) {
-      result = std::fmod(a, n);
+      if (std::isnan(a) || std::isnan(n) || std::isinf(a) || std::isinf(n)) {
+        result = std::numeric_limits<TInput>::quiet_NaN();
+      } else {
+        result = std::fmod(a, n);
+      }
     } else {
       result = a % n;
     }

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -37,24 +37,32 @@ struct RemainderFunction {
       return false;
     }
     if constexpr (std::is_floating_point_v<TInput>) {
-      if (std::isnan(a) || std::isnan(n) || std::isinf(a)) {
-        result = std::numeric_limits<TInput>::quiet_NaN();
-      } else if (std::isinf(n)) {
-        result = a;
-      } else {
-        result = std::fmod(a, n);
-      }
+      handle_floating_point(result, a, n);
     } else {
-      // std::numeric_limits<int64_t>::min() % -1 could crash the program since
-      // abs(std::numeric_limits<int64_t>::min()) can not be represented in
-      // int64_t.
-      if (n == 1 || n == -1) {
-        result = 0;
-      } else {
-        result = a % n;
-      }
+      handle_integral(result, a, n);
     }
     return true;
+  }
+
+ private:
+  template <typename TInput>
+  inline void handle_floating_point(TInput& result, const TInput& a, const TInput& n) {
+    if (std::isnan(a) || std::isnan(n) || std::isinf(a)) {
+      result = std::numeric_limits<TInput>::quiet_NaN();
+    } else if (std::isinf(n)) {
+      result = a;
+    } else {
+      result = std::fmod(a, n);
+    }
+  }
+
+  template <typename TInput>
+  inline void handle_integral(TInput& result, const TInput& a, const TInput& n) {
+    if (n == 1 || n == -1) {
+      result = 0;
+    } else {
+      result = a % n;
+    }
   }
 };
 

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -49,6 +49,23 @@ struct RemainderFunction {
 };
 
 template <typename T>
+struct RemainderFloatFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput a, const TInput n) {
+    if (UNLIKELY(n == 0)) {
+      return false;
+    }
+    if (UNLIKELY(n == 1 || n == -1)) {
+      result = 0;
+    } else {
+      result = std::fmod(a, n);
+    }
+    return true;
+  }
+};
+
+template <typename T>
 struct PModIntFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE bool call(TInput& result, const TInput a, const TInput n)

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -37,16 +37,16 @@ struct RemainderFunction {
       return false;
     }
     if constexpr (std::is_floating_point_v<TInput>) {
-      handle_floating_point(result, a, n);
+      handleFloatingPoint(result, a, n);
     } else {
-      handle_integral(result, a, n);
+      handleIntegral(result, a, n);
     }
     return true;
   }
 
  private:
   template <typename TInput>
-  void handle_floating_point(TInput& result, const TInput& a, const TInput& n) {
+  void handleFloatingPoint(TInput& result, const TInput& a, const TInput& n) {
     if (std::isnan(a) || std::isnan(n) || std::isinf(a)) {
       result = std::numeric_limits<TInput>::quiet_NaN();
     } else if (std::isinf(n)) {
@@ -57,7 +57,7 @@ struct RemainderFunction {
   }
 
   template <typename TInput>
-  void handle_integral(TInput& result, const TInput& a, const TInput& n) {
+  void handleIntegral(TInput& result, const TInput& a, const TInput& n) {
     // std::numeric_limits<int64_t>::min() % -1 could crash the program since
     // abs(std::numeric_limits<int64_t>::min()) can not be represented in
     // int64_t.

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -36,19 +36,23 @@ struct RemainderFunction {
     if (UNLIKELY(n == 0)) {
       return false;
     }
-    // std::numeric_limits<int64_t>::min() % -1 could crash the program since
-    // abs(std::numeric_limits<int64_t>::min()) can not be represented in
-    // int64_t.
-    if (UNLIKELY(n == 1 || n == -1)) {
-      result = 0;
-    } else if constexpr (std::is_same_v<TInput, float> || std::is_same_v<TInput, double>) {
-      if (std::isnan(a) || std::isnan(n) || std::isinf(a) || std::isinf(n)) {
+    if constexpr (std::is_floating_point_v<TInput>) {
+      if (std::isnan(a) || std::isnan(n) || std::isinf(a)) {
         result = std::numeric_limits<TInput>::quiet_NaN();
+      } else if (std::isinf(n)) {
+        result = a;
       } else {
         result = std::fmod(a, n);
       }
     } else {
-      result = a % n;
+      // std::numeric_limits<int64_t>::min() % -1 could crash the program since
+      // abs(std::numeric_limits<int64_t>::min()) can not be represented in
+      // int64_t.
+      if (n == 1 || n == -1) {
+        result = 0;
+      } else {
+        result = a % n;
+      }
     }
     return true;
   }

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -45,11 +45,19 @@ struct RemainderFunction {
   }
 
  private:
+  /**
+     * Handles the floating-point remainder operation, addressing special cases.
+     *
+     * Cases handled:
+     * 1. If 'a' or 'n' is NaN, or if 'a' is infinity, the result is set to NaN.
+     * 2. If 'n' is infinity, the result is set to 'a'.
+     * 3. Otherwise, the result is the remainder of 'a' divided by 'n' using std::fmod.
+     */
   template <typename TInput>
-  void handleFloatingPoint(TInput& result, const TInput& a, const TInput& n) {
-    if (std::isnan(a) || std::isnan(n) || std::isinf(a)) {
+  void handleFloatingPoint(TInput& result, const TInput a, const TInput n) {
+    if (UNLIKELY(std::isnan(a) || std::isnan(n) || std::isinf(a))) {
       result = std::numeric_limits<TInput>::quiet_NaN();
-    } else if (std::isinf(n)) {
+    } else if (UNLIKELY(std::isinf(n))) {
       result = a;
     } else {
       result = std::fmod(a, n);
@@ -57,7 +65,7 @@ struct RemainderFunction {
   }
 
   template <typename TInput>
-  void handleIntegral(TInput& result, const TInput& a, const TInput& n) {
+  void handleIntegral(TInput& result, const TInput a, const TInput n) {
     // std::numeric_limits<int64_t>::min() % -1 could crash the program since
     // abs(std::numeric_limits<int64_t>::min()) can not be represented in
     // int64_t.

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -41,25 +41,10 @@ struct RemainderFunction {
     // int64_t.
     if (UNLIKELY(n == 1 || n == -1)) {
       result = 0;
+    } else if constexpr (std::is_same_v<TInput, float> || std::is_same_v<TInput, double>) {
+      result = std::fmod(a, n);
     } else {
       result = a % n;
-    }
-    return true;
-  }
-};
-
-template <typename T>
-struct RemainderFloatFunction {
-  template <typename TInput>
-  FOLLY_ALWAYS_INLINE bool
-  call(TInput& result, const TInput a, const TInput n) {
-    if (UNLIKELY(n == 0)) {
-      return false;
-    }
-    if (UNLIKELY(n == 1 || n == -1)) {
-      result = 0;
-    } else {
-      result = std::fmod(a, n);
     }
     return true;
   }

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -36,6 +36,7 @@ void registerArithmeticFunctions(const std::string& prefix) {
   registerBinaryNumeric<MultiplyFunction>({prefix + "multiply"});
   registerFunction<DivideFunction, double, double, double>({prefix + "divide"});
   registerBinaryIntegral<RemainderFunction>({prefix + "remainder"});
+  registerBinaryFloatingPoint<RemainderFloatFunction>({prefix + "remainder"});
   registerUnaryNumeric<UnaryMinusFunction>({prefix + "unaryminus"});
   // Math functions.
   registerUnaryNumeric<AbsFunction>({prefix + "abs"});

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -35,8 +35,7 @@ void registerArithmeticFunctions(const std::string& prefix) {
   registerBinaryNumeric<MinusFunction>({prefix + "subtract"});
   registerBinaryNumeric<MultiplyFunction>({prefix + "multiply"});
   registerFunction<DivideFunction, double, double, double>({prefix + "divide"});
-  registerBinaryIntegral<RemainderFunction>({prefix + "remainder"});
-  registerBinaryFloatingPoint<RemainderFloatFunction>({prefix + "remainder"});
+  registerBinaryNumeric<RemainderFunction>({prefix + "remainder"});
   registerUnaryNumeric<UnaryMinusFunction>({prefix + "unaryminus"});
   // Math functions.
   registerUnaryNumeric<AbsFunction>({prefix + "abs"});

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -91,11 +91,6 @@ class RemainderTest : public SparkFunctionBaseTest {
   std::optional<T> remainder(std::optional<T> a, std::optional<T> n) {
     return evaluateOnce<T>("remainder(c0, c1)", a, n);
   };
-
-  template <typename T>
-  T remainder_value(std::optional<T> a, std::optional<T> b) {
-    return remainder<T>(a, b).value();
-  }
 };
 
 TEST_F(RemainderTest, int8) {
@@ -141,36 +136,44 @@ TEST_F(RemainderTest, int64) {
 TEST_F(RemainderTest, double) {
   constexpr double kInf = std::numeric_limits<double>::infinity();
   constexpr double kNan = std::numeric_limits<double>::quiet_NaN();
-  EXPECT_DOUBLE_EQ(0.0, remainder_value<double>(2.0, 1.0));
-  EXPECT_DOUBLE_EQ(1.0, remainder_value<double>(5.0, 2.0));
-  EXPECT_DOUBLE_EQ(-1.0, remainder_value<double>(-5.0, 2.0));
-  EXPECT_DOUBLE_EQ(0.5, remainder_value<double>(1.5, 1.0));
-  EXPECT_DOUBLE_EQ(0.0, remainder_value<double>(0.0, 1.0));
-  EXPECT_DOUBLE_EQ(2.0, remainder_value<double>(2.0, kInf));
+  const auto remainderDouble = [&](std::optional<double> a, std::optional<double> b) {
+    return remainder(a, b).value();
+  }
 
-  EXPECT_TRUE(std::isnan(remainder_value<double>(kNan, 1.0)));
-  EXPECT_TRUE(std::isnan(remainder_value<double>(1.0, kNan)));
-  EXPECT_TRUE(std::isnan(remainder_value<double>(kInf, 1.0)));
-  EXPECT_TRUE(std::isnan(remainder_value<double>(-kInf, 1.0)));
-  EXPECT_TRUE(std::isnan(remainder_value<double>(kInf, kInf)));
+  EXPECT_DOUBLE_EQ(0.0, remainderDouble(2.0, 1.0));
+  EXPECT_DOUBLE_EQ(1.0, remainderDouble(5.0, 2.0));
+  EXPECT_DOUBLE_EQ(-1.0, remainderDouble(-5.0, 2.0));
+  EXPECT_DOUBLE_EQ(0.5, remainderDouble(1.5, 1.0));
+  EXPECT_DOUBLE_EQ(0.0, remainderDouble(0.0, 1.0));
+  EXPECT_DOUBLE_EQ(2.0, remainderDouble(2.0, kInf));
+
+  EXPECT_TRUE(std::isnan(remainderDouble(kNan, 1.0)));
+  EXPECT_TRUE(std::isnan(remainderDouble(1.0, kNan)));
+  EXPECT_TRUE(std::isnan(remainderDouble(kInf, 1.0)));
+  EXPECT_TRUE(std::isnan(remainderDouble(-kInf, 1.0)));
+  EXPECT_TRUE(std::isnan(remainderDouble(kInf, kInf)));
 }
 
 TEST_F(RemainderTest, float) {
   constexpr double kInf = std::numeric_limits<float>::infinity();
   constexpr double kNan = std::numeric_limits<float>::quiet_NaN();
-  EXPECT_FLOAT_EQ(0.0f, remainder_value<float>(2.0f, 1.0f));
-  EXPECT_FLOAT_EQ(1.0f, remainder_value<float>(5.0f, 2.0f));
-  EXPECT_FLOAT_EQ(-1.0f, remainder_value<float>(-5.0f, 2.0f));
-  EXPECT_FLOAT_EQ(0.5f, remainder_value<float>(1.5f, 1.0f));
-  EXPECT_FLOAT_EQ(0.0f, remainder_value<float>(0.0f, 1.0f));
-  EXPECT_FLOAT_EQ(2.0f, remainder_value<float>(2.0f, kInf));
+  const auto remainderFloat = [&](std::optional<float> a, std::optional<float> b) {
+    return remainder(a, b).value();
+  }
 
-  EXPECT_EQ(std::nullopt, remainder<float>(2.0, 0.0));
-  EXPECT_TRUE(std::isnan(remainder_value<float>(kNan, 1.0f)));
-  EXPECT_TRUE(std::isnan(remainder_value<float>(1.0f, kNan)));
-  EXPECT_TRUE(std::isnan(remainder_value<float>(kInf, 1.0f)));
-  EXPECT_TRUE(std::isnan(remainder_value<float>(-kInf, 1.0f)));
-  EXPECT_TRUE(std::isnan(remainder_value<float>(kInf, kInf)));
+  EXPECT_FLOAT_EQ(0.0f, remainderFloat(2.0f, 1.0f));
+  EXPECT_FLOAT_EQ(1.0f, remainderFloat(5.0f, 2.0f));
+  EXPECT_FLOAT_EQ(-1.0f, remainderFloat(-5.0f, 2.0f));
+  EXPECT_FLOAT_EQ(0.5f, remainderFloat(1.5f, 1.0f));
+  EXPECT_FLOAT_EQ(0.0f, remainderFloat(0.0f, 1.0f));
+  EXPECT_FLOAT_EQ(2.0f, remainderFloat(2.0f, kInf));
+
+  EXPECT_EQ(std::nullopt, remainderFloat(2.0, 0.0));
+  EXPECT_TRUE(std::isnan(remainderFloat(kNan, 1.0f)));
+  EXPECT_TRUE(std::isnan(remainderFloat(1.0f, kNan)));
+  EXPECT_TRUE(std::isnan(remainderFloat(kInf, 1.0f)));
+  EXPECT_TRUE(std::isnan(remainderFloat(-kInf, 1.0f)));
+  EXPECT_TRUE(std::isnan(remainderFloat(kInf, kInf)));
 }
 
 class ArithmeticTest : public SparkFunctionBaseTest {

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -91,6 +91,11 @@ class RemainderTest : public SparkFunctionBaseTest {
   std::optional<T> remainder(std::optional<T> a, std::optional<T> n) {
     return evaluateOnce<T>("remainder(c0, c1)", a, n);
   };
+
+  template <typename T>
+  T remainder_value(std::optional<T> a, std::optional<T> b) {
+    return remainder<T>(a, b).value();
+  }
 };
 
 TEST_F(RemainderTest, int8) {
@@ -134,35 +139,34 @@ TEST_F(RemainderTest, int64) {
 }
 
 TEST_F(RemainderTest, double) {
-  EXPECT_DOUBLE_EQ(0.0f, remainder<double>(2.0, 1.0).value());
-  EXPECT_DOUBLE_EQ(1.0f, remainder<double>(5.0, 2.0).value());
-  EXPECT_DOUBLE_EQ(-1.0f, remainder<double>(-5.0, 2.0).value());
-  EXPECT_DOUBLE_EQ(0.5f, remainder<double>(1.5, 1.0).value());
-  EXPECT_DOUBLE_EQ(0.0f, remainder<double>(0.0, 1.0).value());
-  EXPECT_DOUBLE_EQ(2.0f, remainder<double>(2.0, std::numeric_limits<double>::infinity()).value());
+  EXPECT_DOUBLE_EQ(0.0, remainder_value<double>(2.0, 1.0));
+  EXPECT_DOUBLE_EQ(1.0, remainder_value<double>(5.0, 2.0));
+  EXPECT_DOUBLE_EQ(-1.0, remainder_value<double>(-5.0, 2.0));
+  EXPECT_DOUBLE_EQ(0.5, remainder_value<double>(1.5, 1.0));
+  EXPECT_DOUBLE_EQ(0.0, remainder_value<double>(0.0, 1.0));
+  EXPECT_DOUBLE_EQ(2.0, remainder_value<double>(2.0, std::numeric_limits<double>::infinity()));
 
-  EXPECT_EQ(std::nullopt, remainder<double>(2.0, 0.0));
-  EXPECT_TRUE(std::isnan(remainder<double>(std::numeric_limits<double>::quiet_NaN(), 1.0).value()));
-  EXPECT_TRUE(std::isnan(remainder<double>(1.0, std::numeric_limits<double>::quiet_NaN()).value()));
-  EXPECT_TRUE(std::isnan(remainder<double>(std::numeric_limits<double>::infinity(), 1.0).value()));
-  EXPECT_TRUE(std::isnan(remainder<double>(-std::numeric_limits<double>::infinity(), 1.0).value()));
-  EXPECT_TRUE(std::isnan(remainder<double>(std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()).value()));
+  EXPECT_TRUE(std::isnan(remainder_value<double>(std::numeric_limits<double>::quiet_NaN(), 1.0)));
+  EXPECT_TRUE(std::isnan(remainder_value<double>(1.0, std::numeric_limits<double>::quiet_NaN())));
+  EXPECT_TRUE(std::isnan(remainder_value<double>(std::numeric_limits<double>::infinity(), 1.0)));
+  EXPECT_TRUE(std::isnan(remainder_value<double>(-std::numeric_limits<double>::infinity(), 1.0)));
+  EXPECT_TRUE(std::isnan(remainder_value<double>(std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity())));
 }
 
 TEST_F(RemainderTest, float) {
-  EXPECT_FLOAT_EQ(0.0, remainder<float>(0.3, 0.3).value());
-  EXPECT_FLOAT_EQ(0.2, remainder<float>(0.5, 0.3).value());
-  EXPECT_FLOAT_EQ(-1.1, remainder<float>(-1.1, 2).value());
-  EXPECT_EQ(std::nullopt, remainder<float>(2.14159, 0.0));
-  EXPECT_FLOAT_EQ(0.1, remainder<float>(0.7, -0.3).value());
-  EXPECT_FLOAT_EQ(2.0f, remainder<float>(2.0f, std::numeric_limits<float>::infinity()).value());
+  EXPECT_FLOAT_EQ(0.0f, remainder_value<float>(2.0f, 1.0f));
+  EXPECT_FLOAT_EQ(1.0f, remainder_value<float>(5.0f, 2.0f));
+  EXPECT_FLOAT_EQ(-1.0f, remainder_value<float>(-5.0f, 2.0f));
+  EXPECT_FLOAT_EQ(0.5f, remainder_value<float>(1.5f, 1.0f));
+  EXPECT_FLOAT_EQ(0.0f, remainder_value<float>(0.0f, 1.0f));
+  EXPECT_FLOAT_EQ(2.0f, remainder_value<float>(2.0f, std::numeric_limits<float>::infinity()));
 
   EXPECT_EQ(std::nullopt, remainder<float>(2.0, 0.0));
-  EXPECT_TRUE(std::isnan(remainder<float>(std::numeric_limits<float>::quiet_NaN(), 1.0).value()));
-  EXPECT_TRUE(std::isnan(remainder<float>(1.0, std::numeric_limits<float>::quiet_NaN()).value()));
-  EXPECT_TRUE(std::isnan(remainder<float>(std::numeric_limits<float>::infinity(), 1.0).value()));
-  EXPECT_TRUE(std::isnan(remainder<float>(-std::numeric_limits<float>::infinity(), 1.0).value()));
-  EXPECT_TRUE(std::isnan(remainder<float>(std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity()).value()));
+  EXPECT_TRUE(std::isnan(remainder_value<float>(std::numeric_limits<float>::quiet_NaN(), 1.0f)));
+  EXPECT_TRUE(std::isnan(remainder_value<float>(1.0f, std::numeric_limits<float>::quiet_NaN())));
+  EXPECT_TRUE(std::isnan(remainder_value<float>(std::numeric_limits<float>::infinity(), 1.0f)));
+  EXPECT_TRUE(std::isnan(remainder_value<float>(-std::numeric_limits<float>::infinity(), 1.0f)));
+  EXPECT_TRUE(std::isnan(remainder_value<float>(std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity())));
 }
 
 class ArithmeticTest : public SparkFunctionBaseTest {

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -136,7 +136,8 @@ TEST_F(RemainderTest, int64) {
 TEST_F(RemainderTest, double) {
   constexpr double kInf = std::numeric_limits<double>::infinity();
   constexpr double kNan = std::numeric_limits<double>::quiet_NaN();
-  const auto remainderDouble = [&](std::optional<double> a, std::optional<double> b) {
+  const auto remainderDouble = [&](std::optional<double> a,
+                                   std::optional<double> b) {
     return remainder(a, b).value();
   };
 
@@ -147,6 +148,7 @@ TEST_F(RemainderTest, double) {
   EXPECT_DOUBLE_EQ(0.0, remainderDouble(0.0, 1.0));
   EXPECT_DOUBLE_EQ(2.0, remainderDouble(2.0, kInf));
 
+  EXPECT_EQ(std::nullopt, remainder<double>(2.0, 0.0));
   EXPECT_TRUE(std::isnan(remainderDouble(kNan, 1.0)));
   EXPECT_TRUE(std::isnan(remainderDouble(1.0, kNan)));
   EXPECT_TRUE(std::isnan(remainderDouble(kInf, 1.0)));
@@ -155,9 +157,10 @@ TEST_F(RemainderTest, double) {
 }
 
 TEST_F(RemainderTest, float) {
-  constexpr double kInf = std::numeric_limits<float>::infinity();
-  constexpr double kNan = std::numeric_limits<float>::quiet_NaN();
-  const auto remainderFloat = [&](std::optional<float> a, std::optional<float> b) {
+  constexpr float kInf = std::numeric_limits<float>::infinity();
+  constexpr float kNan = std::numeric_limits<float>::quiet_NaN();
+  const auto remainderFloat = [&](std::optional<float> a,
+                                  std::optional<float> b) {
     return remainder(a, b).value();
   };
 
@@ -168,7 +171,7 @@ TEST_F(RemainderTest, float) {
   EXPECT_FLOAT_EQ(0.0f, remainderFloat(0.0f, 1.0f));
   EXPECT_FLOAT_EQ(2.0f, remainderFloat(2.0f, kInf));
 
-  EXPECT_EQ(std::nullopt, remainderFloat(2.0, 0.0));
+  EXPECT_EQ(std::nullopt, remainder<float>(2.0f, 0.0f));
   EXPECT_TRUE(std::isnan(remainderFloat(kNan, 1.0f)));
   EXPECT_TRUE(std::isnan(remainderFloat(1.0f, kNan)));
   EXPECT_TRUE(std::isnan(remainderFloat(kInf, 1.0f)));

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -91,6 +91,11 @@ class RemainderTest : public SparkFunctionBaseTest {
   std::optional<T> remainder(std::optional<T> a, std::optional<T> n) {
     return evaluateOnce<T>("remainder(c0, c1)", a, n);
   };
+
+  template <typename T>
+  T remainderValue(std::optional<T> a, std::optional<T> n) {
+    return remainder<T>(a, n).value();
+  }
 };
 
 TEST_F(RemainderTest, int8) {
@@ -136,47 +141,39 @@ TEST_F(RemainderTest, int64) {
 TEST_F(RemainderTest, double) {
   constexpr double kInf = std::numeric_limits<double>::infinity();
   constexpr double kNan = std::numeric_limits<double>::quiet_NaN();
-  const auto remainderDouble = [&](std::optional<double> a,
-                                   std::optional<double> b) {
-    return remainder(a, b).value();
-  };
 
-  EXPECT_DOUBLE_EQ(0.0, remainderDouble(2.0, 1.0));
-  EXPECT_DOUBLE_EQ(1.0, remainderDouble(5.0, 2.0));
-  EXPECT_DOUBLE_EQ(-1.0, remainderDouble(-5.0, 2.0));
-  EXPECT_DOUBLE_EQ(0.5, remainderDouble(1.5, 1.0));
-  EXPECT_DOUBLE_EQ(0.0, remainderDouble(0.0, 1.0));
-  EXPECT_DOUBLE_EQ(2.0, remainderDouble(2.0, kInf));
+  EXPECT_DOUBLE_EQ(0.0, remainderValue<double>(2.0, 1.0));
+  EXPECT_DOUBLE_EQ(1.0, remainderValue<double>(5.0, 2.0));
+  EXPECT_DOUBLE_EQ(-1.0, remainderValue<double>(-5.0, 2.0));
+  EXPECT_DOUBLE_EQ(0.5, remainderValue<double>(1.5, 1.0));
+  EXPECT_DOUBLE_EQ(0.0, remainderValue<double>(0.0, 1.0));
+  EXPECT_DOUBLE_EQ(2.0, remainderValue<double>(2.0, kInf));
 
   EXPECT_EQ(std::nullopt, remainder<double>(2.0, 0.0));
-  EXPECT_TRUE(std::isnan(remainderDouble(kNan, 1.0)));
-  EXPECT_TRUE(std::isnan(remainderDouble(1.0, kNan)));
-  EXPECT_TRUE(std::isnan(remainderDouble(kInf, 1.0)));
-  EXPECT_TRUE(std::isnan(remainderDouble(-kInf, 1.0)));
-  EXPECT_TRUE(std::isnan(remainderDouble(kInf, kInf)));
+  EXPECT_TRUE(std::isnan(remainderValue<double>(kNan, 1.0)));
+  EXPECT_TRUE(std::isnan(remainderValue<double>(1.0, kNan)));
+  EXPECT_TRUE(std::isnan(remainderValue<double>(kInf, 1.0)));
+  EXPECT_TRUE(std::isnan(remainderValue<double>(-kInf, 1.0)));
+  EXPECT_TRUE(std::isnan(remainderValue<double>(kInf, kInf)));
 }
 
 TEST_F(RemainderTest, float) {
   constexpr float kInf = std::numeric_limits<float>::infinity();
   constexpr float kNan = std::numeric_limits<float>::quiet_NaN();
-  const auto remainderFloat = [&](std::optional<float> a,
-                                  std::optional<float> b) {
-    return remainder(a, b).value();
-  };
 
-  EXPECT_FLOAT_EQ(0.0f, remainderFloat(2.0f, 1.0f));
-  EXPECT_FLOAT_EQ(1.0f, remainderFloat(5.0f, 2.0f));
-  EXPECT_FLOAT_EQ(-1.0f, remainderFloat(-5.0f, 2.0f));
-  EXPECT_FLOAT_EQ(0.5f, remainderFloat(1.5f, 1.0f));
-  EXPECT_FLOAT_EQ(0.0f, remainderFloat(0.0f, 1.0f));
-  EXPECT_FLOAT_EQ(2.0f, remainderFloat(2.0f, kInf));
+  EXPECT_FLOAT_EQ(0.0f, remainderValue<float>(2.0f, 1.0f));
+  EXPECT_FLOAT_EQ(1.0f, remainderValue<float>(5.0f, 2.0f));
+  EXPECT_FLOAT_EQ(-1.0f, remainderValue<float>(-5.0f, 2.0f));
+  EXPECT_FLOAT_EQ(0.5f, remainderValue<float>(1.5f, 1.0f));
+  EXPECT_FLOAT_EQ(0.0f, remainderValue<float>(0.0f, 1.0f));
+  EXPECT_FLOAT_EQ(2.0f, remainderValue<float>(2.0f, kInf));
 
   EXPECT_EQ(std::nullopt, remainder<float>(2.0f, 0.0f));
-  EXPECT_TRUE(std::isnan(remainderFloat(kNan, 1.0f)));
-  EXPECT_TRUE(std::isnan(remainderFloat(1.0f, kNan)));
-  EXPECT_TRUE(std::isnan(remainderFloat(kInf, 1.0f)));
-  EXPECT_TRUE(std::isnan(remainderFloat(-kInf, 1.0f)));
-  EXPECT_TRUE(std::isnan(remainderFloat(kInf, kInf)));
+  EXPECT_TRUE(std::isnan(remainderValue<float>(kNan, 1.0f)));
+  EXPECT_TRUE(std::isnan(remainderValue<float>(1.0f, kNan)));
+  EXPECT_TRUE(std::isnan(remainderValue<float>(kInf, 1.0f)));
+  EXPECT_TRUE(std::isnan(remainderValue<float>(-kInf, 1.0f)));
+  EXPECT_TRUE(std::isnan(remainderValue<float>(kInf, kInf)));
 }
 
 class ArithmeticTest : public SparkFunctionBaseTest {

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -137,7 +137,15 @@ TEST_F(RemainderTest, double) {
   EXPECT_DOUBLE_EQ(0.0, remainder<double>(0.3, 0.3).value());
   EXPECT_DOUBLE_EQ(0.2, remainder<double>(0.5, 0.3).value());
   EXPECT_DOUBLE_EQ(-1.1, remainder<double>(-1.1, 2).value());
+  EXPECT_EQ(std::nullopt, remainder<double>(2.14159, 0.0));
   EXPECT_DOUBLE_EQ(0.1, remainder<double>(0.7, -0.3).value());
+
+  EXPECT_TRUE(std::isnan(remainder<double>(std::numeric_limits<double>::quiet_NaN(), 1.0).value()));
+  EXPECT_TRUE(std::isnan(remainder<double>(std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()).value()));
+
+  EXPECT_TRUE(std::isnan(remainder<double>(std::numeric_limits<double>::infinity(), 1.0).value()));
+  EXPECT_TRUE(std::isnan(remainder<double>(-std::numeric_limits<double>::infinity(), 1.0).value()));
+  EXPECT_TRUE(std::isnan(remainder<double>(std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()).value()));
 }
 
 TEST_F(RemainderTest, float) {
@@ -146,6 +154,13 @@ TEST_F(RemainderTest, float) {
   EXPECT_FLOAT_EQ(-1.1, remainder<float>(-1.1, 2).value());
   EXPECT_EQ(std::nullopt, remainder<float>(2.14159, 0.0));
   EXPECT_FLOAT_EQ(0.1, remainder<float>(0.7, -0.3).value());
+
+  EXPECT_TRUE(std::isnan(remainder<float>(std::numeric_limits<float>::quiet_NaN(), 1.0).value()));
+  EXPECT_TRUE(std::isnan(remainder<float>(std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN()).value()));
+
+  EXPECT_TRUE(std::isnan(remainder<float>(std::numeric_limits<float>::infinity(), 1.0).value()));
+  EXPECT_TRUE(std::isnan(remainder<float>(-std::numeric_limits<float>::infinity(), 1.0).value()));
+  EXPECT_TRUE(std::isnan(remainder<float>(std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity()).value()));
 }
 
 class ArithmeticTest : public SparkFunctionBaseTest {

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -134,15 +134,16 @@ TEST_F(RemainderTest, int64) {
 }
 
 TEST_F(RemainderTest, double) {
-  EXPECT_DOUBLE_EQ(0.0, remainder<double>(0.3, 0.3).value());
-  EXPECT_DOUBLE_EQ(0.2, remainder<double>(0.5, 0.3).value());
-  EXPECT_DOUBLE_EQ(-1.1, remainder<double>(-1.1, 2).value());
-  EXPECT_EQ(std::nullopt, remainder<double>(2.14159, 0.0));
-  EXPECT_DOUBLE_EQ(0.1, remainder<double>(0.7, -0.3).value());
+  EXPECT_DOUBLE_EQ(0.0f, remainder<double>(2.0, 1.0).value());
+  EXPECT_DOUBLE_EQ(1.0f, remainder<double>(5.0, 2.0).value());
+  EXPECT_DOUBLE_EQ(-1.0f, remainder<double>(-5.0, 2.0).value());
+  EXPECT_DOUBLE_EQ(0.5f, remainder<double>(1.5, 1.0).value());
+  EXPECT_DOUBLE_EQ(0.0f, remainder<double>(0.0, 1.0).value());
+  EXPECT_DOUBLE_EQ(2.0f, remainder<double>(2.0, std::numeric_limits<double>::infinity()).value());
 
+  EXPECT_EQ(std::nullopt, remainder<double>(2.0, 0.0));
   EXPECT_TRUE(std::isnan(remainder<double>(std::numeric_limits<double>::quiet_NaN(), 1.0).value()));
-  EXPECT_TRUE(std::isnan(remainder<double>(std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()).value()));
-
+  EXPECT_TRUE(std::isnan(remainder<double>(1.0, std::numeric_limits<double>::quiet_NaN()).value()));
   EXPECT_TRUE(std::isnan(remainder<double>(std::numeric_limits<double>::infinity(), 1.0).value()));
   EXPECT_TRUE(std::isnan(remainder<double>(-std::numeric_limits<double>::infinity(), 1.0).value()));
   EXPECT_TRUE(std::isnan(remainder<double>(std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()).value()));
@@ -154,10 +155,11 @@ TEST_F(RemainderTest, float) {
   EXPECT_FLOAT_EQ(-1.1, remainder<float>(-1.1, 2).value());
   EXPECT_EQ(std::nullopt, remainder<float>(2.14159, 0.0));
   EXPECT_FLOAT_EQ(0.1, remainder<float>(0.7, -0.3).value());
+  EXPECT_FLOAT_EQ(2.0f, remainder<float>(2.0f, std::numeric_limits<float>::infinity()).value());
 
+  EXPECT_EQ(std::nullopt, remainder<float>(2.0, 0.0));
   EXPECT_TRUE(std::isnan(remainder<float>(std::numeric_limits<float>::quiet_NaN(), 1.0).value()));
-  EXPECT_TRUE(std::isnan(remainder<float>(std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN()).value()));
-
+  EXPECT_TRUE(std::isnan(remainder<float>(1.0, std::numeric_limits<float>::quiet_NaN()).value()));
   EXPECT_TRUE(std::isnan(remainder<float>(std::numeric_limits<float>::infinity(), 1.0).value()));
   EXPECT_TRUE(std::isnan(remainder<float>(-std::numeric_limits<float>::infinity(), 1.0).value()));
   EXPECT_TRUE(std::isnan(remainder<float>(std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity()).value()));

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -138,7 +138,7 @@ TEST_F(RemainderTest, double) {
   constexpr double kNan = std::numeric_limits<double>::quiet_NaN();
   const auto remainderDouble = [&](std::optional<double> a, std::optional<double> b) {
     return remainder(a, b).value();
-  }
+  };
 
   EXPECT_DOUBLE_EQ(0.0, remainderDouble(2.0, 1.0));
   EXPECT_DOUBLE_EQ(1.0, remainderDouble(5.0, 2.0));
@@ -159,7 +159,7 @@ TEST_F(RemainderTest, float) {
   constexpr double kNan = std::numeric_limits<float>::quiet_NaN();
   const auto remainderFloat = [&](std::optional<float> a, std::optional<float> b) {
     return remainder(a, b).value();
-  }
+  };
 
   EXPECT_FLOAT_EQ(0.0f, remainderFloat(2.0f, 1.0f));
   EXPECT_FLOAT_EQ(1.0f, remainderFloat(5.0f, 2.0f));

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -133,6 +133,21 @@ TEST_F(RemainderTest, int64) {
   EXPECT_EQ(-1, remainder<int64_t>(INT64_MIN, INT64_MAX));
 }
 
+TEST_F(RemainderTest, double) {
+  EXPECT_DOUBLE_EQ(0.0, remainder<double>(0.3, 0.3).value());
+  EXPECT_DOUBLE_EQ(0.2, remainder<double>(0.5, 0.3).value());
+  EXPECT_DOUBLE_EQ(-1.1, remainder<double>(-1.1, 2).value());
+  EXPECT_DOUBLE_EQ(0.1, remainder<double>(0.7, -0.3).value());
+}
+
+TEST_F(RemainderTest, float) {
+  EXPECT_FLOAT_EQ(0.0, remainder<float>(0.3, 0.3).value());
+  EXPECT_FLOAT_EQ(0.2, remainder<float>(0.5, 0.3).value());
+  EXPECT_FLOAT_EQ(-1.1, remainder<float>(-1.1, 2).value());
+  EXPECT_EQ(std::nullopt, remainder<float>(2.14159, 0.0));
+  EXPECT_FLOAT_EQ(0.1, remainder<float>(0.7, -0.3).value());
+}
+
 class ArithmeticTest : public SparkFunctionBaseTest {
  protected:
   template <typename T>

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -139,34 +139,38 @@ TEST_F(RemainderTest, int64) {
 }
 
 TEST_F(RemainderTest, double) {
+  constexpr double kInf = std::numeric_limits<double>::infinity();
+  constexpr double kNan = std::numeric_limits<double>::quiet_NaN();
   EXPECT_DOUBLE_EQ(0.0, remainder_value<double>(2.0, 1.0));
   EXPECT_DOUBLE_EQ(1.0, remainder_value<double>(5.0, 2.0));
   EXPECT_DOUBLE_EQ(-1.0, remainder_value<double>(-5.0, 2.0));
   EXPECT_DOUBLE_EQ(0.5, remainder_value<double>(1.5, 1.0));
   EXPECT_DOUBLE_EQ(0.0, remainder_value<double>(0.0, 1.0));
-  EXPECT_DOUBLE_EQ(2.0, remainder_value<double>(2.0, std::numeric_limits<double>::infinity()));
+  EXPECT_DOUBLE_EQ(2.0, remainder_value<double>(2.0, kInf));
 
-  EXPECT_TRUE(std::isnan(remainder_value<double>(std::numeric_limits<double>::quiet_NaN(), 1.0)));
-  EXPECT_TRUE(std::isnan(remainder_value<double>(1.0, std::numeric_limits<double>::quiet_NaN())));
-  EXPECT_TRUE(std::isnan(remainder_value<double>(std::numeric_limits<double>::infinity(), 1.0)));
-  EXPECT_TRUE(std::isnan(remainder_value<double>(-std::numeric_limits<double>::infinity(), 1.0)));
-  EXPECT_TRUE(std::isnan(remainder_value<double>(std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity())));
+  EXPECT_TRUE(std::isnan(remainder_value<double>(kNan, 1.0)));
+  EXPECT_TRUE(std::isnan(remainder_value<double>(1.0, kNan)));
+  EXPECT_TRUE(std::isnan(remainder_value<double>(kInf, 1.0)));
+  EXPECT_TRUE(std::isnan(remainder_value<double>(-kInf, 1.0)));
+  EXPECT_TRUE(std::isnan(remainder_value<double>(kInf, kInf)));
 }
 
 TEST_F(RemainderTest, float) {
+  constexpr double kInf = std::numeric_limits<float>::infinity();
+  constexpr double kNan = std::numeric_limits<float>::quiet_NaN();
   EXPECT_FLOAT_EQ(0.0f, remainder_value<float>(2.0f, 1.0f));
   EXPECT_FLOAT_EQ(1.0f, remainder_value<float>(5.0f, 2.0f));
   EXPECT_FLOAT_EQ(-1.0f, remainder_value<float>(-5.0f, 2.0f));
   EXPECT_FLOAT_EQ(0.5f, remainder_value<float>(1.5f, 1.0f));
   EXPECT_FLOAT_EQ(0.0f, remainder_value<float>(0.0f, 1.0f));
-  EXPECT_FLOAT_EQ(2.0f, remainder_value<float>(2.0f, std::numeric_limits<float>::infinity()));
+  EXPECT_FLOAT_EQ(2.0f, remainder_value<float>(2.0f, kInf));
 
   EXPECT_EQ(std::nullopt, remainder<float>(2.0, 0.0));
-  EXPECT_TRUE(std::isnan(remainder_value<float>(std::numeric_limits<float>::quiet_NaN(), 1.0f)));
-  EXPECT_TRUE(std::isnan(remainder_value<float>(1.0f, std::numeric_limits<float>::quiet_NaN())));
-  EXPECT_TRUE(std::isnan(remainder_value<float>(std::numeric_limits<float>::infinity(), 1.0f)));
-  EXPECT_TRUE(std::isnan(remainder_value<float>(-std::numeric_limits<float>::infinity(), 1.0f)));
-  EXPECT_TRUE(std::isnan(remainder_value<float>(std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity())));
+  EXPECT_TRUE(std::isnan(remainder_value<float>(kNan, 1.0f)));
+  EXPECT_TRUE(std::isnan(remainder_value<float>(1.0f, kNan)));
+  EXPECT_TRUE(std::isnan(remainder_value<float>(kInf, 1.0f)));
+  EXPECT_TRUE(std::isnan(remainder_value<float>(-kInf, 1.0f)));
+  EXPECT_TRUE(std::isnan(remainder_value<float>(kInf, kInf)));
 }
 
 class ArithmeticTest : public SparkFunctionBaseTest {


### PR DESCRIPTION
Spark mod support float/double types

(https://github.com/apache/spark/blob/403619a3974c595ba80d6c9dbd23b8c2f1e2233e/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala#L899)