### PR TITLE
Improve stripe metadata cache and increase the ssd checksum verification coverage

### DIFF
--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -168,6 +168,11 @@ void registerVeloxMetrics() {
   DEFINE_METRIC(
       kMetricMemoryCacheNumAgedOutEntries, facebook::velox::StatType::SUM);
 
+  // Number of AsyncDataCache entries that are stale because of cache request
+  // size mismatch.
+  DEFINE_METRIC(
+      kMetricMemoryCacheNumStaleEntries, facebook::velox::StatType::COUNT);
+
   /// ================== SsdCache Counters ==================
 
   // Number of regions currently cached by SSD.
@@ -235,6 +240,11 @@ void registerVeloxMetrics() {
   // Total number of errors while reading from SSD checkpoint files.
   DEFINE_METRIC(
       kMetricSsdCacheReadCheckpointErrors, facebook::velox::StatType::SUM);
+
+  // Total number of SSD cache reads without checksum verification due to
+  // mismatch in SSD cache request size.
+  DEFINE_METRIC(
+      kMetricSsdCacheReadWithoutChecksum, facebook::velox::StatType::COUNT);
 
   // Total number of checkpoints read.
   DEFINE_METRIC(kMetricSsdCacheCheckpointsRead, facebook::velox::StatType::SUM);
@@ -471,5 +481,11 @@ void registerVeloxMetrics() {
 
   // The exchange data size in bytes.
   DEFINE_METRIC(kMetricExchangeDataBytes, facebook::velox::StatType::SUM);
+
+  // The distribution of exchange data size in range of [0, 128MB] with 128
+  // buckets. It is configured to report the capacity at P50, P90, P99, and P100
+  // percentiles.
+  DEFINE_HISTOGRAM_METRIC(
+      kMetricExchangeDataSize, 1L << 20, 0, 128L << 20, 50, 90, 99, 100);
 }
 } // namespace facebook::velox

--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -218,6 +218,9 @@ constexpr folly::StringPiece kMetricMemoryCacheNumAllocClocks{
 constexpr folly::StringPiece kMetricMemoryCacheNumAgedOutEntries{
     "velox.memory_cache_num_aged_out_entries"};
 
+constexpr folly::StringPiece kMetricMemoryCacheNumStaleEntries{
+    "velox.memory_cache_num_stale_entries"};
+
 constexpr folly::StringPiece kMetricSsdCacheCachedRegions{
     "velox.ssd_cache_cached_regions"};
 
@@ -278,6 +281,9 @@ constexpr folly::StringPiece kMetricSsdCacheReadSsdErrors{
 constexpr folly::StringPiece kMetricSsdCacheReadCheckpointErrors{
     "velox.ssd_cache_read_checkpoint_errors"};
 
+constexpr folly::StringPiece kMetricSsdCacheReadWithoutChecksum{
+    "velox.ssd_cache_read_without_checksum"};
+
 constexpr folly::StringPiece kMetricSsdCacheCheckpointsRead{
     "velox.ssd_cache_checkpoints_read"};
 
@@ -295,4 +301,7 @@ constexpr folly::StringPiece kMetricExchangeDataSizeTimeMs{
 
 constexpr folly::StringPiece kMetricExchangeDataBytes{
     "velox.exchange_data_bytes"};
+
+constexpr folly::StringPiece kMetricExchangeDataSize{
+    "velox.exchange_data_size"};
 } // namespace facebook::velox

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -528,7 +528,10 @@ struct CacheStats {
   /// shared mode.
   int64_t numWaitExclusive{0};
   /// Total number of entries that are aged out and beyond TTL.
-  int64_t numAgedOut{};
+  int64_t numAgedOut{0};
+  /// Total number of entries that are stale because of cache request size
+  /// mismatch.
+  int64_t numStales{0};
   /// Cumulative clocks spent in allocating or freeing memory for backing cache
   /// entries.
   uint64_t allocClocks{0};
@@ -673,7 +676,9 @@ class CacheShard {
   // 'numEvict_' measured efficiency of eviction.
   uint64_t numEvictChecks_{0};
   // Cumulative count of entries aged out due to TTL.
-  uint64_t numAgedOut_{};
+  uint64_t numAgedOut_{0};
+  // Cumulative count of stale entries because of cache request size mismatch.
+  uint64_t numStales_{0};
   // Cumulative sum of evict scores. This divided by 'numEvict_' correlates to
   // time data stays in cache.
   uint64_t sumEvictScore_{0};

--- a/velox/common/caching/SsdCache.cpp
+++ b/velox/common/caching/SsdCache.cpp
@@ -42,6 +42,8 @@ SsdCache::SsdCache(const Config& config)
       filePrefix_);
   VELOX_CHECK_NOT_NULL(executor_);
 
+  VELOX_SSD_CACHE_LOG(INFO) << "SSD cache config: " << config.toString();
+
   auto checksumReadVerificationEnabled = config.checksumReadVerificationEnabled;
   if (config.checksumReadVerificationEnabled && !config.checksumEnabled) {
     VELOX_SSD_CACHE_LOG(WARNING)

--- a/velox/common/caching/SsdFile.h
+++ b/velox/common/caching/SsdFile.h
@@ -162,6 +162,8 @@ struct SsdCacheStats {
     readSsdErrors = tsanAtomicValue(other.readSsdErrors);
     readCheckpointErrors = tsanAtomicValue(other.readCheckpointErrors);
     readSsdCorruptions = tsanAtomicValue(other.readSsdCorruptions);
+    readWithoutChecksumChecks =
+        tsanAtomicValue(other.readWithoutChecksumChecks);
   }
 
   SsdCacheStats operator-(const SsdCacheStats& other) const {
@@ -190,6 +192,8 @@ struct SsdCacheStats {
     result.readSsdErrors = readSsdErrors - other.readSsdErrors;
     result.readCheckpointErrors =
         readCheckpointErrors - other.readCheckpointErrors;
+    result.readWithoutChecksumChecks =
+        readWithoutChecksumChecks - other.readWithoutChecksumChecks;
     return result;
   }
 
@@ -220,6 +224,7 @@ struct SsdCacheStats {
   tsan_atomic<uint32_t> readSsdErrors{0};
   tsan_atomic<uint32_t> readCheckpointErrors{0};
   tsan_atomic<uint32_t> readSsdCorruptions{0};
+  tsan_atomic<uint32_t> readWithoutChecksumChecks{0};
 };
 
 /// A shard of SsdCache. Corresponds to one file on SSD. The data backed by each

--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -904,14 +904,39 @@ TEST_P(AsyncDataCacheTest, cacheStats) {
   stats.numAgedOut = 10;
   stats.allocClocks = 1320;
   stats.sumEvictScore = 123;
+  stats.numStales = 100;
   ASSERT_EQ(
       stats.toString(),
       "Cache size: 2.56KB tinySize: 257B large size: 2.31KB\n"
       "Cache entries: 100 read pins: 30 write pins: 20 pinned shared: 10.00MB pinned exclusive: 10.00MB\n"
       " num write wait: 244 empty entries: 20\n"
-      "Cache access miss: 2041 hit: 46 hit bytes: 1.34KB eviction: 463 eviction checks: 348 aged out: 10\n"
+      "Cache access miss: 2041 hit: 46 hit bytes: 1.34KB eviction: 463 eviction checks: 348 aged out: 10 stales: 100\n"
       "Prefetch entries: 30 bytes: 100B\n"
       "Alloc Megaclocks 0");
+
+  CacheStats statsDelta = stats - stats;
+  ASSERT_EQ(statsDelta.tinySize, 0);
+  ASSERT_EQ(statsDelta.largeSize, 0);
+  ASSERT_EQ(statsDelta.tinyPadding, 0);
+  ASSERT_EQ(statsDelta.largePadding, 0);
+  ASSERT_EQ(statsDelta.numEntries, 0);
+  ASSERT_EQ(statsDelta.numExclusive, 0);
+  ASSERT_EQ(statsDelta.numShared, 0);
+  ASSERT_EQ(statsDelta.sharedPinnedBytes, 0);
+  ASSERT_EQ(statsDelta.exclusivePinnedBytes, 0);
+  ASSERT_EQ(statsDelta.numEmptyEntries, 0);
+  ASSERT_EQ(statsDelta.numPrefetch, 0);
+  ASSERT_EQ(statsDelta.prefetchBytes, 0);
+  ASSERT_EQ(statsDelta.numHit, 0);
+  ASSERT_EQ(statsDelta.hitBytes, 0);
+  ASSERT_EQ(statsDelta.numNew, 0);
+  ASSERT_EQ(statsDelta.numEvict, 0);
+  ASSERT_EQ(statsDelta.numEvictChecks, 0);
+  ASSERT_EQ(statsDelta.numWaitExclusive, 0);
+  ASSERT_EQ(statsDelta.numAgedOut, 0);
+  ASSERT_EQ(statsDelta.allocClocks, 0);
+  ASSERT_EQ(statsDelta.sumEvictScore, 0);
+  ASSERT_EQ(statsDelta.numStales, 0);
 
   constexpr uint64_t kRamBytes = 32 << 20;
   constexpr uint64_t kSsdBytes = 512UL << 20;
@@ -921,7 +946,7 @@ TEST_P(AsyncDataCacheTest, cacheStats) {
       "Cache size: 0B tinySize: 0B large size: 0B\n"
       "Cache entries: 0 read pins: 0 write pins: 0 pinned shared: 0B pinned exclusive: 0B\n"
       " num write wait: 0 empty entries: 0\n"
-      "Cache access miss: 0 hit: 0 hit bytes: 0B eviction: 0 eviction checks: 0 aged out: 0\n"
+      "Cache access miss: 0 hit: 0 hit bytes: 0B eviction: 0 eviction checks: 0 aged out: 0 stales: 0\n"
       "Prefetch entries: 0 bytes: 0B\n"
       "Alloc Megaclocks 0\n"
       "Allocated pages: 0 cached pages: 0\n"
@@ -945,11 +970,52 @@ TEST_P(AsyncDataCacheTest, cacheStats) {
       "Cache size: 0B tinySize: 0B large size: 0B\n"
       "Cache entries: 0 read pins: 0 write pins: 0 pinned shared: 0B pinned exclusive: 0B\n"
       " num write wait: 0 empty entries: 0\n"
-      "Cache access miss: 0 hit: 0 hit bytes: 0B eviction: 0 eviction checks: 0 aged out: 0\n"
+      "Cache access miss: 0 hit: 0 hit bytes: 0B eviction: 0 eviction checks: 0 aged out: 0 stales: 0\n"
       "Prefetch entries: 0 bytes: 0B\n"
       "Alloc Megaclocks 0\n"
       "Allocated pages: 0 cached pages: 0\n";
   ASSERT_EQ(cache_->toString(false), expectedShortCacheOutput);
+}
+
+TEST_P(AsyncDataCacheTest, staleEntry) {
+  constexpr uint64_t kRamBytes = 1UL << 30;
+  // Disable SSD cache to test in-memory cache stale entry only.
+  initializeCache(kRamBytes, 0, 0);
+  StringIdLease file(fileIds(), std::string_view("staleEntry"));
+  const uint64_t offset = 1000;
+  const uint64_t size = 200;
+  folly::SemiFuture<bool> wait(false);
+  RawFileCacheKey key{file.id(), offset};
+  auto pin = cache_->findOrCreate(key, size, &wait);
+  ASSERT_FALSE(pin.empty());
+  ASSERT_TRUE(wait.isReady());
+  ASSERT_TRUE(pin.entry()->isExclusive());
+  pin.entry()->setExclusiveToShared();
+  ASSERT_FALSE(pin.entry()->isExclusive());
+  auto stats = cache_->refreshStats();
+  ASSERT_EQ(stats.numStales, 0);
+  ASSERT_EQ(stats.numEntries, 1);
+  ASSERT_EQ(stats.numHit, 0);
+
+  auto validPin = cache_->findOrCreate(key, size, &wait);
+  ASSERT_FALSE(validPin.empty());
+  ASSERT_TRUE(wait.isReady());
+  ASSERT_FALSE(validPin.entry()->isExclusive());
+  stats = cache_->refreshStats();
+  ASSERT_EQ(stats.numStales, 0);
+  ASSERT_EQ(stats.numEntries, 1);
+  ASSERT_EQ(stats.numHit, 1);
+
+  // Stale cache access with large cache size.
+  auto stalePin = cache_->findOrCreate(key, 2 * size, &wait);
+  ASSERT_FALSE(stalePin.empty());
+  ASSERT_TRUE(wait.isReady());
+  ASSERT_TRUE(stalePin.entry()->isExclusive());
+  stalePin.entry()->setExclusiveToShared();
+  stats = cache_->refreshStats();
+  ASSERT_EQ(stats.numStales, 1);
+  ASSERT_EQ(stats.numEntries, 1);
+  ASSERT_EQ(stats.numHit, 1);
 }
 
 TEST_P(AsyncDataCacheTest, shrinkCache) {

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -744,7 +744,7 @@ TEST_P(MemoryPoolTest, memoryCapExceptions) {
                     "0 write pins: 0 pinned shared: 0B pinned exclusive: 0B\n "
                     "num write wait: 0 empty entries: 0\nCache access miss: 0 "
                     "hit: 0 hit bytes: 0B eviction: 0 eviction checks: 0 "
-                    "aged out: 0\nPrefetch entries: 0 bytes: 0B\nAlloc Megaclocks 0\n"
+                    "aged out: 0 stales: 0\nPrefetch entries: 0 bytes: 0B\nAlloc Megaclocks 0\n"
                     "Allocated pages: 0 cached pages: 0\n",
                     isLeafThreadSafe_ ? "thread-safe" : "non-thread-safe"),
                 ex.message());
@@ -778,7 +778,7 @@ TEST_P(MemoryPoolTest, memoryCapExceptions) {
                     "read pins: 0 write pins: 0 pinned shared: 0B pinned "
                     "exclusive: 0B\n num write wait: 0 empty entries: 0\nCache "
                     "access miss: 0 hit: 0 hit bytes: 0B eviction: 0 eviction "
-                    "checks: 0 aged out: 0\nPrefetch entries: 0 bytes: 0B\nAlloc Megaclocks"
+                    "checks: 0 aged out: 0 stales: 0\nPrefetch entries: 0 bytes: 0B\nAlloc Megaclocks"
                     " 0\nAllocated pages: 0 cached pages: 0\n",
                     isLeafThreadSafe_ ? "thread-safe" : "non-thread-safe"),
                 ex.message());

--- a/velox/connectors/hive/HiveDataSource.h
+++ b/velox/connectors/hive/HiveDataSource.h
@@ -166,7 +166,7 @@ class HiveDataSource : public DataSource {
   std::atomic<uint64_t> totalRemainingFilterTime_{0};
   uint64_t completedRows_ = 0;
 
-  // Field indices referenced in both remaining filter and output type.  These
+  // Field indices referenced in both remaining filter and output type. These
   // columns need to be materialized eagerly to avoid missing values in output.
   std::vector<column_index_t> multiReferencedFields_;
 

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -304,9 +304,7 @@ bool SplitReader::checkIfSplitIsEmpty(
 }
 
 void SplitReader::createRowReader() {
-  // NOTE: we firstly reset the finished 'baseRowReader_' of previous split
-  // before setting up for the next one to avoid doubling the peak memory usage.
-  baseRowReader_.reset();
+  VELOX_CHECK_NULL(baseRowReader_);
   baseRowReader_ = baseReader_->createRowReader(baseRowReaderOpts_);
 }
 

--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -305,6 +305,10 @@ Cache
      - Sum
      - Number of AsyncDataCache entries that are aged out and evicted.
        given configured TTL.
+   * - memory_cache_num_stale_entries
+     - Count
+     - Number of AsyncDataCache entries that are stale because of cache request
+       size mismatch.
    * - ssd_cache_cached_regions
      - Avg
      - Number of regions currently cached by SSD.
@@ -346,6 +350,10 @@ Cache
    * - ssd_cache_delete_checkpoint_errors
      - Sum
      - Total number of errors while deleting SSD checkpoint files.
+   * - ssd_cache_read_without_checksum
+     - Sum
+     - Total number of SSD cache reads without checksum verification
+       due to SSD cache request size mismatch
    * - ssd_cache_grow_file_errors
      - Sum
      - Total number of errors while growing SSD cache files.
@@ -466,6 +474,11 @@ Exchange
    * - exchange_data_bytes
      - Sum
      - The exchange data size in bytes.
+   * - exchange_data_size
+     - Histogram
+     - The distribution of exchange data size in range of [0, 128MB] with 128
+       buckets. It is configured to report the capacity at P50, P90, P99, and P100
+       percentiles.
 
 Hive Connector
 --------------

--- a/velox/dwio/common/OnDemandUnitLoader.cpp
+++ b/velox/dwio/common/OnDemandUnitLoader.cpp
@@ -40,7 +40,7 @@ class OnDemandUnitLoader : public UnitLoader {
   ~OnDemandUnitLoader() override = default;
 
   LoadUnit& getLoadedUnit(uint32_t unit) override {
-    VELOX_CHECK(unit < loadUnits_.size(), "Unit out of range");
+    VELOX_CHECK_LT(unit, loadUnits_.size(), "Unit out of range");
 
     if (loadedUnit_) {
       if (*loadedUnit_ == unit) {

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.h
@@ -336,7 +336,7 @@ class E2EFilterTestBase : public testing::Test {
   std::shared_ptr<memory::MemoryPool> rootPool_;
   std::shared_ptr<memory::MemoryPool> leafPool_;
   std::shared_ptr<const RowType> rowType_;
-  std::string_view sinkData_;
+  std::string sinkData_;
   bool useVInts_ = true;
   dwio::common::RuntimeStatistics runtimeStats_;
   // Number of calls to flush policy between starting new stripes.

--- a/velox/dwio/dwrf/reader/DwrfData.cpp
+++ b/velox/dwio/dwrf/reader/DwrfData.cpp
@@ -39,11 +39,10 @@ DwrfData::DwrfData(
     notNullDecoder_ = createBooleanRleDecoder(std::move(stream), encodingKey);
   }
 
-  // We always initialize indexStream_ because indices are needed as
-  // soon as there is a single filter that can trigger row group skips
-  // anywhere in the reader tree. This is not known at construct time
-  // because the first filter can come from a hash join or other run
-  // time pushdown.
+  // We always initialize indexStream_ because indices are needed as soon as
+  // there is a single filter that can trigger row group skips anywhere in the
+  // reader tree. This is not known at construct time because the first filter
+  // can come from a hash join or other run time push-down.
   indexStream_ = stripe.getStream(
       encodingKey.forKind(proto::Stream_Kind_ROW_INDEX),
       streamLabels.label(),

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -305,7 +305,7 @@ DwrfRowReader::DwrfRowReader(
 }
 
 std::unique_ptr<ColumnReader>& DwrfRowReader::getColumnReader() {
-  VELOX_DCHECK(currentUnit_ != nullptr);
+  VELOX_DCHECK_NOT_NULL(currentUnit_);
   return currentUnit_->getColumnReader();
 }
 
@@ -603,7 +603,7 @@ uint64_t DwrfRowReader::next(
     uint64_t size,
     velox::VectorPtr& result,
     const dwio::common::Mutation* mutation) {
-  auto nextRow = nextRowNumber();
+  const auto nextRow = nextRowNumber();
   if (nextRow == kAtEnd) {
     if (!isEmptyFile()) {
       previousRow_ = firstRowOfStripe_[stripeCeiling_ - 1] +

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -132,6 +132,33 @@ class DwrfRowReader : public StrideIndexProvider,
   }
 
  private:
+  bool shouldReadNode(uint32_t nodeId) const;
+
+  std::optional<size_t> estimatedRowSizeHelper(
+      const FooterWrapper& fileFooter,
+      const dwio::common::Statistics& stats,
+      uint32_t nodeId) const;
+
+  bool isEmptyFile() const {
+    return stripeCeiling_ == firstStripe_;
+  }
+
+  void checkSkipStrides(uint64_t strideSize);
+
+  void readNext(
+      uint64_t rowsToRead,
+      const dwio::common::Mutation*,
+      VectorPtr& result);
+
+  uint64_t skip(uint64_t numValues);
+
+  std::unique_ptr<ColumnReader>& getColumnReader();
+
+  std::unique_ptr<dwio::common::SelectiveColumnReader>&
+  getSelectiveColumnReader();
+
+  std::unique_ptr<dwio::common::UnitLoader> getUnitLoader();
+
   // footer
   std::vector<uint64_t> firstRowOfStripe_;
   mutable std::shared_ptr<const dwio::common::TypeWithId> selectedSchema_;
@@ -173,35 +200,6 @@ class DwrfRowReader : public StrideIndexProvider,
 
   std::unique_ptr<dwio::common::UnitLoader> unitLoader_;
   DwrfUnit* currentUnit_;
-
-  // internal methods
-
-  bool shouldReadNode(uint32_t nodeId) const;
-
-  std::optional<size_t> estimatedRowSizeHelper(
-      const FooterWrapper& fileFooter,
-      const dwio::common::Statistics& stats,
-      uint32_t nodeId) const;
-
-  bool isEmptyFile() const {
-    return (stripeCeiling_ == firstStripe_);
-  }
-
-  void checkSkipStrides(uint64_t strideSize);
-
-  void readNext(
-      uint64_t rowsToRead,
-      const dwio::common::Mutation*,
-      VectorPtr& result);
-
-  uint64_t skip(uint64_t numValues);
-
-  std::unique_ptr<ColumnReader>& getColumnReader();
-
-  std::unique_ptr<dwio::common::SelectiveColumnReader>&
-  getSelectiveColumnReader();
-
-  std::unique_ptr<dwio::common::UnitLoader> getUnitLoader();
 };
 
 class DwrfReader : public dwio::common::Reader {

--- a/velox/dwio/dwrf/reader/ReaderBase.h
+++ b/velox/dwio/dwrf/reader/ReaderBase.h
@@ -60,7 +60,7 @@ class FooterStatisticsImpl : public dwio::common::Statistics {
 
 class ReaderBase {
  public:
-  // create reader base from buffered input
+  /// Creates reader base from buffered input.
   ReaderBase(
       memory::MemoryPool& pool,
       std::unique_ptr<dwio::common::BufferedInput> input,
@@ -80,7 +80,7 @@ class ReaderBase {
       std::unique_ptr<dwio::common::BufferedInput> input,
       dwio::common::FileFormat fileFormat);
 
-  // create reader base from metadata
+  /// Creates reader base from metadata.
   ReaderBase(
       memory::MemoryPool& pool,
       std::unique_ptr<dwio::common::BufferedInput> input,
@@ -94,18 +94,18 @@ class ReaderBase {
         cache_{std::move(cache)},
         handler_{std::move(handler)},
         input_{std::move(input)},
+        fileLength_{0},
         schema_{
             std::dynamic_pointer_cast<const RowType>(convertType(*footer_))},
-        fileLength_{0},
         psLength_{0} {
-    DWIO_ENSURE_NOT_NULL(schema_, "invalid schema");
+    VELOX_CHECK_NOT_NULL(schema_, "invalid schema");
     if (!handler_) {
       handler_ = encryption::DecryptionHandler::create(*footer);
     }
   }
 
   // for testing
-  explicit ReaderBase(memory::MemoryPool& pool) : pool_{pool} {}
+  explicit ReaderBase(memory::MemoryPool& pool) : pool_{pool}, fileLength_{0} {}
 
   virtual ~ReaderBase() = default;
 
@@ -260,13 +260,14 @@ class ReaderBase {
   const uint64_t filePreloadThreshold_{
       dwio::common::ReaderOptions::kDefaultFilePreloadThreshold};
 
-  std::unique_ptr<dwio::common::BufferedInput> input_;
+  const std::unique_ptr<dwio::common::BufferedInput> input_;
   const std::shared_ptr<random::RandomSkipTracker> randomSkip_;
   const std::shared_ptr<velox::common::ScanSpec> scanSpec_;
+  const uint64_t fileLength_;
+
   RowTypePtr schema_;
   // Lazily populated
   mutable std::shared_ptr<const dwio::common::TypeWithId> schemaWithId_;
-  uint64_t fileLength_;
   uint64_t psLength_;
 };
 

--- a/velox/dwio/dwrf/reader/StripeReaderBase.cpp
+++ b/velox/dwio/dwrf/reader/StripeReaderBase.cpp
@@ -27,7 +27,7 @@ std::unique_ptr<const StripeMetadata> StripeReaderBase::fetchStripe(
     uint32_t index,
     bool& preload) const {
   auto& fileFooter = reader_->getFooter();
-  DWIO_ENSURE_LT(index, fileFooter.stripesSize(), "invalid stripe index");
+  VELOX_CHECK_LT(index, fileFooter.stripesSize(), "invalid stripe index");
   auto stripe = fileFooter.stripes(index);
   auto& cache = reader_->getMetadataCache();
 

--- a/velox/dwio/dwrf/reader/StripeStream.cpp
+++ b/velox/dwio/dwrf/reader/StripeStream.cpp
@@ -344,15 +344,18 @@ StripeStreamsImpl::getIndexStreamFromCache(
     if (indexBase) {
       auto offset = info.getOffset();
       auto length = info.getLength();
-      if (auto cacheInput =
+      if (auto* cacheInput =
               dynamic_cast<dwio::common::CacheInputStream*>(indexBase.get())) {
         cacheInput->Skip(offset);
         cacheInput->setRemainingBytes(length);
         return indexBase;
       }
       const void* start;
-      int32_t ignored;
-      DWIO_ENSURE(indexBase->Next(&start, &ignored), "failed to read index");
+      {
+        int32_t ignored;
+        const bool ret = indexBase->Next(&start, &ignored);
+        VELOX_CHECK(ret, "Failed to read index");
+      }
       indexStream = std::make_unique<dwio::common::SeekableArrayInputStream>(
           static_cast<const char*>(start) + offset, length);
     }

--- a/velox/dwio/dwrf/reader/StripeStream.h
+++ b/velox/dwio/dwrf/reader/StripeStream.h
@@ -218,31 +218,6 @@ struct StripeReadState {
  * StripeStream Implementation
  */
 class StripeStreamsImpl : public StripeStreamsBase {
- private:
-  std::shared_ptr<StripeReadState> readState_;
-  const dwio::common::ColumnSelector* selector_;
-  const dwio::common::RowReaderOptions& opts_;
-  // When selector_ is null, this needs to be passed in constructor; otherwise
-  // leave it as null and it will be populated from selector_.
-  std::shared_ptr<BitSet> projectedNodes_;
-  const uint64_t stripeStart_;
-  const int64_t stripeNumberOfRows_;
-  const StrideIndexProvider& provider_;
-  const uint32_t stripeIndex_;
-  bool readPlanLoaded_;
-
-  void loadStreams();
-
-  // map of stream id -> stream information
-  folly::F14FastMap<
-      DwrfStreamIdentifier,
-      StreamInformationImpl,
-      dwio::common::StreamIdentifierHash>
-      streams_;
-  folly::F14FastMap<EncodingKey, uint32_t, EncodingKeyHash> encodings_;
-  folly::F14FastMap<EncodingKey, proto::ColumnEncoding, EncodingKeyHash>
-      decryptedEncodings_;
-
  public:
   static constexpr int64_t kUnknownStripeRows = -1;
 
@@ -342,7 +317,7 @@ class StripeStreamsImpl : public StripeStreamsBase {
       const bool throwIfNotFound = true) const {
     auto index = streams_.find(si);
     if (index == streams_.end()) {
-      DWIO_ENSURE(!throwIfNotFound, "stream info not found: ", si.toString());
+      VELOX_CHECK(!throwIfNotFound, "stream info not found: ", si.toString());
       return StreamInformationImpl::getNotFound();
     }
 
@@ -359,6 +334,31 @@ class StripeStreamsImpl : public StripeStreamsBase {
         ? std::addressof(handler.getEncryptionProvider(nodeId))
         : nullptr;
   }
+
+  void loadStreams();
+
+  const std::shared_ptr<StripeReadState> readState_;
+  const dwio::common::ColumnSelector* const selector_;
+  const dwio::common::RowReaderOptions& opts_;
+  // When selector_ is null, this needs to be passed in constructor; otherwise
+  // leave it as null and it will be populated from selector_.
+  std::shared_ptr<BitSet> projectedNodes_;
+  const uint64_t stripeStart_;
+  const int64_t stripeNumberOfRows_;
+  const StrideIndexProvider& provider_;
+  const uint32_t stripeIndex_;
+
+  bool readPlanLoaded_;
+
+  // map of stream id -> stream information
+  folly::F14FastMap<
+      DwrfStreamIdentifier,
+      StreamInformationImpl,
+      dwio::common::StreamIdentifierHash>
+      streams_;
+  folly::F14FastMap<EncodingKey, uint32_t, EncodingKeyHash> encodings_;
+  folly::F14FastMap<EncodingKey, proto::ColumnEncoding, EncodingKeyHash>
+      decryptedEncodings_;
 };
 
 /**

--- a/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
@@ -189,8 +189,9 @@ class ColumnWriterStatsTest : public ::testing::Test {
 
     writer.close();
 
-    std::string_view data(sinkPtr->data(), sinkPtr->size());
-    auto readFile = std::make_shared<facebook::velox::InMemoryReadFile>(data);
+    std::string data(sinkPtr->data(), sinkPtr->size());
+    auto readFile =
+        std::make_shared<facebook::velox::InMemoryReadFile>(std::move(data));
     auto input = std::make_unique<BufferedInput>(readFile, *leafPool_);
 
     dwio::common::ReaderOptions readerOpts{leafPool_.get()};

--- a/velox/dwio/dwrf/test/ColumnWriterTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTest.cpp
@@ -1596,12 +1596,13 @@ std::unique_ptr<DwrfReader> getDwrfReader(
   writer.write(batch);
   writer.close();
 
-  std::string_view data(sinkPtr->data(), sinkPtr->size());
+  std::string data(sinkPtr->data(), sinkPtr->size());
   dwio::common::ReaderOptions readerOpts{&leafPool};
   return std::make_unique<DwrfReader>(
       readerOpts,
       std::make_unique<BufferedInput>(
-          std::make_shared<InMemoryReadFile>(data), readerOpts.memoryPool()));
+          std::make_shared<InMemoryReadFile>(std::move(data)),
+          readerOpts.memoryPool()));
 }
 
 void removeSizeFromStats(std::string& input) {

--- a/velox/dwio/dwrf/test/ReaderBaseTests.cpp
+++ b/velox/dwio/dwrf/test/ReaderBaseTests.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 #include <cstring>
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/dwio/common/InputStream.h"
 #include "velox/dwio/common/encryption/TestProvider.h"
 #include "velox/dwio/common/exception/Exception.h"
@@ -210,7 +211,7 @@ std::unique_ptr<ReaderBase> createCorruptedFileReader(
 
   sink.write(std::move(buf));
   auto readFile = std::make_shared<facebook::velox::InMemoryReadFile>(
-      std::string_view(sink.data(), sink.size()));
+      std::string(sink.data(), sink.size()));
   return std::make_unique<ReaderBase>(
       *pool, std::make_unique<BufferedInput>(readFile, *pool));
 }
@@ -223,8 +224,10 @@ class ReaderBaseTest : public Test {
 };
 
 TEST_F(ReaderBaseTest, InvalidPostScriptThrows) {
-  EXPECT_THROW(
-      { createCorruptedFileReader(1'000'000, 0); }, exception::LoggedException);
-  EXPECT_THROW(
-      { createCorruptedFileReader(0, 1'000'000); }, exception::LoggedException);
+  VELOX_ASSERT_THROW(
+      createCorruptedFileReader(1'000'000, 0),
+      "Corrupted file, footer size is invalid");
+  VELOX_ASSERT_THROW(
+      createCorruptedFileReader(0, 1'000'000),
+      "Corrupted file, cache size is invalid");
 }

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -1735,9 +1735,9 @@ TEST_F(TestReader, testEmptyFile) {
   DataBuffer<char> buf{*pool(), 1};
   buf.data()[0] = psLen;
   sink.write(std::move(buf));
-  std::string_view data(sink.data(), sink.size());
+  std::string data(sink.data(), sink.size());
   auto input = std::make_unique<BufferedInput>(
-      std::make_shared<InMemoryReadFile>(data), *pool());
+      std::make_shared<InMemoryReadFile>(std::move(data)), *pool());
 
   dwio::common::ReaderOptions readerOpts{pool()};
   RowReaderOptions rowReaderOpts;
@@ -1838,9 +1838,9 @@ void testBufferLifeCycle(
   auto writer =
       E2EWriterTestUtil::writeData(std::move(sink), schema, batches, config);
 
-  std::string_view data(sinkPtr->data(), sinkPtr->size());
+  std::string data(sinkPtr->data(), sinkPtr->size());
   auto input = std::make_unique<BufferedInput>(
-      std::make_shared<InMemoryReadFile>(data), *pool);
+      std::make_shared<InMemoryReadFile>(std::move(data)), *pool);
 
   dwio::common::ReaderOptions readerOpts{pool};
   RowReaderOptions rowReaderOpts;
@@ -1896,9 +1896,9 @@ void testFlatmapAsMapFieldLifeCycle(
   auto writer =
       E2EWriterTestUtil::writeData(std::move(sink), schema, batches, config);
 
-  std::string_view data(sinkPtr->data(), sinkPtr->size());
+  std::string data(sinkPtr->data(), sinkPtr->size());
   auto input = std::make_unique<BufferedInput>(
-      std::make_shared<InMemoryReadFile>(data), *pool);
+      std::make_shared<InMemoryReadFile>(std::move(data)), *pool);
 
   dwio::common::ReaderOptions readerOpts{pool};
   RowReaderOptions rowReaderOpts;
@@ -2088,9 +2088,9 @@ createWriterReader(
       batches,
       config,
       std::move(flushPolicy));
-  std::string_view data(sinkPtr->data(), sinkPtr->size());
+  std::string data(sinkPtr->data(), sinkPtr->size());
   auto input = std::make_unique<BufferedInput>(
-      std::make_shared<InMemoryReadFile>(data), *pool);
+      std::make_shared<InMemoryReadFile>(std::move(data)), *pool);
   dwio::common::ReaderOptions readerOpts(pool);
   readerOpts.setFileFormat(FileFormat::DWRF);
   auto reader = DwrfReader::create(std::move(input), readerOpts);

--- a/velox/dwio/dwrf/test/WriterTest.cpp
+++ b/velox/dwio/dwrf/test/WriterTest.cpp
@@ -58,8 +58,8 @@ class WriterTest : public Test {
   }
 
   std::unique_ptr<ReaderBase> createReader() {
-    std::string_view data(sinkPtr_->data(), sinkPtr_->size());
-    auto readFile = std::make_shared<InMemoryReadFile>(data);
+    std::string data(sinkPtr_->data(), sinkPtr_->size());
+    auto readFile = std::make_shared<InMemoryReadFile>(std::move(data));
     auto input = std::make_unique<BufferedInput>(std::move(readFile), *pool_);
     return std::make_unique<ReaderBase>(*pool_, std::move(input));
   }

--- a/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
+++ b/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
@@ -111,7 +111,7 @@ namespace facebook::velox::dwrf {
       writerMemoryCap);
   // read it back and compare
   auto readFile = std::make_shared<InMemoryReadFile>(
-      std::string_view(sinkPtr->data(), sinkPtr->size()));
+      std::string(sinkPtr->data(), sinkPtr->size()));
   auto input = std::make_unique<BufferedInput>(readFile, pool);
 
   dwio::common::ReaderOptions readerOpts{&pool};
@@ -126,7 +126,7 @@ namespace facebook::velox::dwrf {
   size_t dictEncodingCount = 0;
   size_t totalEncodingCount = 0;
   for (size_t i = 0; i < reader->getNumberOfStripes(); ++i) {
-    bool preload;
+    bool preload{false};
     auto stripeMetadata = dwrfRowReader->fetchStripe(i, preload);
     const auto& stripeFooter = *stripeMetadata->footer;
     totalEncodingCount += stripeFooter.encoding_size();

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -59,10 +59,11 @@ class ParquetWriterTest : public ParquetTestBase {
   std::unique_ptr<facebook::velox::parquet::ParquetReader> createReaderInMemory(
       const dwio::common::MemorySink& sink,
       const dwio::common::ReaderOptions& opts) {
-    std::string_view data(sink.data(), sink.size());
+    std::string data(sink.data(), sink.size());
     return std::make_unique<facebook::velox::parquet::ParquetReader>(
         std::make_unique<dwio::common::BufferedInput>(
-            std::make_shared<InMemoryReadFile>(data), opts.memoryPool()),
+            std::make_shared<InMemoryReadFile>(std::move(data)),
+            opts.memoryPool()),
         opts);
   };
 

--- a/velox/exec/ExchangeClient.cpp
+++ b/velox/exec/ExchangeClient.cpp
@@ -165,8 +165,10 @@ void ExchangeClient::request(std::vector<RequestSpec>&& requestSpecs) {
           } else {
             RECORD_HISTOGRAM_METRIC_VALUE(
                 kMetricExchangeDataTimeMs, requestTimeMs);
+            RECORD_METRIC_VALUE(kMetricExchangeDataBytes, response.bytes);
+            RECORD_HISTOGRAM_METRIC_VALUE(
+                kMetricExchangeDataSize, response.bytes);
           }
-          RECORD_METRIC_VALUE(kMetricExchangeDataBytes, response.bytes);
 
           std::vector<RequestSpec> requestSpecs;
           {


### PR DESCRIPTION
Make sure that stripe metadata cache caches file footer up to next load quantum or the tail to
avoid cache request size mismatch which cause unnecessary cache invalidation and enable 
checksum verification on all ssd reads. We have verified using Presto interactive workloads that
all the SSD cache read sizes match the on-disk SSD cache entry sizes. This PR adds counters
to record the number of times that in-memory cache entries get invalidates because of short
cache entry size as well as the number of times that on-disk SSD cache read checksum verifcations
get skipped because of size mismatch. We will enforce check in SSD cache to disallow SSD cache
request size mismatch after rolling out in production for a while.
Some code cleanup in split reader