### PR TITLE
Update the protobuf version in setup-centos9.sh to v21.8

### DIFF
--- a/scripts/setup-adapters.sh
+++ b/scripts/setup-adapters.sh
@@ -73,11 +73,6 @@ function install_gcs-sdk-cpp {
     -DABSL_PROPAGATE_CXX_STD=ON \
     -DABSL_ENABLE_INSTALL=ON
 
-  # protobuf
-  github_checkout protocolbuffers/protobuf v21.4 --depth 1
-  cmake_install \
-    -Dprotobuf_BUILD_TESTS=OFF
-
   # grpc
   github_checkout grpc/grpc v1.48.1 --depth 1
   cmake_install \

--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -124,7 +124,7 @@ function install_fmt {
 }
 
 function install_protobuf {
-  wget_and_untar https://github.com/protocolbuffers/protobuf/releases/download/v21.4/protobuf-all-21.4.tar.gz protobuf
+  wget_and_untar https://github.com/protocolbuffers/protobuf/releases/download/v21.8/protobuf-all-21.8.tar.gz protobuf
   (
     cd protobuf
     ./configure --prefix=/usr


### PR DESCRIPTION
Updates the protobuf version in setup-centos9.sh to v21.8 and removes protobuf 
installation in setup-adapters.sh.