### PR TITLE
Fix code style for CMakeLists.txt files

### DIFF
--- a/velox/benchmarks/CMakeLists.txt
+++ b/velox/benchmarks/CMakeLists.txt
@@ -29,9 +29,11 @@ set(velox_benchmark_deps
     glog::glog)
 
 add_library(velox_benchmark_builder ExpressionBenchmarkBuilder.cpp)
-target_link_libraries(velox_benchmark_builder ${velox_benchmark_deps})
+target_link_libraries(
+  velox_benchmark_builder ${velox_benchmark_deps})
 # This is a workaround for the use of VectorTestBase.h which includes gtest.h
-target_link_libraries(velox_benchmark_builder gtest)
+target_link_libraries(
+  velox_benchmark_builder gtest)
 
 if(${VELOX_ENABLE_BENCHMARKS})
   add_subdirectory(tpch)

--- a/velox/benchmarks/basic/CMakeLists.txt
+++ b/velox/benchmarks/basic/CMakeLists.txt
@@ -29,58 +29,74 @@ set(velox_benchmark_deps
     glog::glog)
 
 add_executable(velox_benchmark_basic_simple_arithmetic SimpleArithmetic.cpp)
-target_link_libraries(velox_benchmark_basic_simple_arithmetic
-                      ${velox_benchmark_deps})
+target_link_libraries(
+  velox_benchmark_basic_simple_arithmetic ${velox_benchmark_deps})
 
 add_executable(velox_benchmark_basic_comparison_conjunct ComparisonConjunct.cpp)
-target_link_libraries(velox_benchmark_basic_comparison_conjunct
-                      ${velox_benchmark_deps})
+target_link_libraries(
+  velox_benchmark_basic_comparison_conjunct ${velox_benchmark_deps})
 
 add_executable(velox_benchmark_basic_simple_cast SimpleCastExpr.cpp)
-target_link_libraries(velox_benchmark_basic_simple_cast ${velox_benchmark_deps})
+target_link_libraries(
+  velox_benchmark_basic_simple_cast ${velox_benchmark_deps})
 
 add_executable(velox_benchmark_basic_decoded_vector DecodedVector.cpp)
-target_link_libraries(velox_benchmark_basic_decoded_vector
-                      ${velox_benchmark_deps})
+target_link_libraries(
+  velox_benchmark_basic_decoded_vector ${velox_benchmark_deps})
 
 add_executable(velox_benchmark_basic_selectivity_vector SelectivityVector.cpp)
-target_link_libraries(velox_benchmark_basic_selectivity_vector
-                      ${velox_benchmark_deps})
+target_link_libraries(
+  velox_benchmark_basic_selectivity_vector ${velox_benchmark_deps})
 
 add_executable(velox_benchmark_basic_vector_compare VectorCompare.cpp)
-target_link_libraries(velox_benchmark_basic_vector_compare
-                      ${velox_benchmark_deps} velox_vector_test_lib)
+target_link_libraries(
+  velox_benchmark_basic_vector_compare ${velox_benchmark_deps}
+  velox_vector_test_lib)
 
 add_executable(velox_benchmark_basic_vector_slice VectorSlice.cpp)
-target_link_libraries(velox_benchmark_basic_vector_slice
-                      ${velox_benchmark_deps} velox_vector_test_lib)
+target_link_libraries(
+  velox_benchmark_basic_vector_slice ${velox_benchmark_deps}
+  velox_vector_test_lib)
 
 add_executable(velox_benchmark_feature_normalization FeatureNormalization.cpp)
-target_link_libraries(velox_benchmark_feature_normalization
-                      ${velox_benchmark_deps} velox_functions_prestosql)
+target_link_libraries(
+  velox_benchmark_feature_normalization ${velox_benchmark_deps}
+  velox_functions_prestosql)
 
 add_executable(velox_benchmark_basic_preproc Preproc.cpp)
-target_link_libraries(velox_benchmark_basic_preproc ${velox_benchmark_deps}
-                      velox_functions_prestosql velox_vector_test_lib)
+target_link_libraries(
+  velox_benchmark_basic_preproc ${velox_benchmark_deps}
+  velox_functions_prestosql velox_vector_test_lib)
 
 add_executable(velox_like_tpch_benchmark LikeTpchBenchmark.cpp)
-target_link_libraries(velox_like_tpch_benchmark ${velox_benchmark_deps}
-                      velox_functions_lib velox_tpch_gen velox_vector_test_lib)
+target_link_libraries(
+  velox_like_tpch_benchmark
+  ${velox_benchmark_deps}
+  velox_functions_lib
+  velox_tpch_gen
+  velox_vector_test_lib)
 
 add_executable(velox_like_benchmark LikeBenchmark.cpp)
 target_link_libraries(
-  velox_like_benchmark ${velox_benchmark_deps} velox_functions_lib
-  velox_functions_prestosql velox_vector_test_lib)
+  velox_like_benchmark
+  ${velox_benchmark_deps}
+  velox_functions_lib
+  velox_functions_prestosql
+  velox_vector_test_lib)
 
 add_executable(velox_benchmark_basic_vector_fuzzer VectorFuzzer.cpp)
-target_link_libraries(velox_benchmark_basic_vector_fuzzer
-                      ${velox_benchmark_deps} velox_vector_test_lib)
+target_link_libraries(
+  velox_benchmark_basic_vector_fuzzer ${velox_benchmark_deps}
+  velox_vector_test_lib)
 
 add_executable(velox_cast_benchmark CastBenchmark.cpp)
-target_link_libraries(velox_cast_benchmark ${velox_benchmark_deps}
-                      velox_vector_test_lib)
+target_link_libraries(
+  velox_cast_benchmark ${velox_benchmark_deps} velox_vector_test_lib)
 
 add_executable(velox_format_datetime_benchmark FormatDateTimeBenchmark.cpp)
 target_link_libraries(
-  velox_format_datetime_benchmark ${velox_benchmark_deps} velox_vector_test_lib
-  velox_functions_spark velox_functions_prestosql)
+  velox_format_datetime_benchmark
+  ${velox_benchmark_deps}
+  velox_vector_test_lib
+  velox_functions_spark
+  velox_functions_prestosql)

--- a/velox/benchmarks/filesystem/CMakeLists.txt
+++ b/velox/benchmarks/filesystem/CMakeLists.txt
@@ -14,9 +14,18 @@
 
 add_library(velox_read_benchmark_lib ReadBenchmark.cpp)
 
-target_link_libraries(velox_read_benchmark_lib
-                      PUBLIC velox_file velox_time Folly::folly gflags::gflags)
+target_link_libraries(
+  velox_read_benchmark_lib
+  PUBLIC velox_file velox_time Folly::folly gflags::gflags)
 
 add_executable(velox_read_benchmark ReadBenchmarkMain.cpp)
 
-target_link_libraries(velox_read_benchmark PRIVATE velox_read_benchmark_lib velox_hive_config velox_s3fs velox_hdfs velox_abfs velox_gcs)
+target_link_libraries(
+  velox_read_benchmark
+  PRIVATE
+    velox_read_benchmark_lib
+    velox_hive_config
+    velox_s3fs
+    velox_hdfs
+    velox_abfs
+    velox_gcs)

--- a/velox/benchmarks/tpch/CMakeLists.txt
+++ b/velox/benchmarks/tpch/CMakeLists.txt
@@ -39,4 +39,5 @@ target_link_libraries(
 
 add_executable(velox_tpch_benchmark TpchBenchmarkMain.cpp)
 
-target_link_libraries(velox_tpch_benchmark velox_tpch_benchmark_lib)
+target_link_libraries(
+  velox_tpch_benchmark velox_tpch_benchmark_lib)

--- a/velox/benchmarks/unstable/CMakeLists.txt
+++ b/velox/benchmarks/unstable/CMakeLists.txt
@@ -27,5 +27,5 @@ set(velox_benchmark_deps
     glog::glog)
 
 add_executable(velox_memory_alloc_benchmark MemoryAllocationBenchmark.cpp)
-target_link_libraries(velox_memory_alloc_benchmark ${velox_benchmark_deps}
-                      velox_memory pthread)
+target_link_libraries(
+  velox_memory_alloc_benchmark ${velox_benchmark_deps} velox_memory pthread)

--- a/velox/common/base/tests/CMakeLists.txt
+++ b/velox/common/base/tests/CMakeLists.txt
@@ -38,21 +38,22 @@ add_test(velox_base_test velox_base_test)
 
 target_link_libraries(
   velox_base_test
-  PRIVATE velox_caching
-          velox_common_base
-          velox_memory
-          velox_time
-          velox_status
-          velox_exception
-          velox_temp_path
-          Boost::filesystem
-          Boost::headers
-          Folly::folly
-          fmt::fmt
-          gflags::gflags
-          gtest
-          gmock
-          gtest_main)
+  PRIVATE
+    velox_caching
+    velox_common_base
+    velox_memory
+    velox_time
+    velox_status
+    velox_exception
+    velox_temp_path
+    Boost::filesystem
+    Boost::headers
+    Folly::folly
+    fmt::fmt
+    gflags::gflags
+    gtest
+    gmock
+    gtest_main)
 
 add_executable(velox_id_map_test IdMapTest.cpp)
 
@@ -72,5 +73,10 @@ target_link_libraries(
 
 add_executable(velox_memcpy_meter Memcpy.cpp)
 target_link_libraries(
-  velox_memcpy_meter PRIVATE velox_common_base velox_exception velox_time
-                             Folly::folly gflags::gflags)
+  velox_memcpy_meter
+  PRIVATE
+    velox_common_base
+    velox_exception
+    velox_time
+    Folly::folly
+    gflags::gflags)

--- a/velox/common/caching/tests/CMakeLists.txt
+++ b/velox/common/caching/tests/CMakeLists.txt
@@ -14,26 +14,43 @@
 
 add_executable(simple_lru_cache_test SimpleLRUCacheTest.cpp)
 add_test(simple_lru_cache_test simple_lru_cache_test)
-target_link_libraries(simple_lru_cache_test PRIVATE Folly::folly velox_time
-                                                    glog::glog gtest gtest_main)
+target_link_libraries(
+  simple_lru_cache_test
+  PRIVATE
+    Folly::folly
+    velox_time
+    glog::glog
+    gtest
+    gtest_main)
 
 add_executable(
-  velox_cache_test AsyncDataCacheTest.cpp CacheTTLControllerTest.cpp
-                   SsdFileTest.cpp SsdFileTrackerTest.cpp StringIdMapTest.cpp)
+  velox_cache_test
+  AsyncDataCacheTest.cpp
+  CacheTTLControllerTest.cpp
+  SsdFileTest.cpp
+  SsdFileTrackerTest.cpp
+  StringIdMapTest.cpp)
 add_test(velox_cache_test velox_cache_test)
 target_link_libraries(
   velox_cache_test
-  PRIVATE velox_caching
-          velox_file
-          velox_memory
-          velox_temp_path
-          Folly::folly
-          glog::glog
-          gtest
-          gtest_main)
+  PRIVATE
+    velox_caching
+    velox_file
+    velox_memory
+    velox_temp_path
+    Folly::folly
+    glog::glog
+    gtest
+    gtest_main)
 
 add_executable(cached_factory_test CachedFactoryTest.cpp)
 add_test(cached_factory_test cached_factory_test)
 target_link_libraries(
-  cached_factory_test PRIVATE velox_process Folly::folly velox_time glog::glog
-                              gtest gtest_main)
+  cached_factory_test
+  PRIVATE
+    velox_process
+    Folly::folly
+    velox_time
+    glog::glog
+    gtest
+    gtest_main)

--- a/velox/common/file/tests/CMakeLists.txt
+++ b/velox/common/file/tests/CMakeLists.txt
@@ -15,10 +15,18 @@
 add_library(velox_file_test_utils TestUtils.cpp FaultyFile.cpp
                                   FaultyFileSystem.cpp)
 
-target_link_libraries(velox_file_test_utils PUBLIC velox_file)
+target_link_libraries(
+  velox_file_test_utils
+  PUBLIC velox_file)
 
 add_executable(velox_file_test FileTest.cpp UtilsTest.cpp)
 add_test(velox_file_test velox_file_test)
 target_link_libraries(
-  velox_file_test PRIVATE velox_file velox_file_test_utils velox_temp_path
-                          gmock gtest gtest_main)
+  velox_file_test
+  PRIVATE
+    velox_file
+    velox_file_test_utils
+    velox_temp_path
+    gmock
+    gtest
+    gtest_main)

--- a/velox/common/hyperloglog/benchmarks/CMakeLists.txt
+++ b/velox/common/hyperloglog/benchmarks/CMakeLists.txt
@@ -14,5 +14,6 @@
 
 add_executable(velox_common_hyperloglog_dense_hll_bm DenseHll.cpp)
 
-target_link_libraries(velox_common_hyperloglog_dense_hll_bm
-                      velox_common_hyperloglog ${FOLLY_BENCHMARK})
+target_link_libraries(
+  velox_common_hyperloglog_dense_hll_bm velox_common_hyperloglog
+  ${FOLLY_BENCHMARK})

--- a/velox/common/hyperloglog/tests/CMakeLists.txt
+++ b/velox/common/hyperloglog/tests/CMakeLists.txt
@@ -18,5 +18,5 @@ add_test(NAME velox_common_hyperloglog_test
          COMMAND velox_common_hyperloglog_test)
 
 target_link_libraries(
-  velox_common_hyperloglog_test PRIVATE velox_common_hyperloglog velox_encode
-                                        gtest gtest_main)
+  velox_common_hyperloglog_test
+  PRIVATE velox_common_hyperloglog velox_encode gtest gtest_main)

--- a/velox/common/memory/tests/CMakeLists.txt
+++ b/velox/common/memory/tests/CMakeLists.txt
@@ -31,34 +31,36 @@ add_executable(
 
 target_link_libraries(
   velox_memory_test
-  PRIVATE velox_caching
-          velox_common_base
-          velox_exception
-          velox_exec
-          velox_exec_test_lib
-          velox_memory
-          velox_temp_path
-          velox_test_util
-          velox_vector_fuzzer
-          Folly::folly
-          fmt::fmt
-          gflags::gflags
-          glog::glog
-          gmock
-          gtest
-          gtest_main
-          re2::re2)
+  PRIVATE
+    velox_caching
+    velox_common_base
+    velox_exception
+    velox_exec
+    velox_exec_test_lib
+    velox_memory
+    velox_temp_path
+    velox_test_util
+    velox_vector_fuzzer
+    Folly::folly
+    fmt::fmt
+    gflags::gflags
+    glog::glog
+    gmock
+    gtest
+    gtest_main
+    re2::re2)
 
 gtest_add_tests(velox_memory_test "" AUTO)
 
 add_executable(velox_fragmentation_benchmark FragmentationBenchmark.cpp)
 
 target_link_libraries(
-  velox_fragmentation_benchmark PRIVATE velox_memory Folly::folly
-                                        gflags::gflags glog::glog)
+  velox_fragmentation_benchmark
+  PRIVATE velox_memory Folly::folly gflags::gflags glog::glog)
 
 add_executable(velox_concurrent_allocation_benchmark
                ConcurrentAllocationBenchmark.cpp)
 
-target_link_libraries(velox_concurrent_allocation_benchmark PRIVATE velox_memory
-                                                                    velox_time)
+target_link_libraries(
+  velox_concurrent_allocation_benchmark
+  PRIVATE velox_memory velox_time)

--- a/velox/common/process/tests/CMakeLists.txt
+++ b/velox/common/process/tests/CMakeLists.txt
@@ -17,5 +17,11 @@ add_executable(velox_process_test ProfilerTest.cpp ThreadLocalRegistryTest.cpp
 
 add_test(velox_process_test velox_process_test)
 
-target_link_libraries(velox_process_test PRIVATE velox_process fmt::fmt gtest
-                                                 velox_time gtest_main)
+target_link_libraries(
+  velox_process_test
+  PRIVATE
+    velox_process
+    fmt::fmt
+    gtest
+    velox_time
+    gtest_main)

--- a/velox/common/serialization/tests/CMakeLists.txt
+++ b/velox/common/serialization/tests/CMakeLists.txt
@@ -16,5 +16,11 @@ add_executable(velox_serialization_test TestRegistry.cpp SerializableTest.cpp)
 add_test(velox_serialization_test velox_serialization_test)
 
 target_link_libraries(
-  velox_serialization_test PRIVATE velox_exception velox_serialization
-                                   Folly::folly glog::glog gtest gtest_main)
+  velox_serialization_test
+  PRIVATE
+    velox_exception
+    velox_serialization
+    Folly::folly
+    glog::glog
+    gtest
+    gtest_main)

--- a/velox/common/testutil/tests/CMakeLists.txt
+++ b/velox/common/testutil/tests/CMakeLists.txt
@@ -16,5 +16,11 @@ add_executable(velox_test_util_test TestScopedTestTime.cpp TestValueTest.cpp)
 gtest_add_tests(velox_test_util_test "" AUTO)
 
 target_link_libraries(
-  velox_test_util_test PRIVATE velox_test_util velox_exception velox_exec
-                               velox_time gtest gtest_main)
+  velox_test_util_test
+  PRIVATE
+    velox_test_util
+    velox_exception
+    velox_exec
+    velox_time
+    gtest
+    gtest_main)

--- a/velox/common/time/tests/CMakeLists.txt
+++ b/velox/common/time/tests/CMakeLists.txt
@@ -15,7 +15,8 @@ include(GoogleTest)
 
 add_executable(velox_time_test CpuWallTimerTest.cpp)
 
-target_link_libraries(velox_time_test PRIVATE velox_time glog::glog gtest
-                                              gtest_main)
+target_link_libraries(
+  velox_time_test
+  PRIVATE velox_time glog::glog gtest gtest_main)
 
 gtest_add_tests(velox_time_test "" AUTO)

--- a/velox/connectors/fuzzer/CMakeLists.txt
+++ b/velox/connectors/fuzzer/CMakeLists.txt
@@ -14,8 +14,8 @@
 
 add_library(velox_fuzzer_connector OBJECT FuzzerConnector.cpp)
 
-target_link_libraries(velox_fuzzer_connector velox_connector
-                      velox_vector_fuzzer)
+target_link_libraries(
+  velox_fuzzer_connector velox_connector velox_vector_fuzzer)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/connectors/hive/storage_adapters/abfs/tests/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/abfs/tests/CMakeLists.txt
@@ -17,16 +17,17 @@ add_executable(velox_abfs_test AbfsFileSystemTest.cpp AbfsUtilTest.cpp
 add_test(velox_abfs_test velox_abfs_test)
 target_link_libraries(
   velox_abfs_test
-  PRIVATE velox_file
-          velox_abfs
-          velox_core
-          velox_exec_test_lib
-          velox_hive_connector
-          velox_dwio_common_exception
-          velox_exec
-          gtest
-          gtest_main
-          Azure::azure-storage-blobs
-          Azure::azure-storage-files-datalake)
+  PRIVATE
+    velox_file
+    velox_abfs
+    velox_core
+    velox_exec_test_lib
+    velox_hive_connector
+    velox_dwio_common_exception
+    velox_exec
+    gtest
+    gtest_main
+    Azure::azure-storage-blobs
+    Azure::azure-storage-files-datalake)
 
 target_compile_options(velox_abfs_test PRIVATE -Wno-deprecated-declarations)

--- a/velox/connectors/tpch/tests/CMakeLists.txt
+++ b/velox/connectors/tpch/tests/CMakeLists.txt
@@ -26,5 +26,10 @@ target_link_libraries(
 
 add_executable(velox_tpch_speed_test SpeedTest.cpp)
 
-target_link_libraries(velox_tpch_speed_test velox_tpch_connector velox_exec
-                      velox_exec_test_lib velox_memory fmt::fmt)
+target_link_libraries(
+  velox_tpch_speed_test
+  velox_tpch_connector
+  velox_exec
+  velox_exec_test_lib
+  velox_memory
+  fmt::fmt)

--- a/velox/core/tests/CMakeLists.txt
+++ b/velox/core/tests/CMakeLists.txt
@@ -26,11 +26,12 @@ add_test(velox_core_test velox_core_test)
 
 target_link_libraries(
   velox_core_test
-  PRIVATE velox_core
-          velox_exception
-          velox_exec_test_lib
-          velox_presto_types
-          velox_type
-          velox_vector_test_lib
-          gtest
-          gtest_main)
+  PRIVATE
+    velox_core
+    velox_exception
+    velox_exec_test_lib
+    velox_presto_types
+    velox_type
+    velox_vector_test_lib
+    gtest
+    gtest_main)

--- a/velox/dwio/catalog/fbhive/test/CMakeLists.txt
+++ b/velox/dwio/catalog/fbhive/test/CMakeLists.txt
@@ -14,5 +14,10 @@
 
 add_executable(file_utils_test FileUtilsTests.cpp)
 add_test(file_utils_test file_utils_test)
-target_link_libraries(file_utils_test velox_dwio_catalog_fbhive
-                      velox_dwio_common_exception gtest gtest_main gmock)
+target_link_libraries(
+  file_utils_test
+  velox_dwio_catalog_fbhive
+  velox_dwio_common_exception
+  gtest
+  gtest_main
+  gmock)

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -60,13 +60,21 @@ target_link_libraries(
 add_executable(velox_dwio_common_data_buffer_benchmark DataBufferBenchmark.cpp)
 
 target_link_libraries(
-  velox_dwio_common_data_buffer_benchmark velox_dwio_common velox_memory
-  velox_dwio_common_exception Folly::folly ${FOLLY_BENCHMARK})
+  velox_dwio_common_data_buffer_benchmark
+  velox_dwio_common
+  velox_memory
+  velox_dwio_common_exception
+  Folly::folly
+  ${FOLLY_BENCHMARK})
 
 add_executable(velox_dwio_common_int_decoder_benchmark IntDecoderBenchmark.cpp)
 target_link_libraries(
-  velox_dwio_common_int_decoder_benchmark velox_dwio_common_exception
-  velox_exception velox_dwio_dwrf_common Folly::folly ${FOLLY_BENCHMARK})
+  velox_dwio_common_int_decoder_benchmark
+  velox_dwio_common_exception
+  velox_exception
+  velox_dwio_dwrf_common
+  Folly::folly
+  ${FOLLY_BENCHMARK})
 
 if(VELOX_ENABLE_ARROW AND VELOX_ENABLE_BENCHMARKS)
   add_subdirectory(Lemire/FastPFor)

--- a/velox/dwio/common/tests/utils/CMakeLists.txt
+++ b/velox/dwio/common/tests/utils/CMakeLists.txt
@@ -14,8 +14,12 @@
 
 add_library(
   velox_dwio_common_test_utils
-  BatchMaker.cpp DataFiles.cpp DataSetBuilder.cpp FilterGenerator.cpp
-  UnitLoaderTestTools.cpp E2EFilterTestBase.cpp)
+  BatchMaker.cpp
+  DataFiles.cpp
+  DataSetBuilder.cpp
+  FilterGenerator.cpp
+  UnitLoaderTestTools.cpp
+  E2EFilterTestBase.cpp)
 
 target_link_libraries(
   velox_dwio_common_test_utils

--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -31,24 +31,27 @@ add_executable(velox_dwio_dwrf_buffered_output_stream_test
 add_test(velox_dwio_dwrf_buffered_output_stream_test
          velox_dwio_dwrf_buffered_output_stream_test)
 
-target_link_libraries(velox_dwio_dwrf_buffered_output_stream_test
-                      velox_link_libs Folly::folly ${TEST_LINK_LIBS})
+target_link_libraries(
+  velox_dwio_dwrf_buffered_output_stream_test velox_link_libs Folly::folly
+  ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_column_statistics_test
                TestDwrfColumnStatistics.cpp)
 add_test(velox_dwio_dwrf_column_statistics_test
          velox_dwio_dwrf_column_statistics_test)
 
-target_link_libraries(velox_dwio_dwrf_column_statistics_test velox_link_libs
-                      Folly::folly ${TEST_LINK_LIBS})
+target_link_libraries(
+  velox_dwio_dwrf_column_statistics_test velox_link_libs Folly::folly
+  ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_orc_column_statistics_test
                TestOrcColumnStatistics.cpp)
 add_test(velox_dwio_orc_column_statistics_test
          velox_dwio_orc_column_statistics_test)
 
-target_link_libraries(velox_dwio_orc_column_statistics_test velox_link_libs
-                      Folly::folly ${TEST_LINK_LIBS})
+target_link_libraries(
+  velox_dwio_orc_column_statistics_test velox_link_libs Folly::folly
+  ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_compression_test CompressionTest.cpp)
 add_test(velox_dwio_dwrf_compression_test velox_dwio_dwrf_compression_test)
@@ -129,35 +132,43 @@ add_executable(velox_dwio_dwrf_dictionary_encoder_test
 add_test(velox_dwio_dwrf_dictionary_encoder_test
          velox_dwio_dwrf_dictionary_encoder_test)
 
-target_link_libraries(velox_dwio_dwrf_dictionary_encoder_test velox_link_libs
-                      Folly::folly ${TEST_LINK_LIBS})
+target_link_libraries(
+  velox_dwio_dwrf_dictionary_encoder_test velox_link_libs Folly::folly
+  ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_encoding_selector_test TestEncodingSelector.cpp)
 add_test(velox_dwio_dwrf_encoding_selector_test
          velox_dwio_dwrf_encoding_selector_test)
 
-target_link_libraries(velox_dwio_dwrf_encoding_selector_test velox_link_libs
-                      Folly::folly ${TEST_LINK_LIBS})
+target_link_libraries(
+  velox_dwio_dwrf_encoding_selector_test velox_link_libs Folly::folly
+  ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_index_builder_test IndexBuilderTests.cpp)
 add_test(velox_dwio_dwrf_index_builder_test velox_dwio_dwrf_index_builder_test)
 
-target_link_libraries(velox_dwio_dwrf_index_builder_test velox_link_libs
-                      Folly::folly ${TEST_LINK_LIBS})
+target_link_libraries(
+  velox_dwio_dwrf_index_builder_test velox_link_libs Folly::folly
+  ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_dictionary_encoding_utils_test
                TestDictionaryEncodingUtils.cpp)
 add_test(velox_dwio_dwrf_dictionary_encoding_utils_test
          velox_dwio_dwrf_dictionary_encoding_utils_test)
 
-target_link_libraries(velox_dwio_dwrf_dictionary_encoding_utils_test
-                      velox_link_libs Folly::folly ${TEST_LINK_LIBS})
+target_link_libraries(
+  velox_dwio_dwrf_dictionary_encoding_utils_test velox_link_libs Folly::folly
+  ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_checksum_test ChecksumTests.cpp)
 add_test(velox_dwio_dwrf_checksum_test velox_dwio_dwrf_checksum_test)
 
-target_link_libraries(velox_dwio_dwrf_checksum_test velox_link_libs
-                      Folly::folly Boost::headers ${TEST_LINK_LIBS})
+target_link_libraries(
+  velox_dwio_dwrf_checksum_test
+  velox_link_libs
+  Folly::folly
+  Boost::headers
+  ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_writer_test WriterTest.cpp)
 add_test(velox_dwio_dwrf_writer_test velox_dwio_dwrf_writer_test)
@@ -204,16 +215,18 @@ target_link_libraries(
 add_executable(velox_dwio_dwrf_writer_sink_test WriterSinkTest.cpp)
 add_test(velox_dwio_dwrf_writer_sink_test velox_dwio_dwrf_writer_sink_test)
 
-target_link_libraries(velox_dwio_dwrf_writer_sink_test velox_link_libs
-                      Folly::folly ${TEST_LINK_LIBS})
+target_link_libraries(
+  velox_dwio_dwrf_writer_sink_test velox_link_libs Folly::folly
+  ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_data_buffer_holder_test
                DataBufferHolderTests.cpp)
 add_test(velox_dwio_dwrf_data_buffer_holder_test
          velox_dwio_dwrf_data_buffer_holder_test)
 
-target_link_libraries(velox_dwio_dwrf_data_buffer_holder_test velox_link_libs
-                      Folly::folly ${TEST_LINK_LIBS})
+target_link_libraries(
+  velox_dwio_dwrf_data_buffer_holder_test velox_link_libs Folly::folly
+  ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_layout_planner_test LayoutPlannerTests.cpp)
 add_test(velox_dwio_dwrf_layout_planner_test
@@ -232,14 +245,16 @@ target_link_libraries(
 add_executable(velox_dwio_dwrf_decryption_test DecryptionTests.cpp)
 add_test(velox_dwio_dwrf_decryption_test velox_dwio_dwrf_decryption_test)
 
-target_link_libraries(velox_dwio_dwrf_decryption_test velox_link_libs
-                      Folly::folly ${TEST_LINK_LIBS})
+target_link_libraries(
+  velox_dwio_dwrf_decryption_test velox_link_libs Folly::folly
+  ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_encryption_test EncryptionTests.cpp)
 add_test(velox_dwio_dwrf_encryption_test velox_dwio_dwrf_encryption_test)
 
-target_link_libraries(velox_dwio_dwrf_encryption_test velox_link_libs
-                      Folly::folly ${TEST_LINK_LIBS})
+target_link_libraries(
+  velox_dwio_dwrf_encryption_test velox_link_libs Folly::folly
+  ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_stripe_reader_base_test
                StripeReaderBaseTests.cpp)
@@ -273,63 +288,83 @@ target_link_libraries(
 add_executable(velox_dwio_dwrf_config_test ConfigTests.cpp)
 add_test(velox_dwio_dwrf_config_test velox_dwio_dwrf_config_test)
 
-target_link_libraries(velox_dwio_dwrf_config_test velox_link_libs Folly::folly
-                      ${TEST_LINK_LIBS})
+target_link_libraries(
+  velox_dwio_dwrf_config_test velox_link_libs Folly::folly ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_ratio_checker_test RatioTrackerTest.cpp)
 add_test(velox_dwio_dwrf_ratio_checker_test velox_dwio_dwrf_ratio_checker_test)
 
-target_link_libraries(velox_dwio_dwrf_ratio_checker_test velox_link_libs
-                      Folly::folly ${TEST_LINK_LIBS})
+target_link_libraries(
+  velox_dwio_dwrf_ratio_checker_test velox_link_libs Folly::folly
+  ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_flush_policy_test FlushPolicyTest.cpp)
 add_test(velox_dwio_dwrf_flush_policy_test velox_dwio_dwrf_flush_policy_test)
 
-target_link_libraries(velox_dwio_dwrf_flush_policy_test velox_link_libs
-                      Folly::folly ${TEST_LINK_LIBS})
+target_link_libraries(
+  velox_dwio_dwrf_flush_policy_test velox_link_libs Folly::folly
+  ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_byte_rle_test TestByteRle.cpp)
 add_test(velox_dwio_dwrf_byte_rle_test velox_dwio_dwrf_byte_rle_test)
 
-target_link_libraries(velox_dwio_dwrf_byte_rle_test velox_link_libs fmt::fmt
-                      Folly::folly ${TEST_LINK_LIBS})
+target_link_libraries(
+  velox_dwio_dwrf_byte_rle_test
+  velox_link_libs
+  fmt::fmt
+  Folly::folly
+  ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_byte_rle_encoder_test TestByteRLEEncoder.cpp)
 add_test(velox_dwio_dwrf_byte_rle_encoder_test
          velox_dwio_dwrf_byte_rle_encoder_test)
 
-target_link_libraries(velox_dwio_dwrf_byte_rle_encoder_test velox_link_libs
-                      fmt::fmt Folly::folly ${TEST_LINK_LIBS})
+target_link_libraries(
+  velox_dwio_dwrf_byte_rle_encoder_test
+  velox_link_libs
+  fmt::fmt
+  Folly::folly
+  ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_int_encoder_test TestIntEncoder.cpp)
 add_test(velox_dwio_dwrf_int_encoder_test velox_dwio_dwrf_int_encoder_test)
 
-target_link_libraries(velox_dwio_dwrf_int_encoder_test velox_link_libs
-                      Folly::folly ${TEST_LINK_LIBS})
+target_link_libraries(
+  velox_dwio_dwrf_int_encoder_test velox_link_libs Folly::folly
+  ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_rle_test TestRle.cpp)
 add_test(velox_dwio_dwrf_rle_test velox_dwio_dwrf_rle_test)
 
-target_link_libraries(velox_dwio_dwrf_rle_test velox_link_libs Folly::folly
-                      ${TEST_LINK_LIBS})
+target_link_libraries(
+  velox_dwio_dwrf_rle_test velox_link_libs Folly::folly ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_int_direct_test TestIntDirect.cpp)
 add_test(velox_dwio_dwrf_int_direct_test velox_dwio_dwrf_int_direct_test)
 
-target_link_libraries(velox_dwio_dwrf_int_direct_test velox_link_libs fmt::fmt
-                      Folly::folly ${TEST_LINK_LIBS})
+target_link_libraries(
+  velox_dwio_dwrf_int_direct_test
+  velox_link_libs
+  fmt::fmt
+  Folly::folly
+  ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_rlev1_encoder_test TestRLEv1Encoder.cpp)
 add_test(velox_dwio_dwrf_rlev1_encoder_test velox_dwio_dwrf_rlev1_encoder_test)
 
-target_link_libraries(velox_dwio_dwrf_rlev1_encoder_test velox_link_libs
-                      Folly::folly ${TEST_LINK_LIBS})
+target_link_libraries(
+  velox_dwio_dwrf_rlev1_encoder_test velox_link_libs Folly::folly
+  ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_column_reader_test TestColumnReader.cpp)
 add_test(velox_dwio_dwrf_column_reader_test velox_dwio_dwrf_column_reader_test)
 
-target_link_libraries(velox_dwio_dwrf_column_reader_test velox_link_libs
-                      Folly::folly fmt::fmt ${TEST_LINK_LIBS})
+target_link_libraries(
+  velox_dwio_dwrf_column_reader_test
+  velox_link_libs
+  Folly::folly
+  fmt::fmt
+  ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_reader_test ReaderTest.cpp)
 add_test(
@@ -371,8 +406,9 @@ add_executable(velox_dwrf_statistics_builder_utils_test
 add_test(velox_dwrf_statistics_builder_utils_test
          velox_dwrf_statistics_builder_utils_test)
 
-target_link_libraries(velox_dwrf_statistics_builder_utils_test velox_link_libs
-                      Folly::folly ${TEST_LINK_LIBS})
+target_link_libraries(
+  velox_dwrf_statistics_builder_utils_test velox_link_libs Folly::folly
+  ${TEST_LINK_LIBS})
 
 add_executable(velox_dwrf_column_writer_test ColumnWriterTest.cpp)
 add_test(velox_dwrf_column_writer_test velox_dwrf_column_writer_test)
@@ -502,8 +538,12 @@ target_link_libraries(
 
 add_executable(velox_dwrf_int_encoder_benchmark IntEncoderBenchmark.cpp)
 target_link_libraries(
-  velox_dwrf_int_encoder_benchmark velox_dwio_dwrf_common velox_memory
-  velox_dwio_common_exception Folly::folly ${FOLLY_BENCHMARK})
+  velox_dwrf_int_encoder_benchmark
+  velox_dwio_dwrf_common
+  velox_memory
+  velox_dwio_common_exception
+  Folly::folly
+  ${FOLLY_BENCHMARK})
 
 add_executable(velox_dwrf_float_column_writer_benchmark
                FloatColumnWriterBenchmark.cpp)

--- a/velox/dwio/orc/test/CMakeLists.txt
+++ b/velox/dwio/orc/test/CMakeLists.txt
@@ -18,5 +18,10 @@ add_test(
   COMMAND velox_dwio_orc_reader_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(velox_dwio_orc_reader_test velox_dwrf_test_utils
-                      velox_dwio_common_test_utils gtest gtest_main gmock)
+target_link_libraries(
+  velox_dwio_orc_reader_test
+  velox_dwrf_test_utils
+  velox_dwio_common_test_utils
+  gtest
+  gtest_main
+  gmock)

--- a/velox/dwio/parquet/tests/thrift/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/thrift/CMakeLists.txt
@@ -15,5 +15,10 @@
 add_executable(velox_dwio_parquet_thrift_test ThriftTransportTest.cpp)
 
 add_test(velox_dwio_parquet_thrift_test velox_dwio_parquet_thrift_test)
-target_link_libraries(velox_dwio_parquet_thrift_test arrow thrift
-                      velox_link_libs gtest gtest_main)
+target_link_libraries(
+  velox_dwio_parquet_thrift_test
+  arrow
+  thrift
+  velox_link_libs
+  gtest
+  gtest_main)

--- a/velox/exec/benchmarks/CMakeLists.txt
+++ b/velox/exec/benchmarks/CMakeLists.txt
@@ -13,43 +13,66 @@
 # limitations under the License.
 add_executable(velox_exec_vector_hasher_benchmark VectorHasherBenchmark.cpp)
 
-target_link_libraries(velox_exec_vector_hasher_benchmark velox_exec
-                      velox_vector_test_lib ${FOLLY_BENCHMARK})
+target_link_libraries(
+  velox_exec_vector_hasher_benchmark velox_exec velox_vector_test_lib
+  ${FOLLY_BENCHMARK})
 
 add_executable(velox_filter_project_benchmark FilterProjectBenchmark.cpp)
 
 target_link_libraries(
-  velox_filter_project_benchmark velox_exec velox_vector_test_lib
-  velox_exec_test_lib ${FOLLY_BENCHMARK})
+  velox_filter_project_benchmark
+  velox_exec
+  velox_vector_test_lib
+  velox_exec_test_lib
+  ${FOLLY_BENCHMARK})
 
 add_executable(velox_exchange_benchmark ExchangeBenchmark.cpp)
 
-target_link_libraries(velox_exchange_benchmark velox_exec velox_exec_test_lib
-                      velox_vector_test_lib ${FOLLY_BENCHMARK})
+target_link_libraries(
+  velox_exchange_benchmark
+  velox_exec
+  velox_exec_test_lib
+  velox_vector_test_lib
+  ${FOLLY_BENCHMARK})
 
 add_executable(velox_merge_benchmark MergeBenchmark.cpp)
 
-target_link_libraries(velox_merge_benchmark velox_exec velox_vector_test_lib
-                      ${FOLLY_BENCHMARK} gtest gtest_main)
+target_link_libraries(
+  velox_merge_benchmark
+  velox_exec
+  velox_vector_test_lib
+  ${FOLLY_BENCHMARK}
+  gtest
+  gtest_main)
 
 add_executable(velox_hash_benchmark HashTableBenchmark.cpp)
 
-target_link_libraries(velox_hash_benchmark velox_exec velox_exec_test_lib
-                      velox_vector_test_lib ${FOLLY_BENCHMARK})
+target_link_libraries(
+  velox_hash_benchmark
+  velox_exec
+  velox_exec_test_lib
+  velox_vector_test_lib
+  ${FOLLY_BENCHMARK})
 
 add_executable(velox_hash_join_list_result_benchmark
                HashJoinListResultBenchmark.cpp)
 
 target_link_libraries(
-  velox_hash_join_list_result_benchmark velox_exec velox_exec_test_lib
-  velox_vector_test_lib ${FOLLY_BENCHMARK})
+  velox_hash_join_list_result_benchmark
+  velox_exec
+  velox_exec_test_lib
+  velox_vector_test_lib
+  ${FOLLY_BENCHMARK})
 
 add_executable(velox_hash_join_prepare_join_table_benchmark
                HashJoinPrepareJoinTableBenchmark.cpp)
 
 target_link_libraries(
-  velox_hash_join_prepare_join_table_benchmark velox_exec velox_exec_test_lib
-  velox_vector_test_lib ${FOLLY_BENCHMARK})
+  velox_hash_join_prepare_join_table_benchmark
+  velox_exec
+  velox_exec_test_lib
+  velox_vector_test_lib
+  ${FOLLY_BENCHMARK})
 
 if(${VELOX_ENABLE_PARQUET})
   add_executable(velox_sort_benchmark RowContainerSortBenchmark.cpp)
@@ -66,5 +89,9 @@ endif()
 
 add_executable(velox_prefixsort_benchmark PrefixSortBenchmark.cpp)
 
-target_link_libraries(velox_prefixsort_benchmark velox_exec velox_vector_fuzzer
-                      velox_vector_test_lib ${FOLLY_BENCHMARK})
+target_link_libraries(
+  velox_prefixsort_benchmark
+  velox_exec
+  velox_vector_fuzzer
+  velox_vector_test_lib
+  ${FOLLY_BENCHMARK})

--- a/velox/exec/prefixsort/tests/CMakeLists.txt
+++ b/velox/exec/prefixsort/tests/CMakeLists.txt
@@ -23,5 +23,6 @@ add_test(
 
 set_tests_properties(velox_exec_prefixsort_test PROPERTIES TIMEOUT 3000)
 
-target_link_libraries(velox_exec_prefixsort_test velox_exec_prefixsort_test_lib
-                      velox_vector_fuzzer velox_vector_test_lib)
+target_link_libraries(
+  velox_exec_prefixsort_test velox_exec_prefixsort_test_lib velox_vector_fuzzer
+  velox_vector_test_lib)

--- a/velox/exec/prefixsort/tests/utils/CMakeLists.txt
+++ b/velox/exec/prefixsort/tests/utils/CMakeLists.txt
@@ -14,4 +14,5 @@
 
 add_library(velox_exec_prefixsort_test_lib EncoderTestUtils.cpp)
 
-target_link_libraries(velox_exec_prefixsort_test_lib velox_vector_test_lib)
+target_link_libraries(
+  velox_exec_prefixsort_test_lib velox_vector_test_lib)

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -23,8 +23,12 @@ add_test(
   COMMAND aggregate_companion_functions_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(aggregate_companion_functions_test velox_exec
-                      velox_function_registry gtest gtest_main)
+target_link_libraries(
+  aggregate_companion_functions_test
+  velox_exec
+  velox_function_registry
+  gtest
+  gtest_main)
 
 add_executable(
   velox_exec_test
@@ -207,26 +211,32 @@ target_link_libraries(
 # RowNumber Fuzzer.
 add_executable(velox_row_number_fuzzer_test RowNumberFuzzerTest.cpp)
 
-target_link_libraries(velox_row_number_fuzzer_test velox_row_number_fuzzer
-                      gtest gtest_main)
+target_link_libraries(
+  velox_row_number_fuzzer_test velox_row_number_fuzzer gtest gtest_main)
 
 # Join Fuzzer.
 add_executable(velox_join_fuzzer_test JoinFuzzerTest.cpp)
 
-target_link_libraries(velox_join_fuzzer_test velox_join_fuzzer gtest gtest_main)
+target_link_libraries(
+  velox_join_fuzzer_test velox_join_fuzzer gtest gtest_main)
 
 # Arbitration Fuzzer.
 add_executable(velox_memory_arbitration_fuzzer_test
                MemoryArbitrationFuzzerTest.cpp)
 
-target_link_libraries(velox_memory_arbitration_fuzzer_test
-                      velox_memory_arbitration_fuzzer gtest gtest_main)
+target_link_libraries(
+  velox_memory_arbitration_fuzzer_test velox_memory_arbitration_fuzzer gtest
+  gtest_main)
 
 # Cache Fuzzer
 add_executable(velox_cache_fuzzer_test CacheFuzzerTest.cpp)
 
-target_link_libraries(velox_cache_fuzzer_test velox_cache_fuzzer
-                      velox_fuzzer_util gtest gtest_main)
+target_link_libraries(
+  velox_cache_fuzzer_test
+  velox_cache_fuzzer
+  velox_fuzzer_util
+  gtest
+  gtest_main)
 
 add_executable(velox_exchange_fuzzer_test ExchangeFuzzer.cpp)
 
@@ -254,15 +264,23 @@ target_link_libraries(
 add_library(velox_simple_aggregate SimpleAverageAggregate.cpp
                                    SimpleArrayAggAggregate.cpp)
 
-target_link_libraries(velox_simple_aggregate velox_exec velox_expression
-                      velox_expression_functions velox_aggregates)
+target_link_libraries(
+  velox_simple_aggregate
+  velox_exec
+  velox_expression
+  velox_expression_functions
+  velox_aggregates)
 
 add_executable(velox_simple_aggregate_test SimpleAggregateAdapterTest.cpp
                                            Main.cpp)
 
 target_link_libraries(
-  velox_simple_aggregate_test velox_simple_aggregate velox_exec
-  velox_functions_aggregates_test_lib gtest gtest_main)
+  velox_simple_aggregate_test
+  velox_simple_aggregate
+  velox_exec
+  velox_functions_aggregates_test_lib
+  gtest
+  gtest_main)
 
 add_library(velox_spiller_join_benchmark_base JoinSpillInputBenchmarkBase.cpp
                                               SpillerBenchmarkBase.cpp)
@@ -278,8 +296,9 @@ target_link_libraries(
   pthread)
 
 add_executable(velox_spiller_join_benchmark SpillerJoinInputBenchmarkTest.cpp)
-target_link_libraries(velox_spiller_join_benchmark velox_exec
-                      velox_exec_test_lib velox_spiller_join_benchmark_base)
+target_link_libraries(
+  velox_spiller_join_benchmark velox_exec velox_exec_test_lib
+  velox_spiller_join_benchmark_base)
 
 add_library(velox_spiller_aggregate_benchmark_base
             AggregateSpillBenchmarkBase.cpp SpillerBenchmarkBase.cpp)
@@ -305,4 +324,5 @@ add_test(
   NAME cpr_http_client_test
   COMMAND cpr_http_client_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(cpr_http_client_test cpr::cpr gtest gtest_main)
+target_link_libraries(
+  cpr_http_client_test cpr::cpr gtest gtest_main)

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -14,7 +14,8 @@
 
 add_library(velox_temp_path TempFilePath.cpp TempDirectoryPath.cpp)
 
-target_link_libraries(velox_temp_path velox_exception)
+target_link_libraries(
+  velox_temp_path velox_exception)
 
 add_library(
   velox_exec_test_lib

--- a/velox/experimental/gpu/tests/CMakeLists.txt
+++ b/velox/experimental/gpu/tests/CMakeLists.txt
@@ -13,4 +13,5 @@
 # limitations under the License.
 
 add_executable(velox_gpu_hash_table_test HashTableTest.cu)
-target_link_libraries(velox_gpu_hash_table_test Folly::folly gflags::gflags)
+target_link_libraries(
+  velox_gpu_hash_table_test Folly::folly gflags::gflags)

--- a/velox/experimental/wave/exec/tests/utils/CMakeLists.txt
+++ b/velox/experimental/wave/exec/tests/utils/CMakeLists.txt
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 add_library(velox_wave_mock_file FileFormat.cpp)
-target_link_libraries(velox_wave_mock_file velox_exception velox_common_base
-                      velox_vector)
+target_link_libraries(
+  velox_wave_mock_file velox_exception velox_common_base velox_vector)
 
 add_library(velox_wave_mock_reader WaveTestSplitReader.cpp TestFormatReader.cpp)
 

--- a/velox/expression/benchmarks/CMakeLists.txt
+++ b/velox/expression/benchmarks/CMakeLists.txt
@@ -13,29 +13,33 @@
 # limitations under the License.
 
 set(BENCHMARK_DEPENDENCIES
-    velox_functions_test_lib velox_exec velox_exec_test_lib gflags::gflags
-    Folly::folly ${FOLLY_BENCHMARK})
+    velox_functions_test_lib
+    velox_exec
+    velox_exec_test_lib
+    gflags::gflags
+    Folly::folly
+    ${FOLLY_BENCHMARK})
 
 add_executable(velox_benchmark_call_null_free_no_nulls
                CallNullFreeBenchmark.cpp)
-target_link_libraries(velox_benchmark_call_null_free_no_nulls
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_benchmark_call_null_free_no_nulls ${BENCHMARK_DEPENDENCIES})
 target_compile_definitions(
   velox_benchmark_call_null_free_no_nulls PUBLIC WITH_NULL_ARRAYS=false
                                                  WITH_NULL_ELEMENTS=false)
 
 add_executable(velox_benchmark_call_null_free_null_arrays
                CallNullFreeBenchmark.cpp)
-target_link_libraries(velox_benchmark_call_null_free_null_arrays
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_benchmark_call_null_free_null_arrays ${BENCHMARK_DEPENDENCIES})
 target_compile_definitions(
   velox_benchmark_call_null_free_null_arrays PUBLIC WITH_NULL_ARRAYS=true
                                                     WITH_NULL_ELEMENTS=false)
 
 add_executable(velox_benchmark_call_null_free_null_elements
                CallNullFreeBenchmark.cpp)
-target_link_libraries(velox_benchmark_call_null_free_null_elements
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_benchmark_call_null_free_null_elements ${BENCHMARK_DEPENDENCIES})
 target_compile_definitions(
   velox_benchmark_call_null_free_null_elements PUBLIC WITH_NULL_ARRAYS=false
                                                       WITH_NULL_ELEMENTS=true)
@@ -50,4 +54,5 @@ target_compile_definitions(
   PUBLIC WITH_NULL_ARRAYS=true WITH_NULL_ELEMENTS=true)
 
 add_executable(velox_benchmark_variadic VariadicBenchmark.cpp)
-target_link_libraries(velox_benchmark_variadic ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_benchmark_variadic ${BENCHMARK_DEPENDENCIES})

--- a/velox/expression/fuzzer/CMakeLists.txt
+++ b/velox/expression/fuzzer/CMakeLists.txt
@@ -15,13 +15,16 @@
 add_library(velox_expression_test_utility ArgumentTypeFuzzer.cpp
                                           FuzzerToolkit.cpp)
 
-target_link_libraries(velox_expression_test_utility velox_type
-                      velox_expression_functions gtest)
+target_link_libraries(
+  velox_expression_test_utility velox_type velox_expression_functions gtest)
 
 add_library(
   velox_expression_fuzzer
-  ArgumentTypeFuzzer.cpp DecimalArgGeneratorBase.cpp ExpressionFuzzer.cpp
-  FuzzerRunner.cpp ExpressionFuzzerVerifier.cpp)
+  ArgumentTypeFuzzer.cpp
+  DecimalArgGeneratorBase.cpp
+  ExpressionFuzzer.cpp
+  FuzzerRunner.cpp
+  ExpressionFuzzerVerifier.cpp)
 
 target_link_libraries(
   velox_expression_fuzzer
@@ -34,13 +37,21 @@ target_link_libraries(
 
 add_executable(velox_expression_fuzzer_test ExpressionFuzzerTest.cpp)
 
-target_link_libraries(velox_expression_fuzzer_test velox_expression_fuzzer
-                      velox_functions_prestosql gtest gtest_main)
+target_link_libraries(
+  velox_expression_fuzzer_test
+  velox_expression_fuzzer
+  velox_functions_prestosql
+  gtest
+  gtest_main)
 
 add_executable(spark_expression_fuzzer_test SparkExpressionFuzzerTest.cpp)
 
-target_link_libraries(spark_expression_fuzzer_test velox_expression_fuzzer
-                      velox_functions_spark gtest gtest_main)
+target_link_libraries(
+  spark_expression_fuzzer_test
+  velox_expression_fuzzer
+  velox_functions_spark
+  gtest
+  gtest_main)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/expression/fuzzer/tests/CMakeLists.txt
+++ b/velox/expression/fuzzer/tests/CMakeLists.txt
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 add_library(velox_expression_fuzzer_test_utility ArgGeneratorTestUtils.cpp)
-target_link_libraries(velox_expression_fuzzer_test_utility
-                      velox_expression_functions velox_function_registry gtest)
+target_link_libraries(
+  velox_expression_fuzzer_test_utility velox_expression_functions
+  velox_function_registry gtest)
 
 add_executable(
   velox_expression_fuzzer_unit_test

--- a/velox/expression/signature_parser/tests/CMakeLists.txt
+++ b/velox/expression/signature_parser/tests/CMakeLists.txt
@@ -16,5 +16,10 @@ add_executable(velox_signature_parser_test ParseTypeSignatureTest.cpp)
 
 add_test(NAME velox_signature_parser_test COMMAND velox_signature_parser_test)
 
-target_link_libraries(velox_signature_parser_test velox_signature_parser
-                      velox_type_signature gtest gtest_main gmock)
+target_link_libraries(
+  velox_signature_parser_test
+  velox_signature_parser
+  velox_type_signature
+  gtest
+  gtest_main
+  gmock)

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -82,18 +82,29 @@ target_link_libraries(
 add_library(velox_expression_verifier ExpressionVerifier.cpp)
 
 target_link_libraries(
-  velox_expression_verifier velox_vector_test_lib velox_vector_fuzzer
-  velox_type velox_expression_test_utility)
+  velox_expression_verifier
+  velox_vector_test_lib
+  velox_vector_fuzzer
+  velox_type
+  velox_expression_test_utility)
 
 add_library(velox_expression_runner ExpressionRunner.cpp)
 target_link_libraries(
-  velox_expression_runner velox_expression_verifier velox_functions_prestosql
-  velox_functions_spark velox_parse_parser gtest)
+  velox_expression_runner
+  velox_expression_verifier
+  velox_functions_prestosql
+  velox_functions_spark
+  velox_parse_parser
+  gtest)
 
 add_executable(velox_expression_runner_test ExpressionRunnerTest.cpp)
 target_link_libraries(
-  velox_expression_runner_test velox_expression_runner velox_exec_test_lib
-  velox_function_registry gtest gtest_main)
+  velox_expression_runner_test
+  velox_expression_runner
+  velox_exec_test_lib
+  velox_function_registry
+  gtest
+  gtest_main)
 
 add_executable(velox_expression_verifier_unit_test
                ExpressionVerifierUnitTest.cpp)

--- a/velox/functions/lib/aggregates/tests/utils/CMakeLists.txt
+++ b/velox/functions/lib/aggregates/tests/utils/CMakeLists.txt
@@ -14,5 +14,5 @@
 
 add_library(velox_functions_aggregates_test_lib AggregationTestBase.cpp)
 
-target_link_libraries(velox_functions_aggregates_test_lib velox_exec_test_lib
-                      velox_vector_test_lib)
+target_link_libraries(
+  velox_functions_aggregates_test_lib velox_exec_test_lib velox_vector_test_lib)

--- a/velox/functions/lib/window/tests/CMakeLists.txt
+++ b/velox/functions/lib/window/tests/CMakeLists.txt
@@ -15,5 +15,9 @@
 add_library(velox_functions_window_test_lib WindowTestBase.cpp)
 
 target_link_libraries(
-  velox_functions_window_test_lib velox_exec_test_lib velox_vector_fuzzer
-  velox_vector_test_lib gflags::gflags gtest)
+  velox_functions_window_test_lib
+  velox_exec_test_lib
+  velox_vector_fuzzer
+  velox_vector_test_lib
+  gflags::gflags
+  gtest)

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -27,34 +27,35 @@ set(BENCHMARK_DEPENDENCIES
 
 add_executable(velox_functions_prestosql_benchmarks_array_contains
                ArrayContainsBenchmark.cpp)
-target_link_libraries(velox_functions_prestosql_benchmarks_array_contains
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_functions_prestosql_benchmarks_array_contains ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_prestosql_benchmarks_array_min_max
                ArrayMinMaxBenchmark.cpp)
-target_link_libraries(velox_functions_prestosql_benchmarks_array_min_max
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_functions_prestosql_benchmarks_array_min_max ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_prestosql_benchmarks_array_position
                ArrayPositionBenchmark.cpp)
-target_link_libraries(velox_functions_prestosql_benchmarks_array_position
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_functions_prestosql_benchmarks_array_position ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_prestosql_benchmarks_array_sum
                ArraySumBenchmark.cpp)
 
-target_link_libraries(velox_functions_prestosql_benchmarks_array_sum
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_functions_prestosql_benchmarks_array_sum ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_prestosql_benchmarks_field_reference
                FieldReferenceBenchmark.cpp)
-target_link_libraries(velox_functions_prestosql_benchmarks_field_reference
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_functions_prestosql_benchmarks_field_reference
+  ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_prestosql_benchmarks_width_bucket
                WidthBucketBenchmark.cpp)
-target_link_libraries(velox_functions_prestosql_benchmarks_width_bucket
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_functions_prestosql_benchmarks_width_bucket ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_prestosql_benchmarks_string_ascii_utf_functions
                StringAsciiUTFFunctionBenchmarks.cpp)
@@ -63,51 +64,54 @@ target_link_libraries(
   ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_prestosql_benchmarks_not NotBenchmark.cpp)
-target_link_libraries(velox_functions_prestosql_benchmarks_not
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_functions_prestosql_benchmarks_not ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_prestosql_benchmarks_date_time
                DateTimeBenchmark.cpp)
-target_link_libraries(velox_functions_prestosql_benchmarks_date_time
-                      velox_type_tz ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_functions_prestosql_benchmarks_date_time velox_type_tz
+  ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_prestosql_benchmarks_bitwise
                BitwiseBenchmark.cpp)
-target_link_libraries(velox_functions_prestosql_benchmarks_bitwise
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_functions_prestosql_benchmarks_bitwise ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_prestosql_benchmarks_in InBenchmark.cpp)
-target_link_libraries(velox_functions_prestosql_benchmarks_in
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_functions_prestosql_benchmarks_in ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_prestosql_benchmarks_map_input
                MapInputBenchmark.cpp)
-target_link_libraries(velox_functions_prestosql_benchmarks_map_input
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_functions_prestosql_benchmarks_map_input ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_benchmarks_url URLBenchmark.cpp)
-target_link_libraries(velox_functions_benchmarks_url ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_functions_benchmarks_url ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_benchmarks_compare CompareBenchmark.cpp)
-target_link_libraries(velox_functions_benchmarks_compare
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_functions_benchmarks_compare ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_benchmark_array_writer_with_nulls ArrayWriterBenchmark.cpp)
 target_compile_definitions(velox_benchmark_array_writer_with_nulls
                            PUBLIC WITH_NULLS=true)
-target_link_libraries(velox_benchmark_array_writer_with_nulls
-                      ${BENCHMARK_DEPENDENCIES_NO_FUNC})
+target_link_libraries(
+  velox_benchmark_array_writer_with_nulls ${BENCHMARK_DEPENDENCIES_NO_FUNC})
 
 add_executable(velox_benchmark_array_writer_no_nulls ArrayWriterBenchmark.cpp)
-target_link_libraries(velox_benchmark_array_writer_no_nulls
-                      ${BENCHMARK_DEPENDENCIES_NO_FUNC})
+target_link_libraries(
+  velox_benchmark_array_writer_no_nulls ${BENCHMARK_DEPENDENCIES_NO_FUNC})
 target_compile_definitions(velox_benchmark_array_writer_no_nulls
                            PUBLIC WITH_NULLS=false)
 
 add_executable(velox_benchmark_nested_array_writer_no_nulls
                NestedArrayWriterBenchmark.cpp)
-target_link_libraries(velox_benchmark_nested_array_writer_no_nulls
-                      ${BENCHMARK_DEPENDENCIES_NO_FUNC})
+target_link_libraries(
+  velox_benchmark_nested_array_writer_no_nulls
+  ${BENCHMARK_DEPENDENCIES_NO_FUNC})
 target_compile_definitions(velox_benchmark_nested_array_writer_no_nulls
                            PUBLIC WITH_NULLS=false)
 
@@ -115,84 +119,88 @@ add_executable(velox_benchmark_nested_array_writer_with_nulls
                NestedArrayWriterBenchmark.cpp)
 target_compile_definitions(velox_benchmark_nested_array_writer_with_nulls
                            PUBLIC WITH_NULLS=true)
-target_link_libraries(velox_benchmark_nested_array_writer_with_nulls
-                      ${BENCHMARK_DEPENDENCIES_NO_FUNC})
+target_link_libraries(
+  velox_benchmark_nested_array_writer_with_nulls
+  ${BENCHMARK_DEPENDENCIES_NO_FUNC})
 
 add_executable(velox_benchmark_map_writer_with_nulls MapWriterBenchmarks.cpp)
 target_compile_definitions(velox_benchmark_map_writer_with_nulls
                            PUBLIC WITH_NULLS=true)
-target_link_libraries(velox_benchmark_map_writer_with_nulls
-                      ${BENCHMARK_DEPENDENCIES_NO_FUNC})
+target_link_libraries(
+  velox_benchmark_map_writer_with_nulls ${BENCHMARK_DEPENDENCIES_NO_FUNC})
 
 add_executable(velox_benchmark_map_writer_no_nulls MapWriterBenchmarks.cpp)
-target_link_libraries(velox_benchmark_map_writer_no_nulls
-                      ${BENCHMARK_DEPENDENCIES_NO_FUNC})
+target_link_libraries(
+  velox_benchmark_map_writer_no_nulls ${BENCHMARK_DEPENDENCIES_NO_FUNC})
 target_compile_definitions(velox_benchmark_map_writer_no_nulls
                            PUBLIC WITH_NULLS=false)
 
 add_executable(velox_functions_benchmarks_row_writer_no_nulls
                RowWriterBenchmark.cpp)
-target_link_libraries(velox_functions_benchmarks_row_writer_no_nulls
-                      ${BENCHMARK_DEPENDENCIES_NO_FUNC})
+target_link_libraries(
+  velox_functions_benchmarks_row_writer_no_nulls
+  ${BENCHMARK_DEPENDENCIES_NO_FUNC})
 
 add_executable(velox_functions_benchmarks_string_writer_no_nulls
                StringWriterBenchmark.cpp)
-target_link_libraries(velox_functions_benchmarks_string_writer_no_nulls
-                      ${BENCHMARK_DEPENDENCIES_NO_FUNC})
+target_link_libraries(
+  velox_functions_benchmarks_string_writer_no_nulls
+  ${BENCHMARK_DEPENDENCIES_NO_FUNC})
 
 add_executable(velox_functions_prestosql_benchmarks_zip ZipBenchmark.cpp)
-target_link_libraries(velox_functions_prestosql_benchmarks_zip
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_functions_prestosql_benchmarks_zip ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_prestosql_benchmarks_row Row.cpp)
-target_link_libraries(velox_functions_prestosql_benchmarks_row
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_functions_prestosql_benchmarks_row ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_prestosql_benchmarks_comparisons
                ComparisonsBenchmark.cpp)
-target_link_libraries(velox_functions_prestosql_benchmarks_comparisons
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_functions_prestosql_benchmarks_comparisons ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_prestosql_benchmarks_concat ConcatBenchmark.cpp)
-target_link_libraries(velox_functions_prestosql_benchmarks_concat
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_functions_prestosql_benchmarks_concat ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_prestosql_benchmarks_zip_with
                ZipWithBenchmark.cpp)
-target_link_libraries(velox_functions_prestosql_benchmarks_zip_with
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_functions_prestosql_benchmarks_zip_with ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_prestosql_benchmarks_map_zip_with
                MapZipWithBenchmark.cpp)
-target_link_libraries(velox_functions_prestosql_benchmarks_map_zip_with
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_functions_prestosql_benchmarks_map_zip_with ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_prestosql_benchmarks_cardinality
                CardinalityBenchmark.cpp)
-target_link_libraries(velox_functions_prestosql_benchmarks_cardinality
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_functions_prestosql_benchmarks_cardinality ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_benchmarks_simdjson_function_with_expr
                JsonExprBenchmark.cpp)
-target_link_libraries(velox_functions_benchmarks_simdjson_function_with_expr
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_functions_benchmarks_simdjson_function_with_expr
+  ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_prestosql_benchmarks_map_subscript
                MapSubscriptCachingBenchmark.cpp)
-target_link_libraries(velox_functions_prestosql_benchmarks_map_subscript
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_functions_prestosql_benchmarks_map_subscript ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_prestosql_benchmarks_regexp_replace
                RegexpReplaceBenchmark.cpp)
-target_link_libraries(velox_functions_prestosql_benchmarks_regexp_replace
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_functions_prestosql_benchmarks_regexp_replace ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_prestosql_benchmarks_generic
                GenericBenchmark.cpp)
-target_link_libraries(velox_functions_prestosql_benchmarks_generic
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_functions_prestosql_benchmarks_generic ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_prestosql_benchmarks_uuid_cast
                UuidCastBenchmark.cpp)
-target_link_libraries(velox_functions_prestosql_benchmarks_uuid_cast
-                      ${BENCHMARK_DEPENDENCIES})
+target_link_libraries(
+  velox_functions_prestosql_benchmarks_uuid_cast ${BENCHMARK_DEPENDENCIES})

--- a/velox/functions/prestosql/coverage/CMakeLists.txt
+++ b/velox/functions/prestosql/coverage/CMakeLists.txt
@@ -14,5 +14,9 @@
 add_executable(velox_prestosql_coverage Coverage.cpp)
 
 target_link_libraries(
-  velox_prestosql_coverage velox_functions_prestosql velox_function_registry
-  velox_aggregates velox_window velox_coverage_util)
+  velox_prestosql_coverage
+  velox_functions_prestosql
+  velox_function_registry
+  velox_aggregates
+  velox_window
+  velox_coverage_util)

--- a/velox/functions/prestosql/fuzzer/CMakeLists.txt
+++ b/velox/functions/prestosql/fuzzer/CMakeLists.txt
@@ -15,8 +15,12 @@
 add_library(velox_aggregation_result_verifier MinMaxByResultVerifier.cpp)
 
 target_link_libraries(
-  velox_aggregation_result_verifier velox_core velox_aggregation_fuzzer_base
-  velox_exec_test_lib velox_vector velox_vector_test_lib)
+  velox_aggregation_result_verifier
+  velox_core
+  velox_aggregation_fuzzer_base
+  velox_exec_test_lib
+  velox_vector
+  velox_vector_test_lib)
 
 add_executable(velox_aggregation_fuzzer_test AggregationFuzzerTest.cpp)
 
@@ -49,5 +53,9 @@ target_link_libraries(
 # Writer Fuzzer
 add_executable(velox_writer_fuzzer_test WriterFuzzerTest.cpp)
 
-target_link_libraries(velox_writer_fuzzer_test velox_writer_fuzzer
-                      velox_fuzzer_util gtest gtest_main)
+target_link_libraries(
+  velox_writer_fuzzer_test
+  velox_writer_fuzzer
+  velox_fuzzer_util
+  gtest
+  gtest_main)

--- a/velox/functions/prestosql/tests/utils/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/utils/CMakeLists.txt
@@ -14,5 +14,9 @@
 
 add_library(velox_functions_test_lib FunctionBaseTest.cpp)
 
-target_link_libraries(velox_functions_test_lib velox_exec velox_exec_test_lib
-                      velox_vector_test_lib velox_parse_parser)
+target_link_libraries(
+  velox_functions_test_lib
+  velox_exec
+  velox_exec_test_lib
+  velox_vector_test_lib
+  velox_parse_parser)

--- a/velox/functions/prestosql/types/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/types/tests/CMakeLists.txt
@@ -14,8 +14,11 @@
 
 add_executable(
   velox_presto_types_test
-  HyperLogLogTypeTest.cpp JsonTypeTest.cpp TimestampWithTimeZoneTypeTest.cpp
-  TypeTestBase.cpp UuidTypeTest.cpp)
+  HyperLogLogTypeTest.cpp
+  JsonTypeTest.cpp
+  TimestampWithTimeZoneTypeTest.cpp
+  TypeTestBase.cpp
+  UuidTypeTest.cpp)
 
 add_test(velox_presto_types_test velox_presto_types_test)
 

--- a/velox/functions/prestosql/window/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/window/tests/CMakeLists.txt
@@ -34,8 +34,8 @@ add_test(
   COMMAND velox_windows_rank_test
   WORKING_DIRECTORY .)
 
-target_link_libraries(velox_windows_rank_test
-                      ${CMAKE_WINDOW_TEST_LINK_LIBRARIES})
+target_link_libraries(
+  velox_windows_rank_test ${CMAKE_WINDOW_TEST_LINK_LIBRARIES})
 
 add_executable(velox_windows_value_test NthValueTest.cpp LeadLagTest.cpp
                                         ${CMAKE_WINDOW_TEST_MAIN_FILES})
@@ -45,8 +45,8 @@ add_test(
   COMMAND velox_windows_value_test
   WORKING_DIRECTORY .)
 
-target_link_libraries(velox_windows_value_test
-                      ${CMAKE_WINDOW_TEST_LINK_LIBRARIES})
+target_link_libraries(
+  velox_windows_value_test ${CMAKE_WINDOW_TEST_LINK_LIBRARIES})
 
 add_executable(velox_windows_agg_test AggregateWindowTest.cpp
                                       ${CMAKE_WINDOW_TEST_MAIN_FILES})
@@ -56,5 +56,5 @@ add_test(
   COMMAND velox_windows_agg_test
   WORKING_DIRECTORY .)
 
-target_link_libraries(velox_windows_agg_test
-                      ${CMAKE_WINDOW_TEST_LINK_LIBRARIES})
+target_link_libraries(
+  velox_windows_agg_test ${CMAKE_WINDOW_TEST_LINK_LIBRARIES})

--- a/velox/functions/sparksql/benchmarks/CMakeLists.txt
+++ b/velox/functions/sparksql/benchmarks/CMakeLists.txt
@@ -25,8 +25,9 @@ target_link_libraries(
   ${FOLLY_BENCHMARK})
 
 add_executable(velox_sparksql_benchmarks_compare CompareBenchmark.cpp)
-target_link_libraries(velox_sparksql_benchmarks_compare velox_functions_spark
-                      velox_benchmark_builder velox_vector_test_lib)
+target_link_libraries(
+  velox_sparksql_benchmarks_compare velox_functions_spark
+  velox_benchmark_builder velox_vector_test_lib)
 
 add_executable(velox_sparksql_benchmarks_simd_compare SIMDCompareBenchmark.cpp)
 target_link_libraries(
@@ -34,5 +35,6 @@ target_link_libraries(
   velox_benchmark_builder velox_vector_test_lib)
 
 add_executable(velox_sparksql_benchmarks_hash HashBenchmark.cpp)
-target_link_libraries(velox_sparksql_benchmarks_hash velox_functions_spark
-                      velox_benchmark_builder velox_vector_test_lib)
+target_link_libraries(
+  velox_sparksql_benchmarks_hash velox_functions_spark velox_benchmark_builder
+  velox_vector_test_lib)

--- a/velox/functions/sparksql/coverage/CMakeLists.txt
+++ b/velox/functions/sparksql/coverage/CMakeLists.txt
@@ -14,6 +14,9 @@
 add_executable(velox_sparksql_coverage Coverage.cpp)
 
 target_link_libraries(
-  velox_sparksql_coverage velox_functions_spark velox_function_registry
-  velox_functions_spark_aggregates velox_functions_spark_window
+  velox_sparksql_coverage
+  velox_functions_spark
+  velox_function_registry
+  velox_functions_spark_aggregates
+  velox_functions_spark_window
   velox_coverage_util)

--- a/velox/functions/sparksql/window/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/window/tests/CMakeLists.txt
@@ -34,5 +34,5 @@ add_test(
   COMMAND velox_spark_windows_test
   WORKING_DIRECTORY .)
 
-target_link_libraries(velox_spark_windows_test
-                      ${CMAKE_WINDOW_TEST_LINK_LIBRARIES})
+target_link_libraries(
+  velox_spark_windows_test ${CMAKE_WINDOW_TEST_LINK_LIBRARIES})

--- a/velox/functions/tests/CMakeLists.txt
+++ b/velox/functions/tests/CMakeLists.txt
@@ -15,5 +15,10 @@ add_executable(velox_function_registry_test FunctionRegistryTest.cpp)
 
 add_test(NAME velox_function_registry_test COMMAND velox_function_registry_test)
 
-target_link_libraries(velox_function_registry_test velox_function_registry
-                      velox_functions_test_lib gmock gtest gtest_main)
+target_link_libraries(
+  velox_function_registry_test
+  velox_function_registry
+  velox_functions_test_lib
+  gmock
+  gtest
+  gtest_main)

--- a/velox/parse/tests/CMakeLists.txt
+++ b/velox/parse/tests/CMakeLists.txt
@@ -16,5 +16,9 @@ add_executable(velox_parse_test QueryPlannerTest.cpp)
 
 add_test(velox_parse_test velox_parse_test)
 
-target_link_libraries(velox_parse_test velox_parse_parser gtest gtest_main
-                      gflags::gflags)
+target_link_libraries(
+  velox_parse_test
+  velox_parse_parser
+  gtest
+  gtest_main
+  gflags::gflags)

--- a/velox/row/tests/CMakeLists.txt
+++ b/velox/row/tests/CMakeLists.txt
@@ -18,11 +18,12 @@ add_test(velox_row_test velox_row_test)
 
 target_link_libraries(
   velox_row_test
-  PRIVATE velox_exception
-          velox_row_fast
-          velox_vector
-          velox_vector_fuzzer
-          velox_vector_test_lib
-          Folly::folly
-          gtest
-          gtest_main)
+  PRIVATE
+    velox_exception
+    velox_row_fast
+    velox_vector
+    velox_vector_fuzzer
+    velox_vector_test_lib
+    Folly::folly
+    gtest
+    gtest_main)

--- a/velox/tpch/gen/tests/CMakeLists.txt
+++ b/velox/tpch/gen/tests/CMakeLists.txt
@@ -15,5 +15,10 @@ add_executable(velox_tpch_gen_test TpchGenTest.cpp)
 
 add_test(velox_tpch_gen_test velox_tpch_gen_test)
 
-target_link_libraries(velox_tpch_gen_test velox_tpch_gen velox_type
-                      velox_vector gtest gtest_main)
+target_link_libraries(
+  velox_tpch_gen_test
+  velox_tpch_gen
+  velox_type
+  velox_vector
+  gtest
+  gtest_main)

--- a/velox/type/fbhive/tests/CMakeLists.txt
+++ b/velox/type/fbhive/tests/CMakeLists.txt
@@ -19,5 +19,10 @@ add_test(
   COMMAND velox_type_fbhive_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(velox_type_fbhive_test velox_type_fbhive
-                      velox_type gtest gtest_main gmock)
+target_link_libraries(
+  velox_type_fbhive_test
+  velox_type_fbhive
+  velox_type
+  gtest
+  gtest_main
+  gmock)

--- a/velox/type/parser/tests/CMakeLists.txt
+++ b/velox/type/parser/tests/CMakeLists.txt
@@ -16,5 +16,10 @@ add_executable(velox_type_parser_test TypeParserTest.cpp)
 
 add_test(NAME velox_type_parser_test COMMAND velox_type_parser_test)
 
-target_link_libraries(velox_type_parser_test velox_type_parser velox_type gtest
-                      gtest_main gmock)
+target_link_libraries(
+  velox_type_parser_test
+  velox_type_parser
+  velox_type
+  gtest
+  gtest_main
+  gmock)

--- a/velox/type/tz/tests/CMakeLists.txt
+++ b/velox/type/tz/tests/CMakeLists.txt
@@ -16,5 +16,10 @@ add_executable(velox_type_tz_test TimeZoneMapTest.cpp)
 
 add_test(velox_type_tz_test velox_type_tz_test)
 
-target_link_libraries(velox_type_tz_test velox_type_tz velox_exception gtest
-                      gtest_main pthread)
+target_link_libraries(
+  velox_type_tz_test
+  velox_type_tz
+  velox_exception
+  gtest
+  gtest_main
+  pthread)

--- a/velox/vector/benchmarks/CMakeLists.txt
+++ b/velox/vector/benchmarks/CMakeLists.txt
@@ -13,22 +13,33 @@
 # limitations under the License.
 add_executable(velox_vector_hash_all_benchmark SimpleVectorHashAllBenchmark.cpp)
 
-target_link_libraries(velox_vector_hash_all_benchmark velox_vector Folly::folly
-                      ${FOLLY_BENCHMARK} fmt::fmt)
+target_link_libraries(
+  velox_vector_hash_all_benchmark
+  velox_vector
+  Folly::folly
+  ${FOLLY_BENCHMARK}
+  fmt::fmt)
 # This is a workaround for the use of VectorTestUtils.h which include gtest.h
-target_link_libraries(velox_vector_hash_all_benchmark gtest)
+target_link_libraries(
+  velox_vector_hash_all_benchmark gtest)
 
 add_executable(velox_vector_selectivity_vector_benchmark
                SelectivityVectorBenchmark.cpp)
 
-target_link_libraries(velox_vector_selectivity_vector_benchmark velox_vector
-                      Folly::folly ${FOLLY_BENCHMARK})
+target_link_libraries(
+  velox_vector_selectivity_vector_benchmark velox_vector Folly::folly
+  ${FOLLY_BENCHMARK})
 
 add_executable(copy_benchmark CopyBenchmark.cpp)
 
-target_link_libraries(copy_benchmark velox_vector_test_lib Folly::folly
-                      ${FOLLY_BENCHMARK})
+target_link_libraries(
+  copy_benchmark velox_vector_test_lib Folly::folly ${FOLLY_BENCHMARK})
 
 add_executable(velox_vector_map_update_benchmark MapUpdateBenchmark.cpp)
-target_link_libraries(velox_vector_map_update_benchmark velox_vector_test_lib
-                      Folly::folly ${FOLLY_BENCHMARK} gflags::gflags glog::glog)
+target_link_libraries(
+  velox_vector_map_update_benchmark
+  velox_vector_test_lib
+  Folly::folly
+  ${FOLLY_BENCHMARK}
+  gflags::gflags
+  glog::glog)

--- a/velox/vector/fuzzer/CMakeLists.txt
+++ b/velox/vector/fuzzer/CMakeLists.txt
@@ -14,7 +14,8 @@
 
 add_library(velox_vector_fuzzer GeneratorSpec.cpp Utils.cpp VectorFuzzer.cpp)
 
-target_link_libraries(velox_vector_fuzzer velox_type velox_vector)
+target_link_libraries(
+  velox_vector_fuzzer velox_type velox_vector)
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   target_compile_options(velox_vector_fuzzer
                          PRIVATE -Wno-deprecated-declarations)

--- a/velox/vector/fuzzer/tests/CMakeLists.txt
+++ b/velox/vector/fuzzer/tests/CMakeLists.txt
@@ -15,5 +15,10 @@ add_executable(velox_vector_fuzzer_test VectorFuzzerTest.cpp)
 
 add_test(velox_vector_fuzzer_test velox_vector_fuzzer_test)
 
-target_link_libraries(velox_vector_fuzzer_test velox_vector_fuzzer velox_memory
-                      gtest gtest_main gmock)
+target_link_libraries(
+  velox_vector_fuzzer_test
+  velox_vector_fuzzer
+  velox_memory
+  gtest
+  gtest_main
+  gmock)

--- a/velox/vector/tests/utils/CMakeLists.txt
+++ b/velox/vector/tests/utils/CMakeLists.txt
@@ -13,4 +13,5 @@
 # limitations under the License.
 add_library(velox_vector_test_lib VectorMaker.cpp VectorTestBase.cpp)
 
-target_link_libraries(velox_vector_test_lib velox_vector gtest gtest_main)
+target_link_libraries(
+  velox_vector_test_lib velox_vector gtest gtest_main)


### PR DESCRIPTION
Fixes #10550
Fixes #10240 

It was fixed by using the following command (because only need to
format `CMakeLists.txt` files, so I modify check.py to skip the check
for python and cpp files)

```
python3 scripts/check.py format tree --fix ./velox
```