### PR TITLE
Fix MemoryPool::capacity_ can be negative

### DIFF
--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -1061,7 +1061,7 @@ uint64_t MemoryPoolImpl::shrink(uint64_t targetBytes) {
   std::lock_guard<std::mutex> l(mutex_);
   // We don't expect to shrink a memory pool without capacity limit.
   VELOX_CHECK_NE(capacity_, kMaxMemory);
-  uint64_t freeBytes = std::max<uint64_t>(0, capacity_ - reservationBytes_);
+  uint64_t freeBytes = std::max<int64_t>(0, capacity_ - reservationBytes_);
   if (targetBytes != 0) {
     freeBytes = std::min(targetBytes, freeBytes);
   }


### PR DESCRIPTION
- Step 1: In some cases, `capacity_` can be smaller than `reservationBytes_`, which will cause `capacity_ - reservationBytes_` to be a negative value.
- Step 2:After converting a negative value to an unsigned number, `freeBytes` will be very large.
- Step 3:`freeBytes` will be truncated to `targetBytes`, which can be larger than `capacity_`.
- Step 4: capacity_ is a negative number.