### PR TITLE
Fix cache shutdown order

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -676,11 +676,11 @@ AsyncDataCache** AsyncDataCache::getInstancePtr() {
 }
 
 void AsyncDataCache::shutdown() {
-  for (auto& shard : shards_) {
-    shard->shutdown();
-  }
   if (ssdCache_) {
     ssdCache_->shutdown();
+  }
+  for (auto& shard : shards_) {
+    shard->shutdown();
   }
 }
 


### PR DESCRIPTION
Currently, ssd cache shutdown happens after shard shutdown where entries are cleared. If there is any pending write, the ssd write will fail as the entry no longer exists. Therefore, the shutdown order needs to be reversed.