### PR TITLE
[WIP] Use HashStringAllocator for raw_vector rows in HashLookup

### DIFF
--- a/velox/common/base/tests/RawVectorTest.cpp
+++ b/velox/common/base/tests/RawVectorTest.cpp
@@ -57,23 +57,18 @@ TEST(RawVectorTest, resize) {
 }
 
 TEST(RawVectorTest, copyAndMove) {
+  const auto kNumRows = 1000;
   raw_vector<int32_t> ints(1000);
+  const auto kDataSize = kNumRows * sizeof(int32_t);
   // a raw_vector is intentionally not initialized.
-  memset(ints.data(), 11, ints.size() * sizeof(int32_t));
-  ints[ints.size() - 1] = 12345;
-  raw_vector<int32_t> intsCopy(ints);
-  EXPECT_EQ(
-      0, memcmp(ints.data(), intsCopy.data(), ints.size() * sizeof(int32_t)));
+  memset(ints.data(), 11, kDataSize);
+  ints[kNumRows - 1] = 12345;
+  auto data = ints.data();
 
   raw_vector<int32_t> intsMoved(std::move(ints));
   EXPECT_TRUE(ints.empty());
 
-  EXPECT_EQ(
-      0,
-      memcmp(
-          intsMoved.data(),
-          intsCopy.data(),
-          intsCopy.size() * sizeof(int32_t)));
+  EXPECT_EQ(0, memcmp(intsMoved.data(), data, kDataSize));
 }
 
 TEST(RawVectorTest, iota) {

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -397,7 +397,8 @@ void GroupingSet::createHashTable() {
     }
   }
 
-  lookup_ = std::make_unique<HashLookup>(table_->hashers());
+  lookup_ = std::make_unique<HashLookup>(
+      table_->hashers(), table_->stringAllocatorShared());
   if (!isAdaptive_ && table_->hashMode() != BaseHashTable::HashMode::kHash) {
     table_->forceGenericHashMode(BaseHashTable::kNoSpillInputStartPartitionBit);
   }
@@ -408,7 +409,7 @@ void GroupingSet::initializeGlobalAggregation() {
     return;
   }
 
-  lookup_ = std::make_unique<HashLookup>(hashers_);
+  lookup_ = std::make_unique<HashLookup>(hashers_, table_->stringAllocatorShared());
   lookup_->reset(1);
 
   // Row layout is:

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -157,8 +157,6 @@ void HashProbe::initialize() {
     keyChannels_.push_back(hasher->channel());
   }
 
-  VELOX_CHECK_NULL(lookup_);
-  lookup_ = std::make_unique<HashLookup>(hashers_);
   auto buildType = joinNode_->sources()[1]->outputType();
   auto tableType = makeTableType(buildType.get(), joinNode_->rightKeys());
   if (joinNode_->filter()) {
@@ -349,6 +347,8 @@ void HashProbe::asyncWaitForHashTable() {
 
   VELOX_CHECK_NOT_NULL(table_);
 
+  VELOX_CHECK_NULL(lookup_);
+  lookup_ = std::make_unique<HashLookup>(hashers_, table_->stringAllocatorShared());
   maybeSetupSpillInputReader(hashBuildResult->restoredPartitionId);
   maybeSetupInputSpiller(hashBuildResult->spillPartitionIds);
   checkMaxSpillLevel(hashBuildResult->restoredPartitionId);

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -2006,7 +2006,7 @@ int32_t HashTable<false>::listNullKeyRows(
   if (!iter->initialized) {
     VELOX_CHECK_GT(nextOffset_, 0);
     VELOX_CHECK_EQ(hashers_.size(), 1);
-    HashLookup lookup(hashers_);
+    HashLookup lookup(hashers_, stringAllocatorShared());
     if (hashMode_ == HashMode::kHash) {
       lookup.hashes.push_back(VectorHasher::kNullHash);
     } else {
@@ -2160,7 +2160,7 @@ template class HashTable<false>;
 namespace {
 void populateLookupRows(
     const SelectivityVector& rows,
-    raw_vector<vector_size_t>& lookupRows) {
+    HsaRawVector<vector_size_t>& lookupRows) {
   if (rows.isAllSelected()) {
     std::iota(lookupRows.begin(), lookupRows.end(), 0);
   } else {

--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -48,7 +48,8 @@ RowNumber::RowNumber(
         false, // hasProbedFlag
         0, // minTableSizeForParallelJoinBuild
         pool());
-    lookup_ = std::make_unique<HashLookup>(table_->hashers());
+    lookup_ = std::make_unique<HashLookup>(
+        table_->hashers(), table_->stringAllocatorShared());
 
     const auto numRowsColumn = table_->rows()->columnAt(numKeys);
     numRowsOffset_ = numRowsColumn.offset();

--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -164,7 +164,8 @@ TopNRowNumber::TopNRowNumber(
         0, // minTableSizeForParallelJoinBuild
         pool());
     partitionOffset_ = table_->rows()->columnAt(numKeys).offset();
-    lookup_ = std::make_unique<HashLookup>(table_->hashers());
+    lookup_ = std::make_unique<HashLookup>(
+        table_->hashers(), table_->stringAllocatorShared());
   } else {
     allocator_ = std::make_unique<HashStringAllocator>(pool());
     singlePartition_ = std::make_unique<TopRows>(allocator_.get(), comparator_);

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -198,7 +198,8 @@ class HashTableTest : public testing::TestWithParam<bool>,
     int32_t sequence = 0;
     std::vector<RowVectorPtr> batches;
     auto table = createHashTableForAggregation(tableType, numKeys);
-    auto lookup = std::make_unique<HashLookup>(table->hashers());
+    auto lookup = std::make_unique<HashLookup>(
+        table->hashers(), table->stringAllocatorShared());
     std::vector<char*> allInserted;
     int32_t numErased = 0;
     // We insert 1000 and delete 500.
@@ -455,7 +456,8 @@ class HashTableTest : public testing::TestWithParam<bool>,
   }
 
   void testProbe() {
-    auto lookup = std::make_unique<HashLookup>(topTable_->hashers());
+    auto lookup = std::make_unique<HashLookup>(
+        topTable_->hashers(), topTable_->stringAllocatorShared());
     const auto batchSize = batches_[0]->size();
     SelectivityVector rows(batchSize);
     const auto mode = topTable_->hashMode();
@@ -695,7 +697,8 @@ TEST_P(HashTableTest, bestWithReserveOverflow) {
       ROW({"a", "b", "c", "d"}, {BIGINT(), BIGINT(), BIGINT(), BIGINT()});
   const auto numKeys = 4;
   auto table = createHashTableForAggregation(rowType, numKeys);
-  auto lookup = std::make_unique<HashLookup>(table->hashers());
+  auto lookup =
+      std::make_unique<HashLookup>(table->hashers(), table->stringAllocatorShared());
 
   // Make sure rangesWithReserve overflows.
   //  Ranges for keys are: 200K, 200K, 200K, 100K.
@@ -756,7 +759,8 @@ TEST_P(HashTableTest, bestWithReserveOverflow) {
 TEST_P(HashTableTest, enableRangeWhereCan) {
   auto rowType = ROW({"a", "b", "c"}, {BIGINT(), VARCHAR(), VARCHAR()});
   auto table = createHashTableForAggregation(rowType, 3);
-  auto lookup = std::make_unique<HashLookup>(table->hashers());
+  auto lookup =
+      std::make_unique<HashLookup>(table->hashers(), table->stringAllocatorShared());
 
   // Generate 3 keys with the following ranges and number of distinct values
   // (ndv):
@@ -795,7 +799,8 @@ TEST_P(HashTableTest, enableRangeWhereCan) {
 
 TEST_P(HashTableTest, arrayProbeNormalizedKey) {
   auto table = createHashTableForAggregation(ROW({"a"}, {BIGINT()}), 1);
-  auto lookup = std::make_unique<HashLookup>(table->hashers());
+  auto lookup =
+      std::make_unique<HashLookup>(table->hashers(), table->stringAllocatorShared());
 
   for (auto i = 0; i < 200; ++i) {
     auto data = makeRowVector({
@@ -950,7 +955,8 @@ TEST_P(HashTableTest, groupBySpill) {
 TEST_P(HashTableTest, checkSizeValidation) {
   auto rowType = ROW({"a"}, {BIGINT()});
   auto table = createHashTableForAggregation(rowType, 1);
-  auto lookup = std::make_unique<HashLookup>(table->hashers());
+  auto lookup =
+      std::make_unique<HashLookup>(table->hashers(), table->stringAllocatorShared());
   auto testHelper = HashTableTestHelper<false>::create(table.get());
 
   // The initial set hash mode with table size of 256K entries.
@@ -1087,7 +1093,8 @@ TEST_P(HashTableTest, offsetOverflowLoadTags) {
   auto rowType = ROW({"a"}, {BIGINT()});
   auto table = createHashTableForAggregation(rowType, rowType->size());
   table->hashMode();
-  auto lookup = std::make_unique<HashLookup>(table->hashers());
+  auto lookup =
+      std::make_unique<HashLookup>(table->hashers(), table->stringAllocatorShared());
   auto batchSize = 1 << 25;
   for (auto i = 0; i < 64; ++i) {
     std::vector<RowVectorPtr> batches;


### PR DESCRIPTION
The rows in the HashLookup are stored as raw_vector. The raw_vector uses a malloc type allocation to acquire aligned memory. It was found this contributes to large unaccounted memory when  mainly using the HashProbe and other operators.

This change allows the usage of a custom allocator for the raw_vector. By default it keeps the current way of allocating and deallocating.

For raw_vectors representing rows in the HashLookup the allocator used is the HashStringAllocator which allows for the accounting of the memory.