### PR TITLE
Fix the path to copy hive.properties from scripts

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -141,7 +141,7 @@ jobs:
       - name: "Run Aggregate Fuzzer"
         run: |
           cd  velox
-          cp ./scripts/etc/hive.properties $PRESTO_HOME/etc/catalog
+          cp ./scripts/presto/etc/hive.properties $PRESTO_HOME/etc/catalog
           ls -lR $PRESTO_HOME/etc
           $PRESTO_HOME/bin/launcher run -v > /tmp/server.log 2>&1 &
           # Sleep for 60 seconds to allow Presto server to start.

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -685,7 +685,7 @@ jobs:
       - name: "Run Aggregate Fuzzer"
         run: |
           cd  velox
-          cp ./scripts/etc/hive.properties $PRESTO_HOME/etc/catalog
+          cp ./scripts/presto/etc/hive.properties $PRESTO_HOME/etc/catalog
           ls -lR $PRESTO_HOME/etc
           $PRESTO_HOME/bin/launcher run -v > /tmp/server.log 2>&1 &
           # Sleep for 60 seconds to allow Presto server to start.
@@ -754,7 +754,7 @@ jobs:
       - name: "Run Bias Aggregate Fuzzer"
         run: |
           cd  velox
-          cp ./scripts/etc/hive.properties $PRESTO_HOME/etc/catalog
+          cp ./scripts/presto/etc/hive.properties $PRESTO_HOME/etc/catalog
           ls -lR $PRESTO_HOME/etc
           $PRESTO_HOME/bin/launcher run -v > /tmp/server.log 2>&1 &
           # Sleep for 60 seconds to allow Presto server to start.
@@ -846,7 +846,7 @@ jobs:
       - name: "Run Window Fuzzer"
         run: |
           cd  velox
-          cp ./scripts/etc/hive.properties $PRESTO_HOME/etc/catalog
+          cp ./scripts/presto/etc/hive.properties $PRESTO_HOME/etc/catalog
           ls -lR $PRESTO_HOME/etc
           $PRESTO_HOME/bin/launcher run -v > /tmp/server.log 2>&1 &
           # Sleep for 60 seconds to allow Presto server to start.


### PR DESCRIPTION
hive.properties has been moved to scripts/presto/etc. We need to update the 
path to copy it from.