### PR TITLE
Enable non-flat vector for approx_percentile percentile array elements

### DIFF
--- a/velox/functions/prestosql/aggregates/tests/ApproxPercentileTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxPercentileTest.cpp
@@ -400,7 +400,7 @@ TEST_F(ApproxPercentileTest, finalAggregateAccuracy) {
   assertQuery(op, "SELECT 5");
 }
 
-TEST_F(ApproxPercentileTest, invalidEncoding) {
+TEST_F(ApproxPercentileTest, nonFlatPercentileArray) {
   auto indices = AlignedBuffer::allocate<vector_size_t>(3, pool());
   auto rawIndices = indices->asMutable<vector_size_t>();
   std::iota(rawIndices, rawIndices + indices->size(), 0);
@@ -421,10 +421,8 @@ TEST_F(ApproxPercentileTest, invalidEncoding) {
                   .values({rows})
                   .singleAggregation({}, {"approx_percentile(c0, c1)"})
                   .planNode();
-  AssertQueryBuilder assertQuery(plan);
-  VELOX_ASSERT_THROW(
-      assertQuery.copyResults(pool()),
-      "Only flat encoding is allowed for percentile array elements");
+  auto expected = makeRowVector({makeArrayVector<int32_t>({{0, 5, 9}})});
+  AssertQueryBuilder(plan).assertResults(expected);
 }
 
 TEST_F(ApproxPercentileTest, invalidWeight) {


### PR DESCRIPTION
Summary:
We do see queries using non-flat vector as percentile array
(e.g. `transform(sequence(1, 9), x -> x * 0.1)`), and Presto Java handles this
without problem.  Enable this for Presto C++ as well.

Differential Revision: D59067455
