### PR TITLE
Refactoring HiveConnectorTestBase::writeToFile() to use dynamic cast for writer of DWRF or Parquet file format

### DIFF
--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -34,21 +34,22 @@ add_library(
 
 target_link_libraries(
   velox_exec_test_lib
-  velox_vector_test_lib
-  velox_temp_path
+  velox_aggregates
   velox_core
-  velox_exception
-  velox_expression
-  velox_parse_parser
   velox_duckdb_conversion
   velox_dwio_common
+  velox_dwio_common_test_utils
   velox_dwio_dwrf_reader
   velox_dwio_dwrf_writer
-  velox_dwio_common_test_utils
+  velox_dwio_parquet_writer
+  velox_exception
+  velox_expression
   velox_file_test_utils
-  velox_type_fbhive
-  velox_hive_connector
-  velox_tpch_connector
-  velox_presto_serializer
   velox_functions_prestosql
-  velox_aggregates)
+  velox_hive_connector
+  velox_parse_parser
+  velox_presto_serializer
+  velox_temp_path
+  velox_tpch_connector
+  velox_type_fbhive
+  velox_vector_test_lib)

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -19,8 +19,6 @@
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/HiveDataSink.h"
 #include "velox/connectors/hive/TableHandle.h"
-#include "velox/dwio/dwrf/common/Config.h"
-#include "velox/dwio/dwrf/writer/FlushPolicy.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/TempFilePath.h"
@@ -43,23 +41,28 @@ class HiveConnectorTestBase : public OperatorTestBase {
   void resetHiveConnector(
       const std::shared_ptr<const config::ConfigBase>& config);
 
-  void writeToFile(const std::string& filePath, RowVectorPtr vector);
+  void writeToFile(
+      const std::string& filePath,
+      const RowVectorPtr vector,
+      dwio::common::FileFormat fileFormat = dwio::common::FileFormat::DWRF);
 
   void writeToFile(
       const std::string& filePath,
       const std::vector<RowVectorPtr>& vectors,
-      std::shared_ptr<dwrf::Config> config =
-          std::make_shared<facebook::velox::dwrf::Config>(),
-      const std::function<std::unique_ptr<dwrf::DWRFFlushPolicy>()>&
-          flushPolicyFactory = nullptr);
+      dwio::common::FileFormat fileFormat = dwio::common::FileFormat::DWRF);
 
   void writeToFile(
       const std::string& filePath,
       const std::vector<RowVectorPtr>& vectors,
-      std::shared_ptr<dwrf::Config> config,
+      std::shared_ptr<dwio::common::WriterOptions> options,
+      dwio::common::FileFormat fileFormat = dwio::common::FileFormat::DWRF);
+
+  void writeToFile(
+      const std::string& filePath,
+      const std::vector<RowVectorPtr>& vectors,
+      std::shared_ptr<dwio::common::WriterOptions> options,
       const TypePtr& schema,
-      const std::function<std::unique_ptr<dwrf::DWRFFlushPolicy>()>&
-          flushPolicyFactory = nullptr);
+      dwio::common::FileFormat fileFormat = dwio::common::FileFormat::DWRF);
 
   std::vector<RowVectorPtr> makeVectors(
       const RowTypePtr& rowType,


### PR DESCRIPTION
Refactoring HiveConnectorTestBase::writeToFile() to use dynamic cast for writer of DWRF or Parquet file format. Also refactoring HiveIcebergTest and TableScanTest since they use HiveConnectorTestBase class. 

Related to work in: 
https://github.com/facebookincubator/velox/pull/9973
https://github.com/facebookincubator/velox/pull/10915

Resolves: 
https://github.com/facebookincubator/velox/issues/9171