### PR TITLE
Fix benchmarks build failure

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: "Install dependencies"
         if: ${{ github.event_name == 'pull_request' }}
-        run: source velox/scripts/setup-ubuntu.sh && install_apt_deps
+        run: source velox/scripts/setup-ubuntu.sh && install_apt_deps && install_duckdb
 
       - name: Build Baseline Benchmarks
         if: ${{ github.event_name == 'pull_request' }}
@@ -117,7 +117,7 @@ jobs:
           submodules: 'recursive'
 
       - name: "Install dependencies"
-        run: source velox/scripts/setup-ubuntu.sh && install_apt_deps
+        run: source velox/scripts/setup-ubuntu.sh && install_apt_deps && install_duckdb
 
       - name: Build Contender Benchmarks
         working-directory: velox

--- a/velox/functions/lib/CheckedArithmetic.h
+++ b/velox/functions/lib/CheckedArithmetic.h
@@ -17,9 +17,9 @@
 
 #include <functional>
 #include <limits>
-#include "CheckedArithmeticImpl.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/functions/Macros.h"
+#include "velox/functions/lib/CheckedArithmeticImpl.h"
 
 namespace facebook::velox::functions {
 


### PR DESCRIPTION
duckdb source includes a copy of re2 as a third-party dependency. However, it defines the re2 headers
 as public which seem to conflict with the system re2 headers.
The workaround is to not bundle duckdb.