### PR TITLE
MergeJoin may hang if right side throws an exception

### DIFF
--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -231,6 +231,8 @@ void notify(std::optional<ContinuePromise>& promise) {
 BlockingReason MergeJoinSource::next(
     ContinueFuture* future,
     RowVectorPtr* data) {
+  common::testutil::TestValue::adjust(
+      "facebook::velox::exec::MergeSource::next", this);
   return state_.withWLock([&](auto& state) {
     if (state.data != nullptr) {
       *data = std::move(state.data);
@@ -252,11 +254,18 @@ BlockingReason MergeJoinSource::next(
 BlockingReason MergeJoinSource::enqueue(
     RowVectorPtr data,
     ContinueFuture* future) {
+  common::testutil::TestValue::adjust(
+      "facebook::velox::exec::MergeSource::enqueue", this);
   return state_.withWLock([&](auto& state) {
     if (state.atEnd) {
       // This can happen if consumer called close() because it doesn't need any
-      // more data.
-      // TODO Finish the pipeline early and avoid unnecessary computing.
+      // more data, or because the Task failed or was aborted and the Driver is
+      // cleaning up.
+      // TODO: Finish the pipeline early and avoid unnecessary computing.
+
+      // Notify consumerPromise_ so the consumer doesn't hang indefinitely if
+      // this is because the Driver is closing operators.
+      notify(consumerPromise_);
       return BlockingReason::kNotBlocked;
     }
 
@@ -281,6 +290,7 @@ void MergeJoinSource::close() {
     state.data = nullptr;
     state.atEnd = true;
     notify(producerPromise_);
+    notify(consumerPromise_);
   });
 }
 } // namespace facebook::velox::exec


### PR DESCRIPTION
Summary:
In MergeJoin if the left side is waiting for data (it's called next on the MergeJoinSource and there 
wasn't any available), it will create a promise consumerPromise_ to be fulfilled once the right side 
adds more data (it calls enqueue on the MergeJoinSource).

If the right side of the join fails before it can call enqueue, the Drivers will be closed and 
consumerPromise_ will be left unfulfilled, leaving the left side hanging.

To fix this, I fulfilled the promise in 2 places, one is in MergeJoinSource::close, the other is in 
enqueue when state.atEnd is already true.  It is safe to do so in either case because state.atEnd has 
already been set to true, so MergeJoinSource::next will return nullptr which is desired.

Either is sufficient to address the issue.  When the Driver is closed, first MergeJoinSource::close is 
called, then CallBackSink::close is called which will call MergeJoinSource::enqueue 
(MergeJoinSource::close will have already set state.atEnd to true).  I did it in both places to ensure
we don't miss any other edge cases.

Discovered running JoinFuzzer with OOM injection enabled.

Differential Revision: D58027361


