### PR TITLE
Fix json_array_contains(json, NaN/Infinity/-Infinity)

### DIFF
--- a/velox/functions/prestosql/SIMDJsonFunctions.h
+++ b/velox/functions/prestosql/SIMDJsonFunctions.h
@@ -58,6 +58,13 @@ struct SIMDJsonArrayContainsFunction {
   template <typename T>
   FOLLY_ALWAYS_INLINE bool
   call(bool& result, const arg_type<Json>& json, const T& value) {
+    if constexpr (std::is_same_v<T, double>) {
+      if (!std::isfinite(value)) {
+        result = false;
+        return true;
+      }
+    }
+
     simdjson::ondemand::document jsonDoc;
 
     simdjson::padded_string paddedJson(json.data(), json.size());

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -465,6 +465,13 @@ TEST_F(JsonFunctionsTest, jsonArrayContainsDouble) {
       jsonArrayContains<double>(R"({"k1":[0,1,2], "k2":"v1"})", 2.3),
       std::nullopt);
 
+  static const double kNan = std::numeric_limits<double>::quiet_NaN();
+  static const double kInf = std::numeric_limits<double>::infinity();
+  EXPECT_EQ(jsonArrayContains<double>(R"([1.1, 2.2, 3.3])", kNan), false);
+  EXPECT_EQ(jsonArrayContains<double>(R"([1.1, 2.2, 3.3])", kInf), false);
+  EXPECT_EQ(jsonArrayContains<double>(R"([1.1, 2.2, 3.3...)", kNan), false);
+  EXPECT_EQ(jsonArrayContains<double>(R"([1.1, 2.2, 3.3...)", kInf), false);
+
   EXPECT_EQ(jsonArrayContains<double>(R"([1.2, 2.3, 3.4])", 2.3), true);
   EXPECT_EQ(jsonArrayContains<double>(R"([1.2, 2.3, 3.4])", 2.4), false);
   EXPECT_EQ(

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -410,11 +410,15 @@ TEST_F(JsonFunctionsTest, jsonArrayContainsBigint) {
   EXPECT_EQ(
       jsonArrayContains<int64_t>(R"("thefoxjumpedoverthefence")", 1),
       std::nullopt);
+
   EXPECT_EQ(jsonArrayContains<int64_t>(R"("")", 1), std::nullopt);
   EXPECT_EQ(jsonArrayContains<int64_t>(R"(true)", 1), std::nullopt);
   EXPECT_EQ(
       jsonArrayContains<int64_t>(R"({"k1":[0,1,2], "k2":"v1"})", 1),
       std::nullopt);
+
+  EXPECT_EQ(jsonArrayContains<int64_t>(R"([1, 2, 3,...)", 2), std::nullopt);
+  EXPECT_EQ(jsonArrayContains<int64_t>(R"([1, 2, 3,...)", 5), std::nullopt);
 
   EXPECT_EQ(jsonArrayContains<int64_t>(R"([1, 2, 3])", 1), true);
   EXPECT_EQ(jsonArrayContains<int64_t>(R"([1, 2, 3])", 4), false);


### PR DESCRIPTION
Summary:
Presto Java returns 'false' if second argument of json_array_contains is NaN or Infinity even if json is not a valid json array.

```
presto> select json_array_contains('{}', nan());
 _col0
-------
 false

presto> select json_array_contains('{}', 1.1);
 _col0
-------
 NULL
```

Differential Revision: D58091034


