### PR TITLE
Use ASSERT_STREQ when comparing C-strings

### DIFF
--- a/velox/functions/prestosql/types/tests/HyperLogLogTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/HyperLogLogTypeTest.cpp
@@ -26,8 +26,8 @@ class HyperLogLogTypeTest : public testing::Test, public TypeTestBase {
 };
 
 TEST_F(HyperLogLogTypeTest, basic) {
-  ASSERT_EQ(HYPERLOGLOG()->name(), "HYPERLOGLOG");
-  ASSERT_EQ(HYPERLOGLOG()->kindName(), "VARBINARY");
+  ASSERT_STREQ(HYPERLOGLOG()->name(), "HYPERLOGLOG");
+  ASSERT_STREQ(HYPERLOGLOG()->kindName(), "VARBINARY");
   ASSERT_TRUE(HYPERLOGLOG()->parameters().empty());
   ASSERT_EQ(HYPERLOGLOG()->toString(), "HYPERLOGLOG");
 

--- a/velox/functions/prestosql/types/tests/IPAddressTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/IPAddressTypeTest.cpp
@@ -26,8 +26,8 @@ class IPAddressTypeTest : public testing::Test, public TypeTestBase {
 };
 
 TEST_F(IPAddressTypeTest, basic) {
-  ASSERT_EQ(IPADDRESS()->name(), "IPADDRESS");
-  ASSERT_EQ(IPADDRESS()->kindName(), "HUGEINT");
+  ASSERT_STREQ(IPADDRESS()->name(), "IPADDRESS");
+  ASSERT_STREQ(IPADDRESS()->kindName(), "HUGEINT");
   ASSERT_TRUE(IPADDRESS()->parameters().empty());
   ASSERT_EQ(IPADDRESS()->toString(), "IPADDRESS");
 

--- a/velox/functions/prestosql/types/tests/JsonTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/JsonTypeTest.cpp
@@ -26,8 +26,8 @@ class JsonTypeTest : public testing::Test, public TypeTestBase {
 };
 
 TEST_F(JsonTypeTest, basic) {
-  ASSERT_EQ(JSON()->name(), "JSON");
-  ASSERT_EQ(JSON()->kindName(), "VARCHAR");
+  ASSERT_STREQ(JSON()->name(), "JSON");
+  ASSERT_STREQ(JSON()->kindName(), "VARCHAR");
   ASSERT_TRUE(JSON()->parameters().empty());
   ASSERT_EQ(JSON()->toString(), "JSON");
 

--- a/velox/functions/prestosql/types/tests/TimestampWithTimeZoneTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/TimestampWithTimeZoneTypeTest.cpp
@@ -27,8 +27,8 @@ class TimestampWithTimeZoneTypeTest : public testing::Test,
 };
 
 TEST_F(TimestampWithTimeZoneTypeTest, basic) {
-  ASSERT_EQ(TIMESTAMP_WITH_TIME_ZONE()->name(), "TIMESTAMP WITH TIME ZONE");
-  ASSERT_EQ(TIMESTAMP_WITH_TIME_ZONE()->kindName(), "BIGINT");
+  ASSERT_STREQ(TIMESTAMP_WITH_TIME_ZONE()->name(), "TIMESTAMP WITH TIME ZONE");
+  ASSERT_STREQ(TIMESTAMP_WITH_TIME_ZONE()->kindName(), "BIGINT");
   ASSERT_TRUE(TIMESTAMP_WITH_TIME_ZONE()->parameters().empty());
   ASSERT_EQ(TIMESTAMP_WITH_TIME_ZONE()->toString(), "TIMESTAMP WITH TIME ZONE");
 

--- a/velox/functions/prestosql/types/tests/UuidTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/UuidTypeTest.cpp
@@ -26,8 +26,8 @@ class UuidTypeTest : public testing::Test, public TypeTestBase {
 };
 
 TEST_F(UuidTypeTest, basic) {
-  ASSERT_EQ(UUID()->name(), "UUID");
-  ASSERT_EQ(std::string(UUID()->kindName()), "HUGEINT");
+  ASSERT_STREQ(UUID()->name(), "UUID");
+  ASSERT_STREQ(UUID()->kindName(), "HUGEINT");
   ASSERT_TRUE(UUID()->parameters().empty());
   ASSERT_EQ(UUID()->toString(), "UUID");
 


### PR DESCRIPTION
Summary:
We currently use ASSERT_EQ to compare two strings as `const char*`
in type tests. ASSERT_EQ compares their pointers instead of the
string content. This has been working because the two operands are
string literals and the compilers usually keep only one copy of a
distinct string literal in a read-only memory space, so the two
operands point to the same address. This diff makes the check safer
by using ASSERT_STREQ that compares the string content.

Differential Revision: D61299100
