### PR TITLE
Reduce number of link jobs in ubuntu debug build

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Make Debug Build
         env:
           VELOX_DEPENDENCY_SOURCE: BUNDLED
-          MAKEFLAGS: "NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=4"
+          MAKEFLAGS: "NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=3"
           EXTRA_CMAKE_FLAGS: "-DVELOX_ENABLE_ARROW=ON -DVELOX_ENABLE_PARQUET=ON"
         run: |
           make debug 

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -171,7 +171,6 @@ jobs:
           MAKEFLAGS: "NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=3"
           EXTRA_CMAKE_FLAGS: "-DVELOX_ENABLE_ARROW=ON -DVELOX_ENABLE_PARQUET=ON"
         run: |
-          free -g
           make debug 
 
       - name: CCache after

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -171,6 +171,7 @@ jobs:
           MAKEFLAGS: "NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=3"
           EXTRA_CMAKE_FLAGS: "-DVELOX_ENABLE_ARROW=ON -DVELOX_ENABLE_PARQUET=ON"
         run: |
+          free -g
           make debug 
 
       - name: CCache after


### PR DESCRIPTION
For some reason the linux debug build has started to fail because it get's oom killed during linking: https://github.com/facebookincubator/velox/actions/runs/10259255187/job/28383420958#step:7:6891

I am not sure if the addition of parquet in #10648 is to blame, in that PR the job did not fail.