### PR TITLE
Fix NaN handling in map_subset

### DIFF
--- a/velox/docs/functions/presto/map.rst
+++ b/velox/docs/functions/presto/map.rst
@@ -87,7 +87,8 @@ Map Functions
 
 .. function:: map_subset(map(K,V), array(k)) -> map(K,V)
 
-    Constructs a map from those entries of ``map`` for which the key is in the array given::
+    Constructs a map from those entries of ``map`` for which the key is in the array given
+    For keys containing REAL and DOUBLE, NANs (Not-a-Number) are considered equal. ::
 
         SELECT map_subset(MAP(ARRAY[1,2], ARRAY['a','b']), ARRAY[10]); -- {}
         SELECT map_subset(MAP(ARRAY[1,2], ARRAY['a','b']), ARRAY[1]); -- {1->'a'}

--- a/velox/functions/prestosql/MapSubset.h
+++ b/velox/functions/prestosql/MapSubset.h
@@ -17,6 +17,7 @@
 
 #include "velox/expression/ComplexViewTypes.h"
 #include "velox/functions/Udf.h"
+#include "velox/type/FloatingPointUtil.h"
 
 namespace facebook::velox::functions {
 
@@ -84,7 +85,7 @@ struct MapSubsetPrimitiveFunction {
   }
 
   bool constantSearchKeys_{false};
-  folly::F14FastSet<arg_type<Key>> searchKeys_;
+  util::floating_point::HashSetNaNAware<arg_type<Key>> searchKeys_;
 };
 
 /// Fast path for constant string keys: map_subset(m, array['a', 'b', 'c']).

--- a/velox/vector/tests/utils/VectorMaker.h
+++ b/velox/vector/tests/utils/VectorMaker.h
@@ -822,6 +822,7 @@ class VectorMaker {
       folly::json::serialization_opts options;
       options.convert_int_keys = true;
       options.allow_non_string_keys = true;
+      options.allow_nan_inf = true;
       folly::dynamic mapObject = folly::parseJson(jsonMap, options);
       if (mapObject.isNull()) {
         // Null map.


### PR DESCRIPTION
Summary:
Ensure NaNs values of any binary representations are treated as equal and
can be identified as keys in a map.

Depends on #9893 #9963

Differential Revision: D57681657


