### PR TITLE
add dependencies to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -322,3 +322,12 @@ src/amalgamation/
 velox/docs/sphinx/source/README_generated_*
 velox/docs/bindings/python/_generate/*
 scripts/bm-report/report.html
+
+#dependencies
+boost/
+fbthrift/
+fizz/
+fmt/
+folly/
+mvfst/
+wangle/


### PR DESCRIPTION
Summary:

add dependencies to .gitignore, to make the velox root directory  cleaner.