### PR TITLE
Disable set_agg in aggregation fuzzer test

### DIFF
--- a/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
@@ -120,6 +120,13 @@ int main(int argc, char** argv) {
       "map_union_sum",
       "approx_set",
       "any_value",
+      // Presto 0.288 makes set_agg and set_union not respect order-by on
+      // inputs. Presto 0.289
+      // re-enables the order-by for them. So skip these two functions until we
+      // compare
+      // Velox result against Presto 0.289 or later versions.
+      "set_agg",
+      "set_union",
   };
 
   using facebook::velox::exec::test::ApproxDistinctResultVerifier;


### PR DESCRIPTION
Summary:
The recent aggregation fuzzer test failures are caused by a change in Presto 0.288 that makes
set_agg not respect order-by on inputs. Presto 0.289 will re-enable order-by on set_agg inputs. So
before we comapre results against Presto 0.289, we skip set_agg in aggregation fuzzer test for
now.

More details can be found in https://github.com/facebookincubator/velox/issues/10442.

Differential Revision: D59883289
