### PR TITLE
Fix date_add() semantic on daylight savings boundaries

### DIFF
--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -1118,7 +1118,7 @@ struct DateTruncFunction : public TimestampWithTimezoneSupport<T> {
         Timestamp::fromMillis(Timestamp::calendarUtcToEpoch(dateTime) * 1000);
     timestamp.toGMT(unpackZoneKeyId(timestampWithTimezone));
 
-    result = pack(timestamp.toMillis(), unpackZoneKeyId(timestampWithTimezone));
+    result = pack(timestamp, unpackZoneKeyId(timestampWithTimezone));
   }
 
  private:
@@ -1207,9 +1207,8 @@ struct DateAddFunction : public TimestampWithTimezoneSupport<T> {
       const arg_type<Varchar>& unitString,
       const int64_t value,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
-    const auto unit = unit_.has_value()
-        ? unit_.value()
-        : fromDateTimeUnitString(unitString, true /*throwIfInvalid*/).value();
+    const auto unit = unit_.value_or(
+        fromDateTimeUnitString(unitString, true /*throwIfInvalid*/).value());
 
     if (value != (int32_t)value) {
       VELOX_UNSUPPORTED("integer overflow");
@@ -1443,7 +1442,7 @@ struct FromIso8601Timestamp {
       tzID = sessionTzID_;
     }
     ts.toGMT(tzID);
-    result = pack(ts.toMillis(), tzID);
+    result = pack(ts, tzID);
     return Status::OK();
   }
 
@@ -1614,7 +1613,7 @@ struct ParseDateTimeFunction {
         ? dateTimeResult->timezoneId
         : sessionTzID_.value_or(0);
     dateTimeResult->timestamp.toGMT(timezoneId);
-    result = pack(dateTimeResult->timestamp.toMillis(), timezoneId);
+    result = pack(dateTimeResult->timestamp, timezoneId);
     return Status::OK();
   }
 };

--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -204,13 +204,8 @@ FOLLY_ALWAYS_INLINE int64_t addToTimestampWithTimezone(
     const DateTimeUnit unit,
     const int32_t value) {
   auto timestamp = unpackTimestampUtc(timestampWithTimezone);
-  auto tzID = unpackZoneKeyId(timestampWithTimezone);
-  timestamp.toTimezone(tzID);
-
-  auto finalTimestamp = addToTimestamp(timestamp, unit, value);
-
-  finalTimestamp.toGMT(tzID);
-  return pack(finalTimestamp.toMillis(), tzID);
+  auto finalTimeStamp = addToTimestamp(timestamp, unit, (int32_t)value);
+  return pack(finalTimeStamp, unpackZoneKeyId(timestampWithTimezone));
 }
 
 FOLLY_ALWAYS_INLINE int64_t diffTimestamp(

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
@@ -142,6 +142,10 @@ inline int64_t pack(int64_t millisUtc, int16_t timeZoneKey) {
   return (millisUtc << kMillisShift) | (timeZoneKey & kTimezoneMask);
 }
 
+inline int64_t pack(const Timestamp& timestamp, int16_t timeZoneKey) {
+  return pack(timestamp.toMillis(), timeZoneKey);
+}
+
 inline Timestamp unpackTimestampUtc(int64_t dateTimeWithTimeZone) {
   return Timestamp::fromMillis(unpackMillisUtc(dateTimeWithTimeZone));
 }


### PR DESCRIPTION
Summary:
date_add() used to apply the timestamp deltas based on the local
timestamp, which makes the conversion linear, but does not follow Presto's
semantic. Changing it to follow Presto semantic. Applying the same 
rules to other timestamp and interval arithmetic functions.

More context on: https://github.com/facebookincubator/velox/issues/10163

Reviewed By: mbasmanova

Differential Revision: D58479195
