### PR TITLE
Add Query Trace Writers and Readers

### DIFF
--- a/velox/core/QueryConfig.cpp
+++ b/velox/core/QueryConfig.cpp
@@ -53,4 +53,9 @@ void QueryConfig::testingOverrideConfigUnsafe(
   config_ = std::make_unique<config::ConfigBase>(std::move(values));
 }
 
+std::unordered_map<std::string, std::string> QueryConfig::rawConfigsCopy()
+    const {
+  return config_->rawConfigsCopy();
+}
+
 } // namespace facebook::velox::core

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -725,6 +725,8 @@ class QueryConfig {
   void testingOverrideConfigUnsafe(
       std::unordered_map<std::string, std::string>&& values);
 
+  std::unordered_map<std::string, std::string> rawConfigsCopy() const;
+
  private:
   void validateConfig();
 

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -85,6 +85,11 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
     return it->second.get();
   }
 
+  const std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>&
+  connectorSessionProperties() const {
+    return connectorSessionProperties_;
+  }
+
   /// Overrides the previous configuration. Note that this function is NOT
   /// thread-safe and should probably only be used in tests.
   void testingOverrideConfigUnsafe(

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -98,7 +98,8 @@ velox_link_libraries(
   velox_common_base
   velox_test_util
   velox_arrow_bridge
-  velox_common_compression)
+  velox_common_compression
+  velox_query_trace_exec)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(fuzzer)
@@ -112,3 +113,4 @@ if(${VELOX_ENABLE_BENCHMARKS})
 endif()
 
 add_subdirectory(prefixsort)
+add_subdirectory(trace)

--- a/velox/exec/trace/CMakeLists.txt
+++ b/velox/exec/trace/CMakeLists.txt
@@ -1,0 +1,44 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_library(velox_query_trace_exec QueryMetadataWriter.cpp QueryTraceConfig.cpp
+                                   QueryDataWriter.cpp)
+
+target_link_libraries(
+  velox_query_trace_exec
+  PRIVATE
+    velox_common_io
+    velox_file
+    velox_core
+    velox_vector
+    velox_connector
+    velox_common_base
+    velox_presto_serializer)
+
+add_library(velox_query_trace_retrieve QueryDataReader.cpp
+                                       QueryMetadataReader.cpp)
+
+target_link_libraries(
+  velox_query_trace_retrieve
+  velox_common_io
+  velox_file
+  velox_core
+  velox_vector
+  velox_connector
+  velox_common_base
+  velox_hive_connector)
+
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(test)
+endif()

--- a/velox/exec/trace/QueryDataReader.cpp
+++ b/velox/exec/trace/QueryDataReader.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/trace/QueryDataReader.h"
+
+#include "velox/common/file/File.h"
+#include "velox/connectors/hive/HiveDataSink.h"
+#include "velox/connectors/hive/TableHandle.h"
+#include "velox/exec/TableWriter.h"
+#include "velox/exec/trace/QueryTraceTraits.h"
+
+namespace facebook::velox::exec::trace {
+
+QueryDataReader::QueryDataReader(std::string path, memory::MemoryPool* pool)
+    : path_(std::move(path)),
+      fs_(filesystems::getFileSystem(path_, nullptr)),
+      pool_(pool),
+      dataType_(getTraceDataType()),
+      dataStream_(getDataInputStream()) {
+  VELOX_CHECK_NOT_NULL(dataType_);
+  VELOX_CHECK_NOT_NULL(dataStream_);
+}
+
+bool QueryDataReader::read(RowVectorPtr& batch) const {
+  if (dataStream_->atEnd()) {
+    batch = nullptr;
+    return false;
+  }
+
+  VectorStreamGroup::read(
+      dataStream_.get(), pool_, dataType_, &batch, &readOptions_);
+  return true;
+}
+
+RowTypePtr QueryDataReader::getTraceDataType() const {
+  const auto summaryFile = fs_->openFileForRead(
+      fmt::format("{}/{}", path_, QueryTraceTraits::kDataSummaryFileName));
+  const auto summary = summaryFile->pread(0, summaryFile->size());
+  VELOX_USER_CHECK(!summary.empty());
+  folly::dynamic obj = folly::parseJson(summary);
+  return ISerializable::deserialize<RowType>(obj["rowType"]);
+}
+
+std::unique_ptr<common::FileInputStream> QueryDataReader::getDataInputStream()
+    const {
+  auto dataFile = fs_->openFileForRead(
+      fmt::format("{}/{}", path_, QueryTraceTraits::kDataFileName));
+  // TODO: Make the buffer size configurable.
+  return std::make_unique<common::FileInputStream>(
+      std::move(dataFile), 1 << 20, pool_);
+}
+
+} // namespace facebook::velox::exec::trace

--- a/velox/exec/trace/QueryDataReader.h
+++ b/velox/exec/trace/QueryDataReader.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/file/FileInputStream.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/core/PlanNode.h"
+#include "velox/core/QueryCtx.h"
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/vector/VectorStream.h"
+
+namespace facebook::velox::exec::trace {
+
+class QueryDataReader {
+ public:
+  explicit QueryDataReader(std::string path, memory::MemoryPool* pool);
+
+  /// Reads from 'dataStream_' and deserializes to 'batch'. Returns false if
+  /// reaches to end of the stream and 'batch' is set to nullptr.
+  bool read(RowVectorPtr& batch) const;
+
+ private:
+  RowTypePtr getTraceDataType() const;
+
+  std::unique_ptr<common::FileInputStream> getDataInputStream() const;
+
+  const std::string path_;
+  const serializer::presto::PrestoVectorSerde::PrestoOptions readOptions_{
+      true,
+      common::CompressionKind_ZSTD, // TODO: Use trace config.
+      /*nullsFirst=*/true};
+  const std::shared_ptr<filesystems::FileSystem> fs_;
+  memory::MemoryPool* const pool_;
+  const RowTypePtr dataType_;
+  const std::unique_ptr<common::FileInputStream> dataStream_;
+};
+} // namespace facebook::velox::exec::trace

--- a/velox/exec/trace/QueryDataWriter.cpp
+++ b/velox/exec/trace/QueryDataWriter.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/trace/QueryDataWriter.h"
+#include "velox/common/base/SpillStats.h"
+#include "velox/common/file/File.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/exec/TreeOfLosers.h"
+#include "velox/exec/UnorderedStreamReader.h"
+#include "velox/exec/trace/QueryTraceTraits.h"
+#include "velox/serializers/PrestoSerializer.h"
+
+namespace facebook::velox::exec::trace {
+
+QueryDataWriter::QueryDataWriter(
+    const std::string& path,
+    memory::MemoryPool* pool)
+    : dirPath_(path),
+      fs_(filesystems::getFileSystem(dirPath_, nullptr)),
+      pool_(pool) {
+  dataFile_ = fs_->openFileForWrite(
+      fmt::format("{}/{}", dirPath_, QueryTraceTraits::kDataFileName));
+  VELOX_CHECK_NOT_NULL(dataFile_);
+}
+
+void QueryDataWriter::write(const RowVectorPtr& rows) {
+  if (batch_ == nullptr) {
+    batch_ = std::make_unique<VectorStreamGroup>(pool_);
+    batch_->createStreamTree(
+        std::static_pointer_cast<const RowType>(rows->type()),
+        1'000,
+        &options_);
+  }
+  batch_->append(rows);
+  dataType_ = rows->type();
+
+  // Serialize and write out each batch.
+  IOBufOutputStream out(
+      *pool_, nullptr, std::max<int64_t>(64 * 1024, batch_->size()));
+  batch_->flush(&out);
+  batch_->clear();
+  auto iobuf = out.getIOBuf();
+  dataFile_->append(std::move(iobuf));
+}
+
+void QueryDataWriter::finish() {
+  VELOX_CHECK_NOT_NULL(
+      dataFile_, "The query data writer has already been finished");
+  dataFile_->close();
+  dataFile_.reset();
+  batch_.reset();
+  writeSummary();
+}
+
+void QueryDataWriter::writeSummary() const {
+  const auto summaryFilePath =
+      fmt::format("{}/{}", dirPath_, QueryTraceTraits::kDataSummaryFileName);
+  const auto file = fs_->openFileForWrite(summaryFilePath);
+  folly::dynamic obj = folly::dynamic::object;
+  obj[QueryTraceTraits::kDataTypeKey] = dataType_->serialize();
+  file->append(folly::toJson(obj));
+  file->close();
+}
+
+} // namespace facebook::velox::exec::trace

--- a/velox/exec/trace/QueryDataWriter.h
+++ b/velox/exec/trace/QueryDataWriter.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/file/File.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/exec/trace/QueryTraceTraits.h"
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/vector/VectorStream.h"
+
+namespace facebook::velox::exec::trace {
+
+/// Used to serialize and write the input vectors from a given operator into a
+/// file.
+class QueryDataWriter {
+ public:
+  explicit QueryDataWriter(const std::string& path, memory::MemoryPool* pool);
+
+  /// Serializes rows and writes out each batch.
+  void write(const RowVectorPtr& rows);
+
+  /// Closes the data file and writes out the data summary.
+  ///
+  /// NOTE: This method should be only called once.
+  void finish();
+
+ private:
+  // Flushes the trace data summaries to the disk.
+  //
+  // TODO: add more summaries such as number of rows etc.
+  void writeSummary() const;
+
+  const std::string dirPath_;
+  // TODO: make 'useLosslessTimestamp' configuerable.
+  const serializer::presto::PrestoVectorSerde::PrestoOptions options_ = {
+      true,
+      common::CompressionKind::CompressionKind_ZSTD,
+      /*nullsFirst=*/true};
+  const std::shared_ptr<filesystems::FileSystem> fs_;
+  memory::MemoryPool* const pool_;
+  std::unique_ptr<WriteFile> dataFile_;
+  TypePtr dataType_;
+  std::unique_ptr<VectorStreamGroup> batch_;
+};
+
+} // namespace facebook::velox::exec::trace

--- a/velox/exec/trace/QueryMetadataReader.cpp
+++ b/velox/exec/trace/QueryMetadataReader.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/trace/QueryMetadataReader.h"
+
+#include "velox/common/file/File.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/connectors/hive/HiveDataSink.h"
+#include "velox/connectors/hive/TableHandle.h"
+#include "velox/core/PlanNode.h"
+#include "velox/exec/PartitionFunction.h"
+#include "velox/exec/TableWriter.h"
+#include "velox/exec/trace/QueryTraceTraits.h"
+
+namespace facebook::velox::exec::trace {
+
+QueryMetadataReader::QueryMetadataReader(
+    std::string traceDir,
+    memory::MemoryPool* pool)
+    : traceDir_(std::move(traceDir)),
+      fs_(filesystems::getFileSystem(traceDir_, nullptr)),
+      metaFilePath_(fmt::format(
+          "{}/{}",
+          traceDir_,
+          QueryTraceTraits::kQueryMetaFileName)),
+      pool_(pool) {
+  VELOX_CHECK_NOT_NULL(fs_);
+  VELOX_CHECK(fs_->exists(metaFilePath_));
+}
+
+void QueryMetadataReader::read(
+    std::unordered_map<std::string, std::string>& queryConfigs,
+    std::unordered_map<
+        std::string,
+        std::unordered_map<std::string, std::string>>& connectorProperties,
+    core::PlanNodePtr& queryPlan) const {
+  const auto file = fs_->openFileForRead(metaFilePath_);
+  VELOX_CHECK_NOT_NULL(file);
+  const auto metadata = file->pread(0, file->size());
+  VELOX_USER_CHECK(!metadata.empty());
+  folly::dynamic obj = folly::parseJson(metadata);
+
+  const auto& queryConfigObj = obj[QueryTraceTraits::kQueryConfigKey];
+  for (const auto& [key, value] : queryConfigObj.items()) {
+    queryConfigs[key.asString()] = value.asString();
+  }
+
+  const auto& connectorPropertiesObj =
+      obj[QueryTraceTraits::kConnectorPropertiesKey];
+  for (const auto& [connectorId, configs] : connectorPropertiesObj.items()) {
+    const auto connectorIdStr = connectorId.asString();
+    connectorProperties[connectorIdStr] = {};
+    for (const auto& [key, value] : configs.items()) {
+      connectorProperties[connectorIdStr][key.asString()] = value.asString();
+    }
+  }
+
+  queryPlan = ISerializable::deserialize<core::PlanNode>(
+      obj[QueryTraceTraits::kPlanNodeKey], pool_);
+}
+} // namespace facebook::velox::exec::trace

--- a/velox/exec/trace/QueryMetadataReader.h
+++ b/velox/exec/trace/QueryMetadataReader.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/file/FileSystems.h"
+#include "velox/core/PlanNode.h"
+#include "velox/core/QueryCtx.h"
+#include "velox/vector/VectorStream.h"
+
+namespace facebook::velox::exec::trace {
+class QueryMetadataReader {
+ public:
+  explicit QueryMetadataReader(std::string traceDir, memory::MemoryPool* pool);
+
+  void read(
+      std::unordered_map<std::string, std::string>& queryConfigs,
+      std::unordered_map<
+          std::string,
+          std::unordered_map<std::string, std::string>>& connectorProperties,
+      core::PlanNodePtr& queryPlan) const;
+
+ private:
+  const std::string traceDir_;
+  const std::shared_ptr<filesystems::FileSystem> fs_;
+  const std::string metaFilePath_;
+  memory::MemoryPool* const pool_;
+};
+} // namespace facebook::velox::exec::trace

--- a/velox/exec/trace/QueryMetadataWriter.cpp
+++ b/velox/exec/trace/QueryMetadataWriter.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/trace/QueryMetadataWriter.h"
+#include "velox/common/config/Config.h"
+#include "velox/common/file/File.h"
+#include "velox/connectors/hive/HiveDataSink.h"
+#include "velox/connectors/hive/TableHandle.h"
+#include "velox/core/PlanNode.h"
+#include "velox/core/QueryCtx.h"
+#include "velox/exec/TableWriter.h"
+#include "velox/exec/trace/QueryTraceTraits.h"
+
+namespace facebook::velox::exec::trace {
+
+QueryMetadataWriter::QueryMetadataWriter(
+    std::string traceDir,
+    memory::MemoryPool* pool)
+    : traceDir_(std::move(traceDir)),
+      fs_(filesystems::getFileSystem(traceDir_, nullptr)),
+      metaFilePath_(fmt::format(
+          "{}/{}",
+          traceDir_,
+          QueryTraceTraits::kQueryMetaFileName)),
+      pool_(pool) {
+  VELOX_CHECK_NOT_NULL(fs_);
+  VELOX_CHECK(!fs_->exists(metaFilePath_));
+}
+
+void QueryMetadataWriter::write(
+    const std::shared_ptr<core::QueryCtx>& queryCtx,
+    const core::PlanNodePtr& planNode) {
+  VELOX_CHECK(!finished_, "Query metadata can only be written once");
+  finished_ = true;
+  folly::dynamic queryConfigObj = folly::dynamic::object;
+  const auto configValues = queryCtx->queryConfig().rawConfigsCopy();
+  for (const auto& [key, value] : configValues) {
+    queryConfigObj[key] = value;
+  }
+
+  folly::dynamic connectorPropertiesObj = folly::dynamic::object;
+  for (const auto& [connectorId, configs] :
+       queryCtx->connectorSessionProperties()) {
+    folly::dynamic obj = folly::dynamic::object;
+    for (const auto& [key, value] : configs->rawConfigsCopy()) {
+      obj[key] = value;
+    }
+    connectorPropertiesObj[connectorId] = obj;
+  }
+
+  folly::dynamic metaObj = folly::dynamic::object;
+  metaObj[QueryTraceTraits::kQueryConfigKey] = queryConfigObj;
+  metaObj[QueryTraceTraits::kConnectorPropertiesKey] = connectorPropertiesObj;
+  metaObj[QueryTraceTraits::kPlanNodeKey] = planNode->serialize();
+
+  const auto metaStr = folly::toJson(metaObj);
+  const auto file = fs_->openFileForWrite(metaFilePath_);
+  file->append(metaStr);
+  file->close();
+}
+
+} // namespace facebook::velox::exec::trace

--- a/velox/exec/trace/QueryMetadataWriter.h
+++ b/velox/exec/trace/QueryMetadataWriter.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/file/FileSystems.h"
+#include "velox/core/PlanNode.h"
+#include "velox/core/QueryCtx.h"
+#include "velox/vector/VectorStream.h"
+
+namespace facebook::velox::exec::trace {
+class QueryMetadataWriter {
+ public:
+  explicit QueryMetadataWriter(std::string traceDir, memory::MemoryPool* pool);
+
+  void write(
+      const std::shared_ptr<core::QueryCtx>& queryCtx,
+      const core::PlanNodePtr& planNode);
+
+ private:
+  const std::string traceDir_;
+  const std::shared_ptr<filesystems::FileSystem> fs_;
+  const std::string metaFilePath_;
+  memory::MemoryPool* const pool_;
+  bool finished_{false};
+};
+} // namespace facebook::velox::exec::trace

--- a/velox/exec/trace/QueryTraceConfig.cpp
+++ b/velox/exec/trace/QueryTraceConfig.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/trace/QueryTraceConfig.h"
+
+namespace facebook::velox::exec::trace {
+
+QueryTraceConfig::QueryTraceConfig(
+    std::unordered_set<std::string> _queryNodeIds,
+    std::string _queryTraceDir)
+    : queryNodes(std::move(_queryNodeIds)),
+      queryTraceDir(std::move(_queryTraceDir)) {}
+
+} // namespace facebook::velox::exec::trace

--- a/velox/exec/trace/QueryTraceConfig.h
+++ b/velox/exec/trace/QueryTraceConfig.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <unordered_set>
+
+namespace facebook::velox::exec::trace {
+struct QueryTraceConfig {
+  /// Target query trace nodes
+  std::unordered_set<std::string> queryNodes;
+  /// Base dir of query trace, normmaly it is $prefix/$taskId.
+  std::string queryTraceDir;
+
+  QueryTraceConfig(
+      std::unordered_set<std::string> _queryNodeIds,
+      std::string _queryTraceDir);
+
+  QueryTraceConfig() = default;
+};
+} // namespace facebook::velox::exec::trace

--- a/velox/exec/trace/QueryTraceTraits.h
+++ b/velox/exec/trace/QueryTraceTraits.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace facebook::velox::exec::trace {
+/// Defines the shared constants used by query trace implementation.
+struct QueryTraceTraits {
+  static inline const std::string kPlanNodeKey = "planNode";
+  static inline const std::string kQueryConfigKey = "queryConfig";
+  static inline const std::string kDataTypeKey = "rowType";
+  static inline const std::string kConnectorPropertiesKey =
+      "connectorProperties";
+
+  static inline const std::string kQueryMetaFileName = "query_meta.json";
+  static inline const std::string kDataSummaryFileName = "data_summary.json";
+  static inline const std::string kDataFileName = "trace.data";
+};
+} // namespace facebook::velox::exec::trace

--- a/velox/exec/trace/test/CMakeLists.txt
+++ b/velox/exec/trace/test/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_executable(velox_exec_trace_test QueryTraceTest.cpp)
+
+add_test(
+  NAME velox_exec_trace_test
+  COMMAND velox_exec_trace_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+set_tests_properties(velox_exec_trace_test PROPERTIES TIMEOUT 3000)
+
+target_link_libraries(
+  velox_exec_trace_test
+  velox_exec
+  velox_exec_test_lib
+  velox_memory
+  velox_query_trace_exec
+  velox_query_trace_retrieve
+  velox_vector_fuzzer)

--- a/velox/exec/trace/test/QueryTraceTest.cpp
+++ b/velox/exec/trace/test/QueryTraceTest.cpp
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <memory>
+
+#include "velox/common/file/FileSystems.h"
+#include "velox/exec/PartitionFunction.h"
+#include "velox/exec/tests/utils/ArbitratorTestUtil.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/exec/trace/QueryDataReader.h"
+#include "velox/exec/trace/QueryDataWriter.h"
+#include "velox/exec/trace/QueryMetadataReader.h"
+#include "velox/exec/trace/QueryMetadataWriter.h"
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::exec::test {
+class QueryTracerTest : public HiveConnectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+    HiveConnectorTestBase::SetUpTestCase();
+    filesystems::registerLocalFileSystem();
+    if (!isRegisteredVectorSerde()) {
+      serializer::presto::PrestoVectorSerde::registerVectorSerde();
+    }
+    Type::registerSerDe();
+    common::Filter::registerSerDe();
+    connector::hive::HiveTableHandle::registerSerDe();
+    connector::hive::LocationHandle::registerSerDe();
+    connector::hive::HiveColumnHandle::registerSerDe();
+    connector::hive::HiveInsertTableHandle::registerSerDe();
+    core::PlanNode::registerSerDe();
+    core::ITypedExpr::registerSerDe();
+    registerPartitionFunctionSerDe();
+  }
+
+  static VectorFuzzer::Options getFuzzerOptions() {
+    return VectorFuzzer::Options{
+        .vectorSize = 16,
+        .nullRatio = 0.2,
+        .stringLength = 1024,
+        .stringVariableLength = false,
+        .allowLazyVector = false,
+    };
+  }
+
+  QueryTracerTest() : vectorFuzzer_{getFuzzerOptions(), pool_.get()} {
+    filesystems::registerLocalFileSystem();
+  }
+
+  RowTypePtr generateTypes(size_t numColumns) {
+    std::vector<std::string> names;
+    names.reserve(numColumns);
+    std::vector<TypePtr> types;
+    types.reserve(numColumns);
+    for (auto i = 0; i < numColumns; ++i) {
+      names.push_back(fmt::format("c{}", i));
+      types.push_back(vectorFuzzer_.randType((2)));
+    }
+    return ROW(std::move(names), std::move(types));
+    ;
+  }
+
+  bool isSamePlan(
+      const core::PlanNodePtr& left,
+      const core::PlanNodePtr& right) {
+    if (left->id() != right->id() || left->name() != right->name()) {
+      return false;
+    }
+
+    if (left->sources().size() != right->sources().size()) {
+      return false;
+    }
+
+    for (auto i = 0; i < left->sources().size(); ++i) {
+      isSamePlan(left->sources().at(i), right->sources().at(i));
+    }
+    return true;
+  }
+
+  VectorFuzzer vectorFuzzer_;
+};
+
+TEST_F(QueryTracerTest, traceData) {
+  const auto rowType = generateTypes(5);
+  std::vector<RowVectorPtr> inputVectors;
+  constexpr auto numBatch = 3;
+  inputVectors.reserve(numBatch);
+  for (auto i = 0; i < numBatch; ++i) {
+    inputVectors.push_back(vectorFuzzer_.fuzzInputRow(rowType));
+  }
+
+  const auto outputDir = TempDirectoryPath::create();
+  auto writer = trace::QueryDataWriter(outputDir->getPath(), pool());
+  for (auto i = 0; i < numBatch; ++i) {
+    writer.write(inputVectors[i]);
+  }
+  writer.finish();
+
+  const auto reader = trace::QueryDataReader(outputDir->getPath(), pool());
+  RowVectorPtr actual;
+  size_t numOutputVectors{0};
+  while (reader.read(actual)) {
+    const auto expected = inputVectors[numOutputVectors];
+    const auto size = actual->size();
+    ASSERT_EQ(size, expected->size());
+    for (auto i = 0; i < size; ++i) {
+      actual->compare(expected.get(), i, i, {.nullsFirst = true});
+    }
+    ++numOutputVectors;
+  }
+  ASSERT_EQ(numOutputVectors, inputVectors.size());
+}
+
+TEST_F(QueryTracerTest, traceMetadata) {
+  const auto rowType =
+      ROW({"c0", "c1", "c2", "c3", "c4", "c5"},
+          {BIGINT(), SMALLINT(), TINYINT(), VARCHAR(), VARCHAR(), VARCHAR()});
+  std::vector<RowVectorPtr> rows;
+  constexpr auto numBatch = 1;
+  rows.reserve(numBatch);
+  for (auto i = 0; i < numBatch; ++i) {
+    rows.push_back(vectorFuzzer_.fuzzRow(rowType, 2));
+  }
+
+  const auto outputDir = TempDirectoryPath::create();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  const auto planNode =
+      PlanBuilder(planNodeIdGenerator)
+          .values(rows, false)
+          .project({"c0", "c1", "c2"})
+          .hashJoin(
+              {"c0"},
+              {"u0"},
+              PlanBuilder(planNodeIdGenerator)
+                  .values(rows, true)
+                  .singleAggregation({"c0", "c1"}, {"min(c2)"})
+                  .project({"c0 AS u0", "c1 AS u1", "a0 AS u2"})
+                  .planNode(),
+              "c0 < 135",
+              {"c0", "c1", "c2"},
+              core::JoinType::kInner)
+          .planNode();
+  const auto expectedQueryConfigs =
+      std::unordered_map<std::string, std::string>{
+          {core::QueryConfig::kSpillEnabled, "true"},
+          {core::QueryConfig::kSpillNumPartitionBits, "17"},
+          {"key1", "value1"},
+      };
+  const auto expectedConnectorProperties =
+      std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>{
+          {"test_trace",
+           std::make_shared<config::ConfigBase>(
+               std::unordered_map<std::string, std::string>{
+                   {"cKey1", "cVal1"}})}};
+  const auto queryCtx = core::QueryCtx::create(
+      executor_.get(),
+      core::QueryConfig(expectedQueryConfigs),
+      expectedConnectorProperties);
+  auto writer = trace::QueryMetadataWriter(outputDir->getPath(), pool());
+  writer.write(queryCtx, planNode);
+
+  std::unordered_map<std::string, std::string> acutalQueryConfigs;
+  std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
+      actualConnectorProperties;
+  core::PlanNodePtr actualQueryPlan;
+  auto reader = trace::QueryMetadataReader(outputDir->getPath(), pool());
+  reader.read(acutalQueryConfigs, actualConnectorProperties, actualQueryPlan);
+
+  ASSERT_TRUE(isSamePlan(actualQueryPlan, planNode));
+  ASSERT_EQ(acutalQueryConfigs.size(), expectedQueryConfigs.size());
+  for (const auto& [key, value] : acutalQueryConfigs) {
+    ASSERT_EQ(acutalQueryConfigs.at(key), expectedQueryConfigs.at(key));
+  }
+
+  ASSERT_EQ(
+      actualConnectorProperties.size(), expectedConnectorProperties.size());
+  ASSERT_EQ(actualConnectorProperties.count("test_trace"), 1);
+  const auto expectedConnectorConfigs =
+      expectedConnectorProperties.at("test_trace")->rawConfigsCopy();
+  const auto actualConnectorConfigs =
+      actualConnectorProperties.at("test_trace");
+  for (const auto& [key, value] : actualConnectorConfigs) {
+    ASSERT_EQ(actualConnectorConfigs.at(key), expectedConnectorConfigs.at(key));
+  }
+}
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
Add a query tracer to log the input data, and metadata (including query configurations,
connector properties, and query plans). This logged data and metadata can be used to
replay the operations of a specific operator or pipeline.

Part of #9668