### PR TITLE
Support fast path for Spark comparison function in join filter

### DIFF
--- a/velox/functions/sparksql/Comparisons.cpp
+++ b/velox/functions/sparksql/Comparisons.cpp
@@ -52,7 +52,7 @@ class ComparisonFunction final : public exec::VectorFunction {
       }
     }
     if (shouldApplyAutoSimdComparison<T, T>(rows, args)) {
-      applyAutoSimdComparison<T, T, Cmp>(rows, args, result);
+      applyAutoSimdComparison<T, T, Cmp>(rows, args, context, result);
       return;
     }
 

--- a/velox/functions/sparksql/Comparisons.cpp
+++ b/velox/functions/sparksql/Comparisons.cpp
@@ -41,20 +41,19 @@ class ComparisonFunction final : public exec::VectorFunction {
     const Cmp cmp;
     context.ensureWritable(rows, BOOLEAN(), result);
     result->clearNulls(rows);
-    if ((args[0]->isFlatEncoding() || args[0]->isConstantEncoding()) &&
-        (args[1]->isFlatEncoding() || args[1]->isConstantEncoding())) {
-      if constexpr (
-          kind == TypeKind::TINYINT || kind == TypeKind::SMALLINT ||
-          kind == TypeKind::INTEGER || kind == TypeKind::BIGINT) {
-        if (rows.isAllSelected()) {
-          applySimdComparison<T, Cmp>(rows, args, result);
-          return;
-        }
-      }
-      if (rows.end() - rows.begin() > 64) {
-        applyAutoSimdComparison<T, T, Cmp>(rows, args, result);
+    if constexpr (
+        kind == TypeKind::TINYINT || kind == TypeKind::SMALLINT ||
+        kind == TypeKind::INTEGER || kind == TypeKind::BIGINT) {
+      if ((args[0]->isFlatEncoding() || args[0]->isConstantEncoding()) &&
+          (args[1]->isFlatEncoding() || args[1]->isConstantEncoding()) &&
+          rows.isAllSelected()) {
+        applySimdComparison<T, Cmp>(rows, args, result);
         return;
       }
+    }
+    if (shouldApplyAutoSimdComparison<T, T>(rows, args)) {
+      applyAutoSimdComparison<T, T, Cmp>(rows, args, result);
+      return;
     }
 
     auto* flatResult = result->asUnchecked<FlatVector<bool>>();

--- a/velox/functions/sparksql/DecimalCompare.cpp
+++ b/velox/functions/sparksql/DecimalCompare.cpp
@@ -116,9 +116,8 @@ class DecimalCompareFunction : public exec::VectorFunction {
       exec::EvalCtx& context,
       VectorPtr& result) const override {
     prepareResults(rows, resultType, context, result);
-    if ((args[0]->isFlatEncoding() || args[0]->isConstantEncoding()) &&
-        (args[1]->isFlatEncoding() || args[1]->isConstantEncoding()) &&
-        rows.end() - rows.begin() > 64) {
+
+    if (shouldApplyAutoSimdComparison<A, B>(rows, args)) {
       applyAutoSimdComparison<A, B, Operation, int8_t, bool>(
           rows, args, result, deltaScale_, need256_);
       return;

--- a/velox/functions/sparksql/DecimalCompare.cpp
+++ b/velox/functions/sparksql/DecimalCompare.cpp
@@ -119,7 +119,7 @@ class DecimalCompareFunction : public exec::VectorFunction {
 
     if (shouldApplyAutoSimdComparison<A, B>(rows, args)) {
       applyAutoSimdComparison<A, B, Operation, int8_t, bool>(
-          rows, args, result, deltaScale_, need256_);
+          rows, args, context, result, deltaScale_, need256_);
       return;
     }
 

--- a/velox/functions/sparksql/tests/ComparisonsTest.cpp
+++ b/velox/functions/sparksql/tests/ComparisonsTest.cpp
@@ -81,6 +81,8 @@ class ComparisonsTest : public SparkFunctionBaseTest {
     auto right = rVector->template as<FlatVector<T>>()->rawValues();
     auto constVector = fuzzer.fuzzConstant(type);
     auto constant = constVector->template as<ConstantVector<T>>()->value();
+    auto lDictVector = fuzzer.fuzzDictionary(lVector);
+    auto rDictVector = fuzzer.fuzzDictionary(rVector);
     SelectivityVector rows(size);
     rows.setValidRange(0, unSelectedRows, false);
 
@@ -99,10 +101,9 @@ class ComparisonsTest : public SparkFunctionBaseTest {
     // Flat, Const
     std::vector<VectorPtr> rConstVectors = {lVector, constVector};
     rowVector = fuzzer.fuzzRow(std::move(rConstVectors), {"c0", "c1"}, size);
-    result =
-        evaluate<SimpleVector<bool>>("greaterthanorequal(c0, c1)", rowVector);
+    result = evaluate<SimpleVector<bool>>("equalto(c0, c1)", rowVector);
     for (auto i = unSelectedRows; i < size; i++) {
-      expectedResult[i] = left[i] >= constant;
+      expectedResult[i] = left[i] == constant;
     }
     velox::test::assertEqualVectors(
         makeFlatVector<bool>(expectedResult), result, rows);
@@ -110,10 +111,31 @@ class ComparisonsTest : public SparkFunctionBaseTest {
     // Const, Flat
     std::vector<VectorPtr> lConstVectors = {constVector, rVector};
     rowVector = fuzzer.fuzzRow(std::move(lConstVectors), {"c0", "c1"}, size);
-    result =
-        evaluate<SimpleVector<bool>>("greaterthanorequal(c0, c1)", rowVector);
+    result = evaluate<SimpleVector<bool>>("lessthan(c0, c1)", rowVector);
     for (auto i = unSelectedRows; i < size; i++) {
-      expectedResult[i] = constant >= right[i];
+      expectedResult[i] = constant < right[i];
+    }
+    velox::test::assertEqualVectors(
+        makeFlatVector<bool>(expectedResult), result, rows);
+
+    // Dict(Flat), Flat
+    childrenVectors = {lDictVector, rVector};
+    rowVector = fuzzer.fuzzRow(std::move(childrenVectors), {"c0", "c1"}, size);
+    result = evaluate<SimpleVector<bool>>("lessthanorequal(c0, c1)", rowVector);
+    DecodedVector lDecodedVector(*lDictVector);
+    for (auto i = unSelectedRows; i < size; i++) {
+      expectedResult[i] = lDecodedVector.valueAt<T>(i) <= right[i];
+    }
+    velox::test::assertEqualVectors(
+        makeFlatVector<bool>(expectedResult), result, rows);
+
+    // Flat, Dict(Flat)
+    childrenVectors = {lVector, rDictVector};
+    rowVector = fuzzer.fuzzRow(std::move(childrenVectors), {"c0", "c1"}, size);
+    result = evaluate<SimpleVector<bool>>("greaterthan(c0, c1)", rowVector);
+    DecodedVector rDecodedVector(*rDictVector);
+    for (auto i = unSelectedRows; i < size; i++) {
+      expectedResult[i] = left[i] > rDecodedVector.valueAt<T>(i);
     }
     velox::test::assertEqualVectors(
         makeFlatVector<bool>(expectedResult), result, rows);

--- a/velox/functions/sparksql/tests/DecimalCompareTest.cpp
+++ b/velox/functions/sparksql/tests/DecimalCompareTest.cpp
@@ -170,6 +170,25 @@ TEST_F(DecimalCompareTest, gt) {
       makeFlatVector<bool>(
           130, [](auto row) { return row % 2 == 0 ? false : true; }),
       row);
+
+  testCompareExpr(
+      "decimal_greaterthan(c0, c1)",
+      {
+          wrapInDictionary(
+              makeIndices(140, [](auto row) { return row % 2; }),
+              makeFlatVector<int64_t>(
+                  2,
+                  [](auto row) { return row % 2 == 0 ? 1000 : 3000; },
+                  nullptr,
+                  DECIMAL(6, 2))),
+          makeFlatVector<int64_t>(
+              140,
+              [](auto row) { return row % 2 == 0 ? 100 : 130; },
+              nullptr,
+              DECIMAL(5, 1)),
+      },
+      makeFlatVector<bool>(
+          140, [](auto row) { return row % 2 == 0 ? false : true; }));
 }
 
 TEST_F(DecimalCompareTest, gte) {
@@ -305,6 +324,24 @@ TEST_F(DecimalCompareTest, gte) {
       },
       makeFlatVector<bool>(130, [](auto /*row*/) { return true; }),
       row);
+
+  testCompareExpr(
+      "decimal_greaterthanorequal(c0, c1)",
+      {
+          wrapInDictionary(
+              makeIndices(140, [](auto row) { return row % 2; }),
+              makeFlatVector<int64_t>(
+                  2,
+                  [](auto row) { return row % 2 == 0 ? 1000 : 3000; },
+                  nullptr,
+                  DECIMAL(6, 2))),
+          makeFlatVector<int64_t>(
+              140,
+              [](auto row) { return row % 2 == 0 ? 100 : 130; },
+              nullptr,
+              DECIMAL(5, 1)),
+      },
+      makeFlatVector<bool>(140, [](auto /*row*/) { return true; }));
 }
 
 TEST_F(DecimalCompareTest, eq) {
@@ -442,6 +479,25 @@ TEST_F(DecimalCompareTest, eq) {
       makeFlatVector<bool>(
           130, [](auto row) { return row % 2 == 0 ? true : false; }),
       row);
+
+  testCompareExpr(
+      "decimal_equalto(c0, c1)",
+      {
+          makeFlatVector<int64_t>(
+              140,
+              [](auto row) { return row % 2 == 0 ? 100 : 130; },
+              nullptr,
+              DECIMAL(5, 1)),
+          wrapInDictionary(
+              makeIndices(140, [](auto row) { return row % 2; }),
+              makeFlatVector<int64_t>(
+                  2,
+                  [](auto row) { return row % 2 == 0 ? 1000 : 3000; },
+                  nullptr,
+                  DECIMAL(6, 2))),
+      },
+      makeFlatVector<bool>(
+          140, [](auto row) { return row % 2 == 0 ? true : false; }));
 }
 
 TEST_F(DecimalCompareTest, neq) {
@@ -579,6 +635,25 @@ TEST_F(DecimalCompareTest, neq) {
       makeFlatVector<bool>(
           130, [](auto row) { return row % 2 == 0 ? false : true; }),
       row);
+
+  testCompareExpr(
+      "decimal_notequalto(c0, c1)",
+      {
+          wrapInDictionary(
+              makeIndices(140, [](auto row) { return row % 2; }),
+              makeFlatVector<int64_t>(
+                  2,
+                  [](auto row) { return row % 2 == 0 ? 1000 : 3000; },
+                  nullptr,
+                  DECIMAL(6, 2))),
+          makeFlatVector<int64_t>(
+              140,
+              [](auto row) { return row % 2 == 0 ? 100 : 130; },
+              nullptr,
+              DECIMAL(5, 1)),
+      },
+      makeFlatVector<bool>(
+          140, [](auto row) { return row % 2 == 0 ? false : true; }));
 }
 
 TEST_F(DecimalCompareTest, lt) {
@@ -714,6 +789,24 @@ TEST_F(DecimalCompareTest, lt) {
       },
       makeFlatVector<bool>(130, [](auto /*row*/) { return false; }),
       row);
+
+  testCompareExpr(
+      "decimal_lessthan(c0, c1)",
+      {
+          wrapInDictionary(
+              makeIndices(140, [](auto row) { return row % 2; }),
+              makeFlatVector<int64_t>(
+                  2,
+                  [](auto row) { return row % 2 == 0 ? 1000 : 3000; },
+                  nullptr,
+                  DECIMAL(6, 2))),
+          makeFlatVector<int64_t>(
+              140,
+              [](auto row) { return row % 2 == 0 ? 100 : 130; },
+              nullptr,
+              DECIMAL(5, 1)),
+      },
+      makeFlatVector<bool>(140, [](auto /*row*/) { return false; }));
 }
 
 TEST_F(DecimalCompareTest, lte) {
@@ -851,6 +944,25 @@ TEST_F(DecimalCompareTest, lte) {
       makeFlatVector<bool>(
           130, [](auto row) { return row % 2 == 0 ? true : false; }),
       row);
+
+  testCompareExpr(
+      "decimal_lessthanorequal(c0, c1)",
+      {
+          wrapInDictionary(
+              makeIndices(140, [](auto row) { return row % 2; }),
+              makeFlatVector<int64_t>(
+                  2,
+                  [](auto row) { return row % 2 == 0 ? 1000 : 3000; },
+                  nullptr,
+                  DECIMAL(6, 2))),
+          makeFlatVector<int64_t>(
+              140,
+              [](auto row) { return row % 2 == 0 ? 100 : 130; },
+              nullptr,
+              DECIMAL(5, 1)),
+      },
+      makeFlatVector<bool>(
+          140, [](auto row) { return row % 2 == 0 ? true : false; }));
 }
 
 } // namespace


### PR DESCRIPTION
Support fast path for Spark comparison function in join filter
We observed the join filter's inputs are flat encoding(build side) and 
dictionary encoding(probe side). This PR extends the optimization we did in 
10273 to cover the input encoding: dict and flat.
