### PR TITLE
Fix Spark CAST(varchar as date) on year digits

### DIFF
--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -195,9 +195,11 @@ TEST_F(SparkCastExprTest, invalidDate) {
       "Unable to parse date value: \"2015-031-8\"",
       VARCHAR());
   testInvalidCast<std::string>(
+      "date", {"-1-1-1"}, "Unable to parse date value: \"-1-1-1\"", VARCHAR());
+  testInvalidCast<std::string>(
       "date",
-      {"-1-1-1"},
-      "Unable to parse date value: \"-1-1-1\"",
+      {"-111-1-1"},
+      "Unable to parse date value: \"-111-1-1\"",
       VARCHAR());
 }
 

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -107,7 +107,6 @@ TEST_F(SparkCastExprTest, date) {
        "1970-01-2",
        "1970-1-02",
        "+1970-01-02",
-       "-1-1-1",
        " 1970-01-01",
        std::nullopt},
       {0,
@@ -121,7 +120,6 @@ TEST_F(SparkCastExprTest, date) {
        1,
        1,
        1,
-       -719893,
        0,
        std::nullopt},
       VARCHAR(),
@@ -195,6 +193,11 @@ TEST_F(SparkCastExprTest, invalidDate) {
       "date",
       {"2015-031-8"},
       "Unable to parse date value: \"2015-031-8\"",
+      VARCHAR());
+  testInvalidCast<std::string>(
+      "date",
+      {"-1-1-1"},
+      "Unable to parse date value: \"-1-1-1\"",
       VARCHAR());
 }
 

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -196,14 +196,17 @@ TEST_F(SparkCastExprTest, invalidDate) {
       VARCHAR());
   testInvalidCast<std::string>(
       "date", {"-1-1-1"}, "Unable to parse date value: \"-1-1-1\"", VARCHAR());
-      testInvalidCast<std::string>(
-      "date", {"-11-1-1"}, "Unable to parse date value: \"-11-1-1\"", VARCHAR());
+  testInvalidCast<std::string>(
+      "date",
+      {"-11-1-1"},
+      "Unable to parse date value: \"-11-1-1\"",
+      VARCHAR());
   testInvalidCast<std::string>(
       "date",
       {"-111-1-1"},
       "Unable to parse date value: \"-111-1-1\"",
       VARCHAR());
-      testInvalidCast<std::string>(
+  testInvalidCast<std::string>(
       "date",
       {"- 1111-1-1"},
       "Unable to parse date value: \"- 1111-1-1\"",

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -196,10 +196,17 @@ TEST_F(SparkCastExprTest, invalidDate) {
       VARCHAR());
   testInvalidCast<std::string>(
       "date", {"-1-1-1"}, "Unable to parse date value: \"-1-1-1\"", VARCHAR());
+      testInvalidCast<std::string>(
+      "date", {"-11-1-1"}, "Unable to parse date value: \"-11-1-1\"", VARCHAR());
   testInvalidCast<std::string>(
       "date",
       {"-111-1-1"},
       "Unable to parse date value: \"-111-1-1\"",
+      VARCHAR());
+      testInvalidCast<std::string>(
+      "date",
+      {"- 1111-1-1"},
+      "Unable to parse date value: \"- 1111-1-1\"",
       VARCHAR());
 }
 

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -254,7 +254,13 @@ bool tryParseDateString(
       break;
     }
   }
-  // Spark digits of year must >= 4.
+  // Spark digits of year must >= 4. The following formats are allowed:
+  // `[+-]yyyy*`
+  // `[+-]yyyy*-[m]m`
+  // `[+-]yyyy*-[m]m-[d]d`
+  // `[+-]yyyy*-[m]m-[d]d `
+  // `[+-]yyyy*-[m]m-[d]d *`
+  // `[+-]yyyy*-[m]m-[d]dT*`
   if (mode == ParseMode::kSparkCast && pos - sign < 4) {
     return false;
   }

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -219,6 +219,7 @@ bool tryParseDateString(
   int32_t month = -1;
   int32_t year = 0;
   bool yearneg = false;
+  // Whether a sign is included in the date string.
   bool sign = false;
   int sep;
   if (mode != ParseMode::kIso8601) {

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -219,7 +219,7 @@ bool tryParseDateString(
   int32_t month = -1;
   int32_t year = 0;
   bool yearneg = false;
-  int signSize = 0;
+  bool sign = false;
   int sep;
   if (mode != ParseMode::kIso8601) {
     skipSpaces(buf, len, pos);
@@ -229,14 +229,14 @@ bool tryParseDateString(
     return false;
   }
   if (buf[pos] == '-') {
-    signSize = 1;
+    sign = true;
     yearneg = true;
     pos++;
     if (pos >= len) {
       return false;
     }
   } else if (buf[pos] == '+') {
-    signSize = 1;
+    sign = true;
     pos++;
     if (pos >= len) {
       return false;
@@ -254,7 +254,7 @@ bool tryParseDateString(
     }
   }
   // Spark digits of year must >= 4.
-  if (mode == ParseMode::kSparkCast && pos - signSize < 4) {
+  if (mode == ParseMode::kSparkCast && pos - sign < 4) {
     return false;
   }
   if (yearneg) {

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -219,6 +219,7 @@ bool tryParseDateString(
   int32_t month = -1;
   int32_t year = 0;
   bool yearneg = false;
+  int signSize = 0;
   int sep;
   if (mode != ParseMode::kIso8601) {
     skipSpaces(buf, len, pos);
@@ -228,12 +229,14 @@ bool tryParseDateString(
     return false;
   }
   if (buf[pos] == '-') {
+    signSize = 1;
     yearneg = true;
     pos++;
     if (pos >= len) {
       return false;
     }
   } else if (buf[pos] == '+') {
+    signSize = 1;
     pos++;
     if (pos >= len) {
       return false;
@@ -249,6 +252,10 @@ bool tryParseDateString(
     if (year > kMaxYear) {
       break;
     }
+  }
+  // Spark digits of year must >= 4.
+  if (mode == ParseMode::kSparkCast && pos - signSize < 4) {
+    return false;
   }
   if (yearneg) {
     year = checkedNegate(year);

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -254,13 +254,13 @@ bool tryParseDateString(
       break;
     }
   }
-  // Spark digits of year must >= 4. The following formats are allowed:
-  // `[+-]yyyy*`
-  // `[+-]yyyy*-[m]m`
-  // `[+-]yyyy*-[m]m-[d]d`
-  // `[+-]yyyy*-[m]m-[d]d `
-  // `[+-]yyyy*-[m]m-[d]d *`
-  // `[+-]yyyy*-[m]m-[d]dT*`
+  /// Spark digits of year must >= 4. The following formats are allowed:
+  /// `[+-]yyyy*`
+  /// `[+-]yyyy*-[m]m`
+  /// `[+-]yyyy*-[m]m-[d]d`
+  /// `[+-]yyyy*-[m]m-[d]d `
+  /// `[+-]yyyy*-[m]m-[d]d *`
+  /// `[+-]yyyy*-[m]m-[d]dT*`
   if (mode == ParseMode::kSparkCast && pos - sign < 4) {
     return false;
   }

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -218,12 +218,13 @@ TEST(DateTimeUtilTest, fromDateString) {
     EXPECT_EQ(1, parseDate("1970-1-02", mode));
 
     EXPECT_EQ(1, parseDate("+1970-01-02", mode));
-    EXPECT_EQ(-719893, parseDate("-1-1-1", mode));
 
     EXPECT_EQ(0, parseDate(" 1970-01-01", mode));
     EXPECT_EQ(0, parseDate("1970-01-01 ", mode));
     EXPECT_EQ(0, parseDate(" 1970-01-01 ", mode));
   }
+
+  EXPECT_EQ(-719893, parseDate("-1-1-1", ParseMode::kPrestoCast));
 
   EXPECT_EQ(3789391, parseDate("12345", ParseMode::kSparkCast));
   EXPECT_EQ(16436, parseDate("2015", ParseMode::kSparkCast));
@@ -277,6 +278,9 @@ TEST(DateTimeUtilTest, fromDateStringInvalid) {
     testCastFromDateStringInvalid("20150318", mode);
     testCastFromDateStringInvalid("2015-031-8", mode);
   }
+
+  testCastFromDateStringInvalid("-1-1-1", ParseMode::kSparkCast);
+  testCastFromDateStringInvalid("-111-1-1", ParseMode::kSparkCast);
 
   testCastFromDateStringInvalid("12345", ParseMode::kStrict);
   testCastFromDateStringInvalid("2015", ParseMode::kStrict);


### PR DESCRIPTION
Spark's year digits should be at least 4, so to cast '-1-1-1' as date is 
invalid.

Spark's implementation: https://github.com/apache/spark/blob/f4f24503bbde6e352a8326efdaf4aa4dd274d3d7/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/SparkDateTimeUtils.scala#L322