### PR TITLE
Do not store exceptions under TRY

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -234,7 +234,7 @@ VectorPtr CastExpr::castToDate(
                         makeErrorMessage(input, row, DATE()),
                         result.error().message()));
               } else {
-                context.setStatus(row, Status::UserError(""));
+                context.setStatus(row, Status::UserError());
               }
             }
           } else {

--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -222,7 +222,11 @@ void EvalCtx::setError(
     throwError(exceptionPtr);
   }
 
-  addError(index, toVeloxException(exceptionPtr), errors_);
+  if (captureErrorDetails_) {
+    addError(index, toVeloxException(exceptionPtr), errors_);
+  } else {
+    addError(index, errors_);
+  }
 }
 
 // This should be used onlly when exceptionPtr is guranteed to be a
@@ -234,7 +238,11 @@ void EvalCtx::setVeloxExceptionError(
     std::rethrow_exception(exceptionPtr);
   }
 
-  addError(index, exceptionPtr, errors_);
+  if (captureErrorDetails_) {
+    addError(index, exceptionPtr, errors_);
+  } else {
+    addError(index, errors_);
+  }
 }
 
 void EvalCtx::setErrors(
@@ -244,9 +252,13 @@ void EvalCtx::setErrors(
     throwError(exceptionPtr);
   }
 
-  auto veloxException = toVeloxException(exceptionPtr);
-  rows.applyToSelected(
-      [&](auto row) { addError(row, veloxException, errors_); });
+  if (captureErrorDetails_) {
+    auto veloxException = toVeloxException(exceptionPtr);
+    rows.applyToSelected(
+        [&](auto row) { addError(row, veloxException, errors_); });
+  } else {
+    rows.applyToSelected([&](auto row) { addError(row, errors_); });
+  }
 }
 
 void EvalCtx::addElementErrorsToTopLevel(

--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -71,7 +71,7 @@ Expected<T> callFollyTo(const F& v) {
   const auto result = folly::tryTo<T>(v);
   if (result.hasError()) {
     if (threadSkipErrorDetails()) {
-      return folly::makeUnexpected(Status::UserError(""));
+      return folly::makeUnexpected(Status::UserError());
     }
     return folly::makeUnexpected(Status::UserError(
         "{}", folly::makeConversionError(result.error(), "").what()));


### PR DESCRIPTION
Summary: Do not store exceptions when EvalCtx::captureErrorDetails() is false.

Differential Revision: D58010139


