### PR TITLE
Fix error on multiple inclusions of FindArrow CMake

### DIFF
--- a/CMake/FindArrow.cmake
+++ b/CMake/FindArrow.cmake
@@ -30,16 +30,19 @@ add_library(thrift ALIAS thrift::thrift)
 
 set(Arrow_FOUND true)
 
-add_library(arrow STATIC IMPORTED GLOBAL)
-add_library(parquet STATIC IMPORTED GLOBAL)
-add_library(arrow_testing STATIC IMPORTED GLOBAL)
+# Only add the libraries once.
+if(NOT TARGET arrow)
+  add_library(arrow STATIC IMPORTED GLOBAL)
+  add_library(parquet STATIC IMPORTED GLOBAL)
+  add_library(arrow_testing STATIC IMPORTED GLOBAL)
 
-find_path(ARROW_INCLUDE_PATH arrow/api.h)
-set_target_properties(
-  arrow arrow_testing parquet PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
-                                         ${ARROW_INCLUDE_PATH})
-set_target_properties(arrow PROPERTIES IMPORTED_LOCATION ${ARROW_LIB}
-                                       INTERFACE_LINK_LIBRARIES thrift)
-set_target_properties(parquet PROPERTIES IMPORTED_LOCATION ${PARQUET_LIB})
-set_target_properties(arrow_testing PROPERTIES IMPORTED_LOCATION
-                                               ${ARROW_TESTING_LIB})
+  find_path(ARROW_INCLUDE_PATH arrow/api.h)
+  set_target_properties(
+    arrow arrow_testing parquet PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                           ${ARROW_INCLUDE_PATH})
+  set_target_properties(arrow PROPERTIES IMPORTED_LOCATION ${ARROW_LIB}
+                                         INTERFACE_LINK_LIBRARIES thrift)
+  set_target_properties(parquet PROPERTIES IMPORTED_LOCATION ${PARQUET_LIB})
+  set_target_properties(arrow_testing PROPERTIES IMPORTED_LOCATION
+                                                 ${ARROW_TESTING_LIB})
+endif()


### PR DESCRIPTION
The FindArrow file could be called more than one time, for example, if additional connectors require Arrow dependencies.

In that case the add_library call invoked a second time fails with the target already being defined and needs to be avoided. If the library was already registered so were the others and we don’t need to check explicitly.