### PR TITLE
Do not pre-allocate error vector in TRY

### DIFF
--- a/velox/expression/TryExpr.cpp
+++ b/velox/expression/TryExpr.cpp
@@ -38,10 +38,6 @@ void TryExpr::evalSpecialForm(
   // threw exceptions which this expression already handled.
   ScopedVarSetter<ErrorVectorPtr> errorsSetter(context.errorsPtr(), nullptr);
 
-  // Allocate error vector to avoid repeated re-allocations for every failed
-  // row.
-  context.ensureErrorsVectorSize(rows.end());
-
   inputs_[0]->eval(rows, context, result);
 
   nullOutErrors(rows, context, result);
@@ -66,10 +62,6 @@ void TryExpr::evalSpecialFormSimplified(
   // parent TRY expression, so the parent won't incorrectly null out rows that
   // threw exceptions which this expression already handled.
   ScopedVarSetter<ErrorVectorPtr> errorsSetter(context.errorsPtr(), nullptr);
-
-  // Allocate error vector to avoid repeated re-allocations for every failed
-  // row.
-  context.ensureErrorsVectorSize(rows.end());
 
   inputs_[0]->evalSimplified(rows, context, result);
 


### PR DESCRIPTION
Summary:
PR https://github.com/facebookincubator/velox/pull/9911 optimized TRY by
pre-allocating error vector in TRY. This helped reduce CPU time for TRY and TRY
(CAST) at the expense of using a bit more memory. However, we are seeing that
memory usage for one of the production streaming pipelines increased 2x 
from 3gb to 6gb. Reverting this change to unblock production.

Before:

```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
cast##try_cast_invalid_empty_input                          2.23ms    449.10
cast##tryexpr_cast_invalid_empty_input                      4.60ms    217.51
cast##try_cast_invalid_nan                                  5.88ms    170.01
cast##tryexpr_cast_invalid_nan                              8.07ms    123.87

```

After:

```
cast##try_cast_invalid_empty_input                          2.18ms    459.47
cast##tryexpr_cast_invalid_empty_input                      8.75ms    114.32
cast##try_cast_invalid_nan                                  5.43ms    184.30
cast##tryexpr_cast_invalid_nan                             12.43ms     80.43
```

Differential Revision: D57891806


