### PR TITLE
Add version to Minio binary to avoid conflicts

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -110,7 +110,11 @@ jobs:
             "-DVELOX_ENABLE_GPU=ON"
           )
           make release EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS[*]}"
-    
+
+      #Temporarily rename Minio binary to include version until CI image is updated with the same.
+      - name: Rename Minio
+        run: [ -f /usr/local/bin/minio ] && mv /usr/local/bin/minio /usr/local/bin/minio-2022-05-26
+
       - name: Ccache after
         run: ccache -s
 

--- a/scripts/setup-adapters.sh
+++ b/scripts/setup-adapters.sh
@@ -33,32 +33,21 @@ function install_aws_deps {
   cmake_install -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DBUILD_SHARED_LIBS:BOOL=OFF -DMINIMIZE_SIZE:BOOL=ON -DENABLE_TESTING:BOOL=OFF -DBUILD_ONLY:STRING="s3;identity-management"
   # Dependencies for S3 testing
   # We need this specific version of Minio for testing.
-  if [[ "$OSTYPE" == linux-gnu* ]]; then
-    wget https://dl.min.io/server/minio/release/linux-amd64/archive/minio-20220526054841.0.0.x86_64.rpm
-    if yum list installed minio >/dev/null 2>&1;then
-      if  prompt "Do you want to replace the installed Minio with version minio-20220526054841.0.0.x86_64.rpm needed for S3 tests?"; then
-        rpm -i --replacepkgs minio-20220526054841.0.0.x86_64.rpm
-      else
-        echo "Minio version minio-20220526054841.0.0.x86_64.rpm needed for S3 tests is not installed."
-      fi
-    else
-      rpm -i minio-20220526054841.0.0.x86_64.rpm
-    fi
-    rm minio-20220526054841.0.0.x86_64.rpm
+  local MINIO_ARCH=$MACHINE
+  if [[ $MACHINE == aarch64 ]]; then
+    MINIO_ARCH="arm64"
+  elif [[ $MACHINE == x86_64 ]]; then
+    MINIO_ARCH="amd64"
   fi
-  # minio will have to approved under the Privacy & Security on MacOS on first use.
+  local MINIO_BINARY="minio-2022-05-26"
+  local MINIO_OS="linux"
   if [[ "$OSTYPE" == darwin* ]]; then
-    if [ "$MACHINE" = "x86_64" ]; then
-      wget https://dl.min.io/server/minio/release/darwin-arm64/archive/minio.RELEASE.2022-05-26T05-48-41Z -O minio
-      chmod +x ./minio
-      sudo mv ./minio /usr/local/bin/
-    fi
-    if [ "$MACHINE" = "arm64" ]; then
-      wget https://dl.min.io/server/minio/release/darwin-arm64/archive/minio.RELEASE.2022-05-26T05-48-41Z -O minio
-      chmod +x ./minio
-      sudo mv ./minio /usr/local/bin/
-    fi
+    # minio will have to approved under the Privacy & Security on MacOS on first use.
+    MINIO_OS="darwin"
   fi
+  wget https://dl.min.io/server/minio/release/${MINIO_OS}-${MINIO_ARCH}/archive/minio.RELEASE.2022-05-26T05-48-41Z -O ${MINIO_BINARY}
+  chmod +x ./${MINIO_BINARY}
+  mv ./${MINIO_BINARY} /usr/local/bin/
 }
 
 function install_gcs-sdk-cpp {

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/MinioServer.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/MinioServer.h
@@ -25,7 +25,7 @@
 using namespace facebook::velox;
 
 namespace {
-constexpr char const* kMinioExecutableName{"minio"};
+constexpr char const* kMinioExecutableName{"minio-2022-05-26"};
 constexpr char const* kMinioAccessKey{"minio"};
 constexpr char const* kMinioSecretKey{"miniopass"};
 } // namespace


### PR DESCRIPTION
S3 tests require a specific older Minio version which supports accessing an S3 bucket via the linux filesystem API.
Simplify Minio download inference based on OS.

Resolves https://github.com/facebookincubator/velox/issues/10386