### PR TITLE
Add gtest pretty printer for Timestamp

### DIFF
--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -413,6 +413,11 @@ struct Timestamp {
     return obj;
   }
 
+  // Pretty printer for gtest.
+  friend void PrintTo(const Timestamp& timestamp, std::ostream* os) {
+    *os << "sec: " << timestamp.seconds_ << ", ns: " << timestamp.nanos_;
+  }
+
  private:
   int64_t seconds_;
   uint64_t nanos_;


### PR DESCRIPTION
Summary:
Adding pretty printer function to make gtest equality comparison fail
with a legible error message. Before:

```
Expected equality of these values:
  Timestamp(0, 0)
    Which is: 16-byte object <00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00>
  dateTrunc("hour", Timestamp(1667725199 ,0))
    Which is: (16-byte object <80-69 67-63 00-00 00-00 00-00 00-00 00-00 00-00>)
```

After

```
Expected equality of these values:
  Timestamp(0, 0)
    Which is: sec: 0, ns: 0
  dateTrunc("hour", Timestamp(1667725199 ,0))
    Which is: (sec: 1667721600, ns: 0)
```

Differential Revision: D57805196


