### PR TITLE
Move hash table overlap bits check earlier

### DIFF
--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -263,7 +263,7 @@ class GroupingSet {
   // groups.
   void extractSpillResult(const RowVectorPtr& result);
 
-  // Return a list of accumulators for 'aggregates_', plus one more accumulator
+  // Returns a list of accumulators for 'aggregates_', plus one more accumulator
   // for 'sortedAggregations_', and one for each 'distinctAggregations_'.  When
   // 'excludeToIntermediate' is true, skip the functions that support
   // 'toIntermediate'.

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -752,10 +752,10 @@ bool HashBuild::finishHashBuild() {
     CpuWallTimer cpuWallTimer{timing};
     table_->prepareJoinTable(
         std::move(otherTables),
-        allowParallelJoinBuild ? operatorCtx_->task()->queryCtx()->executor()
-                               : nullptr,
         isInputFromSpill() ? spillConfig()->startPartitionBit
-                           : BaseHashTable::kNoSpillInputStartPartitionBit);
+                           : BaseHashTable::kNoSpillInputStartPartitionBit,
+        allowParallelJoinBuild ? operatorCtx_->task()->queryCtx()->executor()
+                               : nullptr);
   }
   stats_.wlock()->addRuntimeStat(
       BaseHashTable::kBuildWallNanos,

--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -192,12 +192,8 @@ void TopNRowNumber::addInput(RowVectorPtr input) {
 
     SelectivityVector rows(numInput);
     table_->prepareForGroupProbe(
-        *lookup_,
-        input,
-        rows,
-        false,
-        BaseHashTable::kNoSpillInputStartPartitionBit);
-    table_->groupProbe(*lookup_);
+        *lookup_, input, rows, BaseHashTable::kNoSpillInputStartPartitionBit);
+    table_->groupProbe(*lookup_, BaseHashTable::kNoSpillInputStartPartitionBit);
 
     // Initialize new partitions.
     initializeNewPartitions();

--- a/velox/exec/benchmarks/HashJoinListResultBenchmark.cpp
+++ b/velox/exec/benchmarks/HashJoinListResultBenchmark.cpp
@@ -375,7 +375,10 @@ class HashTableListJoinResultBenchmark : public VectorTestBase {
     SelectivityInfo buildClocks;
     {
       SelectivityTimer timer(buildClocks, 0);
-      topTable_->prepareJoinTable(std::move(otherTables), executor_.get());
+      topTable_->prepareJoinTable(
+          std::move(otherTables),
+          BaseHashTable::kNoSpillInputStartPartitionBit,
+          executor_.get());
     }
     buildTime_ = buildClocks.timeToDropValue();
   }

--- a/velox/exec/benchmarks/HashJoinPrepareJoinTableBenchmark.cpp
+++ b/velox/exec/benchmarks/HashJoinPrepareJoinTableBenchmark.cpp
@@ -126,7 +126,10 @@ class HashJoinPrepareJoinTableBenchmark : public VectorTestBase {
 
   // Run 'prepareJoinTable'.
   void run() {
-    topTable_->prepareJoinTable(std::move(otherTables_), executor_.get());
+    topTable_->prepareJoinTable(
+        std::move(otherTables_),
+        BaseHashTable::kNoSpillInputStartPartitionBit,
+        executor_.get());
     VELOX_CHECK_EQ(topTable_->hashMode(), params_.mode);
   }
 

--- a/velox/exec/benchmarks/HashTableBenchmark.cpp
+++ b/velox/exec/benchmarks/HashTableBenchmark.cpp
@@ -195,7 +195,10 @@ class HashTableBenchmark : public VectorTestBase {
       batches_.insert(batches_.end(), batches.begin(), batches.end());
       startOffset += params_.size;
     }
-    topTable_->prepareJoinTable(std::move(otherTables), executor_.get());
+    topTable_->prepareJoinTable(
+        std::move(otherTables),
+        BaseHashTable::kNoSpillInputStartPartitionBit,
+        executor_.get());
     LOG(INFO) << "Made table " << topTable_->toString();
 
     if (topTable_->hashMode() == BaseHashTable::HashMode::kNormalizedKey) {
@@ -269,12 +272,13 @@ class HashTableBenchmark : public VectorTestBase {
 
     if (rehash) {
       if (table.hashMode() != BaseHashTable::HashMode::kHash) {
-        table.decideHashMode(input.size());
+        table.decideHashMode(
+            input.size(), BaseHashTable::kNoSpillInputStartPartitionBit);
       }
       insertGroups(input, rows, lookup, table);
       return;
     }
-    table.groupProbe(lookup);
+    table.groupProbe(lookup, BaseHashTable::kNoSpillInputStartPartitionBit);
   }
 
   void copyVectorsToTable(


### PR DESCRIPTION
The current check is done after rehash happens in prepareJoinTable. We should let the check happen before that to avoid CPU and time waste and fail early. 
