### PR TITLE
Fix flaky test TaskTest.inconsistentExecutionMode

### DIFF
--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -1278,6 +1278,7 @@ DEBUG_ONLY_TEST_F(TaskTest, inconsistentExecutionMode) {
     while (cursor->hasNext()) {
       cursor->moveNext();
     }
+    waitForTaskCompletion(task);
   }
 
   {


### PR DESCRIPTION
The test is flaky because in parallel mode, the task might still be executing when the first scenario's scope is exited. Add waiting for task to finish at the end of the first scenario prevents the race condition to happen. Stress tests of 200 iterations have been run to make sure the fix is effective.