### PR TITLE
Add end-to-end no-cache retention support

### DIFF
--- a/velox/common/base/CoalesceIo.h
+++ b/velox/common/base/CoalesceIo.h
@@ -19,9 +19,9 @@
 #include <cstdint>
 #include <vector>
 namespace facebook::velox {
-// Utility for combining IOs to nearby location into fewer coalesced
-// IOs. This may increase data transfer but generally reduces
-// latency and may reduce throttling.
+/// Utility for combining IOs to nearby location into fewer coalesced IOs. This
+/// may increase data transfer but generally reduces latency and may reduce
+/// throttling.
 
 /// Describes the outcome of coalescedIo().
 struct CoalesceIoStats {

--- a/velox/common/caching/ScanTracker.cpp
+++ b/velox/common/caching/ScanTracker.cpp
@@ -21,8 +21,8 @@
 
 namespace facebook::velox::cache {
 
-// Marks that 'bytes' worth of data may be accessed in the
-// future. See TrackingData for meaning of quantum.
+// Marks that 'bytes' worth of data may be accessed in the future. See
+// TrackingData for meaning of quantum.
 void ScanTracker::recordReference(
     const TrackingId id,
     uint64_t bytes,
@@ -52,8 +52,9 @@ void ScanTracker::recordRead(
 std::string ScanTracker::toString() const {
   std::stringstream out;
   out << "ScanTracker for " << id_ << std::endl;
-  for (auto& pair : data_) {
-    int pct = 100 * pair.second.readBytes / (1 + pair.second.referencedBytes);
+  for (const auto& pair : data_) {
+    const int pct =
+        100 * pair.second.readBytes / (1 + pair.second.referencedBytes);
     out << pair.first.id() << ": " << pct << "% " << pair.second.readBytes
         << "/" << pair.second.numReads << std::endl;
   }

--- a/velox/common/caching/ScanTracker.h
+++ b/velox/common/caching/ScanTracker.h
@@ -25,11 +25,11 @@
 
 namespace facebook::velox::cache {
 
-// Represents a stream in a table, e.g. nulls/lengths/data of a
-// particular column. Column-level access tracking uses this to
-// identify the column within a file or partition. The low 5 bits are
-// the stream kind, e.g. nulls, data etc. The high 27 bits are the node
-// number in the file schema tree, i.e. the column.
+/// Represents a stream in a table, e.g. nulls/lengths/data of a particular
+/// column. Column-level access tracking uses this to identify the column within
+/// a file or partition. The low 5 bits are the stream kind, e.g. nulls, data
+/// etc. The high 27 bits are the node number in the file schema tree, i.e. the
+/// column.
 class TrackingId {
  public:
   TrackingId() : id_(-1) {}
@@ -71,22 +71,22 @@ namespace facebook::velox::cache {
 
 class FileGroupStats;
 
-// Records references and actual uses of a stream.
+/// Records references and actual uses of a stream.
 struct TrackingData {
   int64_t referencedBytes{};
   int64_t readBytes{};
   int32_t numReferences{};
   int32_t numReads{};
 
-  // Marks that 'bytes' worth of data in the tracked object has been
-  // referenced and may later be accessed. If 'bytes' is larger than a single
-  // 'oadQuantum', the reference counts for as many accesses as are needed to
-  // cover 'bytes'. When reading a large object, we will get a read per quantum.
-  // So then if the referenced and read counts match, we know that the object is
-  // densely read.
+  /// Marks that 'bytes' worth of data in the tracked object has been referenced
+  /// and may later be accessed. If 'bytes' is larger than a single
+  /// 'loadQuantum', the reference counts for as many accesses as are needed to
+  /// cover 'bytes'. When reading a large object, we will get a read per
+  /// quantum. So then if the referenced and read counts match, we know that the
+  /// object is densely read.
   void incrementReference(uint64_t bytes, int32_t loadQuantum) {
     referencedBytes += bytes;
-    if (!loadQuantum) {
+    if (loadQuantum == 0) {
       ++numReferences;
     } else {
       numReferences += bits::roundUp(bytes, loadQuantum) / loadQuantum;
@@ -99,29 +99,28 @@ struct TrackingData {
   }
 };
 
-// Tracks column access frequency during execution of a query. A
-// ScanTracker is created at the level of a Task/TableScan, so that
-// all threads of a scan report in the same tracker. The same
-// ScanTracker tracks all reads of all partitions of the scan. The
-// groupId argument identifies the file group (e.g. partition) a
-// tracking event pertains to, since a single ScanTracker can range
-// over multiple partitions.
+/// Tracks column access frequency during execution of a query. A ScanTracker is
+/// created at the level of a Task/TableScan, so that all threads of a scan
+/// report in the same tracker. The same ScanTracker tracks all reads of all
+/// partitions of the scan. The groupId argument identifies the file group (e.g.
+/// partition) a tracking event pertains to, since a single ScanTracker can
+/// range over multiple partitions.
 class ScanTracker {
  public:
-  ScanTracker() : loadQuantum_(1 /*not used*/) {}
+  ScanTracker() : ScanTracker({}, nullptr, 1) {}
 
-  // Constructs a tracker with 'id'. The tracker will be owned by
-  // shared_ptr and will be referenced from a map from id to weak_ptr
-  // to 'this'. 'unregisterer' is supplied so that the destructor can
-  // remove the weak_ptr from the map of pending trackers. 'loadQuantum' is the
-  // largest single IO size for read.
+  /// Constructs a tracker with 'id'. The tracker will be owned by shared_ptr
+  /// and will be referenced from a map from id to weak_ptr to 'this'.
+  /// 'unregisterer' is supplied so that the destructor can remove the weak_ptr
+  /// from the map of pending trackers. 'loadQuantum' is the largest single IO
+  /// size for read.
   ScanTracker(
       std::string_view id,
-      std::function<void(ScanTracker* FOLLY_NONNULL)> unregisterer,
+      std::function<void(ScanTracker*)> unregisterer,
       int32_t loadQuantum,
       FileGroupStats* fileGroupStats = nullptr)
       : id_(id),
-        unregisterer_(unregisterer),
+        unregisterer_(std::move(unregisterer)),
         loadQuantum_(loadQuantum),
         fileGroupStats_(fileGroupStats) {}
 
@@ -131,33 +130,33 @@ class ScanTracker {
     }
   }
 
-  // Records that a scan references 'bytes' bytes of the stream given
-  // by 'id'. This is called when preparing to read a stripe.
+  /// Records that a scan references 'bytes' bytes of the stream given by 'id'.
+  /// This is called when preparing to read a stripe.
   void recordReference(
       const TrackingId id,
       uint64_t bytes,
       uint64_t fileId,
       uint64_t groupId);
 
-  // Records that 'bytes' bytes have actually been read from the stream
-  // given by 'id'.
+  /// Records that 'bytes' bytes have actually been read from the stream given
+  /// by 'id'.
   void recordRead(
       const TrackingId id,
       uint64_t bytes,
       uint64_t fileId,
       uint64_t groupId);
 
-  // True if 'trackingId' is read at least  'minReadPct' % of the time.
+  /// True if 'trackingId' is read at least 'minReadPct' % of the time.
   bool shouldPrefetch(TrackingId id, int32_t minReadPct) {
     return readPct(id) >= minReadPct;
   }
 
-  // Returns the percentage of referenced columns that are actually read. 100%
-  // if no data.
+  /// Returns the percentage of referenced columns that are actually read. 100%
+  /// if no data.
   int32_t readPct(TrackingId id) {
     std::lock_guard<std::mutex> l(mutex_);
     const auto& data = data_[id];
-    if (!data.numReferences) {
+    if (data.numReferences == 0) {
       return 100;
     }
     return (100 * data.numReads) / data.numReferences;
@@ -179,18 +178,18 @@ class ScanTracker {
   std::string toString() const;
 
  private:
-  std::mutex mutex_;
   // Id of query + scan operator to track.
   const std::string id_;
-  std::function<void(ScanTracker* FOLLY_NONNULL)> unregisterer_;
+  const std::function<void(ScanTracker*)> unregisterer_{nullptr};
+  // Maximum size of a read. 10MB would count as two references if the quantum
+  // were 8MB. At the same time this would count as a single 10MB reference for
+  // 'fileGroupStats_'. 0 means the read size is unlimited.
+  const int32_t loadQuantum_;
+  FileGroupStats* const fileGroupStats_;
+
+  std::mutex mutex_;
   folly::F14FastMap<TrackingId, TrackingData> data_;
   TrackingData sum_;
-  // Maximum size of a read. 10MB would count as two references
-  // if the quantum were 8MB. At the same time this would count as a
-  // single 10MB reference for 'fileGroupStats_'. 0 means the read
-  // size is unlimited.
-  const int32_t loadQuantum_;
-  FileGroupStats* fileGroupStats_;
 };
 
 } // namespace facebook::velox::cache

--- a/velox/common/caching/SsdCache.cpp
+++ b/velox/common/caching/SsdCache.cpp
@@ -231,4 +231,10 @@ uint64_t SsdCache::testingTotalLogEvictionFilesSize() {
   return size;
 }
 
+void SsdCache::testingWaitForWriteToFinish() {
+  while (writesInProgress_ != 0) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100)); // NOLINT
+  }
+}
+
 } // namespace facebook::velox::cache

--- a/velox/common/caching/SsdCache.h
+++ b/velox/common/caching/SsdCache.h
@@ -155,8 +155,11 @@ class SsdCache {
   /// Deletes checkpoint files. Used in testing.
   void testingDeleteCheckpoints();
 
-  /// Returns the total size of eviction log files. Used in testing.
+  /// Returns the total size of eviction log files. Used by test only.
   uint64_t testingTotalLogEvictionFilesSize();
+
+  /// Waits until the pending ssd cache writes finish. Used by test only.
+  void testingWaitForWriteToFinish();
 
  private:
   void checkNotShutdownLocked() {

--- a/velox/common/caching/SsdFile.cpp
+++ b/velox/common/caching/SsdFile.cpp
@@ -240,7 +240,7 @@ CoalesceIoStats SsdFile::load(
   // Do coalesced IO for the pins. For short payloads, the break-even between
   // discrete pread calls and a single preadv that discards gaps is ~25K per
   // gap. For longer payloads this is ~50-100K.
-  auto stats = readPins(
+  const auto stats = readPins(
       pins,
       totalPayloadBytes / pins.size() < 10000 ? 25000 : 50000,
       // Max ranges in one preadv call. Longest gap + longest cache entry are

--- a/velox/common/file/Region.h
+++ b/velox/common/file/Region.h
@@ -20,11 +20,11 @@
 
 namespace facebook::velox::common {
 
-// define a disk region to read
+/// Defines a disk region to read.
 struct Region {
   uint64_t offset;
   uint64_t length;
-  // Optional label used by lower layers for cache warm up
+  /// Optional label used by lower layers for cache warm up.
   std::string_view label;
 
   Region(uint64_t offset = 0, uint64_t length = 0, std::string_view label = {})

--- a/velox/common/io/IoStatistics.h
+++ b/velox/common/io/IoStatistics.h
@@ -164,8 +164,8 @@ class IoStatistics {
   // reads.
   IoCounter ssdRead_;
 
-  // Time spent by a query processing thread waiting for synchronously
-  // issued IO or for an in-progress read-ahead to finish.
+  // Time spent by a query processing thread waiting for synchronously issued IO
+  // or for an in-progress read-ahead to finish.
   IoCounter queryThreadIoLatency_;
 
   std::unordered_map<std::string, OperationCounters> operationStats_;

--- a/velox/common/memory/Allocation.cpp
+++ b/velox/common/memory/Allocation.cpp
@@ -57,7 +57,7 @@ void Allocation::findRun(uint64_t offset, int32_t* index, int32_t* offsetInRun)
     const {
   uint64_t skipped = 0;
   for (int32_t i = 0; i < runs_.size(); ++i) {
-    uint64_t size = runs_[i].numPages() * AllocationTraits::kPageSize;
+    uint64_t size = AllocationTraits::pageBytes(runs_[i].numPages());
     if (offset - skipped < size) {
       *index = i;
       *offsetInRun = static_cast<int32_t>(offset - skipped);

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -254,4 +254,10 @@ uint8_t HiveConfig::parquetWriteTimestampUnit(const Config* session) const {
   return unit;
 }
 
+bool HiveConfig::cacheNoRetention(const Config* session) const {
+  return session->get<bool>(
+      kCacheNoRetentionSession,
+      config_->get<bool>(kCacheNoRetention, /*defaultValue=*/false));
+}
+
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -44,8 +44,9 @@ class HiveConfig {
 
   /// Maximum number of (bucketed) partitions per a single table writer
   /// instance.
-  // TODO: remove hive_orc_use_column_names since it doesn't exist in presto,
-  // right now this is only used for testing.
+  ///
+  /// TODO: remove hive_orc_use_column_names since it doesn't exist in presto,
+  /// right now this is only used for testing.
   static constexpr const char* kMaxPartitionsPerWriters =
       "max-partitions-per-writers";
   static constexpr const char* kMaxPartitionsPerWritersSession =
@@ -211,6 +212,9 @@ class HiveConfig {
   static constexpr const char* kParquetWriteTimestampUnitSession =
       "hive.parquet.writer.timestamp_unit";
 
+  static constexpr const char* kCacheNoRetention = "cache.no_retention";
+  static constexpr const char* kCacheNoRetentionSession = "cache.no_retention";
+
   InsertExistingPartitionsBehavior insertExistingPartitionsBehavior(
       const Config* session) const;
 
@@ -297,6 +301,13 @@ class HiveConfig {
   /// Returns the timestamp unit used when writing timestamps into Parquet
   /// through Arrow bridge. 0: second, 3: milli, 6: micro, 9: nano.
   uint8_t parquetWriteTimestampUnit(const Config* session) const;
+
+  /// Returns true to evict out a query scanned data out of in-memory cache
+  /// right after the access, and also skip staging to the ssd cache. This helps
+  /// to prevent the cache space pollution from the one-time table scan by large
+  /// batch query when mixed running with interactive query which has high data
+  /// locality.
+  bool cacheNoRetention(const Config* session) const;
 
   HiveConfig(std::shared_ptr<const Config> config) {
     VELOX_CHECK_NOT_NULL(

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -538,12 +538,14 @@ void configureReaderOptions(
   readerOptions.setFooterEstimatedSize(hiveConfig->footerEstimatedSize());
   readerOptions.setFilePreloadThreshold(hiveConfig->filePreloadThreshold());
   readerOptions.setPrefetchRowGroups(hiveConfig->prefetchRowGroups());
+  readerOptions.setNoCacheRetention(
+      hiveConfig->cacheNoRetention(sessionProperties));
 
-  if (readerOptions.getFileFormat() != dwio::common::FileFormat::UNKNOWN) {
+  if (readerOptions.fileFormat() != dwio::common::FileFormat::UNKNOWN) {
     VELOX_CHECK(
-        readerOptions.getFileFormat() == hiveSplit->fileFormat,
+        readerOptions.fileFormat() == hiveSplit->fileFormat,
         "HiveDataSource received splits of different formats: {} and {}",
-        dwio::common::toString(readerOptions.getFileFormat()),
+        dwio::common::toString(readerOptions.fileFormat()),
         dwio::common::toString(hiveSplit->fileFormat));
   } else {
     auto serDeOptions =

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -225,7 +225,7 @@ std::string SplitReader::toString() const {
 
 void SplitReader::createReader() {
   VELOX_CHECK_NE(
-      baseReaderOpts_.getFileFormat(), dwio::common::FileFormat::UNKNOWN);
+      baseReaderOpts_.fileFormat(), dwio::common::FileFormat::UNKNOWN);
 
   FileHandleCachedPtr fileHandleCachePtr;
   try {
@@ -258,7 +258,7 @@ void SplitReader::createReader() {
       ioStats_,
       executor_);
 
-  baseReader_ = dwio::common::getReaderFactory(baseReaderOpts_.getFileFormat())
+  baseReader_ = dwio::common::getReaderFactory(baseReaderOpts_.fileFormat())
                     ->createReader(std::move(baseFileInput), baseReaderOpts_);
 }
 
@@ -295,7 +295,7 @@ void SplitReader::createRowReader(
     std::shared_ptr<common::MetadataFilter> metadataFilter,
     const std::shared_ptr<HiveColumnHandle>& rowIndexColumn) {
   auto& fileType = baseReader_->rowType();
-  auto columnTypes = adaptColumns(fileType, baseReaderOpts_.getFileSchema());
+  auto columnTypes = adaptColumns(fileType, baseReaderOpts_.fileSchema());
   auto columnNames = fileType->names();
   if (rowIndexColumn != nullptr) {
     setRowIndexColumn(fileType, rowIndexColumn);

--- a/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
@@ -102,7 +102,7 @@ PositionalDeleteFileReader::PositionalDeleteFileReader(
       executor_);
 
   auto deleteReader =
-      dwio::common::getReaderFactory(deleteReaderOpts.getFileFormat())
+      dwio::common::getReaderFactory(deleteReaderOpts.fileFormat())
           ->createReader(std::move(deleteFileInput), deleteReaderOpts);
 
   // Check if the whole delete file split can be skipped. This could happen when

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -65,6 +65,7 @@ TEST(HiveConfigTest, defaultConfig) {
   ASSERT_EQ(
       hiveConfig->orcWriterLinearStripeSizeHeuristics(emptySession.get()),
       true);
+  ASSERT_FALSE(hiveConfig->cacheNoRetention(emptySession.get()));
 }
 
 TEST(HiveConfigTest, overrideConfig) {
@@ -95,7 +96,8 @@ TEST(HiveConfigTest, overrideConfig) {
       {HiveConfig::kSortWriterMaxOutputRows, "100"},
       {HiveConfig::kSortWriterMaxOutputBytes, "100MB"},
       {HiveConfig::kOrcWriterLinearStripeSizeHeuristics, "false"},
-      {HiveConfig::kOrcWriterMinCompressionSize, "512"}};
+      {HiveConfig::kOrcWriterMinCompressionSize, "512"},
+      {HiveConfig::kCacheNoRetention, "true"}};
   HiveConfig* hiveConfig =
       new HiveConfig(std::make_shared<MemConfig>(configFromFile));
   auto emptySession = std::make_unique<MemConfig>();
@@ -137,6 +139,7 @@ TEST(HiveConfigTest, overrideConfig) {
   ASSERT_EQ(
       hiveConfig->orcWriterLinearStripeSizeHeuristics(emptySession.get()),
       false);
+  ASSERT_TRUE(hiveConfig->cacheNoRetention(emptySession.get()));
 }
 
 TEST(HiveConfigTest, overrideSession) {
@@ -152,7 +155,8 @@ TEST(HiveConfigTest, overrideSession) {
       {HiveConfig::kPartitionPathAsLowerCaseSession, "false"},
       {HiveConfig::kIgnoreMissingFilesSession, "true"},
       {HiveConfig::kOrcWriterMinCompressionSizeSession, "512"},
-      {HiveConfig::kOrcWriterLinearStripeSizeHeuristicsSession, "false"}};
+      {HiveConfig::kOrcWriterLinearStripeSizeHeuristicsSession, "false"},
+      {HiveConfig::kCacheNoRetentionSession, "true"}};
   const auto session = std::make_unique<MemConfig>(sessionOverride);
   ASSERT_EQ(
       hiveConfig->insertExistingPartitionsBehavior(session.get()),
@@ -191,4 +195,5 @@ TEST(HiveConfigTest, overrideSession) {
   ASSERT_EQ(
       hiveConfig->orcWriterLinearStripeSizeHeuristics(session.get()), false);
   ASSERT_EQ(hiveConfig->orcWriterMinCompressionSize(session.get()), 512);
+  ASSERT_TRUE(hiveConfig->cacheNoRetention(session.get()));
 }

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -98,26 +98,23 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
 
   // Default.
   performConfigure();
-  EXPECT_EQ(readerOptions.getFileFormat(), fileFormat);
-  EXPECT_TRUE(
-      compareSerDeOptions(readerOptions.getSerDeOptions(), expectedSerDe));
+  EXPECT_EQ(readerOptions.fileFormat(), fileFormat);
+  EXPECT_TRUE(compareSerDeOptions(readerOptions.serDeOptions(), expectedSerDe));
   EXPECT_EQ(readerOptions.loadQuantum(), hiveConfig->loadQuantum());
   EXPECT_EQ(readerOptions.maxCoalesceBytes(), hiveConfig->maxCoalescedBytes());
   EXPECT_EQ(
       readerOptions.maxCoalesceDistance(),
       hiveConfig->maxCoalescedDistanceBytes());
   EXPECT_EQ(
-      readerOptions.isFileColumnNamesReadAsLowerCase(),
+      readerOptions.fileColumnNamesReadAsLowerCase(),
       hiveConfig->isFileColumnNamesReadAsLowerCase(&sessionProperties));
   EXPECT_EQ(
-      readerOptions.isUseColumnNamesForColumnMapping(),
+      readerOptions.useColumnNamesForColumnMapping(),
       hiveConfig->isOrcUseColumnNames(&sessionProperties));
   EXPECT_EQ(
-      readerOptions.getFooterEstimatedSize(),
-      hiveConfig->footerEstimatedSize());
+      readerOptions.footerEstimatedSize(), hiveConfig->footerEstimatedSize());
   EXPECT_EQ(
-      readerOptions.getFilePreloadThreshold(),
-      hiveConfig->filePreloadThreshold());
+      readerOptions.filePreloadThreshold(), hiveConfig->filePreloadThreshold());
   EXPECT_EQ(readerOptions.prefetchRowGroups(), hiveConfig->prefetchRowGroups());
 
   // Modify field delimiter and change the file format.
@@ -125,33 +122,29 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
   serdeParameters[SerDeOptions::kFieldDelim] = '\t';
   expectedSerDe.separators[size_t(SerDeSeparator::FIELD_DELIM)] = '\t';
   performConfigure();
-  EXPECT_EQ(readerOptions.getFileFormat(), fileFormat);
-  EXPECT_TRUE(
-      compareSerDeOptions(readerOptions.getSerDeOptions(), expectedSerDe));
+  EXPECT_EQ(readerOptions.fileFormat(), fileFormat);
+  EXPECT_TRUE(compareSerDeOptions(readerOptions.serDeOptions(), expectedSerDe));
 
   // Modify collection delimiter.
   clearDynamicParameters(FileFormat::TEXT);
   serdeParameters[SerDeOptions::kCollectionDelim] = '=';
   expectedSerDe.separators[size_t(SerDeSeparator::COLLECTION_DELIM)] = '=';
   performConfigure();
-  EXPECT_TRUE(
-      compareSerDeOptions(readerOptions.getSerDeOptions(), expectedSerDe));
+  EXPECT_TRUE(compareSerDeOptions(readerOptions.serDeOptions(), expectedSerDe));
 
   // Modify map key delimiter.
   clearDynamicParameters(FileFormat::TEXT);
   serdeParameters[SerDeOptions::kMapKeyDelim] = '&';
   expectedSerDe.separators[size_t(SerDeSeparator::MAP_KEY_DELIM)] = '&';
   performConfigure();
-  EXPECT_TRUE(
-      compareSerDeOptions(readerOptions.getSerDeOptions(), expectedSerDe));
+  EXPECT_TRUE(compareSerDeOptions(readerOptions.serDeOptions(), expectedSerDe));
 
   // Modify null string.
   clearDynamicParameters(FileFormat::TEXT);
   tableParameters[TableParameter::kSerializationNullFormat] = "x-x";
   expectedSerDe.nullString = "x-x";
   performConfigure();
-  EXPECT_TRUE(
-      compareSerDeOptions(readerOptions.getSerDeOptions(), expectedSerDe));
+  EXPECT_TRUE(compareSerDeOptions(readerOptions.serDeOptions(), expectedSerDe));
 
   // Modify all previous together.
   clearDynamicParameters(FileFormat::TEXT);
@@ -164,14 +157,10 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
   tableParameters[TableParameter::kSerializationNullFormat] = "";
   expectedSerDe.nullString = "";
   performConfigure();
-  EXPECT_TRUE(
-      compareSerDeOptions(readerOptions.getSerDeOptions(), expectedSerDe));
-  EXPECT_TRUE(
-      compareSerDeOptions(readerOptions.getSerDeOptions(), expectedSerDe));
-  EXPECT_TRUE(
-      compareSerDeOptions(readerOptions.getSerDeOptions(), expectedSerDe));
-  EXPECT_TRUE(
-      compareSerDeOptions(readerOptions.getSerDeOptions(), expectedSerDe));
+  EXPECT_TRUE(compareSerDeOptions(readerOptions.serDeOptions(), expectedSerDe));
+  EXPECT_TRUE(compareSerDeOptions(readerOptions.serDeOptions(), expectedSerDe));
+  EXPECT_TRUE(compareSerDeOptions(readerOptions.serDeOptions(), expectedSerDe));
+  EXPECT_TRUE(compareSerDeOptions(readerOptions.serDeOptions(), expectedSerDe));
 
   // Tests other custom reader options.
   clearDynamicParameters(FileFormat::TEXT);
@@ -194,17 +183,15 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
       readerOptions.maxCoalesceDistance(),
       hiveConfig->maxCoalescedDistanceBytes());
   EXPECT_EQ(
-      readerOptions.isFileColumnNamesReadAsLowerCase(),
+      readerOptions.fileColumnNamesReadAsLowerCase(),
       hiveConfig->isFileColumnNamesReadAsLowerCase(&sessionProperties));
   EXPECT_EQ(
-      readerOptions.isUseColumnNamesForColumnMapping(),
+      readerOptions.useColumnNamesForColumnMapping(),
       hiveConfig->isOrcUseColumnNames(&sessionProperties));
   EXPECT_EQ(
-      readerOptions.getFooterEstimatedSize(),
-      hiveConfig->footerEstimatedSize());
+      readerOptions.footerEstimatedSize(), hiveConfig->footerEstimatedSize());
   EXPECT_EQ(
-      readerOptions.getFilePreloadThreshold(),
-      hiveConfig->filePreloadThreshold());
+      readerOptions.filePreloadThreshold(), hiveConfig->filePreloadThreshold());
   EXPECT_EQ(readerOptions.prefetchRowGroups(), hiveConfig->prefetchRowGroups());
 }
 

--- a/velox/dwio/common/CacheInputStream.h
+++ b/velox/dwio/common/CacheInputStream.h
@@ -35,10 +35,13 @@ class CacheInputStream : public SeekableInputStream {
       const velox::common::Region& region,
       std::shared_ptr<ReadFileInputStream> input,
       uint64_t fileNum,
+      bool noCacheRetention,
       std::shared_ptr<cache::ScanTracker> tracker,
       cache::TrackingId trackingId,
       uint64_t groupId,
       int32_t loadQuantum);
+
+  ~CacheInputStream() override;
 
   bool Next(const void** data, int* size) override;
   void BackUp(int count) override;
@@ -48,16 +51,15 @@ class CacheInputStream : public SeekableInputStream {
   std::string getName() const override;
   size_t positionSize() override;
 
-  /// Returns a copy of 'this', ranging over the same bytes. The clone
-  /// is initially positioned at the position of 'this' and can be
-  /// moved independently within 'region_'.  This is used for first
-  /// caching a range of bytes from a file and then giving out
-  /// delimited subranges of this to callers. skip() and
-  /// setRemainingBytes() set the bounds of the window exposed by the
-  /// clone. In specific, reading protocol buffers requires a stream
-  /// that begins and ends at the exact start and end of the
-  /// serialization. Reading these from cache requires an exactly
-  /// delimited stream.
+  /// Returns a copy of 'this', ranging over the same bytes. The clone is
+  /// initially positioned at the position of 'this' and can be moved
+  /// independently within 'region_'.  This is used for first caching a range of
+  /// bytes from a file and then giving out delimited subranges of this to
+  /// callers. skip() and setRemainingBytes() set the bounds of the window
+  /// exposed by the clone. In specific, reading protocol buffers requires a
+  /// stream that begins and ends at the exact start and end of the
+  /// serialization. Reading these from cache requires an exactly delimited
+  /// stream.
   std::unique_ptr<CacheInputStream> clone() {
     auto copy = std::make_unique<CacheInputStream>(
         bufferedInput_,
@@ -65,6 +67,7 @@ class CacheInputStream : public SeekableInputStream {
         region_,
         input_,
         fileNum_,
+        noCacheRetention_,
         tracker_,
         trackingId_,
         groupId_,
@@ -90,24 +93,32 @@ class CacheInputStream : public SeekableInputStream {
     prefetchPct_ = pct;
   }
 
-  /// Enables a mode where cache entries are made immediately evictable after
-  /// unpinning.
-  void setNoRetention() {
-    noRetention_ = true;
+  bool testingNoCacheRetention() const {
+    return noCacheRetention_;
   }
 
  private:
   // Ensures that the current position is covered by 'pin_'.
   void loadPosition();
 
+  // Returns the next quantized region to load with given loaded position.
+  velox::common::Region nextQuantizedLoadRegion(
+      uint64_t prevLoadedPosition) const;
+
   // Synchronously sets 'pin_' to cover 'region'.
-  void loadSync(velox::common::Region region);
+  void loadSync(const velox::common::Region& region);
 
   // Returns true if there is an SSD cache and 'entry' is present there and
   // successfully loaded.
   bool loadFromSsd(
-      velox::common::Region region,
+      const velox::common::Region& region,
       cache::AsyncDataCacheEntry& entry);
+
+  // Invoked to clear the cache pin of the accessed cache entry and mark it as
+  // immediate evictable if 'noCacheRetention_' flag is set.
+  void clearCachePin();
+
+  void makeCacheEvictable();
 
   // Return SSD cache file path if exists; return empty string if no SSD cache
   // file.
@@ -115,18 +126,23 @@ class CacheInputStream : public SeekableInputStream {
 
   CachedBufferedInput* const bufferedInput_;
   cache::AsyncDataCache* const cache_;
-  IoStatistics* ioStats_;
-  std::shared_ptr<ReadFileInputStream> input_;
+  // True if a pin should be set to the lowest retention score after
+  // unpinning. This applies to sequential reads where second access
+  // to the page is not expected.
+  const bool noCacheRetention_;
   // The region of 'input' 'this' ranges over.
   const velox::common::Region region_;
   const uint64_t fileNum_;
-  std::shared_ptr<cache::ScanTracker> tracker_;
+  const std::shared_ptr<cache::ScanTracker> tracker_;
   const cache::TrackingId trackingId_;
   const uint64_t groupId_;
 
   // Maximum number of bytes read from 'input' at a time. This gives the maximum
   // pin_.entry()->size().
   const int32_t loadQuantum_;
+
+  IoStatistics* const ioStats_;
+  const std::shared_ptr<ReadFileInputStream> input_;
 
   // Handle of cache entry.
   cache::CachePin pin_;
@@ -147,21 +163,16 @@ class CacheInputStream : public SeekableInputStream {
   uint64_t position_ = 0;
 
   // A restricted view over 'region'. offset is relative to 'region_'. A cloned
-  // CacheInputStream can cover a subrange of the range of the original.
+  // CacheInputStream can cover a sub-range of the range of the original.
   std::optional<velox::common::Region> window_;
 
   // Percentage of 'loadQuantum_' at which the next load quantum gets scheduled.
   // Over 100 means no prefetch.
   int32_t prefetchPct_{200};
 
-  // True if prefetch f the next 'loadQuantum_' has been started. Cleared when
+  // True if prefetch the next 'loadQuantum_' has been started. Cleared when
   // moving to the next load quantum.
   bool prefetchStarted_{false};
-
-  // True if a pin should be set to the lowest retention score after
-  // unpinning. This applies to sequential reads where second access
-  // to the page is not expected.
-  bool noRetention_{false};
 };
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/CachedBufferedInput.h
+++ b/velox/dwio/common/CachedBufferedInput.h
@@ -46,10 +46,10 @@ struct CacheRequest {
 
   bool processed{false};
 
-  // True if this should be coalesced into a CoalescedLoad with other
-  // nearby requests with a similar load probability. This is false
-  // for sparsely accessed large columns where hitting one piece
-  // should not load the adjacent pieces.
+  /// True if this should be coalesced into a CoalescedLoad with other nearby
+  /// requests with a similar load probability. This is false for sparsely
+  /// accessed large columns where hitting one piece should not load the
+  /// adjacent pieces.
   bool coalesces{true};
   const SeekableInputStream* stream;
 };
@@ -68,7 +68,7 @@ class CachedBufferedInput : public BufferedInput {
       const io::ReaderOptions& readerOptions)
       : BufferedInput(
             std::move(readFile),
-            readerOptions.getMemoryPool(),
+            readerOptions.memoryPool(),
             metricsLog),
         cache_(cache),
         fileNum_(fileNum),
@@ -88,7 +88,7 @@ class CachedBufferedInput : public BufferedInput {
       std::shared_ptr<IoStatistics> ioStats,
       folly::Executor* executor,
       const io::ReaderOptions& readerOptions)
-      : BufferedInput(std::move(input), readerOptions.getMemoryPool()),
+      : BufferedInput(std::move(input), readerOptions.memoryPool()),
         cache_(cache),
         fileNum_(fileNum),
         tracker_(std::move(tracker)),
@@ -106,11 +106,11 @@ class CachedBufferedInput : public BufferedInput {
 
   std::unique_ptr<SeekableInputStream> enqueue(
       velox::common::Region region,
-      const StreamIdentifier* si) override;
+      const StreamIdentifier* sid) override;
 
-  void load(const LogType) override;
+  void load(const LogType /*unused*/) override;
 
-  bool isBuffered(uint64_t offset, uint64_t length) const override;
+  bool isBuffered(uint64_t /*unused*/, uint64_t /*unused*/) const override;
 
   std::unique_ptr<SeekableInputStream>
   read(uint64_t offset, uint64_t length, LogType logType) const override;
@@ -148,10 +148,9 @@ class CachedBufferedInput : public BufferedInput {
     return cache_;
   }
 
-  // Returns the CoalescedLoad that contains the correlated loads for
-  // 'stream' or nullptr if none. Returns nullptr on all but first
-  // call for 'stream' since the load is to be triggered by the first
-  // access.
+  /// Returns the CoalescedLoad that contains the correlated loads for 'stream'
+  /// or nullptr if none. Returns nullptr on all but first call for 'stream'
+  /// since the load is to be triggered by the first access.
   std::shared_ptr<cache::CoalescedLoad> coalescedLoad(
       const SeekableInputStream* stream);
 
@@ -168,19 +167,20 @@ class CachedBufferedInput : public BufferedInput {
   // is true, starts background loading.
   void makeLoads(std::vector<CacheRequest*> requests, bool prefetch);
 
-  // Makes a CoalescedLoad for 'requests' to be read together, coalescing
-  // IO is appropriate. If 'prefetch' is set, schedules the CoalescedLoad
-  // on 'executor_'. Links the CoalescedLoad  to all CacheInputStreams that it
+  // Makes a CoalescedLoad for 'requests' to be read together, coalescing IO is
+  // appropriate. If 'prefetch' is set, schedules the CoalescedLoad on
+  // 'executor_'. Links the CoalescedLoad to all CacheInputStreams that it
   // concerns.
+  void readRegion(const std::vector<CacheRequest*>& requests, bool prefetch);
 
-  void readRegion(std::vector<CacheRequest*> requests, bool prefetch);
-
-  cache::AsyncDataCache* cache_;
+  cache::AsyncDataCache* const cache_;
   const uint64_t fileNum_;
-  std::shared_ptr<cache::ScanTracker> tracker_;
+  const std::shared_ptr<cache::ScanTracker> tracker_;
   const uint64_t groupId_;
-  std::shared_ptr<IoStatistics> ioStats_;
+  const std::shared_ptr<IoStatistics> ioStats_;
   folly::Executor* const executor_;
+  const uint64_t fileSize_;
+  const io::ReaderOptions options_;
 
   // Regions that are candidates for loading.
   std::vector<CacheRequest> requests_;
@@ -193,9 +193,6 @@ class CachedBufferedInput : public BufferedInput {
 
   // Distinct coalesced loads in 'coalescedLoads_'.
   std::vector<std::shared_ptr<cache::CoalescedLoad>> allCoalescedLoads_;
-
-  const uint64_t fileSize_;
-  io::ReaderOptions options_;
 };
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/DirectBufferedInput.h
+++ b/velox/dwio/common/DirectBufferedInput.h
@@ -43,7 +43,7 @@ struct LoadRequest {
   /// Buffers to be handed to 'stream' after load.
   memory::Allocation data;
   std::string tinyData;
-  // Number of bytes in 'data/tinyData'.
+  /// Number of bytes in 'data/tinyData'.
   int32_t loadSize{0};
 };
 
@@ -69,16 +69,16 @@ class DirectCoalescedLoad : public cache::CoalescedLoad {
     }
   };
 
-  // Loads the regions. Returns {} since no cache entries are made. The loaded
-  // data is retrieved with getData().
-  std::vector<cache::CachePin> loadData(bool isPrefetch) override;
+  /// Loads the regions. Returns {} since no cache entries are made. The loaded
+  /// data is retrieved with getData().
+  std::vector<cache::CachePin> loadData(bool prefetch) override;
 
-  // Returns the buffer for 'region' in either 'data' or 'tinyData'. 'region'
-  // must match a region given to SelectiveBufferedInput::enqueue().
+  /// Returns the buffer for 'region' in either 'data' or 'tinyData'. 'region'
+  /// must match a region given to DirectBufferedInput::enqueue().
   int32_t
   getData(int64_t offset, memory::Allocation& data, std::string& tinyData);
 
-  const auto& requests() {
+  const std::vector<LoadRequest>& requests() {
     return requests_;
   }
 
@@ -114,7 +114,7 @@ class DirectBufferedInput : public BufferedInput {
       const io::ReaderOptions& readerOptions)
       : BufferedInput(
             std::move(readFile),
-            readerOptions.getMemoryPool(),
+            readerOptions.memoryPool(),
             metricsLog),
         fileNum_(fileNum),
         tracker_(std::move(tracker)),
@@ -158,7 +158,7 @@ class DirectBufferedInput : public BufferedInput {
   }
 
   memory::MemoryPool* pool() {
-    return &pool_;
+    return pool_;
   }
 
   /// Returns the CoalescedLoad that contains the correlated loads for
@@ -186,7 +186,7 @@ class DirectBufferedInput : public BufferedInput {
       std::shared_ptr<IoStatistics> ioStats,
       folly::Executor* executor,
       const io::ReaderOptions& readerOptions)
-      : BufferedInput(std::move(input), readerOptions.getMemoryPool()),
+      : BufferedInput(std::move(input), readerOptions.memoryPool()),
         fileNum_(fileNum),
         tracker_(std::move(tracker)),
         groupId_(groupId),
@@ -195,13 +195,13 @@ class DirectBufferedInput : public BufferedInput {
         fileSize_(input_->getLength()),
         options_(readerOptions) {}
 
-  // Sorts requests and makes CoalescedLoads for nearby requests. If
-  // 'shouldPrefetch' is true, starts background loading.
-  void makeLoads(std::vector<LoadRequest*> requests, bool shouldPrefetch);
+  // Sorts requests and makes CoalescedLoads for nearby requests. If 'prefetch'
+  // is true, starts background loading.
+  void makeLoads(std::vector<LoadRequest*> requests, bool prefetch);
 
-  // Makes a CoalescedLoad for 'requests' to be read together, coalescing
-  // IO if appropriate. If 'prefetch' is set, schedules the CoalescedLoad
-  // on 'executor_'. Links the CoalescedLoad  to all DirectInputStreams that it
+  // Makes a CoalescedLoad for 'requests' to be read together, coalescing IO if
+  // appropriate. If 'prefetch' is set, schedules the CoalescedLoad on
+  // 'executor_'. Links the CoalescedLoad  to all DirectInputStreams that it
   // covers.
   void readRegion(std::vector<LoadRequest*> requests, bool prefetch);
 

--- a/velox/dwio/common/InputStream.cpp
+++ b/velox/dwio/common/InputStream.cpp
@@ -16,15 +16,10 @@
 
 #include "velox/dwio/common/InputStream.h"
 
-#include <fcntl.h>
 #include <folly/container/F14Map.h>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#include <cerrno>
 #include <cstdint>
-#include <cstring>
 #include <functional>
 #include <istream>
 #include <numeric>
@@ -88,16 +83,13 @@ void ReadFileInputStream::read(
     stats_->incTotalScanTime((getCurrentTimeMicro() - readStartMicros) * 1000);
   }
 
-  DWIO_ENSURE_EQ(
+  VELOX_CHECK_EQ(
       data_read.size(),
       length,
-      "Should read exactly as requested. File name: ",
+      "Should read exactly as requested. File name: {}, offset: {}, length: {}, read: {}",
       getName(),
-      ", offset: ",
       offset,
-      ", length: ",
       length,
-      ", read: ",
       data_read.size());
 }
 
@@ -108,16 +100,13 @@ void ReadFileInputStream::read(
   const int64_t bufferSize = totalBufferSize(buffers);
   logRead(offset, bufferSize, logType);
   auto size = readFile_->preadv(offset, buffers);
-  DWIO_ENSURE_EQ(
+  VELOX_CHECK_EQ(
       size,
       bufferSize,
-      "Should read exactly as requested. File name: ",
+      "Should read exactly as requested. File name: {}, offset: {}, length: {}, read: {}",
       getName(),
-      ", offset: ",
       offset,
-      ", length: ",
       bufferSize,
-      ", read: ",
       size);
 }
 
@@ -138,7 +127,7 @@ void ReadFileInputStream::vread(
     folly::Range<const velox::common::Region*> regions,
     folly::Range<folly::IOBuf*> iobufs,
     const LogType purpose) {
-  DWIO_ENSURE_GT(regions.size(), 0, "regions to read can't be empty");
+  VELOX_CHECK_GT(regions.size(), 0, "regions to read can't be empty");
   const size_t length = std::accumulate(
       regions.cbegin(),
       regions.cend(),

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -429,19 +429,6 @@ class RowReaderOptions {
  * Options for creating a Reader.
  */
 class ReaderOptions : public io::ReaderOptions {
- private:
-  uint64_t tailLocation;
-  FileFormat fileFormat;
-  RowTypePtr fileSchema;
-  SerDeOptions serDeOptions;
-  std::shared_ptr<encryption::DecrypterFactory> decrypterFactory_;
-  uint64_t footerEstimatedSize{kDefaultFooterEstimatedSize};
-  uint64_t filePreloadThreshold{kDefaultFilePreloadThreshold};
-  bool fileColumnNamesReadAsLowerCase{false};
-  bool useColumnNamesForColumnMapping_{false};
-  std::shared_ptr<folly::Executor> ioExecutor_;
-  std::shared_ptr<random::RandomSkipTracker> randomSkip_;
-
  public:
   static constexpr uint64_t kDefaultFooterEstimatedSize = 1024 * 1024; // 1MB
   static constexpr uint64_t kDefaultFilePreloadThreshold =
@@ -449,74 +436,62 @@ class ReaderOptions : public io::ReaderOptions {
 
   explicit ReaderOptions(velox::memory::MemoryPool* pool)
       : io::ReaderOptions(pool),
-        tailLocation(std::numeric_limits<uint64_t>::max()),
-        fileFormat(FileFormat::UNKNOWN),
-        fileSchema(nullptr) {}
+        tailLocation_(std::numeric_limits<uint64_t>::max()),
+        fileFormat_(FileFormat::UNKNOWN),
+        fileSchema_(nullptr) {}
 
   ReaderOptions& operator=(const ReaderOptions& other) {
     io::ReaderOptions::operator=(other);
-    tailLocation = other.tailLocation;
-    fileFormat = other.fileFormat;
-    if (other.fileSchema != nullptr) {
-      fileSchema = other.getFileSchema();
-    } else {
-      fileSchema = nullptr;
-    }
-    serDeOptions = other.serDeOptions;
+    tailLocation_ = other.tailLocation_;
+    fileFormat_ = other.fileFormat_;
+    fileSchema_ = other.fileSchema_;
+    serDeOptions_ = other.serDeOptions_;
     decrypterFactory_ = other.decrypterFactory_;
-    footerEstimatedSize = other.footerEstimatedSize;
-    filePreloadThreshold = other.filePreloadThreshold;
-    fileColumnNamesReadAsLowerCase = other.fileColumnNamesReadAsLowerCase;
+    footerEstimatedSize_ = other.footerEstimatedSize_;
+    filePreloadThreshold_ = other.filePreloadThreshold_;
+    fileColumnNamesReadAsLowerCase_ = other.fileColumnNamesReadAsLowerCase_;
     useColumnNamesForColumnMapping_ = other.useColumnNamesForColumnMapping_;
     return *this;
   }
 
   ReaderOptions(const ReaderOptions& other)
       : io::ReaderOptions(other),
-        tailLocation(other.tailLocation),
-        fileFormat(other.fileFormat),
-        fileSchema(other.fileSchema),
-        serDeOptions(other.serDeOptions),
+        tailLocation_(other.tailLocation_),
+        fileFormat_(other.fileFormat_),
+        fileSchema_(other.fileSchema_),
+        serDeOptions_(other.serDeOptions_),
         decrypterFactory_(other.decrypterFactory_),
-        footerEstimatedSize(other.footerEstimatedSize),
-        filePreloadThreshold(other.filePreloadThreshold),
-        fileColumnNamesReadAsLowerCase(other.fileColumnNamesReadAsLowerCase),
+        footerEstimatedSize_(other.footerEstimatedSize_),
+        filePreloadThreshold_(other.filePreloadThreshold_),
+        fileColumnNamesReadAsLowerCase_(other.fileColumnNamesReadAsLowerCase_),
         useColumnNamesForColumnMapping_(other.useColumnNamesForColumnMapping_) {
   }
 
-  /**
-   * Set the format of the file, such as "rc" or "dwrf".  The
-   * default is "dwrf".
-   */
+  /// Sets the format of the file, such as "rc" or "dwrf". The default is
+  /// "dwrf".
   ReaderOptions& setFileFormat(FileFormat format) {
-    fileFormat = format;
+    fileFormat_ = format;
     return *this;
   }
 
-  /**
-   * Set the schema of the file (a Type tree).
-   * For "dwrf" format, a default schema is derived from the file.
-   * For "rc" format, there is no default schema.
-   */
+  /// Sets the schema of the file (a Type tree).  For "dwrf" format, a default
+  /// schema is derived from the file. For "rc" format, there is no default
+  /// schema.
   ReaderOptions& setFileSchema(const RowTypePtr& schema) {
-    fileSchema = schema;
+    fileSchema_ = schema;
     return *this;
   }
 
-  /**
-   * Set the location of the tail as defined by the logical length of the
-   * file.
-   */
+  /// Sets the location of the tail as defined by the logical length of the
+  /// file.
   ReaderOptions& setTailLocation(uint64_t offset) {
-    tailLocation = offset;
+    tailLocation_ = offset;
     return *this;
   }
 
-  /**
-   * Modify the serialization-deserialization options.
-   */
-  ReaderOptions& setSerDeOptions(const SerDeOptions& sdo) {
-    serDeOptions = sdo;
+  /// Modifies the serialization-deserialization options.
+  ReaderOptions& setSerDeOptions(const SerDeOptions& serdeOpts) {
+    serDeOptions_ = serdeOpts;
     return *this;
   }
 
@@ -527,17 +502,17 @@ class ReaderOptions : public io::ReaderOptions {
   }
 
   ReaderOptions& setFooterEstimatedSize(uint64_t size) {
-    footerEstimatedSize = size;
+    footerEstimatedSize_ = size;
     return *this;
   }
 
   ReaderOptions& setFilePreloadThreshold(uint64_t threshold) {
-    filePreloadThreshold = threshold;
+    filePreloadThreshold_ = threshold;
     return *this;
   }
 
   ReaderOptions& setFileColumnNamesReadAsLowerCase(bool flag) {
-    fileColumnNamesReadAsLowerCase = flag;
+    fileColumnNamesReadAsLowerCase_ = flag;
     return *this;
   }
 
@@ -551,58 +526,50 @@ class ReaderOptions : public io::ReaderOptions {
     return *this;
   }
 
-  /**
-   * Get the desired tail location.
-   * @return if not set, return the maximum long.
-   */
-  uint64_t getTailLocation() const {
-    return tailLocation;
+  /// Gets the desired tail location.
+  uint64_t tailLocation() const {
+    return tailLocation_;
   }
 
-  /**
-   * Get the file format.
-   */
-  FileFormat getFileFormat() const {
-    return fileFormat;
+  /// Gets the file format.
+  FileFormat fileFormat() const {
+    return fileFormat_;
   }
 
-  /**
-   * Get the file schema.
-   */
-  const std::shared_ptr<const velox::RowType>& getFileSchema() const {
-    return fileSchema;
+  /// Gets the file schema.
+  const std::shared_ptr<const velox::RowType>& fileSchema() const {
+    return fileSchema_;
   }
 
-  SerDeOptions& getSerDeOptions() {
-    return serDeOptions;
+  SerDeOptions& serDeOptions() {
+    return serDeOptions_;
   }
 
-  const SerDeOptions& getSerDeOptions() const {
-    return serDeOptions;
+  const SerDeOptions& serDeOptions() const {
+    return serDeOptions_;
   }
 
-  const std::shared_ptr<encryption::DecrypterFactory> getDecrypterFactory()
-      const {
+  const std::shared_ptr<encryption::DecrypterFactory> decrypterFactory() const {
     return decrypterFactory_;
   }
 
-  uint64_t getFooterEstimatedSize() const {
-    return footerEstimatedSize;
+  uint64_t footerEstimatedSize() const {
+    return footerEstimatedSize_;
   }
 
-  uint64_t getFilePreloadThreshold() const {
-    return filePreloadThreshold;
+  uint64_t filePreloadThreshold() const {
+    return filePreloadThreshold_;
   }
 
-  const std::shared_ptr<folly::Executor>& getIOExecutor() const {
+  const std::shared_ptr<folly::Executor>& ioExecutor() const {
     return ioExecutor_;
   }
 
-  bool isFileColumnNamesReadAsLowerCase() const {
-    return fileColumnNamesReadAsLowerCase;
+  bool fileColumnNamesReadAsLowerCase() const {
+    return fileColumnNamesReadAsLowerCase_;
   }
 
-  bool isUseColumnNamesForColumnMapping() const {
+  bool useColumnNamesForColumnMapping() const {
     return useColumnNamesForColumnMapping_;
   }
 
@@ -613,6 +580,27 @@ class ReaderOptions : public io::ReaderOptions {
   void setRandomSkip(std::shared_ptr<random::RandomSkipTracker> randomSkip) {
     randomSkip_ = randomSkip;
   }
+
+  bool noCacheRetention() const {
+    return noCacheRetention_;
+  }
+
+  void setNoCacheRetention(bool noCacheRetention) {
+    noCacheRetention_ = noCacheRetention;
+  }
+
+ private:
+  uint64_t tailLocation_;
+  FileFormat fileFormat_;
+  RowTypePtr fileSchema_;
+  SerDeOptions serDeOptions_;
+  std::shared_ptr<encryption::DecrypterFactory> decrypterFactory_;
+  uint64_t footerEstimatedSize_{kDefaultFooterEstimatedSize};
+  uint64_t filePreloadThreshold_{kDefaultFilePreloadThreshold};
+  bool fileColumnNamesReadAsLowerCase_{false};
+  bool useColumnNamesForColumnMapping_{false};
+  std::shared_ptr<folly::Executor> ioExecutor_;
+  std::shared_ptr<random::RandomSkipTracker> randomSkip_;
 };
 
 struct WriterOptions {

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
@@ -94,8 +94,7 @@ void E2EFilterTestBase::readWithoutFilter(
   dwio::common::ReaderOptions readerOpts{leafPool_.get()};
   dwio::common::RowReaderOptions rowReaderOpts;
   auto input = std::make_unique<BufferedInput>(
-      std::make_shared<InMemoryReadFile>(sinkData_),
-      readerOpts.getMemoryPool());
+      std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
   auto reader = makeReader(readerOpts, std::move(input));
 
   // The spec must stay live over the lifetime of the reader.
@@ -148,8 +147,7 @@ void E2EFilterTestBase::readWithFilter(
   dwio::common::ReaderOptions readerOpts{leafPool_.get()};
   dwio::common::RowReaderOptions rowReaderOpts;
   auto input = std::make_unique<BufferedInput>(
-      std::make_shared<InMemoryReadFile>(sinkData_),
-      readerOpts.getMemoryPool());
+      std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
   auto reader = makeReader(readerOpts, std::move(input));
 
   // The spec must stay live over the lifetime of the reader.
@@ -456,8 +454,7 @@ void E2EFilterTestBase::testMetadataFilterImpl(
   ReaderOptions readerOpts{leafPool_.get()};
   RowReaderOptions rowReaderOpts;
   auto input = std::make_unique<BufferedInput>(
-      std::make_shared<InMemoryReadFile>(sinkData_),
-      readerOpts.getMemoryPool());
+      std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
   auto reader = makeReader(readerOpts, std::move(input));
   setUpRowReaderOptions(rowReaderOpts, spec);
   rowReaderOpts.setMetadataFilter(metadataFilter);
@@ -653,8 +650,7 @@ void E2EFilterTestBase::testSubfieldsPruning() {
   ReaderOptions readerOpts{leafPool_.get()};
   RowReaderOptions rowReaderOpts;
   auto input = std::make_unique<BufferedInput>(
-      std::make_shared<InMemoryReadFile>(sinkData_),
-      readerOpts.getMemoryPool());
+      std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
   auto reader = makeReader(readerOpts, std::move(input));
   setUpRowReaderOptions(rowReaderOpts, spec);
   auto rowReader = reader->createRowReader(rowReaderOpts);
@@ -718,8 +714,7 @@ void E2EFilterTestBase::testMutationCornerCases() {
   writeToMemory(rowType, batches, false);
   ReaderOptions readerOpts{leafPool_.get()};
   auto input = std::make_unique<BufferedInput>(
-      std::make_shared<InMemoryReadFile>(sinkData_),
-      readerOpts.getMemoryPool());
+      std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
   auto reader = makeReader(readerOpts, std::move(input));
 
   // 1. Interleave batches with and without deletions.

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -744,14 +744,14 @@ DwrfReader::DwrfReader(
     const ReaderOptions& options,
     std::unique_ptr<dwio::common::BufferedInput> input)
     : readerBase_(std::make_unique<ReaderBase>(
-          options.getMemoryPool(),
+          options.memoryPool(),
           std::move(input),
-          options.getDecrypterFactory(),
-          options.getFooterEstimatedSize(),
-          options.getFilePreloadThreshold(),
-          options.getFileFormat() == FileFormat::ORC ? FileFormat::ORC
-                                                     : FileFormat::DWRF,
-          options.isFileColumnNamesReadAsLowerCase(),
+          options.decrypterFactory(),
+          options.footerEstimatedSize(),
+          options.filePreloadThreshold(),
+          options.fileFormat() == FileFormat::ORC ? FileFormat::ORC
+                                                  : FileFormat::DWRF,
+          options.fileColumnNamesReadAsLowerCase(),
           options.randomSkip())),
       options_(options) {
   // If we are not using column names to map table columns to file columns,
@@ -760,8 +760,8 @@ DwrfReader::DwrfReader(
   // code. So we rename column names in the file schema to match table schema.
   // We test the options to have 'fileSchema' (actually table schema) as most
   // of the unit tests fail to provide it.
-  if ((not options_.isUseColumnNamesForColumnMapping()) and
-      (options_.getFileSchema() != nullptr)) {
+  if ((!options_.useColumnNamesForColumnMapping()) &&
+      (options_.fileSchema() != nullptr)) {
     updateColumnNamesFromTableSchema();
   }
 }
@@ -853,7 +853,7 @@ TypePtr updateColumnNames(
 } // namespace
 
 void DwrfReader::updateColumnNamesFromTableSchema() {
-  const auto& tableSchema = options_.getFileSchema();
+  const auto& tableSchema = options_.fileSchema();
   const auto& fileSchema = readerBase_->getSchema();
   auto newSchema = std::dynamic_pointer_cast<const RowType>(
       updateColumnNames(fileSchema, tableSchema, "", ""));

--- a/velox/dwio/dwrf/test/ColumnWriterTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTest.cpp
@@ -1601,8 +1601,7 @@ std::unique_ptr<DwrfReader> getDwrfReader(
   return std::make_unique<DwrfReader>(
       readerOpts,
       std::make_unique<BufferedInput>(
-          std::make_shared<InMemoryReadFile>(data),
-          readerOpts.getMemoryPool()));
+          std::make_shared<InMemoryReadFile>(data), readerOpts.memoryPool()));
 }
 
 void removeSizeFromStats(std::string& input) {

--- a/velox/dwio/dwrf/test/E2EWriterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTest.cpp
@@ -69,7 +69,7 @@ class E2EWriterTest : public testing::Test {
     return std::make_unique<dwrf::DwrfReader>(
         opts,
         std::make_unique<BufferedInput>(
-            std::make_shared<InMemoryReadFile>(data), opts.getMemoryPool()));
+            std::make_shared<InMemoryReadFile>(data), opts.memoryPool()));
   }
 
   void testFlatMapConfig(

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -260,7 +260,7 @@ void verifyFlatMapReading(
   rowReaderOpts.setReturnFlatVector(returnFlatVector);
   rowReaderOpts.select(std::make_shared<ColumnSelector>(getFlatmapSchema()));
   auto reader = DwrfReader::create(
-      createFileBufferedInput(file, readerOpts.getMemoryPool()), readerOpts);
+      createFileBufferedInput(file, readerOpts.memoryPool()), readerOpts);
   auto rowReaderOwner = reader->createRowReader(rowReaderOpts);
   auto rowReader = dynamic_cast<DwrfRowReader*>(rowReaderOwner.get());
 
@@ -379,8 +379,7 @@ TEST_P(TestFlatMapReader, testReadFlatMapEmptyMap) {
      ds:string>"));
   rowReaderOpts.select(std::make_shared<ColumnSelector>(emptyFileType));
   auto reader = DwrfReader::create(
-      createFileBufferedInput(emptyFile, readerOpts.getMemoryPool()),
-      readerOpts);
+      createFileBufferedInput(emptyFile, readerOpts.memoryPool()), readerOpts);
   auto rowReaderOwner = reader->createRowReader(rowReaderOpts);
   auto rowReader = dynamic_cast<DwrfRowReader*>(rowReaderOwner.get());
   VectorPtr batch;
@@ -407,8 +406,7 @@ TEST_P(TestFlatMapReader, testStringKeyLifeCycle) {
     rowReaderOptions.setReturnFlatVector(returnFlatVector);
 
     auto reader = DwrfReader::create(
-        createFileBufferedInput(
-            getFMSmallFile(), readerOptions.getMemoryPool()),
+        createFileBufferedInput(getFMSmallFile(), readerOptions.memoryPool()),
         readerOptions);
     auto rowReader = reader->createRowReader(rowReaderOptions);
     rowReader->next(100, batch);
@@ -518,7 +516,7 @@ class TestFlatMapReaderFlatLayout
 TEST_P(TestFlatMapReaderFlatLayout, testCompare) {
   dwio::common::ReaderOptions readerOptions{pool()};
   auto reader = DwrfReader::create(
-      createFileBufferedInput(getFMSmallFile(), readerOptions.getMemoryPool()),
+      createFileBufferedInput(getFMSmallFile(), readerOptions.memoryPool()),
       readerOptions);
   RowReaderOptions rowReaderOptions;
   auto param = GetParam();
@@ -557,7 +555,7 @@ TEST_F(TestReader, testReadFlatMapWithKeyFilters) {
       std::vector<std::string>{"map1#[1]", "map2#[\"key-1\"]"});
   rowReaderOpts.select(cs);
   auto reader = DwrfReader::create(
-      createFileBufferedInput(getFMSmallFile(), readerOpts.getMemoryPool()),
+      createFileBufferedInput(getFMSmallFile(), readerOpts.memoryPool()),
       readerOpts);
   auto rowReader = reader->createRowReader(rowReaderOpts);
   VectorPtr batch;
@@ -608,7 +606,7 @@ TEST_F(TestReader, testReadFlatMapWithKeyRejectList) {
       getFlatmapSchema(), std::vector<std::string>{"map1#[\"!2\",\"!3\"]"});
   rowReaderOpts.select(cs);
   auto reader = DwrfReader::create(
-      createFileBufferedInput(getFMSmallFile(), readerOpts.getMemoryPool()),
+      createFileBufferedInput(getFMSmallFile(), readerOpts.memoryPool()),
       readerOpts);
   auto rowReader = reader->createRowReader(rowReaderOpts);
   VectorPtr batch;
@@ -660,7 +658,7 @@ TEST_F(TestReader, testStatsCallbackFiredWithFiltering) {
   dwio::common::ReaderOptions readerOpts{pool()};
 
   auto reader = DwrfReader::create(
-      createFileBufferedInput(getFMSmallFile(), readerOpts.getMemoryPool()),
+      createFileBufferedInput(getFMSmallFile(), readerOpts.memoryPool()),
       readerOpts);
   auto rowReader = reader->createRowReader(rowReaderOpts);
   VectorPtr batch;
@@ -698,7 +696,7 @@ TEST_F(TestReader, testBlockedIoCallbackFiredBlocking) {
   dwio::common::ReaderOptions readerOpts{pool()};
 
   auto reader = DwrfReader::create(
-      createFileBufferedInput(getFMLargeFile(), readerOpts.getMemoryPool()),
+      createFileBufferedInput(getFMLargeFile(), readerOpts.memoryPool()),
       readerOpts);
   auto rowReader = reader->createRowReader(rowReaderOpts);
   // We didn't preload first stripe, so we expect metric to not be populated yet
@@ -742,7 +740,7 @@ TEST_F(TestReader, DISABLED_testBlockedIoCallbackFiredNonBlocking) {
   dwio::common::ReaderOptions readerOpts{pool()};
 
   auto reader = DwrfReader::create(
-      createFileBufferedInput(getFMLargeFile(), readerOpts.getMemoryPool()),
+      createFileBufferedInput(getFMLargeFile(), readerOpts.memoryPool()),
       readerOpts);
   auto rowReader = reader->createRowReader(rowReaderOpts);
   EXPECT_EQ(metricToIncrement, std::nullopt);
@@ -791,7 +789,7 @@ TEST_F(TestReader, DISABLED_testBlockedIoCallbackFiredWithFirstStripeLoad) {
   dwio::common::ReaderOptions readerOpts{pool()};
 
   auto reader = DwrfReader::create(
-      createFileBufferedInput(getFMLargeFile(), readerOpts.getMemoryPool()),
+      createFileBufferedInput(getFMLargeFile(), readerOpts.memoryPool()),
       readerOpts);
   EXPECT_EQ(metricToIncrement, std::nullopt);
   auto rowReader = reader->createRowReader(rowReaderOpts);
@@ -826,7 +824,7 @@ TEST_F(TestReader, testEstimatedSize) {
   dwio::common::ReaderOptions readerOpts{pool()};
   {
     auto reader = DwrfReader::create(
-        createFileBufferedInput(getFMSmallFile(), readerOpts.getMemoryPool()),
+        createFileBufferedInput(getFMSmallFile(), readerOpts.memoryPool()),
         readerOpts);
     auto cs = std::make_shared<ColumnSelector>(
         getFlatmapSchema(), std::vector<std::string>{"map2"});
@@ -839,7 +837,7 @@ TEST_F(TestReader, testEstimatedSize) {
 
   {
     auto reader = DwrfReader::create(
-        createFileBufferedInput(getFMSmallFile(), readerOpts.getMemoryPool()),
+        createFileBufferedInput(getFMSmallFile(), readerOpts.memoryPool()),
         readerOpts);
     auto cs = std::make_shared<ColumnSelector>(
         getFlatmapSchema(), std::vector<std::string>{"id"});
@@ -871,7 +869,7 @@ TEST_F(TestReader, testStatsCallbackFiredWithoutFiltering) {
   dwio::common::ReaderOptions readerOpts{pool()};
 
   auto reader = DwrfReader::create(
-      createFileBufferedInput(getFMSmallFile(), readerOpts.getMemoryPool()),
+      createFileBufferedInput(getFMSmallFile(), readerOpts.memoryPool()),
       readerOpts);
   auto rowReader = reader->createRowReader(rowReaderOpts);
   VectorPtr batch;
@@ -955,8 +953,7 @@ void verifyFlatmapStructEncoding(
     size_t batchSize = 1000) {
   dwio::common::ReaderOptions readerOpts{pool};
   auto reader = DwrfReader::create(
-      createFileBufferedInput(filename, readerOpts.getMemoryPool()),
-      readerOpts);
+      createFileBufferedInput(filename, readerOpts.memoryPool()), readerOpts);
 
   const std::string projectedColumn = "map1";
   const vector_size_t projectedColumnIndex = 1;
@@ -1068,7 +1065,7 @@ TEST_F(TestReader, testMismatchSchemaMoreFields) {
   rowReaderOpts.select(std::make_shared<ColumnSelector>(
       requestedType, std::vector<uint64_t>{1, 2, 3}));
   auto reader = DwrfReader::create(
-      createFileBufferedInput(getStructFile(), readerOpts.getMemoryPool()),
+      createFileBufferedInput(getStructFile(), readerOpts.memoryPool()),
       readerOpts);
   auto rowReader = reader->createRowReader(rowReaderOpts);
   VectorPtr batch;
@@ -1087,7 +1084,7 @@ TEST_F(TestReader, testMismatchSchemaMoreFields) {
 
   rowReaderOpts.setProjectSelectedType(true);
   reader = DwrfReader::create(
-      createFileBufferedInput(getStructFile(), readerOpts.getMemoryPool()),
+      createFileBufferedInput(getStructFile(), readerOpts.memoryPool()),
       readerOpts);
   rowReader = reader->createRowReader(rowReaderOpts);
   rowReader->next(1, batch);
@@ -1113,7 +1110,7 @@ TEST_F(TestReader, testMismatchSchemaFewerFields) {
   rowReaderOpts.select(std::make_shared<ColumnSelector>(
       requestedType, std::vector<uint64_t>{1}));
   auto reader = DwrfReader::create(
-      createFileBufferedInput(getStructFile(), readerOpts.getMemoryPool()),
+      createFileBufferedInput(getStructFile(), readerOpts.memoryPool()),
       readerOpts);
   auto rowReader = reader->createRowReader(rowReaderOpts);
   VectorPtr batch;
@@ -1131,7 +1128,7 @@ TEST_F(TestReader, testMismatchSchemaFewerFields) {
   batch.reset();
   rowReaderOpts.setProjectSelectedType(true);
   reader = DwrfReader::create(
-      createFileBufferedInput(getStructFile(), readerOpts.getMemoryPool()),
+      createFileBufferedInput(getStructFile(), readerOpts.memoryPool()),
       readerOpts);
   rowReader = reader->createRowReader(rowReaderOpts);
   rowReader->next(1, batch);
@@ -1155,7 +1152,7 @@ TEST_F(TestReader, testMismatchSchemaNestedMoreFields) {
   rowReaderOpts.select(std::make_shared<ColumnSelector>(
       requestedType, std::vector<std::string>{"b.b", "b.c", "b.d", "c"}));
   auto reader = DwrfReader::create(
-      createFileBufferedInput(getStructFile(), readerOpts.getMemoryPool()),
+      createFileBufferedInput(getStructFile(), readerOpts.memoryPool()),
       readerOpts);
   auto rowReader = reader->createRowReader(rowReaderOpts);
   VectorPtr batch;
@@ -1185,7 +1182,7 @@ TEST_F(TestReader, testMismatchSchemaNestedMoreFields) {
   batch.reset();
   rowReaderOpts.setProjectSelectedType(true);
   reader = DwrfReader::create(
-      createFileBufferedInput(getStructFile(), readerOpts.getMemoryPool()),
+      createFileBufferedInput(getStructFile(), readerOpts.memoryPool()),
       readerOpts);
   rowReader = reader->createRowReader(rowReaderOpts);
   rowReader->next(1, batch);
@@ -1220,7 +1217,7 @@ TEST_F(TestReader, testMismatchSchemaNestedFewerFields) {
   rowReaderOpts.select(std::make_shared<ColumnSelector>(
       requestedType, std::vector<std::string>{"b.b", "c"}));
   auto reader = DwrfReader::create(
-      createFileBufferedInput(getStructFile(), readerOpts.getMemoryPool()),
+      createFileBufferedInput(getStructFile(), readerOpts.memoryPool()),
       readerOpts);
   auto rowReader = reader->createRowReader(rowReaderOpts);
   VectorPtr batch;
@@ -1246,7 +1243,7 @@ TEST_F(TestReader, testMismatchSchemaNestedFewerFields) {
   batch.reset();
   rowReaderOpts.setProjectSelectedType(true);
   reader = DwrfReader::create(
-      createFileBufferedInput(getStructFile(), readerOpts.getMemoryPool()),
+      createFileBufferedInput(getStructFile(), readerOpts.memoryPool()),
       readerOpts);
   rowReader = reader->createRowReader(rowReaderOpts);
   rowReader->next(1, batch);
@@ -1277,7 +1274,7 @@ TEST_F(TestReader, testMismatchSchemaIncompatibleNotSelected) {
   rowReaderOpts.select(std::make_shared<ColumnSelector>(
       requestedType, std::vector<std::string>{"b.b"}));
   auto reader = DwrfReader::create(
-      createFileBufferedInput(getStructFile(), readerOpts.getMemoryPool()),
+      createFileBufferedInput(getStructFile(), readerOpts.memoryPool()),
       readerOpts);
   auto rowReader = reader->createRowReader(rowReaderOpts);
   VectorPtr batch;
@@ -1305,7 +1302,7 @@ TEST_F(TestReader, testMismatchSchemaIncompatibleNotSelected) {
   batch.reset();
   rowReaderOpts.setProjectSelectedType(true);
   reader = DwrfReader::create(
-      createFileBufferedInput(getStructFile(), readerOpts.getMemoryPool()),
+      createFileBufferedInput(getStructFile(), readerOpts.memoryPool()),
       readerOpts);
   rowReader = reader->createRowReader(rowReaderOpts);
   rowReader->next(1, batch);
@@ -1354,7 +1351,7 @@ TEST_F(TestReader, fileColumnNamesReadAsLowerCase) {
   readerOpts.setFileColumnNamesReadAsLowerCase(true);
   auto reader = DwrfReader::create(
       createFileBufferedInput(
-          getExampleFilePath("upper.orc"), readerOpts.getMemoryPool()),
+          getExampleFilePath("upper.orc"), readerOpts.memoryPool()),
       readerOpts);
   auto type = reader->typeWithId();
   auto col0 = type->childAt(0);
@@ -1368,7 +1365,7 @@ TEST_F(TestReader, fileColumnNamesReadAsLowerCaseComplexStruct) {
   readerOpts.setFileColumnNamesReadAsLowerCase(true);
   auto reader = DwrfReader::create(
       createFileBufferedInput(
-          getExampleFilePath("upper_complex.orc"), readerOpts.getMemoryPool()),
+          getExampleFilePath("upper_complex.orc"), readerOpts.memoryPool()),
       readerOpts);
   auto type = reader->typeWithId();
 
@@ -1422,7 +1419,7 @@ TEST_F(TestReader, TestStripeSizeCallback) {
   auto reader = DwrfReader::create(
       createFileBufferedInput(
           getExampleFilePath("dict_encoded_strings.orc"),
-          readerOpts.getMemoryPool()),
+          readerOpts.memoryPool()),
       readerOpts);
   auto rowReaderOwner = reader->createRowReader(rowReaderOpts);
   EXPECT_EQ(stripeCount, 3);
@@ -1451,7 +1448,7 @@ TEST_F(TestReader, TestStripeSizeCallbackLimitsOneStripe) {
   auto reader = DwrfReader::create(
       createFileBufferedInput(
           getExampleFilePath("dict_encoded_strings.orc"),
-          readerOpts.getMemoryPool()),
+          readerOpts.memoryPool()),
       readerOpts);
   auto rowReaderOwner = reader->createRowReader(rowReaderOpts);
   EXPECT_EQ(stripeCount, 1);
@@ -1480,7 +1477,7 @@ TEST_F(TestReader, TestStripeSizeCallbackLimitsTwoStripe) {
   auto reader = DwrfReader::create(
       createFileBufferedInput(
           getExampleFilePath("dict_encoded_strings.orc"),
-          readerOpts.getMemoryPool()),
+          readerOpts.memoryPool()),
       readerOpts);
   auto rowReaderOwner = reader->createRowReader(rowReaderOpts);
   EXPECT_EQ(stripeCount, 2);
@@ -2039,8 +2036,7 @@ TEST_F(TestReader, testOrcReaderSimple) {
   // To make DwrfReader reads ORC file, setFileFormat to FileFormat::ORC
   readerOpts.setFileFormat(dwio::common::FileFormat::ORC);
   auto reader = DwrfReader::create(
-      createFileBufferedInput(simpleTest, readerOpts.getMemoryPool()),
-      readerOpts);
+      createFileBufferedInput(simpleTest, readerOpts.memoryPool()), readerOpts);
 
   RowReaderOptions rowReaderOptions;
   auto rowReader = reader->createRowReader(rowReaderOptions);
@@ -2104,8 +2100,7 @@ TEST_F(TestReader, testOrcReaderComplexTypes) {
   dwio::common::ReaderOptions readerOpts{pool()};
   readerOpts.setFileFormat(dwio::common::FileFormat::ORC);
   auto reader = DwrfReader::create(
-      createFileBufferedInput(icebergOrc, readerOpts.getMemoryPool()),
-      readerOpts);
+      createFileBufferedInput(icebergOrc, readerOpts.memoryPool()), readerOpts);
   auto rowType = reader->rowType();
   EXPECT_TRUE(rowType->equivalent(*expectedType));
 }
@@ -2115,8 +2110,7 @@ TEST_F(TestReader, testOrcReaderVarchar) {
   dwio::common::ReaderOptions readerOpts{pool()};
   readerOpts.setFileFormat(dwio::common::FileFormat::ORC);
   auto reader = DwrfReader::create(
-      createFileBufferedInput(varcharOrc, readerOpts.getMemoryPool()),
-      readerOpts);
+      createFileBufferedInput(varcharOrc, readerOpts.memoryPool()), readerOpts);
 
   RowReaderOptions rowReaderOptions;
   auto rowReader = reader->createRowReader(rowReaderOptions);
@@ -2146,7 +2140,7 @@ TEST_F(TestReader, testOrcReaderDate) {
   dwio::common::ReaderOptions readerOpts{pool()};
   readerOpts.setFileFormat(dwio::common::FileFormat::ORC);
   auto reader = DwrfReader::create(
-      createFileBufferedInput(dateOrc, readerOpts.getMemoryPool()), readerOpts);
+      createFileBufferedInput(dateOrc, readerOpts.memoryPool()), readerOpts);
 
   RowReaderOptions rowReaderOptions;
   auto rowReader = reader->createRowReader(rowReaderOptions);

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -1979,10 +1979,10 @@ TEST_P(TestColumnReader, testShortBlobError) {
     next(100, batch);
     batch->as<RowVector>()->childAt(0)->loadedVector();
     FAIL() << "Expected an error";
-  } catch (const exception::LoggedException& e) {
-    ASSERT_EQ("bad read in readFully", e.message());
   } catch (const VeloxRuntimeError& e) {
-    ASSERT_EQ("Reading past end", e.message());
+    ASSERT_TRUE(
+        "bad read in readFully" == e.message() ||
+        "Reading past end" == e.message());
   }
 }
 

--- a/velox/dwio/dwrf/test/TestDecompression.cpp
+++ b/velox/dwio/dwrf/test/TestDecompression.cpp
@@ -20,6 +20,7 @@
 #include <folly/compression/Zlib.h>
 #include <gtest/gtest.h>
 #include "velox/common/base/BitUtil.h"
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/dwio/common/InputStream.h"
 #include "velox/dwio/common/compression/Compression.h"
 #include "velox/dwio/dwrf/test/OrcTest.h"
@@ -120,7 +121,7 @@ TEST_F(DecompressionTest, testArrayBackup) {
   SeekableArrayInputStream stream(bytes.data(), bytes.size(), 20);
   const void* ptr;
   int32_t len;
-  ASSERT_THROW(stream.BackUp(10), exception::LoggedException);
+  VELOX_ASSERT_THROW(stream.BackUp(10), "(10 vs. 0) Can't backup that much!");
   EXPECT_EQ(true, stream.Next(&ptr, &len));
   EXPECT_EQ(bytes.data(), static_cast<const char*>(ptr));
   EXPECT_EQ(20, len);
@@ -141,7 +142,7 @@ TEST_F(DecompressionTest, testArrayBackup) {
   EXPECT_EQ(10, len);
   EXPECT_EQ(true, !stream.Next(&ptr, &len));
   EXPECT_EQ(0, len);
-  ASSERT_THROW(stream.BackUp(30), exception::LoggedException);
+  VELOX_ASSERT_THROW(stream.BackUp(30), "(30 vs. 20) Can't backup that much!");
   EXPECT_EQ(200, stream.ByteCount());
 }
 
@@ -201,7 +202,7 @@ TEST_F(DecompressionTest, testFileBackup) {
   auto stream = createSeekableFileInputStream();
   const void* ptr;
   int32_t len;
-  ASSERT_THROW(stream.BackUp(10), exception::LoggedException);
+  VELOX_ASSERT_THROW(stream.BackUp(10), "(10 vs. 0) can't backup that far");
   EXPECT_EQ(true, stream.Next(&ptr, &len));
   EXPECT_EQ(20, len);
   checkBytes(static_cast<const char*>(ptr), len, 0);
@@ -222,7 +223,7 @@ TEST_F(DecompressionTest, testFileBackup) {
   }
   EXPECT_EQ(true, !stream.Next(&ptr, &len));
   EXPECT_EQ(0, len);
-  ASSERT_THROW(stream.BackUp(30), exception::LoggedException);
+  VELOX_ASSERT_THROW(stream.BackUp(30), "(30 vs. 20) can't backup that far");
   EXPECT_EQ(200, stream.ByteCount());
 }
 
@@ -289,7 +290,8 @@ TEST_F(DecompressionTest, testFileSeek) {
   {
     std::vector<uint64_t> offsets(1, 201);
     PositionProvider posn(offsets);
-    EXPECT_THROW(stream.seekToPosition(posn), exception::LoggedException);
+    VELOX_ASSERT_THROW(
+        stream.seekToPosition(posn), "(201 vs. 200) seek too far");
   }
 }
 

--- a/velox/dwio/dwrf/test/TestReadFile.h
+++ b/velox/dwio/dwrf/test/TestReadFile.h
@@ -40,10 +40,10 @@ class TestReadFile : public velox::ReadFile {
 
   std::string_view pread(uint64_t offset, uint64_t length, void* buffer)
       const override {
+    const uint64_t content = offset + seed_;
+    const uint64_t available = std::min(length_ - offset, length);
     int fill;
-    uint64_t content = offset + seed_;
-    uint64_t available = std::min(length_ - offset, length);
-    for (fill = 0; fill < (available); ++fill) {
+    for (fill = 0; fill < available; ++fill) {
       reinterpret_cast<char*>(buffer)[fill] = content + fill;
     }
     return std::string_view(static_cast<const char*>(buffer), fill);

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -65,7 +65,7 @@ class ReaderBase {
   }
 
   bool isFileColumnNamesReadAsLowerCase() const {
-    return options_.isFileColumnNamesReadAsLowerCase();
+    return options_.fileColumnNamesReadAsLowerCase();
   }
 
   /// Ensures that streams are enqueued and loading for the row group at
@@ -127,9 +127,9 @@ class ReaderBase {
 ReaderBase::ReaderBase(
     std::unique_ptr<dwio::common::BufferedInput> input,
     const dwio::common::ReaderOptions& options)
-    : pool_{options.getMemoryPool()},
-      footerEstimatedSize_{options.getFooterEstimatedSize()},
-      filePreloadThreshold_{options.getFilePreloadThreshold()},
+    : pool_{options.memoryPool()},
+      footerEstimatedSize_{options.footerEstimatedSize()},
+      filePreloadThreshold_{options.filePreloadThreshold()},
       options_{options},
       input_{std::move(input)},
       fileLength_{input_->getReadFile()->size()} {

--- a/velox/dwio/parquet/tests/ParquetTestBase.h
+++ b/velox/dwio/parquet/tests/ParquetTestBase.h
@@ -64,7 +64,7 @@ class ParquetTestBase : public testing::Test, public test::VectorTestBase {
       const std::string& path,
       const dwio::common::ReaderOptions& opts) {
     auto input = std::make_unique<dwio::common::BufferedInput>(
-        std::make_shared<LocalReadFile>(path), opts.getMemoryPool());
+        std::make_shared<LocalReadFile>(path), opts.memoryPool());
     return std::make_unique<facebook::velox::parquet::ParquetReader>(
         std::move(input), opts);
   }

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -590,8 +590,7 @@ TEST_F(E2EFilterTest, largeMetadata) {
   readerOpts.setFilePreloadThreshold(1024 * 8);
   dwio::common::RowReaderOptions rowReaderOpts;
   auto input = std::make_unique<BufferedInput>(
-      std::make_shared<InMemoryReadFile>(sinkData_),
-      readerOpts.getMemoryPool());
+      std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
   auto reader = makeReader(readerOpts, std::move(input));
   EXPECT_EQ(1000, reader->numberOfRows());
 }
@@ -626,8 +625,7 @@ TEST_F(E2EFilterTest, combineRowGroup) {
   writeToMemory(rowType_, batches, false);
   dwio::common::ReaderOptions readerOpts{leafPool_.get()};
   auto input = std::make_unique<BufferedInput>(
-      std::make_shared<InMemoryReadFile>(sinkData_),
-      readerOpts.getMemoryPool());
+      std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
   auto reader = makeReader(readerOpts, std::move(input));
   auto parquetReader = dynamic_cast<ParquetReader&>(*reader.get());
   EXPECT_EQ(parquetReader.fileMetaData().numRowGroups(), 1);
@@ -642,8 +640,7 @@ TEST_F(E2EFilterTest, writeDecimalAsInteger) {
   writeToMemory(rowVector->type(), {rowVector}, false);
   dwio::common::ReaderOptions readerOpts{leafPool_.get()};
   auto input = std::make_unique<BufferedInput>(
-      std::make_shared<InMemoryReadFile>(sinkData_),
-      readerOpts.getMemoryPool());
+      std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
   auto reader = makeReader(readerOpts, std::move(input));
   auto parquetReader = dynamic_cast<ParquetReader&>(*reader.get());
 
@@ -668,8 +665,7 @@ TEST_F(E2EFilterTest, configurableWriteSchema) {
     writeToMemory(newType, batches, false);
     dwio::common::ReaderOptions readerOpts{leafPool_.get()};
     auto input = std::make_unique<BufferedInput>(
-        std::make_shared<InMemoryReadFile>(sinkData_),
-        readerOpts.getMemoryPool());
+        std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
     auto reader = makeReader(readerOpts, std::move(input));
     auto parquetReader = dynamic_cast<ParquetReader&>(*reader.get());
 

--- a/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
@@ -99,7 +99,7 @@ std::unique_ptr<RowReader> ParquetReaderBenchmark::createReader(
   dwio::common::ReaderOptions readerOpts{leafPool_.get()};
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<LocalReadFile>(fileFolder_->getPath() + "/" + fileName_),
-      readerOpts.getMemoryPool());
+      readerOpts.memoryPool());
 
   std::unique_ptr<Reader> reader =
       std::make_unique<ParquetReader>(std::move(input), readerOpts);

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -140,8 +140,7 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
     dwio::common::ReaderOptions readerOpts{pool.get()};
     auto reader = std::make_unique<ParquetReader>(
         std::make_unique<facebook::velox::dwio::common::BufferedInput>(
-            std::make_shared<LocalReadFile>(filePath),
-            readerOpts.getMemoryPool()),
+            std::make_shared<LocalReadFile>(filePath), readerOpts.memoryPool()),
         readerOpts);
     rowType_ = reader->rowType();
     createDuckDbTable({data});

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -62,7 +62,7 @@ class ParquetWriterTest : public ParquetTestBase {
     std::string_view data(sink.data(), sink.size());
     return std::make_unique<facebook::velox::parquet::ParquetReader>(
         std::make_unique<dwio::common::BufferedInput>(
-            std::make_shared<InMemoryReadFile>(data), opts.getMemoryPool()),
+            std::make_shared<InMemoryReadFile>(data), opts.memoryPool()),
         opts);
   };
 

--- a/velox/examples/ScanOrc.cpp
+++ b/velox/examples/ScanOrc.cpp
@@ -50,8 +50,7 @@ int main(int argc, char** argv) {
   readerOpts.setFileFormat(FileFormat::ORC);
   auto reader = DwrfReader::create(
       std::make_unique<BufferedInput>(
-          std::make_shared<LocalReadFile>(filePath),
-          readerOpts.getMemoryPool()),
+          std::make_shared<LocalReadFile>(filePath), readerOpts.memoryPool()),
       readerOpts);
 
   VectorPtr batch;

--- a/velox/exec/benchmarks/RowContainerSortBenchmark.cpp
+++ b/velox/exec/benchmarks/RowContainerSortBenchmark.cpp
@@ -56,7 +56,7 @@ facebook::velox::parquet::ParquetReader createReader(
     const facebook::velox::dwio::common::ReaderOptions& opts) {
   return facebook::velox::parquet::ParquetReader(
       std::make_unique<facebook::velox::dwio::common::BufferedInput>(
-          std::make_shared<LocalReadFile>(path), opts.getMemoryPool()),
+          std::make_shared<LocalReadFile>(path), opts.memoryPool()),
       opts);
 }
 

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -80,9 +80,9 @@ void TpchQueryBuilder::readFileSchema(
   std::shared_ptr<ReadFile> readFile;
   readFile.reset(uniqueReadFile.release());
   auto input = std::make_unique<dwio::common::BufferedInput>(
-      readFile, readerOptions.getMemoryPool());
+      readFile, readerOptions.memoryPool());
   std::unique_ptr<dwio::common::Reader> reader =
-      dwio::common::getReaderFactory(readerOptions.getFileFormat())
+      dwio::common::getReaderFactory(readerOptions.fileFormat())
           ->createReader(std::move(input), readerOptions);
   const auto fileType = reader->rowType();
   const auto fileColumnNames = fileType->names();


### PR DESCRIPTION
This change add end-to-end no-cache retention support which ensures that either accessed
or prefetched cache entries are marked immediate evictable  on cache input stream destruction
if no-cache retention connection config (or by session property in Prestissimo) is set for a query.
It also ensures those cache entries won't be staged to SSD by extending setExclusiveToShared
to take a ssdSavable flag which only saves to SSD if it is true. For query with no-cache retetion
flag set, it set ssdSavable flag to false when load data from storage.

CacheInputStream adds to mark the previously accessed cache entry as immediate evictable by
adding CacheInputStream::clearCachePin() which calls AsyncDataCacheEntry::makeEvictable
API. On destruction, CacheInputStream calls makeCacheEvictable method which walks through
the potential cache entries by using nextQuantizedLoadRegion() which returns the next quantized
load offset which is also the cache entry key (plus the normalized file number). Correspondingly,
AsyndDataCache provides makeEvictable which takes raw file key to mark the corresponding cache
entry as immediate evictable.

Adds "cache.no_retention" hive config (session) to allow a query to specify the no-cache retention
which helps to run batch and interactive query in the same cluster. The assumption here interactive
has hot data locality in table scan while batch only access the large amount of cold-data in one-pass.

This PR also fixes a bunch of coding styles in dwio input stream code repo as well as a potential
deadlock fix by moving CoalescedLoad::setEndState fulfill the load wait promise out of coalesce lock.