### PR TITLE
Honor Presto's compression level configs and use the same defaults in HiveDataSink

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -213,6 +213,25 @@ uint64_t HiveConfig::orcWriterMinCompressionSize(const Config* session) const {
       config_->get<uint64_t>(kOrcWriterMinCompressionSize, 1024));
 }
 
+std::optional<uint8_t> HiveConfig::orcWriterCompressionLevel(
+    const Config* session) const {
+  auto sessionProp = session->get<uint8_t>(kOrcWriterCompressionLevelSession);
+
+  if (sessionProp.has_value()) {
+    return sessionProp.value();
+  }
+
+  auto configProp = config_->get<uint8_t>(kOrcWriterCompressionLevel);
+
+  if (configProp.has_value()) {
+    return configProp.value();
+  }
+
+  // Presto has a single config controlling this value, but different defaults
+  // depending on the compression kind.
+  return std::nullopt;
+}
+
 std::string HiveConfig::writeFileCreateConfig() const {
   return config_->get<std::string>(kWriteFileCreateConfig, "");
 }

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -185,6 +185,12 @@ class HiveConfig {
   static constexpr const char* kOrcWriterMinCompressionSizeSession =
       "orc_writer_min_compression_size";
 
+  /// The compression level to use with ZLIB and ZSTD.
+  static constexpr const char* kOrcWriterCompressionLevel =
+      "hive.orc.writer.compression-level";
+  static constexpr const char* kOrcWriterCompressionLevelSession =
+      "orc_optimized_writer_compression_level";
+
   /// Config used to create write files. This config is provided to underlying
   /// file system through hive connector and data sink. The config is free form.
   /// The form should be defined by the underlying file system.
@@ -285,6 +291,8 @@ class HiveConfig {
   bool orcWriterLinearStripeSizeHeuristics(const Config* session) const;
 
   uint64_t orcWriterMinCompressionSize(const Config* session) const;
+
+  std::optional<uint8_t> orcWriterCompressionLevel(const Config* session) const;
 
   std::string writeFileCreateConfig() const;
 

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -37,6 +37,9 @@ using facebook::velox::common::testutil::TestValue;
 namespace facebook::velox::connector::hive {
 
 namespace {
+// Default config values taken from Presto.
+constexpr uint8_t kDefaultZlibCompressionLevel = 4;
+constexpr uint8_t kDefaultZstdCompressionLevel = 3;
 
 // Returns the type of non-partition data columns.
 RowTypePtr getNonPartitionTypes(
@@ -700,6 +703,13 @@ uint32_t HiveDataSink::appendWriter(const HiveWriterId& id) {
   options.serdeParameters = std::map<std::string, std::string>(
       insertTableHandle_->serdeParameters().begin(),
       insertTableHandle_->serdeParameters().end());
+
+  auto compressionLevel =
+      hiveConfig_->orcWriterCompressionLevel(connectorSessionProperties);
+  options.zlibCompressionLevel =
+      compressionLevel.value_or(kDefaultZlibCompressionLevel);
+  options.zstdCompressionLevel =
+      compressionLevel.value_or(kDefaultZstdCompressionLevel);
 
   // Prevents the memory allocation during the writer creation.
   WRITER_NON_RECLAIMABLE_SECTION_GUARD(writerInfo_.size() - 1);

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -23,49 +23,50 @@ using namespace facebook::velox::core;
 using facebook::velox::connector::hive::HiveConfig;
 
 TEST(HiveConfigTest, defaultConfig) {
-  HiveConfig* hiveConfig = new HiveConfig(std::make_shared<MemConfig>());
+  HiveConfig hiveConfig(std::make_shared<MemConfig>());
   const auto emptySession = std::make_unique<MemConfig>();
   ASSERT_EQ(
-      hiveConfig->insertExistingPartitionsBehavior(emptySession.get()),
+      hiveConfig.insertExistingPartitionsBehavior(emptySession.get()),
       facebook::velox::connector::hive::HiveConfig::
           InsertExistingPartitionsBehavior::kError);
-  ASSERT_EQ(hiveConfig->maxPartitionsPerWriters(emptySession.get()), 100);
-  ASSERT_EQ(hiveConfig->immutablePartitions(), false);
-  ASSERT_EQ(hiveConfig->s3UseVirtualAddressing(), true);
-  ASSERT_EQ(hiveConfig->s3GetLogLevel(), "FATAL");
-  ASSERT_EQ(hiveConfig->s3UseSSL(), true);
-  ASSERT_EQ(hiveConfig->s3UseInstanceCredentials(), false);
-  ASSERT_EQ(hiveConfig->s3Endpoint(), "");
-  ASSERT_EQ(hiveConfig->s3AccessKey(), std::nullopt);
-  ASSERT_EQ(hiveConfig->s3SecretKey(), std::nullopt);
-  ASSERT_EQ(hiveConfig->s3IAMRole(), std::nullopt);
-  ASSERT_EQ(hiveConfig->s3IAMRoleSessionName(), "velox-session");
-  ASSERT_EQ(hiveConfig->gcsEndpoint(), "");
-  ASSERT_EQ(hiveConfig->gcsScheme(), "https");
-  ASSERT_EQ(hiveConfig->gcsCredentials(), "");
-  ASSERT_EQ(hiveConfig->isOrcUseColumnNames(emptySession.get()), false);
+  ASSERT_EQ(hiveConfig.maxPartitionsPerWriters(emptySession.get()), 100);
+  ASSERT_EQ(hiveConfig.immutablePartitions(), false);
+  ASSERT_EQ(hiveConfig.s3UseVirtualAddressing(), true);
+  ASSERT_EQ(hiveConfig.s3GetLogLevel(), "FATAL");
+  ASSERT_EQ(hiveConfig.s3UseSSL(), true);
+  ASSERT_EQ(hiveConfig.s3UseInstanceCredentials(), false);
+  ASSERT_EQ(hiveConfig.s3Endpoint(), "");
+  ASSERT_EQ(hiveConfig.s3AccessKey(), std::nullopt);
+  ASSERT_EQ(hiveConfig.s3SecretKey(), std::nullopt);
+  ASSERT_EQ(hiveConfig.s3IAMRole(), std::nullopt);
+  ASSERT_EQ(hiveConfig.s3IAMRoleSessionName(), "velox-session");
+  ASSERT_EQ(hiveConfig.gcsEndpoint(), "");
+  ASSERT_EQ(hiveConfig.gcsScheme(), "https");
+  ASSERT_EQ(hiveConfig.gcsCredentials(), "");
+  ASSERT_EQ(hiveConfig.isOrcUseColumnNames(emptySession.get()), false);
   ASSERT_EQ(
-      hiveConfig->isFileColumnNamesReadAsLowerCase(emptySession.get()), false);
+      hiveConfig.isFileColumnNamesReadAsLowerCase(emptySession.get()), false);
 
-  ASSERT_EQ(hiveConfig->maxCoalescedBytes(), 128 << 20);
-  ASSERT_EQ(hiveConfig->maxCoalescedDistanceBytes(), 512 << 10);
-  ASSERT_EQ(hiveConfig->numCacheFileHandles(), 20'000);
-  ASSERT_EQ(hiveConfig->isFileHandleCacheEnabled(), true);
+  ASSERT_EQ(hiveConfig.maxCoalescedBytes(), 128 << 20);
+  ASSERT_EQ(hiveConfig.maxCoalescedDistanceBytes(), 512 << 10);
+  ASSERT_EQ(hiveConfig.numCacheFileHandles(), 20'000);
+  ASSERT_EQ(hiveConfig.isFileHandleCacheEnabled(), true);
   ASSERT_EQ(
-      hiveConfig->orcWriterMaxStripeSize(emptySession.get()),
+      hiveConfig.orcWriterMaxStripeSize(emptySession.get()),
       64L * 1024L * 1024L);
   ASSERT_EQ(
-      hiveConfig->orcWriterMaxDictionaryMemory(emptySession.get()),
+      hiveConfig.orcWriterMaxDictionaryMemory(emptySession.get()),
       16L * 1024L * 1024L);
-  ASSERT_EQ(hiveConfig->sortWriterMaxOutputRows(emptySession.get()), 1024);
+  ASSERT_EQ(hiveConfig.sortWriterMaxOutputRows(emptySession.get()), 1024);
   ASSERT_EQ(
-      hiveConfig->sortWriterMaxOutputBytes(emptySession.get()), 10UL << 20);
-  ASSERT_EQ(hiveConfig->isPartitionPathAsLowerCase(emptySession.get()), true);
-  ASSERT_EQ(hiveConfig->orcWriterMinCompressionSize(emptySession.get()), 1024);
+      hiveConfig.sortWriterMaxOutputBytes(emptySession.get()), 10UL << 20);
+  ASSERT_EQ(hiveConfig.isPartitionPathAsLowerCase(emptySession.get()), true);
+  ASSERT_EQ(hiveConfig.orcWriterMinCompressionSize(emptySession.get()), 1024);
   ASSERT_EQ(
-      hiveConfig->orcWriterLinearStripeSizeHeuristics(emptySession.get()),
-      true);
-  ASSERT_FALSE(hiveConfig->cacheNoRetention(emptySession.get()));
+      hiveConfig.orcWriterCompressionLevel(emptySession.get()), std::nullopt);
+  ASSERT_EQ(
+      hiveConfig.orcWriterLinearStripeSizeHeuristics(emptySession.get()), true);
+  ASSERT_FALSE(hiveConfig.cacheNoRetention(emptySession.get()));
 }
 
 TEST(HiveConfigTest, overrideConfig) {
@@ -97,53 +98,54 @@ TEST(HiveConfigTest, overrideConfig) {
       {HiveConfig::kSortWriterMaxOutputBytes, "100MB"},
       {HiveConfig::kOrcWriterLinearStripeSizeHeuristics, "false"},
       {HiveConfig::kOrcWriterMinCompressionSize, "512"},
+      {HiveConfig::kOrcWriterCompressionLevel, "1"},
       {HiveConfig::kCacheNoRetention, "true"}};
-  HiveConfig* hiveConfig =
-      new HiveConfig(std::make_shared<MemConfig>(configFromFile));
+  HiveConfig hiveConfig(std::make_shared<MemConfig>(configFromFile));
   auto emptySession = std::make_unique<MemConfig>();
   ASSERT_EQ(
-      hiveConfig->insertExistingPartitionsBehavior(emptySession.get()),
+      hiveConfig.insertExistingPartitionsBehavior(emptySession.get()),
       facebook::velox::connector::hive::HiveConfig::
           InsertExistingPartitionsBehavior::kOverwrite);
-  ASSERT_EQ(hiveConfig->maxPartitionsPerWriters(emptySession.get()), 120);
-  ASSERT_EQ(hiveConfig->immutablePartitions(), true);
-  ASSERT_EQ(hiveConfig->s3UseVirtualAddressing(), false);
-  ASSERT_EQ(hiveConfig->s3GetLogLevel(), "Warning");
-  ASSERT_EQ(hiveConfig->s3UseSSL(), false);
-  ASSERT_EQ(hiveConfig->s3UseInstanceCredentials(), true);
-  ASSERT_EQ(hiveConfig->s3Endpoint(), "hey");
-  ASSERT_EQ(hiveConfig->s3AccessKey(), std::optional("hello"));
-  ASSERT_EQ(hiveConfig->s3SecretKey(), std::optional("hello"));
-  ASSERT_EQ(hiveConfig->s3IAMRole(), std::optional("hello"));
-  ASSERT_EQ(hiveConfig->s3IAMRoleSessionName(), "velox");
-  ASSERT_EQ(hiveConfig->gcsEndpoint(), "hey");
-  ASSERT_EQ(hiveConfig->gcsScheme(), "http");
-  ASSERT_EQ(hiveConfig->gcsCredentials(), "hey");
-  ASSERT_EQ(hiveConfig->isOrcUseColumnNames(emptySession.get()), true);
+  ASSERT_EQ(hiveConfig.maxPartitionsPerWriters(emptySession.get()), 120);
+  ASSERT_EQ(hiveConfig.immutablePartitions(), true);
+  ASSERT_EQ(hiveConfig.s3UseVirtualAddressing(), false);
+  ASSERT_EQ(hiveConfig.s3GetLogLevel(), "Warning");
+  ASSERT_EQ(hiveConfig.s3UseSSL(), false);
+  ASSERT_EQ(hiveConfig.s3UseInstanceCredentials(), true);
+  ASSERT_EQ(hiveConfig.s3Endpoint(), "hey");
+  ASSERT_EQ(hiveConfig.s3AccessKey(), std::optional("hello"));
+  ASSERT_EQ(hiveConfig.s3SecretKey(), std::optional("hello"));
+  ASSERT_EQ(hiveConfig.s3IAMRole(), std::optional("hello"));
+  ASSERT_EQ(hiveConfig.s3IAMRoleSessionName(), "velox");
+  ASSERT_EQ(hiveConfig.gcsEndpoint(), "hey");
+  ASSERT_EQ(hiveConfig.gcsScheme(), "http");
+  ASSERT_EQ(hiveConfig.gcsCredentials(), "hey");
+  ASSERT_EQ(hiveConfig.isOrcUseColumnNames(emptySession.get()), true);
   ASSERT_EQ(
-      hiveConfig->isFileColumnNamesReadAsLowerCase(emptySession.get()), true);
-  ASSERT_EQ(hiveConfig->maxCoalescedBytes(), 100);
-  ASSERT_EQ(hiveConfig->maxCoalescedDistanceBytes(), 100);
-  ASSERT_EQ(hiveConfig->numCacheFileHandles(), 100);
-  ASSERT_EQ(hiveConfig->isFileHandleCacheEnabled(), false);
+      hiveConfig.isFileColumnNamesReadAsLowerCase(emptySession.get()), true);
+  ASSERT_EQ(hiveConfig.maxCoalescedBytes(), 100);
+  ASSERT_EQ(hiveConfig.maxCoalescedDistanceBytes(), 100);
+  ASSERT_EQ(hiveConfig.numCacheFileHandles(), 100);
+  ASSERT_EQ(hiveConfig.isFileHandleCacheEnabled(), false);
   ASSERT_EQ(
-      hiveConfig->orcWriterMaxStripeSize(emptySession.get()),
+      hiveConfig.orcWriterMaxStripeSize(emptySession.get()),
       100L * 1024L * 1024L);
   ASSERT_EQ(
-      hiveConfig->orcWriterMaxDictionaryMemory(emptySession.get()),
+      hiveConfig.orcWriterMaxDictionaryMemory(emptySession.get()),
       100L * 1024L * 1024L);
-  ASSERT_EQ(hiveConfig->sortWriterMaxOutputRows(emptySession.get()), 100);
+  ASSERT_EQ(hiveConfig.sortWriterMaxOutputRows(emptySession.get()), 100);
   ASSERT_EQ(
-      hiveConfig->sortWriterMaxOutputBytes(emptySession.get()), 100UL << 20);
-  ASSERT_EQ(hiveConfig->orcWriterMinCompressionSize(emptySession.get()), 512);
+      hiveConfig.sortWriterMaxOutputBytes(emptySession.get()), 100UL << 20);
+  ASSERT_EQ(hiveConfig.orcWriterMinCompressionSize(emptySession.get()), 512);
+  ASSERT_EQ(hiveConfig.orcWriterCompressionLevel(emptySession.get()), 1);
   ASSERT_EQ(
-      hiveConfig->orcWriterLinearStripeSizeHeuristics(emptySession.get()),
+      hiveConfig.orcWriterLinearStripeSizeHeuristics(emptySession.get()),
       false);
-  ASSERT_TRUE(hiveConfig->cacheNoRetention(emptySession.get()));
+  ASSERT_TRUE(hiveConfig.cacheNoRetention(emptySession.get()));
 }
 
 TEST(HiveConfigTest, overrideSession) {
-  HiveConfig* hiveConfig = new HiveConfig(std::make_shared<MemConfig>());
+  HiveConfig hiveConfig(std::make_shared<MemConfig>());
   const std::unordered_map<std::string, std::string> sessionOverride = {
       {HiveConfig::kInsertExistingPartitionsBehaviorSession, "OVERWRITE"},
       {HiveConfig::kOrcUseColumnNamesSession, "true"},
@@ -155,45 +157,47 @@ TEST(HiveConfigTest, overrideSession) {
       {HiveConfig::kPartitionPathAsLowerCaseSession, "false"},
       {HiveConfig::kIgnoreMissingFilesSession, "true"},
       {HiveConfig::kOrcWriterMinCompressionSizeSession, "512"},
+      {HiveConfig::kOrcWriterCompressionLevelSession, "1"},
       {HiveConfig::kOrcWriterLinearStripeSizeHeuristicsSession, "false"},
       {HiveConfig::kCacheNoRetentionSession, "true"}};
   const auto session = std::make_unique<MemConfig>(sessionOverride);
   ASSERT_EQ(
-      hiveConfig->insertExistingPartitionsBehavior(session.get()),
+      hiveConfig.insertExistingPartitionsBehavior(session.get()),
       facebook::velox::connector::hive::HiveConfig::
           InsertExistingPartitionsBehavior::kOverwrite);
-  ASSERT_EQ(hiveConfig->maxPartitionsPerWriters(session.get()), 100);
-  ASSERT_EQ(hiveConfig->immutablePartitions(), false);
-  ASSERT_EQ(hiveConfig->s3UseVirtualAddressing(), true);
-  ASSERT_EQ(hiveConfig->s3GetLogLevel(), "FATAL");
-  ASSERT_EQ(hiveConfig->s3UseSSL(), true);
-  ASSERT_EQ(hiveConfig->s3UseInstanceCredentials(), false);
-  ASSERT_EQ(hiveConfig->s3Endpoint(), "");
-  ASSERT_EQ(hiveConfig->s3AccessKey(), std::nullopt);
-  ASSERT_EQ(hiveConfig->s3SecretKey(), std::nullopt);
-  ASSERT_EQ(hiveConfig->s3IAMRole(), std::nullopt);
-  ASSERT_EQ(hiveConfig->s3IAMRoleSessionName(), "velox-session");
-  ASSERT_EQ(hiveConfig->gcsEndpoint(), "");
-  ASSERT_EQ(hiveConfig->gcsScheme(), "https");
-  ASSERT_EQ(hiveConfig->gcsCredentials(), "");
-  ASSERT_EQ(hiveConfig->isOrcUseColumnNames(session.get()), true);
-  ASSERT_EQ(hiveConfig->isFileColumnNamesReadAsLowerCase(session.get()), true);
+  ASSERT_EQ(hiveConfig.maxPartitionsPerWriters(session.get()), 100);
+  ASSERT_EQ(hiveConfig.immutablePartitions(), false);
+  ASSERT_EQ(hiveConfig.s3UseVirtualAddressing(), true);
+  ASSERT_EQ(hiveConfig.s3GetLogLevel(), "FATAL");
+  ASSERT_EQ(hiveConfig.s3UseSSL(), true);
+  ASSERT_EQ(hiveConfig.s3UseInstanceCredentials(), false);
+  ASSERT_EQ(hiveConfig.s3Endpoint(), "");
+  ASSERT_EQ(hiveConfig.s3AccessKey(), std::nullopt);
+  ASSERT_EQ(hiveConfig.s3SecretKey(), std::nullopt);
+  ASSERT_EQ(hiveConfig.s3IAMRole(), std::nullopt);
+  ASSERT_EQ(hiveConfig.s3IAMRoleSessionName(), "velox-session");
+  ASSERT_EQ(hiveConfig.gcsEndpoint(), "");
+  ASSERT_EQ(hiveConfig.gcsScheme(), "https");
+  ASSERT_EQ(hiveConfig.gcsCredentials(), "");
+  ASSERT_EQ(hiveConfig.isOrcUseColumnNames(session.get()), true);
+  ASSERT_EQ(hiveConfig.isFileColumnNamesReadAsLowerCase(session.get()), true);
 
-  ASSERT_EQ(hiveConfig->maxCoalescedBytes(), 128 << 20);
-  ASSERT_EQ(hiveConfig->maxCoalescedDistanceBytes(), 512 << 10);
-  ASSERT_EQ(hiveConfig->numCacheFileHandles(), 20'000);
-  ASSERT_EQ(hiveConfig->isFileHandleCacheEnabled(), true);
+  ASSERT_EQ(hiveConfig.maxCoalescedBytes(), 128 << 20);
+  ASSERT_EQ(hiveConfig.maxCoalescedDistanceBytes(), 512 << 10);
+  ASSERT_EQ(hiveConfig.numCacheFileHandles(), 20'000);
+  ASSERT_EQ(hiveConfig.isFileHandleCacheEnabled(), true);
   ASSERT_EQ(
-      hiveConfig->orcWriterMaxStripeSize(session.get()), 22L * 1024L * 1024L);
+      hiveConfig.orcWriterMaxStripeSize(session.get()), 22L * 1024L * 1024L);
   ASSERT_EQ(
-      hiveConfig->orcWriterMaxDictionaryMemory(session.get()),
+      hiveConfig.orcWriterMaxDictionaryMemory(session.get()),
       22L * 1024L * 1024L);
-  ASSERT_EQ(hiveConfig->sortWriterMaxOutputRows(session.get()), 20);
-  ASSERT_EQ(hiveConfig->sortWriterMaxOutputBytes(session.get()), 20UL << 20);
-  ASSERT_EQ(hiveConfig->isPartitionPathAsLowerCase(session.get()), false);
-  ASSERT_EQ(hiveConfig->ignoreMissingFiles(session.get()), true);
+  ASSERT_EQ(hiveConfig.sortWriterMaxOutputRows(session.get()), 20);
+  ASSERT_EQ(hiveConfig.sortWriterMaxOutputBytes(session.get()), 20UL << 20);
+  ASSERT_EQ(hiveConfig.isPartitionPathAsLowerCase(session.get()), false);
+  ASSERT_EQ(hiveConfig.ignoreMissingFiles(session.get()), true);
   ASSERT_EQ(
-      hiveConfig->orcWriterLinearStripeSizeHeuristics(session.get()), false);
-  ASSERT_EQ(hiveConfig->orcWriterMinCompressionSize(session.get()), 512);
-  ASSERT_TRUE(hiveConfig->cacheNoRetention(session.get()));
+      hiveConfig.orcWriterLinearStripeSizeHeuristics(session.get()), false);
+  ASSERT_EQ(hiveConfig.orcWriterMinCompressionSize(session.get()), 512);
+  ASSERT_EQ(hiveConfig.orcWriterCompressionLevel(session.get()), 1);
+  ASSERT_TRUE(hiveConfig.cacheNoRetention(session.get()));
 }

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -481,6 +481,11 @@ Each query can override the config by setting corresponding query session proper
      - integer
      - 1024
      - Minimal number of items in an encoded stream.
+   * - hive.orc.writer.compression-level
+     - orc_optimized_writer_compression_level
+     - tinyint
+     - 3 for ZSTD and 4 for ZLIB
+     - The compression level to use with ZLIB and ZSTD. 
    * - cache.no_retention
      - cache.no_retention
      - bool

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -615,6 +615,8 @@ struct WriterOptions {
   std::optional<uint64_t> maxDictionaryMemory{std::nullopt};
   std::map<std::string, std::string> serdeParameters;
   std::optional<uint8_t> parquetWriteTimestampUnit;
+  std::optional<uint8_t> zlibCompressionLevel;
+  std::optional<uint8_t> zstdCompressionLevel;
 };
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -798,6 +798,16 @@ dwrf::WriterOptions getDwrfOptions(const dwio::common::WriterOptions& options) {
         Config::MAX_DICTIONARY_SIZE.configKey(),
         std::to_string(options.maxDictionaryMemory.value()));
   }
+  if (options.zlibCompressionLevel.has_value()) {
+    configs.emplace(
+        Config::ZLIB_COMPRESSION_LEVEL.configKey(),
+        std::to_string(options.zlibCompressionLevel.value()));
+  }
+  if (options.zstdCompressionLevel.has_value()) {
+    configs.emplace(
+        Config::ZSTD_COMPRESSION_LEVEL.configKey(),
+        std::to_string(options.zstdCompressionLevel.value()));
+  }
 
   dwrf::WriterOptions dwrfOptions;
   dwrfOptions.config = Config::fromMap(configs);


### PR DESCRIPTION
Summary:
Presto allows configuring the compression level used with ZSTD and ZLIB compressors when writing
files to Hive.  This change updates HiveDataSink to apply the configured value to the compression
level it  uses.

It also updates the default value(s) used in HiveDataSink to match Presto.  For ZLIB this is 4 and for
ZSTD this is 3.  This was a little awkward given that they're controlled by a shared single config in
Presto.

Differential Revision: D58313487
