### PR TITLE
Add PrestoQueryRunner/DuckDbQueryRunner supports for join fuzzer

### DIFF
--- a/velox/docs/develop/testing/join-fuzzer.rst
+++ b/velox/docs/develop/testing/join-fuzzer.rst
@@ -15,7 +15,7 @@ combined with randomly generated payload. When generating the join plan node,
 fuzzer shuffles join keys and output columns and randomly drops some columns
 from the output.
 
-The fuzzer runs the query plan and compares the results with DuckDB.
+The fuzzer runs the query plan and compares the results with the reference (DuckDB or Presto) as the expected result.
 
 The fuzzer then generates a set of different but logically equivalent plans,
 runs them and verifies that results are the same. Each plan runs twice: with
@@ -64,5 +64,9 @@ Here is a full list of supported command line arguments.
   generate. Default is 5.
 
 * ``--enable_spill``: Whether to test with spilling or not. Default is true.
+
+* ``--arbitrator_capacity``: Arbitrator capacity in bytes. Default is 6L << 30.
+
+* ``--allocator_capacity``: Allocator capacity in bytes. Default is 8L << 30.
 
 If running from CLion IDE, add ``--logtostderr=1`` to see the full output.

--- a/velox/docs/develop/testing/row-number-fuzzer.rst
+++ b/velox/docs/develop/testing/row-number-fuzzer.rst
@@ -52,4 +52,8 @@ Here is a full list of supported command line arguments.
 
 * ``--req_timeout_ms`` Timeout in milliseconds of an HTTP request to the PrestoQueryRunner.
 
+* ``--arbitrator_capacity``: Arbitrator capacity in bytes. Default is 6L << 30.
+
+* ``--allocator_capacity``: Allocator capacity in bytes. Default is 8L << 30.
+
 If running from CLion IDE, add ``--logtostderr=1`` to see the full output.

--- a/velox/exec/fuzzer/DuckQueryRunner.h
+++ b/velox/exec/fuzzer/DuckQueryRunner.h
@@ -39,6 +39,12 @@ class DuckQueryRunner : public ReferenceQueryRunner {
       const std::vector<RowVectorPtr>& input,
       const RowTypePtr& resultType) override;
 
+  std::multiset<std::vector<velox::variant>> execute(
+      const std::string& sql,
+      const std::vector<RowVectorPtr>& probeInput,
+      const std::vector<RowVectorPtr>& buildInput,
+      const RowTypePtr& resultType) override;
+
  private:
   std::optional<std::string> toSql(
       const std::shared_ptr<const core::AggregationNode>& aggregationNode);
@@ -51,6 +57,12 @@ class DuckQueryRunner : public ReferenceQueryRunner {
 
   std::optional<std::string> toSql(
       const std::shared_ptr<const core::RowNumberNode>& rowNumberNode);
+
+  std::optional<std::string> toSql(
+      const std::shared_ptr<const core::HashJoinNode>& joinNode);
+
+  std::optional<std::string> toSql(
+      const std::shared_ptr<const core::NestedLoopJoinNode>& joinNode);
 
   std::unordered_set<std::string> aggregateFunctionNames_;
 };

--- a/velox/exec/fuzzer/FuzzerUtil.h
+++ b/velox/exec/fuzzer/FuzzerUtil.h
@@ -68,4 +68,7 @@ RowTypePtr concat(const RowTypePtr& a, const RowTypePtr& b);
 ///
 /// TODO Investigate mismatches reported when comparing Varbinary.
 bool containsUnsupportedTypes(const TypePtr& type);
+
+// Invoked to set up memory system with arbitration.
+void setupMemory(int64_t allocatorCapacity, int64_t arbitratorCapacity);
 } // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/JoinFuzzer.h
+++ b/velox/exec/fuzzer/JoinFuzzer.h
@@ -16,7 +16,10 @@
 #pragma once
 
 #include <cstddef>
+#include "velox/exec/fuzzer/ReferenceQueryRunner.h"
 
 namespace facebook::velox::exec::test {
-void joinFuzzer(size_t seed);
+void joinFuzzer(
+    size_t seed,
+    std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner);
 }

--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -78,6 +78,28 @@ RowVectorPtr deserialize(
   return result;
 }
 
+RowVectorPtr makeNullRows(
+    const std::vector<velox::RowVectorPtr>& input,
+    const std::string& colName,
+    memory::MemoryPool* pool) {
+  // The query doesn't need to read any columns, but it needs to see a
+  // specific number of rows. Make new 'input' as single all-null BIGINT
+  // column with as many rows as original input. This way we'll be able to
+  // create a temporary test table with the necessary number of rows.
+  vector_size_t numInput = 0;
+  for (const auto& v : input) {
+    numInput += v->size();
+  }
+
+  auto column = BaseVector::createNullConstant(BIGINT(), numInput, pool);
+  return std::make_shared<RowVector>(
+      pool,
+      ROW({colName}, {BIGINT()}),
+      nullptr,
+      numInput,
+      std::vector<VectorPtr>{column});
+}
+
 class ServerResponse {
  public:
   explicit ServerResponse(const std::string& responseJson)
@@ -174,6 +196,16 @@ std::optional<std::string> PrestoQueryRunner::toSql(
   if (auto tableWriteNode =
           std::dynamic_pointer_cast<const core::TableWriteNode>(plan)) {
     return toSql(tableWriteNode);
+  }
+
+  if (const auto joinNode =
+          std::dynamic_pointer_cast<const core::HashJoinNode>(plan)) {
+    return toSql(joinNode);
+  }
+
+  if (const auto joinNode =
+          std::dynamic_pointer_cast<const core::NestedLoopJoinNode>(plan)) {
+    return toSql(joinNode);
   }
 
   VELOX_NYI();
@@ -579,11 +611,217 @@ std::optional<std::string> PrestoQueryRunner::toSql(
   return sql.str();
 }
 
+std::optional<std::string> PrestoQueryRunner::toSql(
+    const std::shared_ptr<const core::HashJoinNode>& joinNode) {
+  if (!isSupportedDwrfType(joinNode->sources()[0]->outputType())) {
+    return std::nullopt;
+  }
+
+  if (!isSupportedDwrfType(joinNode->sources()[1]->outputType())) {
+    return std::nullopt;
+  }
+
+  const auto joinKeysToSql = [](auto keys) {
+    std::stringstream out;
+    for (auto i = 0; i < keys.size(); ++i) {
+      if (i > 0) {
+        out << ", ";
+      }
+      out << keys[i]->name();
+    }
+    return out.str();
+  };
+
+  const auto equiClausesToSql = [](auto joinNode) {
+    std::stringstream out;
+    for (auto i = 0; i < joinNode->leftKeys().size(); ++i) {
+      if (i > 0) {
+        out << " AND ";
+      }
+      out << joinNode->leftKeys()[i]->name() << " = "
+          << joinNode->rightKeys()[i]->name();
+    }
+    return out.str();
+  };
+
+  const auto& outputNames = joinNode->outputType()->names();
+
+  std::stringstream sql;
+  if (joinNode->isLeftSemiProjectJoin()) {
+    sql << "SELECT "
+        << folly::join(", ", outputNames.begin(), --outputNames.end());
+  } else {
+    sql << "SELECT " << folly::join(", ", outputNames);
+  }
+
+  switch (joinNode->joinType()) {
+    case core::JoinType::kInner:
+      sql << " FROM t INNER JOIN u ON " << equiClausesToSql(joinNode);
+      break;
+    case core::JoinType::kLeft:
+      sql << " FROM t LEFT JOIN u ON " << equiClausesToSql(joinNode);
+      break;
+    case core::JoinType::kFull:
+      sql << " FROM t FULL OUTER JOIN u ON " << equiClausesToSql(joinNode);
+      break;
+    case core::JoinType::kLeftSemiFilter:
+      if (joinNode->leftKeys().size() > 1) {
+        return std::nullopt;
+      }
+      sql << " FROM t WHERE " << joinKeysToSql(joinNode->leftKeys())
+          << " IN (SELECT " << joinKeysToSql(joinNode->rightKeys())
+          << " FROM u)";
+      break;
+    case core::JoinType::kLeftSemiProject:
+      if (joinNode->isNullAware()) {
+        sql << ", " << joinKeysToSql(joinNode->leftKeys()) << " IN (SELECT "
+            << joinKeysToSql(joinNode->rightKeys()) << " FROM u) FROM t";
+      } else {
+        sql << ", EXISTS (SELECT * FROM u WHERE " << equiClausesToSql(joinNode)
+            << ") FROM t";
+      }
+      break;
+    case core::JoinType::kAnti:
+      if (joinNode->isNullAware()) {
+        sql << " FROM t WHERE " << joinKeysToSql(joinNode->leftKeys())
+            << " NOT IN (SELECT " << joinKeysToSql(joinNode->rightKeys())
+            << " FROM u)";
+      } else {
+        sql << " FROM t WHERE NOT EXISTS (SELECT * FROM u WHERE "
+            << equiClausesToSql(joinNode) << ")";
+      }
+      break;
+    default:
+      VELOX_UNREACHABLE(
+          "Unknown join type: {}", static_cast<int>(joinNode->joinType()));
+  }
+
+  return sql.str();
+}
+
+std::optional<std::string> PrestoQueryRunner::toSql(
+    const std::shared_ptr<const core::NestedLoopJoinNode>& joinNode) {
+  const auto& joinKeysToSql = [](auto keys) {
+    std::stringstream out;
+    for (auto i = 0; i < keys.size(); ++i) {
+      if (i > 0) {
+        out << ", ";
+      }
+      out << keys[i]->name();
+    }
+    return out.str();
+  };
+
+  const auto& outputNames = joinNode->outputType()->names();
+  std::stringstream sql;
+
+  // Nested loop join without filter.
+  VELOX_CHECK(
+      joinNode->joinCondition() == nullptr,
+      "This code path should be called only for nested loop join without filter");
+  const std::string joinCondition{"(1 = 1)"};
+  switch (joinNode->joinType()) {
+    case core::JoinType::kInner:
+      sql << " FROM t INNER JOIN u ON " << joinCondition;
+      break;
+    case core::JoinType::kLeft:
+      sql << " FROM t LEFT JOIN u ON " << joinCondition;
+      break;
+    case core::JoinType::kFull:
+      sql << " FROM t FULL OUTER JOIN u ON " << joinCondition;
+      break;
+    default:
+      VELOX_UNREACHABLE(
+          "Unknown join type: {}", static_cast<int>(joinNode->joinType()));
+  }
+
+  return sql.str();
+}
+
 std::multiset<std::vector<variant>> PrestoQueryRunner::execute(
     const std::string& sql,
     const std::vector<RowVectorPtr>& input,
     const RowTypePtr& resultType) {
   return exec::test::materialize(executeVector(sql, input, resultType));
+}
+
+std::multiset<std::vector<velox::variant>> PrestoQueryRunner::execute(
+    const std::string& sql,
+    const std::vector<RowVectorPtr>& probeInput,
+    const std::vector<RowVectorPtr>& buildInput,
+    const RowTypePtr& resultType) {
+  return exec::test::materialize(
+      executeVector(sql, probeInput, buildInput, resultType));
+}
+
+std::string PrestoQueryRunner::createTable(
+    const std::string& name,
+    const TypePtr& type) {
+  auto inputType = asRowType(type);
+  std::stringstream nullValues;
+  for (auto i = 0; i < inputType->size(); ++i) {
+    appendComma(i, nullValues);
+    nullValues << fmt::format(
+        "cast(null as {})", toTypeSql(inputType->childAt(i)));
+  }
+
+  execute(fmt::format("DROP TABLE IF EXISTS {}", name));
+
+  execute(fmt::format(
+      "CREATE TABLE {}({}) WITH (format = 'DWRF') AS SELECT {}",
+      name,
+      folly::join(", ", inputType->names()),
+      nullValues.str()));
+
+  // Query Presto to find out table's location on disk.
+  auto results = execute(fmt::format("SELECT \"$path\" FROM {}", name));
+
+  auto filePath = extractSingleValue<StringView>(results);
+  auto tableDirectoryPath = fs::path(filePath).parent_path();
+
+  // Delete the all-null row.
+  execute(fmt::format("DELETE FROM {}", name));
+
+  return tableDirectoryPath;
+}
+
+std::vector<velox::RowVectorPtr> PrestoQueryRunner::executeVector(
+    const std::string& sql,
+    const std::vector<RowVectorPtr>& probeInput,
+    const std::vector<RowVectorPtr>& buildInput,
+    const velox::RowTypePtr& resultType) {
+  auto probeType = asRowType(probeInput[0]->type());
+  if (probeType->size() == 0) {
+    auto rowVector = makeNullRows(probeInput, "x", pool());
+    return executeVector(sql, {rowVector}, buildInput, resultType);
+  }
+
+  auto buildType = asRowType(buildInput[0]->type());
+  if (probeType->size() == 0) {
+    auto rowVector = makeNullRows(buildInput, "y", pool());
+    return executeVector(sql, probeInput, {rowVector}, resultType);
+  }
+
+  auto probeTableDirectoryPath = createTable("t", probeInput[0]->type());
+  auto buildTableDirectoryPath = createTable("u", buildInput[0]->type());
+
+  // Create a new file in table's directory with fuzzer-generated data.
+  auto probeFilePath = fs::path(probeTableDirectoryPath)
+                           .append("probe.dwrf")
+                           .string()
+                           .substr(strlen("file:"));
+
+  auto buildFilePath = fs::path(buildTableDirectoryPath)
+                           .append("build.dwrf")
+                           .string()
+                           .substr(strlen("file:"));
+
+  auto writerPool = rootPool()->addAggregateChild("writer");
+  writeToFile(probeFilePath, probeInput, writerPool.get());
+  writeToFile(buildFilePath, buildInput, writerPool.get());
+
+  // Run the query.
+  return execute(sql);
 }
 
 std::vector<velox::RowVectorPtr> PrestoQueryRunner::executeVector(
@@ -592,50 +830,11 @@ std::vector<velox::RowVectorPtr> PrestoQueryRunner::executeVector(
     const velox::RowTypePtr& resultType) {
   auto inputType = asRowType(input[0]->type());
   if (inputType->size() == 0) {
-    // The query doesn't need to read any columns, but it needs to see a
-    // specific number of rows. Make new 'input' as single all-null BIGINT
-    // column with as many rows as original input. This way we'll be able to
-    // create a 'tmp' table will the necessary number of rows.
-    vector_size_t numInput = 0;
-    for (const auto& v : input) {
-      numInput += v->size();
-    }
-
-    auto column = BaseVector::createNullConstant(BIGINT(), numInput, pool());
-    auto rowVector = std::make_shared<RowVector>(
-        pool(),
-        ROW({"x"}, {BIGINT()}),
-        nullptr,
-        numInput,
-        std::vector<VectorPtr>{column});
+    auto rowVector = makeNullRows(input, "x", pool());
     return executeVector(sql, {rowVector}, resultType);
   }
 
-  // Create tmp table in Presto using DWRF file format and add a single
-  // all-null row to it.
-
-  std::stringstream nullValues;
-  for (auto i = 0; i < inputType->size(); ++i) {
-    appendComma(i, nullValues);
-    nullValues << fmt::format(
-        "cast(null as {})", toTypeSql(inputType->childAt(i)));
-  }
-
-  execute("DROP TABLE IF EXISTS tmp");
-
-  execute(fmt::format(
-      "CREATE TABLE tmp({}) WITH (format = 'DWRF') AS SELECT {}",
-      folly::join(", ", inputType->names()),
-      nullValues.str()));
-
-  // Query Presto to find out table's location on disk.
-  auto results = execute("SELECT \"$path\" FROM tmp");
-
-  auto filePath = extractSingleValue<StringView>(results);
-  auto tableDirectoryPath = fs::path(filePath).parent_path();
-
-  // Delete the all-null row.
-  execute("DELETE FROM tmp");
+  auto tableDirectoryPath = createTable("tmp", input[0]->type());
 
   // Create a new file in table's directory with fuzzer-generated data.
   auto newFilePath = fs::path(tableDirectoryPath)

--- a/velox/exec/fuzzer/PrestoQueryRunner.h
+++ b/velox/exec/fuzzer/PrestoQueryRunner.h
@@ -63,6 +63,12 @@ class PrestoQueryRunner : public velox::exec::test::ReferenceQueryRunner {
       const std::vector<velox::RowVectorPtr>& input,
       const velox::RowTypePtr& resultType) override;
 
+  std::multiset<std::vector<velox::variant>> execute(
+      const std::string& sql,
+      const std::vector<RowVectorPtr>& probeInput,
+      const std::vector<RowVectorPtr>& buildInput,
+      const RowTypePtr& resultType) override;
+
   /// Executes Presto SQL query and returns the results. Tables referenced by
   /// the query must already exist.
   std::vector<velox::RowVectorPtr> execute(const std::string& sql) override;
@@ -72,6 +78,12 @@ class PrestoQueryRunner : public velox::exec::test::ReferenceQueryRunner {
   std::vector<RowVectorPtr> executeVector(
       const std::string& sql,
       const std::vector<RowVectorPtr>& input,
+      const RowTypePtr& resultType) override;
+
+  std::vector<RowVectorPtr> executeVector(
+      const std::string& sql,
+      const std::vector<RowVectorPtr>& probeInput,
+      const std::vector<RowVectorPtr>& buildInput,
       const RowTypePtr& resultType) override;
 
  private:
@@ -99,9 +111,19 @@ class PrestoQueryRunner : public velox::exec::test::ReferenceQueryRunner {
   std::optional<std::string> toSql(
       const std::shared_ptr<const core::TableWriteNode>& tableWriteNode);
 
+  std::optional<std::string> toSql(
+      const std::shared_ptr<const velox::core::HashJoinNode>& joinNode);
+
+  std::optional<std::string> toSql(
+      const std::shared_ptr<const core::NestedLoopJoinNode>& joinNode);
+
   std::string startQuery(const std::string& sql);
 
   std::string fetchNext(const std::string& nextUri);
+
+  // Creates an empty table with given data type and table name. The function
+  // returns the root directory of table files.
+  std::string createTable(const std::string& name, const TypePtr& type);
 
   const std::string coordinatorUri_;
   const std::string user_;

--- a/velox/exec/fuzzer/ReferenceQueryRunner.h
+++ b/velox/exec/fuzzer/ReferenceQueryRunner.h
@@ -36,6 +36,15 @@ class ReferenceQueryRunner {
       const std::vector<RowVectorPtr>& input,
       const RowTypePtr& resultType) = 0;
 
+  /// Executes SQL query returned by the 'toSql' method using 'probeInput' and
+  /// 'buildInput' data for join node.
+  /// Converts results using 'resultType' schema.
+  virtual std::multiset<std::vector<velox::variant>> execute(
+      const std::string& sql,
+      const std::vector<RowVectorPtr>& probeInput,
+      const std::vector<RowVectorPtr>& buildInput,
+      const RowTypePtr& resultType) = 0;
+
   /// Returns true if 'executeVector' can be called to get results as Velox
   /// Vector.
   virtual bool supportsVeloxVectorResults() const {
@@ -47,6 +56,15 @@ class ReferenceQueryRunner {
   virtual std::vector<RowVectorPtr> executeVector(
       const std::string& sql,
       const std::vector<RowVectorPtr>& input,
+      const RowTypePtr& resultType) {
+    VELOX_UNSUPPORTED();
+  }
+
+  /// Similar to above but for join node with 'probeInput' and 'buildInput'.
+  virtual std::vector<RowVectorPtr> executeVector(
+      const std::string& sql,
+      const std::vector<RowVectorPtr>& probeInput,
+      const std::vector<RowVectorPtr>& buildInput,
       const RowTypePtr& resultType) {
     VELOX_UNSUPPORTED();
   }

--- a/velox/exec/tests/JoinFuzzerTest.cpp
+++ b/velox/exec/tests/JoinFuzzerTest.cpp
@@ -19,13 +19,55 @@
 #include <gtest/gtest.h>
 #include <unordered_set>
 
+#include "velox/exec/fuzzer/DuckQueryRunner.h"
+#include "velox/exec/fuzzer/FuzzerUtil.h"
 #include "velox/exec/fuzzer/JoinFuzzerRunner.h"
+#include "velox/exec/fuzzer/PrestoQueryRunner.h"
+#include "velox/exec/fuzzer/ReferenceQueryRunner.h"
 
 DEFINE_int64(
     seed,
     0,
     "Initial seed for random number generator used to reproduce previous "
     "results (0 means start with random seed).");
+
+DEFINE_string(
+    presto_url,
+    "",
+    "Presto coordinator URI along with port. If set, we use Presto "
+    "source of truth. Otherwise, use DuckDB. Example: "
+    "--presto_url=http://127.0.0.1:8080");
+
+DEFINE_uint32(
+    req_timeout_ms,
+    1000,
+    "Timeout in milliseconds for HTTP requests made to reference DB, "
+    "such as Presto. Example: --req_timeout_ms=2000");
+
+DEFINE_int64(allocator_capacity, 8L << 30, "Allocator capacity in bytes.");
+
+DEFINE_int64(arbitrator_capacity, 6L << 30, "Arbitrator capacity in bytes.");
+
+using namespace facebook::velox::exec;
+
+namespace {
+std::unique_ptr<test::ReferenceQueryRunner> setupReferenceQueryRunner(
+    const std::string& prestoUrl,
+    const std::string& runnerName,
+    const uint32_t& reqTimeoutMs) {
+  if (prestoUrl.empty()) {
+    auto duckQueryRunner = std::make_unique<test::DuckQueryRunner>();
+    LOG(INFO) << "Using DuckDB as the reference DB.";
+    return duckQueryRunner;
+  }
+
+  LOG(INFO) << "Using Presto as the reference DB.";
+  return std::make_unique<test::PrestoQueryRunner>(
+      prestoUrl,
+      runnerName,
+      static_cast<std::chrono::milliseconds>(reqTimeoutMs));
+}
+} // namespace
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
@@ -34,7 +76,10 @@ int main(int argc, char** argv) {
   // singletons, installing proper signal handlers for better debugging
   // experience, and initialize glog and gflags.
   folly::Init init(&argc, &argv);
-
-  size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
-  return JoinFuzzerRunner::run(initialSeed);
+  test::setupMemory(FLAGS_allocator_capacity, FLAGS_arbitrator_capacity);
+  auto referenceQueryRunner = setupReferenceQueryRunner(
+      FLAGS_presto_url, "join_fuzzer", FLAGS_req_timeout_ms);
+  const size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
+  return test::JoinFuzzerRunner::run(
+      initialSeed, std::move(referenceQueryRunner));
 }


### PR DESCRIPTION
As a followup for https://github.com/facebookincubator/velox/pull/9788, add supports for PrestoQueryRunner/DuckDbQueryRunner in join fuzzer to enable query runner selection. 