### PR TITLE
Fix timezone conversion bug in date_trunc

### DIFF
--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -1640,6 +1640,7 @@ TEST_F(DateTimeFunctionsTest, dateTrunc) {
   EXPECT_EQ(std::nullopt, dateTrunc("second", std::nullopt));
   EXPECT_EQ(Timestamp(0, 0), dateTrunc("second", Timestamp(0, 0)));
   EXPECT_EQ(Timestamp(0, 0), dateTrunc("second", Timestamp(0, 123)));
+
   EXPECT_EQ(Timestamp(-57600, 0), dateTrunc("day", Timestamp(0, 0)));
   EXPECT_EQ(
       Timestamp(998474645, 0),
@@ -1665,6 +1666,13 @@ TEST_F(DateTimeFunctionsTest, dateTrunc) {
   EXPECT_EQ(
       Timestamp(978336000, 0),
       dateTrunc("year", Timestamp(998'474'645, 321'001'234)));
+
+  // Check that truncation during daylight saving transition where conversions
+  // may be ambiguous return the right values.
+  EXPECT_EQ(
+      Timestamp(1667725200, 0), dateTrunc("hour", Timestamp(1667725200, 0)));
+  EXPECT_EQ(
+      Timestamp(1667725200, 0), dateTrunc("minute", Timestamp(1667725200, 0)));
 
   setQueryTimeZone("Asia/Kolkata");
 


### PR DESCRIPTION
Summary:
date_trunc was incorrectly handling truncations during the daylight
savings transition. Since conversions during these transitions may be
ambiguous, Presto semantic is to always take the earliest UTC timestamp.

For truncations that should happen in the "latest" side of an ambiguous
conversion, converting to UTC and back would result in the truncation being
done is the earliest version of that timestamp. The bug only applied to "minute"
and "hour" truncations, naturally.

Reviewed By: mbasmanova

Differential Revision: D58467148
