### PR TITLE
Test different Wave batch sizes

### DIFF
--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -27,6 +27,8 @@
 using facebook::velox::duckdb::duckdbTimestampToVelox;
 using facebook::velox::duckdb::veloxTimestampToDuckDB;
 
+DEFINE_int32(max_error_rows, 10, "Max number of listed error rows");
+
 namespace facebook::velox::exec::test {
 namespace {
 
@@ -676,7 +678,8 @@ std::string makeErrorMessage(
   message << extraRows.size() << " extra rows, " << missingRows.size()
           << " missing rows" << std::endl;
 
-  auto extraRowsToPrint = std::min((size_t)10, extraRows.size());
+  auto extraRowsToPrint =
+      std::min((size_t)FLAGS_max_error_rows, extraRows.size());
   message << extraRowsToPrint << " of extra rows:" << std::endl;
 
   for (int32_t i = 0; i < extraRowsToPrint; i++) {
@@ -686,7 +689,8 @@ std::string makeErrorMessage(
   }
   message << std::endl;
 
-  auto missingRowsToPrint = std::min((size_t)10, missingRows.size());
+  auto missingRowsToPrint =
+      std::min((size_t)FLAGS_max_error_rows, missingRows.size());
   message << missingRowsToPrint << " of missing rows:" << std::endl;
   for (int32_t i = 0; i < missingRowsToPrint; i++) {
     message << "\t";

--- a/velox/experimental/wave/common/Buffer.cpp
+++ b/velox/experimental/wave/common/Buffer.cpp
@@ -15,11 +15,43 @@
  */
 
 #include "velox/experimental/wave/common/Buffer.h"
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/SuccinctPrinter.h"
+#include "velox/experimental/wave/common/Exception.h"
 #include "velox/experimental/wave/common/GpuArena.h"
+
+DECLARE_bool(wave_buffer_end_guard);
 
 namespace facebook::velox::wave {
 
+void Buffer::check() const {
+  if (!FLAGS_wave_buffer_end_guard) {
+    return;
+  }
+  if (*magicPtr() != kMagic) {
+    VELOX_FAIL("Buffer tail overrun: {}", toString());
+  }
+}
+
+void Buffer::setMagic() {
+  if (!FLAGS_wave_buffer_end_guard) {
+    return;
+  }
+  *magicPtr() = kMagic;
+}
+
+std::string Buffer::toString() const {
+  return fmt::format(
+      "<Buffer {} capacity={} ref={} pin={} dbg={}>",
+      ptr_,
+      capacity_,
+      referenceCount_,
+      pinCount_,
+      debugInfo_);
+}
+
 void Buffer::release() {
+  check();
   if (referenceCount_.fetch_sub(1) == 1) {
     arena_->free(this);
   }

--- a/velox/experimental/wave/common/Buffer.h
+++ b/velox/experimental/wave/common/Buffer.h
@@ -18,6 +18,7 @@
 #include <boost/intrusive_ptr.hpp>
 #include <atomic>
 #include <cstdint>
+#include <string>
 
 namespace facebook::velox::wave {
 
@@ -75,7 +76,29 @@ class Buffer {
 
   virtual void release();
 
+  const std::string& debugInfo() const {
+    return debugInfo_;
+  }
+
+  void setDebugInfo(std::string info) {
+    debugInfo_ = std::move(info);
+  }
+
+  /// Checks consistency of magic numbers. Throws on error.
+  void check() const;
+
+  std::string toString() const;
+
  protected:
+  static constexpr int64_t kMagic = 0xe0be0be0be0be0b;
+
+  int64_t* magicPtr() const {
+    return reinterpret_cast<int64_t*>(
+        reinterpret_cast<char*>(ptr_) + capacity_);
+  }
+
+  void setMagic();
+
   // Number of WaveBufferPtrs referencing 'this'.
   std::atomic<int32_t> referenceCount_{0};
 
@@ -97,6 +120,7 @@ class Buffer {
   // The containeing arena.
   GpuArena* arena_{nullptr};
 
+  std::string debugInfo_;
   friend class GpuArena;
 };
 

--- a/velox/experimental/wave/common/GpuArena.h
+++ b/velox/experimental/wave/common/GpuArena.h
@@ -114,6 +114,17 @@ class GpuSlab {
   GpuAllocator* const allocator_;
 };
 
+struct ArenaStatus {
+  /// Number of allocated Buffers.
+  int32_t numBuffers{0};
+
+  /// Sum of capacity of allocated buffers.
+  int64_t capacity{};
+
+  /// Currently used bytes. Larger than capacity because of padding.
+  int64_t allocatedBytes{0};
+};
+
 /// A class that manages a set of GpuSlabs. It is able to adapt itself by
 /// growing the number of its managed GpuSlab's when extreme memory
 /// fragmentation happens.
@@ -141,6 +152,10 @@ class GpuArena {
     return arenas_;
   }
 
+  /// Checks magic numbers and returns the sum of allocated capacity. Actual
+  /// sizes are padded to larger.
+  ArenaStatus checkBuffers();
+
  private:
   // A preallocated array of Buffer handles for memory of 'this'.
   struct Buffers {
@@ -149,8 +164,9 @@ class GpuArena {
   };
 
   // Returns a new reference counting pointer to a new Buffer initialized to
-  // 'ptr' and 'size'.
-  WaveBufferPtr getBuffer(void* ptr, size_t size);
+  // 'ptr' and 'size'. 'size' is the size to fre, 'capacity' is the usable size
+  // excluding magic numbers and padding.
+  WaveBufferPtr getBuffer(void* ptr, size_t capacity, size_t size);
 
   // Serializes all activity in 'this'.
   std::mutex mutex_;

--- a/velox/experimental/wave/exec/ExprKernel3.cu
+++ b/velox/experimental/wave/exec/ExprKernel3.cu
@@ -39,4 +39,16 @@ __global__ void oneFilter(KernelParams params, int32_t pc, int32_t base) {
   PROGRAM_EPILOGUE();
 }
 
+__global__ void onePlusBigint(KernelParams params, int32_t pc, int32_t base) {
+  PROGRAM_PREAMBLE(base);
+  binaryOpKernel<int64_t>(
+      [](auto left, auto right) { return left + right; },
+      instruction[pc]._.binary,
+      operands,
+      blockBase,
+      &shared->data,
+      laneStatus);
+  PROGRAM_EPILOGUE();
+}
+
 } // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/Wave.cpp
+++ b/velox/experimental/wave/exec/Wave.cpp
@@ -796,7 +796,7 @@ int32_t WaveStream::getOutput(
   VELOX_CHECK(it != launchControl_.end());
   auto* control = it->second[0].get();
   auto* status = control->params.status;
-  auto numBlocks = bits::roundUp(control->inputRows, kBlockSize) / kBlockSize;
+  auto numBlocks = bits::roundUp(numRows_, kBlockSize) / kBlockSize;
   if (operands.empty()) {
     return statusNumRows(status, numBlocks);
   }


### PR DESCRIPTION
Tests and fixes special cases with partially filled ends of batches with multiple concurrent streams per driver.

Adds an optional guard for ends of wave::Buffers and internal consistency checks for GpuArena. These may catch writes past end.