### PR TITLE
Introduce Parquet Reader CLI

### DIFF
--- a/velox/dwio/parquet/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/reader/CMakeLists.txt
@@ -37,3 +37,9 @@ target_link_libraries(
   Snappy::snappy
   thrift
   zstd::zstd)
+
+
+add_library(velox_dwio_native_parquet_reader_cli ParquetReaderCli.cpp)
+
+target_link_libraries(velox_dwio_native_parquet_reader_cli
+        velox_dwio_parquet_reader)

--- a/velox/dwio/parquet/reader/ParquetReaderCli.cpp
+++ b/velox/dwio/parquet/reader/ParquetReaderCli.cpp
@@ -1,0 +1,55 @@
+/*
+* Copyright (c) Facebook, Inc. and its affiliates.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+#include "velox/dwio/parquet/reader/ParquetReaderCli.h"
+
+namespace facebook::velox::parquet {
+
+void ParquetReaderCli::prepareParquetReaderCli() {
+  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  auto input = std::make_unique<dwio::common::BufferedInput>(
+      file_, readerOpts.memoryPool());
+
+  auto reader = std::make_unique<ParquetReader>(std::move(input), readerOpts);
+
+  dwio::common::RowReaderOptions rowReaderOpts;
+  rowReaderOpts.select(
+      std::make_shared<facebook::velox::dwio::common::ColumnSelector>(
+          rowType_, rowType_->names()));
+  rowReaderOpts.setScanSpec(scanSpec_);
+  rowReader_ = reader->createRowReader(rowReaderOpts);
+}
+
+uint64_t ParquetReaderCli::read(std::shared_ptr<BaseVector>& result) {
+  return read(result, readBatchSize_);
+}
+
+uint64_t ParquetReaderCli::read(
+    std::shared_ptr<BaseVector>& result,
+    uint64_t batchSize) {
+  auto numRowsRead = rowReader_->next(batchSize, result);
+  if (numRowsRead == 0) {
+    return 0;
+  }
+
+  auto rowVector = result->asUnchecked<RowVector>();
+  for (auto i = 0; i < rowVector->childrenSize(); ++i) {
+    rowVector->childAt(i)->loadedVector();
+  }
+
+  return numRowsRead;
+}
+} // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/ParquetReaderCli.h
+++ b/velox/dwio/parquet/reader/ParquetReaderCli.h
@@ -1,0 +1,66 @@
+/*
+* Copyright (c) Facebook, Inc. and its affiliates.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "velox/dwio/common/ScanSpec.h"
+#include "velox/dwio/parquet/reader/ParquetReader.h"
+
+namespace facebook::velox::parquet {
+
+// This ParquetReaderCli can be used to read Parquet files directly.
+class ParquetReaderCli {
+public:
+ explicit ParquetReaderCli(
+     uint32_t readBatchSize,
+     std::shared_ptr<memory::MemoryPool> rootPool,
+     std::shared_ptr<memory::MemoryPool> leafPool,
+     std::shared_ptr<ReadFile> file,
+     std::shared_ptr<const RowType> rowType,
+     std::shared_ptr<common::ScanSpec> scanSpec)
+     : readBatchSize_(readBatchSize),
+       file_(file),
+       rootPool_(rootPool),
+       leafPool_(leafPool),
+       rowType_(rowType),
+       scanSpec_(scanSpec) {
+   prepareParquetReaderCli();
+ }
+
+ /**
+  * Read at most readBatchSize_ rows from the file.
+  * @param result Vector to collect the results.
+  * @return number of rows that have been read in this round. If filters exist,
+  * the number of rows in the result vector might be smaller because some rows
+  * might be discarted after applying the filters. It returns none-zero values
+  * if there are remaining data in the file. Otherwise, it returns 0 when the
+  * file is exhausted.
+  */
+ uint64_t read(std::shared_ptr<BaseVector>& result);
+
+ uint64_t read(std::shared_ptr<BaseVector>& result, uint64_t batchSize);
+
+private:
+ void prepareParquetReaderCli();
+
+ uint32_t readBatchSize_;
+ std::shared_ptr<ReadFile> file_;
+ std::shared_ptr<memory::MemoryPool> rootPool_;
+ std::shared_ptr<memory::MemoryPool> leafPool_;
+ std::shared_ptr<const RowType> rowType_;
+ std::shared_ptr<common::ScanSpec> scanSpec_;
+ std::unique_ptr<dwio::common::RowReader> rowReader_;
+};
+
+} // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/tests/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/reader/CMakeLists.txt
@@ -99,6 +99,16 @@ target_link_libraries(
   velox_link_libs
   ${TEST_LINK_LIBS})
 
+add_executable(velox_dwio_parquet_cli_test ParquetReaderCliTest.cpp)
+
+add_test(
+        NAME velox_dwio_parquet_cli_test
+        COMMAND velox_dwio_parquet_cli_test
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(velox_dwio_parquet_cli_test velox_exec_test_lib
+        velox_dwio_native_parquet_reader_cli)
+
 if(${VELOX_ENABLE_ARROW})
 
   add_executable(velox_dwio_parquet_rlebp_decoder_test RleBpDecoderTest.cpp)

--- a/velox/dwio/parquet/tests/reader/ParquetReaderCliTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderCliTest.cpp
@@ -1,0 +1,150 @@
+/*
+* Copyright (c) Facebook, Inc. and its affiliates.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "velox/dwio/parquet/reader/ParquetReaderCli.h"
+#include "velox/dwio/common/tests/utils/DataSetBuilder.h"
+#include "velox/dwio/parquet/tests/ParquetTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::dwio;
+using namespace facebook::velox::dwio::common;
+using namespace facebook::velox::parquet;
+using namespace facebook::velox::test;
+
+const uint32_t kBatchCount = 3;
+const uint32_t kNumRows = 1000000;
+const uint32_t kNumRowsPerGroup = 10000;
+const uint32_t kDefaultReadingSize = 1000;
+
+class ParquetReaderCliTest : public ParquetTestBase {
+protected:
+ void SetUp() override {}
+
+ void createFiles(uint32_t numFiles, std::shared_ptr<const RowType> rowType) {
+   rootPool_ = memory::memoryManager()->addRootPool("ParquetReaderCliTest");
+   leafPool_ = rootPool_->addLeafChild("ParquetReaderCliTest");
+   fileDirectory_ = exec::test::TempDirectoryPath::create();
+   auto dataSetBuilder_ = std::make_unique<DataSetBuilder>(*leafPool_, 0);
+
+   for (uint32_t i = 0; i < numFiles; i++) {
+     auto fileName = std::to_string(i) + ".parquet";
+     auto path = fileDirectory_->getPath() + "/" + fileName;
+     auto localWriteFile = std::make_unique<LocalWriteFile>(path, true, false);
+     auto sink =
+         std::make_unique<WriteFileSink>(std::move(localWriteFile), path);
+     facebook::velox::parquet::WriterOptions options;
+     options.memoryPool = rootPool_.get();
+
+     auto writer_ = std::make_unique<facebook::velox::parquet::Writer>(
+         std::move(sink), options, rowType);
+
+     auto batches =
+         dataSetBuilder_->makeDataset(rowType, kBatchCount, kNumRows)
+             .withRowGroupSpecificData(kNumRowsPerGroup)
+             .build();
+
+     for (auto& batch : *batches) {
+       writer_->write(batch);
+     }
+     writer_->flush();
+     writer_->close();
+     files_.push_back(std::make_shared<LocalReadFile>(path));
+   }
+ }
+
+ std::shared_ptr<memory::MemoryPool> rootPool_;
+ std::shared_ptr<memory::MemoryPool> leafPool_;
+ std::shared_ptr<facebook::velox::exec::test::TempDirectoryPath>
+     fileDirectory_;
+ std::vector<std::shared_ptr<ReadFile>> files_;
+};
+
+TEST_F(ParquetReaderCliTest, readLocalFiles) {
+ auto rowType =
+     ROW({"bigint", "double", "string"}, {BIGINT(), DOUBLE(), VARCHAR()});
+ createFiles(3, rowType);
+
+ std::unique_ptr<FilterGenerator> filterGenerator =
+     std::make_unique<FilterGenerator>(rowType, 0);
+ auto filterBuilder = [&]() {
+   SubfieldFilters filters;
+   return filters;
+ };
+ auto scanSpec = filterGenerator->makeScanSpec(std::move(filterBuilder()));
+
+ for (auto file : files_) {
+   auto reader = ParquetReaderCli(
+       kDefaultReadingSize, rootPool_, leafPool_, file, rowType, scanSpec);
+   auto hasData = true;
+   uint32_t totalSize = 0;
+
+   while (hasData) {
+     auto result = BaseVector::create(rowType, 0, leafPool_.get());
+     auto numRowsRead = reader.read(result);
+
+     hasData = numRowsRead != 0;
+     if (hasData) {
+       auto rowVector = result->asUnchecked<RowVector>();
+
+       totalSize += rowVector->size();
+       EXPECT_EQ(numRowsRead, rowVector->size());
+     }
+   }
+
+   EXPECT_EQ(totalSize, kBatchCount * kNumRows);
+ }
+}
+
+TEST_F(ParquetReaderCliTest, readLocalFilesWithFilter) {
+ auto rowType =
+     ROW({"bigint", "double", "string"}, {BIGINT(), DOUBLE(), VARCHAR()});
+ createFiles(3, rowType);
+
+ std::unique_ptr<FilterGenerator> filterGenerator =
+     std::make_unique<FilterGenerator>(rowType, 0);
+ auto filterBuilder = [&]() {
+   SubfieldFilters filters;
+   filters[Subfield("bigint")] =
+       std::make_unique<facebook::velox::common::BigintRange>(
+           std::numeric_limits<int64_t>::min(),
+           std::numeric_limits<int64_t>::max(),
+           false);
+   return filters;
+ };
+ auto scanSpec = filterGenerator->makeScanSpec(std::move(filterBuilder()));
+
+ for (auto file : files_) {
+   auto reader = ParquetReaderCli(
+       kDefaultReadingSize, rootPool_, leafPool_, file, rowType, scanSpec);
+
+   auto hasData = true;
+   uint32_t totalSize = 0;
+
+   while (hasData) {
+     auto result = BaseVector::create(rowType, 0, leafPool_.get());
+     auto numRowsRead = reader.read(result);
+
+     hasData = numRowsRead != 0;
+
+     if (hasData) {
+       auto rowVector = result->asUnchecked<RowVector>();
+       totalSize += rowVector->size();
+     }
+   }
+
+   EXPECT_NE(totalSize, kBatchCount * kNumRows);
+ }
+}


### PR DESCRIPTION
This command introduces a Parquet Reader CLI, which provide APIs to read Parquet files directly. This CLI also introduces skip() API to skip several rows while reading the file.