### PR TITLE
[Velox] Update version of Ubuntu used in Check jobs to 24.04

### DIFF
--- a/scripts/check-container.dockfile
+++ b/scripts/check-container.dockfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM amd64/ubuntu:22.04
+FROM amd64/ubuntu:24.04
 ARG cpu_target
 COPY scripts/setup-check.sh /root
 COPY scripts/setup-helper-functions.sh /

--- a/scripts/setup-check.sh
+++ b/scripts/setup-check.sh
@@ -18,9 +18,9 @@ set -x
 
 export DEBIAN_FRONTEND=noninteractive
 apt update
-apt install --no-install-recommends -y clang-format-12 python3-pip git make ssh
-pip3 install cmake==3.28.3 cmake_format black regex
+apt install --no-install-recommends -y clang-format-14 python3-pip git make ssh
+pip3 install --break-system-packages cmake==3.28.3 cmake_format black regex
 pip3 cache purge
 apt purge --auto-remove -y python3-pip
-update-alternatives --install /usr/bin/clang-format clang-format "$(command -v clang-format-12)" 12
+update-alternatives --install /usr/bin/clang-format clang-format "$(command -v clang-format-14)" 14
 apt clean


### PR DESCRIPTION
We're currently on 22.04 which is from a 2022, this will allow us to use later versions of clang-format.