### PR TITLE
Add conversion and url to spark_functions.rst

### DIFF
--- a/velox/docs/spark_functions.rst
+++ b/velox/docs/spark_functions.rst
@@ -18,6 +18,8 @@ Spark Functions
     functions/spark/binary
     functions/spark/aggregate
     functions/spark/window
+    functions/spark/conversion
+    functions/spark/url
 
 Here is a list of all scalar and aggregate Spark functions available in Velox.
 Function names link to function descriptions. Check out coverage maps


### PR DESCRIPTION
Add conversion and url in spark_functions.rst to display them in Spark 
functions documentation.