### PR TITLE
Deshim //folly/experimental:threaded_repeating_function_runner in fbcode/velox

### DIFF
--- a/velox/common/base/PeriodicStatsReporter.h
+++ b/velox/common/base/PeriodicStatsReporter.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <folly/experimental/ThreadedRepeatingFunctionRunner.h>
+#include <folly/executors/ThreadedRepeatingFunctionRunner.h>
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/caching/SsdFile.h"
 #include "velox/common/memory/MemoryArbitrator.h"


### PR DESCRIPTION
Summary:
The following rules were deshimmed:
```
//folly/experimental:threaded_repeating_function_runner -> //folly/executors:threaded_repeating_function_runner
```

The following headers were deshimmed:
```
folly/experimental/ThreadedRepeatingFunctionRunner.h -> folly/executors/ThreadedRepeatingFunctionRunner.h
```

This is a codemod. It was automatically generated and will be landed once it is approved and tests are passing in sandcastle.
You have been added as a reviewer by Sentinel or Butterfly.

Autodiff project: detrfr
Autodiff partition: fbcode.velox
Autodiff bookmark: ad.detrfr.fbcode.velox

Differential Revision: D60478389
