### PR TITLE
Fix HyperLogLog type registration in registerApproxDistinctAggregates

### DIFF
--- a/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
@@ -523,9 +523,7 @@ void registerApproxDistinctAggregates(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite) {
-  registerCustomType(
-      prefix + "hyperloglog",
-      std::make_unique<const HyperLogLogTypeFactories>());
+  registerHyperLogLogType();
   registerApproxDistinct(
       prefix + kApproxDistinct,
       false,


### PR DESCRIPTION
Prefix is not needed to register custom type `HyperLogLog` in `ApproxDistinctAggregates`.
`registerHyperLogLogType` is used instead to make registration of customType `HyperLogLog` 
uniform across velox.

Use of prefix in `registerCustomType` here resulted in the following error while running tests
in [presto PR](https://github.com/prestodb/presto/pull/22332):
```
Reason: Type doesn't exist: 'HYPERLOGLOG'
Retriable: False
Function: validateBaseTypeAndCollectTypeParams
File: /Users/pramod/Desktop/velox/velox/expression/FunctionSignature.cpp
Line: 125
```