### PR TITLE
Improve the performance of hash Spark functions for scalar types through auto-vectorization

### DIFF
--- a/velox/functions/sparksql/benchmarks/HashBenchmark.cpp
+++ b/velox/functions/sparksql/benchmarks/HashBenchmark.cpp
@@ -32,6 +32,15 @@ int main(int argc, char** argv) {
   ExpressionBenchmarkBuilder benchmarkBuilder;
 
   std::vector<TypePtr> inputTypes = {
+      TINYINT(),
+      SMALLINT(),
+      BIGINT(),
+      REAL(),
+      DOUBLE(),
+      TIMESTAMP(),
+      VARCHAR(),
+      DECIMAL(18, 6),
+      DECIMAL(38, 6),
       ARRAY(MAP(INTEGER(), VARCHAR())),
       ROW({"f_map", "f_array"}, {MAP(INTEGER(), VARCHAR()), ARRAY(INTEGER())}),
   };
@@ -41,7 +50,7 @@ int main(int argc, char** argv) {
         .addBenchmarkSet(
             fmt::format("hash_{}", inputType->toString()),
             ROW({"c0"}, {inputType}))
-        .withFuzzerOptions({.vectorSize = 1000, .nullRatio = 0.1})
+        .withFuzzerOptions({.vectorSize = 1000, .nullRatio = 0})
         .addExpression("hash", "hash(c0)")
         .addExpression("xxhash64", "xxhash64(c0)")
         .withIterations(100);

--- a/velox/functions/sparksql/tests/HashTest.cpp
+++ b/velox/functions/sparksql/tests/HashTest.cpp
@@ -33,6 +33,31 @@ class HashTest : public SparkFunctionBaseTest {
   VectorPtr hash(VectorPtr vector) {
     return evaluate("hash(c0)", makeRowVector({vector}));
   }
+
+  template <typename T>
+  void runSIMDHashAndAssert(
+      const T value,
+      const int32_t expectedResult,
+      const int32_t size,
+      int unSelectedRows = 0) {
+    // Generate 'size' flat vector to test SIMD code path.
+    // We use same value in the vector to make comparing the results easier.
+    std::vector<T> inputData;
+    inputData.reserve(size);
+    std::vector<int32_t> resultData;
+    resultData.reserve(size);
+    for (auto i = 0; i < size; ++i) {
+      inputData.emplace_back(value);
+      resultData.emplace_back(expectedResult);
+    }
+    auto input = makeFlatVector<T>(inputData);
+    SelectivityVector rows(size);
+    rows.setValidRange(0, unSelectedRows, false);
+    auto result =
+        evaluate<SimpleVector<int32_t>>("hash(c0)", makeRowVector({input}));
+    velox::test::assertEqualVectors(
+        makeFlatVector<int32_t>(resultData), result, rows);
+  }
 };
 
 TEST_F(HashTest, String) {
@@ -225,6 +250,18 @@ TEST_F(HashTest, row) {
 
   row->setNull(1, true);
   assertEqualVectors(makeFlatVector<int32_t>({42, 42}), hash(row));
+}
+
+TEST_F(HashTest, simd) {
+  runSIMDHashAndAssert<int8_t>(1, -559580957, 1024, 10);
+  runSIMDHashAndAssert<int16_t>(-1, -1604776387, 4096);
+  runSIMDHashAndAssert<int32_t>(0xcafecafe, 638354558, 33);
+  runSIMDHashAndAssert<int64_t>(-1, -939490007, 34);
+  runSIMDHashAndAssert<std::string>("Spark", 228093765, 33);
+  runSIMDHashAndAssert<float>(1, -466301895, 77);
+  runSIMDHashAndAssert<double>(1, -460888942, 1000, 32);
+  runSIMDHashAndAssert<Timestamp>(
+      Timestamp::fromMicros(12345678), 1402875301, 1000, 100);
 }
 
 } // namespace

--- a/velox/functions/sparksql/tests/XxHash64Test.cpp
+++ b/velox/functions/sparksql/tests/XxHash64Test.cpp
@@ -32,6 +32,31 @@ class XxHash64Test : public SparkFunctionBaseTest {
   VectorPtr xxhash64(VectorPtr vector) {
     return evaluate("xxhash64(c0)", makeRowVector({vector}));
   }
+
+  template <typename T>
+  void runSIMDHashAndAssert(
+      const T value,
+      const int64_t expectedResult,
+      const int32_t size,
+      int unSelectedRows = 0) {
+    // Generate 'size' flat vector to test SIMD code path.
+    // We use same value in the vector to make comparing the results easier.
+    std::vector<T> inputData;
+    inputData.reserve(size);
+    std::vector<int64_t> resultData;
+    resultData.reserve(size);
+    for (auto i = 0; i < size; ++i) {
+      inputData.emplace_back(value);
+      resultData.emplace_back(expectedResult);
+    }
+    auto input = makeFlatVector<T>(inputData);
+    SelectivityVector rows(size);
+    rows.setValidRange(0, unSelectedRows, false);
+    auto result =
+        evaluate<SimpleVector<int64_t>>("xxhash64(c0)", makeRowVector({input}));
+    velox::test::assertEqualVectors(
+        makeFlatVector<int64_t>(resultData), result, rows);
+  }
 };
 
 // The expected result was obtained by running SELECT xxhash64("Spark") query
@@ -281,6 +306,18 @@ TEST_F(XxHash64Test, hashSeedVarcharArgs) {
   EXPECT_EQ(xxhash64WithSeed(42L, "hello", ""), -5179011742163812830);
   EXPECT_EQ(xxhash64WithSeed(0L, std::nullopt, "hello"), 2794345569481354659);
   EXPECT_EQ(xxhash64WithSeed(0L, "", "hello"), 1992633642622160295);
+}
+
+TEST_F(XxHash64Test, simd) {
+  runSIMDHashAndAssert<int8_t>(1, -6698625589789238999, 1024);
+  runSIMDHashAndAssert<int16_t>(-1, 2017008487422258757, 4096);
+  runSIMDHashAndAssert<int32_t>(0xcafecafe, 3599843564351570672, 33);
+  runSIMDHashAndAssert<int64_t>(-1, 3858142552250413010, 34);
+  runSIMDHashAndAssert<std::string>("Spark", -4294468057691064905, 33);
+  runSIMDHashAndAssert<float>(1, 700633588856507837, 77);
+  runSIMDHashAndAssert<double>(1, -2162451265447482029, 1000);
+  runSIMDHashAndAssert<Timestamp>(
+      Timestamp::fromMicros(12345678), 782671362992292307, 1000, 100);
 }
 
 } // namespace


### PR DESCRIPTION
Improve the performance of hash Spark functions for scalar types through auto-vectorization.
We can observe a measurable speed-up with this change: 
TINYINT: ~4X, SMALLINT: ~4X, BIGINT: ~2X, REAL: ~4X, DOUBLE:~2X, DECIMAL(18, 6): ~2X, DECIMAL(38, 6): ~1.2X, TIMESTAMP: ~1.8X, VARCHAR: ~1.3X.
Benchmark result before this optimization:
```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
hash_ARRAY<MAP<INTEGER,VARCHAR>>##hash                      9.63ms    103.88
hash_ARRAY<MAP<INTEGER,VARCHAR>>##xxhash64                  9.38ms    106.66
----------------------------------------------------------------------------
hash_BIGINT##hash                                         352.84us     2.83K
hash_BIGINT##xxhash64                                     346.62us     2.88K
----------------------------------------------------------------------------
hash_DECIMAL(18, 6)##hash                                 353.29us     2.83K
hash_DECIMAL(18, 6)##xxhash64                             346.79us     2.88K
----------------------------------------------------------------------------
hash_DECIMAL(38, 6)##hash                                 787.34us     1.27K
hash_DECIMAL(38, 6)##xxhash64                             742.86us     1.35K
----------------------------------------------------------------------------
hash_DOUBLE##hash                                         370.08us     2.70K
hash_DOUBLE##xxhash64                                     371.87us     2.69K
----------------------------------------------------------------------------
hash_REAL##hash                                           349.01us     2.87K
hash_REAL##xxhash64                                       360.70us     2.77K
----------------------------------------------------------------------------
hash_ROW<f_map:MAP<INTEGER,VARCHAR>,f_array:ARR            17.70ms     56.50
hash_ROW<f_map:MAP<INTEGER,VARCHAR>,f_array:ARR            17.93ms     55.77
----------------------------------------------------------------------------
hash_SMALLINT##hash                                       331.26us     3.02K
hash_SMALLINT##xxhash64                                   340.99us     2.93K
----------------------------------------------------------------------------
hash_TIMESTAMP##hash                                      493.88us     2.02K
hash_TIMESTAMP##xxhash64                                  486.54us     2.06K
----------------------------------------------------------------------------
hash_TINYINT##hash                                        328.91us     3.04K
hash_TINYINT##xxhash64                                    348.23us     2.87K
----------------------------------------------------------------------------
hash_VARCHAR##hash                                          1.09ms    916.55
hash_VARCHAR##xxhash64                                    959.35us     1.04K
----------------------------------------------------------------------------
```
Benchmark result before after optimization:
```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
hash_ARRAY<MAP<INTEGER,VARCHAR>>##hash                     10.27ms     97.38
hash_ARRAY<MAP<INTEGER,VARCHAR>>##xxhash64                  9.41ms    106.22
----------------------------------------------------------------------------
hash_BIGINT##hash                                         161.41us     6.20K
hash_BIGINT##xxhash64                                     151.50us     6.60K
----------------------------------------------------------------------------
hash_DECIMAL(18, 6)##hash                                 166.50us     6.01K
hash_DECIMAL(18, 6)##xxhash64                             158.21us     6.32K
----------------------------------------------------------------------------
hash_DECIMAL(38, 6)##hash                                 603.90us     1.66K
hash_DECIMAL(38, 6)##xxhash64                             589.37us     1.70K
----------------------------------------------------------------------------
hash_DOUBLE##hash                                         183.81us     5.44K
hash_DOUBLE##xxhash64                                     162.11us     6.17K
----------------------------------------------------------------------------
hash_REAL##hash                                            74.44us    13.43K
hash_REAL##xxhash64                                       130.64us     7.65K
----------------------------------------------------------------------------
hash_ROW<f_map:MAP<INTEGER,VARCHAR>,f_array:ARR            18.18ms     55.00
hash_ROW<f_map:MAP<INTEGER,VARCHAR>,f_array:ARR            17.96ms     55.67
----------------------------------------------------------------------------
hash_SMALLINT##hash                                        70.86us    14.11K
hash_SMALLINT##xxhash64                                   123.17us     8.12K
----------------------------------------------------------------------------
hash_TIMESTAMP##hash                                      270.07us     3.70K
hash_TIMESTAMP##xxhash64                                  257.59us     3.88K
----------------------------------------------------------------------------
hash_TINYINT##hash                                         72.28us    13.84K
hash_TINYINT##xxhash64                                    127.60us     7.84K
----------------------------------------------------------------------------
hash_VARCHAR##hash                                        818.48us     1.22K
hash_VARCHAR##xxhash64                                    660.15us     1.51K
----------------------------------------------------------------------------
```