### PR TITLE
Fix Velox counts incomplete UTF-8 chars differently than Presto Java

### DIFF
--- a/velox/functions/lib/string/StringCore.h
+++ b/velox/functions/lib/string/StringCore.h
@@ -222,10 +222,15 @@ lengthUnicode(const char* inputBuffer, size_t bufferLength) {
   auto currentChar = inputBuffer;
   int64_t size = 0;
   while (currentChar < buffEndAddress) {
-    auto chrOffset = utf8proc_char_length(currentChar);
-    // Skip bad byte if we get utf length < 0.
-    currentChar += UNLIKELY(chrOffset < 0) ? 1 : chrOffset;
-    size++;
+    // This function detects bytes that come after the first byte in a
+    // multi-byte UTF-8 character (provided that the string is valid UTF-8). We
+    // increment size only for the first byte so that we treat all bytes as part
+    // of a single character.
+    if (!utf_cont(*currentChar)) {
+      size++;
+    }
+
+    currentChar++;
   }
   return size;
 }
@@ -474,12 +479,30 @@ inline static size_t replace(
 /// If a bad unicode byte is encountered, then we skip that bad byte and
 /// count that as one codepoint.
 template <bool isAscii>
-static inline std::pair<size_t, size_t>
-getByteRange(const char* str, size_t startCharPosition, size_t length) {
-  if (startCharPosition < 1 && length > 0) {
-    throw std::invalid_argument(
-        "start position must be >= 1 and length must be > 0");
+static inline std::pair<size_t, size_t> getByteRange(
+    const char* str,
+    size_t strLength,
+    size_t startCharPosition,
+    size_t length) {
+  // If the length is 0, then we return an empty range directly.
+  if (length == 0) {
+    return std::make_pair(0, 0);
   }
+
+  if (startCharPosition < 1) {
+    throw std::invalid_argument("start position must be >= 1");
+  }
+
+  VELOX_CHECK_GE(
+      strLength,
+      length,
+      "The length of the string must be at least as large as the length of the substring requested.");
+
+  VELOX_CHECK_GE(
+      strLength,
+      startCharPosition,
+      "The offset of the substring requested must be within the string.");
+
   if constexpr (isAscii) {
     return std::make_pair(
         startCharPosition - 1, startCharPosition + length - 1);
@@ -487,19 +510,43 @@ getByteRange(const char* str, size_t startCharPosition, size_t length) {
     size_t startByteIndex = 0;
     size_t nextCharOffset = 0;
 
+    // Skips any Unicode continuation bytes. These are bytes that appear after
+    // the first byte in a multi-byte Unicode character.  They do not count
+    // towards the position in or length of a string.
+    auto skipContBytes = [&]() {
+      while (nextCharOffset < strLength && utf_cont(str[nextCharOffset])) {
+        nextCharOffset++;
+      }
+    };
+
+    // Skip any invalid continuation bytes at the beginning of the string.
+    skipContBytes();
+
     // Find startByteIndex
-    for (auto i = 0; i < startCharPosition - 1; i++) {
-      auto increment = utf8proc_char_length(&str[nextCharOffset]);
-      nextCharOffset += UNLIKELY(increment < 0) ? 1 : increment;
+    for (auto i = 0; nextCharOffset < strLength && i < startCharPosition - 1;
+         i++) {
+      nextCharOffset++;
+
+      skipContBytes();
     }
 
     startByteIndex = nextCharOffset;
+    size_t charCountInRange = 0;
 
     // Find endByteIndex
-    for (auto i = 0; i < length; i++) {
-      auto increment = utf8proc_char_length(&str[nextCharOffset]);
-      nextCharOffset += UNLIKELY(increment < 0) ? 1 : increment;
+    for (auto i = 0; nextCharOffset < strLength && i < length; i++) {
+      nextCharOffset++;
+      charCountInRange++;
+
+      skipContBytes();
     }
+
+    VELOX_CHECK_EQ(
+        charCountInRange,
+        length,
+        "The substring requested at {} of length {} exceeds the bounds of the string.",
+        startCharPosition,
+        length);
 
     return std::make_pair(startByteIndex, nextCharOffset);
   }

--- a/velox/functions/lib/string/StringImpl.h
+++ b/velox/functions/lib/string/StringImpl.h
@@ -599,7 +599,8 @@ FOLLY_ALWAYS_INLINE void pad(
   // and return it as the result.
   if (UNLIKELY(stringCharLength >= size)) {
     size_t prefixByteSize =
-        stringCore::getByteRange<isAscii>(string.data(), 1, size).second;
+        stringCore::getByteRange<isAscii>(string.data(), string.size(), 1, size)
+            .second;
     output.resize(prefixByteSize);
     if (LIKELY(prefixByteSize > 0)) {
       std::memcpy(output.data(), string.data(), prefixByteSize);
@@ -615,10 +616,12 @@ FOLLY_ALWAYS_INLINE void pad(
   // If the length of padString does not evenly divide the length of the
   // padding we need to add, how long of a prefix of padString needs to be
   // added at the end of the padding.  Will be 0 if it is evenly divisible.
-  size_t padPrefixByteLength =
-      stringCore::getByteRange<isAscii>(
-          padString.data(), 1, fullPaddingCharLength % padStringCharLength)
-          .second;
+  size_t padPrefixByteLength = stringCore::getByteRange<isAscii>(
+                                   padString.data(),
+                                   padString.size(),
+                                   1,
+                                   fullPaddingCharLength % padStringCharLength)
+                                   .second;
   int64_t fullPaddingByteLength =
       padString.size() * fullPadCopies + padPrefixByteLength;
   // The final size of the output string in bytes.

--- a/velox/functions/lib/string/tests/StringImplTest.cpp
+++ b/velox/functions/lib/string/tests/StringImplTest.cpp
@@ -583,12 +583,13 @@ TEST_F(StringImplTest, getByteRange) {
     auto expectedEndByteIndex = strlen(unicodeString);
 
     // Find the byte range of unicodeString[i, end]
-    auto range = getByteRange</*isAscii*/ false>(unicodeString, i, 6 - i + 1);
+    auto range =
+        getByteRange</*isAscii*/ false>(unicodeString, 12, i, 6 - i + 1);
 
     EXPECT_EQ(expectedStartByteIndex, range.first);
     EXPECT_EQ(expectedEndByteIndex, range.second);
 
-    range = getByteRange</*isAscii*/ false>(unicodeString, i, 6 - i + 1);
+    range = getByteRange</*isAscii*/ false>(unicodeString, 12, i, 6 - i + 1);
 
     EXPECT_EQ(expectedStartByteIndex, range.first);
     EXPECT_EQ(expectedEndByteIndex, range.second);
@@ -598,13 +599,14 @@ TEST_F(StringImplTest, getByteRange) {
 
   // This exercises bad unicode byte in determining startByteIndex.
   std::string badUnicode = "aa\xff  ";
-  auto range = getByteRange<false>(badUnicode.data(), 4, 3);
+  auto range =
+      getByteRange<false>(badUnicode.data(), badUnicode.length(), 4, 2);
   EXPECT_EQ(range.first, 3);
-  EXPECT_EQ(range.second, 6);
+  EXPECT_EQ(range.second, 5);
 
   // This exercises bad unicode byte in determining endByteIndex.
   badUnicode = "\xff aa";
-  range = getByteRange<false>(badUnicode.data(), 1, 3);
+  range = getByteRange<false>(badUnicode.data(), badUnicode.length(), 1, 3);
   EXPECT_EQ(range.first, 0);
   EXPECT_EQ(range.second, 3);
 }

--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -121,8 +121,8 @@ struct SubstrFunction {
       length = numCharacters - start + 1;
     }
 
-    auto byteRange =
-        stringCore::getByteRange<isAscii>(input.data(), start, length);
+    auto byteRange = stringCore::getByteRange<isAscii>(
+        input.data(), input.size(), start, length);
 
     // Generating output string
     result.setNoCopy(StringView(

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -576,8 +576,8 @@ struct SubstrFunction {
       return;
     }
 
-    auto byteRange =
-        stringCore::getByteRange<isAscii>(input.data(), start, length);
+    auto byteRange = stringCore::getByteRange<isAscii>(
+        input.data(), input.size(), start, length);
 
     // Generating output string
     result.setNoCopy(StringView(
@@ -623,7 +623,7 @@ struct OverlayFunctionBase {
       std::pair<int32_t, int32_t> pair) {
     if constexpr (isVarchar && !isAscii) {
       auto byteRange = stringCore::getByteRange<false>(
-          input.data(), pair.first + 1, pair.second);
+          input.data(), input.size(), pair.first + 1, pair.second);
       result.append(StringView(
           input.data() + byteRange.first, byteRange.second - byteRange.first));
     } else {
@@ -759,8 +759,8 @@ struct LeftFunction {
 
     int32_t start = 1;
 
-    auto byteRange =
-        stringCore::getByteRange<isAscii>(input.data(), start, length);
+    auto byteRange = stringCore::getByteRange<isAscii>(
+        input.data(), input.size(), start, length);
 
     // Generating output string
     result.setNoCopy(StringView(


### PR DESCRIPTION
Summary:
In String UDFs, when Presto is counting the number of code points in a string, e.g. to compute its
length or to compute a substring it simply ignores UTF-8 continuation characters.

Velox assumes that if it encounters a UTF-8 prefix byte the rest of the bytes in the UTF-8 code
point are well formed (i.e. they're all continuation bytes).  This causes Velox and Presto to count
code points differently.

While both approaches produce (IMO) odd results at times, Velox's seems to be clearly worse (e.g.
a UTF-8 code point with a valid prefix indicating 2 continuation bytes but those continuation bytes
are missing will effectively count as -2 when computing the length) and we usually default to
Presto Java as the source of truth, so I've updated Velox.

Differential Revision: D58620186
