### PR TITLE
Fix bug in left merge join with filter

### DIFF
--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -576,12 +576,14 @@ TEST_F(MergeJoinTest, complexTypedFilter) {
           }
         }
 
-        assertQuery(
-            plan,
-            fmt::format(
-                "SELECT {} FROM t LEFT JOIN u ON t_c0 = u_c0 AND {}",
-                outputs,
-                queryFilter));
+        for (size_t outputBatchSize : {1000, 1024, 13}) {
+          assertQuery(
+              makeCursorParameters(plan, outputBatchSize),
+              fmt::format(
+                  "SELECT {} FROM t LEFT JOIN u ON t_c0 = u_c0 AND {}",
+                  outputs,
+                  queryFilter));
+        }
       };
 
   std::vector<std::vector<std::string>> outputLayouts{


### PR DESCRIPTION
Summary:
Depending on the output buffer alignment, left merge join with filters
was incorrectly generating leftover rows from key matches where filters did not
pass, if another key with a miss has already started in the same buffer.

Adding unit tests that used to reproduce the error, and extensive code
documentation to describe the checks and filter semantics.

Differential Revision: D57520300


