### PR TITLE
Fix typos in Spark function documentation

### DIFF
--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -21,7 +21,7 @@ Array Functions
 
         SELECT array_contains(array(1, 2, 3), 2); -- true
 
-.. spark::function:: array_distinct(array(E)) -> array(E)
+.. spark:function:: array_distinct(array(E)) -> array(E)
 
     Remove duplicate values from the input array. ::
 
@@ -29,7 +29,7 @@ Array Functions
         SELECT array_distinct(ARRAY [1, 2, 1]); -- [1, 2]
         SELECT array_distinct(ARRAY [1, NULL, NULL]); -- [1, NULL]
 
-.. spark::function:: array_except(array(E) x, array(E) y) -> array(E)
+.. spark:function:: array_except(array(E) x, array(E) y) -> array(E)
 
     Returns an array of the elements in array ``x`` but not in array ``y``, without duplicates. ::
 
@@ -45,7 +45,7 @@ Array Functions
 
         SELECT array_intersect(array(1, 2, 3), array(1, 3, 5)); -- [1,3]
 
-.. spark::function:: array_max(array(E)) -> E
+.. spark:function:: array_max(array(E)) -> E
 
     Returns maximum non-NULL element of the array. Returns NULL if array is empty or all elements are NULL.
     When E is DOUBLE or REAL, returns NaN if any element is NaN. ::
@@ -56,7 +56,7 @@ Array Functions
         SELECT array_max(array()); -- NULL
         SELECT array_max(array(-0.0001, -0.0002, -0.0003, float('nan'))); -- NaN
 
-.. spark::function:: array_min(array(E)) -> E
+.. spark:function:: array_min(array(E)) -> E
 
     Returns minimum non-NULL element of the array. Returns NULL if array is empty or all elements are NULL.
     When E is DOUBLE or REAL, NaN value is considered greater than any non-NaN value. ::
@@ -69,7 +69,7 @@ Array Functions
         SELECT array_min(array(4.0, float('nan')]); -- 4.0
         SELECT array_min(array(NULL, float('nan'))); -- NaN
 
-.. spark::function:: array_position(x, element) -> bigint
+.. spark:function:: array_position(x, element) -> bigint
 
     Returns the position (1-based) of the first occurrence of the ``element`` in array ``x`` (or 0 if not found). ::
 
@@ -77,7 +77,7 @@ Array Functions
         SELECT array_position(array(1, 2, 3), 4); -- 0
         SELECT array_position(array(1, 2, 3, 2), 2); -- 2
 
-.. spark::function:: array_remove(x, element) -> array
+.. spark:function:: array_remove(x, element) -> array
 
     Remove all elements that equal ``element`` from array ``x``. Returns NULL as result if ``element`` is NULL.
     If array ``x`` is empty array, returns empty array. If all elements in array ``x`` are NULL but ``element`` is not NULL,

--- a/velox/docs/functions/spark/binary.rst
+++ b/velox/docs/functions/spark/binary.rst
@@ -2,7 +2,7 @@
 Binary Functions
 ================
 
-.. spark::function:: crc32(binary) -> bigint
+.. spark:function:: crc32(binary) -> bigint
 
     Computes the crc32 checksum of ``binary``.
 
@@ -34,7 +34,7 @@ Binary Functions
 
    Returns TRUE if ``bloomFilter`` might contain ``value``. 
 
-   ``bloomFilter`` is a VARBINARY computed using ::spark::function::`bloom_filter_agg` aggregate function. 
+   ``bloomFilter`` is a VARBINARY computed using ::spark:function::`bloom_filter_agg` aggregate function. 
    ``value`` is a BIGINT.
 
 .. spark:function:: sha1(x) -> varchar

--- a/velox/docs/functions/spark/map.rst
+++ b/velox/docs/functions/spark/map.rst
@@ -14,7 +14,7 @@ Map Functions
 
         SELECT map(array(1, 2), array(3, 4)); -- {[1, 2] -> [3, 4]}
 
-.. spark::function:: map_entries(map(K,V)) -> array(row(K,V))
+.. spark:function:: map_entries(map(K,V)) -> array(row(K,V))
 
     Returns an array of all entries in the given map. ::
 
@@ -33,11 +33,11 @@ Map Functions
 
         SELECT map_from_arrays(array(1.0, 3.0), array('2', '4')); -- {1.0 -> 2, 3.0 -> 4}
 
-.. spark::function:: map_keys(x(K,V)) -> array(K)
+.. spark:function:: map_keys(x(K,V)) -> array(K)
 
     Returns all the keys in the map ``x``.
 
-.. spark::function:: map_values(x(K,V)) -> array(V)
+.. spark:function:: map_values(x(K,V)) -> array(V)
 
     Returns all the values in the map ``x``.
 

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -14,7 +14,7 @@ Mathematical Functions
 
     Returns inverse hyperbolic cosine of ``x``.
 
-.. spark::function:: asin(x) -> double
+.. spark:function:: asin(x) -> double
 
     Returns the arc sine of ``x``.
 
@@ -22,7 +22,7 @@ Mathematical Functions
 
     Returns inverse hyperbolic sine of ``x``.
 
-.. spark::function:: atan(x) -> double
+.. spark:function:: atan(x) -> double
 
     Returns the arc tangent of ``x``.
 
@@ -66,7 +66,7 @@ Mathematical Functions
     Returns ``x`` rounded up to the nearest integer.  
     Supported types are: BIGINT and DOUBLE.
 
-.. spark::function:: cos(x) -> double
+.. spark:function:: cos(x) -> double
 
     Returns the cosine of ``x``.
 
@@ -82,7 +82,7 @@ Mathematical Functions
 
     Returns the cosecant of ``x``.
 
-.. spark::function:: degrees(x) -> double
+.. spark:function:: degrees(x) -> double
 
     Converts angle x in radians to degrees.
 
@@ -147,7 +147,7 @@ Mathematical Functions
     Returns true if x is Nan, or false otherwise. Returns false is x is NULL.
     Supported types are: REAL, DOUBLE.
 
-.. spark::function:: log1p(x) -> double
+.. spark:function:: log1p(x) -> double
 
     Returns the natural logarithm of the “given value ``x`` plus one”.
     Return NULL if x is less than or equal to -1.

--- a/velox/docs/functions/spark/regexp.rst
+++ b/velox/docs/functions/spark/regexp.rst
@@ -15,7 +15,7 @@ difference of the character classes.
 
 See https://github.com/google/re2/wiki/Syntax for more information.
 
-.. spark::function:: like(string, pattern) -> boolean
+.. spark:function:: like(string, pattern) -> boolean
                      like(string, pattern, escape) -> boolean
 
     Evaluates if the ``string`` matches the ``pattern``. Patterns can contain
@@ -58,14 +58,14 @@ See https://github.com/google/re2/wiki/Syntax for more information.
 
         SELECT regexp_extract('1a 2b 14m', '(\d+)([a-z]+)', 2); -- 'a'
 
-.. spark::function:: regexp_extract_all(string, pattern) -> array(varchar):
+.. spark:function:: regexp_extract_all(string, pattern) -> array(varchar):
 
     Returns the substring(s) matched by the regular expression ``pattern``
     in ``string``::
 
         SELECT regexp_extract_all('1a 2b 14m', '\d+'); -- [1, 2, 14]
 
-.. spark::function:: regexp_extract_all(string, pattern, group) -> array(varchar):
+.. spark:function:: regexp_extract_all(string, pattern, group) -> array(varchar):
     :noindex:
 
     Finds all occurrences of the regular expression ``pattern`` in

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -158,7 +158,7 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
         SELECT replace('ABCabc', 'abc', ''); -- ABC
         SELECT replace('ABCabc', 'abc', 'DEF'); -- ABCDEF
 
-.. spark::function:: reverse(string) -> varchar
+.. spark:function:: reverse(string) -> varchar
 
     Returns input string with characters in reverse order.
 

--- a/velox/docs/functions/spark/url.rst
+++ b/velox/docs/functions/spark/url.rst
@@ -48,7 +48,7 @@ digits after the percent character "%". All the url extract functions will retur
 Encoding Functions
 ------------------
 
-.. spark::function:: url_encode(value) -> varchar
+.. spark:function:: url_encode(value) -> varchar
 
     Escapes ``value`` by encoding it so that it can be safely included in
     URL query parameter names and values:
@@ -60,7 +60,7 @@ Encoding Functions
       as the string ``%XX`` where ``XX`` is the uppercase hexadecimal
       value of the UTF-8 byte.
 
-.. spark::function:: url_decode(value) -> varchar
+.. spark:function:: url_decode(value) -> varchar
 
     Unescapes the URL encoded ``value``.
     This function is the inverse of :func:`url_encode`.

--- a/velox/docs/functions/spark/url.rst
+++ b/velox/docs/functions/spark/url.rst
@@ -63,4 +63,4 @@ Encoding Functions
 .. spark:function:: url_decode(value) -> varchar
 
     Unescapes the URL encoded ``value``.
-    This function is the inverse of :func:`url_encode`.
+    This function is the inverse of :spark:func:`url_encode`.


### PR DESCRIPTION
Some Spark functions are not displayed due to formatting errors.

For example, "encoding-functions" section is empty in https://facebookincubator.github.io/velox/functions/spark/url.html#encoding-functions .

With this fix, we can see the content:
![Screenshot from 2024-05-30 14-26-01](https://github.com/facebookincubator/velox/assets/13806761/d1ee606e-06cd-4a25-8bfd-6d640807afe7)
