### PR TITLE
[Velox] Fail builds with virtual classes with non-virtual destructors

### DIFF
--- a/CMake/resolve_dependency_modules/duckdb.cmake
+++ b/CMake/resolve_dependency_modules/duckdb.cmake
@@ -43,6 +43,8 @@ set(BUILD_SHELL OFF)
 set(EXPORT_DLL_SYMBOLS OFF)
 set(PREVIOUS_BUILD_TYPE ${CMAKE_BUILD_TYPE})
 set(CMAKE_BUILD_TYPE Release)
+set(PREVIOUS_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-non-virtual-dtor")
 
 FetchContent_MakeAvailable(duckdb)
 
@@ -50,4 +52,5 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
   target_compile_options(duckdb_catalog PRIVATE -Wno-nonnull-compare)
 endif()
 
+set(CMAKE_CXX_FLAGS ${PREVIOUS_CMAKE_CXX_FLAGS})
 set(CMAKE_BUILD_TYPE ${PREVIOUS_BUILD_TYPE})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,6 +337,7 @@ if("${ENABLE_ALL_WARNINGS}")
        -Wno-unused-parameter \
        -Wno-sign-compare \
        -Wno-ignored-qualifiers \
+       -Wnon-virtual-dtor \
        ${KNOWN_COMPILER_SPECIFIC_WARNINGS}")
 
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra ${KNOWN_WARNINGS}")

--- a/velox/connectors/hive/storage_adapters/abfs/AbfsWriteFile.h
+++ b/velox/connectors/hive/storage_adapters/abfs/AbfsWriteFile.h
@@ -45,6 +45,8 @@ using namespace Azure::Storage::Files::DataLake::Models;
  */
 class IBlobStorageFileClient {
  public:
+  virtual ~IBlobStorageFileClient() {}
+
   virtual void create() = 0;
   virtual PathProperties getProperties() = 0;
   virtual void append(const uint8_t* buffer, size_t size, uint64_t offset) = 0;


### PR DESCRIPTION
Internally at Meta our builds apply checks that classes with virtual functions have virtual destructors, and fail if they do not.

Applying the same checks to our OS builds.  It seems like a good check to have in general, and will reduce back and forth
between contributors and folks at Meta after they import changes.

DuckDB does not adhere to this so I had to disable it while building their code.