### PR TITLE
Ignore TSAN errors in WindowFuzzer

### DIFF
--- a/velox/exec/fuzzer/WindowFuzzer.cpp
+++ b/velox/exec/fuzzer/WindowFuzzer.cpp
@@ -374,6 +374,12 @@ bool WindowFuzzer::verifyWindow(
     }
   };
 
+  // There is a known issue where LocalPartition will send DictionaryVectors
+  // with the same underlying base Vector to multiple threads.  This triggers
+  // TSAN to report data races, particularly if that base Vector is from the
+  // TableScan and reused.  Ignore TSAN issues in these tests for now.
+  folly::annotate_ignore_thread_sanitizer_guard g(__FILE__, __LINE__);
+
   auto frame = getFrame(partitionKeys, sortingKeysAndOrders, frameClause);
   auto plan = PlanBuilder()
                   .values(input)


### PR DESCRIPTION
Summary:
There is a known issue where LocalPartition will send DictionaryVectors with the same underlying
base Vector to multiple threads.  This triggers TSAN to report data races, particularly if that base
Vector is from the TableScan and reused.  Ignore TSAN issues in these tests for now.

Differential Revision: D59031959
