### PR TITLE
Make 'Duplicate key' a user error in split_to_map

### DIFF
--- a/velox/functions/prestosql/SplitToMap.h
+++ b/velox/functions/prestosql/SplitToMap.h
@@ -110,7 +110,7 @@ struct SplitToMapFunction {
     const auto key = std::string_view(entry.data(), delimiterPos);
     VELOX_RETURN_IF(
         !keys.insert(key).second,
-        Status::UnknownError("Duplicate keys ({}) are not allowed.", key));
+        Status::UserError("Duplicate keys ({}) are not allowed.", key));
 
     const auto value = StringView(
         entry.data() + delimiterPos + 1, entry.size() - delimiterPos - 1);


### PR DESCRIPTION
Summary: Presto function split_to_map incorrectly reported 'duplicate key' as system error. This should be a user-error suppressible by TRY.

Differential Revision: D58173012


