### PR TITLE
Allow creating Status with no error message

### DIFF
--- a/velox/common/base/Status.cpp
+++ b/velox/common/base/Status.cpp
@@ -54,6 +54,11 @@ std::string_view toString(StatusCode code) {
   return ""; // no-op
 }
 
+Status::Status(StatusCode code) {
+  state_ = new State;
+  state_->code = code;
+}
+
 Status::Status(StatusCode code, std::string msg) {
   if (FOLLY_UNLIKELY(code == StatusCode::kOK)) {
     throw std::invalid_argument("Cannot construct ok status with message");

--- a/velox/common/base/Status.h
+++ b/velox/common/base/Status.h
@@ -156,6 +156,8 @@ class [[nodiscard]] Status {
     }
   }
 
+  explicit Status(StatusCode code);
+
   Status(StatusCode code, std::string msg);
 
   // Copy the specified status.
@@ -192,7 +194,7 @@ class [[nodiscard]] Status {
   //   auto st1 = Status::UserError("my error"):
   //   auto st2 = Status::TypeError("my other error"):
 
-  /// Return an error status for out-of-memory conditions.
+  /// Return an error status for user errors.
   template <typename... Args>
   static Status UserError(Args&&... args) {
     return Status::fromArgs(
@@ -220,6 +222,7 @@ class [[nodiscard]] Status {
     return Status::fromArgs(StatusCode::kKeyError, std::forward<Args>(args)...);
   }
 
+  /// Return an error status when something already exists (e.g. a file).
   template <typename... Args>
   static Status AlreadyExists(Args&&... args) {
     return Status::fromArgs(
@@ -367,6 +370,10 @@ class [[nodiscard]] Status {
   static Status
   fromArgs(StatusCode code, fmt::string_view fmt, Args&&... args) {
     return Status(code, fmt::vformat(fmt, fmt::make_format_args(args...)));
+  }
+
+  static Status fromArgs(StatusCode code) {
+    return Status(code);
   }
 
   void deleteState() {

--- a/velox/common/base/tests/StatusTest.cpp
+++ b/velox/common/base/tests/StatusTest.cpp
@@ -36,6 +36,14 @@ TEST(StatusTest, testCodeAndMessage) {
   ASSERT_EQ("file error", fileError.message());
 }
 
+TEST(StatusTest, testNoMessage) {
+  Status fileError = Status::IOError();
+  ASSERT_EQ(StatusCode::kIOError, fileError.code());
+  ASSERT_EQ("", fileError.message());
+  ASSERT_EQ("IOError: ", fileError.toString());
+  ASSERT_EQ("IOError", fileError.codeAsString());
+}
+
 TEST(StatusTest, testToString) {
   Status fileError = Status::IOError("file error");
   ASSERT_EQ("IOError: file error", fileError.toString());

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -340,7 +340,7 @@ void CastExpr::applyCastKernel(
             makeErrorMessage(*input, row, result->type(), details);
         context.setStatus(row, Status::UserError("{}", errorDetails));
       } else {
-        context.setStatus(row, Status::UserError(""));
+        context.setStatus(row, Status::UserError());
       }
     }
   };

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -340,7 +340,7 @@ void CastExpr::applyCastKernel(
             makeErrorMessage(*input, row, result->type(), details);
         context.setStatus(row, Status::UserError("{}", errorDetails));
       } else {
-        context.setStatus(row, Status::UserError("{}", details));
+        context.setStatus(row, Status::UserError(""));
       }
     }
   };

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -137,6 +137,12 @@ class EvalCtx {
       const ErrorVectorPtr& fromErrors,
       ErrorVectorPtr& toErrors) const;
 
+  /// Like above, but for a single row.
+  void addError(
+      vector_size_t row,
+      const ErrorVectorPtr& fromErrors,
+      ErrorVectorPtr& toErrors) const;
+
   // Given a mapping from element rows to top-level rows, add element-level
   // errors in errors_ to topLevelErrors.
   void addElementErrorsToTopLevel(
@@ -162,9 +168,12 @@ class EvalCtx {
         std::min(errors_->size(), rows.end()));
   }
 
-  // Returns the vector of errors or nullptr if no errors. This is
-  // intentionally a raw pointer to signify that the caller may not
-  // retain references to this.
+  /// Returns the vector of errors or nullptr if no errors. This is
+  /// intentionally a raw pointer to signify that the caller may not
+  /// retain references to this.
+  ///
+  /// When 'captureErrorDetails' is false, only null flags are being set, the
+  /// values are null std::shared_ptr and should not be used.
   ErrorVector* errors() const {
     return errors_.get();
   }
@@ -346,6 +355,10 @@ class EvalCtx {
 
  private:
   void ensureErrorsVectorSize(ErrorVectorPtr& errors, vector_size_t size) const;
+
+  // Updates 'errorPtr' to clear null at 'index' to indicate an error has
+  // occured without specifying error details.
+  void addError(vector_size_t index, ErrorVectorPtr& errorsPtr) const;
 
   // Copy error from 'from' at index 'fromIndex' to 'to' at index 'toIndex'.
   // No-op if 'from' doesn't have an error at 'fromIndex' or if 'to' already has

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -3821,6 +3821,72 @@ TEST_P(ParameterizedExprTest, cseUnderTryWithIf) {
       result);
 }
 
+// Test AND/OR expressions with multiple conjucts generating errors in different
+// rows. With and without TRY.
+TEST_P(ParameterizedExprTest, failingConjuncts) {
+  auto input = makeRowVector({
+      makeFlatVector<std::string>({"10", "foo", "11"}),
+      makeFlatVector<std::string>({"bar", "10", "11"}),
+      makeFlatVector<int64_t>({1, 2, 3}),
+  });
+
+  // cast(c0 as bigint) throws on 1st row.
+  // cast(c1 as bigint) throws on 2nd row.
+  // c2 > 0 doesn't throw and returns true for all rows.
+
+  VELOX_ASSERT_THROW(
+      evaluate(
+          "cast(c0 as bigint) > 0 AND cast(c1 as bigint) > 0 AND c2 > 0",
+          input),
+      "Cannot cast VARCHAR 'bar' to BIGINT.");
+
+  auto result = evaluate(
+      "try(cast(c0 as bigint) > 0 AND cast(c1 as bigint) > 0 AND c2 > 0)",
+      input);
+
+  auto expected =
+      makeNullableFlatVector<bool>({std::nullopt, std::nullopt, true});
+  assertEqualVectors(expected, result);
+
+  // c2 <> 1 returns false for 1st row and masks errors from other conjuncts.
+  VELOX_ASSERT_THROW(
+      evaluate(
+          "cast(c0 as bigint) > 0 AND cast(c1 as bigint) > 0 AND c2 <> 1",
+          input),
+      "Cannot cast VARCHAR 'foo' to BIGINT.");
+
+  result = evaluate(
+      "try(cast(c0 as bigint) > 0 AND cast(c1 as bigint) > 0 AND c2 <> 1)",
+      input);
+  expected = makeNullableFlatVector<bool>({false, std::nullopt, true});
+  assertEqualVectors(expected, result);
+
+  // OR succeeds because c2 > 0 returns 'true' for all rows and masks errors
+  // from other conjuncts.
+
+  result = evaluate(
+      "cast(c0 as bigint) < 0 OR cast(c1 as bigint) < 0 OR c2 > 0", input);
+  expected = makeFlatVector<bool>({true, true, true});
+  assertEqualVectors(expected, result);
+
+  result = evaluate(
+      "try(cast(c0 as bigint) < 0 OR cast(c1 as bigint) < 0 OR c2 > 0)", input);
+  assertEqualVectors(expected, result);
+
+  // c2 <> 1 returns 'false' for 1st row and fails to mask errors from other
+  // conjuncts.
+  VELOX_ASSERT_THROW(
+      evaluate(
+          "cast(c0 as bigint) < 0 OR cast(c1 as bigint) < 0 OR c2 <> 1", input),
+      "Cannot cast VARCHAR 'bar' to BIGINT.");
+
+  result = evaluate(
+      "try(cast(c0 as bigint) < 0 OR cast(c1 as bigint) < 0 OR c2 <> 1)",
+      input);
+  expected = makeNullableFlatVector<bool>({std::nullopt, true, true});
+  assertEqualVectors(expected, result);
+}
+
 TEST_P(ParameterizedExprTest, conjunctUnderTry) {
   auto input = makeRowVector({
       makeFlatVector<StringView>({"a"_sv, "b"_sv}),


### PR DESCRIPTION
Summary:
Status::UserError("") internally calls fmt::format("") and this call shows up pretty high on the profile (16%).

 {F1647622447}

Allow creating Status objects without passing any error details, e.g. Status::UserError().

This change helps speed up TRY(CAST(...)) benchmark by ~20%.

Before:

```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
cast##try_cast_invalid_empty_input                          2.27ms    439.78
cast##tryexpr_cast_invalid_empty_input                      5.93ms    168.61
cast##try_cast_invalid_nan                                  5.64ms    177.35
cast##tryexpr_cast_invalid_nan                              9.44ms    105.94
```

After:

```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
cast##try_cast_invalid_empty_input                          2.16ms    463.62
cast##tryexpr_cast_invalid_empty_input                      4.29ms    232.95
cast##try_cast_invalid_nan                                  5.47ms    182.83
cast##tryexpr_cast_invalid_nan                              7.76ms    128.81
```

Differential Revision: D57728340
