### PR TITLE
feat(type): Add VarcharN and VarbinaryN type support

### DIFF
--- a/velox/docs/functions/presto/string.rst
+++ b/velox/docs/functions/presto/string.rst
@@ -19,6 +19,9 @@ String Functions
     some languages. Specifically, this will return incorrect results for
     Lithuanian, Turkish and Azeri.
 
+    The "string" input parameter indicates an input of either type `varchar` or `varchar(n)`.
+    The output type where indicates as "varchar" is always of type `varchar`.
+
 .. function:: bit_length(string) -> integer
 
     Returns the bit length for the specified string column.

--- a/velox/exec/AggregateFunctionRegistry.cpp
+++ b/velox/exec/AggregateFunctionRegistry.cpp
@@ -85,6 +85,17 @@ TypePtr resolveIntermediateType(
       }
     }
 
+    /*
+      // If no direct match was found re-try with coercions.
+      for (const auto& signature : signatures.value()) {
+        SignatureBinder binder(*signature, argTypes);
+        std::vector<Coercion> coercions;
+        if (binder.tryBindWithCoercions(coercions)) {
+          return binder.tryResolveType(signature->intermediateType());
+        }
+      }
+  */
+
     VELOX_USER_FAIL(
         "Aggregate function signature is not supported: {}. Supported signatures: {}.",
         toString(name, argTypes),

--- a/velox/exec/fuzzer/FuzzerUtil.cpp
+++ b/velox/exec/fuzzer/FuzzerUtil.cpp
@@ -282,7 +282,7 @@ bool containsIPAddress(const TypePtr& type) {
 // case.
 bool containTypeName(
     const exec::TypeSignature& type,
-    const std::string& typeName) {
+    std::string_view typeName) {
   auto sanitizedTypeName = exec::sanitizeName(type.baseName());
   if (sanitizedTypeName == typeName) {
     return true;
@@ -297,7 +297,7 @@ bool containTypeName(
 
 bool usesInputTypeName(
     const exec::FunctionSignature& signature,
-    const std::string& typeName) {
+    std::string_view typeName) {
   for (const auto& argument : signature.argumentTypes()) {
     if (containTypeName(argument, typeName)) {
       return true;
@@ -308,7 +308,7 @@ bool usesInputTypeName(
 
 bool usesTypeName(
     const exec::FunctionSignature& signature,
-    const std::string& typeName) {
+    std::string_view typeName) {
   if (containTypeName(signature.returnType(), typeName)) {
     return true;
   }

--- a/velox/exec/fuzzer/FuzzerUtil.h
+++ b/velox/exec/fuzzer/FuzzerUtil.h
@@ -108,13 +108,13 @@ bool containsIPAddress(const TypePtr& type);
 /// typeName should be in lower case.
 bool usesInputTypeName(
     const exec::FunctionSignature& signature,
-    const std::string& typeName);
+    std::string_view typeName);
 
 /// Determines whether the signature has an argument or return type that
 /// contains typeName. typeName should be in lower case.
 bool usesTypeName(
     const exec::FunctionSignature& signature,
-    const std::string& typeName);
+    std::string_view typeName);
 
 // First resolves typeSignature. Then, the resolved type is a RowType or
 // contains RowTypes with empty field names, adds default names to these fields

--- a/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
+++ b/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
@@ -146,6 +146,27 @@ TEST(PrestoSqlTest, toCallSql) {
               std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a"),
               std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "b"))),
       "(c0 like 'a' escape 'b')");
+  EXPECT_EQ(
+      toCallSql(
+          std::make_shared<core::CallTypedExpr>(
+              BOOLEAN(),
+              std::vector<core::TypedExprPtr>{
+                  std::make_shared<core::FieldAccessTypedExpr>(
+                      VARCHAR(10), "c0"),
+                  std::make_shared<core::ConstantTypedExpr>(VARCHAR(10), "a")},
+              "like")),
+      "(c0 like 'a')");
+  EXPECT_EQ(
+      toCallSql(
+          std::make_shared<core::CallTypedExpr>(
+              BOOLEAN(),
+              std::vector<core::TypedExprPtr>{
+                  std::make_shared<core::FieldAccessTypedExpr>(
+                      VARCHAR(10), "c0"),
+                  std::make_shared<core::ConstantTypedExpr>(VARCHAR(10), "a"),
+                  std::make_shared<core::ConstantTypedExpr>(VARCHAR(10), "b")},
+              "like")),
+      "(c0 like 'a' escape 'b')");
   VELOX_ASSERT_THROW(
       toCallSql(
           std::make_shared<core::CallTypedExpr>(

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -675,7 +675,6 @@ PlanBuilder& PlanBuilder::parallelProject(
       std::move(exprGroups),
       noLoadColumns,
       planNode_);
-
   return *this;
 }
 

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -260,7 +260,12 @@ void CastExpr::applyCastKernel(
     if constexpr (is_string_kind(ToKind)) {
       // Write the result output to the output vector
       auto writer = exec::StringWriter(result, row);
-      writer.copy_from(output);
+      auto maxWriteLength = getVaryingLengthScalarTypeLength(*result->type());
+      if (output.size() > maxWriteLength) {
+        writer.copy_from(output.substr(0, maxWriteLength));
+      } else {
+        writer.copy_from(output);
+      }
       writer.finalize();
     } else {
       result->set(row, output);

--- a/velox/expression/CoalesceExpr.cpp
+++ b/velox/expression/CoalesceExpr.cpp
@@ -40,7 +40,8 @@ TypePtr resolveTypeInt(
   auto resultType = argTypes[0];
 
   for (auto i = 1; i < numArgs; i++) {
-    if (*resultType == *argTypes[i]) {
+    if (*resultType == *argTypes[i] ||
+        TypeCoercer::isTypeOnlyCoercion(resultType, argTypes[i])) {
       continue;
     }
 
@@ -58,7 +59,8 @@ TypePtr resolveTypeInt(
     }
 
     VELOX_USER_CHECK(
-        *argTypes[0] == *argTypes[i],
+        (*argTypes[0] == *argTypes[i] ||
+         TypeCoercer::isTypeOnlyCoercion(resultType, argTypes[i])),
         "Inputs to coalesce must have the same type. Expected {}, but got {}.",
         argTypes[0]->toString(),
         argTypes[i]->toString());
@@ -95,7 +97,8 @@ CoalesceExpr::CoalesceExpr(
   // Apply type checks.
   auto expectedType = resolveTypeInt(inputTypes);
   VELOX_CHECK(
-      *expectedType == *this->type(),
+      (*expectedType == *this->type() ||
+       TypeCoercer::isTypeOnlyCoercion(expectedType, this->type())),
       "Coalesce expression type different than its inputs. Expected {}, but got {}.",
       expectedType->toString(),
       this->type()->toString());

--- a/velox/expression/ConstantExpr.h
+++ b/velox/expression/ConstantExpr.h
@@ -21,9 +21,12 @@ namespace facebook::velox::exec {
 class ConstantExpr : public SpecialForm {
  public:
   explicit ConstantExpr(VectorPtr value)
+      : ConstantExpr(value->type(), value) {};
+
+  explicit ConstantExpr(const TypePtr& type, VectorPtr value)
       : SpecialForm(
             SpecialFormKind::kConstant,
-            value->type(),
+            type,
             std::vector<ExprPtr>(),
             "literal",
             !value->isNullAt(0) /* supportsFlatNoNullsFastPath */,

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -310,7 +310,9 @@ ExprPtr compileCall(
   if (auto simpleFunctionEntry =
           simpleFunctions().resolveFunction(call->name(), inputTypes)) {
     VELOX_USER_CHECK(
-        resultType->equivalent(*simpleFunctionEntry->type().get()),
+        (resultType->equivalent(*simpleFunctionEntry->type().get()) ||
+         TypeCoercer::isTypeOnlyCoercion(
+             resultType, simpleFunctionEntry->type())),
         "Found incompatible return types for '{}' ({} vs. {}) "
         "for input types ({}).",
         call->name(),
@@ -331,6 +333,30 @@ ExprPtr compileCall(
         call->name(),
         trackCpuUsage);
   }
+  /*
+    std::vector<TypePtr> coercedInputTypes;
+    if (auto simpleFunctionEntry =
+    simpleFunctions().resolveFunctionWithCoercions( call->name(), inputTypes,
+    coercedInputTypes)) { VELOX_USER_CHECK(
+          resultType->equivalent(*simpleFunctionEntry->type().get()),
+          "Found incompatible return types for '{}' ({} vs. {}) "
+          "for input types ({}).",
+          call->name(),
+          simpleFunctionEntry->type(),
+          resultType,
+          folly::join(", ", inputTypes));
+
+      auto func = simpleFunctionEntry->createFunction()->createVectorFunction(
+          inputTypes, getConstantInputs(inputs), ctx.queryCtx->queryConfig());
+      return std::make_shared<Expr>(
+          resultType,
+          std::move(inputs),
+          std::move(func),
+          simpleFunctionEntry->metadata(),
+          call->name(),
+          trackCpuUsage);
+    }
+  */
 
   const auto& functionName = call->name();
   auto vectorFunctionSignatures = getVectorFunctionSignatures(functionName);

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -94,7 +94,7 @@ size_t findNextComma(const std::string& str, size_t start) {
 
 namespace {
 /// Returns true only if 'str' contains digits.
-bool isPositiveInteger(const std::string& str) {
+bool isPositiveInteger(std::string_view str) {
   return !str.empty() &&
       std::find_if(str.begin(), str.end(), [](unsigned char c) {
         return !std::isdigit(c);
@@ -172,7 +172,7 @@ void validate(
         "Variable arity requires at least one argument");
   }
 
-  // All type variables should apear in the inputs arguments.
+  // All type variables should appear in the inputs arguments.
   for (auto& [name, variable] : variables) {
     if (variable.isTypeParameter()) {
       VELOX_USER_CHECK(

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -29,7 +29,7 @@ bool isAny(const TypeSignature& typeSignature) {
 }
 
 /// Returns true only if 'str' contains digits.
-bool isPositiveInteger(const std::string& str) {
+bool isPositiveInteger(std::string_view str) {
   return !str.empty() &&
       std::find_if(str.begin(), str.end(), [](unsigned char c) {
         return !std::isdigit(c);
@@ -113,6 +113,29 @@ bool checkNamedRowField(
     return false;
   }
   return true;
+}
+
+// Determine if an actual parameterized type can logically match an
+// unparameterized function signature parameter.
+//
+// Handles the VARCHAR and VARBINARY case where the type signature has no
+// parameters but the actualType does (e.g., VARCHAR(50) matching varchar).
+// This allows binding a parameterized actualType to an unparameterized
+// function signature argument. This is not true coercion because the
+// physical types match and we can logically match them.
+bool isLogicallyCompatible(
+    const TypeSignature& signature,
+    const TypePtr& actualType) {
+  // Only match if signature has no parameters (unparameterized).
+  if (!signature.parameters().empty()) {
+    return false;
+  }
+
+  // Compare base names case-insensitively and verify actualType kinds match.
+  return (boost::algorithm::iequals(signature.baseName(), "varchar") &&
+          actualType->kind() == TypeKind::VARCHAR) ||
+      (boost::algorithm::iequals(signature.baseName(), "varbinary") &&
+       actualType->kind() == TypeKind::VARBINARY);
 }
 
 } // namespace
@@ -456,7 +479,8 @@ bool SignatureBinderBase::tryBind(
   }
 
   // Type Parameters can recurse.
-  if (params.size() != actualType->parameters().size()) {
+  if (params.size() != actualType->parameters().size() &&
+      !isLogicallyCompatible(typeSignature, actualType)) {
     return false;
   }
 

--- a/velox/expression/VectorFunction.cpp
+++ b/velox/expression/VectorFunction.cpp
@@ -201,7 +201,9 @@ getVectorFunctionWithMetadata(
               VectorFunctionMetadata>> {
         for (const auto& signature : entry.signatures) {
           exec::SignatureBinder binder(*signature, inputTypes);
-          if (binder.tryBind()) {
+          std::vector<Coercion> coercions;
+          if (binder
+                  .tryBind()) { // || binder.tryBindWithCoercions(coercions)) {
             auto inputArgs = toVectorFunctionArgs(inputTypes, constantInputs);
 
             return {

--- a/velox/expression/fuzzer/ExpressionFuzzer.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzer.cpp
@@ -311,7 +311,8 @@ ExpressionFuzzer::ExpressionFuzzer(
         continue;
       }
       if (!(signature->variables().empty() || options_.enableComplexTypes ||
-            options_.enableDecimalType)) {
+            options_.enableDecimalType ||
+            containsLengthParameterizedTypeInSignature(*signature))) {
         LOG(WARNING) << "Skipping unsupported signature: " << function.first
                      << signature->toString();
         continue;
@@ -456,7 +457,8 @@ bool ExpressionFuzzer::isSupportedSignature(
           signature,
           "sfmsketch") || // See Issue :
                           // https://github.com/facebookincubator/velox/issues/14643
-      (!options_.enableDecimalType && usesTypeName(signature, "decimal")) ||
+      (!options_.enableDecimalType &&
+       usesTypeName(signature, kNormalizedDecimalTypeName)) ||
       (!options_.enableComplexTypes && useComplexType) ||
       (options_.enableComplexTypes && usesTypeName(signature, "unknown"))) {
     return false;
@@ -468,6 +470,15 @@ bool ExpressionFuzzer::isSupportedSignature(
   }
 
   return true;
+}
+
+bool ExpressionFuzzer::containsLengthParameterizedTypeInSignature(
+    const exec::FunctionSignature& signature) {
+  if (usesTypeName(signature, kNormalizedVarcharTypeName) ||
+      usesTypeName(signature, kNormalizedVarbinaryTypeName)) {
+    return true;
+  }
+  return false;
 }
 
 void ExpressionFuzzer::getTicketsForFunctions() {
@@ -816,7 +827,8 @@ core::TypedExprPtr ExpressionFuzzer::generateExpression(
         expression = generateExpressionFromConcreteSignatures(
             returnType, chosenFunctionName);
         if (!expression &&
-            (options_.enableComplexTypes || options_.enableDecimalType)) {
+            (options_.enableComplexTypes || options_.enableDecimalType ||
+             isVaryingLengthScalarType(returnType))) {
           expression = generateExpressionFromSignatureTemplate(
               returnType, chosenFunctionName);
         }
@@ -1041,8 +1053,14 @@ core::TypedExprPtr ExpressionFuzzer::generateExpressionFromSignatureTemplate(
   }
 
   auto chosenSignature = *chosen->signature;
+  ArgumentTypeFuzzer::Options argFuzzerOptions;
+  argFuzzerOptions.maxVarcharTypeLength = options_.maxVarcharTypeLength;
   ArgumentTypeFuzzer fuzzer{
-      chosenSignature, returnType, rng_, supportedScalarTypes_};
+      chosenSignature,
+      returnType,
+      rng_,
+      supportedScalarTypes_,
+      argFuzzerOptions};
 
   std::vector<TypePtr> argumentTypes;
   // Check if a custom argument type generator exists for this function.

--- a/velox/expression/fuzzer/ExpressionFuzzer.h
+++ b/velox/expression/fuzzer/ExpressionFuzzer.h
@@ -110,6 +110,14 @@ class ExpressionFuzzer {
     // This can be used to control the size of the input of the fuzzer
     // expression.
     std::optional<int32_t> maxInputsThreshold = std::nullopt;
+
+    // When parameterized varchar types are generated this defines the upper
+    // bound for the parametr value. Note: this value is also used by the
+    // VectorFuzzer for the maximum possible constant string value used. Except
+    // the VectorFuzzer also takes the parameterized type into account to avoid
+    // generating a string that's too large for the concrete fuzzed varchar
+    // type. Passed through to the ArgumentFuzzer.
+    int32_t maxVarcharTypeLength = 100;
   };
 
   ExpressionFuzzer(
@@ -162,6 +170,9 @@ class ExpressionFuzzer {
 
  private:
   bool isSupportedSignature(const exec::FunctionSignature& signature);
+
+  bool containsLengthParameterizedTypeInSignature(
+      const exec::FunctionSignature& signature);
 
   // Either generates a new expression of the required return type or if
   // already generated expressions of the same return type exist then there is

--- a/velox/expression/fuzzer/FuzzerRunner.cpp
+++ b/velox/expression/fuzzer/FuzzerRunner.cpp
@@ -162,6 +162,15 @@ DEFINE_string(
     "of functions at every instance. Number of tickets must be a positive "
     "integer. Example: eq=3,floor=5");
 
+DEFINE_int32(
+    max_varchar_type_length,
+    100,
+    "The maximum varying type length for a VARCHAR type. "
+    "The value defines also the maximum string length for a "
+    "string value. However, the fuzzed string value length does "
+    "not exceed the concrete fuzzed type length when generating "
+    "a constant for the VARCHAR typed column.");
+
 namespace facebook::velox::fuzzer {
 
 namespace {
@@ -169,7 +178,7 @@ VectorFuzzer::Options getVectorFuzzerOptions() {
   VectorFuzzer::Options opts;
   opts.vectorSize = FLAGS_batch_size;
   opts.stringVariableLength = true;
-  opts.stringLength = 100;
+  opts.stringLength = FLAGS_max_varchar_type_length;
   opts.nullRatio = FLAGS_null_ratio;
   opts.useRandomNullPattern = true;
   opts.timestampPrecision =
@@ -198,6 +207,7 @@ ExpressionFuzzer::Options getExpressionFuzzerOptions(
   opts.skipFunctions = skipFunctions;
   opts.referenceQueryRunner = referenceQueryRunner;
   opts.exprTransformers = exprTransformers;
+  opts.maxVarcharTypeLength = FLAGS_max_varchar_type_length;
   return opts;
 }
 

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -4063,6 +4063,26 @@ TEST_F(CastExprTest, timestampToTimeCast) {
   testCast(TIMESTAMP(), TIME(), realTimestamps, expectedRealTime);
 }
 
+TEST_F(CastExprTest, varcharToVarchar) {
+  std::vector<std::optional<StringView>> expected = {
+      "foobar123",
+      "truncated",
+      std::nullopt,
+  };
+
+  std::vector<std::optional<StringView>> input = {
+      "foobar123",
+      "truncatedfoobar123",
+      std::nullopt,
+  };
+
+  testCast(VARCHAR(), VARCHAR(9), input, expected);
+  testCast(VARCHAR(20), VARCHAR(9), input, expected);
+
+  input = expected;
+  testCast(VARCHAR(9), VARCHAR(), input, expected);
+}
+
 TEST_F(CastExprTest, numericUpcast) {
   auto testNumericUpcast =
       [&](std::function<bool(vector_size_t /*row*/)> isNullAt = nullptr) {

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -1401,6 +1401,188 @@ TEST(SignatureBinderTest, genericCoercions) {
   }
 }
 
+TEST(SignatureBinderTest, arrayTypeCoercions) {
+  auto signature = exec::FunctionSignatureBuilder()
+                       .returnType("boolean")
+                       .argumentType("ARRAY(SMALLINT)")
+                       .argumentType("ARRAY(INTEGER)")
+                       .argumentType("ARRAY(BIGINT)")
+                       .argumentType("ARRAY(REAL)")
+                       .argumentType("ARRAY(DOUBLE)")
+                       //.argumentType("ARRAY(VARCHAR)")
+                       .build();
+  testCoercions(
+      signature,
+      {ARRAY(TINYINT()),
+       ARRAY(TINYINT()),
+       ARRAY(TINYINT()),
+       ARRAY(TINYINT()),
+       ARRAY(TINYINT())},
+      // ARRAY(VARCHAR(10))},
+      {ARRAY(SMALLINT()),
+       ARRAY(INTEGER()),
+       ARRAY(BIGINT()),
+       ARRAY(REAL()),
+       ARRAY(DOUBLE())},
+      // ARRAY(VARCHAR())},
+      BOOLEAN());
+
+  testCoercions(
+      signature,
+      {ARRAY(SMALLINT()),
+       ARRAY(SMALLINT()),
+       ARRAY(SMALLINT()),
+       ARRAY(REAL()),
+       ARRAY(REAL())},
+      // ARRAY(VARCHAR(999))},
+      {nullptr, ARRAY(INTEGER()), ARRAY(BIGINT()), nullptr, ARRAY(DOUBLE())},
+      // ARRAY(VARCHAR())},
+      BOOLEAN());
+
+  testNoCoercions(
+      signature,
+      {ARRAY(SMALLINT()),
+       ARRAY(INTEGER()),
+       ARRAY(BIGINT()),
+       ARRAY(REAL()),
+       ARRAY(DOUBLE())},
+      // ARRAY(VARCHAR())},
+      BOOLEAN());
+
+  assertCannotBind(
+      signature,
+      {ARRAY(INTEGER()),
+       ARRAY(INTEGER()),
+       ARRAY(INTEGER()),
+       ARRAY(INTEGER()),
+       ARRAY(INTEGER())},
+      // ARRAY(INTEGER())},
+      /*allowCoercion*/ true);
+
+  assertCannotBind(
+      signature,
+      {ARRAY(SMALLINT()),
+       ARRAY(INTEGER()),
+       ARRAY(VARCHAR()),
+       ARRAY(INTEGER()),
+       ARRAY(INTEGER())},
+      // ARRAY(VARCHAR())},
+      /*allowCoercion*/ true);
+}
+
+TEST(SignatureBinderTest, mapTypeCoercions) {
+  auto signature = exec::FunctionSignatureBuilder()
+                       .returnType("boolean")
+                       .argumentType("MAP(SMALLINT, SMALLINT)")
+                       .argumentType("MAP(INTEGER, INTEGER)")
+                       .argumentType("MAP(BIGINT, BIGINT)")
+                       .argumentType("MAP(REAL, REAL)")
+                       .argumentType("MAP(DOUBLE, DOUBLE)")
+                       //.argumentType("MAP(VARCHAR, VARCHAR)")
+                       //.argumentType("MAP(BIGINT, VARCHAR)")
+                       .build();
+
+  testCoercions(
+      signature,
+      {MAP(TINYINT(), TINYINT()),
+       MAP(TINYINT(), TINYINT()),
+       MAP(TINYINT(), TINYINT()),
+       MAP(TINYINT(), TINYINT()),
+       MAP(TINYINT(), TINYINT())},
+      // MAP(VARCHAR(10), VARCHAR(20)),
+      // MAP(TINYINT(), VARCHAR(10))},
+      {MAP(SMALLINT(), SMALLINT()),
+       MAP(INTEGER(), INTEGER()),
+       MAP(BIGINT(), BIGINT()),
+       MAP(REAL(), REAL()),
+       MAP(DOUBLE(), DOUBLE())},
+      // MAP(VARCHAR(), VARCHAR()),
+      // MAP(BIGINT(), VARCHAR())},
+      BOOLEAN());
+
+  testCoercions(
+      signature,
+      {MAP(SMALLINT(), TINYINT()),
+       MAP(SMALLINT(), INTEGER()),
+       MAP(TINYINT(), SMALLINT()),
+       MAP(REAL(), REAL()),
+       MAP(REAL(), REAL())},
+      // MAP(VARCHAR(100), VARCHAR(100000)),
+      // MAP(INTEGER(), VARCHAR(99999))},
+      {MAP(SMALLINT(), SMALLINT()),
+       MAP(INTEGER(), INTEGER()),
+       MAP(BIGINT(), BIGINT()),
+       nullptr,
+       MAP(DOUBLE(), DOUBLE())},
+      // MAP(VARCHAR(), VARCHAR()),
+      // MAP(BIGINT(), VARCHAR())},
+      BOOLEAN());
+
+  testNoCoercions(
+      signature,
+      {MAP(SMALLINT(), SMALLINT()),
+       MAP(INTEGER(), INTEGER()),
+       MAP(BIGINT(), BIGINT()),
+       MAP(REAL(), REAL()),
+       MAP(DOUBLE(), DOUBLE())},
+      // MAP(VARCHAR(), VARCHAR()),
+      // MAP(BIGINT(), VARCHAR())},
+      BOOLEAN());
+
+  assertCannotBind(
+      signature,
+      {MAP(INTEGER(), INTEGER()),
+       MAP(INTEGER(), INTEGER()),
+       MAP(INTEGER(), INTEGER()),
+       MAP(INTEGER(), INTEGER()),
+       MAP(INTEGER(), INTEGER())},
+      // MAP(INTEGER(), INTEGER()),
+      // MAP(INTEGER(), INTEGER())},
+      /*allowCoercion*/ true);
+}
+
+TEST(SignatureBinderTest, rowTypeCoercions) {
+  auto signature =
+      exec::FunctionSignatureBuilder()
+          .returnType("boolean")
+          .argumentType("ROW(SMALLINT)")
+          .argumentType("ROW(SMALLINT, INTEGER)")
+          .argumentType("ROW(BIGINT, DOUBLE)")
+          //.argumentType("ROW(BIGINT, VARCHAR)")
+          //.argumentType("ROW(ARRAY(BIGINT), MAP(BIGINT, VARCHAR))")
+          .build();
+
+  testCoercions(
+      signature,
+      {ROW({TINYINT()}), ROW({TINYINT(), TINYINT()}), ROW({TINYINT(), REAL()})},
+      // ROW({TINYINT(), VARCHAR(100)}),
+      // ROW({ARRAY(TINYINT()), MAP(TINYINT(), VARCHAR(100))})},
+      {ROW({SMALLINT()}),
+       ROW({SMALLINT(), INTEGER()}),
+       ROW({BIGINT(), DOUBLE()})},
+      // ROW({BIGINT(), VARCHAR()}),
+      // ROW({ARRAY(BIGINT()), MAP(BIGINT(), VARCHAR())})},
+      BOOLEAN());
+
+  testNoCoercions(
+      signature,
+      {ROW({SMALLINT()}),
+       ROW({SMALLINT(), INTEGER()}),
+       ROW({BIGINT(), DOUBLE()})},
+      // ROW({BIGINT(), VARCHAR()}),
+      // ROW({ARRAY(BIGINT()), MAP(BIGINT(), VARCHAR())})},
+      BOOLEAN());
+
+  assertCannotBind(
+      signature,
+      {ROW({INTEGER()}),
+       ROW({INTEGER(), INTEGER()}),
+       ROW({INTEGER(), INTEGER()})},
+      // ROW({INTEGER(), INTEGER()}),
+      // ROW({ARRAY(BIGINT()), MAP(BIGINT(), VARCHAR())})},
+      /*allowCoercion*/ true);
+}
+
 TEST(SignatureBinderTest, homogeneousRow) {
   // row(T, ...) -> boolean
   {
@@ -1651,6 +1833,36 @@ TEST(SignatureBinderTest, unknownInComplexTypes) {
   }
 }
 
+TEST(SignatureBinderTest, varcharN) {
+  // varchar -> varchar with varcharN argument type.
+  auto signature = exec::FunctionSignatureBuilder()
+                       .argumentType("varchar")
+                       .returnType("varchar")
+                       .build();
+  testSignatureBinder(signature, {VARCHAR(10)}, VARCHAR());
+
+  // Test with map.
+  signature = exec::FunctionSignatureBuilder()
+                  .argumentType("map(varchar, varchar)")
+                  .returnType("boolean")
+                  .build();
+  testSignatureBinder(signature, {MAP(VARCHAR(5), VARCHAR(10))}, BOOLEAN());
+
+  // Test with Array.
+  signature = exec::FunctionSignatureBuilder()
+                  .argumentType("array(varchar)")
+                  .returnType("boolean")
+                  .build();
+  testSignatureBinder(signature, {ARRAY(VARCHAR(5))}, BOOLEAN());
+
+  // Test with Row.
+  signature = exec::FunctionSignatureBuilder()
+                  .argumentType("row(varchar)")
+                  .returnType("boolean")
+                  .build();
+  testSignatureBinder(signature, {ROW({VARCHAR(5)})}, BOOLEAN());
+}
+
 TEST(SignatureBinderTest, tryResolveReturnTypeWithCoercions) {
   auto makeSignature = [](const std::string& returnType,
                           const std::vector<std::string>& argTypes) {
@@ -1740,6 +1952,5 @@ TEST(SignatureBinderTest, tryResolveReturnTypeWithCoercions) {
     ASSERT_EQ(coercions[1], nullptr);
   }
 }
-
 } // namespace
 } // namespace facebook::velox::exec::test

--- a/velox/functions/lib/SubscriptUtil.cpp
+++ b/velox/functions/lib/SubscriptUtil.cpp
@@ -22,6 +22,7 @@
 #include "velox/common/memory/MemoryPool.h"
 #include "velox/functions/lib/SubscriptUtil.h"
 #include "velox/type/Type.h"
+#include "velox/type/TypeCoercer.h"
 #include "velox/vector/FlatMapVector.h"
 #include "velox/vector/TypeAliases.h"
 
@@ -389,7 +390,13 @@ VectorPtr MapSubscript::applyMap(
   auto& indexArg = args[1];
 
   // Ensure map key type and second argument are the same.
-  VELOX_CHECK(mapArg->type()->childAt(0)->equivalent(*indexArg->type()));
+  VELOX_CHECK(
+      (mapArg->type()->childAt(0)->equivalent(*indexArg->type()) ||
+       TypeCoercer::isTypeOnlyCoercion(
+           mapArg->type()->childAt(0), indexArg->type())),
+      "key type: {}, indexArg[1] type: {}",
+      mapArg->type()->childAt(0)->toString(),
+      indexArg->type()->toString());
 
   // Short-circuit for FlatMapVector encoding. FlatMapVector doesn't need to
   // distinguish between primitive and complex types (where the former requires

--- a/velox/functions/prestosql/JsonFunctions.cpp
+++ b/velox/functions/prestosql/JsonFunctions.cpp
@@ -610,7 +610,7 @@ class JsonFunctionTemplate : public exec::VectorFunction {
     applyImpl(rows, args[0], args[1], outputType, context, localResult);
 
     if (args[0]->type() != JSON()) {
-      VELOX_CHECK_EQ(args[0]->type(), VARCHAR());
+      VELOX_CHECK_EQ(args[0]->type()->kind(), TypeKind::VARCHAR);
       // Remove null and error rows as the parser does not expect nulls.
       exec::MutableRemainingRows remainingRows(rows, context);
       if (localResult->rawNulls()) {

--- a/velox/functions/prestosql/TypeOf.cpp
+++ b/velox/functions/prestosql/TypeOf.cpp
@@ -112,6 +112,11 @@ std::string typeName(const TypePtr& type) {
     return "unknown";
   }
 
+  if (type->isVarcharN()) {
+    auto length = getVarcharLength(*type);
+    return fmt::format("varchar({})", length);
+  }
+
   // Handle unsupported types
   if (type->kind() == TypeKind::OPAQUE || type->kind() == TypeKind::FUNCTION ||
       type->kind() == TypeKind::INVALID) {

--- a/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
@@ -78,6 +78,8 @@ void registerComparisonFunctions(const std::string& prefix) {
   registerFunction<GteFunction, bool, Orderable<T1>, Orderable<T1>>(
       {prefix + "gte"});
 
+  registerFunction<DistinctFromFunction, bool, Varchar, Varchar>(
+      {prefix + "distinct_from"});
   registerFunction<DistinctFromFunction, bool, Generic<T1>, Generic<T1>>(
       {prefix + "distinct_from"});
 

--- a/velox/functions/prestosql/tests/ArrayCombinationsTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayCombinationsTest.cpp
@@ -182,49 +182,57 @@ TEST_F(ArrayCombinationsTest, inlineVarcharArrays) {
 
 TEST_F(ArrayCombinationsTest, varcharArrays) {
   using S = StringView;
-  auto arrayVector = makeNullableArrayVector<S>({
-      {},
-      {""},
-      {std::nullopt},
-      {"red shiny car ahead", std::nullopt, "blue clear sky above"},
-      {"blue clear sky above",
-       "red shiny car ahead",
-       "yellow rose flowers",
-       "red shiny car ahead",
-       "purple is an elegant color"},
-      {"red shiny car ahead", std::nullopt, "blue clear sky above"},
-  });
-  auto comboLengthVector = makeFlatVector<int32_t>({0, 1, 1, 2, 4, 5});
+  TypePtr inputType = ARRAY(VARCHAR());
+  for (int loop = 0; loop < 2; ++loop) {
+    auto arrayVector = makeNullableArrayVector<S>(
+        {
+            {},
+            {""},
+            {std::nullopt},
+            {"red shiny car ahead", std::nullopt, "blue clear sky above"},
+            {"blue clear sky above",
+             "red shiny car ahead",
+             "yellow rose flowers",
+             "red shiny car ahead",
+             "purple is an elegant color"},
+            {"red shiny car ahead", std::nullopt, "blue clear sky above"},
+        },
+        inputType);
+    auto comboLengthVector = makeFlatVector<int32_t>({0, 1, 1, 2, 4, 5});
 
-  auto expected = makeNullableNestedArrayVector<S>(
-      {{{{std::vector<std::optional<S>>()}}},
-       {{{{""}}}},
-       {{{{std::optional<S>(std::nullopt)}}}},
-       {{{{"red shiny car ahead", std::nullopt}},
-         {{"red shiny car ahead", "blue clear sky above"}},
-         {{std::nullopt, "blue clear sky above"}}}},
-       {{{{"blue clear sky above",
-           "red shiny car ahead",
-           "yellow rose flowers",
-           "red shiny car ahead"}},
-         {{"blue clear sky above",
-           "red shiny car ahead",
-           "yellow rose flowers",
-           "purple is an elegant color"}},
-         {{"blue clear sky above",
-           "red shiny car ahead",
-           "red shiny car ahead",
-           "purple is an elegant color"}},
-         {{"blue clear sky above",
-           "yellow rose flowers",
-           "red shiny car ahead",
-           "purple is an elegant color"}},
-         {{"red shiny car ahead",
-           "yellow rose flowers",
-           "red shiny car ahead",
-           "purple is an elegant color"}}}},
-       common::testutil::optionalEmpty});
-  testExpr(expected, "combinations(C0, C1)", {arrayVector, comboLengthVector});
+    auto expected = makeNullableNestedArrayVector<S>(
+        {{{{std::vector<std::optional<S>>()}}},
+         {{{{""}}}},
+         {{{{std::optional<S>(std::nullopt)}}}},
+         {{{{"red shiny car ahead", std::nullopt}},
+           {{"red shiny car ahead", "blue clear sky above"}},
+           {{std::nullopt, "blue clear sky above"}}}},
+         {{{{"blue clear sky above",
+             "red shiny car ahead",
+             "yellow rose flowers",
+             "red shiny car ahead"}},
+           {{"blue clear sky above",
+             "red shiny car ahead",
+             "yellow rose flowers",
+             "purple is an elegant color"}},
+           {{"blue clear sky above",
+             "red shiny car ahead",
+             "red shiny car ahead",
+             "purple is an elegant color"}},
+           {{"blue clear sky above",
+             "yellow rose flowers",
+             "red shiny car ahead",
+             "purple is an elegant color"}},
+           {{"red shiny car ahead",
+             "yellow rose flowers",
+             "red shiny car ahead",
+             "purple is an elegant color"}}}},
+         common::testutil::optionalEmpty},
+        ARRAY(VARCHAR()));
+    testExpr(
+        expected, "combinations(C0, C1)", {arrayVector, comboLengthVector});
+    inputType = ARRAY(VARCHAR(50));
+  }
 }
 
 TEST_F(ArrayCombinationsTest, boolNullableArrays) {

--- a/velox/functions/prestosql/tests/ArrayHasDuplicatesTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayHasDuplicatesTest.cpp
@@ -73,48 +73,61 @@ TEST_F(ArrayHasDuplicatesTest, bigints) {
 TEST_F(ArrayHasDuplicatesTest, inlineStrings) {
   using S = StringView;
 
-  auto array = makeNullableArrayVector<StringView>({
-      {},
-      {""_sv},
-      {std::nullopt},
-      {S("a"), S("b")},
-      {S("a"), std::nullopt, S("b")},
-      {S("a"), S("a")},
-      {S("b"), S("a"), S("b"), S("a"), S("a")},
-      {std::nullopt, std::nullopt},
-      {S("b"), std::nullopt, S("a"), S("a"), std::nullopt, S("b")},
-  });
+  TypePtr type = ARRAY(VARCHAR());
+  for (int i = 0; i < 2; i++) {
+    auto array = makeNullableArrayVector<StringView>(
+        {
+            {},
+            {""_sv},
+            {std::nullopt},
+            {S("a"), S("b")},
+            {S("a"), std::nullopt, S("b")},
+            {S("a"), S("a")},
+            {S("b"), S("a"), S("b"), S("a"), S("a")},
+            {std::nullopt, std::nullopt},
+            {S("b"), std::nullopt, S("a"), S("a"), std::nullopt, S("b")},
+        },
+        type);
 
-  auto expected = makeFlatVector<bool>(
-      {false, false, false, false, false, true, true, true, true});
+    auto expected = makeFlatVector<bool>(
+        {false, false, false, false, false, true, true, true, true});
 
-  testExpr(expected, "array_has_duplicates(C0)", {array});
+    testExpr(expected, "array_has_duplicates(C0)", {array});
+    type = ARRAY(VARCHAR(10));
+    VLOG(0) << "Repeat with VARCHAR(10)";
+  }
 }
 
 // Test non-inline (> 12 character length) strings.
 TEST_F(ArrayHasDuplicatesTest, longStrings) {
   using S = StringView;
 
-  auto array = makeNullableArrayVector<StringView>({
-      {S("red shiny car ahead"), S("blue clear sky above")},
-      {S("blue clear sky above"),
-       S("yellow rose flowers"),
-       std::nullopt,
-       S("blue clear sky above"),
-       S("orange beautiful sunset")},
-      {
-          S("red shiny car ahead"),
-          std::nullopt,
-          S("purple is an elegant color"),
-          S("red shiny car ahead"),
-          S("green plants make us happy"),
-          S("purple is an elegant color"),
-          std::nullopt,
-          S("purple is an elegant color"),
-      },
-  });
-  auto expected = makeFlatVector<bool>({false, true, true});
-  testExpr(expected, "array_has_duplicates(C0)", {array});
+  TypePtr type = ARRAY(VARCHAR());
+  for (int i = 0; i < 2; i++) {
+    auto array = makeNullableArrayVector<StringView>(
+        {
+            {S("red shiny car ahead"), S("blue clear sky above")},
+            {S("blue clear sky above"),
+             S("yellow rose flowers"),
+             std::nullopt,
+             S("blue clear sky above"),
+             S("orange beautiful sunset")},
+            {
+                S("red shiny car ahead"),
+                std::nullopt,
+                S("purple is an elegant color"),
+                S("red shiny car ahead"),
+                S("green plants make us happy"),
+                S("purple is an elegant color"),
+                std::nullopt,
+                S("purple is an elegant color"),
+            },
+        },
+        type);
+    auto expected = makeFlatVector<bool>({false, true, true});
+    testExpr(expected, "array_has_duplicates(C0)", {array});
+    type = ARRAY(VARCHAR(50));
+  }
 }
 
 TEST_F(ArrayHasDuplicatesTest, nullFreeBigints) {

--- a/velox/functions/prestosql/tests/ArrayMinTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayMinTest.cpp
@@ -84,37 +84,50 @@ class ArrayMinTest : public FunctionBaseTest {
   void testInLineVarcharNullable() {
     using S = StringView;
 
-    auto arrayVector = makeNullableArrayVector<StringView>({
-        {S("red"), S("blue")},
-        {std::nullopt, S("blue"), S("yellow"), S("orange")},
-        {},
-        {S("red"), S("purple"), S("green")},
-    });
-    auto expected = makeNullableFlatVector<StringView>(
-        {S("blue"), std::nullopt, std::nullopt, S("green")});
-    testExpr<StringView>(expected, "array_min(C0)", {arrayVector});
+    TypePtr inputType = VARCHAR();
+    for (int loop = 0; loop < 2; ++loop) {
+      auto arrayVector = makeNullableArrayVector<StringView>(
+          {
+              {S("red"), S("blue")},
+              {std::nullopt, S("blue"), S("yellow"), S("orange")},
+              {},
+              {S("red"), S("purple"), S("green")},
+          },
+          ARRAY(inputType));
+      auto expected = makeNullableFlatVector<StringView>(
+          {S("blue"), std::nullopt, std::nullopt, S("green")}, VARCHAR());
+      testExpr<StringView>(expected, "array_min(C0)", {arrayVector});
+      inputType = VARCHAR(12);
+    }
   }
 
   void testVarcharNullable() {
     using S = StringView;
-    // use > 12 length string to avoid inlining
-    auto arrayVector = makeNullableArrayVector<StringView>({
-        {S("red shiny car ahead"), S("blue clear sky above")},
-        {std::nullopt,
-         S("blue clear sky above"),
-         S("yellow rose flowers"),
-         S("orange beautiful sunset")},
-        {},
-        {S("red shiny car ahead"),
-         S("purple is an elegant color"),
-         S("green plants make us happy")},
-    });
-    auto expected = makeNullableFlatVector<StringView>(
-        {S("blue clear sky above"),
-         std::nullopt,
-         std::nullopt,
-         S("green plants make us happy")});
-    testExpr<StringView>(expected, "array_min(C0)", {arrayVector});
+    TypePtr inputType = VARCHAR();
+    for (int loop = 0; loop < 2; ++loop) {
+      // use > 12 length string to avoid inlining
+      auto arrayVector = makeNullableArrayVector<StringView>(
+          {
+              {S("red shiny car ahead"), S("blue clear sky above")},
+              {std::nullopt,
+               S("blue clear sky above"),
+               S("yellow rose flowers"),
+               S("orange beautiful sunset")},
+              {},
+              {S("red shiny car ahead"),
+               S("purple is an elegant color"),
+               S("green plants make us happy")},
+          },
+          ARRAY(inputType));
+      auto expected = makeNullableFlatVector<StringView>(
+          {S("blue clear sky above"),
+           std::nullopt,
+           std::nullopt,
+           S("green plants make us happy")},
+          VARCHAR());
+      testExpr<StringView>(expected, "array_min(C0)", {arrayVector});
+      inputType = VARCHAR(50);
+    }
   }
 
   void testBoolNullable() {

--- a/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
@@ -391,7 +391,8 @@ TEST_F(BinaryFunctionsTest, toHex) {
       toHex("Hello World from Velox!"));
 
   const auto toHexFromBase64 = [&](std::optional<std::string> value) {
-    return evaluateOnce<std::string>("to_hex(from_base64(c0))", value);
+    return evaluateOnceWithVarcharArgs<std::string>(
+        "to_hex(from_base64(c0))", value);
   };
 
   EXPECT_EQ(
@@ -401,7 +402,7 @@ TEST_F(BinaryFunctionsTest, toHex) {
 
 TEST_F(BinaryFunctionsTest, fromHex) {
   const auto fromHex = [&](std::optional<std::string> value) {
-    return evaluateOnce<std::string>("from_hex(c0)", value);
+    return evaluateOnceWithVarcharArgs<std::string>("from_hex(c0)", value);
   };
 
   EXPECT_EQ(std::nullopt, fromHex(std::nullopt));
@@ -424,7 +425,8 @@ TEST_F(BinaryFunctionsTest, fromHex) {
   EXPECT_THROW(fromHex("fff"), VeloxUserError);
 
   const auto fromHexToBase64 = [&](std::optional<std::string> value) {
-    return evaluateOnce<std::string>("to_base64(from_hex(c0))", value);
+    return evaluateOnceWithVarcharArgs<std::string>(
+        "to_base64(from_hex(c0))", value);
   };
   EXPECT_EQ(
       "12PasXXaWBQ0k1T88jiF",
@@ -453,7 +455,7 @@ TEST_F(BinaryFunctionsTest, toBase64) {
     return evaluateOnce<std::string>("to_base64(cast(c0 as varbinary))", value);
   };
   const auto fromHex = [&](std::optional<std::string> value) {
-    return evaluateOnce<std::string>("from_hex(c0)", value);
+    return evaluateOnceWithVarcharArgs<std::string>("from_hex(c0)", value);
   };
 
   EXPECT_EQ(std::nullopt, toBase64(std::nullopt));
@@ -468,11 +470,11 @@ TEST_F(BinaryFunctionsTest, toBase64) {
 
 TEST_F(BinaryFunctionsTest, toBase64Url) {
   const auto toBase64Url = [&](std::optional<std::string> value) {
-    return evaluateOnce<std::string>(
+    return evaluateOnceWithVarcharArgs<std::string>(
         "to_base64url(cast(c0 as varbinary))", value);
   };
   const auto fromHex = [&](std::optional<std::string> value) {
-    return evaluateOnce<std::string>("from_hex(c0)", value);
+    return evaluateOnceWithVarcharArgs<std::string>("from_hex(c0)", value);
   };
 
   EXPECT_EQ(std::nullopt, toBase64Url(std::nullopt));
@@ -490,17 +492,10 @@ TEST_F(BinaryFunctionsTest, fromBase64) {
   const auto fromBase64 = [&](std::optional<std::string> value) {
     // from_base64 allows VARCHAR and VARBINARY inputs.
     auto result =
-        evaluateOnce<std::string>("from_base64(c0)", VARCHAR(), value);
+        evaluateOnceWithVarcharArgs<std::string>("from_base64(c0)", value);
     auto otherResult =
         evaluateOnce<std::string>("from_base64(c0)", VARBINARY(), value);
-
-    VELOX_CHECK_EQ(result.has_value(), otherResult.has_value());
-
-    if (!result.has_value()) {
-      return result;
-    }
-
-    VELOX_CHECK_EQ(result.value(), otherResult.value());
+    EXPECT_EQ(result, otherResult);
     return result;
   };
 
@@ -535,10 +530,12 @@ TEST_F(BinaryFunctionsTest, fromBase64) {
 
 TEST_F(BinaryFunctionsTest, fromBase64Url) {
   const auto fromHex = [&](std::optional<std::string> value) {
-    return evaluateOnce<std::string>("from_hex(cast(c0 as varchar))", value);
+    return evaluateOnceWithVarcharArgs<std::string>(
+        "from_hex(cast(c0 as varchar))", value);
   };
   const auto fromBase64Url = [&](std::optional<std::string> value) {
-    return evaluateOnce<std::string>("from_base64url(c0)", value);
+    return evaluateOnceWithVarcharArgs<std::string>(
+        "from_base64url(c0)", value);
   };
 
   EXPECT_EQ(std::nullopt, fromBase64Url(std::nullopt));

--- a/velox/functions/prestosql/tests/ComparisonsTest.cpp
+++ b/velox/functions/prestosql/tests/ComparisonsTest.cpp
@@ -158,15 +158,12 @@ TEST_F(ComparisonsTest, between) {
 }
 
 TEST_F(ComparisonsTest, betweenVarchar) {
-  using S = StringView;
-
   const auto between = [&](std::optional<std::string> s) {
-    auto expr = "c0 between 'mango' and 'pear'";
-    if (s.has_value()) {
-      return evaluateOnce<bool>(expr, std::optional(S(s.value())));
-    } else {
-      return evaluateOnce<bool>(expr, std::optional<S>());
-    }
+    const std::optional<std::string> lower = "mango";
+    const std::optional<std::string> upper = "pear";
+
+    auto expr = "c0 between c1 and c2";
+    return evaluateOnceWithVarcharArgs<bool>(expr, s, lower, upper);
   };
 
   EXPECT_EQ(std::nullopt, between(std::nullopt));

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -279,7 +279,7 @@ TEST_F(DateTimeFunctionsTest, fromUnixtimeWithTimeZone) {
   const auto fromUnixtime = [&](std::optional<double> timestamp,
                                 std::optional<std::string> timezoneName) {
     return TimestampWithTimezone::unpack(
-        evaluateOnce<int64_t>(
+        evaluateOnceWithVarcharArgs<int64_t>(
             "from_unixtime(c0, c1)", timestamp, timezoneName));
   };
 
@@ -2254,8 +2254,12 @@ TEST_F(DateTimeFunctionsTest, extractFromIntervalYearMonth) {
 TEST_F(DateTimeFunctionsTest, dateTrunc) {
   const auto dateTrunc = [&](const std::string& unit,
                              std::optional<Timestamp> timestamp) {
-    return evaluateOnce<Timestamp>(
+    auto resultWithVarcharN = evaluateOnceWithVarcharArgs<Timestamp>(
+        "date_trunc(c0, c1)", std::make_optional(unit), timestamp);
+    auto result = evaluateOnce<Timestamp>(
         fmt::format("date_trunc('{}', c0)", unit), timestamp);
+    EXPECT_EQ(result, resultWithVarcharN);
+    return result;
   };
 
   disableAdjustTimestampToTimezone();
@@ -2365,8 +2369,15 @@ TEST_F(DateTimeFunctionsTest, dateTrunc) {
 TEST_F(DateTimeFunctionsTest, dateTruncDate) {
   const auto dateTrunc = [&](const std::string& unit,
                              std::optional<int32_t> date) {
-    return evaluateOnce<int32_t>(
+    auto resultWithVarcharN = evaluateOnceWithVarcharArgs<int32_t>(
+        "date_trunc(c0, c1)",
+        {VARCHAR(), DATE()},
+        std::make_optional(unit),
+        date);
+    auto result = evaluateOnce<int32_t>(
         fmt::format("date_trunc('{}', c0)", unit), DATE(), date);
+    EXPECT_EQ(result, resultWithVarcharN);
+    return result;
   };
 
   EXPECT_EQ(std::nullopt, dateTrunc("year", std::nullopt));
@@ -2402,8 +2413,15 @@ TEST_F(DateTimeFunctionsTest, dateTruncDate) {
 TEST_F(DateTimeFunctionsTest, dateTruncDateForWeek) {
   const auto dateTrunc = [&](const std::string& unit,
                              std::optional<int32_t> date) {
-    return evaluateOnce<int32_t>(
+    auto resultWithVarcharN = evaluateOnceWithVarcharArgs<int32_t>(
+        "date_trunc(c0, c1)",
+        {VARCHAR(), DATE()},
+        std::make_optional(unit),
+        date);
+    auto result = evaluateOnce<int32_t>(
         fmt::format("date_trunc('{}', c0)", unit), DATE(), date);
+    EXPECT_EQ(result, resultWithVarcharN);
+    return result;
   };
 
   // Date(19576) is 2023-08-07, which is Monday, should return Monday
@@ -2432,8 +2450,12 @@ TEST_F(DateTimeFunctionsTest, dateTruncDateForWeek) {
 TEST_F(DateTimeFunctionsTest, dateTruncTimeStampForWeek) {
   const auto dateTrunc = [&](const std::string& unit,
                              std::optional<Timestamp> timestamp) {
-    return evaluateOnce<Timestamp>(
+    auto resultWithVarcharN = evaluateOnceWithVarcharArgs<Timestamp>(
+        "date_trunc(c0, c1)", std::make_optional(unit), timestamp);
+    auto result = evaluateOnce<Timestamp>(
         fmt::format("date_trunc('{}', c0)", unit), timestamp);
+    EXPECT_EQ(result, resultWithVarcharN);
+    return result;
   };
 
   EXPECT_EQ(
@@ -2468,14 +2490,22 @@ TEST_F(DateTimeFunctionsTest, dateTruncTimeStampWithTimezoneForWeek) {
                                      int64_t inputTimestamp,
                                      const std::string& timeZone,
                                      int64_t expectedTimestamp) {
+    auto resultWithVarcharN = evaluateOnceWithVarcharArgs<int64_t>(
+        "date_trunc(c0, c1)",
+        {VARCHAR(), TIMESTAMP_WITH_TIME_ZONE()},
+        std::make_optional(truncUnit),
+        TimestampWithTimezone::pack(
+            TimestampWithTimezone(inputTimestamp, timeZone)));
+    auto result = evaluateOnce<int64_t>(
+        fmt::format("date_trunc('{}', c0)", truncUnit),
+        TIMESTAMP_WITH_TIME_ZONE(),
+        TimestampWithTimezone::pack(
+            TimestampWithTimezone(inputTimestamp, timeZone)));
+    EXPECT_EQ(result, resultWithVarcharN);
     EXPECT_EQ(
         TimestampWithTimezone::pack(
             TimestampWithTimezone(expectedTimestamp, timeZone.c_str())),
-        evaluateOnce<int64_t>(
-            fmt::format("date_trunc('{}', c0)", truncUnit),
-            TIMESTAMP_WITH_TIME_ZONE(),
-            TimestampWithTimezone::pack(
-                TimestampWithTimezone(inputTimestamp, timeZone))));
+        result);
   };
   // input 2023-08-07 00:00:00 (19576 days) with timeZone +01:00
   // output 2023-08-06 23:00:00" in UTC.(1691362800000)
@@ -2510,23 +2540,38 @@ TEST_F(DateTimeFunctionsTest, dateTruncTimeStampWithTimezoneForWeek) {
 }
 
 TEST_F(DateTimeFunctionsTest, dateTruncTimeStampWithTimezoneStringForWeek) {
-  const auto evaluateDateTruncFromStrings = [&](const std::string& truncUnit,
-                                                const std::string&
-                                                    inputTimestamp,
-                                                const std::string&
-                                                    expectedTimestamp) {
-    assertEqualVectors(
-        evaluate<FlatVector<int64_t>>(
-            "parse_datetime(c0, 'YYYY-MM-dd+HH:mm:ssZZ')",
-            makeRowVector({makeNullableFlatVector<StringView>(
-                {StringView{expectedTimestamp}})})),
-        evaluate<FlatVector<int64_t>>(
+  constexpr std::string_view kDateTimeFormat = "YYYY-MM-dd+HH:mm:ssZZ";
+  const auto kFormatType = VARCHAR(kDateTimeFormat.size());
+  const auto evaluateDateTruncFromStrings =
+      [&](const std::string& truncUnit,
+          const std::string& inputTimestamp,
+          const std::string& expectedTimestamp) {
+        const auto kUnitType = VARCHAR(truncUnit.size());
+        const auto kInputType = VARCHAR(inputTimestamp.size());
+        auto resultWithVarcharN = evaluate<FlatVector<int64_t>>(
+            "date_trunc(c0, parse_datetime(c1, c2))",
+            makeRowVector(
+                {makeNullableFlatVector<StringView>(
+                     {StringView{truncUnit}}, kUnitType),
+                 makeNullableFlatVector<StringView>(
+                     {StringView{inputTimestamp}}, kInputType),
+                 makeNullableFlatVector<StringView>(
+                     {StringView{kDateTimeFormat}}, kFormatType)}));
+        auto result = evaluate<FlatVector<int64_t>>(
             fmt::format(
-                "date_trunc('{}', parse_datetime(c0, 'YYYY-MM-dd+HH:mm:ssZZ'))",
-                truncUnit),
+                "date_trunc('{}', parse_datetime(c0, '{}'))",
+                truncUnit,
+                kDateTimeFormat),
             makeRowVector({makeNullableFlatVector<StringView>(
-                {StringView{inputTimestamp}})})));
-  };
+                {StringView{inputTimestamp}})}));
+        assertEqualVectors(result, resultWithVarcharN);
+        assertEqualVectors(
+            evaluate<FlatVector<int64_t>>(
+                "parse_datetime(c0, 'YYYY-MM-dd+HH:mm:ssZZ')",
+                makeRowVector({makeNullableFlatVector<StringView>(
+                    {StringView{expectedTimestamp}})})),
+            result);
+      };
   // Monday
   evaluateDateTruncFromStrings(
       "week", "2023-08-07+23:01:02+14:00", "2023-08-07+00:00:00+14:00");
@@ -2558,14 +2603,22 @@ TEST_F(DateTimeFunctionsTest, dateTruncTimestampWithTimezone) {
                                      int64_t inputTimestamp,
                                      const std::string& timeZone,
                                      int64_t expectedTimestamp) {
+    auto resultWithVarcharN = evaluateOnceWithVarcharArgs<int64_t>(
+        "date_trunc(c0, c1)",
+        {VARCHAR(), TIMESTAMP_WITH_TIME_ZONE()},
+        std::make_optional(truncUnit),
+        TimestampWithTimezone::pack(
+            TimestampWithTimezone(inputTimestamp, timeZone)));
+    auto result = evaluateOnce<int64_t>(
+        fmt::format("date_trunc('{}', c0)", truncUnit),
+        TIMESTAMP_WITH_TIME_ZONE(),
+        TimestampWithTimezone::pack(
+            TimestampWithTimezone(inputTimestamp, timeZone)));
+    EXPECT_EQ(result, resultWithVarcharN);
     EXPECT_EQ(
         TimestampWithTimezone::pack(
             TimestampWithTimezone(expectedTimestamp, timeZone.c_str())),
-        evaluateOnce<int64_t>(
-            fmt::format("date_trunc('{}', c0)", truncUnit),
-            TIMESTAMP_WITH_TIME_ZONE(),
-            TimestampWithTimezone::pack(
-                TimestampWithTimezone(inputTimestamp, timeZone))));
+        result);
   };
 
   evaluateDateTrunc("second", 123, "+01:00", 0);
@@ -2668,23 +2721,36 @@ TEST_F(DateTimeFunctionsTest, dateTruncTimestampWithTimezone) {
   evaluateDateTrunc(
       "hour", 1710064799999, "America/Los_Angeles", 1710061200000);
 
-  const auto evaluateDateTruncFromStrings = [&](const std::string& truncUnit,
-                                                const std::string&
-                                                    inputTimestamp,
-                                                const std::string&
-                                                    expectedTimestamp) {
-    assertEqualVectors(
-        evaluate<FlatVector<int64_t>>(
-            "parse_datetime(c0, 'YYYY-MM-dd+HH:mm:ssZZ')",
-            makeRowVector({makeNullableFlatVector<StringView>(
-                {StringView{expectedTimestamp}})})),
-        evaluate<FlatVector<int64_t>>(
+  constexpr std::string_view kDateTimeFormat = "YYYY-MM-dd+HH:mm:ssZZ";
+  const auto type = VARCHAR(100);
+  const auto evaluateDateTruncFromStrings =
+      [&](const std::string& truncUnit,
+          const std::string& inputTimestamp,
+          const std::string& expectedTimestamp) {
+        auto resultWithVarcharN = evaluate<FlatVector<int64_t>>(
+            "date_trunc(c0, parse_datetime(c1, c2))",
+            makeRowVector(
+                {makeNullableFlatVector<StringView>(
+                     {StringView{truncUnit}}, type),
+                 makeNullableFlatVector<StringView>(
+                     {StringView{inputTimestamp}}, type),
+                 makeNullableFlatVector<StringView>(
+                     {StringView{kDateTimeFormat}}, type)}));
+        auto result = evaluate<FlatVector<int64_t>>(
             fmt::format(
-                "date_trunc('{}', parse_datetime(c0, 'YYYY-MM-dd+HH:mm:ssZZ'))",
-                truncUnit),
+                "date_trunc('{}', parse_datetime(c0, '{}'))",
+                truncUnit,
+                kDateTimeFormat),
             makeRowVector({makeNullableFlatVector<StringView>(
-                {StringView{inputTimestamp}})})));
-  };
+                {StringView{inputTimestamp}})}));
+        assertEqualVectors(result, resultWithVarcharN);
+        assertEqualVectors(
+            evaluate<FlatVector<int64_t>>(
+                fmt::format("parse_datetime(c0, '{}')", kDateTimeFormat),
+                makeRowVector({makeNullableFlatVector<StringView>(
+                    {StringView{expectedTimestamp}})})),
+            result);
+      };
 
   evaluateDateTruncFromStrings(
       "minute", "1972-05-20+23:01:02+14:00", "1972-05-20+23:01:00+14:00");
@@ -2716,11 +2782,19 @@ TEST_F(DateTimeFunctionsTest, dateAddDate) {
   const auto dateAdd = [&](const std::string& unit,
                            std::optional<int32_t> value,
                            std::optional<int32_t> date) {
-    return evaluateOnce<int32_t>(
+    auto resultWithVarcharN = evaluateOnceWithVarcharArgs<int32_t>(
+        "date_add(c0, c1, c2)",
+        {VARCHAR(), INTEGER(), DATE()},
+        make_optional(unit),
+        value,
+        date);
+    auto result = evaluateOnce<int32_t>(
         fmt::format("date_add('{}', c0, c1)", unit),
         {INTEGER(), DATE()},
         value,
         date);
+    EXPECT_EQ(result, resultWithVarcharN);
+    return result;
   };
 
   // Check null behaviors
@@ -2773,8 +2847,16 @@ TEST_F(DateTimeFunctionsTest, dateAddTimestamp) {
   const auto dateAdd = [&](const std::string& unit,
                            std::optional<int32_t> value,
                            std::optional<Timestamp> timestamp) {
-    return evaluateOnce<Timestamp>(
+    auto resultWithVarcharN = evaluateOnceWithVarcharArgs<Timestamp>(
+        "date_add(c0, c1, c2)",
+        {VARCHAR(), INTEGER(), TIMESTAMP()},
+        make_optional(unit),
+        value,
+        timestamp);
+    auto result = evaluateOnce<Timestamp>(
         fmt::format("date_add('{}', c0, c1)", unit), value, timestamp);
+    EXPECT_EQ(result, resultWithVarcharN);
+    return result;
   };
 
   // Check null behaviors
@@ -3073,7 +3155,7 @@ TEST_F(DateTimeFunctionsTest, dateAddTimestampWithTimeZone) {
       [&](std::optional<std::string> unit,
           std::optional<int32_t> value,
           std::optional<TimestampWithTimezone> timestampWithTimezone) {
-        auto result = evaluateOnce<int64_t>(
+        auto result = evaluateOnceWithVarcharArgs<int64_t>(
             "date_add(c0, c1, c2)",
             {VARCHAR(), INTEGER(), TIMESTAMP_WITH_TIME_ZONE()},
             unit,
@@ -3102,24 +3184,38 @@ TEST_F(DateTimeFunctionsTest, dateAddTimestampWithTimeZone) {
       TimestampWithTimezone(1673136007, "-08:00"),
       dateAdd("millisecond", +7, TimestampWithTimezone(1673136000, "-08:00")));
 
-  const auto evaluateDateAddFromStrings = [&](const std::string& unit,
-                                              int32_t value,
-                                              const std::string& inputTimestamp,
-                                              const std::string&
-                                                  expectedTimestamp) {
-    assertEqualVectors(
-        evaluate<FlatVector<int64_t>>(
-            "parse_datetime(c0, 'YYYY-MM-dd+HH:mm:ssZZ')",
-            makeRowVector({makeNullableFlatVector<StringView>(
-                {StringView{expectedTimestamp}})})),
-        evaluate<FlatVector<int64_t>>(
+  constexpr std::string_view kDateTimeFormat = "YYYY-MM-dd+HH:mm:ssZZ";
+  const auto kType = VARCHAR(100);
+  const auto evaluateDateAddFromStrings =
+      [&](const std::string& unit,
+          int32_t value,
+          const std::string& inputTimestamp,
+          const std::string& expectedTimestamp) {
+        auto resultWithVarcharN = evaluate<FlatVector<int64_t>>(
+            "date_add(c0, c1, parse_datetime(c2, c3))",
+            makeRowVector(
+                {makeNullableFlatVector<StringView>({StringView{unit}}, kType),
+                 makeNullableFlatVector<int32_t>({value}),
+                 makeNullableFlatVector<StringView>(
+                     {StringView{inputTimestamp}}, kType),
+                 makeNullableFlatVector<StringView>(
+                     {StringView{kDateTimeFormat}}, kType)}));
+        auto result = evaluate<FlatVector<int64_t>>(
             fmt::format(
-                "date_add('{}', {}, parse_datetime(c0, 'YYYY-MM-dd+HH:mm:ssZZ'))",
+                "date_add('{}', {}, parse_datetime(c0, '{}'))",
                 unit,
-                value),
+                value,
+                kDateTimeFormat),
             makeRowVector({makeNullableFlatVector<StringView>(
-                {StringView{inputTimestamp}})})));
-  };
+                {StringView{inputTimestamp}})}));
+        assertEqualVectors(result, resultWithVarcharN);
+        assertEqualVectors(
+            evaluate<FlatVector<int64_t>>(
+                fmt::format("parse_datetime(c0, '{}')", kDateTimeFormat),
+                makeRowVector({makeNullableFlatVector<StringView>(
+                    {StringView{expectedTimestamp}})})),
+            result);
+      };
 
   evaluateDateAddFromStrings(
       "second", 3, "1972-05-20+23:01:02+14:00", "1972-05-20+23:01:05+14:00");
@@ -3156,7 +3252,7 @@ TEST_F(DateTimeFunctionsTest, dateAddTimestampWithTimeZone) {
   auto dateAddAndCast = [&](std::optional<std::string> unit,
                             std::optional<int32_t> value,
                             std::optional<std::string> timestampString) {
-    return evaluateOnce<std::string>(
+    return evaluateOnceWithVarcharArgs<std::string>(
         "cast(date_add(c0, c1, cast(c2 as timestamp with time zone)) as VARCHAR)",
         unit,
         value,
@@ -3370,11 +3466,19 @@ TEST_F(DateTimeFunctionsTest, dateDiffDate) {
   const auto dateDiff = [&](const std::string& unit,
                             std::optional<int32_t> date1,
                             std::optional<int32_t> date2) {
-    return evaluateOnce<int64_t>(
+    auto resultWithVarcharN = evaluateOnceWithVarcharArgs<int64_t>(
+        "date_diff(c0, c1, c2)",
+        {VARCHAR(), DATE(), DATE()},
+        std::make_optional(unit),
+        date1,
+        date2);
+    auto result = evaluateOnce<int64_t>(
         fmt::format("date_diff('{}', c0, c1)", unit),
         {DATE(), DATE()},
         date1,
         date2);
+    EXPECT_EQ(result, resultWithVarcharN);
+    return result;
   };
 
   // Check null behaviors
@@ -3458,8 +3562,15 @@ TEST_F(DateTimeFunctionsTest, dateDiffTimestamp) {
   const auto dateDiff = [&](const std::string& unit,
                             std::optional<Timestamp> timestamp1,
                             std::optional<Timestamp> timestamp2) {
-    return evaluateOnce<int64_t>(
+    auto resultWithVarcharN = evaluateOnceWithVarcharArgs<int64_t>(
+        "date_diff(c0, c1, c2)",
+        std::make_optional(unit),
+        timestamp1,
+        timestamp2);
+    auto result = evaluateOnce<int64_t>(
         fmt::format("date_diff('{}', c0, c1)", unit), timestamp1, timestamp2);
+    EXPECT_EQ(result, resultWithVarcharN);
+    return result;
   };
 
   // Check null behaviors
@@ -3736,7 +3847,7 @@ TEST_F(DateTimeFunctionsTest, dateDiffTimestampWithTimezone) {
   const auto dateDiff = [&](std::optional<std::string> unit,
                             std::optional<TimestampWithTimezone> input1,
                             std::optional<TimestampWithTimezone> input2) {
-    return evaluateOnce<int64_t>(
+    return evaluateOnceWithVarcharArgs<int64_t>(
         "date_diff(c0, c1, c2)",
         {VARCHAR(), TIMESTAMP_WITH_TIME_ZONE(), TIMESTAMP_WITH_TIME_ZONE()},
         unit,
@@ -3849,7 +3960,7 @@ TEST_F(DateTimeFunctionsTest, dateDiffTimestampWithTimezone) {
   auto dateDiffAndCast = [&](std::optional<std::string> unit,
                              std::optional<std::string> timestampString1,
                              std::optional<std::string> timestampString2) {
-    return evaluateOnce<int64_t>(
+    return evaluateOnceWithVarcharArgs<int64_t>(
         "date_diff(c0, cast(c1 as timestamp with time zone), cast(c2 as timestamp with time zone))",
         unit,
         timestampString1,
@@ -4000,7 +4111,7 @@ TEST_F(DateTimeFunctionsTest, parseDatetimeRoundtrip) {
   const auto parseDatetimeRoundTrip =
       [&](const std::optional<std::string>& input,
           const std::optional<std::string>& format) {
-        return evaluateOnce<std::string>(
+        return evaluateOnceWithVarcharArgs<std::string>(
             "cast(parse_datetime(c0, c1) as varchar)", input, format);
       };
 
@@ -4035,8 +4146,8 @@ TEST_F(DateTimeFunctionsTest, parseDatetimeRoundtrip) {
 TEST_F(DateTimeFunctionsTest, parseDatetime) {
   const auto parseDatetime = [&](const std::optional<std::string>& input,
                                  const std::optional<std::string>& format) {
-    auto result =
-        evaluateOnce<int64_t>("parse_datetime(c0, c1)", input, format);
+    auto result = evaluateOnceWithVarcharArgs<int64_t>(
+        "parse_datetime(c0, c1)", input, format);
     return TimestampWithTimezone::unpack(result);
   };
 
@@ -4211,7 +4322,7 @@ TEST_F(DateTimeFunctionsTest, parseDatetime) {
 TEST_F(DateTimeFunctionsTest, formatDateTime) {
   const auto formatDatetime = [&](std::optional<Timestamp> timestamp,
                                   std::optional<std::string> format) {
-    return evaluateOnce<std::string>(
+    return evaluateOnceWithVarcharArgs<std::string>(
         "format_datetime(c0, c1)", timestamp, format);
   };
 
@@ -4651,7 +4762,7 @@ TEST_F(DateTimeFunctionsTest, formatDateTimeTimezone) {
   const auto formatDatetimeWithTimezone =
       [&](std::optional<TimestampWithTimezone> timestampWithTimezone,
           std::optional<std::string> format) {
-        return evaluateOnce<std::string>(
+        return evaluateOnceWithVarcharArgs<std::string>(
             "format_datetime(c0, c1)",
             {TIMESTAMP_WITH_TIME_ZONE(), VARCHAR()},
             TimestampWithTimezone::pack(timestampWithTimezone),
@@ -4694,7 +4805,8 @@ TEST_F(DateTimeFunctionsTest, formatDateTimeTimezone) {
 TEST_F(DateTimeFunctionsTest, dateFormat) {
   const auto dateFormat = [&](std::optional<Timestamp> timestamp,
                               std::optional<std::string> format) {
-    return evaluateOnce<std::string>("date_format(c0, c1)", timestamp, format);
+    return evaluateOnceWithVarcharArgs<std::string>(
+        "date_format(c0, c1)", timestamp, format);
   };
 
   // Check null behaviors.
@@ -4955,10 +5067,11 @@ TEST_F(DateTimeFunctionsTest, dateFormatTimestampWithTimezone) {
   const auto dateFormatTimestampWithTimezone =
       [&](const std::string& formatString,
           std::optional<TimestampWithTimezone> timestampWithTimezone) {
-        return evaluateOnce<std::string>(
-            fmt::format("date_format(c0, '{}')", formatString),
-            TIMESTAMP_WITH_TIME_ZONE(),
-            TimestampWithTimezone::pack(timestampWithTimezone));
+        return evaluateOnceWithVarcharArgs<std::string>(
+            "date_format(c0, c1)",
+            {TIMESTAMP_WITH_TIME_ZONE(), VARCHAR()},
+            TimestampWithTimezone::pack(timestampWithTimezone),
+            std::make_optional(formatString));
       };
 
   EXPECT_EQ(
@@ -4996,7 +5109,8 @@ TEST_F(DateTimeFunctionsTest, dateFormatTimestampWithTimezone) {
 TEST_F(DateTimeFunctionsTest, test_week_year) {
   const auto dateFormat = [&](std::optional<Timestamp> timestamp,
                               std::optional<std::string> format) {
-    return evaluateOnce<std::string>("date_format(c0, c1)", timestamp, format);
+    return evaluateOnceWithVarcharArgs<std::string>(
+        "date_format(c0, c1)", timestamp, format);
   };
   auto rst_wy = dateFormat(Timestamp(1609545600, 0), "%x");
   EXPECT_EQ("2020", rst_wy);
@@ -5013,7 +5127,8 @@ TEST_F(DateTimeFunctionsTest, test_week_year) {
 
 TEST_F(DateTimeFunctionsTest, fromIso8601Date) {
   const auto fromIso = [&](const std::string& input) {
-    return evaluateOnce<int32_t, std::string>("from_iso8601_date(c0)", input);
+    return evaluateOnceWithVarcharArgs<int32_t, std::string>(
+        "from_iso8601_date(c0)", input);
   };
 
   EXPECT_EQ(0, fromIso("1970-01-01"));
@@ -5040,8 +5155,8 @@ TEST_F(DateTimeFunctionsTest, fromIso8601Date) {
 
 TEST_F(DateTimeFunctionsTest, fromIso8601Timestamp) {
   const auto fromIso = [&](const std::string& input) {
-    auto result =
-        evaluateOnce<int64_t, std::string>("from_iso8601_timestamp(c0)", input);
+    auto result = evaluateOnceWithVarcharArgs<int64_t, std::string>(
+        "from_iso8601_timestamp(c0)", input);
     return TimestampWithTimezone::unpack(result);
   };
 
@@ -5263,9 +5378,22 @@ TEST_F(DateTimeFunctionsTest, fromIso8601Timestamp) {
 }
 
 TEST_F(DateTimeFunctionsTest, dateParseMonthOfYearText) {
+  constexpr const char* kInputFormat = "%M_%Y";
+  constexpr const char* kOutputFormat = "%Y-%m";
   auto parseAndFormat = [&](std::optional<std::string> input) {
-    return evaluateOnce<std::string>(
-        "date_format(date_parse(c0, '%M_%Y'), '%Y-%m')", input);
+    auto resultWithVarcharN = evaluateOnceWithVarcharArgs<std::string>(
+        "date_format(date_parse(c0, c1), c2)",
+        input,
+        make_optional(std::string(kInputFormat)),
+        make_optional(std::string(kOutputFormat)));
+    auto result = evaluateOnce<std::string>(
+        fmt::format(
+            "date_format(date_parse(c0, '{}'), '{}')",
+            kInputFormat,
+            kOutputFormat),
+        input);
+    EXPECT_EQ(result, resultWithVarcharN);
+    return result;
   };
 
   EXPECT_EQ(parseAndFormat(std::nullopt), std::nullopt);
@@ -5331,7 +5459,8 @@ TEST_F(DateTimeFunctionsTest, dateParseMonthOfYearText) {
 TEST_F(DateTimeFunctionsTest, dateParse) {
   const auto dateParse = [&](std::optional<std::string> input,
                              std::optional<std::string> format) {
-    return evaluateOnce<Timestamp>("date_parse(c0, c1)", input, format);
+    return evaluateOnceWithVarcharArgs<Timestamp>(
+        "date_parse(c0, c1)", input, format);
   };
 
   // Check null behavior.
@@ -5386,7 +5515,7 @@ TEST_F(DateTimeFunctionsTest, dateParse) {
 
 TEST_F(DateTimeFunctionsTest, dateFunctionVarchar) {
   const auto dateFunction = [&](const std::optional<std::string>& dateString) {
-    return evaluateOnce<int32_t>("date(c0)", dateString);
+    return evaluateOnceWithVarcharArgs<int32_t>("date(c0)", dateString);
   };
 
   // Date(0) is 1970-01-01.
@@ -6257,7 +6386,7 @@ TEST_F(DateTimeFunctionsTest, toISO8601TimestampWithTimezone) {
 TEST_F(DateTimeFunctionsTest, atTimezoneTest) {
   const auto at_timezone = [&](std::optional<int64_t> timestampWithTimezone,
                                std::optional<std::string> targetTimezone) {
-    return evaluateOnce<int64_t>(
+    return evaluateOnceWithVarcharArgs<int64_t>(
         "at_timezone(c0, c1)",
         {TIMESTAMP_WITH_TIME_ZONE(), VARCHAR()},
         timestampWithTimezone,
@@ -6434,8 +6563,8 @@ TEST_F(DateTimeFunctionsTest, toMilliseconds) {
 
 TEST_F(DateTimeFunctionsTest, parseDuration) {
   const auto parseDuration = [&](std::optional<std::string> amountUnit) {
-    return evaluateOnce<int64_t>(
-        "parse_duration(c0)", VARCHAR(), std::move(amountUnit));
+    return evaluateOnceWithVarcharArgs<int64_t>(
+        "parse_duration(c0)", std::move(amountUnit));
   };
   // All units
   int64_t expectedValue = 0;

--- a/velox/functions/prestosql/tests/FailTest.cpp
+++ b/velox/functions/prestosql/tests/FailTest.cpp
@@ -28,18 +28,27 @@ class FailTest : public functions::test::FunctionBaseTest {};
 
 TEST_F(FailTest, basic) {
   auto message = std::optional("test error message");
+  auto type = VARCHAR(strlen(message.value()));
   VELOX_ASSERT_USER_THROW(
       evaluateOnce<UnknownValue>("fail(c0)", message), message.value());
+  VELOX_ASSERT_USER_THROW(
+      evaluateOnce<UnknownValue>("fail(c0)", type, message), message.value());
 
-  EXPECT_EQ(std::nullopt, evaluateOnce<UnknownValue>("try(fail(c0))", message));
+  EXPECT_EQ(
+      std::nullopt,
+      evaluateOnceWithVarcharArgs<UnknownValue>("try(fail(c0))", message));
 
   VELOX_ASSERT_USER_THROW(
       evaluateOnce<UnknownValue>("fail(123::integer, c0)", message),
       message.value());
+  VELOX_ASSERT_USER_THROW(
+      evaluateOnce<UnknownValue>("fail(123::integer, c0)", type, message),
+      message.value());
 
   EXPECT_EQ(
       std::nullopt,
-      evaluateOnce<UnknownValue>("try(fail(123::integer, c0))", message));
+      evaluateOnceWithVarcharArgs<UnknownValue>(
+          "try(fail(123::integer, c0))", message));
 }
 
 TEST_F(FailTest, json) {

--- a/velox/functions/prestosql/tests/FromUtf8Test.cpp
+++ b/velox/functions/prestosql/tests/FromUtf8Test.cpp
@@ -39,11 +39,8 @@ class FromUtf8Test : public test::FunctionBaseTest {
   std::optional<std::string> fromUtf8(
       std::optional<std::string> value,
       std::optional<std::string> replacement) {
-    auto data = makeRowVector({
-        makeNullableFlatVector<std::string>({value}, VARBINARY()),
-        makeNullableFlatVector<std::string>({replacement}),
-    });
-    return evaluateOnce<std::string>("from_utf8(c0, c1)", data);
+    return evaluateOnceWithVarcharArgs<std::string>(
+        "from_utf8(c0, c1)", {VARBINARY(), VARCHAR()}, value, replacement);
   }
 
   static const char* kPound; // 2-byte pound sign.

--- a/velox/functions/prestosql/tests/ParsePrestoDataSizeTest.cpp
+++ b/velox/functions/prestosql/tests/ParsePrestoDataSizeTest.cpp
@@ -34,12 +34,15 @@ class ParsePrestoDataSizeTest : public FunctionBaseTest {
     test::assertEqualVectors(expected, result);
   }
 
-  void assertSize(std::string input, const std::string& outputStr) {
+  void assertSize(const std::string& input, const std::string& outputStr) {
     auto op = makeNullableFlatVector<std::string>({input});
+    auto opWithVarcharN =
+        makeNullableFlatVector<std::string>({input}, VARCHAR(input.size()));
     int128_t outputInt = facebook::velox::HugeInt::parse(outputStr);
     auto expected =
         makeNullableFlatVector<int128_t>({outputInt}, DECIMAL(38, 0));
     assertVectors("parse_presto_data_size(c0)", op, expected);
+    assertVectors("parse_presto_data_size(c0)", opWithVarcharN, expected);
   }
 
   template <typename T, typename U = T, typename V = T>

--- a/velox/functions/prestosql/tests/TypeOfTest.cpp
+++ b/velox/functions/prestosql/tests/TypeOfTest.cpp
@@ -58,6 +58,7 @@ TEST_F(TypeOfTest, basic) {
   EXPECT_EQ("decimal(25,7)", typeOf(DECIMAL(25, 7)));
 
   EXPECT_EQ("varchar", typeOf(VARCHAR()));
+  EXPECT_EQ("varchar(10)", typeOf(VARCHAR(10)));
   EXPECT_EQ("varbinary", typeOf(VARBINARY()));
 
   EXPECT_EQ("timestamp", typeOf(TIMESTAMP()));

--- a/velox/functions/prestosql/tests/URLFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/URLFunctionsTest.cpp
@@ -31,12 +31,12 @@ class URLFunctionsTest : public functions::test::FunctionBaseTest {
       const std::optional<int32_t> expectedPort) {
     const auto extractFn = [&](const std::string& fn,
                                const std::optional<std::string>& a) {
-      return evaluateOnce<std::string>(
+      return evaluateOnceWithVarcharArgs<std::string>(
           fmt::format("url_extract_{}(c0)", fn), a);
     };
 
     const auto extractPort = [&](const std::optional<std::string>& a) {
-      return evaluateOnce<int64_t>("url_extract_port(c0)", a);
+      return evaluateOnceWithVarcharArgs<int64_t>("url_extract_port(c0)", a);
     };
 
     EXPECT_EQ(extractFn("protocol", url), expectedProtocol);
@@ -186,7 +186,8 @@ TEST_F(URLFunctionsTest, validateURL) {
 
 TEST_F(URLFunctionsTest, extractProtocol) {
   const auto extractProtocol = [&](const std::optional<std::string>& url) {
-    return evaluateOnce<std::string>("url_extract_protocol(c0)", url);
+    return evaluateOnceWithVarcharArgs<std::string>(
+        "url_extract_protocol(c0)", url);
   };
 
   // Test minimal protocol.
@@ -205,7 +206,8 @@ TEST_F(URLFunctionsTest, extractProtocol) {
 
 TEST_F(URLFunctionsTest, extractHostIPv4) {
   const auto extractHost = [&](const std::optional<std::string>& url) {
-    return evaluateOnce<std::string>("url_extract_host(c0)", url);
+    return evaluateOnceWithVarcharArgs<std::string>(
+        "url_extract_host(c0)", url);
   };
 
   // Upper bounds of the ranges of the rules for IPv4 dec-octets.
@@ -226,7 +228,8 @@ TEST_F(URLFunctionsTest, extractHostIPv4) {
 
 TEST_F(URLFunctionsTest, extractHostIPv6) {
   const auto extractHost = [&](const std::optional<std::string>& url) {
-    return evaluateOnce<std::string>("url_extract_host(c0)", url);
+    return evaluateOnceWithVarcharArgs<std::string>(
+        "url_extract_host(c0)", url);
   };
 
   // 8 hex blocks.
@@ -317,7 +320,8 @@ TEST_F(URLFunctionsTest, extractHostIPv6) {
 
 TEST_F(URLFunctionsTest, extractHostIPvFuture) {
   const auto extractHost = [&](const std::optional<std::string>& url) {
-    return evaluateOnce<std::string>("url_extract_host(c0)", url);
+    return evaluateOnceWithVarcharArgs<std::string>(
+        "url_extract_host(c0)", url);
   };
 
   // Test minimal.
@@ -346,7 +350,8 @@ TEST_F(URLFunctionsTest, extractHostIPvFuture) {
 
 TEST_F(URLFunctionsTest, extractHostRegName) {
   const auto extractHost = [&](const std::optional<std::string>& url) {
-    return evaluateOnce<std::string>("url_extract_host(c0)", url);
+    return evaluateOnceWithVarcharArgs<std::string>(
+        "url_extract_host(c0)", url);
   };
 
   // Test minimal.
@@ -390,7 +395,8 @@ TEST_F(URLFunctionsTest, extractHostRegName) {
 
 TEST_F(URLFunctionsTest, extractPath) {
   const auto extractPath = [&](const std::optional<std::string>& url) {
-    return evaluateOnce<std::string>("url_extract_path(c0)", url);
+    return evaluateOnceWithVarcharArgs<std::string>(
+        "url_extract_path(c0)", url);
   };
 
   EXPECT_EQ(
@@ -425,7 +431,7 @@ TEST_F(URLFunctionsTest, extractPath) {
 
 TEST_F(URLFunctionsTest, extractPort) {
   const auto extractPort = [&](const std::optional<std::string>& url) {
-    return evaluateOnce<int64_t>("url_extract_port(c0)", url);
+    return evaluateOnceWithVarcharArgs<int64_t>("url_extract_port(c0)", url);
   };
 
   // 0-4 valid.
@@ -441,7 +447,8 @@ TEST_F(URLFunctionsTest, extractPort) {
 
 TEST_F(URLFunctionsTest, extractHostWithUserInfo) {
   const auto extractHost = [&](const std::optional<std::string>& url) {
-    return evaluateOnce<std::string>("url_extract_host(c0)", url);
+    return evaluateOnceWithVarcharArgs<std::string>(
+        "url_extract_host(c0)", url);
   };
 
   // Test extracting a host when user info is present.
@@ -459,7 +466,8 @@ TEST_F(URLFunctionsTest, extractHostWithUserInfo) {
 
 TEST_F(URLFunctionsTest, extractQuery) {
   const auto extractQuery = [&](const std::optional<std::string>& url) {
-    return evaluateOnce<std::string>("url_extract_query(c0)", url);
+    return evaluateOnceWithVarcharArgs<std::string>(
+        "url_extract_query(c0)", url);
   };
 
   // Test empty query.
@@ -485,7 +493,8 @@ TEST_F(URLFunctionsTest, extractQuery) {
 
 TEST_F(URLFunctionsTest, extractFragment) {
   const auto extractFragment = [&](const std::optional<std::string>& url) {
-    return evaluateOnce<std::string>("url_extract_fragment(c0)", url);
+    return evaluateOnceWithVarcharArgs<std::string>(
+        "url_extract_fragment(c0)", url);
   };
 
   // Test empty fragment.
@@ -512,7 +521,8 @@ TEST_F(URLFunctionsTest, extractFragment) {
 TEST_F(URLFunctionsTest, extractParameter) {
   const auto extractParam = [&](const std::optional<std::string>& a,
                                 const std::optional<std::string>& b) {
-    return evaluateOnce<std::string>("url_extract_parameter(c0, c1)", a, b);
+    return evaluateOnceWithVarcharArgs<std::string>(
+        "url_extract_parameter(c0, c1)", a, b);
   };
 
   EXPECT_EQ(
@@ -571,7 +581,7 @@ TEST_F(URLFunctionsTest, extractParameter) {
 
 TEST_F(URLFunctionsTest, urlEncode) {
   const auto urlEncode = [&](std::optional<std::string> value) {
-    return evaluateOnce<std::string>("url_encode(c0)", value);
+    return evaluateOnceWithVarcharArgs<std::string>("url_encode(c0)", value);
   };
 
   EXPECT_EQ(std::nullopt, urlEncode(std::nullopt));
@@ -617,7 +627,7 @@ TEST_F(URLFunctionsTest, urlEncode) {
 
 TEST_F(URLFunctionsTest, urlDecode) {
   const auto urlDecode = [&](std::optional<std::string> value) {
-    return evaluateOnce<std::string>("url_decode(c0)", value);
+    return evaluateOnceWithVarcharArgs<std::string>("url_decode(c0)", value);
   };
 
   EXPECT_EQ(std::nullopt, urlDecode(std::nullopt));

--- a/velox/functions/prestosql/types/UuidRegistration.cpp
+++ b/velox/functions/prestosql/types/UuidRegistration.cpp
@@ -159,6 +159,30 @@ void registerUuidType() {
       {.fromType = "VARBINARY", .toType = "UUID"},
       {.fromType = "UUID", .toType = "VARCHAR"},
       {.fromType = "UUID", .toType = "VARBINARY"},
+      {.fromType = "VARCHARN",
+       .toType = "UUID",
+       .validator =
+           [](const TypePtr& from, const TypePtr& to) {
+             return (from->isVarcharN() && getVarcharLength(*from) < 36);
+           }},
+      {.fromType = "VARBINARYN",
+       .toType = "UUID",
+       .validator =
+           [](const TypePtr& from, const TypePtr& to) {
+             return from->kind() == TypeKind::VARBINARY;
+           }},
+      {.fromType = "UUID",
+       .toType = "VARCHARN",
+       .validator =
+           [](const TypePtr& from, const TypePtr& to) {
+             return from->kind() == TypeKind::VARCHAR;
+           }},
+      {.fromType = "UUID",
+       .toType = "VARBINARYN",
+       .validator =
+           [](const TypePtr& from, const TypePtr& to) {
+             return from->kind() == TypeKind::VARBINARY;
+           }},
   });
 }
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/parser/ParserUtil.cpp
+++ b/velox/functions/prestosql/types/parser/ParserUtil.cpp
@@ -37,6 +37,22 @@ TypePtr typeFromString(
   return inferredType;
 }
 
+TypePtr variableTypeFromString(
+    const std::string& type,
+    uint32_t length,
+    bool failIfNotRegistered = true) {
+  auto upper = type;
+  std::transform(upper.begin(), upper.end(), upper.begin(), ::toupper);
+
+  TypeParameter parameter{length};
+  auto inferredType = getType(upper, {parameter});
+  if (failIfNotRegistered) {
+    VELOX_CHECK(
+        inferredType, "Failed to parse type [{}]. Type not registered.", type);
+  }
+  return inferredType;
+}
+
 TypePtr customTypeWithChildren(
     const std::string& name,
     const std::vector<TypePtr>& children) {

--- a/velox/functions/prestosql/types/parser/ParserUtil.h
+++ b/velox/functions/prestosql/types/parser/ParserUtil.h
@@ -27,6 +27,12 @@ TypePtr typeFromString(
     const std::string& type,
     bool failIfNotRegistered = true);
 
+/// Process VARYING length types.
+TypePtr variableTypeFromString(
+    const std::string& type,
+    uint32_t length,
+    bool failIfNotRegistered = true);
+
 TypePtr customTypeWithChildren(
     const std::string& name,
     const std::vector<TypePtr>& children);

--- a/velox/functions/prestosql/types/parser/TypeParser.yy
+++ b/velox/functions/prestosql/types/parser/TypeParser.yy
@@ -95,7 +95,7 @@ field_name : WORD     { $$ = $1; }
  * Varchar and varbinary have an optional `(int)`
  * e.g. both `varchar` and `varchar(4)` are valid.
  */
-variable_type : VARIABLE LPAREN NUMBER RPAREN  { $$ = facebook::velox::functions::prestosql::typeFromString($1); }
+variable_type : VARIABLE LPAREN NUMBER RPAREN  { $$ = facebook::velox::functions::prestosql::variableTypeFromString($1, $3); }
               | VARIABLE                       { $$ = facebook::velox::functions::prestosql::typeFromString($1); }
               ;
 

--- a/velox/functions/prestosql/types/parser/tests/TypeParserTest.cpp
+++ b/velox/functions/prestosql/types/parser/tests/TypeParserTest.cpp
@@ -98,7 +98,8 @@ TEST_F(TypeParserTest, integerType) {
 
 TEST_F(TypeParserTest, varcharType) {
   ASSERT_EQ(*parseType("varchar"), *VARCHAR());
-  ASSERT_EQ(*parseType("varchar(4)"), *VARCHAR());
+  ASSERT_EQ(*parseType("varchar(4)"), *VARCHAR(4));
+  ASSERT_EQ(*parseType("varchar(2147483647)"), *VARCHAR(2147483647));
 }
 
 TEST_F(TypeParserTest, charType) {
@@ -230,7 +231,7 @@ TEST_F(TypeParserTest, rowType) {
 
   ASSERT_EQ(
       *parseType("row(a varchar(10),b row(a bigint))"),
-      *ROW({"a", "b"}, {VARCHAR(), ROW({"a"}, {BIGINT()})}));
+      *ROW({"a", "b"}, {VARCHAR(10), ROW({"a"}, {BIGINT()})}));
 
   ASSERT_EQ(
       *parseType("array(row(col0 bigint,col1 double))"),
@@ -248,7 +249,7 @@ TEST_F(TypeParserTest, rowType) {
 
   ASSERT_EQ(
       *parseType("row(varchar(10),b row(bigint))"),
-      *ROW({"", "b"}, {VARCHAR(), ROW({BIGINT()})}));
+      *ROW({"", "b"}, {VARCHAR(10), ROW({BIGINT()})}));
 
   ASSERT_EQ(
       *parseType("array(row(col0 bigint,double))"),

--- a/velox/parse/TypeResolver.cpp
+++ b/velox/parse/TypeResolver.cpp
@@ -95,7 +95,13 @@ TypePtr resolveScalarFunctionType(
   if (returnType) {
     return returnType;
   }
-
+  /*
+    std::vector<TypePtr> coercion;
+    returnType = resolveFunctionWithCoercions(name, argTypes, coercion);
+    if (returnType) {
+      return returnType;
+    }
+    */
   if (nullOnFailure) {
     return nullptr;
   }
@@ -161,6 +167,9 @@ std::vector<TypePtr> implicitCastTargets(const TypePtr& type) {
       [[fallthrough]];
     case TypeKind::DOUBLE:
       break;
+    // case TypeKind::VARCHAR:
+    //    targetTypes.emplace_back(VARCHAR()); // different lengths
+    //    break;
     case TypeKind::ARRAY: {
       auto childTargetTypes = implicitCastTargets(type->childAt(0));
       for (const auto& childTarget : childTargetTypes) {

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -86,6 +86,31 @@ std::pair<uint8_t, uint8_t> getDecimalPrecisionScale(const Type& type) {
   VELOX_FAIL("Type is not Decimal");
 }
 
+uint32_t getVarcharLength(const Type& type) {
+  if (type.isVarcharN()) {
+    const auto& varcharType = type.asVarcharN();
+    return varcharType.length();
+  }
+  return kVaryingLengthScalarTypeUnboundedLength;
+}
+
+uint32_t getVarbinaryLength(const Type& type) {
+  if (type.isVarbinaryN()) {
+    const auto& varbinaryType = type.asVarbinaryN();
+    return varbinaryType.length();
+  }
+  return kVaryingLengthScalarTypeUnboundedLength;
+}
+
+uint32_t getVaryingLengthScalarTypeLength(const Type& type) {
+  if (type.kind() == TypeKind::VARCHAR) {
+    return getVarcharLength(type);
+  } else if (type.kind() == TypeKind::VARBINARY) {
+    return getVarbinaryLength(type);
+  }
+  VELOX_FAIL("Type is not VarcharN or VarbinaryN");
+}
+
 namespace {
 struct OpaqueSerdeRegistry {
   struct Entry {
@@ -205,6 +230,18 @@ TypePtr Type::create(const folly::dynamic& obj) {
   auto typeName = obj["type"].asString();
   if (isDecimalName(typeName)) {
     return DECIMAL(obj["precision"].asInt(), obj["scale"].asInt());
+  }
+  if (isVarcharName(typeName)) {
+    if (obj.find("length") != obj.items().end()) {
+      return VARCHAR(obj["length"].asInt());
+    }
+    return VARCHAR();
+  }
+  if (isVarbinaryName(typeName)) {
+    if (obj.find("length") != obj.items().end()) {
+      return VARBINARY(obj["length"].asInt());
+    }
+    return VARBINARY();
   }
   // Checks if 'typeName' specifies a custom type.
   if (customTypeExists(typeName)) {
@@ -1026,6 +1063,42 @@ VELOX_DEFINE_SCALAR_ACCESSOR(VARBINARY);
 
 #undef VELOX_DEFINE_SCALAR_ACCESSOR
 
+template <>
+// static
+const std::shared_ptr<const VaryingLengthScalarType<TypeKind::VARCHAR>>
+VarcharNType::create() {
+  return std::make_shared<const VarcharNType>();
+}
+
+template <>
+// static
+const std::shared_ptr<const VaryingLengthScalarType<TypeKind::VARCHAR>>
+VarcharNType::create(uint32_t length) {
+  return std::make_shared<const VarcharNType>(length);
+}
+
+TypePtr VARCHAR(uint32_t length) {
+  return VarcharNType::create(length);
+}
+
+template <>
+// static
+const std::shared_ptr<const VaryingLengthScalarType<TypeKind::VARBINARY>>
+VarbinaryNType::create() {
+  return std::make_shared<const VarbinaryNType>();
+}
+
+template <>
+// static
+const std::shared_ptr<const VaryingLengthScalarType<TypeKind::VARBINARY>>
+VarbinaryNType::create(uint32_t length) {
+  return std::make_shared<const VarbinaryNType>(length);
+}
+
+TypePtr VARBINARY(uint32_t length) {
+  return VarbinaryNType::create(length);
+}
+
 TypePtr UNKNOWN() {
   return TypeFactory<TypeKind::UNKNOWN>::create();
 }
@@ -1453,6 +1526,24 @@ class FunctionParametricType {
   }
 };
 
+template <TypeKind KIND>
+class VaryingLengthParametricType {
+ public:
+  static TypePtr create(const std::vector<TypeParameter>& parameters) {
+    VELOX_USER_CHECK_EQ(1, parameters.size());
+    VELOX_USER_CHECK(parameters[0].kind == TypeParameterKind::kLongLiteral);
+    VELOX_USER_CHECK(parameters[0].longLiteral.has_value());
+
+    if constexpr (KIND == TypeKind::VARCHAR) {
+      return VARCHAR(parameters[0].longLiteral.value());
+    } else if constexpr (KIND == TypeKind::VARBINARY) {
+      return VARBINARY(parameters[0].longLiteral.value());
+    } else {
+      VELOX_UNSUPPORTED("Unknown TypeKind for varying length parametric type.");
+    }
+  }
+};
+
 using ParametricTypeMap = std::unordered_map<
     std::string,
     std::function<TypePtr(const std::vector<TypeParameter>& parameters)>>;
@@ -1464,6 +1555,8 @@ const ParametricTypeMap& parametricBuiltinTypes() {
       {"MAP", MapParametricType::create},
       {"ROW", RowParametricType::create},
       {"FUNCTION", FunctionParametricType::create},
+      {"VARCHAR", VaryingLengthParametricType<TypeKind::VARCHAR>::create},
+      {"VARBINARY", VaryingLengthParametricType<TypeKind::VARBINARY>::create},
   };
   return kTypes;
 }
@@ -1489,11 +1582,11 @@ bool hasType(const std::string& name) {
 TypePtr getType(
     const std::string& name,
     const std::vector<TypeParameter>& parameters) {
-  if (singletonBuiltInTypes().count(name)) {
+  if (parameters.size() == 0 && singletonBuiltInTypes().count(name)) {
     return singletonBuiltInTypes().at(name);
   }
 
-  if (parametricBuiltinTypes().count(name)) {
+  if (parameters.size() > 0 && parametricBuiltinTypes().count(name)) {
     return parametricBuiltinTypes().at(name)(parameters);
   }
 

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -96,6 +96,10 @@ VELOX_DECLARE_ENUM_NAME(TypeKind);
 
 template <TypeKind KIND>
 class ScalarType;
+template <TypeKind KIND>
+class VaryingLengthScalarType;
+using VarcharNType = VaryingLengthScalarType<TypeKind::VARCHAR>;
+using VarbinaryNType = VaryingLengthScalarType<TypeKind::VARBINARY>;
 class ShortDecimalType;
 class LongDecimalType;
 class ArrayType;
@@ -643,8 +647,12 @@ class Type : public Tree<const TypePtr>, public velox::ISerializable {
   VELOX_FLUENT_CAST(Unknown, UNKNOWN)
   VELOX_FLUENT_CAST(Function, FUNCTION)
 
+  const VarcharNType& asVarcharN() const;
+  const VarbinaryNType& asVarbinaryN() const;
   const ShortDecimalType& asShortDecimal() const;
   const LongDecimalType& asLongDecimal() const;
+  bool isVarcharN() const;
+  bool isVarbinaryN() const;
   bool isShortDecimal() const;
   bool isLongDecimal() const;
   bool isDecimal() const;
@@ -975,6 +983,114 @@ class UnknownType : public CanProvideCustomComparisonType<TypeKind::UNKNOWN> {
     return obj;
   }
 };
+
+static constexpr uint32_t kVaryingLengthScalarTypeUnboundedLength =
+    std::numeric_limits<int32_t>::max();
+static const std::string kVaryingLengthScalarTypeUnboundedLengthStr =
+    std::to_string(kVaryingLengthScalarTypeUnboundedLength);
+
+FOLLY_ALWAYS_INLINE bool isVaryingLengthScalarType(const TypePtr& type) {
+  return (type->isVarcharN() || type->isVarbinaryN());
+}
+
+FOLLY_ALWAYS_INLINE bool isVaryingLengthScalarType(const Type& type) {
+  return (type.isVarcharN() || type.isVarbinaryN());
+}
+
+template <TypeKind KIND>
+class VaryingLengthScalarType : public ScalarType<KIND> {
+ public:
+  explicit VaryingLengthScalarType(
+      const std::optional<uint32_t> length = std::nullopt)
+      : parameters_{
+            length.has_value()
+                ? TypeParameter(length.value())
+                : TypeParameter(kVaryingLengthScalarTypeUnboundedLength)} {
+    VELOX_CHECK_LE(
+        parameters_[0].longLiteral.value(),
+        std::numeric_limits<int32_t>::max(),
+        "Maximum length of varying string or binary type must be greater than 0 and less or equal to {}.",
+        kVaryingLengthScalarTypeUnboundedLength);
+  }
+
+  FOLLY_NOINLINE static const std::shared_ptr<
+      const VaryingLengthScalarType<KIND>>
+  create();
+
+  FOLLY_NOINLINE static const std::shared_ptr<
+      const VaryingLengthScalarType<KIND>>
+  create(uint32_t length);
+
+  inline uint32_t length() const {
+    return parameters_[0].longLiteral.value();
+  }
+
+  inline bool equivalent(const Type& other) const override {
+    if (!Type::hasSameTypeId(other)) {
+      return false;
+    }
+    const auto& otherType =
+        static_cast<const VaryingLengthScalarType<KIND>&>(other);
+    return otherType.length() == length();
+  }
+
+  const char* name() const override {
+    return TypeTraits<KIND>::name;
+  }
+
+  std::string toString() const override {
+    if (length() == kVaryingLengthScalarTypeUnboundedLength) {
+      return std::string(name());
+    }
+    return fmt::format("{}({})", name(), length());
+  }
+
+  folly::dynamic serialize() const override {
+    auto obj = ScalarType<KIND>::serialize();
+    obj["type"] = name();
+    obj["length"] = length();
+    return obj;
+  }
+
+  std::span<const TypeParameter> parameters() const override {
+    return parameters_;
+  }
+
+ private:
+  const std::array<TypeParameter, 1> parameters_;
+};
+
+// Functions for Varchar.
+FOLLY_ALWAYS_INLINE const VarcharNType& Type::asVarcharN() const {
+  return dynamic_cast<const VarcharNType&>(*this);
+}
+
+FOLLY_ALWAYS_INLINE bool Type::isVarcharN() const {
+  return dynamic_cast<const VarcharNType*>(this) != nullptr;
+}
+
+FOLLY_ALWAYS_INLINE bool isVarcharName(std::string_view name) {
+  return (name == "VARCHAR");
+}
+
+uint32_t getVarcharLength(const Type& type);
+
+// Functions for Varbinary.
+FOLLY_ALWAYS_INLINE const VarbinaryNType& Type::asVarbinaryN() const {
+  return dynamic_cast<const VarbinaryNType&>(*this);
+}
+
+FOLLY_ALWAYS_INLINE bool Type::isVarbinaryN() const {
+  return dynamic_cast<const VarbinaryNType*>(this) != nullptr;
+}
+
+FOLLY_ALWAYS_INLINE bool isVarbinaryName(const std::string& name) {
+  return (name == "VARBINARY");
+}
+
+uint32_t getVarbinaryLength(const Type& type);
+
+uint32_t getVaryingLengthScalarTypeLength(const Type& type);
 
 class ArrayType : public TypeBase<TypeKind::ARRAY> {
  public:
@@ -2218,6 +2334,10 @@ VELOX_SCALAR_ACCESSOR(DOUBLE);
 VELOX_SCALAR_ACCESSOR(TIMESTAMP);
 VELOX_SCALAR_ACCESSOR(VARCHAR);
 VELOX_SCALAR_ACCESSOR(VARBINARY);
+
+TypePtr VARCHAR(uint32_t length);
+
+TypePtr VARBINARY(uint32_t length);
 
 TypePtr UNKNOWN();
 

--- a/velox/type/TypeCoercer.cpp
+++ b/velox/type/TypeCoercer.cpp
@@ -63,6 +63,8 @@ allowedCoercions() {
        DOUBLE(),
        VARCHAR(),
        VARBINARY()});
+  // add(VARCHAR(),
+  //     {VARCHAR()}); // Allow coercion between different VARCHAR lengths.
 
   return coercions;
 }
@@ -96,7 +98,14 @@ std::optional<Coercion> TypeCoercer::coerceTypeBase(
     const TypePtr& fromType,
     const std::string& toTypeName) {
   static const auto kAllowedCoercions = allowedCoercions();
+  // Allow name coercion on name alone for primitive types without parameters
+  // and non-primitive types.
   if (fromType->name() == toTypeName) {
+    //&&
+    //((fromType->isPrimitiveType() && fromType->parameters().empty()) ||
+    // !fromType->isPrimitiveType())) {
+    VLOG(0) << "Allow from " << fromType->toString() << " to type name "
+            << toTypeName;
     return Coercion{.type = fromType, .cost = 0};
   }
 
@@ -162,6 +171,36 @@ std::optional<int32_t> TypeCoercer::coercible(
 }
 
 namespace {
+
+bool isSameStringOrBinaryType(const TypePtr& fromType, const TypePtr& toType) {
+  return (fromType->kind() == toType->kind()) &&
+      (fromType->kind() == TypeKind::VARCHAR ||
+       fromType->kind() == TypeKind::VARBINARY);
+}
+
+bool isDecimalTypeOnlyCoercion(const TypePtr& fromType, const TypePtr& toType) {
+  if (!((fromType->isShortDecimal() || fromType->isLongDecimal()) &&
+        (toType->isShortDecimal() || toType->isLongDecimal()))) {
+    return false;
+  }
+
+  const auto [fromPrecision, fromScale] = getDecimalPrecisionScale(*fromType);
+  const auto [toPrecision, toScale] = getDecimalPrecisionScale(*toType);
+
+  // Type-only coercion for decimals requires:
+  // 1. Same decimal subtype (both short or both long)
+  // 2. Same scale
+  // 3. Source precision <= result precision
+  const bool sameDecimalSubtype =
+      (fromType->isShortDecimal() && toType->isShortDecimal()) ||
+      (fromType->isLongDecimal() && toType->isLongDecimal());
+  const bool sameScale = fromScale == toScale;
+  const bool sourcePrecisionIsLessOrEqualToResultPrecision =
+      fromPrecision <= toPrecision;
+
+  return sameDecimalSubtype && sameScale &&
+      sourcePrecisionIsLessOrEqualToResultPrecision;
+}
 
 TypePtr leastCommonSuperRowType(const RowType& a, const RowType& b) {
   std::vector<std::string> childNames;
@@ -238,6 +277,62 @@ TypePtr TypeCoercer::leastCommonSuperType(const TypePtr& a, const TypePtr& b) {
   }
 
   return getType(a->name(), childTypes);
+}
+
+// static
+bool TypeCoercer::isTypeOnlyCoercion(
+    const TypePtr& fromType,
+    const TypePtr& toType) {
+  // If types are equal, it's always type-only coercion
+  if (*fromType == *toType) {
+    return true;
+  }
+
+  // Handle VARCHAR/VARBINARY type coercion (bounded <-> unbounded)
+  if (isSameStringOrBinaryType(fromType, toType)) {
+    return true;
+  }
+
+  // Handle DECIMAL type coercion
+  if (isDecimalTypeOnlyCoercion(fromType, toType)) {
+    return true;
+  }
+
+  // Handle covariant parametrized types (ARRAY, MAP, ROW)
+  if (fromType->kind() == toType->kind() && fromType->size() > 0) {
+    const auto fromTypeParams = fromType->parameters();
+    const auto toTypeParams = toType->parameters();
+
+    if (fromTypeParams.size() != toTypeParams.size()) {
+      return false;
+    }
+
+    // For ROW types, column names must match for type-only coercion
+    if (fromType->kind() == TypeKind::ROW) {
+      const auto& fromRowType = fromType->asRow();
+      const auto& toRowType = toType->asRow();
+      const auto& fromNames = fromRowType.names();
+      const auto& toNames = toRowType.names();
+
+      // Check that all column names match
+      for (size_t i = 0; i < fromNames.size(); ++i) {
+        if (fromNames[i] != toNames[i]) {
+          return false;
+        }
+      }
+    }
+
+    // Recursively check all type parameters
+    return std::all_of(
+        fromTypeParams.begin(),
+        fromTypeParams.end(),
+        [&toTypeParams, i = size_t{0}](const TypeParameter& fromParam) mutable {
+          return isTypeOnlyCoercion(fromParam.type, toTypeParams[i++].type);
+        });
+  }
+
+  // For all other cases, not a type-only coercion
+  return false;
 }
 
 } // namespace facebook::velox

--- a/velox/type/TypeCoercer.h
+++ b/velox/type/TypeCoercer.h
@@ -105,6 +105,16 @@ class TypeCoercer {
   /// When `a` and `b` are ROW types with different field names, the resulting
   /// ROW has empty field names for any positions where the corresponding field
   /// names do not match.
+  /// Checks if coercion from 'fromType' to 'toType' is a type-only coercion,
+  /// meaning no actual data transformation is required. This is true for:
+  /// - Bounded VARCHAR to unbounded VARCHAR (e.g., VARCHAR(10) to VARCHAR)
+  /// - Unbounded VARCHAR to bounded VARCHAR (e.g., VARCHAR to VARCHAR(10))
+  /// - Decimal types with same precision and scale
+  ///
+  /// @return true if the coercion is type-only, false otherwise.
+  static bool isTypeOnlyCoercion(
+      const TypePtr& fromType,
+      const TypePtr& toType);
   static TypePtr leastCommonSuperType(const TypePtr& a, const TypePtr& b);
 };
 

--- a/velox/type/fbhive/HiveTypeParser.cpp
+++ b/velox/type/fbhive/HiveTypeParser.cpp
@@ -120,6 +120,26 @@ Result HiveTypeParser::parseType() {
       eatToken(TokenType::RightRoundBracket);
       return Result{DECIMAL(
           std::atoi(precision.value.data()), std::atoi(scale.value.data()))};
+    } else if (
+        nt.metadata->tokenType == TokenType::String &&
+        lookAhead() == TokenType::LeftRoundBracket) {
+      eatToken(TokenType::LeftRoundBracket);
+      Token length = nextToken();
+      VELOX_CHECK(
+          isPositiveInteger(length.value),
+          "Varchar length must be a positive integer");
+      eatToken(TokenType::RightRoundBracket);
+      return Result{VARCHAR(std::atoi(length.value.data()))};
+    } else if (
+        nt.metadata->tokenType == TokenType::Binary &&
+        lookAhead() == TokenType::LeftRoundBracket) {
+      eatToken(TokenType::LeftRoundBracket);
+      Token length = nextToken();
+      VELOX_CHECK(
+          isPositiveInteger(length.value),
+          "Varbinary length must be a positive integer");
+      eatToken(TokenType::RightRoundBracket);
+      return Result{VARBINARY(std::atoi(length.value.data()))};
     } else if (nt.metadata->tokenString[0] == "date") {
       return Result{DATE()};
     } else if (nt.metadata->tokenString[0] == "time") {
@@ -128,15 +148,6 @@ Result HiveTypeParser::parseType() {
     auto scalarType = createScalarType(nt.typeKind());
     VELOX_CHECK_NOT_NULL(
         scalarType, "Returned a null scalar type for ", nt.typeKind());
-    if (nt.metadata->tokenType == TokenType::String &&
-        lookAhead() == TokenType::LeftRoundBracket) {
-      eatToken(TokenType::LeftRoundBracket);
-      Token length = nextToken();
-      VELOX_CHECK(
-          isPositiveInteger(length.value),
-          "Varchar length must be a positive integer");
-      eatToken(TokenType::RightRoundBracket);
-    }
     return Result{scalarType};
   } else if (nt.isOpaqueType()) {
     eatToken(TokenType::StartSubType);

--- a/velox/type/tests/TypeCoercerTest.cpp
+++ b/velox/type/tests/TypeCoercerTest.cpp
@@ -43,6 +43,7 @@ TEST(TypeCoercerTest, basic) {
   testCoercion(TINYINT(), TINYINT());
   testCoercion(TINYINT(), BIGINT());
   testCoercion(TINYINT(), REAL());
+  // testCoercion(VARCHAR(10), VARCHAR());
 
   testNoCoercion(TINYINT(), VARCHAR());
   testNoCoercion(TINYINT(), DATE());
@@ -87,6 +88,7 @@ TEST(TypeCoercerTest, unknown) {
   ASSERT_TRUE(TypeCoercer::coercible(UNKNOWN(), BOOLEAN()));
   ASSERT_TRUE(TypeCoercer::coercible(UNKNOWN(), BIGINT()));
   ASSERT_TRUE(TypeCoercer::coercible(UNKNOWN(), VARCHAR()));
+  // ASSERT_TRUE(TypeCoercer::coercible(UNKNOWN(), VARCHAR(10)));
   ASSERT_TRUE(TypeCoercer::coercible(UNKNOWN(), ARRAY(INTEGER())));
 }
 
@@ -242,6 +244,91 @@ TEST(TypeCoercerTest, leastCommonSuperType) {
   ASSERT_TRUE(
       TypeCoercer::leastCommonSuperType(
           MAP(INTEGER(), REAL()), ROW({INTEGER(), REAL()})) == nullptr);
+}
+
+TEST(TypeCoercerTest, isTypeOnlyCoercion) {
+  // VARCHAR type-only coercions
+  EXPECT_TRUE(TypeCoercer::isTypeOnlyCoercion(VARCHAR(10), VARCHAR(10)));
+  EXPECT_TRUE(TypeCoercer::isTypeOnlyCoercion(VARCHAR(10), VARCHAR(20)));
+  EXPECT_TRUE(TypeCoercer::isTypeOnlyCoercion(VARCHAR(10), VARCHAR()));
+  EXPECT_TRUE(TypeCoercer::isTypeOnlyCoercion(VARCHAR(), VARCHAR(10)));
+  EXPECT_TRUE(TypeCoercer::isTypeOnlyCoercion(VARCHAR(), VARCHAR()));
+
+  // VARBINARY type-only coercions
+  EXPECT_TRUE(TypeCoercer::isTypeOnlyCoercion(VARBINARY(10), VARBINARY(10)));
+  EXPECT_TRUE(TypeCoercer::isTypeOnlyCoercion(VARBINARY(10), VARBINARY(20)));
+  EXPECT_TRUE(TypeCoercer::isTypeOnlyCoercion(VARBINARY(10), VARBINARY()));
+  EXPECT_TRUE(TypeCoercer::isTypeOnlyCoercion(VARBINARY(), VARBINARY(10)));
+  EXPECT_TRUE(TypeCoercer::isTypeOnlyCoercion(VARBINARY(), VARBINARY()));
+
+  // DECIMAL type-only coercions (same scale, different precision)
+  EXPECT_TRUE(TypeCoercer::isTypeOnlyCoercion(DECIMAL(4, 2), DECIMAL(4, 2)));
+  EXPECT_TRUE(TypeCoercer::isTypeOnlyCoercion(DECIMAL(4, 2), DECIMAL(10, 2)));
+  EXPECT_TRUE(TypeCoercer::isTypeOnlyCoercion(DECIMAL(10, 2), DECIMAL(15, 2)));
+
+  // DECIMAL - same scale, source precision > result precision (not type-only)
+  EXPECT_FALSE(TypeCoercer::isTypeOnlyCoercion(DECIMAL(10, 2), DECIMAL(4, 2)));
+
+  // DECIMAL - different scale (not type-only)
+  EXPECT_FALSE(TypeCoercer::isTypeOnlyCoercion(DECIMAL(10, 2), DECIMAL(10, 3)));
+
+  // DECIMAL - different subtype (short vs long, not type-only)
+  EXPECT_FALSE(TypeCoercer::isTypeOnlyCoercion(DECIMAL(10, 2), DECIMAL(20, 2)));
+
+  // Complex types with VARCHAR
+  EXPECT_TRUE(
+      TypeCoercer::isTypeOnlyCoercion(ARRAY(VARCHAR(10)), ARRAY(VARCHAR(20))));
+  EXPECT_TRUE(
+      TypeCoercer::isTypeOnlyCoercion(ARRAY(VARCHAR(10)), ARRAY(VARCHAR())));
+  EXPECT_TRUE(
+      TypeCoercer::isTypeOnlyCoercion(
+          MAP(VARCHAR(10), INTEGER()), MAP(VARCHAR(20), INTEGER())));
+  EXPECT_TRUE(
+      TypeCoercer::isTypeOnlyCoercion(
+          MAP(INTEGER(), VARCHAR(10)), MAP(INTEGER(), VARCHAR())));
+
+  // ROW type-only coercions with matching column names
+  EXPECT_TRUE(
+      TypeCoercer::isTypeOnlyCoercion(
+          ROW({"a", "b"}, {INTEGER(), VARCHAR(10)}),
+          ROW({"a", "b"}, {INTEGER(), VARCHAR(20)})));
+  EXPECT_TRUE(
+      TypeCoercer::isTypeOnlyCoercion(
+          ROW({"x", "y"}, {VARCHAR(10), INTEGER()}),
+          ROW({"x", "y"}, {VARCHAR(), INTEGER()})));
+
+  // ROW type-only coercions - nested ROW with matching names
+  EXPECT_TRUE(
+      TypeCoercer::isTypeOnlyCoercion(
+          ROW({"outer", "inner"},
+              {INTEGER(), ROW({"a", "b"}, {VARCHAR(10), INTEGER()})}),
+          ROW({"outer", "inner"},
+              {INTEGER(), ROW({"a", "b"}, {VARCHAR(20), INTEGER()})})));
+
+  // ROW - different column names (not type-only)
+  EXPECT_FALSE(
+      TypeCoercer::isTypeOnlyCoercion(
+          ROW({"a", "b"}, {INTEGER(), VARCHAR()}),
+          ROW({"a", "c"}, {INTEGER(), VARCHAR()})));
+  EXPECT_FALSE(
+      TypeCoercer::isTypeOnlyCoercion(
+          ROW({"x", "y"}, {INTEGER(), VARCHAR()}),
+          ROW({"a", "b"}, {INTEGER(), VARCHAR()})));
+
+  // ROW - nested ROW with different column names (not type-only)
+  EXPECT_FALSE(
+      TypeCoercer::isTypeOnlyCoercion(
+          ROW({"outer", "inner"},
+              {INTEGER(), ROW({"a", "b"}, {VARCHAR(), INTEGER()})}),
+          ROW({"outer", "inner"},
+              {INTEGER(), ROW({"x", "y"}, {VARCHAR(), INTEGER()})})));
+
+  // Not type-only coercions
+  EXPECT_FALSE(TypeCoercer::isTypeOnlyCoercion(INTEGER(), BIGINT()));
+  EXPECT_FALSE(TypeCoercer::isTypeOnlyCoercion(REAL(), DOUBLE()));
+  EXPECT_FALSE(TypeCoercer::isTypeOnlyCoercion(VARCHAR(), INTEGER()));
+  EXPECT_FALSE(
+      TypeCoercer::isTypeOnlyCoercion(ARRAY(INTEGER()), ARRAY(BIGINT())));
 }
 
 TEST(TypeCoercerTest, parametricBuiltinTargetDoesNotThrow) {

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -990,6 +990,15 @@ TEST(TypeTest, equivalent) {
       {{"b0", ARRAY(ROW({{"b1", DECIMAL(20, 8)}}))},
        {"b2", MAP(VARCHAR(), ROW({{"b3", DECIMAL(20, 5)}}))}});
   EXPECT_FALSE(complexTypeA->equivalent(*complexTypeB));
+  EXPECT_FALSE(VARCHAR(10)->equivalent(*VARCHAR(20)));
+  EXPECT_TRUE(VARCHAR(10)->equivalent(*VARCHAR(10)));
+  EXPECT_FALSE(VARCHAR(10)->equivalent(
+      *VARCHAR(kVaryingLengthScalarTypeUnboundedLength)));
+  EXPECT_FALSE(VARCHAR(kVaryingLengthScalarTypeUnboundedLength)
+                   ->equivalent(*VARCHAR(10)));
+  EXPECT_FALSE(VARCHAR(10)->equivalent(*VARCHAR()));
+  EXPECT_FALSE(VARCHAR()->equivalent(*VARCHAR(10)));
+  EXPECT_TRUE(VARCHAR()->equivalent(*VARCHAR()));
 }
 
 TEST(TypeTest, kindEquals) {

--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -97,10 +97,14 @@ StringView randString(
     FuzzerGenerator& rng,
     const VectorFuzzer::Options& opts,
     std::string& buf,
-    std::wstring_convert<std::codecvt_utf8<char16_t>, char16_t>& converter) {
+    std::wstring_convert<std::codecvt_utf8<char16_t>, char16_t>& converter,
+    const TypePtr& type) {
+  const size_t maxTypeStringLength = getVaryingLengthScalarTypeLength(*type);
+  const size_t maxAllowedStringLength =
+      std::min(opts.stringLength, maxTypeStringLength);
   const size_t stringLength = opts.stringVariableLength
-      ? rand<uint32_t>(rng) % opts.stringLength
-      : opts.stringLength;
+      ? rand<uint32_t>(rng) % maxAllowedStringLength
+      : maxAllowedStringLength;
 
   randString(rng, stringLength, opts.charEncodings, buf, converter);
   return StringView(buf);
@@ -123,7 +127,7 @@ VectorPtr fuzzConstantPrimitiveImpl(
   if constexpr (std::is_same_v<TCpp, StringView>) {
     std::wstring_convert<std::codecvt_utf8<char16_t>, char16_t> converter;
     std::string buf;
-    auto stringView = randString(rng, opts, buf, converter);
+    auto stringView = randString(rng, opts, buf, converter, type);
 
     return std::make_shared<ConstantVector<TCpp>>(
         pool, size, false, type, std::move(stringView));
@@ -164,7 +168,8 @@ void fuzzFlatPrimitiveImpl(
   std::wstring_convert<std::codecvt_utf8<char16_t>, char16_t> converter;
   for (size_t i = 0; i < vector->size(); ++i) {
     if constexpr (std::is_same_v<TCpp, StringView>) {
-      flatVector->set(i, randString(rng, opts, strBuf, converter));
+      flatVector->set(
+          i, randString(rng, opts, strBuf, converter, vector->type()));
     } else if constexpr (std::is_same_v<TCpp, Timestamp>) {
       flatVector->set(i, randTimestamp(rng, opts.timestampPrecision));
     } else if constexpr (std::is_same_v<TCpp, int64_t>) {

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -388,6 +388,16 @@ class VectorFuzzer {
     return DECIMAL(precision, scale);
   }
 
+  /// Generates varchar TypePtr with random length if stringVariableLength
+  /// was set in the options. Otherwise, returns unbounded varchar.
+  inline TypePtr randVarcharType() {
+    if (opts_.stringVariableLength) {
+      auto length = fuzzer::rand<int32_t>(rng_) % opts_.stringLength;
+      return VARCHAR(length);
+    }
+    return VARCHAR();
+  }
+
   void reSeed(size_t seed) {
     rng_.seed(seed);
   }

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -300,7 +300,8 @@ class VectorTestBase {
   template <typename T>
   ArrayVectorPtr makeNullableNestedArrayVector(
       const std::vector<std::optional<
-          std::vector<std::optional<std::vector<std::optional<T>>>>>>& data) {
+          std::vector<std::optional<std::vector<std::optional<T>>>>>>& data,
+      TypePtr type = ARRAY(CppToType<T>::create())) {
     vector_size_t size = data.size();
     BufferPtr offsets = allocateOffsets(size, pool());
     BufferPtr sizes = allocateSizes(size, pool());
@@ -330,18 +331,11 @@ class VectorTestBase {
     }
 
     // Create the underlying vector.
-    auto baseArray = makeNullableArrayVector<T>(flattenedData);
+    auto baseArray = makeNullableArrayVector<T>(flattenedData, type);
 
     // Build and return a second-level of ArrayVector on top of baseArray.
     return std::make_shared<ArrayVector>(
-        pool(),
-        ARRAY(ARRAY(CppToType<T>::create())),
-        nulls,
-        size,
-        offsets,
-        sizes,
-        baseArray,
-        0);
+        pool(), ARRAY(type), nulls, size, offsets, sizes, baseArray, 0);
   }
 
   // Create an ArrayVector<MapVector<TKey, TValue>> from nested std::vectors of


### PR DESCRIPTION
This is a WIP PR that can be used for further discussion.
This adds basic support for being able to handle length limited data based on the type definition.

This PR also work along side the E2E test using the PrestoQueryRunner enhancement https://github.com/facebookincubator/velox/pull/10523 to test CAST expressions.

It follows mainly the VARCHARN design document: https://docs.google.com/document/d/1wsNcS3Op2E5yyW9uH28gNtzXpJqvUHE6Ds4Xi_w9w54/edit?usp=sharing