### PR TITLE
[VL] New global flag  to allow growing buffers that were created from different task

### DIFF
--- a/velox/exec/MemoryReclaimer.cpp
+++ b/velox/exec/MemoryReclaimer.cpp
@@ -19,6 +19,11 @@
 #include "velox/exec/Driver.h"
 #include "velox/exec/Task.h"
 
+DEFINE_bool(
+    transferred_arbitration_allowed,
+    false,
+    "Whether to allow entering memory arbitration on memory pool that is from another task");
+
 namespace facebook::velox::exec {
 std::unique_ptr<memory::MemoryReclaimer> MemoryReclaimer::create() {
   return std::unique_ptr<memory::MemoryReclaimer>(new MemoryReclaimer());

--- a/velox/exec/MemoryReclaimer.h
+++ b/velox/exec/MemoryReclaimer.h
@@ -18,6 +18,8 @@
 
 #include "velox/common/memory/MemoryArbitrator.h"
 
+DECLARE_bool(transferred_arbitration_allowed);
+
 namespace facebook::velox::exec {
 /// Provides the default leaf memory reclaimer implementation for velox task
 /// execution.

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -569,7 +569,7 @@ void Operator::MemoryReclaimer::enterArbitration() {
       // operator that requests memory arbitration. The reason is that an
       // operator might extend the buffer allocated from the other operator
       // either from the same or different drivers. But they must be from the
-      // same task by the following check. User could set
+      // same task as the following check. User could set
       // FLAGS_transferred_arbitration_allowed=true to bypass this check.
       VELOX_CHECK_EQ(
           runningDriver->task()->taskId(),

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -563,15 +563,19 @@ void Operator::MemoryReclaimer::enterArbitration() {
   }
 
   Driver* const runningDriver = driverThreadCtx->driverCtx.driver;
-  if (auto opDriver = ensureDriver()) {
-    // NOTE: the current running driver might not be the driver of the operator
-    // that requests memory arbitration. The reason is that an operator might
-    // extend the buffer allocated from the other operator either from the same
-    // or different drivers. But they must be from the same task.
-    VELOX_CHECK_EQ(
-        runningDriver->task()->taskId(),
-        opDriver->task()->taskId(),
-        "The current running driver and the request driver must be from the same task");
+  if (!FLAGS_transferred_arbitration_allowed) {
+    if (auto opDriver = ensureDriver()) {
+      // NOTE: the current running driver might not be the driver of the
+      // operator that requests memory arbitration. The reason is that an
+      // operator might extend the buffer allocated from the other operator
+      // either from the same or different drivers. But they must be from the
+      // same task by the following check. User could set
+      // FLAGS_transferred_arbitration_allowed=true to bypass this check.
+      VELOX_CHECK_EQ(
+          runningDriver->task()->taskId(),
+          opDriver->task()->taskId(),
+          "The current running driver and the request driver must be from the same task");
+    }
   }
   if (runningDriver->task()->enterSuspended(runningDriver->state()) !=
       StopReason::kNone) {


### PR DESCRIPTION
Add a global bool flag `FLAGS_transferred_arbitration_allowed` (by default `false`), when it set to `true`, Velox will allow growing a buffer that was created in a different task.

This could fix Gluten issue https://github.com/apache/incubator-gluten/issues/6864.