### PR TITLE
Move decimal-to-string API to DecimalUtil

### DIFF
--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -570,9 +570,6 @@ VectorPtr CastExpr::applyDecimalToVarcharCast(
   const auto simpleInput = input.as<SimpleVector<FromNativeType>>();
   int precision = getDecimalPrecisionScale(*fromType).first;
   int scale = getDecimalPrecisionScale(*fromType).second;
-  // A varchar's size is estimated with unscaled value digits, dot, leading
-  // zero, and possible minus sign.
-  
   auto rowSize = DecimalUtil::maxStringViewSize(precision, scale);
   auto flatResult = result->asFlatVector<StringView>();
   if (StringView::isInline(rowSize)) {

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -15,8 +15,6 @@
  */
 #pragma once
 
-#include <charconv>
-
 #include "velox/common/base/CountBits.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/core/CoreTypeSystem.h"
@@ -50,66 +48,6 @@ inline std::exception_ptr makeBadCastException(
       std::current_exception(),
       makeErrorMessage(input, row, resultType, errorDetails),
       false));
-}
-
-/// @brief Convert the unscaled value of a decimal to varchar and write to raw
-/// string buffer from start position.
-/// @tparam T The type of input value.
-/// @param unscaledValue The input unscaled value.
-/// @param scale The scale of decimal.
-/// @param maxVarcharSize The estimated max size of a varchar.
-/// @param startPosition The start position to write from.
-/// @return A string view.
-template <typename T>
-StringView convertToStringView(
-    T unscaledValue,
-    int32_t scale,
-    int32_t maxVarcharSize,
-    char* const startPosition) {
-  char* writePosition = startPosition;
-  if (unscaledValue == 0) {
-    *writePosition++ = '0';
-    if (scale > 0) {
-      *writePosition++ = '.';
-      // Append leading zeros.
-      std::memset(writePosition, '0', scale);
-      writePosition += scale;
-    }
-  } else {
-    if (unscaledValue < 0) {
-      *writePosition++ = '-';
-      unscaledValue = -unscaledValue;
-    }
-    auto [position, errorCode] = std::to_chars(
-        writePosition,
-        writePosition + maxVarcharSize,
-        unscaledValue / DecimalUtil::kPowersOfTen[scale]);
-    VELOX_DCHECK_EQ(
-        errorCode,
-        std::errc(),
-        "Failed to cast decimal to varchar: {}",
-        std::make_error_code(errorCode).message());
-    writePosition = position;
-
-    if (scale > 0) {
-      *writePosition++ = '.';
-      uint128_t fraction = unscaledValue % DecimalUtil::kPowersOfTen[scale];
-      // Append leading zeros.
-      int numLeadingZeros = std::max(scale - countDigits(fraction), 0);
-      std::memset(writePosition, '0', numLeadingZeros);
-      writePosition += numLeadingZeros;
-      // Append remaining fraction digits.
-      auto result = std::to_chars(
-          writePosition, writePosition + maxVarcharSize, fraction);
-      VELOX_DCHECK_EQ(
-          result.ec,
-          std::errc(),
-          "Failed to cast decimal to varchar: {}",
-          std::make_error_code(result.ec).message());
-      writePosition = result.ptr;
-    }
-  }
-  return StringView(startPosition, writePosition - startPosition);
 }
 
 } // namespace
@@ -634,21 +572,15 @@ VectorPtr CastExpr::applyDecimalToVarcharCast(
   int scale = getDecimalPrecisionScale(*fromType).second;
   // A varchar's size is estimated with unscaled value digits, dot, leading
   // zero, and possible minus sign.
-  int32_t rowSize = precision + 1;
-  if (scale > 0) {
-    ++rowSize; // A dot.
-  }
-  if (precision == scale) {
-    ++rowSize; // Leading zero.
-  }
-
+  
+  auto rowSize = DecimalUtil::maxStringViewSize(precision, scale);
   auto flatResult = result->asFlatVector<StringView>();
   if (StringView::isInline(rowSize)) {
     char inlined[StringView::kInlineSize];
     applyToSelectedNoThrowLocal(context, rows, result, [&](vector_size_t row) {
       flatResult->setNoCopy(
           row,
-          convertToStringView<FromNativeType>(
+          DecimalUtil::convertToStringView<FromNativeType>(
               simpleInput->valueAt(row), scale, rowSize, inlined));
     });
     return result;
@@ -659,7 +591,7 @@ VectorPtr CastExpr::applyDecimalToVarcharCast(
   char* rawBuffer = buffer->asMutable<char>() + buffer->size();
 
   applyToSelectedNoThrowLocal(context, rows, result, [&](vector_size_t row) {
-    auto stringView = convertToStringView<FromNativeType>(
+    auto stringView = DecimalUtil::convertToStringView<FromNativeType>(
         simpleInput->valueAt(row), scale, rowSize, rawBuffer);
     flatResult->setNoCopy(row, stringView);
     if (!stringView.isInline()) {

--- a/velox/type/DecimalUtil.cpp
+++ b/velox/type/DecimalUtil.cpp
@@ -114,4 +114,15 @@ void DecimalUtil::computeAverage(
   }
 }
 
+int32_t DecimalUtil::maxStringViewSize(int precision, int scale) {
+  int32_t rowSize = precision + 1; // Number and symbol.
+  if (scale > 0) {
+    ++rowSize; // A dot.
+  }
+  if (precision == scale) {
+    ++rowSize; // Leading zero.
+  }
+  return rowSize;
+}
+
 } // namespace facebook::velox

--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -311,7 +311,8 @@ class DecimalUtil {
   }
 
   /// Returns the max required size to convert the decimal of this precision and
-  /// scale to string
+  /// scale to varchar. A varchar's size is estimated with unscaled value
+  /// digits, dot, leading zero, and possible minus sign.
   static int32_t maxStringViewSize(int precision, int scale) {
     int32_t rowSize = precision + 1; // Number and symbol.
     if (scale > 0) {

--- a/velox/type/tests/DecimalTest.cpp
+++ b/velox/type/tests/DecimalTest.cpp
@@ -118,7 +118,8 @@ void testConvertToStringView(
   char out[expectedMaxStringSize];
   DecimalUtil::convertToStringView<T>(
       unscaleValue, scale, expectedMaxStringSize, out);
-  EXPECT_EQ(std::memcmp(expected.data(), out, expected.size()), 0);
+  EXPECT_EQ(std::memcmp(expected.data(), out, expected.size()), 0)
+      << StringView(out, expectedMaxStringSize);
 }
 
 std::string zeros(uint32_t numZeros) {
@@ -532,9 +533,6 @@ TEST(DecimalTest, convertToStringView) {
       3,
       22,
       "-18446744073709551.616");
-  int128_t value = HugeInt::parse("-12345678901234567890");
-  std::cout << std::hex << HugeInt::upper(value) << " " << HugeInt::lower(value)
-            << std::endl;
 
   testConvertToStringView<int128_t>(
       HugeInt::build(0xffffffffffffffff, 0x54ab567314e0f52e),

--- a/velox/type/tests/DecimalTest.cpp
+++ b/velox/type/tests/DecimalTest.cpp
@@ -533,21 +533,21 @@ TEST(DecimalTest, castToString) {
       DecimalUtil::kShortDecimalMin, 18, 0, 19, "-" + std::string(18, '9'));
 
   testcastToString<int128_t>(
-      HugeInt::build(0xFFFFFFFFFFFFFFFFull, 0),
+      HugeInt::parse("-18446744073709551616"),
       20,
       0,
       21,
       "-18446744073709551616");
 
   testcastToString<int128_t>(
-      HugeInt::build(0xFFFFFFFFFFFFFFFFull, 0),
+      HugeInt::parse("-18446744073709551616"),
       20,
       3,
       22,
       "-18446744073709551.616");
 
   testcastToString<int128_t>(
-      HugeInt::build(0xffffffffffffffff, 0x54ab567314e0f52e),
+      HugeInt::parse("-12345678901234567890"),
       20,
       20,
       23,


### PR DESCRIPTION
Moves 'convertStringView' function to DecimalUtil for the reuse of Spark 
function 'toprettystring' and renames it as 'castToString'.