### PR TITLE
Make dwrf support taking custom column reader factory

### DIFF
--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -114,6 +114,11 @@ struct RowNumberColumnInfo {
   std::string name;
 };
 
+class FormatSpecificOptions {
+ public:
+  virtual ~FormatSpecificOptions() = default;
+};
+
 /**
  * Options for creating a RowReader.
  */
@@ -160,6 +165,8 @@ class RowReaderOptions {
   std::shared_ptr<UnitLoaderFactory> unitLoaderFactory_;
 
   TimestampPrecision timestampPrecision_ = TimestampPrecision::kMilliseconds;
+
+  std::shared_ptr<FormatSpecificOptions> formatSpecificOptions_;
 
  public:
   RowReaderOptions() noexcept
@@ -436,6 +443,15 @@ class RowReaderOptions {
 
   void setTimestampPrecision(TimestampPrecision precision) {
     timestampPrecision_ = precision;
+  }
+
+  const std::shared_ptr<FormatSpecificOptions>& formatSpecificOptions() const {
+    return formatSpecificOptions_;
+  }
+
+  void setFormatSpecificOptions(
+      std::shared_ptr<FormatSpecificOptions> options) {
+    formatSpecificOptions_ = std::move(options);
   }
 };
 

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -173,7 +173,12 @@ void DwrfUnit::ensureDecoders() {
         options_.getRowNumberColumnInfo().has_value());
   } else {
     auto requestedType = columnSelector_->getSchemaWithId();
-    columnReader_ = ColumnReader::build( // enqueue streams
+    auto factory = &ColumnReaderFactory::defaultFactory();
+    if (auto formatOptions = std::dynamic_pointer_cast<DwrfOptions>(
+            options_.formatSpecificOptions())) {
+      factory = formatOptions->columnReaderFactory().get();
+    }
+    columnReader_ = factory->build(
         requestedType,
         fileType,
         *stripeStreams_,

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -27,6 +27,21 @@ namespace facebook::velox::dwrf {
 class ColumnReader;
 class DwrfUnit;
 
+class DwrfOptions : public dwio::common::FormatSpecificOptions {
+ public:
+  void setColumnReaderFactory(
+      std::shared_ptr<ColumnReaderFactory> columnReaderFactory) {
+    columnReaderFactory_ = std::move(columnReaderFactory);
+  }
+
+  const std::shared_ptr<ColumnReaderFactory>& columnReaderFactory() const {
+    return columnReaderFactory_;
+  }
+
+ private:
+  std::shared_ptr<ColumnReaderFactory> columnReaderFactory_;
+};
+
 class DwrfRowReader : public StrideIndexProvider,
                       public StripeReaderBase,
                       public dwio::common::RowReader {

--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
@@ -113,7 +113,8 @@ std::vector<std::unique_ptr<KeyNode<T>>> getKeyNodesFiltered(
     StripeStreams& stripe,
     const StreamLabels& streamLabels,
     memory::MemoryPool& memoryPool,
-    FlatMapContext& flatMapContext) {
+    FlatMapContext& flatMapContext,
+    ColumnReaderFactory& factory) {
   std::vector<std::unique_ptr<KeyNode<T>>> keyNodes;
 
   auto keySelectionStats =
@@ -150,7 +151,7 @@ std::vector<std::unique_ptr<KeyNode<T>>> getKeyNodesFiltered(
         // build seekable
         auto inMapDecoder = createBooleanRleDecoder(std::move(inMap), seqEk);
 
-        auto valueReader = ColumnReader::build(
+        auto valueReader = factory.build(
             requestedValueType,
             dataValueType,
             stripe,
@@ -213,7 +214,8 @@ FlatMapColumnReader<T>::FlatMapColumnReader(
     const StreamLabels& streamLabels,
     folly::Executor* executor,
     size_t decodingParallelismFactor,
-    FlatMapContext flatMapContext)
+    FlatMapContext flatMapContext,
+    ColumnReaderFactory& factory)
     : ColumnReader(fileType, stripe, streamLabels, std::move(flatMapContext)),
       requestedType_{requestedType},
       returnFlatVector_{stripe.getRowReaderOptions().getReturnFlatVector()},
@@ -229,7 +231,8 @@ FlatMapColumnReader<T>::FlatMapColumnReader(
       stripe,
       streamLabels,
       memoryPool_,
-      flatMapContext_);
+      flatMapContext_,
+      factory);
 
   parallelForOnKeyNodes_ = std::make_unique<dwio::common::ParallelFor>(
       executor_, 0, keyNodes_.size(), decodingParallelismFactor);
@@ -583,7 +586,8 @@ std::vector<std::unique_ptr<KeyNode<T>>> getKeyNodesForStructEncoding(
     StripeStreams& stripe,
     const StreamLabels& streamLabels,
     memory::MemoryPool& memoryPool,
-    FlatMapContext& flatMapContext) {
+    FlatMapContext& flatMapContext,
+    ColumnReaderFactory& factory) {
   // `KeyNode` is ordered based on the projection. So if [3, 2, 1] is
   // projected, the vector of key node will be created [3, 2, 1].
   // If the key is not found in the stripe, the key node will be nullptr.
@@ -597,7 +601,8 @@ std::vector<std::unique_ptr<KeyNode<T>>> getKeyNodesForStructEncoding(
       stripe,
       streamLabels,
       memoryPool,
-      flatMapContext);
+      flatMapContext,
+      factory);
 
   const auto& mapColumnIdAsStruct =
       stripe.getRowReaderOptions().getMapColumnIdAsStruct();
@@ -615,7 +620,8 @@ FlatMapStructEncodingColumnReader<T>::FlatMapStructEncodingColumnReader(
     const StreamLabels& streamLabels,
     folly::Executor* executor,
     size_t decodingParallelismFactor,
-    FlatMapContext flatMapContext)
+    FlatMapContext flatMapContext,
+    ColumnReaderFactory& factory)
     : ColumnReader(
           requestedType,
           stripe,
@@ -628,7 +634,8 @@ FlatMapStructEncodingColumnReader<T>::FlatMapStructEncodingColumnReader(
           stripe,
           streamLabels,
           memoryPool_,
-          flatMapContext_)},
+          flatMapContext_,
+          factory)},
       nullColumnReader_{std::make_unique<NullColumnReader>(
           stripe,
           requestedType_->type()->asMap().valueType())},
@@ -770,7 +777,8 @@ std::unique_ptr<ColumnReader> createFlatMapColumnReader(
     const StreamLabels& streamLabels,
     folly::Executor* executor,
     size_t decodingParallelismFactor,
-    FlatMapContext flatMapContext) {
+    FlatMapContext flatMapContext,
+    ColumnReaderFactory& factory) {
   if (isRequiringStructEncoding(requestedType, stripe.getRowReaderOptions())) {
     return std::make_unique<FlatMapStructEncodingColumnReader<T>>(
         requestedType,
@@ -779,7 +787,8 @@ std::unique_ptr<ColumnReader> createFlatMapColumnReader(
         streamLabels,
         executor,
         decodingParallelismFactor,
-        std::move(flatMapContext));
+        std::move(flatMapContext),
+        factory);
   } else {
     return std::make_unique<FlatMapColumnReader<T>>(
         requestedType,
@@ -788,7 +797,8 @@ std::unique_ptr<ColumnReader> createFlatMapColumnReader(
         streamLabels,
         executor,
         decodingParallelismFactor,
-        std::move(flatMapContext));
+        std::move(flatMapContext),
+        factory);
   }
 }
 
@@ -799,7 +809,8 @@ std::unique_ptr<ColumnReader> createFlatMapColumnReader(
     const StreamLabels& streamLabels,
     folly::Executor* executor,
     size_t decodingParallelismFactor,
-    FlatMapContext flatMapContext) {
+    FlatMapContext flatMapContext,
+    ColumnReaderFactory& factory) {
   // create flat map column reader based on key type
   const auto kind = fileType->childAt(0)->type()->kind();
 
@@ -812,7 +823,8 @@ std::unique_ptr<ColumnReader> createFlatMapColumnReader(
           streamLabels,
           executor,
           decodingParallelismFactor,
-          std::move(flatMapContext));
+          std::move(flatMapContext),
+          factory);
     case TypeKind::SMALLINT:
       return createFlatMapColumnReader<int16_t>(
           requestedType,
@@ -821,7 +833,8 @@ std::unique_ptr<ColumnReader> createFlatMapColumnReader(
           streamLabels,
           executor,
           decodingParallelismFactor,
-          std::move(flatMapContext));
+          std::move(flatMapContext),
+          factory);
     case TypeKind::INTEGER:
       return createFlatMapColumnReader<int32_t>(
           requestedType,
@@ -830,7 +843,8 @@ std::unique_ptr<ColumnReader> createFlatMapColumnReader(
           streamLabels,
           executor,
           decodingParallelismFactor,
-          std::move(flatMapContext));
+          std::move(flatMapContext),
+          factory);
     case TypeKind::BIGINT:
       return createFlatMapColumnReader<int64_t>(
           requestedType,
@@ -839,7 +853,8 @@ std::unique_ptr<ColumnReader> createFlatMapColumnReader(
           streamLabels,
           executor,
           decodingParallelismFactor,
-          std::move(flatMapContext));
+          std::move(flatMapContext),
+          factory);
     case TypeKind::VARBINARY:
     case TypeKind::VARCHAR:
       return createFlatMapColumnReader<StringView>(
@@ -849,7 +864,8 @@ std::unique_ptr<ColumnReader> createFlatMapColumnReader(
           streamLabels,
           executor,
           decodingParallelismFactor,
-          std::move(flatMapContext));
+          std::move(flatMapContext),
+          factory);
     default:
       DWIO_RAISE("Not supported key type: ", kind);
   }

--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.h
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.h
@@ -151,7 +151,8 @@ class FlatMapColumnReader : public ColumnReader {
       const StreamLabels& streamLabels,
       folly::Executor* executor,
       size_t decodingParallelismFactor,
-      FlatMapContext flatMapContext);
+      FlatMapContext flatMapContext,
+      ColumnReaderFactory& factory);
   ~FlatMapColumnReader() override = default;
 
   uint64_t skip(uint64_t numValues) override;
@@ -186,7 +187,8 @@ class FlatMapStructEncodingColumnReader : public ColumnReader {
       const StreamLabels& streamLabels,
       folly::Executor* executor,
       size_t decodingParallelismFactor,
-      FlatMapContext flatMapContext);
+      FlatMapContext flatMapContext,
+      ColumnReaderFactory& factory);
   ~FlatMapStructEncodingColumnReader() override = default;
 
   uint64_t skip(uint64_t numValues) override;
@@ -216,7 +218,8 @@ class FlatMapColumnReaderFactory {
       const StreamLabels& streamLabels,
       folly::Executor* executor,
       size_t decodingParallelismFactor,
-      FlatMapContext flatMapContext);
+      FlatMapContext flatMapContext,
+      ColumnReaderFactory& factory);
 };
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/StripeStream.h
+++ b/velox/dwio/dwrf/reader/StripeStream.h
@@ -278,6 +278,10 @@ class StripeStreamsImpl : public StripeStreamsBase {
       const DwrfStreamIdentifier& si,
       std::string_view label) const;
 
+  uint64_t getStreamOffset(const DwrfStreamIdentifier& si) const {
+    return getStreamInfo(si).getOffset() + stripeStart_;
+  }
+
   uint64_t getStreamLength(const DwrfStreamIdentifier& si) const {
     return getStreamInfo(si).getLength();
   }


### PR DESCRIPTION
Summary: There is a recently need of introducing custom column reader to decode the file in a special way. Extending column reader factory to allow user passing in their own factory.

Differential Revision: D58772345
