### PR TITLE
Optimize reading from table with large number of columns

### DIFF
--- a/velox/common/base/BitSet.h
+++ b/velox/common/base/BitSet.h
@@ -46,7 +46,7 @@ class BitSet {
     bits::setBit(bits_.data(), bit, true);
   }
 
-  bool contains(uint32_t index) {
+  bool contains(uint32_t index) const {
     uint64_t bit = index - min_;
     if (bit >= bits_.size() * 64) {
       // If index was < min_, bit will have wrapped around and will be >

--- a/velox/common/io/Options.h
+++ b/velox/common/io/Options.h
@@ -68,22 +68,6 @@ class ReaderOptions {
         autoPreloadLength_(DEFAULT_AUTO_PRELOAD_SIZE),
         prefetchMode_(PrefetchMode::PREFETCH) {}
 
-  ReaderOptions& operator=(const ReaderOptions& other) {
-    memoryPool_ = other.memoryPool_;
-    autoPreloadLength_ = other.autoPreloadLength_;
-    prefetchMode_ = other.prefetchMode_;
-    maxCoalesceDistance_ = other.maxCoalesceDistance_;
-    maxCoalesceBytes_ = other.maxCoalesceBytes_;
-    prefetchRowGroups_ = other.prefetchRowGroups_;
-    loadQuantum_ = other.loadQuantum_;
-    noCacheRetention_ = other.noCacheRetention_;
-    return *this;
-  }
-
-  ReaderOptions(const ReaderOptions& other) {
-    *this = other;
-  }
-
   /// Sets the memory pool for allocation.
   ReaderOptions& setMemoryPool(velox::memory::MemoryPool& pool) {
     memoryPool_ = &pool;

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -572,8 +572,7 @@ void configureRowReaderOptions(
   }
   rowReaderOptions.setScanSpec(scanSpec);
   rowReaderOptions.setMetadataFilter(std::move(metadataFilter));
-  rowReaderOptions.select(
-      dwio::common::ColumnSelector::fromScanSpec(*scanSpec, rowType));
+  rowReaderOptions.setRequestedType(rowType);
   rowReaderOptions.range(hiveSplit->start, hiveSplit->length);
 }
 

--- a/velox/connectors/hive/SplitReader.h
+++ b/velox/connectors/hive/SplitReader.h
@@ -115,7 +115,9 @@ class SplitReader {
  protected:
   /// Create the dwio::common::Reader object baseReader_, which will be used to
   /// read the data file's metadata and schema
-  void createReader();
+  void createReader(
+      std::shared_ptr<common::MetadataFilter> metadataFilter,
+      const std::shared_ptr<HiveColumnHandle>& rowIndexColumn);
 
   /// Check if the hiveSplit_ is empty. The split is considered empty when
   ///   1) The data file is missing but the user chooses to ignore it
@@ -127,9 +129,7 @@ class SplitReader {
 
   /// Create the dwio::common::RowReader object baseRowReader_, which owns the
   /// ColumnReaders that will be used to read the data
-  void createRowReader(
-      std::shared_ptr<common::MetadataFilter> metadataFilter,
-      const std::shared_ptr<HiveColumnHandle>& rowIndexColumn);
+  void createRowReader();
 
   /// Different table formats may have different meatadata columns.
   /// This function will be used to update the scanSpec for these columns.

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -54,14 +54,14 @@ void IcebergSplitReader::prepareSplit(
     std::shared_ptr<common::MetadataFilter> metadataFilter,
     dwio::common::RuntimeStatistics& runtimeStats,
     const std::shared_ptr<HiveColumnHandle>& rowIndexColumn) {
-  createReader();
+  createReader(std::move(metadataFilter), rowIndexColumn);
 
   if (checkIfSplitIsEmpty(runtimeStats)) {
     VELOX_CHECK(emptySplit_);
     return;
   }
 
-  createRowReader(metadataFilter, rowIndexColumn);
+  createRowReader();
 
   std::shared_ptr<const HiveIcebergSplit> icebergSplit =
       std::dynamic_pointer_cast<const HiveIcebergSplit>(hiveSplit_);

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -205,11 +205,6 @@ TEST_F(HiveConnectorUtilTest, configureRowReaderOptions) {
   float_features->childByName(common::ScanSpec::kMapKeysFieldName)
       ->setFilter(common::createBigintValues({1, 3}, false));
   float_features->setFlatMapFeatureSelection({"1", "3"});
-  RowReaderOptions options;
-  configureRowReaderOptions(options, {}, spec, nullptr, rowType, split);
-  auto& nodes = options.getSelector()->getProjection();
-  ASSERT_EQ(nodes.size(), 1);
-  ASSERT_EQ(nodes[0].expression, "[1,3]");
 }
 
 } // namespace facebook::velox::connector

--- a/velox/dwio/common/FormatData.h
+++ b/velox/dwio/common/FormatData.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include "velox/common/memory/Memory.h"
-#include "velox/dwio/common/ColumnSelector.h"
 #include "velox/dwio/common/ScanSpec.h"
 #include "velox/dwio/common/SeekableInputStream.h"
 #include "velox/dwio/common/Statistics.h"

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -19,7 +19,6 @@
 #include "velox/common/memory/Memory.h"
 #include "velox/common/process/ProcessBase.h"
 #include "velox/common/process/TraceHistory.h"
-#include "velox/dwio/common/ColumnSelector.h"
 #include "velox/dwio/common/FormatData.h"
 #include "velox/dwio/common/IntDecoder.h"
 #include "velox/dwio/common/Mutation.h"

--- a/velox/dwio/common/SelectiveRepeatedColumnReader.h
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.h
@@ -85,7 +85,7 @@ class SelectiveRepeatedColumnReader : public SelectiveColumnReader {
 class SelectiveListColumnReader : public SelectiveRepeatedColumnReader {
  public:
   SelectiveListColumnReader(
-      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       FormatParams& params,
       velox::common::ScanSpec& scanSpec);
@@ -103,13 +103,12 @@ class SelectiveListColumnReader : public SelectiveRepeatedColumnReader {
 
  protected:
   std::unique_ptr<SelectiveColumnReader> child_;
-  const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
 };
 
 class SelectiveMapColumnReader : public SelectiveRepeatedColumnReader {
  public:
   SelectiveMapColumnReader(
-      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       FormatParams& params,
       velox::common::ScanSpec& scanSpec);
@@ -128,7 +127,6 @@ class SelectiveMapColumnReader : public SelectiveRepeatedColumnReader {
 
   std::unique_ptr<SelectiveColumnReader> keyReader_;
   std::unique_ptr<SelectiveColumnReader> elementReader_;
-  const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
 };
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/SelectiveStructColumnReader.h
+++ b/velox/dwio/common/SelectiveStructColumnReader.h
@@ -111,13 +111,12 @@ class SelectiveStructColumnReaderBase : public SelectiveColumnReader {
   static constexpr int32_t kConstantChildSpecSubscript = -1;
 
   SelectiveStructColumnReaderBase(
-      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       FormatParams& params,
       velox::common::ScanSpec& scanSpec,
       bool isRoot = false)
-      : SelectiveColumnReader(fileType->type(), fileType, params, scanSpec),
-        requestedType_(requestedType),
+      : SelectiveColumnReader(requestedType, fileType, params, scanSpec),
         debugString_(
             getExceptionContext().message(VeloxException::Type::kSystem)),
         isRoot_(isRoot) {}
@@ -137,8 +136,6 @@ class SelectiveStructColumnReaderBase : public SelectiveColumnReader {
   bool isChildConstant(const velox::common::ScanSpec& childSpec) const;
 
   void fillOutputRowsFromMutation(vector_size_t size);
-
-  const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
 
   std::vector<SelectiveColumnReader*> children_;
 
@@ -210,7 +207,7 @@ class SelectiveFlatMapColumnReaderHelper {
       reader_.children_[i] = keyNodes_[i].reader.get();
       reader_.children_[i]->setIsFlatMapValue(true);
     }
-    if (auto type = reader_.requestedType_->type()->childAt(1); type->isRow()) {
+    if (auto type = reader_.requestedType_->childAt(1); type->isRow()) {
       childValues_ = BaseVector::create(type, 0, &reader_.memoryPool_);
     }
   }
@@ -228,7 +225,7 @@ class SelectiveFlatMapColumnReaderHelper {
     } else {
       VLOG(1) << "Reallocating result MAP vector of size " << size;
       result = BaseVector::create(
-          reader_.requestedType_->type(), size, &reader_.memoryPool_);
+          reader_.requestedType_, size, &reader_.memoryPool_);
     }
     return *result->asUnchecked<MapVector>();
   }

--- a/velox/dwio/common/TypeWithId.h
+++ b/velox/dwio/common/TypeWithId.h
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <vector>
+#include "velox/dwio/common/ScanSpec.h"
 #include "velox/type/Type.h"
 
 namespace facebook::velox::dwio::common {
@@ -38,6 +39,13 @@ class TypeWithId : public velox::Tree<std::shared_ptr<const TypeWithId>> {
   static std::unique_ptr<TypeWithId> create(
       const std::shared_ptr<const velox::Type>& root,
       uint32_t next = 0);
+
+  /// Create TypeWithId node but leave all the unselected children as nullptr.
+  /// The ids are set correctly even when some of the previous nodes are not
+  /// selected.
+  static std::unique_ptr<TypeWithId> create(
+      const RowTypePtr& type,
+      const velox::common::ScanSpec& spec);
 
   uint32_t size() const override;
 

--- a/velox/dwio/dwrf/reader/BinaryStreamReader.cpp
+++ b/velox/dwio/dwrf/reader/BinaryStreamReader.cpp
@@ -37,7 +37,8 @@ BinaryStripeStreams::BinaryStripeStreams(
           stripeReader.fetchStripe(stripeIndex, preload_))},
       stripeStreams_{
           stripeReadState_,
-          selector,
+          &selector,
+          nullptr,
           options_,
           stripeReadState_->stripeMetadata->stripeInfo.offset(),
           static_cast<int64_t>(

--- a/velox/dwio/dwrf/reader/DwrfData.h
+++ b/velox/dwio/dwrf/reader/DwrfData.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include "velox/common/memory/Memory.h"
-#include "velox/dwio/common/ColumnSelector.h"
 #include "velox/dwio/common/FormatData.h"
 #include "velox/dwio/common/TypeWithId.h"
 #include "velox/dwio/common/compression/Compression.h"

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -146,6 +146,8 @@ class DwrfRowReader : public StrideIndexProvider,
   // column selector
   std::shared_ptr<dwio::common::ColumnSelector> columnSelector_;
 
+  std::shared_ptr<BitSet> projectedNodes_;
+
   const uint64_t* stridesToSkip_;
   int stridesToSkipSize_;
   // Record of strides to skip in each visited stripe. Used for diagnostics.
@@ -167,13 +169,18 @@ class DwrfRowReader : public StrideIndexProvider,
 
   // internal methods
 
+  bool shouldReadNode(uint32_t nodeId) const;
+
   std::optional<size_t> estimatedRowSizeHelper(
       const FooterWrapper& fileFooter,
       const dwio::common::Statistics& stats,
       uint32_t nodeId) const;
 
   std::shared_ptr<const RowType> getType() const {
-    return columnSelector_->getSchema();
+    if (columnSelector_) {
+      return columnSelector_->getSchema();
+    }
+    return options_.requestedType();
   }
 
   bool isEmptyFile() const {

--- a/velox/dwio/dwrf/reader/ReaderBase.cpp
+++ b/velox/dwio/dwrf/reader/ReaderBase.cpp
@@ -95,14 +95,16 @@ ReaderBase::ReaderBase(
     uint64_t filePreloadThreshold,
     FileFormat fileFormat,
     bool fileColumnNamesReadAsLowerCase,
-    std::shared_ptr<random::RandomSkipTracker> randomSkip)
+    std::shared_ptr<random::RandomSkipTracker> randomSkip,
+    std::shared_ptr<velox::common::ScanSpec> scanSpec)
     : pool_{pool},
       arena_(std::make_unique<google::protobuf::Arena>()),
       decryptorFactory_(decryptorFactory),
       footerEstimatedSize_(footerEstimatedSize),
       filePreloadThreshold_(filePreloadThreshold),
       input_(std::move(input)),
-      randomSkip_(std::move(randomSkip)) {
+      randomSkip_(std::move(randomSkip)),
+      scanSpec_(std::move(scanSpec)) {
   process::TraceContext trace("ReaderBase::ReaderBase");
   // read last bytes into buffer to get PostScript
   // If file is small, load the entire file.

--- a/velox/dwio/dwrf/reader/ReaderBase.h
+++ b/velox/dwio/dwrf/reader/ReaderBase.h
@@ -72,7 +72,8 @@ class ReaderBase {
           dwio::common::ReaderOptions::kDefaultFilePreloadThreshold,
       dwio::common::FileFormat fileFormat = dwio::common::FileFormat::DWRF,
       bool fileColumnNamesReadAsLowerCase = false,
-      std::shared_ptr<random::RandomSkipTracker> randomSkip = nullptr);
+      std::shared_ptr<random::RandomSkipTracker> randomSkip = nullptr,
+      std::shared_ptr<velox::common::ScanSpec> scanSpec = nullptr);
 
   ReaderBase(
       memory::MemoryPool& pool,
@@ -131,7 +132,11 @@ class ReaderBase {
   const std::shared_ptr<const dwio::common::TypeWithId>& getSchemaWithId()
       const {
     if (!schemaWithId_) {
-      schemaWithId_ = dwio::common::TypeWithId::create(schema_);
+      if (scanSpec_) {
+        schemaWithId_ = dwio::common::TypeWithId::create(schema_, *scanSpec_);
+      } else {
+        schemaWithId_ = dwio::common::TypeWithId::create(schema_);
+      }
     }
     return schemaWithId_;
   }
@@ -257,6 +262,7 @@ class ReaderBase {
 
   std::unique_ptr<dwio::common::BufferedInput> input_;
   const std::shared_ptr<random::RandomSkipTracker> randomSkip_;
+  const std::shared_ptr<velox::common::ScanSpec> scanSpec_;
   RowTypePtr schema_;
   // Lazily populated
   mutable std::shared_ptr<const dwio::common::TypeWithId> schemaWithId_;

--- a/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
@@ -26,13 +26,13 @@ class SelectiveByteRleColumnReader
   using ValueType = int8_t;
 
   SelectiveByteRleColumnReader(
-      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const TypePtr& requestedType,
       std::shared_ptr<const dwio::common::TypeWithId> fileType,
       DwrfParams& params,
       common::ScanSpec& scanSpec,
       bool isBool)
       : dwio::common::SelectiveByteRleColumnReader(
-            requestedType->type(),
+            requestedType,
             std::move(fileType),
             params,
             scanSpec) {

--- a/velox/dwio/dwrf/reader/SelectiveDwrfReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveDwrfReader.h
@@ -26,7 +26,7 @@ namespace facebook::velox::dwrf {
 class SelectiveDwrfReader {
  public:
   static std::unique_ptr<dwio::common::SelectiveColumnReader> build(
-      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       DwrfParams& params,
       common::ScanSpec& scanSpec,
@@ -35,7 +35,7 @@ class SelectiveDwrfReader {
   // Compatibility wrapper for tests. Takes the components of DwrfParams as
   // separate.
   static std::unique_ptr<dwio::common::SelectiveColumnReader> build(
-      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       StripeStreams& stripe,
       const StreamLabels& streamLabels,
@@ -55,7 +55,7 @@ class SelectiveColumnReaderFactory : public ColumnReaderFactory {
       : scanSpec_(scanSpec) {}
 
   std::unique_ptr<dwio::common::SelectiveColumnReader> buildSelective(
-      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       StripeStreams& stripe,
       const StreamLabels& streamLabels,

--- a/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
@@ -45,15 +45,6 @@ std::string toString(const T& x) {
   }
 }
 
-template <typename T>
-dwio::common::flatmap::KeyPredicate<T> prepareKeyPredicate(
-    const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
-    StripeStreams& stripe) {
-  auto& cs = stripe.getColumnSelector();
-  const auto expr = cs.getNode(requestedType->id())->getNode().expression;
-  return dwio::common::flatmap::prepareKeyPredicate<T>(expr);
-}
-
 // Represent a branch of a value node in a flat map.  Represent a keyed value
 // node.
 template <typename T>
@@ -76,7 +67,7 @@ struct KeyNode {
 
 template <typename T>
 std::vector<KeyNode<T>> getKeyNodes(
-    const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+    const TypePtr& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     DwrfParams& params,
     common::ScanSpec& scanSpec,
@@ -89,7 +80,6 @@ std::vector<KeyNode<T>> getKeyNodes(
   auto& requestedValueType = requestedType->childAt(1);
   auto& dataValueType = fileType->childAt(1);
   auto& stripe = params.stripeStreams();
-  auto keyPredicate = prepareKeyPredicate<T>(requestedType, stripe);
 
   common::ScanSpec* keysSpec = nullptr;
   common::ScanSpec* valuesSpec = nullptr;
@@ -130,10 +120,6 @@ std::vector<KeyNode<T>> getKeyNodes(
         EncodingKey seqEk(dataValueType->id(), sequence);
         const auto& keyInfo = stripe.getEncoding(seqEk).key();
         auto key = extractKey<T>(keyInfo);
-        // Check if we have key filter passed through read schema.
-        if (!keyPredicate(key)) {
-          return;
-        }
         common::ScanSpec* childSpec;
         if (auto it = childSpecs.find(key);
             it != childSpecs.end() && !it->second->isConstant()) {
@@ -183,7 +169,7 @@ template <typename T>
 class SelectiveFlatMapAsStructReader : public SelectiveStructColumnReaderBase {
  public:
   SelectiveFlatMapAsStructReader(
-      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       DwrfParams& params,
       common::ScanSpec& scanSpec)
@@ -212,7 +198,7 @@ template <typename T>
 class SelectiveFlatMapReader : public SelectiveStructColumnReaderBase {
  public:
   SelectiveFlatMapReader(
-      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       DwrfParams& params,
       common::ScanSpec& scanSpec)
@@ -241,7 +227,7 @@ class SelectiveFlatMapReader : public SelectiveStructColumnReaderBase {
 
 template <typename T>
 std::unique_ptr<dwio::common::SelectiveColumnReader> createReader(
-    const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+    const TypePtr& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     DwrfParams& params,
     common::ScanSpec& scanSpec) {
@@ -258,7 +244,7 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> createReader(
 
 std::unique_ptr<dwio::common::SelectiveColumnReader>
 createSelectiveFlatMapColumnReader(
-    const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+    const TypePtr& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     DwrfParams& params,
     common::ScanSpec& scanSpec) {

--- a/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.h
@@ -23,7 +23,7 @@ namespace facebook::velox::dwrf {
 
 std::unique_ptr<dwio::common::SelectiveColumnReader>
 createSelectiveFlatMapColumnReader(
-    const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+    const TypePtr& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     DwrfParams&,
     common::ScanSpec&);

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
@@ -22,13 +22,13 @@ namespace facebook::velox::dwrf {
 using namespace dwio::common;
 
 SelectiveIntegerDictionaryColumnReader::SelectiveIntegerDictionaryColumnReader(
-    const std::shared_ptr<const TypeWithId>& requestedType,
+    const TypePtr& requestedType,
     std::shared_ptr<const TypeWithId> fileType,
     DwrfParams& params,
     common::ScanSpec& scanSpec,
     uint32_t numBytes)
     : SelectiveIntegerColumnReader(
-          requestedType->type(),
+          requestedType,
           params,
           scanSpec,
           std::move(fileType)) {

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h
@@ -28,7 +28,7 @@ class SelectiveIntegerDictionaryColumnReader
   using ValueType = int64_t;
 
   SelectiveIntegerDictionaryColumnReader(
-      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const TypePtr& requestedType,
       std::shared_ptr<const dwio::common::TypeWithId> fileType,
       DwrfParams& params,
       common::ScanSpec& scanSpec,

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
@@ -28,13 +28,13 @@ class SelectiveIntegerDirectColumnReader
   using ValueType = int64_t;
 
   SelectiveIntegerDirectColumnReader(
-      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const TypePtr& requestedType,
       std::shared_ptr<const dwio::common::TypeWithId> fileType,
       DwrfParams& params,
       uint32_t numBytes,
       common::ScanSpec& scanSpec)
       : SelectiveIntegerColumnReader(
-            requestedType->type(),
+            requestedType,
             params,
             scanSpec,
             std::move(fileType)) {

--- a/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.h
@@ -28,7 +28,7 @@ class SelectiveListColumnReader
     : public dwio::common::SelectiveListColumnReader {
  public:
   SelectiveListColumnReader(
-      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       DwrfParams& params,
       common::ScanSpec& scanSpec);
@@ -61,7 +61,7 @@ class SelectiveListColumnReader
 class SelectiveMapColumnReader : public dwio::common::SelectiveMapColumnReader {
  public:
   SelectiveMapColumnReader(
-      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       DwrfParams& params,
       common::ScanSpec& scanSpec);

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
@@ -25,7 +25,7 @@ class SelectiveStructColumnReaderBase
     : public dwio::common::SelectiveStructColumnReaderBase {
  public:
   SelectiveStructColumnReaderBase(
-      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       DwrfParams& params,
       common::ScanSpec& scanSpec,
@@ -80,7 +80,7 @@ class SelectiveStructColumnReaderBase
 
 struct SelectiveStructColumnReader : SelectiveStructColumnReaderBase {
   SelectiveStructColumnReader(
-      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       DwrfParams& params,
       common::ScanSpec& scanSpec,

--- a/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
@@ -104,7 +104,8 @@ void verifyStats(
   StripeStreamsImpl streams{
       std::make_shared<StripeReadState>(
           rowReader.readerBaseShared(), std::move(stripeMetadata)),
-      rowReader.getColumnSelector(),
+      &rowReader.getColumnSelector(),
+      nullptr,
       rowReader.getRowReaderOptions(),
       stripeInfo.offset(),
       static_cast<int64_t>(stripeInfo.numberOfRows()),

--- a/velox/dwio/dwrf/test/E2EWriterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTest.cpp
@@ -186,7 +186,8 @@ class E2EWriterTest : public testing::Test {
         dwrf::StripeStreamsImpl stripeStreams(
             std::make_shared<dwrf::StripeReadState>(
                 dwrfRowReader->readerBaseShared(), std::move(stripeMetadata)),
-            dwrfRowReader->getColumnSelector(),
+            &dwrfRowReader->getColumnSelector(),
+            nullptr,
             rowReaderOpts,
             currentStripeInfo.offset(),
             currentStripeInfo.numberOfRows(),

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -145,7 +145,7 @@ class ColumnReaderTestBase {
       }
       makeFieldSpecs("", 0, rowType, scanSpec);
       selectiveColumnReader_ = SelectiveDwrfReader::build(
-          cs.getSchemaWithId(),
+          cs.getSchema(),
           fileTypeWithId,
           streams_,
           labels_,

--- a/velox/dwio/dwrf/test/TestStripeStream.cpp
+++ b/velox/dwio/dwrf/test/TestStripeStream.cpp
@@ -91,7 +91,8 @@ StripeStreamsImpl createAndLoadStripeStreams(
   TestProvider indexProvider;
   StripeStreamsImpl streams{
       readState,
-      selector,
+      &selector,
+      nullptr,
       RowReaderOptions{},
       0,
       StripeStreamsImpl::kUnknownStripeRows,
@@ -287,7 +288,8 @@ TEST_F(StripeStreamTest, zeroLength) {
   ColumnSelector cs{std::dynamic_pointer_cast<const RowType>(type)};
   StripeStreamsImpl streams{
       stripeReadState,
-      cs,
+      &cs,
+      nullptr,
       RowReaderOptions{},
       0,
       StripeStreamsImpl::kUnknownStripeRows,
@@ -496,7 +498,8 @@ TEST_F(StripeStreamTest, readEncryptedStreams) {
   TestProvider provider;
   StripeStreamsImpl streams{
       stripeReadState,
-      selector,
+      &selector,
+      nullptr,
       RowReaderOptions{},
       0,
       StripeStreamsImpl::kUnknownStripeRows,
@@ -583,7 +586,8 @@ TEST_F(StripeStreamTest, schemaMismatch) {
   TestProvider provider;
   StripeStreamsImpl streams{
       stripeReadState,
-      selector,
+      &selector,
+      nullptr,
       RowReaderOptions{},
       0,
       StripeStreamsImpl::kUnknownStripeRows,

--- a/velox/dwio/parquet/reader/BooleanColumnReader.h
+++ b/velox/dwio/parquet/reader/BooleanColumnReader.h
@@ -25,12 +25,12 @@ class BooleanColumnReader : public dwio::common::SelectiveByteRleColumnReader {
  public:
   using ValueType = bool;
   BooleanColumnReader(
-      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const TypePtr& requestedType,
       std::shared_ptr<const dwio::common::TypeWithId> fileType,
       ParquetParams& params,
       common::ScanSpec& scanSpec)
       : SelectiveByteRleColumnReader(
-            requestedType->type(),
+            requestedType,
             std::move(fileType),
             params,
             scanSpec) {}

--- a/velox/dwio/parquet/reader/IntegerColumnReader.h
+++ b/velox/dwio/parquet/reader/IntegerColumnReader.h
@@ -23,12 +23,12 @@ namespace facebook::velox::parquet {
 class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
  public:
   IntegerColumnReader(
-      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const TypePtr& requestedType,
       std::shared_ptr<const dwio::common::TypeWithId> fileType,
       ParquetParams& params,
       common::ScanSpec& scanSpec)
       : SelectiveIntegerColumnReader(
-            requestedType->type(),
+            requestedType,
             params,
             scanSpec,
             std::move(fileType)) {}

--- a/velox/dwio/parquet/reader/ParquetColumnReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetColumnReader.cpp
@@ -32,7 +32,7 @@ namespace facebook::velox::parquet {
 
 // static
 std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
-    const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+    const TypePtr& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     ParquetParams& params,
     common::ScanSpec& scanSpec) {
@@ -49,10 +49,10 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
 
     case TypeKind::REAL:
       return std::make_unique<FloatingPointColumnReader<float, float>>(
-          requestedType->type(), fileType, params, scanSpec);
+          requestedType, fileType, params, scanSpec);
     case TypeKind::DOUBLE:
       return std::make_unique<FloatingPointColumnReader<double, double>>(
-          requestedType->type(), fileType, params, scanSpec);
+          requestedType, fileType, params, scanSpec);
 
     case TypeKind::ROW:
       return std::make_unique<StructColumnReader>(

--- a/velox/dwio/parquet/reader/ParquetColumnReader.h
+++ b/velox/dwio/parquet/reader/ParquetColumnReader.h
@@ -42,7 +42,7 @@ class ParquetColumnReader {
   /// Builds a reader tree producing 'fileType'. The metadata is in 'params'.
   /// The filters and pruning are in 'scanSpec'.
   static std::unique_ptr<dwio::common::SelectiveColumnReader> build(
-      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       ParquetParams& params,
       common::ScanSpec& scanSpec);

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -25,8 +25,6 @@
 
 namespace facebook::velox::parquet {
 
-using dwio::common::ColumnSelector;
-
 /// Metadata and options for reading Parquet.
 class ReaderBase {
  public:
@@ -751,7 +749,7 @@ class ParquetRowReader::Impl {
           "Input Table Schema (with partition columns): {}\n",
           readerBase_->bufferedInput().getReadFile()->getName(),
           readerBase_->schema()->toString(),
-          requestedType_->type()->toString());
+          requestedType_->toString());
       return exceptionMessageContext;
     };
 
@@ -760,9 +758,8 @@ class ParquetRowReader::Impl {
     }
     ParquetParams params(
         pool_, columnReaderStats_, readerBase_->fileMetaData());
-    auto columnSelector = std::make_shared<ColumnSelector>(
-        ColumnSelector::apply(options_.getSelector(), readerBase_->schema()));
-    requestedType_ = columnSelector->getSchemaWithId();
+    requestedType_ = options_.requestedType() ? options_.requestedType()
+                                              : readerBase_->schema();
     columnReader_ = ParquetColumnReader::build(
         requestedType_,
         readerBase_->schemaWithId(), // Id is schema id
@@ -913,7 +910,7 @@ class ParquetRowReader::Impl {
 
   std::unique_ptr<dwio::common::SelectiveColumnReader> columnReader_;
 
-  std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
+  TypePtr requestedType_;
 
   dwio::common::ColumnReaderStatistics columnReaderStats_;
 };

--- a/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
+++ b/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
@@ -110,7 +110,7 @@ void ensureRepDefs(
 }
 
 MapColumnReader::MapColumnReader(
-    const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+    const TypePtr& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     ParquetParams& params,
     common::ScanSpec& scanSpec)
@@ -220,7 +220,7 @@ void MapColumnReader::filterRowGroups(
 }
 
 ListColumnReader::ListColumnReader(
-    const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+    const TypePtr& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     ParquetParams& params,
     common::ScanSpec& scanSpec)

--- a/velox/dwio/parquet/reader/RepeatedColumnReader.h
+++ b/velox/dwio/parquet/reader/RepeatedColumnReader.h
@@ -56,7 +56,7 @@ class RepeatedLengths {
 class MapColumnReader : public dwio::common::SelectiveMapColumnReader {
  public:
   MapColumnReader(
-      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       ParquetParams& params,
       common::ScanSpec& scanSpec);
@@ -112,7 +112,7 @@ class MapColumnReader : public dwio::common::SelectiveMapColumnReader {
 class ListColumnReader : public dwio::common::SelectiveListColumnReader {
  public:
   ListColumnReader(
-      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       ParquetParams& params,
       common::ScanSpec& scanSpec);

--- a/velox/dwio/parquet/reader/StructColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StructColumnReader.cpp
@@ -27,7 +27,7 @@ class ScanSpec;
 namespace facebook::velox::parquet {
 
 StructColumnReader::StructColumnReader(
-    const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+    const TypePtr& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     ParquetParams& params,
     common::ScanSpec& scanSpec)
@@ -40,7 +40,7 @@ StructColumnReader::StructColumnReader(
     }
     auto childFileType = fileType_->childByName(childSpec->fieldName());
     auto childRequestedType =
-        requestedType_->childByName(childSpec->fieldName());
+        requestedType_->asRow().findChild(childSpec->fieldName());
     addChild(ParquetColumnReader::build(
         childRequestedType, childFileType, params, *childSpec));
 

--- a/velox/dwio/parquet/reader/StructColumnReader.h
+++ b/velox/dwio/parquet/reader/StructColumnReader.h
@@ -32,7 +32,7 @@ class ParquetParams;
 class StructColumnReader : public dwio::common::SelectiveStructColumnReader {
  public:
   StructColumnReader(
-      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       ParquetParams& params,
       common::ScanSpec& scanSpec);

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1672,7 +1672,7 @@ TEST_F(TableScanTest, validFileNoData) {
                    .length(fs::file_size(filePath) / 2)
                    .build();
 
-  auto op = tableScanNode(rowType);
+  auto op = PlanBuilder().tableScan(rowType, {}, "", rowType).planNode();
   assertQuery(op, split, "");
 }
 


### PR DESCRIPTION
Summary:
We see table scan using more CPU than Java on tables with large number
of columns (> 7000).  Some optimizations are implemented to improve the
performance of a typical query from 24.07 hours to 4.7 hours (Java 10.02 hours).

- Remove usage of `ColumnSelector` from selective readers
- Use `Type` instead of `TypeWithId` for `requestedType`
- Do not populate file `TypeWithId` where the column is not selected
- Use arena for `StripeFooter`

Differential Revision: D58364580
