### PR TITLE
Fix NaN handling in Spark In function

### DIFF
--- a/velox/functions/sparksql/In.cpp
+++ b/velox/functions/sparksql/In.cpp
@@ -30,6 +30,18 @@ template <typename T>
 class Set : public folly::F14FastSet<T, folly::hasher<T>, Equal<T>> {};
 
 template <>
+class Set<float> : public folly::F14FastSet<
+                       float,
+                       util::floating_point::NaNAwareHash<float>,
+                       util::floating_point::NaNAwareEquals<float>> {};
+
+template <>
+class Set<double> : public folly::F14FastSet<
+                        double,
+                        util::floating_point::NaNAwareHash<double>,
+                        util::floating_point::NaNAwareEquals<double>> {};
+
+template <>
 class Set<StringView> {
  public:
   using value_type = std::string_view;

--- a/velox/functions/sparksql/tests/InTest.cpp
+++ b/velox/functions/sparksql/tests/InTest.cpp
@@ -143,6 +143,7 @@ TEST_F(InTest, Float) {
   EXPECT_EQ(in<float>(-0.0, {-1.0, 0.0, 1.0}), true);
   EXPECT_EQ(in<float>(kNan, {-1.0, 0.0, 1.0}), false);
   EXPECT_EQ(in<float>(kNan, {kNan, -1.0, 0.0, 1.0}), true);
+  EXPECT_EQ(in<float>(std::nanf("1"), {kNan, -1.0, 0.0, 1.0}), true);
 }
 
 TEST_F(InTest, Double) {
@@ -151,6 +152,7 @@ TEST_F(InTest, Double) {
   EXPECT_EQ(in<double>(-0.0, {-1.0, 0.0, 1.0}), true);
   EXPECT_EQ(in<double>(kNan, {-1.0, 0.0, 1.0}), false);
   EXPECT_EQ(in<double>(kNan, {kNan, -1.0, 0.0, 1.0}), true);
+  EXPECT_EQ(in<double>(std::nan("1"), {kNan, -1.0, 0.0, 1.0}), true);
   EXPECT_EQ(in<double>(kInf, {kNan, -1.0, 0.0, 1.0}), false);
   EXPECT_EQ(in<double>(kInf, {kNan, -1.0, 0.0, 1.0, kInf}), true);
   EXPECT_EQ(in<double>(-kInf, {kNan, -1.0, 0.0, 1.0}), false);


### PR DESCRIPTION
Different NaNs are handled as same in Spark.
https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/SQLOrderingUtil.scala#L28
```
spark.sql("select cast('inf' as double)/cast('inf' as double)  in (1, 2, 3, cast('nan' as double))").collect
res11: Array[org.apache.spark.sql.Row] = Array([true])
spark.sql("select 0 * cast('inf' as double)  in (1, cast('nan' as double))").collect
res12: Array[org.apache.spark.sql.Row] = Array([true])
```