### PR TITLE
Generate row frames with columns in Window Fuzzer

### DIFF
--- a/velox/exec/fuzzer/WindowFuzzer.h
+++ b/velox/exec/fuzzer/WindowFuzzer.h
@@ -82,7 +82,10 @@ class WindowFuzzer : public AggregationFuzzerBase {
 
   // Return a randomly generated frame clause string together with a boolean
   // flag indicating whether it is a ROWS frame.
-  std::tuple<std::string, bool> generateFrameClause();
+  std::string generateFrameClause(
+      std::vector<std::string>& argNames,
+      std::vector<TypePtr>& argTypes,
+      bool& isRowsFrame);
 
   std::string generateOrderByClause(
       const std::vector<SortingKeyAndOrder>& sortingKeysAndOrders);


### PR DESCRIPTION
WindowFuzzer now generate k-rows frames with column boundaries, e.g., ROWS BETWEEN c1 PRECEDING AND c2 FOLLOWING.
These frames are supported in the Window operators, so extension of WindowFuzzer to cover them was added in too.