### PR TITLE
Fix race condition in CacheFuzzer

### DIFF
--- a/velox/exec/fuzzer/CacheFuzzer.cpp
+++ b/velox/exec/fuzzer/CacheFuzzer.cpp
@@ -254,7 +254,7 @@ void CacheFuzzer::readCache() {
   std::vector<std::thread> threads;
   threads.reserve(FLAGS_num_threads);
   for (int32_t i = 0; i < FLAGS_num_threads; ++i) {
-    threads.emplace_back([&]() {
+    threads.emplace_back([&, i]() {
       FuzzerGenerator rng(currentSeed_ + i);
       while (!readStopped) {
         const auto fileIdx = boost::random::uniform_int_distribution<int32_t>(


### PR DESCRIPTION
Summary:
The threads CacheFuzzer spins up use the loop variable "i" captured by reference as part of
generating the seed.  This loop variable changes on every iteration so we get concurrent reads and
writes to this variable which TSAN captures (and also probably violates the intention of the author).

Capturing a copy of the variable fixes it.

Differential Revision: D59476752
