### PR TITLE
Implement bucket conversion in HiveDataSource

### DIFF
--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -263,7 +263,7 @@ void SplitReader::createReader(
   auto columnTypes = adaptColumns(fileType, baseReaderOpts_.fileSchema());
   auto columnNames = fileType->names();
   if (rowIndexColumn != nullptr) {
-    setRowIndexColumn(fileType, rowIndexColumn);
+    setRowIndexColumn(rowIndexColumn);
   }
   configureRowReaderOptions(
       baseRowReaderOpts_,
@@ -311,15 +311,11 @@ void SplitReader::createRowReader() {
 }
 
 void SplitReader::setRowIndexColumn(
-    const RowTypePtr& fileType,
     const std::shared_ptr<HiveColumnHandle>& rowIndexColumn) {
-  auto rowIndexColumnName = rowIndexColumn->name();
-  auto rowIndexMetaColIdx =
-      readerOutputType_->getChildIdxIfExists(rowIndexColumnName);
   dwio::common::RowNumberColumnInfo rowNumberColumnInfo;
-  VELOX_CHECK(rowIndexMetaColIdx.has_value());
-  rowNumberColumnInfo.insertPosition = rowIndexMetaColIdx.value();
-  rowNumberColumnInfo.name = rowIndexColumnName;
+  rowNumberColumnInfo.insertPosition =
+      readerOutputType_->getChildIdx(rowIndexColumn->name());
+  rowNumberColumnInfo.name = rowIndexColumn->name();
   baseRowReaderOpts_.setRowNumberColumnInfo(std::move(rowNumberColumnInfo));
 }
 

--- a/velox/connectors/hive/SplitReader.h
+++ b/velox/connectors/hive/SplitReader.h
@@ -138,7 +138,6 @@ class SplitReader {
       const std::shared_ptr<const velox::RowType>& tableSchema);
 
   void setRowIndexColumn(
-      const RowTypePtr& fileType,
       const std::shared_ptr<HiveColumnHandle>& rowIndexColumn);
 
   void setPartitionValue(

--- a/velox/dwio/common/Reader.cpp
+++ b/velox/dwio/common/Reader.cpp
@@ -167,9 +167,9 @@ void RowReader::readWithRowNumber(
     }
   }
   VectorPtr rowNumVector;
-  auto rowNumberColumnInfo = options.getRowNumberColumnInfo();
-  VELOX_CHECK_EQ(rowNumberColumnInfo.has_value(), true);
-  auto& rowNumberColumnIndex = rowNumberColumnInfo->insertPosition;
+  auto& rowNumberColumnInfo = options.getRowNumberColumnInfo();
+  VELOX_CHECK(rowNumberColumnInfo.has_value());
+  auto rowNumberColumnIndex = rowNumberColumnInfo->insertPosition;
   auto& rowNumberColumnName = rowNumberColumnInfo->name;
   VELOX_CHECK_LE(rowNumberColumnIndex, numChildren);
   if (rowVector->childrenSize() != numChildren) {

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -605,9 +605,9 @@ TEST_F(ParquetTableScanTest, filterNullIcebergPartition) {
       std::unordered_map<std::string, std::optional<std::string>>{
           {"c1", std::nullopt}});
 
-  auto c0 = makeColumnHandle(
+  std::shared_ptr<connector::ColumnHandle> c0 = makeColumnHandle(
       "c0", BIGINT(), BIGINT(), {}, HiveColumnHandle::ColumnType::kRegular);
-  auto c1 = makeColumnHandle(
+  std::shared_ptr<connector::ColumnHandle> c1 = makeColumnHandle(
       "c1",
       BIGINT(),
       BIGINT(),

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -26,6 +26,7 @@
 #include "velox/common/testutil/TestValue.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnector.h"
+#include "velox/connectors/hive/HivePartitionFunction.h"
 #include "velox/dwio/common/CacheInputStream.h"
 #include "velox/dwio/common/tests/utils/DataFiles.h"
 #include "velox/exec/Exchange.h"
@@ -2742,6 +2743,136 @@ TEST_F(TableScanTest, bucket) {
         hsplit,
         fmt::format("SELECT * FROM tmp where c0 = {}", bucketValue));
   }
+}
+
+TEST_F(TableScanTest, bucketConversion) {
+  constexpr int kSize = 100;
+  auto vector = makeRowVector({
+      makeFlatVector<int32_t>(kSize, [](auto i) { return 2 * i + 1; }),
+      makeFlatVector<int64_t>(kSize, folly::identity),
+  });
+  auto schema = asRowType(vector->type());
+  auto file = TempFilePath::create();
+  writeToFile(file->getPath(), {vector});
+  constexpr int kNewNumBuckets = 16;
+  const int selectedBuckets[] = {3, 5, 11};
+  auto makeSplits = [&] {
+    std::vector<std::shared_ptr<connector::ConnectorSplit>> splits;
+    for (int bucket : selectedBuckets) {
+      std::vector<std::unique_ptr<HiveColumnHandle>> handles;
+      handles.push_back(makeColumnHandle("c0", INTEGER(), {}));
+      auto split = makeHiveConnectorSplit(file->getPath());
+      split->tableBucketNumber = bucket;
+      split->bucketConversion = {kNewNumBuckets, 2, std::move(handles)};
+      splits.push_back(split);
+    }
+    return splits;
+  };
+  {
+    auto outputType = ROW({"c1"}, {BIGINT()});
+    auto plan = PlanBuilder().tableScan(outputType, {}, "", schema).planNode();
+    std::vector<int64_t> c1;
+    for (int bucket : selectedBuckets) {
+      for (int i = bucket; i < 2 * kSize + 1; i += kNewNumBuckets) {
+        c1.push_back(i / 2);
+      }
+    }
+    auto expected = makeRowVector({makeFlatVector(c1)});
+    AssertQueryBuilder(plan).splits(makeSplits()).assertResults(expected);
+  }
+  {
+    SCOPED_TRACE("With remaining filter");
+    auto outputType = ROW({"c1"}, {BIGINT()});
+    auto plan = PlanBuilder()
+                    .tableScan(outputType, {}, "c1 % 7 != 0", schema)
+                    .planNode();
+    std::vector<int64_t> c1;
+    for (int bucket : selectedBuckets) {
+      for (int i = bucket; i < 2 * kSize + 1; i += kNewNumBuckets) {
+        if ((i / 2) % 7 != 0) {
+          c1.push_back(i / 2);
+        }
+      }
+    }
+    auto expected = makeRowVector({makeFlatVector(c1)});
+    AssertQueryBuilder(plan).splits(makeSplits()).assertResults(expected);
+  }
+  {
+    SCOPED_TRACE("With row number");
+    auto outputType = ROW({"c2", "c1"}, {BIGINT(), BIGINT()});
+    auto plan = PlanBuilder()
+                    .startTableScan()
+                    .outputType(outputType)
+                    .dataColumns(schema)
+                    .assignments({
+                        {"c2",
+                         std::make_shared<HiveColumnHandle>(
+                             "c2",
+                             HiveColumnHandle::ColumnType::kRowIndex,
+                             BIGINT(),
+                             BIGINT())},
+                        {"c1", makeColumnHandle("c1", BIGINT(), {})},
+                    })
+                    .endTableScan()
+                    .planNode();
+    std::vector<int64_t> c1;
+    for (int bucket : selectedBuckets) {
+      for (int i = bucket; i < 2 * kSize + 1; i += kNewNumBuckets) {
+        c1.push_back(i / 2);
+      }
+    }
+    auto data = makeFlatVector(c1);
+    auto expected = makeRowVector({"c2", "c1"}, {data, data});
+    AssertQueryBuilder(plan).splits(makeSplits()).assertResults(expected);
+  }
+}
+
+TEST_F(TableScanTest, bucketConversionWithSubfieldPruning) {
+  constexpr int kSize = 100;
+  auto key = makeRowVector({
+      makeFlatVector<int64_t>(kSize, folly::identity),
+      makeFlatVector<int64_t>(kSize, [](auto i) { return 2 * i; }),
+  });
+  auto vector = makeRowVector({key});
+  auto schema = asRowType(vector->type());
+  auto file = TempFilePath::create();
+  writeToFile(file->getPath(), {vector});
+  constexpr int kNewNumBuckets = 16;
+  const int selectedBuckets[] = {3, 5, 11};
+  std::vector<std::shared_ptr<connector::ConnectorSplit>> splits;
+  for (int bucket : selectedBuckets) {
+    std::vector<std::unique_ptr<HiveColumnHandle>> handles;
+    handles.push_back(makeColumnHandle("c0", key->type(), {}));
+    auto split = makeHiveConnectorSplit(file->getPath());
+    split->tableBucketNumber = bucket;
+    split->bucketConversion = {kNewNumBuckets, 1, std::move(handles)};
+    splits.push_back(split);
+  }
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .outputType(schema)
+                  .dataColumns(schema)
+                  .assignments({
+                      {"c0", makeColumnHandle("c0", key->type(), {"c0.c0"})},
+                  })
+                  .endTableScan()
+                  .planNode();
+  auto result =
+      AssertQueryBuilder(plan).splits(splits).copyResults(pool_.get());
+  HivePartitionFunction function(kNewNumBuckets, {0});
+  std::vector<uint32_t> partitions;
+  function.partition(*vector, partitions);
+  int j = 0;
+  for (int bucket : selectedBuckets) {
+    for (int i = 0; i < kSize; ++i) {
+      if (partitions[i] == bucket) {
+        ASSERT_LT(j, result->size());
+        ASSERT_TRUE(result->equalValueAt(vector.get(), j, i));
+        ++j;
+      }
+    }
+  }
+  ASSERT_EQ(j, result->size());
 }
 
 TEST_F(TableScanTest, integerNotEqualFilter) {

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -178,7 +178,7 @@ HiveConnectorTestBase::makeHiveConnectorSplits(
   return splits;
 }
 
-std::shared_ptr<connector::hive::HiveColumnHandle>
+std::unique_ptr<connector::hive::HiveColumnHandle>
 HiveConnectorTestBase::makeColumnHandle(
     const std::string& name,
     const TypePtr& type,
@@ -186,7 +186,7 @@ HiveConnectorTestBase::makeColumnHandle(
   return makeColumnHandle(name, type, type, requiredSubfields);
 }
 
-std::shared_ptr<connector::hive::HiveColumnHandle>
+std::unique_ptr<connector::hive::HiveColumnHandle>
 HiveConnectorTestBase::makeColumnHandle(
     const std::string& name,
     const TypePtr& dataType,
@@ -199,7 +199,7 @@ HiveConnectorTestBase::makeColumnHandle(
     subfields.emplace_back(path);
   }
 
-  return std::make_shared<connector::hive::HiveColumnHandle>(
+  return std::make_unique<connector::hive::HiveColumnHandle>(
       name, columnType, dataType, hiveType, std::move(subfields));
 }
 
@@ -218,7 +218,7 @@ HiveConnectorTestBase::makeHiveConnectorSplits(
   return splits;
 }
 
-std::shared_ptr<connector::ConnectorSplit>
+std::shared_ptr<connector::hive::HiveConnectorSplit>
 HiveConnectorTestBase::makeHiveConnectorSplit(
     const std::string& filePath,
     uint64_t start,
@@ -231,7 +231,7 @@ HiveConnectorTestBase::makeHiveConnectorSplit(
       .build();
 }
 
-std::shared_ptr<connector::ConnectorSplit>
+std::shared_ptr<connector::hive::HiveConnectorSplit>
 HiveConnectorTestBase::makeHiveConnectorSplit(
     const std::string& filePath,
     int64_t fileSize,

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -80,13 +80,15 @@ class HiveConnectorTestBase : public OperatorTestBase {
   makeHiveConnectorSplits(
       const std::vector<std::shared_ptr<TempFilePath>>& filePaths);
 
-  static std::shared_ptr<connector::ConnectorSplit> makeHiveConnectorSplit(
+  static std::shared_ptr<connector::hive::HiveConnectorSplit>
+  makeHiveConnectorSplit(
       const std::string& filePath,
       uint64_t start = 0,
       uint64_t length = std::numeric_limits<uint64_t>::max(),
       int64_t splitWeight = 0);
 
-  static std::shared_ptr<connector::ConnectorSplit> makeHiveConnectorSplit(
+  static std::shared_ptr<connector::hive::HiveConnectorSplit>
+  makeHiveConnectorSplit(
       const std::string& filePath,
       int64_t fileSize,
       int64_t fileModifiedTime,
@@ -124,7 +126,7 @@ class HiveConnectorTestBase : public OperatorTestBase {
   /// @param name Column name.
   /// @param type Column type.
   /// @param Required subfields of this column.
-  static std::shared_ptr<connector::hive::HiveColumnHandle> makeColumnHandle(
+  static std::unique_ptr<connector::hive::HiveColumnHandle> makeColumnHandle(
       const std::string& name,
       const TypePtr& type,
       const std::vector<std::string>& requiredSubfields);
@@ -133,7 +135,7 @@ class HiveConnectorTestBase : public OperatorTestBase {
   /// @param type Column type.
   /// @param type Hive type.
   /// @param Required subfields of this column.
-  static std::shared_ptr<connector::hive::HiveColumnHandle> makeColumnHandle(
+  static std::unique_ptr<connector::hive::HiveColumnHandle> makeColumnHandle(
       const std::string& name,
       const TypePtr& dataType,
       const TypePtr& hiveType,

--- a/velox/vector/SelectivityVector.h
+++ b/velox/vector/SelectivityVector.h
@@ -134,6 +134,10 @@ class SelectivityVector {
     return MutableRange<bool>(bits_.data(), begin_, end_);
   }
 
+  const uint64_t* allBits() const {
+    return bits_.data();
+  }
+
   vector_size_t begin() const {
     return begin_;
   }


### PR DESCRIPTION
Summary:
When the bucket count of a table changes over time, there can be
legitimate cases that multiple buckets exist in the same file.  In such cases
the query planner should set bucket conversion for these splits and in
`HiveDataSource` we add extra filter to get only the rows corresponding to the
bucket number requested.

Also clean up a little bit of the row number generation code and add some sanity checks.

Differential Revision: D58670760
