### PR TITLE
Add APIs to get simple and vector function signatures in function registry

### DIFF
--- a/velox/functions/FunctionRegistry.cpp
+++ b/velox/functions/FunctionRegistry.cpp
@@ -64,6 +64,12 @@ FunctionSignatureMap getFunctionSignatures() {
   return result;
 }
 
+FunctionSignatureMap getVectorFunctionSignatures() {
+  FunctionSignatureMap result;
+  populateVectorFunctionSignatures(result);
+  return result;
+}
+
 void clearFunctionRegistry() {
   exec::mutableSimpleFunctions().clearRegistry();
   exec::vectorFunctionFactories().withWLock(

--- a/velox/functions/FunctionRegistry.h
+++ b/velox/functions/FunctionRegistry.h
@@ -31,6 +31,10 @@ using FunctionSignatureMap = std::
 /// The mapping is function name -> list of function signatures
 FunctionSignatureMap getFunctionSignatures();
 
+/// Returns a mapping of all Vector functions registered in Velox
+/// The mapping is function name -> list of function signatures
+FunctionSignatureMap getVectorFunctionSignatures();
+
 /// Given a function name and argument types, returns
 /// the return type if function exists otherwise returns nullptr
 TypePtr resolveFunction(

--- a/velox/functions/tests/FunctionRegistryTest.cpp
+++ b/velox/functions/tests/FunctionRegistryTest.cpp
@@ -390,6 +390,27 @@ TEST_F(FunctionRegistryTest, getFunctionSignatures) {
           ->toString());
 }
 
+TEST_F(FunctionRegistryTest, getVectorFunctionSignatures) {
+  auto functionSignatures = getVectorFunctionSignatures();
+  ASSERT_EQ(functionSignatures.size(), 5);
+
+  std::set<std::string> functionNames;
+  std::transform(
+      functionSignatures.begin(),
+      functionSignatures.end(),
+      std::inserter(functionNames, functionNames.end()),
+      [](auto& signature) { return signature.first; });
+
+  ASSERT_THAT(
+      functionNames,
+      ::testing::UnorderedElementsAre(
+          "vector_func_one",
+          "vector_func_one_alias",
+          "vector_func_two",
+          "vector_func_three",
+          "vector_func_four"));
+}
+
 TEST_F(FunctionRegistryTest, hasSimpleFunctionSignature) {
   auto result = resolveFunction("func_one", {VARCHAR()});
   ASSERT_EQ(*result, *VARCHAR());


### PR DESCRIPTION
Summary:
Currently we only have a way to get the signatures of all the functions that are registered into Velox - simple and vector. This utility API is generally useful to provide info about what UDFs are available to users.

In this change, I added 2 separate APIs to get simple and vector function signatures independently (replicating the same logic as the main one). This is helpful when the separation is desired.

Differential Revision: D57647355


