### PR TITLE
Optimize EvalErrors

### DIFF
--- a/velox/expression/tests/TryExprTest.cpp
+++ b/velox/expression/tests/TryExprTest.cpp
@@ -508,16 +508,9 @@ DEBUG_ONLY_TEST_F(TryExprTest, errorRestoringContext) {
 
 // Verify memory usage increase from wrapping an expression in TRY.
 //
-// When wrapping non-throwing expression memory usage increase should not exceed
+// When wrapping an expression memory usage increase should not exceed
 // the amount of memory needed to store 1 bit per row (to track whether an
 // error occurred or not).
-//
-// When wrapping throwing expression memory usage increase should not exceed the
-// amount of memory needed to store 1 bit + 1
-// std::shared_ptr<std::exception_ptr> per row (16 bytes).
-//
-// We also account for the fact that memory is allocated in minimum chunks
-// (MemoryPool::preferredSize).
 TEST_F(TryExprTest, memoryUsage) {
   vector_size_t size = 10'000;
 
@@ -553,9 +546,7 @@ TEST_F(TryExprTest, memoryUsage) {
 
   // Measure memory usage with TRY over expression that throws from every row.
   {
-    // We need 16 bytes + 1 bit per row. Allow 20 bytes to account for extra
-    // padding, rounding and quantiziing.
-    const auto expectedIncrease = 20 * size;
+    const auto expectedIncrease = size / 2;
 
     auto pool = rootPool_->addLeafChild("test-memory-usage");
     auto result = evaluateWithCustomMemoryPool("try(c0 / 0)", data, pool.get());


### PR DESCRIPTION
Summary:
Use 'errorFlags' buffer and an optional 'exceptions' buffer instead of a FlatVector.

Do not allocate 'exceptions' buffer if no exceptions are stored.

Microbenchmark shows 10-20% reduction in CPU time.

Before:

```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
cast##try_cast_invalid_empty_input                          2.26ms    441.51
cast##tryexpr_cast_invalid_empty_input                      4.77ms    209.74
cast##try_cast_invalid_nan                                  4.35ms    229.99
cast##tryexpr_cast_invalid_nan                              6.94ms    144.01
cast##try_cast_valid                                        3.15ms    317.94
----------------------------------------------------------------------------
cast_varhar_as_date##try_cast_invalid_empty_inp            34.38ms     29.09
cast_varhar_as_date##tryexpr_cast_invalid_empty            59.24ms     16.88
cast_varhar_as_date##try_cast_invalid_input                48.58ms     20.58
cast_varhar_as_date##tryexpr_cast_invalid_input            76.38ms     13.09
cast_varhar_as_date##cast_valid                            34.91ms     28.64
----------------------------------------------------------------------------
cast_varhar_as_timestamp##try_cast_invalid_empt            25.47ms     39.27
cast_varhar_as_timestamp##tryexpr_cast_invalid_            53.43ms     18.71
cast_varhar_as_timestamp##try_cast_invalid_inpu            68.67ms     14.56
cast_varhar_as_timestamp##tryexpr_cast_invalid_           100.99ms      9.90
cast_varhar_as_timestamp##cast_valid                       50.63ms     19.75
----------------------------------------------------------------------------
```

After:

```
cast##try_cast_invalid_empty_input                          2.31ms    433.46
cast##tryexpr_cast_invalid_empty_input                      3.97ms    252.09
cast##try_cast_invalid_nan                                  4.44ms    225.13
cast##tryexpr_cast_invalid_nan                              6.05ms    165.24
cast##try_cast_valid                                        3.11ms    321.17
----------------------------------------------------------------------------
cast_varhar_as_date##try_cast_invalid_empty_inp            34.98ms     28.59
cast_varhar_as_date##tryexpr_cast_invalid_empty            50.85ms     19.66
cast_varhar_as_date##try_cast_invalid_input                47.54ms     21.04
cast_varhar_as_date##tryexpr_cast_invalid_input            67.36ms     14.85
cast_varhar_as_date##cast_valid                            35.35ms     28.29
----------------------------------------------------------------------------
cast_varhar_as_timestamp##try_cast_invalid_empt            24.73ms     40.44
cast_varhar_as_timestamp##tryexpr_cast_invalid_            44.50ms     22.47
cast_varhar_as_timestamp##try_cast_invalid_inpu            68.21ms     14.66
cast_varhar_as_timestamp##tryexpr_cast_invalid_            93.65ms     10.68
cast_varhar_as_timestamp##cast_valid                       50.80ms     19.68
----------------------------------------------------------------------------
```

Differential Revision: D58010749


