### PR TITLE
Add support for negative array index in JSON path

### DIFF
--- a/velox/functions/prestosql/json/JsonPathTokenizer.cpp
+++ b/velox/functions/prestosql/json/JsonPathTokenizer.cpp
@@ -31,7 +31,7 @@ const char OPEN_BRACKET = '[';
 const char CLOSE_BRACKET = ']';
 
 bool isUnquotedBracketKeyFormat(char c) {
-  return c == UNDER_SCORE || c == STAR || std::isalnum(c);
+  return c == UNDER_SCORE || c == STAR || c == DASH || std::isalnum(c);
 }
 
 bool isDotKeyFormat(char c) {

--- a/velox/functions/prestosql/json/SIMDJsonExtractor.cpp
+++ b/velox/functions/prestosql/json/SIMDJsonExtractor.cpp
@@ -90,8 +90,18 @@ simdjson::error_code extractArray(
     std::optional<simdjson::ondemand::value>& ret) {
   SIMDJSON_ASSIGN_OR_RAISE(auto jsonArray, jsonValue.get_array());
   auto rv = folly::tryTo<int32_t>(index);
+
   if (rv.hasValue()) {
-    auto val = jsonArray.at(rv.value());
+    auto i = rv.value();
+    if (i < 0) {
+      size_t numElements;
+      if (jsonArray.count_elements().get(numElements)) {
+        return simdjson::SUCCESS;
+      }
+
+      i += numElements;
+    }
+    auto val = jsonArray.at(i);
     if (!val.error()) {
       ret.emplace(std::move(val));
     }

--- a/velox/functions/prestosql/json/tests/JsonExtractorTest.cpp
+++ b/velox/functions/prestosql/json/tests/JsonExtractorTest.cpp
@@ -416,7 +416,7 @@ TEST(JsonExtractorTest, fullJsonValueTest) {
 
 TEST(JsonExtractorTest, invalidJsonPathTest) {
   EXPECT_THROW_INVALID_ARGUMENT(""s, ""s);
-  EXPECT_THROW_INVALID_ARGUMENT("{}"s, "$.bar[2][-1]"s);
+  EXPECT_THROW_INVALID_ARGUMENT("{}"s, "$.bar[2]-1"s);
   EXPECT_THROW_INVALID_ARGUMENT("{}"s, "$.fuu..bar"s);
   EXPECT_THROW_INVALID_ARGUMENT("{}"s, "$."s);
   EXPECT_THROW_INVALID_ARGUMENT(""s, "$$"s);

--- a/velox/functions/prestosql/json/tests/JsonPathTokenizerTest.cpp
+++ b/velox/functions/prestosql/json/tests/JsonPathTokenizerTest.cpp
@@ -72,6 +72,7 @@ TEST(JsonPathTokenizerTest, validPaths) {
   assertValidPath("$[\"foo\"]"s, TokenList{"foo"s});
   assertValidPath("$[\"foo.bar\"]"s, TokenList{"foo.bar"s});
   assertValidPath("$[42]"s, TokenList{"42"s});
+  assertValidPath("$[-1]"s, TokenList{"-1"s});
   assertValidPath("$.42"s, TokenList{"42"s});
   assertValidPath("$.42.63"s, TokenList{"42"s, "63"s});
   assertValidPath("$.foo.42.bar.63"s, TokenList{"foo"s, "42"s, "bar"s, "63"s});

--- a/velox/functions/prestosql/json/tests/SIMDJsonExtractorTest.cpp
+++ b/velox/functions/prestosql/json/tests/SIMDJsonExtractorTest.cpp
@@ -430,7 +430,7 @@ TEST_F(SIMDJsonExtractorTest, fullJsonValueTest) {
 
 TEST_F(SIMDJsonExtractorTest, invalidJsonPathTest) {
   expectThrowInvalidArgument("", "");
-  expectThrowInvalidArgument("{}", "$.bar[2][-1]");
+  expectThrowInvalidArgument("{}", "$.bar[2]-1");
   expectThrowInvalidArgument("{}", "$.fuu..bar");
   expectThrowInvalidArgument("{}", "$.");
   expectThrowInvalidArgument("", "$$");

--- a/velox/functions/prestosql/tests/JsonExtractScalarTest.cpp
+++ b/velox/functions/prestosql/tests/JsonExtractScalarTest.cpp
@@ -180,7 +180,7 @@ TEST_F(JsonExtractScalarTest, invalidPath) {
   VELOX_ASSERT_THROW(
       jsonExtractScalar(R"([0,1,2])", "$[]"), "Invalid JSON path");
   VELOX_ASSERT_THROW(
-      jsonExtractScalar(R"([0,1,2])", "$[-1]"), "Invalid JSON path");
+      jsonExtractScalar(R"([0,1,2])", "$-1"), "Invalid JSON path");
   VELOX_ASSERT_THROW(
       jsonExtractScalar(R"({"k1":"v1"})", "$k1"), "Invalid JSON path");
   VELOX_ASSERT_THROW(

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -608,7 +608,7 @@ TEST_F(JsonFunctionsTest, jsonSize) {
 TEST_F(JsonFunctionsTest, invalidPath) {
   VELOX_ASSERT_THROW(jsonSize(R"([0,1,2])", ""), "Invalid JSON path");
   VELOX_ASSERT_THROW(jsonSize(R"([0,1,2])", "$[]"), "Invalid JSON path");
-  VELOX_ASSERT_THROW(jsonSize(R"([0,1,2])", "$[-1]"), "Invalid JSON path");
+  VELOX_ASSERT_THROW(jsonSize(R"([0,1,2])", "$-1"), "Invalid JSON path");
   VELOX_ASSERT_THROW(jsonSize(R"({"k1":"v1"})", "$k1"), "Invalid JSON path");
   VELOX_ASSERT_THROW(jsonSize(R"({"k1":"v1"})", "$.k1."), "Invalid JSON path");
   VELOX_ASSERT_THROW(jsonSize(R"({"k1":"v1"})", "$.k1]"), "Invalid JSON path");
@@ -635,8 +635,15 @@ TEST_F(JsonFunctionsTest, jsonExtract) {
       std::nullopt, jsonExtract("{\"x\": {\"a\" : 1, \"b\" : 2} }", "$.x.c"));
   EXPECT_EQ(
       "3", jsonExtract("{\"x\": {\"a\" : 1, \"b\" : [2, 3]} }", "$.x.b[1]"));
-  EXPECT_EQ("2", jsonExtract("[1,2,3]", "$[1]"));
-  EXPECT_EQ("null", jsonExtract("[1,null,3]", "$[1]"));
+
+  EXPECT_EQ("2", jsonExtract("[1, 2, 3]", "$[1]"));
+  EXPECT_EQ("null", jsonExtract("[1, null, 3]", "$[1]"));
+  EXPECT_EQ(std::nullopt, jsonExtract("[1, 2, 3]", "$[10]"));
+
+  EXPECT_EQ("3", jsonExtract("[1, 2, 3]", "$[-1]"));
+  EXPECT_EQ("null", jsonExtract("[1, null, 3]", "$[-2]"));
+  EXPECT_EQ(std::nullopt, jsonExtract("[1, 2, 3]", "$[-10]"));
+
   EXPECT_EQ(std::nullopt, jsonExtract("INVALID_JSON", "$"));
   VELOX_ASSERT_THROW(jsonExtract("{\"\":\"\"}", ""), "Invalid JSON path");
 


### PR DESCRIPTION
Summary: Presto allows negative array indices in JSON paths.

Differential Revision: D58108335


