### PR TITLE
Fix GCC 11 warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]

### DIFF
--- a/velox/vector/SelectivityVector.h
+++ b/velox/vector/SelectivityVector.h
@@ -294,7 +294,9 @@ class SelectivityVector {
     if (begin_ == -1) {
       begin_ = 0;
       end_ = 0;
+      VELOX_SUPPRESS_STRINGOP_OVERFLOW_WARNING
       allSelected_ = false;
+      VELOX_UNSUPPRESS_STRINGOP_OVERFLOW_WARNING
       return;
     }
     end_ = bits::findLastBit(bits_.data(), begin_, size_) + 1;


### PR DESCRIPTION
Similar to https://github.com/facebookincubator/velox/pull/10469 but at a different location.