### PR TITLE
Fix race condition in ProfilerTest

### DIFF
--- a/velox/common/process/Profiler.cpp
+++ b/velox/common/process/Profiler.cpp
@@ -63,7 +63,7 @@ std::string Profiler::resultPath_;
 tsan_atomic<bool> Profiler::shouldStop_;
 folly::Promise<bool> Profiler::sleepPromise_;
 tsan_atomic<bool> Profiler::shouldSaveResult_;
-int64_t Profiler::sampleStartTime_;
+tsan_atomic<int64_t> Profiler::sampleStartTime_;
 int64_t Profiler::cpuAtSampleStart_;
 int64_t Profiler::cpuAtLastCheck_;
 std::function<void()> Profiler::startExtra_;

--- a/velox/common/process/Profiler.h
+++ b/velox/common/process/Profiler.h
@@ -65,7 +65,7 @@ class Profiler {
   static tsan_atomic<bool> shouldSaveResult_;
 
   // Time of starting the profile. Seconds from epoch.
-  static int64_t sampleStartTime_;
+  static tsan_atomic<int64_t> sampleStartTime_;
 
   // CPU time at start of profile.
   static int64_t cpuAtSampleStart_;


### PR DESCRIPTION
Summary:
Profiler sets sampleStartTime_ in one thread and reads it in another, however this class doesn't seem
to be particular concerned about race conditions.

This issue was found running ProfilerTest.basic with TSAN.

Differential Revision: D59028438
