### PR TITLE
Improve Fuzzer Job logging

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -137,7 +137,9 @@ jobs:
         with:
           path: "${{ env.CCACHE_DIR }}"
           key: ccache-fuzzer-centos
-      - run: ls "${{ env.CCACHE_DIR }}"
+      - working-directory: ${{ github.workspace }}
+        run: ls "${{ env.CCACHE_DIR }}"
+
       - name: Fix git permissions
         working-directory: ${{ github.workspace }}
           # Usually actions/checkout does this but as we run in a container

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -137,8 +137,6 @@ jobs:
         with:
           path: "${{ env.CCACHE_DIR }}"
           key: ccache-fuzzer-centos
-      - working-directory: ${{ github.workspace }}
-        run: ls "${{ env.CCACHE_DIR }}"
 
       - name: Fix git permissions
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -378,7 +378,7 @@ jobs:
                 --retry_with_try \
                 --enable_dereference \
                 --duration_sec $DURATION \
-                --minloglevel=1 \
+                --minloglevel=0 \
                 --stderrthreshold=2 \
                 --log_dir=/tmp/fuzzer_repro/logs \
                 --repro_persist_path=/tmp/fuzzer_repro \
@@ -430,7 +430,7 @@ jobs:
                 --max_expression_trees_per_step 2 \
                 --retry_with_try \
                 --enable_dereference \
-                --minloglevel=1 \
+                --minloglevel=0 \
                 --stderrthreshold=2 \
                 --log_dir=/tmp/presto_bias_fuzzer_repro/logs \
                 --repro_persist_path=/tmp/presto_bias_fuzzer_repro \
@@ -465,7 +465,7 @@ jobs:
           ./spark_aggregation_fuzzer_test \
                 --seed ${RANDOM} \
                 --duration_sec $DURATION \
-                --minloglevel=1 \
+                --minloglevel=0 \
                 --stderrthreshold=2 \
                 --log_dir=/tmp/spark_aggregate_fuzzer_repro/logs \
                 --repro_persist_path=/tmp/spark_aggregate_fuzzer_repro \
@@ -508,7 +508,7 @@ jobs:
             ./spark_expression_fuzzer_test \
                 --seed ${RANDOM} \
                 --duration_sec $DURATION \
-                --minloglevel=1 \
+                --minloglevel=0 \
                 --stderrthreshold=2 \
                 --log_dir=/tmp/spark_bias_fuzzer_repro/logs \
                 --assign_function_tickets  $(cat /tmp/signatures/spark_bias_functions) \
@@ -552,7 +552,7 @@ jobs:
                 --retry_with_try \
                 --enable_dereference \
                 --duration_sec $DURATION \
-                --minloglevel=1 \
+                --minloglevel=0 \
                 --stderrthreshold=2 \
                 --log_dir=/tmp/spark_fuzzer_repro/logs \
                 --repro_persist_path=/tmp/spark_fuzzer_repro \
@@ -587,7 +587,7 @@ jobs:
           ./velox_join_fuzzer_test \
                 --seed ${RANDOM} \
                 --duration_sec $DURATION \
-                --minloglevel=1 \
+                --minloglevel=0 \
                 --stderrthreshold=2 \
                 --log_dir=/tmp/join_fuzzer_repro/logs \
             && echo -e "\n\nJoin fuzzer run finished successfully."
@@ -622,7 +622,7 @@ jobs:
           ./velox_exchange_fuzzer_test \
                 --seed ${RANDOM} \
                 --duration_sec $DURATION \
-                --minloglevel=1 \
+                --minloglevel=0 \
                 --stderrthreshold=2 \
                 --log_dir=/tmp/exchange_fuzzer_repro/logs \
                 --repro_path=/tmp/exchange_fuzzer_repro \
@@ -658,7 +658,7 @@ jobs:
           ./velox_row_number_fuzzer_test \
                 --seed ${RANDOM} \
                 --duration_sec $DURATION \
-                --minloglevel=1 \
+                --minloglevel=0 \
                 --stderrthreshold=2 \
                 --log_dir=/tmp/row_fuzzer_repro/logs \
             && echo -e "\n\Row number fuzzer run finished successfully."
@@ -715,7 +715,7 @@ jobs:
           ./velox_aggregation_fuzzer_test \
                 --seed ${RANDOM} \
                 --duration_sec $DURATION \
-                --minloglevel=1 \
+                --minloglevel=0 \
                 --stderrthreshold=2 \
                 --log_dir=/tmp/aggregate_fuzzer_repro/logs \
                 --repro_persist_path=/tmp/aggregate_fuzzer_repro \
@@ -789,7 +789,7 @@ jobs:
           ./velox_aggregation_fuzzer_test \
                 --seed ${RANDOM} \
                 --duration_sec $DURATION \
-                --minloglevel=1 \
+                --minloglevel=0 \
                 --stderrthreshold=2 \
                 --log_dir=/tmp/aggregate_fuzzer_repro/logs \
                 --repro_persist_path=/tmp/aggregate_fuzzer_repro \

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -661,7 +661,6 @@ jobs:
                 --minloglevel=1 \
                 --stderrthreshold=2 \
                 --log_dir=/tmp/row_fuzzer_repro/logs \
-                --repro_path=/tmp/row_fuzzer_repro \
             && echo -e "\n\Row number fuzzer run finished successfully."
 
       - name: Archive row number production artifacts

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -590,7 +590,6 @@ jobs:
                 --minloglevel=1 \
                 --stderrthreshold=2 \
                 --log_dir=/tmp/join_fuzzer_repro/logs \
-                --repro_persist_path=/tmp/join_fuzzer_repro \
             && echo -e "\n\nJoin fuzzer run finished successfully."
 
       - name: Archive aggregate production artifacts
@@ -654,7 +653,7 @@ jobs:
         run: |
           cat /proc/sys/vm/max_map_count
           mkdir -p /tmp/row_fuzzer_repro/logs/
-          chmod -R 777 /tmp/exchange_fuzzer_repro
+          chmod -R 777 /tmp/row_fuzzer_repro
           chmod +x velox_row_number_fuzzer_test
           ./velox_row_number_fuzzer_test \
                 --seed ${RANDOM} \
@@ -665,7 +664,7 @@ jobs:
                 --repro_path=/tmp/row_fuzzer_repro \
             && echo -e "\n\Row number fuzzer run finished successfully."
 
-      - name: Archive Exchange production artifacts
+      - name: Archive row number production artifacts
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -137,7 +137,7 @@ jobs:
         with:
           path: "${{ env.CCACHE_DIR }}"
           key: ccache-fuzzer-centos
-
+      - run: ls "${{ env.CCACHE_DIR }}"
       - name: Fix git permissions
         working-directory: ${{ github.workspace }}
           # Usually actions/checkout does this but as we run in a container

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -364,7 +364,7 @@ jobs:
 
       - name: Run Presto Fuzzer
         run: |
-          mkdir -p /tmp/fuzzer_repro/
+          mkdir -p /tmp/fuzzer_repro/logs/
           chmod -R 777 /tmp/fuzzer_repro
           chmod +x velox_expression_fuzzer_test
           ./velox_expression_fuzzer_test \
@@ -378,8 +378,9 @@ jobs:
                 --retry_with_try \
                 --enable_dereference \
                 --duration_sec $DURATION \
-                --logtostderr=1 \
                 --minloglevel=1 \
+                --stderrthreshold=2 \
+                --log_dir=/tmp/fuzzer_repro/logs \
                 --repro_persist_path=/tmp/fuzzer_repro \
           && echo -e "\n\nFuzzer run finished successfully."
 
@@ -414,8 +415,8 @@ jobs:
       - name: Run Presto Expression Fuzzer
         run: |
           ls /tmp/signatures
-          mkdir -p /tmp/presto_fuzzer_repro/
-            chmod -R 777 /tmp/presto_fuzzer_repro
+          mkdir -p /tmp/presto_bias_fuzzer_repro/logs/
+            chmod -R 777 /tmp/presto_bias_fuzzer_repro
             chmod +x velox_expression_fuzzer_test
             ./velox_expression_fuzzer_test \
                 --seed ${RANDOM} \
@@ -429,9 +430,10 @@ jobs:
                 --max_expression_trees_per_step 2 \
                 --retry_with_try \
                 --enable_dereference \
-                --logtostderr=1 \
                 --minloglevel=1 \
-                --repro_persist_path=/tmp/presto_fuzzer_repro \
+                --stderrthreshold=2 \
+                --log_dir=/tmp/presto_bias_fuzzer_repro/logs \
+                --repro_persist_path=/tmp/presto_bias_fuzzer_repro \
             && echo -e "\n\nPresto Fuzzer run finished successfully."
 
       - name: Archive Spark expression production artifacts
@@ -457,14 +459,15 @@ jobs:
 
       - name: Run Spark Aggregate Fuzzer
         run: |
-          mkdir -p /tmp/spark_aggregate_fuzzer_repro/
+          mkdir -p /tmp/spark_aggregate_fuzzer_repro/logs/
           chmod -R 777 /tmp/spark_aggregate_fuzzer_repro
           chmod +x spark_aggregation_fuzzer_test
           ./spark_aggregation_fuzzer_test \
                 --seed ${RANDOM} \
                 --duration_sec $DURATION \
-                --logtostderr=1 \
                 --minloglevel=1 \
+                --stderrthreshold=2 \
+                --log_dir=/tmp/spark_aggregate_fuzzer_repro/logs \
                 --repro_persist_path=/tmp/spark_aggregate_fuzzer_repro \
           && echo -e "\n\nSpark Aggregation Fuzzer run finished successfully."
 
@@ -499,16 +502,17 @@ jobs:
       - name: Run Spark Expression Fuzzer
         run: |
           ls /tmp/signatures
-          mkdir -p /tmp/spark_fuzzer_repro/
-            chmod -R 777 /tmp/spark_fuzzer_repro
+          mkdir -p /tmp/spark_bias_fuzzer_repro/logs/
+            chmod -R 777 /tmp/spark_bias_fuzzer_repro
             chmod +x spark_expression_fuzzer_test
             ./spark_expression_fuzzer_test \
                 --seed ${RANDOM} \
                 --duration_sec $DURATION \
-                --logtostderr=1 \
                 --minloglevel=1 \
+                --stderrthreshold=2 \
+                --log_dir=/tmp/spark_bias_fuzzer_repro/logs \
                 --assign_function_tickets  $(cat /tmp/signatures/spark_bias_functions) \
-                --repro_persist_path=/tmp/spark_fuzzer_repro \
+                --repro_persist_path=/tmp/spark_bias_fuzzer_repro \
             && echo -e "\n\nSpark Fuzzer run finished successfully."
 
       - name: Archive Spark expression production artifacts
@@ -535,7 +539,7 @@ jobs:
 
       - name: Run Spark Expression Fuzzer
         run: |
-          mkdir -p /tmp/spark_fuzzer_repro/
+          mkdir -p /tmp/spark_fuzzer_repro/logs/
             chmod -R 777 /tmp/spark_fuzzer_repro
             chmod +x spark_expression_fuzzer_test
             ./spark_expression_fuzzer_test \
@@ -548,8 +552,9 @@ jobs:
                 --retry_with_try \
                 --enable_dereference \
                 --duration_sec $DURATION \
-                --logtostderr=1 \
                 --minloglevel=1 \
+                --stderrthreshold=2 \
+                --log_dir=/tmp/spark_fuzzer_repro/logs \
                 --repro_persist_path=/tmp/spark_fuzzer_repro \
             && echo -e "\n\nSpark Fuzzer run finished successfully."
 
@@ -576,15 +581,17 @@ jobs:
 
       - name: Run Join Fuzzer
         run: |
-          mkdir -p /tmp/join_fuzzer_repro/
+          mkdir -p /tmp/join_fuzzer_repro/logs/
           rm -rfv /tmp/join_fuzzer_repro/*
           chmod -R 777 /tmp/join_fuzzer_repro
           chmod +x velox_join_fuzzer_test
           ./velox_join_fuzzer_test \
                 --seed ${RANDOM} \
                 --duration_sec $DURATION \
-                --logtostderr=1 \
                 --minloglevel=1 \
+                --stderrthreshold=2 \
+                --log_dir=/tmp/join_fuzzer_repro/logs \
+                --repro_persist_path=/tmp/join_fuzzer_repro \
             && echo -e "\n\nJoin fuzzer run finished successfully."
 
       - name: Archive aggregate production artifacts
@@ -611,15 +618,16 @@ jobs:
       - name: Run exchange Fuzzer
         run: |
           cat /proc/sys/vm/max_map_count
-          mkdir -p /tmp/exchange_fuzzer_repro/
+          mkdir -p /tmp/exchange_fuzzer_repro/logs/
           rm -rfv /tmp/exchange_fuzzer_repro/*
           chmod -R 777 /tmp/exchange_fuzzer_repro
           chmod +x velox_exchange_fuzzer_test
           ./velox_exchange_fuzzer_test \
                 --seed ${RANDOM} \
-                --duration_sec ${{ env.DURATION }} \
-                --logtostderr=1 \
+                --duration_sec $DURATION \
                 --minloglevel=1 \
+                --stderrthreshold=2 \
+                --log_dir=/tmp/exchange_fuzzer_repro/logs \
                 --repro_path=/tmp/exchange_fuzzer_repro \
             && echo -e "\n\Exchange fuzzer run finished successfully."
 
@@ -647,14 +655,26 @@ jobs:
       - name: Run RowNumber Fuzzer
         run: |
           cat /proc/sys/vm/max_map_count
+          mkdir -p /tmp/row_fuzzer_repro/logs/
+          rm -rfv /tmp/row_fuzzer_repro/*
+          chmod -R 777 /tmp/exchange_fuzzer_repro
           chmod +x velox_row_number_fuzzer_test
           ./velox_row_number_fuzzer_test \
                 --seed ${RANDOM} \
-                --duration_sec ${{ env.DURATION }} \
-                --logtostderr=1 \
+                --duration_sec $DURATION \
                 --minloglevel=1 \
+                --stderrthreshold=2 \
+                --log_dir=/tmp/row_fuzzer_repro/logs \
+                --repro_path=/tmp/row_fuzzer_repro \
             && echo -e "\n\Row number fuzzer run finished successfully."
 
+      - name: Archive Exchange production artifacts
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+            name: row-fuzzer-failure-artifacts
+            path: |
+              /tmp/row_fuzzer_repro
   presto-java-aggregation-fuzzer-run:
     name: Aggregation Fuzzer with Presto as source of truth
     needs: compile
@@ -694,15 +714,16 @@ jobs:
           sleep 60
           /opt/presto-cli --server 127.0.0.1:8080 --execute 'CREATE SCHEMA hive.tpch;'
           cd -
-          mkdir -p /tmp/aggregate_fuzzer_repro/
+          mkdir -p /tmp/aggregate_fuzzer_repro/logs/
           rm -rfv /tmp/aggregate_fuzzer_repro/*
           chmod -R 777 /tmp/aggregate_fuzzer_repro
           chmod +x velox_aggregation_fuzzer_test
           ./velox_aggregation_fuzzer_test \
                 --seed ${RANDOM} \
                 --duration_sec $DURATION \
-                --logtostderr=1 \
                 --minloglevel=1 \
+                --stderrthreshold=2 \
+                --log_dir=/tmp/aggregate_fuzzer_repro/logs \
                 --repro_persist_path=/tmp/aggregate_fuzzer_repro \
                 --enable_sorted_aggregations=true \
                 --presto_url=http://127.0.0.1:8080 \
@@ -763,7 +784,7 @@ jobs:
           sleep 60
           /opt/presto-cli --server 127.0.0.1:8080 --execute 'CREATE SCHEMA hive.tpch;'
           cd -
-          mkdir -p /tmp/aggregate_fuzzer_repro/
+          mkdir -p /tmp/aggregate_fuzzer_repro/logs/
           rm -rfv /tmp/aggregate_fuzzer_repro/*
           chmod -R 777 /tmp/aggregate_fuzzer_repro
           chmod +x velox_aggregation_fuzzer_test
@@ -775,8 +796,9 @@ jobs:
           ./velox_aggregation_fuzzer_test \
                 --seed ${RANDOM} \
                 --duration_sec $DURATION \
-                --logtostderr=1 \
                 --minloglevel=1 \
+                --stderrthreshold=2 \
+                --log_dir=/tmp/aggregate_fuzzer_repro/logs \
                 --repro_persist_path=/tmp/aggregate_fuzzer_repro \
                 --enable_sorted_aggregations=true \
                 --only=$(cat /tmp/signatures/presto_aggregate_bias_functions) \
@@ -855,15 +877,16 @@ jobs:
           sleep 60
           /opt/presto-cli --server 127.0.0.1:8080 --execute 'CREATE SCHEMA hive.tpch;'
           cd -
-          mkdir -p /tmp/window_fuzzer_repro/
+          mkdir -p /tmp/window_fuzzer_repro/logs/
           rm -rfv /tmp/window_fuzzer_repro/*
           chmod -R 777 /tmp/window_fuzzer_repro
           chmod +x velox_window_fuzzer_test
           ./velox_window_fuzzer_test \
                 --seed ${RANDOM} \
                 --duration_sec $DURATION \
-                --logtostderr=1 \
                 --minloglevel=0 \
+                --stderrthreshold=2 \
+                --log_dir=/tmp/window_fuzzer_repro/logs \
                 --repro_persist_path=/tmp/window_fuzzer_repro \
                 --enable_window_reference_verification \
                 --presto_url=http://127.0.0.1:8080 \

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -582,7 +582,6 @@ jobs:
       - name: Run Join Fuzzer
         run: |
           mkdir -p /tmp/join_fuzzer_repro/logs/
-          rm -rfv /tmp/join_fuzzer_repro/*
           chmod -R 777 /tmp/join_fuzzer_repro
           chmod +x velox_join_fuzzer_test
           ./velox_join_fuzzer_test \
@@ -619,7 +618,6 @@ jobs:
         run: |
           cat /proc/sys/vm/max_map_count
           mkdir -p /tmp/exchange_fuzzer_repro/logs/
-          rm -rfv /tmp/exchange_fuzzer_repro/*
           chmod -R 777 /tmp/exchange_fuzzer_repro
           chmod +x velox_exchange_fuzzer_test
           ./velox_exchange_fuzzer_test \
@@ -656,7 +654,6 @@ jobs:
         run: |
           cat /proc/sys/vm/max_map_count
           mkdir -p /tmp/row_fuzzer_repro/logs/
-          rm -rfv /tmp/row_fuzzer_repro/*
           chmod -R 777 /tmp/exchange_fuzzer_repro
           chmod +x velox_row_number_fuzzer_test
           ./velox_row_number_fuzzer_test \
@@ -715,7 +712,6 @@ jobs:
           /opt/presto-cli --server 127.0.0.1:8080 --execute 'CREATE SCHEMA hive.tpch;'
           cd -
           mkdir -p /tmp/aggregate_fuzzer_repro/logs/
-          rm -rfv /tmp/aggregate_fuzzer_repro/*
           chmod -R 777 /tmp/aggregate_fuzzer_repro
           chmod +x velox_aggregation_fuzzer_test
           ./velox_aggregation_fuzzer_test \
@@ -785,7 +781,6 @@ jobs:
           /opt/presto-cli --server 127.0.0.1:8080 --execute 'CREATE SCHEMA hive.tpch;'
           cd -
           mkdir -p /tmp/aggregate_fuzzer_repro/logs/
-          rm -rfv /tmp/aggregate_fuzzer_repro/*
           chmod -R 777 /tmp/aggregate_fuzzer_repro
           chmod +x velox_aggregation_fuzzer_test
           echo "signatures folder"
@@ -878,7 +873,6 @@ jobs:
           /opt/presto-cli --server 127.0.0.1:8080 --execute 'CREATE SCHEMA hive.tpch;'
           cd -
           mkdir -p /tmp/window_fuzzer_repro/logs/
-          rm -rfv /tmp/window_fuzzer_repro/*
           chmod -R 777 /tmp/window_fuzzer_repro
           chmod +x velox_window_fuzzer_test
           ./velox_window_fuzzer_test \


### PR DESCRIPTION
Logging to stderr massively slows down the actual fuzzer jobs when a verbose log level is used but we still want the information. This PR adds logging to file (ERROR and above will still show on stderr) which will be uploaded as part of the repro artifacts.