### PR TITLE
Update cmake to version 3.28.3

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -70,6 +70,9 @@ jobs:
         # it doesn't work
         run: git config --global --add safe.directory /__w/velox/velox
 
+      - name: Install cmake
+        run: python3 -m pip install cmake==3.28.3
+
       - name: Install Dependencies
         run: |
           # Allows to install arbitrary cuda-version whithout needing to update

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -197,6 +197,7 @@ jobs:
         env:
           EXTRA_CMAKE_FLAGS: "-DVELOX_ENABLE_ARROW=ON -DVELOX_BUILD_PYTHON_PACKAGE=ON ${{ inputs.extraCMakeFlags }}"
         run: |
+          python3 -m pip install cmake==3.28.3
           EXTRA_CMAKE_FLAGS="-DPYTHON_EXECUTABLE=$(which python3) $EXTRA_CMAKE_FLAGS"
           make debug
 

--- a/CMake/resolve_dependency_modules/README.md
+++ b/CMake/resolve_dependency_modules/README.md
@@ -26,7 +26,7 @@ by Velox. See details on bundling below.
 | boost             | 1.77.0          | Yes      |
 | flex              | 2.5.13          | No       |
 | bison             | 3.0.4           | No       |
-| cmake             | 3.14            | No       |
+| cmake             | 3.28            | No       |
 | double-conversion | 3.1.5           | No       |
 | xsimd             | 10.0.0          | Yes      |
 | re2               | 2021-04-01      | Yes      |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.28)
 message(STATUS "Building using CMake version: ${CMAKE_VERSION}")
 
 # The policy allows us to change options without caching.

--- a/scripts/setup-adapters.sh
+++ b/scripts/setup-adapters.sh
@@ -58,27 +58,45 @@ function install_gcs-sdk-cpp {
   # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging.md#required-libraries
 
   # abseil-cpp
-  github_checkout abseil/abseil-cpp 20240116.1 --depth 1
-  sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h"
-  cmake_install -DBUILD_SHARED_LIBS=OFF \
-    -DABSL_BUILD_TESTING=OFF
+  github_checkout abseil/abseil-cpp 20240116.2 --depth 1
+  cmake_install \
+    -DABSL_BUILD_TESTING=OFF \
+    -DCMAKE_CXX_STANDARD=14 \
+    -DABSL_PROPAGATE_CXX_STD=ON \
+    -DABSL_ENABLE_INSTALL=ON
+
+  # protobuf
+  github_checkout protocolbuffers/protobuf v21.4 --depth 1
+  cmake_install \
+    -Dprotobuf_BUILD_TESTS=OFF
+
+  # grpc
+  github_checkout grpc/grpc v1.48.1 --depth 1
+  cmake_install \
+    -DgRPC_BUILD_TESTS=OFF \
+    -DgRPC_ABSL_PROVIDER=package \
+    -DgRPC_ZLIB_PROVIDER=package \
+    -DgRPC_CARES_PROVIDER=package \
+    -DgRPC_RE2_PROVIDER=package \
+    -DgRPC_SSL_PROVIDER=package \
+    -DgRPC_PROTOBUF_PROVIDER=package \
+    -DgRPC_INSTALL=ON
 
   # crc32
   github_checkout google/crc32c 1.1.2 --depth 1
-  cmake_install -DBUILD_SHARED_LIBS=OFF \
+  cmake_install \
     -DCRC32C_BUILD_TESTS=OFF \
     -DCRC32C_BUILD_BENCHMARKS=OFF \
     -DCRC32C_USE_GLOG=OFF
 
   # nlohmann json
   github_checkout nlohmann/json v3.11.3 --depth 1
-  cmake_install -DBUILD_SHARED_LIBS=OFF \
+  cmake_install \
     -DJSON_BuildTests=OFF
 
   # google-cloud-cpp
   github_checkout googleapis/google-cloud-cpp v2.22.0 --depth 1
-  cmake_install -DBUILD_SHARED_LIBS=OFF \
-    -DCMAKE_INSTALL_MESSAGE=NEVER \
+  cmake_install \
     -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
     -DGOOGLE_CLOUD_CPP_ENABLE=storage
 }

--- a/scripts/setup-centos8.sh
+++ b/scripts/setup-centos8.sh
@@ -50,8 +50,9 @@ function install_build_prerequisites {
   dnf_install epel-release dnf-plugins-core # For ccache, ninja
   dnf config-manager --set-enabled powertools
   dnf update -y
-  dnf_install ninja-build cmake curl ccache gcc-toolset-9 git wget which
+  dnf_install ninja-build curl ccache gcc-toolset-9 git wget which
   dnf_install autoconf automake python39 python39-devel python39-pip libtool
+  pip3.9 install cmake==3.28.3
 }
 
 # Install dependencies from the package managers.

--- a/scripts/setup-check.sh
+++ b/scripts/setup-check.sh
@@ -19,7 +19,7 @@ set -x
 export DEBIAN_FRONTEND=noninteractive
 apt update
 apt install --no-install-recommends -y clang-format-12 python3-pip git make ssh
-pip3 install cmake_format black regex
+pip3 install cmake==3.28.3 cmake_format black regex
 pip3 cache purge
 apt purge --auto-remove -y python3-pip
 update-alternatives --install /usr/bin/clang-format clang-format "$(command -v clang-format-12)" 12

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -52,13 +52,16 @@ function install_build_prerequisites {
   ${SUDO} apt install -y libunwind-dev
   ${SUDO} apt install -y \
     build-essential \
-    cmake \
+    python3-pip \
     ccache \
     curl \
     ninja-build \
     checkinstall \
     git \
     wget
+
+    # Install to /usr/local to make it available to all users.
+    ${SUDO} pip3 install cmake==3.28.3
 }
 
 # Install packages required for build.

--- a/scripts/velox_env_linux.yml
+++ b/scripts/velox_env_linux.yml
@@ -26,7 +26,7 @@ dependencies:
   - binutils
   - bison
   - clangxx=14
-  - cmake
+  - cmake=3.28.3
   - ccache
   - flex
   - gxx=12 # has to be installed to get clang to work...

--- a/scripts/velox_env_mac.yml
+++ b/scripts/velox_env_mac.yml
@@ -26,7 +26,7 @@ dependencies:
   - binutils
   - bison
   - clangxx=14 # pin to something recent'ish to avoid warings on upgrade
-  - cmake
+  - cmake=3.28
   - ccache
   - flex
   - make


### PR DESCRIPTION
CMake 3.24 and the 3.28 provide two notable improvements to the FetchContent module
- New in version 3.24: OVERRIDE_FIND_PACKAGE - This makes the content available to be available for find_package.
- New in version 3.28: EXCLUDE_FROM_ALL - Prevents the targets of the content from being added to the all target.

These improvements are going to significantly decrease the complexity of dependencies that are provided via cmake modules.