### PR TITLE
Refactor WindowFuzzer: Replace Order-Dependent Flag with Custom Function Handling

### DIFF
--- a/velox/exec/fuzzer/WindowFuzzer.cpp
+++ b/velox/exec/fuzzer/WindowFuzzer.cpp
@@ -215,8 +215,6 @@ void WindowFuzzer::go() {
     if (customVerification) {
       customVerifier = customVerificationFunctions_.at(signature.name);
     }
-    const bool requireSortedInput =
-        orderDependentFunctions_.count(signature.name) != 0;
 
     std::vector<TypePtr> argTypes = signature.args;
     std::vector<std::string> argNames = makeNames(argTypes.size());
@@ -238,7 +236,7 @@ void WindowFuzzer::go() {
         argNames, argTypes, partitionKeys, signature);
     // If the function is order-dependent or uses "rows" frame, sort all input
     // rows by row_number additionally.
-    if (requireSortedInput || isRowsFrame) {
+    if (customfunction(signature.name) || isRowsFrame) {
       sortingKeysAndOrders.emplace_back("row_number", core::kAscNullsLast);
       ++stats_.numSortedInputs;
     }
@@ -490,6 +488,10 @@ void WindowFuzzer::Stats::print(size_t numIterations) const {
   AggregationFuzzerBase::Stats::print(numIterations);
   LOG(INFO) << "Total functions verified in reference DB: "
             << verifiedFunctionNames.size();
+}
+
+bool WindowFuzzer::customfunction(std::string signatureName) {
+  return orderDependentFunctions_.count(signatureName);
 }
 
 } // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/WindowFuzzer.h
+++ b/velox/exec/fuzzer/WindowFuzzer.h
@@ -124,6 +124,7 @@ class WindowFuzzer : public AggregationFuzzerBase {
 
     void print(size_t numIterations) const;
   } stats_;
+  bool customfunction(std::string signatureName);
 };
 
 /// Runs the window fuzzer.


### PR DESCRIPTION
This PR removes the Order-Dependent Flag and introduces Custom Function Handling.

Eliminated the orderDependentFunctions_ set, which was previously used to identify if a function needed sorted input.
Added a new method customfunction to determine whether a function requires special handling or custom verification.
Revised the logic for generating frame clauses and sorting keys to accommodate the removal of the order-dependent flag.



