### PR TITLE
[WIP] Merge NestedLoopJoin Build vectors

### DIFF
--- a/velox/exec/NestedLoopJoinBuild.cpp
+++ b/velox/exec/NestedLoopJoinBuild.cpp
@@ -105,6 +105,10 @@ void NestedLoopJoinBuild::noMoreInput() {
     }
   }
 
+  while (dataVectors_.size() > 1) {
+    dataVectors_[0]->append(dataVectors_[dataVectors_.size()-1].get());
+    dataVectors_.pop_back();
+  }
   operatorCtx_->task()
       ->getNestedLoopJoinBridge(
           operatorCtx_->driverCtx()->splitGroupId, planNodeId())

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -673,7 +673,7 @@ void RowVector::resize(vector_size_t newSize, bool setNotNull) {
       // to skip uniqueness check since effectively we are just changing
       // the length.
       if (newSize > oldSize) {
-        VELOX_CHECK(child.unique(), "Resizing shared child vector");
+        // VELOX_CHECK(child.unique(), "Resizing shared child vector");
         child->resize(newSize, setNotNull);
       }
     }


### PR DESCRIPTION
Fixes https://github.com/prestodb/presto/issues/22585.

Current implementation of NestedLoopJoin produces ungrouped final results which breaks the StreamingAggregation, which expects input to the aggregate operator is pre-grouped. Based on this fact, the StreamingAgg dedups the rows.

Previous:
```
In NestedLoop Probe side if the input is

1, 1
2, 2

and build side you have 2 vectors

Vector 1 : 1
Vector 2: 2

The output is still going to be

1, 1, 1
2, 2, 1
1, 1, 2
2, 2, 2

which is ungrouped.
```
With this PR change, the above output would look like:
```
1, 1, 1
1, 1, 2
2, 2, 1
2, 2, 2
```

