### PR TITLE
Move timezone conversion under velox_type_tz

### DIFF
--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -45,6 +45,7 @@ velox_link_libraries(
     velox_dwio_parquet_writer
     velox_file
     velox_hive_partition_function
+    velox_type_tz
     velox_s3fs
     velox_hdfs
     velox_gcs

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -27,9 +27,9 @@
 #include "velox/expression/Expr.h"
 #include "velox/expression/ExprToSubfieldFilter.h"
 #include "velox/type/TimestampConversion.h"
+#include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox::connector::hive {
-
 namespace {
 
 struct SubfieldSpec {
@@ -545,7 +545,7 @@ void configureReaderOptions(
       hiveConfig->cacheNoRetention(sessionProperties));
   const auto& sessionTzName = connectorQueryCtx->sessionTimezone();
   if (!sessionTzName.empty()) {
-    const auto timezone = date::locate_zone(sessionTzName);
+    const auto timezone = tz::locateZone(sessionTzName);
     readerOptions.setSessionTimezone(timezone);
   }
 

--- a/velox/core/Config.cpp
+++ b/velox/core/Config.cpp
@@ -51,7 +51,7 @@ bool MemConfigMutable::isValueExists(const std::string& key) const {
 void MemConfig::validateConfig() {
   // Validate if timezone name can be recognized.
   if (isValueExists(QueryConfig::kSessionTimezone)) {
-    util::getTimeZoneID(values_[QueryConfig::kSessionTimezone]);
+    tz::getTimeZoneID(values_[QueryConfig::kSessionTimezone]);
   }
 }
 

--- a/velox/docs/develop/scalar-functions.rst
+++ b/velox/docs/develop/scalar-functions.rst
@@ -332,7 +332,7 @@ properties and using it when processing inputs.
   struct HourFunction {
     VELOX_DEFINE_FUNCTION_TYPES(TExec);
 
-    const date::time_zone* timeZone_ = nullptr;
+    const tz::TimeZone* timeZone_ = nullptr;
 
     FOLLY_ALWAYS_INLINE void initialize(
         const std::vector<TypePtr>& inputTypes,
@@ -362,7 +362,7 @@ individual rows.
   struct DateTruncFunction {
     VELOX_DEFINE_FUNCTION_TYPES(TExec);
 
-    const date::time_zone* timeZone_ = nullptr;
+    const tz::TimeZone* timeZone_ = nullptr;
     std::optional<DateTimeUnit> unit_;
 
     FOLLY_ALWAYS_INLINE void initialize(

--- a/velox/docs/develop/timestamp.rst
+++ b/velox/docs/develop/timestamp.rst
@@ -134,7 +134,7 @@ On Linux, you can check the tzdata installed in your system by:
 
 Timezone conversions are done using special methods in the Timestamp class:
 ``Timestamp::toGMT()`` and ``Timestamp::toTimezone()``. They can take either a
-timezone ID or a date::time_zone pointer. Providing a date::time_zone is
+timezone ID or a tz::TimeZone pointer. Providing a tz::TimeZone is
 generally more efficient, but std::chrono does not handle time zone offsets
 such as ``+09:00``.  Timezone offsets are only supported in the API version
 that takes a timezone ID.

--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -77,6 +77,7 @@ velox_link_libraries(
   velox_exception
   velox_expression
   velox_memory
+  velox_type_tz
   Boost::regex
   Folly::folly
   glog::glog

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -34,8 +34,8 @@
 #include "velox/dwio/common/ScanSpec.h"
 #include "velox/dwio/common/UnitLoader.h"
 #include "velox/dwio/common/encryption/Encryption.h"
-#include "velox/external/date/tz.h"
 #include "velox/type/Timestamp.h"
+#include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox::dwio::common {
 
@@ -497,7 +497,7 @@ class ReaderOptions : public io::ReaderOptions {
     return *this;
   }
 
-  ReaderOptions& setSessionTimezone(const date::time_zone* sessionTimezone) {
+  ReaderOptions& setSessionTimezone(const tz::TimeZone* sessionTimezone) {
     sessionTimezone_ = sessionTimezone;
     return *this;
   }
@@ -541,7 +541,7 @@ class ReaderOptions : public io::ReaderOptions {
     return ioExecutor_;
   }
 
-  const date::time_zone* getSessionTimezone() const {
+  const tz::TimeZone* getSessionTimezone() const {
     return sessionTimezone_;
   }
 
@@ -590,7 +590,7 @@ class ReaderOptions : public io::ReaderOptions {
   std::shared_ptr<folly::Executor> ioExecutor_;
   std::shared_ptr<random::RandomSkipTracker> randomSkip_;
   std::shared_ptr<velox::common::ScanSpec> scanSpec_;
-  const date::time_zone* sessionTimezone_{nullptr};
+  const tz::TimeZone* sessionTimezone_{nullptr};
 };
 
 struct WriterOptions {

--- a/velox/dwio/parquet/reader/PageReader.h
+++ b/velox/dwio/parquet/reader/PageReader.h
@@ -42,7 +42,7 @@ class PageReader {
       ParquetTypeWithIdPtr fileType,
       common::CompressionKind codec,
       int64_t chunkSize,
-      const date::time_zone* sessionTimezone)
+      const tz::TimeZone* sessionTimezone)
       : pool_(pool),
         inputStream_(std::move(stream)),
         type_(std::move(fileType)),
@@ -62,7 +62,7 @@ class PageReader {
       memory::MemoryPool& pool,
       common::CompressionKind codec,
       int64_t chunkSize,
-      const date::time_zone* sessionTimezone = nullptr)
+      const tz::TimeZone* sessionTimezone = nullptr)
       : pool_(pool),
         inputStream_(std::move(stream)),
         maxRepeat_(0),
@@ -141,7 +141,7 @@ class PageReader {
   // bufferEnd_ to the corresponding positions.
   thrift::PageHeader readPageHeader();
 
-  const date::time_zone* sessionTimezone() const {
+  const tz::TimeZone* sessionTimezone() const {
     return sessionTimezone_;
   }
 
@@ -481,7 +481,7 @@ class PageReader {
   // Base values of dictionary when reading a string dictionary.
   VectorPtr dictionaryValues_;
 
-  const date::time_zone* sessionTimezone_{nullptr};
+  const tz::TimeZone* sessionTimezone_{nullptr};
 
   // Decoders. Only one will be set at a time.
   std::unique_ptr<dwio::common::DirectDecoder<true>> directDecoder_;

--- a/velox/dwio/parquet/reader/ParquetData.h
+++ b/velox/dwio/parquet/reader/ParquetData.h
@@ -36,7 +36,7 @@ class ParquetParams : public dwio::common::FormatParams {
       memory::MemoryPool& pool,
       dwio::common::ColumnReaderStatistics& stats,
       const FileMetaDataPtr metaData,
-      const date::time_zone* sessionTimezone,
+      const tz::TimeZone* sessionTimezone,
       TimestampPrecision timestampPrecision)
       : FormatParams(pool, stats),
         metaData_(metaData),
@@ -52,7 +52,7 @@ class ParquetParams : public dwio::common::FormatParams {
 
  private:
   const FileMetaDataPtr metaData_;
-  const date::time_zone* sessionTimezone_;
+  const tz::TimeZone* sessionTimezone_;
   const TimestampPrecision timestampPrecision_;
 };
 
@@ -63,7 +63,7 @@ class ParquetData : public dwio::common::FormatData {
       const std::shared_ptr<const dwio::common::TypeWithId>& type,
       const FileMetaDataPtr fileMetadataPtr,
       memory::MemoryPool& pool,
-      const date::time_zone* sessionTimezone)
+      const tz::TimeZone* sessionTimezone)
       : pool_(pool),
         type_(std::static_pointer_cast<const ParquetTypeWithId>(type)),
         fileMetaDataPtr_(fileMetadataPtr),
@@ -215,7 +215,7 @@ class ParquetData : public dwio::common::FormatData {
   const uint32_t maxDefine_;
   const uint32_t maxRepeat_;
   int64_t rowsInRowGroup_;
-  const date::time_zone* sessionTimezone_;
+  const tz::TimeZone* sessionTimezone_;
   std::unique_ptr<PageReader> reader_;
 
   // Nulls derived from leaf repdefs for non-leaf readers.

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -66,7 +66,7 @@ class ReaderBase {
     return options_.fileColumnNamesReadAsLowerCase();
   }
 
-  const date::time_zone* sessionTimezone() const {
+  const tz::TimeZone* sessionTimezone() const {
     return options_.getSessionTimezone();
   }
 

--- a/velox/dwio/parquet/tests/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/reader/CMakeLists.txt
@@ -66,8 +66,11 @@ add_test(
   COMMAND velox_dwio_parquet_reader_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(
-  velox_dwio_parquet_reader_test velox_dwio_native_parquet_reader
-  velox_dwio_parquet_reader_benchmark_lib velox_link_libs ${TEST_LINK_LIBS})
+  velox_dwio_parquet_reader_test
+  velox_dwio_native_parquet_reader
+  velox_dwio_parquet_reader_benchmark_lib
+  velox_link_libs
+  ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_parquet_structure_decoder_test
                NestedStructureDecoderTest.cpp)
@@ -97,6 +100,7 @@ target_link_libraries(
   velox_exec
   velox_hive_connector
   velox_link_libs
+  velox_type_tz
   ${TEST_LINK_LIBS})
 
 if(${VELOX_ENABLE_ARROW})
@@ -107,7 +111,10 @@ if(${VELOX_ENABLE_ARROW})
     COMMAND velox_dwio_parquet_rlebp_decoder_test
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   target_link_libraries(
-    velox_dwio_parquet_rlebp_decoder_test velox_dwio_native_parquet_reader
-    arrow velox_link_libs ${TEST_LINK_LIBS})
+    velox_dwio_parquet_rlebp_decoder_test
+    velox_dwio_native_parquet_reader
+    arrow
+    velox_link_libs
+    ${TEST_LINK_LIBS})
 
 endif()

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -17,17 +17,18 @@
 #include <folly/init/Init.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/connectors/hive/HiveConfig.h"
 #include "velox/dwio/common/tests/utils/DataFiles.h"
 #include "velox/dwio/parquet/RegisterParquetReader.h"
 #include "velox/dwio/parquet/reader/PageReader.h"
 #include "velox/dwio/parquet/reader/ParquetReader.h"
+#include "velox/dwio/parquet/writer/Writer.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/external/date/tz.h"
 #include "velox/type/tests/SubfieldFiltersBuilder.h"
-
-#include "velox/connectors/hive/HiveConfig.h"
-#include "velox/dwio/parquet/writer/Writer.h"
+#include "velox/type/tz/TimeZoneMap.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;

--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -59,6 +59,7 @@ velox_link_libraries(
   velox_common_base
   velox_expression_functions
   velox_functions_util
+  velox_type_tz
   double-conversion::double-conversion
   Folly::folly)
 

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -24,9 +24,9 @@
 #include "velox/expression/PeeledEncoding.h"
 #include "velox/expression/PrestoCastHooks.h"
 #include "velox/expression/ScopedVarSetter.h"
-#include "velox/external/date/tz.h"
 #include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/type/Type.h"
+#include "velox/type/tz/TimeZoneMap.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/FunctionVector.h"
 #include "velox/vector/SelectivityVector.h"
@@ -145,15 +145,17 @@ Status detail::parseHugeInt(
 }
 
 namespace {
-const date::time_zone* getTimeZoneFromConfig(const core::QueryConfig& config) {
+
+const tz::TimeZone* getTimeZoneFromConfig(const core::QueryConfig& config) {
   if (config.adjustTimestampToTimezone()) {
     const auto sessionTzName = config.sessionTimezone();
     if (!sessionTzName.empty()) {
-      return date::locate_zone(sessionTzName);
+      return tz::locateZone(sessionTzName);
     }
   }
   return nullptr;
 }
+
 } // namespace
 
 VectorPtr CastExpr::castFromDate(

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -20,9 +20,9 @@
 #include <folly/Expected.h>
 
 #include "velox/expression/PrestoCastHooks.h"
-#include "velox/external/date/tz.h"
 #include "velox/functions/lib/string/StringImpl.h"
 #include "velox/type/TimestampConversion.h"
+#include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox::exec {
 
@@ -33,7 +33,7 @@ PrestoCastHooks::PrestoCastHooks(const core::QueryConfig& config)
     options_.dateTimeSeparator = ' ';
     const auto sessionTzName = config.sessionTimezone();
     if (config.adjustTimestampToTimezone() && !sessionTzName.empty()) {
-      options_.timeZone = date::locate_zone(sessionTzName);
+      options_.timeZone = tz::locateZone(sessionTzName);
     }
   }
 }

--- a/velox/functions/lib/CMakeLists.txt
+++ b/velox/functions/lib/CMakeLists.txt
@@ -43,6 +43,7 @@ velox_link_libraries(
   velox_functions_lib
   velox_functions_util
   velox_vector
+  velox_type_tz
   re2::re2
   Folly::folly)
 

--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -320,14 +320,14 @@ int64_t parseTimezone(const char* cur, const char* end, Date& date) {
       static std::unordered_map<std::string_view, int64_t> defaultTzNames{
           {"UTC", 0},
           {"GMT", 0},
-          {"EST", util::getTimeZoneID("America/New_York")},
-          {"EDT", util::getTimeZoneID("America/New_York")},
-          {"CST", util::getTimeZoneID("America/Chicago")},
-          {"CDT", util::getTimeZoneID("America/Chicago")},
-          {"MST", util::getTimeZoneID("America/Denver")},
-          {"MDT", util::getTimeZoneID("America/Denver")},
-          {"PST", util::getTimeZoneID("America/Los_Angeles")},
-          {"PDT", util::getTimeZoneID("America/Los_Angeles")},
+          {"EST", tz::getTimeZoneID("America/New_York")},
+          {"EDT", tz::getTimeZoneID("America/New_York")},
+          {"CST", tz::getTimeZoneID("America/Chicago")},
+          {"CDT", tz::getTimeZoneID("America/Chicago")},
+          {"MST", tz::getTimeZoneID("America/Denver")},
+          {"MDT", tz::getTimeZoneID("America/Denver")},
+          {"PST", tz::getTimeZoneID("America/Los_Angeles")},
+          {"PDT", tz::getTimeZoneID("America/Los_Angeles")},
       };
 
       auto it = defaultTzNames.find(std::string_view(cur, 3));
@@ -362,8 +362,7 @@ int64_t parseTimezoneOffset(const char* cur, const char* end, Date& date) {
         if (std::strncmp(cur + 1, "00:00", 5) == 0) {
           date.timezoneId = 0;
         } else {
-          date.timezoneId =
-              util::getTimeZoneID(std::string_view(cur, 6), false);
+          date.timezoneId = tz::getTimeZoneID(std::string_view(cur, 6), false);
           if (date.timezoneId == -1) {
             return -1;
           }
@@ -381,7 +380,7 @@ int64_t parseTimezoneOffset(const char* cur, const char* end, Date& date) {
           // thread_local buffer to prevent extra allocations.
           std::memcpy(&timezoneBuffer[0], cur, 3);
           std::memcpy(&timezoneBuffer[4], cur + 3, 2);
-          date.timezoneId = util::getTimeZoneID(timezoneBuffer, false);
+          date.timezoneId = tz::getTimeZoneID(timezoneBuffer, false);
           if (date.timezoneId == -1) {
             return -1;
           }
@@ -399,7 +398,7 @@ int64_t parseTimezoneOffset(const char* cur, const char* end, Date& date) {
           // buffer to prevent extra allocations.
           std::memcpy(&timezoneBuffer[0], cur, 3);
           std::memcpy(&timezoneBuffer[4], defaultTrailingOffset, 2);
-          date.timezoneId = util::getTimeZoneID(timezoneBuffer, false);
+          date.timezoneId = tz::getTimeZoneID(timezoneBuffer, false);
           if (date.timezoneId == -1) {
             return -1;
           }
@@ -999,8 +998,7 @@ int32_t parseFromPattern(
 
 } // namespace
 
-uint32_t DateTimeFormatter::maxResultSize(
-    const date::time_zone* timezone) const {
+uint32_t DateTimeFormatter::maxResultSize(const tz::TimeZone* timezone) const {
   uint32_t size = 0;
   for (const auto& token : tokens_) {
     if (token.type == DateTimeToken::Type::kLiteral) {
@@ -1080,7 +1078,7 @@ uint32_t DateTimeFormatter::maxResultSize(
 
 int32_t DateTimeFormatter::format(
     const Timestamp& timestamp,
-    const date::time_zone* timezone,
+    const tz::TimeZone* timezone,
     const uint32_t maxResultSize,
     char* result,
     bool allowOverflow) const {

--- a/velox/functions/lib/DateTimeFormatter.h
+++ b/velox/functions/lib/DateTimeFormatter.h
@@ -181,7 +181,7 @@ class DateTimeFormatter {
 
   /// Returns max size of the formatted string. Can be used to preallocate
   /// memory before calling format() to avoid extra copy.
-  uint32_t maxResultSize(const date::time_zone* timezone) const;
+  uint32_t maxResultSize(const tz::TimeZone* timezone) const;
 
   /// Result buffer is pre-allocated according to maxResultSize.
   /// Returns actual size.
@@ -191,7 +191,7 @@ class DateTimeFormatter {
   /// allowed in converting to milliseconds.
   int32_t format(
       const Timestamp& timestamp,
-      const date::time_zone* timezone,
+      const tz::TimeZone* timezone,
       const uint32_t maxResultSize,
       char* result,
       bool allowOverflow = false) const;

--- a/velox/functions/lib/TimeUtils.h
+++ b/velox/functions/lib/TimeUtils.h
@@ -17,8 +17,8 @@
 
 #include <velox/type/Timestamp.h>
 #include "velox/core/QueryConfig.h"
-#include "velox/external/date/tz.h"
 #include "velox/functions/Macros.h"
+#include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox::functions {
 
@@ -26,19 +26,19 @@ inline constexpr int64_t kSecondsInDay = 86'400;
 inline constexpr int64_t kDaysInWeek = 7;
 extern const folly::F14FastMap<std::string, int8_t> kDayOfWeekNames;
 
-FOLLY_ALWAYS_INLINE const date::time_zone* getTimeZoneFromConfig(
+FOLLY_ALWAYS_INLINE const tz::TimeZone* getTimeZoneFromConfig(
     const core::QueryConfig& config) {
   if (config.adjustTimestampToTimezone()) {
     auto sessionTzName = config.sessionTimezone();
     if (!sessionTzName.empty()) {
-      return date::locate_zone(sessionTzName);
+      return tz::locateZone(sessionTzName);
     }
   }
   return nullptr;
 }
 
 FOLLY_ALWAYS_INLINE int64_t
-getSeconds(Timestamp timestamp, const date::time_zone* timeZone) {
+getSeconds(Timestamp timestamp, const tz::TimeZone* timeZone) {
   if (timeZone != nullptr) {
     timestamp.toTimezone(*timeZone);
     return timestamp.getSeconds();
@@ -48,7 +48,7 @@ getSeconds(Timestamp timestamp, const date::time_zone* timeZone) {
 }
 
 FOLLY_ALWAYS_INLINE
-std::tm getDateTime(Timestamp timestamp, const date::time_zone* timeZone) {
+std::tm getDateTime(Timestamp timestamp, const tz::TimeZone* timeZone) {
   int64_t seconds = getSeconds(timestamp, timeZone);
   std::tm dateTime;
   VELOX_USER_CHECK(
@@ -95,7 +95,7 @@ FOLLY_ALWAYS_INLINE int32_t getDayOfYear(const std::tm& time) {
 template <typename T>
 struct InitSessionTimezone {
   VELOX_DEFINE_FUNCTION_TYPES(T);
-  const date::time_zone* timeZone_{nullptr};
+  const tz::TimeZone* timeZone_{nullptr};
 
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,

--- a/velox/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/velox/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -15,7 +15,6 @@
  */
 #include "velox/functions/lib/DateTimeFormatter.h"
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/external/date/tz.h"
 #include "velox/functions/lib/DateTimeFormatterBuilder.h"
 #include "velox/type/TimestampConversion.h"
 #include "velox/type/tz/TimeZoneMap.h"
@@ -113,13 +112,13 @@ class DateTimeFormatterTest : public testing::Test {
     if (result.timezoneId == 0) {
       return "+00:00";
     }
-    return util::getTimeZoneName(result.timezoneId);
+    return tz::getTimeZoneName(result.timezoneId);
   }
 
   std::string formatMysqlDateTime(
       const std::string& format,
       const Timestamp& timestamp,
-      const date::time_zone* timezone) const {
+      const tz::TimeZone* timezone) const {
     auto formatter = buildMysqlDateTimeFormatter(format);
     const auto maxSize = formatter->maxResultSize(timezone);
     std::string result(maxSize, '\0');
@@ -1083,17 +1082,17 @@ TEST_F(JodaDateTimeFormatterTest, parseMixedYMDFormat) {
   // Include timezone.
   auto result = parseJoda("2021-11-05+01:00+09:00", "YYYY-MM-dd+HH:mmZZ");
   EXPECT_EQ(fromTimestampString("2021-11-05 01:00:00"), result.timestamp);
-  EXPECT_EQ("+09:00", util::getTimeZoneName(result.timezoneId));
+  EXPECT_EQ("+09:00", tz::getTimeZoneName(result.timezoneId));
 
   // Timezone offset in -hh:mm format.
   result = parseJoda("-07:232021-11-05+01:00", "ZZYYYY-MM-dd+HH:mm");
   EXPECT_EQ(fromTimestampString("2021-11-05 01:00:00"), result.timestamp);
-  EXPECT_EQ("-07:23", util::getTimeZoneName(result.timezoneId));
+  EXPECT_EQ("-07:23", tz::getTimeZoneName(result.timezoneId));
 
   // Timezone offset in +hhmm format.
   result = parseJoda("+01332022-03-08+13:00", "ZZYYYY-MM-dd+HH:mm");
   EXPECT_EQ(fromTimestampString("2022-03-08 13:00:00"), result.timestamp);
-  EXPECT_EQ("+01:33", util::getTimeZoneName(result.timezoneId));
+  EXPECT_EQ("+01:33", tz::getTimeZoneName(result.timezoneId));
 
   // Z in the input means GMT in Joda.
   EXPECT_EQ(
@@ -1104,7 +1103,7 @@ TEST_F(JodaDateTimeFormatterTest, parseMixedYMDFormat) {
   // Timezone in string format.
   result = parseJoda("2021-11-05+01:00 PST", "YYYY-MM-dd+HH:mm zz");
   EXPECT_EQ(fromTimestampString("2021-11-05 01:00:00"), result.timestamp);
-  EXPECT_EQ("America/Los_Angeles", util::getTimeZoneName(result.timezoneId));
+  EXPECT_EQ("America/Los_Angeles", tz::getTimeZoneName(result.timezoneId));
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseMixedWeekFormat) {
@@ -1226,17 +1225,17 @@ TEST_F(JodaDateTimeFormatterTest, parseMixedWeekFormat) {
   auto result =
       parseJoda("2021 22 1 13:29:21.213+09:00", "x w e HH:mm:ss.SSSZZ");
   EXPECT_EQ(fromTimestampString("2021-05-31 13:29:21.213"), result.timestamp);
-  EXPECT_EQ("+09:00", util::getTimeZoneName(result.timezoneId));
+  EXPECT_EQ("+09:00", tz::getTimeZoneName(result.timezoneId));
 
   // Timezone offset in -hh:mm format.
   result = parseJoda("-07:232021 22 1 13:29:21.213", "ZZx w e HH:mm:ss.SSS");
   EXPECT_EQ(fromTimestampString("2021-05-31 13:29:21.213"), result.timestamp);
-  EXPECT_EQ("-07:23", util::getTimeZoneName(result.timezoneId));
+  EXPECT_EQ("-07:23", tz::getTimeZoneName(result.timezoneId));
 
   // Timezone offset in +hhmm format.
   result = parseJoda("+01332021 22 1 13:29:21.213", "ZZx w e HH:mm:ss.SSS");
   EXPECT_EQ(fromTimestampString("2021-05-31 13:29:21.213"), result.timestamp);
-  EXPECT_EQ("+01:33", util::getTimeZoneName(result.timezoneId));
+  EXPECT_EQ("+01:33", tz::getTimeZoneName(result.timezoneId));
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseFractionOfSecond) {
@@ -1244,13 +1243,13 @@ TEST_F(JodaDateTimeFormatterTest, parseFractionOfSecond) {
   auto result =
       parseJoda("2022-02-23T12:15:00.364+04:00", "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
   EXPECT_EQ(fromTimestampString("2022-02-23 12:15:00.364"), result.timestamp);
-  EXPECT_EQ("+04:00", util::getTimeZoneName(result.timezoneId));
+  EXPECT_EQ("+04:00", tz::getTimeZoneName(result.timezoneId));
 
   // Valid milliseconds and timezone with negative offset.
   result =
       parseJoda("2022-02-23T12:15:00.776-14:00", "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
   EXPECT_EQ(fromTimestampString("2022-02-23 12:15:00.776"), result.timestamp);
-  EXPECT_EQ("-14:00", util::getTimeZoneName(result.timezoneId));
+  EXPECT_EQ("-14:00", tz::getTimeZoneName(result.timezoneId));
 
   // Valid milliseconds.
   EXPECT_EQ(
@@ -1315,7 +1314,7 @@ TEST_F(JodaDateTimeFormatterTest, parseConsecutiveSpecifiers) {
 }
 
 TEST_F(JodaDateTimeFormatterTest, formatResultSize) {
-  auto* timezone = date::locate_zone("GMT");
+  auto* timezone = tz::locateZone("GMT");
 
   EXPECT_EQ(
       buildJodaDateTimeFormatter("yyyy-MM-dd")->maxResultSize(timezone), 12);
@@ -1421,7 +1420,7 @@ TEST_F(MysqlDateTimeTest, invalidBuild) {
 }
 
 TEST_F(MysqlDateTimeTest, formatYear) {
-  auto* timezone = date::locate_zone("GMT");
+  auto* timezone = tz::locateZone("GMT");
   EXPECT_EQ(
       formatMysqlDateTime("%Y", fromTimestampString("0-01-01"), timezone),
       "0000");
@@ -1455,7 +1454,7 @@ TEST_F(MysqlDateTimeTest, formatYear) {
 }
 
 TEST_F(MysqlDateTimeTest, formatMonthDay) {
-  auto* timezone = date::locate_zone("GMT");
+  auto* timezone = tz::locateZone("GMT");
 
   EXPECT_EQ(
       formatMysqlDateTime("%m~%d", fromTimestampString("0-01-01"), timezone),
@@ -1498,7 +1497,7 @@ TEST_F(MysqlDateTimeTest, formatMonthDay) {
 }
 
 TEST_F(MysqlDateTimeTest, formatWeekday) {
-  auto* timezone = date::locate_zone("GMT");
+  auto* timezone = tz::locateZone("GMT");
 
   EXPECT_EQ(
       formatMysqlDateTime(
@@ -1531,7 +1530,7 @@ TEST_F(MysqlDateTimeTest, formatWeekday) {
 }
 
 TEST_F(MysqlDateTimeTest, formatMonth) {
-  auto* timezone = date::locate_zone("GMT");
+  auto* timezone = tz::locateZone("GMT");
 
   EXPECT_EQ(
       formatMysqlDateTime(
@@ -1584,7 +1583,7 @@ TEST_F(MysqlDateTimeTest, formatMonth) {
 }
 
 TEST_F(MysqlDateTimeTest, formatDayOfMonth) {
-  auto* timezone = date::locate_zone("GMT");
+  auto* timezone = tz::locateZone("GMT");
 
   EXPECT_EQ(
       formatMysqlDateTime("%d-%e", fromTimestampString("2000-02-01"), timezone),
@@ -1598,7 +1597,7 @@ TEST_F(MysqlDateTimeTest, formatDayOfMonth) {
 }
 
 TEST_F(MysqlDateTimeTest, formatFractionOfSecond) {
-  auto* timezone = date::locate_zone("GMT");
+  auto* timezone = tz::locateZone("GMT");
 
   EXPECT_EQ(
       formatMysqlDateTime(
@@ -1633,7 +1632,7 @@ TEST_F(MysqlDateTimeTest, formatFractionOfSecond) {
 }
 
 TEST_F(MysqlDateTimeTest, formatHour) {
-  auto* timezone = date::locate_zone("GMT");
+  auto* timezone = tz::locateZone("GMT");
 
   EXPECT_EQ(
       formatMysqlDateTime(
@@ -1656,7 +1655,7 @@ TEST_F(MysqlDateTimeTest, formatHour) {
 }
 
 TEST_F(MysqlDateTimeTest, formatMinute) {
-  auto* timezone = date::locate_zone("GMT");
+  auto* timezone = tz::locateZone("GMT");
 
   EXPECT_EQ(
       formatMysqlDateTime(
@@ -1677,7 +1676,7 @@ TEST_F(MysqlDateTimeTest, formatMinute) {
 }
 
 TEST_F(MysqlDateTimeTest, formatDayOfYear) {
-  auto* timezone = date::locate_zone("GMT");
+  auto* timezone = tz::locateZone("GMT");
 
   EXPECT_EQ(
       formatMysqlDateTime(
@@ -1694,7 +1693,7 @@ TEST_F(MysqlDateTimeTest, formatDayOfYear) {
 }
 
 TEST_F(MysqlDateTimeTest, formatAmPm) {
-  auto* timezone = date::locate_zone("GMT");
+  auto* timezone = tz::locateZone("GMT");
 
   EXPECT_EQ(
       formatMysqlDateTime(
@@ -1715,7 +1714,7 @@ TEST_F(MysqlDateTimeTest, formatAmPm) {
 }
 
 TEST_F(MysqlDateTimeTest, formatSecond) {
-  auto* timezone = date::locate_zone("GMT");
+  auto* timezone = tz::locateZone("GMT");
 
   EXPECT_EQ(
       formatMysqlDateTime(
@@ -1732,7 +1731,7 @@ TEST_F(MysqlDateTimeTest, formatSecond) {
 }
 
 TEST_F(MysqlDateTimeTest, formatCompositeTime) {
-  auto* timezone = date::locate_zone("GMT");
+  auto* timezone = tz::locateZone("GMT");
 
   // 12 hour %r
   EXPECT_EQ(

--- a/velox/functions/prestosql/aggregates/tests/PrestoHasherTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/PrestoHasherTest.cpp
@@ -406,7 +406,7 @@ TEST_F(PrestoHasherTest, timestampWithTimezone) {
           if (timestampWithTimeZone.has_value()) {
             auto timestamp = timestampWithTimeZone.value().first;
             auto tz = timestampWithTimeZone.value().second;
-            const int16_t tzid = util::getTimeZoneID(tz);
+            const int16_t tzid = tz::getTimeZoneID(tz);
             auto timestampWithTimezone = pack(timestamp, tzid);
             timestampWithTimeZoneVector.push_back(timestampWithTimezone);
             bits::clearNull(rawNulls, i);

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -69,7 +69,7 @@ target_link_libraries(velox_functions_prestosql_benchmarks_not
 add_executable(velox_functions_prestosql_benchmarks_date_time
                DateTimeBenchmark.cpp)
 target_link_libraries(velox_functions_prestosql_benchmarks_date_time
-                      ${BENCHMARK_DEPENDENCIES})
+                      velox_type_tz ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_prestosql_benchmarks_bitwise
                BitwiseBenchmark.cpp)

--- a/velox/functions/prestosql/benchmarks/DateTimeBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/DateTimeBenchmark.cpp
@@ -16,9 +16,9 @@
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 #include "velox/expression/VectorFunction.h"
-#include "velox/external/date/tz.h"
 #include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/type/tz/TimeZoneMap.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
 using namespace facebook::velox;
@@ -28,13 +28,13 @@ namespace {
 
 class HourFunction : public exec::VectorFunction {
  public:
-  const date::time_zone* FOLLY_NULLABLE
+  const tz::TimeZone* FOLLY_NULLABLE
   getTimeZoneIfNeeded(const core::QueryConfig& config) const {
-    const date::time_zone* timeZone = nullptr;
+    const tz::TimeZone* timeZone = nullptr;
     if (config.adjustTimestampToTimezone()) {
       auto sessionTzName = config.sessionTimezone();
       if (!sessionTzName.empty()) {
-        timeZone = date::locate_zone(sessionTzName);
+        timeZone = tz::locateZone(sessionTzName);
       }
     }
     return timeZone;

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -89,9 +89,8 @@ class DateTimeFunctionsTest : public functions::test::FunctionBaseTest {
         : milliSeconds_(milliSeconds), timezoneId_(timezoneId) {}
 
     TimestampWithTimezone(int64_t milliSeconds, std::string_view timezoneName)
-        : TimestampWithTimezone{
-              milliSeconds,
-              util::getTimeZoneID(timezoneName)} {}
+        : TimestampWithTimezone{milliSeconds, tz::getTimeZoneID(timezoneName)} {
+    }
 
     int64_t milliSeconds_{0};
     int16_t timezoneId_{0};
@@ -196,7 +195,7 @@ class DateTimeFunctionsTest : public functions::test::FunctionBaseTest {
   }
 
   VectorPtr makeTimestampWithTimeZoneVector(int64_t timestamp, const char* tz) {
-    auto tzid = util::getTimeZoneID(tz);
+    auto tzid = tz::getTimeZoneID(tz);
 
     return makeNullableFlatVector<int64_t>(
         {pack(timestamp, tzid)}, TIMESTAMP_WITH_TIME_ZONE());
@@ -3633,7 +3632,7 @@ TEST_F(DateTimeFunctionsTest, fromIso8601Timestamp) {
   for (const auto& timezone : timezones) {
     setQueryTimeZone(timezone.name);
 
-    const auto timezoneId = util::getTimeZoneID(timezone.name);
+    const auto timezoneId = tz::getTimeZoneID(timezone.name);
 
     EXPECT_EQ(
         TimestampWithTimezone(
@@ -4444,7 +4443,7 @@ TEST_F(DateTimeFunctionsTest, toISO8601Timestamp) {
 
 TEST_F(DateTimeFunctionsTest, toISO8601TimestampWithTimezone) {
   const auto toIso = [&](const char* timestamp, const char* timezone) {
-    const auto tzId = util::getTimeZoneID(timezone);
+    const auto tzId = tz::getTimeZoneID(timezone);
     auto ts = parseTimestamp(timestamp);
     ts.toGMT(tzId);
 
@@ -4484,31 +4483,31 @@ TEST_F(DateTimeFunctionsTest, atTimezoneTest) {
 
   EXPECT_EQ(
       at_timezone(
-          pack(1500101514, util::getTimeZoneID("Asia/Kathmandu")),
+          pack(1500101514, tz::getTimeZoneID("Asia/Kathmandu")),
           "America/Boise"),
-      pack(1500101514, util::getTimeZoneID("America/Boise")));
+      pack(1500101514, tz::getTimeZoneID("America/Boise")));
 
   EXPECT_EQ(
       at_timezone(
-          pack(1500101514, util::getTimeZoneID("America/Boise")),
+          pack(1500101514, tz::getTimeZoneID("America/Boise")),
           "Europe/London"),
-      pack(1500101514, util::getTimeZoneID("Europe/London")));
+      pack(1500101514, tz::getTimeZoneID("Europe/London")));
 
   EXPECT_EQ(
       at_timezone(
-          pack(1500321297, util::getTimeZoneID("Canada/Yukon")),
+          pack(1500321297, tz::getTimeZoneID("Canada/Yukon")),
           "Australia/Melbourne"),
-      pack(1500321297, util::getTimeZoneID("Australia/Melbourne")));
+      pack(1500321297, tz::getTimeZoneID("Australia/Melbourne")));
 
   EXPECT_EQ(
       at_timezone(
-          pack(1500321297, util::getTimeZoneID("Atlantic/Bermuda")),
+          pack(1500321297, tz::getTimeZoneID("Atlantic/Bermuda")),
           "Pacific/Fiji"),
-      pack(1500321297, util::getTimeZoneID("Pacific/Fiji")));
+      pack(1500321297, tz::getTimeZoneID("Pacific/Fiji")));
 
   EXPECT_EQ(
       at_timezone(
-          pack(1500321297, util::getTimeZoneID("Atlantic/Bermuda")),
+          pack(1500321297, tz::getTimeZoneID("Atlantic/Bermuda")),
           std::nullopt),
       std::nullopt);
 

--- a/velox/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
+++ b/velox/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
@@ -89,11 +89,11 @@ TEST_F(TimestampWithTimeZoneCastTest, fromVarchar) {
 
   auto timezones = std::vector<TimeZoneKey>{
       {0,
-       (int16_t)util::getTimeZoneID("America/Denver"),
-       (int16_t)util::getTimeZoneID("-06:00"),
-       (int16_t)util::getTimeZoneID("Europe/Vienna"),
-       (int16_t)util::getTimeZoneID("Pacific/Chatham"),
-       (int16_t)util::getTimeZoneID("+13:45")}};
+       (int16_t)tz::getTimeZoneID("America/Denver"),
+       (int16_t)tz::getTimeZoneID("-06:00"),
+       (int16_t)tz::getTimeZoneID("Europe/Vienna"),
+       (int16_t)tz::getTimeZoneID("Pacific/Chatham"),
+       (int16_t)tz::getTimeZoneID("+13:45")}};
 
   const auto expected = makeTimestampWithTimeZoneVector(
       timestamps.size(),
@@ -111,13 +111,13 @@ TEST_F(TimestampWithTimeZoneCastTest, toVarchar) {
   auto input = makeFlatVector<int64_t>(
       {
           // -5 hours.
-          pack(utcMillis, util::getTimeZoneID("America/New_York")),
+          pack(utcMillis, tz::getTimeZoneID("America/New_York")),
           // -8 hours.
-          pack(utcMillis, util::getTimeZoneID("America/Los_Angeles")),
+          pack(utcMillis, tz::getTimeZoneID("America/Los_Angeles")),
           // +8 hours.
-          pack(utcMillis, util::getTimeZoneID("Asia/Shanghai")),
+          pack(utcMillis, tz::getTimeZoneID("Asia/Shanghai")),
           // +5:30 hours.
-          pack(utcMillis, util::getTimeZoneID("Asia/Calcutta")),
+          pack(utcMillis, tz::getTimeZoneID("Asia/Calcutta")),
       },
       TIMESTAMP_WITH_TIME_ZONE());
 
@@ -142,7 +142,7 @@ TEST_F(TimestampWithTimeZoneCastTest, fromVarcharWithoutTimezone) {
   auto timestamps = std::vector<int64_t>{denverUTC};
 
   auto timezones =
-      std::vector<TimeZoneKey>{(int16_t)util::getTimeZoneID("America/Denver")};
+      std::vector<TimeZoneKey>{(int16_t)tz::getTimeZoneID("America/Denver")};
 
   const auto expected = makeTimestampWithTimeZoneVector(
       timestamps.size(),
@@ -169,7 +169,7 @@ TEST_F(TimestampWithTimeZoneCastTest, fromVarcharInvalidInput) {
   auto timestamps = std::vector<int64_t>{millis};
 
   auto timezones =
-      std::vector<TimeZoneKey>{(int16_t)util::getTimeZoneID("America/Denver")};
+      std::vector<TimeZoneKey>{(int16_t)tz::getTimeZoneID("America/Denver")};
 
   const auto expected = makeTimestampWithTimeZoneVector(
       timestamps.size(),
@@ -233,14 +233,14 @@ TEST_F(TimestampWithTimeZoneCastTest, toDate) {
       {
           // 6AM UTC is 1AM EST (same day), 10PM PST (previous day), 2PM CST
           // (same day).
-          pack(6 * kMillisInHour, util::getTimeZoneID("America/New_York")),
-          pack(6 * kMillisInHour, util::getTimeZoneID("America/Los_Angeles")),
-          pack(6 * kMillisInHour, util::getTimeZoneID("Asia/Shanghai")),
+          pack(6 * kMillisInHour, tz::getTimeZoneID("America/New_York")),
+          pack(6 * kMillisInHour, tz::getTimeZoneID("America/Los_Angeles")),
+          pack(6 * kMillisInHour, tz::getTimeZoneID("Asia/Shanghai")),
           // 6PM UTC is 1PM EST (same day), 10AM PST (same day), 2AM CST (next
           // day).
-          pack(18 * kMillisInHour, util::getTimeZoneID("America/New_York")),
-          pack(18 * kMillisInHour, util::getTimeZoneID("America/Los_Angeles")),
-          pack(18 * kMillisInHour, util::getTimeZoneID("Asia/Shanghai")),
+          pack(18 * kMillisInHour, tz::getTimeZoneID("America/New_York")),
+          pack(18 * kMillisInHour, tz::getTimeZoneID("America/Los_Angeles")),
+          pack(18 * kMillisInHour, tz::getTimeZoneID("Asia/Shanghai")),
       },
       TIMESTAMP_WITH_TIME_ZONE());
   auto expected = makeFlatVector<int32_t>({0, -1, 0, 0, 0, 1}, DATE());
@@ -262,7 +262,7 @@ TEST_F(TimestampWithTimeZoneCastTest, fromDate) {
 
   setQueryTimeZone("America/New_York");
 
-  auto tzId = util::getTimeZoneID("America/New_York");
+  auto tzId = tz::getTimeZoneID("America/New_York");
   auto tzOffset = -5 * kMillisInHour;
   auto expected = makeFlatVector<int64_t>(
       {
@@ -277,7 +277,7 @@ TEST_F(TimestampWithTimeZoneCastTest, fromDate) {
 
   setQueryTimeZone("Asia/Shanghai");
 
-  tzId = util::getTimeZoneID("Asia/Shanghai");
+  tzId = tz::getTimeZoneID("Asia/Shanghai");
   tzOffset = 8 * kMillisInHour;
   expected = makeFlatVector<int64_t>(
       {

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.cpp
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.cpp
@@ -27,7 +27,7 @@ int64_t getTimeZoneIDFromConfig(const core::QueryConfig& config) {
   const auto sessionTzName = config.sessionTimezone();
 
   if (!sessionTzName.empty()) {
-    return util::getTimeZoneID(sessionTzName);
+    return tz::getTimeZoneID(sessionTzName);
   }
 
   return 0;
@@ -117,8 +117,7 @@ void castToString(
 
     const auto timestamp = unpackTimestampUtc(timestampWithTimezone);
     const auto timeZoneId = unpackZoneKeyId(timestampWithTimezone);
-    const auto* timezonePtr =
-        date::locate_zone(util::getTimeZoneName(timeZoneId));
+    const auto* timezonePtr = tz::locateZone(tz::getTimeZoneName(timeZoneId));
 
     exec::StringWriter<false> result(flatResult, row);
 

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
@@ -149,4 +149,5 @@ inline int64_t pack(const Timestamp& timestamp, int16_t timeZoneKey) {
 inline Timestamp unpackTimestampUtc(int64_t dateTimeWithTimeZone) {
   return Timestamp::fromMillis(unpackMillisUtc(dateTimeWithTimeZone));
 }
+
 } // namespace facebook::velox

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -178,7 +178,7 @@ struct UnixTimestampParseFunction {
   void setTimezone(const core::QueryConfig& config) {
     auto sessionTzName = config.sessionTimezone();
     if (!sessionTzName.empty()) {
-      sessionTzID_ = util::getTimeZoneID(sessionTzName);
+      sessionTzID_ = tz::getTimeZoneID(sessionTzName);
     }
   }
 
@@ -291,7 +291,7 @@ struct FromUnixtimeFunction {
     maxResultSize_ = formatter_->maxResultSize(sessionTimeZone_);
   }
 
-  const date::time_zone* sessionTimeZone_{nullptr};
+  const tz::TimeZone* sessionTimeZone_{nullptr};
   std::shared_ptr<DateTimeFormatter> formatter_;
   uint32_t maxResultSize_;
   bool isConstantTimeFormat_{false};
@@ -307,7 +307,7 @@ struct ToUtcTimestampFunction {
       const arg_type<Varchar>* /*input*/,
       const arg_type<Varchar>* timezone) {
     if (timezone) {
-      tzID_ = util::getTimeZoneID(
+      tzID_ = tz::getTimeZoneID(
           std::string_view((*timezone).data(), (*timezone).size()), false);
     }
   }
@@ -319,7 +319,7 @@ struct ToUtcTimestampFunction {
     result = timestamp;
     auto fromTimezoneID = tzID_
         ? tzID_.value()
-        : util::getTimeZoneID(
+        : tz::getTimeZoneID(
               std::string_view(timezone.data(), timezone.size()), false);
     VELOX_USER_CHECK_NE(
         fromTimezoneID, -1, "Unknown time zone: '{}'", timezone);
@@ -340,7 +340,7 @@ struct FromUtcTimestampFunction {
       const arg_type<Varchar>* /*input*/,
       const arg_type<Varchar>* timezone) {
     if (timezone) {
-      tzID_ = util::getTimeZoneID(
+      tzID_ = tz::getTimeZoneID(
           std::string_view((*timezone).data(), (*timezone).size()), false);
     }
   }
@@ -352,7 +352,7 @@ struct FromUtcTimestampFunction {
     result = timestamp;
     auto toTimezoneID = tzID_
         ? tzID_.value()
-        : util::getTimeZoneID(
+        : tz::getTimeZoneID(
               std::string_view(timezone.data(), timezone.size()), false);
     VELOX_USER_CHECK_NE(toTimezoneID, -1, "Unknown time zone: '{}'", timezone);
     result.toTimezone(toTimezoneID);
@@ -374,7 +374,7 @@ struct GetTimestampFunction {
       const arg_type<Varchar>* format) {
     auto sessionTimezoneName = config.sessionTimezone();
     if (!sessionTimezoneName.empty()) {
-      sessionTimezoneId_ = util::getTimeZoneID(sessionTimezoneName);
+      sessionTimezoneId_ = tz::getTimeZoneID(sessionTimezoneName);
     }
     if (format != nullptr) {
       formatter_ = buildJodaDateTimeFormatter(

--- a/velox/functions/sparksql/MakeTimestamp.cpp
+++ b/velox/functions/sparksql/MakeTimestamp.cpp
@@ -73,7 +73,7 @@ void setTimestampOrNull(
     DecodedVector* timeZoneVector,
     FlatVector<Timestamp>* result) {
   const auto timeZone = timeZoneVector->valueAt<StringView>(row);
-  const auto tzID = util::getTimeZoneID(std::string_view(timeZone));
+  const auto tzID = tz::getTimeZoneID(std::string_view(timeZone));
   if (timestamp.has_value()) {
     (*timestamp).toGMT(tzID);
     result->set(row, *timestamp);
@@ -124,7 +124,7 @@ class MakeTimestampFunction : public exec::VectorFunction {
             args[6]->asUnchecked<ConstantVector<StringView>>()->valueAt(0);
         int64_t constantTzID;
         try {
-          constantTzID = util::getTimeZoneID(std::string_view(tz));
+          constantTzID = tz::getTimeZoneID(std::string_view(tz));
         } catch (const VeloxException&) {
           context.setErrors(rows, std::current_exception());
           return;
@@ -190,7 +190,7 @@ std::shared_ptr<exec::VectorFunction> createMakeTimestampFunction(
   VELOX_USER_CHECK(
       !sessionTzName.empty(),
       "make_timestamp requires session time zone to be set.")
-  const auto sessionTzID = util::getTimeZoneID(sessionTzName);
+  const auto sessionTzID = tz::getTimeZoneID(sessionTzName);
 
   const auto& secondsType = inputArgs[5].type;
   VELOX_USER_CHECK(

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -57,7 +57,7 @@ Timestamp Timestamp::now() {
   return fromMillis(epochMs);
 }
 
-void Timestamp::toGMT(const date::time_zone& zone) {
+void Timestamp::toGMT(const tz::TimeZone& zone) {
   // Magic number -2^39 + 24*3600. This number and any number lower than that
   // will cause time_zone::to_sys() to SIGABRT. We don't want that to happen.
   VELOX_USER_CHECK_GT(
@@ -94,7 +94,7 @@ void Timestamp::toGMT(int16_t tzID) {
     seconds_ -= getPrestoTZOffsetInSeconds(tzID);
   } else {
     // Other ids go this path.
-    toGMT(*date::locate_zone(util::getTimeZoneName(tzID)));
+    toGMT(*tz::locateZone(tz::getTimeZoneName(tzID)));
   }
 }
 
@@ -130,7 +130,7 @@ Timestamp::toTimePoint(bool allowOverflow) const {
   return tp;
 }
 
-void Timestamp::toTimezone(const date::time_zone& zone, bool allowOverflow) {
+void Timestamp::toTimezone(const tz::TimeZone& zone, bool allowOverflow) {
   auto tp = toTimePoint(allowOverflow);
 
   try {
@@ -153,18 +153,18 @@ void Timestamp::toTimezone(int16_t tzID) {
     seconds_ += getPrestoTZOffsetInSeconds(tzID);
   } else {
     // Other ids go this path.
-    toTimezone(*date::locate_zone(util::getTimeZoneName(tzID)));
+    toTimezone(*tz::locateZone(tz::getTimeZoneName(tzID)));
   }
 }
 
-const date::time_zone& Timestamp::defaultTimezone() {
-  static const date::time_zone* kDefault = ({
+const tz::TimeZone& Timestamp::defaultTimezone() {
+  static const tz::TimeZone* kDefault = ({
     // TODO: We are hard-coding PST/PDT here to be aligned with the current
     // behavior in DWRF reader/writer.  Once they are fixed, we can use
     // date::current_zone() here.
     //
     // See https://github.com/facebookincubator/velox/issues/8127
-    auto* tz = date::locate_zone("America/Los_Angeles");
+    auto* tz = tz::locateZone("America/Los_Angeles");
     VELOX_CHECK_NOT_NULL(tz);
     tz;
   });

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -23,12 +23,9 @@
 
 #include "velox/common/base/CheckedArithmetic.h"
 #include "velox/type/StringView.h"
+#include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox {
-
-namespace date {
-class time_zone;
-}
 
 enum class TimestampPrecision : int8_t {
   kMilliseconds = 3, // 10^3 milliseconds are equal to one second.
@@ -70,7 +67,7 @@ struct TimestampToStringOptions {
 
   Mode mode = Mode::kFull;
 
-  const date::time_zone* timeZone = nullptr;
+  const tz::TimeZone* timeZone = nullptr;
 };
 
 /// Returns the max length of a converted string from timestamp.
@@ -323,7 +320,7 @@ struct Timestamp {
   // Example: Timestamp ts{0, 0};
   // ts.Timezone("America/Los_Angeles");
   // ts.toString() returns January 1, 1970 08:00:00
-  void toGMT(const date::time_zone& zone);
+  void toGMT(const tz::TimeZone& zone);
 
   // Same as above, but accepts PrestoDB time zone ID.
   void toGMT(int16_t tzID);
@@ -335,13 +332,13 @@ struct Timestamp {
   /// Example: Timestamp ts{0, 0};
   /// ts.Timezone("America/Los_Angeles");
   /// ts.toString() returns December 31, 1969 16:00:00
-  void toTimezone(const date::time_zone& zone, bool allowOverflow = false);
+  void toTimezone(const tz::TimeZone& zone, bool allowOverflow = false);
 
   // Same as above, but accepts PrestoDB time zone ID.
   void toTimezone(int16_t tzID);
 
   /// A default time zone that is same across the process.
-  static const date::time_zone& defaultTimezone();
+  static const tz::TimeZone& defaultTimezone();
 
   bool operator==(const Timestamp& b) const {
     return seconds_ == b.seconds_ && nanos_ == b.nanos_;

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -754,7 +754,7 @@ Expected<std::pair<Timestamp, int16_t>> fromTimestampWithTimezoneString(
 
     std::string_view timezone(str + pos, timezonePos - pos);
 
-    if ((timezoneID = util::getTimeZoneID(timezone, false)) == -1) {
+    if ((timezoneID = tz::getTimeZoneID(timezone, false)) == -1) {
       return folly::makeUnexpected(
           Status::UserError("Unknown timezone value: \"{}\"", timezone));
     }
@@ -772,7 +772,7 @@ Expected<std::pair<Timestamp, int16_t>> fromTimestampWithTimezoneString(
   return std::make_pair(resultTimestamp, timezoneID);
 }
 
-int32_t toDate(const Timestamp& timestamp, const date::time_zone* timeZone_) {
+int32_t toDate(const Timestamp& timestamp, const tz::TimeZone* timeZone_) {
   auto convertToDate = [](const Timestamp& t) -> int32_t {
     static const int32_t kSecsPerDay{86'400};
     auto seconds = t.getSeconds();

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -220,6 +220,6 @@ Timestamp fromDatetime(int64_t daysSinceEpoch, int64_t microsSinceMidnight);
 
 /// Returns the number of days since epoch for a given timestamp and optional
 /// time zone.
-int32_t toDate(const Timestamp& timestamp, const date::time_zone* timeZone_);
+int32_t toDate(const Timestamp& timestamp, const tz::TimeZone* timeZone_);
 
 } // namespace facebook::velox::util

--- a/velox/type/tests/CMakeLists.txt
+++ b/velox/type/tests/CMakeLists.txt
@@ -32,7 +32,6 @@ target_link_libraries(
   velox_type_test
   velox_type
   velox_common_base
-  velox_external_date
   Folly::folly
   gtest
   gtest_main

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -18,7 +18,6 @@
 #include <gmock/gmock.h>
 #include "velox/common/base/VeloxException.h"
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/external/date/tz.h"
 #include "velox/type/Timestamp.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
@@ -255,27 +254,27 @@ TEST(DateTimeUtilTest, fromTimestampWithTimezoneString) {
   // Test timezone offsets.
   EXPECT_EQ(
       parseTimestampWithTimezone("1970-01-01 00:00:00 -02:00"),
-      std::make_pair(Timestamp(0, 0), util::getTimeZoneID("-02:00")));
+      std::make_pair(Timestamp(0, 0), tz::getTimeZoneID("-02:00")));
   EXPECT_EQ(
       parseTimestampWithTimezone("1970-01-01 00:00:00+13:36"),
-      std::make_pair(Timestamp(0, 0), util::getTimeZoneID("+13:36")));
+      std::make_pair(Timestamp(0, 0), tz::getTimeZoneID("+13:36")));
 
   EXPECT_EQ(
       parseTimestampWithTimezone("1970-01-01 00:00:00Z"),
-      std::make_pair(Timestamp(0, 0), util::getTimeZoneID("UTC")));
+      std::make_pair(Timestamp(0, 0), tz::getTimeZoneID("UTC")));
 
   EXPECT_EQ(
       parseTimestampWithTimezone("1970-01-01 00:01:00 UTC"),
-      std::make_pair(Timestamp(60, 0), util::getTimeZoneID("UTC")));
+      std::make_pair(Timestamp(60, 0), tz::getTimeZoneID("UTC")));
 
   EXPECT_EQ(
       parseTimestampWithTimezone("1970-01-01 00:00:01 America/Los_Angeles"),
       std::make_pair(
-          Timestamp(1, 0), util::getTimeZoneID("America/Los_Angeles")));
+          Timestamp(1, 0), tz::getTimeZoneID("America/Los_Angeles")));
 }
 
 TEST(DateTimeUtilTest, toGMT) {
-  auto* laZone = date::locate_zone("America/Los_Angeles");
+  auto* laZone = tz::locateZone("America/Los_Angeles");
 
   // The GMT time when LA gets to "1970-01-01 00:00:00" (8h ahead).
   auto ts = parseTimestamp("1970-01-01 00:00:00");
@@ -292,12 +291,12 @@ TEST(DateTimeUtilTest, toGMT) {
 
   // To Sao Paulo:
   tsCopy = ts;
-  tsCopy.toGMT(*date::locate_zone("America/Sao_Paulo"));
+  tsCopy.toGMT(*tz::locateZone("America/Sao_Paulo"));
   EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 07:23:37"));
 
   // Moscow:
   tsCopy = ts;
-  tsCopy.toGMT(*date::locate_zone("Europe/Moscow"));
+  tsCopy.toGMT(*tz::locateZone("Europe/Moscow"));
   EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 01:23:37"));
 
   // Probe LA's daylight savings boundary (starts at 2021-13-14 02:00am).
@@ -326,7 +325,7 @@ TEST(DateTimeUtilTest, toGMT) {
 }
 
 TEST(DateTimeUtilTest, toTimezone) {
-  auto* laZone = date::locate_zone("America/Los_Angeles");
+  auto* laZone = tz::locateZone("America/Los_Angeles");
 
   // The LA time when GMT gets to "1970-01-01 00:00:00" (8h behind).
   auto ts = parseTimestamp("1970-01-01 00:00:00");
@@ -343,12 +342,12 @@ TEST(DateTimeUtilTest, toTimezone) {
 
   // To Sao Paulo:
   tsCopy = ts;
-  tsCopy.toTimezone(*date::locate_zone("America/Sao_Paulo"));
+  tsCopy.toTimezone(*tz::locateZone("America/Sao_Paulo"));
   EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 01:23:37"));
 
   // Moscow:
   tsCopy = ts;
-  tsCopy.toTimezone(*date::locate_zone("Europe/Moscow"));
+  tsCopy.toTimezone(*tz::locateZone("Europe/Moscow"));
   EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 07:23:37"));
 
   // Probe LA's daylight savings boundary (starts at 2021-13-14 02:00am).
@@ -366,7 +365,7 @@ TEST(DateTimeUtilTest, toTimezone) {
 TEST(DateTimeUtilTest, toGMTFromID) {
   // The GMT time when LA gets to "1970-01-01 00:00:00" (8h ahead).
   auto ts = parseTimestamp("1970-01-01 00:00:00");
-  ts.toGMT(util::getTimeZoneID("America/Los_Angeles"));
+  ts.toGMT(tz::getTimeZoneID("America/Los_Angeles"));
   EXPECT_EQ(ts, parseTimestamp("1970-01-01 08:00:00"));
 
   // Set on a random date/time and try some variations.
@@ -374,26 +373,26 @@ TEST(DateTimeUtilTest, toGMTFromID) {
 
   // To LA:
   auto tsCopy = ts;
-  tsCopy.toGMT(util::getTimeZoneID("America/Los_Angeles"));
+  tsCopy.toGMT(tz::getTimeZoneID("America/Los_Angeles"));
   EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 11:23:37"));
 
   // To Sao Paulo:
   tsCopy = ts;
-  tsCopy.toGMT(util::getTimeZoneID("America/Sao_Paulo"));
+  tsCopy.toGMT(tz::getTimeZoneID("America/Sao_Paulo"));
   EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 07:23:37"));
 
   // Moscow:
   tsCopy = ts;
-  tsCopy.toGMT(util::getTimeZoneID("Europe/Moscow"));
+  tsCopy.toGMT(tz::getTimeZoneID("Europe/Moscow"));
   EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 01:23:37"));
 
   // Numerical time zones: +HH:MM and -HH:MM
   tsCopy = ts;
-  tsCopy.toGMT(util::getTimeZoneID("+14:00"));
+  tsCopy.toGMT(tz::getTimeZoneID("+14:00"));
   EXPECT_EQ(tsCopy, parseTimestamp("2020-04-22 14:23:37"));
 
   tsCopy = ts;
-  tsCopy.toGMT(util::getTimeZoneID("-14:00"));
+  tsCopy.toGMT(tz::getTimeZoneID("-14:00"));
   EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 18:23:37"));
 
   tsCopy = ts;
@@ -401,29 +400,29 @@ TEST(DateTimeUtilTest, toGMTFromID) {
   EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 04:23:37"));
 
   tsCopy = ts;
-  tsCopy.toGMT(util::getTimeZoneID("-00:01"));
+  tsCopy.toGMT(tz::getTimeZoneID("-00:01"));
   EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 04:24:37"));
 
   tsCopy = ts;
-  tsCopy.toGMT(util::getTimeZoneID("+00:01"));
+  tsCopy.toGMT(tz::getTimeZoneID("+00:01"));
   EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 04:22:37"));
 
   // Probe LA's daylight savings boundary (starts at 2021-13-14 02:00am).
   // Before it starts, 8h offset:
   ts = parseTimestamp("2021-03-14 00:00:00");
-  ts.toGMT(util::getTimeZoneID("America/Los_Angeles"));
+  ts.toGMT(tz::getTimeZoneID("America/Los_Angeles"));
   EXPECT_EQ(ts, parseTimestamp("2021-03-14 08:00:00"));
 
   // After it starts, 7h offset:
   ts = parseTimestamp("2021-03-15 00:00:00");
-  ts.toGMT(util::getTimeZoneID("America/Los_Angeles"));
+  ts.toGMT(tz::getTimeZoneID("America/Los_Angeles"));
   EXPECT_EQ(ts, parseTimestamp("2021-03-15 07:00:00"));
 }
 
 TEST(DateTimeUtilTest, toTimezoneFromID) {
   // The LA time when GMT gets to "1970-01-01 00:00:00" (8h behind).
   auto ts = parseTimestamp("1970-01-01 00:00:00");
-  ts.toTimezone(util::getTimeZoneID("America/Los_Angeles"));
+  ts.toTimezone(tz::getTimeZoneID("America/Los_Angeles"));
   EXPECT_EQ(ts, parseTimestamp("1969-12-31 16:00:00"));
 
   // Set on a random date/time and try some variations.
@@ -431,26 +430,26 @@ TEST(DateTimeUtilTest, toTimezoneFromID) {
 
   // To LA:
   auto tsCopy = ts;
-  tsCopy.toTimezone(util::getTimeZoneID("America/Los_Angeles"));
+  tsCopy.toTimezone(tz::getTimeZoneID("America/Los_Angeles"));
   EXPECT_EQ(tsCopy, parseTimestamp("2020-04-22 21:23:37"));
 
   // To Sao Paulo:
   tsCopy = ts;
-  tsCopy.toTimezone(util::getTimeZoneID("America/Sao_Paulo"));
+  tsCopy.toTimezone(tz::getTimeZoneID("America/Sao_Paulo"));
   EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 01:23:37"));
 
   // Moscow:
   tsCopy = ts;
-  tsCopy.toTimezone(util::getTimeZoneID("Europe/Moscow"));
+  tsCopy.toTimezone(tz::getTimeZoneID("Europe/Moscow"));
   EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 07:23:37"));
 
   // Numerical time zones: +HH:MM and -HH:MM
   tsCopy = ts;
-  tsCopy.toTimezone(util::getTimeZoneID("+14:00"));
+  tsCopy.toTimezone(tz::getTimeZoneID("+14:00"));
   EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 18:23:37"));
 
   tsCopy = ts;
-  tsCopy.toTimezone(util::getTimeZoneID("-14:00"));
+  tsCopy.toTimezone(tz::getTimeZoneID("-14:00"));
   EXPECT_EQ(tsCopy, parseTimestamp("2020-04-22 14:23:37"));
 
   tsCopy = ts;
@@ -458,22 +457,22 @@ TEST(DateTimeUtilTest, toTimezoneFromID) {
   EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 04:23:37"));
 
   tsCopy = ts;
-  tsCopy.toTimezone(util::getTimeZoneID("-00:01"));
+  tsCopy.toTimezone(tz::getTimeZoneID("-00:01"));
   EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 04:22:37"));
 
   tsCopy = ts;
-  tsCopy.toTimezone(util::getTimeZoneID("+00:01"));
+  tsCopy.toTimezone(tz::getTimeZoneID("+00:01"));
   EXPECT_EQ(tsCopy, parseTimestamp("2020-04-23 04:24:37"));
 
   // Probe LA's daylight savings boundary (starts at 2021-13-14 02:00am).
   // Before it starts, 8h offset:
   ts = parseTimestamp("2021-03-14 00:00:00");
-  ts.toTimezone(util::getTimeZoneID("America/Los_Angeles"));
+  ts.toTimezone(tz::getTimeZoneID("America/Los_Angeles"));
   EXPECT_EQ(ts, parseTimestamp("2021-03-13 16:00:00"));
 
   // After it starts, 7h offset:
   ts = parseTimestamp("2021-03-15 00:00:00");
-  ts.toTimezone(util::getTimeZoneID("America/Los_Angeles"));
+  ts.toTimezone(tz::getTimeZoneID("America/Los_Angeles"));
   EXPECT_EQ(ts, parseTimestamp("2021-03-14 17:00:00"));
 }
 

--- a/velox/type/tests/TimestampTest.cpp
+++ b/velox/type/tests/TimestampTest.cpp
@@ -18,8 +18,8 @@
 #include <random>
 
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/external/date/tz.h"
 #include "velox/type/Timestamp.h"
+#include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox {
 namespace {
@@ -394,7 +394,7 @@ TEST(TimestampTest, outOfRange) {
   //
   // #1. external/date cannot handle years larger than 32k (date::year::max()).
   // Any conversions exceeding that threshold will fail right away.
-  auto* timezone = date::locate_zone("GMT");
+  auto* timezone = tz::locateZone("GMT");
   Timestamp t1(-3217830796800, 0);
 
   VELOX_ASSERT_THROW(
@@ -407,7 +407,7 @@ TEST(TimestampTest, outOfRange) {
   // example, it will throw for anything larger than 2037 (which is what is
   // currently materialized in OS_TZDBs). America/Los_Angeles is an example of
   // such timezone.
-  timezone = date::locate_zone("America/Los_Angeles");
+  timezone = tz::locateZone("America/Los_Angeles");
   Timestamp t2(32517359891, 0);
   VELOX_ASSERT_THROW(
       t2.toTimezone(*timezone),

--- a/velox/type/tz/CMakeLists.txt
+++ b/velox/type/tz/CMakeLists.txt
@@ -20,6 +20,7 @@ velox_add_library(velox_type_tz TimeZoneMap.h TimeZoneDatabase.cpp
 velox_link_libraries(
   velox_type_tz
   velox_exception
+  velox_external_date
   Boost::regex
   fmt::fmt
   Folly::folly)

--- a/velox/type/tz/TimeZoneDatabase.cpp
+++ b/velox/type/tz/TimeZoneDatabase.cpp
@@ -28,7 +28,7 @@
 #include <unordered_map>
 #include <vector>
 
-namespace facebook::velox::util {
+namespace facebook::velox::tz {
 
 const std::unordered_map<int64_t, std::string>& getTimeZoneDB() {
   static auto* tzDB = new std::unordered_map<int64_t, std::string>([] {
@@ -2272,4 +2272,4 @@ const std::unordered_map<int64_t, std::string>& getTimeZoneDB() {
   return *tzDB;
 }
 
-} // namespace facebook::velox::util
+} // namespace facebook::velox::tz

--- a/velox/type/tz/TimeZoneMap.cpp
+++ b/velox/type/tz/TimeZoneMap.cpp
@@ -21,8 +21,9 @@
 #include <folly/container/F14Map.h>
 #include <folly/container/F14Set.h>
 #include "velox/common/base/Exceptions.h"
+#include "velox/external/date/tz.h"
 
-namespace facebook::velox::util {
+namespace facebook::velox::tz {
 
 // Defined in TimeZoneDatabase.cpp
 extern const std::unordered_map<int64_t, std::string>& getTimeZoneDB();
@@ -166,4 +167,8 @@ int16_t getTimeZoneID(int32_t offsetMinutes) {
   }
 }
 
-} // namespace facebook::velox::util
+const TimeZone* locateZone(std::string_view timeZone) {
+  return date::locate_zone(timeZone);
+}
+
+} // namespace facebook::velox::tz

--- a/velox/type/tz/TimeZoneMap.h
+++ b/velox/type/tz/TimeZoneMap.h
@@ -18,7 +18,34 @@
 
 #include <string>
 
-namespace facebook::velox::util {
+namespace facebook::velox::date {
+class time_zone;
+}
+
+namespace facebook::velox::tz {
+
+/// This library provides time zone lookup and mapping utilities, in addition to
+/// functions to enable timestamp conversions across time zones. It leverages
+/// the velox/external/date underneath to perform conversions.
+///
+/// This library provides a thin layer of functionality on top of
+/// velox/external/date for timezone lookup and conversions, so don't use the
+/// external library directly.
+
+/// TimeZone is the object that allows conversions across timezones using the
+/// .to_sys() and .to_local() methods, as documented in:
+///
+///   https://howardhinnant.github.io/date/tz.html
+///
+using TimeZone = date::time_zone;
+
+/// TimeZone pointers can be found using `locateZone()`.
+///
+/// This function in mostly implemented by velox/external/date, and performs a
+/// binary search in the internal time zone database. On the first call,
+/// velox/external/date will initialize a static list of timezone, read from the
+/// local tzdata database.
+const TimeZone* locateZone(std::string_view timeZone);
 
 /// Returns the timezone name associated with timeZoneID.
 std::string getTimeZoneName(int64_t timeZoneID);
@@ -32,4 +59,14 @@ int16_t getTimeZoneID(std::string_view timeZone, bool failOnError = true);
 /// [-14:00, +14:00] range.
 int16_t getTimeZoneID(int32_t offsetMinutes);
 
+} // namespace facebook::velox::tz
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+namespace facebook::velox::util {
+
+inline std::string getTimeZoneName(int64_t timeZoneID) {
+  return tz::getTimeZoneName(timeZoneID);
+}
+
 } // namespace facebook::velox::util
+#endif

--- a/velox/type/tz/tests/TimeZoneMapTest.cpp
+++ b/velox/type/tz/tests/TimeZoneMapTest.cpp
@@ -20,7 +20,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
-namespace facebook::velox::util {
+namespace facebook::velox::tz {
 namespace {
 
 TEST(TimeZoneMapTest, getTimeZoneName) {
@@ -94,4 +94,4 @@ TEST(TimeZoneMapTest, invalid) {
 }
 
 } // namespace
-} // namespace facebook::velox::util
+} // namespace facebook::velox::tz


### PR DESCRIPTION
Summary:
Moving timezone conversion call of velox/external/date under the
velox_type_tz library. It reduces the callsites to the external library, and
allows us to provide a more unified API.

This will be needed for the next diff, so that we can unify conversion of
timezones and timezone offsets under the same API.

Differential Revision: D60132866
