### PR TITLE
feat: Add support for UUID comparison functions

### DIFF
--- a/velox/functions/prestosql/UuidFunctions.h
+++ b/velox/functions/prestosql/UuidFunctions.h
@@ -20,9 +20,28 @@
 
 #include "velox/functions/Macros.h"
 #include "velox/functions/Registerer.h"
+#include "velox/functions/prestosql/Comparisons.h"
 #include "velox/functions/prestosql/types/UuidType.h"
 
 namespace facebook::velox::functions {
+
+#define VELOX_GEN_BINARY_EXPR_UUID(Name, uuidCompExpr)                         \
+  template <typename T>                                                        \
+  struct Name##Uuid {                                                          \
+    VELOX_DEFINE_FUNCTION_TYPES(T);                                            \
+                                                                               \
+    FOLLY_ALWAYS_INLINE void                                                   \
+    call(bool& result, const arg_type<Uuid>& lhs, const arg_type<Uuid>& rhs) { \
+      result = (uuidCompExpr);                                                 \
+    }                                                                          \
+  };
+
+VELOX_GEN_BINARY_EXPR_UUID(LtFunction, (uint128_t)lhs < (uint128_t)rhs);
+VELOX_GEN_BINARY_EXPR_UUID(GtFunction, (uint128_t)lhs > (uint128_t)rhs);
+VELOX_GEN_BINARY_EXPR_UUID(LteFunction, (uint128_t)lhs <= (uint128_t)rhs);
+VELOX_GEN_BINARY_EXPR_UUID(GteFunction, (uint128_t)lhs >= (uint128_t)rhs);
+
+#undef VELOX_GEN_BINARY_EXPR_UUID
 
 template <typename T>
 struct UuidFunction {
@@ -42,6 +61,10 @@ struct UuidFunction {
 inline void registerUuidFunctions(const std::string& prefix) {
   registerUuidType();
   registerFunction<UuidFunction, Uuid>({prefix + "uuid"});
+  registerFunction<LtFunctionUuid, bool, Uuid, Uuid>({prefix + "lt"});
+  registerFunction<GtFunctionUuid, bool, Uuid, Uuid>({prefix + "gt"});
+  registerFunction<LteFunctionUuid, bool, Uuid, Uuid>({prefix + "lte"});
+  registerFunction<GteFunctionUuid, bool, Uuid, Uuid>({prefix + "gte"});
 }
 
 } // namespace facebook::velox::functions


### PR DESCRIPTION
This adds binary comparison functions <, >, <=, >= to the UUID custom data type. Equality functions are already present. Added unit tests for testing a query with comparisons between UUID values.

The ordering is done lexicographically to conforms with IETF RFC 4122 https://datatracker.ietf.org/doc/html/rfc4122.html, and also matches Presto Java after https://github.com/prestodb/presto/issues/23311.

Related UUID serialization fix at https://github.com/facebookincubator/velox/pull/11197
From https://github.com/facebookincubator/velox/issues/10584