### PR TITLE
Optimize date_trunc

### DIFF
--- a/velox/functions/lib/TimeUtils.h
+++ b/velox/functions/lib/TimeUtils.h
@@ -52,7 +52,7 @@ std::tm getDateTime(Timestamp timestamp, const date::time_zone* timeZone) {
   int64_t seconds = getSeconds(timestamp, timeZone);
   std::tm dateTime;
   VELOX_USER_CHECK(
-      Timestamp::epochToUtc(seconds, dateTime),
+      Timestamp::epochToCalendarUtc(seconds, dateTime),
       "Timestamp is too large: {} seconds since epoch",
       seconds);
   return dateTime;
@@ -64,7 +64,7 @@ std::tm getDateTime(int32_t days) {
   int64_t seconds = days * kSecondsInDay;
   std::tm dateTime;
   VELOX_USER_CHECK(
-      Timestamp::epochToUtc(seconds, dateTime),
+      Timestamp::epochToCalendarUtc(seconds, dateTime),
       "Date is too large: {} days",
       days);
   return dateTime;

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -931,7 +931,7 @@ struct DateTruncFunction : public TimestampWithTimezoneSupport<T> {
       default:
         auto dateTime = getDateTime(timestamp, timeZone_);
         adjustDateTime(dateTime, unit);
-        result = Timestamp(timegm(&dateTime), 0);
+        result = Timestamp(Timestamp::calendarUtcToEpoch(dateTime), 0);
     }
 
     if (timeZone_ != nullptr) {
@@ -955,7 +955,7 @@ struct DateTruncFunction : public TimestampWithTimezoneSupport<T> {
     auto dateTime = getDateTime(date);
     adjustDateTime(dateTime, unit);
 
-    result = timegm(&dateTime) / kSecondsInDay;
+    result = Timestamp::calendarUtcToEpoch(dateTime) / kSecondsInDay;
   }
 
   FOLLY_ALWAYS_INLINE void call(
@@ -980,7 +980,8 @@ struct DateTruncFunction : public TimestampWithTimezoneSupport<T> {
     auto timestamp = this->toTimestamp(timestampWithTimezone);
     auto dateTime = getDateTime(timestamp, nullptr);
     adjustDateTime(dateTime, unit);
-    timestamp = Timestamp::fromMillis(timegm(&dateTime) * 1000);
+    timestamp =
+        Timestamp::fromMillis(Timestamp::calendarUtcToEpoch(dateTime) * 1000);
     timestamp.toGMT(unpackZoneKeyId(timestampWithTimezone));
 
     result = pack(timestamp.toMillis(), unpackZoneKeyId(timestampWithTimezone));

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -282,7 +282,13 @@ struct Timestamp {
   /// concurrency (71% of time is on __tz_convert for some queries).
   ///
   /// Return whether the epoch second can be converted to a valid std::tm.
-  static bool epochToUtc(int64_t seconds, std::tm& out);
+  static bool epochToCalendarUtc(int64_t seconds, std::tm& out);
+
+  /// Our own version of timegm to avoid expensive calls to __tz_convert.
+  ///
+  /// This function is guaranteed to give same result as std::timegm when it is
+  /// successful.
+  static int64_t calendarUtcToEpoch(const std::tm& tm);
 
   /// Converts a std::tm to a time/date/timestamp string in ISO 8601 format
   /// according to TimestampToStringOptions.
@@ -390,7 +396,7 @@ struct Timestamp {
   std::string toString(const TimestampToStringOptions& options = {}) const {
     std::tm tm;
     VELOX_USER_CHECK(
-        epochToUtc(seconds_, tm),
+        epochToCalendarUtc(seconds_, tm),
         "Can't convert seconds to time: {}",
         seconds_);
     std::string result;

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -990,7 +990,7 @@ std::string DateType::toIso8601(int32_t days) {
   int64_t daySeconds = days * (int64_t)(86400);
   std::tm tmValue;
   VELOX_CHECK(
-      Timestamp::epochToUtc(daySeconds, tmValue),
+      Timestamp::epochToCalendarUtc(daySeconds, tmValue),
       "Can't convert days to dates: {}",
       days);
   TimestampToStringOptions options;


### PR DESCRIPTION
Summary: Replace the slow `timegm` function with our own implementation.  This improves some queries by more than 30 times in CPU time (from 140.78 days to 4.46 days, vs Java 14.00 days).

Differential Revision: D58191555


