### PR TITLE
Deprecate currentBytes api

### DIFF
--- a/velox/common/base/PeriodicStatsReporter.cpp
+++ b/velox/common/base/PeriodicStatsReporter.cpp
@@ -243,9 +243,9 @@ void PeriodicStatsReporter::reportSpillStats() {
   }
   const auto spillMemoryStats = spillMemoryPool_->stats();
   LOG(INFO) << "Spill memory usage: current["
-            << velox::succinctBytes(spillMemoryStats.currentBytes) << "] peak["
+            << velox::succinctBytes(spillMemoryStats.usedBytes) << "] peak["
             << velox::succinctBytes(spillMemoryStats.peakBytes) << "]";
-  RECORD_METRIC_VALUE(kMetricSpillMemoryBytes, spillMemoryStats.currentBytes);
+  RECORD_METRIC_VALUE(kMetricSpillMemoryBytes, spillMemoryStats.usedBytes);
   RECORD_METRIC_VALUE(kMetricSpillPeakMemoryBytes, spillMemoryStats.peakBytes);
 }
 

--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -312,10 +312,6 @@ class TestMemoryPool : public memory::MemoryPool {
     return 0;
   }
 
-  int64_t currentBytes() const override {
-    return 0;
-  }
-
   int64_t usedBytes() const override {
     return 0;
   }

--- a/velox/common/memory/tests/MemoryCapExceededTest.cpp
+++ b/velox/common/memory/tests/MemoryCapExceededTest.cpp
@@ -72,9 +72,9 @@ TEST_P(MemoryCapExceededTest, singleDriver) {
       "2.00MB, memory manager cap is 8.00GB, requestor "
       "'op.2.0.0.Aggregation' with current usage 3.70MB"};
   std::vector<std::string> expectedDetailedTexts = {
-      "node.1 usage 1.00MB reserved 1.00MB peak 1.00MB",
+      "node.1 usage 12.00KB reserved 1.00MB peak 1.00MB",
       "op.1.0.0.FilterProject usage 12.00KB reserved 1.00MB peak 12.00KB",
-      "node.2 usage 4.00MB reserved 4.00MB peak 4.00MB",
+      "node.2 usage 3.70MB reserved 4.00MB peak 4.00MB",
       "op.2.0.0.Aggregation usage 3.70MB reserved 4.00MB peak 3.70MB",
       "Top 2 leaf memory pool usages:"};
 

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -2337,7 +2337,7 @@ TEST_P(MemoryPoolTest, concurrentUpdateToDifferentPools) {
   ASSERT_LE(root->stats().peakBytes, root->stats().cumulativeBytes);
   childPools.clear();
   ASSERT_LE(root->stats().peakBytes, root->stats().cumulativeBytes);
-  ASSERT_EQ(root->stats().currentBytes, 0);
+  ASSERT_EQ(root->stats().usedBytes, 0);
 }
 
 TEST_P(MemoryPoolTest, concurrentUpdatesToTheSamePool) {
@@ -2387,7 +2387,7 @@ TEST_P(MemoryPoolTest, concurrentUpdatesToTheSamePool) {
   ASSERT_LE(root->stats().peakBytes, root->stats().cumulativeBytes);
   childPools.clear();
   ASSERT_LE(root->stats().peakBytes, root->stats().cumulativeBytes);
-  ASSERT_EQ(root->stats().currentBytes, 0);
+  ASSERT_EQ(root->stats().usedBytes, 0);
 }
 
 TEST_P(MemoryPoolTest, concurrentUpdateToSharedPools) {
@@ -3005,7 +3005,7 @@ TEST_P(MemoryPoolTest, statsAndToString) {
   void* buf1 = leafChild1->allocate(bufferSize);
   ASSERT_EQ(
       leafChild1->stats().toString(),
-      "currentBytes:1.00KB reservedBytes:1.00MB peakBytes:1.00KB cumulativeBytes:1.00KB numAllocs:1 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
+      "usedBytes:1.00KB reservedBytes:1.00MB peakBytes:1.00KB cumulativeBytes:1.00KB numAllocs:1 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
   ASSERT_EQ(
       leafChild1->toString(),
       fmt::format(
@@ -3014,7 +3014,7 @@ TEST_P(MemoryPoolTest, statsAndToString) {
           isLeafThreadSafe_ ? "thread-safe" : "non-thread-safe"));
   ASSERT_EQ(
       leafChild2->stats().toString(),
-      "currentBytes:0B reservedBytes:0B peakBytes:0B cumulativeBytes:0B numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
+      "usedBytes:0B reservedBytes:0B peakBytes:0B cumulativeBytes:0B numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
   ASSERT_EQ(
       leafChild1->toString(),
       fmt::format(
@@ -3023,36 +3023,36 @@ TEST_P(MemoryPoolTest, statsAndToString) {
           isLeafThreadSafe_ ? "thread-safe" : "non-thread-safe"));
   ASSERT_EQ(
       aggregateChild->stats().toString(),
-      "currentBytes:0B reservedBytes:0B peakBytes:0B cumulativeBytes:0B numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
+      "usedBytes:0B reservedBytes:0B peakBytes:0B cumulativeBytes:0B numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
   ASSERT_EQ(
       root->stats().toString(),
-      "currentBytes:1.00MB reservedBytes:1.00MB peakBytes:1.00MB cumulativeBytes:1.00MB numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
+      "usedBytes:1.00KB reservedBytes:1.00MB peakBytes:1.00MB cumulativeBytes:1.00MB numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
   void* buf2 = leafChild2->allocate(bufferSize);
   ASSERT_EQ(
       leafChild1->stats().toString(),
-      "currentBytes:1.00KB reservedBytes:1.00MB peakBytes:1.00KB cumulativeBytes:1.00KB numAllocs:1 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
+      "usedBytes:1.00KB reservedBytes:1.00MB peakBytes:1.00KB cumulativeBytes:1.00KB numAllocs:1 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
   ASSERT_EQ(
       leafChild2->stats().toString(),
-      "currentBytes:1.00KB reservedBytes:1.00MB peakBytes:1.00KB cumulativeBytes:1.00KB numAllocs:1 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
+      "usedBytes:1.00KB reservedBytes:1.00MB peakBytes:1.00KB cumulativeBytes:1.00KB numAllocs:1 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
   ASSERT_EQ(
       aggregateChild->stats().toString(),
-      "currentBytes:1.00MB reservedBytes:1.00MB peakBytes:1.00MB cumulativeBytes:1.00MB numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
+      "usedBytes:1.00KB reservedBytes:1.00MB peakBytes:1.00MB cumulativeBytes:1.00MB numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
   ASSERT_EQ(
       root->stats().toString(),
-      "currentBytes:2.00MB reservedBytes:2.00MB peakBytes:2.00MB cumulativeBytes:2.00MB numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
+      "usedBytes:2.00KB reservedBytes:2.00MB peakBytes:2.00MB cumulativeBytes:2.00MB numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
   leafChild1->free(buf1, bufferSize);
   ASSERT_EQ(
       leafChild1->stats().toString(),
-      "currentBytes:0B reservedBytes:0B peakBytes:1.00KB cumulativeBytes:1.00KB numAllocs:1 numFrees:1 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
+      "usedBytes:0B reservedBytes:0B peakBytes:1.00KB cumulativeBytes:1.00KB numAllocs:1 numFrees:1 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
   ASSERT_EQ(
       leafChild2->stats().toString(),
-      "currentBytes:1.00KB reservedBytes:1.00MB peakBytes:1.00KB cumulativeBytes:1.00KB numAllocs:1 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
+      "usedBytes:1.00KB reservedBytes:1.00MB peakBytes:1.00KB cumulativeBytes:1.00KB numAllocs:1 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
   ASSERT_EQ(
       aggregateChild->stats().toString(),
-      "currentBytes:1.00MB reservedBytes:1.00MB peakBytes:1.00MB cumulativeBytes:1.00MB numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
+      "usedBytes:1.00KB reservedBytes:1.00MB peakBytes:1.00MB cumulativeBytes:1.00MB numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
   ASSERT_EQ(
       root->stats().toString(),
-      "currentBytes:1.00MB reservedBytes:1.00MB peakBytes:2.00MB cumulativeBytes:2.00MB numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
+      "usedBytes:1.00KB reservedBytes:1.00MB peakBytes:2.00MB cumulativeBytes:2.00MB numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
   leafChild2->free(buf2, bufferSize);
   std::vector<void*> bufs;
   for (int i = 0; i < 10; ++i) {
@@ -3065,11 +3065,11 @@ TEST_P(MemoryPoolTest, statsAndToString) {
   ASSERT_EQ(root->stats().peakBytes, 2097152);
   ASSERT_EQ(root->peakBytes(), 2097152);
   ASSERT_EQ(root->stats().cumulativeBytes, 3145728);
-  ASSERT_EQ(root->stats().currentBytes, 1048576);
+  ASSERT_EQ(root->stats().usedBytes, 10240);
   ASSERT_EQ(root->stats().numCapacityGrowths, 0);
   ASSERT_EQ(leafChild1->stats().numAllocs, 11);
   ASSERT_EQ(leafChild1->stats().numFrees, 1);
-  ASSERT_EQ(leafChild1->stats().currentBytes, 10240);
+  ASSERT_EQ(leafChild1->stats().usedBytes, 10240);
   ASSERT_EQ(leafChild1->stats().peakBytes, 10240);
   ASSERT_EQ(leafChild1->stats().cumulativeBytes, 11264);
   ASSERT_EQ(leafChild1->stats().numReserves, 0);
@@ -3085,11 +3085,11 @@ TEST_P(MemoryPoolTest, statsAndToString) {
   ASSERT_EQ(root->stats().peakBytes, 2097152);
   ASSERT_EQ(root->peakBytes(), 2097152);
   ASSERT_EQ(root->stats().cumulativeBytes, 3145728);
-  ASSERT_EQ(root->stats().currentBytes, 0);
+  ASSERT_EQ(root->stats().usedBytes, 0);
   ASSERT_EQ(root->stats().numCapacityGrowths, 0);
   ASSERT_EQ(leafChild1->stats().numAllocs, 11);
   ASSERT_EQ(leafChild1->stats().numFrees, 11);
-  ASSERT_EQ(leafChild1->stats().currentBytes, 0);
+  ASSERT_EQ(leafChild1->stats().usedBytes, 0);
   ASSERT_EQ(leafChild1->stats().peakBytes, 10240);
   ASSERT_EQ(leafChild1->stats().cumulativeBytes, 11264);
   ASSERT_EQ(leafChild1->stats().numReserves, 0);
@@ -3098,7 +3098,7 @@ TEST_P(MemoryPoolTest, statsAndToString) {
   leafChild1->maybeReserve(bufferSize);
   ASSERT_EQ(leafChild1->stats().numAllocs, 11);
   ASSERT_EQ(leafChild1->stats().numFrees, 11);
-  ASSERT_EQ(leafChild1->stats().currentBytes, 0);
+  ASSERT_EQ(leafChild1->stats().usedBytes, 0);
   ASSERT_EQ(leafChild1->stats().peakBytes, 10240);
   ASSERT_EQ(leafChild1->peakBytes(), 10240);
   ASSERT_EQ(leafChild1->stats().cumulativeBytes, 11264);
@@ -3108,7 +3108,7 @@ TEST_P(MemoryPoolTest, statsAndToString) {
   leafChild1->release();
   ASSERT_EQ(leafChild1->stats().numAllocs, 11);
   ASSERT_EQ(leafChild1->stats().numFrees, 11);
-  ASSERT_EQ(leafChild1->stats().currentBytes, 0);
+  ASSERT_EQ(leafChild1->stats().usedBytes, 0);
   ASSERT_EQ(leafChild1->stats().cumulativeBytes, 11264);
   ASSERT_EQ(leafChild1->stats().peakBytes, 10240);
   ASSERT_EQ(leafChild1->peakBytes(), 10240);
@@ -3139,7 +3139,7 @@ TEST_P(MemoryPoolTest, memoryUsageUpdateCheck) {
 
   ASSERT_THROW(child1->allocate(2 * kMaxSize), VeloxRuntimeError);
 
-  ASSERT_EQ(root->stats().currentBytes, 0);
+  ASSERT_EQ(root->stats().usedBytes, 0);
   ASSERT_EQ(root->stats().reservedBytes, 0);
   ASSERT_EQ(root->stats().cumulativeBytes, 0);
   ASSERT_EQ(root->reservedBytes(), 0);
@@ -3147,7 +3147,7 @@ TEST_P(MemoryPoolTest, memoryUsageUpdateCheck) {
   std::vector<Buffer> buffers;
   buffers.emplace_back(Buffer{child1->allocate(1000), 1000});
   // The memory pool do alignment internally.
-  ASSERT_EQ(child1->stats().currentBytes, 1024);
+  ASSERT_EQ(child1->stats().usedBytes, 1024);
   ASSERT_EQ(root->stats().reservedBytes, MB);
   ASSERT_EQ(child1->usedBytes(), 1024);
   ASSERT_EQ(child1->reservedBytes(), MB);
@@ -3158,26 +3158,26 @@ TEST_P(MemoryPoolTest, memoryUsageUpdateCheck) {
   ASSERT_EQ(MB - 1024, child1->availableReservation());
 
   buffers.emplace_back(Buffer{child1->allocate(1000), 1000});
-  ASSERT_EQ(child1->stats().currentBytes, 2048);
+  ASSERT_EQ(child1->stats().usedBytes, 2048);
   ASSERT_EQ(child1->usedBytes(), 2048);
   ASSERT_EQ(child1->stats().reservedBytes, MB);
   ASSERT_EQ(root->reservedBytes(), MB);
-  ASSERT_EQ(root->stats().currentBytes, MB);
+  ASSERT_EQ(root->stats().usedBytes, 2048);
   ASSERT_EQ(root->stats().cumulativeBytes, MB);
   ASSERT_EQ(root->stats().reservedBytes, MB);
 
   buffers.emplace_back(Buffer{child1->allocate(MB), MB});
-  ASSERT_EQ(child1->stats().currentBytes, 2048 + MB);
+  ASSERT_EQ(child1->stats().usedBytes, 2048 + MB);
   ASSERT_EQ(child1->stats().reservedBytes, 2 * MB);
   ASSERT_EQ(child1->usedBytes(), 2048 + MB);
   ASSERT_EQ(root->reservedBytes(), 2 * MB);
-  ASSERT_EQ(root->stats().currentBytes, 2 * MB);
+  ASSERT_EQ(root->stats().usedBytes, 2048 + MB);
   ASSERT_EQ(root->stats().cumulativeBytes, 2 * MB);
   ASSERT_EQ(root->stats().reservedBytes, 2 * MB);
 
   buffers.emplace_back(Buffer{child1->allocate(100 * MB), 100 * MB});
   ASSERT_EQ(child1->usedBytes(), 2048 + 101 * MB);
-  ASSERT_EQ(child1->stats().currentBytes, 2048 + 101 * MB);
+  ASSERT_EQ(child1->stats().usedBytes, 2048 + 101 * MB);
   ASSERT_EQ(child1->stats().reservedBytes, 104 * MB);
   ASSERT_EQ(child1->reservedBytes(), 104 * MB);
   ASSERT_EQ(
@@ -3185,61 +3185,61 @@ TEST_P(MemoryPoolTest, memoryUsageUpdateCheck) {
       child1->reservedBytes() - child1->usedBytes());
   // Larger sizes round up to next 8MB.
   ASSERT_EQ(root->reservedBytes(), 104 * MB);
-  ASSERT_EQ(root->stats().currentBytes, 104 * MB);
+  ASSERT_EQ(root->stats().usedBytes, 2048 + 101 * MB);
   ASSERT_EQ(root->stats().cumulativeBytes, 104 * MB);
   ASSERT_EQ(root->stats().reservedBytes, 104 * MB);
   ASSERT_EQ(root->availableReservation(), 0);
 
   child1->free(buffers[0].data, buffers[0].length);
   ASSERT_EQ(child1->usedBytes(), 1024 + 101 * MB);
-  ASSERT_EQ(child1->stats().currentBytes, 1024 + 101 * MB);
+  ASSERT_EQ(child1->stats().usedBytes, 1024 + 101 * MB);
   ASSERT_EQ(child1->stats().cumulativeBytes, 2048 + 101 * MB);
   ASSERT_EQ(child1->reservedBytes(), 104 * MB);
   ASSERT_EQ(
       child1->availableReservation(),
       child1->reservedBytes() - child1->usedBytes());
   ASSERT_EQ(root->reservedBytes(), 104 * MB);
-  ASSERT_EQ(root->stats().currentBytes, 104 * MB);
+  ASSERT_EQ(root->stats().usedBytes, 1024 + 101 * MB);
   ASSERT_EQ(root->stats().cumulativeBytes, 104 * MB);
   ASSERT_EQ(root->stats().reservedBytes, 104 * MB);
   ASSERT_EQ(root->availableReservation(), 0);
 
   child1->free(buffers[2].data, buffers[2].length);
   ASSERT_EQ(child1->usedBytes(), 1024 + 100 * MB);
-  ASSERT_EQ(child1->stats().currentBytes, 1024 + 100 * MB);
+  ASSERT_EQ(child1->stats().usedBytes, 1024 + 100 * MB);
   ASSERT_EQ(child1->stats().cumulativeBytes, 2048 + 101 * MB);
   ASSERT_EQ(child1->reservedBytes(), 104 * MB);
   ASSERT_EQ(
       child1->availableReservation(),
       child1->reservedBytes() - child1->usedBytes());
   ASSERT_EQ(root->reservedBytes(), 104 * MB);
-  ASSERT_EQ(root->stats().currentBytes, 104 * MB);
+  ASSERT_EQ(root->stats().usedBytes, 1024 + 100 * MB);
   ASSERT_EQ(root->stats().cumulativeBytes, 104 * MB);
   ASSERT_EQ(root->stats().reservedBytes, 104 * MB);
   ASSERT_EQ(root->availableReservation(), 0);
 
   child1->free(buffers[3].data, buffers[3].length);
   ASSERT_EQ(child1->usedBytes(), 1024);
-  ASSERT_EQ(child1->stats().currentBytes, 1024);
+  ASSERT_EQ(child1->stats().usedBytes, 1024);
   ASSERT_EQ(child1->stats().cumulativeBytes, 2048 + 101 * MB);
   ASSERT_EQ(child1->reservedBytes(), MB);
   ASSERT_EQ(
       child1->availableReservation(),
       child1->reservedBytes() - child1->usedBytes());
   ASSERT_EQ(root->reservedBytes(), MB);
-  ASSERT_EQ(root->stats().currentBytes, MB);
+  ASSERT_EQ(root->stats().usedBytes, 1024);
   ASSERT_EQ(root->stats().cumulativeBytes, 104 * MB);
   ASSERT_EQ(root->stats().reservedBytes, MB);
   ASSERT_EQ(root->availableReservation(), 0);
 
   child1->free(buffers[1].data, buffers[1].length);
   ASSERT_EQ(child1->usedBytes(), 0);
-  ASSERT_EQ(child1->stats().currentBytes, 0);
+  ASSERT_EQ(child1->stats().usedBytes, 0);
   ASSERT_EQ(child1->stats().cumulativeBytes, 2048 + 101 * MB);
   ASSERT_EQ(child1->reservedBytes(), 0);
   ASSERT_EQ(child1->availableReservation(), 0);
   ASSERT_EQ(root->reservedBytes(), 0);
-  ASSERT_EQ(root->stats().currentBytes, 0);
+  ASSERT_EQ(root->stats().usedBytes, 0);
   ASSERT_EQ(root->stats().cumulativeBytes, 104 * MB);
   ASSERT_EQ(root->stats().reservedBytes, 0);
   ASSERT_EQ(root->availableReservation(), 0);
@@ -3278,20 +3278,20 @@ TEST_P(MemoryPoolTest, maybeReserve) {
   // The reservation child shows up as a reservation on the child and as an
   // allocation on the parent.
   ASSERT_EQ(child->usedBytes(), 0);
-  ASSERT_EQ(child->stats().currentBytes, 0);
+  ASSERT_EQ(child->stats().usedBytes, 0);
   ASSERT_EQ(child->stats().cumulativeBytes, 0);
   ASSERT_EQ(child->stats().reservedBytes, 104 * MB);
   ASSERT_EQ(child->availableReservation(), 104 * MB);
 
   ASSERT_EQ(root->reservedBytes(), 104 * MB);
-  ASSERT_EQ(root->stats().currentBytes, 104 * MB);
+  ASSERT_EQ(root->stats().usedBytes, 0);
   ASSERT_EQ(root->stats().reservedBytes, 104 * MB);
   ASSERT_EQ(root->availableReservation(), 0);
 
   std::vector<Buffer> buffers;
   buffers.emplace_back(Buffer{child->allocate(60 * MB), 60 * MB});
   ASSERT_EQ(child->usedBytes(), 60 * MB);
-  ASSERT_EQ(child->stats().currentBytes, 60 * MB);
+  ASSERT_EQ(child->stats().usedBytes, 60 * MB);
   ASSERT_EQ(child->reservedBytes(), 104 * MB);
   ASSERT_EQ(child->stats().reservedBytes, 104 * MB);
   ASSERT_EQ(
@@ -3303,7 +3303,7 @@ TEST_P(MemoryPoolTest, maybeReserve) {
 
   buffers.emplace_back(Buffer{child->allocate(70 * MB), 70 * MB});
   ASSERT_EQ(child->usedBytes(), 130 * MB);
-  ASSERT_EQ(child->stats().currentBytes, 130 * MB);
+  ASSERT_EQ(child->stats().usedBytes, 130 * MB);
   ASSERT_EQ(child->reservedBytes(), 136 * MB);
   ASSERT_EQ(child->stats().reservedBytes, 136 * MB);
   ASSERT_EQ(
@@ -3316,7 +3316,7 @@ TEST_P(MemoryPoolTest, maybeReserve) {
 
   child->free(buffers[0].data, buffers[0].length);
   ASSERT_EQ(child->usedBytes(), 70 * MB);
-  ASSERT_EQ(child->stats().currentBytes, 70 * MB);
+  ASSERT_EQ(child->stats().usedBytes, 70 * MB);
   // Extended and rounded up the reservation to then next 8MB.
   ASSERT_EQ(child->reservedBytes(), 104 * MB);
   ASSERT_EQ(child->stats().reservedBytes, 104 * MB);
@@ -3331,7 +3331,7 @@ TEST_P(MemoryPoolTest, maybeReserve) {
 
   // The reservation goes down to the explicitly made reservation.
   ASSERT_EQ(child->usedBytes(), 0);
-  ASSERT_EQ(child->stats().currentBytes, 0);
+  ASSERT_EQ(child->stats().usedBytes, 0);
   ASSERT_EQ(child->reservedBytes(), 104 * MB);
   ASSERT_EQ(child->stats().reservedBytes, 104 * MB);
   ASSERT_EQ(
@@ -3343,7 +3343,7 @@ TEST_P(MemoryPoolTest, maybeReserve) {
 
   child->release();
   ASSERT_EQ(child->usedBytes(), 0);
-  ASSERT_EQ(child->stats().currentBytes, 0);
+  ASSERT_EQ(child->stats().usedBytes, 0);
   ASSERT_EQ(child->reservedBytes(), 0);
   ASSERT_EQ(child->stats().reservedBytes, 0);
   ASSERT_EQ(child->availableReservation(), 0);

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -152,10 +152,6 @@ class MockMemoryPool : public velox::memory::MemoryPool {
     VELOX_UNSUPPORTED("growContiguous unsupported");
   }
 
-  int64_t currentBytes() const override {
-    return localMemoryUsage_;
-  }
-
   int64_t usedBytes() const override {
     return localMemoryUsage_;
   }

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -72,7 +72,7 @@ struct MemoryStats {
   static MemoryStats memStatsFromPool(const memory::MemoryPool* pool) {
     const auto poolStats = pool->stats();
     MemoryStats memStats;
-    memStats.userMemoryReservation = poolStats.currentBytes;
+    memStats.userMemoryReservation = poolStats.usedBytes;
     memStats.systemMemoryReservation = 0;
     memStats.peakUserMemoryReservation = poolStats.peakBytes;
     memStats.peakSystemMemoryReservation = 0;

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -607,7 +607,7 @@ RowVectorPtr Task::next(ContinueFuture* future) {
     createSplitGroupStateLocked(kUngroupedGroupId);
     std::vector<std::shared_ptr<Driver>> drivers =
         createDriversLocked(kUngroupedGroupId);
-    if (pool_->stats().currentBytes != 0) {
+    if (pool_->reservedBytes() != 0) {
       VELOX_FAIL(
           "Unexpected memory pool allocations during task[{}] driver initialization: {}",
           taskId_,
@@ -780,7 +780,7 @@ void Task::createAndStartDrivers(uint32_t concurrentSplitGroups) {
     // Create drivers.
     std::vector<std::shared_ptr<Driver>> drivers =
         createDriversLocked(kUngroupedGroupId);
-    if (pool_->stats().currentBytes != 0) {
+    if (pool_->reservedBytes() != 0) {
       VELOX_FAIL(
           "Unexpected memory pool allocations during task[{}] driver initialization: {}",
           taskId_,

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -654,7 +654,7 @@ class HashJoinBuilder {
     SCOPED_TRACE(
         injectSpill ? fmt::format("With Max Spill Level: {}", maxSpillLevel)
                     : "Without Spill");
-    ASSERT_EQ(memory::spillMemoryPool()->stats().currentBytes, 0);
+    ASSERT_EQ(memory::spillMemoryPool()->stats().usedBytes, 0);
     const uint64_t peakSpillMemoryUsage =
         memory::spillMemoryPool()->stats().peakBytes;
     TestScopedSpillInjection scopedSpillInjection(spillPct);
@@ -720,7 +720,7 @@ class HashJoinBuilder {
       testVerifier_(task, injectSpill);
     }
     OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
-    ASSERT_EQ(memory::spillMemoryPool()->stats().currentBytes, 0);
+    ASSERT_EQ(memory::spillMemoryPool()->stats().usedBytes, 0);
   }
 
   VectorFuzzer::Options fuzzerOpts_;

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -210,14 +210,14 @@ class OrderByTest : public OperatorTestBase {
       auto inputRows = toPlanStats(task->taskStats()).at(orderById).inputRows;
       const uint64_t peakSpillMemoryUsage =
           memory::spillMemoryPool()->stats().peakBytes;
-      ASSERT_EQ(memory::spillMemoryPool()->stats().currentBytes, 0);
+      ASSERT_EQ(memory::spillMemoryPool()->stats().usedBytes, 0);
       if (inputRows > 0) {
         EXPECT_LT(0, spilledStats(*task).spilledInputBytes);
         EXPECT_LT(0, spilledStats(*task).spilledBytes);
         EXPECT_EQ(1, spilledStats(*task).spilledPartitions);
         EXPECT_LT(0, spilledStats(*task).spilledFiles);
         EXPECT_EQ(inputRows, spilledStats(*task).spilledRows);
-        ASSERT_EQ(memory::spillMemoryPool()->stats().currentBytes, 0);
+        ASSERT_EQ(memory::spillMemoryPool()->stats().usedBytes, 0);
         if (memory::spillMemoryPool()->trackUsage()) {
           ASSERT_GT(memory::spillMemoryPool()->stats().peakBytes, 0);
           ASSERT_GE(

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -409,7 +409,7 @@ TEST_F(SortBufferTest, spill) {
     VectorFuzzer fuzzer({.vectorSize = 1024}, fuzzerPool.get());
     uint64_t totalNumInput = 0;
 
-    ASSERT_EQ(memory::spillMemoryPool()->stats().currentBytes, 0);
+    ASSERT_EQ(memory::spillMemoryPool()->stats().usedBytes, 0);
     const auto peakSpillMemoryUsage =
         memory::spillMemoryPool()->stats().peakBytes;
 
@@ -437,7 +437,7 @@ TEST_F(SortBufferTest, spill) {
       // spill.
       ASSERT_EQ(spillStats.rlock()->spilledFiles, 3);
       sortBuffer.reset();
-      ASSERT_EQ(memory::spillMemoryPool()->stats().currentBytes, 0);
+      ASSERT_EQ(memory::spillMemoryPool()->stats().usedBytes, 0);
       if (memory::spillMemoryPool()->trackUsage()) {
         ASSERT_GT(memory::spillMemoryPool()->stats().peakBytes, 0);
         ASSERT_GE(

--- a/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
@@ -886,7 +886,7 @@ void AggregationTestBase::testAggregationsImpl(
 
     auto spillDirectory = exec::test::TempDirectoryPath::create();
 
-    ASSERT_EQ(memory::spillMemoryPool()->stats().currentBytes, 0);
+    ASSERT_EQ(memory::spillMemoryPool()->stats().usedBytes, 0);
     const auto peakSpillMemoryUsage =
         memory::spillMemoryPool()->stats().peakBytes;
     AssertQueryBuilder queryBuilder(builder.planNode(), duckDbQueryRunner_);
@@ -912,7 +912,7 @@ void AggregationTestBase::testAggregationsImpl(
           << " spilledInputBytes: " << spilledInputBytes(*task)
           << " spilledFiles: " << spilledFiles(*task)
           << " injectedSpills: " << exec::injectedSpillCount();
-      ASSERT_EQ(memory::spillMemoryPool()->stats().currentBytes, 0);
+      ASSERT_EQ(memory::spillMemoryPool()->stats().usedBytes, 0);
       ASSERT_GT(memory::spillMemoryPool()->stats().peakBytes, 0);
       ASSERT_GE(
           memory::spillMemoryPool()->stats().peakBytes, peakSpillMemoryUsage);


### PR DESCRIPTION
Deprecate currentBytes API in memory pool which gives different stats for different
types of memory pool. For leaf memory pool, it returns actual used memory reservation
but for non-leaf memory pool, it returns the aggregated memory reservation from all
its child pools which include the used reservation and not used ones.
This PR changes deprecate currentBytes, and switch to use usedBytes for actual used
reservation stats and reservedBytes for reservation stats. Both returns the same kind
of stats for different types of memory pools. The new usedBytes is bit expensive for 
non-leaf kind of memory pool as it needs to traverse its child memory pool hierarchy to
get the actual used memory.