### PR TITLE
Hold shared reference on memory pool inside arbitrator

### DIFF
--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -373,6 +373,10 @@ class TestMemoryPool : public memory::MemoryPool {
     return nullptr;
   }
 
+  void registerArbitration() override {}
+
+  void unregisterArbitration() override {}
+
   void enterArbitration() override {}
 
   void leaveArbitration() noexcept override {}

--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -180,7 +180,7 @@ MemoryManager::~MemoryManager() {
     if (checkUsageLeak_) {
       VELOX_FAIL(errMsg);
     } else {
-      LOG(ERROR) << errMsg;
+      VELOX_MEM_LOG(ERROR) << errMsg;
     }
   }
 }
@@ -273,7 +273,7 @@ std::shared_ptr<MemoryPool> MemoryManager::addRootPool(
       options);
   pools_.emplace(poolName, pool);
   VELOX_CHECK_EQ(pool->capacity(), 0);
-  arbitrator_->addPool(pool);
+  pool->registerArbitration();
   RECORD_HISTOGRAM_METRIC_VALUE(
       kMetricMemoryPoolInitialCapacityBytes, pool->capacity());
   return pool;
@@ -312,7 +312,6 @@ void MemoryManager::dropPool(MemoryPool* pool) {
   }
   pools_.erase(it);
   VELOX_DCHECK_EQ(pool->reservedBytes(), 0);
-  arbitrator_->removePool(pool);
 }
 
 MemoryPool& MemoryManager::deprecatedSharedLeafPool() {

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -235,6 +235,9 @@ class MemoryManager {
   /// Creates a root memory pool with specified 'name' and 'maxCapacity'. If
   /// 'name' is missing, the memory manager generates a default name internally
   /// to ensure uniqueness.
+  ///
+  /// NOTE: the user needs to call 'unregisterArbitration' to detech the root
+  /// memory pool from the memory arbitrator before the destruction.
   std::shared_ptr<MemoryPool> addRootPool(
       const std::string& name = "",
       int64_t maxCapacity = kMaxMemory,

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -277,6 +277,8 @@ class MemoryReclaimer {
 
     void reset();
 
+    std::string toString() const;
+
     bool operator==(const Stats& other) const;
     bool operator!=(const Stats& other) const;
     Stats& operator+=(const Stats& other);

--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -1039,9 +1039,21 @@ uint64_t MemoryPoolImpl::reclaim(
     uint64_t maxWaitMs,
     memory::MemoryReclaimer::Stats& stats) {
   if (reclaimer() == nullptr) {
+    LOG(ERROR) << "gone";
     return 0;
   }
+  LOG(ERROR) << "continue";
   return reclaimer()->reclaim(this, targetBytes, maxWaitMs, stats);
+}
+
+void MemoryPoolImpl::registerArbitration() {
+  VELOX_CHECK(isRoot());
+  manager_->arbitrator()->addPool(shared_from_this());
+}
+
+void MemoryPoolImpl::unregisterArbitration() {
+  VELOX_CHECK(isRoot());
+  manager_->arbitrator()->removePool(this);
 }
 
 void MemoryPoolImpl::enterArbitration() {

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -432,7 +432,7 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   const bool checkUsageLeak_;
 
   mutable folly::SharedMutex poolLock_;
-  std::unordered_map<MemoryPool*, std::weak_ptr<MemoryPool>> candidates_;
+  std::unordered_map<std::string, std::shared_ptr<MemoryPool>> candidates_;
 
   // Lock used to protect the arbitrator state.
   mutable std::mutex stateLock_;

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -3433,6 +3433,9 @@ TEST_P(MemoryPoolTest, maybeReserveFailWithAbort) {
   MemoryManager& manager = *getMemoryManager();
   auto root = manager.addRootPool(
       "maybeReserveFailWithAbort", kMaxSize, MemoryReclaimer::create());
+  SCOPE_EXIT {
+    root->unregisterArbitration();
+  };
   auto child = root->addLeafChild("maybeReserveFailWithAbort");
   // maybeReserve returns false if reservation fails.
   ASSERT_FALSE(child->maybeReserve(2 * kMaxSize));
@@ -3838,6 +3841,9 @@ TEST_P(MemoryPoolTest, overuseUnderArbitration) {
   MemoryManager& manager = *getMemoryManager();
   auto root = manager.addRootPool(
       "overuseUnderArbitration", kMaxSize, MemoryReclaimer::create());
+  SCOPE_EXIT {
+    root->unregisterArbitration();
+  };
   auto child = root->addLeafChild("overuseUnderArbitration");
   // maybeReserve returns false if reservation fails.
   ASSERT_FALSE(child->maybeReserve(2 * kMaxSize));

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -62,11 +62,18 @@ class HiveDataSinkTest : public exec::test::HiveConnectorTestBase {
   }
 
   void TearDown() override {
+    reset();
+    HiveConnectorTestBase::TearDown();
+  }
+
+  void reset() {
     connectorQueryCtx_.reset();
     connectorPool_.reset();
     opPool_.reset();
+    if (root_ != nullptr) {
+      root_->unregisterArbitration();
+    }
     root_.reset();
-    HiveConnectorTestBase::TearDown();
   }
 
   std::vector<RowVectorPtr> createVectors(int vectorSize, int numVectors) {
@@ -102,10 +109,7 @@ class HiveDataSinkTest : public exec::test::HiveConnectorTestBase {
   }
 
   void setupMemoryPools() {
-    connectorQueryCtx_.reset();
-    connectorPool_.reset();
-    opPool_.reset();
-    root_.reset();
+    reset();
 
     root_ = memory::memoryManager()->addRootPool(
         "HiveDataSinkTest", 1L << 30, exec::MemoryReclaimer::create());

--- a/velox/core/QueryCtx.cpp
+++ b/velox/core/QueryCtx.cpp
@@ -58,6 +58,11 @@ QueryCtx::QueryCtx(
   initPool(queryId);
 }
 
+QueryCtx::~QueryCtx() {
+  VELOX_CHECK(!underArbitration_);
+  pool_->unregisterArbitration();
+}
+
 /*static*/ std::string QueryCtx::generatePoolName(const std::string& queryId) {
   // We attach a monotonically increasing sequence number to ensure the pool
   // name is unique.

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -28,9 +28,7 @@ namespace facebook::velox::core {
 
 class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
  public:
-  ~QueryCtx() {
-    VELOX_CHECK(!underArbitration_);
-  }
+  ~QueryCtx();
 
   /// QueryCtx is used in different places. When used with `Task::start()`, it's
   /// required that the caller supplies the executor and ensure its lifetime
@@ -112,10 +110,6 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
   /// Updates the aggregated spill bytes of this query, and and throws if
   /// exceeds the max spill bytes limit.
   void updateSpilledBytesAndCheckLimit(uint64_t bytes);
-
-  void testingOverrideMemoryPool(std::shared_ptr<memory::MemoryPool> pool) {
-    pool_ = std::move(pool);
-  }
 
   /// Indicates if the query is under memory arbitration or not.
   bool testingUnderArbitration() const {

--- a/velox/dwio/dwrf/test/E2EReaderTest.cpp
+++ b/velox/dwio/dwrf/test/E2EReaderTest.cpp
@@ -138,10 +138,15 @@ TEST_P(E2EReaderTest, SharedDictionaryFlatmapReadAsStruct) {
   RemoveGuard guard(path);
   auto localWriteFile = std::make_unique<LocalWriteFile>(path, true, false);
   auto sink = std::make_unique<WriteFileSink>(std::move(localWriteFile), path);
+  auto writerPool = memory::memoryManager()->addRootPool();
+  SCOPE_EXIT {
+    writerPool->unregisterArbitration();
+  };
   auto writer = E2EWriterTestUtil::createWriter(
       std::move(sink),
       type,
       config,
+      writerPool,
       E2EWriterTestUtil::simpleFlushPolicyFactory(true));
 
   auto seed = folly::Random::secureRand32();

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -187,6 +187,14 @@ class MockMemoryPool : public velox::memory::MemoryPool {
     return nullptr;
   }
 
+  void registerArbitration() override {
+    VELOX_UNSUPPORTED("{} unsupported", __FUNCTION__);
+  }
+
+  void unregisterArbitration() override {
+    VELOX_UNSUPPORTED("{} unsupported", __FUNCTION__);
+  }
+
   void enterArbitration() override {
     VELOX_UNSUPPORTED("{} unsupported", __FUNCTION__);
   }

--- a/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.h
+++ b/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.h
@@ -30,6 +30,7 @@ class E2EWriterTestUtil {
    *                            in-memory or on-disk.
    *    type                    schema of the output data
    *    config                  ORC configs
+   *    pool                    memory pool for the writer
    *    flushPolicyFactory      supplies the policy writer use to determine
    *                            when to flush the current stripe and start a
    *                            new one
@@ -41,6 +42,7 @@ class E2EWriterTestUtil {
       std::unique_ptr<dwio::common::FileSink> sink,
       const std::shared_ptr<const Type>& type,
       const std::shared_ptr<Config>& config,
+      const std::shared_ptr<velox::memory::MemoryPool>& pool,
       std::function<std::unique_ptr<DWRFFlushPolicy>()> flushPolicyFactory =
           nullptr,
       std::function<std::unique_ptr<LayoutPlanner>(

--- a/velox/exec/benchmarks/ExchangeBenchmark.cpp
+++ b/velox/exec/benchmarks/ExchangeBenchmark.cpp
@@ -290,9 +290,12 @@ class ExchangeBenchmark : public VectorTestBase {
       int64_t maxMemory = kMaxMemory) {
     auto configCopy = configSettings_;
     auto queryCtx = core::QueryCtx::create(
-        executor_.get(), core::QueryConfig(std::move(configCopy)));
-    queryCtx->testingOverrideMemoryPool(
-        memory::memoryManager()->addRootPool(queryCtx->queryId(), maxMemory));
+        executor_.get(),
+        core::QueryConfig{std::move(configCopy)},
+        {},
+        nullptr,
+        memory::memoryManager()->addRootPool(taskId, maxMemory));
+
     core::PlanFragment planFragment{planNode};
     return Task::create(
         taskId,

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -77,9 +77,11 @@ class ExchangeClientTest : public testing::Test,
           std::to_string(maxOutputBufferSizeInBytes.value());
     }
     auto queryCtx = core::QueryCtx::create(
-        executor_.get(), core::QueryConfig{std::move(config)});
-    queryCtx->testingOverrideMemoryPool(
-        memory::memoryManager()->addRootPool(queryCtx->queryId()));
+        executor_.get(),
+        core::QueryConfig{std::move(config)},
+        {},
+        nullptr,
+        memory::memoryManager()->addRootPool(taskId));
     auto plan = test::PlanBuilder().values({}).planNode();
     return Task::create(
         taskId,

--- a/velox/exec/tests/ExchangeFuzzer.cpp
+++ b/velox/exec/tests/ExchangeFuzzer.cpp
@@ -485,9 +485,11 @@ class ExchangeFuzzer : public VectorTestBase {
       int64_t maxMemory = kMaxMemory) {
     auto configCopy = configSettings_;
     auto queryCtx = core::QueryCtx::create(
-        executor_.get(), core::QueryConfig(std::move(configCopy)));
-    queryCtx->testingOverrideMemoryPool(
-        memory::memoryManager()->addRootPool(queryCtx->queryId(), maxMemory));
+        executor_.get(),
+        core::QueryConfig(std::move(configCopy)),
+        {},
+        nullptr,
+        memory::memoryManager()->addRootPool(taskId, maxMemory));
     core::PlanFragment planFragment{planNode};
     return Task::create(
         taskId,

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -609,10 +609,12 @@ class HashJoinBuilder {
         core::QueryConfig{{}},
         std::unordered_map<std::string, std::shared_ptr<Config>>{},
         cache::AsyncDataCache::getInstance(),
-        memory::MemoryManager::getInstance()->addRootPool(
-            "query_pool",
-            memory::kMaxMemory,
-            memory::MemoryReclaimer::create()));
+        queryPool_ != nullptr
+            ? queryPool_
+            : memory::MemoryManager::getInstance()->addRootPool(
+                  "query_pool",
+                  memory::kMaxMemory,
+                  exec::MemoryReclaimer::create()));
     std::shared_ptr<TempDirectoryPath> spillDirectory;
     int32_t spillPct{0};
     if (injectSpill) {
@@ -645,9 +647,6 @@ class HashJoinBuilder {
     if (!configs_.empty()) {
       auto configCopy = configs_;
       queryCtx->testingOverrideConfigUnsafe(std::move(configCopy));
-    }
-    if (queryPool_ != nullptr) {
-      queryCtx->testingOverrideMemoryPool(queryPool_);
     }
     builder.queryCtx(queryCtx);
 

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -73,9 +73,12 @@ class MultiFragmentTest : public HiveConnectorTestBase {
       int64_t maxMemory = memory::kMaxMemory) {
     auto configCopy = configSettings_;
     auto queryCtx = core::QueryCtx::create(
-        executor_.get(), core::QueryConfig(std::move(configCopy)));
-    queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
-        queryCtx->queryId(), maxMemory, MemoryReclaimer::create()));
+        executor_.get(),
+        core::QueryConfig(std::move(configCopy)),
+        {},
+        nullptr,
+        memory::memoryManager()->addRootPool(
+            taskId, maxMemory, MemoryReclaimer::create()));
     core::PlanFragment planFragment{planNode};
     return Task::create(
         taskId,

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -555,9 +555,16 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringInputProcessing) {
     SCOPED_TRACE(testData.debugString());
 
     auto spillDirectory = exec::test::TempDirectoryPath::create();
-    auto queryCtx = core::QueryCtx::create(executor_.get());
-    queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
-        queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
+    auto queryCtx = core::QueryCtx::create(
+        executor_.get(),
+        core::QueryConfig{{}},
+        {},
+        nullptr,
+        memory::memoryManager()->addRootPool(
+            "reclaimDuringInputProcessing",
+            kMaxBytes,
+            memory::MemoryReclaimer::create()));
+
     auto expectedResult =
         AssertQueryBuilder(
             PlanBuilder()
@@ -694,9 +701,15 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringReserve) {
   }
 
   auto spillDirectory = exec::test::TempDirectoryPath::create();
-  auto queryCtx = core::QueryCtx::create(executor_.get());
-  queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
-      queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
+  auto queryCtx = core::QueryCtx::create(
+      executor_.get(),
+      core::QueryConfig{{}},
+      {},
+      nullptr,
+      memory::memoryManager()->addRootPool(
+          "reclaimDuringReserve",
+          kMaxBytes,
+          memory::MemoryReclaimer::create()));
   auto expectedResult =
       AssertQueryBuilder(
           PlanBuilder()
@@ -807,9 +820,15 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringAllocation) {
   for (const auto enableSpilling : enableSpillings) {
     SCOPED_TRACE(fmt::format("enableSpilling {}", enableSpilling));
     auto spillDirectory = exec::test::TempDirectoryPath::create();
-    auto queryCtx = core::QueryCtx::create(executor_.get());
-    queryCtx->testingOverrideMemoryPool(
-        memory::memoryManager()->addRootPool(queryCtx->queryId(), kMaxBytes));
+    auto queryCtx = core::QueryCtx::create(
+        executor_.get(),
+        core::QueryConfig{{}},
+        {},
+        nullptr,
+        memory::memoryManager()->addRootPool(
+            "reclaimDuringAllocation",
+            kMaxBytes,
+            memory::MemoryReclaimer::create()));
     auto expectedResult =
         AssertQueryBuilder(
             PlanBuilder()
@@ -937,9 +956,15 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringOutputProcessing) {
   for (const auto enableSpilling : enableSpillings) {
     SCOPED_TRACE(fmt::format("enableSpilling {}", enableSpilling));
     auto spillDirectory = exec::test::TempDirectoryPath::create();
-    auto queryCtx = core::QueryCtx::create(executor_.get());
-    queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
-        queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
+    auto queryCtx = core::QueryCtx::create(
+        executor_.get(),
+        core::QueryConfig{{}},
+        {},
+        nullptr,
+        memory::memoryManager()->addRootPool(
+            "reclaimDuringOutputProcessing",
+            kMaxBytes,
+            memory::MemoryReclaimer::create()));
     auto expectedResult =
         AssertQueryBuilder(
             PlanBuilder()

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -41,8 +41,6 @@ class SortBufferTest : public OperatorTestBase {
   }
 
   void TearDown() override {
-    pool_.reset();
-    rootPool_.reset();
     OperatorTestBase::TearDown();
   }
 

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -44,6 +44,7 @@ namespace facebook::velox::exec::test {
 OperatorTestBase::OperatorTestBase() {
   // Overloads the memory pools used by VectorTestBase to work with memory
   // arbitrator.
+  rootPool_->unregisterArbitration();
   rootPool_ = memory::memoryManager()->addRootPool(
       "", memory::kMaxMemory, exec::MemoryReclaimer::create());
   pool_ = rootPool_->addLeafChild("", true, exec::MemoryReclaimer::create());
@@ -134,7 +135,10 @@ void OperatorTestBase::TearDown() {
   // reference to memory pool. We need to make sure they are properly cleaned.
   testingShutdownLocalExchangeSource();
   pool_.reset();
+  rootPool_->unregisterArbitration();
+
   rootPool_.reset();
+
   resetMemory();
 }
 

--- a/velox/functions/prestosql/aggregates/tests/ApproxMostFrequentTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxMostFrequentTest.cpp
@@ -138,6 +138,9 @@ using ApproxMostFrequentTestInt = ApproxMostFrequentTest<int>;
 TEST_F(ApproxMostFrequentTestInt, invalidBuckets) {
   auto rootPool = memory::memoryManager()->addRootPool(
       "test-root", 1 << 21, exec::MemoryReclaimer::create());
+  SCOPE_EXIT {
+    rootPool->unregisterArbitration();
+  };
   auto leafPool = rootPool->addLeafChild("test-leaf");
   auto run = [&](int64_t buckets) {
     auto rows = makeRowVector({


### PR DESCRIPTION
Let arbitrator hold a shared reference instead of weak pointer to avoid pointer upgrade
to ease the global arbitration implementation in followup