### PR TITLE
Add test parameter isSingleThreaded in SharedArbitratorTest.cpp

### DIFF
--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -63,7 +63,13 @@ AssertQueryBuilder& AssertQueryBuilder::destination(int32_t destination) {
 }
 
 AssertQueryBuilder& AssertQueryBuilder::singleThreaded(bool singleThreaded) {
-  params_.singleThreaded = singleThreaded;
+  if (singleThreaded) {
+    params_.singleThreaded = true;
+    executor_ = nullptr;
+    return *this;
+  }
+  params_.singleThreaded = false;
+  executor_ = newExecutor();
   return *this;
 }
 

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -179,9 +179,13 @@ class AssertQueryBuilder {
   std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>>
   readCursor();
 
+  static std::unique_ptr<folly::Executor> newExecutor() {
+    return std::make_unique<folly::CPUThreadPoolExecutor>(
+        std::thread::hardware_concurrency());
+  }
+
   // Used by the created task as the default driver executor.
-  std::unique_ptr<folly::Executor> executor_{
-      new folly::CPUThreadPoolExecutor(std::thread::hardware_concurrency())};
+  std::unique_ptr<folly::Executor> executor_{newExecutor()};
   DuckDbQueryRunner* const duckDbQueryRunner_;
   CursorParameters params_;
   std::unordered_map<std::string, std::string> configs_;


### PR DESCRIPTION
Separated from https://github.com/facebookincubator/velox/pull/10600

Make the 3 cases parameterized:

SharedArbitrationTest.reclaimToJoinBuilder
SharedArbitrationTest.reclaimToAggregation
SharedArbitrationTest.reclaimToOrderBy

In the patch we still run them with `isSingleThreaded=false` only. `isSingleThreaded=true` will be toggled on in https://github.com/facebookincubator/velox/pull/10600 with essential code fixes.