### PR TITLE
Force external/date to throw instead of returning wrong results

### DIFF
--- a/velox/external/date/tz.cpp
+++ b/velox/external/date/tz.cpp
@@ -2033,6 +2033,28 @@ time_zone::load_data(std::istream& inf,
     }
     for (auto j = 0u; i < transitions_.size(); ++i, ++j)
         transitions_[i].info = ttinfos_.data() + indices[j];
+
+    // Use getline to discard the first newline, then read the extended
+    // information
+    std::string extended_info;
+    std::getline(inf, extended_info);
+    std::getline(inf, extended_info);
+    auto comma1 = extended_info.find(',');
+
+    // Extended info can either be just the name/offset, or name/offset and
+    // rules. If there are rules, they come in pairs (when the rule starts and
+    // when the rule ends), and are separated by commas (',').
+    if (comma1 != std::string::npos) {
+      auto comma2 = extended_info.find(',', comma1 + 1);
+      assert(comma2 != std::string::npos);
+
+      extended_info_.extended_name_ = extended_info.substr(0, comma1);
+      extended_info_.rule_start_ =
+          extended_info.substr(comma1 + 1, comma2 - comma1 - 1);
+      extended_info_.rule_end_ = extended_info.substr(comma2 + 1);
+    } else {
+      extended_info_.extended_name_ = std::move(extended_info);
+    }
 }
 
 void
@@ -2125,6 +2147,16 @@ time_zone::load_sys_info(std::vector<detail::transition>::const_iterator i) cons
     using namespace std::chrono;
     assert(!transitions_.empty());
     assert(i != transitions_.begin());
+
+    // Conversions past OS_TZDB items are not supported if the timezone has
+    // repetition rules. Fail instead of returning wrong results
+    if (i == transitions_.end() && extended_info_.has_rules()) {
+      std::stringstream ss;
+      ss << "Unable to convert timezone '" << name_ << "' past "
+         << transitions_.back().timepoint;
+      throw std::runtime_error(ss.str());
+    }
+
     sys_info r;
     r.begin = i[-1].timepoint;
     r.end = i != transitions_.end() ? i->timepoint :

--- a/velox/external/date/tz.h
+++ b/velox/external/date/tz.h
@@ -790,6 +790,19 @@ private:
 #if USE_OS_TZDB
     std::vector<detail::transition>      transitions_;
     std::vector<detail::expanded_ttinfo> ttinfos_;
+
+    // Stores extended OS_TZDB timezone information, in addition to possible
+    // repetition rules (although these are not supported yet)
+    struct {
+      std::string extended_name_;
+      std::string rule_start_;
+      std::string rule_end_;
+
+      bool has_rules() const {
+        return !rule_start_.empty();
+      }
+    } extended_info_;
+
 #else  // !USE_OS_TZDB
     std::vector<detail::zonelet>         zonelets_;
 #endif  // !USE_OS_TZDB

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -3818,6 +3818,12 @@ TEST_F(DateTimeFunctionsTest, castDateForDateFunction) {
       -18297,
       castDateTest(Timestamp(
           -18297 * kSecondsInDay + kSecondsInDay - 1, kNanosInSecond - 1)));
+
+  // Trying to convert a very large timestamp should fail as velox/external/date
+  // can't convert past year 2037. Note that the correct result here should be
+  // 376358 ('3000-06-08'), and not 376357 ('3000-06-07').
+  VELOX_ASSERT_THROW(
+      castDateTest(Timestamp(32517359891, 0)), "Unable to convert timezone");
 }
 
 TEST_F(DateTimeFunctionsTest, currentDateWithTimezone) {

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -120,9 +120,15 @@ Timestamp::toTimePoint(bool allowOverflow) const {
 
 void Timestamp::toTimezone(const date::time_zone& zone, bool allowOverflow) {
   auto tp = toTimePoint(allowOverflow);
-  auto epoch = zone.to_local(tp).time_since_epoch();
-  // NOTE: Round down to get the seconds of the current time point.
-  seconds_ = std::chrono::floor<std::chrono::seconds>(epoch).count();
+
+  try {
+    auto epoch = zone.to_local(tp).time_since_epoch();
+
+    // NOTE: Round down to get the seconds of the current time point.
+    seconds_ = std::chrono::floor<std::chrono::seconds>(epoch).count();
+  } catch (const std::runtime_error& e) {
+    VELOX_USER_FAIL(e.what());
+  }
 }
 
 void Timestamp::toTimezone(int16_t tzID) {


### PR DESCRIPTION
Summary:
The external/date library we vendor has a known bug caused by the lack
of support for timezone repetition rules. For now, adding code to parse
repetition rules from OS_TZDB, and fail (throw) in cases where it would
return buggy results.

This PR may affect most date/time manipulation functions (in both Presto 
and Spark), in addition to casts across date/time related types. 

Addresses the issue described in https://github.com/facebookincubator/velox/issues/9155

Differential Revision: D58269003
