### PR TITLE
Re-enable alternative plans in join fuzzer

### DIFF
--- a/velox/exec/fuzzer/JoinFuzzer.cpp
+++ b/velox/exec/fuzzer/JoinFuzzer.cpp
@@ -980,6 +980,10 @@ void JoinFuzzer::verify(core::JoinType joinType) {
       flatBuildInput,
       outputColumns));
 
+  makeAlternativePlans(defaultPlan.plan, probeInput, buildInput, altPlans);
+  makeAlternativePlans(
+      defaultPlan.plan, flatProbeInput, flatBuildInput, altPlans);
+
   const auto tableScanDir = exec::test::TempDirectoryPath::create();
   addPlansWithTableScan(
       tableScanDir->getPath(),


### PR DESCRIPTION
Summary:
Alternative join plans (including sort + merge join) were accidentaly
disabled in a recent refactor
(https://github.com/facebookincubator/velox/pull/9045).
Re-enabling them in this PR.

Differential Revision: D57696398


