### PR TITLE
Fix AbfsReadFile::Impl::preadv to return the length of read.

### DIFF
--- a/velox/connectors/hive/storage_adapters/abfs/AbfsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/AbfsFileSystem.cpp
@@ -116,6 +116,7 @@ class AbfsReadFile::Impl {
   uint64_t preadv(
       folly::Range<const common::Region*> regions,
       folly::Range<folly::IOBuf*> iobufs) const {
+    size_t length = 0;
     VELOX_CHECK_EQ(regions.size(), iobufs.size());
     for (size_t i = 0; i < regions.size(); ++i) {
       const auto& region = regions[i];
@@ -123,7 +124,10 @@ class AbfsReadFile::Impl {
       output = folly::IOBuf(folly::IOBuf::CREATE, region.length);
       pread(region.offset, region.length, output.writableData());
       output.append(region.length);
+      length += region.length;
     }
+
+    return length;
   }
 
   uint64_t size() const {

--- a/velox/connectors/hive/storage_adapters/abfs/tests/AbfsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/tests/AbfsFileSystemTest.cpp
@@ -154,8 +154,10 @@ void readData(ReadFile* readFile) {
 
   std::vector<folly::IOBuf> iobufs(2);
   std::vector<Region> regions = {{0, 10}, {10, 5}};
-  readFile->preadv(
-      {regions.data(), regions.size()}, {iobufs.data(), iobufs.size()});
+  ASSERT_EQ(
+      10 + 5,
+      readFile->preadv(
+          {regions.data(), regions.size()}, {iobufs.data(), iobufs.size()}));
   ASSERT_EQ(
       std::string_view(
           reinterpret_cast<const char*>(iobufs[0].writableData()),


### PR DESCRIPTION
https://github.com/facebookincubator/velox/commit/1ae622476ef39e7832f880f5165b05bd0e4c3df4  changed the return value of the `AbfsReadFile::Impl::preadv` method from `void` to `uint64_t`, but the method did not return the corresponding value, which caused CI to be red.
```
FAILED: velox/connectors/hive/storage_adapters/abfs/CMakeFiles/velox_abfs.dir/AbfsFileSystem.cpp.o 
/usr/bin/ccache /opt/rh/gcc-toolset-12/root/bin/g++ -DAZ_RTTI -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_CONTEXT_DYN_LINK -DBOOST_CONTEXT_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_FILESYSTEM_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_REGEX_DYN_LINK -DBOOST_REGEX_NO_LIB -DBOOST_SYSTEM_DYN_LINK -DBOOST_SYSTEM_NO_LIB -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DCURL_STATICLIB -DFOLLY_HAVE_INT128_T=1 -DGFLAGS_IS_A_DLL=0 -DVELOX_ENABLE_ABFS -DVELOX_ENABLE_GCS -DVELOX_ENABLE_HDFS3 -DVELOX_ENABLE_PARQUET -DVELOX_ENABLE_S3 -I/usr/local/cuda-12.4/targets/x86_64-linux/include -I/__w/velox/velox/_build/release/_deps/protobuf-src/src -I/__w/velox/velox/. -I/__w/velox/velox/velox/external/xxhash -I/__w/velox/velox/_build/release/_deps/xsimd-src/include -I/__w/velox/velox/_build/release/_deps/curl-src/include -isystem /__w/velox/velox/velox -isystem /__w/velox/velox/velox/external -isystem /usr/include/libdwarf-0 -mavx2 -mfma -mavx -mf16c -mlzcnt -std=c++17 -mbmi2 -D USE_VELOX_COMMON_BASE -D HAS_UNCAUGHT_EXCEPTIONS -Wall -Wextra -Wno-unused        -Wno-unused-parameter        -Wno-sign-compare        -Wno-ignored-qualifiers        -Wnon-virtual-dtor        -Wno-implicit-fallthrough          -Wno-class-memaccess          -Wno-comment          -Wno-int-in-bool-context          -Wno-redundant-move          -Wno-array-bounds          -Wno-maybe-uninitialized          -Wno-unused-result          -Wno-format-overflow          -Wno-strict-aliasing -Werror -O3 -DNDEBUG -std=gnu++17 -fPIC -fdiagnostics-color=always -MD -MT velox/connectors/hive/storage_adapters/abfs/CMakeFiles/velox_abfs.dir/AbfsFileSystem.cpp.o -MF velox/connectors/hive/storage_adapters/abfs/CMakeFiles/velox_abfs.dir/AbfsFileSystem.cpp.o.d -o velox/connectors/hive/storage_adapters/abfs/CMakeFiles/velox_abfs.dir/AbfsFileSystem.cpp.o -c /__w/velox/velox/velox/connectors/hive/storage_adapters/abfs/AbfsFileSystem.cpp
/__w/velox/velox/velox/connectors/hive/storage_adapters/abfs/AbfsFileSystem.cpp: In member function 'uint64_t facebook::velox::filesystems::abfs::AbfsReadFile::Impl::preadv(folly::Range<const facebook::velox::common::Region*>, folly::Range<folly::IOBuf*>) const':
/__w/velox/velox/velox/connectors/hive/storage_adapters/abfs/AbfsFileSystem.cpp:127:3: error: control reaches end of non-void function [-Werror=return-type]
  127 |   }
      |   ^
cc1plus: all warnings being treated as errors
```

https://github.com/facebookincubator/velox/actions/runs/9676020056/job/26694723464?pr=10260

CC: @Yuhta @helfman 