### PR TITLE
Document Spark version for Spark functions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,6 +182,7 @@ with a benchmark.
    * Describe the function semantics and edge cases clearly.
 
 3. Use Presto or Spark to check the function semantics. 
+   * When implementing a Spark function, check the function semantics using Spark 3.5 with ANSI OFF.
    * Try different edge cases to check whether the function returns null, or
    throws, etc. 
    * Make sure to replicate the exact semantics.

--- a/velox/docs/spark_functions.rst
+++ b/velox/docs/spark_functions.rst
@@ -2,6 +2,8 @@
 Spark Functions
 ***********************
 
+The semantics of Spark functions match Spark 3.5 with ANSI OFF.
+
 .. toctree::
     :maxdepth: 1
 


### PR DESCRIPTION
The semantics of certain Spark functions vary between versions. This PR 
documents the Spark version to match when implementing a Spark function.