### PR TITLE
Fix parallel spills lead to crashes in approx_percentile

### DIFF
--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
@@ -30,6 +30,8 @@ namespace {
 
 template <typename T>
 using KllSketch = functions::kll::KllSketch<T, StlAllocator<T>>;
+template <typename T>
+using KllView = functions::kll::detail::View<T>;
 
 // Accumulator to buffer large count values in addition to the KLL
 // sketch itself.
@@ -67,42 +69,67 @@ struct KllSketchAccumulator {
     }
   }
 
-  void append(const typename KllSketch<T>::View& view) {
+  void append(const KllView<T>& view) {
     sketch_.mergeViews(folly::Range(&view, 1));
   }
 
-  void append(const std::vector<typename KllSketch<T>::View>& views) {
+  void append(const std::vector<KllView<T>>& views) {
     sketch_.mergeViews(views);
   }
 
-  void finalize() {
-    if (!largeCountValues_.empty()) {
-      flush();
-    }
-    sketch_.compact();
+  // Creates a copy of the KllSketch, merges the largeCountValues_ into it,
+  // compacts it, and returns it.
+  // Makes a copy so that uses std::allocator so that this is safe to call
+  // during spilling which may run in parallel.  HashStringAllocator is not
+  // thread safe, so merging into/compacting the original KllSketch which
+  // depends on it can lead to concurrency bugs.
+  functions::kll::KllSketch<T> compact() const {
+    functions::kll::KllSketch<T> newSketch =
+        functions::kll::KllSketch<T>::fromView(
+            sketch_.toView(), std::allocator<T>(), random::getSeed());
+
+    mergeLargeCountValuesIntoSketch(std::allocator<T>(), newSketch);
+
+    newSketch.compact();
+
+    return newSketch;
   }
 
   const KllSketch<T>& getSketch() const {
     return sketch_;
   }
 
+  // This must be called before the KllSketch can be used for estimateQuantile()
+  // or estimateQuantiles().
+  void flush() {
+    mergeLargeCountValuesIntoSketch(StlAllocator<T>(allocator_), sketch_);
+    largeCountValues_.clear();
+
+    sketch_.finish();
+  }
+
  private:
+  template <typename Allocator>
+  void mergeLargeCountValuesIntoSketch(
+      const Allocator& allocator,
+      functions::kll::KllSketch<T, Allocator>& sketch) const {
+    if (!largeCountValues_.empty()) {
+      std::vector<functions::kll::KllSketch<T, Allocator>> sketches;
+      sketches.reserve(largeCountValues_.size());
+      for (auto [x, n] : largeCountValues_) {
+        sketches.push_back(
+            functions::kll::KllSketch<T, Allocator>::fromRepeatedValue(
+                x, n, k_, allocator, random::getSeed()));
+      }
+      sketch.merge(folly::Range(sketches.begin(), sketches.end()));
+    }
+  }
+
   uint16_t k_;
   HashStringAllocator* allocator_;
   KllSketch<T> sketch_;
   std::vector<std::pair<T, int64_t>, StlAllocator<std::pair<T, int64_t>>>
       largeCountValues_;
-
-  void flush() {
-    std::vector<KllSketch<T>> sketches;
-    sketches.reserve(largeCountValues_.size());
-    for (auto [x, n] : largeCountValues_) {
-      sketches.push_back(KllSketch<T>::fromRepeatedValue(
-          x, n, k_, StlAllocator<T>(allocator_), random::getSeed()));
-    }
-    sketch_.merge(folly::Range(sketches.begin(), sketches.end()));
-    largeCountValues_.clear();
-  }
 };
 
 enum IntermediateTypeChildIndex {
@@ -148,7 +175,9 @@ class ApproxPercentileAggregate : public exec::Aggregate {
 
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {
-    finalize(groups, numGroups);
+    for (auto i = 0; i < numGroups; ++i) {
+      value<KllSketchAccumulator<T>>(groups[i])->flush();
+    }
 
     VELOX_CHECK(result);
     // When all inputs are nulls or masked out, percentiles_ can be
@@ -203,7 +232,11 @@ class ApproxPercentileAggregate : public exec::Aggregate {
 
   void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
       override {
-    finalize(groups, numGroups);
+    std::vector<functions::kll::KllSketch<T>> sketches;
+    sketches.reserve(numGroups);
+    for (auto i = 0; i < numGroups; ++i) {
+      sketches.push_back(value<KllSketchAccumulator<T>>(groups[i])->compact());
+    }
 
     VELOX_CHECK(result);
     auto rowResult = (*result)->as<RowVector>();
@@ -272,9 +305,8 @@ class ApproxPercentileAggregate : public exec::Aggregate {
     auto levelsElements = levels->elements()->asFlatVector<int32_t>();
     size_t itemsCount = 0;
     vector_size_t levelsCount = 0;
-    for (int i = 0; i < numGroups; ++i) {
-      auto accumulator = value<const KllSketchAccumulator<T>>(groups[i]);
-      auto v = accumulator->getSketch().toView();
+    for (auto& sketch : sketches) {
+      auto v = sketch.toView();
       itemsCount += v.items.size();
       levelsCount += v.levels.size();
     }
@@ -288,9 +320,8 @@ class ApproxPercentileAggregate : public exec::Aggregate {
     auto rawLevels = levelsElements->mutableRawValues();
     itemsCount = 0;
     levelsCount = 0;
-    for (int i = 0; i < numGroups; ++i) {
-      auto accumulator = value<const KllSketchAccumulator<T>>(groups[i]);
-      auto v = accumulator->getSketch().toView();
+    for (int i = 0; i < sketches.size(); ++i) {
+      auto v = sketches[i].toView();
       if (v.n == 0) {
         rowResult->setNull(i, true);
       } else {
@@ -422,12 +453,6 @@ class ApproxPercentileAggregate : public exec::Aggregate {
   }
 
  private:
-  void finalize(char** groups, int32_t numGroups) {
-    for (auto i = 0; i < numGroups; ++i) {
-      value<KllSketchAccumulator<T>>(groups[i])->finalize();
-    }
-  }
-
   template <typename VectorType, typename ExtractFunc>
   void extract(
       char** groups,
@@ -704,7 +729,7 @@ class ApproxPercentileAggregate : public exec::Aggregate {
     auto rawLevels = levelElements->rawValues<uint32_t>();
 
     KllSketchAccumulator<T>* accumulator = nullptr;
-    std::vector<typename KllSketch<T>::View> views;
+    std::vector<KllView<T>> views;
     if constexpr (kSingleGroup) {
       views.reserve(rows.end());
     }
@@ -752,7 +777,7 @@ class ApproxPercentileAggregate : public exec::Aggregate {
               maxValue->isNullAt(i) || items->isNullAt(i) ||
               levels->isNullAt(i)));
       }
-      typename KllSketch<T>::View v{
+      KllView<T> v{
           .k = static_cast<uint32_t>(k->valueAt(i)),
           .n = static_cast<size_t>(n->valueAt(i)),
           .minValue = minValue->valueAt(i),


### PR DESCRIPTION
Summary:
A recent optimization introduced the ability to spill multiple partitions of an aggregation in parallel.

This has caused queries that use the approx_percentile aggregation to crash, frequently the crash
points to the HashStringAllocator being used to allocate memory in extractAccumulators and finding
that the header it received from the freeList was not marked free.

The root cause is a concurrency issue.  HashStringAllocator is not thread safe.  The KllSketch class
allocates memory while compacting the KllSketch as well as when the KllSketchAccumulator merges
the largeCountValues_ into the KllSketch, both of which happen in KllSketchAccumulator's finalize
method which is invoked by extractAccumulators as part of spilling.  When two KllSketch's try to
get a free header concurrently, they may both find the same one, and then only one wins marking
the header as not free (it's actually possible that both "win" which leads to memory corruption and
crashes elsewhere).

The fix is to copy the KllSketch into a new one which uses an unshared stl::allocator (thread-safe)
instead of the shared HashStringAllocator, and then do the merging and compaction.  There is some
additional cost of copying some std::vectors inside of KllSketch (levels and items), but it's similar to
the cost we pay anyway for growing the vectors beyond their capacity which involves a copy as well.

The extractValues method in ApproxPercentileAggregate currently uses the same logic, but is not
invoked in a thread-unsafe manner, I also found it's unnecessarily compacting the KllSketch.  I
modified it to call flush on the KllSketchAccumulator which only merges the largeCountValues_ and
calls finish (rather than compact) on the KllSketch, all within the original KllSketch (no additional
copy).

To do this I had to move the inner class View out of KllSketch into a top level class, since KllSketch is
templated on the Allocator, but the View doesn't actually depend on it (this makes copying from a
View over a KllSketch with one Allocator into a KllSketch with another Allocator easy).

Differential Revision: D58823050
