### PR TITLE
Remove duplicated code in RowContainer

### DIFF
--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -773,9 +773,6 @@ void RowContainer::storeComplexType(
 
   valueAt<std::string_view>(row, offset) = std::string_view(
       reinterpret_cast<char*>(position.position), stream.size());
-  const auto size = stream.size();
-  valueAt<std::string_view>(row, offset) =
-      std::string_view(reinterpret_cast<char*>(position.position), size);
 }
 
 //   static


### PR DESCRIPTION
 PR [#7519](https://github.com/facebookincubator/velox/pull/7519/files#diff-6380101ed32e065ab578400ad3911fa0c25193e1aecc7f0e2562e7703e550937R672-R682) adds data to `valueAt<std::string_view>(row, offset)` twice in `RowContainer::storeComplexType`. I think this is a duplicate operation and one of them should be deleted.

CC: @mbasmanova @xiaoxmeng 