### PR TITLE
WeekFunction calculates long years incorrectly

### DIFF
--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -213,9 +213,11 @@ struct WeekFunction : public InitSessionTimezone<T>,
       auto firstMondayOfYear =
           1 + (mondayOfWeek + kDaysInWeek - 1) % kDaysInWeek;
 
+      // A long year is any year ending on Thursday and any leap year ending on
+      // Friday.
       if ((util::isLeapYear(time.tm_year + 1900 - 1) &&
-           firstMondayOfYear == 2) ||
-          firstMondayOfYear == 3 || firstMondayOfYear == 4) {
+           firstMondayOfYear == 3) ||
+          firstMondayOfYear == 4) {
         week = 53;
       } else {
         week = 52;

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -500,6 +500,22 @@ TEST_F(DateTimeFunctionsTest, weekDate) {
   EXPECT_EQ(1, weekDate("1970-01-01"));
   EXPECT_EQ(1, weekDate("0001-01-01"));
   EXPECT_EQ(52, weekDate("9999-12-31"));
+
+  // Test various cases where the last week of the previous year extends into
+  // the next year.
+
+  // Leap year that ends on Thursday.
+  EXPECT_EQ(53, weekDate("2021-01-01"));
+  // Leap year that ends on Friday.
+  EXPECT_EQ(53, weekDate("2005-01-01"));
+  // Leap year that ends on Saturday.
+  EXPECT_EQ(52, weekDate("2017-01-01"));
+  // Common year that ends on Thursday.
+  EXPECT_EQ(53, weekDate("2016-01-01"));
+  // Common year that ends on Friday.
+  EXPECT_EQ(52, weekDate("2022-01-01"));
+  // Common year that ends on Saturday.
+  EXPECT_EQ(52, weekDate("2023-01-01"));
 }
 
 TEST_F(DateTimeFunctionsTest, week) {


### PR DESCRIPTION
Summary:
The WeekFunction treats leap years that end on Saturday, and any year that ends on Friday or
Thursday as a year with 53 weeks.

However, according to Wikipedia https://en.wikipedia.org/wiki/ISO_week_date#Weeks_per_year years
with 53 weeks are leap years that end on Friday and any year that ends on Thursday.

I updated the logic to reflect this.

I added tests to cover cases where we end up in Week 0, which is the only case where this logic is
used, and verified the results match Presto Java.

Differential Revision: D60427017
