### PR TITLE
Generate larger partitions in the window fuzzer

### DIFF
--- a/velox/exec/fuzzer/AggregationFuzzer.cpp
+++ b/velox/exec/fuzzer/AggregationFuzzer.cpp
@@ -360,8 +360,8 @@ void AggregationFuzzer::go() {
 
         auto partitionKeys = generateKeys("p", argNames, argTypes);
         auto sortingKeys = generateSortingKeys("s", argNames, argTypes);
-        auto input =
-            generateInputDataWithRowNumber(argNames, argTypes, signature);
+        auto input = generateInputDataWithRowNumber(
+            argNames, argTypes, partitionKeys, signature);
 
         bool failed = verifyWindow(
             partitionKeys,

--- a/velox/exec/fuzzer/AggregationFuzzerBase.cpp
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.cpp
@@ -300,6 +300,7 @@ std::vector<RowVectorPtr> AggregationFuzzerBase::generateInputData(
 std::vector<RowVectorPtr> AggregationFuzzerBase::generateInputDataWithRowNumber(
     std::vector<std::string> names,
     std::vector<TypePtr> types,
+    const std::vector<std::string>& partitionKeys,
     const CallableSignature& signature) {
   names.push_back("row_number");
   types.push_back(BIGINT());
@@ -307,9 +308,16 @@ std::vector<RowVectorPtr> AggregationFuzzerBase::generateInputDataWithRowNumber(
   auto generator = findInputGenerator(signature);
 
   std::vector<RowVectorPtr> input;
-  auto size = vectorFuzzer_.getOptions().vectorSize;
+  vector_size_t size = vectorFuzzer_.getOptions().vectorSize;
   velox::test::VectorMaker vectorMaker{pool_.get()};
   int64_t rowNumber = 0;
+
+  std::unordered_set<std::string> partitionKeySet;
+  partitionKeySet.reserve(partitionKeys.size());
+  for (auto partitionKey : partitionKeys) {
+    partitionKeySet.insert(partitionKey);
+  }
+
   for (auto j = 0; j < FLAGS_num_batches; ++j) {
     std::vector<VectorPtr> children;
 
@@ -318,8 +326,21 @@ std::vector<RowVectorPtr> AggregationFuzzerBase::generateInputDataWithRowNumber(
           generator->generate(signature.args, vectorFuzzer_, rng_, pool_.get());
     }
 
+    // Number of partitions is randomly generated and is at least 1.
+    auto numPartitions = size ? randInt(1, size) : 1;
+    auto indices = vectorFuzzer_.fuzzIndices(size, numPartitions);
+    auto nulls = vectorFuzzer_.fuzzNulls(size);
     for (auto i = children.size(); i < types.size() - 1; ++i) {
-      children.push_back(vectorFuzzer_.fuzz(types[i], size));
+      if (partitionKeySet.find(names[i]) != partitionKeySet.end()) {
+        // The partition keys are built with a dictionary over a smaller set of
+        // values. This is done to introduce some repetition of key values for
+        // windowing.
+        auto baseVector = vectorFuzzer_.fuzz(types[i], numPartitions);
+        children.push_back(
+            BaseVector::wrapInDictionary(nulls, indices, size, baseVector));
+      } else {
+        children.push_back(vectorFuzzer_.fuzz(types[i], size));
+      }
     }
     children.push_back(vectorMaker.flatVector<int64_t>(
         size, [&](auto /*row*/) { return rowNumber++; }));

--- a/velox/exec/fuzzer/AggregationFuzzerBase.h
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.h
@@ -205,6 +205,7 @@ class AggregationFuzzerBase {
   std::vector<RowVectorPtr> generateInputDataWithRowNumber(
       std::vector<std::string> names,
       std::vector<TypePtr> types,
+      const std::vector<std::string>& partitionKeys,
       const CallableSignature& signature);
 
   std::pair<std::optional<MaterializedRowMultiset>, ReferenceQueryErrorCode>

--- a/velox/exec/fuzzer/WindowFuzzer.cpp
+++ b/velox/exec/fuzzer/WindowFuzzer.cpp
@@ -243,8 +243,8 @@ void WindowFuzzer::go() {
     }
     const auto partitionKeys = generateSortingKeys("p", argNames, argTypes);
     const auto [frameClause, isRowsFrame] = generateFrameClause();
-    const auto input =
-        generateInputDataWithRowNumber(argNames, argTypes, signature);
+    const auto input = generateInputDataWithRowNumber(
+        argNames, argTypes, partitionKeys, signature);
     // If the function is order-dependent or uses "rows" frame, sort all input
     // rows by row_number additionally.
     if (requireSortedInput || isRowsFrame) {


### PR DESCRIPTION
Change the partition data generation in the window fuzzer to catch more cases. The new code tries to make broader partitions by generating a small set of fuzz data, and then repeating the values by fuzzing a larger dictionary indices with it.