### PR TITLE
Add support for minus(timestamp with tz, timestamp with tz) Presto function

### DIFF
--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -504,6 +504,13 @@ struct TimestampMinusFunction {
       const arg_type<Timestamp>& b) {
     result = a.toMillis() - b.toMillis();
   }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<IntervalDayTime>& result,
+      const arg_type<TimestampWithTimezone>& a,
+      const arg_type<TimestampWithTimezone>& b) {
+    result = unpackMillisUtc(a) - unpackMillisUtc(b);
+  }
 };
 
 template <typename T>

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -152,6 +152,12 @@ void registerSimpleFunctions(const std::string& prefix) {
       Timestamp,
       Timestamp>({prefix + "minus"});
 
+  registerFunction<
+      TimestampMinusFunction,
+      IntervalDayTime,
+      TimestampWithTimezone,
+      TimestampWithTimezone>({prefix + "minus"});
+
   registerFunction<DayFunction, int64_t, TimestampWithTimezone>(
       {prefix + "day", prefix + "day_of_month"});
   registerFunction<DayOfWeekFunction, int64_t, Timestamp>(


### PR DESCRIPTION
Summary: Add support for subtracting one timestamp with time zone from another.

Differential Revision: D59072212
