### PR TITLE
Optimize readWithVisitor for TrivialEncoding and MainlyConstantEncoding

### DIFF
--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -209,9 +209,13 @@ class SelectiveColumnReader {
 
   // Returns a pointer to output rows  with at least 'size' elements available.
   vector_size_t* mutableOutputRows(int32_t size) {
-    numOutConfirmed_ = outputRows_.size();
-    outputRows_.resize(numOutConfirmed_ + size);
-    return outputRows_.data() + numOutConfirmed_;
+    auto numOutConfirmed = outputRows_.size();
+    outputRows_.resize(numOutConfirmed + size);
+    return outputRows_.data() + numOutConfirmed;
+  }
+
+  void* rawValues() {
+    return rawValues_;
   }
 
   template <typename T>
@@ -616,9 +620,6 @@ class SelectiveColumnReader {
   // Rows passing the filter in readWithVisitor. Must stay
   // constant between consecutive calls to read().
   raw_vector<vector_size_t> outputRows_;
-  // Index of last set value in outputRows. Values between this and
-  // size() can be used as scratchpad inside read().
-  vector_size_t numOutConfirmed_;
   // The row number
   // corresponding to each element in 'values_'
   raw_vector<vector_size_t> valueRows_;

--- a/velox/dwio/common/SelectiveColumnReaderInternal.h
+++ b/velox/dwio/common/SelectiveColumnReaderInternal.h
@@ -95,7 +95,6 @@ void SelectiveColumnReader::prepareRead(
   outputRows_.clear();
   // is part of read() and after read returns getValues may be called.
   mayGetValues_ = true;
-  numOutConfirmed_ = 0;
   numValues_ = 0;
   valueSize_ = sizeof(T);
   inputRows_ = rows;

--- a/velox/dwio/common/tests/utils/DataSetBuilder.h
+++ b/velox/dwio/common/tests/utils/DataSetBuilder.h
@@ -142,6 +142,28 @@ class DataSetBuilder {
   }
 
   template <typename T>
+  DataSetBuilder& withIntMainlyConstantForField(const common::Subfield& field) {
+    for (auto& batch : *batches_) {
+      std::optional<T> value;
+      auto* numbers = dwio::common::getChildBySubfield(batch.get(), field)
+                          ->as<FlatVector<T>>();
+      for (auto row = 0; row < numbers->size(); ++row) {
+        if (numbers->isNullAt(row)) {
+          continue;
+        }
+        if (folly::Random::randDouble01(rng_) < 0.95) {
+          if (!value.has_value()) {
+            value = numbers->valueAt(row);
+          } else {
+            numbers->set(row, *value);
+          }
+        }
+      }
+    }
+    return *this;
+  }
+
+  template <typename T>
   DataSetBuilder& withQuantizedFloatForField(
       const common::Subfield& field,
       int64_t buckets,

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.h
@@ -145,6 +145,11 @@ class E2EFilterTestBase : public testing::Test {
   }
 
   template <typename T>
+  void makeIntMainlyConstant(const std::string& fieldName) {
+    dataSetBuilder_->withIntMainlyConstantForField<T>(Subfield(fieldName));
+  }
+
+  template <typename T>
   void makeQuantizedFloat(
       const std::string& fieldName,
       int64_t buckets,


### PR DESCRIPTION
Summary:
- Fast path for `TrivialEncoding::readWithVisitor`
- Fast path for `MainlyConstantEncoding::readWithVisitor`
- Store `encodingType`, `dataType`, `rowCount` in `Encoding` object memory to reduce memory fetch on `data_`
- Use skip functor only in `readWithVisitorSlow` to avoid virtual call cost

Differential Revision: D58085138


