### PR TITLE
Avoid generating unsupported data types for JoinFuzzer with PQR

### DIFF
--- a/velox/exec/fuzzer/CMakeLists.txt
+++ b/velox/exec/fuzzer/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(velox_fuzzer_util DuckQueryRunner.cpp PrestoQueryRunner.cpp
 
 target_link_libraries(
   velox_fuzzer_util
+  velox_vector_fuzzer
   velox_core
   velox_exec_test_lib
   cpr::cpr

--- a/velox/exec/fuzzer/DuckQueryRunner.cpp
+++ b/velox/exec/fuzzer/DuckQueryRunner.cpp
@@ -63,6 +63,21 @@ void DuckQueryRunner::disableAggregateFunctions(
   }
 }
 
+const std::vector<TypePtr>& DuckQueryRunner::supportedScalarTypes() const {
+  static const std::vector<TypePtr> kScalarTypes{
+      BOOLEAN(),
+      TINYINT(),
+      SMALLINT(),
+      INTEGER(),
+      BIGINT(),
+      REAL(),
+      DOUBLE(),
+      VARCHAR(),
+      DATE(),
+  };
+  return kScalarTypes;
+}
+
 std::multiset<std::vector<velox::variant>> DuckQueryRunner::execute(
     const std::string& sql,
     const std::vector<RowVectorPtr>& input,

--- a/velox/exec/fuzzer/DuckQueryRunner.h
+++ b/velox/exec/fuzzer/DuckQueryRunner.h
@@ -23,6 +23,17 @@ class DuckQueryRunner : public ReferenceQueryRunner {
  public:
   DuckQueryRunner();
 
+  RunnerType runnerType() const override {
+    return RunnerType::kDuckQueryRunner;
+  }
+
+  /// Skip Timestamp, Varbinary, Unknown, and IntervalDayTime types. DuckDB
+  /// doesn't support nanosecond precision for timestamps or casting from Bigint
+  /// to Interval.
+  ///
+  /// TODO Investigate mismatches reported when comparing Varbinary.
+  const std::vector<TypePtr>& supportedScalarTypes() const override;
+
   /// Specify names of aggregate function to exclude from the list of supported
   /// functions. Used to exclude functions that are non-determonistic, have bugs
   /// or whose semantics differ from Velox.

--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -251,6 +251,22 @@ bool isSupportedDwrfType(const TypePtr& type) {
 
 } // namespace
 
+const std::vector<TypePtr>& PrestoQueryRunner::supportedScalarTypes() const {
+  static const std::vector<TypePtr> kScalarTypes{
+      BOOLEAN(),
+      TINYINT(),
+      SMALLINT(),
+      INTEGER(),
+      BIGINT(),
+      REAL(),
+      DOUBLE(),
+      VARCHAR(),
+      VARBINARY(),
+      TIMESTAMP(),
+  };
+  return kScalarTypes;
+}
+
 std::optional<std::string> PrestoQueryRunner::toSql(
     const std::shared_ptr<const core::AggregationNode>& aggregationNode) {
   // Assume plan is Aggregation over Values.

--- a/velox/exec/fuzzer/PrestoQueryRunner.h
+++ b/velox/exec/fuzzer/PrestoQueryRunner.h
@@ -41,6 +41,12 @@ class PrestoQueryRunner : public velox::exec::test::ReferenceQueryRunner {
       std::string user,
       std::chrono::milliseconds timeout);
 
+  RunnerType runnerType() const override {
+    return RunnerType::kPrestoQueryRunner;
+  }
+
+  const std::vector<TypePtr>& supportedScalarTypes() const override;
+
   /// Converts Velox query plan to Presto SQL. Supports Values -> Aggregation or
   /// Window with an optional Project on top.
   ///

--- a/velox/exec/fuzzer/ReferenceQueryRunner.h
+++ b/velox/exec/fuzzer/ReferenceQueryRunner.h
@@ -17,13 +17,24 @@
 
 #include <set>
 #include "velox/core/PlanNode.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
 
 namespace facebook::velox::exec::test {
 
 /// Query runner that uses reference database, i.e. DuckDB, Presto, Spark.
 class ReferenceQueryRunner {
  public:
+  enum class RunnerType { kPrestoQueryRunner, kDuckQueryRunner };
+
   virtual ~ReferenceQueryRunner() = default;
+
+  virtual RunnerType runnerType() const = 0;
+
+  // Scalar types supported by the reference database, to be used to restrict
+  // candidates when generating random types for fuzzers.
+  virtual const std::vector<TypePtr>& supportedScalarTypes() const {
+    return defaultScalarTypes();
+  }
 
   /// Converts Velox plan into SQL accepted by the reference database.
   /// @return std::nullopt if the plan uses features not supported by the

--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -1025,9 +1025,7 @@ VectorPtr VectorLoaderWrap::makeEncodingPreservedCopy(
       std::move(nulls), std::move(indices), vectorSize, baseResult);
 }
 
-namespace {
-
-const std::vector<TypePtr> defaultScalarTypes() {
+const std::vector<TypePtr>& defaultScalarTypes() {
   // @TODO Add decimal TypeKinds to randType.
   // Refer https://github.com/facebookincubator/velox/issues/3942
   static std::vector<TypePtr> kScalarTypes{
@@ -1046,7 +1044,6 @@ const std::vector<TypePtr> defaultScalarTypes() {
   };
   return kScalarTypes;
 }
-} // namespace
 
 TypePtr randType(FuzzerGenerator& rng, int maxDepth) {
   return randType(rng, defaultScalarTypes(), maxDepth);

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -389,4 +389,7 @@ RowTypePtr randRowType(
     const std::vector<TypePtr>& scalarTypes,
     int maxDepth = 5);
 
+/// Default set of scalar types to be chosen from when generating random types.
+const std::vector<TypePtr>& defaultScalarTypes();
+
 } // namespace facebook::velox


### PR DESCRIPTION
Summary: 
When running JoinFuzzerTest with PrestoQueryRunner, currently only about 
16-20% iterations are verified against Presto. The rest iterations are 
unverified due to unsupported data types. This diff makes JoinFuzzer to 
avoid generating unsupported types when running with PrestoQueryRunner. 
After this change, over 85% of iterations are verified against Presto.

Differential Revision: D60768414
