### PR TITLE
Fix S3FileSystemTest test failure

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/common/memory/Memory.h"
+#include "velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/tests/S3Test.h"
 
@@ -27,6 +28,7 @@ class S3FileSystemTest : public S3Test {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance({});
+    filesystems::registerS3FileSystem();
   }
 
   void SetUp() override {
@@ -36,7 +38,7 @@ class S3FileSystemTest : public S3Test {
   }
 
   static void TearDownTestSuite() {
-    filesystems::finalizeS3();
+    filesystems::finalizeS3FileSystem();
   }
 };
 } // namespace


### PR DESCRIPTION
After https://github.com/facebookincubator/velox/pull/9860, `S3FileSystemTest.viaRegistry` and `S3FileSystemTest.fileHandle` test cases cannot run because we did not register the s3 file system when launching the test cases.
CI logs can be found here: https://github.com/facebookincubator/velox/actions/runs/9264234724/job/25483988060?pr=6588

CC: @xiaoxmeng 