### PR TITLE
Add support for time zone offsets to TimeZone

### DIFF
--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -23,9 +23,12 @@
 
 #include "velox/common/base/CheckedArithmetic.h"
 #include "velox/type/StringView.h"
-#include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox {
+
+namespace tz {
+class TimeZone;
+}
 
 enum class TimestampPrecision : int8_t {
   kMilliseconds = 3, // 10^3 milliseconds are equal to one second.

--- a/velox/type/tz/TimeZoneMap.h
+++ b/velox/type/tz/TimeZoneMap.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <string>
 
 namespace facebook::velox::date {
@@ -24,28 +25,25 @@ class time_zone;
 
 namespace facebook::velox::tz {
 
-/// This library provides time zone lookup and mapping utilities, in addition to
-/// functions to enable timestamp conversions across time zones. It leverages
-/// the velox/external/date underneath to perform conversions.
+/// This library provides time zone management primitives. It maintains an
+/// internal static database which is contructed lazily based on the first
+/// access, based on TimeZoneDatabase.cpp and the local tzdata installed in your
+/// system (through velox/external/date).
 ///
-/// This library provides a thin layer of functionality on top of
-/// velox/external/date for timezone lookup and conversions, so don't use the
-/// external library directly.
+/// It provides functions for one to lookup TimeZone pointers based on time zone
+/// name or ID, and to performance timestamp conversion across time zones.
+///
+/// This library provides a layer of functionality on top of
+/// velox/external/date, so do not use the external library directly for
+/// time zone routines.
 
-/// TimeZone is the object that allows conversions across timezones using the
-/// .to_sys() and .to_local() methods, as documented in:
-///
-///   https://howardhinnant.github.io/date/tz.html
-///
-using TimeZone = date::time_zone;
+class TimeZone;
 
-/// TimeZone pointers can be found using `locateZone()`.
-///
-/// This function in mostly implemented by velox/external/date, and performs a
-/// binary search in the internal time zone database. On the first call,
-/// velox/external/date will initialize a static list of timezone, read from the
-/// local tzdata database.
-const TimeZone* locateZone(std::string_view timeZone);
+/// Looks up a TimeZone pointer based on a time zone name. This makes an hash
+/// map access, and will construct the index on the first access. `failOnError`
+/// controls whether to throw or return nullptr in case the time zone was not
+/// found.
+const TimeZone* locateZone(std::string_view timeZone, bool failOnError = true);
 
 /// Returns the timezone name associated with timeZoneID.
 std::string getTimeZoneName(int64_t timeZoneID);
@@ -58,6 +56,89 @@ int16_t getTimeZoneID(std::string_view timeZone, bool failOnError = true);
 /// Returns the timeZoneID for a given offset in minutes. The offset must be in
 /// [-14:00, +14:00] range.
 int16_t getTimeZoneID(int32_t offsetMinutes);
+
+/// TimeZone is the proxy object for time zone management. It provides access to
+/// time zone names, their IDs (as defined in TimeZoneDatabase.cpp and
+/// consistent with Presto), and utilities for timestamp conversion across
+/// timezones by leveraging the .to_sys() and .to_local() methods as documented
+/// in:
+///
+///   https://howardhinnant.github.io/date/tz.html
+///
+/// Do not create your own objects; rather, look up a pointer by using one of
+/// the methods above.
+class TimeZone {
+ public:
+  // Constructor for regular time zones with a name and a pointer to
+  // external/date time zone database (from tzdata).
+  TimeZone(
+      std::string_view timeZoneName,
+      int16_t timeZoneID,
+      const date::time_zone* tz)
+      : tz_(tz),
+        offset_(0),
+        timeZoneName_(timeZoneName),
+        timeZoneID_(timeZoneID) {}
+
+  // Constructor for time zone offsets ("+00:00").
+  TimeZone(
+      std::string_view timeZoneName,
+      int16_t timeZoneID,
+      std::chrono::minutes offset)
+      : tz_(nullptr),
+        offset_(offset),
+        timeZoneName_(timeZoneName),
+        timeZoneID_(timeZoneID) {}
+
+  // Do not copy it.
+  TimeZone(const TimeZone&) = delete;
+  TimeZone& operator=(const TimeZone&) = delete;
+
+  using seconds = std::chrono::seconds;
+
+  /// Converts a local time (the time as perceived in the user time zone
+  /// represented by this object) to a system time (the corresponding time in
+  /// GMT at the same instant).
+  ///
+  /// Conversions from local time to GMT are non-linear and may be ambiguous
+  /// during day light savings transitions, or non existent. By default (kFail),
+  /// `to_sys()` will throw `date::ambiguous_local_time` and
+  /// `date::nonexistent_local_time` in these cases.
+  ///
+  /// You can overwrite the behavior in ambiguous conversions by setting the
+  /// TChoose flag, but it will still throws in case of nonexistent conversions.
+  enum class TChoose {
+    kFail = 0,
+    kEarliest = 1,
+    kLatest = 2,
+  };
+
+  seconds to_sys(seconds timestamp, TChoose choose = TChoose::kFail) const;
+
+  /// Do the opposite conversion. Taking a system time (the time as perceived in
+  /// GMT), convert to the same instant in time as observed in the user local
+  /// time represented by this object). Note that this conversion is not
+  /// susceptible to the error above.
+  seconds to_local(seconds timestamp) const;
+
+  const std::string& name() const {
+    return timeZoneName_;
+  }
+
+  int16_t id() const {
+    return timeZoneID_;
+  }
+
+  const date::time_zone* tz() const {
+    return tz_;
+  }
+
+ private:
+  const date::time_zone* tz_{nullptr};
+  const std::chrono::minutes offset_{0};
+  const std::string timeZoneName_;
+  const int16_t timeZoneID_;
+};
 
 } // namespace facebook::velox::tz
 


### PR DESCRIPTION
Summary:

Adding a new TimeZone class and adding support for time zone offsets to it. 
Now, we will be able to clean up the callsites to use this single APIs, which will
contain time zone name, ID, and conversion capabilities in a more consistent
manner.

Part of https://github.com/facebookincubator/velox/issues/10101 and #8037

Reviewed By: mbasmanova

Differential Revision: D60213004
