### PR TITLE
Disable CUDA/GPU build in CI until centos9 update

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -73,15 +73,6 @@ jobs:
       - name: Install cmake
         run: python3 -m pip install cmake==3.28.3
 
-      - name: Install Dependencies
-        run: |
-          # Allows to install arbitrary cuda-version whithout needing to update
-          # docker container before. It simplifies testing new/different versions
-          if ! yum list installed cuda-nvcc-$(echo ${CUDA_VERSION} | tr '.' '-') 1>/dev/null; then
-            source scripts/setup-centos8.sh
-            install_cuda ${CUDA_VERSION}
-          fi
-
       - uses: assignUser/stash/restore@v1
         with:
           path: '${{ env.CCACHE_DIR }}'
@@ -94,10 +85,6 @@ jobs:
       - name: Make Release Build
         env:
           MAKEFLAGS: 'NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4'
-          CUDA_ARCHITECTURES: 70
-          CUDA_COMPILER: /usr/local/cuda-${CUDA_VERSION}/bin/nvcc
-          # Without that, nvcc picks /usr/bin/c++ which is GCC 8
-          CUDA_FLAGS: "-ccbin /opt/rh/gcc-toolset-9/root/usr/bin"
         run: |
           EXTRA_CMAKE_FLAGS=(
             "-DVELOX_ENABLE_BENCHMARKS=ON"
@@ -108,7 +95,6 @@ jobs:
             "-DVELOX_ENABLE_GCS=ON"
             "-DVELOX_ENABLE_ABFS=ON"
             "-DVELOX_ENABLE_REMOTE_FUNCTIONS=ON"
-            "-DVELOX_ENABLE_GPU=ON"
           )
           make release EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS[*]}"
     


### PR DESCRIPTION
Temporary workaround for https://github.com/facebookincubator/velox/issues/10016
Resolves https://github.com/facebookincubator/velox/issues/10016