### PR TITLE
Install 'gtest' library in setup-macos.sh

### DIFF
--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -34,7 +34,7 @@ source $SCRIPTDIR/setup-helper-functions.sh
 NPROC=$(getconf _NPROCESSORS_ONLN)
 
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
-MACOS_VELOX_DEPS="flex bison protobuf@21 icu4c boost gflags glog libevent lz4 lzo snappy xz zstd openssl libsodium"
+MACOS_VELOX_DEPS="flex bison protobuf@21 icu4c boost gflags glog libevent lz4 lzo snappy xz zstd openssl libsodium googletest"
 MACOS_BUILD_DEPS="ninja cmake ccache"
 FB_OS_VERSION="v2024.05.20.00"
 


### PR DESCRIPTION
The problem of compiling errors when using the precompiled 'gtest'
library has been solved in #10422 , so we can pre-install this library
in setup-macos.sh.