### PR TITLE
Enable comparison functions for INTERVAL inputs

### DIFF
--- a/velox/functions/lib/RegistrationHelpers.h
+++ b/velox/functions/lib/RegistrationHelpers.h
@@ -56,15 +56,6 @@ void registerBinaryScalar(const std::vector<std::string>& aliases) {
   registerFunction<T, TReturn, Date, Date>(aliases);
 }
 
-template <template <class> class T, typename TReturn>
-void registerNonSimdizableScalar(const std::vector<std::string>& aliases) {
-  registerFunction<T, TReturn, Varchar, Varchar>(aliases);
-  registerFunction<T, TReturn, Varbinary, Varbinary>(aliases);
-  registerFunction<T, TReturn, bool, bool>(aliases);
-  registerFunction<T, TReturn, Timestamp, Timestamp>(aliases);
-  registerFunction<T, TReturn, Date, Date>(aliases);
-}
-
 template <template <class> class T>
 void registerUnaryIntegral(const std::vector<std::string>& aliases) {
   registerFunction<T, int8_t, int8_t>(aliases);

--- a/velox/functions/prestosql/Comparisons.cpp
+++ b/velox/functions/prestosql/Comparisons.cpp
@@ -211,7 +211,13 @@ class ComparisonSimdFunction : public exec::VectorFunction {
     std::vector<std::shared_ptr<exec::FunctionSignature>> signatures;
 
     for (const auto& inputType :
-         {"tinyint", "smallint", "integer", "bigint", "real", "double"}) {
+         {"tinyint",
+          "smallint",
+          "integer",
+          "bigint",
+          "real",
+          "double",
+          "date"}) {
       signatures.push_back(exec::FunctionSignatureBuilder()
                                .returnType("boolean")
                                .argumentType(inputType)

--- a/velox/functions/prestosql/Comparisons.cpp
+++ b/velox/functions/prestosql/Comparisons.cpp
@@ -210,14 +210,17 @@ class ComparisonSimdFunction : public exec::VectorFunction {
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
     std::vector<std::shared_ptr<exec::FunctionSignature>> signatures;
 
-    for (const auto& inputType :
-         {"tinyint",
-          "smallint",
-          "integer",
-          "bigint",
-          "real",
-          "double",
-          "date"}) {
+    for (const auto& inputType : {
+             "tinyint",
+             "smallint",
+             "integer",
+             "bigint",
+             "real",
+             "double",
+             "date",
+             "interval day to second",
+             "interval year to month",
+         }) {
       signatures.push_back(exec::FunctionSignatureBuilder()
                                .returnType("boolean")
                                .argumentType(inputType)

--- a/velox/functions/prestosql/benchmarks/ComparisonsBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ComparisonsBenchmark.cpp
@@ -28,6 +28,10 @@ namespace facebook::velox::functions {
 void registerVectorFunctions() {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_eq, "eq");
   registerBinaryScalar<EqFunction, bool>({"nonsimd_eq"});
+  registerFunction<EqFunction, bool, IntervalDayTime, IntervalDayTime>(
+      {"nonsimd_eq"});
+  registerFunction<EqFunction, bool, IntervalYearMonth, IntervalYearMonth>(
+      {"nonsimd_eq"});
 }
 
 } // namespace facebook::velox::functions
@@ -124,6 +128,22 @@ BENCHMARK(non_simd_date_eq) {
 
 BENCHMARK_RELATIVE(simd_date_eq) {
   benchmark->run("eq", DATE());
+}
+
+BENCHMARK(non_simd_interval_day_time_eq) {
+  benchmark->run("nonsimd_eq", INTERVAL_DAY_TIME());
+}
+
+BENCHMARK_RELATIVE(simd_interval_day_time_eq) {
+  benchmark->run("eq", INTERVAL_DAY_TIME());
+}
+
+BENCHMARK(non_simd_interval_year_month_eq) {
+  benchmark->run("nonsimd_eq", INTERVAL_YEAR_MONTH());
+}
+
+BENCHMARK_RELATIVE(simd_interval_year_month_eq) {
+  benchmark->run("eq", INTERVAL_YEAR_MONTH());
 }
 
 } // namespace

--- a/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
@@ -19,6 +19,16 @@
 #include "velox/type/Type.h"
 
 namespace facebook::velox::functions {
+namespace {
+
+template <template <class> class T, typename TReturn>
+void registerNonSimdizableScalar(const std::vector<std::string>& aliases) {
+  registerFunction<T, TReturn, Varchar, Varchar>(aliases);
+  registerFunction<T, TReturn, Varbinary, Varbinary>(aliases);
+  registerFunction<T, TReturn, bool, bool>(aliases);
+  registerFunction<T, TReturn, Timestamp, Timestamp>(aliases);
+}
+} // namespace
 
 void registerComparisonFunctions(const std::string& prefix) {
   // Comparison functions also need TimestampWithTimezoneType,


### PR DESCRIPTION
Summary:
Enable eq, neq, lt, lte, gt, gte comparisons for INTERVAL DAY TO SECOND and
INTERVAL YEAR TO MONTH inputs. Interval values are just integers, hence,
integer comparison works as is.

```
============================================================================
[...]l/benchmarks/ComparisonsBenchmark.cpp     relative  time/iter   iters/s
============================================================================
non_simd_interval_day_time_eq                               2.57ms    389.44
simd_interval_day_time_eq                       592.11%   433.67us     2.31K
non_simd_interval_year_month_eq                             2.53ms    395.52
simd_interval_year_month_eq                     919.43%   274.99us     3.64K
```

Differential Revision: D58522091
