### PR TITLE
Allow column names to contain space

### DIFF
--- a/velox/type/Tokenizer.cpp
+++ b/velox/type/Tokenizer.cpp
@@ -157,7 +157,7 @@ bool Tokenizer::isUnquotedPathCharacter(char c) {
 }
 
 bool Tokenizer::isUnquotedSubscriptCharacter(char c) {
-  return c == '-' || c == '_' || isalnum(c);
+  return c == '-' || c == '_' || c == ' ' || isalnum(c);
 }
 
 std::unique_ptr<Subfield::PathElement> Tokenizer::matchQuotedSubscript() {

--- a/velox/type/tests/SubfieldTest.cpp
+++ b/velox/type/tests/SubfieldTest.cpp
@@ -57,6 +57,9 @@ void testColumnName(
 }
 
 TEST(SubfieldTest, columnNamesWithSpecialCharacters) {
+  testColumnName("two words");
+  testColumnName("two  words");
+  testColumnName("one two three");
   testColumnName("$bucket");
   testColumnName("apollo-11");
   testColumnName("a/b/c:12");


### PR DESCRIPTION
For Hive tables with higher version than 0.13 allows the table and column names to contain spaces. This change allows spaces to be part of unquoted subscript characters