### PR TITLE
Clean up some spurious shared_ptr creations/deletions in DwrfReader

### DIFF
--- a/velox/dwio/common/ColumnSelector.cpp
+++ b/velox/dwio/common/ColumnSelector.cpp
@@ -91,7 +91,7 @@ FilterTypePtr ColumnSelector::buildNode(
   // column selector filter tree
   nodes_.reserve(nodes_.size() + type->size());
   if (node.node == 0) {
-    auto rowType = type->asRow();
+    auto& rowType = type->asRow();
     for (size_t i = 0, size = type->size(); i < size; ++i) {
       bool inData = contentType && i < contentType->size();
       current->addChild(buildNode(

--- a/velox/dwio/common/FilterNode.h
+++ b/velox/dwio/common/FilterNode.h
@@ -267,8 +267,8 @@ class FilterType {
     return node_.node == 0;
   }
 
-  inline void addChild(const FilterTypePtr& child) {
-    children_.push_back(child);
+  inline void addChild(FilterTypePtr child) {
+    children_.push_back(std::move(child));
   }
 
   inline void setSequenceFilter(const SeqFilter& seqFilter) {

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -791,21 +791,29 @@ TypePtr updateColumnNames(const TypePtr& fileType, const TypePtr& tableType) {
   auto fileRowType = std::dynamic_pointer_cast<const T>(fileType);
   auto tableRowType = std::dynamic_pointer_cast<const T>(tableType);
 
-  std::vector<std::string> newFileFieldNames{fileRowType->names()};
-  std::vector<TypePtr> newFileFieldTypes{fileRowType->children()};
+  std::vector<std::string> newFileFieldNames;
+  newFileFieldNames.reserve(fileRowType->size());
+  std::vector<TypePtr> newFileFieldTypes;
+  newFileFieldTypes.reserve(fileRowType->size());
 
   for (auto childIdx = 0; childIdx < tableRowType->size(); ++childIdx) {
     if (childIdx >= fileRowType->size()) {
       break;
     }
 
-    newFileFieldTypes[childIdx] = updateColumnNames(
+    newFileFieldTypes.push_back(updateColumnNames(
         fileRowType->childAt(childIdx),
         tableRowType->childAt(childIdx),
         fileRowType->nameOf(childIdx),
-        tableRowType->nameOf(childIdx));
+        tableRowType->nameOf(childIdx)));
 
-    newFileFieldNames[childIdx] = tableRowType->nameOf(childIdx);
+    newFileFieldNames.push_back(tableRowType->nameOf(childIdx));
+  }
+
+  for (auto childIdx = tableRowType->size(); childIdx < fileRowType->size();
+       ++childIdx) {
+    newFileFieldTypes.push_back(fileRowType->childAt(childIdx));
+    newFileFieldNames.push_back(fileRowType->nameOf(childIdx));
   }
 
   return std::make_shared<const T>(
@@ -830,9 +838,6 @@ TypePtr updateColumnNames(
     return fileType;
   }
 
-  std::vector<std::string> fileFieldNames{fileType->size()};
-  std::vector<TypePtr> fileFieldTypes{fileType->size()};
-
   if (fileType->isRow()) {
     return updateColumnNames<RowType>(fileType, tableType);
   }
@@ -855,9 +860,8 @@ TypePtr updateColumnNames(
 void DwrfReader::updateColumnNamesFromTableSchema() {
   const auto& tableSchema = options_.fileSchema();
   const auto& fileSchema = readerBase_->getSchema();
-  auto newSchema = std::dynamic_pointer_cast<const RowType>(
-      updateColumnNames(fileSchema, tableSchema, "", ""));
-  readerBase_->setSchema(newSchema);
+  readerBase_->setSchema(std::dynamic_pointer_cast<const RowType>(
+      updateColumnNames(fileSchema, tableSchema, "", "")));
 }
 
 std::unique_ptr<StripeInformation> DwrfReader::getStripe(

--- a/velox/dwio/dwrf/reader/ReaderBase.cpp
+++ b/velox/dwio/dwrf/reader/ReaderBase.cpp
@@ -289,23 +289,32 @@ std::shared_ptr<const Type> ReaderBase::convertType(
   const auto type = footer.types(index);
   switch (type.kind()) {
     case TypeKind::BOOLEAN:
+      return BOOLEAN();
     case TypeKind::TINYINT:
+      return TINYINT();
     case TypeKind::SMALLINT:
+      return SMALLINT();
     case TypeKind::INTEGER:
+      return INTEGER();
     case TypeKind::BIGINT:
+      return BIGINT();
     case TypeKind::HUGEINT:
       if (type.format() == DwrfFormat::kOrc &&
           type.getOrcPtr()->kind() == proto::orc::Type_Kind_DECIMAL) {
         return DECIMAL(
             type.getOrcPtr()->precision(), type.getOrcPtr()->scale());
       }
-      [[fallthrough]];
+      return HUGEINT();
     case TypeKind::REAL:
+      return REAL();
     case TypeKind::DOUBLE:
+      return DOUBLE();
     case TypeKind::VARCHAR:
+      return VARCHAR();
     case TypeKind::VARBINARY:
+      return VARBINARY();
     case TypeKind::TIMESTAMP:
-      return createScalarType(type.kind());
+      return TIMESTAMP();
     case TypeKind::ARRAY:
       return ARRAY(convertType(
           footer, type.subtypes(0), fileColumnNamesReadAsLowerCase));

--- a/velox/dwio/dwrf/reader/ReaderBase.h
+++ b/velox/dwio/dwrf/reader/ReaderBase.h
@@ -124,8 +124,8 @@ class ReaderBase {
     return schema_;
   }
 
-  void setSchema(const RowTypePtr& newSchema) {
-    schema_ = newSchema;
+  void setSchema(RowTypePtr newSchema) {
+    schema_ = std::move(newSchema);
   }
 
   const std::shared_ptr<const dwio::common::TypeWithId>& getSchemaWithId()


### PR DESCRIPTION
Summary:
I was looking at a query reading from a table with many columns, and it's spending a huge amount
of CPU time just creating and deleting shared_ptrs when setting up the SplitReader and the
RowReader.

There's still more that can be done but this change cleans up some easy ones.

Differential Revision: D58263307
