### PR TITLE
Support semi projection join type in smj

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1142,6 +1142,8 @@ bool MergeJoinNode::isSupported(core::JoinType joinType) {
     case core::JoinType::kRightSemiFilter:
     case core::JoinType::kAnti:
     case core::JoinType::kFull:
+    case core::JoinType::kLeftSemiProject:
+    case core::JoinType::kRightSemiProject:
       return true;
 
     default:

--- a/velox/exec/MergeJoin.h
+++ b/velox/exec/MergeJoin.h
@@ -247,6 +247,10 @@ class MergeJoin : public Operator {
   /// rows from the left side that have a match on the right.
   RowVectorPtr filterOutputForAntiJoin(const RowVectorPtr& output);
 
+  /// Return each row from the left or right side with a boolean flag indicating
+  /// whether there exists a match on the right or left side.
+  RowVectorPtr filterOutputForSemiProject(const RowVectorPtr& output);
+
   /// As we populate the results of the join, we track whether a given
   /// output row is a result of a match between left and right sides or a miss.
   /// We use JoinTracker::addMatch and addMiss methods for that.

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -1423,7 +1423,23 @@ PlanBuilder& PlanBuilder::mergeJoin(
   if (!filter.empty()) {
     filterExpr = parseExpr(filter, resultType, options_, pool_);
   }
-  auto outputType = extract(resultType, outputLayout);
+  RowTypePtr outputType;
+  if (isLeftSemiProjectJoin(joinType) || isRightSemiProjectJoin(joinType)) {
+    std::vector<std::string> names = outputLayout;
+
+    // Last column in 'outputLayout' must be a boolean 'match'.
+    std::vector<TypePtr> types;
+    types.reserve(outputLayout.size());
+    for (auto i = 0; i < outputLayout.size() - 1; ++i) {
+      types.emplace_back(resultType->findChild(outputLayout[i]));
+    }
+    types.emplace_back(BOOLEAN());
+
+    outputType = ROW(std::move(names), std::move(types));
+  } else {
+    outputType = extract(resultType, outputLayout);
+  }
+
   auto leftKeyFields = fields(leftType, leftKeys);
   auto rightKeyFields = fields(rightType, rightKeys);
 


### PR DESCRIPTION
Return each row from the left or right side with a boolean flag indicating whether there exists a match on the right or left side. If there is a filter, the boolean value will be set based on the result of the filter in the applyFilter method. If there is no filter, the filterOutputForSemiProject is added to set the boolean value based on the records in joinTracker's matchingRows.