### PR TITLE
Refactor internal time zone database

### DIFF
--- a/velox/type/tz/TimeZoneDatabase.cpp
+++ b/velox/type/tz/TimeZoneDatabase.cpp
@@ -30,12 +30,12 @@
 
 namespace facebook::velox::tz {
 
-const std::unordered_map<int64_t, std::string>& getTimeZoneDB() {
-  static auto* tzDB = new std::unordered_map<int64_t, std::string>([] {
+const std::vector<std::pair<int16_t, std::string>>& getTimeZoneEntries() {
+  static auto* tzDB = new std::vector<std::pair<int16_t, std::string>>([] {
     // Work around clang compiler bug causing multi-hour compilation
     // with -fsanitize=fuzzer
     // https://github.com/llvm/llvm-project/issues/75666
-    std::vector<std::pair<int64_t, std::string>> entries = {
+    return std::vector<std::pair<int16_t, std::string>>{
         {0, "+00:00"},
         {1, "-14:00"},
         {2, "-13:59"},
@@ -2266,8 +2266,6 @@ const std::unordered_map<int64_t, std::string>& getTimeZoneDB() {
         {2232, "Europe/Kyiv"},
         {2233, "America/Ciudad_Juarez"},
     };
-    return std::unordered_map<int64_t, std::string>(
-        entries.begin(), entries.end());
   }());
   return *tzDB;
 }

--- a/velox/type/tz/gen_timezone_database.py
+++ b/velox/type/tz/gen_timezone_database.py
@@ -52,16 +52,14 @@ cpp_template = Template(
 
 namespace facebook::velox::util {
 
-const std::unordered_map<int64_t, std::string>& getTimeZoneDB() {
-  static auto* tzDB = new std::unordered_map<int64_t, std::string>([] {
+const std::vector<std::pair<int16_t, std::string>>& getTimeZoneEntries() {
+  static auto* tzDB = new std::vector<std::pair<int16_t, std::string>>([] {
     // Work around clang compiler bug causing multi-hour compilation
     // with -fsanitize=fuzzer
     // https://github.com/llvm/llvm-project/issues/75666
-    std::vector<std::pair<int64_t, std::string>> entries = {
+    return std::vector<std::pair<int16_t, std::string>>{
 $entries
     };
-    return std::unordered_map<int64_t, std::string>(
-        entries.begin(), entries.end());
   }());
   return *tzDB;
 }

--- a/velox/type/tz/tests/TimeZoneMapTest.cpp
+++ b/velox/type/tz/tests/TimeZoneMapTest.cpp
@@ -41,6 +41,7 @@ TEST(TimeZoneMapTest, getTimeZoneID) {
   EXPECT_EQ(0, getTimeZoneID("UTC"));
   EXPECT_EQ(0, getTimeZoneID("GMT"));
   EXPECT_EQ(0, getTimeZoneID("Z"));
+  EXPECT_EQ(0, getTimeZoneID("z"));
   EXPECT_EQ(0, getTimeZoneID("greenwich"));
   EXPECT_EQ(0, getTimeZoneID("ETC/GMT"));
   EXPECT_EQ(0, getTimeZoneID("ETC/GMT0"));


### PR DESCRIPTION
Summary:
Refactoring the internal time zone database to prepare for the next
PR. Moving map from ID to string to vector, to remove the map access
for the hot path. Also re-organizing the code to allow them to
reference each other.

Part of https://github.com/facebookincubator/velox/issues/10101

Differential Revision: D60211961
