### PR TITLE
Use computeChainDataLength() instead of length()

### DIFF
--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -4224,7 +4224,7 @@ void PrestoVectorSerde::deserialize(
         codec->uncompress(compressBuf.get(), header.uncompressedSize);
     std::vector<ByteRange> ranges;
     for (auto range : *uncompress) {
-      ranges.emplace_back(ByteRange{
+      ranges.push_back(ByteRange{
           const_cast<uint8_t*>(range.data()),
           static_cast<int32_t>(range.size()),
           0});

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -3608,7 +3608,7 @@ FlushSizes flushCompressed(
       "UncompressedSize exceeds limit");
   auto iobuf = out.getIOBuf();
   const auto compressedBuffer = codec.compress(iobuf.get());
-  const int32_t compressedSize = compressedBuffer->length();
+  const int32_t compressedSize = compressedBuffer->computeChainDataLength();
   if (compressedSize > uncompressedSize * minCompressionRatio) {
     flushSerialization(
         numRows,


### PR DESCRIPTION
Should use computeChainDataLength() instead of length(), below is comments from `folly/io/IOBuf.h`
```
  /**
   * Get the size of the data for this individual IOBuf in the chain.
   *
   * Use computeChainDataLength() for the sum of data length for the full chain.
   *
   * @methodset Buffer Capacity
   */
  std::size_t length() const { return length_; }

```