### PR TITLE
Fix find_package and linking for 'gtest' library

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -61,10 +61,8 @@ jobs:
         env:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "TRUE"
         run: |
-          brew install \
-            bison boost ccache double-conversion flex fmt gflags glog \
-            icu4c libevent libsodium lz4 lzo ninja openssl protobuf@21 \
-            range-v3 simdjson snappy thrift xz xsimd zstd
+          source scripts/setup-macos.sh
+          brew install $MACOS_BUILD_DEPS $MACOS_VELOX_DEPS
 
           echo "NJOBS=`sysctl -n hw.ncpu`" >> $GITHUB_ENV
           brew unlink protobuf || echo "protobuf not installed"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -540,13 +540,6 @@ include_directories(SYSTEM velox/external)
 
 # these were previously vendored in third-party/
 if(NOT VELOX_DISABLE_GOOGLETEST)
-  # NOTE: Use "GTest" other than "gtest" or "GTEST" because both the
-  # "FindGTest.cmake" (See [1]) provided by cmake and the cmake file generated
-  # when compiling and installing gtest from source, "GTest" is used, not
-  # "gtest" or "GTEST".
-  #
-  # [1]
-  # https://github.com/Kitware/CMake/blob/8fe9454bcca64a327fb3e0ccf5aff7477eb036cc/Modules/FindGTest.cmake#L19-L23
   set(GTest_SOURCE AUTO)
   resolve_dependency(GTest)
   set(VELOX_GTEST_INCUDE_DIR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -540,8 +540,15 @@ include_directories(SYSTEM velox/external)
 
 # these were previously vendored in third-party/
 if(NOT VELOX_DISABLE_GOOGLETEST)
-  set(gtest_SOURCE AUTO)
-  resolve_dependency(gtest)
+  # NOTE: Use "GTest" other than "gtest" or "GTEST" because both the
+  # "FindGTest.cmake" (See [1]) provided by cmake and the cmake file generated
+  # when compiling and installing gtest from source, "GTest" is used, not
+  # "gtest" or "GTEST".
+  #
+  # [1]
+  # https://github.com/Kitware/CMake/blob/8fe9454bcca64a327fb3e0ccf5aff7477eb036cc/Modules/FindGTest.cmake#L19-L23
+  set(GTest_SOURCE AUTO)
+  resolve_dependency(GTest)
   set(VELOX_GTEST_INCUDE_DIR
       "${gtest_SOURCE_DIR}/googletest/include"
       PARENT_SCOPE)

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -34,7 +34,7 @@ source $SCRIPTDIR/setup-helper-functions.sh
 NPROC=$(getconf _NPROCESSORS_ONLN)
 
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
-MACOS_VELOX_DEPS="bison boost double-conversion flex fmt gflags glog googletest icu4c libevent libsodium libunwind lz4 lzo openssl protobuf@21 simdjson snappy thirft xz xsimd zstd"
+MACOS_VELOX_DEPS="bison boost double-conversion flex fmt gflags glog googletest icu4c libevent libsodium libunwind lz4 lzo openssl protobuf@21 simdjson snappy thrift xz xsimd zstd"
 MACOS_BUILD_DEPS="ninja cmake ccache"
 FB_OS_VERSION="v2024.05.20.00"
 FMT_VERSION="10.1.1"

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -34,7 +34,7 @@ source $SCRIPTDIR/setup-helper-functions.sh
 NPROC=$(getconf _NPROCESSORS_ONLN)
 
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
-MACOS_VELOX_DEPS="bison boost double-conversion flex fmt gflags glog googletest icu4c libevent libsodium libunwind lz4 lzo openssl protobuf@21 simdjson snappy thrift xz xsimd zstd"
+MACOS_VELOX_DEPS="bison boost double-conversion flex fmt gflags glog googletest icu4c libevent libsodium lz4 lzo openssl protobuf@21 simdjson snappy thrift xz xsimd zstd"
 MACOS_BUILD_DEPS="ninja cmake ccache"
 FB_OS_VERSION="v2024.05.20.00"
 FMT_VERSION="10.1.1"

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -34,7 +34,7 @@ source $SCRIPTDIR/setup-helper-functions.sh
 NPROC=$(getconf _NPROCESSORS_ONLN)
 
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
-MACOS_VELOX_DEPS="flex bison protobuf@21 icu4c boost gflags glog libevent lz4 lzo snappy xz zstd openssl libsodium"
+MACOS_VELOX_DEPS="flex bison protobuf@21 icu4c boost gflags glog libevent lz4 lzo snappy xz zstd openssl libsodium googletest"
 MACOS_BUILD_DEPS="ninja cmake ccache"
 FB_OS_VERSION="v2024.05.20.00"
 FMT_VERSION="10.1.1"

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -34,7 +34,7 @@ source $SCRIPTDIR/setup-helper-functions.sh
 NPROC=$(getconf _NPROCESSORS_ONLN)
 
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
-MACOS_VELOX_DEPS="flex bison protobuf@21 icu4c boost gflags glog libevent lz4 lzo snappy xz zstd openssl libsodium googletest"
+MACOS_VELOX_DEPS="bison boost double-conversion flex fmt gflags glog googletest icu4c libevent libsodium libunwind lz4 lzo openssl protobuf@21 simdjson snappy thirft xz xsimd zstd"
 MACOS_BUILD_DEPS="ninja cmake ccache"
 FB_OS_VERSION="v2024.05.20.00"
 FMT_VERSION="10.1.1"

--- a/velox/benchmarks/CMakeLists.txt
+++ b/velox/benchmarks/CMakeLists.txt
@@ -33,7 +33,7 @@ target_link_libraries(
   velox_benchmark_builder ${velox_benchmark_deps})
 # This is a workaround for the use of VectorTestBase.h which includes gtest.h
 target_link_libraries(
-  velox_benchmark_builder gtest)
+  velox_benchmark_builder GTest::gtest)
 
 if(${VELOX_ENABLE_BENCHMARKS})
   add_subdirectory(tpch)

--- a/velox/buffer/tests/CMakeLists.txt
+++ b/velox/buffer/tests/CMakeLists.txt
@@ -20,9 +20,9 @@ target_link_libraries(
   velox_memory
   velox_buffer
   velox_test_util
-  gtest
-  gtest_main
-  gmock
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock
   glog::glog
   gflags::gflags
   pthread)

--- a/velox/common/base/tests/CMakeLists.txt
+++ b/velox/common/base/tests/CMakeLists.txt
@@ -51,9 +51,9 @@ target_link_libraries(
     Folly::folly
     fmt::fmt
     gflags::gflags
-    gtest
-    gmock
-    gtest_main)
+    GTest::gtest
+    GTest::gmock
+    GTest::gtest_main)
 
 add_executable(velox_id_map_test IdMapTest.cpp)
 
@@ -67,8 +67,8 @@ target_link_libraries(
   Boost::headers
   gflags::gflags
   glog::glog
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   pthread)
 
 add_executable(velox_memcpy_meter Memcpy.cpp)

--- a/velox/common/caching/tests/CMakeLists.txt
+++ b/velox/common/caching/tests/CMakeLists.txt
@@ -20,8 +20,8 @@ target_link_libraries(
     Folly::folly
     velox_time
     glog::glog
-    gtest
-    gtest_main)
+    GTest::gtest
+    GTest::gtest_main)
 
 add_executable(
   velox_cache_test
@@ -40,8 +40,8 @@ target_link_libraries(
     velox_temp_path
     Folly::folly
     glog::glog
-    gtest
-    gtest_main)
+    GTest::gtest
+    GTest::gtest_main)
 
 add_executable(cached_factory_test CachedFactoryTest.cpp)
 add_test(cached_factory_test cached_factory_test)
@@ -52,5 +52,5 @@ target_link_libraries(
     Folly::folly
     velox_time
     glog::glog
-    gtest
-    gtest_main)
+    GTest::gtest
+    GTest::gtest_main)

--- a/velox/common/compression/tests/CMakeLists.txt
+++ b/velox/common/compression/tests/CMakeLists.txt
@@ -17,4 +17,5 @@ add_test(velox_common_compression_test velox_common_compression_test)
 target_link_libraries(
   velox_common_compression_test
   PUBLIC velox_link_libs
-  PRIVATE velox_common_compression velox_exception gtest gtest_main)
+  PRIVATE velox_common_compression velox_exception GTest::gtest
+          GTest::gtest_main)

--- a/velox/common/encode/tests/CMakeLists.txt
+++ b/velox/common/encode/tests/CMakeLists.txt
@@ -17,4 +17,4 @@ add_test(velox_common_encode_test velox_common_encode_test)
 target_link_libraries(
   velox_common_encode_test
   PUBLIC Folly::folly
-  PRIVATE velox_encode velox_exception gtest gtest_main)
+  PRIVATE velox_encode velox_exception GTest::gtest gtest_main)

--- a/velox/common/encode/tests/CMakeLists.txt
+++ b/velox/common/encode/tests/CMakeLists.txt
@@ -17,4 +17,4 @@ add_test(velox_common_encode_test velox_common_encode_test)
 target_link_libraries(
   velox_common_encode_test
   PUBLIC Folly::folly
-  PRIVATE velox_encode velox_exception GTest::gtest gtest_main)
+  PRIVATE velox_encode velox_exception GTest::gtest GTest::gtest_main)

--- a/velox/common/file/tests/CMakeLists.txt
+++ b/velox/common/file/tests/CMakeLists.txt
@@ -27,6 +27,6 @@ target_link_libraries(
     velox_file
     velox_file_test_utils
     velox_temp_path
-    gmock
-    gtest
-    gtest_main)
+    GTest::gmock
+    GTest::gtest
+    GTest::gtest_main)

--- a/velox/common/hyperloglog/tests/CMakeLists.txt
+++ b/velox/common/hyperloglog/tests/CMakeLists.txt
@@ -19,4 +19,4 @@ add_test(NAME velox_common_hyperloglog_test
 
 target_link_libraries(
   velox_common_hyperloglog_test
-  PRIVATE velox_common_hyperloglog velox_encode gtest gtest_main)
+  PRIVATE velox_common_hyperloglog velox_encode GTest::gtest GTest::gtest_main)

--- a/velox/common/memory/tests/CMakeLists.txt
+++ b/velox/common/memory/tests/CMakeLists.txt
@@ -45,9 +45,9 @@ target_link_libraries(
     fmt::fmt
     gflags::gflags
     glog::glog
-    gmock
-    gtest
-    gtest_main
+    GTest::gmock
+    GTest::gtest
+    GTest::gtest_main
     re2::re2)
 
 gtest_add_tests(velox_memory_test "" AUTO)

--- a/velox/common/process/tests/CMakeLists.txt
+++ b/velox/common/process/tests/CMakeLists.txt
@@ -22,6 +22,6 @@ target_link_libraries(
   PRIVATE
     velox_process
     fmt::fmt
-    gtest
     velox_time
-    gtest_main)
+    GTest::gtest
+    GTest::gtest_main)

--- a/velox/common/serialization/tests/CMakeLists.txt
+++ b/velox/common/serialization/tests/CMakeLists.txt
@@ -22,5 +22,5 @@ target_link_libraries(
     velox_serialization
     Folly::folly
     glog::glog
-    gtest
-    gtest_main)
+    GTest::gtest
+    GTest::gtest_main)

--- a/velox/common/testutil/tests/CMakeLists.txt
+++ b/velox/common/testutil/tests/CMakeLists.txt
@@ -22,5 +22,5 @@ target_link_libraries(
     velox_exception
     velox_exec
     velox_time
-    gtest
-    gtest_main)
+    GTest::gtest
+    GTest::gtest_main)

--- a/velox/common/time/tests/CMakeLists.txt
+++ b/velox/common/time/tests/CMakeLists.txt
@@ -17,6 +17,6 @@ add_executable(velox_time_test CpuWallTimerTest.cpp)
 
 target_link_libraries(
   velox_time_test
-  PRIVATE velox_time glog::glog gtest gtest_main)
+  PRIVATE velox_time glog::glog GTest::gtest GTest::gtest_main)
 
 gtest_add_tests(velox_time_test "" AUTO)

--- a/velox/connectors/fuzzer/tests/CMakeLists.txt
+++ b/velox/connectors/fuzzer/tests/CMakeLists.txt
@@ -21,5 +21,5 @@ target_link_libraries(
   velox_vector_test_lib
   velox_exec_test_lib
   velox_aggregates
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)

--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -55,7 +55,7 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     velox_exec_test_lib
     Folly::folly
     ${FOLLY_BENCHMARK}
-    gtest
-    gtest_main)
+    GTest::gtest
+    GTest::gtest_main)
 
 endif()

--- a/velox/connectors/hive/storage_adapters/abfs/tests/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/abfs/tests/CMakeLists.txt
@@ -25,8 +25,8 @@ target_link_libraries(
     velox_hive_connector
     velox_dwio_common_exception
     velox_exec
-    gtest
-    gtest_main
+    GTest::gtest
+    GTest::gtest_main
     Azure::azure-storage-blobs
     Azure::azure-storage-files-datalake)
 

--- a/velox/connectors/hive/storage_adapters/gcs/tests/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/gcs/tests/CMakeLists.txt
@@ -22,6 +22,6 @@ target_link_libraries(
   velox_hive_connector
   velox_dwio_common_exception
   velox_exec
-  gmock
-  gtest
-  gtest_main)
+  GTest::gmock
+  GTest::gtest
+  GTest::gtest_main)

--- a/velox/connectors/hive/storage_adapters/hdfs/tests/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/hdfs/tests/CMakeLists.txt
@@ -26,9 +26,9 @@ target_link_libraries(
   velox_hive_connector
   velox_dwio_common_exception
   velox_exec
-  gtest
-  gtest_main
-  gmock)
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock)
 
 target_compile_options(velox_hdfs_file_test
                        PRIVATE -Wno-deprecated-declarations)

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/CMakeLists.txt
@@ -23,8 +23,8 @@ target_link_libraries(
   velox_exec_test_lib
   velox_dwio_common_exception
   velox_exec
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)
 
 add_executable(velox_s3registration_test S3FileSystemRegistrationTest.cpp)
 add_test(velox_s3registration_test velox_s3registration_test)
@@ -37,8 +37,8 @@ target_link_libraries(
   velox_exec_test_lib
   velox_dwio_common_exception
   velox_exec
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)
 
 add_executable(velox_s3finalize_test S3FileSystemFinalizeTest.cpp)
 add_test(velox_s3finalize_test velox_s3finalize_test)
@@ -48,8 +48,8 @@ target_link_libraries(
   velox_hive_config
   velox_file
   velox_core
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)
 
 add_executable(velox_s3insert_test S3InsertTest.cpp)
 add_test(velox_s3insert_test velox_s3insert_test)
@@ -62,8 +62,8 @@ target_link_libraries(
   velox_exec_test_lib
   velox_dwio_common_exception
   velox_exec
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)
 
 add_executable(velox_s3read_test S3ReadTest.cpp)
 add_test(
@@ -79,8 +79,8 @@ target_link_libraries(
   velox_exec_test_lib
   velox_dwio_common_exception
   velox_exec
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)
 
 add_executable(velox_s3multiendpoints_test S3MultipleEndpointsTest.cpp)
 add_test(velox_s3multiendpoints_test velox_s3multiendpoints_test)
@@ -93,5 +93,5 @@ target_link_libraries(
   velox_exec_test_lib
   velox_dwio_common_exception
   velox_exec
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)

--- a/velox/connectors/hive/tests/CMakeLists.txt
+++ b/velox/connectors/hive/tests/CMakeLists.txt
@@ -34,5 +34,5 @@ target_link_libraries(
   velox_vector_test_lib
   velox_exec
   velox_exec_test_lib
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)

--- a/velox/connectors/tests/CMakeLists.txt
+++ b/velox/connectors/tests/CMakeLists.txt
@@ -17,8 +17,8 @@ add_test(velox_connector_test velox_connector_test)
 target_link_libraries(
   velox_connector_test
   velox_connector
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   glog::glog
   gflags::gflags
   Folly::folly)

--- a/velox/connectors/tpch/tests/CMakeLists.txt
+++ b/velox/connectors/tpch/tests/CMakeLists.txt
@@ -21,8 +21,8 @@ target_link_libraries(
   velox_vector_test_lib
   velox_exec_test_lib
   velox_aggregates
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)
 
 add_executable(velox_tpch_speed_test SpeedTest.cpp)
 

--- a/velox/core/tests/CMakeLists.txt
+++ b/velox/core/tests/CMakeLists.txt
@@ -33,5 +33,5 @@ target_link_libraries(
     velox_presto_types
     velox_type
     velox_vector_test_lib
-    gtest
-    gtest_main)
+    GTest::gtest
+    GTest::gtest_main)

--- a/velox/duckdb/conversion/tests/CMakeLists.txt
+++ b/velox/duckdb/conversion/tests/CMakeLists.txt
@@ -24,6 +24,6 @@ target_link_libraries(
   velox_functions_prestosql
   velox_functions_lib
   velox_functions_test_lib
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   gflags::gflags)

--- a/velox/dwio/catalog/fbhive/test/CMakeLists.txt
+++ b/velox/dwio/catalog/fbhive/test/CMakeLists.txt
@@ -18,6 +18,6 @@ target_link_libraries(
   file_utils_test
   velox_dwio_catalog_fbhive
   velox_dwio_common_exception
-  gtest
-  gtest_main
-  gmock)
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock)

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -50,9 +50,9 @@ target_link_libraries(
   Folly::folly
   ${TEST_LINK_LIBS}
   gflags::gflags
-  gtest
-  gtest_main
-  gmock
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock
   glog::glog
   fmt::fmt
   protobuf::libprotobuf)

--- a/velox/dwio/common/tests/utils/CMakeLists.txt
+++ b/velox/dwio/common/tests/utils/CMakeLists.txt
@@ -27,7 +27,7 @@ target_link_libraries(
   fmt::fmt
   glog::glog
   gflags::gflags
-  gtest
+  GTest::gtest
   velox_dwio_common
   velox_dwio_common_exception
   velox_exception

--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -20,9 +20,9 @@ set(TEST_LINK_LIBS
     velox_dwio_dwrf_reader
     velox_dwio_dwrf_writer
     gflags::gflags
-    gtest
-    gtest_main
-    gmock
+    GTest::gtest
+    GTest::gtest_main
+    GTest::gmock
     glog::glog
     ${FILESYSTEM})
 

--- a/velox/dwio/dwrf/test/utils/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/utils/CMakeLists.txt
@@ -25,8 +25,8 @@ target_link_libraries(
   velox_memory
   velox_type
   velox_vector
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)
 
 # older versions of GCC need it to allow std::filesystem
 if(CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)

--- a/velox/dwio/dwrf/utils/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/utils/test/CMakeLists.txt
@@ -24,6 +24,6 @@ target_link_libraries(
   velox_dwio_common_exception
   velox_type_fbhive
   gflags::gflags
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   glog::glog)

--- a/velox/dwio/orc/test/CMakeLists.txt
+++ b/velox/dwio/orc/test/CMakeLists.txt
@@ -22,9 +22,9 @@ target_link_libraries(
   velox_dwio_orc_reader_test
   velox_dwrf_test_utils
   velox_dwio_common_test_utils
-  gtest
-  gtest_main
-  gmock)
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock)
 
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/examples
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/velox/dwio/parquet/tests/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/CMakeLists.txt
@@ -17,9 +17,9 @@ set(TEST_LINK_LIBS
     velox_vector_test_lib
     velox_exec_test_lib
     velox_temp_path
-    gtest
-    gtest_main
-    gmock
+    GTest::gtest
+    GTest::gtest_main
+    GTest::gmock
     gflags::gflags
     ${GLOG}
     ${FILESYSTEM})

--- a/velox/dwio/parquet/tests/thrift/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/thrift/CMakeLists.txt
@@ -20,5 +20,5 @@ target_link_libraries(
   arrow
   thrift
   velox_link_libs
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)

--- a/velox/dwio/parquet/tests/writer/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/writer/CMakeLists.txt
@@ -28,7 +28,7 @@ target_link_libraries(
   velox_link_libs
   Folly::folly
   ${TEST_LINK_LIBS}
-  gtest
+  GTest::gtest
   fmt::fmt)
 
 add_executable(velox_parquet_writer_test ParquetWriterTest.cpp)
@@ -46,5 +46,5 @@ target_link_libraries(
   Boost::regex
   Folly::folly
   ${TEST_LINK_LIBS}
-  gtest
+  GTest::gtest
   fmt::fmt)

--- a/velox/dwio/parquet/writer/arrow/tests/CMakeLists.txt
+++ b/velox/dwio/parquet/writer/arrow/tests/CMakeLists.txt
@@ -52,4 +52,4 @@ add_library(
 
 target_link_libraries(
   velox_dwio_arrow_parquet_writer_test_lib arrow
-  velox_dwio_arrow_parquet_writer_lib gtest)
+  velox_dwio_arrow_parquet_writer_lib GTest::gtest)

--- a/velox/dwio/parquet/writer/arrow/tests/CMakeLists.txt
+++ b/velox/dwio/parquet/writer/arrow/tests/CMakeLists.txt
@@ -34,9 +34,9 @@ add_test(velox_dwio_arrow_parquet_writer_test
 target_link_libraries(
   velox_dwio_arrow_parquet_writer_test
   velox_dwio_arrow_parquet_writer_test_lib
-  gmock
-  gtest
-  gtest_main
+  GTest::gmock
+  GTest::gtest
+  GTest::gtest_main
   arrow
   arrow_testing)
 

--- a/velox/exec/benchmarks/CMakeLists.txt
+++ b/velox/exec/benchmarks/CMakeLists.txt
@@ -42,8 +42,8 @@ target_link_libraries(
   velox_exec
   velox_vector_test_lib
   ${FOLLY_BENCHMARK}
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)
 
 add_executable(velox_hash_benchmark HashTableBenchmark.cpp)
 

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -148,9 +148,9 @@ target_link_libraries(
   Boost::regex
   Boost::thread
   Boost::system
-  gtest
-  gtest_main
-  gmock
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock
   Folly::folly
   gflags::gflags
   glog::glog

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -27,8 +27,8 @@ target_link_libraries(
   aggregate_companion_functions_test
   velox_exec
   velox_function_registry
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)
 
 add_executable(
   velox_exec_test
@@ -186,9 +186,9 @@ target_link_libraries(
   Boost::regex
   Boost::thread
   Boost::system
-  gtest
-  gtest_main
-  gmock
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock
   Folly::folly
   gflags::gflags
   glog::glog
@@ -212,21 +212,22 @@ target_link_libraries(
 add_executable(velox_row_number_fuzzer_test RowNumberFuzzerTest.cpp)
 
 target_link_libraries(
-  velox_row_number_fuzzer_test velox_row_number_fuzzer gtest gtest_main)
+  velox_row_number_fuzzer_test velox_row_number_fuzzer GTest::gtest
+  GTest::gtest_main)
 
 # Join Fuzzer.
 add_executable(velox_join_fuzzer_test JoinFuzzerTest.cpp)
 
 target_link_libraries(
-  velox_join_fuzzer_test velox_join_fuzzer gtest gtest_main)
+  velox_join_fuzzer_test velox_join_fuzzer GTest::gtest GTest::gtest_main)
 
 # Arbitration Fuzzer.
 add_executable(velox_memory_arbitration_fuzzer_test
                MemoryArbitrationFuzzerTest.cpp)
 
 target_link_libraries(
-  velox_memory_arbitration_fuzzer_test velox_memory_arbitration_fuzzer gtest
-  gtest_main)
+  velox_memory_arbitration_fuzzer_test velox_memory_arbitration_fuzzer
+  GTest::gtest GTest::gtest_main)
 
 # Cache Fuzzer
 add_executable(velox_cache_fuzzer_test CacheFuzzerTest.cpp)
@@ -235,8 +236,8 @@ target_link_libraries(
   velox_cache_fuzzer_test
   velox_cache_fuzzer
   velox_fuzzer_util
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)
 
 add_executable(velox_exchange_fuzzer_test ExchangeFuzzer.cpp)
 
@@ -246,9 +247,9 @@ target_link_libraries(
   velox_aggregates
   velox_vector_test_lib
   velox_vector_fuzzer
-  gtest
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest
+  GTest::gtest_main)
 
 add_executable(velox_aggregation_runner_test AggregationRunnerTest.cpp)
 
@@ -258,8 +259,8 @@ target_link_libraries(
   velox_fuzzer_util
   velox_aggregates
   velox_vector_test_lib
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)
 
 add_library(velox_simple_aggregate SimpleAverageAggregate.cpp
                                    SimpleArrayAggAggregate.cpp)
@@ -279,8 +280,8 @@ target_link_libraries(
   velox_simple_aggregate
   velox_exec
   velox_functions_aggregates_test_lib
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)
 
 add_library(velox_spiller_join_benchmark_base JoinSpillInputBenchmarkBase.cpp
                                               SpillerBenchmarkBase.cpp)
@@ -325,4 +326,4 @@ add_test(
   COMMAND cpr_http_client_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(
-  cpr_http_client_test cpr::cpr gtest gtest_main)
+  cpr_http_client_test cpr::cpr GTest::gtest GTest::gtest_main)

--- a/velox/experimental/wave/common/tests/CMakeLists.txt
+++ b/velox/experimental/wave/common/tests/CMakeLists.txt
@@ -30,8 +30,8 @@ target_link_libraries(
   velox_memory
   velox_time
   velox_exception
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   gflags::gflags
   glog::glog
   Folly::folly)

--- a/velox/experimental/wave/dwio/decode/tests/CMakeLists.txt
+++ b/velox/experimental/wave/dwio/decode/tests/CMakeLists.txt
@@ -23,8 +23,8 @@ target_link_libraries(
   velox_memory
   velox_time
   velox_exception
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   gflags::gflags
   glog::glog
   Folly::folly)

--- a/velox/experimental/wave/exec/tests/CMakeLists.txt
+++ b/velox/experimental/wave/exec/tests/CMakeLists.txt
@@ -50,9 +50,9 @@ target_link_libraries(
   Boost::regex
   Boost::thread
   Boost::system
-  gtest
-  gtest_main
-  gmock
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock
   Folly::folly
   gflags::gflags
   glog::glog

--- a/velox/experimental/wave/vector/tests/CMakeLists.txt
+++ b/velox/experimental/wave/vector/tests/CMakeLists.txt
@@ -29,9 +29,9 @@ target_link_libraries(
   Boost::regex
   Boost::thread
   Boost::system
-  gtest
-  gtest_main
-  gmock
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock
   Folly::folly
   gflags::gflags
   glog::glog

--- a/velox/expression/fuzzer/CMakeLists.txt
+++ b/velox/expression/fuzzer/CMakeLists.txt
@@ -16,7 +16,8 @@ add_library(velox_expression_test_utility ArgumentTypeFuzzer.cpp
                                           FuzzerToolkit.cpp)
 
 target_link_libraries(
-  velox_expression_test_utility velox_type velox_expression_functions gtest)
+  velox_expression_test_utility velox_type velox_expression_functions
+  GTest::gtest)
 
 add_library(
   velox_expression_fuzzer

--- a/velox/expression/fuzzer/CMakeLists.txt
+++ b/velox/expression/fuzzer/CMakeLists.txt
@@ -41,8 +41,8 @@ target_link_libraries(
   velox_expression_fuzzer_test
   velox_expression_fuzzer
   velox_functions_prestosql
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)
 
 add_executable(spark_expression_fuzzer_test SparkExpressionFuzzerTest.cpp)
 
@@ -50,8 +50,8 @@ target_link_libraries(
   spark_expression_fuzzer_test
   velox_expression_fuzzer
   velox_functions_spark
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/expression/fuzzer/tests/CMakeLists.txt
+++ b/velox/expression/fuzzer/tests/CMakeLists.txt
@@ -29,5 +29,5 @@ target_link_libraries(
   velox_core
   velox_expression
   velox_expression_fuzzer_test_utility
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)

--- a/velox/expression/fuzzer/tests/CMakeLists.txt
+++ b/velox/expression/fuzzer/tests/CMakeLists.txt
@@ -15,7 +15,7 @@
 add_library(velox_expression_fuzzer_test_utility ArgGeneratorTestUtils.cpp)
 target_link_libraries(
   velox_expression_fuzzer_test_utility velox_expression_functions
-  velox_function_registry gtest)
+  velox_function_registry GTest::gtest)
 
 add_executable(
   velox_expression_fuzzer_unit_test

--- a/velox/expression/signature_parser/tests/CMakeLists.txt
+++ b/velox/expression/signature_parser/tests/CMakeLists.txt
@@ -20,6 +20,6 @@ target_link_libraries(
   velox_signature_parser_test
   velox_signature_parser
   velox_type_signature
-  gtest
-  gtest_main
-  gmock)
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock)

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -95,7 +95,7 @@ target_link_libraries(
   velox_functions_prestosql
   velox_functions_spark
   velox_parse_parser
-  gtest)
+  GTest::gtest)
 
 add_executable(velox_expression_runner_test ExpressionRunnerTest.cpp)
 target_link_libraries(

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -71,9 +71,9 @@ target_link_libraries(
   velox_presto_serializer
   velox_vector_test_lib
   velox_vector_fuzzer
-  gtest
-  gtest_main
-  gmock
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock
   Folly::folly
   gflags::gflags
   glog::glog
@@ -103,8 +103,8 @@ target_link_libraries(
   velox_expression_runner
   velox_exec_test_lib
   velox_function_registry
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)
 
 add_executable(velox_expression_verifier_unit_test
                ExpressionVerifierUnitTest.cpp)
@@ -118,8 +118,8 @@ target_link_libraries(
   velox_parse_utils
   velox_type
   velox_vector_test_lib
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)
 
 add_executable(velox_expression_runner_unit_test ExpressionRunnerUnitTest.cpp)
 target_link_libraries(
@@ -133,5 +133,5 @@ target_link_libraries(
   velox_temp_path
   velox_exec_test_lib
   velox_vector_test_lib
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)

--- a/velox/functions/lib/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/lib/aggregates/tests/CMakeLists.txt
@@ -24,6 +24,6 @@ target_link_libraries(
   velox_functions_aggregates
   velox_functions_test_lib
   Folly::folly
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   glog::glog)

--- a/velox/functions/lib/string/tests/CMakeLists.txt
+++ b/velox/functions/lib/string/tests/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries(
   velox_functions_string_test
   velox_functions_string
   Folly::folly
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   gflags::gflags
   glog::glog)

--- a/velox/functions/lib/tests/CMakeLists.txt
+++ b/velox/functions/lib/tests/CMakeLists.txt
@@ -39,7 +39,7 @@ target_link_libraries(
   velox_expression
   velox_memory
   velox_dwio_common_test_utils
-  gtest
-  gtest_main
-  gmock
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock
   gflags::gflags)

--- a/velox/functions/lib/window/tests/CMakeLists.txt
+++ b/velox/functions/lib/window/tests/CMakeLists.txt
@@ -20,4 +20,4 @@ target_link_libraries(
   velox_vector_fuzzer
   velox_vector_test_lib
   gflags::gflags
-  gtest)
+  GTest::gtest)

--- a/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -74,5 +74,5 @@ target_link_libraries(
   velox_vector_fuzzer
   velox_temp_path
   gflags::gflags
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)

--- a/velox/functions/prestosql/fuzzer/CMakeLists.txt
+++ b/velox/functions/prestosql/fuzzer/CMakeLists.txt
@@ -32,8 +32,8 @@ target_link_libraries(
   velox_aggregates
   velox_window
   velox_vector_test_lib
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)
 
 # Window Fuzzer
 add_executable(velox_window_fuzzer_test WindowFuzzerTest.cpp)
@@ -47,8 +47,8 @@ target_link_libraries(
   velox_expression_test_utility
   velox_functions_prestosql
   velox_vector_test_lib
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)
 
 # Writer Fuzzer
 add_executable(velox_writer_fuzzer_test WriterFuzzerTest.cpp)
@@ -57,5 +57,5 @@ target_link_libraries(
   velox_writer_fuzzer_test
   velox_writer_fuzzer
   velox_fuzzer_util
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)

--- a/velox/functions/prestosql/json/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/json/tests/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(
   velox_functions_json_test
   velox_functions_json
   Folly::folly
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   gflags::gflags
   glog::glog)

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -120,8 +120,8 @@ target_link_libraries(
   velox_vector_fuzzer
   velox_expression_fuzzer_test_utility
   velox_expression_fuzzer
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   gflags::gflags
-  gmock
-  gmock_main)
+  GTest::gmock
+  GTest::gmock_main)

--- a/velox/functions/prestosql/types/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/types/tests/CMakeLists.txt
@@ -26,8 +26,8 @@ target_link_libraries(
   velox_presto_types_test
   velox_presto_types
   Folly::folly
-  gtest
-  gtest_main
-  gmock
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock
   gflags::gflags
   glog::glog)

--- a/velox/functions/prestosql/window/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/window/tests/CMakeLists.txt
@@ -21,8 +21,8 @@ set(CMAKE_WINDOW_TEST_LINK_LIBRARIES
     velox_vector_test_lib
     velox_window
     gflags::gflags
-    gtest
-    gtest_main)
+    GTest::gtest
+    GTest::gtest_main)
 
 set(CMAKE_WINDOW_TEST_MAIN_FILES Main.cpp)
 

--- a/velox/functions/remote/client/tests/CMakeLists.txt
+++ b/velox/functions/remote/client/tests/CMakeLists.txt
@@ -24,6 +24,6 @@ target_link_libraries(
   velox_function_registry
   velox_functions_test_lib
   velox_exec_test_lib
-  gmock
-  gtest
-  gtest_main)
+  GTest::gmock
+  GTest::gtest
+  GTest::gtest_main)

--- a/velox/functions/sparksql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/aggregates/tests/CMakeLists.txt
@@ -41,5 +41,5 @@ target_link_libraries(
   velox_hive_connector
   velox_vector_fuzzer
   gflags::gflags
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)

--- a/velox/functions/sparksql/fuzzer/CMakeLists.txt
+++ b/velox/functions/sparksql/fuzzer/CMakeLists.txt
@@ -22,5 +22,5 @@ target_link_libraries(
   velox_fuzzer_util
   velox_window
   velox_vector_test_lib
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -64,7 +64,7 @@ target_link_libraries(
   velox_expression_fuzzer_test_utility
   velox_expression_fuzzer
   fmt::fmt
-  gtest
-  gtest_main
-  gmock
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock
   gflags::gflags)

--- a/velox/functions/sparksql/window/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/window/tests/CMakeLists.txt
@@ -21,8 +21,8 @@ set(CMAKE_WINDOW_TEST_LINK_LIBRARIES
     velox_vector_fuzzer
     velox_vector_test_lib
     gflags::gflags
-    gtest
-    gtest_main)
+    GTest::gtest
+    GTest::gtest_main)
 
 set(CMAKE_WINDOW_TEST_MAIN_FILES Main.cpp)
 

--- a/velox/functions/tests/CMakeLists.txt
+++ b/velox/functions/tests/CMakeLists.txt
@@ -19,6 +19,6 @@ target_link_libraries(
   velox_function_registry_test
   velox_function_registry
   velox_functions_test_lib
-  gmock
-  gtest
-  gtest_main)
+  GTest::gmock
+  GTest::gtest
+  GTest::gtest_main)

--- a/velox/parse/tests/CMakeLists.txt
+++ b/velox/parse/tests/CMakeLists.txt
@@ -19,6 +19,6 @@ add_test(velox_parse_test velox_parse_test)
 target_link_libraries(
   velox_parse_test
   velox_parse_parser
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   gflags::gflags)

--- a/velox/row/tests/CMakeLists.txt
+++ b/velox/row/tests/CMakeLists.txt
@@ -25,5 +25,5 @@ target_link_libraries(
     velox_vector_fuzzer
     velox_vector_test_lib
     Folly::folly
-    gtest
-    gtest_main)
+    GTest::gtest
+    GTest::gtest_main)

--- a/velox/serializers/tests/CMakeLists.txt
+++ b/velox/serializers/tests/CMakeLists.txt
@@ -24,8 +24,8 @@ target_link_libraries(
   velox_vector_test_lib
   velox_vector_fuzzer
   velox_row_fast
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   gflags::gflags
   glog::glog)
 
@@ -36,7 +36,7 @@ target_link_libraries(
   velox_presto_serializer
   velox_vector_test_lib
   velox_vector_fuzzer
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   gflags::gflags
   glog::glog)

--- a/velox/substrait/tests/CMakeLists.txt
+++ b/velox/substrait/tests/CMakeLists.txt
@@ -56,8 +56,8 @@ target_link_libraries(
   Boost::regex
   Boost::thread
   Boost::system
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   Folly::folly
   gflags::gflags
   glog::glog

--- a/velox/tpch/gen/tests/CMakeLists.txt
+++ b/velox/tpch/gen/tests/CMakeLists.txt
@@ -20,5 +20,5 @@ target_link_libraries(
   velox_tpch_gen
   velox_type
   velox_vector
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)

--- a/velox/type/fbhive/tests/CMakeLists.txt
+++ b/velox/type/fbhive/tests/CMakeLists.txt
@@ -23,6 +23,6 @@ target_link_libraries(
   velox_type_fbhive_test
   velox_type_fbhive
   velox_type
-  gtest
-  gtest_main
-  gmock)
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock)

--- a/velox/type/parser/tests/CMakeLists.txt
+++ b/velox/type/parser/tests/CMakeLists.txt
@@ -20,6 +20,6 @@ target_link_libraries(
   velox_type_parser_test
   velox_type_parser
   velox_type
-  gtest
-  gtest_main
-  gmock)
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock)

--- a/velox/type/tests/CMakeLists.txt
+++ b/velox/type/tests/CMakeLists.txt
@@ -33,9 +33,9 @@ target_link_libraries(
   velox_type
   velox_common_base
   Folly::folly
-  gtest
-  gtest_main
-  gmock
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock
   gflags::gflags
   glog::glog)
 
@@ -47,8 +47,8 @@ target_link_libraries(
   velox_serialization
   Folly::folly
   ${FOLLY_BENCHMARK}
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   gflags::gflags
   glog::glog)
 
@@ -61,8 +61,8 @@ target_link_libraries(
   velox_serialization
   Folly::folly
   ${FOLLY_BENCHMARK}
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   gflags::gflags
   glog::glog)
 
@@ -75,8 +75,8 @@ target_link_libraries(
   velox_serialization
   Folly::folly
   ${FOLLY_BENCHMARK}
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   gflags::gflags
   glog::glog)
 
@@ -89,8 +89,8 @@ target_link_libraries(
   velox_serialization
   Folly::folly
   ${FOLLY_BENCHMARK}
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   gflags::gflags
   glog::glog)
 
@@ -103,8 +103,8 @@ target_link_libraries(
   velox_serialization
   Folly::folly
   ${FOLLY_BENCHMARK}
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   gflags::gflags
   glog::glog)
 
@@ -115,7 +115,7 @@ target_link_libraries(
   velox_type
   Folly::folly
   ${FOLLY_BENCHMARK}
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   gflags::gflags
   glog::glog)

--- a/velox/type/tz/tests/CMakeLists.txt
+++ b/velox/type/tz/tests/CMakeLists.txt
@@ -20,6 +20,6 @@ target_link_libraries(
   velox_type_tz_test
   velox_type_tz
   velox_exception
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   pthread)

--- a/velox/vector/arrow/tests/CMakeLists.txt
+++ b/velox/vector/arrow/tests/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries(
   velox_arrow_bridge
   velox_vector_test_lib
   arrow
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   glog::glog
   dl)

--- a/velox/vector/benchmarks/CMakeLists.txt
+++ b/velox/vector/benchmarks/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(
   fmt::fmt)
 # This is a workaround for the use of VectorTestUtils.h which include gtest.h
 target_link_libraries(
-  velox_vector_hash_all_benchmark gtest)
+  velox_vector_hash_all_benchmark GTest::gtest)
 
 add_executable(velox_vector_selectivity_vector_benchmark
                SelectivityVectorBenchmark.cpp)

--- a/velox/vector/fuzzer/tests/CMakeLists.txt
+++ b/velox/vector/fuzzer/tests/CMakeLists.txt
@@ -19,6 +19,6 @@ target_link_libraries(
   velox_vector_fuzzer_test
   velox_vector_fuzzer
   velox_memory
-  gtest
-  gtest_main
-  gmock)
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock)

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -57,8 +57,8 @@ target_link_libraries(
   Boost::regex
   Boost::thread
   Boost::system
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   Folly::folly
   gflags::gflags
   glog::glog
@@ -75,8 +75,8 @@ target_link_libraries(
   velox_buffer
   velox_type
   velox_vector_test_lib
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   Folly::folly
   gflags::gflags
   glog::glog
@@ -90,8 +90,8 @@ target_link_libraries(
   bias_vector_test
   velox_vector
   Boost::filesystem
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   Folly::folly
   gflags::gflags
   glog::glog

--- a/velox/vector/tests/utils/CMakeLists.txt
+++ b/velox/vector/tests/utils/CMakeLists.txt
@@ -14,4 +14,4 @@
 add_library(velox_vector_test_lib VectorMaker.cpp VectorTestBase.cpp)
 
 target_link_libraries(
-  velox_vector_test_lib velox_vector gtest gtest_main)
+  velox_vector_test_lib velox_vector GTest::gtest GTest::gtest_main)


### PR DESCRIPTION
Fixes #10421 

1. Use "GTest"(not `"gtest"` or `"GTEST"`) in `find_package` to solve
   the following warning:

```
CMake Warning at CMake/ResolveDependency.cmake:70 (find_package):
  By not providing "Findgtest.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "gtest", but
  CMake did not find one.

  Could not find a package configuration file provided by "gtest" with any of
  the following names:

    gtestConfig.cmake
    gtest-config.cmake

  Add the installation prefix of "gtest" to CMAKE_PREFIX_PATH or set
  "gtest_DIR" to a directory containing one of the above files.  If "gtest"
  provides a separate development package or SDK, be sure it has been
  installed.
Call Stack (most recent call first):
  CMakeLists.txt:542 (resolve_dependency)
```

2. Use `GTest::gtest` and `Gtest::gtest_main` in the
   `target_link_libraries` to solve the following error when 'gtest' is
   pre-installed(not using the BUNDLED way). See [1]

```
ld: library not found for -gtest
```

3. Finally, because the compilation error of the precompiled 'gtest'
library has been solved, we can pre-install the 'gtest' library
in setup-macos.sh.


[1] https://cmake.org/cmake/help/v3.30/module/FindGTest.html