### PR TITLE
Optimize cross joins with single build batch

### DIFF
--- a/velox/exec/NestedLoopJoinProbe.h
+++ b/velox/exec/NestedLoopJoinProbe.h
@@ -37,8 +37,7 @@ namespace facebook::velox::exec {
 /// To produce output, the operator processes each probe record from probe
 /// input, using the following steps:
 ///
-/// 1. Materialize a cross product by wrapping each probe record (as a constant)
-///    to each build vector.
+/// 1. Materialize a cross-product batch across probe and build.
 /// 2. Evaluate the join condition.
 /// 3. Add key matches to the output.
 /// 4. Once all build vectors are processed for a particular probe row, check if
@@ -49,15 +48,23 @@ namespace facebook::velox::exec {
 ///    collect all build matches at the end, and emit any records that haven't
 ///    been matched by any of the peers.
 ///
-/// The output always contains dictionaries wrapped around probe columns, and
-/// copies for build columns. The only exception are cases when the build side
-/// contains a single record. In that case, each probe batch will be wrapped
-/// with the single build record (as a constant).
+/// There are three different cases for the generation of cross-product across
+/// probe and build (#1 above):
 ///
-/// The buid-side copies are done lazily; it first accumulates the ranges to be
-/// copied, then performs the copies in batch, column-by-column. It produces at
-/// most `outputBatchSize_` records, but it may produce fewer since the output
-/// needs to follow the probe vector boundaries.
+/// a) If build side has a single row, simply wrap that row as a constant and
+/// produce it along with probe batches.
+///
+/// b) If build side has a single batch, produce a dictionary wrapped across
+/// probe and build rows, covering as many probe rows as allowed by
+/// `outputBatchSize_` (maximum record to produce per batch).
+///
+/// c) If build side has multiple vectors, take one probe row are at a time,
+/// wrapping it as a constant, and produce it along with build batches.
+///
+/// If needed, buid-side copies are done lazily; it first accumulates the ranges
+/// to be copied, then performs the copies in batch, column-by-column. It
+/// produces at most `outputBatchSize_` records, but it may produce fewer since
+/// the output needs to follow the probe vector boundaries.
 class NestedLoopJoinProbe : public Operator {
  public:
   NestedLoopJoinProbe(
@@ -140,19 +147,37 @@ class NestedLoopJoinProbe : public Operator {
   }
 
   // Generates the next batch of a cross product between probe and build. It
-  // handles two cases:
-  //
-  // #1. Use the current probe record being processed (`probeRow_` from
-  // `input_`) for probe projections, and the columns from buildVector for build
-  // projections.
-  // #2. For cross joins, if there is a single build record, it uses the columns
-  // from the current probe batch (`input_`), and the single build record
-  // wrapped as a constant.
+  // should be used as the entry point, and will internally delegate to one of
+  // the three functions below.
   //
   // Output projections can be specified so that this function can be used to
   // generate both filter input and actual output (in case there is no join
   // filter - cross join).
   RowVectorPtr getNextCrossProductBatch(
+      const RowVectorPtr& buildVector,
+      const RowTypePtr& outputType,
+      const std::vector<IdentityProjection>& probeProjections,
+      const std::vector<IdentityProjection>& buildProjections);
+
+  // Generates a cross product batch when there is a single build row (probe
+  // batch plus build row as a constant).
+  RowVectorPtr genCrossProductSingleBuildRow(
+      const RowVectorPtr& buildVector,
+      const RowTypePtr& outputType,
+      const std::vector<IdentityProjection>& probeProjections,
+      const std::vector<IdentityProjection>& buildProjections);
+
+  // Generates a cross product batch when there is a single build vector (probe
+  // and build batch wrapped in a dictionary).
+  RowVectorPtr genCrossProductSingleBuildVector(
+      const RowVectorPtr& buildVector,
+      const RowTypePtr& outputType,
+      const std::vector<IdentityProjection>& probeProjections,
+      const std::vector<IdentityProjection>& buildProjections);
+
+  // As a fallback, process the current probe row to as much build data as
+  // possible (probe row as constant, and flat copied data for build records).
+  RowVectorPtr genCrossProductMultipleBuildVectors(
       const RowVectorPtr& buildVector,
       const RowTypePtr& outputType,
       const std::vector<IdentityProjection>& probeProjections,
@@ -209,6 +234,24 @@ class NestedLoopJoinProbe : public Operator {
     return joinCondition_ == nullptr;
   }
 
+  // If build has a single vector, we can wrap probe and build batches into
+  // dictionaries and produce as many combinations of probe and build rows,
+  // until `numOutputRows_` is filled.
+  bool isSingleBuildVector() const {
+    return buildVectors_->size() == 1;
+  }
+
+  // If there are no incoming records in the build side.
+  bool isBuildSideEmpty() const {
+    return buildVectors_->empty();
+  }
+
+  // If build has a single row, we can simply add it as a constant to probe
+  // batches.
+  bool isSingleBuildRow() const {
+    return isSingleBuildVector() && buildVectors_->front()->size() == 1;
+  }
+
   // Wraps rows of 'data' that are not selected in 'matched' and projects
   // to the output according to 'projections'. 'nullProjections' is used to
   // create null column vectors in output for outer join. 'unmatchedMapping' is
@@ -242,6 +285,9 @@ class NestedLoopJoinProbe : public Operator {
   BufferPtr probeIndices_;
   vector_size_t* rawProbeIndices_;
 
+  // Dictionary indices for build columns.
+  BufferPtr buildIndices_;
+
   // Join condition expression.
 
   // May be nullptr for a cross join.
@@ -268,6 +314,9 @@ class NestedLoopJoinProbe : public Operator {
   // Probe row being currently processed (related to `input_`).
   vector_size_t probeRow_{0};
 
+  // How many probe rows are being processed by the current batch.
+  vector_size_t probeRowCount_{1};
+
   // Whether the current probeRow_ has produces a match. Used for left and full
   // outer joins.
   bool probeRowHasMatch_{false};
@@ -287,10 +336,6 @@ class NestedLoopJoinProbe : public Operator {
 
   // Stores the data for build vectors (right side of the join).
   std::optional<std::vector<RowVectorPtr>> buildVectors_;
-  bool buildSideEmpty_{false};
-
-  // Total number of records from the build side (across all vectors).
-  vector_size_t buildRowCount_{0};
 
   // Index into `buildVectors_` for the build vector being currently processed.
   size_t buildIndex_{0};

--- a/velox/exec/tests/NestedLoopJoinTest.cpp
+++ b/velox/exec/tests/NestedLoopJoinTest.cpp
@@ -339,7 +339,8 @@ TEST_F(NestedLoopJoinTest, basicCrossJoin) {
 
   OperatorTestBase::assertQuery(
       params,
-      "SELECT * FROM t, (SELECT * FROM UNNEST (ARRAY[10, 17, 10, 17, 10, 17, 10, 17])) u");
+      "SELECT * FROM t, "
+      "(SELECT * FROM UNNEST (ARRAY[10, 17, 10, 17, 10, 17, 10, 17])) u");
 }
 
 TEST_F(NestedLoopJoinTest, outerJoinWithoutCondition) {


### PR DESCRIPTION
Summary:
As a follow up from:
.
https://github.com/facebookincubator/velox/pull/10690
.
We can also optimize the case of a cross join with a single build batch to
simply wrap probe and build inputs into a dictionary, then avoiding copying
and not producing outputs vectors that are too small.
.
Check in-code header comments for more details.

Differential Revision: D61042584
