### PR TITLE
Simplify the memory pool arbitration process management

### DIFF
--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -307,10 +307,6 @@ class MemoryManager {
  private:
   void dropPool(MemoryPool* pool);
 
-  // Invoked to grow a memory pool's free capacity with at least
-  // 'incrementBytes'. The function returns true on success, otherwise false.
-  bool growPool(MemoryPool* pool, uint64_t incrementBytes);
-
   //  Returns the shared references to all the alive memory pools in 'pools_'.
   std::vector<std::shared_ptr<MemoryPool>> getAlivePools() const;
 
@@ -328,8 +324,6 @@ class MemoryManager {
   // tracked by 'pools_'. It is invoked on the root pool destruction and removes
   // the pool from 'pools_'.
   const MemoryPoolImpl::DestructionCallback poolDestructionCb_;
-  // Callback invoked by the root memory pool to request memory capacity growth.
-  const MemoryPoolImpl::GrowCapacityCallback poolGrowCb_;
 
   const std::shared_ptr<MemoryPool> sysRoot_;
   const std::shared_ptr<MemoryPool> spillPool_;

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -411,10 +411,10 @@ class ScopedMemoryArbitrationContext {
  public:
   explicit ScopedMemoryArbitrationContext(const MemoryPool* requestor);
 
-  // Can be used to restore a previously captured MemoryArbitrationContext.
-  // contextToRestore can be nullptr if there was no context at the time it was
-  // captured, in which case arbitrationCtx is unchanged upon
-  // contruction/destruction of this object.
+  /// Can be used to restore a previously captured MemoryArbitrationContext.
+  /// contextToRestore can be nullptr if there was no context at the time it was
+  /// captured, in which case arbitrationCtx is unchanged upon
+  /// contruction/destruction of this object.
   explicit ScopedMemoryArbitrationContext(
       const MemoryArbitrationContext* contextToRestore);
 
@@ -423,6 +423,17 @@ class ScopedMemoryArbitrationContext {
  private:
   MemoryArbitrationContext* const savedArbitrationCtx_{nullptr};
   MemoryArbitrationContext currentArbitrationCtx_;
+};
+
+/// Object used to setup arbitration context for a memory pool.
+class ScopedMemoryPoolArbitrationCtx {
+ public:
+  explicit ScopedMemoryPoolArbitrationCtx(MemoryPool* pool);
+
+  ~ScopedMemoryPoolArbitrationCtx();
+
+ private:
+  MemoryPool* const pool_;
 };
 
 /// Returns the memory arbitration context set by a per-thread local variable if

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -165,7 +165,6 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   // Contains the execution state of an arbitration operation.
   struct ArbitrationOperation {
     MemoryPool* const requestPool;
-    MemoryPool* const requestRoot;
     const uint64_t requestBytes;
     // The start time of this arbitration operation.
     const std::chrono::steady_clock::time_point startTime;
@@ -187,17 +186,15 @@ class SharedArbitrator : public memory::MemoryArbitrator {
 
     ArbitrationOperation(MemoryPool* _requestor, uint64_t _requestBytes)
         : requestPool(_requestor),
-          requestRoot(_requestor == nullptr ? nullptr : _requestor->root()),
           requestBytes(_requestBytes),
-          startTime(std::chrono::steady_clock::now()) {}
+          startTime(std::chrono::steady_clock::now()) {
+      VELOX_CHECK(requestPool == nullptr || requestPool->isRoot());
+    }
 
     uint64_t waitTimeUs() const {
       return localArbitrationQueueTimeUs + localArbitrationLockWaitTimeUs +
           globalArbitrationLockWaitTimeUs;
     }
-
-    void enterArbitration();
-    void leaveArbitration();
   };
 
   // Used to start and finish an arbitration operation initiated from a memory

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -161,14 +161,12 @@ TEST_P(MemoryPoolTest, ctor) {
         MemoryPool::Kind::kAggregate,
         nullptr,
         nullptr,
-        nullptr,
         nullptr);
     // We can't construct an aggregate memory pool with non-thread safe.
     ASSERT_ANY_THROW(std::make_shared<MemoryPoolImpl>(
         &manager,
         "fake_root",
         MemoryPool::Kind::kAggregate,
-        nullptr,
         nullptr,
         nullptr,
         nullptr,

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -636,8 +636,8 @@ TEST_F(MockSharedArbitrationTest, arbitrationStateCheck) {
   const int minPoolCapacity = 32 * MB;
   std::atomic<int> checkCount{0};
   MemoryArbitrationStateCheckCB checkCountCb = [&](MemoryPool& pool) {
-    const std::string re("MockTask.*");
-    ASSERT_TRUE(RE2::FullMatch(pool.name(), re));
+    const std::string re("RootPool.*");
+    ASSERT_TRUE(RE2::FullMatch(pool.name(), re)) << pool.name();
     ++checkCount;
   };
   setupMemory(memCapacity, 0, 0, 0, 0, checkCountCb);


### PR DESCRIPTION
Move memory arbitration context setting from shared arbitrator to memory pool and pass the
root memory pool to memory arbitrator directly to simplify the the arbitrator backend implementation.
The memory pool handles the memory arbitration context setting and grow the capacity with the
memory arbitrator directly.