### PR TITLE
Add empty2null Spark function

### DIFF
--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -55,7 +55,7 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 
 .. spark:function:: empty2null(input) -> varchar
 
-    Returns NULL when the ```input``` is empty, otherwise, it returns the ```input``` itself. ::
+    Returns NULL when the ``input`` is empty, otherwise, it returns the ``input`` itself. ::
 
         SELECT empty2null(''); -- NULL
         SELECT empty2null('abc'); -- 'abc'

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -53,6 +53,13 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
         SELECT conv("11abc", 10, 10); -- '11'
         SELECT conv('H016F', 16, 10); -- '0'
 
+.. spark:function:: empty2null(input) -> varchar
+
+    Returns NULL when the ```input``` is empty, otherwise, it returns the ```input``` itself. ::
+
+        SELECT empty2null(''); -- NULL
+        SELECT empty2null('abc'); -- 'abc'
+
 .. spark:function:: endswith(left, right) -> boolean
 
     Returns true if 'left' ends with 'right'. Otherwise, returns false. ::
@@ -60,13 +67,6 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
         SELECT endswith('js SQL', 'SQL'); -- true
         SELECT endswith('js SQL', 'js'); -- false
         SELECT endswith('js SQL', NULL); -- NULL
-
-.. spark:function:: empty2null(input) -> varchar
-
-    Returns null when the input is empty, otherwise, it returns the input itself. ::
-
-        SELECT empty2null(''); -- null
-        SELECT empty2null('abc'); -- 'abc'
 
 .. spark:function:: find_in_set(str, strArray) -> integer
 

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -55,7 +55,7 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 
 .. spark:function:: empty2null(input) -> varchar
 
-    Returns NULL when the ``input`` is empty, otherwise, it returns the ``input`` itself. ::
+    Returns NULL if ``input`` is empty. Otherwise, returns ``input``. ::
 
         SELECT empty2null(''); -- NULL
         SELECT empty2null('abc'); -- 'abc'

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -55,7 +55,8 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 
 .. spark:function:: empty2null(input) -> varchar
 
-    Returns NULL if ``input`` is empty. Otherwise, returns ``input``. ::
+    Returns NULL if ``input`` is empty. Otherwise, returns ``input``.
+    Note: it's an internal Spark function used to converts partition value. ::
 
         SELECT empty2null(''); -- NULL
         SELECT empty2null('abc'); -- 'abc'

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -56,7 +56,8 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 .. spark:function:: empty2null(input) -> varchar
 
     Returns NULL if ``input`` is empty. Otherwise, returns ``input``.
-    Note: it's an internal Spark function used to converts partition value. ::
+    Note: it's an internal Spark function used to convert empty value of a partition column,
+    which is then converted to Hive default partition value ``__HIVE_DEFAULT_PARTITION__``. ::
 
         SELECT empty2null(''); -- NULL
         SELECT empty2null('abc'); -- 'abc'

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -61,6 +61,13 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
         SELECT endswith('js SQL', 'js'); -- false
         SELECT endswith('js SQL', NULL); -- NULL
 
+.. spark:function:: empty2null(input) -> varchar
+
+    Returns null when the input is empty, otherwise, it returns the input itself. ::
+
+        SELECT empty2null(''); -- null
+        SELECT empty2null('abc'); -- 'abc'
+
 .. spark:function:: find_in_set(str, strArray) -> integer
 
     Returns 1-based index of the given string ``str`` in the comma-delimited list ``strArray``.

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -242,7 +242,8 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<Sha2HexStringFunction, Varchar, Varbinary, int32_t>(
       {prefix + "sha2"});
   registerFunction<CRC32Function, int64_t, Varbinary>({prefix + "crc32"});
-  registerFunction<Empty2NullFunction, Varchar, Varchar>({prefix + "empty2null"});
+  registerFunction<Empty2NullFunction, Varchar, Varchar>(
+      {prefix + "empty2null"});
 
   exec::registerStatefulVectorFunction(
       prefix + "regexp_extract", re2ExtractSignatures(), makeRegexExtract);

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -242,6 +242,7 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<Sha2HexStringFunction, Varchar, Varbinary, int32_t>(
       {prefix + "sha2"});
   registerFunction<CRC32Function, int64_t, Varbinary>({prefix + "crc32"});
+  registerFunction<Empty2NullFunction, Varchar, Varchar>({prefix + "empty2null"});
 
   exec::registerStatefulVectorFunction(
       prefix + "regexp_extract", re2ExtractSignatures(), makeRegexExtract);

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -1431,6 +1431,10 @@ struct LevenshteinDistanceFunction {
   }
 };
 
+/// empty2null(input) -> varchar
+///
+///    Returns null when the input is empty,
+///    otherwise, it returns the input itself.
 template <typename T>
 struct Empty2NullFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
@@ -1438,22 +1442,7 @@ struct Empty2NullFunction {
   // Results refer to strings in the first argument.
   static constexpr int32_t reuse_strings_from_arg = 0;
 
-  static constexpr bool is_default_ascii_behavior = true;
-
   FOLLY_ALWAYS_INLINE bool call(
-      out_type<Varchar>& result,
-      const arg_type<Varchar>& input) {
-    return doCall(result, input);
-  }
-
-  FOLLY_ALWAYS_INLINE bool callAscii(
-      out_type<Varchar>& result,
-      const arg_type<Varchar>& input) {
-    return doCall(result, input);
-  }
-
- private:
-  FOLLY_ALWAYS_INLINE bool doCall(
       out_type<Varchar>& result,
       const arg_type<Varchar>& input) {
     if (input.empty()) {

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -1431,4 +1431,37 @@ struct LevenshteinDistanceFunction {
   }
 };
 
+template <typename T>
+struct Empty2NullFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // Results refer to strings in the first argument.
+  static constexpr int32_t reuse_strings_from_arg = 0;
+
+  static constexpr bool is_default_ascii_behavior = true;
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& input) {
+    return doCall(result, input);
+  }
+
+  FOLLY_ALWAYS_INLINE bool callAscii(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& input) {
+    return doCall(result, input);
+  }
+
+ private:
+  FOLLY_ALWAYS_INLINE bool doCall(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& input) {
+    if (input.empty()) {
+      return false;
+    }
+    result.setNoCopy(input);
+    return true;
+  }
+};
+
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -1433,7 +1433,7 @@ struct LevenshteinDistanceFunction {
 
 /// empty2null(input) -> varchar
 ///
-///    Returns null when the input is empty,
+///    Returns NULL when the input is empty,
 ///    otherwise, it returns the input itself.
 template <typename T>
 struct Empty2NullFunction {

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -996,7 +996,6 @@ TEST_F(StringTest, trim) {
       "\u6574\u6570 \u6570\u636E!");
 }
 
-
 TEST_F(StringTest, empty2Null) {
   const auto empty2Null = [&](const std::optional<std::string>& a) {
     return evaluateOnce<std::string>("empty2null(c0)", a);

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -995,5 +995,15 @@ TEST_F(StringTest, trim) {
       trimWithTrimStr("\u6570", "\u6574\u6570 \u6570\u636E!"),
       "\u6574\u6570 \u6570\u636E!");
 }
+
+
+TEST_F(StringTest, empty2Null) {
+  const auto empty2Null = [&](const std::optional<std::string>& a) {
+    return evaluateOnce<std::string>("empty2null(c0)", a);
+  };
+
+  EXPECT_EQ(empty2Null(""), std::nullopt);
+  EXPECT_EQ(empty2Null("abc"), "abc");
+}
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
A function converts empty string input to null value.

Spark implementation: https://github.com/apache/spark/blob/34a52ad2ce377dd077c4cf70740ba3ab6c18c739/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala#L3486-L3508