### PR TITLE
Fix flaky spill test

### DIFF
--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -291,7 +291,9 @@ class SpillTest : public ::testing::TestWithParam<common::CompressionKind>,
     ASSERT_EQ(stats.spilledFiles, expectedNumSpilledFiles);
     ASSERT_GT(stats.spilledBytes, 0);
     ASSERT_GT(stats.spillWrites, 0);
-    ASSERT_GT(stats.spillWriteTimeUs, 0);
+    // NOTE: On fast machines we might have sub-microsecond in each write,
+    // resulting in 0us total write time.
+    ASSERT_GE(stats.spillWriteTimeUs, 0);
     ASSERT_GE(stats.spillFlushTimeUs, 0);
     ASSERT_GT(stats.spilledRows, 0);
     // NOTE: the following stats are not collected by spill state.


### PR DESCRIPTION
Fast machines might be able to make each write in sub-microsecond, recorded as 0us in each stats addition. This may result in the total write time to be 0us. Loose the condition to make the test non-flaky.