### PR TITLE
Add `[[noreturn]]` to 2 files inc velox/dwio/common/exception/Exceptions.cpp

### DIFF
--- a/velox/dwio/common/exception/Exceptions.cpp
+++ b/velox/dwio/common/exception/Exceptions.cpp
@@ -44,7 +44,7 @@ void verify(bool c, std::string fmt...) {
   }
 }
 
-void corrupt(std::string fmt...) {
+[[noreturn]] void corrupt(std::string fmt...) {
   va_list ap;
   va_start(ap, fmt);
   auto s = error_string(fmt, ap);

--- a/velox/dwio/common/exception/Exceptions.h
+++ b/velox/dwio/common/exception/Exceptions.h
@@ -89,7 +89,7 @@ void verify_range(uint64_t v, uint64_t rangeMask);
 
 void verify(bool c, std::string fmt...);
 
-void corrupt(std::string fmt...);
+[[noreturn]] void corrupt(std::string fmt...);
 
 std::string error_string(std::string fmt, va_list ap);
 std::string format_error_string(std::string fmt...);


### PR DESCRIPTION
Summary: LLVM-15 has a warning `-Wno-return` which can be used to identify functions that do not return. Qualifying these functions with `[[noreturn]]` is a perf optimization.

Reviewed By: helfman

Differential Revision: D59003605
