### PR TITLE
Fix UBSan error triggered by StringFunctionsTest.normalize

### DIFF
--- a/velox/external/utf8proc/utf8procImpl.h
+++ b/velox/external/utf8proc/utf8procImpl.h
@@ -421,7 +421,7 @@ static utf8proc_ssize_t seqindex_write_char_decomposed(
 
     written += utf8proc_decompose_char(
         entry_cp,
-        dst + written,
+        dst ? dst + written : dst,
         (bufsize > written) ? (bufsize - written) : 0,
         options,
         last_boundclass);


### PR DESCRIPTION
Summary:
https://github.com/facebookincubator/velox/pull/8590 recently introduced the normalize UDF.

The test for it is hitting a UBSan error in velox/external/utf8proc/utf8procImpl.h which has a free
wheeling approach to incrementing nullptrs it will never use.

This fixes it by first checking if the pointer is null before incrementing it.

Differential Revision: D58621849
