### PR TITLE
Fix GroupIdNode`s groupIdName to const method

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -912,7 +912,7 @@ class GroupIdNode : public PlanNode {
     return aggregationInputs_;
   }
 
-  const std::string& groupIdName() {
+  const std::string& groupIdName() const {
     return groupIdName_;
   }
 


### PR DESCRIPTION
Fix GroupIdNode`s groupIdName() to const method, so that it could be access by NodePtr.