### PR TITLE
Shorten AggregationTest.maxSpillBytes from 2m to 2s

### DIFF
--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -3142,7 +3142,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimEmptyOutput) {
 TEST_F(AggregationTest, maxSpillBytes) {
   const auto rowType =
       ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), VARCHAR()});
-  const auto vectors = createVectors(rowType, 1024, 15 << 20);
+  const auto vectors = createVectors(rowType, 128, 1 << 20);
 
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   core::PlanNodeId aggregationNodeId;


### PR DESCRIPTION
AggregationTest.maxSpillBytes currently runs for more than 1 minute close to 2 minutes. This test only test spill vs non-spill condition and does not need such a large data set to achieve the purpose of testing. Make the test run on smaller datasets to reduce this test's run duration by ~99% (2m -> 2s)