### PR TITLE
Iceberg row group fix new

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -52,12 +52,13 @@ class IcebergSplitReader : public SplitReader {
   // The read offset to the beginning of the split in number of rows for the
   // current batch for the base data file
   uint64_t baseReadOffset_;
-
   // The file position for the first row in the split
   uint64_t splitOffset_;
-
   std::list<std::unique_ptr<PositionalDeleteFileReader>>
       positionalDeleteFileReaders_;
   BufferPtr deleteBitmap_;
+  // The offset in bits of the deleteBitmap_ starting from where the bits shall
+  // be consumed
+  uint64_t deleteBitmapBitOffset_;
 };
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
@@ -231,7 +231,9 @@ void PositionalDeleteFileReader::updateDeleteBitmap(
   // the deleteBitmapBuffer should be the largest position among all delte files
   deleteBitmapBuffer->setSize(std::max(
       (uint64_t)deleteBitmapBuffer->size(),
-      deletePositionsOffset_ == 0
+      deletePositionsOffset_ == 0 ||
+              (deletePositionsOffset_ < deletePositionsVector->size() &&
+               deletePositions[deletePositionsOffset_] > rowNumberUpperBound)
           ? 0
           : bits::nbytes(
                 deletePositions[deletePositionsOffset_ - 1] + 1 - offset)));

--- a/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
@@ -49,12 +49,9 @@ PositionalDeleteFileReader::PositionalDeleteFileReader(
       deleteRowReader_(nullptr),
       deletePositionsOutput_(nullptr),
       deletePositionsOffset_(0),
-      endOfFile_(false) {
+      totalNumRowsScanned_(0) {
   VELOX_CHECK(deleteFile_.content == FileContent::kPositionalDeletes);
-
-  if (deleteFile_.recordCount == 0) {
-    return;
-  }
+  VELOX_CHECK(deleteFile_.recordCount);
 
   // TODO: check if the lowerbounds and upperbounds in deleteFile overlap with
   //  this batch. If not, no need to proceed.
@@ -137,13 +134,15 @@ PositionalDeleteFileReader::PositionalDeleteFileReader(
 void PositionalDeleteFileReader::readDeletePositions(
     uint64_t baseReadOffset,
     uint64_t size,
-    int8_t* deleteBitmap) {
+    BufferPtr deleteBitmapBuffer) {
   // We are going to read to the row number up to the end of the batch. For the
   // same base file, the deleted rows are in ascending order in the same delete
-  // file
+  // file. rowNumberUpperBound is the upperbound for the row number in this
+  // batch, excluding boundaries
   int64_t rowNumberUpperBound = splitOffset_ + baseReadOffset + size;
 
-  // Finish unused delete positions from last batch
+  // Finish unused delete positions from last batch. Note that at this point we
+  // don't know how many rows the base row reader would scan yet.
   if (deletePositionsOutput_ &&
       deletePositionsOffset_ < deletePositionsOutput_->size()) {
     updateDeleteBitmap(
@@ -151,7 +150,7 @@ void PositionalDeleteFileReader::readDeletePositions(
             ->childAt(0),
         baseReadOffset,
         rowNumberUpperBound,
-        deleteBitmap);
+        deleteBitmapBuffer);
 
     if (readFinishedForBatch(rowNumberUpperBound)) {
       return;
@@ -166,14 +165,15 @@ void PositionalDeleteFileReader::readDeletePositions(
   // and update the delete bitmap
 
   auto outputType = posColumn_->type;
-
   RowTypePtr outputRowType = ROW({posColumn_->name}, {posColumn_->type});
   if (!deletePositionsOutput_) {
     deletePositionsOutput_ = BaseVector::create(outputRowType, 0, pool_);
   }
 
-  while (!readFinishedForBatch(rowNumberUpperBound)) {
+  do {
     auto rowsScanned = deleteRowReader_->next(size, deletePositionsOutput_);
+    totalNumRowsScanned_ += rowsScanned;
+
     if (rowsScanned > 0) {
       VELOX_CHECK(
           !deletePositionsOutput_->mayHaveNulls(),
@@ -184,42 +184,57 @@ void PositionalDeleteFileReader::readDeletePositions(
         deletePositionsOutput_->loadedVector();
         deletePositionsOffset_ = 0;
 
+        // Convert the row numbers to set bits, up to rowNumberUpperBound.
+        // Beyond that the buffer of deleteBitMap is not available.
         updateDeleteBitmap(
             std::dynamic_pointer_cast<RowVector>(deletePositionsOutput_)
                 ->childAt(0),
             baseReadOffset,
             rowNumberUpperBound,
-            deleteBitmap);
+            deleteBitmapBuffer);
       }
     } else {
       // Reaching the end of the file
-      endOfFile_ = true;
       deleteSplit_.reset();
-      return;
+      break;
     }
-  }
+  } while (!readFinishedForBatch(rowNumberUpperBound));
 }
 
-bool PositionalDeleteFileReader::endOfFile() {
-  return endOfFile_;
+bool PositionalDeleteFileReader::noMoreData() {
+  return totalNumRowsScanned_ >= deleteFile_.recordCount &&
+      deletePositionsOutput_ &&
+      deletePositionsOffset_ >= deletePositionsOutput_->size();
 }
 
 void PositionalDeleteFileReader::updateDeleteBitmap(
     VectorPtr deletePositionsVector,
     uint64_t baseReadOffset,
     int64_t rowNumberUpperBound,
-    int8_t* deleteBitmap) {
+    BufferPtr deleteBitmapBuffer) {
+  auto deleteBitmap = deleteBitmapBuffer->asMutable<uint8_t>();
+
   // Convert the positions in file into positions relative to the start of the
   // split.
   const int64_t* deletePositions =
       deletePositionsVector->as<FlatVector<int64_t>>()->rawValues();
   int64_t offset = baseReadOffset + splitOffset_;
+
   while (deletePositionsOffset_ < deletePositionsVector->size() &&
          deletePositions[deletePositionsOffset_] < rowNumberUpperBound) {
     bits::setBit(
         deleteBitmap, deletePositions[deletePositionsOffset_] - offset);
     deletePositionsOffset_++;
   }
+
+  // There might be multiple delete files for a single base file. The size of
+  // the deleteBitmapBuffer should be the largest position among all delte files
+  deleteBitmapBuffer->setSize(std::max(
+      (uint64_t)deleteBitmapBuffer->size(),
+      deletePositionsOffset_ == 0
+          ? 0
+          : bits::nbytes(
+                deletePositions[deletePositionsOffset_ - 1] + 1 - offset)));
 }
 
 bool PositionalDeleteFileReader::readFinishedForBatch(
@@ -231,9 +246,14 @@ bool PositionalDeleteFileReader::readFinishedForBatch(
   const int64_t* deletePositions =
       deletePositionsVector->as<FlatVector<int64_t>>()->rawValues();
 
-  if (deletePositionsOutput_->size() != 0 &&
-      deletePositionsOffset_ < deletePositionsVector->size() &&
-      deletePositions[deletePositionsOffset_] >= rowNumberUpperBound) {
+  // We've read enough of the delete positions from this delete file when 1) it
+  // reaches the end of the file, or 2) the last read delete position is greater
+  // than the largest base file row number that is going to be read in this
+  // batch
+  if (totalNumRowsScanned_ >= deleteFile_.recordCount ||
+      (deletePositionsVector->size() != 0 &&
+       (deletePositionsOffset_ < deletePositionsVector->size() &&
+        deletePositions[deletePositionsOffset_] >= rowNumberUpperBound))) {
     return true;
   }
   return false;

--- a/velox/connectors/hive/iceberg/PositionalDeleteFileReader.h
+++ b/velox/connectors/hive/iceberg/PositionalDeleteFileReader.h
@@ -50,16 +50,16 @@ class PositionalDeleteFileReader {
   void readDeletePositions(
       uint64_t baseReadOffset,
       uint64_t size,
-      int8_t* deleteBitmap);
+      BufferPtr deleteBitmap);
 
-  bool endOfFile();
+  bool noMoreData();
 
  private:
   void updateDeleteBitmap(
       VectorPtr deletePositionsVector,
       uint64_t baseReadOffset,
       int64_t rowNumberUpperBound,
-      int8_t* deleteBitmap);
+      BufferPtr deleteBitmapBuffer);
 
   bool readFinishedForBatch(int64_t rowNumberUpperBound);
 
@@ -77,9 +77,17 @@ class PositionalDeleteFileReader {
 
   std::shared_ptr<HiveConnectorSplit> deleteSplit_;
   std::unique_ptr<dwio::common::RowReader> deleteRowReader_;
+  // The vector to hold the delete positions read from the positional delete
+  // file. These positions are relative to the start of the whole base data
+  // file.
   VectorPtr deletePositionsOutput_;
+  // The index of deletePositionsOutput_ that indicates up to where the delete
+  // positions have been converted into the bitmap
   uint64_t deletePositionsOffset_;
-  bool endOfFile_;
+  // Total number of rows read from this positional delete file reader,
+  // including the rows filtered out from filters on both filePathColumn_ and
+  // posColumn_.
+  uint64_t totalNumRowsScanned_;
 };
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -538,6 +538,8 @@ TEST_F(HiveIcebergTest, singleBaseFileMultiplePositionalDeleteFiles) {
   // Delete the first and last row in each batch (10000 rows per batch).
   assertSingleBaseFileMultipleDeleteFiles({{0}, {9999}, {10000}, {19999}});
 
+  assertSingleBaseFileMultipleDeleteFiles({{500, 21000}});
+
   assertSingleBaseFileMultipleDeleteFiles(
       {makeRandomIncreasingValues(0, 10000),
        makeRandomIncreasingValues(10000, 20000),

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -34,107 +34,186 @@ namespace facebook::velox::connector::hive::iceberg {
 
 class HiveIcebergTest : public HiveConnectorTestBase {
  public:
-  void assertPositionalDeletes(
-      const std::vector<std::vector<int64_t>>& deleteRowsVec,
-      bool multipleBaseFiles = false) {
-    assertPositionalDeletesInternal(
-        deleteRowsVec, getQuery(deleteRowsVec), multipleBaseFiles, 1, 0);
+  HiveIcebergTest()
+      : config_{std::make_shared<facebook::velox::dwrf::Config>()} {
+    // Make the writers flush per batch so that we can create non-aligned
+    // RowGroups between the base data files and delete files
+    flushPolicyFactory_ = []() {
+      return std::make_unique<dwrf::LambdaFlushPolicy>([]() { return true; });
+    };
   }
 
-  void assertPositionalDeletes(
-      const std::vector<std::vector<int64_t>>& deleteRowsVec,
-      std::string duckdbSql,
-      bool multipleBaseFiles = false) {
-    assertPositionalDeletesInternal(
-        deleteRowsVec, duckdbSql, multipleBaseFiles, 1, 0);
+  /// Create 1 base data file data_file_1 with 2 RowGroups of 10000 rows each.
+  /// Also create 1 delete file delete_file_1 which contains delete positions
+  /// for data_file_1.
+  void assertSingleBaseFileSingleDeleteFile(
+      const std::vector<int64_t>& deletePositionsVec) {
+    std::map<std::string, std::vector<int64_t>> rowGroupSizesForFiles = {
+        {"data_file_1", {10000, 10000}}};
+    std::unordered_map<
+        std::string,
+        std::multimap<std::string, std::vector<int64_t>>>
+        deleteFilesForBaseDatafiles = {
+            {"delete_file_1", {{"data_file_1", deletePositionsVec}}}};
+    false;
+    assertPositionalDeletes(
+        rowGroupSizesForFiles, deleteFilesForBaseDatafiles, 0);
   }
 
-  void assertPositionalDeletes(
-      const std::vector<std::vector<int64_t>>& deleteRowsVec,
-      std::string duckdbSql,
+  /// Create 3 base data files, where the first file data_file_0 has 500 rows,
+  /// the second file data_file_1 contains 2 RowGroups of 10000 rows each, and
+  /// the third file data_file_2 contains 500 rows. It creates 1 positional
+  /// delete file delete_file_1, which contains delete positions for
+  /// data_file_1.
+  void assertMultipleBaseFileSingleDeleteFile(
+      const std::vector<int64_t>& deletePositionsVec) {
+    int64_t previousFileRowCount = 500;
+    int64_t afterFileRowCount = 500;
+
+    assertPositionalDeletes(
+        {
+            {"data_file_0", {previousFileRowCount}},
+            {"data_file_1", {10000, 10000}},
+            {"data_file_2", {afterFileRowCount}},
+        },
+        {{"delete_file_1", {{"data_file_1", deletePositionsVec}}}},
+        0);
+  }
+
+  /// Create 1 base data file data_file_1 with 2 RowGroups of 10000 rows each.
+  /// Create multiple delete files with name data_file_1, data_file_2, and so on
+  void assertSingleBaseFileMultipleDeleteFiles(
+      const std::vector<std::vector<int64_t>>& deletePositionsVecs) {
+    std::map<std::string, std::vector<int64_t>> rowGroupSizesForFiles = {
+        {"data_file_1", {10000, 10000}}};
+
+    std::unordered_map<
+        std::string,
+        std::multimap<std::string, std::vector<int64_t>>>
+        deleteFilesForBaseDatafiles;
+    for (int i = 0; i < deletePositionsVecs.size(); i++) {
+      std::string deleteFileName = fmt::format("delete_file_{}", i);
+      deleteFilesForBaseDatafiles[deleteFileName] = {
+          {"data_file_1", deletePositionsVecs[i]}};
+    }
+    assertPositionalDeletes(
+        rowGroupSizesForFiles, deleteFilesForBaseDatafiles, 0);
+  }
+
+  void assertMultipleSplits(
+      const std::vector<int64_t>& deletePositions,
       int32_t splitCount,
       int32_t numPrefetchSplits) {
-    assertPositionalDeletesInternal(
-        deleteRowsVec, duckdbSql, true, splitCount, numPrefetchSplits);
+    std::map<std::string, std::vector<int64_t>> rowGroupSizesForFiles;
+    for (int32_t i = 0; i < splitCount; i++) {
+      std::string dataFileName = fmt::format("data_file_{}", i);
+      rowGroupSizesForFiles[dataFileName] = {rowCount};
+    }
+
+    std::unordered_map<
+        std::string,
+        std::multimap<std::string, std::vector<int64_t>>>
+        deleteFilesForBaseDatafiles;
+    for (int i = 0; i < splitCount; i++) {
+      std::string deleteFileName = fmt::format("delete_file_{}", i);
+      deleteFilesForBaseDatafiles[deleteFileName] = {
+          {fmt::format("data_file_{}", i), deletePositions}};
+    }
+
+    assertPositionalDeletes(
+        rowGroupSizesForFiles, deleteFilesForBaseDatafiles, numPrefetchSplits);
   }
 
-  std::vector<int64_t> makeRandomDeleteRows(int32_t maxRowNumber) {
+  std::vector<int64_t> makeRandomIncreasingValues(int64_t begin, int64_t end) {
+    VELOX_CHECK(begin < end);
+
     std::mt19937 gen{0};
-    std::vector<int64_t> deleteRows;
-    for (int i = 0; i < maxRowNumber; i++) {
+    std::vector<int64_t> values;
+    values.reserve(end - begin);
+    for (int i = begin; i < end; i++) {
       if (folly::Random::rand32(0, 10, gen) > 8) {
-        deleteRows.push_back(i);
+        values.push_back(i);
       }
     }
-    return deleteRows;
+    return values;
   }
 
-  std::vector<int64_t> makeSequenceRows(int32_t maxRowNumber) {
-    std::vector<int64_t> deleteRows;
-    deleteRows.resize(maxRowNumber);
-    std::iota(deleteRows.begin(), deleteRows.end(), 0);
-    return deleteRows;
+  std::vector<int64_t> makeContinuousIncreasingValues(
+      int64_t begin,
+      int64_t end) {
+    std::vector<int64_t> values;
+    values.resize(end - begin);
+    std::iota(values.begin(), values.end(), begin);
+    return values;
   }
 
-  std::vector<std::vector<int64_t>> makeContinuousRows(
-      int32_t min,
-      int32_t max) {
-    std::vector<std::vector<int64_t>> deleteRows(
-        max - min + 1, std::vector<int64_t>(1));
-    for (auto i = min; i <= max; i++) {
-      deleteRows[i - min][0] = i;
-    }
-    return deleteRows;
-  }
-
-  std::string getQuery(const std::vector<std::vector<int64_t>>& deleteRowsVec) {
-    return "SELECT * FROM tmp WHERE c0 NOT IN (" +
-        makeNotInList(deleteRowsVec) + ")";
-  }
-
-  const static int rowCount = 20000;
-
- private:
-  void assertPositionalDeletesInternal(
-      const std::vector<std::vector<int64_t>>& deleteRowsVec,
-      std::string duckdbSql,
-      bool multipleBaseFiles,
-      int32_t splitCount,
-      int32_t numPrefetchSplits) {
-    auto dataFilePaths = writeDataFile(splitCount, rowCount);
-    std::vector<std::shared_ptr<ConnectorSplit>> splits;
+  /// @rowGroupSizesForFiles The key is the file name, and the value is a vector
+  /// of RowGroup sizes
+  /// @deleteFilesForBaseDatafiles The key is the delete file name, and the
+  /// value contains the information about the content of this delete file.
+  /// e.g. {
+  ///         "delete_file_1",
+  ///         {
+  ///             {"data_file_1", {1, 2, 3}},
+  ///             {"data_file_1", {4, 5, 6}},
+  ///             {"data_file_2", {0, 2, 4}}
+  ///         }
+  ///     }
+  /// represents one delete file called delete_file_1, which contains delete
+  /// positions for data_file_1 and data_file_2. THere are 3 RowGroups in this
+  /// delete file, the first two contain positions for data_file_1, and the last
+  /// contain positions for data_file_2
+  void assertPositionalDeletes(
+      const std::map<std::string, std::vector<int64_t>>& rowGroupSizesForFiles,
+      const std::unordered_map<
+          std::string,
+          std::multimap<std::string, std::vector<int64_t>>>
+          deleteFilesForBaseDatafiles,
+      int32_t numPrefetchSplits = 0) {
     // Keep the reference to the deleteFilePath, otherwise the corresponding
     // file will be deleted.
-    std::vector<std::shared_ptr<TempFilePath>> deleteFilePaths;
-    for (const auto& dataFilePath : dataFilePaths) {
-      std::mt19937 gen{0};
-      int64_t numDeleteRowsBefore =
-          multipleBaseFiles ? folly::Random::rand32(0, 1000, gen) : 0;
-      int64_t numDeleteRowsAfter =
-          multipleBaseFiles ? folly::Random::rand32(0, 1000, gen) : 0;
+    std::map<std::string, std::shared_ptr<TempFilePath>> dataFilePaths =
+        writeDataFiles(rowGroupSizesForFiles);
+    std::unordered_map<
+        std::string,
+        std::pair<int64_t, std::shared_ptr<TempFilePath>>>
+        deleteFilePaths = writePositionDeleteFiles(
+            deleteFilesForBaseDatafiles, dataFilePaths);
+
+    std::vector<std::shared_ptr<ConnectorSplit>> splits;
+
+    for (const auto& dataFile : dataFilePaths) {
+      std::string baseFileName = dataFile.first;
+      std::string baseFilePath = dataFile.second->getPath();
+
       std::vector<IcebergDeleteFile> deleteFiles;
-      deleteFiles.reserve(deleteRowsVec.size());
-      for (auto const& deleteRows : deleteRowsVec) {
-        std::shared_ptr<TempFilePath> deleteFilePath = writePositionDeleteFile(
-            dataFilePath->getPath(),
-            deleteRows,
-            numDeleteRowsBefore,
-            numDeleteRowsAfter);
-        auto path = deleteFilePath->getPath();
-        IcebergDeleteFile deleteFile(
-            FileContent::kPositionalDeletes,
-            deleteFilePath->getPath(),
-            fileFomat_,
-            deleteRows.size() + numDeleteRowsBefore + numDeleteRowsAfter,
-            testing::internal::GetFileSize(std::fopen(path.c_str(), "r")));
-        deleteFilePaths.emplace_back(deleteFilePath);
-        deleteFiles.emplace_back(deleteFile);
+
+      for (auto const& deleteFile : deleteFilesForBaseDatafiles) {
+        std::string deleteFileName = deleteFile.first;
+        std::multimap<std::string, std::vector<int64_t>> deleteFileContent =
+            deleteFile.second;
+
+        if (deleteFileContent.count(baseFileName) != 0) {
+          // If this delete file contains rows for the target base file, then
+          // add it to the split
+          auto deleteFilePath =
+              deleteFilePaths[deleteFileName].second->getPath();
+          IcebergDeleteFile deleteFile(
+              FileContent::kPositionalDeletes,
+              deleteFilePath,
+              fileFomat_,
+              deleteFilePaths[deleteFileName].first,
+              testing::internal::GetFileSize(
+                  std::fopen(deleteFilePath.c_str(), "r")));
+          deleteFiles.push_back(deleteFile);
+        }
       }
 
-      splits.emplace_back(
-          makeIcebergSplit(dataFilePath->getPath(), deleteFiles));
+      splits.emplace_back(makeIcebergSplit(baseFilePath, deleteFiles));
     }
 
+    std::string duckdbSql =
+        getDuckDBQuery(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
     auto plan = tableScanNode();
     auto task = HiveConnectorTestBase::assertQuery(
         plan, splits, duckdbSql, numPrefetchSplits);
@@ -144,6 +223,116 @@ class HiveIcebergTest : public HiveConnectorTestBase {
     auto it = planStats.find(scanNodeId);
     ASSERT_TRUE(it != planStats.end());
     ASSERT_TRUE(it->second.peakMemoryBytes > 0);
+  }
+
+  const static int rowCount = 20000;
+    
+ private:
+  std::map<std::string, std::shared_ptr<TempFilePath>> writeDataFiles(
+      std::map<std::string, std::vector<int64_t>> rowGroupSizesForFiles) {
+    std::map<std::string, std::shared_ptr<TempFilePath>> dataFilePaths;
+
+    std::vector<RowVectorPtr> dataVectorsJoined;
+    dataVectorsJoined.reserve(rowGroupSizesForFiles.size());
+
+    int64_t startingValue = 0;
+    for (auto& dataFile : rowGroupSizesForFiles) {
+      dataFilePaths[dataFile.first] = TempFilePath::create();
+
+      // We make the values are continuously increasing even across base data
+      // files. This is to make constructing DuckDB queries easier
+      std::vector<RowVectorPtr> dataVectors =
+          makeVectors(dataFile.second, startingValue);
+      writeToFile(
+          dataFilePaths[dataFile.first]->getPath(),
+          dataVectors,
+          config_,
+          flushPolicyFactory_);
+
+      for (int i = 0; i < dataVectors.size(); i++) {
+        dataVectorsJoined.push_back(dataVectors[i]);
+      }
+    }
+
+    createDuckDbTable(dataVectorsJoined);
+    return dataFilePaths;
+  }
+
+  /// Input is like <"deleteFile1", <"dataFile1", {pos_RG1, pos_RG2,..}>,
+  /// <"dataFile2", {pos_RG1, pos_RG2,..}>
+  std::unordered_map<
+      std::string,
+      std::pair<int64_t, std::shared_ptr<TempFilePath>>>
+  writePositionDeleteFiles(
+      const std::unordered_map<
+          std::string, // delete file name
+          std::multimap<
+              std::string,
+              std::vector<int64_t>>>
+          deleteFilesForBaseDatafiles, // <base file name, delete position
+                                       // vector for all RowGroups>
+      std::map<std::string, std::shared_ptr<TempFilePath>> baseFilePaths) {
+    std::unordered_map<
+        std::string,
+        std::pair<int64_t, std::shared_ptr<TempFilePath>>>
+        deleteFilePaths;
+    deleteFilePaths.reserve(deleteFilesForBaseDatafiles.size());
+
+    for (auto& deleteFile : deleteFilesForBaseDatafiles) {
+      auto deleteFileName = deleteFile.first;
+      auto deleteFileContent = deleteFile.second;
+      auto deleteFilePath = TempFilePath::create();
+
+      std::vector<RowVectorPtr> deleteFileVectors;
+      int64_t totalPositionsInDeleteFile = 0;
+
+      for (auto& deleteFileRowGroup : deleteFileContent) {
+        auto baseFileName = deleteFileRowGroup.first;
+        auto baseFilePath = baseFilePaths[baseFileName]->getPath();
+        auto positionsInRowGroup = deleteFileRowGroup.second;
+
+        auto filePathVector = makeFlatVector<std::string>(
+            static_cast<vector_size_t>(positionsInRowGroup.size()),
+            [&](vector_size_t row) { return baseFilePath; });
+        auto deletePosVector = makeFlatVector<int64_t>(positionsInRowGroup);
+
+        RowVectorPtr deleteFileVector = makeRowVector(
+            {pathColumn_->name, posColumn_->name},
+            {filePathVector, deletePosVector});
+
+        deleteFileVectors.push_back(deleteFileVector);
+        totalPositionsInDeleteFile += positionsInRowGroup.size();
+      }
+
+      writeToFile(
+          deleteFilePath->getPath(),
+          deleteFileVectors,
+          config_,
+          flushPolicyFactory_);
+
+      deleteFilePaths[deleteFileName] =
+          std::make_pair(totalPositionsInDeleteFile, deleteFilePath);
+    }
+
+    return deleteFilePaths;
+  }
+
+  std::vector<RowVectorPtr> makeVectors(
+      std::vector<int64_t> vectorSizes,
+      int64_t& startingValue) {
+    std::vector<RowVectorPtr> vectors;
+    vectors.reserve(vectorSizes.size());
+
+    vectors.reserve(vectorSizes.size());
+    for (int j = 0; j < vectorSizes.size(); j++) {
+      auto data = makeContinuousIncreasingValues(
+          startingValue, startingValue + vectorSizes[j]);
+      VectorPtr c0 = vectorMaker_.flatVector<int64_t>(data);
+      vectors.push_back(makeRowVector({"c0"}, {c0}));
+      startingValue += vectorSizes[j];
+    }
+
+    return vectors;
   }
 
   std::shared_ptr<ConnectorSplit> makeIcebergSplit(
@@ -170,106 +359,114 @@ class HiveIcebergTest : public HiveConnectorTestBase {
         deleteFiles);
   }
 
-  std::vector<RowVectorPtr> makeVectors(int32_t count, int32_t rowsPerVector) {
-    std::vector<RowVectorPtr> vectors;
-    for (int i = 0; i < count; i++) {
-      auto data = makeSequenceRows(rowsPerVector);
-      VectorPtr c0 = vectorMaker_.flatVector<int64_t>(data);
-      vectors.push_back(makeRowVector({"c0"}, {c0}));
+  std::string getDuckDBQuery(
+      const std::map<std::string, std::vector<int64_t>>& rowGroupSizesForFiles,
+      const std::unordered_map<
+          std::string,
+          std::multimap<std::string, std::vector<int64_t>>>
+          deleteFilesForBaseDatafiles) {
+    int64_t totalNumRowsInAllBaseFiles = 0;
+    std::map<std::string, int64_t> baseFileSizes;
+    for (auto rowGroupSizesInFile : rowGroupSizesForFiles) {
+      // Sum up the row counts in all RowGroups in each base file
+      baseFileSizes[rowGroupSizesInFile.first] += std::accumulate(
+          rowGroupSizesInFile.second.begin(),
+          rowGroupSizesInFile.second.end(),
+          0);
+      totalNumRowsInAllBaseFiles += baseFileSizes[rowGroupSizesInFile.first];
     }
 
-    return vectors;
-  }
-
-  std::vector<std::shared_ptr<TempFilePath>> writeDataFile(
-      int32_t splitCount,
-      uint64_t numRows) {
-    auto dataVectors = makeVectors(splitCount, numRows);
-    std::vector<std::shared_ptr<TempFilePath>> dataFilePaths;
-    dataFilePaths.reserve(dataVectors.size());
-    for (auto i = 0; i < dataVectors.size(); i++) {
-      dataFilePaths.emplace_back(TempFilePath::create());
-      writeToFile(dataFilePaths.back()->getPath(), dataVectors[i]);
+    // Group the delete vectors by baseFileName
+    std::map<std::string, std::vector<std::vector<int64_t>>>
+        deletePosVectorsForAllBaseFiles;
+    for (auto deleteFile : deleteFilesForBaseDatafiles) {
+      auto deleteFileContent = deleteFile.second;
+      for (auto rowGroup : deleteFileContent) {
+        auto baseFileName = rowGroup.first;
+        deletePosVectorsForAllBaseFiles[baseFileName].push_back(
+            rowGroup.second);
+      }
     }
-    createDuckDbTable(dataVectors);
-    return dataFilePaths;
-  }
 
-  std::shared_ptr<TempFilePath> writePositionDeleteFile(
-      const std::string& dataFilePath,
-      const std::vector<int64_t>& deleteRows,
-      int64_t numRowsBefore = 0,
-      int64_t numRowsAfter = 0) {
-    // if containsMultipleDataFiles == true, we will write rows for other base
-    // files before and after the target base file
-    uint32_t numDeleteRows = numRowsBefore + deleteRows.size() + numRowsAfter;
+    // Flatten and deduplicate the delete position vectors in
+    // deletePosVectorsForAllBaseFiles from previous step, and count the total
+    // number of distinct delete positions for all base files
+    std::map<std::string, std::vector<int64_t>>
+        flattenedDeletePosVectorsForAllBaseFiles;
+    int64_t totalNumDeletePositions = 0;
+    for (auto deleteVectorsForBaseFile : deletePosVectorsForAllBaseFiles) {
+      auto baseFileName = deleteVectorsForBaseFile.first;
+      auto deletePositionVectors = deleteVectorsForBaseFile.second;
+      std::vector<int64_t> deletePositionVector =
+          flattenAndDedup(deletePositionVectors, baseFileSizes[baseFileName]);
+      flattenedDeletePosVectorsForAllBaseFiles[baseFileName] =
+          deletePositionVector;
+      totalNumDeletePositions += deletePositionVector.size();
+    }
 
-    std::string dataFilePathBefore = dataFilePath + "_before";
-    std::string dataFilePathAfter = dataFilePath + "_after";
+    // Now build the DuckDB queries
+    if (totalNumDeletePositions == 0) {
+      return "SELECT * FROM tmp";
+    } else if (totalNumDeletePositions >= totalNumRowsInAllBaseFiles) {
+      return "SELECT * FROM tmp WHERE 1 = 0";
+    } else {
+      // Convert the delete positions in all base files into column values
+      std::vector<int64_t> allDeleteValues;
 
-    auto filePathVector =
-        vectorMaker_.flatVector<StringView>(numDeleteRows, [&](auto row) {
-          if (row < numRowsBefore) {
-            return StringView(dataFilePathBefore);
-          } else if (
-              row >= numRowsBefore && row < deleteRows.size() + numRowsBefore) {
-            return StringView(dataFilePath);
-          } else if (
-              row >= deleteRows.size() + numRowsBefore && row < numDeleteRows) {
-            return StringView(dataFilePathAfter);
-          } else {
-            return StringView();
+      int64_t numRowsInPreviousBaseFiles = 0;
+      for (auto baseFileSize : baseFileSizes) {
+        auto deletePositions =
+            flattenedDeletePosVectorsForAllBaseFiles[baseFileSize.first];
+
+        if (numRowsInPreviousBaseFiles > 0) {
+          for (int64_t& deleteValue : deletePositions) {
+            deleteValue += numRowsInPreviousBaseFiles;
           }
-        });
+        }
 
-    std::vector<int64_t> deleteRowsVec;
-    deleteRowsVec.reserve(numDeleteRows);
+        allDeleteValues.insert(
+            allDeleteValues.end(),
+            deletePositions.begin(),
+            deletePositions.end());
 
-    if (numRowsBefore > 0) {
-      auto rowsBefore = makeSequenceRows(numRowsBefore);
-      deleteRowsVec.insert(
-          deleteRowsVec.end(), rowsBefore.begin(), rowsBefore.end());
+        numRowsInPreviousBaseFiles += baseFileSize.second;
+      }
+
+      return fmt::format(
+          "SELECT * FROM tmp WHERE c0 NOT IN ({})",
+          makeNotInList(allDeleteValues));
     }
-    deleteRowsVec.insert(
-        deleteRowsVec.end(), deleteRows.begin(), deleteRows.end());
-    if (numRowsAfter > 0) {
-      auto rowsAfter = makeSequenceRows(numRowsAfter);
-      deleteRowsVec.insert(
-          deleteRowsVec.end(), rowsAfter.begin(), rowsAfter.end());
-    }
-
-    auto deletePositionsVector =
-        vectorMaker_.flatVector<int64_t>(deleteRowsVec);
-    RowVectorPtr deleteFileVectors = makeRowVector(
-        {pathColumn_->name, posColumn_->name},
-        {filePathVector, deletePositionsVector});
-
-    auto deleteFilePath = TempFilePath::create();
-    writeToFile(deleteFilePath->getPath(), deleteFileVectors);
-
-    return deleteFilePath;
   }
 
-  std::string makeNotInList(
-      const std::vector<std::vector<int64_t>>& deleteRowsVec) {
-    std::vector<int64_t> deleteRows;
-    size_t totalSize = 0;
-    for (const auto& subVec : deleteRowsVec) {
-      totalSize += subVec.size();
-    }
-    deleteRows.reserve(totalSize);
-    for (const auto& subVec : deleteRowsVec) {
-      deleteRows.insert(deleteRows.end(), subVec.begin(), subVec.end());
+  std::vector<int64_t> flattenAndDedup(
+      const std::vector<std::vector<int64_t>>& deletePositionVectors,
+      int64_t baseFileSize) {
+    std::vector<int64_t> deletePositionVector;
+    for (auto vec : deletePositionVectors) {
+      for (auto pos : vec) {
+        if (pos >= 0 && pos < baseFileSize) {
+          deletePositionVector.push_back(pos);
+        }
+      }
     }
 
-    if (deleteRows.empty()) {
+    std::sort(deletePositionVector.begin(), deletePositionVector.end());
+    auto last =
+        std::unique(deletePositionVector.begin(), deletePositionVector.end());
+    deletePositionVector.erase(last, deletePositionVector.end());
+
+    return deletePositionVector;
+  }
+
+  std::string makeNotInList(const std::vector<int64_t>& deletePositionVector) {
+    if (deletePositionVector.empty()) {
       return "";
     }
 
     return std::accumulate(
-        deleteRows.begin() + 1,
-        deleteRows.end(),
-        std::to_string(deleteRows[0]),
+        deletePositionVector.begin() + 1,
+        deletePositionVector.end(),
+        std::to_string(deletePositionVector[0]),
         [](const std::string& a, int64_t b) {
           return a + ", " + std::to_string(b);
         });
@@ -280,6 +477,9 @@ class HiveIcebergTest : public HiveConnectorTestBase {
   }
 
   dwio::common::FileFormat fileFomat_{dwio::common::FileFormat::DWRF};
+  std::shared_ptr<dwrf::Config> config_;
+  std::function<std::unique_ptr<dwrf::DWRFFlushPolicy>()> flushPolicyFactory_;
+
   RowTypePtr rowType_{ROW({"c0"}, {BIGINT()})};
   std::shared_ptr<IcebergMetadataColumn> pathColumn_ =
       IcebergMetadataColumn::icebergDeleteFilePathColumn();
@@ -287,64 +487,93 @@ class HiveIcebergTest : public HiveConnectorTestBase {
       IcebergMetadataColumn::icebergDeletePosColumn();
 };
 
-TEST_F(HiveIcebergTest, positionalDeletesSingleBaseFile) {
+/// This test creates one single data file and one delete file. The parameter
+/// passed to assertSingleBaseFileSingleDeleteFile is the delete positions.
+TEST_F(HiveIcebergTest, singleBaseFileSinglePositionalDeleteFile) {
   folly::SingletonVault::singleton()->registrationComplete();
 
-  // Delete row 0, 1, 2, 3 from the first batch out of two.
-  assertPositionalDeletes({{0, 1, 2, 3}});
+  assertSingleBaseFileSingleDeleteFile({{0, 1, 2, 3}});
   // Delete the first and last row in each batch (10000 rows per batch)
-  assertPositionalDeletes({{0, 9999, 10000, 19999}});
+  assertSingleBaseFileSingleDeleteFile({{0, 9999, 10000, 19999}});
   // Delete several rows in the second batch (10000 rows per batch)
-  assertPositionalDeletes({{10000, 10002, 19999}});
+  assertSingleBaseFileSingleDeleteFile({{10000, 10002, 19999}});
   // Delete random rows
-  assertPositionalDeletes({makeRandomDeleteRows(rowCount)});
+  assertSingleBaseFileSingleDeleteFile({makeRandomIncreasingValues(0, 20000)});
   // Delete 0 rows
-  assertPositionalDeletes({}, "SELECT * FROM tmp", false);
+  assertSingleBaseFileSingleDeleteFile({});
   // Delete all rows
-  assertPositionalDeletes(
-      {makeSequenceRows(rowCount)}, "SELECT * FROM tmp WHERE 1 = 0", false);
+  assertSingleBaseFileSingleDeleteFile(
+      {makeContinuousIncreasingValues(0, 20000)});
   // Delete rows that don't exist
-  assertPositionalDeletes({{20000, 29999}});
+  assertSingleBaseFileSingleDeleteFile({{20000, 29999}});
 }
 
-// The positional delete file contains rows from multiple base files
-TEST_F(HiveIcebergTest, positionalDeletesMultipleBaseFiles) {
+/// This test creates 3 base data files, only the middle one has corresponding
+/// delete positions. The parameter passed to
+/// assertSingleBaseFileSingleDeleteFile is the delete positions.for the middle
+/// base file.
+TEST_F(HiveIcebergTest, MultipleBaseFilesSinglePositionalDeleteFile) {
   folly::SingletonVault::singleton()->registrationComplete();
 
-  // Delete row 0, 1, 2, 3 from the first batch out of two.
-  assertPositionalDeletes({{0, 1, 2, 3}}, true);
-  // Delete the first and last row in each batch (10000 rows per batch)
-  assertPositionalDeletes({{0, 9999, 10000, 19999}}, true);
-  // Delete several rows in the second batch (10000 rows per batch)
-  assertPositionalDeletes({{10000, 10002, 19999}}, true);
-  // Delete random rows
-  assertPositionalDeletes({makeRandomDeleteRows(rowCount)}, true);
-  // Delete 0 rows
-  assertPositionalDeletes({}, "SELECT * FROM tmp", true);
-  // Delete all rows
-  assertPositionalDeletes(
-      {makeSequenceRows(rowCount)}, "SELECT * FROM tmp WHERE 1 = 0", true);
-  // Delete rows that don't exist
-  assertPositionalDeletes({{20000, 29999}}, true);
+  assertMultipleBaseFileSingleDeleteFile({0, 1, 2, 3});
+  assertMultipleBaseFileSingleDeleteFile({0, 9999, 10000, 19999});
+  assertMultipleBaseFileSingleDeleteFile({10000, 10002, 19999});
+  assertMultipleBaseFileSingleDeleteFile({10000, 10002, 19999});
+  assertMultipleBaseFileSingleDeleteFile(
+      makeRandomIncreasingValues(0, rowCount));
+  assertMultipleBaseFileSingleDeleteFile({});
+  assertMultipleBaseFileSingleDeleteFile(
+      makeContinuousIncreasingValues(0, rowCount));
 }
 
-// The base file has multiple delete files.
-TEST_F(HiveIcebergTest, baseFileMultiplePositionalDeletes) {
+/// This test creates one base data file/split with multiple delete files. The
+/// parameter passed to assertSingleBaseFileMultipleDeleteFiles is the vector of
+/// delete files. Each leaf vector represents the delete positions in that
+/// delete file.
+TEST_F(HiveIcebergTest, singleBaseFileMultiplePositionalDeleteFiles) {
   folly::SingletonVault::singleton()->registrationComplete();
 
   // Delete row 0, 1, 2, 3 from the first batch out of two.
-  assertPositionalDeletes({{1}, {2}, {3}, {4}});
+  assertSingleBaseFileMultipleDeleteFiles({{1}, {2}, {3}, {4}});
   // Delete the first and last row in each batch (10000 rows per batch).
-  assertPositionalDeletes({{0}, {9999}, {10000}, {19999}});
+  assertSingleBaseFileMultipleDeleteFiles({{0}, {9999}, {10000}, {19999}});
+
+  assertSingleBaseFileMultipleDeleteFiles(
+      {makeRandomIncreasingValues(0, 10000),
+       makeRandomIncreasingValues(10000, 20000),
+       makeRandomIncreasingValues(5000, 15000)});
+
+  assertSingleBaseFileMultipleDeleteFiles(
+      {makeContinuousIncreasingValues(0, 10000),
+       makeContinuousIncreasingValues(10000, 20000)});
+
+  assertSingleBaseFileMultipleDeleteFiles(
+      {makeContinuousIncreasingValues(0, 10000),
+       makeContinuousIncreasingValues(10000, 20000),
+       makeRandomIncreasingValues(5000, 15000)});
+
+  assertSingleBaseFileMultipleDeleteFiles(
+      {makeContinuousIncreasingValues(0, 20000),
+       makeContinuousIncreasingValues(0, 20000)});
+
+  assertSingleBaseFileMultipleDeleteFiles(
+      {makeRandomIncreasingValues(0, 20000),
+       {},
+       makeRandomIncreasingValues(5000, 15000)});
+
+  assertSingleBaseFileMultipleDeleteFiles({{}, {}});
 }
 
 TEST_F(HiveIcebergTest, positionalDeletesMultipleSplits) {
   folly::SingletonVault::singleton()->registrationComplete();
-  constexpr int32_t splitCount = 50;
-  constexpr int32_t numPrefetchSplits = 10;
-  std::vector<std::vector<int64_t>> deletedRows = {{1}, {2}, {3, 4}};
-  assertPositionalDeletes(
-      deletedRows, getQuery(deletedRows), splitCount, numPrefetchSplits);
+
+  assertMultipleSplits({1, 2, 3, 4}, 10, 5);
+  assertMultipleSplits({1, 2, 3, 4}, 10, 0);
+  assertMultipleSplits({1, 2, 3, 4}, 10, 10);
+  assertMultipleSplits({0, 9999, 10000, 19999}, 10, 3);
+  assertMultipleSplits(makeRandomIncreasingValues(0, 20000), 10, 3);
+  assertMultipleSplits(makeContinuousIncreasingValues(0, 20000), 10, 3);
+  assertMultipleSplits({}, 10, 3);
 }
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -20,6 +20,7 @@
 #include "velox/connectors/hive/HiveDataSink.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/dwio/dwrf/common/Config.h"
+#include "velox/dwio/dwrf/writer/FlushPolicy.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/TempFilePath.h"
@@ -47,13 +48,17 @@ class HiveConnectorTestBase : public OperatorTestBase {
       const std::string& filePath,
       const std::vector<RowVectorPtr>& vectors,
       std::shared_ptr<dwrf::Config> config =
-          std::make_shared<facebook::velox::dwrf::Config>());
+          std::make_shared<facebook::velox::dwrf::Config>(),
+      const std::function<std::unique_ptr<dwrf::DWRFFlushPolicy>()>&
+          flushPolicyFactory = nullptr);
 
   void writeToFile(
       const std::string& filePath,
       const std::vector<RowVectorPtr>& vectors,
       std::shared_ptr<dwrf::Config> config,
-      const TypePtr& schema);
+      const TypePtr& schema,
+      const std::function<std::unique_ptr<dwrf::DWRFFlushPolicy>()>&
+          flushPolicyFactory = nullptr);
 
   std::vector<RowVectorPtr> makeVectors(
       const RowTypePtr& rowType,


### PR DESCRIPTION
This PR contains two fixes:
1. 
Fixes https://github.com/facebookincubator/velox/issues/9856
When the base data file and positional delete files contains multiple
unaligned RowGroups, some of the bits at the end of
IcebergSplitReader::deleteBitmap_ could be mistakenly skipped, causing
wrong result. This commit fixes it by introducing an offset into this
deleteBitmap_ and shift the unused bits to the beginning for each batch.

2.
When a base file batch doesn't have matching delete positions, the delete 
bitmap size was set incorrectly. For such a batch, the delete bitmap size should
be set as 0.