### PR TITLE
Add 'fail' Presto function

### DIFF
--- a/velox/docs/functions.rst
+++ b/velox/docs/functions.rst
@@ -22,6 +22,7 @@ Presto Functions
     functions/presto/window
     functions/presto/hyperloglog
     functions/presto/uuid
+    functions/presto/misc
 
 Here is a list of all scalar and aggregate Presto functions available in Velox.
 Function names link to function descriptions. Check out coverage maps

--- a/velox/docs/functions/presto/misc.rst
+++ b/velox/docs/functions/presto/misc.rst
@@ -1,0 +1,20 @@
+=======================
+Miscellaneous Functions
+=======================
+
+.. function:: fail(message)
+
+    Throws user error with the specified message.
+
+.. function:: fail(code, message)
+
+    Throws user error with the specified message. Ignores 'code' argument.
+
+.. function:: fail(json)
+
+    Throws user error with the message specified in 'message' field of the JSON.
+
+.. function:: fail(code, message)
+
+    Throws user error with the message specified in 'message' field of the JSON.
+    Ignores 'code' argument.

--- a/velox/docs/functions/presto/uuid.rst
+++ b/velox/docs/functions/presto/uuid.rst
@@ -1,5 +1,5 @@
 ==============
-UUID functions
+UUID Functions
 ==============
 
 .. function:: uuid() -> uuid

--- a/velox/functions/prestosql/Fail.h
+++ b/velox/functions/prestosql/Fail.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/functions/Macros.h"
+#include "velox/functions/prestosql/json/SIMDJsonExtractor.h"
+#include "velox/functions/prestosql/json/SIMDJsonWrapper.h"
+#include "velox/functions/prestosql/types/JsonType.h"
+
+namespace facebook::velox::functions {
+
+template <typename TExec>
+struct FailFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  FOLLY_ALWAYS_INLINE Status
+  call(out_type<UnknownValue>& /*result*/, const arg_type<Varchar>& message) {
+    if (threadSkipErrorDetails()) {
+      return Status::UserError();
+    }
+
+    return Status::UserError("{}", message);
+  }
+
+  FOLLY_ALWAYS_INLINE Status call(
+      out_type<UnknownValue>& result,
+      const arg_type<int32_t>& /*errorCode*/,
+      const arg_type<Varchar>& message) {
+    return call(result, message);
+  }
+};
+
+template <typename TExec>
+struct FailFromJsonFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  FOLLY_ALWAYS_INLINE Status
+  call(out_type<UnknownValue>& /*result*/, const arg_type<Json>& json) {
+    if (threadSkipErrorDetails()) {
+      return Status::UserError();
+    }
+
+    // Extract 'message' field from 'json'.
+    std::string_view message;
+    if (extractMessage(json, message) != simdjson::SUCCESS) {
+      return Status::UserError(
+          "Cannot extract 'message' from the JSON: {}", json);
+    }
+
+    return Status::UserError("{}", message);
+  }
+
+  FOLLY_ALWAYS_INLINE Status call(
+      out_type<UnknownValue>& result,
+      const arg_type<int32_t>& /*errorCode*/,
+      const arg_type<Json>& json) {
+    return call(result, json);
+  }
+
+ private:
+  static simdjson::error_code extractMessage(
+      const StringView& json,
+      std::string_view& message) {
+    simdjson::padded_string paddedJson(json.data(), json.size());
+
+    SIMDJSON_ASSIGN_OR_RAISE(auto jsonDoc, simdjsonParse(paddedJson));
+
+    SIMDJSON_ASSIGN_OR_RAISE(message, jsonDoc["message"].get_string());
+
+    return simdjson::SUCCESS;
+  }
+};
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
@@ -17,13 +17,23 @@
 #include "velox/functions/Registerer.h"
 #include "velox/functions/lib/IsNull.h"
 #include "velox/functions/prestosql/Cardinality.h"
+#include "velox/functions/prestosql/Fail.h"
 #include "velox/functions/prestosql/GreatestLeast.h"
 #include "velox/functions/prestosql/InPredicate.h"
 
 namespace facebook::velox::functions {
 
+namespace {
+
+void registerFailFunction(const std::vector<std::string>& names) {
+  registerFunction<FailFunction, UnknownValue, Varchar>(names);
+  registerFunction<FailFunction, UnknownValue, int32_t, Varchar>(names);
+  registerFunction<FailFromJsonFunction, UnknownValue, Json>(names);
+  registerFunction<FailFromJsonFunction, UnknownValue, int32_t, Json>(names);
+}
+
 template <typename T>
-inline void registerGreatestLeastFunction(const std::string& prefix) {
+void registerGreatestLeastFunction(const std::string& prefix) {
   registerFunction<ParameterBinder<GreatestFunction, T>, T, T, Variadic<T>>(
       {prefix + "greatest"});
 
@@ -31,7 +41,7 @@ inline void registerGreatestLeastFunction(const std::string& prefix) {
       {prefix + "least"});
 }
 
-inline void registerAllGreatestLeastFunctions(const std::string& prefix) {
+void registerAllGreatestLeastFunctions(const std::string& prefix) {
   registerGreatestLeastFunction<bool>(prefix);
   registerGreatestLeastFunction<int8_t>(prefix);
   registerGreatestLeastFunction<int16_t>(prefix);
@@ -45,6 +55,7 @@ inline void registerAllGreatestLeastFunctions(const std::string& prefix) {
   registerGreatestLeastFunction<Date>(prefix);
   registerGreatestLeastFunction<Timestamp>(prefix);
 }
+} // namespace
 
 extern void registerSubscriptFunction(
     const std::string& name,
@@ -81,6 +92,8 @@ void registerGeneralFunctions(const std::string& prefix) {
       {prefix + "cardinality"});
   registerFunction<CardinalityFunction, int64_t, Map<Any, Any>>(
       {prefix + "cardinality"});
+
+  registerFailFunction({prefix + "fail"});
 
   registerAllSpecialFormGeneralFunctions();
 }

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -57,6 +57,7 @@ add_executable(
   DateTimeFunctionsTest.cpp
   DecimalArithmeticTest.cpp
   ElementAtTest.cpp
+  FailTest.cpp
   FindFirstTest.cpp
   FromUtf8Test.cpp
   GreatestLeastTest.cpp

--- a/velox/functions/prestosql/tests/FailTest.cpp
+++ b/velox/functions/prestosql/tests/FailTest.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/types/JsonType.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+
+namespace facebook::velox::functions {
+
+namespace {
+
+class FailTest : public functions::test::FunctionBaseTest {};
+
+TEST_F(FailTest, basic) {
+  auto message = std::optional("test error message");
+  VELOX_ASSERT_USER_THROW(
+      evaluateOnce<UnknownValue>("fail(c0)", message), message.value());
+
+  EXPECT_EQ(std::nullopt, evaluateOnce<UnknownValue>("try(fail(c0))", message));
+
+  VELOX_ASSERT_USER_THROW(
+      evaluateOnce<UnknownValue>("fail(123::integer, c0)", message),
+      message.value());
+
+  EXPECT_EQ(
+      std::nullopt,
+      evaluateOnce<UnknownValue>("try(fail(123::integer, c0))", message));
+}
+
+TEST_F(FailTest, json) {
+  auto json =
+      std::optional(R"({"code": 123, "message": "test error message"})");
+
+  VELOX_ASSERT_USER_THROW(
+      evaluateOnce<UnknownValue>("fail(c0)", JSON(), json),
+      "test error message");
+
+  EXPECT_EQ(
+      std::nullopt, evaluateOnce<UnknownValue>("try(fail(c0))", JSON(), json));
+
+  VELOX_ASSERT_USER_THROW(
+      evaluateOnce<UnknownValue>("fail(123::integer, c0)", JSON(), json),
+      "test error message");
+
+  EXPECT_EQ(
+      std::nullopt,
+      evaluateOnce<UnknownValue>("try(fail(123::integer, c0))", JSON(), json));
+}
+
+TEST_F(FailTest, invalidJson) {
+  // Invalid JSON.
+  VELOX_ASSERT_USER_THROW(
+      evaluateOnce<UnknownValue>(
+          "fail(c0)", JSON(), std::optional("not a valid JSON")),
+      "Cannot extract 'message' from the JSON");
+
+  // Valid JSON with missing 'message' field.
+  VELOX_ASSERT_USER_THROW(
+      evaluateOnce<UnknownValue>("fail(c0)", JSON(), std::optional("{}")),
+      "Cannot extract 'message' from the JSON");
+
+  VELOX_ASSERT_USER_THROW(
+      evaluateOnce<UnknownValue>(
+          "fail(c0)", JSON(), std::optional(R"({"code": 123})")),
+      "Cannot extract 'message' from the JSON");
+
+  // Valid JSON with 'message' field that's not string.
+  VELOX_ASSERT_USER_THROW(
+      evaluateOnce<UnknownValue>(
+          "fail(c0)",
+          JSON(),
+          std::optional(R"({"code": 123, "message": [1, 2, 3]})")),
+      "Cannot extract 'message' from the JSON");
+}
+
+} // namespace
+} // namespace facebook::velox::functions


### PR DESCRIPTION
Summary:
Fail Presto function throws user error with the specified error message.

Presto Java supports 4 signatures:
- message:varchar
- code:integer, message:varchar
- error:json
- code:integer, error:json

Code argument refers to Presto error code which doesn't exist in Velox,
hence, Velox ignores that argument.

Error json corresponds to Java class FailureInfo with multiple fields that
allow to construct a Java exception. Velox ignores all fields except for 'message'.

```
    JsonCreator
    public FailureInfo(
            JsonProperty("type") String type,
            JsonProperty("message") String message,
            JsonProperty("cause") FailureInfo cause,
            JsonProperty("suppressed") List<FailureInfo> suppressed,
            JsonProperty("stack") List<String> stack,
            JsonProperty("errorLocation") Nullable ErrorLocation errorLocation)
```

Differential Revision: D58571813
