### PR TITLE
Throw unsupported error if a writerfactory is not registered.

### DIFF
--- a/velox/dwio/common/WriterFactory.cpp
+++ b/velox/dwio/common/WriterFactory.cpp
@@ -48,10 +48,10 @@ bool unregisterWriterFactory(FileFormat format) {
 
 std::shared_ptr<WriterFactory> getWriterFactory(FileFormat format) {
   auto it = writerFactories().find(format);
-  VELOX_CHECK(
-      it != writerFactories().end(),
-      "WriterFactory is not registered for format {}",
-      toString(format));
+  if (it == writerFactories().end()) {
+    VELOX_UNSUPPORTED(
+        "WriterFactory is not registered for format {}", toString(format));
+  }
   return it->second;
 }
 


### PR DESCRIPTION
Summary: Throwing unsupported error is more appropriate when a writer factory is not registered but queries are sent to worker. This makes error message cleaner, and helps error classification.

Differential Revision: D59588660
