### PR TITLE
Fix yaml syntax error in linux-build.yml

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -113,7 +113,8 @@ jobs:
 
       #Temporarily rename Minio binary to include version until CI image is updated with the same.
       - name: Rename Minio
-        run: [ -f /usr/local/bin/minio ] && mv /usr/local/bin/minio /usr/local/bin/minio-2022-05-26
+        run: |
+          [ -f /usr/local/bin/minio ] && mv /usr/local/bin/minio /usr/local/bin/minio-2022-05-26
 
       - name: Ccache after
         run: ccache -s

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -111,11 +111,6 @@ jobs:
           )
           make release EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS[*]}"
 
-      #Temporarily rename Minio binary to include version until CI image is updated with the same.
-      - name: Rename Minio
-        run: |
-          [ -f /usr/local/bin/minio ] && mv /usr/local/bin/minio /usr/local/bin/minio-2022-05-26
-
       - name: Ccache after
         run: ccache -s
 


### PR DESCRIPTION
#10373 broke the linux-build.yml workflows due to a syntax error, this fixes it.