### PR TITLE
Fix Presto bitwise_shift_left function

### DIFF
--- a/velox/functions/prestosql/Bitwise.h
+++ b/velox/functions/prestosql/Bitwise.h
@@ -198,7 +198,7 @@ struct BitwiseShiftLeftFunction {
     // Presto defines this only for bigint, thus we will define this only for
     // int64_t.
     if (bits == 64) {
-      result = number >> shift;
+      result = number << shift;
       return true;
     }
 

--- a/velox/functions/prestosql/tests/BitwiseTest.cpp
+++ b/velox/functions/prestosql/tests/BitwiseTest.cpp
@@ -385,12 +385,18 @@ TEST_F(BitwiseTest, shiftLeft) {
         "bitwise_shift_left(c0, c1, c2)", number, shift, bits);
   };
 
-  EXPECT_EQ(evalFunc(1, 1, 64), 0);
+  EXPECT_EQ(evalFunc(1, 1, 64), 2);
+  EXPECT_EQ(evalFunc(1, 5, 64), 32);
+  EXPECT_EQ(evalFunc(32, 60, 64), 0);
+  EXPECT_EQ(evalFunc(48, 60, 64), 0);
+  EXPECT_EQ(evalFunc(56, 60, 64), 1L << 63);
+  EXPECT_EQ(evalFunc(-1, 1, 64), -2); // -1 << 1
+  EXPECT_EQ(evalFunc(-1, 32, 64), -4294967296); // -1 << 32
   EXPECT_EQ(evalFunc(-1, 1, 2), 2);
   EXPECT_EQ(evalFunc(-1, 32, 32), 0);
   EXPECT_EQ(evalFunc(-1, 31, 32), 2147483648);
   EXPECT_EQ(evalFunc(kMin64, 10, 32), 0);
-  EXPECT_EQ(evalFunc(kMin64, kMax64, 64), -1);
+  EXPECT_EQ(evalFunc(kMin64, kMax64, 64), 0);
   EXPECT_EQ(evalFunc(kMax64, kMin64, 64), kMax64);
   EXPECT_EQ(evalFunc(7, 0, 64), 7);
 


### PR DESCRIPTION
Bitwise_shift_left function has a bug where if the bits field is 64 it right shifted instead of left shifted. This PR fixes this bug. 