### PR TITLE
Do not allocate dictionary filter cache if the filter is IsNotNull to avoid OOM

### DIFF
--- a/velox/dwio/common/ColumnVisitors.h
+++ b/velox/dwio/common/ColumnVisitors.h
@@ -756,7 +756,7 @@ class DictionaryColumnVisitor
     vector_size_t previous =
         isDense && TFilter::deterministic ? 0 : super::currentRow();
     T valueInDictionary = dict()[value];
-    if (std::is_same_v<TFilter, velox::common::AlwaysTrue>) {
+    if constexpr (!hasFilter()) {
       super::filterPassed(valueInDictionary);
     } else {
       // check the dictionary cache
@@ -811,7 +811,7 @@ class DictionaryColumnVisitor
       T* values,
       int32_t& numValues) {
     DCHECK_EQ(input, values + numValues);
-    if (!hasFilter) {
+    if constexpr (!DictionaryColumnVisitor::hasFilter()) {
       if (hasHook) {
         translateByDict(input, numInput, values);
         super::values_.hook().addValues(
@@ -824,17 +824,28 @@ class DictionaryColumnVisitor
         super::rowIndex_ += numInput;
         return;
       }
-      if (inDict()) {
-        translateScatter<true, scatter>(
-            input, numInput, scatterRows, numValues, values);
+      if constexpr (std::is_same_v<TFilter, velox::common::IsNotNull>) {
+        auto* begin = (scatter ? scatterRows : super::rows_) + super::rowIndex_;
+        std::copy(begin, begin + numInput, filterHits + numValues);
+        if constexpr (!super::kFilterOnly) {
+          translateByDict(input, numInput, values + numValues);
+        }
+        numValues += numInput;
       } else {
-        translateScatter<false, scatter>(
-            input, numInput, scatterRows, numValues, values);
+        if (inDict()) {
+          translateScatter<true, scatter>(
+              input, numInput, scatterRows, numValues, values);
+        } else {
+          translateScatter<false, scatter>(
+              input, numInput, scatterRows, numValues, values);
+        }
+        numValues = scatter ? scatterRows[super::rowIndex_ + numInput - 1] + 1
+                            : numValues + numInput;
       }
       super::rowIndex_ += numInput;
-      numValues = scatter ? scatterRows[super::rowIndex_ - 1] + 1
-                          : numValues + numInput;
       return;
+    } else {
+      static_assert(hasFilter);
     }
     // The filter path optionally extracts values but always sets
     // filterHits. It first loads a vector of indices. It translates
@@ -1091,6 +1102,13 @@ class DictionaryColumnVisitor
     return state_.filterCache;
   }
 
+  static constexpr bool hasFilter() {
+    // Dictionary values cannot be null.  See the explanation in
+    // `DictionaryValues::hasFilter'.
+    return !std::is_same_v<TFilter, velox::common::AlwaysTrue> &&
+        !std::is_same_v<TFilter, velox::common::IsNotNull>;
+  }
+
   RawScanState state_;
   const uint8_t width_;
 };
@@ -1141,7 +1159,7 @@ class StringDictionaryColumnVisitor
     }
     vector_size_t previous =
         isDense && TFilter::deterministic ? 0 : super::currentRow();
-    if (std::is_same_v<TFilter, velox::common::AlwaysTrue>) {
+    if constexpr (!DictSuper::hasFilter()) {
       super::filterPassed(index);
     } else {
       // check the dictionary cache
@@ -1194,7 +1212,7 @@ class StringDictionaryColumnVisitor
       int32_t& numValues) {
     DCHECK(input == values + numValues);
     setByInDict(values + numValues, numInput);
-    if (!hasFilter) {
+    if constexpr (!DictSuper::hasFilter()) {
       if (hasHook) {
         for (auto i = 0; i < numInput; ++i) {
           auto value = input[i];
@@ -1204,15 +1222,21 @@ class StringDictionaryColumnVisitor
               value);
         }
       }
-      DCHECK_EQ(input, values + numValues);
-      if (scatter) {
+      if constexpr (std::is_same_v<TFilter, velox::common::IsNotNull>) {
+        auto* begin = (scatter ? scatterRows : super::rows_) + super::rowIndex_;
+        std::copy(begin, begin + numInput, filterHits + numValues);
+        numValues += numInput;
+      } else if constexpr (scatter) {
         dwio::common::scatterDense(
             input, scatterRows + super::rowIndex_, numInput, values);
+        numValues = scatterRows[super::rowIndex_ + numInput - 1] + 1;
+      } else {
+        numValues += numInput;
       }
-      numValues = scatter ? scatterRows[super::rowIndex_ + numInput - 1] + 1
-                          : numValues + numInput;
       super::rowIndex_ += numInput;
       return;
+    } else {
+      static_assert(hasFilter);
     }
     constexpr bool filterOnly =
         std::is_same_v<typename super::Extract, DropValues>;

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -50,6 +50,17 @@ struct DictionaryValues {
     numValues = 0;
     sorted = false;
   }
+
+  /// Whether the dictionary values have filter on it.
+  static bool hasFilter(const velox::common::Filter* filter) {
+    // Dictionary values cannot be null.  It's by design not possible in ORC and
+    // Parquet; in other formats even when it is possible in theory, it should
+    // not be used in a normal file because outside dictionary we only need 1
+    // bit to encode a null, but if we move it inside dictionary, we would need
+    // 1 integer to encode a null.  A sanity check can be added on encoding
+    // metadata for such formats.
+    return filter && filter->kind() != velox::common::FilterKind::kIsNotNull;
+  }
 };
 
 struct RawDictionaryState {

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
@@ -117,7 +117,7 @@ void SelectiveIntegerDictionaryColumnReader::ensureInitialized() {
 
   Timer timer;
   scanState_.dictionary.values = dictInit_();
-  if (scanSpec_->hasFilter()) {
+  if (DictionaryValues::hasFilter(scanSpec_->filter())) {
     // Make sure there is a cache even for an empty dictionary because of asan
     // failure when preparing a gather with all lanes masked out.
     scanState_.filterCache.resize(

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
@@ -152,7 +152,7 @@ void SelectiveStringDictionaryColumnReader::loadStrideDictionary() {
   lastStrideIndex_ = nextStride;
   dictionaryValues_ = nullptr;
 
-  if (scanSpec_->hasFilter()) {
+  if (DictionaryValues::hasFilter(scanSpec_->filter())) {
     scanState_.filterCache.resize(
         scanState_.dictionary.numValues + scanState_.dictionary2.numValues);
     simd::memset(
@@ -333,7 +333,7 @@ void SelectiveStringDictionaryColumnReader::ensureInitialized() {
 
   loadDictionary(*blobStream_, *lengthDecoder_, scanState_.dictionary);
 
-  if (scanSpec_->hasFilter()) {
+  if (DictionaryValues::hasFilter(scanSpec_->filter())) {
     scanState_.filterCache.resize(scanState_.dictionary.numValues);
     simd::memset(
         scanState_.filterCache.data(),


### PR DESCRIPTION
Summary:
For map keys we added a `IsNotNull` filter to align the behavior with
Presto Java.  When the key column is dictionary encoded, we allocate the filter
cache even the dictionary values always pass the filter because they cannot be
null.  This caused some memory regression and we fix it by ignoring the
`IsNotNull` filter on dictionary values.

Differential Revision: D58023156


