### PR TITLE
Add from_iso8601_timestamp Presto function

### DIFF
--- a/velox/docs/functions/presto/datetime.rst
+++ b/velox/docs/functions/presto/datetime.rst
@@ -95,25 +95,52 @@ Date and Time Functions
 .. function:: from_iso8601_date(string) -> date
 
     Parses the ISO 8601 formatted ``string`` into a ``date``.
-    ISO 8601 ``string`` can be formatted as any of the following:
-    ``[+-][Y]Y*``
 
-    ``[+-][Y]Y*-[M]M*``
+    Accepts formats described by the following syntax::
 
-    ``[+-][Y]Y*-[M]M*-[D]D*``
+       date = yyyy ['-' MM ['-' dd]]
 
-    ``[+-][Y]Y*-[M]M*-[D]D* *``
+    Examples of valid input strings:
 
-    Year value must contain at least one digit, and may contain up to six digits.
-    Month and day values are optional and may each contain one or two digits.
+    * '2012'
+    * '2012-4'
+    * '2012-04'
+    * '2012-4-7'
+    * '2012-04-07'
+    * '2012-04-07   '
 
-    Examples of supported input strings:
-    "2012",
-    "2012-4",
-    "2012-04",
-    "2012-4-7",
-    "2012-04-07",
-    "2012-04-07  ”
+.. function:: from_iso8601_timestamp(string) -> timestamp with time zone
+
+    Parses the ISO 8601 formatted string into a timestamp with time zone.
+
+    Accepts formats described by the following syntax::
+
+        datetime          = time | date-opt-time
+        time              = 'T' time-element [offset]
+        date-opt-time     = date-element ['T' [time-element] [offset]]
+        date-element      = yyyy ['-' MM ['-' dd]]
+        time-element      = HH [minute-element] | [fraction]
+        minute-element    = ':' mm [second-element] | [fraction]
+        second-element    = ':' ss [fraction]
+        fraction          = ('.' | ',') digit+
+        offset            = 'Z' | (('+' | '-') HH [':' mm [':' ss [('.' | ',') SSS]]])
+
+    Examples of valid input strings:
+
+    * '2012'
+    * '2012-4'
+    * '2012-04'
+    * '2012-4-7'
+    * '2012-04-07'
+    * '2012-04-07   '
+    * '2012-04T01:02'
+    * 'T01:02:34'
+    * 'T01:02:34,123'
+    * '2012-04-07T01:02:34'
+    * '2012-04-07T01:02:34.123'
+    * '2012-04-07T01:02:34,123'
+    * '2012-04-07T01:02:34.123Z'
+    * '2012-04-07T01:02:34.123-05:00'
 
 .. function:: from_unixtime(unixtime) -> timestamp
 

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -4195,10 +4195,12 @@ TEST_F(TableScanTest, timestampPartitionKey) {
           makeFlatVector<Timestamp>(
               std::end(inputs) - std::begin(inputs),
               [&](auto i) {
-                auto t = util::fromTimestampString(inputs[i]).thenOrThrow(
-                    folly::identity, [&](const Status& status) {
-                      VELOX_USER_FAIL("{}", status.message());
-                    });
+                auto t = util::fromTimestampString(
+                             inputs[i], util::TimestampParseMode::kPrestoCast)
+                             .thenOrThrow(
+                                 folly::identity, [&](const Status& status) {
+                                   VELOX_USER_FAIL("{}", status.message());
+                                 });
                 t.toGMT(Timestamp::defaultTimezone());
                 return t;
               }),

--- a/velox/expression/ConstantExpr.cpp
+++ b/velox/expression/ConstantExpr.cpp
@@ -175,14 +175,20 @@ void appendSqlLiteral(
     }
     case TypeKind::HUGEINT:
       [[fallthrough]];
-    case TypeKind::TIMESTAMP:
-      [[fallthrough]];
     case TypeKind::REAL:
       [[fallthrough]];
     case TypeKind::DOUBLE:
       out << "'" << vector.wrappedVector()->toString(vector.wrappedIndex(row))
           << "'::" << vector.type()->toString();
       break;
+    case TypeKind::TIMESTAMP: {
+      TimestampToStringOptions options;
+      options.dateTimeSeparator = ' ';
+      const auto ts =
+          vector.wrappedVector()->as<SimpleVector<Timestamp>>()->valueAt(row);
+      out << "'" << ts.toString(options) << "'::" << vector.type()->toString();
+      break;
+    }
     case TypeKind::VARCHAR:
       appendSqlString(
           vector.wrappedVector()->toString(vector.wrappedIndex(row)), out);

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -34,8 +34,8 @@ PrestoCastHooks::PrestoCastHooks(const core::QueryConfig& config)
 
 Expected<Timestamp> PrestoCastHooks::castStringToTimestamp(
     const StringView& view) const {
-  const auto conversionResult =
-      util::fromTimestampWithTimezoneString(view.data(), view.size());
+  const auto conversionResult = util::fromTimestampWithTimezoneString(
+      view.data(), view.size(), util::TimestampParseMode::kPrestoCast);
   if (conversionResult.hasError()) {
     return folly::makeUnexpected(conversionResult.error());
   }

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -609,6 +609,11 @@ TEST_F(CastExprTest, stringToTimestamp) {
       Timestamp(946729316, 0),
   };
   testCast<std::string, Timestamp>("timestamp", input, expected);
+
+  VELOX_ASSERT_THROW(
+      (evaluateOnce<Timestamp, std::string>(
+          "cast(c0 as timestamp)", "1970-01-01T00:00")),
+      "Cannot cast VARCHAR '1970-01-01T00:00' to TIMESTAMP. Unable to parse timestamp value");
 }
 
 TEST_F(CastExprTest, timestampToString) {

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2660,7 +2660,7 @@ TEST_P(ParameterizedExprTest, constantToSql) {
 
   ASSERT_EQ(
       toSql(Timestamp(123'456, 123'000)),
-      "'1970-01-02T10:17:36.000123000'::TIMESTAMP");
+      "'1970-01-02 10:17:36.000123000'::TIMESTAMP");
   ASSERT_EQ(toSql(variant::null(TypeKind::TIMESTAMP)), "NULL::TIMESTAMP");
 
   ASSERT_EQ(

--- a/velox/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/velox/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -59,9 +59,11 @@ class DateTimeFormatterTest : public testing::Test {
   };
 
   static Timestamp fromTimestampString(const StringView& timestamp) {
-    return util::fromTimestampString(timestamp).thenOrThrow(
-        folly::identity,
-        [&](const Status& status) { VELOX_USER_FAIL("{}", status.message()); });
+    return util::fromTimestampString(
+               timestamp, util::TimestampParseMode::kPrestoCast)
+        .thenOrThrow(folly::identity, [&](const Status& status) {
+          VELOX_USER_FAIL("{}", status.message());
+        });
   }
 
   void testTokenRange(

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -197,6 +197,8 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "date_parse"});
   registerFunction<FromIso8601Date, Date, Varchar>(
       {prefix + "from_iso8601_date"});
+  registerFunction<FromIso8601Timestamp, TimestampWithTimezone, Varchar>(
+      {prefix + "from_iso8601_timestamp"});
   registerFunction<CurrentDateFunction, Date>({prefix + "current_date"});
   registerFunction<ToISO8601Function, Varchar, Date>({prefix + "to_iso8601"});
   registerFunction<

--- a/velox/functions/prestosql/tests/ComparisonsTest.cpp
+++ b/velox/functions/prestosql/tests/ComparisonsTest.cpp
@@ -115,15 +115,10 @@ TEST_F(ComparisonsTest, betweenTimestamp) {
     auto expr =
         "c0 between cast(\'2019-02-28 10:00:00.500\' as timestamp) and"
         " cast(\'2019-02-28 10:00:00.600\' as timestamp)";
-    if (s.has_value()) {
-      const auto ts =
-          util::fromTimestampString((StringView)s.value())
-              .thenOrThrow(folly::identity, [&](const Status& status) {
-                VELOX_USER_FAIL("{}", status.message());
-              });
-      return evaluateOnce<bool>(expr, std::optional(ts));
+    if (!s.has_value()) {
+      return evaluateOnce<bool>(expr, std::optional<Timestamp>());
     }
-    return evaluateOnce<bool>(expr, std::optional<Timestamp>());
+    return evaluateOnce<bool>(expr, std::optional{parseTimestamp(s.value())});
   };
 
   EXPECT_EQ(std::nullopt, between(std::nullopt));

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include <optional>
-#include <string>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/external/date/tz.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
@@ -81,12 +79,6 @@ class DateTimeFunctionsTest : public functions::test::FunctionBaseTest {
     queryCtx_->testingOverrideConfigUnsafe({
         {core::QueryConfig::kAdjustTimestampToTimezone, "false"},
     });
-  }
-
-  static Timestamp fromTimestampString(const StringView& timestamp) {
-    return util::fromTimestampString(timestamp).thenOrThrow(
-        folly::identity,
-        [&](const Status& status) { VELOX_USER_FAIL("{}", status.message()); });
   }
 
  public:
@@ -2375,50 +2367,50 @@ TEST_F(DateTimeFunctionsTest, dateDiffTimestamp) {
       60 * 1000 + 500,
       dateDiff(
           "millisecond",
-          fromTimestampString("2019-02-28 10:00:00.500"),
-          fromTimestampString("2019-02-28 10:01:01.000")));
+          parseTimestamp("2019-02-28 10:00:00.500"),
+          parseTimestamp("2019-02-28 10:01:01.000")));
   EXPECT_EQ(
       60 * 60 * 24,
       dateDiff(
           "second",
-          fromTimestampString("2019-02-28 10:00:00.500"),
-          fromTimestampString("2019-03-01 10:00:00.500")));
+          parseTimestamp("2019-02-28 10:00:00.500"),
+          parseTimestamp("2019-03-01 10:00:00.500")));
   EXPECT_EQ(
       60 * 24,
       dateDiff(
           "minute",
-          fromTimestampString("2019-02-28 10:00:00.500"),
-          fromTimestampString("2019-03-01 10:00:00.500")));
+          parseTimestamp("2019-02-28 10:00:00.500"),
+          parseTimestamp("2019-03-01 10:00:00.500")));
   EXPECT_EQ(
       24,
       dateDiff(
           "hour",
-          fromTimestampString("2019-02-28 10:00:00.500"),
-          fromTimestampString("2019-03-01 10:00:00.500")));
+          parseTimestamp("2019-02-28 10:00:00.500"),
+          parseTimestamp("2019-03-01 10:00:00.500")));
   EXPECT_EQ(
       1,
       dateDiff(
           "day",
-          fromTimestampString("2019-02-28 10:00:00.500"),
-          fromTimestampString("2019-03-01 10:00:00.500")));
+          parseTimestamp("2019-02-28 10:00:00.500"),
+          parseTimestamp("2019-03-01 10:00:00.500")));
   EXPECT_EQ(
       12 + 1,
       dateDiff(
           "month",
-          fromTimestampString("2019-02-28 10:00:00.500"),
-          fromTimestampString("2020-03-28 10:00:00.500")));
+          parseTimestamp("2019-02-28 10:00:00.500"),
+          parseTimestamp("2020-03-28 10:00:00.500")));
   EXPECT_EQ(
       4,
       dateDiff(
           "quarter",
-          fromTimestampString("2019-02-28 10:00:00.500"),
-          fromTimestampString("2020-02-28 10:00:00.500")));
+          parseTimestamp("2019-02-28 10:00:00.500"),
+          parseTimestamp("2020-02-28 10:00:00.500")));
   EXPECT_EQ(
       1,
       dateDiff(
           "year",
-          fromTimestampString("2019-02-28 10:00:00.500"),
-          fromTimestampString("2020-02-28 10:00:00.500")));
+          parseTimestamp("2019-02-28 10:00:00.500"),
+          parseTimestamp("2020-02-28 10:00:00.500")));
 
   // Test for daylight saving. Daylight saving in US starts at 2021-03-14
   // 02:00:00 PST.
@@ -2427,50 +2419,50 @@ TEST_F(DateTimeFunctionsTest, dateDiffTimestamp) {
       1000 * 60 * 60 * 24,
       dateDiff(
           "millisecond",
-          fromTimestampString("2021-03-14 01:00:00.000"),
-          fromTimestampString("2021-03-15 01:00:00.000")));
+          parseTimestamp("2021-03-14 01:00:00.000"),
+          parseTimestamp("2021-03-15 01:00:00.000")));
   EXPECT_EQ(
       60 * 60 * 24,
       dateDiff(
           "second",
-          fromTimestampString("2021-03-14 01:00:00.000"),
-          fromTimestampString("2021-03-15 01:00:00.000")));
+          parseTimestamp("2021-03-14 01:00:00.000"),
+          parseTimestamp("2021-03-15 01:00:00.000")));
   EXPECT_EQ(
       60 * 24,
       dateDiff(
           "minute",
-          fromTimestampString("2021-03-14 01:00:00.000"),
-          fromTimestampString("2021-03-15 01:00:00.000")));
+          parseTimestamp("2021-03-14 01:00:00.000"),
+          parseTimestamp("2021-03-15 01:00:00.000")));
   EXPECT_EQ(
       24,
       dateDiff(
           "hour",
-          fromTimestampString("2021-03-14 01:00:00.000"),
-          fromTimestampString("2021-03-15 01:00:00.000")));
+          parseTimestamp("2021-03-14 01:00:00.000"),
+          parseTimestamp("2021-03-15 01:00:00.000")));
   EXPECT_EQ(
       1,
       dateDiff(
           "day",
-          fromTimestampString("2021-03-14 01:00:00.000"),
-          fromTimestampString("2021-03-15 01:00:00.000")));
+          parseTimestamp("2021-03-14 01:00:00.000"),
+          parseTimestamp("2021-03-15 01:00:00.000")));
   EXPECT_EQ(
       1,
       dateDiff(
           "month",
-          fromTimestampString("2021-03-14 01:00:00.000"),
-          fromTimestampString("2021-04-14 01:00:00.000")));
+          parseTimestamp("2021-03-14 01:00:00.000"),
+          parseTimestamp("2021-04-14 01:00:00.000")));
   EXPECT_EQ(
       1,
       dateDiff(
           "quarter",
-          fromTimestampString("2021-03-14 01:00:00.000"),
-          fromTimestampString("2021-06-14 01:00:00.000")));
+          parseTimestamp("2021-03-14 01:00:00.000"),
+          parseTimestamp("2021-06-14 01:00:00.000")));
   EXPECT_EQ(
       1,
       dateDiff(
           "year",
-          fromTimestampString("2021-03-14 01:00:00.000"),
-          fromTimestampString("2022-03-14 01:00:00.000")));
+          parseTimestamp("2021-03-14 01:00:00.000"),
+          parseTimestamp("2022-03-14 01:00:00.000")));
 
   // When adjust_timestamp_to_timezone is on, respect Daylight saving in the
   // session time zone
@@ -2480,126 +2472,126 @@ TEST_F(DateTimeFunctionsTest, dateDiffTimestamp) {
       1000 * 60 * 60 * 24,
       dateDiff(
           "millisecond",
-          fromTimestampString("2021-03-14 09:00:00.000"),
-          fromTimestampString("2021-03-15 09:00:00.000")));
+          parseTimestamp("2021-03-14 09:00:00.000"),
+          parseTimestamp("2021-03-15 09:00:00.000")));
   EXPECT_EQ(
       60 * 60 * 24,
       dateDiff(
           "second",
-          fromTimestampString("2021-03-14 09:00:00.000"),
-          fromTimestampString("2021-03-15 09:00:00.000")));
+          parseTimestamp("2021-03-14 09:00:00.000"),
+          parseTimestamp("2021-03-15 09:00:00.000")));
   EXPECT_EQ(
       60 * 24,
       dateDiff(
           "minute",
-          fromTimestampString("2021-03-14 09:00:00.000"),
-          fromTimestampString("2021-03-15 09:00:00.000")));
+          parseTimestamp("2021-03-14 09:00:00.000"),
+          parseTimestamp("2021-03-15 09:00:00.000")));
   EXPECT_EQ(
       24,
       dateDiff(
           "hour",
-          fromTimestampString("2021-03-14 09:00:00.000"),
-          fromTimestampString("2021-03-15 09:00:00.000")));
+          parseTimestamp("2021-03-14 09:00:00.000"),
+          parseTimestamp("2021-03-15 09:00:00.000")));
   EXPECT_EQ(
       1,
       dateDiff(
           "day",
-          fromTimestampString("2021-03-14 09:00:00.000"),
-          fromTimestampString("2021-03-15 09:00:00.000")));
+          parseTimestamp("2021-03-14 09:00:00.000"),
+          parseTimestamp("2021-03-15 09:00:00.000")));
   EXPECT_EQ(
       1,
       dateDiff(
           "month",
-          fromTimestampString("2021-03-14 09:00:00.000"),
-          fromTimestampString("2021-04-14 09:00:00.000")));
+          parseTimestamp("2021-03-14 09:00:00.000"),
+          parseTimestamp("2021-04-14 09:00:00.000")));
   EXPECT_EQ(
       1,
       dateDiff(
           "quarter",
-          fromTimestampString("2021-03-14 09:00:00.000"),
-          fromTimestampString("2021-06-14 09:00:00.000")));
+          parseTimestamp("2021-03-14 09:00:00.000"),
+          parseTimestamp("2021-06-14 09:00:00.000")));
   EXPECT_EQ(
       1,
       dateDiff(
           "year",
-          fromTimestampString("2021-03-14 09:00:00.000"),
-          fromTimestampString("2022-03-14 09:00:00.000")));
+          parseTimestamp("2021-03-14 09:00:00.000"),
+          parseTimestamp("2022-03-14 09:00:00.000")));
 
   // Test for respecting the last day of a year-month
   EXPECT_EQ(
       365 + 30,
       dateDiff(
           "day",
-          fromTimestampString("2019-01-30 10:00:00.500"),
-          fromTimestampString("2020-02-29 10:00:00.500")));
+          parseTimestamp("2019-01-30 10:00:00.500"),
+          parseTimestamp("2020-02-29 10:00:00.500")));
   EXPECT_EQ(
       12 + 1,
       dateDiff(
           "month",
-          fromTimestampString("2019-01-30 10:00:00.500"),
-          fromTimestampString("2020-02-29 10:00:00.500")));
+          parseTimestamp("2019-01-30 10:00:00.500"),
+          parseTimestamp("2020-02-29 10:00:00.500")));
   EXPECT_EQ(
       1,
       dateDiff(
           "quarter",
-          fromTimestampString("2019-11-30 10:00:00.500"),
-          fromTimestampString("2020-02-29 10:00:00.500")));
+          parseTimestamp("2019-11-30 10:00:00.500"),
+          parseTimestamp("2020-02-29 10:00:00.500")));
   EXPECT_EQ(
       10,
       dateDiff(
           "year",
-          fromTimestampString("2020-02-29 10:00:00.500"),
-          fromTimestampString("2030-02-28 10:00:00.500")));
+          parseTimestamp("2020-02-29 10:00:00.500"),
+          parseTimestamp("2030-02-28 10:00:00.500")));
 
   // Test for negative difference
   EXPECT_EQ(
       -60 * 60 * 24 * 1000 - 500,
       dateDiff(
           "millisecond",
-          fromTimestampString("2020-03-01 00:00:00.500"),
-          fromTimestampString("2020-02-29 00:00:00.000")));
+          parseTimestamp("2020-03-01 00:00:00.500"),
+          parseTimestamp("2020-02-29 00:00:00.000")));
   EXPECT_EQ(
       -60 * 60 * 24,
       dateDiff(
           "second",
-          fromTimestampString("2020-03-01 00:00:00.500"),
-          fromTimestampString("2020-02-29 00:00:00.500")));
+          parseTimestamp("2020-03-01 00:00:00.500"),
+          parseTimestamp("2020-02-29 00:00:00.500")));
   EXPECT_EQ(
       -60 * 24,
       dateDiff(
           "minute",
-          fromTimestampString("2020-03-01 00:00:00.500"),
-          fromTimestampString("2020-02-29 00:00:00.500")));
+          parseTimestamp("2020-03-01 00:00:00.500"),
+          parseTimestamp("2020-02-29 00:00:00.500")));
   EXPECT_EQ(
       -24,
       dateDiff(
           "hour",
-          fromTimestampString("2020-03-01 00:00:00.500"),
-          fromTimestampString("2020-02-29 00:00:00.500")));
+          parseTimestamp("2020-03-01 00:00:00.500"),
+          parseTimestamp("2020-02-29 00:00:00.500")));
   EXPECT_EQ(
       -366,
       dateDiff(
           "day",
-          fromTimestampString("2020-02-29 10:00:00.500"),
-          fromTimestampString("2019-02-28 10:00:00.500")));
+          parseTimestamp("2020-02-29 10:00:00.500"),
+          parseTimestamp("2019-02-28 10:00:00.500")));
   EXPECT_EQ(
       -12,
       dateDiff(
           "month",
-          fromTimestampString("2020-02-29 10:00:00.500"),
-          fromTimestampString("2019-02-28 10:00:00.500")));
+          parseTimestamp("2020-02-29 10:00:00.500"),
+          parseTimestamp("2019-02-28 10:00:00.500")));
   EXPECT_EQ(
       -4,
       dateDiff(
           "quarter",
-          fromTimestampString("2020-02-29 10:00:00.500"),
-          fromTimestampString("2019-02-28 10:00:00.500")));
+          parseTimestamp("2020-02-29 10:00:00.500"),
+          parseTimestamp("2019-02-28 10:00:00.500")));
   EXPECT_EQ(
       -2,
       dateDiff(
           "year",
-          fromTimestampString("2020-02-29 10:00:00.500"),
-          fromTimestampString("2018-02-28 10:00:00.500")));
+          parseTimestamp("2020-02-29 10:00:00.500"),
+          parseTimestamp("2018-02-28 10:00:00.500")));
 }
 
 TEST_F(DateTimeFunctionsTest, dateDiffTimestampWithTimezone) {
@@ -2748,97 +2740,93 @@ TEST_F(DateTimeFunctionsTest, parseDatetime) {
 
 TEST_F(DateTimeFunctionsTest, formatDateTime) {
   // era test cases - 'G'
-  EXPECT_EQ("AD", formatDatetime(fromTimestampString("1970-01-01"), "G"));
-  EXPECT_EQ("BC", formatDatetime(fromTimestampString("-100-01-01"), "G"));
-  EXPECT_EQ("BC", formatDatetime(fromTimestampString("0-01-01"), "G"));
-  EXPECT_EQ("AD", formatDatetime(fromTimestampString("01-01-01"), "G"));
-  EXPECT_EQ("AD", formatDatetime(fromTimestampString("01-01-01"), "GGGGGGG"));
+  EXPECT_EQ("AD", formatDatetime(parseTimestamp("1970-01-01"), "G"));
+  EXPECT_EQ("BC", formatDatetime(parseTimestamp("-100-01-01"), "G"));
+  EXPECT_EQ("BC", formatDatetime(parseTimestamp("0-01-01"), "G"));
+  EXPECT_EQ("AD", formatDatetime(parseTimestamp("01-01-01"), "G"));
+  EXPECT_EQ("AD", formatDatetime(parseTimestamp("01-01-01"), "GGGGGGG"));
 
   // century of era test cases - 'C'
-  EXPECT_EQ("19", formatDatetime(fromTimestampString("1900-01-01"), "C"));
-  EXPECT_EQ("19", formatDatetime(fromTimestampString("1955-01-01"), "C"));
-  EXPECT_EQ("20", formatDatetime(fromTimestampString("2000-01-01"), "C"));
-  EXPECT_EQ("20", formatDatetime(fromTimestampString("2020-01-01"), "C"));
-  EXPECT_EQ("0", formatDatetime(fromTimestampString("0-01-01"), "C"));
-  EXPECT_EQ("1", formatDatetime(fromTimestampString("-100-01-01"), "C"));
-  EXPECT_EQ("19", formatDatetime(fromTimestampString("-1900-01-01"), "C"));
-  EXPECT_EQ(
-      "000019", formatDatetime(fromTimestampString("1955-01-01"), "CCCCCC"));
+  EXPECT_EQ("19", formatDatetime(parseTimestamp("1900-01-01"), "C"));
+  EXPECT_EQ("19", formatDatetime(parseTimestamp("1955-01-01"), "C"));
+  EXPECT_EQ("20", formatDatetime(parseTimestamp("2000-01-01"), "C"));
+  EXPECT_EQ("20", formatDatetime(parseTimestamp("2020-01-01"), "C"));
+  EXPECT_EQ("0", formatDatetime(parseTimestamp("0-01-01"), "C"));
+  EXPECT_EQ("1", formatDatetime(parseTimestamp("-100-01-01"), "C"));
+  EXPECT_EQ("19", formatDatetime(parseTimestamp("-1900-01-01"), "C"));
+  EXPECT_EQ("000019", formatDatetime(parseTimestamp("1955-01-01"), "CCCCCC"));
 
   // year of era test cases - 'Y'
-  EXPECT_EQ("1970", formatDatetime(fromTimestampString("1970-01-01"), "Y"));
-  EXPECT_EQ("2020", formatDatetime(fromTimestampString("2020-01-01"), "Y"));
-  EXPECT_EQ("1", formatDatetime(fromTimestampString("0-01-01"), "Y"));
-  EXPECT_EQ("101", formatDatetime(fromTimestampString("-100-01-01"), "Y"));
-  EXPECT_EQ("70", formatDatetime(fromTimestampString("1970-01-01"), "YY"));
-  EXPECT_EQ("70", formatDatetime(fromTimestampString("-1970-01-01"), "YY"));
-  EXPECT_EQ("1948", formatDatetime(fromTimestampString("1948-01-01"), "YYY"));
-  EXPECT_EQ("1234", formatDatetime(fromTimestampString("1234-01-01"), "YYYY"));
+  EXPECT_EQ("1970", formatDatetime(parseTimestamp("1970-01-01"), "Y"));
+  EXPECT_EQ("2020", formatDatetime(parseTimestamp("2020-01-01"), "Y"));
+  EXPECT_EQ("1", formatDatetime(parseTimestamp("0-01-01"), "Y"));
+  EXPECT_EQ("101", formatDatetime(parseTimestamp("-100-01-01"), "Y"));
+  EXPECT_EQ("70", formatDatetime(parseTimestamp("1970-01-01"), "YY"));
+  EXPECT_EQ("70", formatDatetime(parseTimestamp("-1970-01-01"), "YY"));
+  EXPECT_EQ("1948", formatDatetime(parseTimestamp("1948-01-01"), "YYY"));
+  EXPECT_EQ("1234", formatDatetime(parseTimestamp("1234-01-01"), "YYYY"));
   EXPECT_EQ(
-      "0000000001",
-      formatDatetime(fromTimestampString("01-01-01"), "YYYYYYYYYY"));
+      "0000000001", formatDatetime(parseTimestamp("01-01-01"), "YYYYYYYYYY"));
 
   // day of week number - 'e'
   for (int i = 0; i < 31; i++) {
     std::string date("2022-08-" + std::to_string(i + 1));
     EXPECT_EQ(
         std::to_string(i % 7 + 1),
-        formatDatetime(fromTimestampString(StringView{date}), "e"));
+        formatDatetime(parseTimestamp(StringView{date}), "e"));
   }
-  EXPECT_EQ(
-      "000001", formatDatetime(fromTimestampString("2022-08-01"), "eeeeee"));
+  EXPECT_EQ("000001", formatDatetime(parseTimestamp("2022-08-01"), "eeeeee"));
 
   // day of week text - 'E'
   for (int i = 0; i < 31; i++) {
     std::string date("2022-08-" + std::to_string(i + 1));
     EXPECT_EQ(
         daysShort[i % 7],
-        formatDatetime(fromTimestampString(StringView{date}), "E"));
+        formatDatetime(parseTimestamp(StringView{date}), "E"));
     EXPECT_EQ(
         daysShort[i % 7],
-        formatDatetime(fromTimestampString(StringView{date}), "EE"));
+        formatDatetime(parseTimestamp(StringView{date}), "EE"));
     EXPECT_EQ(
         daysShort[i % 7],
-        formatDatetime(fromTimestampString(StringView{date}), "EEE"));
+        formatDatetime(parseTimestamp(StringView{date}), "EEE"));
     EXPECT_EQ(
         daysLong[i % 7],
-        formatDatetime(fromTimestampString(StringView{date}), "EEEE"));
+        formatDatetime(parseTimestamp(StringView{date}), "EEEE"));
     EXPECT_EQ(
         daysLong[i % 7],
-        formatDatetime(fromTimestampString(StringView{date}), "EEEEEEEE"));
+        formatDatetime(parseTimestamp(StringView{date}), "EEEEEEEE"));
   }
 
   // year test cases - 'y'
-  EXPECT_EQ("2022", formatDatetime(fromTimestampString("2022-06-20"), "y"));
-  EXPECT_EQ("22", formatDatetime(fromTimestampString("2022-06-20"), "yy"));
-  EXPECT_EQ("2022", formatDatetime(fromTimestampString("2022-06-20"), "yyy"));
-  EXPECT_EQ("2022", formatDatetime(fromTimestampString("2022-06-20"), "yyyy"));
+  EXPECT_EQ("2022", formatDatetime(parseTimestamp("2022-06-20"), "y"));
+  EXPECT_EQ("22", formatDatetime(parseTimestamp("2022-06-20"), "yy"));
+  EXPECT_EQ("2022", formatDatetime(parseTimestamp("2022-06-20"), "yyy"));
+  EXPECT_EQ("2022", formatDatetime(parseTimestamp("2022-06-20"), "yyyy"));
 
-  EXPECT_EQ("10", formatDatetime(fromTimestampString("10-06-20"), "y"));
-  EXPECT_EQ("10", formatDatetime(fromTimestampString("10-06-20"), "yy"));
-  EXPECT_EQ("010", formatDatetime(fromTimestampString("10-06-20"), "yyy"));
-  EXPECT_EQ("0010", formatDatetime(fromTimestampString("10-06-20"), "yyyy"));
+  EXPECT_EQ("10", formatDatetime(parseTimestamp("10-06-20"), "y"));
+  EXPECT_EQ("10", formatDatetime(parseTimestamp("10-06-20"), "yy"));
+  EXPECT_EQ("010", formatDatetime(parseTimestamp("10-06-20"), "yyy"));
+  EXPECT_EQ("0010", formatDatetime(parseTimestamp("10-06-20"), "yyyy"));
 
-  EXPECT_EQ("-16", formatDatetime(fromTimestampString("-16-06-20"), "y"));
-  EXPECT_EQ("16", formatDatetime(fromTimestampString("-16-06-20"), "yy"));
-  EXPECT_EQ("-016", formatDatetime(fromTimestampString("-16-06-20"), "yyy"));
-  EXPECT_EQ("-0016", formatDatetime(fromTimestampString("-16-06-20"), "yyyy"));
+  EXPECT_EQ("-16", formatDatetime(parseTimestamp("-16-06-20"), "y"));
+  EXPECT_EQ("16", formatDatetime(parseTimestamp("-16-06-20"), "yy"));
+  EXPECT_EQ("-016", formatDatetime(parseTimestamp("-16-06-20"), "yyy"));
+  EXPECT_EQ("-0016", formatDatetime(parseTimestamp("-16-06-20"), "yyyy"));
 
-  EXPECT_EQ("00", formatDatetime(fromTimestampString("-1600-06-20"), "yy"));
-  EXPECT_EQ("01", formatDatetime(fromTimestampString("-1601-06-20"), "yy"));
-  EXPECT_EQ("10", formatDatetime(fromTimestampString("-1610-06-20"), "yy"));
+  EXPECT_EQ("00", formatDatetime(parseTimestamp("-1600-06-20"), "yy"));
+  EXPECT_EQ("01", formatDatetime(parseTimestamp("-1601-06-20"), "yy"));
+  EXPECT_EQ("10", formatDatetime(parseTimestamp("-1610-06-20"), "yy"));
 
   // day of year test cases - 'D'
-  EXPECT_EQ("1", formatDatetime(fromTimestampString("2022-01-01"), "D"));
-  EXPECT_EQ("10", formatDatetime(fromTimestampString("2022-01-10"), "D"));
-  EXPECT_EQ("100", formatDatetime(fromTimestampString("2022-04-10"), "D"));
-  EXPECT_EQ("365", formatDatetime(fromTimestampString("2022-12-31"), "D"));
-  EXPECT_EQ(
-      "00100", formatDatetime(fromTimestampString("2022-04-10"), "DDDDD"));
+  EXPECT_EQ("1", formatDatetime(parseTimestamp("2022-01-01"), "D"));
+  EXPECT_EQ("10", formatDatetime(parseTimestamp("2022-01-10"), "D"));
+  EXPECT_EQ("100", formatDatetime(parseTimestamp("2022-04-10"), "D"));
+  EXPECT_EQ("365", formatDatetime(parseTimestamp("2022-12-31"), "D"));
+  EXPECT_EQ("00100", formatDatetime(parseTimestamp("2022-04-10"), "DDDDD"));
 
   // leap year case
-  EXPECT_EQ("60", formatDatetime(fromTimestampString("2020-02-29"), "D"));
-  EXPECT_EQ("366", formatDatetime(fromTimestampString("2020-12-31"), "D"));
+  EXPECT_EQ("60", formatDatetime(parseTimestamp("2020-02-29"), "D"));
+  EXPECT_EQ("366", formatDatetime(parseTimestamp("2020-12-31"), "D"));
 
   // month of year test cases - 'M'
   for (int i = 0; i < 12; i++) {
@@ -2846,59 +2834,52 @@ TEST_F(DateTimeFunctionsTest, formatDateTime) {
     std::string date("2022-" + std::to_string(month) + "-01");
     EXPECT_EQ(
         std::to_string(month),
-        formatDatetime(fromTimestampString(StringView{date}), "M"));
+        formatDatetime(parseTimestamp(StringView{date}), "M"));
     EXPECT_EQ(
         padNumber(month),
-        formatDatetime(fromTimestampString(StringView{date}), "MM"));
+        formatDatetime(parseTimestamp(StringView{date}), "MM"));
     EXPECT_EQ(
         monthsShort[i],
-        formatDatetime(fromTimestampString(StringView{date}), "MMM"));
+        formatDatetime(parseTimestamp(StringView{date}), "MMM"));
     EXPECT_EQ(
         monthsLong[i],
-        formatDatetime(fromTimestampString(StringView{date}), "MMMM"));
+        formatDatetime(parseTimestamp(StringView{date}), "MMMM"));
     EXPECT_EQ(
         monthsLong[i],
-        formatDatetime(fromTimestampString(StringView{date}), "MMMMMMMM"));
+        formatDatetime(parseTimestamp(StringView{date}), "MMMMMMMM"));
   }
 
   // day of month test cases - 'd'
-  EXPECT_EQ("1", formatDatetime(fromTimestampString("2022-01-01"), "d"));
-  EXPECT_EQ("10", formatDatetime(fromTimestampString("2022-01-10"), "d"));
-  EXPECT_EQ("28", formatDatetime(fromTimestampString("2022-01-28"), "d"));
-  EXPECT_EQ("31", formatDatetime(fromTimestampString("2022-01-31"), "d"));
+  EXPECT_EQ("1", formatDatetime(parseTimestamp("2022-01-01"), "d"));
+  EXPECT_EQ("10", formatDatetime(parseTimestamp("2022-01-10"), "d"));
+  EXPECT_EQ("28", formatDatetime(parseTimestamp("2022-01-28"), "d"));
+  EXPECT_EQ("31", formatDatetime(parseTimestamp("2022-01-31"), "d"));
   EXPECT_EQ(
-      "00000031",
-      formatDatetime(fromTimestampString("2022-01-31"), "dddddddd"));
+      "00000031", formatDatetime(parseTimestamp("2022-01-31"), "dddddddd"));
 
   // leap year case
-  EXPECT_EQ("29", formatDatetime(fromTimestampString("2020-02-29"), "d"));
+  EXPECT_EQ("29", formatDatetime(parseTimestamp("2020-02-29"), "d"));
 
   // halfday of day test cases - 'a'
+  EXPECT_EQ("AM", formatDatetime(parseTimestamp("2022-01-01 00:00:00"), "a"));
+  EXPECT_EQ("AM", formatDatetime(parseTimestamp("2022-01-01 11:59:59"), "a"));
+  EXPECT_EQ("PM", formatDatetime(parseTimestamp("2022-01-01 12:00:00"), "a"));
+  EXPECT_EQ("PM", formatDatetime(parseTimestamp("2022-01-01 23:59:59"), "a"));
   EXPECT_EQ(
-      "AM", formatDatetime(fromTimestampString("2022-01-01 00:00:00"), "a"));
+      "AM", formatDatetime(parseTimestamp("2022-01-01 00:00:00"), "aaaaaaaa"));
   EXPECT_EQ(
-      "AM", formatDatetime(fromTimestampString("2022-01-01 11:59:59"), "a"));
-  EXPECT_EQ(
-      "PM", formatDatetime(fromTimestampString("2022-01-01 12:00:00"), "a"));
-  EXPECT_EQ(
-      "PM", formatDatetime(fromTimestampString("2022-01-01 23:59:59"), "a"));
-  EXPECT_EQ(
-      "AM",
-      formatDatetime(fromTimestampString("2022-01-01 00:00:00"), "aaaaaaaa"));
-  EXPECT_EQ(
-      "PM",
-      formatDatetime(fromTimestampString("2022-01-01 12:00:00"), "aaaaaaaa"));
+      "PM", formatDatetime(parseTimestamp("2022-01-01 12:00:00"), "aaaaaaaa"));
 
   // hour of halfday test cases - 'K'
   for (int i = 0; i < 24; i++) {
     std::string buildString = "2022-01-01 " + padNumber(i) + ":00:00";
     StringView date(buildString);
     EXPECT_EQ(
-        std::to_string(i % 12), formatDatetime(fromTimestampString(date), "K"));
+        std::to_string(i % 12), formatDatetime(parseTimestamp(date), "K"));
   }
   EXPECT_EQ(
       "00000011",
-      formatDatetime(fromTimestampString("2022-01-01 11:00:00"), "KKKKKKKK"));
+      formatDatetime(parseTimestamp("2022-01-01 11:00:00"), "KKKKKKKK"));
 
   // clockhour of halfday test cases - 'h'
   for (int i = 0; i < 24; i++) {
@@ -2906,22 +2887,21 @@ TEST_F(DateTimeFunctionsTest, formatDateTime) {
     StringView date(buildString);
     EXPECT_EQ(
         std::to_string((i + 11) % 12 + 1),
-        formatDatetime(fromTimestampString(date), "h"));
+        formatDatetime(parseTimestamp(date), "h"));
   }
   EXPECT_EQ(
       "00000011",
-      formatDatetime(fromTimestampString("2022-01-01 11:00:00"), "hhhhhhhh"));
+      formatDatetime(parseTimestamp("2022-01-01 11:00:00"), "hhhhhhhh"));
 
   // hour of day test cases - 'H'
   for (int i = 0; i < 24; i++) {
     std::string buildString = "2022-01-01 " + padNumber(i) + ":00:00";
     StringView date(buildString);
-    EXPECT_EQ(
-        std::to_string(i), formatDatetime(fromTimestampString(date), "H"));
+    EXPECT_EQ(std::to_string(i), formatDatetime(parseTimestamp(date), "H"));
   }
   EXPECT_EQ(
       "00000011",
-      formatDatetime(fromTimestampString("2022-01-01 11:00:00"), "HHHHHHHH"));
+      formatDatetime(parseTimestamp("2022-01-01 11:00:00"), "HHHHHHHH"));
 
   // clockhour of day test cases - 'k'
   for (int i = 0; i < 24; i++) {
@@ -2929,130 +2909,108 @@ TEST_F(DateTimeFunctionsTest, formatDateTime) {
     StringView date(buildString);
     EXPECT_EQ(
         std::to_string((i + 23) % 24 + 1),
-        formatDatetime(fromTimestampString(date), "k"));
+        formatDatetime(parseTimestamp(date), "k"));
   }
   EXPECT_EQ(
       "00000011",
-      formatDatetime(fromTimestampString("2022-01-01 11:00:00"), "kkkkkkkk"));
+      formatDatetime(parseTimestamp("2022-01-01 11:00:00"), "kkkkkkkk"));
 
   // minute of hour test cases - 'm'
-  EXPECT_EQ(
-      "0", formatDatetime(fromTimestampString("2022-01-01 00:00:00"), "m"));
-  EXPECT_EQ(
-      "1", formatDatetime(fromTimestampString("2022-01-01 01:01:00"), "m"));
-  EXPECT_EQ(
-      "10", formatDatetime(fromTimestampString("2022-01-01 02:10:00"), "m"));
-  EXPECT_EQ(
-      "30", formatDatetime(fromTimestampString("2022-01-01 03:30:00"), "m"));
-  EXPECT_EQ(
-      "59", formatDatetime(fromTimestampString("2022-01-01 04:59:00"), "m"));
+  EXPECT_EQ("0", formatDatetime(parseTimestamp("2022-01-01 00:00:00"), "m"));
+  EXPECT_EQ("1", formatDatetime(parseTimestamp("2022-01-01 01:01:00"), "m"));
+  EXPECT_EQ("10", formatDatetime(parseTimestamp("2022-01-01 02:10:00"), "m"));
+  EXPECT_EQ("30", formatDatetime(parseTimestamp("2022-01-01 03:30:00"), "m"));
+  EXPECT_EQ("59", formatDatetime(parseTimestamp("2022-01-01 04:59:00"), "m"));
   EXPECT_EQ(
       "00000042",
-      formatDatetime(fromTimestampString("2022-01-01 00:42:42"), "mmmmmmmm"));
+      formatDatetime(parseTimestamp("2022-01-01 00:42:42"), "mmmmmmmm"));
 
   // second of minute test cases - 's'
-  EXPECT_EQ(
-      "0", formatDatetime(fromTimestampString("2022-01-01 00:00:00"), "s"));
-  EXPECT_EQ(
-      "1", formatDatetime(fromTimestampString("2022-01-01 01:01:01"), "s"));
-  EXPECT_EQ(
-      "10", formatDatetime(fromTimestampString("2022-01-01 02:10:10"), "s"));
-  EXPECT_EQ(
-      "30", formatDatetime(fromTimestampString("2022-01-01 03:30:30"), "s"));
-  EXPECT_EQ(
-      "59", formatDatetime(fromTimestampString("2022-01-01 04:59:59"), "s"));
+  EXPECT_EQ("0", formatDatetime(parseTimestamp("2022-01-01 00:00:00"), "s"));
+  EXPECT_EQ("1", formatDatetime(parseTimestamp("2022-01-01 01:01:01"), "s"));
+  EXPECT_EQ("10", formatDatetime(parseTimestamp("2022-01-01 02:10:10"), "s"));
+  EXPECT_EQ("30", formatDatetime(parseTimestamp("2022-01-01 03:30:30"), "s"));
+  EXPECT_EQ("59", formatDatetime(parseTimestamp("2022-01-01 04:59:59"), "s"));
   EXPECT_EQ(
       "00000042",
-      formatDatetime(fromTimestampString("2022-01-01 00:42:42"), "ssssssss"));
+      formatDatetime(parseTimestamp("2022-01-01 00:42:42"), "ssssssss"));
 
   // fraction of second test cases - 'S'
+  EXPECT_EQ("0", formatDatetime(parseTimestamp("2022-01-01 00:00:00.0"), "S"));
+  EXPECT_EQ("1", formatDatetime(parseTimestamp("2022-01-01 00:00:00.1"), "S"));
+  EXPECT_EQ("1", formatDatetime(parseTimestamp("2022-01-01 01:01:01.11"), "S"));
   EXPECT_EQ(
-      "0", formatDatetime(fromTimestampString("2022-01-01 00:00:00.0"), "S"));
+      "11", formatDatetime(parseTimestamp("2022-01-01 02:10:10.11"), "SS"));
   EXPECT_EQ(
-      "1", formatDatetime(fromTimestampString("2022-01-01 00:00:00.1"), "S"));
+      "9", formatDatetime(parseTimestamp("2022-01-01 03:30:30.999"), "S"));
   EXPECT_EQ(
-      "1", formatDatetime(fromTimestampString("2022-01-01 01:01:01.11"), "S"));
+      "99", formatDatetime(parseTimestamp("2022-01-01 03:30:30.999"), "SS"));
   EXPECT_EQ(
-      "11",
-      formatDatetime(fromTimestampString("2022-01-01 02:10:10.11"), "SS"));
-  EXPECT_EQ(
-      "9", formatDatetime(fromTimestampString("2022-01-01 03:30:30.999"), "S"));
-  EXPECT_EQ(
-      "99",
-      formatDatetime(fromTimestampString("2022-01-01 03:30:30.999"), "SS"));
-  EXPECT_EQ(
-      "999",
-      formatDatetime(fromTimestampString("2022-01-01 03:30:30.999"), "SSS"));
+      "999", formatDatetime(parseTimestamp("2022-01-01 03:30:30.999"), "SSS"));
   EXPECT_EQ(
       "12300000",
-      formatDatetime(
-          fromTimestampString("2022-01-01 03:30:30.123"), "SSSSSSSS"));
+      formatDatetime(parseTimestamp("2022-01-01 03:30:30.123"), "SSSSSSSS"));
   EXPECT_EQ(
       "0990",
-      formatDatetime(fromTimestampString("2022-01-01 03:30:30.099"), "SSSS"));
+      formatDatetime(parseTimestamp("2022-01-01 03:30:30.099"), "SSSS"));
   EXPECT_EQ(
       "0010",
-      formatDatetime(fromTimestampString("2022-01-01 03:30:30.001"), "SSSS"));
+      formatDatetime(parseTimestamp("2022-01-01 03:30:30.001"), "SSSS"));
 
   // time zone test cases - 'z'
   setQueryTimeZone("Asia/Kolkata");
   EXPECT_EQ(
-      "Asia/Kolkata",
-      formatDatetime(fromTimestampString("1970-01-01"), "zzzz"));
+      "Asia/Kolkata", formatDatetime(parseTimestamp("1970-01-01"), "zzzz"));
 
   // literal test cases
+  EXPECT_EQ("hello", formatDatetime(parseTimestamp("1970-01-01"), "'hello'"));
+  EXPECT_EQ("'", formatDatetime(parseTimestamp("1970-01-01"), "''"));
   EXPECT_EQ(
-      "hello", formatDatetime(fromTimestampString("1970-01-01"), "'hello'"));
-  EXPECT_EQ("'", formatDatetime(fromTimestampString("1970-01-01"), "''"));
+      "1970 ' 1970", formatDatetime(parseTimestamp("1970-01-01"), "y '' y"));
   EXPECT_EQ(
-      "1970 ' 1970",
-      formatDatetime(fromTimestampString("1970-01-01"), "y '' y"));
-  EXPECT_EQ(
-      "he'llo", formatDatetime(fromTimestampString("1970-01-01"), "'he''llo'"));
+      "he'llo", formatDatetime(parseTimestamp("1970-01-01"), "'he''llo'"));
   EXPECT_EQ(
       "'he'llo'",
-      formatDatetime(fromTimestampString("1970-01-01"), "'''he''llo'''"));
+      formatDatetime(parseTimestamp("1970-01-01"), "'''he''llo'''"));
   EXPECT_EQ(
-      "1234567890",
-      formatDatetime(fromTimestampString("1970-01-01"), "1234567890"));
+      "1234567890", formatDatetime(parseTimestamp("1970-01-01"), "1234567890"));
   EXPECT_EQ(
       "\\\"!@#$%^&*()-+[]{}||`~<>.,?/;:1234567890",
       formatDatetime(
-          fromTimestampString("1970-01-01"),
+          parseTimestamp("1970-01-01"),
           "\\\"!@#$%^&*()-+[]{}||`~<>.,?/;:1234567890"));
 
   // Multi-specifier and literal formats
   EXPECT_EQ(
       "AD 19 1970 4 Thu 1970 1 1 1 AM 8 8 8 8 3 11 5 Asia/Kolkata",
       formatDatetime(
-          fromTimestampString("1970-01-01 02:33:11.5"),
+          parseTimestamp("1970-01-01 02:33:11.5"),
           "G C Y e E y D M d a K h H k m s S zzzz"));
   EXPECT_EQ(
       "AD 19 1970 4 asdfghjklzxcvbnmqwertyuiop Thu ' 1970 1 1 1 AM 8 8 8 8 3 11 5 1234567890\\\"!@#$%^&*()-+`~{}[];:,./ Asia/Kolkata",
       formatDatetime(
-          fromTimestampString("1970-01-01 02:33:11.5"),
+          parseTimestamp("1970-01-01 02:33:11.5"),
           "G C Y e 'asdfghjklzxcvbnmqwertyuiop' E '' y D M d a K h H k m s S 1234567890\\\"!@#$%^&*()-+`~{}[];:,./ zzzz"));
 
   // User format errors or unsupported errors
   EXPECT_THROW(
-      formatDatetime(fromTimestampString("1970-01-01"), "x"), VeloxUserError);
+      formatDatetime(parseTimestamp("1970-01-01"), "x"), VeloxUserError);
   EXPECT_THROW(
-      formatDatetime(fromTimestampString("1970-01-01"), "w"), VeloxUserError);
+      formatDatetime(parseTimestamp("1970-01-01"), "w"), VeloxUserError);
   EXPECT_THROW(
-      formatDatetime(fromTimestampString("1970-01-01"), "z"), VeloxUserError);
+      formatDatetime(parseTimestamp("1970-01-01"), "z"), VeloxUserError);
   EXPECT_THROW(
-      formatDatetime(fromTimestampString("1970-01-01"), "zz"), VeloxUserError);
+      formatDatetime(parseTimestamp("1970-01-01"), "zz"), VeloxUserError);
   EXPECT_THROW(
-      formatDatetime(fromTimestampString("1970-01-01"), "zzz"), VeloxUserError);
+      formatDatetime(parseTimestamp("1970-01-01"), "zzz"), VeloxUserError);
   EXPECT_THROW(
-      formatDatetime(fromTimestampString("1970-01-01"), "q"), VeloxUserError);
+      formatDatetime(parseTimestamp("1970-01-01"), "q"), VeloxUserError);
   EXPECT_THROW(
-      formatDatetime(fromTimestampString("1970-01-01"), "'abcd"),
-      VeloxUserError);
+      formatDatetime(parseTimestamp("1970-01-01"), "'abcd"), VeloxUserError);
 }
 
 TEST_F(DateTimeFunctionsTest, formatDateTimeTimezone) {
-  const auto zeroTs = fromTimestampString("1970-01-01");
+  const auto zeroTs = parseTimestamp("1970-01-01");
 
   // No timezone set; default to GMT.
   EXPECT_EQ(
@@ -3081,50 +3039,44 @@ TEST_F(DateTimeFunctionsTest, dateFormat) {
   EXPECT_EQ(std::nullopt, dateFormatOnce(std::nullopt, "%Y"));
 
   // Normal cases
-  EXPECT_EQ(
-      "1970-01-01", dateFormat(fromTimestampString("1970-01-01"), "%Y-%m-%d"));
+  EXPECT_EQ("1970-01-01", dateFormat(parseTimestamp("1970-01-01"), "%Y-%m-%d"));
   EXPECT_EQ(
       "2000-02-29 12:00:00 AM",
-      dateFormat(
-          fromTimestampString("2000-02-29 00:00:00.987"), "%Y-%m-%d %r"));
+      dateFormat(parseTimestamp("2000-02-29 00:00:00.987"), "%Y-%m-%d %r"));
   EXPECT_EQ(
       "2000-02-29 00:00:00.987000",
       dateFormat(
-          fromTimestampString("2000-02-29 00:00:00.987"),
-          "%Y-%m-%d %H:%i:%s.%f"));
+          parseTimestamp("2000-02-29 00:00:00.987"), "%Y-%m-%d %H:%i:%s.%f"));
   EXPECT_EQ(
       "-2000-02-29 00:00:00.987000",
       dateFormat(
-          fromTimestampString("-2000-02-29 00:00:00.987"),
-          "%Y-%m-%d %H:%i:%s.%f"));
+          parseTimestamp("-2000-02-29 00:00:00.987"), "%Y-%m-%d %H:%i:%s.%f"));
 
   // Varying digit year cases
-  EXPECT_EQ("06", dateFormat(fromTimestampString("-6-06-20"), "%y"));
-  EXPECT_EQ("-0006", dateFormat(fromTimestampString("-6-06-20"), "%Y"));
-  EXPECT_EQ("16", dateFormat(fromTimestampString("-16-06-20"), "%y"));
-  EXPECT_EQ("-0016", dateFormat(fromTimestampString("-16-06-20"), "%Y"));
-  EXPECT_EQ("66", dateFormat(fromTimestampString("-166-06-20"), "%y"));
-  EXPECT_EQ("-0166", dateFormat(fromTimestampString("-166-06-20"), "%Y"));
-  EXPECT_EQ("66", dateFormat(fromTimestampString("-1666-06-20"), "%y"));
-  EXPECT_EQ("00", dateFormat(fromTimestampString("-1900-06-20"), "%y"));
-  EXPECT_EQ("01", dateFormat(fromTimestampString("-1901-06-20"), "%y"));
-  EXPECT_EQ("10", dateFormat(fromTimestampString("-1910-06-20"), "%y"));
-  EXPECT_EQ("12", dateFormat(fromTimestampString("-12-06-20"), "%y"));
-  EXPECT_EQ("00", dateFormat(fromTimestampString("1900-06-20"), "%y"));
-  EXPECT_EQ("01", dateFormat(fromTimestampString("1901-06-20"), "%y"));
-  EXPECT_EQ("10", dateFormat(fromTimestampString("1910-06-20"), "%y"));
+  EXPECT_EQ("06", dateFormat(parseTimestamp("-6-06-20"), "%y"));
+  EXPECT_EQ("-0006", dateFormat(parseTimestamp("-6-06-20"), "%Y"));
+  EXPECT_EQ("16", dateFormat(parseTimestamp("-16-06-20"), "%y"));
+  EXPECT_EQ("-0016", dateFormat(parseTimestamp("-16-06-20"), "%Y"));
+  EXPECT_EQ("66", dateFormat(parseTimestamp("-166-06-20"), "%y"));
+  EXPECT_EQ("-0166", dateFormat(parseTimestamp("-166-06-20"), "%Y"));
+  EXPECT_EQ("66", dateFormat(parseTimestamp("-1666-06-20"), "%y"));
+  EXPECT_EQ("00", dateFormat(parseTimestamp("-1900-06-20"), "%y"));
+  EXPECT_EQ("01", dateFormat(parseTimestamp("-1901-06-20"), "%y"));
+  EXPECT_EQ("10", dateFormat(parseTimestamp("-1910-06-20"), "%y"));
+  EXPECT_EQ("12", dateFormat(parseTimestamp("-12-06-20"), "%y"));
+  EXPECT_EQ("00", dateFormat(parseTimestamp("1900-06-20"), "%y"));
+  EXPECT_EQ("01", dateFormat(parseTimestamp("1901-06-20"), "%y"));
+  EXPECT_EQ("10", dateFormat(parseTimestamp("1910-06-20"), "%y"));
 
   // Day of week cases
   for (int i = 0; i < 8; i++) {
     std::string date("1996-01-0" + std::to_string(i + 1));
     // Full length name
     EXPECT_EQ(
-        daysLong[i % 7],
-        dateFormat(fromTimestampString(StringView{date}), "%W"));
+        daysLong[i % 7], dateFormat(parseTimestamp(StringView{date}), "%W"));
     // Abbreviated name
     EXPECT_EQ(
-        daysShort[i % 7],
-        dateFormat(fromTimestampString(StringView{date}), "%a"));
+        daysShort[i % 7], dateFormat(parseTimestamp(StringView{date}), "%a"));
   }
 
   // Month cases
@@ -3133,23 +3085,19 @@ TEST_F(DateTimeFunctionsTest, dateFormat) {
     std::string monthNum = std::to_string(i + 1);
     // Full length name
     EXPECT_EQ(
-        monthsLong[i % 12],
-        dateFormat(fromTimestampString(StringView{date}), "%M"));
+        monthsLong[i % 12], dateFormat(parseTimestamp(StringView{date}), "%M"));
     // Abbreviated name
     EXPECT_EQ(
         monthsShort[i % 12],
-        dateFormat(fromTimestampString(StringView{date}), "%b"));
+        dateFormat(parseTimestamp(StringView{date}), "%b"));
     // Numeric
-    EXPECT_EQ(
-        monthNum, dateFormat(fromTimestampString(StringView{date}), "%c"));
+    EXPECT_EQ(monthNum, dateFormat(parseTimestamp(StringView{date}), "%c"));
     // Numeric 0-padded
     if (i + 1 < 10) {
       EXPECT_EQ(
-          "0" + monthNum,
-          dateFormat(fromTimestampString(StringView{date}), "%m"));
+          "0" + monthNum, dateFormat(parseTimestamp(StringView{date}), "%m"));
     } else {
-      EXPECT_EQ(
-          monthNum, dateFormat(fromTimestampString(StringView{date}), "%m"));
+      EXPECT_EQ(monthNum, dateFormat(parseTimestamp(StringView{date}), "%m"));
     }
   }
 
@@ -3157,47 +3105,36 @@ TEST_F(DateTimeFunctionsTest, dateFormat) {
   for (int i = 1; i <= 31; i++) {
     std::string dayOfMonth = std::to_string(i);
     std::string date("1970-01-" + dayOfMonth);
-    EXPECT_EQ(
-        dayOfMonth, dateFormat(fromTimestampString(StringView{date}), "%e"));
+    EXPECT_EQ(dayOfMonth, dateFormat(parseTimestamp(StringView{date}), "%e"));
     if (i < 10) {
       EXPECT_EQ(
-          "0" + dayOfMonth,
-          dateFormat(fromTimestampString(StringView{date}), "%d"));
+          "0" + dayOfMonth, dateFormat(parseTimestamp(StringView{date}), "%d"));
     } else {
-      EXPECT_EQ(
-          dayOfMonth, dateFormat(fromTimestampString(StringView{date}), "%d"));
+      EXPECT_EQ(dayOfMonth, dateFormat(parseTimestamp(StringView{date}), "%d"));
     }
   }
 
   // Fraction of second cases
   EXPECT_EQ(
-      "000000", dateFormat(fromTimestampString("2022-01-01 00:00:00.0"), "%f"));
+      "000000", dateFormat(parseTimestamp("2022-01-01 00:00:00.0"), "%f"));
   EXPECT_EQ(
-      "100000", dateFormat(fromTimestampString("2022-01-01 00:00:00.1"), "%f"));
+      "100000", dateFormat(parseTimestamp("2022-01-01 00:00:00.1"), "%f"));
   EXPECT_EQ(
-      "110000",
-      dateFormat(fromTimestampString("2022-01-01 01:01:01.11"), "%f"));
+      "110000", dateFormat(parseTimestamp("2022-01-01 01:01:01.11"), "%f"));
   EXPECT_EQ(
-      "110000",
-      dateFormat(fromTimestampString("2022-01-01 02:10:10.11"), "%f"));
+      "110000", dateFormat(parseTimestamp("2022-01-01 02:10:10.11"), "%f"));
   EXPECT_EQ(
-      "999000",
-      dateFormat(fromTimestampString("2022-01-01 03:30:30.999"), "%f"));
+      "999000", dateFormat(parseTimestamp("2022-01-01 03:30:30.999"), "%f"));
   EXPECT_EQ(
-      "999000",
-      dateFormat(fromTimestampString("2022-01-01 03:30:30.999"), "%f"));
+      "999000", dateFormat(parseTimestamp("2022-01-01 03:30:30.999"), "%f"));
   EXPECT_EQ(
-      "999000",
-      dateFormat(fromTimestampString("2022-01-01 03:30:30.999"), "%f"));
+      "999000", dateFormat(parseTimestamp("2022-01-01 03:30:30.999"), "%f"));
   EXPECT_EQ(
-      "123000",
-      dateFormat(fromTimestampString("2022-01-01 03:30:30.123"), "%f"));
+      "123000", dateFormat(parseTimestamp("2022-01-01 03:30:30.123"), "%f"));
   EXPECT_EQ(
-      "099000",
-      dateFormat(fromTimestampString("2022-01-01 03:30:30.099"), "%f"));
+      "099000", dateFormat(parseTimestamp("2022-01-01 03:30:30.099"), "%f"));
   EXPECT_EQ(
-      "001000",
-      dateFormat(fromTimestampString("2022-01-01 03:30:30.001234"), "%f"));
+      "001000", dateFormat(parseTimestamp("2022-01-01 03:30:30.001234"), "%f"));
 
   // Hour cases
   for (int i = 0; i < 24; i++) {
@@ -3206,22 +3143,20 @@ TEST_F(DateTimeFunctionsTest, dateFormat) {
     std::string clockHourString = std::to_string(clockHour);
     std::string toBuild = "1996-01-01 " + hour + ":00:00";
     StringView date(toBuild);
-    EXPECT_EQ(hour, dateFormat(fromTimestampString(date), "%k"));
+    EXPECT_EQ(hour, dateFormat(parseTimestamp(date), "%k"));
     if (i < 10) {
-      EXPECT_EQ("0" + hour, dateFormat(fromTimestampString(date), "%H"));
+      EXPECT_EQ("0" + hour, dateFormat(parseTimestamp(date), "%H"));
     } else {
-      EXPECT_EQ(hour, dateFormat(fromTimestampString(date), "%H"));
+      EXPECT_EQ(hour, dateFormat(parseTimestamp(date), "%H"));
     }
 
-    EXPECT_EQ(clockHourString, dateFormat(fromTimestampString(date), "%l"));
+    EXPECT_EQ(clockHourString, dateFormat(parseTimestamp(date), "%l"));
     if (clockHour < 10) {
-      EXPECT_EQ(
-          "0" + clockHourString, dateFormat(fromTimestampString(date), "%h"));
-      EXPECT_EQ(
-          "0" + clockHourString, dateFormat(fromTimestampString(date), "%I"));
+      EXPECT_EQ("0" + clockHourString, dateFormat(parseTimestamp(date), "%h"));
+      EXPECT_EQ("0" + clockHourString, dateFormat(parseTimestamp(date), "%I"));
     } else {
-      EXPECT_EQ(clockHourString, dateFormat(fromTimestampString(date), "%h"));
-      EXPECT_EQ(clockHourString, dateFormat(fromTimestampString(date), "%I"));
+      EXPECT_EQ(clockHourString, dateFormat(parseTimestamp(date), "%h"));
+      EXPECT_EQ(clockHourString, dateFormat(parseTimestamp(date), "%I"));
     }
   }
 
@@ -3231,9 +3166,9 @@ TEST_F(DateTimeFunctionsTest, dateFormat) {
     std::string toBuild = "1996-01-01 00:" + minute + ":00";
     StringView date(toBuild);
     if (i < 10) {
-      EXPECT_EQ("0" + minute, dateFormat(fromTimestampString(date), "%i"));
+      EXPECT_EQ("0" + minute, dateFormat(parseTimestamp(date), "%i"));
     } else {
-      EXPECT_EQ(minute, dateFormat(fromTimestampString(date), "%i"));
+      EXPECT_EQ(minute, dateFormat(parseTimestamp(date), "%i"));
     }
   }
 
@@ -3243,98 +3178,86 @@ TEST_F(DateTimeFunctionsTest, dateFormat) {
     std::string toBuild = "1996-01-01 00:00:" + second;
     StringView date(toBuild);
     if (i < 10) {
-      EXPECT_EQ("0" + second, dateFormat(fromTimestampString(date), "%S"));
-      EXPECT_EQ("0" + second, dateFormat(fromTimestampString(date), "%s"));
+      EXPECT_EQ("0" + second, dateFormat(parseTimestamp(date), "%S"));
+      EXPECT_EQ("0" + second, dateFormat(parseTimestamp(date), "%s"));
     } else {
-      EXPECT_EQ(second, dateFormat(fromTimestampString(date), "%S"));
-      EXPECT_EQ(second, dateFormat(fromTimestampString(date), "%s"));
+      EXPECT_EQ(second, dateFormat(parseTimestamp(date), "%S"));
+      EXPECT_EQ(second, dateFormat(parseTimestamp(date), "%s"));
     }
   }
 
   // Day of year cases
-  EXPECT_EQ("001", dateFormat(fromTimestampString("2022-01-01"), "%j"));
-  EXPECT_EQ("010", dateFormat(fromTimestampString("2022-01-10"), "%j"));
-  EXPECT_EQ("100", dateFormat(fromTimestampString("2022-04-10"), "%j"));
-  EXPECT_EQ("365", dateFormat(fromTimestampString("2022-12-31"), "%j"));
+  EXPECT_EQ("001", dateFormat(parseTimestamp("2022-01-01"), "%j"));
+  EXPECT_EQ("010", dateFormat(parseTimestamp("2022-01-10"), "%j"));
+  EXPECT_EQ("100", dateFormat(parseTimestamp("2022-04-10"), "%j"));
+  EXPECT_EQ("365", dateFormat(parseTimestamp("2022-12-31"), "%j"));
 
   // Halfday of day cases
-  EXPECT_EQ("AM", dateFormat(fromTimestampString("2022-01-01 00:00:00"), "%p"));
-  EXPECT_EQ("AM", dateFormat(fromTimestampString("2022-01-01 11:59:59"), "%p"));
-  EXPECT_EQ("PM", dateFormat(fromTimestampString("2022-01-01 12:00:00"), "%p"));
-  EXPECT_EQ("PM", dateFormat(fromTimestampString("2022-01-01 23:59:59"), "%p"));
+  EXPECT_EQ("AM", dateFormat(parseTimestamp("2022-01-01 00:00:00"), "%p"));
+  EXPECT_EQ("AM", dateFormat(parseTimestamp("2022-01-01 11:59:59"), "%p"));
+  EXPECT_EQ("PM", dateFormat(parseTimestamp("2022-01-01 12:00:00"), "%p"));
+  EXPECT_EQ("PM", dateFormat(parseTimestamp("2022-01-01 23:59:59"), "%p"));
 
   // 12-hour time cases
   EXPECT_EQ(
-      "12:00:00 AM",
-      dateFormat(fromTimestampString("2022-01-01 00:00:00"), "%r"));
+      "12:00:00 AM", dateFormat(parseTimestamp("2022-01-01 00:00:00"), "%r"));
   EXPECT_EQ(
-      "11:59:59 AM",
-      dateFormat(fromTimestampString("2022-01-01 11:59:59"), "%r"));
+      "11:59:59 AM", dateFormat(parseTimestamp("2022-01-01 11:59:59"), "%r"));
   EXPECT_EQ(
-      "12:00:00 PM",
-      dateFormat(fromTimestampString("2022-01-01 12:00:00"), "%r"));
+      "12:00:00 PM", dateFormat(parseTimestamp("2022-01-01 12:00:00"), "%r"));
   EXPECT_EQ(
-      "11:59:59 PM",
-      dateFormat(fromTimestampString("2022-01-01 23:59:59"), "%r"));
+      "11:59:59 PM", dateFormat(parseTimestamp("2022-01-01 23:59:59"), "%r"));
 
   // 24-hour time cases
   EXPECT_EQ(
-      "00:00:00", dateFormat(fromTimestampString("2022-01-01 00:00:00"), "%T"));
+      "00:00:00", dateFormat(parseTimestamp("2022-01-01 00:00:00"), "%T"));
   EXPECT_EQ(
-      "11:59:59", dateFormat(fromTimestampString("2022-01-01 11:59:59"), "%T"));
+      "11:59:59", dateFormat(parseTimestamp("2022-01-01 11:59:59"), "%T"));
   EXPECT_EQ(
-      "12:00:00", dateFormat(fromTimestampString("2022-01-01 12:00:00"), "%T"));
+      "12:00:00", dateFormat(parseTimestamp("2022-01-01 12:00:00"), "%T"));
   EXPECT_EQ(
-      "23:59:59", dateFormat(fromTimestampString("2022-01-01 23:59:59"), "%T"));
+      "23:59:59", dateFormat(parseTimestamp("2022-01-01 23:59:59"), "%T"));
 
   // Percent followed by non-existent specifier case
-  EXPECT_EQ("q", dateFormat(fromTimestampString("1970-01-01"), "%q"));
-  EXPECT_EQ("z", dateFormat(fromTimestampString("1970-01-01"), "%z"));
-  EXPECT_EQ("g", dateFormat(fromTimestampString("1970-01-01"), "%g"));
+  EXPECT_EQ("q", dateFormat(parseTimestamp("1970-01-01"), "%q"));
+  EXPECT_EQ("z", dateFormat(parseTimestamp("1970-01-01"), "%z"));
+  EXPECT_EQ("g", dateFormat(parseTimestamp("1970-01-01"), "%g"));
 
   // With timezone. Indian Standard Time (IST) UTC+5:30.
   setQueryTimeZone("Asia/Kolkata");
 
-  EXPECT_EQ(
-      "1970-01-01", dateFormat(fromTimestampString("1970-01-01"), "%Y-%m-%d"));
+  EXPECT_EQ("1970-01-01", dateFormat(parseTimestamp("1970-01-01"), "%Y-%m-%d"));
   EXPECT_EQ(
       "2000-02-29 05:30:00 AM",
-      dateFormat(
-          fromTimestampString("2000-02-29 00:00:00.987"), "%Y-%m-%d %r"));
+      dateFormat(parseTimestamp("2000-02-29 00:00:00.987"), "%Y-%m-%d %r"));
   EXPECT_EQ(
       "2000-02-29 05:30:00.987000",
       dateFormat(
-          fromTimestampString("2000-02-29 00:00:00.987"),
-          "%Y-%m-%d %H:%i:%s.%f"));
+          parseTimestamp("2000-02-29 00:00:00.987"), "%Y-%m-%d %H:%i:%s.%f"));
   EXPECT_EQ(
       "-2000-02-29 05:53:28.987000",
       dateFormat(
-          fromTimestampString("-2000-02-29 00:00:00.987"),
-          "%Y-%m-%d %H:%i:%s.%f"));
+          parseTimestamp("-2000-02-29 00:00:00.987"), "%Y-%m-%d %H:%i:%s.%f"));
 
   // Same timestamps with a different timezone. Pacific Daylight Time (North
   // America) PDT UTC-8:00.
   setQueryTimeZone("America/Los_Angeles");
 
-  EXPECT_EQ(
-      "1969-12-31", dateFormat(fromTimestampString("1970-01-01"), "%Y-%m-%d"));
+  EXPECT_EQ("1969-12-31", dateFormat(parseTimestamp("1970-01-01"), "%Y-%m-%d"));
   EXPECT_EQ(
       "2000-02-28 04:00:00 PM",
-      dateFormat(
-          fromTimestampString("2000-02-29 00:00:00.987"), "%Y-%m-%d %r"));
+      dateFormat(parseTimestamp("2000-02-29 00:00:00.987"), "%Y-%m-%d %r"));
   EXPECT_EQ(
       "2000-02-28 16:00:00.987000",
       dateFormat(
-          fromTimestampString("2000-02-29 00:00:00.987"),
-          "%Y-%m-%d %H:%i:%s.%f"));
+          parseTimestamp("2000-02-29 00:00:00.987"), "%Y-%m-%d %H:%i:%s.%f"));
   EXPECT_EQ(
       "-2000-02-28 16:07:02.987000",
       dateFormat(
-          fromTimestampString("-2000-02-29 00:00:00.987"),
-          "%Y-%m-%d %H:%i:%s.%f"));
+          parseTimestamp("-2000-02-29 00:00:00.987"), "%Y-%m-%d %H:%i:%s.%f"));
 
   // User format errors or unsupported errors.
-  const auto timestamp = fromTimestampString("-2000-02-29 00:00:00.987");
+  const auto timestamp = parseTimestamp("-2000-02-29 00:00:00.987");
   VELOX_ASSERT_THROW(
       dateFormat(timestamp, "%D"),
       "Date format specifier is not supported: %D");
@@ -3413,11 +3336,159 @@ TEST_F(DateTimeFunctionsTest, fromIso8601Date) {
 
   VELOX_ASSERT_THROW(fromIso(" 2024-01-12"), "Unable to parse date value");
   VELOX_ASSERT_THROW(fromIso("2024-01-12  "), "Unable to parse date value");
+  VELOX_ASSERT_THROW(fromIso("2024 "), "Unable to parse date value");
   VELOX_ASSERT_THROW(fromIso("2024-01-xx"), "Unable to parse date value");
   VELOX_ASSERT_THROW(
       fromIso("2024-01-02T12:31:00"), "Unable to parse date value");
   VELOX_ASSERT_THROW(
       fromIso("2024-01-02 12:31:00"), "Unable to parse date value");
+}
+
+TEST_F(DateTimeFunctionsTest, fromIso8601Timestamp) {
+  const auto fromIso = [&](const std::string& input) {
+    auto result =
+        evaluateOnce<int64_t, std::string>("from_iso8601_timestamp(c0)", input);
+    VELOX_CHECK(result.has_value());
+
+    return TimestampWithTimezone(
+        unpackMillisUtc(result.value()), unpackZoneKeyId(result.value()));
+  };
+
+  // Full strings with different time zones.
+  const auto millis = kMillisInDay + 11 * kMillisInHour + 38 * kMillisInMinute +
+      56 * kMillisInSecond + 123;
+  const std::string ts = "1970-01-02T11:38:56.123";
+
+  EXPECT_EQ(
+      TimestampWithTimezone(
+          millis + 5 * kMillisInHour, util::getTimeZoneID("-05:00")),
+      fromIso(ts + "-05:00"));
+
+  EXPECT_EQ(
+      TimestampWithTimezone(
+          millis - 8 * kMillisInHour, util::getTimeZoneID("+08:00")),
+      fromIso(ts + "+08:00"));
+
+  EXPECT_EQ(
+      TimestampWithTimezone(millis, util::getTimeZoneID("UTC")),
+      fromIso(ts + "Z"));
+
+  EXPECT_EQ(
+      TimestampWithTimezone(millis, util::getTimeZoneID("UTC")), fromIso(ts));
+
+  // Partial strings with different session time zones.
+  struct {
+    std::string name;
+    int32_t offset;
+  } timezones[] = {
+      {"America/New_York", -5 * kMillisInHour},
+      {"Asia/Kolkata", 5 * kMillisInHour + 30 * kMillisInMinute},
+  };
+
+  for (auto timezone : timezones) {
+    setQueryTimeZone(timezone.name);
+
+    const auto timezoneId = util::getTimeZoneID(timezone.name);
+
+    EXPECT_EQ(
+        TimestampWithTimezone(
+            kMillisInDay + 11 * kMillisInHour + 38 * kMillisInMinute +
+                56 * kMillisInSecond + 123 - timezone.offset,
+            timezoneId),
+        fromIso("1970-01-02T11:38:56.123"));
+
+    // Comma separator between seconds and microseconds.
+    EXPECT_EQ(
+        TimestampWithTimezone(
+            kMillisInDay + 11 * kMillisInHour + 38 * kMillisInMinute +
+                56 * kMillisInSecond + 123 - timezone.offset,
+            timezoneId),
+        fromIso("1970-01-02T11:38:56,123"));
+
+    EXPECT_EQ(
+        TimestampWithTimezone(
+            kMillisInDay + 11 * kMillisInHour + 38 * kMillisInMinute +
+                56 * kMillisInSecond - timezone.offset,
+            timezoneId),
+        fromIso("1970-01-02T11:38:56"));
+
+    EXPECT_EQ(
+        TimestampWithTimezone(
+            kMillisInDay + 11 * kMillisInHour + 38 * kMillisInMinute -
+                timezone.offset,
+            timezoneId),
+        fromIso("1970-01-02T11:38"));
+
+    EXPECT_EQ(
+        TimestampWithTimezone(
+            kMillisInDay + 11 * kMillisInHour - timezone.offset, timezoneId),
+        fromIso("1970-01-02T11"));
+
+    // No time.
+    EXPECT_EQ(
+        TimestampWithTimezone(kMillisInDay - timezone.offset, timezoneId),
+        fromIso("1970-01-02"));
+
+    EXPECT_EQ(
+        TimestampWithTimezone(-timezone.offset, timezoneId),
+        fromIso("1970-01-01"));
+    EXPECT_EQ(
+        TimestampWithTimezone(-timezone.offset, timezoneId),
+        fromIso("1970-01"));
+    EXPECT_EQ(
+        TimestampWithTimezone(-timezone.offset, timezoneId), fromIso("1970"));
+
+    // No date.
+    EXPECT_EQ(
+        TimestampWithTimezone(
+            11 * kMillisInHour + 38 * kMillisInMinute + 56 * kMillisInSecond +
+                123 - timezone.offset,
+            timezoneId),
+        fromIso("T11:38:56.123"));
+
+    EXPECT_EQ(
+        TimestampWithTimezone(
+            11 * kMillisInHour + 38 * kMillisInMinute + 56 * kMillisInSecond +
+                123 - timezone.offset,
+            timezoneId),
+        fromIso("T11:38:56,123"));
+
+    EXPECT_EQ(
+        TimestampWithTimezone(
+            11 * kMillisInHour + 38 * kMillisInMinute + 56 * kMillisInSecond -
+                timezone.offset,
+            timezoneId),
+        fromIso("T11:38:56"));
+
+    EXPECT_EQ(
+        TimestampWithTimezone(
+            11 * kMillisInHour + 38 * kMillisInMinute - timezone.offset,
+            timezoneId),
+        fromIso("T11:38"));
+
+    EXPECT_EQ(
+        TimestampWithTimezone(11 * kMillisInHour - timezone.offset, timezoneId),
+        fromIso("T11"));
+  }
+
+  VELOX_ASSERT_THROW(
+      fromIso("1970-01-02 11:38"),
+      R"(Unable to parse timestamp value: "1970-01-02 11:38")");
+
+  VELOX_ASSERT_THROW(
+      fromIso("1970-01-02T11:38:56.123 America/New_York"),
+      R"(Unable to parse timestamp value: "1970-01-02T11:38:56.123 America/New_York")");
+
+  VELOX_ASSERT_THROW(fromIso("T"), R"(Unable to parse timestamp value: "T")");
+
+  // Leading and trailing spaces are not allowed.
+  VELOX_ASSERT_THROW(
+      fromIso(" 1970-01-02"),
+      R"(Unable to parse timestamp value: " 1970-01-02")");
+
+  VELOX_ASSERT_THROW(
+      fromIso("1970-01-02 "),
+      R"(Unable to parse timestamp value: "1970-01-02 ")");
 }
 
 TEST_F(DateTimeFunctionsTest, dateParseMonthOfYearText) {
@@ -3788,7 +3859,7 @@ TEST_F(DateTimeFunctionsTest, currentDateWithoutTimezone) {
 
 TEST_F(DateTimeFunctionsTest, timeZoneHour) {
   const auto timezone_hour = [&](const char* time, const char* timezone) {
-    Timestamp ts = fromTimestampString(time);
+    Timestamp ts = parseTimestamp(time);
     auto timestamp = ts.toMillis();
     auto hour = evaluateWithTimestampWithTimezone<int64_t>(
                     "timezone_hour(c0)", timestamp, timezone)
@@ -3828,7 +3899,7 @@ TEST_F(DateTimeFunctionsTest, timeZoneHour) {
 
 TEST_F(DateTimeFunctionsTest, timeZoneMinute) {
   const auto timezone_minute = [&](const char* time, const char* timezone) {
-    Timestamp ts = fromTimestampString(time);
+    Timestamp ts = parseTimestamp(time);
     auto timestamp = ts.toMillis();
     auto minute = evaluateWithTimestampWithTimezone<int64_t>(
                       "timezone_minute(c0)", timestamp, timezone)
@@ -4005,7 +4076,7 @@ TEST_F(DateTimeFunctionsTest, lastDayOfMonthTimestamp) {
   };
 
   const auto lastDay = [&](const StringView& dateStr) {
-    return lastDayFunc(fromTimestampString(dateStr));
+    return lastDayFunc(parseTimestamp(dateStr));
   };
 
   setQueryTimeZone("Pacific/Apia");

--- a/velox/functions/prestosql/tests/SequenceTest.cpp
+++ b/velox/functions/prestosql/tests/SequenceTest.cpp
@@ -26,12 +26,6 @@ namespace {
 
 class SequenceTest : public FunctionBaseTest {
  protected:
-  static Timestamp fromTimestampString(const StringView& timestamp) {
-    return util::fromTimestampString(timestamp).thenOrThrow(
-        folly::identity,
-        [&](const Status& status) { VELOX_USER_FAIL("{}", status.message()); });
-  }
-
   void testExpression(
       const std::string& expression,
       const std::vector<VectorPtr>& input,
@@ -403,47 +397,47 @@ TEST_F(SequenceTest, timestampInvalidIntervalStep) {
 
 TEST_F(SequenceTest, timestampYearMonthStep) {
   const auto startVector = makeFlatVector<Timestamp>(
-      {fromTimestampString("1975-01-31 10:00:00.500"),
-       fromTimestampString("1975-03-15 10:10:10.200"),
-       fromTimestampString("2023-12-31 23:00:00.500")});
+      {parseTimestamp("1975-01-31 10:00:00.500"),
+       parseTimestamp("1975-03-15 10:10:10.200"),
+       parseTimestamp("2023-12-31 23:00:00.500")});
   const auto stopVector = makeFlatVector<Timestamp>(
-      {fromTimestampString("1975-06-01 01:00:00.500"),
-       fromTimestampString("1974-12-15 10:20:00.500"),
-       fromTimestampString("2024-05-31 10:00:00.500")});
+      {parseTimestamp("1975-06-01 01:00:00.500"),
+       parseTimestamp("1974-12-15 10:20:00.500"),
+       parseTimestamp("2024-05-31 10:00:00.500")});
 
   const auto stepVector =
       makeFlatVector<int32_t>({1, -1, 2}, INTERVAL_YEAR_MONTH());
   const auto expected = makeArrayVector<Timestamp>(
       {// last day of Feb
-       {fromTimestampString("1975-01-31 10:00:00.500"),
-        fromTimestampString("1975-02-28 10:00:00.500"),
-        fromTimestampString("1975-03-31 10:00:00.500"),
-        fromTimestampString("1975-04-30 10:00:00.500"),
-        fromTimestampString("1975-05-31 10:00:00.500")},
+       {parseTimestamp("1975-01-31 10:00:00.500"),
+        parseTimestamp("1975-02-28 10:00:00.500"),
+        parseTimestamp("1975-03-31 10:00:00.500"),
+        parseTimestamp("1975-04-30 10:00:00.500"),
+        parseTimestamp("1975-05-31 10:00:00.500")},
        // date is the same but timestamp is different so couldn't include
        // 1974-12-15 10:10:10.200
        // negative step
-       {fromTimestampString("1975-03-15 10:10:10.200"),
-        fromTimestampString("1975-02-15 10:10:10.200"),
-        fromTimestampString("1975-01-15 10:10:10.200")},
+       {parseTimestamp("1975-03-15 10:10:10.200"),
+        parseTimestamp("1975-02-15 10:10:10.200"),
+        parseTimestamp("1975-01-15 10:10:10.200")},
        // leap year
        // result won't include 2024-05-31 10:00:00.500
-       {fromTimestampString("2023-12-31 23:00:00.500"),
-        fromTimestampString("2024-02-29 23:00:00.500"),
-        fromTimestampString("2024-04-30 23:00:00.500")}});
+       {parseTimestamp("2023-12-31 23:00:00.500"),
+        parseTimestamp("2024-02-29 23:00:00.500"),
+        parseTimestamp("2024-04-30 23:00:00.500")}});
   testExpression(
       "sequence(C0, C1, C2)", {startVector, stopVector, stepVector}, expected);
 }
 
 TEST_F(SequenceTest, timestampInvalidYearMonthStep) {
   const auto startVector = makeFlatVector<Timestamp>(
-      {fromTimestampString("1975-01-31 10:00:00.500"),
-       fromTimestampString("1975-03-15 10:10:10.200"),
-       fromTimestampString("2023-12-31 23:00:00.500")});
+      {parseTimestamp("1975-01-31 10:00:00.500"),
+       parseTimestamp("1975-03-15 10:10:10.200"),
+       parseTimestamp("2023-12-31 23:00:00.500")});
   const auto stopVector = makeFlatVector<Timestamp>(
-      {fromTimestampString("1975-06-01 01:00:00.500"),
-       fromTimestampString("1974-12-15 10:20:00.500"),
-       fromTimestampString("2024-05-31 10:00:00.500")});
+      {parseTimestamp("1975-06-01 01:00:00.500"),
+       parseTimestamp("1974-12-15 10:20:00.500"),
+       parseTimestamp("2024-05-31 10:00:00.500")});
 
   auto stepVector = makeFlatVector<int32_t>({0, 0, 0}, INTERVAL_DAY_TIME());
   testExpressionWithError(
@@ -461,17 +455,17 @@ TEST_F(SequenceTest, timestampInvalidYearMonthStep) {
 
   auto expected = makeNullableArrayVector<Timestamp>(
       {// last day of Feb
-       {{fromTimestampString("1975-01-31 10:00:00.500"),
-         fromTimestampString("1975-02-28 10:00:00.500"),
-         fromTimestampString("1975-03-31 10:00:00.500"),
-         fromTimestampString("1975-04-30 10:00:00.500"),
-         fromTimestampString("1975-05-31 10:00:00.500")}},
+       {{parseTimestamp("1975-01-31 10:00:00.500"),
+         parseTimestamp("1975-02-28 10:00:00.500"),
+         parseTimestamp("1975-03-31 10:00:00.500"),
+         parseTimestamp("1975-04-30 10:00:00.500"),
+         parseTimestamp("1975-05-31 10:00:00.500")}},
        std::nullopt,
        // leap year
        // result won't include 2024-05-31 10:00:00.500
-       {{fromTimestampString("2023-12-31 23:00:00.500"),
-         fromTimestampString("2024-02-29 23:00:00.500"),
-         fromTimestampString("2024-04-30 23:00:00.500")}}});
+       {{parseTimestamp("2023-12-31 23:00:00.500"),
+         parseTimestamp("2024-02-29 23:00:00.500"),
+         parseTimestamp("2024-04-30 23:00:00.500")}}});
   testExpression(
       "try(sequence(C0, C1, C2))",
       {startVector, stopVector, stepVector},
@@ -480,13 +474,13 @@ TEST_F(SequenceTest, timestampInvalidYearMonthStep) {
 
 TEST_F(SequenceTest, timestampIntervalExceedMaxEntries) {
   const auto startVector = makeFlatVector<Timestamp>(
-      {fromTimestampString("1975-01-31 10:00:00.500"),
-       fromTimestampString("1975-03-15 10:10:10.200"),
-       fromTimestampString("2023-12-31 23:00:00.500")});
+      {parseTimestamp("1975-01-31 10:00:00.500"),
+       parseTimestamp("1975-03-15 10:10:10.200"),
+       parseTimestamp("2023-12-31 23:00:00.500")});
   const auto stopVector = makeFlatVector<Timestamp>(
-      {fromTimestampString("3975-06-01 01:00:00.500"),
-       fromTimestampString("3974-12-15 10:20:00.500"),
-       fromTimestampString("4024-05-31 10:00:00.500")});
+      {parseTimestamp("3975-06-01 01:00:00.500"),
+       parseTimestamp("3974-12-15 10:20:00.500"),
+       parseTimestamp("4024-05-31 10:00:00.500")});
   auto stepVector = makeFlatVector<int32_t>({1, 1, 1}, INTERVAL_YEAR_MONTH());
   testExpressionWithError(
       "sequence(C0, C1, C2)",

--- a/velox/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
+++ b/velox/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
@@ -23,12 +23,6 @@ namespace {
 
 class TimestampWithTimeZoneCastTest : public functions::test::CastBaseTest {
  public:
-  static Timestamp fromTimestampString(const StringView& timestamp) {
-    return util::fromTimestampString(timestamp).thenOrThrow(
-        folly::identity,
-        [&](const Status& status) { VELOX_USER_FAIL("{}", status.message()); });
-  }
-
   VectorPtr makeTimestampWithTimeZoneVector(
       vector_size_t size,
       const std::function<int64_t(int32_t row)>& timestampAt,
@@ -86,9 +80,9 @@ TEST_F(TimestampWithTimeZoneCastTest, fromVarchar) {
   // '2012-10-31 01:00:47' in Denver. Below, we use UTC representations of the
   // above local wall-clocks, to match the UTC timepoints held in the
   // TimestampWithTimezone type.
-  auto denverUTC = fromTimestampString("2012-10-31 07:00:47").toMillis();
-  auto viennaUTC = fromTimestampString("1994-05-06 13:49:00").toMillis();
-  auto chathamUTC = fromTimestampString("1979-02-23 18:48:31").toMillis();
+  auto denverUTC = parseTimestamp("2012-10-31 07:00:47").toMillis();
+  auto viennaUTC = parseTimestamp("1994-05-06 13:49:00").toMillis();
+  auto chathamUTC = parseTimestamp("1979-02-23 18:48:31").toMillis();
 
   auto timestamps = std::vector<int64_t>{
       0, denverUTC, denverUTC, viennaUTC, chathamUTC, chathamUTC};
@@ -143,7 +137,7 @@ TEST_F(TimestampWithTimeZoneCastTest, fromVarcharWithoutTimezone) {
 
   const auto stringVector =
       makeNullableFlatVector<StringView>({"2012-10-31 01:00:47"});
-  auto denverUTC = fromTimestampString("2012-10-31 07:00:47").toMillis();
+  auto denverUTC = parseTimestamp("2012-10-31 07:00:47").toMillis();
 
   auto timestamps = std::vector<int64_t>{denverUTC};
 
@@ -171,7 +165,7 @@ TEST_F(TimestampWithTimeZoneCastTest, fromVarcharInvalidInput) {
   const auto invalidStringVector4 = makeNullableFlatVector<StringView>(
       {"2012-10-31 35:00:47 America/Los_Angeles"});
 
-  auto millis = fromTimestampString("2012-10-31 07:00:47").toMillis();
+  auto millis = parseTimestamp("2012-10-31 07:00:47").toMillis();
   auto timestamps = std::vector<int64_t>{millis};
 
   auto timezones =

--- a/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
@@ -318,6 +318,16 @@ class FunctionBaseTest : public testing::Test,
     return result[0];
   }
 
+  /// Parses a timestamp string into Timestamp.
+  /// Accepts strings formatted as 'YYYY-MM-DD HH:mm:ss[.nnn]'.
+  static Timestamp parseTimestamp(const std::string& text) {
+    return util::fromTimestampString(
+               text.data(), text.size(), util::TimestampParseMode::kPrestoCast)
+        .thenOrThrow(folly::identity, [&](const Status& status) {
+          VELOX_USER_FAIL("{}", status.message());
+        });
+  }
+
   /// Returns a vector of signatures for the given function name and return
   /// type.
   /// @param returnType The name of expected return type defined in function

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.cpp
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.cpp
@@ -82,7 +82,9 @@ void castFromString(
     int64_t* rawResults) {
   context.applyToSelectedNoThrow(rows, [&](auto row) {
     const auto castResult = util::fromTimestampWithTimezoneString(
-        inputVector.valueAt(row).data(), inputVector.valueAt(row).size());
+        inputVector.valueAt(row).data(),
+        inputVector.valueAt(row).size(),
+        util::TimestampParseMode::kPrestoCast);
     if (castResult.hasError()) {
       context.setStatus(row, castResult.error());
     } else {

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -22,7 +22,8 @@ namespace facebook::velox::functions::sparksql {
 
 Expected<Timestamp> SparkCastHooks::castStringToTimestamp(
     const StringView& view) const {
-  return util::fromTimestampString(view.data(), view.size());
+  return util::fromTimestampString(
+      view.data(), view.size(), util::TimestampParseMode::kSparkCast);
 }
 
 Expected<int32_t> SparkCastHooks::castStringToDate(

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -51,12 +51,6 @@ class DateTimeFunctionsTest : public SparkFunctionBaseTest {
     });
   }
 
-  static Timestamp fromTimestampString(const StringView& timestamp) {
-    return util::fromTimestampString(timestamp).thenOrThrow(
-        folly::identity,
-        [&](const Status& status) { VELOX_USER_FAIL("{}", status.message()); });
-  }
-
   static int32_t parseDate(const std::string& dateStr) {
     return DATE()->toDays(dateStr);
   }
@@ -78,7 +72,7 @@ class DateTimeFunctionsTest : public SparkFunctionBaseTest {
 
 TEST_F(DateTimeFunctionsTest, toUtcTimestamp) {
   const auto toUtcTimestamp = [&](const StringView& ts, const std::string& tz) {
-    auto timestamp = std::make_optional<Timestamp>(fromTimestampString(ts));
+    auto timestamp = std::make_optional<Timestamp>(parseTimestamp(ts));
     auto result = evaluateOnce<Timestamp>(
         "to_utc_timestamp(c0, c1)",
         timestamp,
@@ -108,7 +102,7 @@ TEST_F(DateTimeFunctionsTest, toUtcTimestamp) {
 TEST_F(DateTimeFunctionsTest, fromUtcTimestamp) {
   const auto fromUtcTimestamp = [&](const StringView& ts,
                                     const std::string& tz) {
-    auto timestamp = std::make_optional<Timestamp>(fromTimestampString(ts));
+    auto timestamp = std::make_optional<Timestamp>(parseTimestamp(ts));
     auto result = evaluateOnce<Timestamp>(
         "from_utc_timestamp(c0, c1)",
         timestamp,
@@ -138,7 +132,7 @@ TEST_F(DateTimeFunctionsTest, fromUtcTimestamp) {
 TEST_F(DateTimeFunctionsTest, toFromUtcTimestamp) {
   const auto toFromUtcTimestamp = [&](const StringView& ts,
                                       const std::string& tz) {
-    auto timestamp = std::make_optional<Timestamp>(fromTimestampString(ts));
+    auto timestamp = std::make_optional<Timestamp>(parseTimestamp(ts));
     auto result = evaluateOnce<Timestamp>(
         "to_utc_timestamp(from_utc_timestamp(c0, c1), c1)",
         timestamp,
@@ -802,8 +796,7 @@ TEST_F(DateTimeFunctionsTest, getTimestamp) {
 
 TEST_F(DateTimeFunctionsTest, hour) {
   const auto hour = [&](const StringView timestampStr) {
-    const auto timeStamp =
-        std::make_optional(fromTimestampString(timestampStr));
+    const auto timeStamp = std::make_optional(parseTimestamp(timestampStr));
     return evaluateOnce<int32_t>("hour(c0)", timeStamp);
   };
 
@@ -825,8 +818,7 @@ TEST_F(DateTimeFunctionsTest, hour) {
 
 TEST_F(DateTimeFunctionsTest, minute) {
   const auto minute = [&](const StringView& timestampStr) {
-    const auto timeStamp =
-        std::make_optional(fromTimestampString(timestampStr));
+    const auto timeStamp = std::make_optional(parseTimestamp(timestampStr));
     return evaluateOnce<int32_t>("minute(c0)", timeStamp);
   };
 
@@ -854,8 +846,7 @@ TEST_F(DateTimeFunctionsTest, minute) {
 
 TEST_F(DateTimeFunctionsTest, second) {
   const auto second = [&](const StringView& timestampStr) {
-    const auto timeStamp =
-        std::make_optional(fromTimestampString(timestampStr));
+    const auto timeStamp = std::make_optional(parseTimestamp(timestampStr));
     return evaluateOnce<int32_t>("second(c0)", timeStamp);
   };
 
@@ -867,7 +858,7 @@ TEST_F(DateTimeFunctionsTest, second) {
 
 TEST_F(DateTimeFunctionsTest, fromUnixtime) {
   const auto getUnixTime = [&](const StringView& str) {
-    Timestamp t = fromTimestampString(str);
+    Timestamp t = parseTimestamp(str);
     return t.getSeconds();
   };
 
@@ -999,7 +990,7 @@ TEST_F(DateTimeFunctionsTest, yearOfWeek) {
 TEST_F(DateTimeFunctionsTest, unixSeconds) {
   const auto unixSeconds = [&](const StringView time) {
     return evaluateOnce<int64_t>(
-        "unix_seconds(c0)", std::make_optional(fromTimestampString(time)));
+        "unix_seconds(c0)", std::make_optional(parseTimestamp(time)));
   };
   EXPECT_EQ(unixSeconds("1970-01-01 00:00:01"), 1);
   EXPECT_EQ(unixSeconds("1970-01-01 00:00:00.000127"), 0);
@@ -1012,76 +1003,70 @@ TEST_F(DateTimeFunctionsTest, microsToTimestamp) {
   const auto microsToTimestamp = [&](std::optional<int64_t> micros) {
     return evaluateOnce<Timestamp>("timestamp_micros(c0)", micros);
   };
-  EXPECT_EQ(
-      microsToTimestamp(1000000), fromTimestampString("1970-01-01 00:00:01"));
+  EXPECT_EQ(microsToTimestamp(1000000), parseTimestamp("1970-01-01 00:00:01"));
   EXPECT_EQ(
       microsToTimestamp(1230219000123123),
-      fromTimestampString("2008-12-25 15:30:00.123123"));
+      parseTimestamp("2008-12-25 15:30:00.123123"));
 
   EXPECT_EQ(
       microsToTimestamp(kMaxTinyint),
-      fromTimestampString("1970-01-01 00:00:00.000127"));
+      parseTimestamp("1970-01-01 00:00:00.000127"));
   EXPECT_EQ(
       microsToTimestamp(kMinTinyint),
-      fromTimestampString("1969-12-31 23:59:59.999872"));
+      parseTimestamp("1969-12-31 23:59:59.999872"));
   EXPECT_EQ(
       microsToTimestamp(kMaxSmallint),
-      fromTimestampString("1970-01-01 00:00:00.032767"));
+      parseTimestamp("1970-01-01 00:00:00.032767"));
   EXPECT_EQ(
       microsToTimestamp(kMinSmallint),
-      fromTimestampString("1969-12-31 23:59:59.967232"));
+      parseTimestamp("1969-12-31 23:59:59.967232"));
   EXPECT_EQ(
-      microsToTimestamp(kMax),
-      fromTimestampString("1970-01-01 00:35:47.483647"));
+      microsToTimestamp(kMax), parseTimestamp("1970-01-01 00:35:47.483647"));
   EXPECT_EQ(
-      microsToTimestamp(kMin),
-      fromTimestampString("1969-12-31 23:24:12.516352"));
+      microsToTimestamp(kMin), parseTimestamp("1969-12-31 23:24:12.516352"));
   EXPECT_EQ(
       microsToTimestamp(kMaxBigint),
-      fromTimestampString("294247-01-10 04:00:54.775807"));
+      parseTimestamp("294247-01-10 04:00:54.775807"));
   EXPECT_EQ(
       microsToTimestamp(kMinBigint),
-      fromTimestampString("-290308-12-21 19:59:05.224192"));
+      parseTimestamp("-290308-12-21 19:59:05.224192"));
 }
 
 TEST_F(DateTimeFunctionsTest, millisToTimestamp) {
   const auto millisToTimestamp = [&](int64_t millis) {
     return evaluateOnce<Timestamp, int64_t>("timestamp_millis(c0)", millis);
   };
-  EXPECT_EQ(
-      millisToTimestamp(1000), fromTimestampString("1970-01-01 00:00:01"));
+  EXPECT_EQ(millisToTimestamp(1000), parseTimestamp("1970-01-01 00:00:01"));
   EXPECT_EQ(
       millisToTimestamp(1230219000123),
-      fromTimestampString("2008-12-25 15:30:00.123"));
+      parseTimestamp("2008-12-25 15:30:00.123"));
 
   EXPECT_EQ(
       millisToTimestamp(kMaxTinyint),
-      fromTimestampString("1970-01-01 00:00:00.127"));
+      parseTimestamp("1970-01-01 00:00:00.127"));
   EXPECT_EQ(
       millisToTimestamp(kMinTinyint),
-      fromTimestampString("1969-12-31 23:59:59.872"));
+      parseTimestamp("1969-12-31 23:59:59.872"));
   EXPECT_EQ(
       millisToTimestamp(kMaxSmallint),
-      fromTimestampString("1970-01-01 00:00:32.767"));
+      parseTimestamp("1970-01-01 00:00:32.767"));
   EXPECT_EQ(
       millisToTimestamp(kMinSmallint),
-      fromTimestampString("1969-12-31 23:59:27.232"));
-  EXPECT_EQ(
-      millisToTimestamp(kMax), fromTimestampString("1970-01-25 20:31:23.647"));
-  EXPECT_EQ(
-      millisToTimestamp(kMin), fromTimestampString("1969-12-07 03:28:36.352"));
+      parseTimestamp("1969-12-31 23:59:27.232"));
+  EXPECT_EQ(millisToTimestamp(kMax), parseTimestamp("1970-01-25 20:31:23.647"));
+  EXPECT_EQ(millisToTimestamp(kMin), parseTimestamp("1969-12-07 03:28:36.352"));
   EXPECT_EQ(
       millisToTimestamp(kMaxBigint),
-      fromTimestampString("292278994-08-17T07:12:55.807"));
+      parseTimestamp("292278994-08-17 07:12:55.807"));
   EXPECT_EQ(
       millisToTimestamp(kMinBigint),
-      fromTimestampString("-292275055-05-16T16:47:04.192"));
+      parseTimestamp("-292275055-05-16 16:47:04.192"));
 }
 
 TEST_F(DateTimeFunctionsTest, timestampToMicros) {
   const auto timestampToMicros = [&](const StringView time) {
     return evaluateOnce<int64_t, Timestamp>(
-        "unix_micros(c0)", fromTimestampString(time));
+        "unix_micros(c0)", parseTimestamp(time));
   };
   EXPECT_EQ(timestampToMicros("1970-01-01 00:00:01"), 1000000);
   EXPECT_EQ(timestampToMicros("2008-12-25 15:30:00.123123"), 1230219000123123);
@@ -1098,9 +1083,9 @@ TEST_F(DateTimeFunctionsTest, timestampToMicros) {
 }
 
 TEST_F(DateTimeFunctionsTest, timestampToMillis) {
-  const auto timestampToMillis = [&](const StringView time) {
+  const auto timestampToMillis = [&](const std::string& time) {
     return evaluateOnce<int64_t, Timestamp>(
-        "unix_millis(c0)", fromTimestampString(time));
+        "unix_millis(c0)", parseTimestamp(time));
   };
   EXPECT_EQ(timestampToMillis("1970-01-01 00:00:01"), 1000);
   EXPECT_EQ(timestampToMillis("2008-12-25 15:30:00.123"), 1230219000123);
@@ -1111,8 +1096,8 @@ TEST_F(DateTimeFunctionsTest, timestampToMillis) {
   EXPECT_EQ(timestampToMillis("1969-12-31 23:59:27.232"), kMinSmallint);
   EXPECT_EQ(timestampToMillis("1970-01-25 20:31:23.647"), kMax);
   EXPECT_EQ(timestampToMillis("1969-12-07 03:28:36.352"), kMin);
-  EXPECT_EQ(timestampToMillis("292278994-08-17T07:12:55.807"), kMaxBigint);
-  EXPECT_EQ(timestampToMillis("-292275055-05-16T16:47:04.192"), kMinBigint);
+  EXPECT_EQ(timestampToMillis("292278994-08-17 07:12:55.807"), kMaxBigint);
+  EXPECT_EQ(timestampToMillis("-292275055-05-16 16:47:04.192"), kMinBigint);
 }
 
 } // namespace

--- a/velox/functions/sparksql/tests/MakeTimestampTest.cpp
+++ b/velox/functions/sparksql/tests/MakeTimestampTest.cpp
@@ -29,12 +29,6 @@ class MakeTimestampTest : public SparkFunctionBaseTest {
         {core::QueryConfig::kAdjustTimestampToTimezone, "true"},
     });
   }
-
-  static Timestamp fromTimestampString(const StringView& timestamp) {
-    return util::fromTimestampString(timestamp).thenOrThrow(
-        folly::identity,
-        [&](const Status& status) { VELOX_USER_FAIL("{}", status.message()); });
-  }
 };
 
 TEST_F(MakeTimestampTest, basic) {
@@ -69,20 +63,20 @@ TEST_F(MakeTimestampTest, basic) {
 
     setQueryTimeZone("GMT");
     auto expectedGMT = makeNullableFlatVector<Timestamp>(
-        {fromTimestampString("2021-07-11 06:30:45.678"),
-         fromTimestampString("2021-07-11 06:30:01"),
-         fromTimestampString("2021-07-11 06:31:00"),
-         fromTimestampString("2021-07-11 06:30:59.999999"),
+        {parseTimestamp("2021-07-11 06:30:45.678"),
+         parseTimestamp("2021-07-11 06:30:01"),
+         parseTimestamp("2021-07-11 06:31:00"),
+         parseTimestamp("2021-07-11 06:30:59.999999"),
          std::nullopt});
     testMakeTimestamp(data, expectedGMT, false);
     testConstantTimezone(data, "GMT", expectedGMT);
 
     setQueryTimeZone("Asia/Shanghai");
     auto expectedSessionTimezone = makeNullableFlatVector<Timestamp>(
-        {fromTimestampString("2021-07-10 22:30:45.678"),
-         fromTimestampString("2021-07-10 22:30:01"),
-         fromTimestampString("2021-07-10 22:31:00"),
-         fromTimestampString("2021-07-10 22:30:59.999999"),
+        {parseTimestamp("2021-07-10 22:30:45.678"),
+         parseTimestamp("2021-07-10 22:30:01"),
+         parseTimestamp("2021-07-10 22:31:00"),
+         parseTimestamp("2021-07-10 22:30:59.999999"),
          std::nullopt});
     testMakeTimestamp(data, expectedSessionTimezone, false);
     // Session time zone will be ignored if time zone is specified in argument.
@@ -105,8 +99,8 @@ TEST_F(MakeTimestampTest, basic) {
         makeRowVector({year, month, day, hour, minute, micros, timeZone});
     // Session time zone will be ignored if time zone is specified in argument.
     auto expected = makeNullableFlatVector<Timestamp>(
-        {fromTimestampString("2021-07-11 06:30:45.678"),
-         fromTimestampString("2021-07-11 04:30:45.678"),
+        {parseTimestamp("2021-07-11 06:30:45.678"),
+         parseTimestamp("2021-07-11 04:30:45.678"),
          std::nullopt});
     testMakeTimestamp(data, expected, true);
   }

--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -600,15 +600,18 @@ struct Converter<TypeKind::TIMESTAMP, void, TPolicy> {
   }
 
   static Expected<Timestamp> tryCast(folly::StringPiece v) {
-    return fromTimestampString(v.data(), v.size());
+    return fromTimestampString(
+        v.data(), v.size(), TimestampParseMode::kPrestoCast);
   }
 
   static Expected<Timestamp> tryCast(const StringView& v) {
-    return fromTimestampString(v.data(), v.size());
+    return fromTimestampString(
+        v.data(), v.size(), TimestampParseMode::kPrestoCast);
   }
 
   static Expected<Timestamp> tryCast(const std::string& v) {
-    return fromTimestampString(v.data(), v.size());
+    return fromTimestampString(
+        v.data(), v.size(), TimestampParseMode::kPrestoCast);
   }
 };
 

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -52,20 +52,24 @@ enum class ParseMode {
   // For timestamp string conversion, align with DuckDB's implementation.
   kNonStrict,
 
-  // Strictly processes dates only in complete ISO 8601 format,
-  // e.g. [+-](YYYY-MM-DD).
-  // Align with Presto casting conventions.
+  // Accepts complete ISO 8601 format, i.e. [+-](YYYY-MM-DD). Allows leading and
+  // trailing spaces.
+  // Aligned with Presto casting conventions.
+  // TODO Rename to kPrestoCast.
   kStandardCast,
 
   // Like kStandardCast but permits years less than four digits, missing
   // day/month, and allows trailing 'T' or spaces.
-  // Align with Spark SQL casting conventions.
+  // Aligned with Spark SQL casting conventions.
+  //
   // Supported formats:
   // `[+-][Y]Y*`
   // `[+-][Y]Y*-[M]M`
   // `[+-][Y]Y*-[M]M*-[D]D`
   // `[+-][Y]Y*-[M]M*-[D]D *`
   // `[+-][Y]Y*-[M]M*-[D]DT*`
+  //
+  // TODO Rename to kSparkCast.
   kNonStandardCast,
 
   // ISO-8601 format. No leading or trailing spaces allowed.
@@ -74,7 +78,8 @@ enum class ParseMode {
   // `[+-][Y]Y*`
   // `[+-][Y]Y*-[M]M`
   // `[+-][Y]Y*-[M]M*-[D]D`
-  // `[+-][Y]Y*-[M]M*-[D]D *`
+  //
+  // TODO Rename to kIso8601.
   kNonStandardNoTimeCast
 };
 
@@ -148,6 +153,8 @@ int32_t extractISODayOfTheWeek(int32_t daysSinceEpoch);
 int64_t
 fromTime(int32_t hour, int32_t minute, int32_t second, int32_t microseconds);
 
+// TODO These are used only in tests. Move them to test-only location.
+
 /// Parses the input string and returns the number of cumulative microseconds,
 /// following the "HH:MM[:SS[.MS]]" format (ISO 8601).
 //
@@ -160,11 +167,41 @@ inline int64_t fromTimeString(const StringView& str) {
 
 // Timestamp conversion
 
-/// Parses a full ISO 8601 timestamp string, following the format:
-///
-///  "YYYY-MM-DD HH:MM[:SS[.MS]]"
-///
-/// Seconds and milliseconds are optional.
+enum class TimestampParseMode {
+  /// Accepted syntax:
+  // clang-format off
+  ///   datetime          = time | date-opt-time
+  ///   time              = 'T' time-element [offset]
+  ///   date-opt-time     = date-element ['T' [time-element] [offset]]
+  ///   date-element      = yyyy ['-' MM ['-' dd]]
+  ///   time-element      = HH [minute-element] | [fraction]
+  ///   minute-element    = ':' mm [second-element] | [fraction]
+  ///   second-element    = ':' ss [fraction]
+  ///   fraction          = ('.' | ',') digit+
+  ///   offset            = 'Z' | (('+' | '-') HH [':' mm [':' ss [('.' | ',') SSS]]])
+  // clang-format on
+  kIso8601,
+
+  /// Accepted syntax:
+  // clang-format off
+  ///   date-opt-time     = date-element [' ' [time-element] [[' '] [offset]]]
+  ///   date-element      = yyyy ['-' MM ['-' dd]]
+  ///   time-element      = HH [minute-element] | [fraction]
+  ///   minute-element    = ':' mm [second-element] | [fraction]
+  ///   second-element    = ':' ss [fraction]
+  ///   fraction          = '.' digit+
+  ///   offset            = 'Z' | ZZZ
+  // clang-format on
+  // Allows leading and trailing spaces.
+  kPrestoCast,
+
+  /// A Spark-compatible timestamp string. A mix of the above. Accepts T and
+  /// space as separator between date and time. Allows leading and trailing
+  /// spaces.
+  kSparkCast,
+};
+
+/// Parses a timestamp string using specified TimestampParseMode.
 ///
 /// This function does not accept any timezone information in the string (e.g.
 /// UTC, Z, or a timezone offsets). This is because the returned timestamp does
@@ -175,15 +212,16 @@ inline int64_t fromTimeString(const StringView& str) {
 ///
 /// For a timezone-aware version of this function, check
 /// `fromTimestampWithTimezoneString()` below.
-Expected<Timestamp> fromTimestampString(const char* buf, size_t len);
+Expected<Timestamp>
+fromTimestampString(const char* buf, size_t len, TimestampParseMode parseMode);
 
-inline Expected<Timestamp> fromTimestampString(const StringView& str) {
-  return fromTimestampString(str.data(), str.size());
+inline Expected<Timestamp> fromTimestampString(
+    const StringView& str,
+    TimestampParseMode parseMode) {
+  return fromTimestampString(str.data(), str.size(), parseMode);
 }
 
-/// Parses a full ISO 8601 timestamp string, following the format:
-///
-///  "YYYY-MM-DD HH:MM[:SS[.MS]] +00:00"
+/// Parses a timestamp string using specified TimestampParseMode.
 ///
 /// This is a timezone-aware version of the function above
 /// `fromTimestampString()` which returns both the parsed timestamp and the
@@ -197,13 +235,15 @@ inline Expected<Timestamp> fromTimestampString(const StringView& str) {
 ///
 /// -1 means no timezone information was found. Throws VeloxUserError in case of
 /// parsing errors.
-Expected<std::pair<Timestamp, int64_t>> fromTimestampWithTimezoneString(
+Expected<std::pair<Timestamp, int16_t>> fromTimestampWithTimezoneString(
     const char* buf,
-    size_t len);
+    size_t len,
+    TimestampParseMode parseMode);
 
-inline Expected<std::pair<Timestamp, int64_t>> fromTimestampWithTimezoneString(
-    const StringView& str) {
-  return fromTimestampWithTimezoneString(str.data(), str.size());
+inline Expected<std::pair<Timestamp, int16_t>> fromTimestampWithTimezoneString(
+    const StringView& str,
+    TimestampParseMode parseMode) {
+  return fromTimestampWithTimezoneString(str.data(), str.size(), parseMode);
 }
 
 Timestamp fromDatetime(int64_t daysSinceEpoch, int64_t microsSinceMidnight);

--- a/velox/type/tz/TimeZoneMap.cpp
+++ b/velox/type/tz/TimeZoneMap.cpp
@@ -117,7 +117,7 @@ std::string getTimeZoneName(int64_t timeZoneID) {
   return it->second;
 }
 
-int64_t getTimeZoneID(std::string_view timeZone, bool failOnError) {
+int16_t getTimeZoneID(std::string_view timeZone, bool failOnError) {
   static folly::F14FastMap<std::string, int64_t> nameToIdMap =
       makeReverseMap(getTimeZoneDB());
   std::string timeZoneLowered;

--- a/velox/type/tz/TimeZoneMap.h
+++ b/velox/type/tz/TimeZoneMap.h
@@ -26,6 +26,6 @@ std::string getTimeZoneName(int64_t timeZoneID);
 // Returns the timeZoneID for the timezone name.
 // If failOnError = true, throws an exception for unrecognized timezone.
 // Otherwise, returns -1.
-int64_t getTimeZoneID(std::string_view timeZone, bool failOnError = true);
+int16_t getTimeZoneID(std::string_view timeZone, bool failOnError = true);
 
 } // namespace facebook::velox::util


### PR DESCRIPTION
Summary:
from_iso8601_timestamp parses the ISO 8601 formatted string into a timestamp with time zone.

Accepts formats described by the following syntax::

        datetime          = time | date-opt-time
        time              = 'T' time-element [offset]
        date-opt-time     = date-element ['T' [time-element] [offset]]
        date-element      = yyyy ['-' MM ['-' dd]]
        time-element      = HH [minute-element] | [fraction]
        minute-element    = ':' mm [second-element] | [fraction]
        second-element    = ':' ss [fraction]
        fraction          = ('.' | ',') digit+
        offset            = 'Z' | (('+' | '-') HH [':' mm [':' ss [('.' | ',') SSS]]])

Examples of valid input strings:

* '2012'
* '2012-4'
* '2012-04'
* '2012-4-7'
* '2012-04-07'
* '2012-04-07   '
* '2012-04T01:02'
* 'T01:02:34'
* 'T01:02:34,123'
* '2012-04-07T01:02:34'
* '2012-04-07T01:02:34.123'
* '2012-04-07T01:02:34,123'
* '2012-04-07T01:02:34.123Z'
* '2012-04-07T01:02:34.123-05:00'

Limitations:

- Presto doesn't allow leading or trailing spaces, but Velox allows leading spaces. This limitation exists for from_iso8601_date as well: https://github.com/facebookincubator/velox/issues/10061
- Presto supports ordinal and week dates, but Velox doesn't. This limitation exists for from_iso8601_date as well: https://github.com/facebookincubator/velox/issues/10058

from_iso8601_timestamp is similar to CAST, but it is not the same. CAST accepts the following formats:

       date-opt-time     = date-element [' ' [time-element] [[' '] [offset]]]
       date-element      = yyyy ['-' MM ['-' dd]]
       time-element      = HH [minute-element] | [fraction]
       minute-element    = ':' mm [second-element] | [fraction]
       second-element    = ':' ss [fraction]
       fraction          = '.' digit+
       offset            = 'Z' | ZZZ

Notable differences are:

* Separator between date and time: space in CAST; T in from_iso.
* Separator between seconds and microseconds: period in CAST; period or comma in from_iso.
* Time zones: offsets or names in CAST; only offsets in from_iso.
* Partial date: not allowed in CAST; allowed in from_iso.
* Hour-only time: not allowed in CAST; allowed in from_iso.
* Leading and trailing whitespaces: allowed in CAST; not allowed in from_iso.

Also, fixed CAST(varchar AS timestamp) and CAST(varchar AS timestamp with time
zone) to not accept 'T' as the separator between date and time. 

Fixes https://github.com/facebookincubator/velox/issues/7258

Fixes https://github.com/facebookincubator/velox/issues/10059

Differential Revision: D58182255


