### PR TITLE
SIMD-ize comparisons for DATE

### DIFF
--- a/velox/functions/lib/RegistrationHelpers.h
+++ b/velox/functions/lib/RegistrationHelpers.h
@@ -56,15 +56,6 @@ void registerBinaryScalar(const std::vector<std::string>& aliases) {
   registerFunction<T, TReturn, Date, Date>(aliases);
 }
 
-template <template <class> class T, typename TReturn>
-void registerNonSimdizableScalar(const std::vector<std::string>& aliases) {
-  registerFunction<T, TReturn, Varchar, Varchar>(aliases);
-  registerFunction<T, TReturn, Varbinary, Varbinary>(aliases);
-  registerFunction<T, TReturn, bool, bool>(aliases);
-  registerFunction<T, TReturn, Timestamp, Timestamp>(aliases);
-  registerFunction<T, TReturn, Date, Date>(aliases);
-}
-
 template <template <class> class T>
 void registerUnaryIntegral(const std::vector<std::string>& aliases) {
   registerFunction<T, int8_t, int8_t>(aliases);

--- a/velox/functions/prestosql/Comparisons.cpp
+++ b/velox/functions/prestosql/Comparisons.cpp
@@ -211,7 +211,13 @@ class ComparisonSimdFunction : public exec::VectorFunction {
     std::vector<std::shared_ptr<exec::FunctionSignature>> signatures;
 
     for (const auto& inputType :
-         {"tinyint", "smallint", "integer", "bigint", "real", "double"}) {
+         {"tinyint",
+          "smallint",
+          "integer",
+          "bigint",
+          "real",
+          "double",
+          "date"}) {
       signatures.push_back(exec::FunctionSignatureBuilder()
                                .returnType("boolean")
                                .argumentType(inputType)

--- a/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
@@ -19,6 +19,16 @@
 #include "velox/type/Type.h"
 
 namespace facebook::velox::functions {
+namespace {
+
+template <template <class> class T, typename TReturn>
+void registerNonSimdizableScalar(const std::vector<std::string>& aliases) {
+  registerFunction<T, TReturn, Varchar, Varchar>(aliases);
+  registerFunction<T, TReturn, Varbinary, Varbinary>(aliases);
+  registerFunction<T, TReturn, bool, bool>(aliases);
+  registerFunction<T, TReturn, Timestamp, Timestamp>(aliases);
+}
+} // namespace
 
 void registerComparisonFunctions(const std::string& prefix) {
   // Comparison functions also need TimestampWithTimezoneType,


### PR DESCRIPTION
Summary:
DATE values are just integers representing number of days. Hence, comparisons for DATE are the same as comparisons for INTEGER.

```
============================================================================
[...]l/benchmarks/ComparisonsBenchmark.cpp     relative  time/iter   iters/s
============================================================================
non_simd_bigint_eq                                          2.40ms    416.17
simd_bigint_eq                                  554.55%   433.30us     2.31K
non_simd_integer_eq                                         2.35ms    425.23
simd_integer_eq                                 841.11%   279.59us     3.58K
non_simd_smallint_eq                                        2.38ms    420.55
simd_smallint_eq                                1244.2%   191.11us     5.23K
non_simd_tinyint_eq                                         2.44ms    409.45
simd_tinyint_eq                                 1761.6%   138.64us     7.21K
non_simd_double_eq                                          2.42ms    413.95
simd_double_eq                                  554.73%   435.48us     2.30K
non_simd_real_eq                                            2.37ms    422.07
simd_real_eq                                    892.13%   265.58us     3.77K
non_simd_date_eq                                            2.52ms    396.80
simd_date_eq                                    898.35%   280.53us     3.56K
```

Differential Revision: D58521736
