### PR TITLE
Use orderable type in Spark max_by and min_by

### DIFF
--- a/velox/functions/sparksql/aggregates/MinMaxByAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/MinMaxByAggregate.cpp
@@ -94,7 +94,7 @@ exec::AggregateRegistrationResult registerMinMaxBy(
   // V, C -> row(V, C) -> V.
   signatures.push_back(exec::AggregateFunctionSignatureBuilder()
                            .typeVariable("V")
-                           .typeVariable("C")
+                           .orderableTypeVariable("C")
                            .returnType("V")
                            .intermediateType("row(V,C)")
                            .argumentType("V")

--- a/velox/functions/sparksql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
 #include "velox/functions/sparksql/aggregates/Register.h"
@@ -112,54 +113,18 @@ TEST_F(MinMaxByAggregateTest, arrayCompare) {
 
 TEST_F(MinMaxByAggregateTest, mapCompare) {
   auto data = makeRowVector({
-      makeArrayVector<int64_t>({
-          {1, 2, 3},
-          {4, 5},
-          {6, 7, 8},
-      }),
-      makeNullableMapVector<int64_t, int64_t>({
-          {{{1, 1}, {2, 2}}},
-          {{{1, 1}, {2, std::nullopt}}},
-          {{{4, 50}}},
-      }),
+      makeArrayVector<int64_t>({}),
+      makeNullableMapVector<int64_t, int64_t>({}),
   });
+  std::vector<RowVectorPtr> expected = {};
 
-  auto expected = makeRowVector({
-      makeArrayVector<int64_t>({
-          {4, 5},
-      }),
-      makeArrayVector<int64_t>({
-          {6, 7, 8},
-      }),
-  });
+  VELOX_ASSERT_USER_THROW(
+      testAggregations({data}, {}, {"spark_min_by(c0, c1)"}, expected),
+      "Aggregate function signature is not supported");
 
-  testAggregations(
-      {data}, {}, {"spark_min_by(c0, c1)", "spark_max_by(c0, c1)"}, {expected});
-
-  data = makeRowVector({
-      makeArrayVector<int64_t>({
-          {1, 2, 3},
-          {4, 5},
-          {6, 7, 8},
-      }),
-      makeNullableMapVector<int64_t, int64_t>({
-          {{{1, 1}, {2, 2}}},
-          {{{1, 1}, {2, 3}}},
-          {{{4, 50}}},
-      }),
-  });
-
-  expected = makeRowVector({
-      makeArrayVector<int64_t>({
-          {1, 2, 3},
-      }),
-      makeArrayVector<int64_t>({
-          {6, 7, 8},
-      }),
-  });
-
-  testAggregations(
-      {data}, {}, {"spark_min_by(c0, c1)", "spark_max_by(c0, c1)"}, {expected});
+  VELOX_ASSERT_USER_THROW(
+      testAggregations({data}, {}, {"spark_max_by(c0, c1)"}, expected),
+      "Aggregate function signature is not supported");
 }
 
 TEST_F(MinMaxByAggregateTest, rowCompare) {


### PR DESCRIPTION
Fixes below exception noticed when running aggregate fuzzer test. Spark's
`max_by` and `min_by` do not support ordering on map type.

```
org.apache.spark.sql.AnalysisException: [DATATYPE_MISMATCH.INVALID_ORDERING_TYPE] Cannot resolve "min_by(c0, c1)" due to data type mismatch: The `min_by` does not support ordering on type "MAP<TIMESTAMP_NTZ, TINYINT>".; line 1 pos 15;
'Aggregate [g0#33927, g1#33928], [g0#33927, g1#33928, min_by(c0#33925, c1#33926) AS a0#33924]
+- SubqueryAlias tmp
   +- View (`tmp`, [c0#33925,c1#33926,g0#33927,g1#33928])
      +- Project [cast(c0#33929 as struct<f0:bigint>) AS c0#33925, cast(c1#33930 as map<timestamp_ntz,tinyint>) AS c1#33926, cast(g0#33931 as struct<f0:boolean>) AS g0#33927, cast(g1#33932 as struct<f0:boolean>) AS g1#33928]
         +- Project [c0#33929, c1#33930, g0#33931, g1#33932]
            +- Relation [c0#33929,c1#33930,g0#33931,g1#33932] parquet
```