### PR TITLE
Add row size estimation support for selective ARRAY and MAP column readers

### DIFF
--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -477,11 +477,15 @@ class SelectiveColumnReader {
   template <typename T>
   void filterNulls(RowSet rows, bool isNull, bool extractValues);
 
-  // Temporary method for estimate in-memory row size (number of bits) of this
-  // column for Nimble.  Will be removed once column statistics are added for
-  // Nimble.
-  virtual std::optional<size_t> estimatedRowBitSize() const {
-    return std::nullopt;
+  // Temporary method for estimate total in-memory byte size and row count of
+  // current encoding chunk on this column for Nimble.  Will be removed once
+  // column statistics are added for Nimble.  Note that the estimations are
+  // based on current encoding chunk, so in multi-chunk stripe this is not
+  // accurate.  Other formats should not use this.
+  virtual bool estimateMaterializedSize(
+      size_t& /*byteSize*/,
+      size_t& /*rowCount*/) const {
+    return false;
   }
 
   StringView copyStringValueIfNeed(folly::StringPiece value) {


### PR DESCRIPTION
Summary:
To do estimation on repeated types, we need the method to return not
just the byte size but also the row count of inner data, so that we can get
estimation on the average size of elements in one array or map.

Differential Revision: D60477335
