### PR TITLE
Fix null-handling of IN with constant in-list

### DIFF
--- a/velox/functions/prestosql/InPredicate.h
+++ b/velox/functions/prestosql/InPredicate.h
@@ -24,7 +24,8 @@ namespace facebook::velox::functions {
 // - input value is NULL
 // - in-list is NULL or empty
 // - input value doesn't have an exact match, but has an indeterminate match in
-// the in-list. E.g., array[null] in (array[1]) or array[1] in (array[null]).
+// the in-list. E.g., 'array[null] in (array[1])', 'array[1] in (array[null])',
+// or '1 in (null)'.
 template <typename TExec>
 struct GenericInPredicateFunction {
   VELOX_DEFINE_FUNCTION_TYPES(TExec);

--- a/velox/functions/prestosql/tests/InPredicateTest.cpp
+++ b/velox/functions/prestosql/tests/InPredicateTest.cpp
@@ -950,6 +950,7 @@ TEST_F(InPredicateTest, arrays) {
           std::nullopt,
           {{2, 4, 5, 6}},
           {{1, std::nullopt, 2}},
+          {{1, std::nullopt}},
           {{1, 2, 3, 4}},
       }),
   });
@@ -959,6 +960,7 @@ TEST_F(InPredicateTest, arrays) {
       true,
       false,
       std::nullopt,
+      false,
       false,
       std::nullopt,
       false,
@@ -971,6 +973,7 @@ TEST_F(InPredicateTest, arrays) {
       {1, std::nullopt, 2},
       {1, 2, 3},
       {},
+      {1, std::nullopt},
   });
 
   expected = makeNullableFlatVector<bool>(
@@ -978,9 +981,10 @@ TEST_F(InPredicateTest, arrays) {
        true,
        std::nullopt,
        std::nullopt,
+       false,
        std::nullopt,
        std::nullopt,
-       std::nullopt});
+       false});
   result = evaluate(makeInExpression(inValuesWithNulls), {data});
   assertEqualVectors(expected, result);
 }


### PR DESCRIPTION
Summary: The ComplexTypeInPredicate class for constant in-list doesn't match Presto behavior on handling nested NULL elements (https://github.com/facebookincubator/velox/issues/10570). This diff fixes it.

Differential Revision: D60768330
