### PR TITLE
Support read flat map as struct in table scan

### DIFF
--- a/velox/dwio/common/ScanSpec.h
+++ b/velox/dwio/common/ScanSpec.h
@@ -328,6 +328,14 @@ class ScanSpec {
   template <typename F>
   void visit(const Type& type, F&& f);
 
+  bool isFlatMapAsStruct() const {
+    return isFlatMapAsStruct_;
+  }
+
+  void setFlatMapAsStruct(bool value) {
+    isFlatMapAsStruct_ = value;
+  }
+
  private:
   void reorder();
 
@@ -407,6 +415,10 @@ class ScanSpec {
 
   // Used only for bulk reader to project flat map features.
   std::vector<std::string> flatMapFeatureSelection_;
+
+  // This node represents a flat map column that need to be read as struct,
+  // i.e. in table schema it is a MAP, but in result vector it is ROW.
+  bool isFlatMapAsStruct_ = false;
 };
 
 template <typename F>

--- a/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
@@ -322,6 +322,10 @@ void SelectiveMapColumnReader::read(
 
 void SelectiveMapColumnReader::getValues(RowSet rows, VectorPtr* result) {
   VELOX_DCHECK_NOT_NULL(result);
+  VELOX_CHECK(
+      !result->get() || result->get()->type()->isMap(),
+      "Expect MAP result vector, got {}",
+      result->get()->type()->toString());
   prepareResult(*result, requestedType_->type(), rows.size(), &memoryPool_);
   auto* resultMap = result->get()->asUnchecked<MapVector>();
   makeOffsetsAndSizes(rows, *resultMap);

--- a/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
@@ -186,8 +186,7 @@ class SelectiveFlatMapAsStructReader : public SelectiveStructColumnReaderBase {
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       DwrfParams& params,
-      common::ScanSpec& scanSpec,
-      const std::vector<std::string>& /*keys*/)
+      common::ScanSpec& scanSpec)
       : SelectiveStructColumnReaderBase(
             requestedType,
             fileType,
@@ -246,12 +245,9 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> createReader(
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     DwrfParams& params,
     common::ScanSpec& scanSpec) {
-  auto& mapColumnIdAsStruct =
-      params.stripeStreams().getRowReaderOptions().getMapColumnIdAsStruct();
-  auto it = mapColumnIdAsStruct.find(requestedType->id());
-  if (it != mapColumnIdAsStruct.end()) {
+  if (scanSpec.isFlatMapAsStruct()) {
     return std::make_unique<SelectiveFlatMapAsStructReader<T>>(
-        requestedType, fileType, params, scanSpec, it->second);
+        requestedType, fileType, params, scanSpec);
   } else {
     return std::make_unique<SelectiveFlatMapReader<T>>(
         requestedType, fileType, params, scanSpec);

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -71,9 +71,17 @@ void HiveConnectorTestBase::writeToFile(
     const std::string& filePath,
     const std::vector<RowVectorPtr>& vectors,
     std::shared_ptr<dwrf::Config> config) {
+  writeToFile(filePath, vectors, std::move(config), vectors[0]->type());
+}
+
+void HiveConnectorTestBase::writeToFile(
+    const std::string& filePath,
+    const std::vector<RowVectorPtr>& vectors,
+    std::shared_ptr<dwrf::Config> config,
+    const TypePtr& schema) {
   velox::dwrf::WriterOptions options;
   options.config = config;
-  options.schema = vectors[0]->type();
+  options.schema = schema;
   auto localWriteFile = std::make_unique<LocalWriteFile>(filePath, true, false);
   auto sink = std::make_unique<dwio::common::WriteFileSink>(
       std::move(localWriteFile), filePath);

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -49,6 +49,12 @@ class HiveConnectorTestBase : public OperatorTestBase {
       std::shared_ptr<dwrf::Config> config =
           std::make_shared<facebook::velox::dwrf::Config>());
 
+  void writeToFile(
+      const std::string& filePath,
+      const std::vector<RowVectorPtr>& vectors,
+      std::shared_ptr<dwrf::Config> config,
+      const TypePtr& schema);
+
   std::vector<RowVectorPtr> makeVectors(
       const RowTypePtr& rowType,
       int32_t numVectors,


### PR DESCRIPTION
Summary:
For flat map column, we always get MAP type for both table schema and
file type, but if we are asked for ROW type in result vector, the read-as-struct
code path is triggered.

Differential Revision: D57693809


