### PR TITLE
Consolidate all sites that can hash a value inside a vector

### DIFF
--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -20,6 +20,7 @@
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/ContainerRowSerde.h"
 #include "velox/exec/Operator.h"
+#include "velox/type/FloatingPointUtil.h"
 
 namespace facebook::velox::exec {
 namespace {
@@ -866,6 +867,8 @@ void RowContainer::hashTyped(
           Kind == TypeKind::MAP) {
         auto in = prepareRead(row, offset);
         hash = ContainerRowSerde::hash(in, type);
+      } else if constexpr (std::is_floating_point_v<T>) {
+        hash = util::floating_point::NaNAwareHash<T>()(valueAt<T>(row, offset));
       } else {
         hash = folly::hasher<T>()(valueAt<T>(row, offset));
       }

--- a/velox/type/FloatingPointUtil.h
+++ b/velox/type/FloatingPointUtil.h
@@ -76,11 +76,11 @@ template <
 struct NaNAwareHash {
   std::size_t operator()(const FLOAT& val) const noexcept {
     static const std::size_t kNanHash =
-        std::hash<FLOAT>{}(std::numeric_limits<FLOAT>::quiet_NaN());
+        folly::hasher<FLOAT>{}(std::numeric_limits<FLOAT>::quiet_NaN());
     if (std::isnan(val)) {
       return kNanHash;
     }
-    return std::hash<FLOAT>{}(val);
+    return folly::hasher<FLOAT>{}(val);
   }
 };
 


### PR DESCRIPTION
Summary:
This commit aims to guarantee consistent evaluation and hashing of NaN
(Not-a-Number) values for floating-point types across multiple sites,
including SimpleVector, VectorHasher, RowContainer, and ContainerRowSerde.
Unit tests will be added incrementally to make it easier to review and to
include additional changes that might be required for it.

The changes to these classes would affect the following:
- Multiple aggregates that have 'distinct' like semantics. Only for
   the codepaths that consume complex types as inputs. Aggregates
   include: multimap_agg, map_union_sum, map_union, count(distinct)
- In-predicate
- Map_subscript, only one optimization code path for
   constant/dictionary encoded map
- Hash Partitioning operator (HashPartition)
- Hash Join operator (HashProbe, HashTable)
- Local partitioning operator (LocalPartition)
- Hash Aggregation operator (GroupingSet)

Differential Revision: D57892204


