### PR TITLE
Remove EXACT protobuf dependency on 3.21.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,7 +441,7 @@ if(${VELOX_BUILD_MINIMAL_WITH_DWIO}
 
   # Locate or build protobuf.
   set_source(Protobuf)
-  resolve_dependency(Protobuf 3.21.4 EXACT)
+  resolve_dependency(Protobuf 3.21.4)
   include_directories(${Protobuf_INCLUDE_DIRS})
 endif()
 


### PR DESCRIPTION
Fixes: https://github.com/facebookincubator/velox/issues/10112