### PR TITLE
Allow for serde parameters to be passed to TableWrite in PlanBuilder

### DIFF
--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -388,7 +388,8 @@ PlanBuilder& PlanBuilder::tableWrite(
     const std::vector<std::string>& sortBy,
     const dwio::common::FileFormat fileFormat,
     const std::vector<std::string>& aggregates,
-    const std::string& connectorId) {
+    const std::string& connectorId,
+    const std::unordered_map<std::string, std::string>& serdeParameters) {
   VELOX_CHECK_NOT_NULL(planNode_, "TableWrite cannot be the source node");
   auto rowType = planNode_->outputType();
 
@@ -422,7 +423,8 @@ PlanBuilder& PlanBuilder::tableWrite(
       locationHandle,
       fileFormat,
       bucketProperty,
-      common::CompressionKind_NONE);
+      common::CompressionKind_NONE,
+      serdeParameters);
 
   auto insertHandle =
       std::make_shared<core::InsertTableHandle>(connectorId, hiveHandle);

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -444,7 +444,8 @@ class PlanBuilder {
       const dwio::common::FileFormat fileFormat =
           dwio::common::FileFormat::DWRF,
       const std::vector<std::string>& aggregates = {},
-      const std::string& connectorId = "test-hive");
+      const std::string& connectorId = "test-hive",
+      const std::unordered_map<std::string, std::string>& serdeParameters = {});
 
   /// Add a TableWriteMergeNode.
   PlanBuilder& tableWriteMerge(


### PR DESCRIPTION
Summary: as title, serde parameteres were quietly being left empty through the tableWrite function, exposing them out here

Differential Revision: D58382361


