### PR TITLE
Fix race conditions in AsyncDataCache AccessStats

### DIFF
--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -62,8 +62,8 @@ inline AccessTime accessTime() {
 }
 
 struct AccessStats {
-  AccessTime lastUse{0};
-  int32_t numUses{0};
+  tsan_atomic<AccessTime> lastUse{0};
+  tsan_atomic<int32_t> numUses{0};
 
   // Retention score. A higher number means less worth retaining. This
   // works well with a typical formula of time over use count going to


### PR DESCRIPTION
Summary:
AsyncDataCache uses an AccessStats object to track when an entry was last accessed and how
many times it's been accessed.  With multiple threads accessing entries and threads that may have
never used an entry checking to see if it can be evicted from the cache to make space, these need
to be guarded to ensure consistency in the face of concurrent updates/reads.

This was exposed running CacheTest.readAhead with TSAN enabled.

Differential Revision: D59021411
