### PR TITLE
Fix IN on complex type inputs with NULL elements

### DIFF
--- a/velox/functions/prestosql/InPredicate.cpp
+++ b/velox/functions/prestosql/InPredicate.cpp
@@ -20,6 +20,7 @@
 namespace facebook::velox::functions {
 namespace {
 
+// TODO: Fix this class to follow the same behavior as InPredicate.h.
 // Returns NULL if
 // - input value is NULL or contains NULL;
 // - input value doesn't match any of the in-list values, but some of in-list

--- a/velox/functions/prestosql/InPredicate.h
+++ b/velox/functions/prestosql/InPredicate.h
@@ -15,10 +15,16 @@
  */
 #pragma once
 
+#include "velox/common/base/CompareFlags.h"
 #include "velox/functions/Macros.h"
 
 namespace facebook::velox::functions {
 
+// Returns NULL if
+// - input value is NULL
+// - in-list is NULL or empty
+// - input value doesn't have an exact match, but has an indeterminate match in
+// the in-list. E.g., array[null] in (array[1]) or array[1] in (array[null]).
 template <typename TExec>
 struct GenericInPredicateFunction {
   VELOX_DEFINE_FUNCTION_TYPES(TExec);
@@ -35,10 +41,17 @@ struct GenericInPredicateFunction {
       return false;
     }
 
+    const static auto compareFlag = CompareFlags::equality(
+        CompareFlags::NullHandlingMode::kNullAsIndeterminate);
     bool hasNull = false;
     for (const auto& v : *inList) {
       if (v.has_value()) {
-        if (*value == v) {
+        auto compareResult = value->compare(v.value(), compareFlag);
+        if UNLIKELY (!compareResult.has_value()) {
+          hasNull = true;
+          continue;
+        }
+        if (compareResult.value() == 0) {
           result = true;
           return true; // Non-NULL result.
         }
@@ -46,8 +59,12 @@ struct GenericInPredicateFunction {
         hasNull = true;
       }
     }
-
-    return !hasNull;
+    if (hasNull) {
+      return false;
+    } else {
+      result = false;
+      return true;
+    }
   }
 };
 


### PR DESCRIPTION
Summary:
When input columns of an expression `a IN (b, c)` are complex-typed, NULLs nested in the 
complex-typed values are treated as indeterminate in Presto. E.g., `select c0 in (c0, c0) from (values (array[array[1, null]])) t(c0) -- NULL`. 
However, Velox currently returns `true` for this query. This diff fixes IN with non-constant in-list to 
follow the Presto behavior.

This is a fix of https://github.com/facebookincubator/velox/issues/10570.

Differential Revision: D60397542
