### PR TITLE
Add arbitration/grow message to memory pool oom

### DIFF
--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -852,13 +852,15 @@ bool MemoryPoolImpl::incrementReservationThreadSafe(
     return true;
   }
   VELOX_MEM_POOL_CAP_EXCEEDED(fmt::format(
-      "Exceeded memory pool cap of {} with max {} when requesting {}, memory "
-      "manager cap is {}, requestor '{}' with current usage {}\n{}",
+      "Exceeded memory pool capacity after attempt to grow capacity "
+      "through arbitration. Requestor pool name '{}', request size {}, memory "
+      "pool capacity {}, memory pool max capacity {}, memory manager capacity "
+      "{}, current usage {}\n{}",
+      requestor->name(),
+      succinctBytes(size),
       capacityToString(capacity()),
       capacityToString(maxCapacity_),
-      succinctBytes(size),
       capacityToString(manager_->capacity()),
-      requestor->name(),
       succinctBytes(requestor->usedBytes()),
       treeMemoryUsage()));
 }

--- a/velox/common/memory/tests/MemoryArbitratorTest.cpp
+++ b/velox/common/memory/tests/MemoryArbitratorTest.cpp
@@ -148,7 +148,9 @@ TEST_F(MemoryArbitrationTest, queryMemoryCapacity) {
     void* buffer;
     VELOX_ASSERT_THROW(
         buffer = leafPool->allocate(7L << 20),
-        "Exceeded memory pool cap of 4.00MB");
+        "Exceeded memory pool capacity after attempt to grow capacity through "
+        "arbitration. Requestor pool name 'leaf-1.0', request size 7.00MB, "
+        "memory pool capacity 4.00MB, memory pool max capacity 8.00MB");
     ASSERT_NO_THROW(buffer = leafPool->allocate(4L << 20));
     ASSERT_EQ(manager.arbitrator()->shrinkCapacity(rootPool.get(), 0), 0);
     ASSERT_EQ(manager.arbitrator()->shrinkCapacity(leafPool.get(), 0), 0);

--- a/velox/common/memory/tests/MemoryCapExceededTest.cpp
+++ b/velox/common/memory/tests/MemoryCapExceededTest.cpp
@@ -68,9 +68,10 @@ TEST_P(MemoryCapExceededTest, singleDriver) {
   // We look for these lines separately, since their order can change (not sure
   // why).
   std::vector<std::string> expectedTexts = {
-      "Exceeded memory pool cap of 5.00MB with max 5.00MB when requesting "
-      "2.00MB, memory manager cap is 8.00GB, requestor "
-      "'op.2.0.0.Aggregation' with current usage 3.70MB"};
+      "Exceeded memory pool capacity after attempt to grow capacity through "
+      "arbitration. Requestor pool name 'op.2.0.0.Aggregation', request size "
+      "2.00MB, memory pool capacity 5.00MB, memory pool max capacity 5.00MB, "
+      "memory manager capacity 8.00GB, current usage 3.70MB"};
   std::vector<std::string> expectedDetailedTexts = {
       "node.1 usage 12.00KB reserved 1.00MB peak 1.00MB",
       "op.1.0.0.FilterProject usage 12.00KB reserved 1.00MB peak 12.00KB",

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -718,10 +718,11 @@ TEST_P(MemoryPoolTest, memoryCapExceptions) {
         ASSERT_EQ(error_code::kMemCapExceeded.c_str(), ex.errorCode());
         ASSERT_TRUE(ex.isRetriable());
         ASSERT_EQ(
-            "Exceeded memory pool cap of 128.00MB with max 128.00MB when "
-            "requesting 136.00MB, memory manager cap is 128.00MB, requestor "
-            "'static_quota' with current usage 0B\nMemoryCapExceptions usage "
-            "0B reserved 0B peak 0B\n",
+            "Exceeded memory pool capacity after attempt to grow capacity "
+            "through arbitration. Requestor pool name 'static_quota', request "
+            "size 136.00MB, memory pool capacity 128.00MB, memory pool max "
+            "capacity 128.00MB, memory manager capacity 128.00MB, current "
+            "usage 0B\nMemoryCapExceptions usage 0B reserved 0B peak 0B\n",
             ex.message());
       }
     }

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -2021,7 +2021,7 @@ TEST_F(MockSharedArbitrationTest, ensureMemoryPoolMaxCapacity) {
     } else {
       VELOX_ASSERT_THROW(
           requestorOp->allocate(testData.requestBytes),
-          "Exceeded memory pool cap of");
+          "Exceeded memory pool capacity");
     }
     if (testData.expectedReclaimFromOther) {
       ASSERT_GT(otherOp->reclaimer()->stats().numReclaims, 0);
@@ -2052,7 +2052,9 @@ TEST_F(MockSharedArbitrationTest, ensureNodeMaxCapacity) {
 
     std::string debugString() const {
       return fmt::format(
-          "nodeCapacity {} poolMaxCapacity {} isReclaimable {} allocatedBytes {} requestBytes {} expectedSuccess {} expectedReclaimedBytes {}",
+          "nodeCapacity {} poolMaxCapacity {} isReclaimable {} "
+          "allocatedBytes {} requestBytes {} expectedSuccess {} "
+          "expectedReclaimedBytes {}",
           succinctBytes(nodeCapacity),
           succinctBytes(poolMaxCapacity),
           isReclaimable,


### PR DESCRIPTION
Current error message is confusing as people may wonder why max cap being much larger than current cap and the query still oom. Put the message more explicit that it is even after grow attempt we still cannot acquire enough capacity to fulfill the request.