### PR TITLE
Enable anti join type in SMJ 

### DIFF
--- a/velox/exec/MergeJoin.cpp
+++ b/velox/exec/MergeJoin.cpp
@@ -37,7 +37,7 @@ MergeJoin::MergeJoin(
   VELOX_USER_CHECK(
       joinNode_->isInnerJoin() || joinNode_->isLeftJoin() ||
           joinNode_->isLeftSemiFilterJoin() ||
-          joinNode_->isRightSemiFilterJoin(),
+          joinNode_->isRightSemiFilterJoin() || joinNode_->isAntiJoin(),
       "Merge join supports only inner, left and left semi joins. Other join types are not supported yet.");
 }
 
@@ -89,10 +89,16 @@ void MergeJoin::initialize() {
   if (joinNode_->filter()) {
     initializeFilter(joinNode_->filter(), leftType, rightType);
 
-    if (joinNode_->isLeftJoin()) {
+    if (joinNode_->isLeftJoin() || joinNode_->isAntiJoin()) {
       leftJoinTracker_ = LeftJoinTracker(outputBatchSize_, pool());
     }
   }
+
+  // Anti join need to track the left side rows that have no match on the right.
+  if (joinNode_->isAntiJoin() && !filter_) {
+    leftJoinTracker_ = LeftJoinTracker(outputBatchSize_, pool());
+  }
+
   joinNode_.reset();
 }
 
@@ -319,6 +325,12 @@ void MergeJoin::addOutputRow(
       // Record left-side row with a match on the right-side.
       leftJoinTracker_->addMatch(left, leftIndex, outputSize_);
     }
+  }
+
+  // Anti join need to track the left side rows that have no match on the right.
+  if (isAntiJoin(joinType_) && !filter_ && leftJoinTracker_) {
+    // Record left-side row with a match on the right-side.
+    leftJoinTracker_->addMatch(left, leftIndex, outputSize_);
   }
 
   ++outputSize_;
@@ -565,7 +577,34 @@ RowVectorPtr MergeJoin::getOutput() {
         // No rows survived the filter. Get more rows.
         continue;
       } else {
-        return output;
+        if (isAntiJoin(joinType_)) {
+          auto numRows = output->size();
+          const auto& filterRows = leftJoinTracker_->matchingRows(numRows);
+          auto numPassed = 0;
+
+          BufferPtr indices = allocateIndices(numRows, pool());
+          auto rawIndices = indices->asMutable<vector_size_t>();
+          for (auto i = 0; i < numRows; i++) {
+            if (!filterRows.isValid(i)) {
+              rawIndices[numPassed++] = i;
+            }
+          }
+
+          if (numPassed == 0) {
+            // No rows passed.
+            return nullptr;
+          }
+
+          if (numPassed == numRows) {
+            // All rows passed.
+            return output;
+          }
+
+          // Some, but not all rows passed.
+          return wrap(numPassed, indices, output);
+        } else {
+          return output;
+        }
       }
     }
 
@@ -669,7 +708,7 @@ RowVectorPtr MergeJoin::doGetOutput() {
   }
 
   if (!input_ || !rightInput_) {
-    if (isLeftJoin(joinType_)) {
+    if (isLeftJoin(joinType_) || isAntiJoin(joinType_)) {
       if (input_ && noMoreRightInput_) {
         // If output_ is currently wrapping a different buffer, return it
         // first.
@@ -716,7 +755,7 @@ RowVectorPtr MergeJoin::doGetOutput() {
   for (;;) {
     // Catch up input_ with rightInput_.
     while (compareResult < 0) {
-      if (isLeftJoin(joinType_)) {
+      if (isLeftJoin(joinType_) || isAntiJoin(joinType_)) {
         // If output_ is currently wrapping a different buffer, return it
         // first.
         if (prepareOutput(input_, nullptr)) {
@@ -833,11 +872,13 @@ RowVectorPtr MergeJoin::applyFilter(const RowVectorPtr& output) {
     // If all matches for a given left-side row fail the filter, add a row to
     // the output with nulls for the right-side columns.
     auto onMiss = [&](auto row) {
-      rawIndices[numPassed++] = row;
+      if (!isAntiJoin(joinType_)) {
+        rawIndices[numPassed++] = row;
 
-      for (auto& projection : rightProjections_) {
-        auto target = output->childAt(projection.outputChannel);
-        target->setNull(row, true);
+        for (auto& projection : rightProjections_) {
+          auto target = output->childAt(projection.outputChannel);
+          target->setNull(row, true);
+        }
       }
     };
 
@@ -848,8 +889,14 @@ RowVectorPtr MergeJoin::applyFilter(const RowVectorPtr& output) {
 
         leftJoinTracker_->processFilterResult(i, passed, onMiss);
 
-        if (passed) {
-          rawIndices[numPassed++] = i;
+        if (isAntiJoin(joinType_)) {
+          if (!passed) {
+            rawIndices[numPassed++] = i;
+          }
+        } else {
+          if (passed) {
+            rawIndices[numPassed++] = i;
+          }
         }
       } else {
         // This row doesn't have a match on the right side. Keep it

--- a/velox/exec/MergeJoin.h
+++ b/velox/exec/MergeJoin.h
@@ -224,6 +224,13 @@ class MergeJoin : public Operator {
   /// the result using 'decodedFilterResult_'.
   void evaluateFilter(const SelectivityVector& rows);
 
+  /// An anti join is equivalent to a left join that retains only the rows from
+  /// the left side which do not have a corresponding match on the right side.
+  /// When an anti join includes a filter, it is processed using the applyFilter
+  /// method. For an anti join without a filter, we must specifically exclude
+  /// rows from the left side that have a match on the right.
+  RowVectorPtr filterOutputForAntiJoin(const RowVectorPtr& output);
+
   /// As we populate the results of the left join, we track whether a given
   /// output row is a result of a match between left and right sides or a miss.
   /// We use LeftJoinTracker::addMatch and addMiss methods for that.

--- a/velox/exec/fuzzer/JoinFuzzer.cpp
+++ b/velox/exec/fuzzer/JoinFuzzer.cpp
@@ -858,9 +858,11 @@ void JoinFuzzer::makeAlternativePlans(
               joinNode->isNullAware())
           .planNode()});
 
-  // Use OrderBy + MergeJoin (if join type is inner or left).
+  // Use OrderBy + MergeJoin (if join type is inner, left, left semi, right semi
+  // and anti).
   if (joinNode->isInnerJoin() || joinNode->isLeftJoin() ||
-      joinNode->isLeftSemiFilterJoin() || joinNode->isRightSemiFilterJoin()) {
+      joinNode->isLeftSemiFilterJoin() || joinNode->isRightSemiFilterJoin() ||
+      joinNode->isAntiJoin()) {
     auto planWithSplits = makeMergeJoinPlan(
         joinType, probeKeys, buildKeys, probeInput, buildInput, outputColumns);
     plans.push_back(planWithSplits);

--- a/velox/exec/fuzzer/JoinFuzzer.cpp
+++ b/velox/exec/fuzzer/JoinFuzzer.cpp
@@ -858,8 +858,7 @@ void JoinFuzzer::makeAlternativePlans(
               joinNode->isNullAware())
           .planNode()});
 
-  // Use OrderBy + MergeJoin (if join type is inner, left, left semi, right semi
-  // and anti).
+  // Use OrderBy + MergeJoin
   if (joinNode->isInnerJoin() || joinNode->isLeftJoin() ||
       joinNode->isLeftSemiFilterJoin() || joinNode->isRightSemiFilterJoin() ||
       joinNode->isAntiJoin()) {


### PR DESCRIPTION
Anti join is equal to the left join with the left side rows that have no match on the right.