### PR TITLE
Add extra info to Profiler, Hooks for memory stats recording

### DIFF
--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -400,6 +400,11 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
   /// thread. The message is cleared after return.
   std::string getAndClearFailureMessage();
 
+  void getTracingHooks(
+      std::function<void()>& init,
+      std::function<std::string()>& report,
+      std::function<int64_t()> ioVolume = nullptr);
+
  protected:
   explicit MemoryAllocator() = default;
 

--- a/velox/common/process/Profiler.h
+++ b/velox/common/process/Profiler.h
@@ -29,7 +29,10 @@ namespace facebook::velox::process {
 class Profiler {
  public:
   /// Starts periodic production of perf reports.
-  static void start(const std::string& path);
+  static void start(
+      const std::string& path,
+      std::function<void()> extraStart = nullptr,
+      std::function<std::string()> extraReport = nullptr);
 
   // Stops profiling background associated threads. Threads are stopped on
   // return.
@@ -69,6 +72,9 @@ class Profiler {
 
   // CPU time at last periodic check.
   static int64_t cpuAtLastCheck_;
+
+  static std::function<void()> startExtra_;
+  static std::function<std::string()> extraReport_;
 };
 
 } // namespace facebook::velox::process

--- a/velox/exec/benchmarks/HashTableBenchmark.cpp
+++ b/velox/exec/benchmarks/HashTableBenchmark.cpp
@@ -28,11 +28,17 @@
 #include <gtest/gtest.h>
 #include <memory>
 
+#include "velox/common/process/Profiler.h"
+
 DEFINE_int64(custom_size, 0, "Custom number of entries");
 DEFINE_int32(custom_hit_rate, 0, "Percentage of hits in custom test");
 DEFINE_int32(custom_key_spacing, 1, "Spacing between key values");
 
 DEFINE_int32(custom_num_ways, 10, "Number of build threads");
+
+DEFINE_bool(profile, false, "Generate perf profiles and memory stats");
+
+DECLARE_bool(velox_time_allocations);
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
@@ -617,7 +623,18 @@ int main(int argc, char** argv) {
   options.useMmapArena = true;
   options.mmapArenaCapacityRatio = 1;
   memory::MemoryManager::initialize(options);
-
+  if (FLAGS_profile) {
+    auto allocator = memory::MemoryManager::getInstance()->allocator();
+    std::function<void()> reportInit;
+    std::function<std::string()> report;
+    allocator->getTracingHooks(reportInit, report, nullptr);
+    FLAGS_profiler_check_interval_seconds = 20;
+    FLAGS_profiler_min_cpu_pct = 50;
+    FLAGS_profiler_max_sample_seconds = 30;
+    FLAGS_velox_time_allocations = true;
+    filesystems::registerLocalFileSystem();
+    process::Profiler::start("/tmp/hashprof", reportInit, report);
+  }
   auto bm = std::make_unique<HashTableBenchmark>();
   std::vector<HashTableBenchmarkRun> results;
 


### PR DESCRIPTION
Adds functions for initializing and reporting on a profiled interval with process::Profiler. This can annotate a perf profile with other information captured from inside the Velox process.

Adds hooks reporting memory allocation sizes and times to MemoryAllocator. These can be installed into process::Profiler to produce memory volume stats alongside profiles.