### PR TITLE
Fix filter on missing field

### DIFF
--- a/velox/dwio/common/ScanSpec.cpp
+++ b/velox/dwio/common/ScanSpec.cpp
@@ -129,6 +129,18 @@ bool ScanSpec::hasFilter() const {
   return false;
 }
 
+bool ScanSpec::testNull() const {
+  if (filter_ && !filter_->testNull()) {
+    return false;
+  }
+  for (auto& child : children_) {
+    if (!child->isArrayElementOrMapEntry_ && !child->testNull()) {
+      return false;
+    }
+  }
+  return true;
+}
+
 void ScanSpec::moveAdaptationFrom(ScanSpec& other) {
   // moves the filters and filter order from 'other'.
   for (auto& child : children_) {

--- a/velox/dwio/common/ScanSpec.h
+++ b/velox/dwio/common/ScanSpec.h
@@ -255,6 +255,12 @@ class ScanSpec {
   // This may change as a result of runtime adaptation.
   bool hasFilter() const;
 
+  /// Assume this field is read as null constant vector (usually due to missing
+  /// field), check if any filter in the struct subtree would make the whole
+  /// vector to be filtered out.  Return false when the whole vector should be
+  /// filtered out.
+  bool testNull() const;
+
   // Resets cached values after this or children were updated, e.g. a new filter
   // was added or existing filter was modified.
   void resetCachedValues(bool doReorder) {


### PR DESCRIPTION
Summary:
When there is a subfield filter on a missing field, we used to ignore
the filter, because we thought all constant fields are supplied by coordinator
(via `infoColumns`) and should not be filtered in worker.  This is not true for
the null constant caused by missing field in file.  So we add the checks for
this case.

Differential Revision: D61473660
