### PR TITLE
Fix GCC12 return-type warning

### DIFF
--- a/velox/functions/lib/aggregates/BitwiseAggregateBase.h
+++ b/velox/functions/lib/aggregates/BitwiseAggregateBase.h
@@ -108,8 +108,7 @@ exec::AggregateRegistrationResult registerBitwise(
           case TypeKind::BIGINT:
             return std::make_unique<T<int64_t>>(resultType);
           default:
-            VELOX_CHECK(
-                false,
+            VELOX_UNREACHABLE(
                 "Unknown input type for {} aggregation {}",
                 name,
                 inputType->kindName());

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -971,10 +971,8 @@ exec::AggregateRegistrationResult registerMinMax(
               if (inputType->isLongDecimal()) {
                 return std::make_unique<TNumericN<int128_t>>(resultType);
               }
-              VELOX_UNREACHABLE();
             default:
-              VELOX_CHECK(
-                  false,
+              VELOX_UNREACHABLE(
                   "Unknown input type for {} aggregation {}",
                   name,
                   inputType->kindName());
@@ -1012,8 +1010,7 @@ exec::AggregateRegistrationResult registerMinMax(
               return std::make_unique<TNonNumeric>(
                   inputType, throwOnNestedNulls);
             default:
-              VELOX_CHECK(
-                  false,
+              VELOX_UNREACHABLE(
                   "Unknown input type for {} aggregation {}",
                   name,
                   inputType->kindName());

--- a/velox/functions/prestosql/aggregates/SumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/SumAggregate.cpp
@@ -104,8 +104,7 @@ exec::AggregateRegistrationResult registerSum(
             return std::make_unique<DecimalSumAggregate<int128_t>>(resultType);
 
           default:
-            VELOX_CHECK(
-                false,
+            VELOX_UNREACHABLE(
                 "Unknown input type for {} aggregation {}",
                 name,
                 inputType->kindName());

--- a/velox/functions/sparksql/aggregates/SumAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/SumAggregate.cpp
@@ -148,8 +148,7 @@ exec::AggregateRegistrationResult registerSum(
           }
             [[fallthrough]];
           default:
-            VELOX_CHECK(
-                false,
+            VELOX_UNREACHABLE(
                 "Unknown input type for {} aggregation {}",
                 name,
                 inputType->kindName());


### PR DESCRIPTION
Fix warnings of type `control reaches end of non-void function [-Wreturn-type]`