### PR TITLE
Memory corruption in PartitionedOutput when keys are not a prefix of input

### DIFF
--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -297,14 +297,18 @@ void PartitionedOutput::collectNullRows() {
 
   decodedVectors_.resize(keyChannels_.size());
 
-  for (auto i : keyChannels_) {
-    if (i == kConstantChannel) {
+  for (size_t keyChannelIndex = 0; keyChannelIndex < keyChannels_.size();
+       ++keyChannelIndex) {
+    column_index_t keyChannel = keyChannels_[keyChannelIndex];
+    // Skip constant channel.
+    if (keyChannel == kConstantChannel) {
       continue;
     }
-    auto& keyVector = input_->childAt(i);
+    auto& keyVector = input_->childAt(keyChannel);
     if (keyVector->mayHaveNulls()) {
-      decodedVectors_[i].decode(*keyVector, rows_);
-      if (auto* rawNulls = decodedVectors_[i].nulls(&rows_)) {
+      DecodedVector& decodedVector = decodedVectors_[keyChannelIndex];
+      decodedVector.decode(*keyVector, rows_);
+      if (auto* rawNulls = decodedVector.nulls(&rows_)) {
         bits::orWithNegatedBits(
             nullRows_.asMutableRange().bits(), rawNulls, 0, size);
       }


### PR DESCRIPTION
Summary:
In PartitionedOutput's collectNullRows() function, it assumes that the key channels are a prefix of the 
input channels, i.e. the keys appear at the beginning of the input type.  It allocates an std::vector of 
size equal to the number of key channels to hold DecodedVectors and assumes it can access these
using the key channels as indices.

When that assumption does not hold it accesses a DecodedVector off the end of that std::vector and
writes to it, leading to memory corruption as it writes to arbitrary memory.

The fix is to access the std::vector using the index of the keyChannel rather than the value of the 
keyChannel.  This guarantees the std::vector is of minimal sufficient size and we do not read off the
end of it.

Note, this bug only happens if some of the keys are not a prefix of the input and 
replicateNullsAndAny is set and there are nulls one of the key columns that is not a prefix of the 
input.

Differential Revision: D58216159


