### PR TITLE
Add helper function to return the number of days since epoch for a week-of-month date

### DIFF
--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -144,6 +144,26 @@ bool isValidWeekDate(int32_t weekYear, int32_t weekOfYear, int32_t dayOfWeek) {
   return true;
 }
 
+bool isValidWeekOfMonthDate(
+    int32_t year,
+    int32_t month,
+    int32_t weekOfMonth,
+    int32_t dayOfWeek) {
+  if (dayOfWeek < 1 || dayOfWeek > 7) {
+    return false;
+  }
+  if (weekOfMonth < 1 || weekOfMonth > 5) {
+    return false;
+  }
+  if (month < 1 || month > 12) {
+    return false;
+  }
+  if (year < kMinYear || year > kMaxYear) {
+    return false;
+  }
+  return true;
+}
+
 inline bool validDate(int64_t daysSinceEpoch) {
   return daysSinceEpoch >= std::numeric_limits<int32_t>::min() &&
       daysSinceEpoch <= std::numeric_limits<int32_t>::max();
@@ -590,6 +610,26 @@ Status daysSinceEpochFromWeekDate(
 
   out = daysSinceEpochOfJanFourth - (firstDayOfWeekYear - 1) +
       7 * (weekOfYear - 1) + dayOfWeek - 1;
+  return Status::OK();
+}
+
+Status daysSinceEpochFromWeekOfMonthDate(
+    int32_t year,
+    int32_t month,
+    int32_t weekOfMonth,
+    int32_t dayOfWeek,
+    int64_t& out) {
+  if (!isValidWeekOfMonthDate(year, month, weekOfMonth, dayOfWeek)) {
+    return Status::UserError(
+        "Date out of range: {}-{}-{}-{}", year, month, weekOfMonth, dayOfWeek);
+  }
+  int64_t daysSinceEpochOfFirstDayOfMonth;
+  VELOX_RETURN_NOT_OK(
+      daysSinceEpochFromDate(year, month, 1, daysSinceEpochOfFirstDayOfMonth));
+  int32_t firstDayOfWeek =
+      extractISODayOfTheWeek(daysSinceEpochOfFirstDayOfMonth);
+  out = daysSinceEpochOfFirstDayOfMonth - (firstDayOfWeek - 1) +
+        7 * (weekOfMonth - 1) + dayOfWeek - 1;
   return Status::OK();
 }
 

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -144,10 +144,7 @@ bool isValidWeekDate(int32_t weekYear, int32_t weekOfYear, int32_t dayOfWeek) {
   return true;
 }
 
-bool isValidWeekOfMonthDate(
-    int32_t year,
-    int32_t month,
-    int32_t dayOfWeek) {
+bool isValidWeekOfMonthDate(int32_t year, int32_t month, int32_t dayOfWeek) {
   if (dayOfWeek < 1 || dayOfWeek > 7) {
     return false;
   }
@@ -615,13 +612,17 @@ Expected<int64_t> daysSinceEpochFromWeekOfMonthDate(
     int32_t weekOfMonth,
     int32_t dayOfWeek) {
   if (!isValidWeekOfMonthDate(year, month, dayOfWeek)) {
-    return folly::makeUnexpected(Status::UserError(
-        "Date out of range: {}-{}-{}-{}", year, month, weekOfMonth, dayOfWeek));
+    if (threadSkipErrorDetails()) {
+      return folly::makeUnexpected(Status::UserError());
+    } else {
+      return folly::makeUnexpected(Status::UserError(
+          "Date out of range: {}-{}-{}", year, month, dayOfWeek));
+    }
   }
   int64_t daysSinceEpochOfFirstDayOfMonth;
   Status status =
       daysSinceEpochFromDate(year, month, 1, daysSinceEpochOfFirstDayOfMonth);
-  if (status.ok() == false) {
+  if (!status.ok()) {
     return folly::makeUnexpected(status);
   }
   int32_t firstDayOfWeek =

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -629,7 +629,7 @@ Status daysSinceEpochFromWeekOfMonthDate(
   int32_t firstDayOfWeek =
       extractISODayOfTheWeek(daysSinceEpochOfFirstDayOfMonth);
   out = daysSinceEpochOfFirstDayOfMonth - (firstDayOfWeek - 1) +
-        7 * (weekOfMonth - 1) + dayOfWeek - 1;
+      7 * (weekOfMonth - 1) + dayOfWeek - 1;
   return Status::OK();
 }
 

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -623,7 +623,8 @@ Expected<int64_t> daysSinceEpochFromWeekOfMonthDate(
         "Date out of range: {}-{}-{}-{}", year, month, weekOfMonth, dayOfWeek));
   }
   int64_t daysSinceEpochOfFirstDayOfMonth;
-  Status status = daysSinceEpochFromDate(year, month, 1, daysSinceEpochOfFirstDayOfMonth);
+  Status status =
+      daysSinceEpochFromDate(year, month, 1, daysSinceEpochOfFirstDayOfMonth);
   if (status.ok() == false) {
     return folly::makeUnexpected(status);
   }

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -147,12 +147,8 @@ bool isValidWeekDate(int32_t weekYear, int32_t weekOfYear, int32_t dayOfWeek) {
 bool isValidWeekOfMonthDate(
     int32_t year,
     int32_t month,
-    int32_t weekOfMonth,
     int32_t dayOfWeek) {
   if (dayOfWeek < 1 || dayOfWeek > 7) {
-    return false;
-  }
-  if (weekOfMonth < 1 || weekOfMonth > 5) {
     return false;
   }
   if (month < 1 || month > 12) {
@@ -618,7 +614,7 @@ Expected<int64_t> daysSinceEpochFromWeekOfMonthDate(
     int32_t month,
     int32_t weekOfMonth,
     int32_t dayOfWeek) {
-  if (!isValidWeekOfMonthDate(year, month, weekOfMonth, dayOfWeek)) {
+  if (!isValidWeekOfMonthDate(year, month, dayOfWeek)) {
     return folly::makeUnexpected(Status::UserError(
         "Date out of range: {}-{}-{}-{}", year, month, weekOfMonth, dayOfWeek));
   }

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -42,9 +42,9 @@
 
 #include "velox/type/TimestampConversion.h"
 #include <folly/Expected.h>
-#include "HugeInt.h"
 #include "velox/common/base/CheckedArithmetic.h"
 #include "velox/common/base/Exceptions.h"
+#include "velox/type/HugeInt.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox::util {

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -602,7 +602,11 @@ daysSinceEpochFromDate(int32_t year, int32_t month, int32_t day, int64_t& out) {
   int64_t daysSinceEpoch = 0;
 
   if (!isValidDate(year, month, day)) {
-    return Status::UserError("Date out of range: {}-{}-{}", year, month, day);
+    if (threadSkipErrorDetails()) {
+      return Status::UserError();
+    } else {
+      return Status::UserError("Date out of range: {}-{}-{}", year, month, day);
+    }
   }
   while (year < 1970) {
     year += kYearInterval;
@@ -677,11 +681,7 @@ Expected<int64_t> daysSinceEpochFromWeekOfMonthDate(
   const Status status =
       daysSinceEpochFromDate(year, month, 1, daysSinceEpochOfFirstDayOfMonth);
   if (!status.ok()) {
-    if (threadSkipErrorDetails()) {
-      return folly::makeUnexpected(Status::UserError());
-    } else {
-      return folly::makeUnexpected(status);
-    }
+    return folly::makeUnexpected(status);
   }
   const int32_t firstDayOfWeek =
       extractISODayOfTheWeek(daysSinceEpochOfFirstDayOfMonth);

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -170,9 +170,9 @@ bool isValidWeekOfMonthDate(
   const int32_t firstWeekLength = 7 - firstDayOfWeek + 1;
   const int32_t monthLength =
       isLeapYear(year) ? kLeapDays[month] : kNormalDays[month];
-  const int32_t maxWeekOfMonth =
+  const int32_t actualNumberOfWeeks =
       1 + ceil((monthLength - firstWeekLength) / 7.0);
-  if (weekOfMonth < 1 || weekOfMonth > maxWeekOfMonth) {
+  if (weekOfMonth < 1 || weekOfMonth > actualNumberOfWeeks) {
     return false;
   }
 
@@ -184,7 +184,7 @@ bool isValidWeekOfMonthDate(
   const int32_t lastWeekLength = (monthLength - firstWeekLength) % 7;
   // If dayOfWeek is after the last day of the last week of the month, it is
   // considered invalid.
-  if (weekOfMonth == maxWeekOfMonth && lastWeekLength != 0 &&
+  if (weekOfMonth == actualNumberOfWeeks && lastWeekLength != 0 &&
       dayOfWeek > lastWeekLength) {
     return false;
   }

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -171,8 +171,7 @@ bool isValidWeekOfMonthDate(
   const int32_t firstWeekLength = 7 - firstDayOfWeek + 1;
   const int32_t monthLength =
       isLeapYear(year) ? kLeapDays[month] : kNormalDays[month];
-  const int32_t actualWeeks =
-      1 + ceil((monthLength - firstWeekLength) / 7.0);
+  const int32_t actualWeeks = 1 + ceil((monthLength - firstWeekLength) / 7.0);
   if (weekOfMonth < 1 || weekOfMonth > actualWeeks) {
     return false;
   }

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -42,10 +42,10 @@
 
 #include "velox/type/TimestampConversion.h"
 #include <folly/Expected.h>
+#include "HugeInt.h"
 #include "velox/common/base/CheckedArithmetic.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/type/tz/TimeZoneMap.h"
-#include "HugeInt.h"
 
 namespace facebook::velox::util {
 

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -109,6 +109,15 @@ Status daysSinceEpochFromWeekDate(
 
 /// Computes the (signed) number of days since unix epoch (1970-01-01).
 /// Returns UserError status if the date is invalid.
+Status daysSinceEpochFromWeekOfMonthDate(
+    int32_t year,
+    int32_t month,
+    int32_t weekOfMonth,
+    int32_t dayOfWeek,
+    int64_t& out);
+
+/// Computes the (signed) number of days since unix epoch (1970-01-01).
+/// Returns UserError status if the date is invalid.
 Status
 daysSinceEpochFromDayOfYear(int32_t year, int32_t dayOfYear, int64_t& out);
 

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -107,15 +107,25 @@ Status daysSinceEpochFromWeekDate(
     int32_t dayOfWeek,
     int64_t& out);
 
-/// Computes the (signed) number of days since unix epoch (1970-01-01).
-/// Returns error status if the date is invalid. We treat days of the previous
-/// or next months as a part of the specified WEEK_OF_MONTH. For example, if
-/// weekOfMonth is 5 but the current month only has 4 weeks (such as February),
-/// the first week of March will be considered as the 5th week of February.
-/// @param year Year, can be negative e.g: 1996, -2000
-/// @param month Month of year, A value in [1, 12] range. For example, 1 is Jan,
+/// Computes the signed number of days since the Unix epoch (1970-01-01). To
+/// align with Spark's SimpleDateFormat behavior, this function offers two
+/// modes: lenient and non-lenient. If `lenient` is false, it returns an error
+/// status if the date is invalid. If `lenient` is true, it accepts a wider
+/// range of arguments. For the month parameter, values greater than 12 wrap
+/// around to the start of the year, and values less than 1 count backward from
+/// December. For example, 13 corresponds to January of the following year and
+/// -1 corresponds to November of the previous year. For the weekOfMonth
+/// parameter, we consider days of the previous or next months as part of the
+/// specified weekOfMonth and dayOfWeek. For example, if weekOfMonth is 5 but
+/// the current month only has 4 weeks (such as February), the first week of
+/// March will be considered as the 5th week of February. For the dayOfWeek
+/// parameter, if weekOfMonth is 1 and dayOfWeek is 1 but the month's first day
+/// is a Saturday, the Monday of the last week of the previous month will be
+/// used.
+/// @param year Year, A value in [1, 292278994] range. e.g: 1996, -2000
+/// @param month Month of year. A value in [1, 12] range. For example, 1 is Jan,
 /// 7 is Jul.
-/// @param weekOfMonth Week of the month. A value in [1, 5] range. For example,
+/// @param weekOfMonth Week of the month. A value in [1, 6] range. For example,
 /// 1 is 1st week, 3 is 3rd week.
 /// @param dayOfWeek Day number of week. A value in [1, 7] range. For example, 1
 /// is Monday, 7 is Sunday.
@@ -123,7 +133,8 @@ Expected<int64_t> daysSinceEpochFromWeekOfMonthDate(
     int32_t year,
     int32_t month,
     int32_t weekOfMonth,
-    int32_t dayOfWeek);
+    int32_t dayOfWeek,
+    bool lenient);
 
 /// Computes the (signed) number of days since unix epoch (1970-01-01).
 /// Returns UserError status if the date is invalid.

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -108,11 +108,17 @@ Status daysSinceEpochFromWeekDate(
     int64_t& out);
 
 /// Computes the (signed) number of days since unix epoch (1970-01-01).
-/// Returns UserError status if the date is invalid.
+/// Returns error status if the date is invalid. We treat days of the previous
+/// or next months as a part of the specified WEEK_OF_MONTH. For example, if
+/// weekOfMonth is 5 but the current month only has 4 weeks (such as February),
+/// the first week of March will be considered as the 5th week of February.
 /// @param year Year, can be negative e.g: 1996, -2000
-/// @param month Month of year, e.g: 7
-/// @param weekOfMonth Week of month, 1 ~ 5 e.g: 2
-/// @param dayOfWeek Day of week, 1 ~ 7 e.g: 4
+/// @param month Month of year, A value in [1, 12] range. For example, 1 is Jan,
+/// 7 is Jul.
+/// @param weekOfMonth Week of the month. A value in [1, 5] range. For example,
+/// 1 is 1st week, 3 is 3rd week.
+/// @param dayOfWeek Day number of week. A value in [1, 7] range. For example, 1
+/// is Monday, 7 is Sunday.
 Expected<int64_t> daysSinceEpochFromWeekOfMonthDate(
     int32_t year,
     int32_t month,

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -109,7 +109,6 @@ Status daysSinceEpochFromWeekDate(
 
 /// Computes the (signed) number of days since unix epoch (1970-01-01).
 /// Returns UserError status if the date is invalid.
-/// Runs the aggregation fuzzer.
 /// @param year Year, can be negative e.g: 1996, -2000
 /// @param month Month of year, e.g: 7
 /// @param weekOfMonth Week of month, 1 ~ 5 e.g: 2

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -111,24 +111,26 @@ Status daysSinceEpochFromWeekDate(
 /// align with Spark's SimpleDateFormat behavior, this function offers two
 /// modes: lenient and non-lenient. If `lenient` is false, it returns an error
 /// status if the date is invalid. If `lenient` is true, it accepts a wider
-/// range of arguments. For the month parameter, values greater than 12 wrap
-/// around to the start of the year, and values less than 1 count backward from
-/// December. For example, 13 corresponds to January of the following year and
-/// -1 corresponds to November of the previous year. For the weekOfMonth
-/// parameter, we consider days of the previous or next months as part of the
-/// specified weekOfMonth and dayOfWeek. For example, if weekOfMonth is 5 but
-/// the current month only has 4 weeks (such as February), the first week of
-/// March will be considered as the 5th week of February. For the dayOfWeek
-/// parameter, if weekOfMonth is 1 and dayOfWeek is 1 but the month's first day
-/// is a Saturday, the Monday of the last week of the previous month will be
-/// used.
-/// @param year Year, A value in [1, 292278994] range. e.g: 1996, -2000
-/// @param month Month of year. A value in [1, 12] range. For example, 1 is Jan,
-/// 7 is Jul.
-/// @param weekOfMonth Week of the month. A value in [1, 6] range. For example,
-/// 1 is 1st week, 3 is 3rd week.
-/// @param dayOfWeek Day number of week. A value in [1, 7] range. For example, 1
-/// is Monday, 7 is Sunday.
+/// range of arguments.
+/// @param year Year. For non-lenient mode, it should be in the range [1,
+/// 292278994]. e.g: 1996, -2000
+/// @param month Month of year. For non-lenient mode, it should be in the range
+/// [1, 12]. For example, 1 is Jan, 7 is Jul. For lenient mode, values greater
+/// than 12 wrap around to the start of the year, and values less than 1 count
+/// backward from December. For example, 13 corresponds to January of the
+/// following year and -1 corresponds to November of the previous year.
+/// @param weekOfMonth Week of the month. For non-lenient mode, it should be in
+/// the range [1, 6]. For example, 1 is 1st week, 3 is 3rd week. For lenient
+/// mode, we consider days of the previous or next months as part of the
+/// specified weekOfMonth. For example, if weekOfMonth is 5 but the current
+/// month only has 4 weeks (such as February), the first week of March will be
+/// considered as the 5th week of February.
+/// @param dayOfWeek Day number of week. For non-lenient mode, it should be in
+/// the range [1, 7]. For example, 1 is Monday, 7 is Sunday. For lenient mode,
+/// we consider days of the previous or next months as part of the specified
+/// dayOfWeek.For example, if weekOfMonth is 1 and dayOfWeek is 1 but the
+/// month's first day is Saturday, the Monday of the last week of the previous
+/// month will be used.
 Expected<int64_t> daysSinceEpochFromWeekOfMonthDate(
     int32_t year,
     int32_t month,
@@ -152,7 +154,7 @@ inline Expected<int32_t> fromDateString(const StringView& str, ParseMode mode) {
 }
 
 // Extracts the day of the week from the number of days since epoch
-int32_t extractISODayOfTheWeek(int32_t daysSinceEpoch);
+int32_t extractISODayOfTheWeek(int64_t daysSinceEpoch);
 
 /// Time conversions.
 

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -109,16 +109,16 @@ Status daysSinceEpochFromWeekDate(
 
 /// Computes the signed number of days since the Unix epoch (1970-01-01). To
 /// align with Spark's SimpleDateFormat behavior, this function offers two
-/// modes: lenient and non-lenient. If `lenient` is false, it returns an error
-/// status if the date is invalid. If `lenient` is true, it accepts a wider
-/// range of arguments.
+/// modes: lenient and non-lenient. For non-lenient mode, it returns an error
+/// status if the date is invalid. For lenient mode, it accepts a wider range of
+/// arguments.
 /// @param year Year. For non-lenient mode, it should be in the range [1,
 /// 292278994]. e.g: 1996, -2000. For lenient mode, values outside this range
 /// could result in overflow.
 /// @param month Month of year. For non-lenient mode, it should be in the range
-/// [1, 12]. For example, 1 is Jan, 7 is Jul. For lenient mode, values greater
-/// than 12 wrap around to the start of the year, and values less than 1 count
-/// backward from December. For example, 13 corresponds to January of the
+/// [1, 12]. For example, 1 is January, 7 is July. For lenient mode, values
+/// greater than 12 wrap around to the start of the year, and values less than 1
+/// count backward from December. For example, 13 corresponds to January of the
 /// following year and -1 corresponds to November of the previous year.
 /// @param weekOfMonth Week of the month. For non-lenient mode, it should be in
 /// the range [1, 6]. For example, 1 is 1st week, 3 is 3rd week. For lenient

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -113,13 +113,11 @@ Status daysSinceEpochFromWeekDate(
 /// @param month Month of year, e.g: 7
 /// @param weekOfMonth Week of month, 1 ~ 5 e.g: 2
 /// @param dayOfWeek Day of week, 1 ~ 7 e.g: 4
-/// @param out Reference for days since epoch
-Status daysSinceEpochFromWeekOfMonthDate(
+Expected<int64_t> daysSinceEpochFromWeekOfMonthDate(
     int32_t year,
     int32_t month,
     int32_t weekOfMonth,
-    int32_t dayOfWeek,
-    int64_t& out);
+    int32_t dayOfWeek);
 
 /// Computes the (signed) number of days since unix epoch (1970-01-01).
 /// Returns UserError status if the date is invalid.

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -109,12 +109,12 @@ Status daysSinceEpochFromWeekDate(
 
 /// Computes the signed number of days since the Unix epoch (1970-01-01). To
 /// align with Spark's SimpleDateFormat behavior, this function offers two
-/// modes: lenient and non-lenient. For non-lenient mode, it returns an error
-/// status if the date is invalid. For lenient mode, it accepts a wider range of
-/// arguments.
+/// modes: lenient and non-lenient. For non-lenient mode, dates before Jan 1, 1
+/// are not supported, and it returns an error status if the date is invalid.
+/// For lenient mode, it accepts a wider range of arguments.
 /// @param year Year. For non-lenient mode, it should be in the range [1,
-/// 292278994]. e.g: 1996, -2000. For lenient mode, values outside this range
-/// could result in overflow.
+/// 292278994]. e.g: 1996, 2024. For lenient mode, it should be in the range
+/// [-292275055, 292278994].
 /// @param month Month of year. For non-lenient mode, it should be in the range
 /// [1, 12]. For example, 1 is January, 7 is July. For lenient mode, values
 /// greater than 12 wrap around to the start of the year, and values less than 1

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -109,6 +109,12 @@ Status daysSinceEpochFromWeekDate(
 
 /// Computes the (signed) number of days since unix epoch (1970-01-01).
 /// Returns UserError status if the date is invalid.
+/// Runs the aggregation fuzzer.
+/// @param year Year, can be negative e.g: 1996, -2000
+/// @param month Month of year, e.g: 7
+/// @param weekOfMonth Week of month, 1 ~ 5 e.g: 2
+/// @param dayOfWeek Day of week, 1 ~ 7 e.g: 4
+/// @param out Reference days since epoch
 Status daysSinceEpochFromWeekOfMonthDate(
     int32_t year,
     int32_t month,

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -109,24 +109,24 @@ Status daysSinceEpochFromWeekDate(
 
 /// Computes the signed number of days since the Unix epoch (1970-01-01). To
 /// align with Spark's SimpleDateFormat behavior, this function offers two
-/// modes: lenient and non-lenient. For non-lenient mode, dates before Jan 1, 1
+/// modes: lenient and strict. For strict mode, dates before Jan 1, 1
 /// are not supported, and it returns an error status if the date is invalid.
 /// For lenient mode, it accepts a wider range of arguments.
-/// @param year Year. For non-lenient mode, it should be in the range [1,
+/// @param year Year. For strict mode, it should be in the range [1,
 /// 292278994]. e.g: 1996, 2024. For lenient mode, it should be in the range
 /// [-292275055, 292278994].
-/// @param month Month of year. For non-lenient mode, it should be in the range
+/// @param month Month of year. For strict mode, it should be in the range
 /// [1, 12]. For example, 1 is January, 7 is July. For lenient mode, values
 /// greater than 12 wrap around to the start of the year, and values less than 1
 /// count backward from December. For example, 13 corresponds to January of the
 /// following year and -1 corresponds to November of the previous year.
-/// @param weekOfMonth Week of the month. For non-lenient mode, it should be in
+/// @param weekOfMonth Week of the month. For strict mode, it should be in
 /// the range [1, depends on month]. For example, 1 is 1st week, 3 is 3rd week.
 /// For lenient mode, we consider days of the previous or next months as part of
 /// the specified weekOfMonth. For example, if weekOfMonth is 5 but the current
 /// month only has 4 weeks (such as February), the first week of March will be
 /// considered as the 5th week of February.
-/// @param dayOfWeek Day number of week. For non-lenient mode, it should be in
+/// @param dayOfWeek Day number of week. For strict mode, it should be in
 /// the range [1, depends on month]. For example, 1 is Monday, 7 is Sunday. For
 /// lenient mode, we consider days of the previous or next months as part of the
 /// specified dayOfWeek.For example, if weekOfMonth is 1 and dayOfWeek is 1 but

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -113,7 +113,8 @@ Status daysSinceEpochFromWeekDate(
 /// status if the date is invalid. If `lenient` is true, it accepts a wider
 /// range of arguments.
 /// @param year Year. For non-lenient mode, it should be in the range [1,
-/// 292278994]. e.g: 1996, -2000
+/// 292278994]. e.g: 1996, -2000. For lenient mode, values outside this range
+/// could result in overflow.
 /// @param month Month of year. For non-lenient mode, it should be in the range
 /// [1, 12]. For example, 1 is Jan, 7 is Jul. For lenient mode, values greater
 /// than 12 wrap around to the start of the year, and values less than 1 count

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -121,17 +121,17 @@ Status daysSinceEpochFromWeekDate(
 /// count backward from December. For example, 13 corresponds to January of the
 /// following year and -1 corresponds to November of the previous year.
 /// @param weekOfMonth Week of the month. For non-lenient mode, it should be in
-/// the range [1, 6]. For example, 1 is 1st week, 3 is 3rd week. For lenient
-/// mode, we consider days of the previous or next months as part of the
-/// specified weekOfMonth. For example, if weekOfMonth is 5 but the current
+/// the range [1, depends on month]. For example, 1 is 1st week, 3 is 3rd week.
+/// For lenient mode, we consider days of the previous or next months as part of
+/// the specified weekOfMonth. For example, if weekOfMonth is 5 but the current
 /// month only has 4 weeks (such as February), the first week of March will be
 /// considered as the 5th week of February.
 /// @param dayOfWeek Day number of week. For non-lenient mode, it should be in
-/// the range [1, 7]. For example, 1 is Monday, 7 is Sunday. For lenient mode,
-/// we consider days of the previous or next months as part of the specified
-/// dayOfWeek.For example, if weekOfMonth is 1 and dayOfWeek is 1 but the
-/// month's first day is Saturday, the Monday of the last week of the previous
-/// month will be used.
+/// the range [1, depends on month]. For example, 1 is Monday, 7 is Sunday. For
+/// lenient mode, we consider days of the previous or next months as part of the
+/// specified dayOfWeek.For example, if weekOfMonth is 1 and dayOfWeek is 1 but
+/// the month's first day is Saturday, the Monday of the last week of the
+/// previous month will be used.
 Expected<int64_t> daysSinceEpochFromWeekOfMonthDate(
     int32_t year,
     int32_t month,

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -113,7 +113,7 @@ Status daysSinceEpochFromWeekDate(
 /// @param month Month of year, e.g: 7
 /// @param weekOfMonth Week of month, 1 ~ 5 e.g: 2
 /// @param dayOfWeek Day of week, 1 ~ 7 e.g: 4
-/// @param out Reference days since epoch
+/// @param out Reference for days since epoch
 Status daysSinceEpochFromWeekOfMonthDate(
     int32_t year,
     int32_t month,

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -162,7 +162,7 @@ TEST(DateTimeUtilTest, fromWeekOfMonthDate) {
 }
 
 TEST(DateTimeUtilTest, extractISODayOfTheWeek) {
-  EXPECT_EQ(6, util::extractISODayOfTheWeek(int64_t(INT_MAX) + 1));
+  EXPECT_EQ(4, util::extractISODayOfTheWeek(std::numeric_limits<int64_t>::max()));
 }
 
 TEST(DateTimeUtilTest, fromWeekOfMonthDateInvalid) {

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -156,8 +156,8 @@ TEST(DateTimeUtilTest, fromWeekOfMonthDate) {
   EXPECT_EQ(-430, daysSinceEpochLenient(1970, -13, 1, 1));
 
   // Out of range year.
-  auto result = util::daysSinceEpochFromWeekOfMonthDate(
-      292278995, 1, 1, 1, true);
+  auto result =
+      util::daysSinceEpochFromWeekOfMonthDate(292278995, 1, 1, 1, true);
   EXPECT_EQ(result.error().message(), "Date out of range: 292278995-1-1");
 }
 

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -170,7 +170,7 @@ TEST(DateTimeUtilTest, extractISODayOfTheWeek) {
   EXPECT_EQ(7, util::extractISODayOfTheWeek(10));
 }
 
-TEST(DateTimeUtilTest, daysSinceEpochFromWeekOfMonthDateNonLenient) {
+TEST(DateTimeUtilTest, daysSinceEpochFromWeekOfMonthDateStrict) {
   auto daysSinceEpochReturnError = [](int32_t year,
                                       int32_t month,
                                       int32_t weekOfMonth,

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -105,36 +105,81 @@ TEST(DateTimeUtilTest, fromDateInvalid) {
 }
 
 TEST(DateTimeUtilTest, fromWeekOfMonthDate) {
-  auto daysSinceEpochFromWeekOfMonthDate =
+  auto daysSinceEpoch =
       [](int32_t year, int32_t month, int32_t weekOfMonth, int32_t dayOfWeek) {
         auto result = util::daysSinceEpochFromWeekOfMonthDate(
-            year, month, weekOfMonth, dayOfWeek);
+            year, month, weekOfMonth, dayOfWeek, true);
         EXPECT_TRUE(!result.hasError());
         return result.value();
       };
-  EXPECT_EQ(4, daysSinceEpochFromWeekOfMonthDate(1970, 1, 2, 1));
-  EXPECT_EQ(361, daysSinceEpochFromWeekOfMonthDate(1971, 1, 1, 1));
-  EXPECT_EQ(396, daysSinceEpochFromWeekOfMonthDate(1971, 2, 1, 1));
+  EXPECT_EQ(4, daysSinceEpoch(1970, 1, 2, 1));
+  EXPECT_EQ(361, daysSinceEpoch(1971, 1, 1, 1));
+  EXPECT_EQ(396, daysSinceEpoch(1971, 2, 1, 1));
 
-  EXPECT_EQ(10952, daysSinceEpochFromWeekOfMonthDate(2000, 1, 1, 1));
-  EXPECT_EQ(19905, daysSinceEpochFromWeekOfMonthDate(2024, 7, 1, 1));
+  EXPECT_EQ(10952, daysSinceEpoch(2000, 1, 1, 1));
+  EXPECT_EQ(19905, daysSinceEpoch(2024, 7, 1, 1));
 
   // Before unix epoch.
-  EXPECT_EQ(-3, daysSinceEpochFromWeekOfMonthDate(1970, 1, 1, 1));
-  EXPECT_EQ(-2, daysSinceEpochFromWeekOfMonthDate(1970, 1, 1, 2));
-  EXPECT_EQ(-31, daysSinceEpochFromWeekOfMonthDate(1969, 12, 1, 1));
-  EXPECT_EQ(-367, daysSinceEpochFromWeekOfMonthDate(1969, 1, 1, 1));
-  EXPECT_EQ(-724, daysSinceEpochFromWeekOfMonthDate(1968, 1, 2, 1));
-  EXPECT_EQ(-719533, daysSinceEpochFromWeekOfMonthDate(0, 1, 1, 1));
+  EXPECT_EQ(-3, daysSinceEpoch(1970, 1, 1, 1));
+  EXPECT_EQ(-2, daysSinceEpoch(1970, 1, 1, 2));
+  EXPECT_EQ(-31, daysSinceEpoch(1969, 12, 1, 1));
+  EXPECT_EQ(-367, daysSinceEpoch(1969, 1, 1, 1));
+  EXPECT_EQ(-724, daysSinceEpoch(1968, 1, 2, 1));
+  EXPECT_EQ(-719533, daysSinceEpoch(0, 1, 1, 1));
 
   // Negative year - BC.
-  EXPECT_EQ(-719561, daysSinceEpochFromWeekOfMonthDate(-1, 12, 1, 1));
-  EXPECT_EQ(-719897, daysSinceEpochFromWeekOfMonthDate(-1, 1, 1, 1));
+  EXPECT_EQ(-719561, daysSinceEpoch(-1, 12, 1, 1));
+  EXPECT_EQ(-719897, daysSinceEpoch(-1, 1, 1, 1));
 
-  // day in previous month
-  EXPECT_EQ(19783, daysSinceEpochFromWeekOfMonthDate(2024, 2, 5, 5));
-  // day in next month
-  EXPECT_EQ(19751, daysSinceEpochFromWeekOfMonthDate(2024, 2, 1, 1));
+  // Day in the previous month.
+  EXPECT_EQ(19783, daysSinceEpoch(2024, 2, 5, 5));
+  // Day in the next month.
+  EXPECT_EQ(19751, daysSinceEpoch(2024, 2, 1, 1));
+
+  // Out of range day of week.
+  EXPECT_EQ(338, daysSinceEpoch(1970, 12, 1, 0));
+  EXPECT_EQ(337, daysSinceEpoch(1970, 12, 1, -1));
+  EXPECT_EQ(337, daysSinceEpoch(1970, 12, 1, -8));
+
+  EXPECT_EQ(332, daysSinceEpoch(1970, 12, 1, 8));
+  EXPECT_EQ(333, daysSinceEpoch(1970, 12, 1, 9));
+  EXPECT_EQ(336, daysSinceEpoch(1970, 12, 1, 19));
+
+  // Out of range month.
+  EXPECT_EQ(-3, daysSinceEpoch(1970, 1, 1, 1));
+  EXPECT_EQ(207, daysSinceEpoch(1970, 8, 1, 1));
+  EXPECT_EQ(361, daysSinceEpoch(1970, 13, 1, 1));
+
+  EXPECT_EQ(-31, daysSinceEpoch(1970, 0, 1, 1));
+  EXPECT_EQ(-66, daysSinceEpoch(1970, -1, 1, 1));
+  EXPECT_EQ(-430, daysSinceEpoch(1970, -13, 1, 1));
+}
+
+TEST(DateTimeUtilTest, fromWeekOfMonthDateInvalid) {
+  auto daysSinceEpoch = [](int32_t year,
+                           int32_t month,
+                           int32_t weekOfMonth,
+                           int32_t dayOfWeek,
+                           const std::string& error) {
+    auto result = util::daysSinceEpochFromWeekOfMonthDate(
+        year, month, weekOfMonth, dayOfWeek, false);
+    EXPECT_TRUE(result.error().isUserError());
+    EXPECT_EQ(result.error().message(), error);
+  };
+
+  EXPECT_NO_THROW(daysSinceEpoch(-1, 1, 1, 1, "Date out of range: -1-1-1-1"));
+  EXPECT_NO_THROW(
+      daysSinceEpoch(292278995, 1, 1, 1, "Date out of range: 292278995-1-1-1"));
+  EXPECT_NO_THROW(
+      daysSinceEpoch(2024, 0, 1, 1, "Date out of range: 2024-0-1-1"));
+  EXPECT_NO_THROW(
+      daysSinceEpoch(2024, 13, 1, 1, "Date out of range: 2024-13-1-1"));
+  EXPECT_NO_THROW(
+      daysSinceEpoch(2024, 1, 6, 1, "Date out of range: 2024-1-6-1"));
+  EXPECT_NO_THROW(
+      daysSinceEpoch(2024, 2, 1, 1, "Date out of range: 2024-2-1-1"));
+  EXPECT_NO_THROW(
+      daysSinceEpoch(2024, 2, 5, 5, "Date out of range: 2024-2-5-5"));
 }
 
 TEST(DateTimeUtilTest, fromDateString) {

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -157,10 +157,10 @@ TEST(DateTimeUtilTest, fromWeekOfMonthDate) {
 
 TEST(DateTimeUtilTest, fromWeekOfMonthDateInvalid) {
   auto daysSinceEpochNonLenient = [](int32_t year,
-                           int32_t month,
-                           int32_t weekOfMonth,
-                           int32_t dayOfWeek,
-                           const std::string& error) {
+                                     int32_t month,
+                                     int32_t weekOfMonth,
+                                     int32_t dayOfWeek,
+                                     const std::string& error) {
     auto result = util::daysSinceEpochFromWeekOfMonthDate(
         year, month, weekOfMonth, dayOfWeek, false);
     EXPECT_TRUE(result.error().isUserError());
@@ -169,10 +169,12 @@ TEST(DateTimeUtilTest, fromWeekOfMonthDateInvalid) {
 
   EXPECT_NO_THROW(
       daysSinceEpochNonLenient(-1, 1, 1, 1, "Date out of range: -1-1-1-1"));
-  EXPECT_NO_THROW(daysSinceEpochNonLenient(292278995, 1, 1, 1, "Date out of range: 292278995-1-1-1"));
+  EXPECT_NO_THROW(daysSinceEpochNonLenient(
+      292278995, 1, 1, 1, "Date out of range: 292278995-1-1-1"));
   EXPECT_NO_THROW(
       daysSinceEpochNonLenient(2024, 0, 1, 1, "Date out of range: 2024-0-1-1"));
-  EXPECT_NO_THROW(daysSinceEpochNonLenient(2024, 13, 1, 1, "Date out of range: 2024-13-1-1"));
+  EXPECT_NO_THROW(daysSinceEpochNonLenient(
+      2024, 13, 1, 1, "Date out of range: 2024-13-1-1"));
   EXPECT_NO_THROW(
       daysSinceEpochNonLenient(2024, 1, 6, 1, "Date out of range: 2024-1-6-1"));
   EXPECT_NO_THROW(

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -104,6 +104,35 @@ TEST(DateTimeUtilTest, fromDateInvalid) {
       1970, 6, 31, "Date out of range: 1970-6-31"));
 }
 
+TEST(DateTimeUtilTest, fromWeekOfMonthDate) {
+  auto testDaysSinceEpochFromWeekOfMonthDate =
+      [](int32_t year, int32_t month, int32_t weekOfMonth, int32_t dayOfWeek) {
+        int64_t daysSinceEpoch;
+        auto status = util::daysSinceEpochFromWeekOfMonthDate(
+            year, month, weekOfMonth, dayOfWeek, daysSinceEpoch);
+        EXPECT_TRUE(status.ok());
+        return daysSinceEpoch;
+      };
+  EXPECT_EQ(4, testDaysSinceEpochFromWeekOfMonthDate(1970, 1, 2, 1));
+  EXPECT_EQ(361, testDaysSinceEpochFromWeekOfMonthDate(1971, 1, 1, 1));
+  EXPECT_EQ(396, testDaysSinceEpochFromWeekOfMonthDate(1971, 2, 1, 1));
+
+  EXPECT_EQ(10952, testDaysSinceEpochFromWeekOfMonthDate(2000, 1, 1, 1));
+  EXPECT_EQ(19905, testDaysSinceEpochFromWeekOfMonthDate(2024, 7, 1, 1));
+
+  // Before unix epoch.
+  EXPECT_EQ(-3, testDaysSinceEpochFromWeekOfMonthDate(1970, 1, 1, 1));
+  EXPECT_EQ(-2, testDaysSinceEpochFromWeekOfMonthDate(1970, 1, 1, 2));
+  EXPECT_EQ(-31, testDaysSinceEpochFromWeekOfMonthDate(1969, 12, 1, 1));
+  EXPECT_EQ(-367, testDaysSinceEpochFromWeekOfMonthDate(1969, 1, 1, 1));
+  EXPECT_EQ(-724, testDaysSinceEpochFromWeekOfMonthDate(1968, 1, 2, 1));
+  EXPECT_EQ(-719533, testDaysSinceEpochFromWeekOfMonthDate(0, 1, 1, 1));
+
+  // Negative year - BC.
+  EXPECT_EQ(-719561, testDaysSinceEpochFromWeekOfMonthDate(-1, 12, 1, 1));
+  EXPECT_EQ(-719897, testDaysSinceEpochFromWeekOfMonthDate(-1, 1, 1, 1));
+}
+
 TEST(DateTimeUtilTest, fromDateString) {
   for (ParseMode mode : {ParseMode::kPrestoCast, ParseMode::kSparkCast}) {
     EXPECT_EQ(0, parseDate("1970-01-01", mode));

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -105,32 +105,36 @@ TEST(DateTimeUtilTest, fromDateInvalid) {
 }
 
 TEST(DateTimeUtilTest, fromWeekOfMonthDate) {
-  auto testDaysSinceEpochFromWeekOfMonthDate =
+  auto daysSinceEpochFromWeekOfMonthDate =
       [](int32_t year, int32_t month, int32_t weekOfMonth, int32_t dayOfWeek) {
-        int64_t daysSinceEpoch;
-        auto expected = util::daysSinceEpochFromWeekOfMonthDate(
+        auto result = util::daysSinceEpochFromWeekOfMonthDate(
             year, month, weekOfMonth, dayOfWeek);
-        EXPECT_TRUE(!expected.hasError());
-        return expected.value();
+        EXPECT_TRUE(!result.hasError());
+        return result.value();
       };
-  EXPECT_EQ(4, testDaysSinceEpochFromWeekOfMonthDate(1970, 1, 2, 1));
-  EXPECT_EQ(361, testDaysSinceEpochFromWeekOfMonthDate(1971, 1, 1, 1));
-  EXPECT_EQ(396, testDaysSinceEpochFromWeekOfMonthDate(1971, 2, 1, 1));
+  EXPECT_EQ(4, daysSinceEpochFromWeekOfMonthDate(1970, 1, 2, 1));
+  EXPECT_EQ(361, daysSinceEpochFromWeekOfMonthDate(1971, 1, 1, 1));
+  EXPECT_EQ(396, daysSinceEpochFromWeekOfMonthDate(1971, 2, 1, 1));
 
-  EXPECT_EQ(10952, testDaysSinceEpochFromWeekOfMonthDate(2000, 1, 1, 1));
-  EXPECT_EQ(19905, testDaysSinceEpochFromWeekOfMonthDate(2024, 7, 1, 1));
+  EXPECT_EQ(10952, daysSinceEpochFromWeekOfMonthDate(2000, 1, 1, 1));
+  EXPECT_EQ(19905, daysSinceEpochFromWeekOfMonthDate(2024, 7, 1, 1));
 
   // Before unix epoch.
-  EXPECT_EQ(-3, testDaysSinceEpochFromWeekOfMonthDate(1970, 1, 1, 1));
-  EXPECT_EQ(-2, testDaysSinceEpochFromWeekOfMonthDate(1970, 1, 1, 2));
-  EXPECT_EQ(-31, testDaysSinceEpochFromWeekOfMonthDate(1969, 12, 1, 1));
-  EXPECT_EQ(-367, testDaysSinceEpochFromWeekOfMonthDate(1969, 1, 1, 1));
-  EXPECT_EQ(-724, testDaysSinceEpochFromWeekOfMonthDate(1968, 1, 2, 1));
-  EXPECT_EQ(-719533, testDaysSinceEpochFromWeekOfMonthDate(0, 1, 1, 1));
+  EXPECT_EQ(-3, daysSinceEpochFromWeekOfMonthDate(1970, 1, 1, 1));
+  EXPECT_EQ(-2, daysSinceEpochFromWeekOfMonthDate(1970, 1, 1, 2));
+  EXPECT_EQ(-31, daysSinceEpochFromWeekOfMonthDate(1969, 12, 1, 1));
+  EXPECT_EQ(-367, daysSinceEpochFromWeekOfMonthDate(1969, 1, 1, 1));
+  EXPECT_EQ(-724, daysSinceEpochFromWeekOfMonthDate(1968, 1, 2, 1));
+  EXPECT_EQ(-719533, daysSinceEpochFromWeekOfMonthDate(0, 1, 1, 1));
 
   // Negative year - BC.
-  EXPECT_EQ(-719561, testDaysSinceEpochFromWeekOfMonthDate(-1, 12, 1, 1));
-  EXPECT_EQ(-719897, testDaysSinceEpochFromWeekOfMonthDate(-1, 1, 1, 1));
+  EXPECT_EQ(-719561, daysSinceEpochFromWeekOfMonthDate(-1, 12, 1, 1));
+  EXPECT_EQ(-719897, daysSinceEpochFromWeekOfMonthDate(-1, 1, 1, 1));
+
+  // day in previous month
+  EXPECT_EQ(19783, daysSinceEpochFromWeekOfMonthDate(2024, 2, 5, 5));
+  // day in next month
+  EXPECT_EQ(19751, daysSinceEpochFromWeekOfMonthDate(2024, 2, 1, 1));
 }
 
 TEST(DateTimeUtilTest, fromDateString) {

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -171,7 +171,7 @@ TEST(DateTimeUtilTest, extractISODayOfTheWeek) {
 }
 
 TEST(DateTimeUtilTest, daysSinceEpochFromWeekOfMonthDateNonLenient) {
-  auto daysSinceEpoch = [](int32_t year,
+  auto daysSinceEpochReturnError = [](int32_t year,
                            int32_t month,
                            int32_t weekOfMonth,
                            int32_t dayOfWeek,
@@ -182,19 +182,25 @@ TEST(DateTimeUtilTest, daysSinceEpochFromWeekOfMonthDateNonLenient) {
     EXPECT_EQ(result.error().message(), error);
   };
 
-  EXPECT_NO_THROW(
-      daysSinceEpoch(292278995, 1, 1, 1, "Date out of range: 292278995-1-1-1"));
-  EXPECT_NO_THROW(
-      daysSinceEpoch(2024, 0, 1, 1, "Date out of range: 2024-0-1-1"));
-  EXPECT_NO_THROW(
-      daysSinceEpoch(2024, 13, 1, 1, "Date out of range: 2024-13-1-1"));
-  EXPECT_NO_THROW(
-      daysSinceEpoch(2024, 1, 6, 1, "Date out of range: 2024-1-6-1"));
-  EXPECT_NO_THROW(
-      daysSinceEpoch(2024, 2, 1, 1, "Date out of range: 2024-2-1-1"));
-  EXPECT_NO_THROW(
-      daysSinceEpoch(2024, 2, 5, 5, "Date out of range: 2024-2-5-5"));
-  EXPECT_EQ(4, daysSinceEpochFromWeekOfMonthDate(1970, 1, 2, 1, false).value());
+  EXPECT_NO_THROW(daysSinceEpochReturnError(292278995, 1, 1, 1, "Date out of range: 292278995-1-1-1"));
+  EXPECT_NO_THROW(daysSinceEpochReturnError(2024, 0, 1, 1, "Date out of range: 2024-0-1-1"));
+  EXPECT_NO_THROW(daysSinceEpochReturnError(2024, 13, 1, 1, "Date out of range: 2024-13-1-1"));
+  EXPECT_NO_THROW(daysSinceEpochReturnError(2024, 1, 6, 1, "Date out of range: 2024-1-6-1"));
+  EXPECT_NO_THROW(daysSinceEpochReturnError(2024, 2, 1, 1, "Date out of range: 2024-2-1-1"));
+  EXPECT_NO_THROW(daysSinceEpochReturnError(2024, 2, 5, 5, "Date out of range: 2024-2-5-5"));
+
+  auto daysSinceEpochReturnValues =
+      [](int32_t year, int32_t month, int32_t weekOfMonth, int32_t dayOfWeek) {
+        auto result = util::daysSinceEpochFromWeekOfMonthDate(
+            year, month, weekOfMonth, dayOfWeek, false);
+        EXPECT_TRUE(!result.hasError());
+        return result.value();
+      };
+
+  EXPECT_EQ(-724, daysSinceEpochReturnValues(1968, 1, 2, 1));
+  EXPECT_EQ(4, daysSinceEpochReturnValues(1970, 1, 2, 1));
+  EXPECT_EQ(396, daysSinceEpochReturnValues(1971, 2, 1, 1));
+  EXPECT_EQ(19905, daysSinceEpochReturnValues(2024, 7, 1, 1));
 }
 
 TEST(DateTimeUtilTest, fromDateString) {

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -161,6 +161,10 @@ TEST(DateTimeUtilTest, fromWeekOfMonthDate) {
   EXPECT_EQ(result.error().message(), "Date out of range: 292278995-1-1");
 }
 
+TEST(DateTimeUtilTest, extractISODayOfTheWeek) {
+  EXPECT_EQ(6, util::extractISODayOfTheWeek(int64_t(INT_MAX) + 1));
+}
+
 TEST(DateTimeUtilTest, fromWeekOfMonthDateInvalid) {
   auto daysSinceEpochNonLenient = [](int32_t year,
                                      int32_t month,

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -105,58 +105,58 @@ TEST(DateTimeUtilTest, fromDateInvalid) {
 }
 
 TEST(DateTimeUtilTest, fromWeekOfMonthDate) {
-  auto daysSinceEpoch =
+  auto daysSinceEpochLenient =
       [](int32_t year, int32_t month, int32_t weekOfMonth, int32_t dayOfWeek) {
         auto result = util::daysSinceEpochFromWeekOfMonthDate(
             year, month, weekOfMonth, dayOfWeek, true);
         EXPECT_TRUE(!result.hasError());
         return result.value();
       };
-  EXPECT_EQ(4, daysSinceEpoch(1970, 1, 2, 1));
-  EXPECT_EQ(361, daysSinceEpoch(1971, 1, 1, 1));
-  EXPECT_EQ(396, daysSinceEpoch(1971, 2, 1, 1));
+  EXPECT_EQ(4, daysSinceEpochLenient(1970, 1, 2, 1));
+  EXPECT_EQ(361, daysSinceEpochLenient(1971, 1, 1, 1));
+  EXPECT_EQ(396, daysSinceEpochLenient(1971, 2, 1, 1));
 
-  EXPECT_EQ(10952, daysSinceEpoch(2000, 1, 1, 1));
-  EXPECT_EQ(19905, daysSinceEpoch(2024, 7, 1, 1));
+  EXPECT_EQ(10952, daysSinceEpochLenient(2000, 1, 1, 1));
+  EXPECT_EQ(19905, daysSinceEpochLenient(2024, 7, 1, 1));
 
   // Before unix epoch.
-  EXPECT_EQ(-3, daysSinceEpoch(1970, 1, 1, 1));
-  EXPECT_EQ(-2, daysSinceEpoch(1970, 1, 1, 2));
-  EXPECT_EQ(-31, daysSinceEpoch(1969, 12, 1, 1));
-  EXPECT_EQ(-367, daysSinceEpoch(1969, 1, 1, 1));
-  EXPECT_EQ(-724, daysSinceEpoch(1968, 1, 2, 1));
-  EXPECT_EQ(-719533, daysSinceEpoch(0, 1, 1, 1));
+  EXPECT_EQ(-3, daysSinceEpochLenient(1970, 1, 1, 1));
+  EXPECT_EQ(-2, daysSinceEpochLenient(1970, 1, 1, 2));
+  EXPECT_EQ(-31, daysSinceEpochLenient(1969, 12, 1, 1));
+  EXPECT_EQ(-367, daysSinceEpochLenient(1969, 1, 1, 1));
+  EXPECT_EQ(-724, daysSinceEpochLenient(1968, 1, 2, 1));
+  EXPECT_EQ(-719533, daysSinceEpochLenient(0, 1, 1, 1));
 
   // Negative year - BC.
-  EXPECT_EQ(-719561, daysSinceEpoch(-1, 12, 1, 1));
-  EXPECT_EQ(-719897, daysSinceEpoch(-1, 1, 1, 1));
+  EXPECT_EQ(-719561, daysSinceEpochLenient(-1, 12, 1, 1));
+  EXPECT_EQ(-719897, daysSinceEpochLenient(-1, 1, 1, 1));
 
   // Day in the previous month.
-  EXPECT_EQ(19783, daysSinceEpoch(2024, 2, 5, 5));
+  EXPECT_EQ(19783, daysSinceEpochLenient(2024, 2, 5, 5));
   // Day in the next month.
-  EXPECT_EQ(19751, daysSinceEpoch(2024, 2, 1, 1));
+  EXPECT_EQ(19751, daysSinceEpochLenient(2024, 2, 1, 1));
 
   // Out of range day of week.
-  EXPECT_EQ(338, daysSinceEpoch(1970, 12, 1, 0));
-  EXPECT_EQ(337, daysSinceEpoch(1970, 12, 1, -1));
-  EXPECT_EQ(337, daysSinceEpoch(1970, 12, 1, -8));
+  EXPECT_EQ(338, daysSinceEpochLenient(1970, 12, 1, 0));
+  EXPECT_EQ(337, daysSinceEpochLenient(1970, 12, 1, -1));
+  EXPECT_EQ(337, daysSinceEpochLenient(1970, 12, 1, -8));
 
-  EXPECT_EQ(332, daysSinceEpoch(1970, 12, 1, 8));
-  EXPECT_EQ(333, daysSinceEpoch(1970, 12, 1, 9));
-  EXPECT_EQ(336, daysSinceEpoch(1970, 12, 1, 19));
+  EXPECT_EQ(332, daysSinceEpochLenient(1970, 12, 1, 8));
+  EXPECT_EQ(333, daysSinceEpochLenient(1970, 12, 1, 9));
+  EXPECT_EQ(336, daysSinceEpochLenient(1970, 12, 1, 19));
 
   // Out of range month.
-  EXPECT_EQ(-3, daysSinceEpoch(1970, 1, 1, 1));
-  EXPECT_EQ(207, daysSinceEpoch(1970, 8, 1, 1));
-  EXPECT_EQ(361, daysSinceEpoch(1970, 13, 1, 1));
+  EXPECT_EQ(-3, daysSinceEpochLenient(1970, 1, 1, 1));
+  EXPECT_EQ(207, daysSinceEpochLenient(1970, 8, 1, 1));
+  EXPECT_EQ(361, daysSinceEpochLenient(1970, 13, 1, 1));
 
-  EXPECT_EQ(-31, daysSinceEpoch(1970, 0, 1, 1));
-  EXPECT_EQ(-66, daysSinceEpoch(1970, -1, 1, 1));
-  EXPECT_EQ(-430, daysSinceEpoch(1970, -13, 1, 1));
+  EXPECT_EQ(-31, daysSinceEpochLenient(1970, 0, 1, 1));
+  EXPECT_EQ(-66, daysSinceEpochLenient(1970, -1, 1, 1));
+  EXPECT_EQ(-430, daysSinceEpochLenient(1970, -13, 1, 1));
 }
 
 TEST(DateTimeUtilTest, fromWeekOfMonthDateInvalid) {
-  auto daysSinceEpoch = [](int32_t year,
+  auto daysSinceEpochNonLenient = [](int32_t year,
                            int32_t month,
                            int32_t weekOfMonth,
                            int32_t dayOfWeek,
@@ -167,19 +167,18 @@ TEST(DateTimeUtilTest, fromWeekOfMonthDateInvalid) {
     EXPECT_EQ(result.error().message(), error);
   };
 
-  EXPECT_NO_THROW(daysSinceEpoch(-1, 1, 1, 1, "Date out of range: -1-1-1-1"));
   EXPECT_NO_THROW(
-      daysSinceEpoch(292278995, 1, 1, 1, "Date out of range: 292278995-1-1-1"));
+      daysSinceEpochNonLenient(-1, 1, 1, 1, "Date out of range: -1-1-1-1"));
+  EXPECT_NO_THROW(daysSinceEpochNonLenient(292278995, 1, 1, 1, "Date out of range: 292278995-1-1-1"));
   EXPECT_NO_THROW(
-      daysSinceEpoch(2024, 0, 1, 1, "Date out of range: 2024-0-1-1"));
+      daysSinceEpochNonLenient(2024, 0, 1, 1, "Date out of range: 2024-0-1-1"));
+  EXPECT_NO_THROW(daysSinceEpochNonLenient(2024, 13, 1, 1, "Date out of range: 2024-13-1-1"));
   EXPECT_NO_THROW(
-      daysSinceEpoch(2024, 13, 1, 1, "Date out of range: 2024-13-1-1"));
+      daysSinceEpochNonLenient(2024, 1, 6, 1, "Date out of range: 2024-1-6-1"));
   EXPECT_NO_THROW(
-      daysSinceEpoch(2024, 1, 6, 1, "Date out of range: 2024-1-6-1"));
+      daysSinceEpochNonLenient(2024, 2, 1, 1, "Date out of range: 2024-2-1-1"));
   EXPECT_NO_THROW(
-      daysSinceEpoch(2024, 2, 1, 1, "Date out of range: 2024-2-1-1"));
-  EXPECT_NO_THROW(
-      daysSinceEpoch(2024, 2, 5, 5, "Date out of range: 2024-2-5-5"));
+      daysSinceEpochNonLenient(2024, 2, 5, 5, "Date out of range: 2024-2-5-5"));
 }
 
 TEST(DateTimeUtilTest, fromDateString) {

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -112,6 +112,7 @@ TEST(DateTimeUtilTest, fromWeekOfMonthDate) {
         EXPECT_TRUE(!result.hasError());
         return result.value();
       };
+
   EXPECT_EQ(4, daysSinceEpochLenient(1970, 1, 2, 1));
   EXPECT_EQ(361, daysSinceEpochLenient(1971, 1, 1, 1));
   EXPECT_EQ(396, daysSinceEpochLenient(1971, 2, 1, 1));
@@ -153,6 +154,11 @@ TEST(DateTimeUtilTest, fromWeekOfMonthDate) {
   EXPECT_EQ(-31, daysSinceEpochLenient(1970, 0, 1, 1));
   EXPECT_EQ(-66, daysSinceEpochLenient(1970, -1, 1, 1));
   EXPECT_EQ(-430, daysSinceEpochLenient(1970, -13, 1, 1));
+
+  // Out of range year.
+  auto result = util::daysSinceEpochFromWeekOfMonthDate(
+      292278995, 1, 1, 1, true);
+  EXPECT_EQ(result.error().message(), "Date out of range: 292278995-1-1");
 }
 
 TEST(DateTimeUtilTest, fromWeekOfMonthDateInvalid) {

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -162,7 +162,12 @@ TEST(DateTimeUtilTest, fromWeekOfMonthDate) {
 }
 
 TEST(DateTimeUtilTest, extractISODayOfTheWeek) {
-  EXPECT_EQ(4, util::extractISODayOfTheWeek(std::numeric_limits<int64_t>::max()));
+  EXPECT_EQ(
+      4, util::extractISODayOfTheWeek(std::numeric_limits<int64_t>::max()));
+  EXPECT_EQ(
+      3, util::extractISODayOfTheWeek(std::numeric_limits<int64_t>::min()));
+  EXPECT_EQ(1, util::extractISODayOfTheWeek(-10));
+  EXPECT_EQ(7, util::extractISODayOfTheWeek(10));
 }
 
 TEST(DateTimeUtilTest, fromWeekOfMonthDateInvalid) {

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -172,25 +172,22 @@ TEST(DateTimeUtilTest, extractISODayOfTheWeek) {
 
 TEST(DateTimeUtilTest, daysSinceEpochFromWeekOfMonthDateNonLenient) {
   auto daysSinceEpoch = [](int32_t year,
-                                     int32_t month,
-                                     int32_t weekOfMonth,
-                                     int32_t dayOfWeek,
-                                     const std::string& error) {
+                           int32_t month,
+                           int32_t weekOfMonth,
+                           int32_t dayOfWeek,
+                           const std::string& error) {
     auto result = util::daysSinceEpochFromWeekOfMonthDate(
         year, month, weekOfMonth, dayOfWeek, false);
     EXPECT_TRUE(result.error().isUserError());
     EXPECT_EQ(result.error().message(), error);
   };
 
-  EXPECT_NO_THROW(daysSinceEpoch(-1, 1, 1, 1, "Date out of range: -1-1-1-1"));
   EXPECT_NO_THROW(
-      daysSinceEpoch(
-      292278995, 1, 1, 1, "Date out of range: 292278995-1-1-1"));
+      daysSinceEpoch(292278995, 1, 1, 1, "Date out of range: 292278995-1-1-1"));
   EXPECT_NO_THROW(
       daysSinceEpoch(2024, 0, 1, 1, "Date out of range: 2024-0-1-1"));
   EXPECT_NO_THROW(
-      daysSinceEpoch(
-      2024, 13, 1, 1, "Date out of range: 2024-13-1-1"));
+      daysSinceEpoch(2024, 13, 1, 1, "Date out of range: 2024-13-1-1"));
   EXPECT_NO_THROW(
       daysSinceEpoch(2024, 1, 6, 1, "Date out of range: 2024-1-6-1"));
   EXPECT_NO_THROW(

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -104,8 +104,8 @@ TEST(DateTimeUtilTest, fromDateInvalid) {
       1970, 6, 31, "Date out of range: 1970-6-31"));
 }
 
-TEST(DateTimeUtilTest, fromWeekOfMonthDate) {
-  auto daysSinceEpochLenient =
+TEST(DateTimeUtilTest, daysSinceEpochFromWeekOfMonthDateLenient) {
+  auto daysSinceEpoch =
       [](int32_t year, int32_t month, int32_t weekOfMonth, int32_t dayOfWeek) {
         auto result = util::daysSinceEpochFromWeekOfMonthDate(
             year, month, weekOfMonth, dayOfWeek, true);
@@ -113,47 +113,47 @@ TEST(DateTimeUtilTest, fromWeekOfMonthDate) {
         return result.value();
       };
 
-  EXPECT_EQ(4, daysSinceEpochLenient(1970, 1, 2, 1));
-  EXPECT_EQ(361, daysSinceEpochLenient(1971, 1, 1, 1));
-  EXPECT_EQ(396, daysSinceEpochLenient(1971, 2, 1, 1));
+  EXPECT_EQ(4, daysSinceEpoch(1970, 1, 2, 1));
+  EXPECT_EQ(361, daysSinceEpoch(1971, 1, 1, 1));
+  EXPECT_EQ(396, daysSinceEpoch(1971, 2, 1, 1));
 
-  EXPECT_EQ(10952, daysSinceEpochLenient(2000, 1, 1, 1));
-  EXPECT_EQ(19905, daysSinceEpochLenient(2024, 7, 1, 1));
+  EXPECT_EQ(10952, daysSinceEpoch(2000, 1, 1, 1));
+  EXPECT_EQ(19905, daysSinceEpoch(2024, 7, 1, 1));
 
   // Before unix epoch.
-  EXPECT_EQ(-3, daysSinceEpochLenient(1970, 1, 1, 1));
-  EXPECT_EQ(-2, daysSinceEpochLenient(1970, 1, 1, 2));
-  EXPECT_EQ(-31, daysSinceEpochLenient(1969, 12, 1, 1));
-  EXPECT_EQ(-367, daysSinceEpochLenient(1969, 1, 1, 1));
-  EXPECT_EQ(-724, daysSinceEpochLenient(1968, 1, 2, 1));
-  EXPECT_EQ(-719533, daysSinceEpochLenient(0, 1, 1, 1));
+  EXPECT_EQ(-3, daysSinceEpoch(1970, 1, 1, 1));
+  EXPECT_EQ(-2, daysSinceEpoch(1970, 1, 1, 2));
+  EXPECT_EQ(-31, daysSinceEpoch(1969, 12, 1, 1));
+  EXPECT_EQ(-367, daysSinceEpoch(1969, 1, 1, 1));
+  EXPECT_EQ(-724, daysSinceEpoch(1968, 1, 2, 1));
+  EXPECT_EQ(-719533, daysSinceEpoch(0, 1, 1, 1));
 
   // Negative year - BC.
-  EXPECT_EQ(-719561, daysSinceEpochLenient(-1, 12, 1, 1));
-  EXPECT_EQ(-719897, daysSinceEpochLenient(-1, 1, 1, 1));
+  EXPECT_EQ(-719561, daysSinceEpoch(-1, 12, 1, 1));
+  EXPECT_EQ(-719897, daysSinceEpoch(-1, 1, 1, 1));
 
   // Day in the previous month.
-  EXPECT_EQ(19783, daysSinceEpochLenient(2024, 2, 5, 5));
+  EXPECT_EQ(19783, daysSinceEpoch(2024, 2, 5, 5));
   // Day in the next month.
-  EXPECT_EQ(19751, daysSinceEpochLenient(2024, 2, 1, 1));
+  EXPECT_EQ(19751, daysSinceEpoch(2024, 2, 1, 1));
 
   // Out of range day of week.
-  EXPECT_EQ(338, daysSinceEpochLenient(1970, 12, 1, 0));
-  EXPECT_EQ(337, daysSinceEpochLenient(1970, 12, 1, -1));
-  EXPECT_EQ(337, daysSinceEpochLenient(1970, 12, 1, -8));
+  EXPECT_EQ(338, daysSinceEpoch(1970, 12, 1, 0));
+  EXPECT_EQ(337, daysSinceEpoch(1970, 12, 1, -1));
+  EXPECT_EQ(337, daysSinceEpoch(1970, 12, 1, -8));
 
-  EXPECT_EQ(332, daysSinceEpochLenient(1970, 12, 1, 8));
-  EXPECT_EQ(333, daysSinceEpochLenient(1970, 12, 1, 9));
-  EXPECT_EQ(336, daysSinceEpochLenient(1970, 12, 1, 19));
+  EXPECT_EQ(332, daysSinceEpoch(1970, 12, 1, 8));
+  EXPECT_EQ(333, daysSinceEpoch(1970, 12, 1, 9));
+  EXPECT_EQ(336, daysSinceEpoch(1970, 12, 1, 19));
 
   // Out of range month.
-  EXPECT_EQ(-3, daysSinceEpochLenient(1970, 1, 1, 1));
-  EXPECT_EQ(207, daysSinceEpochLenient(1970, 8, 1, 1));
-  EXPECT_EQ(361, daysSinceEpochLenient(1970, 13, 1, 1));
+  EXPECT_EQ(-3, daysSinceEpoch(1970, 1, 1, 1));
+  EXPECT_EQ(207, daysSinceEpoch(1970, 8, 1, 1));
+  EXPECT_EQ(361, daysSinceEpoch(1970, 13, 1, 1));
 
-  EXPECT_EQ(-31, daysSinceEpochLenient(1970, 0, 1, 1));
-  EXPECT_EQ(-66, daysSinceEpochLenient(1970, -1, 1, 1));
-  EXPECT_EQ(-430, daysSinceEpochLenient(1970, -13, 1, 1));
+  EXPECT_EQ(-31, daysSinceEpoch(1970, 0, 1, 1));
+  EXPECT_EQ(-66, daysSinceEpoch(1970, -1, 1, 1));
+  EXPECT_EQ(-430, daysSinceEpoch(1970, -13, 1, 1));
 
   // Out of range year.
   auto result =
@@ -170,8 +170,8 @@ TEST(DateTimeUtilTest, extractISODayOfTheWeek) {
   EXPECT_EQ(7, util::extractISODayOfTheWeek(10));
 }
 
-TEST(DateTimeUtilTest, fromWeekOfMonthDateInvalid) {
-  auto daysSinceEpochNonLenient = [](int32_t year,
+TEST(DateTimeUtilTest, daysSinceEpochFromWeekOfMonthDateNonLenient) {
+  auto daysSinceEpoch = [](int32_t year,
                                      int32_t month,
                                      int32_t weekOfMonth,
                                      int32_t dayOfWeek,
@@ -182,20 +182,22 @@ TEST(DateTimeUtilTest, fromWeekOfMonthDateInvalid) {
     EXPECT_EQ(result.error().message(), error);
   };
 
+  EXPECT_NO_THROW(daysSinceEpoch(-1, 1, 1, 1, "Date out of range: -1-1-1-1"));
   EXPECT_NO_THROW(
-      daysSinceEpochNonLenient(-1, 1, 1, 1, "Date out of range: -1-1-1-1"));
-  EXPECT_NO_THROW(daysSinceEpochNonLenient(
+      daysSinceEpoch(
       292278995, 1, 1, 1, "Date out of range: 292278995-1-1-1"));
   EXPECT_NO_THROW(
-      daysSinceEpochNonLenient(2024, 0, 1, 1, "Date out of range: 2024-0-1-1"));
-  EXPECT_NO_THROW(daysSinceEpochNonLenient(
+      daysSinceEpoch(2024, 0, 1, 1, "Date out of range: 2024-0-1-1"));
+  EXPECT_NO_THROW(
+      daysSinceEpoch(
       2024, 13, 1, 1, "Date out of range: 2024-13-1-1"));
   EXPECT_NO_THROW(
-      daysSinceEpochNonLenient(2024, 1, 6, 1, "Date out of range: 2024-1-6-1"));
+      daysSinceEpoch(2024, 1, 6, 1, "Date out of range: 2024-1-6-1"));
   EXPECT_NO_THROW(
-      daysSinceEpochNonLenient(2024, 2, 1, 1, "Date out of range: 2024-2-1-1"));
+      daysSinceEpoch(2024, 2, 1, 1, "Date out of range: 2024-2-1-1"));
   EXPECT_NO_THROW(
-      daysSinceEpochNonLenient(2024, 2, 5, 5, "Date out of range: 2024-2-5-5"));
+      daysSinceEpoch(2024, 2, 5, 5, "Date out of range: 2024-2-5-5"));
+  EXPECT_EQ(4, daysSinceEpochFromWeekOfMonthDate(1970, 1, 2, 1, false).value());
 }
 
 TEST(DateTimeUtilTest, fromDateString) {

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -172,22 +172,28 @@ TEST(DateTimeUtilTest, extractISODayOfTheWeek) {
 
 TEST(DateTimeUtilTest, daysSinceEpochFromWeekOfMonthDateNonLenient) {
   auto daysSinceEpochReturnError = [](int32_t year,
-                           int32_t month,
-                           int32_t weekOfMonth,
-                           int32_t dayOfWeek,
-                           const std::string& error) {
+                                      int32_t month,
+                                      int32_t weekOfMonth,
+                                      int32_t dayOfWeek,
+                                      const std::string& error) {
     auto result = util::daysSinceEpochFromWeekOfMonthDate(
         year, month, weekOfMonth, dayOfWeek, false);
     EXPECT_TRUE(result.error().isUserError());
     EXPECT_EQ(result.error().message(), error);
   };
 
-  EXPECT_NO_THROW(daysSinceEpochReturnError(292278995, 1, 1, 1, "Date out of range: 292278995-1-1-1"));
-  EXPECT_NO_THROW(daysSinceEpochReturnError(2024, 0, 1, 1, "Date out of range: 2024-0-1-1"));
-  EXPECT_NO_THROW(daysSinceEpochReturnError(2024, 13, 1, 1, "Date out of range: 2024-13-1-1"));
-  EXPECT_NO_THROW(daysSinceEpochReturnError(2024, 1, 6, 1, "Date out of range: 2024-1-6-1"));
-  EXPECT_NO_THROW(daysSinceEpochReturnError(2024, 2, 1, 1, "Date out of range: 2024-2-1-1"));
-  EXPECT_NO_THROW(daysSinceEpochReturnError(2024, 2, 5, 5, "Date out of range: 2024-2-5-5"));
+  EXPECT_NO_THROW(daysSinceEpochReturnError(
+      292278995, 1, 1, 1, "Date out of range: 292278995-1-1-1"));
+  EXPECT_NO_THROW(daysSinceEpochReturnError(
+      2024, 0, 1, 1, "Date out of range: 2024-0-1-1"));
+  EXPECT_NO_THROW(daysSinceEpochReturnError(
+      2024, 13, 1, 1, "Date out of range: 2024-13-1-1"));
+  EXPECT_NO_THROW(daysSinceEpochReturnError(
+      2024, 1, 6, 1, "Date out of range: 2024-1-6-1"));
+  EXPECT_NO_THROW(daysSinceEpochReturnError(
+      2024, 2, 1, 1, "Date out of range: 2024-2-1-1"));
+  EXPECT_NO_THROW(daysSinceEpochReturnError(
+      2024, 2, 5, 5, "Date out of range: 2024-2-5-5"));
 
   auto daysSinceEpochReturnValues =
       [](int32_t year, int32_t month, int32_t weekOfMonth, int32_t dayOfWeek) {

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -108,10 +108,10 @@ TEST(DateTimeUtilTest, fromWeekOfMonthDate) {
   auto testDaysSinceEpochFromWeekOfMonthDate =
       [](int32_t year, int32_t month, int32_t weekOfMonth, int32_t dayOfWeek) {
         int64_t daysSinceEpoch;
-        auto status = util::daysSinceEpochFromWeekOfMonthDate(
-            year, month, weekOfMonth, dayOfWeek, daysSinceEpoch);
-        EXPECT_TRUE(status.ok());
-        return daysSinceEpoch;
+        auto expected = util::daysSinceEpochFromWeekOfMonthDate(
+            year, month, weekOfMonth, dayOfWeek);
+        EXPECT_TRUE(!expected.hasError());
+        return expected.value();
       };
   EXPECT_EQ(4, testDaysSinceEpochFromWeekOfMonthDate(1970, 1, 2, 1));
   EXPECT_EQ(361, testDaysSinceEpochFromWeekOfMonthDate(1971, 1, 1, 1));


### PR DESCRIPTION
This helper function is only used by Spark. To align with Spark's SimpleDateFormat behavior, this function offers two modes: lenient and non-lenient. For non-lenient mode, it returns an error status if the date is invalid. For lenient mode, it accepts a wider range of arguments.

Part of #10511 