### PR TITLE
Fix map_top_n on empty values.

### DIFF
--- a/velox/functions/prestosql/MapTopN.h
+++ b/velox/functions/prestosql/MapTopN.h
@@ -42,7 +42,7 @@ struct MapTopNFunction {
 
         return comp > 0;
       } else if (FOLLY_UNLIKELY(
-                     l->second.has_value() && r->second.has_value())) {
+                     !l->second.has_value() && !r->second.has_value())) {
         return l->first.compare(r->first, flags) > 0;
       }
 

--- a/velox/functions/prestosql/tests/MapTopNTest.cpp
+++ b/velox/functions/prestosql/tests/MapTopNTest.cpp
@@ -73,8 +73,8 @@ TEST_F(MapTopNTest, equalValues) {
       makeMapVectorFromJson<int32_t, int64_t>(
           {"{6:3, 2:5, 3:1, 4:4, 5:2, 1:3}",
            "{1:3, 2:5, 3:null, 4:4, 5:2, 6:5 }",
-           "{1:null, 2:null, 3:1, 4:4, 5:null}",
-           "{1:null, 2:null, 3:null, 4:null, 5:null}"}),
+           "{5:null, 2:null, 3:1, 4:4, 1:null}",
+           "{1:null, 5:null, 3:null, 4:null, 2:null}"}),
   });
 
   auto result = evaluate("map_top_n(c0, 3)", data);


### PR DESCRIPTION
Thanks to @danielhunte for pointing this out. Previous PR to fix map_top_n had a typo where it was missing a not , and thus when values were null it would not use the keys to compare. The test case would pass since it unfortunately had the higher value keys in ascending order and would pick the last  value. This PR fixes the bug and test case.