### PR TITLE
Remove redundant memory management initialization

### DIFF
--- a/velox/exec/tests/AggregationRunnerTest.cpp
+++ b/velox/exec/tests/AggregationRunnerTest.cpp
@@ -75,7 +75,6 @@ int main(int argc, char** argv) {
 
   facebook::velox::aggregate::prestosql::registerAllAggregateFunctions();
   facebook::velox::functions::prestosql::registerAllScalarFunctions();
-  facebook::velox::memory::MemoryManager::initialize({});
 
   auto duckQueryRunner =
       std::make_unique<facebook::velox::exec::test::DuckQueryRunner>();


### PR DESCRIPTION
Summary: MemoryManager initalization was moved up further in the code but the original placement wasn't removed

Differential Revision: D59545365
