### PR TITLE
Fix ApproxDistinctResultVerifier for window fuzzer

### DIFF
--- a/velox/functions/prestosql/fuzzer/ApproxDistinctResultVerifier.h
+++ b/velox/functions/prestosql/fuzzer/ApproxDistinctResultVerifier.h
@@ -228,7 +228,7 @@ class ApproxDistinctResultVerifier : public ResultVerifier {
 
     // We expect large deviations (>2 stddev) in < 5% of values.
     if (numGroups >= 50) {
-      return largeGaps.size() <= 3;
+      return largeGaps.size() <= 0.05 * numGroups;
     }
 
     return largeGaps.empty();


### PR DESCRIPTION
Summary:
ApproxDistinctResultVerifier expects the number of groups with large
errors to not exceed 5% of the number of all groups. The code
currently instead hardcodes the bound to allow only 3 groups of large
errors. This diff fixes the bound to be 5% * numGroups.

The verification logic for aggregation fuzzer works fine so far, so this
diff doesn't update the bound for aggregation fuzzer.

Differential Revision: D59530860
