### PR TITLE
Optimize VectorHasher::makeValueIdsDecoded to not cache hash values when it is not beneficial

### DIFF
--- a/velox/exec/VectorHasher.h
+++ b/velox/exec/VectorHasher.h
@@ -338,6 +338,15 @@ class VectorHasher {
   template <TypeKind Kind>
   bool makeValueIds(const SelectivityVector& rows, uint64_t* result);
 
+  template <typename T, bool mayHaveNulls>
+  FOLLY_ALWAYS_INLINE void makeValueIdForOneRow(
+      const uint64_t* nulls,
+      vector_size_t row,
+      const T* values,
+      vector_size_t valueRow,
+      uint64_t* result,
+      bool& success);
+
   template <typename T>
   bool makeValueIdsFlatNoNulls(const SelectivityVector& rows, uint64_t* result);
 

--- a/velox/exec/benchmarks/VectorHasherBenchmark.cpp
+++ b/velox/exec/benchmarks/VectorHasherBenchmark.cpp
@@ -239,6 +239,36 @@ BENCHMARK(computeValueIdsLowCardinalityNotAllUsed) {
   }
 }
 
+BENCHMARK(computeValueIdsDictionaryForFiltering) {
+  folly::BenchmarkSuspender suspender;
+
+  vector_size_t cardinality = 30'000'000;
+  vector_size_t batchSize = 300;
+  BenchmarkBase base;
+
+  auto data = base.vectorMaker().flatVector<int64_t>(
+      cardinality, [](vector_size_t row) { return row; });
+  BufferPtr indices = allocateIndices(batchSize, base.pool());
+  auto rawIndices = indices->asMutable<vector_size_t>();
+  // Assign indices such that array is reversed.
+  for (size_t i = 0; i < batchSize; ++i) {
+    rawIndices[i] = i * 1000;
+  }
+  auto values = BaseVector::wrapInDictionary(nullptr, indices, batchSize, data);
+
+  for (int i = 0; i < 10; i++) {
+    raw_vector<uint64_t> hashes(batchSize);
+    SelectivityVector rows(batchSize);
+    VectorHasher hasher(BIGINT(), 0);
+    hasher.decode(*values, rows);
+    suspender.dismiss();
+
+    bool ok = hasher.computeValueIds(rows, hashes);
+    folly::doNotOptimizeAway(ok);
+    suspender.rehire();
+  }
+}
+
 int main(int argc, char** argv) {
   folly::Init init{&argc, &argv};
   memory::MemoryManager::initialize({});

--- a/velox/exec/tests/VectorHasherTest.cpp
+++ b/velox/exec/tests/VectorHasherTest.cpp
@@ -827,6 +827,24 @@ TEST_F(VectorHasherTest, computeValueIdsStrings) {
   }
 
   ASSERT_LE(uniqueValues.size(), multiplier);
+
+  {
+    result[42] = 0xAAAAAAAAAAAAAAAA;
+    VectorHasher hasher(dictionaryVectors[0]->type(), 0);
+    SelectivityVector oneRow(size, false);
+    oneRow.setValid(42, true);
+    oneRow.updateBounds();
+    hasher.decode(*dictionaryVectors[0], oneRow);
+    ASSERT_FALSE(hasher.computeValueIds(oneRow, result));
+    uint64_t asRange;
+    uint64_t asDistinct;
+    hasher.cardinality(0, asRange, asDistinct);
+    ASSERT_EQ(asDistinct, 2);
+    hasher.enableValueIds(1, 0);
+    hasher.decode(*dictionaryVectors[0], oneRow);
+    ASSERT_TRUE(hasher.computeValueIds(oneRow, result));
+    ASSERT_EQ(result[42], 1);
+  }
 }
 
 namespace {


### PR DESCRIPTION
Summary:
Similar to https://github.com/facebookincubator/velox/pull/7150, when we only need to make IDs for a small number of rows fewer than dictionary values, using cache is slower and we should just compute the IDs directly.

Related issue: https://github.com/facebookincubator/velox/issues/10057

Differential Revision: D58215380


