### PR TITLE
Fix double NaN compare  in prefixsort 

### DIFF
--- a/velox/exec/prefixsort/PrefixSortEncoder.h
+++ b/velox/exec/prefixsort/PrefixSortEncoder.h
@@ -155,13 +155,13 @@ static FOLLY_ALWAYS_INLINE uint64_t encodeDouble(double value) {
   if (value == 0) {
     return 1ull << 63;
   }
-  // Nan is max value.
+  // Nan is collapsed to a single "canonical" value.
   if (std::isnan(value)) {
-    return std::numeric_limits<uint64_t>::max();
+    return 0x7ff8000000000000L;
   }
-  // Infinity is the second max value.
+  // Infinity is the max value.
   if (value > std::numeric_limits<double>::max()) {
-    return std::numeric_limits<uint64_t>::max() - 1;
+    return std::numeric_limits<uint64_t>::max();
   }
   // -Infinity is the smallest value.
   if (value < -std::numeric_limits<double>::max()) {
@@ -178,7 +178,8 @@ static FOLLY_ALWAYS_INLINE uint64_t encodeDouble(double value) {
   return encoded;
 }
 
-// Logic is as same as double.
+/// Logic is as same as double except NaN. NaN is a single "canonical" value in
+/// double which is more than max uint32_t, so use max uint32 as NaN.
 static FOLLY_ALWAYS_INLINE uint32_t encodeFloat(float value) {
   if (value == 0) {
     return 1u << 31;

--- a/velox/exec/prefixsort/tests/PrefixEncoderTest.cpp
+++ b/velox/exec/prefixsort/tests/PrefixEncoderTest.cpp
@@ -151,14 +151,28 @@ class PrefixEncoderTest : public testing::Test,
     encode(descNullsLastEncoder_);
     ASSERT_GT(compare(encodedNull, encodedMax), 0);
 
-    // For float / double`s NaN.
-    if (TypeLimits<T>::isFloat) {
+    // For float`s NaN.
+    if constexpr (std::is_same_v<T, float>) {
       std::optional<T> nan = TypeLimits<T>::nan();
       char encodedNaN[sizeof(T) + 1];
 
       ascNullsFirstEncoder_.encode(nan, encodedNaN);
       ascNullsFirstEncoder_.encode(max, encodedMax);
       ASSERT_GT(compare(encodedNaN, encodedMax), 0);
+
+      ascNullsFirstEncoder_.encode(nan, encodedNaN);
+      ascNullsFirstEncoder_.encode(nullValue, encodedNull);
+      ASSERT_LT(compare(encodedNull, encodedNaN), 0);
+    }
+
+    // For double`s NaN.
+    if constexpr (std::is_same_v<T, double>) {
+      std::optional<T> nan = TypeLimits<T>::nan();
+      char encodedNaN[sizeof(T) + 1];
+
+      ascNullsFirstEncoder_.encode(nan, encodedNaN);
+      ascNullsFirstEncoder_.encode(max, encodedMax);
+      ASSERT_LT(compare(encodedNaN, encodedMax), 0);
 
       ascNullsFirstEncoder_.encode(nan, encodedNaN);
       ascNullsFirstEncoder_.encode(nullValue, encodedNull);


### PR DESCRIPTION
In Spark, float and double use the same logic to get prefix.
https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala#L159
https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/SortPrefixUtils.scala#L50
all NaN values are collapsed to a single "canonical" NaN value
https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/lang/Double.java#L1263