### PR TITLE
Fix isFinite for NaN input

### DIFF
--- a/velox/functions/prestosql/Arithmetic.h
+++ b/velox/functions/prestosql/Arithmetic.h
@@ -451,7 +451,7 @@ struct InfinityFunction {
 template <typename T>
 struct IsFiniteFunction {
   FOLLY_ALWAYS_INLINE void call(bool& result, double a) {
-    result = !std::isinf(a);
+    result = std::isfinite(a);
   }
 };
 

--- a/velox/functions/prestosql/tests/ArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/ArithmeticTest.cpp
@@ -599,6 +599,7 @@ TEST_F(ArithmeticTest, isFinite) {
   EXPECT_EQ(false, isFinite(-kInf));
   EXPECT_EQ(false, isFinite(1.0 / 0.0));
   EXPECT_EQ(false, isFinite(-1.0 / 0.0));
+  EXPECT_EQ(false, isFinite(kNan));
 }
 
 TEST_F(ArithmeticTest, isInfinite) {
@@ -607,6 +608,7 @@ TEST_F(ArithmeticTest, isInfinite) {
   };
 
   EXPECT_EQ(false, isInfinite(0.0));
+  EXPECT_EQ(false, isInfinite(kNan));
   EXPECT_EQ(true, isInfinite(kInf));
   EXPECT_EQ(true, isInfinite(-kInf));
   EXPECT_EQ(true, isInfinite(1.0 / 0.0));


### PR DESCRIPTION
Summary: isFinite() currently incorrectly classifies NaN as finite. This fixes that bug.

Reviewed By: amitkdutta

Differential Revision: D60204120
