### PR TITLE
Fix local exchange source race which might cause memory leak check failure

### DIFF
--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -47,10 +47,6 @@ class MultiFragmentTest : public HiveConnectorTestBase {
   }
 
   void TearDown() override {
-    // There might be lingering exchange source on executor even after all tasks
-    // are deleted. This can cause memory leak because exchange source holds
-    // reference to memory pool. We need to make sure they are properly cleaned.
-    testingShutdownLocalExchangeSource();
     vectors_.clear();
     HiveConnectorTestBase::TearDown();
   }

--- a/velox/exec/tests/utils/LocalExchangeSource.h
+++ b/velox/exec/tests/utils/LocalExchangeSource.h
@@ -26,6 +26,11 @@ std::unique_ptr<exec::ExchangeSource> createLocalExchangeSource(
     std::shared_ptr<exec::ExchangeQueue> queue,
     memory::MemoryPool* pool);
 
+/// Sets the local exchange source to start by clearing 'stop_'. This is used
+/// when we run multiple test cases sequentially and restarts the local exchange
+/// source between tests.
+void testingStartLocalExchangeSource();
+
 /// Ensures that there are no references to ExchangeSource callbacks,
 /// e.g. while waiting for timing out. Call this before end of unit
 /// tests to ensure no ASAN errors at exit.

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -23,6 +23,7 @@
 #include "velox/exec/Exchange.h"
 #include "velox/exec/OutputBufferManager.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/LocalExchangeSource.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/parse/Expressions.h"
@@ -112,10 +113,15 @@ void OperatorTestBase::SetUp() {
   }
   driverExecutor_ = std::make_unique<folly::CPUThreadPoolExecutor>(3);
   ioExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(3);
+  testingStartLocalExchangeSource();
 }
 
 void OperatorTestBase::TearDown() {
   waitForAllTasksToBeDeleted();
+  // There might be lingering exchange source on executor even after all tasks
+  // are deleted. This can cause memory leak because exchange source holds
+  // reference to memory pool. We need to make sure they are properly cleaned.
+  testingShutdownLocalExchangeSource();
   pool_.reset();
   rootPool_.reset();
   resetMemory();


### PR DESCRIPTION
We have seen memory pool leak check failure at the end of some multi-fragment test case.
By checking the log, there is no leaking task as OperatorTestBase::tearDown waits for the
pending tasks to be destroyed. We do have pending shared_ptr reference to the leaked
memory pool. By looking at the code, it could be due to the following race in how we handle
the local exchange source shutdown (note local exchange source is used by unit test for now):
T1. task sends a request;
T2. before the local exchange sets a timeout for this request, the test quit because of fault
      injection and multi-fragment test case tearDown stops the local exchange source execution
      which clears the timeout and reset the background timeout check daemon;
T3. the local exchange source tries to set timeout for the request in T1 and create a new timeout
T4. the operator test base shutdown waits for all the created tasks to be destroyed.
T5. the memory system shutdown and found there is leaked reference to the memory pool held
       by pending timeout created by T3.

This PR fixes this by adding localExchangeSource start method which is called when we start the
the multiframent unit test case in startUp method which clears 'stop_' flag to allow to create the
background daemon on the first request. Correspondingly, if 'stop_' has been set, we shouldn't allow
to create anymore request timeout and throws if 'stop_' is set. Also when we shutdown
localExchangeSource, we set 'stop_' under lock and makes sure stop_ and background timeout check
daemon and the pending timeouts states are always consistent.

Passed Meta internal test for 10'000 times: https://www.internalfb.com/intern/testinfra/testrun/10133099196500739