### PR TITLE
Move computeReferenceResults APIs to FuzzerUtil.h

### DIFF
--- a/velox/exec/fuzzer/AggregationFuzzerBase.h
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.h
@@ -102,12 +102,6 @@ class AggregationFuzzerBase {
     size_t numFailed{0};
   };
 
-  enum ReferenceQueryErrorCode {
-    kSuccess,
-    kReferenceQueryFail,
-    kReferenceQueryUnsupported
-  };
-
  protected:
   struct Stats {
     // Names of functions that were tested.
@@ -136,8 +130,7 @@ class AggregationFuzzerBase {
 
     void print(size_t numIterations) const;
 
-    void updateReferenceQueryStats(
-        AggregationFuzzerBase::ReferenceQueryErrorCode errorCode);
+    void updateReferenceQueryStats(ReferenceQueryErrorCode errorCode);
   };
 
   int32_t randInt(int32_t min, int32_t max);
@@ -208,26 +201,12 @@ class AggregationFuzzerBase {
       const std::vector<std::string>& partitionKeys,
       const CallableSignature& signature);
 
-  std::pair<std::optional<MaterializedRowMultiset>, ReferenceQueryErrorCode>
-  computeReferenceResults(
-      const core::PlanNodePtr& plan,
-      const std::vector<RowVectorPtr>& input);
-
   velox::fuzzer::ResultOrError execute(
       const core::PlanNodePtr& plan,
       const std::vector<exec::Split>& splits = {},
       bool injectSpill = false,
       bool abandonPartial = false,
       int32_t maxDrivers = 2);
-
-  // Will throw if referenceQueryRunner doesn't support
-  // returning results as a vector.
-  std::pair<
-      std::optional<std::vector<RowVectorPtr>>,
-      AggregationFuzzerBase::ReferenceQueryErrorCode>
-  computeReferenceResultsAsVector(
-      const core::PlanNodePtr& plan,
-      const std::vector<RowVectorPtr>& input);
 
   void compare(
       const velox::fuzzer::ResultOrError& actual,

--- a/velox/exec/fuzzer/FuzzerUtil.cpp
+++ b/velox/exec/fuzzer/FuzzerUtil.cpp
@@ -224,4 +224,52 @@ void setupMemory(int64_t allocatorCapacity, int64_t arbitratorCapacity) {
   options.arbitrationStateCheckCb = memoryArbitrationStateCheck;
   facebook::velox::memory::MemoryManager::initialize(options);
 }
+
+std::pair<std::optional<MaterializedRowMultiset>, ReferenceQueryErrorCode>
+computeReferenceResults(
+    const core::PlanNodePtr& plan,
+    const std::vector<RowVectorPtr>& input,
+    ReferenceQueryRunner* referenceQueryRunner) {
+  if (auto sql = referenceQueryRunner->toSql(plan)) {
+    try {
+      return std::make_pair(
+          referenceQueryRunner->execute(sql.value(), input, plan->outputType()),
+          ReferenceQueryErrorCode::kSuccess);
+    } catch (...) {
+      LOG(WARNING) << "Query failed in the reference DB";
+      return std::make_pair(
+          std::nullopt, ReferenceQueryErrorCode::kReferenceQueryFail);
+    }
+  }
+
+  LOG(INFO) << "Query not supported by the reference DB";
+  return std::make_pair(
+      std::nullopt, ReferenceQueryErrorCode::kReferenceQueryUnsupported);
+}
+
+std::pair<std::optional<std::vector<RowVectorPtr>>, ReferenceQueryErrorCode>
+computeReferenceResultsAsVector(
+    const core::PlanNodePtr& plan,
+    const std::vector<RowVectorPtr>& input,
+    ReferenceQueryRunner* referenceQueryRunner) {
+  VELOX_CHECK(referenceQueryRunner->supportsVeloxVectorResults());
+
+  if (auto sql = referenceQueryRunner->toSql(plan)) {
+    try {
+      return std::make_pair(
+          referenceQueryRunner->executeVector(
+              sql.value(), input, plan->outputType()),
+          ReferenceQueryErrorCode::kSuccess);
+    } catch (...) {
+      LOG(WARNING) << "Query failed in the reference DB";
+      return std::make_pair(
+          std::nullopt, ReferenceQueryErrorCode::kReferenceQueryFail);
+    }
+  } else {
+    LOG(INFO) << "Query not supported by the reference DB";
+  }
+
+  return std::make_pair(
+      std::nullopt, ReferenceQueryErrorCode::kReferenceQueryUnsupported);
+}
 } // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/FuzzerUtil.h
+++ b/velox/exec/fuzzer/FuzzerUtil.h
@@ -17,6 +17,8 @@
 
 #include "velox/core/PlanNode.h"
 #include "velox/exec/Split.h"
+#include "velox/exec/fuzzer/ReferenceQueryRunner.h"
+#include "velox/exec/tests/utils/QueryAssertions.h"
 
 namespace facebook::velox::exec::test {
 const std::string kHiveConnectorId = "test-hive";
@@ -81,4 +83,30 @@ bool containsUnsupportedTypes(const TypePtr& type);
 
 // Invoked to set up memory system with arbitration.
 void setupMemory(int64_t allocatorCapacity, int64_t arbitratorCapacity);
+
+enum ReferenceQueryErrorCode {
+  kSuccess,
+  kReferenceQueryFail,
+  kReferenceQueryUnsupported
+};
+
+// Converts 'plan' into an SQL query and runs it on 'input' in the reference DB.
+// Result is returned as a MaterializedRowMultiset with the
+// ReferenceQueryErrorCode::kSuccess if successful, or an std::nullopt with a
+// ReferenceQueryErrorCode if the query fails.
+std::pair<std::optional<MaterializedRowMultiset>, ReferenceQueryErrorCode>
+computeReferenceResults(
+    const core::PlanNodePtr& plan,
+    const std::vector<RowVectorPtr>& input,
+    ReferenceQueryRunner* referenceQueryRunner);
+
+// Similar to computeReferenceResults(), but returns the result as a
+// std::vector<RowVectorPtr>. This API throws if referenceQueryRunner doesn't
+// support returning results as a vector.
+std::pair<std::optional<std::vector<RowVectorPtr>>, ReferenceQueryErrorCode>
+computeReferenceResultsAsVector(
+    const core::PlanNodePtr& plan,
+    const std::vector<RowVectorPtr>& input,
+    ReferenceQueryRunner* referenceQueryRunner);
+
 } // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/WindowFuzzer.cpp
+++ b/velox/exec/fuzzer/WindowFuzzer.cpp
@@ -406,7 +406,8 @@ bool WindowFuzzer::verifyWindow(
 
     if (!customVerification) {
       if (resultOrError.result && enableWindowVerification) {
-        auto referenceResult = computeReferenceResults(plan, input);
+        auto referenceResult =
+            computeReferenceResults(plan, input, referenceQueryRunner_.get());
         stats_.updateReferenceQueryStats(referenceResult.second);
         if (auto expectedResult = referenceResult.first) {
           ++stats_.numVerified;


### PR DESCRIPTION
Summary:
Move computeReferenceResults() and computeReferenceResultsAsVector() to FuzzerUtil.h. This is 
needed for reusing these methods in Expression fuzzer (https://github.com/facebookincubator/velox/issues/10308).

Reviewed By: amitkdutta

Differential Revision: D60121321
