### PR TITLE
Fix failing Linux release with adapters

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -62,7 +62,7 @@ jobs:
       Protobuf_SOURCE: BUNDLED # can be removed after #10134 is merged
       simdjson_SOURCE: BUNDLED
       xsimd_SOURCE: BUNDLED
-      Arrow_SOURCE: AUTO
+      Arrow_SOURCE: BUNDLED
       CUDA_VERSION: "12.4"
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This is a temporary workaround.
The actual fix is to build and install thrift.

Resolves https://github.com/facebookincubator/velox/issues/10352