### PR TITLE
Wave Metrics

### DIFF
--- a/velox/benchmarks/CMakeLists.txt
+++ b/velox/benchmarks/CMakeLists.txt
@@ -39,3 +39,27 @@ if(${VELOX_ENABLE_BENCHMARKS})
   add_subdirectory(tpch)
   add_subdirectory(filesystem)
 endif()
+
+add_library(velox_query_benchmark QueryBenchmarkBase.cpp)
+target_link_libraries(
+  velox_query_benchmark
+  velox_aggregates
+  velox_exec
+  velox_exec_test_lib
+  velox_dwio_common
+  velox_dwio_common_exception
+  velox_dwio_parquet_reader
+  velox_dwio_common_test_utils
+  velox_hive_connector
+  velox_exception
+  velox_memory
+  velox_process
+  velox_serialization
+  velox_encode
+  velox_type
+  velox_type_fbhive
+  velox_caching
+  velox_vector_test_lib
+  ${FOLLY_BENCHMARK}
+  Folly::folly
+  fmt::fmt)

--- a/velox/benchmarks/QueryBenchmarkBase.cpp
+++ b/velox/benchmarks/QueryBenchmarkBase.cpp
@@ -1,0 +1,391 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/benchmarks/QueryBenchmarkBase.h"
+
+DEFINE_string(data_format, "parquet", "Data format");
+
+DEFINE_validator(
+    data_format,
+    &facebook::velox::QueryBenchmarkBase::validateDataFormat);
+
+DEFINE_bool(
+    include_custom_stats,
+    false,
+    "Include custom statistics along with execution statistics");
+DEFINE_bool(include_results, false, "Include results in the output");
+DEFINE_int32(num_drivers, 4, "Number of drivers");
+
+DEFINE_int32(num_splits_per_file, 10, "Number of splits per file");
+DEFINE_int32(
+    cache_gb,
+    0,
+    "GB of process memory for cache and query.. if "
+    "non-0, uses mmap to allocator and in-process data cache.");
+DEFINE_int32(num_repeats, 1, "Number of times to run each query");
+DEFINE_int32(num_io_threads, 8, "Threads for speculative IO");
+DEFINE_string(
+    test_flags_file,
+    "",
+    "Path to a file containing gflafs and "
+    "values to try. Produces results for each flag combination "
+    "sorted on performance");
+DEFINE_bool(
+    full_sorted_stats,
+    true,
+    "Add full stats to the report on  --test_flags_file");
+
+DEFINE_string(ssd_path, "", "Directory for local SSD cache");
+DEFINE_int32(ssd_cache_gb, 0, "Size of local SSD cache in GB");
+DEFINE_int32(
+    ssd_checkpoint_interval_gb,
+    8,
+    "Checkpoint every n "
+    "GB new data in cache");
+DEFINE_bool(
+    clear_ram_cache,
+    false,
+    "Clear RAM cache before each query."
+    "Flushes in process and OS file system cache (if root on Linux)");
+DEFINE_bool(
+    clear_ssd_cache,
+    false,
+    "Clears SSD cache before "
+    "each query");
+
+DEFINE_bool(
+    warmup_after_clear,
+    false,
+    "Runs one warmup of the query before "
+    "measured run. Use to run warm after clearing caches.");
+
+DEFINE_int64(
+    max_coalesced_bytes,
+    128 << 20,
+    "Maximum size of single coalesced IO");
+
+DEFINE_int32(
+    max_coalesced_distance_bytes,
+    512 << 10,
+    "Maximum distance in bytes in which coalesce will combine requests");
+
+DEFINE_int32(
+    parquet_prefetch_rowgroups,
+    1,
+    "Number of next row groups to "
+    "prefetch. 1 means prefetch the next row group before decoding "
+    "the current one");
+
+DEFINE_int32(split_preload_per_driver, 2, "Prefetch split metadata");
+
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+using namespace facebook::velox::dwio::common;
+
+namespace facebook::velox {
+
+//  static
+bool QueryBenchmarkBase::validateDataFormat(
+    const char* flagname,
+    const std::string& value) {
+  if ((value.compare("parquet") == 0) || (value.compare("dwrf") == 0)) {
+    return true;
+  }
+  std::cout
+      << fmt::format(
+             "Invalid value for --{}: {}. Allowed values are [\"parquet\", \"dwrf\"]",
+             flagname,
+             value)
+      << std::endl;
+  return false;
+}
+
+// static
+void QueryBenchmarkBase::ensureTaskCompletion(exec::Task* task) {
+  // ASSERT_TRUE requires a function with return type void.
+  ASSERT_TRUE(exec::test::waitForTaskCompletion(task));
+}
+
+// static
+void QueryBenchmarkBase::printResults(
+    const std::vector<RowVectorPtr>& results,
+    std::ostream& out) {
+  out << "Results:" << std::endl;
+  bool printType = true;
+  for (const auto& vector : results) {
+    // Print RowType only once.
+    if (printType) {
+      out << vector->type()->asRow().toString() << std::endl;
+      printType = false;
+    }
+    for (vector_size_t i = 0; i < vector->size(); ++i) {
+      out << vector->toString(i) << std::endl;
+    }
+  }
+}
+
+void QueryBenchmarkBase::initialize() {
+  if (FLAGS_cache_gb) {
+    memory::MemoryManagerOptions options;
+    int64_t memoryBytes = FLAGS_cache_gb * (1LL << 30);
+    options.useMmapAllocator = true;
+    options.allocatorCapacity = memoryBytes;
+    options.useMmapArena = true;
+    options.mmapArenaCapacityRatio = 1;
+    memory::MemoryManager::testingSetInstance(options);
+    std::unique_ptr<cache::SsdCache> ssdCache;
+    if (FLAGS_ssd_cache_gb) {
+      constexpr int32_t kNumSsdShards = 16;
+      cacheExecutor_ =
+          std::make_unique<folly::IOThreadPoolExecutor>(kNumSsdShards);
+      const cache::SsdCache::Config config(
+          FLAGS_ssd_path,
+          static_cast<uint64_t>(FLAGS_ssd_cache_gb) << 30,
+          kNumSsdShards,
+          cacheExecutor_.get(),
+          static_cast<uint64_t>(FLAGS_ssd_checkpoint_interval_gb) << 30);
+      ssdCache = std::make_unique<cache::SsdCache>(config);
+    }
+
+    cache_ = cache::AsyncDataCache::create(
+        memory::memoryManager()->allocator(), std::move(ssdCache));
+    cache::AsyncDataCache::setInstance(cache_.get());
+  } else {
+    memory::MemoryManager::testingSetInstance({});
+  }
+  functions::prestosql::registerAllScalarFunctions();
+  aggregate::prestosql::registerAllAggregateFunctions();
+  parse::registerTypeResolver();
+  filesystems::registerLocalFileSystem();
+
+  ioExecutor_ =
+      std::make_unique<folly::IOThreadPoolExecutor>(FLAGS_num_io_threads);
+
+  // Add new values into the hive configuration...
+  auto configurationValues = std::unordered_map<std::string, std::string>();
+  configurationValues[connector::hive::HiveConfig::kMaxCoalescedBytes] =
+      std::to_string(FLAGS_max_coalesced_bytes);
+  configurationValues[connector::hive::HiveConfig::kMaxCoalescedDistanceBytes] =
+      std::to_string(FLAGS_max_coalesced_distance_bytes);
+  configurationValues[connector::hive::HiveConfig::kPrefetchRowGroups] =
+      std::to_string(FLAGS_parquet_prefetch_rowgroups);
+  auto properties = std::make_shared<const config::ConfigBase>(
+      std::move(configurationValues));
+
+  // Create hive connector with config...
+  auto hiveConnector =
+      connector::getConnectorFactory(
+          connector::hive::HiveConnectorFactory::kHiveConnectorName)
+          ->newConnector(kHiveConnectorId, properties, ioExecutor_.get());
+  connector::registerConnector(hiveConnector);
+}
+
+std::vector<std::shared_ptr<connector::ConnectorSplit>>
+QueryBenchmarkBase::listSplits(
+    const std::string& path,
+    int32_t numSplitsPerFile,
+    const exec::test::TpchPlan& plan) {
+  std::vector<std::shared_ptr<connector::ConnectorSplit>> result;
+  auto temp = HiveConnectorTestBase::makeHiveConnectorSplits(
+      path, numSplitsPerFile, plan.dataFileFormat);
+  for (auto& i : temp) {
+    result.push_back(i);
+  }
+  return result;
+}
+
+void QueryBenchmarkBase::shutdown() {
+  if (cache_) {
+    cache_->shutdown();
+  }
+}
+
+std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>>
+QueryBenchmarkBase::run(const TpchPlan& tpchPlan) {
+  int32_t repeat = 0;
+  try {
+    for (;;) {
+      CursorParameters params;
+      params.maxDrivers = FLAGS_num_drivers;
+      params.planNode = tpchPlan.plan;
+      params.queryConfigs[core::QueryConfig::kMaxSplitPreloadPerDriver] =
+          std::to_string(FLAGS_split_preload_per_driver);
+      const int numSplitsPerFile = FLAGS_num_splits_per_file;
+
+      bool noMoreSplits = false;
+      auto addSplits = [&](exec::Task* task) {
+        if (!noMoreSplits) {
+          for (const auto& entry : tpchPlan.dataFiles) {
+            for (const auto& path : entry.second) {
+              auto splits = listSplits(path, numSplitsPerFile, tpchPlan);
+              for (auto split : splits) {
+                task->addSplit(entry.first, exec::Split(std::move(split)));
+              }
+            }
+            task->noMoreSplits(entry.first);
+          }
+        }
+        noMoreSplits = true;
+      };
+      auto result = readCursor(params, addSplits);
+      ensureTaskCompletion(result.first->task().get());
+      if (++repeat >= FLAGS_num_repeats) {
+        return result;
+      }
+    }
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Query terminated with: " << e.what();
+    return {nullptr, std::vector<RowVectorPtr>()};
+  }
+}
+
+void QueryBenchmarkBase::readCombinations() {
+  std::ifstream file(FLAGS_test_flags_file);
+  std::string line;
+  while (std::getline(file, line)) {
+    ParameterDim dim;
+    int32_t previous = 0;
+    for (auto i = 0; i < line.size(); ++i) {
+      if (line[i] == ':') {
+        dim.flag = line.substr(0, i);
+        previous = i + 1;
+      } else if (line[i] == ',') {
+        dim.values.push_back(line.substr(previous, i - previous));
+        previous = i + 1;
+      }
+    }
+    if (previous < line.size()) {
+      dim.values.push_back(line.substr(previous, line.size() - previous));
+    }
+    if (!dim.flag.empty() && !dim.values.empty()) {
+      parameters_.push_back(dim);
+    }
+  }
+}
+
+void QueryBenchmarkBase::runCombinations(int32_t level) {
+  if (level == parameters_.size()) {
+    if (FLAGS_clear_ram_cache) {
+#ifdef linux
+      // system("echo 3 >/proc/sys/vm/drop_caches");
+      bool success = false;
+      auto fd = open("/proc//sys/vm/drop_caches", O_WRONLY);
+      if (fd > 0) {
+        success = write(fd, "3", 1) == 1;
+        close(fd);
+      }
+      if (!success) {
+        LOG(ERROR) << "Failed to clear OS disk cache: errno=" << errno;
+      }
+#endif
+
+      if (cache_) {
+        cache_->clear();
+      }
+    }
+    if (FLAGS_clear_ssd_cache) {
+      if (cache_) {
+        auto ssdCache = cache_->ssdCache();
+        if (ssdCache) {
+          ssdCache->clear();
+        }
+      }
+    }
+    if (FLAGS_warmup_after_clear) {
+      std::stringstream result;
+      RunStats ignore;
+      runMain(result, ignore);
+    }
+    RunStats stats;
+    std::stringstream result;
+    uint64_t micros = 0;
+    {
+      struct rusage start;
+      getrusage(RUSAGE_SELF, &start);
+      MicrosecondTimer timer(&micros);
+      runMain(result, stats);
+      struct rusage final;
+      getrusage(RUSAGE_SELF, &final);
+      auto tvNanos = [](struct timeval tv) {
+        return tv.tv_sec * 1000000000 + tv.tv_usec * 1000;
+      };
+      stats.userNanos = tvNanos(final.ru_utime) - tvNanos(start.ru_utime);
+      stats.systemNanos = tvNanos(final.ru_stime) - tvNanos(start.ru_stime);
+    }
+    stats.micros = micros;
+    stats.output = result.str();
+    for (auto i = 0; i < parameters_.size(); ++i) {
+      std::string name;
+      gflags::GetCommandLineOption(parameters_[i].flag.c_str(), &name);
+      stats.flags[parameters_[i].flag] = name;
+    }
+    runStats_.push_back(std::move(stats));
+  } else {
+    auto& flag = parameters_[level].flag;
+    for (auto& value : parameters_[level].values) {
+      std::string result =
+          gflags::SetCommandLineOption(flag.c_str(), value.c_str());
+      if (result.empty()) {
+        LOG(ERROR) << "Failed to set " << flag << "=" << value;
+      }
+      std::cout << result << std::endl;
+      runCombinations(level + 1);
+    }
+  }
+}
+
+void QueryBenchmarkBase::runOne(std::ostream& out, RunStats& stats) {
+  std::stringstream result;
+  uint64_t micros = 0;
+  {
+    struct rusage start;
+    getrusage(RUSAGE_SELF, &start);
+    MicrosecondTimer timer(&micros);
+    runMain(out, stats);
+    struct rusage final;
+    getrusage(RUSAGE_SELF, &final);
+    auto tvNanos = [](struct timeval tv) {
+      return tv.tv_sec * 1000000000 + tv.tv_usec * 1000;
+    };
+    stats.userNanos = tvNanos(final.ru_utime) - tvNanos(start.ru_utime);
+    stats.systemNanos = tvNanos(final.ru_stime) - tvNanos(start.ru_stime);
+  }
+  stats.micros = micros;
+  stats.output = result.str();
+  out << result.str();
+}
+
+void QueryBenchmarkBase::runAllCombinations() {
+  readCombinations();
+  runCombinations(0);
+  std::sort(
+      runStats_.begin(),
+      runStats_.end(),
+      [](const RunStats& left, const RunStats& right) {
+        return left.micros < right.micros;
+      });
+  for (auto& stats : runStats_) {
+    std::cout << stats.toString(false);
+  }
+  if (FLAGS_full_sorted_stats) {
+    std::cout << "Detail for stats:" << std::endl;
+    for (auto& stats : runStats_) {
+      std::cout << stats.toString(true);
+    }
+  }
+}
+
+} // namespace facebook::velox

--- a/velox/benchmarks/QueryBenchmarkBase.h
+++ b/velox/benchmarks/QueryBenchmarkBase.h
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <fcntl.h>
+#include <sys/resource.h>
+#include <sys/time.h>
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <gflags/gflags.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fstream>
+
+#include "velox/common/base/SuccinctPrinter.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/common/memory/MmapAllocator.h"
+#include "velox/connectors/hive/HiveConfig.h"
+#include "velox/connectors/hive/HiveConnector.h"
+#include "velox/dwio/common/Options.h"
+#include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/Split.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/TpchQueryBuilder.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/parse/TypeResolver.h"
+
+DECLARE_string(test_flags_file);
+DECLARE_bool(include_results);
+DECLARE_bool(include_custom_stats);
+DECLARE_string(data_format);
+
+namespace facebook::velox {
+
+struct RunStats {
+  std::map<std::string, std::string> flags;
+  int64_t micros{0};
+  int64_t rawInputBytes{0};
+  int64_t userNanos{0};
+  int64_t systemNanos{0};
+  std::string output;
+
+  std::string toString(bool detail) {
+    std::stringstream out;
+    out << succinctNanos(micros * 1000) << " "
+        << succinctBytes(rawInputBytes / (micros / 1000000.0)) << "/s raw, "
+        << succinctNanos(userNanos) << " user " << succinctNanos(systemNanos)
+        << " system (" << (100 * (userNanos + systemNanos) / (micros * 1000))
+        << "%), flags: ";
+    for (auto& pair : flags) {
+      out << pair.first << "=" << pair.second << " ";
+    }
+    out << std::endl << "======" << std::endl;
+    if (detail) {
+      out << std::endl << output << std::endl;
+    }
+    return out.str();
+  }
+};
+
+struct ParameterDim {
+  std::string flag;
+  std::vector<std::string> values;
+};
+
+class QueryBenchmarkBase {
+ public:
+  virtual ~QueryBenchmarkBase() = default;
+  virtual void initialize();
+  void shutdown();
+  std::pair<std::unique_ptr<exec::test::TaskCursor>, std::vector<RowVectorPtr>>
+  run(const exec::test::TpchPlan& tpchPlan);
+
+  virtual std::vector<std::shared_ptr<connector::ConnectorSplit>> listSplits(
+      const std::string& path,
+      int32_t numSplitsPerFile,
+      const exec::test::TpchPlan& plan);
+
+  static void ensureTaskCompletion(exec::Task* task);
+
+  static bool validateDataFormat(
+      const char* flagname,
+      const std::string& value);
+
+  static void printResults(
+      const std::vector<RowVectorPtr>& results,
+      std::ostream& out);
+
+  void readCombinations();
+
+  /// Entry point invoked with different settings to run the benchmark.
+  virtual void runMain(std::ostream& out, RunStats& runStats) = 0;
+
+  void runOne(std::ostream& outtt, RunStats& stats);
+
+  void runCombinations(int32_t level);
+
+  void runAllCombinations();
+
+ protected:
+  std::unique_ptr<folly::IOThreadPoolExecutor> ioExecutor_;
+  std::unique_ptr<folly::IOThreadPoolExecutor> cacheExecutor_;
+  std::shared_ptr<memory::MemoryAllocator> allocator_;
+  std::shared_ptr<cache::AsyncDataCache> cache_;
+  // Parameter combinations to try. Each element specifies a flag and possible
+  // values. All permutations are tried.
+  std::vector<ParameterDim> parameters_;
+
+  std::vector<RunStats> runStats_;
+};
+} // namespace facebook::velox

--- a/velox/benchmarks/tpch/CMakeLists.txt
+++ b/velox/benchmarks/tpch/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(velox_tpch_benchmark_lib TpchBenchmark.cpp)
 
 target_link_libraries(
   velox_tpch_benchmark_lib
+  velox_query_benchmark
   velox_aggregates
   velox_exec
   velox_exec_test_lib

--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -14,74 +14,12 @@
  * limitations under the License.
  */
 
-#include <fcntl.h>
-#include <sys/resource.h>
-#include <sys/time.h>
-
-#include <folly/Benchmark.h>
-#include <folly/init/Init.h>
-#include <gflags/gflags.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <fstream>
-
-#include "velox/common/base/SuccinctPrinter.h"
-#include "velox/common/file/FileSystems.h"
-#include "velox/common/memory/MmapAllocator.h"
-#include "velox/connectors/hive/HiveConfig.h"
-#include "velox/connectors/hive/HiveConnector.h"
-#include "velox/dwio/common/Options.h"
-#include "velox/exec/PlanNodeStats.h"
-#include "velox/exec/Split.h"
-#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
-#include "velox/exec/tests/utils/TpchQueryBuilder.h"
-#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
-#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
-#include "velox/parse/TypeResolver.h"
+#include "velox/benchmarks/QueryBenchmarkBase.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
 using namespace facebook::velox::dwio::common;
-
-namespace {
-static bool notEmpty(const char* /*flagName*/, const std::string& value) {
-  return !value.empty();
-}
-
-static bool validateDataFormat(const char* flagname, const std::string& value) {
-  if ((value.compare("parquet") == 0) || (value.compare("dwrf") == 0)) {
-    return true;
-  }
-  std::cout
-      << fmt::format(
-             "Invalid value for --{}: {}. Allowed values are [\"parquet\", \"dwrf\"]",
-             flagname,
-             value)
-      << std::endl;
-  return false;
-}
-
-void ensureTaskCompletion(exec::Task* task) {
-  // ASSERT_TRUE requires a function with return type void.
-  ASSERT_TRUE(waitForTaskCompletion(task));
-}
-
-void printResults(const std::vector<RowVectorPtr>& results, std::ostream& out) {
-  out << "Results:" << std::endl;
-  bool printType = true;
-  for (const auto& vector : results) {
-    // Print RowType only once.
-    if (printType) {
-      out << vector->type()->asRow().toString() << std::endl;
-      printType = false;
-    }
-    for (vector_size_t i = 0; i < vector->size(); ++i) {
-      out << vector->toString(i) << std::endl;
-    }
-  }
-}
-} // namespace
 
 DEFINE_string(
     data_path,
@@ -100,6 +38,13 @@ DEFINE_string(
     "each table. If they are files, they contain a file system path for each "
     "data file, one per line. This allows running against cloud storage or "
     "HDFS");
+namespace {
+static bool notEmpty(const char* /*flagName*/, const std::string& value) {
+  return !value.empty();
+}
+} // namespace
+
+DEFINE_validator(data_path, &notEmpty);
 
 DEFINE_int32(
     run_query_verbose,
@@ -112,216 +57,11 @@ DEFINE_int32(
     "include in IO meter query. The columns are sorted by name and the n% first "
     "are scanned");
 
-DEFINE_bool(
-    include_custom_stats,
-    false,
-    "Include custom statistics along with execution statistics");
-DEFINE_bool(include_results, false, "Include results in the output");
-DEFINE_int32(num_drivers, 4, "Number of drivers");
-DEFINE_string(data_format, "parquet", "Data format");
-DEFINE_int32(num_splits_per_file, 10, "Number of splits per file");
-DEFINE_int32(
-    cache_gb,
-    0,
-    "GB of process memory for cache and query.. if "
-    "non-0, uses mmap to allocator and in-process data cache.");
-DEFINE_int32(num_repeats, 1, "Number of times to run each query");
-DEFINE_int32(num_io_threads, 8, "Threads for speculative IO");
-DEFINE_string(
-    test_flags_file,
-    "",
-    "Path to a file containing gflafs and "
-    "values to try. Produces results for each flag combination "
-    "sorted on performance");
-DEFINE_bool(
-    full_sorted_stats,
-    true,
-    "Add full stats to the report on  --test_flags_file");
-
-DEFINE_string(ssd_path, "", "Directory for local SSD cache");
-DEFINE_int32(ssd_cache_gb, 0, "Size of local SSD cache in GB");
-DEFINE_int32(
-    ssd_checkpoint_interval_gb,
-    8,
-    "Checkpoint every n "
-    "GB new data in cache");
-DEFINE_bool(
-    clear_ram_cache,
-    false,
-    "Clear RAM cache before each query."
-    "Flushes in process and OS file system cache (if root on Linux)");
-DEFINE_bool(
-    clear_ssd_cache,
-    false,
-    "Clears SSD cache before "
-    "each query");
-
-DEFINE_bool(
-    warmup_after_clear,
-    false,
-    "Runs one warmup of the query before "
-    "measured run. Use to run warm after clearing caches.");
-
-DEFINE_validator(data_path, &notEmpty);
-DEFINE_validator(data_format, &validateDataFormat);
-
-DEFINE_int64(
-    max_coalesced_bytes,
-    128 << 20,
-    "Maximum size of single coalesced IO");
-
-DEFINE_int32(
-    max_coalesced_distance_bytes,
-    512 << 10,
-    "Maximum distance in bytes in which coalesce will combine requests");
-
-DEFINE_int32(
-    parquet_prefetch_rowgroups,
-    1,
-    "Number of next row groups to "
-    "prefetch. 1 means prefetch the next row group before decoding "
-    "the current one");
-
-DEFINE_int32(split_preload_per_driver, 2, "Prefetch split metadata");
-
-struct RunStats {
-  std::map<std::string, std::string> flags;
-  int64_t micros{0};
-  int64_t rawInputBytes{0};
-  int64_t userNanos{0};
-  int64_t systemNanos{0};
-  std::string output;
-
-  std::string toString(bool detail) {
-    std::stringstream out;
-    out << succinctNanos(micros * 1000) << " "
-        << succinctBytes(rawInputBytes / (micros / 1000000.0)) << "/s raw, "
-        << succinctNanos(userNanos) << " user " << succinctNanos(systemNanos)
-        << " system (" << (100 * (userNanos + systemNanos) / (micros * 1000))
-        << "%), flags: ";
-    for (auto& pair : flags) {
-      out << pair.first << "=" << pair.second << " ";
-    }
-    out << std::endl << "======" << std::endl;
-    if (detail) {
-      out << std::endl << output << std::endl;
-    }
-    return out.str();
-  }
-};
-
-struct ParameterDim {
-  std::string flag;
-  std::vector<std::string> values;
-};
-
 std::shared_ptr<TpchQueryBuilder> queryBuilder;
 
-class TpchBenchmark {
+class TpchBenchmark : public QueryBenchmarkBase {
  public:
-  void initialize() {
-    if (FLAGS_cache_gb) {
-      memory::MemoryManagerOptions options;
-      int64_t memoryBytes = FLAGS_cache_gb * (1LL << 30);
-      options.useMmapAllocator = true;
-      options.allocatorCapacity = memoryBytes;
-      options.useMmapArena = true;
-      options.mmapArenaCapacityRatio = 1;
-      memory::MemoryManager::testingSetInstance(options);
-      std::unique_ptr<cache::SsdCache> ssdCache;
-      if (FLAGS_ssd_cache_gb) {
-        constexpr int32_t kNumSsdShards = 16;
-        cacheExecutor_ =
-            std::make_unique<folly::IOThreadPoolExecutor>(kNumSsdShards);
-        const cache::SsdCache::Config config(
-            FLAGS_ssd_path,
-            static_cast<uint64_t>(FLAGS_ssd_cache_gb) << 30,
-            kNumSsdShards,
-            cacheExecutor_.get(),
-            static_cast<uint64_t>(FLAGS_ssd_checkpoint_interval_gb) << 30);
-        ssdCache = std::make_unique<cache::SsdCache>(config);
-      }
-
-      cache_ = cache::AsyncDataCache::create(
-          memory::memoryManager()->allocator(), std::move(ssdCache));
-      cache::AsyncDataCache::setInstance(cache_.get());
-    } else {
-      memory::MemoryManager::testingSetInstance({});
-    }
-    functions::prestosql::registerAllScalarFunctions();
-    aggregate::prestosql::registerAllAggregateFunctions();
-    parse::registerTypeResolver();
-    filesystems::registerLocalFileSystem();
-
-    ioExecutor_ =
-        std::make_unique<folly::IOThreadPoolExecutor>(FLAGS_num_io_threads);
-
-    // Add new values into the hive configuration...
-    auto configurationValues = std::unordered_map<std::string, std::string>();
-    configurationValues[connector::hive::HiveConfig::kMaxCoalescedBytes] =
-        std::to_string(FLAGS_max_coalesced_bytes);
-    configurationValues
-        [connector::hive::HiveConfig::kMaxCoalescedDistanceBytes] =
-            std::to_string(FLAGS_max_coalesced_distance_bytes);
-    configurationValues[connector::hive::HiveConfig::kPrefetchRowGroups] =
-        std::to_string(FLAGS_parquet_prefetch_rowgroups);
-    auto properties = std::make_shared<const config::ConfigBase>(
-        std::move(configurationValues));
-
-    // Create hive connector with config...
-    auto hiveConnector =
-        connector::getConnectorFactory(
-            connector::hive::HiveConnectorFactory::kHiveConnectorName)
-            ->newConnector(kHiveConnectorId, properties, ioExecutor_.get());
-    connector::registerConnector(hiveConnector);
-  }
-
-  void shutdown() {
-    cache_->shutdown();
-  }
-
-  std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>> run(
-      const TpchPlan& tpchPlan) {
-    int32_t repeat = 0;
-    try {
-      for (;;) {
-        CursorParameters params;
-        params.maxDrivers = FLAGS_num_drivers;
-        params.planNode = tpchPlan.plan;
-        params.queryConfigs[core::QueryConfig::kMaxSplitPreloadPerDriver] =
-            std::to_string(FLAGS_split_preload_per_driver);
-        const int numSplitsPerFile = FLAGS_num_splits_per_file;
-
-        bool noMoreSplits = false;
-        auto addSplits = [&](exec::Task* task) {
-          if (!noMoreSplits) {
-            for (const auto& entry : tpchPlan.dataFiles) {
-              for (const auto& path : entry.second) {
-                auto const splits =
-                    HiveConnectorTestBase::makeHiveConnectorSplits(
-                        path, numSplitsPerFile, tpchPlan.dataFileFormat);
-                for (const auto& split : splits) {
-                  task->addSplit(entry.first, exec::Split(split));
-                }
-              }
-              task->noMoreSplits(entry.first);
-            }
-          }
-          noMoreSplits = true;
-        };
-        auto result = readCursor(params, addSplits);
-        ensureTaskCompletion(result.first->task().get());
-        if (++repeat >= FLAGS_num_repeats) {
-          return result;
-        }
-      }
-    } catch (const std::exception& e) {
-      LOG(ERROR) << "Query terminated with: " << e.what();
-      return {nullptr, std::vector<RowVectorPtr>()};
-    }
-  }
-
-  void runMain(std::ostream& out, RunStats& runStats) {
+  void runMain(std::ostream& out, RunStats& runStats) override {
     if (FLAGS_run_query_verbose == -1 && FLAGS_io_meter_column_pct == 0) {
       folly::runBenchmarks();
     } else {
@@ -363,130 +103,6 @@ class TpchBenchmark {
           << std::endl;
     }
   }
-
-  void readCombinations() {
-    std::ifstream file(FLAGS_test_flags_file);
-    std::string line;
-    while (std::getline(file, line)) {
-      ParameterDim dim;
-      int32_t previous = 0;
-      for (auto i = 0; i < line.size(); ++i) {
-        if (line[i] == ':') {
-          dim.flag = line.substr(0, i);
-          previous = i + 1;
-        } else if (line[i] == ',') {
-          dim.values.push_back(line.substr(previous, i - previous));
-          previous = i + 1;
-        }
-      }
-      if (previous < line.size()) {
-        dim.values.push_back(line.substr(previous, line.size() - previous));
-      }
-
-      parameters_.push_back(dim);
-    }
-  }
-
-  void runCombinations(int32_t level) {
-    if (level == parameters_.size()) {
-      if (FLAGS_clear_ram_cache) {
-#ifdef linux
-        // system("echo 3 >/proc/sys/vm/drop_caches");
-        bool success = false;
-        auto fd = open("/proc//sys/vm/drop_caches", O_WRONLY);
-        if (fd > 0) {
-          success = write(fd, "3", 1) == 1;
-          close(fd);
-        }
-        if (!success) {
-          LOG(ERROR) << "Failed to clear OS disk cache: errno=" << errno;
-        }
-#endif
-
-        if (cache_) {
-          cache_->clear();
-        }
-      }
-      if (FLAGS_clear_ssd_cache) {
-        if (cache_) {
-          auto ssdCache = cache_->ssdCache();
-          if (ssdCache) {
-            ssdCache->clear();
-          }
-        }
-      }
-      if (FLAGS_warmup_after_clear) {
-        std::stringstream result;
-        RunStats ignore;
-        runMain(result, ignore);
-      }
-      RunStats stats;
-      std::stringstream result;
-      uint64_t micros = 0;
-      {
-        struct rusage start;
-        getrusage(RUSAGE_SELF, &start);
-        MicrosecondTimer timer(&micros);
-        runMain(result, stats);
-        struct rusage final;
-        getrusage(RUSAGE_SELF, &final);
-        auto tvNanos = [](struct timeval tv) {
-          return tv.tv_sec * 1000000000 + tv.tv_usec * 1000;
-        };
-        stats.userNanos = tvNanos(final.ru_utime) - tvNanos(start.ru_utime);
-        stats.systemNanos = tvNanos(final.ru_stime) - tvNanos(start.ru_stime);
-      }
-      stats.micros = micros;
-      stats.output = result.str();
-      for (auto i = 0; i < parameters_.size(); ++i) {
-        std::string name;
-        gflags::GetCommandLineOption(parameters_[i].flag.c_str(), &name);
-        stats.flags[parameters_[i].flag] = name;
-      }
-      runStats_.push_back(std::move(stats));
-    } else {
-      auto& flag = parameters_[level].flag;
-      for (auto& value : parameters_[level].values) {
-        std::string result =
-            gflags::SetCommandLineOption(flag.c_str(), value.c_str());
-        if (result.empty()) {
-          LOG(ERROR) << "Failed to set " << flag << "=" << value;
-        }
-        std::cout << result << std::endl;
-        runCombinations(level + 1);
-      }
-    }
-  }
-
-  void runAllCombinations() {
-    readCombinations();
-    runCombinations(0);
-    std::sort(
-        runStats_.begin(),
-        runStats_.end(),
-        [](const RunStats& left, const RunStats& right) {
-          return left.micros < right.micros;
-        });
-    for (auto& stats : runStats_) {
-      std::cout << stats.toString(false);
-    }
-    if (FLAGS_full_sorted_stats) {
-      std::cout << "Detail for stats:" << std::endl;
-      for (auto& stats : runStats_) {
-        std::cout << stats.toString(true);
-      }
-    }
-  }
-
-  std::unique_ptr<folly::IOThreadPoolExecutor> ioExecutor_;
-  std::unique_ptr<folly::IOThreadPoolExecutor> cacheExecutor_;
-  std::shared_ptr<memory::MemoryAllocator> allocator_;
-  std::shared_ptr<cache::AsyncDataCache> cache_;
-  // Parameter combinations to try. Each element specifies a flag and possible
-  // values. All permutations are tried.
-  std::vector<ParameterDim> parameters_;
-
-  std::vector<RunStats> runStats_;
 };
 
 TpchBenchmark benchmark;

--- a/velox/experimental/wave/common/Cuda.cu
+++ b/velox/experimental/wave/common/Cuda.cu
@@ -68,6 +68,9 @@ class CudaDeviceAllocator : public GpuAllocator {
   void free(void* ptr, size_t /*size*/) override {
     cudaFree(ptr);
   }
+  bool isDevice() const override {
+    return true;
+  }
 };
 
 class CudaHostAllocator : public GpuAllocator {
@@ -81,6 +84,10 @@ class CudaHostAllocator : public GpuAllocator {
   void free(void* ptr, size_t /*size*/) override {
     cudaFreeHost(ptr);
   };
+
+  bool isHost() const override {
+    return true;
+  }
 };
 
 } // namespace
@@ -125,6 +132,10 @@ void Stream::wait() {
 void Stream::prefetch(Device* device, void* ptr, size_t size) {
   CUDA_CHECK(cudaMemPrefetchAsync(
       ptr, size, device ? device->deviceId : cudaCpuDeviceId, stream_->stream));
+}
+
+void Stream::memset(void* ptr, int32_t value, size_t size) {
+  CUDA_CHECK(cudaMemsetAsync(ptr, value, size, stream_->stream));
 }
 
 void Stream::hostToDeviceAsync(

--- a/velox/experimental/wave/common/Cuda.h
+++ b/velox/experimental/wave/common/Cuda.h
@@ -48,6 +48,9 @@ class Stream {
   /// Waits  until the stream is completed.
   void wait();
 
+  /// Enqueus a memset on 'device'.
+  void memset(void* address, int32_t value, size_t size);
+
   /// Enqueus a prefetch. Prefetches to host if 'device' is nullptr, otherwise
   /// to 'device'.
   void prefetch(Device* device, void* address, size_t size);
@@ -127,6 +130,16 @@ class GpuAllocator {
   /// Frees a pointer from allocate(). 'size' must correspond to the size given
   /// to allocate(). A Memory must be freed to the same allocator it came from.
   virtual void free(void* ptr, size_t bytes) = 0;
+
+  /// True if allocates host pinned memory.
+  virtual bool isHost() const {
+    return false;
+  }
+
+  /// True if allocates device side memory.
+  virtual bool isDevice() const {
+    return false;
+  }
 
   class Deleter;
 

--- a/velox/experimental/wave/common/GpuArena.h
+++ b/velox/experimental/wave/common/GpuArena.h
@@ -130,7 +130,10 @@ struct ArenaStatus {
 /// fragmentation happens.
 class GpuArena {
  public:
-  GpuArena(uint64_t singleArenaCapacity, GpuAllocator* allocator);
+  GpuArena(
+      uint64_t singleArenaCapacity,
+      GpuAllocator* allocator,
+      uint64_t standbyCapacity = 0);
 
   WaveBufferPtr allocateBytes(uint64_t bytes);
 
@@ -152,9 +155,36 @@ class GpuArena {
     return arenas_;
   }
 
+  uint64_t maxCapacity() const {
+    return maxCapacity_;
+  }
+
+  uint64_t totalAllocated() const {
+    return totalAllocated_;
+  }
+
+  uint64_t numAllocations() const {
+    return numAllocations_;
+  }
+
+  uint64_t retainedSize() const {
+    return capacity_;
+  }
+
+  void setSizes(uint64_t arenaSize, uint64_t standbyCapacity) {
+    singleArenaCapacity_ = arenaSize;
+    standbyCapacity_ = standbyCapacity;
+  }
+
+  bool isDevice() const {
+    return allocator_->isDevice();
+  }
+
   /// Checks magic numbers and returns the sum of allocated capacity. Actual
   /// sizes are padded to larger.
   ArenaStatus checkBuffers();
+
+  std::string toString() const;
 
  private:
   // A preallocated array of Buffer handles for memory of 'this'.
@@ -178,8 +208,14 @@ class GpuArena {
   // Head of Buffer free list.
   Buffer* firstFreeBuffer_{nullptr};
 
+  // Total capacity in all arenas.
+  uint64_t capacity_{0};
+
   // Capacity in bytes for a single GpuSlab managed by this.
-  const uint64_t singleArenaCapacity_;
+  uint64_t singleArenaCapacity_;
+
+  // Lower bound of capacity to keep around even if usage is below this.
+  uint64_t standbyCapacity_{0};
 
   GpuAllocator* const allocator_;
 
@@ -189,6 +225,10 @@ class GpuArena {
   // All allocations should come from this GpuSlab. When it is no longer able
   // to handle allocations it will be updated to a newly created GpuSlab.
   std::shared_ptr<GpuSlab> currentArena_;
+
+  uint64_t numAllocations_{0};
+  uint64_t totalAllocated_{0};
+  uint64_t maxCapacity_{0};
 };
 
 } // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/ResultStaging.h
+++ b/velox/experimental/wave/common/ResultStaging.h
@@ -90,4 +90,24 @@ class ResultStaging {
   std::vector<WaveBufferPtr> buffers_;
 };
 
+/// Manages parameters of kernel launch. Provides pinned host buffer and a
+/// device side copy destination.
+struct LaunchParams {
+  LaunchParams(GpuArena& arena) : arena(arena) {}
+
+  /// Returns a host, device address pair of 'size' bytes.
+  std::pair<char*, char*> setup(size_t size);
+
+  void transfer(Stream& stream);
+
+  GpuArena& arena;
+  WaveBufferPtr host;
+  WaveBufferPtr device;
+};
+
+// Arena for decode and program launch param blocks. Lifetime of allocations is
+// a wave in WaveStream, typical size under 1MB, e.g. 1K blocks with 1K of
+// params.
+GpuArena& getSmallTransferArena();
+
 } // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/tests/CudaTest.cpp
+++ b/velox/experimental/wave/common/tests/CudaTest.cpp
@@ -1464,7 +1464,7 @@ TEST_F(CudaTest, reduceMatrix) {
     return;
   }
 
-  std::vector<std::string> modes = {/*"unified", "device",*/ "devicecoalesced"};
+  std::vector<std::string> modes = {"unified", "device", "devicecoalesced"};
   std::vector<int32_t> batchMBValues = {30, 100};
   std::vector<int32_t> numThreadsValues = {1, 2, 3};
   std::vector<int32_t> workPerThreadValues = {2, 4};

--- a/velox/experimental/wave/dwio/decode/DecodeStep.h
+++ b/velox/experimental/wave/dwio/decode/DecodeStep.h
@@ -118,18 +118,18 @@ struct alignas(16) GpuDecode {
 
   NullMode nullMode;
 
-  // Ordinal number of TB in TBs working on the same column. Each TB does a
-  // multiple of TB width rows. The TBs for different ranges of rows are
-  // launched in the same grid but are independent. The ordinal for non-first
-  // TBs gets the base index for values.
-  uint8_t nthBlock{0};
-
   /// Number of chunks (e.g. Parquet pages). If > 1, different rows row ranges
   /// have different encodings. The first chunk's encoding is in 'data'. The
   /// next chunk's encoding is in the next GpuDecode's 'data'. Each chunk has
   /// its own 'nulls'. The input row numbers and output data/row numbers are
   /// given by the first GpuDecode.
   uint8_t numChunks{1};
+
+  // Ordinal number of TB in TBs working on the same column. Each TB does a
+  // multiple of TB width rows. The TBs for different ranges of rows are
+  // launched in the same grid but are independent. The ordinal for non-first
+  // TBs gets the base index for values.
+  uint16_t nthBlock{0};
 
   uint16_t numRowsPerThread{1};
 
@@ -400,8 +400,7 @@ struct DecodePrograms {
 
 void launchDecode(
     const DecodePrograms& programs,
-    GpuArena* arena,
-    WaveBufferPtr& extra,
+    LaunchParams& params,
     Stream* stream);
 
 } // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/Aggregation.cpp
+++ b/velox/experimental/wave/exec/Aggregation.cpp
@@ -354,8 +354,4 @@ void Aggregation::schedule(WaveStream& waveStream, int32_t maxRows) {
           << stats_.ingestedRowCount / stats_.gpuTimeMs * 1000 << " rows/s";
 }
 
-vector_size_t Aggregation::outputSize(WaveStream&) const {
-  return container_->actualNumGroups;
-}
-
 } // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/Aggregation.h
+++ b/velox/experimental/wave/exec/Aggregation.h
@@ -51,8 +51,6 @@ class Aggregation : public WaveOperator {
     return finished_;
   }
 
-  vector_size_t outputSize(WaveStream&) const override;
-
   std::string toString() const override {
     return "Aggregation";
   }

--- a/velox/experimental/wave/exec/Instruction.h
+++ b/velox/experimental/wave/exec/Instruction.h
@@ -96,13 +96,13 @@ struct AdvanceResult {
     return numRows == 0 && !isRetry;
   }
 
-  ///  Max umber of result rows.
+  ///  Max number of result rows.
   int32_t numRows{0};
 
   /// The sequence number of kernel launch that needs continue.
   int32_t nthLaunch{0};
 
-  /// The ordinal of the program i the launch.
+  /// The ordinal of the program in the launch.
   int32_t programIdx{0};
 
   /// The instruction where to pick up. If not 0, must have 'isRetry' true.

--- a/velox/experimental/wave/exec/Project.h
+++ b/velox/experimental/wave/exec/Project.h
@@ -60,8 +60,6 @@ class Project : public WaveOperator {
 
   void schedule(WaveStream& stream, int32_t maxRows = 0) override;
 
-  vector_size_t outputSize(WaveStream& stream) const override;
-
   void finalize(CompileState& state) override;
 
   std::string toString() const override {

--- a/velox/experimental/wave/exec/TableScan.cpp
+++ b/velox/experimental/wave/exec/TableScan.cpp
@@ -18,6 +18,7 @@
 #include "velox/common/time/Timer.h"
 #include "velox/exec/Task.h"
 #include "velox/experimental/wave/exec/WaveDriver.h"
+#include "velox/experimental/wave/exec/WaveSplitReader.h"
 #include "velox/expression/Expr.h"
 
 namespace facebook::velox::wave {
@@ -53,7 +54,33 @@ void TableScan::schedule(WaveStream& stream, int32_t maxRows) {
   waveDataSource_->schedule(stream, maxRows);
   nextAvailableRows_ = waveDataSource_->canAdvance(stream);
   if (nextAvailableRows_ == 0) {
+    updateStats(
+        waveDataSource_->splitReader()->runtimeStats(),
+        waveDataSource_->splitReader().get());
     needNewSplit_ = true;
+  }
+}
+
+void TableScan::updateStats(
+    std::unordered_map<std::string, RuntimeCounter> connectorStats,
+    WaveSplitReader* splitReader) {
+  auto lockedStats = stats().wlock();
+  if (splitReader) {
+    lockedStats->rawInputPositions = splitReader->getCompletedRows();
+    lockedStats->rawInputBytes = splitReader->getCompletedBytes();
+  }
+  for (const auto& [name, counter] : connectorStats) {
+    if (name == "ioWaitNanos") {
+      ioWaitNanos_ += counter.value - lastIoWaitNanos_;
+      lastIoWaitNanos_ = counter.value;
+    }
+    if (UNLIKELY(lockedStats->runtimeStats.count(name) == 0)) {
+      lockedStats->runtimeStats.insert(
+          std::make_pair(name, RuntimeMetric(counter.unit)));
+    } else {
+      VELOX_CHECK_EQ(lockedStats->runtimeStats.at(name).unit, counter.unit);
+    }
+    lockedStats->runtimeStats.at(name).addValue(counter.value);
   }
 }
 
@@ -73,21 +100,7 @@ BlockingReason TableScan::nextSplit(ContinueFuture* future) {
   if (!split.hasConnectorSplit()) {
     noMoreSplits_ = true;
     if (dataSource_) {
-      auto connectorStats = dataSource_->runtimeStats();
-      auto lockedStats = stats().wlock();
-      for (const auto& [name, counter] : connectorStats) {
-        if (name == "ioWaitNanos") {
-          ioWaitNanos_ += counter.value - lastIoWaitNanos_;
-          lastIoWaitNanos_ = counter.value;
-        }
-        if (UNLIKELY(lockedStats->runtimeStats.count(name) == 0)) {
-          lockedStats->runtimeStats.insert(
-              std::make_pair(name, RuntimeMetric(counter.unit)));
-        } else {
-          VELOX_CHECK_EQ(lockedStats->runtimeStats.at(name).unit, counter.unit);
-        }
-        lockedStats->runtimeStats.at(name).addValue(counter.value);
-      }
+      updateStats(dataSource_->runtimeStats());
     }
     return BlockingReason::kNotBlocked;
   }
@@ -129,6 +142,8 @@ BlockingReason TableScan::nextSplit(ContinueFuture* future) {
       waveDataSource_->addSplit(connectorSplit);
     }
   }
+  ++stats().wlock()->numSplits;
+
   for (const auto& entry : pendingDynamicFilters_) {
     waveDataSource_->addDynamicFilter(entry.first, entry.second);
   }

--- a/velox/experimental/wave/exec/TableScan.h
+++ b/velox/experimental/wave/exec/TableScan.h
@@ -54,10 +54,6 @@ class TableScan : public WaveSourceOperator {
 
   void schedule(WaveStream& stream, int32_t maxRows = 0) override;
 
-  vector_size_t outputSize(WaveStream& stream) const {
-    return waveDataSource_->outputSize(stream);
-  }
-
   bool isStreaming() const override {
     return true;
   }
@@ -97,6 +93,15 @@ class TableScan : public WaveSourceOperator {
   // background on the executor of the connector. If the DataSource is
   // needed before prepare is done, it will be made when needed.
   void preload(std::shared_ptr<connector::ConnectorSplit> split);
+
+  // Adds 'stats' to operator stats of the containing WaveDriver. Some
+  // stats come from DataSource, others from SplitReader. If
+  // 'splitReader' is given, the completed rows/bytes from
+  // 'splitReader' are added. These do not come in the runtimeStats()
+  // map.
+  void updateStats(
+      std::unordered_map<std::string, RuntimeCounter> stats,
+      WaveSplitReader* splitReader = nullptr);
 
   // Process-wide IO wait time.
   static std::atomic<uint64_t> ioWaitNanos_;

--- a/velox/experimental/wave/exec/ToWave.cpp
+++ b/velox/experimental/wave/exec/ToWave.cpp
@@ -464,6 +464,7 @@ void CompileState::makeAggregateAccumulate(const core::AggregationNode* node) {
   folly::F14FastSet<Program*> programs;
   std::vector<AbstractOperand*> allArgs;
   std::vector<AbstractAggInstruction> aggregates;
+  int numPrograms = allPrograms_.size();
   for (auto& key : node->groupingKeys()) {
     auto arg = findCurrentValue(key);
     allArgs.push_back(arg);
@@ -520,7 +521,6 @@ void CompileState::makeAggregateAccumulate(const core::AggregationNode* node) {
       sourceList.push_back(s);
     }
   }
-  int numPrograms = allPrograms_.size();
   auto aggInstruction = instruction.get();
   addInstruction(std::move(instruction), nullptr, sourceList);
   if (allPrograms_.size() > numPrograms) {

--- a/velox/experimental/wave/exec/Values.h
+++ b/velox/experimental/wave/exec/Values.h
@@ -36,12 +36,6 @@ class Values : public WaveSourceOperator {
     return roundsLeft_ == (current_ == values_.size());
   }
 
-  vector_size_t outputSize(WaveStream& stream) const override {
-    // Must not be called before schedule().
-    VELOX_CHECK_LT(0, current_);
-    return values_[current_ - 1]->size();
-  }
-
   std::string toString() const override;
 
  private:

--- a/velox/experimental/wave/exec/WaveDataSource.h
+++ b/velox/experimental/wave/exec/WaveDataSource.h
@@ -48,8 +48,6 @@ class WaveDataSource : public std::enable_shared_from_this<WaveDataSource> {
 
   virtual void schedule(WaveStream& stream, int32_t maxRows = 0) = 0;
 
-  virtual vector_size_t outputSize(WaveStream& stream) const = 0;
-
   virtual bool isFinished() = 0;
 
   virtual std::shared_ptr<WaveSplitReader> splitReader() = 0;

--- a/velox/experimental/wave/exec/WaveDriver.h
+++ b/velox/experimental/wave/exec/WaveDriver.h
@@ -59,10 +59,6 @@ class WaveDriver : public exec::SourceOperator {
     return *arena_;
   }
 
-  GpuArena& hostArena() const {
-    return *hostArena_;
-  }
-
   const std::vector<std::unique_ptr<AbstractOperand>>& operands() {
     return operands_;
   }
@@ -160,7 +156,6 @@ class WaveDriver : public exec::SourceOperator {
 
   std::unique_ptr<GpuArena> arena_;
   std::unique_ptr<GpuArena> deviceArena_;
-  std::unique_ptr<GpuArena> hostArena_;
 
   ContinueFuture blockingFuture_{ContinueFuture::makeEmpty()};
   exec::BlockingReason blockingReason_;

--- a/velox/experimental/wave/exec/WaveHiveDataSource.cpp
+++ b/velox/experimental/wave/exec/WaveHiveDataSource.cpp
@@ -112,10 +112,6 @@ void WaveHiveDataSource::schedule(WaveStream& stream, int32_t maxRows) {
   stream.setSplitReader(splitReader_);
 }
 
-vector_size_t WaveHiveDataSource::outputSize(WaveStream& stream) const {
-  return splitReader_->outputSize(stream);
-}
-
 bool WaveHiveDataSource::isFinished() {
   if (!splitReader_) {
     return false;

--- a/velox/experimental/wave/exec/WaveHiveDataSource.h
+++ b/velox/experimental/wave/exec/WaveHiveDataSource.h
@@ -50,8 +50,6 @@ class WaveHiveDataSource : public WaveDataSource {
 
   void schedule(WaveStream& stream, int32_t maxRows) override;
 
-  vector_size_t outputSize(WaveStream& stream) const override;
-
   bool isFinished() override;
 
   std::shared_ptr<WaveSplitReader> splitReader() override {

--- a/velox/experimental/wave/exec/WaveOperator.h
+++ b/velox/experimental/wave/exec/WaveOperator.h
@@ -127,13 +127,6 @@ class WaveOperator {
     driver_ = driver;
   }
 
-  // Returns the number of non-filtered out result rows in the invocation inside
-  // 'stream'. 'this' must have had schedule() called with the same stream and
-  // the stream must have arrived. The actual result rows may be non-contiguous
-  // in the result vectors and may need indirection to access, as seen in output
-  // operands of the corresponding executables.
-  virtual vector_size_t outputSize(WaveStream& stream) const = 0;
-
   const OperandSet& outputIds() const {
     return outputIds_;
   }
@@ -171,7 +164,7 @@ class WaveOperator {
  protected:
   folly::Synchronized<exec::OperatorStats>& stats();
 
-  // Sequence number in WaveOperator sequence inside WaveDriver. IUsed to label
+  // Sequence number in WaveOperator sequence inside WaveDriver. Used to label
   // states of different oprators in WaveStream.
   int32_t id_;
 

--- a/velox/experimental/wave/exec/WaveSplitReader.h
+++ b/velox/experimental/wave/exec/WaveSplitReader.h
@@ -60,8 +60,6 @@ class WaveSplitReader {
 
   virtual void schedule(WaveStream& stream, int32_t maxRows) = 0;
 
-  virtual vector_size_t outputSize(WaveStream& stream) const = 0;
-
   virtual bool isFinished() const = 0;
 
   virtual uint64_t getCompletedBytes() = 0;

--- a/velox/experimental/wave/exec/tests/CMakeLists.txt
+++ b/velox/experimental/wave/exec/tests/CMakeLists.txt
@@ -17,8 +17,6 @@ add_subdirectory(utils)
 add_executable(velox_wave_exec_test FilterProjectTest.cpp TableScanTest.cpp
                                     AggregationTest.cpp Main.cpp)
 
-add_test(velox_wave_exec_test velox_wave_exec_test)
-
 target_link_libraries(
   velox_wave_exec_test
   velox_wave_exec
@@ -50,9 +48,55 @@ target_link_libraries(
   Boost::regex
   Boost::thread
   Boost::system
-  GTest::gtest
-  GTest::gtest_main
-  GTest::gmock
+  gtest
+  gtest_main
+  gmock
+  Folly::folly
+  gflags::gflags
+  glog::glog
+  fmt::fmt
+  ${FILESYSTEM})
+
+add_test(velox_wave_exec_test velox_wave_exec_test)
+
+add_executable(velox_wave_benchmark WaveBenchmark.cpp)
+
+target_link_libraries(
+  velox_wave_benchmark
+  velox_query_benchmark
+  velox_wave_exec
+  velox_wave_mock_reader
+  velox_aggregates
+  velox_dwio_common
+  velox_dwio_common_exception
+  velox_dwio_common_test_utils
+  velox_dwio_parquet_reader
+  velox_dwio_parquet_writer
+  velox_exec
+  velox_exec_test_lib
+  velox_functions_json
+  velox_functions_lib
+  velox_functions_prestosql
+  velox_functions_test_lib
+  velox_hive_connector
+  velox_memory
+  velox_serialization
+  velox_test_util
+  velox_type
+  velox_vector
+  velox_vector_fuzzer
+  Boost::atomic
+  Boost::context
+  Boost::date_time
+  Boost::filesystem
+  Boost::program_options
+  Boost::regex
+  Boost::thread
+  Boost::system
+  gtest
+  gtest_main
+  gmock
+  ${FOLLY_BENCHMARK}
   Folly::folly
   gflags::gflags
   glog::glog

--- a/velox/experimental/wave/exec/tests/WaveBenchmark.cpp
+++ b/velox/experimental/wave/exec/tests/WaveBenchmark.cpp
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/benchmarks/QueryBenchmarkBase.h"
+#include "velox/common/process/TraceContext.h"
+#include "velox/dwio/dwrf/writer/Writer.h"
+#include "velox/dwio/dwrf/writer/WriterContext.h"
+#include "velox/experimental/wave/exec/ToWave.h"
+#include "velox/experimental/wave/exec/WaveHiveDataSource.h"
+#include "velox/experimental/wave/exec/tests/utils/FileFormat.h"
+#include "velox/experimental/wave/exec/tests/utils/WaveTestSplitReader.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+using namespace facebook::velox::dwio::common;
+
+DEFINE_string(
+    data_path,
+    "",
+    "Root path of test data. Data layout must follow Hive-style partitioning. "
+    "If the content are directories, they contain the data files for "
+    "each table. If they are files, they contain a file system path for each "
+    "data file, one per line. This allows running against cloud storage or "
+    "HDFS");
+
+DEFINE_bool(
+    generate,
+    true,
+    "Generate input data. If false, data_path must "
+    "contain a directory with a subdirectory per table.");
+
+DEFINE_bool(preload, false, "Preload Wave data into RAM before starting query");
+
+DEFINE_bool(wave, true, "Run benchmark with Wave");
+
+DEFINE_int32(num_columns, 10, "Number of columns in test table");
+
+DEFINE_int64(filter_pass_pct, 100, "Passing % for one filter");
+
+DEFINE_int32(null_pct, 0, "Pct of null values in columns");
+
+DEFINE_int32(num_column_filters, 0, "Number of columns wit a filter");
+
+DEFINE_int32(num_expr_filters, 0, "Number of columns  with a filter expr");
+
+DEFINE_int32(
+    num_arithmetic,
+    0,
+    "Number of arithmetic ops per column after filters");
+
+DEFINE_int32(rows_per_stripe, 200000, "Rows in a stripe");
+
+DEFINE_int64(num_rows, 1000000000, "Rows in test table");
+
+DEFINE_int32(
+    run_query_verbose,
+    -1,
+    "Run a given query and print execution statistics");
+
+class WaveBenchmark : public QueryBenchmarkBase {
+ public:
+  ~WaveBenchmark() {
+    wave::test::Table::dropAll();
+  }
+
+  void initialize() override {
+    QueryBenchmarkBase::initialize();
+    if (FLAGS_wave) {
+      wave::registerWave();
+      wave::WaveHiveDataSource::registerConnector();
+      wave::test::WaveTestSplitReader::registerTestSplitReader();
+    }
+    rootPool_ = memory::memoryManager()->addRootPool("WaveBenchmark");
+    leafPool_ = rootPool_->addLeafChild("WaveBenchmark");
+  }
+
+  void makeData(
+      const RowTypePtr& type,
+      int32_t numVectors,
+      int32_t vectorSize,
+      float nullPct = 0) {
+    auto vectors = makeVectors(type, numVectors, vectorSize, nullPct / 100);
+    int32_t cnt = 0;
+    for (auto& vector : vectors) {
+      makeRange(vector, 1000000000, nullPct == 0);
+      auto rn = vector->childAt(type->size() - 1)->as<FlatVector<int64_t>>();
+      for (auto i = 0; i < rn->size(); ++i) {
+        rn->set(i, cnt++);
+      }
+    }
+    if (FLAGS_wave) {
+      makeTable(FLAGS_data_path + "/test.wave", vectors);
+      if (FLAGS_generate) {
+        auto table =
+            wave::test::Table::getTable(FLAGS_data_path + "/test.wave");
+        table->toFile(FLAGS_data_path + "/test.wave");
+      }
+    } else {
+      std::string temp = FLAGS_data_path + "/data.dwrf";
+      auto config = std::make_shared<dwrf::Config>();
+      config->set(dwrf::Config::COMPRESSION, common::CompressionKind_NONE);
+      config->set(
+          dwrf::Config::STRIPE_SIZE,
+          static_cast<uint64_t>(FLAGS_rows_per_stripe * FLAGS_num_columns * 4));
+      writeToFile(temp, vectors, config, vectors.front()->type());
+    }
+  }
+
+  std::vector<RowVectorPtr> makeVectors(
+      const RowTypePtr& rowType,
+      int32_t numVectors,
+      int32_t rowsPerVector,
+      float nullRatio = 0) {
+    std::vector<RowVectorPtr> vectors;
+    options_.vectorSize = rowsPerVector;
+    options_.nullRatio = nullRatio;
+    fuzzer_ = std::make_unique<VectorFuzzer>(options_, leafPool_.get());
+    for (int32_t i = 0; i < numVectors; ++i) {
+      auto vector = fuzzer_->fuzzInputFlatRow(rowType);
+      vectors.push_back(vector);
+    }
+    return vectors;
+  }
+
+  void makeRange(
+      RowVectorPtr row,
+      int64_t mod = std::numeric_limits<int64_t>::max(),
+      bool notNull = true) {
+    for (auto i = 0; i < row->type()->size(); ++i) {
+      auto child = row->childAt(i);
+      if (auto ints = child->as<FlatVector<int64_t>>()) {
+        for (auto i = 0; i < child->size(); ++i) {
+          if (!notNull && ints->isNullAt(i)) {
+            continue;
+          }
+          ints->set(i, ints->valueAt(i) % mod);
+        }
+      }
+      if (notNull) {
+        child->clearNulls(0, row->size());
+      }
+    }
+  }
+
+  wave::test::SplitVector makeTable(
+      const std::string& name,
+      std::vector<RowVectorPtr>& rows) {
+    wave::test::Table::dropTable(name);
+    return wave::test::Table::defineTable(name, rows)->splits();
+  }
+
+  void writeToFile(
+      const std::string& filePath,
+      const std::vector<RowVectorPtr>& vectors,
+      std::shared_ptr<dwrf::Config> config,
+      const TypePtr& schema) {
+    dwrf::WriterOptions options;
+    options.config = config;
+    options.schema = schema;
+    auto localWriteFile =
+        std::make_unique<LocalWriteFile>(filePath, true, false);
+    auto sink = std::make_unique<dwio::common::WriteFileSink>(
+        std::move(localWriteFile), filePath);
+    auto childPool =
+        rootPool_->addAggregateChild("HiveConnectorTestBase.Writer");
+    options.memoryPool = childPool.get();
+    facebook::velox::dwrf::Writer writer{std::move(sink), options};
+    for (size_t i = 0; i < vectors.size(); ++i) {
+      writer.write(vectors[i]);
+    }
+    writer.close();
+  }
+
+  exec::test::TpchPlan getQueryPlan(int32_t query) {
+    switch (query) {
+      case 1: {
+        if (!type_) {
+          type_ = makeType();
+        }
+
+        exec::test::TpchPlan plan;
+        if (FLAGS_wave) {
+          plan.dataFiles["0"] = {FLAGS_data_path + "/test.wave"};
+        } else {
+          plan.dataFiles["0"] = {FLAGS_data_path + "/data.dwrf"};
+        }
+        int64_t bound = (1'000'000'000LL * FLAGS_filter_pass_pct) / 100;
+        std::vector<std::string> scanFilters;
+        for (auto i = 0; i < FLAGS_num_column_filters; ++i) {
+          scanFilters.push_back(fmt::format("c{} < {}", i, bound));
+        }
+        auto builder =
+            PlanBuilder(leafPool_.get()).tableScan(type_, scanFilters);
+
+        for (auto i = 0; i < FLAGS_num_expr_filters; ++i) {
+          builder = builder.filter(
+              fmt::format("c{} < {}", FLAGS_num_column_filters + i, bound));
+        }
+
+        std::vector<std::string> aggInputs;
+        if (FLAGS_num_arithmetic > 0) {
+          std::vector<std::string> projects;
+          for (auto c = 0; c < type_->size(); ++c) {
+            std::string expr = fmt::format("c{} ", c);
+            for (auto i = 0; i < FLAGS_num_arithmetic; ++i) {
+              expr += fmt::format(" + c{}", c);
+            }
+            expr += fmt::format(" as f{}", c);
+            projects.push_back(std::move(expr));
+            aggInputs.push_back(fmt::format("f{}", c));
+          }
+          builder = builder.project(std::move(projects));
+        } else {
+          for (auto i = 0; i < type_->size(); ++i) {
+            aggInputs.push_back(fmt::format("c{}", i));
+          }
+        }
+        std::vector<std::string> aggs;
+        for (auto i = 0; i < aggInputs.size(); ++i) {
+          aggs.push_back(fmt::format("sum({})", aggInputs[i]));
+        }
+
+        plan.plan = builder.singleAggregation({}, aggs).planNode();
+
+        plan.dataFileFormat =
+            FLAGS_wave ? FileFormat::UNKNOWN : FileFormat::DWRF;
+        return plan;
+      }
+      default:
+        VELOX_FAIL("Bad query number");
+    }
+  }
+
+  void prepareQuery(int32_t query) {
+    switch (query) {
+      case 1: {
+        type_ = makeType();
+        auto numVectors =
+            std::max<int64_t>(1, FLAGS_num_rows / FLAGS_rows_per_stripe);
+        if (FLAGS_generate) {
+          makeData(
+              type_, numVectors, FLAGS_num_rows / numVectors, FLAGS_null_pct);
+        } else {
+          loadData();
+        }
+        break;
+      }
+      default:
+        VELOX_FAIL("Bad query number");
+    }
+  }
+
+  void loadData() {
+    if (FLAGS_wave) {
+      auto table =
+          wave::test::Table::getTable(FLAGS_data_path + "/test.wave", true);
+      table->fromFile(FLAGS_data_path + "/test.wave");
+      if (FLAGS_preload) {
+        table->loadData(leafPool_);
+      }
+    }
+  }
+
+  std::vector<std::shared_ptr<connector::ConnectorSplit>> listSplits(
+      const std::string& path,
+      int32_t numSplitsPerFile,
+      const TpchPlan& plan) override {
+    if (plan.dataFileFormat == FileFormat::UNKNOWN) {
+      auto table = wave::test::Table::getTable(path);
+      return table->splits();
+    }
+    return QueryBenchmarkBase::listSplits(path, numSplitsPerFile, plan);
+  }
+
+  void runMain(std::ostream& out, RunStats& runStats) override {
+    if (FLAGS_run_query_verbose == -1) {
+      folly::runBenchmarks();
+    } else {
+      const auto queryPlan = getQueryPlan(FLAGS_run_query_verbose);
+      auto [cursor, actualResults] = run(queryPlan);
+      if (!cursor) {
+        LOG(ERROR) << "Query terminated with error. Exiting";
+        exit(1);
+      }
+      auto task = cursor->task();
+      ensureTaskCompletion(task.get());
+      if (FLAGS_include_results) {
+        printResults(actualResults, out);
+        out << std::endl;
+      }
+      const auto stats = task->taskStats();
+      int64_t rawInputBytes = 0;
+      for (auto& pipeline : stats.pipelineStats) {
+        auto& first = pipeline.operatorStats[0];
+        if (first.operatorType == "TableScan" || first.operatorType == "Wave") {
+          rawInputBytes += first.rawInputBytes;
+        }
+      }
+      runStats.rawInputBytes = rawInputBytes;
+      out << fmt::format(
+                 "Execution time: {}",
+                 succinctMillis(
+                     stats.executionEndTimeMs - stats.executionStartTimeMs))
+          << std::endl;
+      out << fmt::format(
+                 "Splits total: {}, finished: {}",
+                 stats.numTotalSplits,
+                 stats.numFinishedSplits)
+          << std::endl;
+      out << printPlanWithStats(
+                 *queryPlan.plan, stats, FLAGS_include_custom_stats)
+          << std::endl;
+    }
+  }
+
+  RowTypePtr makeType() {
+    std::vector<std::string> names;
+    std::vector<TypePtr> types;
+    for (auto i = 0; i < FLAGS_num_columns; ++i) {
+      names.push_back(fmt::format("c{}", i));
+      types.push_back(BIGINT());
+    }
+    return ROW(std::move(names), std::move(types));
+  }
+
+  std::shared_ptr<memory::MemoryPool> rootPool_;
+  std::shared_ptr<memory::MemoryPool> leafPool_;
+  RowTypePtr type_;
+  VectorFuzzer::Options options_;
+  std::unique_ptr<VectorFuzzer> fuzzer_;
+};
+
+void waveBenchmarkMain() {
+  auto benchmark = std::make_unique<WaveBenchmark>();
+  benchmark->initialize();
+  if (FLAGS_run_query_verbose != -1) {
+    benchmark->prepareQuery(FLAGS_run_query_verbose);
+  }
+  if (FLAGS_test_flags_file.empty()) {
+    RunStats stats;
+    benchmark->runOne(std::cout, stats);
+    std::cout << stats.toString(false);
+  } else {
+    benchmark->runAllCombinations();
+  }
+  benchmark->shutdown();
+}
+
+int main(int argc, char** argv) {
+  std::string kUsage(
+      "This program benchmarks Wave. Run 'velox_wave_benchmark -helpon=WaveBenchmark' for available options.\n");
+  gflags::SetUsageMessage(kUsage);
+  folly::Init init{&argc, &argv, false};
+  facebook::velox::wave::printKernels();
+  waveBenchmarkMain();
+  return 0;
+}

--- a/velox/experimental/wave/exec/tests/utils/FileFormat.h
+++ b/velox/experimental/wave/exec/tests/utils/FileFormat.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/common/file/Region.h"
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/dwio/common/TypeWithId.h"
@@ -26,12 +27,17 @@ namespace facebook::velox::wave::test {
 
 class Table;
 
-enum Encoding { kFlat, kDict };
+enum Encoding : uint8_t { kFlat, kDict, kStruct, kNone };
 
 struct Column {
-  TypeKind kind;
+  void load(
+      std::unique_ptr<ReadFile>& file,
+      const std::string& path,
+      memory::MemoryPool* pool);
+
   Encoding encoding;
-  // Number of encoded values.
+  TypeKind kind;
+  // Number of encoded values including nulls.
   int32_t numValues{0};
 
   // Distinct values in kDict.
@@ -52,23 +58,48 @@ struct Column {
   /// Encoded column with 'numValues' null bits, nullptr if no nulls. If set,
   /// 'values' has an entry for each non-null.
   std::unique_ptr<Column> nulls;
+
+  /// Location of raw data in the backing file, or 0,0 if no backing file.
+  common::Region region;
+
+  std::vector<std::unique_ptr<Column>> children;
 };
 
 struct Stripe {
   Stripe(
       std::vector<std::unique_ptr<Column>>&& in,
-      const std::shared_ptr<const dwio::common::TypeWithId>& type)
-      : typeWithId(type), columns(std::move(in)) {}
+      const std::shared_ptr<const dwio::common::TypeWithId>& type,
+      int32_t numRows,
+      std::string path = "")
+      : typeWithId(type),
+        numRows(numRows),
+        columns(std::move(in)),
+        path(std::move(path)) {}
 
   const Column* findColumn(const dwio::common::TypeWithId& child) const;
+
+  bool isLoaded() const {
+    for (auto i = 0; i < columns.size(); ++i) {
+      if (!columns[i]->values) {
+        return false;
+      }
+    }
+    return true;
+  }
 
   // Unique name assigned when associating with a Table.
   std::string name;
 
   std::shared_ptr<const dwio::common::TypeWithId> typeWithId;
 
+  /// Number of rows. Needed for counting if no columns.
+  int32_t numRows{0};
+
   // Top level columns.
   std::vector<std::unique_ptr<Column>> columns;
+
+  /// Path of file referenced by Region in Columns.
+  std::string path;
 };
 
 class StringSet {
@@ -211,6 +242,19 @@ class Table {
     }
     return it->second.get();
   }
+
+  void toFile(const std::string& path);
+
+  /// Initializes from 'path' for stripes whose start falls between 'start' and
+  /// 'start + size'.
+  void fromFile(
+      const std::string& path,
+      int64_t start = 0,
+      int64_t size = std::numeric_limits<int64_t>::max());
+
+  /// Reads the encoded data for all columns in column->buffer, allocating from
+  /// 'pool'.
+  void loadData(std::shared_ptr<memory::MemoryPool> pool);
 
   static void dropTable(const std::string& name);
 

--- a/velox/experimental/wave/exec/tests/utils/TestFormatReader.cpp
+++ b/velox/experimental/wave/exec/tests/utils/TestFormatReader.cpp
@@ -35,18 +35,23 @@ std::unique_ptr<FormatData> TestFormatParams::toFormatData(
 int TestFormatData::stageNulls(
     ResultStaging& deviceStaging,
     SplitStaging& splitStaging) {
+  if (!column_->nulls) {
+    nullsStaged_ = true;
+    return kNotRegistered;
+  }
+
   if (nullsStaged_) {
+    splitStaging.addDependency(nullsStagingId_);
     return kNotRegistered;
   }
   nullsStaged_ = true;
   auto* nulls = column_->nulls.get();
-  if (!nulls) {
-    return kNotRegistered;
-  }
   Staging staging(
       nulls->values->as<char>(),
-      bits::nwords(column_->numValues) * sizeof(uint64_t));
+      bits::nwords(column_->numValues) * sizeof(uint64_t),
+      column_->region);
   auto id = splitStaging.add(staging);
+  nullsStagingId_ = splitStaging.id();
   splitStaging.registerPointer(id, &grid_.nulls, true);
   return id;
 }
@@ -90,8 +95,12 @@ void TestFormatData::startOp(
   stageNulls(deviceStaging, splitStaging);
   if (!staged_) {
     staged_ = true;
-    Staging staging(column_->values->as<char>(), column_->values->size());
+    Staging staging(
+        column_->values->as<char>(), column_->values->size(), column_->region);
     id = splitStaging.add(staging);
+    lastStagingId_ = splitStaging.id();
+  } else {
+    splitStaging.addDependency(lastStagingId_);
   }
   auto rowsPerBlock = FLAGS_wave_reader_rows_per_tb;
   int32_t numBlocks =

--- a/velox/experimental/wave/exec/tests/utils/TestFormatReader.h
+++ b/velox/experimental/wave/exec/tests/utils/TestFormatReader.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "velox/connectors/hive/FileHandle.h"
 #include "velox/experimental/wave/dwio/ColumnReader.h"
 #include "velox/experimental/wave/exec/tests/utils/FileFormat.h"
 #include "velox/type/Subfield.h"
@@ -69,6 +70,7 @@ class TestFormatData : public wave::FormatData {
   int32_t stageNulls(ResultStaging& deviceStaging, SplitStaging& splitStaging);
 
   const OperandId operand_;
+
   int32_t totalRows_{0};
 
   const test::Column* column_;

--- a/velox/experimental/wave/exec/tests/utils/WaveTestSplitReader.h
+++ b/velox/experimental/wave/exec/tests/utils/WaveTestSplitReader.h
@@ -31,7 +31,7 @@ class WaveTestSplitReader : public WaveSplitReader {
       const DefinesMap* defines);
 
   bool emptySplit() override {
-    return !stripe_ || stripe_->columns[0]->numValues == 0;
+    return !stripe_ || stripe_->columns[0]->numValues == 0 || emptySplit_;
   }
 
   int32_t canAdvance(WaveStream& stream) override;
@@ -43,11 +43,11 @@ class WaveTestSplitReader : public WaveSplitReader {
   bool isFinished() const override;
 
   uint64_t getCompletedBytes() override {
-    return 0;
+    return params_.ioStats->rawBytesRead();
   }
 
   uint64_t getCompletedRows() override {
-    return 0;
+    return nextRow_;
   }
 
   std::unordered_map<std::string, RuntimeCounter> runtimeStats() override {
@@ -63,6 +63,8 @@ class WaveTestSplitReader : public WaveSplitReader {
 
   std::shared_ptr<connector::ConnectorSplit> split_;
   SplitReaderParams params_;
+  FileHandleCachedPtr fileHandleCachePtr;
+  cache::AsyncDataCache* cache_{nullptr};
   test::Stripe* stripe_{nullptr};
   std::unique_ptr<ColumnReader> columnReader_;
   // First unscheduled row.
@@ -70,6 +72,9 @@ class WaveTestSplitReader : public WaveSplitReader {
   int32_t scheduledRows_{0};
   dwio::common::ColumnReaderStatistics readerStats_;
   raw_vector<int32_t> rows_;
+  FileHandleCachedPtr fileHandle_;
+  FileInfo fileInfo_;
+  bool emptySplit_{false};
 };
 
 } // namespace facebook::velox::wave::test


### PR DESCRIPTION
- Make multithreaded memcpy for staging transfers for GPU table scan.
- Make variants of bit unpacking in GpuDecoder-inl.cuh. Make selective decoding templatized as opposed to runtime switching.
- Add pieces to GpuDecoderTest, like comparing calling via launchDecode or (multi-function blocks) or decodeGlobal (single function thread blocks).
- Add a metric for driver thread waiting for first continuable stream.
- Check approx correctness of Wave runtimeStats.
- Refactor QueryBenchmarkBase.* from TpchBenchmark. Logic to do sweeps across parameter combinations.
- Add persistent file format to Wave mock format.
- Add benchmark for scan, filter, filter expr, projection. aggregation combinations with Wave and Dwrf.