### PR TITLE
Fix double counting of lazy loading time

### DIFF
--- a/velox/vector/LazyVector.h
+++ b/velox/vector/LazyVector.h
@@ -105,12 +105,6 @@ class VectorLoader {
       ValueHook* hook,
       vector_size_t resultSize,
       VectorPtr* result) = 0;
-
-  virtual void loadInternal(
-      const SelectivityVector& rows,
-      ValueHook* hook,
-      vector_size_t resultSize,
-      VectorPtr* result);
 };
 
 // Vector class which produces values on first use. This is used for


### PR DESCRIPTION
Summary:
Currently lazy loading time is double counted in 2 situations:
1. Loaded with `SelectivityVector`, including all `loadedVector` calls
2. Lazy loading happening in non-sink operator

Fix these to get more accurate timing and fair comparison with Java.  Also fix the locking in `processLazyTiming`.

Differential Revision: D58932813
