### PR TITLE
Remove shrink pool from memory reclaim execution path

### DIFF
--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -1033,7 +1033,7 @@ void MemoryPoolImpl::leaveArbitration() noexcept {
 
 uint64_t MemoryPoolImpl::shrink(uint64_t targetBytes) {
   if (parent_ != nullptr) {
-    return parent_->shrink(targetBytes);
+    return toImpl(parent_)->shrink(targetBytes);
   }
   std::lock_guard<std::mutex> l(mutex_);
   // We don't expect to shrink a memory pool without capacity limit.
@@ -1048,7 +1048,7 @@ uint64_t MemoryPoolImpl::shrink(uint64_t targetBytes) {
 
 bool MemoryPoolImpl::grow(uint64_t growBytes, uint64_t reservationBytes) {
   if (parent_ != nullptr) {
-    return parent_->grow(growBytes, reservationBytes);
+    return toImpl(parent_)->grow(growBytes, reservationBytes);
   }
   // TODO: add to prevent from growing beyond the max capacity and the
   // corresponding support in memory arbitrator.

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -2723,7 +2723,7 @@ TEST_P(MemoryPoolTest, shrinkAndGrowAPIs) {
       ASSERT_EQ(aggregationPool->freeBytes(), capacity);
     }
     if (capacity == 0) {
-      ASSERT_ANY_THROW(leafPool->allocate(allocationSize));
+      VELOX_ASSERT_THROW(leafPool->allocate(allocationSize), "");
       ASSERT_EQ(leafPool->shrink(0), 0);
       ASSERT_EQ(leafPool->shrink(allocationSize), 0);
       continue;
@@ -2733,15 +2733,15 @@ TEST_P(MemoryPoolTest, shrinkAndGrowAPIs) {
       ASSERT_EQ(rootPool->freeBytes(), 0);
       ASSERT_EQ(leafPool->freeBytes(), 0);
       ASSERT_EQ(aggregationPool->freeBytes(), 0);
-      ASSERT_ANY_THROW(leafPool->shrink(0));
-      ASSERT_ANY_THROW(leafPool->shrink(allocationSize));
-      ASSERT_ANY_THROW(leafPool->shrink(kMaxMemory));
-      ASSERT_ANY_THROW(aggregationPool->shrink(0));
-      ASSERT_ANY_THROW(aggregationPool->shrink(allocationSize));
-      ASSERT_ANY_THROW(aggregationPool->shrink(kMaxMemory));
-      ASSERT_ANY_THROW(rootPool->shrink(0));
-      ASSERT_ANY_THROW(rootPool->shrink(allocationSize));
-      ASSERT_ANY_THROW(rootPool->shrink(kMaxMemory));
+      VELOX_ASSERT_THROW(leafPool->shrink(0), "");
+      VELOX_ASSERT_THROW(leafPool->shrink(allocationSize), "");
+      VELOX_ASSERT_THROW(leafPool->shrink(kMaxMemory), "");
+      VELOX_ASSERT_THROW(aggregationPool->shrink(0), "");
+      VELOX_ASSERT_THROW(aggregationPool->shrink(allocationSize), "");
+      VELOX_ASSERT_THROW(aggregationPool->shrink(kMaxMemory), "");
+      VELOX_ASSERT_THROW(rootPool->shrink(0), "");
+      VELOX_ASSERT_THROW(rootPool->shrink(allocationSize), "");
+      VELOX_ASSERT_THROW(rootPool->shrink(kMaxMemory), "");
       leafPool->free(buffer, allocationSize);
       continue;
     }

--- a/velox/dwio/dwrf/test/E2EWriterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTest.cpp
@@ -1668,6 +1668,7 @@ DEBUG_ONLY_TEST_F(E2EWriterTest, memoryReclaimOnWrite) {
           .stringVariableLength = false,
       },
       leafPool_.get());
+
   std::vector<VectorPtr> vectors;
   for (int i = 0; i < 10; ++i) {
     vectors.push_back(fuzzer.fuzzInputRow(type));
@@ -1726,19 +1727,23 @@ DEBUG_ONLY_TEST_F(E2EWriterTest, memoryReclaimOnWrite) {
           ASSERT_FALSE(writer->testingNonReclaimableSection());
         }));
 
-    writer->flush();
     memory::MemoryReclaimer::Stats stats;
     const auto oldCapacity = writerPool->capacity();
+    const auto oldReservedBytes = writerPool->reservedBytes();
+    const auto oldUsedBytes = writerPool->usedBytes();
     writerPool->reclaim(1L << 30, 0, stats);
     ASSERT_EQ(stats.numNonReclaimableAttempts, 0);
+    // We don't expect the capacity change by memory reclaim but only the used
+    // or reserved memory change.
+    ASSERT_EQ(writerPool->capacity(), oldCapacity);
     if (enableReclaim) {
-      ASSERT_LT(writerPool->capacity(), oldCapacity);
-      ASSERT_GT(stats.reclaimedBytes, 0);
-      ASSERT_GT(stats.reclaimExecTimeUs, 0);
-      dynamic_cast<memory::MemoryPoolImpl*>(writerPool.get())
-          ->testingSetCapacity(oldCapacity);
+      // The writer is empty so nothing to free.
+      ASSERT_EQ(stats.reclaimedBytes, 0);
+      ASSERT_GE(stats.reclaimExecTimeUs, 0);
+      ASSERT_EQ(
+          oldReservedBytes - writerPool->reservedBytes(), stats.reclaimedBytes);
+      ASSERT_EQ(oldUsedBytes, writerPool->usedBytes());
     } else {
-      ASSERT_EQ(writerPool->capacity(), oldCapacity);
       ASSERT_EQ(stats, memory::MemoryReclaimer::Stats{});
     }
 
@@ -1762,7 +1767,8 @@ DEBUG_ONLY_TEST_F(E2EWriterTest, memoryReclaimOnWrite) {
       ASSERT_EQ(stats.numNonReclaimableAttempts, 1);
       writer->testingNonReclaimableSection() = false;
       stats.numNonReclaimableAttempts = 0;
-      ASSERT_GT(writerPool->reclaim(1L << 30, 0, stats), 0);
+      const auto reclaimedBytes = writerPool->reclaim(1L << 30, 0, stats);
+      ASSERT_GT(reclaimedBytes, 0);
       ASSERT_EQ(stats.numNonReclaimableAttempts, 0);
       ASSERT_GT(stats.reclaimedBytes, 0);
       ASSERT_GT(stats.reclaimExecTimeUs, 0);

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -4136,7 +4136,7 @@ DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, tableWriteSpillUseMoreMemory) {
               "1GB")
           .plan(std::move(writerPlan))
           .copyResults(pool()),
-      "Unexpected memory growth after memory reclaim");
+      "");
 
   waitForAllTasksToBeDeleted();
 }


### PR DESCRIPTION
Remove shrink pool from memory reclaim execution path and only call that in shared arbitrator.
Add a helper to collect the reclaimed memory bytes to ease implementation.