### PR TITLE
Deprecate old core::Config class

### DIFF
--- a/velox/benchmarks/filesystem/ReadBenchmark.cpp
+++ b/velox/benchmarks/filesystem/ReadBenchmark.cpp
@@ -16,11 +16,11 @@
 
 #include "velox/benchmarks/filesystem/ReadBenchmark.h"
 
+#include "velox/common/config/Config.h"
 #include "velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.h"
 #include "velox/connectors/hive/storage_adapters/gcs/RegisterGCSFileSystem.h"
 #include "velox/connectors/hive/storage_adapters/hdfs/RegisterHdfsFileSystem.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h"
-#include "velox/core/Config.h"
 
 DEFINE_string(path, "", "Path of the input file");
 DEFINE_int64(
@@ -60,7 +60,7 @@ DEFINE_validator(path, &notEmpty);
 
 namespace facebook::velox {
 
-std::shared_ptr<Config> readConfig(const std::string& filePath) {
+std::shared_ptr<config::ConfigBase> readConfig(const std::string& filePath) {
   std::ifstream configFile(filePath);
   if (!configFile.is_open()) {
     throw std::runtime_error(
@@ -80,7 +80,7 @@ std::shared_ptr<Config> readConfig(const std::string& filePath) {
     properties.emplace(name, value);
   }
 
-  return std::make_shared<facebook::velox::core::MemConfig>(properties);
+  return std::make_shared<config::ConfigBase>(std::move(properties));
 }
 
 // Initialize a LocalReadFile instance for the specified 'path'.
@@ -108,7 +108,7 @@ void ReadBenchmark::initialize() {
     filesystems::registerGCSFileSystem();
     filesystems::registerHdfsFileSystem();
     filesystems::abfs::registerAbfsFileSystem();
-    std::shared_ptr<Config> config;
+    std::shared_ptr<config::ConfigBase> config;
     if (!FLAGS_config.empty()) {
       config = readConfig(FLAGS_config);
     }

--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -265,8 +265,8 @@ class TpchBenchmark {
             std::to_string(FLAGS_max_coalesced_distance_bytes);
     configurationValues[connector::hive::HiveConfig::kPrefetchRowGroups] =
         std::to_string(FLAGS_parquet_prefetch_rowgroups);
-    auto properties =
-        std::make_shared<const core::MemConfig>(configurationValues);
+    auto properties = std::make_shared<const config::ConfigBase>(
+        std::move(configurationValues));
 
     // Create hive connector with config...
     auto hiveConnector =

--- a/velox/common/config/Config.h
+++ b/velox/common/config/Config.h
@@ -80,6 +80,8 @@ class ConfigBase {
       bool _mutable = false)
       : configs_(std::move(configs)), mutable_(_mutable) {}
 
+  virtual ~ConfigBase() {}
+
   template <typename T>
   ConfigBase& set(const Entry<T>& entry, const T& val) {
     VELOX_CHECK(mutable_, "Cannot set in immutable config");

--- a/velox/common/file/FileSystems.cpp
+++ b/velox/common/file/FileSystems.cpp
@@ -30,8 +30,9 @@ constexpr std::string_view kFileScheme("file:");
 
 using RegisteredFileSystems = std::vector<std::pair<
     std::function<bool(std::string_view)>,
-    std::function<std::shared_ptr<
-        FileSystem>(std::shared_ptr<const Config>, std::string_view)>>>;
+    std::function<std::shared_ptr<FileSystem>(
+        std::shared_ptr<const config::ConfigBase>,
+        std::string_view)>>>;
 
 RegisteredFileSystems& registeredFileSystems() {
   // Meyers singleton.
@@ -44,14 +45,14 @@ RegisteredFileSystems& registeredFileSystems() {
 void registerFileSystem(
     std::function<bool(std::string_view)> schemeMatcher,
     std::function<std::shared_ptr<FileSystem>(
-        std::shared_ptr<const Config>,
+        std::shared_ptr<const config::ConfigBase>,
         std::string_view)> fileSystemGenerator) {
   registeredFileSystems().emplace_back(schemeMatcher, fileSystemGenerator);
 }
 
 std::shared_ptr<FileSystem> getFileSystem(
     std::string_view filePath,
-    std::shared_ptr<const Config> properties) {
+    std::shared_ptr<const config::ConfigBase> properties) {
   const auto& filesystems = registeredFileSystems();
   for (const auto& p : filesystems) {
     if (p.first(filePath)) {
@@ -78,7 +79,7 @@ folly::once_flag localFSInstantiationFlag;
 // Implement Local FileSystem.
 class LocalFileSystem : public FileSystem {
  public:
-  explicit LocalFileSystem(std::shared_ptr<const Config> config)
+  explicit LocalFileSystem(std::shared_ptr<const config::ConfigBase> config)
       : FileSystem(config) {}
 
   ~LocalFileSystem() override {}
@@ -193,9 +194,9 @@ class LocalFileSystem : public FileSystem {
   }
 
   static std::function<std::shared_ptr<
-      FileSystem>(std::shared_ptr<const Config>, std::string_view)>
+      FileSystem>(std::shared_ptr<const config::ConfigBase>, std::string_view)>
   fileSystemGenerator() {
-    return [](std::shared_ptr<const Config> properties,
+    return [](std::shared_ptr<const config::ConfigBase> properties,
               std::string_view filePath) {
       // One instance of Local FileSystem is sufficient.
       // Initialize on first access and reuse after that.

--- a/velox/common/file/FileSystems.h
+++ b/velox/common/file/FileSystems.h
@@ -23,7 +23,9 @@
 #include <string_view>
 
 namespace facebook::velox {
-class Config;
+namespace config {
+class ConfigBase;
+}
 class ReadFile;
 class WriteFile;
 } // namespace facebook::velox
@@ -50,7 +52,7 @@ struct FileOptions {
 /// An abstract FileSystem
 class FileSystem {
  public:
-  FileSystem(std::shared_ptr<const Config> config)
+  FileSystem(std::shared_ptr<const config::ConfigBase> config)
       : config_(std::move(config)) {}
   virtual ~FileSystem() = default;
 
@@ -101,12 +103,12 @@ class FileSystem {
   virtual void rmdir(std::string_view path) = 0;
 
  protected:
-  std::shared_ptr<const Config> config_;
+  std::shared_ptr<const config::ConfigBase> config_;
 };
 
 std::shared_ptr<FileSystem> getFileSystem(
     std::string_view filename,
-    std::shared_ptr<const Config> config);
+    std::shared_ptr<const config::ConfigBase> config);
 
 /// Returns true if filePath is supported by any registered file system,
 /// otherwise false.
@@ -120,7 +122,7 @@ bool isPathSupportedByRegisteredFileSystems(const std::string_view& filePath);
 void registerFileSystem(
     std::function<bool(std::string_view)> schemeMatcher,
     std::function<std::shared_ptr<FileSystem>(
-        std::shared_ptr<const Config>,
+        std::shared_ptr<const config::ConfigBase>,
         std::string_view)> fileSystemGenerator);
 
 /// Register the local filesystem.

--- a/velox/common/file/tests/FaultyFileSystem.cpp
+++ b/velox/common/file/tests/FaultyFileSystem.cpp
@@ -38,9 +38,9 @@ std::function<bool(std::string_view)> schemeMatcher() {
 folly::once_flag faultFilesystemInitOnceFlag;
 
 std::function<std::shared_ptr<
-    FileSystem>(std::shared_ptr<const Config>, std::string_view)>
+    FileSystem>(std::shared_ptr<const config::ConfigBase>, std::string_view)>
 fileSystemGenerator() {
-  return [](std::shared_ptr<const Config> properties,
+  return [](std::shared_ptr<const config::ConfigBase> properties,
             std::string_view /*unused*/) {
     // One instance of faulty FileSystem is sufficient. Initializes on first
     // access and reuse after that.

--- a/velox/common/file/tests/FaultyFileSystem.h
+++ b/velox/common/file/tests/FaultyFileSystem.h
@@ -32,7 +32,7 @@ using namespace filesystems;
 /// file operation to the real file system underneath.
 class FaultyFileSystem : public FileSystem {
  public:
-  explicit FaultyFileSystem(std::shared_ptr<const Config> config)
+  explicit FaultyFileSystem(std::shared_ptr<const config::ConfigBase> config)
       : FileSystem(std::move(config)) {}
 
   ~FaultyFileSystem() override {}

--- a/velox/connectors/CMakeLists.txt
+++ b/velox/connectors/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 velox_add_library(velox_connector Connector.cpp)
 
-velox_link_libraries(velox_connector velox_config velox_vector)
+velox_link_libraries(velox_connector velox_common_config velox_vector)
 
 add_subdirectory(fuzzer)
 

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -29,15 +29,17 @@
 
 #include <folly/Synchronized.h>
 
+namespace facebook::velox {
+class Config;
+}
 namespace facebook::velox::wave {
 class WaveDataSource;
 }
 namespace facebook::velox::common {
 class Filter;
 }
-
-namespace facebook::velox {
-class Config;
+namespace facebook::velox::config {
+class ConfigBase;
 }
 
 namespace facebook::velox::connector {
@@ -256,7 +258,7 @@ class ConnectorQueryCtx {
   ConnectorQueryCtx(
       memory::MemoryPool* operatorPool,
       memory::MemoryPool* connectorPool,
-      const Config* sessionProperties,
+      const config::ConfigBase* sessionProperties,
       const common::SpillConfig* spillConfig,
       common::PrefixSortConfig prefixSortConfig,
       std::unique_ptr<core::ExpressionEvaluator> expressionEvaluator,
@@ -297,7 +299,7 @@ class ConnectorQueryCtx {
     return connectorPool_;
   }
 
-  const Config* sessionProperties() const {
+  const config::ConfigBase* sessionProperties() const {
     return sessionProperties_;
   }
 
@@ -356,7 +358,7 @@ class ConnectorQueryCtx {
  private:
   memory::MemoryPool* const operatorPool_;
   memory::MemoryPool* const connectorPool_;
-  const Config* const sessionProperties_;
+  const config::ConfigBase* const sessionProperties_;
   const common::SpillConfig* const spillConfig_;
   const common::PrefixSortConfig prefixSortConfig_;
   std::unique_ptr<core::ExpressionEvaluator> expressionEvaluator_;
@@ -380,7 +382,8 @@ class Connector {
     return id_;
   }
 
-  virtual const std::shared_ptr<const Config>& connectorConfig() const {
+  virtual const std::shared_ptr<const config::ConfigBase>& connectorConfig()
+      const {
     VELOX_NYI("connectorConfig is not supported yet");
   }
 
@@ -447,6 +450,12 @@ class ConnectorFactory {
     return name_;
   }
 
+  virtual std::shared_ptr<Connector> newConnector(
+      const std::string& id,
+      std::shared_ptr<const config::ConfigBase> config,
+      folly::Executor* executor = nullptr) = 0;
+
+  // TODO(jtan6): [Config Refactor] Remove this old API when refactor is done.
   virtual std::shared_ptr<Connector> newConnector(
       const std::string& id,
       std::shared_ptr<const Config> config,

--- a/velox/connectors/fuzzer/FuzzerConnector.h
+++ b/velox/connectors/fuzzer/FuzzerConnector.h
@@ -15,8 +15,10 @@
  */
 #pragma once
 
+#include "velox/common/config/Config.h"
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/fuzzer/FuzzerConnectorSplit.h"
+#include "velox/core/Config.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
 namespace facebook::velox::connector::fuzzer {
@@ -103,7 +105,7 @@ class FuzzerConnector final : public Connector {
  public:
   FuzzerConnector(
       const std::string& id,
-      std::shared_ptr<const Config> config,
+      std::shared_ptr<const config::ConfigBase> config,
       folly::Executor* /*executor*/)
       : Connector(id) {}
 
@@ -139,9 +141,20 @@ class FuzzerConnectorFactory : public ConnectorFactory {
 
   std::shared_ptr<Connector> newConnector(
       const std::string& id,
-      std::shared_ptr<const Config> config,
+      std::shared_ptr<const config::ConfigBase> config,
       folly::Executor* executor = nullptr) override {
     return std::make_shared<FuzzerConnector>(id, config, executor);
+  }
+
+  std::shared_ptr<Connector> newConnector(
+      const std::string& id,
+      std::shared_ptr<const Config> config,
+      folly::Executor* executor = nullptr) override {
+    std::shared_ptr<const config::ConfigBase> convertedConfig;
+    convertedConfig = config == nullptr
+        ? nullptr
+        : std::make_shared<config::ConfigBase>(config->valuesCopy());
+    return newConnector(id, convertedConfig, executor);
   }
 };
 

--- a/velox/connectors/fuzzer/tests/FuzzerConnectorTestBase.h
+++ b/velox/connectors/fuzzer/tests/FuzzerConnectorTestBase.h
@@ -26,10 +26,11 @@ class FuzzerConnectorTestBase : public exec::test::OperatorTestBase {
 
   void SetUp() override {
     OperatorTestBase::SetUp();
+    std::shared_ptr<const config::ConfigBase> config;
     auto fuzzerConnector =
         connector::getConnectorFactory(
             connector::fuzzer::FuzzerConnectorFactory::kFuzzerConnectorName)
-            ->newConnector(kFuzzerConnectorId, nullptr);
+            ->newConnector(kFuzzerConnectorId, config);
     connector::registerConnector(fuzzerConnector);
   }
 

--- a/velox/connectors/hive/FileHandle.h
+++ b/velox/connectors/hive/FileHandle.h
@@ -27,12 +27,11 @@
 
 #include "velox/common/caching/CachedFactory.h"
 #include "velox/common/caching/FileIds.h"
+#include "velox/common/config/Config.h"
 #include "velox/common/file/File.h"
 #include "velox/connectors/hive/FileProperties.h"
 
 namespace facebook::velox {
-
-class Config;
 
 // See the file comment.
 struct FileHandle {
@@ -66,14 +65,14 @@ using FileHandleCache = SimpleLRUCache<std::string, FileHandle>;
 class FileHandleGenerator {
  public:
   FileHandleGenerator() {}
-  FileHandleGenerator(std::shared_ptr<const Config> properties)
+  FileHandleGenerator(std::shared_ptr<const config::ConfigBase> properties)
       : properties_(std::move(properties)) {}
   std::unique_ptr<FileHandle> operator()(
       const std::string& filename,
       const FileProperties* properties);
 
  private:
-  const std::shared_ptr<const Config> properties_;
+  const std::shared_ptr<const config::ConfigBase> properties_;
 };
 
 using FileHandleFactory = CachedFactory<

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "velox/connectors/hive/HiveConfig.h"
-#include "velox/core/Config.h"
+#include "velox/common/config/Config.h"
 #include "velox/core/QueryConfig.h"
 
 #include <boost/algorithm/string.hpp>
@@ -53,13 +53,15 @@ std::string HiveConfig::insertExistingPartitionsBehaviorString(
 }
 
 HiveConfig::InsertExistingPartitionsBehavior
-HiveConfig::insertExistingPartitionsBehavior(const Config* session) const {
+HiveConfig::insertExistingPartitionsBehavior(
+    const config::ConfigBase* session) const {
   return stringToInsertExistingPartitionsBehavior(session->get<std::string>(
       kInsertExistingPartitionsBehaviorSession,
       config_->get<std::string>(kInsertExistingPartitionsBehavior, "ERROR")));
 }
 
-uint32_t HiveConfig::maxPartitionsPerWriters(const Config* session) const {
+uint32_t HiveConfig::maxPartitionsPerWriters(
+    const config::ConfigBase* session) const {
   return session->get<uint32_t>(
       kMaxPartitionsPerWritersSession,
       config_->get<uint32_t>(kMaxPartitionsPerWriters, 100));
@@ -90,15 +92,18 @@ std::string HiveConfig::s3Endpoint() const {
 }
 
 std::optional<std::string> HiveConfig::s3AccessKey() const {
-  return static_cast<std::optional<std::string>>(config_->get(kS3AwsAccessKey));
+  return static_cast<std::optional<std::string>>(
+      config_->get<std::string>(kS3AwsAccessKey));
 }
 
 std::optional<std::string> HiveConfig::s3SecretKey() const {
-  return static_cast<std::optional<std::string>>(config_->get(kS3AwsSecretKey));
+  return static_cast<std::optional<std::string>>(
+      config_->get<std::string>(kS3AwsSecretKey));
 }
 
 std::optional<std::string> HiveConfig::s3IAMRole() const {
-  return static_cast<std::optional<std::string>>(config_->get(kS3IamRole));
+  return static_cast<std::optional<std::string>>(
+      config_->get<std::string>(kS3IamRole));
 }
 
 std::string HiveConfig::s3IAMRoleSessionName() const {
@@ -151,22 +156,24 @@ std::optional<std::string> HiveConfig::gcsMaxRetryTime() const {
       config_->get<std::string>(kGCSMaxRetryTime));
 }
 
-bool HiveConfig::isOrcUseColumnNames(const Config* session) const {
+bool HiveConfig::isOrcUseColumnNames(const config::ConfigBase* session) const {
   return session->get<bool>(
       kOrcUseColumnNamesSession, config_->get<bool>(kOrcUseColumnNames, false));
 }
 
-bool HiveConfig::isFileColumnNamesReadAsLowerCase(const Config* session) const {
+bool HiveConfig::isFileColumnNamesReadAsLowerCase(
+    const config::ConfigBase* session) const {
   return session->get<bool>(
       kFileColumnNamesReadAsLowerCaseSession,
       config_->get<bool>(kFileColumnNamesReadAsLowerCase, false));
 }
 
-bool HiveConfig::isPartitionPathAsLowerCase(const Config* session) const {
+bool HiveConfig::isPartitionPathAsLowerCase(
+    const config::ConfigBase* session) const {
   return session->get<bool>(kPartitionPathAsLowerCaseSession, true);
 }
 
-bool HiveConfig::ignoreMissingFiles(const Config* session) const {
+bool HiveConfig::ignoreMissingFiles(const config::ConfigBase* session) const {
   return session->get<bool>(kIgnoreMissingFilesSession, false);
 }
 
@@ -194,7 +201,8 @@ bool HiveConfig::isFileHandleCacheEnabled() const {
   return config_->get<bool>(kEnableFileHandleCache, true);
 }
 
-uint64_t HiveConfig::orcWriterMaxStripeSize(const Config* session) const {
+uint64_t HiveConfig::orcWriterMaxStripeSize(
+    const config::ConfigBase* session) const {
   return config::toCapacity(
       session->get<std::string>(
           kOrcWriterMaxStripeSizeSession,
@@ -202,7 +210,8 @@ uint64_t HiveConfig::orcWriterMaxStripeSize(const Config* session) const {
       config::CapacityUnit::BYTE);
 }
 
-uint64_t HiveConfig::orcWriterMaxDictionaryMemory(const Config* session) const {
+uint64_t HiveConfig::orcWriterMaxDictionaryMemory(
+    const config::ConfigBase* session) const {
   return config::toCapacity(
       session->get<std::string>(
           kOrcWriterMaxDictionaryMemorySession,
@@ -211,34 +220,35 @@ uint64_t HiveConfig::orcWriterMaxDictionaryMemory(const Config* session) const {
 }
 
 bool HiveConfig::isOrcWriterIntegerDictionaryEncodingEnabled(
-    const Config* session) const {
+    const config::ConfigBase* session) const {
   return session->get<bool>(
       kOrcWriterIntegerDictionaryEncodingEnabledSession,
       config_->get<bool>(kOrcWriterIntegerDictionaryEncodingEnabled, true));
 }
 
 bool HiveConfig::isOrcWriterStringDictionaryEncodingEnabled(
-    const Config* session) const {
+    const config::ConfigBase* session) const {
   return session->get<bool>(
       kOrcWriterStringDictionaryEncodingEnabledSession,
       config_->get<bool>(kOrcWriterStringDictionaryEncodingEnabled, true));
 }
 
 bool HiveConfig::orcWriterLinearStripeSizeHeuristics(
-    const Config* session) const {
+    const config::ConfigBase* session) const {
   return session->get<bool>(
       kOrcWriterLinearStripeSizeHeuristicsSession,
       config_->get<bool>(kOrcWriterLinearStripeSizeHeuristics, true));
 }
 
-uint64_t HiveConfig::orcWriterMinCompressionSize(const Config* session) const {
+uint64_t HiveConfig::orcWriterMinCompressionSize(
+    const config::ConfigBase* session) const {
   return session->get<uint64_t>(
       kOrcWriterMinCompressionSizeSession,
       config_->get<uint64_t>(kOrcWriterMinCompressionSize, 1024));
 }
 
 std::optional<uint8_t> HiveConfig::orcWriterCompressionLevel(
-    const Config* session) const {
+    const config::ConfigBase* session) const {
   auto sessionProp = session->get<uint8_t>(kOrcWriterCompressionLevelSession);
 
   if (sessionProp.has_value()) {
@@ -260,13 +270,15 @@ std::string HiveConfig::writeFileCreateConfig() const {
   return config_->get<std::string>(kWriteFileCreateConfig, "");
 }
 
-uint32_t HiveConfig::sortWriterMaxOutputRows(const Config* session) const {
+uint32_t HiveConfig::sortWriterMaxOutputRows(
+    const config::ConfigBase* session) const {
   return session->get<uint32_t>(
       kSortWriterMaxOutputRowsSession,
       config_->get<uint32_t>(kSortWriterMaxOutputRows, 1024));
 }
 
-uint64_t HiveConfig::sortWriterMaxOutputBytes(const Config* session) const {
+uint64_t HiveConfig::sortWriterMaxOutputBytes(
+    const config::ConfigBase* session) const {
   return config::toCapacity(
       session->get<std::string>(
           kSortWriterMaxOutputBytesSession,
@@ -286,7 +298,7 @@ bool HiveConfig::s3UseProxyFromEnv() const {
   return config_->get<bool>(kS3UseProxyFromEnv, false);
 }
 
-uint8_t HiveConfig::readTimestampUnit(const Config* session) const {
+uint8_t HiveConfig::readTimestampUnit(const config::ConfigBase* session) const {
   const auto unit = session->get<uint8_t>(
       kReadTimestampUnitSession,
       config_->get<uint8_t>(kReadTimestampUnit, 3 /*milli*/));
@@ -296,7 +308,7 @@ uint8_t HiveConfig::readTimestampUnit(const Config* session) const {
   return unit;
 }
 
-bool HiveConfig::cacheNoRetention(const Config* session) const {
+bool HiveConfig::cacheNoRetention(const config::ConfigBase* session) const {
   return session->get<bool>(
       kCacheNoRetentionSession,
       config_->get<bool>(kCacheNoRetention, /*defaultValue=*/false));

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -17,10 +17,10 @@
 
 #include <optional>
 #include <string>
-#include "velox/core/Config.h"
+#include "velox/common/base/Exceptions.h"
 
-namespace facebook::velox {
-class Config;
+namespace facebook::velox::config {
+class ConfigBase;
 }
 
 namespace facebook::velox::connector::hive {
@@ -241,9 +241,9 @@ class HiveConfig {
   static constexpr const char* kCacheNoRetentionSession = "cache.no_retention";
 
   InsertExistingPartitionsBehavior insertExistingPartitionsBehavior(
-      const Config* session) const;
+      const config::ConfigBase* session) const;
 
-  uint32_t maxPartitionsPerWriters(const Config* session) const;
+  uint32_t maxPartitionsPerWriters(const config::ConfigBase* session) const;
 
   bool immutablePartitions() const;
 
@@ -285,13 +285,14 @@ class HiveConfig {
 
   std::optional<std::string> gcsMaxRetryTime() const;
 
-  bool isOrcUseColumnNames(const Config* session) const;
+  bool isOrcUseColumnNames(const config::ConfigBase* session) const;
 
-  bool isFileColumnNamesReadAsLowerCase(const Config* session) const;
+  bool isFileColumnNamesReadAsLowerCase(
+      const config::ConfigBase* session) const;
 
-  bool isPartitionPathAsLowerCase(const Config* session) const;
+  bool isPartitionPathAsLowerCase(const config::ConfigBase* session) const;
 
-  bool ignoreMissingFiles(const Config* session) const;
+  bool ignoreMissingFiles(const config::ConfigBase* session) const;
 
   int64_t maxCoalescedBytes() const;
 
@@ -307,25 +308,30 @@ class HiveConfig {
 
   uint64_t fileWriterFlushThresholdBytes() const;
 
-  uint64_t orcWriterMaxStripeSize(const Config* session) const;
+  uint64_t orcWriterMaxStripeSize(const config::ConfigBase* session) const;
 
-  uint64_t orcWriterMaxDictionaryMemory(const Config* session) const;
+  uint64_t orcWriterMaxDictionaryMemory(
+      const config::ConfigBase* session) const;
 
-  bool isOrcWriterIntegerDictionaryEncodingEnabled(const Config* session) const;
+  bool isOrcWriterIntegerDictionaryEncodingEnabled(
+      const config::ConfigBase* session) const;
 
-  bool isOrcWriterStringDictionaryEncodingEnabled(const Config* session) const;
+  bool isOrcWriterStringDictionaryEncodingEnabled(
+      const config::ConfigBase* session) const;
 
-  bool orcWriterLinearStripeSizeHeuristics(const Config* session) const;
+  bool orcWriterLinearStripeSizeHeuristics(
+      const config::ConfigBase* session) const;
 
-  uint64_t orcWriterMinCompressionSize(const Config* session) const;
+  uint64_t orcWriterMinCompressionSize(const config::ConfigBase* session) const;
 
-  std::optional<uint8_t> orcWriterCompressionLevel(const Config* session) const;
+  std::optional<uint8_t> orcWriterCompressionLevel(
+      const config::ConfigBase* session) const;
 
   std::string writeFileCreateConfig() const;
 
-  uint32_t sortWriterMaxOutputRows(const Config* session) const;
+  uint32_t sortWriterMaxOutputRows(const config::ConfigBase* session) const;
 
-  uint64_t sortWriterMaxOutputBytes(const Config* session) const;
+  uint64_t sortWriterMaxOutputBytes(const config::ConfigBase* session) const;
 
   uint64_t footerEstimatedSize() const;
 
@@ -334,28 +340,28 @@ class HiveConfig {
   bool s3UseProxyFromEnv() const;
 
   // Returns the timestamp unit used when reading timestamps from files.
-  uint8_t readTimestampUnit(const Config* session) const;
+  uint8_t readTimestampUnit(const config::ConfigBase* session) const;
 
   /// Returns true to evict out a query scanned data out of in-memory cache
   /// right after the access, and also skip staging to the ssd cache. This helps
   /// to prevent the cache space pollution from the one-time table scan by large
   /// batch query when mixed running with interactive query which has high data
   /// locality.
-  bool cacheNoRetention(const Config* session) const;
+  bool cacheNoRetention(const config::ConfigBase* session) const;
 
-  HiveConfig(std::shared_ptr<const Config> config) {
+  HiveConfig(std::shared_ptr<const config::ConfigBase> config) {
     VELOX_CHECK_NOT_NULL(
         config, "Config is null for HiveConfig initialization");
     config_ = std::move(config);
     // TODO: add sanity check
   }
 
-  const std::shared_ptr<const Config>& config() const {
+  const std::shared_ptr<const config::ConfigBase>& config() const {
     return config_;
   }
 
  private:
-  std::shared_ptr<const Config> config_;
+  std::shared_ptr<const config::ConfigBase> config_;
 };
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -45,7 +45,7 @@ namespace facebook::velox::connector::hive {
 
 HiveConnector::HiveConnector(
     const std::string& id,
-    std::shared_ptr<const Config> config,
+    std::shared_ptr<const config::ConfigBase> config,
     folly::Executor* executor)
     : Connector(id),
       hiveConfig_(std::make_shared<HiveConfig>(config)),

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -31,10 +31,11 @@ class HiveConnector : public Connector {
  public:
   HiveConnector(
       const std::string& id,
-      std::shared_ptr<const Config> config,
+      std::shared_ptr<const config::ConfigBase> config,
       folly::Executor* executor);
 
-  const std::shared_ptr<const Config>& connectorConfig() const override {
+  const std::shared_ptr<const config::ConfigBase>& connectorConfig()
+      const override {
     return hiveConfig_->config();
   }
 
@@ -96,9 +97,20 @@ class HiveConnectorFactory : public ConnectorFactory {
 
   std::shared_ptr<Connector> newConnector(
       const std::string& id,
-      std::shared_ptr<const Config> config,
+      std::shared_ptr<const config::ConfigBase> config,
       folly::Executor* executor = nullptr) override {
     return std::make_shared<HiveConnector>(id, config, executor);
+  }
+
+  std::shared_ptr<Connector> newConnector(
+      const std::string& id,
+      std::shared_ptr<const Config> config,
+      folly::Executor* executor = nullptr) override {
+    std::shared_ptr<const config::ConfigBase> convertedConfig;
+    convertedConfig = config == nullptr
+        ? nullptr
+        : std::make_shared<config::ConfigBase>(config->valuesCopy());
+    return newConnector(id, convertedConfig, executor);
   }
 };
 

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -574,7 +574,7 @@ void configureRowReaderOptions(
     const RowTypePtr& rowType,
     const std::shared_ptr<const HiveConnectorSplit>& hiveSplit,
     const std::shared_ptr<const HiveConfig>& hiveConfig,
-    const Config* sessionProperties) {
+    const config::ConfigBase* sessionProperties) {
   auto skipRowsIt =
       tableParameters.find(dwio::common::TableParameter::kSkipHeaderLineCount);
   if (skipRowsIt != tableParameters.end()) {

--- a/velox/connectors/hive/HiveConnectorUtil.h
+++ b/velox/connectors/hive/HiveConnectorUtil.h
@@ -83,7 +83,7 @@ void configureRowReaderOptions(
     const RowTypePtr& rowType,
     const std::shared_ptr<const HiveConnectorSplit>& hiveSplit,
     const std::shared_ptr<const HiveConfig>& hiveConfig = nullptr,
-    const Config* sessionProperties = nullptr);
+    const config::ConfigBase* sessionProperties = nullptr);
 
 bool testFilters(
     const common::ScanSpec* scanSpec,

--- a/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.cpp
@@ -290,7 +290,8 @@ void IcebergSplitReaderBenchmark::readSingleColumn(
           rowType);
 
   std::shared_ptr<HiveConfig> hiveConfig =
-      std::make_shared<HiveConfig>(std::make_shared<core::MemConfigMutable>());
+      std::make_shared<HiveConfig>(std::make_shared<config::ConfigBase>(
+          std::unordered_map<std::string, std::string>(), true));
   const RowTypePtr readerOutputType;
   const std::shared_ptr<io::IoStatistics> ioStats =
       std::make_shared<io::IoStatistics>();
@@ -301,8 +302,9 @@ void IcebergSplitReaderBenchmark::readSingleColumn(
   std::shared_ptr<memory::MemoryPool> opPool = root->addLeafChild("operator");
   std::shared_ptr<memory::MemoryPool> connectorPool =
       root->addAggregateChild(kHiveConnectorId, MemoryReclaimer::create());
-  std::shared_ptr<core::MemConfig> connectorSessionProperties_ =
-      std::make_shared<core::MemConfig>();
+  std::shared_ptr<config::ConfigBase> connectorSessionProperties_ =
+      std::make_shared<config::ConfigBase>(
+          std::unordered_map<std::string, std::string>());
 
   std::unique_ptr<connector::ConnectorQueryCtx> connectorQueryCtx_ =
       std::make_unique<connector::ConnectorQueryCtx>(

--- a/velox/connectors/hive/storage_adapters/abfs/AbfsFileSystem.h
+++ b/velox/connectors/hive/storage_adapters/abfs/AbfsFileSystem.h
@@ -34,7 +34,8 @@ namespace facebook::velox::filesystems::abfs {
 /// https://learn.microsoft.com/en-us/azure/databricks/storage/azure-storage.
 class AbfsFileSystem : public FileSystem {
  public:
-  explicit AbfsFileSystem(const std::shared_ptr<const Config>& config);
+  explicit AbfsFileSystem(
+      const std::shared_ptr<const config::ConfigBase>& config);
 
   std::string name() const override;
 

--- a/velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.cpp
@@ -15,9 +15,9 @@
  */
 
 #ifdef VELOX_ENABLE_ABFS
+#include "velox/common/config/Config.h"
 #include "velox/connectors/hive/storage_adapters/abfs/AbfsFileSystem.h" // @manual
 #include "velox/connectors/hive/storage_adapters/abfs/AbfsUtil.h" // @manual
-#include "velox/core/Config.h"
 #endif
 
 namespace facebook::velox::filesystems::abfs {
@@ -26,7 +26,7 @@ namespace facebook::velox::filesystems::abfs {
 folly::once_flag abfsInitiationFlag;
 
 std::shared_ptr<FileSystem> abfsFileSystemGenerator(
-    std::shared_ptr<const Config> properties,
+    std::shared_ptr<const config::ConfigBase> properties,
     std::string_view filePath) {
   static std::shared_ptr<FileSystem> filesystem;
   folly::call_once(abfsInitiationFlag, [&properties]() {

--- a/velox/connectors/hive/storage_adapters/abfs/tests/AbfsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/tests/AbfsFileSystemTest.cpp
@@ -44,7 +44,7 @@ static const std::string fullFilePath =
 
 class AbfsFileSystemTest : public testing::Test {
  public:
-  static std::shared_ptr<const Config> hiveConfig(
+  static std::shared_ptr<const config::ConfigBase> hiveConfig(
       const std::unordered_map<std::string, std::string> configOverride = {}) {
     std::unordered_map<std::string, std::string> config({});
 
@@ -55,7 +55,7 @@ class AbfsFileSystemTest : public testing::Test {
                 << std::endl;
     }
 
-    return std::make_shared<const core::MemConfig>(std::move(config));
+    return std::make_shared<const config::ConfigBase>(std::move(config));
   }
 
  public:

--- a/velox/connectors/hive/storage_adapters/abfs/tests/AzuriteServer.h
+++ b/velox/connectors/hive/storage_adapters/abfs/tests/AzuriteServer.h
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#include "velox/core/Config.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 
 #include <azure/storage/blobs/blob_container_client.hpp>

--- a/velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.cpp
@@ -16,10 +16,10 @@
 
 #include "velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.h"
 #include "velox/common/base/Exceptions.h"
+#include "velox/common/config/Config.h"
 #include "velox/common/file/File.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/storage_adapters/gcs/GCSUtil.h"
-#include "velox/core/Config.h"
 #include "velox/core/QueryConfig.h"
 
 #include <fmt/format.h>
@@ -258,9 +258,9 @@ auto constexpr kGCSInvalidPath = "File {} is not a valid gcs file";
 
 class GCSFileSystem::Impl {
  public:
-  Impl(const Config* config)
+  Impl(const config::ConfigBase* config)
       : hiveConfig_(std::make_shared<HiveConfig>(
-            std::make_shared<core::MemConfig>(config->values()))) {}
+            std::make_shared<config::ConfigBase>(config->rawConfigsCopy()))) {}
 
   ~Impl() = default;
 
@@ -315,7 +315,7 @@ class GCSFileSystem::Impl {
   std::shared_ptr<gcs::Client> client_;
 };
 
-GCSFileSystem::GCSFileSystem(std::shared_ptr<const Config> config)
+GCSFileSystem::GCSFileSystem(std::shared_ptr<const config::ConfigBase> config)
     : FileSystem(config) {
   impl_ = std::make_shared<Impl>(config.get());
 }

--- a/velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.h
+++ b/velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.h
@@ -26,7 +26,7 @@ namespace facebook::velox::filesystems {
 /// (register|generate)ReadFile and (register|generate)WriteFile functions.
 class GCSFileSystem : public FileSystem {
  public:
-  explicit GCSFileSystem(std::shared_ptr<const Config> config);
+  explicit GCSFileSystem(std::shared_ptr<const config::ConfigBase> config);
 
   /// Initialize the google::cloud::storage::Client from the input Config
   /// parameters.

--- a/velox/connectors/hive/storage_adapters/gcs/examples/GCSFileSystemExample.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/examples/GCSFileSystemExample.cpp
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/common/config/Config.h"
 #include "velox/common/file/File.h"
 #include "velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.h"
-#include "velox/core/Config.h"
 
 #include <folly/init/Init.h>
-
 #include <gflags/gflags.h>
-
 #include <iostream>
 
 DEFINE_string(gcs_path, "", "Path of GCS bucket");
@@ -37,7 +35,7 @@ auto newConfiguration() {
   if (!FLAGS_gcs_max_retry_time.empty()) {
     configOverride.emplace("hive.gcs.max-retry-time", FLAGS_gcs_max_retry_time);
   }
-  return std::make_shared<const core::MemConfig>(std::move(configOverride));
+  return std::make_shared<const config::ConfigBase>(std::move(configOverride));
 }
 
 int main(int argc, char** argv) {

--- a/velox/connectors/hive/storage_adapters/gcs/tests/GCSFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/tests/GCSFileSystemTest.cpp
@@ -16,10 +16,10 @@
 
 #include "velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/config/Config.h"
 #include "velox/common/file/File.h"
 #include "velox/connectors/hive/FileHandle.h"
 #include "velox/connectors/hive/storage_adapters/gcs/GCSUtil.h"
-#include "velox/core/Config.h"
 #include "velox/exec/tests/utils/TempFilePath.h"
 
 #include <boost/process.hpp>
@@ -139,12 +139,13 @@ class GCSFileSystemTest : public testing::Test {
                              << ">, status=" << object.status();
   }
 
-  std::shared_ptr<const Config> testGcsOptions() const {
+  std::shared_ptr<const config::ConfigBase> testGcsOptions() const {
     std::unordered_map<std::string, std::string> configOverride = {};
 
     configOverride["hive.gcs.scheme"] = "http";
     configOverride["hive.gcs.endpoint"] = "localhost:" + testbench_->port();
-    return std::make_shared<const core::MemConfig>(std::move(configOverride));
+    return std::make_shared<const config::ConfigBase>(
+        std::move(configOverride));
   }
 
   std::string preexistingBucketName() {
@@ -345,8 +346,8 @@ TEST_F(GCSFileSystemTest, credentialsConfig) {
   })""";
   configOverride["hive.gcs.scheme"] = "http";
   configOverride["hive.gcs.endpoint"] = "localhost:" + testbench_->port();
-  std::shared_ptr<const Config> conf =
-      std::make_shared<const core::MemConfig>(std::move(configOverride));
+  std::shared_ptr<const config::ConfigBase> conf =
+      std::make_shared<const config::ConfigBase>(std::move(configOverride));
 
   filesystems::GCSFileSystem gcfs(conf);
 

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
@@ -43,7 +43,7 @@ struct HdfsServiceEndpoint {
 class HdfsFileSystem : public FileSystem {
  public:
   explicit HdfsFileSystem(
-      const std::shared_ptr<const Config>& config,
+      const std::shared_ptr<const config::ConfigBase>& config,
       const HdfsServiceEndpoint& endpoint);
 
   std::string name() const override;
@@ -88,7 +88,7 @@ class HdfsFileSystem : public FileSystem {
   /// will be used.
   static HdfsServiceEndpoint getServiceEndpoint(
       const std::string_view filePath,
-      const Config* config);
+      const config::ConfigBase* config);
 
   static std::string_view kScheme;
 

--- a/velox/connectors/hive/storage_adapters/hdfs/RegisterHdfsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/RegisterHdfsFileSystem.cpp
@@ -17,9 +17,9 @@
 #ifdef VELOX_ENABLE_HDFS3
 #include "folly/concurrency/ConcurrentHashMap.h"
 
+#include "velox/common/config/Config.h"
 #include "velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h" // @manual
 #include "velox/connectors/hive/storage_adapters/hdfs/HdfsUtil.h" // @manual
-#include "velox/core/Config.h"
 #include "velox/dwio/common/FileSink.h"
 #endif
 
@@ -29,9 +29,10 @@ namespace facebook::velox::filesystems {
 std::mutex mtx;
 
 std::function<std::shared_ptr<
-    FileSystem>(std::shared_ptr<const Config>, std::string_view)>
+    FileSystem>(std::shared_ptr<const config::ConfigBase>, std::string_view)>
 hdfsFileSystemGenerator() {
-  static auto filesystemGenerator = [](std::shared_ptr<const Config> properties,
+  static auto filesystemGenerator = [](std::shared_ptr<const config::ConfigBase>
+                                           properties,
                                        std::string_view filePath) {
     static folly::ConcurrentHashMap<std::string, std::shared_ptr<FileSystem>>
         filesystems;

--- a/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.cpp
@@ -37,7 +37,7 @@ FileSystemMap& fileSystems() {
   return instances;
 }
 
-std::string getS3Identity(const std::shared_ptr<core::MemConfig>& config) {
+std::string getS3Identity(const std::shared_ptr<config::ConfigBase>& config) {
   HiveConfig hiveConfig = HiveConfig(config);
   auto endpoint = hiveConfig.s3Endpoint();
   if (!endpoint.empty()) {
@@ -49,11 +49,13 @@ std::string getS3Identity(const std::shared_ptr<core::MemConfig>& config) {
 }
 
 std::shared_ptr<FileSystem> fileSystemGenerator(
-    std::shared_ptr<const Config> properties,
+    std::shared_ptr<const config::ConfigBase> properties,
     std::string_view /*filePath*/) {
-  std::shared_ptr<core::MemConfig> config = std::make_shared<core::MemConfig>();
+  std::shared_ptr<config::ConfigBase> config =
+      std::make_shared<config::ConfigBase>(
+          std::unordered_map<std::string, std::string>());
   if (properties) {
-    *config = core::MemConfig(properties->values());
+    config = std::make_shared<config::ConfigBase>(properties->rawConfigsCopy());
   }
   const auto s3Identity = getS3Identity(config);
 

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
@@ -22,7 +22,7 @@
 namespace facebook::velox::filesystems {
 using namespace facebook::velox::connector::hive;
 
-bool initializeS3(const Config* config);
+bool initializeS3(const config::ConfigBase* config);
 
 void finalizeS3();
 
@@ -31,7 +31,7 @@ void finalizeS3();
 /// type of file can be constructed based on a filename.
 class S3FileSystem : public FileSystem {
  public:
-  explicit S3FileSystem(std::shared_ptr<const Config> config);
+  explicit S3FileSystem(std::shared_ptr<const config::ConfigBase> config);
 
   std::string name() const override;
 

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/MinioServer.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/MinioServer.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "velox/core/Config.h"
+#include "velox/common/config/Config.h"
 #include "velox/exec/tests/utils/PortUtil.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 
@@ -54,7 +54,7 @@ class MinioServer {
     return tempPath_->getPath();
   }
 
-  std::shared_ptr<const Config> hiveConfig(
+  std::shared_ptr<const config::ConfigBase> hiveConfig(
       const std::unordered_map<std::string, std::string> configOverride = {})
       const {
     std::unordered_map<std::string, std::string> config({
@@ -70,7 +70,7 @@ class MinioServer {
       config[configName] = configValue;
     }
 
-    return std::make_shared<const core::MemConfig>(std::move(config));
+    return std::make_shared<const config::ConfigBase>(std::move(config));
   }
 
  private:

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemFinalizeTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemFinalizeTest.cpp
@@ -15,8 +15,8 @@
  */
 
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/config/Config.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h"
-#include "velox/core/Config.h"
 
 #include "gtest/gtest.h"
 
@@ -24,7 +24,8 @@ namespace facebook::velox {
 namespace {
 
 TEST(S3FileSystemFinalizeTest, finalize) {
-  auto s3Config = std::make_shared<core::MemConfig>();
+  auto s3Config = std::make_shared<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>());
   ASSERT_TRUE(filesystems::initializeS3(s3Config.get()));
   ASSERT_FALSE(filesystems::initializeS3(s3Config.get()));
   {

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
@@ -62,11 +62,11 @@ TEST_F(S3FileSystemTest, writeAndRead) {
 
 TEST_F(S3FileSystemTest, invalidCredentialsConfig) {
   {
-    const std::unordered_map<std::string, std::string> config(
+    std::unordered_map<std::string, std::string> config(
         {{"hive.s3.use-instance-credentials", "true"},
          {"hive.s3.iam-role", "dummy-iam-role"}});
     auto hiveConfig =
-        std::make_shared<const core::MemConfig>(std::move(config));
+        std::make_shared<const config::ConfigBase>(std::move(config));
 
     // Both instance credentials and iam-role cannot be specified
     VELOX_ASSERT_THROW(
@@ -74,34 +74,34 @@ TEST_F(S3FileSystemTest, invalidCredentialsConfig) {
         "Invalid configuration: specify only one among 'access/secret keys', 'use instance credentials', 'IAM role'");
   }
   {
-    const std::unordered_map<std::string, std::string> config(
+    std::unordered_map<std::string, std::string> config(
         {{"hive.s3.aws-secret-key", "dummy-key"},
          {"hive.s3.aws-access-key", "dummy-key"},
          {"hive.s3.iam-role", "dummy-iam-role"}});
     auto hiveConfig =
-        std::make_shared<const core::MemConfig>(std::move(config));
+        std::make_shared<const config::ConfigBase>(std::move(config));
     // Both access/secret keys and iam-role cannot be specified
     VELOX_ASSERT_THROW(
         filesystems::S3FileSystem(hiveConfig),
         "Invalid configuration: specify only one among 'access/secret keys', 'use instance credentials', 'IAM role'");
   }
   {
-    const std::unordered_map<std::string, std::string> config(
+    std::unordered_map<std::string, std::string> config(
         {{"hive.s3.aws-secret-key", "dummy"},
          {"hive.s3.aws-access-key", "dummy"},
          {"hive.s3.use-instance-credentials", "true"}});
     auto hiveConfig =
-        std::make_shared<const core::MemConfig>(std::move(config));
+        std::make_shared<const config::ConfigBase>(std::move(config));
     // Both access/secret keys and instance credentials cannot be specified
     VELOX_ASSERT_THROW(
         filesystems::S3FileSystem(hiveConfig),
         "Invalid configuration: specify only one among 'access/secret keys', 'use instance credentials', 'IAM role'");
   }
   {
-    const std::unordered_map<std::string, std::string> config(
+    std::unordered_map<std::string, std::string> config(
         {{"hive.s3.aws-secret-key", "dummy"}});
     auto hiveConfig =
-        std::make_shared<const core::MemConfig>(std::move(config));
+        std::make_shared<const config::ConfigBase>(std::move(config));
     // Both access key and secret key must be specified
     VELOX_ASSERT_THROW(
         filesystems::S3FileSystem(hiveConfig),
@@ -167,7 +167,8 @@ TEST_F(S3FileSystemTest, noBackendServer) {
 TEST_F(S3FileSystemTest, logLevel) {
   std::unordered_map<std::string, std::string> config;
   auto checkLogLevelName = [&config](std::string_view expected) {
-    auto s3Config = std::make_shared<const core::MemConfig>(config);
+    auto s3Config =
+        std::make_shared<const config::ConfigBase>(std::move(config));
     filesystems::S3FileSystem s3fs(s3Config);
     EXPECT_EQ(s3fs.getLogLevelName(), expected);
   };

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -16,15 +16,17 @@
 
 #include "velox/connectors/hive/HiveConfig.h"
 #include "gtest/gtest.h"
-#include "velox/core/Config.h"
+#include "velox/common/config/Config.h"
 
+using namespace facebook::velox;
 using namespace facebook::velox::connector::hive;
-using namespace facebook::velox::core;
 using facebook::velox::connector::hive::HiveConfig;
 
 TEST(HiveConfigTest, defaultConfig) {
-  HiveConfig hiveConfig(std::make_shared<MemConfig>());
-  const auto emptySession = std::make_unique<MemConfig>();
+  HiveConfig hiveConfig(std::make_shared<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>()));
+  const auto emptySession = std::make_unique<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>());
   ASSERT_EQ(
       hiveConfig.insertExistingPartitionsBehavior(emptySession.get()),
       facebook::velox::connector::hive::HiveConfig::
@@ -77,7 +79,7 @@ TEST(HiveConfigTest, defaultConfig) {
 }
 
 TEST(HiveConfigTest, overrideConfig) {
-  const std::unordered_map<std::string, std::string> configFromFile = {
+  std::unordered_map<std::string, std::string> configFromFile = {
       {HiveConfig::kInsertExistingPartitionsBehavior, "OVERWRITE"},
       {HiveConfig::kMaxPartitionsPerWriters, "120"},
       {HiveConfig::kImmutablePartitions, "true"},
@@ -109,8 +111,10 @@ TEST(HiveConfigTest, overrideConfig) {
       {HiveConfig::kOrcWriterMinCompressionSize, "512"},
       {HiveConfig::kOrcWriterCompressionLevel, "1"},
       {HiveConfig::kCacheNoRetention, "true"}};
-  HiveConfig hiveConfig(std::make_shared<MemConfig>(configFromFile));
-  auto emptySession = std::make_unique<MemConfig>();
+  HiveConfig hiveConfig(
+      std::make_shared<config::ConfigBase>(std::move(configFromFile)));
+  auto emptySession = std::make_shared<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>());
   ASSERT_EQ(
       hiveConfig.insertExistingPartitionsBehavior(emptySession.get()),
       facebook::velox::connector::hive::HiveConfig::
@@ -161,8 +165,9 @@ TEST(HiveConfigTest, overrideConfig) {
 }
 
 TEST(HiveConfigTest, overrideSession) {
-  HiveConfig hiveConfig(std::make_shared<MemConfig>());
-  const std::unordered_map<std::string, std::string> sessionOverride = {
+  HiveConfig hiveConfig(std::make_shared<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>()));
+  std::unordered_map<std::string, std::string> sessionOverride = {
       {HiveConfig::kInsertExistingPartitionsBehaviorSession, "OVERWRITE"},
       {HiveConfig::kOrcUseColumnNamesSession, "true"},
       {HiveConfig::kFileColumnNamesReadAsLowerCaseSession, "true"},
@@ -178,7 +183,8 @@ TEST(HiveConfigTest, overrideSession) {
       {HiveConfig::kOrcWriterCompressionLevelSession, "1"},
       {HiveConfig::kOrcWriterLinearStripeSizeHeuristicsSession, "false"},
       {HiveConfig::kCacheNoRetentionSession, "true"}};
-  const auto session = std::make_unique<MemConfig>(sessionOverride);
+  const auto session =
+      std::make_unique<config::ConfigBase>(std::move(sessionOverride));
   ASSERT_EQ(
       hiveConfig.insertExistingPartitionsBehavior(session.get()),
       facebook::velox::connector::hive::HiveConfig::

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -19,7 +19,6 @@
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/TableHandle.h"
-#include "velox/core/Config.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PrefixSortUtils.h"
 
@@ -42,7 +41,7 @@ class HiveConnectorUtilTest : public exec::test::HiveConnectorTestBase {
 };
 
 TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
-  core::MemConfig sessionProperties;
+  config::ConfigBase sessionProperties({});
   auto connectorQueryCtx = std::make_unique<connector::ConnectorQueryCtx>(
       pool_.get(),
       pool_.get(),
@@ -57,7 +56,8 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
       0,
       "");
   auto hiveConfig =
-      std::make_shared<hive::HiveConfig>(std::make_shared<core::MemConfig>());
+      std::make_shared<hive::HiveConfig>(std::make_shared<config::ConfigBase>(
+          std::unordered_map<std::string, std::string>()));
   const std::unordered_map<std::string, std::optional<std::string>>
       partitionKeys;
   const std::unordered_map<std::string, std::string> customSplitInfo;
@@ -188,7 +188,7 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
   customHiveConfigProps[hive::HiveConfig::kFilePreloadThreshold] = "9999";
   customHiveConfigProps[hive::HiveConfig::kPrefetchRowGroups] = "10";
   hiveConfig = std::make_shared<hive::HiveConfig>(
-      std::make_shared<core::MemConfig>(customHiveConfigProps));
+      std::make_shared<config::ConfigBase>(std::move(customHiveConfigProps)));
   performConfigure();
   EXPECT_EQ(readerOptions.loadQuantum(), hiveConfig->loadQuantum());
   EXPECT_EQ(readerOptions.maxCoalesceBytes(), hiveConfig->maxCoalescedBytes());

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -22,7 +22,6 @@
 #include "velox/common/base/Fs.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/testutil/TestValue.h"
-#include "velox/core/Config.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -204,11 +203,13 @@ class HiveDataSinkTest : public exec::test::HiveConnectorTestBase {
   std::shared_ptr<memory::MemoryPool> opPool_;
   std::shared_ptr<memory::MemoryPool> connectorPool_;
   RowTypePtr rowType_;
-  std::shared_ptr<core::MemConfig> connectorSessionProperties_ =
-      std::make_shared<core::MemConfig>();
+  std::shared_ptr<config::ConfigBase> connectorSessionProperties_ =
+      std::make_shared<config::ConfigBase>(
+          std::unordered_map<std::string, std::string>());
   std::unique_ptr<ConnectorQueryCtx> connectorQueryCtx_;
   std::shared_ptr<HiveConfig> connectorConfig_ =
-      std::make_shared<HiveConfig>(std::make_shared<core::MemConfig>());
+      std::make_shared<HiveConfig>(std::make_shared<config::ConfigBase>(
+          std::unordered_map<std::string, std::string>()));
   std::unique_ptr<folly::IOThreadPoolExecutor> spillExecutor_;
 };
 
@@ -820,7 +821,7 @@ TEST_F(HiveDataSinkTest, memoryReclaimAfterClose) {
     connectorConfig.emplace("hive.orc.writer.dictionary-max-memory", "1GB");
 
     connectorConfig_ = std::make_shared<HiveConfig>(
-        std::make_shared<core::MemConfig>(std::move(connectorConfig)));
+        std::make_shared<config::ConfigBase>(std::move(connectorConfig)));
     const auto outputDirectory = TempDirectoryPath::create();
     std::shared_ptr<HiveBucketProperty> bucketProperty;
     std::vector<std::string> partitionBy;

--- a/velox/connectors/tests/ConnectorTest.cpp
+++ b/velox/connectors/tests/ConnectorTest.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/connectors/Connector.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/config/Config.h"
 
 #include <gtest/gtest.h>
 
@@ -61,6 +62,13 @@ class TestConnectorFactory : public connector::ConnectorFactory {
       folly::Executor* /*executor*/ = nullptr) override {
     return std::make_shared<TestConnector>(id);
   }
+
+  std::shared_ptr<Connector> newConnector(
+      const std::string& id,
+      std::shared_ptr<const config::ConfigBase> /*config*/,
+      folly::Executor* /*executor*/ = nullptr) override {
+    return std::make_shared<TestConnector>(id);
+  }
 };
 
 } // namespace
@@ -75,7 +83,10 @@ TEST_F(ConnectorTest, getAllConnectors) {
   for (int32_t i = 0; i < numConnectors; i++) {
     registerConnector(
         getConnectorFactory(TestConnectorFactory::kConnectorFactoryName)
-            ->newConnector(fmt::format("connector-{}", i), {}));
+            ->newConnector(
+                fmt::format("connector-{}", i),
+                std::make_shared<config::ConfigBase>(
+                    std::unordered_map<std::string, std::string>())));
   }
   const auto& connectors = getAllConnectors();
   EXPECT_EQ(connectors.size(), numConnectors);

--- a/velox/connectors/tpch/TpchConnector.h
+++ b/velox/connectors/tpch/TpchConnector.h
@@ -15,8 +15,10 @@
  */
 #pragma once
 
+#include "velox/common/config/Config.h"
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/tpch/TpchConnectorSplit.h"
+#include "velox/core/Config.h"
 #include "velox/tpch/gen/TpchGen.h"
 
 namespace facebook::velox::connector::tpch {
@@ -130,7 +132,7 @@ class TpchConnector final : public Connector {
  public:
   TpchConnector(
       const std::string& id,
-      std::shared_ptr<const Config> config,
+      std::shared_ptr<const config::ConfigBase> config,
       folly::Executor* /*executor*/)
       : Connector(id) {}
 
@@ -169,9 +171,20 @@ class TpchConnectorFactory : public ConnectorFactory {
 
   std::shared_ptr<Connector> newConnector(
       const std::string& id,
-      std::shared_ptr<const Config> config,
+      std::shared_ptr<const config::ConfigBase> config,
       folly::Executor* executor = nullptr) override {
     return std::make_shared<TpchConnector>(id, config, executor);
+  }
+
+  std::shared_ptr<Connector> newConnector(
+      const std::string& id,
+      std::shared_ptr<const Config> config,
+      folly::Executor* executor = nullptr) override {
+    std::shared_ptr<const config::ConfigBase> convertedConfig;
+    convertedConfig = config == nullptr
+        ? nullptr
+        : std::make_shared<config::ConfigBase>(config->valuesCopy());
+    return newConnector(id, convertedConfig, executor);
   }
 };
 

--- a/velox/connectors/tpch/tests/SpeedTest.cpp
+++ b/velox/connectors/tpch/tests/SpeedTest.cpp
@@ -60,7 +60,9 @@ class TpchSpeedTest {
         connector::getConnectorFactory(
             connector::tpch::TpchConnectorFactory::kTpchConnectorName)
             ->newConnector(
-                kTpchConnectorId_, std::make_shared<core::MemConfig>());
+                kTpchConnectorId_,
+                std::make_shared<config::ConfigBase>(
+                    std::unordered_map<std::string, std::string>()));
     connector::registerConnector(tpchConnector);
   }
 

--- a/velox/connectors/tpch/tests/TpchConnectorTest.cpp
+++ b/velox/connectors/tpch/tests/TpchConnectorTest.cpp
@@ -40,7 +40,9 @@ class TpchConnectorTest : public exec::test::OperatorTestBase {
         connector::getConnectorFactory(
             connector::tpch::TpchConnectorFactory::kTpchConnectorName)
             ->newConnector(
-                kTpchConnectorId, std::make_shared<core::MemConfig>());
+                kTpchConnectorId,
+                std::make_shared<config::ConfigBase>(
+                    std::unordered_map<std::string, std::string>()));
     connector::registerConnector(tpchConnector);
   }
 

--- a/velox/core/CMakeLists.txt
+++ b/velox/core/CMakeLists.txt
@@ -35,6 +35,7 @@ velox_link_libraries(
   PUBLIC velox_arrow_bridge
          velox_caching
          velox_config
+         velox_common_config
          velox_connector
          velox_exception
          velox_expression_functions

--- a/velox/core/QueryConfig.cpp
+++ b/velox/core/QueryConfig.cpp
@@ -16,103 +16,41 @@
 
 #include <re2/re2.h>
 
+#include "velox/common/config/Config.h"
 #include "velox/core/QueryConfig.h"
+#include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox::core {
 
-double toBytesPerCapacityUnit(CapacityUnit unit) {
-  switch (unit) {
-    case CapacityUnit::BYTE:
-      return 1;
-    case CapacityUnit::KILOBYTE:
-      return exp2(10);
-    case CapacityUnit::MEGABYTE:
-      return exp2(20);
-    case CapacityUnit::GIGABYTE:
-      return exp2(30);
-    case CapacityUnit::TERABYTE:
-      return exp2(40);
-    case CapacityUnit::PETABYTE:
-      return exp2(50);
-    default:
-      VELOX_USER_FAIL("Invalid capacity unit '{}'", (int)unit);
-  }
-}
-
-CapacityUnit valueOfCapacityUnit(const std::string& unitStr) {
-  if (unitStr == "B") {
-    return CapacityUnit::BYTE;
-  }
-  // To be backward compatible this is lowercase.
-  if (unitStr == "kB") {
-    return CapacityUnit::KILOBYTE;
-  }
-  if (unitStr == "MB") {
-    return CapacityUnit::MEGABYTE;
-  }
-  if (unitStr == "GB") {
-    return CapacityUnit::GIGABYTE;
-  }
-  if (unitStr == "TB") {
-    return CapacityUnit::TERABYTE;
-  }
-  if (unitStr == "PB") {
-    return CapacityUnit::PETABYTE;
-  }
-  VELOX_USER_FAIL("Invalid capacity unit '{}'", unitStr);
-}
-
-// Convert capacity string with unit to the capacity number in the specified
-// units
-uint64_t toCapacity(const std::string& from, CapacityUnit to) {
-  static const RE2 kPattern(R"(^\s*(\d+(?:\.\d+)?)\s*([a-zA-Z]+)\s*$)");
-  double value;
-  std::string unit;
-  if (!RE2::FullMatch(from, kPattern, &value, &unit)) {
-    VELOX_USER_FAIL("Invalid capacity string '{}'", from);
-  }
-
-  return value *
-      (toBytesPerCapacityUnit(valueOfCapacityUnit(unit)) /
-       toBytesPerCapacityUnit(to));
-}
-
-std::chrono::duration<double> toDuration(const std::string& str) {
-  static const RE2 kPattern(R"(^\s*(\d+(?:\.\d+)?)\s*([a-zA-Z]+)\s*)");
-
-  double value;
-  std::string unit;
-  if (!RE2::FullMatch(str, kPattern, &value, &unit)) {
-    VELOX_USER_FAIL("Invalid duration {}", str);
-  }
-  if (unit == "ns") {
-    return std::chrono::duration<double, std::nano>(value);
-  } else if (unit == "us") {
-    return std::chrono::duration<double, std::micro>(value);
-  } else if (unit == "ms") {
-    return std::chrono::duration<double, std::milli>(value);
-  } else if (unit == "s") {
-    return std::chrono::duration<double>(value);
-  } else if (unit == "m") {
-    return std::chrono::duration<double, std::ratio<60>>(value);
-  } else if (unit == "h") {
-    return std::chrono::duration<double, std::ratio<60 * 60>>(value);
-  } else if (unit == "d") {
-    return std::chrono::duration<double, std::ratio<60 * 60 * 24>>(value);
-  }
-  VELOX_USER_FAIL("Invalid duration {}", str);
-}
-
 QueryConfig::QueryConfig(
     const std::unordered_map<std::string, std::string>& values)
-    : config_{std::make_unique<MemConfig>(values)} {}
+    : config_{std::make_unique<config::ConfigBase>(
+          std::unordered_map<std::string, std::string>(values))} {
+  validateConfig();
+}
 
 QueryConfig::QueryConfig(std::unordered_map<std::string, std::string>&& values)
-    : config_{std::make_unique<MemConfig>(std::move(values))} {}
+    : config_{std::make_unique<config::ConfigBase>(std::move(values))} {
+  validateConfig();
+}
+
+void QueryConfig::validateConfig() {
+  // Validate if timezone name can be recognized.
+  if (config_->valueExists(QueryConfig::kSessionTimezone)) {
+    VELOX_USER_CHECK(
+        tz::getTimeZoneID(
+            config_->get<std::string>(QueryConfig::kSessionTimezone).value(),
+            false) != -1,
+        fmt::format(
+            "session '{}' set with invalid value '{}'",
+            QueryConfig::kSessionTimezone,
+            config_->get<std::string>(QueryConfig::kSessionTimezone).value()));
+  }
+}
 
 void QueryConfig::testingOverrideConfigUnsafe(
     std::unordered_map<std::string, std::string>&& values) {
-  config_ = std::make_unique<MemConfig>(std::move(values));
+  config_ = std::make_unique<config::ConfigBase>(std::move(values));
 }
 
 } // namespace facebook::velox::core

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -19,24 +19,6 @@
 #include "velox/core/Config.h"
 
 namespace facebook::velox::core {
-enum class CapacityUnit {
-  BYTE,
-  KILOBYTE,
-  MEGABYTE,
-  GIGABYTE,
-  TERABYTE,
-  PETABYTE
-};
-
-double toBytesPerCapacityUnit(CapacityUnit unit);
-
-CapacityUnit valueOfCapacityUnit(const std::string& unitStr);
-
-/// Convert capacity string with unit to the capacity number in the specified
-/// units
-uint64_t toCapacity(const std::string& from, CapacityUnit to);
-
-std::chrono::duration<double> toDuration(const std::string& str);
 
 /// A simple wrapper around velox::Config. Defines constants for query
 /// config properties and accessor methods.
@@ -745,6 +727,8 @@ class QueryConfig {
       std::unordered_map<std::string, std::string>&& values);
 
  private:
-  std::unique_ptr<velox::Config> config_;
+  void validateConfig();
+
+  std::unique_ptr<velox::config::ConfigBase> config_;
 };
 } // namespace facebook::velox::core

--- a/velox/core/tests/QueryConfigTest.cpp
+++ b/velox/core/tests/QueryConfigTest.cpp
@@ -47,53 +47,10 @@ TEST_F(QueryConfigTest, setConfig) {
 
 TEST_F(QueryConfigTest, invalidConfig) {
   std::unordered_map<std::string, std::string> configData(
-      {{QueryConfig::kSessionTimezone, "Invalid"}});
+      {{QueryConfig::kSessionTimezone, "invalid"}});
   VELOX_ASSERT_USER_THROW(
       QueryCtx::create(nullptr, QueryConfig{std::move(configData)}),
-      "Unknown time zone: 'Invalid'");
-
-  auto queryCtx = QueryCtx::create(nullptr);
-  VELOX_ASSERT_USER_THROW(
-      queryCtx->testingOverrideConfigUnsafe({
-          {core::QueryConfig::kSessionTimezone, ""},
-      }),
-      "Unknown time zone: ''");
-}
-
-TEST_F(QueryConfigTest, memConfig) {
-  const std::string tz = "UTC";
-  const std::unordered_map<std::string, std::string> configData(
-      {{QueryConfig::kSessionTimezone, tz}});
-
-  {
-    MemConfig cfg{configData};
-    MemConfig cfg2{};
-    auto configDataCopy = configData;
-    ASSERT_EQ(
-        tz,
-        cfg.Config::get<std::string>(QueryConfig::kSessionTimezone).value());
-    ASSERT_FALSE(cfg.Config::get<std::string>("missing-entry").has_value());
-    ASSERT_EQ(configData, cfg.values());
-    ASSERT_EQ(configData, cfg.valuesCopy());
-  }
-
-  {
-    MemConfigMutable cfg{configData};
-    MemConfigMutable cfg2{};
-    auto configDataCopy = configData;
-    MemConfigMutable cfg3{std::move(configDataCopy)};
-    ASSERT_EQ(
-        tz,
-        cfg.Config::get<std::string>(QueryConfig::kSessionTimezone).value());
-    ASSERT_FALSE(cfg.Config::get<std::string>("missing-entry").has_value());
-    const std::string tz2 = "PST";
-    ASSERT_NO_THROW(cfg.setValue(QueryConfig::kSessionTimezone, tz2));
-    ASSERT_EQ(
-        tz2,
-        cfg.Config::get<std::string>(QueryConfig::kSessionTimezone).value());
-    ASSERT_THROW(cfg.values(), VeloxException);
-    ASSERT_EQ(configData, cfg3.valuesCopy());
-  }
+      "session 'session_timezone' set with invalid value 'invalid'");
 }
 
 TEST_F(QueryConfigTest, taskWriterCountConfig) {
@@ -185,65 +142,6 @@ TEST_F(QueryConfigTest, enableExpressionEvaluationCacheConfig) {
 
   testConfig(true);
   testConfig(false);
-}
-
-TEST_F(QueryConfigTest, capacityConversion) {
-  folly::Random::DefaultGenerator rng;
-  rng.seed(1);
-
-  std::unordered_map<CapacityUnit, std::string> unitStrLookup{
-      {CapacityUnit::BYTE, "B"},
-      {CapacityUnit::KILOBYTE, "kB"},
-      {CapacityUnit::MEGABYTE, "MB"},
-      {CapacityUnit::GIGABYTE, "GB"},
-      {CapacityUnit::TERABYTE, "TB"},
-      {CapacityUnit::PETABYTE, "PB"}};
-
-  std::vector<std::pair<CapacityUnit, double>> units{
-      {CapacityUnit::BYTE, 1},
-      {CapacityUnit::KILOBYTE, 1024},
-      {CapacityUnit::MEGABYTE, 1024 * 1024},
-      {CapacityUnit::GIGABYTE, 1024 * 1024 * 1024},
-      {CapacityUnit::TERABYTE, 1024ll * 1024 * 1024 * 1024},
-      {CapacityUnit::PETABYTE, 1024ll * 1024 * 1024 * 1024 * 1024}};
-  for (int32_t i = 0; i < units.size(); i++) {
-    for (int32_t j = 0; j < units.size(); j++) {
-      // We use this diffRatio to prevent float conversion overflow when
-      // converting from one unit to another.
-      uint64_t diffRatio = i < j ? units[j].second / units[i].second
-                                 : units[i].second / units[j].second;
-      uint64_t randNumber = folly::Random::rand64(rng);
-      uint64_t testNumber = i > j ? randNumber / diffRatio : randNumber;
-      ASSERT_EQ(
-          toCapacity(
-              std::string(
-                  std::to_string(testNumber) + unitStrLookup[units[i].first]),
-              units[j].first),
-          (uint64_t)(testNumber * (units[i].second / units[j].second)));
-    }
-  }
-}
-
-TEST_F(QueryConfigTest, durationConversion) {
-  folly::Random::DefaultGenerator rng;
-  rng.seed(1);
-
-  std::vector<std::pair<std::string, uint64_t>> units{
-      {"ns", 1},
-      {"us", 1000},
-      {"ms", 1000 * 1000},
-      {"s", 1000ll * 1000 * 1000},
-      {"m", 1000ll * 1000 * 1000 * 60},
-      {"h", 1000ll * 1000 * 1000 * 60 * 60},
-      {"d", 1000ll * 1000 * 1000 * 60 * 60 * 24}};
-  for (uint32_t i = 0; i < units.size(); i++) {
-    auto testNumber = folly::Random::rand32(rng) % 10000;
-    auto duration =
-        toDuration(std::string(std::to_string(testNumber) + units[i].first));
-    ASSERT_EQ(
-        testNumber * units[i].second,
-        std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count());
-  }
 }
 
 } // namespace facebook::velox::core::test

--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -71,7 +71,7 @@ velox_link_libraries(
   velox_caching
   velox_common_io
   velox_common_compression
-  velox_config
+  velox_common_config
   velox_dwio_common_encryption
   velox_dwio_common_exception
   velox_exception

--- a/velox/dwio/common/FileSink.h
+++ b/velox/dwio/common/FileSink.h
@@ -18,15 +18,12 @@
 
 #include <chrono>
 
+#include "velox/common/config/Config.h"
 #include "velox/common/file/File.h"
 #include "velox/common/io/IoStatistics.h"
 #include "velox/dwio/common/Closeable.h"
 #include "velox/dwio/common/DataBuffer.h"
 #include "velox/dwio/common/MetricsLog.h"
-
-namespace facebook::velox {
-class Config;
-}
 
 namespace facebook::velox::dwio::common {
 using namespace facebook::velox::io;
@@ -40,7 +37,8 @@ class FileSink : public Closeable {
     bool bufferWrite{true};
     /// Connector properties are required to create a FileSink on FileSystems
     /// such as S3.
-    const std::shared_ptr<const Config>& connectorProperties{nullptr};
+    const std::shared_ptr<const config::ConfigBase>& connectorProperties{
+        nullptr};
     /// Config used to create sink files. This config is provided to underlying
     /// file system and the config is free form. The form should be defined by
     /// the underlying file system.
@@ -111,7 +109,7 @@ class FileSink : public Closeable {
       const std::function<uint64_t(const DataBuffer<char>&)>& callback);
 
   const std::string name_;
-  const std::shared_ptr<const Config> connectorProperties_;
+  const std::shared_ptr<const config::ConfigBase> connectorProperties_;
   memory::MemoryPool* const pool_;
   const MetricsLogPtr metricLogger_;
   IoStatistics* const stats_;

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -23,9 +23,9 @@
 #include "velox/common/base/RandomUtil.h"
 #include "velox/common/base/SpillConfig.h"
 #include "velox/common/compression/Compression.h"
+#include "velox/common/config/Config.h"
 #include "velox/common/io/Options.h"
 #include "velox/common/memory/Memory.h"
-#include "velox/core/Config.h"
 #include "velox/dwio/common/ColumnSelector.h"
 #include "velox/dwio/common/ErrorTolerance.h"
 #include "velox/dwio/common/FlatMapHelper.h"
@@ -620,8 +620,8 @@ struct WriterOptions {
 
   // WriterOption implementations should provide this function to specify how to
   // process format-specific session and connector configs.
-  virtual void processSessionConfigs(const Config&) {}
-  virtual void processHiveConnectorConfigs(const Config&) {}
+  virtual void processSessionConfigs(const config::ConfigBase&) {}
+  virtual void processHiveConnectorConfigs(const config::ConfigBase&) {}
 
   virtual ~WriterOptions() = default;
 };

--- a/velox/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -57,14 +57,18 @@ class ParquetTpchTest : public testing::Test {
         connector::getConnectorFactory(
             connector::hive::HiveConnectorFactory::kHiveConnectorName)
             ->newConnector(
-                kHiveConnectorId, std::make_shared<core::MemConfig>());
+                kHiveConnectorId,
+                std::make_shared<config::ConfigBase>(
+                    std::unordered_map<std::string, std::string>()));
     connector::registerConnector(hiveConnector);
 
     auto tpchConnector =
         connector::getConnectorFactory(
             connector::tpch::TpchConnectorFactory::kTpchConnectorName)
             ->newConnector(
-                kTpchConnectorId, std::make_shared<core::MemConfig>());
+                kTpchConnectorId,
+                std::make_shared<config::ConfigBase>(
+                    std::unordered_map<std::string, std::string>()));
     connector::registerConnector(tpchConnector);
 
     saveTpchTablesAsParquet();

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -49,7 +49,9 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
         connector::getConnectorFactory(
             connector::hive::HiveConnectorFactory::kHiveConnectorName)
             ->newConnector(
-                kHiveConnectorId, std::make_shared<core::MemConfig>());
+                kHiveConnectorId,
+                std::make_shared<config::ConfigBase>(
+                    std::unordered_map<std::string, std::string>()));
     connector::registerConnector(hiveConnector);
   }
 

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -46,7 +46,9 @@ class ParquetWriterTest : public ParquetTestBase {
         connector::getConnectorFactory(
             connector::hive::HiveConnectorFactory::kHiveConnectorName)
             ->newConnector(
-                kHiveConnectorId, std::make_shared<core::MemConfig>());
+                kHiveConnectorId,
+                std::make_shared<config::ConfigBase>(
+                    std::unordered_map<std::string, std::string>()));
     connector::registerConnector(hiveConnector);
     parquet::registerParquetWriterFactory();
   }

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -18,6 +18,7 @@
 #include <arrow/c/bridge.h>
 #include <arrow/io/interfaces.h>
 #include <arrow/table.h>
+#include "velox/common/config/Config.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/dwio/parquet/writer/arrow/Properties.h"
@@ -410,7 +411,7 @@ void Writer::setMemoryReclaimers() {
 namespace {
 
 std::optional<TimestampUnit> getTimestampUnit(
-    const Config& config,
+    const config::ConfigBase& config,
     const char* configKey) {
   if (const auto unit = config.get<uint8_t>(configKey)) {
     VELOX_CHECK(
@@ -424,7 +425,7 @@ std::optional<TimestampUnit> getTimestampUnit(
 }
 
 std::optional<std::string> getTimestampTimeZone(
-    const Config& config,
+    const config::ConfigBase& config,
     const char* configKey) {
   if (const auto timezone = config.get<std::string>(configKey)) {
     return timezone.value();
@@ -434,7 +435,7 @@ std::optional<std::string> getTimestampTimeZone(
 
 } // namespace
 
-void WriterOptions::processSessionConfigs(const Config& config) {
+void WriterOptions::processSessionConfigs(const config::ConfigBase& config) {
   if (!parquetWriteTimestampUnit) {
     parquetWriteTimestampUnit =
         getTimestampUnit(config, kParquetSessionWriteTimestampUnit);
@@ -446,7 +447,8 @@ void WriterOptions::processSessionConfigs(const Config& config) {
   }
 }
 
-void WriterOptions::processHiveConnectorConfigs(const Config& config) {
+void WriterOptions::processHiveConnectorConfigs(
+    const config::ConfigBase& config) {
   if (!parquetWriteTimestampUnit) {
     parquetWriteTimestampUnit =
         getTimestampUnit(config, kParquetHiveConnectorWriteTimestampUnit);

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include "velox/common/compression/Compression.h"
-#include "velox/core/Config.h"
+#include "velox/common/config/Config.h"
 #include "velox/dwio/common/DataBuffer.h"
 #include "velox/dwio/common/FileSink.h"
 #include "velox/dwio/common/FlushPolicy.h"
@@ -123,8 +123,8 @@ struct WriterOptions : public dwio::common::WriterOptions {
       "hive.parquet.writer.timestamp-unit";
 
   // Process hive connector and session configs.
-  void processSessionConfigs(const Config& config) override;
-  void processHiveConnectorConfigs(const Config& config) override;
+  void processSessionConfigs(const config::ConfigBase& config) override;
+  void processHiveConnectorConfigs(const config::ConfigBase& config) override;
 };
 
 // Writes Velox vectors into  a DataSink using Arrow Parquet writer.

--- a/velox/examples/ScanAndSort.cpp
+++ b/velox/examples/ScanAndSort.cpp
@@ -89,7 +89,10 @@ int main(int argc, char** argv) {
   auto hiveConnector =
       connector::getConnectorFactory(
           connector::hive::HiveConnectorFactory::kHiveConnectorName)
-          ->newConnector(kHiveConnectorId, std::make_shared<core::MemConfig>());
+          ->newConnector(
+              kHiveConnectorId,
+              std::make_shared<config::ConfigBase>(
+                  std::unordered_map<std::string, std::string>()));
   connector::registerConnector(hiveConnector);
 
   // To be able to read local files, we need to register the local file

--- a/velox/exec/fuzzer/AggregationFuzzerBase.h
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.h
@@ -78,7 +78,9 @@ class AggregationFuzzerBase {
         connector::getConnectorFactory(
             connector::hive::HiveConnectorFactory::kHiveConnectorName)
             ->newConnector(
-                kHiveConnectorId, std::make_shared<core::MemConfig>());
+                kHiveConnectorId,
+                std::make_shared<config::ConfigBase>(
+                    std::unordered_map<std::string, std::string>()));
     connector::registerConnector(hiveConnector);
 
     seed(initialSeed);

--- a/velox/exec/fuzzer/JoinFuzzer.cpp
+++ b/velox/exec/fuzzer/JoinFuzzer.cpp
@@ -309,13 +309,14 @@ JoinFuzzer::JoinFuzzer(
   filesystems::registerLocalFileSystem();
 
   // Make sure not to run out of open file descriptors.
-  const std::unordered_map<std::string, std::string> hiveConfig = {
+  std::unordered_map<std::string, std::string> hiveConfig = {
       {connector::hive::HiveConfig::kNumCacheFileHandles, "1000"}};
   auto hiveConnector =
       connector::getConnectorFactory(
           connector::hive::HiveConnectorFactory::kHiveConnectorName)
           ->newConnector(
-              kHiveConnectorId, std::make_shared<core::MemConfig>(hiveConfig));
+              kHiveConnectorId,
+              std::make_shared<config::ConfigBase>(std::move(hiveConfig)));
   connector::registerConnector(hiveConnector);
 
   seed(initialSeed);

--- a/velox/exec/fuzzer/MemoryArbitrationFuzzer.cpp
+++ b/velox/exec/fuzzer/MemoryArbitrationFuzzer.cpp
@@ -220,13 +220,14 @@ class MemoryArbitrationFuzzer {
 MemoryArbitrationFuzzer::MemoryArbitrationFuzzer(size_t initialSeed)
     : vectorFuzzer_{getFuzzerOptions(), pool_.get()} {
   // Make sure not to run out of open file descriptors.
-  const std::unordered_map<std::string, std::string> hiveConfig = {
+  std::unordered_map<std::string, std::string> hiveConfig = {
       {connector::hive::HiveConfig::kNumCacheFileHandles, "1000"}};
   const auto hiveConnector =
       connector::getConnectorFactory(
           connector::hive::HiveConnectorFactory::kHiveConnectorName)
           ->newConnector(
-              kHiveConnectorId, std::make_shared<core::MemConfig>(hiveConfig));
+              kHiveConnectorId,
+              std::make_shared<config::ConfigBase>(std::move(hiveConfig)));
   connector::registerConnector(hiveConnector);
   seed(initialSeed);
 }

--- a/velox/exec/fuzzer/RowNumberFuzzer.cpp
+++ b/velox/exec/fuzzer/RowNumberFuzzer.cpp
@@ -173,13 +173,14 @@ RowNumberFuzzer::RowNumberFuzzer(
   filesystems::registerLocalFileSystem();
 
   // Make sure not to run out of open file descriptors.
-  const std::unordered_map<std::string, std::string> hiveConfig = {
+  std::unordered_map<std::string, std::string> hiveConfig = {
       {connector::hive::HiveConfig::kNumCacheFileHandles, "1000"}};
   auto hiveConnector =
       connector::getConnectorFactory(
           connector::hive::HiveConnectorFactory::kHiveConnectorName)
           ->newConnector(
-              kHiveConnectorId, std::make_shared<core::MemConfig>(hiveConfig));
+              kHiveConnectorId,
+              std::make_shared<config::ConfigBase>(std::move(hiveConfig)));
   connector::registerConnector(hiveConnector);
 
   seed(initialSeed);

--- a/velox/exec/fuzzer/WriterFuzzerRunner.h
+++ b/velox/exec/fuzzer/WriterFuzzerRunner.h
@@ -75,7 +75,9 @@ class WriterFuzzerRunner {
         connector::getConnectorFactory(
             connector::hive::HiveConnectorFactory::kHiveConnectorName)
             ->newConnector(
-                kHiveConnectorId, std::make_shared<core::MemConfig>());
+                kHiveConnectorId,
+                std::make_shared<config::ConfigBase>(
+                    std::unordered_map<std::string, std::string>()));
     connector::registerConnector(hiveConnector);
     facebook::velox::exec::test::writerFuzzer(
         seed, std::move(referenceQueryRunner));

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -2387,8 +2387,8 @@ TEST_P(UnpartitionedTableWriterTest, immutableSettings) {
     std::unordered_map<std::string, std::string> propFromFile{
         {"hive.immutable-partitions",
          testData.immutablePartitionsEnabled ? "true" : "false"}};
-    std::shared_ptr<const Config> config{
-        std::make_shared<core::MemConfig>(propFromFile)};
+    std::shared_ptr<const config::ConfigBase> config{
+        std::make_shared<config::ConfigBase>(std::move(propFromFile))};
     resetHiveConnector(config);
 
     auto input = makeVectors(10, 10);

--- a/velox/exec/tests/VeloxIn10MinDemo.cpp
+++ b/velox/exec/tests/VeloxIn10MinDemo.cpp
@@ -52,7 +52,9 @@ class VeloxIn10MinDemo : public VectorTestBase {
         connector::getConnectorFactory(
             connector::tpch::TpchConnectorFactory::kTpchConnectorName)
             ->newConnector(
-                kTpchConnectorId, std::make_shared<core::MemConfig>());
+                kTpchConnectorId,
+                std::make_shared<config::ConfigBase>(
+                    std::unordered_map<std::string, std::string>()));
     connector::registerConnector(tpchConnector);
   }
 

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -36,7 +36,8 @@ void HiveConnectorTestBase::SetUp() {
           connector::hive::HiveConnectorFactory::kHiveConnectorName)
           ->newConnector(
               kHiveConnectorId,
-              std::make_shared<core::MemConfig>(),
+              std::make_shared<config::ConfigBase>(
+                  std::unordered_map<std::string, std::string>()),
               ioExecutor_.get());
   connector::registerConnector(hiveConnector);
 }
@@ -50,7 +51,7 @@ void HiveConnectorTestBase::TearDown() {
 }
 
 void HiveConnectorTestBase::resetHiveConnector(
-    const std::shared_ptr<const Config>& config) {
+    const std::shared_ptr<const config::ConfigBase>& config) {
   connector::unregisterConnector(kHiveConnectorId);
   auto hiveConnector =
       connector::getConnectorFactory(

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -40,7 +40,8 @@ class HiveConnectorTestBase : public OperatorTestBase {
   void SetUp() override;
   void TearDown() override;
 
-  void resetHiveConnector(const std::shared_ptr<const Config>& config);
+  void resetHiveConnector(
+      const std::shared_ptr<const config::ConfigBase>& config);
 
   void writeToFile(const std::string& filePath, RowVectorPtr vector);
 

--- a/velox/experimental/wave/exec/WaveHiveDataSource.cpp
+++ b/velox/experimental/wave/exec/WaveHiveDataSource.cpp
@@ -160,7 +160,8 @@ void WaveHiveDataSource::registerConnector() {
     return;
   }
   registered = true;
-  auto config = std::make_shared<const core::MemConfig>();
+  auto config = std::make_shared<const config::ConfigBase>(
+      std::unordered_map<std::string, std::string>());
 
   // Create hive connector with config...
   auto hiveConnector =

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -844,10 +844,6 @@ TEST_F(CastExprTest, timestampAdjustToTimezone) {
       });
 }
 
-TEST_F(CastExprTest, timestampAdjustToTimezoneInvalid) {
-  VELOX_ASSERT_USER_THROW(setTimezone("bla"), "Unknown time zone: 'bla'");
-}
-
 TEST_F(CastExprTest, date) {
   testCast<std::string, int32_t>(
       "date",

--- a/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
@@ -70,7 +70,10 @@ void AggregationTestBase::SetUp() {
   auto hiveConnector =
       connector::getConnectorFactory(
           connector::hive::HiveConnectorFactory::kHiveConnectorName)
-          ->newConnector(kHiveConnectorId, std::make_shared<core::MemConfig>());
+          ->newConnector(
+              kHiveConnectorId,
+              std::make_shared<config::ConfigBase>(
+                  std::unordered_map<std::string, std::string>()));
   connector::registerConnector(hiveConnector);
 }
 


### PR DESCRIPTION
As part of the consolidating and polishing config effort, all configs should now utilize common/config/Config.h as it provides richer functionality. Deprecate the old one to make the codebase clean