### PR TITLE
Unescape url after extracting parameters

### DIFF
--- a/velox/functions/prestosql/URLFunctions.h
+++ b/velox/functions/prestosql/URLFunctions.h
@@ -423,7 +423,7 @@ struct UrlExtractParameterFunction {
           auto key = detail::submatch((*it), 2);
           if (param.compare(key) == 0) {
             auto value = detail::submatch((*it), 3);
-            result.setNoCopy(value);
+            detail::urlUnescape(result, value);
             return true;
           }
         }

--- a/velox/functions/prestosql/tests/URLFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/URLFunctionsTest.cpp
@@ -157,6 +157,10 @@ TEST_F(URLFunctionsTest, extractParameter) {
       extractParam(
           "http://example.com/path1/p.php?k1=v1&k2=v2&k3&k4#Ref1", "k1"),
       "v1");
+  // Tests unescaping functionality.
+  EXPECT_EQ(
+      extractParam("http://example.com/path1/p.php?k1=v1%2Bv2#Ref1", "k1"),
+      "v1+v2");
   EXPECT_EQ(
       extractParam(
           "http://example.com/path1/p.php?k1=v1&k2=v2&k3&k4#Ref1", "k3"),


### PR DESCRIPTION
Summary: The extractParam function now includes unescaping functionality for URL parameters.

Differential Revision: D58559892
