### PR TITLE
Add python venv to setup-macos.sh and Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@ autoconf/autom4te.cache
 projects/*
 !projects/*.*
 !projects/Makefile
-
+.venv
 
 #==============================================================================#
 # Autotools artifacts

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ BENCHMARKS_BASIC_DIR=$(BUILD_BASE_DIR)/$(BUILD_DIR)/velox/benchmarks/basic/
 BENCHMARKS_DUMP_DIR=dumps
 TREAT_WARNINGS_AS_ERRORS ?= 1
 ENABLE_WALL ?= 1
+PYTHON_VENV ?= .venv
 
 # Option to make a minimal build. By default set to "OFF"; set to
 # "ON" to only build a minimal set of components. This may override
@@ -169,17 +170,16 @@ fuzzertest: debug
 			--minloglevel=0
 
 format-fix: 			#: Fix formatting issues in the main branch
-	scripts/check.py format main --fix
+	source ${PYTHON_VENV}/bin/activate; scripts/check.py format main --fix
 
 format-check: 			#: Check for formatting issues on the main branch
-	clang-format --version
-	scripts/check.py format main
+	source ${PYTHON_VENV}/bin/activate; scripts/check.py format main
 
 header-fix:				#: Fix license header issues in the current branch
-	scripts/check.py header main --fix
+	source ${PYTHON_VENV}/bin/activate; scripts/check.py header main --fix
 
 header-check:			#: Check for license header issues on the main branch
-	scripts/check.py header main
+	source ${PYTHON_VENV}/bin/activate; scripts/check.py header main
 
 circleci-container:			#: Build the linux container for CircleCi
 	$(MAKE) linux-container CONTAINER_NAME=circleci

--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,7 @@ format-fix: 			#: Fix formatting issues in the main branch
 	source ${PYTHON_VENV}/bin/activate; scripts/check.py format main --fix
 
 format-check: 			#: Check for formatting issues on the main branch
+	clang-format --version
 	source ${PYTHON_VENV}/bin/activate; scripts/check.py format main
 
 header-fix:				#: Fix license header issues in the current branch

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@
 # limitations under the License.
 .PHONY: all cmake build clean debug release unit
 
+SHELL=/bin/bash
 BUILD_BASE_DIR=_build
 BUILD_DIR=release
 BUILD_TYPE=Release

--- a/Makefile
+++ b/Makefile
@@ -170,17 +170,33 @@ fuzzertest: debug
 			--minloglevel=0
 
 format-fix: 			#: Fix formatting issues in the main branch
+ifneq ("$(wildcard ${PYTHON_VENV}/pyvenv.cfg)","")
 	source ${PYTHON_VENV}/bin/activate; scripts/check.py format main --fix
+else
+	scripts/check.py format main --fix
+endif
 
 format-check: 			#: Check for formatting issues on the main branch
 	clang-format --version
+ifneq ("$(wildcard ${PYTHON_VENV}/pyvenv.cfg)","")
 	source ${PYTHON_VENV}/bin/activate; scripts/check.py format main
+else
+	scripts/check.py format main
+endif
 
-header-fix:				#: Fix license header issues in the current branch
+header-fix:			#: Fix license header issues in the current branch
+ifneq ("$(wildcard ${PYTHON_VENV}/pyvenv.cfg)","")
 	source ${PYTHON_VENV}/bin/activate; scripts/check.py header main --fix
+else
+	scripts/check.py header main --fix
+endif
 
 header-check:			#: Check for license header issues on the main branch
+ifneq ("$(wildcard ${PYTHON_VENV}/pyvenv.cfg)","")
 	source ${PYTHON_VENV}/bin/activate; scripts/check.py header main
+else
+	scripts/check.py header main
+endif
 
 circleci-container:			#: Build the linux container for CircleCi
 	$(MAKE) linux-container CONTAINER_NAME=circleci

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -74,10 +74,9 @@ function install_build_prerequisites {
   done
   if [ ! -f ${PYTHON_VENV}/pyvenv.cfg ]; then
     echo "Creating Python Virtual Environment at ${PYTHON_VENV}"
-    python3 -m ${PYTHON_VENV}
+    python3 -m venv ${PYTHON_VENV}
   fi
-  source ${PYTHON_VENV}/bin/activate
-  pip3 install --user cmake-format regex pyyaml
+  source ${PYTHON_VENV}/bin/activate; pip3 install cmake-format regex pyyaml
 }
 
 function install_velox_deps_from_brew {

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -30,6 +30,7 @@ set -x # Print commands that are executed.
 
 SCRIPTDIR=$(dirname "${BASH_SOURCE[0]}")
 source $SCRIPTDIR/setup-helper-functions.sh
+PYTHON_VENV=${PYHTON_VENV:-"${SCRIPTDIR}/../.venv"}
 
 NPROC=$(getconf _NPROCESSORS_ONLN)
 
@@ -71,6 +72,11 @@ function install_build_prerequisites {
   do
     install_from_brew ${pkg}
   done
+  if [ ! -f ${PYTHON_VENV}/pyvenv.cfg ]; then
+    echo "Creating Python Virtual Environment at ${PYTHON_VENV}"
+    python3 -m ${PYTHON_VENV}
+  fi
+  source ${PYTHON_VENV}/bin/activate
   pip3 install --user cmake-format regex pyyaml
 }
 


### PR DESCRIPTION
Create python virtual environment in the Velox root directory if missing.

Resolves https://github.com/facebookincubator/velox/issues/9519