### PR TITLE
Add missing GTest namespace to targets

### DIFF
--- a/velox/common/config/tests/CMakeLists.txt
+++ b/velox/common/config/tests/CMakeLists.txt
@@ -17,4 +17,4 @@ add_test(velox_config_test velox_config_test)
 target_link_libraries(
   velox_config_test
   PUBLIC Folly::folly
-  PRIVATE velox_common_config gtest gtest_main)
+  PRIVATE velox_common_config GTest::gtest GTest::gtest_main)


### PR DESCRIPTION
There was a delay between running the CI in #10422 and merging it, in this time a new target was added that was missing the namespace.
Fixes #10721 