### PR TITLE
Fix cast(IntervalDayTime as Varchar) for negative intervals

### DIFF
--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -2603,7 +2603,10 @@ TEST_F(CastExprTest, intervalDayTimeToVarchar) {
            kMillisInMinute,
            kMillisInSecond,
            5 * kMillisInDay + 14 * kMillisInHour + 20 * kMillisInMinute +
-               52 * kMillisInSecond + 88},
+               52 * kMillisInSecond + 88,
+           -(kMillisInDay + kMillisInHour + kMillisInMinute + kMillisInSecond +
+             88),
+           std::numeric_limits<int64_t>::min()},
           INTERVAL_DAY_TIME()),
   });
 
@@ -2614,9 +2617,11 @@ TEST_F(CastExprTest, intervalDayTimeToVarchar) {
       "0 00:01:00.000",
       "0 00:00:01.000",
       "5 14:20:52.088",
+      "-1 01:01:01.088",
+      "-106751991167 07:12:55.808",
   });
 
-  assertEqualVectors(result, expected);
+  assertEqualVectors(expected, result);
 
   // Reverse cast is not supported.
   VELOX_ASSERT_THROW(

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -937,9 +937,14 @@ void toTypeSql(const TypePtr& type, std::ostream& out) {
 }
 
 std::string IntervalDayTimeType::valueToString(int64_t value) const {
-  static const char* kIntervalFormat = "%d %02d:%02d:%02d.%03d";
+  static const char* kIntervalFormat = "%s%lld %02d:%02d:%02d.%03d";
 
-  int64_t remainMillis = value;
+  int128_t remainMillis = value;
+  std::string sign{};
+  if (remainMillis < 0) {
+    sign = "-";
+    remainMillis = -remainMillis;
+  }
   const int64_t days = remainMillis / kMillisInDay;
   remainMillis -= days * kMillisInDay;
   const int64_t hours = remainMillis / kMillisInHour;
@@ -953,6 +958,7 @@ std::string IntervalDayTimeType::valueToString(int64_t value) const {
       buf,
       sizeof(buf),
       kIntervalFormat,
+      sign.c_str(),
       days,
       hours,
       minutes,


### PR DESCRIPTION
Summary:
For negitive intervals, the negative sign should only appear before 
the number of days, e.g., `-1 01:01:01.001`. The current code adds 
negative signs before the number of days, hours, minutes, seconds, 
and milliseconds too, e.g., `-1 -1:-1:-1.-1`. This diff fixes this bug.

Differential Revision: D57572125


