### PR TITLE
Fix recover ssd cache data by preserving file id map

### DIFF
--- a/velox/common/caching/SsdFile.cpp
+++ b/velox/common/caching/SsdFile.cpp
@@ -998,8 +998,7 @@ void SsdFile::readCheckpoint(std::ifstream& state) {
     std::string name;
     name.resize(readNumber<int32_t>(state));
     state.read(name.data(), name.size());
-    auto lease = StringIdLease(fileIds(), name);
-    idMap[id] = std::move(lease);
+    idMap[id] = StringIdLease(fileIds(), id, name);
   }
 
   const auto logSize = ::lseek(evictLogFd_, 0, SEEK_END);

--- a/velox/common/caching/tests/StringIdMapTest.cpp
+++ b/velox/common/caching/tests/StringIdMapTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/common/caching/StringIdMap.h"
 
 #include "gtest/gtest.h"
+#include "velox/common/base/tests/GTestUtils.h"
 
 using namespace facebook::velox;
 
@@ -52,4 +53,53 @@ TEST(StringIdMapTest, rehash) {
     auto name = fmt::format("filename_{}", i);
     EXPECT_EQ(ids[i].id(), StringIdLease(map, name).id());
   }
+}
+
+TEST(StringIdMapTest, recover) {
+  constexpr const char* kRecoverFile1 = "file_1";
+  constexpr const char* kRecoverFile2 = "file_2";
+  constexpr const char* kRecoverFile3 = "file_3";
+  StringIdMap map;
+  const uint64_t recoverId1{10};
+  const uint64_t recoverId2{20};
+  {
+    StringIdLease lease(map, recoverId1, kRecoverFile1);
+    ASSERT_TRUE(lease.hasValue());
+    ASSERT_EQ(map.pinnedSize(), ::strlen(kRecoverFile1));
+    ASSERT_EQ(map.testingLastId(), recoverId1);
+    VELOX_ASSERT_THROW(
+        std::make_unique<StringIdLease>(map, recoverId1, kRecoverFile2),
+        "(1 vs. 0) Reused recover id 10 assigned to file_2");
+    VELOX_ASSERT_THROW(
+        std::make_unique<StringIdLease>(map, recoverId2, kRecoverFile1),
+        "(20 vs. 10) Multiple recover ids assigned to file_1");
+  }
+  ASSERT_EQ(map.pinnedSize(), 0);
+
+  StringIdLease lease1(map, kRecoverFile1);
+  ASSERT_EQ(map.pinnedSize(), ::strlen(kRecoverFile1));
+  ASSERT_EQ(map.testingLastId(), recoverId1 + 1);
+
+  {
+    StringIdLease lease(map, recoverId2, kRecoverFile2);
+    ASSERT_TRUE(lease.hasValue());
+    ASSERT_EQ(lease.id(), recoverId2);
+    ASSERT_EQ(
+        map.pinnedSize(), ::strlen(kRecoverFile1) + ::strlen(kRecoverFile2));
+    ASSERT_EQ(map.testingLastId(), recoverId2);
+    VELOX_ASSERT_THROW(
+        std::make_unique<StringIdLease>(map, recoverId2, kRecoverFile3),
+        "(1 vs. 0) Reused recover id 20 assigned to file_3");
+    VELOX_ASSERT_THROW(
+        std::make_unique<StringIdLease>(map, recoverId2, kRecoverFile1),
+        "(20 vs. 11) Multiple recover ids assigned to file_1");
+    StringIdLease dupLease(map, recoverId2, kRecoverFile2);
+    ASSERT_TRUE(lease.hasValue());
+    ASSERT_EQ(lease.id(), recoverId2);
+    ASSERT_EQ(
+        map.pinnedSize(), ::strlen(kRecoverFile1) + ::strlen(kRecoverFile2));
+  }
+
+  ASSERT_EQ(map.testingLastId(), recoverId2);
+  ASSERT_EQ(map.pinnedSize(), ::strlen(kRecoverFile1));
 }


### PR DESCRIPTION
In Meta interactive Prestissimo workload, we found there is not much read can hit in SSD cache
after cluster upgrade or worker reboot if we rerun the same set of queries. Sometime this is
because of the non-deterministic  execution order of multiple filter conditions in table scan. If the
filter rate is high, then the last few filter conditions might not be executed and the decision is
local to a split which means that filter condition execution order varies across splits. This might
cause the rerun query to read from remote storage instead of local SSD cache. But this only
cause a small portion of reads go to remote storage.

The main problem is due to the recover cache entries from checkpoint. Even though we guarantee
that the same source file name maps to the same file id but we can't guarantee that the newly 
assigned file id will be mapped to the same SSD file shard. This will cause the cache space polution.
Even if we recovered all the SSD cache entries from checkpoint file, the cache lookup can't find them
if the newly assigned file id is mapped to a different SSD file shard.

To fix this problem, we add a new constructor in StringIdMap which takes both id and string to recover
the previous string id map. The caller guarantees there is no conflict for the passed id/string pairs, and 
StringIdMap will throw if breaks. Correspondingly, when SSD file recovers from the checkpoint file, it
will use the persisted file id and name to rebuild the string id map.

Verified on Meta interactive cluster with SSD and a second run after cluster reboot read all the data from
local SSD. The end-to-end query latency has been reduced by half compared with the first run.
