### PR TITLE
Enable truncate Presto function for REAL inputs

### DIFF
--- a/velox/docs/functions/presto/math.rst
+++ b/velox/docs/functions/presto/math.rst
@@ -159,14 +159,17 @@ Mathematical Functions
 
     Returns the base-``radix`` representation of ``x``. ``radix`` must be between 2 and 36.
 
-.. function:: truncate(x) -> double
+.. function:: truncate(x) -> [same as x]
 
     Returns x rounded to integer by dropping digits after decimal point.
+    Supported types of ``x`` are: REAL and DOUBLE.
 
-.. function:: truncate(x, n) -> double
+.. function:: truncate(x, n) -> [same as x]
    :noindex:
 
     Returns x truncated to n decimal places. n can be negative to truncate n digits left of the decimal point.
+    Supported types of ``x`` are: REAL and DOUBLE.
+    ``n`` is an INTEGER.
 
 .. function:: width_bucket(x, bound1, bound2, n) -> bigint
 

--- a/velox/functions/prestosql/Arithmetic.h
+++ b/velox/functions/prestosql/Arithmetic.h
@@ -580,13 +580,21 @@ struct EulerConstantFunction {
   }
 };
 
-template <typename T>
+template <typename TExec>
 struct TruncateFunction {
   FOLLY_ALWAYS_INLINE void call(double& result, double a) {
     result = std::trunc(a);
   }
 
+  FOLLY_ALWAYS_INLINE void call(float& result, float a) {
+    result = std::trunc(a);
+  }
+
   FOLLY_ALWAYS_INLINE void call(double& result, double a, int32_t n) {
+    result = truncate(a, n);
+  }
+
+  FOLLY_ALWAYS_INLINE void call(float& result, float a, int32_t n) {
     result = truncate(a, n);
   }
 };

--- a/velox/functions/prestosql/ArithmeticImpl.h
+++ b/velox/functions/prestosql/ArithmeticImpl.h
@@ -133,16 +133,14 @@ T ceil(const T& arg) {
   return results;
 }
 
-FOLLY_ALWAYS_INLINE double truncate(
-    const double& number,
-    const int32_t& decimals = 0) {
+FOLLY_ALWAYS_INLINE double truncate(double number, int32_t decimals) {
   const bool decNegative = (decimals < 0);
   const auto log10Size = DoubleUtil::kPowersOfTen.size(); // 309
   if (decNegative && decimals <= -log10Size) {
     return 0.0;
   }
 
-  const uint64_t absDec = decNegative ? -decimals : decimals;
+  const uint64_t absDec = std::abs(decimals);
   const double tmp = (absDec < log10Size) ? DoubleUtil::kPowersOfTen[absDec]
                                           : std::pow(10.0, (double)absDec);
 

--- a/velox/functions/prestosql/registration/MathematicalFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/MathematicalFunctionsRegistration.cpp
@@ -22,6 +22,14 @@
 namespace facebook::velox::functions {
 
 namespace {
+
+void registerTruncate(const std::vector<std::string>& names) {
+  registerFunction<TruncateFunction, double, double>(names);
+  registerFunction<TruncateFunction, float, float>(names);
+  registerFunction<TruncateFunction, double, double, int32_t>(names);
+  registerFunction<TruncateFunction, float, float, int32_t>(names);
+}
+
 void registerMathFunctions(const std::string& prefix) {
   registerUnaryNumeric<CeilFunction>({prefix + "ceil", prefix + "ceiling"});
   registerUnaryNumeric<FloorFunction>({prefix + "floor"});
@@ -98,9 +106,9 @@ void registerMathFunctions(const std::string& prefix) {
       {prefix + "to_base"});
   registerFunction<PiFunction, double>({prefix + "pi"});
   registerFunction<EulerConstantFunction, double>({prefix + "e"});
-  registerFunction<TruncateFunction, double, double>({prefix + "truncate"});
-  registerFunction<TruncateFunction, double, double, int32_t>(
-      {prefix + "truncate"});
+
+  registerTruncate({prefix + "truncate"});
+
   registerFunction<
       CosineSimilarityFunction,
       double,


### PR DESCRIPTION
Summary:
Presto supports both DOUBLE and REAL inputs in 'truncate'.

```
presto:di> show functions like 'truncate';
 Function |  Return Type  |    Argument Types     | Function Type | Deterministic |                               Description                               | Variable Arity | Built In | Temporary>
----------+---------------+-----------------------+---------------+---------------+-------------------------------------------------------------------------+----------------+----------+---------->
 truncate | decimal(p,s)  | decimal(p,s), integer | scalar        | true          | round to integer by dropping given number of digits after decimal point | false          | true     | false    >
 truncate | decimal(rp,0) | decimal(p,s)          | scalar        | true          | round to integer by dropping digits after decimal point                 | false          | true     | false    >
 truncate | double        | double                | scalar        | true          | round to integer by dropping digits after decimal point                 | false          | true     | false    >
 truncate | double        | double, integer       | scalar        | true          | truncate to double by dropping digits after decimal point               | false          | true     | false    >
 truncate | real          | real                  | scalar        | true          | round to integer by dropping digits after decimal point                 | false          | true     | false    >
 truncate | real          | real, integer         | scalar        | true          | truncate to float by dropping digits after decimal point                | false          | true     | false    >
(6 rows)
```

Differential Revision: D58635374
