### PR TITLE
Add shrink target adjustment mechanism in memory arbitration

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -87,6 +87,10 @@ std::unique_ptr<MemoryArbitrator> createArbitrator(
           "B";
       extraArbitratorConfigs["slow-capacity-grow-pct"] =
           folly::to<std::string>(options.slowCapacityGrowPct);
+      extraArbitratorConfigs["memory-pool-min-free-capacity"] =
+          folly::to<std::string>(options.memoryPoolMinFreeCapacity) + "B";
+      extraArbitratorConfigs["memory-pool-min-free-capacity-pct"] =
+          folly::to<std::string>(options.memoryPoolMinFreeCapacityPct);
       extraArbitratorConfigs["memory-reclaim-max-wait-time"] =
           folly::to<std::string>(options.memoryReclaimWaitMs) + "ms";
       extraArbitratorConfigs["global-arbitration-enabled"] =

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -82,6 +82,7 @@ struct MemoryManagerOptions {
   bool coreOnAllocationFailureEnabled{false};
 
   /// ================== 'MemoryAllocator' settings ==================
+
   /// Specifies the max memory allocation capacity in bytes enforced by
   /// MemoryAllocator, default unlimited.
   int64_t allocatorCapacity{kMaxMemory};
@@ -195,6 +196,23 @@ struct MemoryManagerOptions {
   /// otherwise it is disabled.
   uint64_t fastExponentialGrowthCapacityLimit{512 << 20};
   double slowCapacityGrowPct{0.25};
+
+  /// When shrinking capacity, the shrink bytes will be adjusted in a way such
+  /// that AFTER shrink, the stricter (whichever is smaller) of the following
+  /// conditions is met, in order to better fit the pool's current memory
+  /// usage:
+  /// - Free capacity is greater or equal to capacity *
+  /// 'memoryPoolMinFreeCapacityPct'
+  /// - Free capacity is greater or equal to 'memoryPoolMinFreeCapacity'
+  ///
+  /// NOTE: In the conditions when original requested shrink bytes ends up
+  /// with more free capacity than above 2 conditions, the adjusted shrink
+  /// bytes is not respected.
+  ///
+  /// NOTE: Capacity shrink adjustment is enabled when both
+  /// 'memoryPoolMinFreeCapacityPct' and 'memoryPoolMinFreeCapacity' are set.
+  uint64_t memoryPoolMinFreeCapacity{128 << 20};
+  double memoryPoolMinFreeCapacityPct{0.25};
 
   /// Specifies the max time to wait for memory reclaim by arbitration. The
   /// memory reclaim might fail if the max wait time has exceeded. If it is

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -80,6 +80,33 @@ class SharedArbitrator : public memory::MemoryArbitrator {
     static uint64_t getMemoryReclaimMaxWaitTimeMs(
         const std::unordered_map<std::string, std::string>& configs);
 
+    /// When shrinking capacity, the shrink bytes will be adjusted in a way such
+    /// that AFTER shrink, the stricter (whichever is smaller) of the following
+    /// conditions is met, in order to better fit the pool's current memory
+    /// usage:
+    /// - Free capacity is greater or equal to capacity *
+    /// 'memoryPoolMinFreeCapacityPct'
+    /// - Free capacity is greater or equal to 'memoryPoolMinFreeCapacity'
+    ///
+    /// NOTE: In the conditions when original requested shrink bytes ends up
+    /// with more free capacity than above 2 conditions, the adjusted shrink
+    /// bytes is not respected.
+    ///
+    /// NOTE: Capacity shrink adjustment is enabled when both
+    /// 'memoryPoolMinFreeCapacityPct' and 'memoryPoolMinFreeCapacity' are set.
+    static constexpr std::string_view kMemoryPoolMinFreeCapacity{
+        "memory-pool-min-free-capacity"};
+    static constexpr std::string_view kDefaultMemoryPoolMinFreeCapacity{
+        "128MB"};
+    static uint64_t getMemoryPoolMinFreeCapacity(
+        const std::unordered_map<std::string, std::string>& configs);
+
+    static constexpr std::string_view kMemoryPoolMinFreeCapacityPct{
+        "memory-pool-min-free-capacity-pct"};
+    static constexpr double kDefaultMemoryPoolMinFreeCapacityPct{0.25};
+    static double getMemoryPoolMinFreeCapacityPct(
+        const std::unordered_map<std::string, std::string>& configs);
+
     /// If true, it allows memory arbitrator to reclaim used memory cross query
     /// memory pools.
     static constexpr std::string_view kGlobalArbitrationEnabled{
@@ -143,7 +170,7 @@ class SharedArbitrator : public memory::MemoryArbitrator {
 
   bool growCapacity(MemoryPool* pool, uint64_t requestBytes) final;
 
-  uint64_t shrinkCapacity(MemoryPool* pool, uint64_t requestBytes) final;
+  uint64_t shrinkCapacity(MemoryPool* pool, uint64_t requestBytes = 0) final;
 
   uint64_t shrinkCapacity(
       uint64_t requestBytes,
@@ -470,6 +497,14 @@ class SharedArbitrator : public memory::MemoryArbitrator {
       const MemoryPool& pool,
       uint64_t requestBytes) const;
 
+  // The capacity shrink target is adjusted from request shrink bytes to give
+  // the memory pool more headroom free capacity after shrink. It can help to
+  // reduce the number of future grow calls, and hence reducing the number of
+  // unnecessary memory arbitration requests.
+  uint64_t getCapacityShrinkTarget(
+      const MemoryPool& pool,
+      uint64_t requestBytes) const;
+
   // Returns true if 'pool' is under memory arbitration.
   bool isUnderArbitrationLocked(MemoryPool* pool) const;
 
@@ -487,6 +522,8 @@ class SharedArbitrator : public memory::MemoryArbitrator {
 
   const uint64_t fastExponentialGrowthCapacityLimit_;
   const double slowCapacityGrowPct_;
+  const uint64_t memoryPoolMinFreeCapacity_;
+  const double memoryPoolMinFreeCapacityPct_;
 
   mutable folly::SharedMutex poolLock_;
   std::unordered_map<MemoryPool*, std::weak_ptr<MemoryPool>> candidates_;

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -278,7 +278,7 @@ class SharedArbitrationTestBase : public exec::test::HiveConnectorTestBase {
       VELOX_CHECK_EQ(
           stats.customStats.count(SharedArbitrator::kGlobalArbitrationCount),
           1);
-      VELOX_CHECK_EQ(
+      VELOX_CHECK_GE(
           stats.customStats.at(SharedArbitrator::kGlobalArbitrationCount).sum,
           1);
       VELOX_CHECK_EQ(


### PR DESCRIPTION
Create a protection when shrinking capacity of a memory pool. The protection intends to give the memory pool more headroom after shinking so that the chance of the same memory pool needing to increase capacity in the future is slimmer. This is to reduce the future number of arbitrations. 

In combination with grow target adjustment, the execution time reduced by 15% for Meta's internal production workload stress shadow.