### PR TITLE
Fix NaN handling in comparison functions

### DIFF
--- a/velox/type/FloatingPointUtil.h
+++ b/velox/type/FloatingPointUtil.h
@@ -61,12 +61,36 @@ struct NaNAwareLessThan {
 template <
     typename FLOAT,
     std::enable_if_t<std::is_floating_point<FLOAT>::value, bool> = true>
+struct NaNAwareLessThanEqual {
+  bool operator()(const FLOAT& lhs, const FLOAT& rhs) const {
+    if (std::isnan(rhs)) {
+      return true;
+    }
+    return lhs <= rhs;
+  }
+};
+
+template <
+    typename FLOAT,
+    std::enable_if_t<std::is_floating_point<FLOAT>::value, bool> = true>
 struct NaNAwareGreaterThan {
   bool operator()(const FLOAT& lhs, const FLOAT& rhs) const {
     if (std::isnan(lhs) && !std::isnan(rhs)) {
       return true;
     }
     return lhs > rhs;
+  }
+};
+
+template <
+    typename FLOAT,
+    std::enable_if_t<std::is_floating_point<FLOAT>::value, bool> = true>
+struct NaNAwareGreaterThanEqual {
+  bool operator()(const FLOAT& lhs, const FLOAT& rhs) const {
+    if (std::isnan(lhs)) {
+      return true;
+    }
+    return lhs >= rhs;
   }
 };
 

--- a/velox/type/tests/FloatingPointUtilTest.cpp
+++ b/velox/type/tests/FloatingPointUtilTest.cpp
@@ -39,10 +39,24 @@ void testFloatingPoint() {
   ASSERT_FALSE(NaNAwareLessThan<T>{}(kNaN, kInf));
   ASSERT_TRUE(NaNAwareLessThan<T>{}(kInf, kNaN));
 
+  ASSERT_TRUE(NaNAwareLessThanEqual<T>{}(kNaN, kNaN));
+  ASSERT_TRUE(NaNAwareLessThanEqual<T>{}(kNaN, kSNAN));
+  ASSERT_TRUE(NaNAwareLessThanEqual<T>{}(kInf, kNaN));
+  ASSERT_TRUE(NaNAwareLessThanEqual<T>{}(0.0, kInf));
+  ASSERT_FALSE(NaNAwareLessThanEqual<T>{}(kNaN, kInf));
+  ASSERT_FALSE(NaNAwareLessThanEqual<T>{}(kNaN, 0.0));
+
   ASSERT_FALSE(NaNAwareGreaterThan<T>{}(kNaN, kNaN));
   ASSERT_FALSE(NaNAwareGreaterThan<T>{}(kNaN, kSNAN));
   ASSERT_FALSE(NaNAwareGreaterThan<T>{}(kInf, kNaN));
   ASSERT_TRUE(NaNAwareGreaterThan<T>{}(kNaN, kInf));
+
+  ASSERT_TRUE(NaNAwareGreaterThanEqual<T>{}(kNaN, kNaN));
+  ASSERT_TRUE(NaNAwareGreaterThanEqual<T>{}(kNaN, kSNAN));
+  ASSERT_FALSE(NaNAwareGreaterThanEqual<T>{}(kInf, kNaN));
+  ASSERT_FALSE(NaNAwareGreaterThanEqual<T>{}(0.0, kInf));
+  ASSERT_TRUE(NaNAwareGreaterThanEqual<T>{}(kNaN, kInf));
+  ASSERT_TRUE(NaNAwareGreaterThanEqual<T>{}(kNaN, 0.0));
 
   ASSERT_EQ(NaNAwareHash<T>{}(kNaN), NaNAwareHash<T>{}(kSNAN));
   ASSERT_EQ(NaNAwareHash<T>{}(kNaN), NaNAwareHash<T>{}(kNaN));


### PR DESCRIPTION
Summary:
This change ensures that comparison functions treat all NaN bit
representations as equal and greater than infinity.

Summary of changes:
Currently, numerical primitive types, including floating points, have
an optimized SIMD implementation. However, this relies on low-level
instructions that follow IEEE floating point semantics, where NaN
compared to any other number, including itself, returns false. There
is no trivial way to implement NaN checking and handling using SIMD,
so for now, we are falling back to the regular non-SIMD version that
employs comparators supporting NaN handling in the intended way.

Additionally, this change currently handles this by adding a special
case in the ComparisonSimdFunction vector function instead of
registering the SimpleFunction for floating types. This is because
registering an additional/different function to handle floating types
is causing a regression in an internal integration which is still under
investigation.

Differential Revision: D58471982
