### PR TITLE
Fix bound value calculation for last match

### DIFF
--- a/velox/exec/WindowPartition.cpp
+++ b/velox/exec/WindowPartition.cpp
@@ -228,9 +228,13 @@ vector_size_t WindowPartition::linearSearchFrameValue(
 
     // The bound value was found. Return if firstMatch required.
     // If the last match is required, then we need to find the first row that
-    // crosses the bound and return the prior row.
+    // crosses the bound and return the prior row. However, if last match is
+    // required when we are at the last row in our search space and the bound
+    // value is found, return the last row.
     if (compareResult == 0) {
       if (firstMatch) {
+        return i;
+      } else if (i == end - 1) {
         return i;
       }
     }


### PR DESCRIPTION
When testing kRange frames with the window fuzzer, the results of the following query 
in velox were observed not to match with that of Presto:
```
I20240613 10:52:29.830026 18262486 WindowFuzzer.cpp:379] ==============================> Started iteration 72 (seed: 1575309408)
I20240613 10:52:29.831157 18262486 AggregationFuzzerBase.cpp:436] Executing query plan: 
-- Window[1][partition by [p0] order by [s0 ASC NULLS FIRST] w0 := checksum(ROW["c0"]) RANGE between UNBOUNDED PRECEDING and k1 PRECEDING] -> c0:MAP<INTEGER,TINYINT>, s0:INTEGER, p0:TIMESTAMP, row_number:BIGINT, k1:INTEGER, w0:VARBINARY
  -- Values[0][20 rows in 1 vectors] -> c0:MAP<INTEGER,TINYINT>, s0:INTEGER, p0:TIMESTAMP, row_number:BIGINT, k1:INTEGER

I20240613 10:52:30.082160 18262486 PrestoQueryRunner.cpp:805] Execute presto sql: SELECT c0, s0, p0, row_number, k1, checksum(c0) OVER (PARTITION BY p0 ORDER BY s0 ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) FROM tmp

Failed
Expected 20, got 20
20 extra rows, 20 missing rows
5 of extra rows:
	null | 895228022 | "206031014-12-16T19:36:02.173000000" | 14 | 895228022 | null
	null | 1446266780 | "206031014-12-16T19:36:02.173000000" | 0 | 1446266780 | null
	[{"key":26220126,"value":69},{"key":199073092,"value":33},{"key":802967125,"value":65},{"key":1234250293,"value":117},{"key":1512371150,"value":1},{"key":1839437038,"value":115},{"key":1861919868,"value":32},{"key":2109980618,"value":78}] | 140011922 | "206031014-12-16T19:36:02.173000000" | 8 | 140011922 | null
	[{"key":26220126,"value":69},{"key":199073092,"value":33},{"key":802967125,"value":65},{"key":1234250293,"value":117},{"key":1512371150,"value":1},{"key":1839437038,"value":115},{"key":1861919868,"value":32},{"key":2109980618,"value":78}] | 997647417 | "206031014-12-16T19:36:02.173000000" | 6 | 997647417 | null
	[{"key":26220126,"value":69},{"key":199073092,"value":33},{"key":802967125,"value":65},{"key":1234250293,"value":117},{"key":1512371150,"value":1},{"key":1839437038,"value":115},{"key":1861919868,"value":32},{"key":2109980618,"value":78}] | 1353196810 | null | 1 | 1353196810 | null
	[{"key":26220126,"value":69},{"key":199073092,"value":33},{"key":802967125,"value":65},{"key":1234250293,"value":117},{"key":1512371150,"value":1},{"key":1839437038,"value":115},{"key":1861919868,"value":32},{"key":2109980618,"value":78}] | 1560563411 | "206031014-12-16T19:36:02.173000000" | 12 | 1560563411 | null

5 of missing rows:
	null | 895228022 | "206031014-12-16T19:36:02.173000000" | 14 | 895228022 | "7ga2rkqWAh0="
	null | 1446266780 | "206031014-12-16T19:36:02.173000000" | 0 | 1446266780 | "LqiICzr1ZgY="
	[{"key":26220126,"value":69},{"key":199073092,"value":33},{"key":802967125,"value":65},{"key":1234250293,"value":117},{"key":1512371150,"value":1},{"key":1839437038,"value":115},{"key":1861919868,"value":32},{"key":2109980618,"value":78}] | 140011922 | "206031014-12-16T19:36:02.173000000" | 8 | 140011922 | "MmWzMGS00R0="
	[{"key":26220126,"value":69},{"key":199073092,"value":33},{"key":802967125,"value":65},{"key":1234250293,"value":117},{"key":1512371150,"value":1},{"key":1839437038,"value":115},{"key":1861919868,"value":32},{"key":2109980618,"value":78}] | 997647417 | "206031014-12-16T19:36:02.173000000" | 6 | 997647417 | "KqO8nzGm08E="
	[{"key":26220126,"value":69},{"key":199073092,"value":33},{"key":802967125,"value":65},{"key":1234250293,"value":117},{"key":1512371150,"value":1},{"key":1839437038,"value":115},{"key":1861919868,"value":32},{"key":2109980618,"value":78}] | 1353196810 | null | 1 | 1353196810 | "iGFSB/v9Rpo="
```

This appears to be because the function `linearSearchFrameValue`, which looks for the frame end
bound corresponding to the frame end clause of `0 PRECEDING`, returns -1 when it cannot find a
value in the frame bound column greater than the value in orderBy column. With the frame clause
`RANGE BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING`, the frame bound column is the
same as the orderBy column. Since the search space is confined to one row, we don't find the first
row where the value of frame bound column exceeds the value of orderBy column. 
In such cases where the last match is required, we can return the last row in our search space if the
bound value is found and we are at the last row in our search space.