### PR TITLE
Add checked_add, checked_divide, checked_multiply, checked_subtract Spark functions

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -69,22 +69,22 @@ Mathematical Functions
 .. function:: check_add(x, y) -> [same as x]
 
     Returns the result of adding x to y. The types of x and y must be the same.
-    For integral types, overflow results in an error. Corresponds to sparks's operator ``+`` with ``failOnError`` as true.
+    For integral types, overflow results in an error. Corresponds to Spark's operator ``+`` with ``failOnError`` as true.
 
 .. function:: check_divide(x, y) -> [same as x]
 
     Returns the results of dividing x by y. The types of x and y must be the same.
-    Division by zero results in an error. Corresponds to sparks's operator ``/`` with ``failOnError`` as true.
+    Division by zero results in an error. Corresponds to Spark's operator ``/`` with ``failOnError`` as true.
 
 .. function:: check_multiply(x, y) -> [same as x]
 
     Returns the result of multiplying x by y. The types of x and y must be the same.
-    For integral types, overflow results in an error. Corresponds to sparks's operator ``*`` with ``failOnError`` as true.
+    For integral types, overflow results in an error. Corresponds to Spark's operator ``*`` with ``failOnError`` as true.
 
 .. function:: check_subtract(x, y) -> [same as x]
 
     Returns the result of subtracting y from x. The types of x and y must be the same.
-    For integral types, overflow results in an error. Corresponds to sparks's operator ``-`` with ``failOnError`` as true.
+    For integral types, overflow results in an error. Corresponds to Spark's operator ``-`` with ``failOnError`` as true.
 
 .. spark:function:: cos(x) -> double
 

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -66,6 +66,26 @@ Mathematical Functions
     Returns ``x`` rounded up to the nearest integer.  
     Supported types are: BIGINT and DOUBLE.
 
+.. function:: check_add(x, y) -> [same as x]
+
+    Returns the result of adding x to y. The types of x and y must be the same and integral types.
+    Overflow results in an error.
+
+.. function:: check_divide(x, y) -> [same as x]
+
+    Returns the results of dividing x by y. The types of x and y must be the same and integral types.
+    Division by zero results in an error.
+
+.. function:: check_multiply(x, y) -> [same as x]
+
+    Returns the result of multiplying x by y. The types of x and y must be the same and integral types.
+    Overflow results in an error.
+
+.. function:: check_subtract(x, y) -> [same as x]
+
+    Returns the result of subtracting y from x. The types of x and y must be the same and integral types.
+    Overflow results in an error.
+
 .. spark:function:: cos(x) -> double
 
     Returns the cosine of ``x``.

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -66,22 +66,22 @@ Mathematical Functions
     Returns ``x`` rounded up to the nearest integer.  
     Supported types are: BIGINT and DOUBLE.
 
-.. function:: check_add(x, y) -> [same as x]
+.. function:: checked_add(x, y) -> [same as x]
 
     Returns the result of adding x to y. The types of x and y must be the same.
     For integral types, overflow results in an error. Corresponds to Spark's operator ``+`` with ``failOnError`` as true.
 
-.. function:: check_divide(x, y) -> [same as x]
+.. function:: checked_divide(x, y) -> [same as x]
 
     Returns the results of dividing x by y. The types of x and y must be the same.
     Division by zero results in an error. Corresponds to Spark's operator ``/`` with ``failOnError`` as true.
 
-.. function:: check_multiply(x, y) -> [same as x]
+.. function:: checked_multiply(x, y) -> [same as x]
 
     Returns the result of multiplying x by y. The types of x and y must be the same.
     For integral types, overflow results in an error. Corresponds to Spark's operator ``*`` with ``failOnError`` as true.
 
-.. function:: check_subtract(x, y) -> [same as x]
+.. function:: checked_subtract(x, y) -> [same as x]
 
     Returns the result of subtracting y from x. The types of x and y must be the same.
     For integral types, overflow results in an error. Corresponds to Spark's operator ``-`` with ``failOnError`` as true.

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -41,7 +41,7 @@ Mathematical Functions
 .. spark:function:: add(x, y) -> [same as x]
 
     Returns the result of adding x to y. The types of x and y must be the same.
-    For integral types, overflow results in an error. Corresponds to sparks's operator ``+``.
+    Corresponds to sparks's operator ``+``.
 
 .. spark:function:: add(x, y) -> decimal
 
@@ -68,23 +68,23 @@ Mathematical Functions
 
 .. function:: check_add(x, y) -> [same as x]
 
-    Returns the result of adding x to y. The types of x and y must be the same and integral types.
-    Overflow results in an error.
+    Returns the result of adding x to y. The types of x and y must be the same.
+    For integral types, overflow results in an error. Corresponds to sparks's operator ``+`` with ``failOnError`` as true.
 
 .. function:: check_divide(x, y) -> [same as x]
 
-    Returns the results of dividing x by y. The types of x and y must be the same and integral types.
-    Division by zero results in an error.
+    Returns the results of dividing x by y. The types of x and y must be the same.
+    Division by zero results in an error. Corresponds to sparks's operator ``/`` with ``failOnError`` as true.
 
 .. function:: check_multiply(x, y) -> [same as x]
 
-    Returns the result of multiplying x by y. The types of x and y must be the same and integral types.
-    Overflow results in an error.
+    Returns the result of multiplying x by y. The types of x and y must be the same.
+    For integral types, overflow results in an error. Corresponds to sparks's operator ``*`` with ``failOnError`` as true.
 
 .. function:: check_subtract(x, y) -> [same as x]
 
-    Returns the result of subtracting y from x. The types of x and y must be the same and integral types.
-    Overflow results in an error.
+    Returns the result of subtracting y from x. The types of x and y must be the same.
+    For integral types, overflow results in an error. Corresponds to sparks's operator ``-`` with ``failOnError`` as true.
 
 .. spark:function:: cos(x) -> double
 
@@ -183,7 +183,7 @@ Mathematical Functions
 .. spark:function:: multiply(x, y) -> [same as x]
 
     Returns the result of multiplying x by y. The types of x and y must be the same.
-    For integral types, overflow results in an error. Corresponds to Spark's operator ``*``.
+    Corresponds to Spark's operator ``*``.
 
 .. spark:function:: multiply(x, y) -> [decimal]
 
@@ -267,7 +267,7 @@ Mathematical Functions
 .. spark:function:: subtract(x, y) -> [same as x]
 
     Returns the result of subtracting y from x. The types of x and y must be the same.
-    For integral types, overflow results in an error. Corresponds to Spark's operator ``-``.
+    Corresponds to Spark's operator ``-``.
 
 .. spark:function:: subtract(x, y) -> decimal
 

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -22,6 +22,7 @@
 #include <type_traits>
 
 #include "velox/common/base/Doubles.h"
+#include "velox/common/base/Status.h"
 #include "velox/functions/Macros.h"
 #include "velox/functions/lib/ToHex.h"
 
@@ -481,6 +482,96 @@ struct RIntFunction {
 
   FOLLY_ALWAYS_INLINE void call(double& result, double input) {
     result = std::rint(input);
+  }
+};
+
+template <typename TExec>
+struct CheckedAddFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+  template <typename T>
+  FOLLY_ALWAYS_INLINE Status call(T& result, const T& a, const T& b) {
+    if constexpr (std::is_integral_v<T>) {
+      T res;
+      bool overflow = __builtin_add_overflow(a, b, &res);
+      if (UNLIKELY(overflow)) {
+        if (threadSkipErrorDetails()) {
+          return Status::UserError();
+        }
+        return Status::UserError(
+            "[ARITHMETIC_OVERFLOW] overflow: {} + {}", a, b);
+      }
+      result = res;
+    } else {
+      result = a + b;
+    }
+    return Status::OK();
+  }
+};
+
+template <typename TExec>
+struct CheckedSubtractFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+  template <typename T>
+  FOLLY_ALWAYS_INLINE Status call(T& result, const T& a, const T& b) {
+    if constexpr (std::is_integral_v<T>) {
+      bool overflow = __builtin_sub_overflow(a, b, &result);
+      if (UNLIKELY(overflow)) {
+        if (threadSkipErrorDetails()) {
+          return Status::UserError();
+        }
+        return Status::UserError(
+            "[ARITHMETIC_OVERFLOW] overflow: {} - {}", a, b);
+      }
+    } else {
+      result = a - b;
+    }
+    return Status::OK();
+  }
+};
+
+template <typename TExec>
+struct CheckedMultiplyFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+  template <typename T>
+  FOLLY_ALWAYS_INLINE Status call(T& result, const T& a, const T& b) {
+    if constexpr (std::is_integral_v<T>) {
+      bool overflow = __builtin_mul_overflow(a, b, &result);
+      if (UNLIKELY(overflow)) {
+        if (threadSkipErrorDetails()) {
+          return Status::UserError();
+        }
+        return Status::UserError(
+            "[ARITHMETIC_OVERFLOW] overflow: {} * {}", a, b);
+      }
+    } else {
+      result = a * b;
+    }
+    return Status::OK();
+  }
+};
+
+template <typename TExec>
+struct CheckedDivideFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+  template <typename T>
+  FOLLY_ALWAYS_INLINE Status call(T& result, const T& a, const T& b) {
+    if (b == 0) {
+      if (threadSkipErrorDetails()) {
+        return Status::UserError();
+      }
+      return Status::UserError("division by zero");
+    }
+    if constexpr (std::is_integral_v<T>) {
+      if (UNLIKELY(a == std::numeric_limits<T>::min() && b == -1)) {
+        if (threadSkipErrorDetails()) {
+          return Status::UserError();
+        }
+        return Status::UserError(
+            "[ARITHMETIC_OVERFLOW] overflow: {} / {}", a, b);
+      }
+    }
+    result = a / b;
+    return Status::OK();
   }
 };
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -497,8 +497,7 @@ struct CheckedAddFunction {
         if (threadSkipErrorDetails()) {
           return Status::UserError();
         }
-        return Status::UserError(
-            "[ARITHMETIC_OVERFLOW] overflow: {} + {}", a, b);
+        return Status::UserError("Arithmetic overflow: {} + {}", a, b);
       }
       result = res;
     } else {
@@ -519,8 +518,7 @@ struct CheckedSubtractFunction {
         if (threadSkipErrorDetails()) {
           return Status::UserError();
         }
-        return Status::UserError(
-            "[ARITHMETIC_OVERFLOW] overflow: {} - {}", a, b);
+        return Status::UserError("Arithmetic overflow: {} - {}", a, b);
       }
     } else {
       result = a - b;
@@ -540,8 +538,7 @@ struct CheckedMultiplyFunction {
         if (threadSkipErrorDetails()) {
           return Status::UserError();
         }
-        return Status::UserError(
-            "[ARITHMETIC_OVERFLOW] overflow: {} * {}", a, b);
+        return Status::UserError("Arithmetic overflow: {} * {}", a, b);
       }
     } else {
       result = a * b;
@@ -566,8 +563,7 @@ struct CheckedDivideFunction {
         if (threadSkipErrorDetails()) {
           return Status::UserError();
         }
-        return Status::UserError(
-            "[ARITHMETIC_OVERFLOW] overflow: {} / {}", a, b);
+        return Status::UserError("Arithmetic overflow: {} / {}", a, b);
       }
     }
     result = a / b;

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -110,6 +110,13 @@ void registerArithmeticFunctions(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_div, prefix + "divide");
   registerFunction<sparksql::IsNanFunction, bool, float>({prefix + "isnan"});
   registerFunction<sparksql::IsNanFunction, bool, double>({prefix + "isnan"});
+
+  // Register checked arithmetic functions for Spark arithmetic exprs with try
+  // eval mode.
+  registerBinaryIntegral<CheckedPlusFunction>({prefix + "check_add"});
+  registerBinaryIntegral<CheckedMinusFunction>({prefix + "check_subtract"});
+  registerBinaryIntegral<CheckedMultiplyFunction>({prefix + "check_multiply"});
+  registerBinaryIntegral<CheckedDivideFunction>({prefix + "check_divide"});
 }
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 #include "velox/functions/sparksql/RegisterArithmetic.h"
-#include "velox/functions/lib/CheckedArithmetic.h"
 #include "velox/functions/lib/RegistrationHelpers.h"
 #include "velox/functions/prestosql/Arithmetic.h"
 #include "velox/functions/sparksql/Arithmetic.h"
@@ -113,10 +112,10 @@ void registerArithmeticFunctions(const std::string& prefix) {
 
   // Register checked arithmetic functions for Spark arithmetic exprs with try
   // eval mode.
-  registerBinaryIntegral<CheckedPlusFunction>({prefix + "check_add"});
-  registerBinaryIntegral<CheckedMinusFunction>({prefix + "check_subtract"});
-  registerBinaryIntegral<CheckedMultiplyFunction>({prefix + "check_multiply"});
-  registerBinaryIntegral<CheckedDivideFunction>({prefix + "check_divide"});
+  registerBinaryNumeric<CheckedAddFunction>({prefix + "check_add"});
+  registerBinaryNumeric<CheckedSubtractFunction>({prefix + "check_subtract"});
+  registerBinaryNumeric<CheckedMultiplyFunction>({prefix + "check_multiply"});
+  registerBinaryNumeric<CheckedDivideFunction>({prefix + "check_divide"});
 }
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -110,8 +110,6 @@ void registerArithmeticFunctions(const std::string& prefix) {
   registerFunction<sparksql::IsNanFunction, bool, float>({prefix + "isnan"});
   registerFunction<sparksql::IsNanFunction, bool, double>({prefix + "isnan"});
 
-  // Register checked arithmetic functions for Spark arithmetic exprs with try
-  // eval mode.
   registerBinaryNumeric<CheckedAddFunction>({prefix + "check_add"});
   registerBinaryNumeric<CheckedSubtractFunction>({prefix + "check_subtract"});
   registerBinaryNumeric<CheckedMultiplyFunction>({prefix + "check_multiply"});

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -110,10 +110,10 @@ void registerArithmeticFunctions(const std::string& prefix) {
   registerFunction<sparksql::IsNanFunction, bool, float>({prefix + "isnan"});
   registerFunction<sparksql::IsNanFunction, bool, double>({prefix + "isnan"});
 
-  registerBinaryNumeric<CheckedAddFunction>({prefix + "check_add"});
-  registerBinaryNumeric<CheckedSubtractFunction>({prefix + "check_subtract"});
-  registerBinaryNumeric<CheckedMultiplyFunction>({prefix + "check_multiply"});
-  registerBinaryNumeric<CheckedDivideFunction>({prefix + "check_divide"});
+  registerBinaryNumeric<CheckedAddFunction>({prefix + "checked_add"});
+  registerBinaryNumeric<CheckedSubtractFunction>({prefix + "checked_subtract"});
+  registerBinaryNumeric<CheckedMultiplyFunction>({prefix + "checked_multiply"});
+  registerBinaryNumeric<CheckedDivideFunction>({prefix + "checked_divide"});
 }
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -147,39 +147,31 @@ class ArithmeticTest : public SparkFunctionBaseTest {
   }
 
   template <typename T>
-  std::optional<T> checkedArithmetic(
-      const std::string& func,
-      const std::optional<T> a,
-      const std::optional<T> b) {
-    return evaluateOnce<T>(fmt::format("{}(c0, c1)", func), a, b);
-  }
-
-  template <typename T>
   std::optional<T> checkedAdd(
       const std::optional<T> a,
       const std::optional<T> b) {
-    return checkedArithmetic<T>("checked_add", a, b);
+    return evaluateOnce<T>("checked_add(c0, c1)", a, b);
   }
 
   template <typename T>
   std::optional<T> checkedDivide(
       const std::optional<T> a,
       const std::optional<T> b) {
-    return checkedArithmetic<T>("checked_divide", a, b);
+    return evaluateOnce<T>("checked_divide(c0, c1)", a, b);
   }
 
   template <typename T>
   std::optional<T> checkedMultiply(
       const std::optional<T> a,
       const std::optional<T> b) {
-    return checkedArithmetic<T>("checked_multiply", a, b);
+    return evaluateOnce<T>("checked_multiply(c0, c1)", a, b);
   }
 
   template <typename T>
-  std::optional<T> checkedSubstract(
+  std::optional<T> checkedSubtract(
       const std::optional<T> a,
       const std::optional<T> b) {
-    return checkedArithmetic<T>("checked_subtract", a, b);
+    return evaluateOnce<T>("checked_subtract(c0, c1)", a, b);
   }
 
   template <typename T>
@@ -224,7 +216,7 @@ class ArithmeticTest : public SparkFunctionBaseTest {
   }
 
   template <typename T>
-  void assertErrorForCheckedSubstract(
+  void assertErrorForcheckedSubtract(
       const std::optional<T> a,
       const std::optional<T> b,
       const std::string& errorMessage) {
@@ -654,17 +646,17 @@ TEST_F(ArithmeticTest, checkedAdd) {
   EXPECT_EQ(checkedAdd<double>(kInfDouble, 1), kInfDouble);
 }
 
-TEST_F(ArithmeticTest, checkedSubstract) {
-  assertErrorForCheckedSubstract<int8_t>(
+TEST_F(ArithmeticTest, checkedSubtract) {
+  assertErrorForcheckedSubtract<int8_t>(
       INT8_MIN, 1, "Arithmetic overflow: -128 - 1");
-  assertErrorForCheckedSubstract<int16_t>(
+  assertErrorForcheckedSubtract<int16_t>(
       INT16_MIN, 1, "Arithmetic overflow: -32768 - 1");
-  assertErrorForCheckedSubstract<int32_t>(
+  assertErrorForcheckedSubtract<int32_t>(
       INT32_MIN, 1, "Arithmetic overflow: -2147483648 - 1");
-  assertErrorForCheckedSubstract<int64_t>(
+  assertErrorForcheckedSubtract<int64_t>(
       INT64_MIN, 1, "Arithmetic overflow: -9223372036854775808 - 1");
-  EXPECT_EQ(checkedSubstract<float>(kInf, 1), kInf);
-  EXPECT_EQ(checkedSubstract<double>(kInfDouble, 1), kInfDouble);
+  EXPECT_EQ(checkedSubtract<float>(kInf, 1), kInf);
+  EXPECT_EQ(checkedSubtract<double>(kInfDouble, 1), kInfDouble);
 }
 
 TEST_F(ArithmeticTest, checkedMultiply) {

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -147,23 +147,11 @@ class ArithmeticTest : public SparkFunctionBaseTest {
   }
 
   template <typename T>
-  std::optional<T> checkAdd(std::optional<T> a, std::optional<T> b) {
-    return evaluateOnce<T>("check_add(c0, c1)", a, b);
-  }
-
-  template <typename T>
-  std::optional<T> checkSubstract(std::optional<T> a, std::optional<T> b) {
-    return evaluateOnce<T>("check_subtract(c0, c1)", a, b);
-  }
-
-  template <typename T>
-  std::optional<T> checkMultiply(std::optional<T> a, std::optional<T> b) {
-    return evaluateOnce<T>("check_multiply(c0, c1)", a, b);
-  }
-
-  template <typename T>
-  std::optional<T> checkDivide(std::optional<T> a, std::optional<T> b) {
-    return evaluateOnce<T>("check_divide(c0, c1)", a, b);
+  std::optional<T> checkArithmetic(
+      const std::string& func,
+      const std::optional<T> a,
+      const std::optional<T> b) {
+    return evaluateOnce<T>(fmt::format("{}(c0, c1)", func), a, b);
   }
 
   template <typename T>
@@ -607,8 +595,8 @@ TEST_F(ArithmeticTest, checkAdd) {
       INT64_MAX,
       1,
       "[ARITHMETIC_OVERFLOW] overflow: 9223372036854775807 + 1");
-  EXPECT_EQ(checkAdd<float>(kInf, 1), kInf);
-  EXPECT_EQ(checkAdd<double>(kInfDouble, 1), kInfDouble);
+  EXPECT_EQ(checkArithmetic<float>(func, kInf, 1), kInf);
+  EXPECT_EQ(checkArithmetic<double>(func, kInfDouble, 1), kInfDouble);
 }
 
 TEST_F(ArithmeticTest, checkSubstract) {
@@ -624,8 +612,8 @@ TEST_F(ArithmeticTest, checkSubstract) {
       INT64_MIN,
       1,
       "[ARITHMETIC_OVERFLOW] overflow: -9223372036854775808 - 1");
-  EXPECT_EQ(checkSubstract<float>(kInf, 1), kInf);
-  EXPECT_EQ(checkSubstract<double>(kInfDouble, 1), kInfDouble);
+  EXPECT_EQ(checkArithmetic<float>(func, kInf, 1), kInf);
+  EXPECT_EQ(checkArithmetic<double>(func, kInfDouble, 1), kInfDouble);
 }
 
 TEST_F(ArithmeticTest, checkMultiply) {
@@ -641,8 +629,8 @@ TEST_F(ArithmeticTest, checkMultiply) {
       INT64_MAX,
       2,
       "[ARITHMETIC_OVERFLOW] overflow: 9223372036854775807 * 2");
-  EXPECT_EQ(checkMultiply<float>(kInf, 1), kInf);
-  EXPECT_EQ(checkMultiply<double>(kInfDouble, 1), kInfDouble);
+  EXPECT_EQ(checkArithmetic<float>(func, kInf, 1), kInf);
+  EXPECT_EQ(checkArithmetic<double>(func, kInfDouble, 1), kInfDouble);
 }
 
 TEST_F(ArithmeticTest, checkDivide) {
@@ -659,8 +647,8 @@ TEST_F(ArithmeticTest, checkDivide) {
       INT64_MIN,
       -1,
       "[ARITHMETIC_OVERFLOW] overflow: -9223372036854775808 / -1");
-  EXPECT_EQ(checkDivide<float>(kInf, 1), kInf);
-  EXPECT_EQ(checkDivide<double>(kInfDouble, 1), kInfDouble);
+  EXPECT_EQ(checkArithmetic<float>(func, kInf, 1), kInf);
+  EXPECT_EQ(checkArithmetic<double>(func, kInfDouble, 1), kInfDouble);
 }
 
 class LogNTest : public SparkFunctionBaseTest {

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -147,7 +147,7 @@ class ArithmeticTest : public SparkFunctionBaseTest {
   }
 
   template <typename T>
-  std::optional<T> checkArithmetic(
+  std::optional<T> checkedArithmetic(
       const std::string& func,
       const std::optional<T> a,
       const std::optional<T> b) {
@@ -155,7 +155,35 @@ class ArithmeticTest : public SparkFunctionBaseTest {
   }
 
   template <typename T>
-  void assertErrorForCheckArithmetic(
+  std::optional<T> checkedAdd(
+      const std::optional<T> a,
+      const std::optional<T> b) {
+    return checkedArithmetic<T>("checked_add", a, b);
+  }
+
+  template <typename T>
+  std::optional<T> checkedDivide(
+      const std::optional<T> a,
+      const std::optional<T> b) {
+    return checkedArithmetic<T>("checked_divide", a, b);
+  }
+
+  template <typename T>
+  std::optional<T> checkedMultiply(
+      const std::optional<T> a,
+      const std::optional<T> b) {
+    return checkedArithmetic<T>("checked_multiply", a, b);
+  }
+
+  template <typename T>
+  std::optional<T> checkedSubstract(
+      const std::optional<T> a,
+      const std::optional<T> b) {
+    return checkedArithmetic<T>("checked_subtract", a, b);
+  }
+
+  template <typename T>
+  void assertErrorForCheckedArithmetic(
       const std::string& func,
       const std::optional<T> a,
       const std::optional<T> b,
@@ -169,6 +197,38 @@ class ArithmeticTest : public SparkFunctionBaseTest {
       ASSERT_TRUE(
           std::string(e.what()).find(errorMessage) != std::string::npos);
     }
+  }
+
+  template <typename T>
+  void assertErrorForCheckedAdd(
+      const std::optional<T> a,
+      const std::optional<T> b,
+      const std::string& errorMessage) {
+    assertErrorForCheckedArithmetic("checked_add", a, b, errorMessage);
+  }
+
+  template <typename T>
+  void assertErrorForCheckedDivide(
+      const std::optional<T> a,
+      const std::optional<T> b,
+      const std::string& errorMessage) {
+    assertErrorForCheckedArithmetic("checked_divide", a, b, errorMessage);
+  }
+
+  template <typename T>
+  void assertErrorForCheckedMultiply(
+      const std::optional<T> a,
+      const std::optional<T> b,
+      const std::string& errorMessage) {
+    assertErrorForCheckedArithmetic("checked_multiply", a, b, errorMessage);
+  }
+
+  template <typename T>
+  void assertErrorForCheckedSubstract(
+      const std::optional<T> a,
+      const std::optional<T> b,
+      const std::string& errorMessage) {
+    assertErrorForCheckedArithmetic("checked_subtract", a, b, errorMessage);
   }
 
   static constexpr float kNan = std::numeric_limits<float>::quiet_NaN();
@@ -582,73 +642,56 @@ TEST_F(ArithmeticTest, widthBucket) {
   EXPECT_EQ(widthBucket(-kInf, 0, 4, 3), 0);
 }
 
-TEST_F(ArithmeticTest, checkAdd) {
-  std::string func = "check_add";
-  assertErrorForCheckArithmetic<int8_t>(
-      func, INT8_MAX, 1, "[ARITHMETIC_OVERFLOW] overflow: 127 + 1");
-  assertErrorForCheckArithmetic<int16_t>(
-      func, INT16_MAX, 1, "[ARITHMETIC_OVERFLOW] overflow: 32767 + 1");
-  assertErrorForCheckArithmetic<int32_t>(
-      func, INT32_MAX, 1, "[ARITHMETIC_OVERFLOW] overflow: 2147483647 + 1");
-  assertErrorForCheckArithmetic<int64_t>(
-      func,
-      INT64_MAX,
-      1,
-      "[ARITHMETIC_OVERFLOW] overflow: 9223372036854775807 + 1");
-  EXPECT_EQ(checkArithmetic<float>(func, kInf, 1), kInf);
-  EXPECT_EQ(checkArithmetic<double>(func, kInfDouble, 1), kInfDouble);
+TEST_F(ArithmeticTest, checkedAdd) {
+  assertErrorForCheckedAdd<int8_t>(INT8_MAX, 1, "Arithmetic overflow: 127 + 1");
+  assertErrorForCheckedAdd<int16_t>(
+      INT16_MAX, 1, "Arithmetic overflow: 32767 + 1");
+  assertErrorForCheckedAdd<int32_t>(
+      INT32_MAX, 1, "Arithmetic overflow: 2147483647 + 1");
+  assertErrorForCheckedAdd<int64_t>(
+      INT64_MAX, 1, "Arithmetic overflow: 9223372036854775807 + 1");
+  EXPECT_EQ(checkedAdd<float>(kInf, 1), kInf);
+  EXPECT_EQ(checkedAdd<double>(kInfDouble, 1), kInfDouble);
 }
 
-TEST_F(ArithmeticTest, checkSubstract) {
-  std::string func = "check_subtract";
-  assertErrorForCheckArithmetic<int8_t>(
-      func, INT8_MIN, 1, "[ARITHMETIC_OVERFLOW] overflow: -128 - 1");
-  assertErrorForCheckArithmetic<int16_t>(
-      func, INT16_MIN, 1, "[ARITHMETIC_OVERFLOW] overflow: -32768 - 1");
-  assertErrorForCheckArithmetic<int32_t>(
-      func, INT32_MIN, 1, "[ARITHMETIC_OVERFLOW] overflow: -2147483648 - 1");
-  assertErrorForCheckArithmetic<int64_t>(
-      func,
-      INT64_MIN,
-      1,
-      "[ARITHMETIC_OVERFLOW] overflow: -9223372036854775808 - 1");
-  EXPECT_EQ(checkArithmetic<float>(func, kInf, 1), kInf);
-  EXPECT_EQ(checkArithmetic<double>(func, kInfDouble, 1), kInfDouble);
+TEST_F(ArithmeticTest, checkedSubstract) {
+  assertErrorForCheckedSubstract<int8_t>(
+      INT8_MIN, 1, "Arithmetic overflow: -128 - 1");
+  assertErrorForCheckedSubstract<int16_t>(
+      INT16_MIN, 1, "Arithmetic overflow: -32768 - 1");
+  assertErrorForCheckedSubstract<int32_t>(
+      INT32_MIN, 1, "Arithmetic overflow: -2147483648 - 1");
+  assertErrorForCheckedSubstract<int64_t>(
+      INT64_MIN, 1, "Arithmetic overflow: -9223372036854775808 - 1");
+  EXPECT_EQ(checkedSubstract<float>(kInf, 1), kInf);
+  EXPECT_EQ(checkedSubstract<double>(kInfDouble, 1), kInfDouble);
 }
 
-TEST_F(ArithmeticTest, checkMultiply) {
-  std::string func = "check_multiply";
-  assertErrorForCheckArithmetic<int8_t>(
-      func, INT8_MAX, 2, "[ARITHMETIC_OVERFLOW] overflow: 127 * 2");
-  assertErrorForCheckArithmetic<int16_t>(
-      func, INT16_MAX, 2, "[ARITHMETIC_OVERFLOW] overflow: 32767 * 2");
-  assertErrorForCheckArithmetic<int32_t>(
-      func, INT32_MAX, 2, "[ARITHMETIC_OVERFLOW] overflow: 2147483647 * 2");
-  assertErrorForCheckArithmetic<int64_t>(
-      func,
-      INT64_MAX,
-      2,
-      "[ARITHMETIC_OVERFLOW] overflow: 9223372036854775807 * 2");
-  EXPECT_EQ(checkArithmetic<float>(func, kInf, 1), kInf);
-  EXPECT_EQ(checkArithmetic<double>(func, kInfDouble, 1), kInfDouble);
+TEST_F(ArithmeticTest, checkedMultiply) {
+  assertErrorForCheckedMultiply<int8_t>(
+      INT8_MAX, 2, "Arithmetic overflow: 127 * 2");
+  assertErrorForCheckedMultiply<int16_t>(
+      INT16_MAX, 2, "Arithmetic overflow: 32767 * 2");
+  assertErrorForCheckedMultiply<int32_t>(
+      INT32_MAX, 2, "Arithmetic overflow: 2147483647 * 2");
+  assertErrorForCheckedMultiply<int64_t>(
+      INT64_MAX, 2, "Arithmetic overflow: 9223372036854775807 * 2");
+  EXPECT_EQ(checkedMultiply<float>(kInf, 1), kInf);
+  EXPECT_EQ(checkedMultiply<double>(kInfDouble, 1), kInfDouble);
 }
 
-TEST_F(ArithmeticTest, checkDivide) {
-  std::string func = "check_divide";
-  assertErrorForCheckArithmetic<int32_t>(func, 1, 0, "division by zero");
-  assertErrorForCheckArithmetic<int8_t>(
-      func, INT8_MIN, -1, "[ARITHMETIC_OVERFLOW] overflow: -128 / -1");
-  assertErrorForCheckArithmetic<int16_t>(
-      func, INT16_MIN, -1, "[ARITHMETIC_OVERFLOW] overflow: -32768 / -1");
-  assertErrorForCheckArithmetic<int32_t>(
-      func, INT32_MIN, -1, "[ARITHMETIC_OVERFLOW] overflow: -2147483648 / -1");
-  assertErrorForCheckArithmetic<int64_t>(
-      func,
-      INT64_MIN,
-      -1,
-      "[ARITHMETIC_OVERFLOW] overflow: -9223372036854775808 / -1");
-  EXPECT_EQ(checkArithmetic<float>(func, kInf, 1), kInf);
-  EXPECT_EQ(checkArithmetic<double>(func, kInfDouble, 1), kInfDouble);
+TEST_F(ArithmeticTest, checkedDivide) {
+  assertErrorForCheckedDivide<int32_t>(1, 0, "division by zero");
+  assertErrorForCheckedDivide<int8_t>(
+      INT8_MIN, -1, "Arithmetic overflow: -128 / -1");
+  assertErrorForCheckedDivide<int16_t>(
+      INT16_MIN, -1, "Arithmetic overflow: -32768 / -1");
+  assertErrorForCheckedDivide<int32_t>(
+      INT32_MIN, -1, "Arithmetic overflow: -2147483648 / -1");
+  assertErrorForCheckedDivide<int64_t>(
+      INT64_MIN, -1, "Arithmetic overflow: -9223372036854775808 / -1");
+  EXPECT_EQ(checkedDivide<float>(kInf, 1), kInf);
+  EXPECT_EQ(checkedDivide<double>(kInfDouble, 1), kInfDouble);
 }
 
 class LogNTest : public SparkFunctionBaseTest {

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -155,7 +155,7 @@ class ArithmeticTest : public SparkFunctionBaseTest {
   }
 
   template <typename T>
-  void assertErrorForCheckFunc(
+  void assertErrorForCheckArithmetic(
       const std::string& func,
       const std::optional<T> a,
       const std::optional<T> b,
@@ -584,13 +584,13 @@ TEST_F(ArithmeticTest, widthBucket) {
 
 TEST_F(ArithmeticTest, checkAdd) {
   std::string func = "check_add";
-  assertErrorForCheckFunc<int8_t>(
+  assertErrorForCheckArithmetic<int8_t>(
       func, INT8_MAX, 1, "[ARITHMETIC_OVERFLOW] overflow: 127 + 1");
-  assertErrorForCheckFunc<int16_t>(
+  assertErrorForCheckArithmetic<int16_t>(
       func, INT16_MAX, 1, "[ARITHMETIC_OVERFLOW] overflow: 32767 + 1");
-  assertErrorForCheckFunc<int32_t>(
+  assertErrorForCheckArithmetic<int32_t>(
       func, INT32_MAX, 1, "[ARITHMETIC_OVERFLOW] overflow: 2147483647 + 1");
-  assertErrorForCheckFunc<int64_t>(
+  assertErrorForCheckArithmetic<int64_t>(
       func,
       INT64_MAX,
       1,
@@ -601,13 +601,13 @@ TEST_F(ArithmeticTest, checkAdd) {
 
 TEST_F(ArithmeticTest, checkSubstract) {
   std::string func = "check_subtract";
-  assertErrorForCheckFunc<int8_t>(
+  assertErrorForCheckArithmetic<int8_t>(
       func, INT8_MIN, 1, "[ARITHMETIC_OVERFLOW] overflow: -128 - 1");
-  assertErrorForCheckFunc<int16_t>(
+  assertErrorForCheckArithmetic<int16_t>(
       func, INT16_MIN, 1, "[ARITHMETIC_OVERFLOW] overflow: -32768 - 1");
-  assertErrorForCheckFunc<int32_t>(
+  assertErrorForCheckArithmetic<int32_t>(
       func, INT32_MIN, 1, "[ARITHMETIC_OVERFLOW] overflow: -2147483648 - 1");
-  assertErrorForCheckFunc<int64_t>(
+  assertErrorForCheckArithmetic<int64_t>(
       func,
       INT64_MIN,
       1,
@@ -618,13 +618,13 @@ TEST_F(ArithmeticTest, checkSubstract) {
 
 TEST_F(ArithmeticTest, checkMultiply) {
   std::string func = "check_multiply";
-  assertErrorForCheckFunc<int8_t>(
+  assertErrorForCheckArithmetic<int8_t>(
       func, INT8_MAX, 2, "[ARITHMETIC_OVERFLOW] overflow: 127 * 2");
-  assertErrorForCheckFunc<int16_t>(
+  assertErrorForCheckArithmetic<int16_t>(
       func, INT16_MAX, 2, "[ARITHMETIC_OVERFLOW] overflow: 32767 * 2");
-  assertErrorForCheckFunc<int32_t>(
+  assertErrorForCheckArithmetic<int32_t>(
       func, INT32_MAX, 2, "[ARITHMETIC_OVERFLOW] overflow: 2147483647 * 2");
-  assertErrorForCheckFunc<int64_t>(
+  assertErrorForCheckArithmetic<int64_t>(
       func,
       INT64_MAX,
       2,
@@ -635,14 +635,14 @@ TEST_F(ArithmeticTest, checkMultiply) {
 
 TEST_F(ArithmeticTest, checkDivide) {
   std::string func = "check_divide";
-  assertErrorForCheckFunc<int32_t>(func, 1, 0, "division by zero");
-  assertErrorForCheckFunc<int8_t>(
+  assertErrorForCheckArithmetic<int32_t>(func, 1, 0, "division by zero");
+  assertErrorForCheckArithmetic<int8_t>(
       func, INT8_MIN, -1, "[ARITHMETIC_OVERFLOW] overflow: -128 / -1");
-  assertErrorForCheckFunc<int16_t>(
+  assertErrorForCheckArithmetic<int16_t>(
       func, INT16_MIN, -1, "[ARITHMETIC_OVERFLOW] overflow: -32768 / -1");
-  assertErrorForCheckFunc<int32_t>(
+  assertErrorForCheckArithmetic<int32_t>(
       func, INT32_MIN, -1, "[ARITHMETIC_OVERFLOW] overflow: -2147483648 / -1");
-  assertErrorForCheckFunc<int64_t>(
+  assertErrorForCheckArithmetic<int64_t>(
       func,
       INT64_MIN,
       -1,


### PR DESCRIPTION
Implement checked_add, checked_divide, checked_multiply, checked_subtract Spark 
functions with non-throwing Simple Functions.

These functions are used to implment `try_add`, `try_subtract`, `try_multiply`, 
`try_divide` functions. `try_XX` functions are `RuntimeReplaceable` which are 
converted to [`try(XX(failOnError=true))`](https://github.com/apache/spark/blob/branch-3.3/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TryEval.scala#L81C23-L81C69) during planning. For example `try_add` 
is converted to  `try(add(failOnError=true))`. We add `checked_xx` functions in velox 
to implement `xx(failOnError=true)`.

try_add: https://spark.apache.org/docs/latest/api/sql/#try_add
try_subtract: https://spark.apache.org/docs/latest/api/sql/#try_subtract
try_multiply: https://spark.apache.org/docs/latest/api/sql/#try_multiply
try_divide: https://spark.apache.org/docs/latest/api/sql/#try_divide

Overflow check for types in Spark: https://github.com/apache/spark/blob/94912920b0e92c9470bdb27a409799d0fe48ff69/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala#L35C5-L35C18