### PR TITLE
Simplify EvalCtx::ensureErrorsVectorSize API

### DIFF
--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -278,6 +278,25 @@ void EvalCtx::convertElementErrorsToTopLevelNulls(
   });
 }
 
+void EvalCtx::moveAppendErrors(ErrorVectorPtr& other) {
+  if (!errors_) {
+    return;
+  }
+
+  if (!other) {
+    std::swap(errors_, other);
+    return;
+  }
+
+  ensureErrorsVectorSize(other, errors_->size());
+  bits::forEachBit(
+      errors_->rawNulls(), 0, errors_->size(), bits::kNotNull, [&](auto row) {
+        other->set(row, errors_->valueAt(row));
+      });
+
+  errors_.reset();
+}
+
 const VectorPtr& EvalCtx::getField(int32_t index) const {
   const VectorPtr* field;
   if (!peeledFields_.empty()) {

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -173,29 +173,19 @@ class EvalCtx {
     return &errors_;
   }
 
+  /// Make sure the error vector is addressable up to index `size`-1. Initialize
+  /// all
+  /// new elements to null.
+  void ensureErrorsVectorSize(vector_size_t size) {
+    ensureErrorsVectorSize(errors_, size);
+  }
+
   void swapErrors(ErrorVectorPtr& other) {
     std::swap(errors_, other);
   }
 
   /// Adds errors in 'this' to 'other'. Clears errors from 'this'.
-  void moveAppendErrors(ErrorVectorPtr& other) {
-    if (!errors_) {
-      return;
-    }
-
-    if (!other) {
-      std::swap(errors_, other);
-      return;
-    }
-
-    ensureErrorsVectorSize(other, errors_->size());
-    bits::forEachBit(
-        errors_->rawNulls(), 0, errors_->size(), bits::kNotNull, [&](auto row) {
-          other->set(row, errors_->valueAt(row));
-        });
-
-    errors_.reset();
-  }
+  void moveAppendErrors(ErrorVectorPtr& other);
 
   /// Boolean indicating whether exceptions that occur during expression
   /// evaluation should be thrown directly or saved for later processing.
@@ -338,9 +328,6 @@ class EvalCtx {
         rows, type, execCtx_->pool(), result, execCtx_->vectorPool());
   }
 
-  /// Make sure the vector is addressable up to index `size`-1. Initialize all
-  /// new elements to null.
-  void ensureErrorsVectorSize(ErrorVectorPtr& vector, vector_size_t size) const;
   PeeledEncoding* getPeeledEncoding() {
     return peeledEncoding_.get();
   }
@@ -358,6 +345,8 @@ class EvalCtx {
   }
 
  private:
+  void ensureErrorsVectorSize(ErrorVectorPtr& errors, vector_size_t size) const;
+
   core::ExecCtx* const execCtx_;
   ExprSet* const exprSet_;
   const RowVector* row_;

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -402,7 +402,7 @@ bool Expr::evalArgsDefaultNulls(
       // An error adds itself to argument errors.
       if (context.errors()) {
         // There are new errors.
-        context.ensureErrorsVectorSize(*context.errorsPtr(), rows.rows().end());
+        context.ensureErrorsVectorSize(rows.rows().end());
         auto newErrors = context.errors();
         assert(newErrors); // lint
         if (flatNulls) {

--- a/velox/expression/tests/EvalCtxTest.cpp
+++ b/velox/expression/tests/EvalCtxTest.cpp
@@ -109,7 +109,7 @@ TEST_F(EvalCtxTest, vectorRecycler) {
 
 TEST_F(EvalCtxTest, ensureErrorsVectorSize) {
   EvalCtx context(&execCtx_);
-  context.ensureErrorsVectorSize(*context.errorsPtr(), 10);
+  context.ensureErrorsVectorSize(10);
   ASSERT_GE(context.errors()->size(), 10);
   ASSERT_EQ(BaseVector::countNulls(context.errors()->nulls(), 10), 10);
 
@@ -119,7 +119,7 @@ TEST_F(EvalCtxTest, ensureErrorsVectorSize) {
 
   ASSERT_EQ(BaseVector::countNulls(context.errors()->nulls(), 10), 9);
 
-  context.ensureErrorsVectorSize(*context.errorsPtr(), 20);
+  context.ensureErrorsVectorSize(20);
 
   ASSERT_GE(context.errors()->size(), 20);
   ASSERT_EQ(BaseVector::countNulls(context.errors()->nulls(), 20), 19);


### PR DESCRIPTION
Summary:
Remove redundant first agument.

Before:

```
context.ensureErrorsVectorSize(*context.errorsPtr(), rows.size());
```

After:

```
context.ensureErrorsVectorSize(rows.size());
```

Also, move implementation of moveAppendErrors method from header file to .cpp.

Differential Revision: D57724966


