### PR TITLE
Fix str_to_map udf according to the meaning of spark and add test samples

### DIFF
--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -241,15 +241,18 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 
     Returns a map by splitting ``string`` into entries with ``entryDelimiter`` and splitting
     each entry into key/value with ``keyValueDelimiter``.
-    ``entryDelimiter`` and ``keyValueDelimiter`` must be constant strings with single ascii
-    character. Allows ``keyValueDelimiter`` not found when splitting an entry. Throws exception
-    when duplicate map keys are found for single row's result, consistent with Spark's default
-    behavior. ::
+    The entryDelimiter and keyValueDelimiter can be multiple characters, 
+    can also be regular expressions, and support Unicode encoded strings.
+    Allows ``keyValueDelimiter`` not found when splitting an entry. 
+    Throws exception when duplicate map keys are found for single row's result, consistent 
+    with Spark's default behavior. ::
 
         SELECT str_to_map('a:1,b:2,c:3', ',', ':'); -- {"a":"1","b":"2","c":"3"}
         SELECT str_to_map('a', ',', ':'); -- {"a":NULL}
         SELECT str_to_map('', ',', ':'); -- {"":NULL}
         SELECT str_to_map('a:1,b:2,c:3', ',', ','); -- {"a:1":NULL,"b:2":NULL,"c:3":NULL}
+        SELECT str_to_map({'a✈✈1☺☺b✈✈2☺☺c✈✈3', '☺☺', '✈✈'}); -- {"a":"1","b":"2","c":"3"}
+        SELECT str_to_map({'a443d121b344e221c344f', '[12]+', '[34]+''}); -- {"a":"d","b":"e","c":"f"}
 
 .. spark:function:: substring(string, start) -> varchar
 

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -215,7 +215,6 @@ void registerFunctions(const std::string& prefix) {
       Varchar,
       Varchar,
       Varchar>({prefix + "str_to_map"});
-
   registerFunction<
       sparksql::StringToMapFunction,
       Map<Varchar, Varchar>,

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -215,15 +215,6 @@ void registerFunctions(const std::string& prefix) {
       Varchar,
       Varchar,
       Varchar>({prefix + "str_to_map"});
-  registerFunction<
-      sparksql::StringToMapFunction,
-      Map<Varchar, Varchar>,
-      Varchar,
-      Varchar>({prefix + "str_to_map"});
-  registerFunction<
-      sparksql::StringToMapFunction,
-      Map<Varchar, Varchar>,
-      Varchar>({prefix + "str_to_map"});
 
   registerFunction<sparksql::LeftFunction, Varchar, Varchar, int32_t>(
       {prefix + "left"});

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -216,6 +216,16 @@ void registerFunctions(const std::string& prefix) {
       Varchar,
       Varchar>({prefix + "str_to_map"});
 
+  registerFunction<
+      sparksql::StringToMapFunction,
+      Map<Varchar, Varchar>,
+      Varchar,
+      Varchar>({prefix + "str_to_map"});
+  registerFunction<
+      sparksql::StringToMapFunction,
+      Map<Varchar, Varchar>,
+      Varchar>({prefix + "str_to_map"});
+
   registerFunction<sparksql::LeftFunction, Varchar, Varchar, int32_t>(
       {prefix + "left"});
 

--- a/velox/functions/sparksql/StringToMap.h
+++ b/velox/functions/sparksql/StringToMap.h
@@ -23,30 +23,32 @@ namespace facebook::velox::functions::sparksql {
 template <typename T>
 struct StringToMapFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
+
   // Results refer to strings in the first argument.
   static constexpr int32_t reuse_strings_from_arg = 0;
+
   void call(
       out_type<Map<Varchar, Varchar>>& out,
       const arg_type<Varchar>& input,
       const arg_type<Varchar>& entryDelimiter,
       const arg_type<Varchar>& keyValueDelimiter) {
     VELOX_USER_CHECK_GE(
-        entryDelimiter.size(), 1, "entryDelimiter's size should >= 1.");
+        entryDelimiter.size(), 1, "The entry delimiter should not be empty.");
     VELOX_USER_CHECK_GE(
-        keyValueDelimiter.size(), 1, "keyValueDelimiter's size should >= 1.");
+        keyValueDelimiter.size(),
+        1,
+        "The keyValue delimiter should not be empty.");
     callImpl(out, input, entryDelimiter, keyValueDelimiter);
   }
 
  private:
-  /**
-   * @brief Retrieve the index of the pattern string
-   *
-   * This function retrieves all subscripts in the target string that match the
-   * start and end of the pattern
-   *
-   * @param targetStr The target string to search for
-   * @param pattern Search pattern.
-   */
+  /// @brief Retrieve the index of the pattern string
+  ///
+  /// This function retrieves all subscripts in the target string that match the
+  /// start and end of the pattern
+  ///
+  /// @param targetStr The target string to search for
+  /// @param pattern Search pattern.
   std::vector<std::pair<int, int>> findPatternIndex(
       const StringView& targetStr,
       const StringView& pattern) {
@@ -65,17 +67,16 @@ struct StringToMapFunction {
     }
     return result;
   }
-  /**
-   * @brief Separate the target string based on the delimiter
-   *
-   * This function will separate the target string based on a delimiter and
-   * return an array of separated strings
-   *
-   * @param targetStr The target string to be separated
-   * @param delimeter Delimiter
-   * @param onlyOne When encountering the first delimiter, simply separate the
-   * string into two longer parts
-   */
+
+  /// @brief Separate the target string based on the delimiter
+  ///
+  /// This function will separate the target string based on a delimiter and
+  /// return an array of separated strings
+  ///
+  /// @param targetStr The target string to be separated
+  /// @param delimeter Delimiter
+  /// @param onlyOne When encountering the first delimiter, simply separate the
+  /// string into two longer parts
   std::vector<StringView> split(
       const StringView& targetStr,
       const StringView& delimeter,

--- a/velox/functions/sparksql/StringToMap.h
+++ b/velox/functions/sparksql/StringToMap.h
@@ -23,80 +23,105 @@ namespace facebook::velox::functions::sparksql {
 template <typename T>
 struct StringToMapFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
+  static StringView entryDelimiter_;
+  static StringView keyValueDelimiter_;
 
   // Results refer to strings in the first argument.
   static constexpr int32_t reuse_strings_from_arg = 0;
-
+  // One parameter
+  void call(
+      out_type<Map<Varchar, Varchar>>& out,
+      const arg_type<Varchar>& input) {
+    callImpl(out, input, entryDelimiter_, keyValueDelimiter_);
+  }
+  // Two parameters
+  void call(
+      out_type<Map<Varchar, Varchar>>& out,
+      const arg_type<Varchar>& input,
+      const arg_type<Varchar>& entryDelimiter) {
+    VELOX_USER_CHECK(
+        entryDelimiter.size() >= 1, "entryDelimiter's size should >= 1.");
+    callImpl(out, input, entryDelimiter, keyValueDelimiter_);
+  }
+  // Three parameters
   void call(
       out_type<Map<Varchar, Varchar>>& out,
       const arg_type<Varchar>& input,
       const arg_type<Varchar>& entryDelimiter,
       const arg_type<Varchar>& keyValueDelimiter) {
-    VELOX_USER_CHECK_EQ(
-        entryDelimiter.size(), 1, "entryDelimiter's size should be 1.");
-    VELOX_USER_CHECK_EQ(
-        keyValueDelimiter.size(), 1, "keyValueDelimiter's size should be 1.");
-
-    callImpl(
-        out,
-        toStringView(input),
-        toStringView(entryDelimiter),
-        toStringView(keyValueDelimiter));
+    VELOX_USER_CHECK(
+        entryDelimiter.size() >= 1, "entryDelimiter's size should >= 1.");
+    VELOX_USER_CHECK(
+        keyValueDelimiter.size() >= 1, "keyValueDelimiter's size should >= 1.");
+    callImpl(out, input, entryDelimiter, keyValueDelimiter);
   }
 
  private:
-  static std::string_view toStringView(const arg_type<Varchar>& input) {
-    return std::string_view(input.data(), input.size());
+  std::vector<std::pair<int, int>> strStrRex(
+      const StringView& allStr,
+      const StringView& s) {
+    std::vector<std::pair<int, int>> result;
+    boost::regex re(s.str());
+    boost::smatch match;
+    auto inputs = allStr.str();
+    std::string::const_iterator search_start = inputs.begin();
+    while (boost::regex_search(search_start, inputs.cend(), match, re)) {
+      result.push_back(
+          {match[0].first - inputs.begin(), match[0].second - inputs.begin()});
+      search_start = match[0].second;
+    }
+    return result;
+  }
+  std::vector<StringView> splitMult(
+      const StringView& target,
+      const StringView& delimeter,
+      bool onlyOne = false) {
+    std::vector<StringView> result;
+    auto allIndex = strStrRex(target, delimeter);
+    int begin = 0;
+    for (int i = 0; i < allIndex.size(); ++i) {
+      result.push_back(
+          StringView(target.data() + begin, allIndex[i].first - begin));
+      begin = allIndex[i].second;
+      if (onlyOne) {
+        break;
+      }
+    }
+    if (begin <= target.size()) {
+      result.push_back(
+          StringView(target.data() + begin, target.size() - begin));
+    }
+    return result;
   }
 
   void callImpl(
       out_type<Map<Varchar, Varchar>>& out,
-      std::string_view input,
-      std::string_view entryDelimiter,
-      std::string_view keyValueDelimiter) const {
-    size_t pos = 0;
+      const StringView& input,
+      const StringView& entryDelimiter,
+      const StringView& keyValueDelimiter) {
     folly::F14FastSet<std::string_view> keys;
+    auto entryItems = splitMult(input, entryDelimiter);
+    for (const auto& entryItem : entryItems) {
+      auto kvItems = splitMult(entryItem, keyValueDelimiter, true);
+      VELOX_USER_CHECK(
+          keys.insert(kvItems[0]).second,
+          "Duplicate keys are not allowed: '{}'.",
+          kvItems[0]);
 
-    auto nextEntryPos = input.find(entryDelimiter, pos);
-    while (nextEntryPos != std::string::npos) {
-      processEntry(
-          out,
-          std::string_view(input.data() + pos, nextEntryPos - pos),
-          keyValueDelimiter,
-          keys);
-
-      pos = nextEntryPos + 1;
-      nextEntryPos = input.find(entryDelimiter, pos);
+      if (kvItems.size() > 1) {
+        auto [keyWriter, valueWriter] = out.add_item();
+        keyWriter.setNoCopy(kvItems[0]);
+        valueWriter.setNoCopy(kvItems[1]);
+      } else {
+        out.add_null().setNoCopy(kvItems[0]);
+      }
     }
-
-    processEntry(
-        out,
-        std::string_view(input.data() + pos, input.size() - pos),
-        keyValueDelimiter,
-        keys);
-  }
-
-  void processEntry(
-      out_type<Map<Varchar, Varchar>>& out,
-      std::string_view entry,
-      std::string_view keyValueDelimiter,
-      folly::F14FastSet<std::string_view>& keys) const {
-    const auto delimiterPos = entry.find(keyValueDelimiter, 0);
-    // Allows keyValue delimiter not found.
-    if (delimiterPos == std::string::npos) {
-      out.add_null().setNoCopy(StringView(entry));
-      return;
-    }
-    const auto key = std::string_view(entry.data(), delimiterPos);
-    VELOX_USER_CHECK(
-        keys.insert(key).second, "Duplicate keys are not allowed: '{}'.", key);
-    const auto value = StringView(
-        entry.data() + delimiterPos + 1, entry.size() - delimiterPos - 1);
-
-    auto [keyWriter, valueWriter] = out.add_item();
-    keyWriter.setNoCopy(StringView(key));
-    valueWriter.setNoCopy(value);
   }
 };
+template <typename T>
+StringView StringToMapFunction<T>::entryDelimiter_(",");
+
+template <typename T>
+StringView StringToMapFunction<T>::keyValueDelimiter_(":");
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/StringToMap.h
+++ b/velox/functions/sparksql/StringToMap.h
@@ -27,19 +27,6 @@ struct StringToMapFunction {
   static constexpr int32_t reuse_strings_from_arg = 0;
   void call(
       out_type<Map<Varchar, Varchar>>& out,
-      const arg_type<Varchar>& input) {
-    callImpl(out, input, entryDelimiter_, keyValueDelimiter_);
-  }
-  void call(
-      out_type<Map<Varchar, Varchar>>& out,
-      const arg_type<Varchar>& input,
-      const arg_type<Varchar>& entryDelimiter) {
-    VELOX_USER_CHECK_GE(
-        entryDelimiter.size(), 1, "entryDelimiter's size should >= 1.");
-    callImpl(out, input, entryDelimiter, keyValueDelimiter_);
-  }
-  void call(
-      out_type<Map<Varchar, Varchar>>& out,
       const arg_type<Varchar>& input,
       const arg_type<Varchar>& entryDelimiter,
       const arg_type<Varchar>& keyValueDelimiter) {

--- a/velox/functions/sparksql/tests/StringToMapTest.cpp
+++ b/velox/functions/sparksql/tests/StringToMapTest.cpp
@@ -63,28 +63,28 @@ TEST_F(StringToMapTest, basic) {
       {"a:1_b:2_c:3", "_", "_"},
       {{"a:1", std::nullopt}, {"b:2", std::nullopt}, {"c:3", std::nullopt}});
 
+  // Multi size delimiter
+  testStringToMap(
+      {"a::1__b::2__c::3", "__", "::"}, {{"a", "1"}, {"b", "2"}, {"c", "3"}});
+  testStringToMap(
+      {"a::1__b:::2__c::::3", "__", "::"},
+      {{"a", "1"}, {"b", ":2"}, {"c", "::3"}});
+  testStringToMap(
+      {"a::1___b:::2____c::::3", "__", "::"},
+      {{"a", "1"}, {"_b", ":2"}, {"", std::nullopt}, {"c", "::3"}});
+
+  // Number of different parameters
+  testStringToMap({"a:1,b:2,c:3", ","}, {{"a", "1"}, {"b", "2"}, {"c", "3"}});
+  testStringToMap({"a:1,b:2,c:3"}, {{"a", "1"}, {"b", "2"}, {"c", "3"}});
+
   // Exception for illegal delimiters.
   // Empty string is used.
   VELOX_ASSERT_THROW(
       evaluateStringToMap({"a:1,b:2", "", ":"}),
-      "entryDelimiter's size should be 1.");
+      "entryDelimiter's size should >= 1.");
   VELOX_ASSERT_THROW(
       evaluateStringToMap({"a:1,b:2", ",", ""}),
-      "keyValueDelimiter's size should be 1.");
-  // Delimiter's length > 1.
-  VELOX_ASSERT_THROW(
-      evaluateStringToMap({"a:1,b:2", ";;", ":"}),
-      "entryDelimiter's size should be 1.");
-  VELOX_ASSERT_THROW(
-      evaluateStringToMap({"a:1,b:2", ",", "::"}),
-      "keyValueDelimiter's size should be 1.");
-  // Unicode character is used.
-  VELOX_ASSERT_THROW(
-      evaluateStringToMap({"a:1,b:2", "å", ":"}),
-      "entryDelimiter's size should be 1.");
-  VELOX_ASSERT_THROW(
-      evaluateStringToMap({"a:1,b:2", ",", "æ"}),
-      "keyValueDelimiter's size should be 1.");
+      "keyValueDelimiter's size should >= 1.");
 
   // Exception for duplicated keys.
   VELOX_ASSERT_THROW(

--- a/velox/functions/sparksql/tests/StringToMapTest.cpp
+++ b/velox/functions/sparksql/tests/StringToMapTest.cpp
@@ -73,10 +73,6 @@ TEST_F(StringToMapTest, basic) {
       {"a::1___b:::2____c::::3", "__", "::"},
       {{"a", "1"}, {"_b", ":2"}, {"", std::nullopt}, {"c", "::3"}});
 
-  // Number of different parameters
-  testStringToMap({"a:1,b:2,c:3", ","}, {{"a", "1"}, {"b", "2"}, {"c", "3"}});
-  testStringToMap({"a:1,b:2,c:3"}, {{"a", "1"}, {"b", "2"}, {"c", "3"}});
-
   // Exception for illegal delimiters.
   // Empty string is used.
   VELOX_ASSERT_THROW(

--- a/velox/functions/sparksql/tests/StringToMapTest.cpp
+++ b/velox/functions/sparksql/tests/StringToMapTest.cpp
@@ -77,10 +77,22 @@ TEST_F(StringToMapTest, basic) {
   // Empty string is used.
   VELOX_ASSERT_THROW(
       evaluateStringToMap({"a:1,b:2", "", ":"}),
-      "entryDelimiter's size should >= 1.");
+      "The entry delimiter should not be empty.");
   VELOX_ASSERT_THROW(
       evaluateStringToMap({"a:1,b:2", ",", ""}),
-      "keyValueDelimiter's size should >= 1.");
+      "The keyValue delimiter should not be empty.");
+
+  // Unicode characters
+  testStringToMap(
+      {"a✈✈1☺☺b✈✈2☺☺c✈✈3", "☺☺", "✈✈"}, {{"a", "1"}, {"b", "2"}, {"c", "3"}});
+  testStringToMap(
+      {"我✈✈是☺☺猪✈✈头☺☺三✈✈！", "☺☺", "✈✈"},
+      {{"我", "是"}, {"猪", "头"}, {"三", "！"}});
+
+  // regular expressions
+  testStringToMap(
+      {"a443d121b344e221c344f", "[12]+", "[34]+"},
+      {{"a", "d"}, {"b", "e"}, {"c", "f"}});
 
   // Exception for duplicated keys.
   VELOX_ASSERT_THROW(


### PR DESCRIPTION
    Summary:
    
    1. compatible with calling this UDF with one or two parameters.
    2. compatible with delimiter sizes greater than 1, and delimiter can use regular expressions.
    3. try to use the input type StringView for operations to reduce the cost of type conversion.