### PR TITLE
change type signature of cardinality from any to type var

### DIFF
--- a/velox/functions/prestosql/Cardinality.h
+++ b/velox/functions/prestosql/Cardinality.h
@@ -23,11 +23,11 @@ template <typename T>
 struct CardinalityFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  void call(int64_t& out, const arg_type<Array<Any>>& input) {
+  void call(int64_t& out, const arg_type<Array<Generic<T1>>>& input) {
     out = input.size();
   }
 
-  void call(int64_t& out, const arg_type<Map<Any, Any>>& input) {
+  void call(int64_t& out, const arg_type<Map<Generic<T1>, Generic<T2>>>& input) {
     out = input.size();
   }
 };

--- a/velox/functions/prestosql/Cardinality.h
+++ b/velox/functions/prestosql/Cardinality.h
@@ -27,7 +27,9 @@ struct CardinalityFunction {
     out = input.size();
   }
 
-  void call(int64_t& out, const arg_type<Map<Generic<T1>, Generic<T2>>>& input) {
+  void call(
+      int64_t& out,
+      const arg_type<Map<Generic<T1>, Generic<T2>>>& input) {
     out = input.size();
   }
 };

--- a/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
@@ -100,9 +100,9 @@ void registerGeneralFunctions(const std::string& prefix) {
 
   registerAllGreatestLeastFunctions(prefix);
 
-  registerFunction<CardinalityFunction, int64_t, Array<Any>>(
+  registerFunction<CardinalityFunction, int64_t, Array<Generic<T1>>>(
       {prefix + "cardinality"});
-  registerFunction<CardinalityFunction, int64_t, Map<Any, Any>>(
+  registerFunction<CardinalityFunction, int64_t, Map<Generic<T1>, Generic<T2>>>(
       {prefix + "cardinality"});
 
   registerFailFunction({prefix + "fail"});

--- a/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
@@ -57,8 +57,8 @@ TEST_F(HyperLogLogFunctionsTest, cardinalitySignatures) {
   auto signatures = getSignatureStrings("cardinality");
   ASSERT_EQ(3, signatures.size());
 
-  ASSERT_EQ(1, signatures.count("(map(any,any)) -> bigint"));
-  ASSERT_EQ(1, signatures.count("(array(any)) -> bigint"));
+  ASSERT_EQ(1, signatures.count("(map(__user_T1,__user_T2)) -> bigint"));
+  ASSERT_EQ(1, signatures.count("(array(__user_T1)) -> bigint"));
   ASSERT_EQ(1, signatures.count("(hyperloglog) -> bigint"));
 }
 


### PR DESCRIPTION
'any' is now treated as a concrete type by our underlying system, xstream. we need the signature to indicate it explicitly to be a type var.

Test plan:
```
make unittest
```

it fails on 8 tests but are the same tests that fail on the main branch.