### PR TITLE
Check determinism using function name only

### DIFF
--- a/velox/expression/VectorFunction.cpp
+++ b/velox/expression/VectorFunction.cpp
@@ -62,6 +62,13 @@ VectorFunctionMap& vectorFunctionFactories() {
   return factories;
 }
 
+std::optional<VectorFunctionMetadata> getVectorFunctionMetadata(
+    const std::string& name) {
+  return applyToVectorFunctionEntry<VectorFunctionMetadata>(
+      name,
+      [&](const auto& /*name*/, const auto& entry) { return entry.metadata; });
+}
+
 std::optional<std::vector<FunctionSignaturePtr>> getVectorFunctionSignatures(
     const std::string& name) {
   return applyToVectorFunctionEntry<std::vector<FunctionSignaturePtr>>(

--- a/velox/expression/VectorFunction.h
+++ b/velox/expression/VectorFunction.h
@@ -170,6 +170,11 @@ class SimpleFunctionAdapterFactory {
   virtual ~SimpleFunctionAdapterFactory() = default;
 };
 
+/// Returns the function metadata with the specified name. Returns std::nullopt
+/// if there is no function with the specified name.
+std::optional<VectorFunctionMetadata> getVectorFunctionMetadata(
+    const std::string& name);
+
 /// Returns a list of signatures supported by VectorFunction with the specified
 /// name. Returns std::nullopt if there is no function with the specified name.
 std::optional<std::vector<FunctionSignaturePtr>> getVectorFunctionSignatures(

--- a/velox/functions/FunctionRegistry.cpp
+++ b/velox/functions/FunctionRegistry.cpp
@@ -76,6 +76,25 @@ void clearFunctionRegistry() {
       [](auto& functionMap) { functionMap.clear(); });
 }
 
+std::optional<bool> isDeterministic(const std::string& functionName) {
+  const auto simpleFunctions =
+      exec::simpleFunctions().getFunctionSignaturesAndMetadata(functionName);
+  const auto metadata = exec::getVectorFunctionMetadata(functionName);
+  if (simpleFunctions.empty() && !metadata.has_value()) {
+    return std::nullopt;
+  }
+
+  for (const auto& [metadata, _] : simpleFunctions) {
+    if (!metadata.deterministic) {
+      return false;
+    }
+  }
+  if (metadata.has_value() && !metadata.value().deterministic) {
+    return false;
+  }
+  return true;
+}
+
 TypePtr resolveFunction(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes) {

--- a/velox/functions/FunctionRegistry.h
+++ b/velox/functions/FunctionRegistry.h
@@ -35,6 +35,12 @@ FunctionSignatureMap getFunctionSignatures();
 /// The mapping is function name -> list of function signatures
 FunctionSignatureMap getVectorFunctionSignatures();
 
+/// Returns if a function is deterministic by fetching all registry entries for
+/// the given function name and checking if all of them are deterministic.
+/// Returns std::nullopt if the function is not found. Returns false if any of
+/// the entries are not deterministic.
+std::optional<bool> isDeterministic(const std::string& functionName);
+
 /// Given a function name and argument types, returns
 /// the return type if function exists otherwise returns nullptr
 TypePtr resolveFunction(

--- a/velox/functions/tests/FunctionRegistryTest.cpp
+++ b/velox/functions/tests/FunctionRegistryTest.cpp
@@ -24,6 +24,7 @@
 #include "velox/functions/FunctionRegistry.h"
 #include "velox/functions/Macros.h"
 #include "velox/functions/Registerer.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/type/Type.h"
 
@@ -493,6 +494,20 @@ TEST_F(FunctionRegistryTest, functionNameInMixedCase) {
   ASSERT_EQ(*result, *VARCHAR());
   result = resolveFunction("variadiC_funC", {});
   ASSERT_EQ(*result, *VARCHAR());
+}
+
+TEST_F(FunctionRegistryTest, isDeterministic) {
+  functions::prestosql::registerAllScalarFunctions();
+  ASSERT_TRUE(isDeterministic("plus").value());
+  ASSERT_TRUE(isDeterministic("in").value());
+
+  ASSERT_FALSE(isDeterministic("rand").value());
+  ASSERT_FALSE(isDeterministic("uuid").value());
+  ASSERT_FALSE(isDeterministic("shuffle").value());
+
+  // Not found functions.
+  ASSERT_FALSE(isDeterministic("cast").has_value());
+  ASSERT_FALSE(isDeterministic("not_found_function").has_value());
 }
 
 template <typename T>


### PR DESCRIPTION
In ExpressionFuzzer, the determinism could be decided without argument 
types. This PR changes to check determinism using function name only by 
fetching all registry entries for the given function name and checking if all 
of them are deterministic. The function is deterministic if "deterministic" is 
true for every entry. With this change, argument types are not required when 
the signature variables are not empty.