### PR TITLE
Set hash_probe_finish_early_on_empty_build to false by default.

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -683,7 +683,7 @@ class QueryConfig {
   }
 
   bool hashProbeFinishEarlyOnEmptyBuild() const {
-    return get<bool>(kHashProbeFinishEarlyOnEmptyBuild, true);
+    return get<bool>(kHashProbeFinishEarlyOnEmptyBuild, false);
   }
 
   uint32_t minTableRowsForParallelJoinBuild() const {


### PR DESCRIPTION
Summary: Keeping `hash_probe_finish_early_on_empty_build` to true causes queries to fail with `split source is closed` error. This is very hard to debug and in all deployment setup we set it to `false`. Making the default behavior to `false` to avoid confusing query errors for users.

Differential Revision: D61193165
