### PR TITLE
Support complex types for Spark EqualTo and EqualNullSafe functions

### DIFF
--- a/velox/docs/functions/spark/comparison.rst
+++ b/velox/docs/functions/spark/comparison.rst
@@ -10,22 +10,28 @@ Comparison Functions
 
 .. spark:function:: equalnullsafe(x, y) -> boolean
 
-    Returns true if x is equal to y. Supports all types. The
-    types of x and y must be the same. Unlike :spark:func:`equalto` returns true if both inputs
+    Returns true if ``x`` is equal to ``y``. Supports all types. The
+    types of ``x`` and ``y`` must be the same. Unlike :spark:func:`equalto` returns true if both inputs
     are NULL and false if one of the inputs is NULL.
     Corresponds to Spark's operator ``<=>``.
     Note that NaN in Spark is handled differently from standard floating point semantics.
     It is considered larger than any other numeric values. This rule is applied for functions
     "equalnullsafe", "equalto", "greaterthan", "greaterthanorequal", "lessthan", "lessthanorequal".
-    Nested nulls are allowed within input values if x is complex type. Nested 
-    nulls are treated as values.
+    Nested nulls are allowed within input values if ``x`` is complex type. Nested 
+    nulls are treated as values during comparsion. ::
+        SELECT equalnullsafe(null, null); -- true
+        SELECT equalnullsafe(null, ARRAY[1]); -- false
+        SELECT equalnullsafe(ARRAY[1, null], ARRAY[1, null]); -- true
 
 .. spark:function:: equalto(x, y) -> boolean
 
     Returns true if x is equal to y. Supports all types. The
     types of x and y must be the same. Corresponds to Spark's operators ``=`` and ``==``.
     Nested nulls are allowed within input values if x is complex type. Nested 
-    nulls are treated as values.
+    nulls are treated as values during comparsion. ::
+        SELECT equalto(null, null); -- null
+        SELECT equalto(null, ARRAY[1]); -- null
+        SELECT equalto(ARRAY[1, null], ARRAY[1, null]); -- true
 
 .. spark:function:: greaterthan(x, y) -> boolean
 

--- a/velox/docs/functions/spark/comparison.rst
+++ b/velox/docs/functions/spark/comparison.rst
@@ -12,7 +12,7 @@ Comparison Functions
 
     Returns true if ``x`` is equal to ``y``. Supports all types. The
     types of ``x`` and ``y`` must be the same. Unlike :spark:func:`equalto` returns true if both inputs
-    are NULL and false if one of the inputs is NULL. Nested nulls are treated similarly.
+    are NULL and false if one of the inputs is NULL. Nested nulls are compared as values.
     Corresponds to Spark's operator ``<=>``.
     Note that NaN in Spark is handled differently from standard floating point semantics.
     It is considered larger than any other numeric values. This rule is applied for functions

--- a/velox/docs/functions/spark/comparison.rst
+++ b/velox/docs/functions/spark/comparison.rst
@@ -12,13 +12,12 @@ Comparison Functions
 
     Returns true if ``x`` is equal to ``y``. Supports all types. The
     types of ``x`` and ``y`` must be the same. Unlike :spark:func:`equalto` returns true if both inputs
-    are NULL and false if one of the inputs is NULL.
+    are NULL and false if one of the inputs is NULL. Nested nulls are treated similarly.
     Corresponds to Spark's operator ``<=>``.
     Note that NaN in Spark is handled differently from standard floating point semantics.
     It is considered larger than any other numeric values. This rule is applied for functions
-    "equalnullsafe", "equalto", "greaterthan", "greaterthanorequal", "lessthan", "lessthanorequal".
-    Nested nulls are allowed within input values if ``x`` is complex type. Nested 
-    nulls are treated as values during comparsion. ::
+    "equalnullsafe", "equalto", "greaterthan", "greaterthanorequal", "lessthan", "lessthanorequal". ::
+
         SELECT equalnullsafe(null, null); -- true
         SELECT equalnullsafe(null, ARRAY[1]); -- false
         SELECT equalnullsafe(ARRAY[1, null], ARRAY[1, null]); -- true
@@ -27,8 +26,8 @@ Comparison Functions
 
     Returns true if x is equal to y. Supports all types. The
     types of x and y must be the same. Corresponds to Spark's operators ``=`` and ``==``.
-    Nested nulls are allowed within input values if x is complex type. Nested 
-    nulls are treated as values during comparsion. ::
+    Returns NULL for any NULL input, but nested nulls are compared as values. ::
+    
         SELECT equalto(null, null); -- null
         SELECT equalto(null, ARRAY[1]); -- null
         SELECT equalto(ARRAY[1, null], ARRAY[1, null]); -- true

--- a/velox/docs/functions/spark/comparison.rst
+++ b/velox/docs/functions/spark/comparison.rst
@@ -10,7 +10,7 @@ Comparison Functions
 
 .. spark:function:: equalnullsafe(x, y) -> boolean
 
-    Returns true if ``x`` is equal to ``y``. Supports all types. The
+    Returns true if ``x`` is equal to ``y``. Supports all scalar and complex types. The
     types of ``x`` and ``y`` must be the same. Unlike :spark:func:`equalto` returns true if both inputs
     are NULL and false if one of the inputs is NULL. Nested nulls are compared as values.
     Corresponds to Spark's operator ``<=>``.
@@ -24,7 +24,7 @@ Comparison Functions
 
 .. spark:function:: equalto(x, y) -> boolean
 
-    Returns true if x is equal to y. Supports all types. The
+    Returns true if x is equal to y. Supports all scalar and complex types. The
     types of x and y must be the same. Corresponds to Spark's operators ``=`` and ``==``.
     Returns NULL for any NULL input, but nested nulls are compared as values. ::
     

--- a/velox/docs/functions/spark/comparison.rst
+++ b/velox/docs/functions/spark/comparison.rst
@@ -10,7 +10,7 @@ Comparison Functions
 
 .. spark:function:: equalnullsafe(x, y) -> boolean
 
-    Returns true if x is equal to y. Supports all scalar types. The
+    Returns true if x is equal to y. Supports all types. The
     types of x and y must be the same. Unlike :spark:func:`equalto` returns true if both inputs
     are NULL and false if one of the inputs is NULL.
     Corresponds to Spark's operator ``<=>``.
@@ -20,7 +20,7 @@ Comparison Functions
 
 .. spark:function:: equalto(x, y) -> boolean
 
-    Returns true if x is equal to y. Supports all scalar types. The
+    Returns true if x is equal to y. Supports all types. The
     types of x and y must be the same. Corresponds to Spark's operators ``=`` and ``==``.
 
 .. spark:function:: greaterthan(x, y) -> boolean

--- a/velox/docs/functions/spark/comparison.rst
+++ b/velox/docs/functions/spark/comparison.rst
@@ -17,11 +17,15 @@ Comparison Functions
     Note that NaN in Spark is handled differently from standard floating point semantics.
     It is considered larger than any other numeric values. This rule is applied for functions
     "equalnullsafe", "equalto", "greaterthan", "greaterthanorequal", "lessthan", "lessthanorequal".
+    Nested nulls are allowed within input values if x is complex type. Nested 
+    nulls are treated as values.
 
 .. spark:function:: equalto(x, y) -> boolean
 
     Returns true if x is equal to y. Supports all types. The
     types of x and y must be the same. Corresponds to Spark's operators ``=`` and ``==``.
+    Nested nulls are allowed within input values if x is complex type. Nested 
+    nulls are treated as values.
 
 .. spark:function:: greaterthan(x, y) -> boolean
 

--- a/velox/functions/sparksql/Comparisons.h
+++ b/velox/functions/sparksql/Comparisons.h
@@ -174,7 +174,7 @@ std::shared_ptr<exec::VectorFunction> makeEqualToNullSafe(
     const core::QueryConfig& config);
 
 template <typename T>
-struct EqFunction {
+struct EqualToFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
   // For arbitrary nested complex types.
   FOLLY_ALWAYS_INLINE void call(
@@ -190,7 +190,7 @@ struct EqFunction {
 };
 
 template <typename T>
-struct EqNullSafeFunction {
+struct EqualNullSafeFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
   // For arbitrary nested complex types.
   FOLLY_ALWAYS_INLINE void callNullable(

--- a/velox/functions/sparksql/Comparisons.h
+++ b/velox/functions/sparksql/Comparisons.h
@@ -15,7 +15,9 @@
  */
 #pragma once
 
+#include "velox/common/base/CompareFlags.h"
 #include "velox/expression/VectorFunction.h"
+#include "velox/functions/Macros.h"
 
 namespace facebook::velox::functions::sparksql {
 
@@ -170,5 +172,42 @@ std::shared_ptr<exec::VectorFunction> makeEqualToNullSafe(
     const std::string& name,
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& config);
+
+template <typename T>
+struct EqFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+  // For arbitrary nested complex types.
+  FOLLY_ALWAYS_INLINE void call(
+      bool& out,
+      const arg_type<Generic<T1>>& lhs,
+      const arg_type<Generic<T1>>& rhs) {
+    static constexpr CompareFlags kFlags =
+        CompareFlags::equality(CompareFlags::NullHandlingMode::kNullAsValue);
+
+    auto result = lhs.compare(rhs, kFlags);
+    out = (result.value() == 0);
+  }
+};
+
+template <typename T>
+struct EqNullSafeFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+  // For arbitrary nested complex types.
+  FOLLY_ALWAYS_INLINE void callNullable(
+      bool& out,
+      const arg_type<Generic<T1>>* lhs,
+      const arg_type<Generic<T1>>* rhs) {
+    static constexpr CompareFlags kFlags =
+        CompareFlags::equality(CompareFlags::NullHandlingMode::kNullAsValue);
+    if (!lhs && !rhs) {
+      out = true;
+    } else if (!lhs || !rhs) {
+      out = false;
+    } else {
+      auto result = lhs->compare(*rhs, kFlags);
+      out = (result.value() == 0);
+    }
+  }
+};
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/RegisterCompare.cpp
+++ b/velox/functions/sparksql/RegisterCompare.cpp
@@ -23,6 +23,8 @@ namespace facebook::velox::functions::sparksql {
 void registerCompareFunctions(const std::string& prefix) {
   exec::registerStatefulVectorFunction(
       prefix + "equalto", comparisonSignatures(), makeEqualTo);
+  registerFunction<EqFunction, bool, Generic<T1>, Generic<T1>>(
+      {prefix + "equalto"});
   exec::registerStatefulVectorFunction(
       prefix + "lessthan", comparisonSignatures(), makeLessThan);
   exec::registerStatefulVectorFunction(
@@ -39,6 +41,8 @@ void registerCompareFunctions(const std::string& prefix) {
       comparisonSignatures(),
       makeEqualToNullSafe,
       exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build());
+  registerFunction<EqNullSafeFunction, bool, Generic<T1>, Generic<T1>>(
+      {prefix + "equalnullsafe"});
   registerFunction<BetweenFunction, bool, int8_t, int8_t, int8_t>(
       {prefix + "between"});
   registerFunction<BetweenFunction, bool, int16_t, int16_t, int16_t>(

--- a/velox/functions/sparksql/RegisterCompare.cpp
+++ b/velox/functions/sparksql/RegisterCompare.cpp
@@ -23,7 +23,7 @@ namespace facebook::velox::functions::sparksql {
 void registerCompareFunctions(const std::string& prefix) {
   exec::registerStatefulVectorFunction(
       prefix + "equalto", comparisonSignatures(), makeEqualTo);
-  registerFunction<EqFunction, bool, Generic<T1>, Generic<T1>>(
+  registerFunction<EqualToFunction, bool, Generic<T1>, Generic<T1>>(
       {prefix + "equalto"});
   exec::registerStatefulVectorFunction(
       prefix + "lessthan", comparisonSignatures(), makeLessThan);
@@ -41,7 +41,7 @@ void registerCompareFunctions(const std::string& prefix) {
       comparisonSignatures(),
       makeEqualToNullSafe,
       exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build());
-  registerFunction<EqNullSafeFunction, bool, Generic<T1>, Generic<T1>>(
+  registerFunction<EqualNullSafeFunction, bool, Generic<T1>, Generic<T1>>(
       {prefix + "equalnullsafe"});
   registerFunction<BetweenFunction, bool, int8_t, int8_t, int8_t>(
       {prefix + "between"});

--- a/velox/functions/sparksql/tests/ComparisonsTest.cpp
+++ b/velox/functions/sparksql/tests/ComparisonsTest.cpp
@@ -557,10 +557,7 @@ TEST_F(ComparisonsTest, dateTypes) {
 
 TEST_F(ComparisonsTest, notSupportedTypes) {
   const auto candidataFuncs = {
-      "lessthan",
-      "lessthanorequal",
-      "greaterthan",
-      "greaterthanorequal"};
+      "lessthan", "lessthanorequal", "greaterthan", "greaterthanorequal"};
   auto arrayData = makeArrayVectorFromJson<int64_t>({"[1, 2, 3]"});
   auto mapData = makeMapVectorFromJson<int64_t, int64_t>({"{1: 1}"});
   auto rowData = makeRowVector({arrayData});

--- a/velox/functions/sparksql/tests/ComparisonsTest.cpp
+++ b/velox/functions/sparksql/tests/ComparisonsTest.cpp
@@ -109,15 +109,15 @@ class ComparisonsTest : public SparkFunctionBaseTest {
 
 TEST_F(ComparisonsTest, equaltonullsafe) {
   const auto funcName = "equalnullsafe";
-  auto assertArrayInput = [&](const std::string& array1,
-                              const std::string& array2,
-                              std::optional<bool> expectedResult) {
+  auto testArrayInput = [&](const std::string& array1,
+                            const std::string& array2,
+                            std::optional<bool> expectedResult) {
     runAndCompareForArrayInput(funcName, array1, array2, expectedResult);
   };
 
-  auto assertRowInput = [&](const std::optional<int64_t>& value1,
-                            const std::optional<int64_t>& value2,
-                            std::optional<bool> expectedResult) {
+  auto testRowInput = [&](const std::optional<int64_t>& value1,
+                          const std::optional<int64_t>& value2,
+                          std::optional<bool> expectedResult) {
     runAndCompareForRowInput(
         funcName,
         constructRowVector(value1),
@@ -135,31 +135,31 @@ TEST_F(ComparisonsTest, equaltonullsafe) {
   EXPECT_EQ(equaltonullsafe<double>(kNaN, 1), false);
   EXPECT_EQ(equaltonullsafe<double>(kNaN, kNaN), true);
 
-  assertArrayInput("null", "null", true);
-  assertArrayInput("null", "[1.0]", false);
-  assertArrayInput("[1.0]", "null", false);
+  testArrayInput("null", "null", true);
+  testArrayInput("null", "[1.0]", false);
+  testArrayInput("[1.0]", "null", false);
 
-  assertArrayInput("[]", "[]", true);
+  testArrayInput("[]", "[]", true);
 
-  assertArrayInput("[1.0, 2.0, 3.0]", "[1.0, 2.0, 3.0]", true);
-  assertArrayInput("[1.0, 2.0, 3.0]", "[1.0, 2.0, 4.0]", false);
+  testArrayInput("[1.0, 2.0, 3.0]", "[1.0, 2.0, 3.0]", true);
+  testArrayInput("[1.0, 2.0, 3.0]", "[1.0, 2.0, 4.0]", false);
 
-  assertArrayInput("[1.0, null]", "[6.0, 2.0]", false);
-  assertArrayInput("[1.0, null]", "[1.0, 2.0]", false);
-  assertArrayInput("[1.0, NaN]", "[1.0, NaN]", true);
+  testArrayInput("[1.0, null]", "[6.0, 2.0]", false);
+  testArrayInput("[1.0, null]", "[1.0, 2.0]", false);
+  testArrayInput("[1.0, NaN]", "[1.0, NaN]", true);
 
-  assertArrayInput("[]", "[null, null]", false);
-  assertArrayInput("[1.0, 2.0]", "[1.0, 2.0, null]", false);
-  assertArrayInput("[null, null]", "[null, null, null]", false);
+  testArrayInput("[]", "[null, null]", false);
+  testArrayInput("[1.0, 2.0]", "[1.0, 2.0, null]", false);
+  testArrayInput("[null, null]", "[null, null, null]", false);
 
-  assertArrayInput("[null, null]", "[null, null]", true);
+  testArrayInput("[null, null]", "[null, null]", true);
 
-  assertRowInput(std::nullopt, std::nullopt, true);
-  assertRowInput(std::nullopt, 1, false);
-  assertRowInput(1, std::nullopt, false);
+  testRowInput(std::nullopt, std::nullopt, true);
+  testRowInput(std::nullopt, 1, false);
+  testRowInput(1, std::nullopt, false);
 
-  assertRowInput(1, 2, false);
-  assertRowInput(1, 1, true);
+  testRowInput(1, 2, false);
+  testRowInput(1, 1, true);
 
   runAndCompareForRowInput(
       funcName,
@@ -180,15 +180,15 @@ TEST_F(ComparisonsTest, equaltonullsafe) {
 
 TEST_F(ComparisonsTest, equalto) {
   const auto funcName = "equalto";
-  auto assertArrayInput = [&](const std::string& array1,
-                              const std::string& array2,
-                              std::optional<bool> expectedResult) {
+  auto testArrayInput = [&](const std::string& array1,
+                            const std::string& array2,
+                            std::optional<bool> expectedResult) {
     runAndCompareForArrayInput(funcName, array1, array2, expectedResult);
   };
 
-  auto assertRowInput = [&](const std::optional<int64_t>& value1,
-                            const std::optional<int64_t>& value2,
-                            std::optional<bool> expectedResult) {
+  auto testRowInput = [&](const std::optional<int64_t>& value1,
+                          const std::optional<int64_t>& value2,
+                          std::optional<bool> expectedResult) {
     runAndCompareForRowInput(
         funcName,
         constructRowVector(value1),
@@ -217,31 +217,31 @@ TEST_F(ComparisonsTest, equalto) {
   EXPECT_EQ(equalto<float>(kInfF, -kInfF), false);
   EXPECT_EQ(equalto<double>(kInf, kNaN), false);
 
-  assertArrayInput("null", "null", std::nullopt);
-  assertArrayInput("null", "[1.0]", std::nullopt);
-  assertArrayInput("[1.0]", "null", std::nullopt);
+  testArrayInput("null", "null", std::nullopt);
+  testArrayInput("null", "[1.0]", std::nullopt);
+  testArrayInput("[1.0]", "null", std::nullopt);
 
-  assertArrayInput("[]", "[]", true);
+  testArrayInput("[]", "[]", true);
 
-  assertArrayInput("[1.0, 2.0, 3.0]", "[1.0, 2.0, 3.0]", true);
-  assertArrayInput("[1.0, 2.0, 3.0]", "[1.0, 2.0, 4.0]", false);
+  testArrayInput("[1.0, 2.0, 3.0]", "[1.0, 2.0, 3.0]", true);
+  testArrayInput("[1.0, 2.0, 3.0]", "[1.0, 2.0, 4.0]", false);
 
-  assertArrayInput("[1.0, null]", "[6.0, 2.0]", false);
-  assertArrayInput("[1.0, null]", "[1.0, 2.0]", false);
-  assertArrayInput("[1.0, NaN]", "[1.0, NaN]", true);
+  testArrayInput("[1.0, null]", "[6.0, 2.0]", false);
+  testArrayInput("[1.0, null]", "[1.0, 2.0]", false);
+  testArrayInput("[1.0, NaN]", "[1.0, NaN]", true);
 
-  assertArrayInput("[]", "[null, null]", false);
-  assertArrayInput("[1.0, 2.0]", "[1.0, 2.0, null]", false);
-  assertArrayInput("[null, null]", "[null, null, null]", false);
+  testArrayInput("[]", "[null, null]", false);
+  testArrayInput("[1.0, 2.0]", "[1.0, 2.0, null]", false);
+  testArrayInput("[null, null]", "[null, null, null]", false);
 
-  assertArrayInput("[null, null]", "[null, null]", true);
+  testArrayInput("[null, null]", "[null, null]", true);
 
-  assertRowInput(std::nullopt, std::nullopt, true);
-  assertRowInput(std::nullopt, 1, false);
-  assertRowInput(1, std::nullopt, false);
+  testRowInput(std::nullopt, std::nullopt, true);
+  testRowInput(std::nullopt, 1, false);
+  testRowInput(1, std::nullopt, false);
 
-  assertRowInput(1, 2, false);
-  assertRowInput(1, 1, true);
+  testRowInput(1, 2, false);
+  testRowInput(1, 1, true);
 
   runAndCompareForRowInput(
       funcName,

--- a/velox/functions/sparksql/tests/ComparisonsTest.cpp
+++ b/velox/functions/sparksql/tests/ComparisonsTest.cpp
@@ -102,11 +102,8 @@ class ComparisonsTest : public SparkFunctionBaseTest {
       const std::string& functionName,
       const RowVectorPtr& vector1,
       const RowVectorPtr& vector2,
-      std::optional<bool> expectedResult) {
-    runAndCompare(
-        functionName,
-        {vector1, vector2},
-        makeNullableFlatVector<bool>({expectedResult}));
+      const VectorPtr& expectedResult) {
+    runAndCompare(functionName, {vector1, vector2}, expectedResult);
   }
 };
 
@@ -125,7 +122,7 @@ TEST_F(ComparisonsTest, equaltonullsafe) {
         funcName,
         constructRowVector(value1),
         constructRowVector(value2),
-        expectedResult);
+        makeNullableFlatVector<bool>({expectedResult}));
   };
 
   EXPECT_EQ(equaltonullsafe<int64_t>(1, 1), true);
@@ -168,17 +165,17 @@ TEST_F(ComparisonsTest, equaltonullsafe) {
       funcName,
       constructRowVector(std::nullopt, true),
       constructRowVector(std::nullopt, true),
-      true);
+      makeNullableFlatVector<bool>({true}));
   runAndCompareForRowInput(
       funcName,
       constructRowVector(std::nullopt, true),
       constructRowVector(1, false),
-      false);
+      makeNullableFlatVector<bool>({false}));
   runAndCompareForRowInput(
       funcName,
       constructRowVector(1, false),
       constructRowVector(std::nullopt, true),
-      false);
+      makeNullableFlatVector<bool>({false}));
 }
 
 TEST_F(ComparisonsTest, equalto) {
@@ -196,7 +193,7 @@ TEST_F(ComparisonsTest, equalto) {
         funcName,
         constructRowVector(value1),
         constructRowVector(value2),
-        expectedResult);
+        makeNullableFlatVector<bool>({expectedResult}));
   };
   EXPECT_EQ(equalto<Timestamp>(Timestamp(2, 2), Timestamp(2, 2)), true);
   EXPECT_EQ(equalto<StringView>("test"_sv, "test"_sv), true);
@@ -250,17 +247,17 @@ TEST_F(ComparisonsTest, equalto) {
       funcName,
       constructRowVector(std::nullopt, true),
       constructRowVector(std::nullopt, true),
-      std::nullopt);
+      makeNullableFlatVector<bool>({std::nullopt}));
   runAndCompareForRowInput(
       funcName,
       constructRowVector(std::nullopt, true),
       constructRowVector(1, false),
-      std::nullopt);
+      makeNullableFlatVector<bool>({std::nullopt}));
   runAndCompareForRowInput(
       funcName,
       constructRowVector(1, false),
       constructRowVector(std::nullopt, true),
-      std::nullopt);
+      makeNullableFlatVector<bool>({std::nullopt}));
 }
 
 TEST_F(ComparisonsTest, between) {


### PR DESCRIPTION
Support complex types for Spark EqualTo and EqualNullSafe functions.
Some samples for special cases:
```
spark.sql("select struct('Spark', null) = struct('Spark', null)").collect
res10: Array[org.apache.spark.sql.Row] = Array([true])

spark.sql("select struct('Spark', null) <=> struct('Spark', null)").collect
res9: Array[org.apache.spark.sql.Row] = Array([true])

spark.sql("select CAST(NULL AS STRUCT<Field1:INT,Field2:ARRAY<INT>>) == CAST(NULL AS STRUCT<Field1:INT,Field2:ARRAY<INT>>)").collect
res4: Array[org.apache.spark.sql.Row] = Array([null])

spark.sql("select CAST(NULL AS STRUCT<Field1:INT,Field2:ARRAY<INT>>) <=> CAST(NULL AS STRUCT<Field1:INT,Field2:ARRAY<INT>>)").collect
res13: Array[org.apache.spark.sql.Row] = Array([true])

```