### PR TITLE
Fix FlatVector<T>::setNull API

### DIFF
--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -225,6 +225,13 @@ class FlatVector final : public SimpleVector<T> {
 
   Range<T> asRange() const;
 
+  void setNull(vector_size_t idx, bool isNull) override {
+    BaseVector::setNull(idx, isNull);
+    if (!isNull) {
+      ensureValues();
+    }
+  }
+
   void set(vector_size_t idx, T value) {
     VELOX_DCHECK_LT(idx, BaseVector::length_);
     ensureValues();

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -3493,7 +3493,7 @@ TEST_F(VectorTest, flatAllNulls) {
 
   auto nulls = allocateNulls(size, pool(), bits::kNull);
 
-  // BIGINT.
+  // BIGINT. set API.
   {
     auto flat = makeFlatNullValues<int64_t>(size, BIGINT(), nulls, pool());
 
@@ -3505,6 +3505,26 @@ TEST_F(VectorTest, flatAllNulls) {
     flat->set(7, 123LL);
     ASSERT_FALSE(flat->isNullAt(7));
     ASSERT_EQ(123LL, flat->valueAt(7));
+
+    for (auto i = 0; i < size; ++i) {
+      if (i != 7) {
+        ASSERT_TRUE(flat->isNullAt(i));
+      }
+    }
+  }
+
+  // BIGINT. setNull API.
+  {
+    auto flat = makeFlatNullValues<int64_t>(size, BIGINT(), nulls, pool());
+
+    for (auto i = 0; i < size; ++i) {
+      ASSERT_TRUE(flat->isNullAt(i));
+    }
+
+    // Change some rows to non-null.
+    flat->setNull(7, false);
+    ASSERT_FALSE(flat->isNullAt(7));
+    ASSERT_NO_THROW(flat->valueAt(7));
 
     for (auto i = 0; i < size; ++i) {
       if (i != 7) {


### PR DESCRIPTION
Summary:
A FlatVector with all null rows may have a null 'values' buffer. In this case,
setting one of the rows to not-null by calling setNull(row, false) leaves
vector is a bad state and causes failures when accessing the non-null value.

Fix `FlatVector<T>::setNull(row, false)` to allocate 'values' buffer.

UndefinedBehaviorSanitizer: nullptr-with-nonzero-offset .../velox/vector/FlatVector-inl.h:63:10

Differential Revision: D57968774


