### PR TITLE
[Velox] Fix some gaps in clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -54,6 +54,7 @@ IncludeCategories:
 IndentCaseLabels: true
 IndentWidth:     2
 IndentWrappedFunctionNames: false
+InsertNewlineAtEOF: true
 KeepEmptyLinesAtTheStartOfBlocks: false
 MacroBlockBegin: ''
 MacroBlockEnd:   ''

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -185,7 +185,7 @@ def get_files(commit, path):
 
     if commit != "":
         status, stdout, stderr = util.run(
-            f"git diff --relative --name-only --diff-filter='ACM' {commit}"
+            f"git diff --relative --name-only --diff-filter='ACMR' {commit}"
         )
         filelist = stdout.splitlines()
     else:

--- a/scripts/setup-check.sh
+++ b/scripts/setup-check.sh
@@ -18,9 +18,10 @@ set -x
 
 export DEBIAN_FRONTEND=noninteractive
 apt update
-apt install --no-install-recommends -y clang-format-12 python3-pip git make ssh
+apt list clang-format
+apt install --no-install-recommends -y clang-format-16 python3-pip git make ssh
 pip3 install cmake==3.28.3 cmake_format black regex
 pip3 cache purge
 apt purge --auto-remove -y python3-pip
-update-alternatives --install /usr/bin/clang-format clang-format "$(command -v clang-format-12)" 12
+update-alternatives --install /usr/bin/clang-format clang-format "$(command -v clang-format-16)" 16
 apt clean


### PR DESCRIPTION
Importing some recent diffs I noticed a couple gaps in our clang formatting (make format-fix).

1) clang formatting does not run on renamed files, renamed files may also have code changes so these should be checked 
as well
2) we do not check for new lines at the end of files

The latter requires using clang-format 16 or above.