### PR TITLE
Provide usedBytes() return the actual used memory from non-leaf…

### DIFF
--- a/velox/buffer/tests/BufferTest.cpp
+++ b/velox/buffer/tests/BufferTest.cpp
@@ -69,7 +69,7 @@ TEST_F(BufferTest, testAlignedBuffer) {
         testString,
         testStringLength);
     other = buffer;
-    EXPECT_EQ(pool_->currentBytes(), pool_->preferredSize(sizeWithHeader));
+    EXPECT_EQ(pool_->usedBytes(), pool_->preferredSize(sizeWithHeader));
 
     AlignedBuffer::reallocate<char>(&other, size * 3, 'e');
     EXPECT_NE(other, buffer);
@@ -85,18 +85,17 @@ TEST_F(BufferTest, testAlignedBuffer) {
         0);
     EXPECT_EQ(other->as<char>()[buffer->capacity()], 'e');
     EXPECT_EQ(
-        pool_->currentBytes(),
+        pool_->usedBytes(),
         pool_->preferredSize(sizeWithHeader) +
             pool_->preferredSize(3 * size + kHeaderSize));
   }
-  EXPECT_EQ(
-      pool_->currentBytes(), pool_->preferredSize(3 * size + kHeaderSize));
+  EXPECT_EQ(pool_->usedBytes(), pool_->preferredSize(3 * size + kHeaderSize));
   other = nullptr;
   BufferPtr bits = AlignedBuffer::allocate<bool>(65, pool_.get(), true);
   EXPECT_EQ(bits->size(), 9);
   EXPECT_EQ(bits->as<uint8_t>()[8], 0xff);
   bits = nullptr;
-  EXPECT_EQ(pool_->currentBytes(), 0);
+  EXPECT_EQ(pool_->usedBytes(), 0);
 }
 
 TEST_F(BufferTest, testAsRange) {
@@ -179,7 +178,7 @@ TEST_F(BufferTest, testReallocate) {
     }
   }
   buffers.clear();
-  EXPECT_EQ(pool_->currentBytes(), 0);
+  EXPECT_EQ(pool_->usedBytes(), 0);
   EXPECT_GT(numInPlace, 0);
   EXPECT_GT(numMoved, 0);
 }
@@ -440,9 +439,9 @@ TEST_F(BufferTest, testNonPOD) {
 
 TEST_F(BufferTest, testNonPODMemoryUsage) {
   using T = std::shared_ptr<void>;
-  const int64_t currentBytes = pool_->currentBytes();
+  const int64_t currentBytes = pool_->usedBytes();
   { auto buffer = AlignedBuffer::allocate<T>(0, pool_.get()); }
-  EXPECT_EQ(pool_->currentBytes(), currentBytes);
+  EXPECT_EQ(pool_->usedBytes(), currentBytes);
 }
 
 TEST_F(BufferTest, testAllocateSizeOverflow) {

--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -316,6 +316,10 @@ class TestMemoryPool : public memory::MemoryPool {
     return 0;
   }
 
+  int64_t usedBytes() const override {
+    return 0;
+  }
+
   int64_t peakBytes() const override {
     return 0;
   }

--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -679,11 +679,11 @@ TEST_F(AsyncDataCacheTest, evictAccounting) {
   memory::ContiguousAllocation large;
   pool->allocateNonContiguous(1200, allocation);
   pool->allocateContiguous(1200, large);
-  EXPECT_EQ(memory::AllocationTraits::pageBytes(2400), pool->currentBytes());
+  EXPECT_EQ(memory::AllocationTraits::pageBytes(2400), pool->usedBytes());
   loadLoop(0, kMaxBytes * 1.1);
   pool->allocateNonContiguous(2400, allocation);
   pool->allocateContiguous(2400, large);
-  EXPECT_EQ(memory::AllocationTraits::pageBytes(4800), pool->currentBytes());
+  EXPECT_EQ(memory::AllocationTraits::pageBytes(4800), pool->usedBytes());
   auto stats = cache_->refreshStats();
   EXPECT_LT(0, stats.numEvict);
 }

--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -282,7 +282,7 @@ void MemoryManager::dropPool(MemoryPool* pool) {
     VELOX_FAIL("The dropped memory pool {} not found", pool->name());
   }
   pools_.erase(it);
-  VELOX_DCHECK_EQ(pool->currentBytes(), 0);
+  VELOX_DCHECK_EQ(pool->reservedBytes(), 0);
   arbitrator_->shrinkCapacity(pool, 0);
 }
 

--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -682,6 +682,21 @@ int64_t MemoryPoolImpl::capacity() const {
   return capacity_;
 }
 
+int64_t MemoryPoolImpl::usedBytes() const {
+  if (isLeaf()) {
+    return currentBytes();
+  }
+  if (currentBytes() == 0) {
+    return 0;
+  }
+  int64_t usedBytes{0};
+  visitChildren([&](MemoryPool* pool) {
+    usedBytes += pool->usedBytes();
+    return true;
+  });
+  return usedBytes;
+}
+
 std::shared_ptr<MemoryPool> MemoryPoolImpl::genChild(
     std::shared_ptr<MemoryPool> parent,
     const std::string& name,
@@ -821,7 +836,7 @@ bool MemoryPoolImpl::incrementReservationThreadSafe(
       succinctBytes(size),
       capacityToString(manager_->capacity()),
       requestor->name(),
-      succinctBytes(requestor->currentBytes()),
+      succinctBytes(requestor->usedBytes()),
       treeMemoryUsage()));
 }
 

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -320,8 +320,16 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   /// 'capacity()' is fixed and set to 'maxCapacity()' on creation.
   virtual int64_t capacity() const = 0;
 
-  /// Returns the currently used memory in bytes of this memory pool.
+  /// Returns the currently used memory in bytes of this memory pool. For
+  /// non-leaf memory pool, the function returns the aggregated memory
+  /// reservation from all its child memory pools.
   virtual int64_t currentBytes() const = 0;
+
+  /// Returns the currently used memory in bytes of this memory pool. It returns
+  /// the same usage as currentBytes() for leaf memory pool. But for non-leaf
+  /// memory pool, the function returns the aggregated used memory from all its
+  /// child memory pools.
+  virtual int64_t usedBytes() const = 0;
 
   /// Returns the peak memory usage in bytes of this memory pool.
   virtual int64_t peakBytes() const = 0;
@@ -615,6 +623,8 @@ class MemoryPoolImpl : public MemoryPool {
     std::lock_guard<std::mutex> l(mutex_);
     return currentBytesLocked();
   }
+
+  int64_t usedBytes() const override;
 
   int64_t peakBytes() const override {
     std::lock_guard<std::mutex> l(mutex_);

--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -100,7 +100,7 @@ void sortCandidatesByUsage(
       candidates.end(),
       [](const SharedArbitrator::Candidate& lhs,
          const SharedArbitrator::Candidate& rhs) {
-        return lhs.currentBytes > rhs.currentBytes;
+        return lhs.reservedBytes > rhs.reservedBytes;
       });
 }
 
@@ -185,7 +185,7 @@ void SharedArbitrator::getCandidateStats(
     op->candidates.push_back(
         {freeCapacityOnly ? 0 : reclaimableUsedCapacity(*pool, selfCandidate),
          reclaimableFreeCapacity(*pool, selfCandidate),
-         pool->currentBytes(),
+         pool->reservedBytes(),
          pool.get()});
   }
 }
@@ -208,7 +208,7 @@ int64_t SharedArbitrator::maxReclaimableCapacity(
   // limit check.
   // NOTE: for query system like Prestissimo, it holds a finished query
   // state in minutes for query stats fetch request from the Presto coordinator.
-  if (isSelfReclaim || (pool.currentBytes() == 0 && pool.peakBytes() != 0)) {
+  if (isSelfReclaim || (pool.reservedBytes() == 0 && pool.peakBytes() != 0)) {
     return pool.capacity();
   }
   return std::max<int64_t>(0, pool.capacity() - memoryPoolReservedCapacity_);
@@ -713,7 +713,7 @@ uint64_t SharedArbitrator::reclaimUsedMemoryFromCandidatesByAbort(
       VELOX_MEM_POOL_ABORTED(fmt::format(
           "Memory pool aborted to reclaim used memory, current usage {}, "
           "memory pool details:\n{}\n{}",
-          succinctBytes(candidate.currentBytes),
+          succinctBytes(candidate.reservedBytes),
           candidate.pool->toString(),
           candidate.pool->treeMemoryUsage()));
     } catch (VeloxRuntimeError&) {

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -68,7 +68,7 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   struct Candidate {
     int64_t reclaimableBytes{0};
     int64_t freeBytes{0};
-    int64_t currentBytes{0};
+    int64_t reservedBytes{0};
     MemoryPool* pool;
 
     std::string toString() const;

--- a/velox/common/memory/tests/AllocationPoolTest.cpp
+++ b/velox/common/memory/tests/AllocationPoolTest.cpp
@@ -59,17 +59,17 @@ TEST_F(AllocationPoolTest, hugePages) {
     EXPECT_EQ(1, allocationPool->numRanges());
     EXPECT_EQ(allocationPool->testingFreeAddressableBytes(), 64 << 10);
     allocationPool->newRun(64 << 10);
-    EXPECT_LE(128 << 10, pool_->currentBytes());
+    EXPECT_LE(128 << 10, pool_->usedBytes());
     allocationPool->allocateFixed(64 << 10);
     // Now at end of second 64K range, next will go to huge pages.
     setByte(allocationPool->allocateFixed(11));
     EXPECT_LE((2 << 20) - 11, allocationPool->testingFreeAddressableBytes());
     // The first 2MB of the hugepage run are marked reserved.
-    EXPECT_LE((2048 + 128) << 10, pool_->currentBytes());
+    EXPECT_LE((2048 + 128) << 10, pool_->usedBytes());
 
     // The next allocation starts reserves the next 2MB of the mmapped range.
     setByte(allocationPool->allocateFixed(2 << 20));
-    EXPECT_LE((4096 + 128) << 10, pool_->currentBytes());
+    EXPECT_LE((4096 + 128) << 10, pool_->usedBytes());
 
     // Allocate the rest.
     allocationPool->allocateFixed(
@@ -97,7 +97,7 @@ TEST_F(AllocationPoolTest, hugePages) {
     EXPECT_LE(
         (5UL << 30) + (31 << 20) + (128 << 10),
         allocationPool->allocatedBytes());
-    EXPECT_LE((5UL << 30) + (31 << 20) + (128 << 10), pool_->currentBytes());
+    EXPECT_LE((5UL << 30) + (31 << 20) + (128 << 10), pool_->usedBytes());
 
     if (counter++ >= 1) {
       break;
@@ -106,11 +106,11 @@ TEST_F(AllocationPoolTest, hugePages) {
     // Repeat the above after a clear().
     allocationPool->clear();
     // Should be empty after clear().
-    EXPECT_EQ(0, pool_->currentBytes());
+    EXPECT_EQ(0, pool_->usedBytes());
   }
   allocationPool.reset();
   // Should be empty after destruction.
-  EXPECT_EQ(0, pool_->currentBytes());
+  EXPECT_EQ(0, pool_->usedBytes());
 }
 
 // This test relies on TestValue, so needs to be run in debug mode.

--- a/velox/common/memory/tests/ByteStreamTest.cpp
+++ b/velox/common/memory/tests/ByteStreamTest.cpp
@@ -348,13 +348,13 @@ TEST_F(ByteStreamTest, appendWindow) {
     {
       AppendWindow<uint64_t> window(stream, scratch);
       auto ptr = window.get(numWords);
-      bytes = arena->pool()->currentBytes();
+      bytes = arena->pool()->usedBytes();
       memcpy(ptr, words.data() + offset, numWords * sizeof(words[0]));
       offset += numWords;
       ++counter;
     }
     // We check that there is no allocation at exit of AppendWindow block.k
-    EXPECT_EQ(arena->pool()->currentBytes(), bytes);
+    EXPECT_EQ(arena->pool()->usedBytes(), bytes);
   }
   std::stringstream stringStream;
   OStreamOutputStream out(&stringStream);

--- a/velox/common/memory/tests/HashStringAllocatorTest.cpp
+++ b/velox/common/memory/tests/HashStringAllocatorTest.cpp
@@ -505,24 +505,24 @@ TEST_F(HashStringAllocatorTest, externalLeak) {
   constexpr int32_t kSize = HashStringAllocator ::kMaxAlloc * 10;
   auto root = memory::memoryManager()->addRootPool("HSALeakTestRoot");
   auto pool = root->addLeafChild("HSALeakLeaf");
-  auto initialBytes = pool->currentBytes();
+  auto initialBytes = pool->usedBytes();
   auto allocator = std::make_unique<HashStringAllocator>(pool.get());
 
   for (auto i = 0; i < 100; ++i) {
     allocator->allocate(kSize);
   }
-  EXPECT_LE(100 * kSize, pool->currentBytes());
+  EXPECT_LE(100 * kSize, pool->usedBytes());
 
   StlAllocator<char> stlAlloc(allocator.get());
   for (auto i = 0; i < 100; ++i) {
     stlAlloc.allocate(kSize);
   }
-  EXPECT_LE(200 * kSize, pool->currentBytes());
+  EXPECT_LE(200 * kSize, pool->usedBytes());
   allocator->clear();
-  EXPECT_GE(initialBytes + 1000, pool->currentBytes());
+  EXPECT_GE(initialBytes + 1000, pool->usedBytes());
 
   allocator.reset();
-  EXPECT_EQ(initialBytes, pool->currentBytes());
+  EXPECT_EQ(initialBytes, pool->usedBytes());
 }
 
 TEST_F(HashStringAllocatorTest, freeLists) {

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -359,7 +359,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, skipNonReclaimableTaskTest) {
             op->testingOperatorCtx()->operatorType() != "PartialAggregation") {
           return;
         }
-        if (op->pool()->currentBytes() == 0) {
+        if (op->pool()->usedBytes() == 0) {
           return;
         }
         if (op->testingOperatorCtx()->operatorType() == "PartialAggregation") {
@@ -1073,7 +1073,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, arbitrateMemoryFromOtherOperator) {
               if (!RE2::FullMatch(pool->name(), re)) {
                 return;
               }
-              if (pool->root()->currentBytes() == 0) {
+              if (pool->root()->usedBytes() == 0) {
                 return;
               }
               if (!injectReallocateOnce.exchange(false)) {

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -969,14 +969,13 @@ uint64_t HiveDataSink::WriterReclaimer::reclaim(
     RECORD_METRIC_VALUE(kMetricMemoryNonReclaimableCount);
     LOG(WARNING) << "Can't reclaim from hive writer pool " << pool->name()
                  << " which is under non-reclaimable section, "
-                 << " used memory: " << succinctBytes(pool->currentBytes())
-                 << ", reserved memory: "
+                 << " reserved memory: "
                  << succinctBytes(pool->reservedBytes());
     ++stats.numNonReclaimableAttempts;
     return 0;
   }
 
-  const uint64_t memoryUsageBeforeReclaim = pool->currentBytes();
+  const uint64_t memoryUsageBeforeReclaim = pool->reservedBytes();
   const std::string memoryUsageTreeBeforeReclaim = pool->treeMemoryUsage();
   const auto writtenBytesBeforeReclaim = ioStats_->rawBytesWritten();
   const auto reclaimedBytes =
@@ -990,7 +989,7 @@ uint64_t HiveDataSink::WriterReclaimer::reclaim(
     RECORD_METRIC_VALUE(
         kMetricFileWriterEarlyFlushedRawBytes, earlyFlushedRawBytes);
   }
-  const uint64_t memoryUsageAfterReclaim = pool->currentBytes();
+  const uint64_t memoryUsageAfterReclaim = pool->reservedBytes();
   if (memoryUsageAfterReclaim > memoryUsageBeforeReclaim) {
     VELOX_FAIL(
         "Unexpected memory growth after memory reclaim from {}, the memory usage before reclaim: {}, after reclaim: {}\nThe memory tree usage before reclaim:\n{}\nThe memory tree usage after reclaim:\n{}",

--- a/velox/dwio/common/SortingWriter.cpp
+++ b/velox/dwio/common/SortingWriter.cpp
@@ -89,7 +89,7 @@ uint64_t SortingWriter::reclaim(
   if (!isRunning()) {
     LOG(WARNING) << "Can't reclaim from a not running hive sort writer pool: "
                  << sortPool_->name() << ", state: " << state()
-                 << "used memory: " << succinctBytes(sortPool_->currentBytes())
+                 << "used memory: " << succinctBytes(sortPool_->usedBytes())
                  << ", reserved memory: "
                  << succinctBytes(sortPool_->reservedBytes());
     ++stats.numNonReclaimableAttempts;
@@ -132,7 +132,7 @@ bool SortingWriter::MemoryReclaimer::reclaimableBytes(
   if (!writer_->canReclaim()) {
     return false;
   }
-  reclaimableBytes = pool.currentBytes();
+  reclaimableBytes = pool.usedBytes();
   return true;
 }
 

--- a/velox/dwio/common/tests/DataBufferTests.cpp
+++ b/velox/dwio/common/tests/DataBufferTests.cpp
@@ -164,15 +164,15 @@ TEST_F(DataBufferTest, Move) {
     }
     ASSERT_EQ(15, buffer.size());
     ASSERT_EQ(16, buffer.capacity());
-    const auto usedBytes = pool_->currentBytes();
+    const auto usedBytes = pool_->usedBytes();
 
     // Expect no double freeing from memory pool.
     DataBuffer<uint8_t> newBuffer{std::move(buffer)};
     ASSERT_EQ(15, newBuffer.size());
     ASSERT_EQ(16, newBuffer.capacity());
-    ASSERT_EQ(usedBytes, pool_->currentBytes());
+    ASSERT_EQ(usedBytes, pool_->usedBytes());
   }
-  ASSERT_EQ(0, pool_->currentBytes());
+  ASSERT_EQ(0, pool_->usedBytes());
 }
 } // namespace common
 } // namespace dwio

--- a/velox/dwio/dwrf/test/E2EWriterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTest.cpp
@@ -1823,7 +1823,7 @@ DEBUG_ONLY_TEST_F(E2EWriterTest, memoryReclaimOnFlush) {
           auto& context = writer->getContext();
           auto& outputPool =
               context.getMemoryPool(dwrf::MemoryUsageCategory::OUTPUT_STREAM);
-          const auto memoryUsage = outputPool.currentBytes();
+          const auto memoryUsage = outputPool.usedBytes();
           const auto availableMemoryUsage = outputPool.availableReservation();
           ASSERT_GE(
               availableMemoryUsage,

--- a/velox/dwio/dwrf/test/TestStringDictionaryEncoder.cpp
+++ b/velox/dwio/dwrf/test/TestStringDictionaryEncoder.cpp
@@ -226,7 +226,7 @@ TEST_F(TestStringDictionaryEncoder, Clear) {
   for (size_t i = 0; i != 2500; ++i) {
     stringDictEncoder.addKey(baseString + genPaddedIntegerString(i, 4), 0);
   }
-  auto peakMemory = pool->currentBytes();
+  auto peakMemory = pool->usedBytes();
   stringDictEncoder.clear();
   EXPECT_EQ(0, stringDictEncoder.size());
   EXPECT_EQ(0, stringDictEncoder.keyIndex_.size());
@@ -238,7 +238,7 @@ TEST_F(TestStringDictionaryEncoder, Clear) {
   EXPECT_EQ(0, stringDictEncoder.counts_.capacity());
   EXPECT_EQ(0, stringDictEncoder.firstSeenStrideIndex_.size());
   EXPECT_EQ(0, stringDictEncoder.firstSeenStrideIndex_.capacity());
-  EXPECT_LT(pool->currentBytes(), peakMemory);
+  EXPECT_LT(pool->usedBytes(), peakMemory);
 }
 
 TEST_F(TestStringDictionaryEncoder, MemBenchmark) {
@@ -249,7 +249,7 @@ TEST_F(TestStringDictionaryEncoder, MemBenchmark) {
     stringDictEncoder.addKey(baseString + genPaddedIntegerString(i, 4), 0);
   }
 
-  LOG(INFO) << "Total memory bytes: " << pool->currentBytes();
+  LOG(INFO) << "Total memory bytes: " << pool->usedBytes();
 }
 
 TEST_F(TestStringDictionaryEncoder, Limit) {

--- a/velox/dwio/dwrf/test/WriterContextTest.cpp
+++ b/velox/dwio/dwrf/test/WriterContextTest.cpp
@@ -172,11 +172,11 @@ TEST_F(WriterContextTest, memory) {
   ASSERT_EQ(context.getTotalMemoryUsage(), 262208 + bufferSize * 3);
   ASSERT_EQ(context.availableMemoryReservation(), 2880448);
 
-  ASSERT_EQ(generalPool.currentBytes(), 262208 + bufferSize);
+  ASSERT_EQ(generalPool.usedBytes(), 262208 + bufferSize);
   ASSERT_EQ(generalPool.reservedBytes(), 1048576);
-  ASSERT_EQ(dictPool.currentBytes(), bufferSize);
+  ASSERT_EQ(dictPool.usedBytes(), bufferSize);
   ASSERT_EQ(dictPool.reservedBytes(), 1048576);
-  ASSERT_EQ(outputPool.currentBytes(), bufferSize);
+  ASSERT_EQ(outputPool.usedBytes(), bufferSize);
   ASSERT_EQ(outputPool.reservedBytes(), 1048576);
   ASSERT_EQ(context.getTotalMemoryUsage(), 262208 + bufferSize * 3);
   ASSERT_EQ(context.availableMemoryReservation(), 2880448);
@@ -184,22 +184,22 @@ TEST_F(WriterContextTest, memory) {
   ASSERT_TRUE(generalPool.maybeReserve(4L << 20));
   ASSERT_TRUE(dictPool.maybeReserve(4L << 20));
   ASSERT_TRUE(outputPool.maybeReserve(4L << 20));
-  ASSERT_EQ(generalPool.currentBytes(), 262208 + bufferSize);
+  ASSERT_EQ(generalPool.usedBytes(), 262208 + bufferSize);
   ASSERT_EQ(generalPool.reservedBytes(), 9437184);
-  ASSERT_EQ(dictPool.currentBytes(), bufferSize);
+  ASSERT_EQ(dictPool.usedBytes(), bufferSize);
   ASSERT_EQ(dictPool.reservedBytes(), 9437184);
-  ASSERT_EQ(outputPool.currentBytes(), bufferSize);
+  ASSERT_EQ(outputPool.usedBytes(), bufferSize);
   ASSERT_EQ(outputPool.reservedBytes(), 9437184);
   ASSERT_EQ(context.getTotalMemoryUsage(), 262208 + bufferSize * 3);
   ASSERT_EQ(context.availableMemoryReservation(), 28046272);
 
   context.releaseMemoryReservation();
   ASSERT_EQ(context.getTotalMemoryUsage(), 262208 + bufferSize * 3);
-  ASSERT_EQ(generalPool.currentBytes(), 262208 + bufferSize);
+  ASSERT_EQ(generalPool.usedBytes(), 262208 + bufferSize);
   ASSERT_EQ(generalPool.reservedBytes(), 1048576);
-  ASSERT_EQ(dictPool.currentBytes(), bufferSize);
+  ASSERT_EQ(dictPool.usedBytes(), bufferSize);
   ASSERT_EQ(dictPool.reservedBytes(), 1048576);
-  ASSERT_EQ(outputPool.currentBytes(), bufferSize);
+  ASSERT_EQ(outputPool.usedBytes(), bufferSize);
   ASSERT_EQ(outputPool.reservedBytes(), 1048576);
   ASSERT_EQ(context.getTotalMemoryUsage(), 262208 + bufferSize * 3);
   ASSERT_EQ(context.availableMemoryReservation(), 2880448);
@@ -208,11 +208,11 @@ TEST_F(WriterContextTest, memory) {
   dictPool.free(dictBuf, bufferSize);
   outputPool.free(outputBuf, bufferSize);
   ASSERT_EQ(context.getTotalMemoryUsage(), 262208);
-  ASSERT_EQ(generalPool.currentBytes(), 262208);
+  ASSERT_EQ(generalPool.usedBytes(), 262208);
   ASSERT_EQ(generalPool.reservedBytes(), 1048576);
-  ASSERT_EQ(dictPool.currentBytes(), 0);
+  ASSERT_EQ(dictPool.usedBytes(), 0);
   ASSERT_EQ(dictPool.reservedBytes(), 0);
-  ASSERT_EQ(outputPool.currentBytes(), 0);
+  ASSERT_EQ(outputPool.usedBytes(), 0);
   ASSERT_EQ(outputPool.reservedBytes(), 0);
   ASSERT_EQ(context.getTotalMemoryUsage(), 262208);
   ASSERT_EQ(context.availableMemoryReservation(), 786368);
@@ -239,11 +239,11 @@ TEST_F(WriterContextTest, abort) {
   ASSERT_EQ(context.getTotalMemoryUsage(), 262208 + bufferSize * 3);
   ASSERT_EQ(context.availableMemoryReservation(), 2880448);
 
-  ASSERT_EQ(generalPool.currentBytes(), 262208 + bufferSize);
+  ASSERT_EQ(generalPool.usedBytes(), 262208 + bufferSize);
   ASSERT_EQ(generalPool.reservedBytes(), 1048576);
-  ASSERT_EQ(dictPool.currentBytes(), bufferSize);
+  ASSERT_EQ(dictPool.usedBytes(), bufferSize);
   ASSERT_EQ(dictPool.reservedBytes(), 1048576);
-  ASSERT_EQ(outputPool.currentBytes(), bufferSize);
+  ASSERT_EQ(outputPool.usedBytes(), bufferSize);
   ASSERT_EQ(outputPool.reservedBytes(), 1048576);
   ASSERT_EQ(context.getTotalMemoryUsage(), 262208 + bufferSize * 3);
   ASSERT_EQ(context.availableMemoryReservation(), 2880448);
@@ -251,11 +251,11 @@ TEST_F(WriterContextTest, abort) {
   ASSERT_TRUE(generalPool.maybeReserve(4L << 20));
   ASSERT_TRUE(dictPool.maybeReserve(4L << 20));
   ASSERT_TRUE(outputPool.maybeReserve(4L << 20));
-  ASSERT_EQ(generalPool.currentBytes(), 262208 + bufferSize);
+  ASSERT_EQ(generalPool.usedBytes(), 262208 + bufferSize);
   ASSERT_EQ(generalPool.reservedBytes(), 9437184);
-  ASSERT_EQ(dictPool.currentBytes(), bufferSize);
+  ASSERT_EQ(dictPool.usedBytes(), bufferSize);
   ASSERT_EQ(dictPool.reservedBytes(), 9437184);
-  ASSERT_EQ(outputPool.currentBytes(), bufferSize);
+  ASSERT_EQ(outputPool.usedBytes(), bufferSize);
   ASSERT_EQ(outputPool.reservedBytes(), 9437184);
   ASSERT_EQ(context.getTotalMemoryUsage(), 262208 + bufferSize * 3);
   ASSERT_EQ(context.availableMemoryReservation(), 28046272);
@@ -263,11 +263,11 @@ TEST_F(WriterContextTest, abort) {
   context.abort();
 
   ASSERT_EQ(context.getTotalMemoryUsage(), bufferSize * 3);
-  ASSERT_EQ(generalPool.currentBytes(), bufferSize);
+  ASSERT_EQ(generalPool.usedBytes(), bufferSize);
   ASSERT_EQ(generalPool.reservedBytes(), 1048576);
-  ASSERT_EQ(dictPool.currentBytes(), bufferSize);
+  ASSERT_EQ(dictPool.usedBytes(), bufferSize);
   ASSERT_EQ(dictPool.reservedBytes(), 1048576);
-  ASSERT_EQ(outputPool.currentBytes(), bufferSize);
+  ASSERT_EQ(outputPool.usedBytes(), bufferSize);
   ASSERT_EQ(outputPool.reservedBytes(), 1048576);
   ASSERT_EQ(context.availableMemoryReservation(), 3142656);
 
@@ -275,11 +275,11 @@ TEST_F(WriterContextTest, abort) {
   dictPool.free(dictBuf, bufferSize);
   outputPool.free(outputBuf, bufferSize);
   ASSERT_EQ(context.getTotalMemoryUsage(), 0);
-  ASSERT_EQ(generalPool.currentBytes(), 0);
+  ASSERT_EQ(generalPool.usedBytes(), 0);
   ASSERT_EQ(generalPool.reservedBytes(), 0);
-  ASSERT_EQ(dictPool.currentBytes(), 0);
+  ASSERT_EQ(dictPool.usedBytes(), 0);
   ASSERT_EQ(dictPool.reservedBytes(), 0);
-  ASSERT_EQ(outputPool.currentBytes(), 0);
+  ASSERT_EQ(outputPool.usedBytes(), 0);
   ASSERT_EQ(outputPool.reservedBytes(), 0);
   ASSERT_EQ(context.getTotalMemoryUsage(), 0);
   ASSERT_EQ(context.availableMemoryReservation(), 0);

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -156,6 +156,10 @@ class MockMemoryPool : public velox::memory::MemoryPool {
     return localMemoryUsage_;
   }
 
+  int64_t usedBytes() const override {
+    return localMemoryUsage_;
+  }
+
   std::shared_ptr<MemoryPool> genChild(
       std::shared_ptr<MemoryPool> parent,
       const std::string& name,
@@ -320,7 +324,7 @@ struct SimulatedFlush {
     auto& generalPool = dynamic_cast<MockMemoryPool&>(
         context.getMemoryPool(MemoryUsageCategory::GENERAL));
     dictPool.setLocalMemoryUsage(dictMemoryUsage);
-    ASSERT_EQ(outputStreamMemoryUsage, outputPool.currentBytes());
+    ASSERT_EQ(outputStreamMemoryUsage, outputPool.usedBytes());
     outputPool.updateLocalMemoryUsage(flushOverhead);
     generalPool.setLocalMemoryUsage(generalMemoryUsage);
 
@@ -417,13 +421,12 @@ class WriterFlushTestHelper {
       if (writer->shouldFlush(context, write.numRows)) {
         ASSERT_EQ(
             0,
-            context.getMemoryPool(MemoryUsageCategory::DICTIONARY)
-                .currentBytes());
+            context.getMemoryPool(MemoryUsageCategory::DICTIONARY).usedBytes());
         auto outputStreamMemoryUsage =
             context.getMemoryPool(MemoryUsageCategory::OUTPUT_STREAM)
-                .currentBytes();
+                .usedBytes();
         auto generalMemoryUsage =
-            context.getMemoryPool(MemoryUsageCategory::GENERAL).currentBytes();
+            context.getMemoryPool(MemoryUsageCategory::GENERAL).usedBytes();
 
         uint64_t flushOverhead =
             folly::Random::rand32(0, context.stripeRawSize(), gen);

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -286,7 +286,7 @@ bool Writer::maybeReserveMemory(
   auto& context = getContext();
   auto& pool = context.getMemoryPool(memoryUsageCategory);
   const uint64_t availableReservation = pool.availableReservation();
-  const uint64_t usedReservationBytes = pool.currentBytes();
+  const uint64_t usedReservationBytes = pool.usedBytes();
   const uint64_t minReservationBytes =
       usedReservationBytes * spillConfig_->minSpillableReservationPct / 100;
   const uint64_t estimatedIncrementBytes =
@@ -536,7 +536,7 @@ void Writer::flushStripe(bool close) {
   metrics.availableMemory = context.getMemoryBudget() - totalMemoryUsage;
 
   auto& dictionaryPool = context.getMemoryPool(MemoryUsageCategory::DICTIONARY);
-  metrics.dictionaryMemory = dictionaryPool.currentBytes();
+  metrics.dictionaryMemory = dictionaryPool.usedBytes();
   // TODO: what does this try to capture?
   metrics.maxDictSize = dictionaryPool.stats().peakBytes;
 

--- a/velox/dwio/dwrf/writer/WriterContext.cpp
+++ b/velox/dwio/dwrf/writer/WriterContext.cpp
@@ -116,11 +116,11 @@ int64_t WriterContext::getMemoryUsage(
     const MemoryUsageCategory& category) const {
   switch (category) {
     case MemoryUsageCategory::DICTIONARY:
-      return dictionaryPool_->currentBytes();
+      return dictionaryPool_->usedBytes();
     case MemoryUsageCategory::OUTPUT_STREAM:
-      return outputStreamPool_->currentBytes();
+      return outputStreamPool_->usedBytes();
     case MemoryUsageCategory::GENERAL:
-      return generalPool_->currentBytes();
+      return generalPool_->usedBytes();
     default:
       VELOX_FAIL("Unreachable: {}", static_cast<int>(category));
   }

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -856,7 +856,7 @@ void GroupingSet::ensureInputFits(const RowVectorPtr& input) {
     return;
   }
 
-  const auto currentUsage = pool_.currentBytes();
+  const auto currentUsage = pool_.usedBytes();
   const auto minReservationBytes =
       currentUsage * spillConfig_->minSpillableReservationPct / 100;
   const auto availableReservationBytes = pool_.availableReservation();
@@ -902,7 +902,7 @@ void GroupingSet::ensureInputFits(const RowVectorPtr& input) {
   }
   LOG(WARNING) << "Failed to reserve " << succinctBytes(targetIncrementBytes)
                << " for memory pool " << pool_.name()
-               << ", usage: " << succinctBytes(pool_.currentBytes())
+               << ", usage: " << succinctBytes(pool_.usedBytes())
                << ", reservation: " << succinctBytes(pool_.reservedBytes());
 }
 
@@ -934,7 +934,7 @@ void GroupingSet::ensureOutputFits() {
   LOG(WARNING) << "Failed to reserve "
                << succinctBytes(outputBufferSizeToReserve)
                << " for memory pool " << pool_.name()
-               << ", usage: " << succinctBytes(pool_.currentBytes())
+               << ", usage: " << succinctBytes(pool_.usedBytes())
                << ", reservation: " << succinctBytes(pool_.reservedBytes());
 }
 

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -408,7 +408,7 @@ void HashAggregation::reclaim(
       LOG(WARNING)
           << "Can't reclaim from aggregation operator which has spilled and is under output processing, pool "
           << pool()->name()
-          << ", memory usage: " << succinctBytes(pool()->currentBytes())
+          << ", memory usage: " << succinctBytes(pool()->usedBytes())
           << ", reservation: " << succinctBytes(pool()->reservedBytes());
       return;
     }

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -446,7 +446,7 @@ void HashBuild::ensureInputFits(RowVectorPtr& input) {
       rows->stringAllocator().retainedSize() - outOfLineFreeBytes;
   const auto outOfLineBytesPerRow =
       std::max<uint64_t>(1, numRows == 0 ? 0 : outOfLineBytes / numRows);
-  const auto currentUsage = pool()->currentBytes();
+  const auto currentUsage = pool()->usedBytes();
 
   if (numRows != 0) {
     // Test-only spill path.
@@ -499,7 +499,7 @@ void HashBuild::ensureInputFits(RowVectorPtr& input) {
       LOG(WARNING) << "Failed to reserve "
                    << succinctBytes(targetIncrementBytes) << " for memory pool "
                    << pool()->name()
-                   << ", usage: " << succinctBytes(pool()->currentBytes())
+                   << ", usage: " << succinctBytes(pool()->usedBytes())
                    << ", reservation: "
                    << succinctBytes(pool()->reservedBytes());
     }
@@ -798,7 +798,7 @@ void HashBuild::ensureTableFits(uint64_t numRows) {
 
   LOG(WARNING) << "Failed to reserve " << succinctBytes(bytesToReserve)
                << " for memory pool " << pool()->name()
-               << ", usage: " << succinctBytes(pool()->currentBytes())
+               << ", usage: " << succinctBytes(pool()->usedBytes())
                << ", reservation: " << succinctBytes(pool()->reservedBytes());
 }
 
@@ -821,7 +821,7 @@ void HashBuild::ensureNextRowVectorFits(
     if (!pool()->maybeReserve(bytesToReserve)) {
       LOG(WARNING) << "Failed to reserve " << succinctBytes(bytesToReserve)
                    << " for memory pool " << pool()->name()
-                   << ", usage: " << succinctBytes(pool()->currentBytes())
+                   << ", usage: " << succinctBytes(pool()->usedBytes())
                    << ", reservation: "
                    << succinctBytes(pool()->reservedBytes());
     }
@@ -831,8 +831,7 @@ void HashBuild::ensureNextRowVectorFits(
     if (!build->pool()->maybeReserve(bytesToReserve)) {
       LOG(WARNING) << "Failed to reserve " << succinctBytes(bytesToReserve)
                    << " for memory pool " << build->pool()->name()
-                   << ", usage: "
-                   << succinctBytes(build->pool()->currentBytes())
+                   << ", usage: " << succinctBytes(build->pool()->usedBytes())
                    << ", reservation: "
                    << succinctBytes(build->pool()->reservedBytes());
     }
@@ -1079,7 +1078,7 @@ void HashBuild::reclaim(
                 ? "cleared"
                 : (spiller_->finalized() ? "finalized" : "non-finalized"))
         << "] " << pool()->name()
-        << ", usage: " << succinctBytes(pool()->currentBytes());
+        << ", usage: " << succinctBytes(pool()->usedBytes());
     return;
   }
 
@@ -1099,7 +1098,7 @@ void HashBuild::reclaim(
           << "Can't reclaim from hash build operator, state_["
           << stateName(buildOp->state_) << "], nonReclaimableSection_["
           << buildOp->nonReclaimableSection_ << "], " << buildOp->pool()->name()
-          << ", usage: " << succinctBytes(buildOp->pool()->currentBytes());
+          << ", usage: " << succinctBytes(buildOp->pool()->usedBytes());
       return;
     }
   }

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1546,7 +1546,7 @@ void HashProbe::ensureOutputFits() {
   }
   LOG(WARNING) << "Failed to reserve " << succinctBytes(bytesToReserve)
                << " for memory pool " << pool()->name()
-               << ", usage: " << succinctBytes(pool()->currentBytes())
+               << ", usage: " << succinctBytes(pool()->usedBytes())
                << ", reservation: " << succinctBytes(pool()->reservedBytes());
 }
 
@@ -1577,9 +1577,9 @@ void HashProbe::reclaim(
         << "Can't reclaim from hash probe operator, state_["
         << ProbeOperatorState(state_) << "], nonReclaimableSection_["
         << nonReclaimableSection_ << "], " << pool()->name()
-        << ", usage: " << succinctBytes(pool()->currentBytes())
-        << ", node pool usage: "
-        << succinctBytes(pool()->parent()->currentBytes());
+        << ", usage: " << succinctBytes(pool()->usedBytes())
+        << ", node pool reservation: "
+        << succinctBytes(pool()->parent()->reservedBytes());
     return;
   }
 
@@ -1597,9 +1597,9 @@ void HashProbe::reclaim(
           << "Can't reclaim from hash probe operator, state_["
           << ProbeOperatorState(probeOp->state_) << "], nonReclaimableSection_["
           << probeOp->nonReclaimableSection_ << "], " << probeOp->pool()->name()
-          << ", usage: " << succinctBytes(pool()->currentBytes())
-          << ", node pool usage: "
-          << succinctBytes(pool()->parent()->currentBytes());
+          << ", usage: " << succinctBytes(pool()->usedBytes())
+          << ", node pool reservation: "
+          << succinctBytes(pool()->parent()->reservedBytes());
       return;
     }
     hasMoreProbeInput |= !probeOp->noMoreSpillInput_;

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -140,10 +140,9 @@ std::unique_ptr<JoinBridge> Operator::joinBridgeFromPlanNode(
 void Operator::initialize() {
   VELOX_CHECK(!initialized_);
   VELOX_CHECK_EQ(
-      pool()->currentBytes(),
+      pool()->usedBytes(),
       0,
-      "Unexpected memory usage {} from pool {} before operator init",
-      succinctBytes(pool()->currentBytes()),
+      "Unexpected memory usage from pool {} before operator init",
       pool()->name());
   initialized_ = true;
   maybeSetReclaimer();
@@ -641,7 +640,7 @@ uint64_t Operator::MemoryReclaimer::reclaim(
     RECORD_METRIC_VALUE(kMetricMemoryNonReclaimableCount);
     LOG(WARNING) << "Can't reclaim from memory pool " << pool->name()
                  << " which is under non-reclaimable section, memory usage: "
-                 << succinctBytes(pool->currentBytes())
+                 << succinctBytes(pool->usedBytes())
                  << ", reservation: " << succinctBytes(pool->reservedBytes());
     return 0;
   }

--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -201,7 +201,7 @@ void RowNumber::ensureInputFits(const RowVectorPtr& input) {
     return;
   }
 
-  const auto currentUsage = pool()->currentBytes();
+  const auto currentUsage = pool()->usedBytes();
   const auto minReservationBytes =
       currentUsage * spillConfig_->minSpillableReservationPct / 100;
   const auto availableReservationBytes = pool()->availableReservation();
@@ -235,7 +235,7 @@ void RowNumber::ensureInputFits(const RowVectorPtr& input) {
 
   LOG(WARNING) << "Failed to reserve " << succinctBytes(targetIncrementBytes)
                << " for memory pool " << pool()->name()
-               << ", usage: " << succinctBytes(pool()->currentBytes())
+               << ", usage: " << succinctBytes(pool()->usedBytes())
                << ", reservation: " << succinctBytes(pool()->reservedBytes());
 }
 

--- a/velox/exec/SortBuffer.cpp
+++ b/velox/exec/SortBuffer.cpp
@@ -199,7 +199,7 @@ void SortBuffer::ensureInputFits(const VectorPtr& input) {
     return;
   }
 
-  const auto currentMemoryUsage = pool_->currentBytes();
+  const auto currentMemoryUsage = pool_->usedBytes();
   const auto minReservationBytes =
       currentMemoryUsage * spillConfig_->minSpillableReservationPct / 100;
   const auto availableReservationBytes = pool_->availableReservation();
@@ -233,7 +233,7 @@ void SortBuffer::ensureInputFits(const VectorPtr& input) {
   }
   LOG(WARNING) << "Failed to reserve " << succinctBytes(targetIncrementBytes)
                << " for memory pool " << pool()->name()
-               << ", usage: " << succinctBytes(pool()->currentBytes())
+               << ", usage: " << succinctBytes(pool()->usedBytes())
                << ", reservation: " << succinctBytes(pool()->reservedBytes());
 }
 

--- a/velox/exec/SortWindowBuild.cpp
+++ b/velox/exec/SortWindowBuild.cpp
@@ -100,7 +100,7 @@ void SortWindowBuild::ensureInputFits(const RowVectorPtr& input) {
       data_->stringAllocator().retainedSize() - outOfLineFreeBytes;
   const auto outOfLineBytesPerRow = outOfLineBytes / data_->numRows();
 
-  const auto currentUsage = data_->pool()->currentBytes();
+  const auto currentUsage = data_->pool()->usedBytes();
   const auto minReservationBytes =
       currentUsage * spillConfig_->minSpillableReservationPct / 100;
   const auto availableReservationBytes = data_->pool()->availableReservation();
@@ -132,7 +132,7 @@ void SortWindowBuild::ensureInputFits(const RowVectorPtr& input) {
 
   LOG(WARNING) << "Failed to reserve " << succinctBytes(targetIncrementBytes)
                << " for memory pool " << data_->pool()->name()
-               << ", usage: " << succinctBytes(data_->pool()->currentBytes())
+               << ", usage: " << succinctBytes(data_->pool()->usedBytes())
                << ", reservation: "
                << succinctBytes(data_->pool()->reservedBytes());
 }

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -326,7 +326,7 @@ uint64_t TableWriter::ConnectorReclaimer::reclaim(
     ++stats.numNonReclaimableAttempts;
     LOG(WARNING) << "Can't reclaim from a closed writer connector pool: "
                  << pool->name()
-                 << ", memory usage: " << succinctBytes(pool->currentBytes());
+                 << ", memory usage: " << succinctBytes(pool->reservedBytes());
     return 0;
   }
 
@@ -336,7 +336,7 @@ uint64_t TableWriter::ConnectorReclaimer::reclaim(
     LOG(WARNING)
         << "Can't reclaim from a writer connector pool which hasn't initialized yet: "
         << pool->name()
-        << ", memory usage: " << succinctBytes(pool->currentBytes());
+        << ", memory usage: " << succinctBytes(pool->reservedBytes());
     return 0;
   }
   RuntimeStatWriterScopeGuard opStatsGuard(op_);

--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -649,8 +649,7 @@ void TopNRowNumber::reclaim(
     // TODO Add support for spilling after noMoreInput().
     LOG(WARNING)
         << "Can't reclaim from topNRowNumber operator which has started producing output: "
-        << pool()->name()
-        << ", usage: " << succinctBytes(pool()->currentBytes())
+        << pool()->name() << ", usage: " << succinctBytes(pool()->usedBytes())
         << ", reservation: " << succinctBytes(pool()->reservedBytes());
     return;
   }
@@ -684,7 +683,7 @@ void TopNRowNumber::ensureInputFits(const RowVectorPtr& input) {
       data_->stringAllocator().retainedSize() - outOfLineFreeBytes;
   const auto outOfLineBytesPerRow = outOfLineBytes / data_->numRows();
 
-  const auto currentUsage = pool()->currentBytes();
+  const auto currentUsage = pool()->usedBytes();
   const auto minReservationBytes =
       currentUsage * spillConfig_->minSpillableReservationPct / 100;
   const auto availableReservationBytes = pool()->availableReservation();
@@ -719,7 +718,7 @@ void TopNRowNumber::ensureInputFits(const RowVectorPtr& input) {
 
   LOG(WARNING) << "Failed to reserve " << succinctBytes(targetIncrementBytes)
                << " for memory pool " << pool()->name()
-               << ", usage: " << succinctBytes(pool()->currentBytes())
+               << ", usage: " << succinctBytes(pool()->usedBytes())
                << ", reservation: " << succinctBytes(pool()->reservedBytes());
 }
 

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -203,8 +203,7 @@ void Window::reclaim(
     // TODO Add support for spilling after noMoreInput().
     LOG(WARNING)
         << "Can't reclaim from window operator which has started producing output: "
-        << pool()->name()
-        << ", usage: " << succinctBytes(pool()->currentBytes())
+        << pool()->name() << ", usage: " << succinctBytes(pool()->usedBytes())
         << ", reservation: " << succinctBytes(pool()->reservedBytes());
     return;
   }

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -1134,7 +1134,7 @@ TEST_F(AggregationTest, partialAggregationMaybeReservationReleaseCheck) {
   EXPECT_EQ(0, runtimeStats.count("partialAggregationPct"));
   // Check all the reserved memory have been released.
   EXPECT_EQ(0, task->pool()->availableReservation());
-  EXPECT_GT(kMaxPartialMemoryUsage, task->pool()->currentBytes());
+  EXPECT_GT(kMaxPartialMemoryUsage, task->pool()->reservedBytes());
 }
 
 TEST_F(AggregationTest, spillAll) {
@@ -1783,7 +1783,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, minSpillableMemoryReservation) {
               memory::MemoryPool& pool = groupingSet->testingPool();
               const auto availableReservationBytes =
                   pool.availableReservation();
-              const auto currentUsedBytes = pool.currentBytes();
+              const auto currentUsedBytes = pool.usedBytes();
               // Verifies we always have min reservation after ensuring the
               // input.
               ASSERT_GE(
@@ -2108,7 +2108,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringInputProcessing) {
     }
 
     if (testData.expectedReclaimable) {
-      const auto usedMemory = op->pool()->currentBytes();
+      const auto usedMemory = op->pool()->usedBytes();
       reclaimAndRestoreCapacity(
           op,
           folly::Random::oneIn(2) ? 0 : folly::Random::rand32(rng_),
@@ -2118,7 +2118,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringInputProcessing) {
       reclaimerStats_.reset();
       // The hash table itself in the grouping set is not cleared so it still
       // uses some memory.
-      ASSERT_LT(op->pool()->currentBytes(), usedMemory);
+      ASSERT_LT(op->pool()->usedBytes(), usedMemory);
     } else {
       VELOX_ASSERT_THROW(
           op->reclaim(
@@ -2232,7 +2232,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringReserve) {
   ASSERT_TRUE(reclaimable);
   ASSERT_GT(reclaimableBytes, 0);
 
-  const auto usedMemory = op->pool()->currentBytes();
+  const auto usedMemory = op->pool()->usedBytes();
   reclaimAndRestoreCapacity(
       op,
       folly::Random::oneIn(2) ? 0 : folly::Random::rand32(rng_),
@@ -2242,7 +2242,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringReserve) {
   reclaimerStats_.reset();
   // The hash table itself in the grouping set is not cleared so it still
   // uses some memory.
-  ASSERT_LT(op->pool()->currentBytes(), usedMemory);
+  ASSERT_LT(op->pool()->usedBytes(), usedMemory);
 
   driverWait.notify();
   Task::resume(task);
@@ -2475,13 +2475,13 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringOutputProcessing) {
     ASSERT_EQ(reclaimable, enableSpilling);
     if (enableSpilling) {
       ASSERT_GT(reclaimableBytes, 0);
-      const auto usedMemory = op->pool()->currentBytes();
+      const auto usedMemory = op->pool()->usedBytes();
       reclaimAndRestoreCapacity(
           op,
           folly::Random::oneIn(2) ? 0 : folly::Random::rand32(rng_),
           reclaimerStats_);
       ASSERT_EQ(reclaimerStats_.numNonReclaimableAttempts, 0);
-      ASSERT_GT(usedMemory, op->pool()->currentBytes());
+      ASSERT_GT(usedMemory, op->pool()->usedBytes());
       ASSERT_GT(reclaimerStats_.reclaimedBytes, 0);
       ASSERT_GT(reclaimerStats_.reclaimExecTimeUs, 0);
       reclaimerStats_.reset();
@@ -2564,7 +2564,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringNonReclaimableSection) {
           if (!testData.nonReclaimableInput) {
             return;
           }
-          if (groupSet->testingPool().currentBytes() == 0) {
+          if (groupSet->testingPool().usedBytes() == 0) {
             return;
           }
           if (!injectNonReclaimableSectionOnce.exchange(false)) {
@@ -2763,14 +2763,14 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimWithEmptyAggregationTable) {
     ASSERT_EQ(reclaimable, enableSpilling);
     if (enableSpilling) {
       ASSERT_EQ(reclaimableBytes, 0);
-      const auto usedMemory = op->pool()->currentBytes();
+      const auto usedMemory = op->pool()->usedBytes();
       reclaimAndRestoreCapacity(
           op,
           folly::Random::oneIn(2) ? 0 : folly::Random::rand32(rng_),
           reclaimerStats_);
       ASSERT_EQ(reclaimerStats_, memory::MemoryReclaimer::Stats{});
       // No reclaim as the operator has started output processing.
-      ASSERT_EQ(usedMemory, op->pool()->currentBytes());
+      ASSERT_EQ(usedMemory, op->pool()->usedBytes());
     } else {
       ASSERT_EQ(reclaimableBytes, 0);
       VELOX_ASSERT_THROW(
@@ -2846,7 +2846,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, abortDuringOutputProcessing) {
                                            : abortPool(op->pool());
           // We can't directly reclaim memory from this hash build operator as
           // its driver thread is running and in suspension state.
-          ASSERT_GT(op->pool()->root()->currentBytes(), 0);
+          ASSERT_GT(op->pool()->root()->usedBytes(), 0);
           ASSERT_EQ(
               driver->task()->leaveSuspended(driver->state()),
               StopReason::kAlreadyTerminated);
@@ -2910,7 +2910,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, abortDuringInputgProcessing) {
                                            : abortPool(op->pool());
           // We can't directly reclaim memory from this hash build operator as
           // its driver thread is running and in suspension state.
-          ASSERT_GT(op->pool()->root()->currentBytes(), 0);
+          ASSERT_GT(op->pool()->root()->usedBytes(), 0);
           ASSERT_EQ(
               driver->task()->leaveSuspended(driver->state()),
               StopReason::kAlreadyTerminated);

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -5509,7 +5509,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringInputProcessing) {
       ASSERT_GT(reclaimerStats_.reclaimExecTimeUs, 0);
       ASSERT_GT(reclaimerStats_.reclaimedBytes, 0);
       reclaimerStats_.reset();
-      ASSERT_EQ(op->pool()->currentBytes(), 0);
+      ASSERT_EQ(op->pool()->usedBytes(), 0);
     } else {
       VELOX_ASSERT_THROW(
           op->reclaim(
@@ -5588,7 +5588,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringReserve) {
               return;
             }
             ASSERT_TRUE(op->canReclaim());
-            if (op->pool()->currentBytes() == 0) {
+            if (op->pool()->usedBytes() == 0) {
               // We skip trigger memory reclaim when the hash table is empty on
               // memory reservation.
               return;
@@ -5645,7 +5645,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringReserve) {
       reclaimerStats_);
   ASSERT_GT(reclaimerStats_.reclaimedBytes, 0);
   ASSERT_GT(reclaimerStats_.reclaimExecTimeUs, 0);
-  ASSERT_EQ(op->pool()->currentBytes(), 0);
+  ASSERT_EQ(op->pool()->usedBytes(), 0);
 
   driverWaitFlag = false;
   driverWait.notifyAll();
@@ -5890,7 +5890,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringOutputProcessing) {
 
     if (enableSpilling) {
       ASSERT_GT(reclaimableBytes, 0);
-      const auto usedMemoryBytes = op->pool()->currentBytes();
+      const auto usedMemoryBytes = op->pool()->usedBytes();
       reclaimAndRestoreCapacity(
           op,
           folly::Random::oneIn(2) ? 0 : folly::Random::rand32(),
@@ -5898,7 +5898,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringOutputProcessing) {
       ASSERT_GT(reclaimerStats_.reclaimedBytes, 0);
       ASSERT_GT(reclaimerStats_.reclaimExecTimeUs, 0);
       // No reclaim as the operator has started output processing.
-      ASSERT_EQ(usedMemoryBytes, op->pool()->currentBytes());
+      ASSERT_EQ(usedMemoryBytes, op->pool()->usedBytes());
     } else {
       ASSERT_EQ(reclaimableBytes, 0);
       VELOX_ASSERT_THROW(
@@ -6034,7 +6034,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringWaitForProbe) {
   ASSERT_TRUE(reclaimable);
   ASSERT_GT(reclaimableBytes, 0);
 
-  const auto usedMemoryBytes = op->pool()->currentBytes();
+  const auto usedMemoryBytes = op->pool()->usedBytes();
   reclaimerStats_.reset();
   reclaimAndRestoreCapacity(
       op,
@@ -6043,7 +6043,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringWaitForProbe) {
   ASSERT_GT(reclaimerStats_.reclaimedBytes, 0);
   ASSERT_GT(reclaimerStats_.reclaimExecTimeUs, 0);
   //  No reclaim as the build operator is not in building table state.
-  ASSERT_EQ(usedMemoryBytes, op->pool()->currentBytes());
+  ASSERT_EQ(usedMemoryBytes, op->pool()->usedBytes());
 
   driverWaitFlag = false;
   driverWait.notifyAll();
@@ -6099,7 +6099,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashBuildAbortDuringOutputProcessing) {
           if (!injectOnce.exchange(false)) {
             return;
           }
-          ASSERT_GT(op->pool()->currentBytes(), 0);
+          ASSERT_GT(op->pool()->usedBytes(), 0);
           auto* driver = op->testingOperatorCtx()->driver();
           ASSERT_EQ(
               driver->task()->enterSuspended(driver->state()),
@@ -6108,7 +6108,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashBuildAbortDuringOutputProcessing) {
                                            : abortPool(op->pool());
           // We can't directly reclaim memory from this hash build operator as
           // its driver thread is running and in suspension state.
-          ASSERT_GT(op->pool()->root()->currentBytes(), 0);
+          ASSERT_GT(op->pool()->root()->usedBytes(), 0);
           ASSERT_EQ(
               driver->task()->leaveSuspended(driver->state()),
               StopReason::kAlreadyTerminated);
@@ -6175,7 +6175,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashBuildAbortDuringInputProcessing) {
           if (++numInputs != 2) {
             return;
           }
-          ASSERT_GT(op->pool()->currentBytes(), 0);
+          ASSERT_GT(op->pool()->usedBytes(), 0);
           auto* driver = op->testingOperatorCtx()->driver();
           ASSERT_EQ(
               driver->task()->enterSuspended(driver->state()),
@@ -6184,7 +6184,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashBuildAbortDuringInputProcessing) {
                                            : abortPool(op->pool());
           // We can't directly reclaim memory from this hash build operator as
           // its driver thread is running and in suspension state.
-          ASSERT_GT(op->pool()->root()->currentBytes(), 0);
+          ASSERT_GT(op->pool()->root()->usedBytes(), 0);
           ASSERT_EQ(
               driver->task()->leaveSuspended(driver->state()),
               StopReason::kAlreadyTerminated);
@@ -6254,7 +6254,6 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashBuildAbortDuringAllocation) {
                 return;
               }
 
-              // ASSERT_GT(pool->currentBytes(), 0);
               auto& driverCtx = driverThreadContext()->driverCtx;
               ASSERT_EQ(
                   driverCtx.task->enterSuspended(driverCtx.driver->state()),
@@ -6263,7 +6262,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashBuildAbortDuringAllocation) {
                                                : abortPool(pool);
               // We can't directly reclaim memory from this hash build operator
               // as its driver thread is running and in suspegnsion state.
-              ASSERT_GE(pool->root()->currentBytes(), 0);
+              ASSERT_GE(pool->root()->usedBytes(), 0);
               ASSERT_EQ(
                   driverCtx.task->leaveSuspended(driverCtx.driver->state()),
                   StopReason::kAlreadyTerminated);
@@ -6498,7 +6497,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, minSpillableMemoryReservation) {
         std::function<void(exec::HashBuild*)>(([&](exec::HashBuild* hashBuild) {
           memory::MemoryPool* pool = hashBuild->pool();
           const auto availableReservationBytes = pool->availableReservation();
-          const auto currentUsedBytes = pool->currentBytes();
+          const auto currentUsedBytes = pool->usedBytes();
           // Verifies we always have min reservation after ensuring the input.
           ASSERT_GE(
               availableReservationBytes,

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -154,11 +154,11 @@ class HashTableTest : public testing::TestWithParam<bool>,
 
     const uint64_t estimatedTableSize =
         topTable_->estimateHashTableSize(numRows);
-    const uint64_t usedMemoryBytes = topTable_->rows()->pool()->currentBytes();
+    const uint64_t usedMemoryBytes = topTable_->rows()->pool()->usedBytes();
     topTable_->prepareJoinTable(std::move(otherTables), executor_.get());
     ASSERT_GE(
         estimatedTableSize,
-        topTable_->rows()->pool()->currentBytes() - usedMemoryBytes);
+        topTable_->rows()->pool()->usedBytes() - usedMemoryBytes);
     ASSERT_EQ(topTable_->hashMode(), mode);
     ASSERT_EQ(topTable_->allRows().size(), numWays);
     uint64_t rowCount{0};
@@ -174,13 +174,13 @@ class HashTableTest : public testing::TestWithParam<bool>,
     testEraseEveryN(4);
     testProbe();
     testGroupBySpill(size, buildType, numKeys);
-    const auto memoryUsage = pool()->currentBytes();
+    const auto memoryUsage = pool()->usedBytes();
     topTable_->clear(true);
     for (const auto* rowContainer : topTable_->allRows()) {
       ASSERT_EQ(rowContainer->numRows(), 0);
     }
     ASSERT_EQ(topTable_->numDistinct(), 0);
-    ASSERT_LT(pool()->currentBytes(), memoryUsage);
+    ASSERT_LT(pool()->usedBytes(), memoryUsage);
   }
 
   // Inserts and deletes rows in a HashTable, similarly to a group by

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -668,7 +668,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringInputProcessing) {
       ASSERT_GT(reclaimerStats_.reclaimedBytes, 0);
       ASSERT_GT(reclaimerStats_.reclaimExecTimeUs, 0);
       reclaimerStats_.reset();
-      ASSERT_EQ(op->pool()->currentBytes(), 0);
+      ASSERT_EQ(op->pool()->usedBytes(), 0);
     } else {
       VELOX_ASSERT_THROW(
           op->reclaim(
@@ -791,7 +791,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringReserve) {
   ASSERT_GT(reclaimerStats_.reclaimedBytes, 0);
   ASSERT_GT(reclaimerStats_.reclaimExecTimeUs, 0);
   reclaimerStats_.reset();
-  ASSERT_EQ(op->pool()->currentBytes(), 0);
+  ASSERT_EQ(op->pool()->usedBytes(), 0);
 
   driverWait.notify();
   Task::resume(task);
@@ -1092,7 +1092,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, abortDuringOutputProcessing) {
           if (!injectOnce.exchange(false)) {
             return;
           }
-          ASSERT_GT(op->pool()->currentBytes(), 0);
+          ASSERT_GT(op->pool()->usedBytes(), 0);
           auto* driver = op->testingOperatorCtx()->driver();
           ASSERT_EQ(
               driver->task()->enterSuspended(driver->state()),
@@ -1101,7 +1101,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, abortDuringOutputProcessing) {
                                            : abortPool(op->pool());
           // We can't directly reclaim memory from this hash build operator as
           // its driver thread is running and in suspension state.
-          ASSERT_GT(op->pool()->root()->currentBytes(), 0);
+          ASSERT_GT(op->pool()->root()->usedBytes(), 0);
           ASSERT_EQ(
               driver->task()->leaveSuspended(driver->state()),
               StopReason::kAlreadyTerminated);
@@ -1167,7 +1167,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, abortDuringInputgProcessing) {
                                            : abortPool(op->pool());
           // We can't directly reclaim memory from this hash build operator as
           // its driver thread is running and in suspension state.
-          ASSERT_GT(op->pool()->root()->currentBytes(), 0);
+          ASSERT_GT(op->pool()->root()->usedBytes(), 0);
           ASSERT_EQ(
               driver->task()->leaveSuspended(driver->state()),
               StopReason::kAlreadyTerminated);


### PR DESCRIPTION
Provide usedBytes API to return actual used memory from non-leaf memory pool. It traverse
the child memory pools to calculate the aggregated memory usage.