### PR TITLE
Add session property for sorted table write fuzzer

### DIFF
--- a/velox/exec/fuzzer/PrestoQueryRunner.h
+++ b/velox/exec/fuzzer/PrestoQueryRunner.h
@@ -73,6 +73,11 @@ class PrestoQueryRunner : public velox::exec::test::ReferenceQueryRunner {
   /// the query must already exist.
   std::vector<velox::RowVectorPtr> execute(const std::string& sql) override;
 
+  /// Executes Presto SQL query with extra presto session property.
+  std::vector<velox::RowVectorPtr> execute(
+      const std::string& sql,
+      const std::string& sessionProperty) override;
+
   bool supportsVeloxVectorResults() const override;
 
   std::vector<RowVectorPtr> executeVector(
@@ -117,7 +122,9 @@ class PrestoQueryRunner : public velox::exec::test::ReferenceQueryRunner {
   std::optional<std::string> toSql(
       const std::shared_ptr<const core::NestedLoopJoinNode>& joinNode);
 
-  std::string startQuery(const std::string& sql);
+  std::string startQuery(
+      const std::string& sql,
+      const std::string& sessionProperty = "");
 
   std::string fetchNext(const std::string& nextUri);
 

--- a/velox/exec/fuzzer/ReferenceQueryRunner.h
+++ b/velox/exec/fuzzer/ReferenceQueryRunner.h
@@ -72,6 +72,12 @@ class ReferenceQueryRunner {
   virtual std::vector<velox::RowVectorPtr> execute(const std::string& sql) {
     VELOX_UNSUPPORTED();
   }
+
+  virtual std::vector<velox::RowVectorPtr> execute(
+      const std::string& sql,
+      const std::string& sessionProperty) {
+    VELOX_UNSUPPORTED();
+  }
 };
 
 } // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/WriterFuzzer.cpp
+++ b/velox/exec/fuzzer/WriterFuzzer.cpp
@@ -513,8 +513,8 @@ void WriterFuzzer::verifyWriter(
           partitionKeys,
           sortBy);
 
-      const auto referenceResult =
-          referenceQueryRunner_->execute(singleSplitReferenceSql);
+      const auto referenceResult = referenceQueryRunner_->execute(
+          singleSplitReferenceSql, "task_concurrency=1");
       const auto& referenceData = referenceResult.at(0);
       for (int i = 1; i < referenceResult.size(); ++i) {
         referenceData->append(referenceResult.at(i).get());
@@ -738,7 +738,7 @@ std::string WriterFuzzer::partitionToSql(
     const TypePtr& type,
     std::string partitionValue) {
   if (type->isVarchar()) {
-    RE2::Replace(&partitionValue, "'", "''");
+    RE2::GlobalReplace(&partitionValue, "'", "''");
     return "'" + partitionValue + "'";
   }
   return partitionValue;


### PR DESCRIPTION
When reading back the data from each split of a sorted table from presto, 
set session property task.concurrency to 1 to force returning sorted result.