### PR TITLE
Respect kPreferredOutputBatchRows strictly in Unnest

### DIFF
--- a/velox/exec/Unnest.cpp
+++ b/velox/exec/Unnest.cpp
@@ -114,9 +114,9 @@ RowVectorPtr Unnest::getOutput() {
   const auto size = input_->size();
 
   // Limit the number of input rows to keep output batch size within
-  // 'maxOutputSize' if possible. Not process each input row fully when
-  // row's output exceeds maxOutputSize. Single row's output maybe into
-  // multiple batches.
+  // 'maxOutputSize' if possible. Not process each input row fully when a
+  // row's output exceeds 'maxOutputSize'. The output of single row may be
+  // divided into multiple batches.
   vector_size_t numElements = 0;
   vector_size_t partialProcessRowStart = -1;
   auto rowRange = extractRowRange(size, numElements, partialProcessRowStart);
@@ -145,7 +145,7 @@ RowVectorPtr Unnest::getOutput() {
 }
 
 const Unnest::RowRange Unnest::extractRowRange(
-  vector_size_t size,
+    vector_size_t size,
     vector_size_t& numElements,
     vector_size_t& partialProcessRowStart) {
   VELOX_DCHECK_LT(nextInputRow_, size);

--- a/velox/exec/Unnest.cpp
+++ b/velox/exec/Unnest.cpp
@@ -154,15 +154,16 @@ const Unnest::RowRange Unnest::extractRowRange(
   vector_size_t firstRowEnd = rawMaxSizes_[nextInputRow_];
   vector_size_t lastRowEnd = -1;
   // May split the first row and the last row, not split middle rows.
-  // If there is only 1 row, the end row will not take effect, its start is
-  // always 0.
+  // The end row related variables firstRowEnd and lastRowEnd will not be used
+  // if there is just one row, its start is always 0.
   for (auto row = nextInputRow_; row < size; ++row) {
     bool isFirstRow = (row == nextInputRow_);
     vector_size_t remainingSize =
         isFirstRow ? firstRowEnd - firstRowStart_ : rawMaxSizes_[row];
     if (numElements + remainingSize > maxOutputSize_) {
-      // Single row's output is into multiple batches.
-      // Read the size range from them, not use 0 to rawMaxSizes_[row].
+      // Single row's output is divided into multiple batches.
+      // Computes the row range to process the first and last row
+      // partially instead of 0 to rawMaxSizes_[row].
       if (isFirstRow) {
         firstRowEnd = firstRowStart_ + maxOutputSize_ - numElements;
         partialProcessRowStart = firstRowEnd;

--- a/velox/exec/Unnest.cpp
+++ b/velox/exec/Unnest.cpp
@@ -134,12 +134,12 @@ RowVectorPtr Unnest::getOutput() {
       numElements = maxOutputSize_;
       partialProcessRowStartSize = firstRowEndSize;
     } else {
-      // Not need to split this row
+      // No need to split this row.
       numElements += remainingSize;
     }
     ++numInput;
   }
-  // Not split middle row.
+  // Not split middle rows.
   // If there is only 1 row, the end row will not take effect, its startSize is
   // always 0.
   vector_size_t endRowEndSize = -1;
@@ -164,7 +164,7 @@ RowVectorPtr Unnest::getOutput() {
       ++numInput;
     }
   }
-  // The end row is not partial, set it to the maxSize.
+  // The end row is not partial and should take effect, set it to the maxSize.
   if (endRowEndSize == -1 && numInput > 1) {
     endRowEndSize = rawMaxSizes_[nextInputRow_ + numInput - 1];
   }

--- a/velox/exec/Unnest.cpp
+++ b/velox/exec/Unnest.cpp
@@ -184,7 +184,7 @@ const Unnest::RowRange Unnest::extractRowRange(
     }
   }
   // The end row is not partial and should take effect, set it to the maxSize.
-  if (lastRowEnd == -1 && numInput > 1) {
+  if (!lastRowEnd.has_value() && numInput > 1) {
     lastRowEnd = rawMaxSizes_[nextInputRow_ + numInput - 1];
   }
   return {nextInputRow_, numInput, firstRowEnd, lastRowEnd};

--- a/velox/exec/Unnest.cpp
+++ b/velox/exec/Unnest.cpp
@@ -186,7 +186,7 @@ void Unnest::generateRepeatedColumns(
   VELOX_DCHECK_GT(range.size, 0);
   // Record the row number to process.
   range.forEachRow(
-      [&](vector_size_t row, vector_size_t start, vector_size_t size) {
+      [&](vector_size_t row, vector_size_t /*start*/, vector_size_t size) {
         std::fill(
             rawRepeatedIndices + index, rawRepeatedIndices + index + size, row);
         index += size;
@@ -350,7 +350,10 @@ bool Unnest::isFinished() {
 }
 
 void Unnest::RowRange::forEachRow(
-    std::function<void(vector_size_t, vector_size_t, vector_size_t)> func,
+    std::function<void(
+        vector_size_t /*row*/,
+        vector_size_t /*start*/,
+        vector_size_t /*size*/)> func,
     const vector_size_t* const rawMaxSizes,
     vector_size_t firstRowStart) const {
   // Process the first row.

--- a/velox/exec/Unnest.h
+++ b/velox/exec/Unnest.h
@@ -40,11 +40,14 @@ class Unnest : public Operator {
 
  private:
   // Generate output for 'size' input rows starting from 'start' input row.
-  // Get the firstRowStartSize from class member `firstRowStartSize_`.
+  // The firstRowStartSize is class member `firstRowStartSize_` and the
+  // endRowStartSize is always 0.
   //
   // @param start First input row to include in the output.
   // @param size Number of input rows to include in the output.
   // @param outputSize Pre-computed number of output rows.
+  // @param firstRowEndSize First input row output end range.
+  // @param endRowEndSize End input row output end range.
   RowVectorPtr generateOutput(
       vector_size_t start,
       vector_size_t size,
@@ -93,10 +96,12 @@ class Unnest : public Operator {
 
   std::vector<DecodedVector> unnestDecoded_;
 
+  // The maxium number of output batch rows.
   const uint32_t maxOutputSize_;
   BufferPtr maxSizes_;
   vector_size_t* rawMaxSizes_{nullptr};
 
+  // The first input row output start range.
   vector_size_t firstRowStartSize_ = 0;
 
   std::vector<const vector_size_t*> rawSizes_;

--- a/velox/exec/Unnest.h
+++ b/velox/exec/Unnest.h
@@ -53,20 +53,20 @@ class Unnest : public Operator {
     vector_size_t firstRowEnd;
 
     // Processing of the last input row begins at index 0 and ends at
-    // 'lastRowEnd'.
-    vector_size_t lastRowEnd;
+    // 'lastRowEnd'. It is nullopt when there is only one row to process.
+    std::optional<vector_size_t> lastRowEnd;
   };
 
   // Extract the range of rows to process.
   // @param size The size of input RowVector.
-  // @param numElements Records the number of output rows..
+  // @param numElements Records the number of output rows.
   // @param partialProcessRowStart Records the start index when processing the
   // first row in the next iteration. It will not be changed when all the input
   // rows can be fully processed.
   const RowRange extractRowRange(
       vector_size_t size,
       vector_size_t& numElements,
-      vector_size_t& partialProcessRowStart);
+      std::optional<vector_size_t>& partialProcessRowStart);
 
   // Generate output for 'rowRange' represented rows.
   // @param rowRange Range of rows to process.

--- a/velox/exec/Unnest.h
+++ b/velox/exec/Unnest.h
@@ -40,6 +40,7 @@ class Unnest : public Operator {
 
  private:
   // Generate output for 'size' input rows starting from 'start' input row.
+  // Get the firstRowStartSize from class member `firstRowStartSize_`.
   //
   // @param start First input row to include in the output.
   // @param size Number of input rows to include in the output.
@@ -47,7 +48,9 @@ class Unnest : public Operator {
   RowVectorPtr generateOutput(
       vector_size_t start,
       vector_size_t size,
-      vector_size_t outputSize);
+      vector_size_t outputSize,
+      vector_size_t firstRowEndSize,
+      vector_size_t endRowEndSize);
 
   // Invoked by generateOutput function above to generate the repeated output
   // columns.
@@ -55,7 +58,9 @@ class Unnest : public Operator {
       vector_size_t start,
       vector_size_t size,
       vector_size_t numElements,
-      std::vector<VectorPtr>& outputs);
+      std::vector<VectorPtr>& outputs,
+      vector_size_t firstRowEndSize,
+      vector_size_t endRowEndSize);
 
   struct UnnestChannelEncoding {
     BufferPtr indices;
@@ -71,21 +76,28 @@ class Unnest : public Operator {
       column_index_t channel,
       vector_size_t start,
       vector_size_t size,
-      vector_size_t numElements);
+      vector_size_t numElements,
+      vector_size_t firstRowEndSize,
+      vector_size_t endRowEndSize);
 
   // Invoked by generateOutput for the ordinality column.
   VectorPtr generateOrdinalityVector(
       vector_size_t start,
       vector_size_t size,
-      vector_size_t numElements);
+      vector_size_t numElements,
+      vector_size_t firstRowEndSize,
+      vector_size_t endRowEndSize);
 
   const bool withOrdinality_;
   std::vector<column_index_t> unnestChannels_;
 
   std::vector<DecodedVector> unnestDecoded_;
 
+  const uint32_t maxOutputSize_;
   BufferPtr maxSizes_;
   vector_size_t* rawMaxSizes_{nullptr};
+
+  vector_size_t firstRowStartSize_ = 0;
 
   std::vector<const vector_size_t*> rawSizes_;
   std::vector<const vector_size_t*> rawOffsets_;

--- a/velox/exec/Unnest.h
+++ b/velox/exec/Unnest.h
@@ -61,7 +61,8 @@ class Unnest : public Operator {
   // @param size The size of input RowVector.
   // @param numElements Records the number of output rows..
   // @param partialProcessRowStart Records the start index when processing the
-  // first row in the next iteration.
+  // first row in the next iteration. It will not be changed when all the input
+  // rows can be fully processed.
   const RowRange extractRowRange(
       vector_size_t size,
       vector_size_t& numElements,

--- a/velox/exec/Unnest.h
+++ b/velox/exec/Unnest.h
@@ -39,25 +39,29 @@ class Unnest : public Operator {
   bool isFinished() override;
 
  private:
-  // Represents the range of rows to process and specify that first and last row
-  // may need to be processed partially.
+  // Represents the range of rows to process and indicates that first and last
+  // row may need to be processed partially.
   struct RowRange {
-    // First input row to include in the output.
+    // First input row to be included in the output.
     vector_size_t start;
-    // Number of input rows to include in the output.
+
+    // Number of input rows to be included in the output.
     vector_size_t size;
-    // First input row start processing from `firstRowStart_`end processing.
+
+    // Processing of the first input row begins at index `firstRowStart_` and
+    // ends at 'firstRowEnd'.
     vector_size_t firstRowEnd;
-    // Last input row start processing from 0, end processing at index
-    // `lastRowEnd`.
+
+    // Processing of the last input row begins at index 0 and ends at
+    // 'lastRowEnd'.
     vector_size_t lastRowEnd;
   };
 
   // Extract the range of rows to process.
   // @param size The size of input RowVector.
-  // @param numElements Number of output rows to set.
-  // @param partialProcessRowStart record the next getOutput loop
-  // `firstRowStart`.
+  // @param numElements Records the number of output rows..
+  // @param partialProcessRowStart Records the start index when processing the
+  // first row in the next iteration.
   const RowRange extractRowRange(
       vector_size_t size,
       vector_size_t& numElements,
@@ -102,12 +106,12 @@ class Unnest : public Operator {
 
   std::vector<DecodedVector> unnestDecoded_;
 
-  // The maxium number of output batch rows.
+  // The maximum number of output batch rows.
   const uint32_t maxOutputSize_;
   BufferPtr maxSizes_;
   vector_size_t* rawMaxSizes_{nullptr};
 
-  // The first input row output start range.
+  // Start processing the first row input from `firstRowStart_`.
   vector_size_t firstRowStart_ = 0;
 
   std::vector<const vector_size_t*> rawSizes_;

--- a/velox/exec/Unnest.h
+++ b/velox/exec/Unnest.h
@@ -39,13 +39,14 @@ class Unnest : public Operator {
   bool isFinished() override;
 
  private:
-  // Represents the range of rows to process and indicates that first and last
-  // row may need to be processed partially to match the output batch size.
-  // The row range is firstRowStart_ to lasRowEnd when there is
-  // single row to process, moreover, the row range for first row is
-  // firstRowStart_ to rawMaxSizes_[firstRow] and the row range for last row is
-  // 0 to lastRowEnd when there are several rows to process unless the last row
-  // process fully, in that case, use rawMaxSizes_[lastRow] as end of the last
+  // Represents the range of rows to process and indicates that the first and
+  // last
+  // rows may need to be processed partially to match the configured output
+  // batch size. When processing a single row, the range is from
+  // 'firstRowStart_' to 'lastRowEnd'. For multiple rows, the range for the
+  // first row is from 'firstRowStart_' to 'rawMaxSizes_[firstRow]', and for the
+  // last row, it is from 0 to 'lastRowEnd', unless the last row is processed
+  // fully, in which case' rawMaxSizes_[lastRow]' is used as the end of the last
   // row.
   //
   // Single row:
@@ -61,13 +62,13 @@ class Unnest : public Operator {
   //                 lastRowEnd
   // The size is end - start, the range is [start, end).
   struct RowRange {
-    // Invokes a function on each row represent by the RowRange.
-    // @param func Call the function for each row, `row` means the current row
-    // number whose range is [start, start + size), `start` means the row number
-    // to start to process, `size` means the number of input rows to process.
+    // Invokes a function on each row represented by the RowRange.
+    // @param func The function to call for each row. 'row' is the current row
+    // number in the '[start, start + size)' range, 'start' is the row number to
+    // start processing, and 'size' is the number of rows to process..
     // @param rawMaxSizes Used to compute the end of each row.
-    // @param firstRowStart Same with Unnest member firstRowStart_, start
-    // processing the first row input from `firstRowStart_`.
+    // @param firstRowStart The index to start processing the first row. Same
+    // with Unnest member firstRowStart_.
     void forEachRow(
         std::function<void(
             vector_size_t /*row*/,
@@ -82,9 +83,9 @@ class Unnest : public Operator {
     // Number of input rows to be included in the output.
     const vector_size_t size;
 
-    // Processing of the last input row begins at index firstRowStart_ or 0
-    // depending on whether the row to process is first row and ends at
-    // 'lastRowEnd'. It is nullopt when processing the last row fully.
+    // The processing of the last input row starts at index 'firstRowStart_' or
+    // 0, depending on whether it is the first row being processed, and ends at
+    // 'lastRowEnd'. It is nullopt when the last row is processed completely.
     const std::optional<vector_size_t> lastRowEnd;
 
     // Total number of inner rows in the range.
@@ -132,7 +133,7 @@ class Unnest : public Operator {
   BufferPtr maxSizes_;
   vector_size_t* rawMaxSizes_{nullptr};
 
-  // Start processing the first row input from `firstRowStart_`.
+  // The index to start processing the first row.
   vector_size_t firstRowStart_ = 0;
 
   std::vector<const vector_size_t*> rawSizes_;

--- a/velox/exec/Unnest.h
+++ b/velox/exec/Unnest.h
@@ -62,12 +62,17 @@ class Unnest : public Operator {
   // The size is end - start, the range is [start, end).
   struct RowRange {
     // Invokes a function on each row represent by the RowRange.
-    // @param func Call the function for each row.
+    // @param func Call the function for each row, `row` means the current row
+    // number whose range is [start, start + size), `start` means the row number
+    // to start to process, `size` means the number of input rows to process.
     // @param rawMaxSizes Used to compute the end of each row.
     // @param firstRowStart Same with Unnest member firstRowStart_, start
     // processing the first row input from `firstRowStart_`.
     void forEachRow(
-        std::function<void(vector_size_t, vector_size_t, vector_size_t)> func,
+        std::function<void(
+            vector_size_t /*row*/,
+            vector_size_t /*start*/,
+            vector_size_t /*size*/)> func,
         const vector_size_t* const rawMaxSizes,
         vector_size_t firstRowStart) const;
 
@@ -82,7 +87,7 @@ class Unnest : public Operator {
     // 'lastRowEnd'. It is nullopt when processing the last row fully.
     const std::optional<vector_size_t> lastRowEnd;
 
-    // Records the number of output rows.
+    // Total number of inner rows in the range.
     const vector_size_t numElements;
   };
 

--- a/velox/exec/Unnest.h
+++ b/velox/exec/Unnest.h
@@ -45,6 +45,13 @@ class Unnest : public Operator {
   /// single row to process, moreover, the row range for first row is
   /// firstRowStart_ to rawMaxSizes_[firstRow] and the row range for last row is
   /// 0 to lastRowEnd when there are several rows to process.
+  ///    firstRowStart_
+  ///---|------------------- start
+  ///-----------------------
+  ///-----------------------
+  ///-----------------|------ end
+  ///                 lastRowEnd
+  /// The size is end - start.
   struct RowRange {
     // First input row to be included in the output.
     const vector_size_t start;
@@ -59,6 +66,7 @@ class Unnest : public Operator {
   };
 
   /// Extract the range of rows to process.
+
   /// @param size The size of input RowVector.
   /// @param numElements Records the number of output rows.
   /// @param lastRowPartial True when processing last row partially, the

--- a/velox/exec/Unnest.h
+++ b/velox/exec/Unnest.h
@@ -39,34 +39,34 @@ class Unnest : public Operator {
   bool isFinished() override;
 
  private:
-  // Represents the range of rows to process and indicates that first and last
-  // row may need to be processed partially.
+  /// Represents the range of rows to process and indicates that first and last
+  /// row may need to be processed partially to match the output batch size.
+  /// The row range is firstRowStart_ to lasRowEnd when there is
+  /// single row to process, moreover, the row range for first row is
+  /// firstRowStart_ to rawMaxSizes_[firstRow] and the row range for last row is
+  /// 0 to lastRowEnd when there are several rows to process.
   struct RowRange {
     // First input row to be included in the output.
-    vector_size_t start;
+    const vector_size_t start;
 
     // Number of input rows to be included in the output.
-    vector_size_t size;
+    const vector_size_t size;
 
-    // Processing of the first input row begins at index `firstRowStart_` and
-    // ends at 'firstRowEnd'.
-    vector_size_t firstRowEnd;
-
-    // Processing of the last input row begins at index 0 and ends at
-    // 'lastRowEnd'. It is nullopt when there is only one row to process.
-    std::optional<vector_size_t> lastRowEnd;
+    /// Processing of the last input row begins at index firstRowStart_ or 0
+    /// depending on whether the row to process is first row and ends at
+    /// 'lastRowEnd'.
+    const vector_size_t lastRowEnd;
   };
 
-  // Extract the range of rows to process.
-  // @param size The size of input RowVector.
-  // @param numElements Records the number of output rows.
-  // @param partialProcessRowStart Records the start index when processing the
-  // first row in the next iteration. It will not be changed when all the input
-  // rows can be fully processed.
+  /// Extract the range of rows to process.
+  /// @param size The size of input RowVector.
+  /// @param numElements Records the number of output rows.
+  /// @param lastRowPartial True when processing last row partially, the
+  /// firstRowStart_ is lastRowEnd, otherwise, the firstRowStart_ is 0.
   const RowRange extractRowRange(
       vector_size_t size,
       vector_size_t& numElements,
-      std::optional<vector_size_t>& partialProcessRowStart);
+      bool& lastRowPartial);
 
   // Generate output for 'rowRange' represented rows.
   // @param rowRange Range of rows to process.

--- a/velox/exec/tests/UnnestTest.cpp
+++ b/velox/exec/tests/UnnestTest.cpp
@@ -23,7 +23,7 @@ using namespace facebook::velox;
 using namespace facebook::velox::exec::test;
 
 class UnnestTest : public OperatorTestBase,
-                   public testing::WithParamInterface<int32_t> {
+                   public testing::WithParamInterface<vector_size_t> {
   void SetUp() override {
     OperatorTestBase::SetUp();
   }
@@ -33,7 +33,6 @@ class UnnestTest : public OperatorTestBase,
   }
 
  protected:
-  const int32_t batchSize_{GetParam()};
   const CursorParameters makeCursorParameters(
       const core::PlanNodePtr planNode) const {
     CursorParameters params;
@@ -42,6 +41,8 @@ class UnnestTest : public OperatorTestBase,
         std::to_string(batchSize_);
     return params;
   }
+
+  const vector_size_t batchSize_{GetParam()};
 };
 
 TEST_P(UnnestTest, basicArray) {

--- a/velox/exec/tests/UnnestTest.cpp
+++ b/velox/exec/tests/UnnestTest.cpp
@@ -60,7 +60,7 @@ TEST_P(UnnestTest, basicArray) {
   // TODO Add tests with empty arrays. This requires better support in DuckDB.
 
   auto op = PlanBuilder().values({vector}).unnest({"c0"}, {"c1"}).planNode();
-  auto params = std::move(makeCursorParameters(op));
+  auto params = makeCursorParameters(op);
   assertQuery(params, "SELECT c0, UNNEST(c1) FROM tmp WHERE c0 % 7 > 0");
 }
 
@@ -96,7 +96,7 @@ TEST_P(UnnestTest, arrayWithOrdinality) {
        makeNullableFlatVector<int32_t>(
            {1, 2, std::nullopt, 4, 5, 6, std::nullopt, 7, 8, 9}),
        makeNullableFlatVector<int64_t>({1, 2, 3, 4, 1, 2, 1, 1, 2, 3})});
-  auto params = std::move(makeCursorParameters(op));
+  auto params = makeCursorParameters(op);
   assertQuery(params, expected);
 
   // Test with array wrapped in dictionary.
@@ -124,7 +124,7 @@ TEST_P(UnnestTest, arrayWithOrdinality) {
        makeNullableFlatVector<int32_t>(
            {7, 8, 9, std::nullopt, 5, 6, 1, 2, std::nullopt, 4}),
        makeNullableFlatVector<int64_t>({1, 2, 3, 1, 1, 2, 1, 2, 3, 4})});
-  params = std::move(makeCursorParameters(op));
+  params = makeCursorParameters(op);
   assertQuery(params, expectedInDict);
 }
 
@@ -150,7 +150,7 @@ TEST_P(UnnestTest, basicMap) {
            [](auto /* row */) { return 2; },
            [](auto /* row */, auto index) { return index + 1; })});
   createDuckDbTable({duckDbVector});
-  auto params = std::move(makeCursorParameters(op));
+  auto params = makeCursorParameters(op);
   assertQuery(params, "SELECT c0, UNNEST(c1), UNNEST(c2) FROM tmp");
 }
 
@@ -173,7 +173,7 @@ TEST_P(UnnestTest, mapWithOrdinality) {
        makeNullableFlatVector<double>(
            {1.1, std::nullopt, 3.3, 4.4, 5.5, std::nullopt}),
        makeNullableFlatVector<int64_t>({1, 2, 1, 2, 3, 1})});
-  auto params = std::move(makeCursorParameters(op));
+  auto params = makeCursorParameters(op);
   assertQuery(params, expected);
 
   // Test with map wrapped in dictionary.
@@ -192,7 +192,7 @@ TEST_P(UnnestTest, mapWithOrdinality) {
        makeNullableFlatVector<double>(
            {std::nullopt, 3.3, 4.4, 5.5, 1.1, std::nullopt}),
        makeNullableFlatVector<int64_t>({1, 1, 2, 3, 1, 2})});
-  params = std::move(makeCursorParameters(op));
+  params = makeCursorParameters(op);
   assertQuery(params, expectedInDict);
 }
 
@@ -243,7 +243,7 @@ TEST_P(UnnestTest, multipleColumns) {
            nullEvery(7)),
        makeArrayVector(offsets, makeConstant<int32_t>(7, 700))});
   createDuckDbTable({duckDbVector});
-  auto params = std::move(makeCursorParameters(op));
+  auto params = makeCursorParameters(op);
   assertQuery(
       params,
       "SELECT c0, UNNEST(c1), UNNEST(c2), UNNEST(c3), UNNEST(c4) FROM tmp");
@@ -314,7 +314,7 @@ TEST_P(UnnestTest, multipleColumnsWithOrdinality) {
              return index + 1;
            })});
   createDuckDbTable({duckDbVector});
-  auto params = std::move(makeCursorParameters(op));
+  auto params = makeCursorParameters(op);
   assertQuery(
       params,
       "SELECT c0, UNNEST(c1), UNNEST(c2), UNNEST(c3), UNNEST(c4), UNNEST(c5) FROM tmp");
@@ -382,7 +382,7 @@ TEST_P(UnnestTest, multipleColumnsWithOrdinality) {
             std::nullopt,
             std::nullopt}),
        makeNullableFlatVector<int64_t>({1, 2, 3, 4, 1, 2, 3, 1, 2, 1})});
-  params = std::move(makeCursorParameters(op));
+  params = makeCursorParameters(op);
   assertQuery(params, expected);
 }
 
@@ -402,7 +402,7 @@ TEST_P(UnnestTest, allEmptyOrNullArrays) {
 
   auto op =
       PlanBuilder().values({vector}).unnest({"c0"}, {"c1", "c2"}).planNode();
-  auto params = std::move(makeCursorParameters(op));
+  auto params = makeCursorParameters(op);
   assertQueryReturnsEmptyResult(params);
 
   op = PlanBuilder()
@@ -430,14 +430,14 @@ TEST_P(UnnestTest, allEmptyOrNullMaps) {
 
   auto op =
       PlanBuilder().values({vector}).unnest({"c0"}, {"c1", "c2"}).planNode();
-  auto params = std::move(makeCursorParameters(op));
+  auto params = makeCursorParameters(op);
   assertQueryReturnsEmptyResult(params);
 
   op = PlanBuilder()
            .values({vector})
            .unnest({"c0"}, {"c1", "c2"}, "ordinal")
            .planNode();
-  params = std::move(makeCursorParameters(op));
+  params = makeCursorParameters(op);
   assertQueryReturnsEmptyResult(params);
 }
 

--- a/velox/exec/tests/UnnestTest.cpp
+++ b/velox/exec/tests/UnnestTest.cpp
@@ -477,4 +477,4 @@ TEST_P(UnnestTest, batchSize) {
 VELOX_INSTANTIATE_TEST_SUITE_P(
     UnnestTest,
     UnnestTest,
-    testing::ValuesIn({2, 17, 33, 1024}));
+    testing::ValuesIn(/*batchSize*/ {2, 17, 33, 1024}));

--- a/velox/exec/tests/utils/OperatorTestBase.h
+++ b/velox/exec/tests/utils/OperatorTestBase.h
@@ -118,6 +118,12 @@ class OperatorTestBase : public testing::Test,
     return test::assertQuery(plan, {expectedResults});
   }
 
+  std::shared_ptr<Task> assertQuery(
+      const CursorParameters& params,
+      const RowVectorPtr& expectedResults) {
+    return test::assertQuery(params, {expectedResults});
+  }
+
   /// Assumes plan has a single leaf node. All splits are added to that node.
   std::shared_ptr<Task> assertQuery(
       const core::PlanNodePtr& plan,

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -999,6 +999,14 @@ std::shared_ptr<Task> assertQueryReturnsEmptyResult(
   return cursor->task();
 }
 
+std::shared_ptr<Task> assertQueryReturnsEmptyResult(
+    const CursorParameters& params) {
+  VELOX_DCHECK_NOT_NULL(params.planNode);
+  auto [cursor, results] = readCursor(params, [](Task*) {});
+  assertEmptyResults(results);
+  return cursor->task();
+}
+
 void assertEmptyResults(const std::vector<RowVectorPtr>& results) {
   size_t totalCount = 0;
   for (const auto& vector : results) {

--- a/velox/exec/tests/utils/QueryAssertions.h
+++ b/velox/exec/tests/utils/QueryAssertions.h
@@ -236,6 +236,9 @@ std::shared_ptr<Task> assertQuery(
 std::shared_ptr<Task> assertQueryReturnsEmptyResult(
     const core::PlanNodePtr& plan);
 
+std::shared_ptr<Task> assertQueryReturnsEmptyResult(
+    const CursorParameters& params);
+
 void assertEmptyResults(const std::vector<RowVectorPtr>& results);
 
 void assertResults(


### PR DESCRIPTION
Before this patch, it has restriction that one row output should be in one batch, an unusually long array or map in a single row may result in a very large batch size, which can cause OOM when later processed by column to UnsafeRow operator  because row format may cost more memory even to 10x than column format for nested struct column type.
After this patch, it is split to several batches to match output batch size kPreferedOutputBatchRows.
Record the start of the first row, process the first row and last row in different branch, the middle rows range is 0 to maxSize while the first row range is firstRowStart_ to maxSize and last row range is 0 to maxSize or lastRowEnd depending on if the lastRowEnd is available when there is not only 1 row to process. 
To cover almost all the cases, the Unnest test is changed to parameterized test which accepts several batch size {2, 17, 33, 1024}, even more, I test batch size {2, 5, 7, 12, 16, 17, 33, 45, 50, 60, 71, 1024} local,  it does not appeal to any more problem, so current approach is valid enough.

Resolves https://github.com/facebookincubator/velox/issues/10655