### PR TITLE
Fix checksum to be compatible with Presto on -0.0 .

### DIFF
--- a/velox/functions/prestosql/aggregates/PrestoHasher.cpp
+++ b/velox/functions/prestosql/aggregates/PrestoHasher.cpp
@@ -78,12 +78,16 @@ FOLLY_ALWAYS_INLINE void hashFloating(
   using IntegralType =
       std::conditional_t<std::is_same_v<T, float>, int32_t, int64_t>;
   applyHashFunction(rows, vector, hashes, [&](auto row) {
-    if (std::isnan(vector.valueAt<T>(row))) {
+    auto value = vector.valueAt<T>(row);
+    if (std::isnan(value)) {
       if constexpr (std::is_same_v<T, float>) {
         return hashInteger<IntegralType>(0x7fc00000);
       } else {
         return hashInteger<IntegralType>(0x7ff8000000000000L);
       }
+    } else if (value == (T{})) {
+      // If -0.0 treat it same as 0
+      return hashInteger<IntegralType>(0);
     } else {
       return hashInteger<IntegralType>(vector.valueAt<IntegralType>(row));
     }

--- a/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
@@ -122,6 +122,7 @@ TEST_F(ChecksumAggregateTest, doubles) {
   assertSingleGroupChecksum<double>({99.9}, "iVY+6I1lKyo=");
   assertSingleGroupChecksum<double>({1, 2, 3}, "AACEg9cR14o=");
   assertSingleGroupChecksum<double>({kNaN, kNaN, kNaN}, "AACMau93L28=");
+  assertSingleGroupChecksum<double>({{-0.0}}, "AAAAAAAAAAA=");
 
   assertGroupingChecksum<int8_t, double>(
       {'a', 'b', 'a'}, {1, 2, 3}, {"AACEI6XSDyU=", "AAAAYDI/x2U="});
@@ -130,7 +131,7 @@ TEST_F(ChecksumAggregateTest, doubles) {
   assertGroupingChecksum<int8_t, double>(
       {1, 1, 2}, {kNaN, kNaN, kNaN}, {"AAAIR0qlH0o=", "AACEI6XSDyU="});
   assertGroupingChecksum<int8_t, double>(
-      {1, 2}, {0.0, -0.0}, {"AAAAAAAAAAA=", "AAAAQMzUhO4="});
+      {1, 2}, {0.0, -0.0}, {"AAAAAAAAAAA=", "AAAAAAAAAAA="});
 }
 
 TEST_F(ChecksumAggregateTest, reals) {
@@ -139,6 +140,7 @@ TEST_F(ChecksumAggregateTest, reals) {
   assertSingleGroupChecksum<float>({99.9}, "IX/UyPhj6MY=");
   assertSingleGroupChecksum<float>({1, 2, 3}, "b/j7Q4YtV+g=");
   assertSingleGroupChecksum<float>({kNaNF, kNaNF, kNaNF}, "AmWPYoutLK0=");
+  assertSingleGroupChecksum<float>({{-0.0}}, "AAAAAAAAAAA=");
 
   assertGroupingChecksum<int8_t, float>(
       {'a', 'b', 'a'}, {1, 2, 3}, {"Vswv9sY4wxY=", "GSzMTb/0k9E="});
@@ -147,7 +149,7 @@ TEST_F(ChecksumAggregateTest, reals) {
   assertGroupingChecksum<int8_t, float>(
       {1, 1, 2}, {kNaNF, kNaNF, kNaNF}, {"rJhf7Fwec3M=", "Vswvdi6PuTk="});
   assertGroupingChecksum<int8_t, float>(
-      {1, 2}, {0.0, -0.0}, {"AAAAAAAAAAA=", "bAFBcIKzvC4="});
+      {1, 2}, {0.0, -0.0}, {"AAAAAAAAAAA=", "AAAAAAAAAAA="});
 }
 
 TEST_F(ChecksumAggregateTest, dates) {


### PR DESCRIPTION
The recent changes in Presto (https://github.com/kgpai/presto/commit/aa5de0c3ffcbab531d95ed6409bc635681272831) have made 0 equivalent to -0.0. This change has affected the previous checksum behavior, and this pull request ensures that Velox's behavior is consistent with Presto's behavior.