### PR TITLE
Fix int128::max() to double conversion issue

### DIFF
--- a/velox/common/base/Doubles.h
+++ b/velox/common/base/Doubles.h
@@ -35,7 +35,12 @@ namespace facebook::velox {
 /// [1].https://en.wikipedia.org/wiki/Double-precision_floating-point_format#Precision_limitations_on_integer_values
 
 /// 2 ^ 63 - 1024
-static constexpr double kMaxDoubleBelowInt64Max = 9223372036854774784.0;
+constexpr double kMaxDoubleBelowInt64Max = 9223372036854774784.0;
 /// 2 ^ 63
-static constexpr double kMinDoubleAboveInt64Max = 9223372036854775808.0;
+constexpr double kMinDoubleAboveInt64Max = 9223372036854775808.0;
+
+/// For int128::max()
+///  2 ^ 127 - 2 ^ 74
+constexpr double kMaxDoubleBelowInt128Max =
+    170141183460469212842221372237303250944.0;
 } // namespace facebook::velox

--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -19,6 +19,7 @@
 #include <string>
 #include "velox/common/base/CheckedArithmetic.h"
 #include "velox/common/base/CountBits.h"
+#include "velox/common/base/Doubles.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/Nulls.h"
 #include "velox/common/base/Status.h"
@@ -217,8 +218,15 @@ class DecimalUtil {
     if (!std::isfinite(value)) {
       return Status::UserError("The input value should be finite.");
     }
-    if (value <= std::numeric_limits<TOutput>::min() ||
-        value >= std::numeric_limits<TOutput>::max()) {
+
+    TInput maxValue;
+    if constexpr (std::is_same_v<TOutput, int64_t>) {
+      maxValue = kMaxDoubleBelowInt64Max;
+    } else {
+      maxValue = kMaxDoubleBelowInt128Max;
+    }
+
+    if (value <= std::numeric_limits<TOutput>::min() || value > maxValue) {
       return Status::UserError("Result overflows.");
     }
 


### PR DESCRIPTION
Comparing the int64::max and int128::max values with float or double values causes compilation issue on Clang17 due to implicit conversion to double.

However, the max value cannot be represented by the target type and loses precision.

This change adds the value below the int128::max to be used for comparison purposes.

Related PR https://github.com/facebookincubator/velox/pull/8177