### PR TITLE
Add Arm64 CPU detect and adjust the appropriate compiling flag

### DIFF
--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -116,7 +116,32 @@ function get_cxx_flags {
     ;;
 
     "aarch64")
-      echo -n "-mcpu=neoverse-n1 -std=c++17"
+      # Read Arm MIDR_EL1 register to detect Arm cpu.
+      # https://developer.arm.com/documentation/100616/0301/register-descriptions/aarch64-system-registers/midr-el1--main-id-register--el1
+      ARM_CPU_FILE="/sys/devices/system/cpu/cpu0/regs/identification/midr_el1"
+
+      # https://gitlab.arm.com/telemetry-solution/telemetry-solution/-/blob/main/data/pmu/cpu/neoverse/neoverse-n1.json#L13
+      # N1:0xd0c; N2:0xd49; V1:0xd40;
+      Neoverse_N1="0xd0c"
+      Neoverse_N2="0xd49"
+      Neoverse_V1="0xd40"
+      hex_mask="0xfff0"
+      if [ -f "$ARM_CPU_FILE" ]; then
+        hex_ARM_CPU_DETECT=`cat $ARM_CPU_FILE`
+        ARM_CPU_PRODUCT=$(python -c "print(hex((int('$hex_ARM_CPU_DETECT', 16) & int('$hex_mask', 16)) >> 4))")
+
+        if [ "$ARM_CPU_PRODUCT" = "$Neoverse_N1" ]; then
+          echo -n "-mcpu=neoverse-n1 -std=c++17 $ADDITIONAL_FLAGS"
+        elif [ "$ARM_CPU_PRODUCT" = "$Neoverse_N2" ]; then
+          echo -n "-mcpu=neoverse-n2 -std=c++17 $ADDITIONAL_FLAGS"
+        elif [ "$ARM_CPU_PRODUCT" = "$Neoverse_V1" ]; then
+          echo -n "-mcpu=neoverse-v1 -std=c++17 $ADDITIONAL_FLAGS"
+        else
+          echo -n "-march=armv8-a+crc+crypto -std=c++17 $ADDITIONAL_FLAGS"
+        fi
+      else
+        echo -n "-std=c++17 $ADDITIONAL_FLAGS"
+      fi
     ;;
   *)
     echo -n "Architecture not supported!"

--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -121,14 +121,13 @@ function get_cxx_flags {
       ARM_CPU_FILE="/sys/devices/system/cpu/cpu0/regs/identification/midr_el1"
 
       # https://gitlab.arm.com/telemetry-solution/telemetry-solution/-/blob/main/data/pmu/cpu/neoverse/neoverse-n1.json#L13
-      # N1:0xd0c; N2:0xd49; V1:0xd40;
-      Neoverse_N1="0xd0c"
-      Neoverse_N2="0xd49"
-      Neoverse_V1="0xd40"
-      hex_mask="0xfff0"
+      # N1:d0c; N2:d49; V1:d40;
+      Neoverse_N1="d0c"
+      Neoverse_N2="d49"
+      Neoverse_V1="d40"
       if [ -f "$ARM_CPU_FILE" ]; then
         hex_ARM_CPU_DETECT=`cat $ARM_CPU_FILE`
-        ARM_CPU_PRODUCT=$(python -c "print(hex((int('$hex_ARM_CPU_DETECT', 16) & int('$hex_mask', 16)) >> 4))")
+        ARM_CPU_PRODUCT=${hex_ARM_CPU_DETECT: -4:3}
 
         if [ "$ARM_CPU_PRODUCT" = "$Neoverse_N1" ]; then
           echo -n "-mcpu=neoverse-n1 -std=c++17 $ADDITIONAL_FLAGS"

--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -127,19 +127,20 @@ function get_cxx_flags {
       Neoverse_V1="d40"
       if [ -f "$ARM_CPU_FILE" ]; then
         hex_ARM_CPU_DETECT=`cat $ARM_CPU_FILE`
+        # PartNum, [15:4]: The primary part number such as Neoverse N1/N2 core.
         ARM_CPU_PRODUCT=${hex_ARM_CPU_DETECT: -4:3}
 
         if [ "$ARM_CPU_PRODUCT" = "$Neoverse_N1" ]; then
-          echo -n "-mcpu=neoverse-n1 -std=c++17 $ADDITIONAL_FLAGS"
+          echo -n "-mcpu=neoverse-n1 -std=c++17"
         elif [ "$ARM_CPU_PRODUCT" = "$Neoverse_N2" ]; then
-          echo -n "-mcpu=neoverse-n2 -std=c++17 $ADDITIONAL_FLAGS"
+          echo -n "-mcpu=neoverse-n2 -std=c++17"
         elif [ "$ARM_CPU_PRODUCT" = "$Neoverse_V1" ]; then
-          echo -n "-mcpu=neoverse-v1 -std=c++17 $ADDITIONAL_FLAGS"
+          echo -n "-mcpu=neoverse-v1 -std=c++17"
         else
-          echo -n "-march=armv8-a+crc+crypto -std=c++17 $ADDITIONAL_FLAGS"
+          echo -n "-march=armv8-a+crc+crypto -std=c++17"
         fi
       else
-        echo -n "-std=c++17 $ADDITIONAL_FLAGS"
+        echo -n "-std=c++17"
       fi
     ;;
   *)


### PR DESCRIPTION
1. Added Add Arm64 CPU detect (Neoverse N1/N2/V1) and adjusted the appropriate compiling flag.

2. Fixed Illegal `instruction (core dumped)` In the earlier Arm platform:
```
#0  0x0000aaaac0d97254 in boost::detail::atomic_count::operator++ (this=0xaaaac6ad4630)
    at /usr/include/boost/smart_ptr/detail/atomic_count_gcc_atomic.hpp:38
38          return __atomic_add_fetch( &value_, +1, __ATOMIC_ACQ_REL );
(gdb) bt
#0  0x0000aaaac0d97254 in boost::detail::atomic_count::operator++ (this=0xaaaac6ad4630)
    at /usr/include/boost/smart_ptr/detail/atomic_count_gcc_atomic.hpp:38
...

```
```
atomic_add_fetch ->
ldaddal w1, w2, [x0]

```
N1/N2/v1  includes the Large System Extension (`LSE`) instruction:`ldaddal`. If we build velox on the platform which does not inlcude LSE extension. The Illegal instruction occurred in code generating in `fbthrift building`.

So we should add Arm64 CPU detect here.

3. I confirmed that velox could be successfully built on `Arm Neoverse N1/N2` and other Arm CPU platforms with this PR.



