### PR TITLE
Fix data verification for Table Writer Fuzzer

### DIFF
--- a/velox/exec/fuzzer/FuzzerUtil.cpp
+++ b/velox/exec/fuzzer/FuzzerUtil.cpp
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 #include "velox/exec/fuzzer/FuzzerUtil.h"
+#include <filesystem>
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
@@ -47,6 +47,15 @@ std::vector<Split> makeSplits(
     splits.push_back(makeSplit(filePath));
   }
 
+  return splits;
+}
+
+std::vector<Split> makeSplits(const std::string& directory) {
+  std::vector<Split> splits;
+  for (auto const& p : std::filesystem::directory_iterator{directory}) {
+    VELOX_CHECK(!p.is_directory());
+    splits.emplace_back(makeSplit(p.path().string()));
+  }
   return splits;
 }
 

--- a/velox/exec/fuzzer/FuzzerUtil.h
+++ b/velox/exec/fuzzer/FuzzerUtil.h
@@ -32,6 +32,12 @@ std::vector<Split> makeSplits(
     const std::string& path,
     const std::shared_ptr<memory::MemoryPool>& writerPool);
 
+/// Create splits from files in a directory. Don't support nested directory.
+///
+/// TODO: Add support for nested directory, need to parse directory information
+/// into split schema.
+std::vector<Split> makeSplits(const std::string& directory);
+
 /// Create a split from an exsiting file.
 Split makeSplit(const std::string& filePath);
 


### PR DESCRIPTION
When verifying data, now it uses the inputVector to construct split thus the 
comparison is always true.
Change to construct the split from files written.