### PR TITLE
Add substrings search path for constant like pattern

### DIFF
--- a/velox/docs/functions/presto/regexp.rst
+++ b/velox/docs/functions/presto/regexp.rst
@@ -24,10 +24,12 @@ limited to 20 different expressions per instance and thread of execution.
     Note: Each function instance allow for a maximum of 20 regular expressions to
     be compiled per thread of execution. Not all patterns require
     compilation of regular expressions. Patterns 'hello', 'hello%', '_hello__%',
-    '%hello', '%__hello_', '%hello%', where 'hello', 'velox'
-    contains only regular characters and '_' wildcards are evaluated without
-    using regular expressions. Only those patterns that require the compilation of
-    regular expressions are counted towards the limit.
+    '%hello', '%__hello_', '%hello%' where 'hello', 'velox' contains only regular
+    characters and '_' wildcards are evaluated without using regular expressions,
+    and constant pattern '%hello%velox%' where 'hello', 'velox' contains only regular
+    characters(not contains '_' '#' wildcards) is evaluated with substrings-searching.
+    Only those patterns that require the compilation of regular expressions are
+    counted towards the limit.
 
         SELECT like('abc', '%b%'); -- true
         SELECT like('a_c', '%#_%', '#'); -- true

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -460,6 +460,9 @@ TEST_F(Re2FunctionsTest, likePattern) {
       false);
 
   testLike("abc", "MEDIUM POLISHED%", false);
+
+  testLike("aabbccddeeff", "%aa%bb%", true);
+  testLike("aaccddeeff", "%aa%bb%", false);
 }
 
 TEST_F(Re2FunctionsTest, likeDeterminePatternKind) {
@@ -1500,5 +1503,27 @@ TEST_F(Re2FunctionsTest, split) {
   assertEqualVectors(expected, result);
 }
 
+TEST_F(Re2FunctionsTest, parseSubstrings) {
+  auto test = [&](const std::string& input,
+                  const std::vector<std::string>& expected) {
+    ASSERT_EQ(PatternMetadata::parseSubstrings(input), expected);
+  };
+  // Cases that not supported by substrings-search.
+  // Note: we always return LikeGeneric for escape-case, see makeLike().
+  test("%%", {});
+  // Not supports prefix.
+  test("aa%bb%%", {});
+  // Not supports sufix.
+  test("%aa%bb", {});
+  // Not supports '_'.
+  test("%aa_%", {});
+  // Not supports '#'.
+  test("%aa#%", {});
+
+  // Cases that supported by substrings-search.
+  test("%aa%", {"aa"});
+  test("%aa%bb%%", {"aa", "bb"});
+  test("%aa%bb%%%cc%", {"aa", "bb", "cc"});
+}
 } // namespace
 } // namespace facebook::velox::functions


### PR DESCRIPTION
We noticed that some like constant-patterns can be equivalent to substrings search such as tpch queries Q13 and Q16: "%special%requests%" "%Customer%Complaints%"

1.  Add substring-search fast path for like with search pattern : "((%+[^%#_\\]+)+%+)"
2. Some OLAP engine supports "\_" for substring-search. In order to obtain the best performance, "\_" is not supported here, '#' is not support for the same reason too.
3. This PR will also affect single substring-search like tpch Q9,  if a fast-simd-strstr to speedup string-search will be added as follow-up, changes nothing right now.

benchmark result :
before:

tpchQuery9                                                 23.96ms     41.73
tpchQuery13                                               156.02ms      6.41
tpchQuery16Part                                             9.02ms    110.83
tpchQuery16Supplier                                       192.13ms      5.20

after:

tpchQuery9                                                 24.30ms     41.14
tpchQuery13                                                55.03ms     18.17
tpchQuery16Part                                             8.92ms    112.07
tpchQuery16Supplier                                        17.64ms     56.69
