### PR TITLE
Remove DictEncoder dtor checking in Parquet writer

### DIFF
--- a/velox/dwio/parquet/writer/arrow/Encoding.cpp
+++ b/velox/dwio/parquet/writer/arrow/Encoding.cpp
@@ -505,9 +505,7 @@ class DictEncoderImpl : public EncoderImpl, virtual public DictEncoder<DType> {
         dict_encoded_size_(0),
         memo_table_(pool, kInitialHashTableSize) {}
 
-  ~DictEncoderImpl() override {
-    DCHECK(buffered_indices_.empty());
-  }
+  ~DictEncoderImpl() = default;
 
   int dict_encoded_size() const override {
     return dict_encoded_size_;


### PR DESCRIPTION
Below exception is noticed when running spark_aggregation_fuzzer_test with 
https://github.com/facebookincubator/velox/pull/9559, which writes Velox vectors into Parquet files for Spark to read.

```
velox/dwio/parquet/writer/arrow/Encoding.cpp:513:  Check failed: buffered_indices_.empty() 
./velox/functions/sparksql/fuzzer/spark_aggregation_fuzzer_test
```
This PR follows https://github.com/apache/arrow/commit/02ad5ae6cb24cf02f76fabc818e94539059078ba to remove this check.