### PR TITLE
Add folly cancellation token support in task and connector source

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "folly/CancellationToken.h"
 #include "velox/common/base/AsyncSource.h"
 #include "velox/common/base/RuntimeMetrics.h"
 #include "velox/common/base/SpillConfig.h"
@@ -259,7 +260,8 @@ class ConnectorQueryCtx {
       const std::string& queryId,
       const std::string& taskId,
       const std::string& planNodeId,
-      int driverId)
+      int driverId,
+      folly::CancellationToken cancellationToken = {})
       : operatorPool_(operatorPool),
         connectorPool_(connectorPool),
         sessionProperties_(sessionProperties),
@@ -270,7 +272,8 @@ class ConnectorQueryCtx {
         queryId_(queryId),
         taskId_(taskId),
         driverId_(driverId),
-        planNodeId_(planNodeId) {
+        planNodeId_(planNodeId),
+        cancellationToken_(std::move(cancellationToken)) {
     VELOX_CHECK_NOT_NULL(sessionProperties);
   }
 
@@ -327,6 +330,11 @@ class ConnectorQueryCtx {
     return planNodeId_;
   }
 
+  /// Returns the cancellation token associated with this task.
+  const folly::CancellationToken& cancellationToken() const {
+    return cancellationToken_;
+  }
+
  private:
   memory::MemoryPool* const operatorPool_;
   memory::MemoryPool* const connectorPool_;
@@ -339,6 +347,7 @@ class ConnectorQueryCtx {
   const std::string taskId_;
   const int driverId_;
   const std::string planNodeId_;
+  const folly::CancellationToken cancellationToken_;
 };
 
 class Connector {

--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -19,10 +19,13 @@
 #include <string>
 #include <unordered_map>
 
+#include "velox/common/testutil/TestValue.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnectorUtil.h"
 #include "velox/dwio/common/ReaderFactory.h"
 #include "velox/expression/FieldReference.h"
+
+using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::connector::hive {
 
@@ -301,6 +304,9 @@ std::optional<RowVectorPtr> HiveDataSource::next(
     velox::ContinueFuture& /*future*/) {
   VELOX_CHECK(split_ != nullptr, "No split to process. Call addSplit first.");
   VELOX_CHECK_NOT_NULL(splitReader_, "No split reader present");
+
+  TestValue::adjust(
+      "facebook::velox::connector::hive::HiveDataSource::next", this);
 
   if (splitReader_->emptySplit()) {
     resetSplit();

--- a/velox/connectors/hive/HiveDataSource.h
+++ b/velox/connectors/hive/HiveDataSource.h
@@ -95,6 +95,10 @@ class HiveDataSource : public DataSource {
 
   static void registerWaveDelegateHook(WaveDelegateHookFunction hook);
 
+  const ConnectorQueryCtx* testingConnectorQueryCtx() const {
+    return connectorQueryCtx_;
+  }
+
  protected:
   virtual std::unique_ptr<SplitReader> createSplitReader();
 

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -53,18 +53,20 @@ OperatorCtx::createConnectorQueryCtx(
     const std::string& planNodeId,
     memory::MemoryPool* connectorPool,
     const common::SpillConfig* spillConfig) const {
+  const auto& task = driverCtx_->task;
   return std::make_shared<connector::ConnectorQueryCtx>(
       pool_,
       connectorPool,
-      driverCtx_->task->queryCtx()->connectorSessionProperties(connectorId),
+      task->queryCtx()->connectorSessionProperties(connectorId),
       spillConfig,
       std::make_unique<SimpleExpressionEvaluator>(
           execCtx()->queryCtx(), execCtx()->pool()),
-      driverCtx_->task->queryCtx()->cache(),
-      driverCtx_->task->queryCtx()->queryId(),
+      task->queryCtx()->cache(),
+      task->queryCtx()->queryId(),
       taskId(),
       planNodeId,
-      driverCtx_->driverId);
+      driverCtx_->driverId,
+      task->getCancellationToken());
 }
 
 Operator::Operator(

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1855,7 +1855,7 @@ ContinueFuture Task::terminate(TaskState terminalState) {
     if (taskStats_.executionEndTimeMs == 0) {
       taskStats_.executionEndTimeMs = getCurrentTimeMs();
     }
-    if (not isRunningLocked()) {
+    if (!isRunningLocked()) {
       return makeFinishFutureLocked("Task::terminate");
     }
     state_ = terminalState;
@@ -1872,6 +1872,10 @@ ContinueFuture Task::terminate(TaskState terminalState) {
       } catch (const std::exception&) {
         exception_ = std::current_exception();
       }
+    }
+    if (state_ != TaskState::kFinished) {
+      VELOX_CHECK(!cancellationSource_.isCancellationRequested());
+      cancellationSource_.requestCancellation();
     }
 
     LOG(INFO) << "Terminating task " << taskId() << " with state "

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -659,6 +659,13 @@ class Task : public std::enable_shared_from_this<Task> {
     return numDriversInPartitionedOutput_ > 0;
   }
 
+  /// Returns the cancellation token to check if this task has been terminated
+  /// or not. This helps the Velox integration with query system using folly
+  /// cancellation mechanism.
+  folly::CancellationToken getCancellationToken() {
+    return cancellationSource_.getToken();
+  }
+
   void testingIncrementThreads() {
     std::lock_guard l(mutex_);
     ++numThreads_;
@@ -1162,6 +1169,8 @@ class Task : public std::enable_shared_from_this<Task> {
   // Stores unconsumed preloading splits to ensure they are closed promptly.
   folly::F14FastSet<std::shared_ptr<connector::ConnectorSplit>>
       preloadingSplits_;
+
+  folly::CancellationSource cancellationSource_;
 };
 
 /// Listener invoked on task completion.


### PR DESCRIPTION
Add folly cancellation support in velox task to help integration with query system using folly
cancellation mechanism. To support this, each velox task has a cancellation source which is
only set when a task fails. The user code just needs to get a cancellation token from velox task
and then it detects when the task is cancelled. Also we expose the task cancellation token to
connector source by passing a cancellation token in ConnectorQueryCtx, and the customized
connector implementation can get a cancellation token from ConnectorQueryCtx and merge
with cancellation token to detect any async cancellation including velox task. The cancellation is
copiable and internally the cancellation source and all created or copied cancellation tokens shared
the same cancellation state through a counted reference.