### PR TITLE
Back out "Optimize evaluation by reducing peeled vectors size"

### DIFF
--- a/velox/expression/PeeledEncoding.h
+++ b/velox/expression/PeeledEncoding.h
@@ -163,38 +163,19 @@ class PeeledEncoding {
   /// Takes a set of outer rows (rows defined over the peel) and a functor that
   /// is executed for each outer row which does not map to a null row.
   /// The outer and its corresponding inner row is passed to the functor.
-  template <typename F>
-  void applyToNonNullInnerRows(const SelectivityVector& outerRows, F&& func)
-      const {
-    auto* wrapNulls = wrapNulls_ ? wrapNulls_->as<uint64_t>() : nullptr;
-    switch (wrapEncoding_) {
-      case VectorEncoding::Simple::FLAT:
-        outerRows.applyToSelected([&](auto outerRow) {
-          if (wrapNulls && bits::isBitNull(wrapNulls, outerRow)) {
-            return;
-          }
-          func(outerRow, outerRow);
-        });
-        break;
-      case VectorEncoding::Simple::CONSTANT:
-        VELOX_CHECK_NULL(wrapNulls);
-        outerRows.applyToSelected(
-            [&](auto outerRow) { func(outerRow, constantWrapIndex_); });
-        break;
-      case VectorEncoding::Simple::DICTIONARY: {
-        auto indices = wrap_->as<vector_size_t>();
-        outerRows.applyToSelected([&](auto outerRow) {
-          // A known null in the outer row masks an error.
-          if (wrapNulls && bits::isBitNull(wrapNulls, outerRow)) {
-            return;
-          }
-          func(outerRow, indices[outerRow]);
-        });
-        break;
+  void applyToNonNullInnerRows(
+      const SelectivityVector& outerRows,
+      std::function<void(vector_size_t, vector_size_t)> func) const {
+    auto indices = wrap_ ? wrap_->as<vector_size_t>() : nullptr;
+    auto wrapNulls = wrapNulls_ ? wrapNulls_->as<uint64_t>() : nullptr;
+    outerRows.applyToSelected([&](auto outerRow) {
+      // A known null in the outer row masks an error.
+      if (wrapNulls && bits::isBitNull(wrapNulls, outerRow)) {
+        return;
       }
-      default:
-        VELOX_UNREACHABLE();
-    }
+      vector_size_t innerRow = indices ? indices[outerRow] : constantWrapIndex_;
+      func(outerRow, innerRow);
+    });
   }
 
  private:
@@ -214,32 +195,22 @@ class PeeledEncoding {
       const SelectivityVector& rows,
       BaseVector& firstWrapper);
 
-  void flattenPeeledVectors(
-      const SelectivityVector& rows,
-      const std::vector<bool>& constantFields,
-      std::vector<VectorPtr>& peeledVectors);
-
-  // The encoding of the peel. Set after getPeeledVectors() is called. Is equal
-  // to Flat if getPeeledVectors() has not been called or peeling was not
-  // successful.
+  /// The encoding of the peel. Set after getPeeledVectors() is called. Is equal
+  /// to Flat if getPeeledVectors() has not been called or peeling was not
+  /// successful.
   VectorEncoding::Simple wrapEncoding_ = VectorEncoding::Simple::FLAT;
 
-  // The dictionary indices. Only valid if wrapEncoding_ = DICTIONARY.
+  /// The dictionary indices. Only valid if wrapEncoding_ = DICTIONARY.
   BufferPtr wrap_;
 
-  // The dictionary nulls. Only valid if wrapEncoding_ = DICTIONARY.
+  /// The dictionary nulls. Only valid if wrapEncoding_ = DICTIONARY.
   BufferPtr wrapNulls_;
 
-  // The size of one of the peeled vectors. Only valid if wrapEncoding_ =
-  // DICTIONARY.
+  /// The size of one of the peeled vectors. Only valid if wrapEncoding_ =
+  /// DICTIONARY.
   vector_size_t baseSize_ = 0;
 
-  // The constant index. Only valid if wrapEncoding_ = CONSTANT.
+  /// The constant index. Only valid if wrapEncoding_ = CONSTANT.
   vector_size_t constantWrapIndex_ = 0;
-
-  // Deep copies of peeled vectors with low selectivity to avoid cost on unused
-  // rows.  Stored here to bring their lifecycles no shorter than PeeledEncoding
-  // object.
-  std::vector<VectorPtr> flattenPeeled_;
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2094,7 +2094,7 @@ TEST_F(ExprTest, memo) {
   // 1. correctly evaluates the unevaluated rows on subsequent runs
   // 2. Only caches results if it encounters the same base twice
   auto base = makeArrayVector<int64_t>(
-      500,
+      1'000,
       [](auto row) { return row % 5 + 1; },
       [](auto row, auto index) { return (row % 3) + index; });
 
@@ -2142,7 +2142,7 @@ TEST_F(ExprTest, memo) {
 
   // Create a new base
   base = makeArrayVector<int64_t>(
-      500,
+      1'000,
       [](auto row) { return row % 5 + 1; },
       [](auto row, auto index) { return (row % 3) + index; });
 

--- a/velox/expression/tests/PeeledEncodingTest.cpp
+++ b/velox/expression/tests/PeeledEncodingTest.cpp
@@ -72,13 +72,6 @@ class PeeledEncodingTest : public testing::Test, public VectorTestBase {
     }
   }
 
-  VectorPtr wrap(
-      const PeeledEncoding& peeledEncoding,
-      const VectorPtr& vector,
-      const SelectivityVector& rows) {
-    return peeledEncoding.wrap(vector->type(), pool(), vector, rows);
-  }
-
   void SetUp() override {
     VectorFuzzer::Options options;
     options.nullRatio = 0.3;
@@ -182,22 +175,12 @@ TEST_P(PeeledEncodingBasicTests, allCommonDictionaryLayers) {
   auto peeledEncoding = PeeledEncoding::peel(
       {input1, input2, input3}, rows, localDecodedVector, true, peeledVectors);
   ASSERT_EQ(peeledVectors.size(), 3);
-  if (rows.countSelected() > 1) {
-    ASSERT_EQ(
-        peeledEncoding->wrapEncoding(), VectorEncoding::Simple::DICTIONARY);
-    ASSERT_EQ(peeledVectors[0].get(), flat1.get());
-    ASSERT_EQ(peeledVectors[1].get(), const1.get());
-    ASSERT_EQ(peeledVectors[2].get(), peelWrappings(2, input3).get());
-  } else {
-    ASSERT_EQ(peeledEncoding->wrapEncoding(), VectorEncoding::Simple::FLAT);
-    ASSERT_EQ(peeledVectors[0]->encoding(), VectorEncoding::Simple::FLAT);
-  }
+  ASSERT_EQ(peeledEncoding->wrapEncoding(), VectorEncoding::Simple::DICTIONARY);
+  ASSERT_EQ(peeledVectors[0].get(), flat1.get());
+  ASSERT_EQ(peeledVectors[1].get(), const1.get());
+  ASSERT_EQ(peeledVectors[2].get(), peelWrappings(2, input3).get());
   assertEqualVectors(
-      input1, wrap(*peeledEncoding, peeledVectors[0], rows), rows);
-  assertEqualVectors(
-      input2, wrap(*peeledEncoding, peeledVectors[1], rows), rows);
-  assertEqualVectors(
-      input3, wrap(*peeledEncoding, peeledVectors[2], rows), rows);
+      input1, peeledEncoding->wrap(flat1->type(), pool(), flat1, rows), rows);
 }
 
 TEST_P(PeeledEncodingBasicTests, someCommonDictionaryLayers) {
@@ -217,25 +200,14 @@ TEST_P(PeeledEncodingBasicTests, someCommonDictionaryLayers) {
   auto peeledEncoding = PeeledEncoding::peel(
       {input1, input2, input3}, rows, localDecodedVector, true, peeledVectors);
   ASSERT_EQ(peeledVectors.size(), 3);
-  if (rows.countSelected() > 1) {
-    ASSERT_EQ(
-        peeledEncoding->wrapEncoding(), VectorEncoding::Simple::DICTIONARY);
-    ASSERT_EQ(peeledVectors[0].get(), peelWrappings(1, input1).get());
-    ASSERT_EQ(peeledVectors[1].get(), peelWrappings(1, input2).get());
-    ASSERT_EQ(peeledVectors[2].get(), peelWrappings(1, input3).get());
-    assertEqualVectors(
-        wrapInDictionaryLayers(flat1, {&dictWrap1}),
-        peeledEncoding->wrap(flat1->type(), pool(), flat1, rows),
-        rows);
-  } else {
-    ASSERT_EQ(peeledEncoding->wrapEncoding(), VectorEncoding::Simple::FLAT);
-  }
+  ASSERT_EQ(peeledEncoding->wrapEncoding(), VectorEncoding::Simple::DICTIONARY);
+  ASSERT_EQ(peeledVectors[0].get(), peelWrappings(1, input1).get());
+  ASSERT_EQ(peeledVectors[1].get(), peelWrappings(1, input2).get());
+  ASSERT_EQ(peeledVectors[2].get(), peelWrappings(1, input3).get());
   assertEqualVectors(
-      input1, wrap(*peeledEncoding, peeledVectors[0], rows), rows);
-  assertEqualVectors(
-      input2, wrap(*peeledEncoding, peeledVectors[1], rows), rows);
-  assertEqualVectors(
-      input3, wrap(*peeledEncoding, peeledVectors[2], rows), rows);
+      wrapInDictionaryLayers(flat1, {&dictWrap1}),
+      peeledEncoding->wrap(flat1->type(), pool(), flat1, rows),
+      rows);
 }
 
 TEST_P(PeeledEncodingBasicTests, commonDictionaryLayersAndAConstant) {
@@ -256,23 +228,15 @@ TEST_P(PeeledEncodingBasicTests, commonDictionaryLayersAndAConstant) {
   auto peeledEncoding = PeeledEncoding::peel(
       {input1, input2, input3}, rows, localDecodedVector, true, peeledVectors);
   ASSERT_EQ(peeledVectors.size(), 3);
-  if (rows.countSelected() > 1) {
-    ASSERT_EQ(
-        peeledEncoding->wrapEncoding(), VectorEncoding::Simple::DICTIONARY);
-    ASSERT_EQ(peeledVectors[0].get(), flat1.get());
-    ASSERT_EQ(peeledVectors[2].get(), peelWrappings(2, input3).get());
-    if (peeledVectors[1].get() != const1.get()) {
-      // In case the constant is resized to match other peeledVector's size.
-      assertEqualVectors(peeledVectors[1], const1, rows);
-    }
-  } else {
-    ASSERT_EQ(peeledEncoding->wrapEncoding(), VectorEncoding::Simple::FLAT);
-    ASSERT_EQ(peeledVectors[1].get(), const1.get());
+  ASSERT_EQ(peeledEncoding->wrapEncoding(), VectorEncoding::Simple::DICTIONARY);
+  ASSERT_EQ(peeledVectors[0].get(), flat1.get());
+  if (peeledVectors[1].get() != const1.get()) {
+    // In case the constant is resized to match other peeledVector's size.
+    assertEqualVectors(peeledVectors[1], const1, rows);
   }
+  ASSERT_EQ(peeledVectors[2].get(), peelWrappings(2, input3).get());
   assertEqualVectors(
-      input1, wrap(*peeledEncoding, peeledVectors[0], rows), rows);
-  assertEqualVectors(
-      input3, wrap(*peeledEncoding, peeledVectors[2], rows), rows);
+      input1, peeledEncoding->wrap(flat1->type(), pool(), flat1, rows), rows);
 }
 
 TEST_P(PeeledEncodingBasicTests, singleConstantEncodedVector) {
@@ -415,27 +379,17 @@ TEST_P(PeeledEncodingBasicTests, dictionaryLayersHavingNulls) {
   auto peeledEncoding = PeeledEncoding::peel(
       {input1, input2, input3}, rows, localDecodedVector, false, peeledVectors);
   ASSERT_EQ(peeledVectors.size(), 3);
-  if (rows.countSelected() > 1) {
-    ASSERT_EQ(
-        peeledEncoding->wrapEncoding(), VectorEncoding::Simple::DICTIONARY);
-    ASSERT_EQ(peeledVectors[0].get(), peelWrappings(1, input1).get());
-    if (peeledVectors[1].get() != const1.get()) {
-      // In case the constant is resized to match other peeledVector's size.
-      assertEqualVectors(peeledVectors[1], const1, rows);
-    }
-    ASSERT_EQ(peeledVectors[2].get(), peelWrappings(1, input3).get());
-    assertEqualVectors(
-        wrapInDictionaryLayers(flat1, {&dictNoNulls}),
-        peeledEncoding->wrap(flat1->type(), pool(), flat1, rows),
-        rows);
-  } else {
-    ASSERT_EQ(peeledEncoding->wrapEncoding(), VectorEncoding::Simple::FLAT);
-    ASSERT_EQ(peeledVectors[1].get(), const1.get());
+  ASSERT_EQ(peeledEncoding->wrapEncoding(), VectorEncoding::Simple::DICTIONARY);
+  ASSERT_EQ(peeledVectors[0].get(), peelWrappings(1, input1).get());
+  if (peeledVectors[1].get() != const1.get()) {
+    // In case the constant is resized to match other peeledVector's size.
+    assertEqualVectors(peeledVectors[1], const1, rows);
   }
+  ASSERT_EQ(peeledVectors[2].get(), peelWrappings(1, input3).get());
   assertEqualVectors(
-      input1, wrap(*peeledEncoding, peeledVectors[0], rows), rows);
-  assertEqualVectors(
-      input3, wrap(*peeledEncoding, peeledVectors[2], rows), rows);
+      wrapInDictionaryLayers(flat1, {&dictNoNulls}),
+      peeledEncoding->wrap(flat1->type(), pool(), flat1, rows),
+      rows);
 }
 
 TEST_P(PeeledEncodingBasicTests, constantResize) {
@@ -453,19 +407,15 @@ TEST_P(PeeledEncodingBasicTests, constantResize) {
   auto peeledEncoding = PeeledEncoding::peel(
       {input1, input2}, rows, localDecodedVector, true, peeledVectors);
   ASSERT_EQ(peeledVectors.size(), 2);
-  if (rows.countSelected() > 1) {
-    ASSERT_EQ(
-        peeledEncoding->wrapEncoding(), VectorEncoding::Simple::DICTIONARY);
-    ASSERT_EQ(peeledVectors[0].get(), flatLarge.get());
-    ASSERT_NE(peeledVectors[1].get(), const1.get());
-    ASSERT_EQ(peeledVectors[1]->encoding(), VectorEncoding::Simple::CONSTANT);
-    ASSERT_EQ(peeledVectors[1]->size(), 2 * vectorSize_);
-  } else {
-    ASSERT_EQ(peeledEncoding->wrapEncoding(), VectorEncoding::Simple::FLAT);
-    ASSERT_EQ(peeledVectors[1].get(), const1.get());
-  }
+  ASSERT_EQ(peeledEncoding->wrapEncoding(), VectorEncoding::Simple::DICTIONARY);
+  ASSERT_EQ(peeledVectors[0].get(), flatLarge.get());
+  ASSERT_NE(peeledVectors[1].get(), const1.get());
+  ASSERT_EQ(peeledVectors[1]->encoding(), VectorEncoding::Simple::CONSTANT);
+  ASSERT_EQ(peeledVectors[1]->size(), 2 * vectorSize_);
   assertEqualVectors(
-      input1, wrap(*peeledEncoding, peeledVectors[0], rows), rows);
+      input1,
+      peeledEncoding->wrap(flatLarge->type(), pool(), flatLarge, rows),
+      rows);
 }
 
 TEST_P(PeeledEncodingBasicTests, intermidiateLazyLayer) {
@@ -484,21 +434,13 @@ TEST_P(PeeledEncodingBasicTests, intermidiateLazyLayer) {
   auto peeledEncoding = PeeledEncoding::peel(
       {input1}, rows, localDecodedVector, true, peeledVectors);
   ASSERT_EQ(peeledVectors.size(), 1);
+  ASSERT_EQ(peeledEncoding->wrapEncoding(), VectorEncoding::Simple::DICTIONARY);
   ASSERT_TRUE(peeledVectors[0]->isFlatEncoding());
   // Loading generates a new vector so we compare their contents instead.
   LocalSelectivityVector traslatedRowsHolder(execCtx_);
   auto translatedRows =
       peeledEncoding->translateToInnerRows(rows, traslatedRowsHolder);
-  if (rows.countSelected() > 1) {
-    ASSERT_EQ(
-        peeledEncoding->wrapEncoding(), VectorEncoding::Simple::DICTIONARY);
-    assertEqualVectors(peeledVectors[0], flat1, *translatedRows);
-  } else {
-    ASSERT_EQ(peeledEncoding->wrapEncoding(), VectorEncoding::Simple::FLAT);
-    assertEqualVectors(
-        input1, wrap(*peeledEncoding, peeledVectors[0], rows), rows);
-    ASSERT_EQ(*translatedRows, rows);
-  }
+  assertEqualVectors(peeledVectors[0], flat1, *translatedRows);
 }
 
 TEST_F(PeeledEncodingTest, peelingFails) {


### PR DESCRIPTION
Summary:
This reverses an optimization in peeling where a flat vector is
created as a peeled vector if the number of rows to peel is less
than 1/8 the size of the dictionary's alphabet, to prevent the
circulation of large peeled vectors that can cause large
intermediate allocations and affect memory and performance.

This resulted in a bug where the Common sub expression optimization,
that relies on the address of the input vector to re-use the cached
result, would get a different flat vector in its subsequent
invocation but would have the same memory address and assume it can
re-use the cached results. This would then cause wrong results. 

Original commit changeset: 23ef4c590eba

Original Phabricator Diff: D60064934

Differential Revision: D61240010
