### PR TITLE
Reduce array_filter and map_filter memory usage

### DIFF
--- a/velox/functions/prestosql/tests/ArrayFilterTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayFilterTest.cpp
@@ -77,6 +77,19 @@ TEST_F(ArrayFilterTest, filter) {
       });
 }
 
+TEST_F(ArrayFilterTest, copyWhenFilteringRateIsHigh) {
+  auto data = makeRowVector({
+      makeArrayVector<int64_t>(
+          10, [](auto) { return 20; }, [](auto i) { return i % 20; }),
+  });
+  auto result = evaluate("filter(c0, x -> (x = 3))", data);
+  auto* arrayResult = result->asUnchecked<ArrayVector>();
+  ASSERT_TRUE(arrayResult->elements()->isFlatEncoding());
+  auto expected = makeArrayVector<int64_t>(
+      10, [](auto) { return 1; }, [](auto) { return 3; });
+  assertEqualVectors(expected, result);
+}
+
 TEST_F(ArrayFilterTest, empty) {
   auto rowType = ROW({"long_val", "array_val"}, {BIGINT(), ARRAY(BIGINT())});
   auto data = std::static_pointer_cast<RowVector>(


### PR DESCRIPTION
Summary:
We observed some OOM happening because the downstream operator of
`map_filter` is accumulating the input vectors.  These vectors are dictionary
with very few indices but a large alphabet, i.e. result of filtering.  To
prevent OOM from such cases, we add in a threshold that when the filtering ratio
is below it, we copy the result instead of holding on to a large base vector to
reduce memory usage.

Differential Revision: D59125367
