### PR TITLE
Add Spark concat_ws function

### DIFF
--- a/velox/functions/sparksql/ConcatWs.h
+++ b/velox/functions/sparksql/ConcatWs.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include "folly/container/F14Set.h"
+#include "velox/functions/Udf.h"
+
+namespace facebook::velox::functions::sparksql {
+
+template <typename T>
+struct ConcatWsFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Varchar>& result,
+      const arg_type<Variadic<Varchar>>& inputs) {
+    concatWsImpl(result, inputs);
+  }
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Varchar>& result,
+      const arg_type<Array<Varchar>>& inputs) {
+    concatWsImpl(result, inputs);
+  }
+  template <class Tout, class Tin>
+  void concatWsImpl(Tout& result, const Tin& inputs) {
+    if (!inputs[0]) {
+      return;
+    }
+    bool first = true;
+    for (int i = 1; i < inputs.size(); ++i) {
+      if (inputs[i]) {
+        if (first) {
+          first = false;
+        } else {
+          result.append(inputs[0].value());
+        }
+        result.append(inputs[i].value());
+      }
+    }
+  }
+};
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -51,6 +51,7 @@
 #include "velox/functions/sparksql/specialforms/DecimalRound.h"
 #include "velox/functions/sparksql/specialforms/MakeDecimal.h"
 #include "velox/functions/sparksql/specialforms/SparkCastExpr.h"
+#include "velox/functions/sparksql/ConcatWs.h
 
 namespace facebook::velox::functions {
 extern void registerElementAtFunction(
@@ -477,6 +478,10 @@ void registerFunctions(const std::string& prefix) {
       int32_t>({prefix + "levenshtein"});
   registerFunction<LevenshteinDistanceFunction, int32_t, Varchar, Varchar>(
       {prefix + "levenshtein"});
+  registerFunction<ConcatWsFunction, Varchar, Variadic<Varchar>>(
+      {prefix + "concat_ws"});
+  registerFunction<ConcatWsFunction, Varchar, Array<Varchar>>(
+      {prefix + "concat_ws"});
 }
 
 } // namespace sparksql

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -50,7 +50,8 @@ add_executable(
   StringToMapTest.cpp
   UnscaledValueFunctionTest.cpp
   UuidTest.cpp
-  XxHash64Test.cpp)
+  XxHash64Test.cpp
+  ConcatWsTest.cpp)
 
 add_test(velox_functions_spark_test velox_functions_spark_test)
 

--- a/velox/functions/sparksql/tests/ConcatWsTest.cpp
+++ b/velox/functions/sparksql/tests/ConcatWsTest.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+using namespace facebook::velox::test;
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class ConcatWsFunctionsTest : public SparkFunctionBaseTest {
+ protected:
+  template <class... Args>
+  void testVariadic(const char* result, Args... args) {
+    int size = sizeof...(args);
+    std::string expr("concat_ws(");
+    std::string c("c");
+    for (int i = 0; i < size; ++i) {
+      expr += c + std::to_string(i) + " ,";
+    }
+    expr.size() > 10               ? expr = expr.substr(0, expr.size() - 2),
+                       expr += ")" : expr += ")";
+    EXPECT_EQ(
+        result,
+        evaluateOnce<std::string>(expr, std::optional<std::string>(args)...));
+  }
+  void testArray(
+      const char* result,
+      const std::vector<std::vector<std::optional<std::string>>>& data) {
+    auto row = makeRowVector({makeNullableArrayVector<std::string>(data)});
+    EXPECT_EQ(result, evaluateOnce<std::string>("concat_ws(c0)", row));
+  }
+};
+TEST_F(ConcatWsFunctionsTest, ConcatWs) {
+  testVariadic("1+2+3", "+", "1", "2", "3");
+  testVariadic("1_2_3_4_5", "_", "1", "2", "3", "4", "5");
+
+  testArray("121_221", {{"_", "121", "221"}});
+  testArray("121+221+43+17", {{"+", "121", "221", "43", "17"}});
+}
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
A function that concatenates strings based on separators.

Spark document:
https://spark.apache.org/docs/3.5.1/api/sql/#concat_ws
Spark implementation:
https://github.com/apache/spark/blob/285489b0225004e918b6e937f7367e492292815e/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala#L76