### PR TITLE
Fix race condition in CachedFactoryTest.fuzzer

### DIFF
--- a/velox/common/caching/tests/CachedFactoryTest.cpp
+++ b/velox/common/caching/tests/CachedFactoryTest.cpp
@@ -471,7 +471,6 @@ TEST(CachedFactoryTest, fuzzer) {
   const int numThreads = 32;
   const int testDurationMs = 5'000;
   const size_t expirationDurationMs = 1;
-  folly::Random::DefaultGenerator rng(23);
   for (const bool expireCache : {false, true}) {
     SCOPED_TRACE(fmt::format("expireCache: {}", expireCache));
     auto generator = std::make_unique<IdentityGenerator>();
@@ -483,7 +482,8 @@ TEST(CachedFactoryTest, fuzzer) {
     std::vector<std::thread> threads;
     threads.reserve(numThreads);
     for (int i = 0; i < numThreads; ++i) {
-      threads.emplace_back([&]() {
+      threads.emplace_back([&factory, i]() {
+        folly::Random::DefaultGenerator rng(23 + i);
         const auto startTimeMs = getCurrentTimeMs();
         while (startTimeMs + testDurationMs > getCurrentTimeMs()) {
           const auto key = folly::Random::rand32(rng) % 256;


### PR DESCRIPTION
Summary:
CachedFactoryTest.fuzzer runs mutliple threads that all share the same random generator, this
causes TSAN to report a race condition.  Changing it so each thread uses a different generator with
a unique seed resolves this.

Differential Revision: D59020596
