### PR TITLE
Schema evolution support for reader value hooks

### DIFF
--- a/velox/dwio/common/ColumnVisitors.h
+++ b/velox/dwio/common/ColumnVisitors.h
@@ -97,7 +97,7 @@ class ExtractToHook {
 
   template <typename V>
   void addValue(vector_size_t rowIndex, V value) {
-    hook_.addValue(rowIndex, &value);
+    hook_.addValueTyped(rowIndex, value);
   }
 
   auto& hook() {
@@ -126,7 +126,7 @@ class ExtractToGenericHook {
 
   template <typename V>
   void addValue(vector_size_t rowIndex, V value) {
-    hook_->addValue(rowIndex, &value);
+    hook_->addValueTyped(rowIndex, value);
   }
 
   ValueHook& hook() {
@@ -819,8 +819,7 @@ class DictionaryColumnVisitor
                     : velox::iota(super::numRows_, super::innerNonNullRows()) +
                     super::rowIndex_,
             values,
-            numInput,
-            sizeof(T));
+            numInput);
         super::rowIndex_ += numInput;
         return;
       }
@@ -1389,14 +1388,14 @@ class ExtractStringDictionaryToGenericHook {
     // according to the index. Stride dictionary indices are offset up
     // by the stripe dict size.
     if (value < dictionarySize()) {
-      auto view = folly::StringPiece(
-          reinterpret_cast<const StringView*>(state_.dictionary.values)[value]);
-      hook_->addValue(rowIndex, &view);
+      auto* strings =
+          reinterpret_cast<const StringView*>(state_.dictionary.values);
+      hook_->addValue(rowIndex, strings[value]);
     } else {
       VELOX_DCHECK(state_.inDictionary);
-      auto view = folly::StringPiece(reinterpret_cast<const StringView*>(
-          state_.dictionary2.values)[value - dictionarySize()]);
-      hook_->addValue(rowIndex, &view);
+      auto* strings =
+          reinterpret_cast<const StringView*>(state_.dictionary2.values);
+      hook_->addValue(rowIndex, strings[value - dictionarySize()]);
     }
   }
 

--- a/velox/dwio/common/DecoderUtil.h
+++ b/velox/dwio/common/DecoderUtil.h
@@ -180,7 +180,7 @@ void fixedWidthScan(
       [&](T value, int32_t rowIndex) {
         if (!hasFilter) {
           if (hasHook) {
-            hook.addValue(scatterRows[rowIndex], &value);
+            hook.addValueTyped(scatterRows[rowIndex], value);
           } else {
             auto targetRow = scatter ? scatterRows[rowIndex] : rowIndex;
             rawValues[targetRow] = value;
@@ -214,8 +214,7 @@ void fixedWidthScan(
                   hook.addValues(
                       scatterRows + rowIndex,
                       buffer + firstRow - rowOffset,
-                      kStep,
-                      sizeof(T));
+                      kStep);
                 } else {
                   if (scatter) {
                     scatterDense(
@@ -266,7 +265,9 @@ void fixedWidthScan(
                 if (!hasFilter) {
                   if (hasHook) {
                     hook.addValues(
-                        scatterRows + rowIndex, &values, kWidth, sizeof(T));
+                        scatterRows + rowIndex,
+                        reinterpret_cast<T*>(&values),
+                        kWidth);
                   } else {
                     if (scatter) {
                       scatterDense<T>(
@@ -322,7 +323,9 @@ void fixedWidthScan(
                 if (!hasFilter) {
                   if (hasHook) {
                     hook.addValues(
-                        scatterRows + rowIndex, &values, width, sizeof(T));
+                        scatterRows + rowIndex,
+                        reinterpret_cast<T*>(&values),
+                        width);
                   } else {
                     if (scatter) {
                       scatterDense<T>(
@@ -473,7 +476,7 @@ void processFixedWidthRun(
   constexpr bool hasHook = !std::is_same_v<THook, NoHook>;
   if (!hasFilter) {
     if (hasHook) {
-      hook.addValues(scatterRows + rowIndex, values, rows.size(), sizeof(T));
+      hook.addValues(scatterRows + rowIndex, values, rows.size());
     } else if (scatter) {
       scatterNonNulls(rowIndex, numInput, numValues, scatterRows, values);
       numValues = scatterRows[rowIndex + numInput - 1] + 1;

--- a/velox/dwio/common/SelectiveByteRleColumnReader.h
+++ b/velox/dwio/common/SelectiveByteRleColumnReader.h
@@ -149,17 +149,13 @@ void SelectiveByteRleColumnReader::processValueHook(
     ValueHook* hook) {
   using namespace facebook::velox::aggregate;
   switch (hook->kind()) {
-    case aggregate::AggregationHook::kSumBigintToBigint:
+    case aggregate::AggregationHook::kBigintSum:
       readHelper<Reader, velox::common::AlwaysTrue, isDense>(
-          &dwio::common::alwaysTrue(),
-          rows,
-          dwio::common::ExtractToHook<SumHook<int64_t, int64_t>>(hook));
+          &alwaysTrue(), rows, ExtractToHook<SumHook<int64_t>>(hook));
       break;
     default:
       readHelper<Reader, velox::common::AlwaysTrue, isDense>(
-          &dwio::common::alwaysTrue(),
-          rows,
-          dwio::common::ExtractToGenericHook(hook));
+          &alwaysTrue(), rows, ExtractToGenericHook(hook));
   }
 }
 

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -734,10 +734,19 @@ velox::common::AlwaysTrue& alwaysTrue();
 } // namespace facebook::velox::dwio::common
 
 namespace facebook::velox::dwio::common {
+
 // Template parameter to indicate no hook in fast scan path. This is
 // referenced in decoders, thus needs to be declared in a header.
-struct NoHook : public ValueHook {
-  void addValue(vector_size_t /*row*/, const void* /*value*/) override {}
+struct NoHook final : public ValueHook {
+  void addValue(vector_size_t /*row*/, int64_t /*value*/) final {}
+
+  void addValue(vector_size_t /*row*/, int128_t /*value*/) final {}
+
+  void addValue(vector_size_t /*row*/, float /*value*/) final {}
+
+  void addValue(vector_size_t /*row*/, double /*value*/) final {}
+
+  void addValue(vector_size_t /*row*/, folly::StringPiece /*value*/) final {}
 };
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/SelectiveFloatingPointColumnReader.h
+++ b/velox/dwio/common/SelectiveFloatingPointColumnReader.h
@@ -45,7 +45,7 @@ class SelectiveFloatingPointColumnReader : public SelectiveColumnReader {
   readCommon(vector_size_t offset, RowSet rows, const uint64_t* incomingNulls);
 
   void getValues(RowSet rows, VectorPtr* result) override {
-    getFlatValues<TRequested, TRequested>(rows, result, requestedType_);
+    getFlatValues<TData, TRequested>(rows, result, requestedType_);
   }
 
  protected:
@@ -83,7 +83,7 @@ void SelectiveFloatingPointColumnReader<TData, TRequested>::readHelper(
     ExtractValues extractValues) {
   reinterpret_cast<Reader*>(this)->readWithVisitor(
       rows,
-      ColumnVisitor<TRequested, TFilter, ExtractValues, isDense>(
+      ColumnVisitor<TData, TFilter, ExtractValues, isDense>(
           *reinterpret_cast<TFilter*>(filter), this, rows, extractValues));
 }
 
@@ -145,27 +145,17 @@ void SelectiveFloatingPointColumnReader<TData, TRequested>::processValueHook(
     RowSet rows,
     ValueHook* hook) {
   switch (hook->kind()) {
-    case aggregate::AggregationHook::kSumFloatToDouble:
+    case aggregate::AggregationHook::kDoubleSum:
       readHelper<Reader, velox::common::AlwaysTrue, isDense>(
-          &alwaysTrue(),
-          rows,
-          ExtractToHook<aggregate::SumHook<float, double>>(hook));
+          &alwaysTrue(), rows, ExtractToHook<aggregate::SumHook<double>>(hook));
       break;
-    case aggregate::AggregationHook::kSumDoubleToDouble:
-      readHelper<Reader, velox::common::AlwaysTrue, isDense>(
-          &alwaysTrue(),
-          rows,
-          ExtractToHook<aggregate::SumHook<double, double>>(hook));
-      break;
-    case aggregate::AggregationHook::kFloatMax:
-    case aggregate::AggregationHook::kDoubleMax:
+    case aggregate::AggregationHook::kFloatingPointMax:
       readHelper<Reader, velox::common::AlwaysTrue, isDense>(
           &alwaysTrue(),
           rows,
           ExtractToHook<aggregate::MinMaxHook<TRequested, false>>(hook));
       break;
-    case aggregate::AggregationHook::kFloatMin:
-    case aggregate::AggregationHook::kDoubleMin:
+    case aggregate::AggregationHook::kFloatingPointMin:
       readHelper<Reader, velox::common::AlwaysTrue, isDense>(
           &alwaysTrue(),
           rows,
@@ -183,7 +173,7 @@ void SelectiveFloatingPointColumnReader<TData, TRequested>::readCommon(
     vector_size_t offset,
     RowSet rows,
     const uint64_t* incomingNulls) {
-  prepareRead<TRequested>(offset, rows, incomingNulls);
+  prepareRead<TData>(offset, rows, incomingNulls);
   bool isDense = rows.back() == rows.size() - 1;
   if (scanSpec_->keepValues()) {
     if (scanSpec_->valueHook()) {

--- a/velox/dwio/common/SelectiveIntegerColumnReader.h
+++ b/velox/dwio/common/SelectiveIntegerColumnReader.h
@@ -53,7 +53,7 @@ class SelectiveIntegerColumnReader : public SelectiveColumnReader {
 
   // Switches based on the type of ValueHook between different readWithVisitor
   // instantiations.
-  template <typename Reader, bool isDence>
+  template <typename Reader, bool isDense>
   void processValueHook(RowSet rows, ValueHook* hook);
 
   // Instantiates a Visitor based on type, isDense, value processing.
@@ -196,17 +196,17 @@ void SelectiveIntegerColumnReader::processValueHook(
     RowSet rows,
     ValueHook* hook) {
   switch (hook->kind()) {
-    case aggregate::AggregationHook::kSumBigintToBigint:
+    case aggregate::AggregationHook::kBigintSum:
       readHelper<Reader, velox::common::AlwaysTrue, isDense>(
           &alwaysTrue(),
           rows,
-          ExtractToHook<aggregate::SumHook<int64_t, int64_t, false>>(hook));
+          ExtractToHook<aggregate::SumHook<int64_t, false>>(hook));
       break;
-    case aggregate::AggregationHook::kSumBigintToBigintOverflow:
+    case aggregate::AggregationHook::kBigintSumOverflow:
       readHelper<Reader, velox::common::AlwaysTrue, isDense>(
           &alwaysTrue(),
           rows,
-          ExtractToHook<aggregate::SumHook<int64_t, int64_t, true>>(hook));
+          ExtractToHook<aggregate::SumHook<int64_t, true>>(hook));
       break;
     case aggregate::AggregationHook::kBigintMax:
       readHelper<Reader, velox::common::AlwaysTrue, isDense>(

--- a/velox/dwio/common/tests/DecoderUtilTest.cpp
+++ b/velox/dwio/common/tests/DecoderUtilTest.cpp
@@ -166,9 +166,8 @@ namespace facebook::velox::dwio::common {
 struct NoHook {
   void addValues(
       const int32_t* /*rows*/,
-      const void* /*values*/,
-      int32_t /*size*/,
-      uint8_t /*valueWidth*/) {}
+      const int32_t* /*values*/,
+      int32_t /*size*/) {}
 };
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.h
@@ -39,21 +39,41 @@ class TestingHook : public ValueHook {
  public:
   explicit TestingHook(FlatVector<T>* result) : result_(result) {}
 
-  void addValue(vector_size_t row, const void* value) override {
-    result_->set(row, *reinterpret_cast<const T*>(value));
+  void addValue(vector_size_t row, int64_t value) override {
+    if constexpr (std::is_integral_v<T>) {
+      result_->set(row, value);
+    } else {
+      VELOX_FAIL();
+    }
+  }
+
+  void addValue(vector_size_t row, float value) override {
+    if constexpr (std::is_same_v<T, float>) {
+      result_->set(row, value);
+    } else {
+      VELOX_FAIL();
+    }
+  }
+
+  void addValue(vector_size_t row, double value) override {
+    if constexpr (std::is_same_v<T, double>) {
+      result_->set(row, value);
+    } else {
+      VELOX_FAIL();
+    }
+  }
+
+  void addValue(vector_size_t row, folly::StringPiece value) override {
+    if constexpr (std::is_same_v<T, StringView>) {
+      result_->set(row, StringView(value));
+    } else {
+      VELOX_FAIL();
+    }
   }
 
  private:
   FlatVector<T>* result_;
 };
-
-template <>
-inline void TestingHook<StringView>::addValue(
-    vector_size_t row,
-    const void* value) {
-  result_->set(
-      row, StringView(*reinterpret_cast<const folly::StringPiece*>(value)));
-}
 
 // Utility for checking that a subsequent batch of output does not
 // overwrite internals of a possibly retained previous batch.

--- a/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.cpp
@@ -112,6 +112,7 @@ void SelectiveDecimalColumnReader<DataT>::read(
     RowSet rows,
     const uint64_t* incomingNulls) {
   VELOX_CHECK(!scanSpec_->filter());
+  VELOX_CHECK(!scanSpec_->valueHook());
   prepareRead<int64_t>(offset, rows, incomingNulls);
   bool isDense = rows.back() == rows.size() - 1;
   if (isDense) {

--- a/velox/functions/lib/aggregates/MinMaxAggregateBase.cpp
+++ b/velox/functions/lib/aggregates/MinMaxAggregateBase.cpp
@@ -110,15 +110,14 @@ class MaxAggregate : public MinMaxAggregate<T> {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool mayPushdown) override {
-    // Re-enable pushdown for TIMESTAMP after
-    // https://github.com/facebookincubator/velox/issues/6297 is fixed.
-    if (args[0]->typeKind() == TypeKind::TIMESTAMP) {
+    if constexpr (BaseAggregate::template kMayPushdown<T>) {
+      if (mayPushdown && args[0]->isLazy()) {
+        BaseAggregate::template pushdown<
+            velox::aggregate::MinMaxHook<T, false>>(groups, rows, args[0]);
+        return;
+      }
+    } else {
       mayPushdown = false;
-    }
-    if (mayPushdown && args[0]->isLazy()) {
-      BaseAggregate::template pushdown<velox::aggregate::MinMaxHook<T, false>>(
-          groups, rows, args[0]);
-      return;
     }
     BaseAggregate::template updateGroups<true, T>(
         groups, rows, args[0], updateGroup, mayPushdown);
@@ -208,15 +207,14 @@ class MinAggregate : public MinMaxAggregate<T> {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool mayPushdown) override {
-    // Re-enable pushdown for TIMESTAMP after
-    // https://github.com/facebookincubator/velox/issues/6297 is fixed.
-    if (args[0]->typeKind() == TypeKind::TIMESTAMP) {
+    if constexpr (BaseAggregate::template kMayPushdown<T>) {
+      if (mayPushdown && args[0]->isLazy()) {
+        BaseAggregate::template pushdown<velox::aggregate::MinMaxHook<T, true>>(
+            groups, rows, args[0]);
+        return;
+      }
+    } else {
       mayPushdown = false;
-    }
-    if (mayPushdown && args[0]->isLazy()) {
-      BaseAggregate::template pushdown<velox::aggregate::MinMaxHook<T, true>>(
-          groups, rows, args[0]);
-      return;
     }
     BaseAggregate::template updateGroups<true, T>(
         groups, rows, args[0], updateGroup, mayPushdown);

--- a/velox/functions/lib/aggregates/SimpleNumericAggregate.h
+++ b/velox/functions/lib/aggregates/SimpleNumericAggregate.h
@@ -35,6 +35,10 @@ class SimpleNumericAggregate : public exec::Aggregate {
   }
 
  protected:
+  template <typename T>
+  static constexpr bool kMayPushdown = !std::is_same_v<T, int128_t> &&
+      !std::is_same_v<T, Timestamp> && !std::is_same_v<T, UnknownValue>;
+
   // TData is either TAccumulator or TResult, which in most cases are the same,
   // but for sum(real) can differ.
   template <typename TData = TResult, typename ExtractOneValue>
@@ -95,20 +99,21 @@ class SimpleNumericAggregate : public exec::Aggregate {
       bool mayPushdown) {
     DecodedVector decoded(*arg, rows, !mayPushdown);
     auto encoding = decoded.base()->encoding();
-    if (encoding == VectorEncoding::Simple::LAZY) {
-      velox::aggregate::SimpleCallableHook<TValue, TData, UpdateSingleValue>
-          hook(
-              exec::Aggregate::offset_,
-              exec::Aggregate::nullByte_,
-              exec::Aggregate::nullMask_,
-              groups,
-              &this->exec::Aggregate::numNulls_,
-              updateSingleValue);
+    if constexpr (kMayPushdown<TData>) {
+      if (encoding == VectorEncoding::Simple::LAZY) {
+        velox::aggregate::SimpleCallableHook<TData, UpdateSingleValue> hook(
+            exec::Aggregate::offset_,
+            exec::Aggregate::nullByte_,
+            exec::Aggregate::nullMask_,
+            groups,
+            &this->exec::Aggregate::numNulls_,
+            updateSingleValue);
 
-      auto indices = decoded.indices();
-      decoded.base()->as<const LazyVector>()->load(
-          RowSet(indices, arg->size()), &hook);
-      return;
+        auto indices = decoded.indices();
+        decoded.base()->as<const LazyVector>()->load(
+            RowSet(indices, arg->size()), &hook);
+        return;
+      }
     }
 
     if (decoded.isConstantMapping()) {

--- a/velox/functions/lib/aggregates/tests/SumTestBase.h
+++ b/velox/functions/lib/aggregates/tests/SumTestBase.h
@@ -46,7 +46,7 @@ void testHookLimits(bool expectOverflow = false) {
     ResultType expected = 0;
     char* row = reinterpret_cast<char*>(&sumRow);
     uint64_t numNulls = 0;
-    facebook::velox::aggregate::SumHook<InputType, ResultType, Overflow> hook(
+    facebook::velox::aggregate::SumHook<ResultType, Overflow> hook(
         offsetof(SumRow<ResultType>, sum),
         offsetof(SumRow<ResultType>, nulls),
         0,
@@ -54,14 +54,14 @@ void testHookLimits(bool expectOverflow = false) {
         &numNulls);
 
     // Adding limit should not overflow.
-    ASSERT_NO_THROW(hook.addValue(0, &limit));
+    ASSERT_NO_THROW(hook.addValueTyped(0, limit));
     expected += limit;
     EXPECT_EQ(expected, sumRow.sum);
     // Adding overflow based on the ResultType should throw.
     if (expectOverflow) {
-      VELOX_ASSERT_THROW(hook.addValue(0, &overflow), "overflow");
+      VELOX_ASSERT_THROW(hook.addValueTyped(0, overflow), "overflow");
     } else {
-      ASSERT_NO_THROW(hook.addValue(0, &overflow));
+      ASSERT_NO_THROW(hook.addValueTyped(0, overflow));
       expected += overflow;
       EXPECT_EQ(expected, sumRow.sum);
     }

--- a/velox/functions/prestosql/aggregates/tests/SumTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SumTest.cpp
@@ -405,7 +405,7 @@ TEST_F(SumTest, hook) {
 
   char* row = reinterpret_cast<char*>(&sumRow);
   uint64_t numNulls = 1;
-  aggregate::SumHook<int64_t, int64_t> hook(
+  aggregate::SumHook<int64_t> hook(
       offsetof(SumRow<int64_t>, sum),
       offsetof(SumRow<int64_t>, nulls),
       1,
@@ -413,7 +413,7 @@ TEST_F(SumTest, hook) {
       &numNulls);
 
   int64_t value = 11;
-  hook.addValue(0, &value);
+  hook.addValue(0, value);
   EXPECT_EQ(0, sumRow.nulls);
   EXPECT_EQ(0, numNulls);
   EXPECT_EQ(value, sumRow.sum);

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -78,7 +78,11 @@ class TestingLoader : public VectorLoader {
         }
       } else {
         T value = values->valueAt(row);
-        hook->addValue(i, &value);
+        if constexpr (std::is_same_v<T, Timestamp>) {
+          VELOX_FAIL();
+        } else {
+          hook->addValueTyped(i, value);
+        }
       }
     }
   }
@@ -2016,12 +2020,12 @@ class TestingHook : public ValueHook {
     return false;
   }
 
-  void addValue(vector_size_t row, const void* value) override {
+  void addValue(vector_size_t row, int64_t value) override {
     if (values_->isNullAt(rows_[row])) {
       ++errors_;
     } else {
       auto original = values_->valueAt(rows_[row]);
-      if (original != *reinterpret_cast<const int64_t*>(value)) {
+      if (original != value) {
         ++errors_;
       }
     }


### PR DESCRIPTION
Summary: Currently reader value hook is not considering schema evolution at all, this change fix that.

Differential Revision: D61229494
