### PR TITLE
Update MacOS version of re2 in setup script

### DIFF
--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -122,7 +122,7 @@ function install_ranges_v3 {
 }
 
 function install_re2 {
-  github_checkout google/re2 2021-04-01
+  github_checkout google/re2 2022-02-01
   cmake_install -DRE2_BUILD_TESTING=OFF
 }
 


### PR DESCRIPTION
The setup-macos.sh script installed an older version of RE2.
Update it to match the bundled version and the version in the dependency README.

Once available install the new version by running
```
setup-macos.sh install_re2
```