### PR TITLE
Respect Presto configs for enabling/disabling dictionary encoding in DWRF writer

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -210,6 +210,20 @@ uint64_t HiveConfig::orcWriterMaxDictionaryMemory(const Config* session) const {
       core::CapacityUnit::BYTE);
 }
 
+bool HiveConfig::isOrcWriterIntegerDictionaryEncodingEnabled(
+    const Config* session) const {
+  return session->get<bool>(
+      kOrcWriterIntegerDictionaryEncodingEnabledSession,
+      config_->get<bool>(kOrcWriterIntegerDictionaryEncodingEnabled, true));
+}
+
+bool HiveConfig::isOrcWriterStringDictionaryEncodingEnabled(
+    const Config* session) const {
+  return session->get<bool>(
+      kOrcWriterStringDictionaryEncodingEnabledSession,
+      config_->get<bool>(kOrcWriterStringDictionaryEncodingEnabled, true));
+}
+
 bool HiveConfig::orcWriterLinearStripeSizeHeuristics(
     const Config* session) const {
   return session->get<bool>(

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -180,6 +180,18 @@ class HiveConfig {
   static constexpr const char* kOrcWriterMaxDictionaryMemorySession =
       "orc_optimized_writer_max_dictionary_memory";
 
+  /// Configs to control dictionary encoding.
+  static constexpr const char* kOrcWriterIntegerDictionaryEncodingEnabled =
+      "hive.orc.writer.integer-dictionary-encoding-enabled";
+  static constexpr const char*
+      kOrcWriterIntegerDictionaryEncodingEnabledSession =
+          "orc_optimized_writer_integer_dictionary_encoding_enabled";
+  static constexpr const char* kOrcWriterStringDictionaryEncodingEnabled =
+      "hive.orc.writer.string-dictionary-encoding-enabled";
+  static constexpr const char*
+      kOrcWriterStringDictionaryEncodingEnabledSession =
+          "orc_optimized_writer_string_dictionary_encoding_enabled";
+
   /// Enables historical based stripe size estimation after compression.
   static constexpr const char* kOrcWriterLinearStripeSizeHeuristics =
       "hive.orc.writer.linear-stripe-size-heuristics";
@@ -298,6 +310,10 @@ class HiveConfig {
   uint64_t orcWriterMaxStripeSize(const Config* session) const;
 
   uint64_t orcWriterMaxDictionaryMemory(const Config* session) const;
+
+  bool isOrcWriterIntegerDictionaryEncodingEnabled(const Config* session) const;
+
+  bool isOrcWriterStringDictionaryEncodingEnabled(const Config* session) const;
 
   bool orcWriterLinearStripeSizeHeuristics(const Config* session) const;
 

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -693,6 +693,12 @@ uint32_t HiveDataSink::appendWriter(const HiveWriterId& id) {
       hiveConfig_->orcWriterMaxStripeSize(connectorSessionProperties));
   options.maxDictionaryMemory = std::optional(
       hiveConfig_->orcWriterMaxDictionaryMemory(connectorSessionProperties));
+  options.orcWriterIntegerDictionaryEncodingEnabled =
+      hiveConfig_->isOrcWriterIntegerDictionaryEncodingEnabled(
+          connectorSessionProperties);
+  options.orcWriterStringDictionaryEncodingEnabled =
+      hiveConfig_->isOrcWriterStringDictionaryEncodingEnabled(
+          connectorSessionProperties);
   options.parquetWriteTimestampUnit =
       hiveConfig_->parquetWriteTimestampUnit(connectorSessionProperties);
   options.orcMinCompressionSize = std::optional(

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -57,6 +57,13 @@ TEST(HiveConfigTest, defaultConfig) {
   ASSERT_EQ(
       hiveConfig.orcWriterMaxDictionaryMemory(emptySession.get()),
       16L * 1024L * 1024L);
+  ASSERT_EQ(
+      hiveConfig.isOrcWriterIntegerDictionaryEncodingEnabled(
+          emptySession.get()),
+      true);
+  ASSERT_EQ(
+      hiveConfig.isOrcWriterStringDictionaryEncodingEnabled(emptySession.get()),
+      true);
   ASSERT_EQ(hiveConfig.sortWriterMaxOutputRows(emptySession.get()), 1024);
   ASSERT_EQ(
       hiveConfig.sortWriterMaxOutputBytes(emptySession.get()), 10UL << 20);
@@ -94,6 +101,8 @@ TEST(HiveConfigTest, overrideConfig) {
       {HiveConfig::kEnableFileHandleCache, "false"},
       {HiveConfig::kOrcWriterMaxStripeSize, "100MB"},
       {HiveConfig::kOrcWriterMaxDictionaryMemory, "100MB"},
+      {HiveConfig::kOrcWriterIntegerDictionaryEncodingEnabled, "false"},
+      {HiveConfig::kOrcWriterStringDictionaryEncodingEnabled, "false"},
       {HiveConfig::kSortWriterMaxOutputRows, "100"},
       {HiveConfig::kSortWriterMaxOutputBytes, "100MB"},
       {HiveConfig::kOrcWriterLinearStripeSizeHeuristics, "false"},
@@ -133,6 +142,13 @@ TEST(HiveConfigTest, overrideConfig) {
   ASSERT_EQ(
       hiveConfig.orcWriterMaxDictionaryMemory(emptySession.get()),
       100L * 1024L * 1024L);
+  ASSERT_EQ(
+      hiveConfig.isOrcWriterIntegerDictionaryEncodingEnabled(
+          emptySession.get()),
+      false);
+  ASSERT_EQ(
+      hiveConfig.isOrcWriterStringDictionaryEncodingEnabled(emptySession.get()),
+      false);
   ASSERT_EQ(hiveConfig.sortWriterMaxOutputRows(emptySession.get()), 100);
   ASSERT_EQ(
       hiveConfig.sortWriterMaxOutputBytes(emptySession.get()), 100UL << 20);
@@ -152,6 +168,8 @@ TEST(HiveConfigTest, overrideSession) {
       {HiveConfig::kFileColumnNamesReadAsLowerCaseSession, "true"},
       {HiveConfig::kOrcWriterMaxStripeSizeSession, "22MB"},
       {HiveConfig::kOrcWriterMaxDictionaryMemorySession, "22MB"},
+      {HiveConfig::kOrcWriterIntegerDictionaryEncodingEnabledSession, "false"},
+      {HiveConfig::kOrcWriterStringDictionaryEncodingEnabledSession, "false"},
       {HiveConfig::kSortWriterMaxOutputRowsSession, "20"},
       {HiveConfig::kSortWriterMaxOutputBytesSession, "20MB"},
       {HiveConfig::kPartitionPathAsLowerCaseSession, "false"},
@@ -191,6 +209,12 @@ TEST(HiveConfigTest, overrideSession) {
   ASSERT_EQ(
       hiveConfig.orcWriterMaxDictionaryMemory(session.get()),
       22L * 1024L * 1024L);
+  ASSERT_EQ(
+      hiveConfig.isOrcWriterIntegerDictionaryEncodingEnabled(session.get()),
+      false);
+  ASSERT_EQ(
+      hiveConfig.isOrcWriterStringDictionaryEncodingEnabled(session.get()),
+      false);
   ASSERT_EQ(hiveConfig.sortWriterMaxOutputRows(session.get()), 20);
   ASSERT_EQ(hiveConfig.sortWriterMaxOutputBytes(session.get()), 20UL << 20);
   ASSERT_EQ(hiveConfig.isPartitionPathAsLowerCase(session.get()), false);

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -478,6 +478,16 @@ Each query can override the config by setting corresponding query session proper
      - string
      - 16M
      - Maximum dictionary memory that can be used in orc writer.
+   * - hive.orc.writer.integer-dictionary-encoding-enabled
+     - orc_optimized_writer_integer_dictionary_encoding_enabled
+     - bool
+     - true
+     - Whether or not dictionary encoding of integer types should be used by the ORC writer.
+   * - hive.orc.writer.string-dictionary-encoding-enabled
+     - orc_optimized_writer_string_dictionary_encoding_enabled
+     - bool
+     - true
+     - Whether or not dictionary encoding of string types should be used by the ORC writer.
    * - hive.parquet.writer.timestamp-unit
      - hive.parquet.writer.timestamp_unit
      - tinyint
@@ -498,7 +508,7 @@ Each query can override the config by setting corresponding query session proper
      - orc_optimized_writer_compression_level
      - tinyint
      - 3 for ZSTD and 4 for ZLIB
-     - The compression level to use with ZLIB and ZSTD. 
+     - The compression level to use with ZLIB and ZSTD.
    * - cache.no_retention
      - cache.no_retention
      - bool
@@ -583,7 +593,7 @@ Each query can override the config by setting corresponding query session proper
      - **Allowed values:** "standard", "adaptive", "legacy". By default it's empty, S3 client will be created with RetryStrategy.
        Legacy mode only enables throttled retry for transient errors.
        Standard mode is built on top of legacy mode and has throttled retry enabled for throttling errors apart from transient errors.
-       Adaptive retry mode dynamically limits the rate of AWS requests to maximize success rate. 
+       Adaptive retry mode dynamically limits the rate of AWS requests to maximize success rate.
 ``Google Cloud Storage Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. list-table::

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -602,6 +602,8 @@ struct WriterOptions {
   std::optional<uint64_t> maxStripeSize{std::nullopt};
   std::optional<bool> orcLinearStripeSizeHeuristics{std::nullopt};
   std::optional<uint64_t> maxDictionaryMemory{std::nullopt};
+  std::optional<bool> orcWriterIntegerDictionaryEncodingEnabled{std::nullopt};
+  std::optional<bool> orcWriterStringDictionaryEncodingEnabled{std::nullopt};
   std::map<std::string, std::string> serdeParameters;
   std::optional<uint8_t> parquetWriteTimestampUnit;
   std::optional<uint8_t> zlibCompressionLevel;

--- a/velox/dwio/dwrf/common/Config.cpp
+++ b/velox/dwio/dwrf/common/Config.cpp
@@ -188,6 +188,14 @@ Config::Entry<uint64_t> Config::MAX_DICTIONARY_SIZE(
     "hive.exec.orc.max.dictionary.size",
     80L * 1024L * 1024L);
 
+Config::Entry<bool> Config::INTEGER_DICTIONARY_ENCODING_ENABLED(
+    "hive.exec.orc.integer.dictionary.encoding.enabled",
+    true);
+
+Config::Entry<bool> Config::STRING_DICTIONARY_ENCODING_ENABLED(
+    "hive.exec.orc.string.dictionary.encoding.enabled",
+    true);
+
 Config::Entry<uint64_t> Config::STRIPE_SIZE(
     "hive.exec.orc.stripe.size",
     256L * 1024L * 1024L);

--- a/velox/dwio/dwrf/common/Config.h
+++ b/velox/dwio/dwrf/common/Config.h
@@ -61,6 +61,8 @@ class Config : public common::ConfigBase<Config> {
       MAP_FLAT_COLS_STRUCT_KEYS;
   static Entry<uint32_t> MAP_FLAT_MAX_KEYS;
   static Entry<uint64_t> MAX_DICTIONARY_SIZE;
+  static Entry<bool> INTEGER_DICTIONARY_ENCODING_ENABLED;
+  static Entry<bool> STRING_DICTIONARY_ENCODING_ENABLED;
   static Entry<uint64_t> STRIPE_SIZE;
   static Entry<bool> LINEAR_STRIPE_SIZE_HEURISTICS;
   /// With this config, we don't even try the more memory intensive encodings on

--- a/velox/dwio/dwrf/test/ColumnWriterTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTest.cpp
@@ -386,6 +386,36 @@ TEST_F(ColumnWriterTest, LowMemoryModeConfig) {
   EXPECT_TRUE(writer->useDictionaryEncoding());
 }
 
+TEST_F(ColumnWriterTest, IntegerDictionaryEncodingEnabledConfig) {
+  auto dataTypeWithId = TypeWithId::create(INTEGER(), 1);
+  auto config = std::make_shared<Config>();
+  config->set(Config::INTEGER_DICTIONARY_ENCODING_ENABLED, true);
+  WriterContext context{config, memory::memoryManager()->addRootPool()};
+  context.initBuffer();
+  auto writer = BaseColumnWriter::create(context, *dataTypeWithId);
+  EXPECT_TRUE(writer->useDictionaryEncoding());
+
+  dataTypeWithId = TypeWithId::create(INTEGER(), 2);
+  config->set(Config::INTEGER_DICTIONARY_ENCODING_ENABLED, false);
+  writer = BaseColumnWriter::create(context, *dataTypeWithId);
+  EXPECT_FALSE(writer->useDictionaryEncoding());
+}
+
+TEST_F(ColumnWriterTest, StringDictionaryEncodingEnabledConfig) {
+  auto dataTypeWithId = TypeWithId::create(VARCHAR(), 1);
+  auto config = std::make_shared<Config>();
+  config->set(Config::STRING_DICTIONARY_ENCODING_ENABLED, true);
+  WriterContext context{config, memory::memoryManager()->addRootPool()};
+  context.initBuffer();
+  auto writer = BaseColumnWriter::create(context, *dataTypeWithId);
+  EXPECT_TRUE(writer->useDictionaryEncoding());
+
+  dataTypeWithId = TypeWithId::create(VARCHAR(), 2);
+  config->set(Config::STRING_DICTIONARY_ENCODING_ENABLED, false);
+  writer = BaseColumnWriter::create(context, *dataTypeWithId);
+  EXPECT_FALSE(writer->useDictionaryEncoding());
+}
+
 TEST_F(ColumnWriterTest, TestBooleanWriter) {
   std::vector<std::optional<bool>> data;
   for (auto i = 0; i < ITERATIONS; ++i) {

--- a/velox/dwio/dwrf/writer/ColumnWriter.cpp
+++ b/velox/dwio/dwrf/writer/ColumnWriter.cpp
@@ -447,6 +447,11 @@ class IntegerColumnWriter : public BaseColumnWriter {
     }
   }
 
+  bool useDictionaryEncoding() const override {
+    return getConfig(Config::INTEGER_DICTIONARY_ENCODING_ENABLED) &&
+        BaseColumnWriter::useDictionaryEncoding();
+  }
+
   void populateDictionaryEncodingStreams();
   void convertToDirectEncoding();
 
@@ -955,14 +960,6 @@ class StringColumnWriter : public BaseColumnWriter {
     return true;
   }
 
- protected:
-  bool useDictionaryEncoding() const override {
-    return (sequence_ == 0 ||
-            !context_.getConfig(
-                Config::MAP_FLAT_DISABLE_DICT_ENCODING_STRING)) &&
-        !context_.isLowMemoryMode();
-  }
-
  private:
   uint64_t writeDict(
       DecodedVector& decodedVector,
@@ -1056,6 +1053,13 @@ class StringColumnWriter : public BaseColumnWriter {
     if (endOfLastStride < rows_.size()) {
       populateData(endOfLastStride, rows_.size(), numStrides);
     }
+  }
+
+  bool useDictionaryEncoding() const override {
+    return getConfig(Config::STRING_DICTIONARY_ENCODING_ENABLED) &&
+        (sequence_ == 0 ||
+         !getConfig(Config::MAP_FLAT_DISABLE_DICT_ENCODING_STRING)) &&
+        !context_.isLowMemoryMode();
   }
 
   void populateDictionaryEncodingStreams();

--- a/velox/dwio/dwrf/writer/ColumnWriter.h
+++ b/velox/dwio/dwrf/writer/ColumnWriter.h
@@ -269,6 +269,8 @@ class BaseColumnWriter : public ColumnWriter {
   const std::function<void(IndexBuilder&)> onRecordPosition_;
 
   VELOX_FRIEND_TEST(ColumnWriterTest, LowMemoryModeConfig);
+  VELOX_FRIEND_TEST(ColumnWriterTest, IntegerDictionaryEncodingEnabledConfig);
+  VELOX_FRIEND_TEST(ColumnWriterTest, StringDictionaryEncodingEnabledConfig);
   friend class ValueStatisticsBuilder;
   friend class ValueWriter;
 };

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -821,6 +821,18 @@ dwrf::WriterOptions getDwrfOptions(const dwio::common::WriterOptions& options) {
         Config::MAX_DICTIONARY_SIZE.configKey(),
         std::to_string(options.maxDictionaryMemory.value()));
   }
+  if (options.orcWriterIntegerDictionaryEncodingEnabled.has_value()) {
+    configs.emplace(
+        Config::INTEGER_DICTIONARY_ENCODING_ENABLED.configKey(),
+        std::to_string(
+            options.orcWriterIntegerDictionaryEncodingEnabled.value()));
+  }
+  if (options.orcWriterStringDictionaryEncodingEnabled.has_value()) {
+    configs.emplace(
+        Config::STRING_DICTIONARY_ENCODING_ENABLED.configKey(),
+        std::to_string(
+            options.orcWriterStringDictionaryEncodingEnabled.value()));
+  }
   if (options.zlibCompressionLevel.has_value()) {
     configs.emplace(
         Config::ZLIB_COMPRESSION_LEVEL.configKey(),


### PR DESCRIPTION
Summary:
Today we don't support the configs Presto uses to enable/disable dictionary encoding in DWRF
writer.  This means we use the Velox default which is to enable dictionary encoding for both integer
and string types.  The default in Presto is to disable dictionary encoding of integer types.

This change adds support for those configs to HiveConfig and plumbs them through HiveDataSink
down to the Writer. I modified the ColumnWriters to include this in their useDictionaryEncoding()
functions.

Differential Revision: D59541486
