### PR TITLE
Enable more combinations in join fuzzer

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -27,9 +27,7 @@ namespace facebook::velox::core {
 
 typedef std::string PlanNodeId;
 
-/**
- * Generic representation of InsertTable
- */
+/// Generic representation of InsertTable
 struct InsertTableHandle {
  public:
   InsertTableHandle(
@@ -1643,22 +1641,16 @@ class MergeJoinNode : public AbstractJoinNode {
       TypedExprPtr filter,
       PlanNodePtr left,
       PlanNodePtr right,
-      RowTypePtr outputType)
-      : AbstractJoinNode(
-            id,
-            joinType,
-            leftKeys,
-            rightKeys,
-            std::move(filter),
-            std::move(left),
-            std::move(right),
-            std::move(outputType)) {}
+      RowTypePtr outputType);
 
   std::string_view name() const override {
     return "MergeJoin";
   }
 
   folly::dynamic serialize() const override;
+
+  /// If merge join supports this join type.
+  static bool isSupported(core::JoinType joinType);
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
 };
@@ -1667,7 +1659,7 @@ class MergeJoinNode : public AbstractJoinNode {
 /// exec::NestedLoopJoinProbe and exec::NestedLoopJoinBuild. A separate pipeline
 /// is produced for the build side when generating exec::Operators.
 ///
-/// Nested loop join supports both equal and non-equal joins. Expressions
+/// Nested loop join (NLJ) supports both equal and non-equal joins. Expressions
 /// specified in joinCondition are evaluated on every combination of left/right
 /// tuple, to emit result. Results are emitted following the same input order of
 /// probe rows for inner and left joins, for each thread of execution.
@@ -1711,6 +1703,9 @@ class NestedLoopJoinNode : public PlanNode {
   }
 
   folly::dynamic serialize() const override;
+
+  /// If nested loop join supports this join type.
+  static bool isSupported(core::JoinType joinType);
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
 

--- a/velox/exec/MergeJoin.cpp
+++ b/velox/exec/MergeJoin.cpp
@@ -35,25 +35,9 @@ MergeJoin::MergeJoin(
       numKeys_{joinNode->leftKeys().size()},
       joinNode_(joinNode) {
   VELOX_USER_CHECK(
-      isSupported(joinNode_->joinType()),
+      core::MergeJoinNode::isSupported(joinNode_->joinType()),
       "The join type is not supported by merge join: ",
       joinTypeName(joinNode_->joinType()));
-}
-
-// static
-bool MergeJoin::isSupported(core::JoinType joinType) {
-  switch (joinType) {
-    case core::JoinType::kInner:
-    case core::JoinType::kLeft:
-    case core::JoinType::kRight:
-    case core::JoinType::kLeftSemiFilter:
-    case core::JoinType::kRightSemiFilter:
-    case core::JoinType::kAnti:
-      return true;
-
-    default:
-      return false;
-  }
 }
 
 void MergeJoin::initialize() {

--- a/velox/exec/MergeJoin.h
+++ b/velox/exec/MergeJoin.h
@@ -68,9 +68,6 @@ class MergeJoin : public Operator {
     Operator::close();
   }
 
-  /// If merge join supports this join type.
-  static bool isSupported(core::JoinType joinType);
-
  private:
   // Sets up 'filter_' and related member variables.
   void initializeFilter(


### PR DESCRIPTION
Summary:
Refactoring the isSupported() method for MergeJoin and NestedLoopJoin
to centralize them, and enabling a few types not tested in JoinFuzzer today.

Reviewed By: xiaoxmeng

Differential Revision: D60797642
