### PR TITLE
OrcReaderTest: Copy test input files to the binary dir

### DIFF
--- a/velox/dwio/orc/test/CMakeLists.txt
+++ b/velox/dwio/orc/test/CMakeLists.txt
@@ -25,3 +25,6 @@ target_link_libraries(
   gtest
   gtest_main
   gmock)
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/examples
+     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
This is a follow-up PR of #10194 to address test failures in the out-of-source build:

```
E20240728 Exceptions.h:67] Line: velox/velox/common/file/File.cpp:112, Function:LocalReadFile, Expression:  No such file or directory: cmake-build-debug/velox/velox/dwio/orc/test/examples/TestStringDictionary.testRowIndex.orc, Source: RUNTIME, ErrorCode: FILE_NOT_FOUND
E20240728 Exceptions.h:67] Line: velox/velox/common/file/File.cpp:112, Function:LocalReadFile, Expression:  No such file or directory: cmake-build-debug/velox/velox/dwio/orc/test/examples/complextypes_iceberg.orc, Source: RUNTIME, ErrorCode: FILE_NOT_FOUND
E20240728 Exceptions.h:67] Line: velox/velox/common/file/File.cpp:112, Function:LocalReadFile, Expression:  No such file or directory: cmake-build-debug/velox/velox/dwio/orc/test/examples/orc_index_int_string.orc, Source: RUNTIME, ErrorCode: FILE_NOT_FOUND
E20240728 Exceptions.h:67] Line: velox/velox/common/file/File.cpp:112, Function:LocalReadFile, Expression:  No such file or directory: cmake-build-debug/velox/velox/dwio/orc/test/examples/TestOrcFile.testDate1900.orc, Source: RUNTIME, ErrorCode: FILE_NOT_FOUND
E20240728 Exceptions.h:67] Line: velox/velox/common/file/File.cpp:112, Function:LocalReadFile, Expression:  No such file or directory: cmake-build-debug/velox/velox/dwio/orc/test/examples/orc_all_type.orc, Source: RUNTIME, ErrorCode: FILE_NOT_FOUND
```