### PR TITLE
Apply grow target adjustment to reduce arbitration count

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -82,6 +82,11 @@ std::unique_ptr<MemoryArbitrator> createArbitrator(
           folly::to<std::string>(options.memoryPoolReservedCapacity) + "B";
       extraArbitratorConfigs["memory-pool-transfer-capacity"] =
           folly::to<std::string>(options.memoryPoolTransferCapacity) + "B";
+      extraArbitratorConfigs["fast-exponential-growth-capacity-limit"] =
+          folly::to<std::string>(options.fastExponentialGrowthCapacityLimit) +
+          "B";
+      extraArbitratorConfigs["slow-capacity-grow-pct"] =
+          folly::to<std::string>(options.slowCapacityGrowPct);
       extraArbitratorConfigs["memory-reclaim-max-wait-time"] =
           folly::to<std::string>(options.memoryReclaimWaitMs) + "ms";
       extraArbitratorConfigs["global-arbitration-enabled"] =

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -92,7 +92,7 @@ struct MemoryManagerOptions {
   /// std::malloc.
   bool useMmapAllocator{false};
 
-  // Number of pages in the largest size class in MmapAllocator.
+  /// Number of pages in the largest size class in MmapAllocator.
   int32_t largestSizeClassPages{256};
 
   /// If true, allocations larger than largest size class size will be delegated
@@ -174,6 +174,27 @@ struct MemoryManagerOptions {
   /// The minimal memory capacity to transfer out of or into a memory pool
   /// during the memory arbitration.
   uint64_t memoryPoolTransferCapacity{128 << 20};
+
+  /// When growing capacity, the growth bytes will be adjusted in the
+  /// following way:
+  ///  - If 2 * current capacity is less than or equal to
+  ///    'fastExponentialGrowthCapacityLimit', grow through fast path by at
+  ///    least doubling the current capacity, when conditions allow (see below
+  ///    NOTE section).
+  ///  - If 2 * current capacity is greater than
+  ///    'fastExponentialGrowthCapacityLimit', grow through slow path by growing
+  ///    capacity by at least 'slowCapacityGrowPct' * current capacity if
+  ///    allowed (see below NOTE section).
+  ///
+  /// NOTE: If original requested growth bytes is larger than the adjusted
+  /// growth bytes or adjusted growth bytes reaches max capacity limit, the
+  /// adjusted growth bytes will not be respected.
+  ///
+  /// NOTE: Capacity growth adjust is only enabled if both
+  /// 'fastExponentialGrowthCapacityLimit' and 'slowCapacityGrowPct' are set,
+  /// otherwise it is disabled.
+  uint64_t fastExponentialGrowthCapacityLimit{512 << 20};
+  double slowCapacityGrowPct{0.25};
 
   /// Specifies the max time to wait for memory reclaim by arbitration. The
   /// memory reclaim might fail if the max wait time has exceeded. If it is

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -57,7 +57,7 @@ class MemoryArbitrator {
     /// manager.
     int64_t capacity;
 
-    /// callback to check if a memory arbitration request is issued from a
+    /// Callback to check if a memory arbitration request is issued from a
     /// driver thread, then the driver should be put in suspended state to avoid
     /// the potential deadlock when reclaim memory from the task of the request
     /// memory pool.
@@ -118,7 +118,7 @@ class MemoryArbitrator {
   /// up a number of pools to either shrink its memory capacity without actually
   /// freeing memory or reclaim its used memory to free up enough memory for
   /// 'requestor' to grow.
-  virtual bool growCapacity(MemoryPool* pool, uint64_t targetBytes) = 0;
+  virtual bool growCapacity(MemoryPool* pool, uint64_t requestBytes) = 0;
 
   /// Invoked by the memory manager to shrink up to 'targetBytes' free capacity
   /// from a memory 'pool', and returns them back to the arbitrator. If

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -425,6 +425,8 @@ class MockSharedArbitrationTest : public testing::Test {
       uint64_t memoryPoolInitCapacity = kMemoryPoolInitCapacity,
       uint64_t memoryPoolReserveCapacity = kMemoryPoolReservedCapacity,
       uint64_t memoryPoolTransferCapacity = kMemoryPoolTransferCapacity,
+      uint64_t fastExponentialGrowthCapacityLimit = 0,
+      double slowCapacityGrowPct = 0,
       std::function<void(MemoryPool&)> arbitrationStateCheckCb = nullptr,
       bool globalArtbitrationEnabled = true) {
     MemoryManagerOptions options;
@@ -435,6 +437,9 @@ class MockSharedArbitrationTest : public testing::Test {
     options.memoryPoolInitCapacity = memoryPoolInitCapacity;
     options.memoryPoolReservedCapacity = memoryPoolReserveCapacity;
     options.memoryPoolTransferCapacity = memoryPoolTransferCapacity;
+    options.fastExponentialGrowthCapacityLimit =
+        fastExponentialGrowthCapacityLimit;
+    options.slowCapacityGrowPct = slowCapacityGrowPct;
     options.globalArbitrationEnabled = globalArtbitrationEnabled;
     options.arbitrationStateCheckCb = std::move(arbitrationStateCheckCb);
     options.checkUsageLeak = true;
@@ -651,7 +656,7 @@ TEST_F(MockSharedArbitrationTest, arbitrationStateCheck) {
     ASSERT_TRUE(RE2::FullMatch(pool.name(), re)) << pool.name();
     ++checkCount;
   };
-  setupMemory(memCapacity, 0, 0, 0, 0, checkCountCb);
+  setupMemory(memCapacity, 0, 0, 0, 0, 0, 0, checkCountCb);
 
   const int numTasks{5};
   std::vector<std::shared_ptr<MockTask>> tasks;
@@ -676,7 +681,7 @@ TEST_F(MockSharedArbitrationTest, arbitrationStateCheck) {
   MemoryArbitrationStateCheckCB badCheckCb = [&](MemoryPool& /*unused*/) {
     VELOX_FAIL("bad check");
   };
-  setupMemory(memCapacity, 0, 0, 0, 0, badCheckCb);
+  setupMemory(memCapacity, 0, 0, 0, 0, 0, 0, badCheckCb);
   std::shared_ptr<MockTask> task = addTask(kMemoryCapacity);
   ASSERT_EQ(task->capacity(), 0);
   MockMemoryOperator* memOp = task->addMemoryOp();
@@ -1691,6 +1696,8 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, globalArbitrationEnableCheck) {
         memoryPoolInitCapacity,
         0,
         memoryPoolTransferCapacity,
+        0,
+        0,
         nullptr,
         globalArbitrationEnabled);
 
@@ -1898,37 +1905,86 @@ DEBUG_ONLY_TEST_F(
 }
 
 TEST_F(MockSharedArbitrationTest, singlePoolGrowWithoutArbitration) {
-  const int64_t memoryCapacity = 128 << 20;
-  const uint64_t memoryPoolInitCapacity = 32 << 20;
-  const uint64_t memoryPoolTransferCapacity = 8 << 20;
-  setupMemory(
-      memoryCapacity, 0, memoryPoolInitCapacity, 0, memoryPoolTransferCapacity);
+  int64_t memoryCapacity = 512 << 20;
+  uint64_t memoryPoolInitCapacity = 32 << 20;
+  struct TestParam {
+    uint64_t memoryPoolTransferCapacity;
+    uint64_t fastExponentialGrowthCapacityLimit;
+    double slowCapacityGrowPct;
+    std::string debugString() const {
+      return fmt::format(
+          "memoryPoolTransferCapacity {}, "
+          "fastExponentialGrowthCapacityLimit {}, "
+          "slowCapacityGrowPct {}",
+          succinctBytes(memoryPoolTransferCapacity),
+          succinctBytes(fastExponentialGrowthCapacityLimit),
+          slowCapacityGrowPct);
+    }
+  };
 
-  auto* memOp = addMemoryOp();
-  const int allocateSize = 1 * MB;
-  while (memOp->capacity() < memoryCapacity) {
-    memOp->allocate(allocateSize);
+  // Try to make each test allocation larger than the largest memory pool
+  // quantization(8MB) to not have noise.
+  std::vector<TestParam> testParams{
+      {8 << 20, 0, 0},
+      {0, 128 << 20, 0.1},
+      {32 << 20, 128 << 20, 0.1},
+      {16 << 20, 128 << 20, 0.5},
+  };
+
+  for (const auto& testParam : testParams) {
+    SCOPED_TRACE(testParam.debugString());
+    setupMemory(
+        memoryCapacity,
+        0,
+        memoryPoolInitCapacity,
+        0,
+        testParam.memoryPoolTransferCapacity,
+        testParam.fastExponentialGrowthCapacityLimit,
+        testParam.slowCapacityGrowPct);
+
+    auto* memOp = addMemoryOp();
+    const int allocateSize = 1 * MB;
+    while (memOp->capacity() < memoryCapacity) {
+      memOp->allocate(allocateSize);
+    }
+
+    // Computations of expected number of requests depending on capacity grow
+    // strategy (fast path or not).
+    uint64_t expectedNumRequests{0};
+    if (testParam.fastExponentialGrowthCapacityLimit == 0) {
+      expectedNumRequests = (memoryCapacity - memoryPoolInitCapacity) /
+          testParam.memoryPoolTransferCapacity;
+    } else {
+      uint64_t simulateCapacity = memoryPoolInitCapacity;
+      while (simulateCapacity * 2 <=
+             testParam.fastExponentialGrowthCapacityLimit) {
+        simulateCapacity +=
+            std::max(simulateCapacity, testParam.memoryPoolTransferCapacity);
+        expectedNumRequests++;
+      }
+      while (simulateCapacity < memoryCapacity) {
+        auto growth = std::max(
+            static_cast<uint64_t>(
+                simulateCapacity * testParam.slowCapacityGrowPct),
+            testParam.memoryPoolTransferCapacity);
+        simulateCapacity += growth;
+        expectedNumRequests++;
+      }
+    }
+
+    verifyArbitratorStats(
+        arbitrator_->stats(), memoryCapacity, 0, 0, expectedNumRequests);
+
+    verifyReclaimerStats(memOp->reclaimer()->stats(), 0, expectedNumRequests);
+
+    clearTasks();
+    verifyArbitratorStats(
+        arbitrator_->stats(),
+        memoryCapacity,
+        memoryCapacity,
+        0,
+        expectedNumRequests);
   }
-
-  verifyArbitratorStats(
-      arbitrator_->stats(),
-      memoryCapacity,
-      0,
-      0,
-      (memoryCapacity - memoryPoolInitCapacity) / memoryPoolTransferCapacity);
-
-  verifyReclaimerStats(
-      memOp->reclaimer()->stats(),
-      0,
-      (memoryCapacity - memoryPoolInitCapacity) / memoryPoolTransferCapacity);
-
-  clearTasks();
-  verifyArbitratorStats(
-      arbitrator_->stats(),
-      memoryCapacity,
-      memoryCapacity,
-      0,
-      (memoryCapacity - memoryPoolInitCapacity) / memoryPoolTransferCapacity);
 }
 
 TEST_F(MockSharedArbitrationTest, maxCapacityReserve) {

--- a/velox/exec/tests/utils/ArbitratorTestUtil.cpp
+++ b/velox/exec/tests/utils/ArbitratorTestUtil.cpp
@@ -45,7 +45,9 @@ std::unique_ptr<memory::MemoryManager> createMemoryManager(
     int64_t arbitratorCapacity,
     uint64_t memoryPoolInitCapacity,
     uint64_t memoryPoolTransferCapacity,
-    uint64_t maxReclaimWaitMs) {
+    uint64_t maxReclaimWaitMs,
+    uint64_t fastExponentialGrowthCapacityLimit,
+    double slowCapacityGrowPct) {
   memory::MemoryManagerOptions options;
   options.arbitratorCapacity = arbitratorCapacity;
   options.arbitratorReservedCapacity = 0;
@@ -58,6 +60,9 @@ std::unique_ptr<memory::MemoryManager> createMemoryManager(
   options.memoryReclaimWaitMs = maxReclaimWaitMs;
   options.globalArbitrationEnabled = true;
   options.checkUsageLeak = true;
+  options.fastExponentialGrowthCapacityLimit =
+      fastExponentialGrowthCapacityLimit;
+  options.slowCapacityGrowPct = slowCapacityGrowPct;
   options.arbitrationStateCheckCb = memoryArbitrationStateCheck;
   return std::make_unique<memory::MemoryManager>(options);
 }

--- a/velox/exec/tests/utils/ArbitratorTestUtil.h
+++ b/velox/exec/tests/utils/ArbitratorTestUtil.h
@@ -96,7 +96,9 @@ std::unique_ptr<memory::MemoryManager> createMemoryManager(
     int64_t arbitratorCapacity = kMemoryCapacity,
     uint64_t memoryPoolInitCapacity = kMemoryPoolInitCapacity,
     uint64_t memoryPoolTransferCapacity = kMemoryPoolTransferCapacity,
-    uint64_t maxReclaimWaitMs = 0);
+    uint64_t maxReclaimWaitMs = 0,
+    uint64_t fastExponentialGrowthCapacityLimit = 0,
+    double slowCapacityGrowPct = 0);
 
 // Contains the query result.
 struct QueryTestResult {


### PR DESCRIPTION
Add grow target bytes adjustment so that when growing capacity we grow more than requested if requested target is small. This can help to give allocation headrooms after grow and hence reduce arbitration frequency. Consequently it can help to reduce workload in arbitrator and in turn improve overall performance of the system.