### PR TITLE
[WIP] Add IPADDRESS and IPPREFIX and corresponding functions

### DIFF
--- a/velox/docs/develop/types.rst
+++ b/velox/docs/develop/types.rst
@@ -136,6 +136,8 @@ HYPERLOGLOG               VARBINARY
 JSON                      VARCHAR
 TIMESTAMP WITH TIME ZONE  BIGINT
 UUID                      HUGEINT
+IPADDRESS                 HUGEINT
+IPPREFIX                  (HUGEINT, TINYINT)
 ========================  =====================
 
 TIMESTAMP WITH TIME ZONE represents a time point in milliseconds precision

--- a/velox/docs/functions/presto/ipaddress.rst
+++ b/velox/docs/functions/presto/ipaddress.rst
@@ -1,0 +1,51 @@
+===================
+IP Functions
+===================
+
+.. function:: ip_prefix(ip_address, prefix_bits) -> ipprefix
+
+    Returns the IP prefix of a given ``ip_address`` with subnet size of ``prefix_bits``.
+    ``ip_address`` can be either of type ``VARCHAR`` or type ``IPADDRESS``. ::
+
+        SELECT ip_prefix(CAST('192.168.255.255' AS IPADDRESS), 9); -- {192.128.0.0/9}
+        SELECT ip_prefix('2001:0db8:85a3:0001:0001:8a2e:0370:7334', 48); -- {2001:db8:85a3::/48}
+
+.. function:: ip_subnet_min(ip_prefix) -> ip_address
+
+    Returns the smallest IP address of type ``IPADDRESS`` in the subnet
+    specified by ``ip_prefix``. ::
+
+        SELECT ip_subnet_min(IPPREFIX '192.168.255.255/9'); -- {192.128.0.0}
+        SELECT ip_subnet_min(IPPREFIX '2001:0db8:85a3:0001:0001:8a2e:0370:7334/48'); -- {2001:db8:85a3::}
+
+.. function:: ip_subnet_max(ip_prefix) -> ip_address
+
+    Returns the largest IP address of type ``IPADDRESS`` in the subnet
+    specified by ``ip_prefix``. ::
+
+        SELECT ip_subnet_max(IPPREFIX '192.64.0.0/9'); -- {192.127.255.255}
+        SELECT ip_subnet_max(IPPREFIX '2001:0db8:85a3:0001:0001:8a2e:0370:7334/48'); -- {2001:db8:85a3:ffff:ffff:ffff:ffff:ffff}
+
+.. function:: ip_subnet_range(ip_prefix) -> array(ip_address)
+
+    Return an array of 2 IP addresses.
+    The array contains the smallest and the largest IP address
+    in the subnet specified by ``ip_prefix``. ::
+
+        SELECT ip_subnet_range(IPPREFIX '1.2.3.160/24'); -- [{1.2.3.0}, {1.2.3.255}]
+        SELECT ip_subnet_range(IPPREFIX '64:ff9b::52f4/120'); -- [{64:ff9b::5200}, {64:ff9b::52ff}]
+
+.. function:: is_subnet_of(ip_prefix, ip_address) -> boolean
+
+    Returns ``true`` if the ``ip_address`` is in the subnet of ``ip_prefix``. ::
+
+        SELECT is_subnet_of(IPPREFIX '1.2.3.128/26', IPADDRESS '1.2.3.129'); -- true
+        SELECT is_subnet_of(IPPREFIX '64:fa9b::17/64', IPADDRESS '64:ffff::17'); -- false
+
+.. function:: is_subnet_of(ip_prefix1, ip_prefix2) -> boolean
+
+    Returns ``true`` if ``ip_prefix2`` is a subnet of ``ip_prefix1``. ::
+
+        SELECT is_subnet_of(IPPREFIX '192.168.3.131/26', IPPREFIX '192.168.3.144/30'); -- true
+        SELECT is_subnet_of(IPPREFIX '64:ff9b::17/64', IPPREFIX '64:ffff::17/64'); -- false
+        SELECT is_subnet_of(IPPREFIX '192.168.3.131/26', IPPREFIX '192.168.3.131/26'); -- true

--- a/velox/expression/tests/CustomTypeTest.cpp
+++ b/velox/expression/tests/CustomTypeTest.cpp
@@ -216,7 +216,8 @@ TEST_F(CustomTypeTest, getCustomTypeNames) {
           "HYPERLOGLOG",
           "TIMESTAMP WITH TIME ZONE",
           "UUID",
-      }),
+          "IPADDRESS",
+          "IPPREFIX"}),
       names);
 
   ASSERT_TRUE(registerCustomType(
@@ -229,6 +230,8 @@ TEST_F(CustomTypeTest, getCustomTypeNames) {
           "HYPERLOGLOG",
           "TIMESTAMP WITH TIME ZONE",
           "UUID",
+          "IPADDRESS",
+          "IPPREFIX",
           "FANCY_INT",
       }),
       names);

--- a/velox/functions/prestosql/IPAddressFunctions.h
+++ b/velox/functions/prestosql/IPAddressFunctions.h
@@ -15,15 +15,11 @@
  */
 #pragma once
 
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-
 #include "velox/functions/Macros.h"
 #include "velox/functions/Registerer.h"
 #include "velox/functions/lib/string/StringImpl.h"
 #include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/IPPrefixType.h"
-#include "velox/functions/prestosql/types/UuidType.h"
 
 #include <iostream>
 

--- a/velox/functions/prestosql/IPAddressFunctions.h
+++ b/velox/functions/prestosql/IPAddressFunctions.h
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+
+#include "velox/functions/Macros.h"
+#include "velox/functions/Registerer.h"
+#include "velox/functions/lib/string/StringImpl.h"
+#include "velox/functions/prestosql/types/IPAddressType.h"
+#include "velox/functions/prestosql/types/IPPrefixType.h"
+#include "velox/functions/prestosql/types/UuidType.h"
+
+#include <iostream>
+
+namespace facebook::velox::functions {
+
+inline bool isIPV4(int128_t ip) {
+  int128_t ipV4 = 0x0000FFFF00000000;
+  int128_t mask = 0xFFFFFFFFFFFFFFFF;
+  mask = (mask << 64) | 0xFFFFFFFF00000000;
+  return (ip & mask) == ipV4;
+}
+
+template <typename T>
+struct IPPrefixFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<TheIPPrefix>& result,
+      const arg_type<IPAddress>& ip,
+      const arg_type<int8_t> prefixBits) {
+    // Presto stores prefixBits in one signed byte. Cast to unsigned
+    uint8_t prefix = (uint8_t)prefixBits;
+    boost::asio::ip::address_v6::bytes_type addrBytes;
+    memcpy(&addrBytes, &ip, 16);
+    bigEndianByteArray(addrBytes);
+
+    // All IPs are stored as V6
+    auto v6Addr = boost::asio::ip::make_address_v6(addrBytes);
+    boost::asio::ip::address_v6 v6CanonicalAddr;
+
+    // For return
+    int128_t canonicalAddrInt;
+
+    // Convert to V4/V6 respectively and create network to get canonical
+    // address as well as check validity of the prefix.
+    if (v6Addr.is_v4_mapped()) {
+      auto v4Addr =
+          boost::asio::ip::make_address_v4(boost::asio::ip::v4_mapped, v6Addr);
+      auto v4Network = boost::asio::ip::make_network_v4(v4Addr, prefix);
+      v6CanonicalAddr = boost::asio::ip::make_address_v6(
+          boost::asio::ip::v4_mapped, v4Network.canonical().address());
+    } else {
+      auto v6Network = boost::asio::ip::make_network_v6(v6Addr, prefix);
+      v6CanonicalAddr = v6Network.canonical().address();
+    }
+
+    auto canonicalBytes = v6CanonicalAddr.to_bytes();
+    bigEndianByteArray(canonicalBytes);
+    memcpy(&canonicalAddrInt, &canonicalBytes, 16);
+
+    result = std::make_shared<IPPrefix>(canonicalAddrInt, prefix);
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<TheIPPrefix>& result,
+      const arg_type<Varchar>& ip,
+      const arg_type<int8_t> prefixBits) {
+    boost::asio::ip::address_v6::bytes_type addrBytes;
+    auto addr = boost::asio::ip::make_address(ip);
+    int128_t intAddr;
+    if (addr.is_v4()) {
+      addrBytes = boost::asio::ip::make_address_v6(
+                      boost::asio::ip::v4_mapped, addr.to_v4())
+                      .to_bytes();
+    } else {
+      addrBytes = addr.to_v6().to_bytes();
+    }
+
+    bigEndianByteArray(addrBytes);
+    memcpy(&intAddr, &addrBytes, 16);
+
+    call(result, intAddr, prefixBits);
+  }
+};
+
+template <typename T>
+struct IPSubnetMinFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<IPAddress>& result,
+      const arg_type<TheIPPrefix>& ipPrefix) {
+    // IPPrefix type should store the smallest(canonical) IP already
+    memcpy(&result, &ipPrefix->ip, 16);
+  }
+};
+
+inline int128_t getIPSubnetMax(int128_t ip, uint8_t prefix) {
+  uint128_t mask = 1;
+  int128_t result;
+  boost::asio::ip::address_v6::bytes_type addrBytes;
+  memcpy(&result, &ip, 16);
+
+  if (isIPV4(ip)) {
+    result |= (mask << (32 - prefix)) - 1;
+  } else {
+    // Special case: Overflow to all 0 subtracting 1 does not work.
+    if (prefix == 0) {
+      result = -1;
+    } else {
+      result |= (mask << (128 - prefix)) - 1;
+    }
+  }
+  return result;
+}
+
+template <typename T>
+struct IPSubnetMaxFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<IPAddress>& result,
+      const arg_type<TheIPPrefix>& ipPrefix) {
+    result = getIPSubnetMax(ipPrefix->ip, (uint8_t)ipPrefix->prefix);
+  }
+};
+
+template <typename T>
+struct IPSubnetRangeFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Array<IPAddress>>& result,
+      const arg_type<TheIPPrefix>& ipPrefix) {
+    result.push_back(ipPrefix->ip);
+    result.push_back(getIPSubnetMax(ipPrefix->ip, (uint8_t)ipPrefix->prefix));
+  }
+};
+
+template <typename T>
+struct IPSubnetOfFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<bool>& result,
+      const arg_type<TheIPPrefix>& ipPrefix,
+      const arg_type<IPAddress>& ip) {
+    uint128_t mask = 1;
+    uint8_t prefix = (uint8_t)ipPrefix->prefix;
+    int128_t checkIP = ip;
+
+    if (isIPV4(ipPrefix->ip)) {
+      checkIP &= ((mask << (32 - prefix)) - 1) ^ -1;
+    } else {
+      // Special case: Overflow to all 0 subtracting 1 does not work.
+      if (prefix == 0) {
+        checkIP = 0;
+      } else {
+        checkIP &= ((mask << (128 - prefix)) - 1) ^ -1;
+      }
+    }
+    result = (ipPrefix->ip == checkIP);
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<bool>& result,
+      const arg_type<TheIPPrefix>& ipPrefix,
+      const arg_type<TheIPPrefix>& ipPrefix2) {
+    call(result, ipPrefix, ipPrefix2->ip);
+    result = result && (ipPrefix2->prefix >= ipPrefix->prefix);
+  }
+};
+
+void registerIPAddressFunctions(const std::string& prefix) {
+  registerIPAddressType();
+  registerIPPrefixType();
+  registerFunction<IPPrefixFunction, TheIPPrefix, IPAddress, int8_t>(
+      {prefix + "ip_prefix"});
+  registerFunction<IPPrefixFunction, TheIPPrefix, Varchar, int8_t>(
+      {prefix + "ip_prefix"});
+  registerFunction<IPSubnetMinFunction, IPAddress, TheIPPrefix>(
+      {prefix + "ip_subnet_min"});
+  registerFunction<IPSubnetMaxFunction, IPAddress, TheIPPrefix>(
+      {prefix + "ip_subnet_max"});
+  registerFunction<IPSubnetRangeFunction, Array<IPAddress>, TheIPPrefix>(
+      {prefix + "ip_subnet_range"});
+  registerFunction<IPSubnetOfFunction, bool, TheIPPrefix, IPAddress>(
+      {prefix + "is_subnet_of"});
+  registerFunction<IPSubnetOfFunction, bool, TheIPPrefix, TheIPPrefix>(
+      {prefix + "is_subnet_of"});
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/TypeOf.cpp
+++ b/velox/functions/prestosql/TypeOf.cpp
@@ -15,6 +15,8 @@
  */
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
+#include "velox/functions/prestosql/types/IPAddressType.h"
+#include "velox/functions/prestosql/types/IPPrefixType.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/functions/prestosql/types/UuidType.h"
@@ -54,6 +56,8 @@ std::string typeName(const TypePtr& type) {
     case TypeKind::HUGEINT: {
       if (isUuidType(type)) {
         return "uuid";
+      } else if (isIPAddressType(type)) {
+        return "ipaddress";
       }
       VELOX_USER_CHECK(
           type->isDecimal(),
@@ -104,6 +108,11 @@ std::string typeName(const TypePtr& type) {
     }
     case TypeKind::UNKNOWN:
       return "unknown";
+    case TypeKind::OPAQUE:
+      if (isIPPrefixType(type)) {
+        return "ipprefix";
+      }
+      return "opaque";
     default:
       VELOX_UNSUPPORTED("Unsupported type: {}", type->toString())
   }

--- a/velox/functions/prestosql/registration/RegistrationFunctions.cpp
+++ b/velox/functions/prestosql/registration/RegistrationFunctions.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include <string>
+#include "velox/functions/prestosql/IPAddressFunctions.h"
 #include "velox/functions/prestosql/UuidFunctions.h"
 
 namespace facebook::velox::functions {
@@ -104,6 +105,7 @@ void registerAllScalarFunctions(const std::string& prefix) {
   registerGeneralFunctions(prefix);
   registerDateTimeFunctions(prefix);
   registerURLFunctions(prefix);
+  registerIPAddressFunctions(prefix);
   registerStringFunctions(prefix);
   registerBinaryFunctions(prefix);
   registerBitwiseFunctions(prefix);

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -61,6 +61,7 @@ add_executable(
   GreatestLeastTest.cpp
   HyperLogLogCastTest.cpp
   HyperLogLogFunctionsTest.cpp
+  IPAddressFunctionsTest.cpp
   InPredicateTest.cpp
   JsonCastTest.cpp
   JsonExtractScalarTest.cpp

--- a/velox/functions/prestosql/tests/IPAddressFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/IPAddressFunctionsTest.cpp
@@ -1,0 +1,461 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+namespace facebook::velox::functions::prestosql {
+
+namespace {
+
+class IPAddressTest : public functions::test::FunctionBaseTest {
+ protected:
+  std::optional<std::string> castIPAddress(
+      const std::optional<std::string> input) {
+    auto result = evaluateOnce<std::string>(
+        "cast(cast(c0 as ipaddress) as varchar)", input);
+    return result;
+  }
+
+  std::optional<std::string> castIPPrefix(
+      const std::optional<std::string> input) {
+    auto result = evaluateOnce<std::string>(
+        "cast(cast(c0 as ipprefix) as varchar)", input);
+    return result;
+  }
+
+  std::optional<std::string> getIPPrefix(
+      const std::optional<std::string> input,
+      std::optional<int8_t> mask) {
+    auto result = evaluateOnce<std::string>(
+        "cast(ip_prefix(cast(c0 as ipaddress), c1) as varchar)", input, mask);
+    return result;
+  }
+
+  std::optional<std::string> getIPPrefixUsingVarchar(
+      const std::optional<std::string> input,
+      std::optional<int8_t> mask) {
+    auto result = evaluateOnce<std::string>(
+        "cast(ip_prefix(c0, c1) as varchar)", input, mask);
+    return result;
+  }
+
+  std::optional<std::string> getIPSubnetMin(
+      const std::optional<std::string> input) {
+    auto result = evaluateOnce<std::string>(
+        "cast(ip_subnet_min(cast(c0 as ipprefix)) as varchar)", input);
+    return result;
+  }
+
+  std::optional<std::string> getIPSubnetMax(
+      const std::optional<std::string> input) {
+    auto result = evaluateOnce<std::string>(
+        "cast(ip_subnet_max(cast(c0 as ipprefix)) as varchar)", input);
+    return result;
+  }
+
+  std::optional<std::string> getIPSubnetRangeMin(
+      const std::optional<std::string> input) {
+    auto result = evaluateOnce<std::string>(
+        "cast(ip_subnet_range(cast(c0 as ipprefix))[1] as varchar)", input);
+    return result;
+  }
+
+  std::optional<std::string> getIPSubnetRangeMax(
+      const std::optional<std::string> input) {
+    auto result = evaluateOnce<std::string>(
+        "cast(ip_subnet_range(cast(c0 as ipprefix))[2] as varchar)", input);
+    return result;
+  }
+
+  std::optional<bool> getIsSubnetOfIP(
+      const std::optional<std::string> prefix,
+      const std::optional<std::string> ip) {
+    auto result = evaluateOnce<bool>(
+        "is_subnet_of(cast(c0 as ipprefix), cast(c1 as ipaddress))",
+        prefix,
+        ip);
+    return result;
+  }
+
+  std::optional<bool> getIsSubnetOfIPPrefix(
+      const std::optional<std::string> prefix,
+      const std::optional<std::string> prefix2) {
+    auto result = evaluateOnce<bool>(
+        "is_subnet_of(cast(c0 as ipprefix), cast(c1 as ipprefix))",
+        prefix,
+        prefix2);
+    return result;
+  }
+};
+
+TEST_F(IPAddressTest, castFail) {
+  EXPECT_THROW(castIPAddress("12.483.09.1"), VeloxUserError);
+  EXPECT_THROW(castIPAddress("10.135.23.12.12"), VeloxUserError);
+  EXPECT_THROW(castIPAddress("10.135.23"), VeloxUserError);
+  EXPECT_THROW(
+      castIPAddress("q001:0db8:85a3:0001:0001:8a2e:0370:7334"), VeloxUserError);
+  EXPECT_THROW(
+      castIPAddress("2001:0db8:85a3:542e:0001:0001:8a2e:0370:7334"),
+      VeloxUserError);
+  EXPECT_THROW(
+      castIPAddress("2001:0db8:85a3:0001:0001:8a2e:0370"), VeloxUserError);
+
+  EXPECT_THROW(castIPPrefix("12.135.23.12/-1"), VeloxUserError);
+  EXPECT_THROW(castIPPrefix("10.135.23.12/33"), VeloxUserError);
+  EXPECT_THROW(castIPPrefix("::ffff:1.2.3.4/-1"), VeloxUserError);
+  EXPECT_THROW(castIPPrefix("::ffff:1.2.3.4/33"), VeloxUserError);
+  EXPECT_THROW(castIPPrefix("64:ff9b::10/-1"), VeloxUserError);
+  EXPECT_THROW(castIPPrefix("64:ff9b::10/129"), VeloxUserError);
+  EXPECT_THROW(castIPPrefix("::ffff:1.2.3.4/-1"), VeloxUserError);
+  EXPECT_THROW(castIPPrefix("::ffff:1.2.3.4/33"), VeloxUserError);
+  EXPECT_THROW(castIPPrefix("::ffff:909:909/-1"), VeloxUserError);
+  EXPECT_THROW(castIPPrefix("::ffff:909:909/33"), VeloxUserError);
+  EXPECT_THROW(castIPPrefix("64:ff9b::10/-1"), VeloxUserError);
+  EXPECT_THROW(castIPPrefix("64:ff9b::10/129"), VeloxUserError);
+  EXPECT_THROW(castIPPrefix("localhost/24"), VeloxUserError);
+  EXPECT_THROW(castIPPrefix("64::ff9b::10/24"), VeloxUserError);
+  EXPECT_THROW(castIPPrefix("64:face:book::10/24"), VeloxUserError);
+  EXPECT_THROW(castIPPrefix("123.456.789.012/24"), VeloxUserError);
+}
+
+TEST_F(IPAddressTest, castRoundTrip) {
+  auto strings = makeFlatVector<std::string>(
+      {"87a0:ce14:8989:44c9:826e:b4d8:73f9:1542",
+       "7cd6:bcec:1216:5c20:4b67:b1bd:173:ced",
+       "192.128.0.0"});
+
+  auto ipaddresses =
+      evaluate("cast(c0 as ipaddress)", makeRowVector({strings}));
+  auto stringsCopy =
+      evaluate("cast(c0 as varchar)", makeRowVector({ipaddresses}));
+  auto ipaddressesCopy =
+      evaluate("cast(c0 as ipaddress)", makeRowVector({stringsCopy}));
+
+  velox::test::assertEqualVectors(strings, stringsCopy);
+  velox::test::assertEqualVectors(ipaddresses, ipaddressesCopy);
+}
+
+TEST_F(IPAddressTest, IPPrefixv4) {
+  // EXPECT_EQ("10.0.0.0/8", getIPPrefixUsingVarchar("10.135.23.12", 8));
+
+  EXPECT_EQ("10.0.0.0/8", getIPPrefix("10.135.23.12", 8));
+  EXPECT_EQ("192.128.0.0/9", getIPPrefix("192.168.255.255", 9));
+  EXPECT_EQ("192.168.255.255/32", getIPPrefix("192.168.255.255", 32));
+  EXPECT_EQ("0.0.0.0/0", getIPPrefix("192.168.255.255", 0));
+
+  EXPECT_THROW(getIPPrefix("12.483.09.1", 8), VeloxUserError);
+  EXPECT_THROW(getIPPrefix("10.135.23.12.12", 8), VeloxUserError);
+  EXPECT_THROW(getIPPrefix("10.135.23", 8), VeloxUserError);
+  EXPECT_THROW(getIPPrefix("12.135.23.12", -1), VeloxUserError);
+  EXPECT_THROW(getIPPrefix("10.135.23.12", 33), VeloxUserError);
+}
+
+TEST_F(IPAddressTest, IPPrefixv4UsingVarchar) {
+  EXPECT_EQ("10.0.0.0/8", getIPPrefixUsingVarchar("10.135.23.12", 8));
+  EXPECT_EQ("192.128.0.0/9", getIPPrefixUsingVarchar("192.168.255.255", 9));
+  EXPECT_EQ(
+      "192.168.255.255/32", getIPPrefixUsingVarchar("192.168.255.255", 32));
+  EXPECT_EQ("0.0.0.0/0", getIPPrefixUsingVarchar("192.168.255.255", 0));
+
+  EXPECT_THROW(getIPPrefixUsingVarchar("12.483.09.1", 8), VeloxUserError);
+  EXPECT_THROW(getIPPrefixUsingVarchar("10.135.23.12.12", 8), VeloxUserError);
+  EXPECT_THROW(getIPPrefixUsingVarchar("10.135.23", 8), VeloxUserError);
+  EXPECT_THROW(getIPPrefixUsingVarchar("12.135.23.12", -1), VeloxUserError);
+  EXPECT_THROW(getIPPrefixUsingVarchar("10.135.23.12", 33), VeloxUserError);
+}
+
+TEST_F(IPAddressTest, IPPrefixv6) {
+  EXPECT_EQ(
+      "2001:db8:85a3::/48",
+      getIPPrefix("2001:0db8:85a3:0001:0001:8a2e:0370:7334", 48));
+  EXPECT_EQ(
+      "2001:db8:85a3::/52",
+      getIPPrefix("2001:0db8:85a3:0001:0001:8a2e:0370:7334", 52));
+  EXPECT_EQ(
+      "2001:db8:85a3:1:1:8a2e:370:7334/128",
+      getIPPrefix("2001:0db8:85a3:0001:0001:8a2e:0370:7334", 128));
+  EXPECT_EQ("::/0", getIPPrefix("2001:0db8:85a3:0001:0001:8a2e:0370:7334", 0));
+
+  EXPECT_THROW(
+      getIPPrefix("q001:0db8:85a3:0001:0001:8a2e:0370:7334", 8),
+      VeloxUserError);
+  EXPECT_THROW(
+      getIPPrefix("2001:0db8:85a3:542e:0001:0001:8a2e:0370:7334", 8),
+      VeloxUserError);
+  EXPECT_THROW(
+      getIPPrefix("2001:0db8:85a3:0001:0001:8a2e:0370", 8), VeloxUserError);
+  EXPECT_THROW(
+      getIPPrefix("2001:0db8:85a3:0001:0001:8a2e:0370:7334", -1),
+      VeloxUserError);
+  EXPECT_THROW(
+      getIPPrefix("2001:0db8:85a3:0001:0001:8a2e:0370:7334", 140),
+      VeloxUserError);
+}
+
+TEST_F(IPAddressTest, IPPrefixv6UsingVarchar) {
+  EXPECT_EQ(
+      "2001:db8:85a3::/48",
+      getIPPrefixUsingVarchar("2001:0db8:85a3:0001:0001:8a2e:0370:7334", 48));
+  EXPECT_EQ(
+      "2001:db8:85a3::/52",
+      getIPPrefixUsingVarchar("2001:0db8:85a3:0001:0001:8a2e:0370:7334", 52));
+  EXPECT_EQ(
+      "2001:db8:85a3:1:1:8a2e:370:7334/128",
+      getIPPrefixUsingVarchar("2001:0db8:85a3:0001:0001:8a2e:0370:7334", 128));
+  EXPECT_EQ(
+      "::/0",
+      getIPPrefixUsingVarchar("2001:0db8:85a3:0001:0001:8a2e:0370:7334", 0));
+
+  EXPECT_THROW(
+      getIPPrefixUsingVarchar("q001:0db8:85a3:0001:0001:8a2e:0370:7334", 8),
+      VeloxUserError);
+  EXPECT_THROW(
+      getIPPrefixUsingVarchar(
+          "2001:0db8:85a3:542e:0001:0001:8a2e:0370:7334", 8),
+      VeloxUserError);
+  EXPECT_THROW(
+      getIPPrefixUsingVarchar("2001:0db8:85a3:0001:0001:8a2e:0370", 8),
+      VeloxUserError);
+  EXPECT_THROW(
+      getIPPrefixUsingVarchar("2001:0db8:85a3:0001:0001:8a2e:0370:7334", -1),
+      VeloxUserError);
+  EXPECT_THROW(
+      getIPPrefixUsingVarchar("2001:0db8:85a3:0001:0001:8a2e:0370:7334", 140),
+      VeloxUserError);
+}
+
+TEST_F(IPAddressTest, IPPrefixPrestoTests) {
+  EXPECT_EQ(getIPPrefix("1.2.3.4", 24), "1.2.3.0/24");
+  EXPECT_EQ(getIPPrefix("1.2.3.4", 32), "1.2.3.4/32");
+  EXPECT_EQ(getIPPrefix("1.2.3.4", 0), "0.0.0.0/0");
+  EXPECT_EQ(getIPPrefix("::ffff:1.2.3.4", 24), "1.2.3.0/24");
+  EXPECT_EQ(getIPPrefix("64:ff9b::17", 64), "64:ff9b::/64");
+  EXPECT_EQ(getIPPrefix("64:ff9b::17", 127), "64:ff9b::16/127");
+  EXPECT_EQ(getIPPrefix("64:ff9b::17", 128), "64:ff9b::17/128");
+  EXPECT_EQ(getIPPrefix("64:ff9b::17", 0), "::/0");
+  EXPECT_THROW(getIPPrefix("::ffff:1.2.3.4", -1), VeloxUserError);
+  EXPECT_THROW(getIPPrefix("::ffff:1.2.3.4", 33), VeloxUserError);
+  EXPECT_THROW(getIPPrefix("64:ff9b::10", -1), VeloxUserError);
+  EXPECT_THROW(getIPPrefix("64:ff9b::10", 129), VeloxUserError);
+}
+
+TEST_F(IPAddressTest, IPPrefixVarcharPrestoTests) {
+  EXPECT_EQ(getIPPrefixUsingVarchar("1.2.3.4", 24), "1.2.3.0/24");
+  EXPECT_EQ(getIPPrefixUsingVarchar("1.2.3.4", 32), "1.2.3.4/32");
+  EXPECT_EQ(getIPPrefixUsingVarchar("1.2.3.4", 0), "0.0.0.0/0");
+  EXPECT_EQ(getIPPrefixUsingVarchar("::ffff:1.2.3.4", 24), "1.2.3.0/24");
+  EXPECT_EQ(getIPPrefixUsingVarchar("64:ff9b::17", 64), "64:ff9b::/64");
+  EXPECT_EQ(getIPPrefixUsingVarchar("64:ff9b::17", 127), "64:ff9b::16/127");
+  EXPECT_EQ(getIPPrefixUsingVarchar("64:ff9b::17", 128), "64:ff9b::17/128");
+  EXPECT_EQ(getIPPrefixUsingVarchar("64:ff9b::17", 0), "::/0");
+  EXPECT_THROW(getIPPrefixUsingVarchar("::ffff:1.2.3.4", -1), VeloxUserError);
+  EXPECT_THROW(getIPPrefixUsingVarchar("::ffff:1.2.3.4", 33), VeloxUserError);
+  EXPECT_THROW(getIPPrefixUsingVarchar("64:ff9b::10", -1), VeloxUserError);
+  EXPECT_THROW(getIPPrefixUsingVarchar("64:ff9b::10", 129), VeloxUserError);
+  EXPECT_THROW(getIPPrefixUsingVarchar("localhost", 24), VeloxUserError);
+  EXPECT_THROW(getIPPrefixUsingVarchar("64::ff9b::10", 24), VeloxUserError);
+  EXPECT_THROW(getIPPrefixUsingVarchar("64:face:book::10", 24), VeloxUserError);
+  EXPECT_THROW(getIPPrefixUsingVarchar("123.456.789.012", 24), VeloxUserError);
+}
+
+TEST_F(IPAddressTest, castRoundTripPrefix) {
+  auto strings = makeFlatVector<std::string>(
+      {"87a0:ce14:8989::/48", "7800::/5", "192.0.0.0/5"});
+
+  auto ipprefixes = evaluate("cast(c0 as ipprefix)", makeRowVector({strings}));
+  auto stringsCopy =
+      evaluate("cast(c0 as varchar)", makeRowVector({ipprefixes}));
+  auto ipprefixesCopy =
+      evaluate("cast(c0 as ipprefix)", makeRowVector({stringsCopy}));
+
+  velox::test::assertEqualVectors(strings, stringsCopy);
+}
+
+TEST_F(IPAddressTest, IPSubnetMin) {
+  EXPECT_EQ("192.0.0.0", getIPSubnetMin("192.64.1.1/9"));
+  EXPECT_EQ("0.0.0.0", getIPSubnetMin("192.64.1.1/0"));
+  EXPECT_EQ("128.0.0.0", getIPSubnetMin("192.64.1.1/1"));
+  EXPECT_EQ("192.64.1.0", getIPSubnetMin("192.64.1.1/31"));
+  EXPECT_EQ("192.64.1.1", getIPSubnetMin("192.64.1.1/32"));
+
+  EXPECT_EQ(
+      "2001:db8:85a3::",
+      getIPSubnetMin("2001:0db8:85a3:0001:0001:8a2e:0370:7334/48"));
+  EXPECT_EQ("::", getIPSubnetMin("2001:0db8:85a3:0001:0001:8a2e:0370:7334/0"));
+  EXPECT_EQ("::", getIPSubnetMin("2001:0db8:85a3:0001:0001:8a2e:0370:7334/1"));
+  EXPECT_EQ(
+      "2001:db8:85a3:1:1:8a2e:370:7334",
+      getIPSubnetMin("2001:0db8:85a3:0001:0001:8a2e:0370:7334/127"));
+  EXPECT_EQ(
+      "2001:db8:85a3:1:1:8a2e:370:7334",
+      getIPSubnetMin("2001:0db8:85a3:0001:0001:8a2e:0370:7334/128"));
+}
+
+TEST_F(IPAddressTest, IPSubnetMinPrestoTests) {
+  EXPECT_EQ(getIPSubnetMin("1.2.3.4/24"), "1.2.3.0");
+  EXPECT_EQ(getIPSubnetMin("1.2.3.4/32"), "1.2.3.4");
+  EXPECT_EQ(getIPSubnetMin("64:ff9b::17/64"), "64:ff9b::");
+  EXPECT_EQ(getIPSubnetMin("64:ff9b::17/127"), "64:ff9b::16");
+  EXPECT_EQ(getIPSubnetMin("64:ff9b::17/128"), "64:ff9b::17");
+  EXPECT_EQ(getIPSubnetMin("64:ff9b::17/0"), "::");
+}
+
+TEST_F(IPAddressTest, IPSubnetMax) {
+  EXPECT_EQ("192.127.255.255", getIPSubnetMax("192.64.1.1/9"));
+  EXPECT_EQ("255.255.255.255", getIPSubnetMax("192.64.1.1/0"));
+  EXPECT_EQ("255.255.255.255", getIPSubnetMax("192.64.1.1/1"));
+  EXPECT_EQ("192.64.1.1", getIPSubnetMax("192.64.1.1/31"));
+  EXPECT_EQ("192.64.1.1", getIPSubnetMax("192.64.1.1/32"));
+
+  EXPECT_EQ(
+      "2001:db8:85a3:ffff:ffff:ffff:ffff:ffff",
+      getIPSubnetMax("2001:0db8:85a3:0001:0001:8a2e:0370:7334/48"));
+  EXPECT_EQ(
+      "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+      getIPSubnetMax("2001:0db8:85a3:0001:0001:8a2e:0370:7334/0"));
+  EXPECT_EQ(
+      "7fff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+      getIPSubnetMax("2001:0db8:85a3:0001:0001:8a2e:0370:7334/1"));
+  EXPECT_EQ(
+      "2001:db8:85a3:1:1:8a2e:370:7335",
+      getIPSubnetMax("2001:0db8:85a3:0001:0001:8a2e:0370:7334/127"));
+  EXPECT_EQ(
+      "2001:db8:85a3:1:1:8a2e:370:7334",
+      getIPSubnetMax("2001:0db8:85a3:0001:0001:8a2e:0370:7334/128"));
+}
+
+TEST_F(IPAddressTest, IPSubnetMaxPrestoTests) {
+  EXPECT_EQ(getIPSubnetMax("1.2.3.128/26"), "1.2.3.191");
+  EXPECT_EQ(getIPSubnetMax("192.168.128.4/32"), "192.168.128.4");
+  EXPECT_EQ(getIPSubnetMax("10.1.16.3/9"), "10.127.255.255");
+  EXPECT_EQ(getIPSubnetMax("2001:db8::16/127"), "2001:db8::17");
+  EXPECT_EQ(getIPSubnetMax("2001:db8::16/128"), "2001:db8::16");
+  EXPECT_EQ(getIPSubnetMax("64:ff9b::17/64"), "64:ff9b::ffff:ffff:ffff:ffff");
+  EXPECT_EQ(getIPSubnetMax("64:ff9b::17/72"), "64:ff9b::ff:ffff:ffff:ffff");
+  EXPECT_EQ(
+      getIPSubnetMax("64:ff9b::17/0"),
+      "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
+}
+
+TEST_F(IPAddressTest, IPSubnetRange) {
+  EXPECT_EQ("192.0.0.0", getIPSubnetRangeMin("192.64.1.1/9"));
+  EXPECT_EQ("192.127.255.255", getIPSubnetRangeMax("192.64.1.1/9"));
+
+  EXPECT_EQ("0.0.0.0", getIPSubnetRangeMin("192.64.1.1/0"));
+  EXPECT_EQ("255.255.255.255", getIPSubnetRangeMax("192.64.1.1/0"));
+
+  EXPECT_EQ("128.0.0.0", getIPSubnetRangeMin("192.64.1.1/1"));
+  EXPECT_EQ("255.255.255.255", getIPSubnetRangeMax("192.64.1.1/1"));
+
+  EXPECT_EQ("192.64.1.0", getIPSubnetRangeMin("192.64.1.1/31"));
+  EXPECT_EQ("192.64.1.1", getIPSubnetRangeMax("192.64.1.1/31"));
+
+  EXPECT_EQ("192.64.1.1", getIPSubnetRangeMin("192.64.1.1/32"));
+  EXPECT_EQ("192.64.1.1", getIPSubnetRangeMax("192.64.1.1/32"));
+
+  EXPECT_EQ(
+      "2001:db8:85a3::",
+      getIPSubnetRangeMin("2001:0db8:85a3:0001:0001:8a2e:0370:7334/48"));
+  EXPECT_EQ(
+      "2001:db8:85a3:ffff:ffff:ffff:ffff:ffff",
+      getIPSubnetRangeMax("2001:0db8:85a3:0001:0001:8a2e:0370:7334/48"));
+
+  EXPECT_EQ(
+      "::", getIPSubnetRangeMin("2001:0db8:85a3:0001:0001:8a2e:0370:7334/0"));
+  EXPECT_EQ(
+      "::", getIPSubnetRangeMin("2001:0db8:85a3:0001:0001:8a2e:0370:7334/1"));
+  EXPECT_EQ(
+      "2001:db8:85a3:1:1:8a2e:370:7334",
+      getIPSubnetRangeMin("2001:0db8:85a3:0001:0001:8a2e:0370:7334/127"));
+  EXPECT_EQ(
+      "2001:db8:85a3:1:1:8a2e:370:7334",
+      getIPSubnetRangeMin("2001:0db8:85a3:0001:0001:8a2e:0370:7334/128"));
+
+  EXPECT_EQ(
+      "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+      getIPSubnetRangeMax("2001:0db8:85a3:0001:0001:8a2e:0370:7334/0"));
+  EXPECT_EQ(
+      "7fff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+      getIPSubnetRangeMax("2001:0db8:85a3:0001:0001:8a2e:0370:7334/1"));
+  EXPECT_EQ(
+      "2001:db8:85a3:1:1:8a2e:370:7335",
+      getIPSubnetRangeMax("2001:0db8:85a3:0001:0001:8a2e:0370:7334/127"));
+  EXPECT_EQ(
+      "2001:db8:85a3:1:1:8a2e:370:7334",
+      getIPSubnetRangeMax("2001:0db8:85a3:0001:0001:8a2e:0370:7334/128"));
+}
+
+TEST_F(IPAddressTest, IPSubnetRangePrestoTests) {
+  EXPECT_EQ(getIPSubnetRangeMin("1.2.3.160/24"), "1.2.3.0");
+  EXPECT_EQ(getIPSubnetRangeMin("1.2.3.128/31"), "1.2.3.128");
+  EXPECT_EQ(getIPSubnetRangeMin("10.1.6.46/32"), "10.1.6.46");
+  EXPECT_EQ(getIPSubnetRangeMin("10.1.6.46/0"), "0.0.0.0");
+  EXPECT_EQ(getIPSubnetRangeMin("64:ff9b::17/64"), "64:ff9b::");
+  EXPECT_EQ(getIPSubnetRangeMin("64:ff9b::52f4/120"), "64:ff9b::5200");
+  EXPECT_EQ(getIPSubnetRangeMin("64:ff9b::17/128"), "64:ff9b::17");
+
+  EXPECT_EQ(getIPSubnetRangeMax("1.2.3.160/24"), "1.2.3.255");
+  EXPECT_EQ(getIPSubnetRangeMax("1.2.3.128/31"), "1.2.3.129");
+  EXPECT_EQ(getIPSubnetRangeMax("10.1.6.46/32"), "10.1.6.46");
+  EXPECT_EQ(getIPSubnetRangeMax("10.1.6.46/0"), "255.255.255.255");
+  EXPECT_EQ(
+      getIPSubnetRangeMax("64:ff9b::17/64"), "64:ff9b::ffff:ffff:ffff:ffff");
+  EXPECT_EQ(getIPSubnetRangeMax("64:ff9b::52f4/120"), "64:ff9b::52ff");
+  EXPECT_EQ(getIPSubnetRangeMax("64:ff9b::17/128"), "64:ff9b::17");
+}
+
+TEST_F(IPAddressTest, IPSubnetOfIPAddress) {
+  EXPECT_EQ(getIsSubnetOfIP("1.2.3.128/26", "1.2.3.129"), true);
+  EXPECT_EQ(getIsSubnetOfIP("64:fa9b::17/64", "64:ffff::17"), false);
+}
+
+TEST_F(IPAddressTest, IPSubnetOfIPPrefix) {
+  EXPECT_EQ(
+      getIsSubnetOfIPPrefix("192.168.3.131/26", "192.168.3.144/30"), true);
+  EXPECT_EQ(getIsSubnetOfIPPrefix("64:ff9b::17/64", "64:ffff::17/64"), false);
+  EXPECT_EQ(getIsSubnetOfIPPrefix("64:ff9b::17/32", "64:ffff::17/24"), false);
+  EXPECT_EQ(getIsSubnetOfIPPrefix("64:ffff::17/24", "64:ff9b::17/32"), true);
+  EXPECT_EQ(
+      getIsSubnetOfIPPrefix("192.168.3.131/26", "192.168.3.131/26"), true);
+}
+
+TEST_F(IPAddressTest, IPSubnetOfPrestoTests) {
+  EXPECT_EQ(getIsSubnetOfIP("1.2.3.128/26", "1.2.3.129"), true);
+  EXPECT_EQ(getIsSubnetOfIP("1.2.3.128/26", "1.2.5.1"), false);
+  EXPECT_EQ(getIsSubnetOfIP("1.2.3.128/32", "1.2.3.128"), true);
+  EXPECT_EQ(getIsSubnetOfIP("1.2.3.128/0", "192.168.5.1"), true);
+  EXPECT_EQ(getIsSubnetOfIP("64:ff9b::17/64", "64:ff9b::ffff:ff"), true);
+  EXPECT_EQ(getIsSubnetOfIP("64:ff9b::17/64", "64:ffff::17"), false);
+
+  EXPECT_EQ(
+      getIsSubnetOfIPPrefix("192.168.3.131/26", "192.168.3.144/30"), true);
+  EXPECT_EQ(getIsSubnetOfIPPrefix("1.2.3.128/26", "1.2.5.1/30"), false);
+  EXPECT_EQ(getIsSubnetOfIPPrefix("1.2.3.128/26", "1.2.3.128/26"), true);
+  EXPECT_EQ(getIsSubnetOfIPPrefix("64:ff9b::17/64", "64:ff9b::ff:25/80"), true);
+  EXPECT_EQ(getIsSubnetOfIPPrefix("64:ff9b::17/64", "64:ffff::17/64"), false);
+  EXPECT_EQ(
+      getIsSubnetOfIPPrefix("2804:431:b000::/37", "2804:431:b000::/38"), true);
+  EXPECT_EQ(
+      getIsSubnetOfIPPrefix("2804:431:b000::/38", "2804:431:b000::/37"), false);
+  EXPECT_EQ(getIsSubnetOfIPPrefix("170.0.52.0/22", "170.0.52.0/24"), true);
+  EXPECT_EQ(getIsSubnetOfIPPrefix("170.0.52.0/24", "170.0.52.0/22"), false);
+}
+
+} // namespace
+
+} // namespace facebook::velox::functions::prestosql
+                                                    

--- a/velox/functions/prestosql/types/CMakeLists.txt
+++ b/velox/functions/prestosql/types/CMakeLists.txt
@@ -11,8 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(velox_presto_types HyperLogLogType.cpp JsonType.cpp
-                               TimestampWithTimeZoneType.cpp UuidType.cpp)
+add_library(
+  velox_presto_types
+  HyperLogLogType.cpp JsonType.cpp TimestampWithTimeZoneType.cpp UuidType.cpp
+  IPAddressType.cpp IPPrefixType.cpp)
 
 target_link_libraries(
   velox_presto_types velox_memory velox_expression velox_functions_util

--- a/velox/functions/prestosql/types/IPAddressType.cpp
+++ b/velox/functions/prestosql/types/IPAddressType.cpp
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/types/IPAddressType.h"
+#include <iostream>
+
+namespace facebook::velox {
+
+namespace {
+
+class IPAddressCastOperator : public exec::CastOperator {
+ public:
+  bool isSupportedFromType(const TypePtr& other) const override {
+    return VARCHAR()->equivalent(*other);
+  }
+
+  bool isSupportedToType(const TypePtr& other) const override {
+    return VARCHAR()->equivalent(*other);
+  }
+
+  void castTo(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      VectorPtr& result) const override {
+    context.ensureWritable(rows, resultType, result);
+
+    if (input.typeKind() == TypeKind::VARCHAR) {
+      castFromString(input, context, rows, *result);
+    } else {
+      VELOX_UNSUPPORTED(
+          "Cast from {} to IPAddress not yet supported",
+          resultType->toString());
+    }
+  }
+
+  void castFrom(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      VectorPtr& result) const override {
+    context.ensureWritable(rows, resultType, result);
+
+    if (resultType->kind() == TypeKind::VARCHAR) {
+      castToString(input, context, rows, *result);
+    } else {
+      VELOX_UNSUPPORTED(
+          "Cast from IPAddress to {} not yet supported",
+          resultType->toString());
+    }
+  }
+
+ private:
+  static void castToString(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      BaseVector& result) {
+    auto* flatResult = result.as<FlatVector<StringView>>();
+    const auto* ipaddresses = input.as<SimpleVector<int128_t>>();
+
+    context.applyToSelectedNoThrow(rows, [&](auto row) {
+      const auto intAddr = ipaddresses->valueAt(row);
+      boost::asio::ip::address_v6::bytes_type addrBytes;
+      std::string s;
+      memcpy(&addrBytes, &intAddr, 16);
+
+      bigEndianByteArray(addrBytes);
+      auto v6Addr = boost::asio::ip::make_address_v6(addrBytes);
+
+      if (v6Addr.is_v4_mapped()) {
+        auto v4Addr = boost::asio::ip::make_address_v4(
+            boost::asio::ip::v4_mapped, v6Addr);
+        s = boost::lexical_cast<std::string>(v4Addr);
+      } else {
+        s = boost::lexical_cast<std::string>(v6Addr);
+      }
+
+      exec::StringWriter<false> result(flatResult, row);
+      result.append(s);
+      result.finalize();
+    });
+  }
+
+  static void castFromString(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      BaseVector& result) {
+    auto* flatResult = result.as<FlatVector<int128_t>>();
+    const auto* ipAddressStrings = input.as<SimpleVector<StringView>>();
+
+    context.applyToSelectedNoThrow(rows, [&](auto row) {
+      const auto ipAddressString = ipAddressStrings->valueAt(row);
+      boost::asio::ip::address_v6::bytes_type addrBytes;
+      auto addr = boost::asio::ip::make_address(ipAddressString);
+      int128_t intAddr;
+      if (addr.is_v4()) {
+        addrBytes = boost::asio::ip::make_address_v6(
+                        boost::asio::ip::v4_mapped, addr.to_v4())
+                        .to_bytes();
+      } else {
+        addrBytes = addr.to_v6().to_bytes();
+      }
+
+      bigEndianByteArray(addrBytes);
+      memcpy(&intAddr, &addrBytes, 16);
+
+      flatResult->set(row, intAddr);
+    });
+  }
+};
+
+class IPAddressTypeFactories : public CustomTypeFactories {
+ public:
+  IPAddressTypeFactories() = default;
+
+  TypePtr getType() const override {
+    return IPADDRESS();
+  }
+
+  exec::CastOperatorPtr getCastOperator() const override {
+    return std::make_shared<IPAddressCastOperator>();
+  }
+};
+
+} // namespace
+
+void registerIPAddressType() {
+  registerCustomType(
+      "ipaddress", std::make_unique<const IPAddressTypeFactories>());
+}
+
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/IPAddressType.h
+++ b/velox/functions/prestosql/types/IPAddressType.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <boost/asio/ip/address.hpp>
+#include <boost/asio/ip/network_v4.hpp>
+#include <boost/asio/ip/network_v6.hpp>
+#include <boost/lexical_cast.hpp>
+#include <folly/Bits.h>
+#include "velox/expression/CastExpr.h"
+#include "velox/type/SimpleFunctionApi.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox {
+
+// Converts BigEndian <-> native byte array
+// NOOP if system is Big Endian already
+inline void bigEndianByteArray(
+    boost::asio::ip::address_v6::bytes_type& addrBytes) {
+  if (folly::kIsLittleEndian) {
+    std::reverse(addrBytes.begin(), addrBytes.end());
+  }
+}
+
+class IPAddressType : public HugeintType {
+  IPAddressType() = default;
+
+ public:
+  static const std::shared_ptr<const IPAddressType>& get() {
+    static const std::shared_ptr<const IPAddressType> instance{
+        new IPAddressType()};
+
+    return instance;
+  }
+
+  bool equivalent(const Type& other) const override {
+    // Pointer comparison works since this type is a singleton.
+    return this == &other;
+  }
+
+  const char* name() const override {
+    return "IPADDRESS";
+  }
+
+  std::string toString() const override {
+    return name();
+  }
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = "Type";
+    obj["type"] = name();
+    return obj;
+  }
+};
+
+FOLLY_ALWAYS_INLINE bool isIPAddressType(const TypePtr& type) {
+  // Pointer comparison works since this type is a singleton.
+  return IPAddressType::get() == type;
+}
+
+FOLLY_ALWAYS_INLINE std::shared_ptr<const IPAddressType> IPADDRESS() {
+  return IPAddressType::get();
+}
+
+// Type used for function registration.
+struct IPAddressT {
+  using type = int128_t;
+  static constexpr const char* typeName = "ipaddress";
+};
+
+using IPAddress = CustomType<IPAddressT>;
+
+void registerIPAddressType();
+
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/IPPrefixType.cpp
+++ b/velox/functions/prestosql/types/IPPrefixType.cpp
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/types/IPPrefixType.h"
+#include "velox/functions/prestosql/types/IPAddressType.h"
+
+namespace facebook::velox {
+
+namespace {
+
+class IPPrefixCastOperator : public exec::CastOperator {
+ public:
+  bool isSupportedFromType(const TypePtr& other) const override {
+    return VARCHAR()->equivalent(*other);
+  }
+
+  bool isSupportedToType(const TypePtr& other) const override {
+    return VARCHAR()->equivalent(*other);
+  }
+
+  void castTo(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      VectorPtr& result) const override {
+    context.ensureWritable(rows, resultType, result);
+
+    if (input.typeKind() == TypeKind::VARCHAR) {
+      castFromString(input, context, rows, *result);
+    } else {
+      VELOX_UNSUPPORTED(
+          "Cast from {} to IPPrefix not yet supported", resultType->toString());
+    }
+  }
+
+  void castFrom(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      VectorPtr& result) const override {
+    context.ensureWritable(rows, resultType, result);
+
+    if (resultType->kind() == TypeKind::VARCHAR) {
+      castToString(input, context, rows, *result);
+    } else {
+      VELOX_UNSUPPORTED(
+          "Cast from IPPrefix to {} not yet supported", resultType->toString());
+    }
+  }
+
+ private:
+  static void castToString(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      BaseVector& result) {
+    auto* flatResult = result.as<FlatVector<StringView>>();
+    const auto* ipaddresses = input.as<SimpleVector<std::shared_ptr<void>>>();
+
+    context.applyToSelectedNoThrow(rows, [&](auto row) {
+      const auto intAddr =
+          std::static_pointer_cast<IPPrefix>(ipaddresses->valueAt(row));
+      boost::asio::ip::address_v6::bytes_type addrBytes;
+      std::string s;
+
+      memcpy(&addrBytes, &intAddr->ip, 16);
+      bigEndianByteArray(addrBytes);
+      auto v6Addr = boost::asio::ip::make_address_v6(addrBytes);
+
+      if (v6Addr.is_v4_mapped()) {
+        auto v4Addr = boost::asio::ip::make_address_v4(
+            boost::asio::ip::v4_mapped, v6Addr);
+        auto v4Net =
+            boost::asio::ip::network_v4(v4Addr, (uint8_t)intAddr->prefix);
+        s = boost::lexical_cast<std::string>(v4Net);
+      } else {
+        auto v6Net =
+            boost::asio::ip::network_v6(v6Addr, (uint8_t)intAddr->prefix);
+        s = boost::lexical_cast<std::string>(v6Net);
+      }
+
+      exec::StringWriter<false> result(flatResult, row);
+      result.append(s);
+      result.finalize();
+    });
+  }
+
+  static void castFromString(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      BaseVector& result) {
+    auto* flatResult = result.as<FlatVector<std::shared_ptr<void>>>();
+    const auto* ipAddressStrings = input.as<SimpleVector<StringView>>();
+
+    context.applyToSelectedNoThrow(rows, [&](auto row) {
+      const auto ipAddressString = ipAddressStrings->valueAt(row);
+      int slashPos = ipAddressString.str().find_last_of('/');
+      std::string ipOnly = ipAddressString.str().substr(0, slashPos);
+      boost::asio::ip::address_v6 v6Addr;
+      boost::asio::ip::address_v6::bytes_type addrBytes;
+
+      auto addr = boost::asio::ip::make_address(ipOnly);
+      IPPrefix res(0, 0);
+      if (addr.is_v4()) {
+        auto v4Net = boost::asio::ip::make_network_v4(ipAddressString);
+        res.prefix = (uint8_t)v4Net.prefix_length();
+        addrBytes = boost::asio::ip::make_address_v6(
+                        boost::asio::ip::v4_mapped, v4Net.canonical().address())
+                        .to_bytes();
+      } else {
+        auto v6Net = boost::asio::ip::make_network_v6(ipAddressString);
+        if (addr.to_v6().is_v4_mapped()) {
+          auto v4Addr = boost::asio::ip::make_address_v4(
+              boost::asio::ip::v4_mapped, addr.to_v6());
+          auto v4Net = boost::asio::ip::make_network_v4(
+              v4Addr, (uint8_t)v6Net.prefix_length());
+          addrBytes =
+              boost::asio::ip::make_address_v6(
+                  boost::asio::ip::v4_mapped, v4Net.canonical().address())
+                  .to_bytes();
+        } else {
+          addrBytes = v6Net.canonical().address().to_bytes();
+        }
+        res.prefix = (uint8_t)v6Net.prefix_length();
+      }
+
+      bigEndianByteArray(addrBytes);
+      memcpy(&res.ip, &addrBytes, 16);
+
+      flatResult->set(
+          row, std::make_shared<IPPrefix>(res.ip, (uint8_t)res.prefix));
+    });
+  }
+};
+
+class IPPrefixTypeFactories : public CustomTypeFactories {
+ public:
+  TypePtr getType() const override {
+    return IPPrefixType::get();
+  }
+
+  exec::CastOperatorPtr getCastOperator() const override {
+    return std::make_shared<IPPrefixCastOperator>();
+  }
+};
+
+} // namespace
+
+void registerIPPrefixType() {
+  registerCustomType(
+      "ipprefix", std::make_unique<const IPPrefixTypeFactories>());
+}
+
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/IPPrefixType.h
+++ b/velox/functions/prestosql/types/IPPrefixType.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <boost/asio/ip/address.hpp>
+#include <boost/asio/ip/network_v4.hpp>
+#include <boost/asio/ip/network_v6.hpp>
+#include <boost/lexical_cast.hpp>
+#include <folly/IPAddress.h>
+#include "velox/expression/CastExpr.h"
+#include "velox/type/OpaqueCustomTypes.h"
+#include "velox/type/SimpleFunctionApi.h"
+#include "velox/type/Type.h"
+
+#include <iostream>
+
+namespace facebook::velox {
+
+struct IPPrefix {
+  int128_t ip;
+  int8_t prefix;
+  explicit IPPrefix(int128_t _ip, int8_t _prefix) : ip{_ip}, prefix{_prefix} {}
+};
+
+class IPPrefixType : public OpaqueType {
+  IPPrefixType() : OpaqueType(std::type_index(typeid(IPPrefix))) {}
+
+ public:
+  static const std::shared_ptr<const IPPrefixType>& get() {
+    static const std::shared_ptr<const IPPrefixType> instance{
+        new IPPrefixType()};
+
+    return instance;
+  }
+
+  bool equivalent(const Type& other) const override {
+    // Pointer comparison works since this type is a singleton.
+    return this == &other;
+  }
+
+  const char* name() const override {
+    return "IPPREFIX";
+  }
+
+  std::string toString() const override {
+    return name();
+  }
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = "Type";
+    obj["type"] = name();
+    return obj;
+  }
+};
+
+FOLLY_ALWAYS_INLINE bool isIPPrefixType(const TypePtr& type) {
+  // Pointer comparison works since this type is a singleton.
+  return IPPrefixType::get() == type;
+}
+
+FOLLY_ALWAYS_INLINE std::shared_ptr<const IPPrefixType> IPPREFIX() {
+  return IPPrefixType::get();
+}
+
+struct IPPrefixT {
+  using type = std::shared_ptr<IPPrefix>;
+  static constexpr const char* typeName = "ipprefix";
+};
+using TheIPPrefix = CustomType<IPPrefixT>;
+
+void registerIPPrefixType();
+
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/types/tests/CMakeLists.txt
@@ -14,8 +14,13 @@
 
 add_executable(
   velox_presto_types_test
-  HyperLogLogTypeTest.cpp JsonTypeTest.cpp TimestampWithTimeZoneTypeTest.cpp
-  TypeTestBase.cpp UuidTypeTest.cpp)
+  HyperLogLogTypeTest.cpp
+  JsonTypeTest.cpp
+  TimestampWithTimeZoneTypeTest.cpp
+  TypeTestBase.cpp
+  UuidTypeTest.cpp
+  IPAddressTypeTest.cpp
+  IPPrefixTypeTest.cpp)
 
 add_test(velox_presto_types_test velox_presto_types_test)
 

--- a/velox/functions/prestosql/types/tests/IPAddressTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/IPAddressTypeTest.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/types/IPAddressType.h"
+#include "velox/functions/prestosql/types/tests/TypeTestBase.h"
+
+namespace facebook::velox::test {
+
+class IPAddressTypeTest : public testing::Test, public TypeTestBase {
+ public:
+  IPAddressTypeTest() {
+    registerIPAddressType();
+  }
+};
+
+TEST_F(IPAddressTypeTest, basic) {
+  ASSERT_EQ(IPADDRESS()->name(), "IPADDRESS");
+  ASSERT_EQ(IPADDRESS()->kindName(), "HUGEINT");
+  ASSERT_TRUE(IPADDRESS()->parameters().empty());
+  ASSERT_EQ(IPADDRESS()->toString(), "IPADDRESS");
+
+  ASSERT_TRUE(hasType("IPADDRESS"));
+  ASSERT_EQ(*getType("IPADDRESS", {}), *IPADDRESS());
+}
+
+TEST_F(IPAddressTypeTest, serde) {
+  testTypeSerde(IPADDRESS());
+}
+} // namespace facebook::velox::test

--- a/velox/functions/prestosql/types/tests/IPPrefixTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/IPPrefixTypeTest.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/types/IPPrefixType.h"
+#include "velox/functions/prestosql/types/tests/TypeTestBase.h"
+
+namespace facebook::velox::test {
+
+class IPPrefixTypeTest : public testing::Test, public TypeTestBase {
+ public:
+  IPPrefixTypeTest() {
+    registerIPPrefixType();
+  }
+};
+
+TEST_F(IPPrefixTypeTest, basic) {
+  ASSERT_EQ(IPPREFIX()->name(), "IPPREFIX");
+  ASSERT_TRUE(IPPREFIX()->parameters().empty());
+  ASSERT_EQ(IPPREFIX()->toString(), "IPPREFIX");
+
+  ASSERT_TRUE(hasType("IPPREFIX"));
+  ASSERT_EQ(*getType("IPPREFIX", {}), *IPPREFIX());
+}
+
+TEST_F(IPPrefixTypeTest, serde) {
+  testTypeSerde(IPPREFIX());
+}
+} // namespace facebook::velox::test


### PR DESCRIPTION
# IPADDRESS/IPPREFIX

## Types
### IPADDRESS (HUGEINT)
    All IPs are stored as IPV6. IPV4 is converted to IPV6 with a form of 
    0x 0000 0000 0000 0000 0000 FFFF XXXX XXXX

### IPPREFIX ({HUGEINT, TINYINT})
    Stored as a an opaque type of struct 
    { int128_t ip, int8_t prefix}

## Functions
NOTE: We cannot apply IPV4 operations on an IPV4 converted IPV6 address.
Ex. We can apply a length 100 prefix on an IPV4 converted address. So we need
to always convert IPV6 to IPV4 if possible. 

### cast(ipaddress as varchar) → varchar
    memcpy int128_t from ipaddress type into boost byte array. 
    If we are loading from a little endian system we need to flip
   the bytes since it needs to be in network byte order.

    We then check if it is a v4 mapped address so we can make
    the correct boost ipV4/V6 object to print correctly.

    All error handling done by the boost library.
### cast(ipaddressString as IPADDRESS) → IPADDRESS
    Create IP address boost object with the string. Check the object,
    if its V4 then convert to V6. Extract the bytes and flip if we are on
   a little endian system. Copy back into the int128_t for the result.

    All error handling done by the boost library.
### cast(ipprefix as VARCHAR) → VARCHAR
    Same as ipaddress, except we create a network with the IP
### cast(ipprefixString as IPADDRESS) → IPPREFIX
    Find the last occurance of '/' creating a boost IP address object 
    with whatever comes before it. If there are two '/' IP object creation will fail
    if there is no slash ex. an IP without any prefix we will continue
    but fail at a later point.

    Use the address object to see if we have an IP V4 or V6 network 
    and create the V4/V6 network with the original string. Network 
    creation will fail if the IP is not parseable. 
    
    If we have an IPV6 object, there is a chance that they entered an
    IPV4 formatted as an IPV6 so we need to create an IPV4 network
    to properly get the canonical address and check prefix validity. 

    Use the network to get the canonical address, flipping the bytes 
    if necessary before putting it in the IPPREFIX ip variable. 

    Copy over the prefix from prefixBits argument.

### ip_prefix(ipaddress, prefix_bits) → IPPREFIX
    If ipaddress is a varchar, use same logic as cast to convert to
    ip address and call with ipaddress type. 

    Create boost v6 ipaddress object with the ipaddress type passed in.
    Create corresponding v4/v6 boost network and pass in the prefix_bits
    converting it to uint8_t since the presto type is int8_t. 

    Get the canonical ip address from the network object as a byte array,
    flipping if on little endian to prepare for placing in the HUGEINT type. 

    IP Parsing and prefix size restriction error handling is all done in boost. 
### ip_subnet_min(ipprefix) → IPADDRESS
    Return the canonical IP address already stored in the IP Prefix object.
    It is the smallest IP we could have.
### ip_subnet_max(ipprefix) → IPADDRESS
    We want to set all non prefix bits to 1. For IPV4 thats max 32 bits, for IPV6
    thats max 128. Subtract prefix from the max and do some bit manipulation
    to flip that many bits.

    EX. Prefix is 25 on an IPV4. So we want to flip the 7 LSBs. 
    1 << 7 = (1,0,0,0,0,0,0,0)
    (1,0,0,0,0,0,0,0) - 1 = (0,1,1,1,1,1,1,1);

    We then OR this with IPPREFIX's canonical IP to set them all to 1.

    Note, for ipprefix = 0 in IPV6 we should be able to overflow then subtract one
    from a bit standpoint but it does not work. So added a special case. 
### ip_subnet_range(ipprefix) → [IPADDRESS, IPADDRESS]
    Just return ip_subnet_min and ip_subnet_max in an array. 
### is_subnet_of(ipprefix, ipaddress) → BOOLEAN
    We just need to make sure that the prefix of IPADDRESS is equal to the ip
    of IPPREFIX when subject to the prefix length of IPPREFIX.
    To do this we do a similar bit operation. However we flip the bits to get the prefix
    side and AND them together to extract the prefix bits from the IP. 
    We then compare to check if the prefix are equal. 

    Note, for ipprefix = 0 in IPV6 we should be able to overflow then subtract one
    from a bit standpoint but it does not work. So added a special case. 
### is_subnet_of(ipprefix1, ipprefix2) → BOOLEAN
    Just call is_subnet_of(ipprefix, ipaddress) however with an additional condition
    to make sure that the prefix of ipprefix2 is longer or equal to that of ipprefix1.
    If its shorter than there is no way for ipprefix1 to contain all of ipprefix2. 