### PR TITLE
Fix arrays_overlap for empty arrays

### DIFF
--- a/velox/functions/prestosql/ArrayIntersectExcept.cpp
+++ b/velox/functions/prestosql/ArrayIntersectExcept.cpp
@@ -172,11 +172,7 @@ class ArrayIntersectExceptFunction : public exec::VectorFunction {
       auto offset = baseLeftArray->offsetAt(idx);
 
       outputSet.reset();
-      if (size == 0 || rightSet.empty()) {
-        return;
-      }
       rawNewOffsets[row] = indicesCursor;
-
       // Scans the array elements on the left-hand side.
       for (vector_size_t i = offset; i < (offset + size); ++i) {
         if (decodedLeftElements->isNullAt(i)) {

--- a/velox/functions/prestosql/ArrayIntersectExcept.cpp
+++ b/velox/functions/prestosql/ArrayIntersectExcept.cpp
@@ -286,6 +286,10 @@ class ArraysOverlapFunction : public exec::VectorFunction {
       auto offset = baseLeftArray->offsetAt(idx);
       auto size = baseLeftArray->sizeAt(idx);
       bool hasNull = rightSet.hasNull;
+      if (size == 0 || (rightSet.set.size() == 0 && !hasNull)) {
+        resultBoolVector->set(row, false);
+        return;
+      }
       for (auto i = offset; i < (offset + size); ++i) {
         // For each element in the current row search for it in the rightSet.
         if (decodedLeftElements->isNullAt(i)) {

--- a/velox/functions/prestosql/tests/ArrayIntersectTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayIntersectTest.cpp
@@ -60,6 +60,7 @@ class ArrayIntersectTest : public FunctionBaseTest {
         {{3, 8, std::nullopt}},
         std::nullopt,
         {{1, 1, -2, -2, -2, 4, 8}},
+        {{}},
     });
     auto array2 = makeNullableArrayVector<T>({
         {1, -2, 4},
@@ -67,6 +68,7 @@ class ArrayIntersectTest : public FunctionBaseTest {
         {1, -2, 4},
         {1, 2},
         {1, -2, 4},
+        {{std::nullopt}},
     });
     auto expected = makeNullableArrayVector<T>({
         {{1, -2, 4}},
@@ -74,6 +76,7 @@ class ArrayIntersectTest : public FunctionBaseTest {
         {{}},
         std::nullopt,
         {{1, -2, 4}},
+        {{}},
     });
     testExpr(expected, "array_intersect(C0, C1)", {array1, array2});
     testExpr(expected, "array_intersect(C1, C0)", {array1, array2});
@@ -85,6 +88,7 @@ class ArrayIntersectTest : public FunctionBaseTest {
         {std::nullopt, std::nullopt, std::nullopt},
         {0, 0, 0},
         {8, 1, 8, 1},
+        {{1, std::nullopt}},
     });
     expected = makeNullableArrayVector<T>({
         {{}},
@@ -92,6 +96,7 @@ class ArrayIntersectTest : public FunctionBaseTest {
         {std::vector<std::optional<T>>{std::nullopt}},
         std::nullopt,
         {{1, 8}},
+        {{}},
     });
     testExpr(expected, "array_intersect(C0, C1)", {array1, array2});
   }

--- a/velox/functions/prestosql/tests/ArraysOverlapTest.cpp
+++ b/velox/functions/prestosql/tests/ArraysOverlapTest.cpp
@@ -55,7 +55,11 @@ class ArraysOverlapTest : public FunctionBaseTest {
          {1, 1, -2, -2, -2, 4, 8},
          {2, -1},
          {1, 2, 3},
-         {std::nullopt}});
+         {std::nullopt},
+         {},
+         {std::nullopt},
+         {},
+         {1, 2}});
     auto array2 = makeNullableArrayVector<T>(
         {{1, -2, 4},
          {1, -2, 4},
@@ -63,9 +67,23 @@ class ArraysOverlapTest : public FunctionBaseTest {
          {1, -2, 4},
          {1, -2, std::nullopt},
          {5, 6, 7},
-         {std::nullopt}});
+         {std::nullopt},
+         {1, std::nullopt},
+         {},
+         {std::nullopt},
+         {}});
     auto expected = makeNullableFlatVector<bool>(
-        {true, true, std::nullopt, true, std::nullopt, false, std::nullopt});
+        {true,
+         true,
+         std::nullopt,
+         true,
+         std::nullopt,
+         false,
+         std::nullopt,
+         false,
+         false,
+         false,
+         false});
     testExpr(expected, "arrays_overlap(C0, C1)", {array1, array2});
     testExpr(expected, "arrays_overlap(C1, C0)", {array1, array2});
   }


### PR DESCRIPTION
arrays_overlap should return false if either array is empty, even if another array contains a NULL.
https://github.com/prestodb/presto/blob/master/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java#L1260

