### PR TITLE
Add support for CAST(timestamp with time zone AS date)

### DIFF
--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -181,9 +181,9 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      -
+     - Y
+     - Y
      -
-     - Y
-     - Y
      -
      -
      -
@@ -197,7 +197,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      - Y
      - Y
-     -
+     - Y
      -
      -
      -
@@ -335,7 +335,7 @@ Valid examples
 Invalid examples
 
 ::
-  
+
   SELECT cast(214748364890 decimal(12, 2) as integer); -- Out of range
 
 Cast to Boolean
@@ -614,7 +614,7 @@ From VARCHAR
 ^^^^^^^^^^^^
 
 Casting from a string to timestamp is allowed if the string represents a
-timestamp in the format `YYYY-MM-DD` followed by an optional `hh:mm:ss.MS`. 
+timestamp in the format `YYYY-MM-DD` followed by an optional `hh:mm:ss.MS`.
 Seconds and milliseconds are optional. Casting from invalid input values throws.
 
 Valid examples:
@@ -766,6 +766,20 @@ Valid examples
 
   SELECT cast(timestamp '1970-01-01 00:00:00' as date); -- 1970-01-01
   SELECT cast(timestamp '1970-01-01 23:59:59' as date); -- 1970-01-01
+
+From TIMESTAMP WITH TIME ZONE
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Casting from TIMESTAMP WITH TIME ZONE to DATE is allowed. If present,
+the part of `hh:mm:ss` in the input is ignored.
+
+Session time zone does not affect the result.
+
+Valid examples
+
+::
+
+  SELECT CAST(timestamp '2024-06-01 01:38:00 America/New_York' as DATE); -- 2024-06-01
 
 Cast to Decimal
 ---------------

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -119,7 +119,7 @@ struct DateFunction : public TimestampWithTimezoneSupport<T> {
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
       const arg_type<TimestampWithTimezone>* timestampWithTimezone) {
-    timeZone_ = getTimeZoneFromConfig(config);
+    // Do nothing. Session timezone doesn't affect the result.
   }
 
   FOLLY_ALWAYS_INLINE void call(
@@ -137,7 +137,7 @@ struct DateFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void call(
       out_type<Date>& result,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
-    result = util::toDate(this->toTimestamp(timestampWithTimezone), timeZone_);
+    result = util::toDate(this->toTimestamp(timestampWithTimezone), nullptr);
   }
 
  private:

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -3599,8 +3599,12 @@ TEST_F(DateTimeFunctionsTest, dateFunctionTimestampWithTimezone) {
   const auto dateFunction =
       [&](std::optional<int64_t> timestamp,
           const std::optional<std::string>& timeZoneName) {
-        return evaluateWithTimestampWithTimezone<int32_t>(
+        auto r1 = evaluateWithTimestampWithTimezone<int32_t>(
             "date(c0)", timestamp, timeZoneName);
+        auto r2 = evaluateWithTimestampWithTimezone<int32_t>(
+            "cast(c0 as date)", timestamp, timeZoneName);
+        EXPECT_EQ(r1, r2);
+        return r1;
       };
 
   // 1970-01-01 00:00:00.000 +00:00


### PR DESCRIPTION
Summary:
CAST(timestamp with time zone AS date) is not affected by the session time zone.

For example, 1AM EST is 10PM PST. When session time zone is PST, cast(1M as date) returns 'today' even though it is 'yesterday' in session's time zone.

```
presto> SELECT current_timezone();
        _col0
---------------------
 America/Los_Angeles

presto> select date(timestamp '2024-06-01 01:00 America/New_York');
   _col0
------------
 2024-06-01

presto> select cast(timestamp '2024-06-01 01:00 America/New_York' as timestamp);
          _col0
-------------------------
 2024-05-31 22:00:00.000

presto> select date(cast(timestamp '2024-06-01 01:00 America/New_York' as timestamp));
   _col0
------------
 2024-05-31
``` 

date(timestamp with time zone) is an alias for CAST(timestamp with time zone AS
date). It used to apply session time zone incorrectly. Fix that.

Remove redundant null checks for inputs.

Differential Revision: D58078617


