### PR TITLE
Implement TPCH Query 4 in TPCHQueryBuilder

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -504,6 +504,11 @@ BENCHMARK(q3) {
   benchmark.run(planContext);
 }
 
+BENCHMARK(q4) {
+  const auto planContext = queryBuilder->getQueryPlan(4);
+  benchmark.run(planContext);
+}
+
 BENCHMARK(q5) {
   const auto planContext = queryBuilder->getQueryPlan(5);
   benchmark.run(planContext);

--- a/velox/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -171,6 +171,11 @@ TEST_F(ParquetTpchTest, Q3) {
   assertQuery(3, std::move(sortingKeys));
 }
 
+TEST_F(ParquetTpchTest, Q4) {
+  std::vector<uint32_t> sortingKeys{0};
+  assertQuery(4, std::move(sortingKeys));
+}
+
 TEST_F(ParquetTpchTest, Q5) {
   std::vector<uint32_t> sortingKeys{1};
   assertQuery(5, std::move(sortingKeys));

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -93,6 +93,7 @@ class TpchQueryBuilder {
   TpchPlan getQ1Plan() const;
   TpchPlan getQ2Plan() const;
   TpchPlan getQ3Plan() const;
+  TpchPlan getQ4Plan() const;
   TpchPlan getQ5Plan() const;
   TpchPlan getQ6Plan() const;
   TpchPlan getQ7Plan() const;


### PR DESCRIPTION
This PR introduces TPC-H Query 4 into the TpchQueryBuilder and extends the TpchBenchmark and ParquetTpchTest to include this query. Additionally, it provides a detailed performance comparison with DuckDB using the Parquet file format and includes the output of PrintPlanWithStats for detailed analysis.

### Performance Comparison
Chip: Apple M3 Pro
Total Number of Cores: 12 (6 performance and 6 efficiency)
Memory: 36 GB

The following table summarizes the performance comparison between Velox and DuckDB (with Parquet file format) across various numbers of threads/drivers:

| # Num Threads/ Drivers | Velox(ms) | DuckDB(ms) |
|:----------------------:|:---------:|:----------:|
|            1           |     193     |     206    |  
|            4           |     74    |     96.9    |  
|            8           |     45     |     67.7    | 
|           16           |     42     |     72.6    |

More detailed notes: https://ibm.box.com/s/b9ycmgjc43ysy56vm3z0ihlx0qjyvkds
https://ibm.box.com/s/05d49gyyxyj47mhqa03nc3yg8yo2jvbc
PPT:https://ibm.box.com/s/ctwyx67bdig3dtts6xrbi562v5rwl7c2