### PR TITLE
Add regexp_replace lambda Presto function

### DIFF
--- a/velox/docs/functions/presto/regexp.rst
+++ b/velox/docs/functions/presto/regexp.rst
@@ -93,6 +93,16 @@ limited to 20 different expressions per instance and thread of execution.
 
         SELECT regexp_replace('1a 2b 14m', '(\d+)([ab]) ', '3c$2 '); -- '3ca 3cb 14m'
 
+.. function:: regexp_replace(string, pattern, function) -> varchar
+
+    Replaces every instance of the substring matched by the regular expression
+    ``pattern`` in ``string`` using ``function``. The lambda expression
+    ``function`` is invoked for each match with the capturing groups passed as an
+    array. Capturing group numbers start at 1; there is no group for the entire match
+    (if you need this, surround the entire expression with parenthesis). ::
+
+        SELECT regexp_replace('new york', '(\w)(\w*)', x -> upper(x[1]) || lower(x[2])); --'New York'
+
 .. function:: regexp_split(string, pattern) -> array(varchar):
 
     Splits ``string`` using the regular expression ``pattern`` and returns an

--- a/velox/functions/lib/Re2Functions.h
+++ b/velox/functions/lib/Re2Functions.h
@@ -248,6 +248,8 @@ class ReCache {
  public:
   RE2* findOrCompile(const StringView& pattern);
 
+  Expected<RE2*> tryFindOrCompile(const StringView& pattern);
+
  private:
   folly::F14FastMap<std::string, std::unique_ptr<RE2>> cache_;
 };
@@ -402,6 +404,14 @@ struct Re2RegexpSplit {
  private:
   detail::ReCache cache_;
 };
+
+std::shared_ptr<exec::VectorFunction> makeRegexpReplaceWithLambda(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    const core::QueryConfig& config);
+
+std::vector<std::shared_ptr<exec::FunctionSignature>>
+regexpReplaceWithLambdaSignatures();
 
 } // namespace facebook::velox::functions
 

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -182,6 +182,11 @@ add_executable(velox_functions_prestosql_benchmarks_map_subscript
 target_link_libraries(velox_functions_prestosql_benchmarks_map_subscript
                       ${BENCHMARK_DEPENDENCIES})
 
+add_executable(velox_functions_prestosql_benchmarks_regexp_replace
+               RegexpReplaceBenchmark.cpp)
+target_link_libraries(velox_functions_prestosql_benchmarks_regexp_replace
+                      ${BENCHMARK_DEPENDENCIES})
+
 add_executable(velox_functions_prestosql_benchmarks_generic
                GenericBenchmark.cpp)
 target_link_libraries(velox_functions_prestosql_benchmarks_generic

--- a/velox/functions/prestosql/benchmarks/RegexpReplaceBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/RegexpReplaceBenchmark.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/type/Type.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/DecodedVector.h"
+
+using namespace facebook::velox;
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  memory::MemoryManager::initialize({});
+  facebook::velox::functions::prestosql::registerAllScalarFunctions();
+
+  ExpressionBenchmarkBuilder benchmarkBuilder;
+
+  VectorFuzzer::Options options;
+  options.vectorSize = 1'000;
+  options.nullRatio = 0.01;
+
+  auto* pool = benchmarkBuilder.pool();
+  auto& vm = benchmarkBuilder.vectorMaker();
+
+  // Compare regexp_replace with fixed and lambda replacement.
+  benchmarkBuilder.addBenchmarkSet("lambda_one_group", ROW({"c0"}, {VARCHAR()}))
+      .withFuzzerOptions(options)
+      .addExpression("fixed", "regexp_replace(c0, '(\\w)', '$1')")
+      .addExpression("lambda", "regexp_replace(c0, '(\\w)', x -> x[1])");
+  benchmarkBuilder
+      .addBenchmarkSet("lambda_two_groups", ROW({"c0"}, {VARCHAR()}))
+      .withFuzzerOptions(options)
+      .addExpression("fixed", "regexp_replace(c0, '(\\w)(\\w*)', '$1$2')")
+      .addExpression(
+          "lambda",
+          "regexp_replace(c0, '(\\w)(\\w*)', x -> concat(x[1], x[2]))");
+
+  // Compare regexp_replace with fixed-string pattern and replace.
+  benchmarkBuilder
+      .addBenchmarkSet("fixed_replacement", ROW({"c0"}, {VARCHAR()}))
+      .withFuzzerOptions(options)
+      .addExpression("replace", "replace(c0, 'a', '_')")
+      .addExpression("regexp_replace", "regexp_replace(c0, 'a','_')");
+
+  benchmarkBuilder.registerBenchmarks();
+  benchmarkBuilder.testBenchmarks();
+
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -85,6 +85,11 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "regexp_replace"});
   registerFunction<Re2RegexpReplacePresto, Varchar, Varchar, Varchar, Varchar>(
       {prefix + "regexp_replace"});
+  exec::registerStatefulVectorFunction(
+      prefix + "regexp_replace",
+      regexpReplaceWithLambdaSignatures(),
+      makeRegexpReplaceWithLambda,
+      exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build());
 
   registerFunction<Re2RegexpSplit, Array<Varchar>, Varchar, Varchar>(
       {prefix + "regexp_split"});

--- a/velox/functions/prestosql/tests/RegexpReplaceTest.cpp
+++ b/velox/functions/prestosql/tests/RegexpReplaceTest.cpp
@@ -16,6 +16,7 @@
 #include <exception>
 #include <optional>
 
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 
 namespace facebook::velox {
@@ -69,6 +70,7 @@ TEST_F(RegexpReplaceTest, withReplacement) {
   EXPECT_EQ(regexpReplace("a12b34c5", "\\d", "."), "a..b..c.");
   EXPECT_EQ(regexpReplace("", "\\d", "."), "");
   EXPECT_EQ(regexpReplace("abc", "", "."), ".a.b.c.");
+  EXPECT_EQ(regexpReplace("", "", "."), ".");
   EXPECT_EQ(
       regexpReplace("1a 2b 14m", "(\\d+)([ab]) ", "3c$2 "), "3ca 3cb 14m");
   EXPECT_EQ(regexpReplace("1a 2b 14m", "(\\d+)([ab])", "3c$2"), "3ca 3cb 14m");
@@ -110,6 +112,159 @@ TEST_F(RegexpReplaceTest, withReplacement) {
 
   expected = makeFlatVector<std::string>(
       {"apple||", "|| banana", "oran||23 ...", "12 3|| ||||"});
+  test::assertEqualVectors(expected, result);
+}
+
+TEST_F(RegexpReplaceTest, lambda) {
+  auto input = makeRowVector({
+      makeFlatVector<std::string>(
+          {"new york", "", "los angeles", "san francisco", "seattle"}),
+      makeFlatVector<std::string>({"[a]", "[b]", "[c]", "[d]", "[e]"}),
+      makeFlatVector<int64_t>({0, 1, 2, 3, 4}),
+  });
+
+  auto result = evaluate(
+      "regexp_replace(c0, '(\\w)(\\w*)', x -> (concat(upper(x[1]), lower(x[2]))))",
+      input);
+
+  VectorPtr expected = makeFlatVector<std::string>(
+      {"New York", "", "Los Angeles", "San Francisco", "Seattle"});
+  test::assertEqualVectors(expected, result);
+
+  // No matches for any input string. The result should be the same as input.
+  result = evaluate(
+      "regexp_replace(c0, '\\d+', x -> (concat(upper(x[1]), lower(x[2]))))",
+      input);
+  test::assertEqualVectors(input->childAt(0), result);
+
+  // No matches for the second group.
+  result = evaluate(
+      "regexp_replace(c0, '(\\w)(\\d*)', x -> (concat(upper(x[1]), lower(x[2]))))",
+      input);
+  expected = makeFlatVector<std::string>(
+      {"NEW YORK", "", "LOS ANGELES", "SAN FRANCISCO", "SEATTLE"});
+  test::assertEqualVectors(expected, result);
+
+  // Regex with no matching groups.
+  result = evaluate("regexp_replace(c0, '\\w\\w*', x -> '_')", input);
+  expected = makeFlatVector<std::string>({"_ _", "", "_ _", "_ _", "_"});
+  test::assertEqualVectors(expected, result);
+
+  // Lambda references non-existent matching groups.
+  VELOX_ASSERT_THROW(
+      (evaluate(
+          "regexp_replace(c0, '\\w(\\w*)', x -> (concat(upper(x[1]), lower(x[2]))))",
+          input)),
+      "Array subscript out of bounds");
+
+  result = evaluate(
+      "regexp_replace(c0, '\\w(\\w*)', x -> try(concat(upper(x[1]), lower(x[2]))))",
+      input);
+  expected = makeNullableFlatVector<std::string>(
+      {std::nullopt, "", std::nullopt, std::nullopt, std::nullopt});
+  test::assertEqualVectors(expected, result);
+
+  result = evaluate(
+      "try(regexp_replace(c0, '\\w(\\w*)', x -> (concat(upper(x[1]), lower(x[2])))))",
+      input);
+  test::assertEqualVectors(expected, result);
+
+  // Empty pattern.
+  result = evaluate("regexp_replace(c0, '', x -> '_')", input);
+  expected = makeFlatVector<std::string>(
+      {"_n_e_w_ _y_o_r_k_",
+       "_",
+       "_l_o_s_ _a_n_g_e_l_e_s_",
+       "_s_a_n_ _f_r_a_n_c_i_s_c_o_",
+       "_s_e_a_t_t_l_e_"});
+  test::assertEqualVectors(expected, result);
+
+  // Regex that "matches" empty string.
+  result = evaluate("regexp_replace(c0, '\\d*', x -> '_')", input);
+  test::assertEqualVectors(expected, result);
+
+  // Lambda with captures.
+  result = evaluate(
+      "regexp_replace(c0, '(\\w)(\\w*)', x -> concat(c1, lower(x[2])))", input);
+  expected = makeFlatVector<std::string>(
+      {"[a]ew [a]ork",
+       "",
+       "[c]os [c]ngeles",
+       "[d]an [d]rancisco",
+       "[e]eattle"});
+  test::assertEqualVectors(expected, result);
+
+  // Different lambdas for different rows.
+  // Even rows: replace each word with the first letter uppercase.
+  // Odd rows: remove first letter from each word.
+  result = evaluate(
+      "regexp_replace(c0, '(\\w)(\\w*)', if (c2 % 2 = 0, x -> upper(x[1]), x -> x[2]))",
+      input);
+  expected =
+      makeFlatVector<std::string>({"N Y", "", "L A", "an rancisco", "S"});
+  test::assertEqualVectors(expected, result);
+
+  // Lambda fails for some rows.
+  VELOX_ASSERT_THROW(
+      (evaluate(
+          "regexp_replace(c0, '(\\w)(\\w*)', x -> if (x[1] = 's', x[10], concat(upper(x[1]), lower(x[2]))))",
+          input)),
+      "Array subscript out of bounds");
+
+  result = evaluate(
+      "regexp_replace(c0, '(\\w)(\\w*)', x -> try(if (x[1] = 's', x[10], concat(upper(x[1]), lower(x[2])))))",
+      input);
+  expected = makeNullableFlatVector<std::string>(
+      {"New York", "", "Los Angeles", std::nullopt, std::nullopt});
+  test::assertEqualVectors(expected, result);
+
+  // Nulls in 'string', 'pattern' or 'capture'.
+  auto inputWithNulls = makeRowVector({
+      makeNullableFlatVector<std::string>(
+          {"new york",
+           std::nullopt,
+           "los angeles",
+           "san francisco",
+           "seattle",
+           std::nullopt}),
+      makeNullableFlatVector<std::string>({
+          "(\\w+)",
+          "(\\d+)",
+          std::nullopt,
+          "(\\w)",
+          "(\\w)",
+          "(\\d+)",
+      }),
+      makeNullableFlatVector<std::string>({
+          "!",
+          "[b]",
+          "[c]",
+          std::nullopt,
+          "_",
+          "_",
+      }),
+
+  });
+
+  result = evaluate("regexp_replace(c0, c1, x -> upper(x[1]))", inputWithNulls);
+  expected = makeNullableFlatVector<std::string>(
+      {"NEW YORK",
+       std::nullopt,
+       std::nullopt,
+       "SAN FRANCISCO",
+       "SEATTLE",
+       std::nullopt});
+  test::assertEqualVectors(expected, result);
+
+  result =
+      evaluate("regexp_replace(c0, c1, x -> concat(c2, x[1]))", inputWithNulls);
+  expected = makeNullableFlatVector<std::string>(
+      {"!new !york",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       "_s_e_a_t_t_l_e",
+       std::nullopt});
   test::assertEqualVectors(expected, result);
 }
 


### PR DESCRIPTION
Summary:
Presto supports regexp_replace with a lambda function to compute the replacement.

https://prestodb.io/docs/current/functions/regexp.html#id3

For example, regexp_replace can be used to capitalize first letter of every word:

```
SELECT regexp_replace('new york', '(\w)(\w*)', x -> upper(x[1]) || lower(x[2])); --'New York'
```

Added a simple benchmark to make sure regexp_replace with lambda is not dramatically slower than regexp_replace with a fixed replacement.

```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
identity1##fixed                                             7.98s   125.39m
identity1##lambda                                            9.59s   104.26m
----------------------------------------------------------------------------
identity2##fixed                                             3.68s   271.46m
identity2##lambda                                            4.90s   204.19m
----------------------------------------------------------------------------
regexp_replace2##replace                                   79.18ms     12.63
regexp_replace2##regexp_replace                           288.96ms      3.46
```

Differential Revision: D58313238
