### PR TITLE
Fix HashStringAllocator::clear

### DIFF
--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -90,7 +90,10 @@ void HashStringAllocator::clear() {
   freeBytes_ = 0;
   std::fill(std::begin(freeNonEmpty_), std::end(freeNonEmpty_), 0);
   for (auto& pair : allocationsFromPool_) {
-    pool()->free(pair.first, pair.second);
+    const auto size = pair.second;
+    pool()->free(pair.first, size);
+    sizeFromPool_ -= size;
+    cumulativeBytes_ -= size;
   }
   allocationsFromPool_.clear();
   for (auto i = 0; i < kNumFreeLists; ++i) {

--- a/velox/common/memory/tests/HashStringAllocatorTest.cpp
+++ b/velox/common/memory/tests/HashStringAllocatorTest.cpp
@@ -670,5 +670,13 @@ TEST_F(HashStringAllocatorTest, storeStringFast) {
   allocator_->checkConsistency();
 }
 
+TEST_F(HashStringAllocatorTest, clear) {
+  allocator_->allocate(HashStringAllocator::kMinAlloc);
+  allocator_->allocate(HashStringAllocator::kMaxAlloc + 1);
+  EXPECT_GT(allocator_->retainedSize(), 0);
+  allocator_->clear();
+  EXPECT_EQ(allocator_->retainedSize(), 0);
+}
+
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
Summary: Decrement memory counters as in HashStringAllocator::freeToPool

Differential Revision: D58171132


