### PR TITLE
Fix some race conditions in PeriodicStatsReporterTest

### DIFF
--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -211,14 +211,17 @@ class TestStatsReportAsyncDataCache : public cache::AsyncDataCache {
       : cache::AsyncDataCache(nullptr, nullptr), stats_(stats) {}
 
   cache::CacheStats refreshStats() const override {
+    std::lock_guard<std::mutex> l(mutex_);
     return stats_;
   }
 
   void updateStats(cache::CacheStats stats) {
+    std::lock_guard<std::mutex> l(mutex_);
     stats_ = stats;
   }
 
  private:
+  mutable std::mutex mutex_;
   cache::CacheStats stats_;
 };
 
@@ -231,6 +234,7 @@ class TestStatsReportMemoryArbitrator : public memory::MemoryArbitrator {
   ~TestStatsReportMemoryArbitrator() override = default;
 
   void updateStats(memory::MemoryArbitrator::Stats stats) {
+    std::lock_guard<std::mutex> l(mutex_);
     stats_ = stats;
   }
 
@@ -264,6 +268,7 @@ class TestStatsReportMemoryArbitrator : public memory::MemoryArbitrator {
   }
 
   Stats stats() const override {
+    std::lock_guard<std::mutex> l(mutex_);
     return stats_;
   }
 
@@ -272,6 +277,7 @@ class TestStatsReportMemoryArbitrator : public memory::MemoryArbitrator {
   }
 
  private:
+  mutable std::mutex mutex_;
   memory::MemoryArbitrator::Stats stats_;
 };
 


### PR DESCRIPTION
Summary:
PeriodicStatsReporter runs in a separate background thread and accesses CacheStats,
PeriodicStatsReporterTest updates CacheStats in the main thread.  Wrapping the CacheStats update
and access with a mutex resolves a race condition exposed by TSAN.

Differential Revision: D59020196
