### PR TITLE
Fix array_distinct to throw when input contains NULL elements

### DIFF
--- a/velox/functions/prestosql/benchmarks/ArrayDistinctBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayDistinctBenchmark.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/prestosql/ArrayFunctions.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::functions;
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+  memory::MemoryManager::initialize({});
+
+  functions::prestosql::registerArrayFunctions();
+
+  ExpressionBenchmarkBuilder benchmarkBuilder;
+  auto inputType = ARRAY(ARRAY(BIGINT()));
+  const vector_size_t vectorSize = 1000;
+  auto vectorMaker = benchmarkBuilder.vectorMaker();
+  auto nestedArrays = vectorMaker.arrayVector<int64_t>(
+      vectorSize,
+      [](auto /*row*/) { return 10; },
+      [](auto row) { return row; });
+
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "array_distinct_complex",
+          vectorMaker.rowVector({"nested_array"}, {nestedArrays}))
+      .addExpression("array", "array_distinct(nested_array)");
+
+  benchmarkBuilder.registerBenchmarks();
+
+  folly::runBenchmarks();
+  return 0;
+}


### PR DESCRIPTION
Summary:

Presto throws a NOT_SUPPORTED exception when inputs are 
complex-typed values containing NULL elements. Example query: 
`select array_distinct(c0) from (values (array[map(array[1], array[null]), map(array[1], array[null])])) t(c0)`.

This diff fixes Velox to align with Presto's behavior.

The added benchmark shows no regression of the performance.
Before the change:
```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
array_distinct_complex##array                             178.57ms      5.60
----------------------------------------------------------------------------
```

After the change:
```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
array_distinct_complex##array                             177.14ms      5.65
----------------------------------------------------------------------------
```

Differential Revision: D59617629
