### PR TITLE
Add repeat Spark function

### DIFF
--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -149,10 +149,6 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 
         SELECT repeat('123', 2); -- 123123
 
-.. spark:function:: string_repeat(str, n) -> varchar
-
-    This is an alias for ``repeat(str, n)``.
-
 .. spark:function:: replace(input, replaced) -> varchar
 
     Removes all instances of ``replaced`` from ``input``.
@@ -231,6 +227,10 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
         SELECT startswith('js SQL', 'js'); -- true
         SELECT startswith('js SQL', 'SQL'); -- false
         SELECT startswith('js SQL', null); -- NULL
+
+.. spark:function:: string_repeat(str, n) -> varchar
+
+    This is an alias for ``repeat(str, n)``.
 
 .. spark:function:: str_to_map(string, entryDelimiter, keyValueDelimiter) -> map(string, string)
 

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -144,11 +144,12 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 .. spark:function:: repeat(str, n) -> varchar
 
     Returns the string which repeats the given string value ``n`` times. 
-    ``n`` must be less or equal than 10000. ::
+    ``n`` must be less or equal than 10000.
+    If ``n`` is less or equal than 0, empry string is returned. ::
 
-        SSELECT repeat('123', 2); -- 123123
+        SELECT repeat('123', 2); -- 123123
 
-.. function:: string_repeat(str, n) -> varchar
+.. spark:function:: string_repeat(str, n) -> varchar
 
     This is an alias for ``repeat(str, n)``.
 

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -141,9 +141,9 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
         SELECT overlay('Spark SQL', 'tructured', 2, 4); -- "Structured SQL"
         SELECT overlay('Spark SQL', '_', -6, 3); -- "_Sql"
 
-.. spark:function:: repeat(str, n) -> varchar
+.. spark:function:: repeat(string, n) -> varchar
 
-    Returns the string which repeats the given string value ``n`` times. 
+    Returns the string which repeats ``string`` ``n`` times. 
     ``n`` must be less than or equal to 10000.
     If ``n`` is less than or equal to 0, empry string is returned. ::
 

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -141,9 +141,9 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
         SELECT overlay('Spark SQL', 'tructured', 2, 4); -- "Structured SQL"
         SELECT overlay('Spark SQL', '_', -6, 3); -- "_Sql"
 
-.. spark:function:: repeat(string, n) -> varchar
+.. spark:function:: repeat(input, n) -> varchar
 
-    Returns the string which repeats ``string`` ``n`` times. 
+    Returns the string which repeats ``input`` ``n`` times. 
     Result size must be less than or equal to 1MB.
     If ``n`` is less than or equal to 0, empty string is returned. ::
 
@@ -227,10 +227,6 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
         SELECT startswith('js SQL', 'js'); -- true
         SELECT startswith('js SQL', 'SQL'); -- false
         SELECT startswith('js SQL', null); -- NULL
-
-.. spark:function:: string_repeat(string, n) -> varchar
-
-    This is an alias for :spark:func:`repeat`.
 
 .. spark:function:: str_to_map(string, entryDelimiter, keyValueDelimiter) -> map(string, string)
 

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -143,7 +143,8 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 
 .. spark:function:: repeat(str, n) -> varchar
 
-    Returns the string which repeats the given string value ``n`` times. ::
+    Returns the string which repeats the given string value ``n`` times. 
+    ``n`` must be less or equal than 10000. ::
 
         SSELECT repeat('123', 2); -- 123123
 

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -141,11 +141,15 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
         SELECT overlay('Spark SQL', 'tructured', 2, 4); -- "Structured SQL"
         SELECT overlay('Spark SQL', '_', -6, 3); -- "_Sql"
 
-.. spark:function:: string_repeat(str, n) -> varchar
+.. spark:function:: repeat(str, n) -> varchar
 
     Returns the string which repeats the given string value ``n`` times. ::
 
-        SSELECT string_repeat('123', 2); -- 123123
+        SSELECT repeat('123', 2); -- 123123
+
+.. function:: string_repeat(str, n) -> varchar
+
+    This is an alias for ``repeat(str, n)``.
 
 .. spark:function:: replace(input, replaced) -> varchar
 

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -144,8 +144,8 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 .. spark:function:: repeat(str, n) -> varchar
 
     Returns the string which repeats the given string value ``n`` times. 
-    ``n`` must be less or equal than 10000.
-    If ``n`` is less or equal than 0, empry string is returned. ::
+    ``n`` must be less than or equal to 10000.
+    If ``n`` is less than or equal to 0, empry string is returned. ::
 
         SELECT repeat('123', 2); -- 123123
 

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -141,6 +141,12 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
         SELECT overlay('Spark SQL', 'tructured', 2, 4); -- "Structured SQL"
         SELECT overlay('Spark SQL', '_', -6, 3); -- "_Sql"
 
+.. spark:function:: string_repeat(str, n) -> varchar
+
+    Returns the string which repeats the given string value ``n`` times. ::
+
+        SSELECT string_repeat('123', 2); -- 123123
+
 .. spark:function:: replace(input, replaced) -> varchar
 
     Removes all instances of ``replaced`` from ``input``.

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -144,8 +144,8 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 .. spark:function:: repeat(string, n) -> varchar
 
     Returns the string which repeats ``string`` ``n`` times. 
-    ``n`` must be less than or equal to 10000.
-    If ``n`` is less than or equal to 0, empry string is returned. ::
+    Result size must be less than or equal to 1MB.
+    If ``n`` is less than or equal to 0, empty string is returned. ::
 
         SELECT repeat('123', 2); -- 123123
 
@@ -228,9 +228,9 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
         SELECT startswith('js SQL', 'SQL'); -- false
         SELECT startswith('js SQL', null); -- NULL
 
-.. spark:function:: string_repeat(str, n) -> varchar
+.. spark:function:: string_repeat(string, n) -> varchar
 
-    This is an alias for ``repeat(str, n)``.
+    This is an alias for :spark:func:`repeat`.
 
 .. spark:function:: str_to_map(string, entryDelimiter, keyValueDelimiter) -> map(string, string)
 

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -462,7 +462,7 @@ void registerFunctions(const std::string& prefix) {
       Array<Array<Generic<T1>>>>({prefix + "flatten"});
 
   registerFunction<RepeatFunction, Varchar, Varchar, int32_t>(
-      {prefix + "repeat", prefix + "string_repeat"});
+      {prefix + "repeat"});
 
   registerFunction<SoundexFunction, Varchar, Varchar>({prefix + "soundex"});
 

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -461,6 +461,9 @@ void registerFunctions(const std::string& prefix) {
       Array<Generic<T1>>,
       Array<Array<Generic<T1>>>>({prefix + "flatten"});
 
+  registerFunction<RepeatFunction, Varchar, Varchar, int32_t>(
+      {prefix + "string_repeat"});
+
   registerFunction<SoundexFunction, Varchar, Varchar>({prefix + "soundex"});
 
   registerFunction<RaiseErrorFunction, UnknownValue, Varchar>(

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -462,7 +462,7 @@ void registerFunctions(const std::string& prefix) {
       Array<Array<Generic<T1>>>>({prefix + "flatten"});
 
   registerFunction<RepeatFunction, Varchar, Varchar, int32_t>(
-      {prefix + "repeat", "string_repeat"});
+      {prefix + "repeat", prefix + "string_repeat"});
 
   registerFunction<SoundexFunction, Varchar, Varchar>({prefix + "soundex"});
 

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -462,7 +462,7 @@ void registerFunctions(const std::string& prefix) {
       Array<Array<Generic<T1>>>>({prefix + "flatten"});
 
   registerFunction<RepeatFunction, Varchar, Varchar, int32_t>(
-      {prefix + "string_repeat"});
+      {prefix + "repeat", "string_repeat"});
 
   registerFunction<SoundexFunction, Varchar, Varchar>({prefix + "soundex"});
 

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -1181,6 +1181,12 @@ struct FindInSetFunction {
   }
 };
 
+/// repeat(input, times) -> varchar
+/// string_repeat(input, times) -> varchar
+///
+///    Returns the string which repeats ``input`` ``times`` times.
+///    Result size must be less than or equal to 1MB.
+///    If ``times`` is less than or equal to 0, empty string is returned.
 template <typename T>
 struct RepeatFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -1191,6 +1191,7 @@ struct RepeatFunction {
       out_type<Varchar>& result,
       const arg_type<Varchar>& input,
       int32_t times) {
+    VELOX_USER_CHECK_LE(times, 10000, "Repeat times is too big.");
     if (times <= 0) {
       result.resize(0);
       return;

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -1181,36 +1181,33 @@ struct FindInSetFunction {
   }
 };
 
-/// repeat(input, times) -> varchar
-/// string_repeat(input, times) -> varchar
+/// repeat(input, n) -> varchar
 ///
-///    Returns the string which repeats ``input`` ``times`` times.
+///    Returns the string which repeats input n times.
 ///    Result size must be less than or equal to 1MB.
-///    If ``times`` is less than or equal to 0, empty string is returned.
+///    If n is less than or equal to 0, empty string is returned.
 template <typename T>
 struct RepeatFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   static constexpr bool is_default_ascii_behavior = true;
 
-  FOLLY_ALWAYS_INLINE void call(
-      out_type<Varchar>& result,
-      const arg_type<Varchar>& input,
-      int32_t times) {
+  FOLLY_ALWAYS_INLINE void
+  call(out_type<Varchar>& result, const arg_type<Varchar>& input, int32_t n) {
     static constexpr size_t resultMaxSize = 1024 * 1024; // 1MB
     auto inputSize = input.size();
-    if (inputSize == 0 || times <= 0) {
+    if (inputSize == 0 || n <= 0) {
       result.resize(0);
       return;
     }
-    int32_t newSize = velox::checkedMultiply<int32_t>(inputSize, times);
+    int32_t newSize = velox::checkedMultiply<int32_t>(inputSize, n);
     VELOX_USER_CHECK_LE(
         newSize,
         resultMaxSize,
         "Result size must be less than or equal to {}",
         resultMaxSize);
     result.resize(newSize);
-    for (auto i = 0; i < times; ++i) {
+    for (auto i = 0; i < n; ++i) {
       std::memcpy(result.data() + i * inputSize, input.data(), inputSize);
     }
   }

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -1182,6 +1182,33 @@ struct FindInSetFunction {
 };
 
 template <typename T>
+struct RepeatFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  static constexpr bool is_default_ascii_behavior = true;
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& input,
+      int32_t times) {
+    if (times <= 0) {
+      result.resize(0);
+      return;
+    }
+    auto inputSize = input.size();
+    if (inputSize == 0) {
+      result.resize(0);
+      return;
+    }
+    int32_t newSize = velox::checkedMultiply<int32_t>(inputSize, times);
+    result.resize(newSize);
+    for (auto i = 0; i < times; ++i) {
+      std::memcpy(result.data() + i * inputSize, input.data(), inputSize);
+    }
+  }
+};
+
+template <typename T>
 struct SoundexFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -1191,13 +1191,18 @@ struct RepeatFunction {
       out_type<Varchar>& result,
       const arg_type<Varchar>& input,
       int32_t times) {
-    VELOX_USER_CHECK_LE(times, 10000, "Repeat times is too large.");
+    static constexpr size_t resultMaxSize = 1024 * 1024; // 1MB
     auto inputSize = input.size();
     if (inputSize == 0 || times <= 0) {
       result.resize(0);
       return;
     }
     int32_t newSize = velox::checkedMultiply<int32_t>(inputSize, times);
+    VELOX_USER_CHECK_LE(
+        newSize,
+        resultMaxSize,
+        "Result size must be less than or equal to {}",
+        resultMaxSize);
     result.resize(newSize);
     for (auto i = 0; i < times; ++i) {
       std::memcpy(result.data() + i * inputSize, input.data(), inputSize);

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -1191,13 +1191,9 @@ struct RepeatFunction {
       out_type<Varchar>& result,
       const arg_type<Varchar>& input,
       int32_t times) {
-    VELOX_USER_CHECK_LE(times, 10000, "Repeat times is too big.");
-    if (times <= 0) {
-      result.resize(0);
-      return;
-    }
+    VELOX_USER_CHECK_LE(times, 10000, "Repeat times is too large.");
     auto inputSize = input.size();
-    if (inputSize == 0) {
+    if (inputSize == 0 || times <= 0) {
       result.resize(0);
       return;
     }

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -448,6 +448,17 @@ TEST_F(StringTest, overlayVarbinary) {
   EXPECT_EQ(overlay("Spark SQL", "##", -10, 4), "##rk SQL");
 }
 
+TEST_F(StringTest, repeat) {
+  const auto stringRepeat = [&](const std::optional<std::string>& str,
+                                const std::optional<int32_t>& times) {
+    return evaluateOnce<std::string>("string_repeat(c0, c1)", str, times);
+  };
+
+  EXPECT_EQ(stringRepeat("hh", 2), "hhhh");
+  EXPECT_EQ(stringRepeat("abab", 0), "");
+  EXPECT_EQ(stringRepeat("123\u6570", 2), "123\u6570123\u6570");
+}
+
 TEST_F(StringTest, replace) {
   const auto replace = [&](const std::optional<std::string>& str,
                            const std::optional<std::string>& replaced) {

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -450,25 +450,23 @@ TEST_F(StringTest, overlayVarbinary) {
 }
 
 TEST_F(StringTest, repeat) {
-  for (const auto& func : {"repeat", "string_repeat"}) {
-    const auto stringRepeat = [&](const std::optional<std::string>& str,
-                                  const std::optional<int32_t>& times) {
-      return evaluateOnce<std::string>(
-          fmt::format("{}(c0, c1)", func), str, times);
-    };
+  const auto stringRepeat = [&](const std::optional<std::string>& str,
+                                const std::optional<int32_t>& times) {
+    return evaluateOnce<std::string>(
+        fmt::format("{}(c0, c1)", "repeat"), str, times);
+  };
 
-    EXPECT_EQ(stringRepeat("hh", 2), "hhhh");
-    EXPECT_EQ(stringRepeat("abab", 0), "");
-    EXPECT_EQ(stringRepeat("abab", -1), "");
-    EXPECT_EQ(stringRepeat("", 2), "");
-    EXPECT_EQ(stringRepeat("123\u6570", 2), "123\u6570123\u6570");
-    VELOX_ASSERT_USER_THROW(
-        stringRepeat("hh", 524289),
-        "Result size must be less than or equal to 1048576");
-    VELOX_ASSERT_USER_THROW(
-        stringRepeat(std::string(214749, 'l'), 10000),
-        "integer overflow: 214749 * 10000");
-  }
+  EXPECT_EQ(stringRepeat("hh", 2), "hhhh");
+  EXPECT_EQ(stringRepeat("abab", 0), "");
+  EXPECT_EQ(stringRepeat("abab", -1), "");
+  EXPECT_EQ(stringRepeat("", 2), "");
+  EXPECT_EQ(stringRepeat("123\u6570", 2), "123\u6570123\u6570");
+  VELOX_ASSERT_USER_THROW(
+      stringRepeat("hh", 524289),
+      "Result size must be less than or equal to 1048576");
+  VELOX_ASSERT_USER_THROW(
+      stringRepeat(std::string(214749, 'l'), 10000),
+      "integer overflow: 214749 * 10000");
 }
 
 TEST_F(StringTest, replace) {

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -461,7 +461,10 @@ TEST_F(StringTest, repeat) {
   EXPECT_EQ(stringRepeat("", 2), "");
   EXPECT_EQ(stringRepeat("123\u6570", 2), "123\u6570123\u6570");
   VELOX_ASSERT_USER_THROW(
-      stringRepeat("hh", 10001), "Repeat times is too big.");
+      stringRepeat("hh", 10001), "Repeat times is too large.");
+  VELOX_ASSERT_USER_THROW(
+      stringRepeat(std::string(214749, 'l'), 10000),
+      "integer overflow: 214749 * 10000");
 }
 
 TEST_F(StringTest, replace) {

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -463,7 +463,8 @@ TEST_F(StringTest, repeat) {
     EXPECT_EQ(stringRepeat("", 2), "");
     EXPECT_EQ(stringRepeat("123\u6570", 2), "123\u6570123\u6570");
     VELOX_ASSERT_USER_THROW(
-        stringRepeat("hh", 10001), "Repeat times is too large.");
+        stringRepeat("hh", 524289),
+        "Result size must be less than or equal to 1048576");
     VELOX_ASSERT_USER_THROW(
         stringRepeat(std::string(214749, 'l'), 10000),
         "integer overflow: 214749 * 10000");

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -457,6 +457,8 @@ TEST_F(StringTest, repeat) {
 
   EXPECT_EQ(stringRepeat("hh", 2), "hhhh");
   EXPECT_EQ(stringRepeat("abab", 0), "");
+  EXPECT_EQ(stringRepeat("abab", -1), "");
+  EXPECT_EQ(stringRepeat("", 2), "");
   EXPECT_EQ(stringRepeat("123\u6570", 2), "123\u6570123\u6570");
   VELOX_ASSERT_USER_THROW(
       stringRepeat("hh", 10001), "Repeat times is too big.");

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 #include "velox/type/Type.h"
 
@@ -451,12 +452,14 @@ TEST_F(StringTest, overlayVarbinary) {
 TEST_F(StringTest, repeat) {
   const auto stringRepeat = [&](const std::optional<std::string>& str,
                                 const std::optional<int32_t>& times) {
-    return evaluateOnce<std::string>("string_repeat(c0, c1)", str, times);
+    return evaluateOnce<std::string>("repeat(c0, c1)", str, times);
   };
 
   EXPECT_EQ(stringRepeat("hh", 2), "hhhh");
   EXPECT_EQ(stringRepeat("abab", 0), "");
   EXPECT_EQ(stringRepeat("123\u6570", 2), "123\u6570123\u6570");
+  VELOX_ASSERT_USER_THROW(
+      stringRepeat("hh", 10001), "Repeat times is too big.");
 }
 
 TEST_F(StringTest, replace) {

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -450,21 +450,24 @@ TEST_F(StringTest, overlayVarbinary) {
 }
 
 TEST_F(StringTest, repeat) {
-  const auto stringRepeat = [&](const std::optional<std::string>& str,
-                                const std::optional<int32_t>& times) {
-    return evaluateOnce<std::string>("repeat(c0, c1)", str, times);
-  };
+  for (const auto& func : {"repeat", "string_repeat"}) {
+    const auto stringRepeat = [&](const std::optional<std::string>& str,
+                                  const std::optional<int32_t>& times) {
+      return evaluateOnce<std::string>(
+          fmt::format("{}(c0, c1)", func), str, times);
+    };
 
-  EXPECT_EQ(stringRepeat("hh", 2), "hhhh");
-  EXPECT_EQ(stringRepeat("abab", 0), "");
-  EXPECT_EQ(stringRepeat("abab", -1), "");
-  EXPECT_EQ(stringRepeat("", 2), "");
-  EXPECT_EQ(stringRepeat("123\u6570", 2), "123\u6570123\u6570");
-  VELOX_ASSERT_USER_THROW(
-      stringRepeat("hh", 10001), "Repeat times is too large.");
-  VELOX_ASSERT_USER_THROW(
-      stringRepeat(std::string(214749, 'l'), 10000),
-      "integer overflow: 214749 * 10000");
+    EXPECT_EQ(stringRepeat("hh", 2), "hhhh");
+    EXPECT_EQ(stringRepeat("abab", 0), "");
+    EXPECT_EQ(stringRepeat("abab", -1), "");
+    EXPECT_EQ(stringRepeat("", 2), "");
+    EXPECT_EQ(stringRepeat("123\u6570", 2), "123\u6570123\u6570");
+    VELOX_ASSERT_USER_THROW(
+        stringRepeat("hh", 10001), "Repeat times is too large.");
+    VELOX_ASSERT_USER_THROW(
+        stringRepeat(std::string(214749, 'l'), 10000),
+        "integer overflow: 214749 * 10000");
+  }
 }
 
 TEST_F(StringTest, replace) {


### PR DESCRIPTION
Doc: https://spark.apache.org/docs/latest/api/sql/#repeat
Code:https://github.com/apache/spark/blob/257a7883f2150e037eb05f8c7a111184103ad9a1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala#L1885
BTW, `repeat` is used for other fucntions for Presto, so register this with a different name.
https://github.com/facebookincubator/velox/blob/main/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp#L160