### PR TITLE
Reclaim unused reserved memory in dwrf writer

### DIFF
--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -324,6 +324,10 @@ class TestMemoryPool : public memory::MemoryPool {
     return 0;
   }
 
+  int64_t releasableReservation() const override {
+    return 0;
+  }
+
   int64_t reservedBytes() const override {
     return 0;
   }

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -208,11 +208,11 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
     return threadSafe_;
   }
 
-  /// Invoked to traverse the memory pool subtree rooted at this, and calls
-  /// 'visitor' on each visited child memory pool with the parent pool's
-  /// 'poolMutex_' reader lock held. The 'visitor' must not access the
-  /// parent memory pool to avoid the potential recursive locking issues. Note
-  /// that the traversal stops if 'visitor' returns false.
+  /// Invoked to visit the memory pool's direct children, and calls 'visitor' on
+  /// each visited child memory pool with the parent pool's 'poolMutex_' reader
+  /// lock held. The 'visitor' must not access the parent memory pool to avoid
+  /// the potential recursive locking issues. Note that the traversal stops if
+  /// 'visitor' returns false.
   virtual void visitChildren(
       const std::function<bool(MemoryPool*)>& visitor) const;
 
@@ -328,14 +328,21 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   /// Returns the peak memory usage in bytes of this memory pool.
   virtual int64_t peakBytes() const = 0;
 
-  /// Returns the reserved but not used memory reservation in bytes of this
-  /// memory pool.
+  /// Returns the reserved but not used memory in bytes of this memory pool.
   ///
-  /// NOTE: this is always zero for non-leaf memory pool as it only aggregate
+  /// NOTE: this is always zero for non-leaf memory pool as it only aggregates
   /// the memory reservations from its child memory pools but not
   /// differentiating whether the aggregated reservations have been actually
   /// used in child pools or not.
   virtual int64_t availableReservation() const = 0;
+
+  /// Returns the reserved but not used memory in bytes that can be released by
+  /// calling 'release()'. This might be different from 'availableReservation()'
+  /// because leaf memory pool makes quantized memory reservation.
+  ///
+  /// NOTE: For non-leaf memory pool, it returns the aggregated releasable
+  /// memory reservations from all its leaf memory pool.
+  virtual int64_t releasableReservation() const = 0;
 
   /// Returns the reserved memory reservation in bytes including both used and
   /// unused reservations.
@@ -631,6 +638,8 @@ class MemoryPoolImpl : public MemoryPool {
     std::lock_guard<std::mutex> l(mutex_);
     return availableReservationLocked();
   }
+
+  int64_t releasableReservation() const override;
 
   int64_t reservedBytes() const override {
     return reservationBytes_;
@@ -1002,7 +1011,7 @@ class MemoryPoolImpl : public MemoryPool {
   // name matches the specified regular expression 'debugPoolNameRegex_'.
   const std::string debugPoolNameRegex_;
 
-  // Serializes updates on 'grantedReservationBytes_', 'usedReservationBytes_'
+  // Serializes updates on 'reservationBytes_', 'usedReservationBytes_'
   // and 'minReservationBytes_' to make reservation decision on a consistent
   // read/write of those counters. incrementReservation()/decrementReservation()
   // work based on atomic 'reservationBytes_' without mutex as children updating

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -24,6 +24,7 @@
 #include "velox/common/testutil/TestValue.h"
 #include "velox/core/Config.h"
 #include "velox/dwio/common/Options.h"
+#include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
@@ -621,7 +622,7 @@ TEST_F(HiveDataSinkTest, abort) {
   }
 }
 
-TEST_F(HiveDataSinkTest, memoryReclaim) {
+DEBUG_ONLY_TEST_F(HiveDataSinkTest, memoryReclaim) {
   const int numBatches = 200;
   auto vectors = createVectors(500, 200);
 
@@ -644,7 +645,7 @@ TEST_F(HiveDataSinkTest, memoryReclaim) {
           expectedWriterReclaimed);
     }
   } testSettings[] = {
-      //    {dwio::common::FileFormat::DWRF, true, true, 1 << 30, true, true},
+      {dwio::common::FileFormat::DWRF, true, true, 1 << 30, true, true},
       {dwio::common::FileFormat::DWRF, true, true, 1, true, true},
       {dwio::common::FileFormat::DWRF, true, false, 1 << 30, false, false},
       {dwio::common::FileFormat::DWRF, true, false, 1, false, false},
@@ -664,6 +665,13 @@ TEST_F(HiveDataSinkTest, memoryReclaim) {
       {dwio::common::FileFormat::PARQUET, false, false, 1, false, false}
 #endif
   };
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::dwrf::Writer::MemoryReclaimer::reclaimableBytes",
+      std::function<void(dwrf::Writer*)>([&](dwrf::Writer* writer) {
+        // Release before reclaim to make it not able to reclaim from reserved
+        // memory.
+        writer->getContext().releaseMemoryReservation();
+      }));
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     setupMemoryPools();

--- a/velox/dwio/dwrf/test/E2EWriterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTest.cpp
@@ -2040,7 +2040,14 @@ DEBUG_ONLY_TEST_F(E2EWriterTest, memoryReclaimDuringInit) {
   }
 }
 
-TEST_F(E2EWriterTest, memoryReclaimThreshold) {
+DEBUG_ONLY_TEST_F(E2EWriterTest, memoryReclaimThreshold) {
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::dwrf::Writer::MemoryReclaimer::reclaimableBytes",
+      std::function<void(dwrf::Writer*)>([&](dwrf::Writer* writer) {
+        // Release before reclaim to make it not able to reclaim from reserved
+        // memory.
+        writer->getContext().releaseMemoryReservation();
+      }));
   const auto type = ROW(
       {{"int_val", INTEGER()},
        {"string_val", VARCHAR()},

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -57,8 +57,12 @@ class MockMemoryPool : public velox::memory::MemoryPool {
     VELOX_NYI("{} unsupported", __FUNCTION__);
   }
 
-  int64_t reservedBytes() const override {
+  int64_t releasableReservation() const override {
     VELOX_NYI("{} unsupported", __FUNCTION__);
+  }
+
+  int64_t reservedBytes() const override {
+    return localMemoryUsage_;
   }
 
   bool maybeReserve(uint64_t size) override {

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -289,11 +289,11 @@ bool Writer::maybeReserveMemory(
   auto& context = getContext();
   auto& pool = context.getMemoryPool(memoryUsageCategory);
   const uint64_t availableReservation = pool.availableReservation();
-  const uint64_t usedReservationBytes = pool.usedBytes();
+  const uint64_t usedBytes = pool.usedBytes();
   const uint64_t minReservationBytes =
-      usedReservationBytes * spillConfig_->minSpillableReservationPct / 100;
+      usedBytes * spillConfig_->minSpillableReservationPct / 100;
   const uint64_t estimatedIncrementBytes =
-      usedReservationBytes * estimatedMemoryGrowthRatio;
+      usedBytes * estimatedMemoryGrowthRatio;
   if ((availableReservation > minReservationBytes) &&
       (availableReservation > 2 * estimatedIncrementBytes)) {
     return true;
@@ -301,15 +301,15 @@ bool Writer::maybeReserveMemory(
 
   const uint64_t bytesToReserve = std::max(
       estimatedIncrementBytes * 2,
-      usedReservationBytes * spillConfig_->spillableReservationGrowthPct / 100);
+      usedBytes * spillConfig_->spillableReservationGrowthPct / 100);
   return pool.maybeReserve(bytesToReserve);
 }
 
-void Writer::releaseMemory() {
+int64_t Writer::releaseMemory() {
   if (!canReclaim()) {
-    return;
+    return 0;
   }
-  getContext().releaseMemoryReservation();
+  return getContext().releaseMemoryReservation();
 }
 
 uint64_t Writer::flushTimeMemoryUsageEstimate(
@@ -406,7 +406,7 @@ void Writer::flushStripe(bool close) {
     createRowIndexEntry();
   }
 
-  const auto preFlushMem = context.getTotalMemoryUsage();
+  const auto preFlushTotalMemBytes = context.getTotalMemoryUsage();
   ensureStripeFlushFits();
   // NOTE: ensureStripeFlushFits() might trigger memory arbitration that have
   // flushed the current stripe.
@@ -434,7 +434,7 @@ void Writer::flushStripe(bool close) {
   metrics.flushOverhead = static_cast<uint64_t>(flushOverhead);
   context.recordFlushOverhead(metrics.flushOverhead);
 
-  const auto postFlushMem = context.getTotalMemoryUsage();
+  const auto postFlushTotalMemBytes = context.getTotalMemoryUsage();
 
   auto& sink = writerBase_->getSink();
   auto stripeOffset = sink.size();
@@ -559,8 +559,8 @@ void Writer::flushStripe(bool close) {
       metrics.stripeIndex,
       metrics.flushOverhead,
       metrics.stripeSize,
-      preFlushMem,
-      postFlushMem,
+      preFlushTotalMemBytes,
+      postFlushTotalMemBytes,
       metrics.close);
   addThreadLocalRuntimeStat(
       "stripeSize",
@@ -721,11 +721,18 @@ bool Writer::MemoryReclaimer::reclaimableBytes(
   if (!writer_->canReclaim()) {
     return false;
   }
-  const uint64_t memoryUsage = writer_->getContext().getTotalMemoryUsage();
-  if (memoryUsage < writer_->spillConfig_->writerFlushThresholdSize) {
+  TestValue::adjust(
+      "facebook::velox::dwrf::Writer::MemoryReclaimer::reclaimableBytes",
+      writer_);
+  const auto& context = writer_->getContext();
+  const auto usedBytes = context.getTotalMemoryUsage();
+  const auto releasableBytes = context.releasableMemoryReservation();
+  const bool flushable =
+      usedBytes >= writer_->spillConfig_->writerFlushThresholdSize;
+  if (releasableBytes == 0 && !flushable) {
     return false;
   }
-  reclaimableBytes = memoryUsage;
+  reclaimableBytes = (flushable ? usedBytes : 0) + releasableBytes;
   return true;
 }
 
@@ -741,7 +748,8 @@ uint64_t Writer::MemoryReclaimer::reclaim(
   if (*writer_->nonReclaimableSection_) {
     RECORD_METRIC_VALUE(kMetricMemoryNonReclaimableCount);
     LOG(WARNING)
-        << "Can't reclaim from dwrf writer which is under non-reclaimable section: "
+        << "Can't reclaim from dwrf writer which is under non-reclaimable "
+           "section: "
         << pool->name();
     ++stats.numNonReclaimableAttempts;
     return 0;
@@ -752,24 +760,34 @@ uint64_t Writer::MemoryReclaimer::reclaim(
     ++stats.numNonReclaimableAttempts;
     return 0;
   }
-  const uint64_t memoryUsage = writer_->getContext().getTotalMemoryUsage();
-  if (memoryUsage < writer_->spillConfig_->writerFlushThresholdSize) {
-    RECORD_METRIC_VALUE(kMetricMemoryNonReclaimableCount);
-    LOG(WARNING)
-        << "Can't reclaim memory from dwrf writer pool " << pool->name()
-        << " which doesn't have sufficient memory to flush, writer memory usage: "
-        << succinctBytes(memoryUsage) << ", writer flush memory threshold: "
-        << succinctBytes(writer_->spillConfig_->writerFlushThresholdSize);
-    ++stats.numNonReclaimableAttempts;
-    return 0;
-  }
 
   return memory::MemoryReclaimer::run(
       [&]() {
         int64_t reclaimedBytes{0};
         {
           memory::ScopedReclaimedBytesRecorder recorder(pool, &reclaimedBytes);
-          writer_->flushInternal(false);
+          const auto& context = writer_->getContext();
+          const auto usedBytes = context.getTotalMemoryUsage();
+          const auto releasedBytes = writer_->releaseMemory();
+          if (releasedBytes == 0 &&
+              usedBytes < writer_->spillConfig_->writerFlushThresholdSize) {
+            RECORD_METRIC_VALUE(kMetricMemoryNonReclaimableCount);
+            LOG(WARNING)
+                << "Can't reclaim memory from dwrf writer pool " << pool->name()
+                << " which doesn't have sufficient memory to release or flush, "
+                   "writer memory usage: "
+                << succinctBytes(usedBytes)
+                << ", writer memory available reservation: "
+                << succinctBytes(context.availableMemoryReservation())
+                << ", writer flush memory threshold: "
+                << succinctBytes(
+                       writer_->spillConfig_->writerFlushThresholdSize);
+            ++stats.numNonReclaimableAttempts;
+          } else {
+            if (usedBytes >= writer_->spillConfig_->writerFlushThresholdSize) {
+              writer_->flushInternal(false);
+            }
+          }
         }
         return reclaimedBytes;
       },

--- a/velox/dwio/dwrf/writer/Writer.h
+++ b/velox/dwio/dwrf/writer/Writer.h
@@ -188,8 +188,9 @@ class Writer : public dwio::common::Writer {
       MemoryUsageCategory memoryUsageCategory,
       double estimatedMemoryGrowthRatio);
 
-  // Releases the unused memory reservations after we flush a stripe.
-  void releaseMemory();
+  // Releases the unused memory reservations after we flush a stripe. Returns
+  // the total number of released bytes.
+  int64_t releaseMemory();
 
   // Create a new stripe. No-op if there is no data written.
   void flushInternal(bool close = false);


### PR DESCRIPTION
During memory reclaim, we can release the previously reserved memory from writer to spare more memory for query to run. This PR also fixed the flush overhead calculation by adding dictionary memory usage during overhead estimation to align with the recording.