### PR TITLE
Let memory arbitration directly track the liveness of query memory pools

### DIFF
--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -242,15 +242,12 @@ class TestStatsReportMemoryArbitrator : public memory::MemoryArbitrator {
     return "test";
   }
 
-  uint64_t growCapacity(memory::MemoryPool* /*unused*/, uint64_t /*unused*/)
-      override {
-    return 0;
-  }
+  void addPool(const std::shared_ptr<memory::MemoryPool>& pool) override {}
 
-  bool growCapacity(
-      memory::MemoryPool* /*unused*/,
-      const std::vector<std::shared_ptr<memory::MemoryPool>>& /*unused*/,
-      uint64_t /*unused*/) override {
+  void removePool(memory::MemoryPool* pool) override {}
+
+  bool growCapacity(memory::MemoryPool* /*unused*/, uint64_t /*unused*/)
+      override {
     return false;
   }
 
@@ -259,11 +256,8 @@ class TestStatsReportMemoryArbitrator : public memory::MemoryArbitrator {
     return 0;
   }
 
-  uint64_t shrinkCapacity(
-      const std::vector<std::shared_ptr<memory::MemoryPool>>& /*unused*/,
-      uint64_t /*unused*/,
-      bool /*unused*/,
-      bool /*unused*/) override {
+  uint64_t shrinkCapacity(uint64_t /*unused*/, bool /*unused*/, bool /*unused*/)
+      override {
     return 0;
   }
 
@@ -546,7 +540,7 @@ TEST_F(PeriodicStatsReporterTest, basic) {
        .sumEvictScore = 10,
        .ssdStats = newSsdStats});
   arbitrator.updateStats(memory::MemoryArbitrator::Stats(
-      10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10));
+      10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10));
   std::this_thread::sleep_for(std::chrono::milliseconds(4'000));
 
   // Stop right after sufficient wait to ensure the following reads from main

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -61,6 +61,10 @@ class MemoryArbitrator {
     /// capacity of 'memoryPoolReservedCapacity' to run.
     int64_t reservedCapacity{0};
 
+    /// The initial memory capacity to reserve for a newly created query memory
+    /// pool.
+    uint64_t memoryPoolInitCapacity{256 << 20};
+
     /// The minimal amount of memory capacity reserved for each query to run.
     uint64_t memoryPoolReservedCapacity{0};
 
@@ -129,29 +133,23 @@ class MemoryArbitrator {
 
   virtual ~MemoryArbitrator() = default;
 
-  /// Invoked by the memory manager to allocate up to 'targetBytes' of free
-  /// memory capacity without triggering memory arbitration. The function will
-  /// grow the memory pool's capacity based on the free available memory
-  /// capacity in the arbitrator, and returns the actual grown capacity in
-  /// bytes.
-  virtual uint64_t growCapacity(MemoryPool* pool, uint64_t bytes) = 0;
+  /// Invoked by the memory manager to add a newly created memory pool. The
+  /// memory arbitrator allocates the initial capacity for 'pool' and
+  /// dynamically adjusts its capacity based query memory needs through memory
+  /// arbitration.
+  virtual void addPool(const std::shared_ptr<MemoryPool>& pool) = 0;
+
+  /// Invoked by the memory manager to remove a destroyed memory pool. The
+  /// memory arbitrator frees up all its capacity and stops memory arbitration
+  /// operation on it.
+  virtual void removePool(MemoryPool* pool) = 0;
 
   /// Invoked by the memory manager to grow a memory pool's capacity.
-  /// 'pool' is the memory pool to request to grow. 'candidates' is a list
-  /// of query root pools to participate in the memory arbitration. The memory
-  /// arbitrator picks up a number of pools to either shrink its memory capacity
-  /// without actually freeing memory or reclaim its used memory to free up
-  /// enough memory for 'requestor' to grow. Different arbitrators use different
-  /// policies to select the candidate pools. The shared memory arbitrator used
-  /// by both Prestissimo and Prestissimo-on-Spark, selects the candidates with
-  /// more memory capacity.
-  ///
-  /// NOTE: the memory manager keeps 'candidates' valid during the arbitration
-  /// processing.
-  virtual bool growCapacity(
-      MemoryPool* pool,
-      const std::vector<std::shared_ptr<MemoryPool>>& candidatePools,
-      uint64_t targetBytes) = 0;
+  /// 'pool' is the memory pool to request to grow. The memory arbitrator picks
+  /// up a number of pools to either shrink its memory capacity without actually
+  /// freeing memory or reclaim its used memory to free up enough memory for
+  /// 'requestor' to grow.
+  virtual bool growCapacity(MemoryPool* pool, uint64_t targetBytes) = 0;
 
   /// Invoked by the memory manager to shrink up to 'targetBytes' free capacity
   /// from a memory 'pool', and returns them back to the arbitrator. If
@@ -159,17 +157,16 @@ class MemoryArbitrator {
   /// pool. The function returns the actual freed capacity from 'pool'.
   virtual uint64_t shrinkCapacity(MemoryPool* pool, uint64_t targetBytes) = 0;
 
-  /// Invoked by the memory manager to shrink memory capacity from a given list
-  /// of memory pools by reclaiming free and used memory. The freed memory
-  /// capacity is given back to the arbitrator.  If 'targetBytes' is zero, then
-  /// try to reclaim all the memory from 'pools'. The function returns the
-  /// actual freed memory capacity in bytes. If 'allowSpill' is true, it
-  /// reclaims the used memory by spilling. If 'allowAbort' is true, it reclaims
-  /// the used memory by aborting the queries with the most memory usage. If
-  /// both are true, it first reclaims the used memory by spilling and then
-  /// abort queries to reach the reclaim target.
+  /// Invoked by the memory manager to shrink memory capacity from memory pools
+  /// by reclaiming free and used memory. The freed memory capacity is given
+  /// back to the arbitrator.  If 'targetBytes' is zero, then try to reclaim all
+  /// the memory from 'pools'. The function returns the actual freed memory
+  /// capacity in bytes. If 'allowSpill' is true, it reclaims the used memory by
+  /// spilling. If 'allowAbort' is true, it reclaims the used memory by aborting
+  /// the queries with the most memory usage. If both are true, it first
+  /// reclaims the used memory by spilling and then abort queries to reach the
+  /// reclaim target.
   virtual uint64_t shrinkCapacity(
-      const std::vector<std::shared_ptr<MemoryPool>>& pools,
       uint64_t targetBytes,
       bool allowSpill = true,
       bool allowAbort = false) = 0;
@@ -205,10 +202,8 @@ class MemoryArbitrator {
     /// The total number of times of the reclaim attempts that end up failing
     /// due to reclaiming at non-reclaimable stage.
     uint64_t numNonReclaimableAttempts{0};
-    /// The total number of memory reservations.
-    uint64_t numReserves{0};
-    /// The total number of memory releases.
-    uint64_t numReleases{0};
+    /// The total number of memory capacity shrinks.
+    uint64_t numShrinks{0};
 
     Stats(
         uint64_t _numRequests,
@@ -224,8 +219,7 @@ class MemoryArbitrator {
         uint64_t _freeReservedCapacityBytes,
         uint64_t _reclaimTimeUs,
         uint64_t _numNonReclaimableAttempts,
-        uint64_t _numReserves,
-        uint64_t _numReleases);
+        uint64_t _numShrinks);
 
     Stats() = default;
 
@@ -259,6 +253,7 @@ class MemoryArbitrator {
   explicit MemoryArbitrator(const Config& config)
       : capacity_(config.capacity),
         reservedCapacity_(config.reservedCapacity),
+        memoryPoolInitialCapacity_(config.memoryPoolInitCapacity),
         memoryPoolReservedCapacity_(config.memoryPoolReservedCapacity),
         memoryPoolTransferCapacity_(config.memoryPoolTransferCapacity),
         memoryReclaimWaitMs_(config.memoryReclaimWaitMs),
@@ -277,6 +272,7 @@ class MemoryArbitrator {
 
   const uint64_t capacity_;
   const uint64_t reservedCapacity_;
+  const uint64_t memoryPoolInitialCapacity_;
   const uint64_t memoryPoolReservedCapacity_;
   const uint64_t memoryPoolTransferCapacity_;
   const uint64_t memoryReclaimWaitMs_;

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -19,6 +19,7 @@
 #include "velox/common/memory/MemoryArbitrator.h"
 
 #include "velox/common/base/Counters.h"
+#include "velox/common/base/GTestMacros.h"
 #include "velox/common/base/StatsReporter.h"
 #include "velox/common/future/VeloxPromise.h"
 #include "velox/common/memory/Memory.h"
@@ -43,17 +44,15 @@ class SharedArbitrator : public memory::MemoryArbitrator {
 
   static void unregisterFactory();
 
-  uint64_t growCapacity(MemoryPool* pool, uint64_t requestBytes) final;
+  void addPool(const std::shared_ptr<MemoryPool>& pool) final;
 
-  bool growCapacity(
-      MemoryPool* pool,
-      const std::vector<std::shared_ptr<MemoryPool>>& candidatePools,
-      uint64_t requestBytes) final;
+  void removePool(MemoryPool* pool) final;
+
+  bool growCapacity(MemoryPool* pool, uint64_t requestBytes) final;
 
   uint64_t shrinkCapacity(MemoryPool* pool, uint64_t requestBytes) final;
 
   uint64_t shrinkCapacity(
-      const std::vector<std::shared_ptr<MemoryPool>>& pools,
       uint64_t requestBytes,
       bool allowSpill = true,
       bool force = false) override final;
@@ -63,16 +62,6 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   std::string kind() const override;
 
   std::string toString() const final;
-
-  /// The candidate memory pool stats used by arbitration.
-  struct Candidate {
-    int64_t reclaimableBytes{0};
-    int64_t freeBytes{0};
-    int64_t reservedBytes{0};
-    MemoryPool* pool;
-
-    std::string toString() const;
-  };
 
   /// Returns 'freeCapacity' back to the arbitrator for testing.
   void testingFreeCapacity(uint64_t freeCapacity);
@@ -99,6 +88,26 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   static inline const std::string kGlobalArbitrationLockWaitWallNanos{
       "globalArbitrationLockWaitWallNanos"};
 
+  /// The candidate memory pool stats used by arbitration.
+  struct Candidate {
+    std::shared_ptr<MemoryPool> pool;
+    int64_t reclaimableBytes{0};
+    int64_t freeBytes{0};
+    int64_t reservedBytes{0};
+
+    Candidate(
+        int64_t _reclaimableBytes,
+        int64_t _freeBytes,
+        int64_t _reservedBytes,
+        std::shared_ptr<MemoryPool> _pool)
+        : pool(std::move(_pool)),
+          reclaimableBytes(_reclaimableBytes),
+          freeBytes(_freeBytes),
+          reservedBytes(_reservedBytes) {}
+
+    std::string toString() const;
+  };
+
  private:
   // The kind string of shared arbitrator.
   inline static const std::string kind_{"SHARED"};
@@ -107,12 +116,11 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   struct ArbitrationOperation {
     MemoryPool* const requestPool;
     MemoryPool* const requestRoot;
-    const std::vector<std::shared_ptr<MemoryPool>>& candidatePools;
     const uint64_t requestBytes;
     // The start time of this arbitration operation.
     const std::chrono::steady_clock::time_point startTime;
 
-    // The stats of candidate memory pools used for memory arbitration.
+    // The candidate memory pools.
     std::vector<Candidate> candidates;
 
     // The time that waits in local arbitration queue.
@@ -124,18 +132,12 @@ class SharedArbitrator : public memory::MemoryArbitrator {
     // The time that waits to acquire the global arbitration lock.
     uint64_t globalArbitrationLockWaitTimeUs{0};
 
-    ArbitrationOperation(
-        uint64_t requestBytes,
-        const std::vector<std::shared_ptr<MemoryPool>>& candidatePools)
-        : ArbitrationOperation(nullptr, requestBytes, candidatePools) {}
+    explicit ArbitrationOperation(uint64_t requestBytes)
+        : ArbitrationOperation(nullptr, requestBytes) {}
 
-    ArbitrationOperation(
-        MemoryPool* _requestor,
-        uint64_t _requestBytes,
-        const std::vector<std::shared_ptr<MemoryPool>>& _candidatePools)
+    ArbitrationOperation(MemoryPool* _requestor, uint64_t _requestBytes)
         : requestPool(_requestor),
           requestRoot(_requestor == nullptr ? nullptr : _requestor->root()),
-          candidatePools(_candidatePools),
           requestBytes(_requestBytes),
           startTime(std::chrono::steady_clock::now()) {}
 
@@ -230,12 +232,29 @@ class SharedArbitrator : public memory::MemoryArbitrator {
       uint64_t& maxGrowTarget,
       uint64_t& minGrowTarget);
 
-  // Invoked to get or refresh the memory stats of the candidate memory pools
-  // for arbitration. If 'freeCapacityOnly' is true, then we only get free
-  // capacity stats for each candidate memory pool.
-  void getCandidateStats(
-      ArbitrationOperation* op,
-      bool freeCapacityOnly = false);
+  // Invoked to get or refresh the candidate memory pools for arbitration. If
+  // 'freeCapacityOnly' is true, then we only get free capacity stats for each
+  // candidate memory pool.
+  void getCandidates(ArbitrationOperation* op, bool freeCapacityOnly = false);
+
+  // Sorts 'candidates' based on reclaimable free capacity in descending order.
+  static void sortCandidatesByReclaimableFreeCapacity(
+      std::vector<Candidate>& candidates);
+
+  // Sorts 'candidates' based on reclaimable used capacity in descending order.
+  static void sortCandidatesByReclaimableUsedCapacity(
+      std::vector<Candidate>& candidates);
+
+  // Sorts 'candidates' based on actual used memory in descending order.
+  static void sortCandidatesByUsage(std::vector<Candidate>& candidates);
+
+  // Finds the candidate with the largest capacity. For 'requestor', the
+  // capacity for comparison including its current capacity and the capacity to
+  // grow.
+  static const SharedArbitrator::Candidate& findCandidateWithLargestCapacity(
+      MemoryPool* requestor,
+      uint64_t targetBytes,
+      const std::vector<Candidate>& candidates);
 
   // Invoked to reclaim free memory capacity from 'candidates' without
   // actually freeing used memory.
@@ -348,14 +367,16 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   int64_t minGrowCapacity(const MemoryPool& pool) const;
 
   // Returns true if 'pool' is under memory arbitration.
-  bool isUnderArbitration(MemoryPool* pool) const;
   bool isUnderArbitrationLocked(MemoryPool* pool) const;
 
   void updateArbitrationRequestStats();
   void updateArbitrationFailureStats();
 
+  mutable folly::SharedMutex poolLock_;
+  std::unordered_map<MemoryPool*, std::weak_ptr<MemoryPool>> candidates_;
+
   // Lock used to protect the arbitrator state.
-  mutable std::mutex mutex_;
+  mutable std::mutex stateLock_;
   tsan_atomic<uint64_t> freeReservedCapacity_{0};
   tsan_atomic<uint64_t> freeNonReservedCapacity_{0};
 
@@ -381,7 +402,6 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   tsan_atomic<uint64_t> reclaimedUsedBytes_{0};
   tsan_atomic<uint64_t> reclaimTimeUs_{0};
   tsan_atomic<uint64_t> numNonReclaimableAttempts_{0};
-  tsan_atomic<uint64_t> numReserves_{0};
-  tsan_atomic<uint64_t> numReleases_{0};
+  tsan_atomic<uint64_t> numShrinks_{0};
 };
 } // namespace facebook::velox::memory

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -26,7 +26,6 @@
 #include <folly/Random.h>
 #include <folly/Range.h>
 #include <gflags/gflags.h>
-#include <glog/logging.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 

--- a/velox/common/memory/tests/MemoryArbitratorTest.cpp
+++ b/velox/common/memory/tests/MemoryArbitratorTest.cpp
@@ -63,14 +63,14 @@ TEST_F(MemoryArbitrationTest, stats) {
   ASSERT_EQ(
       stats.toString(),
       "STATS[numRequests 2 numAborted 3 numFailures 100 "
-      "numNonReclaimableAttempts 5 numReserves 0 numReleases 0 "
+      "numNonReclaimableAttempts 5 numShrinks 0 "
       "queueTime 230.00ms arbitrationTime 1.02ms reclaimTime 1.00ms "
       "shrunkMemory 95.37MB reclaimedMemory 9.77KB "
       "maxCapacity 0B freeCapacity 1.95KB freeReservedCapacity 1000B]");
   ASSERT_EQ(
       fmt::format("{}", stats),
       "STATS[numRequests 2 numAborted 3 numFailures 100 "
-      "numNonReclaimableAttempts 5 numReserves 0 numReleases 0 "
+      "numNonReclaimableAttempts 5 numShrinks 0 "
       "queueTime 230.00ms arbitrationTime 1.02ms reclaimTime 1.00ms "
       "shrunkMemory 95.37MB reclaimedMemory 9.77KB "
       "maxCapacity 0B freeCapacity 1.95KB freeReservedCapacity 1000B]");
@@ -137,10 +137,12 @@ TEST_F(MemoryArbitrationTest, queryMemoryCapacity) {
     auto rootPool =
         manager.addRootPool("root-1", 8L << 20, MemoryReclaimer::create());
     ASSERT_EQ(rootPool->capacity(), 1 << 20);
-    ASSERT_EQ(
-        manager.arbitrator()->growCapacity(rootPool.get(), 1 << 20), 1 << 20);
-    ASSERT_EQ(
-        manager.arbitrator()->growCapacity(rootPool.get(), 6 << 20), 2 << 20);
+    ASSERT_TRUE(manager.arbitrator()->growCapacity(rootPool.get(), 1 << 20));
+    ASSERT_EQ(rootPool->capacity(), 1 << 20);
+    ASSERT_FALSE(manager.arbitrator()->growCapacity(rootPool.get(), 6 << 20));
+    ASSERT_EQ(rootPool->capacity(), 1 << 20);
+    ASSERT_TRUE(manager.arbitrator()->growCapacity(rootPool.get(), 2 << 20));
+    ASSERT_EQ(rootPool->capacity(), 4 << 20);
     ASSERT_EQ(manager.arbitrator()->stats().freeCapacityBytes, 2 << 20);
     ASSERT_EQ(manager.arbitrator()->stats().freeReservedCapacityBytes, 2 << 20);
 
@@ -151,19 +153,19 @@ TEST_F(MemoryArbitrationTest, queryMemoryCapacity) {
         "Exceeded memory pool capacity after attempt to grow capacity through "
         "arbitration. Requestor pool name 'leaf-1.0', request size 7.00MB, "
         "memory pool capacity 4.00MB, memory pool max capacity 8.00MB");
-    ASSERT_NO_THROW(buffer = leafPool->allocate(4L << 20));
-    ASSERT_EQ(manager.arbitrator()->shrinkCapacity(rootPool.get(), 0), 0);
+    ASSERT_EQ(manager.arbitrator()->shrinkCapacity(rootPool.get(), 0), 1 << 20);
     ASSERT_EQ(manager.arbitrator()->shrinkCapacity(leafPool.get(), 0), 0);
     ASSERT_EQ(manager.arbitrator()->shrinkCapacity(leafPool.get(), 1), 0);
     ASSERT_EQ(manager.arbitrator()->shrinkCapacity(rootPool.get(), 1), 0);
-    leafPool->free(buffer, 4L << 20);
+    ASSERT_EQ(rootPool->capacity(), 3 << 20);
+    static_cast<MemoryPoolImpl*>(rootPool.get())->testingSetReservation(0);
     ASSERT_EQ(
         manager.arbitrator()->shrinkCapacity(leafPool.get(), 1 << 20), 1 << 20);
     ASSERT_EQ(
         manager.arbitrator()->shrinkCapacity(rootPool.get(), 1 << 20), 1 << 20);
-    ASSERT_EQ(rootPool->capacity(), 2 << 20);
-    ASSERT_EQ(leafPool->capacity(), 2 << 20);
-    ASSERT_EQ(manager.arbitrator()->shrinkCapacity(leafPool.get(), 0), 2 << 20);
+    ASSERT_EQ(rootPool->capacity(), 1 << 20);
+    ASSERT_EQ(leafPool->capacity(), 1 << 20);
+    ASSERT_EQ(manager.arbitrator()->shrinkCapacity(leafPool.get(), 0), 1 << 20);
     ASSERT_EQ(rootPool->capacity(), 0);
     ASSERT_EQ(leafPool->capacity(), 0);
   }
@@ -307,19 +309,17 @@ TEST_F(MemoryArbitrationTest, reservedCapacityFreeByPoolShrink) {
   pools.push_back(manager.addRootPool("", kMaxMemory));
 
   ASSERT_GE(pools.back()->capacity(), 0);
-  ASSERT_EQ(arbitrator->shrinkCapacity(pools, 1 << 20), 2 << 20);
-  ASSERT_EQ(arbitrator->growCapacity(pools[numPools - 1].get(), 1 << 20), 0);
-  ASSERT_EQ(arbitrator->growCapacity(pools.back().get(), 2 << 20), 1 << 20);
+  ASSERT_EQ(arbitrator->shrinkCapacity(1 << 20), 2 << 20);
 }
 
 TEST_F(MemoryArbitrationTest, arbitratorStats) {
   const MemoryArbitrator::Stats emptyStats;
   ASSERT_TRUE(emptyStats.empty());
   const MemoryArbitrator::Stats anchorStats(
-      5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5);
+      5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5);
   ASSERT_FALSE(anchorStats.empty());
   const MemoryArbitrator::Stats largeStats(
-      8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8);
+      8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8);
   ASSERT_FALSE(largeStats.empty());
   ASSERT_TRUE(!(anchorStats == largeStats));
   ASSERT_TRUE(anchorStats != largeStats);
@@ -329,11 +329,10 @@ TEST_F(MemoryArbitrationTest, arbitratorStats) {
   ASSERT_TRUE(!(anchorStats >= largeStats));
   const auto delta = largeStats - anchorStats;
   ASSERT_EQ(
-      delta,
-      MemoryArbitrator::Stats(3, 3, 3, 3, 3, 3, 3, 3, 8, 8, 8, 3, 3, 3, 3));
+      delta, MemoryArbitrator::Stats(3, 3, 3, 3, 3, 3, 3, 3, 8, 8, 8, 3, 3, 3));
 
   const MemoryArbitrator::Stats smallStats(
-      2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
+      2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
   ASSERT_TRUE(!(anchorStats == smallStats));
   ASSERT_TRUE(anchorStats != smallStats);
   ASSERT_TRUE(!(anchorStats < smallStats));
@@ -342,7 +341,7 @@ TEST_F(MemoryArbitrationTest, arbitratorStats) {
   ASSERT_TRUE(anchorStats >= smallStats);
 
   const MemoryArbitrator::Stats invalidStats(
-      2, 2, 2, 2, 2, 2, 8, 8, 8, 8, 8, 8, 2, 8, 2);
+      2, 2, 2, 2, 2, 2, 8, 8, 8, 8, 8, 2, 8, 2);
   ASSERT_TRUE(!(anchorStats == invalidStats));
   ASSERT_TRUE(anchorStats != invalidStats);
   VELOX_ASSERT_THROW(anchorStats < invalidStats, "");
@@ -365,23 +364,16 @@ class FakeTestArbitrator : public MemoryArbitrator {
     return "USER";
   }
 
-  uint64_t growCapacity(MemoryPool* /*unused*/, uint64_t /*unused*/) override {
-    VELOX_NYI();
-    return 0;
-  }
+  void addPool(const std::shared_ptr<MemoryPool>& pool) override {}
 
-  bool growCapacity(
-      MemoryPool* /*unused*/,
-      const std::vector<std::shared_ptr<MemoryPool>>& /*unused*/,
-      uint64_t /*unused*/) override {
+  void removePool(MemoryPool* pool) override {}
+
+  bool growCapacity(MemoryPool* /*unused*/, uint64_t /*unused*/) override {
     VELOX_NYI();
   }
 
-  uint64_t shrinkCapacity(
-      const std::vector<std::shared_ptr<MemoryPool>>& /*unused*/,
-      uint64_t /*unused*/,
-      bool /*unused*/,
-      bool /*unused*/) override {
+  uint64_t shrinkCapacity(uint64_t /*unused*/, bool /*unused*/, bool /*unused*/)
+      override {
     VELOX_NYI();
   }
 

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -124,19 +124,17 @@ class FakeTestArbitrator : public MemoryArbitrator {
              .memoryPoolTransferCapacity = config.memoryPoolTransferCapacity}) {
   }
 
-  uint64_t growCapacity(MemoryPool* /*unused*/, uint64_t /*unused*/) override {
-    VELOX_NYI();
-  }
+  void addPool(const std::shared_ptr<MemoryPool>& pool) override {}
+
+  void removePool(MemoryPool* pool) override {}
 
   bool growCapacity(
       MemoryPool* /*unused*/,
-      const std::vector<std::shared_ptr<MemoryPool>>& /*unused*/,
       uint64_t /*unused*/) override {
     VELOX_NYI();
   }
 
   uint64_t shrinkCapacity(
-      const std::vector<std::shared_ptr<MemoryPool>>& /*unused*/,
       uint64_t /*unused*/,
       bool /*unused*/,
       bool /*unused*/) override {

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -2361,6 +2361,7 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, orderedArbitration) {
                   (*candidates)[i - 1].reclaimableBytes);
             }
           })));
+
   folly::Random::DefaultGenerator rng;
   rng.seed(512);
   const uint64_t memCapacity = 512 * MB;

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -526,7 +526,6 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimToOrderBy) {
     const auto newStats = arbitrator_->stats();
     ASSERT_GT(newStats.numReclaimedBytes, oldStats.numReclaimedBytes);
     ASSERT_GT(newStats.reclaimTimeUs, oldStats.reclaimTimeUs);
-    ASSERT_EQ(arbitrator_->stats().numReserves, numAddedPools_);
     ASSERT_GT(orderByQueryCtx->pool()->stats().numCapacityGrowths, 0);
   }
 }
@@ -629,7 +628,6 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimToAggregation) {
     const auto newStats = arbitrator_->stats();
     ASSERT_GT(newStats.numReclaimedBytes, oldStats.numReclaimedBytes);
     ASSERT_GT(newStats.reclaimTimeUs, oldStats.reclaimTimeUs);
-    ASSERT_EQ(newStats.numReserves, numAddedPools_);
   }
 }
 
@@ -742,7 +740,6 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimToJoinBuilder) {
     const auto newStats = arbitrator_->stats();
     ASSERT_GT(newStats.numReclaimedBytes, oldStats.numReclaimedBytes);
     ASSERT_GT(newStats.reclaimTimeUs, oldStats.reclaimTimeUs);
-    ASSERT_EQ(arbitrator_->stats().numReserves, numAddedPools_);
   }
 }
 
@@ -1289,10 +1286,8 @@ TEST_F(SharedArbitrationTest, reserveReleaseCounters) {
         threads.emplace_back([&]() {
           {
             std::lock_guard<std::mutex> l(mutex);
-            auto oldNum = arbitrator_->stats().numReserves;
             queries.emplace_back(
                 newQueryCtx(memoryManager_.get(), executor_.get()));
-            ASSERT_EQ(arbitrator_->stats().numReserves, oldNum + 1);
           }
         });
       }
@@ -1300,11 +1295,9 @@ TEST_F(SharedArbitrationTest, reserveReleaseCounters) {
       for (auto& queryThread : threads) {
         queryThread.join();
       }
-      ASSERT_EQ(arbitrator_->stats().numReserves, numRootPools);
-      ASSERT_EQ(arbitrator_->stats().numReleases, 0);
+      ASSERT_EQ(arbitrator_->stats().numShrinks, 0);
     }
-    ASSERT_EQ(arbitrator_->stats().numReserves, numRootPools);
-    ASSERT_EQ(arbitrator_->stats().numReleases, numRootPools);
+    ASSERT_EQ(arbitrator_->stats().numShrinks, numRootPools);
   }
 }
 } // namespace facebook::velox::memory


### PR DESCRIPTION
In current implementation, memory manager tracks the liveness of query memory pools. For each
memory arbitration, it makes a copy of all the alive memory pools and pass them to the memory 
arbitrator which is not required most of the time. This PR changes to let memory arbitrator track the
memory pools directly to avoid this cost. This also enables the global memory arbitration optimizations
in followup