### PR TITLE
Fix spill time metric unit

### DIFF
--- a/velox/common/base/SpillStats.cpp
+++ b/velox/common/base/SpillStats.cpp
@@ -42,34 +42,34 @@ SpillStats::SpillStats(
     uint64_t _spilledRows,
     uint32_t _spilledPartitions,
     uint64_t _spilledFiles,
-    uint64_t _spillFillTimeUs,
-    uint64_t _spillSortTimeUs,
-    uint64_t _spillSerializationTimeUs,
+    uint64_t _spillFillTimeNanos,
+    uint64_t _spillSortTimeNanos,
+    uint64_t _spillSerializationTimeNanos,
     uint64_t _spillWrites,
-    uint64_t _spillFlushTimeUs,
-    uint64_t _spillWriteTimeUs,
+    uint64_t _spillFlushTimeNanos,
+    uint64_t _spillWriteTimeNanos,
     uint64_t _spillMaxLevelExceededCount,
     uint64_t _spillReadBytes,
     uint64_t _spillReads,
-    uint64_t _spillReadTimeUs,
-    uint64_t _spillDeserializationTimeUs)
+    uint64_t _spillReadTimeNanos,
+    uint64_t _spillDeserializationTimeNanos)
     : spillRuns(_spillRuns),
       spilledInputBytes(_spilledInputBytes),
       spilledBytes(_spilledBytes),
       spilledRows(_spilledRows),
       spilledPartitions(_spilledPartitions),
       spilledFiles(_spilledFiles),
-      spillFillTimeUs(_spillFillTimeUs),
-      spillSortTimeUs(_spillSortTimeUs),
-      spillSerializationTimeUs(_spillSerializationTimeUs),
+      spillFillTimeNanos(_spillFillTimeNanos),
+      spillSortTimeNanos(_spillSortTimeNanos),
+      spillSerializationTimeNanos(_spillSerializationTimeNanos),
       spillWrites(_spillWrites),
-      spillFlushTimeUs(_spillFlushTimeUs),
-      spillWriteTimeUs(_spillWriteTimeUs),
+      spillFlushTimeNanos(_spillFlushTimeNanos),
+      spillWriteTimeNanos(_spillWriteTimeNanos),
       spillMaxLevelExceededCount(_spillMaxLevelExceededCount),
       spillReadBytes(_spillReadBytes),
       spillReads(_spillReads),
-      spillReadTimeUs(_spillReadTimeUs),
-      spillDeserializationTimeUs(_spillDeserializationTimeUs) {}
+      spillReadTimeNanos(_spillReadTimeNanos),
+      spillDeserializationTimeNanos(_spillDeserializationTimeNanos) {}
 
 SpillStats& SpillStats::operator+=(const SpillStats& other) {
   spillRuns += other.spillRuns;
@@ -78,17 +78,17 @@ SpillStats& SpillStats::operator+=(const SpillStats& other) {
   spilledRows += other.spilledRows;
   spilledPartitions += other.spilledPartitions;
   spilledFiles += other.spilledFiles;
-  spillFillTimeUs += other.spillFillTimeUs;
-  spillSortTimeUs += other.spillSortTimeUs;
-  spillSerializationTimeUs += other.spillSerializationTimeUs;
+  spillFillTimeNanos += other.spillFillTimeNanos;
+  spillSortTimeNanos += other.spillSortTimeNanos;
+  spillSerializationTimeNanos += other.spillSerializationTimeNanos;
   spillWrites += other.spillWrites;
-  spillFlushTimeUs += other.spillFlushTimeUs;
-  spillWriteTimeUs += other.spillWriteTimeUs;
+  spillFlushTimeNanos += other.spillFlushTimeNanos;
+  spillWriteTimeNanos += other.spillWriteTimeNanos;
   spillMaxLevelExceededCount += other.spillMaxLevelExceededCount;
   spillReadBytes += other.spillReadBytes;
   spillReads += other.spillReads;
-  spillReadTimeUs += other.spillReadTimeUs;
-  spillDeserializationTimeUs += other.spillDeserializationTimeUs;
+  spillReadTimeNanos += other.spillReadTimeNanos;
+  spillDeserializationTimeNanos += other.spillDeserializationTimeNanos;
   return *this;
 }
 
@@ -100,20 +100,20 @@ SpillStats SpillStats::operator-(const SpillStats& other) const {
   result.spilledRows = spilledRows - other.spilledRows;
   result.spilledPartitions = spilledPartitions - other.spilledPartitions;
   result.spilledFiles = spilledFiles - other.spilledFiles;
-  result.spillFillTimeUs = spillFillTimeUs - other.spillFillTimeUs;
-  result.spillSortTimeUs = spillSortTimeUs - other.spillSortTimeUs;
-  result.spillSerializationTimeUs =
-      spillSerializationTimeUs - other.spillSerializationTimeUs;
+  result.spillFillTimeNanos = spillFillTimeNanos - other.spillFillTimeNanos;
+  result.spillSortTimeNanos = spillSortTimeNanos - other.spillSortTimeNanos;
+  result.spillSerializationTimeNanos =
+      spillSerializationTimeNanos - other.spillSerializationTimeNanos;
   result.spillWrites = spillWrites - other.spillWrites;
-  result.spillFlushTimeUs = spillFlushTimeUs - other.spillFlushTimeUs;
-  result.spillWriteTimeUs = spillWriteTimeUs - other.spillWriteTimeUs;
+  result.spillFlushTimeNanos = spillFlushTimeNanos - other.spillFlushTimeNanos;
+  result.spillWriteTimeNanos = spillWriteTimeNanos - other.spillWriteTimeNanos;
   result.spillMaxLevelExceededCount =
       spillMaxLevelExceededCount - other.spillMaxLevelExceededCount;
   result.spillReadBytes = spillReadBytes - other.spillReadBytes;
   result.spillReads = spillReads - other.spillReads;
-  result.spillReadTimeUs = spillReadTimeUs - other.spillReadTimeUs;
-  result.spillDeserializationTimeUs =
-      spillDeserializationTimeUs - other.spillDeserializationTimeUs;
+  result.spillReadTimeNanos = spillReadTimeNanos - other.spillReadTimeNanos;
+  result.spillDeserializationTimeNanos =
+      spillDeserializationTimeNanos - other.spillDeserializationTimeNanos;
   return result;
 }
 
@@ -135,17 +135,17 @@ bool SpillStats::operator<(const SpillStats& other) const {
   UPDATE_COUNTER(spilledRows);
   UPDATE_COUNTER(spilledPartitions);
   UPDATE_COUNTER(spilledFiles);
-  UPDATE_COUNTER(spillFillTimeUs);
-  UPDATE_COUNTER(spillSortTimeUs);
-  UPDATE_COUNTER(spillSerializationTimeUs);
+  UPDATE_COUNTER(spillFillTimeNanos);
+  UPDATE_COUNTER(spillSortTimeNanos);
+  UPDATE_COUNTER(spillSerializationTimeNanos);
   UPDATE_COUNTER(spillWrites);
-  UPDATE_COUNTER(spillFlushTimeUs);
-  UPDATE_COUNTER(spillWriteTimeUs);
+  UPDATE_COUNTER(spillFlushTimeNanos);
+  UPDATE_COUNTER(spillWriteTimeNanos);
   UPDATE_COUNTER(spillMaxLevelExceededCount);
   UPDATE_COUNTER(spillReadBytes);
   UPDATE_COUNTER(spillReads);
-  UPDATE_COUNTER(spillReadTimeUs);
-  UPDATE_COUNTER(spillDeserializationTimeUs);
+  UPDATE_COUNTER(spillReadTimeNanos);
+  UPDATE_COUNTER(spillDeserializationTimeNanos);
 #undef UPDATE_COUNTER
   VELOX_CHECK(
       !((gtCount > 0) && (ltCount > 0)),
@@ -175,17 +175,17 @@ bool SpillStats::operator==(const SpillStats& other) const {
              spilledRows,
              spilledPartitions,
              spilledFiles,
-             spillFillTimeUs,
-             spillSortTimeUs,
-             spillSerializationTimeUs,
+             spillFillTimeNanos,
+             spillSortTimeNanos,
+             spillSerializationTimeNanos,
              spillWrites,
-             spillFlushTimeUs,
-             spillWriteTimeUs,
+             spillFlushTimeNanos,
+             spillWriteTimeNanos,
              spillMaxLevelExceededCount,
              spillReadBytes,
              spillReads,
-             spillReadTimeUs,
-             spillDeserializationTimeUs) ==
+             spillReadTimeNanos,
+             spillDeserializationTimeNanos) ==
       std::tie(
              other.spillRuns,
              other.spilledInputBytes,
@@ -193,17 +193,17 @@ bool SpillStats::operator==(const SpillStats& other) const {
              other.spilledRows,
              other.spilledPartitions,
              other.spilledFiles,
-             other.spillFillTimeUs,
-             other.spillSortTimeUs,
-             other.spillSerializationTimeUs,
+             other.spillFillTimeNanos,
+             other.spillSortTimeNanos,
+             other.spillSerializationTimeNanos,
              other.spillWrites,
-             other.spillFlushTimeUs,
-             other.spillWriteTimeUs,
+             other.spillFlushTimeNanos,
+             other.spillWriteTimeNanos,
              spillMaxLevelExceededCount,
              spillReadBytes,
              spillReads,
-             spillReadTimeUs,
-             spillDeserializationTimeUs);
+             spillReadTimeNanos,
+             spillDeserializationTimeNanos);
 }
 
 void SpillStats::reset() {
@@ -213,44 +213,44 @@ void SpillStats::reset() {
   spilledRows = 0;
   spilledPartitions = 0;
   spilledFiles = 0;
-  spillFillTimeUs = 0;
-  spillSortTimeUs = 0;
-  spillSerializationTimeUs = 0;
+  spillFillTimeNanos = 0;
+  spillSortTimeNanos = 0;
+  spillSerializationTimeNanos = 0;
   spillWrites = 0;
-  spillFlushTimeUs = 0;
-  spillWriteTimeUs = 0;
+  spillFlushTimeNanos = 0;
+  spillWriteTimeNanos = 0;
   spillMaxLevelExceededCount = 0;
   spillReadBytes = 0;
   spillReads = 0;
-  spillReadTimeUs = 0;
-  spillDeserializationTimeUs = 0;
+  spillReadTimeNanos = 0;
+  spillDeserializationTimeNanos = 0;
 }
 
 std::string SpillStats::toString() const {
   return fmt::format(
       "spillRuns[{}] spilledInputBytes[{}] spilledBytes[{}] spilledRows[{}] "
-      "spilledPartitions[{}] spilledFiles[{}] spillFillTimeUs[{}] "
-      "spillSortTime[{}] spillSerializationTime[{}] spillWrites[{}] "
-      "spillFlushTime[{}] spillWriteTime[{}] maxSpillExceededLimitCount[{}] "
-      "spillReadBytes[{}] spillReads[{}] spillReadTime[{}] "
-      "spillReadDeserializationTime[{}]",
+      "spilledPartitions[{}] spilledFiles[{}] spillFillTimeNanos[{}] "
+      "spillSortTimeNanos[{}] spillSerializationTimeNanos[{}] spillWrites[{}] "
+      "spillFlushTimeNanos[{}] spillWriteTimeNanos[{}] maxSpillExceededLimitCount[{}] "
+      "spillReadBytes[{}] spillReads[{}] spillReadTimeNanos[{}] "
+      "spillReadDeserializationTimeNanos[{}]",
       spillRuns,
       succinctBytes(spilledInputBytes),
       succinctBytes(spilledBytes),
       spilledRows,
       spilledPartitions,
       spilledFiles,
-      succinctMicros(spillFillTimeUs),
-      succinctMicros(spillSortTimeUs),
-      succinctMicros(spillSerializationTimeUs),
+      succinctNanos(spillFillTimeNanos),
+      succinctNanos(spillSortTimeNanos),
+      succinctNanos(spillSerializationTimeNanos),
       spillWrites,
-      succinctMicros(spillFlushTimeUs),
-      succinctMicros(spillWriteTimeUs),
+      succinctNanos(spillFlushTimeNanos),
+      succinctNanos(spillWriteTimeNanos),
       spillMaxLevelExceededCount,
       succinctBytes(spillReadBytes),
       spillReads,
-      succinctMicros(spillReadTimeUs),
-      succinctMicros(spillDeserializationTimeUs));
+      succinctNanos(spillReadTimeNanos),
+      succinctNanos(spillDeserializationTimeNanos));
 }
 
 void updateGlobalSpillRunStats(uint64_t numRuns) {
@@ -260,52 +260,54 @@ void updateGlobalSpillRunStats(uint64_t numRuns) {
 
 void updateGlobalSpillAppendStats(
     uint64_t numRows,
-    uint64_t serializationTimeUs) {
+    uint64_t serializationTimeNs) {
   RECORD_METRIC_VALUE(kMetricSpilledRowsCount, numRows);
   RECORD_HISTOGRAM_METRIC_VALUE(
-      kMetricSpillSerializationTimeMs, serializationTimeUs / 1'000);
+      kMetricSpillSerializationTimeMs, serializationTimeNs / 1'000'000);
   auto statsLocked = localSpillStats().wlock();
   statsLocked->spilledRows += numRows;
-  statsLocked->spillSerializationTimeUs += serializationTimeUs;
+  statsLocked->spillSerializationTimeNanos += serializationTimeNs;
 }
 
 void incrementGlobalSpilledPartitionStats() {
   ++localSpillStats().wlock()->spilledPartitions;
 }
 
-void updateGlobalSpillFillTime(uint64_t timeUs) {
-  RECORD_HISTOGRAM_METRIC_VALUE(kMetricSpillFillTimeMs, timeUs / 1'000);
-  localSpillStats().wlock()->spillFillTimeUs += timeUs;
+void updateGlobalSpillFillTime(uint64_t timeNs) {
+  RECORD_HISTOGRAM_METRIC_VALUE(kMetricSpillFillTimeMs, timeNs / 1'000'000);
+  localSpillStats().wlock()->spillFillTimeNanos += timeNs;
 }
 
-void updateGlobalSpillSortTime(uint64_t timeUs) {
-  RECORD_HISTOGRAM_METRIC_VALUE(kMetricSpillSortTimeMs, timeUs / 1'000);
-  localSpillStats().wlock()->spillSortTimeUs += timeUs;
+void updateGlobalSpillSortTime(uint64_t timeNs) {
+  RECORD_HISTOGRAM_METRIC_VALUE(kMetricSpillSortTimeMs, timeNs / 1'000'000);
+  localSpillStats().wlock()->spillSortTimeNanos += timeNs;
 }
 
 void updateGlobalSpillWriteStats(
     uint64_t spilledBytes,
-    uint64_t flushTimeUs,
-    uint64_t writeTimeUs) {
+    uint64_t flushTimeNs,
+    uint64_t writeTimeNs) {
   RECORD_METRIC_VALUE(kMetricSpillWritesCount);
   RECORD_METRIC_VALUE(kMetricSpilledBytes, spilledBytes);
-  RECORD_HISTOGRAM_METRIC_VALUE(kMetricSpillFlushTimeMs, flushTimeUs / 1'000);
-  RECORD_HISTOGRAM_METRIC_VALUE(kMetricSpillWriteTimeMs, writeTimeUs / 1'000);
+  RECORD_HISTOGRAM_METRIC_VALUE(
+      kMetricSpillFlushTimeMs, flushTimeNs / 1'000'000);
+  RECORD_HISTOGRAM_METRIC_VALUE(
+      kMetricSpillWriteTimeMs, writeTimeNs / 1'000'000);
   auto statsLocked = localSpillStats().wlock();
   ++statsLocked->spillWrites;
   statsLocked->spilledBytes += spilledBytes;
-  statsLocked->spillFlushTimeUs += flushTimeUs;
-  statsLocked->spillWriteTimeUs += writeTimeUs;
+  statsLocked->spillFlushTimeNanos += flushTimeNs;
+  statsLocked->spillWriteTimeNanos += writeTimeNs;
 }
 
 void updateGlobalSpillReadStats(
     uint64_t spillReads,
     uint64_t spillReadBytes,
-    uint64_t spillRadTimeUs) {
+    uint64_t spillReadTimeNs) {
   auto statsLocked = localSpillStats().wlock();
   statsLocked->spillReads += spillReads;
   statsLocked->spillReadBytes += spillReadBytes;
-  statsLocked->spillReadTimeUs += spillRadTimeUs;
+  statsLocked->spillReadTimeNanos += spillReadTimeNs;
 }
 
 void updateGlobalSpillMemoryBytes(uint64_t spilledInputBytes) {
@@ -325,8 +327,8 @@ void updateGlobalMaxSpillLevelExceededCount(
       maxSpillLevelExceededCount;
 }
 
-void updateGlobalSpillDeserializationTimeUs(uint64_t timeUs) {
-  localSpillStats().wlock()->spillDeserializationTimeUs += timeUs;
+void updateGlobalSpillDeserializationTimeNs(uint64_t timeNs) {
+  localSpillStats().wlock()->spillDeserializationTimeNanos += timeNs;
 }
 
 SpillStats globalSpillStats() {

--- a/velox/common/base/SpillStats.h
+++ b/velox/common/base/SpillStats.h
@@ -39,19 +39,19 @@ struct SpillStats {
   /// The number of spilled files.
   uint64_t spilledFiles{0};
   /// The time spent on filling rows for spilling.
-  uint64_t spillFillTimeUs{0};
+  uint64_t spillFillTimeNanos{0};
   /// The time spent on sorting rows for spilling.
-  uint64_t spillSortTimeUs{0};
+  uint64_t spillSortTimeNanos{0};
   /// The time spent on serializing rows for spilling.
-  uint64_t spillSerializationTimeUs{0};
+  uint64_t spillSerializationTimeNanos{0};
   /// The number of spill writer flushes, equivalent to number of write calls to
   /// underlying filesystem.
   uint64_t spillWrites{0};
   /// The time spent on copy out serialized rows for disk write. If compression
   /// is enabled, this includes the compression time.
-  uint64_t spillFlushTimeUs{0};
+  uint64_t spillFlushTimeNanos{0};
   /// The time spent on writing spilled rows to disk.
-  uint64_t spillWriteTimeUs{0};
+  uint64_t spillWriteTimeNanos{0};
   /// The number of times that an hash build operator exceeds the max spill
   /// limit.
   uint64_t spillMaxLevelExceededCount{0};
@@ -61,9 +61,9 @@ struct SpillStats {
   /// to the underlying filesystem.
   uint64_t spillReads{0};
   /// The time spent on read data from spilled files.
-  uint64_t spillReadTimeUs{0};
+  uint64_t spillReadTimeNanos{0};
   /// The time spent on deserializing rows read from spilled files.
-  uint64_t spillDeserializationTimeUs{0};
+  uint64_t spillDeserializationTimeNanos{0};
 
   SpillStats(
       uint64_t _spillRuns,
@@ -72,17 +72,17 @@ struct SpillStats {
       uint64_t _spilledRows,
       uint32_t _spilledPartitions,
       uint64_t _spilledFiles,
-      uint64_t _spillFillTimeUs,
-      uint64_t _spillSortTimeUs,
-      uint64_t _spillSerializationTimeUs,
+      uint64_t _spillFillTimeNanos,
+      uint64_t _spillSortTimeNanos,
+      uint64_t _spillSerializationTimeNanos,
       uint64_t _spillWrites,
-      uint64_t _spillFlushTimeUs,
-      uint64_t _spillWriteTimeUs,
+      uint64_t _spillFlushTimeNanos,
+      uint64_t _spillWriteTimeNanos,
       uint64_t _spillMaxLevelExceededCount,
       uint64_t _spillReadBytes,
       uint64_t _spillReads,
-      uint64_t _spillReadTimeUs,
-      uint64_t _spillDeserializationTimeUs);
+      uint64_t _spillReadTimeNanos,
+      uint64_t _spillDeserializationTimeNanos);
 
   SpillStats() = default;
 
@@ -157,7 +157,7 @@ void updateGlobalMaxSpillLevelExceededCount(
     uint64_t maxSpillLevelExceededCount);
 
 /// Increments the spill read deserialization time.
-void updateGlobalSpillDeserializationTimeUs(uint64_t timeUs);
+void updateGlobalSpillDeserializationTimeNs(uint64_t timeUs);
 
 /// Gets the cumulative global spill stats.
 SpillStats globalSpillStats();

--- a/velox/common/base/tests/SpillStatsTest.cpp
+++ b/velox/common/base/tests/SpillStatsTest.cpp
@@ -123,18 +123,18 @@ TEST(SpillStatsTest, spillStats) {
       stats2.toString(),
       "spillRuns[100] spilledInputBytes[2.00KB] spilledBytes[1.00KB] "
       "spilledRows[1031] spilledPartitions[1025] spilledFiles[1026] "
-      "spillFillTimeNanos[1.03ns] spillSortTimeNanos[1.03ns] "
-      "spillSerializationTime[1.03ms] spillWrites[1028] spillFlushTimeNanos[1.03ns] "
-      "spillWriteTimeNanos[1.03ns] maxSpillExceededLimitCount[4] "
+      "spillFillTimeNanos[1.03us] spillSortTimeNanos[1.03us] "
+      "spillSerializationTimeNanos[1.03us] spillWrites[1028] spillFlushTimeNanos[1.03us] "
+      "spillWriteTimeNanos[1.03us] maxSpillExceededLimitCount[4] "
       "spillReadBytes[2.00KB] spillReads[10] spillReadTimeNanos[100ns] "
       "spillReadDeserializationTimeNanos[100ns]");
   ASSERT_EQ(
       fmt::format("{}", stats2),
       "spillRuns[100] spilledInputBytes[2.00KB] spilledBytes[1.00KB] "
       "spilledRows[1031] spilledPartitions[1025] spilledFiles[1026] "
-      "spillFillTimeNanos[1.03ns] spillSortTimeNanos[1.03ns] "
-      "spillSerializationTimeNanos[1.03ns] spillWrites[1028] "
-      "spillFlushTimeNanos[1.03ms] spillWriteTimeNanos[1.03ns] "
+      "spillFillTimeNanos[1.03us] spillSortTimeNanos[1.03us] "
+      "spillSerializationTimeNanos[1.03us] spillWrites[1028] "
+      "spillFlushTimeNanos[1.03us] spillWriteTimeNanos[1.03us] "
       "maxSpillExceededLimitCount[4] "
       "spillReadBytes[2.00KB] spillReads[10] spillReadTimeNanos[100ns] "
       "spillReadDeserializationTimeNanos[100ns]");

--- a/velox/common/base/tests/SpillStatsTest.cpp
+++ b/velox/common/base/tests/SpillStatsTest.cpp
@@ -29,18 +29,18 @@ TEST(SpillStatsTest, spillStats) {
   stats1.spilledBytes = 1024;
   stats1.spilledPartitions = 1024;
   stats1.spilledFiles = 1023;
-  stats1.spillWriteTimeUs = 1023;
-  stats1.spillFlushTimeUs = 1023;
+  stats1.spillWriteTimeNanos = 1023;
+  stats1.spillFlushTimeNanos = 1023;
   stats1.spillWrites = 1023;
-  stats1.spillSortTimeUs = 1023;
-  stats1.spillFillTimeUs = 1023;
+  stats1.spillSortTimeNanos = 1023;
+  stats1.spillFillTimeNanos = 1023;
   stats1.spilledRows = 1023;
-  stats1.spillSerializationTimeUs = 1023;
+  stats1.spillSerializationTimeNanos = 1023;
   stats1.spillMaxLevelExceededCount = 3;
   stats1.spillReadBytes = 1024;
   stats1.spillReads = 10;
-  stats1.spillReadTimeUs = 100;
-  stats1.spillDeserializationTimeUs = 100;
+  stats1.spillReadTimeNanos = 100;
+  stats1.spillDeserializationTimeNanos = 100;
   ASSERT_FALSE(stats1.empty());
   SpillStats stats2;
   stats2.spillRuns = 100;
@@ -48,18 +48,18 @@ TEST(SpillStatsTest, spillStats) {
   stats2.spilledBytes = 1024;
   stats2.spilledPartitions = 1025;
   stats2.spilledFiles = 1026;
-  stats2.spillWriteTimeUs = 1026;
-  stats2.spillFlushTimeUs = 1027;
+  stats2.spillWriteTimeNanos = 1026;
+  stats2.spillFlushTimeNanos = 1027;
   stats2.spillWrites = 1028;
-  stats2.spillSortTimeUs = 1029;
-  stats2.spillFillTimeUs = 1030;
+  stats2.spillSortTimeNanos = 1029;
+  stats2.spillFillTimeNanos = 1030;
   stats2.spilledRows = 1031;
-  stats2.spillSerializationTimeUs = 1032;
+  stats2.spillSerializationTimeNanos = 1032;
   stats2.spillMaxLevelExceededCount = 4;
   stats2.spillReadBytes = 2048;
   stats2.spillReads = 10;
-  stats2.spillReadTimeUs = 100;
-  stats2.spillDeserializationTimeUs = 100;
+  stats2.spillReadTimeNanos = 100;
+  stats2.spillDeserializationTimeNanos = 100;
   ASSERT_TRUE(stats1 < stats2);
   ASSERT_TRUE(stats1 <= stats2);
   ASSERT_FALSE(stats1 > stats2);
@@ -79,34 +79,34 @@ TEST(SpillStatsTest, spillStats) {
   ASSERT_EQ(delta.spilledBytes, 0);
   ASSERT_EQ(delta.spilledPartitions, 1);
   ASSERT_EQ(delta.spilledFiles, 3);
-  ASSERT_EQ(delta.spillWriteTimeUs, 3);
-  ASSERT_EQ(delta.spillFlushTimeUs, 4);
+  ASSERT_EQ(delta.spillWriteTimeNanos, 3);
+  ASSERT_EQ(delta.spillFlushTimeNanos, 4);
   ASSERT_EQ(delta.spillWrites, 5);
-  ASSERT_EQ(delta.spillSortTimeUs, 6);
-  ASSERT_EQ(delta.spillFillTimeUs, 7);
+  ASSERT_EQ(delta.spillSortTimeNanos, 6);
+  ASSERT_EQ(delta.spillFillTimeNanos, 7);
   ASSERT_EQ(delta.spilledRows, 8);
-  ASSERT_EQ(delta.spillSerializationTimeUs, 9);
+  ASSERT_EQ(delta.spillSerializationTimeNanos, 9);
   ASSERT_EQ(delta.spillReadBytes, 1024);
   ASSERT_EQ(delta.spillReads, 0);
-  ASSERT_EQ(delta.spillReadTimeUs, 0);
-  ASSERT_EQ(delta.spillDeserializationTimeUs, 0);
+  ASSERT_EQ(delta.spillReadTimeNanos, 0);
+  ASSERT_EQ(delta.spillDeserializationTimeNanos, 0);
   delta = stats1 - stats2;
   ASSERT_EQ(delta.spilledInputBytes, 0);
   ASSERT_EQ(delta.spilledBytes, 0);
   ASSERT_EQ(delta.spilledPartitions, -1);
   ASSERT_EQ(delta.spilledFiles, -3);
-  ASSERT_EQ(delta.spillWriteTimeUs, -3);
-  ASSERT_EQ(delta.spillFlushTimeUs, -4);
+  ASSERT_EQ(delta.spillWriteTimeNanos, -3);
+  ASSERT_EQ(delta.spillFlushTimeNanos, -4);
   ASSERT_EQ(delta.spillWrites, -5);
-  ASSERT_EQ(delta.spillSortTimeUs, -6);
-  ASSERT_EQ(delta.spillFillTimeUs, -7);
+  ASSERT_EQ(delta.spillSortTimeNanos, -6);
+  ASSERT_EQ(delta.spillFillTimeNanos, -7);
   ASSERT_EQ(delta.spilledRows, -8);
-  ASSERT_EQ(delta.spillSerializationTimeUs, -9);
+  ASSERT_EQ(delta.spillSerializationTimeNanos, -9);
   ASSERT_EQ(delta.spillMaxLevelExceededCount, -1);
   ASSERT_EQ(delta.spillReadBytes, -1024);
   ASSERT_EQ(delta.spillReads, 0);
-  ASSERT_EQ(delta.spillReadTimeUs, 0);
-  ASSERT_EQ(delta.spillDeserializationTimeUs, 0);
+  ASSERT_EQ(delta.spillReadTimeNanos, 0);
+  ASSERT_EQ(delta.spillDeserializationTimeNanos, 0);
   stats1.spilledInputBytes = 2060;
   stats1.spilledBytes = 1030;
   stats1.spillReadBytes = 4096;
@@ -123,19 +123,19 @@ TEST(SpillStatsTest, spillStats) {
       stats2.toString(),
       "spillRuns[100] spilledInputBytes[2.00KB] spilledBytes[1.00KB] "
       "spilledRows[1031] spilledPartitions[1025] spilledFiles[1026] "
-      "spillFillTimeUs[1.03ms] spillSortTime[1.03ms] "
-      "spillSerializationTime[1.03ms] spillWrites[1028] spillFlushTime[1.03ms] "
-      "spillWriteTime[1.03ms] maxSpillExceededLimitCount[4] "
-      "spillReadBytes[2.00KB] spillReads[10] spillReadTime[100us] "
-      "spillReadDeserializationTime[100us]");
+      "spillFillTimeNanos[1.03ns] spillSortTimeNanos[1.03ns] "
+      "spillSerializationTime[1.03ms] spillWrites[1028] spillFlushTimeNanos[1.03ns] "
+      "spillWriteTimeNanos[1.03ns] maxSpillExceededLimitCount[4] "
+      "spillReadBytes[2.00KB] spillReads[10] spillReadTimeNanos[100ns] "
+      "spillReadDeserializationTimeNanos[100ns]");
   ASSERT_EQ(
       fmt::format("{}", stats2),
       "spillRuns[100] spilledInputBytes[2.00KB] spilledBytes[1.00KB] "
       "spilledRows[1031] spilledPartitions[1025] spilledFiles[1026] "
-      "spillFillTimeUs[1.03ms] spillSortTime[1.03ms] "
-      "spillSerializationTime[1.03ms] spillWrites[1028] "
-      "spillFlushTime[1.03ms] spillWriteTime[1.03ms] "
+      "spillFillTimeNanos[1.03ns] spillSortTimeNanos[1.03ns] "
+      "spillSerializationTimeNanos[1.03ns] spillWrites[1028] "
+      "spillFlushTimeNanos[1.03ms] spillWriteTimeNanos[1.03ns] "
       "maxSpillExceededLimitCount[4] "
-      "spillReadBytes[2.00KB] spillReads[10] spillReadTime[100us] "
-      "spillReadDeserializationTime[100us]");
+      "spillReadBytes[2.00KB] spillReads[10] spillReadTimeNanos[100ns] "
+      "spillReadDeserializationTimeNanos[100ns]");
 }

--- a/velox/common/time/Timer.h
+++ b/velox/common/time/Timer.h
@@ -44,6 +44,24 @@ class MicrosecondTimer {
   uint64_t* timer_;
 };
 
+class NanosecondTimer {
+ public:
+  explicit NanosecondTimer(uint64_t* timer) : timer_(timer) {
+    start_ = std::chrono::steady_clock::now();
+  }
+
+  ~NanosecondTimer() {
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::steady_clock::now() - start_);
+
+    (*timer_) += duration.count();
+  }
+
+ private:
+  std::chrono::steady_clock::time_point start_;
+  uint64_t* timer_;
+};
+
 /// Measures the time between construction and destruction with CPU clock
 /// counter (rdtsc on X86) and increments a user-supplied counter with the cycle
 /// count.

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -492,10 +492,10 @@ TEST_F(HiveDataSinkTest, basic) {
       stats.toString(),
       "numWrittenBytes 0B numWrittenFiles 0 spillRuns[0] spilledInputBytes[0B] "
       "spilledBytes[0B] spilledRows[0] spilledPartitions[0] spilledFiles[0] "
-      "spillFillTimeNanos[0us] spillSortTime[0us] spillSerializationTime[0us] "
-      "spillWrites[0] spillFlushTime[0us] spillWriteTime[0us] "
+      "spillFillTimeNanos[0ns] spillSortTimeNanos[0ns] spillSerializationTimeNanos[0ns] "
+      "spillWrites[0] spillFlushTimeNanos[0ns] spillWriteTimeNanos[0ns] "
       "maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] "
-      "spillReadTime[0us] spillReadDeserializationTime[0us]");
+      "spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns]");
 
   const int numBatches = 10;
   const auto vectors = createVectors(500, numBatches);
@@ -540,10 +540,10 @@ TEST_F(HiveDataSinkTest, basicBucket) {
       stats.toString(),
       "numWrittenBytes 0B numWrittenFiles 0 spillRuns[0] spilledInputBytes[0B] "
       "spilledBytes[0B] spilledRows[0] spilledPartitions[0] spilledFiles[0] "
-      "spillFillTimeNanos[0us] spillSortTime[0us] spillSerializationTime[0us] "
-      "spillWrites[0] spillFlushTime[0us] spillWriteTime[0us] "
+      "spillFillTimeNanos[0ns] spillSortTimeNanos[0ns] spillSerializationTimeNanos[0ns] "
+      "spillWrites[0] spillFlushTimeNanos[0ns] spillWriteTimeNanos[0ns] "
       "maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] "
-      "spillReadTime[0us] spillReadDeserializationTime[0us]");
+      "spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns]");
 
   const int numBatches = 10;
   const auto vectors = createVectors(500, numBatches);

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -492,7 +492,7 @@ TEST_F(HiveDataSinkTest, basic) {
       stats.toString(),
       "numWrittenBytes 0B numWrittenFiles 0 spillRuns[0] spilledInputBytes[0B] "
       "spilledBytes[0B] spilledRows[0] spilledPartitions[0] spilledFiles[0] "
-      "spillFillTimeUs[0us] spillSortTime[0us] spillSerializationTime[0us] "
+      "spillFillTimeNanos[0us] spillSortTime[0us] spillSerializationTime[0us] "
       "spillWrites[0] spillFlushTime[0us] spillWriteTime[0us] "
       "maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] "
       "spillReadTime[0us] spillReadDeserializationTime[0us]");
@@ -540,7 +540,7 @@ TEST_F(HiveDataSinkTest, basicBucket) {
       stats.toString(),
       "numWrittenBytes 0B numWrittenFiles 0 spillRuns[0] spilledInputBytes[0B] "
       "spilledBytes[0B] spilledRows[0] spilledPartitions[0] spilledFiles[0] "
-      "spillFillTimeUs[0us] spillSortTime[0us] spillSerializationTime[0us] "
+      "spillFillTimeNanos[0us] spillSortTime[0us] spillSerializationTime[0us] "
       "spillWrites[0] spillFlushTime[0us] spillWriteTime[0us] "
       "maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] "
       "spillReadTime[0us] spillReadDeserializationTime[0us]");

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1512,7 +1512,7 @@ void HashProbe::noMoreInputInternal() {
         spillInputPartitionIds_.size(),
         inputSpiller_->spilledPartitionSet().size());
     inputSpiller_->finishSpill(spillPartitionSet_);
-    VELOX_CHECK_EQ(spillStats_.rlock()->spillSortTimeUs, 0);
+    VELOX_CHECK_EQ(spillStats_.rlock()->spillSortTimeNanos, 0);
   }
 
   const bool hasSpillEnabled = spillEnabled();

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -300,55 +300,40 @@ void Operator::recordSpillStats() {
   lockedStats->spilledRows += lockedSpillStats->spilledRows;
   lockedStats->spilledPartitions += lockedSpillStats->spilledPartitions;
   lockedStats->spilledFiles += lockedSpillStats->spilledFiles;
-  if (lockedSpillStats->spillFillTimeUs != 0) {
+  if (lockedSpillStats->spillFillTimeNanos != 0) {
     lockedStats->addRuntimeStat(
         kSpillFillTime,
         RuntimeCounter{
-            static_cast<int64_t>(
-                lockedSpillStats->spillFillTimeUs *
-                Timestamp::kNanosecondsInMicrosecond),
-            RuntimeCounter::Unit::kNanos});
+            static_cast<int64_t>(lockedSpillStats->spillFillTimeNanos)});
   }
-  if (lockedSpillStats->spillSortTimeUs != 0) {
+  if (lockedSpillStats->spillSortTimeNanos != 0) {
     lockedStats->addRuntimeStat(
         kSpillSortTime,
         RuntimeCounter{
-            static_cast<int64_t>(
-                lockedSpillStats->spillSortTimeUs *
-                Timestamp::kNanosecondsInMicrosecond),
-            RuntimeCounter::Unit::kNanos});
+            static_cast<int64_t>(lockedSpillStats->spillSortTimeNanos)});
   }
-  if (lockedSpillStats->spillSerializationTimeUs != 0) {
+  if (lockedSpillStats->spillSerializationTimeNanos != 0) {
     lockedStats->addRuntimeStat(
         kSpillSerializationTime,
-        RuntimeCounter{
-            static_cast<int64_t>(
-                lockedSpillStats->spillSerializationTimeUs *
-                Timestamp::kNanosecondsInMicrosecond),
-            RuntimeCounter::Unit::kNanos});
+        RuntimeCounter{static_cast<int64_t>(
+            lockedSpillStats->spillSerializationTimeNanos)});
   }
-  if (lockedSpillStats->spillFlushTimeUs != 0) {
+  if (lockedSpillStats->spillFlushTimeNanos != 0) {
     lockedStats->addRuntimeStat(
         kSpillFlushTime,
         RuntimeCounter{
-            static_cast<int64_t>(
-                lockedSpillStats->spillFlushTimeUs *
-                Timestamp::kNanosecondsInMicrosecond),
-            RuntimeCounter::Unit::kNanos});
+            static_cast<int64_t>(lockedSpillStats->spillFlushTimeNanos)});
   }
   if (lockedSpillStats->spillWrites != 0) {
     lockedStats->addRuntimeStat(
         kSpillWrites,
         RuntimeCounter{static_cast<int64_t>(lockedSpillStats->spillWrites)});
   }
-  if (lockedSpillStats->spillWriteTimeUs != 0) {
+  if (lockedSpillStats->spillWriteTimeNanos != 0) {
     lockedStats->addRuntimeStat(
         kSpillWriteTime,
         RuntimeCounter{
-            static_cast<int64_t>(
-                lockedSpillStats->spillWriteTimeUs *
-                Timestamp::kNanosecondsInMicrosecond),
-            RuntimeCounter::Unit::kNanos});
+            static_cast<int64_t>(lockedSpillStats->spillWriteTimeNanos)});
   }
   if (lockedSpillStats->spillRuns != 0) {
     lockedStats->addRuntimeStat(
@@ -380,22 +365,18 @@ void Operator::recordSpillStats() {
         RuntimeCounter{static_cast<int64_t>(lockedSpillStats->spillReads)});
   }
 
-  if (lockedSpillStats->spillReadTimeUs != 0) {
+  if (lockedSpillStats->spillReadTimeNanos != 0) {
     lockedStats->addRuntimeStat(
         kSpillReadTime,
         RuntimeCounter{
-            static_cast<int64_t>(lockedSpillStats->spillReadTimeUs) *
-                Timestamp::kNanosecondsInMicrosecond,
-            RuntimeCounter::Unit::kNanos});
+            static_cast<int64_t>(lockedSpillStats->spillReadTimeNanos)});
   }
 
-  if (lockedSpillStats->spillDeserializationTimeUs != 0) {
+  if (lockedSpillStats->spillDeserializationTimeNanos != 0) {
     lockedStats->addRuntimeStat(
         kSpillDeserializationTime,
-        RuntimeCounter{
-            static_cast<int64_t>(lockedSpillStats->spillDeserializationTimeUs) *
-                Timestamp::kNanosecondsInMicrosecond,
-            RuntimeCounter::Unit::kNanos});
+        RuntimeCounter{static_cast<int64_t>(
+            lockedSpillStats->spillDeserializationTimeNanos)});
   }
   lockedSpillStats->reset();
 }

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -293,12 +293,12 @@ class SpillTest : public ::testing::TestWithParam<common::CompressionKind>,
     ASSERT_GT(stats.spillWrites, 0);
     // NOTE: On fast machines we might have sub-microsecond in each write,
     // resulting in 0us total write time.
-    ASSERT_GE(stats.spillWriteTimeUs, 0);
-    ASSERT_GE(stats.spillFlushTimeUs, 0);
+    ASSERT_GE(stats.spillWriteTimeNanos, 0);
+    ASSERT_GE(stats.spillFlushTimeNanos, 0);
     ASSERT_GT(stats.spilledRows, 0);
     // NOTE: the following stats are not collected by spill state.
-    ASSERT_EQ(stats.spillFillTimeUs, 0);
-    ASSERT_EQ(stats.spillSortTimeUs, 0);
+    ASSERT_EQ(stats.spillFillTimeNanos, 0);
+    ASSERT_EQ(stats.spillSortTimeNanos, 0);
     const auto newGStats = common::globalSpillStats();
     ASSERT_EQ(
         prevGStats.spilledPartitions + stats.spilledPartitions,
@@ -310,19 +310,19 @@ class SpillTest : public ::testing::TestWithParam<common::CompressionKind>,
     ASSERT_EQ(
         prevGStats.spillWrites + stats.spillWrites, newGStats.spillWrites);
     ASSERT_EQ(
-        prevGStats.spillWriteTimeUs + stats.spillWriteTimeUs,
-        newGStats.spillWriteTimeUs);
+        prevGStats.spillWriteTimeNanos + stats.spillWriteTimeNanos,
+        newGStats.spillWriteTimeNanos);
     ASSERT_EQ(
-        prevGStats.spillFlushTimeUs + stats.spillFlushTimeUs,
-        newGStats.spillFlushTimeUs);
+        prevGStats.spillFlushTimeNanos + stats.spillFlushTimeNanos,
+        newGStats.spillFlushTimeNanos);
     ASSERT_EQ(
         prevGStats.spilledRows + stats.spilledRows, newGStats.spilledRows);
     ASSERT_EQ(
-        prevGStats.spillFillTimeUs + stats.spillFillTimeUs,
-        newGStats.spillFillTimeUs);
+        prevGStats.spillFillTimeNanos + stats.spillFillTimeNanos,
+        newGStats.spillFillTimeNanos);
     ASSERT_EQ(
-        prevGStats.spillSortTimeUs + stats.spillSortTimeUs,
-        newGStats.spillSortTimeUs);
+        prevGStats.spillSortTimeNanos + stats.spillSortTimeNanos,
+        newGStats.spillSortTimeNanos);
 
     // Verifies the spill file id
     for (auto& partitionNum : state_->spilledPartitionSet()) {
@@ -395,35 +395,33 @@ class SpillTest : public ::testing::TestWithParam<common::CompressionKind>,
     const auto finalStats = spillStats_.copy();
     ASSERT_EQ(finalStats.spillReadBytes, finalStats.spilledBytes);
     ASSERT_GT(finalStats.spillReads, 0);
-    ASSERT_GT(finalStats.spillReadTimeUs, 0);
-    ASSERT_GT(finalStats.spillDeserializationTimeUs, 0);
-
+    ASSERT_GT(finalStats.spillReadTimeNanos, 0);
+    ASSERT_GT(finalStats.spillDeserializationTimeNanos, 0);
     ASSERT_EQ(
         finalStats.toString(),
         fmt::format(
-            "spillRuns[{}] spilledInputBytes[{}] spilledBytes[{}] "
-            "spilledRows[{}] spilledPartitions[{}] spilledFiles[{}] "
-            "spillFillTimeUs[{}] spillSortTime[{}] spillSerializationTime[{}] "
-            "spillWrites[{}] spillFlushTime[{}] spillWriteTime[{}] "
-            "maxSpillExceededLimitCount[0] spillReadBytes[{}] spillReads[{}] "
-            "spillReadTime[{}] spillReadDeserializationTime[{}]",
+            "spillRuns[{}] spilledInputBytes[{}] spilledBytes[{}] spilledRows[{}] "
+            "spilledPartitions[{}] spilledFiles[{}] spillFillTimeNanos[{}] "
+            "spillSortTimeNanos[{}] spillSerializationTimeNanos[{}] spillWrites[{}] "
+            "spillFlushTimeNanos[{}] spillWriteTimeNanos[{}] maxSpillExceededLimitCount[0] "
+            "spillReadBytes[{}] spillReads[{}] spillReadTimeNanos[{}] "
+            "spillReadDeserializationTimeNanos[{}]",
             finalStats.spillRuns,
             succinctBytes(finalStats.spilledInputBytes),
             succinctBytes(finalStats.spilledBytes),
             finalStats.spilledRows,
             finalStats.spilledPartitions,
             finalStats.spilledFiles,
-            succinctMicros(finalStats.spillFillTimeUs),
-            succinctMicros(finalStats.spillSortTimeUs),
-            succinctMicros(finalStats.spillSerializationTimeUs),
+            succinctNanos(finalStats.spillFillTimeNanos),
+            succinctNanos(finalStats.spillSortTimeNanos),
+            succinctNanos(finalStats.spillSerializationTimeNanos),
             finalStats.spillWrites,
-            succinctMicros(finalStats.spillFlushTimeUs),
-            succinctMicros(finalStats.spillWriteTimeUs),
+            succinctNanos(finalStats.spillFlushTimeNanos),
+            succinctNanos(finalStats.spillWriteTimeNanos),
             succinctBytes(finalStats.spillReadBytes),
             finalStats.spillReads,
-            succinctMicros(finalStats.spillReadTimeUs),
-            succinctMicros(finalStats.spillDeserializationTimeUs)));
-
+            succinctNanos(finalStats.spillReadTimeNanos),
+            succinctNanos(finalStats.spillDeserializationTimeNanos)));
     // Verify the spilled files are still there after spill state destruction.
     for (const auto& spilledFile : spilledFileSet) {
       ASSERT_TRUE(fs->exists(spilledFile));

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -290,15 +290,15 @@ class SpillerTest : public exec::test::RowContainerTestBase {
 
     ASSERT_EQ(stats.spilledBytes, totalSpilledBytes);
     ASSERT_EQ(stats.spillReadBytes, totalSpilledBytes);
-    ASSERT_GT(stats.spillWriteTimeUs, 0);
+    ASSERT_GT(stats.spillWriteTimeNanos, 0);
     if (type_ == Spiller::Type::kAggregateOutput) {
-      ASSERT_EQ(stats.spillSortTimeUs, 0);
+      ASSERT_EQ(stats.spillSortTimeNanos, 0);
     } else {
-      ASSERT_GT(stats.spillSortTimeUs, 0);
+      ASSERT_GT(stats.spillSortTimeNanos, 0);
     }
-    ASSERT_GT(stats.spillFlushTimeUs, 0);
-    ASSERT_GT(stats.spillFillTimeUs, 0);
-    ASSERT_GT(stats.spillSerializationTimeUs, 0);
+    ASSERT_GT(stats.spillFlushTimeNanos, 0);
+    ASSERT_GT(stats.spillFillTimeNanos, 0);
+    ASSERT_GT(stats.spillSerializationTimeNanos, 0);
     ASSERT_GT(stats.spillWrites, 0);
 
     const auto newGStats = common::globalSpillStats();
@@ -316,29 +316,30 @@ class SpillerTest : public exec::test::RowContainerTestBase {
         newGStats.spillReadBytes);
     ASSERT_EQ(prevGStats.spillReads + stats.spillReads, newGStats.spillReads);
     ASSERT_EQ(
-        prevGStats.spillReadTimeUs + stats.spillReadTimeUs,
-        newGStats.spillReadTimeUs);
+        prevGStats.spillReadTimeNanos + stats.spillReadTimeNanos,
+        newGStats.spillReadTimeNanos);
     ASSERT_EQ(
-        prevGStats.spillDeserializationTimeUs +
-            stats.spillDeserializationTimeUs,
-        newGStats.spillDeserializationTimeUs);
+        prevGStats.spillDeserializationTimeNanos +
+            stats.spillDeserializationTimeNanos,
+        newGStats.spillDeserializationTimeNanos);
     ASSERT_EQ(
-        prevGStats.spillWriteTimeUs + stats.spillWriteTimeUs,
-        newGStats.spillWriteTimeUs);
+        prevGStats.spillWriteTimeNanos + stats.spillWriteTimeNanos,
+        newGStats.spillWriteTimeNanos);
     ASSERT_EQ(
-        prevGStats.spillSortTimeUs + stats.spillSortTimeUs,
-        newGStats.spillSortTimeUs);
+        prevGStats.spillSortTimeNanos + stats.spillSortTimeNanos,
+        newGStats.spillSortTimeNanos);
     ASSERT_EQ(
-        prevGStats.spillFlushTimeUs + stats.spillFlushTimeUs,
-        newGStats.spillFlushTimeUs)
-        << prevGStats.spillFlushTimeUs << " " << stats.spillFlushTimeUs << " "
-        << newGStats.spillFlushTimeUs;
+        prevGStats.spillFlushTimeNanos + stats.spillFlushTimeNanos,
+        newGStats.spillFlushTimeNanos)
+        << prevGStats.spillFlushTimeNanos << " " << stats.spillFlushTimeNanos
+        << " " << newGStats.spillFlushTimeNanos;
     ASSERT_EQ(
-        prevGStats.spillFillTimeUs + stats.spillFillTimeUs,
-        newGStats.spillFillTimeUs);
+        prevGStats.spillFillTimeNanos + stats.spillFillTimeNanos,
+        newGStats.spillFillTimeNanos);
     ASSERT_EQ(
-        prevGStats.spillSerializationTimeUs + stats.spillSerializationTimeUs,
-        newGStats.spillSerializationTimeUs);
+        prevGStats.spillSerializationTimeNanos +
+            stats.spillSerializationTimeNanos,
+        newGStats.spillSerializationTimeNanos);
     ASSERT_EQ(
         prevGStats.spillWrites + stats.spillWrites, newGStats.spillWrites);
 
@@ -846,33 +847,33 @@ class SpillerTest : public exec::test::RowContainerTestBase {
         if (numAppendBatches == 0) {
           ASSERT_EQ(stats.spilledRows, 0);
           ASSERT_EQ(stats.spilledBytes, 0);
-          ASSERT_EQ(stats.spillWriteTimeUs, 0);
-          ASSERT_EQ(stats.spillFlushTimeUs, 0);
-          ASSERT_EQ(stats.spillSerializationTimeUs, 0);
+          ASSERT_EQ(stats.spillWriteTimeNanos, 0);
+          ASSERT_EQ(stats.spillFlushTimeNanos, 0);
+          ASSERT_EQ(stats.spillSerializationTimeNanos, 0);
           ASSERT_EQ(stats.spillWrites, 0);
         } else {
           ASSERT_GT(stats.spilledRows, 0);
           ASSERT_GT(stats.spilledBytes, 0);
-          ASSERT_GT(stats.spillWriteTimeUs, 0);
-          ASSERT_GT(stats.spillFlushTimeUs, 0);
-          ASSERT_GT(stats.spillSerializationTimeUs, 0);
+          ASSERT_GT(stats.spillWriteTimeNanos, 0);
+          ASSERT_GT(stats.spillFlushTimeNanos, 0);
+          ASSERT_GT(stats.spillSerializationTimeNanos, 0);
           ASSERT_GT(stats.spillWrites, 0);
         }
       } else {
         ASSERT_GT(stats.spilledRows, 0);
         ASSERT_GT(stats.spilledBytes, 0);
-        ASSERT_GT(stats.spillWriteTimeUs, 0);
-        ASSERT_GT(stats.spillFlushTimeUs, 0);
-        ASSERT_GT(stats.spillSerializationTimeUs, 0);
+        ASSERT_GT(stats.spillWriteTimeNanos, 0);
+        ASSERT_GT(stats.spillFlushTimeNanos, 0);
+        ASSERT_GT(stats.spillSerializationTimeNanos, 0);
         ASSERT_GT(stats.spillWrites, 0);
       }
       ASSERT_GT(stats.spilledPartitions, 0);
-      ASSERT_EQ(stats.spillSortTimeUs, 0);
+      ASSERT_EQ(stats.spillSortTimeNanos, 0);
       if (type_ == Spiller::Type::kHashJoinBuild ||
           type_ == Spiller::Type::kRowNumber) {
-        ASSERT_GT(stats.spillFillTimeUs, 0);
+        ASSERT_GT(stats.spillFillTimeNanos, 0);
       } else {
-        ASSERT_EQ(stats.spillFillTimeUs, 0);
+        ASSERT_EQ(stats.spillFillTimeNanos, 0);
       }
 
       const auto newGStats = common::globalSpillStats();
@@ -886,22 +887,23 @@ class SpillerTest : public exec::test::RowContainerTestBase {
       ASSERT_EQ(
           prevGStats.spilledBytes + stats.spilledBytes, newGStats.spilledBytes);
       ASSERT_EQ(
-          prevGStats.spillWriteTimeUs + stats.spillWriteTimeUs,
-          newGStats.spillWriteTimeUs);
+          prevGStats.spillWriteTimeNanos + stats.spillWriteTimeNanos,
+          newGStats.spillWriteTimeNanos);
       ASSERT_EQ(
-          prevGStats.spillSortTimeUs + stats.spillSortTimeUs,
-          newGStats.spillSortTimeUs);
+          prevGStats.spillSortTimeNanos + stats.spillSortTimeNanos,
+          newGStats.spillSortTimeNanos);
       ASSERT_EQ(
-          prevGStats.spillFlushTimeUs + stats.spillFlushTimeUs,
-          newGStats.spillFlushTimeUs)
-          << prevGStats.spillFlushTimeUs << " " << stats.spillFlushTimeUs << " "
-          << newGStats.spillFlushTimeUs;
+          prevGStats.spillFlushTimeNanos + stats.spillFlushTimeNanos,
+          newGStats.spillFlushTimeNanos)
+          << prevGStats.spillFlushTimeNanos << " " << stats.spillFlushTimeNanos
+          << " " << newGStats.spillFlushTimeNanos;
       ASSERT_EQ(
-          prevGStats.spillFillTimeUs + stats.spillFillTimeUs,
-          newGStats.spillFillTimeUs);
+          prevGStats.spillFillTimeNanos + stats.spillFillTimeNanos,
+          newGStats.spillFillTimeNanos);
       ASSERT_EQ(
-          prevGStats.spillSerializationTimeUs + stats.spillSerializationTimeUs,
-          newGStats.spillSerializationTimeUs);
+          prevGStats.spillSerializationTimeNanos +
+              stats.spillSerializationTimeNanos,
+          newGStats.spillSerializationTimeNanos);
       ASSERT_EQ(
           prevGStats.spillWrites + stats.spillWrites, newGStats.spillWrites);
 
@@ -1464,7 +1466,7 @@ TEST_P(AggregationOutputOnly, basic) {
       ASSERT_EQ(stats.spilledFiles, 1) << stats.toString();
       ASSERT_EQ(stats.spilledRows, expectedNumSpilledRows) << stats.toString();
     }
-    ASSERT_EQ(stats.spillSortTimeUs, 0);
+    ASSERT_EQ(stats.spillSortTimeNanos, 0);
   }
 }
 
@@ -1571,7 +1573,7 @@ TEST_P(OrderByOutputOnly, basic) {
       ASSERT_EQ(stats.spilledFiles, 1) << stats.toString();
       ASSERT_EQ(stats.spilledRows, expectedNumSpilledRows) << stats.toString();
     }
-    ASSERT_EQ(stats.spillSortTimeUs, 0);
+    ASSERT_EQ(stats.spillSortTimeNanos, 0);
   }
 }
 


### PR DESCRIPTION
Change the spill time metric from microseconds to nanosecond.
This is a follow up of https://github.com/facebookincubator/velox/pull/9765/

Resolves: https://github.com/facebookincubator/velox/issues/10688