### PR TITLE
Remove InsertNewlineAtEOF in .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -72,7 +72,6 @@ IndentPPDirectives: None
 IndentExternBlock: AfterExternBlock
 IndentWidth: 2
 IndentWrappedFunctionNames: false
-InsertNewlineAtEOF: true
 InsertTrailingCommas: None
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true


### PR DESCRIPTION
Fix #10236.

We may need to upgrade the version of clang to support this option.

https://clang.llvm.org/docs/ClangFormatStyleOptions.html#insertnewlineateof