### PR TITLE
Fix NaN handling for map_union_sum

### DIFF
--- a/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
@@ -26,13 +26,11 @@ namespace {
 
 template <typename K, typename S>
 struct Accumulator {
-  folly::F14FastMap<
+  using ValuesMap = typename util::floating_point::HashMapNaNAwareTypeTraits<
       K,
       S,
-      std::hash<K>,
-      std::equal_to<K>,
-      AlignedStlAllocator<std::pair<const K, S>, 16>>
-      sums;
+      AlignedStlAllocator<std::pair<const K, S>, 16>>::Type;
+  ValuesMap sums;
 
   explicit Accumulator(HashStringAllocator* allocator)
       : sums{AlignedStlAllocator<std::pair<const K, S>, 16>(allocator)} {}


### PR DESCRIPTION
Summary:
Ensures that NaNs with different binary representations are considered
equal and deduplicated when used as keys in a map.

Differential Revision: D58212769


