### PR TITLE
Distinguish null constant and non-null constant in simple function's initialize method

### DIFF
--- a/velox/core/SimpleFunctionMetadata.h
+++ b/velox/core/SimpleFunctionMetadata.h
@@ -836,7 +836,7 @@ class UDFHolder {
       void,
       const std::vector<TypePtr>&,
       const core::QueryConfig&,
-      const exec_arg_type<TArgs>*...>::value;
+      const ConstantArg<exec_arg_type<TArgs>*...>::value>*;
 
   // TODO Remove
   static constexpr bool udf_has_legacy_initialize = util::has_method<

--- a/velox/core/SimpleFunctionMetadata.h
+++ b/velox/core/SimpleFunctionMetadata.h
@@ -836,7 +836,7 @@ class UDFHolder {
       void,
       const std::vector<TypePtr>&,
       const core::QueryConfig&,
-      const ConstantArg<exec_arg_type<TArgs>*...>::value>*;
+      const exec_arg_type<TArgs>*...>::value;
 
   // TODO Remove
   static constexpr bool udf_has_legacy_initialize = util::has_method<

--- a/velox/core/SimpleFunctionMetadata.h
+++ b/velox/core/SimpleFunctionMetadata.h
@@ -24,6 +24,7 @@
 #include "velox/core/CoreTypeSystem.h"
 #include "velox/core/Metaprogramming.h"
 #include "velox/core/QueryConfig.h"
+#include "velox/expression/ComplexViewTypes.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/expression/SignatureBinder.h"
 #include "velox/type/SimpleFunctionApi.h"
@@ -924,7 +925,7 @@ class UDFHolder {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& inputTypes,
       const core::QueryConfig& config,
-      const typename exec_resolver<TArgs>::in_type*... constantArgs) {
+      const facebook::velox::exec::OptionalAccessor<typename exec_resolver<TArgs>::in_type>*... constantArgs) {
     if constexpr (udf_has_initialize) {
       return instance_.initialize(inputTypes, config, constantArgs...);
     }

--- a/velox/examples/SimpleFunctions.cpp
+++ b/velox/examples/SimpleFunctions.cpp
@@ -334,8 +334,8 @@ struct MyRegexpMatchFunction {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig&,
-      const arg_type<Varchar>*,
-      const arg_type<Varchar>* pattern) {
+      const optional_arg_type<Varchar>*,
+      const optional_arg_type<Varchar>* pattern) {
     // Compile the RE2 object just once if pattern is constant. Functions might
     // choose to throw in case the regexp pattern is not constant, as it can be
     // quite expensive to compile it on a per-row basis. In this example we

--- a/velox/expression/SimpleFunctionAdapter.h
+++ b/velox/expression/SimpleFunctionAdapter.h
@@ -221,7 +221,7 @@ class SimpleFunctionAdapter : public VectorFunction {
       const std::vector<TypePtr>& inputTypes,
       const core::QueryConfig& config,
       const std::vector<VectorPtr>& packed,
-      const Values*... values) const {
+      const ConstantArg<Values>*... values) const {
     if constexpr (POSITION == FUNC::num_args) {
       return (*fn_).initialize(inputTypes, config, values...);
     } else {
@@ -229,14 +229,25 @@ class SimpleFunctionAdapter : public VectorFunction {
         SelectivityVector rows(1);
         DecodedVector decodedVector(*packed.at(POSITION), rows);
         auto oneReader = VectorReader<arg_at<POSITION>>(&decodedVector);
-        auto oneValue = oneReader[0];
-
-        unpackInitialize<POSITION + 1>(
-            inputTypes, config, packed, values..., &oneValue);
+        if (oneReader.containsNull(0)) {
+          unpackInitialize<POSITION + 1>(
+              inputTypes, config, packed, values..., &ConstantArg());
+        } else {
+          unpackInitialize<POSITION + 1>(
+              inputTypes,
+              config,
+              packed,
+              values...,
+              &ConstantArg(oneReader[0]));
+        }
       } else {
         using temp_type = exec_arg_at<POSITION>;
         unpackInitialize<POSITION + 1>(
-            inputTypes, config, packed, values..., (const temp_type*)nullptr);
+            inputTypes,
+            config,
+            packed,
+            values...,
+            (const ConstantArg<temp_type>*)nullptr);
       }
     }
   }

--- a/velox/expression/tests/SimpleFunctionInitTest.cpp
+++ b/velox/expression/tests/SimpleFunctionInitTest.cpp
@@ -39,8 +39,8 @@ struct NonDefaultWithArrayInitFunction {
   void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const arg_type<int32_t>* /*first*/,
-      const arg_type<velox::Array<int32_t>>* second) {
+      const optional_arg_type<int32_t>* /*first*/,
+      const optional_arg_type<velox::Array<int32_t>>* second) {
     if (second == nullptr) {
       return;
     }
@@ -134,8 +134,8 @@ struct NonDefaultWithMapInitFunction {
   void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const arg_type<int32_t>* /*first*/,
-      const arg_type<velox::Map<int32_t, int64_t>>* second) {
+      const optional_arg_type<int32_t>* /*first*/,
+      const optional_arg_type<velox::Map<int32_t, int64_t>>* second) {
     if (second == nullptr) {
       return;
     }
@@ -204,7 +204,7 @@ struct InitAlwaysThrowsFunction {
   void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const arg_type<int32_t>* /*first*/) {
+      const optional_arg_type<int32_t>* /*first*/) {
     VELOX_USER_FAIL("Unconditional throw!");
   }
 

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -1253,12 +1253,12 @@ struct ConstantArgumentFunction {
   void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const arg_type<int32_t>* /*first*/,
-      const arg_type<int32_t>* /*second*/,
-      const arg_type<Varchar>* /*third*/,
-      const arg_type<Generic<T1>>* /*fourth*/,
-      const arg_type<Array<int32_t>>* /*fifth*/,
-      const arg_type<Map<int32_t, int32_t>>* /*sixth*/) {}
+      const optional_arg_type<int32_t>* /*first*/,
+      const optional_arg_type<int32_t>* /*second*/,
+      const optional_arg_type<Varchar>* /*third*/,
+      const optional_arg_type<Generic<T1>>* /*fourth*/,
+      const optional_arg_type<Array<int32_t>>* /*fifth*/,
+      const optional_arg_type<Map<int32_t, int32_t>>* /*sixth*/) {}
 
   bool callNullable(
       out_type<int64_t>& out,
@@ -1301,7 +1301,7 @@ struct DecimalPlusOneFunction {
   void initialize(
       const std::vector<TypePtr>& inputTypes,
       const core::QueryConfig& /*config*/,
-      const A* /*a*/) {
+      const optional_arg_type<A>* /*a*/) {
     scale_ = getDecimalPrecisionScale(*inputTypes[0]).second;
   }
 
@@ -1322,7 +1322,7 @@ struct DecimalPlusTwoFunction {
   void initialize(
       const std::vector<TypePtr>& inputTypes,
       const core::QueryConfig& /*config*/,
-      const A* /*a*/) {
+      const optional_arg_type<A>* /*a*/) {
     scale_ = getDecimalPrecisionScale(*inputTypes[0]).second;
   }
 

--- a/velox/functions/Macros.h
+++ b/velox/functions/Macros.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "velox/core/Metaprogramming.h"
+#include "velox/expression/ComplexViewTypes.h"
 #include "velox/type/SimpleFunctionApi.h"
 #include "velox/type/Type.h"
 
@@ -35,6 +36,10 @@
   template <typename TArgs>                                             \
   using opt_out_type = std::optional<                                   \
       typename __Velox_ExecParams::template resolver<TArgs>::out_type>; \
+                                                                        \
+  template <typename TArgs>                                             \
+  using optional_arg_type = facebook::velox::exec::OptionalAccessor<    \
+      typename __Velox_ExecParams::template resolver<TArgs>::in_type>;  \
                                                                         \
   DECLARE_CONDITIONAL_TYPE_NAME(                                        \
       null_free_in_type_resolver, null_free_in_type, in_type);          \

--- a/velox/functions/lib/Re2Functions.h
+++ b/velox/functions/lib/Re2Functions.h
@@ -300,11 +300,11 @@ struct Re2RegexpReplace {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const ConstantArg<arg_type<Varchar>>* /*string*/,
-      const ConstantArg<arg_type<Varchar>>* pattern,
-      const ConstantArg<arg_type<Varchar>>* replacement) {
+      const arg_type<Varchar>* /*string*/,
+      const arg_type<Varchar>* pattern,
+      const arg_type<Varchar>* replacement) {
     if (pattern != nullptr) {
-      const auto processedPattern = prepareRegexpPattern(*pattern->value());
+      const auto processedPattern = prepareRegexpPattern(*pattern);
       re_.emplace(processedPattern, RE2::Quiet);
       VELOX_USER_CHECK(
           re_->ok(),
@@ -318,7 +318,7 @@ struct Re2RegexpReplace {
       // Constant 'replacement' with non-constant 'pattern' needs to be
       // processed separately for each row.
       if (pattern != nullptr) {
-        ensureProcessedReplacement(re_.value(), *replacement->value());
+        ensureProcessedReplacement(re_.value(), *replacement);
         constantReplacement_ = true;
       }
     }
@@ -327,8 +327,8 @@ struct Re2RegexpReplace {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& inputTypes,
       const core::QueryConfig& config,
-      const ConstantArg<arg_type<Varchar>>* string,
-      const ConstantArg<arg_type<Varchar>>* pattern) {
+      const arg_type<Varchar>* string,
+      const arg_type<Varchar>* pattern) {
     initialize(inputTypes, config, string, pattern, nullptr);
   }
 

--- a/velox/functions/lib/Re2Functions.h
+++ b/velox/functions/lib/Re2Functions.h
@@ -300,11 +300,11 @@ struct Re2RegexpReplace {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Varchar>* /*string*/,
-      const arg_type<Varchar>* pattern,
-      const arg_type<Varchar>* replacement) {
+      const ConstantArg<arg_type<Varchar>>* /*string*/,
+      const ConstantArg<arg_type<Varchar>>* pattern,
+      const ConstantArg<arg_type<Varchar>>* replacement) {
     if (pattern != nullptr) {
-      const auto processedPattern = prepareRegexpPattern(*pattern);
+      const auto processedPattern = prepareRegexpPattern(*pattern->value());
       re_.emplace(processedPattern, RE2::Quiet);
       VELOX_USER_CHECK(
           re_->ok(),
@@ -318,7 +318,7 @@ struct Re2RegexpReplace {
       // Constant 'replacement' with non-constant 'pattern' needs to be
       // processed separately for each row.
       if (pattern != nullptr) {
-        ensureProcessedReplacement(re_.value(), *replacement);
+        ensureProcessedReplacement(re_.value(), *replacement->value());
         constantReplacement_ = true;
       }
     }
@@ -327,8 +327,8 @@ struct Re2RegexpReplace {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& inputTypes,
       const core::QueryConfig& config,
-      const arg_type<Varchar>* string,
-      const arg_type<Varchar>* pattern) {
+      const ConstantArg<arg_type<Varchar>>* string,
+      const ConstantArg<arg_type<Varchar>>* pattern) {
     initialize(inputTypes, config, string, pattern, nullptr);
   }
 

--- a/velox/functions/lib/Re2Functions.h
+++ b/velox/functions/lib/Re2Functions.h
@@ -300,9 +300,9 @@ struct Re2RegexpReplace {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Varchar>* /*string*/,
-      const arg_type<Varchar>* pattern,
-      const arg_type<Varchar>* replacement) {
+      const optional_arg_type<Varchar>* /*string*/,
+      const optional_arg_type<Varchar>* pattern,
+      const optional_arg_type<Varchar>* replacement) {
     if (pattern != nullptr) {
       const auto processedPattern = prepareRegexpPattern(*pattern);
       re_.emplace(processedPattern, RE2::Quiet);
@@ -327,8 +327,8 @@ struct Re2RegexpReplace {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& inputTypes,
       const core::QueryConfig& config,
-      const arg_type<Varchar>* string,
-      const arg_type<Varchar>* pattern) {
+      const optional_arg_type<Varchar>* string,
+      const optional_arg_type<Varchar>* pattern) {
     initialize(inputTypes, config, string, pattern, nullptr);
   }
 

--- a/velox/functions/lib/TimeUtils.h
+++ b/velox/functions/lib/TimeUtils.h
@@ -122,7 +122,7 @@ struct InitSessionTimezone {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Timestamp>* /*timestamp*/) {
+      const optional_arg_type<Timestamp>* /*timestamp*/) {
     timeZone_ = getTimeZoneFromConfig(config);
   }
 };

--- a/velox/functions/lib/TimeUtils.h
+++ b/velox/functions/lib/TimeUtils.h
@@ -122,7 +122,7 @@ struct InitSessionTimezone {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Timestamp>* /*timestamp*/) {
+      const ConstantArg<arg_type<Timestamp>>* /*timestamp*/) {
     timeZone_ = getTimeZoneFromConfig(config);
   }
 };

--- a/velox/functions/lib/TimeUtils.h
+++ b/velox/functions/lib/TimeUtils.h
@@ -122,7 +122,7 @@ struct InitSessionTimezone {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const ConstantArg<arg_type<Timestamp>>* /*timestamp*/) {
+      const arg_type<Timestamp>* /*timestamp*/) {
     timeZone_ = getTimeZoneFromConfig(config);
   }
 };

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -63,8 +63,8 @@ struct FromUnixtimeFunction {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const arg_type<double>* /*unixtime*/,
-      const arg_type<Varchar>* timezone) {
+      const optional_arg_type<double>* /*unixtime*/,
+      const optional_arg_type<Varchar>* timezone) {
     if (timezone != nullptr) {
       tzID_ = tz::getTimeZoneID((std::string_view)(*timezone));
     }
@@ -84,8 +84,8 @@ struct FromUnixtimeFunction {
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
       const arg_type<double>* /*unixtime*/,
-      const arg_type<int64_t>* hours,
-      const arg_type<int64_t>* minutes) {
+      const optional_arg_type<int64_t>* hours,
+      const optional_arg_type<int64_t>* minutes) {
     if (hours != nullptr && minutes != nullptr) {
       tzID_ = tz::getTimeZoneID(*hours * 60 + *minutes);
     }
@@ -151,21 +151,21 @@ struct DateFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Varchar>* date) {
+      const optional_arg_type<Varchar>* date) {
     timeZone_ = getTimeZoneFromConfig(config);
   }
 
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Timestamp>* timestamp) {
+      const optional_arg_type<Timestamp>* timestamp) {
     timeZone_ = getTimeZoneFromConfig(config);
   }
 
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<TimestampWithTimezone>* timestampWithTimezone) {
+      const optional_arg_type<TimestampWithTimezone>* timestampWithTimezone) {
     // Do nothing. Session timezone doesn't affect the result.
   }
 
@@ -930,8 +930,8 @@ struct DateTruncFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Varchar>* unitString,
-      const arg_type<Timestamp>* /*timestamp*/) {
+      const optional_arg_type<Varchar>* unitString,
+      const optional_arg_type<Timestamp>* /*timestamp*/) {
     timeZone_ = getTimeZoneFromConfig(config);
 
     if (unitString != nullptr) {
@@ -942,8 +942,8 @@ struct DateTruncFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const arg_type<Varchar>* unitString,
-      const arg_type<Date>* /*date*/) {
+      const optional_arg_type<Varchar>* unitString,
+      const optional_arg_type<Date>* /*date*/) {
     if (unitString != nullptr) {
       unit_ = getDateUnit(*unitString, false);
     }
@@ -952,8 +952,8 @@ struct DateTruncFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const arg_type<Varchar>* unitString,
-      const arg_type<TimestampWithTimezone>* /*timestamp*/) {
+      const optional_arg_type<Varchar>* unitString,
+      const optional_arg_type<TimestampWithTimezone>* /*timestamp*/) {
     if (unitString != nullptr) {
       unit_ = getTimestampUnit(*unitString);
     }
@@ -1052,9 +1052,9 @@ struct DateAddFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Varchar>* unitString,
-      const int64_t* /*value*/,
-      const arg_type<Timestamp>* /*timestamp*/) {
+      const optional_arg_type<Varchar>* unitString,
+      const optional_arg_type<int64_t>* /*value*/,
+      const optional_arg_type<Timestamp>* /*timestamp*/) {
     sessionTimeZone_ = getTimeZoneFromConfig(config);
     if (unitString != nullptr) {
       unit_ = fromDateTimeUnitString(*unitString, /*throwIfInvalid=*/false);
@@ -1064,9 +1064,9 @@ struct DateAddFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const arg_type<Varchar>* unitString,
-      const int64_t* /*value*/,
-      const arg_type<Date>* /*date*/) {
+      const optional_arg_type<Varchar>* unitString,
+      const optional_arg_type<int64_t>* /*value*/,
+      const optional_arg_type<Date>* /*date*/) {
     if (unitString != nullptr) {
       unit_ = getDateUnit(*unitString, false);
     }
@@ -1156,9 +1156,9 @@ struct DateDiffFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Varchar>* unitString,
-      const arg_type<Timestamp>* /*timestamp1*/,
-      const arg_type<Timestamp>* /*timestamp2*/) {
+      const optional_arg_type<Varchar>* unitString,
+      const optional_arg_type<Timestamp>* /*timestamp1*/,
+      const optional_arg_type<Timestamp>* /*timestamp2*/) {
     if (unitString != nullptr) {
       unit_ = fromDateTimeUnitString(*unitString, /*throwIfInvalid=*/false);
     }
@@ -1169,9 +1169,9 @@ struct DateDiffFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const arg_type<Varchar>* unitString,
-      const arg_type<Date>* /*date1*/,
-      const arg_type<Date>* /*date2*/) {
+      const optional_arg_type<Varchar>* unitString,
+      const optional_arg_type<Date>* /*date1*/,
+      const optional_arg_type<Date>* /*date2*/) {
     if (unitString != nullptr) {
       unit_ = getDateUnit(*unitString, false);
     }
@@ -1180,9 +1180,9 @@ struct DateDiffFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Varchar>* unitString,
-      const arg_type<TimestampWithTimezone>* /*timestampWithTimezone1*/,
-      const arg_type<TimestampWithTimezone>* /*timestampWithTimezone2*/) {
+      const optional_arg_type<Varchar>* unitString,
+      const optional_arg_type<TimestampWithTimezone>* /*timestampWithTimezone1*/,
+      const optional_arg_type<TimestampWithTimezone>* /*timestampWithTimezone2*/) {
     if (unitString != nullptr) {
       unit_ = fromDateTimeUnitString(*unitString, /*throwIfInvalid=*/false);
     }
@@ -1257,8 +1257,8 @@ struct DateFormatFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Timestamp>* /*timestamp*/,
-      const arg_type<Varchar>* formatString) {
+      const optional_arg_type<Timestamp>* /*timestamp*/,
+      const optional_arg_type<Varchar>* formatString) {
     sessionTimeZone_ = getTimeZoneFromConfig(config);
     if (formatString != nullptr) {
       setFormatter(*formatString);
@@ -1269,8 +1269,8 @@ struct DateFormatFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const arg_type<TimestampWithTimezone>* /*timestamp*/,
-      const arg_type<Varchar>* formatString) {
+      const optional_arg_type<TimestampWithTimezone>* /*timestamp*/,
+      const optional_arg_type<Varchar>* formatString) {
     if (formatString != nullptr) {
       setFormatter(*formatString);
       isConstFormat_ = true;
@@ -1340,7 +1340,7 @@ struct FromIso8601Timestamp {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Varchar>* /*input*/) {
+      const optional_arg_type<Varchar>* /*input*/) {
     auto sessionTzName = config.sessionTimezone();
     if (!sessionTzName.empty()) {
       sessionTimeZone_ = tz::locateZone(sessionTzName);
@@ -1385,8 +1385,8 @@ struct DateParseFunction {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Varchar>* /*input*/,
-      const arg_type<Varchar>* formatString) {
+      const optional_arg_type<Varchar>* /*input*/,
+      const optional_arg_type<Varchar>* formatString) {
     if (formatString != nullptr) {
       format_ =
           buildMysqlDateTimeFormatter(
@@ -1433,8 +1433,8 @@ struct FormatDateTimeFunction {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Timestamp>* /*timestamp*/,
-      const arg_type<Varchar>* formatString) {
+      const optional_arg_type<Timestamp>* /*timestamp*/,
+      const optional_arg_type<Varchar>* formatString) {
     sessionTimeZone_ = getTimeZoneFromConfig(config);
     if (formatString != nullptr) {
       setFormatter(*formatString);
@@ -1510,8 +1510,8 @@ struct ParseDateTimeFunction {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Varchar>* /*input*/,
-      const arg_type<Varchar>* format) {
+      const optional_arg_type<Varchar>* /*input*/,
+      const optional_arg_type<Varchar>* format) {
     if (format != nullptr) {
       format_ = buildJodaDateTimeFormatter(
                     std::string_view(format->data(), format->size()))
@@ -1622,7 +1622,7 @@ struct ToISO8601Function {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& inputTypes,
       const core::QueryConfig& config,
-      const arg_type<Timestamp>* /*input*/) {
+      const optional_arg_type<Timestamp>* /*input*/) {
     if (inputTypes[0]->isTimestamp()) {
       timeZone_ = getTimeZoneFromConfig(config);
     }
@@ -1675,8 +1675,8 @@ struct AtTimezoneFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<TimestampWithTimezone>* /*tsWithTz*/,
-      const arg_type<Varchar>* timezone) {
+      const optional_arg_type<TimestampWithTimezone>* /*tsWithTz*/,
+      const optional_arg_type<Varchar>* timezone) {
     if (timezone) {
       targetTimezoneID_ = tz::getTimeZoneID(
           std::string_view(timezone->data(), timezone->size()));

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -63,8 +63,8 @@ struct FromUnixtimeFunction {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const ConstantArg<arg_type<double>>* /*unixtime*/,
-      const ConstantArg<arg_type<Varchar>>* timezone) {
+      const arg_type<double>* /*unixtime*/,
+      const arg_type<Varchar>* timezone) {
     if (timezone != nullptr) {
       tzID_ = tz::getTimeZoneID((std::string_view)(*timezone));
     }
@@ -83,9 +83,9 @@ struct FromUnixtimeFunction {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const ConstantArg<arg_type<double>>* /*unixtime*/,
-      const ConstantArg<arg_type<int64_t>>* hours,
-      const ConstantArg<arg_type<int64_t>>* minutes) {
+      const arg_type<double>* /*unixtime*/,
+      const arg_type<int64_t>* hours,
+      const arg_type<int64_t>* minutes) {
     if (hours != nullptr && minutes != nullptr) {
       tzID_ = tz::getTimeZoneID(*hours * 60 + *minutes);
     }
@@ -151,21 +151,21 @@ struct DateFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const ConstantArg<arg_type<Varchar>>* date) {
+      const arg_type<Varchar>* date) {
     timeZone_ = getTimeZoneFromConfig(config);
   }
 
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const ConstantArg<arg_type<Timestamp>>* timestamp) {
+      const arg_type<Timestamp>* timestamp) {
     timeZone_ = getTimeZoneFromConfig(config);
   }
 
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const ConstantArg<arg_type<TimestampWithTimezone>>* timestampWithTimezone) {
+      const arg_type<TimestampWithTimezone>* timestampWithTimezone) {
     // Do nothing. Session timezone doesn't affect the result.
   }
 
@@ -930,8 +930,8 @@ struct DateTruncFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const ConstantArg<arg_type<Varchar>>* unitString,
-      const ConstantArg<arg_type<Timestamp>>* /*timestamp*/) {
+      const arg_type<Varchar>* unitString,
+      const arg_type<Timestamp>* /*timestamp*/) {
     timeZone_ = getTimeZoneFromConfig(config);
 
     if (unitString != nullptr) {
@@ -942,8 +942,8 @@ struct DateTruncFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const ConstantArg<arg_type<Varchar>>* unitString,
-      const ConstantArg<arg_type<Date>>* /*date*/) {
+      const arg_type<Varchar>* unitString,
+      const arg_type<Date>* /*date*/) {
     if (unitString != nullptr) {
       unit_ = getDateUnit(*unitString, false);
     }
@@ -952,8 +952,8 @@ struct DateTruncFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const ConstantArg<arg_type<Varchar>>* unitString,
-      const ConstantArg<arg_type<TimestampWithTimezone>>* /*timestamp*/) {
+      const arg_type<Varchar>* unitString,
+      const arg_type<TimestampWithTimezone>* /*timestamp*/) {
     if (unitString != nullptr) {
       unit_ = getTimestampUnit(*unitString);
     }
@@ -1052,9 +1052,9 @@ struct DateAddFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const ConstantArg<arg_type<Varchar>>* unitString,
-      const ConstantArg<int64_t>* /*value*/,
-      const ConstantArg<arg_type<Timestamp>>* /*timestamp*/) {
+      const arg_type<Varchar>* unitString,
+      const int64_t* /*value*/,
+      const arg_type<Timestamp>* /*timestamp*/) {
     sessionTimeZone_ = getTimeZoneFromConfig(config);
     if (unitString != nullptr) {
       unit_ = fromDateTimeUnitString(*unitString, /*throwIfInvalid=*/false);
@@ -1064,9 +1064,9 @@ struct DateAddFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const ConstantArg<arg_type<Varchar>>* unitString,
-      const ConstantArg<int64_t>* /*value*/,
-      const ConstantArg<arg_type<Date>>* /*date*/) {
+      const arg_type<Varchar>* unitString,
+      const int64_t* /*value*/,
+      const arg_type<Date>* /*date*/) {
     if (unitString != nullptr) {
       unit_ = getDateUnit(*unitString, false);
     }
@@ -1156,9 +1156,9 @@ struct DateDiffFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const ConstantArg<arg_type<Varchar>>* unitString,
-      const ConstantArg<arg_type<Timestamp>>* /*timestamp1*/,
-      const ConstantArg<arg_type<Timestamp>>* /*timestamp2*/) {
+      const arg_type<Varchar>* unitString,
+      const arg_type<Timestamp>* /*timestamp1*/,
+      const arg_type<Timestamp>* /*timestamp2*/) {
     if (unitString != nullptr) {
       unit_ = fromDateTimeUnitString(*unitString, /*throwIfInvalid=*/false);
     }
@@ -1169,9 +1169,9 @@ struct DateDiffFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const ConstantArg<arg_type<Varchar>>* unitString,
-      const ConstantArg<arg_type<Date>>* /*date1*/,
-      const ConstantArg<arg_type<Date>>* /*date2*/) {
+      const arg_type<Varchar>* unitString,
+      const arg_type<Date>* /*date1*/,
+      const arg_type<Date>* /*date2*/) {
     if (unitString != nullptr) {
       unit_ = getDateUnit(*unitString, false);
     }
@@ -1180,9 +1180,9 @@ struct DateDiffFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const ConstantArg<arg_type<Varchar>>* unitString,
-      const ConstantArg<arg_type<TimestampWithTimezone>>* /*timestampWithTimezone1*/,
-      const ConstantArg<arg_type<TimestampWithTimezone>>* /*timestampWithTimezone2*/) {
+      const arg_type<Varchar>* unitString,
+      const arg_type<TimestampWithTimezone>* /*timestampWithTimezone1*/,
+      const arg_type<TimestampWithTimezone>* /*timestampWithTimezone2*/) {
     if (unitString != nullptr) {
       unit_ = fromDateTimeUnitString(*unitString, /*throwIfInvalid=*/false);
     }
@@ -1257,8 +1257,8 @@ struct DateFormatFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const ConstantArg<arg_type<Timestamp>>* /*timestamp*/,
-      const ConstantArg<arg_type<Varchar>>* formatString) {
+      const arg_type<Timestamp>* /*timestamp*/,
+      const arg_type<Varchar>* formatString) {
     sessionTimeZone_ = getTimeZoneFromConfig(config);
     if (formatString != nullptr) {
       setFormatter(*formatString);

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -63,8 +63,8 @@ struct FromUnixtimeFunction {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const arg_type<double>* /*unixtime*/,
-      const arg_type<Varchar>* timezone) {
+      const ConstantArg<arg_type<double>>* /*unixtime*/,
+      const ConstantArg<arg_type<Varchar>>* timezone) {
     if (timezone != nullptr) {
       tzID_ = tz::getTimeZoneID((std::string_view)(*timezone));
     }
@@ -83,9 +83,9 @@ struct FromUnixtimeFunction {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const arg_type<double>* /*unixtime*/,
-      const arg_type<int64_t>* hours,
-      const arg_type<int64_t>* minutes) {
+      const ConstantArg<arg_type<double>>* /*unixtime*/,
+      const ConstantArg<arg_type<int64_t>>* hours,
+      const ConstantArg<arg_type<int64_t>>* minutes) {
     if (hours != nullptr && minutes != nullptr) {
       tzID_ = tz::getTimeZoneID(*hours * 60 + *minutes);
     }
@@ -151,21 +151,21 @@ struct DateFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Varchar>* date) {
+      const ConstantArg<arg_type<Varchar>>* date) {
     timeZone_ = getTimeZoneFromConfig(config);
   }
 
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Timestamp>* timestamp) {
+      const ConstantArg<arg_type<Timestamp>>* timestamp) {
     timeZone_ = getTimeZoneFromConfig(config);
   }
 
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<TimestampWithTimezone>* timestampWithTimezone) {
+      const ConstantArg<arg_type<TimestampWithTimezone>>* timestampWithTimezone) {
     // Do nothing. Session timezone doesn't affect the result.
   }
 
@@ -930,8 +930,8 @@ struct DateTruncFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Varchar>* unitString,
-      const arg_type<Timestamp>* /*timestamp*/) {
+      const ConstantArg<arg_type<Varchar>>* unitString,
+      const ConstantArg<arg_type<Timestamp>>* /*timestamp*/) {
     timeZone_ = getTimeZoneFromConfig(config);
 
     if (unitString != nullptr) {
@@ -942,8 +942,8 @@ struct DateTruncFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const arg_type<Varchar>* unitString,
-      const arg_type<Date>* /*date*/) {
+      const ConstantArg<arg_type<Varchar>>* unitString,
+      const ConstantArg<arg_type<Date>>* /*date*/) {
     if (unitString != nullptr) {
       unit_ = getDateUnit(*unitString, false);
     }
@@ -952,8 +952,8 @@ struct DateTruncFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const arg_type<Varchar>* unitString,
-      const arg_type<TimestampWithTimezone>* /*timestamp*/) {
+      const ConstantArg<arg_type<Varchar>>* unitString,
+      const ConstantArg<arg_type<TimestampWithTimezone>>* /*timestamp*/) {
     if (unitString != nullptr) {
       unit_ = getTimestampUnit(*unitString);
     }
@@ -1052,9 +1052,9 @@ struct DateAddFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Varchar>* unitString,
-      const int64_t* /*value*/,
-      const arg_type<Timestamp>* /*timestamp*/) {
+      const ConstantArg<arg_type<Varchar>>* unitString,
+      const ConstantArg<int64_t>* /*value*/,
+      const ConstantArg<arg_type<Timestamp>>* /*timestamp*/) {
     sessionTimeZone_ = getTimeZoneFromConfig(config);
     if (unitString != nullptr) {
       unit_ = fromDateTimeUnitString(*unitString, /*throwIfInvalid=*/false);
@@ -1064,9 +1064,9 @@ struct DateAddFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const arg_type<Varchar>* unitString,
-      const int64_t* /*value*/,
-      const arg_type<Date>* /*date*/) {
+      const ConstantArg<arg_type<Varchar>>* unitString,
+      const ConstantArg<int64_t>* /*value*/,
+      const ConstantArg<arg_type<Date>>* /*date*/) {
     if (unitString != nullptr) {
       unit_ = getDateUnit(*unitString, false);
     }
@@ -1156,9 +1156,9 @@ struct DateDiffFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Varchar>* unitString,
-      const arg_type<Timestamp>* /*timestamp1*/,
-      const arg_type<Timestamp>* /*timestamp2*/) {
+      const ConstantArg<arg_type<Varchar>>* unitString,
+      const ConstantArg<arg_type<Timestamp>>* /*timestamp1*/,
+      const ConstantArg<arg_type<Timestamp>>* /*timestamp2*/) {
     if (unitString != nullptr) {
       unit_ = fromDateTimeUnitString(*unitString, /*throwIfInvalid=*/false);
     }
@@ -1169,9 +1169,9 @@ struct DateDiffFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const arg_type<Varchar>* unitString,
-      const arg_type<Date>* /*date1*/,
-      const arg_type<Date>* /*date2*/) {
+      const ConstantArg<arg_type<Varchar>>* unitString,
+      const ConstantArg<arg_type<Date>>* /*date1*/,
+      const ConstantArg<arg_type<Date>>* /*date2*/) {
     if (unitString != nullptr) {
       unit_ = getDateUnit(*unitString, false);
     }
@@ -1180,9 +1180,9 @@ struct DateDiffFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Varchar>* unitString,
-      const arg_type<TimestampWithTimezone>* /*timestampWithTimezone1*/,
-      const arg_type<TimestampWithTimezone>* /*timestampWithTimezone2*/) {
+      const ConstantArg<arg_type<Varchar>>* unitString,
+      const ConstantArg<arg_type<TimestampWithTimezone>>* /*timestampWithTimezone1*/,
+      const ConstantArg<arg_type<TimestampWithTimezone>>* /*timestampWithTimezone2*/) {
     if (unitString != nullptr) {
       unit_ = fromDateTimeUnitString(*unitString, /*throwIfInvalid=*/false);
     }
@@ -1257,8 +1257,8 @@ struct DateFormatFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Timestamp>* /*timestamp*/,
-      const arg_type<Varchar>* formatString) {
+      const ConstantArg<arg_type<Timestamp>>* /*timestamp*/,
+      const ConstantArg<arg_type<Varchar>>* formatString) {
     sessionTimeZone_ = getTimeZoneFromConfig(config);
     if (formatString != nullptr) {
       setFormatter(*formatString);

--- a/velox/functions/prestosql/DecimalFunctions.cpp
+++ b/velox/functions/prestosql/DecimalFunctions.cpp
@@ -32,8 +32,8 @@ struct DecimalPlusFunction {
   void initialize(
       const std::vector<TypePtr>& inputTypes,
       const core::QueryConfig& /*config*/,
-      A* /*a*/,
-      B* /*b*/) {
+      optional_arg_type<A>* /*a*/,
+      optional_arg_type<B>* /*b*/) {
     auto aType = inputTypes[0];
     auto bType = inputTypes[1];
     auto aScale = getDecimalPrecisionScale(*aType).second;
@@ -81,8 +81,8 @@ struct DecimalMinusFunction {
   void initialize(
       const std::vector<TypePtr>& inputTypes,
       const core::QueryConfig& /*config*/,
-      A* /*a*/,
-      B* /*b*/) {
+      optional_arg_type<A>* /*a*/,
+      optional_arg_type<B>* /*b*/) {
     const auto& aType = inputTypes[0];
     const auto& bType = inputTypes[1];
     auto aScale = getDecimalPrecisionScale(*aType).second;
@@ -141,8 +141,8 @@ struct DecimalDivideFunction {
   void initialize(
       const std::vector<TypePtr>& inputTypes,
       const core::QueryConfig& /*config*/,
-      A* /*a*/,
-      B* /*b*/) {
+      optional_arg_type<A>* /*a*/,
+      optional_arg_type<B>* /*b*/) {
     auto aType = inputTypes[0];
     auto bType = inputTypes[1];
     auto aScale = getDecimalPrecisionScale(*aType).second;
@@ -171,8 +171,8 @@ struct DecimalModulusFunction {
   void initialize(
       const std::vector<TypePtr>& inputTypes,
       const core::QueryConfig& /*config*/,
-      A* /*a*/,
-      B* /*b*/) {
+      optional_arg_type<A>* /*a*/,
+      optional_arg_type<B>* /*b*/) {
     const auto& aType = inputTypes[0];
     const auto& bType = inputTypes[1];
     auto [aPrecision, aScale] = getDecimalPrecisionScale(*aType);
@@ -221,7 +221,7 @@ struct DecimalRoundFunction {
   void initialize(
       const std::vector<TypePtr>& inputTypes,
       const core::QueryConfig& config,
-      A* a) {
+      optional_arg_type<A>* a) {
     initialize(inputTypes, config, a, nullptr);
   }
 
@@ -229,8 +229,8 @@ struct DecimalRoundFunction {
   void initialize(
       const std::vector<TypePtr>& inputTypes,
       const core::QueryConfig& /*config*/,
-      A* /*a*/,
-      const int32_t* /*n*/) {
+      optional_arg_type<A>* /*a*/,
+      const optional_arg_type<int32_t>* /*n*/) {
     const auto [precision, scale] = getDecimalPrecisionScale(*inputTypes[0]);
     precision_ = precision;
     scale_ = scale;
@@ -271,7 +271,7 @@ struct DecimalFloorFunction {
   void initialize(
       const std::vector<TypePtr>& inputTypes,
       const core::QueryConfig& /*config*/,
-      A* /*a*/) {
+      optional_arg_type<A>* /*a*/) {
     scale_ = getDecimalPrecisionScale(*inputTypes[0]).second;
   }
 
@@ -296,7 +296,7 @@ struct DecimalTruncateFunction {
   void initialize(
       const std::vector<TypePtr>& inputTypes,
       const core::QueryConfig& /*config*/,
-      A* /*a*/) {
+      optional_arg_type<A>* /*a*/) {
     const auto [precision, scale] = getDecimalPrecisionScale(*inputTypes[0]);
     precision_ = precision;
     scale_ = scale;
@@ -306,8 +306,8 @@ struct DecimalTruncateFunction {
   void initialize(
       const std::vector<TypePtr>& inputTypes,
       const core::QueryConfig& config,
-      A* a,
-      const int32_t* /*n*/) {
+      optional_arg_type<A>* a,
+      const optional_arg_type<int32_t>* /*n*/) {
     initialize(inputTypes, config, a);
   }
 

--- a/velox/functions/prestosql/HyperLogLogFunctions.h
+++ b/velox/functions/prestosql/HyperLogLogFunctions.h
@@ -64,7 +64,7 @@ struct EmptyApproxSetWithMaxErrorFunction {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const double* maxStandardError) {
+      const optional_arg_type<double>* maxStandardError) {
     VELOX_USER_CHECK_NOT_NULL(
         maxStandardError,
         "empty_approx_set function requires constant value for maxStandardError argument");

--- a/velox/functions/prestosql/MapSubset.h
+++ b/velox/functions/prestosql/MapSubset.h
@@ -29,8 +29,8 @@ struct MapSubsetPrimitiveFunction {
   void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const arg_type<Map<Key, Generic<T1>>>* /*inputMap*/,
-      const arg_type<Array<Key>>* keys) {
+      const optional_arg_type<Map<Key, Generic<T1>>>* /*inputMap*/,
+      const optional_arg_type<Array<Key>>* keys) {
     if (keys != nullptr) {
       constantSearchKeys_ = true;
       initializeSearchKeys(*keys);
@@ -96,8 +96,8 @@ struct MapSubsetVarcharFunction {
   void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const arg_type<Map<Varchar, Generic<T1>>>* /*inputMap*/,
-      const arg_type<Array<Varchar>>* keys) {
+      const optional_arg_type<Map<Varchar, Generic<T1>>>* /*inputMap*/,
+      const optional_arg_type<Array<Varchar>>* keys) {
     if (keys != nullptr) {
       constantSearchKeys_ = true;
 

--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -613,8 +613,8 @@ struct NormalizeFunction {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const arg_type<Varchar>* /*string*/,
-      const arg_type<Varchar>* form) {
+      const optional_arg_type<Varchar>* /*string*/,
+      const optional_arg_type<Varchar>* form) {
     VELOX_USER_CHECK_NOT_NULL(form);
     VELOX_USER_CHECK_NE(
         normalizationOptions.count(*form),

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -152,7 +152,7 @@ struct UnixTimestampParseFunction {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Varchar>* /*input*/) {
+      const optional_arg_type<Varchar>* /*input*/) {
     auto formatter = detail::getDateTimeFormatter(
         kDefaultFormat_,
         config.sparkLegacyDateFormatter() ? DateTimeFormatterType::STRICT_SIMPLE
@@ -204,8 +204,8 @@ struct UnixTimestampParseWithFormatFunction
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Varchar>* /*input*/,
-      const arg_type<Varchar>* format) {
+      const optional_arg_type<Varchar>* /*input*/,
+      const optional_arg_type<Varchar>* format) {
     legacyFormatter_ = config.sparkLegacyDateFormatter();
     if (format != nullptr) {
       auto formatter = detail::getDateTimeFormatter(
@@ -285,8 +285,8 @@ struct FromUnixtimeFunction {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<int64_t>* /*unixtime*/,
-      const arg_type<Varchar>* format) {
+      const optional_arg_type<int64_t>* /*unixtime*/,
+      const optional_arg_type<Varchar>* format) {
     legacyFormatter_ = config.sparkLegacyDateFormatter();
     sessionTimeZone_ = getTimeZoneFromConfig(config);
     if (format != nullptr) {
@@ -344,8 +344,8 @@ struct ToUtcTimestampFunction {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const arg_type<Varchar>* /*input*/,
-      const arg_type<Varchar>* timezone) {
+      const optional_arg_type<Varchar>* /*input*/,
+      const optional_arg_type<Varchar>* timezone) {
     if (timezone) {
       timeZone_ = tz::locateZone(std::string_view(*timezone), false);
     }
@@ -375,8 +375,8 @@ struct FromUtcTimestampFunction {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const arg_type<Varchar>* /*input*/,
-      const arg_type<Varchar>* timezone) {
+      const optional_arg_type<Varchar>* /*input*/,
+      const optional_arg_type<Varchar>* timezone) {
     if (timezone) {
       timeZone_ = tz::locateZone(std::string_view(*timezone), false);
     }
@@ -406,8 +406,8 @@ struct GetTimestampFunction {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Varchar>* /*input*/,
-      const arg_type<Varchar>* format) {
+      const optional_arg_type<Varchar>* /*input*/,
+      const optional_arg_type<Varchar>* format) {
     legacyFormatter_ = config.sparkLegacyDateFormatter();
     auto sessionTimezoneName = config.sessionTimezone();
     if (!sessionTimezoneName.empty()) {
@@ -725,8 +725,8 @@ struct NextDayFunction {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const arg_type<Date>* /*startDate*/,
-      const arg_type<Varchar>* dayOfWeek) {
+      const optional_arg_type<Date>* /*startDate*/,
+      const optional_arg_type<Varchar>* dayOfWeek) {
     if (dayOfWeek != nullptr) {
       weekDay_ = getDayOfWeekFromString(*dayOfWeek);
       if (!weekDay_.has_value()) {

--- a/velox/functions/sparksql/In.cpp
+++ b/velox/functions/sparksql/In.cpp
@@ -83,8 +83,8 @@ struct InFunctionOuter {
     FOLLY_ALWAYS_INLINE void initialize(
         const std::vector<TypePtr>& /*inputTypes*/,
         const core::QueryConfig& /*config*/,
-        const arg_type<TInput>* /*searchTerm*/,
-        const arg_type<velox::Array<TInput>>* searchElements) {
+        const optional_arg_type<TInput>* /*searchTerm*/,
+        const optional_arg_type<velox::Array<TInput>>* searchElements) {
       if (searchElements == nullptr) {
         return;
       }

--- a/velox/functions/sparksql/MightContain.h
+++ b/velox/functions/sparksql/MightContain.h
@@ -28,8 +28,8 @@ struct BloomFilterMightContainFunction {
   void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig&,
-      const arg_type<Varbinary>* serialized,
-      const arg_type<int64_t>*) {
+      const optional_arg_type<Varbinary>* serialized,
+      const optional_arg_type<int64_t>*) {
     if (serialized != nullptr) {
       bloomFilter_.merge(serialized->str().c_str());
     }

--- a/velox/functions/sparksql/Rand.h
+++ b/velox/functions/sparksql/Rand.h
@@ -21,13 +21,15 @@ namespace facebook::velox::functions::sparksql {
 
 template <typename T>
 struct RandFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
   static constexpr bool is_deterministic = false;
 
   template <typename TInput>
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const TInput* seedInput) {
+      const optional_arg_type<TInput>* seedInput) {
     const auto partitionId = config.sparkPartitionId();
     int64_t seed = seedInput ? (int64_t)*seedInput : 0;
     generator_.seed(seed + partitionId);

--- a/velox/functions/sparksql/Size.cpp
+++ b/velox/functions/sparksql/Size.cpp
@@ -32,7 +32,7 @@ struct Size {
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
       const TInput* /*input*/,
-      const bool* legacySizeOfNull) {
+      const optional_arg_type<bool>* legacySizeOfNull) {
     if (legacySizeOfNull == nullptr) {
       VELOX_USER_FAIL("Constant legacySizeOfNull is expected.");
     }

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -878,9 +878,9 @@ struct TranslateFunction {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
-      const arg_type<Varchar>* /*string*/,
-      const arg_type<Varchar>* match,
-      const arg_type<Varchar>* replace) {
+      const optional_arg_type<Varchar>* /*string*/,
+      const optional_arg_type<Varchar>* match,
+      const optional_arg_type<Varchar>* replace) {
     if (match != nullptr && replace != nullptr) {
       isConstantDictionary_ = true;
     }

--- a/velox/functions/sparksql/Uuid.h
+++ b/velox/functions/sparksql/Uuid.h
@@ -34,7 +34,7 @@ struct UuidFunction {
   void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const int64_t* seed) {
+      const optional_arg_type<int64_t>* seed) {
     VELOX_CHECK_NOT_NULL(seed, "seed argument must be constant");
     const int32_t partitionId = config.sparkPartitionId();
     generator_.seed((*seed) + partitionId);

--- a/velox/type/SimpleFunctionApi.h
+++ b/velox/type/SimpleFunctionApi.h
@@ -249,27 +249,6 @@ struct ConstantChecker {
       isConstantType<TArgs>::value...};
 };
 
-template <typename T>
-struct ConstantArg {
- public:
-  ConstantArg() {}
-
-  ConstantArg(T* value) : value_(value) {}
-
-  T* value() {
-    VELOX_USER_CHECK_NOT_NULL(value_, "NULL input for constant argument");
-    return value_;
-  }
-
-  // Null Constant.
-  bool isNull() {
-    return value_ == nullptr;
-  }
-
- private:
-  T* value_ = nullptr;
-};
-
 /// CppToType templates for types introduced above.
 
 template <>

--- a/velox/type/SimpleFunctionApi.h
+++ b/velox/type/SimpleFunctionApi.h
@@ -249,6 +249,27 @@ struct ConstantChecker {
       isConstantType<TArgs>::value...};
 };
 
+template <typename T>
+struct ConstantArg {
+ public:
+  ConstantArg() {}
+
+  ConstantArg(T* value) : value_(value) {}
+
+  T* value() {
+    VELOX_USER_CHECK_NOT_NULL(value_, "NULL input for constant argument");
+    return value_;
+  }
+
+  // Null Constant.
+  bool isNull() {
+    return value_ == nullptr;
+  }
+
+ private:
+  T* value_ = nullptr;
+};
+
 /// CppToType templates for types introduced above.
 
 template <>


### PR DESCRIPTION
In the current simple function framework, if null constant argument is passed, initialize method will wrongly use the value 0 of NullConstant vector. In this pr, `ConstantArg` is proposed to represent function's input with null constant and non-null constant distinguished. If the proposed API change is acceptable, this pr will modify all simple functions' initialize method. 

Fix #6569.