### PR TITLE
Remove backward compatible method in TimeZoneMap.h

### DIFF
--- a/velox/type/tz/TimeZoneMap.h
+++ b/velox/type/tz/TimeZoneMap.h
@@ -155,13 +155,3 @@ class TimeZone {
 };
 
 } // namespace facebook::velox::tz
-
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-namespace facebook::velox::util {
-
-inline std::string getTimeZoneName(int64_t timeZoneID) {
-  return tz::getTimeZoneName(timeZoneID);
-}
-
-} // namespace facebook::velox::util
-#endif


### PR DESCRIPTION
Summary:
Prestodb is updated in https://github.com/prestodb/presto/pull/23345
Removing backward compatible method.

Differential Revision: D60707470
