### PR TITLE
Fix NaN handling for map subscript and add test for map()

### DIFF
--- a/velox/docs/functions/presto/map.rst
+++ b/velox/docs/functions/presto/map.rst
@@ -39,7 +39,8 @@ Map Functions
 .. function:: map(array(K), array(V)) -> map(K,V)
    :noindex:
 
-    Returns a map created using the given key/value arrays. Keys are not allowed to be null or to contain nulls. ::
+    Returns a map created using the given key/value arrays. Keys are not allowed to be null or to contain nulls.
+    For REAL and DOUBLE, NaNs (Not-a-Number) are considered equal. ::
 
         SELECT map(ARRAY[1,3], ARRAY[2,4]); -- {1 -> 2, 3 -> 4}
 
@@ -148,6 +149,7 @@ Map Functions
    :noindex:
 
     Returns value for given ``key``. Return null if the key is not contained in the map.
+    For REAL and DOUBLE, NaNs (Not-a-Number) are considered equal and can be used as keys.
     Corresponds to SQL subscript operator [].
 
     SELECT name_to_age_map['Bob'] AS bob_age;

--- a/velox/functions/lib/SubscriptUtil.cpp
+++ b/velox/functions/lib/SubscriptUtil.cpp
@@ -28,6 +28,15 @@ namespace facebook::velox::functions {
 
 namespace {
 
+template <typename T>
+inline bool isPrimitiveEqual(const T& lhs, const T& rhs) {
+  if constexpr (std::is_floating_point_v<T>) {
+    return util::floating_point::NaNAwareEquals<T>{}(lhs, rhs);
+  } else {
+    return lhs == rhs;
+  }
+}
+
 template <TypeKind Kind>
 struct SimpleType {
   using type = typename TypeTraits<Kind>::NativeType;
@@ -128,7 +137,8 @@ VectorPtr applyMapTyped(
     } else {
       // Search map without caching.
       for (size_t offset = offsetStart; offset < offsetEnd; ++offset) {
-        if (decodedMapKeys->valueAt<TKey>(offset) == searchKey) {
+        if (isPrimitiveEqual<TKey>(
+                decodedMapKeys->valueAt<TKey>(offset), searchKey)) {
           rawIndices[row] = offset;
           found = true;
           break;

--- a/velox/functions/lib/SubscriptUtil.h
+++ b/velox/functions/lib/SubscriptUtil.h
@@ -21,6 +21,7 @@
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/expression/VectorReaders.h"
+#include "velox/type/FloatingPointUtil.h"
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/ComplexVector.h"
@@ -77,12 +78,8 @@ class LookupTable : public LookupTableBase {
   using inner_allocator_t =
       memory::StlAllocator<std::pair<key_t const, vector_size_t>>;
 
-  using inner_map_t = folly::F14FastMap<
-      key_t,
-      vector_size_t,
-      folly::f14::DefaultHasher<key_t>,
-      folly::f14::DefaultKeyEqual<key_t>,
-      inner_allocator_t>;
+  using inner_map_t = typename util::floating_point::
+      HashMapNaNAwareTypeTraits<key_t, vector_size_t, inner_allocator_t>::Type;
 
   using outer_allocator_t =
       memory::StlAllocator<std::pair<vector_size_t const, inner_map_t>>;


### PR DESCRIPTION
Summary:
Ensures that map subscript identifies NaN as a key where NaNs with any binary
representation are considered equal.

Differential Revision: D57634535


