### PR TITLE
Fix max-drivers of `TableWriteNode`

### DIFF
--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -238,7 +238,6 @@ uint32_t maxDrivers(
       if (!connectorInsertHandle->supportsMultiThreading()) {
         return 1;
       } else {
-        
         auto writerCount = tableWrite->hasPartitioningScheme()
             ? queryConfig.taskPartitionedWriterCount()
             : queryConfig.taskWriterCount();

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -238,6 +238,7 @@ uint32_t maxDrivers(
       if (!connectorInsertHandle->supportsMultiThreading()) {
         return 1;
       } else {
+        
         auto writerCount = tableWrite->hasPartitioningScheme()
             ? queryConfig.taskPartitionedWriterCount()
             : queryConfig.taskWriterCount();


### PR DESCRIPTION
TableWriteNode isn't always the last plan node in driver-factory, so don't return directly when writerCount is not 1.