### PR TITLE
Add SparkSql function to_pretty_string

### DIFF
--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -342,15 +342,15 @@ String Functions
         SELECT substring_index('aaaaa', 'aa', 5); -- "aaaaa"
         SELECT substring_index('aaaaa', 'aa', -5); -- "aaaaa"
 
-.. spark:function:: toprettystring(x) -> varchar
+.. spark:function:: to_pretty_string(x) -> varchar
 
-    Returns pretty string for all scalar type. It has several differences with casting value to string:
+    Returns pretty string for all scalar type. Considering the time zone if config ``session_timezone`` is set. 
+
+    It has several differences with casting value to string:
 
     - It prints null values (either from column or struct field) as "NULL".
 
     - It prints binary values (either from column or struct field) using the hex format.
-    
-    Considering the time zone if config ``session_timezone`` is set. ::
 
 .. spark:function:: translate(string, match, replace) -> varchar
 

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -344,11 +344,11 @@ String Functions
 
 .. spark:function:: to_pretty_string(x) -> varchar
 
-    Returns pretty string for all scalar type. Considering the time zone if config ``session_timezone`` is set. 
+    Returns pretty string for ``x``. All scalar types are supported.
+    Adjusts the timestamp input to the given time zone if set through ``session_timezone`` config.
+    The result is different from that of casting ``x`` as string in the following aspects.
 
-    It has several differences with casting value to string:
-
-    - It prints null values as "NULL".
+    - It prints null input as "NULL" rather than producing null output.
 
     - It prints binary values using the hex format.
 

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -348,9 +348,9 @@ String Functions
 
     It has several differences with casting value to string:
 
-    - It prints null values (either from column or struct field) as "NULL".
+    - It prints null values as "NULL".
 
-    - It prints binary values (either from column or struct field) using the hex format.
+    - It prints binary values using the hex format.
 
 .. spark:function:: translate(string, match, replace) -> varchar
 

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -342,6 +342,16 @@ String Functions
         SELECT substring_index('aaaaa', 'aa', 5); -- "aaaaa"
         SELECT substring_index('aaaaa', 'aa', -5); -- "aaaaa"
 
+.. spark:function:: toprettystring(x) -> varchar
+
+    Returns pretty string for all scalar type. It has several differences with casting value to string:
+
+    - It prints null values (either from column or struct field) as "NULL".
+
+    - It prints binary values (either from column or struct field) using the hex format.
+    
+    Considering the time zone if config ``session_timezone`` is set. ::
+
 .. spark:function:: translate(string, match, replace) -> varchar
 
     Returns a new translated string. It translates the character in ``string`` by a

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -49,6 +49,7 @@ inline std::exception_ptr makeBadCastException(
       makeErrorMessage(input, row, resultType, errorDetails),
       false));
 }
+
 } // namespace
 
 namespace detail {
@@ -589,7 +590,11 @@ VectorPtr CastExpr::applyDecimalToVarcharCast(
     auto actualSize = DecimalUtil::castToString<FromNativeType>(
         simpleInput->valueAt(row), scale, rowSize, rawBuffer);
     flatResult->setNoCopy(row, StringView(rawBuffer, actualSize));
+    if (!StringView::isInline(actualSize)) {
       // If string view is inline, corresponding bytes on the raw string buffer
+      // are not needed.
+      rawBuffer += actualSize;
+    }
   });
   // Update the exact buffer size.
   buffer->setSize(rawBuffer - buffer->asMutable<char>());

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -49,7 +49,6 @@ inline std::exception_ptr makeBadCastException(
       makeErrorMessage(input, row, resultType, errorDetails),
       false));
 }
-
 } // namespace
 
 namespace detail {
@@ -590,11 +589,7 @@ VectorPtr CastExpr::applyDecimalToVarcharCast(
     auto actualSize = DecimalUtil::castToString<FromNativeType>(
         simpleInput->valueAt(row), scale, rowSize, rawBuffer);
     flatResult->setNoCopy(row, StringView(rawBuffer, actualSize));
-    if (!StringView::isInline(actualSize)) {
       // If string view is inline, corresponding bytes on the raw string buffer
-      // are not needed.
-      rawBuffer += actualSize;
-    }
   });
   // Update the exact buffer size.
   buffer->setSize(rawBuffer - buffer->asMutable<char>());

--- a/velox/functions/lib/RegistrationHelpers.h
+++ b/velox/functions/lib/RegistrationHelpers.h
@@ -78,6 +78,13 @@ void registerUnaryFloatingPoint(const std::vector<std::string>& aliases) {
   registerFunction<T, float, float>(aliases);
 }
 
+template <template <class> class T, typename TReturn>
+void registerUnaryFloatingPointWithReturn(
+    const std::vector<std::string>& aliases) {
+  registerFunction<T, TReturn, double>(aliases);
+  registerFunction<T, TReturn, float>(aliases);
+}
+
 template <template <class> class T>
 void registerUnaryNumeric(const std::vector<std::string>& aliases) {
   registerUnaryIntegral<T>(aliases);

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -172,7 +172,7 @@ inline void registerArrayMinMaxFunctions(const std::string& prefix) {
 }
 
 void registerToPrettyStringFunctions(const std::string& prefix) {
-  const std::vector<std::string> aliases = aliases;
+  const std::vector<std::string> aliases = {prefix + "to_pretty_string"};
   registerUnaryIntegralWithTReturn<ToPrettyStringFunction, Varchar>(aliases);
   registerUnaryFloatingPointWithReturn<ToPrettyStringFunction, Varchar>(
       aliases);

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -172,26 +172,23 @@ inline void registerArrayMinMaxFunctions(const std::string& prefix) {
 }
 
 void registerToPrettyStringFunctions(const std::string& prefix) {
-  registerUnaryIntegralWithTReturn<ToPrettyStringFunction, Varchar>(
-      {prefix + "toprettystring"});
+  const std::vector<std::string> aliases = aliases;
+  registerUnaryIntegralWithTReturn<ToPrettyStringFunction, Varchar>(aliases);
   registerUnaryFloatingPointWithReturn<ToPrettyStringFunction, Varchar>(
-      {prefix + "toprettystring"});
-  registerFunction<ToPrettyStringFunction, Varchar, bool>(
-      {prefix + "toprettystring"});
-  registerFunction<ToPrettyStringFunction, Varchar, Varchar>(
-      {prefix + "toprettystring"});
-  registerFunction<ToPrettyStringFunction, Varchar, Date>(
-      {prefix + "toprettystring"});
+      aliases);
+  registerFunction<ToPrettyStringFunction, Varchar, bool>(aliases);
+  registerFunction<ToPrettyStringFunction, Varchar, Varchar>(aliases);
+  registerFunction<ToPrettyStringFunction, Varchar, Date>(aliases);
   registerFunction<ToPrettyStringVarbinaryFunction, Varchar, Varbinary>(
-      {prefix + "toprettystring"});
-  registerFunction<ToPrettyStringTimeStampFunction, Varchar, Timestamp>(
-      {prefix + "toprettystring"});
+      aliases);
+  registerFunction<ToPrettyStringTimestampFunction, Varchar, Timestamp>(
+      aliases);
   registerFunction<
       ToPrettyStringDecimalFunction,
       Varchar,
-      ShortDecimal<P1, S1>>({prefix + "toprettystring"});
+      ShortDecimal<P1, S1>>(aliases);
   registerFunction<ToPrettyStringDecimalFunction, Varchar, LongDecimal<P1, S1>>(
-      {prefix + "toprettystring"});
+      aliases);
 }
 } // namespace
 
@@ -246,6 +243,7 @@ void registerFunctions(const std::string& prefix) {
       Varchar,
       Varchar,
       Varchar>({prefix + "str_to_map"});
+
   registerToPrettyStringFunctions(prefix);
 
   registerFunction<sparksql::LeftFunction, Varchar, Varchar, int32_t>(

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -178,11 +178,12 @@ void registerToPrettyStringFunctions(const std::string& prefix) {
       aliases);
   registerFunction<ToPrettyStringFunction, Varchar, bool>(aliases);
   registerFunction<ToPrettyStringFunction, Varchar, Varchar>(aliases);
-  registerFunction<ToPrettyStringFunction, Varchar, Date>(aliases);
   registerFunction<ToPrettyStringVarbinaryFunction, Varchar, Varbinary>(
       aliases);
+  registerFunction<ToPrettyStringFunction, Varchar, Date>(aliases);
   registerFunction<ToPrettyStringTimestampFunction, Varchar, Timestamp>(
       aliases);
+  registerFunction<ToPrettyStringFunction, Varchar, UnknownValue>(aliases);
   registerFunction<
       ToPrettyStringDecimalFunction,
       Varchar,

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -50,6 +50,7 @@
 #include "velox/functions/sparksql/Split.h"
 #include "velox/functions/sparksql/String.h"
 #include "velox/functions/sparksql/StringToMap.h"
+#include "velox/functions/sparksql/ToPrettyString.h"
 #include "velox/functions/sparksql/UnscaledValueFunction.h"
 #include "velox/functions/sparksql/Uuid.h"
 #include "velox/functions/sparksql/specialforms/DecimalRound.h"
@@ -169,6 +170,29 @@ inline void registerArrayMinMaxFunctions(const std::string& prefix) {
   registerArrayMinMaxFunctions<Timestamp>(prefix);
   registerArrayMinMaxFunctions<Date>(prefix);
 }
+
+void registerToPrettyStringFunctions(const std::string& prefix) {
+  registerUnaryIntegralWithTReturn<ToPrettyStringFunction, Varchar>(
+      {prefix + "toprettystring"});
+  registerUnaryFloatingPointWithReturn<ToPrettyStringFunction, Varchar>(
+      {prefix + "toprettystring"});
+  registerFunction<ToPrettyStringFunction, Varchar, bool>(
+      {prefix + "toprettystring"});
+  registerFunction<ToPrettyStringFunction, Varchar, Varchar>(
+      {prefix + "toprettystring"});
+  registerFunction<ToPrettyStringFunction, Varchar, Date>(
+      {prefix + "toprettystring"});
+  registerFunction<ToPrettyStringVarbinaryFunction, Varchar, Varbinary>(
+      {prefix + "toprettystring"});
+  registerFunction<ToPrettyStringTimeStampFunction, Varchar, Timestamp>(
+      {prefix + "toprettystring"});
+  registerFunction<
+      ToPrettyStringDecimalFunction,
+      Varchar,
+      ShortDecimal<P1, S1>>({prefix + "toprettystring"});
+  registerFunction<ToPrettyStringDecimalFunction, Varchar, LongDecimal<P1, S1>>(
+      {prefix + "toprettystring"});
+}
 } // namespace
 
 void registerFunctions(const std::string& prefix) {
@@ -222,6 +246,7 @@ void registerFunctions(const std::string& prefix) {
       Varchar,
       Varchar,
       Varchar>({prefix + "str_to_map"});
+  registerToPrettyStringFunctions(prefix);
 
   registerFunction<sparksql::LeftFunction, Varchar, Varchar, int32_t>(
       {prefix + "left"});

--- a/velox/functions/sparksql/ToPrettyString.h
+++ b/velox/functions/sparksql/ToPrettyString.h
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/expression/CastExpr-inl.h"
+#include "velox/functions/Udf.h"
+#include "velox/type/Conversions.h"
+
+namespace facebook::velox::functions::sparksql {
+namespace detail {
+static const StringView kNull = "NULL";
+}
+
+/// toprettystring(x) -> varchar
+/// Returns pretty string for int8, int16, int32, int64, bool, Date, Varchar. It
+/// has one difference with casting value to string:
+/// - It prints null values (either from column or struct field) as "NULL".
+template <typename TExec>
+struct ToPrettyStringFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  // Results refer to strings in the first argument.
+  static constexpr int32_t reuse_strings_from_arg = 0;
+
+  template <typename A>
+  void initialize(
+      const std::vector<TypePtr>& inputTypes,
+      const core::QueryConfig& /*config*/,
+      A* /*a*/) {
+    inputType_ = inputTypes[0];
+  }
+
+  template <typename TInput>
+  void callNullable(out_type<Varchar>& result, const TInput* input) {
+    if (input) {
+      if constexpr (std::is_same_v<TInput, StringView>) {
+        result.setNoCopy(*input);
+        return;
+      }
+      if constexpr (std::is_same_v<TInput, int32_t>) {
+        if (inputType_->isDate()) {
+          auto output = DATE()->toString(*input);
+          result.append(output);
+          return;
+        }
+      }
+      const auto castResult =
+          util::Converter<TypeKind::VARCHAR, void, util::SparkCastPolicy>::
+              tryCast(*input);
+      if (castResult.hasError()) {
+        result.setNoCopy(detail::kNull);
+      } else {
+        result.copy_from(castResult.value());
+      }
+    } else {
+      result.setNoCopy(detail::kNull);
+    }
+  }
+
+ private:
+  TypePtr inputType_;
+};
+
+/// Returns pretty string for Varbinary. It has several differences with casting
+/// value to string:
+/// - It prints null values (either from column or struct field) as "NULL".
+/// - It prints binary values (either from column or struct field) using the hex
+/// format. Returns a pretty string of the byte array which prints each byte as
+/// a hex digit and add spaces between them. For example, [1A C0].
+template <typename TExec>
+struct ToPrettyStringVarbinaryFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  template <typename TInput>
+  void callNullable(out_type<Varchar>& result, const TInput* input) {
+    if (input) {
+      // One byte spares 2 char, and with the spaces and the boxes.
+      // Byte size: 2 * input->size(), spaces size: input->size() - 1, boxes
+      // size: 2, its sum is 1 + 3 * input->size().
+      result.resize(1 + 3 * input->size());
+      char* const startPosition = result.data();
+      char* pos = startPosition;
+      *pos++ = '[';
+      for (auto i = 0; i < input->size(); i++) {
+        auto formated = fmt::format("{:X}", input->data()[i]);
+        *pos++ = formated.data()[0];
+        *pos++ = formated.data()[1];
+        *pos++ = ' ';
+      }
+      *--pos = ']';
+    } else {
+      result.setNoCopy(detail::kNull);
+    }
+  }
+};
+
+/// Returns pretty string for Timestamp. It has one difference with casting
+/// value to string:
+/// - It prints null values (either from column or struct field) as "NULL".
+template <typename TExec>
+struct ToPrettyStringTimeStampFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      const arg_type<Timestamp>* /*timestamp*/) {
+    auto timezone = config.sessionTimezone();
+    if (!timezone.empty()) {
+      options_.timeZone = date::locate_zone(timezone);
+    }
+    timestampRowSize_ = getMaxStringLength(options_);
+  }
+
+  void callNullable(
+      out_type<Varchar>& result,
+      const arg_type<Timestamp>* timestamp) {
+    if (timestamp) {
+      Timestamp inputValue(*timestamp);
+      if (options_.timeZone) {
+        inputValue.toTimezone(*(options_.timeZone));
+      }
+      result.reserve(timestampRowSize_);
+      const auto stringView =
+          Timestamp::tsToStringView(inputValue, options_, result.data());
+      result.resize(stringView.size());
+    } else {
+      result.setNoCopy(detail::kNull);
+    }
+  }
+
+ private:
+  TimestampToStringOptions options_ = {
+      .precision = TimestampToStringOptions::Precision::kMicroseconds,
+      .leadingPositiveSign = true,
+      .skipTrailingZeros = true,
+      .zeroPaddingYear = true,
+      .dateTimeSeparator = ' ',
+  };
+  std::string::size_type timestampRowSize_;
+};
+
+/// Returns pretty string for short decimal and long decimal. It has one
+/// difference with casting value to string:
+/// - It prints null values (either from column or struct field) as "NULL".
+template <typename TExec>
+struct ToPrettyStringDecimalFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  template <typename A>
+  void initialize(
+      const std::vector<TypePtr>& inputTypes,
+      const core::QueryConfig& /*config*/,
+      A* /*a*/) {
+    const auto [precision, scale] = getDecimalPrecisionScale(*inputTypes[0]);
+    precision_ = precision;
+    scale_ = scale;
+    
+    maxRowSize_ = velox::DecimalUtil::getMaxStringLength();
+    if (scale > 0) {
+      ++maxRowSize_; // A dot.
+    }
+    if (precision == scale) {
+      ++maxRowSize_; // Leading zero.
+    }
+  }
+
+  template <typename TInput>
+  void callNullable(out_type<Varchar>& result, const TInput* input) {
+    if (input) {
+      if (StringView::isInline(maxRowSize_)) {
+        auto view = exec::detail::convertToStringView<TInput>(
+            *input, scale_, maxRowSize_, inlined_);
+        result.setNoCopy(inlined_);
+      } else {
+        result.reserve(maxRowSize_);
+        auto view = exec::detail::convertToStringView<TInput>(
+            *input, scale_, maxRowSize_, result.data());
+        result.resize(view.size());
+      }
+
+    } else {
+      result.setNoCopy(detail::kNull);
+    }
+  }
+
+ private:
+  uint8_t precision_;
+  uint8_t scale_;
+  int32_t maxRowSize_;
+  char inlined_[StringView::kInlineSize];
+};
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/ToPrettyString.h
+++ b/velox/functions/sparksql/ToPrettyString.h
@@ -27,7 +27,7 @@ static const StringView kNull = "NULL";
 /// to_pretty_string(x) -> varchar
 /// Returns pretty string for int8, int16, int32, int64, bool, Date, Varchar. It
 /// has one difference with casting value to string:
-/// 1) It prints null values as "NULL".
+/// 1) It prints null input as "NULL" rather than producing null output.
 template <typename TExec>
 struct ToPrettyStringFunction {
   VELOX_DEFINE_FUNCTION_TYPES(TExec);
@@ -78,8 +78,8 @@ struct ToPrettyStringFunction {
 
 /// Returns pretty string for varbinary. It has several differences with
 /// cast(varbinary as string):
-/// 1) It prints null values as "NULL".
-/// 2) It prints binary values using the hex format
+/// 1) It prints null input as "NULL" rather than producing null output.
+/// 2) It prints binary value as hex string representation rather than UTF-8.
 /// The pretty string is composed of the hex digits of bytes and spaces between
 /// them. E.g., the result of to_pretty_string("abc") is "[31 32 33]".
 template <typename TExec>
@@ -97,9 +97,9 @@ struct ToPrettyStringVarbinaryFunction {
       char* pos = startPosition;
       *pos++ = '[';
       for (auto i = 0; i < input->size(); i++) {
-        auto formatted = fmt::format("{:X}", input->data()[i]);
-        *pos++ = formatted.data()[0];
-        *pos++ = formatted.data()[1];
+        int count = std::sprintf(pos, "%02X", input->data()[i]);
+        VELOX_DCHECK_EQ(count, 2);
+        pos += 2;
         *pos++ = ' ';
       }
       *--pos = ']';
@@ -111,7 +111,7 @@ struct ToPrettyStringVarbinaryFunction {
 
 /// Returns pretty string for Timestamp. It has one difference with
 /// cast(timestamp as string):
-/// 1) It prints null values as "NULL".
+/// 1) It prints null input as "NULL" rather than producing null output.
 template <typename TExec>
 struct ToPrettyStringTimestampFunction {
   VELOX_DEFINE_FUNCTION_TYPES(TExec);
@@ -162,7 +162,7 @@ struct ToPrettyStringTimestampFunction {
 
 /// Returns pretty string for short decimal and long decimal. It has one
 /// difference with cast(decimal as string):
-/// 1) It prints null values as "NULL".
+/// 1) It prints null input as "NULL" rather than producing null output.
 template <typename TExec>
 struct ToPrettyStringDecimalFunction {
   VELOX_DEFINE_FUNCTION_TYPES(TExec);

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -51,6 +51,7 @@ add_executable(
   SplitTest.cpp
   StringTest.cpp
   StringToMapTest.cpp
+  ToPrettyStringTest.cpp
   UnscaledValueFunctionTest.cpp
   UuidTest.cpp
   XxHash64Test.cpp)

--- a/velox/functions/sparksql/tests/ToPrettyStringTest.cpp
+++ b/velox/functions/sparksql/tests/ToPrettyStringTest.cpp
@@ -58,6 +58,7 @@ TEST_F(ToPrettyStringTest, toPrettyStringTest) {
   EXPECT_EQ(
       toPrettyString<StringView>("str_is_not_inline"), "str_is_not_inline");
   EXPECT_EQ(toPrettyString<int8_t>(std::nullopt), kNull);
+  EXPECT_EQ(toPrettyString<UnknownValue>(UnknownValue()), kNull);
 }
 
 TEST_F(ToPrettyStringTest, date) {

--- a/velox/functions/sparksql/tests/ToPrettyStringTest.cpp
+++ b/velox/functions/sparksql/tests/ToPrettyStringTest.cpp
@@ -22,7 +22,7 @@ class ToPrettyStringTest : public SparkFunctionBaseTest {
  protected:
   template <typename T>
   std::optional<std::string> toPrettyString(std::optional<T> arg) {
-    return evaluateOnce<std::string>("toprettystring(c0)", arg);
+    return evaluateOnce<std::string>("to_pretty_string(c0)", arg);
   }
 
   template <TypeKind KIND>
@@ -63,13 +63,13 @@ TEST_F(ToPrettyStringTest, toPrettyStringTest) {
 TEST_F(ToPrettyStringTest, date) {
   EXPECT_EQ(
       evaluateOnce<std::string>(
-          "toprettystring(c0)", DATE(), std::optional<int32_t>(18262)),
+          "to_pretty_string(c0)", DATE(), std::optional<int32_t>(18262)),
       "2020-01-01");
 }
 
 TEST_F(ToPrettyStringTest, binary) {
   auto toPrettyStringBinary = [&](const std::optional<std::string>& input) {
-    return evaluateOnce<std::string>("toprettystring(c0)", VARBINARY(), input)
+    return evaluateOnce<std::string>("to_pretty_string(c0)", VARBINARY(), input)
         .value();
   };
 
@@ -94,7 +94,7 @@ TEST_F(ToPrettyStringTest, timestamp) {
 TEST_F(ToPrettyStringTest, decimal) {
   testDecimalExpr<TypeKind::VARCHAR>(
       {makeFlatVector<StringView>({"0.123", "0.552", "0.000"})},
-      "toprettystring(c0)",
+      "to_pretty_string(c0)",
       {makeFlatVector<int64_t>({123, 552, 0}, DECIMAL(3, 3))});
 
   testDecimalExpr<TypeKind::VARCHAR>(
@@ -103,7 +103,7 @@ TEST_F(ToPrettyStringTest, decimal) {
            "55555555555555.55555",
            "0.00000",
            StringView(kNull)})},
-      "toprettystring(c0)",
+      "to_pretty_string(c0)",
       {makeNullableFlatVector<int128_t>(
           {1234567890123456789, 5555555555555555555, 0, std::nullopt},
           DECIMAL(19, 5))});

--- a/velox/functions/sparksql/tests/ToPrettyStringTest.cpp
+++ b/velox/functions/sparksql/tests/ToPrettyStringTest.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <string>
+
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+namespace facebook::velox::functions::sparksql::test {
+class ToPrettyStringTest : public SparkFunctionBaseTest {
+ protected:
+  template <typename T>
+  std::optional<std::string> toPrettyString(std::optional<T> arg) {
+    return evaluateOnce<std::string>("toprettystring(c0)", arg);
+  }
+
+  template <TypeKind KIND>
+  void testDecimalExpr(
+      const VectorPtr& expected,
+      const std::string& expression,
+      const std::vector<VectorPtr>& input) {
+    using EvalType = typename velox::TypeTraits<KIND>::NativeType;
+    auto result =
+        evaluate<SimpleVector<EvalType>>(expression, makeRowVector(input));
+    velox::test::assertEqualVectors(expected, result);
+  }
+
+  void setQueryTimeZone(const std::string& timeZone) {
+    queryCtx_->testingOverrideConfigUnsafe({
+        {core::QueryConfig::kSessionTimezone, timeZone},
+        {core::QueryConfig::kAdjustTimestampToTimezone, "true"},
+    });
+  }
+
+  const std::string kNull = "NULL";
+};
+
+TEST_F(ToPrettyStringTest, toPrettyStringTest) {
+  EXPECT_EQ(toPrettyString<int8_t>(1), "1");
+  EXPECT_EQ(toPrettyString<int16_t>(1), "1");
+  EXPECT_EQ(toPrettyString<int32_t>(1), "1");
+  EXPECT_EQ(toPrettyString<int64_t>(1), "1");
+  EXPECT_EQ(toPrettyString<float>(1.0), "1.0");
+  EXPECT_EQ(toPrettyString<double>(1.0), "1.0");
+  EXPECT_EQ(toPrettyString<bool>(true), "true");
+  EXPECT_EQ(toPrettyString<StringView>("str"), "str");
+  EXPECT_EQ(
+      toPrettyString<StringView>("str_is_not_inline"), "str_is_not_inline");
+  EXPECT_EQ(toPrettyString<int8_t>(std::nullopt), kNull);
+}
+
+TEST_F(ToPrettyStringTest, date) {
+  EXPECT_EQ(
+      evaluateOnce<std::string>(
+          "toprettystring(c0)", DATE(), std::optional<int32_t>(18262)),
+      "2020-01-01");
+}
+
+TEST_F(ToPrettyStringTest, binary) {
+  auto toPrettyStringBinary = [&](const std::optional<std::string>& input) {
+    return evaluateOnce<std::string>("toprettystring(c0)", VARBINARY(), input)
+        .value();
+  };
+
+  EXPECT_EQ(toPrettyStringBinary("abcdef"), "[61 62 63 64 65 66]");
+
+  EXPECT_EQ(toPrettyStringBinary("ABC."), "[41 42 43 2E]");
+}
+
+TEST_F(ToPrettyStringTest, timestamp) {
+  EXPECT_EQ(
+      toPrettyString<Timestamp>(Timestamp(946729316, 123)),
+      "2000-01-01 12:21:56");
+
+  setQueryTimeZone("America/Los_Angeles");
+  EXPECT_EQ(
+      toPrettyString<Timestamp>(Timestamp(946729316, 123)),
+      "2000-01-01 04:21:56");
+
+  EXPECT_EQ(toPrettyString<Timestamp>(std::nullopt), kNull);
+}
+
+TEST_F(ToPrettyStringTest, decimal) {
+  testDecimalExpr<TypeKind::VARCHAR>(
+      {makeFlatVector<StringView>({"0.123", "0.552", "0.000"})},
+      "toprettystring(c0)",
+      {makeFlatVector<int64_t>({123, 552, 0}, DECIMAL(3, 3))});
+
+  testDecimalExpr<TypeKind::VARCHAR>(
+      {makeFlatVector<StringView>(
+          {"12345678901234.56789",
+           "55555555555555.55555",
+           "0.00000",
+           StringView(kNull)})},
+      "toprettystring(c0)",
+      {makeNullableFlatVector<int128_t>(
+          {1234567890123456789, 5555555555555555555, 0, std::nullopt},
+          DECIMAL(19, 5))});
+}
+
+} // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
Spark implement: https://github.com/apache/spark/blob/branch-3.5/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ToPrettyString.scala

This is an internal spark function.