### PR TITLE
optimize saveVector and restoreVector (#10617)

### DIFF
--- a/velox/vector/VectorSaver.cpp
+++ b/velox/vector/VectorSaver.cpp
@@ -242,17 +242,13 @@ void restoreVectorStringViews(
   auto rawValues = strings->asMutable<StringView>();
 
   int64_t offset = reinterpret_cast<int64_t>(stringBuffers->as<char>());
-  // int64_t offset = 0;
   if (nulls) {
     auto* rawNulls = nulls->asMutable<uint64_t>();
     for (auto i = 0; i < size; ++i) {
       auto value = rawValues[i];
       if (!bits::isBitNull(rawNulls, i) && !value.isInline()) {
-        int64_t* i1 =
-            reinterpret_cast<int64_t*>(rawBytes + i * sizeof(StringView) + 8);
-        i1[0] = offset;
-        // rawValues[i] =
-        // StringView(stringBuffers->as<char>() + offset, value.size());
+        reinterpret_cast<int64_t*>(rawBytes + i * sizeof(StringView) + 8)[0] =
+            offset;
         offset += value.size();
       }
     }
@@ -260,11 +256,8 @@ void restoreVectorStringViews(
     for (auto i = 0; i < size; ++i) {
       auto value = rawValues[i];
       if (!value.isInline()) {
-        int64_t* i1 =
-            reinterpret_cast<int64_t*>(rawBytes + i * sizeof(StringView) + 8);
-        i1[0] = offset;
-        // rawValues[i] =
-        // StringView(stringBuffers->as<char>() + offset, value.size());
+        reinterpret_cast<int64_t*>(rawBytes + i * sizeof(StringView) + 8)[0] =
+            offset;
         offset += value.size();
       }
     }

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -97,5 +97,5 @@ target_link_libraries(
   glog::glog
   fmt::fmt)
 if(${VELOX_ENABLE_BENCHMARKS})
-    add_subdirectory(benchmarks)
+  add_subdirectory(benchmarks)
 endif()

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -96,3 +96,6 @@ target_link_libraries(
   gflags::gflags
   glog::glog
   fmt::fmt)
+if(${VELOX_ENABLE_BENCHMARKS})
+    add_subdirectory(benchmarks)
+endif()

--- a/velox/vector/tests/benchmarks/CMakeLists.txt
+++ b/velox/vector/tests/benchmarks/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+add_executable(velox_vector_saver_benchmark
+        VectorSaverBenchmark.cpp)
+
+target_link_libraries(
+        velox_vector_saver_benchmark
+        velox_vector_test_lib ${FOLLY_BENCHMARK})

--- a/velox/vector/tests/benchmarks/CMakeLists.txt
+++ b/velox/vector/tests/benchmarks/CMakeLists.txt
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_executable(velox_vector_saver_benchmark
-        VectorSaverBenchmark.cpp)
+add_executable(velox_vector_saver_benchmark VectorSaverBenchmark.cpp)
 
 target_link_libraries(
-        velox_vector_saver_benchmark
-        velox_vector_test_lib ${FOLLY_BENCHMARK})
+  velox_vector_saver_benchmark velox_vector_test_lib ${FOLLY_BENCHMARK})

--- a/velox/vector/tests/benchmarks/VectorSaverBenchmark.cpp
+++ b/velox/vector/tests/benchmarks/VectorSaverBenchmark.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <functions/sparksql/Register.h>
+#include <gtest/gtest.h>
+#include <type/StringView.h>
+#include <vector/ComplexVector.h>
+#include <vector/FlatVector.h>
+#include <vector/VectorSaver.h>
+#include "velox/buffer/Buffer.h"
+
+#include <iostream>
+
+#include "velox/functions/prestosql/window/WindowFunctionsRegistration.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+
+namespace {
+std::shared_ptr<memory::MemoryPool> pool_;
+class VectorSaverBenchmark {
+ public:
+  VectorPtr generateTestVector(vector_size_t size, bool withNulls) {
+    VectorPtr base = BaseVector::create(VARCHAR(), size, pool_.get());
+    auto flat = std::dynamic_pointer_cast<FlatVector<StringView>>(base);
+    for (int32_t i = 0; i < flat->size(); ++i) {
+      if (withNulls && i % 3 == 0) {
+        flat->setNull(i, true);
+      } else {
+        flat->set(i, testValue(base, i));
+      }
+    }
+    return base;
+  }
+  static StringView testValue(VectorPtr vector, int32_t n) {
+    std::stringstream out;
+    out << n;
+    for (int32_t i = 0; i < n % 20; ++i) {
+      out << " " << i * i;
+    }
+    std::string str = out.str();
+    if (str.size() > 12) {
+      BufferPtr buffer = AlignedBuffer::allocate<char>(str.size(), pool_.get());
+      std::dynamic_pointer_cast<FlatVector<StringView>>(vector)
+          ->addStringBuffer(buffer);
+      EXPECT_LE(str.size(), buffer->capacity());
+      memcpy(buffer->asMutable<char>(), str.data(), str.size());
+      return StringView(buffer->as<char>(), str.size());
+    }
+    return StringView(str.data(), str.size());
+  }
+
+  std::string runSaveVector(const VectorPtr& vector) {
+    std::ostringstream out;
+    saveVector(*vector, out);
+    return out.str();
+  }
+
+  void runRestoreVector(const std::string& data) {
+    std::istringstream dataStream(data);
+    restoreVector(dataStream, pool_.get());
+  }
+};
+
+VectorPtr data10k;
+VectorPtr data100k;
+VectorPtr data1000k;
+
+std::string data10kString;
+std::string data100kString;
+std::string data1000kString;
+
+std::shared_ptr<VectorSaverBenchmark> cb;
+
+BENCHMARK(save_vector_10k) {
+  cb->runSaveVector(data10k);
+}
+
+BENCHMARK(save_vector_100k) {
+  cb->runSaveVector(data100k);
+}
+BENCHMARK(save_vector_1000k) {
+  cb->runSaveVector(data1000k);
+}
+
+BENCHMARK(restore_vector_10k) {
+  cb->runRestoreVector(data10kString);
+}
+BENCHMARK(restore_vector_100k) {
+  cb->runRestoreVector(data100kString);
+}
+
+BENCHMARK(restore_vector_10000k) {
+  cb->runRestoreVector(data1000kString);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  memory::MemoryManager::initialize({});
+  pool_ = {memory::memoryManager()->addLeafPool()};
+  cb = std::make_shared<VectorSaverBenchmark>();
+  data10k = cb->generateTestVector(10 * 1000, true);
+  data100k = cb->generateTestVector(100 * 1000, true);
+  data1000k = cb->generateTestVector(1000 * 1000, true);
+  data10kString = cb->runSaveVector(data10k);
+  data100kString = cb->runSaveVector(data100k);
+  data1000kString = cb->runSaveVector(data1000k);
+  folly::runBenchmarks();
+  data10k.reset();
+  data100k.reset();
+  data1000k.reset();
+  return 0;
+}


### PR DESCRIPTION
rewrite 
 writeStringViews and restoreVectorStringViews 


before the 1000k can't run:


[...]s/benchmarks/VectorSaverBenchmark.cpp     relative  time/iter   iters/s
save_vector_10k                                            58.76ms     17.02
save_vector_100k                                             7.96s   125.67m
restore_vector_10k                                         22.15ms     45.15
restore_vector_100k                                          4.60s   217.40m


`
after:



[...]s/benchmarks/VectorSaverBenchmark.cpp     relative  time/iter   iters/s
save_vector_10k                                           170.42us     5.87K
save_vector_100k                                            2.51ms    399.06
save_vector_1000k                                          39.88ms     25.08
restore_vector_10k                                         25.00us    40.00K
restore_vector_100k                                       274.83us     3.64K
restore_vector_10000k                                       4.98ms    200.79
`