### PR TITLE
Add cmake helper to find libdouble-conversion

### DIFF
--- a/CMake/Finddouble-conversion.cmake
+++ b/CMake/Finddouble-conversion.cmake
@@ -1,0 +1,34 @@
+# Copyright (C) 2022 The Qt Company Ltd.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Fallback find module for double-conversion if double-conversion is built with
+# CMake it'll install a config module, which we prefer if it's built with Scons
+# (their default), we search ourselves
+
+find_package(double-conversion CONFIG)
+if(double-conversion_FOUND)
+  if(TARGET double-conversion::double-conversion)
+    return()
+  endif()
+endif()
+
+find_path(
+  DOUBLE_CONVERSION_INCLUDE_DIR
+  NAMES double-conversion.h
+  PATH_SUFFIXES double-conversion)
+find_library(DOUBLE_CONVERSION_LIBRARY NAMES double-conversion)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  double-conversion DEFAULT_MSG DOUBLE_CONVERSION_LIBRARY
+  DOUBLE_CONVERSION_INCLUDE_DIR)
+
+if(double-conversion_FOUND AND NOT TARGET double-conversion::double-conversion)
+  add_library(double-conversion::double-conversion UNKNOWN IMPORTED)
+  set_target_properties(
+    double-conversion::double-conversion
+    PROPERTIES IMPORTED_LOCATION "${DOUBLE_CONVERSION_LIBRARY}"
+               INTERFACE_INCLUDE_DIRECTORIES "${DOUBLE_CONVERSION_INCLUDE_DIR}")
+endif()
+
+mark_as_advanced(DOUBLE_CONVERSION_INCLUDE_DIR DOUBLE_CONVERSION_LIBRARY)

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,9 @@
+The Velox Project
+Copyright © 2024 Meta Platforms, Inc.
+
+This product includes software from the The gRPC project (Apache 2.0).
+* https://github.com/grpc/grpc/blob/v1.64.2/cmake/re2.cmake
+
+This product includes software from the QT project (BSD, 3-clause).
+* https://github.com/qt/qtbase/blob/6.6.3/cmake/FindWrapSystemDoubleConversion.cmake
+

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -204,6 +204,7 @@ def get_files(commit, path):
         and "build/fbcode_builder" not in file
         and "build/deps" not in file
         and "cmake-build-debug" not in file
+        and "NOTICE.txt" != file
     ]
 
 


### PR DESCRIPTION
The package of libdouble-conversion-dev in Ubuntu 20.04 does not provide a cmake config file. Therefore, cmakes fails to initialize stating that it cannot find any of the names:
  double-conversionConfig.cmake,
  double-conversion-config.cmake.

This change provides a cmake helper to let Velox find the library. It was originally copied from:
  https://github.com/qt/qtbase/blob/v6.3.1/cmake/Finddouble-conversion.cmake
that was later refactored into:
  https://github.com/qt/qtbase/blob/dev/cmake/FindWrapSystemDoubleConversion.cmake

Fixes #10230