### PR TITLE
Changes to compile with Clang15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,11 @@ if(${VELOX_FORCE_COLORED_OUTPUT})
   endif()
 endif()
 
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"
+   AND "${CMAKE_CXX_COMPILER_VERSION}" VERSION_GREATER_EQUAL 15)
+  set(CMAKE_EXE_LINKER_FLAGS "-latomic")
+endif()
+
 # At the moment we prefer static linking but by default cmake looks for shared
 # libs first. This will still fallback to shared libs when static ones are not
 # found

--- a/README.md
+++ b/README.md
@@ -138,6 +138,22 @@ $ make
 
 Note that `setup-adapters.sh` supports MacOS and Ubuntu 20.04 or later.
 
+### Using Clang on Linux
+
+Clang 15 can be additionally installed during the setup step for Ubuntu 22.04/24.04
+and CentOS 9 by setting the `USE_CLANG` environment variable prior to running the platform specific setup script.
+```shell
+$ export USE_CLANG=true
+```
+This will install and use Clang 15 to build the dependencies instead of using the default GCC compiler.
+
+Once completed, and before running any `make` command, set the compiler to be used:
+```shell
+$ export CC=/usr/bin/clang-15
+$ export CXX=/usr/bin/clang++-15
+$ make
+```
+
 ### Building Velox
 
 Run `make` in the root directory to compile the sources. For development, use


### PR DESCRIPTION
Clang needs lib atomic symbols to be resolved for a number of executables. It is added as needed.
```
/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13/../../../../bin/ld: velox/exec/libvelox_exec.a(Task.cpp.o): in function `std::__atomic_base<unsigned int>::is_lock_free() const': /opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/bits/atomic_base.h:460: undefined reference to `__atomic_is_lock_free' /opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13/../../../../bin/ld: velox/exec/libvelox_exec.a(Task.cpp.o): in function `std::__atomic_base<long>::is_lock_free() const': /opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/bits/atomic_base.h:460: undefined reference to `__atomic_is_lock_free'clang++: error: linker command failed with exit code 1 (use -v to see invocation)ninja: build stopped: subcommand failed.
```