### PR TITLE
misc: Add OrderBy benchmark

### DIFF
--- a/velox/exec/benchmarks/CMakeLists.txt
+++ b/velox/exec/benchmarks/CMakeLists.txt
@@ -87,11 +87,25 @@ if(${VELOX_ENABLE_PARQUET})
     thrift)
 endif()
 
+add_library(velox_orderby_benchmark_util OrderByBenchmarkUtil.cpp)
+
+target_link_libraries(
+  velox_orderby_benchmark_util velox_vector_fuzzer velox_vector_test_lib)
+
 add_executable(velox_prefixsort_benchmark PrefixSortBenchmark.cpp)
 
 target_link_libraries(
-  velox_prefixsort_benchmark
+  velox_prefixsort_benchmark velox_exec velox_orderby_benchmark_util
+  Folly::follybenchmark)
+
+add_executable(velox_orderby_benchmark OrderByBenchmark.cpp
+                                       OrderByBenchmarkUtil.cpp)
+
+target_link_libraries(
+  velox_orderby_benchmark
   velox_exec
+  velox_exec_test_lib
+  velox_orderby_benchmark_util
   velox_vector_fuzzer
   velox_vector_test_lib
   Folly::follybenchmark)

--- a/velox/exec/benchmarks/OrderByBenchmark.cpp
+++ b/velox/exec/benchmarks/OrderByBenchmark.cpp
@@ -56,7 +56,7 @@ class OrderByBenchmark {
             const auto start = getCurrentTimeMicro();
             for (auto i = 0; i < iterations; ++i) {
               std::shared_ptr<Task> task;
-              test::AssertQueryBuilder(plan).countResults(task);
+              test::AssertQueryBuilder(plan).runWithoutResults(task);
               auto taskStats = exec::toPlanStats(task->taskStats());
               auto& stats = taskStats.at(orderByNodeId);
               inputNs += stats.addInputTiming.wallNanos;
@@ -80,7 +80,7 @@ class OrderByBenchmark {
     folly::BenchmarkSuspender suspender;
     std::vector<RowVectorPtr> vectors;
     vectors.emplace_back(OrderByBenchmarkUtil::fuzzRows(
-        test.rowType, test.numRows, test.numKeys, pool_.get()));
+        test.rowType, test.numRows, pool_.get()));
 
     std::vector<std::string> keys;
     keys.reserve(test.numKeys);

--- a/velox/exec/benchmarks/OrderByBenchmark.cpp
+++ b/velox/exec/benchmarks/OrderByBenchmark.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <iostream>
+
+#include "glog/logging.h"
+#include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/benchmarks/OrderByBenchmarkUtil.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+
+namespace {
+
+struct TestCase {
+  vector_size_t numRows;
+  RowTypePtr rowType;
+  int numKeys;
+};
+
+class OrderByBenchmark {
+ public:
+  void addBenchmark(
+      const std::string& testName,
+      vector_size_t numRows,
+      const RowTypePtr& rowType,
+      int32_t iterations,
+      int numKeys) {
+    TestCase testCase = {numRows, rowType, numKeys};
+    {
+      folly::addBenchmark(
+          __FILE__,
+          "OrderBy_" + testName,
+          [test = testCase, iterations = std::max(1, iterations / 10), this]() {
+            core::PlanNodeId orderByNodeId;
+            auto plan = makeOrderByPlan(test, orderByNodeId);
+            uint64_t inputNanos = 0;
+            uint64_t outputNanos = 0;
+            uint64_t finishNanos = 0;
+            auto start = getCurrentTimeMicro();
+            for (auto i = 0; i < iterations; ++i) {
+              std::shared_ptr<Task> task;
+              test::AssertQueryBuilder(plan).countResults(task);
+              auto taskStats = exec::toPlanStats(task->taskStats());
+              auto& stats = taskStats.at(orderByNodeId);
+              inputNanos += stats.addInputTiming.wallNanos;
+              finishNanos += stats.finishTiming.wallNanos;
+              outputNanos += stats.getOutputTiming.wallNanos;
+            }
+            uint64_t total = getCurrentTimeMicro() - start;
+            std::cout << "Total " << succinctMicros(total) << " Input "
+                      << succinctNanos(inputNanos) << " Output "
+                      << succinctNanos(outputNanos) << " Finish "
+                      << succinctNanos(finishNanos) << std::endl;
+            return 1;
+          });
+    }
+  }
+
+ private:
+  core::PlanNodePtr makeOrderByPlan(
+      const TestCase& test,
+      core::PlanNodeId& orderByNodeId) {
+    folly::BenchmarkSuspender suspender;
+    std::vector<RowVectorPtr> vectors;
+    vectors.emplace_back(OrderByBenchmarkUtil::fuzzRows(
+        test.rowType, test.numRows, test.numKeys, pool_.get()));
+
+    std::vector<std::string> keys;
+    keys.reserve(test.numKeys);
+    for (auto i = 0; i < test.numKeys; i++) {
+      keys.emplace_back(fmt::format("c{} ASC NULLS LAST", i));
+    }
+
+    return test::PlanBuilder()
+        .values(vectors)
+        .orderBy(keys, false)
+        .capturePlanNodeId(orderByNodeId)
+        .planNode();
+  }
+
+  std::shared_ptr<memory::MemoryPool> rootPool_{
+      memory::memoryManager()->addRootPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      rootPool_->addLeafChild("OrderByBenchmark")};
+};
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+
+  memory::MemoryManager::initialize({});
+  OrderByBenchmark bm;
+  OrderByBenchmarkUtil::addBenchmarks([&](const std::string& testName,
+                                          vector_size_t numRows,
+                                          const RowTypePtr& rowType,
+                                          int iterations,
+                                          int numKeys) {
+    bm.addBenchmark(testName, numRows, rowType, iterations, numKeys);
+  });
+
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/exec/benchmarks/OrderByBenchmark.cpp
+++ b/velox/exec/benchmarks/OrderByBenchmark.cpp
@@ -37,7 +37,7 @@ struct TestCase {
 class OrderByBenchmark {
  public:
   void addBenchmark(
-      const std::string& testName,
+      const std::string& benchmarkName,
       vector_size_t numRows,
       const RowTypePtr& rowType,
       int32_t iterations,
@@ -46,28 +46,28 @@ class OrderByBenchmark {
     {
       folly::addBenchmark(
           __FILE__,
-          "OrderBy_" + testName,
+          "OrderBy_" + benchmarkName,
           [test = testCase, iterations = std::max(1, iterations / 10), this]() {
             core::PlanNodeId orderByNodeId;
-            auto plan = makeOrderByPlan(test, orderByNodeId);
-            uint64_t inputNanos = 0;
-            uint64_t outputNanos = 0;
-            uint64_t finishNanos = 0;
-            auto start = getCurrentTimeMicro();
+            const auto plan = makeOrderByPlan(test, orderByNodeId);
+            uint64_t inputNs = 0;
+            uint64_t outputNs = 0;
+            uint64_t finishNs = 0;
+            const auto start = getCurrentTimeMicro();
             for (auto i = 0; i < iterations; ++i) {
               std::shared_ptr<Task> task;
               test::AssertQueryBuilder(plan).countResults(task);
               auto taskStats = exec::toPlanStats(task->taskStats());
               auto& stats = taskStats.at(orderByNodeId);
-              inputNanos += stats.addInputTiming.wallNanos;
-              finishNanos += stats.finishTiming.wallNanos;
-              outputNanos += stats.getOutputTiming.wallNanos;
+              inputNs += stats.addInputTiming.wallNanos;
+              finishNs += stats.finishTiming.wallNanos;
+              outputNs += stats.getOutputTiming.wallNanos;
             }
-            uint64_t total = getCurrentTimeMicro() - start;
+            const uint64_t total = getCurrentTimeMicro() - start;
             std::cout << "Total " << succinctMicros(total) << " Input "
-                      << succinctNanos(inputNanos) << " Output "
-                      << succinctNanos(outputNanos) << " Finish "
-                      << succinctNanos(finishNanos) << std::endl;
+                      << succinctNanos(inputNs) << " Output "
+                      << succinctNanos(outputNs) << " Finish "
+                      << succinctNanos(finishNs) << std::endl;
             return 1;
           });
     }
@@ -107,12 +107,12 @@ int main(int argc, char** argv) {
 
   memory::MemoryManager::initialize({});
   OrderByBenchmark bm;
-  OrderByBenchmarkUtil::addBenchmarks([&](const std::string& testName,
+  OrderByBenchmarkUtil::addBenchmarks([&](const std::string& benchmarkName,
                                           vector_size_t numRows,
                                           const RowTypePtr& rowType,
                                           int iterations,
                                           int numKeys) {
-    bm.addBenchmark(testName, numRows, rowType, iterations, numKeys);
+    bm.addBenchmark(benchmarkName, numRows, rowType, iterations, numKeys);
   });
 
   folly::runBenchmarks();

--- a/velox/exec/benchmarks/OrderByBenchmarkUtil.cpp
+++ b/velox/exec/benchmarks/OrderByBenchmarkUtil.cpp
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/benchmarks/OrderByBenchmarkUtil.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
+
+DEFINE_double(data_null_ratio, 0.7, "Data null ratio");
+
+using namespace facebook::velox;
+
+namespace facebook::velox::exec {
+namespace {
+
+void addBenchmark(
+    const std::string& prefix,
+    const std::string& keyName,
+    const std::vector<vector_size_t>& batchSizes,
+    const std::vector<RowTypePtr>& rowTypes,
+    const std::vector<int>& numKeys,
+    int32_t iterations,
+    std::function<void(
+        const std::string& testName,
+        size_t numRows,
+        const RowTypePtr& rowType,
+        int iterations,
+        int numKeys)>& benchmark) {
+  for (auto batchSize : batchSizes) {
+    for (auto i = 0; i < rowTypes.size(); ++i) {
+      const auto name = fmt::format(
+          "{}_{}_{}_{}k", prefix, numKeys[i], keyName, batchSize / 1000.0);
+      benchmark(name, batchSize, rowTypes[i], iterations, numKeys[i]);
+    }
+  }
+}
+
+std::vector<RowTypePtr> smallintRowTypes(bool noPayload) {
+  if (noPayload) {
+    return {
+        ROW({SMALLINT()}),
+        ROW({SMALLINT(), SMALLINT()}),
+        ROW({SMALLINT(), SMALLINT(), SMALLINT()}),
+        ROW({SMALLINT(), SMALLINT(), SMALLINT(), SMALLINT()}),
+    };
+  } else {
+    return {
+        ROW({SMALLINT(), VARCHAR(), VARCHAR()}),
+        ROW({SMALLINT(), SMALLINT(), VARCHAR(), VARCHAR()}),
+        ROW({SMALLINT(), SMALLINT(), SMALLINT(), VARCHAR(), VARCHAR()}),
+        ROW(
+            {SMALLINT(),
+             SMALLINT(),
+             SMALLINT(),
+             SMALLINT(),
+             VARCHAR(),
+             VARCHAR()}),
+    };
+  }
+}
+
+std::vector<RowTypePtr> bigintRowTypes(bool noPayload) {
+  if (noPayload) {
+    return {
+        test::VectorMaker::rowType({BIGINT()}),
+        test::VectorMaker::rowType({BIGINT(), BIGINT()}),
+        test::VectorMaker::rowType({BIGINT(), BIGINT(), BIGINT()}),
+        test::VectorMaker::rowType({BIGINT(), BIGINT(), BIGINT(), BIGINT()}),
+    };
+  } else {
+    return {
+        test::VectorMaker::rowType({BIGINT(), VARCHAR(), VARCHAR()}),
+        test::VectorMaker::rowType({BIGINT(), BIGINT(), VARCHAR(), VARCHAR()}),
+        test::VectorMaker::rowType(
+            {BIGINT(), BIGINT(), BIGINT(), VARCHAR(), VARCHAR()}),
+        test::VectorMaker::rowType(
+            {BIGINT(), BIGINT(), BIGINT(), BIGINT(), VARCHAR(), VARCHAR()}),
+    };
+  }
+}
+
+std::vector<RowTypePtr> largeVarcharRowTypes() {
+  return {
+      test::VectorMaker::rowType({VARCHAR()}),
+      test::VectorMaker::rowType({VARCHAR(), VARCHAR()}),
+      test::VectorMaker::rowType({VARCHAR(), VARCHAR(), VARCHAR()}),
+      test::VectorMaker::rowType({VARCHAR(), VARCHAR(), VARCHAR(), VARCHAR()}),
+  };
+}
+
+void bigint(
+    bool noPayload,
+    int numIterations,
+    const std::vector<vector_size_t>& batchSizes,
+    std::function<void(
+        const std::string& testName,
+        size_t numRows,
+        const RowTypePtr& rowType,
+        int iterations,
+        int numKeys)> benchmark) {
+  std::vector<RowTypePtr> rowTypes = bigintRowTypes(noPayload);
+  std::vector<int> numKeys = {1, 2, 3, 4};
+  addBenchmark(
+      noPayload ? "no-payload" : "payload",
+      "bigint",
+      batchSizes,
+      rowTypes,
+      numKeys,
+      numIterations,
+      benchmark);
+}
+
+void smallBigint(std::function<void(
+                     const std::string& testName,
+                     size_t numRows,
+                     const RowTypePtr& rowType,
+                     int iterations,
+                     int numKeys)> benchmark) {
+  // For small dateset, iterations need to be large enough to ensure that the
+  // benchmark runs for enough time.
+  const auto iterations = 100'000;
+  const std::vector<vector_size_t> batchSizes = {10, 50, 100, 500};
+  bigint(true, iterations, batchSizes, benchmark);
+}
+
+void smallBigintWithPayload(std::function<void(
+                                const std::string& testName,
+                                size_t numRows,
+                                const RowTypePtr& rowType,
+                                int iterations,
+                                int numKeys)> benchmark) {
+  const auto iterations = 100'000;
+  const std::vector<vector_size_t> batchSizes = {10, 50, 100, 500};
+  bigint(false, iterations, batchSizes, benchmark);
+}
+
+void largeBigint(std::function<void(
+                     const std::string& testName,
+                     size_t numRows,
+                     const RowTypePtr& rowType,
+                     int iterations,
+                     int numKeys)> benchmark) {
+  const auto iterations = 10;
+  const std::vector<vector_size_t> batchSizes = {
+      1'000, 10'000, 100'000, 1'000'000};
+  bigint(true, iterations, batchSizes, benchmark);
+}
+
+void largeBigintWithPayloads(std::function<void(
+                                 const std::string& testName,
+                                 size_t numRows,
+                                 const RowTypePtr& rowType,
+                                 int iterations,
+                                 int numKeys)> benchmark) {
+  const auto iterations = 10;
+  const std::vector<vector_size_t> batchSizes = {
+      1'000, 10'000, 100'000, 1'000'000};
+  bigint(false, iterations, batchSizes, benchmark);
+}
+
+void largeVarchar(std::function<void(
+                      const std::string& testName,
+                      size_t numRows,
+                      const RowTypePtr& rowType,
+                      int iterations,
+                      int numKeys)> benchmark) {
+  const auto iterations = 10;
+  const std::vector<vector_size_t> batchSizes = {
+      1'000, 10'000, 100'000, 1'000'000};
+  std::vector<RowTypePtr> rowTypes = largeVarcharRowTypes();
+  std::vector<int> numKeys = {1, 2, 3, 4};
+  addBenchmark(
+      "no-payloads",
+      "varchar",
+      batchSizes,
+      rowTypes,
+      numKeys,
+      iterations,
+      benchmark);
+}
+
+void smallint(
+    bool noPayload,
+    int numIterations,
+    const std::vector<vector_size_t>& batchSizes,
+    std::function<void(
+        const std::string& testName,
+        size_t numRows,
+        const RowTypePtr& rowType,
+        int iterations,
+        int numKeys)> benchmark) {
+  std::vector<RowTypePtr> rowTypes = smallintRowTypes(noPayload);
+  std::vector<int> numKeys = {1, 2, 3, 4};
+  addBenchmark(
+      noPayload ? "no-payload" : "payload",
+      "smallint",
+      batchSizes,
+      rowTypes,
+      numKeys,
+      numIterations,
+      benchmark);
+}
+
+void smallSmallint(std::function<void(
+                       const std::string& testName,
+                       size_t numRows,
+                       const RowTypePtr& rowType,
+                       int iterations,
+                       int numKeys)> benchmark) {
+  // For small dateset, iterations need to be large enough to ensure that the
+  // benchmark runs for enough time.
+  const auto iterations = 100'000;
+  const std::vector<vector_size_t> batchSizes = {10, 50, 100, 500};
+  smallint(true, iterations, batchSizes, benchmark);
+}
+
+void smallSmallintWithPayload(std::function<void(
+                                  const std::string& testName,
+                                  size_t numRows,
+                                  const RowTypePtr& rowType,
+                                  int iterations,
+                                  int numKeys)> benchmark) {
+  const auto iterations = 100'000;
+  const std::vector<vector_size_t> batchSizes = {10, 50, 100, 500};
+  smallint(false, iterations, batchSizes, benchmark);
+}
+
+void largeSmallint(std::function<void(
+                       const std::string& testName,
+                       size_t numRows,
+                       const RowTypePtr& rowType,
+                       int iterations,
+                       int numKeys)> benchmark) {
+  const auto iterations = 10;
+  const std::vector<vector_size_t> batchSizes = {
+      1'000, 10'000, 100'000, 1'000'000};
+  smallint(true, iterations, batchSizes, benchmark);
+}
+
+void largeSmallintWithPayloads(std::function<void(
+                                   const std::string& testName,
+                                   size_t numRows,
+                                   const RowTypePtr& rowType,
+                                   int iterations,
+                                   int numKeys)> benchmark) {
+  const auto iterations = 10;
+  const std::vector<vector_size_t> batchSizes = {
+      1'000, 10'000, 100'000, 1'000'000};
+  smallint(false, iterations, batchSizes, benchmark);
+}
+} // namespace
+
+RowVectorPtr OrderByBenchmarkUtil::fuzzRows(
+    const RowTypePtr& rowType,
+    vector_size_t numRows,
+    int numKeys,
+    memory::MemoryPool* pool) {
+  VectorFuzzer fuzzer({.vectorSize = static_cast<size_t>(numRows)}, pool);
+  VectorFuzzer fuzzerWithNulls(
+      {.vectorSize = static_cast<size_t>(numRows),
+       .nullRatio = FLAGS_data_null_ratio},
+      pool);
+  std::vector<VectorPtr> children;
+
+  // Fuzz keys: for front keys (column 0 to numKeys -2) use high
+  // nullRatio to enforce all columns to be compared.
+  for (auto i = 0; i < numKeys - 1; ++i) {
+    children.push_back(fuzzerWithNulls.fuzz(rowType->childAt(i)));
+  }
+  children.push_back(fuzzer.fuzz(rowType->childAt(numKeys - 1)));
+
+  // Fuzz payload.
+  for (auto i = numKeys; i < rowType->size(); ++i) {
+    children.push_back(fuzzer.fuzz(rowType->childAt(i)));
+  }
+  return std::make_shared<RowVector>(
+      pool, rowType, nullptr, numRows, std::move(children));
+}
+
+void OrderByBenchmarkUtil::addBenchmarks(std::function<void(
+                                             const std::string& testName,
+                                             vector_size_t numRows,
+                                             const RowTypePtr& rowType,
+                                             int iterations,
+                                             int numKeys)> benchmark) {
+  smallBigint(benchmark);
+  largeBigint(benchmark);
+  largeBigintWithPayloads(benchmark);
+  smallBigintWithPayload(benchmark);
+  largeVarchar(benchmark);
+  smallSmallint(benchmark);
+  largeSmallint(benchmark);
+  smallSmallintWithPayload(benchmark);
+  largeSmallintWithPayloads(benchmark);
+}
+} // namespace facebook::velox::exec

--- a/velox/exec/benchmarks/OrderByBenchmarkUtil.cpp
+++ b/velox/exec/benchmarks/OrderByBenchmarkUtil.cpp
@@ -42,9 +42,9 @@ void addBenchmark(
     const OrderByBenchmarkFunction& benchmark) {
   for (auto batchSize : batchSizes) {
     for (auto i = 0; i < rowTypes.size(); ++i) {
-      const auto name = fmt::format(
+      const auto benchmarkName = fmt::format(
           "{}_{}_{}_{}k", prefix, numKeys[i], keyName, batchSize / 1000.0);
-      benchmark(name, batchSize, rowTypes[i], iterations, numKeys[i]);
+      benchmark(benchmarkName, batchSize, rowTypes[i], iterations, numKeys[i]);
     }
   }
 }
@@ -149,13 +149,12 @@ void largeVarchar(const OrderByBenchmarkFunction& benchmark) {
   const auto iterations = 10;
   const std::vector<vector_size_t> batchSizes = {
       1'000, 10'000, 100'000, 1'000'000};
-  std::vector<RowTypePtr> rowTypes = largeVarcharRowTypes();
-  std::vector<int> numKeys = {1, 2, 3, 4};
+  const std::vector<int> numKeys = {1, 2, 3, 4};
   addBenchmark(
       "no-payloads",
       "varchar",
       batchSizes,
-      rowTypes,
+      largeVarcharRowTypes(),
       numKeys,
       iterations,
       benchmark);

--- a/velox/exec/benchmarks/OrderByBenchmarkUtil.h
+++ b/velox/exec/benchmarks/OrderByBenchmarkUtil.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox::exec {
+
+class OrderByBenchmarkUtil {
+ public:
+  /// Add the benchmarks with the parameter.
+  /// @param benchmark benchmark generator.
+  static void addBenchmarks(std::function<void(
+                                const std::string& testName,
+                                vector_size_t numRows,
+                                const RowTypePtr& rowType,
+                                int iterations,
+                                int numKeys)> benchmark);
+
+  /// Generate RowVector by VectorFuzzer according to rowType, for front keys
+  /// (column 0 to numKeys -2) use high
+  /// nullRatio to enforce all columns to be compared.
+  /// @param numKeys 0 to numKeys - 2 is high null ratio column, other
+  /// columns do not have null values.
+  static RowVectorPtr fuzzRows(
+      const RowTypePtr& rowType,
+      vector_size_t numRows,
+      int numKeys,
+      memory::MemoryPool* pool);
+};
+} // namespace facebook::velox::exec

--- a/velox/exec/benchmarks/OrderByBenchmarkUtil.h
+++ b/velox/exec/benchmarks/OrderByBenchmarkUtil.h
@@ -23,12 +23,12 @@ class OrderByBenchmarkUtil {
  public:
   /// Add the benchmarks with the parameter.
   /// @param benchmark benchmark generator.
-  static void addBenchmarks(std::function<void(
-                                const std::string& testName,
+  static void addBenchmarks(const std::function<void(
+                                const std::string& benchmarkName,
                                 vector_size_t numRows,
                                 const RowTypePtr& rowType,
                                 int iterations,
-                                int numKeys)> benchmark);
+                                int numKeys)>& benchmark);
 
   /// Generate RowVector by VectorFuzzer according to rowType, for front keys
   /// (column 0 to numKeys -2) use high

--- a/velox/exec/benchmarks/OrderByBenchmarkUtil.h
+++ b/velox/exec/benchmarks/OrderByBenchmarkUtil.h
@@ -22,23 +22,19 @@ namespace facebook::velox::exec {
 class OrderByBenchmarkUtil {
  public:
   /// Add the benchmarks with the parameter.
-  /// @param benchmark benchmark generator.
+  /// @param benchmarkFunc benchmark generator.
   static void addBenchmarks(const std::function<void(
                                 const std::string& benchmarkName,
                                 vector_size_t numRows,
                                 const RowTypePtr& rowType,
                                 int iterations,
-                                int numKeys)>& benchmark);
+                                int numKeys)>& benchmarkFunc);
 
-  /// Generate RowVector by VectorFuzzer according to rowType, for front keys
-  /// (column 0 to numKeys -2) use high
-  /// nullRatio to enforce all columns to be compared.
-  /// @param numKeys 0 to numKeys - 2 is high null ratio column, other
-  /// columns do not have null values.
+  /// Generate RowVector by VectorFuzzer according to rowType. Use
+  /// FLAGS_data_null_ratio to specify the columns null ratio
   static RowVectorPtr fuzzRows(
       const RowTypePtr& rowType,
       vector_size_t numRows,
-      int numKeys,
       memory::MemoryPool* pool);
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/benchmarks/PrefixSortBenchmark.cpp
+++ b/velox/exec/benchmarks/PrefixSortBenchmark.cpp
@@ -18,9 +18,7 @@
 
 #include "glog/logging.h"
 #include "velox/exec/PrefixSort.h"
-#include "velox/vector/fuzzer/VectorFuzzer.h"
-
-DEFINE_double(data_null_ratio, 0.7, "Data null ratio");
+#include "velox/exec/benchmarks/OrderByBenchmarkUtil.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
@@ -47,7 +45,8 @@ class TestCase {
       }
     }
     data_ = std::make_unique<RowContainer>(keyTypes, dependentTypes, pool);
-    RowVectorPtr sortedRows = fuzzRows(numRows, numKeys);
+    RowVectorPtr sortedRows =
+        OrderByBenchmarkUtil::fuzzRows(rowType, numRows, numKeys, pool_);
     storeRows(numRows, sortedRows);
 
     // Initialize CompareFlags, it could be same for each key in benchmark.
@@ -89,30 +88,6 @@ class TestCase {
       rowContainer()->store(
           decoded, folly::Range(rows_.data(), numRows), column);
     }
-  }
-
-  RowVectorPtr fuzzRows(size_t numRows, int numKeys) {
-    VectorFuzzer fuzzer({.vectorSize = numRows}, pool_);
-    VectorFuzzer fuzzerWithNulls(
-        {.vectorSize = numRows, .nullRatio = FLAGS_data_null_ratio}, pool_);
-    std::vector<VectorPtr> children;
-
-    // Fuzz keys: for front keys (column 0 to numKeys -2) use high
-    // nullRatio to enforce all columns to be compared.
-    {
-      for (auto i = 0; i < numKeys - 1; ++i) {
-        children.push_back(fuzzerWithNulls.fuzz(rowType_->childAt(i)));
-      }
-      children.push_back(fuzzer.fuzz(rowType_->childAt(numKeys - 1)));
-    }
-    // Fuzz payload
-    {
-      for (auto i = numKeys; i < rowType_->size(); ++i) {
-        children.push_back(fuzzer.fuzz(rowType_->childAt(i)));
-      }
-    }
-    return std::make_shared<RowVector>(
-        pool_, rowType_, nullptr, numRows, std::move(children));
   }
 
   const std::string testName_;
@@ -167,30 +142,27 @@ class PrefixSortBenchmark {
       size_t numRows,
       const RowTypePtr& rowType,
       int iterations,
-      int numKeys,
-      bool testStdSort) {
+      int numKeys) {
     auto testCase =
         std::make_unique<TestCase>(pool_, testName, numRows, rowType, numKeys);
     // Add benchmarks for std-sort and prefix-sort.
     {
-      if (testStdSort) {
-        folly::addBenchmark(
-            __FILE__,
-            "StdSort_" + testCase->testName(),
-            [rows = testCase->rows(),
-             container = testCase->rowContainer(),
-             sortFlags = testCase->compareFlags(),
-             iterations = iterations,
-             this]() {
-              for (auto i = 0; i < iterations; ++i) {
-                runStdSort(rows, container, sortFlags);
-              }
-              return rows.size() * iterations;
-            });
-      }
       folly::addBenchmark(
           __FILE__,
-          testStdSort ? "%PrefixSort" : "PrefixSort_" + testCase->testName(),
+          "StdSort_" + testCase->testName(),
+          [rows = testCase->rows(),
+           container = testCase->rowContainer(),
+           sortFlags = testCase->compareFlags(),
+           iterations = iterations,
+           this]() {
+            for (auto i = 0; i < iterations; ++i) {
+              runStdSort(rows, container, sortFlags);
+            }
+            return rows.size() * iterations;
+          });
+      folly::addBenchmark(
+          __FILE__,
+          "%PrefixSort",
           [rows = testCase->rows(),
            container = testCase->rowContainer(),
            sortFlags = testCase->compareFlags(),
@@ -203,182 +175,6 @@ class PrefixSortBenchmark {
           });
     }
     testCases_.push_back(std::move(testCase));
-  }
-
-  void benchmark(
-      const std::string& prefix,
-      const std::string& keyName,
-      const std::vector<vector_size_t>& batchSizes,
-      const std::vector<RowTypePtr>& rowTypes,
-      const std::vector<int>& numKeys,
-      int32_t iterations,
-      bool testStdSort = true) {
-    for (auto batchSize : batchSizes) {
-      for (auto i = 0; i < rowTypes.size(); ++i) {
-        const auto name = fmt::format(
-            "{}_{}_{}_{}k", prefix, numKeys[i], keyName, batchSize / 1000.0);
-        addBenchmark(
-            name, batchSize, rowTypes[i], iterations, numKeys[i], testStdSort);
-      }
-    }
-  }
-
-  std::vector<RowTypePtr> bigintRowTypes(bool noPayload) {
-    if (noPayload) {
-      return {
-          ROW({BIGINT()}),
-          ROW({BIGINT(), BIGINT()}),
-          ROW({BIGINT(), BIGINT(), BIGINT()}),
-          ROW({BIGINT(), BIGINT(), BIGINT(), BIGINT()}),
-      };
-    } else {
-      return {
-          ROW({BIGINT(), VARCHAR(), VARCHAR()}),
-          ROW({BIGINT(), BIGINT(), VARCHAR(), VARCHAR()}),
-          ROW({BIGINT(), BIGINT(), BIGINT(), VARCHAR(), VARCHAR()}),
-          ROW({BIGINT(), BIGINT(), BIGINT(), BIGINT(), VARCHAR(), VARCHAR()}),
-      };
-    }
-  }
-
-  std::vector<RowTypePtr> smallintRowTypes(bool noPayload) {
-    if (noPayload) {
-      return {
-          ROW({SMALLINT()}),
-          ROW({SMALLINT(), SMALLINT()}),
-          ROW({SMALLINT(), SMALLINT(), SMALLINT()}),
-          ROW({SMALLINT(), SMALLINT(), SMALLINT(), SMALLINT()}),
-      };
-    } else {
-      return {
-          ROW({SMALLINT(), VARCHAR(), VARCHAR()}),
-          ROW({SMALLINT(), SMALLINT(), VARCHAR(), VARCHAR()}),
-          ROW({SMALLINT(), SMALLINT(), SMALLINT(), VARCHAR(), VARCHAR()}),
-          ROW(
-              {SMALLINT(),
-               SMALLINT(),
-               SMALLINT(),
-               SMALLINT(),
-               VARCHAR(),
-               VARCHAR()}),
-      };
-    }
-  }
-
-  void bigint(
-      bool noPayload,
-      int numIterations,
-      const std::vector<vector_size_t>& batchSizes) {
-    std::vector<RowTypePtr> rowTypes = bigintRowTypes(noPayload);
-    std::vector<int> numKeys = {1, 2, 3, 4};
-    benchmark(
-        noPayload ? "no-payload" : "payload",
-        "bigint",
-        batchSizes,
-        rowTypes,
-        numKeys,
-        numIterations);
-  }
-
-  void smallBigint() {
-    // For small dateset, iterations need to be large enough to ensure that the
-    // benchmark runs for enough time.
-    const auto iterations = 100'000;
-    const std::vector<vector_size_t> batchSizes = {10, 50, 100, 500};
-    bigint(true, iterations, batchSizes);
-  }
-
-  void smallBigintWithPayload() {
-    const auto iterations = 100'000;
-    const std::vector<vector_size_t> batchSizes = {10, 50, 100, 500};
-    bigint(false, iterations, batchSizes);
-  }
-
-  void largeBigint() {
-    const auto iterations = 10;
-    const std::vector<vector_size_t> batchSizes = {
-        1'000, 10'000, 100'000, 1'000'000};
-    bigint(true, iterations, batchSizes);
-  }
-
-  void largeBigintWithPayloads() {
-    const auto iterations = 10;
-    const std::vector<vector_size_t> batchSizes = {
-        1'000, 10'000, 100'000, 1'000'000};
-    bigint(false, iterations, batchSizes);
-  }
-
-  void hugeInt() {
-    const auto iterations = 10;
-    const std::vector<vector_size_t> batchSizes = {
-        1'000, 10'000, 100'000, 1'000'000};
-    std::vector<RowTypePtr> rowTypes = {
-        ROW({DECIMAL(23, 2)}),
-        ROW({DECIMAL(30, 2), DECIMAL(32, 5)}),
-        ROW({DECIMAL(19, 5), DECIMAL(34, 8), DECIMAL(38, 2)}),
-        ROW({DECIMAL(30, 2), DECIMAL(24, 3), DECIMAL(32, 5), DECIMAL(34, 3)}),
-    };
-    std::vector<int> numKeys = {1, 2, 3, 4};
-    benchmark(
-        "no-payloads", "hugeint", batchSizes, rowTypes, numKeys, iterations);
-  }
-
-  void largeVarchar() {
-    const auto iterations = 10;
-    const std::vector<vector_size_t> batchSizes = {
-        1'000, 10'000, 100'000, 1'000'000};
-    std::vector<RowTypePtr> rowTypes = {
-        ROW({VARCHAR()}),
-        ROW({VARCHAR(), VARCHAR()}),
-        ROW({VARCHAR(), VARCHAR(), VARCHAR()}),
-        ROW({VARCHAR(), VARCHAR(), VARCHAR(), VARCHAR()}),
-    };
-    std::vector<int> numKeys = {1, 2, 3, 4};
-    benchmark(
-        "no-payloads", "varchar", batchSizes, rowTypes, numKeys, iterations);
-  }
-
-  void smallint(
-      bool noPayload,
-      int numIterations,
-      const std::vector<vector_size_t>& batchSizes) {
-    std::vector<RowTypePtr> rowTypes = smallintRowTypes(noPayload);
-    std::vector<int> numKeys = {1, 2, 3, 4};
-    benchmark(
-        noPayload ? "no-payload" : "payload",
-        "smallint",
-        batchSizes,
-        rowTypes,
-        numKeys,
-        numIterations);
-  }
-
-  void smallSmallint() {
-    // For small dateset, iterations need to be large enough to ensure that the
-    // benchmark runs for enough time.
-    const auto iterations = 100'000;
-    const std::vector<vector_size_t> batchSizes = {10, 50, 100, 500};
-    smallint(true, iterations, batchSizes);
-  }
-
-  void smallSmallintWithPayload() {
-    const auto iterations = 100'000;
-    const std::vector<vector_size_t> batchSizes = {10, 50, 100, 500};
-    smallint(false, iterations, batchSizes);
-  }
-
-  void largeSmallint() {
-    const auto iterations = 10;
-    const std::vector<vector_size_t> batchSizes = {
-        1'000, 10'000, 100'000, 1'000'000};
-    smallint(true, iterations, batchSizes);
-  }
-
-  void largeSmallintWithPayloads() {
-    const auto iterations = 10;
-    const std::vector<vector_size_t> batchSizes = {
-        1'000, 10'000, 100'000, 1'000'000};
-    smallint(false, iterations, batchSizes);
   }
 
  private:
@@ -396,16 +192,13 @@ int main(int argc, char** argv) {
 
   PrefixSortBenchmark bm(leafPool.get());
 
-  bm.smallBigint();
-  bm.largeBigint();
-  bm.hugeInt();
-  bm.largeBigintWithPayloads();
-  bm.smallBigintWithPayload();
-  bm.largeVarchar();
-  bm.smallSmallint();
-  bm.largeSmallint();
-  bm.smallSmallintWithPayload();
-  bm.largeSmallintWithPayloads();
+  OrderByBenchmarkUtil::addBenchmarks([&](const std::string& testName,
+                                          size_t numRows,
+                                          const RowTypePtr& rowType,
+                                          int iterations,
+                                          int numKeys) {
+    bm.addBenchmark(testName, numRows, rowType, iterations, numKeys);
+  });
 
   folly::runBenchmarks();
   return 0;

--- a/velox/exec/benchmarks/PrefixSortBenchmark.cpp
+++ b/velox/exec/benchmarks/PrefixSortBenchmark.cpp
@@ -46,7 +46,7 @@ class TestCase {
     }
     data_ = std::make_unique<RowContainer>(keyTypes, dependentTypes, pool);
     RowVectorPtr sortedRows =
-        OrderByBenchmarkUtil::fuzzRows(rowType, numRows, numKeys, pool_);
+        OrderByBenchmarkUtil::fuzzRows(rowType, numRows, pool_);
     storeRows(numRows, sortedRows);
 
     // Initialize CompareFlags, it could be same for each key in benchmark.

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -253,6 +253,16 @@ RowVectorPtr AssertQueryBuilder::copyResults(
   return copy;
 }
 
+uint64_t AssertQueryBuilder::countResults(std::shared_ptr<Task>& task) {
+  auto [cursor, results] = readCursor();
+  uint64_t count = 0;
+  for (const auto& result : results) {
+    count += result->size();
+  }
+  task = cursor->task();
+  return count;
+}
+
 std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>>
 AssertQueryBuilder::readCursor() {
   VELOX_CHECK_NOT_NULL(params_.planNode);

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -253,7 +253,7 @@ RowVectorPtr AssertQueryBuilder::copyResults(
   return copy;
 }
 
-uint64_t AssertQueryBuilder::countResults(std::shared_ptr<Task>& task) {
+uint64_t AssertQueryBuilder::runWithoutResults(std::shared_ptr<Task>& task) {
   auto [cursor, results] = readCursor();
   uint64_t count = 0;
   for (const auto& result : results) {

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -183,6 +183,9 @@ class AssertQueryBuilder {
       memory::MemoryPool* pool,
       std::shared_ptr<Task>& task);
 
+  /// Run the query and return the number of result rows.
+  uint64_t countResults(std::shared_ptr<Task>& task);
+
  private:
   std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>>
   readCursor();

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -184,7 +184,7 @@ class AssertQueryBuilder {
       std::shared_ptr<Task>& task);
 
   /// Run the query and return the number of result rows.
-  uint64_t countResults(std::shared_ptr<Task>& task);
+  uint64_t runWithoutResults(std::shared_ptr<Task>& task);
 
  private:
   std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>>


### PR DESCRIPTION
To track the OrderBy performance and measure order by optimization performance, add this benchmark.

The key number varies with 1 to 4, benchmark result is:
```
Key Type | Dataset Size | Time(No Payload)   |  Time(With Payload)             |
---------|--------------|--------------------|-------------------------------------|
 bigint  | 0.01k        | 6.63s ~ 7.32s      | 7.50s ~ 7.95s                   |
 bigint  | 0.05k        | 7.03s ~ 7.75s      | 7.89s ~ 8.57s                   |
 bigint  | 1k           | 7.33s ~ 8.42s      | 8.33s ~ 9.44s                   |
 bigint  | 10k          | 9.83s ~ 12.26s     | 13.44s ~ 16.00s                 |
 bigint  | 100k         | 1.10ms ~ 1.60ms    | 1.89ms ~ 2.95ms                 |
 bigint  | 1000k        | 6.14ms ~ 10.07ms   | 15.48ms ~ 23.55ms               |
 varchar | 1k           | 1.89ms ~ 2.95ms    |                                 |
 varchar | 10k          | 15.48ms ~ 23.55ms  |                                 |
 varchar | 100k         | 85.17ms ~ 134.06ms |                                 |
 varchar | 1000k        | 1.31s ~ 2.06s      |                                 |
```
We can run this benchmark by `./velox_orderby_benchmark` or run single benchmark `./velox_orderby_benchmark -bm_estimate_time -bm_regex OrderBy_no-payload_1_bigint_0.01k`

From the printed metrics, we can see addInput(storeRows to RowContainer) and getOutput(extract column from RowContainer) expires most of the time, the noMoreInput(Finish time, do prefixsort) is little.
```
OrderBy_no-payload_1_bigint_0.01k                            6.52s   153.38m
Total 6.40s Input 179.60ms Output 198.20ms Finish 67.48ms
OrderBy_no-payloads_1_varchar_1k                            1.94ms    515.31
Total 2.32ms Input 261.25us Output 99.17us Finish 7.59us
```