### PR TITLE
Verify checksum for full SSD entry only

### DIFF
--- a/velox/common/caching/SsdFile.cpp
+++ b/velox/common/caching/SsdFile.cpp
@@ -268,7 +268,9 @@ CoalesceIoStats SsdFile::load(
     pins[i].checkedEntry()->setSsdFile(this, ssdPins[i].run().offset());
     auto* entry = pins[i].checkedEntry();
     auto ssdRun = ssdPins[i].run();
-    maybeVerifyChecksum(*entry, ssdRun);
+    if (ssdRun.size() == entry->size()) {
+      maybeVerifyChecksum(*entry, ssdRun);
+    }
   }
   return stats;
 }


### PR DESCRIPTION
When loading data from 'ssdPins' into 'pins', mismatches occur if the requested 'pins' range is shorter than the SSD cache entries. This is because the checksum is calculated on partial data but compared with a checksum of the full entry. To resolve this, checksum verification should only be applied when reading the entire SSD entry.