### PR TITLE
Remove duplicate assignment in Task::toJson method

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2338,7 +2338,6 @@ folly::dynamic Task::toJson() const {
   obj["groupedPartitionedOutput"] = groupedPartitionedOutput_;
   obj["concurrentSplitGroups"] = concurrentSplitGroups_;
   obj["numRunningSplitGroups"] = numRunningSplitGroups_;
-  obj["numDriversUngrouped"] = numDriversUngrouped_;
   obj["partitionedOutputConsumed"] = partitionedOutputConsumed_;
   obj["noMoreOutputBuffers"] = noMoreOutputBuffers_;
   obj["onThreadSince"] = std::to_string(onThreadSince_);


### PR DESCRIPTION
summary:

The Task::toJson method currently contains a duplicate assignment of the numDriversUngrouped_ attribute, which is unnecessary and redundant.
This commit removes the superfluous line to clean up the code and prevent any potential confusion.