### PR TITLE
Fix input_file_name spark function to return full path of file not only name

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -64,6 +64,10 @@ struct ConnectorSplit {
   virtual std::string getFileName() const {
     return "";
   }
+
+  virtual std::string getFullFileName() const {
+    return "";
+  }
 };
 
 class ColumnHandle : public ISerializable {

--- a/velox/connectors/hive/HiveConnectorSplit.h
+++ b/velox/connectors/hive/HiveConnectorSplit.h
@@ -82,8 +82,7 @@ struct HiveConnectorSplit : public connector::ConnectorSplit {
   }
 
   std::string getFileName() const override {
-    auto i = filePath.rfind('/');
-    return i == std::string::npos ? filePath : filePath.substr(i + 1);
+    return filePath;
   }
 };
 

--- a/velox/connectors/hive/HiveConnectorSplit.h
+++ b/velox/connectors/hive/HiveConnectorSplit.h
@@ -82,6 +82,11 @@ struct HiveConnectorSplit : public connector::ConnectorSplit {
   }
 
   std::string getFileName() const override {
+    auto i = filePath.rfind('/');
+    return i == std::string::npos ? filePath : filePath.substr(i + 1);
+  }
+
+  std::string getFullFileName() const override {
     return filePath;
   }
 };

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -354,7 +354,7 @@ void TableScan::checkPreload() {
 
 void TableScan::setInputFileName(
     std::shared_ptr<connector::ConnectorSplit> split) {
-  driverCtx_->inputFileName = split->getFileName();
+  driverCtx_->inputFileName = split->getFullFileName();
 }
 
 bool TableScan::isFinished() {


### PR DESCRIPTION
Spark expect `input_file_name` return fall absolute path of the file not only file name.

for example `file:///tmp/spark-xxxxx.parquet` is correct not `spark-xxx.parquet`

Verifed in gluten end to end and pass the spark ut when offload to velox.

spark code https://github.com/apache/spark/blob/4fc2910f92d1b5f7e0dd5f803e822668f23c21c5/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/inputFileBlock.scala#L50C1-L50C42