### PR TITLE
Replace ErrorVector with EvalErrors class

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -234,7 +234,7 @@ VectorPtr CastExpr::castToDate(
                         makeErrorMessage(input, row, DATE()),
                         result.error().message()));
               } else {
-                context.setStatus(row, Status::UserError(""));
+                context.setStatus(row, Status::UserError());
               }
             }
           } else {

--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -222,7 +222,11 @@ void EvalCtx::setError(
     throwError(exceptionPtr);
   }
 
-  addError(index, toVeloxException(exceptionPtr), errors_);
+  if (captureErrorDetails_) {
+    addError(index, toVeloxException(exceptionPtr), errors_);
+  } else {
+    addError(index, errors_);
+  }
 }
 
 // This should be used onlly when exceptionPtr is guranteed to be a
@@ -234,7 +238,11 @@ void EvalCtx::setVeloxExceptionError(
     std::rethrow_exception(exceptionPtr);
   }
 
-  addError(index, exceptionPtr, errors_);
+  if (captureErrorDetails_) {
+    addError(index, exceptionPtr, errors_);
+  } else {
+    addError(index, errors_);
+  }
 }
 
 void EvalCtx::setErrors(
@@ -244,9 +252,13 @@ void EvalCtx::setErrors(
     throwError(exceptionPtr);
   }
 
-  auto veloxException = toVeloxException(exceptionPtr);
-  rows.applyToSelected(
-      [&](auto row) { addError(row, veloxException, errors_); });
+  if (captureErrorDetails_) {
+    auto veloxException = toVeloxException(exceptionPtr);
+    rows.applyToSelected(
+        [&](auto row) { addError(row, veloxException, errors_); });
+  } else {
+    rows.applyToSelected([&](auto row) { addError(row, errors_); });
+  }
 }
 
 void EvalCtx::addElementErrorsToTopLevel(

--- a/velox/expression/LambdaExpr.cpp
+++ b/velox/expression/LambdaExpr.cpp
@@ -66,7 +66,7 @@ class ExprCallable : public Callable {
       const BufferPtr& wrapCapture,
       EvalCtx* context,
       const std::vector<VectorPtr>& args,
-      ErrorVectorPtr& elementErrors,
+      EvalErrorsPtr& elementErrors,
       VectorPtr* result) override {
     auto row = createRowVector(context, wrapCapture, args, rows.end());
     EvalCtx lambdaCtx = createLambdaCtx(context, row, validRowsInReusedResult);

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(
   ExprTest.cpp
   ExprToSubfieldFilterTest.cpp
   EvalCtxTest.cpp
+  EvalErrorsTest.cpp
   EvalSimplifiedTest.cpp
   FunctionCallToSpecialFormTest.cpp
   GenericViewTest.cpp

--- a/velox/expression/tests/EvalErrorsTest.cpp
+++ b/velox/expression/tests/EvalErrorsTest.cpp
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <exception>
+#include "gtest/gtest.h"
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/expression/EvalCtx.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::exec {
+namespace {
+
+class EvalErrorsTest : public testing::Test, public test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
+
+TEST_F(EvalErrorsTest, noErrors) {
+  EvalErrors errors(pool(), 10);
+
+  ASSERT_EQ(errors.size(), 10);
+  ASSERT_EQ(errors.countErrors(), 0);
+  ASSERT_FALSE(errors.hasError());
+
+  for (auto i = 0; i < errors.size(); ++i) {
+    ASSERT_FALSE(errors.hasErrorAt(i));
+    ASSERT_NO_THROW(errors.throwIfErrorAt(i));
+    ASSERT_FALSE(errors.errorAt(i).has_value());
+    ASSERT_FALSE(bits::isBitSet(errors.errorFlags(), i));
+  }
+
+  // Test 'out-of-bounds' indices.
+  for (auto i = errors.size(); i < errors.size() + 5; ++i) {
+    ASSERT_FALSE(errors.hasErrorAt(i));
+    ASSERT_NO_THROW(errors.throwIfErrorAt(i));
+    ASSERT_FALSE(errors.errorAt(i).has_value());
+  }
+
+  SelectivityVector rows(123);
+  ASSERT_NO_THROW(errors.throwFirstError(rows));
+}
+
+TEST_F(EvalErrorsTest, someErrors) {
+  EvalErrors errors(pool(), 10);
+
+  errors.setError(3);
+
+  ASSERT_EQ(errors.size(), 10);
+  ASSERT_EQ(errors.countErrors(), 1);
+  ASSERT_TRUE(errors.hasError());
+  ASSERT_TRUE(errors.hasErrorAt(3));
+
+  for (auto i = 0; i < errors.size(); ++i) {
+    if (i != 3) {
+      ASSERT_FALSE(errors.hasErrorAt(i));
+      ASSERT_NO_THROW(errors.throwIfErrorAt(i));
+      ASSERT_FALSE(errors.errorAt(i).has_value());
+      ASSERT_FALSE(bits::isBitSet(errors.errorFlags(), i));
+    }
+  }
+
+  // Test 'out-of-bounds' index.
+  errors.setError(23);
+
+  ASSERT_EQ(errors.size(), 24);
+  ASSERT_EQ(errors.countErrors(), 2);
+  ASSERT_TRUE(errors.hasError());
+  ASSERT_TRUE(errors.hasErrorAt(3));
+  ASSERT_TRUE(errors.hasErrorAt(23));
+
+  for (auto i = 0; i < errors.size(); ++i) {
+    if (i != 3 && i != 23) {
+      ASSERT_FALSE(errors.hasErrorAt(i));
+      ASSERT_NO_THROW(errors.throwIfErrorAt(i));
+      ASSERT_FALSE(errors.errorAt(i).has_value());
+      ASSERT_FALSE(bits::isBitSet(errors.errorFlags(), i));
+    }
+  }
+
+  errors.clearError(3);
+
+  ASSERT_EQ(errors.size(), 24);
+  ASSERT_EQ(errors.countErrors(), 1);
+  ASSERT_TRUE(errors.hasError());
+  ASSERT_TRUE(errors.hasErrorAt(23));
+
+  for (auto i = 0; i < errors.size(); ++i) {
+    if (i != 23) {
+      ASSERT_FALSE(errors.hasErrorAt(i));
+      ASSERT_NO_THROW(errors.throwIfErrorAt(i));
+      ASSERT_FALSE(errors.errorAt(i).has_value());
+      ASSERT_FALSE(bits::isBitSet(errors.errorFlags(), i));
+    }
+  }
+
+  errors.clearError(23);
+
+  ASSERT_EQ(errors.size(), 24);
+  ASSERT_EQ(errors.countErrors(), 0);
+  ASSERT_FALSE(errors.hasError());
+
+  for (auto i = 0; i < errors.size(); ++i) {
+    ASSERT_FALSE(errors.hasErrorAt(i));
+    ASSERT_NO_THROW(errors.throwIfErrorAt(i));
+    ASSERT_FALSE(errors.errorAt(i).has_value());
+    ASSERT_FALSE(bits::isBitSet(errors.errorFlags(), i));
+  }
+}
+
+std::exception_ptr makeVeloxException(const std::string& errorMessage) {
+  try {
+    VELOX_USER_FAIL(errorMessage);
+    return nullptr;
+  } catch (...) {
+    return std::current_exception();
+  }
+}
+
+TEST_F(EvalErrorsTest, errorDetails) {
+  EvalErrors errors(pool(), 10);
+
+  errors.setError(0, makeVeloxException("Test error X"));
+  errors.setError(3, makeVeloxException("Test error Y"));
+  errors.setError(23, makeVeloxException("Test error Z"));
+
+  ASSERT_EQ(errors.size(), 24);
+  ASSERT_EQ(errors.countErrors(), 3);
+  ASSERT_TRUE(errors.hasError());
+
+  ASSERT_TRUE(errors.hasErrorAt(0));
+  VELOX_ASSERT_THROW(errors.throwIfErrorAt(0), "Test error X");
+
+  ASSERT_TRUE(errors.hasErrorAt(3));
+  VELOX_ASSERT_THROW(errors.throwIfErrorAt(3), "Test error Y");
+
+  ASSERT_TRUE(errors.hasErrorAt(23));
+  VELOX_ASSERT_THROW(errors.throwIfErrorAt(23), "Test error Z");
+
+  SelectivityVector rows(123);
+  VELOX_ASSERT_THROW(errors.throwFirstError(rows), "Test error X");
+
+  rows.setValid(0, false);
+  rows.updateBounds();
+  VELOX_ASSERT_THROW(errors.throwFirstError(rows), "Test error Y");
+
+  for (auto i = 0; i < errors.size(); ++i) {
+    if (i != 0 && i != 3 && i != 23) {
+      ASSERT_FALSE(errors.hasErrorAt(i));
+      ASSERT_NO_THROW(errors.throwIfErrorAt(i));
+      ASSERT_FALSE(errors.errorAt(i).has_value());
+      ASSERT_FALSE(bits::isBitSet(errors.errorFlags(), i));
+    }
+  }
+}
+
+TEST_F(EvalErrorsTest, copyError) {
+  EvalErrors other(pool(), 10);
+  for (auto i = 0; i < 20; i += 3) {
+    other.setError(i);
+  }
+
+  ASSERT_EQ(other.countErrors(), 7);
+
+  // Copy errors from 3 rows. Only one of these has an error.
+  EvalErrors errors(pool(), 10);
+  errors.copyError(other, 10, 0);
+  errors.copyError(other, 11, 1);
+  errors.copyError(other, 12, 2);
+
+  ASSERT_EQ(errors.size(), 10);
+  ASSERT_EQ(errors.countErrors(), 1);
+  ASSERT_TRUE(errors.hasError());
+  ASSERT_TRUE(errors.hasErrorAt(2));
+
+  // Copy errors from all rows. Shift destination rows by 5.
+  for (auto i = 0; i < other.size(); ++i) {
+    errors.copyError(other, i, i + 5);
+  }
+
+  ASSERT_EQ(errors.size(), 24);
+  ASSERT_EQ(errors.countErrors(), 8);
+  ASSERT_TRUE(errors.hasError());
+  ASSERT_TRUE(errors.hasErrorAt(2));
+  ASSERT_TRUE(errors.hasErrorAt(5));
+  ASSERT_TRUE(errors.hasErrorAt(8));
+  ASSERT_TRUE(errors.hasErrorAt(11));
+  ASSERT_TRUE(errors.hasErrorAt(14));
+  ASSERT_TRUE(errors.hasErrorAt(17));
+  ASSERT_TRUE(errors.hasErrorAt(20));
+  ASSERT_TRUE(errors.hasErrorAt(23));
+}
+
+TEST_F(EvalErrorsTest, copyErrorWithDetails) {
+  EvalErrors other(pool(), 10);
+  for (auto i = 0; i < 20; i += 2) {
+    other.setError(i, makeVeloxException(fmt::format("Test error at {}", i)));
+  }
+
+  ASSERT_EQ(other.countErrors(), 10);
+
+  // Copy errors from rows 10 to 19. Shift destination row by 10 down: 0 to 9.
+  EvalErrors errors(pool(), 10);
+  for (auto i = 10; i < 30; ++i) {
+    errors.copyError(other, i, i - 10);
+  }
+
+  ASSERT_EQ(errors.size(), 10);
+  ASSERT_EQ(errors.countErrors(), 5);
+  ASSERT_TRUE(errors.hasError());
+
+  ASSERT_TRUE(errors.hasErrorAt(0));
+  VELOX_ASSERT_THROW(errors.throwIfErrorAt(0), "Test error at 10");
+
+  ASSERT_TRUE(errors.hasErrorAt(2));
+  VELOX_ASSERT_THROW(errors.throwIfErrorAt(2), "Test error at 12");
+
+  ASSERT_TRUE(errors.hasErrorAt(4));
+  VELOX_ASSERT_THROW(errors.throwIfErrorAt(4), "Test error at 14");
+
+  ASSERT_TRUE(errors.hasErrorAt(6));
+  VELOX_ASSERT_THROW(errors.throwIfErrorAt(6), "Test error at 16");
+
+  ASSERT_TRUE(errors.hasErrorAt(8));
+  VELOX_ASSERT_THROW(errors.throwIfErrorAt(8), "Test error at 18");
+
+  // Copy one more error from row 0 to row 27.
+  errors.copyError(other, 0, 27);
+
+  ASSERT_EQ(errors.size(), 28);
+  ASSERT_EQ(errors.countErrors(), 6);
+  ASSERT_TRUE(errors.hasError());
+
+  ASSERT_TRUE(errors.hasErrorAt(27));
+  VELOX_ASSERT_THROW(errors.throwIfErrorAt(27), "Test error at 0");
+}
+
+TEST_F(EvalErrorsTest, copyErrors) {
+  EvalErrors other(pool(), 10);
+  for (auto i = 0; i < 20; i += 2) {
+    other.setError(i);
+  }
+
+  ASSERT_EQ(other.countErrors(), 10);
+
+  SelectivityVector rows(123, false);
+  rows.setValidRange(0, 5, true);
+  rows.setValidRange(10, 100, true);
+  rows.updateBounds();
+
+  EvalErrors errors(pool(), 10);
+  errors.copyErrors(rows, other);
+
+  ASSERT_EQ(errors.size(), 19);
+  ASSERT_EQ(errors.countErrors(), 8);
+  ASSERT_TRUE(errors.hasError());
+
+  ASSERT_TRUE(errors.hasErrorAt(0));
+  ASSERT_TRUE(errors.hasErrorAt(2));
+  ASSERT_TRUE(errors.hasErrorAt(4));
+  ASSERT_TRUE(errors.hasErrorAt(10));
+  ASSERT_TRUE(errors.hasErrorAt(12));
+  ASSERT_TRUE(errors.hasErrorAt(14));
+  ASSERT_TRUE(errors.hasErrorAt(16));
+  ASSERT_TRUE(errors.hasErrorAt(18));
+}
+
+TEST_F(EvalErrorsTest, copyAllErrors) {
+  EvalErrors other(pool(), 10);
+  for (auto i = 0; i < 20; i += 2) {
+    other.setError(i, makeVeloxException(fmt::format("Test error at {}", i)));
+  }
+
+  ASSERT_EQ(other.countErrors(), 10);
+
+  // Copy all errors from 'other' to this. Make sure pre-existing error doesn't
+  // get overwritten.
+  EvalErrors errors(pool(), 10);
+  errors.setError(4, makeVeloxException("Some other error"));
+  errors.copyErrors(other);
+
+  ASSERT_EQ(errors.size(), 19);
+  ASSERT_EQ(errors.countErrors(), 10);
+  ASSERT_TRUE(errors.hasError());
+
+  for (auto i = 0; i < 20; i += 2) {
+    ASSERT_TRUE(errors.hasErrorAt(i));
+    if (i == 4) {
+      VELOX_ASSERT_THROW(errors.throwIfErrorAt(i), "Some other error");
+    } else {
+      VELOX_ASSERT_THROW(
+          errors.throwIfErrorAt(i), fmt::format("Test error at {}", i));
+    }
+  }
+
+  for (auto i = 1; i < 20; i += 2) {
+    ASSERT_FALSE(errors.hasErrorAt(i));
+  }
+}
+} // namespace
+} // namespace facebook::velox::exec

--- a/velox/functions/prestosql/types/JsonType.cpp
+++ b/velox/functions/prestosql/types/JsonType.cpp
@@ -225,7 +225,7 @@ struct AsJson {
       : decoded_(context) {
     VELOX_CHECK(rows.hasSelections());
 
-    ErrorVectorPtr oldErrors;
+    exec::EvalErrorsPtr oldErrors;
     context.swapErrors(oldErrors);
     if (isJsonType(input->type())) {
       json_ = input;
@@ -320,7 +320,7 @@ struct AsJson {
       exec::EvalCtx& context,
       const SelectivityVector& rows,
       const BufferPtr& elementToTopLevelRows,
-      ErrorVectorPtr& oldErrors) {
+      exec::EvalErrorsPtr& oldErrors) {
     if (context.errors()) {
       if (elementToTopLevelRows) {
         context.addElementErrorsToTopLevel(

--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -71,7 +71,7 @@ Expected<T> callFollyTo(const F& v) {
   const auto result = folly::tryTo<T>(v);
   if (result.hasError()) {
     if (threadSkipErrorDetails()) {
-      return folly::makeUnexpected(Status::UserError(""));
+      return folly::makeUnexpected(Status::UserError());
     }
     return folly::makeUnexpected(Status::UserError(
         "{}", folly::makeConversionError(result.error(), "").what()));

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -617,13 +617,6 @@ void FlatVector<StringView>::prepareForReuse();
 template <typename T>
 using FlatVectorPtr = std::shared_ptr<FlatVector<T>>;
 
-// Error vector uses an opaque flat vector to store std::exception_ptr.
-// Since opaque types are stored as shared_ptr<void>, this ends up being a
-// double pointer in the form of std::shared_ptr<std::exception_ptr>. This is
-// fine since we only need to actually follow the pointer in failure cases.
-using ErrorVector = FlatVector<std::shared_ptr<void>>;
-using ErrorVectorPtr = std::shared_ptr<ErrorVector>;
-
 } // namespace facebook::velox
 
 #include "velox/vector/FlatVector-inl.h"

--- a/velox/vector/FunctionVector.h
+++ b/velox/vector/FunctionVector.h
@@ -22,6 +22,9 @@ namespace facebook::velox {
 
 namespace exec {
 class EvalCtx;
+class EvalErrors;
+
+using EvalErrorsPtr = std::shared_ptr<EvalErrors>;
 } // namespace exec
 
 // Represents a function with possible captures.
@@ -67,7 +70,7 @@ class Callable {
       const BufferPtr& wrapCapture,
       exec::EvalCtx* context,
       const std::vector<VectorPtr>& args,
-      ErrorVectorPtr& elementErrors,
+      exec::EvalErrorsPtr& elementErrors,
       VectorPtr* result) = 0;
 };
 


### PR DESCRIPTION
Summary:
ErrorVector was a flat vector storing `std::shared_ptr<std::exception_ptr>`.

In many cases (e.g. TRY) it is sufficient to simply indicate that a row has an
error. It is not necessary to store the actual error that occurred. ErrorVector
used 'nulls' buffer to indicate whether a row has an error and 'values' buffer 
to store the exception or null (if error details are not provided). Allocating 
unnecessary 'values' buffer wastes ~20 bytes per row. 

To use memory more efficiently, we replace ErrorVector with a custom 
class EvalErrors. Initially, EvalErrors simply wraps ErrorVector. A follow-up 
change will modify EvalErrors to store 'nulls' buffer and an optional 'values' 
buffer directly. EvalErrors will not allocate 'values' buffer unless it is needed 
to store error details.

A two-step transition is necessary to keep each change relatively small, 
easier to review and safer to land.

Differential Revision: D57992922


