### PR TITLE
Fix casting nan and infinity to floating-point types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -530,6 +530,7 @@ if(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
 endif()
 find_package(BISON 3.0.4 REQUIRED)
 find_package(FLEX 2.5.13 REQUIRED)
+find_package(double-conversion 3.1.5 REQUIRED)
 
 include_directories(SYSTEM velox)
 include_directories(SYSTEM velox/external)

--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -429,9 +429,9 @@ Valid examples
   SELECT cast('1.' as real); -- 1.0
   SELECT cast('1' as real); -- 1.0
   SELECT cast('1.7E308' as real); -- Infinity
-  SELECT cast('Infinity' as real); -- Infinity (case insensitive)
-  SELECT cast('-Infinity' as real); -- -Infinity (case insensitive)
-  SELECT cast('NaN' as real); -- NaN (case insensitive)
+  SELECT cast('Infinity' as real); -- Infinity (case sensitive)
+  SELECT cast('-Infinity' as real); -- -Infinity (case sensitive)
+  SELECT cast('NaN' as real); -- NaN (case sensitive)
 
 Invalid examples
 
@@ -439,21 +439,13 @@ Invalid examples
 
   SELECT cast('1.2a' as real); -- Invalid argument
   SELECT cast('1.2.3' as real); -- Invalid argument
-
-There are a few corner cases where Velox behaves differently from Presto.
-Presto throws INVALID_CAST_ARGUMENT on these queries, while Velox allows these
-conversions. We keep the Velox behaivor by intention because it is more
-consistent with other supported cases of cast.
-
-::
-
-  SELECT cast('infinity' as real); -- Infinity
-  SELECT cast('-infinity' as real); -- -Infinity
-  SELECT cast('inf' as real); -- Infinity
-  SELECT cast('InfiNiTy' as real); -- Infinity
-  SELECT cast('INFINITY' as real); -- Infinity
-  SELECT cast('nAn' as real); -- NaN
-  SELECT cast('nan' as real); -- NaN
+  SELECT cast('infinity' as real); -- Invalid argument
+  SELECT cast('-infinity' as real); -- -Invalid argument
+  SELECT cast('inf' as real); -- Invalid argument
+  SELECT cast('InfiNiTy' as real); -- Invalid argument
+  SELECT cast('INFINITY' as real); -- Invalid argument
+  SELECT cast('nAn' as real); -- Invalid argument
+  SELECT cast('nan' as real); -- Invalid argument
 
 Below cases are supported in Presto, but throw in Velox.
 

--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -50,8 +50,14 @@ add_library(
   VectorFunction.cpp)
 
 target_link_libraries(
-  velox_expression velox_core velox_vector velox_common_base
-  velox_expression_functions velox_functions_util)
+  velox_expression
+  velox_core
+  velox_vector
+  velox_common_base
+  velox_expression_functions
+  velox_functions_util
+  double-conversion::double-conversion
+  Folly::folly)
 
 add_subdirectory(type_calculation)
 add_subdirectory(signature_parser)

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -303,7 +303,7 @@ void CastExpr::applyCastKernel(
     const SimpleVector<typename TypeTraits<FromKind>::NativeType>* input,
     FlatVector<typename TypeTraits<ToKind>::NativeType>* result) {
   bool wrapException = true;
-  auto setError = [&](const std::string& details) {
+  auto setError = [&](const std::string& details) INLINE_LAMBDA {
     if (setNullInResultAtError()) {
       result->setNull(row, true);
     } else {
@@ -317,6 +317,18 @@ void CastExpr::applyCastKernel(
       }
     }
   };
+
+  // If castResult has an error, set the error in context. Otherwise, set the
+  // value in castResult directly to result. This lambda should be called only
+  // when ToKind is primitive and is not VARCHAR or VARBINARY.
+  auto setResultOrError = [&](const auto& castResult, vector_size_t row)
+                              INLINE_LAMBDA {
+                                if (castResult.hasError()) {
+                                  setError(castResult.error().message());
+                                } else {
+                                  result->set(row, castResult.value());
+                                }
+                              };
 
   try {
     auto inputRowValue = input->valueAt(row);
@@ -335,11 +347,17 @@ void CastExpr::applyCastKernel(
       }
       if constexpr (ToKind == TypeKind::TIMESTAMP) {
         const auto castResult = hooks_->castStringToTimestamp(inputRowValue);
-        if (castResult.hasError()) {
-          setError(castResult.error().message());
-        } else {
-          result->set(row, castResult.value());
-        }
+        setResultOrError(castResult, row);
+        return;
+      }
+      if constexpr (ToKind == TypeKind::REAL) {
+        const auto castResult = hooks_->castStringToReal(inputRowValue);
+        setResultOrError(castResult, row);
+        return;
+      }
+      if constexpr (ToKind == TypeKind::DOUBLE) {
+        const auto castResult = hooks_->castStringToDouble(inputRowValue);
+        setResultOrError(castResult, row);
         return;
       }
     }

--- a/velox/expression/CastHooks.h
+++ b/velox/expression/CastHooks.h
@@ -22,8 +22,8 @@
 namespace facebook::velox::exec {
 
 /// This class provides cast hooks to allow different behaviors of CastExpr and
-/// SparkCastExpr. The main purpose is crate customized cast implementation by
-/// taking full usage of existing cast expression.
+/// SparkCastExpr. The main purpose is to create customized cast implementation
+/// by taking full usage of existing cast expression.
 class CastHooks {
  public:
   virtual ~CastHooks() = default;
@@ -33,6 +33,14 @@ class CastHooks {
 
   virtual Expected<int32_t> castStringToDate(
       const StringView& dateString) const = 0;
+
+  // 'data' is guaranteed to be non-empty and has been processed by
+  // removeWhiteSpaces.
+  virtual Expected<float> castStringToReal(const StringView& data) const = 0;
+
+  // 'data' is guaranteed to be non-empty and has been processed by
+  // removeWhiteSpaces.
+  virtual Expected<double> castStringToDouble(const StringView& data) const = 0;
 
   // Returns whether legacy cast semantics are enabled.
   virtual bool legacy() const = 0;

--- a/velox/expression/PrestoCastHooks.h
+++ b/velox/expression/PrestoCastHooks.h
@@ -34,6 +34,14 @@ class PrestoCastHooks : public CastHooks {
   Expected<int32_t> castStringToDate(
       const StringView& dateString) const override;
 
+  // Allows casting 'NaN', 'Infinity', and '-Infinity' to real, but not 'Inf' or
+  // these strings with different letter cases.
+  Expected<float> castStringToReal(const StringView& data) const override;
+
+  // Allows casting 'NaN', 'Infinity', and '-Infinity' to double, but not 'Inf'
+  // or these strings with different letter cases.
+  Expected<double> castStringToDouble(const StringView& data) const override;
+
   bool legacy() const override {
     return legacyCast_;
   }

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -339,27 +339,13 @@ TEST_F(CastExprTest, basics) {
       {false, true, true, true, true, true, true, true, true});
   testCast<std::string, float>(
       "float",
-      {"1.888",
-       "1.",
-       "1",
-       "1.7E308",
-       "Infinity",
-       "-Infinity",
-       "infinity",
-       "inf",
-       "INFINITY",
-       "NaN",
-       "nan"},
+      {"1.888", "1.", "1", "1.7E308", "Infinity", "-Infinity", "NaN"},
       {1.888,
        1.0,
        1.0,
        std::numeric_limits<float>::infinity(),
        std::numeric_limits<float>::infinity(),
        -std::numeric_limits<float>::infinity(),
-       std::numeric_limits<float>::infinity(),
-       std::numeric_limits<float>::infinity(),
-       std::numeric_limits<float>::infinity(),
-       std::numeric_limits<float>::quiet_NaN(),
        std::numeric_limits<float>::quiet_NaN()});
 
   gflags::FlagSaver flagSaver;
@@ -1012,13 +998,29 @@ TEST_F(CastExprTest, primitiveInvalidCornerCases) {
 
     // Invalid strings.
     testInvalidCast<std::string>(
-        "real",
-        {"1.2a"},
-        "Non-whitespace character found after end of conversion");
+        "real", {"1.2a"}, "Cannot cast VARCHAR '1.2a' to REAL");
     testInvalidCast<std::string>(
-        "real",
-        {"1.2.3"},
-        "Non-whitespace character found after end of conversion");
+        "real", {"1.2.3"}, "Cannot cast VARCHAR '1.2.3' to REAL");
+    testInvalidCast<std::string>(
+        "real", {"nAn"}, "Cannot cast VARCHAR 'nAn' to REAL");
+    testInvalidCast<std::string>(
+        "real", {" nAn "}, "Cannot cast VARCHAR ' nAn ' to REAL");
+    testInvalidCast<std::string>(
+        "double", {"nAn"}, "Cannot cast VARCHAR 'nAn' to DOUBLE");
+    testInvalidCast<std::string>(
+        "real", {"iNfinitY"}, "Cannot cast VARCHAR 'iNfinitY' to REAL");
+    testInvalidCast<std::string>(
+        "double", {"iNfinitY"}, "Cannot cast VARCHAR 'iNfinitY' to DOUBLE");
+    testInvalidCast<std::string>(
+        "double", {" iNfinitY "}, "Cannot cast VARCHAR ' iNfinitY ' to DOUBLE");
+    testInvalidCast<std::string>(
+        "double", {""}, "Cannot cast VARCHAR '' to DOUBLE");
+    testInvalidCast<std::string>(
+        "double", {"   "}, "Cannot cast VARCHAR '   ' to DOUBLE");
+    testInvalidCast<std::string>(
+        "real", {"NaN  ."}, "Cannot cast VARCHAR 'NaN  .' to REAL");
+    testInvalidCast<std::string>(
+        "real", {"- NaN"}, "Cannot cast VARCHAR '- NaN' to REAL");
   }
 
   // To boolean.
@@ -1063,14 +1065,13 @@ TEST_F(CastExprTest, primitiveValidCornerCases) {
     testCast<std::string, float>("real", {"1.7E308"}, {kInf});
     testCast<std::string, float>("real", {"1."}, {1.0});
     testCast<std::string, float>("real", {"1"}, {1});
-    // When casting from "Infinity" and "NaN", Presto is case sensitive. But we
-    // let them be case insensitive to be consistent with other conversions.
-    testCast<std::string, float>("real", {"infinity"}, {kInf});
-    testCast<std::string, float>("real", {"-infinity"}, {-kInf});
-    testCast<std::string, float>("real", {"InfiNiTy"}, {kInf});
-    testCast<std::string, float>("real", {"-InfiNiTy"}, {-kInf});
-    testCast<std::string, float>("real", {"nan"}, {kNan});
-    testCast<std::string, float>("real", {"nAn"}, {kNan});
+    testCast<std::string, float>("real", {"  1  "}, {1});
+    testCast<std::string, float>("real", {"-Infinity"}, {-kInf});
+    testCast<std::string, float>("real", {"+Infinity"}, {kInf});
+    testCast<std::string, float>("real", {" Infinity "}, {kInf});
+    testCast<std::string, float>("real", {"  NaN  "}, {kNan});
+    testCast<std::string, float>("real", {"  -NaN  "}, {kNan});
+    testCast<std::string, float>("real", {"  +NaN  "}, {kNan});
   }
 
   // To boolean.

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -43,6 +43,15 @@ Expected<int32_t> SparkCastHooks::castStringToDate(
       removeWhiteSpaces(dateString), util::ParseMode::kSparkCast);
 }
 
+Expected<float> SparkCastHooks::castStringToReal(const StringView& data) const {
+  return util::Converter<TypeKind::REAL>::tryCast(data);
+}
+
+Expected<double> SparkCastHooks::castStringToDouble(
+    const StringView& data) const {
+  return util::Converter<TypeKind::DOUBLE>::tryCast(data);
+}
+
 StringView SparkCastHooks::removeWhiteSpaces(const StringView& view) const {
   StringView output;
   stringImpl::trimUnicodeWhiteSpace<true, true, StringView, StringView>(

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -32,6 +32,14 @@ class SparkCastHooks : public exec::CastHooks {
   Expected<int32_t> castStringToDate(
       const StringView& dateString) const override;
 
+  // Allows casting 'NaN', 'Infinity', '-Infinity', 'Inf', '-Inf', and these
+  // strings with different letter cases to real.
+  Expected<float> castStringToReal(const StringView& data) const override;
+
+  // Allows casting 'NaN', 'Infinity', '-Infinity', 'Inf', '-Inf', and these
+  // strings with different letter cases to double.
+  Expected<double> castStringToDouble(const StringView& data) const override;
+
   bool legacy() const override {
     return false;
   }


### PR DESCRIPTION
Summary: 
Presto only allow casting "Infinity" and "NaN" to floating-point types, 
but not these strings in different letter cases or "Inf". Velox allows 
these strings to be case insensitive. Since Spark cast function allows 
different letter cases of "NaN", "Infinity", and "Inf", this diff adds APIs 
of casting string to REAL and DOUBLE to CastHooks and fixes Velox's 
Presto cast function in PrestoCastHooks.

Before the fix:
```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
cast_varchar_as_double##cast_valid                        108.03ms      9.26
cast_varchar_as_double##try_cast_invalid_nan               51.91ms     19.26
cast_varchar_as_double##try_cast_invalid_infini            53.39ms     18.73
```

After the fix:
```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
cast_varchar_as_double##cast_valid                         85.87ms     11.65
cast_varchar_as_double##try_cast_invalid_nan               35.05ms     28.53
cast_varchar_as_double##try_cast_invalid_infini            71.88ms     13.91
```

Differential Revision: D57888059


