### PR TITLE
Fix .gitignore and some typos.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,7 +88,7 @@ _build/
 *.pdf
 *.swp
 a.out
-CMake/resolve_dependency_module/boost/FindBoost.cmake
+CMake/resolve_dependency_modules/boost/FindBoost.cmake
 __cmake_systeminformation/
 
 #==============================================================================#

--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -651,7 +651,7 @@ class CastTypedExpr : public ITypedExpr {
 
 using CastTypedExprPtr = std::shared_ptr<const CastTypedExpr>;
 
-/// A collection of convenince methods for working with expressions.
+/// A collection of convenience methods for working with expressions.
 class TypedExprs {
  public:
   /// Returns true if 'expr' is a field access expression.

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -453,7 +453,7 @@ class Operator : public BaseRuntimeStatWriter {
         toString());
   }
 
-  /// Returns a list of identify projections, e.g. columns that are projected
+  /// Returns a list of identity projections, e.g. columns that are projected
   /// as-is possibly after applying a filter.
   const std::vector<IdentityProjection>& identityProjections() const {
     return identityProjections_;
@@ -489,7 +489,7 @@ class Operator : public BaseRuntimeStatWriter {
     stats_.wlock()->addRuntimeStat(name, value);
   }
 
-  /// Returns reference to the operator stats synchronized object to gain bulck
+  /// Returns reference to the operator stats synchronized object to gain bulk
   /// read/write access to the stats.
   folly::Synchronized<OperatorStats>& stats() {
     return stats_;
@@ -499,7 +499,7 @@ class Operator : public BaseRuntimeStatWriter {
 
   virtual std::string toString() const;
 
-  /// Used in debug ednpoints.
+  /// Used in debug endpoints.
   virtual folly::dynamic toJson() const {
     folly::dynamic obj = folly::dynamic::object;
     obj["operator"] = toString();


### PR DESCRIPTION
This PR fixes the `.gitignore` path for `CMake/resolve_dependency_modules/boost/FindBoost.cmake`. It also corrects a few typos found while reading the code.