### PR TITLE
Remove unused flags "velox_memory_pool_mb"

### DIFF
--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -30,7 +30,6 @@
 #include "velox/common/memory/Allocation.h"
 #include "velox/common/time/Timer.h"
 
-DECLARE_int32(velox_memory_pool_mb);
 DECLARE_bool(velox_time_allocations);
 
 namespace facebook::velox::memory {

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -34,7 +34,6 @@
 #include <fstream>
 #endif // linux
 
-DECLARE_int32(velox_memory_pool_mb);
 DECLARE_bool(velox_memory_leak_check_enabled);
 
 using namespace facebook::velox::common::testutil;

--- a/velox/flag_definitions/flags.cpp
+++ b/velox/flag_definitions/flags.cpp
@@ -19,11 +19,6 @@
 // Used in velox/common/memory/MappedMemory.cpp
 
 DEFINE_int32(
-    velox_memory_pool_mb,
-    4 * 1024,
-    "Size of file cache/operator working memory in MB");
-
-DEFINE_int32(
     velox_memory_num_shared_leaf_pools,
     32,
     "Number of shared leaf memory pools per process");


### PR DESCRIPTION
The `velox_memory_pool_mb` gflag is not used anywhere.