### PR TITLE
Back out "Make concat function throw when there are less than 2 arguments"

### DIFF
--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -309,10 +309,6 @@ class FunctionSignatureBuilder {
     return *this;
   }
 
-  /// Variable arity arguments can appear
-  /// only at the end of the argument list and their types must match the type
-  /// specified in the last entry of 'argumentTypes'. Variable arity arguments
-  /// can appear zero or more times.
   FunctionSignatureBuilder& variableArity() {
     variableArity_ = true;
     return *this;

--- a/velox/expression/tests/ExprCompilerTest.cpp
+++ b/velox/expression/tests/ExprCompilerTest.cpp
@@ -268,7 +268,9 @@ TEST_F(ExprCompilerTest, functionSignatureNotRegistered) {
 
   VELOX_ASSERT_THROW(
       compile(expression),
-      "Scalar function concat not registered with arguments: (BIGINT, BIGINT)");
+      "Scalar function concat not registered with arguments: (BIGINT, BIGINT). "
+      "Found function registered with the following signatures:\n"
+      "((varchar,varchar...) -> varchar)");
 }
 
 TEST_F(ExprCompilerTest, constantFromFlatVector) {

--- a/velox/functions/prestosql/StringFunctions.cpp
+++ b/velox/functions/prestosql/StringFunctions.cpp
@@ -258,13 +258,11 @@ class ConcatFunction : public exec::VectorFunction {
             .returnType("varchar")
             .argumentType("varchar")
             .argumentType("varchar")
-            .argumentType("varchar")
             .variableArity()
             .build(),
         // varbinary, varbinary,.. -> varbinary
         exec::FunctionSignatureBuilder()
             .returnType("varbinary")
-            .argumentType("varbinary")
             .argumentType("varbinary")
             .argumentType("varbinary")
             .variableArity()

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -844,7 +844,7 @@ TEST_F(StringFunctionsTest, concat) {
   size_t maxStringLength = 100;
 
   std::vector<std::vector<std::string>> inputTable;
-  for (int argsCount = 2; argsCount <= maxArgsCount; argsCount++) {
+  for (int argsCount = 1; argsCount <= maxArgsCount; argsCount++) {
     inputTable.clear();
 
     // Create table with argsCount columns
@@ -929,13 +929,6 @@ TEST_F(StringFunctionsTest, concat) {
     });
 
     test::assertEqualVectors(expected, result);
-  }
-
-  // Less than 2 concatenation arguments throws exception.
-  {
-    VELOX_ASSERT_THROW(
-        evaluateOnce<std::string>("concat('a')", {}),
-        "Scalar function signature is not supported: concat(VARCHAR).");
   }
 }
 


### PR DESCRIPTION
Summary: This diff D60536630 seems to be breaking all of xstream engine's AB tests, e.g. https://www.internalfb.com/conveyor/xstream/query_runtime/releases

Differential Revision: D61150783
