### PR TITLE
Fix memory leak in HashBuild operator

### DIFF
--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -661,14 +661,14 @@ bool HashBuild::finishHashBuild() {
 
   TestValue::adjust("facebook::velox::exec::HashBuild::finishHashBuild", this);
 
-  auto promisesGuard = folly::makeGuard([&]() {
+  SCOPE_EXIT {
     // Realize the promises so that the other Drivers (which were not
     // the last to finish) can continue from the barrier and finish.
     peers.clear();
     for (auto& promise : promises) {
       promise.setValue();
     }
-  });
+  };
 
   if (joinHasNullKeys_ && isAntiJoin(joinType_) && nullAware_ &&
       !joinNode_->filter()) {
@@ -728,6 +728,21 @@ bool HashBuild::finishHashBuild() {
     ensureNextRowVectorFits(numRows, otherBuilds);
   }
 
+  SCOPE_EXIT {
+    // Make a guard to release the unused memory reservation since we have
+    // finished the merged table build. The guard makes sure we release the
+    // memory reserved for other operators even when exceptions are thrown to
+    // prevent memory leak. We cannot rely on other operator's cleanup mechanism
+    // because when exceptions are thrown, other operator's cleanup mechanism
+    // might already have finished.
+    pool()->release();
+    if (allowDuplicateRows) {
+      for (auto* build : otherBuilds) {
+        build->pool()->release();
+      }
+    }
+  };
+
   if (spiller_ != nullptr) {
     spiller_->finishSpill(spillPartitions);
     removeEmptyPartitions(spillPartitions);
@@ -766,15 +781,6 @@ bool HashBuild::finishHashBuild() {
       std::move(table_), std::move(spillPartitions), joinHasNullKeys_);
   if (spillEnabled()) {
     stateCleared_ = true;
-  }
-
-  // Release the unused memory reservation since we have finished the merged
-  // table build.
-  pool()->release();
-  if (allowDuplicateRows) {
-    for (auto* build : otherBuilds) {
-      build->pool()->release();
-    }
   }
   return true;
 }


### PR DESCRIPTION
Following sequence may cause memory leak:
1. T1 last hash build operator tries to collect and build hash table in finishHashBuild().
2. T2 some other driver's operator of the same task triggered exception, terminates the task.
3. T2 driver's operator cleanup mechanism runs, released any reserved memory.
4. T1 continues to reserve memory for itself as well as all its peer operators.
5. T1 encountered some exception while building join table, and throws.
6. T1's hash build operator cleanup mechanism is triggered.

Note that the reservation made by T1 for T2's hash build operator in step 4 will never be released, causing a memory leak.

The PR resolves the situation by adding a guard on that particular location to release any reserved memory. 