### PR TITLE
Pass memory pool to create method of TableWriteNode and TableWriteMergeNode

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1822,7 +1822,7 @@ PlanNodePtr TableWriteNode::create(const folly::dynamic& obj, void* context) {
   auto outputType = deserializeRowType(obj["outputType"]);
   auto commitStrategy =
       connector::stringToCommitStrategy(obj["commitStrategy"].asString());
-  auto source = ISerializable::deserialize<PlanNode>(obj["sources"]);
+  auto source = ISerializable::deserialize<PlanNode>(obj["sources"], context);
   return std::make_shared<TableWriteNode>(
       id,
       columns,
@@ -1853,7 +1853,7 @@ folly::dynamic TableWriteMergeNode::serialize() const {
 // static
 PlanNodePtr TableWriteMergeNode::create(
     const folly::dynamic& obj,
-    void* /*unused*/) {
+    void* context) {
   auto id = obj["id"].asString();
   auto outputType = deserializeRowType(obj["outputType"]);
   std::shared_ptr<AggregationNode> aggregationNode;
@@ -1861,7 +1861,7 @@ PlanNodePtr TableWriteMergeNode::create(
     aggregationNode = std::const_pointer_cast<AggregationNode>(
         ISerializable::deserialize<AggregationNode>(obj["aggregationNode"]));
   }
-  auto source = ISerializable::deserialize<PlanNode>(obj["sources"]);
+  auto source = ISerializable::deserialize<PlanNode>(obj["sources"], context);
   return std::make_shared<TableWriteMergeNode>(
       id, outputType, aggregationNode, source);
 }

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -538,6 +538,12 @@ TEST_F(PlanNodeSerdeTest, write) {
       PlanBuilder(pool_.get()).tableScan(rowTypePtr, {"c1 = true"}, "c0 < 100");
   auto plan = planBuilder.tableWrite("targetDirectory").planNode();
   testSerde(plan);
+
+  plan = PlanBuilder(pool_.get())
+             .values(data_)
+             .tableWrite("targetDirectory")
+             .planNode();
+  testSerde(plan);
 }
 
 TEST_F(PlanNodeSerdeTest, tableWriteMerge) {
@@ -548,6 +554,14 @@ TEST_F(PlanNodeSerdeTest, tableWriteMerge) {
                   .localPartition(std::vector<std::string>{})
                   .tableWriteMerge()
                   .planNode();
+  testSerde(plan);
+
+  plan = PlanBuilder(pool_.get())
+             .values(data_)
+             .tableWrite("targetDirectory")
+             .localPartition(std::vector<std::string>{})
+             .tableWriteMerge()
+             .planNode();
   testSerde(plan);
 }
 


### PR DESCRIPTION
The ValuesNode::create must use a valid memory pool to restore
serialized vectors. TableWriteNode/TableWriteMergeNode::create
should pass the memory pool pointer as their source node may be
a `ValuesNode`.