### PR TITLE
Add support for CAST(timestamp with time zone AS varchar)

### DIFF
--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -181,9 +181,9 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      -
+     - Y
+     - Y
      -
-     - Y
-     - Y
      -
      -
      -
@@ -197,7 +197,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      - Y
      - Y
-     -
+     - Y
      -
      -
      -
@@ -335,7 +335,7 @@ Valid examples
 Invalid examples
 
 ::
-  
+
   SELECT cast(214748364890 decimal(12, 2) as integer); -- Out of range
 
 Cast to Boolean
@@ -614,7 +614,7 @@ From VARCHAR
 ^^^^^^^^^^^^
 
 Casting from a string to timestamp is allowed if the string represents a
-timestamp in the format `YYYY-MM-DD` followed by an optional `hh:mm:ss.MS`. 
+timestamp in the format `YYYY-MM-DD` followed by an optional `hh:mm:ss.MS`.
 Seconds and milliseconds are optional. Casting from invalid input values throws.
 
 Valid examples:
@@ -766,6 +766,20 @@ Valid examples
 
   SELECT cast(timestamp '1970-01-01 00:00:00' as date); -- 1970-01-01
   SELECT cast(timestamp '1970-01-01 23:59:59' as date); -- 1970-01-01
+
+From TIMESTAMP WITH TIME ZONE
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Casting from TIMESTAMP WITH TIME ZONE to DATE is allowed. If present,
+the part of `hh:mm:ss` in the input is ignored.
+
+Session time zone does not affect the result.
+
+Valid examples
+
+::
+
+  SELECT CAST(timestamp '2024-06-01 01:38:00 America/New_York' as DATE); -- 2024-06-01
 
 Cast to Decimal
 ---------------

--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -155,7 +155,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
-     -
+     - Y
      - Y
      -
      - Y
@@ -497,6 +497,7 @@ Valid examples
   SELECT cast(infinity() as varchar); -- 'Infinity'
   SELECT cast(true as varchar); -- 'true'
   SELECT cast(timestamp '1970-01-01 00:00:00' as varchar); -- '1970-01-01 00:00:00.000'
+  SELECT cast(timestamp '2024-06-01 11:37:15.123 America/New_York' as varchar); -- '2024-06-01 11:37:15.123 America/New_York'
   SELECT cast(cast(22.51 as DECIMAL(5, 3)) as varchar); -- '22.510'
   SELECT cast(cast(-22.51 as DECIMAL(4, 2)) as varchar); -- '-22.51'
   SELECT cast(cast(0.123 as DECIMAL(3, 3)) as varchar); -- '0.123'

--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -184,7 +184,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      -
-     -
+     - Y
      -
      -
    * - date
@@ -726,6 +726,21 @@ Valid examples
   SELECT cast(timestamp '1970-01-01 00:00:00' as timestamp with time zone); -- 1970-01-01 00:00:00.000 America/Los_Angeles
   SELECT cast(timestamp '2012-03-09 10:00:00' as timestamp with time zone); -- 2012-03-09 10:00:00.000 America/Los_Angeles
   SELECT cast(from_unixtime(0) as timestamp with time zone); -- 1970-01-01 00:00:00.000 America/Los_Angeles
+
+From DATE
+^^^^^^^^^
+
+The results depend on `session_timestamp`.
+
+Valid examples
+
+::
+
+    -- session_timezone = America/Los_Angeles
+    SELECT cast(date '2024-06-01' as timestamp with time zone); -- 2024-06-01 00:00:00.000 America/Los_Angeles
+
+    -- session_timezone = Asia/Shanghai
+    SELECT cast(date '2024-06-01' as timestamp with time zone); -- 2024-06-01 00:00:00.000 Asia/Shanghai
 
 Cast to Date
 ------------

--- a/velox/duckdb/conversion/DuckConversion.cpp
+++ b/velox/duckdb/conversion/DuckConversion.cpp
@@ -140,6 +140,12 @@ TypePtr toVeloxType(LogicalType type, bool fileColumnNamesReadAsLowerCase) {
       return DATE();
     case LogicalTypeId::TIMESTAMP:
       return TIMESTAMP();
+    case LogicalTypeId::TIMESTAMP_TZ: {
+      if (auto customType = getCustomType("TIMESTAMP WITH TIME ZONE")) {
+        return customType;
+      }
+      [[fallthrough]];
+    }
     case LogicalTypeId::INTERVAL:
       return INTERVAL_DAY_TIME();
     case LogicalTypeId::BLOB:

--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/core/PlanNode.h"
 #include "velox/functions/prestosql/types/JsonType.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/parse/Expressions.h"
 
 using namespace facebook::velox;
@@ -372,6 +373,16 @@ TEST(DuckParserTest, castToJson) {
   registerJsonType();
   EXPECT_EQ("cast(\"c0\", JSON)", parseExpr("cast(c0 as json)")->toString());
   EXPECT_EQ("cast(\"c0\", JSON)", parseExpr("cast(c0 as JSON)")->toString());
+}
+
+TEST(DuckParserTest, castToTimestampWithTimeZone) {
+  registerTimestampWithTimeZoneType();
+  EXPECT_EQ(
+      "cast(\"c0\", TIMESTAMP WITH TIME ZONE)",
+      parseExpr("cast(c0 as timestamp with time zone)")->toString());
+  EXPECT_EQ(
+      "cast(\"c0\", TIMESTAMP WITH TIME ZONE)",
+      parseExpr("cast(c0 as TIMESTAMP WITH TIME ZONE)")->toString());
 }
 
 TEST(DuckParserTest, ifCase) {

--- a/velox/functions/lib/CMakeLists.txt
+++ b/velox/functions/lib/CMakeLists.txt
@@ -20,13 +20,16 @@ add_library(velox_functions_util LambdaFunctionUtil.cpp RowsTranslationUtil.cpp)
 
 target_link_libraries(velox_functions_util velox_vector velox_common_base)
 
+add_library(velox_functions_lib_date_time_formatter
+            DateTimeFormatter.cpp DateTimeFormatterBuilder.cpp)
+
+target_link_libraries(velox_functions_lib_date_time_formatter velox_type_tz)
+
 add_library(
   velox_functions_lib
   ArrayShuffle.cpp
   CheckDuplicateKeys.cpp
   CheckNestedNulls.cpp
-  DateTimeFormatter.cpp
-  DateTimeFormatterBuilder.cpp
   KllSketch.cpp
   MapConcat.cpp
   Re2Functions.cpp

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -119,7 +119,7 @@ struct DateFunction : public TimestampWithTimezoneSupport<T> {
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
       const arg_type<TimestampWithTimezone>* timestampWithTimezone) {
-    timeZone_ = getTimeZoneFromConfig(config);
+    // Do nothing. Session timezone doesn't affect the result.
   }
 
   FOLLY_ALWAYS_INLINE void call(
@@ -137,7 +137,7 @@ struct DateFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void call(
       out_type<Date>& result,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
-    result = util::toDate(this->toTimestamp(timestampWithTimezone), timeZone_);
+    result = util::toDate(this->toTimestamp(timestampWithTimezone), nullptr);
   }
 
  private:

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -3599,8 +3599,12 @@ TEST_F(DateTimeFunctionsTest, dateFunctionTimestampWithTimezone) {
   const auto dateFunction =
       [&](std::optional<int64_t> timestamp,
           const std::optional<std::string>& timeZoneName) {
-        return evaluateWithTimestampWithTimezone<int32_t>(
+        auto r1 = evaluateWithTimestampWithTimezone<int32_t>(
             "date(c0)", timestamp, timeZoneName);
+        auto r2 = evaluateWithTimestampWithTimezone<int32_t>(
+            "cast(c0 as date)", timestamp, timeZoneName);
+        EXPECT_EQ(r1, r2);
+        return r1;
       };
 
   // 1970-01-01 00:00:00.000 +00:00

--- a/velox/functions/prestosql/types/CMakeLists.txt
+++ b/velox/functions/prestosql/types/CMakeLists.txt
@@ -14,8 +14,9 @@
 add_library(velox_presto_types HyperLogLogType.cpp JsonType.cpp
                                TimestampWithTimeZoneType.cpp)
 
-target_link_libraries(velox_presto_types velox_memory velox_expression
-                      velox_functions_util velox_functions_json)
+target_link_libraries(
+  velox_presto_types velox_memory velox_expression velox_functions_util
+  velox_functions_json velox_functions_lib_date_time_formatter)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)


### PR DESCRIPTION
Summary:
CAST(timestamp with time zone AS varchar) returns a string like

`1970-01-01 01:11:37.123 America/New_York`

Differential Revision: D58082355


