### PR TITLE
Extend filesystem APIs

### DIFF
--- a/velox/common/file/FileSystems.cpp
+++ b/velox/common/file/FileSystems.cpp
@@ -103,8 +103,12 @@ class LocalFileSystem : public FileSystem {
 
   std::unique_ptr<WriteFile> openFileForWrite(
       std::string_view path,
-      const FileOptions& /*unused*/) override {
-    return std::make_unique<LocalWriteFile>(extractPath(path));
+      const FileOptions& options) override {
+    return std::make_unique<LocalWriteFile>(
+        extractPath(path),
+        options.shouldCreateParentDirectories,
+        options.shouldThrowOnFileAlreadyExists,
+        options.bufferWrite);
   }
 
   void remove(std::string_view path) override {

--- a/velox/common/file/FileSystems.h
+++ b/velox/common/file/FileSystems.h
@@ -47,6 +47,23 @@ struct FileOptions {
   memory::MemoryPool* pool{nullptr};
   /// If specified then can be trusted to be the file size.
   std::optional<int64_t> fileSize;
+
+  /// Whether to create parent directories if they don't exist.
+  ///
+  /// NOTE: this only applies for write open file.
+  bool shouldCreateParentDirectories{false};
+
+  /// Whether to throw an error if a file already exists.
+  ///
+  /// NOTE: this only applies for write open file.
+  bool shouldThrowOnFileAlreadyExists{true};
+
+  /// Whether to buffer the write data in file system client or not. For local
+  /// filesystem on Unix-like operating system, this corresponds to the direct
+  /// IO mode if set.
+  ///
+  /// NOTE: this only applies for write open file.
+  bool bufferWrite{true};
 };
 
 /// An abstract FileSystem

--- a/velox/common/file/tests/FaultyFile.cpp
+++ b/velox/common/file/tests/FaultyFile.cpp
@@ -112,8 +112,29 @@ void FaultyWriteFile::append(std::unique_ptr<folly::IOBuf> data) {
   delegatedFile_->append(std::move(data));
 }
 
+void FaultyWriteFile::write(
+    const std::vector<iovec>& iovecs,
+    int64_t offset,
+    int64_t length) {
+  delegatedFile_->write(iovecs, offset, length);
+}
+
+void FaultyWriteFile::truncate(int64_t newSize) {
+  delegatedFile_->truncate(newSize);
+}
+
 void FaultyWriteFile::flush() {
   delegatedFile_->flush();
+}
+
+void FaultyWriteFile::setAttributes(
+    const std::unordered_map<std::string, std::string>& attributes) {
+  delegatedFile_->setAttributes(attributes);
+}
+
+std::unordered_map<std::string, std::string> FaultyWriteFile::getAttributes()
+    const {
+  return delegatedFile_->getAttributes();
 }
 
 void FaultyWriteFile::close() {

--- a/velox/common/file/tests/FaultyFile.h
+++ b/velox/common/file/tests/FaultyFile.h
@@ -167,7 +167,17 @@ class FaultyWriteFile : public WriteFile {
 
   void append(std::unique_ptr<folly::IOBuf> data) override;
 
+  void write(const std::vector<iovec>& iovecs, int64_t offset, int64_t length)
+      override;
+
+  void truncate(int64_t newSize) override;
+
   void flush() override;
+
+  void setAttributes(
+      const std::unordered_map<std::string, std::string>& attributes) override;
+
+  std::unordered_map<std::string, std::string> getAttributes() const override;
 
   void close() override;
 


### PR DESCRIPTION
Add the following APIs to filesystem:
- write: Writes data at the given offset of the file.
- truncate: Truncates file to a new size.
- setAttributes: Sets the file attributes.
- getAttributes: Gets the file attributes.
- unlink: Deletes the file.

Switch `FILE*` to file descriptor in `LocalWriteFile` for more granular control. This is also aligned with `LocalReadFile`.