### PR TITLE
Introduce velox::Expected

### DIFF
--- a/velox/common/base/Status.h
+++ b/velox/common/base/Status.h
@@ -20,6 +20,7 @@
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#include <folly/Expected.h>
 #include <folly/Likely.h>
 #include <string>
 #include <utility>
@@ -489,6 +490,24 @@ inline Status genericToStatus(Status&& st) {
 }
 
 } // namespace internal
+
+/// Holds a result or an error. Designed to be used by APIs that do not throw.
+///
+/// Here is an example of a modulo operation that doesn't throw, but indicates
+/// failure using Status.
+///
+/// Expected<int> modulo(int a, int b) {
+///   if (b == 0) {
+///     return folly::makeUnexpected(Status::UserError("division by zero"));
+///   }
+///
+///   return a % b;
+/// }
+///
+/// Status should not be OK.
+template <typename T>
+using Expected = folly::Expected<T, Status>;
+
 } // namespace facebook::velox
 
 template <>

--- a/velox/common/base/tests/StatusTest.cpp
+++ b/velox/common/base/tests/StatusTest.cpp
@@ -128,5 +128,23 @@ TEST(StatusTest, macros) {
   ASSERT_TRUE(didThrow) << "VELOX_CHECK_OK did not throw";
 }
 
+Expected<int> modulo(int a, int b) {
+  if (b == 0) {
+    return folly::makeUnexpected(Status::UserError("division by zero"));
+  }
+
+  return a % b;
+}
+
+TEST(StatusTest, expected) {
+  auto result = modulo(10, 3);
+  EXPECT_TRUE(result.hasValue());
+  EXPECT_EQ(result.value(), 1);
+
+  result = modulo(10, 0);
+  EXPECT_TRUE(result.hasError());
+  EXPECT_EQ(result.error(), Status::UserError("division by zero"));
+}
+
 } // namespace
 } // namespace facebook::velox::test


### PR DESCRIPTION
Summary: `velox::Expected<T>` can be used by no-throw APIs to return result or error.

Differential Revision: D57496990


