### PR TITLE
Support overflow in Timestamp::toTimeZone method

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -1086,7 +1086,7 @@ int32_t DateTimeFormatter::format(
   Timestamp t = timestamp;
   if (timezone != nullptr) {
     const auto utcSeconds = timestamp.getSeconds();
-    t.toTimezone(*timezone);
+    t.toTimezone(*timezone, allowOverflow);
 
     offset = t.getSeconds() - utcSeconds;
   }

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -891,6 +891,14 @@ TEST_F(DateTimeFunctionsTest, fromUnixtime) {
   // 8 hours ahead UTC.
   setQueryTimeZone("Asia/Shanghai");
 
+#ifdef NDEBUG
+  // Integer overflow in the internal conversion from seconds to milliseconds in
+  // release mode.
+  EXPECT_EQ(
+      fromUnixTime(std::numeric_limits<int64_t>::max(), "yyyy-MM-dd HH:mm:ss"),
+      "1970-01-01 07:59:59");
+#endif
+
   EXPECT_EQ(fromUnixTime(0, "yyyy-MM-dd HH:mm:ss"), "1970-01-01 08:00:00");
   EXPECT_EQ(fromUnixTime(120, "yyyy-MM-dd HH:mm"), "1970-01-01 08:02");
   EXPECT_EQ(fromUnixTime(-59, "yyyy-MM-dd HH:mm:ss"), "1970-01-01 07:59:01");

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -94,9 +94,11 @@ Timestamp::toTimePointMs(bool allowOverflow) const {
   return tp;
 }
 
-void Timestamp::toTimezone(const tz::TimeZone& zone) {
+void Timestamp::toTimezone(const tz::TimeZone& zone, bool allowOverflow) {
   try {
-    seconds_ = zone.to_local(std::chrono::seconds(seconds_)).count();
+    auto tp = toTimePointMs(allowOverflow);
+    auto seconds = tp.time_since_epoch().count() / 1000;
+    seconds_ = zone.to_local(std::chrono::seconds(seconds)).count();
   } catch (const std::invalid_argument& e) {
     // Invalid argument means we hit a conversion not supported by
     // external/date. Need to throw a RuntimeError so that try() statements do

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -354,7 +354,7 @@ struct Timestamp {
   ///  Timestamp ts{0, 0};
   ///  ts.Timezone("America/Los_Angeles");
   ///  ts.toString(); // returns December 31, 1969 16:00:00
-  void toTimezone(const tz::TimeZone& zone);
+  void toTimezone(const tz::TimeZone& zone, bool allowOverflow = false);
 
   // Same as above, but accepts PrestoDB time zone ID.
   void toTimezone(int16_t tzID);


### PR DESCRIPTION
After merging the  [PR#10563](https://github.com/facebookincubator/velox/pull/10563/files#diff-4ec398f7f5c4ab9996a57283368b3f08d1c76b39d031f7a552276ca812aba44aL1089), we encountered an error during the unit tests in Gluten. 

```
Error Source: USER
Error Code: INVALID_ARGUMENT
Reason: Timepoint is outside of supported year range: [-32767, 32767], got 1587287
Retriable: False
Context: Top-level Expression: from_unixtime(9223372036854775807:BIGINT, yyyy-MM-dd HH:mm:ss.SSS:VARCHAR)
Function: validateRangeImpl
File: /mnt/DP_disk3/jk/projects/gluten/ep/build-velox/build/velox_ep/velox/type/tz/TimeZoneMap.cpp
Line: 187
Stack trace:
# 0  facebook::velox::VeloxException::VeloxException(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, facebook::velox::VeloxException::Type, std::basic_string_view<char, std::char_traits<char> >)
# 1  void facebook::velox::detail::veloxCheckFail<facebook::velox::VeloxUserError, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>(facebook::velox::detail::VeloxCheckFailArgs const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
# 2  facebook::velox::tz::validateRange(std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long, std::ratio<1l, 1l> > >)
# 3  facebook::velox::tz::TimeZone::to_local(std::chrono::duration<long, std::ratio<1l, 1l> >) const
# 4  facebook::velox::Timestamp::toTimezone(facebook::velox::tz::TimeZone const&)
# 5  facebook::velox::functions::DateTimeFormatter::format(facebook::velox::Timestamp const&, facebook::velox::tz::TimeZone const*, unsigned int, char*, bool) const
# 6  _ZNK8facebook5velox17SelectivityVector15applyToSelectedIZNS0_4exec7EvalCtx22applyToSelectedNoThrowIZNKS3_21SimpleFunctionAdapterINS0_4core9UDFHolderINS0_9functions8sparksql20FromUnixtimeFunctionINS3_10VectorExecEEESC_NS0_7VarcharENS0_15ConstantCheckerIJlSE_EEEJlSE_EEEE8applyUdfIZNKSI_7iterateIJNS3_20ConstantVectorReaderIlEENSL_ISE_EEEEEvRNSI_12ApplyContextEDpRT_EUlRT_RT0_T1_E1_EEvSP_ST_EUlST_E_ZNKSJ_ISY_EEvSP_ST_EUlST_E0_EEvRKS1_ST_SV_EUlST_E_EEvST_
# 7  facebook::velox::exec::SimpleFunctionAdapter<facebook::velox::core::UDFHolder<facebook::velox::functions::sparksql::FromUnixtimeFunction<facebook::velox::exec::VectorExec>, facebook::velox::exec::VectorExec, facebook::velox::Varchar, facebook::velox::ConstantChecker<long, facebook::velox::Varchar>, long, facebook::velox::Varchar> >::apply(facebook::velox::SelectivityVector const&, std::vector<std::shared_ptr<facebook::velox::BaseVector>, std::allocator<std::shared_ptr<facebook::velox::BaseVector> > >&, std::shared_ptr<facebook::velox::Type const> const&, facebook::velox::exec::EvalCtx&, std::shared_ptr<facebook::velox::BaseVector>&) const
# 8  facebook::velox::exec::Expr::applyFunction(facebook::velox::SelectivityVector const&, facebook::velox::exec::EvalCtx&, std::shared_ptr<facebook::velox::BaseVector>&)
# 9  facebook::velox::exec::Expr::applyFunctionWithPeeling(facebook::velox::SelectivityVector const&, facebook::velox::exec::EvalCtx&, std::shared_ptr<facebook::velox::BaseVector>&)
# 10 facebook::velox::exec::Expr::evalAllImpl(facebook::velox::SelectivityVector const&, facebook::velox::exec::EvalCtx&, std::shared_ptr<facebook::velox::BaseVector>&)
# 11 facebook::velox::exec::Expr::evalAll(facebook::velox::SelectivityVector const&, facebook::velox::exec::EvalCtx&, std::shared_ptr<facebook::velox::BaseVector>&)
# 12 facebook::velox::exec::Expr::evalWithNulls(facebook::velox::SelectivityVector const&, facebook::velox::exec::EvalCtx&, std::shared_ptr<facebook::velox::BaseVector>&)
# 13 facebook::velox::exec::Expr::evalEncodings(facebook::velox::SelectivityVector const&, facebook::velox::exec::EvalCtx&, std::shared_ptr<facebook::velox::BaseVector>&)
# 14 facebook::velox::exec::Expr::eval(facebook::velox::SelectivityVector const&, facebook::velox::exec::EvalCtx&, std::shared_ptr<facebook::velox::BaseVector>&, facebook::velox::exec::ExprSet const*)
# 15 facebook::velox::exec::ExprSet::eval(int, int, bool, facebook::velox::SelectivityVector const&, facebook::velox::exec::EvalCtx&, std::vector<std::shared_ptr<facebook::velox::BaseVector>, std::allocator<std::shared_ptr<facebook::velox::BaseVector> > >&)
# 16 facebook::velox::exec::FilterProject::project(facebook::velox::SelectivityVector const&, facebook::velox::exec::EvalCtx&)
# 17 facebook::velox::exec::FilterProject::getOutput()
# 18 facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)
# 19 facebook::velox::exec::Driver::next(std::shared_ptr<facebook::velox::exec::BlockingState>&)
# 20 facebook::velox::exec::Task::next(folly::SemiFuture<folly::Unit>*)
```

The reason is that this [PR#10563](https://github.com/facebookincubator/velox/pull/10563/files#diff-4ec398f7f5c4ab9996a57283368b3f08d1c76b39d031f7a552276ca812aba44aL1089) removed the handling for overflow. We have added handling for overflow in the toTimeZone method in this PR.