### PR TITLE
Fix timezone handling in to_iso8601(timestamp)

### DIFF
--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -1726,12 +1726,7 @@ struct ToISO8601Function {
       const core::QueryConfig& config,
       const arg_type<Timestamp>* /*input*/) {
     if (inputTypes[0]->isTimestamp()) {
-      auto sessionTzName = config.sessionTimezone();
-      if (!sessionTzName.empty()) {
-        timeZone_ = tz::locateZone(sessionTzName);
-      } else {
-        timeZone_ = tz::locateZone("UTC");
-      }
+      timeZone_ = getTimeZoneFromConfig(config);
     }
   }
 
@@ -1744,13 +1739,7 @@ struct ToISO8601Function {
   FOLLY_ALWAYS_INLINE void call(
       out_type<Varchar>& result,
       const arg_type<Timestamp>& timestamp) {
-    // TODO DateTimeFormatter requires timestamp in UTC. It then converts it to
-    // the specified timezone. We can avoid extra conversion if we change
-    // DateTimeFormatter to accept non-UTC timestamps.
-    auto utcTimestamp = timestamp;
-    utcTimestamp.toGMT(*timeZone_);
-
-    toIso8601(utcTimestamp, timeZone_, result);
+    toIso8601(timestamp, timeZone_, result);
   }
 
   FOLLY_ALWAYS_INLINE void call(

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -4426,19 +4426,27 @@ TEST_F(DateTimeFunctionsTest, toISO8601Timestamp) {
     return evaluateOnce<std::string>(
         "to_iso8601(c0)", std::make_optional(parseTimestamp(timestamp)));
   };
+  disableAdjustTimestampToTimezone();
+  EXPECT_EQ("2024-11-01T10:00:00.000+00:00", toIso("2024-11-01 10:00"));
+  EXPECT_EQ("2024-11-04T10:00:00.000+00:00", toIso("2024-11-04 10:00"));
+  EXPECT_EQ("2024-11-04T15:05:34.100+00:00", toIso("2024-11-04 15:05:34.1"));
+  EXPECT_EQ("2024-11-04T15:05:34.123+00:00", toIso("2024-11-04 15:05:34.123"));
+  EXPECT_EQ("0022-11-01T10:00:00.000+00:00", toIso("22-11-01 10:00"));
+
+  setQueryTimeZone("America/Los_Angeles");
+  EXPECT_EQ("2024-11-01T03:00:00.000-07:00", toIso("2024-11-01 10:00"));
 
   setQueryTimeZone("America/New_York");
-
-  EXPECT_EQ("2024-11-01T10:00:00.000-04:00", toIso("2024-11-01 10:00"));
-  EXPECT_EQ("2024-11-04T10:00:00.000-05:00", toIso("2024-11-04 10:00"));
-  EXPECT_EQ("2024-11-04T15:05:34.100-05:00", toIso("2024-11-04 15:05:34.1"));
-  EXPECT_EQ("2024-11-04T15:05:34.123-05:00", toIso("2024-11-04 15:05:34.123"));
-  EXPECT_EQ("0022-11-01T10:00:00.000-04:56:02", toIso("22-11-01 10:00"));
+  EXPECT_EQ("2024-11-01T06:00:00.000-04:00", toIso("2024-11-01 10:00"));
+  EXPECT_EQ("2024-11-04T05:00:00.000-05:00", toIso("2024-11-04 10:00"));
+  EXPECT_EQ("2024-11-04T10:05:34.100-05:00", toIso("2024-11-04 15:05:34.1"));
+  EXPECT_EQ("2024-11-04T10:05:34.123-05:00", toIso("2024-11-04 15:05:34.123"));
+  EXPECT_EQ("0022-11-01T05:03:58.000-04:56:02", toIso("22-11-01 10:00"));
 
   setQueryTimeZone("Asia/Kathmandu");
-
-  EXPECT_EQ("2024-11-01T10:00:00.000+05:45", toIso("2024-11-01 10:00"));
-  EXPECT_EQ("0022-11-01T10:00:00.000+05:41:16", toIso("22-11-01 10:00"));
+  EXPECT_EQ("2024-11-01T15:45:00.000+05:45", toIso("2024-11-01 10:00"));
+  EXPECT_EQ("0022-11-01T15:41:16.000+05:41:16", toIso("22-11-01 10:00"));
+  EXPECT_EQ("0022-11-01T15:41:16.000+05:41:16", toIso("22-11-01 10:00"));
 }
 
 TEST_F(DateTimeFunctionsTest, toISO8601TimestampWithTimezone) {


### PR DESCRIPTION
1. Current adjustment changes the actual unix time which is incorrect. Based on the [Presto implementation](https://github.com/prestodb/presto/blob/6a9f3cd9ef9f25855af9c4c6eb54d8612621eb84/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java#L255-L267), only the timestamp representation should be adjusted with the specified timezone.
2. Adjustment is needed only when `adjustTimestampToTimezone` is true.