### PR TITLE
Fix MergeJoinTest.dictionaryOutput flakyness

### DIFF
--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -544,6 +544,9 @@ TEST_F(MergeJoinTest, dictionaryOutput) {
   for (const auto& child : output->children()) {
     EXPECT_TRUE(isDictionary(child->encoding()));
   }
+
+  // Output can't outlive the task.
+  output.reset();
 }
 
 TEST_F(MergeJoinTest, semiJoin) {


### PR DESCRIPTION
Summary:
Ensure the captured output does not accidentaly outlive task, since
the pool gets deleted as task destruction.

Differential Revision: D58248079


