### PR TITLE
Add test for multimap_agg for complex keys containing NaN values

### DIFF
--- a/velox/functions/prestosql/aggregates/tests/MultiMapAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MultiMapAggTest.cpp
@@ -299,6 +299,51 @@ TEST_F(MultiMapAggTest, doubleKeyGlobal) {
       // Sort the result arrays to ensure deterministic results.
       {"transform_values(a0, (k, v) -> array_sort(v))"},
       {expected});
+
+  // Input keys are complex type (row).
+  data = makeRowVector({
+      makeRowVector(
+          {makeFlatVector<double>(
+               {KNan1,
+                KNan2,
+                1.1,
+                0.2,
+                23.0,
+                2.0,
+                23.0,
+                2.0,
+                1.1,
+                0.2,
+                23.0,
+                2.0}),
+           makeFlatVector<int64_t>(std::vector<int64_t>(13, 0))}),
+      makeFlatVector<int64_t>({-2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+  });
+
+  expected = makeRowVector({
+      makeMapVector(
+          {
+              0,
+          },
+          makeRowVector(
+              {makeFlatVector<double>({KNan1, 0.2, 1.1, 2.0, 23.0}),
+               makeFlatVector<int64_t>(std::vector<int64_t>(5, 0))}),
+          makeArrayVector<int64_t>({
+              {-2, -1},
+              {1, 7},
+              {0, 6},
+              {3, 5, 9},
+              {2, 4, 8},
+          })),
+  });
+
+  testAggregations(
+      {data},
+      {},
+      {"multimap_agg(c0, c1)"},
+      // Sort the result arrays to ensure deterministic results.
+      {"transform_values(a0, (k, v) -> array_sort(v))"},
+      {expected});
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
The map data structure used in multimap_agg that handles complex keys
uses BaseVector::hashValueAt() and ContainerRowSerde::compare() as its
hash and equals functions respectively. These were fixed in #9963 to handle
NaN values correctly. Therefore, this change adds a unit to verify handling
of complex keys that can contain NaN values.

Differential Revision: D58212803


