### PR TITLE
Add support for VARBINARY input to from_base64 Presto function

### DIFF
--- a/velox/functions/prestosql/BinaryFunctions.h
+++ b/velox/functions/prestosql/BinaryFunctions.h
@@ -282,21 +282,19 @@ struct ToBase64Function {
   }
 };
 
-template <typename T>
+template <typename TExec>
 struct FromBase64Function {
-  VELOX_DEFINE_FUNCTION_TYPES(T);
-  FOLLY_ALWAYS_INLINE void call(
-      out_type<Varbinary>& result,
-      const arg_type<Varchar>& input) {
-    try {
-      auto inputSize = input.size();
-      result.resize(
-          encoding::Base64::calculateDecodedSize(input.data(), inputSize));
-      encoding::Base64::decode(
-          input.data(), inputSize, result.data(), result.size());
-    } catch (const encoding::Base64Exception& e) {
-      VELOX_USER_FAIL(e.what());
-    }
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  // T can be either arg_type<Varchar> or arg_type<Varbinary>. These are the
+  // same, but hard-coding one of them might be confusing.
+  template <typename T>
+  FOLLY_ALWAYS_INLINE void call(out_type<Varbinary>& result, const T& input) {
+    auto inputSize = input.size();
+    result.resize(
+        encoding::Base64::calculateDecodedSize(input.data(), inputSize));
+    encoding::Base64::decode(
+        input.data(), inputSize, result.data(), result.size());
   }
 };
 

--- a/velox/functions/prestosql/registration/BinaryFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/BinaryFunctionsRegistration.cpp
@@ -45,8 +45,12 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerFunction<FromHexFunction, Varbinary, Varchar>({prefix + "from_hex"});
   registerFunction<ToBase64Function, Varchar, Varbinary>(
       {prefix + "to_base64"});
+
   registerFunction<FromBase64Function, Varbinary, Varchar>(
       {prefix + "from_base64"});
+  registerFunction<FromBase64Function, Varbinary, Varbinary>(
+      {prefix + "from_base64"});
+
   registerFunction<ToBase64UrlFunction, Varchar, Varbinary>(
       {prefix + "to_base64url"});
   registerFunction<FromBase64UrlFunction, Varbinary, Varchar>(


### PR DESCRIPTION
Summary:
Presto supports both VARCHAR and VARBINARY input to from_base64 function.

```
presto:di> show functions like 'from_base64';
  Function   | Return Type | Argument Types | Function Type | Deterministic |            Description            | Variable Arity | Built In | Temporary >
-------------+-------------+----------------+---------------+---------------+-----------------------------------+----------------+----------+----------->
 from_base64 | varbinary   | varbinary      | scalar        | true          | decode base64 encoded binary data | false          | true     | false     >
 from_base64 | varbinary   | varchar(x)     | scalar        | true          | decode base64 encoded binary data | false          | true     | false     >
(2 rows)
```

Reviewed By: amitkdutta

Differential Revision: D59070858
