### PR TITLE
Add normalization rules for time zone offsets

### DIFF
--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -565,6 +565,8 @@ TEST_F(CastExprTest, stringToTimestamp) {
       "1970-01-01 00:00:00",
       "2000-01-01 12:21:56",
       "1970-01-01 00:00:00-02:00",
+      "1970-01-01 00:00:00 +02",
+      "1970-01-01 00:00:00 -0101",
       std::nullopt,
   };
   std::vector<std::optional<Timestamp>> expected{
@@ -574,6 +576,8 @@ TEST_F(CastExprTest, stringToTimestamp) {
       Timestamp(0, 0),
       Timestamp(946729316, 0),
       Timestamp(7200, 0),
+      Timestamp(-7200, 0),
+      Timestamp(3660, 0),
       std::nullopt,
   };
   testCast<std::string, Timestamp>("timestamp", input, expected);

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -258,6 +258,12 @@ TEST(DateTimeUtilTest, fromTimestampWithTimezoneString) {
   EXPECT_EQ(
       parseTimestampWithTimezone("1970-01-01 00:00:00+13:36"),
       std::make_pair(Timestamp(0, 0), tz::getTimeZoneID("+13:36")));
+  EXPECT_EQ(
+      parseTimestampWithTimezone("1970-01-01 00:00:00 -11"),
+      std::make_pair(Timestamp(0, 0), tz::getTimeZoneID("-11:00")));
+  EXPECT_EQ(
+      parseTimestampWithTimezone("1970-01-01 00:00:00 +0000"),
+      std::make_pair(Timestamp(0, 0), tz::getTimeZoneID("+00:00")));
 
   EXPECT_EQ(
       parseTimestampWithTimezone("1970-01-01 00:00:00Z"),

--- a/velox/type/tz/tests/TimeZoneMapTest.cpp
+++ b/velox/type/tz/tests/TimeZoneMapTest.cpp
@@ -182,9 +182,18 @@ TEST(TimeZoneMapTest, getTimeZoneID) {
   // (+/-)XX:MM format.
   EXPECT_EQ(840, getTimeZoneID("-00:01"));
   EXPECT_EQ(0, getTimeZoneID("+00:00"));
+  EXPECT_EQ(0, getTimeZoneID("-00:00"));
   EXPECT_EQ(454, getTimeZoneID("-06:27"));
   EXPECT_EQ(541, getTimeZoneID("-05:00"));
   EXPECT_EQ(1140, getTimeZoneID("+05:00"));
+
+  // Incomplete time zone offsets.
+  EXPECT_EQ(1140, getTimeZoneID("+05"));
+  EXPECT_EQ(1140, getTimeZoneID("+0500"));
+  EXPECT_EQ(1150, getTimeZoneID("+0510"));
+  EXPECT_EQ(181, getTimeZoneID("-1100"));
+  EXPECT_EQ(181, getTimeZoneID("-11"));
+  EXPECT_EQ(0, getTimeZoneID("+0000"));
 
   EXPECT_EQ(0, getTimeZoneID("etc/GMT+0"));
   EXPECT_EQ(0, getTimeZoneID("etc/GMT-0"));


### PR DESCRIPTION
Summary:
When resolving time zone offsets, minutes or the ':' separator may be
omitted (check inline code comments).

Reviewed By: amitkdutta

Differential Revision: D60432366
