### PR TITLE
StringWriter needs to implement finalizeNull

### DIFF
--- a/velox/expression/ComplexWriterTypes.h
+++ b/velox/expression/ComplexWriterTypes.h
@@ -50,6 +50,8 @@ class VectorWriterBase {
   virtual void commit(bool isSet) = 0;
   virtual void ensureSize(size_t size) = 0;
   virtual void finish() {}
+  // Implementations that write variable length data or complex types should
+  // override this to reset their state and that of their children.
   virtual void finalizeNull() {}
   virtual ~VectorWriterBase() {}
   vector_size_t offset_ = 0;

--- a/velox/expression/VectorWriters.h
+++ b/velox/expression/VectorWriters.h
@@ -373,16 +373,21 @@ struct VectorWriter<
 
   void commitNull() {
     proxy_.vector_->setNull(proxy_.offset_, true);
+    finalizeNull();
+  }
+
+  void finalizeNull() override {
+    proxy_.prepareForReuse(false);
   }
 
   void commit(bool isSet) override {
     // this code path is called when the slice is top-level
     if (isSet) {
       proxy_.finalize();
+      proxy_.prepareForReuse(true);
     } else {
       commitNull();
     }
-    proxy_.prepareForReuse(isSet);
   }
 
   void setOffset(vector_size_t offset) override {


### PR DESCRIPTION
Summary:
When StringWriter commits it calls proxy_.prepareForReuse to update the state of the proxy, either
advancing it if a value is being written or resetting it if a null is being written.

StringWriter needs to implement finalizeNull to do the same in case its parent commits a null.  When
a writer for a complex type commits a null, it invokes finalizeNull on its children to reset their state.
StringWriter does not implement this today which means, e.g. if it is the writer for the elements of
an Array, if the code has written an uncommitted String to the Array when the Array is committed as
null, the next Array that gets written will end up with its StringWriter still holding the state from that
last string in the previous Array, meaning its contents could appear at the beginning of the first string
in that Array.

We were also not calling proxy_.prepareForReuse in commitNull (only commit(false)) which resulted
in a similar issue, this change also fixes that.

This partially addresses the issue identified in https://github.com/facebookincubator/velox/issues/10162

Differential Revision: D59291362
