### PR TITLE
Add metrics to track shuffle data and transfer times

### DIFF
--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -457,5 +457,19 @@ void registerVeloxMetrics() {
 
   // The peak spilling memory usage in bytes.
   DEFINE_METRIC(kMetricSpillPeakMemoryBytes, facebook::velox::StatType::AVG);
+
+  // The data exchange time distribution in range of [0, 5s] with 50 buckets. It
+  // is configured to report the latency at P50, P90, P99, and P100 percentiles.
+  DEFINE_HISTOGRAM_METRIC(
+      kMetricExchangeDataTimeMs, 1'00, 0, 5'000, 50, 90, 99, 100);
+
+  // The data exchange size time distribution in range of [0, 5s] with 50
+  // buckets. It is configured to report the latency at P50, P90, P99, and P100
+  // percentiles.
+  DEFINE_HISTOGRAM_METRIC(
+      kMetricExchangeDataSizeTimeMs, 1'00, 0, 5'000, 50, 90, 99, 100);
+
+  // The exchange data size in bytes.
+  DEFINE_METRIC(kMetricExchangeDataBytes, facebook::velox::StatType::SUM);
 }
 } // namespace facebook::velox

--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -286,4 +286,13 @@ constexpr folly::StringPiece kMetricSsdCacheCheckpointsWritten{
 
 constexpr folly::StringPiece kMetricSsdCacheRegionsEvicted{
     "velox.ssd_cache_regions_evicted"};
+
+constexpr folly::StringPiece kMetricExchangeDataTimeMs{
+    "velox.exchange_data_time_ms"};
+
+constexpr folly::StringPiece kMetricExchangeDataSizeTimeMs{
+    "velox.exchange_data_size_time_ms"};
+
+constexpr folly::StringPiece kMetricExchangeDataBytes{
+    "velox.exchange_data_bytes"};
 } // namespace facebook::velox

--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -443,6 +443,30 @@ Spilling
      - Avg
      - The peak spilling memory usage in bytes.
 
+Exchange
+--------
+
+.. list-table::
+   :widths: 40 10 50
+   :header-rows: 1
+
+   * - Metric Name
+     - Type
+     - Description
+   * - exchange_data_time_ms
+     - Histogram
+     - The distribution of data exchange latency in range of [0, 50s] with 50
+       buckets. It is configured to report latency at P50, P90, P99, and P100
+       percentiles.
+   * - exchange_data_size_time_ms
+     - Histogram
+     - The distribution of data exchange size latency in range of [0, 5s] with 50
+       buckets. It is configured to report latency at P50, P90, P99, and P100
+       percentiles.
+   * - exchange_data_bytes
+     - Sum
+     - The exchange data size in bytes.
+
 Hive Connector
 --------------
 


### PR DESCRIPTION
Add metrics to track the time distribution of exchange data and exchange data size transfer, as well
as the exchange data volume.