### PR TITLE
Fix warnings caused by -Wunused-but-set-variable

### DIFF
--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -926,7 +926,7 @@ class RowContainer {
     BufferPtr& nullBuffer = result->mutableNulls(maxRows);
     auto nulls = nullBuffer->asMutable<uint64_t>();
     BufferPtr valuesBuffer = result->mutableValues(maxRows);
-    FOLLY_MAYBE_UNUSED auto values = valuesBuffer->asMutableRange<T>();
+    [[maybe_unused]] auto values = valuesBuffer->asMutableRange<T>();
     for (int32_t i = 0; i < numRows; ++i) {
       const char* row;
       if constexpr (useRowNumbers) {
@@ -960,7 +960,7 @@ class RowContainer {
     auto maxRows = numRows + resultOffset;
     VELOX_DCHECK_LE(maxRows, result->size());
     BufferPtr valuesBuffer = result->mutableValues(maxRows);
-    FOLLY_MAYBE_UNUSED auto values = valuesBuffer->asMutableRange<T>();
+    [[maybe_unused]] auto values = valuesBuffer->asMutableRange<T>();
     for (int32_t i = 0; i < numRows; ++i) {
       const char* row;
       if constexpr (useRowNumbers) {

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -926,7 +926,7 @@ class RowContainer {
     BufferPtr& nullBuffer = result->mutableNulls(maxRows);
     auto nulls = nullBuffer->asMutable<uint64_t>();
     BufferPtr valuesBuffer = result->mutableValues(maxRows);
-    auto values = valuesBuffer->asMutableRange<T>();
+    FOLLY_MAYBE_UNUSED auto values = valuesBuffer->asMutableRange<T>();
     for (int32_t i = 0; i < numRows; ++i) {
       const char* row;
       if constexpr (useRowNumbers) {
@@ -960,7 +960,7 @@ class RowContainer {
     auto maxRows = numRows + resultOffset;
     VELOX_DCHECK_LE(maxRows, result->size());
     BufferPtr valuesBuffer = result->mutableValues(maxRows);
-    auto values = valuesBuffer->asMutableRange<T>();
+    FOLLY_MAYBE_UNUSED auto values = valuesBuffer->asMutableRange<T>();
     for (int32_t i = 0; i < numRows; ++i) {
       const char* row;
       if constexpr (useRowNumbers) {


### PR DESCRIPTION
Variable `values` would not be used if the condition `if constexpr (std::is_same_v<T, StringView>)`  is true.

```
/__w/incubator-gluten/incubator-gluten/cpp/../ep/build-velox/build/velox_ep/velox/exec/RowContainer.h:1416:3:   required from here
/__w/incubator-gluten/incubator-gluten/cpp/../ep/build-velox/build/velox_ep/velox/exec/RowContainer.h:962:10: warning: variable 'values' set but not used [-Wunused-but-set-variable]
  962 |     auto values = valuesBuffer->asMutableRange<T>();
      |          ^~~~~~
/__w/incubator-gluten/incubator-gluten/cpp/../ep/build-velox/build/velox_ep/velox/exec/RowContainer.h: In instantiation of 'static void facebook::velox::exec::RowContainer::extractValuesWithNulls(const char* const*, folly::Range<const int*>, int32_t, int32_t, int32_t, uint8_t, int32_t, facebook::velox::FlatVector<T>*) [with bool useRowNumbers = true; T = facebook::velox::StringView; int32_t = int; uint8_t = unsigned char]':
/__w/incubator-gluten/incubator-gluten/cpp/../ep/build-velox/build/velox_ep/velox/exec/RowContainer.h:850:47:   required from 'static void facebook::velox::exec::RowContainer::extractColumnTypedInternal(const char* const*, folly::Range<const int*>, int32_t, facebook::velox::exec::RowColumn, int32_t, const VectorPtr&) [with bool useRowNumbers = true; facebook::velox::TypeKind Kind = facebook::velox::TypeKind::VARCHAR; int32_t = int; facebook::velox::VectorPtr = std::shared_ptr<facebook::velox::BaseVector>]'
/__w/incubator-gluten/incubator-gluten/cpp/../ep/build-velox/build/velox_ep/velox/exec/RowContainer.h:817:45:   required from 'static void facebook::velox::exec::RowContainer::extractColumnTyped(const char* const*, folly::Range<const int*>, int32_t, facebook::velox::exec::RowColumn, int32_t, const VectorPtr&) [with facebook::velox::TypeKind Kind = facebook::velox::TypeKind::VARCHAR; int32_t = int; facebook::velox::VectorPtr = std::shared_ptr<facebook::velox::BaseVector>]'
/__w/incubator-gluten/incubator-gluten/cpp/../ep/build-velox/build/velox_ep/velox/exec/RowContainer.h:1416:3:   required from here
/__w/incubator-gluten/incubator-gluten/cpp/../ep/build-velox/build/velox_ep/velox/exec/RowContainer.h:928:10: warning: variable 'values' set but not used [-Wunused-but-set-variable]
  928 |     auto values = valuesBuffer->asMutableRange<T>();
      |          ^~~~~~
```