### PR TITLE
Fix NaN handling for histogram, map_agg and map_union aggregates

### DIFF
--- a/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
@@ -28,12 +28,10 @@ namespace {
 
 template <typename T>
 struct Accumulator {
-  using ValueMap = folly::F14FastMap<
+  using ValueMap = typename util::floating_point::HashMapNaNAwareTypeTraits<
       T,
       int64_t,
-      std::hash<T>,
-      std::equal_to<T>,
-      AlignedStlAllocator<std::pair<const T, int64_t>, 16>>;
+      AlignedStlAllocator<std::pair<const T, int64_t>, 16>>::Type;
   ValueMap values;
 
   explicit Accumulator(HashStringAllocator* allocator)

--- a/velox/functions/prestosql/aggregates/MapAccumulator.h
+++ b/velox/functions/prestosql/aggregates/MapAccumulator.h
@@ -226,6 +226,22 @@ struct MapAccumulatorTypeTraits {
 };
 
 template <>
+struct MapAccumulatorTypeTraits<float> {
+  using AccumulatorType = MapAccumulator<
+      float,
+      util::floating_point::NaNAwareHash<float>,
+      util::floating_point::NaNAwareEquals<float>>;
+};
+
+template <>
+struct MapAccumulatorTypeTraits<double> {
+  using AccumulatorType = MapAccumulator<
+      double,
+      util::floating_point::NaNAwareHash<double>,
+      util::floating_point::NaNAwareEquals<double>>;
+};
+
+template <>
 struct MapAccumulatorTypeTraits<StringView> {
   using AccumulatorType = StringViewMapAccumulator;
 };


### PR DESCRIPTION
Summary:
Ensures that NaNs with different binary representations are considered
equal and deduplicated when used as keys in a map.

Summary of changes:
For primitive types, we ensure that the Map data structure used to
accumulate uses hash and equality functions that handle NaN.
For complex input it uses BaseVector::hashValueAt() and
ContainerRowSerde::compare() as a hash and equality function,
respectively which were fixed to handle NaNs properly in #9963

Differential Revision: D58209683


