### PR TITLE
Quote cast(x as json) when x is nan(), or infinity().

### DIFF
--- a/velox/functions/prestosql/tests/JsonCastTest.cpp
+++ b/velox/functions/prestosql/tests/JsonCastTest.cpp
@@ -311,10 +311,10 @@ TEST_F(JsonCastTest, fromDoubleAndReal) {
        "12345.0"_sv,
        "1.0E7"_sv,
        "1.2345678901234567E8"_sv,
-       "NaN"_sv,
-       "NaN"_sv,
-       "Infinity"_sv,
-       "-Infinity"_sv,
+       "\"NaN\""_sv,
+       "\"NaN\""_sv,
+       "\"Infinity\""_sv,
+       "\"-Infinity\""_sv,
        std::nullopt});
   testCastToJson<float>(
       REAL(),
@@ -343,10 +343,10 @@ TEST_F(JsonCastTest, fromDoubleAndReal) {
        "12345.0"_sv,
        "1.0E7"_sv,
        "1.2345678E8"_sv,
-       "NaN"_sv,
-       "NaN"_sv,
-       "Infinity"_sv,
-       "-Infinity"_sv,
+       "\"NaN\""_sv,
+       "\"NaN\""_sv,
+       "\"Infinity\""_sv,
+       "\"-Infinity\""_sv,
        std::nullopt});
 
   testCastToJson<double>(

--- a/velox/functions/prestosql/types/JsonType.cpp
+++ b/velox/functions/prestosql/types/JsonType.cpp
@@ -76,15 +76,7 @@ void generateJsonTyped(
               util::Converter<TypeKind::VARCHAR>::tryCast(value).value());
         }
       } else {
-        if (FOLLY_UNLIKELY(std::isinf(value) || std::isnan(value))) {
-          folly::toAppend<std::string, std::string>("\"", &result);
-        }
-
         folly::toAppend<std::string, T>(value, &result);
-
-        if (FOLLY_UNLIKELY(std::isinf(value) || std::isnan(value))) {
-          folly::toAppend<std::string, std::string>("\"", &result);
-        }
       }
     } else if constexpr (std::is_same_v<T, Timestamp>) {
       result.append(std::to_string(value));


### PR DESCRIPTION
This PR fixes the missing quotes when casting NaN's , Infinity to json in Velox. 

In Presto:
```sql

presto:privacy> select cast(x as json) from (values nan(), infinity(), 1.12) as t(x);
   _col0              
------------
 "NaN"      
 "Infinity" 
 1.12       
 ```

In Velox:
```
presto:default> select cast(x as json) from (values nan(), infinity(), 1.12) as t(x);
  _col0               
----------
 NaN      
 Infinity 
 1.12    
 ```
 
Spark doesnt support json as native data type, however I added a legacy spark flag to support this behavior if it affects Spark/Gluten. cc: @rui-mo . Please let me know if this is not required and I will remove it. 