### PR TITLE
Let memory arbitration directly track the liveness of query memory pools

### DIFF
--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -242,15 +242,13 @@ class TestStatsReportMemoryArbitrator : public memory::MemoryArbitrator {
     return "test";
   }
 
-  uint64_t growCapacity(memory::MemoryPool* /*unused*/, uint64_t /*unused*/)
-      override {
-    return 0;
+  void addPool(const std::shared_ptr<memory::MemoryPool>& /*unused*/) override {
   }
 
-  bool growCapacity(
-      memory::MemoryPool* /*unused*/,
-      const std::vector<std::shared_ptr<memory::MemoryPool>>& /*unused*/,
-      uint64_t /*unused*/) override {
+  void removePool(memory::MemoryPool* /*unused*/) override {}
+
+  bool growCapacity(memory::MemoryPool* /*unused*/, uint64_t /*unused*/)
+      override {
     return false;
   }
 
@@ -259,11 +257,8 @@ class TestStatsReportMemoryArbitrator : public memory::MemoryArbitrator {
     return 0;
   }
 
-  uint64_t shrinkCapacity(
-      const std::vector<std::shared_ptr<memory::MemoryPool>>& /*unused*/,
-      uint64_t /*unused*/,
-      bool /*unused*/,
-      bool /*unused*/) override {
+  uint64_t shrinkCapacity(uint64_t /*unused*/, bool /*unused*/, bool /*unused*/)
+      override {
     return 0;
   }
 
@@ -546,7 +541,7 @@ TEST_F(PeriodicStatsReporterTest, basic) {
        .sumEvictScore = 10,
        .ssdStats = newSsdStats});
   arbitrator.updateStats(memory::MemoryArbitrator::Stats(
-      10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10));
+      10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10));
   std::this_thread::sleep_for(std::chrono::milliseconds(4'000));
 
   // Stop right after sufficient wait to ensure the following reads from main

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -19,6 +19,7 @@
 #include "velox/common/memory/MemoryArbitrator.h"
 
 #include "velox/common/base/Counters.h"
+#include "velox/common/base/GTestMacros.h"
 #include "velox/common/base/StatsReporter.h"
 #include "velox/common/future/VeloxPromise.h"
 #include "velox/common/memory/Memory.h"
@@ -41,6 +42,14 @@ class SharedArbitrator : public memory::MemoryArbitrator {
     static constexpr std::string_view kReservedCapacity{"reserved-capacity"};
     static constexpr int64_t kDefaultReservedCapacity{0};
     static int64_t getReservedCapacity(
+        const std::unordered_map<std::string, std::string>& configs);
+
+    /// The initial memory capacity to reserve for a newly created query memory
+    /// pool.
+    static constexpr std::string_view kMemoryPoolInitialCapacity{
+        "memory-pool-initial-capacity"};
+    static constexpr uint64_t kDefaultMemoryPoolInitialCapacity{256 << 20};
+    static uint64_t getMemoryPoolInitialCapacity(
         const std::unordered_map<std::string, std::string>& configs);
 
     /// The minimal amount of memory capacity reserved for each query to run.
@@ -95,17 +104,15 @@ class SharedArbitrator : public memory::MemoryArbitrator {
 
   static void unregisterFactory();
 
-  uint64_t growCapacity(MemoryPool* pool, uint64_t requestBytes) final;
+  void addPool(const std::shared_ptr<MemoryPool>& pool) final;
 
-  bool growCapacity(
-      MemoryPool* pool,
-      const std::vector<std::shared_ptr<MemoryPool>>& candidatePools,
-      uint64_t requestBytes) final;
+  void removePool(MemoryPool* pool) final;
+
+  bool growCapacity(MemoryPool* pool, uint64_t requestBytes) final;
 
   uint64_t shrinkCapacity(MemoryPool* pool, uint64_t requestBytes) final;
 
   uint64_t shrinkCapacity(
-      const std::vector<std::shared_ptr<MemoryPool>>& pools,
       uint64_t requestBytes,
       bool allowSpill = true,
       bool force = false) override final;
@@ -115,16 +122,6 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   std::string kind() const override;
 
   std::string toString() const final;
-
-  /// The candidate memory pool stats used by arbitration.
-  struct Candidate {
-    int64_t reclaimableBytes{0};
-    int64_t freeBytes{0};
-    int64_t reservedBytes{0};
-    MemoryPool* pool;
-
-    std::string toString() const;
-  };
 
   /// Returns 'freeCapacity' back to the arbitrator for testing.
   void testingFreeCapacity(uint64_t freeCapacity);
@@ -151,6 +148,16 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   static inline const std::string kGlobalArbitrationLockWaitWallNanos{
       "globalArbitrationLockWaitWallNanos"};
 
+  /// The candidate memory pool stats used by arbitration.
+  struct Candidate {
+    std::shared_ptr<MemoryPool> pool;
+    int64_t reclaimableBytes{0};
+    int64_t freeBytes{0};
+    int64_t reservedBytes{0};
+
+    std::string toString() const;
+  };
+
  private:
   // The kind string of shared arbitrator.
   inline static const std::string kind_{"SHARED"};
@@ -159,12 +166,11 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   struct ArbitrationOperation {
     MemoryPool* const requestPool;
     MemoryPool* const requestRoot;
-    const std::vector<std::shared_ptr<MemoryPool>>& candidatePools;
     const uint64_t requestBytes;
     // The start time of this arbitration operation.
     const std::chrono::steady_clock::time_point startTime;
 
-    // The stats of candidate memory pools used for memory arbitration.
+    // The candidate memory pools.
     std::vector<Candidate> candidates;
 
     // The time that waits in local arbitration queue.
@@ -176,18 +182,12 @@ class SharedArbitrator : public memory::MemoryArbitrator {
     // The time that waits to acquire the global arbitration lock.
     uint64_t globalArbitrationLockWaitTimeUs{0};
 
-    ArbitrationOperation(
-        uint64_t requestBytes,
-        const std::vector<std::shared_ptr<MemoryPool>>& candidatePools)
-        : ArbitrationOperation(nullptr, requestBytes, candidatePools) {}
+    explicit ArbitrationOperation(uint64_t requestBytes)
+        : ArbitrationOperation(nullptr, requestBytes) {}
 
-    ArbitrationOperation(
-        MemoryPool* _requestor,
-        uint64_t _requestBytes,
-        const std::vector<std::shared_ptr<MemoryPool>>& _candidatePools)
+    ArbitrationOperation(MemoryPool* _requestor, uint64_t _requestBytes)
         : requestPool(_requestor),
           requestRoot(_requestor == nullptr ? nullptr : _requestor->root()),
-          candidatePools(_candidatePools),
           requestBytes(_requestBytes),
           startTime(std::chrono::steady_clock::now()) {}
 
@@ -282,12 +282,29 @@ class SharedArbitrator : public memory::MemoryArbitrator {
       uint64_t& maxGrowTarget,
       uint64_t& minGrowTarget);
 
-  // Invoked to get or refresh the memory stats of the candidate memory pools
-  // for arbitration. If 'freeCapacityOnly' is true, then we only get free
-  // capacity stats for each candidate memory pool.
-  void getCandidateStats(
-      ArbitrationOperation* op,
-      bool freeCapacityOnly = false);
+  // Invoked to get or refresh the candidate memory pools for arbitration. If
+  // 'freeCapacityOnly' is true, then we only get free capacity stats for each
+  // candidate memory pool.
+  void getCandidates(ArbitrationOperation* op, bool freeCapacityOnly = false);
+
+  // Sorts 'candidates' based on reclaimable free capacity in descending order.
+  static void sortCandidatesByReclaimableFreeCapacity(
+      std::vector<Candidate>& candidates);
+
+  // Sorts 'candidates' based on reclaimable used capacity in descending order.
+  static void sortCandidatesByReclaimableUsedCapacity(
+      std::vector<Candidate>& candidates);
+
+  // Sorts 'candidates' based on actual used memory in descending order.
+  static void sortCandidatesByUsage(std::vector<Candidate>& candidates);
+
+  // Finds the candidate with the largest capacity. For 'requestor', the
+  // capacity for comparison including its current capacity and the capacity to
+  // grow.
+  static const SharedArbitrator::Candidate& findCandidateWithLargestCapacity(
+      MemoryPool* requestor,
+      uint64_t targetBytes,
+      const std::vector<Candidate>& candidates);
 
   // Invoked to reclaim free memory capacity from 'candidates' without
   // actually freeing used memory.
@@ -400,21 +417,25 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   int64_t minGrowCapacity(const MemoryPool& pool) const;
 
   // Returns true if 'pool' is under memory arbitration.
-  bool isUnderArbitration(MemoryPool* pool) const;
   bool isUnderArbitrationLocked(MemoryPool* pool) const;
 
   void updateArbitrationRequestStats();
+
   void updateArbitrationFailureStats();
 
   const uint64_t reservedCapacity_;
+  const uint64_t memoryPoolInitialCapacity_;
   const uint64_t memoryPoolReservedCapacity_;
   const uint64_t memoryPoolTransferCapacity_;
   const uint64_t memoryReclaimWaitMs_;
   const bool globalArbitrationEnabled_;
   const bool checkUsageLeak_;
 
+  mutable folly::SharedMutex poolLock_;
+  std::unordered_map<MemoryPool*, std::weak_ptr<MemoryPool>> candidates_;
+
   // Lock used to protect the arbitrator state.
-  mutable std::mutex mutex_;
+  mutable std::mutex stateLock_;
   tsan_atomic<uint64_t> freeReservedCapacity_{0};
   tsan_atomic<uint64_t> freeNonReservedCapacity_{0};
 
@@ -440,7 +461,6 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   tsan_atomic<uint64_t> reclaimedUsedBytes_{0};
   tsan_atomic<uint64_t> reclaimTimeUs_{0};
   tsan_atomic<uint64_t> numNonReclaimableAttempts_{0};
-  tsan_atomic<uint64_t> numReserves_{0};
-  tsan_atomic<uint64_t> numReleases_{0};
+  tsan_atomic<uint64_t> numShrinks_{0};
 };
 } // namespace facebook::velox::memory

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -26,7 +26,6 @@
 #include <folly/Random.h>
 #include <folly/Range.h>
 #include <gflags/gflags.h>
-#include <glog/logging.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -108,7 +108,7 @@ TEST_F(MemoryManagerTest, ctor) {
         "allocated pages 0 mapped pages 0]\n"
         "ARBITRATOR[SHARED CAPACITY[4.00GB] PENDING[0] "
         "STATS[numRequests 0 numAborted 0 numFailures 0 "
-        "numNonReclaimableAttempts 0 numReserves 0 numReleases 0 queueTime 0us "
+        "numNonReclaimableAttempts 0 numShrinks 0 queueTime 0us "
         "arbitrationTime 0us reclaimTime 0us shrunkMemory 0B "
         "reclaimedMemory 0B maxCapacity 4.00GB freeCapacity 4.00GB freeReservedCapacity 0B]]]");
   }
@@ -123,22 +123,16 @@ class FakeTestArbitrator : public MemoryArbitrator {
              .capacity = config.capacity,
              .extraConfigs = config.extraConfigs}) {}
 
-  uint64_t growCapacity(MemoryPool* /*unused*/, uint64_t /*unused*/) override {
+  void addPool(const std::shared_ptr<MemoryPool>& /*unused*/) override {}
+
+  void removePool(MemoryPool* /*unused*/) override {}
+
+  bool growCapacity(MemoryPool* /*unused*/, uint64_t /*unused*/) override {
     VELOX_NYI();
   }
 
-  bool growCapacity(
-      MemoryPool* /*unused*/,
-      const std::vector<std::shared_ptr<MemoryPool>>& /*unused*/,
-      uint64_t /*unused*/) override {
-    VELOX_NYI();
-  }
-
-  uint64_t shrinkCapacity(
-      const std::vector<std::shared_ptr<MemoryPool>>& /*unused*/,
-      uint64_t /*unused*/,
-      bool /*unused*/,
-      bool /*unused*/) override {
+  uint64_t shrinkCapacity(uint64_t /*unused*/, bool /*unused*/, bool /*unused*/)
+      override {
     VELOX_NYI();
   }
 

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -2446,6 +2446,7 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, orderedArbitration) {
                   (*candidates)[i - 1].reclaimableBytes);
             }
           })));
+
   folly::Random::DefaultGenerator rng;
   rng.seed(512);
   const uint64_t memCapacity = 512 * MB;

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -526,7 +526,6 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimToOrderBy) {
     const auto newStats = arbitrator_->stats();
     ASSERT_GT(newStats.numReclaimedBytes, oldStats.numReclaimedBytes);
     ASSERT_GT(newStats.reclaimTimeUs, oldStats.reclaimTimeUs);
-    ASSERT_EQ(arbitrator_->stats().numReserves, numAddedPools_);
     ASSERT_GT(orderByQueryCtx->pool()->stats().numCapacityGrowths, 0);
   }
 }
@@ -629,7 +628,6 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimToAggregation) {
     const auto newStats = arbitrator_->stats();
     ASSERT_GT(newStats.numReclaimedBytes, oldStats.numReclaimedBytes);
     ASSERT_GT(newStats.reclaimTimeUs, oldStats.reclaimTimeUs);
-    ASSERT_EQ(newStats.numReserves, numAddedPools_);
   }
 }
 
@@ -742,7 +740,6 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimToJoinBuilder) {
     const auto newStats = arbitrator_->stats();
     ASSERT_GT(newStats.numReclaimedBytes, oldStats.numReclaimedBytes);
     ASSERT_GT(newStats.reclaimTimeUs, oldStats.reclaimTimeUs);
-    ASSERT_EQ(arbitrator_->stats().numReserves, numAddedPools_);
   }
 }
 
@@ -1289,10 +1286,8 @@ TEST_F(SharedArbitrationTest, reserveReleaseCounters) {
         threads.emplace_back([&]() {
           {
             std::lock_guard<std::mutex> l(mutex);
-            auto oldNum = arbitrator_->stats().numReserves;
             queries.emplace_back(
                 newQueryCtx(memoryManager_.get(), executor_.get()));
-            ASSERT_EQ(arbitrator_->stats().numReserves, oldNum + 1);
           }
         });
       }
@@ -1300,11 +1295,9 @@ TEST_F(SharedArbitrationTest, reserveReleaseCounters) {
       for (auto& queryThread : threads) {
         queryThread.join();
       }
-      ASSERT_EQ(arbitrator_->stats().numReserves, numRootPools);
-      ASSERT_EQ(arbitrator_->stats().numReleases, 0);
+      ASSERT_EQ(arbitrator_->stats().numShrinks, 0);
     }
-    ASSERT_EQ(arbitrator_->stats().numReserves, numRootPools);
-    ASSERT_EQ(arbitrator_->stats().numReleases, numRootPools);
+    ASSERT_EQ(arbitrator_->stats().numShrinks, numRootPools);
   }
 }
 } // namespace facebook::velox::memory

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -7287,7 +7287,6 @@ DEBUG_ONLY_TEST_F(HashJoinTest, joinBuildSpillError) {
 
   waitForAllTasksToBeDeleted();
   ASSERT_EQ(arbitrator->stats().numFailures, 1);
-  ASSERT_EQ(arbitrator->stats().numReserves, 1);
 
   // Wait again here as this test uses on-demand created memory manager instead
   // of the global one. We need to make sure any used memory got cleaned up

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -3742,8 +3742,7 @@ DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, writerFlushThreshold) {
     ASSERT_GE(arbitrator->stats().numReclaimedBytes, testParam.bytesToReserve);
     waitForAllTasksToBeDeleted(3'000'000);
     queryCtx.reset();
-    ASSERT_EQ(arbitrator->stats().numReserves, 1);
-    ASSERT_EQ(arbitrator->stats().numReleases, 1);
+    ASSERT_EQ(arbitrator->stats().numShrinks, 1);
   }
 }
 
@@ -3823,7 +3822,6 @@ DEBUG_ONLY_TEST_F(
 
   ASSERT_EQ(arbitrator->stats().numFailures, 1);
   ASSERT_EQ(arbitrator->stats().numNonReclaimableAttempts, 1);
-  ASSERT_EQ(arbitrator->stats().numReserves, 1);
   waitForAllTasksToBeDeleted();
 }
 
@@ -3916,7 +3914,6 @@ DEBUG_ONLY_TEST_F(
   ASSERT_EQ(arbitrator->stats().numNonReclaimableAttempts, 0);
   ASSERT_EQ(arbitrator->stats().numFailures, 0);
   ASSERT_GT(arbitrator->stats().numReclaimedBytes, 0);
-  ASSERT_EQ(arbitrator->stats().numReserves, 1);
   waitForAllTasksToBeDeleted();
 }
 
@@ -4014,7 +4011,6 @@ DEBUG_ONLY_TEST_F(
 
   ASSERT_EQ(arbitrator->stats().numFailures, 1);
   ASSERT_EQ(arbitrator->stats().numNonReclaimableAttempts, 1);
-  ASSERT_EQ(arbitrator->stats().numReserves, 1);
   const auto updatedSpillStats = common::globalSpillStats();
   ASSERT_EQ(updatedSpillStats, spillStats);
   waitForAllTasksToBeDeleted();


### PR DESCRIPTION
In current implementation, memory manager tracks the liveness of query memory pools. For each memory arbitration, it makes a copy of all the alive memory pools and pass them to the memory arbitrator which is not required most of the time. This PR changes to let memory arbitrator track the memory pools directly to avoid this cost. This also enables the global memory arbitration optimizations in followup. The Meta internal shadow run shows 4% cpu reduction.