### PR TITLE
Support creating child scan spec by name

### DIFF
--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -416,7 +416,7 @@ std::shared_ptr<common::ScanSpec> makeScanSpec(
         subfieldSpecs.push_back({subfield, true});
       }
       auto& type = dataColumns->findChild(fieldName);
-      auto* fieldSpec = spec->getOrCreateChild(common::Subfield(fieldName));
+      auto* fieldSpec = spec->getOrCreateChild(fieldName);
       addSubfields(*type, subfieldSpecs, 1, pool, *fieldSpec);
       processFieldSpec(dataColumns, type, *fieldSpec);
       subfieldSpecs.clear();

--- a/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
@@ -59,8 +59,7 @@ PositionalDeleteFileReader::PositionalDeleteFileReader(
   // Create the ScanSpec for this delete file
   auto scanSpec = std::make_shared<common::ScanSpec>("<root>");
   scanSpec->addField(posColumn_->name, 0);
-  auto* pathSpec =
-      scanSpec->getOrCreateChild(common::Subfield(filePathColumn_->name));
+  auto* pathSpec = scanSpec->getOrCreateChild(filePathColumn_->name);
   pathSpec->setFilter(std::make_unique<common::BytesValues>(
       std::vector<std::string>({baseFilePath_}), false));
 

--- a/velox/dwio/common/ScanSpec.cpp
+++ b/velox/dwio/common/ScanSpec.cpp
@@ -19,6 +19,17 @@
 
 namespace facebook::velox::common {
 
+ScanSpec* ScanSpec::getOrCreateChild(const std::string& name) {
+  if (auto it = this->childByFieldName_.find(name);
+      it != this->childByFieldName_.end()) {
+    return it->second;
+  }
+  this->children_.push_back(std::make_unique<ScanSpec>(name));
+  auto* child = this->children_.back().get();
+  this->childByFieldName_[child->fieldName()] = child;
+  return child;
+}
+
 ScanSpec* ScanSpec::getOrCreateChild(const Subfield& subfield) {
   auto container = this;
   auto& path = subfield.path();
@@ -26,15 +37,7 @@ ScanSpec* ScanSpec::getOrCreateChild(const Subfield& subfield) {
     auto element = path[depth].get();
     VELOX_CHECK_EQ(element->kind(), kNestedField);
     auto* nestedField = static_cast<const Subfield::NestedField*>(element);
-    auto it = container->childByFieldName_.find(nestedField->name());
-    if (it != container->childByFieldName_.end()) {
-      container = it->second;
-    } else {
-      container->children_.push_back(std::make_unique<ScanSpec>(*element));
-      auto* child = container->children_.back().get();
-      container->childByFieldName_[child->fieldName()] = child;
-      container = child;
-    }
+    container = container->getOrCreateChild(nestedField->name());
   }
   return container;
 }
@@ -369,7 +372,7 @@ void ScanSpec::addFilter(const Filter& filter) {
 }
 
 ScanSpec* ScanSpec::addField(const std::string& name, column_index_t channel) {
-  auto child = getOrCreateChild(Subfield(name));
+  auto child = getOrCreateChild(name);
   child->setProjectOut(true);
   child->setChannel(channel);
   return child;

--- a/velox/dwio/common/ScanSpec.h
+++ b/velox/dwio/common/ScanSpec.h
@@ -44,16 +44,6 @@ class ScanSpec {
   static constexpr const char* kMapValuesFieldName = "values";
   static constexpr const char* kArrayElementsFieldName = "elements";
 
-  explicit ScanSpec(const Subfield::PathElement& element) {
-    if (element.kind() == kNestedField) {
-      auto field = reinterpret_cast<const Subfield::NestedField*>(&element);
-      fieldName_ = field->name();
-
-    } else {
-      VELOX_CHECK(false, "Only nested fields are supported");
-    }
-  }
-
   explicit ScanSpec(const std::string& name) : fieldName_(name) {}
 
   // Filter to apply. If 'this' corresponds to a struct/list/map, this
@@ -195,6 +185,10 @@ class ScanSpec {
   // will initialize the read order on first call and calling this at
   // each level of struct is mandatory.
   uint64_t newRead();
+
+  /// Returns the ScanSpec corresponding to 'name'. Creates it if needed without
+  /// any intermediate level.
+  ScanSpec* getOrCreateChild(const std::string& name);
 
   // Returns the ScanSpec corresponding to 'subfield'. Creates it if
   // needed, including any intermediate levels. This is used at

--- a/velox/dwio/common/tests/ReaderTest.cpp
+++ b/velox/dwio/common/tests/ReaderTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/dwio/common/Reader.h"
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 #include <gtest/gtest.h>
@@ -30,6 +31,35 @@ class ReaderTest : public testing::Test, public test::VectorTestBase {
     memory::MemoryManager::testingSetInstance({});
   }
 };
+
+TEST_F(ReaderTest, getOrCreateChild) {
+  constexpr int kSize = 5;
+  auto input = makeRowVector(
+      {"c.0", "c.1"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<int64_t>({2, 4, 6, 7, 8}),
+      });
+
+  common::ScanSpec spec("<root>");
+  spec.addField("c.0", 0);
+  // Create child from name.
+  spec.getOrCreateChild("c.1")->setFilter(
+      common::createBigintValues({2, 4, 6}, false));
+
+  auto actual = RowReader::projectColumns(input, spec, nullptr);
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3}),
+  });
+  test::assertEqualVectors(expected, actual);
+
+  // Create child from subfield.
+  spec.getOrCreateChild(common::Subfield("c.1"))
+      ->setFilter(common::createBigintValues({2, 4, 6}, false));
+  VELOX_ASSERT_USER_THROW(
+      RowReader::projectColumns(input, spec, nullptr),
+      "Field not found: c. Available fields are: c.0, c.1.");
+}
 
 TEST_F(ReaderTest, projectColumnsFilterStruct) {
   constexpr int kSize = 10;

--- a/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
@@ -86,10 +86,9 @@ std::vector<KeyNode<T>> getKeyNodes(
   std::unordered_map<KeyValue<T>, common::ScanSpec*, KeyValueHash<T>>
       childSpecs;
   if (!asStruct) {
-    keysSpec = scanSpec.getOrCreateChild(
-        common::Subfield(common::ScanSpec::kMapKeysFieldName));
-    valuesSpec = scanSpec.getOrCreateChild(
-        common::Subfield(common::ScanSpec::kMapValuesFieldName));
+    keysSpec = scanSpec.getOrCreateChild(common::ScanSpec::kMapKeysFieldName);
+    valuesSpec =
+        scanSpec.getOrCreateChild(common::ScanSpec::kMapValuesFieldName);
     VELOX_CHECK(!valuesSpec->hasFilter());
     keysSpec->setProjectOut(true);
     keysSpec->setExtractValues(true);

--- a/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.cpp
@@ -61,8 +61,7 @@ SelectiveListColumnReader::SelectiveListColumnReader(
   // count the number of selected sub-columns
   auto& childType = requestedType_->childAt(0);
   if (scanSpec_->children().empty()) {
-    scanSpec.getOrCreateChild(
-        common::Subfield(common::ScanSpec::kArrayElementsFieldName));
+    scanSpec.getOrCreateChild(common::ScanSpec::kArrayElementsFieldName);
   }
   scanSpec_->children()[0]->setProjectOut(true);
   scanSpec_->children()[0]->setExtractValues(true);
@@ -92,10 +91,8 @@ SelectiveMapColumnReader::SelectiveMapColumnReader(
   EncodingKey encodingKey{fileType_->id(), params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
   if (scanSpec_->children().empty()) {
-    scanSpec_->getOrCreateChild(
-        common::Subfield(common::ScanSpec::kMapKeysFieldName));
-    scanSpec_->getOrCreateChild(
-        common::Subfield(common::ScanSpec::kMapValuesFieldName));
+    scanSpec_->getOrCreateChild(common::ScanSpec::kMapKeysFieldName);
+    scanSpec_->getOrCreateChild(common::ScanSpec::kMapValuesFieldName);
   }
   scanSpec_->children()[0]->setProjectOut(true);
   scanSpec_->children()[0]->setExtractValues(true);


### PR DESCRIPTION
Some of the scan spec child creations should be single level field accessing 
and do not involve field name parsing. This PR adds
`getOrCreateChild(const std::string& name)` to replace these usage.

https://github.com/facebookincubator/velox/pull/7484#issuecomment-2265660197