### PR TITLE
Add support for "week of month" in date parsing pattern

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -1443,7 +1443,11 @@ Expected<DateTimeResult> DateTimeFormatter::parse(
         date.year, date.dayOfYear, daysSinceEpoch);
   } else if (date.weekOfMonthDateFormat) {
     status = util::daysSinceEpochFromWeekOfMonthDate(
-        date.year, date.month, date.weekOfMonth, date.dayOfWeek, daysSinceEpoch);
+        date.year,
+        date.month,
+        date.weekOfMonth,
+        date.dayOfWeek,
+        daysSinceEpoch);
   } else {
     status = util::daysSinceEpochFromDate(
         date.year, date.month, date.day, daysSinceEpoch);

--- a/velox/functions/lib/DateTimeFormatter.h
+++ b/velox/functions/lib/DateTimeFormatter.h
@@ -100,7 +100,10 @@ enum class DateTimeFormatSpecifier : uint8_t {
   TIMEZONE_OFFSET_ID = 22,
 
   // A literal % character
-  LITERAL_PERCENT = 23
+  LITERAL_PERCENT = 23,
+
+  // Week of month, e.g: 2
+  WEEK_OF_MONTH = 24
 };
 
 struct FormatPattern {

--- a/velox/functions/lib/DateTimeFormatterBuilder.cpp
+++ b/velox/functions/lib/DateTimeFormatterBuilder.cpp
@@ -56,6 +56,13 @@ DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendWeekOfWeekYear(
   return *this;
 }
 
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendWeekOfMonth(
+    size_t minDigits) {
+  tokens_.emplace_back(
+      FormatPattern{DateTimeFormatSpecifier::WEEK_OF_MONTH, minDigits});
+  return *this;
+}
+
 DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendDayOfWeek0Based(
     size_t minDigits) {
   tokens_.emplace_back(

--- a/velox/functions/lib/DateTimeFormatterBuilder.h
+++ b/velox/functions/lib/DateTimeFormatterBuilder.h
@@ -88,6 +88,16 @@ class DateTimeFormatterBuilder {
   /// will be 001
   DateTimeFormatterBuilder& appendWeekOfWeekYear(size_t minDigits);
 
+  /// Appends week of month to formatter builder, e.g: 2
+  ///
+  /// \param minDigits describes the minimum number of digits this format is
+  /// required to represent week of month. The format by default is going
+  /// use as few digits as possible greater than or equal to minDigits to
+  /// represent week of month. e.g. 1999-01-01, with min digit being 1 the
+  /// formatted result will be 1, with min digit being 4 the formatted result
+  /// will be 0001
+  DateTimeFormatterBuilder& appendWeekOfMonth(size_t minDigits);
+
   /// Appends day of week to formatter builder. The number is 0 based with 0 ~ 6
   /// representing Sunday to Saturday respectively
   ///

--- a/velox/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/velox/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -2304,4 +2304,35 @@ TEST_F(MysqlDateTimeTest, parseConsecutiveSpecifiers) {
   EXPECT_THROW(parseMysql("1212", "%Y%H"), VeloxUserError);
 }
 
+class WeekOfMonthPatternTest : public DateTimeFormatterTest {};
+
+TEST_F(WeekOfMonthPatternTest, parseWeekOfMonth) {
+  DateTimeFormatterBuilder builder1(1);
+  builder1.appendWeekOfMonth(1);
+  std::shared_ptr<DateTimeFormatter> formatter1 =
+      builder1.setType(DateTimeFormatterType::JODA).build();
+  EXPECT_EQ(
+      fromTimestampString("1969-12-29 00:00:00"),
+      formatter1->parse("1")->timestamp);
+  EXPECT_EQ(
+      fromTimestampString("1970-01-12 00:00:00"),
+      formatter1->parse("3")->timestamp);
+
+  DateTimeFormatterBuilder builder2(11);
+  builder2.appendYear(4);
+  builder2.appendLiteral(" ");
+  builder2.appendMonthOfYear(2);
+  builder2.appendLiteral(" ");
+  builder2.appendWeekOfMonth(1);
+  builder2.appendLiteral(" ");
+  builder2.appendDayOfWeek1Based(1);
+  std::shared_ptr<DateTimeFormatter> formatter2 =
+      builder2.setType(DateTimeFormatterType::JODA).build();
+  EXPECT_EQ(
+      fromTimestampString("1999-11-29 00:00:00"),
+      formatter2->parse("1999 12 1 1")->timestamp);
+  EXPECT_EQ(
+      fromTimestampString("1999-12-14 00:00:00"),
+      formatter2->parse("1999 12 3 2")->timestamp);
+}
 } // namespace facebook::velox::functions

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -144,7 +144,11 @@ bool isValidWeekDate(int32_t weekYear, int32_t weekOfYear, int32_t dayOfWeek) {
   return true;
 }
 
-bool isValidWeekOfMonthDate(int32_t year, int32_t month, int32_t weekOfMonth, int32_t dayOfWeek) {
+bool isValidWeekOfMonthDate(
+    int32_t year,
+    int32_t month,
+    int32_t weekOfMonth,
+    int32_t dayOfWeek) {
   if (dayOfWeek < 1 || dayOfWeek > 7) {
     return false;
   }
@@ -625,7 +629,7 @@ Status daysSinceEpochFromWeekOfMonthDate(
   int32_t firstDayOfWeek =
       extractISODayOfTheWeek(daysSinceEpochOfFirstDayOfMonth);
   out = daysSinceEpochOfFirstDayOfMonth - (firstDayOfWeek - 1) +
-        7 * (weekOfMonth - 1) + dayOfWeek - 1;
+      7 * (weekOfMonth - 1) + dayOfWeek - 1;
   return Status::OK();
 }
 

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -144,6 +144,22 @@ bool isValidWeekDate(int32_t weekYear, int32_t weekOfYear, int32_t dayOfWeek) {
   return true;
 }
 
+bool isValidWeekOfMonthDate(int32_t year, int32_t month, int32_t weekOfMonth, int32_t dayOfWeek) {
+  if (dayOfWeek < 1 || dayOfWeek > 7) {
+    return false;
+  }
+  if (weekOfMonth < 1 || weekOfMonth > 5) {
+    return false;
+  }
+  if (month < 1 || month > 12) {
+    return false;
+  }
+  if (year < kMinYear || year > kMaxYear) {
+    return false;
+  }
+  return true;
+}
+
 inline bool validDate(int64_t daysSinceEpoch) {
   return daysSinceEpoch >= std::numeric_limits<int32_t>::min() &&
       daysSinceEpoch <= std::numeric_limits<int32_t>::max();
@@ -590,6 +606,26 @@ Status daysSinceEpochFromWeekDate(
 
   out = daysSinceEpochOfJanFourth - (firstDayOfWeekYear - 1) +
       7 * (weekOfYear - 1) + dayOfWeek - 1;
+  return Status::OK();
+}
+
+Status daysSinceEpochFromWeekOfMonthDate(
+    int32_t year,
+    int32_t month,
+    int32_t weekOfMonth,
+    int32_t dayOfWeek,
+    int64_t& out) {
+  if (!isValidWeekOfMonthDate(year, month, weekOfMonth, dayOfWeek)) {
+    return Status::UserError(
+        "Date out of range: {}-{}-{}-{}", year, month, weekOfMonth, dayOfWeek);
+  }
+  int64_t daysSinceEpochOfFirstDayOfMonth;
+  VELOX_RETURN_NOT_OK(
+      daysSinceEpochFromDate(year, month, 1, daysSinceEpochOfFirstDayOfMonth));
+  int32_t firstDayOfWeek =
+      extractISODayOfTheWeek(daysSinceEpochOfFirstDayOfMonth);
+  out = daysSinceEpochOfFirstDayOfMonth - (firstDayOfWeek - 1) +
+        7 * (weekOfMonth - 1) + dayOfWeek - 1;
   return Status::OK();
 }
 

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -109,6 +109,15 @@ Status daysSinceEpochFromWeekDate(
 
 /// Computes the (signed) number of days since unix epoch (1970-01-01).
 /// Returns UserError status if the date is invalid.
+Status daysSinceEpochFromWeekOfMonthDate(
+    int32_t year,
+    int32_t month,
+    int32_t weekOfMonth,
+    int32_t dayOfWeek,
+    int64_t& out);
+
+/// Computes the (signed) number of days since unix epoch (1970-01-01).
+/// Returns UserError status if the date is invalid.
 Status
 daysSinceEpochFromDayOfYear(int32_t year, int32_t dayOfYear, int64_t& out);
 

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -104,6 +104,35 @@ TEST(DateTimeUtilTest, fromDateInvalid) {
       1970, 6, 31, "Date out of range: 1970-6-31"));
 }
 
+TEST(DateTimeUtilTest, fromWeekOfMonthDate) {
+  auto testDaysSinceEpochFromWeekOfMonthDate =
+      [](int32_t year, int32_t month, int32_t weekOfMonth, int32_t dayOfWeek) {
+        int64_t daysSinceEpoch;
+        auto status = util::daysSinceEpochFromWeekOfMonthDate(
+            year, month, weekOfMonth, dayOfWeek, daysSinceEpoch);
+        EXPECT_TRUE(status.ok());
+        return daysSinceEpoch;
+      };
+  EXPECT_EQ(4, testDaysSinceEpochFromWeekOfMonthDate(1970, 1, 2, 1));
+  EXPECT_EQ(361, testDaysSinceEpochFromWeekOfMonthDate(1971, 1, 1, 1));
+  EXPECT_EQ(396, testDaysSinceEpochFromWeekOfMonthDate(1971, 2, 1, 1));
+
+  EXPECT_EQ(10952, testDaysSinceEpochFromWeekOfMonthDate(2000, 1, 1, 1));
+  EXPECT_EQ(19905, testDaysSinceEpochFromWeekOfMonthDate(2024, 7, 1, 1));
+
+  // Before unix epoch.
+  EXPECT_EQ(-3, testDaysSinceEpochFromWeekOfMonthDate(1970, 1, 1, 1));
+  EXPECT_EQ(-2, testDaysSinceEpochFromWeekOfMonthDate(1970, 1, 1, 2));
+  EXPECT_EQ(-31, testDaysSinceEpochFromWeekOfMonthDate(1969, 12, 1, 1));
+  EXPECT_EQ(-367, testDaysSinceEpochFromWeekOfMonthDate(1969, 1, 1, 1));
+  EXPECT_EQ(-724, testDaysSinceEpochFromWeekOfMonthDate(1968, 1, 2, 1));
+  EXPECT_EQ(-719533, testDaysSinceEpochFromWeekOfMonthDate(0, 1, 1, 1));
+
+  // Negative year - BC.
+  EXPECT_EQ(-719561, testDaysSinceEpochFromWeekOfMonthDate(-1, 12, 1, 1));
+  EXPECT_EQ(-719897, testDaysSinceEpochFromWeekOfMonthDate(-1, 1, 1, 1));
+}
+
 TEST(DateTimeUtilTest, fromDateString) {
   for (ParseMode mode : {ParseMode::kPrestoCast, ParseMode::kSparkCast}) {
     EXPECT_EQ(0, parseDate("1970-01-01", mode));


### PR DESCRIPTION
In date parsing pattern, "week of month" is used by `java.text.SimpleDateFormat`. So we need to support it for supporting SimpleDateFormat date parsing mode in DateTimeFormatter.  It's presented by number and the range is [1,5].

relates issue:#6374