### PR TITLE
Rename prestosql/SIMDJsonXxx structs to JsonXxx

### DIFF
--- a/velox/functions/prestosql/JsonFunctions.h
+++ b/velox/functions/prestosql/JsonFunctions.h
@@ -26,7 +26,7 @@
 namespace facebook::velox::functions {
 
 template <typename T>
-struct SIMDIsJsonScalarFunction {
+struct IsJsonScalarFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE Status call(bool& result, const arg_type<Json>& json) {
@@ -52,7 +52,7 @@ struct SIMDIsJsonScalarFunction {
 };
 
 template <typename TExec>
-struct SIMDJsonArrayContainsFunction {
+struct JsonArrayContainsFunction {
   VELOX_DEFINE_FUNCTION_TYPES(TExec);
 
   template <typename T>
@@ -122,7 +122,7 @@ struct SIMDJsonArrayContainsFunction {
 };
 
 template <typename T>
-struct SIMDJsonArrayLengthFunction {
+struct JsonArrayLengthFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE bool call(int64_t& len, const arg_type<Json>& json) {
@@ -148,7 +148,7 @@ struct SIMDJsonArrayLengthFunction {
 };
 
 template <typename TExec>
-struct SIMDJsonArrayGetFunction {
+struct JsonArrayGetFunction {
   VELOX_DEFINE_FUNCTION_TYPES(TExec);
 
   FOLLY_ALWAYS_INLINE bool
@@ -194,7 +194,7 @@ struct SIMDJsonArrayGetFunction {
 // to being encoded as JSON). The value referenced by json_path must be a scalar
 // (boolean, number or string)
 template <typename T>
-struct SIMDJsonExtractScalarFunction {
+struct JsonExtractScalarFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE bool call(
@@ -257,7 +257,7 @@ struct SIMDJsonExtractScalarFunction {
 };
 
 template <typename T>
-struct SIMDJsonExtractFunction {
+struct JsonExtractFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   bool call(
@@ -337,7 +337,7 @@ struct SIMDJsonExtractFunction {
 };
 
 template <typename T>
-struct SIMDJsonSizeFunction {
+struct JsonSizeFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE bool call(

--- a/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
@@ -15,57 +15,57 @@
  */
 
 #include "velox/functions/Registerer.h"
-#include "velox/functions/prestosql/SIMDJsonFunctions.h"
+#include "velox/functions/prestosql/JsonFunctions.h"
 
 namespace facebook::velox::functions {
 void registerJsonFunctions(const std::string& prefix) {
   registerJsonType();
 
-  registerFunction<SIMDIsJsonScalarFunction, bool, Json>(
+  registerFunction<IsJsonScalarFunction, bool, Json>(
       {prefix + "is_json_scalar"});
-  registerFunction<SIMDIsJsonScalarFunction, bool, Varchar>(
+  registerFunction<IsJsonScalarFunction, bool, Varchar>(
       {prefix + "is_json_scalar"});
 
-  registerFunction<SIMDJsonExtractScalarFunction, Varchar, Json, Varchar>(
+  registerFunction<JsonExtractScalarFunction, Varchar, Json, Varchar>(
       {prefix + "json_extract_scalar"});
-  registerFunction<SIMDJsonExtractScalarFunction, Varchar, Varchar, Varchar>(
+  registerFunction<JsonExtractScalarFunction, Varchar, Varchar, Varchar>(
       {prefix + "json_extract_scalar"});
 
-  registerFunction<SIMDJsonExtractFunction, Json, Json, Varchar>(
+  registerFunction<JsonExtractFunction, Json, Json, Varchar>(
       {prefix + "json_extract"});
-  registerFunction<SIMDJsonExtractFunction, Json, Varchar, Varchar>(
+  registerFunction<JsonExtractFunction, Json, Varchar, Varchar>(
       {prefix + "json_extract"});
 
-  registerFunction<SIMDJsonArrayLengthFunction, int64_t, Json>(
+  registerFunction<JsonArrayLengthFunction, int64_t, Json>(
       {prefix + "json_array_length"});
-  registerFunction<SIMDJsonArrayLengthFunction, int64_t, Varchar>(
+  registerFunction<JsonArrayLengthFunction, int64_t, Varchar>(
       {prefix + "json_array_length"});
 
-  registerFunction<SIMDJsonArrayContainsFunction, bool, Json, bool>(
+  registerFunction<JsonArrayContainsFunction, bool, Json, bool>(
       {prefix + "json_array_contains"});
-  registerFunction<SIMDJsonArrayContainsFunction, bool, Varchar, bool>(
+  registerFunction<JsonArrayContainsFunction, bool, Varchar, bool>(
       {prefix + "json_array_contains"});
-  registerFunction<SIMDJsonArrayContainsFunction, bool, Json, int64_t>(
+  registerFunction<JsonArrayContainsFunction, bool, Json, int64_t>(
       {prefix + "json_array_contains"});
-  registerFunction<SIMDJsonArrayContainsFunction, bool, Varchar, int64_t>(
+  registerFunction<JsonArrayContainsFunction, bool, Varchar, int64_t>(
       {prefix + "json_array_contains"});
-  registerFunction<SIMDJsonArrayContainsFunction, bool, Json, double>(
+  registerFunction<JsonArrayContainsFunction, bool, Json, double>(
       {prefix + "json_array_contains"});
-  registerFunction<SIMDJsonArrayContainsFunction, bool, Varchar, double>(
+  registerFunction<JsonArrayContainsFunction, bool, Varchar, double>(
       {prefix + "json_array_contains"});
-  registerFunction<SIMDJsonArrayContainsFunction, bool, Json, Varchar>(
+  registerFunction<JsonArrayContainsFunction, bool, Json, Varchar>(
       {prefix + "json_array_contains"});
-  registerFunction<SIMDJsonArrayContainsFunction, bool, Varchar, Varchar>(
+  registerFunction<JsonArrayContainsFunction, bool, Varchar, Varchar>(
       {prefix + "json_array_contains"});
 
-  registerFunction<SIMDJsonArrayGetFunction, Json, Json, int64_t>(
+  registerFunction<JsonArrayGetFunction, Json, Json, int64_t>(
       {prefix + "json_array_get"});
-  registerFunction<SIMDJsonArrayGetFunction, Json, Varchar, int64_t>(
+  registerFunction<JsonArrayGetFunction, Json, Varchar, int64_t>(
       {prefix + "json_array_get"});
 
-  registerFunction<SIMDJsonSizeFunction, int64_t, Json, Varchar>(
+  registerFunction<JsonSizeFunction, int64_t, Json, Varchar>(
       {prefix + "json_size"});
-  registerFunction<SIMDJsonSizeFunction, int64_t, Varchar, Varchar>(
+  registerFunction<JsonSizeFunction, int64_t, Varchar, Varchar>(
       {prefix + "json_size"});
 
   VELOX_REGISTER_VECTOR_FUNCTION(udf_json_format, prefix + "json_format");


### PR DESCRIPTION
Summary:
We no longer have two versions of json functions. We replaced all(*) folly-based
functions with simdjson. Hence, no need for SIMD prefix.

(*) The only json function that still uses folly is json_format. That's because simdjson library only supports parsing JSON.

Differential Revision: D58206474
