### PR TITLE
Exclude map-type grouping keys for Spark aggregation fuzzer test

### DIFF
--- a/velox/exec/fuzzer/AggregationFuzzer.cpp
+++ b/velox/exec/fuzzer/AggregationFuzzer.cpp
@@ -61,6 +61,7 @@ class AggregationFuzzer : public AggregationFuzzerBase {
           customInputGenerators,
       VectorFuzzer::Options::TimestampPrecision timestampPrecision,
       const std::unordered_map<std::string, std::string>& queryConfigs,
+      bool orderableGroupKeys,
       std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner);
 
   void go();
@@ -211,6 +212,7 @@ void aggregateFuzzer(
         customInputGenerators,
     VectorFuzzer::Options::TimestampPrecision timestampPrecision,
     const std::unordered_map<std::string, std::string>& queryConfigs,
+    bool orderableGroupKeys,
     const std::optional<std::string>& planPath,
     std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner) {
   auto aggregationFuzzer = AggregationFuzzer(
@@ -220,6 +222,7 @@ void aggregateFuzzer(
       customInputGenerators,
       timestampPrecision,
       queryConfigs,
+      orderableGroupKeys,
       std::move(referenceQueryRunner));
   planPath.has_value() ? aggregationFuzzer.go(planPath.value())
                        : aggregationFuzzer.go();
@@ -236,6 +239,7 @@ AggregationFuzzer::AggregationFuzzer(
         customInputGenerators,
     VectorFuzzer::Options::TimestampPrecision timestampPrecision,
     const std::unordered_map<std::string, std::string>& queryConfigs,
+    bool orderableGroupKeys,
     std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner)
     : AggregationFuzzerBase{
           seed,
@@ -243,6 +247,7 @@ AggregationFuzzer::AggregationFuzzer(
           customInputGenerators,
           timestampPrecision,
           queryConfigs,
+          orderableGroupKeys,
           std::move(referenceQueryRunner)} {
   VELOX_CHECK(!signatureMap.empty(), "No function signatures available.");
 
@@ -303,18 +308,20 @@ bool canSortInputs(const CallableSignature& signature) {
 }
 
 // Returns true if specified aggregate function can be applied to distinct
-// inputs.
-bool supportsDistinctInputs(const CallableSignature& signature) {
+// inputs. If 'orderableGroupKeys' is true the argument type must be orderable,
+// otherwise it must be comparable.
+bool supportsDistinctInputs(
+    const CallableSignature& signature,
+    bool orderableGroupKeys) {
   if (signature.args.empty()) {
     return false;
   }
 
   const auto& arg = signature.args.at(0);
-  if (!arg->isComparable()) {
-    return false;
+  if (orderableGroupKeys) {
+    return arg->isOrderable();
   }
-
-  return true;
+  return arg->isComparable();
 }
 
 void AggregationFuzzer::go() {
@@ -391,7 +398,8 @@ void AggregationFuzzer::go() {
         // x).
         const bool distinctInputs = !sortedInputs &&
             (signature.name.find("approx_") == std::string::npos) &&
-            supportsDistinctInputs(signature) && vectorFuzzer_.coinToss(0.2);
+            supportsDistinctInputs(signature, orderableGroupKeys_) &&
+            vectorFuzzer_.coinToss(0.2);
 
         auto call = makeFunctionCall(
             signature.name, argNames, sortedInputs, distinctInputs);

--- a/velox/exec/fuzzer/AggregationFuzzer.h
+++ b/velox/exec/fuzzer/AggregationFuzzer.h
@@ -27,6 +27,8 @@ namespace facebook::velox::exec::test {
 /// @param seed Random seed - Pass the same seed for reproducibility.
 /// @param orderDependentFunctions Map of functions that depend on order of
 /// input.
+/// @param orderableGroupKeys Whether group keys must be orderable or be just
+/// comparable.
 /// @param planPath Path to persisted plan information. If this is
 /// supplied, fuzzer will only verify the plans.
 /// @param referenceQueryRunner Reference query runner for results
@@ -40,6 +42,7 @@ void aggregateFuzzer(
         customInputGenerators,
     VectorFuzzer::Options::TimestampPrecision timestampPrecision,
     const std::unordered_map<std::string, std::string>& queryConfigs,
+    bool orderableGroupKeys,
     const std::optional<std::string>& planPath,
     std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner);
 

--- a/velox/exec/fuzzer/AggregationFuzzerBase.cpp
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.cpp
@@ -227,7 +227,12 @@ std::vector<std::string> AggregationFuzzerBase::generateKeys(
     keys.push_back(fmt::format("{}{}", prefix, i));
 
     // Pick random, possibly complex, type.
-    types.push_back(vectorFuzzer_.randType(kNonFloatingPointTypes, 2));
+    if (orderableGroupKeys_) {
+      types.push_back(
+          vectorFuzzer_.randOrderableType(kNonFloatingPointTypes, 2));
+    } else {
+      types.push_back(vectorFuzzer_.randType(kNonFloatingPointTypes, 2));
+    }
     names.push_back(keys.back());
   }
   return keys;

--- a/velox/exec/fuzzer/AggregationFuzzerBase.h
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.h
@@ -63,10 +63,12 @@ class AggregationFuzzerBase {
           customInputGenerators,
       VectorFuzzer::Options::TimestampPrecision timestampPrecision,
       const std::unordered_map<std::string, std::string>& queryConfigs,
+      bool orderableGroupKeys,
       std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner)
       : customVerificationFunctions_{customVerificationFunctions},
         customInputGenerators_{customInputGenerators},
         queryConfigs_{queryConfigs},
+        orderableGroupKeys_{orderableGroupKeys},
         persistAndRunOnce_{FLAGS_persist_and_run_once},
         reproPersistPath_{FLAGS_repro_persist_path},
         referenceQueryRunner_{std::move(referenceQueryRunner)},
@@ -243,6 +245,9 @@ class AggregationFuzzerBase {
   const std::unordered_map<std::string, std::shared_ptr<InputGenerator>>
       customInputGenerators_;
   const std::unordered_map<std::string, std::string> queryConfigs_;
+
+  // Whether group keys must be orderable or be just comparable.
+  bool orderableGroupKeys_;
   const bool persistAndRunOnce_;
   const std::string reproPersistPath_;
 

--- a/velox/exec/fuzzer/AggregationFuzzerOptions.h
+++ b/velox/exec/fuzzer/AggregationFuzzerOptions.h
@@ -58,6 +58,9 @@ struct AggregationFuzzerOptions {
   /// Could be used to specify timezone or enable/disable settings that
   /// affect semantics of individual aggregate functions.
   std::unordered_map<std::string, std::string> queryConfigs;
+
+  // Whether group keys must be orderable or be just comparable.
+  bool orderableGroupKeys = false;
 };
 
 } // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/AggregationFuzzerRunner.h
+++ b/velox/exec/fuzzer/AggregationFuzzerRunner.h
@@ -114,6 +114,7 @@ class AggregationFuzzerRunner {
         options.customInputGenerators,
         options.timestampPrecision,
         options.queryConfigs,
+        options.orderableGroupKeys,
         planPath,
         std::move(referenceQueryRunner));
     // Calling gtest here so that it can be recognized as tests in CI systems.

--- a/velox/exec/fuzzer/WindowFuzzer.cpp
+++ b/velox/exec/fuzzer/WindowFuzzer.cpp
@@ -471,6 +471,7 @@ void windowFuzzer(
     const std::unordered_set<std::string>& orderDependentFunctions,
     VectorFuzzer::Options::TimestampPrecision timestampPrecision,
     const std::unordered_map<std::string, std::string>& queryConfigs,
+    bool orderableGroupKeys,
     const std::optional<std::string>& planPath,
     std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner) {
   auto windowFuzzer = WindowFuzzer(
@@ -482,6 +483,7 @@ void windowFuzzer(
       orderDependentFunctions,
       timestampPrecision,
       queryConfigs,
+      orderableGroupKeys,
       std::move(referenceQueryRunner));
   planPath.has_value() ? windowFuzzer.go(planPath.value()) : windowFuzzer.go();
 }

--- a/velox/exec/fuzzer/WindowFuzzer.h
+++ b/velox/exec/fuzzer/WindowFuzzer.h
@@ -40,8 +40,9 @@ class WindowFuzzer : public AggregationFuzzerBase {
       const std::unordered_set<std::string>& orderDependentFunctions,
       VectorFuzzer::Options::TimestampPrecision timestampPrecision,
       const std::unordered_map<std::string, std::string>& queryConfigs,
+      bool orderableGroupKeys,
       std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner)
-      : AggregationFuzzerBase{seed, customVerificationFunctions, customInputGenerators, timestampPrecision, queryConfigs, std::move(referenceQueryRunner)},
+      : AggregationFuzzerBase{seed, customVerificationFunctions, customInputGenerators, timestampPrecision, queryConfigs, orderableGroupKeys, std::move(referenceQueryRunner)},
         orderDependentFunctions_{orderDependentFunctions} {
     VELOX_CHECK(
         !aggregationSignatureMap.empty() || !windowSignatureMap.empty(),
@@ -147,6 +148,7 @@ void windowFuzzer(
     const std::unordered_set<std::string>& orderDependentFunctions,
     VectorFuzzer::Options::TimestampPrecision timestampPrecision,
     const std::unordered_map<std::string, std::string>& queryConfigs,
+    bool orderableGroupKeys,
     const std::optional<std::string>& planPath,
     std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner);
 

--- a/velox/exec/fuzzer/WindowFuzzerRunner.h
+++ b/velox/exec/fuzzer/WindowFuzzerRunner.h
@@ -88,6 +88,7 @@ class WindowFuzzerRunner {
         options.orderDependentFunctions,
         options.timestampPrecision,
         options.queryConfigs,
+        options.orderableGroupKeys,
         planPath,
         std::move(referenceQueryRunner));
     // Calling gtest here so that it can be recognized as tests in CI systems.

--- a/velox/functions/sparksql/fuzzer/SparkAggregationFuzzerTest.cpp
+++ b/velox/functions/sparksql/fuzzer/SparkAggregationFuzzerTest.cpp
@@ -113,5 +113,6 @@ int main(int argc, char** argv) {
   options.onlyFunctions = FLAGS_only;
   options.skipFunctions = skipFunctions;
   options.customVerificationFunctions = customVerificationFunctions;
+  options.orderableGroupKeys = true;
   return Runner::run(initialSeed, std::move(duckQueryRunner), options);
 }

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -256,11 +256,16 @@ class VectorFuzzer {
   // the future.
   TypePtr randType(int maxDepth = 5);
 
+  TypePtr randType(const std::vector<TypePtr>& scalarTypes, int maxDepth = 5);
+
   /// Same as the function above, but only generate orderable types.
   /// MAP types are not generated as they are not orderable.
   TypePtr randOrderableType(int maxDepth = 5);
 
-  TypePtr randType(const std::vector<TypePtr>& scalarTypes, int maxDepth = 5);
+  TypePtr randOrderableType(
+      const std::vector<TypePtr>& scalarTypes,
+      int maxDepth = 5);
+
   RowTypePtr randRowType(int maxDepth = 5);
   RowTypePtr randRowType(
       const std::vector<TypePtr>& scalarTypes,
@@ -362,11 +367,16 @@ class VectorFuzzer {
 /// no complex types are allowed.
 TypePtr randType(FuzzerGenerator& rng, int maxDepth = 5);
 
+TypePtr randType(
+    FuzzerGenerator& rng,
+    const std::vector<TypePtr>& scalarTypes,
+    int maxDepth = 5);
+
 /// Same as the function above, but only generate orderable types.
 /// MAP types are not generated as they are not orderable.
 TypePtr randOrderableType(FuzzerGenerator& rng, int maxDepth = 5);
 
-TypePtr randType(
+TypePtr randOrderableType(
     FuzzerGenerator& rng,
     const std::vector<TypePtr>& scalarTypes,
     int maxDepth = 5);


### PR DESCRIPTION
In this PR, option 'orderableGroupKeys' is added as a parameter of 
AggregationFuzzer and WindowFuzzer. It is enabled for Spark aggregation fuzzer 
test as Spark does not accept map-type grouping keys and distinct columns. 
Method 'randOrderableType' taking 'scalarTypes' as parameter is added to 
generate grouping keys for Spark.