### PR TITLE
Use correct label for 8-core-ubuntu larger runner

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -41,7 +41,7 @@ defaults:
 jobs:
   benchmark:
     if: github.repository == 'facebookincubator/velox'
-    runs-on: 8-core
+    runs-on: 8-core-ubuntu
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"
       CCACHE_BASEDIR: "${{ github.workspace }}"

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -47,7 +47,7 @@ permissions:
 
 jobs:
   compile:
-    runs-on: 8-core
+    runs-on: 8-core-ubuntu
     timeout-minutes: 120
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"
@@ -105,7 +105,7 @@ jobs:
 
 
   presto-java-aggregation-fuzzer-run:
-    runs-on: 8-core
+    runs-on: 8-core-ubuntu
     container: ghcr.io/facebookincubator/velox-dev:presto-java
     timeout-minutes: 120
     env:

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -51,7 +51,7 @@ jobs:
     name: Linux release with adapters
     # prevent errors when forks ff their main branch
     if: ${{ github.repository == 'facebookincubator/velox' }}
-    runs-on: 8-core
+    runs-on: 8-core-ubuntu
     container: ghcr.io/facebookincubator/velox-dev:adapters
     defaults:
       run:
@@ -113,7 +113,7 @@ jobs:
           ctest -j 8 --output-on-failure --no-tests=error
 
   ubuntu-debug:
-    runs-on: 8-core
+    runs-on: 8-core-ubuntu
     # prevent errors when forks ff their main branch
     if: ${{ github.repository == 'facebookincubator/velox' }}
     name: "Ubuntu debug with resolve_dependency"


### PR DESCRIPTION
'8-core' will stop being a valid label on the 17th of June: https://github.blog/changelog/2024-05-16-new-dates-for-actions-larger-runner-multi-label-deprecation/

Names can be found here:  https://github.com/facebookincubator/velox/actions/runners