### PR TITLE
Use ${{ github.workspace }} variable in CI

### DIFF
--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Fix git permissions
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
-        run: git config --global --add safe.directory /__w/velox/velox
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
       - name: Make ${{ matrix.type }} Build
         env:

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Fix git permissions
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
-        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+        run: git config --global --add safe.directory ${{ github.workspace }}
 
       - name: Make ${{ matrix.type }} Build
         env:

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Fix git permissions
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
-        run: git config --global --add safe.directory ${{ github.workspace }}
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
       - name: Make ${{ matrix.type }} Build
         env:

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -109,7 +109,7 @@ jobs:
     container: ghcr.io/facebookincubator/velox-dev:presto-java
     timeout-minutes: 120
     env:
-      CCACHE_DIR: "/__w/velox/velox/.ccache/"
+      CCACHE_DIR: "${GITHUB_WORKSPACE}/.ccache/"
       LINUX_DISTRO: "centos"
     steps:
 

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -109,7 +109,7 @@ jobs:
     container: ghcr.io/facebookincubator/velox-dev:presto-java
     timeout-minutes: 120
     env:
-      CCACHE_DIR: "${GITHUB_WORKSPACE}/.ccache/"
+      CCACHE_DIR: "${{ github.workspace }}/.ccache/"
       LINUX_DISTRO: "centos"
     steps:
 

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -103,13 +103,12 @@ jobs:
           name: join
           path: velox/_build/debug/velox/exec/tests/velox_join_fuzzer_test
 
-
   presto-java-aggregation-fuzzer-run:
     runs-on: 8-core-ubuntu
     container: ghcr.io/facebookincubator/velox-dev:presto-java
     timeout-minutes: 120
     env:
-      CCACHE_DIR: "${GITHUB_WORKSPACE}/.ccache/"
+      CCACHE_DIR: "${{ github.workspace }}/.ccache/"
       LINUX_DISTRO: "centos"
     steps:
 

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -109,7 +109,7 @@ jobs:
     container: ghcr.io/facebookincubator/velox-dev:presto-java
     timeout-minutes: 120
     env:
-      CCACHE_DIR: "${{ github.workspace }}/.ccache/"
+      CCACHE_DIR: "${GITHUB_WORKSPACE}/.ccache/"
       LINUX_DISTRO: "centos"
     steps:
 

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -57,7 +57,7 @@ jobs:
       run:
         shell: bash
     env:
-      CCACHE_DIR: "${GITHUB_WORKSPACE}/.ccache"
+      CCACHE_DIR: "${{ github.workspace }}/.ccache"
       VELOX_DEPENDENCY_SOURCE: SYSTEM
       Protobuf_SOURCE: BUNDLED # can be removed after #10134 is merged
       simdjson_SOURCE: BUNDLED
@@ -124,7 +124,7 @@ jobs:
         # Some of the adapters dependencies are in the 'adapters' conda env
         shell: mamba run --no-capture-output -n adapters /usr/bin/bash -e {0}
         env:
-          LIBHDFS3_CONF: "${GITHUB_WORKSPACE}/scripts/hdfs-client.xml"
+          LIBHDFS3_CONF: "${{ github.workspace }}/scripts/hdfs-client.xml"
         working-directory: _build/release
         run: |
           ctest -j 8 --output-on-failure --no-tests=error

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -57,7 +57,7 @@ jobs:
       run:
         shell: bash
     env:
-      CCACHE_DIR: "${GITHUB_WORKSPACE}/.ccache"
+      CCACHE_DIR: "${{ github.workspace }}/.ccache"
       VELOX_DEPENDENCY_SOURCE: SYSTEM
       Protobuf_SOURCE: BUNDLED # can be removed after #10134 is merged
       simdjson_SOURCE: BUNDLED
@@ -70,7 +70,7 @@ jobs:
       - name: Fix git permissions
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
-        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+        run: git config --global --add safe.directory ${{ github.workspace }}
 
       - name: Install Dependencies
         run: |
@@ -124,7 +124,7 @@ jobs:
         # Some of the adapters dependencies are in the 'adapters' conda env
         shell: mamba run --no-capture-output -n adapters /usr/bin/bash -e {0}
         env:
-          LIBHDFS3_CONF: "${GITHUB_WORKSPACE}/scripts/hdfs-client.xml"
+          LIBHDFS3_CONF: "${{ github.workspace }}/scripts/hdfs-client.xml"
         working-directory: _build/release
         run: |
           ctest -j 8 --output-on-failure --no-tests=error

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -57,7 +57,7 @@ jobs:
       run:
         shell: bash
     env:
-      CCACHE_DIR: "${{ github.workspace }}/.ccache"
+      CCACHE_DIR: "${GITHUB_WORKSPACE}/.ccache"
       VELOX_DEPENDENCY_SOURCE: SYSTEM
       Protobuf_SOURCE: BUNDLED # can be removed after #10134 is merged
       simdjson_SOURCE: BUNDLED
@@ -70,7 +70,7 @@ jobs:
       - name: Fix git permissions
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
-        run: git config --global --add safe.directory ${{ github.workspace }}
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
       - name: Install Dependencies
         run: |
@@ -124,7 +124,7 @@ jobs:
         # Some of the adapters dependencies are in the 'adapters' conda env
         shell: mamba run --no-capture-output -n adapters /usr/bin/bash -e {0}
         env:
-          LIBHDFS3_CONF: "${{ github.workspace }}/scripts/hdfs-client.xml"
+          LIBHDFS3_CONF: "${GITHUB_WORKSPACE}/scripts/hdfs-client.xml"
         working-directory: _build/release
         run: |
           ctest -j 8 --output-on-failure --no-tests=error

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -57,7 +57,7 @@ jobs:
       run:
         shell: bash
     env:
-      CCACHE_DIR: "/__w/velox/velox/.ccache"
+      CCACHE_DIR: "${GITHUB_WORKSPACE}/.ccache"
       VELOX_DEPENDENCY_SOURCE: SYSTEM
       Protobuf_SOURCE: BUNDLED # can be removed after #10134 is merged
       simdjson_SOURCE: BUNDLED
@@ -70,7 +70,7 @@ jobs:
       - name: Fix git permissions
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
-        run: git config --global --add safe.directory /__w/velox/velox
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
       - name: Install Dependencies
         run: |
@@ -124,7 +124,7 @@ jobs:
         # Some of the adapters dependencies are in the 'adapters' conda env
         shell: mamba run --no-capture-output -n adapters /usr/bin/bash -e {0}
         env:
-          LIBHDFS3_CONF: "/__w/velox/velox/scripts/hdfs-client.xml"
+          LIBHDFS3_CONF: "${GITHUB_WORKSPACE}/scripts/hdfs-client.xml"
         working-directory: _build/release
         run: |
           ctest -j 8 --output-on-failure --no-tests=error

--- a/.github/workflows/preliminary_checks.yml
+++ b/.github/workflows/preliminary_checks.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { name: "License Header", 
+          - { name: "License Header",
               command: "header-fix",
               message: "Found missing License Header(s)",
             }
@@ -50,9 +50,9 @@ jobs:
       - name: Fix git permissions
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
-        run: git config --global --add safe.directory /__w/velox/velox
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
-      - name: Check ${{ matrix.config.name }} 
+      - name: Check ${{ matrix.config.name }}
         run: |
           make ${{ matrix.config.command }}
 

--- a/.github/workflows/preliminary_checks.yml
+++ b/.github/workflows/preliminary_checks.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Fix git permissions
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
-        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+        run: git config --global --add safe.directory ${{ github.workspace }}
 
       - name: Check ${{ matrix.config.name }}
         run: |

--- a/.github/workflows/preliminary_checks.yml
+++ b/.github/workflows/preliminary_checks.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Fix git permissions
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
-        run: git config --global --add safe.directory ${{ github.workspace }}
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
       - name: Check ${{ matrix.config.name }}
         run: |

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -92,7 +92,7 @@ jobs:
     container: ghcr.io/facebookincubator/velox-dev:centos9
     timeout-minutes: 120
     env:
-      CCACHE_DIR: "${GITHUB_WORKSPACE}/.ccache"
+      CCACHE_DIR: "${{ github.workspace }}/.ccache"
       LINUX_DISTRO: "ubuntu"
       MAKEFLAGS: "NUM_THREADS=${{ inputs.numThreads || 16 }} MAX_HIGH_MEM_JOBS=${{ inputs.maxHighMemJobs || 8 }} MAX_LINK_JOBS=${{ inputs.maxLinkJobs || 4 }}"
 
@@ -143,8 +143,8 @@ jobs:
           # Usually actions/checkout does this but as we run in a container
           # it doesn't work
         run: |
-          git config --global --add safe.directory ${GITHUB_WORKSPACE}/velox
-          git config --global --add safe.directory ${GITHUB_WORKSPACE}/velox_main
+          git config --global --add safe.directory ${{ github.workspace }}/velox
+          git config --global --add safe.directory ${{ github.workspace }}/velox_main
 
       - name: Ensure Stash Dirs Exists
         working-directory: ${{ github.workspace }}
@@ -703,7 +703,7 @@ jobs:
       - name: Fix git permissions
           # Usually actions/checkout does this but as we run in a container
         # it doesn't work
-        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}/velox
+        run: git config --global --add safe.directory ${{ github.workspace }}/velox
 
 
       - name: "Run Aggregate Fuzzer"
@@ -767,7 +767,7 @@ jobs:
       - name: Fix git permissions
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
-        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}/velox
+        run: git config --global --add safe.directory ${{ github.workspace }}/velox
 
       - name: Download Signatures
         uses: actions/download-artifact@v4
@@ -864,7 +864,7 @@ jobs:
       - name: Fix git permissions
           # Usually actions/checkout does this but as we run in a container
         # it doesn't work
-        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}/velox
+        run: git config --global --add safe.directory ${{ github.workspace }}/velox
 
 
       - name: "Run Window Fuzzer"
@@ -926,7 +926,7 @@ jobs:
       - name: Fix git permissions
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
-        run: git config --global --add safe.directory /__w/velox/velox/velox
+        run: git config --global --add safe.directory ${{ github.workspace }}/velox
 
 
       - name: "Run Writer Fuzzer"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -92,7 +92,7 @@ jobs:
     container: ghcr.io/facebookincubator/velox-dev:centos9
     timeout-minutes: 120
     env:
-      CCACHE_DIR: "${GITHUB_WORKSPACE}/.ccache"
+      CCACHE_DIR: "${{ github.workspace }}/.ccache"
       LINUX_DISTRO: "ubuntu"
       MAKEFLAGS: "NUM_THREADS=${{ inputs.numThreads || 16 }} MAX_HIGH_MEM_JOBS=${{ inputs.maxHighMemJobs || 8 }} MAX_LINK_JOBS=${{ inputs.maxLinkJobs || 4 }}"
 
@@ -926,8 +926,7 @@ jobs:
       - name: Fix git permissions
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
-        run: git config --global --add safe.directory /__w/velox/velox/velox
-
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}/velox
 
       - name: "Run Writer Fuzzer"
         run: |

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -92,7 +92,7 @@ jobs:
     container: ghcr.io/facebookincubator/velox-dev:centos9
     timeout-minutes: 120
     env:
-      CCACHE_DIR: "${{ github.workspace }}/.ccache"
+      CCACHE_DIR: "${GITHUB_WORKSPACE}/.ccache"
       LINUX_DISTRO: "ubuntu"
       MAKEFLAGS: "NUM_THREADS=${{ inputs.numThreads || 16 }} MAX_HIGH_MEM_JOBS=${{ inputs.maxHighMemJobs || 8 }} MAX_LINK_JOBS=${{ inputs.maxLinkJobs || 4 }}"
 
@@ -143,8 +143,8 @@ jobs:
           # Usually actions/checkout does this but as we run in a container
           # it doesn't work
         run: |
-          git config --global --add safe.directory ${{ github.workspace }}/velox
-          git config --global --add safe.directory ${{ github.workspace }}/velox_main
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}/velox
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}/velox_main
 
       - name: Ensure Stash Dirs Exists
         working-directory: ${{ github.workspace }}
@@ -703,7 +703,7 @@ jobs:
       - name: Fix git permissions
           # Usually actions/checkout does this but as we run in a container
         # it doesn't work
-        run: git config --global --add safe.directory ${{ github.workspace }}/velox
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}/velox
 
 
       - name: "Run Aggregate Fuzzer"
@@ -767,7 +767,7 @@ jobs:
       - name: Fix git permissions
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
-        run: git config --global --add safe.directory ${{ github.workspace }}/velox
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}/velox
 
       - name: Download Signatures
         uses: actions/download-artifact@v4
@@ -864,7 +864,7 @@ jobs:
       - name: Fix git permissions
           # Usually actions/checkout does this but as we run in a container
         # it doesn't work
-        run: git config --global --add safe.directory ${{ github.workspace }}/velox
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}/velox
 
 
       - name: "Run Window Fuzzer"
@@ -926,7 +926,7 @@ jobs:
       - name: Fix git permissions
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
-        run: git config --global --add safe.directory ${{ github.workspace }}/velox
+        run: git config --global --add safe.directory /__w/velox/velox/velox
 
 
       - name: "Run Writer Fuzzer"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -92,7 +92,7 @@ jobs:
     container: ghcr.io/facebookincubator/velox-dev:centos9
     timeout-minutes: 120
     env:
-      CCACHE_DIR: "/__w/velox/velox/.ccache"
+      CCACHE_DIR: "${GITHUB_WORKSPACE}/.ccache"
       LINUX_DISTRO: "ubuntu"
       MAKEFLAGS: "NUM_THREADS=${{ inputs.numThreads || 16 }} MAX_HIGH_MEM_JOBS=${{ inputs.maxHighMemJobs || 8 }} MAX_LINK_JOBS=${{ inputs.maxLinkJobs || 4 }}"
 
@@ -143,8 +143,8 @@ jobs:
           # Usually actions/checkout does this but as we run in a container
           # it doesn't work
         run: |
-          git config --global --add safe.directory /__w/velox/velox/velox
-          git config --global --add safe.directory /__w/velox/velox/velox_main
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}/velox
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}/velox_main
 
       - name: Ensure Stash Dirs Exists
         working-directory: ${{ github.workspace }}
@@ -703,7 +703,7 @@ jobs:
       - name: Fix git permissions
           # Usually actions/checkout does this but as we run in a container
         # it doesn't work
-        run: git config --global --add safe.directory /__w/velox/velox/velox
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}/velox
 
 
       - name: "Run Aggregate Fuzzer"
@@ -767,7 +767,7 @@ jobs:
       - name: Fix git permissions
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
-        run: git config --global --add safe.directory /__w/velox/velox/velox
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}/velox
 
       - name: Download Signatures
         uses: actions/download-artifact@v4
@@ -864,7 +864,7 @@ jobs:
       - name: Fix git permissions
           # Usually actions/checkout does this but as we run in a container
         # it doesn't work
-        run: git config --global --add safe.directory /__w/velox/velox/velox
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}/velox
 
 
       - name: "Run Window Fuzzer"


### PR DESCRIPTION
This PR does some cleanup to replace hardcoded paths with `${{ github.workspace }}`. This helps make CI more robust on forks.