### PR TITLE
Correct required simdjson version in resolving dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -443,7 +443,7 @@ if(${VELOX_BUILD_PYTHON_PACKAGE})
 endif()
 
 set_source(simdjson)
-resolve_dependency(simdjson 3.8.0)
+resolve_dependency(simdjson 3.9.3)
 
 # Locate or build folly.
 add_compile_definitions(FOLLY_HAVE_INT128_T=1)


### PR DESCRIPTION
Follow-up fix for https://github.com/facebookincubator/velox/pull/9985.