### PR TITLE
Reject duplicate sorting keys

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1743,11 +1743,12 @@ class OrderByNode : public PlanNode {
         "Number of sorting keys and sorting orders in OrderBy must be the same");
     // Reject duplicate sorting keys.
     std::unordered_set<std::string> uniqueKeys;
-    for (const auto& sortKey: sortingKeys) {
+    for (const auto& sortKey : sortingKeys) {
       VELOX_USER_CHECK_NOT_NULL(sortKey, "Sorting key cannot be null");
       VELOX_USER_CHECK(
           uniqueKeys.insert(sortKey->name()).second,
-          "Duplicate sorting keys are not allowed: {}", sortKey->name());
+          "Duplicate sorting keys are not allowed: {}",
+          sortKey->name());
     }
   }
 

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1741,6 +1741,14 @@ class OrderByNode : public PlanNode {
         sortingKeys.size(),
         sortingOrders.size(),
         "Number of sorting keys and sorting orders in OrderBy must be the same");
+    // Reject duplicate sorting keys.
+    std::unordered_set<std::string> uniqueKeys;
+    for (const auto& sortKey: sortingKeys) {
+      VELOX_USER_CHECK_NOT_NULL(sortKey, "Sorting key cannot be null");
+      VELOX_USER_CHECK(
+          uniqueKeys.insert(sortKey->name()).second,
+          "Duplicate sorting keys are not allowed: {}", sortKey->name());
+    }
   }
 
   const std::vector<FieldAccessTypedExprPtr>& sortingKeys() const {

--- a/velox/core/tests/PlanFragmentTest.cpp
+++ b/velox/core/tests/PlanFragmentTest.cpp
@@ -105,7 +105,8 @@ TEST_F(PlanFragmentTest, orderByCanSpill) {
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
 
-    const std::vector<FieldAccessTypedExprPtr> sortingKeys{nullptr};
+    const std::vector<FieldAccessTypedExprPtr> sortingKeys{
+        std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "c0")};
     const std::vector<SortOrder> sortingOrders{{true, true}};
     auto orderBy = std::make_shared<OrderByNode>(
         "orderBy", sortingKeys, sortingOrders, false, valueNode_);

--- a/velox/core/tests/PlanNodeTest.cpp
+++ b/velox/core/tests/PlanNodeTest.cpp
@@ -107,6 +107,8 @@ TEST(TestPlanNode, duplicateSortKeys) {
   };
   auto sortingOrders =
       std::vector<SortOrder>{{true, true}, {false, false}, {true, true}};
-  VELOX_ASSERT_USER_THROW(std::make_shared<OrderByNode>(
-      "orderBy", sortingKeys, sortingOrders, false, nullptr), "Duplicate sorting keys are not allowed: c0");
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<OrderByNode>(
+          "orderBy", sortingKeys, sortingOrders, false, nullptr),
+      "Duplicate sorting keys are not allowed: c0");
 }

--- a/velox/core/tests/PlanNodeTest.cpp
+++ b/velox/core/tests/PlanNodeTest.cpp
@@ -15,6 +15,7 @@
  */
 #include <gtest/gtest.h>
 
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/core/PlanNode.h"
 
 using namespace ::facebook::velox;
@@ -96,4 +97,16 @@ TEST(TestPlanNode, sortOrder) {
       ASSERT_NE(testData.order1, testData.order2);
     }
   }
+}
+
+TEST(TestPlanNode, duplicateSortKeys) {
+  auto sortingKeys = std::vector<FieldAccessTypedExprPtr>{
+      std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "c0"),
+      std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "c1"),
+      std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "c0"),
+  };
+  auto sortingOrders =
+      std::vector<SortOrder>{{true, true}, {false, false}, {true, true}};
+  VELOX_ASSERT_USER_THROW(std::make_shared<OrderByNode>(
+      "orderBy", sortingKeys, sortingOrders, false, nullptr), "Duplicate sorting keys are not allowed: c0");
 }

--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -592,7 +592,7 @@ identified sort fields as well as a sorting order.
    * - Property
      - Description
    * - sortingKeys
-     - List of one of more input columns to sort by.
+     - List of one of more input columns to sort by. Sorting keys must be unique.
    * - sortingOrders
      - Sorting order for each of the soring keys. The supported orders are: ascending nulls first, ascending nulls last, descending nulls first, descending nulls last.
    * - isPartial


### PR DESCRIPTION
A SQL query may specify duplicate sorting keys:

```
SELECT c1 FROM t ORDER BY c1, c1
```

Such query fails in Gluten:

```
Caused by: java.lang.RuntimeException: Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: (1 vs. 2)
Retriable: False
Expression: input_->size() >= sortCompareFlags_.size()
Function: SortBuffer
File: /opt/gluten/gluten/ep/build-velox/build/velox_ep/velox/exec/SortBuffer.cpp
Line: 36
```

Harden OrderByNode to reject duplicate sorting keys. The query planner should ensure the sorting keys are unique.