### PR TITLE
Remove unused function from velox/common/base/BitUtil.cpp

### DIFF
--- a/velox/common/base/BitUtil.cpp
+++ b/velox/common/base/BitUtil.cpp
@@ -39,6 +39,7 @@ void scatterBitsSimple(
   }
 }
 
+#ifdef __BMI2__
 // Fetches 'numBits' bits of data, from data starting at lastBit -
 // numbits (inclusive) and ending at lastBit (exclusive). 'lastBit' is
 // updated to be the bit offset of the lowest returned bit. Successive
@@ -58,6 +59,7 @@ uint64_t getBitField(const char* data, int32_t numBits, int32_t& lastBit) {
   lastBit -= numBits;
   return bits;
 }
+#endif
 
 // Copy bits backward while the remaining data is still larger than size of T.
 template <typename T>

--- a/velox/tpch/gen/dbgen/text.cpp
+++ b/velox/tpch/gen/dbgen/text.cpp
@@ -64,60 +64,6 @@
 
 #include "dbgen/dss.h" // @manual
 
-/*
- * txt_np() --
- *		generate a noun phrase by
- *		1) selecting a noun phrase form
- *		2) parsing it to select parts of speech
- *		3) selecting appropriate words
- *		4) adding punctuation as required
- *
- *	Returns: length of generated phrase
- *	Called By: txt_sentence()
- *	Calls: pick_str(),
- */
-static int txt_np(char* dest, seed_t* seed) {
-  char syntax[MAX_GRAMMAR_LEN + 1], *cptr, *parse_target;
-  distribution* src;
-  int i, res = 0;
-
-  pick_str(&np, seed, &syntax[0]);
-  parse_target = syntax;
-  while ((cptr = strtok(parse_target, " ")) != NULL) {
-    src = NULL;
-    switch (*cptr) {
-      case 'A':
-        src = &articles;
-        break;
-      case 'J':
-        src = &adjectives;
-        break;
-      case 'D':
-        src = &adverbs;
-        break;
-      case 'N':
-        src = &nouns;
-        break;
-    } /* end of POS switch statement */
-    i = pick_str(src, seed, dest);
-    i = (int)strlen(DIST_MEMBER(src, i));
-    dest += i;
-    res += i;
-    if (*(++cptr)) /* miscelaneous fillagree, like punctuation */
-    {
-      *dest = *cptr;
-      dest += 1;
-      res += 1;
-    }
-    *dest = ' ';
-    dest++;
-    res++;
-    parse_target = NULL;
-  } /* end of while loop */
-
-  return (res);
-}
-
 static char* gen_text(char* dest, seed_t* seed, distribution* s) {
   long i = 0;
   DSS_HUGE j;

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -186,23 +186,6 @@ const int16_t daysBeforeFirstDayOfMonth[][12] = {
     {0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335},
 };
 
-// clang-format off
-const char intToStr[][3] = {
-    "00", "01", "02", "03", "04", "05", "06", "07", "08", "09",
-    "10", "11", "12", "13", "14", "15", "16", "17", "18", "19",
-    "20", "21", "22", "23", "24", "25", "26", "27", "28", "29",
-    "30", "31", "32", "33", "34", "35", "36", "37", "38", "39",
-    "40", "41", "42", "43", "44", "45", "46", "47", "48", "49",
-    "50", "51", "52", "53", "54", "55", "56", "57", "58", "59",
-    "60", "61",
-};
-// clang-format on
-
-void appendSmallInt(int n, std::string& out) {
-  VELOX_DCHECK_LE(n, 61);
-  out.append(intToStr[n], 2);
-}
-
 } // namespace
 
 bool Timestamp::epochToCalendarUtc(int64_t epoch, std::tm& tm) {

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -509,66 +509,6 @@ bool tryParseTimestampString(
   return true;
 }
 
-bool tryParseUTCOffsetString(
-    const char* buf,
-    size_t& pos,
-    size_t len,
-    int& hourOffset,
-    int& minuteOffset) {
-  minuteOffset = 0;
-  size_t curpos = pos;
-
-  // Parse the next 3 characters.
-  if (curpos + 3 > len) {
-    // No characters left to parse.
-    return false;
-  }
-
-  char sign_char = buf[curpos];
-  if (sign_char != '+' && sign_char != '-') {
-    // Expected either + or -
-    return false;
-  }
-
-  curpos++;
-  if (!characterIsDigit(buf[curpos]) || !characterIsDigit(buf[curpos + 1])) {
-    // Expected +HH or -HH
-    return false;
-  }
-
-  hourOffset = (buf[curpos] - '0') * 10 + (buf[curpos + 1] - '0');
-
-  if (sign_char == '-') {
-    hourOffset = -hourOffset;
-  }
-  curpos += 2;
-
-  // Optional minute specifier: expected either "MM" or ":MM".
-  if (curpos >= len) {
-    // Done, nothing left.
-    pos = curpos;
-    return true;
-  }
-  if (buf[curpos] == ':') {
-    curpos++;
-  }
-
-  if (curpos + 2 > len || !characterIsDigit(buf[curpos]) ||
-      !characterIsDigit(buf[curpos + 1])) {
-    // No MM specifier.
-    pos = curpos;
-    return true;
-  }
-
-  // We have an MM specifier: parse it.
-  minuteOffset = (buf[curpos] - '0') * 10 + (buf[curpos + 1] - '0');
-  if (sign_char == '-') {
-    minuteOffset = -minuteOffset;
-  }
-  pos = curpos + 2;
-  return true;
-}
-
 } // namespace
 
 bool isLeapYear(int32_t year) {


### PR DESCRIPTION
Summary: `-Wunused-function` has identified an unused function. This diff removes it. In many cases these functions have existed for years in an unused state.

Differential Revision: D59644676
