### PR TITLE
Fix flaky MultiFragmentTest.exchangeStatsOnFailure

### DIFF
--- a/velox/exec/ExchangeSource.h
+++ b/velox/exec/ExchangeSource.h
@@ -139,12 +139,16 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
 
   static std::vector<Factory>& factories();
 
+  ExchangeQueue* testingQueue() const {
+    return queue_.get();
+  }
+
  protected:
   // ID of the task producing data
   const std::string taskId_;
   // Destination number of 'this' on producer
   const int destination_;
-  const std::shared_ptr<ExchangeQueue> queue_;
+  const std::shared_ptr<ExchangeQueue> queue_{nullptr};
   // Holds a shared reference on the memory pool as it might be still possible
   // to be accessed by external components after the query task is destroyed.
   // For instance, in Prestissimo, there might be a pending http request issued

--- a/velox/exec/tests/utils/LocalExchangeSource.cpp
+++ b/velox/exec/tests/utils/LocalExchangeSource.cpp
@@ -110,7 +110,7 @@ class LocalExchangeSource : public exec::ExchangeSource {
 
       try {
         common::testutil::TestValue::adjust(
-            "facebook::velox::exec::test::LocalExchangeSource", &numPages_);
+            "facebook::velox::exec::test::LocalExchangeSource", this);
       } catch (const std::exception& e) {
         queue_->setError(e.what());
         checkSetRequestPromise();


### PR DESCRIPTION
This test is flaky in Meta internal test as the number of received page update in exchange queue
update is after the error injection on page receiving. Therefore if the number of received pages is
more one, the runtime stats check breaks. This PR de-flake this test by setting the expected received
page runtime stats when we throw exception.