### PR TITLE
Fix arrow export of row vectors

### DIFF
--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -769,14 +769,18 @@ void exportOffsets(
     memory::MemoryPool* pool,
     VeloxToArrowBridgeHolder& holder,
     Selection& childRows) {
+  VELOX_CHECK_GE(vec.size(), rows.count());
+
   auto offsets = AlignedBuffer::allocate<vector_size_t>(
       checkedPlus<size_t>(out.length, 1), pool);
   auto rawOffsets = offsets->asMutable<vector_size_t>();
+
   if (!rows.changed() && isCompact(vec)) {
-    memcpy(rawOffsets, vec.rawOffsets(), sizeof(vector_size_t) * vec.size());
-    rawOffsets[vec.size()] = vec.size() == 0
+    vector_size_t rowCount = rows.count();
+    memcpy(rawOffsets, vec.rawOffsets(), sizeof(vector_size_t) * rowCount);
+    rawOffsets[rowCount] = rowCount == 0
         ? 0
-        : vec.offsetAt(vec.size() - 1) + vec.sizeAt(vec.size() - 1);
+        : vec.offsetAt(rowCount - 1) + vec.sizeAt(rowCount - 1);
   } else {
     childRows.clearAll();
     // j: Index of element we are writing.


### PR DESCRIPTION
Summary:
It is valid to have row vectors with children longer than the row vector
size. For these cases, making sure that map exportOffset doesn't use the size
of the child, but rather to the size of the container.

Differential Revision: D61058146
