### PR TITLE
Fix min and max aggregates for floating points

### DIFF
--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -117,24 +117,34 @@ General Aggregate Functions
     Returns the maximum value of all input values.
     ``x`` must not contain nulls when it is complex type.
     ``x`` must be an orderable type.
+    Nulls are ignored if there are any non-null inputs.
+    For REAL and DOUBLE types, NaN is considered greater than Infinity.
 
 .. function:: max(x, n) -> array<[same as x]>
     :noindex:
 
     Returns ``n`` largest values of all input values of ``x``.
     ``n`` must be a positive integer and not exceed 10'000.
+    Currently not supported for ARRAY, MAP, and ROW input types.
+    Nulls are not included in the output array.
+    For REAL and DOUBLE types, NaN is considered greater than Infinity.
 
 .. function:: min(x) -> [same as x]
 
     Returns the minimum value of all input values.
     ``x`` must not contain nulls when it is complex type.
     ``x`` must be an orderable type.
+    Nulls are ignored if there are any non-null inputs.
+    For REAL and DOUBLE types, NaN is considered greater than Infinity.
 
 .. function:: min(x, n) -> array<[same as x]>
     :noindex:
 
     Returns ``n`` smallest values of all input values of ``x``.
     ``n`` must be a positive integer and not exceed 10'000.
+    Currently not supported for ARRAY, MAP, and ROW input types.
+    Nulls are not included in output array.
+    For REAL and DOUBLE types, NaN is considered greater than Infinity.
 
 .. function:: multimap_agg(K key, V value) -> map(K,array(V))
 

--- a/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
@@ -104,6 +104,135 @@ class MinMaxTest : public functions::aggregate::test::AggregationTestBase {
         {agg(c1)},
         fmt::format("SELECT {} FROM tmp WHERE c0 % 2 = 0", agg(c1)));
   }
+
+  template <typename T>
+  void testExtremeFloatValues() {
+    // Tests to ensure that extreme floating point values are handled correctly,
+    // including, INF, -INF, NaN. This validates that the groups have initial
+    // value set correctly, (-INF for max() and NaN for min()) and NaN is
+    // considered greater than INF. Also tests for when floating points are
+    // nested inside complex types.
+    static const T kNaN = std::numeric_limits<T>::quiet_NaN();
+    static const T kSNaN = std::numeric_limits<T>::signaling_NaN();
+    static const T kInf = std::numeric_limits<T>::infinity();
+
+    auto data = makeRowVector({
+        // regular ordering
+        makeFlatVector<T>({2.0, kNaN, 1.1, kInf, -1.1}),
+        // with nulls
+        makeNullableFlatVector<T>({2.0, kNaN, std::nullopt, 1.1, -1.1}),
+        // only nans (use a different binary representation for NaN to verify
+        // that they are considered equal)
+        makeFlatVector<T>({kSNaN, kSNaN, kSNaN, kSNaN, kSNaN}),
+        // only Inf
+        makeFlatVector<T>({kInf, kInf, kInf, kInf, kInf}),
+        // only -Inf
+        makeFlatVector<T>({-kInf, -kInf, -kInf, -kInf, -kInf}),
+        // group by column
+        makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+    });
+
+    // Global aggregation.
+    {
+      auto expected = makeRowVector(
+          {makeFlatVector<T>(std::vector<T>({-1.1})),
+           makeFlatVector<T>(std::vector<T>({kNaN})),
+           makeFlatVector<T>(std::vector<T>({-1.1})),
+           makeFlatVector<T>(std::vector<T>({kNaN})),
+           makeFlatVector<T>(std::vector<T>({kNaN})),
+           makeFlatVector<T>(std::vector<T>({kNaN})),
+           makeFlatVector<T>(std::vector<T>({kInf})),
+           makeFlatVector<T>(std::vector<T>({kInf})),
+           makeFlatVector<T>(std::vector<T>({-kInf})),
+           makeFlatVector<T>(std::vector<T>({-kInf}))});
+
+      testAggregations(
+          {data},
+          {},
+          {"min(c0)",
+           "max(c0)",
+           "min(c1)",
+           "max(c1)",
+           "min(c2)",
+           "max(c2)",
+           "min(c3)",
+           "max(c3)",
+           "min(c4)",
+           "max(c4)"},
+          {expected});
+    }
+
+    // group-by aggregation.
+    {
+      auto expected = makeRowVector(
+          {makeFlatVector<int32_t>({1, 2}),
+           makeFlatVector<T>({1.1, -1.1}),
+           makeFlatVector<T>({kNaN, kInf}),
+           makeFlatVector<T>({2.0, -1.1}),
+           makeFlatVector<T>({kNaN, 1.1}),
+           makeFlatVector<T>({kNaN, kNaN}),
+           makeFlatVector<T>({kNaN, kNaN}),
+           makeFlatVector<T>({kInf, kInf}),
+           makeFlatVector<T>({kInf, kInf}),
+           makeFlatVector<T>({-kInf, -kInf}),
+           makeFlatVector<T>({-kInf, -kInf})});
+
+      testAggregations(
+          {data},
+          {"c5"},
+          {"min(c0)",
+           "max(c0)",
+           "min(c1)",
+           "max(c1)",
+           "min(c2)",
+           "max(c2)",
+           "min(c3)",
+           "max(c3)",
+           "min(c4)",
+           "max(c4)"},
+          {expected});
+    }
+
+    // Test for float point values nested inside complex type.
+    data = makeRowVector({
+        makeRowVector({
+            makeFlatVector<T>({2, kNaN, 1, kInf, -1, kNaN}),
+            makeFlatVector<int32_t>({1, 1, 1, 2, 2, 2}),
+        }),
+        makeFlatVector<int32_t>({1, 1, 1, 2, 2, 2}),
+    });
+
+    // Global aggregation.
+    {
+      auto expected = makeRowVector(
+          {makeRowVector({
+               makeFlatVector<T>(std::vector<T>({-1})),
+               makeFlatVector<int32_t>(std::vector<int32_t>({2})),
+           }),
+           makeRowVector({
+               makeFlatVector<T>(std::vector<T>({kNaN})),
+               makeFlatVector<int32_t>(std::vector<int32_t>({2})),
+           })});
+
+      testAggregations({data}, {}, {"min(c0)", "max(c0)"}, {expected});
+    }
+
+    // group-by aggregation.
+    {
+      auto expected = makeRowVector(
+          {makeFlatVector<int32_t>({1, 2}),
+           makeRowVector({
+               makeFlatVector<T>(std::vector<T>({1, -1})),
+               makeFlatVector<int32_t>(std::vector<int32_t>({1, 2})),
+           }),
+           makeRowVector({
+               makeFlatVector<T>(std::vector<T>({kNaN, kNaN})),
+               makeFlatVector<int32_t>(std::vector<int32_t>({1, 2})),
+           })});
+
+      testAggregations({data}, {"c1"}, {"min(c0)", "max(c0)"}, {expected});
+    }
+  }
 };
 
 TEST_F(MinMaxTest, maxTinyint) {
@@ -124,10 +253,12 @@ TEST_F(MinMaxTest, maxBigint) {
 
 TEST_F(MinMaxTest, maxReal) {
   doTest(max, REAL());
+  testExtremeFloatValues<float>();
 }
 
 TEST_F(MinMaxTest, maxDouble) {
   doTest(max, DOUBLE());
+  testExtremeFloatValues<double>();
 }
 
 TEST_F(MinMaxTest, maxVarchar) {
@@ -936,6 +1067,59 @@ class MinMaxNTest : public functions::aggregate::test::AggregationTestBase {
         {"min(c1, 2)", "min(c1, 5)", "max(c1, 3)", "max(c1, 7)"},
         {expected});
   }
+
+  template <typename T>
+  void testNaNFloatValues() {
+    // Tests to ensure NaN is correctly handled and considered greater than
+    // Infinity.
+    static const T kNaN = std::numeric_limits<T>::quiet_NaN();
+    static const T kInf = std::numeric_limits<T>::infinity();
+
+    auto data = makeRowVector({
+        // regular ordering
+        makeFlatVector<T>({2.0, kNaN, kInf, kNaN, -1.1, 0.0}),
+        // with nulls (null is ignored)
+        makeNullableFlatVector<T>({2.0, kNaN, std::nullopt, 1.1, -1.1, 0.0}),
+        // group by column
+        makeFlatVector<int32_t>({1, 1, 1, 2, 2, 2}),
+    });
+
+    // Global aggregation.
+    {
+      auto expected = makeRowVector(
+          {makeArrayVector<T>({{-1.1, 0.0, 2.0, kInf, kNaN, kNaN}}),
+           makeArrayVector<T>({{kNaN, kNaN, kInf, 2.0, 0.0, -1.1}}),
+           makeArrayVector<T>({{-1.1, 0.0, 1.1, 2.0, kNaN}}),
+           makeArrayVector<T>({{kNaN, 2.0, 1.1, 0.0, -1.1}})});
+
+      testAggregations(
+          {data},
+          {},
+          {
+              "min(c0, 6)",
+              "max(c0, 6)",
+              "min(c1, 6)",
+              "max(c1, 6)",
+          },
+          {expected});
+    }
+
+    // group-by aggregation.
+    {
+      auto expected = makeRowVector(
+          {makeFlatVector<int32_t>({1, 2}),
+           makeArrayVector<T>({{2.0, kInf, kNaN}, {-1.1, 0.0, kNaN}}),
+           makeArrayVector<T>({{kNaN, kInf, 2.0}, {kNaN, 0.0, -1.1}}),
+           makeArrayVector<T>({{2.0, kNaN}, {-1.1, 0.0, 1.1}}),
+           makeArrayVector<T>({{kNaN, 2.0}, {1.1, 0.0, -1.1}})});
+
+      testAggregations(
+          {data},
+          {"c2"},
+          {"min(c0, 3)", "max(c0, 3)", "min(c1, 3)", "max(c1, 3)"},
+          {expected});
+    }
+  }
 };
 
 TEST_F(MinMaxNTest, tinyint) {
@@ -961,11 +1145,13 @@ TEST_F(MinMaxNTest, bigint) {
 TEST_F(MinMaxNTest, real) {
   testNumericGlobal<float>();
   testNumericGroupBy<float>();
+  testNaNFloatValues<float>();
 }
 
 TEST_F(MinMaxNTest, double) {
   testNumericGlobal<double>();
   testNumericGroupBy<double>();
+  testNaNFloatValues<double>();
 }
 
 TEST_F(MinMaxNTest, shortdecimal) {


### PR DESCRIPTION
Summary:
This change ensures that extreme floating point values are handled
correctly, including INF, -INF, and NaN, where NaN is considered
greater than INF. Additionally, it correctly sets the initial group
values for floating point types (-INF for max() and NaN for min()),
which is relevant when the inputs consist solely of these extreme
values.

Differential Revision: D57801191


