### PR TITLE
Set timestamp time zone in parquet writer

### DIFF
--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -150,6 +150,7 @@ DEBUG_ONLY_TEST_F(ParquetWriterTest, unitFromWriterOptions) {
                 std::dynamic_pointer_cast<::arrow::TimestampType>(
                     arrowSchema->field(0)->type());
             ASSERT_EQ(tsType->unit(), ::arrow::TimeUnit::MICRO);
+            ASSERT_EQ(tsType->timezone(), "America/Los_Angeles");
           })));
 
   const auto data = makeRowVector({makeFlatVector<Timestamp>(
@@ -157,6 +158,7 @@ DEBUG_ONLY_TEST_F(ParquetWriterTest, unitFromWriterOptions) {
   parquet::WriterOptions writerOptions;
   writerOptions.memoryPool = leafPool_.get();
   writerOptions.parquetWriteTimestampUnit = TimestampUnit::kMicro;
+  writerOptions.parquetWriteTimestampTimeZone = "America/Los_Angeles";
 
   // Create an in-memory writer.
   auto sink = std::make_unique<MemorySink>(

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -179,7 +179,7 @@ DEBUG_ONLY_TEST_F(ParquetWriterTest, parquetWriteTimestampTimeZoneWithDefault) {
                 std::dynamic_pointer_cast<::arrow::TimestampType>(
                     arrowSchema->field(0)->type());
             ASSERT_EQ(tsType->unit(), ::arrow::TimeUnit::MICRO);
-            ASSERT_EQ(tsType->timezone(), "UTC");
+            ASSERT_EQ(tsType->timezone(), "");
           })));
 
   const auto data = makeRowVector({makeFlatVector<Timestamp>(

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -170,6 +170,34 @@ DEBUG_ONLY_TEST_F(ParquetWriterTest, unitFromWriterOptions) {
   writer->close();
 };
 
+DEBUG_ONLY_TEST_F(ParquetWriterTest, parquetWriteTimestampTimeZoneWithDefault) {
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::parquet::Writer::write",
+      std::function<void(const ::arrow::Schema*)>(
+          ([&](const ::arrow::Schema* arrowSchema) {
+            const auto tsType =
+                std::dynamic_pointer_cast<::arrow::TimestampType>(
+                    arrowSchema->field(0)->type());
+            ASSERT_EQ(tsType->unit(), ::arrow::TimeUnit::MICRO);
+            ASSERT_EQ(tsType->timezone(), "UTC");
+          })));
+
+  const auto data = makeRowVector({makeFlatVector<Timestamp>(
+      10'000, [](auto row) { return Timestamp(row, row); })});
+  parquet::WriterOptions writerOptions;
+  writerOptions.memoryPool = leafPool_.get();
+  writerOptions.parquetWriteTimestampUnit = TimestampUnit::kMicro;
+
+  // Create an in-memory writer.
+  auto sink = std::make_unique<MemorySink>(
+      200 * 1024 * 1024,
+      dwio::common::FileSink::Options{.pool = leafPool_.get()});
+  auto writer = std::make_unique<parquet::Writer>(
+      std::move(sink), writerOptions, rootPool_, ROW({"c0"}, {TIMESTAMP()}));
+  writer->write(data);
+  writer->close();
+};
+
 #ifdef VELOX_ENABLE_PARQUET
 DEBUG_ONLY_TEST_F(ParquetWriterTest, unitFromHiveConfig) {
   SCOPED_TESTVALUE_SET(

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -170,7 +170,7 @@ DEBUG_ONLY_TEST_F(ParquetWriterTest, unitFromWriterOptions) {
   writer->close();
 };
 
-DEBUG_ONLY_TEST_F(ParquetWriterTest, parquetWriteTimestampTimeZoneWithDefault) {
+TEST_F(ParquetWriterTest, parquetWriteTimestampTimeZoneWithDefault) {
   SCOPED_TESTVALUE_SET(
       "facebook::velox::parquet::Writer::write",
       std::function<void(const ::arrow::Schema*)>(

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -238,7 +238,8 @@ Writer::Writer(
   }
   options_.timestampUnit =
       options.parquetWriteTimestampUnit.value_or(TimestampUnit::kNano);
-  options_.timestampTimeZone = options.parquetWriteTimestampTimeZone.value_or("");
+  options_.timestampTimeZone =
+      options.parquetWriteTimestampTimeZone.value_or("");
   arrowContext_->properties =
       getArrowParquetWriterOptions(options, flushPolicy_);
   setMemoryReclaimers();
@@ -452,7 +453,7 @@ void WriterOptions::processHiveConnectorConfigs(const Config& config) {
         getTimestampUnit(config, kParquetHiveConnectorWriteTimestampUnit);
   }
 
-    if (!parquetWriteTimestampTimeZone) {
+  if (!parquetWriteTimestampTimeZone) {
     parquetWriteTimestampTimeZone =
         getTimestampTimeZone(config, core::QueryConfig::kSessionTimezone);
   }

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -238,8 +238,7 @@ Writer::Writer(
   }
   options_.timestampUnit =
       options.parquetWriteTimestampUnit.value_or(TimestampUnit::kNano);
-  options_.timestampTimeZone =
-      options.parquetWriteTimestampTimeZone.value_or("UTC");
+  options_.timestampTimeZone = options.parquetWriteTimestampTimeZone;
   arrowContext_->properties =
       getArrowParquetWriterOptions(options, flushPolicy_);
   setMemoryReclaimers();

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -19,6 +19,7 @@
 #include <arrow/io/interfaces.h>
 #include <arrow/table.h>
 #include "velox/common/testutil/TestValue.h"
+#include "velox/core/QueryConfig.h"
 #include "velox/dwio/parquet/writer/arrow/Properties.h"
 #include "velox/dwio/parquet/writer/arrow/Writer.h"
 #include "velox/exec/MemoryReclaimer.h"
@@ -237,6 +238,7 @@ Writer::Writer(
   }
   options_.timestampUnit =
       options.parquetWriteTimestampUnit.value_or(TimestampUnit::kNano);
+  options_.timestampTimeZone = options.parquetWriteTimestampTimeZone.value_or("");
   arrowContext_->properties =
       getArrowParquetWriterOptions(options, flushPolicy_);
   setMemoryReclaimers();
@@ -421,6 +423,15 @@ std::optional<TimestampUnit> getTimestampUnit(
   return std::nullopt;
 }
 
+std::optional<std::string> getTimestampTimeZone(
+    const Config& config,
+    const char* configKey) {
+  if (const auto timezone = config.get<std::string>(configKey)) {
+    return std::optional(static_cast<std::string>(timezone.value()));
+  }
+  return std::nullopt;
+}
+
 } // namespace
 
 void WriterOptions::processSessionConfigs(const Config& config) {
@@ -428,12 +439,22 @@ void WriterOptions::processSessionConfigs(const Config& config) {
     parquetWriteTimestampUnit =
         getTimestampUnit(config, kParquetSessionWriteTimestampUnit);
   }
+
+  if (!parquetWriteTimestampTimeZone) {
+    parquetWriteTimestampTimeZone =
+        getTimestampTimeZone(config, core::QueryConfig::kSessionTimezone);
+  }
 }
 
 void WriterOptions::processHiveConnectorConfigs(const Config& config) {
   if (!parquetWriteTimestampUnit) {
     parquetWriteTimestampUnit =
         getTimestampUnit(config, kParquetHiveConnectorWriteTimestampUnit);
+  }
+
+    if (!parquetWriteTimestampTimeZone) {
+    parquetWriteTimestampTimeZone =
+        getTimestampTimeZone(config, core::QueryConfig::kSessionTimezone);
   }
 }
 

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -239,7 +239,7 @@ Writer::Writer(
   options_.timestampUnit =
       options.parquetWriteTimestampUnit.value_or(TimestampUnit::kNano);
   options_.timestampTimeZone =
-      options.parquetWriteTimestampTimeZone.value_or("");
+      options.parquetWriteTimestampTimeZone.value_or("UTC");
   arrowContext_->properties =
       getArrowParquetWriterOptions(options, flushPolicy_);
   setMemoryReclaimers();
@@ -428,7 +428,7 @@ std::optional<std::string> getTimestampTimeZone(
     const Config& config,
     const char* configKey) {
   if (const auto timezone = config.get<std::string>(configKey)) {
-    return std::optional(static_cast<std::string>(timezone.value()));
+    return timezone.value();
   }
   return std::nullopt;
 }

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -109,6 +109,7 @@ struct WriterOptions : public dwio::common::WriterOptions {
   /// Timestamp unit for Parquet write through Arrow bridge.
   /// Default if not specified: TimestampUnit::kNano (9).
   std::optional<TimestampUnit> parquetWriteTimestampUnit;
+  std::optional<std::string> parquetWriteTimestampTimeZone;
   bool writeInt96AsTimestamp = false;
 
   // Parsing session and hive configs.

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -110,7 +110,6 @@ struct WriterOptions : public dwio::common::WriterOptions {
   /// Default if not specified: TimestampUnit::kNano (9).
   std::optional<TimestampUnit> parquetWriteTimestampUnit;
   /// Timestamp time zone for Parquet write through Arrow bridge.
-  /// Default if not specified: "UTC".
   std::optional<std::string> parquetWriteTimestampTimeZone{std::nullopt};
   bool writeInt96AsTimestamp = false;
 

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -110,7 +110,7 @@ struct WriterOptions : public dwio::common::WriterOptions {
   /// Default if not specified: TimestampUnit::kNano (9).
   std::optional<TimestampUnit> parquetWriteTimestampUnit;
   /// Timestamp time zone for Parquet write through Arrow bridge.
-  std::optional<std::string> parquetWriteTimestampTimeZone{std::nullopt};
+  std::optional<std::string> parquetWriteTimestampTimeZone;
   bool writeInt96AsTimestamp = false;
 
   // Parsing session and hive configs.

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -109,6 +109,8 @@ struct WriterOptions : public dwio::common::WriterOptions {
   /// Timestamp unit for Parquet write through Arrow bridge.
   /// Default if not specified: TimestampUnit::kNano (9).
   std::optional<TimestampUnit> parquetWriteTimestampUnit;
+  /// Timestamp time zone for Parquet write through Arrow bridge.
+  /// Default if not specified: "UTC".
   std::optional<std::string> parquetWriteTimestampTimeZone;
   bool writeInt96AsTimestamp = false;
 

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -111,7 +111,7 @@ struct WriterOptions : public dwio::common::WriterOptions {
   std::optional<TimestampUnit> parquetWriteTimestampUnit;
   /// Timestamp time zone for Parquet write through Arrow bridge.
   /// Default if not specified: "UTC".
-  std::optional<std::string> parquetWriteTimestampTimeZone;
+  std::optional<std::string> parquetWriteTimestampTimeZone{std::nullopt};
   bool writeInt96AsTimestamp = false;
 
   // Parsing session and hive configs.

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -218,20 +218,25 @@ const char* exportArrowFormatTimestampStr(
     std::string& formatBuffer) {
   switch (options.timestampUnit) {
     case TimestampUnit::kSecond:
-      formatBuffer = fmt::format("tss:{}", options.timestampTimeZone);
+      formatBuffer = "tss:";
       break;
     case TimestampUnit::kMilli:
-      formatBuffer = fmt::format("tsm:{}", options.timestampTimeZone);
+      formatBuffer = "tsm:";
       break;
     case TimestampUnit::kMicro:
-      formatBuffer = fmt::format("tsu:{}", options.timestampTimeZone);
+      formatBuffer = "tsu:";
       break;
     case TimestampUnit::kNano:
-      formatBuffer = fmt::format("tsn:{}", options.timestampTimeZone);
+      formatBuffer = "tsn:";
       break;
     default:
       VELOX_UNREACHABLE();
   }
+
+  if (options.timestampTimeZone.has_value()) {
+    formatBuffer += options.timestampTimeZone.value();
+  }
+
   return formatBuffer.c_str();
 }
 

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -255,18 +255,24 @@ const char* exportArrowFormatStr(
     case TypeKind::UNKNOWN:
       return "n"; // NullType
     case TypeKind::TIMESTAMP:
+      thread_local std::string timestampString;
       switch (options.timestampUnit) {
         case TimestampUnit::kSecond:
-          return "tss:";
+          timestampString = "tss:" + options.timestampTimeZone;
+          break;
         case TimestampUnit::kMilli:
-          return "tsm:";
+          timestampString = "tsm:" + options.timestampTimeZone;
+          break;
         case TimestampUnit::kMicro:
-          return "tsu:";
+          timestampString = "tsu:" + options.timestampTimeZone;
+          break;
         case TimestampUnit::kNano:
-          return "tsn:";
+          timestampString = "tsn:" + options.timestampTimeZone;
+          break;
         default:
           VELOX_UNREACHABLE();
       }
+      return timestampString.c_str();
     // Complex/nested types.
     case TypeKind::ARRAY:
       static_assert(sizeof(vector_size_t) == 4);

--- a/velox/vector/arrow/Bridge.h
+++ b/velox/vector/arrow/Bridge.h
@@ -36,6 +36,7 @@ struct ArrowOptions {
   bool flattenDictionary{false};
   bool flattenConstant{false};
   TimestampUnit timestampUnit = TimestampUnit::kNano;
+  std::string timestampTimeZone = "";
 };
 
 namespace facebook::velox {

--- a/velox/vector/arrow/Bridge.h
+++ b/velox/vector/arrow/Bridge.h
@@ -36,7 +36,7 @@ struct ArrowOptions {
   bool flattenDictionary{false};
   bool flattenConstant{false};
   TimestampUnit timestampUnit = TimestampUnit::kNano;
-  std::optional<std::string> timestampTimeZone = {"UTC"};
+  std::optional<std::string> timestampTimeZone{std::nullopt};
 };
 
 namespace facebook::velox {

--- a/velox/vector/arrow/Bridge.h
+++ b/velox/vector/arrow/Bridge.h
@@ -36,7 +36,7 @@ struct ArrowOptions {
   bool flattenDictionary{false};
   bool flattenConstant{false};
   TimestampUnit timestampUnit = TimestampUnit::kNano;
-  std::string timestampTimeZone = "";
+  std::optional<std::string> timestampTimeZone = {"UTC"};
 };
 
 namespace facebook::velox {

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -884,7 +884,8 @@ TEST_F(ArrowBridgeArrayExportTest, mapTimestamp) {
   EXPECT_EQ(array->null_count(), 0);
   ASSERT_EQ(
       *array->type(),
-      *arrow::map(arrow::int32(), arrow::timestamp(arrow::TimeUnit::NANO)));
+      *arrow::map(
+          arrow::int32(), arrow::timestamp(arrow::TimeUnit::NANO, "UTC")));
   {
     auto& mapArray = static_cast<const arrow::MapArray&>(*array);
     auto& values = static_cast<const arrow::TimestampArray&>(*mapArray.items());
@@ -906,7 +907,8 @@ TEST_F(ArrowBridgeArrayExportTest, mapTimestamp) {
   EXPECT_EQ(array->null_count(), 0);
   ASSERT_EQ(
       *array->type(),
-      *arrow::map(arrow::int32(), arrow::timestamp(arrow::TimeUnit::NANO)));
+      *arrow::map(
+          arrow::int32(), arrow::timestamp(arrow::TimeUnit::NANO, "UTC")));
   {
     auto& mapArray = static_cast<const arrow::MapArray&>(*array);
     auto& values = static_cast<const arrow::TimestampArray&>(*mapArray.items());

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -884,8 +884,7 @@ TEST_F(ArrowBridgeArrayExportTest, mapTimestamp) {
   EXPECT_EQ(array->null_count(), 0);
   ASSERT_EQ(
       *array->type(),
-      *arrow::map(
-          arrow::int32(), arrow::timestamp(arrow::TimeUnit::NANO, "UTC")));
+      *arrow::map(arrow::int32(), arrow::timestamp(arrow::TimeUnit::NANO)));
   {
     auto& mapArray = static_cast<const arrow::MapArray&>(*array);
     auto& values = static_cast<const arrow::TimestampArray&>(*mapArray.items());
@@ -907,8 +906,7 @@ TEST_F(ArrowBridgeArrayExportTest, mapTimestamp) {
   EXPECT_EQ(array->null_count(), 0);
   ASSERT_EQ(
       *array->type(),
-      *arrow::map(
-          arrow::int32(), arrow::timestamp(arrow::TimeUnit::NANO, "UTC")));
+      *arrow::map(arrow::int32(), arrow::timestamp(arrow::TimeUnit::NANO)));
   {
     auto& mapArray = static_cast<const arrow::MapArray&>(*array);
     auto& values = static_cast<const arrow::TimestampArray&>(*mapArray.items());

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -192,14 +192,15 @@ TEST_F(ArrowBridgeSchemaExportTest, scalar) {
   testScalarType(VARCHAR(), "u");
   testScalarType(VARBINARY(), "z");
 
+  options_.timestampTimeZone = "America/Los_Angeles";
   options_.timestampUnit = TimestampUnit::kSecond;
-  testScalarType(TIMESTAMP(), "tss:");
+  testScalarType(TIMESTAMP(), "tss:America/Los_Angeles");
   options_.timestampUnit = TimestampUnit::kMilli;
-  testScalarType(TIMESTAMP(), "tsm:");
+  testScalarType(TIMESTAMP(), "tsm:America/Los_Angeles");
   options_.timestampUnit = TimestampUnit::kMicro;
-  testScalarType(TIMESTAMP(), "tsu:");
+  testScalarType(TIMESTAMP(), "tsu:America/Los_Angeles");
   options_.timestampUnit = TimestampUnit::kNano;
-  testScalarType(TIMESTAMP(), "tsn:");
+  testScalarType(TIMESTAMP(), "tsn:America/Los_Angeles");
 
   testScalarType(DATE(), "tdD");
   testScalarType(INTERVAL_YEAR_MONTH(), "tiM");

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -192,15 +192,14 @@ TEST_F(ArrowBridgeSchemaExportTest, scalar) {
   testScalarType(VARCHAR(), "u");
   testScalarType(VARBINARY(), "z");
 
-  options_.timestampTimeZone = "America/Los_Angeles";
   options_.timestampUnit = TimestampUnit::kSecond;
-  testScalarType(TIMESTAMP(), "tss:America/Los_Angeles");
+  testScalarType(TIMESTAMP(), "tss:UTC");
   options_.timestampUnit = TimestampUnit::kMilli;
-  testScalarType(TIMESTAMP(), "tsm:America/Los_Angeles");
+  testScalarType(TIMESTAMP(), "tsm:UTC");
   options_.timestampUnit = TimestampUnit::kMicro;
-  testScalarType(TIMESTAMP(), "tsu:America/Los_Angeles");
+  testScalarType(TIMESTAMP(), "tsu:UTC");
   options_.timestampUnit = TimestampUnit::kNano;
-  testScalarType(TIMESTAMP(), "tsn:America/Los_Angeles");
+  testScalarType(TIMESTAMP(), "tsn:UTC");
 
   testScalarType(DATE(), "tdD");
   testScalarType(INTERVAL_YEAR_MONTH(), "tiM");

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -192,14 +192,15 @@ TEST_F(ArrowBridgeSchemaExportTest, scalar) {
   testScalarType(VARCHAR(), "u");
   testScalarType(VARBINARY(), "z");
 
+  options_.timestampTimeZone = "+01:0";
   options_.timestampUnit = TimestampUnit::kSecond;
-  testScalarType(TIMESTAMP(), "tss:UTC");
+  testScalarType(TIMESTAMP(), "tss:+01:0");
   options_.timestampUnit = TimestampUnit::kMilli;
-  testScalarType(TIMESTAMP(), "tsm:UTC");
+  testScalarType(TIMESTAMP(), "tsm:+01:0");
   options_.timestampUnit = TimestampUnit::kMicro;
-  testScalarType(TIMESTAMP(), "tsu:UTC");
+  testScalarType(TIMESTAMP(), "tsu:+01:0");
   options_.timestampUnit = TimestampUnit::kNano;
-  testScalarType(TIMESTAMP(), "tsn:UTC");
+  testScalarType(TIMESTAMP(), "tsn:+01:0");
 
   testScalarType(DATE(), "tdD");
   testScalarType(INTERVAL_YEAR_MONTH(), "tiM");

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -192,6 +192,17 @@ TEST_F(ArrowBridgeSchemaExportTest, scalar) {
   testScalarType(VARCHAR(), "u");
   testScalarType(VARBINARY(), "z");
 
+  // Test default timezone
+  options_.timestampUnit = TimestampUnit::kSecond;
+  testScalarType(TIMESTAMP(), "tss:");
+  options_.timestampUnit = TimestampUnit::kMilli;
+  testScalarType(TIMESTAMP(), "tsm:");
+  options_.timestampUnit = TimestampUnit::kMicro;
+  testScalarType(TIMESTAMP(), "tsu:");
+  options_.timestampUnit = TimestampUnit::kNano;
+  testScalarType(TIMESTAMP(), "tsn:");
+
+  // Test specific timezone
   options_.timestampTimeZone = "+01:0";
   options_.timestampUnit = TimestampUnit::kSecond;
   testScalarType(TIMESTAMP(), "tss:+01:0");


### PR DESCRIPTION
When we use Gluten's Parquet write to write timestamp data, we noticed that the timestamp data read out differs by a 7-hour time zone difference compared to vanilla Spark. We observed that Spark automatically adjusts the time zone to UTC when writing timestamp data. However, Velox's Parquet write function does not make such an adjustment, due to the fact that we did not set the time zone when creating the Arrow TimestampType. To address this issue, this PR will set the time zone in the Arrow TimestampType based on the kSessionTimezone configuration.