### PR TITLE
Add timestamp precision in DWRF reader and truncate to milliseconds by default

### DIFF
--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -33,6 +33,7 @@
 #include "velox/dwio/common/ScanSpec.h"
 #include "velox/dwio/common/UnitLoader.h"
 #include "velox/dwio/common/encryption/Encryption.h"
+#include "velox/type/Timestamp.h"
 
 namespace facebook::velox::dwio::common {
 
@@ -156,6 +157,8 @@ class RowReaderOptions {
   bool eagerFirstStripeLoad = true;
   uint64_t skipRows_ = 0;
   std::shared_ptr<UnitLoaderFactory> unitLoaderFactory_;
+
+  TimestampPrecision timestampPrecision_ = TimestampPrecision::kMilliseconds;
 
  public:
   RowReaderOptions() noexcept
@@ -411,6 +414,14 @@ class RowReaderOptions {
 
   size_t getDecodingParallelismFactor() const {
     return decodingParallelismFactor_;
+  }
+
+  TimestampPrecision timestampPrecision() const {
+    return timestampPrecision_;
+  }
+
+  void setTimestampPrecision(TimestampPrecision precision) {
+    timestampPrecision_ = precision;
   }
 };
 

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.h
@@ -205,6 +205,7 @@ class E2EFilterTestBase : public testing::Test {
       dwio::common::RowReaderOptions& opts,
       const std::shared_ptr<ScanSpec>& spec) {
     opts.setScanSpec(spec);
+    opts.setTimestampPrecision(TimestampPrecision::kNanoseconds);
   }
 
   void readWithoutFilter(

--- a/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.cpp
@@ -26,7 +26,9 @@ SelectiveTimestampColumnReader::SelectiveTimestampColumnReader(
     const std::shared_ptr<const TypeWithId>& fileType,
     DwrfParams& params,
     common::ScanSpec& scanSpec)
-    : SelectiveColumnReader(fileType->type(), fileType, params, scanSpec) {
+    : SelectiveColumnReader(fileType->type(), fileType, params, scanSpec),
+      precision_(
+          params.stripeStreams().getRowReaderOptions().timestampPrecision()) {
   EncodingKey encodingKey{fileType_->id(), params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
   version_ = convertRleVersion(stripe.getEncoding(encodingKey).kind());
@@ -147,6 +149,16 @@ void SelectiveTimestampColumnReader::readHelper(
       auto seconds = secondsData[i] + EPOCH_OFFSET;
       if (seconds < 0 && nanos != 0) {
         seconds -= 1;
+      }
+      switch (precision_) {
+        case TimestampPrecision::kMilliseconds:
+          nanos = nanos / 1'000'000 * 1'000'000;
+          break;
+        case TimestampPrecision::kMicroseconds:
+          nanos = nanos / 1'000 * 1'000;
+          break;
+        case TimestampPrecision::kNanoseconds:
+          break;
       }
       rawTs[i] = Timestamp(seconds, nanos);
     }

--- a/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.h
@@ -51,6 +51,8 @@ class SelectiveTimestampColumnReader
       const RowSet rows,
       const uint64_t* rawNulls);
 
+  const TimestampPrecision precision_;
+
   std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ true>> seconds_;
   std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> nano_;
 

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -127,6 +127,7 @@ class ColumnReaderTestBase {
     ColumnSelector cs(rowType, nodes, true);
     auto options = RowReaderOptions();
     options.setReturnFlatVector(returnFlatVector());
+    options.setTimestampPrecision(TimestampPrecision::kNanoseconds);
 
     EXPECT_CALL(streams_, getColumnSelectorProxy())
         .WillRepeatedly(testing::Return(&cs));

--- a/velox/exec/fuzzer/AggregationFuzzerOptions.h
+++ b/velox/exec/fuzzer/AggregationFuzzerOptions.h
@@ -52,7 +52,7 @@ struct AggregationFuzzerOptions {
 
   /// Timestamp precision to use when generating inputs of type TIMESTAMP.
   VectorFuzzer::Options::TimestampPrecision timestampPrecision{
-      VectorFuzzer::Options::TimestampPrecision::kNanoSeconds};
+      VectorFuzzer::Options::TimestampPrecision::kMilliSeconds};
 
   /// A set of configuration properties to use when running query plans.
   /// Could be used to specify timezone or enable/disable settings that

--- a/velox/exec/fuzzer/JoinFuzzer.cpp
+++ b/velox/exec/fuzzer/JoinFuzzer.cpp
@@ -105,6 +105,8 @@ class JoinFuzzer {
     opts.stringVariableLength = true;
     opts.stringLength = 100;
     opts.nullRatio = FLAGS_null_ratio;
+    opts.timestampPrecision =
+        VectorFuzzer::Options::TimestampPrecision::kMilliSeconds;
     return opts;
   }
 

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -30,12 +30,14 @@ namespace date {
 class time_zone;
 }
 
+enum class TimestampPrecision : int8_t {
+  kMilliseconds = 3, // 10^3 milliseconds are equal to one second.
+  kMicroseconds = 6, // 10^6 microseconds are equal to one second.
+  kNanoseconds = 9, // 10^9 nanoseconds are equal to one second.
+};
+
 struct TimestampToStringOptions {
-  enum class Precision : int8_t {
-    kMilliseconds = 3, // 10^3 milliseconds are equal to one second.
-    kMicroseconds = 6, // 10^6 microseconds are equal to one second.
-    kNanoseconds = 9, // 10^9 nanoseconds are equal to one second.
-  };
+  using Precision = TimestampPrecision;
 
   Precision precision = Precision::kNanoseconds;
 


### PR DESCRIPTION
Summary: For timestamp column, Presto can only handle millisecond by default and we should align with the behavior by truncating the value out of reader.

Differential Revision: D58085206


