### PR TITLE
Add IPAddress Presto type

### DIFF
--- a/velox/docs/develop/types.rst
+++ b/velox/docs/develop/types.rst
@@ -136,6 +136,7 @@ HYPERLOGLOG               VARBINARY
 JSON                      VARCHAR
 TIMESTAMP WITH TIME ZONE  BIGINT
 UUID                      HUGEINT
+IPADDRESS                 HUGEINT
 ========================  =====================
 
 TIMESTAMP WITH TIME ZONE represents a time point in milliseconds precision

--- a/velox/docs/develop/types.rst
+++ b/velox/docs/develop/types.rst
@@ -148,7 +148,7 @@ store timezone ID. Supported range of timezone ID is [1, 1680].
 The definition of timezone IDs can be found in ``TimeZoneDatabase.cpp``.
 
 IPADDRESS represents an IPV6 or IPV4 formatted IPV6 address. Its physical
-type is BIGINT. The format that the address is stored in is defined as part of `(RFC 4291#section-2.5.5.2) <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.5.5.2>`_
+type is HUGEINT. The format that the address is stored in is defined as part of `(RFC 4291#section-2.5.5.2) <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.5.5.2>`_
 As Velox is run on Little Endian systems and the standard is network byte(Big Endian)
 order, we reverse the bytes to allow for masking and other bit operations
 used in IPADDRESS/IPPREFIX related functions. This type can be used to

--- a/velox/docs/develop/types.rst
+++ b/velox/docs/develop/types.rst
@@ -147,6 +147,14 @@ Supported range of milliseconds is [0xFFF8000000000000L, 0x7FFFFFFFFFFFF]
 store timezone ID. Supported range of timezone ID is [1, 1680].
 The definition of timezone IDs can be found in ``TimeZoneDatabase.cpp``.
 
+IPADDRESS represents an IPV6 or IPV4 formatted IPV6 address. Its physical
+type is BIGINT. The format that the address is stored in is defined as part of `(RFC 4291#section-2.5.5.2) <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.5.5.2>`_
+As Velox is run on Little Endian systems and the standard is network byte(Big Endian)
+order, we reverse the bytes to allow for masking and other bit operations
+used in IPADDRESS/IPPREFIX related functions. This type can be used to
+create IPPREFIX networks as well as to check IPADDRESS validity within
+IPPREFIX netowrks.
+
 Spark Types
 ~~~~~~~~~~~~
 The `data types <https://spark.apache.org/docs/latest/sql-ref-datatypes.html>`_ in Spark have some semantic differences compared to those in 

--- a/velox/docs/develop/types.rst
+++ b/velox/docs/develop/types.rst
@@ -153,7 +153,7 @@ As Velox is run on Little Endian systems and the standard is network byte(Big En
 order, we reverse the bytes to allow for masking and other bit operations
 used in IPADDRESS/IPPREFIX related functions. This type can be used to
 create IPPREFIX networks as well as to check IPADDRESS validity within
-IPPREFIX netowrks.
+IPPREFIX networks.
 
 Spark Types
 ~~~~~~~~~~~~

--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -991,19 +991,20 @@ IPV4 or IPV6.
 For IPV4 it must be in the form of:
 x.x.x.x where each x is an integer value between 0-255.
 
-For IPV6 it must follow any of the forms defined in `RFC 4291#section-2.2 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.2>`_
-1. Full form:
+For IPV6 it must follow any of the forms defined in `RFC 4291#section-2.2 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.2>`_.
+
+Full form:
 
 ::
 
    2001:0DB8:0000:0000:0008:0800:200C:417A
    2001:DB8:0:0:8:800:200C:417A
 
-2. Compressed form:
+Compressed form:
 ::
   2001:DB8::8:800:200C:417A
 
-3. Alternate form:
+Alternate form:
 ::
   0:0:0:0:0:0:13.1.68.3
   ::13.1.68.3
@@ -1014,7 +1015,7 @@ When creating an IPADDRESS, IPv4 addresses will be mapped into that range.
 When formatting an IPADDRESS, any address within the mapped range will be formatted as an IPv4 address.
 Other addresses will be formatted as IPv6 using the canonical format defined in `RFC 5952 <https://datatracker.ietf.org/doc/html/rfc5952.html>`_.
 
-Valid examples
+Valid examples:
 
 ::
 
@@ -1022,7 +1023,7 @@ Valid examples
   SELECT cast('1.2.3.4' as ipaddress); -- ipaddress '1.2.3.4'
   SELECT cast('::ffff:ffff:ffff' as ipaddress); -- ipaddress '255.255.255.255'
 
-Invalid examples
+Invalid examples:
 
 ::
 
@@ -1034,10 +1035,32 @@ From VARBINARY
 
 To cast a varbinary to IPAddress it must be either IPV4(4 Bytes)
 or IPV6(16 Bytes) in network byte order.
-All IPV6 addresses in the form of an IPV4 mapped IPV6
-address will be assumed to be IPV4 addresses. 
 
-Valid examples
+IPV4:
+
+::
+
+[01, 02, 03, 04] -> 1.2.3.4
+
+IPV6:
+
+::
+
+[0x20, 0x01, 0x0d, 0xb8 0x00, 0x00, 0x00, 0x00 0x00 0x00, 0xff, 0x00, 0x00, 0x42, 0x83, 0x29] -> 2001:db8::ff00:42:8329
+
+Internally, the type is a pure IPv6 address. Support for IPv4 is handled using the IPv4-mapped IPv6 address range `(RFC 4291#section-2.5.5.2) <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.5.5.2>`_.
+When creating an IPADDRESS, IPv4 addresses will be mapped into that range.
+
+When formatting an IPADDRESS, any address within the mapped range will be formatted as an IPv4 address.
+Other addresses will be formatted as IPv6 using the canonical format defined in `RFC 5952 <https://datatracker.ietf.org/doc/html/rfc5952.html>`_.
+
+IPV6 mapped IPV4 address:
+
+::
+
+[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0x01, 0x02, 0x03, 0x04] -> 1.2.3.4
+
+Valid examples:
 
 ::
 
@@ -1045,11 +1068,11 @@ Valid examples
   SELECT cast(from_hex('01020304') as ipaddress); -- ipaddress '1.2.3.4'
   SELECT cast(from_hex('00000000000000000000ffff01020304') as ipaddress); -- ipaddress '1.2.3.4'
 
-Invalid examples
+Invalid examples:
 
 ::
 
-  SELECT cast(from_hex('f000001100') as ipaddress); -- Varbinary length 5, must be IPV4(4), or IPV6(16)
+  SELECT cast(from_hex('f000001100') as ipaddress); -- Invalid IP address binary length: 5
 
 Miscellaneous
 -------------

--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -668,7 +668,7 @@ From IPADDRESS
 ^^^^^^^^^^^^^^
 
 Casting from IPADDRESS to VARCHAR returns a string formatted as x.x.x.x for IPV4 formatted IPV6 addresses.
-For all other IPV6 addresses it will be formatted in compressed IPV6 defined in `RFC 4291#section-2.2 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.2>`_
+For all other IPV6 addresses it will be formatted in compressed alternate form IPV6 defined in `RFC 4291#section-2.2 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.2>`_
 
 IPV4:
 
@@ -681,6 +681,7 @@ IPV6:
 ::
 
   SELECT cast(ipaddress '2001:0db8:0000:0000:0000:ff00:0042:8329' as varchar); -- '2001:db8::ff00:42:8329'
+  SELECT cast(ipaddress '0:0:0:0:0:0:13.1.68.3' as varchar); -- '::13.1.68.3'
 
 IPV4 mapped IPV6:
 

--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -979,16 +979,40 @@ Invalid example
   SELECT cast('-3E+2.1' as decimal(12, 2)); -- Value is not a number
   SELECT cast('3E+' as decimal(12, 2)); -- Value is not a number
 
-Cast to IPAddress
+Cast to IPADDRESS
 ---------------
 
-From varchar type
+From VARCHAR
 ^^^^^^^^^^^^^^^^^
 
-To cast a varchar to IPAddress it must be in the form of either
-IPV4 or IPV6. It can be written in full form or shortened form.
-All IPV6 addresses that have the form of an IPV4 mapped IPV6
-address will be assumed to be IPV4 addresses. 
+To cast a varchar to IPAddress input string must be in the form of either
+IPV4 or IPV6.
+
+For IPV4 it must be in the form of:
+x.x.x.x where each x is an integer value between 0-255.
+
+For IPV6 it must follow any of the forms defined in `RFC 4291#section-2.2 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.2>`_
+1. Full form:
+
+::
+
+   2001:0DB8:0000:0000:0008:0800:200C:417A
+   2001:DB8:0:0:8:800:200C:417A
+
+2. Compressed form:
+::
+  2001:DB8::8:800:200C:417A
+
+3. Alternate form:
+::
+  0:0:0:0:0:0:13.1.68.3
+  ::13.1.68.3
+
+Internally, the type is a pure IPv6 address. Support for IPv4 is handled using the IPv4-mapped IPv6 address range `(RFC 4291#section-2.5.5.2) <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.5.5.2>`_.
+When creating an IPADDRESS, IPv4 addresses will be mapped into that range.
+
+When formatting an IPADDRESS, any address within the mapped range will be formatted as an IPv4 address.
+Other addresses will be formatted as IPv6 using the canonical format defined in `RFC 5952 <https://datatracker.ietf.org/doc/html/rfc5952.html>`_.
 
 Valid examples
 
@@ -1005,12 +1029,12 @@ Invalid examples
   SELECT cast('2001:db8::1::1' as ipaddress); -- Invalid IP address
   SELECT cast('789.1.1.1' as ipaddress); -- Invalid IP address
 
-From varbinary type
+From VARBINARY
 ^^^^^^^^^^^^^^^^^
 
 To cast a varbinary to IPAddress it must be either IPV4(4 Bytes)
 or IPV6(16 Bytes) in network byte order.
-All IPV6 addresses that have the form of an IPV4 mapped IPV6
+All IPV6 addresses in the form of an IPV4 mapped IPV6
 address will be assumed to be IPV4 addresses. 
 
 Valid examples

--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -664,6 +664,59 @@ is the number of whole days in the interval, HH is then number of hours between 
     SELECT cast(now() - date('2024-03-01') as varchar); -- '35 09:15:54.092'
     SELECT cast(date('2024-03-01') - now() as varchar); -- '-35 09:16:20.598'
 
+From IPADDRESS
+^^^^^^^^^^^^^^
+
+Casting from IPADDRESS to VARCHAR returns a string formatted as x.x.x.x for IPV4 formatted IPV6 addresses.
+For all other IPV6 addresses it will be formatted in compressed IPV6 defined in `RFC 4291#section-2.2 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.2>`_
+
+IPV4:
+
+::
+
+  SELECT cast(ipaddress '1.2.3.4' as varchar); -- '1.2.3.4'
+
+IPV6:
+
+::
+
+  SELECT cast(ipaddress '2001:0db8:0000:0000:0000:ff00:0042:8329' as varchar); -- '2001:db8::ff00:42:8329'
+
+IPV4 mapped IPV6:
+
+::
+
+  SELECT cast(ipaddress '::ffff:ffff:ffff' as varchar); -- '255.255.255.255'
+
+Cast to VARBINARY
+-----------------
+
+From IPADDRESS
+^^^^^^^^^^^^^^
+
+Returns the IPV6 address as a 16 byte varbinary string in network byte order.
+
+Internally, the type is a pure IPv6 address. Support for IPv4 is handled using the IPv4-mapped IPv6 address range `(RFC 4291#section-2.5.5.2) <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.5.5.2>`_.
+When creating an IPADDRESS, IPv4 addresses will be mapped into that range.
+
+IPV6:
+
+::
+
+  SELECT cast(ipaddress '2001:0db8:0000:0000:0000:ff00:0042:8329' as varbinary); -- 0x20010db8000000000000ff0000428329
+
+IPV4:
+
+::
+
+  SELECT cast('1.2.3.4' as ipaddress); -- 0x00000000000000000000ffff01020304
+
+IPV4 mapped IPV6:
+
+::
+
+  SELECT cast('::ffff:ffff:ffff' as ipaddress); -- 0x00000000000000000000ffffffffffff
+
 Cast to TIMESTAMP
 -----------------
 
@@ -980,10 +1033,10 @@ Invalid example
   SELECT cast('3E+' as decimal(12, 2)); -- Value is not a number
 
 Cast to IPADDRESS
----------------
+-----------------
 
 From VARCHAR
-^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^
 
 To cast a varchar to IPAddress input string must be in the form of either
 IPV4 or IPV6.
@@ -1031,7 +1084,7 @@ Invalid examples:
   SELECT cast('789.1.1.1' as ipaddress); -- Invalid IP address
 
 From VARBINARY
-^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^
 
 To cast a varbinary to IPAddress it must be either IPV4(4 Bytes)
 or IPV6(16 Bytes) in network byte order.

--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -1080,8 +1080,8 @@ Invalid examples:
 
 ::
 
-  SELECT cast('2001:db8::1::1' as ipaddress); -- Invalid IP address
-  SELECT cast('789.1.1.1' as ipaddress); -- Invalid IP address
+  SELECT cast('2001:db8::1::1' as ipaddress); -- Invalid IP address '2001:db8::1::1'
+  SELECT cast('789.1.1.1' as ipaddress); -- Invalid IP address '789.1.1.1'
 
 From VARBINARY
 ^^^^^^^^^^^^^^

--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -30,7 +30,7 @@ are supported if the conversion of their element types are supported. In additio
 supported conversions to/from JSON are listed in :doc:`json`.
 
 .. list-table::
-   :widths: 25 25 25 25 25 25 25 25 25 25 25 25 25 25
+   :widths: 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25
    :header-rows: 1
 
    * -
@@ -42,11 +42,13 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - real
      - double
      - varchar
+     - varbinary
      - timestamp
      - timestamp with time zone
      - date
      - interval day to second
      - decimal
+     - ipaddress
    * - tinyint
      - Y
      - Y
@@ -56,11 +58,13 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
+     - 
      -
      -
      -
      -
      - Y
+     - 
    * - smallint
      - Y
      - Y
@@ -70,11 +74,13 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
+     - 
      -
      -
      -
      -
      - Y
+     - 
    * - integer
      - Y
      - Y
@@ -84,11 +90,13 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
+     - 
      -
      -
      -
      -
      - Y
+     - 
    * - bigint
      - Y
      - Y
@@ -98,11 +106,13 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
+     - 
      -
      -
      -
      -
      - Y
+     - 
    * - boolean
      - Y
      - Y
@@ -112,11 +122,13 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
+     - 
      -
      -
      -
      -
      - Y
+     - 
    * - real
      - Y
      - Y
@@ -126,11 +138,13 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
+     - 
      -
      -
      -
      -
      - Y
+     - 
    * - double
      - Y
      - Y
@@ -140,11 +154,13 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
+     - 
      -
      -
      -
      -
      - Y
+     - 
    * - varchar
      - Y
      - Y
@@ -154,10 +170,28 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
+     - 
      - Y
      - Y
      - Y
      -
+     - Y
+     - Y
+   * - varbinary
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     -
+     - 
      - Y
    * - timestamp
      -
@@ -168,11 +202,13 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      - Y
+     - 
      - Y
      - Y
      - Y
      -
      -
+     - 
    * - timestamp with time zone
      -
      -
@@ -182,9 +218,11 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      - Y
+     - 
      - Y
      -
      - Y
+     -
      -
      -
    * - date
@@ -196,8 +234,10 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      - Y
+     - 
      - Y
      - Y
+     -
      -
      -
      -
@@ -210,6 +250,8 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      - Y
+     - 
+     -
      -
      -
      -
@@ -224,11 +266,29 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
+     - 
      -
      -
      -
      -
      - Y
+     -
+   * - ipaddress
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - Y
+     - Y
+     -
+     -
+     -
+     -
+     - 
+     - 
 
 Cast to Integral Types
 ----------------------
@@ -918,6 +978,54 @@ Invalid example
   SELECT cast(' -3E+2' as decimal(12, 2)); -- Value is not a number
   SELECT cast('-3E+2.1' as decimal(12, 2)); -- Value is not a number
   SELECT cast('3E+' as decimal(12, 2)); -- Value is not a number
+
+Cast to IPAddress
+---------------
+
+From varchar type
+^^^^^^^^^^^^^^^^^
+
+To cast a varchar to IPAddress it must be in the form of either
+IPV4 or IPV6. It can be written in full form or shortened form.
+All IPV6 addresses that have the form of an IPV4 mapped IPV6
+address will be assumed to be IPV4 addresses. 
+
+Valid examples
+
+::
+
+  SELECT cast('2001:0db8:0000:0000:0000:ff00:0042:8329' as ipaddress); -- ipaddress '2001:db8::ff00:42:8329'
+  SELECT cast('1.2.3.4' as ipaddress); -- ipaddress '1.2.3.4'
+  SELECT cast('::ffff:ffff:ffff' as ipaddress); -- ipaddress '255.255.255.255'
+
+Invalid examples
+
+::
+
+  SELECT cast('2001:db8::1::1' as ipaddress); -- Invalid IP address
+  SELECT cast('789.1.1.1' as ipaddress); -- Invalid IP address
+
+From varbinary type
+^^^^^^^^^^^^^^^^^
+
+To cast a varbinary to IPAddress it must be either IPV4(4 Bytes)
+or IPV6(16 Bytes) in network byte order.
+All IPV6 addresses that have the form of an IPV4 mapped IPV6
+address will be assumed to be IPV4 addresses. 
+
+Valid examples
+
+::
+
+  SELECT cast(from_hex('20010db8000000000000ff0000428329') as ipaddress); -- ipaddress '2001:db8::ff00:42:8329'
+  SELECT cast(from_hex('01020304') as ipaddress); -- ipaddress '1.2.3.4'
+  SELECT cast(from_hex('00000000000000000000ffff01020304') as ipaddress); -- ipaddress '1.2.3.4'
+
+Invalid examples
+
+::
+
+  SELECT cast(from_hex('f000001100') as ipaddress); -- Varbinary length 5, must be IPV4(4), or IPV6(16)
 
 Miscellaneous
 -------------

--- a/velox/expression/tests/CustomTypeTest.cpp
+++ b/velox/expression/tests/CustomTypeTest.cpp
@@ -216,6 +216,7 @@ TEST_F(CustomTypeTest, getCustomTypeNames) {
           "HYPERLOGLOG",
           "TIMESTAMP WITH TIME ZONE",
           "UUID",
+          "IPADDRESS",
       }),
       names);
 
@@ -229,6 +230,7 @@ TEST_F(CustomTypeTest, getCustomTypeNames) {
           "HYPERLOGLOG",
           "TIMESTAMP WITH TIME ZONE",
           "UUID",
+          "IPADDRESS",
           "FANCY_INT",
       }),
       names);

--- a/velox/functions/prestosql/IPAddressFunctions.h
+++ b/velox/functions/prestosql/IPAddressFunctions.h
@@ -15,9 +15,6 @@
  */
 #pragma once
 
-#include "velox/functions/Macros.h"
-#include "velox/functions/Registerer.h"
-#include "velox/functions/lib/string/StringImpl.h"
 #include "velox/functions/prestosql/types/IPAddressType.h"
 
 namespace facebook::velox::functions {

--- a/velox/functions/prestosql/IPAddressFunctions.h
+++ b/velox/functions/prestosql/IPAddressFunctions.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/functions/Macros.h"
+#include "velox/functions/Registerer.h"
+#include "velox/functions/lib/string/StringImpl.h"
+#include "velox/functions/prestosql/types/IPAddressType.h"
+
+namespace facebook::velox::functions {
+
+void registerIPAddressFunctions(const std::string& prefix) {
+  registerIPAddressType();
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/TypeOf.cpp
+++ b/velox/functions/prestosql/TypeOf.cpp
@@ -55,8 +55,7 @@ std::string typeName(const TypePtr& type) {
     case TypeKind::HUGEINT: {
       if (isUuidType(type)) {
         return "uuid";
-      }
-      else if (isIPAddressType(type)) {
+      } else if (isIPAddressType(type)) {
         return "ipaddress";
       }
       VELOX_USER_CHECK(

--- a/velox/functions/prestosql/TypeOf.cpp
+++ b/velox/functions/prestosql/TypeOf.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
+#include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/functions/prestosql/types/UuidType.h"
@@ -54,6 +55,9 @@ std::string typeName(const TypePtr& type) {
     case TypeKind::HUGEINT: {
       if (isUuidType(type)) {
         return "uuid";
+      }
+      else if (isIPAddressType(type)) {
+        return "ipaddress";
       }
       VELOX_USER_CHECK(
           type->isDecimal(),

--- a/velox/functions/prestosql/registration/RegistrationFunctions.cpp
+++ b/velox/functions/prestosql/registration/RegistrationFunctions.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 #include <string>
-#include "velox/functions/prestosql/UuidFunctions.h"
 #include "velox/functions/prestosql/IPAddressFunctions.h"
+#include "velox/functions/prestosql/UuidFunctions.h"
 
 namespace facebook::velox::functions {
 

--- a/velox/functions/prestosql/registration/RegistrationFunctions.cpp
+++ b/velox/functions/prestosql/registration/RegistrationFunctions.cpp
@@ -15,6 +15,7 @@
  */
 #include <string>
 #include "velox/functions/prestosql/UuidFunctions.h"
+#include "velox/functions/prestosql/IPAddressFunctions.h"
 
 namespace facebook::velox::functions {
 
@@ -108,6 +109,7 @@ void registerAllScalarFunctions(const std::string& prefix) {
   registerBinaryFunctions(prefix);
   registerBitwiseFunctions(prefix);
   registerUuidFunctions(prefix);
+  registerIPAddressFunctions(prefix);
 }
 
 void registerMapAllowingDuplicates(

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -64,6 +64,7 @@ add_executable(
   HyperLogLogCastTest.cpp
   HyperLogLogFunctionsTest.cpp
   InPredicateTest.cpp
+  IPAddressFunctionsTest.cpp
   JsonCastTest.cpp
   JsonExtractScalarTest.cpp
   JsonFunctionsTest.cpp

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -64,7 +64,7 @@ add_executable(
   HyperLogLogCastTest.cpp
   HyperLogLogFunctionsTest.cpp
   InPredicateTest.cpp
-  IPAddressFunctionsTest.cpp
+  IPAddressCastTest.cpp
   JsonCastTest.cpp
   JsonExtractScalarTest.cpp
   JsonFunctionsTest.cpp

--- a/velox/functions/prestosql/tests/IPAddressCastTest.cpp
+++ b/velox/functions/prestosql/tests/IPAddressCastTest.cpp
@@ -37,8 +37,7 @@ class IPAddressCastTest : public functions::test::FunctionBaseTest {
     return result;
   }
 
-  std::optional<std::string> allCasts(
-      const std::optional<std::string> input) {
+  std::optional<std::string> allCasts(const std::optional<std::string> input) {
     auto result = evaluateOnce<std::string>(
         "cast(cast(cast(cast(c0 as ipaddress) as varbinary) as ipaddress) as varchar)",
         input);
@@ -53,28 +52,26 @@ TEST_F(IPAddressCastTest, castToVarchar) {
   EXPECT_EQ(
       castToVarchar("2001:0db8:0000:0000:0000:ff00:0042:8329"),
       "2001:db8::ff00:42:8329");
+  EXPECT_EQ(castToVarchar("2001:db8::ff00:42:8329"), "2001:db8::ff00:42:8329");
+  EXPECT_EQ(castToVarchar("2001:db8:0:0:1:0:0:1"), "2001:db8::1:0:0:1");
+  EXPECT_EQ(castToVarchar("2001:db8:0:0:1::1"), "2001:db8::1:0:0:1");
+  EXPECT_EQ(castToVarchar("2001:db8::1:0:0:1"), "2001:db8::1:0:0:1");
   EXPECT_EQ(
-      castToVarchar("2001:db8::ff00:42:8329"),
-      "2001:db8::ff00:42:8329");
-  EXPECT_EQ(
-      castToVarchar("2001:db8:0:0:1:0:0:1"), "2001:db8::1:0:0:1");
-  EXPECT_EQ(
-      castToVarchar("2001:db8:0:0:1::1"), "2001:db8::1:0:0:1");
-  EXPECT_EQ(
-      castToVarchar("2001:db8::1:0:0:1"), "2001:db8::1:0:0:1");
-  EXPECT_EQ(
-      castToVarchar("2001:DB8::FF00:ABCD:12EF"),
-      "2001:db8::ff00:abcd:12ef");
-  VELOX_ASSERT_THROW(castToVarchar("facebook.com"), "Invalid IP address 'facebook.com'");
-  VELOX_ASSERT_THROW(castToVarchar("localhost"), "Invalid IP address 'localhost'");
-  VELOX_ASSERT_THROW(castToVarchar("2001:db8::1::1"), "Invalid IP address '2001:db8::1::1'");
-  VELOX_ASSERT_THROW(castToVarchar("2001:zxy::1::1"), "Invalid IP address '2001:zxy::1::1'");
-  VELOX_ASSERT_THROW(castToVarchar("789.1.1.1"), "Invalid IP address '789.1.1.1'");
+      castToVarchar("2001:DB8::FF00:ABCD:12EF"), "2001:db8::ff00:abcd:12ef");
+  VELOX_ASSERT_THROW(
+      castToVarchar("facebook.com"), "Invalid IP address 'facebook.com'");
+  VELOX_ASSERT_THROW(
+      castToVarchar("localhost"), "Invalid IP address 'localhost'");
+  VELOX_ASSERT_THROW(
+      castToVarchar("2001:db8::1::1"), "Invalid IP address '2001:db8::1::1'");
+  VELOX_ASSERT_THROW(
+      castToVarchar("2001:zxy::1::1"), "Invalid IP address '2001:zxy::1::1'");
+  VELOX_ASSERT_THROW(
+      castToVarchar("789.1.1.1"), "Invalid IP address '789.1.1.1'");
 }
 
 TEST_F(IPAddressCastTest, castToVarbinary) {
-  EXPECT_EQ(
-      castToVarbinary("00000000000000000000ffff01020304"), "1.2.3.4");
+  EXPECT_EQ(castToVarbinary("00000000000000000000ffff01020304"), "1.2.3.4");
   EXPECT_EQ(castToVarbinary("01020304"), "1.2.3.4");
   EXPECT_EQ(castToVarbinary("c0a80000"), "192.168.0.0");
   EXPECT_EQ(
@@ -88,9 +85,7 @@ TEST_F(IPAddressCastTest, allCasts) {
   EXPECT_EQ(
       allCasts("2001:0db8:0000:0000:0000:ff00:0042:8329"),
       "2001:db8::ff00:42:8329");
-  EXPECT_EQ(
-      allCasts("2001:db8::ff00:42:8329"),
-      "2001:db8::ff00:42:8329");
+  EXPECT_EQ(allCasts("2001:db8::ff00:42:8329"), "2001:db8::ff00:42:8329");
 }
 
 TEST_F(IPAddressCastTest, nullTest) {

--- a/velox/functions/prestosql/tests/IPAddressCastTest.cpp
+++ b/velox/functions/prestosql/tests/IPAddressCastTest.cpp
@@ -21,23 +21,23 @@ namespace facebook::velox::functions::prestosql {
 
 namespace {
 
-class IPAddressTest : public functions::test::FunctionBaseTest {
+class IPAddressCastTest : public functions::test::FunctionBaseTest {
  protected:
-  std::optional<std::string> castIPAddressVarcharCycle(
+  std::optional<std::string> castToVarchar(
       const std::optional<std::string> input) {
     auto result = evaluateOnce<std::string>(
         "cast(cast(c0 as ipaddress) as varchar)", input);
     return result;
   }
 
-  std::optional<std::string> castIPAddressVarbinary(
+  std::optional<std::string> castToVarbinary(
       const std::optional<std::string> input) {
     auto result = evaluateOnce<std::string>(
         "cast(cast(from_hex(c0) as ipaddress) as varchar)", input);
     return result;
   }
 
-  std::optional<std::string> castIPAddressVarbinaryVarchar(
+  std::optional<std::string> allCasts(
       const std::optional<std::string> input) {
     auto result = evaluateOnce<std::string>(
         "cast(cast(cast(cast(c0 as ipaddress) as varbinary) as ipaddress) as varchar)",
@@ -46,59 +46,59 @@ class IPAddressTest : public functions::test::FunctionBaseTest {
   }
 };
 
-TEST_F(IPAddressTest, testVarcharIpAddressCast) {
-  EXPECT_EQ(castIPAddressVarcharCycle("::ffff:1.2.3.4"), "1.2.3.4");
-  EXPECT_EQ(castIPAddressVarcharCycle("1.2.3.4"), "1.2.3.4");
-  EXPECT_EQ(castIPAddressVarcharCycle("192.168.0.0"), "192.168.0.0");
+TEST_F(IPAddressCastTest, castToVarchar) {
+  EXPECT_EQ(castToVarchar("::ffff:1.2.3.4"), "1.2.3.4");
+  EXPECT_EQ(castToVarchar("1.2.3.4"), "1.2.3.4");
+  EXPECT_EQ(castToVarchar("192.168.0.0"), "192.168.0.0");
   EXPECT_EQ(
-      castIPAddressVarcharCycle("2001:0db8:0000:0000:0000:ff00:0042:8329"),
+      castToVarchar("2001:0db8:0000:0000:0000:ff00:0042:8329"),
       "2001:db8::ff00:42:8329");
   EXPECT_EQ(
-      castIPAddressVarcharCycle("2001:db8::ff00:42:8329"),
+      castToVarchar("2001:db8::ff00:42:8329"),
       "2001:db8::ff00:42:8329");
   EXPECT_EQ(
-      castIPAddressVarcharCycle("2001:db8:0:0:1:0:0:1"), "2001:db8::1:0:0:1");
+      castToVarchar("2001:db8:0:0:1:0:0:1"), "2001:db8::1:0:0:1");
   EXPECT_EQ(
-      castIPAddressVarcharCycle("2001:db8:0:0:1::1"), "2001:db8::1:0:0:1");
+      castToVarchar("2001:db8:0:0:1::1"), "2001:db8::1:0:0:1");
   EXPECT_EQ(
-      castIPAddressVarcharCycle("2001:db8::1:0:0:1"), "2001:db8::1:0:0:1");
+      castToVarchar("2001:db8::1:0:0:1"), "2001:db8::1:0:0:1");
   EXPECT_EQ(
-      castIPAddressVarcharCycle("2001:DB8::FF00:ABCD:12EF"),
+      castToVarchar("2001:DB8::FF00:ABCD:12EF"),
       "2001:db8::ff00:abcd:12ef");
-  EXPECT_THROW(castIPAddressVarcharCycle("facebook.com"), VeloxUserError);
-  EXPECT_THROW(castIPAddressVarcharCycle("localhost"), VeloxUserError);
-  EXPECT_THROW(castIPAddressVarcharCycle("2001:db8::1::1"), VeloxUserError);
-  EXPECT_THROW(castIPAddressVarcharCycle("2001:zxy::1::1"), VeloxUserError);
-  EXPECT_THROW(castIPAddressVarcharCycle("789.1.1.1"), VeloxUserError);
+  EXPECT_THROW(castToVarchar("facebook.com"), VeloxUserError);
+  EXPECT_THROW(castToVarchar("localhost"), VeloxUserError);
+  EXPECT_THROW(castToVarchar("2001:db8::1::1"), VeloxUserError);
+  EXPECT_THROW(castToVarchar("2001:zxy::1::1"), VeloxUserError);
+  EXPECT_THROW(castToVarchar("789.1.1.1"), VeloxUserError);
 }
 
-TEST_F(IPAddressTest, testVarbinaryIpAddressCast) {
+TEST_F(IPAddressCastTest, castToVarbinary) {
   EXPECT_EQ(
-      castIPAddressVarbinary("00000000000000000000ffff01020304"), "1.2.3.4");
-  EXPECT_EQ(castIPAddressVarbinary("01020304"), "1.2.3.4");
-  EXPECT_EQ(castIPAddressVarbinary("c0a80000"), "192.168.0.0");
+      castToVarbinary("00000000000000000000ffff01020304"), "1.2.3.4");
+  EXPECT_EQ(castToVarbinary("01020304"), "1.2.3.4");
+  EXPECT_EQ(castToVarbinary("c0a80000"), "192.168.0.0");
   EXPECT_EQ(
-      castIPAddressVarbinary("20010db8000000000000ff0000428329"),
+      castToVarbinary("20010db8000000000000ff0000428329"),
       "2001:db8::ff00:42:8329");
-  EXPECT_THROW(castIPAddressVarbinary("f000001100"), VeloxUserError);
+  EXPECT_THROW(castToVarbinary("f000001100"), VeloxUserError);
 }
 
-TEST_F(IPAddressTest, testVarbinaryIpAddressVarchar) {
-  EXPECT_EQ(castIPAddressVarbinaryVarchar("::ffff:1.2.3.4"), "1.2.3.4");
+TEST_F(IPAddressCastTest, allCasts) {
+  EXPECT_EQ(allCasts("::ffff:1.2.3.4"), "1.2.3.4");
   EXPECT_EQ(
-      castIPAddressVarbinaryVarchar("2001:0db8:0000:0000:0000:ff00:0042:8329"),
+      allCasts("2001:0db8:0000:0000:0000:ff00:0042:8329"),
       "2001:db8::ff00:42:8329");
   EXPECT_EQ(
-      castIPAddressVarbinaryVarchar("2001:db8::ff00:42:8329"),
+      allCasts("2001:db8::ff00:42:8329"),
       "2001:db8::ff00:42:8329");
 }
 
-TEST_F(IPAddressTest, nullTest) {
-  EXPECT_EQ(castIPAddressVarcharCycle(std::nullopt), std::nullopt);
-  EXPECT_EQ(castIPAddressVarbinary(std::nullopt), std::nullopt);
+TEST_F(IPAddressCastTest, nullTest) {
+  EXPECT_EQ(castToVarchar(std::nullopt), std::nullopt);
+  EXPECT_EQ(castToVarbinary(std::nullopt), std::nullopt);
 }
 
-TEST_F(IPAddressTest, castRoundTrip) {
+TEST_F(IPAddressCastTest, castRoundTrip) {
   auto strings = makeFlatVector<std::string>(
       {"87a0:ce14:8989:44c9:826e:b4d8:73f9:1542",
        "7cd6:bcec:1216:5c20:4b67:b1bd:173:ced",

--- a/velox/functions/prestosql/tests/IPAddressCastTest.cpp
+++ b/velox/functions/prestosql/tests/IPAddressCastTest.cpp
@@ -32,8 +32,8 @@ class IPAddressCastTest : public functions::test::FunctionBaseTest {
 
   std::optional<int128_t> castFromVarbinary(
       const std::optional<std::string> input) {
-    auto result = evaluateOnce<int128_t>(
-        "cast(from_hex(c0) as ipaddress)", input);
+    auto result =
+        evaluateOnce<int128_t>("cast(from_hex(c0) as ipaddress)", input);
     return result;
   }
 
@@ -45,12 +45,12 @@ class IPAddressCastTest : public functions::test::FunctionBaseTest {
   }
 };
 
-int128_t stringToInt128(std::string value){
-    int128_t res = 0;
-    for(char c : value){
-      res = res * 10 + c - '0';
-    }
-    return res;
+int128_t stringToInt128(std::string value) {
+  int128_t res = 0;
+  for (char c : value) {
+    res = res * 10 + c - '0';
+  }
+  return res;
 }
 
 TEST_F(IPAddressCastTest, castToVarchar) {
@@ -79,7 +79,9 @@ TEST_F(IPAddressCastTest, castToVarchar) {
 }
 
 TEST_F(IPAddressCastTest, castFromVarbinary) {
-  EXPECT_EQ(castFromVarbinary("00000000000000000000ffff01020304"), stringToInt128("281470698652420"));
+  EXPECT_EQ(
+      castFromVarbinary("00000000000000000000ffff01020304"),
+      stringToInt128("281470698652420"));
   EXPECT_EQ(castFromVarbinary("01020304"), stringToInt128("281470698652420"));
   EXPECT_EQ(castFromVarbinary("c0a80000"), stringToInt128("281473913978880"));
   EXPECT_EQ(

--- a/velox/functions/prestosql/tests/IPAddressCastTest.cpp
+++ b/velox/functions/prestosql/tests/IPAddressCastTest.cpp
@@ -65,11 +65,11 @@ TEST_F(IPAddressCastTest, castToVarchar) {
   EXPECT_EQ(
       castToVarchar("2001:DB8::FF00:ABCD:12EF"),
       "2001:db8::ff00:abcd:12ef");
-  EXPECT_THROW(castToVarchar("facebook.com"), VeloxUserError);
-  EXPECT_THROW(castToVarchar("localhost"), VeloxUserError);
-  EXPECT_THROW(castToVarchar("2001:db8::1::1"), VeloxUserError);
-  EXPECT_THROW(castToVarchar("2001:zxy::1::1"), VeloxUserError);
-  EXPECT_THROW(castToVarchar("789.1.1.1"), VeloxUserError);
+  VELOX_ASSERT_THROW(castToVarchar("facebook.com"), "Invalid IP address 'facebook.com'");
+  VELOX_ASSERT_THROW(castToVarchar("localhost"), "Invalid IP address 'localhost'");
+  VELOX_ASSERT_THROW(castToVarchar("2001:db8::1::1"), "Invalid IP address '2001:db8::1::1'");
+  VELOX_ASSERT_THROW(castToVarchar("2001:zxy::1::1"), "Invalid IP address '2001:zxy::1::1'");
+  VELOX_ASSERT_THROW(castToVarchar("789.1.1.1"), "Invalid IP address '789.1.1.1'");
 }
 
 TEST_F(IPAddressCastTest, castToVarbinary) {

--- a/velox/functions/prestosql/tests/IPAddressCastTest.cpp
+++ b/velox/functions/prestosql/tests/IPAddressCastTest.cpp
@@ -55,6 +55,7 @@ int128_t stringToInt128(std::string value) {
 
 TEST_F(IPAddressCastTest, castToVarchar) {
   EXPECT_EQ(castToVarchar("::ffff:1.2.3.4"), "1.2.3.4");
+  EXPECT_EQ(castToVarchar("0:0:0:0:0:0:13.1.68.3"), "::13.1.68.3");
   EXPECT_EQ(castToVarchar("1.2.3.4"), "1.2.3.4");
   EXPECT_EQ(castToVarchar("192.168.0.0"), "192.168.0.0");
   EXPECT_EQ(

--- a/velox/functions/prestosql/tests/IPAddressFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/IPAddressFunctionsTest.cpp
@@ -40,7 +40,8 @@ class IPAddressTest : public functions::test::FunctionBaseTest {
   std::optional<std::string> castIPAddressVarbinaryVarchar(
       const std::optional<std::string> input) {
     auto result = evaluateOnce<std::string>(
-        "cast(cast(cast(cast(c0 as ipaddress) as varbinary) as ipaddress) as varchar)", input);
+        "cast(cast(cast(cast(c0 as ipaddress) as varbinary) as ipaddress) as varchar)",
+        input);
     return result;
   }
 };
@@ -49,12 +50,21 @@ TEST_F(IPAddressTest, testVarcharIpAddressCast) {
   EXPECT_EQ(castIPAddressVarcharCycle("::ffff:1.2.3.4"), "1.2.3.4");
   EXPECT_EQ(castIPAddressVarcharCycle("1.2.3.4"), "1.2.3.4");
   EXPECT_EQ(castIPAddressVarcharCycle("192.168.0.0"), "192.168.0.0");
-  EXPECT_EQ(castIPAddressVarcharCycle("2001:0db8:0000:0000:0000:ff00:0042:8329"), "2001:db8::ff00:42:8329");
-  EXPECT_EQ(castIPAddressVarcharCycle("2001:db8::ff00:42:8329"), "2001:db8::ff00:42:8329");
-  EXPECT_EQ(castIPAddressVarcharCycle("2001:db8:0:0:1:0:0:1"), "2001:db8::1:0:0:1");
-  EXPECT_EQ(castIPAddressVarcharCycle("2001:db8:0:0:1::1"), "2001:db8::1:0:0:1");
-  EXPECT_EQ(castIPAddressVarcharCycle("2001:db8::1:0:0:1"), "2001:db8::1:0:0:1");
-  EXPECT_EQ(castIPAddressVarcharCycle("2001:DB8::FF00:ABCD:12EF"), "2001:db8::ff00:abcd:12ef");
+  EXPECT_EQ(
+      castIPAddressVarcharCycle("2001:0db8:0000:0000:0000:ff00:0042:8329"),
+      "2001:db8::ff00:42:8329");
+  EXPECT_EQ(
+      castIPAddressVarcharCycle("2001:db8::ff00:42:8329"),
+      "2001:db8::ff00:42:8329");
+  EXPECT_EQ(
+      castIPAddressVarcharCycle("2001:db8:0:0:1:0:0:1"), "2001:db8::1:0:0:1");
+  EXPECT_EQ(
+      castIPAddressVarcharCycle("2001:db8:0:0:1::1"), "2001:db8::1:0:0:1");
+  EXPECT_EQ(
+      castIPAddressVarcharCycle("2001:db8::1:0:0:1"), "2001:db8::1:0:0:1");
+  EXPECT_EQ(
+      castIPAddressVarcharCycle("2001:DB8::FF00:ABCD:12EF"),
+      "2001:db8::ff00:abcd:12ef");
   EXPECT_THROW(castIPAddressVarcharCycle("facebook.com"), VeloxUserError);
   EXPECT_THROW(castIPAddressVarcharCycle("localhost"), VeloxUserError);
   EXPECT_THROW(castIPAddressVarcharCycle("2001:db8::1::1"), VeloxUserError);
@@ -63,17 +73,24 @@ TEST_F(IPAddressTest, testVarcharIpAddressCast) {
 }
 
 TEST_F(IPAddressTest, testVarbinaryIpAddressCast) {
-  EXPECT_EQ(castIPAddressVarbinary("00000000000000000000ffff01020304"), "1.2.3.4");
+  EXPECT_EQ(
+      castIPAddressVarbinary("00000000000000000000ffff01020304"), "1.2.3.4");
   EXPECT_EQ(castIPAddressVarbinary("01020304"), "1.2.3.4");
   EXPECT_EQ(castIPAddressVarbinary("c0a80000"), "192.168.0.0");
-  EXPECT_EQ(castIPAddressVarbinary("20010db8000000000000ff0000428329"), "2001:db8::ff00:42:8329");
+  EXPECT_EQ(
+      castIPAddressVarbinary("20010db8000000000000ff0000428329"),
+      "2001:db8::ff00:42:8329");
   EXPECT_THROW(castIPAddressVarbinary("f000001100"), VeloxUserError);
 }
 
 TEST_F(IPAddressTest, testVarbinaryIpAddressVarchar) {
   EXPECT_EQ(castIPAddressVarbinaryVarchar("::ffff:1.2.3.4"), "1.2.3.4");
-  EXPECT_EQ(castIPAddressVarbinaryVarchar("2001:0db8:0000:0000:0000:ff00:0042:8329"), "2001:db8::ff00:42:8329");
-  EXPECT_EQ(castIPAddressVarbinaryVarchar("2001:db8::ff00:42:8329"), "2001:db8::ff00:42:8329");
+  EXPECT_EQ(
+      castIPAddressVarbinaryVarchar("2001:0db8:0000:0000:0000:ff00:0042:8329"),
+      "2001:db8::ff00:42:8329");
+  EXPECT_EQ(
+      castIPAddressVarbinaryVarchar("2001:db8::ff00:42:8329"),
+      "2001:db8::ff00:42:8329");
 }
 
 TEST_F(IPAddressTest, nullTest) {
@@ -100,4 +117,3 @@ TEST_F(IPAddressTest, castRoundTrip) {
 } // namespace
 
 } // namespace facebook::velox::functions::prestosql
-

--- a/velox/functions/prestosql/tests/IPAddressFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/IPAddressFunctionsTest.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+namespace facebook::velox::functions::prestosql {
+
+namespace {
+
+class IPAddressTest : public functions::test::FunctionBaseTest {
+ protected:
+  std::optional<std::string> castIPAddressVarcharCycle(
+      const std::optional<std::string> input) {
+    auto result = evaluateOnce<std::string>(
+        "cast(cast(c0 as ipaddress) as varchar)", input);
+    return result;
+  }
+
+  std::optional<std::string> castIPAddressVarbinary(
+      const std::optional<std::string> input) {
+    auto result = evaluateOnce<std::string>(
+        "cast(cast(from_hex(c0) as ipaddress) as varchar)", input);
+    return result;
+  }
+
+  std::optional<std::string> castIPAddressVarbinaryVarchar(
+      const std::optional<std::string> input) {
+    auto result = evaluateOnce<std::string>(
+        "cast(cast(cast(cast(c0 as ipaddress) as varbinary) as ipaddress) as varchar)", input);
+    return result;
+  }
+};
+
+TEST_F(IPAddressTest, testVarcharIpAddressCast) {
+  EXPECT_EQ(castIPAddressVarcharCycle("::ffff:1.2.3.4"), "1.2.3.4");
+  EXPECT_EQ(castIPAddressVarcharCycle("1.2.3.4"), "1.2.3.4");
+  EXPECT_EQ(castIPAddressVarcharCycle("192.168.0.0"), "192.168.0.0");
+  EXPECT_EQ(castIPAddressVarcharCycle("2001:0db8:0000:0000:0000:ff00:0042:8329"), "2001:db8::ff00:42:8329");
+  EXPECT_EQ(castIPAddressVarcharCycle("2001:db8::ff00:42:8329"), "2001:db8::ff00:42:8329");
+  EXPECT_EQ(castIPAddressVarcharCycle("2001:db8:0:0:1:0:0:1"), "2001:db8::1:0:0:1");
+  EXPECT_EQ(castIPAddressVarcharCycle("2001:db8:0:0:1::1"), "2001:db8::1:0:0:1");
+  EXPECT_EQ(castIPAddressVarcharCycle("2001:db8::1:0:0:1"), "2001:db8::1:0:0:1");
+  EXPECT_EQ(castIPAddressVarcharCycle("2001:DB8::FF00:ABCD:12EF"), "2001:db8::ff00:abcd:12ef");
+  EXPECT_THROW(castIPAddressVarcharCycle("facebook.com"), VeloxUserError);
+  EXPECT_THROW(castIPAddressVarcharCycle("localhost"), VeloxUserError);
+  EXPECT_THROW(castIPAddressVarcharCycle("2001:db8::1::1"), VeloxUserError);
+  EXPECT_THROW(castIPAddressVarcharCycle("2001:zxy::1::1"), VeloxUserError);
+  EXPECT_THROW(castIPAddressVarcharCycle("789.1.1.1"), VeloxUserError);
+}
+
+TEST_F(IPAddressTest, testVarbinaryIpAddressCast) {
+  EXPECT_EQ(castIPAddressVarbinary("00000000000000000000ffff01020304"), "1.2.3.4");
+  EXPECT_EQ(castIPAddressVarbinary("01020304"), "1.2.3.4");
+  EXPECT_EQ(castIPAddressVarbinary("c0a80000"), "192.168.0.0");
+  EXPECT_EQ(castIPAddressVarbinary("20010db8000000000000ff0000428329"), "2001:db8::ff00:42:8329");
+  EXPECT_THROW(castIPAddressVarbinary("f000001100"), VeloxUserError);
+}
+
+TEST_F(IPAddressTest, testVarbinaryIpAddressVarchar) {
+  EXPECT_EQ(castIPAddressVarbinaryVarchar("::ffff:1.2.3.4"), "1.2.3.4");
+  EXPECT_EQ(castIPAddressVarbinaryVarchar("2001:0db8:0000:0000:0000:ff00:0042:8329"), "2001:db8::ff00:42:8329");
+  EXPECT_EQ(castIPAddressVarbinaryVarchar("2001:db8::ff00:42:8329"), "2001:db8::ff00:42:8329");
+}
+
+TEST_F(IPAddressTest, nullTest) {
+  EXPECT_EQ(castIPAddressVarcharCycle(std::nullopt), std::nullopt);
+  EXPECT_EQ(castIPAddressVarbinary(std::nullopt), std::nullopt);
+}
+
+TEST_F(IPAddressTest, castRoundTrip) {
+  auto strings = makeFlatVector<std::string>(
+      {"87a0:ce14:8989:44c9:826e:b4d8:73f9:1542",
+       "7cd6:bcec:1216:5c20:4b67:b1bd:173:ced",
+       "192.128.0.0"});
+
+  auto ipaddresses =
+      evaluate("cast(c0 as ipaddress)", makeRowVector({strings}));
+  auto stringsCopy =
+      evaluate("cast(c0 as varchar)", makeRowVector({ipaddresses}));
+  auto ipaddressesCopy =
+      evaluate("cast(c0 as ipaddress)", makeRowVector({stringsCopy}));
+
+  velox::test::assertEqualVectors(strings, stringsCopy);
+  velox::test::assertEqualVectors(ipaddresses, ipaddressesCopy);
+}
+} // namespace
+
+} // namespace facebook::velox::functions::prestosql
+

--- a/velox/functions/prestosql/types/CMakeLists.txt
+++ b/velox/functions/prestosql/types/CMakeLists.txt
@@ -16,7 +16,8 @@ velox_add_library(
   HyperLogLogType.cpp
   JsonType.cpp
   TimestampWithTimeZoneType.cpp
-  UuidType.cpp)
+  UuidType.cpp
+  IPAddressType.cpp)
 
 velox_link_libraries(
   velox_presto_types

--- a/velox/functions/prestosql/types/IPAddressType.cpp
+++ b/velox/functions/prestosql/types/IPAddressType.cpp
@@ -96,9 +96,6 @@ class IPAddressCastOperator : public exec::CastOperator {
     const auto* ipaddresses = input.as<SimpleVector<int128_t>>();
     folly::ByteArray16 addrBytes;
 
-    flatResult->resize(rows.size());
-    flatResult->getRawStringBufferWithSpace(rows.size() * kIPAddressMaxStrLen);
-
     context.applyToSelectedNoThrow(rows, [&](auto row) {
       const auto intAddr = ipaddresses->valueAt(row);
       memcpy(&addrBytes, &intAddr, kIPAddressBytes);
@@ -156,9 +153,6 @@ class IPAddressCastOperator : public exec::CastOperator {
       BaseVector& result) {
     auto* flatResult = result.as<FlatVector<StringView>>();
     const auto* ipaddresses = input.as<SimpleVector<int128_t>>();
-
-    flatResult->resize(rows.size());
-    flatResult->getRawStringBufferWithSpace(rows.size() * kIPAddressBytes);
 
     context.applyToSelectedNoThrow(rows, [&](auto row) {
       const auto intAddr = ipaddresses->valueAt(row);

--- a/velox/functions/prestosql/types/IPAddressType.cpp
+++ b/velox/functions/prestosql/types/IPAddressType.cpp
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/types/IPAddressType.h"
+
+namespace facebook::velox {
+
+namespace {
+
+class IPAddressCastOperator : public exec::CastOperator {
+ public:
+  bool isSupportedFromType(const TypePtr& other) const override {
+    switch (other->kind()) {
+      case TypeKind::VARBINARY:
+        return true;
+      case TypeKind::VARCHAR:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  bool isSupportedToType(const TypePtr& other) const override {
+    switch (other->kind()) {
+      case TypeKind::VARBINARY:
+        return true;
+      case TypeKind::VARCHAR:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  void castTo(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      VectorPtr& result) const override {
+    context.ensureWritable(rows, resultType, result);
+
+    if (input.typeKind() == TypeKind::VARCHAR) {
+      castFromString(input, context, rows, *result);
+    } else if (input.typeKind() == TypeKind::VARBINARY) {
+      castFromVarbinary(input, context, rows, *result);
+    } else {
+      VELOX_UNSUPPORTED(
+          "Cast from {} to IPAddress not supported",
+          resultType->toString());
+    }
+  }
+
+  void castFrom(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      VectorPtr& result) const override {
+    context.ensureWritable(rows, resultType, result);
+
+    if (resultType->kind() == TypeKind::VARCHAR) {
+      castToString(input, context, rows, *result);
+    } else if (resultType->kind() == TypeKind::VARBINARY) {
+      castToVarbinary(input, context, rows, *result);
+    } else {
+      VELOX_UNSUPPORTED(
+          "Cast from IPAddress to {} not supported",
+          resultType->toString());
+    }
+  }
+
+ private:
+  static void castToString(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      BaseVector& result) {
+    auto* flatResult = result.as<FlatVector<StringView>>();
+    const auto* ipaddresses = input.as<SimpleVector<int128_t>>();
+
+    context.applyToSelectedNoThrow(rows, [&](auto row) {
+      const auto intAddr = ipaddresses->valueAt(row);
+      folly::ByteArray16 addrBytes;
+      std::string s;
+      memcpy(&addrBytes, &intAddr, kIPAddressBytes);
+
+      bigEndianByteArray(addrBytes);
+      folly::IPAddressV6 v6Addr(addrBytes);
+
+      if (v6Addr.isIPv4Mapped()) {
+        s = v6Addr.createIPv4().str();
+      } else {
+        s = v6Addr.str();
+      }
+
+      exec::StringWriter<false> result(flatResult, row);
+      result.append(s);
+      result.finalize();
+    });
+  }
+
+  static void castFromString(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      BaseVector& result) {
+    auto* flatResult = result.as<FlatVector<int128_t>>();
+    const auto* ipAddressStrings = input.as<SimpleVector<StringView>>();
+
+    context.applyToSelectedNoThrow(rows, [&](auto row) {
+      const auto ipAddressString = ipAddressStrings->valueAt(row);
+      int128_t intAddr;
+      folly::IPAddress addr(ipAddressString);
+
+      auto addrBytes = folly::IPAddress::createIPv6(addr).toByteArray();
+
+      bigEndianByteArray(addrBytes);
+      memcpy(&intAddr, &addrBytes, kIPAddressBytes);
+
+      flatResult->set(row, intAddr);
+    });
+  }
+
+    static void castToVarbinary(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      BaseVector& result) {
+    auto* flatResult = result.as<FlatVector<StringView>>();
+    const auto* ipaddresses = input.as<SimpleVector<int128_t>>();
+
+    context.applyToSelectedNoThrow(rows, [&](auto row) {
+      const auto intAddr = ipaddresses->valueAt(row);
+      folly::ByteArray16 addrBytes;
+      memcpy(&addrBytes, &intAddr, kIPAddressBytes);
+      bigEndianByteArray(addrBytes);
+
+      exec::StringWriter<false> result(flatResult, row);
+      result.resize(kIPAddressBytes);
+      memcpy(result.data(), &addrBytes, kIPAddressBytes);
+      result.finalize();
+    });
+  }
+
+  static void castFromVarbinary(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      BaseVector& result) {
+    auto* flatResult = result.as<FlatVector<int128_t>>();
+    const auto* ipAddressBinaries = input.as<SimpleVector<StringView>>();
+
+    context.applyToSelectedNoThrow(rows, [&](auto row) {
+      int128_t intAddr;
+      folly::ByteArray16 addrBytes = {};
+      const auto ipAddressBinary = ipAddressBinaries->valueAt(row);
+
+      if(ipAddressBinary.size() == kIPV4AddressBytes){
+        addrBytes[kIPV4ToV6FFIndex] = 0xFF;
+        addrBytes[kIPV4ToV6FFIndex + 1] = 0xFF;
+        memcpy(&addrBytes[kIPV4ToV6Index], ipAddressBinary.data(), kIPV4AddressBytes);
+      } else if(ipAddressBinary.size() == kIPAddressBytes){
+        memcpy(&addrBytes, ipAddressBinary.data(), kIPAddressBytes);
+      } else{
+        context.setStatus(row, Status::UserError("Varbinary length {}, must be IPV4({}), or IPV6({})", ipAddressBinary.size(), kIPV4AddressBytes, kIPAddressBytes));
+        return;
+      }
+
+      bigEndianByteArray(addrBytes);
+      memcpy(&intAddr, &addrBytes, kIPAddressBytes);
+      flatResult->set(row, intAddr);
+    });
+  }
+};
+
+class IPAddressTypeFactories : public CustomTypeFactories {
+ public:
+  IPAddressTypeFactories() = default;
+
+  TypePtr getType() const override {
+    return IPADDRESS();
+  }
+
+  exec::CastOperatorPtr getCastOperator() const override {
+    return std::make_shared<IPAddressCastOperator>();
+  }
+};
+
+} // namespace
+
+void registerIPAddressType() {
+  registerCustomType(
+      "ipaddress", std::make_unique<const IPAddressTypeFactories>());
+}
+
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/IPAddressType.cpp
+++ b/velox/functions/prestosql/types/IPAddressType.cpp
@@ -96,6 +96,9 @@ class IPAddressCastOperator : public exec::CastOperator {
     const auto* ipaddresses = input.as<SimpleVector<int128_t>>();
     folly::ByteArray16 addrBytes;
 
+    flatResult->resize(rows.size());
+    flatResult->getRawStringBufferWithSpace(rows.size() * kIPAddressMaxStrLen);
+
     context.applyToSelectedNoThrow(rows, [&](auto row) {
       const auto intAddr = ipaddresses->valueAt(row);
       memcpy(&addrBytes, &intAddr, kIPAddressBytes);
@@ -104,7 +107,6 @@ class IPAddressCastOperator : public exec::CastOperator {
       folly::IPAddressV6 v6Addr(addrBytes);
 
       exec::StringWriter<false> result(flatResult, row);
-      result.reserve(kIPAddressMaxStrLen);
       if (v6Addr.isIPv4Mapped()) {
         result.append(v6Addr.createIPv4().str());
       } else {
@@ -154,6 +156,9 @@ class IPAddressCastOperator : public exec::CastOperator {
       BaseVector& result) {
     auto* flatResult = result.as<FlatVector<StringView>>();
     const auto* ipaddresses = input.as<SimpleVector<int128_t>>();
+
+    flatResult->resize(rows.size());
+    flatResult->getRawStringBufferWithSpace(rows.size() * kIPAddressBytes);
 
     context.applyToSelectedNoThrow(rows, [&](auto row) {
       const auto intAddr = ipaddresses->valueAt(row);

--- a/velox/functions/prestosql/types/IPAddressType.cpp
+++ b/velox/functions/prestosql/types/IPAddressType.cpp
@@ -135,6 +135,7 @@ class IPAddressCastOperator : public exec::CastOperator {
               row,
               Status::UserError("Invalid IP address '{}'", ipAddressString));
         }
+        return;
       }
       folly::IPAddress addr = maybeIp.value();
       auto addrBytes = folly::IPAddress::createIPv6(addr).toByteArray();

--- a/velox/functions/prestosql/types/IPAddressType.cpp
+++ b/velox/functions/prestosql/types/IPAddressType.cpp
@@ -18,14 +18,6 @@
 
 namespace facebook::velox {
 
-// Converts BigEndian <-> native byte array
-// NOOP if system is Big Endian already
-void bigEndianByteArray(folly::ByteArray16& addrBytes) {
-  if (folly::kIsLittleEndian) {
-    std::reverse(addrBytes.begin(), addrBytes.end());
-  }
-}
-
 namespace {
 
 class IPAddressCastOperator : public exec::CastOperator {
@@ -102,7 +94,7 @@ class IPAddressCastOperator : public exec::CastOperator {
 
       memcpy(&addrBytes, &intAddr, kIPAddressBytes);
 
-      bigEndianByteArray(addrBytes);
+      std::reverse(addrBytes.begin(), addrBytes.end());
       folly::IPAddressV6 v6Addr(addrBytes);
 
       if (v6Addr.isIPv4Mapped()) {
@@ -132,7 +124,7 @@ class IPAddressCastOperator : public exec::CastOperator {
 
       auto addrBytes = folly::IPAddress::createIPv6(addr).toByteArray();
 
-      bigEndianByteArray(addrBytes);
+      std::reverse(addrBytes.begin(), addrBytes.end());
       memcpy(&intAddr, &addrBytes, kIPAddressBytes);
 
       flatResult->set(row, intAddr);
@@ -151,7 +143,7 @@ class IPAddressCastOperator : public exec::CastOperator {
       const auto intAddr = ipaddresses->valueAt(row);
       folly::ByteArray16 addrBytes;
       memcpy(&addrBytes, &intAddr, kIPAddressBytes);
-      bigEndianByteArray(addrBytes);
+      std::reverse(addrBytes.begin(), addrBytes.end());
 
       exec::StringWriter<false> result(flatResult, row);
       result.resize(kIPAddressBytes);
@@ -193,7 +185,7 @@ class IPAddressCastOperator : public exec::CastOperator {
         return;
       }
 
-      bigEndianByteArray(addrBytes);
+      std::reverse(addrBytes.begin(), addrBytes.end());
       memcpy(&intAddr, &addrBytes, kIPAddressBytes);
       flatResult->set(row, intAddr);
     });

--- a/velox/functions/prestosql/types/IPAddressType.cpp
+++ b/velox/functions/prestosql/types/IPAddressType.cpp
@@ -175,13 +175,19 @@ class IPAddressCastOperator : public exec::CastOperator {
       } else if (ipAddressBinary.size() == kIPAddressBytes) {
         memcpy(&addrBytes, ipAddressBinary.data(), kIPAddressBytes);
       } else {
-        context.setStatus(
+        if (threadSkipErrorDetails()) {
+          context.setStatus(
+            row,
+            Status::UserError());
+        } else {
+          context.setStatus(
             row,
             Status::UserError(
                 "Varbinary length {}, must be IPV4({}), or IPV6({})",
                 ipAddressBinary.size(),
                 kIPV4AddressBytes,
                 kIPAddressBytes));
+        }
         return;
       }
 

--- a/velox/functions/prestosql/types/IPAddressType.cpp
+++ b/velox/functions/prestosql/types/IPAddressType.cpp
@@ -126,7 +126,6 @@ class IPAddressCastOperator : public exec::CastOperator {
     context.applyToSelectedNoThrow(rows, [&](auto row) {
       const auto ipAddressString = ipAddressStrings->valueAt(row);
 
-      
       auto maybeIp = folly::IPAddress::tryFromString(ipAddressString);
       if (maybeIp.hasError()) {
         if (threadSkipErrorDetails()) {
@@ -134,9 +133,7 @@ class IPAddressCastOperator : public exec::CastOperator {
         } else {
           context.setStatus(
               row,
-              Status::UserError(
-                  "Invalid IP address '{}'",
-                  ipAddressString));
+              Status::UserError("Invalid IP address '{}'", ipAddressString));
         }
       }
       folly::IPAddress addr = maybeIp.value();

--- a/velox/functions/prestosql/types/IPAddressType.cpp
+++ b/velox/functions/prestosql/types/IPAddressType.cpp
@@ -176,17 +176,15 @@ class IPAddressCastOperator : public exec::CastOperator {
         memcpy(&addrBytes, ipAddressBinary.data(), kIPAddressBytes);
       } else {
         if (threadSkipErrorDetails()) {
-          context.setStatus(
-            row,
-            Status::UserError());
+          context.setStatus(row, Status::UserError());
         } else {
           context.setStatus(
-            row,
-            Status::UserError(
-                "Varbinary length {}, must be IPV4({}), or IPV6({})",
-                ipAddressBinary.size(),
-                kIPV4AddressBytes,
-                kIPAddressBytes));
+              row,
+              Status::UserError(
+                  "Varbinary length {}, must be IPV4({}), or IPV6({})",
+                  ipAddressBinary.size(),
+                  kIPV4AddressBytes,
+                  kIPAddressBytes));
         }
         return;
       }

--- a/velox/functions/prestosql/types/IPAddressType.cpp
+++ b/velox/functions/prestosql/types/IPAddressType.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+#include "velox/functions/prestosql/types/IPAddressType.h"
 #include <folly/IPAddress.h>
 #include "velox/expression/CastExpr.h"
-#include "velox/functions/prestosql/types/IPAddressType.h"
 
 static constexpr int kIPV4AddressBytes = 4;
 static constexpr int kIPV4ToV6FFIndex = 10;
@@ -187,7 +187,7 @@ class IPAddressCastOperator : public exec::CastOperator {
               row,
               Status::UserError(
                   "Invalid IP address binary length: {}",
-                  ipAddressBinary.size()))  ;
+                  ipAddressBinary.size()));
         }
         return;
       }

--- a/velox/functions/prestosql/types/IPAddressType.cpp
+++ b/velox/functions/prestosql/types/IPAddressType.cpp
@@ -181,10 +181,8 @@ class IPAddressCastOperator : public exec::CastOperator {
           context.setStatus(
               row,
               Status::UserError(
-                  "Varbinary length {}, must be IPV4({}), or IPV6({})",
-                  ipAddressBinary.size(),
-                  kIPV4AddressBytes,
-                  kIPAddressBytes));
+                  "Invalid IP address binary length: {}",
+                  ipAddressBinary.size()));
         }
         return;
       }

--- a/velox/functions/prestosql/types/IPAddressType.cpp
+++ b/velox/functions/prestosql/types/IPAddressType.cpp
@@ -58,8 +58,7 @@ class IPAddressCastOperator : public exec::CastOperator {
       castFromVarbinary(input, context, rows, *result);
     } else {
       VELOX_UNSUPPORTED(
-          "Cast from {} to IPAddress not supported",
-          resultType->toString());
+          "Cast from {} to IPAddress not supported", resultType->toString());
     }
   }
 
@@ -77,8 +76,7 @@ class IPAddressCastOperator : public exec::CastOperator {
       castToVarbinary(input, context, rows, *result);
     } else {
       VELOX_UNSUPPORTED(
-          "Cast from IPAddress to {} not supported",
-          resultType->toString());
+          "Cast from IPAddress to {} not supported", resultType->toString());
     }
   }
 
@@ -134,7 +132,7 @@ class IPAddressCastOperator : public exec::CastOperator {
     });
   }
 
-    static void castToVarbinary(
+  static void castToVarbinary(
       const BaseVector& input,
       exec::EvalCtx& context,
       const SelectivityVector& rows,
@@ -168,14 +166,23 @@ class IPAddressCastOperator : public exec::CastOperator {
       folly::ByteArray16 addrBytes = {};
       const auto ipAddressBinary = ipAddressBinaries->valueAt(row);
 
-      if(ipAddressBinary.size() == kIPV4AddressBytes){
+      if (ipAddressBinary.size() == kIPV4AddressBytes) {
         addrBytes[kIPV4ToV6FFIndex] = 0xFF;
         addrBytes[kIPV4ToV6FFIndex + 1] = 0xFF;
-        memcpy(&addrBytes[kIPV4ToV6Index], ipAddressBinary.data(), kIPV4AddressBytes);
-      } else if(ipAddressBinary.size() == kIPAddressBytes){
+        memcpy(
+            &addrBytes[kIPV4ToV6Index],
+            ipAddressBinary.data(),
+            kIPV4AddressBytes);
+      } else if (ipAddressBinary.size() == kIPAddressBytes) {
         memcpy(&addrBytes, ipAddressBinary.data(), kIPAddressBytes);
-      } else{
-        context.setStatus(row, Status::UserError("Varbinary length {}, must be IPV4({}), or IPV6({})", ipAddressBinary.size(), kIPV4AddressBytes, kIPAddressBytes));
+      } else {
+        context.setStatus(
+            row,
+            Status::UserError(
+                "Varbinary length {}, must be IPV4({}), or IPV6({})",
+                ipAddressBinary.size(),
+                kIPV4AddressBytes,
+                kIPAddressBytes));
         return;
       }
 

--- a/velox/functions/prestosql/types/IPAddressType.h
+++ b/velox/functions/prestosql/types/IPAddressType.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/Bits.h>
+#include <folly/IPAddress.h>
+#include "velox/expression/CastExpr.h"
+#include "velox/type/SimpleFunctionApi.h"
+#include "velox/type/Type.h"
+
+static constexpr int kIPV4AddressBytes = 4;
+static constexpr int kIPV4ToV6FFIndex = 10;
+static constexpr int kIPV4ToV6Index = 12;
+static constexpr int kIPAddressBytes = 16;
+static constexpr int kIPV4Bits = 32;
+static constexpr int kIPV6HalfBits = 64;
+static constexpr int kIPV6Bits = 128;
+
+namespace facebook::velox {
+
+// Converts BigEndian <-> native byte array
+// NOOP if system is Big Endian already
+inline void bigEndianByteArray(folly::ByteArray16& addrBytes) {
+  if (folly::kIsLittleEndian) {
+    std::reverse(addrBytes.begin(), addrBytes.end());
+  }
+}
+
+class IPAddressType : public HugeintType {
+  IPAddressType() = default;
+
+ public:
+  static const std::shared_ptr<const IPAddressType>& get() {
+    static const std::shared_ptr<const IPAddressType> instance{
+        new IPAddressType()};
+
+    return instance;
+  }
+
+  bool equivalent(const Type& other) const override {
+    // Pointer comparison works since this type is a singleton.
+    return this == &other;
+  }
+
+  const char* name() const override {
+    return "IPADDRESS";
+  }
+
+  std::string toString() const override {
+    return name();
+  }
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = "Type";
+    obj["type"] = name();
+    return obj;
+  }
+};
+
+FOLLY_ALWAYS_INLINE bool isIPAddressType(const TypePtr& type) {
+  // Pointer comparison works since this type is a singleton.
+  return IPAddressType::get() == type;
+}
+
+FOLLY_ALWAYS_INLINE std::shared_ptr<const IPAddressType> IPADDRESS() {
+  return IPAddressType::get();
+}
+
+// Type used for function registration.
+struct IPAddressT {
+  using type = int128_t;
+  static constexpr const char* typeName = "ipaddress";
+};
+
+using IPAddress = CustomType<IPAddressT>;
+
+void registerIPAddressType();
+
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/IPAddressType.h
+++ b/velox/functions/prestosql/types/IPAddressType.h
@@ -31,13 +31,7 @@ static constexpr int kIPV6Bits = 128;
 
 namespace facebook::velox {
 
-// Converts BigEndian <-> native byte array
-// NOOP if system is Big Endian already
-inline void bigEndianByteArray(folly::ByteArray16& addrBytes) {
-  if (folly::kIsLittleEndian) {
-    std::reverse(addrBytes.begin(), addrBytes.end());
-  }
-}
+void bigEndianByteArray(folly::ByteArray16& addrBytes);
 
 class IPAddressType : public HugeintType {
   IPAddressType() = default;

--- a/velox/functions/prestosql/types/IPAddressType.h
+++ b/velox/functions/prestosql/types/IPAddressType.h
@@ -15,23 +15,10 @@
  */
 #pragma once
 
-#include <folly/Bits.h>
-#include <folly/IPAddress.h>
-#include "velox/expression/CastExpr.h"
 #include "velox/type/SimpleFunctionApi.h"
 #include "velox/type/Type.h"
 
-static constexpr int kIPV4AddressBytes = 4;
-static constexpr int kIPV4ToV6FFIndex = 10;
-static constexpr int kIPV4ToV6Index = 12;
-static constexpr int kIPAddressBytes = 16;
-static constexpr int kIPV4Bits = 32;
-static constexpr int kIPV6HalfBits = 64;
-static constexpr int kIPV6Bits = 128;
-
 namespace facebook::velox {
-
-void bigEndianByteArray(folly::ByteArray16& addrBytes);
 
 class IPAddressType : public HugeintType {
   IPAddressType() = default;

--- a/velox/functions/prestosql/types/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/types/tests/CMakeLists.txt
@@ -18,7 +18,8 @@ add_executable(
   JsonTypeTest.cpp
   TimestampWithTimeZoneTypeTest.cpp
   TypeTestBase.cpp
-  UuidTypeTest.cpp)
+  UuidTypeTest.cpp
+  IPAddressTypeTest.cpp)
 
 add_test(velox_presto_types_test velox_presto_types_test)
 

--- a/velox/functions/prestosql/types/tests/IPAddressTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/IPAddressTypeTest.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/types/IPAddressType.h"
+#include "velox/functions/prestosql/types/tests/TypeTestBase.h"
+
+namespace facebook::velox::test {
+
+class IPAddressTypeTest : public testing::Test, public TypeTestBase {
+ public:
+  IPAddressTypeTest() {
+    registerIPAddressType();
+  }
+};
+
+TEST_F(IPAddressTypeTest, basic) {
+  ASSERT_EQ(IPADDRESS()->name(), "IPADDRESS");
+  ASSERT_EQ(IPADDRESS()->kindName(), "HUGEINT");
+  ASSERT_TRUE(IPADDRESS()->parameters().empty());
+  ASSERT_EQ(IPADDRESS()->toString(), "IPADDRESS");
+
+  ASSERT_TRUE(hasType("IPADDRESS"));
+  ASSERT_EQ(*getType("IPADDRESS", {}), *IPADDRESS());
+}
+
+TEST_F(IPAddressTypeTest, serde) {
+  testTypeSerde(IPADDRESS());
+}
+} // namespace facebook::velox::test


### PR DESCRIPTION
Split of https://github.com/facebookincubator/velox/pull/10538

In response to @mbasmanova :
https://github.com/facebookincubator/velox/pull/10538#pullrequestreview-2199314267

Took a look and added the to and from varbinary casting
Contains CAST functions for IPAddress <-> Varchar and IPAddress <-> Varbinary utilizing the folly library.

In response to:
https://velox-lib.io/blog/optimize-try-more

I believe the folly library utilizes makeUnexpected already. 
https://github.com/facebook/folly/blob/main/folly/IPAddress.cpp
I added one error for Varbinary conversion utilizing `context.setStatus`
If I'm not understanding something correctly please let me know. 

As for adding a limited fuzzer @aditi-pandit 
https://github.com/facebookincubator/velox/pull/10538#issuecomment-2251076870

Is this to test the casting `IPAddress <-> Varchar and IPAddress <-> Varbinary` or something else.
We already test the casting using the duckdb type, we also have the prestissimo test in the E2E test. 
Fuzzer support will be added in after the types and functions have been added. 




