### PR TITLE
Do not load the first stripe if it can be skipped during random sampling

### DIFF
--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -285,7 +285,6 @@ bool SplitReader::checkIfSplitIsEmpty(
     return true;
   }
 
-  // Note that this doesn't apply to Hudi tables.
   if (!baseReader_ || baseReader_->numberOfRows() == 0) {
     emptySplit_ = true;
   } else {

--- a/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
@@ -112,7 +112,9 @@ PositionalDeleteFileReader::PositionalDeleteFileReader(
           deleteSplit_->filePath,
           deleteSplit_->partitionKeys,
           {})) {
-    ++runtimeStats.skippedSplits;
+    // We only count the number of base splits skipped as skippedSplits runtime
+    // statistics in Velox.  Skipped delta split is only counted as skipped
+    // bytes.
     runtimeStats.skippedSplitBytes += deleteSplit_->length;
     deleteSplit_.reset();
     return;

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -1116,7 +1116,7 @@ std::unique_ptr<DwrfRowReader> DwrfReader::createDwrfRowReader(
     // background have a reader tree and can preload the first
     // stripe. Also the reader tree needs to exist in order to receive
     // adaptation from a previous reader.
-    rowReader->loadCurrentStripe();
+    rowReader->nextRowNumber();
   }
   return rowReader;
 }


### PR DESCRIPTION
Summary:
In DWRF reader, we always load the first stripe even that stripe could
be skipped during random sampling.  Fix this by calling `nextRowNumber()` which
will correctly skip the stripes according to the random skip tracker.  Also add similar functionality to selective Nimble reader.

Differential Revision: D60194287
