### PR TITLE
Bump up JVM memory for presto query runner

### DIFF
--- a/scripts/presto/etc/jvm.config.example
+++ b/scripts/presto/etc/jvm.config.example
@@ -1,5 +1,5 @@
 -server
--Xmx1G
+-Xmx10G
 -XX:+UseG1GC
 -XX:G1HeapRegionSize=32M
 -XX:+UseGCOverheadLimit


### PR DESCRIPTION
Table writer fuzzer runs against presto query runner and 
presto query runner is crashing because of out of memory.