### PR TITLE
Fix bug in grouping set spill

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -994,7 +994,8 @@ void GroupingSet::spill() {
          ++partition) {
       numDistinctSpillFilesPerPartition_[partition] =
           spiller_->state().numFinishedFiles(partition);
-      totalNumDistinctSpilledFiles += numDistinctSpillFilesPerPartition_.back();
+      totalNumDistinctSpilledFiles +=
+          numDistinctSpillFilesPerPartition_[partition];
     }
     VELOX_CHECK_GT(totalNumDistinctSpilledFiles, 0);
   }

--- a/velox/exec/PlanNodeStats.h
+++ b/velox/exec/PlanNodeStats.h
@@ -109,7 +109,7 @@ struct PlanNodeStats {
   /// Number of total splits.
   int numSplits{0};
 
-  // Total bytes in memory for spilling
+  /// Total bytes in memory for spilling
   uint64_t spilledInputBytes{0};
 
   /// Total bytes written for spilling.


### PR DESCRIPTION
At fix site, The use of .back() on an already resized std::vector caused the totalNumDistinctSpilledFiles potentially be 0 as long as the last partition spilled file count is 0. 