### PR TITLE
LazyVector support for Parquet Reader

### DIFF
--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -276,17 +276,7 @@ class SelectiveColumnReader {
   void initReturnReaderNulls(const RowSet& rows);
 
   void setNumValues(vector_size_t size) {
-    numValues_ = numScanned_ + size;
-  }
-
-  void setNumScanned(vector_size_t numScanned) {
-    numScanned_ = numScanned;
-  }
-
-  // Number of rows scanned so far. Contains rows scanned in previous pages
-  // during this read call as well.
-  vector_size_t numScanned() {
-    return numScanned_;
+    numValues_ = size;
   }
 
   // The number of passing after filtering.
@@ -300,7 +290,7 @@ class SelectiveColumnReader {
   }
 
   void setNumRows(vector_size_t size) {
-    outputRows_.resize(numScanned_ + size);
+    outputRows_.resize(size);
   }
 
   // Sets the result nulls to be returned in getValues(). This is used for
@@ -662,10 +652,6 @@ class SelectiveColumnReader {
   // Writable content in 'values'
   void* rawValues_ = nullptr;
   vector_size_t numValues_ = 0;
-
-  // Number of rows scanned so far. Contains rows scanned in previous pages
-  // during this read call as well.
-  vector_size_t numScanned_{0};
 
   // Size of fixed width value in 'rawValues'. For integers, values
   // are read at 64 bit width and can be compacted or extracted at a

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -276,7 +276,17 @@ class SelectiveColumnReader {
   void initReturnReaderNulls(const RowSet& rows);
 
   void setNumValues(vector_size_t size) {
-    numValues_ = size;
+    numValues_ = numScanned_ + size;
+  }
+
+  void setNumScanned(vector_size_t numScanned) {
+    numScanned_ = numScanned;
+  }
+
+  // Number of rows scanned so far. Contains rows scanned in previous pages
+  // during this read call as well.
+  vector_size_t numScanned() {
+    return numScanned_;
   }
 
   // The number of passing after filtering.
@@ -288,8 +298,9 @@ class SelectiveColumnReader {
   int32_t numValues() const {
     return numValues_;
   }
+
   void setNumRows(vector_size_t size) {
-    outputRows_.resize(size);
+    outputRows_.resize(numScanned_ + size);
   }
 
   // Sets the result nulls to be returned in getValues(). This is used for
@@ -651,6 +662,11 @@ class SelectiveColumnReader {
   // Writable content in 'values'
   void* rawValues_ = nullptr;
   vector_size_t numValues_ = 0;
+
+  // Number of rows scanned so far. Contains rows scanned in previous pages
+  // during this read call as well.
+  vector_size_t numScanned_{0};
+
   // Size of fixed width value in 'rawValues'. For integers, values
   // are read at 64 bit width and can be compacted or extracted at a
   // different width.

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.h
@@ -253,11 +253,12 @@ class E2EFilterTestBase : public testing::Test {
       int32_t rowIndex) {
     using T = typename TypeTraits<Kind>::NativeType;
     std::vector<vector_size_t> rows;
-    // The 5 first values are densely read.
+    // The first 5 values are densely read.
     for (int32_t i = 0; i < 5 && i < batch->size(); ++i) {
       rows.push_back(i);
     }
-    for (int32_t i = 5; i < 5 && i < batch->size(); i += 2) {
+    // The last 5 values are sparsely read.
+    for (int32_t i = 5; i < 15 && i < batch->size(); i += 2) {
       rows.push_back(i);
     }
     auto result = std::static_pointer_cast<FlatVector<T>>(

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.h
@@ -47,6 +47,14 @@ class TestingHook : public ValueHook {
     }
   }
 
+  void addValue(vector_size_t row, int128_t value) override {
+    if constexpr (std::is_integral_v<T>) {
+      result_->set(row, value);
+    } else {
+      VELOX_FAIL();
+    }
+  }
+
   void addValue(vector_size_t row, float value) override {
     if constexpr (std::is_same_v<T, float>) {
       result_->set(row, value);

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
@@ -235,13 +235,13 @@ void SelectiveStringDictionaryColumnReader::read(
             &alwaysTrue(),
             rows,
             ExtractStringDictionaryToGenericHook(
-                scanSpec_->valueHook(), rows, scanState_.rawState));
+                scanSpec_->valueHook(), rows, &scanState_.rawState));
       } else {
         readHelper<common::AlwaysTrue, false>(
             &alwaysTrue(),
             rows,
             ExtractStringDictionaryToGenericHook(
-                scanSpec_->valueHook(), rows, scanState_.rawState));
+                scanSpec_->valueHook(), rows, &scanState_.rawState));
       }
     } else {
       if (isDense) {

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
@@ -478,7 +478,7 @@ void SelectiveStringDirectColumnReader::read(
       lengths_->asMutable<int32_t>(), numRows - numNulls);
   rawLengths_ = lengths_->as<uint32_t>();
   lengthIndex_ = 0;
-  dwio::common::StringColumnReadWithVisitorHelper<true>(
+  dwio::common::StringColumnReadWithVisitorHelper<true, false>(
       *this, rows)([&](auto visitor) { readWithVisitor(rows, visitor); });
   readOffset_ += numRows;
 }

--- a/velox/dwio/parquet/reader/PageReader.h
+++ b/velox/dwio/parquet/reader/PageReader.h
@@ -526,7 +526,7 @@ void PageReader::readWithVisitor(Visitor& visitor) {
   while (rowsForPage(reader, hasFilter, mayProduceNulls, pageRows, nulls)) {
     bool nullsFromFastPath = false;
     int32_t numValuesBeforePage = numRowsInReader<hasFilter>(reader);
-    visitor.setNumValuesBias(numValuesBeforePage);
+    reader.setNumScanned(numValuesBeforePage);
     visitor.setRows(pageRows);
     callDecoder(nulls, nullsFromFastPath, visitor);
     if (encoding_ == thrift::Encoding::DELTA_BINARY_PACKED &&

--- a/velox/dwio/parquet/reader/ParquetData.cpp
+++ b/velox/dwio/parquet/reader/ParquetData.cpp
@@ -96,6 +96,7 @@ void ParquetData::enqueueRowGroup(
   if (chunk.hasDictionaryPageOffset() && chunk.dictionaryPageOffset() >= 4) {
     // this assumes the data pages follow the dict pages directly.
     chunkReadOffset = chunk.dictionaryPageOffset();
+    hasDictionary_ = true;
   }
 
   uint64_t readSize =

--- a/velox/dwio/parquet/reader/ParquetData.h
+++ b/velox/dwio/parquet/reader/ParquetData.h
@@ -185,7 +185,7 @@ class ParquetData : public dwio::common::FormatData {
   }
 
   bool hasDictionary() const {
-    return reader_->isDictionary();
+    return hasDictionary_;
   }
 
   bool isDeltaBinaryPacked() const {
@@ -217,6 +217,7 @@ class ParquetData : public dwio::common::FormatData {
   int64_t rowsInRowGroup_;
   const tz::TimeZone* sessionTimezone_;
   std::unique_ptr<PageReader> reader_;
+  bool hasDictionary_{false};
 
   // Nulls derived from leaf repdefs for non-leaf readers.
   BufferPtr presetNulls_;

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -856,6 +856,7 @@ class ParquetRowReader::Impl {
         *options_.scanSpec());
     columnReader_->setFillMutatedOutputRows(
         options_.rowNumberColumnInfo().has_value());
+    columnReader_->setIsTopLevel();
 
     filterRowGroups();
     if (!rowGroupIds_.empty()) {

--- a/velox/dwio/parquet/reader/StringDecoder.h
+++ b/velox/dwio/parquet/reader/StringDecoder.h
@@ -41,7 +41,8 @@ class StringDecoder {
   }
 
   template <bool hasNulls, typename Visitor>
-  void readWithVisitor(const uint64_t* nulls, Visitor visitor) {
+  void
+  readWithVisitor(const uint64_t* nulls, Visitor visitor, int32_t numScanned) {
     int32_t current = visitor.start();
     int32_t numValues = 0;
     skip<hasNulls>(current, 0, nulls);
@@ -73,7 +74,9 @@ class StringDecoder {
 
         // We are at a non-null value on a row to visit.
         toSkip = visitor.process(
-            fixedLength_ > 0 ? readFixedString() : readString(), atEnd);
+            fixedLength_ > 0 ? readFixedString() : readString(),
+            atEnd,
+            numScanned);
       }
       ++current;
       ++numValues;

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -69,7 +69,6 @@ TEST_F(ParquetReaderTest, parseSample) {
   // Data is in plain uncompressed format:
   //   a: [1..20]
   //   b: [1.0..20.0]
-  google::InstallFailureSignalHandler();
   const std::string sample(getExampleFilePath("sample.parquet"));
 
   dwio::common::ReaderOptions readerOptions{leafPool_.get()};
@@ -759,7 +758,8 @@ TEST_F(ParquetReaderTest, parseRowArrayTest) {
 
   ASSERT_TRUE(rowReader->next(1, result));
   // data: 10, 9, <empty>, null, {9}, 2 elements starting at 0 {{9}, {10}}}
-  auto structArray = result->as<RowVector>()->childAt(5)->as<ArrayVector>();
+  auto structArray =
+      result->as<RowVector>()->childAt(5)->loadedVector()->as<ArrayVector>();
   auto structEle = structArray->elements()
                        ->as<RowVector>()
                        ->childAt(0)

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -648,8 +648,14 @@ TEST_F(ParquetReaderTest, parseIntDecimal) {
   rowReader->next(6, result);
   EXPECT_EQ(result->size(), 6ULL);
   auto decimals = result->as<RowVector>();
-  auto a = decimals->childAt(0)->asFlatVector<int64_t>()->rawValues();
-  auto b = decimals->childAt(1)->asFlatVector<int64_t>()->rawValues();
+  auto a = decimals->childAt(0)
+               ->loadedVector()
+               ->asFlatVector<int64_t>()
+               ->rawValues();
+  auto b = decimals->childAt(1)
+               ->loadedVector()
+               ->asFlatVector<int64_t>()
+               ->rawValues();
   for (int i = 0; i < 3; i++) {
     int index = 2 * i;
     EXPECT_EQ(a[index], expectValues[i]);
@@ -1198,8 +1204,11 @@ TEST_F(ParquetReaderTest, readVarbinaryFromFLBA) {
   rowReader->next(1, result);
   EXPECT_EQ(
       expected,
-      result->as<RowVector>()->childAt(0)->asFlatVector<StringView>()->valueAt(
-          0));
+      result->as<RowVector>()
+          ->childAt(0)
+          ->loadedVector()
+          ->asFlatVector<StringView>()
+          ->valueAt(0));
 }
 
 TEST_F(ParquetReaderTest, readBinaryAsStringFromNation) {
@@ -1226,10 +1235,11 @@ TEST_F(ParquetReaderTest, readBinaryAsStringFromNation) {
   auto expected = std::string("ALGERIA");
   VectorPtr result = BaseVector::create(outputRowType, 0, &(*leafPool_));
   rowReader->next(1, result);
+  auto nameVector = result->as<RowVector>()->childAt(1);
+  ASSERT_TRUE(isLazyNotLoaded(*nameVector));
   EXPECT_EQ(
       expected,
-      result->as<RowVector>()->childAt(1)->asFlatVector<StringView>()->valueAt(
-          0));
+      nameVector->loadedVector()->asFlatVector<StringView>()->valueAt(0));
 }
 
 TEST_F(ParquetReaderTest, readFixedLenBinaryAsStringFromUuid) {
@@ -1254,10 +1264,11 @@ TEST_F(ParquetReaderTest, readFixedLenBinaryAsStringFromUuid) {
   auto expected = std::string("5468454a-363f-ccc8-7d0b-76072a75dfaa");
   VectorPtr result = BaseVector::create(outputRowType, 0, &(*leafPool_));
   rowReader->next(1, result);
+  auto uuidVector = result->as<RowVector>()->childAt(0);
+  ASSERT_TRUE(isLazyNotLoaded(*uuidVector));
   EXPECT_EQ(
       expected,
-      result->as<RowVector>()->childAt(0)->asFlatVector<StringView>()->valueAt(
-          0));
+      uuidVector->loadedVector()->asFlatVector<StringView>()->valueAt(0));
 }
 
 TEST_F(ParquetReaderTest, testV2PageWithZeroMaxDefRep) {
@@ -1452,7 +1463,11 @@ TEST_F(ParquetReaderTest, testLzoDataPage) {
   VectorPtr result = BaseVector::create(outputRowType, 0, &*leafPool_);
   rowReader->next(23'547ULL, result);
   EXPECT_EQ(23'547ULL, result->size());
-  auto values = result->as<RowVector>()->childAt(0)->as<RowVector>();
+  auto rowVector = result->as<RowVector>();
+  auto child = rowVector->childAt(0);
+  SelectivityVector rows(child->size());
+  LazyVector::ensureLoadedRows(child, rows);
+  auto values = child->loadedVector()->as<RowVector>();
   auto intField = values->childAt(0)->asFlatVector<int32_t>();
   auto stringArray = values->childAt(1)->as<ArrayVector>();
   EXPECT_EQ(intField->valueAt(0), 1);

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -69,6 +69,7 @@ TEST_F(ParquetReaderTest, parseSample) {
   // Data is in plain uncompressed format:
   //   a: [1..20]
   //   b: [1.0..20.0]
+  google::InstallFailureSignalHandler();
   const std::string sample(getExampleFilePath("sample.parquet"));
 
   dwio::common::ReaderOptions readerOptions{leafPool_.get()};

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -848,7 +848,7 @@ TEST_F(ParquetTableScanTest, remainingFilterLazyWithMultiReferences) {
   writeToParquetFile(file->getPath(), {vector});
   CursorParameters params;
   params.copyResult = false;
-  params.singleThreaded = true;
+  params.serialExecution = true;
   params.planNode = PlanBuilder().tableScan(schema, {}, "c0 >= 0").planNode();
   auto cursor = TaskCursor::create(params);
   cursor->task()->addSplit("0", exec::Split(makeSplit(file->getPath())));


### PR DESCRIPTION
Fix #9563 

This PR addresses the following issues:

- Parquet supports lazy loading when reading data
- Solve the problem that Parquet does not load data correctly in some scenarios through ValueHook

Before this PR:
```
presto:velox_devcloud> select count(l_comment) from lineitem_parquet where substr(l_shipmode, 1, 1) = 'B';
 _col0 
-------
     0 
(1 row)

Query 20240717_021756_00007_x5e5p, FINISHED, 1 node
Splits: 2 total, 2 done (100.00%)
[Latency: client-side: 0:23, server-side: 0:23] [500K rows, 15.8MB] [21.9K rows/s, 707KB/s]
```

After this PR:
```
presto:velox_devcloud> select count(l_comment) from lineitem_parquet where substr(l_shipmode, 1, 1) = 'B';
 _col0 
-------
     0 
(1 row)

Query 20240717_021239_00005_x5e5p, FINISHED, 1 node
Splits: 2 total, 2 done (100.00%)
[Latency: client-side: 0:06, server-side: 0:06] [500K rows, 186KB] [90.6K rows/s, 33.7KB/s]
```