### PR TITLE
Pre-allocate error vector in TRY

### DIFF
--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -86,13 +86,14 @@ void EvalCtx::saveAndReset(ContextSaver& saver, const SelectivityVector& rows) {
 void EvalCtx::ensureErrorsVectorSize(ErrorVectorPtr& vector, vector_size_t size)
     const {
   if (!vector) {
+    // Do not allocate 'values' buffer. It uses ~20 bytes per row and it may not
+    // be needed.
     vector = std::make_shared<ErrorVector>(
         pool(),
         OpaqueType::create<void>(),
         allocateNulls(size, pool(), bits::kNull),
         size,
-        AlignedBuffer::allocate<ErrorVector::value_type>(
-            size, pool(), ErrorVector::value_type()),
+        nullptr,
         std::vector<BufferPtr>{});
   } else if (vector->size() < size) {
     const auto oldSize = vector->size();


### PR DESCRIPTION
Summary:
TRY(CAST(...)) is up to 4x slower than TRY_CAST when many rows fail.
The profile reveals that significant percentage of cpu time goes to
EvalCtx::ensureErrorsVectorSize. For every row that fails, we call
EvalCtx::ensureErrorsVectorSize to resize the error vector to accommodate that
row. When many rows fail we end up resizing a lot: resize(1), resize(2), resize
(3),....resize(n). Fix this by pre-allocating error vector in TryExpr.

An earlier attempt at fixing this https://github.com/facebookincubator/velox/pull/9911 caused 2x memory regression in one of the streaming pipelines. The change 
was reverted: https://github.com/facebookincubator/velox/pull/9971

The regression was due to TRY starting to allocate 'nulls' buffer in results
unconditionally. Even if there were no errors, TRY would still allocate 'nulls'
buffer. When result is a boolean vector, allocating unnecessary 'nulls' buffer
increases memory usage for 'result' by 2x. This fix makes sure not to do that
and adds a test. 

Also, this change creates ErrorVector with only nulls buffer allocated.
The 'values' buffer that requires ~20 bytes per row is allocated only if an
error occurs.

Before:

```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
cast##try_cast_invalid_empty_input                          2.27ms    440.97
cast##tryexpr_cast_invalid_empty_input                      8.96ms    111.56
cast##try_cast_invalid_nan                                  5.49ms    182.26
cast##tryexpr_cast_invalid_nan                             12.96ms     77.17
```

After:

```
cast##try_cast_invalid_empty_input                          2.22ms    451.34
cast##tryexpr_cast_invalid_empty_input                      4.52ms    221.06
cast##try_cast_invalid_nan                                  5.79ms    172.69
cast##tryexpr_cast_invalid_nan                              8.16ms    122.48
```

Differential Revision: D57968341


