### PR TITLE
feat: Increase peer rows in partitions generated by window fuzzer

### DIFF
--- a/velox/exec/fuzzer/AggregationFuzzer.cpp
+++ b/velox/exec/fuzzer/AggregationFuzzer.cpp
@@ -385,7 +385,7 @@ void AggregationFuzzer::go() {
         auto partitionKeys = generateKeys("p", argNames, argTypes);
         auto sortingKeys = generateSortingKeys("s", argNames, argTypes);
         auto input = generateInputDataWithRowNumber(
-            argNames, argTypes, partitionKeys, {}, signature);
+            argNames, argTypes, partitionKeys, {}, sortingKeys, signature);
 
         logVectors(input);
 

--- a/velox/exec/fuzzer/AggregationFuzzerBase.h
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.h
@@ -209,6 +209,7 @@ class AggregationFuzzerBase {
       std::vector<TypePtr> types,
       const std::vector<std::string>& partitionKeys,
       const std::vector<std::string>& windowFrameBounds,
+      const std::vector<std::string>& sortingKeys,
       const CallableSignature& signature);
 
   velox::fuzzer::ResultOrError execute(

--- a/velox/exec/fuzzer/WindowFuzzer.cpp
+++ b/velox/exec/fuzzer/WindowFuzzer.cpp
@@ -491,8 +491,17 @@ void WindowFuzzer::go() {
           generateSortingKeysAndOrders("s", argNames, argTypes, false, numKeys);
     }
 
+    std::vector<std::string> sortingKeys;
+    for (const auto& sortingKeyAndOrder : sortingKeysAndOrders) {
+      sortingKeys.push_back(sortingKeyAndOrder.key_);
+    }
     auto input = generateInputDataWithRowNumber(
-        argNames, argTypes, partitionKeys, kBoundColumns, signature);
+        argNames,
+        argTypes,
+        partitionKeys,
+        kBoundColumns,
+        sortingKeys,
+        signature);
     // Offset column names used for k-RANGE frame bounds have fixed names: off0
     // and off1, representing the precomputed offset columns used as frame start
     // and frame end bound respectively.


### PR DESCRIPTION
Peer rows are important for functions like rank, dense_rank etc where peers have the same result value. This new data generation constructs input data sets that has multiple peer rows in each partition.