### PR TITLE
Refactor cast(x as date)

### DIFF
--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -287,14 +287,6 @@ class CastExpr : public SpecialForm {
       const BaseVector& input,
       VectorPtr& result);
 
-  template <bool adjustForTimeZone>
-  void castTimestampToDate(
-      const SelectivityVector& rows,
-      const BaseVector& input,
-      exec::EvalCtx& context,
-      VectorPtr& result,
-      const date::time_zone* timeZone = nullptr);
-
   VectorPtr applyTimestampToVarcharCast(
       const TypePtr& toType,
       const SelectivityVector& rows,

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -207,4 +207,8 @@ inline Expected<std::pair<Timestamp, int64_t>> fromTimestampWithTimezoneString(
 
 Timestamp fromDatetime(int64_t daysSinceEpoch, int64_t microsSinceMidnight);
 
+/// Returns the number of days since epoch for a given timestamp and optional
+/// time zone.
+int32_t toDate(const Timestamp& timestamp, const date::time_zone* timeZone_);
+
 } // namespace facebook::velox::util


### PR DESCRIPTION
Summary:
date(timestamp) is an alias for cast(timestamp as date). 

Refactor these to share the implementation.

Differential Revision: D58073147


