### PR TITLE
Remove unused exception parameter from velox/common/caching/SsdFile.cpp

### DIFF
--- a/velox/common/caching/SsdFile.cpp
+++ b/velox/common/caching/SsdFile.cpp
@@ -795,7 +795,7 @@ void SsdFile::checkpoint(bool force) {
           state.write(asChar(&checksum), sizeof(checksum));
         }
       }
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
       fileSync->close();
       std::rethrow_exception(std::current_exception());
     }

--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -256,7 +256,7 @@ class AsyncDataCacheTest : public ::testing::TestWithParam<TestParam> {
       EXPECT_TRUE(pin.entry()->isExclusive());
       pin.entry()->setPrefetch();
       return pin;
-    } catch (const VeloxException& e) {
+    } catch (const VeloxException&) {
       return CachePin();
     };
   }
@@ -365,12 +365,12 @@ class TestingCoalescedSsdLoad : public TestingCoalescedLoad {
     try {
       file.load(toLoad, pins);
       VELOX_CHECK(!injectError_, "Testing error");
-    } catch (std::exception& e) {
+    } catch (std::exception&) {
       try {
         for (const auto& ssdPin : toLoad) {
           file.erase(RawFileCacheKey{fileNum, ssdPin.run().offset()});
         }
-      } catch (const std::exception& e2) {
+      } catch (const std::exception&) {
         // Ignore error.
       }
       throw;
@@ -480,7 +480,7 @@ void AsyncDataCacheTest::loadBatch(
       };
       try {
         load->loadOrFuture(nullptr);
-      } catch (const std::exception& e) {
+      } catch (const std::exception&) {
         // Expecting error, ignore.
       };
       if (semaphore) {
@@ -513,7 +513,7 @@ void AsyncDataCacheTest::loadBatch(
       };
       try {
         load->loadOrFuture(nullptr);
-      } catch (const std::exception& e) {
+      } catch (const std::exception&) {
         // Expecting error, ignore.
       };
       if (semaphore) {
@@ -604,7 +604,7 @@ void AsyncDataCacheTest::loadLoop(
           loadBatch(fileNum, batch, injectError);
           try {
             checkBatch(fileNum, batch, injectError);
-          } catch (std::exception& e) {
+          } catch (std::exception&) {
             continue;
           }
           batch.clear();

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -2559,7 +2559,7 @@ TEST_F(MockSharedArbitrationTest, noArbitratiognFromAbortedPool) {
   reclaimedOp->allocate(128);
   try {
     VELOX_MEM_POOL_ABORTED("Manual abort pool");
-  } catch (VeloxException& e) {
+  } catch (VeloxException&) {
     reclaimedOp->pool()->abort(std::current_exception());
   }
   ASSERT_TRUE(reclaimedOp->pool()->aborted());

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -1636,7 +1636,7 @@ DEBUG_ONLY_TEST_F(
   std::thread failThread([&]() {
     try {
       VELOX_FAIL("Test terminate task");
-    } catch (const VeloxException& e) {
+    } catch (const VeloxException&) {
       task->setError(std::current_exception());
     }
   });
@@ -1953,7 +1953,7 @@ TEST_F(MultiFragmentTest, earlyTaskFailure) {
     if (internalFailure) {
       try {
         VELOX_FAIL("memoryAbortTest");
-      } catch (const VeloxRuntimeError& e) {
+      } catch (const VeloxRuntimeError&) {
         finalSortTask->pool()->abort(std::current_exception());
       }
     } else {

--- a/velox/functions/prestosql/Slice.cpp
+++ b/velox/functions/prestosql/Slice.cpp
@@ -134,7 +134,7 @@ class SliceFunction : public exec::VectorFunction {
             static_cast<vector_size_t>(decodedStart->valueAt<T>(0)));
         context.applyToSelectedNoThrow(
             rows, [&](auto row) { fillResultVectorFunc(row, adjustedStart); });
-      } catch (const std::exception& /*e*/) {
+      } catch (const std::exception&) {
         context.setErrors(rows, std::current_exception());
       }
     } else {


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: dmm-fb

Differential Revision: D58830787
