### PR TITLE
Add unknown type support for Spark hash function

### DIFF
--- a/velox/functions/sparksql/Hash.cpp
+++ b/velox/functions/sparksql/Hash.cpp
@@ -175,7 +175,7 @@ class UnknowTypeVectorHasher : public SparkVectorHasher<HashClass> {
   using SeedType = typename HashClass::SeedType;
   using ReturnType = typename HashClass::ReturnType;
 
-  UnknowTypeVectorHasher(DecodedVector& decoded)
+  explicit UnknowTypeVectorHasher(DecodedVector& decoded)
       : SparkVectorHasher<HashClass>(decoded) {}
 
   ReturnType hashNotNullAt(vector_size_t /*index*/, SeedType /*seed*/)

--- a/velox/functions/sparksql/Hash.h
+++ b/velox/functions/sparksql/Hash.h
@@ -54,12 +54,10 @@ std::shared_ptr<exec::VectorFunction> makeHashWithSeed(
 //   - Decimal
 //   - Date
 //   - Timestamp
-//
-// Unsupported:
-//   - Structs, Arrays: hash the elements in order
-//   - Maps: iterate over map, hashing key then value. Since map ordering is
-//        unspecified, hashing logically equivalent maps may result in
-//        different hash values.
+//   - UnknownType
+//   - Struct
+//   - Array
+//   - Map
 
 std::vector<std::shared_ptr<exec::FunctionSignature>> xxhash64Signatures();
 

--- a/velox/functions/sparksql/benchmarks/HashBenchmark.cpp
+++ b/velox/functions/sparksql/benchmarks/HashBenchmark.cpp
@@ -41,6 +41,7 @@ int main(int argc, char** argv) {
       VARCHAR(),
       DECIMAL(18, 6),
       DECIMAL(38, 6),
+      UNKNOWN(),
       ARRAY(MAP(INTEGER(), VARCHAR())),
       ROW({"f_map", "f_array"}, {MAP(INTEGER(), VARCHAR()), ARRAY(INTEGER())}),
   };

--- a/velox/functions/sparksql/tests/HashTest.cpp
+++ b/velox/functions/sparksql/tests/HashTest.cpp
@@ -252,6 +252,33 @@ TEST_F(HashTest, row) {
   assertEqualVectors(makeFlatVector<int32_t>({42, 42}), hash(row));
 }
 
+TEST_F(HashTest, unknown) {
+  assertEqualVectors(
+      makeFlatVector<int32_t>({42, 42, 42}),
+      hash(makeAllNullFlatVector<UnknownValue>(3)));
+
+  assertEqualVectors(
+      makeFlatVector<int32_t>({42, 42}),
+      hash(makeNullableArrayVector<UnknownValue>({
+          {std::nullopt, std::nullopt},
+          {std::nullopt, std::nullopt, std::nullopt},
+      })));
+
+  auto mapVector = makeNullableMapVector<UnknownValue, UnknownValue>({
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
+  });
+  assertEqualVectors(makeFlatVector<int32_t>({42, 42, 42}), hash(mapVector));
+
+  auto row = makeRowVector({
+      makeFlatVector<int64_t>({1, 3, 4}),
+      makeAllNullFlatVector<UnknownValue>(3),
+  });
+  assertEqualVectors(
+      makeFlatVector<int32_t>({-1712319331, 519220707, 1344313940}), hash(row));
+}
+
 TEST_F(HashTest, simd) {
   runSIMDHashAndAssert<int8_t>(1, -559580957, 1024, 10);
   runSIMDHashAndAssert<int16_t>(-1, -1604776387, 4096);

--- a/velox/functions/sparksql/tests/HashTest.cpp
+++ b/velox/functions/sparksql/tests/HashTest.cpp
@@ -42,15 +42,22 @@ class HashTest : public SparkFunctionBaseTest {
       int unSelectedRows = 0) {
     // Generate 'size' flat vector to test SIMD code path.
     // We use same value in the vector to make comparing the results easier.
-    std::vector<T> inputData;
-    inputData.reserve(size);
     std::vector<int32_t> resultData;
     resultData.reserve(size);
     for (auto i = 0; i < size; ++i) {
-      inputData.emplace_back(value);
       resultData.emplace_back(expectedResult);
     }
-    auto input = makeFlatVector<T>(inputData);
+    VectorPtr input;
+    if constexpr (std::is_same_v<T, UnknownValue>) {
+      input = makeAllNullFlatVector<T>(size);
+    } else {
+      std::vector<T> inputData;
+      inputData.reserve(size);
+      for (auto i = 0; i < size; ++i) {
+        inputData.emplace_back(value);
+      }
+      input = makeFlatVector<T>(inputData);
+    }
     SelectivityVector rows(size);
     rows.setValidRange(0, unSelectedRows, false);
     auto result =
@@ -293,6 +300,7 @@ TEST_F(HashTest, simd) {
   runSIMDHashAndAssert<int64_t>(-1, -939490007, 1024, 1023);
   runSIMDHashAndAssert<int64_t>(-1, -939490007, 1024, 512);
   runSIMDHashAndAssert<int64_t>(-1, -939490007, 1024, 3);
+  runSIMDHashAndAssert<UnknownValue>(UnknownValue(), 42, 10);
 }
 
 } // namespace

--- a/velox/functions/sparksql/tests/XxHash64Test.cpp
+++ b/velox/functions/sparksql/tests/XxHash64Test.cpp
@@ -269,6 +269,36 @@ TEST_F(XxHash64Test, row) {
   assertEqualVectors(makeFlatVector<int64_t>({42, 42}), xxhash64(row));
 }
 
+TEST_F(XxHash64Test, unknown) {
+  assertEqualVectors(
+      makeFlatVector<int64_t>({42, 42, 42}),
+      xxhash64(makeAllNullFlatVector<UnknownValue>(3)));
+
+  assertEqualVectors(
+      makeFlatVector<int64_t>({42, 42}),
+      xxhash64(makeNullableArrayVector<UnknownValue>({
+          {std::nullopt, std::nullopt},
+          {std::nullopt, std::nullopt, std::nullopt},
+      })));
+
+  auto mapVector = makeNullableMapVector<UnknownValue, UnknownValue>({
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
+  });
+  assertEqualVectors(
+      makeFlatVector<int64_t>({42, 42, 42}), xxhash64(mapVector));
+
+  auto row = makeRowVector({
+      makeFlatVector<int64_t>({1, 3, 4}),
+      makeAllNullFlatVector<UnknownValue>(3),
+  });
+  assertEqualVectors(
+      makeFlatVector<int64_t>(
+          {-7001672635703045582, 3188756510806108107, 404280023041566627}),
+      xxhash64(row));
+}
+
 TEST_F(XxHash64Test, hashSeed) {
   auto xxhash64WithSeed = [&](int64_t seed, const std::optional<int64_t>& arg) {
     return evaluateOnce<int64_t>(


### PR DESCRIPTION
Below exception was noticed in Gluten. This PR adds unknown type support for 
Spark hash function.

```c++
org.apache.gluten.exception.GlutenException: java.lang.RuntimeException: Exception: VeloxUserError
Error Source: USER
Error Code: INVALID_ARGUMENT
Reason: Unsupported type for hash: UNKNOWN
Retriable: False
Function: checkArgTypes
File: /velox/velox/functions/sparksql/Hash.cpp
```