### PR TITLE
Fix dynamic filters pushdown from multiple operators on same column

### DIFF
--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -367,7 +367,12 @@ void TableScan::addDynamicFilter(
   if (dataSource_) {
     dataSource_->addDynamicFilter(outputChannel, filter);
   }
-  dynamicFilters_.emplace(outputChannel, filter);
+  auto& currentFilter = dynamicFilters_[outputChannel];
+  if (currentFilter) {
+    currentFilter = currentFilter->mergeWith(filter.get());
+  } else {
+    currentFilter = filter;
+  }
   stats_.wlock()->dynamicFilterStats.producerNodeIds.emplace(producer);
 }
 

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -4457,6 +4457,56 @@ TEST_F(TableScanTest, readFlatMapAsStruct) {
   AssertQueryBuilder(plan).split(split).assertResults(vector);
 }
 
+TEST_F(TableScanTest, dynamicFilters) {
+  // Make sure filters on same column from multiple downstream operators are
+  // merged properly without overwriting each other.
+  auto aVector =
+      makeRowVector({"a"}, {makeFlatVector<int64_t>(20'000, folly::identity)});
+  auto bVector =
+      makeRowVector({"b"}, {makeFlatVector<int64_t>(10'000, folly::identity)});
+  auto cVector = makeRowVector(
+      {"c"},
+      {makeFlatVector<int64_t>(10'000, [](auto i) { return i + 10'000; })});
+  std::shared_ptr<TempFilePath> files[3];
+  files[0] = TempFilePath::create();
+  writeToFile(files[0]->getPath(), {aVector});
+  files[1] = TempFilePath::create();
+  writeToFile(files[1]->getPath(), {bVector});
+  files[2] = TempFilePath::create();
+  writeToFile(files[2]->getPath(), {cVector});
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId aScanId;
+  core::PlanNodeId bScanId;
+  core::PlanNodeId cScanId;
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .tableScan(ROW({"a"}, {BIGINT()}))
+                  .capturePlanNodeId(aScanId)
+                  .hashJoin(
+                      {"a"},
+                      {"b"},
+                      PlanBuilder(planNodeIdGenerator)
+                          .tableScan(ROW({"b"}, {BIGINT()}))
+                          .capturePlanNodeId(bScanId)
+                          .planNode(),
+                      "", /*filter*/
+                      {"a"})
+                  .hashJoin(
+                      {"a"},
+                      {"c"},
+                      PlanBuilder(planNodeIdGenerator)
+                          .tableScan(ROW({"c"}, {BIGINT()}))
+                          .capturePlanNodeId(cScanId)
+                          .planNode(),
+                      "", /*filter*/
+                      {"a"})
+                  .planNode();
+  AssertQueryBuilder(plan)
+      .split(aScanId, makeHiveConnectorSplit(files[0]->getPath()))
+      .split(bScanId, makeHiveConnectorSplit(files[1]->getPath()))
+      .split(cScanId, makeHiveConnectorSplit(files[2]->getPath()))
+      .assertResults(makeRowVector({makeFlatVector<int64_t>(0)}));
+}
+
 // TODO: re-enable this test once we add back driver suspension support for
 // table scan.
 TEST_F(TableScanTest, DISABLED_memoryArbitrationWithSlowTableScan) {


### PR DESCRIPTION
Summary:
The data structure we used in table scan operator to keep dynamic
filters can only hold one filter per column.  When multiple operators pushing
dynamic filters to the same column, the later ones would overwrite the previous
filters on the same column.  Fix this by merging the existing filter with the
new filter.

Differential Revision: D59814502
