### PR TITLE
Upgrade presto version for verification in window fuzzer

### DIFF
--- a/scripts/prestojava-container.dockerfile
+++ b/scripts/prestojava-container.dockerfile
@@ -15,7 +15,7 @@
 #
 FROM ghcr.io/facebookincubator/velox-dev:centos8 
 
-ARG PRESTO_VERSION=0.286
+ARG PRESTO_VERSION=0.287
 
 ADD scripts /velox/scripts/
 RUN wget https://repo1.maven.org/maven2/com/facebook/presto/presto-server/${PRESTO_VERSION}/presto-server-${PRESTO_VERSION}.tar.gz


### PR DESCRIPTION
Github action `Window Fuzzer with Presto as source of truth` is failing because linear 
regression functions added in [this commit](https://github.com/prestodb/presto/commit/d0b658e483a63914177a5e643b5e60dc6c649b4d) are missing in presto 0.286 
used for verification. Upgrades the presto version to 0.287 to resolve this issue.