### PR TITLE
Fix childName to consider ReaderOption fileColumnNamesReadAsLowerCase

### DIFF
--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -280,7 +280,10 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
     auto curSchemaIdx = schemaIdx;
     for (int32_t i = 0; i < schemaElement.num_children; i++) {
       ++schemaIdx;
-      auto& childName = schema[schemaIdx].name;
+      auto childName = schema[schemaIdx].name;
+      if (isFileColumnNamesReadAsLowerCase()) {
+        folly::toLowerAscii(childName);
+      }
       auto childRequestedType =
           requestedType ? requestedType->asRow().findChild(childName) : nullptr;
       auto child = getParquetColumnInfo(

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -304,6 +304,8 @@ TEST_F(ParquetReaderTest, parseReadAsLowerCase) {
   const std::string upper(getExampleFilePath("upper.parquet"));
 
   dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  auto outputRowType = ROW({"a", "b"}, {BIGINT(), BIGINT()});
+  readerOptions.setFileSchema(outputRowType);
   readerOptions.setFileColumnNamesReadAsLowerCase(true);
   auto reader = createReader(upper, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 2ULL);


### PR DESCRIPTION
Converts `childName` to lowercase if hive config `isFileColumnNamesReadAsLowerCase`
is enabled.

cc: @yingsu00 @aditi-pandit 