### PR TITLE
Fix typo in metrics document

### DIFF
--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -1,4 +1,3 @@
-
 ===============
 Runtime Metrics
 ===============
@@ -43,7 +42,7 @@ number of shuffle requests per second.
 **Histogram**: tracks the distribution of event data point values, such as query
 execution time distribution. The histogram metric divides the entire data range
 into a series of adjacent equal-sized intervals or buckets, and then count how
-many data values fall into each bucket. DEFINE_HISTOGRAM_STAT specifies the data
+many data values fall into each bucket. DEFINE_HISTOGRAM_METRIC specifies the data
 range by min/max values, and the number of buckets. Any collected data value
 less than min is counted in min bucket, and any one larger than max is counted
 in max bucket. It also allows to specify the value percentiles to report for


### PR DESCRIPTION
`DEFINE_HISTOGRAM_STAT` --> `DEFINE_HISTOGRAM_METRIC`

The name of the macro used to register a histogram-type metric is
`DEFINE_HISTOGRAM_METRIC`, not `DEFINE_HISTOGRAM_STAT`, this PR
fixes it.