### PR TITLE
Enrich TableWriteNode addDetails

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -113,6 +113,10 @@ class ConnectorInsertTableHandle : public ISerializable {
     return false;
   }
 
+  virtual std::string toString() const {
+    VELOX_NYI();
+  }
+
   folly::dynamic serialize() const override {
     VELOX_NYI();
   }

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -113,9 +113,7 @@ class ConnectorInsertTableHandle : public ISerializable {
     return false;
   }
 
-  virtual std::string toString() const {
-    VELOX_NYI();
-  }
+  virtual std::string toString() const = 0;
 
   folly::dynamic serialize() const override {
     VELOX_NYI();

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -990,11 +990,22 @@ void HiveInsertTableHandle::registerSerDe() {
 
 std::string HiveInsertTableHandle::toString() const {
   std::ostringstream out;
-  out << "HiveInsertTableHandle [inputColumns: [";
+  out << "HiveInsertTableHandle ["
+      << dwio::common::toString(tableStorageFormat_);
+  if (compressionKind_.has_value()) {
+    out << " " << common::compressionKindToString(compressionKind_.value());
+  } else {
+    out << " none";
+  }
+  out << "], [inputColumns: [";
   for (const auto& i : inputColumns_) {
     out << " " << i->toString();
   }
-  out << " ], locationHandle: " << locationHandle_->toString() << "]";
+  out << " ], locationHandle: " << locationHandle_->toString();
+  if (bucketProperty_) {
+    out << ", bucketProperty: " << bucketProperty_->toString();
+  }
+  out << "]";
   return out.str();
 }
 

--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -258,7 +258,7 @@ class HiveInsertTableHandle : public ConnectorInsertTableHandle {
 
   static void registerSerDe();
 
-  std::string toString() const;
+  std::string toString() const override;
 
  private:
   const std::vector<std::shared_ptr<const HiveColumnHandle>> inputColumns_;

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -968,6 +968,27 @@ DEBUG_ONLY_TEST_F(HiveDataSinkTest, sortWriterFailureTest) {
 
   VELOX_ASSERT_THROW(dataSink->close(), "inject failure");
 }
+
+TEST_F(HiveDataSinkTest, insertTableHandleToString) {
+  const int32_t numBuckets = 4;
+  auto bucketProperty = std::make_shared<HiveBucketProperty>(
+      HiveBucketProperty::Kind::kHiveCompatible,
+      numBuckets,
+      std::vector<std::string>{"c5"},
+      std::vector<TypePtr>{VARCHAR()},
+      std::vector<std::shared_ptr<const HiveSortingColumn>>{
+          std::make_shared<HiveSortingColumn>(
+              "c5", core::SortOrder{false, false})});
+  auto insertTableHandle = createHiveInsertTableHandle(
+      rowType_,
+      "/path/to/test",
+      dwio::common::FileFormat::DWRF,
+      {"c5", "c6"},
+      bucketProperty);
+  ASSERT_EQ(
+      insertTableHandle->toString(),
+      "HiveInsertTableHandle [dwrf zstd], [inputColumns: [ HiveColumnHandle [name: c0, columnType: Regular, dataType: BIGINT, requiredSubfields: [ ]] HiveColumnHandle [name: c1, columnType: Regular, dataType: INTEGER, requiredSubfields: [ ]] HiveColumnHandle [name: c2, columnType: Regular, dataType: SMALLINT, requiredSubfields: [ ]] HiveColumnHandle [name: c3, columnType: Regular, dataType: REAL, requiredSubfields: [ ]] HiveColumnHandle [name: c4, columnType: Regular, dataType: DOUBLE, requiredSubfields: [ ]] HiveColumnHandle [name: c5, columnType: PartitionKey, dataType: VARCHAR, requiredSubfields: [ ]] HiveColumnHandle [name: c6, columnType: PartitionKey, dataType: BOOLEAN, requiredSubfields: [ ]] ], locationHandle: LocationHandle [targetPath: /path/to/test, writePath: /path/to/test, tableType: kNew,, bucketProperty: \nHiveBucketProperty[<HIVE_COMPATIBLE 4>\n\tBucket Columns:\n\t\tc5\n\tBucket Types:\n\t\tVARCHAR\n\tSortedBy Columns:\n\t\t[COLUMN[c5] ORDER[DESC NULLS LAST]]\n]\n]");
+}
 } // namespace
 } // namespace facebook::velox::connector::hive
 

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1783,7 +1783,9 @@ PlanNodePtr LocalMergeNode::create(const folly::dynamic& obj, void* context) {
       std::move(sources));
 }
 
-void TableWriteNode::addDetails(std::stringstream& /*unused*/) const {}
+void TableWriteNode::addDetails(std::stringstream& stream) const {
+  stream << insertTableHandle_->connectorInsertTableHandle()->toString();
+}
 
 folly::dynamic TableWriteNode::serialize() const {
   auto obj = PlanNode::serialize();


### PR DESCRIPTION
Print `ConnectorInsertTableHandle` when `TableWriteNode` details is enabled, and add more info for `HiveInsertTableHandle`: storage format, compression code, bucket property.