### PR TITLE
Remove old time zone ID based API from Timestamp

### DIFF
--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -54,8 +54,8 @@ Expected<Timestamp> PrestoCastHooks::castStringToTimestamp(
   // If the parsed string has timezone information, convert the timestamp at
   // GMT at that time. For example, "1970-01-01 00:00:00 -00:01" is 60 seconds
   // at GMT.
-  if (result.second != -1) {
-    result.first.toGMT(result.second);
+  if (result.second != nullptr) {
+    result.first.toGMT(*result.second);
 
   }
   // If no timezone information is available in the input string, check if we

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -4461,14 +4461,14 @@ TEST_F(DateTimeFunctionsTest, toISO8601Timestamp) {
 
 TEST_F(DateTimeFunctionsTest, toISO8601TimestampWithTimezone) {
   const auto toIso = [&](const char* timestamp, const char* timezone) {
-    const auto tzId = tz::getTimeZoneID(timezone);
+    const auto* timeZone = tz::locateZone(timezone);
     auto ts = parseTimestamp(timestamp);
-    ts.toGMT(tzId);
+    ts.toGMT(*timeZone);
 
     return evaluateOnce<std::string>(
         "to_iso8601(c0)",
         TIMESTAMP_WITH_TIME_ZONE(),
-        std::make_optional(pack(ts.toMillis(), tzId)));
+        std::make_optional(pack(ts.toMillis(), timeZone->id())));
   };
 
   EXPECT_EQ(

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -345,9 +345,6 @@ struct Timestamp {
   //  ts.toString(); // returns January 1, 1970 08:00:00
   void toGMT(const tz::TimeZone& zone);
 
-  // Same as above, but accepts PrestoDB time zone ID.
-  void toGMT(int16_t tzID);
-
   /// Assuming the timestamp represents a GMT time, converts it to the time at
   /// the same moment at zone. For example:
   ///
@@ -355,9 +352,6 @@ struct Timestamp {
   ///  ts.Timezone("America/Los_Angeles");
   ///  ts.toString(); // returns December 31, 1969 16:00:00
   void toTimezone(const tz::TimeZone& zone);
-
-  // Same as above, but accepts PrestoDB time zone ID.
-  void toTimezone(int16_t tzID);
 
   /// A default time zone that is same across the process.
   static const tz::TimeZone& defaultTimezone();

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -20,6 +20,10 @@
 #include "velox/common/base/Status.h"
 #include "velox/type/Timestamp.h"
 
+namespace facebook::velox::tz {
+class TimeZone;
+}
+
 namespace facebook::velox::util {
 
 constexpr const int32_t kHoursPerDay{24};
@@ -195,22 +199,24 @@ inline Expected<Timestamp> fromTimestampString(
 ///
 /// This is a timezone-aware version of the function above
 /// `fromTimestampString()` which returns both the parsed timestamp and the
-/// timezone ID. It is up to the client to do the expected conversion based on
-/// these two values.
+/// TimeZone pointer. It is up to the client to do the expected conversion based
+/// on these two values.
 ///
 /// The timezone information at the end of the string may contain a timezone
 /// name (as defined in velox/type/tz/*), such as "UTC" or
 /// "America/Los_Angeles", or a timezone offset, like "+06:00" or "-09:30". The
 /// white space between the hour definition and timestamp is optional.
 ///
-/// -1 means no timezone information was found. Returns Unexpected with
+/// `nullptr` means no timezone information was found. Returns Unexpected with
 /// UserError status in case of parsing errors.
-Expected<std::pair<Timestamp, int16_t>> fromTimestampWithTimezoneString(
+Expected<std::pair<Timestamp, const tz::TimeZone*>>
+fromTimestampWithTimezoneString(
     const char* buf,
     size_t len,
     TimestampParseMode parseMode);
 
-inline Expected<std::pair<Timestamp, int16_t>> fromTimestampWithTimezoneString(
+inline Expected<std::pair<Timestamp, const tz::TimeZone*>>
+fromTimestampWithTimezoneString(
     const StringView& str,
     TimestampParseMode parseMode) {
   return fromTimestampWithTimezoneString(str.data(), str.size(), parseMode);

--- a/velox/type/tz/TimeZoneMap.h
+++ b/velox/type/tz/TimeZoneMap.h
@@ -39,11 +39,17 @@ namespace facebook::velox::tz {
 
 class TimeZone;
 
-/// Looks up a TimeZone pointer based on a time zone name. This makes an hash
+/// Returns a TimeZone pointer based on a time zone name. This makes an hash
 /// map access, and will construct the index on the first access. `failOnError`
 /// controls whether to throw or return nullptr in case the time zone was not
 /// found.
 const TimeZone* locateZone(std::string_view timeZone, bool failOnError = true);
+
+/// Returns a TimeZone pointer based on a time zone ID. This makes a simple
+/// vector access, and will construct the index on the first access.
+/// `failOnError` controls whether to throw or return nullptr in case the time
+/// zone ID was not valid.
+const TimeZone* locateZone(int16_t timeZoneID, bool failOnError = true);
 
 /// Returns the timezone name associated with timeZoneID.
 std::string getTimeZoneName(int64_t timeZoneID);


### PR DESCRIPTION
Summary:
With the recent refactor, all conversions can now be done through the
TimeZone pointer, so there is not need to do multiple hops of conversion from
ID to name, from name to time zone object. Removing the legacy APIs and
cleaning up callsites.

Differential Revision: D60477527
