### PR TITLE
Add support for DECIMAL input to greatest and least Spark functions

### DIFF
--- a/velox/functions/sparksql/LeastGreatest.cpp
+++ b/velox/functions/sparksql/LeastGreatest.cpp
@@ -161,6 +161,7 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> leastSignatures() {
                               .integerVariable("s")
                               .returnType("decimal(p,s)")
                               .argumentType("decimal(p,s)")
+                              .argumentType("decimal(p,s)")
                               .variableArity()
                               .build());
   return signatures;

--- a/velox/functions/sparksql/LeastGreatest.cpp
+++ b/velox/functions/sparksql/LeastGreatest.cpp
@@ -109,6 +109,7 @@ std::shared_ptr<exec::VectorFunction> makeImpl(
     SCALAR_CASE(SMALLINT)
     SCALAR_CASE(INTEGER)
     SCALAR_CASE(BIGINT)
+    SCALAR_CASE(HUGEINT)
     SCALAR_CASE(REAL)
     SCALAR_CASE(DOUBLE)
     SCALAR_CASE(VARCHAR)
@@ -155,6 +156,13 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> leastSignatures() {
                                 .variableArity()
                                 .build());
   }
+  signatures.emplace_back(exec::FunctionSignatureBuilder()
+                              .integerVariable("p")
+                              .integerVariable("s")
+                              .returnType("decimal(p,s)")
+                              .argumentType("decimal(p,s)")
+                              .variableArity()
+                              .build());
   return signatures;
 }
 

--- a/velox/functions/sparksql/LeastGreatest.h
+++ b/velox/functions/sparksql/LeastGreatest.h
@@ -27,6 +27,7 @@ namespace facebook::velox::functions::sparksql {
 /// SMALLINT
 /// INTEGER
 /// BIGINT
+/// HUGEINT
 /// REAL
 /// DOUBLE
 /// BOOLEAN

--- a/velox/functions/sparksql/tests/LeastGreatestTest.cpp
+++ b/velox/functions/sparksql/tests/LeastGreatestTest.cpp
@@ -179,6 +179,14 @@ TEST_F(LeastTest, date) {
   EXPECT_EQ(least<int32_t>(100, 1000, 10000, DATE()), 100);
 }
 
+TEST_F(LeastTest, decimal) {
+  flat<int64_t>(DECIMAL(6, 2));
+  constant<int64_t>(DECIMAL(6, 2));
+
+  flat<int128_t>(DECIMAL(28, 12));
+  constant<int128_t>(DECIMAL(28, 12));
+}
+
 class GreatestTest : public SparkFunctionBaseTest {
  protected:
   template <typename T>
@@ -338,6 +346,14 @@ TEST_F(GreatestTest, timestamp) {
 
 TEST_F(GreatestTest, date) {
   EXPECT_EQ(greatest<int32_t>(100, 1000, 10000, DATE()), 10000);
+}
+
+TEST_F(GreatestTest, decimal) {
+  flat<int64_t>(DECIMAL(6, 2));
+  constant<int64_t>(DECIMAL(6, 2));
+
+  flat<int128_t>(DECIMAL(28, 12));
+  constant<int128_t>(DECIMAL(28, 12));
 }
 
 } // namespace


### PR DESCRIPTION
Add support for DECIMAL input to greatest and least Spark functions.
Spark adds cast to handle different decimal types during planning, so we don't 
need to handle the type difference in functions.
https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala#L482
Example:
```
spark.sql("""
SELECT *
    FROM VALUES (
        CAST(5.345 AS DECIMAL(6, 2)),
        CAST(5.35 AS DECIMAL(5, 4)))) AS data(a, b);
""").write.mode("overwrite").parquet("decimal_table")
spark.read.parquet("decimal_table").createOrReplaceTempView("decimal_table")
val df = spark.sql("SELECT greatest(a, b) from decimal_table")
```
`Project [greatest(cast(a#6 as decimal(8,4)), cast(b#7 as decimal(8,4))) AS greatest(a, b)#10]`