### PR TITLE
Add arg generator for Presto mod decimal function

### DIFF
--- a/velox/functions/prestosql/fuzzer/DivideArgGenerator.h
+++ b/velox/functions/prestosql/fuzzer/DivideArgGenerator.h
@@ -19,7 +19,6 @@
 
 namespace facebook::velox::exec::test {
 
-// An argument type generator for decimal divide Presto function.
 class DivideArgGenerator : public fuzzer::DecimalArgGeneratorBase {
  public:
   DivideArgGenerator() {

--- a/velox/functions/prestosql/fuzzer/FloorAndRoundArgGenerator.h
+++ b/velox/functions/prestosql/fuzzer/FloorAndRoundArgGenerator.h
@@ -20,7 +20,6 @@
 
 namespace facebook::velox::exec::test {
 
-// An argument type generator for decimal floor and round Presto functions.
 class FloorAndRoundArgGenerator : public fuzzer::ArgGenerator {
  public:
   std::vector<TypePtr> generateArgs(

--- a/velox/functions/prestosql/fuzzer/ModulusArgGenerator.h
+++ b/velox/functions/prestosql/fuzzer/ModulusArgGenerator.h
@@ -19,9 +19,9 @@
 
 namespace facebook::velox::exec::test {
 
-class PlusMinusArgGenerator : public fuzzer::DecimalArgGeneratorBase {
+class ModulusArgGenerator : public fuzzer::DecimalArgGeneratorBase {
  public:
-  PlusMinusArgGenerator() {
+  ModulusArgGenerator() {
     initialize(2);
   }
 
@@ -29,7 +29,7 @@ class PlusMinusArgGenerator : public fuzzer::DecimalArgGeneratorBase {
   std::optional<std::pair<int, int>>
   toReturnType(int p1, int s1, int p2, int s2) override {
     auto s = std::max(s1, s2);
-    auto p = std::min(38, std::max(p1 - s1, p2 - s2) + 1 + s);
+    auto p = std::min(p2 - s2, p1 - s1) + s;
     return {{p, s}};
   }
 };

--- a/velox/functions/prestosql/fuzzer/MultiplyArgGenerator.h
+++ b/velox/functions/prestosql/fuzzer/MultiplyArgGenerator.h
@@ -19,7 +19,6 @@
 
 namespace facebook::velox::exec::test {
 
-// An argument type generator for decimal multiply Presto function.
 class MultiplyArgGenerator : public fuzzer::DecimalArgGeneratorBase {
  public:
   MultiplyArgGenerator() {

--- a/velox/functions/prestosql/tests/ArgGeneratorTest.cpp
+++ b/velox/functions/prestosql/tests/ArgGeneratorTest.cpp
@@ -16,6 +16,7 @@
 #include "velox/expression/fuzzer/tests/ArgGeneratorTestUtils.h"
 #include "velox/functions/prestosql/fuzzer/DivideArgGenerator.h"
 #include "velox/functions/prestosql/fuzzer/FloorAndRoundArgGenerator.h"
+#include "velox/functions/prestosql/fuzzer/ModulusArgGenerator.h"
 #include "velox/functions/prestosql/fuzzer/MultiplyArgGenerator.h"
 #include "velox/functions/prestosql/fuzzer/PlusMinusArgGenerator.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
@@ -119,6 +120,17 @@ TEST_F(ArgGeneratorTest, round) {
   assertEmptyArgs(generator, twoArgsSignature, DECIMAL(18, 18));
   assertEmptyArgs(generator, twoArgsSignature, DECIMAL(38, 38));
   assertEmptyArgs(generator, twoArgsSignature, DECIMAL(1, 0));
+}
+
+TEST_F(ArgGeneratorTest, modulus) {
+  const auto& signature = getOnlySignature("mod");
+  const auto generator = std::make_shared<exec::test::ModulusArgGenerator>();
+
+  assertReturnType(generator, signature, DECIMAL(10, 2));
+  assertReturnType(generator, signature, DECIMAL(32, 6));
+  assertReturnType(generator, signature, DECIMAL(38, 20));
+  assertReturnType(generator, signature, DECIMAL(38, 38));
+  assertReturnType(generator, signature, DECIMAL(38, 0));
 }
 
 } // namespace


### PR DESCRIPTION
Required by decimal fuzzer test to generate correct argument types for Presto 
mod decimal function following specified constraints.