### PR TITLE
Extend early dictionary assessment to all stripes

### DIFF
--- a/velox/dwio/dwrf/writer/FlushPolicy.h
+++ b/velox/dwio/dwrf/writer/FlushPolicy.h
@@ -23,7 +23,7 @@
 namespace facebook::velox::dwrf {
 enum class FlushDecision {
   SKIP,
-  EVALUATE_DICTIONARY,
+  CHECK_DICTIONARY,
   FLUSH_DICTIONARY,
   ABANDON_DICTIONARY,
 };
@@ -76,11 +76,13 @@ class DefaultFlushPolicy : public DWRFFlushPolicy {
   void onClose() override {}
 
  private:
-  uint64_t getDictionaryAssessmentIncrement() const;
+  void setNextDictionaryCheckThreshold(uint64_t stripeSizeEstimate = 0);
 
   const uint64_t stripeSizeThreshold_;
   const uint64_t dictionarySizeThreshold_;
-  uint64_t dictionaryAssessmentThreshold_;
+  const uint64_t dictionaryCheckIncrement_;
+  uint64_t stripeIndex_{0};
+  uint64_t dictionaryCheckThreshold_{0};
 };
 
 class RowsPerStripeFlushPolicy : public DWRFFlushPolicy {

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -354,7 +354,7 @@ bool Writer::shouldFlush(const WriterContext& context, size_t nextWriteRows) {
     overBudget = overMemoryBudget(context, nextWriteRows);
     stripeProgressDecision =
         flushPolicy_->shouldFlush(getStripeProgress(context));
-  } else if (dictionaryFlushDecision == FlushDecision::EVALUATE_DICTIONARY) {
+  } else if (dictionaryFlushDecision == FlushDecision::CHECK_DICTIONARY) {
     writer_->tryAbandonDictionaries(/*force=*/false);
   }
 


### PR DESCRIPTION
Summary:
Follow up diff to allow assessing dictionary early for all stripes.

Currently, this will cause continual invocation of abandonDictionaries for later stripes that are no-ops.

Differential Revision: D58396478
