### PR TITLE
Guard metrics upload and report generation for fork PRs

### DIFF
--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -100,6 +100,8 @@ jobs:
           python3 -m pip install -r scripts/benchmark-requirements.txt
 
       - name: "Upload Metrics"
+        # This disables the upload and report generation on fork PRs but allows it for forks from within the main repo.
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'facebookincubator/velox' }}
         env:
           CONBENCH_URL: "https://velox-conbench.voltrondata.run/"
           CONBENCH_MACHINE_INFO_NAME: "GitHub-runner-${{ matrix.runner }}"
@@ -118,6 +120,7 @@ jobs:
             "/tmp/metrics"
 
   upload-report:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'facebookincubator/velox' }}
     permissions:
       contents: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
I noticed in #9903 that the upload errors due to missing credentials. This PR adds a guard that allows the job to finish :heavy_check_mark: even from a fork. It will still run the upload (for testing) when the PR is from within the main repo. 