### PR TITLE
Cache operation support for Prestissimo

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -404,14 +404,14 @@ class TpchBenchmark {
 #endif
 
         if (cache_) {
-          cache_->testingClear();
+          cache_->clear();
         }
       }
       if (FLAGS_clear_ssd_cache) {
         if (cache_) {
           auto ssdCache = cache_->ssdCache();
           if (ssdCache) {
-            ssdCache->testingClear();
+            ssdCache->clear();
           }
         }
       }

--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -149,6 +149,11 @@ void registerVeloxMetrics() {
   // last counter retrieval.
   DEFINE_METRIC(kMetricMemoryCacheNumEvicts, facebook::velox::StatType::SUM);
 
+  // Number of times a valid entry was removed in order to make space but has
+  // not been saved to SSD yet, since last counter retrieval.
+  DEFINE_METRIC(
+      kMetricMemoryCacheNumSavableEvicts, facebook::velox::StatType::SUM);
+
   // Number of entries considered for evicting, since last counter retrieval.
   DEFINE_METRIC(
       kMetricMemoryCacheNumEvictChecks, facebook::velox::StatType::SUM);
@@ -255,6 +260,10 @@ void registerVeloxMetrics() {
 
   // Total number of cache regions evicted.
   DEFINE_METRIC(kMetricSsdCacheRegionsEvicted, facebook::velox::StatType::SUM);
+
+  // Total number of cache entries recovered from checkpoint.
+  DEFINE_METRIC(
+      kMetricSsdCacheRecoveredEntries, facebook::velox::StatType::SUM);
 
   /// ================== Memory Arbitration Counters =================
 

--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -206,6 +206,9 @@ constexpr folly::StringPiece kMetricMemoryCacheNumNew{
 constexpr folly::StringPiece kMetricMemoryCacheNumEvicts{
     "velox.memory_cache_num_evicts"};
 
+constexpr folly::StringPiece kMetricMemoryCacheNumSavableEvicts{
+    "velox.memory_cache_num_savable_evicts"};
+
 constexpr folly::StringPiece kMetricMemoryCacheNumEvictChecks{
     "velox.memory_cache_num_evict_checks"};
 
@@ -292,6 +295,9 @@ constexpr folly::StringPiece kMetricSsdCacheCheckpointsWritten{
 
 constexpr folly::StringPiece kMetricSsdCacheRegionsEvicted{
     "velox.ssd_cache_regions_evicted"};
+
+constexpr folly::StringPiece kMetricSsdCacheRecoveredEntries{
+    "velox.ssd_cache_recovered_entries"};
 
 constexpr folly::StringPiece kMetricExchangeDataTimeMs{
     "velox.exchange_data_time_ms"};

--- a/velox/common/base/PeriodicStatsReporter.cpp
+++ b/velox/common/base/PeriodicStatsReporter.cpp
@@ -160,6 +160,8 @@ void PeriodicStatsReporter::reportCacheStats() {
   REPORT_IF_NOT_ZERO(kMetricMemoryCacheNumNew, deltaCacheStats.numNew);
   REPORT_IF_NOT_ZERO(kMetricMemoryCacheNumEvicts, deltaCacheStats.numEvict);
   REPORT_IF_NOT_ZERO(
+      kMetricMemoryCacheNumSavableEvicts, deltaCacheStats.numSavableEvict);
+  REPORT_IF_NOT_ZERO(
       kMetricMemoryCacheNumEvictChecks, deltaCacheStats.numEvictChecks);
   REPORT_IF_NOT_ZERO(
       kMetricMemoryCacheNumWaitExclusive, deltaCacheStats.numWaitExclusive);
@@ -227,6 +229,8 @@ void PeriodicStatsReporter::reportCacheStats() {
     REPORT_IF_NOT_ZERO(
         kMetricSsdCacheReadWithoutChecksum,
         deltaSsdStats.readWithoutChecksumChecks);
+    REPORT_IF_NOT_ZERO(
+        kMetricSsdCacheRecoveredEntries, deltaSsdStats.entriesRecovered);
   }
 
   // TTL controler snapshot stats.

--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -477,6 +477,7 @@ TEST_F(PeriodicStatsReporterTest, basic) {
     ASSERT_EQ(counterMap.count(kMetricMemoryCacheHitBytes.str()), 0);
     ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumNew.str()), 0);
     ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumEvicts.str()), 0);
+    ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumSavableEvicts.str()), 0);
     ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumEvictChecks.str()), 0);
     ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumWaitExclusive.str()), 0);
     ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumAllocClocks.str()), 0);
@@ -502,6 +503,7 @@ TEST_F(PeriodicStatsReporterTest, basic) {
     ASSERT_EQ(counterMap.count(kMetricSsdCacheRegionsEvicted.str()), 0);
     ASSERT_EQ(counterMap.count(kMetricSsdCacheAgedOutEntries.str()), 0);
     ASSERT_EQ(counterMap.count(kMetricSsdCacheAgedOutRegions.str()), 0);
+    ASSERT_EQ(counterMap.count(kMetricSsdCacheRecoveredEntries.str()), 0);
     ASSERT_EQ(counterMap.count(kMetricSsdCacheReadWithoutChecksum.str()), 0);
     ASSERT_EQ(counterMap.size(), 22);
   }
@@ -530,11 +532,13 @@ TEST_F(PeriodicStatsReporterTest, basic) {
   newSsdStats->readSsdCorruptions = 10;
   newSsdStats->readCheckpointErrors = 10;
   newSsdStats->readWithoutChecksumChecks = 10;
+  newSsdStats->entriesRecovered = 10;
   cache.updateStats(
       {.numHit = 10,
        .hitBytes = 10,
        .numNew = 10,
        .numEvict = 10,
+       .numSavableEvict = 10,
        .numEvictChecks = 10,
        .numWaitExclusive = 10,
        .numAgedOut = 10,
@@ -556,6 +560,7 @@ TEST_F(PeriodicStatsReporterTest, basic) {
     ASSERT_EQ(counterMap.count(kMetricMemoryCacheHitBytes.str()), 1);
     ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumNew.str()), 1);
     ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumEvicts.str()), 1);
+    ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumSavableEvicts.str()), 1);
     ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumEvictChecks.str()), 1);
     ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumWaitExclusive.str()), 1);
     ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumAllocClocks.str()), 1);
@@ -581,8 +586,9 @@ TEST_F(PeriodicStatsReporterTest, basic) {
     ASSERT_EQ(counterMap.count(kMetricSsdCacheRegionsEvicted.str()), 1);
     ASSERT_EQ(counterMap.count(kMetricSsdCacheAgedOutEntries.str()), 1);
     ASSERT_EQ(counterMap.count(kMetricSsdCacheAgedOutRegions.str()), 1);
+    ASSERT_EQ(counterMap.count(kMetricSsdCacheRecoveredEntries.str()), 1);
     ASSERT_EQ(counterMap.count(kMetricSsdCacheReadWithoutChecksum.str()), 1);
-    ASSERT_EQ(counterMap.size(), 52);
+    ASSERT_EQ(counterMap.size(), 54);
   }
 }
 

--- a/velox/common/caching/SsdCache.h
+++ b/velox/common/caching/SsdCache.h
@@ -115,9 +115,18 @@ class SsdCache {
 
   /// Stores the entries of 'pins' into the corresponding files. Sets the file
   /// for the successfully stored entries. May evict existing entries from
-  /// unpinned regions. startWrite() must have been called first and it must
-  /// have returned true.
+  /// unpinned regions.
+  ///
+  /// NOTE: startWrite() must have been called first and it must have returned
+  /// true.
   void write(std::vector<CachePin> pins);
+
+  /// Invoked to write checkpoints to all ssd files. This is used by Prestissimo
+  /// worker operation.
+  ///
+  /// NOTE: startWrite() must have been called first and it must have returned
+  /// true.
+  void checkpoint();
 
   /// Removes cached entries from all SsdFiles for files in the fileNum set
   /// 'filesToRemove'. If successful, return true, and 'filesRetained' contains
@@ -147,7 +156,13 @@ class SsdCache {
   /// Drops all entries. Outstanding pins become invalid but reading them will
   /// mostly succeed since the files will not be rewritten until new content is
   /// stored.
-  void testingClear();
+  ///
+  /// NOTE: it is used by test and Prestissimo worker operation.
+  void clear();
+
+  /// Waits until the pending ssd cache writes or checkpoints to finish. Used by
+  /// test and Prestissimo worker operation.
+  void waitForWriteToFinish();
 
   /// Deletes backing files. Used in testing.
   void testingDeleteFiles();
@@ -157,9 +172,6 @@ class SsdCache {
 
   /// Returns the total size of eviction log files. Used by test only.
   uint64_t testingTotalLogEvictionFilesSize();
-
-  /// Waits until the pending ssd cache writes finish. Used by test only.
-  void testingWaitForWriteToFinish();
 
  private:
   void checkNotShutdownLocked() {

--- a/velox/common/caching/SsdFileTracker.h
+++ b/velox/common/caching/SsdFileTracker.h
@@ -85,7 +85,9 @@ class SsdFileTracker {
   }
 
   /// Resets scores of all regions.
-  void testingClear() {
+  ///
+  /// NOTE: this is only used by test and Prestissimo worker operation.
+  void clear() {
     std::fill(regionScores_.begin(), regionScores_.end(), 0);
   }
 

--- a/velox/common/caching/tests/SsdFileTest.cpp
+++ b/velox/common/caching/tests/SsdFileTest.cpp
@@ -654,13 +654,13 @@ TEST_F(SsdFileTest, ssdReadWithoutChecksumCheck) {
   };
 
   pins.clear();
-  cache_->testingClear();
+  cache_->clear();
   ASSERT_EQ(cache_->refreshStats().numEntries, 0);
 
   ASSERT_EQ(checkEntries(entries), entries.size());
   ASSERT_EQ(ssdFile_->testingStats().readWithoutChecksumChecks, 0);
 
-  cache_->testingClear();
+  cache_->clear();
   ASSERT_EQ(cache_->refreshStats().numEntries, 0);
 
 #ifndef NDEBUG

--- a/velox/common/caching/tests/SsdFileTrackerTest.cpp
+++ b/velox/common/caching/tests/SsdFileTrackerTest.cpp
@@ -50,7 +50,7 @@ TEST(SsdFileTrackerTest, tracker) {
   EXPECT_EQ(candidates, expected);
 
   // Test large region scores.
-  tracker.testingClear();
+  tracker.clear();
   for (auto region = 0; region < kNumRegions; ++region) {
     tracker.regionRead(region, INT32_MAX);
     tracker.regionRead(region, region * 100'000'000);

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -743,7 +743,7 @@ TEST_P(MemoryPoolTest, memoryCapExceptions) {
                     "tinySize: 0B large size: 0B\nCache entries: 0 read pins: "
                     "0 write pins: 0 pinned shared: 0B pinned exclusive: 0B\n "
                     "num write wait: 0 empty entries: 0\nCache access miss: 0 "
-                    "hit: 0 hit bytes: 0B eviction: 0 eviction checks: 0 "
+                    "hit: 0 hit bytes: 0B eviction: 0 savable eviction: 0 eviction checks: 0 "
                     "aged out: 0 stales: 0\nPrefetch entries: 0 bytes: 0B\nAlloc Megaclocks 0\n"
                     "Allocated pages: 0 cached pages: 0\n",
                     isLeafThreadSafe_ ? "thread-safe" : "non-thread-safe"),
@@ -777,7 +777,7 @@ TEST_P(MemoryPoolTest, memoryCapExceptions) {
                     "size: 0B tinySize: 0B large size: 0B\nCache entries: 0 "
                     "read pins: 0 write pins: 0 pinned shared: 0B pinned "
                     "exclusive: 0B\n num write wait: 0 empty entries: 0\nCache "
-                    "access miss: 0 hit: 0 hit bytes: 0B eviction: 0 eviction "
+                    "access miss: 0 hit: 0 hit bytes: 0B eviction: 0 savable eviction: 0 eviction "
                     "checks: 0 aged out: 0 stales: 0\nPrefetch entries: 0 bytes: 0B\nAlloc Megaclocks"
                     " 0\nAllocated pages: 0 cached pages: 0\n",
                     isLeafThreadSafe_ ? "thread-safe" : "non-thread-safe"),

--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -290,6 +290,10 @@ Cache
      - Sum
      - Number of times a valid entry was removed in order to make space, since
        last counter retrieval.
+   * - memory_cache_num_savable_evicts
+     - Sum
+     - Number of times a valid entry was removed in order to make space but has not
+       been saved to SSD yet, since last counter retrieval.
    * - memory_cache_num_evict_checks
      - Sum
      - Number of entries considered for evicting, since last counter retrieval.
@@ -384,6 +388,9 @@ Cache
    * - ssd_cache_regions_evicted
      - Sum
      - Total number of cache regions evicted.
+   * - ssd_cache_recovered_entries
+     - Sum
+     - Total number of cache entries recovered from checkpoint.
 
 Storage
 -------

--- a/velox/dwio/dwrf/test/CacheInputTest.cpp
+++ b/velox/dwio/dwrf/test/CacheInputTest.cpp
@@ -533,7 +533,7 @@ TEST_F(CacheTest, ssd) {
   EXPECT_LT(0, ioStats_->rawOverreadBytes());
   auto fullStripeBytes = ioStats_->rawBytesRead();
   auto bytes = ioStats_->rawBytesRead();
-  cache_->testingClear();
+  cache_->clear();
   // We read 10 stripes with some columns sparsely accessed.
   readLoop("testfile", 30, 70, 10, 10, 1, /*noCacheRetention=*/false, ioStats_);
   auto sparseStripeBytes = (ioStats_->rawBytesRead() - bytes) / 10;
@@ -548,7 +548,7 @@ TEST_F(CacheTest, ssd) {
       "prefix1_", 0, kSsdBytes / bytesPerFile, 30, 100, 1, kStripesPerFile, 4);
 
   waitForWrite();
-  cache_->testingClear();
+  cache_->clear();
   // Read double this to get some eviction from SSD.
   readFiles(
       "prefix1_",
@@ -824,7 +824,7 @@ TEST_F(CacheTest, noCacheRetention) {
     ASSERT_LT(0, ioStats_->rawBytesRead());
     auto* ssdCache = cache_->ssdCache();
     if (ssdCache != nullptr) {
-      ssdCache->testingWaitForWriteToFinish();
+      ssdCache->waitForWriteToFinish();
       if (testData.noCacheRetention) {
         ASSERT_EQ(ssdCache->stats().entriesCached, 0);
       } else {
@@ -945,7 +945,7 @@ TEST_F(CacheTest, ssdReadVerification) {
   // Corrupt SSD cache file.
   corruptSsdFile(fmt::format("{}/cache0", tempDirectory_->getPath()));
   // Clear memory cache to force ssd read.
-  cache_->testingClear();
+  cache_->clear();
 
   // Record the baseline stats.
   const auto prevStats = cache_->refreshStats();

--- a/velox/exec/fuzzer/CacheFuzzer.cpp
+++ b/velox/exec/fuzzer/CacheFuzzer.cpp
@@ -275,7 +275,7 @@ void CacheFuzzer::readCache() {
 
 void CacheFuzzer::reset() {
   cache_->shutdown();
-  cache_->ssdCache()->testingWaitForWriteToFinish();
+  cache_->ssdCache()->waitForWriteToFinish();
   executor_->join();
   executor_.reset();
   fileNames_.clear();

--- a/velox/exec/tests/PrintPlanWithStatsTest.cpp
+++ b/velox/exec/tests/PrintPlanWithStatsTest.cpp
@@ -234,7 +234,7 @@ TEST_F(PrintPlanWithStatsTest, partialAggregateWithTableScan) {
   const std::vector<int32_t> numPrefetchSplits = {0, 2};
   for (const auto& numPrefetchSplit : numPrefetchSplits) {
     SCOPED_TRACE(fmt::format("numPrefetchSplit {}", numPrefetchSplit));
-    asyncDataCache_->testingClear();
+    asyncDataCache_->clear();
     auto filePath = TempFilePath::create();
     writeToFile(filePath->getPath(), vectors);
 

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -84,7 +84,7 @@ void OperatorTestBase::setupMemory(
     int64_t memoryPoolInitCapacity,
     int64_t memoryPoolReservedCapacity) {
   if (asyncDataCache_ != nullptr) {
-    asyncDataCache_->testingClear();
+    asyncDataCache_->clear();
     asyncDataCache_.reset();
   }
   MemoryManagerOptions options;


### PR DESCRIPTION
Add checkpoint and ssd write functions support for Prestissimo worker to operate the
cache for performance tuning and online debugging in a test environment
Add metrics about how many ssd cache entries are recovered and how many in-memory 
cache entries are evicted without saving to SSD.
Other logs improvements.
