### PR TITLE
Build boost statically

### DIFF
--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -103,7 +103,7 @@ function install_boost {
   (
    cd boost
    ./bootstrap.sh --prefix=/usr/local
-   ./b2 "-j$(nproc)" -d0 install threading=multi --without-python
+   ./b2 "-j$(nproc)" -d0 install link=static threading=multi --without-python
   )
 }
 
@@ -148,7 +148,7 @@ function install_folly {
   wget_and_untar https://github.com/facebook/folly/archive/refs/tags/${FB_OS_VERSION}.tar.gz folly
   (
     cd folly
-    cmake_install -DFOLLY_HAVE_INT128_T=ON
+    cmake_install -DFOLLY_HAVE_INT128_T=ON -DBOOST_LINK_STATIC=ON
   )
 }
 

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -101,12 +101,12 @@ function install_fmt {
 function install_boost {
   github_checkout boostorg/boost "${BOOST_VERSION}" --recursive
   ./bootstrap.sh --prefix=/usr/local
-  ${SUDO} ./b2 "-j$(nproc)" -d0 install threading=multi --without-python
+  ${SUDO} ./b2 "-j$(nproc)" -d0 install link=static threading=multi --without-python
 }
 
 function install_folly {
   github_checkout facebook/folly "${FB_OS_VERSION}"
-  cmake_install -DBUILD_TESTS=OFF -DFOLLY_HAVE_INT128_T=ON
+  cmake_install -DBUILD_TESTS=OFF -DFOLLY_HAVE_INT128_T=ON -DBOOST_LINK_STATIC=ON
 }
 
 function install_fizz {


### PR DESCRIPTION
This change modifies boost to build statically.
The benefit is that users will not have to install boost on each node. Considering that a multi-node deployment could consists on dozens of nodes, this changes saves significant time and resources.