### PR TITLE
Remove unused exception parameter from velox/common/base/tests/AsyncSourceTest.cpp

### DIFF
--- a/velox/common/base/tests/AsyncSourceTest.cpp
+++ b/velox/common/base/tests/AsyncSourceTest.cpp
@@ -140,7 +140,7 @@ TEST(AsyncSourceTest, errorsWithThreads) {
             auto gizmo =
                 gizmos[folly::Random::rand32(rng) % gizmos.size()]->move();
             EXPECT_EQ(nullptr, gizmo);
-          } catch (std::exception& e) {
+          } catch (std::exception&) {
             ++numErrors;
           }
         }

--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -248,7 +248,7 @@ uint64_t SharedArbitrator::growCapacity(
       decrementFreeCapacityLocked(maxBytesToReserve, minBytesToReserve);
   try {
     checkedGrow(pool, reservedBytes, 0);
-  } catch (const VeloxRuntimeError& error) {
+  } catch (const VeloxRuntimeError&) {
     reservedBytes = 0;
   }
   return reservedBytes;

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -121,7 +121,7 @@ class MemoryAllocatorTest : public testing::TestWithParam<int> {
         EXPECT_TRUE(result.empty());
         return false;
       }
-    } catch (const VeloxException& e) {
+    } catch (const VeloxException&) {
       EXPECT_TRUE(result.empty());
       return false;
     }

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -126,7 +126,7 @@ class MemoryPoolTest : public testing::TestWithParam<TestParam> {
   void abortPool(MemoryPool* pool) {
     try {
       VELOX_FAIL("Manual MemoryPool Abortion");
-    } catch (const VeloxException& error) {
+    } catch (const VeloxException&) {
       pool->abort(std::current_exception());
     }
   }

--- a/velox/exec/fuzzer/RowNumberFuzzer.cpp
+++ b/velox/exec/fuzzer/RowNumberFuzzer.cpp
@@ -506,7 +506,7 @@ void RowNumberFuzzer::verify() {
           VELOX_CHECK(
               assertEqualResults({expected}, {actual}),
               "Logically equivalent plans produced different results");
-        } catch (const VeloxException& e) {
+        } catch (const VeloxException&) {
           LOG(ERROR) << "Expected\n"
                      << expected->toString(0, expected->size()) << "\nActual\n"
                      << actual->toString(0, actual->size());

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -1480,7 +1480,7 @@ DEBUG_ONLY_TEST_F(TaskTest, driverCounters) {
     try {
       while (cursor->moveNext()) {
       };
-    } catch (VeloxRuntimeError& ex) {
+    } catch (VeloxRuntimeError&) {
     }
   });
 
@@ -1763,7 +1763,7 @@ DEBUG_ONLY_TEST_F(
 
   try {
     VELOX_FAIL(abortErrorMessage);
-  } catch (VeloxException& e) {
+  } catch (VeloxException&) {
     abortWait.await([&]() { return abortWaitFlag.load(); });
     blockingTask->pool()->abort(std::current_exception());
   }
@@ -1818,7 +1818,7 @@ DEBUG_ONLY_TEST_F(TaskTest, longRunningOperatorInTaskReclaimerAbort) {
   const std::string abortErrorMessage("Synthetic Exception");
   try {
     VELOX_FAIL(abortErrorMessage);
-  } catch (VeloxException& e) {
+  } catch (VeloxException&) {
     blockingTask->pool()->abort(std::current_exception());
   }
   waitForTaskCompletion(blockingTask.get());

--- a/velox/functions/sparksql/MakeTimestamp.cpp
+++ b/velox/functions/sparksql/MakeTimestamp.cpp
@@ -125,7 +125,7 @@ class MakeTimestampFunction : public exec::VectorFunction {
         int64_t constantTzID;
         try {
           constantTzID = util::getTimeZoneID(std::string_view(tz));
-        } catch (const VeloxException& e) {
+        } catch (const VeloxException&) {
           context.setErrors(rows, std::current_exception());
           return;
         }


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D57636920


