### PR TITLE
Add to support byte input stream back by file

### DIFF
--- a/velox/common/base/SpillStats.cpp
+++ b/velox/common/base/SpillStats.cpp
@@ -299,10 +299,11 @@ void updateGlobalSpillWriteStats(
 }
 
 void updateGlobalSpillReadStats(
+    uint64_t spillReads,
     uint64_t spillReadBytes,
     uint64_t spillRadTimeUs) {
   auto statsLocked = localSpillStats().wlock();
-  ++statsLocked->spillReads;
+  statsLocked->spillReads += spillReads;
   statsLocked->spillReadBytes += spillReadBytes;
   statsLocked->spillReadTimeUs += spillRadTimeUs;
 }

--- a/velox/common/base/SpillStats.h
+++ b/velox/common/base/SpillStats.h
@@ -142,6 +142,7 @@ void updateGlobalSpillWriteStats(
 /// Updates the stats for disk read including the number of disk reads, the
 /// amount of data read in bytes, and the time it takes to read from the disk.
 void updateGlobalSpillReadStats(
+    uint64_t spillReads,
     uint64_t spillReadBytes,
     uint64_t spillRadTimeUs);
 

--- a/velox/common/file/CMakeLists.txt
+++ b/velox/common/file/CMakeLists.txt
@@ -14,11 +14,16 @@
 
 # for generated headers
 include_directories(.)
-velox_add_library(velox_file File.cpp FileSystems.cpp Utils.cpp)
+velox_add_library(
+  velox_file
+  File.cpp
+  FileInputStream.cpp
+  FileSystems.cpp
+  Utils.cpp)
 velox_link_libraries(
   velox_file
   PUBLIC velox_exception Folly::folly
-  PRIVATE velox_common_base fmt::fmt glog::glog)
+  PRIVATE velox_buffer velox_common_base fmt::fmt glog::glog)
 
 if(${VELOX_BUILD_TESTING} OR ${VELOX_BUILD_TEST_UTILS})
   add_subdirectory(tests)

--- a/velox/common/file/FileInputStream.cpp
+++ b/velox/common/file/FileInputStream.cpp
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/file/FileInputStream.h"
+
+namespace facebook::velox::common {
+
+FileInputStream::FileInputStream(
+    std::unique_ptr<ReadFile>&& file,
+    uint64_t bufferSize,
+    memory::MemoryPool* pool)
+    : file_(std::move(file)),
+      fileSize_(file_->size()),
+      bufferSize_(std::min(fileSize_, bufferSize)),
+      pool_(pool),
+      readAheadEnabled_((bufferSize_ < fileSize_) && file_->hasPreadvAsync()) {
+  VELOX_CHECK_NOT_NULL(pool_);
+  VELOX_CHECK_GT(fileSize_, 0, "Empty FileInputStream");
+
+  buffers_.push_back(AlignedBuffer::allocate<char>(bufferSize_, pool_));
+  if (readAheadEnabled_) {
+    buffers_.push_back(AlignedBuffer::allocate<char>(bufferSize_, pool_));
+  }
+  readNextRange();
+}
+
+FileInputStream::~FileInputStream() {
+  if (!readAheadWait_.valid()) {
+    return;
+  }
+  try {
+    readAheadWait_.wait();
+  } catch (const std::exception& ex) {
+    // ignore any prefetch error when query has failed.
+    LOG(WARNING) << "FileInputStream read-ahead failed on destruction "
+                 << ex.what();
+  }
+}
+
+void FileInputStream::readNextRange() {
+  VELOX_CHECK(current_ == nullptr || current_->availableBytes() == 0);
+  ranges_.clear();
+  current_ = nullptr;
+
+  int32_t readBytes{0};
+  uint64_t readTimeUs{0};
+  {
+    MicrosecondTimer timer{&readTimeUs};
+    if (readAheadWait_.valid()) {
+      readBytes = std::move(readAheadWait_)
+                      .via(&folly::QueuedImmediateExecutor::instance())
+                      .wait()
+                      .value();
+      VELOX_CHECK(!readAheadWait_.valid());
+      VELOX_CHECK_LT(
+          0, readBytes, "Read past end of FileInputStream {}", fileSize_);
+      advanceBuffer();
+    } else {
+      readBytes = readSize();
+      VELOX_CHECK_LT(
+          0, readBytes, "Read past end of FileInputStream {}", fileSize_);
+      MicrosecondTimer timer{&readTimeUs};
+      file_->pread(fileOffset_, readBytes, buffer()->asMutable<char>());
+    }
+  }
+
+  ranges_.resize(1);
+  ranges_[0] = {buffer()->asMutable<uint8_t>(), readBytes, 0};
+  current_ = ranges_.data();
+  fileOffset_ += readBytes;
+
+  updateStats(readBytes, readTimeUs);
+
+  maybeIssueReadahead();
+}
+
+size_t FileInputStream::size() const {
+  return fileSize_;
+}
+
+bool FileInputStream::atEnd() const {
+  return tellp() >= fileSize_;
+}
+
+std::streampos FileInputStream::tellp() const {
+  if (current_ == nullptr) {
+    VELOX_CHECK_EQ(fileOffset_, fileSize_);
+    return fileOffset_;
+  }
+  return fileOffset_ - current_->availableBytes();
+}
+
+void FileInputStream::seekp(std::streampos position) {
+  static_assert(sizeof(std::streamsize) <= sizeof(int64_t));
+  const int64_t seekPos = position;
+  const int64_t curPos = tellp();
+  VELOX_CHECK_GE(
+      seekPos, curPos, "Backward seek is not supported by FileInputStream");
+
+  const int64_t toSkip = seekPos - curPos;
+  if (toSkip == 0) {
+    return;
+  }
+  doSeek(toSkip);
+}
+
+void FileInputStream::skip(int32_t size) {
+  doSeek(size);
+}
+
+void FileInputStream::doSeek(int64_t skipBytes) {
+  VELOX_CHECK_GE(skipBytes, 0, "Attempting to skip negative number of bytes");
+  if (skipBytes == 0) {
+    return;
+  }
+
+  VELOX_CHECK_LE(
+      skipBytes,
+      remainingSize(),
+      "Skip past the end of FileInputStream: {}",
+      fileSize_);
+
+  for (;;) {
+    const int64_t skippedBytes =
+        std::min<int64_t>(current_->availableBytes(), skipBytes);
+    skipBytes -= skippedBytes;
+    current_->position += skippedBytes;
+    if (skipBytes == 0) {
+      return;
+    }
+    readNextRange();
+  }
+}
+
+size_t FileInputStream::remainingSize() const {
+  return fileSize_ - tellp();
+}
+
+uint8_t FileInputStream::readByte() {
+  VELOX_CHECK_GT(
+      remainingSize(), 0, "Read past the end of input file {}", fileSize_);
+
+  if (current_->availableBytes() > 0) {
+    return current_->buffer[current_->position++];
+  }
+  readNextRange();
+  return readByte();
+}
+
+void FileInputStream::readBytes(uint8_t* bytes, int32_t size) {
+  VELOX_CHECK_GE(size, 0, "Attempting to read negative number of bytes");
+  if (size == 0) {
+    return;
+  }
+
+  VELOX_CHECK_LE(
+      size, remainingSize(), "Read past the end of input file {}", fileSize_);
+
+  int32_t offset{0};
+  for (;;) {
+    const int32_t readBytes =
+        std::min<int64_t>(current_->availableBytes(), size);
+    simd::memcpy(
+        bytes + offset, current_->buffer + current_->position, readBytes);
+    offset += readBytes;
+    size -= readBytes;
+    current_->position += readBytes;
+    if (size == 0) {
+      return;
+    }
+    readNextRange();
+  }
+}
+
+std::string_view FileInputStream::nextView(int32_t size) {
+  VELOX_CHECK_GE(size, 0, "Attempting to view negative number of bytes");
+  if (remainingSize() == 0) {
+    return std::string_view(nullptr, 0);
+  }
+
+  if (current_->availableBytes() == 0) {
+    readNextRange();
+  }
+
+  VELOX_CHECK_GT(current_->availableBytes(), 0);
+  const auto position = current_->position;
+  const auto viewSize = std::min<int64_t>(current_->availableBytes(), size);
+  current_->position += viewSize;
+  return std::string_view(
+      reinterpret_cast<char*>(current_->buffer) + position, viewSize);
+}
+
+uint64_t FileInputStream::readSize() const {
+  return std::min(fileSize_ - fileOffset_, bufferSize_);
+}
+
+void FileInputStream::maybeIssueReadahead() {
+  VELOX_CHECK(!readAheadWait_.valid());
+  if (!readAheadEnabled_) {
+    return;
+  }
+  const auto size = readSize();
+  if (size == 0) {
+    return;
+  }
+  std::vector<folly::Range<char*>> ranges;
+  ranges.emplace_back(nextBuffer()->asMutable<char>(), size);
+  readAheadWait_ = file_->preadvAsync(fileOffset_, ranges);
+  VELOX_CHECK(readAheadWait_.valid());
+}
+
+void FileInputStream::updateStats(uint64_t readBytes, uint64_t readTimeUs) {
+  stats_.readBytes += readBytes;
+  stats_.readTimeUs += readTimeUs;
+  ++stats_.numReads;
+}
+
+std::string FileInputStream::toString() const {
+  return fmt::format(
+      "file (offset {}/size {}) current (position {}/ size {})",
+      succinctBytes(fileOffset_),
+      succinctBytes(fileSize_),
+      current_ == nullptr ? "NULL" : succinctBytes(current_->position),
+      current_ == nullptr ? "NULL" : succinctBytes(current_->size));
+}
+
+FileInputStream::Stats FileInputStream::stats() const {
+  return stats_;
+}
+
+bool FileInputStream::Stats::operator==(
+    const FileInputStream::Stats& other) const {
+  return std::tie(numReads, readBytes, readTimeUs) ==
+      std::tie(other.numReads, other.readBytes, other.readTimeUs);
+}
+
+std::string FileInputStream::Stats::toString() const {
+  return fmt::format(
+      "numReads: {}, readBytes: {}, readTimeUs: {}",
+      numReads,
+      succinctBytes(readBytes),
+      succinctMicros(readTimeUs));
+}
+} // namespace facebook::velox::common

--- a/velox/common/file/FileInputStream.h
+++ b/velox/common/file/FileInputStream.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#include "velox/buffer/Buffer.h"
+#include "velox/common/file/File.h"
+#include "velox/common/memory/ByteStream.h"
+
+namespace facebook::velox::common {
+
+#ifndef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+/// Readonly byte input stream backed by file.
+class FileInputStream : public ByteInputStream {
+ public:
+  FileInputStream(
+      std::unique_ptr<ReadFile>&& file,
+      uint64_t bufferSize,
+      memory::MemoryPool* pool);
+
+  ~FileInputStream() override;
+
+  FileInputStream(const FileInputStream&) = delete;
+  FileInputStream& operator=(const FileInputStream& other) = delete;
+  FileInputStream(FileInputStream&& other) noexcept = delete;
+  FileInputStream& operator=(FileInputStream&& other) noexcept = delete;
+
+  size_t size() const override;
+
+  bool atEnd() const override;
+
+  std::streampos tellp() const override;
+
+  void seekp(std::streampos pos) override;
+
+  void skip(int32_t size) override;
+
+  size_t remainingSize() const override;
+
+  uint8_t readByte() override;
+
+  void readBytes(uint8_t* bytes, int32_t size) override;
+
+  std::string_view nextView(int32_t size) override;
+
+  std::string toString() const override;
+
+  /// Records the file read stats.
+  struct Stats {
+    uint32_t numReads{0};
+    uint64_t readBytes{0};
+    uint64_t readTimeUs{0};
+
+    bool operator==(const Stats& other) const;
+
+    std::string toString() const;
+  };
+  Stats stats() const;
+
+ private:
+  void doSeek(int64_t skipBytes);
+
+  // Invoked to read the next byte range from the file in a buffer.
+  void readNextRange();
+
+  // Issues readahead if underlying file system supports async mode read.
+  //
+  // TODO: we might consider to use AsyncSource to support read-ahead on
+  // filesystem which doesn't support async mode read.
+  void maybeIssueReadahead();
+
+  inline uint64_t readSize() const;
+
+  inline uint32_t bufferIndex() const {
+    return bufferIndex_;
+  }
+
+  inline uint32_t nextBufferIndex() const {
+    return (bufferIndex_ + 1) % buffers_.size();
+  }
+
+  // Advances buffer index to point to the next buffer for read.
+  inline void advanceBuffer() {
+    bufferIndex_ = nextBufferIndex();
+  }
+
+  inline Buffer* buffer() const {
+    return buffers_[bufferIndex()].get();
+  }
+
+  inline Buffer* nextBuffer() const {
+    return buffers_[nextBufferIndex()].get();
+  }
+
+  void updateStats(uint64_t readBytes, uint64_t readTimeUs);
+
+  const std::unique_ptr<ReadFile> file_;
+  const uint64_t fileSize_;
+  const uint64_t bufferSize_;
+  memory::MemoryPool* const pool_;
+  const bool readAheadEnabled_;
+
+  // Offset of the next byte to read from file.
+  uint64_t fileOffset_ = 0;
+
+  std::vector<BufferPtr> buffers_;
+  uint32_t bufferIndex_{0};
+  // Sets to read-ahead future if valid.
+  folly::SemiFuture<uint64_t> readAheadWait_{
+      folly::SemiFuture<uint64_t>::makeEmpty()};
+
+  Stats stats_;
+};
+#endif
+} // namespace facebook::velox::common

--- a/velox/common/file/Utils.cpp
+++ b/velox/common/file/Utils.cpp
@@ -34,5 +34,4 @@ bool CoalesceIfDistanceLE::operator()(
   }
   return shouldCoalesce;
 }
-
 } // namespace facebook::velox::file::utils

--- a/velox/common/file/Utils.h
+++ b/velox/common/file/Utils.h
@@ -165,5 +165,4 @@ class ReadToIOBufs {
   OutputIter output_;
   Reader reader_;
 };
-
 } // namespace facebook::velox::file::utils

--- a/velox/common/file/tests/CMakeLists.txt
+++ b/velox/common/file/tests/CMakeLists.txt
@@ -19,11 +19,13 @@ target_link_libraries(
   velox_file_test_utils
   PUBLIC velox_file)
 
-add_executable(velox_file_test FileTest.cpp UtilsTest.cpp)
+add_executable(velox_file_test FileTest.cpp FileInputStreamTest.cpp
+                               UtilsTest.cpp)
 add_test(velox_file_test velox_file_test)
 target_link_libraries(
   velox_file_test
   PRIVATE
+    velox_buffer
     velox_file
     velox_file_test_utils
     velox_temp_path

--- a/velox/common/file/tests/FileInputStreamTest.cpp
+++ b/velox/common/file/tests/FileInputStreamTest.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/memory/ByteStream.h"
+
+#include "velox/common/base/BitUtil.h"
+#include "velox/common/file/FileInputStream.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/common/memory/MmapAllocator.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+
+#include <gflags/gflags.h>
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+using namespace facebook::velox::memory;
+
+class FileInputStreamTest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    filesystems::registerLocalFileSystem();
+  }
+
+  void SetUp() override {
+    constexpr uint64_t kMaxMappedMemory = 64 << 20;
+    MemoryManagerOptions options;
+    options.useMmapAllocator = true;
+    options.allocatorCapacity = kMaxMappedMemory;
+    options.arbitratorCapacity = kMaxMappedMemory;
+    options.arbitratorReservedCapacity = 0;
+    memoryManager_ = std::make_unique<MemoryManager>(options);
+    mmapAllocator_ = static_cast<MmapAllocator*>(memoryManager_->allocator());
+    pool_ = memoryManager_->addLeafPool("ByteStreamTest");
+    rng_.seed(124);
+    tempDirPath_ = exec::test::TempDirectoryPath::create();
+    fs_ = filesystems::getFileSystem(tempDirPath_->getPath(), nullptr);
+  }
+
+  void TearDown() override {}
+
+  std::unique_ptr<common::FileInputStream> createStream(
+      uint64_t streamSize,
+      uint32_t bufferSize = 1024) {
+    const auto filePath =
+        fmt::format("{}/{}", tempDirPath_->getPath(), fileId_++);
+    auto writeFile = fs_->openFileForWrite(filePath);
+    std::uint8_t buffer[streamSize];
+    for (int i = 0; i < streamSize; ++i) {
+      buffer[i] = i % 256;
+    }
+    writeFile->append(
+        std::string_view(reinterpret_cast<char*>(buffer), streamSize));
+    writeFile->close();
+    return std::make_unique<common::FileInputStream>(
+        fs_->openFileForRead(filePath), bufferSize, pool_.get());
+  }
+
+  folly::Random::DefaultGenerator rng_;
+  std::unique_ptr<MemoryManager> memoryManager_;
+  MmapAllocator* mmapAllocator_;
+  std::shared_ptr<memory::MemoryPool> pool_;
+  std::atomic_uint64_t fileId_{0};
+  std::shared_ptr<exec::test::TempDirectoryPath> tempDirPath_;
+  std::shared_ptr<filesystems::FileSystem> fs_;
+};
+
+TEST_F(FileInputStreamTest, stats) {
+  struct {
+    size_t streamSize;
+    size_t bufferSize;
+
+    std::string debugString() const {
+      return fmt::format(
+          "streamSize {}, bufferSize {}", streamSize, bufferSize);
+    }
+  } testSettings[] = {
+      {4096, 1024}, {4096, 4096}, {4096, 8192}, {4096, 4096 + 1024}};
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+
+    auto byteStream = createStream(testData.streamSize, testData.bufferSize);
+    ASSERT_EQ(byteStream->stats().numReads, 1);
+    ASSERT_EQ(
+        byteStream->stats().readBytes,
+        std::min(testData.streamSize, testData.bufferSize));
+    ASSERT_GT(byteStream->stats().readTimeUs, 0);
+    uint8_t buffer[testData.streamSize / 8];
+    for (int offset = 0; offset < testData.streamSize;) {
+      byteStream->readBytes(buffer, testData.streamSize / 8);
+      for (int i = 0; i < testData.streamSize / 8; ++i, ++offset) {
+        ASSERT_EQ(buffer[i], offset % 256);
+      }
+    }
+    ASSERT_TRUE(byteStream->atEnd());
+    ASSERT_EQ(
+        byteStream->stats().numReads,
+        bits::roundUp(testData.streamSize, testData.bufferSize) /
+            testData.bufferSize);
+    ASSERT_EQ(byteStream->stats().readBytes, testData.streamSize);
+    ASSERT_GT(byteStream->stats().readTimeUs, 0);
+  }
+}

--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -166,7 +166,7 @@ void HashStringAllocator::freeToPool(void* ptr, size_t size) {
 }
 
 // static
-ByteInputStream HashStringAllocator::prepareRead(
+std::unique_ptr<ByteInputStream> HashStringAllocator::prepareRead(
     const Header* begin,
     size_t maxBytes) {
   std::vector<ByteRange> ranges;
@@ -187,7 +187,7 @@ ByteInputStream HashStringAllocator::prepareRead(
 
     header = header->nextContinued();
   }
-  return ByteInputStream(std::move(ranges));
+  return std::make_unique<BufferInputStream>(std::move(ranges));
 }
 
 HashStringAllocator::Position HashStringAllocator::newWrite(
@@ -365,7 +365,7 @@ StringView HashStringAllocator::contiguousString(
 
   auto stream = prepareRead(headerOf(view.data()));
   storage.resize(view.size());
-  stream.readBytes(storage.data(), view.size());
+  stream->readBytes(storage.data(), view.size());
   return StringView(storage);
 }
 

--- a/velox/common/memory/HashStringAllocator.h
+++ b/velox/common/memory/HashStringAllocator.h
@@ -237,7 +237,7 @@ class HashStringAllocator : public StreamArena {
   /// possible continuation ranges.
   /// @param maxBytes If provided, the returned stream will cover at most that
   /// many bytes.
-  static ByteInputStream prepareRead(
+  static std::unique_ptr<ByteInputStream> prepareRead(
       const Header* header,
       size_t maxBytes = std::numeric_limits<size_t>::max());
 

--- a/velox/common/memory/tests/HashStringAllocatorTest.cpp
+++ b/velox/common/memory/tests/HashStringAllocatorTest.cpp
@@ -258,11 +258,11 @@ TEST_F(HashStringAllocatorTest, finishWrite) {
 
   std::string copy;
   copy.resize(longString.size());
-  inputStream.readBytes(copy.data(), copy.size());
+  inputStream->readBytes(copy.data(), copy.size());
   ASSERT_EQ(copy, longString);
 
   copy.resize(4);
-  inputStream.readBytes(copy.data(), 4);
+  inputStream->readBytes(copy.data(), 4);
   ASSERT_EQ(copy, "abcd");
 
   auto allocatedBytes = allocator_->checkConsistency();
@@ -280,7 +280,7 @@ TEST_F(HashStringAllocatorTest, finishWrite) {
     auto inStream = HSA::prepareRead(start.header);
     std::string copy;
     copy.resize(largeString.size());
-    inStream.readBytes(copy.data(), copy.size());
+    inStream->readBytes(copy.data(), copy.size());
     ASSERT_EQ(copy, largeString);
     allocatedBytes = allocator_->checkConsistency();
     ASSERT_EQ(allocatedBytes, allocator_->currentBytes());
@@ -397,9 +397,9 @@ TEST_F(HashStringAllocatorTest, rewrite) {
     position = allocator_->finishWrite(stream, 0).second;
     EXPECT_EQ(3 * sizeof(int64_t), HSA::offset(header, position));
     auto inStream = HSA::prepareRead(header);
-    EXPECT_EQ(123456789012345LL, inStream.read<int64_t>());
-    EXPECT_EQ(12345LL, inStream.read<int64_t>());
-    EXPECT_EQ(67890LL, inStream.read<int64_t>());
+    EXPECT_EQ(123456789012345LL, inStream->read<int64_t>());
+    EXPECT_EQ(12345LL, inStream->read<int64_t>());
+    EXPECT_EQ(67890LL, inStream->read<int64_t>());
   }
   // The stream contains 3 int64_t's.
   auto end = HSA::seek(header, 3 * sizeof(int64_t));
@@ -694,20 +694,20 @@ TEST_F(HashStringAllocatorTest, sizeAndPosition) {
     stream.seekp(start);
     EXPECT_EQ(start, stream.tellp());
     EXPECT_EQ(kUnitSize * 10, stream.size());
-    ByteInputStream input = stream.inputStream();
-    input.seekp(start);
-    EXPECT_EQ(kUnitSize * 10 - start, input.remainingSize());
+    auto input = stream.inputStream();
+    input->seekp(start);
+    EXPECT_EQ(kUnitSize * 10 - start, input->remainingSize());
     for (auto c = 0; c < 10; ++c) {
-      uint8_t byte = input.readByte();
+      uint8_t byte = input->readByte();
       EXPECT_EQ(byte, (start + c) % kUnitSize);
     }
     // Overwrite the bytes just read.
     stream.seekp(start);
     stream.appendStringView(std::string_view(allChars.data(), 100));
     input = stream.inputStream();
-    input.seekp(start);
+    input->seekp(start);
     for (auto c = 0; c < 100; ++c) {
-      uint8_t byte = input.readByte();
+      uint8_t byte = input->readByte();
       EXPECT_EQ(byte, c % kUnitSize);
     }
   }

--- a/velox/exec/AddressableNonNullValueList.cpp
+++ b/velox/exec/AddressableNonNullValueList.cpp
@@ -84,12 +84,13 @@ HashStringAllocator::Position AddressableNonNullValueList::appendSerialized(
 
 namespace {
 
-ByteInputStream prepareRead(const AddressableNonNullValueList::Entry& entry) {
+std::unique_ptr<ByteInputStream> prepareRead(
+    const AddressableNonNullValueList::Entry& entry) {
   auto header = entry.offset.header;
   auto seek = entry.offset.position - header->begin();
 
   auto stream = HashStringAllocator::prepareRead(header, entry.size + seek);
-  stream.seekp(seek);
+  stream->seekp(seek);
   return stream;
 }
 } // namespace
@@ -109,7 +110,7 @@ bool AddressableNonNullValueList::equalTo(
   CompareFlags compareFlags =
       CompareFlags::equality(CompareFlags::NullHandlingMode::kNullAsValue);
   return exec::ContainerRowSerde::compare(
-             leftStream, rightStream, type.get(), compareFlags) == 0;
+             *leftStream, *rightStream, type.get(), compareFlags) == 0;
 }
 
 // static
@@ -118,7 +119,7 @@ void AddressableNonNullValueList::read(
     BaseVector& result,
     vector_size_t index) {
   auto stream = prepareRead(position);
-  exec::ContainerRowSerde::deserialize(stream, index, &result);
+  exec::ContainerRowSerde::deserialize(*stream, index, &result);
 }
 
 // static
@@ -126,7 +127,7 @@ void AddressableNonNullValueList::readSerialized(
     const Entry& position,
     char* dest) {
   auto stream = prepareRead(position);
-  stream.readBytes(dest, position.size);
+  stream->readBytes(dest, position.size);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -121,9 +121,14 @@ RowVectorPtr Exchange::getOutput() {
 
     auto inputStream = page->prepareStreamForDeserialize();
 
-    while (!inputStream.atEnd()) {
+    while (!inputStream->atEnd()) {
       getSerde()->deserialize(
-          &inputStream, pool(), outputType_, &result_, resultOffset, &options_);
+          inputStream.get(),
+          pool(),
+          outputType_,
+          &result_,
+          resultOffset,
+          &options_);
       resultOffset = result_->size();
     }
   }

--- a/velox/exec/ExchangeQueue.cpp
+++ b/velox/exec/ExchangeQueue.cpp
@@ -41,9 +41,15 @@ SerializedPage::~SerializedPage() {
   }
 }
 
+#ifndef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+std::unique_ptr<ByteInputStream> SerializedPage::prepareStreamForDeserialize() {
+  return std::make_unique<BufferInputStream>(std::move(ranges_));
+}
+#else
 ByteInputStream SerializedPage::prepareStreamForDeserialize() {
   return ByteInputStream(std::move(ranges_));
 }
+#endif
 
 void ExchangeQueue::noMoreSources() {
   std::vector<ContinuePromise> promises;

--- a/velox/exec/ExchangeQueue.h
+++ b/velox/exec/ExchangeQueue.h
@@ -19,11 +19,11 @@
 
 namespace facebook::velox::exec {
 
-// Corresponds to Presto SerializedPage, i.e. a container for
-// serialize vectors in Presto wire format.
+/// Corresponds to Presto SerializedPage, i.e. a container for serialize vectors
+/// in Presto wire format.
 class SerializedPage {
  public:
-  // Construct from IOBuf chain.
+  /// Construct from IOBuf chain.
   explicit SerializedPage(
       std::unique_ptr<folly::IOBuf> iobuf,
       std::function<void(folly::IOBuf&)> onDestructionCb = nullptr,
@@ -31,7 +31,7 @@ class SerializedPage {
 
   ~SerializedPage();
 
-  // Returns the size of the serialized data in bytes.
+  /// Returns the size of the serialized data in bytes.
   uint64_t size() const {
     return iobufBytes_;
   }
@@ -40,9 +40,13 @@ class SerializedPage {
     return numRows_;
   }
 
-  // Makes 'input' ready for deserializing 'this' with
-  // VectorStreamGroup::read().
+#ifndef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  /// Makes 'input' ready for deserializing 'this' with
+  /// VectorStreamGroup::read().
+  std::unique_ptr<ByteInputStream> prepareStreamForDeserialize();
+#else
   ByteInputStream prepareStreamForDeserialize();
+#endif
 
   std::unique_ptr<folly::IOBuf> getIOBuf() const {
     return iobuf_->clone();

--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -153,14 +153,14 @@ class MergeExchangeSource : public MergeSource {
         return BlockingReason::kWaitForProducer;
       }
     }
-    if (!inputStream_.has_value()) {
+    if (inputStream_ == nullptr) {
       mergeExchange_->stats().wlock()->rawInputBytes += currentPage_->size();
-      inputStream_.emplace(currentPage_->prepareStreamForDeserialize());
+      inputStream_ = currentPage_->prepareStreamForDeserialize();
     }
 
     if (!inputStream_->atEnd()) {
       VectorStreamGroup::read(
-          &inputStream_.value(),
+          inputStream_.get(),
           mergeExchange_->pool(),
           mergeExchange_->outputType(),
           &data);
@@ -191,7 +191,7 @@ class MergeExchangeSource : public MergeSource {
  private:
   MergeExchange* const mergeExchange_;
   std::shared_ptr<ExchangeClient> client_;
-  std::optional<ByteInputStream> inputStream_;
+  std::unique_ptr<ByteInputStream> inputStream_;
   std::unique_ptr<SerializedPage> currentPage_;
   bool atEnd_ = false;
 

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -537,7 +537,9 @@ void RowContainer::store(
   }
 }
 
-ByteInputStream RowContainer::prepareRead(const char* row, int32_t offset) {
+std::unique_ptr<ByteInputStream> RowContainer::prepareRead(
+    const char* row,
+    int32_t offset) {
   const auto& view = reinterpret_cast<const std::string_view*>(row + offset);
   // We set 'stream' to range over the ranges that start at the Header
   // immediately below the first character in the std::string_view.
@@ -591,7 +593,7 @@ int32_t RowContainer::extractVariableSizeAt(
     } else {
       auto stream = HashStringAllocator::prepareRead(
           HashStringAllocator::headerOf(value.data()));
-      stream.readBytes(output + 4, size);
+      stream->readBytes(output + 4, size);
     }
     return 4 + size;
   }
@@ -602,7 +604,7 @@ int32_t RowContainer::extractVariableSizeAt(
   auto stream = prepareRead(row, rowColumn.offset());
 
   ::memcpy(output, &size, 4);
-  stream.readBytes(output + 4, size);
+  stream->readBytes(output + 4, size);
 
   return 4 + size;
 }
@@ -750,7 +752,7 @@ void RowContainer::extractString(
   auto rawBuffer = values->getRawStringBufferWithSpace(value.size());
   auto stream = HashStringAllocator::prepareRead(
       HashStringAllocator::headerOf(value.data()));
-  stream.readBytes(rawBuffer, value.size());
+  stream->readBytes(rawBuffer, value.size());
   values->setNoCopy(index, StringView(rawBuffer, value.size()));
 }
 
@@ -799,7 +801,7 @@ int RowContainer::compareComplexType(
   VELOX_DCHECK(flags.nullAsValue(), "not supported null handling mode");
 
   auto stream = prepareRead(row, offset);
-  return ContainerRowSerde::compare(stream, decoded, index, flags);
+  return ContainerRowSerde::compare(*stream, decoded, index, flags);
 }
 
 int32_t RowContainer::compareStringAsc(StringView left, StringView right) {
@@ -820,7 +822,7 @@ int32_t RowContainer::compareComplexType(
 
   auto leftStream = prepareRead(left, leftOffset);
   auto rightStream = prepareRead(right, rightOffset);
-  return ContainerRowSerde::compare(leftStream, rightStream, type, flags);
+  return ContainerRowSerde::compare(*leftStream, *rightStream, type, flags);
 }
 
 int32_t RowContainer::compareComplexType(
@@ -860,7 +862,7 @@ void RowContainer::hashTyped(
           Kind == TypeKind::ROW || Kind == TypeKind::ARRAY ||
           Kind == TypeKind::MAP) {
         auto in = prepareRead(row, offset);
-        hash = ContainerRowSerde::hash(in, type);
+        hash = ContainerRowSerde::hash(*in, type);
       } else if constexpr (std::is_floating_point_v<T>) {
         hash = util::floating_point::NaNAwareHash<T>()(valueAt<T>(row, offset));
       } else {

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -986,7 +986,9 @@ class RowContainer {
     }
   }
 
-  static ByteInputStream prepareRead(const char* row, int32_t offset);
+  static std::unique_ptr<ByteInputStream> prepareRead(
+      const char* row,
+      int32_t offset);
 
   template <TypeKind Kind>
   void hashTyped(
@@ -1153,7 +1155,7 @@ class RowContainer {
         result->setNull(resultIndex, true);
       } else {
         auto stream = prepareRead(row, offset);
-        ContainerRowSerde::deserialize(stream, resultIndex, result.get());
+        ContainerRowSerde::deserialize(*stream, resultIndex, result.get());
       }
     }
   }

--- a/velox/exec/SortedAggregations.cpp
+++ b/velox/exec/SortedAggregations.cpp
@@ -54,7 +54,7 @@ struct RowPointers {
     auto stream = HashStringAllocator::prepareRead(firstBlock);
 
     for (auto i = 0; i < size; ++i) {
-      rows[i] = reinterpret_cast<char*>(stream.read<uintptr_t>());
+      rows[i] = reinterpret_cast<char*>(stream->read<uintptr_t>());
     }
   }
 };

--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -59,13 +59,13 @@ void writeToFile(
   writer->close();
 }
 
-ByteInputStream toByteStream(const std::string& input) {
+std::unique_ptr<ByteInputStream> toByteStream(const std::string& input) {
   std::vector<ByteRange> ranges;
   ranges.push_back(
       {reinterpret_cast<uint8_t*>(const_cast<char*>(input.data())),
        (int32_t)input.length(),
        0});
-  return ByteInputStream(std::move(ranges));
+  return std::make_unique<BufferInputStream>(std::move(ranges));
 }
 
 RowVectorPtr deserialize(
@@ -75,7 +75,7 @@ RowVectorPtr deserialize(
   auto byteStream = toByteStream(input);
   auto serde = std::make_unique<serializer::presto::PrestoVectorSerde>();
   RowVectorPtr result;
-  serde->deserialize(&byteStream, pool, rowType, &result, nullptr);
+  serde->deserialize(byteStream.get(), pool, rowType, &result, nullptr);
   return result;
 }
 

--- a/velox/exec/tests/ContainerRowSerdeTest.cpp
+++ b/velox/exec/tests/ContainerRowSerdeTest.cpp
@@ -82,7 +82,7 @@ class ContainerRowSerdeTest : public testing::Test,
 
     auto in = HashStringAllocator::prepareRead(position.header);
     for (auto i = 0; i < numRows; ++i) {
-      ContainerRowSerde::deserialize(in, i, data.get());
+      ContainerRowSerde::deserialize(*in, i, data.get());
     }
     return data;
   }
@@ -117,13 +117,13 @@ class ContainerRowSerdeTest : public testing::Test,
           !equalsOnly) {
         VELOX_ASSERT_THROW(
             ContainerRowSerde::compareWithNulls(
-                stream, decodedVector, i, compareFlags),
+                *stream, decodedVector, i, compareFlags),
             "Ordering nulls is not supported");
       } else {
         ASSERT_EQ(
             expected.at(i),
             ContainerRowSerde::compareWithNulls(
-                stream, decodedVector, i, compareFlags));
+                *stream, decodedVector, i, compareFlags));
       }
     }
   }
@@ -154,13 +154,13 @@ class ContainerRowSerdeTest : public testing::Test,
           !equalsOnly) {
         VELOX_ASSERT_THROW(
             ContainerRowSerde::compareWithNulls(
-                leftStream, rightStream, type.get(), compareFlags),
+                *leftStream, *rightStream, type.get(), compareFlags),
             "Ordering nulls is not supported");
       } else {
         ASSERT_EQ(
             expected.at(i),
             ContainerRowSerde::compareWithNulls(
-                leftStream, rightStream, type.get(), compareFlags));
+                *leftStream, *rightStream, type.get(), compareFlags));
       }
     }
   }
@@ -176,7 +176,8 @@ class ContainerRowSerdeTest : public testing::Test,
     for (auto i = 0; i < positions.size(); ++i) {
       auto stream = HashStringAllocator::prepareRead(positions.at(i).header);
       ASSERT_EQ(
-          0, ContainerRowSerde::compare(stream, decodedVector, i, compareFlags))
+          0,
+          ContainerRowSerde::compare(*stream, decodedVector, i, compareFlags))
           << "at " << i << ": " << vector->toString(i);
     }
   }
@@ -593,13 +594,13 @@ TEST_F(ContainerRowSerdeTest, nans) {
   for (auto i = 0; i < positions.size(); ++i) {
     auto stream = HashStringAllocator::prepareRead(positions.at(i).header);
     ASSERT_EQ(
-        0, ContainerRowSerde::compare(stream, decodedVector, i, compareFlags))
+        0, ContainerRowSerde::compare(*stream, decodedVector, i, compareFlags))
         << "at " << i << ": " << vector->toString(i);
 
     stream = HashStringAllocator::prepareRead(positions.at(i).header);
     ASSERT_EQ(
         expected->hashValueAt(i),
-        ContainerRowSerde::hash(stream, vector->type().get()))
+        ContainerRowSerde::hash(*stream, vector->type().get()))
         << "at " << i << ": " << vector->toString(i);
   }
 }

--- a/velox/functions/lib/aggregates/SingleValueAccumulator.cpp
+++ b/velox/functions/lib/aggregates/SingleValueAccumulator.cpp
@@ -42,7 +42,7 @@ void SingleValueAccumulator::read(const VectorPtr& vector, vector_size_t index)
   VELOX_CHECK_NOT_NULL(start_.header);
 
   auto stream = HashStringAllocator::prepareRead(start_.header);
-  exec::ContainerRowSerde::deserialize(stream, index, vector.get());
+  exec::ContainerRowSerde::deserialize(*stream, index, vector.get());
 }
 
 bool SingleValueAccumulator::hasValue() const {
@@ -57,7 +57,7 @@ std::optional<int32_t> SingleValueAccumulator::compare(
 
   auto stream = HashStringAllocator::prepareRead(start_.header);
   return exec::ContainerRowSerde::compareWithNulls(
-      stream, decoded, index, compareFlags);
+      *stream, decoded, index, compareFlags);
 }
 
 void SingleValueAccumulator::destroy(HashStringAllocator* allocator) {

--- a/velox/functions/lib/aggregates/ValueList.cpp
+++ b/velox/functions/lib/aggregates/ValueList.cpp
@@ -113,13 +113,13 @@ bool ValueListReader::next(BaseVector& output, vector_size_t outputIndex) {
   if (pos_ == lastNullsStart_) {
     nulls_ = lastNulls_;
   } else if (pos_ % 64 == 0) {
-    nulls_ = nullsStream_.read<uint64_t>();
+    nulls_ = nullsStream_->read<uint64_t>();
   }
 
   if (nulls_ & (1UL << (pos_ % 64))) {
     output.setNull(outputIndex, true);
   } else {
-    exec::ContainerRowSerde::deserialize(dataStream_, outputIndex, &output);
+    exec::ContainerRowSerde::deserialize(*dataStream_, outputIndex, &output);
   }
 
   pos_++;

--- a/velox/functions/lib/aggregates/ValueList.h
+++ b/velox/functions/lib/aggregates/ValueList.h
@@ -127,8 +127,8 @@ class ValueListReader {
   const vector_size_t size_;
   const vector_size_t lastNullsStart_;
   const uint64_t lastNulls_;
-  ByteInputStream dataStream_;
-  ByteInputStream nullsStream_;
+  std::unique_ptr<ByteInputStream> dataStream_;
+  std::unique_ptr<ByteInputStream> nullsStream_;
   uint64_t nulls_;
   vector_size_t pos_{0};
 };

--- a/velox/functions/lib/aggregates/ValueSet.cpp
+++ b/velox/functions/lib/aggregates/ValueSet.cpp
@@ -55,7 +55,7 @@ void ValueSet::read(
   VELOX_CHECK_NOT_NULL(header);
 
   auto stream = HashStringAllocator::prepareRead(header);
-  exec::ContainerRowSerde::deserialize(stream, index, vector);
+  exec::ContainerRowSerde::deserialize(*stream, index, vector);
 }
 
 void ValueSet::free(HashStringAllocator::Header* header) const {

--- a/velox/row/benchmark/UnsafeRowSerializeBenchmark.cpp
+++ b/velox/row/benchmark/UnsafeRowSerializeBenchmark.cpp
@@ -101,7 +101,7 @@ class SerializeBenchmark {
 
     auto in = HashStringAllocator::prepareRead(position.header);
     for (auto i = 0; i < data->size(); ++i) {
-      exec::ContainerRowSerde::deserialize(in, i, copy.get());
+      exec::ContainerRowSerde::deserialize(*in, i, copy.get());
     }
 
     VELOX_CHECK_EQ(copy->size(), data->size());

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -4224,10 +4224,10 @@ void PrestoVectorSerde::deserialize(
         codec->uncompress(compressBuf.get(), header.uncompressedSize);
     ByteRange byteRange{
         uncompress->writableData(), (int32_t)uncompress->length(), 0};
-    ByteInputStream uncompressedSource({byteRange});
-
+    auto uncompressedSource =
+        std::make_unique<BufferInputStream>(std::vector<ByteRange>{byteRange});
     readTopColumns(
-        uncompressedSource, type, pool, *result, resultOffset, prestoOptions);
+        *uncompressedSource, type, pool, *result, resultOffset, prestoOptions);
   }
 }
 

--- a/velox/serializers/tests/CompactRowSerializerTest.cpp
+++ b/velox/serializers/tests/CompactRowSerializerTest.cpp
@@ -54,7 +54,7 @@ class CompactRowSerializerTest : public ::testing::Test,
     ASSERT_EQ(size, output->tellp());
   }
 
-  ByteInputStream toByteStream(
+  std::unique_ptr<ByteInputStream> toByteStream(
       const std::string_view& input,
       size_t pageSize = 32) {
     auto rawBytes = reinterpret_cast<uint8_t*>(const_cast<char*>(input.data()));
@@ -71,7 +71,7 @@ class CompactRowSerializerTest : public ::testing::Test,
       offset += pageSize;
     }
 
-    return ByteInputStream(std::move(ranges));
+    return std::make_unique<BufferInputStream>(std::move(ranges));
   }
 
   RowVectorPtr deserialize(
@@ -80,7 +80,7 @@ class CompactRowSerializerTest : public ::testing::Test,
     auto byteStream = toByteStream(input);
 
     RowVectorPtr result;
-    serde_->deserialize(&byteStream, pool_.get(), rowType, &result);
+    serde_->deserialize(byteStream.get(), pool_.get(), rowType, &result);
     return result;
   }
 

--- a/velox/serializers/tests/UnsafeRowSerializerTest.cpp
+++ b/velox/serializers/tests/UnsafeRowSerializerTest.cpp
@@ -54,7 +54,8 @@ class UnsafeRowSerializerTest : public ::testing::Test,
     ASSERT_EQ(size, output->tellp());
   }
 
-  ByteInputStream toByteStream(const std::vector<std::string_view>& inputs) {
+  std::unique_ptr<ByteInputStream> toByteStream(
+      const std::vector<std::string_view>& inputs) {
     std::vector<ByteRange> ranges;
     ranges.reserve(inputs.size());
 
@@ -64,7 +65,7 @@ class UnsafeRowSerializerTest : public ::testing::Test,
            (int32_t)input.length(),
            0});
     }
-    return ByteInputStream(std::move(ranges));
+    return std::make_unique<BufferInputStream>(std::move(ranges));
   }
 
   RowVectorPtr deserialize(
@@ -73,7 +74,7 @@ class UnsafeRowSerializerTest : public ::testing::Test,
     auto byteStream = toByteStream(input);
 
     RowVectorPtr result;
-    serde_->deserialize(&byteStream, pool_.get(), rowType, &result);
+    serde_->deserialize(byteStream.get(), pool_.get(), rowType, &result);
     return result;
   }
 
@@ -284,7 +285,7 @@ TEST_F(UnsafeRowSerializerTest, incompleteRow) {
   buffers = {{rawData, 2}};
   VELOX_ASSERT_RUNTIME_THROW(
       testDeserialize(buffers, expected),
-      "Reading past end of ByteInputStream");
+      "(1 vs. 1) Reading past end of BufferInputStream");
 }
 
 TEST_F(UnsafeRowSerializerTest, types) {

--- a/velox/vector/VectorStream.cpp
+++ b/velox/vector/VectorStream.cpp
@@ -242,14 +242,15 @@ RowVectorPtr IOBufToRowVector(
         const_cast<uint8_t*>(range.data()), (int32_t)range.size(), 0});
   }
 
-  ByteInputStream byteStream(std::move(ranges));
+  auto byteStream = std::make_unique<BufferInputStream>(std::move(ranges));
   RowVectorPtr outputVector;
 
   // If not supplied, use the default one.
   if (serde == nullptr) {
     serde = getVectorSerde();
   }
-  serde->deserialize(&byteStream, &pool, outputType, &outputVector, nullptr);
+  serde->deserialize(
+      byteStream.get(), &pool, outputType, &outputVector, nullptr);
   return outputVector;
 }
 

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -754,7 +754,7 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
     }
   }
 
-  ByteInputStream prepareInput(std::string& string) {
+  std::unique_ptr<ByteInputStream> prepareInput(std::string& string) {
     // Put 'string' in 'input' in many pieces.
     const int32_t size = string.size();
     std::vector<ByteRange> ranges;
@@ -767,7 +767,7 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
       ranges.back().position = 0;
     }
 
-    return ByteInputStream(std::move(ranges));
+    return std::make_unique<BufferInputStream>(std::move(ranges));
   }
 
   void checkSizes(
@@ -874,7 +874,7 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
     auto evenInput = prepareInput(evenString);
 
     RowVectorPtr resultRow;
-    VectorStreamGroup::read(&evenInput, pool(), sourceRowType, &resultRow);
+    VectorStreamGroup::read(evenInput.get(), pool(), sourceRowType, &resultRow);
     VectorPtr result = resultRow->childAt(0);
     switch (source->encoding()) {
       case VectorEncoding::Simple::FLAT:
@@ -903,7 +903,7 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
     auto oddString = oddStream.str();
     auto oddInput = prepareInput(oddString);
 
-    VectorStreamGroup::read(&oddInput, pool(), sourceRowType, &resultRow);
+    VectorStreamGroup::read(oddInput.get(), pool(), sourceRowType, &resultRow);
     result = resultRow->childAt(0);
     for (int32_t i = 0; i < oddIndices.size(); ++i) {
       EXPECT_TRUE(result->equalValueAt(source.get(), i, oddIndices[i].begin))


### PR DESCRIPTION
Current spill leverage SpillInputStream to handle the byte stream read from spilled file. SpillInputStream is a
derived class from ByteInputStream and its implementation a bit hack as most of operations of ByteInputStream
doesn't apply for SpillInputStream as we don't support backward seek on a file for now. It just works for now.
It is better to split them and make a generic file based input stream which can be used in other cases as well.