### PR TITLE
Fix incorrect result of approx_percentile in window operations

### DIFF
--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
@@ -213,6 +213,7 @@ class ApproxPercentileAggregate : public exec::Aggregate {
               vector_size_t index) {
             digest.estimateQuantiles(percentiles, rawValues + elementsCount);
             result->setOffsetAndSize(index, elementsCount, percentiles.size());
+            result->setNull(index, false);
             elementsCount += percentiles.size();
           });
     } else {


### PR DESCRIPTION
Summary:
approx_percentile(x, percentiles) returns incorrect result in a window
operation where a frame that should return non-NULL follows a frame
that returns NULL. Before the fix, the window operation returns NULL
for both frames. This is because
AggregationWindowFunction::computeAggregate() reuses the same
result vector across frames. It calls BaseVector::prepareForReuse()
before computing the aggregation for a frame. prepareForReuse()
doesn't clear the nulls buffer of the vector as it expects the code that
reuse the vector to set nulls properly. ApproxPercentileAggregate,
however, doesn't set the result rows to be non-null in the code path
for array-typed percentiles.

This diff fixes this bug by setting the nulls buffer properly.

Differential Revision: D59257658
