### PR TITLE
Adding Parquet file format support for tests in velox_hive_connector_test and IcebergReadTest

### DIFF
--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -106,7 +106,8 @@ class HiveIcebergTest : public HiveConnectorTestBase {
     // Keep the reference to the deleteFilePath, otherwise the corresponding
     // file will be deleted.
     std::vector<std::shared_ptr<TempFilePath>> deleteFilePaths;
-    // Use PARQUET instead of default DWRF if Parquet Writer Factory is present
+    // If Parquet Writer Factory is present, then use the PARQUET file format
+    // instead of the default DWRF file format.
     if (hasWriterFactory(dwio::common::FileFormat::PARQUET)) {
       fileFormat_ = {dwio::common::FileFormat::PARQUET};
     }
@@ -161,7 +162,8 @@ class HiveIcebergTest : public HiveConnectorTestBase {
                     ->openFileForRead(dataFilePath);
     const int64_t fileSize = file->size();
 
-    // Use PARQUET instead of default DWRF if Parquet Writer Factory is present
+    // If Parquet Writer Factory is present, then use the PARQUET file format
+    // instead of the default DWRF file format.
     if (hasWriterFactory(dwio::common::FileFormat::PARQUET)) {
       fileFormat_ = {dwio::common::FileFormat::PARQUET};
     }

--- a/velox/connectors/hive/tests/HiveConnectorSerDeTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorSerDeTest.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/hive/HiveConnector.h"
+#include "velox/dwio/common/Options.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/expression/ExprToSubfieldFilter.h"
 
@@ -125,8 +126,16 @@ TEST_F(HiveConnectorSerDeTest, hiveInsertTableHandle) {
       "targetDirectory",
       std::optional("writeDirectory"),
       LocationHandle::TableType::kNew);
+  auto fileFormat = dwio::common::FileFormat::DWRF;
+  if (hasWriterFactory(dwio::common::FileFormat::PARQUET)) {
+    fileFormat = dwio::common::FileFormat::PARQUET;
+  }
   auto hiveInsertTableHandle =
       exec::test::HiveConnectorTestBase::makeHiveInsertTableHandle(
-          tableColumnNames, tableColumnTypes, {"loc"}, locationHandle);
+          tableColumnNames,
+          tableColumnTypes,
+          {"loc"},
+          locationHandle,
+          fileFormat);
   testSerde(*hiveInsertTableHandle);
 }

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -52,6 +52,9 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
   // Dynamic parameters.
   dwio::common::ReaderOptions readerOptions(pool_.get());
   FileFormat fileFormat{FileFormat::DWRF};
+  if (hasWriterFactory(FileFormat::PARQUET)) {
+    fileFormat = {FileFormat::PARQUET};
+  }
   std::unordered_map<std::string, std::string> tableParameters;
   std::unordered_map<std::string, std::string> serdeParameters;
   SerDeOptions expectedSerDe;

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -80,6 +80,8 @@ void HiveConnectorTestBase::writeToFile(
     std::shared_ptr<dwrf::Config> config,
     const TypePtr& schema) {
   velox::dwrf::WriterOptions options;
+  // WIP: Need to edit this function to support writing in Parquet, currently
+  // only writing for DWRF
   options.config = config;
   options.schema = schema;
   auto localWriteFile = std::make_unique<LocalWriteFile>(filePath, true, false);


### PR DESCRIPTION
Adding Parquet file format support for tests in velox_hive_connector_test and IcebergReadTest.

This PR is also related to the work done for the issue and PR below:
https://github.com/facebookincubator/velox/issues/5560
https://github.com/facebookincubator/velox/pull/7025

Since issue#5560 is resolved, the tests in this PR also need to be updated to support testing with Parquet file format.

Resolves: https://github.com/facebookincubator/velox/issues/9171