### PR TITLE
Optimize readWithVisitor for RleEncoding and NullableEncoding

### DIFF
--- a/velox/dwio/common/DecoderUtil.cpp
+++ b/velox/dwio/common/DecoderUtil.cpp
@@ -54,7 +54,7 @@ bool nonNullRowsFromSparse(
     RowSet rows,
     raw_vector<int32_t>& innerRows,
     raw_vector<int32_t>& outerRows,
-    uint64_t* resultNulls,
+    uint8_t* resultNullBytes,
     int32_t& tailSkip) {
   constexpr int32_t kStep = xsimd::batch<int32_t>::size;
   bool anyNull = false;
@@ -66,7 +66,6 @@ bool nonNullRowsFromSparse(
   int32_t numNulls = 0;
   int32_t numInner = 0;
   int32_t lastNonNull = -1;
-  auto resultNullBytes = reinterpret_cast<uint8_t*>(resultNulls);
 
   // Returns the index in terms of non-null rows for
   // 'rows[i]'. Assumes that i is increasing between calls.
@@ -158,7 +157,7 @@ template bool nonNullRowsFromSparse<true, false>(
     RowSet rows,
     raw_vector<int32_t>& innerRows,
     raw_vector<int32_t>& outerRows,
-    uint64_t* resultNulls,
+    uint8_t* resultNullBytes,
     int32_t& tailSkip);
 
 template bool nonNullRowsFromSparse<false, true>(
@@ -166,7 +165,7 @@ template bool nonNullRowsFromSparse<false, true>(
     RowSet rows,
     raw_vector<int32_t>& innerRows,
     raw_vector<int32_t>& outerRows,
-    uint64_t* resultNulls,
+    uint8_t* resultNullBytes,
     int32_t& tailSkip);
 
 template bool nonNullRowsFromSparse<false, false>(
@@ -174,7 +173,7 @@ template bool nonNullRowsFromSparse<false, false>(
     RowSet rows,
     raw_vector<int32_t>& innerRows,
     raw_vector<int32_t>& outerRows,
-    uint64_t* resultNulls,
+    uint8_t* resultNullBytes,
     int32_t& tailSkip);
 
 template <typename T>

--- a/velox/dwio/common/DecoderUtil.h
+++ b/velox/dwio/common/DecoderUtil.h
@@ -385,8 +385,21 @@ bool nonNullRowsFromSparse(
     RowSet rows,
     raw_vector<int32_t>& innerRows,
     raw_vector<int32_t>& outerRows,
-    uint64_t* resultNulls,
+    uint8_t* resultNulls,
     int32_t& tailSkip);
+
+template <bool isFilter, bool outputNulls>
+bool nonNullRowsFromSparse(
+    const uint64_t* nulls,
+    RowSet rows,
+    raw_vector<int32_t>& innerRows,
+    raw_vector<int32_t>& outerRows,
+    uint64_t* resultNulls,
+    int32_t& tailSkip) {
+  auto* resultNullBytes = reinterpret_cast<uint8_t*>(resultNulls);
+  return nonNullRowsFromSparse<isFilter, outputNulls>(
+      nulls, rows, innerRows, outerRows, resultNullBytes, tailSkip);
+}
 
 // See SelectiveColumnReader::useBulkPath.
 template <typename Visitor, bool hasNulls>
@@ -399,6 +412,12 @@ bool useFastPath(Visitor& visitor) {
        !hasNulls || !visitor.allowNulls()) &&
       (std::is_same_v<typename Visitor::HookType, NoHook> || !hasNulls ||
        Visitor::HookType::kSkipNulls);
+}
+
+template <typename Visitor>
+bool useFastPath(Visitor& visitor, bool hasNulls) {
+  return hasNulls ? useFastPath<Visitor, true>(visitor)
+                  : useFastPath<Visitor, false>(visitor);
 }
 
 // Scatters 'numValues' elements of 'data' starting at data[sourceBegin] to

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
@@ -155,6 +155,9 @@ void E2EFilterTestBase::readWithFilter(
   // The spec must stay live over the lifetime of the reader.
   setUpRowReaderOptions(rowReaderOpts, spec);
   VLOG(1) << "spec: " << spec->toString();
+  if (!mutationSpec.deletedRows.empty()) {
+    VLOG(1) << "numDeletedRows=" << mutationSpec.deletedRows.size();
+  }
   OwnershipChecker ownershipChecker;
   auto rowReader = reader->createRowReader(rowReaderOpts);
   runtimeStats_ = dwio::common::RuntimeStatistics();
@@ -192,8 +195,8 @@ void E2EFilterTestBase::readWithFilter(
       if (haveDelete) {
         mutation.deletedRows = isDeleted.data();
       }
+      VLOG(1) << "readSize=" << readSize;
       auto rowsScanned = rowReader->next(readSize, resultBatch, &mutation);
-      VLOG(1) << "rowsScanned=" << rowsScanned;
       ASSERT_EQ(rowsScanned, readSize);
       if (resultBatch->size() == 0) {
         // No hits in the last resultBatch of rows.

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.h
@@ -82,16 +82,19 @@ class E2EFilterTestBase : public testing::Test {
     memory::MemoryManager::testingSetInstance({});
   }
 
+  static bool useRandomSeed() {
+    // Check environment variable because `buck test` does not allow pass in
+    // command line arguments.
+    const char* env = getenv("VELOX_TEST_USE_RANDOM_SEED");
+    return !env ? false : folly::to<bool>(env);
+  }
+
   void SetUp() override {
     rootPool_ = memory::memoryManager()->addRootPool("E2EFilterTestBase");
     leafPool_ = rootPool_->addLeafChild("E2EFilterTestBase");
-    // Check environment variable because `buck test` does not allow pass in
-    // command line arguments.
-    if (const char* useRandomSeed = getenv("VELOX_TEST_USE_RANDOM_SEED")) {
-      if (folly::to<bool>(useRandomSeed)) {
-        seed_ = folly::Random::secureRand32();
-        LOG(INFO) << "Random seed: " << seed_;
-      }
+    if (useRandomSeed()) {
+      seed_ = folly::Random::secureRand32();
+      LOG(INFO) << "Random seed: " << seed_;
     }
   }
 
@@ -134,6 +137,11 @@ class E2EFilterTestBase : public testing::Test {
         rareMin,
         rareMax,
         keepNulls);
+  }
+
+  template <typename T>
+  void makeIntRle(const std::string& fieldName) {
+    dataSetBuilder_->withIntRleForField<T>(Subfield(fieldName));
   }
 
   template <typename T>


### PR DESCRIPTION
Summary:
- Add fash path for `RleEncoding::readWithVisitor`
- Use `materializeBoolsAsBits` in `NullableEncoding::readWithVisitor`
- Merge `ChunkedBoolsDecoder` with `ChunkedDecoder`

Differential Revision: D57675525


