### PR TITLE
Fix argument check error message for HistogramAggregate

### DIFF
--- a/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
@@ -506,10 +506,7 @@ void registerHistogramAggregate(
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
         VELOX_CHECK_EQ(
-            argTypes.size(),
-            1,
-            "{} ({}): unexpected number of arguments",
-            name);
+            argTypes.size(), 1, "{}: unexpected number of arguments", name);
 
         auto inputType = argTypes[0];
         switch (exec::isRawInput(step) ? inputType->kind()

--- a/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
@@ -175,7 +175,7 @@ void registerMapAggAggregate(
         VELOX_CHECK_EQ(
             argTypes.size(),
             rawInput ? 2 : 1,
-            "{} ({}): unexpected number of arguments",
+            "{}: unexpected number of arguments",
             name);
         const bool throwOnNestedNulls = rawInput;
         const auto typeKind = resultType->childAt(0)->kind();

--- a/velox/functions/prestosql/aggregates/MapUnionAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapUnionAggregate.cpp
@@ -99,10 +99,7 @@ void registerMapUnionAggregate(
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
         VELOX_CHECK_EQ(
-            argTypes.size(),
-            1,
-            "{} ({}): unexpected number of arguments",
-            name);
+            argTypes.size(), 1, "{}: unexpected number of arguments", name);
 
         return createMapAggregate<MapUnionAggregate>(resultType);
       },


### PR DESCRIPTION
`"{} ({}): unexpected number of arguments",` ->
`C++ exception with description "argument not found" thrown in the test body.`