### PR TITLE
Optimize TRY(CAST) for many failed rows

### DIFF
--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -340,7 +340,7 @@ void CastExpr::applyCastKernel(
             makeErrorMessage(*input, row, result->type(), details);
         context.setStatus(row, Status::UserError("{}", errorDetails));
       } else {
-        context.setStatus(row, Status::UserError("{}", details));
+        context.setStatus(row, Status::UserError(""));
       }
     }
   };

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -137,6 +137,12 @@ class EvalCtx {
       const ErrorVectorPtr& fromErrors,
       ErrorVectorPtr& toErrors) const;
 
+  /// Like above, but for a single row.
+  void addError(
+      vector_size_t row,
+      const ErrorVectorPtr& fromErrors,
+      ErrorVectorPtr& toErrors) const;
+
   // Given a mapping from element rows to top-level rows, add element-level
   // errors in errors_ to topLevelErrors.
   void addElementErrorsToTopLevel(
@@ -162,9 +168,12 @@ class EvalCtx {
         std::min(errors_->size(), rows.end()));
   }
 
-  // Returns the vector of errors or nullptr if no errors. This is
-  // intentionally a raw pointer to signify that the caller may not
-  // retain references to this.
+  /// Returns the vector of errors or nullptr if no errors. This is
+  /// intentionally a raw pointer to signify that the caller may not
+  /// retain references to this.
+  ///
+  /// When 'captureErrorDetails' is false, only null flags are being set, the
+  /// values are null std::shared_ptr and should not be used.
   ErrorVector* errors() const {
     return errors_.get();
   }
@@ -346,6 +355,10 @@ class EvalCtx {
 
  private:
   void ensureErrorsVectorSize(ErrorVectorPtr& errors, vector_size_t size) const;
+
+  // Updates 'errorPtr' to clear null at 'index' to indicate an error has
+  // occured without specifying error details.
+  void addError(vector_size_t index, ErrorVectorPtr& errorsPtr) const;
 
   // Copy error from 'from' at index 'fromIndex' to 'to' at index 'toIndex'.
   // No-op if 'from' doesn't have an error at 'fromIndex' or if 'to' already has

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -3821,6 +3821,72 @@ TEST_P(ParameterizedExprTest, cseUnderTryWithIf) {
       result);
 }
 
+// Test AND/OR expressions with multiple conjucts generating errors in different
+// rows. With and without TRY.
+TEST_P(ParameterizedExprTest, failingConjuncts) {
+  auto input = makeRowVector({
+      makeFlatVector<std::string>({"10", "foo", "11"}),
+      makeFlatVector<std::string>({"bar", "10", "11"}),
+      makeFlatVector<int64_t>({1, 2, 3}),
+  });
+
+  // cast(c0 as bigint) throws on 1st row.
+  // cast(c1 as bigint) throws on 2nd row.
+  // c2 > 0 doesn't throw and returns true for all rows.
+
+  VELOX_ASSERT_THROW(
+      evaluate(
+          "cast(c0 as bigint) > 0 AND cast(c1 as bigint) > 0 AND c2 > 0",
+          input),
+      "Cannot cast VARCHAR 'bar' to BIGINT.");
+
+  auto result = evaluate(
+      "try(cast(c0 as bigint) > 0 AND cast(c1 as bigint) > 0 AND c2 > 0)",
+      input);
+
+  auto expected =
+      makeNullableFlatVector<bool>({std::nullopt, std::nullopt, true});
+  assertEqualVectors(expected, result);
+
+  // c2 <> 1 returns false for 1st row and masks errors from other conjuncts.
+  VELOX_ASSERT_THROW(
+      evaluate(
+          "cast(c0 as bigint) > 0 AND cast(c1 as bigint) > 0 AND c2 <> 1",
+          input),
+      "Cannot cast VARCHAR 'foo' to BIGINT.");
+
+  result = evaluate(
+      "try(cast(c0 as bigint) > 0 AND cast(c1 as bigint) > 0 AND c2 <> 1)",
+      input);
+  expected = makeNullableFlatVector<bool>({false, std::nullopt, true});
+  assertEqualVectors(expected, result);
+
+  // OR succeeds because c2 > 0 returns 'true' for all rows and masks errors
+  // from other conjuncts.
+
+  result = evaluate(
+      "cast(c0 as bigint) < 0 OR cast(c1 as bigint) < 0 OR c2 > 0", input);
+  expected = makeFlatVector<bool>({true, true, true});
+  assertEqualVectors(expected, result);
+
+  result = evaluate(
+      "try(cast(c0 as bigint) < 0 OR cast(c1 as bigint) < 0 OR c2 > 0)", input);
+  assertEqualVectors(expected, result);
+
+  // c2 <> 1 returns 'false' for 1st row and fails to mask errors from other
+  // conjuncts.
+  VELOX_ASSERT_THROW(
+      evaluate(
+          "cast(c0 as bigint) < 0 OR cast(c1 as bigint) < 0 OR c2 <> 1", input),
+      "Cannot cast VARCHAR 'bar' to BIGINT.");
+
+  result = evaluate(
+      "try(cast(c0 as bigint) < 0 OR cast(c1 as bigint) < 0 OR c2 <> 1)",
+      input);
+  expected = makeNullableFlatVector<bool>({std::nullopt, true, true});
+  assertEqualVectors(expected, result);
+}
+
 TEST_P(ParameterizedExprTest, conjunctUnderTry) {
   auto input = makeRowVector({
       makeFlatVector<StringView>({"a"_sv, "b"_sv}),


### PR DESCRIPTION
Summary:
TRY(CAST(...)) is up to 5x slower than TRY_CAST when many rows fail.

The profile reveals that 30% of cpu time goes to
EvalCtx::ensureErrorsVectorSize. For every row that fails, we call
EvalCtx::ensureErrorsVectorSize to resize the error vector to accommodate that
row. When many rows fail we end up resizing a lot: resize(1), resize(2), resize
(3),....resize(n). Fix this by pre-allocating error vector in TryExpr.

Another 30% of cpu time goes into managing reference counts for
`std::shared_ptr<std::exception_ptr>` stores in the errors vector. We do not
need error details for TRY, hence, no need to store these values. Fix this by
making error values in error vector optional and updating EvalCtx::setStatus to
not write these under TRY.

Finally, replace BaseVector::setNull with bits::setNull in TryExpr::nullOutErrors.

{F1647570993}

Combined these optimizations improve try(cast) benchmark by 3x.

Before:

```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
cast##try_cast_invalid_empty_input                          2.41ms    415.65
cast##tryexpr_cast_invalid_empty_input                     24.90ms     40.16
cast##try_cast_invalid_nan                                  5.76ms    173.52
cast##tryexpr_cast_invalid_nan                             27.75ms     36.03
```

After:

```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
cast##try_cast_invalid_empty_input                          2.27ms    439.78
cast##tryexpr_cast_invalid_empty_input                      5.93ms    168.61
cast##try_cast_invalid_nan                                  5.64ms    177.35
cast##tryexpr_cast_invalid_nan                              9.44ms    105.94
```

Differential Revision: D57704232
