### PR TITLE
Ignore time zones that are not recognizable by OS when building time zone database

### DIFF
--- a/velox/external/date/patches/0005-add_error_type_for_invalid_timezone.patch
+++ b/velox/external/date/patches/0005-add_error_type_for_invalid_timezone.patch
@@ -1,0 +1,51 @@
+diff --git a/velox/external/date/tz.cpp b/velox/external/date/tz.cpp
+index c3a3a8f7e..69513d7d3 100644
+--- a/velox/external/date/tz.cpp
++++ b/velox/external/date/tz.cpp
+@@ -3577,7 +3577,7 @@ tzdb::locate_zone(const std::string& tz_name) const
+                 return &*zi;
+         }
+ #endif  // !USE_OS_TZDB
+-        throw std::runtime_error(std::string(tz_name) + " not found in timezone database");
++        throw invalid_timezone(std::string(tz_name));
+     }
+     return &*zi;
+ }
+diff --git a/velox/external/date/tz.h b/velox/external/date/tz.h
+index a70bda4ad..c85b30eb7 100644
+--- a/velox/external/date/tz.h
++++ b/velox/external/date/tz.h
+@@ -284,6 +284,33 @@ ambiguous_local_time::make_msg(local_time<Duration> tp, const local_info& i)
+     return os.str();
+ }
+ 
++class invalid_timezone
++    : public std::runtime_error
++{
++public:
++    invalid_timezone(const std::string tz_name);
++
++private:
++    static
++    std::string
++    make_msg(const std::string tz_name);
++};
++
++inline
++invalid_timezone::invalid_timezone(const std::string tz_name)
++    : std::runtime_error(make_msg(tz_name))
++{
++}
++
++inline
++std::string
++invalid_timezone::make_msg(const std::string tz_name)
++{
++    std::ostringstream os;
++    os << tz_name << " not found in timezone database";
++    return os.str();
++}
++
+ class time_zone;
+ 
+ #if HAS_STRING_VIEW

--- a/velox/external/date/tz.cpp
+++ b/velox/external/date/tz.cpp
@@ -3577,7 +3577,7 @@ tzdb::locate_zone(const std::string& tz_name) const
                 return &*zi;
         }
 #endif  // !USE_OS_TZDB
-        throw std::runtime_error(std::string(tz_name) + " not found in timezone database");
+        throw invalid_timezone(std::string(tz_name));
     }
     return &*zi;
 }

--- a/velox/external/date/tz.h
+++ b/velox/external/date/tz.h
@@ -284,6 +284,33 @@ ambiguous_local_time::make_msg(local_time<Duration> tp, const local_info& i)
     return os.str();
 }
 
+class invalid_timezone
+    : public std::runtime_error
+{
+public:
+    invalid_timezone(const std::string& tz_name);
+
+private:
+    static
+    std::string
+    make_msg(const std::string& tz_name);
+};
+
+inline
+invalid_timezone::invalid_timezone(const std::string& tz_name)
+    : std::runtime_error(make_msg(tz_name))
+{
+}
+
+inline
+std::string
+invalid_timezone::make_msg(const std::string& tz_name)
+{
+    std::ostringstream os;
+    os << tz_name << " not found in timezone database";
+    return os.str();
+}
+
 class time_zone;
 
 #if HAS_STRING_VIEW

--- a/velox/type/tz/tests/CMakeLists.txt
+++ b/velox/type/tz/tests/CMakeLists.txt
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 add_executable(velox_type_tz_test TimeZoneMapTest.cpp)
-
 add_test(velox_type_tz_test velox_type_tz_test)
 
 target_link_libraries(
@@ -22,4 +21,17 @@ target_link_libraries(
   velox_exception
   GTest::gtest
   GTest::gtest_main
+  pthread)
+
+add_executable(velox_type_tz_ext_invalid_test
+               TimeZoneMapExternalInvalidTest.cpp)
+add_test(velox_type_tz_ext_invalid_test velox_type_tz_ext_invalid_test)
+
+target_link_libraries(
+  velox_type_tz_ext_invalid_test
+  velox_type_tz
+  velox_test_util
+  velox_exception
+  gtest
+  gtest_main
   pthread)

--- a/velox/type/tz/tests/CMakeLists.txt
+++ b/velox/type/tz/tests/CMakeLists.txt
@@ -32,6 +32,6 @@ target_link_libraries(
   velox_type_tz
   velox_test_util
   velox_exception
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   pthread)

--- a/velox/type/tz/tests/TimeZoneMapExternalInvalidTest.cpp
+++ b/velox/type/tz/tests/TimeZoneMapExternalInvalidTest.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/testutil/TestValue.h"
+#include "velox/external/date/tz.h"
+#include "velox/type/tz/TimeZoneMap.h"
+
+namespace facebook::velox::tz {
+namespace {
+
+using namespace std::chrono;
+
+DEBUG_ONLY_TEST(TimeZoneMapExternalInvalidTest, externalInvalid) {
+  const int16_t testZoneId = 1681;
+  const std::string testZone = "Africa/Abidjan";
+  common::testutil::TestValue::enable();
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::tz::locateZoneImpl",
+      std::function<void(std::string_view * tz_name)>(
+          [&](std::string_view* tz_name) -> void {
+            if (*tz_name == testZone) {
+              // Emulates an invalid_timezone error thrown from external API
+              // date::locate_zone. In real scenarios, this could happen when
+              // the timezone is not found in operating system's timezone list.
+              throw date::invalid_timezone(std::string(*tz_name));
+            }
+          }));
+
+  VELOX_ASSERT_THROW(
+      getTimeZoneName(testZoneId), "Unable to resolve timeZoneID");
+  VELOX_ASSERT_THROW(getTimeZoneID(testZone), "Unknown time zone");
+
+  EXPECT_EQ("UTC", getTimeZoneName(0));
+  EXPECT_EQ(0, getTimeZoneID("+00:00"));
+  EXPECT_EQ("Africa/Accra", getTimeZoneName(1682));
+  EXPECT_EQ(1682, getTimeZoneID("Africa/Accra"));
+}
+} // namespace
+} // namespace facebook::velox::tz


### PR DESCRIPTION
Related to discussion https://github.com/facebookincubator/velox/pull/10577#discussion_r1694501747

The patch fixes fatal error `<zone id> not found in timezone database` when at least one of the timezone IDs in [file](https://github.com/facebookincubator/velox/blob/main/velox/type/tz/TimeZoneDatabase.cpp) don't exist in OS's supported timezone list.