### PR TITLE
Test NestedLoopJoin and MergeJoin in join fuzzer

### DIFF
--- a/velox/exec/NestedLoopJoinProbe.cpp
+++ b/velox/exec/NestedLoopJoinProbe.cpp
@@ -128,6 +128,9 @@ void NestedLoopJoinProbe::addInput(RowVectorPtr input) {
     child->loadedVector();
   }
   input_ = std::move(input);
+  if (input_->size() > 0) {
+    probeSideEmpty_ = false;
+  }
   VELOX_CHECK_EQ(buildIndex_, 0);
   if (needsProbeMismatch(joinType_)) {
     probeMatched_.resizeFill(input_->size(), false);
@@ -238,7 +241,12 @@ RowVectorPtr NestedLoopJoinProbe::getMismatchedOutput(
     BufferPtr& unmatchedMapping,
     const std::vector<IdentityProjection>& projections,
     const std::vector<IdentityProjection>& nullProjections) {
-  if (matched.isAllSelected() || joinCondition_ == nullptr) {
+  // If data is all matched or the join is a cross product, there is no
+  // mismatched rows. But there is an exception that if the join is a cross
+  // product but the build or probe side is empty, there could still be
+  // mismatched rows from the other side.
+  if (matched.isAllSelected() ||
+      (joinCondition_ == nullptr && !probeSideEmpty_ && !buildSideEmpty_)) {
     return nullptr;
   }
 
@@ -311,6 +319,7 @@ void NestedLoopJoinProbe::beginBuildMismatch() {
     VELOX_CHECK_NOT_NULL(probe);
     for (auto i = 0; i < buildMatched_.size(); ++i) {
       buildMatched_[i].select(probe->buildMatched_[i]);
+      probeSideEmpty_ &= probe->probeSideEmpty_;
     }
   }
   peers.clear();

--- a/velox/exec/NestedLoopJoinProbe.h
+++ b/velox/exec/NestedLoopJoinProbe.h
@@ -146,6 +146,10 @@ class NestedLoopJoinProbe : public Operator {
   std::vector<IdentityProjection> filterProbeProjections_;
   BufferPtr probeOutMapping_;
   BufferPtr probeIndices_;
+  // Indicate if the probe side has empty input or not. For the last prober,
+  // this indicates if all the probe sides are empty or not. This flag is used
+  // for mismatched output producing.
+  bool probeSideEmpty_{true};
 
   // Build side state
   std::optional<std::vector<RowVectorPtr>> buildVectors_;

--- a/velox/exec/fuzzer/JoinFuzzerRunner.h
+++ b/velox/exec/fuzzer/JoinFuzzerRunner.h
@@ -21,6 +21,8 @@
 #include "velox/common/memory/SharedArbitrator.h"
 #include "velox/exec/MemoryReclaimer.h"
 #include "velox/exec/fuzzer/JoinFuzzer.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/parse/TypeResolver.h"
 #include "velox/serializers/PrestoSerializer.h"
 
 /// Join FuzzerRunner leverages JoinFuzzer and VectorFuzzer to
@@ -62,6 +64,8 @@ class JoinFuzzerRunner {
     facebook::velox::serializer::presto::PrestoVectorSerde::
         registerVectorSerde();
     facebook::velox::filesystems::registerLocalFileSystem();
+    facebook::velox::functions::prestosql::registerAllScalarFunctions();
+    facebook::velox::parse::registerTypeResolver();
 
     facebook::velox::exec::test::joinFuzzer(seed);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
Summary:
A correctness bug was found in NestedLoopJoin recently (https://github.com/facebookincubator/velox/pull/9892), 
so this diff adds NestedLoopJoin query plans with and without
TableScan to JoinFuzzer. It also adds MergeJoin with TableScan.

Differential Revision: D57703982


