### PR TITLE
Optimize evaluation by reducing peeled vectors size

### DIFF
--- a/velox/expression/PeeledEncoding.cpp
+++ b/velox/expression/PeeledEncoding.cpp
@@ -55,7 +55,9 @@ namespace facebook::velox::exec {
 SelectivityVector* PeeledEncoding::translateToInnerRows(
     const SelectivityVector& outerRows,
     LocalSelectivityVector& innerRowsHolder) const {
-  VELOX_CHECK(wrapEncoding_ != VectorEncoding::Simple::FLAT);
+  if (wrapEncoding_ == VectorEncoding::Simple::FLAT) {
+    return innerRowsHolder.get(outerRows);
+  }
   if (wrapEncoding_ == VectorEncoding::Simple::CONSTANT) {
     auto newRows = innerRowsHolder.get(constantWrapIndex_ + 1, false);
     newRows->setValid(constantWrapIndex_, true);
@@ -107,6 +109,61 @@ void PeeledEncoding::setDictionaryWrapping(
   auto wrapping = decoded.dictionaryWrapping(firstWrapper, rows.end());
   wrap_ = std::move(wrapping.indices);
   wrapNulls_ = std::move(wrapping.nulls);
+}
+
+void PeeledEncoding::flattenPeeledVectors(
+    const SelectivityVector& rows,
+    const std::vector<bool>& constantFields,
+    std::vector<VectorPtr>& peeledVectors) {
+  VELOX_CHECK(flattenPeeled_.empty());
+  for (int i = 0; i < peeledVectors.size(); ++i) {
+    if (!constantFields.empty() && constantFields[i]) {
+      continue;
+    }
+    if (peeledVectors[i]->isConstantEncoding() && !wrapNulls_) {
+      continue;
+    }
+    switch (peeledVectors[i]->typeKind()) {
+      case TypeKind::ARRAY:
+      case TypeKind::MAP:
+      case TypeKind::ROW:
+        return;
+      default:
+        if (isLazyNotLoaded(*peeledVectors[i])) {
+          return;
+        }
+    }
+  }
+  auto nonNullRows = rows;
+  if (wrapNulls_) {
+    nonNullRows.deselectNulls(
+        wrapNulls_->as<uint64_t>(), rows.begin(), rows.end());
+  }
+  for (int i = 0; i < peeledVectors.size(); ++i) {
+    if (!constantFields.empty() && constantFields[i]) {
+      continue;
+    }
+    if (peeledVectors[i]->isConstantEncoding() && !wrapNulls_) {
+      if (peeledVectors[i]->size() < rows.end()) {
+        peeledVectors[i] =
+            BaseVector::wrapInConstant(rows.end(), 0, peeledVectors[i]);
+      }
+    } else {
+      auto flat = BaseVector::create(
+          peeledVectors[i]->type(), rows.end(), peeledVectors[i]->pool());
+      flat->copy(
+          peeledVectors[i].get(), nonNullRows, wrap_->as<vector_size_t>());
+      if (!nonNullRows.isAllSelected()) {
+        bits::andBits(
+            flat->mutableRawNulls(), nonNullRows.allBits(), 0, rows.end());
+      }
+      peeledVectors[i] = flat;
+      flattenPeeled_.push_back(std::move(flat));
+    }
+  }
+  wrapEncoding_ = VectorEncoding::Simple::FLAT;
+  baseSize_ = rows.end();
+  wrap_.reset();
 }
 
 bool PeeledEncoding::peelInternal(
@@ -223,6 +280,12 @@ bool PeeledEncoding::peelInternal(
       constantWrapIndex_ = innerIdx;
     } else {
       setDictionaryWrapping(decodedVector, rows, *firstWrapper);
+      if (baseSize_ / 8 > rows.end()) {
+        // For large base vector, peeling would still need to allocate and
+        // initialize/copy the memory of unselected rows, resulting in large
+        // performance penalty, thus it's safer to do deep copy in this case.
+        flattenPeeledVectors(rows, constantFields, peeledVectors);
+      }
       // Make sure all the constant vectors have at least the same length as the
       // base vector after peeling. This will make sure any translated rows
       // point to valid rows in the constant vector.
@@ -248,7 +311,9 @@ VectorPtr PeeledEncoding::wrap(
     velox::memory::MemoryPool* pool,
     VectorPtr peeledResult,
     const SelectivityVector& rows) const {
-  VELOX_CHECK(wrapEncoding_ != VectorEncoding::Simple::FLAT);
+  if (wrapEncoding_ == VectorEncoding::Simple::FLAT) {
+    return peeledResult;
+  }
   VectorPtr wrappedResult;
   if (wrapEncoding_ == VectorEncoding::Simple::DICTIONARY) {
     if (!peeledResult) {

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2094,7 +2094,7 @@ TEST_F(ExprTest, memo) {
   // 1. correctly evaluates the unevaluated rows on subsequent runs
   // 2. Only caches results if it encounters the same base twice
   auto base = makeArrayVector<int64_t>(
-      1'000,
+      500,
       [](auto row) { return row % 5 + 1; },
       [](auto row, auto index) { return (row % 3) + index; });
 
@@ -2142,7 +2142,7 @@ TEST_F(ExprTest, memo) {
 
   // Create a new base
   base = makeArrayVector<int64_t>(
-      1'000,
+      500,
       [](auto row) { return row % 5 + 1; },
       [](auto row, auto index) { return (row % 3) + index; });
 


### PR DESCRIPTION
Summary:
In case the peeled vector is sparsely selected (e.g. as a result of
filtering) and peeled, we still need to allocate and initialize/copy the memory
for unselected rows in result vector during evaluation, causing large
performance penalty in some queries.  Fix this by compacting the peeled vector
if the number of selected rows is smaller than 1/8 of the underlying base
vector.  A typical slow query due to this improved from 17.32 CPU days to 1.65
days, comparing to Java using 3.53 days.

Differential Revision: D60064934
