### PR TITLE
Advance version of simdjson to the latest.

### DIFF
--- a/CMake/resolve_dependency_modules/README.md
+++ b/CMake/resolve_dependency_modules/README.md
@@ -31,7 +31,7 @@ by Velox. See details on bundling below.
 | xsimd             | 10.0.0          | Yes      |
 | re2               | 2021-04-01      | Yes      |
 | fmt               | 10.1.1          | Yes      |
-| simdjson          | 3.8.0           | Yes      |
+| simdjson          | 3.9.3           | Yes      |
 | folly             | v2024.04.01.00  | Yes      |
 | fizz              | v2024.04.01.00  | No       |
 | wangle            | v2024.04.01.00  | No       |

--- a/CMake/resolve_dependency_modules/simdjson.cmake
+++ b/CMake/resolve_dependency_modules/simdjson.cmake
@@ -13,9 +13,9 @@
 # limitations under the License.
 include_guard(GLOBAL)
 
-set(VELOX_SIMDJSON_VERSION 3.8.0)
+set(VELOX_SIMDJSON_VERSION 3.9.3)
 set(VELOX_SIMDJSON_BUILD_SHA256_CHECKSUM
-    e28e3f46f0012d405b67de6c0a75e8d8c9a612b0548cb59687822337d73ca78b)
+    2e3d10abcde543d3dd8eba9297522cafdcebdd1db4f51b28f3bc95bf1d6ad23c)
 set(VELOX_SIMDJSON_SOURCE_URL
     "https://github.com/simdjson/simdjson/archive/refs/tags/v${VELOX_SIMDJSON_VERSION}.tar.gz"
 )


### PR DESCRIPTION
Summary:
This is to include the https://github.com/simdjson/simdjson/pull/2189
The change will allow us to support incomplete json in json_extract.

Differential Revision: D57977853


