### PR TITLE
Back out "Move hash table overlap bits check earlier"

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -228,6 +228,7 @@ void GroupingSet::addInputForActiveRows(
       *lookup_,
       input,
       activeRows_,
+      ignoreNullKeys_,
       BaseHashTable::kNoSpillInputStartPartitionBit);
   if (lookup_->rows.empty()) {
     // No rows to probe. Can happen when ignoreNullKeys_ is true and all rows
@@ -235,7 +236,7 @@ void GroupingSet::addInputForActiveRows(
     return;
   }
 
-  table_->groupProbe(*lookup_, BaseHashTable::kNoSpillInputStartPartitionBit);
+  table_->groupProbe(*lookup_);
   masks_.addInput(input, activeRows_);
 
   auto* groups = lookup_->hits.data();
@@ -399,7 +400,7 @@ void GroupingSet::createHashTable() {
 
   lookup_ = std::make_unique<HashLookup>(table_->hashers());
   if (!isAdaptive_ && table_->hashMode() != BaseHashTable::HashMode::kHash) {
-    table_->forceGenericHashMode(BaseHashTable::kNoSpillInputStartPartitionBit);
+    table_->forceGenericHashMode();
   }
 }
 

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -263,7 +263,7 @@ class GroupingSet {
   // groups.
   void extractSpillResult(const RowVectorPtr& result);
 
-  // Returns a list of accumulators for 'aggregates_', plus one more accumulator
+  // Return a list of accumulators for 'aggregates_', plus one more accumulator
   // for 'sortedAggregations_', and one for each 'distinctAggregations_'.  When
   // 'excludeToIntermediate' is true, skip the functions that support
   // 'toIntermediate'.

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -752,10 +752,10 @@ bool HashBuild::finishHashBuild() {
     CpuWallTimer cpuWallTimer{timing};
     table_->prepareJoinTable(
         std::move(otherTables),
-        isInputFromSpill() ? spillConfig()->startPartitionBit
-                           : BaseHashTable::kNoSpillInputStartPartitionBit,
         allowParallelJoinBuild ? operatorCtx_->task()->queryCtx()->executor()
-                               : nullptr);
+                               : nullptr,
+        isInputFromSpill() ? spillConfig()->startPartitionBit
+                           : BaseHashTable::kNoSpillInputStartPartitionBit);
   }
   stats_.wlock()->addRuntimeStat(
       BaseHashTable::kBuildWallNanos,

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -192,17 +192,16 @@ class BaseHashTable {
   /// decode grouping keys from 'input'. If 'ignoreNullKeys' is true, updates
   /// 'rows' to remove entries with null grouping keys. After this call, 'rows'
   /// may have no entries selected.
-  virtual void prepareForGroupProbe(
+  void prepareForGroupProbe(
       HashLookup& lookup,
       const RowVectorPtr& input,
       SelectivityVector& rows,
-      int8_t spillInputStartPartitionBit) = 0;
+      bool ignoreNullKeys,
+      int8_t spillInputStartPartitionBit);
 
   /// Finds or creates a group for each key in 'lookup'. The keys are
   /// returned in 'lookup.hits'.
-  virtual void groupProbe(
-      HashLookup& lookup,
-      int8_t spillInputStartPartitionBit) = 0;
+  virtual void groupProbe(HashLookup& lookup) = 0;
 
   /// Returns the first hit for each key in 'lookup'. The keys are in
   /// 'lookup.hits' with a nullptr representing a miss. This is for use in hash
@@ -217,11 +216,11 @@ class BaseHashTable {
   /// to remove entries with null grouping keys. Otherwise, assumes the caller
   /// has done that already. After this call, 'rows' may have no entries
   /// selected.
-  virtual void prepareForJoinProbe(
+  void prepareForJoinProbe(
       HashLookup& lookup,
       const RowVectorPtr& input,
       SelectivityVector& rows,
-      bool decodeAndRemoveNulls) = 0;
+      bool decodeAndRemoveNulls);
 
   /// Fills 'hits' with consecutive hash join results. The corresponding element
   /// of 'inputRows' is set to the corresponding row number in probe keys.
@@ -265,8 +264,8 @@ class BaseHashTable {
 
   virtual void prepareJoinTable(
       std::vector<std::unique_ptr<BaseHashTable>> tables,
-      int8_t spillInputStartPartitionBit,
-      folly::Executor* executor = nullptr) = 0;
+      folly::Executor* executor = nullptr,
+      int8_t spillInputStartPartitionBit = kNoSpillInputStartPartitionBit) = 0;
 
   /// Returns the memory footprint in bytes for any data structures
   /// owned by 'this'.
@@ -305,8 +304,8 @@ class BaseHashTable {
   virtual HashMode hashMode() const = 0;
 
   /// Disables use of array or normalized key hash modes.
-  void forceGenericHashMode(int8_t spillInputStartPartitionBit) {
-    setHashMode(HashMode::kHash, 0, spillInputStartPartitionBit);
+  void forceGenericHashMode() {
+    setHashMode(HashMode::kHash, 0);
   }
 
   /// Decides the hash table representation based on the statistics in
@@ -324,7 +323,6 @@ class BaseHashTable {
   /// lifetime of 'this'.
   virtual void decideHashMode(
       int32_t numNew,
-      int8_t spillInputStartPartitionBit,
       bool disableRangeArrayHash = false) = 0;
 
   // Removes 'rows' from the hash table and its RowContainer. 'rows' must exist
@@ -391,10 +389,21 @@ class BaseHashTable {
     return sizeof(void*);
   }
 
-  virtual void setHashMode(
-      HashMode mode,
-      int32_t numNew,
-      int8_t spillInputStartPartitionBit) = 0;
+  virtual void setHashMode(HashMode mode, int32_t numNew) = 0;
+
+  virtual int sizeBits() const = 0;
+
+  // We don't want any overlap in the bit ranges used by bucket index and those
+  // used by spill partitioning; otherwise because we receive data from only one
+  // partition, the overlapped bits would be the same and only a fraction of the
+  // buckets would be used.  This would cause the insertion taking very long
+  // time and block driver threads.
+  void checkHashBitsOverlap(int8_t spillInputStartPartitionBit) {
+    if (spillInputStartPartitionBit != kNoSpillInputStartPartitionBit &&
+        hashMode() != HashMode::kArray) {
+      VELOX_CHECK_LE(sizeBits(), spillInputStartPartitionBit);
+    }
+  }
 
   std::vector<std::unique_ptr<VectorHasher>> hashers_;
   std::unique_ptr<RowContainer> rows_;
@@ -482,8 +491,7 @@ class HashTable : public BaseHashTable {
         pool);
   }
 
-  void groupProbe(HashLookup& lookup, int8_t spillInputStartPartitionBit)
-      override;
+  void groupProbe(HashLookup& lookup) override;
 
   void joinProbe(HashLookup& lookup) override;
 
@@ -549,39 +557,26 @@ class HashTable : public BaseHashTable {
     return hashMode_;
   }
 
-  void decideHashMode(
-      int32_t numNew,
-      int8_t spillInputStartPartitionBit,
-      bool disableRangeArrayHash = false) override;
+  void decideHashMode(int32_t numNew, bool disableRangeArrayHash = false)
+      override;
 
   void erase(folly::Range<char**> rows) override;
 
-  /// Moves the contents of 'tables' into 'this' and prepares 'this'
-  /// for use in hash join probe. A hash join build side is prepared as
-  /// follows: 1. Each build side thread gets a random selection of the
-  /// build stream. Each accumulates rows into its own
-  /// HashTable'sRowContainer and updates the VectorHashers of the
-  /// table to reflect the data as long as the data shows promise for
-  /// kArray or kNormalizedKey representation. After all the build
-  /// tables are filled, they are combined into one top level table
-  /// with prepareJoinTable. This then takes ownership of all the data
-  /// and VectorHashers and decides the hash mode and representation.
+  // Moves the contents of 'tables' into 'this' and prepares 'this'
+  // for use in hash join probe. A hash join build side is prepared as
+  // follows: 1. Each build side thread gets a random selection of the
+  // build stream. Each accumulates rows into its own
+  // HashTable'sRowContainer and updates the VectorHashers of the
+  // table to reflect the data as long as the data shows promise for
+  // kArray or kNormalizedKey representation. After all the build
+  // tables are filled, they are combined into one top level table
+  // with prepareJoinTable. This then takes ownership of all the data
+  // and VectorHashers and decides the hash mode and representation.
   void prepareJoinTable(
       std::vector<std::unique_ptr<BaseHashTable>> tables,
-      int8_t spillInputStartPartitionBit,
-      folly::Executor* executor = nullptr) override;
-
-  void prepareForJoinProbe(
-      HashLookup& lookup,
-      const RowVectorPtr& input,
-      SelectivityVector& rows,
-      bool decodeAndRemoveNulls) override;
-
-  void prepareForGroupProbe(
-      HashLookup& lookup,
-      const RowVectorPtr& input,
-      SelectivityVector& rows,
-      int8_t spillInputStartPartitionBit) override;
+      folly::Executor* executor = nullptr,
+      int8_t spillInputStartPartitionBit =
+          kNoSpillInputStartPartitionBit) override;
 
   uint64_t hashTableSizeIncrease(int32_t numNewDistinct) const override {
     if (numDistinct_ + numNewDistinct > rehashSize()) {
@@ -604,6 +599,10 @@ class HashTable : public BaseHashTable {
         memory::AllocationTraits::kPageSize);
   }
 
+  uint64_t rehashSize() const {
+    return rehashSize(capacity_ - numTombstones_);
+  }
+
   std::vector<RowContainer*> allRows() const override;
 
   std::string toString() override;
@@ -624,10 +623,6 @@ class HashTable : public BaseHashTable {
 
   auto& testingOtherTables() const {
     return otherTables_;
-  }
-
-  uint64_t testingRehashSize() const {
-    return rehashSize();
   }
 
  private:
@@ -711,10 +706,7 @@ class HashTable : public BaseHashTable {
 
   void arrayGroupProbe(HashLookup& lookup);
 
-  void setHashMode(
-      HashMode mode,
-      int32_t numNew,
-      int8_t spillInputStartPartitionBit) override;
+  void setHashMode(HashMode mode, int32_t numNew) override;
 
   // Fast path for join results when there are no duplicates in the table.
   int32_t listJoinResultsNoDuplicates(
@@ -741,28 +733,20 @@ class HashTable : public BaseHashTable {
   // VectorHashers.
   void clearUseRange(std::vector<bool>& useRange);
 
-  void rehash(bool initNormalizedKeys, int8_t spillInputStartPartitionBit);
-
-  uint64_t rehashSize() const {
-    return rehashSize(capacity_ - numTombstones_);
-  }
-
+  void rehash(bool initNormalizedKeys);
   void storeKeys(HashLookup& lookup, vector_size_t row);
 
   void storeRowPointer(uint64_t index, uint64_t hash, char* row);
 
   // Allocates new tables for tags and payload pointers. The size must
   // a power of 2.
-  void allocateTables(uint64_t size, int8_t spillInputStartPartitionBit);
+  void allocateTables(uint64_t size);
 
   // 'initNormalizedKeys' is passed to 'rehash' --> 'rehash' --> 'insertBatch'.
   // If it's false and the table is in normalized keys mode,
   // the keys are retrieved from the row and the hash is made
   // from this, without recomputing the normalized key.
-  void checkSize(
-      int32_t numNew,
-      bool initNormalizedKeys,
-      int8_t spillInputStartPartitionBit);
+  void checkSize(int32_t numNew, bool initNormalizedKeys);
 
   // Computes hash numbers of the appropriate hash mode for 'groups',
   // stores these in 'hashes' and inserts the groups using
@@ -956,12 +940,9 @@ class HashTable : public BaseHashTable {
     }
   }
 
-  // We don't want any overlap in the bit ranges used by bucket index and those
-  // used by spill partitioning; otherwise because we receive data from only one
-  // partition, the overlapped bits would be the same and only a fraction of the
-  // buckets would be used.  This would cause the insertion taking very long
-  // time and block driver threads.
-  void checkHashBitsOverlap(int8_t spillInputStartPartitionBit);
+  int sizeBits() const final {
+    return sizeBits_;
+  }
 
   // The min table size in row to trigger parallel join table build.
   const uint32_t minTableSizeForParallelJoinBuild_;

--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -84,8 +84,12 @@ void RowNumber::addInput(RowVectorPtr input) {
 
     SelectivityVector rows(numInput);
     table_->prepareForGroupProbe(
-        *lookup_, input, rows, BaseHashTable::kNoSpillInputStartPartitionBit);
-    table_->groupProbe(*lookup_, BaseHashTable::kNoSpillInputStartPartitionBit);
+        *lookup_,
+        input,
+        rows,
+        false,
+        BaseHashTable::kNoSpillInputStartPartitionBit);
+    table_->groupProbe(*lookup_);
 
     // Initialize new partitions with zeros.
     for (auto i : lookup_->newGroups) {
@@ -108,10 +112,9 @@ void RowNumber::addSpillInput() {
   const auto numInput = input_->size();
   SelectivityVector rows(numInput);
 
-  VELOX_CHECK(spillConfig_.has_value());
   table_->prepareForGroupProbe(
-      *lookup_, input_, rows, spillConfig_->startPartitionBit);
-  table_->groupProbe(*lookup_, spillConfig_->startPartitionBit);
+      *lookup_, input_, rows, false, spillConfig_->startPartitionBit);
+  table_->groupProbe(*lookup_);
 
   // Initialize new partitions with zeros.
   for (auto i : lookup_->newGroups) {
@@ -164,8 +167,8 @@ void RowNumber::restoreNextSpillPartition() {
       const auto numInput = input->size();
       SelectivityVector rows(numInput);
       table_->prepareForGroupProbe(
-          *lookup_, input, rows, spillConfig_->startPartitionBit);
-      table_->groupProbe(*lookup_, spillConfig_->startPartitionBit);
+          *lookup_, input, rows, false, spillConfig_->startPartitionBit);
+      table_->groupProbe(*lookup_);
 
       auto* counts = data->children().back()->as<FlatVector<int64_t>>();
 

--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -192,8 +192,12 @@ void TopNRowNumber::addInput(RowVectorPtr input) {
 
     SelectivityVector rows(numInput);
     table_->prepareForGroupProbe(
-        *lookup_, input, rows, BaseHashTable::kNoSpillInputStartPartitionBit);
-    table_->groupProbe(*lookup_, BaseHashTable::kNoSpillInputStartPartitionBit);
+        *lookup_,
+        input,
+        rows,
+        false,
+        BaseHashTable::kNoSpillInputStartPartitionBit);
+    table_->groupProbe(*lookup_);
 
     // Initialize new partitions.
     initializeNewPartitions();

--- a/velox/exec/benchmarks/HashJoinListResultBenchmark.cpp
+++ b/velox/exec/benchmarks/HashJoinListResultBenchmark.cpp
@@ -375,10 +375,7 @@ class HashTableListJoinResultBenchmark : public VectorTestBase {
     SelectivityInfo buildClocks;
     {
       SelectivityTimer timer(buildClocks, 0);
-      topTable_->prepareJoinTable(
-          std::move(otherTables),
-          BaseHashTable::kNoSpillInputStartPartitionBit,
-          executor_.get());
+      topTable_->prepareJoinTable(std::move(otherTables), executor_.get());
     }
     buildTime_ = buildClocks.timeToDropValue();
   }

--- a/velox/exec/benchmarks/HashJoinPrepareJoinTableBenchmark.cpp
+++ b/velox/exec/benchmarks/HashJoinPrepareJoinTableBenchmark.cpp
@@ -126,10 +126,7 @@ class HashJoinPrepareJoinTableBenchmark : public VectorTestBase {
 
   // Run 'prepareJoinTable'.
   void run() {
-    topTable_->prepareJoinTable(
-        std::move(otherTables_),
-        BaseHashTable::kNoSpillInputStartPartitionBit,
-        executor_.get());
+    topTable_->prepareJoinTable(std::move(otherTables_), executor_.get());
     VELOX_CHECK_EQ(topTable_->hashMode(), params_.mode);
   }
 

--- a/velox/exec/benchmarks/HashTableBenchmark.cpp
+++ b/velox/exec/benchmarks/HashTableBenchmark.cpp
@@ -195,10 +195,7 @@ class HashTableBenchmark : public VectorTestBase {
       batches_.insert(batches_.end(), batches.begin(), batches.end());
       startOffset += params_.size;
     }
-    topTable_->prepareJoinTable(
-        std::move(otherTables),
-        BaseHashTable::kNoSpillInputStartPartitionBit,
-        executor_.get());
+    topTable_->prepareJoinTable(std::move(otherTables), executor_.get());
     LOG(INFO) << "Made table " << topTable_->toString();
 
     if (topTable_->hashMode() == BaseHashTable::HashMode::kNormalizedKey) {
@@ -272,13 +269,12 @@ class HashTableBenchmark : public VectorTestBase {
 
     if (rehash) {
       if (table.hashMode() != BaseHashTable::HashMode::kHash) {
-        table.decideHashMode(
-            input.size(), BaseHashTable::kNoSpillInputStartPartitionBit);
+        table.decideHashMode(input.size());
       }
       insertGroups(input, rows, lookup, table);
       return;
     }
-    table.groupProbe(lookup, BaseHashTable::kNoSpillInputStartPartitionBit);
+    table.groupProbe(lookup);
   }
 
   void copyVectorsToTable(


### PR DESCRIPTION
Summary:
Original commit changeset: 0e4a61d1f307

Original Phabricator Diff: D58967938

Queries are failing with

```
com.facebook.presto.verifier.framework.PrestoQueryException: java.sql.SQLException: Query failed (#20240711_160619_00752_kznww): sizeBits_ - 1 < spillInputStartPartitionBit (13 vs. 1) Operator: PartialAggregation[1802] 3
```

Differential Revision: D59640854
