### PR TITLE
Optimize CastHooks::castStringToDate/Timestamp to avoid throwing exceptions

### DIFF
--- a/velox/benchmarks/basic/CastBenchmark.cpp
+++ b/velox/benchmarks/basic/CastBenchmark.cpp
@@ -62,6 +62,8 @@ int main(int argc, char** argv) {
   auto validDateStrings = vectorMaker.flatVector<std::string>(
       vectorSize,
       [](auto row) { return fmt::format("2024-05-{:02d}", 1 + row % 30); });
+  auto invalidDateStrings = vectorMaker.flatVector<std::string>(
+      vectorSize, [](auto row) { return fmt::format("2024-05...{}", row); });
 
   emptyInput->resize(vectorSize);
   validInput->resize(vectorSize);
@@ -77,21 +79,31 @@ int main(int argc, char** argv) {
       .addBenchmarkSet(
           "cast_varhar_as_date",
           vectorMaker.rowVector(
-              {"empty", "valid_date"}, {emptyInput, validDateStrings}))
+              {"empty", "invalid_date", "valid_date"},
+              {emptyInput, invalidDateStrings, validDateStrings}))
       .addExpression("try_cast_invalid_empty_input", "try_cast(empty as date) ")
       .addExpression(
           "tryexpr_cast_invalid_empty_input", "try(cast (empty as date))")
+      .addExpression(
+          "try_cast_invalid_input", "try_cast(invalid_date as date) ")
+      .addExpression(
+          "tryexpr_cast_invalid_input", "try(cast (invalid_date as date))")
       .addExpression("cast_valid", "cast(valid_date as date)");
 
   benchmarkBuilder
       .addBenchmarkSet(
           "cast_varhar_as_timestamp",
           vectorMaker.rowVector(
-              {"empty", "valid_date"}, {emptyInput, validDateStrings}))
+              {"empty", "invalid_date", "valid_date"},
+              {emptyInput, invalidDateStrings, validDateStrings}))
       .addExpression(
           "try_cast_invalid_empty_input", "try_cast(empty as timestamp) ")
       .addExpression(
           "tryexpr_cast_invalid_empty_input", "try(cast (empty as timestamp))")
+      .addExpression(
+          "try_cast_invalid_input", "try_cast(invalid_date as timestamp) ")
+      .addExpression(
+          "tryexpr_cast_invalid_input", "try(cast (invalid_date as timestamp))")
       .addExpression("cast_valid", "cast(valid_date as timestamp)");
 
   benchmarkBuilder

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -41,7 +41,10 @@ VectorPtr newConstantFromString(
 
   if (type->isDate()) {
     auto copy = util::castFromDateString(
-        StringView(value.value()), util::ParseMode::kStandardCast);
+                    StringView(value.value()), util::ParseMode::kStandardCast)
+                    .thenOrThrow(folly::identity, [&](const Status& status) {
+                      VELOX_USER_FAIL("{}", status.message());
+                    });
     return std::make_shared<ConstantVector<int32_t>>(
         pool, size, false, type, std::move(copy));
   }

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -4098,7 +4098,10 @@ TEST_F(TableScanTest, timestampPartitionKey) {
           makeFlatVector<Timestamp>(
               std::end(inputs) - std::begin(inputs),
               [&](auto i) {
-                auto t = util::fromTimestampString(inputs[i]);
+                auto t = util::fromTimestampString(inputs[i]).thenOrThrow(
+                    folly::identity, [&](const Status& status) {
+                      VELOX_USER_FAIL("{}", status.message());
+                    });
                 t.toGMT(Timestamp::defaultTimezone());
                 return t;
               }),

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -361,7 +361,12 @@ void CastExpr::applyCastKernel(
         }
       }
       if constexpr (ToKind == TypeKind::TIMESTAMP) {
-        result->set(row, hooks_->castStringToTimestamp(inputRowValue));
+        const auto castResult = hooks_->castStringToTimestamp(inputRowValue);
+        if (castResult.hasError()) {
+          setError(castResult.error().message());
+        } else {
+          result->set(row, castResult.value());
+        }
         return;
       }
     }

--- a/velox/expression/CastHooks.h
+++ b/velox/expression/CastHooks.h
@@ -28,9 +28,11 @@ class CastHooks {
  public:
   virtual ~CastHooks() = default;
 
-  virtual Timestamp castStringToTimestamp(const StringView& view) const = 0;
+  virtual Expected<Timestamp> castStringToTimestamp(
+      const StringView& view) const = 0;
 
-  virtual int32_t castStringToDate(const StringView& dateString) const = 0;
+  virtual Expected<int32_t> castStringToDate(
+      const StringView& dateString) const = 0;
 
   // Returns whether legacy cast semantics are enabled.
   virtual bool legacy() const = 0;

--- a/velox/expression/PrestoCastHooks.h
+++ b/velox/expression/PrestoCastHooks.h
@@ -27,10 +27,12 @@ class PrestoCastHooks : public CastHooks {
   explicit PrestoCastHooks(const core::QueryConfig& config);
 
   // Uses the default implementation of 'castFromDateString'.
-  Timestamp castStringToTimestamp(const StringView& view) const override;
+  Expected<Timestamp> castStringToTimestamp(
+      const StringView& view) const override;
 
   // Uses standard cast mode to cast from string to date.
-  int32_t castStringToDate(const StringView& dateString) const override;
+  Expected<int32_t> castStringToDate(
+      const StringView& dateString) const override;
 
   bool legacy() const override {
     return legacyCast_;

--- a/velox/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/velox/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -58,6 +58,12 @@ class DateTimeFormatterTest : public testing::Test {
       "Dec",
   };
 
+  static Timestamp fromTimestampString(const StringView& timestamp) {
+    return util::fromTimestampString(timestamp).thenOrThrow(
+        folly::identity,
+        [&](const Status& status) { VELOX_USER_FAIL("{}", status.message()); });
+  }
+
   void testTokenRange(
       char specifier,
       int numTokenStart,
@@ -394,51 +400,45 @@ TEST_F(JodaDateTimeFormatterTest, invalid) {
 TEST_F(JodaDateTimeFormatterTest, parseJodaEra) {
   // Normal era cases
   EXPECT_EQ(
-      util::fromTimestampString("-100-01-01"),
-      parseJoda("BC 101", "G Y").timestamp);
+      fromTimestampString("-100-01-01"), parseJoda("BC 101", "G Y").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("101-01-01"),
-      parseJoda("AD 101", "G Y").timestamp);
+      fromTimestampString("101-01-01"), parseJoda("AD 101", "G Y").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("-100-01-01"),
-      parseJoda("bc 101", "G Y").timestamp);
+      fromTimestampString("-100-01-01"), parseJoda("bc 101", "G Y").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("101-01-01"),
-      parseJoda("ad 101", "G Y").timestamp);
+      fromTimestampString("101-01-01"), parseJoda("ad 101", "G Y").timestamp);
 
   // Era specifier with 'y' specifier
   EXPECT_EQ(
-      util::fromTimestampString("101-01-01"),
-      parseJoda("BC 101", "G y").timestamp);
+      fromTimestampString("101-01-01"), parseJoda("BC 101", "G y").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("2012-01-01"),
-      parseJoda("BC 2012", "G y").timestamp);
+      fromTimestampString("2012-01-01"), parseJoda("BC 2012", "G y").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("-101-01-01"),
+      fromTimestampString("-101-01-01"),
       parseJoda("AD 2012 -101", "G Y y").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("2012-01-01"),
+      fromTimestampString("2012-01-01"),
       parseJoda("BC 101 2012", "G Y y").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("-2011-01-01"),
+      fromTimestampString("-2011-01-01"),
       parseJoda("BC 2000 2012", "G y Y").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("-2011-01-01"),
+      fromTimestampString("-2011-01-01"),
       parseJoda("BC 2000 2012 BC", "G y Y G").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("-2014-01-01"),
+      fromTimestampString("-2014-01-01"),
       parseJoda("BC 1 BC 2015", "G y G Y").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("2015-01-01"),
+      fromTimestampString("2015-01-01"),
       parseJoda("BC 0 BC 2015 AD", "G y G Y G").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("2015-01-01"),
+      fromTimestampString("2015-01-01"),
       parseJoda("AD 0 AD 2015", "G y G Y").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("-2011-01-01"),
+      fromTimestampString("-2011-01-01"),
       parseJoda("BC 0 BC 2015 2 2012 BC", "G y G Y y Y G").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("2012-01-01"),
+      fromTimestampString("2012-01-01"),
       parseJoda("AD 0 AD 2015 2 2012 AD", "G y G Y y Y G").timestamp);
 
   // Invalid cases
@@ -453,23 +453,19 @@ TEST_F(JodaDateTimeFormatterTest, parseJodaEra) {
 
 TEST_F(JodaDateTimeFormatterTest, parseYearOfEra) {
   // By the default, assume epoch.
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01"), parseJoda(" ", " ").timestamp);
+  EXPECT_EQ(fromTimestampString("1970-01-01"), parseJoda(" ", " ").timestamp);
 
   // Number of times the token is repeated doesn't change the parsing behavior.
   EXPECT_EQ(
-      util::fromTimestampString("2134-01-01"),
-      parseJoda("2134", "Y").timestamp);
+      fromTimestampString("2134-01-01"), parseJoda("2134", "Y").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("2134-01-01"),
+      fromTimestampString("2134-01-01"),
       parseJoda("2134", "YYYYYYYY").timestamp);
 
   // Probe the year of era range. Joda only supports positive years.
   EXPECT_EQ(
-      util::fromTimestampString("294247-01-01"),
-      parseJoda("294247", "Y").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("0001-01-01"), parseJoda("1", "Y").timestamp);
+      fromTimestampString("294247-01-01"), parseJoda("294247", "Y").timestamp);
+  EXPECT_EQ(fromTimestampString("0001-01-01"), parseJoda("1", "Y").timestamp);
   EXPECT_THROW(parseJoda("292278994", "Y"), VeloxUserError);
   EXPECT_THROW(parseJoda("0", "Y"), VeloxUserError);
   EXPECT_THROW(parseJoda("-1", "Y"), VeloxUserError);
@@ -477,27 +473,19 @@ TEST_F(JodaDateTimeFormatterTest, parseYearOfEra) {
   EXPECT_THROW(parseJoda(" 1 2", "Y Y"), VeloxUserError);
 
   // 2 'Y' token case
+  EXPECT_EQ(fromTimestampString("2012-01-01"), parseJoda("12", "YY").timestamp);
+  EXPECT_EQ(fromTimestampString("2069-01-01"), parseJoda("69", "YY").timestamp);
+  EXPECT_EQ(fromTimestampString("1970-01-01"), parseJoda("70", "YY").timestamp);
+  EXPECT_EQ(fromTimestampString("1999-01-01"), parseJoda("99", "YY").timestamp);
+  EXPECT_EQ(fromTimestampString("0002-01-01"), parseJoda("2", "YY").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("2012-01-01"), parseJoda("12", "YY").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("2069-01-01"), parseJoda("69", "YY").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01"), parseJoda("70", "YY").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("1999-01-01"), parseJoda("99", "YY").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("0002-01-01"), parseJoda("2", "YY").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("0210-01-01"),
-      parseJoda("210", "YY").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("0001-01-01"), parseJoda("1", "YY").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("2001-01-01"), parseJoda("01", "YY").timestamp);
+      fromTimestampString("0210-01-01"), parseJoda("210", "YY").timestamp);
+  EXPECT_EQ(fromTimestampString("0001-01-01"), parseJoda("1", "YY").timestamp);
+  EXPECT_EQ(fromTimestampString("2001-01-01"), parseJoda("01", "YY").timestamp);
 
   // Last token read overwrites:
   EXPECT_EQ(
-      util::fromTimestampString("0005-01-01"),
+      fromTimestampString("0005-01-01"),
       parseJoda("1 2 3 4 5", "Y Y Y Y Y").timestamp);
 
   // Throws on consumption of plus sign
@@ -506,57 +494,39 @@ TEST_F(JodaDateTimeFormatterTest, parseYearOfEra) {
 
 // Same semantic as YEAR_OF_ERA, except that it accepts zero and negative years.
 TEST_F(JodaDateTimeFormatterTest, parseYear) {
+  EXPECT_EQ(fromTimestampString("123-01-01"), parseJoda("123", "y").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("123-01-01"), parseJoda("123", "y").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("321-01-01"),
-      parseJoda("321", "yyyyyyyy").timestamp);
+      fromTimestampString("321-01-01"), parseJoda("321", "yyyyyyyy").timestamp);
 
+  EXPECT_EQ(fromTimestampString("0-01-01"), parseJoda("0", "y").timestamp);
+  EXPECT_EQ(fromTimestampString("-1-01-01"), parseJoda("-1", "y").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("0-01-01"), parseJoda("0", "y").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("-1-01-01"), parseJoda("-1", "y").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("-1234-01-01"),
-      parseJoda("-1234", "y").timestamp);
+      fromTimestampString("-1234-01-01"), parseJoda("-1234", "y").timestamp);
 
   // Last token read overwrites:
   EXPECT_EQ(
-      util::fromTimestampString("0-01-01"),
-      parseJoda("123 0", "Y y").timestamp);
+      fromTimestampString("0-01-01"), parseJoda("123 0", "Y y").timestamp);
 
   // 2 'y' token case
+  EXPECT_EQ(fromTimestampString("2012-01-01"), parseJoda("12", "yy").timestamp);
+  EXPECT_EQ(fromTimestampString("2069-01-01"), parseJoda("69", "yy").timestamp);
+  EXPECT_EQ(fromTimestampString("1970-01-01"), parseJoda("70", "yy").timestamp);
+  EXPECT_EQ(fromTimestampString("1999-01-01"), parseJoda("99", "yy").timestamp);
+  EXPECT_EQ(fromTimestampString("0002-01-01"), parseJoda("2", "yy").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("2012-01-01"), parseJoda("12", "yy").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("2069-01-01"), parseJoda("69", "yy").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01"), parseJoda("70", "yy").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("1999-01-01"), parseJoda("99", "yy").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("0002-01-01"), parseJoda("2", "yy").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("0210-01-01"),
-      parseJoda("210", "yy").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("0001-01-01"), parseJoda("1", "yy").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("2001-01-01"), parseJoda("01", "yy").timestamp);
+      fromTimestampString("0210-01-01"), parseJoda("210", "yy").timestamp);
+  EXPECT_EQ(fromTimestampString("0001-01-01"), parseJoda("1", "yy").timestamp);
+  EXPECT_EQ(fromTimestampString("2001-01-01"), parseJoda("01", "yy").timestamp);
 
   // Plus sign consumption valid when y operator is not followed by another
   // specifier
+  EXPECT_EQ(fromTimestampString("10-01-01"), parseJoda("+10", "y").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("10-01-01"), parseJoda("+10", "y").timestamp);
+      fromTimestampString("99-02-01"), parseJoda("+99 02", "y M").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("99-02-01"),
-      parseJoda("+99 02", "y M").timestamp);
+      fromTimestampString("10-10-01"), parseJoda("10 +10", "M y").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("10-10-01"),
-      parseJoda("10 +10", "M y").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("100-02-01"),
-      parseJoda("2+100", "My").timestamp);
+      fromTimestampString("100-02-01"), parseJoda("2+100", "My").timestamp);
   EXPECT_THROW(parseJoda("+10001", "yM"), VeloxUserError);
   EXPECT_THROW(parseJoda("++100", "y"), VeloxUserError);
 
@@ -564,72 +534,59 @@ TEST_F(JodaDateTimeFormatterTest, parseYear) {
   EXPECT_THROW(parseJoda("-292275056", "y"), VeloxUserError);
   EXPECT_THROW(parseJoda("292278995", "y"), VeloxUserError);
   EXPECT_EQ(
-      util::fromTimestampString("292278994-01-01"),
+      fromTimestampString("292278994-01-01"),
       parseJoda("292278994", "y").timestamp);
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseWeekYear) {
   // Covers entire range of possible week year start dates (12-29 to 01-04)
   EXPECT_EQ(
-      util::fromTimestampString("1969-12-29 00:00:00"),
+      fromTimestampString("1969-12-29 00:00:00"),
       parseJoda("1970", "x").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("2024-12-30 00:00:00"),
+      fromTimestampString("2024-12-30 00:00:00"),
       parseJoda("2025", "x").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1934-12-31 00:00:00"),
+      fromTimestampString("1934-12-31 00:00:00"),
       parseJoda("1935", "x").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1990-01-01 00:00:00"),
+      fromTimestampString("1990-01-01 00:00:00"),
       parseJoda("1990", "x").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("0204-01-02 00:00:00"),
+      fromTimestampString("0204-01-02 00:00:00"),
       parseJoda("204", "x").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("-0102-01-03 00:00:00"),
+      fromTimestampString("-0102-01-03 00:00:00"),
       parseJoda("-102", "x").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("-0108-01-04 00:00:00"),
+      fromTimestampString("-0108-01-04 00:00:00"),
       parseJoda("-108", "x").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("-1002-12-31 00:00:00"),
+      fromTimestampString("-1002-12-31 00:00:00"),
       parseJoda("-1001", "x").timestamp);
 
   // 2 'x' token case
+  EXPECT_EQ(fromTimestampString("2012-01-02"), parseJoda("12", "xx").timestamp);
+  EXPECT_EQ(fromTimestampString("2068-12-31"), parseJoda("69", "xx").timestamp);
+  EXPECT_EQ(fromTimestampString("1969-12-29"), parseJoda("70", "xx").timestamp);
+  EXPECT_EQ(fromTimestampString("1999-01-04"), parseJoda("99", "xx").timestamp);
+  EXPECT_EQ(fromTimestampString("0001-12-31"), parseJoda("2", "xx").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("2012-01-02"), parseJoda("12", "xx").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("2068-12-31"), parseJoda("69", "xx").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("1969-12-29"), parseJoda("70", "xx").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("1999-01-04"), parseJoda("99", "xx").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("0001-12-31"), parseJoda("2", "xx").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("0210-01-01"),
-      parseJoda("210", "xx").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("0001-01-01"), parseJoda("1", "xx").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("2001-01-01"), parseJoda("01", "xx").timestamp);
+      fromTimestampString("0210-01-01"), parseJoda("210", "xx").timestamp);
+  EXPECT_EQ(fromTimestampString("0001-01-01"), parseJoda("1", "xx").timestamp);
+  EXPECT_EQ(fromTimestampString("2001-01-01"), parseJoda("01", "xx").timestamp);
 
   // Plus sign consumption valid when x operator is not followed by another
   // specifier
+  EXPECT_EQ(fromTimestampString("10-01-04"), parseJoda("+10", "x").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("10-01-04"), parseJoda("+10", "x").timestamp);
+      fromTimestampString("0098-12-29"), parseJoda("+99 01", "x w").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("0098-12-29"),
-      parseJoda("+99 01", "x w").timestamp);
+      fromTimestampString("0099-01-05"), parseJoda("+99 02", "x w").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("0099-01-05"),
-      parseJoda("+99 02", "x w").timestamp);
+      fromTimestampString("10-03-08"), parseJoda("10 +10", "w x").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("10-03-08"),
-      parseJoda("10 +10", "w x").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("100-01-11"),
-      parseJoda("2+100", "wx").timestamp);
+      fromTimestampString("100-01-11"), parseJoda("2+100", "wx").timestamp);
   EXPECT_THROW(parseJoda("+10001", "xM"), VeloxUserError);
   EXPECT_THROW(parseJoda("++100", "x"), VeloxUserError);
 
@@ -641,11 +598,10 @@ TEST_F(JodaDateTimeFormatterTest, parseWeekYear) {
 TEST_F(JodaDateTimeFormatterTest, parseCenturyOfEra) {
   // Probe century range
   EXPECT_EQ(
-      util::fromTimestampString("292278900-01-01 00:00:00"),
+      fromTimestampString("292278900-01-01 00:00:00"),
       parseJoda("2922789", "CCCCCCC").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("00-01-01 00:00:00"),
-      parseJoda("0", "C").timestamp);
+      fromTimestampString("00-01-01 00:00:00"), parseJoda("0", "C").timestamp);
 
   // Invalid century values
   EXPECT_THROW(parseJoda("-1", "CCCCCCC"), VeloxUserError);
@@ -655,17 +611,13 @@ TEST_F(JodaDateTimeFormatterTest, parseCenturyOfEra) {
 TEST_F(JodaDateTimeFormatterTest, parseJodaMonth) {
   // Joda has this weird behavior where if minute or hour is specified, year
   // falls back to 2000, instead of epoch (1970)  ¯\_(ツ)_/¯
+  EXPECT_EQ(fromTimestampString("2000-01-01"), parseJoda("1", "M").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("2000-01-01"), parseJoda("1", "M").timestamp);
+      fromTimestampString("2000-07-01"), parseJoda(" 7", " MM").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("2000-07-01"),
-      parseJoda(" 7", " MM").timestamp);
+      fromTimestampString("2000-11-01"), parseJoda("11-", "M-").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("2000-11-01"),
-      parseJoda("11-", "M-").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("2000-12-01"),
-      parseJoda("-12-", "-M-").timestamp);
+      fromTimestampString("2000-12-01"), parseJoda("-12-", "-M-").timestamp);
 
   EXPECT_THROW(parseJoda("0", "M"), VeloxUserError);
   EXPECT_THROW(parseJoda("13", "M"), VeloxUserError);
@@ -675,8 +627,7 @@ TEST_F(JodaDateTimeFormatterTest, parseJodaMonth) {
   // names
   for (int i = 0; i < 12; i++) {
     const auto timestampString = fmt::format("2000-{}-01", i + 1);
-    const auto timestamp =
-        util::fromTimestampString(StringView(timestampString));
+    const auto timestamp = fromTimestampString(StringView(timestampString));
     EXPECT_EQ(timestamp, parseJoda(monthsShort[i], "MMM").timestamp);
     EXPECT_EQ(timestamp, parseJoda(monthsFull[i], "MMM").timestamp);
     EXPECT_EQ(timestamp, parseJoda(monthsShort[i], "MMMM").timestamp);
@@ -693,17 +644,13 @@ TEST_F(JodaDateTimeFormatterTest, parseJodaMonth) {
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseDayOfMonth) {
+  EXPECT_EQ(fromTimestampString("2000-01-01"), parseJoda("1", "d").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("2000-01-01"), parseJoda("1", "d").timestamp);
+      fromTimestampString("2000-01-07"), parseJoda("7 ", "dd ").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("2000-01-07"),
-      parseJoda("7 ", "dd ").timestamp);
+      fromTimestampString("2000-01-11"), parseJoda("/11", "/dd").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("2000-01-11"),
-      parseJoda("/11", "/dd").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("2000-01-31"),
-      parseJoda("/31/", "/d/").timestamp);
+      fromTimestampString("2000-01-31"), parseJoda("/31/", "/d/").timestamp);
 
   EXPECT_THROW(parseJoda("0", "d"), VeloxUserError);
   EXPECT_THROW(parseJoda("32", "d"), VeloxUserError);
@@ -716,12 +663,12 @@ TEST_F(JodaDateTimeFormatterTest, parseDayOfMonth) {
   EXPECT_THROW(parseJoda("1 31 20 2", "M d d M"), VeloxUserError);
   EXPECT_THROW(parseJoda("2 31 20 4", "M d d M"), VeloxUserError);
   EXPECT_EQ(
-      util::fromTimestampString("2000-01-31"),
+      fromTimestampString("2000-01-31"),
       parseJoda("2 31 1", "M d M").timestamp);
 
   // Probe around leap year.
   EXPECT_EQ(
-      util::fromTimestampString("2000-02-29"),
+      fromTimestampString("2000-02-29"),
       parseJoda("2000-02-29", "Y-M-d").timestamp);
   EXPECT_THROW(parseJoda("2001-02-29", "Y-M-d"), VeloxUserError);
 }
@@ -729,78 +676,67 @@ TEST_F(JodaDateTimeFormatterTest, parseDayOfMonth) {
 TEST_F(JodaDateTimeFormatterTest, parseDayOfYear) {
   // Just day of year specifier should default to 2000. Also covers leap year
   // case
+  EXPECT_EQ(fromTimestampString("2000-01-01"), parseJoda("1", "D").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("2000-01-01"), parseJoda("1", "D").timestamp);
+      fromTimestampString("2000-01-07"), parseJoda("7 ", "DD ").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("2000-01-07"),
-      parseJoda("7 ", "DD ").timestamp);
+      fromTimestampString("2000-01-11"), parseJoda("/11", "/DD").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("2000-01-11"),
-      parseJoda("/11", "/DD").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("2000-01-31"),
-      parseJoda("/31/", "/DDD/").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("2000-02-01"), parseJoda("32", "D").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("2000-02-29"), parseJoda("60", "D").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("2000-12-30"), parseJoda("365", "D").timestamp);
-  EXPECT_EQ(
-      util::fromTimestampString("2000-12-31"), parseJoda("366", "D").timestamp);
+      fromTimestampString("2000-01-31"), parseJoda("/31/", "/DDD/").timestamp);
+  EXPECT_EQ(fromTimestampString("2000-02-01"), parseJoda("32", "D").timestamp);
+  EXPECT_EQ(fromTimestampString("2000-02-29"), parseJoda("60", "D").timestamp);
+  EXPECT_EQ(fromTimestampString("2000-12-30"), parseJoda("365", "D").timestamp);
+  EXPECT_EQ(fromTimestampString("2000-12-31"), parseJoda("366", "D").timestamp);
 
   // Year specified cases
   EXPECT_EQ(
-      util::fromTimestampString("1950-01-01"),
-      parseJoda("1950 1", "y D").timestamp);
+      fromTimestampString("1950-01-01"), parseJoda("1950 1", "y D").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1950-01-07"),
+      fromTimestampString("1950-01-07"),
       parseJoda("1950 7 ", "y DD ").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1950-01-11"),
+      fromTimestampString("1950-01-11"),
       parseJoda("1950 /11", "y /DD").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1950-01-31"),
+      fromTimestampString("1950-01-31"),
       parseJoda("1950 /31/", "y /DDD/").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1950-02-01"),
-      parseJoda("1950 32", "y D").timestamp);
+      fromTimestampString("1950-02-01"), parseJoda("1950 32", "y D").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1950-03-01"),
-      parseJoda("1950 60", "y D").timestamp);
+      fromTimestampString("1950-03-01"), parseJoda("1950 60", "y D").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1950-12-31"),
+      fromTimestampString("1950-12-31"),
       parseJoda("1950 365", "y D").timestamp);
   EXPECT_THROW(parseJoda("1950 366", "Y D"), VeloxUserError);
 
   // Negative year specified cases
   EXPECT_EQ(
-      util::fromTimestampString("-1950-01-01"),
+      fromTimestampString("-1950-01-01"),
       parseJoda("-1950 1", "y D").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("-1950-01-07"),
+      fromTimestampString("-1950-01-07"),
       parseJoda("-1950 7 ", "y DD ").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("-1950-01-11"),
+      fromTimestampString("-1950-01-11"),
       parseJoda("-1950 /11", "y /DD").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("-1950-01-31"),
+      fromTimestampString("-1950-01-31"),
       parseJoda("-1950 /31/", "y /DDD/").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("-1950-02-01"),
+      fromTimestampString("-1950-02-01"),
       parseJoda("-1950 32", "y D").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("-1950-03-01"),
+      fromTimestampString("-1950-03-01"),
       parseJoda("-1950 60", "y D").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("-1950-12-31"),
+      fromTimestampString("-1950-12-31"),
       parseJoda("-1950 365", "y D").timestamp);
   EXPECT_THROW(parseJoda("-1950 366", "Y D"), VeloxUserError);
 
   // Ensure all days of year are checked against final selected year
   EXPECT_THROW(parseJoda("2000 366 2001", "y D y"), VeloxUserError);
   EXPECT_EQ(
-      util::fromTimestampString("2000-12-31"),
+      fromTimestampString("2000-12-31"),
       parseJoda("2001 366 2000", "y D y").timestamp);
 
   EXPECT_THROW(parseJoda("0", "d"), VeloxUserError);
@@ -809,16 +745,16 @@ TEST_F(JodaDateTimeFormatterTest, parseDayOfYear) {
 
 TEST_F(JodaDateTimeFormatterTest, parseHourOfDay) {
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"),
+      fromTimestampString("1970-01-01 07:00:00"),
       parseJoda("7", "H").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 23:00:00"),
+      fromTimestampString("1970-01-01 23:00:00"),
       parseJoda("23", "HH").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
+      fromTimestampString("1970-01-01 00:00:00"),
       parseJoda("0", "HHH").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 10:00:00"),
+      fromTimestampString("1970-01-01 10:00:00"),
       parseJoda("10", "HHHHHHHH").timestamp);
 
   // Hour of day invalid
@@ -829,16 +765,16 @@ TEST_F(JodaDateTimeFormatterTest, parseHourOfDay) {
 
 TEST_F(JodaDateTimeFormatterTest, parseClockHourOfDay) {
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"),
+      fromTimestampString("1970-01-01 07:00:00"),
       parseJoda("7", "k").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
+      fromTimestampString("1970-01-01 00:00:00"),
       parseJoda("24", "kk").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 01:00:00"),
+      fromTimestampString("1970-01-01 01:00:00"),
       parseJoda("1", "kkk").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 10:00:00"),
+      fromTimestampString("1970-01-01 10:00:00"),
       parseJoda("10", "kkkkkkkk").timestamp);
 
   // Clock hour of day invalid
@@ -849,16 +785,16 @@ TEST_F(JodaDateTimeFormatterTest, parseClockHourOfDay) {
 
 TEST_F(JodaDateTimeFormatterTest, parseHourOfHalfDay) {
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"),
+      fromTimestampString("1970-01-01 07:00:00"),
       parseJoda("7", "K").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 11:00:00"),
+      fromTimestampString("1970-01-01 11:00:00"),
       parseJoda("11", "KK").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
+      fromTimestampString("1970-01-01 00:00:00"),
       parseJoda("0", "KKK").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 10:00:00"),
+      fromTimestampString("1970-01-01 10:00:00"),
       parseJoda("10", "KKKKKKKK").timestamp);
 
   // Hour of half day invalid
@@ -869,16 +805,16 @@ TEST_F(JodaDateTimeFormatterTest, parseHourOfHalfDay) {
 
 TEST_F(JodaDateTimeFormatterTest, parseClockHourOfHalfDay) {
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"),
+      fromTimestampString("1970-01-01 07:00:00"),
       parseJoda("7", "h").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
+      fromTimestampString("1970-01-01 00:00:00"),
       parseJoda("12", "hh").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 01:00:00"),
+      fromTimestampString("1970-01-01 01:00:00"),
       parseJoda("1", "hhh").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 10:00:00"),
+      fromTimestampString("1970-01-01 10:00:00"),
       parseJoda("10", "hhhhhhhh").timestamp);
 
   // Clock hour of half day invalid
@@ -891,132 +827,132 @@ TEST_F(JodaDateTimeFormatterTest, parseHalfOfDay) {
   // Half of day has no effect if hour or clockhour of day is provided
   // hour of day tests
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"),
+      fromTimestampString("1970-01-01 07:00:00"),
       parseJoda("7 PM", "H a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"),
+      fromTimestampString("1970-01-01 07:00:00"),
       parseJoda("7 AM", "H a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"),
+      fromTimestampString("1970-01-01 07:00:00"),
       parseJoda("7 pm", "H a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"),
+      fromTimestampString("1970-01-01 07:00:00"),
       parseJoda("7 am", "H a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
+      fromTimestampString("1970-01-01 00:00:00"),
       parseJoda("0 PM", "H a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
+      fromTimestampString("1970-01-01 00:00:00"),
       parseJoda("0 AM", "H a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
+      fromTimestampString("1970-01-01 00:00:00"),
       parseJoda("0 pm", "H a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
+      fromTimestampString("1970-01-01 00:00:00"),
       parseJoda("0 am", "H a").timestamp);
 
   // clock hour of day tests
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"),
+      fromTimestampString("1970-01-01 07:00:00"),
       parseJoda("7 PM", "k a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"),
+      fromTimestampString("1970-01-01 07:00:00"),
       parseJoda("7 AM", "k a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"),
+      fromTimestampString("1970-01-01 07:00:00"),
       parseJoda("7 pm", "k a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"),
+      fromTimestampString("1970-01-01 07:00:00"),
       parseJoda("7 am", "k a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
+      fromTimestampString("1970-01-01 00:00:00"),
       parseJoda("24 PM", "k a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
+      fromTimestampString("1970-01-01 00:00:00"),
       parseJoda("24 AM", "k a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
+      fromTimestampString("1970-01-01 00:00:00"),
       parseJoda("24 pm", "k a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
+      fromTimestampString("1970-01-01 00:00:00"),
       parseJoda("24 am", "k a").timestamp);
 
   // Half of day has effect if hour or clockhour of halfday is provided
   // hour of halfday tests
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 12:00:00"),
+      fromTimestampString("1970-01-01 12:00:00"),
       parseJoda("0 PM", "K a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
+      fromTimestampString("1970-01-01 00:00:00"),
       parseJoda("0 AM", "K a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 18:00:00"),
+      fromTimestampString("1970-01-01 18:00:00"),
       parseJoda("6 PM", "K a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 06:00:00"),
+      fromTimestampString("1970-01-01 06:00:00"),
       parseJoda("6 AM", "K a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 23:00:00"),
+      fromTimestampString("1970-01-01 23:00:00"),
       parseJoda("11 PM", "K a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 11:00:00"),
+      fromTimestampString("1970-01-01 11:00:00"),
       parseJoda("11 AM", "K a").timestamp);
 
   // clockhour of halfday tests
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 13:00:00"),
+      fromTimestampString("1970-01-01 13:00:00"),
       parseJoda("1 PM", "h a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 01:00:00"),
+      fromTimestampString("1970-01-01 01:00:00"),
       parseJoda("1 AM", "h a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 18:00:00"),
+      fromTimestampString("1970-01-01 18:00:00"),
       parseJoda("6 PM", "h a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 06:00:00"),
+      fromTimestampString("1970-01-01 06:00:00"),
       parseJoda("6 AM", "h a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 12:00:00"),
+      fromTimestampString("1970-01-01 12:00:00"),
       parseJoda("12 PM", "h a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
+      fromTimestampString("1970-01-01 00:00:00"),
       parseJoda("12 AM", "h a").timestamp);
 
   // time gives precendent to most recent time specifier
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 01:00:00"),
+      fromTimestampString("1970-01-01 01:00:00"),
       parseJoda("0 1 AM", "H h a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 13:00:00"),
+      fromTimestampString("1970-01-01 13:00:00"),
       parseJoda("12 1 PM", "H h a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
+      fromTimestampString("1970-01-01 00:00:00"),
       parseJoda("1 AM 0", "h a H").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 12:00:00"),
+      fromTimestampString("1970-01-01 12:00:00"),
       parseJoda("1 AM 12", "h a H").timestamp);
 
   // Half of day still has effect even though hour or clockhour is not provided.
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 12:00:00"),
+      fromTimestampString("1970-01-01 12:00:00"),
       parseJoda("PM", "a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 12:11:11"),
+      fromTimestampString("1970-01-01 12:11:11"),
       parseJoda("11:11 PM", "mm:ss a").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("2018-04-28 12:59:30"),
+      fromTimestampString("2018-04-28 12:59:30"),
       parseJoda("2018-04-28 59:30 PM", "yyyy-MM-dd mm:ss a").timestamp);
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseMinute) {
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:08:00"),
+      fromTimestampString("1970-01-01 00:08:00"),
       parseJoda("8", "m").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:59:00"),
+      fromTimestampString("1970-01-01 00:59:00"),
       parseJoda("59", "mm").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
+      fromTimestampString("1970-01-01 00:00:00"),
       parseJoda("0/", "mmm/").timestamp);
 
   EXPECT_THROW(parseJoda("60", "m"), VeloxUserError);
@@ -1026,13 +962,13 @@ TEST_F(JodaDateTimeFormatterTest, parseMinute) {
 
 TEST_F(JodaDateTimeFormatterTest, parseSecond) {
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:09"),
+      fromTimestampString("1970-01-01 00:00:09"),
       parseJoda("9", "s").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:58"),
+      fromTimestampString("1970-01-01 00:00:58"),
       parseJoda("58", "ss").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
+      fromTimestampString("1970-01-01 00:00:00"),
       parseJoda("0/", "s/").timestamp);
 
   EXPECT_THROW(parseJoda("60", "s"), VeloxUserError);
@@ -1121,143 +1057,143 @@ TEST_F(JodaDateTimeFormatterTest, parseTimezone) {
 TEST_F(JodaDateTimeFormatterTest, parseMixedYMDFormat) {
   // Common patterns found.
   EXPECT_EQ(
-      util::fromTimestampString("2021-01-04 23:00:00"),
+      fromTimestampString("2021-01-04 23:00:00"),
       parseJoda("2021-01-04+23:00", "YYYY-MM-dd+HH:mm").timestamp);
 
   EXPECT_EQ(
-      util::fromTimestampString("2019-07-03 11:04:10"),
+      fromTimestampString("2019-07-03 11:04:10"),
       parseJoda("2019-07-03 11:04:10", "YYYY-MM-dd HH:mm:ss").timestamp);
 
   // Backwards, just for fun:
   EXPECT_EQ(
-      util::fromTimestampString("2019-07-03 11:04:10"),
+      fromTimestampString("2019-07-03 11:04:10"),
       parseJoda("10:04:11 03-07-2019", "ss:mm:HH dd-MM-YYYY").timestamp);
 
   // Include timezone.
   auto result = parseJoda("2021-11-05+01:00+09:00", "YYYY-MM-dd+HH:mmZZ");
-  EXPECT_EQ(util::fromTimestampString("2021-11-05 01:00:00"), result.timestamp);
+  EXPECT_EQ(fromTimestampString("2021-11-05 01:00:00"), result.timestamp);
   EXPECT_EQ("+09:00", util::getTimeZoneName(result.timezoneId));
 
   // Timezone offset in -hh:mm format.
   result = parseJoda("-07:232021-11-05+01:00", "ZZYYYY-MM-dd+HH:mm");
-  EXPECT_EQ(util::fromTimestampString("2021-11-05 01:00:00"), result.timestamp);
+  EXPECT_EQ(fromTimestampString("2021-11-05 01:00:00"), result.timestamp);
   EXPECT_EQ("-07:23", util::getTimeZoneName(result.timezoneId));
 
   // Timezone offset in +hhmm format.
   result = parseJoda("+01332022-03-08+13:00", "ZZYYYY-MM-dd+HH:mm");
-  EXPECT_EQ(util::fromTimestampString("2022-03-08 13:00:00"), result.timestamp);
+  EXPECT_EQ(fromTimestampString("2022-03-08 13:00:00"), result.timestamp);
   EXPECT_EQ("+01:33", util::getTimeZoneName(result.timezoneId));
 
   // Z in the input means GMT in Joda.
   EXPECT_EQ(
-      util::fromTimestampString("2022-07-29 20:03:54.667"),
+      fromTimestampString("2022-07-29 20:03:54.667"),
       parseJoda("2022-07-29T20:03:54.667Z", "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
           .timestamp);
 
   // Timezone in string format.
   result = parseJoda("2021-11-05+01:00 PST", "YYYY-MM-dd+HH:mm zz");
-  EXPECT_EQ(util::fromTimestampString("2021-11-05 01:00:00"), result.timestamp);
+  EXPECT_EQ(fromTimestampString("2021-11-05 01:00:00"), result.timestamp);
   EXPECT_EQ("America/Los_Angeles", util::getTimeZoneName(result.timezoneId));
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseMixedWeekFormat) {
   // Common patterns found.
   EXPECT_EQ(
-      util::fromTimestampString("2021-01-04 13:29:21.213"),
+      fromTimestampString("2021-01-04 13:29:21.213"),
       parseJoda("2021 1 1 13:29:21.213", "x w e HH:mm:ss.SSS").timestamp);
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-05-31 13:29:21.213"),
+      fromTimestampString("2021-05-31 13:29:21.213"),
       parseJoda("2021 22 1 13:29:21.213", "x w e HH:mm:ss.SSS").timestamp);
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-06-03 13:29:21.213"),
+      fromTimestampString("2021-06-03 13:29:21.213"),
       parseJoda("2021 22 4 13:29:21.213", "x w e HH:mm:ss.SSS").timestamp);
 
   // Day of week short text normal capitlization
   EXPECT_EQ(
-      util::fromTimestampString("2021-01-04 13:29:21.213"),
+      fromTimestampString("2021-01-04 13:29:21.213"),
       parseJoda("2021 1 Mon 13:29:21.213", "x w E HH:mm:ss.SSS").timestamp);
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-05-31 13:29:21.213"),
+      fromTimestampString("2021-05-31 13:29:21.213"),
       parseJoda("2021 22 Mon 13:29:21.213", "x w E HH:mm:ss.SSS").timestamp);
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-06-03 13:29:21.213"),
+      fromTimestampString("2021-06-03 13:29:21.213"),
       parseJoda("2021 22 Thu 13:29:21.213", "x w E HH:mm:ss.SSS").timestamp);
 
   // Day of week long text normal capitlization
   EXPECT_EQ(
-      util::fromTimestampString("2021-01-04 13:29:21.213"),
+      fromTimestampString("2021-01-04 13:29:21.213"),
       parseJoda("2021 1 Monday 13:29:21.213", "x w EEE HH:mm:ss.SSS")
           .timestamp);
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-05-31 13:29:21.213"),
+      fromTimestampString("2021-05-31 13:29:21.213"),
       parseJoda("2021 22 Monday 13:29:21.213", "x w EEE HH:mm:ss.SSS")
           .timestamp);
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-06-03 13:29:21.213"),
+      fromTimestampString("2021-06-03 13:29:21.213"),
       parseJoda("2021 22 Thursday 13:29:21.213", "x w EEE HH:mm:ss.SSS")
           .timestamp);
 
   // Day of week short text upper case
   EXPECT_EQ(
-      util::fromTimestampString("2021-01-04 13:29:21.213"),
+      fromTimestampString("2021-01-04 13:29:21.213"),
       parseJoda("2021 1 MON 13:29:21.213", "x w E HH:mm:ss.SSS").timestamp);
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-05-31 13:29:21.213"),
+      fromTimestampString("2021-05-31 13:29:21.213"),
       parseJoda("2021 22 MON 13:29:21.213", "x w E HH:mm:ss.SSS").timestamp);
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-06-03 13:29:21.213"),
+      fromTimestampString("2021-06-03 13:29:21.213"),
       parseJoda("2021 22 THU 13:29:21.213", "x w E HH:mm:ss.SSS").timestamp);
 
   // Day of week long text upper case
   EXPECT_EQ(
-      util::fromTimestampString("2021-01-04 13:29:21.213"),
+      fromTimestampString("2021-01-04 13:29:21.213"),
       parseJoda("2021 1 MONDAY 13:29:21.213", "x w EEE HH:mm:ss.SSS")
           .timestamp);
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-05-31 13:29:21.213"),
+      fromTimestampString("2021-05-31 13:29:21.213"),
       parseJoda("2021 22 MONDAY 13:29:21.213", "x w EEE HH:mm:ss.SSS")
           .timestamp);
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-06-03 13:29:21.213"),
+      fromTimestampString("2021-06-03 13:29:21.213"),
       parseJoda("2021 22 THURSDAY 13:29:21.213", "x w EEE HH:mm:ss.SSS")
           .timestamp);
 
   // Day of week short text lower case
   EXPECT_EQ(
-      util::fromTimestampString("2021-01-04 13:29:21.213"),
+      fromTimestampString("2021-01-04 13:29:21.213"),
       parseJoda("2021 1 mon 13:29:21.213", "x w E HH:mm:ss.SSS").timestamp);
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-05-31 13:29:21.213"),
+      fromTimestampString("2021-05-31 13:29:21.213"),
       parseJoda("2021 22 mon 13:29:21.213", "x w E HH:mm:ss.SSS").timestamp);
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-06-03 13:29:21.213"),
+      fromTimestampString("2021-06-03 13:29:21.213"),
       parseJoda("2021 22 thu 13:29:21.213", "x w E HH:mm:ss.SSS").timestamp);
 
   // Day of week long text lower case
   EXPECT_EQ(
-      util::fromTimestampString("2021-01-04 13:29:21.213"),
+      fromTimestampString("2021-01-04 13:29:21.213"),
       parseJoda("2021 1 monday 13:29:21.213", "x w EEE HH:mm:ss.SSS")
           .timestamp);
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-05-31 13:29:21.213"),
+      fromTimestampString("2021-05-31 13:29:21.213"),
       parseJoda("2021 22 monday 13:29:21.213", "x w EEE HH:mm:ss.SSS")
           .timestamp);
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-06-03 13:29:21.213"),
+      fromTimestampString("2021-06-03 13:29:21.213"),
       parseJoda("2021 22 thursday 13:29:21.213", "x w EEE HH:mm:ss.SSS")
           .timestamp);
 
@@ -1272,26 +1208,23 @@ TEST_F(JodaDateTimeFormatterTest, parseMixedWeekFormat) {
 
   // Backwards, just for fun:
   EXPECT_EQ(
-      util::fromTimestampString("2021-05-31 13:29:21.213"),
+      fromTimestampString("2021-05-31 13:29:21.213"),
       parseJoda("213.21:29:13 1 22 2021", "SSS.ss:mm:HH e w x").timestamp);
 
   // Include timezone.
   auto result =
       parseJoda("2021 22 1 13:29:21.213+09:00", "x w e HH:mm:ss.SSSZZ");
-  EXPECT_EQ(
-      util::fromTimestampString("2021-05-31 13:29:21.213"), result.timestamp);
+  EXPECT_EQ(fromTimestampString("2021-05-31 13:29:21.213"), result.timestamp);
   EXPECT_EQ("+09:00", util::getTimeZoneName(result.timezoneId));
 
   // Timezone offset in -hh:mm format.
   result = parseJoda("-07:232021 22 1 13:29:21.213", "ZZx w e HH:mm:ss.SSS");
-  EXPECT_EQ(
-      util::fromTimestampString("2021-05-31 13:29:21.213"), result.timestamp);
+  EXPECT_EQ(fromTimestampString("2021-05-31 13:29:21.213"), result.timestamp);
   EXPECT_EQ("-07:23", util::getTimeZoneName(result.timezoneId));
 
   // Timezone offset in +hhmm format.
   result = parseJoda("+01332021 22 1 13:29:21.213", "ZZx w e HH:mm:ss.SSS");
-  EXPECT_EQ(
-      util::fromTimestampString("2021-05-31 13:29:21.213"), result.timestamp);
+  EXPECT_EQ(fromTimestampString("2021-05-31 13:29:21.213"), result.timestamp);
   EXPECT_EQ("+01:33", util::getTimeZoneName(result.timezoneId));
 }
 
@@ -1299,52 +1232,50 @@ TEST_F(JodaDateTimeFormatterTest, parseFractionOfSecond) {
   // Valid milliseconds and timezone with positive offset.
   auto result =
       parseJoda("2022-02-23T12:15:00.364+04:00", "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-  EXPECT_EQ(
-      util::fromTimestampString("2022-02-23 12:15:00.364"), result.timestamp);
+  EXPECT_EQ(fromTimestampString("2022-02-23 12:15:00.364"), result.timestamp);
   EXPECT_EQ("+04:00", util::getTimeZoneName(result.timezoneId));
 
   // Valid milliseconds and timezone with negative offset.
   result =
       parseJoda("2022-02-23T12:15:00.776-14:00", "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-  EXPECT_EQ(
-      util::fromTimestampString("2022-02-23 12:15:00.776"), result.timestamp);
+  EXPECT_EQ(fromTimestampString("2022-02-23 12:15:00.776"), result.timestamp);
   EXPECT_EQ("-14:00", util::getTimeZoneName(result.timezoneId));
 
   // Valid milliseconds.
   EXPECT_EQ(
-      util::fromTimestampString("2022-02-24 02:19:33.283"),
+      fromTimestampString("2022-02-24 02:19:33.283"),
       parseJoda("2022-02-24 02:19:33.283", "yyyy-MM-dd HH:mm:ss.SSS")
           .timestamp);
 
   // Test without milliseconds.
   EXPECT_EQ(
-      util::fromTimestampString("2022-02-23 20:30:00"),
+      fromTimestampString("2022-02-23 20:30:00"),
       parseJoda("2022-02-23T20:30:00", "yyyy-MM-dd'T'HH:mm:ss").timestamp);
 
   // Assert on difference in milliseconds.
   EXPECT_NE(
-      util::fromTimestampString("2022-02-23 12:15:00.223"),
+      fromTimestampString("2022-02-23 12:15:00.223"),
       parseJoda("2022-02-23T12:15:00.776", "yyyy-MM-dd'T'HH:mm:ss.SSS")
           .timestamp);
 
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00.000"),
+      fromTimestampString("1970-01-01 00:00:00.000"),
       parseJoda("000", "SSS").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00.001"),
+      fromTimestampString("1970-01-01 00:00:00.001"),
       parseJoda("001", "SSS").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00.999"),
+      fromTimestampString("1970-01-01 00:00:00.999"),
       parseJoda("999", "SSS").timestamp);
 
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00.045"),
+      fromTimestampString("1970-01-01 00:00:00.045"),
       parseJoda("045", "SSS").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00.450"),
+      fromTimestampString("1970-01-01 00:00:00.450"),
       parseJoda("45", "SS").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00.450"),
+      fromTimestampString("1970-01-01 00:00:00.450"),
       parseJoda("45", "SSSS").timestamp);
 
   EXPECT_THROW(parseJoda("-1", "S"), VeloxUserError);
@@ -1353,23 +1284,21 @@ TEST_F(JodaDateTimeFormatterTest, parseFractionOfSecond) {
 
 TEST_F(JodaDateTimeFormatterTest, parseConsecutiveSpecifiers) {
   EXPECT_EQ(
-      util::fromTimestampString("2012-12-01"),
-      parseJoda("1212", "YYM").timestamp);
+      fromTimestampString("2012-12-01"), parseJoda("1212", "YYM").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("0012-12-01"),
-      parseJoda("1212", "MY").timestamp);
+      fromTimestampString("0012-12-01"), parseJoda("1212", "MY").timestamp);
   EXPECT_THROW(parseJoda("1212", "YM"), VeloxUserError);
 
   EXPECT_EQ(
-      util::fromTimestampString("2012-01-01 12:00:00"),
+      fromTimestampString("2012-01-01 12:00:00"),
       parseJoda("1212", "YYH").timestamp);
   EXPECT_EQ(
-      util::fromTimestampString("0012-01-01 12:00:00"),
+      fromTimestampString("0012-01-01 12:00:00"),
       parseJoda("1212", "HY").timestamp);
   EXPECT_THROW(parseJoda("1212", "YH"), VeloxUserError);
 
   EXPECT_EQ(
-      util::fromTimestampString("2012-01-01 12:00:00"),
+      fromTimestampString("2012-01-01 12:00:00"),
       parseJoda("1212", "yyH").timestamp);
   EXPECT_THROW(parseJoda("12312", "yyH"), VeloxUserError);
 }
@@ -1483,42 +1412,34 @@ TEST_F(MysqlDateTimeTest, invalidBuild) {
 TEST_F(MysqlDateTimeTest, formatYear) {
   auto* timezone = date::locate_zone("GMT");
   EXPECT_EQ(
-      formatMysqlDateTime("%Y", util::fromTimestampString("0-01-01"), timezone),
+      formatMysqlDateTime("%Y", fromTimestampString("0-01-01"), timezone),
       "0000");
   EXPECT_EQ(
-      formatMysqlDateTime("%Y", util::fromTimestampString("1-01-01"), timezone),
+      formatMysqlDateTime("%Y", fromTimestampString("1-01-01"), timezone),
       "0001");
   EXPECT_EQ(
-      formatMysqlDateTime(
-          "%Y", util::fromTimestampString("199-01-01"), timezone),
+      formatMysqlDateTime("%Y", fromTimestampString("199-01-01"), timezone),
       "0199");
   EXPECT_EQ(
-      formatMysqlDateTime(
-          "%Y", util::fromTimestampString("9999-01-01"), timezone),
+      formatMysqlDateTime("%Y", fromTimestampString("9999-01-01"), timezone),
       "9999");
   EXPECT_EQ(
-      formatMysqlDateTime(
-          "%Y", util::fromTimestampString("-1-01-01"), timezone),
+      formatMysqlDateTime("%Y", fromTimestampString("-1-01-01"), timezone),
       "-0001");
   EXPECT_EQ(
-      formatMysqlDateTime(
-          "%Y", util::fromTimestampString("19999-01-01"), timezone),
+      formatMysqlDateTime("%Y", fromTimestampString("19999-01-01"), timezone),
       "19999");
   EXPECT_EQ(
-      formatMysqlDateTime(
-          "%Y", util::fromTimestampString("-19999-01-01"), timezone),
+      formatMysqlDateTime("%Y", fromTimestampString("-19999-01-01"), timezone),
       "-19999");
   EXPECT_EQ(
-      formatMysqlDateTime(
-          "%Y", util::fromTimestampString("-1-01-01"), timezone),
+      formatMysqlDateTime("%Y", fromTimestampString("-1-01-01"), timezone),
       "-0001");
   EXPECT_THROW(
-      formatMysqlDateTime(
-          "%Y", util::fromTimestampString("-99999-01-01"), timezone),
+      formatMysqlDateTime("%Y", fromTimestampString("-99999-01-01"), timezone),
       VeloxUserError);
   EXPECT_THROW(
-      formatMysqlDateTime(
-          "%Y", util::fromTimestampString("99999-01-01"), timezone),
+      formatMysqlDateTime("%Y", fromTimestampString("99999-01-01"), timezone),
       VeloxUserError);
 }
 
@@ -1526,52 +1447,42 @@ TEST_F(MysqlDateTimeTest, formatMonthDay) {
   auto* timezone = date::locate_zone("GMT");
 
   EXPECT_EQ(
-      formatMysqlDateTime(
-          "%m~%d", util::fromTimestampString("0-01-01"), timezone),
+      formatMysqlDateTime("%m~%d", fromTimestampString("0-01-01"), timezone),
       "01~01");
   EXPECT_EQ(
-      formatMysqlDateTime(
-          "%m~%d", util::fromTimestampString("1-10-24"), timezone),
+      formatMysqlDateTime("%m~%d", fromTimestampString("1-10-24"), timezone),
       "10~24");
   EXPECT_EQ(
-      formatMysqlDateTime(
-          "%m~%d", util::fromTimestampString("199-09-30"), timezone),
+      formatMysqlDateTime("%m~%d", fromTimestampString("199-09-30"), timezone),
       "09~30");
   EXPECT_EQ(
-      formatMysqlDateTime(
-          "%m~%d", util::fromTimestampString("9999-01-01"), timezone),
+      formatMysqlDateTime("%m~%d", fromTimestampString("9999-01-01"), timezone),
+      "01~01");
+  EXPECT_EQ(
+      formatMysqlDateTime("%m~%d", fromTimestampString("-1-01-01"), timezone),
       "01~01");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%m~%d", util::fromTimestampString("-1-01-01"), timezone),
+          "%m~%d", fromTimestampString("19999-01-01"), timezone),
       "01~01");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%m~%d", util::fromTimestampString("19999-01-01"), timezone),
+          "%m~%d", fromTimestampString("-19999-01-01"), timezone),
       "01~01");
   EXPECT_EQ(
-      formatMysqlDateTime(
-          "%m~%d", util::fromTimestampString("-19999-01-01"), timezone),
+      formatMysqlDateTime("%m~%d", fromTimestampString("-1-01-01"), timezone),
       "01~01");
   EXPECT_EQ(
-      formatMysqlDateTime(
-          "%m~%d", util::fromTimestampString("-1-01-01"), timezone),
-      "01~01");
-  EXPECT_EQ(
-      formatMysqlDateTime(
-          "%m~%d", util::fromTimestampString("2000-02-29"), timezone),
+      formatMysqlDateTime("%m~%d", fromTimestampString("2000-02-29"), timezone),
       "02~29");
   EXPECT_THROW(
-      formatMysqlDateTime(
-          "%m~%d", util::fromTimestampString("-1-13-01"), timezone),
+      formatMysqlDateTime("%m~%d", fromTimestampString("-1-13-01"), timezone),
       VeloxUserError);
   EXPECT_THROW(
-      formatMysqlDateTime(
-          "%m~%d", util::fromTimestampString("1999-02-50"), timezone),
+      formatMysqlDateTime("%m~%d", fromTimestampString("1999-02-50"), timezone),
       VeloxUserError);
   EXPECT_THROW(
-      formatMysqlDateTime(
-          "%m~%d", util::fromTimestampString("1999-02-29"), timezone),
+      formatMysqlDateTime("%m~%d", fromTimestampString("1999-02-29"), timezone),
       VeloxUserError);
 }
 
@@ -1580,31 +1491,31 @@ TEST_F(MysqlDateTimeTest, formatWeekday) {
 
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%a..->%W", util::fromTimestampString("1999-01-04"), timezone),
+          "%a..->%W", fromTimestampString("1999-01-04"), timezone),
       "Mon..->Monday");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%a..->%W", util::fromTimestampString("1999-01-05"), timezone),
+          "%a..->%W", fromTimestampString("1999-01-05"), timezone),
       "Tue..->Tuesday");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%a..->%W", util::fromTimestampString("1999-01-06"), timezone),
+          "%a..->%W", fromTimestampString("1999-01-06"), timezone),
       "Wed..->Wednesday");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%a..->%W", util::fromTimestampString("1999-01-07"), timezone),
+          "%a..->%W", fromTimestampString("1999-01-07"), timezone),
       "Thu..->Thursday");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%a..->%W", util::fromTimestampString("1999-01-08"), timezone),
+          "%a..->%W", fromTimestampString("1999-01-08"), timezone),
       "Fri..->Friday");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%a..->%W", util::fromTimestampString("1999-01-09"), timezone),
+          "%a..->%W", fromTimestampString("1999-01-09"), timezone),
       "Sat..->Saturday");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%a..->%W", util::fromTimestampString("1999-01-10"), timezone),
+          "%a..->%W", fromTimestampString("1999-01-10"), timezone),
       "Sun..->Sunday");
 }
 
@@ -1613,51 +1524,51 @@ TEST_F(MysqlDateTimeTest, formatMonth) {
 
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%c-%m-%M", util::fromTimestampString("1999-01-04"), timezone),
+          "%c-%m-%M", fromTimestampString("1999-01-04"), timezone),
       "1-01-January");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%c-%m-%M", util::fromTimestampString("1999-02-04"), timezone),
+          "%c-%m-%M", fromTimestampString("1999-02-04"), timezone),
       "2-02-February");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%c-%m-%M", util::fromTimestampString("1999-03-04"), timezone),
+          "%c-%m-%M", fromTimestampString("1999-03-04"), timezone),
       "3-03-March");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%c-%m-%M", util::fromTimestampString("1999-04-04"), timezone),
+          "%c-%m-%M", fromTimestampString("1999-04-04"), timezone),
       "4-04-April");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%c-%m-%M", util::fromTimestampString("1999-05-04"), timezone),
+          "%c-%m-%M", fromTimestampString("1999-05-04"), timezone),
       "5-05-May");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%c-%m-%M", util::fromTimestampString("1999-06-04"), timezone),
+          "%c-%m-%M", fromTimestampString("1999-06-04"), timezone),
       "6-06-June");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%c-%m-%M", util::fromTimestampString("1999-07-04"), timezone),
+          "%c-%m-%M", fromTimestampString("1999-07-04"), timezone),
       "7-07-July");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%c-%m-%M", util::fromTimestampString("1999-08-04"), timezone),
+          "%c-%m-%M", fromTimestampString("1999-08-04"), timezone),
       "8-08-August");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%c-%m-%M", util::fromTimestampString("1999-09-04"), timezone),
+          "%c-%m-%M", fromTimestampString("1999-09-04"), timezone),
       "9-09-September");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%c-%m-%M", util::fromTimestampString("1999-10-04"), timezone),
+          "%c-%m-%M", fromTimestampString("1999-10-04"), timezone),
       "10-10-October");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%c-%m-%M", util::fromTimestampString("1999-11-04"), timezone),
+          "%c-%m-%M", fromTimestampString("1999-11-04"), timezone),
       "11-11-November");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%c-%m-%M", util::fromTimestampString("1999-12-04"), timezone),
+          "%c-%m-%M", fromTimestampString("1999-12-04"), timezone),
       "12-12-December");
 }
 
@@ -1665,16 +1576,13 @@ TEST_F(MysqlDateTimeTest, formatDayOfMonth) {
   auto* timezone = date::locate_zone("GMT");
 
   EXPECT_EQ(
-      formatMysqlDateTime(
-          "%d-%e", util::fromTimestampString("2000-02-01"), timezone),
+      formatMysqlDateTime("%d-%e", fromTimestampString("2000-02-01"), timezone),
       "01-1");
   EXPECT_EQ(
-      formatMysqlDateTime(
-          "%d-%e", util::fromTimestampString("2000-02-29"), timezone),
+      formatMysqlDateTime("%d-%e", fromTimestampString("2000-02-29"), timezone),
       "29-29");
   EXPECT_EQ(
-      formatMysqlDateTime(
-          "%d-%e", util::fromTimestampString("2000-12-31"), timezone),
+      formatMysqlDateTime("%d-%e", fromTimestampString("2000-12-31"), timezone),
       "31-31");
 }
 
@@ -1683,43 +1591,33 @@ TEST_F(MysqlDateTimeTest, formatFractionOfSecond) {
 
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%f", util::fromTimestampString("2000-02-01 00:00:00.987"), timezone),
+          "%f", fromTimestampString("2000-02-01 00:00:00.987"), timezone),
       "987000");
 
   // As our current precision is 3 decimal places.
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%f",
-          util::fromTimestampString("2000-02-01 00:00:00.987654"),
-          timezone),
+          "%f", fromTimestampString("2000-02-01 00:00:00.987654"), timezone),
       "987000");
 
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%f",
-          util::fromTimestampString("2000-02-01 00:00:00.900654"),
-          timezone),
+          "%f", fromTimestampString("2000-02-01 00:00:00.900654"), timezone),
       "900000");
 
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%f",
-          util::fromTimestampString("2000-02-01 00:00:00.090654"),
-          timezone),
+          "%f", fromTimestampString("2000-02-01 00:00:00.090654"), timezone),
       "090000");
 
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%f",
-          util::fromTimestampString("2000-02-01 00:00:00.009654"),
-          timezone),
+          "%f", fromTimestampString("2000-02-01 00:00:00.009654"), timezone),
       "009000");
 
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%f",
-          util::fromTimestampString("2000-02-01 00:00:00.000654"),
-          timezone),
+          "%f", fromTimestampString("2000-02-01 00:00:00.000654"), timezone),
       "000000");
 }
 
@@ -1729,19 +1627,19 @@ TEST_F(MysqlDateTimeTest, formatHour) {
   EXPECT_EQ(
       formatMysqlDateTime(
           "%h--%H--%I--%k--%l",
-          util::fromTimestampString("2000-02-01 00:00:00"),
+          fromTimestampString("2000-02-01 00:00:00"),
           timezone),
       "12--00--12--0--12");
   EXPECT_EQ(
       formatMysqlDateTime(
           "%h--%H--%I--%k--%l",
-          util::fromTimestampString("2000-02-01 12:12:01"),
+          fromTimestampString("2000-02-01 12:12:01"),
           timezone),
       "12--12--12--12--12");
   EXPECT_EQ(
       formatMysqlDateTime(
           "%h--%H--%I--%k--%l",
-          util::fromTimestampString("2000-02-01 23:23:01"),
+          fromTimestampString("2000-02-01 23:23:01"),
           timezone),
       "11--23--11--23--11");
 }
@@ -1751,19 +1649,19 @@ TEST_F(MysqlDateTimeTest, formatMinute) {
 
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%i", util::fromTimestampString("2000-02-01 00:00:00"), timezone),
+          "%i", fromTimestampString("2000-02-01 00:00:00"), timezone),
       "00");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%i", util::fromTimestampString("2000-02-01 00:09:00"), timezone),
+          "%i", fromTimestampString("2000-02-01 00:09:00"), timezone),
       "09");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%i", util::fromTimestampString("2000-02-01 00:31:00"), timezone),
+          "%i", fromTimestampString("2000-02-01 00:31:00"), timezone),
       "31");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%i", util::fromTimestampString("2000-02-01 00:59:00"), timezone),
+          "%i", fromTimestampString("2000-02-01 00:59:00"), timezone),
       "59");
 }
 
@@ -1772,15 +1670,15 @@ TEST_F(MysqlDateTimeTest, formatDayOfYear) {
 
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%j", util::fromTimestampString("2000-01-01 00:00:00"), timezone),
+          "%j", fromTimestampString("2000-01-01 00:00:00"), timezone),
       "001");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%j", util::fromTimestampString("2000-12-31 00:09:00"), timezone),
+          "%j", fromTimestampString("2000-12-31 00:09:00"), timezone),
       "366");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%j", util::fromTimestampString("1999-12-31 00:31:00"), timezone),
+          "%j", fromTimestampString("1999-12-31 00:31:00"), timezone),
       "365");
 }
 
@@ -1789,19 +1687,19 @@ TEST_F(MysqlDateTimeTest, formatAmPm) {
 
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%p", util::fromTimestampString("2000-01-01 00:00:00"), timezone),
+          "%p", fromTimestampString("2000-01-01 00:00:00"), timezone),
       "AM");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%p", util::fromTimestampString("2000-01-01 11:59:59"), timezone),
+          "%p", fromTimestampString("2000-01-01 11:59:59"), timezone),
       "AM");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%p", util::fromTimestampString("2000-01-01 12:00:00"), timezone),
+          "%p", fromTimestampString("2000-01-01 12:00:00"), timezone),
       "PM");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%p", util::fromTimestampString("2000-01-01 23:59:59"), timezone),
+          "%p", fromTimestampString("2000-01-01 23:59:59"), timezone),
       "PM");
 }
 
@@ -1810,15 +1708,15 @@ TEST_F(MysqlDateTimeTest, formatSecond) {
 
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%s-%S", util::fromTimestampString("2000-01-01 00:00:00"), timezone),
+          "%s-%S", fromTimestampString("2000-01-01 00:00:00"), timezone),
       "00-00");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%s-%S", util::fromTimestampString("2000-01-01 00:00:30"), timezone),
+          "%s-%S", fromTimestampString("2000-01-01 00:00:30"), timezone),
       "30-30");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%s-%S", util::fromTimestampString("2000-01-01 00:00:59"), timezone),
+          "%s-%S", fromTimestampString("2000-01-01 00:00:59"), timezone),
       "59-59");
 }
 
@@ -1828,120 +1726,103 @@ TEST_F(MysqlDateTimeTest, formatCompositeTime) {
   // 12 hour %r
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%r", util::fromTimestampString("2000-01-01 00:00:00"), timezone),
+          "%r", fromTimestampString("2000-01-01 00:00:00"), timezone),
       "12:00:00 AM");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%r", util::fromTimestampString("2000-01-01 11:59:59"), timezone),
+          "%r", fromTimestampString("2000-01-01 11:59:59"), timezone),
       "11:59:59 AM");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%r", util::fromTimestampString("2000-01-01 12:00:00"), timezone),
+          "%r", fromTimestampString("2000-01-01 12:00:00"), timezone),
       "12:00:00 PM");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%r", util::fromTimestampString("2000-01-01 23:59:59"), timezone),
+          "%r", fromTimestampString("2000-01-01 23:59:59"), timezone),
       "11:59:59 PM");
 
   // 24 hour %T
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%T", util::fromTimestampString("2000-01-01 00:00:00"), timezone),
+          "%T", fromTimestampString("2000-01-01 00:00:00"), timezone),
 
       "00:00:00");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%T", util::fromTimestampString("2000-01-01 11:59:59"), timezone),
+          "%T", fromTimestampString("2000-01-01 11:59:59"), timezone),
       "11:59:59");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%T", util::fromTimestampString("2000-01-01 12:00:00"), timezone),
+          "%T", fromTimestampString("2000-01-01 12:00:00"), timezone),
       "12:00:00");
   EXPECT_EQ(
       formatMysqlDateTime(
-          "%T", util::fromTimestampString("2000-01-01 23:59:59"), timezone),
+          "%T", fromTimestampString("2000-01-01 23:59:59"), timezone),
       "23:59:59");
 }
 
 // Same semantic as YEAR_OF_ERA, except that it accepts zero and negative years.
 TEST_F(MysqlDateTimeTest, parseFourDigitYear) {
-  EXPECT_EQ(util::fromTimestampString("123-01-01"), parseMysql("123", "%Y"));
-  EXPECT_EQ(util::fromTimestampString("321-01-01"), parseMysql("321", "%Y"));
+  EXPECT_EQ(fromTimestampString("123-01-01"), parseMysql("123", "%Y"));
+  EXPECT_EQ(fromTimestampString("321-01-01"), parseMysql("321", "%Y"));
 
-  EXPECT_EQ(util::fromTimestampString("0-01-01"), parseMysql("0", "%Y"));
-  EXPECT_EQ(util::fromTimestampString("-1-01-01"), parseMysql("-1", "%Y"));
-  EXPECT_EQ(
-      util::fromTimestampString("-1234-01-01"), parseMysql("-1234", "%Y"));
+  EXPECT_EQ(fromTimestampString("0-01-01"), parseMysql("0", "%Y"));
+  EXPECT_EQ(fromTimestampString("-1-01-01"), parseMysql("-1", "%Y"));
+  EXPECT_EQ(fromTimestampString("-1234-01-01"), parseMysql("-1234", "%Y"));
 
   // Last token read overwrites:
-  EXPECT_EQ(util::fromTimestampString("0-01-01"), parseMysql("123 0", "%Y %Y"));
+  EXPECT_EQ(fromTimestampString("0-01-01"), parseMysql("123 0", "%Y %Y"));
 
   // Plus sign consumption valid when %Y operator is not followed by another
   // specifier
-  EXPECT_EQ(util::fromTimestampString("10-01-01"), parseMysql("+10", "%Y"));
-  EXPECT_EQ(
-      util::fromTimestampString("99-02-01"), parseMysql("+99 02", "%Y %m"));
-  EXPECT_EQ(
-      util::fromTimestampString("10-10-01"), parseMysql("10 +10", "%m %Y"));
-  EXPECT_EQ(
-      util::fromTimestampString("100-02-01"), parseMysql("2+100", "%m%Y"));
+  EXPECT_EQ(fromTimestampString("10-01-01"), parseMysql("+10", "%Y"));
+  EXPECT_EQ(fromTimestampString("99-02-01"), parseMysql("+99 02", "%Y %m"));
+  EXPECT_EQ(fromTimestampString("10-10-01"), parseMysql("10 +10", "%m %Y"));
+  EXPECT_EQ(fromTimestampString("100-02-01"), parseMysql("2+100", "%m%Y"));
   EXPECT_THROW(parseMysql("+10001", "%Y%m"), VeloxUserError);
   EXPECT_THROW(parseMysql("++100", "%Y"), VeloxUserError);
 
   // Probe the year range
   EXPECT_THROW(parseMysql("-10000", "%Y"), VeloxUserError);
   EXPECT_THROW(parseMysql("10000", "%Y"), VeloxUserError);
-  EXPECT_EQ(util::fromTimestampString("9999-01-01"), parseMysql("9999", "%Y"));
+  EXPECT_EQ(fromTimestampString("9999-01-01"), parseMysql("9999", "%Y"));
 }
 
 TEST_F(MysqlDateTimeTest, parseTwoDigitYear) {
-  EXPECT_EQ(util::fromTimestampString("1970-01-01"), parseMysql("70", "%y"));
-  EXPECT_EQ(util::fromTimestampString("2069-01-01"), parseMysql("69", "%y"));
-  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parseMysql("00", "%y"));
+  EXPECT_EQ(fromTimestampString("1970-01-01"), parseMysql("70", "%y"));
+  EXPECT_EQ(fromTimestampString("2069-01-01"), parseMysql("69", "%y"));
+  EXPECT_EQ(fromTimestampString("2000-01-01"), parseMysql("00", "%y"));
 
   // Last token read overwrites:
-  EXPECT_EQ(
-      util::fromTimestampString("2030-01-01"), parseMysql("80 30", "%y %y"));
+  EXPECT_EQ(fromTimestampString("2030-01-01"), parseMysql("80 30", "%y %y"));
 }
 
 TEST_F(MysqlDateTimeTest, parseWeekYear) {
   // Covers entire range of possible week year start dates (12-29 to 01-04)
   EXPECT_EQ(
-      util::fromTimestampString("1969-12-29 00:00:00"),
-      parseMysql("1970", "%x"));
+      fromTimestampString("1969-12-29 00:00:00"), parseMysql("1970", "%x"));
   EXPECT_EQ(
-      util::fromTimestampString("2024-12-30 00:00:00"),
-      parseMysql("2025", "%x"));
+      fromTimestampString("2024-12-30 00:00:00"), parseMysql("2025", "%x"));
   EXPECT_EQ(
-      util::fromTimestampString("1934-12-31 00:00:00"),
-      parseMysql("1935", "%x"));
+      fromTimestampString("1934-12-31 00:00:00"), parseMysql("1935", "%x"));
   EXPECT_EQ(
-      util::fromTimestampString("1990-01-01 00:00:00"),
-      parseMysql("1990", "%x"));
+      fromTimestampString("1990-01-01 00:00:00"), parseMysql("1990", "%x"));
   EXPECT_EQ(
-      util::fromTimestampString("0204-01-02 00:00:00"),
-      parseMysql("204", "%x"));
+      fromTimestampString("0204-01-02 00:00:00"), parseMysql("204", "%x"));
   EXPECT_EQ(
-      util::fromTimestampString("-0102-01-03 00:00:00"),
-      parseMysql("-102", "%x"));
+      fromTimestampString("-0102-01-03 00:00:00"), parseMysql("-102", "%x"));
   EXPECT_EQ(
-      util::fromTimestampString("-0108-01-04 00:00:00"),
-      parseMysql("-108", "%x"));
+      fromTimestampString("-0108-01-04 00:00:00"), parseMysql("-108", "%x"));
   EXPECT_EQ(
-      util::fromTimestampString("-1002-12-31 00:00:00"),
-      parseMysql("-1001", "%x"));
+      fromTimestampString("-1002-12-31 00:00:00"), parseMysql("-1001", "%x"));
 
   // Plus sign consumption valid when %x operator is not followed by another
   // specifier
-  EXPECT_EQ(util::fromTimestampString("10-01-04"), parseMysql("+10", "%x"));
-  EXPECT_EQ(
-      util::fromTimestampString("0098-12-29"), parseMysql("+99 01", "%x %v"));
-  EXPECT_EQ(
-      util::fromTimestampString("0099-01-05"), parseMysql("+99 02", "%x %v"));
-  EXPECT_EQ(
-      util::fromTimestampString("10-03-08"), parseMysql("10 +10", "%v %x"));
-  EXPECT_EQ(
-      util::fromTimestampString("100-01-11"), parseMysql("2+100", "%v%x"));
+  EXPECT_EQ(fromTimestampString("10-01-04"), parseMysql("+10", "%x"));
+  EXPECT_EQ(fromTimestampString("0098-12-29"), parseMysql("+99 01", "%x %v"));
+  EXPECT_EQ(fromTimestampString("0099-01-05"), parseMysql("+99 02", "%x %v"));
+  EXPECT_EQ(fromTimestampString("10-03-08"), parseMysql("10 +10", "%v %x"));
+  EXPECT_EQ(fromTimestampString("100-01-11"), parseMysql("2+100", "%v%x"));
   VELOX_ASSERT_THROW(
       parseMysql("+10001", "%x%m"), "Invalid date format: '+10001'");
   VELOX_ASSERT_THROW(parseMysql("++100", "%x"), "Invalid date format: '++100'");
@@ -1956,25 +1837,23 @@ TEST_F(MysqlDateTimeTest, parseWeekYear) {
 TEST_F(MysqlDateTimeTest, parseMonth) {
   // Joda has this weird behavior where if minute or hour is specified, year
   // falls back to 2000, instead of epoch (1970)  ¯\_(ツ)_/¯
-  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parseMysql("1", "%m"));
-  EXPECT_EQ(util::fromTimestampString("2000-07-01"), parseMysql(" 7", " %m"));
-  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parseMysql("01", "%m"));
-  EXPECT_EQ(util::fromTimestampString("2000-07-01"), parseMysql(" 07", " %m"));
-  EXPECT_EQ(util::fromTimestampString("2000-11-01"), parseMysql("11-", "%m-"));
-  EXPECT_EQ(
-      util::fromTimestampString("2000-12-01"), parseMysql("-12-", "-%m-"));
+  EXPECT_EQ(fromTimestampString("2000-01-01"), parseMysql("1", "%m"));
+  EXPECT_EQ(fromTimestampString("2000-07-01"), parseMysql(" 7", " %m"));
+  EXPECT_EQ(fromTimestampString("2000-01-01"), parseMysql("01", "%m"));
+  EXPECT_EQ(fromTimestampString("2000-07-01"), parseMysql(" 07", " %m"));
+  EXPECT_EQ(fromTimestampString("2000-11-01"), parseMysql("11-", "%m-"));
+  EXPECT_EQ(fromTimestampString("2000-12-01"), parseMysql("-12-", "-%m-"));
 
   EXPECT_THROW(parseMysql("0", "%m"), VeloxUserError);
   EXPECT_THROW(parseMysql("13", "%m"), VeloxUserError);
   EXPECT_THROW(parseMysql("12345", "%m"), VeloxUserError);
 
-  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parseMysql("1", "%c"));
-  EXPECT_EQ(util::fromTimestampString("2000-07-01"), parseMysql(" 7", " %c"));
-  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parseMysql("01", "%c"));
-  EXPECT_EQ(util::fromTimestampString("2000-07-01"), parseMysql(" 07", " %c"));
-  EXPECT_EQ(util::fromTimestampString("2000-11-01"), parseMysql("11-", "%c-"));
-  EXPECT_EQ(
-      util::fromTimestampString("2000-12-01"), parseMysql("-12-", "-%c-"));
+  EXPECT_EQ(fromTimestampString("2000-01-01"), parseMysql("1", "%c"));
+  EXPECT_EQ(fromTimestampString("2000-07-01"), parseMysql(" 7", " %c"));
+  EXPECT_EQ(fromTimestampString("2000-01-01"), parseMysql("01", "%c"));
+  EXPECT_EQ(fromTimestampString("2000-07-01"), parseMysql(" 07", " %c"));
+  EXPECT_EQ(fromTimestampString("2000-11-01"), parseMysql("11-", "%c-"));
+  EXPECT_EQ(fromTimestampString("2000-12-01"), parseMysql("-12-", "-%c-"));
 
   EXPECT_THROW(parseMysql("0", "%c"), VeloxUserError);
   EXPECT_THROW(parseMysql("13", "%c"), VeloxUserError);
@@ -1985,16 +1864,16 @@ TEST_F(MysqlDateTimeTest, parseMonth) {
   for (int i = 0; i < 12; i++) {
     std::string buildString("2000-" + std::to_string(i + 1) + "-01");
     EXPECT_EQ(
-        util::fromTimestampString(StringView{buildString}),
+        fromTimestampString(StringView{buildString}),
         parseMysql(monthsShort[i], "%b"));
     EXPECT_EQ(
-        util::fromTimestampString(StringView{buildString}),
+        fromTimestampString(StringView{buildString}),
         parseMysql(monthsFull[i], "%b"));
     EXPECT_EQ(
-        util::fromTimestampString(StringView{buildString}),
+        fromTimestampString(StringView{buildString}),
         parseMysql(monthsShort[i], "%M"));
     EXPECT_EQ(
-        util::fromTimestampString(StringView{buildString}),
+        fromTimestampString(StringView{buildString}),
         parseMysql(monthsFull[i], "%M"));
   }
 
@@ -2008,11 +1887,10 @@ TEST_F(MysqlDateTimeTest, parseMonth) {
 }
 
 TEST_F(MysqlDateTimeTest, parseDayOfMonth) {
-  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parseMysql("1", "%d"));
-  EXPECT_EQ(util::fromTimestampString("2000-01-07"), parseMysql("7 ", "%d "));
-  EXPECT_EQ(util::fromTimestampString("2000-01-11"), parseMysql("/11", "/%d"));
-  EXPECT_EQ(
-      util::fromTimestampString("2000-01-31"), parseMysql("/31/", "/%d/"));
+  EXPECT_EQ(fromTimestampString("2000-01-01"), parseMysql("1", "%d"));
+  EXPECT_EQ(fromTimestampString("2000-01-07"), parseMysql("7 ", "%d "));
+  EXPECT_EQ(fromTimestampString("2000-01-11"), parseMysql("/11", "/%d"));
+  EXPECT_EQ(fromTimestampString("2000-01-31"), parseMysql("/31/", "/%d/"));
 
   EXPECT_THROW(parseMysql("0", "%d"), VeloxUserError);
   EXPECT_THROW(parseMysql("32", "%d"), VeloxUserError);
@@ -2025,75 +1903,58 @@ TEST_F(MysqlDateTimeTest, parseDayOfMonth) {
   EXPECT_THROW(parseMysql("1 31 20 2", "%m %d %d %m"), VeloxUserError);
   EXPECT_THROW(parseMysql("2 31 20 4", "%m %d %d %m"), VeloxUserError);
   EXPECT_EQ(
-      util::fromTimestampString("2000-01-31"),
-      parseMysql("2 31 1", "%m %d %m"));
+      fromTimestampString("2000-01-31"), parseMysql("2 31 1", "%m %d %m"));
 
   // Probe around leap year.
   EXPECT_EQ(
-      util::fromTimestampString("2000-02-29"),
-      parseMysql("2000-02-29", "%Y-%m-%d"));
+      fromTimestampString("2000-02-29"), parseMysql("2000-02-29", "%Y-%m-%d"));
   EXPECT_THROW(parseMysql("2001-02-29", "%Y-%m-%d"), VeloxUserError);
 }
 
 TEST_F(MysqlDateTimeTest, parseDayOfYear) {
   // Just day of year specifier should default to 2000. Also covers leap year
   // case
-  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parseMysql("1", "%j"));
-  EXPECT_EQ(util::fromTimestampString("2000-01-07"), parseMysql("7 ", "%j "));
-  EXPECT_EQ(util::fromTimestampString("2000-01-11"), parseMysql("/11", "/%j"));
-  EXPECT_EQ(
-      util::fromTimestampString("2000-01-31"), parseMysql("/31/", "/%j/"));
-  EXPECT_EQ(util::fromTimestampString("2000-02-01"), parseMysql("32", "%j"));
-  EXPECT_EQ(util::fromTimestampString("2000-02-29"), parseMysql("60", "%j"));
-  EXPECT_EQ(util::fromTimestampString("2000-12-30"), parseMysql("365", "%j"));
-  EXPECT_EQ(util::fromTimestampString("2000-12-31"), parseMysql("366", "%j"));
+  EXPECT_EQ(fromTimestampString("2000-01-01"), parseMysql("1", "%j"));
+  EXPECT_EQ(fromTimestampString("2000-01-07"), parseMysql("7 ", "%j "));
+  EXPECT_EQ(fromTimestampString("2000-01-11"), parseMysql("/11", "/%j"));
+  EXPECT_EQ(fromTimestampString("2000-01-31"), parseMysql("/31/", "/%j/"));
+  EXPECT_EQ(fromTimestampString("2000-02-01"), parseMysql("32", "%j"));
+  EXPECT_EQ(fromTimestampString("2000-02-29"), parseMysql("60", "%j"));
+  EXPECT_EQ(fromTimestampString("2000-12-30"), parseMysql("365", "%j"));
+  EXPECT_EQ(fromTimestampString("2000-12-31"), parseMysql("366", "%j"));
 
   // Year specified cases
+  EXPECT_EQ(fromTimestampString("1950-01-01"), parseMysql("1950 1", "%Y %j"));
+  EXPECT_EQ(fromTimestampString("1950-01-07"), parseMysql("1950 7 ", "%Y %j "));
   EXPECT_EQ(
-      util::fromTimestampString("1950-01-01"), parseMysql("1950 1", "%Y %j"));
+      fromTimestampString("1950-01-11"), parseMysql("1950 /11", "%Y /%j"));
   EXPECT_EQ(
-      util::fromTimestampString("1950-01-07"), parseMysql("1950 7 ", "%Y %j "));
-  EXPECT_EQ(
-      util::fromTimestampString("1950-01-11"),
-      parseMysql("1950 /11", "%Y /%j"));
-  EXPECT_EQ(
-      util::fromTimestampString("1950-01-31"),
-      parseMysql("1950 /31/", "%Y /%j/"));
-  EXPECT_EQ(
-      util::fromTimestampString("1950-02-01"), parseMysql("1950 32", "%Y %j"));
-  EXPECT_EQ(
-      util::fromTimestampString("1950-03-01"), parseMysql("1950 60", "%Y %j"));
-  EXPECT_EQ(
-      util::fromTimestampString("1950-12-31"), parseMysql("1950 365", "%Y %j"));
+      fromTimestampString("1950-01-31"), parseMysql("1950 /31/", "%Y /%j/"));
+  EXPECT_EQ(fromTimestampString("1950-02-01"), parseMysql("1950 32", "%Y %j"));
+  EXPECT_EQ(fromTimestampString("1950-03-01"), parseMysql("1950 60", "%Y %j"));
+  EXPECT_EQ(fromTimestampString("1950-12-31"), parseMysql("1950 365", "%Y %j"));
   EXPECT_THROW(parseMysql("1950 366", "%Y %j"), VeloxUserError);
 
   // Negative year specified cases
+  EXPECT_EQ(fromTimestampString("-1950-01-01"), parseMysql("-1950 1", "%Y %j"));
   EXPECT_EQ(
-      util::fromTimestampString("-1950-01-01"), parseMysql("-1950 1", "%Y %j"));
+      fromTimestampString("-1950-01-07"), parseMysql("-1950 7 ", "%Y %j "));
   EXPECT_EQ(
-      util::fromTimestampString("-1950-01-07"),
-      parseMysql("-1950 7 ", "%Y %j "));
+      fromTimestampString("-1950-01-11"), parseMysql("-1950 /11", "%Y /%j"));
   EXPECT_EQ(
-      util::fromTimestampString("-1950-01-11"),
-      parseMysql("-1950 /11", "%Y /%j"));
+      fromTimestampString("-1950-01-31"), parseMysql("-1950 /31/", "%Y /%j/"));
   EXPECT_EQ(
-      util::fromTimestampString("-1950-01-31"),
-      parseMysql("-1950 /31/", "%Y /%j/"));
+      fromTimestampString("-1950-02-01"), parseMysql("-1950 32", "%Y %j"));
   EXPECT_EQ(
-      util::fromTimestampString("-1950-02-01"),
-      parseMysql("-1950 32", "%Y %j"));
+      fromTimestampString("-1950-03-01"), parseMysql("-1950 60", "%Y %j"));
   EXPECT_EQ(
-      util::fromTimestampString("-1950-03-01"),
-      parseMysql("-1950 60", "%Y %j"));
-  EXPECT_EQ(
-      util::fromTimestampString("-1950-12-31"),
-      parseMysql("-1950 365", "%Y %j"));
+      fromTimestampString("-1950-12-31"), parseMysql("-1950 365", "%Y %j"));
   EXPECT_THROW(parseMysql("-1950 366", "%Y %j"), VeloxUserError);
 
   // Ensure all days of year are checked against final selected year
   EXPECT_THROW(parseMysql("2000 366 2001", "%Y %j %Y"), VeloxUserError);
   EXPECT_EQ(
-      util::fromTimestampString("2000-12-31"),
+      fromTimestampString("2000-12-31"),
       parseMysql("2001 366 2000", "%Y %j %Y"));
 
   EXPECT_THROW(parseMysql("0", "%j"), VeloxUserError);
@@ -2101,28 +1962,20 @@ TEST_F(MysqlDateTimeTest, parseDayOfYear) {
 }
 
 TEST_F(MysqlDateTimeTest, parseHourOfDay) {
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"), parseMysql("7", "%H"));
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 23:00:00"), parseMysql("23", "%H"));
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"), parseMysql("0", "%H"));
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 10:00:00"), parseMysql("10", "%H"));
+  EXPECT_EQ(fromTimestampString("1970-01-01 07:00:00"), parseMysql("7", "%H"));
+  EXPECT_EQ(fromTimestampString("1970-01-01 23:00:00"), parseMysql("23", "%H"));
+  EXPECT_EQ(fromTimestampString("1970-01-01 00:00:00"), parseMysql("0", "%H"));
+  EXPECT_EQ(fromTimestampString("1970-01-01 10:00:00"), parseMysql("10", "%H"));
 
   // Hour of day invalid
   EXPECT_THROW(parseMysql("24", "%H"), VeloxUserError);
   EXPECT_THROW(parseMysql("-1", "%H"), VeloxUserError);
   EXPECT_THROW(parseMysql("123456789", "%H"), VeloxUserError);
 
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"), parseMysql("7", "%k"));
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 23:00:00"), parseMysql("23", "%k"));
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"), parseMysql("0", "%k"));
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 10:00:00"), parseMysql("10", "%k"));
+  EXPECT_EQ(fromTimestampString("1970-01-01 07:00:00"), parseMysql("7", "%k"));
+  EXPECT_EQ(fromTimestampString("1970-01-01 23:00:00"), parseMysql("23", "%k"));
+  EXPECT_EQ(fromTimestampString("1970-01-01 00:00:00"), parseMysql("0", "%k"));
+  EXPECT_EQ(fromTimestampString("1970-01-01 10:00:00"), parseMysql("10", "%k"));
 
   // Hour of day invalid
   EXPECT_THROW(parseMysql("24", "%k"), VeloxUserError);
@@ -2131,42 +1984,30 @@ TEST_F(MysqlDateTimeTest, parseHourOfDay) {
 }
 
 TEST_F(MysqlDateTimeTest, parseClockHourOfHalfDay) {
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"), parseMysql("7", "%h"));
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"), parseMysql("12", "%h"));
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 01:00:00"), parseMysql("1", "%h"));
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 10:00:00"), parseMysql("10", "%h"));
+  EXPECT_EQ(fromTimestampString("1970-01-01 07:00:00"), parseMysql("7", "%h"));
+  EXPECT_EQ(fromTimestampString("1970-01-01 00:00:00"), parseMysql("12", "%h"));
+  EXPECT_EQ(fromTimestampString("1970-01-01 01:00:00"), parseMysql("1", "%h"));
+  EXPECT_EQ(fromTimestampString("1970-01-01 10:00:00"), parseMysql("10", "%h"));
 
   // Clock hour of half day invalid
   EXPECT_THROW(parseMysql("13", "%h"), VeloxUserError);
   EXPECT_THROW(parseMysql("0", "%h"), VeloxUserError);
   EXPECT_THROW(parseMysql("123456789", "%h"), VeloxUserError);
 
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"), parseMysql("7", "%I"));
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"), parseMysql("12", "%I"));
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 01:00:00"), parseMysql("1", "%I"));
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 10:00:00"), parseMysql("10", "%I"));
+  EXPECT_EQ(fromTimestampString("1970-01-01 07:00:00"), parseMysql("7", "%I"));
+  EXPECT_EQ(fromTimestampString("1970-01-01 00:00:00"), parseMysql("12", "%I"));
+  EXPECT_EQ(fromTimestampString("1970-01-01 01:00:00"), parseMysql("1", "%I"));
+  EXPECT_EQ(fromTimestampString("1970-01-01 10:00:00"), parseMysql("10", "%I"));
 
   // Clock hour of half day invalid
   EXPECT_THROW(parseMysql("13", "%l"), VeloxUserError);
   EXPECT_THROW(parseMysql("0", "%l"), VeloxUserError);
   EXPECT_THROW(parseMysql("123456789", "%l"), VeloxUserError);
 
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"), parseMysql("7", "%l"));
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"), parseMysql("12", "%l"));
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 01:00:00"), parseMysql("1", "%l"));
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 10:00:00"), parseMysql("10", "%l"));
+  EXPECT_EQ(fromTimestampString("1970-01-01 07:00:00"), parseMysql("7", "%l"));
+  EXPECT_EQ(fromTimestampString("1970-01-01 00:00:00"), parseMysql("12", "%l"));
+  EXPECT_EQ(fromTimestampString("1970-01-01 01:00:00"), parseMysql("1", "%l"));
+  EXPECT_EQ(fromTimestampString("1970-01-01 10:00:00"), parseMysql("10", "%l"));
 
   // Clock hour of half day invalid
   EXPECT_THROW(parseMysql("13", "%l"), VeloxUserError);
@@ -2178,136 +2019,99 @@ TEST_F(MysqlDateTimeTest, parseHalfOfDay) {
   // Half of day has no effect if hour of day is provided
   // hour of day tests
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"),
-      parseMysql("7 PM", "%H %p"));
+      fromTimestampString("1970-01-01 07:00:00"), parseMysql("7 PM", "%H %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"),
-      parseMysql("7 AM", "%H %p"));
+      fromTimestampString("1970-01-01 07:00:00"), parseMysql("7 AM", "%H %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"),
-      parseMysql("7 pm", "%H %p"));
+      fromTimestampString("1970-01-01 07:00:00"), parseMysql("7 pm", "%H %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"),
-      parseMysql("7 am", "%H %p"));
+      fromTimestampString("1970-01-01 07:00:00"), parseMysql("7 am", "%H %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
-      parseMysql("0 PM", "%H %p"));
+      fromTimestampString("1970-01-01 00:00:00"), parseMysql("0 PM", "%H %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
-      parseMysql("0 AM", "%H %p"));
+      fromTimestampString("1970-01-01 00:00:00"), parseMysql("0 AM", "%H %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
-      parseMysql("0 pm", "%H %p"));
+      fromTimestampString("1970-01-01 00:00:00"), parseMysql("0 pm", "%H %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
-      parseMysql("0 am", "%H %p"));
+      fromTimestampString("1970-01-01 00:00:00"), parseMysql("0 am", "%H %p"));
 
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"),
-      parseMysql("7 PM", "%k %p"));
+      fromTimestampString("1970-01-01 07:00:00"), parseMysql("7 PM", "%k %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"),
-      parseMysql("7 AM", "%k %p"));
+      fromTimestampString("1970-01-01 07:00:00"), parseMysql("7 AM", "%k %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"),
-      parseMysql("7 pm", "%k %p"));
+      fromTimestampString("1970-01-01 07:00:00"), parseMysql("7 pm", "%k %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"),
-      parseMysql("7 am", "%k %p"));
+      fromTimestampString("1970-01-01 07:00:00"), parseMysql("7 am", "%k %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
-      parseMysql("0 PM", "%k %p"));
+      fromTimestampString("1970-01-01 00:00:00"), parseMysql("0 PM", "%k %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
-      parseMysql("0 AM", "%k %p"));
+      fromTimestampString("1970-01-01 00:00:00"), parseMysql("0 AM", "%k %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
-      parseMysql("0 pm", "%k %p"));
+      fromTimestampString("1970-01-01 00:00:00"), parseMysql("0 pm", "%k %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
-      parseMysql("0 am", "%k %p"));
+      fromTimestampString("1970-01-01 00:00:00"), parseMysql("0 am", "%k %p"));
 
   // Half of day has effect if clockhour of halfday is provided
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 13:00:00"),
-      parseMysql("1 PM", "%h %p"));
+      fromTimestampString("1970-01-01 13:00:00"), parseMysql("1 PM", "%h %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 01:00:00"),
-      parseMysql("1 AM", "%h %p"));
+      fromTimestampString("1970-01-01 01:00:00"), parseMysql("1 AM", "%h %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 18:00:00"),
-      parseMysql("6 PM", "%h %p"));
+      fromTimestampString("1970-01-01 18:00:00"), parseMysql("6 PM", "%h %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 06:00:00"),
-      parseMysql("6 AM", "%h %p"));
+      fromTimestampString("1970-01-01 06:00:00"), parseMysql("6 AM", "%h %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 12:00:00"),
-      parseMysql("12 PM", "%h %p"));
+      fromTimestampString("1970-01-01 12:00:00"), parseMysql("12 PM", "%h %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
-      parseMysql("12 AM", "%h %p"));
+      fromTimestampString("1970-01-01 00:00:00"), parseMysql("12 AM", "%h %p"));
 
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 13:00:00"),
-      parseMysql("1 PM", "%I %p"));
+      fromTimestampString("1970-01-01 13:00:00"), parseMysql("1 PM", "%I %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 01:00:00"),
-      parseMysql("1 AM", "%I %p"));
+      fromTimestampString("1970-01-01 01:00:00"), parseMysql("1 AM", "%I %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 18:00:00"),
-      parseMysql("6 PM", "%I %p"));
+      fromTimestampString("1970-01-01 18:00:00"), parseMysql("6 PM", "%I %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 06:00:00"),
-      parseMysql("6 AM", "%I %p"));
+      fromTimestampString("1970-01-01 06:00:00"), parseMysql("6 AM", "%I %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 12:00:00"),
-      parseMysql("12 PM", "%I %p"));
+      fromTimestampString("1970-01-01 12:00:00"), parseMysql("12 PM", "%I %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
-      parseMysql("12 AM", "%I %p"));
+      fromTimestampString("1970-01-01 00:00:00"), parseMysql("12 AM", "%I %p"));
 
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 13:00:00"),
-      parseMysql("1 PM", "%l %p"));
+      fromTimestampString("1970-01-01 13:00:00"), parseMysql("1 PM", "%l %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 01:00:00"),
-      parseMysql("1 AM", "%l %p"));
+      fromTimestampString("1970-01-01 01:00:00"), parseMysql("1 AM", "%l %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 18:00:00"),
-      parseMysql("6 PM", "%l %p"));
+      fromTimestampString("1970-01-01 18:00:00"), parseMysql("6 PM", "%l %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 06:00:00"),
-      parseMysql("6 AM", "%l %p"));
+      fromTimestampString("1970-01-01 06:00:00"), parseMysql("6 AM", "%l %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 12:00:00"),
-      parseMysql("12 PM", "%l %p"));
+      fromTimestampString("1970-01-01 12:00:00"), parseMysql("12 PM", "%l %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
-      parseMysql("12 AM", "%l %p"));
+      fromTimestampString("1970-01-01 00:00:00"), parseMysql("12 AM", "%l %p"));
 
   // time gives precendent to most recent time specifier
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 01:00:00"),
+      fromTimestampString("1970-01-01 01:00:00"),
       parseMysql("0 1 AM", "%H %h %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 13:00:00"),
+      fromTimestampString("1970-01-01 13:00:00"),
       parseMysql("12 1 PM", "%H %h %p"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
+      fromTimestampString("1970-01-01 00:00:00"),
       parseMysql("1 AM 0", "%h %p %H"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 12:00:00"),
+      fromTimestampString("1970-01-01 12:00:00"),
       parseMysql("1 AM 12", "%h %p %H"));
 }
 
 TEST_F(MysqlDateTimeTest, parseMinute) {
+  EXPECT_EQ(fromTimestampString("1970-01-01 00:08:00"), parseMysql("8", "%i"));
+  EXPECT_EQ(fromTimestampString("1970-01-01 00:59:00"), parseMysql("59", "%i"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:08:00"), parseMysql("8", "%i"));
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:59:00"), parseMysql("59", "%i"));
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
-      parseMysql("0/", "%i/"));
+      fromTimestampString("1970-01-01 00:00:00"), parseMysql("0/", "%i/"));
 
   EXPECT_THROW(parseMysql("60", "%i"), VeloxUserError);
   EXPECT_THROW(parseMysql("-1", "%i"), VeloxUserError);
@@ -2315,25 +2119,19 @@ TEST_F(MysqlDateTimeTest, parseMinute) {
 }
 
 TEST_F(MysqlDateTimeTest, parseSecond) {
+  EXPECT_EQ(fromTimestampString("1970-01-01 00:00:09"), parseMysql("9", "%s"));
+  EXPECT_EQ(fromTimestampString("1970-01-01 00:00:58"), parseMysql("58", "%s"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:09"), parseMysql("9", "%s"));
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:58"), parseMysql("58", "%s"));
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
-      parseMysql("0/", "%s/"));
+      fromTimestampString("1970-01-01 00:00:00"), parseMysql("0/", "%s/"));
 
   EXPECT_THROW(parseMysql("60", "%s"), VeloxUserError);
   EXPECT_THROW(parseMysql("-1", "%s"), VeloxUserError);
   EXPECT_THROW(parseMysql("123456789", "%s"), VeloxUserError);
 
+  EXPECT_EQ(fromTimestampString("1970-01-01 00:00:09"), parseMysql("9", "%S"));
+  EXPECT_EQ(fromTimestampString("1970-01-01 00:00:58"), parseMysql("58", "%S"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:09"), parseMysql("9", "%S"));
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:58"), parseMysql("58", "%S"));
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
-      parseMysql("0/", "%S/"));
+      fromTimestampString("1970-01-01 00:00:00"), parseMysql("0/", "%S/"));
 
   EXPECT_THROW(parseMysql("60", "%S"), VeloxUserError);
   EXPECT_THROW(parseMysql("-1", "%S"), VeloxUserError);
@@ -2343,105 +2141,105 @@ TEST_F(MysqlDateTimeTest, parseSecond) {
 TEST_F(MysqlDateTimeTest, parseMixedYMDFormat) {
   // Common patterns found.
   EXPECT_EQ(
-      util::fromTimestampString("2021-01-04 23:00:00"),
+      fromTimestampString("2021-01-04 23:00:00"),
       parseMysql("2021-01-04+23:00:00", "%Y-%m-%d+%H:%i:%s"));
 
   EXPECT_EQ(
-      util::fromTimestampString("2019-07-03 11:04:10"),
+      fromTimestampString("2019-07-03 11:04:10"),
       parseMysql("2019-07-03 11:04:10", "%Y-%m-%d %H:%i:%s"));
 
   // Backwards, just for fun:
   EXPECT_EQ(
-      util::fromTimestampString("2019-07-03 11:04:10"),
+      fromTimestampString("2019-07-03 11:04:10"),
       parseMysql("10:04:11 03-07-2019", "%s:%i:%H %d-%m-%Y"));
 }
 
 TEST_F(MysqlDateTimeTest, parseMixedWeekFormat) {
   // Common patterns found.
   EXPECT_EQ(
-      util::fromTimestampString("2021-01-04 13:29:21.213"),
+      fromTimestampString("2021-01-04 13:29:21.213"),
       parseMysql("2021 1 13:29:21.213", "%x %v %H:%i:%s.%f"));
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-05-31 13:29:21.213"),
+      fromTimestampString("2021-05-31 13:29:21.213"),
       parseMysql("2021 22 13:29:21.213", "%x %v %H:%i:%s.%f"));
 
   // Day of week short text normal capitlization
   EXPECT_EQ(
-      util::fromTimestampString("2021-01-04 13:29:21.213"),
+      fromTimestampString("2021-01-04 13:29:21.213"),
       parseMysql("2021 1 Mon 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-05-31 13:29:21.213"),
+      fromTimestampString("2021-05-31 13:29:21.213"),
       parseMysql("2021 22 Mon 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-06-03 13:29:21.213"),
+      fromTimestampString("2021-06-03 13:29:21.213"),
       parseMysql("2021 22 Thu 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   // Day of week long text normal capitlization
   EXPECT_EQ(
-      util::fromTimestampString("2021-01-04 13:29:21.213"),
+      fromTimestampString("2021-01-04 13:29:21.213"),
       parseMysql("2021 1 Monday 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-05-31 13:29:21.213"),
+      fromTimestampString("2021-05-31 13:29:21.213"),
       parseMysql("2021 22 Monday 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-06-03 13:29:21.213"),
+      fromTimestampString("2021-06-03 13:29:21.213"),
       parseMysql("2021 22 Thursday 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   // Day of week short text upper case
   EXPECT_EQ(
-      util::fromTimestampString("2021-01-04 13:29:21.213"),
+      fromTimestampString("2021-01-04 13:29:21.213"),
       parseMysql("2021 1 MON 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-05-31 13:29:21.213"),
+      fromTimestampString("2021-05-31 13:29:21.213"),
       parseMysql("2021 22 MON 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-06-03 13:29:21.213"),
+      fromTimestampString("2021-06-03 13:29:21.213"),
       parseMysql("2021 22 THU 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   // Day of week long text upper case
   EXPECT_EQ(
-      util::fromTimestampString("2021-01-04 13:29:21.213"),
+      fromTimestampString("2021-01-04 13:29:21.213"),
       parseMysql("2021 1 MONDAY 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-05-31 13:29:21.213"),
+      fromTimestampString("2021-05-31 13:29:21.213"),
       parseMysql("2021 22 MONDAY 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-06-03 13:29:21.213"),
+      fromTimestampString("2021-06-03 13:29:21.213"),
       parseMysql("2021 22 THURSDAY 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   // Day of week short text lower case
   EXPECT_EQ(
-      util::fromTimestampString("2021-01-04 13:29:21.213"),
+      fromTimestampString("2021-01-04 13:29:21.213"),
       parseMysql("2021 1 mon 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-05-31 13:29:21.213"),
+      fromTimestampString("2021-05-31 13:29:21.213"),
       parseMysql("2021 22 mon 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-06-03 13:29:21.213"),
+      fromTimestampString("2021-06-03 13:29:21.213"),
       parseMysql("2021 22 thu 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   // Day of week long text lower case
   EXPECT_EQ(
-      util::fromTimestampString("2021-01-04 13:29:21.213"),
+      fromTimestampString("2021-01-04 13:29:21.213"),
       parseMysql("2021 1 monday 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-05-31 13:29:21.213"),
+      fromTimestampString("2021-05-31 13:29:21.213"),
       parseMysql("2021 22 monday 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   EXPECT_EQ(
-      util::fromTimestampString("2021-06-03 13:29:21.213"),
+      fromTimestampString("2021-06-03 13:29:21.213"),
       parseMysql("2021 22 thursday 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   // Invalid day of week throw cases
@@ -2455,53 +2253,43 @@ TEST_F(MysqlDateTimeTest, parseMixedWeekFormat) {
 
   // Backwards, just for fun:
   EXPECT_EQ(
-      util::fromTimestampString("2021-05-31 13:29:21.213"),
+      fromTimestampString("2021-05-31 13:29:21.213"),
       parseMysql("213.21:29:13 22 2021", "%f.%s:%i:%H %v %x"));
 }
 
 TEST_F(MysqlDateTimeTest, parseFractionOfSecond) {
   // Assert on difference in milliseconds.
   EXPECT_NE(
-      util::fromTimestampString("2022-02-23 12:15:00.223"),
+      fromTimestampString("2022-02-23 12:15:00.223"),
       parseMysql("2022-02-23T12:15:00.776", "%Y-%m-%dT%H:%i:%s.%f"));
 
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00.000"),
-      parseMysql("000", "%f"));
+      fromTimestampString("1970-01-01 00:00:00.000"), parseMysql("000", "%f"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00.001"),
-      parseMysql("001", "%f"));
+      fromTimestampString("1970-01-01 00:00:00.001"), parseMysql("001", "%f"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00.999"),
-      parseMysql("999", "%f"));
+      fromTimestampString("1970-01-01 00:00:00.999"), parseMysql("999", "%f"));
 
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00.045"),
-      parseMysql("045", "%f"));
+      fromTimestampString("1970-01-01 00:00:00.045"), parseMysql("045", "%f"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00.450"),
-      parseMysql("45", "%f"));
+      fromTimestampString("1970-01-01 00:00:00.450"), parseMysql("45", "%f"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00.450"),
-      parseMysql("45", "%f"));
+      fromTimestampString("1970-01-01 00:00:00.450"), parseMysql("45", "%f"));
 
   EXPECT_THROW(parseMysql("-1", "%f"), VeloxUserError);
   EXPECT_THROW(parseMysql("9999999", "%f"), VeloxUserError);
 }
 
 TEST_F(MysqlDateTimeTest, parseConsecutiveSpecifiers) {
-  EXPECT_EQ(
-      util::fromTimestampString("2012-12-01"), parseMysql("1212", "%y%m"));
-  EXPECT_EQ(
-      util::fromTimestampString("0012-12-01"), parseMysql("1212", "%m%Y"));
+  EXPECT_EQ(fromTimestampString("2012-12-01"), parseMysql("1212", "%y%m"));
+  EXPECT_EQ(fromTimestampString("0012-12-01"), parseMysql("1212", "%m%Y"));
   EXPECT_THROW(parseMysql("1212", "%Y%m"), VeloxUserError);
 
   EXPECT_EQ(
-      util::fromTimestampString("2012-01-01 12:00:00"),
-      parseMysql("1212", "%y%H"));
+      fromTimestampString("2012-01-01 12:00:00"), parseMysql("1212", "%y%H"));
   EXPECT_EQ(
-      util::fromTimestampString("0012-01-01 12:00:00"),
-      parseMysql("1212", "%H%Y"));
+      fromTimestampString("0012-01-01 12:00:00"), parseMysql("1212", "%H%Y"));
   EXPECT_THROW(parseMysql("1212", "%Y%H"), VeloxUserError);
 }
 

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -1260,11 +1260,16 @@ template <typename T>
 struct FromIso8601Date {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE void call(
-      out_type<Date>& result,
-      const arg_type<Varchar>& input) {
-    result = util::castFromDateString(
+  FOLLY_ALWAYS_INLINE Status
+  call(out_type<Date>& result, const arg_type<Varchar>& input) {
+    const auto castResult = util::castFromDateString(
         input.data(), input.size(), util::ParseMode::kNonStandardNoTimeCast);
+    if (castResult.hasError()) {
+      return castResult.error();
+    }
+
+    result = castResult.value();
+    return Status::OK();
   }
 };
 

--- a/velox/functions/prestosql/tests/ComparisonsTest.cpp
+++ b/velox/functions/prestosql/tests/ComparisonsTest.cpp
@@ -111,15 +111,17 @@ TEST_F(ComparisonsTest, betweenDate) {
 }
 
 TEST_F(ComparisonsTest, betweenTimestamp) {
-  using util::fromTimestampString;
-
   const auto between = [&](std::optional<std::string> s) {
     auto expr =
         "c0 between cast(\'2019-02-28 10:00:00.500\' as timestamp) and"
         " cast(\'2019-02-28 10:00:00.600\' as timestamp)";
     if (s.has_value()) {
-      return evaluateOnce<bool>(
-          expr, std::optional(fromTimestampString((StringView)s.value())));
+      const auto ts =
+          util::fromTimestampString((StringView)s.value())
+              .thenOrThrow(folly::identity, [&](const Status& status) {
+                VELOX_USER_FAIL("{}", status.message());
+              });
+      return evaluateOnce<bool>(expr, std::optional(ts));
     }
     return evaluateOnce<bool>(expr, std::optional<Timestamp>());
   };

--- a/velox/functions/prestosql/tests/SequenceTest.cpp
+++ b/velox/functions/prestosql/tests/SequenceTest.cpp
@@ -26,6 +26,12 @@ namespace {
 
 class SequenceTest : public FunctionBaseTest {
  protected:
+  static Timestamp fromTimestampString(const StringView& timestamp) {
+    return util::fromTimestampString(timestamp).thenOrThrow(
+        folly::identity,
+        [&](const Status& status) { VELOX_USER_FAIL("{}", status.message()); });
+  }
+
   void testExpression(
       const std::string& expression,
       const std::vector<VectorPtr>& input,
@@ -397,48 +403,47 @@ TEST_F(SequenceTest, timestampInvalidIntervalStep) {
 
 TEST_F(SequenceTest, timestampYearMonthStep) {
   const auto startVector = makeFlatVector<Timestamp>(
-      {facebook::velox::util::fromTimestampString("1975-01-31 10:00:00.500"),
-       facebook::velox::util::fromTimestampString("1975-03-15 10:10:10.200"),
-       facebook::velox::util::fromTimestampString("2023-12-31 23:00:00.500")});
+      {fromTimestampString("1975-01-31 10:00:00.500"),
+       fromTimestampString("1975-03-15 10:10:10.200"),
+       fromTimestampString("2023-12-31 23:00:00.500")});
   const auto stopVector = makeFlatVector<Timestamp>(
-      {facebook::velox::util::fromTimestampString("1975-06-01 01:00:00.500"),
-       facebook::velox::util::fromTimestampString("1974-12-15 10:20:00.500"),
-       facebook::velox::util::fromTimestampString("2024-05-31 10:00:00.500")});
+      {fromTimestampString("1975-06-01 01:00:00.500"),
+       fromTimestampString("1974-12-15 10:20:00.500"),
+       fromTimestampString("2024-05-31 10:00:00.500")});
 
   const auto stepVector =
       makeFlatVector<int32_t>({1, -1, 2}, INTERVAL_YEAR_MONTH());
   const auto expected = makeArrayVector<Timestamp>(
       {// last day of Feb
-       {facebook::velox::util::fromTimestampString("1975-01-31 10:00:00.500"),
-        facebook::velox::util::fromTimestampString("1975-02-28 10:00:00.500"),
-        facebook::velox::util::fromTimestampString("1975-03-31 10:00:00.500"),
-        facebook::velox::util::fromTimestampString("1975-04-30 10:00:00.500"),
-        facebook::velox::util::fromTimestampString("1975-05-31 10:00:00.500")},
+       {fromTimestampString("1975-01-31 10:00:00.500"),
+        fromTimestampString("1975-02-28 10:00:00.500"),
+        fromTimestampString("1975-03-31 10:00:00.500"),
+        fromTimestampString("1975-04-30 10:00:00.500"),
+        fromTimestampString("1975-05-31 10:00:00.500")},
        // date is the same but timestamp is different so couldn't include
        // 1974-12-15 10:10:10.200
        // negative step
-       {facebook::velox::util::fromTimestampString("1975-03-15 10:10:10.200"),
-        facebook::velox::util::fromTimestampString("1975-02-15 10:10:10.200"),
-        facebook::velox::util::fromTimestampString("1975-01-15 10:10:10.200")},
+       {fromTimestampString("1975-03-15 10:10:10.200"),
+        fromTimestampString("1975-02-15 10:10:10.200"),
+        fromTimestampString("1975-01-15 10:10:10.200")},
        // leap year
        // result won't include 2024-05-31 10:00:00.500
-       {facebook::velox::util::fromTimestampString("2023-12-31 23:00:00.500"),
-        facebook::velox::util::fromTimestampString("2024-02-29 23:00:00.500"),
-        facebook::velox::util::fromTimestampString(
-            "2024-04-30 23:00:00.500")}});
+       {fromTimestampString("2023-12-31 23:00:00.500"),
+        fromTimestampString("2024-02-29 23:00:00.500"),
+        fromTimestampString("2024-04-30 23:00:00.500")}});
   testExpression(
       "sequence(C0, C1, C2)", {startVector, stopVector, stepVector}, expected);
 }
 
 TEST_F(SequenceTest, timestampInvalidYearMonthStep) {
   const auto startVector = makeFlatVector<Timestamp>(
-      {facebook::velox::util::fromTimestampString("1975-01-31 10:00:00.500"),
-       facebook::velox::util::fromTimestampString("1975-03-15 10:10:10.200"),
-       facebook::velox::util::fromTimestampString("2023-12-31 23:00:00.500")});
+      {fromTimestampString("1975-01-31 10:00:00.500"),
+       fromTimestampString("1975-03-15 10:10:10.200"),
+       fromTimestampString("2023-12-31 23:00:00.500")});
   const auto stopVector = makeFlatVector<Timestamp>(
-      {facebook::velox::util::fromTimestampString("1975-06-01 01:00:00.500"),
-       facebook::velox::util::fromTimestampString("1974-12-15 10:20:00.500"),
-       facebook::velox::util::fromTimestampString("2024-05-31 10:00:00.500")});
+      {fromTimestampString("1975-06-01 01:00:00.500"),
+       fromTimestampString("1974-12-15 10:20:00.500"),
+       fromTimestampString("2024-05-31 10:00:00.500")});
 
   auto stepVector = makeFlatVector<int32_t>({0, 0, 0}, INTERVAL_DAY_TIME());
   testExpressionWithError(
@@ -456,19 +461,17 @@ TEST_F(SequenceTest, timestampInvalidYearMonthStep) {
 
   auto expected = makeNullableArrayVector<Timestamp>(
       {// last day of Feb
-       {{facebook::velox::util::fromTimestampString("1975-01-31 10:00:00.500"),
-         facebook::velox::util::fromTimestampString("1975-02-28 10:00:00.500"),
-         facebook::velox::util::fromTimestampString("1975-03-31 10:00:00.500"),
-         facebook::velox::util::fromTimestampString("1975-04-30 10:00:00.500"),
-         facebook::velox::util::fromTimestampString(
-             "1975-05-31 10:00:00.500")}},
+       {{fromTimestampString("1975-01-31 10:00:00.500"),
+         fromTimestampString("1975-02-28 10:00:00.500"),
+         fromTimestampString("1975-03-31 10:00:00.500"),
+         fromTimestampString("1975-04-30 10:00:00.500"),
+         fromTimestampString("1975-05-31 10:00:00.500")}},
        std::nullopt,
        // leap year
        // result won't include 2024-05-31 10:00:00.500
-       {{facebook::velox::util::fromTimestampString("2023-12-31 23:00:00.500"),
-         facebook::velox::util::fromTimestampString("2024-02-29 23:00:00.500"),
-         facebook::velox::util::fromTimestampString(
-             "2024-04-30 23:00:00.500")}}});
+       {{fromTimestampString("2023-12-31 23:00:00.500"),
+         fromTimestampString("2024-02-29 23:00:00.500"),
+         fromTimestampString("2024-04-30 23:00:00.500")}}});
   testExpression(
       "try(sequence(C0, C1, C2))",
       {startVector, stopVector, stepVector},
@@ -477,13 +480,13 @@ TEST_F(SequenceTest, timestampInvalidYearMonthStep) {
 
 TEST_F(SequenceTest, timestampIntervalExceedMaxEntries) {
   const auto startVector = makeFlatVector<Timestamp>(
-      {facebook::velox::util::fromTimestampString("1975-01-31 10:00:00.500"),
-       facebook::velox::util::fromTimestampString("1975-03-15 10:10:10.200"),
-       facebook::velox::util::fromTimestampString("2023-12-31 23:00:00.500")});
+      {fromTimestampString("1975-01-31 10:00:00.500"),
+       fromTimestampString("1975-03-15 10:10:10.200"),
+       fromTimestampString("2023-12-31 23:00:00.500")});
   const auto stopVector = makeFlatVector<Timestamp>(
-      {facebook::velox::util::fromTimestampString("3975-06-01 01:00:00.500"),
-       facebook::velox::util::fromTimestampString("3974-12-15 10:20:00.500"),
-       facebook::velox::util::fromTimestampString("4024-05-31 10:00:00.500")});
+      {fromTimestampString("3975-06-01 01:00:00.500"),
+       fromTimestampString("3974-12-15 10:20:00.500"),
+       fromTimestampString("4024-05-31 10:00:00.500")});
   auto stepVector = makeFlatVector<int32_t>({1, 1, 1}, INTERVAL_YEAR_MONTH());
   testExpressionWithError(
       "sequence(C0, C1, C2)",

--- a/velox/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
+++ b/velox/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
@@ -22,6 +22,12 @@ using namespace facebook::velox;
 
 class TimestampWithTimeZoneCastTest : public functions::test::CastBaseTest {
  public:
+  static Timestamp fromTimestampString(const StringView& timestamp) {
+    return util::fromTimestampString(timestamp).thenOrThrow(
+        folly::identity,
+        [&](const Status& status) { VELOX_USER_FAIL("{}", status.message()); });
+  }
+
   VectorPtr makeTimestampWithTimeZoneVector(
       vector_size_t size,
       const std::function<int64_t(int32_t row)>& timestampAt,
@@ -79,9 +85,9 @@ TEST_F(TimestampWithTimeZoneCastTest, fromVarchar) {
   // '2012-10-31 01:00:47' in Denver. Below, we use UTC representations of the
   // above local wall-clocks, to match the UTC timepoints held in the
   // TimestampWithTimezone type.
-  auto denverUTC = util::fromTimestampString("2012-10-31 07:00:47").toMillis();
-  auto viennaUTC = util::fromTimestampString("1994-05-06 13:49:00").toMillis();
-  auto chathamUTC = util::fromTimestampString("1979-02-23 18:48:31").toMillis();
+  auto denverUTC = fromTimestampString("2012-10-31 07:00:47").toMillis();
+  auto viennaUTC = fromTimestampString("1994-05-06 13:49:00").toMillis();
+  auto chathamUTC = fromTimestampString("1979-02-23 18:48:31").toMillis();
 
   auto timestamps = std::vector<int64_t>{
       0, denverUTC, denverUTC, viennaUTC, chathamUTC, chathamUTC};
@@ -108,7 +114,7 @@ TEST_F(TimestampWithTimeZoneCastTest, fromVarcharWithoutTimezone) {
 
   const auto stringVector =
       makeNullableFlatVector<StringView>({"2012-10-31 01:00:47"});
-  auto denverUTC = util::fromTimestampString("2012-10-31 07:00:47").toMillis();
+  auto denverUTC = fromTimestampString("2012-10-31 07:00:47").toMillis();
 
   auto timestamps = std::vector<int64_t>{denverUTC};
 
@@ -136,7 +142,7 @@ TEST_F(TimestampWithTimeZoneCastTest, fromVarcharInvalidInput) {
   const auto invalidStringVector4 = makeNullableFlatVector<StringView>(
       {"2012-10-31 35:00:47 America/Los_Angeles"});
 
-  auto millis = util::fromTimestampString("2012-10-31 07:00:47").toMillis();
+  auto millis = fromTimestampString("2012-10-31 07:00:47").toMillis();
   auto timestamps = std::vector<int64_t>{millis};
 
   auto timezones =

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -20,11 +20,13 @@
 
 namespace facebook::velox::functions::sparksql {
 
-Timestamp SparkCastHooks::castStringToTimestamp(const StringView& view) const {
+Expected<Timestamp> SparkCastHooks::castStringToTimestamp(
+    const StringView& view) const {
   return util::fromTimestampString(view.data(), view.size());
 }
 
-int32_t SparkCastHooks::castStringToDate(const StringView& dateString) const {
+Expected<int32_t> SparkCastHooks::castStringToDate(
+    const StringView& dateString) const {
   // Allows all patterns supported by Spark:
   // `[+-]yyyy*`
   // `[+-]yyyy*-[m]m`

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -24,11 +24,13 @@ namespace facebook::velox::functions::sparksql {
 class SparkCastHooks : public exec::CastHooks {
  public:
   // TODO: Spark hook allows more string patterns than Presto.
-  Timestamp castStringToTimestamp(const StringView& view) const override;
+  Expected<Timestamp> castStringToTimestamp(
+      const StringView& view) const override;
 
   /// 1) Removes all leading and trailing UTF8 white-spaces before cast. 2) Uses
   /// non-standard cast mode to cast from string to date.
-  int32_t castStringToDate(const StringView& dateString) const override;
+  Expected<int32_t> castStringToDate(
+      const StringView& dateString) const override;
 
   bool legacy() const override {
     return false;

--- a/velox/functions/sparksql/tests/MakeTimestampTest.cpp
+++ b/velox/functions/sparksql/tests/MakeTimestampTest.cpp
@@ -29,6 +29,12 @@ class MakeTimestampTest : public SparkFunctionBaseTest {
         {core::QueryConfig::kAdjustTimestampToTimezone, "true"},
     });
   }
+
+  static Timestamp fromTimestampString(const StringView& timestamp) {
+    return util::fromTimestampString(timestamp).thenOrThrow(
+        folly::identity,
+        [&](const Status& status) { VELOX_USER_FAIL("{}", status.message()); });
+  }
 };
 
 TEST_F(MakeTimestampTest, basic) {
@@ -63,20 +69,20 @@ TEST_F(MakeTimestampTest, basic) {
 
     setQueryTimeZone("GMT");
     auto expectedGMT = makeNullableFlatVector<Timestamp>(
-        {util::fromTimestampString("2021-07-11 06:30:45.678"),
-         util::fromTimestampString("2021-07-11 06:30:01"),
-         util::fromTimestampString("2021-07-11 06:31:00"),
-         util::fromTimestampString("2021-07-11 06:30:59.999999"),
+        {fromTimestampString("2021-07-11 06:30:45.678"),
+         fromTimestampString("2021-07-11 06:30:01"),
+         fromTimestampString("2021-07-11 06:31:00"),
+         fromTimestampString("2021-07-11 06:30:59.999999"),
          std::nullopt});
     testMakeTimestamp(data, expectedGMT, false);
     testConstantTimezone(data, "GMT", expectedGMT);
 
     setQueryTimeZone("Asia/Shanghai");
     auto expectedSessionTimezone = makeNullableFlatVector<Timestamp>(
-        {util::fromTimestampString("2021-07-10 22:30:45.678"),
-         util::fromTimestampString("2021-07-10 22:30:01"),
-         util::fromTimestampString("2021-07-10 22:31:00"),
-         util::fromTimestampString("2021-07-10 22:30:59.999999"),
+        {fromTimestampString("2021-07-10 22:30:45.678"),
+         fromTimestampString("2021-07-10 22:30:01"),
+         fromTimestampString("2021-07-10 22:31:00"),
+         fromTimestampString("2021-07-10 22:30:59.999999"),
          std::nullopt});
     testMakeTimestamp(data, expectedSessionTimezone, false);
     // Session time zone will be ignored if time zone is specified in argument.
@@ -99,8 +105,8 @@ TEST_F(MakeTimestampTest, basic) {
         makeRowVector({year, month, day, hour, minute, micros, timeZone});
     // Session time zone will be ignored if time zone is specified in argument.
     auto expected = makeNullableFlatVector<Timestamp>(
-        {util::fromTimestampString("2021-07-11 06:30:45.678"),
-         util::fromTimestampString("2021-07-11 04:30:45.678"),
+        {fromTimestampString("2021-07-11 06:30:45.678"),
+         fromTimestampString("2021-07-11 04:30:45.678"),
          std::nullopt});
     testMakeTimestamp(data, expected, true);
   }

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -128,9 +128,12 @@ inline int64_t fromDateString(const StringView& str) {
 /// ParseMode. Refer to ParseMode enum for further info.
 ///
 /// Throws VeloxUserError if the format or date is invalid.
-int32_t castFromDateString(const char* buf, size_t len, ParseMode mode);
+Expected<int32_t>
+castFromDateString(const char* buf, size_t len, ParseMode mode);
 
-inline int32_t castFromDateString(const StringView& str, ParseMode mode) {
+inline Expected<int32_t> castFromDateString(
+    const StringView& str,
+    ParseMode mode) {
   return castFromDateString(str.data(), str.size(), mode);
 }
 
@@ -171,9 +174,9 @@ inline int64_t fromTimeString(const StringView& str) {
 ///
 /// For a timezone-aware version of this function, check
 /// `fromTimestampWithTimezoneString()` below.
-Timestamp fromTimestampString(const char* buf, size_t len);
+Expected<Timestamp> fromTimestampString(const char* buf, size_t len);
 
-inline Timestamp fromTimestampString(const StringView& str) {
+inline Expected<Timestamp> fromTimestampString(const StringView& str) {
   return fromTimestampString(str.data(), str.size());
 }
 
@@ -193,11 +196,12 @@ inline Timestamp fromTimestampString(const StringView& str) {
 ///
 /// -1 means no timezone information was found. Throws VeloxUserError in case of
 /// parsing errors.
-std::pair<Timestamp, int64_t> fromTimestampWithTimezoneString(
+Expected<std::pair<Timestamp, int64_t>> fromTimestampWithTimezoneString(
     const char* buf,
     size_t len);
 
-inline auto fromTimestampWithTimezoneString(const StringView& str) {
+inline Expected<std::pair<Timestamp, int64_t>> fromTimestampWithTimezoneString(
+    const StringView& str) {
   return fromTimestampWithTimezoneString(str.data(), str.size());
 }
 

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -25,6 +25,27 @@
 namespace facebook::velox::util {
 namespace {
 
+Timestamp parseTimestamp(const StringView& timestamp) {
+  return fromTimestampString(timestamp).thenOrThrow(
+      folly::identity,
+      [&](const Status& status) { VELOX_USER_FAIL("{}", status.message()); });
+}
+
+int32_t parseDate(const StringView& str, ParseMode mode) {
+  return castFromDateString(str.data(), str.size(), mode)
+      .thenOrThrow(folly::identity, [&](const Status& status) {
+        VELOX_USER_FAIL("{}", status.message());
+      });
+}
+
+std::pair<Timestamp, int64_t> parseTimestampWithTimezone(
+    const StringView& str) {
+  return fromTimestampWithTimezoneString(str.data(), str.size())
+      .thenOrThrow(folly::identity, [&](const Status& status) {
+        VELOX_USER_FAIL("{}", status.message());
+      });
+}
+
 TEST(DateTimeUtilTest, fromDate) {
   auto testDaysSinceEpochFromDate =
       [](int32_t year, int32_t month, int32_t day) {
@@ -134,36 +155,29 @@ TEST(DateTimeUtilTest, fromDateStrInvalid) {
 TEST(DateTimeUtilTest, castFromDateString) {
   for (ParseMode mode :
        {ParseMode::kStandardCast, ParseMode::kNonStandardCast}) {
-    EXPECT_EQ(0, castFromDateString("1970-01-01", mode));
-    EXPECT_EQ(3789742, castFromDateString("12345-12-18", mode));
+    EXPECT_EQ(0, parseDate("1970-01-01", mode));
+    EXPECT_EQ(3789742, parseDate("12345-12-18", mode));
 
-    EXPECT_EQ(1, castFromDateString("1970-1-2", mode));
-    EXPECT_EQ(1, castFromDateString("1970-01-2", mode));
-    EXPECT_EQ(1, castFromDateString("1970-1-02", mode));
+    EXPECT_EQ(1, parseDate("1970-1-2", mode));
+    EXPECT_EQ(1, parseDate("1970-01-2", mode));
+    EXPECT_EQ(1, parseDate("1970-1-02", mode));
 
-    EXPECT_EQ(1, castFromDateString("+1970-01-02", mode));
-    EXPECT_EQ(-719893, castFromDateString("-1-1-1", mode));
+    EXPECT_EQ(1, parseDate("+1970-01-02", mode));
+    EXPECT_EQ(-719893, parseDate("-1-1-1", mode));
 
-    EXPECT_EQ(0, castFromDateString(" 1970-01-01", mode));
+    EXPECT_EQ(0, parseDate(" 1970-01-01", mode));
   }
 
-  EXPECT_EQ(3789391, castFromDateString("12345", ParseMode::kNonStandardCast));
-  EXPECT_EQ(16436, castFromDateString("2015", ParseMode::kNonStandardCast));
-  EXPECT_EQ(16495, castFromDateString("2015-03", ParseMode::kNonStandardCast));
-  EXPECT_EQ(
-      16512, castFromDateString("2015-03-18T", ParseMode::kNonStandardCast));
-  EXPECT_EQ(
-      16512,
-      castFromDateString("2015-03-18T123123", ParseMode::kNonStandardCast));
-  EXPECT_EQ(
-      16512,
-      castFromDateString("2015-03-18 123142", ParseMode::kNonStandardCast));
-  EXPECT_EQ(
-      16512,
-      castFromDateString("2015-03-18 (BC)", ParseMode::kNonStandardCast));
+  EXPECT_EQ(3789391, parseDate("12345", ParseMode::kNonStandardCast));
+  EXPECT_EQ(16436, parseDate("2015", ParseMode::kNonStandardCast));
+  EXPECT_EQ(16495, parseDate("2015-03", ParseMode::kNonStandardCast));
+  EXPECT_EQ(16512, parseDate("2015-03-18T", ParseMode::kNonStandardCast));
+  EXPECT_EQ(16512, parseDate("2015-03-18T123123", ParseMode::kNonStandardCast));
+  EXPECT_EQ(16512, parseDate("2015-03-18 123142", ParseMode::kNonStandardCast));
+  EXPECT_EQ(16512, parseDate("2015-03-18 (BC)", ParseMode::kNonStandardCast));
 
-  EXPECT_EQ(0, castFromDateString("1970-01-01 ", ParseMode::kNonStandardCast));
-  EXPECT_EQ(0, castFromDateString(" 1970-01-01 ", ParseMode::kNonStandardCast));
+  EXPECT_EQ(0, parseDate("1970-01-01 ", ParseMode::kNonStandardCast));
+  EXPECT_EQ(0, parseDate(" 1970-01-01 ", ParseMode::kNonStandardCast));
 }
 
 TEST(DateTimeUtilTest, castFromDateStringInvalid) {
@@ -171,7 +185,7 @@ TEST(DateTimeUtilTest, castFromDateStringInvalid) {
                                            ParseMode mode) {
     if (mode == ParseMode::kStandardCast) {
       VELOX_ASSERT_THROW(
-          castFromDateString(str, mode),
+          parseDate(str, mode),
           fmt::format(
               "Unable to parse date value: \"{}\". "
               "Valid date string pattern is (YYYY-MM-DD), "
@@ -179,7 +193,7 @@ TEST(DateTimeUtilTest, castFromDateStringInvalid) {
               std::string(str.data(), str.size())));
     } else if (mode == ParseMode::kNonStandardCast) {
       VELOX_ASSERT_THROW(
-          castFromDateString(str, mode),
+          parseDate(str, mode),
           fmt::format(
               "Unable to parse date value: \"{}\". "
               "Valid date string patterns include "
@@ -189,7 +203,7 @@ TEST(DateTimeUtilTest, castFromDateStringInvalid) {
               std::string(str.data(), str.size())));
     } else if (mode == ParseMode::kNonStandardNoTimeCast) {
       VELOX_ASSERT_THROW(
-          castFromDateString(str, mode),
+          parseDate(str, mode),
           fmt::format(
               "Unable to parse date value: \"{}\". "
               "Valid date string patterns include "
@@ -274,19 +288,16 @@ TEST(DateTimeUtilTest, fromTimeStrInvalid) {
 // $ date -d "2000-01-01 12:21:56Z" +%s
 // ('Z' at the end means UTC).
 TEST(DateTimeUtilTest, fromTimestampString) {
-  EXPECT_EQ(Timestamp(0, 0), fromTimestampString("1970-01-01"));
-  EXPECT_EQ(Timestamp(946684800, 0), fromTimestampString("2000-01-01"));
+  EXPECT_EQ(Timestamp(0, 0), parseTimestamp("1970-01-01"));
+  EXPECT_EQ(Timestamp(946684800, 0), parseTimestamp("2000-01-01"));
 
-  EXPECT_EQ(Timestamp(0, 0), fromTimestampString("1970-01-01 00:00"));
-  EXPECT_EQ(Timestamp(0, 0), fromTimestampString("1970-01-01 00:00:00"));
-  EXPECT_EQ(Timestamp(0, 0), fromTimestampString("1970-01-01 00:00:00    "));
+  EXPECT_EQ(Timestamp(0, 0), parseTimestamp("1970-01-01 00:00"));
+  EXPECT_EQ(Timestamp(0, 0), parseTimestamp("1970-01-01 00:00:00"));
+  EXPECT_EQ(Timestamp(0, 0), parseTimestamp("1970-01-01 00:00:00    "));
 
-  EXPECT_EQ(
-      Timestamp(946729316, 0), fromTimestampString("2000-01-01 12:21:56"));
-  EXPECT_EQ(
-      Timestamp(946729316, 0), fromTimestampString("2000-01-01T12:21:56"));
-  EXPECT_EQ(
-      Timestamp(946729316, 0), fromTimestampString("2000-01-01T 12:21:56"));
+  EXPECT_EQ(Timestamp(946729316, 0), parseTimestamp("2000-01-01 12:21:56"));
+  EXPECT_EQ(Timestamp(946729316, 0), parseTimestamp("2000-01-01T12:21:56"));
+  EXPECT_EQ(Timestamp(946729316, 0), parseTimestamp("2000-01-01T 12:21:56"));
 }
 
 TEST(DateTimeUtilTest, fromTimestampStringInvalid) {
@@ -295,66 +306,60 @@ TEST(DateTimeUtilTest, fromTimestampStringInvalid) {
   const std::string_view timezoneError = "Unknown timezone value: ";
 
   // Needs at least a date.
-  VELOX_ASSERT_THROW(fromTimestampString(""), parserError);
-  VELOX_ASSERT_THROW(fromTimestampString("00:00:00"), parserError);
+  VELOX_ASSERT_THROW(parseTimestamp(""), parserError);
+  VELOX_ASSERT_THROW(parseTimestamp("00:00:00"), parserError);
 
   // Integer overflow during timestamp parsing.
   VELOX_ASSERT_THROW(
-      fromTimestampString("2773581570-01-01 00:00:00-asd"), overflowError);
+      parseTimestamp("2773581570-01-01 00:00:00-asd"), overflowError);
   VELOX_ASSERT_THROW(
-      fromTimestampString("-2147483648-01-01 00:00:00-asd"), overflowError);
+      parseTimestamp("-2147483648-01-01 00:00:00-asd"), overflowError);
 
   // Unexpected timezone definition.
+  VELOX_ASSERT_THROW(parseTimestamp("1970-01-01 00:00:00     a"), parserError);
+  VELOX_ASSERT_THROW(parseTimestamp("1970-01-01 00:00:00Z"), parserError);
+  VELOX_ASSERT_THROW(parseTimestamp("1970-01-01 00:00:00Z"), parserError);
+  VELOX_ASSERT_THROW(parseTimestamp("1970-01-01 00:00:00 UTC"), parserError);
   VELOX_ASSERT_THROW(
-      fromTimestampString("1970-01-01 00:00:00     a"), parserError);
-  VELOX_ASSERT_THROW(fromTimestampString("1970-01-01 00:00:00Z"), parserError);
-  VELOX_ASSERT_THROW(fromTimestampString("1970-01-01 00:00:00Z"), parserError);
-  VELOX_ASSERT_THROW(
-      fromTimestampString("1970-01-01 00:00:00 UTC"), parserError);
-  VELOX_ASSERT_THROW(
-      fromTimestampString("1970-01-01 00:00:00 America/Los_Angeles"),
-      parserError);
+      parseTimestamp("1970-01-01 00:00:00 America/Los_Angeles"), parserError);
 
   // Parse timestamp with (broken) timezones.
   VELOX_ASSERT_THROW(
-      fromTimestampWithTimezoneString("1970-01-01 00:00:00-asd"),
-      timezoneError);
+      parseTimestampWithTimezone("1970-01-01 00:00:00-asd"), timezoneError);
   VELOX_ASSERT_THROW(
-      fromTimestampWithTimezoneString("1970-01-01 00:00:00Z UTC"), parserError);
+      parseTimestampWithTimezone("1970-01-01 00:00:00Z UTC"), parserError);
   VELOX_ASSERT_THROW(
-      fromTimestampWithTimezoneString("1970-01-01 00:00:00+00:00:00"),
+      parseTimestampWithTimezone("1970-01-01 00:00:00+00:00:00"),
       timezoneError);
 
   // Can't have multiple spaces.
   VELOX_ASSERT_THROW(
-      fromTimestampWithTimezoneString("1970-01-01 00:00:00  UTC"),
-      timezoneError);
+      parseTimestampWithTimezone("1970-01-01 00:00:00  UTC"), timezoneError);
 }
 
 TEST(DateTimeUtilTest, fromTimestampWithTimezoneString) {
   // -1 means no timezone information.
   auto expected = std::make_pair<Timestamp, int64_t>(Timestamp(0, 0), -1);
-  EXPECT_EQ(fromTimestampWithTimezoneString("1970-01-01 00:00:00"), expected);
+  EXPECT_EQ(parseTimestampWithTimezone("1970-01-01 00:00:00"), expected);
 
   // Test timezone offsets.
   EXPECT_EQ(
-      fromTimestampWithTimezoneString("1970-01-01 00:00:00 -02:00"),
+      parseTimestampWithTimezone("1970-01-01 00:00:00 -02:00"),
       std::make_pair(Timestamp(0, 0), util::getTimeZoneID("-02:00")));
   EXPECT_EQ(
-      fromTimestampWithTimezoneString("1970-01-01 00:00:00+13:36"),
+      parseTimestampWithTimezone("1970-01-01 00:00:00+13:36"),
       std::make_pair(Timestamp(0, 0), util::getTimeZoneID("+13:36")));
 
   EXPECT_EQ(
-      fromTimestampWithTimezoneString("1970-01-01 00:00:00Z"),
+      parseTimestampWithTimezone("1970-01-01 00:00:00Z"),
       std::make_pair(Timestamp(0, 0), util::getTimeZoneID("UTC")));
 
   EXPECT_EQ(
-      fromTimestampWithTimezoneString("1970-01-01 00:01:00 UTC"),
+      parseTimestampWithTimezone("1970-01-01 00:01:00 UTC"),
       std::make_pair(Timestamp(60, 0), util::getTimeZoneID("UTC")));
 
   EXPECT_EQ(
-      fromTimestampWithTimezoneString(
-          "1970-01-01 00:00:01 America/Los_Angeles"),
+      parseTimestampWithTimezone("1970-01-01 00:00:01 America/Los_Angeles"),
       std::make_pair(
           Timestamp(1, 0), util::getTimeZoneID("America/Los_Angeles")));
 }
@@ -363,50 +368,50 @@ TEST(DateTimeUtilTest, toGMT) {
   auto* laZone = date::locate_zone("America/Los_Angeles");
 
   // The GMT time when LA gets to "1970-01-01 00:00:00" (8h ahead).
-  auto ts = fromTimestampString("1970-01-01 00:00:00");
+  auto ts = parseTimestamp("1970-01-01 00:00:00");
   ts.toGMT(*laZone);
-  EXPECT_EQ(ts, fromTimestampString("1970-01-01 08:00:00"));
+  EXPECT_EQ(ts, parseTimestamp("1970-01-01 08:00:00"));
 
   // Set on a random date/time and try some variations.
-  ts = fromTimestampString("2020-04-23 04:23:37");
+  ts = parseTimestamp("2020-04-23 04:23:37");
 
   // To LA:
   auto tsCopy = ts;
   tsCopy.toGMT(*laZone);
-  EXPECT_EQ(tsCopy, fromTimestampString("2020-04-23 11:23:37"));
+  EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 11:23:37"));
 
   // To Sao Paulo:
   tsCopy = ts;
   tsCopy.toGMT(*date::locate_zone("America/Sao_Paulo"));
-  EXPECT_EQ(tsCopy, fromTimestampString("2020-04-23 07:23:37"));
+  EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 07:23:37"));
 
   // Moscow:
   tsCopy = ts;
   tsCopy.toGMT(*date::locate_zone("Europe/Moscow"));
-  EXPECT_EQ(tsCopy, fromTimestampString("2020-04-23 01:23:37"));
+  EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 01:23:37"));
 
   // Probe LA's daylight savings boundary (starts at 2021-13-14 02:00am).
   // Before it starts, 8h offset:
-  ts = fromTimestampString("2021-03-14 00:00:00");
+  ts = parseTimestamp("2021-03-14 00:00:00");
   ts.toGMT(*laZone);
-  EXPECT_EQ(ts, fromTimestampString("2021-03-14 08:00:00"));
+  EXPECT_EQ(ts, parseTimestamp("2021-03-14 08:00:00"));
 
   // After it starts, 7h offset:
-  ts = fromTimestampString("2021-03-14 08:00:00");
+  ts = parseTimestamp("2021-03-14 08:00:00");
   ts.toGMT(*laZone);
-  EXPECT_EQ(ts, fromTimestampString("2021-03-14 15:00:00"));
+  EXPECT_EQ(ts, parseTimestamp("2021-03-14 15:00:00"));
 
   // Ambiguous time 2019-11-03 01:00:00.
   // It could be 2019-11-03 01:00:00 PDT == 2019-11-03 08:00:00 UTC
   // or 2019-11-03 01:00:00 PST == 2019-11-03 09:00:00 UTC.
-  ts = fromTimestampString("2019-11-03 01:00:00");
+  ts = parseTimestamp("2019-11-03 01:00:00");
   ts.toGMT(*laZone);
-  EXPECT_EQ(ts, fromTimestampString("2019-11-03 08:00:00"));
+  EXPECT_EQ(ts, parseTimestamp("2019-11-03 08:00:00"));
 
   // Nonexistent time 2019-03-10 02:00:00.
   // It is in a gap between 2019-03-10 02:00:00 PST and 2019-03-10 03:00:00 PDT
   // which are both equivalent to 2019-03-10 10:00:00 UTC.
-  ts = fromTimestampString("2019-03-10 02:00:00");
+  ts = parseTimestamp("2019-03-10 02:00:00");
   EXPECT_THROW(ts.toGMT(*laZone), VeloxUserError);
 }
 
@@ -414,152 +419,152 @@ TEST(DateTimeUtilTest, toTimezone) {
   auto* laZone = date::locate_zone("America/Los_Angeles");
 
   // The LA time when GMT gets to "1970-01-01 00:00:00" (8h behind).
-  auto ts = fromTimestampString("1970-01-01 00:00:00");
+  auto ts = parseTimestamp("1970-01-01 00:00:00");
   ts.toTimezone(*laZone);
-  EXPECT_EQ(ts, fromTimestampString("1969-12-31 16:00:00"));
+  EXPECT_EQ(ts, parseTimestamp("1969-12-31 16:00:00"));
 
   // Set on a random date/time and try some variations.
-  ts = fromTimestampString("2020-04-23 04:23:37");
+  ts = parseTimestamp("2020-04-23 04:23:37");
 
   // To LA:
   auto tsCopy = ts;
   tsCopy.toTimezone(*laZone);
-  EXPECT_EQ(tsCopy, fromTimestampString("2020-04-22 21:23:37"));
+  EXPECT_EQ(tsCopy, parseTimestamp("2020-04-22 21:23:37"));
 
   // To Sao Paulo:
   tsCopy = ts;
   tsCopy.toTimezone(*date::locate_zone("America/Sao_Paulo"));
-  EXPECT_EQ(tsCopy, fromTimestampString("2020-04-23 01:23:37"));
+  EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 01:23:37"));
 
   // Moscow:
   tsCopy = ts;
   tsCopy.toTimezone(*date::locate_zone("Europe/Moscow"));
-  EXPECT_EQ(tsCopy, fromTimestampString("2020-04-23 07:23:37"));
+  EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 07:23:37"));
 
   // Probe LA's daylight savings boundary (starts at 2021-13-14 02:00am).
   // Before it starts, 8h offset:
-  ts = fromTimestampString("2021-03-14 00:00:00");
+  ts = parseTimestamp("2021-03-14 00:00:00");
   ts.toTimezone(*laZone);
-  EXPECT_EQ(ts, fromTimestampString("2021-03-13 16:00:00"));
+  EXPECT_EQ(ts, parseTimestamp("2021-03-13 16:00:00"));
 
   // After it starts, 7h offset:
-  ts = fromTimestampString("2021-03-15 00:00:00");
+  ts = parseTimestamp("2021-03-15 00:00:00");
   ts.toTimezone(*laZone);
-  EXPECT_EQ(ts, fromTimestampString("2021-03-14 17:00:00"));
+  EXPECT_EQ(ts, parseTimestamp("2021-03-14 17:00:00"));
 }
 
 TEST(DateTimeUtilTest, toGMTFromID) {
   // The GMT time when LA gets to "1970-01-01 00:00:00" (8h ahead).
-  auto ts = fromTimestampString("1970-01-01 00:00:00");
+  auto ts = parseTimestamp("1970-01-01 00:00:00");
   ts.toGMT(util::getTimeZoneID("America/Los_Angeles"));
-  EXPECT_EQ(ts, fromTimestampString("1970-01-01 08:00:00"));
+  EXPECT_EQ(ts, parseTimestamp("1970-01-01 08:00:00"));
 
   // Set on a random date/time and try some variations.
-  ts = fromTimestampString("2020-04-23 04:23:37");
+  ts = parseTimestamp("2020-04-23 04:23:37");
 
   // To LA:
   auto tsCopy = ts;
   tsCopy.toGMT(util::getTimeZoneID("America/Los_Angeles"));
-  EXPECT_EQ(tsCopy, fromTimestampString("2020-04-23 11:23:37"));
+  EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 11:23:37"));
 
   // To Sao Paulo:
   tsCopy = ts;
   tsCopy.toGMT(util::getTimeZoneID("America/Sao_Paulo"));
-  EXPECT_EQ(tsCopy, fromTimestampString("2020-04-23 07:23:37"));
+  EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 07:23:37"));
 
   // Moscow:
   tsCopy = ts;
   tsCopy.toGMT(util::getTimeZoneID("Europe/Moscow"));
-  EXPECT_EQ(tsCopy, fromTimestampString("2020-04-23 01:23:37"));
+  EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 01:23:37"));
 
   // Numerical time zones: +HH:MM and -HH:MM
   tsCopy = ts;
   tsCopy.toGMT(util::getTimeZoneID("+14:00"));
-  EXPECT_EQ(tsCopy, fromTimestampString("2020-04-22 14:23:37"));
+  EXPECT_EQ(tsCopy, parseTimestamp("2020-04-22 14:23:37"));
 
   tsCopy = ts;
   tsCopy.toGMT(util::getTimeZoneID("-14:00"));
-  EXPECT_EQ(tsCopy, fromTimestampString("2020-04-23 18:23:37"));
+  EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 18:23:37"));
 
   tsCopy = ts;
   tsCopy.toGMT(0); // "+00:00" is not in the time zone id map
-  EXPECT_EQ(tsCopy, fromTimestampString("2020-04-23 04:23:37"));
+  EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 04:23:37"));
 
   tsCopy = ts;
   tsCopy.toGMT(util::getTimeZoneID("-00:01"));
-  EXPECT_EQ(tsCopy, fromTimestampString("2020-04-23 04:24:37"));
+  EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 04:24:37"));
 
   tsCopy = ts;
   tsCopy.toGMT(util::getTimeZoneID("+00:01"));
-  EXPECT_EQ(tsCopy, fromTimestampString("2020-04-23 04:22:37"));
+  EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 04:22:37"));
 
   // Probe LA's daylight savings boundary (starts at 2021-13-14 02:00am).
   // Before it starts, 8h offset:
-  ts = fromTimestampString("2021-03-14 00:00:00");
+  ts = parseTimestamp("2021-03-14 00:00:00");
   ts.toGMT(util::getTimeZoneID("America/Los_Angeles"));
-  EXPECT_EQ(ts, fromTimestampString("2021-03-14 08:00:00"));
+  EXPECT_EQ(ts, parseTimestamp("2021-03-14 08:00:00"));
 
   // After it starts, 7h offset:
-  ts = fromTimestampString("2021-03-15 00:00:00");
+  ts = parseTimestamp("2021-03-15 00:00:00");
   ts.toGMT(util::getTimeZoneID("America/Los_Angeles"));
-  EXPECT_EQ(ts, fromTimestampString("2021-03-15 07:00:00"));
+  EXPECT_EQ(ts, parseTimestamp("2021-03-15 07:00:00"));
 }
 
 TEST(DateTimeUtilTest, toTimezoneFromID) {
   // The LA time when GMT gets to "1970-01-01 00:00:00" (8h behind).
-  auto ts = fromTimestampString("1970-01-01 00:00:00");
+  auto ts = parseTimestamp("1970-01-01 00:00:00");
   ts.toTimezone(util::getTimeZoneID("America/Los_Angeles"));
-  EXPECT_EQ(ts, fromTimestampString("1969-12-31 16:00:00"));
+  EXPECT_EQ(ts, parseTimestamp("1969-12-31 16:00:00"));
 
   // Set on a random date/time and try some variations.
-  ts = fromTimestampString("2020-04-23 04:23:37");
+  ts = parseTimestamp("2020-04-23 04:23:37");
 
   // To LA:
   auto tsCopy = ts;
   tsCopy.toTimezone(util::getTimeZoneID("America/Los_Angeles"));
-  EXPECT_EQ(tsCopy, fromTimestampString("2020-04-22 21:23:37"));
+  EXPECT_EQ(tsCopy, parseTimestamp("2020-04-22 21:23:37"));
 
   // To Sao Paulo:
   tsCopy = ts;
   tsCopy.toTimezone(util::getTimeZoneID("America/Sao_Paulo"));
-  EXPECT_EQ(tsCopy, fromTimestampString("2020-04-23 01:23:37"));
+  EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 01:23:37"));
 
   // Moscow:
   tsCopy = ts;
   tsCopy.toTimezone(util::getTimeZoneID("Europe/Moscow"));
-  EXPECT_EQ(tsCopy, fromTimestampString("2020-04-23 07:23:37"));
+  EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 07:23:37"));
 
   // Numerical time zones: +HH:MM and -HH:MM
   tsCopy = ts;
   tsCopy.toTimezone(util::getTimeZoneID("+14:00"));
-  EXPECT_EQ(tsCopy, fromTimestampString("2020-04-23 18:23:37"));
+  EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 18:23:37"));
 
   tsCopy = ts;
   tsCopy.toTimezone(util::getTimeZoneID("-14:00"));
-  EXPECT_EQ(tsCopy, fromTimestampString("2020-04-22 14:23:37"));
+  EXPECT_EQ(tsCopy, parseTimestamp("2020-04-22 14:23:37"));
 
   tsCopy = ts;
   tsCopy.toTimezone(0); // "+00:00" is not in the time zone id map
-  EXPECT_EQ(tsCopy, fromTimestampString("2020-04-23 04:23:37"));
+  EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 04:23:37"));
 
   tsCopy = ts;
   tsCopy.toTimezone(util::getTimeZoneID("-00:01"));
-  EXPECT_EQ(tsCopy, fromTimestampString("2020-04-23 04:22:37"));
+  EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 04:22:37"));
 
   tsCopy = ts;
   tsCopy.toTimezone(util::getTimeZoneID("+00:01"));
-  EXPECT_EQ(tsCopy, fromTimestampString("2020-04-23 04:24:37"));
+  EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 04:24:37"));
 
   // Probe LA's daylight savings boundary (starts at 2021-13-14 02:00am).
   // Before it starts, 8h offset:
-  ts = fromTimestampString("2021-03-14 00:00:00");
+  ts = parseTimestamp("2021-03-14 00:00:00");
   ts.toTimezone(util::getTimeZoneID("America/Los_Angeles"));
-  EXPECT_EQ(ts, fromTimestampString("2021-03-13 16:00:00"));
+  EXPECT_EQ(ts, parseTimestamp("2021-03-13 16:00:00"));
 
   // After it starts, 7h offset:
-  ts = fromTimestampString("2021-03-15 00:00:00");
+  ts = parseTimestamp("2021-03-15 00:00:00");
   ts.toTimezone(util::getTimeZoneID("America/Los_Angeles"));
-  EXPECT_EQ(ts, fromTimestampString("2021-03-14 17:00:00"));
+  EXPECT_EQ(ts, parseTimestamp("2021-03-14 17:00:00"));
 }
 
 } // namespace


### PR DESCRIPTION
Make casts from VARCHAR to DATE and TIMESTAMP non-throwing.

Convert 'from_iso8601_date' Presto function to non-throwing.

These changes improve performance of casts from empty or invalid strings by
100x. Note that cast from empty string to TIMESTAMP has been optimized already,
hence, these changes do not improve that use case.

Before:

```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
cast_varhar_as_date##try_cast_invalid_empty_inp             12.42s    80.49m
cast_varhar_as_date##tryexpr_cast_invalid_empty             16.66s    60.01m
cast_varhar_as_date##try_cast_invalid_input                 12.43s    80.46m
cast_varhar_as_date##tryexpr_cast_invalid_input             16.86s    59.30m
cast_varhar_as_date##cast_valid                            35.18ms     28.43
----------------------------------------------------------------------------
cast_varhar_as_timestamp##try_cast_invalid_empt            26.31ms     38.00
cast_varhar_as_timestamp##tryexpr_cast_invalid_            54.89ms     18.22
cast_varhar_as_timestamp##try_cast_invalid_inpu              6.99s   143.12m
cast_varhar_as_timestamp##tryexpr_cast_invalid_              9.00s   111.17m
cast_varhar_as_timestamp##cast_valid                       43.74ms     22.86
----------------------------------------------------------------------------
```

After:

```
cast_varhar_as_date##try_cast_invalid_empty_inp            49.96ms     20.02
cast_varhar_as_date##tryexpr_cast_invalid_empty            83.63ms     11.96
cast_varhar_as_date##try_cast_invalid_input                59.09ms     16.92
cast_varhar_as_date##tryexpr_cast_invalid_input            96.01ms     10.42
cast_varhar_as_date##cast_valid                            35.89ms     27.86
----------------------------------------------------------------------------
cast_varhar_as_timestamp##try_cast_invalid_empt            25.88ms     38.64
cast_varhar_as_timestamp##tryexpr_cast_invalid_            51.45ms     19.43
cast_varhar_as_timestamp##try_cast_invalid_inpu            80.67ms     12.40
cast_varhar_as_timestamp##tryexpr_cast_invalid_           109.51ms      9.13
cast_varhar_as_timestamp##cast_valid                       49.48ms     20.21
----------------------------------------------------------------------------
```

Fixes https://github.com/facebookincubator/velox/issues/9914

Differential Revision: D57733757
