### PR TITLE
Add IO throttler support

### DIFF
--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -487,5 +487,20 @@ void registerVeloxMetrics() {
   // percentiles.
   DEFINE_HISTOGRAM_METRIC(
       kMetricExchangeDataSize, 1L << 20, 0, 128L << 20, 50, 90, 99, 100);
+
+  /// ================== Storage Counters =================
+
+  // The time distribution of storage IO throttled duration in range of [0, 30s]
+  // with 30 buckets. It is configured to report the capacity at P50, P90, P99,
+  // and P100 percentiles.
+  DEFINE_HISTOGRAM_METRIC(
+      kMetricStorageThrottledDurationMs, 1'000, 0, 30'000, 50, 90, 99, 100);
+
+  // The number of times that storage IOs get throttled in a storage directory.
+  DEFINE_METRIC(kMetricStorageLocalThrottled, facebook::velox::StatType::COUNT);
+
+  // The number of times that storage IOs get throttled in a storage cluster.
+  DEFINE_METRIC(
+      kMetricStorageGlobalThrottled, facebook::velox::StatType::COUNT);
 }
 } // namespace facebook::velox

--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -304,4 +304,13 @@ constexpr folly::StringPiece kMetricExchangeDataBytes{
 
 constexpr folly::StringPiece kMetricExchangeDataSize{
     "velox.exchange_data_size"};
+
+constexpr folly::StringPiece kMetricStorageThrottledDurationMs{
+    "velox.storage_throttled_duration_ms"};
+
+constexpr folly::StringPiece kMetricStorageLocalThrottled{
+    "velox.storage_local_throttled_count"};
+
+constexpr folly::StringPiece kMetricStorageGlobalThrottled{
+    "velox.storage_global_throttled_count"};
 } // namespace facebook::velox

--- a/velox/common/caching/tests/CachedFactoryTest.cpp
+++ b/velox/common/caching/tests/CachedFactoryTest.cpp
@@ -371,6 +371,11 @@ TEST(CachedFactoryTest, retrievedCached) {
   std::vector<int> keys(10);
   for (int i = 0; i < 10; ++i) {
     keys[i] = i;
+    if (i % 2 == 0) {
+      ASSERT_EQ(*factory.get(keys[i]), i * 2) << i;
+    } else {
+      ASSERT_EQ(factory.get(keys[i]).get(), nullptr);
+    }
   }
   std::vector<std::pair<int, CachedPtr<int, int>>> cached;
   std::vector<int> missing;

--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -385,6 +385,28 @@ Cache
      - Sum
      - Total number of cache regions evicted.
 
+Storage
+-------
+
+.. list-table::
+   :widths: 40 10 50
+   :header-rows: 1
+
+   * - Metric Name
+     - Type
+     - Description
+   * - storage_throttled_duration_ms
+     - Histogram
+     - The time distribution of storage IO throttled duration in range of [0, 30s]
+       with 30 buckets. It is configured to report the capacity at P50, P90, P99,
+       and P100 percentiles.
+   * - storage_local_throttled_count
+     - Count
+     - The number of times that storage IOs get throttled in a storage directory.
+   * - storage_global_throttled_count
+     - Count
+     - The number of times that storage IOs get throttled in a storage cluster.
+
 Spilling
 --------
 

--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -57,6 +57,7 @@ add_library(
   SelectiveStructColumnReader.cpp
   SortingWriter.cpp
   SortingWriter.h
+  Throttler.cpp
   TypeUtils.cpp
   TypeWithId.cpp
   Writer.cpp

--- a/velox/dwio/common/Throttler.cpp
+++ b/velox/dwio/common/Throttler.cpp
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/Throttler.h"
+
+#include <boost/random/uniform_int_distribution.hpp>
+
+#include "velox/common/base/Counters.h"
+#include "velox/common/base/StatsReporter.h"
+#include "velox/common/base/SuccinctPrinter.h"
+
+namespace facebook::velox::dwio::common {
+namespace {
+// Builds key in local throttled cache to make it unique across storage
+// clusters.
+std::string localThrottleCacheKey(
+    const std::string& cluster,
+    const std::string& directory) {
+  return fmt::format("{}:{}", cluster, directory);
+}
+} // namespace
+
+Throttler::Config::Config(
+    bool _throttleEnabled,
+    uint64_t _minThrottleBackoffMs,
+    uint64_t _maxThrottleBackoffMs,
+    double _backoffScaleFactor,
+    uint32_t _minLocalThrottledSignals,
+    uint32_t _minGlobalThrottledSignals,
+    uint32_t _maxCacheEntries,
+    uint32_t _cacheTTLMs)
+    : throttleEnabled(_throttleEnabled),
+      minThrottleBackoffMs(_minThrottleBackoffMs),
+      maxThrottleBackoffMs(_maxThrottleBackoffMs),
+      backoffScaleFactor(_backoffScaleFactor),
+      minLocalThrottledSignals(_minLocalThrottledSignals),
+      minGlobalThrottledSignals(_minGlobalThrottledSignals),
+      maxCacheEntries(_maxCacheEntries),
+      cacheTTLMs(_cacheTTLMs) {}
+
+std::string Throttler::Config::toString() const {
+  return fmt::format(
+      "throttleEnabled:{} minThrottleBackoffMs:{} maxThrottleBackoffMs:{} backoffScaleFactor:{} minLocalThrottledSignals:{} minGlobalThrottledSignals:{} maxCacheEntries:{} cacheTTLMs:{}",
+      throttleEnabled,
+      succinctMillis(minThrottleBackoffMs),
+      succinctMillis(maxThrottleBackoffMs),
+      backoffScaleFactor,
+      minLocalThrottledSignals,
+      minGlobalThrottledSignals,
+      maxCacheEntries,
+      succinctMillis(cacheTTLMs));
+};
+
+std::string Throttler::signalTypeName(SignalType type) {
+  switch (type) {
+    case SignalType::kNone:
+      return "None";
+    case SignalType::kLocal:
+      return "Local";
+    case SignalType::kGlobal:
+      return "Global";
+    default:
+      return fmt::format("Unknown Signal Type: {}", static_cast<int>(type));
+  }
+}
+
+std::ostream& operator<<(std::ostream& os, Throttler::SignalType type) {
+  os << Throttler::signalTypeName(type);
+  return os;
+}
+
+void Throttler::init(const Config& config) {
+  std::unique_lock guard{instanceLock()};
+  auto& instance = instanceRef();
+  VELOX_CHECK_NULL(instance, "Throttler has already been set");
+  instance = std::unique_ptr<Throttler>(new Throttler(config));
+}
+
+Throttler* Throttler::instance() {
+  std::shared_lock guard{instanceLock()};
+  auto& instance = instanceRef();
+  if (instance == nullptr) {
+    return nullptr;
+  }
+  return instance.get();
+}
+
+Throttler::Throttler(const Config& config)
+    : throttleEnabled_(config.throttleEnabled),
+      minThrottleBackoffDurationMs_(config.minThrottleBackoffMs),
+      maxThrottleBackoffDurationMs_(config.maxThrottleBackoffMs),
+      backoffScaleFactor_(config.backoffScaleFactor),
+      minLocalThrottledSignalsToBackoff_(config.minLocalThrottledSignals),
+      minGlobalThrottledSignalsToBackoff_(config.minGlobalThrottledSignals),
+      localThrottleCache_(
+          !throttleEnabled_
+              ? nullptr
+              : new ThrottleSignalFactory{std::make_unique<SimpleLRUCache<std::string, ThrottleSignal>>(
+                     config.maxCacheEntries,
+                     config.cacheTTLMs),
+                 std::unique_ptr<ThrottleSignalGenerator>{
+                     new ThrottleSignalGenerator{}}}),
+      globalThrottleCache_(
+          !throttleEnabled_
+              ? nullptr
+              : new ThrottleSignalFactory{std::make_unique<SimpleLRUCache<std::string, ThrottleSignal>>(
+                                              config.maxCacheEntries,
+                                              config.cacheTTLMs),
+                                          std::unique_ptr<ThrottleSignalGenerator>{
+                                              new ThrottleSignalGenerator{}}}) {
+  LOG(INFO) << "IO throttler config: " << config.toString();
+}
+
+uint64_t Throttler::throttleBackoff(
+    SignalType type,
+    const std::string& cluster,
+    const std::string& directory) {
+  if (!throttleEnabled() || type == SignalType::kNone) {
+    return kNoBackOffMs_;
+  }
+
+  const uint64_t backOffDurationMs =
+      calculateBackoffDurationAndUpdateThrottleCache(type, cluster, directory);
+  if (backOffDurationMs == kNoBackOffMs_) {
+    return kNoBackOffMs_;
+  }
+
+  updateThrottleStats(type, backOffDurationMs);
+
+  std::this_thread::sleep_for(
+      std::chrono::milliseconds(backOffDurationMs)); // NOLINT
+  return backOffDurationMs;
+}
+
+void Throttler::updateThrottleStats(SignalType type, uint64_t backoffDelayMs) {
+  stats_.backOffDelay.increment(backoffDelayMs);
+  RECORD_HISTOGRAM_METRIC_VALUE(
+      kMetricStorageThrottledDurationMs, backoffDelayMs);
+  if (type == SignalType::kLocal) {
+    ++stats_.localThrottled;
+    RECORD_METRIC_VALUE(kMetricStorageLocalThrottled);
+  } else {
+    ++stats_.globalThrottled;
+    RECORD_METRIC_VALUE(kMetricStorageGlobalThrottled);
+  }
+}
+
+void Throttler::updateThrottleCacheLocked(
+    SignalType type,
+    const std::string& cluster,
+    const std::string& directory,
+    CachedThrottleSignalPtr& localSignal,
+    CachedThrottleSignalPtr& globalSignal) {
+  VELOX_CHECK(throttleEnabled());
+
+  if (type == SignalType::kLocal) {
+    if (localSignal.get() == nullptr) {
+      localThrottleCache_->generate(localThrottleCacheKey(cluster, directory));
+    } else {
+      ++localSignal->count;
+    }
+  } else {
+    if (globalSignal.get() == nullptr) {
+      globalThrottleCache_->generate(cluster);
+    } else {
+      ++globalSignal->count;
+    }
+  }
+}
+
+uint64_t Throttler::calculateBackoffDurationAndUpdateThrottleCache(
+    SignalType type,
+    const std::string& cluster,
+    const std::string& directoy) {
+  std::lock_guard<std::mutex> l(mu_);
+  // Gets maximum count of local and global throttle signals in Cache.
+  auto localThrottleCachePtr =
+      localThrottleCache_->get(localThrottleCacheKey(cluster, directoy));
+  int64_t localThrottleCount =
+      (localThrottleCachePtr.get() != nullptr ? localThrottleCachePtr->count
+                                              : 0) +
+      (type == SignalType::kLocal ? 1 : 0) - minLocalThrottledSignalsToBackoff_;
+  auto globalThrottleCachePtr = globalThrottleCache_->get(cluster);
+  const int64_t globalThrottleCount =
+      (globalThrottleCachePtr.get() != nullptr ? globalThrottleCachePtr->count
+                                               : 0) +
+      (type == SignalType::kGlobal ? 1 : 0) -
+      minGlobalThrottledSignalsToBackoff_;
+  // Update throttling signal cache.
+  updateThrottleCacheLocked(
+      type, cluster, directoy, localThrottleCachePtr, globalThrottleCachePtr);
+
+  const int64_t throttleAttempts =
+      std::max(localThrottleCount, globalThrottleCount);
+
+  // Calculates the delay with exponential backoff
+  if (throttleAttempts <= 0) {
+    return kNoBackOffMs_;
+  }
+
+  const uint64_t backoffDelayMs = std::round(
+      minThrottleBackoffDurationMs_ *
+      pow(backoffScaleFactor_, throttleAttempts - 1));
+
+  // Adds some casualness so requests can be waken up at different timestamp
+  return std::min(
+      backoffDelayMs +
+          boost::random::uniform_int_distribution<uint64_t>(
+              1, std::max<uint64_t>(1, (uint64_t)(backoffDelayMs * 0.1)))(rng_),
+      maxThrottleBackoffDurationMs_);
+}
+
+std::unique_ptr<Throttler::ThrottleSignal>
+Throttler::ThrottleSignalGenerator::operator()(
+    const std::string& /*unused*/,
+    const void* /*unused*/) {
+  return std::unique_ptr<ThrottleSignal>(new ThrottleSignal{1});
+}
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/Throttler.h
+++ b/velox/dwio/common/Throttler.h
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdint.h>
+#include <mutex>
+#include <random>
+
+#include "velox/common/caching/CachedFactory.h"
+#include "velox/common/caching/SimpleLRUCache.h"
+#include "velox/common/io/IoStatistics.h"
+
+#pragma once
+
+namespace facebook::velox::dwio::common {
+
+/// A throttler that can be used to backoff IO when the storage is overloaded.
+class Throttler {
+ public:
+  /// The configuration of the throttler.
+  struct Config {
+    /// If true, enables throttling of IO.
+    bool throttleEnabled;
+
+    /// The minimum backoff duration in milliseconds.
+    uint64_t minThrottleBackoffMs;
+
+    /// The maximum backoff duration in milliseconds.
+    uint64_t maxThrottleBackoffMs;
+
+    /// The backoff duration scale factor.
+    double backoffScaleFactor;
+
+    /// The minimum number of received local throttled signals before starting
+    /// backoff.
+    uint32_t minLocalThrottledSignals;
+
+    /// The minimum number of received global throttled signals before starting
+    /// backoff.
+    uint32_t minGlobalThrottledSignals;
+
+    /// The maximum number of entries in the throttled signal cache. There is
+    /// one cache for each throttle signal type. For local throttle signal
+    /// cache, each cache entry corresponds to a unqiue file direcotry in a
+    /// storage system. For global throttle signal cache, each entry corresponds
+    /// to a unique storage system.
+    uint32_t maxCacheEntries;
+
+    /// The TTL of the throttled signal cache entries in milliseconds. We only
+    /// track the recently throtted signals.
+    uint32_t cacheTTLMs;
+
+    static constexpr bool kThrottleEnabledDefault{true};
+    static constexpr uint64_t kMinThrottleBackoffMsDefault{200};
+    static constexpr uint64_t kMaxThrottleBackoffMsDefault{30'000};
+    static constexpr double kBackoffScaleFactorDefault{2.0};
+    static constexpr uint32_t kMinLocalThrottledSignalsDefault{1'000};
+    static constexpr uint32_t kMinGlobalThrottledSignalsDefault{100'000};
+    static constexpr uint32_t kMaxCacheEntriesDefault{10'000};
+    static constexpr uint32_t kCacheTTLMsDefault{3 * 60 * 1'000};
+
+    Config(
+        bool throttleEnabled = kThrottleEnabledDefault,
+        uint64_t minThrottleBackoffMs = kMinThrottleBackoffMsDefault,
+        uint64_t maxThrottleBackoffMs = kMaxThrottleBackoffMsDefault,
+        double backoffScaleFactor = kBackoffScaleFactorDefault,
+        uint32_t minLocalThrottledSignals = kMinLocalThrottledSignalsDefault,
+        uint32_t minGlobalThrottledSignals = kMinGlobalThrottledSignalsDefault,
+        uint32_t maxCacheEntries = kMaxCacheEntriesDefault,
+        uint32_t cacheTTLMs = kCacheTTLMsDefault);
+
+    std::string toString() const;
+  };
+
+  /// The throttler stats.
+  struct Stats {
+    std::atomic_uint64_t localThrottled{0};
+    std::atomic_uint64_t globalThrottled{0};
+    /// Counts the backoff delay in milliseconds.
+    io::IoCounter backOffDelay;
+  };
+
+  static void init(const Config& config);
+
+  static Throttler* instance();
+
+  /// The type of throttle signal type.
+  enum class SignalType {
+    /// No throttled signal.
+    kNone,
+    /// A file directory throttled signal.
+    kLocal,
+    /// A cluster-wise throttled signal.
+    kGlobal,
+  };
+  static std::string signalTypeName(SignalType type);
+
+  /// Invoked to backoff when received a throttled signal on a particular
+  /// storage location. 'type' specifies the throttled signal type received from
+  /// the storage system. 'cluster' specifies the storage system. A query system
+  /// might access data from different storage systems. 'directory' specifies
+  /// the file directory within the storage system. The function returns the
+  /// actual throttled duration in milliseconds. It returns zero if not
+  /// throttled.
+  uint64_t throttleBackoff(
+      SignalType type,
+      const std::string& cluster,
+      const std::string& directory);
+
+  const Stats& stats() const {
+    return stats_;
+  }
+
+  static void testingReset() {
+    instanceRef().reset();
+  }
+
+ private:
+  static folly::SharedMutex& instanceLock() {
+    static folly::SharedMutex mu;
+    return mu;
+  }
+
+  static std::unique_ptr<Throttler>& instanceRef() {
+    static std::unique_ptr<Throttler> instance;
+    return instance;
+  }
+
+  explicit Throttler(const Config& config);
+
+  bool throttleEnabled() const {
+    return throttleEnabled_;
+  }
+
+  // Calculates the delay in milliseconds with exponential backoff for a storage
+  // location, using the signal counters in cache and flags in config, and
+  // update the throttle signal caches.
+  uint64_t calculateBackoffDurationAndUpdateThrottleCache(
+      SignalType type,
+      const std::string& cluster,
+      const std::string& directory);
+
+  struct ThrottleSignal {
+    uint64_t count{0};
+
+    explicit ThrottleSignal(uint64_t _count) : count(_count) {}
+  };
+
+  // Creates ThrottleSignal via the Generator interface the CachedFactory
+  // requires.
+  class ThrottleSignalGenerator {
+   public:
+    ThrottleSignalGenerator() = default;
+
+    std::unique_ptr<ThrottleSignal> operator()(
+        const std::string& /*unused*/,
+        const void* /*unused*/);
+  };
+
+  using CachedThrottleSignalPtr = CachedPtr<std::string, ThrottleSignal>;
+
+  using ThrottleSignalFactory = facebook::velox::
+      CachedFactory<std::string, ThrottleSignal, ThrottleSignalGenerator>;
+
+  void updateThrottleCacheLocked(
+      SignalType type,
+      const std::string& cluster,
+      const std::string& directory,
+      CachedThrottleSignalPtr& localSignal,
+      CachedThrottleSignalPtr& globalSignal);
+
+  void updateThrottleStats(SignalType type, uint64_t backoffDelayMs);
+
+  static const uint64_t kNoBackOffMs_{0};
+
+  const bool throttleEnabled_;
+  const uint64_t minThrottleBackoffDurationMs_;
+  const uint64_t maxThrottleBackoffDurationMs_;
+  const double backoffScaleFactor_;
+  const uint32_t minLocalThrottledSignalsToBackoff_;
+  const uint32_t minGlobalThrottledSignalsToBackoff_;
+  const std::unique_ptr<ThrottleSignalFactory> localThrottleCache_;
+  const std::unique_ptr<ThrottleSignalFactory> globalThrottleCache_;
+
+  mutable std::mutex mu_;
+
+  std::mt19937 rng_;
+  Stats stats_;
+};
+
+std::ostream& operator<<(std::ostream& os, Throttler::SignalType type);
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(
   ReaderTest.cpp
   RetryTests.cpp
   TestBufferedInput.cpp
+  ThrottlerTest.cpp
   TypeTests.cpp
   UnitLoaderToolsTests.cpp
   WriterTest.cpp

--- a/velox/dwio/common/tests/ThrottlerTest.cpp
+++ b/velox/dwio/common/tests/ThrottlerTest.cpp
@@ -1,0 +1,558 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/Throttler.h"
+
+#include <gtest/gtest.h>
+
+#include "folly/Random.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+namespace facebook::velox::dwio::common {
+namespace {
+
+class ThrottlerTest : public testing::Test {
+ protected:
+  static Throttler::Config throttleConfig(uint32_t cacheTTLMs = 3'600 * 1'000) {
+    return Throttler::Config(true, 1, 4, 2.0, 10, 40, 4, cacheTTLMs);
+  }
+
+  void SetUp() override {
+    Throttler::testingReset();
+  }
+};
+
+TEST_F(ThrottlerTest, config) {
+  const auto config = throttleConfig();
+  ASSERT_EQ(
+      config.toString(),
+      "throttleEnabled:true minThrottleBackoffMs:1ms maxThrottleBackoffMs:4ms backoffScaleFactor:2 minLocalThrottledSignals:10 minGlobalThrottledSignals:40 maxCacheEntries:4 cacheTTLMs:1h 0m 0s");
+}
+
+TEST_F(ThrottlerTest, signalType) {
+  ASSERT_EQ(Throttler::signalTypeName(Throttler::SignalType::kLocal), "Local");
+  ASSERT_EQ(
+      Throttler::signalTypeName(Throttler::SignalType::kGlobal), "Global");
+  ASSERT_EQ(Throttler::signalTypeName(Throttler::SignalType::kNone), "None");
+  ASSERT_EQ(
+      Throttler::signalTypeName(static_cast<Throttler::SignalType>(100)),
+      "Unknown Signal Type: 100");
+}
+
+TEST_F(ThrottlerTest, init) {
+  ASSERT_EQ(Throttler::instance(), nullptr);
+  Throttler::init(throttleConfig());
+  auto* instance = Throttler::instance();
+  ASSERT_NE(instance, nullptr);
+  ASSERT_EQ(instance, Throttler::instance());
+  VELOX_ASSERT_THROW(
+      Throttler::init(throttleConfig()), "Throttler has already been set");
+  ASSERT_EQ(instance, Throttler::instance());
+}
+
+TEST_F(ThrottlerTest, throttleDisabled) {
+  Throttler::init(Throttler::Config(false));
+  const std::string cluster{"throttleDisabled"};
+  const std::string directory{"throttleDisabled"};
+  auto* instance = Throttler::instance();
+  for (int i = 1; i <= 100; ++i) {
+    ASSERT_EQ(
+        instance->throttleBackoff(
+            i % 2 ? Throttler::SignalType::kLocal
+                  : Throttler::SignalType::kGlobal,
+            cluster,
+            directory),
+        0);
+  }
+  const auto& stats = instance->stats();
+  ASSERT_EQ(stats.localThrottled, 0);
+  ASSERT_EQ(stats.globalThrottled, 0);
+  ASSERT_EQ(stats.backOffDelay.count(), 0);
+}
+
+TEST_F(ThrottlerTest, noThrottlerSignal) {
+  Throttler::init(Throttler::Config(true, 100, 200, 2.0, 10, 1'000));
+  const std::string cluster{"noThrottlerSignal"};
+  const std::string directory{"noThrottlerSignal"};
+  auto* instance = Throttler::instance();
+  for (int i = 1; i <= 100; ++i) {
+    ASSERT_EQ(
+        instance->throttleBackoff(
+            Throttler::SignalType::kNone, cluster, directory),
+        0);
+  }
+  const auto& stats = instance->stats();
+  ASSERT_EQ(stats.localThrottled, 0);
+  ASSERT_EQ(stats.globalThrottled, 0);
+  ASSERT_EQ(stats.backOffDelay.count(), 0);
+}
+
+TEST_F(ThrottlerTest, throttle) {
+  const uint64_t minThrottleBackoffMs = 1'000;
+  const uint64_t maxThrottleBackoffMs = 2'000;
+  for (const bool global : {true, false}) {
+    SCOPED_TRACE(fmt::format("global {}", global));
+
+    Throttler::testingReset();
+    Throttler::init(Throttler::Config(
+        true,
+        minThrottleBackoffMs,
+        maxThrottleBackoffMs,
+        2.0,
+        global ? 1'0000 : 2,
+        global ? 2 : 1'0000));
+    auto* instance = Throttler::instance();
+    const auto& stats = instance->stats();
+    ASSERT_EQ(stats.localThrottled, 0);
+    ASSERT_EQ(stats.globalThrottled, 0);
+    ASSERT_EQ(stats.backOffDelay.count(), 0);
+
+    const Throttler::SignalType type =
+        global ? Throttler::SignalType::kGlobal : Throttler::SignalType::kLocal;
+    const std::string cluster{"throttle"};
+    const std::string directory{"throttle"};
+    ASSERT_EQ(instance->throttleBackoff(type, cluster, directory), 0);
+    ASSERT_EQ(instance->throttleBackoff(type, cluster, directory), 0);
+
+    ASSERT_EQ(stats.localThrottled, 0);
+    ASSERT_EQ(stats.globalThrottled, 0);
+    ASSERT_EQ(stats.backOffDelay.count(), 0);
+
+    uint64_t measuredBackOffMs{0};
+    uint64_t firstBackoffMs{0};
+    {
+      MicrosecondTimer timer(&measuredBackOffMs);
+      firstBackoffMs = instance->throttleBackoff(type, cluster, directory);
+    }
+    ASSERT_LE(firstBackoffMs, maxThrottleBackoffMs);
+    ASSERT_GE(firstBackoffMs, minThrottleBackoffMs);
+    ASSERT_GE(measuredBackOffMs, firstBackoffMs);
+
+    ASSERT_EQ(stats.localThrottled, global ? 0 : 1);
+    ASSERT_EQ(stats.globalThrottled, global ? 1 : 0);
+    ASSERT_EQ(stats.backOffDelay.count(), 1);
+    ASSERT_EQ(stats.backOffDelay.sum(), firstBackoffMs);
+
+    measuredBackOffMs = 0;
+    uint64_t secondBackoffMs{0};
+    {
+      MicrosecondTimer timer(&measuredBackOffMs);
+      secondBackoffMs = instance->throttleBackoff(type, cluster, directory);
+    }
+    ASSERT_LE(secondBackoffMs, maxThrottleBackoffMs);
+    ASSERT_GE(secondBackoffMs, minThrottleBackoffMs);
+    ASSERT_GE(measuredBackOffMs, secondBackoffMs);
+    ASSERT_LT(firstBackoffMs, secondBackoffMs);
+
+    ASSERT_EQ(stats.localThrottled, global ? 0 : 2);
+    ASSERT_EQ(stats.globalThrottled, global ? 2 : 0);
+    ASSERT_EQ(stats.backOffDelay.count(), 2);
+    ASSERT_EQ(stats.backOffDelay.sum(), firstBackoffMs + secondBackoffMs);
+  }
+}
+
+TEST_F(ThrottlerTest, expire) {
+  const uint64_t minThrottleBackoffMs = 1'00;
+  const uint64_t maxThrottleBackoffMs = 2'00;
+  for (const bool global : {true, false}) {
+    SCOPED_TRACE(fmt::format("global {}", global));
+    Throttler::testingReset();
+    Throttler::init(Throttler::Config(
+        true,
+        minThrottleBackoffMs,
+        maxThrottleBackoffMs,
+        2.0,
+        global ? 1'0000 : 2,
+        global ? 2 : 1'0000,
+        1'000,
+        1'000));
+    auto* instance = Throttler::instance();
+    const auto& stats = instance->stats();
+    ASSERT_EQ(stats.localThrottled, 0);
+    ASSERT_EQ(stats.globalThrottled, 0);
+    ASSERT_EQ(stats.backOffDelay.count(), 0);
+
+    const Throttler::SignalType type =
+        global ? Throttler::SignalType::kGlobal : Throttler::SignalType::kLocal;
+    const std::string cluster{"expire"};
+    const std::string directory{"expire"};
+    ASSERT_EQ(instance->throttleBackoff(type, cluster, directory), 0);
+    ASSERT_EQ(instance->throttleBackoff(type, cluster, directory), 0);
+
+    ASSERT_EQ(stats.localThrottled, 0);
+    ASSERT_EQ(stats.globalThrottled, 0);
+    ASSERT_EQ(stats.backOffDelay.count(), 0);
+
+    std::this_thread::sleep_for(std::chrono::seconds(2)); // NOLINT
+
+    ASSERT_EQ(instance->throttleBackoff(type, cluster, directory), 0);
+    ASSERT_EQ(instance->throttleBackoff(type, cluster, directory), 0);
+
+    ASSERT_EQ(stats.localThrottled, 0);
+    ASSERT_EQ(stats.globalThrottled, 0);
+    ASSERT_EQ(stats.backOffDelay.count(), 0);
+  }
+}
+
+TEST_F(ThrottlerTest, differentLocals) {
+  const uint64_t minThrottleBackoffMs = 1'000;
+  const uint64_t maxThrottleBackoffMs = 2'000;
+  Throttler::init(Throttler::Config(
+      true, minThrottleBackoffMs, maxThrottleBackoffMs, 2.0, 2, 1'0000));
+  auto* instance = Throttler::instance();
+  const auto& stats = instance->stats();
+  ASSERT_EQ(stats.localThrottled, 0);
+  ASSERT_EQ(stats.globalThrottled, 0);
+  ASSERT_EQ(stats.backOffDelay.count(), 0);
+
+  const std::string cluster1{"differentLocals1"};
+  const std::string directory1{"differentLocals1"};
+  ASSERT_EQ(
+      instance->throttleBackoff(
+          Throttler::SignalType::kLocal, cluster1, directory1),
+      0);
+  ASSERT_EQ(
+      instance->throttleBackoff(
+          Throttler::SignalType::kLocal, cluster1, directory1),
+      0);
+
+  ASSERT_EQ(stats.localThrottled, 0);
+  ASSERT_EQ(stats.globalThrottled, 0);
+  ASSERT_EQ(stats.backOffDelay.count(), 0);
+
+  const std::string directory2{"differentLocals2"};
+  ASSERT_EQ(
+      instance->throttleBackoff(
+          Throttler::SignalType::kLocal, cluster1, directory2),
+      0);
+  ASSERT_EQ(
+      instance->throttleBackoff(
+          Throttler::SignalType::kLocal, cluster1, directory2),
+      0);
+
+  ASSERT_EQ(stats.localThrottled, 0);
+  ASSERT_EQ(stats.globalThrottled, 0);
+  ASSERT_EQ(stats.backOffDelay.count(), 0);
+
+  const auto path1firstBackoffMs = instance->throttleBackoff(
+      Throttler::SignalType::kLocal, cluster1, directory1);
+  ASSERT_GT(path1firstBackoffMs, 0);
+  ASSERT_LT(path1firstBackoffMs, maxThrottleBackoffMs);
+
+  ASSERT_EQ(stats.localThrottled, 1);
+  ASSERT_EQ(stats.globalThrottled, 0);
+  ASSERT_EQ(stats.backOffDelay.count(), 1);
+  ASSERT_EQ(stats.backOffDelay.sum(), path1firstBackoffMs);
+
+  const auto path2firstBackoffMs = instance->throttleBackoff(
+      Throttler::SignalType::kLocal, cluster1, directory2);
+  ASSERT_GT(path2firstBackoffMs, 0);
+  ASSERT_LT(path2firstBackoffMs, maxThrottleBackoffMs);
+
+  ASSERT_EQ(stats.localThrottled, 2);
+  ASSERT_EQ(stats.globalThrottled, 0);
+  ASSERT_EQ(stats.backOffDelay.count(), 2);
+  ASSERT_EQ(
+      stats.backOffDelay.sum(), path1firstBackoffMs + path2firstBackoffMs);
+
+  const auto path1SecondBackoffMs = instance->throttleBackoff(
+      Throttler::SignalType::kLocal, cluster1, directory1);
+  ASSERT_EQ(path1SecondBackoffMs, maxThrottleBackoffMs);
+
+  ASSERT_EQ(stats.localThrottled, 3);
+  ASSERT_EQ(stats.globalThrottled, 0);
+  ASSERT_EQ(stats.backOffDelay.count(), 3);
+  ASSERT_EQ(
+      stats.backOffDelay.sum(),
+      path1firstBackoffMs + path2firstBackoffMs + path1SecondBackoffMs);
+
+  const auto path2SecondBackoffMs = instance->throttleBackoff(
+      Throttler::SignalType::kLocal, cluster1, directory2);
+  ASSERT_EQ(path2SecondBackoffMs, maxThrottleBackoffMs);
+
+  ASSERT_EQ(stats.localThrottled, 4);
+  ASSERT_EQ(stats.globalThrottled, 0);
+  ASSERT_EQ(stats.backOffDelay.count(), 4);
+  ASSERT_EQ(
+      stats.backOffDelay.sum(),
+      path1firstBackoffMs + path2firstBackoffMs + path1SecondBackoffMs +
+          path2SecondBackoffMs);
+}
+
+TEST_F(ThrottlerTest, differentGlobals) {
+  const uint64_t minThrottleBackoffMs = 1'000;
+  const uint64_t maxThrottleBackoffMs = 2'000;
+  Throttler::init(Throttler::Config(
+      true, minThrottleBackoffMs, maxThrottleBackoffMs, 2.0, 1'0000, 2));
+  auto* instance = Throttler::instance();
+  const auto& stats = instance->stats();
+  ASSERT_EQ(stats.localThrottled, 0);
+  ASSERT_EQ(stats.globalThrottled, 0);
+  ASSERT_EQ(stats.backOffDelay.count(), 0);
+
+  const std::string cluster1{"differentGlobals1"};
+  const std::string directory1{"differentGlobals1"};
+  ASSERT_EQ(
+      instance->throttleBackoff(
+          Throttler::SignalType::kGlobal, cluster1, directory1),
+      0);
+  ASSERT_EQ(
+      instance->throttleBackoff(
+          Throttler::SignalType::kGlobal, cluster1, directory1),
+      0);
+
+  ASSERT_EQ(stats.localThrottled, 0);
+  ASSERT_EQ(stats.globalThrottled, 0);
+  ASSERT_EQ(stats.backOffDelay.count(), 0);
+
+  const std::string cluster2{"differentGlobals2"};
+  const std::string directory2{"differentGlobals1"};
+  ASSERT_EQ(
+      instance->throttleBackoff(
+          Throttler::SignalType::kGlobal, cluster2, directory2),
+      0);
+  ASSERT_EQ(
+      instance->throttleBackoff(
+          Throttler::SignalType::kGlobal, cluster2, directory2),
+      0);
+
+  ASSERT_EQ(stats.localThrottled, 0);
+  ASSERT_EQ(stats.globalThrottled, 0);
+  ASSERT_EQ(stats.backOffDelay.count(), 0);
+
+  const auto path1firstBackoffMs = instance->throttleBackoff(
+      Throttler::SignalType::kGlobal, cluster1, directory1);
+  ASSERT_GT(path1firstBackoffMs, 0);
+  ASSERT_LT(path1firstBackoffMs, maxThrottleBackoffMs);
+
+  ASSERT_EQ(stats.localThrottled, 0);
+  ASSERT_EQ(stats.globalThrottled, 1);
+  ASSERT_EQ(stats.backOffDelay.count(), 1);
+  ASSERT_EQ(stats.backOffDelay.sum(), path1firstBackoffMs);
+
+  const auto path2firstBackoffMs = instance->throttleBackoff(
+      Throttler::SignalType::kGlobal, cluster2, directory2);
+  ASSERT_GT(path2firstBackoffMs, 0);
+  ASSERT_LT(path2firstBackoffMs, maxThrottleBackoffMs);
+
+  ASSERT_EQ(stats.localThrottled, 0);
+  ASSERT_EQ(stats.globalThrottled, 2);
+  ASSERT_EQ(stats.backOffDelay.count(), 2);
+  ASSERT_EQ(
+      stats.backOffDelay.sum(), path1firstBackoffMs + path2firstBackoffMs);
+
+  const auto path1SecondBackoffMs = instance->throttleBackoff(
+      Throttler::SignalType::kGlobal, cluster1, directory1);
+  ASSERT_EQ(path1SecondBackoffMs, maxThrottleBackoffMs);
+
+  ASSERT_EQ(stats.localThrottled, 0);
+  ASSERT_EQ(stats.globalThrottled, 3);
+  ASSERT_EQ(stats.backOffDelay.count(), 3);
+  ASSERT_EQ(
+      stats.backOffDelay.sum(),
+      path1firstBackoffMs + path2firstBackoffMs + path1SecondBackoffMs);
+
+  const auto path2SecondBackoffMs = instance->throttleBackoff(
+      Throttler::SignalType::kGlobal, cluster2, directory2);
+  ASSERT_EQ(path2SecondBackoffMs, maxThrottleBackoffMs);
+
+  ASSERT_EQ(stats.localThrottled, 0);
+  ASSERT_EQ(stats.globalThrottled, 4);
+  ASSERT_EQ(stats.backOffDelay.count(), 4);
+  ASSERT_EQ(
+      stats.backOffDelay.sum(),
+      path1firstBackoffMs + path2firstBackoffMs + path1SecondBackoffMs +
+          path2SecondBackoffMs);
+}
+
+TEST_F(ThrottlerTest, maxOfGlobalAndLocal) {
+  const uint64_t minThrottleBackoffMs = 1'000;
+  const uint64_t maxThrottleBackoffMs = 2'000;
+  for (const bool localFirst : {false, true}) {
+    SCOPED_TRACE(fmt::format("localFirst: {}", localFirst));
+    Throttler::testingReset();
+    Throttler::init(Throttler::Config(
+        true, minThrottleBackoffMs, maxThrottleBackoffMs, 2.0, 2, 2));
+    auto* instance = Throttler::instance();
+    const auto& stats = instance->stats();
+    ASSERT_EQ(stats.localThrottled, 0);
+    ASSERT_EQ(stats.globalThrottled, 0);
+    ASSERT_EQ(stats.backOffDelay.count(), 0);
+
+    const std::string cluster1{"maxOfGlobalAndLocal1"};
+    const std::string directory1{"maxOfGlobalAndLocal1"};
+    ASSERT_EQ(
+        instance->throttleBackoff(
+            localFirst ? Throttler::SignalType::kLocal
+                       : Throttler::SignalType::kGlobal,
+            cluster1,
+            directory1),
+        0);
+    ASSERT_EQ(
+        instance->throttleBackoff(
+            localFirst ? Throttler::SignalType::kLocal
+                       : Throttler::SignalType::kGlobal,
+            cluster1,
+            directory1),
+        0);
+
+    ASSERT_EQ(stats.localThrottled, 0);
+    ASSERT_EQ(stats.globalThrottled, 0);
+    ASSERT_EQ(stats.backOffDelay.count(), 0);
+
+    auto backoffMs = instance->throttleBackoff(
+        localFirst ? Throttler::SignalType::kLocal
+                   : Throttler::SignalType::kGlobal,
+        cluster1,
+        directory1);
+    ASSERT_GT(backoffMs, 0);
+    ASSERT_LT(backoffMs, maxThrottleBackoffMs);
+
+    backoffMs = instance->throttleBackoff(
+        localFirst ? Throttler::SignalType::kGlobal
+                   : Throttler::SignalType::kLocal,
+        cluster1,
+        directory1);
+    ASSERT_GT(backoffMs, 0);
+    ASSERT_LT(backoffMs, maxThrottleBackoffMs);
+
+    backoffMs = instance->throttleBackoff(
+        localFirst ? Throttler::SignalType::kGlobal
+                   : Throttler::SignalType::kLocal,
+        cluster1,
+        directory1);
+    ASSERT_GT(backoffMs, 0);
+    ASSERT_LT(backoffMs, maxThrottleBackoffMs);
+
+    backoffMs = instance->throttleBackoff(
+        localFirst ? Throttler::SignalType::kLocal
+                   : Throttler::SignalType::kGlobal,
+        cluster1,
+        directory1);
+    ASSERT_EQ(backoffMs, maxThrottleBackoffMs);
+
+    const std::string cluster2{"maxOfGlobalAndLocal2"};
+    const std::string directory2{"maxOfGlobalAndLocal1"};
+    ASSERT_EQ(
+        instance->throttleBackoff(
+            localFirst ? Throttler::SignalType::kGlobal
+                       : Throttler::SignalType::kLocal,
+            cluster2,
+            directory2),
+        0);
+    ASSERT_EQ(
+        instance->throttleBackoff(
+            localFirst ? Throttler::SignalType::kGlobal
+                       : Throttler::SignalType::kLocal,
+            cluster2,
+            directory2),
+        0);
+
+    backoffMs = instance->throttleBackoff(
+        localFirst ? Throttler::SignalType::kGlobal
+                   : Throttler::SignalType::kLocal,
+        cluster2,
+        directory2);
+    ASSERT_GT(backoffMs, 0);
+    ASSERT_LT(backoffMs, maxThrottleBackoffMs);
+
+    const std::string directory3{"maxOfGlobalAndLocal3"};
+    backoffMs = instance->throttleBackoff(
+        Throttler::SignalType::kGlobal, cluster1, directory3);
+    if (localFirst) {
+      ASSERT_GT(backoffMs, 0);
+      ASSERT_LT(backoffMs, maxThrottleBackoffMs);
+    } else {
+      ASSERT_EQ(backoffMs, maxThrottleBackoffMs);
+    }
+
+    if (localFirst) {
+      ASSERT_EQ(stats.localThrottled, 2);
+      ASSERT_EQ(stats.globalThrottled, 4);
+    } else {
+      ASSERT_EQ(stats.localThrottled, 3);
+      ASSERT_EQ(stats.globalThrottled, 3);
+    }
+    ASSERT_EQ(stats.backOffDelay.count(), 6);
+  }
+}
+
+TEST_F(ThrottlerTest, fuzz) {
+  const uint64_t minThrottleBackoffMs = 1;
+  const uint64_t maxThrottleBackoffMs = 8;
+  const double backoffScaleFactor = 2.0;
+  const uint32_t minLocalThrottledSignals = 10;
+  const uint32_t minGlobalThrottledSignals = 20;
+  const uint32_t maxCacheEntries = 64;
+  const uint32_t cacheTTLMs = 10;
+  Throttler::testingReset();
+  Throttler::init(Throttler::Config(
+      true,
+      minThrottleBackoffMs,
+      maxThrottleBackoffMs,
+      backoffScaleFactor,
+      minLocalThrottledSignals,
+      minGlobalThrottledSignals,
+      maxCacheEntries,
+      cacheTTLMs));
+  auto* instance = Throttler::instance();
+
+  const auto seed = getCurrentTimeMs();
+  LOG(INFO) << "Random seed: " << getCurrentTimeMs();
+
+  const int numDirectories = 4096;
+  std::vector<std::string> directories;
+  directories.reserve(numDirectories);
+  for (int i = 0; i < numDirectories; ++i) {
+    directories.emplace_back(fmt::format("fuzz-{}", i));
+  }
+  const int numClusters = 128;
+  std::vector<std::string> clusters;
+  clusters.reserve(numClusters);
+  for (int i = 0; i < numClusters; ++i) {
+    clusters.emplace_back(fmt::format("fuzz-{}", i));
+  }
+
+  std::atomic_bool stopped{false};
+
+  const int numThreads = 64;
+  std::vector<std::thread> threads;
+  threads.reserve(numThreads);
+  for (int i = 0; i < numThreads; ++i) {
+    threads.emplace_back([&]() {
+      folly::Random::DefaultGenerator rng(seed);
+      while (!stopped) {
+        const Throttler::SignalType type = folly::Random::oneIn(3)
+            ? Throttler::SignalType::kGlobal
+            : Throttler::SignalType::kLocal;
+        const int directoryIndex = folly::Random::rand32(rng) % numDirectories;
+        const int clusterIndex = directoryIndex % numClusters;
+        instance->throttleBackoff(
+            type, clusters[clusterIndex], directories[directoryIndex]);
+      }
+    });
+  }
+
+  // Test for 5 seconds.
+  std::this_thread::sleep_for(std::chrono::seconds(5)); // NOLINT
+  stopped = true;
+  for (auto& thread : threads) {
+    thread.join();
+  }
+}
+
+} // namespace
+} // namespace facebook::velox::dwio::common


### PR DESCRIPTION
This PR adds IO throttler support which can back off based on the storage throttling signal with a given file
path. Currently we support two kinds of throttling signals: one is local which only apply to a particular file folder
or directory, and the other is a storage cluster. Correspondingly, we expect two other inputs one is the file folder
path and the other is the cluster name which are actual storage system specific. Note here we assume that
a query system might access data from different storage systems and the cluster is the storage system abstraction.
The IO throttler takes a set of config parameters to control the actual backoff algorithms. Uses a cache to track
the recent storage throttling signals. We integrate this with Meta internal storage system to slow down the
IO when storage system is overloaded. Next we will add to support operation based throttling to prevent
server OOM from the non-velox memory usage by storage system.