### PR TITLE
Fix array_union to throw when input contains nested NULL elements

### DIFF
--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -1208,6 +1208,25 @@ class GenericView {
   vector_size_t index_;
 };
 
+struct GenericViewEqualTo {
+  bool operator()(const GenericView& left, const GenericView& right) const {
+    static constexpr CompareFlags kCompareFlags = CompareFlags::equality(
+        CompareFlags::NullHandlingMode::kNullAsIndeterminate);
+    auto result = left.compare(right, kCompareFlags);
+    if (result.has_value()) {
+      return result.value() == 0;
+    }
+    VELOX_UNSUPPORTED(
+        "Comparison not supported for {} with null elements.",
+        left.type()->toString());
+  }
+};
+
+using GenericViewHashSet = folly::F14FastSet<
+    GenericView,
+    std::hash<facebook::velox::exec::GenericView>,
+    GenericViewEqualTo>;
+
 } // namespace facebook::velox::exec
 
 namespace std {

--- a/velox/functions/prestosql/ArrayFunctions.h
+++ b/velox/functions/prestosql/ArrayFunctions.h
@@ -881,6 +881,24 @@ struct ArrayUnionFunction {
   template <typename Out, typename In>
   void call(Out& out, const In& inputArray1, const In& inputArray2) {
     util::floating_point::HashSetNaNAware<typename In::element_t> elementSet;
+    doCall(out, inputArray1, inputArray2, elementSet);
+  }
+
+  void call(
+      out_type<Array<Generic<T1>>>& out,
+      const arg_type<Array<Generic<T1>>>& inputArray1,
+      const arg_type<Array<Generic<T1>>>& inputArray2) {
+    exec::GenericViewHashSet elementSet;
+    doCall(out, inputArray1, inputArray2, elementSet);
+  }
+
+ private:
+  template <typename Out, typename In, typename Set>
+  void doCall(
+      Out& out,
+      const In& inputArray1,
+      const In& inputArray2,
+      Set& elementSet) {
     bool nullAdded = false;
     auto addItems = [&](auto& inputArray) {
       for (const auto& item : inputArray) {

--- a/velox/functions/prestosql/benchmarks/ArrayUnionBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayUnionBenchmark.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/prestosql/ArrayFunctions.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::functions;
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+  memory::MemoryManager::initialize({});
+
+  functions::prestosql::registerArrayFunctions();
+
+  ExpressionBenchmarkBuilder benchmarkBuilder;
+  auto inputType = ARRAY(ARRAY(BIGINT()));
+  const vector_size_t vectorSize = 1000;
+  auto vectorMaker = benchmarkBuilder.vectorMaker();
+  auto nestedArray1 = vectorMaker.arrayVector<int64_t>(
+      vectorSize,
+      [](auto /*row*/) { return 10; },
+      [](auto row) { return row; });
+  auto nestedArray2 = vectorMaker.arrayVector<int64_t>(
+      vectorSize,
+      [](auto /*row*/) { return 15; },
+      [](auto row) { return row / 15 * 10 + row % 15; });
+
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "array_union_complex",
+          vectorMaker.rowVector({"c0", "c1"}, {nestedArray1, nestedArray2}))
+      .addExpression("array", "array_union(c0, c1)");
+
+  benchmarkBuilder.registerBenchmarks();
+
+  folly::runBenchmarks();
+  return 0;
+}


### PR DESCRIPTION
Summary:
Presto throws a NOT_SUPPORTED exception when inputs are
complex-typed values containing NULL elements. Example query:
`select array_union(c0, c1) from (values (array[array[1], array[null]], array[array[null]])) t(c0, c1)`.

This diff fixes Velox to align with Presto's behavior.

Differential Revision: D59663163
