### PR TITLE
Add support for casting hex floating string to floating-point types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -530,6 +530,7 @@ if(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
 endif()
 find_package(BISON 3.0.4 REQUIRED)
 find_package(FLEX 2.5.13 REQUIRED)
+find_package(double-conversion 3.1.5 REQUIRED)
 
 include_directories(SYSTEM velox)
 include_directories(SYSTEM velox/external)

--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -429,9 +429,9 @@ Valid examples
   SELECT cast('1.' as real); -- 1.0
   SELECT cast('1' as real); -- 1.0
   SELECT cast('1.7E308' as real); -- Infinity
-  SELECT cast('Infinity' as real); -- Infinity (case insensitive)
-  SELECT cast('-Infinity' as real); -- -Infinity (case insensitive)
-  SELECT cast('NaN' as real); -- NaN (case insensitive)
+  SELECT cast('Infinity' as real); -- Infinity (case sensitive)
+  SELECT cast('-Infinity' as real); -- -Infinity (case sensitive)
+  SELECT cast('NaN' as real); -- NaN (case sensitive)
 
 Invalid examples
 
@@ -439,21 +439,13 @@ Invalid examples
 
   SELECT cast('1.2a' as real); -- Invalid argument
   SELECT cast('1.2.3' as real); -- Invalid argument
-
-There are a few corner cases where Velox behaves differently from Presto.
-Presto throws INVALID_CAST_ARGUMENT on these queries, while Velox allows these
-conversions. We keep the Velox behaivor by intention because it is more
-consistent with other supported cases of cast.
-
-::
-
-  SELECT cast('infinity' as real); -- Infinity
-  SELECT cast('-infinity' as real); -- -Infinity
-  SELECT cast('inf' as real); -- Infinity
-  SELECT cast('InfiNiTy' as real); -- Infinity
-  SELECT cast('INFINITY' as real); -- Infinity
-  SELECT cast('nAn' as real); -- NaN
-  SELECT cast('nan' as real); -- NaN
+  SELECT cast('infinity' as real); -- Invalid argument
+  SELECT cast('-infinity' as real); -- -Invalid argument
+  SELECT cast('inf' as real); -- Invalid argument
+  SELECT cast('InfiNiTy' as real); -- Invalid argument
+  SELECT cast('INFINITY' as real); -- Invalid argument
+  SELECT cast('nAn' as real); -- Invalid argument
+  SELECT cast('nan' as real); -- Invalid argument
 
 Below cases are supported in Presto, but throw in Velox.
 

--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -428,6 +428,8 @@ Valid examples
 
   SELECT cast('1.' as real); -- 1.0
   SELECT cast('1' as real); -- 1.0
+  SELECT cast('0x1.2p3' as real); -- 9.0
+  SELECT cast('01234' as real); -- 1234.0
   SELECT cast('1.7E308' as real); -- Infinity
   SELECT cast('Infinity' as real); -- Infinity (case sensitive)
   SELECT cast('-Infinity' as real); -- -Infinity (case sensitive)

--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -50,8 +50,14 @@ add_library(
   VectorFunction.cpp)
 
 target_link_libraries(
-  velox_expression velox_core velox_vector velox_common_base
-  velox_expression_functions velox_functions_util)
+  velox_expression
+  velox_core
+  velox_vector
+  velox_common_base
+  velox_expression_functions
+  velox_functions_util
+  double-conversion::double-conversion
+  Folly::folly)
 
 add_subdirectory(type_calculation)
 add_subdirectory(signature_parser)

--- a/velox/expression/CastHooks.h
+++ b/velox/expression/CastHooks.h
@@ -22,8 +22,8 @@
 namespace facebook::velox::exec {
 
 /// This class provides cast hooks to allow different behaviors of CastExpr and
-/// SparkCastExpr. The main purpose is crate customized cast implementation by
-/// taking full usage of existing cast expression.
+/// SparkCastExpr. The main purpose is to create customized cast implementation
+/// by taking full usage of existing cast expression.
 class CastHooks {
  public:
   virtual ~CastHooks() = default;
@@ -33,6 +33,14 @@ class CastHooks {
 
   virtual Expected<int32_t> castStringToDate(
       const StringView& dateString) const = 0;
+
+  // 'data' is guaranteed to be non-empty and has been processed by
+  // removeWhiteSpaces.
+  virtual Expected<float> castStringToReal(const StringView& data) const = 0;
+
+  // 'data' is guaranteed to be non-empty and has been processed by
+  // removeWhiteSpaces.
+  virtual Expected<double> castStringToDouble(const StringView& data) const = 0;
 
   // Returns whether legacy cast semantics are enabled.
   virtual bool legacy() const = 0;

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -79,7 +79,8 @@ template <typename T>
 Expected<T> doCastToFloatingPoint(const StringView& data) {
   static const T kNan = std::numeric_limits<T>::quiet_NaN();
   static StringToDoubleConverter stringToDoubleConverter{
-      StringToDoubleConverter::ALLOW_TRAILING_SPACES,
+      StringToDoubleConverter::ALLOW_TRAILING_SPACES |
+          StringToDoubleConverter::ALLOW_HEX_FLOATS,
       /*empty_string_value*/ kNan,
       /*junk_string_value*/ kNan,
       "Infinity",

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -14,8 +14,14 @@
  * limitations under the License.
  */
 
+#include <cmath>
+
+#include <double-conversion/double-conversion.h>
+#include <folly/Expected.h>
+
 #include "velox/expression/PrestoCastHooks.h"
 #include "velox/external/date/tz.h"
+#include "velox/functions/lib/string/StringImpl.h"
 #include "velox/type/TimestampConversion.h"
 
 namespace facebook::velox::exec {
@@ -63,6 +69,53 @@ Expected<int32_t> PrestoCastHooks::castStringToDate(
   // Cast from string to date allows only complete ISO 8601 formatted strings:
   // [+-](YYYY-MM-DD).
   return util::castFromDateString(dateString, util::ParseMode::kStandardCast);
+}
+
+namespace {
+
+using double_conversion::StringToDoubleConverter;
+
+template <typename T>
+Expected<T> doCastToFloatingPoint(const StringView& data) {
+  static const T kNan = std::numeric_limits<T>::quiet_NaN();
+  static StringToDoubleConverter stringToDoubleConverter{
+      StringToDoubleConverter::ALLOW_TRAILING_SPACES,
+      /*empty_string_value*/ kNan,
+      /*junk_string_value*/ kNan,
+      "Infinity",
+      "NaN"};
+  int processedCharactersCount;
+  T result;
+  auto* begin = std::find_if_not(data.begin(), data.end(), [](char c) {
+    return functions::stringImpl::isAsciiWhiteSpace(c);
+  });
+  auto length = data.end() - begin;
+  if constexpr (std::is_same_v<T, float>) {
+    result = stringToDoubleConverter.StringToFloat(
+        begin, length, &processedCharactersCount);
+  } else if constexpr (std::is_same_v<T, double>) {
+    result = stringToDoubleConverter.StringToDouble(
+        begin, length, &processedCharactersCount);
+  }
+  // Since we already removed leading space, if processedCharactersCount == 0,
+  // it means the remaining string is either empty or a junk string. So return a
+  // user error in this case.
+  if UNLIKELY (processedCharactersCount == 0) {
+    return folly::makeUnexpected(Status::UserError());
+  }
+  return result;
+}
+
+} // namespace
+
+Expected<float> PrestoCastHooks::castStringToReal(
+    const StringView& data) const {
+  return doCastToFloatingPoint<float>(data);
+}
+
+Expected<double> PrestoCastHooks::castStringToDouble(
+    const StringView& data) const {
+  return doCastToFloatingPoint<double>(data);
 }
 
 StringView PrestoCastHooks::removeWhiteSpaces(const StringView& view) const {

--- a/velox/expression/PrestoCastHooks.h
+++ b/velox/expression/PrestoCastHooks.h
@@ -34,6 +34,14 @@ class PrestoCastHooks : public CastHooks {
   Expected<int32_t> castStringToDate(
       const StringView& dateString) const override;
 
+  // Allows casting 'NaN', 'Infinity', and '-Infinity' to real, but not 'Inf' or
+  // these strings with different letter cases.
+  Expected<float> castStringToReal(const StringView& data) const override;
+
+  // Allows casting 'NaN', 'Infinity', and '-Infinity' to double, but not 'Inf'
+  // or these strings with different letter cases.
+  Expected<double> castStringToDouble(const StringView& data) const override;
+
   bool legacy() const override {
     return legacyCast_;
   }

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -1053,6 +1053,9 @@ TEST_F(CastExprTest, primitiveValidCornerCases) {
     testCast<std::string, float>("real", {"  NaN  "}, {kNan});
     testCast<std::string, float>("real", {"  -NaN  "}, {kNan});
     testCast<std::string, float>("real", {"  +NaN  "}, {kNan});
+    testCast<std::string, float>("real", {" 0x1.2p3 "}, {9.0});
+    testCast<std::string, float>("real", {" 0x10.1p0 "}, {16.0625});
+    testCast<std::string, float>("real", {"01234"}, {1234});
   }
 
   // To boolean.

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -339,27 +339,13 @@ TEST_F(CastExprTest, basics) {
       {false, true, true, true, true, true, true, true, true});
   testCast<std::string, float>(
       "float",
-      {"1.888",
-       "1.",
-       "1",
-       "1.7E308",
-       "Infinity",
-       "-Infinity",
-       "infinity",
-       "inf",
-       "INFINITY",
-       "NaN",
-       "nan"},
+      {"1.888", "1.", "1", "1.7E308", "Infinity", "-Infinity", "NaN"},
       {1.888,
        1.0,
        1.0,
        std::numeric_limits<float>::infinity(),
        std::numeric_limits<float>::infinity(),
        -std::numeric_limits<float>::infinity(),
-       std::numeric_limits<float>::infinity(),
-       std::numeric_limits<float>::infinity(),
-       std::numeric_limits<float>::infinity(),
-       std::numeric_limits<float>::quiet_NaN(),
        std::numeric_limits<float>::quiet_NaN()});
 
   gflags::FlagSaver flagSaver;
@@ -996,13 +982,29 @@ TEST_F(CastExprTest, primitiveInvalidCornerCases) {
 
     // Invalid strings.
     testInvalidCast<std::string>(
-        "real",
-        {"1.2a"},
-        "Non-whitespace character found after end of conversion");
+        "real", {"1.2a"}, "Cannot cast VARCHAR '1.2a' to REAL");
     testInvalidCast<std::string>(
-        "real",
-        {"1.2.3"},
-        "Non-whitespace character found after end of conversion");
+        "real", {"1.2.3"}, "Cannot cast VARCHAR '1.2.3' to REAL");
+    testInvalidCast<std::string>(
+        "real", {"nAn"}, "Cannot cast VARCHAR 'nAn' to REAL");
+    testInvalidCast<std::string>(
+        "real", {" nAn "}, "Cannot cast VARCHAR ' nAn ' to REAL");
+    testInvalidCast<std::string>(
+        "double", {"nAn"}, "Cannot cast VARCHAR 'nAn' to DOUBLE");
+    testInvalidCast<std::string>(
+        "real", {"iNfinitY"}, "Cannot cast VARCHAR 'iNfinitY' to REAL");
+    testInvalidCast<std::string>(
+        "double", {"iNfinitY"}, "Cannot cast VARCHAR 'iNfinitY' to DOUBLE");
+    testInvalidCast<std::string>(
+        "double", {" iNfinitY "}, "Cannot cast VARCHAR ' iNfinitY ' to DOUBLE");
+    testInvalidCast<std::string>(
+        "double", {""}, "Cannot cast VARCHAR '' to DOUBLE");
+    testInvalidCast<std::string>(
+        "double", {"   "}, "Cannot cast VARCHAR '   ' to DOUBLE");
+    testInvalidCast<std::string>(
+        "real", {"NaN  ."}, "Cannot cast VARCHAR 'NaN  .' to REAL");
+    testInvalidCast<std::string>(
+        "real", {"- NaN"}, "Cannot cast VARCHAR '- NaN' to REAL");
   }
 
   // To boolean.
@@ -1047,14 +1049,10 @@ TEST_F(CastExprTest, primitiveValidCornerCases) {
     testCast<std::string, float>("real", {"1.7E308"}, {kInf});
     testCast<std::string, float>("real", {"1."}, {1.0});
     testCast<std::string, float>("real", {"1"}, {1});
-    // When casting from "Infinity" and "NaN", Presto is case sensitive. But we
-    // let them be case insensitive to be consistent with other conversions.
-    testCast<std::string, float>("real", {"infinity"}, {kInf});
-    testCast<std::string, float>("real", {"-infinity"}, {-kInf});
-    testCast<std::string, float>("real", {"InfiNiTy"}, {kInf});
-    testCast<std::string, float>("real", {"-InfiNiTy"}, {-kInf});
-    testCast<std::string, float>("real", {"nan"}, {kNan});
-    testCast<std::string, float>("real", {"nAn"}, {kNan});
+    testCast<std::string, float>("real", {"  1  "}, {1});
+    testCast<std::string, float>("real", {"  NaN  "}, {kNan});
+    testCast<std::string, float>("real", {"  -NaN  "}, {kNan});
+    testCast<std::string, float>("real", {"  +NaN  "}, {kNan});
   }
 
   // To boolean.

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -42,6 +42,15 @@ Expected<int32_t> SparkCastHooks::castStringToDate(
       removeWhiteSpaces(dateString), util::ParseMode::kNonStandardCast);
 }
 
+Expected<float> SparkCastHooks::castStringToReal(const StringView& data) const {
+  return util::Converter<TypeKind::REAL>::tryCast(data);
+}
+
+Expected<double> SparkCastHooks::castStringToDouble(
+    const StringView& data) const {
+  return util::Converter<TypeKind::DOUBLE>::tryCast(data);
+}
+
 StringView SparkCastHooks::removeWhiteSpaces(const StringView& view) const {
   StringView output;
   stringImpl::trimUnicodeWhiteSpace<true, true, StringView, StringView>(

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -32,6 +32,14 @@ class SparkCastHooks : public exec::CastHooks {
   Expected<int32_t> castStringToDate(
       const StringView& dateString) const override;
 
+  // Allows casting 'NaN', 'Infinity', '-Infinity', 'Inf', '-Inf', and these
+  // strings with different letter cases to real.
+  Expected<float> castStringToReal(const StringView& data) const override;
+
+  // Allows casting 'NaN', 'Infinity', '-Infinity', 'Inf', '-Inf', and these
+  // strings with different letter cases to double.
+  Expected<double> castStringToDouble(const StringView& data) const override;
+
   bool legacy() const override {
     return false;
   }


### PR DESCRIPTION
Summary: Allows casting from hex floating strings to floating-point types, such as `cast('0x1.2p3' as double) -- 9.0`.

Differential Revision: D58201095
