### PR TITLE
Restore CAST(varchar AS timestamp) behavior for legacy cast

### DIFF
--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -35,7 +35,10 @@ PrestoCastHooks::PrestoCastHooks(const core::QueryConfig& config)
 Expected<Timestamp> PrestoCastHooks::castStringToTimestamp(
     const StringView& view) const {
   const auto conversionResult = util::fromTimestampWithTimezoneString(
-      view.data(), view.size(), util::TimestampParseMode::kPrestoCast);
+      view.data(),
+      view.size(),
+      legacyCast_ ? util::TimestampParseMode::kLegacyCast
+                  : util::TimestampParseMode::kPrestoCast);
   if (conversionResult.hasError()) {
     return folly::makeUnexpected(conversionResult.error());
   }

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -614,6 +614,27 @@ TEST_F(CastExprTest, stringToTimestamp) {
       (evaluateOnce<Timestamp, std::string>(
           "cast(c0 as timestamp)", "1970-01-01T00:00")),
       "Cannot cast VARCHAR '1970-01-01T00:00' to TIMESTAMP. Unable to parse timestamp value");
+
+  setLegacyCast(true);
+  input = {
+      "1970-01-01",
+      "1970-01-01T00:00 America/Sao_Paulo",
+      "2000-01-01",
+      "1970-01-01T00:00:00",
+      "2000-01-01 12:21:56",
+      "1970-01-01T00:00:00-02:00",
+      std::nullopt,
+  };
+  expected = {
+      Timestamp(0, 0),
+      Timestamp(10800, 0),
+      Timestamp(946684800, 0),
+      Timestamp(0, 0),
+      Timestamp(946729316, 0),
+      Timestamp(7200, 0),
+      std::nullopt,
+  };
+  testCast<std::string, Timestamp>("timestamp", input, expected);
 }
 
 TEST_F(CastExprTest, timestampToString) {

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -351,6 +351,7 @@ void parseTimeSeparator(
         pos++;
       }
       break;
+    case TimestampParseMode::kLegacyCast:
     case TimestampParseMode::kSparkCast:
       if (buf[pos] == ' ' || buf[pos] == 'T') {
         pos++;

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -162,6 +162,9 @@ enum class TimestampParseMode {
   // Allows leading and trailing spaces.
   kPrestoCast,
 
+  // Same as kPrestoCast, but allows 'T' separator between date and time.
+  kLegacyCast,
+
   /// A Spark-compatible timestamp string. A mix of the above. Accepts T and
   /// space as separator between date and time. Allows leading and trailing
   /// spaces.


### PR DESCRIPTION
Summary: Allow 'T' separator when legacyCast is true.

Differential Revision: D58283486
