### PR TITLE
Fix errors in memory arbitration/reclaim in single-threaded execution

### DIFF
--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -329,7 +329,7 @@ class SharedArbitrationTestWithThreadingModes
       public SharedArbitrationTestBase {
  public:
   static std::vector<TestParam> getTestParams() {
-    return std::vector<TestParam>({{false}});
+    return std::vector<TestParam>({{false}, {true}});
   }
 
  protected:

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -366,16 +366,15 @@ RowVectorPtr Driver::next(ContinueFuture* future) {
   const auto stop = runInternal(self, blockingState, result);
 
   if (blockingState != nullptr) {
-    VELOX_DCHECK_NULL(result);
+    VELOX_CHECK_NULL(result);
     *future = blockingState->future();
     return nullptr;
   }
 
   if (stop == StopReason::kPause) {
-    VELOX_DCHECK_NULL(result);
-    if (!task()->pauseRequested(future)) {
-      *future = ContinueFuture::makeEmpty();
-    }
+    VELOX_CHECK_NULL(result);
+    const auto paused = task()->pauseRequested(future);
+    VELOX_CHECK_EQ(paused, future->valid());
     return nullptr;
   }
 

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -359,7 +359,7 @@ class Driver : public std::enable_shared_from_this<Driver> {
 
   /// Run the pipeline until it produces a batch of data or gets blocked.
   /// Return the data produced or nullptr if pipeline finished processing and
-  /// will not produce more data. Return nullptr and set 'blockingState' if
+  /// will not produce more data. Return nullptr and set 'future' if
   /// pipeline got blocked.
   ///
   /// This API supports execution of a Task synchronously in the caller's
@@ -367,7 +367,7 @@ class Driver : public std::enable_shared_from_this<Driver> {
   /// When using 'enqueue', the last operator in the pipeline (sink) must not
   /// return any data from Operator::getOutput(). When using 'next', the last
   /// operator must produce data that will be returned to caller.
-  RowVectorPtr next(std::shared_ptr<BlockingState>& blockingState);
+  RowVectorPtr next(ContinueFuture* future);
 
   /// Invoked to initialize the operators from this driver once on its first
   /// execution.

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -192,7 +192,7 @@ class Task : public std::enable_shared_from_this<Task> {
 
   /// Resumes execution of 'self' after a successful pause. All 'drivers_' must
   /// be off-thread and there must be no 'exception_'
-  static void resume(std::shared_ptr<Task> self);
+  static void resume(std::shared_ptr<Task> self) noexcept;
 
   /// Sets the (so far) max split sequence id, so all splits with sequence id
   /// equal or below that, will be ignored in the 'addSplitWithSequence' call.

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -1470,8 +1470,8 @@ DEBUG_ONLY_TEST_F(TaskPauseTest, resumeFuture) {
   std::atomic<bool> taskResumeAllowed{false};
   std::thread observeThread([&]() {
     ContinueFuture future = ContinueFuture::makeEmpty();
-    const bool requested = task_->pauseRequested(&future);
-    ASSERT_TRUE(requested);
+    const bool paused = task_->pauseRequested(&future);
+    ASSERT_TRUE(paused);
     taskResumeAllowed = true;
     taskResumeAllowedWait.notifyAll();
     future.wait();

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -1499,7 +1499,6 @@ DEBUG_ONLY_TEST_F(TaskPauseTest, resumeFutureAfterTaskTerminated) {
   ASSERT_EQ(task_->numFinishedDrivers(), 0);
   ASSERT_EQ(task_->numRunningDrivers(), 1);
   task_->requestCancel().wait();
-  std::this_thread::sleep_for(std::chrono::milliseconds(100)); // NOLINT
   ASSERT_EQ(task_->numTotalDrivers(), 1);
   ASSERT_EQ(task_->numFinishedDrivers(), 0);
   ASSERT_EQ(task_->numRunningDrivers(), 0);

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -1502,9 +1502,9 @@ DEBUG_ONLY_TEST_F(TaskPauseTest, resumeFutureAfterTaskTerminated) {
   ASSERT_EQ(task_->numTotalDrivers(), 1);
   ASSERT_EQ(task_->numFinishedDrivers(), 0);
   ASSERT_EQ(task_->numRunningDrivers(), 0);
+  std::this_thread::sleep_for(std::chrono::milliseconds(100)); // NOLINT
   ASSERT_FALSE(future.isReady());
   Task::resume(task_->shared_from_this());
-  std::this_thread::sleep_for(std::chrono::milliseconds(100)); // NOLINT
   ASSERT_TRUE(future.isReady());
   future.wait();
   ASSERT_FALSE(task_->pauseRequested());

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -1373,77 +1373,94 @@ DEBUG_ONLY_TEST_F(TaskTest, findPeerOperators) {
   }
 }
 
-DEBUG_ONLY_TEST_F(TaskTest, raceBetweenTaskPauseAndTerminate) {
-  const std::vector<RowVectorPtr> values = {makeRowVector(
-      {"t_c0", "t_c1"},
-      {
-          makeFlatVector<int64_t>({1, 2, 3, 4}),
-          makeFlatVector<int64_t>({10, 20, 30, 40}),
-      })};
+class TaskPauseTest : public TaskTest {
+ public:
+  void testPause() {
+    const std::vector<RowVectorPtr> values = {makeRowVector(
+        {"t_c0", "t_c1"},
+        {
+            makeFlatVector<int64_t>({1, 2, 3, 4}),
+            makeFlatVector<int64_t>({10, 20, 30, 40}),
+        })};
 
-  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
-  CursorParameters params;
-  params.planNode =
-      PlanBuilder(planNodeIdGenerator).values(values, true).planNode();
-  params.queryCtx = core::QueryCtx::create(driverExecutor_.get());
-  params.maxDrivers = 1;
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    CursorParameters params;
+    params.planNode =
+        PlanBuilder(planNodeIdGenerator).values(values, true).planNode();
+    params.queryCtx = core::QueryCtx::create(driverExecutor_.get());
+    params.maxDrivers = 1;
 
-  auto cursor = TaskCursor::create(params);
-  auto* task = cursor->task().get();
-  folly::EventCount taskPauseWait;
-  std::atomic<bool> taskPaused{false};
+    cursor_ = TaskCursor::create(params);
+    task_ = cursor_->task().get();
+    folly::EventCount taskPauseWait;
+    std::atomic<bool> taskPaused{false};
 
-  folly::EventCount taskPauseStartWait;
-  std::atomic<bool> taskPauseStarted{false};
+    folly::EventCount taskPauseStartWait;
+    std::atomic<bool> taskPauseStarted{false};
 
-  // Set up a testvalue to trigger task abort when hash build tries to reserve
-  // memory.
-  SCOPED_TESTVALUE_SET(
-      "facebook::velox::exec::Driver::runInternal::addInput",
-      std::function<void(Operator*)>([&](Operator* testOp) {
-        if (taskPauseStarted.exchange(true)) {
-          return;
-        }
-        taskPauseStartWait.notifyAll();
-        taskPauseWait.await([&]() { return taskPaused.load(); });
-      }));
+    // Set up a testvalue to trigger task abort when hash build tries to reserve
+    // memory.
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Driver::runInternal::addInput",
+        std::function<void(Operator*)>([&](Operator* testOp) {
+          if (taskPauseStarted.exchange(true)) {
+            return;
+          }
+          taskPauseStartWait.notifyAll();
+          taskPauseWait.await([&]() { return taskPaused.load(); });
+        }));
 
-  std::thread taskThread([&]() {
-    try {
-      while (cursor->moveNext()) {
-      };
-    } catch (VeloxRuntimeError&) {
-    }
-  });
+    taskThread_ = std::thread([&]() {
+      try {
+        while (cursor_->moveNext()) {
+        };
+      } catch (VeloxRuntimeError&) {
+      }
+    });
 
-  taskPauseStartWait.await([&]() { return taskPauseStarted.load(); });
+    taskPauseStartWait.await([&]() { return taskPauseStarted.load(); });
 
-  ASSERT_EQ(task->numTotalDrivers(), 1);
-  ASSERT_EQ(task->numFinishedDrivers(), 0);
-  ASSERT_EQ(task->numRunningDrivers(), 1);
+    ASSERT_EQ(task_->numTotalDrivers(), 1);
+    ASSERT_EQ(task_->numFinishedDrivers(), 0);
+    ASSERT_EQ(task_->numRunningDrivers(), 1);
 
-  auto pauseFuture = task->requestPause();
-  taskPaused = true;
-  taskPauseWait.notifyAll();
-  pauseFuture.wait();
+    auto pauseFuture = task_->requestPause();
+    taskPaused = true;
+    taskPauseWait.notifyAll();
+    pauseFuture.wait();
 
-  ASSERT_EQ(task->numTotalDrivers(), 1);
-  ASSERT_EQ(task->numFinishedDrivers(), 0);
-  ASSERT_EQ(task->numRunningDrivers(), 1);
+    ASSERT_EQ(task_->numTotalDrivers(), 1);
+    ASSERT_EQ(task_->numFinishedDrivers(), 0);
+    ASSERT_EQ(task_->numRunningDrivers(), 1);
+    ASSERT_TRUE(task_->pauseRequested());
+  }
 
-  task->requestAbort().wait();
+  void TearDown() override {
+    cursor_.reset();
+    HiveConnectorTestBase::TearDown();
+  }
 
-  ASSERT_EQ(task->numTotalDrivers(), 1);
-  ASSERT_EQ(task->numFinishedDrivers(), 0);
-  ASSERT_EQ(task->numRunningDrivers(), 0);
+ protected:
+  Task* task_{nullptr};
+  std::unique_ptr<TaskCursor> cursor_{};
+  std::thread taskThread_{};
+};
 
-  Task::resume(task->shared_from_this());
+DEBUG_ONLY_TEST_F(TaskPauseTest, raceBetweenTaskPauseAndTerminate) {
+  testPause();
+  task_->requestAbort().wait();
 
-  ASSERT_EQ(task->numTotalDrivers(), 1);
-  ASSERT_EQ(task->numFinishedDrivers(), 1);
-  ASSERT_EQ(task->numRunningDrivers(), 0);
+  ASSERT_EQ(task_->numTotalDrivers(), 1);
+  ASSERT_EQ(task_->numFinishedDrivers(), 0);
+  ASSERT_EQ(task_->numRunningDrivers(), 0);
 
-  taskThread.join();
+  Task::resume(task_->shared_from_this());
+
+  ASSERT_EQ(task_->numTotalDrivers(), 1);
+  ASSERT_EQ(task_->numFinishedDrivers(), 1);
+  ASSERT_EQ(task_->numRunningDrivers(), 0);
+
+  taskThread_.join();
 }
 
 DEBUG_ONLY_TEST_F(TaskTest, driverCounters) {
@@ -1675,6 +1692,69 @@ TEST_F(TaskTest, spillDirNotCreated) {
   // destructor has not removed the directory if it was created earlier.
   auto fs = filesystems::getFileSystem(tmpDirectoryPath, nullptr);
   ASSERT_FALSE(fs->exists(tmpDirectoryPath));
+}
+
+DEBUG_ONLY_TEST_F(TaskPauseTest, resumeFuture) {
+  // Test for trivial wait on Task::pauseRequested future.
+  testPause();
+  folly::EventCount taskResumeAllowedWait;
+  std::atomic<bool> taskResumeAllowed{false};
+  std::thread observeThread([&]() {
+    ContinueFuture future = ContinueFuture::makeEmpty();
+    bool requested = task_->pauseRequested(&future);
+    ASSERT_TRUE(requested);
+    taskResumeAllowed = true;
+    taskResumeAllowedWait.notifyAll();
+    future.wait();
+    ASSERT_TRUE(!task_->pauseRequested());
+  });
+
+  taskResumeAllowedWait.await([&]() { return taskResumeAllowed.load(); });
+  std::this_thread::sleep_for(std::chrono::milliseconds(100)); // NOLINT
+  Task::resume(task_->shared_from_this());
+
+  taskThread_.join();
+  observeThread.join();
+
+  ASSERT_EQ(task_->numTotalDrivers(), 1);
+  ASSERT_EQ(task_->numFinishedDrivers(), 1);
+  ASSERT_EQ(task_->numRunningDrivers(), 0);
+}
+
+DEBUG_ONLY_TEST_F(TaskPauseTest, resumeFutureNeverFulfilled) {
+  // Test for Task::pauseRequested future to throw when task is never resumed.
+  testPause();
+  folly::EventCount taskAbortAllowedWait;
+  std::atomic<bool> taskAbortAllowed{false};
+  std::thread observeThread([&]() {
+    ContinueFuture future = ContinueFuture::makeEmpty();
+    bool requested = task_->pauseRequested(&future);
+    ASSERT_TRUE(requested);
+    taskAbortAllowed = true;
+    taskAbortAllowedWait.notifyAll();
+    future.wait();
+    ASSERT_TRUE(future.hasException());
+    ASSERT_EQ(
+        std::string(future.result().exception().what()),
+        "folly::BrokenPromise: Broken promise for type name `folly::Unit`");
+  });
+  taskAbortAllowedWait.await([&]() { return taskAbortAllowed.load(); });
+  std::this_thread::sleep_for(std::chrono::milliseconds(100)); // NOLINT
+  ASSERT_EQ(task_->numTotalDrivers(), 1);
+  ASSERT_EQ(task_->numFinishedDrivers(), 0);
+  ASSERT_EQ(task_->numRunningDrivers(), 1);
+  std::vector<Driver*> drivers{};
+  task_->testingVisitDrivers(
+      [&](Driver* driver) -> void { drivers.push_back(driver); });
+  for (const auto& driver : drivers) {
+    Task::removeDriver(task_->shared_from_this(), driver);
+  }
+  ASSERT_EQ(task_->numTotalDrivers(), 1);
+  ASSERT_EQ(task_->numFinishedDrivers(), 1);
+  ASSERT_EQ(task_->numRunningDrivers(), 0);
+  cursor_.reset();
+  taskThread_.join();
+  observeThread.join();
 }
 
 DEBUG_ONLY_TEST_F(TaskTest, resumeAfterTaskFinish) {


### PR DESCRIPTION
Memory arbitration/reclaim works as expected in single-threaded execution in most cases except for some issues during handling task pause/resume. This patch fixes the issues.

Issues fixed by the PR:

1. `SIGSEGV` by null pointer error during calling `Driver::enqueue` when arbitrator resumes the task
2. `INVALID_STATE` calling `Task::next` when task was paused by arbitration triggered by another task managed by the same shared arbitrator
   ```
   Error Source: RUNTIME
   Error Code: INVALID_STATE
   Retriable: False
   Expression: stop == StopReason::kBlock || stop == StopReason::kAtEnd || stop == StopReason::kAlreadyTerminated || stop 
   == StopReason::kTerminate
   Function: next
   File: /opt/gluten/ep/build-velox/build/velox_ep/velox/exec/Driver.cpp
   ```
And enable 3 existing test cases in SharedArbitratorTest for single-threaded execution:

SharedArbitrationTest.reclaimToJoinBuilder
SharedArbitrationTest.reclaimToAggregation
SharedArbitrationTest.reclaimToOrderBy

This reopens https://github.com/facebookincubator/velox/pull/8629.