### PR TITLE
Ensure Nested Loop Join output follows probe order

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1669,7 +1669,8 @@ class MergeJoinNode : public AbstractJoinNode {
 ///
 /// Nested loop join supports both equal and non-equal joins. Expressions
 /// specified in joinCondition are evaluated on every combination of left/right
-/// tuple, to emit result.
+/// tuple, to emit result. Results are emitted following the same input order of
+/// probe rows for inner and left joins, for each thread of execution.
 ///
 /// To create Cartesian product of the left/right's output, use the constructor
 /// without `joinType` and `joinCondition` parameter.

--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -562,7 +562,9 @@ NestedLoopJoinNode
 NestedLoopJoinNode represents an implementation that iterates through each row from
 the left side of the join and, for each row, iterates through all rows from the right
 side of the join, comparing them based on the join condition to find matching rows
-and emitting results. Nested loop join supports non-equality join.
+and emitting results. Nested loop join supports non-equality joins, and emit output
+rows in the same order as the probe input (for inner and left outer joins) for each
+thread of execution.
 
 .. list-table::
    :widths: 10 30

--- a/velox/exec/NestedLoopJoinProbe.h
+++ b/velox/exec/NestedLoopJoinProbe.h
@@ -20,6 +20,39 @@
 #include "velox/exec/ProbeOperatorState.h"
 
 namespace facebook::velox::exec {
+
+/// Implements a Nested Loop Join (NLJ) between records from the probe (input_)
+/// and build (NestedLoopJoinBridge) sides. It supports inner, left, right and
+/// full outer joins.
+///
+/// This class is generally useful to evaluate non-equi-joins (e.g. "k1 >= k2"),
+/// when join conditions may need to be evaluated against a full cross product
+/// of the input.
+///
+/// The output follows the order of the probe side rows (for inner and left
+/// joins). All build vectors are materialized upfront (check buildVectors_),
+/// but probe batches are processed one-by-one as a stream.
+///
+/// To produce output, the operator processes each probe record from probe
+/// input, using the following steps:
+///
+/// 1. Materialize a cross product by wrapping each probe record (as a constant)
+///    to each build vector.
+/// 2. Evaluate the join condition.
+/// 3. Add key matches to the output.
+/// 4. Once all build vectors are processed for a particular probe row, check if
+///    a probe mismatch is needed (only for left and full outer joins).
+/// 5. Once all probe and build inputs are processed, check if build mismatches
+///    are needed (only for right and full outer joins).
+/// 6. If so, signal other peer operators; only a single operator instance will
+///    collect all build matches at the end, and emit any records that haven't
+///    been matched by any of the peers.
+///
+/// The output always contains dictionaries wrapped around probe columns, and
+/// copies for build columns. The buid-side copies are done lazily; it first
+/// accumulates the ranges to be copied, then performs the copies in batch,
+/// column-by-column. It produces at most `outputBatchSize_` records, but it may
+/// produce fewer since the output needs to follow the probe vector boundaries.
 class NestedLoopJoinProbe : public Operator {
  public:
   NestedLoopJoinProbe(
@@ -56,38 +89,109 @@ class NestedLoopJoinProbe : public Operator {
       const RowTypePtr& leftType,
       const RowTypePtr& rightType);
 
+  // Materializes build data from nested loop join bridge into `buildVectors_`.
+  // Returns whether the data has been materialized and is ready for use. Nested
+  // loop join requires all build data to be materialized and available in
+  // `buildVectors_` before it can produce output.
   bool getBuildData(ContinueFuture* future);
 
-  // Calculates the number of probe rows to match with the build side vectors
-  // given the output batch size limit.
-  vector_size_t getNumProbeRows() const;
+  // Generates output from join matches between probe and build sides, as well
+  // as probe mismatches (for left and full outer joins). As much as possible,
+  // generates outputs `outputBatchSize_` records at a time, but batches may be
+  // smaller in some cases - outputs follow the probe side buffer boundaries.
+  RowVectorPtr generateOutput();
 
-  // Generates cross product of next 'probeCnt' rows of input_, and all rows of
-  // build side vector at 'buildIndex_' in 'buildData_'.
-  // 'outputType' specifies the type of output.
-  // Projections from input_ and buildData_ to the output are specified by
-  // 'probeProjections' and 'buildProjections' respectively. Caller is
-  // responsible for ensuring all columns in outputType is contained in either
+  // Fill in joined output to `output_` by matching the current probeRow_ and
+  // successive build vectors (using getNextCrossProductBatch()). Stops when
+  // either all build vectors were matched for the current probeRow (returns
+  // true), or if the output is full (returns false). If it returns false, a
+  // valid vector with more than zero records will be available at `output_`; if
+  // it returns true, either nullptr or zero records may be placed at `output_`.
+  //
+  // Also updates `buildMatched_` if the build records that received a match, so
+  // that they can be used to implement right and full outer join semantic once
+  // all probe data has been processed.
+  bool addToOutput();
+
+  // Advances 'probeRow_' and resets required state information. Returns true
+  // if there is not more probe data to be processed in the current `input_`
+  // (and hence a new probe input is required). False otherwise.
+  bool advanceProbeRow();
+
+  // Ensures a new batch of records is available at `output_` and ready to
+  // receive rows. Batches have space for `outputBatchSize_`.
+  void prepareOutput();
+
+  // Evaluates the joinCondition for a given build vector. This method sets
+  // `filterOutput_` and `decodedFilterResult_`, which will be ready to be used
+  // by `isJoinConditionMatch(buildRow)` below.
+  void evaluateJoinFilter(const RowVectorPtr& buildVector);
+
+  // Checks if the join condition matched for a particular row.
+  bool isJoinConditionMatch(vector_size_t i) const {
+    return (
+        !decodedFilterResult_.isNullAt(i) &&
+        decodedFilterResult_.valueAt<bool>(i));
+  }
+
+  // Generates the next batch of a cross product between probe and build. It
+  // uses the current probe record being processed (`probeRow_` from `intput_`)
+  // for probe projections, and the columns from buildVector for build
   // projections.
-  // TODO: consider consolidate the routine of producing cartesian product that
-  // can be reused at MergeJoin::addToOutput
-  RowVectorPtr getCrossProduct(
-      vector_size_t probeCnt,
+  //
+  // Output projections can be specified so that this function can be used to
+  // generate both filter input and actual output (in case there is no join
+  // filter - cross join).
+  RowVectorPtr getNextCrossProductBatch(
+      const RowVectorPtr& buildVector,
       const RowTypePtr& outputType,
       const std::vector<IdentityProjection>& probeProjections,
       const std::vector<IdentityProjection>& buildProjections);
 
-  // Evaluates joinCondition against the output of getCrossProduct(probeCnt),
-  // returns the result that passed joinCondition, updates probeMatched_,
-  // buildMatched_ accordingly.
-  RowVectorPtr doMatch(vector_size_t probeCnt);
+  // Add a single record to `output_` based on buildRow from buildVector, and
+  // the current probeRow and probe vector (input_). Probe side projections are
+  // zero-copy (dictionary indices), and build side projections are marked to be
+  // copied using `buildCopyRanges_`; they will be copied later on by
+  // `copyBuildValues()`.
+  void addOutputRow(vector_size_t buildRow);
 
-  // Updates 'probeRow_' and 'buildIndex_' by advancing 'probeRow_' by probeCnt.
-  // Returns true if 'buildIndex_' points to the end of 'buildData_'.
-  bool advanceProbeRows(vector_size_t probeCnt);
+  // Checks if it is required to add a probe mismatch row, and does it if
+  // needed. The caller needs to ensure there is available space in `output_`
+  // for the new record, which has nulled out build projections.
+  void checkProbeMismatchRow();
 
+  // Add a probe mismatch (only for left/full outer joins). The record is based
+  // on the current probeRow and vector (input_) and build projections are null.
+  void addProbeMismatchRow();
+
+  // Copies the ranges from buildVector specified by `buildCopyRanges_` to
+  // `output_`, one projected column at a time. Clears buildCopyRanges_.
+  void copyBuildValues(const RowVectorPtr& buildVector);
+
+  // Called when we are done processing the current probe batch, to signal we
+  // are ready for the next one.
+  //
+  // If this is the last probe batch (and this is a right or full outer join),
+  // change the operator state to signal peers.
+  void finishProbeInput();
+
+  // When doing right/full joins, all but the last probe operator that finished
+  // matching probe-side input will turn into kFinish state.
+  // The last finishing operator will gather buildMatched from all the other
+  // probe operators to emit output for mismatched build side rows.
+  void beginBuildMismatch();
+
+  // If this is the operator producing build mismatches (only after producing
+  // all matches and probe mismatches).
+  bool processingBuildMismatch() const {
+    return state_ == ProbeOperatorState::kRunning && input_ == nullptr &&
+        noMoreInput_;
+  }
+
+  // Whether we have processed all build data for the current probe row (based
+  // on buildIndex_'s value).
   bool hasProbedAllBuildData() const {
-    return (buildIndex_ == buildVectors_.value().size());
+    return (buildIndex_ >= buildVectors_.value().size());
   }
 
   // Wraps rows of 'data' that are not selected in 'matched' and projects
@@ -95,25 +199,12 @@ class NestedLoopJoinProbe : public Operator {
   // create null column vectors in output for outer join. 'unmatchedMapping' is
   // the reusable buffer to record the mismatched row numbers for output
   // projections.
-  RowVectorPtr getMismatchedOutput(
+  RowVectorPtr getBuildMismatchedOutput(
       const RowVectorPtr& data,
       const SelectivityVector& matched,
       BufferPtr& unmatchedMapping,
       const std::vector<IdentityProjection>& projections,
       const std::vector<IdentityProjection>& nullProjections);
-
-  void finishProbeInput();
-
-  // When doing right/full joins, all but the last probe operators that finished
-  // matching and probe-side mismatch output, will turn into kFinish state.
-  // The last finishing operator will gather buildMatched from all the other
-  // probe operators to emit output for mismatched build side rows.
-  void beginBuildMismatch();
-
-  bool processingBuildMismatch() const {
-    return state_ == ProbeOperatorState::kRunning && input_ == nullptr &&
-        noMoreInput_;
-  }
 
   // TODO: Add state transition check.
   void setState(ProbeOperatorState state) {
@@ -121,48 +212,92 @@ class NestedLoopJoinProbe : public Operator {
   }
 
  private:
+  // Output buffer members.
+
   // Maximum number of rows in the output batch.
   const uint32_t outputBatchSize_;
+
+  // The current output batch being populated.
+  RowVectorPtr output_;
+
+  // Number of output rows in the current output batch.
+  vector_size_t numOutputRows_{0};
+
+  // Dictionary indices for probe columns.
+  BufferPtr probeIndices_;
+  vector_size_t* rawProbeIndices_;
+
+  // Join condition expression.
+
+  // May be nullptr for a cross join.
+  std::unique_ptr<ExprSet> joinCondition_;
+
+  // Input type for the join condition expression.
+  RowTypePtr filterInputType_;
+
+  // Join condition evaluation state that need to persisted across the
+  // generation of successive output buffers.
+  SelectivityVector filterInputRows_;
+  VectorPtr filterOutput_;
+  DecodedVector decodedFilterResult_;
+
+  // Join metadata and state.
   std::shared_ptr<const core::NestedLoopJoinNode> joinNode_;
   const core::JoinType joinType_;
 
   ProbeOperatorState state_{ProbeOperatorState::kWaitForBuild};
   ContinueFuture future_{ContinueFuture::makeEmpty()};
 
-  // Join condition-related state
-  std::unique_ptr<ExprSet> joinCondition_;
-  RowTypePtr filterInputType_;
-  SelectivityVector filterInputRows_;
+  // Probe side state.
 
-  // Probe side state
-  // Input row to process on next call to getOutput().
+  // Probe row being currently processed (related to `input_`).
   vector_size_t probeRow_{0};
-  // Records the number of probed rows in last getCrossProduct() call. It is
-  // reset upon each 'buildIndex_' update.
-  vector_size_t numPrevProbedRows_{0};
+
+  // Whether the current probeRow_ has produces a match. Used for left and full
+  // outer joins.
+  bool probeRowHasMatch_{false};
+
+  // Controls if this is the operator gathering and producing right/full outer
+  // join mismatches. This is only set after all probe and build data has been
+  // processed, only for right/full outer joins, and only executed in one single
+  // operator (need to wait until all peers are finished).
   bool lastProbe_{false};
-  // Represents whether probe side rows have been matched.
-  SelectivityVector probeMatched_;
-  std::vector<IdentityProjection> filterProbeProjections_;
-  BufferPtr probeOutMapping_;
-  BufferPtr probeIndices_;
-  // Indicate if the probe side has empty input or not. For the last prober,
+
+  // Indicate if the probe side has empty input or not. For the last probe,
   // this indicates if all the probe sides are empty or not. This flag is used
   // for mismatched output producing.
   bool probeSideEmpty_{true};
 
-  // Build side state
+  // Build side state.
+
+  // Stores the data for build vectors (right side of the join).
   std::optional<std::vector<RowVectorPtr>> buildVectors_;
   bool buildSideEmpty_{false};
-  // Index into buildData_ for the build side vector to process on next call to
-  // getOutput().
-  size_t buildIndex_{0};
-  std::vector<IdentityProjection> buildProjections_;
-  BufferPtr buildIndices_;
 
-  // Represents whether probe build rows have been matched.
+  // Index into `buildVectors_` for the build vector being currently processed.
+  size_t buildIndex_{0};
+
+  // Row being currently processed from `buildVectors_[buildIndex_]`.
+  vector_size_t buildRow_{0};
+
+  // Keep track of the build rows that had matches (only used for right or full
+  // outer joins).
   std::vector<SelectivityVector> buildMatched_;
+
+  // Stores the ranges of build values to be copied to the output vector (we
+  // batch them and copy once, instead of copying them row-by-row).
+  std::vector<BaseVector::CopyRange> buildCopyRanges_;
+
+  // List of output projections from the build side. Note that the list of
+  // projections from the probe side is available at `identityProjections_`.
+  std::vector<IdentityProjection> buildProjections_;
+
+  // Projections needed as input to the filter to evaluation join filter
+  // conditions. Note that if this is a cross-join, filter projections are the
+  // same as output projections.
+  std::vector<IdentityProjection> filterProbeProjections_;
   std::vector<IdentityProjection> filterBuildProjections_;
+
   BufferPtr buildOutMapping_;
 };
 

--- a/velox/exec/tests/NestedLoopJoinTest.cpp
+++ b/velox/exec/tests/NestedLoopJoinTest.cpp
@@ -19,9 +19,10 @@
 #include "velox/exec/tests/utils/VectorTestUtil.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
-using namespace facebook::velox;
-using namespace facebook::velox::exec;
-using namespace facebook::velox::exec::test;
+namespace facebook::velox::exec::test {
+namespace {
+
+using facebook::velox::test::assertEqualVectors;
 
 class NestedLoopJoinTest : public HiveConnectorTestBase {
  protected:
@@ -70,16 +71,27 @@ class NestedLoopJoinTest : public HiveConnectorTestBase {
       const std::vector<RowVectorPtr>& buildVectors) {
     runTest(probeVectors, buildVectors, 1);
     runTest(probeVectors, buildVectors, 4);
+    runTest(
+        probeVectors,
+        buildVectors,
+        4,
+        4); // Run with smaller output batch size.
   }
 
   void runTest(
       const std::vector<RowVectorPtr>& probeVectors,
       const std::vector<RowVectorPtr>& buildVectors,
-      int32_t numDrivers) {
+      int32_t numDrivers,
+      size_t preferredOutputBatchSize = 1024) {
     createDuckDbTable("t", probeVectors);
     createDuckDbTable("u", buildVectors);
+    auto queryCtx = core::QueryCtx::create(executor_.get());
 
     CursorParameters params;
+    params.queryCtx = queryCtx;
+    params.queryCtx->testingOverrideConfigUnsafe(
+        {{core::QueryConfig::kPreferredOutputBatchRows,
+          std::to_string(preferredOutputBatchSize)}});
     params.maxDrivers = numDrivers;
     auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
 
@@ -123,7 +135,8 @@ class NestedLoopJoinTest : public HiveConnectorTestBase {
       core::JoinType::kInner,
       core::JoinType::kLeft,
       core::JoinType::kRight,
-      core::JoinType::kFull};
+      core::JoinType::kFull,
+  };
   std::vector<std::string> outputLayout_{probeKeyName_, buildKeyName_};
   std::string joinConditionStr_{probeKeyName_ + " {} " + buildKeyName_};
   std::string queryStr_{fmt::format(
@@ -448,8 +461,8 @@ TEST_F(NestedLoopJoinTest, zeroColumnBuild) {
 }
 
 TEST_F(NestedLoopJoinTest, bigintArray) {
-  auto probeVectors = makeBatches(1000, 5, probeType_, pool_.get());
-  auto buildVectors = makeBatches(900, 5, buildType_, pool_.get());
+  auto probeVectors = makeBatches(100, 5, probeType_, pool_.get());
+  auto buildVectors = makeBatches(90, 5, buildType_, pool_.get());
   setComparisons({"="});
   setJoinTypes({core::JoinType::kFull});
   runSingleAndMultiDriverTest(probeVectors, buildVectors);
@@ -488,3 +501,72 @@ TEST_F(NestedLoopJoinTest, allTypes) {
       "SELECT t0, u0 FROM t {0} JOIN u ON t.t0 {1} u0 AND t1 {1} u1 AND t2 {1} u2 AND t3 {1} u3 AND t4 {1} u4 AND t5 {1} u5 AND t6 {1} u6");
   runSingleAndMultiDriverTest(probeVectors, buildVectors);
 }
+
+// Ensures output order follows the probe input order for inner and left joins.
+TEST_F(NestedLoopJoinTest, outputOrder) {
+  auto probeVectors = makeRowVector(
+      {"l1", "l2"},
+      {
+          makeNullableFlatVector<int64_t>({1, 8, 6, std::nullopt, 7, 4}),
+          makeFlatVector<StringView>({"a", "b", "c", "d", "e", "f"}),
+      });
+  auto buildVector1 = makeRowVector(
+      {"r1", "r2"},
+      {
+          makeNullableFlatVector<int64_t>({4, 6, 1}),
+          makeFlatVector<StringView>({"z", "x", "y"}),
+      });
+
+  auto buildVector2 = makeRowVector(
+      {"r1", "r2"},
+      {
+          makeNullableFlatVector<int64_t>({10, std::nullopt, 6}),
+          makeFlatVector<StringView>({"z", "p", "u"}),
+      });
+
+  const auto createPlan = [&](core::JoinType joinType) {
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    return PlanBuilder(planNodeIdGenerator)
+        .values({probeVectors})
+        .nestedLoopJoin(
+            PlanBuilder(planNodeIdGenerator)
+                .values({buildVector1, buildVector2})
+                .project({"r1", "r2"})
+                .planNode(),
+            "l1 < r1",
+            {"l1", "l2", "r1", "r2"},
+            joinType)
+        .planNode();
+  };
+
+  // Inner.
+  auto results = AssertQueryBuilder(createPlan(core::JoinType::kInner))
+                     .copyResults(pool());
+  auto expectedInner = makeRowVector({
+      makeNullableFlatVector<int64_t>({1, 1, 1, 1, 8, 6, 7, 4, 4, 4}),
+      makeFlatVector<StringView>(
+          {"a", "a", "a", "a", "b", "c", "e", "f", "f", "f"}),
+      makeNullableFlatVector<int64_t>({4, 6, 10, 6, 10, 10, 10, 6, 10, 6}),
+      makeFlatVector<StringView>(
+          {"z", "x", "z", "u", "z", "z", "z", "x", "z", "u"}),
+  });
+  assertEqualVectors(expectedInner, results);
+
+  // Left.
+  results =
+      AssertQueryBuilder(createPlan(core::JoinType::kLeft)).copyResults(pool());
+  auto expectedLeft = makeRowVector({
+      makeNullableFlatVector<int64_t>(
+          {1, 1, 1, 1, 8, 6, std::nullopt, 7, 4, 4, 4}),
+      makeNullableFlatVector<StringView>(
+          {"a", "a", "a", "a", "b", "c", "d", "e", "f", "f", "f"}),
+      makeNullableFlatVector<int64_t>(
+          {4, 6, 10, 6, 10, 10, std::nullopt, 10, 6, 10, 6}),
+      makeNullableFlatVector<StringView>(
+          {"z", "x", "z", "u", "z", "z", std::nullopt, "z", "x", "z", "u"}),
+  });
+  assertEqualVectors(expectedLeft, results);
+}
+
+} // namespace
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary:
To follow expectations from engines such as Presto, changing NLJ
operator to emit output in the same order as probe inputs are read. This
required us to make changes to how the operator processes data internally
(check the documentation added to the header file).
.
The main difference (other than a large code refactor), is the now each probe
record needs to be processed entirely before we can move to the next; this
means we can emit probe mismatches right away in the right order.
.
As a downside, since we process probe records entirely, the output may contain
records from multiple build vectors, so we can't just wrap them into
dictionaries. We still produce dictionaries wrapped around probe columns
though.

Differential Revision: D60685613
