### PR TITLE
Restore path after arrow dependency install

### DIFF
--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -191,7 +191,7 @@ ARROW_VERSION=15.0.0
 
 function install_arrow {
   wget_and_untar https://archive.apache.org/dist/arrow/arrow-${ARROW_VERSION}/apache-arrow-${ARROW_VERSION}.tar.gz arrow
-  cd arrow/cpp
+  pushd arrow/cpp
   cmake_install \
     -DARROW_PARQUET=OFF \
     -DARROW_WITH_THRIFT=ON \
@@ -208,6 +208,7 @@ function install_arrow {
     -DCMAKE_BUILD_TYPE=Release \
     -DARROW_BUILD_STATIC=ON \
     -DThrift_SOURCE=BUNDLED
+  popd
 }
 
 function install_cuda {

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -161,7 +161,7 @@ ARROW_VERSION=15.0.0
 
 function install_arrow {
   wget_and_untar https://archive.apache.org/dist/arrow/arrow-${ARROW_VERSION}/apache-arrow-${ARROW_VERSION}.tar.gz arrow
-  cd arrow/cpp
+  pushd arrow/cpp
   cmake_install \
     -DARROW_PARQUET=OFF \
     -DARROW_WITH_THRIFT=ON \
@@ -178,6 +178,7 @@ function install_arrow {
     -DCMAKE_BUILD_TYPE=Release \
     -DARROW_BUILD_STATIC=ON \
     -DThrift_SOURCE=BUNDLED
+  popd
 }
 
 function install_cuda {


### PR DESCRIPTION
After the arrow dependency was installed the path is not returned to where it
originally was.
As a result sourcing the script results in subsequent processing to be within the arrow directory rather than the original base directory.