### PR TITLE
Add getLocalFileSystem API and enforce non-null config to getFileSystem

### DIFF
--- a/velox/common/caching/SsdCache.cpp
+++ b/velox/common/caching/SsdCache.cpp
@@ -46,8 +46,8 @@ SsdCache::SsdCache(
       filePrefix_.find("/") == 0,
       "Ssd path '{}' does not start with '/' that points to local file system.",
       filePrefix_);
-  filesystems::getFileSystem(filePrefix_, nullptr)
-      ->mkdir(std::filesystem::path(filePrefix).parent_path().string());
+  filesystems::getLocalFileSystem()->mkdir(
+      std::filesystem::path(filePrefix).parent_path().string());
 
   files_.reserve(numShards_);
   // Cache size must be a multiple of this so that each shard has the same max

--- a/velox/common/file/FileSystems.cpp
+++ b/velox/common/file/FileSystems.cpp
@@ -52,6 +52,7 @@ void registerFileSystem(
 std::shared_ptr<FileSystem> getFileSystem(
     std::string_view filePath,
     std::shared_ptr<const Config> properties) {
+  VELOX_CHECK_NOT_NULL(properties);
   const auto& filesystems = registeredFileSystems();
   for (const auto& p : filesystems) {
     if (p.first(filePath)) {
@@ -203,4 +204,9 @@ void registerLocalFileSystem() {
   registerFileSystem(
       LocalFileSystem::schemeMatcher(), LocalFileSystem::fileSystemGenerator());
 }
+
+std::shared_ptr<FileSystem> getLocalFileSystem() {
+  return LocalFileSystem::fileSystemGenerator()(nullptr, kFileScheme);
+}
+
 } // namespace facebook::velox::filesystems

--- a/velox/common/file/FileSystems.h
+++ b/velox/common/file/FileSystems.h
@@ -98,9 +98,14 @@ class FileSystem {
   std::shared_ptr<const Config> config_;
 };
 
+/// Get the filesystem based on the input filename and config.
+/// Config cannot be null.
 std::shared_ptr<FileSystem> getFileSystem(
     std::string_view filename,
     std::shared_ptr<const Config> config);
+
+/// Get the local filesystem.
+std::shared_ptr<FileSystem> getLocalFileSystem();
 
 /// FileSystems must be registered explicitly.
 /// The registration function takes two parameters:

--- a/velox/common/file/tests/CMakeLists.txt
+++ b/velox/common/file/tests/CMakeLists.txt
@@ -20,5 +20,11 @@ target_link_libraries(velox_file_test_utils PUBLIC velox_file)
 add_executable(velox_file_test FileTest.cpp UtilsTest.cpp)
 add_test(velox_file_test velox_file_test)
 target_link_libraries(
-  velox_file_test PRIVATE velox_file velox_file_test_utils velox_temp_path
-                          gmock gtest gtest_main)
+  velox_file_test
+  PRIVATE velox_file
+          velox_file_test_utils
+          velox_temp_path
+          velox_config
+          gmock
+          gtest
+          gtest_main)

--- a/velox/common/file/tests/FileTest.cpp
+++ b/velox/common/file/tests/FileTest.cpp
@@ -20,6 +20,7 @@
 #include "velox/common/file/File.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/file/tests/FaultyFileSystem.h"
+#include "velox/core/Config.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 #include "velox/exec/tests/utils/TempFilePath.h"
 
@@ -147,7 +148,8 @@ TEST_P(LocalFileTest, writeAndRead) {
 
     auto tempFile = exec::test::TempFilePath::create(useFaultyFs_);
     const auto& filename = tempFile->getPath();
-    auto fs = filesystems::getFileSystem(filename, {});
+    auto fs = filesystems::getFileSystem(
+        filename, std::make_shared<core::MemConfig>());
     fs->remove(filename);
     {
       auto writeFile = fs->openFileForWrite(filename);
@@ -163,7 +165,8 @@ TEST_P(LocalFileTest, writeAndRead) {
 TEST_P(LocalFileTest, viaRegistry) {
   auto tempFile = exec::test::TempFilePath::create(useFaultyFs_);
   const auto& filename = tempFile->getPath();
-  auto fs = filesystems::getFileSystem(filename, {});
+  auto fs =
+      filesystems::getFileSystem(filename, std::make_shared<core::MemConfig>());
   fs->remove(filename);
   {
     auto writeFile = fs->openFileForWrite(filename);
@@ -182,7 +185,8 @@ TEST_P(LocalFileTest, rename) {
   const auto b = fmt::format("{}/b", tempFolder->getPath());
   const auto newA = fmt::format("{}/newA", tempFolder->getPath());
   const std::string data("aaaaa");
-  auto localFs = filesystems::getFileSystem(a, nullptr);
+  auto localFs =
+      filesystems::getFileSystem(a, std::make_shared<core::MemConfig>());
   {
     auto writeFile = localFs->openFileForWrite(a);
     writeFile = localFs->openFileForWrite(b);
@@ -207,7 +211,9 @@ TEST_P(LocalFileTest, exists) {
   auto tempFolder = ::exec::test::TempDirectoryPath::create(useFaultyFs_);
   auto a = fmt::format("{}/a", tempFolder->getPath());
   auto b = fmt::format("{}/b", tempFolder->getPath());
-  auto localFs = filesystems::getFileSystem(a, nullptr);
+  // Test local filesystem via the getFileSystem API
+  auto localFs =
+      filesystems::getFileSystem(a, std::make_shared<core::MemConfig>());
   {
     auto writeFile = localFs->openFileForWrite(a);
     writeFile = localFs->openFileForWrite(b);
@@ -226,7 +232,8 @@ TEST_P(LocalFileTest, list) {
   const auto tempFolder = ::exec::test::TempDirectoryPath::create(useFaultyFs_);
   const auto a = fmt::format("{}/1", tempFolder->getPath());
   const auto b = fmt::format("{}/2", tempFolder->getPath());
-  auto localFs = filesystems::getFileSystem(a, nullptr);
+  auto localFs =
+      filesystems::getFileSystem(a, std::make_shared<core::MemConfig>());
   {
     auto writeFile = localFs->openFileForWrite(a);
     writeFile = localFs->openFileForWrite(b);
@@ -248,7 +255,8 @@ TEST_P(LocalFileTest, readFileDestructor) {
   }
   auto tempFile = exec::test::TempFilePath::create(useFaultyFs_);
   const auto& filename = tempFile->getPath();
-  auto fs = filesystems::getFileSystem(filename, {});
+  auto fs =
+      filesystems::getFileSystem(filename, std::make_shared<core::MemConfig>());
   fs->remove(filename);
   {
     auto writeFile = fs->openFileForWrite(filename);
@@ -283,7 +291,8 @@ TEST_P(LocalFileTest, mkdir) {
   auto tempFolder = exec::test::TempDirectoryPath::create(useFaultyFs_);
 
   std::string path = tempFolder->getPath();
-  auto localFs = filesystems::getFileSystem(path, nullptr);
+  auto localFs =
+      filesystems::getFileSystem(path, std::make_shared<core::MemConfig>());
 
   // Create 3 levels of directories and ensure they exist.
   path += "/level1/level2/level3";
@@ -308,7 +317,8 @@ TEST_P(LocalFileTest, rmdir) {
   auto tempFolder = exec::test::TempDirectoryPath::create(useFaultyFs_);
 
   std::string path = tempFolder->getPath();
-  auto localFs = filesystems::getFileSystem(path, nullptr);
+  auto localFs =
+      filesystems::getFileSystem(path, std::make_shared<core::MemConfig>());
 
   // Create 3 levels of directories and ensure they exist.
   path += "/level1/level2/level3";
@@ -340,7 +350,8 @@ TEST_P(LocalFileTest, rmdir) {
 TEST_P(LocalFileTest, fileNotFound) {
   auto tempFolder = exec::test::TempDirectoryPath::create(useFaultyFs_);
   auto path = fmt::format("{}/file", tempFolder->getPath());
-  auto localFs = filesystems::getFileSystem(path, nullptr);
+  auto localFs =
+      filesystems::getFileSystem(path, std::make_shared<core::MemConfig>());
   VELOX_ASSERT_RUNTIME_THROW_CODE(
       localFs->openFileForRead(path),
       error_code::kFileNotFound,
@@ -364,7 +375,8 @@ class FaultyFsTest : public ::testing::Test {
   void SetUp() {
     dir_ = exec::test::TempDirectoryPath::create(true);
     fs_ = std::dynamic_pointer_cast<tests::utils::FaultyFileSystem>(
-        filesystems::getFileSystem(dir_->getPath(), {}));
+        filesystems::getFileSystem(
+            dir_->getPath(), std::make_shared<core::MemConfig>()));
     VELOX_CHECK_NOT_NULL(fs_);
     readFilePath_ = fmt::format("{}/faultyTestReadFile", dir_->getPath());
     writeFilePath_ = fmt::format("{}/faultyTestWriteFile", dir_->getPath());

--- a/velox/common/file/tests/FileTest.cpp
+++ b/velox/common/file/tests/FileTest.cpp
@@ -90,6 +90,13 @@ void readData(ReadFile* readFile, bool checkFileSize = true) {
   ASSERT_EQ(std::string_view(tail, sizeof(tail)), "ccddddd");
 }
 
+TEST(RegistrationTest, missingRegistration) {
+  VELOX_ASSERT_THROW(
+      filesystems::getFileSystem(
+          "/", std::make_shared<const core::MemConfig>()),
+      "No registered file system matched with file path '/'");
+}
+
 // We could templated this test, but that's kinda overkill for how simple it is.
 TEST(InMemoryFile, writeAndRead) {
   for (bool useIOBuf : {true, false}) {

--- a/velox/common/process/Profiler.cpp
+++ b/velox/common/process/Profiler.cpp
@@ -312,7 +312,7 @@ void Profiler::start(const std::string& path) {
   char temp[1000] = {};
   gethostname(temp, sizeof(temp) - 1);
   hostname = std::string(temp);
-  fileSystem_ = velox::filesystems::getFileSystem(path, nullptr);
+  fileSystem_ = velox::filesystems::getLocalFileSystem();
   if (!fileSystem_) {
     LOG(ERROR) << "PROFILE: Failed to find file system for " << path
                << ". Profiler not started.";

--- a/velox/connectors/hive/FileHandle.cpp
+++ b/velox/connectors/hive/FileHandle.cpp
@@ -43,8 +43,13 @@ std::shared_ptr<FileHandle> FileHandleGenerator::operator()(
   {
     MicrosecondTimer timer(&elapsedTimeUs);
     fileHandle = std::make_shared<FileHandle>();
-    fileHandle->file = filesystems::getFileSystem(filename, properties_)
-                           ->openFileForRead(filename);
+    if (properties_) {
+      fileHandle->file = filesystems::getFileSystem(filename, properties_)
+                             ->openFileForRead(filename);
+    } else {
+      fileHandle->file =
+          filesystems::getLocalFileSystem()->openFileForRead(filename);
+    }
     fileHandle->uuid = StringIdLease(fileIds(), filename);
     fileHandle->groupId = StringIdLease(fileIds(), groupName(filename));
     VLOG(1) << "Generating file handle for: " << filename

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -153,8 +153,8 @@ class HiveIcebergTest : public HiveConnectorTestBase {
     std::unordered_map<std::string, std::string> customSplitInfo;
     customSplitInfo["table_format"] = "hive-iceberg";
 
-    auto file = filesystems::getFileSystem(dataFilePath, nullptr)
-                    ->openFileForRead(dataFilePath);
+    auto file =
+        filesystems::getLocalFileSystem()->openFileForRead(dataFilePath);
     const int64_t fileSize = file->size();
 
     return std::make_shared<HiveIcebergSplit>(

--- a/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsFileSystemTest.cpp
@@ -210,10 +210,10 @@ TEST_F(HdfsFileSystemTest, fallbackToUseConfig) {
 }
 
 TEST_F(HdfsFileSystemTest, oneFsInstanceForOneEndpoint) {
-  auto hdfsFileSystem1 =
-      filesystems::getFileSystem(fullDestinationPath, nullptr);
-  auto hdfsFileSystem2 =
-      filesystems::getFileSystem(fullDestinationPath, nullptr);
+  auto hdfsFileSystem1 = filesystems::getFileSystem(
+      fullDestinationPath, std::make_shared<const core::MemConfig>());
+  auto hdfsFileSystem2 = filesystems::getFileSystem(
+      fullDestinationPath, std::make_shared<const core::MemConfig>());
   ASSERT_TRUE(hdfsFileSystem1 == hdfsFileSystem2);
 }
 
@@ -283,18 +283,9 @@ TEST_F(HdfsFileSystemTest, missingFileViaReadFile) {
 }
 
 TEST_F(HdfsFileSystemTest, schemeMatching) {
-  try {
-    auto fs = std::dynamic_pointer_cast<filesystems::HdfsFileSystem>(
-        filesystems::getFileSystem("/", nullptr));
-    FAIL() << "expected VeloxException";
-  } catch (VeloxException const& error) {
-    EXPECT_THAT(
-        error.message(),
-        testing::HasSubstr(
-            "No registered file system matched with file path '/'"));
-  }
   auto fs = std::dynamic_pointer_cast<filesystems::HdfsFileSystem>(
-      filesystems::getFileSystem(fullDestinationPath, nullptr));
+      filesystems::getFileSystem(
+          fullDestinationPath, std::make_shared<const core::MemConfig>()));
   ASSERT_TRUE(fs->isHdfsFile(fullDestinationPath));
 }
 

--- a/velox/core/CMakeLists.txt
+++ b/velox/core/CMakeLists.txt
@@ -16,7 +16,8 @@ if(${VELOX_BUILD_TESTING})
 endif()
 
 add_library(velox_config Config.cpp)
-target_link_libraries(velox_config PUBLIC velox_exception Folly::folly)
+target_link_libraries(velox_config PUBLIC velox_type_tz velox_exception
+                                          Folly::folly)
 
 add_library(velox_core Expressions.cpp PlanFragment.cpp PlanNode.cpp
                        QueryConfig.cpp QueryCtx.cpp SimpleFunctionMetadata.cpp)

--- a/velox/exec/SpillFile.cpp
+++ b/velox/exec/SpillFile.cpp
@@ -63,7 +63,7 @@ SpillWriteFile::SpillWriteFile(
     const std::string& pathPrefix,
     const std::string& fileCreateConfig)
     : id_(id), path_(fmt::format("{}-{}", pathPrefix, ordinalCounter_++)) {
-  auto fs = filesystems::getFileSystem(path_, nullptr);
+  auto fs = filesystems::getLocalFileSystem();
   file_ = fs->openFileForWrite(
       path_,
       filesystems::FileOptions{
@@ -322,7 +322,7 @@ SpillReadFile::SpillReadFile(
       stats_(stats) {
   constexpr uint64_t kMaxReadBufferSize =
       (1 << 20) - AlignedBuffer::kPaddedSize; // 1MB - padding.
-  auto fs = filesystems::getFileSystem(path_, nullptr);
+  auto fs = filesystems::getLocalFileSystem();
   auto file = fs->openFileForRead(path_);
   auto buffer = AlignedBuffer::allocate<char>(
       std::min<uint64_t>(size_, kMaxReadBufferSize), pool_);

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -386,7 +386,7 @@ const std::string& Task::getOrCreateSpillDirectory() {
     return spillDirectory_;
   }
   try {
-    auto fileSystem = filesystems::getFileSystem(spillDirectory_, nullptr);
+    auto fileSystem = filesystems::getLocalFileSystem();
     fileSystem->mkdir(spillDirectory_);
   } catch (const std::exception& e) {
     VELOX_FAIL(
@@ -404,7 +404,7 @@ void Task::removeSpillDirectoryIfExists() {
     return;
   }
   try {
-    auto fs = filesystems::getFileSystem(spillDirectory_, nullptr);
+    auto fs = filesystems::getLocalFileSystem();
     fs->rmdir(spillDirectory_);
   } catch (const std::exception& e) {
     LOG(ERROR) << "Failed to remove spill directory '" << spillDirectory_

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -336,8 +336,7 @@ class SpillTest : public ::testing::TestWithParam<common::CompressionKind>,
     ASSERT_EQ(spilledFileSet.size(), spilledFiles.size());
     ASSERT_EQ(expectedNumSpilledFiles, spilledFileSet.size());
     // Verify the spilled file exist on file system.
-    std::shared_ptr<FileSystem> fs =
-        filesystems::getFileSystem(tempDir_->getPath(), nullptr);
+    std::shared_ptr<FileSystem> fs = filesystems::getLocalFileSystem();
     uint64_t totalFileBytes{0};
     for (const auto& spilledFile : spilledFileSet) {
       auto readFile = fs->openFileForRead(spilledFile);

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -160,7 +160,7 @@ class SpillerTest : public exec::test::RowContainerTestBase {
     RowContainerTestBase::SetUp();
     rng_.seed(1);
     tempDirPath_ = exec::test::TempDirectoryPath::create();
-    fs_ = filesystems::getFileSystem(tempDirPath_->getPath(), nullptr);
+    fs_ = filesystems::getLocalFileSystem();
     containerType_ = ROW({
         {"bool_val", BOOLEAN()},
         {"tiny_val", TINYINT()},

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -1669,7 +1669,7 @@ TEST_F(TaskTest, spillDirNotCreated) {
   ASSERT_EQ(stats.spilledRows, 0);
   // Check for spill folder without destroying the Task object to ensure its
   // destructor has not removed the directory if it was created earlier.
-  auto fs = filesystems::getFileSystem(tmpDirectoryPath, nullptr);
+  auto fs = filesystems::getLocalFileSystem();
   ASSERT_FALSE(fs->exists(tmpDirectoryPath));
 }
 

--- a/velox/exec/tests/utils/Cursor.cpp
+++ b/velox/exec/tests/utils/Cursor.cpp
@@ -174,8 +174,7 @@ class TaskCursorBase : public TaskCursor {
 
     if (!params.spillDirectory.empty()) {
       taskSpillDirectory_ = params.spillDirectory + "/" + taskId_;
-      auto fileSystem =
-          velox::filesystems::getFileSystem(taskSpillDirectory_, nullptr);
+      auto fileSystem = velox::filesystems::getLocalFileSystem();
       VELOX_CHECK_NOT_NULL(fileSystem, "File System is null!");
       try {
         fileSystem->mkdir(taskSpillDirectory_);

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -139,8 +139,9 @@ HiveConnectorTestBase::makeHiveConnectorSplits(
     const std::optional<
         std::unordered_map<std::string, std::optional<std::string>>>&
         partitionKeys) {
-  auto file =
-      filesystems::getFileSystem(filePath, nullptr)->openFileForRead(filePath);
+  auto file = filesystems::getFileSystem(
+                  filePath, std::make_shared<const core::MemConfig>())
+                  ->openFileForRead(filePath);
   const int64_t fileSize = file->size();
   // Take the upper bound.
   const int splitSize = std::ceil((fileSize) / splitCount);

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -227,7 +227,7 @@ core::TypedExprPtr OperatorTestBase::parseExpr(
 
   // If a spilling directory was set, ensure it was removed after the task is
   // gone.
-  auto fs = filesystems::getFileSystem(spillDirectoryStr, nullptr);
+  auto fs = filesystems::getLocalFileSystem();
   EXPECT_FALSE(fs->exists(spillDirectoryStr));
 }
 

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -76,7 +76,7 @@ void TpchQueryBuilder::readFileSchema(
   dwio::common::ReaderOptions readerOptions{pool_.get()};
   readerOptions.setFileFormat(format_);
   auto uniqueReadFile =
-      filesystems::getFileSystem(filePath, nullptr)->openFileForRead(filePath);
+      filesystems::getLocalFileSystem()->openFileForRead(filePath);
   std::shared_ptr<ReadFile> readFile;
   readFile.reset(uniqueReadFile.release());
   auto input = std::make_unique<dwio::common::BufferedInput>(

--- a/velox/expression/tests/ExpressionVerifierUnitTest.cpp
+++ b/velox/expression/tests/ExpressionVerifierUnitTest.cpp
@@ -89,7 +89,7 @@ TEST_F(ExpressionVerifierUnitTest, persistReproInfo) {
   filesystems::registerLocalFileSystem();
   auto reproFolder = exec::test::TempDirectoryPath::create();
   const auto reproPath = reproFolder->getPath();
-  auto localFs = filesystems::getFileSystem(reproPath, nullptr);
+  auto localFs = filesystems::getLocalFileSystem();
 
   ExpressionVerifierOptions options{false, reproPath.c_str(), false};
   ExpressionVerifier verifier{&execCtx_, options};


### PR DESCRIPTION
As discussed here https://github.com/facebookincubator/velox/discussions/8071, enforce a non-null configuration is passed to the `getFileSystem` API call.
Add `getLocalFileSystem` API and use it where a local file is expected to be used.