### PR TITLE
Allow variable pattern and replacement in regexp_replace Presto function

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -64,6 +64,7 @@ int main(int argc, char** argv) {
       "regexp_extract",
       "regexp_extract_all",
       "regexp_like",
+      "regexp_replace",
   };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
   return FuzzerRunner::run(initialSeed, skipFunctions, {{}});

--- a/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -81,14 +81,10 @@ void registerSimpleFunctions(const std::string& prefix) {
   exec::registerStatefulVectorFunction(
       prefix + "like", likeSignatures(), makeLike);
 
-  registerFunction<Re2RegexpReplacePresto, Varchar, Varchar, Constant<Varchar>>(
+  registerFunction<Re2RegexpReplacePresto, Varchar, Varchar, Varchar>(
       {prefix + "regexp_replace"});
-  registerFunction<
-      Re2RegexpReplacePresto,
-      Varchar,
-      Varchar,
-      Constant<Varchar>,
-      Constant<Varchar>>({prefix + "regexp_replace"});
+  registerFunction<Re2RegexpReplacePresto, Varchar, Varchar, Varchar, Varchar>(
+      {prefix + "regexp_replace"});
 }
 } // namespace
 


### PR DESCRIPTION
Summary: Presto allows non-constant pattern and replacement.

Differential Revision: D58285738
