### PR TITLE
Add memory arbitration fuzzer test

### DIFF
--- a/velox/docs/develop/testing/memory-arbitration-fuzzer.rst
+++ b/velox/docs/develop/testing/memory-arbitration-fuzzer.rst
@@ -1,0 +1,57 @@
+=========================
+MemoryArbitration Fuzzer
+=========================
+
+The MemoryArbitrationFuzzer is a test tool designed to automatically generate and execute multiple query plans
+in parallel with tight total memory budget. It aims to stress the memory arbitration processing, and validate there is
+no crash or hanging in a concurrent query execution mode. The query either succeeds or failed with expected errors.
+It works as follows:
+
+1. Data Generation: It starts by generating a random set of input data, also known as a vector. This data can
+   have a variety of encodings and data layouts to ensure thorough testing.
+2. Plan Generation: Generate multiple plans with different query shapes. Currently, it supports HashJoin and
+   HashAggregation plans.
+3. Query Execution: Create multiple threads, each thread randomly picks a plan with spill enabled or not, and repeatedly
+   running this process until ${iteration_duration_sec} seconds. The query thread expects query to succeed or fail with
+   query OOM or abort errors, otherwise it throws.
+4. Iteration: This process is repeated multiple times to ensure reliability and robustness.
+
+How to run
+----------
+
+Use velox_memory_arbitration_fuzzer_test binary to run this fuzzer:
+
+::
+
+    velox/exec/tests/velox_memory_arbitration_fuzzer_test --seed 123 --duration_sec 60
+
+By default, the fuzzer will go through 10 iterations. Use --steps
+or --duration-sec flag to run fuzzer for longer. Use --seed to
+reproduce fuzzer failures.
+
+Here is a full list of supported command line arguments.
+
+* ``–-steps``: How many iterations to run. Each iteration generates and
+  evaluates one expression or aggregation. Default is 10.
+
+* ``–-duration_sec``: For how long to run in seconds. If both ``-–steps``
+  and ``-–duration_sec`` are specified, –duration_sec takes precedence.
+
+* ``–-seed``: The seed to generate random expressions and input vectors with.
+
+* ``–-v=1``: Verbose logging (from `Google Logging Library <https://github.com/google/glog#setting-flags>`_).
+
+* ``–-batch_size``: The size of input vectors to generate. Default is 100.
+
+* ``--num_batches``: The number of input vectors of size `--batch_size` to
+  generate. Default is 5.
+
+* ``--iteration_duration_sec``: For how long it should run (in seconds) per iteration.
+
+* ``--arbitrator_capacity``: Arbitrator capacity in bytes.
+
+* ``--allocator_capacity``: Allocator capacity in bytes.
+
+* ``--num_threads``: Number of threads running queries in parallel per iteration.
+
+If running from CLion IDE, add ``--logtostderr=1`` to see the full output.

--- a/velox/exec/fuzzer/CMakeLists.txt
+++ b/velox/exec/fuzzer/CMakeLists.txt
@@ -80,3 +80,15 @@ target_link_libraries(
   velox_expression_test_utility
   velox_temp_path
   velox_vector_test_lib)
+
+add_library(velox_memory_arbitration_fuzzer MemoryArbitrationFuzzer.cpp)
+
+target_link_libraries(
+  velox_memory_arbitration_fuzzer
+  velox_fuzzer_util
+  velox_type
+  velox_vector_fuzzer
+  velox_exec_test_lib
+  velox_expression_test_utility
+  velox_functions_prestosql
+  velox_aggregates)

--- a/velox/exec/fuzzer/MemoryArbitrationFuzzer.cpp
+++ b/velox/exec/fuzzer/MemoryArbitrationFuzzer.cpp
@@ -1,0 +1,719 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/fuzzer/MemoryArbitrationFuzzer.h"
+#include <boost/random/uniform_int_distribution.hpp>
+#include <functions/lib/aggregates/AverageAggregateBase.h>
+#include <functions/sparksql/aggregates/Register.h>
+
+#include <vector>
+#include "velox/common/file/FileSystems.h"
+#include "velox/common/memory/SharedArbitrator.h"
+#include "velox/connectors/hive/HiveConnector.h"
+#include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/dwio/dwrf/reader/DwrfReader.h"
+#include "velox/dwio/dwrf/writer/Writer.h"
+#include "velox/exec/MemoryReclaimer.h"
+#include "velox/exec/TableWriter.h"
+#include "velox/exec/tests/utils/ArbitratorTestUtil.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+DEFINE_int32(steps, 10, "Number of test iterations.");
+
+DEFINE_int32(
+    duration_sec,
+    0,
+    "For how long it should run (in seconds). If zero, "
+    "it executes exactly --steps iterations and exits.");
+
+DEFINE_int32(
+    iteration_duration_sec,
+    10,
+    "For how long it should run (in seconds) per iteration.");
+
+DEFINE_int32(
+    batch_size,
+    100,
+    "The number of elements on each generated vector.");
+
+DEFINE_int32(num_batches, 32, "The number of generated vectors.");
+
+DEFINE_double(
+    null_ratio,
+    0.2,
+    "Chance of adding a null value in a vector "
+    "(expressed as double from 0 to 1).");
+
+DEFINE_int32(
+    num_threads,
+    72,
+    "The number of threads to run queries concurrently for each iteration.");
+
+DEFINE_int64(arbitrator_capacity, 256L << 20, "Arbitrator capacity in bytes.");
+
+namespace facebook::velox::exec::test {
+namespace {
+
+class MemoryArbitrationFuzzer {
+ public:
+  explicit MemoryArbitrationFuzzer(size_t initialSeed);
+
+  struct PlanWithSplits {
+    core::PlanNodePtr plan;
+    std::unordered_map<core::PlanNodeId, std::vector<Split>> splits;
+
+    PlanWithSplits(
+        core::PlanNodePtr _plan,
+        const std::unordered_map<core::PlanNodeId, std::vector<Split>>& _splits)
+        : plan(std::move(_plan)), splits(_splits) {}
+  };
+
+  struct Stats {
+    size_t successCount{0};
+    size_t failureCount{0};
+    size_t oomCount{0};
+    size_t abortCount{0};
+
+    void print() const {
+      std::stringstream ss;
+      ss << "Success count = " << successCount
+         << ", failure count = " << failureCount
+         << ". OOM count  = " << oomCount << " Abort count = " << abortCount;
+      LOG(INFO) << ss.str();
+    }
+  };
+
+  void go();
+
+ private:
+  void seed(size_t seed) {
+    currentSeed_ = seed;
+    vectorFuzzer_.reSeed(seed);
+    rng_.seed(currentSeed_);
+  }
+
+  void reSeed() {
+    seed(rng_());
+  }
+
+  int32_t randInt(int32_t min, int32_t max) {
+    return boost::random::uniform_int_distribution<int32_t>(min, max)(rng_);
+  }
+
+  // Returns a list of randomly generated key types for join and aggregation.
+  std::vector<TypePtr> generateKeyTypes(int32_t numKeys);
+
+  // Returns randomly generated probe input with up to 3 additional payload
+  // columns.
+  std::vector<RowVectorPtr> generateProbeInput(
+      const std::vector<std::string>& keyNames,
+      const std::vector<TypePtr>& keyTypes);
+
+  // Reuses the 'generateProbeInput' method to return randomly generated
+  // aggregation input.
+  std::vector<RowVectorPtr> generateAggregateInput(
+      const std::vector<std::string>& keyNames,
+      const std::vector<TypePtr>& keyTypes);
+
+  // Same as generateProbeInput() but copies over 10% of the input in the probe
+  // columns to ensure some matches during joining. Also generates an empty
+  // input with a 10% chance.
+  std::vector<RowVectorPtr> generateBuildInput(
+      const std::vector<RowVectorPtr>& probeInput,
+      const std::vector<std::string>& probeKeys,
+      const std::vector<std::string>& buildKeys);
+
+  std::vector<PlanWithSplits> hashJoinPlans(
+      const core::JoinType& joinType,
+      const std::vector<std::string>& probeKeys,
+      const std::vector<std::string>& buildKeys,
+      const std::vector<RowVectorPtr>& probeInput,
+      const std::vector<RowVectorPtr>& buildInput,
+      const std::vector<std::shared_ptr<connector::ConnectorSplit>>&
+          probeSplits,
+      const std::vector<std::shared_ptr<connector::ConnectorSplit>>&
+          buildSplits);
+
+  std::vector<PlanWithSplits> hashJoinPlans(const std::string& tableDir);
+
+  std::vector<PlanWithSplits> aggregatePlans(const std::string& tableDir);
+
+  void verify();
+
+  std::shared_ptr<connector::ConnectorSplit> makeSplit(
+      const std::string& filePath);
+
+  static VectorFuzzer::Options getFuzzerOptions() {
+    VectorFuzzer::Options opts;
+    opts.vectorSize = FLAGS_batch_size;
+    opts.stringVariableLength = true;
+    opts.stringLength = 100;
+    opts.nullRatio = FLAGS_null_ratio;
+    return opts;
+  }
+
+  static inline const std::string kHiveConnectorId = "test-hive";
+
+  FuzzerGenerator rng_;
+  size_t currentSeed_{0};
+  std::unordered_map<std::string, std::string> queryConfigsWithSpill_{
+      {core::QueryConfig::kSpillEnabled, "true"},
+      {core::QueryConfig::kJoinSpillEnabled, "true"},
+      {core::QueryConfig::kSpillStartPartitionBit, "29"},
+      {core::QueryConfig::kAggregationSpillEnabled, "true"},
+  };
+
+  std::shared_ptr<memory::MemoryPool> rootPool_{
+      memory::memoryManager()->addRootPool(
+          "memoryArbitrationFuzzer",
+          memory::kMaxMemory,
+          memory::MemoryReclaimer::create())};
+  std::shared_ptr<memory::MemoryPool> pool_{rootPool_->addLeafChild(
+      "memoryArbitrationFuzzerLeaf",
+      true,
+      exec::MemoryReclaimer::create())};
+  std::shared_ptr<memory::MemoryPool> writerPool_{rootPool_->addAggregateChild(
+      "joinFuzzerWriter",
+      exec::MemoryReclaimer::create())};
+
+  VectorFuzzer vectorFuzzer_;
+  std::shared_ptr<folly::Executor> executor_{
+      std::make_shared<folly::CPUThreadPoolExecutor>(
+          std::thread::hardware_concurrency())};
+  folly::Synchronized<Stats> stats_;
+};
+
+MemoryArbitrationFuzzer::MemoryArbitrationFuzzer(size_t initialSeed)
+    : vectorFuzzer_{getFuzzerOptions(), pool_.get()} {
+  // Make sure not to run out of open file descriptors.
+  const std::unordered_map<std::string, std::string> hiveConfig = {
+      {connector::hive::HiveConfig::kNumCacheFileHandles, "1000"}};
+  const auto hiveConnector =
+      connector::getConnectorFactory(
+          connector::hive::HiveConnectorFactory::kHiveConnectorName)
+          ->newConnector(
+              kHiveConnectorId, std::make_shared<core::MemConfig>(hiveConfig));
+  connector::registerConnector(hiveConnector);
+  seed(initialSeed);
+}
+
+template <typename T>
+bool isDone(size_t i, T startTime) {
+  if (FLAGS_duration_sec > 0) {
+    const std::chrono::duration<double> elapsed =
+        std::chrono::system_clock::now() - startTime;
+    return elapsed.count() >= FLAGS_duration_sec;
+  }
+  return i >= FLAGS_steps;
+}
+
+std::vector<TypePtr> MemoryArbitrationFuzzer::generateKeyTypes(
+    int32_t numKeys) {
+  std::vector<TypePtr> types;
+  types.reserve(numKeys);
+  for (auto i = 0; i < numKeys; ++i) {
+    // Pick random scalar type.
+    types.push_back(vectorFuzzer_.randType(0 /*maxDepth*/));
+  }
+  return types;
+}
+
+std::vector<RowVectorPtr> MemoryArbitrationFuzzer::generateProbeInput(
+    const std::vector<std::string>& keyNames,
+    const std::vector<TypePtr>& keyTypes) {
+  std::vector<std::string> names = keyNames;
+  std::vector<TypePtr> types = keyTypes;
+
+  bool keyTypesAllBool = true;
+  for (const auto& type : keyTypes) {
+    if (!type->isBoolean()) {
+      keyTypesAllBool = false;
+      break;
+    }
+  }
+
+  // Add up to 3 payload columns.
+  const auto numPayload = randInt(0, 3);
+  for (auto i = 0; i < numPayload; ++i) {
+    names.push_back(fmt::format("tp{}", i + keyNames.size()));
+    types.push_back(vectorFuzzer_.randType(2 /*maxDepth*/));
+  }
+
+  const auto inputType = ROW(std::move(names), std::move(types));
+  std::vector<RowVectorPtr> input;
+  for (auto i = 0; i < FLAGS_num_batches; ++i) {
+    if (keyTypesAllBool) {
+      // Joining on just boolean keys creates so many hits it explodes the
+      // output size, reduce the batch size to 10% to control the output size
+      // while still covering this case.
+      input.push_back(
+          vectorFuzzer_.fuzzRow(inputType, FLAGS_batch_size / 10, false));
+    } else {
+      input.push_back(vectorFuzzer_.fuzzInputRow(inputType));
+    }
+  }
+  return input;
+}
+
+std::vector<RowVectorPtr> MemoryArbitrationFuzzer::generateBuildInput(
+    const std::vector<RowVectorPtr>& probeInput,
+    const std::vector<std::string>& probeKeys,
+    const std::vector<std::string>& buildKeys) {
+  std::vector<std::string> names = buildKeys;
+  std::vector<TypePtr> types;
+  for (const auto& key : probeKeys) {
+    types.push_back(asRowType(probeInput[0]->type())->findChild(key));
+  }
+
+  // Add up to 3 payload columns.
+  const auto numPayload = randInt(0, 3);
+  for (auto i = 0; i < numPayload; ++i) {
+    names.push_back(fmt::format("bp{}", i + buildKeys.size()));
+    types.push_back(vectorFuzzer_.randType(2 /*maxDepth*/));
+  }
+
+  const auto rowType = ROW(std::move(names), std::move(types));
+
+  // 1 in 10 times use empty build.
+  if (vectorFuzzer_.coinToss(0.1)) {
+    return {BaseVector::create<RowVector>(rowType, 0, pool_.get())};
+  }
+
+  // To ensure there are some matches, sample with replacement 10% of probe join
+  // keys and use these as build keys.
+  std::vector<RowVectorPtr> input;
+  for (const auto& probe : probeInput) {
+    const auto numRows = 1 + probe->size() / 10;
+    auto build = BaseVector::create<RowVector>(rowType, numRows, probe->pool());
+
+    // Pick probe side rows to copy.
+    std::vector<vector_size_t> rowNumbers(numRows);
+    for (auto i = 0; i < numRows; ++i) {
+      rowNumbers[i] = randInt(0, probe->size() - 1);
+    }
+
+    SelectivityVector rows(numRows);
+    for (auto i = 0; i < probeKeys.size(); ++i) {
+      build->childAt(i)->resize(numRows);
+      build->childAt(i)->copy(probe->childAt(i).get(), rows, rowNumbers.data());
+    }
+
+    for (auto i = 0; i < numPayload; ++i) {
+      const auto column = i + probeKeys.size();
+      build->childAt(column) =
+          vectorFuzzer_.fuzz(rowType->childAt(column), numRows);
+    }
+
+    input.push_back(build);
+  }
+
+  return input;
+}
+
+std::vector<RowVectorPtr> MemoryArbitrationFuzzer::generateAggregateInput(
+    const std::vector<std::string>& keyNames,
+    const std::vector<TypePtr>& keyTypes) {
+  return generateProbeInput(keyNames, keyTypes);
+}
+
+std::vector<std::string> makeNames(const std::string& prefix, size_t n) {
+  std::vector<std::string> names;
+  names.reserve(n);
+  for (auto i = 0; i < n; ++i) {
+    names.push_back(fmt::format("{}{}", prefix, i));
+  }
+  return names;
+}
+
+RowTypePtr concat(const RowTypePtr& a, const RowTypePtr& b) {
+  std::vector<std::string> names = a->names();
+  std::vector<TypePtr> types = a->children();
+
+  for (auto i = 0; i < b->size(); ++i) {
+    names.push_back(b->nameOf(i));
+    types.push_back(b->childAt(i));
+  }
+
+  return ROW(std::move(names), std::move(types));
+}
+
+std::vector<Split> fromConnectorSplits(
+    std::vector<std::shared_ptr<connector::ConnectorSplit>> connectorSplits) {
+  std::vector<Split> splits;
+  splits.reserve(connectorSplits.size());
+  for (auto& connectorSplit : connectorSplits) {
+    splits.emplace_back(std::move(connectorSplit));
+  }
+  return splits;
+}
+
+bool isTableScanSupported(const TypePtr& type) {
+  if (type->kind() == TypeKind::ROW && type->size() == 0) {
+    return false;
+  }
+  if (type->kind() == TypeKind::UNKNOWN) {
+    return false;
+  }
+
+  for (auto i = 0; i < type->size(); ++i) {
+    if (!isTableScanSupported(type->childAt(i))) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+std::vector<MemoryArbitrationFuzzer::PlanWithSplits>
+MemoryArbitrationFuzzer::hashJoinPlans(
+    const core::JoinType& joinType,
+    const std::vector<std::string>& probeKeys,
+    const std::vector<std::string>& buildKeys,
+    const std::vector<RowVectorPtr>& probeInput,
+    const std::vector<RowVectorPtr>& buildInput,
+    const std::vector<std::shared_ptr<connector::ConnectorSplit>>& probeSplits,
+    const std::vector<std::shared_ptr<connector::ConnectorSplit>>&
+        buildSplits) {
+  auto outputColumns =
+      (core::isLeftSemiProjectJoin(joinType) ||
+       core::isLeftSemiFilterJoin(joinType) || core::isAntiJoin(joinType))
+      ? asRowType(probeInput[0]->type())->names()
+      : concat(
+            asRowType(probeInput[0]->type()), asRowType(buildInput[0]->type()))
+            ->names();
+
+  if (core::isLeftSemiProjectJoin(joinType) ||
+      core::isRightSemiProjectJoin(joinType)) {
+    outputColumns.emplace_back("match");
+  }
+
+  std::vector<PlanWithSplits> plans;
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .values(probeInput)
+          .hashJoin(
+              probeKeys,
+              buildKeys,
+              PlanBuilder(planNodeIdGenerator).values(buildInput).planNode(),
+              /*filter=*/"",
+              outputColumns,
+              joinType,
+              false)
+          .planNode();
+  plans.push_back(PlanWithSplits{std::move(plan), {}});
+
+  if (!isTableScanSupported(probeInput[0]->type()) ||
+      !isTableScanSupported(buildInput[0]->type())) {
+    return plans;
+  }
+
+  planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  const auto probeType = asRowType(probeInput[0]->type());
+  const auto buildType = asRowType(buildInput[0]->type());
+  core::PlanNodeId probeScanId;
+  core::PlanNodeId buildScanId;
+  plan = PlanBuilder(planNodeIdGenerator)
+             .tableScan(probeType)
+             .capturePlanNodeId(probeScanId)
+             .hashJoin(
+                 probeKeys,
+                 buildKeys,
+                 PlanBuilder(planNodeIdGenerator)
+                     .tableScan(buildType)
+                     .capturePlanNodeId(buildScanId)
+                     .planNode(),
+                 /*filter=*/"",
+                 outputColumns,
+                 joinType,
+                 false)
+             .planNode();
+  plans.push_back(PlanWithSplits{
+      std::move(plan),
+      {{probeScanId, fromConnectorSplits(probeSplits)},
+       {buildScanId, fromConnectorSplits(buildSplits)}}});
+  return plans;
+}
+
+void writeToFile(
+    const std::string& path,
+    const VectorPtr& vector,
+    memory::MemoryPool* pool) {
+  dwrf::WriterOptions options;
+  options.schema = vector->type();
+  options.memoryPool = pool;
+  auto writeFile = std::make_unique<LocalWriteFile>(path, true, false);
+  auto sink =
+      std::make_unique<dwio::common::WriteFileSink>(std::move(writeFile), path);
+  dwrf::Writer writer(std::move(sink), options);
+  writer.write(vector);
+  writer.close();
+}
+
+std::shared_ptr<connector::ConnectorSplit> MemoryArbitrationFuzzer::makeSplit(
+    const std::string& filePath) {
+  return std::make_shared<connector::hive::HiveConnectorSplit>(
+      kHiveConnectorId, filePath, dwio::common::FileFormat::DWRF);
+}
+
+std::vector<MemoryArbitrationFuzzer::PlanWithSplits>
+MemoryArbitrationFuzzer::hashJoinPlans(const std::string& tableDir) {
+  static const std::vector<core::JoinType> kJoinTypes = {
+      core::JoinType::kInner,
+      core::JoinType::kLeft,
+      core::JoinType::kFull,
+      core::JoinType::kLeftSemiFilter,
+      core::JoinType::kLeftSemiProject,
+      core::JoinType::kAnti};
+
+  const auto numKeys = randInt(1, 5);
+  const std::vector<TypePtr> keyTypes = generateKeyTypes(numKeys);
+  std::vector<std::string> probeKeys = makeNames("t", keyTypes.size());
+  std::vector<std::string> buildKeys = makeNames("u", keyTypes.size());
+  const auto probeInput = generateProbeInput(probeKeys, keyTypes);
+  const auto buildInput = generateBuildInput(probeInput, probeKeys, buildKeys);
+
+  std::vector<std::shared_ptr<connector::ConnectorSplit>> probeScanSplits;
+  for (auto i = 0; i < probeInput.size(); ++i) {
+    const std::string filePath = fmt::format("{}/probe{}", tableDir, i);
+    writeToFile(filePath, probeInput[i], writerPool_.get());
+    probeScanSplits.push_back(makeSplit(filePath));
+  }
+
+  std::vector<std::shared_ptr<connector::ConnectorSplit>> buildScanSplits;
+  for (auto i = 0; i < buildInput.size(); ++i) {
+    const std::string filePath = fmt::format("{}/build{}", tableDir, i);
+    writeToFile(filePath, buildInput[i], writerPool_.get());
+    buildScanSplits.push_back(makeSplit(filePath));
+  }
+
+  std::vector<PlanWithSplits> totalPlans;
+  for (const auto& joinType : kJoinTypes) {
+    auto plans = hashJoinPlans(
+        joinType,
+        probeKeys,
+        buildKeys,
+        probeInput,
+        buildInput,
+        probeScanSplits,
+        buildScanSplits);
+    totalPlans.insert(
+        totalPlans.end(),
+        std::make_move_iterator(plans.begin()),
+        std::make_move_iterator(plans.end()));
+  }
+  return totalPlans;
+}
+
+std::vector<MemoryArbitrationFuzzer::PlanWithSplits>
+MemoryArbitrationFuzzer::aggregatePlans(const std::string& tableDir) {
+  const auto numKeys = randInt(1, 5);
+  // Reuse the hash join utilites to generate aggregation keys and inputs.
+  const std::vector<TypePtr> keyTypes = generateKeyTypes(numKeys);
+  const std::vector<std::string> groupingKeys = makeNames("g", keyTypes.size());
+  const auto aggregateInput = generateAggregateInput(groupingKeys, keyTypes);
+  const std::vector<std::string> aggregates{"count(1)"};
+
+  std::vector<std::shared_ptr<connector::ConnectorSplit>> splits;
+  for (auto i = 0; i < aggregateInput.size(); ++i) {
+    const std::string filePath = fmt::format("{}/aggregate{}", tableDir, i);
+    writeToFile(filePath, aggregateInput[i], writerPool_.get());
+    splits.push_back(makeSplit(filePath));
+  }
+
+  std::vector<PlanWithSplits> plans;
+  const auto inputRowType = asRowType(aggregateInput[0]->type());
+  {
+    const auto planNodeIdGenerator =
+        std::make_shared<core::PlanNodeIdGenerator>();
+    core::PlanNodeId scanId;
+    auto plan = PlanWithSplits{
+        PlanBuilder(planNodeIdGenerator)
+            .tableScan(inputRowType)
+            .capturePlanNodeId(scanId)
+            .singleAggregation(groupingKeys, aggregates, {})
+            .planNode(),
+        {{scanId, fromConnectorSplits(splits)}}};
+    plans.push_back(std::move(plan));
+
+    plan = PlanWithSplits{
+        PlanBuilder()
+            .values(aggregateInput)
+            .singleAggregation(groupingKeys, aggregates, {})
+            .planNode(),
+        {}};
+    plans.push_back(std::move(plan));
+  }
+
+  {
+    // Partial -> final aggregation plan.
+    const auto planNodeIdGenerator =
+        std::make_shared<core::PlanNodeIdGenerator>();
+    core::PlanNodeId scanId;
+    auto plan = PlanWithSplits{
+        PlanBuilder(planNodeIdGenerator)
+            .tableScan(inputRowType)
+            .capturePlanNodeId(scanId)
+            .partialAggregation(groupingKeys, aggregates, {})
+            .finalAggregation()
+            .planNode(),
+        {{scanId, fromConnectorSplits(splits)}}};
+    plans.push_back(std::move(plan));
+
+    plan = PlanWithSplits{
+        PlanBuilder()
+            .values(aggregateInput)
+            .partialAggregation(groupingKeys, aggregates, {})
+            .finalAggregation()
+            .planNode(),
+        {}};
+    plans.push_back(std::move(plan));
+  }
+
+  {
+    // Partial -> intermediate -> final aggregation plan.
+    const auto planNodeIdGenerator =
+        std::make_shared<core::PlanNodeIdGenerator>();
+    core::PlanNodeId scanId;
+    auto plan = PlanWithSplits{
+        PlanBuilder(planNodeIdGenerator)
+            .tableScan(inputRowType)
+            .capturePlanNodeId(scanId)
+            .partialAggregation(groupingKeys, aggregates, {})
+            .intermediateAggregation()
+            .finalAggregation()
+            .planNode(),
+        {{scanId, fromConnectorSplits(splits)}}};
+    plans.push_back(std::move(plan));
+
+    plan = PlanWithSplits{
+        PlanBuilder()
+            .values(aggregateInput)
+            .partialAggregation(groupingKeys, aggregates, {})
+            .intermediateAggregation()
+            .finalAggregation()
+            .planNode(),
+        {}};
+    plans.push_back(std::move(plan));
+  }
+
+  return plans;
+}
+
+void MemoryArbitrationFuzzer::verify() {
+  const auto outputDirectory = TempDirectoryPath::create();
+  const auto spillDirectory = exec::test::TempDirectoryPath::create();
+  const auto tableScanDir = exec::test::TempDirectoryPath::create();
+
+  std::vector<PlanWithSplits> plans;
+  for (const auto& plan : hashJoinPlans(tableScanDir->getPath())) {
+    plans.push_back(plan);
+  }
+  for (const auto& plan : aggregatePlans(tableScanDir->getPath())) {
+    plans.push_back(plan);
+  }
+
+  SCOPE_EXIT {
+    waitForAllTasksToBeDeleted();
+  };
+
+  const auto numThreads = FLAGS_num_threads;
+  std::atomic_bool stop{false};
+  std::vector<std::thread> queryThreads;
+  queryThreads.reserve(numThreads);
+  for (int i = 0; i < numThreads; ++i) {
+    queryThreads.emplace_back([&, i]() {
+      while (!stop) {
+        try {
+          const auto queryCtx = newQueryCtx(
+              memory::memoryManager(),
+              executor_.get(),
+              FLAGS_arbitrator_capacity);
+          const auto plan = plans.at(randInt(0, plans.size() - 1));
+          AssertQueryBuilder builder(plan.plan);
+          builder.queryCtx(queryCtx);
+          for (const auto& [planNodeId, nodeSplits] : plan.splits) {
+            builder.splits(planNodeId, nodeSplits);
+          }
+
+          if (vectorFuzzer_.coinToss(0.3)) {
+            builder.queryCtx(queryCtx).copyResults(pool_.get());
+          } else {
+            auto res =
+                builder.configs(queryConfigsWithSpill_)
+                    .spillDirectory(
+                        spillDirectory->getPath() + fmt::format("/{}/", i))
+                    .queryCtx(queryCtx)
+                    .copyResults(pool_.get());
+          }
+          ++stats_.wlock()->successCount;
+        } catch (const VeloxException& e) {
+          auto lockedStats = stats_.wlock();
+          if (e.errorCode() == error_code::kMemCapExceeded.c_str()) {
+            ++lockedStats->oomCount;
+          } else if (e.errorCode() == error_code::kMemAborted.c_str()) {
+            ++lockedStats->abortCount;
+          } else {
+            ++lockedStats->failureCount;
+            std::rethrow_exception(std::current_exception());
+          }
+        }
+      }
+    });
+  }
+
+  std::this_thread::sleep_for(
+      std::chrono::seconds(FLAGS_iteration_duration_sec));
+  stop = true;
+
+  for (auto& queryThread : queryThreads) {
+    queryThread.join();
+  }
+}
+
+void MemoryArbitrationFuzzer::go() {
+  VELOX_USER_CHECK(
+      FLAGS_steps > 0 || FLAGS_duration_sec > 0,
+      "Either --steps or --duration_sec needs to be greater than zero.")
+  VELOX_USER_CHECK_GE(FLAGS_batch_size, 10, "Batch size must be at least 10.");
+
+  const auto startTime = std::chrono::system_clock::now();
+  size_t iteration = 0;
+
+  while (!isDone(iteration, startTime)) {
+    LOG(WARNING) << "==============================> Started iteration "
+                 << iteration << " (seed: " << currentSeed_ << ")";
+
+    verify();
+
+    LOG(INFO) << "==============================> Done with iteration "
+              << iteration;
+    stats_.rlock()->print();
+
+    reSeed();
+    ++iteration;
+  }
+}
+
+} // namespace
+
+void memoryArbitrationFuzzer(size_t seed) {
+  MemoryArbitrationFuzzer(seed).go();
+}
+} // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/MemoryArbitrationFuzzer.h
+++ b/velox/exec/fuzzer/MemoryArbitrationFuzzer.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+
+namespace facebook::velox::exec::test {
+void memoryArbitrationFuzzer(size_t seed);
+}

--- a/velox/exec/fuzzer/MemoryArbitrationFuzzerRunner.h
+++ b/velox/exec/fuzzer/MemoryArbitrationFuzzerRunner.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "velox/common/file/FileSystems.h"
+
+#include "velox/exec/fuzzer/MemoryArbitrationFuzzer.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/serializers/PrestoSerializer.h"
+
+namespace facebook::velox::exec::test {
+
+class MemoryArbitrationFuzzerRunner {
+ public:
+  static int run(size_t seed) {
+    serializer::presto::PrestoVectorSerde::registerVectorSerde();
+    filesystems::registerLocalFileSystem();
+    functions::prestosql::registerAllScalarFunctions();
+    aggregate::prestosql::registerAllAggregateFunctions();
+    memoryArbitrationFuzzer(seed);
+    return RUN_ALL_TESTS();
+  }
+};
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -214,6 +214,13 @@ add_executable(velox_join_fuzzer_test JoinFuzzerTest.cpp)
 
 target_link_libraries(velox_join_fuzzer_test velox_join_fuzzer gtest gtest_main)
 
+# Arbitration Fuzzer.
+add_executable(velox_memory_arbitration_fuzzer_test
+               MemoryArbitrationFuzzerTest.cpp)
+
+target_link_libraries(velox_memory_arbitration_fuzzer_test
+                      velox_memory_arbitration_fuzzer gtest gtest_main)
+
 add_executable(velox_exchange_fuzzer_test ExchangeFuzzer.cpp)
 
 target_link_libraries(

--- a/velox/exec/tests/MemoryArbitrationFuzzerTest.cpp
+++ b/velox/exec/tests/MemoryArbitrationFuzzerTest.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/init/Init.h>
+#include <gflags/gflags.h>
+#include <gtest/gtest.h>
+#include <unordered_set>
+#include "velox/common/memory/SharedArbitrator.h"
+#include "velox/connectors/hive/HiveConnector.h"
+#include "velox/exec/MemoryReclaimer.h"
+#include "velox/exec/fuzzer/MemoryArbitrationFuzzerRunner.h"
+#include "velox/exec/fuzzer/PrestoQueryRunner.h"
+#include "velox/exec/fuzzer/ReferenceQueryRunner.h"
+
+DEFINE_int64(allocator_capacity, 32L << 30, "Allocator capacity in bytes.");
+
+DECLARE_int64(arbitrator_capacity);
+
+DEFINE_int64(
+    seed,
+    0,
+    "Initial seed for random number generator used to reproduce previous "
+    "results (0 means start with random seed).");
+
+using namespace facebook::velox::exec;
+
+namespace {
+// Invoked to set up memory system with arbitration.
+void setupMemory() {
+  FLAGS_velox_enable_memory_usage_track_in_default_memory_pool = true;
+  FLAGS_velox_memory_leak_check_enabled = true;
+  facebook::velox::memory::SharedArbitrator::registerFactory();
+  facebook::velox::memory::MemoryManagerOptions options;
+  options.allocatorCapacity = FLAGS_allocator_capacity;
+  options.arbitratorCapacity = FLAGS_arbitrator_capacity;
+  options.arbitratorKind = "SHARED";
+  options.checkUsageLeak = true;
+  options.arbitrationStateCheckCb = memoryArbitrationStateCheck;
+  facebook::velox::memory::MemoryManager::initialize(options);
+}
+} // namespace
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // Calls common init functions in the necessary order, initializing
+  // singletons, installing proper signal handlers for better debugging
+  // experience, and initialize glog and gflags.
+  folly::Init init(&argc, &argv);
+  setupMemory();
+  const size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
+  return test::MemoryArbitrationFuzzerRunner::run(initialSeed);
+}


### PR DESCRIPTION
The MemoryArbitrationFuzzer is a testing tool designed to automatically
generate and execute multiple query plans. It aims to trigger memory
arbitration and validate whether the query succeeds or throws expected exceptions.
It works as follows:

1. Data Generation: It starts by generating a random set of input data, also known as a vector.
    This data can have a variety of encodings and data layouts to ensure thorough testing.
2. Plan Generation: Generate multiple plans with different query shapes. 
    Currently, it supports HashJoin and HashAggregation plans.
3. Query Execution: Create multiple threads, each threads randomly pick a plan,
   enables spill randomly, and then runs for `${iteration_duration_sec}` seconds.
   It throws if the exception is not an expected memory arbitration exception.
4. Iteration: This process is repeated multiple times to ensure reliability and robustness.