### PR TITLE
Let MemoryArbitrator API not have impl dependent info

### DIFF
--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -191,6 +191,12 @@ struct MemoryManagerOptions {
   /// potential deadlock when reclaim memory from the task of the request memory
   /// pool.
   MemoryArbitrationStateCheckCB arbitrationStateCheckCb{nullptr};
+
+  /// TODO(jtan6): [Config Refactor] Remove above shared arbitrator specific
+  /// configs after Prestissimo switch to use extra configs map.
+  ///
+  /// Additional configs that are arbitrator implementation specific.
+  std::unordered_map<std::string, std::string> extraArbitratorConfigs{};
 };
 
 /// 'MemoryManager' is responsible for creating allocator, arbitrator and

--- a/velox/common/memory/tests/MemoryArbitratorTest.cpp
+++ b/velox/common/memory/tests/MemoryArbitratorTest.cpp
@@ -85,7 +85,6 @@ TEST_F(MemoryArbitrationTest, create) {
   for (const auto& kind : kinds) {
     MemoryArbitrator::Config config;
     config.capacity = 8 * GB;
-    config.reservedCapacity = 4 * GB;
     config.kind = kind;
     if (kind.empty()) {
       auto arbitrator = MemoryArbitrator::create(config);
@@ -103,7 +102,6 @@ TEST_F(MemoryArbitrationTest, create) {
 TEST_F(MemoryArbitrationTest, createWithDefaultConf) {
   MemoryArbitrator::Config config;
   config.capacity = 8 * GB;
-  config.reservedCapacity = 4 * GB;
   const auto& arbitrator = MemoryArbitrator::create(config);
   ASSERT_EQ(arbitrator->kind(), "NOOP");
 }
@@ -358,8 +356,7 @@ class FakeTestArbitrator : public MemoryArbitrator {
       : MemoryArbitrator(
             {.kind = config.kind,
              .capacity = config.capacity,
-             .memoryPoolTransferCapacity = config.memoryPoolTransferCapacity}) {
-  }
+             .extraConfigs = config.extraConfigs}) {}
 
   std::string kind() const override {
     return "USER";

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -121,8 +121,7 @@ class FakeTestArbitrator : public MemoryArbitrator {
       : MemoryArbitrator(
             {.kind = config.kind,
              .capacity = config.capacity,
-             .memoryPoolTransferCapacity = config.memoryPoolTransferCapacity}) {
-  }
+             .extraConfigs = config.extraConfigs}) {}
 
   uint64_t growCapacity(MemoryPool* /*unused*/, uint64_t /*unused*/) override {
     VELOX_NYI();

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -518,6 +518,91 @@ void verifyReclaimerStats(
   }
 }
 
+TEST_F(MockSharedArbitrationTest, extraConfigs) {
+  // Testing default values
+  std::unordered_map<std::string, std::string> emptyConfigs;
+  ASSERT_EQ(
+      SharedArbitrator::ExtraConfig::getReservedCapacity(emptyConfigs),
+      SharedArbitrator::ExtraConfig::kDefaultReservedCapacity);
+  ASSERT_EQ(
+      SharedArbitrator::ExtraConfig::getMemoryPoolReservedCapacity(
+          emptyConfigs),
+      SharedArbitrator::ExtraConfig::kDefaultMemoryPoolReservedCapacity);
+  ASSERT_EQ(
+      SharedArbitrator::ExtraConfig::getMemoryPoolTransferCapacity(
+          emptyConfigs),
+      SharedArbitrator::ExtraConfig::kDefaultMemoryPoolTransferCapacity);
+  ASSERT_EQ(
+      SharedArbitrator::ExtraConfig::getMemoryReclaimWaitMs(emptyConfigs),
+      SharedArbitrator::ExtraConfig::kDefaultMemoryReclaimWaitMs);
+  ASSERT_EQ(
+      SharedArbitrator::ExtraConfig::getGlobalArbitrationEnabled(emptyConfigs),
+      SharedArbitrator::ExtraConfig::kDefaultGlobalArbitrationEnabled);
+  ASSERT_EQ(
+      SharedArbitrator::ExtraConfig::getCheckUsageLeak(emptyConfigs),
+      SharedArbitrator::ExtraConfig::kDefaultCheckUsageLeak);
+
+  // Testing custom values
+  std::unordered_map<std::string, std::string> configs;
+  configs[std::string(SharedArbitrator::ExtraConfig::kReservedCapacity)] =
+      "100";
+  configs[std::string(
+      SharedArbitrator::ExtraConfig::kMemoryPoolReservedCapacity)] = "200";
+  configs[std::string(
+      SharedArbitrator::ExtraConfig::kMemoryPoolTransferCapacity)] =
+      "256000000";
+  configs[std::string(SharedArbitrator::ExtraConfig::kMemoryReclaimWaitMs)] =
+      "5000";
+  configs[std::string(
+      SharedArbitrator::ExtraConfig::kGlobalArbitrationEnabled)] = "true";
+  configs[std::string(SharedArbitrator::ExtraConfig::kCheckUsageLeak)] =
+      "false";
+  ASSERT_EQ(SharedArbitrator::ExtraConfig::getReservedCapacity(configs), 100);
+  ASSERT_EQ(
+      SharedArbitrator::ExtraConfig::getMemoryPoolReservedCapacity(configs),
+      200);
+  ASSERT_EQ(
+      SharedArbitrator::ExtraConfig::getMemoryPoolTransferCapacity(configs),
+      256000000);
+  ASSERT_EQ(
+      SharedArbitrator::ExtraConfig::getMemoryReclaimWaitMs(configs), 5000);
+  ASSERT_TRUE(
+      SharedArbitrator::ExtraConfig::getGlobalArbitrationEnabled(configs));
+  ASSERT_FALSE(SharedArbitrator::ExtraConfig::getCheckUsageLeak(configs));
+
+  // Testing invalid values
+  configs[std::string(SharedArbitrator::ExtraConfig::kReservedCapacity)] =
+      "invalid";
+  configs[std::string(
+      SharedArbitrator::ExtraConfig::kMemoryPoolReservedCapacity)] = "invalid";
+  configs[std::string(
+      SharedArbitrator::ExtraConfig::kMemoryPoolTransferCapacity)] = "invalid";
+  configs[std::string(SharedArbitrator::ExtraConfig::kMemoryReclaimWaitMs)] =
+      "invalid";
+  configs[std::string(
+      SharedArbitrator::ExtraConfig::kGlobalArbitrationEnabled)] = "invalid";
+  configs[std::string(SharedArbitrator::ExtraConfig::kCheckUsageLeak)] =
+      "invalid";
+  VELOX_ASSERT_THROW(
+      SharedArbitrator::ExtraConfig::getReservedCapacity(configs),
+      "Failed while parsing SharedArbitrator configs");
+  VELOX_ASSERT_THROW(
+      SharedArbitrator::ExtraConfig::getMemoryPoolReservedCapacity(configs),
+      "Failed while parsing SharedArbitrator configs");
+  VELOX_ASSERT_THROW(
+      SharedArbitrator::ExtraConfig::getMemoryPoolTransferCapacity(configs),
+      "Failed while parsing SharedArbitrator configs");
+  VELOX_ASSERT_THROW(
+      SharedArbitrator::ExtraConfig::getMemoryReclaimWaitMs(configs),
+      "Failed while parsing SharedArbitrator configs");
+  VELOX_ASSERT_THROW(
+      SharedArbitrator::ExtraConfig::getGlobalArbitrationEnabled(configs),
+      "Failed while parsing SharedArbitrator configs");
+  VELOX_ASSERT_THROW(
+      SharedArbitrator::ExtraConfig::getCheckUsageLeak(configs),
+      "Failed while parsing SharedArbitrator configs");
+}
+
 TEST_F(MockSharedArbitrationTest, constructor) {
   const int reservedCapacity = arbitrator_->stats().freeReservedCapacityBytes;
   const int nonReservedCapacity =


### PR DESCRIPTION
MemoryArbitrator has information that is implementation dependent. E.g. reserved memory, memory pool transfer capacity and so on are all shared arbitrator (impl) dependent. This PR makes the API clean by removing these impl dependent information out from MemoryArbitrator.