### PR TITLE
find_first and find_first_index have default null behavior

### DIFF
--- a/velox/functions/prestosql/FindFirst.cpp
+++ b/velox/functions/prestosql/FindFirst.cpp
@@ -403,16 +403,14 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> indexSignatures() {
 /// For example: find_first(array[1, 2, 3], x -> x > coalesce(a, 0)) should
 /// not return null when 'a' is null.
 
-VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
+VELOX_DECLARE_VECTOR_FUNCTION(
     udf_find_first,
     valueSignatures(),
-    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<FindFirstFunction>());
 
-VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
+VELOX_DECLARE_VECTOR_FUNCTION(
     udf_find_first_index,
     indexSignatures(),
-    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<FindFirstIndexFunction>());
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/FindFirstTest.cpp
+++ b/velox/functions/prestosql/tests/FindFirstTest.cpp
@@ -101,6 +101,15 @@ TEST_F(FindFirstTest, basic) {
   expected =
       makeNullableFlatVector<int64_t>({3, std::nullopt, std::nullopt, 5});
   verify("find_first_index(c0, -2, x -> (x > 0))", data, expected);
+
+  expected = makeNullConstant(TypeKind::INTEGER, 4);
+  verify("find_first(c0, cast(null as INTEGER), x -> (x > 0))", data, expected);
+
+  expected = makeNullConstant(TypeKind::BIGINT, 4);
+  verify(
+      "find_first_index(c0, cast(null as INTEGER), x -> (x > 0))",
+      data,
+      expected);
 }
 
 TEST_F(FindFirstTest, firstMatchIsNull) {


### PR DESCRIPTION
Summary:
I verified in Presto Java find_first and find_first_index have default null behavior.  In Velox they do not
which leads to inconsistent behavior when actually evaluating the function could produce errors that
are skipped thanks to the optimizations that can be done when default null behavior is set.

The original code that set the non-default behavior included the following comment
    // find_first function is null preserving for the array argument, but
    // predicate expression may use other fields and may not preserve nulls in
    // these.
    // For example: find_first(array[1, 2, 3], x -> x > coalesce(a, 0)) should
    // not return null when 'a' is null.

If I'm reading this right, it's saying that null elements in the array may not produce null results in the
lambda.  AFAIK default null behavior isn't recursive so it only matters if the entire array is null.

There are already tests that verify if the array is NULL the result is NULL, I added tests that verify if
the optional start index argument is NULL the result is NULL.  I verified these passed before and after
my change, so this does not change the behavior of the function except in the presence of errors.

This is to address https://github.com/facebookincubator/velox/issues/10564

Differential Revision: D60412963
