### PR TITLE
Add support for VARBINARY inputs to substr Presto function

### DIFF
--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -130,6 +130,42 @@ struct SubstrFunction {
   }
 };
 
+template <typename TExec>
+struct SubstrVarbinaryFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  // Results refer to strings in the first argument.
+  static constexpr int32_t reuse_strings_from_arg = 0;
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& input,
+      int64_t start,
+      int64_t length = std::numeric_limits<int64_t>::max()) {
+    if (start == 0 || length <= 0) {
+      result.setEmpty();
+      return;
+    }
+
+    int64_t size = input.size();
+
+    if (start < 0) {
+      start = size + start + 1;
+    }
+
+    if (start <= 0 || start > size) {
+      result.setEmpty();
+      return;
+    }
+
+    if (size - start + 1 < length) {
+      length = size - start + 1;
+    }
+
+    result.setNoCopy(StringView(input.data() + start - 1, length));
+  }
+};
+
 /// Trim functions
 /// ltrim(string) -> varchar
 ///    Removes leading whitespaces from the string.

--- a/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -56,10 +56,22 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "substr"});
   registerFunction<SubstrFunction, Varchar, Varchar, int64_t, int64_t>(
       {prefix + "substr"});
+
+  // TODO Presto doesn't allow INTEGER types for 2nd and 3rd arguments. Remove
+  // these signatures.
   registerFunction<SubstrFunction, Varchar, Varchar, int32_t>(
       {prefix + "substr"});
   registerFunction<SubstrFunction, Varchar, Varchar, int32_t, int32_t>(
       {prefix + "substr"});
+
+  registerFunction<SubstrVarbinaryFunction, Varbinary, Varbinary, int64_t>(
+      {prefix + "substr"});
+  registerFunction<
+      SubstrVarbinaryFunction,
+      Varbinary,
+      Varbinary,
+      int64_t,
+      int64_t>({prefix + "substr"});
 
   registerFunction<SplitPart, Varchar, Varchar, Varchar, int64_t>(
       {prefix + "split_part"});

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -666,6 +666,54 @@ TEST_F(StringFunctionsTest, substrWithConditionalSingleBuffer) {
   }
 }
 
+TEST_F(StringFunctionsTest, substrVarbinary) {
+  auto substr = [&](const std::string& input,
+                    int64_t start,
+                    std::optional<int64_t> length = {}) {
+    if (length.has_value()) {
+      return evaluateOnce<std::string>(
+          "substr(c0, c1, c2)",
+          {VARBINARY(), BIGINT(), BIGINT()},
+          std::optional(input),
+          std::optional(start),
+          length);
+    } else {
+      return evaluateOnce<std::string>(
+          "substr(c0, c1)",
+          {VARBINARY(), BIGINT()},
+          std::optional(input),
+          std::optional(start));
+    }
+  };
+
+  EXPECT_EQ(substr("Apple", 0), "");
+  EXPECT_EQ(substr("Apple", 1), "Apple");
+  EXPECT_EQ(substr("Apple", 3), "ple");
+  EXPECT_EQ(substr("Apple", 5), "e");
+  EXPECT_EQ(substr("Apple", 100), "");
+
+  EXPECT_EQ(substr("Apple", -1), "e");
+  EXPECT_EQ(substr("Apple", -4), "pple");
+  EXPECT_EQ(substr("Apple", -5), "Apple");
+  EXPECT_EQ(substr("Apple", -100), "");
+
+  EXPECT_EQ(substr("", 0), "");
+  EXPECT_EQ(substr("", 1), "");
+  EXPECT_EQ(substr("", -1), "");
+
+  EXPECT_EQ(substr("Apple", 1, 1), "A");
+  EXPECT_EQ(substr("Apple", 2, 3), "ppl");
+  EXPECT_EQ(substr("Apple", 2, 4), "pple");
+  EXPECT_EQ(substr("Apple", 2, 10), "pple");
+
+  EXPECT_EQ(substr("Apple", -1, 1), "e");
+  EXPECT_EQ(substr("Apple", -3, 2), "pl");
+  EXPECT_EQ(substr("Apple", -3, 5), "ple");
+  EXPECT_EQ(substr("Apple", -5, 4), "Appl");
+  EXPECT_EQ(substr("Apple", -5, 10), "Apple");
+  EXPECT_EQ(substr("Apple", -6, 1), "");
+}
+
 namespace {
 std::vector<std::tuple<std::string, std::string>> getUpperAsciiTestData() {
   return {


### PR DESCRIPTION
Summary:
Presto allows both VARCHAR and VARBINARY inputs.

With VARBINARY input, start and length refer to start byte and length in bytes. With VARBINARY input, start and length refer to start character and length in characters.

```
presto:di> show functions like 'substr';
 Function | Return Type |       Argument Types       | Function Type | Deterministic |                  Description                   | Variable Arity |>
----------+-------------+----------------------------+---------------+---------------+------------------------------------------------+----------------+>
 substr   | char(x)     | char(x), bigint            | scalar        | true          | suffix starting at given index                 | false          |>
 substr   | char(x)     | char(x), bigint, bigint    | scalar        | true          | substring of given length starting at an index | false          |>
 substr   | varbinary   | varbinary, bigint          | scalar        | true          | suffix starting at given index                 | false          |>
 substr   | varbinary   | varbinary, bigint, bigint  | scalar        | true          | substring of given length starting at an index | false          |>
 substr   | varchar(x)  | varchar(x), bigint         | scalar        | true          | suffix starting at given index                 | false          |>
 substr   | varchar(x)  | varchar(x), bigint, bigint | scalar        | true          | substring of given length starting at an index | false          |>
(6 rows)
```

Differential Revision: D59089582
