### PR TITLE
Add support for TIMESTAMP inputs to to_iso8601 Presto function

### DIFF
--- a/velox/docs/functions/presto/datetime.rst
+++ b/velox/docs/functions/presto/datetime.rst
@@ -154,7 +154,14 @@ Date and Time Functions
 
 .. function:: to_iso8601(x) -> varchar
 
-    Formats ``x`` as an ISO 8601 string. Supported types for ``x`` are: DATE.
+    Formats ``x`` as an ISO 8601 string. Supported types for ``x`` are:
+    DATE, TIMESTAMP, TIMESTAMP WITH TIME ZONE.
+
+    Example results::
+
+        SELECT to_iso8601(current_date); -- 2024-06-06
+        SELECT to_iso8601(now()); -- 2024-06-06T20:25:46.726-07:00
+        SELECT to_iso8601(now() + interval '6' month); -- 2024-12-06T20:27:11.992-08:00
 
 .. function:: to_unixtime(timestamp) -> double
 
@@ -284,6 +291,10 @@ pattern format. The symbols currently supported are ``y``, ``Y``, ``M`` , ``d``,
 specified using the format ``+00``, ``+00:00`` or ``+0000`` (or ``-``). ``Z``
 also accepts ``UTC``,  ``UCT``, ``GMT``, and ``GMT0`` as valid representations
 of GMT.
+
+.. function:: format_datetime(timestamp, format) -> varchar
+
+    Formats ``timestamp`` as a string using ``format``.
 
 .. function:: parse_datetime(string, format) -> timestamp with time zone
 

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -1359,25 +1359,13 @@ struct FormatDateTimeFunction {
     }
   }
 
-  FOLLY_ALWAYS_INLINE void ensureFormatter(
-      const arg_type<Varchar>& formatString) {
-    if (!isConstFormat_) {
-      setFormatter(formatString);
-    }
-  }
-
   FOLLY_ALWAYS_INLINE void call(
       out_type<Varchar>& result,
       const arg_type<Timestamp>& timestamp,
       const arg_type<Varchar>& formatString) {
     ensureFormatter(formatString);
 
-    // TODO: We should give dateTimeFormatter a sink/ostream to prevent the
-    // copy.
-    result.reserve(maxResultSize_);
-    const auto resultSize = jodaDateTime_->format(
-        timestamp, sessionTimeZone_, maxResultSize_, result.data());
-    result.resize(resultSize);
+    format(timestamp, sessionTimeZone_, maxResultSize_, result);
   }
 
   FOLLY_ALWAYS_INLINE void call(
@@ -1390,18 +1378,33 @@ struct FormatDateTimeFunction {
     const auto timeZoneId = unpackZoneKeyId(timestampWithTimezone);
     auto* timezonePtr = date::locate_zone(util::getTimeZoneName(timeZoneId));
 
-    auto maxResultSize = jodaDateTime_->maxResultSize(timezonePtr);
-    result.reserve(maxResultSize);
-    auto resultSize = jodaDateTime_->format(
-        timestamp, timezonePtr, maxResultSize, result.data());
-    result.resize(resultSize);
+    const auto maxResultSize = jodaDateTime_->maxResultSize(timezonePtr);
+    format(timestamp, timezonePtr, maxResultSize, result);
   }
 
  private:
+  FOLLY_ALWAYS_INLINE void ensureFormatter(
+      const arg_type<Varchar>& formatString) {
+    if (!isConstFormat_) {
+      setFormatter(formatString);
+    }
+  }
+
   FOLLY_ALWAYS_INLINE void setFormatter(const arg_type<Varchar>& formatString) {
     jodaDateTime_ = buildJodaDateTimeFormatter(
         std::string_view(formatString.data(), formatString.size()));
     maxResultSize_ = jodaDateTime_->maxResultSize(sessionTimeZone_);
+  }
+
+  void format(
+      const Timestamp& timestamp,
+      const date::time_zone* timeZone,
+      uint32_t maxResultSize,
+      out_type<Varchar>& result) const {
+    result.reserve(maxResultSize);
+    const auto resultSize = jodaDateTime_->format(
+        timestamp, timeZone, maxResultSize, result.data());
+    result.resize(resultSize);
   }
 
   const date::time_zone* sessionTimeZone_ = nullptr;
@@ -1515,11 +1518,63 @@ template <typename T>
 struct ToISO8601Function {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& inputTypes,
+      const core::QueryConfig& config,
+      const arg_type<Timestamp>* /*input*/) {
+    if (inputTypes[0]->isTimestamp()) {
+      auto sessionTzName = config.sessionTimezone();
+      if (!sessionTzName.empty()) {
+        timeZone_ = date::locate_zone(sessionTzName);
+      } else {
+        timeZone_ = date::locate_zone("UTC");
+      }
+    }
+  }
+
   FOLLY_ALWAYS_INLINE void call(
       out_type<Varchar>& result,
       const arg_type<Date>& date) {
     result = DateType::toIso8601(date);
   }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Varchar>& result,
+      const arg_type<Timestamp>& timestamp) {
+    // TODO DateTimeFormatter requires timestamp in UTC. It then converts it to
+    // the specified timezone. We can avoid extra conversion if we change
+    // DateTimeFormatter to accept non-UTC timestamps.
+    auto utcTimestamp = timestamp;
+    utcTimestamp.toGMT(*timeZone_);
+
+    toIso8601(utcTimestamp, timeZone_, result);
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Varchar>& result,
+      const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
+    const auto timestamp = unpackTimestampUtc(timestampWithTimezone);
+    const auto timeZoneId = unpackZoneKeyId(timestampWithTimezone);
+    const auto* timeZone = date::locate_zone(util::getTimeZoneName(timeZoneId));
+
+    toIso8601(timestamp, timeZone, result);
+  }
+
+ private:
+  void toIso8601(
+      const Timestamp& timestamp,
+      const date::time_zone* timeZone,
+      out_type<Varchar>& result) const {
+    const auto maxResultSize = formatter_->maxResultSize(timeZone);
+    result.reserve(maxResultSize);
+    const auto resultSize =
+        formatter_->format(timestamp, timeZone, maxResultSize, result.data());
+    result.resize(resultSize);
+  }
+
+  const date::time_zone* timeZone_{nullptr};
+  std::shared_ptr<DateTimeFormatter> formatter_ =
+      functions::buildJodaDateTimeFormatter("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
 };
 
 template <typename T>

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -200,7 +200,13 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerFunction<FromIso8601Timestamp, TimestampWithTimezone, Varchar>(
       {prefix + "from_iso8601_timestamp"});
   registerFunction<CurrentDateFunction, Date>({prefix + "current_date"});
+
   registerFunction<ToISO8601Function, Varchar, Date>({prefix + "to_iso8601"});
+  registerFunction<ToISO8601Function, Varchar, Timestamp>(
+      {prefix + "to_iso8601"});
+  registerFunction<ToISO8601Function, Varchar, TimestampWithTimezone>(
+      {prefix + "to_iso8601"});
+
   registerFunction<
       AtTimezoneFunction,
       TimestampWithTimezone,


### PR DESCRIPTION
Summary:
Add support for TIMESTAMP and TIMESTAMP WITH TIME ZONE inputs to to_iso8601 Presto function.

Example results:

        SELECT to_iso8601(now()); -- 2024-06-06T20:25:46.726-07:00
        SELECT to_iso8601(now() + interval '6' month); -- 2024-12-06T20:27:11.992-08:00

Note that the output uses offsets for the time zone.

Differential Revision: D58271775
