### PR TITLE
Enable kLeftSemiFilter and  kRightSemiFilter  join type in SMJ

### DIFF
--- a/velox/exec/MergeJoin.cpp
+++ b/velox/exec/MergeJoin.cpp
@@ -35,7 +35,8 @@ MergeJoin::MergeJoin(
       numKeys_{joinNode->leftKeys().size()},
       joinNode_(joinNode) {
   VELOX_USER_CHECK(
-      joinNode_->isInnerJoin() || joinNode_->isLeftJoin(),
+      joinNode_->isInnerJoin() || joinNode_->isLeftJoin() ||
+          joinNode_->isLeftSemiFilterJoin(),
       "Merge join supports only inner and left joins. Other join types are not supported yet.");
 }
 

--- a/velox/exec/MergeJoin.cpp
+++ b/velox/exec/MergeJoin.cpp
@@ -37,7 +37,7 @@ MergeJoin::MergeJoin(
   VELOX_USER_CHECK(
       joinNode_->isInnerJoin() || joinNode_->isLeftJoin() ||
           joinNode_->isLeftSemiFilterJoin(),
-      "Merge join supports only inner and left joins. Other join types are not supported yet.");
+      "Merge join supports only inner, left and left semi joins. Other join types are not supported yet.");
 }
 
 void MergeJoin::initialize() {
@@ -71,6 +71,12 @@ void MergeJoin::initialize() {
     if (outIndex.has_value()) {
       rightProjections_.emplace_back(i, outIndex.value());
     }
+  }
+
+  if (joinNode_->isLeftSemiFilterJoin()) {
+    VELOX_USER_CHECK(
+        rightProjections_.empty(),
+        "The right side projections should be empty for left semi join");
   }
 
   if (joinNode_->filter()) {

--- a/velox/exec/MergeJoin.cpp
+++ b/velox/exec/MergeJoin.cpp
@@ -397,6 +397,10 @@ bool MergeJoin::addToOutput() {
         auto rightEnd =
             r == numRights - 1 ? rightMatch_->endIndex : right->size();
 
+        // TODO: Since semi joins only require determining if there is at least
+        // one match on the other side, we could explore specialized algorithms
+        // or data structures that short-circuit the join process once a match
+        // is found.
         if (isLeftSemiFilterJoin(joinType_) ||
             isRightSemiFilterJoin(joinType_)) {
           // LeftSemiFilter produce each row from the left at most once.

--- a/velox/exec/MergeJoin.cpp
+++ b/velox/exec/MergeJoin.cpp
@@ -384,6 +384,11 @@ bool MergeJoin::addToOutput() {
         auto rightEnd =
             r == numRights - 1 ? rightMatch_->endIndex : right->size();
 
+        if (isLeftSemiFilterJoin(joinType_)) {
+          // LeftSemiFilter produce each row from the left at most once.
+          rightEnd = rightStart + 1;
+        }
+
         for (auto j = rightStart; j < rightEnd; ++j) {
           if (outputSize_ == outputBatchSize_) {
             leftMatch_->setCursor(l, i);

--- a/velox/exec/fuzzer/JoinFuzzer.cpp
+++ b/velox/exec/fuzzer/JoinFuzzer.cpp
@@ -963,7 +963,8 @@ void JoinFuzzer::makeAlternativePlans(
           .planNode()});
 
   // Use OrderBy + MergeJoin (if join type is inner or left).
-  if (joinNode->isInnerJoin() || joinNode->isLeftJoin()) {
+  if (joinNode->isInnerJoin() || joinNode->isLeftJoin() ||
+      joinNode->isLeftSemiFilterJoin() || joinNode->isRightSemiFilterJoin()) {
     auto planWithSplits = makeMergeJoinPlan(
         joinType, probeKeys, buildKeys, probeInput, buildInput, outputColumns);
     plans.push_back(planWithSplits);

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -499,46 +499,46 @@ TEST_F(MergeJoinTest, lazyVectors) {
 }
 
 TEST_F(MergeJoinTest, semiJoin) {
-  auto left =
-      makeRowVector({"t0"}, {makeNullableFlatVector<int64_t>({1, 2, 2, 6})});
+  auto left = makeRowVector(
+      {"t0"}, {makeNullableFlatVector<int64_t>({1, 2, 2, 6, std::nullopt})});
 
-  auto right =
-      makeRowVector({"u0"}, {makeNullableFlatVector<int64_t>({1, 2, 2, 7})});
+  auto right = makeRowVector(
+      {"u0"},
+      {makeNullableFlatVector<int64_t>(
+          {1, 2, 2, 7, std::nullopt, std::nullopt})});
 
   createDuckDbTable("t", {left});
   createDuckDbTable("u", {right});
 
-  // Left Semi join.
-  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
-  auto plan =
-      PlanBuilder(planNodeIdGenerator)
-          .values({left})
-          .mergeJoin(
-              {"t0"},
-              {"u0"},
-              PlanBuilder(planNodeIdGenerator).values({right}).planNode(),
-              "t0 > 1",
-              {"t0"},
-              core::JoinType::kLeftSemiFilter)
-          .planNode();
-  AssertQueryBuilder(plan, duckDbQueryRunner_)
-      .assertResults(
-          "SELECT t0 FROM t where t0 IN (SELECT u0 from u) and t0 > 1");
+  auto testSemiJoin = [&](const std::string& filter,
+                          const std::string& sql,
+                          const std::vector<std::string>& outputLayout,
+                          core::JoinType joinType) {
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    auto plan =
+        PlanBuilder(planNodeIdGenerator)
+            .values({left})
+            .mergeJoin(
+                {"t0"},
+                {"u0"},
+                PlanBuilder(planNodeIdGenerator).values({right}).planNode(),
+                filter,
+                outputLayout,
+                joinType)
+            .planNode();
+    AssertQueryBuilder(plan, duckDbQueryRunner_).assertResults(sql);
+  };
 
-  // Right Semi join.
-  plan = PlanBuilder(planNodeIdGenerator)
-             .values({left})
-             .mergeJoin(
-                 {"t0"},
-                 {"u0"},
-                 PlanBuilder(planNodeIdGenerator).values({right}).planNode(),
-                 "u0 > 1",
-                 {"u0"},
-                 core::JoinType::kRightSemiFilter)
-             .planNode();
-  AssertQueryBuilder(plan, duckDbQueryRunner_)
-      .assertResults(
-          "SELECT u0 FROM u where u0 IN (SELECT t0 from t) and u0 > 1");
+  testSemiJoin(
+      "t0 >1",
+      "SELECT t0 FROM t where t0 IN (SELECT u0 from u) and t0 > 1",
+      {"t0"},
+      core::JoinType::kLeftSemiFilter);
+  testSemiJoin(
+      "u0 > 1",
+      "SELECT u0 FROM u where u0 IN (SELECT t0 from t) and u0 > 1",
+      {"u0"},
+      core::JoinType::kRightSemiFilter);
 }
 
 TEST_F(MergeJoinTest, nullKeys) {

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -503,7 +503,7 @@ TEST_F(MergeJoinTest, semiJoin) {
       makeRowVector({"t0"}, {makeNullableFlatVector<int64_t>({1, 2, 5, 6})});
 
   auto right =
-      makeRowVector({"u0"}, {makeNullableFlatVector<int64_t>({1, 5, 7})});
+      makeRowVector({"u0"}, {makeNullableFlatVector<int64_t>({1, 1, 5, 7})});
 
   createDuckDbTable("t", {left});
   createDuckDbTable("u", {right});
@@ -517,13 +517,12 @@ TEST_F(MergeJoinTest, semiJoin) {
               {"t0"},
               {"u0"},
               PlanBuilder(planNodeIdGenerator).values({right}).planNode(),
-              "t0 > 1",
+              "",
               {"t0"},
               core::JoinType::kLeftSemiFilter)
           .planNode();
   AssertQueryBuilder(plan, duckDbQueryRunner_)
-      .assertResults(
-          "SELECT t0 FROM t where t0 IN (SELECT u0 from u) and t0 > 1");
+      .assertResults("SELECT t0 FROM t where t0 IN (SELECT u0 from u)");
 }
 
 TEST_F(MergeJoinTest, nullKeys) {

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -503,7 +503,7 @@ TEST_F(MergeJoinTest, semiJoin) {
       makeRowVector({"t0"}, {makeNullableFlatVector<int64_t>({1, 2, 5, 6})});
 
   auto right =
-      makeRowVector({"u0"}, {makeNullableFlatVector<int64_t>({1, 1, 5, 7})});
+      makeRowVector({"u0"}, {makeNullableFlatVector<int64_t>({1, 2, 2, 7})});
 
   createDuckDbTable("t", {left});
   createDuckDbTable("u", {right});
@@ -517,12 +517,13 @@ TEST_F(MergeJoinTest, semiJoin) {
               {"t0"},
               {"u0"},
               PlanBuilder(planNodeIdGenerator).values({right}).planNode(),
-              "",
+              "t0 > 1",
               {"t0"},
               core::JoinType::kLeftSemiFilter)
           .planNode();
   AssertQueryBuilder(plan, duckDbQueryRunner_)
-      .assertResults("SELECT t0 FROM t where t0 IN (SELECT u0 from u)");
+      .assertResults(
+          "SELECT t0 FROM t where t0 IN (SELECT u0 from u) and t0 > 1");
 }
 
 TEST_F(MergeJoinTest, nullKeys) {


### PR DESCRIPTION
The kLeftSemiFilter and kRightSemiFilter  Join can leverage the logic of the Inner Join with two key modifications:

1. Even if there are duplicate records in the right/left table, the corresponding records from the left/right table should only appear once in the final result.
2. The final output should exclude all records from the right/left table. Since the rightProjections/leftProjections of the leftSemiFilter/rightSemiFilter are empty [here](https://github.com/facebookincubator/velox/blob/main/velox/exec/MergeJoin.cpp#L69), it will not copy the results from the right/left side into the final output [here](https://github.com/facebookincubator/velox/blob/main/velox/exec/MergeJoin.cpp#L270).