### PR TITLE
Enable right join in smj

### DIFF
--- a/velox/exec/MergeJoin.h
+++ b/velox/exec/MergeJoin.h
@@ -398,6 +398,7 @@ class MergeJoin : public Operator {
     bool currentRowPassed_{false};
   };
 
+  /// Used to record both left and right join.
   std::optional<JoinTracker> joinTracker_{std::nullopt};
 
   // Indices buffer used by the output dictionaries. All projection from the

--- a/velox/exec/MergeJoin.h
+++ b/velox/exec/MergeJoin.h
@@ -215,6 +215,13 @@ class MergeJoin : public Operator {
       const RowVectorPtr& left,
       vector_size_t leftIndex);
 
+  /// Adds one row of output for a right-side row with no left-side match.
+  /// Copies values from the 'rightIndex' row of 'right' and fills in nulls
+  /// for columns that correspond to the right side.
+  void addOutputRowForRightJoin(
+      const RowVectorPtr& right,
+      vector_size_t rightIndex);
+
   /// Evaluates join filter on 'filterInput_' and returns 'output' that contains
   /// a subset of rows on which the filter passed. Returns nullptr if no rows
   /// passed the filter.
@@ -231,9 +238,9 @@ class MergeJoin : public Operator {
   /// rows from the left side that have a match on the right.
   RowVectorPtr filterOutputForAntiJoin(const RowVectorPtr& output);
 
-  /// As we populate the results of the left join, we track whether a given
+  /// As we populate the results of the join, we track whether a given
   /// output row is a result of a match between left and right sides or a miss.
-  /// We use LeftJoinTracker::addMatch and addMiss methods for that.
+  /// We use JoinTracker::addMatch and addMiss methods for that.
   ///
   /// The semantic of the filter is to include at least one left side row in the
   /// output after filters are applied. Therefore:
@@ -256,8 +263,8 @@ class MergeJoin : public Operator {
   /// block, we keep the subset of passing rows. However, if the filter failed
   /// on all rows in such a block, we add one of these rows back and update
   /// build-side columns to null.
-  struct LeftJoinTracker {
-    LeftJoinTracker(vector_size_t numRows, memory::MemoryPool* pool)
+  struct JoinTracker {
+    JoinTracker(vector_size_t numRows, memory::MemoryPool* pool)
         : matchingRows_{numRows, false} {
       leftRowNumbers_ = AlignedBuffer::allocate<vector_size_t>(numRows, pool);
       rawLeftRowNumbers_ = leftRowNumbers_->asMutable<vector_size_t>();
@@ -391,7 +398,7 @@ class MergeJoin : public Operator {
     bool currentRowPassed_{false};
   };
 
-  std::optional<LeftJoinTracker> leftJoinTracker_{std::nullopt};
+  std::optional<JoinTracker> joinTracker_{std::nullopt};
 
   // Indices buffer used by the output dictionaries. All projection from the
   // left share `leftIndices_`, and projections in the right share

--- a/velox/exec/fuzzer/JoinFuzzer.cpp
+++ b/velox/exec/fuzzer/JoinFuzzer.cpp
@@ -858,16 +858,10 @@ void JoinFuzzer::makeAlternativePlans(
               joinNode->isNullAware())
           .planNode()});
 
-<<<<<<< HEAD
   // Use OrderBy + MergeJoin
   if (joinNode->isInnerJoin() || joinNode->isLeftJoin() ||
       joinNode->isLeftSemiFilterJoin() || joinNode->isRightSemiFilterJoin() ||
-      joinNode->isAntiJoin()) {
-=======
-  if (joinNode->isInnerJoin() || joinNode->isLeftJoin() ||
-      joinNode->isLeftSemiFilterJoin() || joinNode->isRightSemiFilterJoin() ||
-      joinNode->isRightJoin()) {
->>>>>>> Enable right join in smj
+      joinNode->isAntiJoin() || joinNode->isRightJoin()) {
     auto planWithSplits = makeMergeJoinPlan(
         joinType, probeKeys, buildKeys, probeInput, buildInput, outputColumns);
     plans.push_back(planWithSplits);

--- a/velox/exec/fuzzer/JoinFuzzer.cpp
+++ b/velox/exec/fuzzer/JoinFuzzer.cpp
@@ -858,10 +858,16 @@ void JoinFuzzer::makeAlternativePlans(
               joinNode->isNullAware())
           .planNode()});
 
+<<<<<<< HEAD
   // Use OrderBy + MergeJoin
   if (joinNode->isInnerJoin() || joinNode->isLeftJoin() ||
       joinNode->isLeftSemiFilterJoin() || joinNode->isRightSemiFilterJoin() ||
       joinNode->isAntiJoin()) {
+=======
+  if (joinNode->isInnerJoin() || joinNode->isLeftJoin() ||
+      joinNode->isLeftSemiFilterJoin() || joinNode->isRightSemiFilterJoin() ||
+      joinNode->isRightJoin()) {
+>>>>>>> Enable right join in smj
     auto planWithSplits = makeMergeJoinPlan(
         joinType, probeKeys, buildKeys, probeInput, buildInput, outputColumns);
     plans.push_back(planWithSplits);

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -155,34 +155,69 @@ class MergeJoinTest : public HiveConnectorTestBase {
 
     // Test LEFT join.
     planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
-    plan = PlanBuilder(planNodeIdGenerator)
-               .values(left)
-               .mergeJoin(
-                   {"c0"},
-                   {"u_c0"},
-                   PlanBuilder(planNodeIdGenerator)
-                       .values(right)
-                       .project({"c1 as u_c1", "c0 as u_c0"})
-                       .planNode(),
-                   "",
-                   {"c0", "c1", "u_c1"},
-                   core::JoinType::kLeft)
-               .planNode();
+    auto leftPlan = PlanBuilder(planNodeIdGenerator)
+                        .values(left)
+                        .mergeJoin(
+                            {"c0"},
+                            {"u_c0"},
+                            PlanBuilder(planNodeIdGenerator)
+                                .values(right)
+                                .project({"c1 as u_c1", "c0 as u_c0"})
+                                .planNode(),
+                            "",
+                            {"c0", "c1", "u_c1"},
+                            core::JoinType::kLeft)
+                        .planNode();
 
     // Use very small output batch size.
     assertQuery(
-        makeCursorParameters(plan, 16),
+        makeCursorParameters(leftPlan, 16),
         "SELECT t.c0, t.c1, u.c1 FROM t LEFT JOIN u ON t.c0 = u.c0");
 
     // Use regular output batch size.
     assertQuery(
-        makeCursorParameters(plan, 1024),
+        makeCursorParameters(leftPlan, 1024),
         "SELECT t.c0, t.c1, u.c1 FROM t LEFT JOIN u ON t.c0 = u.c0");
 
     // Use very large output batch size.
     assertQuery(
-        makeCursorParameters(plan, 10'000),
+        makeCursorParameters(leftPlan, 10'000),
         "SELECT t.c0, t.c1, u.c1 FROM t LEFT JOIN u ON t.c0 = u.c0");
+
+    // Test RIGHT join.
+    planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    auto rightPlan = PlanBuilder(planNodeIdGenerator)
+                         .values(right)
+                         .mergeJoin(
+                             {"c0"},
+                             {"u_c0"},
+                             PlanBuilder(planNodeIdGenerator)
+                                 .values(left)
+                                 .project({"c1 as u_c1", "c0 as u_c0"})
+                                 .planNode(),
+                             "",
+                             {"u_c0", "u_c1", "c1"},
+                             core::JoinType::kRight)
+                         .planNode();
+
+    // Use very small output batch size.
+    assertQuery(
+        makeCursorParameters(rightPlan, 16),
+        "SELECT t.c0, t.c1, u.c1 FROM u RIGHT JOIN t ON t.c0 = u.c0");
+
+    // Use regular output batch size.
+    assertQuery(
+        makeCursorParameters(rightPlan, 1024),
+        "SELECT t.c0, t.c1, u.c1 FROM u RIGHT JOIN t ON t.c0 = u.c0");
+
+    // Use very large output batch size.
+    assertQuery(
+        makeCursorParameters(rightPlan, 10'000),
+        "SELECT t.c0, t.c1, u.c1 FROM u RIGHT JOIN t ON t.c0 = u.c0");
+
+    // Test right join and left join with same result.
+    auto expectedResult = AssertQueryBuilder(leftPlan).copyResults(pool_.get());
+    AssertQueryBuilder(rightPlan).assertResults(expectedResult);
   }
 };
 
@@ -346,7 +381,7 @@ TEST_F(MergeJoinTest, innerJoinFilter) {
       "SELECT t_c0, u_c0, u_c1 FROM t, u WHERE t_c0 = u_c0 AND (t_c1 + u_c1) % 2 = 0");
 }
 
-TEST_F(MergeJoinTest, leftJoinFilter) {
+TEST_F(MergeJoinTest, leftAndRightJoinFilter) {
   // Each row on the left side has at most one match on the right side.
   auto left = makeRowVector(
       {"t_c0", "t_c1"},
@@ -366,7 +401,7 @@ TEST_F(MergeJoinTest, leftJoinFilter) {
   createDuckDbTable("u", {right});
 
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
-  auto plan = [&](const std::string& filter) {
+  auto leftPlan = [&](const std::string& filter) {
     return PlanBuilder(planNodeIdGenerator)
         .values({left})
         .mergeJoin(
@@ -379,11 +414,28 @@ TEST_F(MergeJoinTest, leftJoinFilter) {
         .planNode();
   };
 
+  auto rightPlan = [&](const std::string& filter) {
+    return PlanBuilder(planNodeIdGenerator)
+        .values({right})
+        .mergeJoin(
+            {"u_c0"},
+            {"t_c0"},
+            PlanBuilder(planNodeIdGenerator).values({left}).planNode(),
+            filter,
+            {"t_c0", "t_c1", "u_c1"},
+            core::JoinType::kRight)
+        .planNode();
+  };
+
   // Test with different output batch sizes.
   for (auto batchSize : {1, 3, 16}) {
     assertQuery(
-        makeCursorParameters(plan("(t_c1 + u_c1) % 2 = 0"), batchSize),
+        makeCursorParameters(leftPlan("(t_c1 + u_c1) % 2 = 0"), batchSize),
         "SELECT t_c0, t_c1, u_c1 FROM t LEFT JOIN u ON t_c0 = u_c0 AND (t_c1 + u_c1) % 2 = 0");
+
+    assertQuery(
+        makeCursorParameters(rightPlan("(t_c1 + u_c1) % 2 = 0"), batchSize),
+        "SELECT t_c0, t_c1, u_c1 FROM u RIGHT JOIN t ON t_c0 = u_c0 AND (t_c1 + u_c1) % 2 = 0");
   }
 
   // A left-side row with multiple matches on the right side.
@@ -412,9 +464,14 @@ TEST_F(MergeJoinTest, leftJoinFilter) {
           "t_c1 + u_c1 > 100",
           "t_c1 + u_c1 < 100"}) {
       assertQuery(
-          makeCursorParameters(plan(filter), batchSize),
+          makeCursorParameters(leftPlan(filter), batchSize),
           fmt::format(
               "SELECT t_c0, t_c1, u_c1 FROM t LEFT JOIN u ON t_c0 = u_c0 AND {}",
+              filter));
+      assertQuery(
+          makeCursorParameters(rightPlan(filter), batchSize),
+          fmt::format(
+              "SELECT t_c0, t_c1, u_c1 FROM u RIGHT JOIN t ON t_c0 = u_c0 AND {}",
               filter));
     }
   }
@@ -608,7 +665,7 @@ TEST_F(MergeJoinTest, rightJoin) {
 
   // Right join.
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
-  auto plan =
+  auto rightPlan =
       PlanBuilder(planNodeIdGenerator)
           .values({left})
           .mergeJoin(
@@ -619,9 +676,23 @@ TEST_F(MergeJoinTest, rightJoin) {
               {"t0", "u0"},
               core::JoinType::kRight)
           .planNode();
-  AssertQueryBuilder(plan, duckDbQueryRunner_)
+  AssertQueryBuilder(rightPlan, duckDbQueryRunner_)
       .assertResults(
           "SELECT * FROM t RIGHT JOIN u ON t.t0 = u.u0 AND t.t0 > 2");
+
+  auto leftPlan =
+      PlanBuilder(planNodeIdGenerator)
+          .values({right})
+          .mergeJoin(
+              {"u0"},
+              {"t0"},
+              PlanBuilder(planNodeIdGenerator).values({left}).planNode(),
+              "t0 > 2",
+              {"t0", "u0"},
+              core::JoinType::kLeft)
+          .planNode();
+  auto expectedResult = AssertQueryBuilder(leftPlan).copyResults(pool_.get());
+  AssertQueryBuilder(rightPlan).assertResults(expectedResult);
 }
 
 TEST_F(MergeJoinTest, nullKeys) {


### PR DESCRIPTION
The semantics of the right join are similar to  the left join, so we referenced the implementation of the left join to achieve the implementation of the right join.