### PR TITLE
Fix Spark WeekFunction on long years

### DIFF
--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -486,7 +486,7 @@ TEST_F(DateTimeFunctionsTest, week) {
                     VELOX_USER_FAIL("{}", status.message());
                   });
     auto timestamp =
-        std::make_optional(Timestamp(ts.getSeconds() * 100'000'000, 0));
+        std::make_optional(Timestamp(ts.getSeconds() * 100'000, 0));
 
     auto week = evaluateOnce<int64_t>("week(c0)", timestamp).value();
     auto weekOfYear =
@@ -497,11 +497,11 @@ TEST_F(DateTimeFunctionsTest, week) {
   };
 
   EXPECT_EQ(1, weekTimestamp("T00:00:00"));
-  EXPECT_EQ(10, weekTimestamp("T11:59:59"));
-  EXPECT_EQ(51, weekTimestamp("T06:01:01"));
-  EXPECT_EQ(24, weekTimestamp("T06:59:59"));
-  EXPECT_EQ(27, weekTimestamp("T12:00:01"));
-  EXPECT_EQ(7, weekTimestamp("T12:59:59"));
+  EXPECT_EQ(47, weekTimestamp("T11:59:59"));
+  EXPECT_EQ(33, weekTimestamp("T06:01:01"));
+  EXPECT_EQ(44, weekTimestamp("T06:59:59"));
+  EXPECT_EQ(47, weekTimestamp("T12:00:01"));
+  EXPECT_EQ(16, weekTimestamp("T12:59:59"));
 }
 
 TEST_F(DateTimeFunctionsTest, weekTimestampWithTimezone) {

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -364,7 +364,6 @@ void registerFunctions(const std::string& prefix) {
   // Register date functions.
   registerFunction<YearFunction, int32_t, Timestamp>({prefix + "year"});
   registerFunction<YearFunction, int32_t, Date>({prefix + "year"});
-  registerFunction<WeekFunction, int32_t, Timestamp>({prefix + "week_of_year"});
   registerFunction<WeekFunction, int32_t, Date>({prefix + "week_of_year"});
   registerFunction<YearOfWeekFunction, int32_t, Date>(
       {prefix + "year_of_week"});

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -206,6 +206,22 @@ TEST_F(DateTimeFunctionsTest, weekOfYear) {
   EXPECT_EQ(8, weekOfYear("2008-02-20"));
   EXPECT_EQ(15, weekOfYear("2015-04-08"));
   EXPECT_EQ(15, weekOfYear("2013-04-08"));
+
+  // Test various cases where the last week of the previous year extends into
+  // the next year.
+
+  // Leap year that ends on Thursday.
+  EXPECT_EQ(53, weekOfYear("2021-01-01"));
+  // Leap year that ends on Friday.
+  EXPECT_EQ(53, weekOfYear("2005-01-01"));
+  // Leap year that ends on Saturday.
+  EXPECT_EQ(52, weekOfYear("2017-01-01"));
+  // Common year that ends on Thursday.
+  EXPECT_EQ(53, weekOfYear("2016-01-01"));
+  // Common year that ends on Friday.
+  EXPECT_EQ(52, weekOfYear("2022-01-01"));
+  // Common year that ends on Saturday.
+  EXPECT_EQ(52, weekOfYear("2023-01-01"));
 }
 
 TEST_F(DateTimeFunctionsTest, unixDate) {

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -35,6 +35,12 @@ Timestamp Timestamp::fromDaysAndNanos(int32_t days, int64_t nanos) {
 }
 
 // static
+Timestamp Timestamp::fromDate(int32_t date) {
+  int64_t seconds = (int64_t)date * kSecondsInDay;
+  return Timestamp(seconds, 0);
+}
+
+// static
 Timestamp Timestamp::now() {
   auto now = std::chrono::system_clock::now();
   auto epochMs = std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -117,6 +117,9 @@ struct Timestamp {
   /// and the number of nanoseconds.
   static Timestamp fromDaysAndNanos(int32_t days, int64_t nanos);
 
+  // date is the number of days since unix epoch.
+  static Timestamp fromDate(int32_t date);
+
   // Returns the current unix timestamp (ms precision).
   static Timestamp now();
 


### PR DESCRIPTION
Similar to #10599, in Spark, a long year is any year ending on Thursday and any 
leap year ending on Friday. Since the only difference between Presto and Spark 
is on return type, this PR extracts the 'getWeek' function to functions/lib and 
changed to use 'weeknum' from external/date library for the week calculation.