### PR TITLE
Fix spark-server docker image

### DIFF
--- a/scripts/spark-container.dockerfile
+++ b/scripts/spark-container.dockerfile
@@ -30,7 +30,8 @@ RUN dnf install -y java-11-openjdk less procps python3 tzdata \
     && ln -s $(which python3) /usr/bin/python \
     && tar -zxf $SPARK_PKG \
     && mv ./spark-${SPARK_VERSION}-bin-hadoop3 $SPARK_HOME \
-    && mv ./$SPARK_CONNECT_JAR ${SPARK_HOME}/jars/
+    && mkdir ${SPARK_HOME}/misc/ \
+    && mv ./$SPARK_CONNECT_JAR ${SPARK_HOME}/misc/
 
 # We set the timezone to America/Los_Angeles due to issue
 # detailed here : https://github.com/facebookincubator/velox/issues/8127

--- a/scripts/spark/start-spark.sh
+++ b/scripts/spark/start-spark.sh
@@ -15,5 +15,4 @@
 
 set -e
 
-cd $SPARK_HOME
-./sbin/start-connect-server.sh --jars $SPARK_HOME/jars/spark-connect_2.12-3.5.1.jar
+$SPARK_HOME/sbin/start-connect-server.sh --jars $SPARK_HOME/misc/spark-connect_2.12-3.5.1.jar


### PR DESCRIPTION
On centos 9, below exception is noticed when starting Spark if putting 
`SPARK_CONNECT_JAR` under `${SPARK_HOME}/jars/`. This PR moves it in
`${SPARK_HOME}/misc/` to avoid the incompatibility.
```
Exception in thread "main" java.lang.NoClassDefFoundError: org/sparkproject/guava/util/concurrent/internal/InternalFutureFailureAccess
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1022)
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:174)
	at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:800)
	at java.base/
```
https://github.com/facebookincubator/velox/pull/9559
