### PR TITLE
Add isPathSupportedByRegisteredFileSystems api

### DIFF
--- a/velox/common/file/FileSystems.cpp
+++ b/velox/common/file/FileSystems.cpp
@@ -61,6 +61,16 @@ std::shared_ptr<FileSystem> getFileSystem(
   VELOX_FAIL("No registered file system matched with file path '{}'", filePath);
 }
 
+bool isPathSupportedByRegisteredFileSystems(const std::string_view& filePath) {
+  const auto& filesystems = registeredFileSystems();
+  for (const auto& p : filesystems) {
+    if (p.first(filePath)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 namespace {
 
 folly::once_flag localFSInstantiationFlag;

--- a/velox/common/file/FileSystems.h
+++ b/velox/common/file/FileSystems.h
@@ -108,6 +108,10 @@ std::shared_ptr<FileSystem> getFileSystem(
     std::string_view filename,
     std::shared_ptr<const Config> config);
 
+/// Returns true if filePath is supported by any registered file system,
+/// otherwise false.
+bool isPathSupportedByRegisteredFileSystems(const std::string_view& filePath);
+
 /// FileSystems must be registered explicitly.
 /// The registration function takes two parameters:
 /// a std::function<bool(std::string_view)> that says whether the registered

--- a/velox/common/file/tests/FileTest.cpp
+++ b/velox/common/file/tests/FileTest.cpp
@@ -419,6 +419,13 @@ class FaultyFsTest : public ::testing::Test {
   std::exception_ptr fileError_;
 };
 
+TEST_F(FaultyFsTest, schemCheck) {
+  ASSERT_TRUE(
+      filesystems::isPathSupportedByRegisteredFileSystems("faulty:/test"));
+  ASSERT_FALSE(
+      filesystems::isPathSupportedByRegisteredFileSystems("other:/test"));
+}
+
 TEST_F(FaultyFsTest, fileReadErrorInjection) {
   // Set read error.
   fs_->setFileInjectionError(fileError_, {FaultFileOperation::Type::kRead});


### PR DESCRIPTION
We would like to add API isPathSupportedByRegisteredFileSystems to verify if 
a given path is supported by registered file systems. This functionality is 
necessary to ensure that in Gluten scan operators can fallback appropriately 
when encountering paths not supported by the registered file systems in Velox.

Since this new API is intended for validation, it will not trigger any side 
effects such as instantiating the file system or throwing exceptions.