### PR TITLE
Add session timezone to DWRF/ORC TimestampColumnWriter&TimestampColumnReader

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -269,6 +269,7 @@ class ConnectorQueryCtx {
       const std::string& planNodeId,
       int driverId,
       const std::string& sessionTimezone,
+      bool adjustTimestampToTimezone = false,
       folly::CancellationToken cancellationToken = {})
       : operatorPool_(operatorPool),
         connectorPool_(connectorPool),
@@ -283,6 +284,7 @@ class ConnectorQueryCtx {
         driverId_(driverId),
         planNodeId_(planNodeId),
         sessionTimezone_(sessionTimezone),
+        adjustTimestampToTimezone_(adjustTimestampToTimezone),
         cancellationToken_(std::move(cancellationToken)) {
     VELOX_CHECK_NOT_NULL(sessionProperties);
   }
@@ -351,6 +353,11 @@ class ConnectorQueryCtx {
     return sessionTimezone_;
   }
 
+  /// Use legacy TIMESTAMP semantics
+  const bool adjustTimestampToTimezone() const {
+    return adjustTimestampToTimezone_;
+  }
+
   /// Returns the cancellation token associated with this task.
   const folly::CancellationToken& cancellationToken() const {
     return cancellationToken_;
@@ -370,6 +377,7 @@ class ConnectorQueryCtx {
   const int driverId_;
   const std::string planNodeId_;
   const std::string sessionTimezone_;
+  bool adjustTimestampToTimezone_;
   const folly::CancellationToken cancellationToken_;
 };
 

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -548,6 +548,8 @@ void configureReaderOptions(
     const auto timezone = tz::locateZone(sessionTzName);
     readerOptions.setSessionTimezone(timezone);
   }
+  readerOptions.setAdjustTimestampToTimezone(
+      connectorQueryCtx->adjustTimestampToTimezone());
 
   if (readerOptions.fileFormat() != dwio::common::FileFormat::UNKNOWN) {
     VELOX_CHECK(

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -778,6 +778,13 @@ uint32_t HiveDataSink::appendWriter(const HiveWriterId& id) {
         compressionLevel.value_or(kDefaultZstdCompressionLevel);
   }
 
+  const auto& sessionTzName = connectorQueryCtx_->sessionTimezone();
+  if (!sessionTzName.empty()) {
+    options->sessionTimezone = tz::locateZone(sessionTzName);
+  }
+  options->adjustTimestampToTimezone =
+      connectorQueryCtx_->adjustTimestampToTimezone();
+
   // Prevents the memory allocation during the writer creation.
   WRITER_NON_RECLAIMABLE_SECTION_GUARD(writerInfo_.size() - 1);
   auto writer = writerFactory_->createWriter(

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -502,6 +502,11 @@ class ReaderOptions : public io::ReaderOptions {
     return *this;
   }
 
+  ReaderOptions& setAdjustTimestampToTimezone(bool adjustTimestampToTimezone) {
+    adjustTimestampToTimezone_ = adjustTimestampToTimezone;
+    return *this;
+  }
+
   /// Gets the desired tail location.
   uint64_t tailLocation() const {
     return tailLocation_;
@@ -543,6 +548,10 @@ class ReaderOptions : public io::ReaderOptions {
 
   const tz::TimeZone* getSessionTimezone() const {
     return sessionTimezone_;
+  }
+
+  bool adjustTimestampToTimezone() const {
+    return adjustTimestampToTimezone_;
   }
 
   bool fileColumnNamesReadAsLowerCase() const {
@@ -591,6 +600,7 @@ class ReaderOptions : public io::ReaderOptions {
   std::shared_ptr<random::RandomSkipTracker> randomSkip_;
   std::shared_ptr<velox::common::ScanSpec> scanSpec_;
   const tz::TimeZone* sessionTimezone_{nullptr};
+  bool adjustTimestampToTimezone_{false};
 };
 
 struct WriterOptions {
@@ -617,6 +627,9 @@ struct WriterOptions {
   std::map<std::string, std::string> serdeParameters;
   std::optional<uint8_t> zlibCompressionLevel;
   std::optional<uint8_t> zstdCompressionLevel;
+
+  const tz::TimeZone* sessionTimezone{nullptr};
+  bool adjustTimestampToTimezone{false};
 
   // WriterOption implementations should provide this function to specify how to
   // process format-specific session and connector configs.

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
@@ -94,6 +94,7 @@ void E2EFilterTestBase::readWithoutFilter(
     const std::vector<RowVectorPtr>& batches,
     uint64_t& time) {
   dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   dwio::common::RowReaderOptions rowReaderOpts;
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
@@ -147,6 +148,7 @@ void E2EFilterTestBase::readWithFilter(
     bool useValueHook,
     bool skipCheck) {
   dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   dwio::common::RowReaderOptions rowReaderOpts;
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
@@ -455,6 +457,7 @@ void E2EFilterTestBase::testMetadataFilterImpl(
   specC->setProjectOut(true);
   specC->setChannel(0);
   ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   RowReaderOptions rowReaderOpts;
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
@@ -651,6 +654,7 @@ void E2EFilterTestBase::testSubfieldsPruning() {
   specD->childByName(common::ScanSpec::kMapKeysFieldName)
       ->setFilter(common::createBigintValues({1}, false));
   ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   RowReaderOptions rowReaderOpts;
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
@@ -716,6 +720,7 @@ void E2EFilterTestBase::testMutationCornerCases() {
   auto& rowType = batches[0]->type();
   writeToMemory(rowType, batches, false);
   ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
   auto reader = makeReader(readerOpts, std::move(input));

--- a/velox/dwio/dwrf/common/Config.cpp
+++ b/velox/dwio/dwrf/common/Config.cpp
@@ -27,7 +27,7 @@ Config::Entry<WriterVersion> Config::WRITER_VERSION(
 
 Config::Entry<common::CompressionKind> Config::COMPRESSION(
     "hive.exec.orc.compress",
-    common::CompressionKind::CompressionKind_ZSTD);
+    common::CompressionKind::CompressionKind_NONE);
 
 Config::Entry<int32_t> Config::ZLIB_COMPRESSION_LEVEL(
     "hive.exec.orc.compress.zlib.level",

--- a/velox/dwio/dwrf/common/Config.cpp
+++ b/velox/dwio/dwrf/common/Config.cpp
@@ -27,7 +27,7 @@ Config::Entry<WriterVersion> Config::WRITER_VERSION(
 
 Config::Entry<common::CompressionKind> Config::COMPRESSION(
     "hive.exec.orc.compress",
-    common::CompressionKind::CompressionKind_NONE);
+    common::CompressionKind::CompressionKind_ZSTD);
 
 Config::Entry<int32_t> Config::ZLIB_COMPRESSION_LEVEL(
     "hive.exec.orc.compress.zlib.level",

--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/dwio/dwrf/reader/ColumnReader.h"
+#include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/common/IntCodecCommon.h"
 #include "velox/dwio/common/IntDecoder.h"
 #include "velox/dwio/common/ParallelFor.h"
@@ -35,6 +36,7 @@
 
 namespace facebook::velox::dwrf {
 
+using common::testutil::TestValue;
 using dwio::common::IntDecoder;
 using memory::MemoryPool;
 
@@ -52,7 +54,11 @@ void fillTimestamps(
     const uint64_t* nullsPtr,
     const int64_t* secondsPtr,
     const uint64_t* nanosPtr,
-    vector_size_t numValues) {
+    vector_size_t numValues,
+    const tz::TimeZone* sessionTimezone,
+    const bool adjustTimestampToTimezone) {
+  TestValue::adjust(
+      "facebook::velox::dwrf::detail::fillTimestamps", (void*)sessionTimezone);
   for (vector_size_t i = 0; i < numValues; i++) {
     if (!nullsPtr || !bits::isBitNull(nullsPtr, i)) {
       auto nanos = nanosPtr[i];
@@ -63,11 +69,21 @@ void fillTimestamps(
           nanos *= 10;
         }
       }
-      auto seconds = secondsPtr[i] + dwio::common::EPOCH_OFFSET;
+
+      int64_t seconds;
+      if (sessionTimezone) {
+        seconds = secondsPtr[i] + dwio::common::UTC_EPOCH_OFFSET;
+      } else {
+        // Compatible with meta internal use cases.
+        seconds = secondsPtr[i] + dwio::common::EPOCH_OFFSET;
+      }
       if (seconds < 0 && nanos != 0) {
         seconds -= 1;
       }
       timestamps[i] = Timestamp(seconds, nanos);
+      if (adjustTimestampToTimezone && sessionTimezone) {
+        timestamps[i].toGMT(*sessionTimezone);
+      }
     }
   }
 }
@@ -752,6 +768,9 @@ class TimestampColumnReader : public ColumnReader {
   std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ true>> seconds;
   std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> nano;
 
+  const tz::TimeZone* sessionTimezone_{nullptr};
+  bool adjustTimestampToTimezone_{false};
+
   BufferPtr secondsBuffer_;
   BufferPtr nanosBuffer_;
 
@@ -797,6 +816,9 @@ TimestampColumnReader::TimestampColumnReader(
       memoryPool_,
       nanoVInts,
       dwio::common::LONG_BYTE_SIZE);
+
+  sessionTimezone_ = stripe.getSessionTimezone();
+  adjustTimestampToTimezone_ = stripe.adjustTimestampToTimezone();
 }
 
 uint64_t TimestampColumnReader::skip(uint64_t numValues) {
@@ -843,7 +865,13 @@ void TimestampColumnReader::next(
   nano->next(reinterpret_cast<int64_t*>(nanosData), numValues, nullsPtr);
   auto* valuesPtr = values->asMutable<Timestamp>();
   detail::fillTimestamps(
-      valuesPtr, nullsPtr, secondsData, nanosData, numValues);
+      valuesPtr,
+      nullsPtr,
+      secondsData,
+      nanosData,
+      numValues,
+      sessionTimezone_,
+      adjustTimestampToTimezone_);
 }
 
 template <class T>

--- a/velox/dwio/dwrf/reader/ColumnReader.h
+++ b/velox/dwio/dwrf/reader/ColumnReader.h
@@ -192,7 +192,9 @@ void fillTimestamps(
     const uint64_t* nulls,
     const int64_t* seconds,
     const uint64_t* nanos,
-    vector_size_t numValues);
+    vector_size_t numValues,
+    const tz::TimeZone* sessionTimezone,
+    const bool adjustTimestampToTimezone);
 
 } // namespace detail
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/DwrfData.h
+++ b/velox/dwio/dwrf/reader/DwrfData.h
@@ -149,6 +149,14 @@ class DwrfParams : public dwio::common::FormatParams {
     return streamLabels_;
   }
 
+  const tz::TimeZone* getSessionTimezone() const {
+    return stripeStreams_.getSessionTimezone();
+  }
+
+  bool adjustTimestampToTimezone() const {
+    return stripeStreams_.adjustTimestampToTimezone();
+  }
+
  private:
   StripeStreams& stripeStreams_;
   FlatMapContext flatMapContext_;

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -780,26 +780,15 @@ std::optional<size_t> DwrfRowReader::estimatedRowSize() const {
 DwrfReader::DwrfReader(
     const ReaderOptions& options,
     std::unique_ptr<dwio::common::BufferedInput> input)
-    : readerBase_(std::make_unique<ReaderBase>(
-          options.memoryPool(),
-          std::move(input),
-          options.decrypterFactory(),
-          options.footerEstimatedSize(),
-          options.filePreloadThreshold(),
-          options.fileFormat() == FileFormat::ORC ? FileFormat::ORC
-                                                  : FileFormat::DWRF,
-          options.fileColumnNamesReadAsLowerCase(),
-          options.randomSkip(),
-          options.scanSpec())),
-      options_(options) {
+    : readerBase_(std::make_unique<ReaderBase>(options, std::move(input))) {
   // If we are not using column names to map table columns to file columns,
   // then we use indices. In that case we need to ensure the names completely
   // match, because we are still mapping columns by names further down the
   // code. So we rename column names in the file schema to match table schema.
   // We test the options to have 'fileSchema' (actually table schema) as most
   // of the unit tests fail to provide it.
-  if ((!options_.useColumnNamesForColumnMapping()) &&
-      (options_.fileSchema() != nullptr)) {
+  if ((!readerBase_->getReaderOptions().useColumnNamesForColumnMapping()) &&
+      (readerBase_->getReaderOptions().fileSchema() != nullptr)) {
     updateColumnNamesFromTableSchema();
   }
 }
@@ -896,7 +885,7 @@ TypePtr updateColumnNames(
 } // namespace
 
 void DwrfReader::updateColumnNamesFromTableSchema() {
-  const auto& tableSchema = options_.fileSchema();
+  const auto& tableSchema = readerBase_->getReaderOptions().fileSchema();
   const auto& fileSchema = readerBase_->getSchema();
   readerBase_->setSchema(std::dynamic_pointer_cast<const RowType>(
       updateColumnNames(fileSchema, tableSchema, "", "")));

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -346,7 +346,6 @@ class DwrfReader : public dwio::common::Reader {
 
  private:
   std::shared_ptr<ReaderBase> readerBase_;
-  const dwio::common::ReaderOptions options_;
 };
 
 class DwrfReaderFactory : public dwio::common::ReaderFactory {

--- a/velox/dwio/dwrf/reader/ReaderBase.cpp
+++ b/velox/dwio/dwrf/reader/ReaderBase.cpp
@@ -77,44 +77,21 @@ FooterStatisticsImpl::FooterStatisticsImpl(
 }
 
 ReaderBase::ReaderBase(
-    MemoryPool& pool,
-    std::unique_ptr<dwio::common::BufferedInput> input,
-    FileFormat fileFormat)
-    : ReaderBase(
-          pool,
-          std::move(input),
-          nullptr,
-          dwio::common::ReaderOptions::kDefaultFooterEstimatedSize,
-          dwio::common::ReaderOptions::kDefaultFilePreloadThreshold,
-          fileFormat) {}
-
-ReaderBase::ReaderBase(
-    MemoryPool& pool,
-    std::unique_ptr<dwio::common::BufferedInput> input,
-    std::shared_ptr<DecrypterFactory> decryptorFactory,
-    uint64_t footerEstimatedSize,
-    uint64_t filePreloadThreshold,
-    FileFormat fileFormat,
-    bool fileColumnNamesReadAsLowerCase,
-    std::shared_ptr<random::RandomSkipTracker> randomSkip,
-    std::shared_ptr<velox::common::ScanSpec> scanSpec)
-    : pool_{pool},
+    const dwio::common::ReaderOptions& options,
+    std::unique_ptr<dwio::common::BufferedInput> input)
+    : options_{options},
       arena_(std::make_unique<google::protobuf::Arena>()),
-      decryptorFactory_(decryptorFactory),
-      footerEstimatedSize_(footerEstimatedSize),
-      filePreloadThreshold_(filePreloadThreshold),
       input_(std::move(input)),
-      randomSkip_(std::move(randomSkip)),
-      scanSpec_(std::move(scanSpec)),
       fileLength_(input_->getReadFile()->size()) {
   process::TraceContext trace("ReaderBase::ReaderBase");
   // TODO: make a config
   DWIO_ENSURE(fileLength_ > 0, "ORC file is empty");
   VELOX_CHECK_GE(fileLength_, 4, "File size too small");
 
-  const auto preloadFile = fileLength_ <= filePreloadThreshold_;
-  const uint64_t readSize =
-      preloadFile ? fileLength_ : std::min(fileLength_, footerEstimatedSize_);
+  const auto preloadFile = fileLength_ <= options_.filePreloadThreshold();
+  const uint64_t readSize = preloadFile
+      ? fileLength_
+      : std::min(fileLength_, options_.footerEstimatedSize());
   if (input_->supportSyncLoad()) {
     input_->enqueue({fileLength_ - readSize, readSize, "footer"});
     input_->load(preloadFile ? LogType::FILE : LogType::FOOTER);
@@ -135,7 +112,7 @@ ReaderBase::ReaderBase(
       fileLength_,
       "Corrupted file, Post script size is invalid");
 
-  if (fileFormat == FileFormat::DWRF) {
+  if (options.fileFormat() == FileFormat::DWRF) {
     auto postScript = ProtoUtils::readProto<proto::PostScript>(
         input_->read(fileLength_ - psLength_ - 1, psLength_, LogType::FOOTER));
     postScript_ = std::make_unique<PostScript>(std::move(postScript));
@@ -173,7 +150,7 @@ ReaderBase::ReaderBase(
 
   auto footerStream = input_->read(
       fileLength_ - psLength_ - footerSize - 1, footerSize, LogType::FOOTER);
-  if (fileFormat == FileFormat::DWRF) {
+  if (options.fileFormat() == FileFormat::DWRF) {
     auto footer =
         google::protobuf::Arena::CreateMessage<proto::Footer>(arena_.get());
     ProtoUtils::readProtoInto<proto::Footer>(
@@ -190,7 +167,7 @@ ReaderBase::ReaderBase(
   }
 
   schema_ = std::dynamic_pointer_cast<const RowType>(
-      convertType(*footer_, 0, fileColumnNamesReadAsLowerCase));
+      convertType(*footer_, 0, options_.fileColumnNamesReadAsLowerCase()));
   VELOX_CHECK_NOT_NULL(schema_, "invalid schema");
 
   // load stripe index/footer cache
@@ -204,8 +181,8 @@ ReaderBase::ReaderBase(
           input_->read(cacheOffset, cacheSize, LogType::FOOTER));
       input_->load(LogType::FOOTER);
     } else {
-      auto cacheBuffer =
-          std::make_shared<dwio::common::DataBuffer<char>>(pool, cacheSize);
+      auto cacheBuffer = std::make_shared<dwio::common::DataBuffer<char>>(
+          options_.memoryPool(), cacheSize);
       input_->read(cacheOffset, cacheSize, LogType::FOOTER)
           ->readFully(cacheBuffer->data(), cacheSize);
       cache_ = std::make_unique<StripeMetadataCache>(
@@ -226,7 +203,8 @@ ReaderBase::ReaderBase(
     }
   }
   // initialize file decrypter
-  handler_ = DecryptionHandler::create(*footer_, decryptorFactory_.get());
+  handler_ =
+      DecryptionHandler::create(*footer_, options_.decrypterFactory().get());
 }
 
 std::vector<uint64_t> ReaderBase::getRowsPerStripe() const {

--- a/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.h
@@ -59,6 +59,8 @@ class SelectiveTimestampColumnReader
   // Values from copied from 'seconds_'. Nanos are in 'values_'.
   BufferPtr secondsValues_;
   RleVersion version_;
+  const tz::TimeZone* sessionTimezone_{nullptr};
+  bool adjustTimestampToTimezone_{false};
 };
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/StripeStream.h
+++ b/velox/dwio/dwrf/reader/StripeStream.h
@@ -105,6 +105,18 @@ class StripeStreams {
    */
   virtual const dwio::common::ColumnSelector& getColumnSelector() const = 0;
 
+  /**
+   * Session timezone used for reading Timestamp.
+   */
+  virtual const tz::TimeZone* getSessionTimezone() const = 0;
+
+  /**
+   * Whether to adjust Timestamp to the timeZone obtained through
+   * getSessionTimezone(). This is used to be compatible with the
+   * old logic of Presto.
+   */
+  virtual bool adjustTimestampToTimezone() const = 0;
+
   // Get row reader options
   virtual const dwio::common::RowReaderOptions& getRowReaderOptions() const = 0;
 
@@ -251,6 +263,15 @@ class StripeStreamsImpl : public StripeStreamsBase {
 
   const dwio::common::ColumnSelector& getColumnSelector() const override {
     return *selector_;
+  }
+
+  const tz::TimeZone* getSessionTimezone() const override {
+    return readState_->readerBase->getReaderOptions().getSessionTimezone();
+  }
+
+  bool adjustTimestampToTimezone() const override {
+    return readState_->readerBase->getReaderOptions()
+        .adjustTimestampToTimezone();
   }
 
   const dwio::common::RowReaderOptions& getRowReaderOptions() const override {

--- a/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
@@ -195,6 +195,7 @@ class ColumnWriterStatsTest : public ::testing::Test {
     auto input = std::make_unique<BufferedInput>(readFile, *leafPool_);
 
     dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+    readerOpts.setFileFormat(FileFormat::DWRF);
     RowReaderOptions rowReaderOpts;
     auto reader = std::make_unique<DwrfReader>(readerOpts, std::move(input));
     return reader->createRowReader(rowReaderOpts);

--- a/velox/dwio/dwrf/test/ColumnWriterTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTest.cpp
@@ -153,6 +153,14 @@ class TestStripeStreams : public StripeStreamsBase {
     return selector_;
   }
 
+  const tz::TimeZone* getSessionTimezone() const override {
+    return context_.getSessionTimezone();
+  }
+
+  bool adjustTimestampToTimezone() const override {
+    return context_.adjustTimestampToTimezone();
+  }
+
   const RowReaderOptions& getRowReaderOptions() const override {
     return options_;
   }

--- a/velox/dwio/dwrf/test/ColumnWriterTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTest.cpp
@@ -1638,6 +1638,7 @@ std::unique_ptr<DwrfReader> getDwrfReader(
 
   std::string data(sinkPtr->data(), sinkPtr->size());
   dwio::common::ReaderOptions readerOpts{&leafPool};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   return std::make_unique<DwrfReader>(
       readerOpts,
       std::make_unique<BufferedInput>(

--- a/velox/dwio/dwrf/test/E2EReaderTest.cpp
+++ b/velox/dwio/dwrf/test/E2EReaderTest.cpp
@@ -175,6 +175,7 @@ TEST_P(E2EReaderTest, SharedDictionaryFlatmapReadAsStruct) {
   writer.reset();
 
   dwio::common::ReaderOptions readerOpts{pool.get()};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   auto bufferedInput = std::make_unique<BufferedInput>(
       std::make_shared<LocalReadFile>(path), *pool);
   auto reader = DwrfReader::create(std::move(bufferedInput), readerOpts);

--- a/velox/dwio/dwrf/test/E2EWriterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTest.cpp
@@ -103,6 +103,7 @@ class E2EWriterTest : public testing::Test {
     writer.close();
 
     dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+    readerOpts.setFileFormat(FileFormat::DWRF);
     RowReaderOptions rowReaderOpts;
     auto reader = createReader(*sinkPtr, readerOpts);
     auto rowReader = reader->createRowReader(rowReaderOpts);
@@ -165,6 +166,7 @@ class E2EWriterTest : public testing::Test {
     writer.close();
 
     dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+    readerOpts.setFileFormat(FileFormat::DWRF);
     RowReaderOptions rowReaderOpts;
     auto reader = createReader(*sinkPtr, readerOpts);
     auto rowReader = reader->createRowReader(rowReaderOpts);
@@ -376,7 +378,6 @@ TEST_F(E2EWriterTest, E2E) {
 }
 
 TEST_F(E2EWriterTest, testTmestampTimezone) {
-  google::InstallFailureSignalHandler();
   const size_t batchCount = 4;
   size_t batchSize = 1100;
 
@@ -633,6 +634,7 @@ TEST_F(E2EWriterTest, PresentStreamIsSuppressedOnFlatMap) {
       dwrf::E2EWriterTestUtil::simpleFlushPolicyFactory(true));
 
   dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   RowReaderOptions rowReaderOpts;
   auto reader = createReader(*sinkPtr, readerOpts);
   auto rowReader = reader->createRowReader(rowReaderOpts);
@@ -1015,6 +1017,7 @@ TEST_F(E2EWriterTest, PartialStride) {
   writer.close();
 
   dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   RowReaderOptions rowReaderOpts;
   auto reader = createReader(*sinkPtr, readerOpts);
   ASSERT_EQ(
@@ -1227,6 +1230,7 @@ class E2EEncryptionTest : public E2EWriterTest {
 
     // read it back for compare
     dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+    readerOpts.setFileFormat(FileFormat::DWRF);
     readerOpts.setDecrypterFactory(decrypterFactory);
     return createReader(*sink_, readerOpts);
   }

--- a/velox/dwio/dwrf/test/OrcTest.h
+++ b/velox/dwio/dwrf/test/OrcTest.h
@@ -108,6 +108,14 @@ class MockStripeStreams : public StripeStreams {
     return *getColumnSelectorProxy();
   }
 
+  const tz::TimeZone* getSessionTimezone() const override {
+    return nullptr;
+  }
+
+  bool adjustTimestampToTimezone() const override {
+    return false;
+  }
+
   const dwio::common::RowReaderOptions& getRowReaderOptions() const override {
     auto ptr = getRowReaderOptionsProxy();
     return ptr ? *ptr : options_;

--- a/velox/dwio/dwrf/test/ReaderBaseTests.cpp
+++ b/velox/dwio/dwrf/test/ReaderBaseTests.cpp
@@ -104,6 +104,7 @@ class EncryptedStatsTest : public Test {
         std::make_shared<facebook::velox::InMemoryReadFile>(std::string());
     readerPool_ = pool_->addLeafChild("reader");
     facebook::velox::dwio::common::ReaderOptions readerOpts{readerPool_.get()};
+    readerOpts.setFileFormat(FileFormat::DWRF);
     reader_ = std::make_unique<ReaderBase>(
         readerOpts,
         std::make_unique<BufferedInput>(readFile, *readerPool_),
@@ -214,6 +215,7 @@ std::unique_ptr<ReaderBase> createCorruptedFileReader(
   auto readFile = std::make_shared<facebook::velox::InMemoryReadFile>(
       std::string(sink.data(), sink.size()));
   facebook::velox::dwio::common::ReaderOptions readerOpts{pool.get()};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   return std::make_unique<ReaderBase>(
       readerOpts, std::make_unique<BufferedInput>(readFile, *pool));
 }

--- a/velox/dwio/dwrf/test/ReaderBaseTests.cpp
+++ b/velox/dwio/dwrf/test/ReaderBaseTests.cpp
@@ -103,8 +103,9 @@ class EncryptedStatsTest : public Test {
     auto readFile =
         std::make_shared<facebook::velox::InMemoryReadFile>(std::string());
     readerPool_ = pool_->addLeafChild("reader");
+    facebook::velox::dwio::common::ReaderOptions readerOpts{readerPool_.get()};
     reader_ = std::make_unique<ReaderBase>(
-        *readerPool_,
+        readerOpts,
         std::make_unique<BufferedInput>(readFile, *readerPool_),
         std::make_unique<PostScript>(std::move(ps)),
         footer,
@@ -212,8 +213,9 @@ std::unique_ptr<ReaderBase> createCorruptedFileReader(
   sink.write(std::move(buf));
   auto readFile = std::make_shared<facebook::velox::InMemoryReadFile>(
       std::string(sink.data(), sink.size()));
+  facebook::velox::dwio::common::ReaderOptions readerOpts{pool.get()};
   return std::make_unique<ReaderBase>(
-      *pool, std::make_unique<BufferedInput>(readFile, *pool));
+      readerOpts, std::make_unique<BufferedInput>(readFile, *pool));
 }
 
 class ReaderBaseTest : public Test {

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -241,7 +241,7 @@ void verifyFlatMapReading(
     const std::vector<uint32_t>& expectedPrefetchRowSizes = {},
     const std::vector<bool>& shouldTryPrefetch = {}) {
   dwio::common::ReaderOptions readerOpts{pool};
-
+  readerOpts.setFileFormat(FileFormat::DWRF);
   /* If an extra sanity check is desired you can uncomment the 2 below lines and
    * re-run */
   // readerOpts.setFooterEstimatedSize(257);
@@ -361,6 +361,7 @@ TEST_P(TestFlatMapReader, testReadFlatMapEmptyMap) {
   auto returnFlatVector = GetParam();
 
   dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   RowReaderOptions rowReaderOpts;
   rowReaderOpts.setReturnFlatVector(returnFlatVector);
   std::shared_ptr<const RowType> emptyFileType =
@@ -391,6 +392,7 @@ TEST_P(TestFlatMapReader, testStringKeyLifeCycle) {
 
   VectorPtr batch;
   dwio::common::ReaderOptions readerOptions{pool()};
+  readerOptions.setFileFormat(FileFormat::DWRF);
 
   {
     RowReaderOptions rowReaderOptions;
@@ -506,6 +508,7 @@ class TestFlatMapReaderFlatLayout
 
 TEST_P(TestFlatMapReaderFlatLayout, testCompare) {
   dwio::common::ReaderOptions readerOptions{pool()};
+  readerOptions.setFileFormat(FileFormat::DWRF);
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMSmallFile(), readerOptions.memoryPool()),
       readerOptions);
@@ -539,6 +542,7 @@ TEST_F(TestReader, testReadFlatMapWithKeyFilters) {
   // batch size is set as 1000 in reading
   // file has schema: a int, b struct<a:int, b:float, c:string>, c float
   dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   RowReaderOptions rowReaderOpts;
   // set map key filter for map1 we only need key=1, and map2 only key-1
   auto cs = std::make_shared<ColumnSelector>(
@@ -592,6 +596,7 @@ TEST_F(TestReader, testReadFlatMapWithKeyRejectList) {
   // batch size is set as 1000 in reading
   // file has schema: a int, b struct<a:int, b:float, c:string>, c float
   dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   RowReaderOptions rowReaderOpts;
   auto cs = std::make_shared<ColumnSelector>(
       getFlatmapSchema(), std::vector<std::string>{"map1#[\"!2\",\"!3\"]"});
@@ -647,7 +652,7 @@ TEST_F(TestReader, testStatsCallbackFiredWithFiltering) {
       });
 
   dwio::common::ReaderOptions readerOpts{pool()};
-
+  readerOpts.setFileFormat(FileFormat::DWRF);
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMSmallFile(), readerOpts.memoryPool()),
       readerOpts);
@@ -685,7 +690,7 @@ TEST_F(TestReader, testBlockedIoCallbackFiredBlocking) {
   rowReaderOpts.setEagerFirstStripeLoad(false);
 
   dwio::common::ReaderOptions readerOpts{pool()};
-
+  readerOpts.setFileFormat(FileFormat::DWRF);
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMLargeFile(), readerOpts.memoryPool()),
       readerOpts);
@@ -813,6 +818,7 @@ TEST_F(TestReader, DISABLED_testBlockedIoCallbackFiredWithFirstStripeLoad) {
 
 TEST_F(TestReader, testEstimatedSize) {
   dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   {
     auto reader = DwrfReader::create(
         createFileBufferedInput(getFMSmallFile(), readerOpts.memoryPool()),
@@ -858,7 +864,7 @@ TEST_F(TestReader, testStatsCallbackFiredWithoutFiltering) {
       });
 
   dwio::common::ReaderOptions readerOpts{pool()};
-
+  readerOpts.setFileFormat(FileFormat::DWRF);
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMSmallFile(), readerOpts.memoryPool()),
       readerOpts);
@@ -943,6 +949,7 @@ void verifyFlatmapStructEncoding(
     const std::vector<int32_t>& keysToSelect,
     size_t batchSize = 1000) {
   dwio::common::ReaderOptions readerOpts{pool};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   auto reader = DwrfReader::create(
       createFileBufferedInput(filename, readerOpts.memoryPool()), readerOpts);
 
@@ -1049,6 +1056,7 @@ TEST_F(TestReader, testFlatmapAsStructRequiringKeyList) {
 TEST_F(TestReader, testMismatchSchemaMoreFields) {
   // file has schema: a int, b struct<a:int, b:float, c:string>, c float
   dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   RowReaderOptions rowReaderOpts;
   std::shared_ptr<const RowType> requestedType =
       std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse(
@@ -1094,6 +1102,7 @@ TEST_F(TestReader, testMismatchSchemaMoreFields) {
 TEST_F(TestReader, testMismatchSchemaFewerFields) {
   // file has schema: a int, b struct<a:int, b:float, c:string>, c float
   dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   RowReaderOptions rowReaderOpts;
   std::shared_ptr<const RowType> requestedType =
       std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse(
@@ -1135,6 +1144,7 @@ TEST_F(TestReader, testMismatchSchemaFewerFields) {
 TEST_F(TestReader, testMismatchSchemaNestedMoreFields) {
   // file has schema: a int, b struct<a:int, b:float>, c float
   dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   RowReaderOptions rowReaderOpts;
   std::shared_ptr<const RowType> requestedType =
       std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse(
@@ -1201,6 +1211,7 @@ TEST_F(TestReader, testMismatchSchemaNestedMoreFields) {
 TEST_F(TestReader, testMismatchSchemaNestedFewerFields) {
   // file has schema: a int, b struct<a:int, b:float>, c float
   dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   RowReaderOptions rowReaderOpts;
   std::shared_ptr<const RowType> requestedType =
       std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse(
@@ -1258,6 +1269,7 @@ TEST_F(TestReader, testMismatchSchemaNestedFewerFields) {
 TEST_F(TestReader, testMismatchSchemaIncompatibleNotSelected) {
   // file has schema: a int, b struct<a:int, b:float>, c float
   dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   RowReaderOptions rowReaderOpts;
   std::shared_ptr<const RowType> requestedType =
       std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse(
@@ -1339,6 +1351,7 @@ TEST_F(TestReader, testMismatchSchemaIncompatible) {
 TEST_F(TestReader, fileColumnNamesReadAsLowerCase) {
   // upper.orc holds one columns (Bool_Val: BOOLEAN, b: BIGINT)
   dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   readerOpts.setFileColumnNamesReadAsLowerCase(true);
   auto reader = DwrfReader::create(
       createFileBufferedInput(
@@ -1353,6 +1366,7 @@ TEST_F(TestReader, fileColumnNamesReadAsLowerCaseComplexStruct) {
   // upper_complex.orc holds type
   // Cc:struct<CcLong0:bigint,CcMap1:map<string,struct<CcArray2:array<struct<CcInt3:int>>>>>
   dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   readerOpts.setFileColumnNamesReadAsLowerCase(true);
   auto reader = DwrfReader::create(
       createFileBufferedInput(
@@ -1391,6 +1405,7 @@ TEST_F(TestReader, fileColumnNamesReadAsLowerCaseComplexStruct) {
 
 TEST_F(TestReader, TestStripeSizeCallback) {
   dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   readerOpts.setFilePreloadThreshold(0);
   readerOpts.setFooterEstimatedSize(4);
   RowReaderOptions rowReaderOpts;
@@ -1419,6 +1434,7 @@ TEST_F(TestReader, TestStripeSizeCallback) {
 
 TEST_F(TestReader, TestStripeSizeCallbackLimitsOneStripe) {
   dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   readerOpts.setFilePreloadThreshold(0);
   readerOpts.setFooterEstimatedSize(4);
   RowReaderOptions rowReaderOpts;
@@ -1448,6 +1464,7 @@ TEST_F(TestReader, TestStripeSizeCallbackLimitsOneStripe) {
 
 TEST_F(TestReader, TestStripeSizeCallbackLimitsTwoStripe) {
   dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   readerOpts.setFilePreloadThreshold(0);
   readerOpts.setFooterEstimatedSize(4);
   RowReaderOptions rowReaderOpts;
@@ -1843,6 +1860,7 @@ void testBufferLifeCycle(
       std::make_shared<InMemoryReadFile>(std::move(data)), *pool);
 
   dwio::common::ReaderOptions readerOpts{pool};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   RowReaderOptions rowReaderOpts;
   rowReaderOpts.setReturnFlatVector(true);
   auto reader = std::make_unique<DwrfReader>(readerOpts, std::move(input));
@@ -1901,6 +1919,7 @@ void testFlatmapAsMapFieldLifeCycle(
       std::make_shared<InMemoryReadFile>(std::move(data)), *pool);
 
   dwio::common::ReaderOptions readerOpts{pool};
+  readerOpts.setFileFormat(FileFormat::DWRF);
   RowReaderOptions rowReaderOpts;
   rowReaderOpts.setReturnFlatVector(true);
   auto reader = std::make_unique<DwrfReader>(readerOpts, std::move(input));

--- a/velox/dwio/dwrf/test/StripeReaderBaseTests.cpp
+++ b/velox/dwio/dwrf/test/StripeReaderBaseTests.cpp
@@ -65,9 +65,9 @@ class StripeLoadKeysTest : public Test {
     auto handler =
         DecryptionHandler::create(FooterWrapper(footer_.get()), &factory);
     pool_ = memoryManager()->addLeafPool();
-
+    dwio::common::ReaderOptions readerOpts{pool_.get()};
     reader_ = std::make_unique<ReaderBase>(
-        *pool_,
+        readerOpts,
         std::make_unique<BufferedInput>(
             std::make_shared<InMemoryReadFile>(std::string()), *pool_),
         nullptr,

--- a/velox/dwio/dwrf/test/TestStripeStream.cpp
+++ b/velox/dwio/dwrf/test/TestStripeStream.cpp
@@ -127,8 +127,9 @@ TEST_F(StripeStreamTest, planReads) {
   ProtoUtils::writeType(*type, *footer);
   auto is = std::make_unique<RecordingInputStream>();
   auto isPtr = is.get();
+  facebook::velox::dwio::common::ReaderOptions readerOpts{pool_.get()};
   auto readerBase = std::make_shared<ReaderBase>(
-      *pool_,
+      readerOpts,
       std::make_unique<BufferedInput>(
           std::move(is),
           *pool_,
@@ -186,8 +187,9 @@ TEST_F(StripeStreamTest, filterSequences) {
   ProtoUtils::writeType(*type, *footer);
   auto is = std::make_unique<RecordingInputStream>();
   auto isPtr = is.get();
+  facebook::velox::dwio::common::ReaderOptions readerOpts{pool_.get()};
   auto readerBase = std::make_shared<ReaderBase>(
-      *pool_,
+      readerOpts,
       std::make_unique<BufferedInput>(std::move(is), *pool_),
       std::make_unique<PostScript>(proto::PostScript{}),
       footer,
@@ -253,8 +255,9 @@ TEST_F(StripeStreamTest, zeroLength) {
   ps.set_compression(proto::CompressionKind::ZSTD);
   auto is = std::make_unique<RecordingInputStream>();
   auto isPtr = is.get();
+  facebook::velox::dwio::common::ReaderOptions readerOpts{pool_.get()};
   auto readerBase = std::make_shared<ReaderBase>(
-      *pool_,
+      readerOpts,
       std::make_unique<BufferedInput>(std::move(is), *pool_),
       std::make_unique<PostScript>(std::move(ps)),
       footer,
@@ -345,8 +348,9 @@ TEST_F(StripeStreamTest, planReadsIndex) {
 
   auto is = std::make_unique<RecordingInputStream>();
   auto isPtr = is.get();
+  facebook::velox::dwio::common::ReaderOptions readerOpts{pool_.get()};
   auto readerBase = std::make_shared<ReaderBase>(
-      *pool_,
+      readerOpts,
       std::make_unique<BufferedInput>(std::move(is), *pool_),
       std::make_unique<PostScript>(std::move(ps)),
       footer,
@@ -476,8 +480,9 @@ TEST_F(StripeStreamTest, readEncryptedStreams) {
   *stripeFooter->add_encryptiongroups() = "";
 
   auto readerPool = pool->addLeafChild("reader");
+  facebook::velox::dwio::common::ReaderOptions readerOpts{pool_.get()};
   auto readerBase = std::make_shared<ReaderBase>(
-      *readerPool,
+      readerOpts,
       std::make_unique<BufferedInput>(
           std::make_shared<facebook::velox::InMemoryReadFile>(std::string()),
           *readerPool),
@@ -558,9 +563,10 @@ TEST_F(StripeStreamTest, schemaMismatch) {
   encrypter.setKey("key");
   pw.writeProto(*stripeFooter->add_encryptiongroups(), group, encrypter);
 
+  facebook::velox::dwio::common::ReaderOptions readerOpts{pool_.get()};
   auto readerPool = pool->addLeafChild("reader");
   auto readerBase = std::make_shared<ReaderBase>(
-      *readerPool,
+      readerOpts,
       std::make_unique<BufferedInput>(
           std::make_shared<facebook::velox::InMemoryReadFile>(std::string()),
           *pool_),
@@ -632,6 +638,14 @@ class TestStripeStreams : public StripeStreamsBase {
   const facebook::velox::dwio::common::ColumnSelector& getColumnSelector()
       const override {
     VELOX_UNSUPPORTED();
+  }
+
+  const facebook::velox::tz::TimeZone* getSessionTimezone() const override {
+    VELOX_UNSUPPORTED();
+  }
+
+  bool adjustTimestampToTimezone() const override {
+    return false;
   }
 
   const facebook::velox::dwio::common::RowReaderOptions& getRowReaderOptions()

--- a/velox/dwio/dwrf/test/WriterExtendedTests.cpp
+++ b/velox/dwio/dwrf/test/WriterExtendedTests.cpp
@@ -83,10 +83,13 @@ void testWriterDefaultFlushPolicy(
       numStripesLower,
       numStripesUpper,
       config,
+      /*sessionTzName=*/"",
+      /*useSelectiveColumnReader=*/false,
+      /*adjustTimestampToTimezone=*/false,
       /*flushPolicyFactory=*/nullptr,
       /*layoutPlannerFactory=*/nullptr,
       memoryBudget,
-      false);
+      /*verifyContent=*/false);
 }
 
 class E2EWriterTest : public testing::Test {

--- a/velox/dwio/dwrf/test/WriterTest.cpp
+++ b/velox/dwio/dwrf/test/WriterTest.cpp
@@ -61,7 +61,8 @@ class WriterTest : public Test {
     std::string data(sinkPtr_->data(), sinkPtr_->size());
     auto readFile = std::make_shared<InMemoryReadFile>(std::move(data));
     auto input = std::make_unique<BufferedInput>(std::move(readFile), *pool_);
-    return std::make_unique<ReaderBase>(*pool_, std::move(input));
+    dwio::common::ReaderOptions readerOpts{pool_.get()};
+    return std::make_unique<ReaderBase>(readerOpts, std::move(input));
   }
 
   auto& getContext() {

--- a/velox/dwio/dwrf/test/WriterTest.cpp
+++ b/velox/dwio/dwrf/test/WriterTest.cpp
@@ -62,6 +62,7 @@ class WriterTest : public Test {
     auto readFile = std::make_shared<InMemoryReadFile>(std::move(data));
     auto input = std::make_unique<BufferedInput>(std::move(readFile), *pool_);
     dwio::common::ReaderOptions readerOpts{pool_.get()};
+    readerOpts.setFileFormat(FileFormat::DWRF);
     return std::make_unique<ReaderBase>(readerOpts, std::move(input));
   }
 

--- a/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.h
+++ b/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.h
@@ -43,6 +43,8 @@ class E2EWriterTestUtil {
       const std::shared_ptr<Config>& config,
       std::function<std::unique_ptr<DWRFFlushPolicy>()> flushPolicyFactory =
           nullptr,
+      const tz::TimeZone* sessionTimezone = nullptr,
+      const bool adjustTimestampToTimezone = false,
       std::function<std::unique_ptr<LayoutPlanner>(
           const dwio::common::TypeWithId&)> layoutPlannerFactory = nullptr,
       const int64_t writerMemoryCap = std::numeric_limits<int64_t>::max());
@@ -79,6 +81,8 @@ class E2EWriterTestUtil {
       const std::shared_ptr<Config>& config,
       std::function<std::unique_ptr<DWRFFlushPolicy>()> flushPolicyFactory =
           nullptr,
+      const tz::TimeZone* sessionTimezone = nullptr,
+      const bool adjustTimestampToTimezone = false,
       std::function<std::unique_ptr<LayoutPlanner>(
           const dwio::common::TypeWithId&)> layoutPlannerFactory = nullptr,
       const int64_t writerMemoryCap = std::numeric_limits<int64_t>::max());
@@ -97,6 +101,9 @@ class E2EWriterTestUtil {
       size_t numStripesLower,
       size_t numStripesUpper,
       const std::shared_ptr<Config>& config,
+      const std::string& sessionTzName = "",
+      const bool useSelectiveColumnReader = false,
+      const bool adjustTimestampToTimezone = false,
       std::function<std::unique_ptr<DWRFFlushPolicy>()> flushPolicyFactory =
           nullptr,
       std::function<std::unique_ptr<LayoutPlanner>(

--- a/velox/dwio/dwrf/writer/ColumnWriter.cpp
+++ b/velox/dwio/dwrf/writer/ColumnWriter.cpp
@@ -29,7 +29,6 @@
 
 using namespace facebook::velox::dwio::common;
 using namespace facebook::velox::memory;
-
 namespace facebook::velox::dwrf {
 
 WriterContext::LocalDecodedVector BaseColumnWriter::decode(
@@ -672,7 +671,9 @@ class TimestampColumnWriter : public BaseColumnWriter {
             RleVersion_1,
             newStream(StreamKind::StreamKind_NANO_DATA),
             context.getConfig(Config::USE_VINTS),
-            LONG_BYTE_SIZE)} {
+            LONG_BYTE_SIZE)},
+        sessionTimezone_{context.getSessionTimezone()},
+        adjustTimestampToTimezone_(context.adjustTimestampToTimezone()) {
     reset();
   }
 
@@ -695,14 +696,21 @@ class TimestampColumnWriter : public BaseColumnWriter {
  private:
   std::unique_ptr<IntEncoder<true>> seconds_;
   std::unique_ptr<IntEncoder<false>> nanos_;
+  const tz::TimeZone* sessionTimezone_{nullptr};
+  bool adjustTimestampToTimezone_{false};
 };
 
 namespace {
-FOLLY_ALWAYS_INLINE int64_t formatTime(int64_t seconds, uint64_t nanos) {
+FOLLY_ALWAYS_INLINE int64_t formatTime(
+    Timestamp timestamp,
+    const tz::TimeZone* sessionTimezone,
+    bool adjustTimestampToTimezone) {
+  auto seconds = timestamp.getSeconds();
+  auto nanos = timestamp.getNanos();
   DWIO_ENSURE(seconds >= MIN_SECONDS);
 
   if (seconds < 0 && nanos != 0) {
-    // Adding 1 for neagive seconds is there to imitate the Java ORC writer.
+    // Adding 1 for negative seconds is there to imitate the Java ORC writer.
     // Consider the case where -1500 milliseconds need to be represented.
     // In java world, due to a bug (-1500/1000 will result in -1 or rounding up)
     // Due to this Java represented -1500 millis as -1 for seconds and 5*10^8
@@ -715,6 +723,13 @@ FOLLY_ALWAYS_INLINE int64_t formatTime(int64_t seconds, uint64_t nanos) {
     seconds += 1;
   }
 
+  if (adjustTimestampToTimezone && sessionTimezone) {
+    timestamp.toTimezone(*sessionTimezone);
+    return timestamp.getSeconds() - UTC_EPOCH_OFFSET;
+  } else if (!adjustTimestampToTimezone && sessionTimezone) {
+    return seconds - UTC_EPOCH_OFFSET;
+  }
+  // Compatible with meta internal use cases.
   return seconds - EPOCH_OFFSET;
 }
 
@@ -752,7 +767,8 @@ uint64_t TimestampColumnWriter::write(
     for (auto& pos : ranges) {
       if (!decodedVector.isNullAt(pos)) {
         auto ts = decodedVector.valueAt<Timestamp>(pos);
-        seconds_->writeValue(formatTime(ts.getSeconds(), ts.getNanos()));
+        seconds_->writeValue(
+            formatTime(ts, sessionTimezone_, adjustTimestampToTimezone_));
         nanos_->writeValue(formatNanos(ts.getNanos()));
         ++count;
       }
@@ -760,7 +776,8 @@ uint64_t TimestampColumnWriter::write(
   } else {
     for (auto& pos : ranges) {
       auto ts = decodedVector.valueAt<Timestamp>(pos);
-      seconds_->writeValue(formatTime(ts.getSeconds(), ts.getNanos()));
+      seconds_->writeValue(
+          formatTime(ts, sessionTimezone_, adjustTimestampToTimezone_));
       nanos_->writeValue(formatNanos(ts.getNanos()));
       ++count;
     }

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -78,8 +78,14 @@ Writer::Writer(
                                     *options.encryptionSpec,
                                     options.encrypterFactory.get())
                               : nullptr);
-  writerBase_->initContext(options.config, pool, std::move(handler));
-
+  writerBase_->initContext(
+      options.config,
+      pool,
+      options.sessionTimezone,
+      options.adjustTimestampToTimezone,
+      std::move(handler));
+  common::testutil::TestValue::adjust(
+      "facebook::velox::dwrf::Writer::Writer", writerBase_.get());
   auto& context = writerBase_->getContext();
   VELOX_CHECK_EQ(
       context.getTotalMemoryUsage(),
@@ -854,6 +860,8 @@ dwrf::WriterOptions getDwrfOptions(const dwio::common::WriterOptions& options) {
   dwrfOptions.memoryPool = options.memoryPool;
   dwrfOptions.spillConfig = options.spillConfig;
   dwrfOptions.nonReclaimableSection = options.nonReclaimableSection;
+  dwrfOptions.sessionTimezone = options.sessionTimezone;
+  dwrfOptions.adjustTimestampToTimezone = options.adjustTimestampToTimezone;
   return dwrfOptions;
 }
 

--- a/velox/dwio/dwrf/writer/Writer.h
+++ b/velox/dwio/dwrf/writer/Writer.h
@@ -51,6 +51,8 @@ struct WriterOptions : public dwio::common::WriterOptions {
       WriterContext& context,
       const velox::dwio::common::TypeWithId& type)>
       columnWriterFactory;
+  const tz::TimeZone* sessionTimezone{nullptr};
+  bool adjustTimestampToTimezone{false};
 
   void processConfigs(
       const config::ConfigBase& connectorConfig,

--- a/velox/dwio/dwrf/writer/WriterBase.h
+++ b/velox/dwio/dwrf/writer/WriterBase.h
@@ -74,9 +74,16 @@ class WriterBase {
   void initContext(
       const std::shared_ptr<const Config>& config,
       std::shared_ptr<velox::memory::MemoryPool> pool,
+      const tz::TimeZone* sessionTimezone = nullptr,
+      const bool adjustTimestampToTimezone = false,
       std::unique_ptr<encryption::EncryptionHandler> handler = nullptr) {
     context_ = std::make_unique<WriterContext>(
-        config, std::move(pool), sink_->metricsLog(), std::move(handler));
+        config,
+        std::move(pool),
+        sink_->metricsLog(),
+        sessionTimezone,
+        adjustTimestampToTimezone,
+        std::move(handler));
     writerSink_ = std::make_unique<WriterSink>(
         *sink_,
         context_->getMemoryPool(MemoryUsageCategory::OUTPUT_STREAM),

--- a/velox/dwio/dwrf/writer/WriterContext.cpp
+++ b/velox/dwio/dwrf/writer/WriterContext.cpp
@@ -27,6 +27,8 @@ WriterContext::WriterContext(
     const std::shared_ptr<const Config>& config,
     std::shared_ptr<memory::MemoryPool> pool,
     const dwio::common::MetricsLogPtr& metricLogger,
+    const tz::TimeZone* sessionTimezone,
+    const bool adjustTimestampToTimezone,
     std::unique_ptr<encryption::EncryptionHandler> handler)
     : config_{config},
       pool_{std::move(pool)},
@@ -52,6 +54,8 @@ WriterContext::WriterContext(
       // metadata with dwio::common::request::AccessDescriptor upstream and
       // pass down the metric log.
       metricLogger_{metricLogger},
+      sessionTimezone_{sessionTimezone},
+      adjustTimestampToTimezone_{adjustTimestampToTimezone},
       handler_{std::move(handler)} {
   const bool forceLowMemoryMode{getConfig(Config::FORCE_LOW_MEMORY_MODE)};
   const bool disableLowMemoryMode{getConfig(Config::DISABLE_LOW_MEMORY_MODE)};

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -43,6 +43,8 @@ class WriterContext : public CompressionBufferPool {
       std::shared_ptr<memory::MemoryPool> pool,
       const dwio::common::MetricsLogPtr& metricLogger =
           dwio::common::MetricsLog::voidLog(),
+      const tz::TimeZone* sessionTimezone = nullptr,
+      const bool adjustTimestampToTimezone = false,
       std::unique_ptr<encryption::EncryptionHandler> handler = nullptr);
 
   ~WriterContext() override;
@@ -595,6 +597,14 @@ class WriterContext : public CompressionBufferPool {
     return compressionBuffer_.get();
   }
 
+  const tz::TimeZone* getSessionTimezone() const {
+    return sessionTimezone_;
+  }
+
+  bool adjustTimestampToTimezone() const {
+    return adjustTimestampToTimezone_;
+  }
+
  private:
   void validateConfigs() const;
 
@@ -628,6 +638,8 @@ class WriterContext : public CompressionBufferPool {
   const bool streamSizeAboveThresholdCheckEnabled_;
   const uint64_t rawDataSizePerBatch_;
   const dwio::common::MetricsLogPtr metricLogger_;
+  const tz::TimeZone* sessionTimezone_;
+  const bool adjustTimestampToTimezone_;
 
   // Map needs referential stability because reference to map value is stored by
   // another class.

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -68,6 +68,7 @@ OperatorCtx::createConnectorQueryCtx(
       planNodeId,
       driverCtx_->driverId,
       driverCtx_->queryConfig().sessionTimezone(),
+      driverCtx_->queryConfig().adjustTimestampToTimezone(),
       task->getCancellationToken());
 }
 

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -4588,39 +4588,61 @@ TEST_F(TableScanTest, varbinaryPartitionKey) {
 
 TEST_F(TableScanTest, timestampPartitionKey) {
   const char* inputs[] = {"2023-10-14 07:00:00.0", "2024-01-06 04:00:00.0"};
-  auto expected = makeRowVector(
-      {"t"},
-      {
-          makeFlatVector<Timestamp>(
-              std::end(inputs) - std::begin(inputs),
-              [&](auto i) {
-                auto t = util::fromTimestampString(
-                             inputs[i], util::TimestampParseMode::kPrestoCast)
-                             .thenOrThrow(
-                                 folly::identity, [&](const Status& status) {
-                                   VELOX_USER_FAIL("{}", status.message());
-                                 });
-                t.toGMT(Timestamp::defaultTimezone());
-                return t;
-              }),
-      });
-  auto vectors = makeVectors(1, 1);
-  auto filePath = TempFilePath::create();
-  writeToFile(filePath->getPath(), vectors);
-  ColumnHandleMap assignments = {{"t", partitionKey("t", TIMESTAMP())}};
-  std::vector<std::shared_ptr<connector::ConnectorSplit>> splits;
-  for (auto& t : inputs) {
-    splits.push_back(HiveConnectorSplitBuilder(filePath->getPath())
-                         .partitionKey("t", t)
-                         .build());
+  for (std::string sessionTimezone :
+       {"", "Asia/Shanghai", "America/Los_Angeles", "UTC"}) {
+    SCOPED_TRACE(fmt::format("sessionTimezone {}", sessionTimezone));
+
+    auto expected = makeRowVector(
+        {"t"},
+        {
+            makeFlatVector<Timestamp>(
+                std::end(inputs) - std::begin(inputs),
+                [&](auto i) {
+                  auto t = util::fromTimestampString(
+                               inputs[i], util::TimestampParseMode::kPrestoCast)
+                               .thenOrThrow(
+                                   folly::identity, [&](const Status& status) {
+                                     VELOX_USER_FAIL("{}", status.message());
+                                   });
+
+                  if (sessionTimezone.empty()) {
+                    t.toGMT(Timestamp::defaultTimezone());
+                  } else {
+                    const auto timezone = tz::locateZone(sessionTimezone);
+                    t.toGMT(*timezone);
+                  }
+
+                  return t;
+                }),
+        });
+    auto vectors = makeVectors(1, 1);
+    auto filePath = TempFilePath::create();
+    writeToFile(filePath->getPath(), vectors);
+    ColumnHandleMap assignments = {{"t", partitionKey("t", TIMESTAMP())}};
+    std::vector<std::shared_ptr<connector::ConnectorSplit>> splits;
+    for (auto& t : inputs) {
+      splits.push_back(HiveConnectorSplitBuilder(filePath->getPath())
+                           .partitionKey("t", t)
+                           .build());
+    }
+    auto plan = PlanBuilder()
+                    .startTableScan()
+                    .outputType(ROW({"t"}, {TIMESTAMP()}))
+                    .assignments(assignments)
+                    .endTableScan()
+                    .planNode();
+
+    if (!sessionTimezone.empty()) {
+      AssertQueryBuilder(plan)
+          .config(core::QueryConfig::kSessionTimezone, sessionTimezone)
+          .splits(std::move(splits))
+          .assertResults(expected);
+    } else {
+      AssertQueryBuilder(plan)
+          .splits(std::move(splits))
+          .assertResults(expected);
+    }
   }
-  auto plan = PlanBuilder()
-                  .startTableScan()
-                  .outputType(ROW({"t"}, {TIMESTAMP()}))
-                  .assignments(assignments)
-                  .endTableScan()
-                  .planNode();
-  AssertQueryBuilder(plan).splits(std::move(splits)).assertResults(expected);
 }
 
 TEST_F(TableScanTest, partitionKeyNotMatchPartitionKeysHandle) {

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -337,12 +337,12 @@ struct Timestamp {
       const TimestampToStringOptions& options,
       char* const startPosition);
 
-  // Assuming the timestamp represents a time at zone, converts it to the GMT
-  // time at the same moment. For example:
-  //
-  //  Timestamp ts{0, 0};
-  //  ts.Timezone("America/Los_Angeles");
-  //  ts.toString(); // returns January 1, 1970 08:00:00
+  /// Assuming the timestamp represents a time at zone, converts it to the GMT
+  /// time at the same moment. For example:
+  ///
+  ///  Timestamp ts{0, 0};
+  ///  ts.Timezone("America/Los_Angeles");
+  ///  ts.toString(); // returns January 1, 1970 08:00:00
   void toGMT(const tz::TimeZone& zone);
 
   /// Assuming the timestamp represents a GMT time, converts it to the time at

--- a/velox/type/tests/TimestampTest.cpp
+++ b/velox/type/tests/TimestampTest.cpp
@@ -608,6 +608,5 @@ TEST(TimestampTest, skipTrailingZeros) {
       timestampToString(Timestamp(-50049331200, 726600000), options),
       "0384-01-01 08:00:00.7266");
 }
-
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
As described in https://github.com/facebookincubator/velox/issues/8127, Velox's DWRF/ORC `TimestampColumnReader` and `TimestampColumnWriter` currently hard-code the time zone. If we use Presto to write timestamps and use velox to read them, the results will be incorrect, and vice versa. 

This PR passes `ConnectorQueryCtx#sessionTimezone()` and `ConnectorQueryCtx#adjustTimestampToTimezone()` to `TimestampColumnReader` and `TimestampColumnWriter`, allowing us to use the user-set Timezone.