### PR TITLE
Add hasConnectorFactory and unregisterConnectorFactory APIs

### DIFF
--- a/velox/connectors/Connector.cpp
+++ b/velox/connectors/Connector.cpp
@@ -54,6 +54,15 @@ bool registerConnectorFactory(std::shared_ptr<ConnectorFactory> factory) {
   return true;
 }
 
+bool hasConnectorFactory(const std::string& connectorName) {
+  return connectorFactories().count(connectorName) == 1;
+}
+
+bool unregisterConnectorFactory(const std::string& connectorName) {
+  auto count = connectorFactories().erase(connectorName);
+  return count == 1;
+}
+
 std::shared_ptr<ConnectorFactory> getConnectorFactory(
     const std::string& connectorName) {
   auto it = connectorFactories().find(connectorName);

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -433,6 +433,15 @@ class ConnectorFactory {
 /// FB_ANONYMOUS_VARIABLE.
 bool registerConnectorFactory(std::shared_ptr<ConnectorFactory> factory);
 
+/// Returns true if a connector with the specified name has been registered,
+/// false otherwise.
+bool hasConnectorFactory(const std::string& connectorName);
+
+/// Unregister a connector factory by name.
+/// Returns true if a connector with the specified name has been unregistered,
+/// false otherwise.
+bool unregisterConnectorFactory(const std::string& connectorName);
+
 /// Returns a factory for creating connectors with the specified name. Throws if
 /// factory doesn't exist.
 std::shared_ptr<ConnectorFactory> getConnectorFactory(

--- a/velox/connectors/tests/ConnectorTest.cpp
+++ b/velox/connectors/tests/ConnectorTest.cpp
@@ -47,13 +47,30 @@ class TestConnector : public connector::Connector {
   }
 };
 
+class TestConnectorFactory : public connector::ConnectorFactory {
+ public:
+  static constexpr const char* kConnectorFactoryName = "test-factory";
+
+  TestConnectorFactory() : ConnectorFactory(kConnectorFactoryName) {}
+
+  std::shared_ptr<Connector> newConnector(
+      const std::string& id,
+      std::shared_ptr<const Config> config,
+      folly::Executor* executor = nullptr) override {
+    return std::make_shared<TestConnector>(id);
+  }
+};
+
 } // namespace
 
 TEST_F(ConnectorTest, getAllConnectors) {
+  registerConnectorFactory(std::make_shared<TestConnectorFactory>());
+  EXPECT_TRUE(hasConnectorFactory(TestConnectorFactory::kConnectorFactoryName));
   const int32_t numConnectors = 10;
   for (int32_t i = 0; i < numConnectors; i++) {
     registerConnector(
-        std::make_shared<TestConnector>(fmt::format("connector-{}", i)));
+        getConnectorFactory(TestConnectorFactory::kConnectorFactoryName)
+            ->newConnector(fmt::format("connector-{}", i), {}));
   }
   const auto& connectors = getAllConnectors();
   EXPECT_EQ(connectors.size(), numConnectors);
@@ -64,5 +81,9 @@ TEST_F(ConnectorTest, getAllConnectors) {
     unregisterConnector(fmt::format("connector-{}", i));
   }
   EXPECT_EQ(getAllConnectors().size(), 0);
+  EXPECT_TRUE(
+      unregisterConnectorFactory(TestConnectorFactory::kConnectorFactoryName));
+  EXPECT_FALSE(
+      unregisterConnectorFactory(TestConnectorFactory::kConnectorFactoryName));
 }
 } // namespace facebook::velox::connector

--- a/velox/connectors/tests/ConnectorTest.cpp
+++ b/velox/connectors/tests/ConnectorTest.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "velox/connectors/Connector.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
 #include <gtest/gtest.h>
 
 namespace facebook::velox::connector {
@@ -65,6 +67,9 @@ class TestConnectorFactory : public connector::ConnectorFactory {
 
 TEST_F(ConnectorTest, getAllConnectors) {
   registerConnectorFactory(std::make_shared<TestConnectorFactory>());
+  VELOX_ASSERT_THROW(
+      registerConnectorFactory(std::make_shared<TestConnectorFactory>()),
+      "ConnectorFactory with name 'test-factory' is already registered");
   EXPECT_TRUE(hasConnectorFactory(TestConnectorFactory::kConnectorFactoryName));
   const int32_t numConnectors = 10;
   for (int32_t i = 0; i < numConnectors; i++) {


### PR DESCRIPTION
We are removing all connector factory registrations from the Velox library here https://github.com/facebookincubator/velox/pull/8871
Adding these APIs first will help transition this removal in clients such as Prestissimo.
These APIs will help us add conditional connector factory registrations in Prestissimo.