### PR TITLE
Only cancel fuzzer runs in PRs

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -71,7 +71,10 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  # This will not cancel fuzzer runs on main (regardless of which trigger)
+  # by making the commit sha part of the group but will use the branch
+  # name in PRs to cancel on going runs on a new commit.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha  }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
We want fuzzer runs on main to always run the full time regardless of trigger (push, schedule, manual workflow dispatch). In PRs new commits should cancel on going runs to save CI resources.