### PR TITLE
Fix bitwise_xxx_shift Presto functions

### DIFF
--- a/velox/docs/functions/presto/bitwise.rst
+++ b/velox/docs/functions/presto/bitwise.rst
@@ -12,45 +12,51 @@ Bitwise Functions
         SELECT bit_count(-7, 64); -- 62
         SELECT bit_count(-7, 8); -- 6
 
-.. function:: bitwise_and(x, y) -> [bigint]
+.. function:: bitwise_and(x, y) -> bigint
 
     Returns the bitwise AND of ``x`` and ``y`` in 2's complement representation.
 
-.. function:: bitwise_arithmetic_shift_right(x, shift) -> [bigint]``
+.. function:: bitwise_arithmetic_shift_right(x, shift) -> bigint
 
     Returns the arithmetic right shift operation on ``x`` shifted by ``shift`` in 2’s complement representation.
     ``shift`` must not be negative.
 
-.. function:: bitwise_left_shift(x, shift) -> [bigint]``
+.. function:: bitwise_left_shift(x, shift) -> [same as x]
 
-    Returns the left shifted value of ``x``. Here x can be of type ``TINYINT`` , ``SMALLINT``, ``INTEGER`` and ``BIGINT``.
+    Returns the left shifted value of ``x``.
+    Supported types of x are: ``TINYINT`` , ``SMALLINT``, ``INTEGER`` and ``BIGINT``.
+    ``shift`` is an ``INTEGER``.
 
-.. function:: bitwise_logical_shift_right(x, shift, bits) -> [bigint]``
+.. function:: bitwise_logical_shift_right(x, shift, bits) -> bigint
 
     Returns the logical right shift operation on ``x`` (treated as ``bits``-bit integer) shifted by ``shift``.
     ``shift`` must not be negative.
 
-.. function:: bitwise_not(x) -> [bigint]
+.. function:: bitwise_not(x) -> bigint
 
     Returns the bitwise NOT of ``x`` in 2's complement representation.
 
-.. function:: bitwise_or(x, y) -> [bigint]
+.. function:: bitwise_or(x, y) -> bigint
 
     Returns the bitwise OR of ``x`` and ``y`` in 2's complement representation.
 
-.. function:: bitwise_right_shift(x, shift) -> [bigint]``
+.. function:: bitwise_right_shift(x, shift) -> [same as x]
 
-    Returns the logical right shifted value of ``x``. Here x can be of type ``TINYINT``, ``SMALLINT``, ``INTEGER`` and ``BIGINT``.
+    Returns the logical right shifted value of ``x``.
+    Supported types of x are: ``TINYINT``, ``SMALLINT``, ``INTEGER`` and ``BIGINT``.
+    ``shift`` is an ``INTEGER``.
 
-.. function:: bitwise_right_shift_arithmetic(x, shift) -> [bigint]``
+.. function:: bitwise_right_shift_arithmetic(x, shift) -> [same as x]
 
     Returns the arithmetic right shift value of ``x``.
+    Supported types of x are: ``TINYINT``, ``SMALLINT``, ``INTEGER`` and ``BIGINT``.
+    ``shift`` is an ``INTEGER``.
 
-.. function:: bitwise_shift_left(x, shift, bits) -> [bigint]``
+.. function:: bitwise_shift_left(x, shift, bits) -> bigint
 
     Returns the left shift operation on ``x`` (treated as ``bits``-bit integer) shifted by ``shift``.
     ``shift`` must not be negative.
 
-.. function:: bitwise_xor(x, y) -> [bigint]``
+.. function:: bitwise_xor(x, y) -> bigint
 
     Returns the bitwise XOR of ``x`` and ``y`` in 2's complement representation.

--- a/velox/functions/prestosql/registration/BitwiseFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/BitwiseFunctionsRegistration.cpp
@@ -34,6 +34,14 @@ void registerBitwiseUnaryIntegral(const std::vector<std::string>& aliases) {
   registerFunction<T, int64_t, int32_t>(aliases);
   registerFunction<T, int64_t, int64_t>(aliases);
 }
+
+template <template <class> class T>
+void registerShift(const std::vector<std::string>& aliases) {
+  registerFunction<T, int8_t, int8_t, int32_t>(aliases);
+  registerFunction<T, int16_t, int16_t, int32_t>(aliases);
+  registerFunction<T, int32_t, int32_t, int32_t>(aliases);
+  registerFunction<T, int64_t, int64_t, int32_t>(aliases);
+}
 } // namespace
 
 void registerBitwiseFunctions(const std::string& prefix) {
@@ -47,11 +55,9 @@ void registerBitwiseFunctions(const std::string& prefix) {
       int64_t,
       int64_t,
       int64_t>({prefix + "bitwise_arithmetic_shift_right"});
-  registerBitwiseBinaryIntegral<BitwiseLeftShiftFunction>(
-      {prefix + "bitwise_left_shift"});
-  registerBitwiseBinaryIntegral<BitwiseRightShiftFunction>(
-      {prefix + "bitwise_right_shift"});
-  registerBitwiseBinaryIntegral<BitwiseRightShiftArithmeticFunction>(
+  registerShift<BitwiseLeftShiftFunction>({prefix + "bitwise_left_shift"});
+  registerShift<BitwiseRightShiftFunction>({prefix + "bitwise_right_shift"});
+  registerShift<BitwiseRightShiftArithmeticFunction>(
       {prefix + "bitwise_right_shift_arithmetic"});
   registerFunction<
       BitwiseLogicalShiftRightFunction,

--- a/velox/functions/prestosql/tests/BitwiseTest.cpp
+++ b/velox/functions/prestosql/tests/BitwiseTest.cpp
@@ -71,23 +71,22 @@ class BitwiseTest : public functions::test::FunctionBaseTest {
   template <typename T>
   std::optional<int64_t> bitwiseRightShiftArithmetic(
       std::optional<T> a,
-      std::optional<T> b) {
-    return evaluateOnce<int64_t>(
-        "bitwise_right_shift_arithmetic(c0, c1)", a, b);
+      std::optional<int32_t> b) {
+    return evaluateOnce<T>("bitwise_right_shift_arithmetic(c0, c1)", a, b);
   }
 
   template <typename T>
   std::optional<int64_t> bitwiseLeftShift(
       std::optional<T> a,
-      std::optional<T> b) {
-    return evaluateOnce<int64_t>("bitwise_left_shift(c0, c1)", a, b);
+      std::optional<int32_t> b) {
+    return evaluateOnce<T>("bitwise_left_shift(c0, c1)", a, b);
   }
 
   template <typename T>
   std::optional<int64_t> bitwiseRightShift(
       std::optional<T> a,
-      std::optional<T> b) {
-    return evaluateOnce<int64_t>("bitwise_right_shift(c0, c1)", a, b);
+      std::optional<int32_t> b) {
+    return evaluateOnce<T>("bitwise_right_shift(c0, c1)", a, b);
   }
 };
 
@@ -303,7 +302,7 @@ TEST_F(BitwiseTest, rightShiftArithmetic) {
   EXPECT_EQ(bitwiseRightShiftArithmetic<int64_t>(kMax64, kMax64), 0);
   EXPECT_EQ(bitwiseRightShiftArithmetic<int64_t>(kMax64, 1), kMax64 >> 1);
   EXPECT_EQ(bitwiseRightShiftArithmetic<int64_t>(kMin64, 1), kMin64 >> 1);
-  EXPECT_EQ(bitwiseRightShiftArithmetic<int64_t>(1, kMin64), 0);
+  EXPECT_EQ(bitwiseRightShiftArithmetic<int64_t>(1, kMin32), 0);
 }
 
 TEST_F(BitwiseTest, leftShift) {
@@ -319,8 +318,8 @@ TEST_F(BitwiseTest, leftShift) {
 
   EXPECT_EQ(bitwiseLeftShift<int16_t>(kMin16, kMax16), 0);
   EXPECT_EQ(bitwiseLeftShift<int16_t>(kMax16, kMax16), 0);
-  EXPECT_EQ(bitwiseLeftShift<int16_t>(kMax16, 1), kMax16 << 1);
-  EXPECT_EQ(bitwiseLeftShift<int16_t>(kMin16, 1), -65536);
+  EXPECT_EQ(bitwiseLeftShift<int16_t>(kMax16, 1), -2);
+  EXPECT_EQ(bitwiseLeftShift<int16_t>(kMin16, 1), 0);
 
   EXPECT_EQ(bitwiseLeftShift<int32_t>(kMin32, kMax32), 0);
   EXPECT_EQ(bitwiseLeftShift<int32_t>(kMax32, kMax32), 0);
@@ -329,8 +328,7 @@ TEST_F(BitwiseTest, leftShift) {
 
   EXPECT_EQ(bitwiseLeftShift<int64_t>(kMin64, kMax64), 0);
   EXPECT_EQ(bitwiseLeftShift<int64_t>(kMax64, kMax64), 0);
-  EXPECT_EQ(
-      bitwiseLeftShift<int64_t>(5787029258914367756, 6918663727935913984), 0);
+  EXPECT_EQ(bitwiseLeftShift<int64_t>(5787029258914367756, 123456), 0);
   EXPECT_EQ(bitwiseLeftShift<int64_t>(kMax64, 1), kMax64 << 1);
   EXPECT_EQ(bitwiseLeftShift<int64_t>(kMin64, 1), 0);
 }
@@ -353,8 +351,7 @@ TEST_F(BitwiseTest, rightShift) {
 
   EXPECT_EQ(bitwiseRightShift<int64_t>(kMin64, kMax64), 0);
   EXPECT_EQ(bitwiseRightShift<int64_t>(kMax64, kMax64), 0);
-  EXPECT_EQ(
-      bitwiseRightShift<int64_t>(5787029258914367756, 6918663727935913984), 0);
+  EXPECT_EQ(bitwiseRightShift<int64_t>(5787029258914367756, 123456), 0);
   EXPECT_EQ(bitwiseRightShift<int64_t>(kMax64, 1), kMax64 >> 1);
   EXPECT_EQ(bitwiseRightShift<int64_t>(kMin64, 1), (kMax64 >> 1) + 1);
 }


### PR DESCRIPTION
Summary:
Fix bitwise_left_shift,  bitwise_right_shift, bitwise_right_shift_arithmetic signatures to match Presto. These used to be (T, T) -> bigint in Velox while (T, integer) -> T in Presto.

```
presto:di> show functions like 'bitwise_%';
            Function            | Return Type |     Argument Types     | Function Type | Deterministic |                    Description                    | Variable Arity | Built In | Temporary | Language
--------------------------------+-------------+------------------------+---------------+---------------+---------------------------------------------------+----------------+----------+-----------+----------
 bitwise_left_shift             | bigint      | bigint, integer        | scalar        | true          | bitwise left shift                                | false          | true     | false     |
 bitwise_left_shift             | integer     | integer, integer       | scalar        | true          | bitwise left shift                                | false          | true     | false     |
 bitwise_left_shift             | smallint    | smallint, integer      | scalar        | true          | bitwise left shift                                | false          | true     | false     |
 bitwise_left_shift             | tinyint     | tinyint, integer       | scalar        | true          | bitwise left shift                                | false          | true     | false     |

 bitwise_right_shift            | bigint      | bigint, integer        | scalar        | true          | bitwise logical right shift                       | false          | true     | false     |
 bitwise_right_shift            | integer     | integer, integer       | scalar        | true          | bitwise logical right shift                       | false          | true     | false     |
 bitwise_right_shift            | smallint    | smallint, integer      | scalar        | true          | bitwise logical right shift                       | false          | true     | false     |
 bitwise_right_shift            | tinyint     | tinyint, integer       | scalar        | true          | bitwise logical right shift                       | false          | true     | false     |

 bitwise_right_shift_arithmetic | bigint      | bigint, integer        | scalar        | true          | bitwise arithmetic right shift                    | false          | true     | false     |
 bitwise_right_shift_arithmetic | integer     | integer, integer       | scalar        | true          | bitwise arithmetic right shift                    | false          | true     | false     |
 bitwise_right_shift_arithmetic | smallint    | smallint, integer      | scalar        | true          | bitwise arithmetic right shift                    | false          | true     | false     |
 bitwise_right_shift_arithmetic | tinyint     | tinyint, integer       | scalar        | true          | bitwise arithmetic right shift                    | false          | true     | false     |

```

Test changes are due to 'shift' no longer being 64-bit, but 32-bit and result being T, not int64_t.

```
  EXPECT_EQ(bitwiseLeftShift<int16_t>(kMax16, 1), -2);
  EXPECT_EQ(bitwiseLeftShift<int16_t>(kMin16, 1), 0);

presto:di> select x, bitwise_left_shift(cast(x as smallint), 1) as left_shift, bitwise_right_shift(cast(x as smallint), 1) as right_shift from (values 32767, -32768) as t(x);
   x    | left_shift | right_shift
--------+------------+-------------
  32767 |         -2 |       16383
 -32768 |          0 |       16384
(2 rows)
```

Differential Revision: D58621700
