### PR TITLE
Allow returning Status from callNullable and callNullFree methods

### DIFF
--- a/velox/core/SimpleFunctionMetadata.h
+++ b/velox/core/SimpleFunctionMetadata.h
@@ -676,7 +676,9 @@ class UDFHolder {
   //
   // Each of these methods can return bool, void or Status. Returning void
   // means that the UDF is assumed never to return null values. Returning
-  // Status to hold success or error outcome of the function call.
+  // Status to hold success or error outcome of the function call, and it
+  // implies result is not null. If you need to return null as result, please
+  // use bool return type.
   //
   // Optionally, UDFs can also provide the following methods:
   //

--- a/velox/core/SimpleFunctionMetadata.h
+++ b/velox/core/SimpleFunctionMetadata.h
@@ -709,13 +709,13 @@ class UDFHolder {
 
   static_assert(
       !(udf_has_call_return_bool && udf_has_call_return_void),
-      "Provided call() methods need to return either void OR bool OR status.");
+      "Provided call() methods need to return either void OR bool OR Status.");
   static_assert(
       !(udf_has_call_return_bool && udf_has_call_return_status),
-      "Provided call() methods need to return either void OR bool OR status.");
+      "Provided call() methods need to return either void OR bool OR Status.");
   static_assert(
       !(udf_has_call_return_void && udf_has_call_return_status),
-      "Provided call() methods need to return either void OR bool OR status.");
+      "Provided call() methods need to return either void OR bool OR Status.");
 
   // callNullable():
   static constexpr bool udf_has_callNullable_return_bool = util::has_method<
@@ -741,13 +741,13 @@ class UDFHolder {
       udf_has_callNullable_return_status;
   static_assert(
       !(udf_has_callNullable_return_bool && udf_has_callNullable_return_void),
-      "Provided callNullable() methods need to return either void OR bool OR status.");
+      "Provided callNullable() methods need to return either void OR bool OR Status.");
   static_assert(
       !(udf_has_callNullable_return_bool && udf_has_callNullable_return_status),
-      "Provided callNullable() methods need to return either void OR bool OR status.");
+      "Provided callNullable() methods need to return either void OR bool OR Status.");
   static_assert(
       !(udf_has_callNullable_return_void && udf_has_callNullable_return_status),
-      "Provided callNullable() methods need to return either void OR bool OR status.");
+      "Provided callNullable() methods need to return either void OR bool OR Status.");
 
   // callNullFree():
   static constexpr bool udf_has_callNullFree_return_bool = util::has_method<

--- a/velox/core/SimpleFunctionMetadata.h
+++ b/velox/core/SimpleFunctionMetadata.h
@@ -671,10 +671,11 @@ class UDFHolder {
   //
   // - bool|void|Status call(...)
   // - bool|void|Status callNullable(...)
-  // - bool|void callNullFree(...)
+  // - bool|void|Status callNullFree(...)
   //
-  // Each of these methods can return either bool or void. Returning void means
-  // that the UDF is assumed never to return null values.
+  // Each of these methods can return either bool or void or Status. Returning
+  // void means that the UDF is assumed never to return null values. Returning
+  // Status to hold success or error outcome of the function call.
   //
   // Optionally, UDFs can also provide the following methods:
   //
@@ -761,11 +762,24 @@ class UDFHolder {
       void,
       exec_return_type,
       const exec_no_nulls_arg_type<TArgs>&...>::value;
+  static constexpr bool udf_has_callNullFree_return_status = util::has_method<
+      Fun,
+      callNullFree_method_resolver,
+      Status,
+      exec_return_type,
+      const exec_no_nulls_arg_type<TArgs>&...>::value;
   static constexpr bool udf_has_callNullFree =
-      udf_has_callNullFree_return_bool | udf_has_callNullFree_return_void;
+      udf_has_callNullFree_return_bool | udf_has_callNullFree_return_void |
+      udf_has_callNullFree_return_status;
   static_assert(
       !(udf_has_callNullFree_return_bool && udf_has_callNullFree_return_void),
-      "Provided callNullFree() methods need to return either void OR bool.");
+      "Provided callNullFree() methods need to return either void OR bool OR Status.");
+  static_assert(
+      !(udf_has_callNullFree_return_bool && udf_has_callNullFree_return_status),
+      "Provided callNullFree() methods need to return either void OR bool OR Status.");
+  static_assert(
+      !(udf_has_callNullFree_return_void && udf_has_callNullFree_return_status),
+      "Provided callNullFree() methods need to return either void OR bool OR Status.");
 
   // callAscii():
   static constexpr bool udf_has_callAscii_return_bool = util::has_method<

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -1562,10 +1562,13 @@ TEST_F(SimpleFunctionTest, callNullableNoThrow) {
   VELOX_ASSERT_THROW(
       (evaluateOnce<int64_t, int64_t>("nullable_no_throw(c0)", std::nullopt)),
       "Input cannot be NULL");
-
   auto result = evaluateOnce<int64_t, int64_t>(
       "try(nullable_no_throw(c0))", std::nullopt);
   EXPECT_EQ(std::nullopt, result);
+
+  // No error.
+  result = evaluateOnce<int64_t, int64_t>("nullable_no_throw(c0)", 1);
+  EXPECT_EQ(2, result);
 }
 
 template <typename TExec>
@@ -1591,7 +1594,6 @@ TEST_F(SimpleFunctionTest, callNullFreeNoThrow) {
   VELOX_ASSERT_THROW(
       (evaluateOnce<int64_t, int64_t>("null_free_no_throw(c0)", 0)),
       "Input cannot be 0");
-
   auto result =
       evaluateOnce<int64_t, int64_t>("try(null_free_no_throw(c0))", 0);
   EXPECT_EQ(std::nullopt, result);
@@ -1599,9 +1601,12 @@ TEST_F(SimpleFunctionTest, callNullFreeNoThrow) {
   VELOX_ASSERT_THROW(
       (evaluateOnce<int64_t, int64_t>("null_free_no_throw(c0)", 4)),
       "Input cannot be even");
-
   result = evaluateOnce<int64_t, int64_t>("try(null_free_no_throw(c0))", 4);
   EXPECT_EQ(std::nullopt, result);
+
+  // No error.
+  result = evaluateOnce<int64_t, int64_t>("null_free_no_throw(c0)", 1);
+  EXPECT_EQ(2, result);
 }
 
 } // namespace

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -1548,6 +1548,7 @@ TEST_F(SimpleFunctionTest, noThrow) {
       (evaluateOnce<int64_t, int64_t>("try(no_throw(c0))", 6)),
       "Input must not be 6");
 
+  // Error reported via Status by callNullable.
   VELOX_ASSERT_THROW(
       (evaluateOnce<int64_t, int64_t>("no_throw(c0)", std::nullopt)),
       "Input cannot be NULL");

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -1508,13 +1508,6 @@ struct NoThrowFunction {
     out = in / 6;
     return Status::OK();
   }
-
-  Status callNullable(out_type<int64_t>& out, const arg_type<int64_t>* in) {
-    if (!in) {
-      return Status::UserError("Input cannot be NULL");
-    }
-    return Status::OK();
-  }
 };
 
 TEST_F(SimpleFunctionTest, noThrow) {
@@ -1547,12 +1540,67 @@ TEST_F(SimpleFunctionTest, noThrow) {
   VELOX_ASSERT_THROW(
       (evaluateOnce<int64_t, int64_t>("try(no_throw(c0))", 6)),
       "Input must not be 6");
+}
 
+template <typename TExec>
+struct CallNullableNoThrowFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  Status callNullable(out_type<int64_t>& out, const arg_type<int64_t>* in) {
+    if (!in) {
+      return Status::UserError("Input cannot be NULL");
+    }
+    out = *in + 1;
+    return Status::OK();
+  }
+};
+
+TEST_F(SimpleFunctionTest, callNullableNoThrow) {
+  registerFunction<CallNullableNoThrowFunction, int64_t, int64_t>(
+      {"nullable_no_throw"});
   // Error reported via Status by callNullable.
   VELOX_ASSERT_THROW(
-      (evaluateOnce<int64_t, int64_t>("no_throw(c0)", std::nullopt)),
+      (evaluateOnce<int64_t, int64_t>("nullable_no_throw(c0)", std::nullopt)),
       "Input cannot be NULL");
-  result = evaluateOnce<int64_t, int64_t>("try(no_throw(c0))", std::nullopt);
+
+  auto result = evaluateOnce<int64_t, int64_t>(
+      "try(nullable_no_throw(c0))", std::nullopt);
+  EXPECT_EQ(std::nullopt, result);
+}
+
+template <typename TExec>
+struct CallNullFreeNoThrowFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  Status callNullFree(out_type<int64_t>& out, const arg_type<int64_t>& in) {
+    if (in == 0) {
+      return Status::UserError("Input cannot be 0");
+    }
+    if (in % 2 == 0) {
+      return Status::UserError("Input cannot be even");
+    }
+    out = in + 1;
+    return Status::OK();
+  }
+};
+
+TEST_F(SimpleFunctionTest, callNullFreeNoThrow) {
+  registerFunction<CallNullFreeNoThrowFunction, int64_t, int64_t>(
+      {"null_free_no_throw"});
+  // Error reported via Status by callNullable.
+  VELOX_ASSERT_THROW(
+      (evaluateOnce<int64_t, int64_t>("null_free_no_throw(c0)", 0)),
+      "Input cannot be 0");
+
+  auto result =
+      evaluateOnce<int64_t, int64_t>("try(null_free_no_throw(c0))", 0);
+  EXPECT_EQ(std::nullopt, result);
+
+  VELOX_ASSERT_THROW(
+      (evaluateOnce<int64_t, int64_t>("null_free_no_throw(c0)", 4)),
+      "Input cannot be even");
+
+  result = evaluateOnce<int64_t, int64_t>("try(null_free_no_throw(c0))", 4);
   EXPECT_EQ(std::nullopt, result);
 }
 

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -1508,6 +1508,13 @@ struct NoThrowFunction {
     out = in / 6;
     return Status::OK();
   }
+
+  Status callNullable(out_type<int64_t>& out, const arg_type<int64_t>* in) {
+    if (!in) {
+      return Status::UserError("Input cannot be NULL");
+    }
+    return Status::OK();
+  }
 };
 
 TEST_F(SimpleFunctionTest, noThrow) {
@@ -1540,6 +1547,12 @@ TEST_F(SimpleFunctionTest, noThrow) {
   VELOX_ASSERT_THROW(
       (evaluateOnce<int64_t, int64_t>("try(no_throw(c0))", 6)),
       "Input must not be 6");
+
+  VELOX_ASSERT_THROW(
+      (evaluateOnce<int64_t, int64_t>("no_throw(c0)", std::nullopt)),
+      "Input cannot be NULL");
+  result = evaluateOnce<int64_t, int64_t>("try(no_throw(c0))", std::nullopt);
+  EXPECT_EQ(std::nullopt, result);
 }
 
 } // namespace


### PR DESCRIPTION
This pr continues the no-throw-exception optimization for more simple
function methods, following the work of PR https://github.com/facebookincubator/velox/pull/9659.

Fixes https://github.com/facebookincubator/velox/issues/10265