### PR TITLE
Rewrite some common reduce patterns with array_sum and transform

### DIFF
--- a/velox/expression/TryExpr.cpp
+++ b/velox/expression/TryExpr.cpp
@@ -140,7 +140,9 @@ void TryExpr::nullOutErrors(
     // Wrap in dictionary indices all pointing to index 0.
     auto indices = allocateIndices(size, context.pool());
     result = BaseVector::wrapInDictionary(nulls, indices, size, result);
-  } else if (result.unique() && result->isNullsWritable()) {
+  } else if (
+      result.unique() && result->isNullsWritable() &&
+      result->size() >= rows.end()) {
     auto* rawNulls = result->mutableRawNulls();
     rows.applyToSelected([&](auto row) {
       if (errors->hasErrorAt(row)) {

--- a/velox/expression/tests/ExprCompilerTest.cpp
+++ b/velox/expression/tests/ExprCompilerTest.cpp
@@ -302,6 +302,30 @@ TEST_F(ExprCompilerTest, rewrites) {
           makeTypedExpr("c1 + 5", rowType),
       },
       execCtx_.get()));
+
+  auto exprSet = compile(makeTypedExpr(
+      "reduce(c0, 1, (s, x) -> s + x * 2, s -> s)",
+      ROW({"c0"}, {ARRAY(BIGINT())})));
+  ASSERT_EQ(exprSet->size(), 1);
+  ASSERT_EQ(
+      exprSet->expr(0)->toString(),
+      "plus(1:BIGINT, array_sum_propagate_element_null(transform(c0, (x) -> multiply(x, 2:BIGINT))))");
+
+  exprSet = compile(makeTypedExpr(
+      "reduce(c0, 1, (s, x) -> (s + 2) - x, s -> s)",
+      ROW({"c0"}, {ARRAY(BIGINT())})));
+  ASSERT_EQ(exprSet->size(), 1);
+  ASSERT_EQ(
+      exprSet->expr(0)->toString(),
+      "plus(1:BIGINT, array_sum_propagate_element_null(transform(c0, (x) -> minus(2:BIGINT, x))))");
+
+  exprSet = compile(makeTypedExpr(
+      "reduce(c0, 1, (s, x) -> if(x % 2 = 0, s + 3, s), s -> s)",
+      ROW({"c0"}, {ARRAY(BIGINT())})));
+  ASSERT_EQ(exprSet->size(), 1);
+  ASSERT_EQ(
+      exprSet->expr(0)->toString(),
+      "plus(1:BIGINT, array_sum_propagate_element_null(transform(c0, (x) -> switch(eq(mod(x, 2:BIGINT), 0:BIGINT), 3:BIGINT, 0:BIGINT))))");
 }
 
 TEST_F(ExprCompilerTest, eliminateUnnecessaryCast) {

--- a/velox/functions/prestosql/Reduce.h
+++ b/velox/functions/prestosql/Reduce.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace facebook::velox::functions {
+
+void registerReduceRewrites(const std::string& prefix);
+
+}

--- a/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
@@ -20,6 +20,7 @@
 #include "velox/functions/prestosql/Fail.h"
 #include "velox/functions/prestosql/GreatestLeast.h"
 #include "velox/functions/prestosql/InPredicate.h"
+#include "velox/functions/prestosql/Reduce.h"
 
 namespace facebook::velox::functions {
 
@@ -95,6 +96,7 @@ void registerGeneralFunctions(const std::string& prefix) {
 
   VELOX_REGISTER_VECTOR_FUNCTION(udf_transform, prefix + "transform");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_reduce, prefix + "reduce");
+  registerReduceRewrites(prefix);
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_filter, prefix + "filter");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_typeof, prefix + "typeof");
 

--- a/velox/vector/tests/LazyVectorTest.cpp
+++ b/velox/vector/tests/LazyVectorTest.cpp
@@ -17,7 +17,6 @@
 #include <gtest/gtest.h>
 
 #include "velox/common/base/RawVector.h"
-#include "velox/common/base/RuntimeMetrics.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 using namespace facebook::velox;
@@ -624,21 +623,6 @@ TEST_F(LazyVectorTest, reset) {
   lazy.reset(std::make_unique<test::SimpleVectorLoader>(loader), kVectorSize);
   ASSERT_EQ(lazy.nulls(), nullptr);
 }
-
-class TestRuntimeStatWriter : public BaseRuntimeStatWriter {
- public:
-  void addRuntimeStat(const std::string& name, const RuntimeCounter& value)
-      override {
-    stats_.emplace_back(name, value);
-  }
-
-  const std::vector<std::pair<std::string, RuntimeCounter>>& stats() const {
-    return stats_;
-  }
-
- private:
-  std::vector<std::pair<std::string, RuntimeCounter>> stats_;
-};
 
 TEST_F(LazyVectorTest, runtimeStats) {
   TestRuntimeStatWriter writer;

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -18,6 +18,7 @@
 #include <folly/Executor.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
 
+#include "velox/common/base/RuntimeMetrics.h"
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
 
@@ -815,6 +816,21 @@ class VectorTestBase {
   std::shared_ptr<folly::Executor> spillExecutor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
           std::thread::hardware_concurrency())};
+};
+
+class TestRuntimeStatWriter : public BaseRuntimeStatWriter {
+ public:
+  void addRuntimeStat(const std::string& name, const RuntimeCounter& value)
+      override {
+    stats_.emplace_back(name, value);
+  }
+
+  const std::vector<std::pair<std::string, RuntimeCounter>>& stats() const {
+    return stats_;
+  }
+
+ private:
+  std::vector<std::pair<std::string, RuntimeCounter>> stats_;
 };
 
 } // namespace facebook::velox::test


### PR DESCRIPTION
Summary:
Lambda expression in Velox is interpreted instead of compiled like in
Presto Java, this makes us losing in performance in places like `reduce`.  By
rewriting some common patterns of `reduce`, we improve the performance
significantly (more than 45x on a query).

Also fix a bug in `TryExpr` where we are not checking enough space for result
nulls.

Differential Revision: D59406443
