### PR TITLE
Fix row index wrong value issue when only project with const data column

### DIFF
--- a/velox/dwio/common/Reader.cpp
+++ b/velox/dwio/common/Reader.cpp
@@ -157,9 +157,13 @@ void RowReader::readWithRowNumber(
     VectorPtr& result) {
   auto* rowVector = result->asUnchecked<RowVector>();
   column_index_t numChildren = 0;
+  column_index_t numConstChildren = 0;
   for (auto& column : options.getScanSpec()->children()) {
     if (column->projectOut()) {
       ++numChildren;
+      if (column->isConstant()) {
+        ++numConstChildren;
+      }
     }
   }
   VectorPtr rowNumVector;
@@ -205,7 +209,8 @@ void RowReader::readWithRowNumber(
     flatRowNum = rowNumVector->asUnchecked<FlatVector<int64_t>>();
   }
   auto* rawRowNum = flatRowNum->mutableRawValues();
-  if (numChildren == 0 && !hasDeletion(mutation)) {
+  if ((numChildren == 0 || numChildren == numConstChildren) &&
+      !hasDeletion(mutation)) {
     VELOX_DCHECK_EQ(rowsToRead, result->size());
     std::iota(rawRowNum, rawRowNum + rowsToRead, previousRow);
   } else {

--- a/velox/dwio/common/Reader.cpp
+++ b/velox/dwio/common/Reader.cpp
@@ -209,8 +209,7 @@ void RowReader::readWithRowNumber(
     flatRowNum = rowNumVector->asUnchecked<FlatVector<int64_t>>();
   }
   auto* rawRowNum = flatRowNum->mutableRawValues();
-  if ((numChildren == 0 || numChildren == numConstChildren) &&
-      !hasDeletion(mutation)) {
+  if (numChildren == numConstChildren && !hasDeletion(mutation)) {
     VELOX_DCHECK_EQ(rowsToRead, result->size());
     std::iota(rawRowNum, rawRowNum + rowsToRead, previousRow);
   } else {

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -128,8 +128,10 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
       RowVectorPtr data,
       const std::optional<
           std::unordered_map<std::string, std::optional<std::string>>>&
-          partitionKeys = std::nullopt) {
-    splits_ = {makeSplit(filePath)};
+          partitionKeys = std::nullopt,
+      const std::optional<std::unordered_map<std::string, std::string>>&
+          infoColumns = std::nullopt) {
+    splits_ = {makeSplit(filePath, partitionKeys, infoColumns)};
     rowType_ = rowType;
     createDuckDbTable({data});
   }
@@ -156,9 +158,15 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
       const std::string& filePath,
       const std::optional<
           std::unordered_map<std::string, std::optional<std::string>>>&
-          partitionKeys = std::nullopt) {
+          partitionKeys = std::nullopt,
+      const std::optional<std::unordered_map<std::string, std::string>>&
+          infoColumns = std::nullopt) {
     return makeHiveConnectorSplits(
-        filePath, 1, dwio::common::FileFormat::PARQUET, partitionKeys)[0];
+        filePath,
+        1,
+        dwio::common::FileFormat::PARQUET,
+        partitionKeys,
+        infoColumns)[0];
   }
 
  private:
@@ -496,18 +504,24 @@ TEST_F(ParquetTableScanTest, readAsLowerCase) {
 }
 
 TEST_F(ParquetTableScanTest, rowIndex) {
+  static const char* kPath = "file_path";
   // case 1: file not have `_tmp_metadata_row_index`, scan generate it for user.
+  auto filePath = getExampleFilePath("sample.parquet");
   loadData(
-      getExampleFilePath("sample.parquet"),
-      ROW({"a", "b", "_tmp_metadata_row_index"},
-          {BIGINT(), DOUBLE(), BIGINT()}),
+      filePath,
+      ROW({"a", "b", "_tmp_metadata_row_index", kPath},
+          {BIGINT(), DOUBLE(), BIGINT(), VARCHAR()}),
       makeRowVector(
-          {"a", "b", "_tmp_metadata_row_index"},
+          {"a", "b", "_tmp_metadata_row_index", kPath},
           {
               makeFlatVector<int64_t>(20, [](auto row) { return row + 1; }),
               makeFlatVector<double>(20, [](auto row) { return row + 1; }),
               makeFlatVector<int64_t>(20, [](auto row) { return row; }),
-          }));
+              makeFlatVector<std::string>(
+                  20, [filePath](auto row) { return filePath; }),
+          }),
+      std::nullopt,
+      std::unordered_map<std::string, std::string>{{kPath, filePath}});
   std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
       assignments;
   assignments["a"] = std::make_shared<connector::hive::HiveColumnHandle>(
@@ -520,6 +534,7 @@ TEST_F(ParquetTableScanTest, rowIndex) {
       connector::hive::HiveColumnHandle::ColumnType::kRegular,
       DOUBLE(),
       DOUBLE());
+  assignments[kPath] = synthesizedColumn(kPath, VARCHAR());
   assignments["_tmp_metadata_row_index"] =
       std::make_shared<connector::hive::HiveColumnHandle>(
           "_tmp_metadata_row_index",
@@ -540,6 +555,10 @@ TEST_F(ParquetTableScanTest, rowIndex) {
       {"_tmp_metadata_row_index"},
       assignments,
       "SELECT _tmp_metadata_row_index FROM tmp");
+  assertSelectWithAssignments(
+      {kPath, "_tmp_metadata_row_index"},
+      assignments,
+      fmt::format("SELECT {}, _tmp_metadata_row_index FROM tmp", kPath));
 
   // case 2: file has `_tmp_metadata_row_index` column, then use user data
   // insteads of generating it.

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -146,7 +146,9 @@ HiveConnectorTestBase::makeHiveConnectorSplits(
     dwio::common::FileFormat format,
     const std::optional<
         std::unordered_map<std::string, std::optional<std::string>>>&
-        partitionKeys) {
+        partitionKeys,
+    const std::optional<std::unordered_map<std::string, std::string>>&
+        infoColumns) {
   auto file =
       filesystems::getFileSystem(filePath, nullptr)->openFileForRead(filePath);
   const int64_t fileSize = file->size();
@@ -159,6 +161,11 @@ HiveConnectorTestBase::makeHiveConnectorSplits(
                             .fileFormat(format)
                             .start(i * splitSize)
                             .length(splitSize);
+    if (infoColumns.has_value()) {
+      for (auto infoColumn : infoColumns.value()) {
+        splitBuilder.infoColumn(infoColumn.first, infoColumn.second);
+      }
+    }
     if (partitionKeys.has_value()) {
       for (auto partitionKey : partitionKeys.value()) {
         splitBuilder.partitionKey(partitionKey.first, partitionKey.second);

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -102,7 +102,9 @@ class HiveConnectorTestBase : public OperatorTestBase {
       dwio::common::FileFormat format,
       const std::optional<
           std::unordered_map<std::string, std::optional<std::string>>>&
-          partitionKeys = {});
+          partitionKeys = {},
+      const std::optional<std::unordered_map<std::string, std::string>>&
+          infoColumns = {});
 
   static std::shared_ptr<connector::hive::HiveTableHandle> makeTableHandle(
       common::test::SubfieldFilters subfieldFilters = {},


### PR DESCRIPTION
Fix row index wrong value issue when only project with const data column

fix below query

```
select file_path, _tmp_row_index_column from tmp
```
where `file_path` is const data column (`kSynthesized column`)

Fix https://github.com/facebookincubator/velox/issues/9943