### PR TITLE
Add support for Protobuf v22+

### DIFF
--- a/CMake/resolve_dependency_modules/google_cloud_cpp_storage.cmake
+++ b/CMake/resolve_dependency_modules/google_cloud_cpp_storage.cmake
@@ -13,11 +13,8 @@
 # limitations under the License.
 include_guard(GLOBAL)
 
-set_source(absl)
-resolve_dependency(absl 20240116 EXACT)
-
 set_source(gRPC)
-resolve_dependency(gRPC 1.48.1 EXACT)
+resolve_dependency(gRPC CONFIG 1.48.1 REQUIRED)
 
 set(VELOX_GOOGLE_CLOUD_CPP_BUILD_VERSION 2.22.0)
 set(VELOX_GOOGLE_CLOUD_CPP_BUILD_SHA256_CHECKSUM

--- a/CMake/resolve_dependency_modules/grpc.cmake
+++ b/CMake/resolve_dependency_modules/grpc.cmake
@@ -13,6 +13,9 @@
 # limitations under the License.
 include_guard(GLOBAL)
 
+set_source(absl)
+resolve_dependency(absl CONFIG REQUIRED)
+
 set(VELOX_GRPC_BUILD_VERSION 1.48.1)
 set(VELOX_GRPC_BUILD_SHA256_CHECKSUM
     320366665d19027cda87b2368c03939006a37e0388bfd1091c8d2a96fbc93bd8)

--- a/CMake/resolve_dependency_modules/protobuf.cmake
+++ b/CMake/resolve_dependency_modules/protobuf.cmake
@@ -16,12 +16,20 @@ include_guard(GLOBAL)
 set(VELOX_PROTOBUF_BUILD_VERSION 21.8)
 set(VELOX_PROTOBUF_BUILD_SHA256_CHECKSUM
     83ad4faf95ff9cbece7cb9c56eb3ca9e42c3497b77001840ab616982c6269fb6)
-string(
-  CONCAT
-    VELOX_PROTOBUF_SOURCE_URL
-    "https://github.com/protocolbuffers/protobuf/releases/download/"
-    "v${VELOX_PROTOBUF_BUILD_VERSION}/protobuf-all-${VELOX_PROTOBUF_BUILD_VERSION}.tar.gz"
-)
+if(${VELOX_PROTOBUF_BUILD_VERSION} LESS 22.0)
+  string(
+    CONCAT
+      VELOX_PROTOBUF_SOURCE_URL
+      "https://github.com/protocolbuffers/protobuf/releases/download/"
+      "v${VELOX_PROTOBUF_BUILD_VERSION}/protobuf-all-${VELOX_PROTOBUF_BUILD_VERSION}.tar.gz"
+  )
+else()
+  set_source(absl)
+  resolve_dependency(absl CONFIG REQUIRED)
+  string(CONCAT VELOX_PROTOBUF_SOURCE_URL
+                "https://github.com/protocolbuffers/protobuf/archive/"
+                "v${VELOX_PROTOBUF_BUILD_VERSION}.tar.gz")
+endif()
 
 resolve_dependency_url(PROTOBUF)
 
@@ -34,6 +42,8 @@ FetchContent_Declare(
   OVERRIDE_FIND_PACKAGE EXCLUDE_FROM_ALL SYSTEM)
 
 set(protobuf_BUILD_TESTS OFF)
+set(protobuf_ABSL_PROVIDER
+    "package"
+    CACHE STRING "Provider of absl library")
 FetchContent_MakeAvailable(protobuf)
 set(Protobuf_INCLUDE_DIRS ${protobuf_SOURCE_DIR}/src)
-set(Protobuf_PROTOC_EXECUTABLE "${protobuf_BINARY_DIR}/protoc")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,7 +442,7 @@ if(${VELOX_BUILD_MINIMAL_WITH_DWIO}
 
   # Locate or build protobuf.
   set_source(Protobuf)
-  resolve_dependency(Protobuf 3.21.7...<4)
+  resolve_dependency(Protobuf CONFIG 3.21.7 REQUIRED)
   include_directories(${Protobuf_INCLUDE_DIRS})
 endif()
 
@@ -470,7 +470,7 @@ endif()
 
 if(VELOX_ENABLE_GCS)
   set_source(google_cloud_cpp_storage)
-  resolve_dependency(google_cloud_cpp_storage 2.22.0 EXACT)
+  resolve_dependency(google_cloud_cpp_storage CONFIG 2.22.0 REQUIRED)
   add_definitions(-DVELOX_ENABLE_GCS)
 endif()
 

--- a/scripts/setup-adapters.sh
+++ b/scripts/setup-adapters.sh
@@ -73,6 +73,12 @@ function install_gcs-sdk-cpp {
     -DABSL_PROPAGATE_CXX_STD=ON \
     -DABSL_ENABLE_INSTALL=ON
 
+  # protobuf
+  github_checkout protocolbuffers/protobuf v21.8 --depth 1
+  cmake_install \
+    -Dprotobuf_BUILD_TESTS=OFF \
+    -Dprotobuf_ABSL_PROVIDER=package
+
   # grpc
   github_checkout grpc/grpc v1.48.1 --depth 1
   cmake_install \

--- a/velox/dwio/dwrf/proto/CMakeLists.txt
+++ b/velox/dwio/dwrf/proto/CMakeLists.txt
@@ -30,12 +30,16 @@ endforeach()
 set(PROTO_OUTPUT_FILES ${PROTO_HDRS} ${PROTO_SRCS})
 set_source_files_properties(${PROTO_OUTPUT_FILES} PROPERTIES GENERATED TRUE)
 
+# Ensure that the option --proto_path is not given an empty argument
+foreach(PROTO_PATH ${CMAKE_SOURCE_DIR} ${Protobuf_INCLUDE_DIRS})
+  list(APPEND PROTO_PATH_ARGS --proto_path=${PROTO_PATH})
+endforeach()
+
 add_custom_command(
   OUTPUT ${PROTO_OUTPUT_FILES}
-  COMMAND
-    ${Protobuf_PROTOC_EXECUTABLE} --proto_path ${CMAKE_SOURCE_DIR}/ --proto_path
-    ${Protobuf_INCLUDE_DIRS} --cpp_out ${CMAKE_BINARY_DIR} ${PROTO_FILES_FULL}
-  DEPENDS ${Protobuf_PROTOC_EXECUTABLE}
+  COMMAND protobuf::protoc ${PROTO_PATH_ARGS} --cpp_out ${CMAKE_BINARY_DIR}
+          ${PROTO_FILES_FULL}
+  DEPENDS protobuf::protoc
   COMMENT "Running PROTO compiler"
   VERBATIM)
 add_custom_target(dwio_proto ALL DEPENDS ${PROTO_OUTPUT_FILES})

--- a/velox/substrait/CMakeLists.txt
+++ b/velox/substrait/CMakeLists.txt
@@ -30,14 +30,17 @@ set_source_files_properties(${PROTO_OUTPUT_FILES} PROPERTIES GENERATED TRUE)
 
 get_filename_component(PROTO_DIR ${substrait_proto_directory}/, DIRECTORY)
 
+# Ensure that the option --proto_path is not given an empty argument
+foreach(PROTO_PATH ${PROJECT_SOURCE_DIR} ${Protobuf_INCLUDE_DIRS})
+  list(APPEND PROTO_PATH_ARGS --proto_path=${PROTO_PATH})
+endforeach()
+
 # Generate Substrait hearders
 add_custom_command(
   OUTPUT ${PROTO_OUTPUT_FILES}
-  COMMAND
-    ${Protobuf_PROTOC_EXECUTABLE} --proto_path ${PROJECT_SOURCE_DIR}/
-    --proto_path ${Protobuf_INCLUDE_DIRS} --cpp_out ${PROJECT_SOURCE_DIR}
-    ${PROTO_FILES}
-  DEPENDS ${PROTO_DIR} ${Protobuf_PROTOC_EXECUTABLE}
+  COMMAND protobuf::protoc ${PROTO_PATH_ARGS} --cpp_out ${PROJECT_SOURCE_DIR}
+          ${PROTO_FILES}
+  DEPENDS ${PROTO_DIR} protobuf::protoc
   COMMENT "Running PROTO compiler"
   VERBATIM)
 add_custom_target(substrait_proto ALL DEPENDS ${PROTO_OUTPUT_FILES})

--- a/velox/substrait/tests/JsonToProtoConverter.cpp
+++ b/velox/substrait/tests/JsonToProtoConverter.cpp
@@ -33,5 +33,5 @@ void JsonToProtoConverter::readFromFile(
   VELOX_CHECK(
       status.ok(),
       "Failed to parse Substrait JSON: {}",
-      status.message().ToString());
+      std::string_view(status.message().data(), status.message().size()));
 }


### PR DESCRIPTION
This change adds compatibility with newer versions of Protobuf.
The actual version of Protobuf is not being updated.
Protobuf v27.2 was used for testing.
Protobuf v21.8 is still supported.

Fixes #10133 