### PR TITLE
Remove unused-but-set variables in velox/exec/tests/TableWriteTest.cpp +1

### DIFF
--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -3919,9 +3919,7 @@ DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, tableFileWriteError) {
   VectorFuzzer fuzzer(options, pool());
   const int numBatches = 20;
   std::vector<RowVectorPtr> vectors;
-  int numRows{0};
   for (int i = 0; i < numBatches; ++i) {
-    numRows += batchSize;
     vectors.push_back(fuzzer.fuzzRow(rowType_));
   }
 


### PR DESCRIPTION
Summary:
This diff removes a variable that was set, but which was not used.

LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused but set variables often indicate a programming mistake, but can also just be unnecessary cruft that harms readability and performance.

Removing this variable will not change how your code works, but the unused variable may indicate your code isn't working the way you thought it was. If you feel the diff needs changes before landing, **please commandeer** and make appropriate changes: there are hundreds of these and responding to them individually is challenging.

For questions/comments, contact r-barnes.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: meyering

Differential Revision: D57761236


