### PR TITLE
Capture MemoryArbitrationContext and ThreadDebugInfo in AsyncSource and restore them when invoking make

### DIFF
--- a/velox/common/base/tests/AsyncSourceTest.cpp
+++ b/velox/common/base/tests/AsyncSourceTest.cpp
@@ -23,6 +23,7 @@
 #include <chrono>
 #include <thread>
 #include "velox/common/base/Exceptions.h"
+#include "velox/common/memory/Memory.h"
 
 using namespace facebook::velox;
 using namespace std::chrono_literals;
@@ -243,4 +244,73 @@ TEST(AsyncSourceTest, close) {
   EXPECT_EQ(DataCounter::numCreatedDataCounters(), 1);
   EXPECT_EQ(DataCounter::numDeletedDataCounters(), 1);
   thread1.join();
+}
+
+void verifyContexts(
+    const std::string& expectedPoolName,
+    const std::string& expectedTaskId) {
+  EXPECT_EQ(
+      memory::memoryArbitrationContext()->requestor->name(), expectedPoolName);
+  EXPECT_EQ(process::GetThreadDebugInfo()->taskId_, expectedTaskId);
+}
+
+TEST(AsyncSourceTest, emptyContexts) {
+  memory::MemoryManager::testingSetInstance({});
+
+  EXPECT_EQ(memory::memoryArbitrationContext(), nullptr);
+  EXPECT_EQ(process::GetThreadDebugInfo(), nullptr);
+
+  AsyncSource<bool> src([]() {
+    // The Contexts at the time this was created were null so we should inherit
+    // them from the caller.
+    verifyContexts("test", "task_id");
+
+    return std::make_unique<bool>(true);
+  });
+
+  auto pool = memory::MemoryManager::getInstance()->addRootPool("test");
+  memory::ScopedMemoryArbitrationContext scopedMemoryArbitrationContext(
+      pool.get());
+  process::ThreadDebugInfo debugInfo{"query_id", "task_id", nullptr};
+  process::ScopedThreadDebugInfo scopedDebugInfo(debugInfo);
+
+  verifyContexts("test", "task_id");
+
+  ASSERT_TRUE(*src.move());
+
+  verifyContexts("test", "task_id");
+}
+
+TEST(AsyncSourceTest, setContexts) {
+  memory::MemoryManager::testingSetInstance({});
+
+  auto pool1 = memory::MemoryManager::getInstance()->addRootPool("test1");
+  process::ThreadDebugInfo debugInfo1{"query_id1", "task_id1", nullptr};
+
+  std::unique_ptr<AsyncSource<bool>> src;
+  memory::ScopedMemoryArbitrationContext scopedMemoryArbitrationContext1(
+      pool1.get());
+  process::ScopedThreadDebugInfo scopedDebugInfo1(debugInfo1);
+
+  verifyContexts("test1", "task_id1");
+
+  src = std::make_unique<AsyncSource<bool>>(([]() {
+    // The Contexts at the time this was created were set so we should have
+    // the same contexts when this is executed.
+    verifyContexts("test1", "task_id1");
+
+    return std::make_unique<bool>(true);
+  }));
+
+  auto pool2 = memory::MemoryManager::getInstance()->addRootPool("test2");
+  memory::ScopedMemoryArbitrationContext scopedMemoryArbitrationContext2(
+      pool2.get());
+  process::ThreadDebugInfo debugInfo2{"query_id2", "task_id2", nullptr};
+  process::ScopedThreadDebugInfo scopedDebugInfo2(debugInfo2);
+
+  verifyContexts("test2", "task_id2");
+
+  ASSERT_TRUE(*src->move());
+
+  verifyContexts("test2", "task_id2");
 }

--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -125,6 +125,7 @@ class StatsReporterTest : public testing::Test {
   void SetUp() override {
     reporter_ = std::dynamic_pointer_cast<TestReporter>(
         folly::Singleton<BaseStatsReporter>::try_get());
+    reporter_->clear();
   }
   void TearDown() override {
     reporter_->clear();

--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -489,11 +489,20 @@ ScopedMemoryArbitrationContext::ScopedMemoryArbitrationContext(
   arbitrationCtx = &currentArbitrationCtx_;
 }
 
+ScopedMemoryArbitrationContext::ScopedMemoryArbitrationContext(
+    const MemoryArbitrationContext* contextToRestore)
+    : savedArbitrationCtx_(arbitrationCtx) {
+  if (contextToRestore != nullptr) {
+    currentArbitrationCtx_ = *contextToRestore;
+    arbitrationCtx = &currentArbitrationCtx_;
+  }
+}
+
 ScopedMemoryArbitrationContext::~ScopedMemoryArbitrationContext() {
   arbitrationCtx = savedArbitrationCtx_;
 }
 
-MemoryArbitrationContext* memoryArbitrationContext() {
+const MemoryArbitrationContext* memoryArbitrationContext() {
   return arbitrationCtx;
 }
 

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -18,7 +18,6 @@
 
 #include <vector>
 
-#include "velox/common/base/AsyncSource.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/Portability.h"
 #include "velox/common/base/SuccinctPrinter.h"
@@ -462,6 +461,14 @@ struct MemoryArbitrationContext {
 class ScopedMemoryArbitrationContext {
  public:
   explicit ScopedMemoryArbitrationContext(const MemoryPool* requestor);
+
+  // Can be used to restore a previously captured MemoryArbitrationContext.
+  // contextToRestore can be nullptr if there was no context at the time it was
+  // captured, in which case arbitrationCtx is unchanged upon
+  // contruction/destruction of this object.
+  explicit ScopedMemoryArbitrationContext(
+      const MemoryArbitrationContext* contextToRestore);
+
   ~ScopedMemoryArbitrationContext();
 
  private:
@@ -471,27 +478,10 @@ class ScopedMemoryArbitrationContext {
 
 /// Returns the memory arbitration context set by a per-thread local variable if
 /// the running thread is under memory arbitration processing.
-MemoryArbitrationContext* memoryArbitrationContext();
+const MemoryArbitrationContext* memoryArbitrationContext();
 
 /// Returns true if the running thread is under memory arbitration or not.
 bool underMemoryArbitration();
-
-/// Creates an async memory reclaim task with memory arbitration context set.
-/// This is to avoid recursive memory arbitration during memory reclaim.
-///
-/// NOTE: this must be called under memory arbitration.
-template <typename Item>
-std::shared_ptr<AsyncSource<Item>> createAsyncMemoryReclaimTask(
-    std::function<std::unique_ptr<Item>()> task) {
-  auto* arbitrationCtx = memory::memoryArbitrationContext();
-  VELOX_CHECK_NOT_NULL(arbitrationCtx);
-  return std::make_shared<AsyncSource<Item>>(
-      [asyncTask = std::move(task), arbitrationCtx]() -> std::unique_ptr<Item> {
-        VELOX_CHECK_NOT_NULL(arbitrationCtx);
-        memory::ScopedMemoryArbitrationContext ctx(arbitrationCtx->requestor);
-        return asyncTask();
-      });
-}
 
 /// The function triggers memory arbitration by shrinking memory pools from
 /// 'manager' by invoking shrinkPools API. If 'manager' is not set, then it

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -601,7 +601,7 @@ TEST_F(MockSharedArbitrationTest, asyncArbitrationWork) {
 
           explicit Result(bool _succeeded) : succeeded(_succeeded) {}
         };
-        auto asyncReclaimTask = createAsyncMemoryReclaimTask<Result>([&]() {
+        auto asyncReclaimTask = std::make_shared<AsyncSource<Result>>([&]() {
           memoryOp->allocate(poolCapacity);
           return std::make_unique<Result>(true);
         });

--- a/velox/common/process/ThreadDebugInfo.cpp
+++ b/velox/common/process/ThreadDebugInfo.cpp
@@ -53,10 +53,19 @@ static void printCurrentQueryId() {
 const ThreadDebugInfo* GetThreadDebugInfo() {
   return threadDebugInfo;
 }
+
 ScopedThreadDebugInfo::ScopedThreadDebugInfo(
-    const ThreadDebugInfo& localDebugInfo) {
-  prevThreadDebugInfo_ = threadDebugInfo;
+    const ThreadDebugInfo& localDebugInfo)
+    : prevThreadDebugInfo_(threadDebugInfo) {
   threadDebugInfo = &localDebugInfo;
+}
+
+ScopedThreadDebugInfo::ScopedThreadDebugInfo(
+    const ThreadDebugInfo* localDebugInfo)
+    : prevThreadDebugInfo_(threadDebugInfo) {
+  if (localDebugInfo != nullptr) {
+    threadDebugInfo = localDebugInfo;
+  }
 }
 
 ScopedThreadDebugInfo::~ScopedThreadDebugInfo() {

--- a/velox/common/process/ThreadDebugInfo.h
+++ b/velox/common/process/ThreadDebugInfo.h
@@ -34,6 +34,9 @@ struct ThreadDebugInfo {
 class ScopedThreadDebugInfo {
  public:
   explicit ScopedThreadDebugInfo(const ThreadDebugInfo& localDebugInfo);
+
+  explicit ScopedThreadDebugInfo(const ThreadDebugInfo* localDebugInfo);
+
   ~ScopedThreadDebugInfo();
 
  private:

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -1114,7 +1114,7 @@ void HashBuild::reclaim(
   for (auto* op : operators) {
     HashBuild* buildOp = static_cast<HashBuild*>(op);
     spillTasks.push_back(
-        memory::createAsyncMemoryReclaimTask<SpillResult>([buildOp]() {
+        std::make_shared<AsyncSource<SpillResult>>([buildOp]() {
           try {
             buildOp->spiller_->spill();
             buildOp->table_->clear();

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1667,7 +1667,7 @@ void HashProbe::spillOutput(const std::vector<HashProbe*>& operators) {
   for (auto* op : operators) {
     HashProbe* probeOp = static_cast<HashProbe*>(op);
     spillTasks.push_back(
-        memory::createAsyncMemoryReclaimTask<SpillResult>([probeOp]() {
+        std::make_shared<AsyncSource<SpillResult>>([probeOp]() {
           try {
             probeOp->spillOutput();
             return std::make_unique<SpillResult>(nullptr);
@@ -1769,8 +1769,8 @@ SpillPartitionSet HashProbe::spillTable() {
     if (rowContainer->numRows() == 0) {
       continue;
     }
-    spillTasks.push_back(memory::createAsyncMemoryReclaimTask<SpillResult>(
-        [this, rowContainer]() {
+    spillTasks.push_back(
+        std::make_shared<AsyncSource<SpillResult>>([this, rowContainer]() {
           try {
             return std::make_unique<SpillResult>(spillTable(rowContainer));
           } catch (const std::exception& e) {

--- a/velox/exec/MemoryReclaimer.cpp
+++ b/velox/exec/MemoryReclaimer.cpp
@@ -122,7 +122,7 @@ uint64_t ParallelMemoryReclaimer::reclaim(
     if (candidate.reclaimableBytes == 0) {
       continue;
     }
-    reclaimTasks.push_back(memory::createAsyncMemoryReclaimTask<ReclaimResult>(
+    reclaimTasks.push_back(std::make_shared<AsyncSource<ReclaimResult>>(
         [&, reclaimPool = candidate.pool]() {
           try {
             Stats reclaimStats;


### PR DESCRIPTION
Summary:
In AsyncSource, at the time make is invoked, we've lost the MemoryArbitrationContext and
ThreadDebugInfo that were in scope at the time it was created.

To help provide debugging context, this diff modifies AsyncSource to capture and restore that info
so that it can be used if "make" should fail.

This was already being done for MemoryArbitrationContext inside of
createAsyncMemoryReclaimTask, this diff does the same thing in a more general way.

This was inspired by a crash that occurred in Prestissimo while spilling inside an AsyncSource, the
relevant debug info was lost.

Differential Revision: D58558331
