### PR TITLE
Fix GCC 11 warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]

### DIFF
--- a/velox/common/base/Macros.h
+++ b/velox/common/base/Macros.h
@@ -18,19 +18,13 @@
 
 // Macros to disable deprecation warnings
 #ifdef __clang__
-#define VELOX_SUPPRESS_DEPRECATION_WARNING \
-  _Pragma("clang diagnostic push");        \
-  _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
-#define VELOX_UNSUPPRESS_DEPRECATION_WARNING _Pragma("clang diagnostic pop");
-#define VELOX_SUPPRESS_RETURN_LOCAL_ADDR_WARNING
-#define VELOX_UNSUPPRESS_RETURN_LOCAL_ADDR_WARNING
+#define VELOX_SUPPRESS_STRINGOP_OVERFLOW_WARNING
+#define VELOX_UNSUPPRESS_STRINGOP_OVERFLOW_WARNING
 #else
-#define VELOX_SUPPRESS_DEPRECATION_WARNING
-#define VELOX_UNSUPPRESS_DEPRECATION_WARNING
-#define VELOX_SUPPRESS_RETURN_LOCAL_ADDR_WARNING \
+#define VELOX_SUPPRESS_STRINGOP_OVERFLOW_WARNING \
   _Pragma("GCC diagnostic push");                \
-  _Pragma("GCC diagnostic ignored \"-Wreturn-local-addr\"")
-#define VELOX_UNSUPPRESS_RETURN_LOCAL_ADDR_WARNING \
+  _Pragma("GCC diagnostic ignored \"-Wstringop-overflow\"")
+#define VELOX_UNSUPPRESS_STRINGOP_OVERFLOW_WARNING \
   _Pragma("GCC diagnostic pop");
 #endif
 

--- a/velox/vector/SelectivityVector.h
+++ b/velox/vector/SelectivityVector.h
@@ -24,6 +24,7 @@
 #include "velox/buffer/Buffer.h"
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/Exceptions.h"
+#include "velox/common/base/Macros.h"
 #include "velox/common/base/Range.h"
 #include "velox/vector/TypeAliases.h"
 
@@ -160,7 +161,9 @@ class SelectivityVector {
     bits::fillBits(bits_.data(), 0, size_, false);
     begin_ = 0;
     end_ = 0;
+    VELOX_SUPPRESS_STRINGOP_OVERFLOW_WARNING
     allSelected_ = false;
+    VELOX_UNSUPPRESS_STRINGOP_OVERFLOW_WARNING
   }
 
   /**


### PR DESCRIPTION
I hit this on ubuntu-22.04 arm64 with GCC11.
This was reported in the past as well https://github.com/facebookincubator/velox/pull/9578