### PR TITLE
Fix Spark collect_set result when no input

### DIFF
--- a/velox/docs/functions/spark/aggregate.rst
+++ b/velox/docs/functions/spark/aggregate.rst
@@ -60,8 +60,8 @@ General Aggregate Functions
 
 .. spark:function:: collect_set(x) -> array<[same as x]>
 
-    Returns an array consisting of all unique values from the input ``x`` elements. 
-    Null values are excluded, and returns an empty array when all inputs are null.
+    Returns an array consisting of all unique values from the input ``x`` elements excluding NULLs.
+    Returns empty array if input is empty or all NULL.
 
     Example::
 

--- a/velox/functions/prestosql/aggregates/SetAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/SetAggregates.cpp
@@ -103,14 +103,15 @@ class SetUnionAggregate : public SetBaseAggregate<T> {
 /// Returns the number of distinct non-null values in a group. This is an
 /// internal function only used for testing.
 template <typename T>
-class CountDistinctAggregate : public SetAggAggregate<T, true> {
+class CountDistinctAggregate : public SetAggAggregate<T, true, false> {
  public:
   explicit CountDistinctAggregate(
       const TypePtr& resultType,
       const TypePtr& inputType)
-      : SetAggAggregate<T, true>(resultType, false), inputType_{inputType} {}
+      : SetAggAggregate<T, true, false>(resultType, false),
+        inputType_{inputType} {}
 
-  using Base = SetAggAggregate<T, true>;
+  using Base = SetAggAggregate<T, true, false>;
 
   bool supportsToIntermediate() const override {
     return false;

--- a/velox/functions/sparksql/aggregates/CollectSetAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/CollectSetAggregate.cpp
@@ -16,6 +16,16 @@
 #include "velox/functions/lib/aggregates/SetBaseAggregate.h"
 
 namespace facebook::velox::functions::aggregate::sparksql {
+namespace {
+
+// Null inputs are excluded by setting 'ignoreNulls' as true.
+// Empty arrays are returned for empty groups by setting 'nullForEmpty'
+// as false.
+template <typename T>
+using SparkSetAggAggregate = SetAggAggregate<T, true, false>;
+
+} // namespace
+
 void registerCollectSetAggAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
@@ -44,42 +54,41 @@ void registerCollectSetAggAggregate(
         const TypePtr& inputType =
             isRawInput ? argTypes[0] : argTypes[0]->childAt(0);
         const TypeKind typeKind = inputType->kind();
-        // Null inputs are excluded by setting 'ignoreNulls' as true.
+
         switch (typeKind) {
           case TypeKind::BOOLEAN:
-            return std::make_unique<SetAggAggregate<bool, true>>(resultType);
+            return std::make_unique<SparkSetAggAggregate<bool>>(resultType);
           case TypeKind::TINYINT:
-            return std::make_unique<SetAggAggregate<int8_t, true>>(resultType);
+            return std::make_unique<SparkSetAggAggregate<int8_t>>(resultType);
           case TypeKind::SMALLINT:
-            return std::make_unique<SetAggAggregate<int16_t, true>>(resultType);
+            return std::make_unique<SparkSetAggAggregate<int16_t>>(resultType);
           case TypeKind::INTEGER:
-            return std::make_unique<SetAggAggregate<int32_t, true>>(resultType);
+            return std::make_unique<SparkSetAggAggregate<int32_t>>(resultType);
           case TypeKind::BIGINT:
-            return std::make_unique<SetAggAggregate<int64_t, true>>(resultType);
+            return std::make_unique<SparkSetAggAggregate<int64_t>>(resultType);
           case TypeKind::HUGEINT:
             VELOX_CHECK(
                 inputType->isLongDecimal(),
                 "Non-decimal use of HUGEINT is not supported");
-            return std::make_unique<SetAggAggregate<int128_t, true>>(
-                resultType);
+            return std::make_unique<SparkSetAggAggregate<int128_t>>(resultType);
           case TypeKind::REAL:
-            return std::make_unique<SetAggAggregate<float, true>>(resultType);
+            return std::make_unique<SparkSetAggAggregate<float>>(resultType);
           case TypeKind::DOUBLE:
-            return std::make_unique<SetAggAggregate<double, true>>(resultType);
+            return std::make_unique<SparkSetAggAggregate<double>>(resultType);
           case TypeKind::TIMESTAMP:
-            return std::make_unique<SetAggAggregate<Timestamp, true>>(
+            return std::make_unique<SparkSetAggAggregate<Timestamp>>(
                 resultType);
           case TypeKind::VARBINARY:
             [[fallthrough]];
           case TypeKind::VARCHAR:
-            return std::make_unique<SetAggAggregate<StringView, true>>(
+            return std::make_unique<SparkSetAggAggregate<StringView>>(
                 resultType);
           case TypeKind::ARRAY:
             [[fallthrough]];
           case TypeKind::ROW:
             // Nested nulls are allowed by setting 'throwOnNestedNulls' as
             // false.
-            return std::make_unique<SetAggAggregate<ComplexType, true>>(
+            return std::make_unique<SparkSetAggAggregate<ComplexType>>(
                 resultType, false);
           default:
             VELOX_UNSUPPORTED(


### PR DESCRIPTION
When ignoring nulls, if the group's accumulator is null, the corresponding 
result is an empty array.
Fixes https://github.com/facebookincubator/velox/issues/10736.