### PR TITLE
Optimize remaining filter to not eagerly materialize multi-referenced fields only directly referenced in AND clauses

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -299,7 +299,7 @@ void Expr::computeMetadata() {
   }
 
   // (5) Compute hasConditionals_.
-  hasConditionals_ = hasConditionals(this);
+  hasConditionals_ = exec::hasConditionals(this);
 
   metaDataComputed_ = true;
 }

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -279,6 +279,10 @@ class Expr {
     return false;
   }
 
+  bool hasConditionals() const {
+    return hasConditionals_;
+  }
+
   bool isDeterministic() const {
     return deterministic_;
   }
@@ -295,6 +299,16 @@ class Expr {
 
   void setMultiplyReferenced() {
     isMultiplyReferenced_ = true;
+  }
+
+  /// True if this is a special form where the next argument will always be
+  /// evaluated on a subset of the rows for which the previous one was
+  /// evaluated.  This is true of AND and no other at this time.  This implies
+  /// that lazies can be loaded on first use and not before starting evaluating
+  /// the form.  This is so because a subsequent use will never access rows that
+  /// were not in scope for the previous one.
+  virtual bool evaluatesArgumentsOnNonIncreasingSelection() const {
+    return false;
   }
 
   std::vector<common::Subfield> extractSubfields() const;
@@ -555,16 +569,6 @@ class Expr {
   // Computes distinctFields for this expression. Also updates any multiply
   // referenced fields.
   virtual void computeDistinctFields();
-
-  // True if this is a spcial form where the next argument will always be
-  // evaluated on a subset of the rows for which the previous one was evaluated.
-  // This is true of AND and no other at this time.  This implies that lazies
-  // can be loaded on first use and not before starting evaluating the form.
-  // This is so because a subsequent use will never access rows that were not in
-  // scope for the previous one.
-  virtual bool evaluatesArgumentsOnNonIncreasingSelection() const {
-    return false;
-  }
 
   const TypePtr type_;
   const std::vector<std::shared_ptr<Expr>> inputs_;


### PR DESCRIPTION
Summary:
When a field is referenced in both remaining filter and output vector,
we eagerly materialize it to avoid missing rows loaded.  The condition here can
be relaxed: if the field is only referenced in AND clauses without any other
conditional expressions, we should consider it safe to be lazy loaded because we
will not need more rows than any of the AND clause needs.  This helps us
improving some queries from 181 hours to 7.53 hours, comparing to Java using
38.8 hours.

Differential Revision: D60561537
