### PR TITLE
Running free() multiple times on the same memory block should result in an error

### DIFF
--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -443,6 +443,7 @@ void HashStringAllocator::free(Header* header) {
           removeFromFreeList(next);
           headerToFree->setSize(
               headerToFree->size() + next->size() + sizeof(Header));
+          next->setFree();
           next = reinterpret_cast<Header*>(headerToFree->end());
           VELOX_CHECK(next->isArenaEnd() || !next->isFree());
         }


### PR DESCRIPTION
Currently, HashStringAllocator can execute free() multiple times on the same memory block ,which causes incorrect results for `freeBytes_` and `cumulativeBytes_` in `HashStringAllocator`.

CC: @xiaoxmeng @mbasmanova 