### PR TITLE
[Spark] Add support for allow-precision-loss in decimal operations

### DIFF
--- a/velox/docs/functions/spark/decimal.rst
+++ b/velox/docs/functions/spark/decimal.rst
@@ -3,7 +3,7 @@ Decimal Operators
 =================
 
 The result precision and scale computation of arithmetic operators contains two stages.
-First stage computes precision and scale using formulas based on the SQL standard, and Hive when allow-precision-loss is true.
+First stage computes precision and scale using formulas based on the SQL standard and Hive when allow-precision-loss is true.
 The result may exceed maximum allowed precision of 38.
 
 Second stage caps precision at 38 and either reduces the scale or not depending on allow-precision-loss flag.
@@ -16,14 +16,14 @@ Without allow-precision-loss, some additions will return NULL.
 
 For example,
 
-The following queries keep accuracy or returns NULL with allow-precision-loss is false:
+The following queries keep accuracy or return NULL when allow-precision-loss is false:
 
 ::
 
     select cast('1.1232154' as decimal(38, 7)) + cast('1' as decimal(10, 0)); -- 2.123215
     select cast('9999999999999999999999999999999.2345678' as decimal(38, 7)) + cast('1' as decimal(10, 0)); -- NULL
 
-And succeed with allow-precision-loss is true:
+These same operations succeed when allow-precision-loss is true:
 
 ::
 
@@ -33,7 +33,7 @@ And succeed with allow-precision-loss is true:
 Decimal Precision and Scale Computation Formulas
 ------------------------------------------------
 
-The Hive SQL behavior:
+The HiveQL behavior:
 
 https://cwiki.apache.org/confluence/download/attachments/27362075/Hive_Decimal_Precision_Scale_Support.pdf
 
@@ -58,14 +58,14 @@ Multiplication
 
 Division
 ~~~~~~~~
-When allow-precision-loss:
+When allow-precision-loss is true:
 
 ::
 
     p = p1 - s1 + s2 + max(6, s1 + p2 + 1)
     s = max(6, s1 + p2 + 1)
 
-When precision loss is not allowed:
+When allow-precision-loss is false:
 
 ::
 
@@ -79,7 +79,7 @@ Decimal Precision and Scale Adjustment
 
 When allow-precision-loss is true, rounds the decimal part of the result if an exact representation is not possible.
 Otherwise, returns NULL.
-Notice: some operations succeed if precision loss is allowed and returns NULL if not.
+Notice: some operations succeed if precision loss is allowed and return NULL if not.
 
 For example,
 

--- a/velox/functions/sparksql/DecimalUtil.h
+++ b/velox/functions/sparksql/DecimalUtil.h
@@ -211,6 +211,16 @@ class DecimalUtil {
     }
   }
 
+  /// This method is used when the function is registered with
+  /// ``allowPrecisionLoss`` being false. Caps precision and scale at 38.
+  static std::pair<uint8_t, uint8_t> bounded(
+      uint8_t rPrecision,
+      uint8_t rScale) {
+    return {
+        std::min(rPrecision, DecimalType<TypeKind::HUGEINT>::kMaxPrecision),
+        std::min(rScale, DecimalType<TypeKind::HUGEINT>::kMaxPrecision)};
+  }
+
  private:
   /// Maintains the max bits that need to be increased for rescaling a value by
   /// certain scale. The calculation relies on the following formula:

--- a/velox/functions/sparksql/tests/DecimalUtilTest.cpp
+++ b/velox/functions/sparksql/tests/DecimalUtilTest.cpp
@@ -60,4 +60,16 @@ TEST_F(DecimalUtilTest, minLeadingZeros) {
       12);
   ASSERT_EQ(result, 0);
 }
+
+TEST_F(DecimalUtilTest, bounded) {
+  auto testBounded = [](uint8_t rPrecision,
+                        uint8_t rScale,
+                        std::pair<uint8_t, uint8_t> expected) {
+    ASSERT_EQ(DecimalUtil::bounded(rPrecision, rScale), expected);
+  };
+
+  testBounded(10, 3, {10, 3});
+  testBounded(40, 3, {38, 3});
+  testBounded(44, 42, {38, 38});
+}
 } // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
Each of the decimal operation functions is registered as two functions such as `add_deny_precision_loss` and `add`.
When allowing precision loss, establishing the result type of an arithmetic operation happens according to Hive behavior and SQL ANSI 2011 specification, i.e. rounding the decimal part of the result if an exact representation is not possible. Otherwise, NULL is returned in those cases, as previously.
When not allowing precision loss, not rounding the decimal part.

For example, 
  | decimal(38, 7) + decimal(10, 0) result type | 1.1232154   + 1| decimal(38, 18) * decimal(38, 18)| 0.1234567891011 * 1234.1
-- | -- | -- | -- | --
allow   precision loss | decimal(38, 6) | 2.123215 | decimal(38, 6) | 152.358023
deny precision   loss | decimal(38, 7) | 2.1232154 | decimal(38, 36) | NULL

```
spark-sql (default)> set spark.sql.decimalOperations.allowPrecisionLoss=true;

spark-sql (default)> select cast(0.1234567891011 as decimal(38, 18)) * cast(1234.1 as decimal(38, 18));
152.358023

spark-sql (default)> set spark.sql.decimalOperations.allowPrecisionLoss=false;

spark-sql (default)> select cast(0.1234567891011 as decimal(38, 18)) * cast(1234.1 as decimal(38, 18));
NULL
```

Spark implementation: https://github.com/apache/spark/blob/branch-3.5/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala#L814