### PR TITLE
Fix deadlock in MemoryPool

### DIFF
--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -323,7 +323,7 @@ std::shared_ptr<MemoryPool> MemoryPool::addLeafChild(
       0,
       "Leaf child memory pool {} already exists in {}",
       name,
-      toString());
+      name_);
   auto child = genChild(
       shared_from_this(),
       name,
@@ -352,7 +352,7 @@ std::shared_ptr<MemoryPool> MemoryPool::addAggregateChild(
       0,
       "Child memory pool {} already exists in {}",
       name,
-      toString());
+      name_);
   auto child = genChild(
       shared_from_this(),
       name,

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -225,19 +225,30 @@ TEST_P(MemoryPoolTest, addChild) {
   });
   ASSERT_THAT(
       nodes, UnorderedElementsAreArray({childOne.get(), childTwo.get()}));
+
   // Child pool name collision.
   ASSERT_THROW(root->addAggregateChild("child_one"), VeloxRuntimeError);
   ASSERT_EQ(root->getChildCount(), 2);
+
+  constexpr int64_t kChunkSize{128};
+  void* buff = childOne->allocate(kChunkSize);
+  // Add child when 'reservedBytes != 0', in which case 'usedBytes()' will call
+  // 'visitChildren()'.
+  ASSERT_THROW(root->addAggregateChild("child_one"), VeloxRuntimeError);
+  childOne->free(buff, kChunkSize);
+  ASSERT_EQ(root->getChildCount(), 2);
+
   childOne.reset();
   ASSERT_EQ(root->getChildCount(), 1);
   childOne = root->addLeafChild("child_one", isLeafThreadSafe_);
   ASSERT_EQ(root->getChildCount(), 2);
-  ASSERT_EQ(root->treeMemoryUsage(), "root usage 0B reserved 0B peak 0B\n");
-  ASSERT_EQ(root->treeMemoryUsage(true), "root usage 0B reserved 0B peak 0B\n");
+  ASSERT_EQ(root->treeMemoryUsage(), "root usage 0B reserved 0B peak 1.00MB\n");
+  ASSERT_EQ(
+      root->treeMemoryUsage(true), "root usage 0B reserved 0B peak 1.00MB\n");
   const std::string treeUsageWithEmptyPool = root->treeMemoryUsage(false);
   ASSERT_THAT(
       treeUsageWithEmptyPool,
-      testing::HasSubstr("root usage 0B reserved 0B peak 0B\n"));
+      testing::HasSubstr("root usage 0B reserved 0B peak 1.00MB\n"));
   ASSERT_THAT(
       treeUsageWithEmptyPool,
       testing::HasSubstr("child_one usage 0B reserved 0B peak 0B\n"));


### PR DESCRIPTION
Fixes #10342

`MemoryPool::poolMutex_` is used to protect `MemoryPool::children_` in 
the following 4 member methods:
`addLeafChild()`/`addAggregateChild()`/`getChildCount()`/`visitChildren`.

In other words, to avoid deadlock:
1. First of all, we can't call the above 4 methods while holding 
   `poolMutex_`.
2. Furthermore, we cannot call methods that use these 4 methods while  
   holding `poolMutex_`;
4. Finally, **there cannot be any direct or indirect calls between  
   these 4 methods. (This is the root cause of this problem)**.

```cpp
addAggregateChild() ------ will acquire 'poolMutex_'
--> toString() [When duplicate names appear, used to print error messages]
    --> usedBytes()
        --> visitChildren() ------ [When reservedBytes() != 0] will acquire 'poolMutex_' again, **DEADLOCK!!**
```

So, `addAggregateChild()` indirectly calls `visitChildren()` [When  
`reservedBytes() != 0`], causing a deadlock.

To solve this problem, the easiest way is to simplify the error message  
printed when duplicate names appear.  After all, we only need to know  
the name of the parent pool, just like many other places in this class do.