### PR TITLE
Add velox_type_tz to velox_config target

### DIFF
--- a/velox/core/CMakeLists.txt
+++ b/velox/core/CMakeLists.txt
@@ -16,7 +16,10 @@ if(${VELOX_BUILD_TESTING})
 endif()
 
 add_library(velox_config Config.cpp)
-target_link_libraries(velox_config PUBLIC velox_exception Folly::folly)
+target_link_libraries(
+  velox_config
+  PUBLIC velox_exception Folly::folly
+  PRIVATE velox_type_tz)
 
 add_library(velox_core Expressions.cpp PlanFragment.cpp PlanNode.cpp
                        QueryConfig.cpp QueryCtx.cpp SimpleFunctionMetadata.cpp)


### PR DESCRIPTION
`MemConfig::validateConfig()` calls `util::getTimeZoneID` which is defined in velox_type_tz.
Add this missing dependency.