### PR TITLE
Move commonly used function makeSplit to FuzzerUtil

### DIFF
--- a/velox/exec/fuzzer/CMakeLists.txt
+++ b/velox/exec/fuzzer/CMakeLists.txt
@@ -71,12 +71,12 @@ add_library(velox_row_number_fuzzer RowNumberFuzzer.cpp)
 
 target_link_libraries(
   velox_row_number_fuzzer velox_fuzzer_util velox_type velox_vector_fuzzer
-  velox_exec_test_lib velox_expression_test_utility)
+  velox_exec_test_lib velox_expression_test_utility velox_fuzzer_util)
 
 add_library(velox_join_fuzzer JoinFuzzer.cpp)
 
 target_link_libraries(velox_join_fuzzer velox_type velox_vector_fuzzer
-                      velox_exec_test_lib velox_expression_test_utility)
+                      velox_exec_test_lib velox_expression_test_utility velox_fuzzer_util)
 
 add_library(velox_writer_fuzzer WriterFuzzer.cpp)
 

--- a/velox/exec/fuzzer/FuzzerUtil.cpp
+++ b/velox/exec/fuzzer/FuzzerUtil.cpp
@@ -53,6 +53,11 @@ std::vector<exec::Split> makeSplits(
 }
 
 exec::Split makeSplit(const std::string& filePath) {
-  return exec::Split{std::make_shared<connector::hive::HiveConnectorSplit>(
-      kHiveConnectorId, filePath, dwio::common::FileFormat::DWRF)};
+  return exec::Split{makeConnectorSplit(filePath)};
+}
+
+std::shared_ptr<connector::ConnectorSplit> makeConnectorSplit(
+    const std::string& filePath) {
+  return std::make_shared<connector::hive::HiveConnectorSplit>(
+      kHiveConnectorId, filePath, dwio::common::FileFormat::DWRF);
 }

--- a/velox/exec/fuzzer/FuzzerUtil.h
+++ b/velox/exec/fuzzer/FuzzerUtil.h
@@ -23,4 +23,9 @@ std::vector<facebook::velox::exec::Split> makeSplits(
     const std::string& path,
     const std::shared_ptr<facebook::velox::memory::MemoryPool>& pool);
 
+/// Makes a exec::split from a file path.
 facebook::velox::exec::Split makeSplit(const std::string& filePath);
+
+// Makes a connector split from a file path on storage.
+std::shared_ptr<facebook::velox::connector::ConnectorSplit> makeConnectorSplit(
+    const std::string& filePath);


### PR DESCRIPTION
Multiple fuzzers are creating same makeSplit function in themselves. 
Move this function to FuzzerUtil.