### PR TITLE
Keep DuckDB re2 headers private

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: "Install dependencies"
         if: ${{ github.event_name == 'pull_request' }}
-        run: source velox/scripts/setup-ubuntu.sh && install_apt_deps
+        run: source velox/scripts/setup-ubuntu.sh && install_apt_deps && install_duckdb
 
       - name: Build Baseline Benchmarks
         if: ${{ github.event_name == 'pull_request' }}

--- a/CMake/resolve_dependency_modules/duckdb.cmake
+++ b/CMake/resolve_dependency_modules/duckdb.cmake
@@ -33,7 +33,8 @@ FetchContent_Declare(
   URL_HASH ${VELOX_DUCKDB_BUILD_SHA256_CHECKSUM}
   PATCH_COMMAND
     git apply ${CMAKE_CURRENT_LIST_DIR}/duckdb/remove-ccache.patch && git apply
-    ${CMAKE_CURRENT_LIST_DIR}/duckdb/fix-duckdbversion.patch)
+    ${CMAKE_CURRENT_LIST_DIR}/duckdb/fix-duckdbversion.patch && git apply
+    ${CMAKE_CURRENT_LIST_DIR}/duckdb/re2.patch)
 
 set(BUILD_UNITTESTS OFF)
 set(ENABLE_SANITIZER OFF)

--- a/CMake/resolve_dependency_modules/duckdb/re2.patch
+++ b/CMake/resolve_dependency_modules/duckdb/re2.patch
@@ -1,0 +1,11 @@
+--- a/third_party/re2/CMakeLists.txt
++++ b/third_party/re2/CMakeLists.txt
+@@ -90,7 +90,7 @@
+ 
+ target_include_directories(
+   duckdb_re2
+-  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
++  PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+ 
+ install(TARGETS duckdb_re2
+         EXPORT "${DUCKDB_EXPORT_SET}"

--- a/velox/functions/lib/CheckedArithmetic.h
+++ b/velox/functions/lib/CheckedArithmetic.h
@@ -17,9 +17,9 @@
 
 #include <functional>
 #include <limits>
-#include "CheckedArithmeticImpl.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/functions/Macros.h"
+#include "velox/functions/lib/CheckedArithmeticImpl.h"
 
 namespace facebook::velox::functions {
 


### PR DESCRIPTION
DuckDB source when bundled includes a copy of re2 as a third-party dependency. However, it defines
the re2 headers as public which seem to conflict with the system re2 headers.

The base build needs the manual install_duckdb since it is being built off master.

Developers must delete the `_deps/duckdb_*` folders in their build folder for the patches to apply cleanly.

Resolves https://github.com/facebookincubator/velox/issues/10154
