### PR TITLE
Add support for TS_WITH_TZ +/- INTERVAL Presto functions

### DIFF
--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -466,6 +466,22 @@ struct TimestampPlusInterval {
       const arg_type<IntervalYearMonth>& interval) {
     result = addToTimestamp(timestamp, DateTimeUnit::kMonth, interval);
   }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<TimestampWithTimezone>& result,
+      const arg_type<TimestampWithTimezone>& timestampWithTimezone,
+      const arg_type<IntervalDayTime>& interval) {
+    result = addToTimestampWithTimezone(
+        timestampWithTimezone, DateTimeUnit::kMillisecond, interval);
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<TimestampWithTimezone>& result,
+      const arg_type<TimestampWithTimezone>& timestampWithTimezone,
+      const arg_type<IntervalYearMonth>& interval) {
+    result = addToTimestampWithTimezone(
+        timestampWithTimezone, DateTimeUnit::kMonth, interval);
+  }
 };
 
 template <typename T>
@@ -491,6 +507,22 @@ struct IntervalPlusTimestamp {
       const arg_type<Timestamp>& timestamp) {
     result = addToTimestamp(timestamp, DateTimeUnit::kMonth, interval);
   }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<TimestampWithTimezone>& result,
+      const arg_type<IntervalDayTime>& interval,
+      const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
+    result = addToTimestampWithTimezone(
+        timestampWithTimezone, DateTimeUnit::kMillisecond, interval);
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<TimestampWithTimezone>& result,
+      const arg_type<IntervalYearMonth>& interval,
+      const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
+    result = addToTimestampWithTimezone(
+        timestampWithTimezone, DateTimeUnit::kMonth, interval);
+  }
 };
 
 template <typename T>
@@ -515,6 +547,22 @@ struct TimestampMinusInterval {
       const arg_type<Timestamp>& timestamp,
       const arg_type<IntervalYearMonth>& interval) {
     result = addToTimestamp(timestamp, DateTimeUnit::kMonth, -interval);
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<TimestampWithTimezone>& result,
+      const arg_type<TimestampWithTimezone>& timestampWithTimezone,
+      const arg_type<IntervalDayTime>& interval) {
+    result = addToTimestampWithTimezone(
+        timestampWithTimezone, DateTimeUnit::kMillisecond, -interval);
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<TimestampWithTimezone>& result,
+      const arg_type<TimestampWithTimezone>& timestampWithTimezone,
+      const arg_type<IntervalYearMonth>& interval) {
+    result = addToTimestampWithTimezone(
+        timestampWithTimezone, DateTimeUnit::kMonth, -interval);
   }
 };
 
@@ -1081,11 +1129,8 @@ struct DateAddFunction : public TimestampWithTimezoneSupport<T> {
       VELOX_UNSUPPORTED("integer overflow");
     }
 
-    auto finalTimeStamp = addToTimestamp(
-        this->toTimestamp(timestampWithTimezone), unit, (int32_t)value);
-    auto tzID = unpackZoneKeyId(timestampWithTimezone);
-    finalTimeStamp.toGMT(tzID);
-    result = pack(finalTimeStamp.toMillis(), tzID);
+    result =
+        addToTimestampWithTimezone(timestampWithTimezone, unit, (int32_t)value);
   }
 
   FOLLY_ALWAYS_INLINE void call(

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -20,6 +20,52 @@
 
 namespace facebook::velox::functions {
 namespace {
+
+// Register timestamp + interval and interval + timestamp
+// functions for specified TTimestamp type and 2 supported interval types
+// (IntervalDayTime and IntervalYearMonth).
+// @tparam TTimestamp Timestamp or TimestampWithTimezone.
+template <typename TTimestamp>
+void registerTimestampPlusInterval(const std::string& name) {
+  registerFunction<
+      TimestampPlusInterval,
+      TTimestamp,
+      TTimestamp,
+      IntervalDayTime>({name});
+  registerFunction<
+      TimestampPlusInterval,
+      TTimestamp,
+      TTimestamp,
+      IntervalYearMonth>({name});
+  registerFunction<
+      IntervalPlusTimestamp,
+      TTimestamp,
+      IntervalDayTime,
+      TTimestamp>({name});
+  registerFunction<
+      IntervalPlusTimestamp,
+      TTimestamp,
+      IntervalYearMonth,
+      TTimestamp>({name});
+}
+
+// Register timestamp - IntervalYearMonth and timestamp - IntervalDayTime
+// functions for specified TTimestamp type.
+// @tparam TTimestamp Timestamp or TimestampWithTimezone.
+template <typename TTimestamp>
+void registerTimestampMinusInterval(const std::string& name) {
+  registerFunction<
+      TimestampMinusInterval,
+      TTimestamp,
+      TTimestamp,
+      IntervalDayTime>({name});
+  registerFunction<
+      TimestampMinusInterval,
+      TTimestamp,
+      TTimestamp,
+      IntervalYearMonth>({name});
+}
+
 void registerSimpleFunctions(const std::string& prefix) {
   // Date time functions.
   registerFunction<ToUnixtimeFunction, double, Timestamp>(
@@ -69,41 +115,18 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "plus"});
   registerFunction<DatePlusInterval, Date, Date, IntervalYearMonth>(
       {prefix + "plus"});
-  registerFunction<
-      TimestampMinusInterval,
-      Timestamp,
-      Timestamp,
-      IntervalDayTime>({prefix + "minus"});
-  registerFunction<
-      TimestampMinusInterval,
-      Timestamp,
-      Timestamp,
-      IntervalYearMonth>({prefix + "minus"});
-  registerFunction<
-      TimestampPlusInterval,
-      Timestamp,
-      Timestamp,
-      IntervalDayTime>({prefix + "plus"});
-  registerFunction<
-      TimestampPlusInterval,
-      Timestamp,
-      Timestamp,
-      IntervalYearMonth>({prefix + "plus"});
-  registerFunction<
-      IntervalPlusTimestamp,
-      Timestamp,
-      IntervalDayTime,
-      Timestamp>({prefix + "plus"});
-  registerFunction<
-      IntervalPlusTimestamp,
-      Timestamp,
-      IntervalYearMonth,
-      Timestamp>({prefix + "plus"});
+
+  registerTimestampPlusInterval<Timestamp>({prefix + "plus"});
+  registerTimestampMinusInterval<Timestamp>({prefix + "minus"});
+  registerTimestampPlusInterval<TimestampWithTimezone>({prefix + "plus"});
+  registerTimestampMinusInterval<TimestampWithTimezone>({prefix + "minus"});
+
   registerFunction<
       TimestampMinusFunction,
       IntervalDayTime,
       Timestamp,
       Timestamp>({prefix + "minus"});
+
   registerFunction<DayFunction, int64_t, TimestampWithTimezone>(
       {prefix + "day", prefix + "day_of_month"});
   registerFunction<DayOfWeekFunction, int64_t, Timestamp>(


### PR DESCRIPTION
Summary:
Add the following functions:

- plus(ts_with_tz, interval)
- plus(interval, ts_with_tz)
- minus(ts_with_tz, interval)

Interval can be either INTERVAL_DAY_TIME or INTERVAL_YEAR_MONTH.

These functions are equivalent to date_add and share it's implementation, i.e.

plus(ts, interval '1' hour) == date_add('hour', 1, ts).

Also, plus(ts, interval) == plus(interval, ts) == minus(ts, -interval).

Note that Presto doesn't define minus(interval, ts).

date_add has existing bugs described in https://github.com/facebookincubator/velox/issues/10163

Newly added function share implementation with date_add, hence, suffer from the same bugs.

Differential Revision: D58466111
