### PR TITLE
Add partial support for split_to_map Presto lambda function

### DIFF
--- a/velox/docs/functions/presto/string.rst
+++ b/velox/docs/functions/presto/string.rst
@@ -166,6 +166,20 @@ String Functions
 
     Raises an error if there are duplicate keys.
 
+.. function:: split_to_map(string, entryDelimiter, keyValueDelimiter, function(K,V1,V2,R)) -> map<varchar, varchar>
+
+    Splits ``string`` by ``entryDelimiter`` and ``keyValueDelimiter`` and returns a map.
+    ``entryDelimiter`` splits ``string`` into key-value pairs. ``keyValueDelimiter`` splits
+    each pair into key and value. Note that ``entryDelimiter`` and ``keyValueDelimiter`` are
+    interpreted literally, i.e., as full string matches.
+
+    ``function(K,V1,V2,R)`` is used to decide whether to keep first or last value for
+    duplicate keys. (k, v1, v2) -> v1 keeps first value. (k, v1, v2) -> v2 keeps last
+    value. Arbitrary functions are not supported. ::
+
+        SELECT(split_to_map('a:1;b:2;a:3', ';', ':', (k, v1, v2) -> v1)); -- {"a": "1", "b": "2"}
+        SELECT(split_to_map('a:1;b:2;a:3', ';', ':', (k, v1, v2) -> v2)); -- {"a": "3", "b": "2"}
+
 .. function:: starts_with(string, substring) -> boolean
 
     Returns whether ``string`` starts with ``substring``.

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -54,6 +54,7 @@ int main(int argc, char** argv) {
       "width_bucket",
       // Fuzzer cannot generate valid 'comparator' lambda.
       "array_sort(array(T),constant function(T,T,bigint)) -> array(T)",
+      "split_to_map(varchar,varchar,varchar,function(varchar,varchar,varchar,varchar)) -> map(varchar,varchar)",
       // https://github.com/facebookincubator/velox/issues/8919
       "plus(date,interval year to month) -> date",
       "minus(date,interval year to month) -> date",

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(
   SimpleComparisonMatcher.cpp
   Slice.cpp
   Split.cpp
+  SplitToMap.cpp
   StringFunctions.cpp
   Subscript.cpp
   ToUtf8.cpp

--- a/velox/functions/prestosql/SplitToMap.cpp
+++ b/velox/functions/prestosql/SplitToMap.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/SplitToMap.h"
+
+namespace facebook::velox::functions {
+
+namespace {
+
+core::CallTypedExprPtr asSplitToMapCall(
+    const std::string& prefix,
+    const core::TypedExprPtr& expr) {
+  if (auto call = std::dynamic_pointer_cast<const core::CallTypedExpr>(expr)) {
+    if (call->name() == prefix + "split_to_map") {
+      return call;
+    }
+  }
+  return nullptr;
+}
+
+} // namespace
+
+core::TypedExprPtr rewriteSplitToMapCall(
+    const std::string& prefix,
+    const core::TypedExprPtr& expr) {
+  const auto call = asSplitToMapCall(prefix, expr);
+  if (call == nullptr || call->inputs().size() != 4) {
+    return nullptr;
+  }
+
+  const auto* lambda =
+      dynamic_cast<const core::LambdaTypedExpr*>(call->inputs()[3].get());
+  VELOX_CHECK_NOT_NULL(lambda);
+
+  const auto v1 = lambda->signature()->nameOf(1);
+  const auto v2 = lambda->signature()->nameOf(2);
+
+  const auto& body = lambda->body();
+  std::optional<bool> keepFirst;
+  if (auto field =
+          std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(body)) {
+    if (field->isInputColumn()) {
+      if (field->name() == v1) {
+        keepFirst = true;
+      } else if (field->name() == v2) {
+        keepFirst = false;
+      }
+    }
+  }
+
+  if (!keepFirst.has_value()) {
+    static const std::string kNotSupported =
+        "split_to_map with arbitrary lambda is not supported: {}";
+    VELOX_USER_FAIL(kNotSupported, lambda->toString())
+  }
+
+  return std::make_shared<core::CallTypedExpr>(
+      call->type(),
+      std::vector<core::TypedExprPtr>{
+          call->inputs()[0],
+          call->inputs()[1],
+          call->inputs()[2],
+          std::make_shared<core::ConstantTypedExpr>(
+              BOOLEAN(), keepFirst.value())},
+      "$internal$split_to_map");
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/ScalarFunctionRegTest.cpp
+++ b/velox/functions/prestosql/tests/ScalarFunctionRegTest.cpp
@@ -69,6 +69,11 @@ TEST_F(ScalarFunctionRegTest, prefix) {
     if (funcName == "in") {
       continue;
     }
+
+    // Skip internal functions. They don't have any prefix.
+    if (funcName.find("$internal$") == 0) {
+      continue;
+    }
     EXPECT_EQ(prefix, funcName.substr(0, prefixSize));
     EXPECT_EQ(1, scalarSimpleFuncBaseNames.count(funcName.substr(prefixSize)));
   }


### PR DESCRIPTION
Summary:
Add limited support for split_to_map with a lambda argument.

Supported lambdas are:

- (k, v1, v2) ->v1 - keeps first value
- (k, v1, v2) ->v2 - keeps last value

The implementation consists of:

- Define and register an $internal$split_to_map function with a boolean argument that tells whether to keep first or last value for the key.
- Register 'split_to_map' with lambda argument using ApplyNeverCalled. This adds a registry entry with desired signature.
- Register a rewrite that replaces lambda function with $internal$split_to_map for qualified lambdas.

Fixes https://github.com/facebookincubator/velox/issues/10330

Differential Revision: D59096851
