### PR TITLE
Selective array and map column reader

### DIFF
--- a/velox/dwio/common/tests/utils/DataSetBuilder.cpp
+++ b/velox/dwio/common/tests/utils/DataSetBuilder.cpp
@@ -37,7 +37,8 @@ RowTypePtr DataSetBuilder::makeRowType(
 DataSetBuilder& DataSetBuilder::makeDataset(
     RowTypePtr rowType,
     const size_t batchCount,
-    const size_t numRows) {
+    const size_t numRows,
+    const bool withRecursiveNulls) {
   if (batches_) {
     batches_->clear();
   } else {
@@ -45,8 +46,18 @@ DataSetBuilder& DataSetBuilder::makeDataset(
   }
 
   for (size_t i = 0; i < batchCount; ++i) {
-    batches_->push_back(std::static_pointer_cast<RowVector>(
-        BatchMaker::createBatch(rowType, numRows, pool_, nullptr, i)));
+    if (withRecursiveNulls) {
+      batches_->push_back(std::static_pointer_cast<RowVector>(
+          BatchMaker::createBatch(rowType, numRows, pool_, nullptr, i)));
+    } else {
+      batches_->push_back(
+          std::static_pointer_cast<RowVector>(BatchMaker::createBatch(
+              rowType,
+              numRows,
+              pool_,
+              [](vector_size_t /*index*/) { return false; },
+              i)));
+    }
   }
 
   return *this;

--- a/velox/dwio/common/tests/utils/DataSetBuilder.h
+++ b/velox/dwio/common/tests/utils/DataSetBuilder.h
@@ -43,7 +43,8 @@ class DataSetBuilder {
   DataSetBuilder& makeDataset(
       RowTypePtr rowType,
       const size_t batchCount,
-      const size_t numRows);
+      const size_t numRows,
+      const bool withRecursiveNulls = true);
 
   // Adds high values to 'batches_' so that these values occur only in some row
   // groups. Tests skipping row groups based on row group stats.

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.h
@@ -105,7 +105,8 @@ class E2EFilterTestBase : public testing::Test {
 
   std::vector<RowVectorPtr> makeDataset(
       std::function<void()> customize,
-      bool forRowGroupSkip);
+      bool forRowGroupSkip,
+      bool withRecursiveNulls);
 
   void makeAllNulls(const std::string& fieldName);
 
@@ -297,7 +298,8 @@ class E2EFilterTestBase : public testing::Test {
       std::function<void()> customize,
       bool wrapInStruct,
       const std::vector<std::string>& filterable,
-      int32_t numCombinations);
+      int32_t numCombinations,
+      bool withRecursiveNulls = true);
 
  private:
   void testMetadataFilterImpl(


### PR DESCRIPTION
Summary:
Implement selective array and map column reader. This is another type of top level column without independent null streams, hence requiring some new functionalities for loading nullable encoding.

There is another nuance in the diff where selective reader currently always loads the nulls first and then the values, and passes the combined nulls into readLengths methods instead of just the top level incoming nulls for scattering. We have 3 more ideal options
1) a materializeNonNull api for encodings
2) a materialize materializeNullable api for encodings for combined nulls
3) a way to have selective reader not having to materialize combined nulls without compromising efficiency.

For now we have added a hack in NimbleData to load values along with the nulls for nullable encodings and return the cached value when calling readLengths later. In order to fit this access pattern, we also override the skip methods.

Differential Revision: D58937281
