### PR TITLE
Ensure flattening an array or map does not result in an oversized values vector

### DIFF
--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -17,6 +17,7 @@
 #include <optional>
 #include <sstream>
 
+#include "velox/common/base/CheckedArithmetic.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/ComplexVector.h"
@@ -613,7 +614,7 @@ void ArrayVectorBase::copyRangesImpl(
 
         mutableOffsets[targetIndex] = childSize;
         mutableSizes[targetIndex] = copySize;
-        childSize += copySize;
+        childSize = checkedPlus<vector_size_t>(childSize, copySize);
       }
     });
 

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -3805,5 +3805,15 @@ TEST_F(VectorTest, arrayCopyTargetNullOffsets) {
   test::assertEqualVectors(source, target);
 }
 
+TEST_F(VectorTest, testOverSizedArray) {
+  // Verify that flattening an array/map cannot result in a values vector
+  // greater than vector_size_t
+  auto flat = makeFlatVector<int32_t>(1000, [](auto /*row*/) { return 1; });
+  std::vector<vector_size_t> offsets(1, 0);
+  auto array = makeArrayVector(offsets, flat);
+  auto constArray = BaseVector::wrapInConstant(21474830, 0, array);
+  EXPECT_THROW(BaseVector::flattenVector(constArray), VeloxUserError);
+}
+
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:
We recently found a bug in the transform lambda expression where the
capture of a lambda is an array and each row has more than 1000
elements. When inside the lambda eval, the capture is replicated by
wrapping it in a dictionary that aligns each row with each element
of the array that the transform is applied to. It then attempted to
flatten this wrapped vector, resulting in a segmentation fault.

This is a bandaid fix for this issue to ensure we fail instead of
crashing. A proper fix for transform lambda will be added later.

Differential Revision: D61305363
