### PR TITLE
Fix build of remote function target in monolithic build

### DIFF
--- a/velox/functions/remote/client/CMakeLists.txt
+++ b/velox/functions/remote/client/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 velox_add_library(velox_functions_remote_thrift_client ThriftClient.cpp)
 velox_link_libraries(velox_functions_remote_thrift_client
-                     PUBLIC velox_remote_function_thrift FBThrift::thriftcpp2)
+                     PUBLIC remote_function_thrift FBThrift::thriftcpp2)
 
 velox_add_library(velox_functions_remote Remote.cpp)
 velox_link_libraries(

--- a/velox/functions/remote/client/tests/CMakeLists.txt
+++ b/velox/functions/remote/client/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ add_test(velox_functions_remote_client_test velox_functions_remote_client_test)
 
 target_link_libraries(
   velox_functions_remote_client_test
-  velox_remote_function_thrift
+  remote_function_thrift
   velox_functions_remote_server
   velox_functions_remote
   velox_function_registry

--- a/velox/functions/remote/if/CMakeLists.txt
+++ b/velox/functions/remote/if/CMakeLists.txt
@@ -17,7 +17,7 @@ include(FBThriftCppLibrary)
 add_fbthrift_cpp_library(remote_function_thrift RemoteFunction.thrift
                          SERVICES RemoteFunctionService)
 
-target_compile_options(velox_remote_function_thrift
+target_compile_options(remote_function_thrift
                        PRIVATE -Wno-deprecated-declarations)
 
 velox_add_library(velox_functions_remote_get_serde GetSerde.cpp)

--- a/velox/functions/remote/if/CMakeLists.txt
+++ b/velox/functions/remote/if/CMakeLists.txt
@@ -14,13 +14,12 @@
 
 include(FBThriftCppLibrary)
 
-add_fbthrift_cpp_library(remote_function_thrift RemoteFunction.thrift
-                         SERVICES RemoteFunctionService)
+add_fbthrift_cpp_library(remote_function_thrift RemoteFunction.thrift SERVICES
+                         RemoteFunctionService)
 
 target_compile_options(remote_function_thrift
                        PRIVATE -Wno-deprecated-declarations)
 
 velox_add_library(velox_functions_remote_get_serde GetSerde.cpp)
-velox_link_libraries(
-  velox_functions_remote_get_serde PUBLIC remote_function_thrift
-                                          velox_presto_serializer)
+velox_link_libraries(velox_functions_remote_get_serde
+                     PUBLIC remote_function_thrift velox_presto_serializer)

--- a/velox/functions/remote/if/CMakeLists.txt
+++ b/velox/functions/remote/if/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 include(FBThriftCppLibrary)
 
-add_fbthrift_cpp_library(velox_remote_function_thrift RemoteFunction.thrift
+add_fbthrift_cpp_library(remote_function_thrift RemoteFunction.thrift
                          SERVICES RemoteFunctionService)
 
 target_compile_options(velox_remote_function_thrift
@@ -22,5 +22,5 @@ target_compile_options(velox_remote_function_thrift
 
 velox_add_library(velox_functions_remote_get_serde GetSerde.cpp)
 velox_link_libraries(
-  velox_functions_remote_get_serde PUBLIC velox_remote_function_thrift
+  velox_functions_remote_get_serde PUBLIC remote_function_thrift
                                           velox_presto_serializer)

--- a/velox/functions/remote/server/CMakeLists.txt
+++ b/velox/functions/remote/server/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(velox_functions_remote_server RemoteFunctionService.cpp)
 
 target_link_libraries(
   velox_functions_remote_server
-  PUBLIC velox_remote_function_thrift velox_functions_remote_get_serde
+  PUBLIC remote_function_thrift velox_functions_remote_get_serde
          velox_type_fbhive velox_memory)
 
 add_executable(velox_functions_remote_server_main RemoteFunctionServiceMain.cpp)

--- a/velox/functions/remote/server/CMakeLists.txt
+++ b/velox/functions/remote/server/CMakeLists.txt
@@ -21,5 +21,6 @@ target_link_libraries(
 
 add_executable(velox_functions_remote_server_main RemoteFunctionServiceMain.cpp)
 
-target_link_libraries(velox_functions_remote_server_main
-                      velox_functions_remote_server velox_functions_prestosql)
+target_link_libraries(
+  velox_functions_remote_server_main velox_functions_remote_server
+  velox_functions_prestosql)


### PR DESCRIPTION
When building the monolithic library `velox_link_libraries` filters out anything `^velox_*` as they are just aliases to `velox::velox`. So targets that are created with `velox_add_library` can't be named that way. I will look into refining that behavior in the future.