### PR TITLE
Remove unnecessary comment from BitPackDecoder.h

### DIFF
--- a/velox/dwio/common/BitPackDecoder.h
+++ b/velox/dwio/common/BitPackDecoder.h
@@ -21,7 +21,7 @@
 #include "velox/vector/TypeAliases.h"
 
 #include <folly/Range.h>
-#include <xsimd/config/xsimd_config.hpp> // @manual
+#include <xsimd/config/xsimd_config.hpp>
 
 namespace facebook::velox::dwio::common {
 


### PR DESCRIPTION
Summary:
BitPackDecoder.h has a comment on one of its include files.  This is a directive for Buck which Meta uses internally, and 
isn't needed anymore, so we can remove it.

Differential Revision: D58592995
