### PR TITLE
Code cleanup to use concept serial / parallel to replace single-threaded / multi-threaded as task execution modes

### DIFF
--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -345,8 +345,8 @@ class SharedArbitrator : public memory::MemoryArbitrator {
 
   // Invoked to run global arbitration to reclaim free or used memory from the
   // other queries. The global arbitration run is protected by the exclusive
-  // lock of 'arbitrationLock_' for serial execution. The function returns true
-  // on success, false on failure.
+  // lock of 'arbitrationLock_' for serial execution mode. The function returns
+  // true on success, false on failure.
   bool runGlobalArbitration(ArbitrationOperation* op);
 
   // Gets the mim/max memory capacity growth targets for 'op'. The min and max

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -1117,7 +1117,7 @@ TEST_F(MockSharedArbitrationTest, shrinkPools) {
 }
 
 // This test verifies local arbitration runs from the same query has to wait for
-// serial execution.
+// serial execution mode.
 DEBUG_ONLY_TEST_F(
     MockSharedArbitrationTest,
     localArbitrationRunsFromSameQuery) {

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -324,7 +324,7 @@ class SharedArbitrationTest : public SharedArbitrationTestBase {
 };
 /// A test fixture that runs cases within both serial and
 /// parallel execution modes.
-class SharedArbitrationTestWithThreadingModes
+class SharedArbitrationTestWithExecutionModes
     : public testing::WithParamInterface<TestParam>,
       public SharedArbitrationTestBase {
  public:
@@ -471,7 +471,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, skipNonReclaimableTaskTest) {
   ASSERT_EQ(taskPausedCount, 1);
 }
 
-DEBUG_ONLY_TEST_P(SharedArbitrationTestWithThreadingModes, reclaimToOrderBy) {
+DEBUG_ONLY_TEST_P(SharedArbitrationTestWithExecutionModes, reclaimToOrderBy) {
   const int numVectors = 32;
   std::vector<RowVectorPtr> vectors;
   for (int i = 0; i < numVectors; ++i) {
@@ -574,7 +574,7 @@ DEBUG_ONLY_TEST_P(SharedArbitrationTestWithThreadingModes, reclaimToOrderBy) {
 }
 
 DEBUG_ONLY_TEST_P(
-    SharedArbitrationTestWithThreadingModes,
+    SharedArbitrationTestWithExecutionModes,
     reclaimToAggregation) {
   const int numVectors = 32;
   std::vector<RowVectorPtr> vectors;
@@ -679,7 +679,7 @@ DEBUG_ONLY_TEST_P(
 }
 
 DEBUG_ONLY_TEST_P(
-    SharedArbitrationTestWithThreadingModes,
+    SharedArbitrationTestWithExecutionModes,
     reclaimToJoinBuilder) {
   const int numVectors = 32;
   std::vector<RowVectorPtr> vectors;
@@ -1353,10 +1353,10 @@ TEST_F(SharedArbitrationTest, reserveReleaseCounters) {
 }
 
 VELOX_INSTANTIATE_TEST_SUITE_P(
-    SharedArbitrationTestWithThreadingModes,
-    SharedArbitrationTestWithThreadingModes,
+    SharedArbitrationTestWithExecutionModes,
+    SharedArbitrationTestWithExecutionModes,
     testing::ValuesIn(
-        SharedArbitrationTestWithThreadingModes::getTestParams()));
+        SharedArbitrationTestWithExecutionModes::getTestParams()));
 } // namespace facebook::velox::memory
 
 int main(int argc, char** argv) {

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -310,7 +310,7 @@ std::unique_ptr<folly::Executor> newParallelExecutor() {
 }
 
 struct TestParam {
-  bool isSerial{false};
+  bool isSerialExecution{false};
 };
 } // namespace
 
@@ -335,15 +335,15 @@ class SharedArbitrationTestWithExecutionModes
  protected:
   void SetUp() override {
     SharedArbitrationTestBase::SetUp();
-    isSerial_ = GetParam().isSerial;
-    if (isSerial_) {
+    isSerialExecution_ = GetParam().isSerialExecution;
+    if (isSerialExecution_) {
       executor_ = nullptr;
     } else {
       executor_ = newParallelExecutor();
     }
   }
 
-  bool isSerial_{false};
+  bool isSerialExecution_{false};
 };
 
 DEBUG_ONLY_TEST_F(SharedArbitrationTest, queryArbitrationStateCheck) {
@@ -536,7 +536,7 @@ DEBUG_ONLY_TEST_P(SharedArbitrationTestWithExecutionModes, reclaimToOrderBy) {
       auto task =
           AssertQueryBuilder(duckDbQueryRunner_)
               .queryCtx(orderByQueryCtx)
-              .serial(isSerial_)
+              .serialExecution(isSerialExecution_)
               .plan(PlanBuilder()
                         .values(vectors)
                         .orderBy({"c0 ASC NULLS LAST"}, false)
@@ -553,7 +553,7 @@ DEBUG_ONLY_TEST_P(SharedArbitrationTestWithExecutionModes, reclaimToOrderBy) {
       auto task =
           AssertQueryBuilder(duckDbQueryRunner_)
               .queryCtx(fakeMemoryQueryCtx)
-              .serial(isSerial_)
+              .serialExecution(isSerialExecution_)
               .plan(PlanBuilder()
                         .values(vectors)
                         .addNode([&](std::string id, core::PlanNodePtr input) {
@@ -640,7 +640,7 @@ DEBUG_ONLY_TEST_P(
       auto task =
           AssertQueryBuilder(duckDbQueryRunner_)
               .queryCtx(aggregationQueryCtx)
-              .serial(isSerial_)
+              .serialExecution(isSerialExecution_)
               .plan(PlanBuilder()
                         .values(vectors)
                         .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
@@ -658,7 +658,7 @@ DEBUG_ONLY_TEST_P(
       auto task =
           AssertQueryBuilder(duckDbQueryRunner_)
               .queryCtx(fakeMemoryQueryCtx)
-              .serial(isSerial_)
+              .serialExecution(isSerialExecution_)
               .plan(PlanBuilder()
                         .values(vectors)
                         .addNode([&](std::string id, core::PlanNodePtr input) {
@@ -746,7 +746,7 @@ DEBUG_ONLY_TEST_P(
       auto task =
           AssertQueryBuilder(duckDbQueryRunner_)
               .queryCtx(joinQueryCtx)
-              .serial(isSerial_)
+              .serialExecution(isSerialExecution_)
               .plan(PlanBuilder(planNodeIdGenerator)
                         .values(vectors)
                         .project({"c0 AS t0", "c1 AS t1", "c2 AS t2"})
@@ -774,7 +774,7 @@ DEBUG_ONLY_TEST_P(
       auto task =
           AssertQueryBuilder(duckDbQueryRunner_)
               .queryCtx(fakeMemoryQueryCtx)
-              .serial(isSerial_)
+              .serialExecution(isSerialExecution_)
               .plan(PlanBuilder()
                         .values(vectors)
                         .addNode([&](std::string id, core::PlanNodePtr input) {

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -310,7 +310,7 @@ std::unique_ptr<folly::Executor> newParallelExecutor() {
 }
 
 struct TestParam {
-  bool isSerialExecution{false};
+  bool isSerialExecutionMode{false};
 };
 } // namespace
 
@@ -335,15 +335,15 @@ class SharedArbitrationTestWithExecutionModes
  protected:
   void SetUp() override {
     SharedArbitrationTestBase::SetUp();
-    isSerialExecution_ = GetParam().isSerialExecution;
-    if (isSerialExecution_) {
+    isSerialExecutionMode_ = GetParam().isSerialExecutionMode;
+    if (isSerialExecutionMode_) {
       executor_ = nullptr;
     } else {
       executor_ = newParallelExecutor();
     }
   }
 
-  bool isSerialExecution_{false};
+  bool isSerialExecutionMode_{false};
 };
 
 DEBUG_ONLY_TEST_F(SharedArbitrationTest, queryArbitrationStateCheck) {
@@ -536,7 +536,7 @@ DEBUG_ONLY_TEST_P(SharedArbitrationTestWithExecutionModes, reclaimToOrderBy) {
       auto task =
           AssertQueryBuilder(duckDbQueryRunner_)
               .queryCtx(orderByQueryCtx)
-              .serialExecution(isSerialExecution_)
+              .serialExecution(isSerialExecutionMode_)
               .plan(PlanBuilder()
                         .values(vectors)
                         .orderBy({"c0 ASC NULLS LAST"}, false)
@@ -553,7 +553,7 @@ DEBUG_ONLY_TEST_P(SharedArbitrationTestWithExecutionModes, reclaimToOrderBy) {
       auto task =
           AssertQueryBuilder(duckDbQueryRunner_)
               .queryCtx(fakeMemoryQueryCtx)
-              .serialExecution(isSerialExecution_)
+              .serialExecution(isSerialExecutionMode_)
               .plan(PlanBuilder()
                         .values(vectors)
                         .addNode([&](std::string id, core::PlanNodePtr input) {
@@ -640,7 +640,7 @@ DEBUG_ONLY_TEST_P(
       auto task =
           AssertQueryBuilder(duckDbQueryRunner_)
               .queryCtx(aggregationQueryCtx)
-              .serialExecution(isSerialExecution_)
+              .serialExecution(isSerialExecutionMode_)
               .plan(PlanBuilder()
                         .values(vectors)
                         .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
@@ -658,7 +658,7 @@ DEBUG_ONLY_TEST_P(
       auto task =
           AssertQueryBuilder(duckDbQueryRunner_)
               .queryCtx(fakeMemoryQueryCtx)
-              .serialExecution(isSerialExecution_)
+              .serialExecution(isSerialExecutionMode_)
               .plan(PlanBuilder()
                         .values(vectors)
                         .addNode([&](std::string id, core::PlanNodePtr input) {
@@ -746,7 +746,7 @@ DEBUG_ONLY_TEST_P(
       auto task =
           AssertQueryBuilder(duckDbQueryRunner_)
               .queryCtx(joinQueryCtx)
-              .serialExecution(isSerialExecution_)
+              .serialExecution(isSerialExecutionMode_)
               .plan(PlanBuilder(planNodeIdGenerator)
                         .values(vectors)
                         .project({"c0 AS t0", "c1 AS t1", "c2 AS t2"})
@@ -774,7 +774,7 @@ DEBUG_ONLY_TEST_P(
       auto task =
           AssertQueryBuilder(duckDbQueryRunner_)
               .queryCtx(fakeMemoryQueryCtx)
-              .serialExecution(isSerialExecution_)
+              .serialExecution(isSerialExecutionMode_)
               .plan(PlanBuilder()
                         .values(vectors)
                         .addNode([&](std::string id, core::PlanNodePtr input) {

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -65,7 +65,6 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
 
   folly::Executor* executor() const {
     return executor_;
-    ;
   }
 
   bool isExecutorSupplied() const {

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -779,7 +779,7 @@ StopReason Driver::runInternal(
                     result->estimateFlatSize(), result->size());
               }
 
-              // This code path is used only in single-threaded execution.
+              // This code path is used only in serial execution.
               blockingReason_ = BlockingReason::kWaitForConsumer;
               guard.notThrown();
               return StopReason::kBlock;

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -779,7 +779,7 @@ StopReason Driver::runInternal(
                     result->estimateFlatSize(), result->size());
               }
 
-              // This code path is used only in serial execution.
+              // This code path is used only in serial execution mode.
               blockingReason_ = BlockingReason::kWaitForConsumer;
               guard.notThrown();
               return StopReason::kBlock;

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -241,7 +241,7 @@ class BlockingState {
   }
 
   /// Moves out the blocking future stored inside. Can be called only once.
-  /// Used in serial execution.
+  /// Used in serial execution mode.
   ContinueFuture future() {
     return std::move(future_);
   }

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -241,7 +241,7 @@ class BlockingState {
   }
 
   /// Moves out the blocking future stored inside. Can be called only once.
-  /// Used in single-threaded execution.
+  /// Used in serial execution.
   ContinueFuture future() {
     return std::move(future_);
   }
@@ -616,7 +616,7 @@ struct DriverFactory {
 
   static void registerAdapter(DriverAdapter adapter);
 
-  bool supportsSingleThreadedExecution() const {
+  bool supportsSerialExecution() const {
     return !needsPartitionedOutput() && !needsExchangeClient() &&
         !needsLocalExchange();
   }

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -307,10 +307,6 @@ Task::Task(
   }
 
   maybeInitQueryTrace();
-  // Executor must not be specified for serial execution mode.
-  if (mode_ == Task::ExecutionMode::kSerial) {
-    VELOX_CHECK_NULL(queryCtx_->executor());
-  }
 }
 
 Task::~Task() {

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -307,7 +307,7 @@ Task::Task(
   }
 
   maybeInitQueryTrace();
-  // Executor must not be specified for serial execution.
+  // Executor must not be specified for serial execution mode.
   if (mode_ == Task::ExecutionMode::kSerial) {
     VELOX_CHECK_NULL(queryCtx_->executor());
   }
@@ -554,7 +554,7 @@ velox::memory::MemoryPool* Task::addExchangeClientPool(
   return childPools_.back().get();
 }
 
-bool Task::supportsSerialExecution() const {
+bool Task::supportsSerialExecutionMode() const {
   if (consumerSupplier_) {
     return false;
   }
@@ -579,13 +579,13 @@ RowVectorPtr Task::next(ContinueFuture* future) {
   VELOX_CHECK_EQ(
       core::ExecutionStrategy::kUngrouped,
       planFragment_.executionStrategy,
-      "Serial execution supports only ungrouped execution");
+      "Serial execution mode supports only ungrouped execution");
 
   if (!splitsStates_.empty()) {
     for (const auto& it : splitsStates_) {
       VELOX_CHECK(
           it.second.noMoreSplits,
-          "Serial execution requires all splits to be added before "
+          "Serial execution mode requires all splits to be added before "
           "calling Task::next().");
     }
   }
@@ -599,7 +599,7 @@ RowVectorPtr Task::next(ContinueFuture* future) {
   if (driverFactories_.empty()) {
     VELOX_CHECK_NULL(
         consumerSupplier_,
-        "Serial execution doesn't support delivering results to a "
+        "Serial execution mode doesn't support delivering results to a "
         "callback");
 
     taskStats_.executionStartTimeMs = getCurrentTimeMs();
@@ -947,7 +947,7 @@ void Task::resume(std::shared_ptr<Task> self) {
           // event. The Driver gets enqueued by the promise realization.
           //
           // Do not continue the driver if no executor is supplied,
-          // This usually happens in serial execution.
+          // This usually happens in serial execution mode.
           Driver::enqueue(driver);
         }
       }

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -165,9 +165,9 @@ class Task : public std::enable_shared_from_this<Task> {
   /// splits groups processed concurrently.
   void start(uint32_t maxDrivers, uint32_t concurrentSplitGroups = 1);
 
-  /// If this returns true, this Task supports the single-threaded execution API
+  /// If this returns true, this Task supports the serial execution API
   /// next().
-  bool supportsSingleThreadedExecution() const;
+  bool supportsSerialExecution() const;
 
   /// Single-threaded execution API. Runs the query and returns results one
   /// batch at a time. Returns nullptr if query evaluation is finished and no

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -167,7 +167,7 @@ class Task : public std::enable_shared_from_this<Task> {
 
   /// If this returns true, this Task supports the serial execution API
   /// next().
-  bool supportsSerialExecution() const;
+  bool supportsSerialExecutionMode() const;
 
   /// Single-threaded execution API. Runs the query and returns results one
   /// batch at a time. Returns nullptr if query evaluation is finished and no

--- a/velox/exec/tests/AssertQueryBuilderTest.cpp
+++ b/velox/exec/tests/AssertQueryBuilderTest.cpp
@@ -41,10 +41,10 @@ TEST_F(AssertQueryBuilderTest, serial) {
   const auto& plan = builder.values({data}).planNode();
 
   AssertQueryBuilder(plan, duckDbQueryRunner_)
-      .serial(true)
+      .serialExecution(true)
       .assertResults("VALUES (1), (2), (3)");
 
-  AssertQueryBuilder(plan).serial(true).assertResults(data);
+  AssertQueryBuilder(plan).serialExecution(true).assertResults(data);
 }
 
 TEST_F(AssertQueryBuilderTest, orderedResults) {

--- a/velox/exec/tests/AssertQueryBuilderTest.cpp
+++ b/velox/exec/tests/AssertQueryBuilderTest.cpp
@@ -34,17 +34,17 @@ TEST_F(AssertQueryBuilderTest, basic) {
       .assertResults(data);
 }
 
-TEST_F(AssertQueryBuilderTest, singleThreaded) {
+TEST_F(AssertQueryBuilderTest, serial) {
   auto data = makeRowVector({makeFlatVector<int32_t>({1, 2, 3})});
 
   PlanBuilder builder;
   const auto& plan = builder.values({data}).planNode();
 
   AssertQueryBuilder(plan, duckDbQueryRunner_)
-      .singleThreaded(true)
+      .serial(true)
       .assertResults("VALUES (1), (2), (3)");
 
-  AssertQueryBuilder(plan).singleThreaded(true).assertResults(data);
+  AssertQueryBuilder(plan).serial(true).assertResults(data);
 }
 
 TEST_F(AssertQueryBuilderTest, orderedResults) {

--- a/velox/exec/tests/AssertQueryBuilderTest.cpp
+++ b/velox/exec/tests/AssertQueryBuilderTest.cpp
@@ -34,7 +34,7 @@ TEST_F(AssertQueryBuilderTest, basic) {
       .assertResults(data);
 }
 
-TEST_F(AssertQueryBuilderTest, serial) {
+TEST_F(AssertQueryBuilderTest, serialExecution) {
   auto data = makeRowVector({makeFlatVector<int32_t>({1, 2, 3})});
 
   PlanBuilder builder;

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -6658,7 +6658,7 @@ TEST_F(HashJoinTest, leftJoinPreserveProbeOrder) {
           .planNode();
   auto result = AssertQueryBuilder(plan)
                     .config(core::QueryConfig::kPreferredOutputBatchRows, "1")
-                    .singleThreaded(true)
+                    .serialExecution(true)
                     .copyResults(pool_.get());
   ASSERT_EQ(result->size(), 3);
   auto* v1 =

--- a/velox/exec/tests/QueryAssertionsTest.cpp
+++ b/velox/exec/tests/QueryAssertionsTest.cpp
@@ -34,12 +34,12 @@ class QueryAssertionsTest : public OperatorTestBase {
       const std::string& duckDbSql) {
     CursorParameters parallelParams{};
     parallelParams.planNode = plan;
-    parallelParams.serialExecutionMode = false;
+    parallelParams.serialExecution = false;
     assertQuery(parallelParams, duckDbSql);
 
     CursorParameters serialParams{};
     serialParams.planNode = plan;
-    serialParams.serialExecutionMode = true;
+    serialParams.serialExecution = true;
     assertQuery(serialParams, duckDbSql);
   }
 };

--- a/velox/exec/tests/QueryAssertionsTest.cpp
+++ b/velox/exec/tests/QueryAssertionsTest.cpp
@@ -34,12 +34,12 @@ class QueryAssertionsTest : public OperatorTestBase {
       const std::string& duckDbSql) {
     CursorParameters parallelParams{};
     parallelParams.planNode = plan;
-    parallelParams.serial = false;
+    parallelParams.serialExecutionMode = false;
     assertQuery(parallelParams, duckDbSql);
 
     CursorParameters serialParams{};
     serialParams.planNode = plan;
-    serialParams.serial = true;
+    serialParams.serialExecutionMode = true;
     assertQuery(serialParams, duckDbSql);
   }
 };

--- a/velox/exec/tests/QueryAssertionsTest.cpp
+++ b/velox/exec/tests/QueryAssertionsTest.cpp
@@ -32,15 +32,15 @@ class QueryAssertionsTest : public OperatorTestBase {
   void assertQueryWithThreadingConfigs(
       const core::PlanNodePtr& plan,
       const std::string& duckDbSql) {
-    CursorParameters multiThreadedParams{};
-    multiThreadedParams.planNode = plan;
-    multiThreadedParams.singleThreaded = false;
-    assertQuery(multiThreadedParams, duckDbSql);
+    CursorParameters parallelParams{};
+    parallelParams.planNode = plan;
+    parallelParams.serial = false;
+    assertQuery(parallelParams, duckDbSql);
 
-    CursorParameters singleThreadedParams{};
-    singleThreadedParams.planNode = plan;
-    singleThreadedParams.singleThreaded = true;
-    assertQuery(singleThreadedParams, duckDbSql);
+    CursorParameters serialParams{};
+    serialParams.planNode = plan;
+    serialParams.serial = true;
+    assertQuery(serialParams, duckDbSql);
   }
 };
 

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -3277,7 +3277,7 @@ TEST_F(TableScanTest, remainingFilterLazyWithMultiReferences) {
   writeToFile(file->getPath(), {vector});
   CursorParameters params;
   params.copyResult = false;
-  params.singleThreaded = true;
+  params.serial = true;
   params.planNode =
       PlanBuilder()
           .tableScan(schema, {}, "NOT (c0 % 2 == 0 AND c2 % 3 == 0)")
@@ -3318,7 +3318,7 @@ TEST_F(
   writeToFile(file->getPath(), {vector});
   CursorParameters params;
   params.copyResult = false;
-  params.singleThreaded = true;
+  params.serial = true;
   params.planNode = PlanBuilder()
                         .tableScan(schema, {}, "c0 % 7 == 0 AND c1 % 2 == 0")
                         .planNode();

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -3277,7 +3277,7 @@ TEST_F(TableScanTest, remainingFilterLazyWithMultiReferences) {
   writeToFile(file->getPath(), {vector});
   CursorParameters params;
   params.copyResult = false;
-  params.serial = true;
+  params.serialExecutionMode = true;
   params.planNode =
       PlanBuilder()
           .tableScan(schema, {}, "NOT (c0 % 2 == 0 AND c2 % 3 == 0)")
@@ -3318,7 +3318,7 @@ TEST_F(
   writeToFile(file->getPath(), {vector});
   CursorParameters params;
   params.copyResult = false;
-  params.serial = true;
+  params.serialExecutionMode = true;
   params.planNode = PlanBuilder()
                         .tableScan(schema, {}, "c0 % 7 == 0 AND c1 % 2 == 0")
                         .planNode();

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -3277,7 +3277,7 @@ TEST_F(TableScanTest, remainingFilterLazyWithMultiReferences) {
   writeToFile(file->getPath(), {vector});
   CursorParameters params;
   params.copyResult = false;
-  params.serialExecutionMode = true;
+  params.serialExecution = true;
   params.planNode =
       PlanBuilder()
           .tableScan(schema, {}, "NOT (c0 % 2 == 0 AND c2 % 3 == 0)")
@@ -3318,7 +3318,7 @@ TEST_F(
   writeToFile(file->getPath(), {vector});
   CursorParameters params;
   params.copyResult = false;
-  params.serialExecutionMode = true;
+  params.serialExecution = true;
   params.planNode = PlanBuilder()
                         .tableScan(schema, {}, "c0 % 7 == 0 AND c1 % 2 == 0")
                         .planNode();

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -462,7 +462,7 @@ class TestBadMemoryTranslator : public exec::Operator::PlanNodeTranslator {
 class TaskTest : public HiveConnectorTestBase {
  protected:
   static std::pair<std::shared_ptr<exec::Task>, std::vector<RowVectorPtr>>
-  executeSingleThreaded(
+  executeSerial(
       core::PlanFragment plan,
       const std::unordered_map<std::string, std::vector<std::string>>&
           filePaths = {}) {
@@ -480,7 +480,7 @@ class TaskTest : public HiveConnectorTestBase {
       task->noMoreSplits(nodeId);
     }
 
-    VELOX_CHECK(task->supportsSingleThreadedExecution());
+    VELOX_CHECK(task->supportsSerialExecution());
 
     vector_size_t numRows = 0;
     std::vector<RowVectorPtr> results;
@@ -727,7 +727,7 @@ TEST_F(TaskTest, testTerminateDeadlock) {
       cursor->task()->toString().find("zombie drivers:"), std::string::npos);
 }
 
-TEST_F(TaskTest, singleThreadedExecution) {
+TEST_F(TaskTest, serialExecution) {
   auto data = makeRowVector({
       makeFlatVector<int64_t>(1'000, [](auto row) { return row; }),
   });
@@ -746,7 +746,7 @@ TEST_F(TaskTest, singleThreadedExecution) {
   uint64_t numCreatedTasks = Task::numCreatedTasks();
   uint64_t numDeletedTasks = Task::numDeletedTasks();
   {
-    auto [task, results] = executeSingleThreaded(plan);
+    auto [task, results] = executeSerial(plan);
     assertEqualResults(
         std::vector<RowVectorPtr>{expectedResult, expectedResult}, results);
   }
@@ -779,7 +779,7 @@ TEST_F(TaskTest, singleThreadedExecution) {
   ++numCreatedTasks;
   ++numDeletedTasks;
   {
-    auto [task, results] = executeSingleThreaded(plan);
+    auto [task, results] = executeSerial(plan);
     assertEqualResults({expectedResult}, results);
   }
   ASSERT_EQ(numCreatedTasks + 1, Task::numCreatedTasks());
@@ -799,16 +799,16 @@ TEST_F(TaskTest, singleThreadedExecution) {
 
   {
     auto [task, results] =
-        executeSingleThreaded(plan, {{scanId, {filePath->getPath()}}});
+        executeSerial(plan, {{scanId, {filePath->getPath()}}});
     assertEqualResults({expectedResult}, results);
   }
 
   // Query failure.
   plan = PlanBuilder().values({data, data}).project({"c0 / 0"}).planFragment();
-  VELOX_ASSERT_THROW(executeSingleThreaded(plan), "division by zero");
+  VELOX_ASSERT_THROW(executeSerial(plan), "division by zero");
 }
 
-TEST_F(TaskTest, singleThreadedHashJoin) {
+TEST_F(TaskTest, serialHashJoin) {
   auto left = makeRowVector(
       {"t_c0", "t_c1"},
       {
@@ -850,7 +850,7 @@ TEST_F(TaskTest, singleThreadedHashJoin) {
   });
 
   {
-    auto [task, results] = executeSingleThreaded(
+    auto [task, results] = executeSerial(
         plan,
         {{leftScanId, {leftPath->getPath()}},
          {rightScanId, {rightPath->getPath()}}});
@@ -858,7 +858,7 @@ TEST_F(TaskTest, singleThreadedHashJoin) {
   }
 }
 
-TEST_F(TaskTest, singleThreadedCrossJoin) {
+TEST_F(TaskTest, serialCrossJoin) {
   auto left = makeRowVector({"t_c0"}, {makeFlatVector<int64_t>({1, 2, 3})});
   auto leftPath = TempFilePath::create();
   writeToFile(leftPath->getPath(), {left});
@@ -888,7 +888,7 @@ TEST_F(TaskTest, singleThreadedCrossJoin) {
   });
 
   {
-    auto [task, results] = executeSingleThreaded(
+    auto [task, results] = executeSerial(
         plan,
         {{leftScanId, {leftPath->getPath()}},
          {rightScanId, {rightPath->getPath()}}});
@@ -896,7 +896,7 @@ TEST_F(TaskTest, singleThreadedCrossJoin) {
   }
 }
 
-TEST_F(TaskTest, singleThreadedExecutionExternalBlockable) {
+TEST_F(TaskTest, serialExecutionExternalBlockable) {
   exec::Operator::registerOperator(
       std::make_unique<TestExternalBlockableTranslator>());
   auto data = makeRowVector({
@@ -967,7 +967,7 @@ TEST_F(TaskTest, singleThreadedExecutionExternalBlockable) {
   EXPECT_EQ(3, results.size());
 }
 
-TEST_F(TaskTest, supportsSingleThreadedExecution) {
+TEST_F(TaskTest, supportsSerialExecution) {
   auto plan = PlanBuilder()
                   .tableScan(ROW({"c0"}, {BIGINT()}))
                   .project({"c0 % 10"})
@@ -980,9 +980,9 @@ TEST_F(TaskTest, supportsSingleThreadedExecution) {
       core::QueryCtx::create(),
       Task::ExecutionMode::kSerial);
 
-  // PartitionedOutput does not support single threaded execution, therefore the
+  // PartitionedOutput does not support serial execution, therefore the
   // task doesn't support it either.
-  ASSERT_FALSE(task->supportsSingleThreadedExecution());
+  ASSERT_FALSE(task->supportsSerialExecution());
 }
 
 TEST_F(TaskTest, updateBroadCastOutputBuffers) {
@@ -1794,7 +1794,7 @@ DEBUG_ONLY_TEST_F(TaskTest, resumeAfterTaskFinish) {
 
 DEBUG_ONLY_TEST_F(
     TaskTest,
-    singleThreadedLongRunningOperatorInTaskReclaimerAbort) {
+    serialLongRunningOperatorInTaskReclaimerAbort) {
   auto data = makeRowVector({
       makeFlatVector<int64_t>(1'000, [](auto row) { return row; }),
   });

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -1792,9 +1792,7 @@ DEBUG_ONLY_TEST_F(TaskTest, resumeAfterTaskFinish) {
   waitForAllTasksToBeDeleted();
 }
 
-DEBUG_ONLY_TEST_F(
-    TaskTest,
-    serialLongRunningOperatorInTaskReclaimerAbort) {
+DEBUG_ONLY_TEST_F(TaskTest, serialLongRunningOperatorInTaskReclaimerAbort) {
   auto data = makeRowVector({
       makeFlatVector<int64_t>(1'000, [](auto row) { return row; }),
   });

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -480,7 +480,7 @@ class TaskTest : public HiveConnectorTestBase {
       task->noMoreSplits(nodeId);
     }
 
-    VELOX_CHECK(task->supportsSerialExecution());
+    VELOX_CHECK(task->supportsSerialExecutionMode());
 
     vector_size_t numRows = 0;
     std::vector<RowVectorPtr> results;
@@ -967,7 +967,7 @@ TEST_F(TaskTest, serialExecutionExternalBlockable) {
   EXPECT_EQ(3, results.size());
 }
 
-TEST_F(TaskTest, supportsSerialExecution) {
+TEST_F(TaskTest, supportsSerialExecutionMode) {
   auto plan = PlanBuilder()
                   .tableScan(ROW({"c0"}, {BIGINT()}))
                   .project({"c0 % 10"})
@@ -980,9 +980,9 @@ TEST_F(TaskTest, supportsSerialExecution) {
       core::QueryCtx::create(),
       Task::ExecutionMode::kSerial);
 
-  // PartitionedOutput does not support serial execution, therefore the
+  // PartitionedOutput does not support serial execution mode, therefore the
   // task doesn't support it either.
-  ASSERT_FALSE(task->supportsSerialExecution());
+  ASSERT_FALSE(task->supportsSerialExecutionMode());
 }
 
 TEST_F(TaskTest, updateBroadCastOutputBuffers) {
@@ -1286,7 +1286,7 @@ DEBUG_ONLY_TEST_F(TaskTest, inconsistentExecutionMode) {
 
   {
     // Scenario 2: Serial execution starts first then kicks in Parallel
-    // execution.
+    // execution mode.
 
     auto data = makeRowVector({
         makeFlatVector<int64_t>(1'000, [](auto row) { return row; }),

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -62,13 +62,13 @@ AssertQueryBuilder& AssertQueryBuilder::destination(int32_t destination) {
   return *this;
 }
 
-AssertQueryBuilder& AssertQueryBuilder::singleThreaded(bool singleThreaded) {
-  if (singleThreaded) {
-    params_.singleThreaded = true;
+AssertQueryBuilder& AssertQueryBuilder::serial(bool serial) {
+  if (serial) {
+    params_.serial = true;
     executor_ = nullptr;
     return *this;
   }
-  params_.singleThreaded = false;
+  params_.serial = false;
   executor_ = newExecutor();
   return *this;
 }

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -64,11 +64,11 @@ AssertQueryBuilder& AssertQueryBuilder::destination(int32_t destination) {
 
 AssertQueryBuilder& AssertQueryBuilder::serialExecution(bool serial) {
   if (serial) {
-    params_.serialExecutionMode = true;
+    params_.serialExecution = true;
     executor_ = nullptr;
     return *this;
   }
-  params_.serialExecutionMode = false;
+  params_.serialExecution = false;
   executor_ = newExecutor();
   return *this;
 }

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -62,13 +62,13 @@ AssertQueryBuilder& AssertQueryBuilder::destination(int32_t destination) {
   return *this;
 }
 
-AssertQueryBuilder& AssertQueryBuilder::serial(bool serial) {
+AssertQueryBuilder& AssertQueryBuilder::serialExecution(bool serial) {
   if (serial) {
-    params_.serial = true;
+    params_.serialExecutionMode = true;
     executor_ = nullptr;
     return *this;
   }
-  params_.serial = false;
+  params_.serialExecutionMode = false;
   executor_ = newExecutor();
   return *this;
 }

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -39,9 +39,9 @@ class AssertQueryBuilder {
   /// Default is 0.
   AssertQueryBuilder& destination(int32_t destination);
 
-  /// Use single-threaded execution to execute the Velox plan.
+  /// Use serial execution to execute the Velox plan.
   /// Default is false.
-  AssertQueryBuilder& singleThreaded(bool singleThreaded);
+  AssertQueryBuilder& serial(bool serial);
 
   /// Set configuration property. May be called multiple times to set multiple
   /// properties.

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -39,9 +39,9 @@ class AssertQueryBuilder {
   /// Default is 0.
   AssertQueryBuilder& destination(int32_t destination);
 
-  /// Use serial execution to execute the Velox plan.
+  /// Use serial execution mode to execute the Velox plan.
   /// Default is false.
-  AssertQueryBuilder& serial(bool serial);
+  AssertQueryBuilder& serialExecution(bool serial);
 
   /// Set configuration property. May be called multiple times to set multiple
   /// properties.

--- a/velox/exec/tests/utils/Cursor.cpp
+++ b/velox/exec/tests/utils/Cursor.cpp
@@ -214,7 +214,7 @@ class MultiThreadedTaskCursor : public TaskCursorBase {
         maxDrivers_{params.maxDrivers},
         numConcurrentSplitGroups_{params.numConcurrentSplitGroups},
         numSplitGroups_{params.numSplitGroups} {
-    VELOX_CHECK(!params.serialExecutionMode)
+    VELOX_CHECK(!params.serialExecution)
     VELOX_CHECK(
         queryCtx_->isExecutorSupplied(),
         "Executor should be set in parallel task cursor")
@@ -322,7 +322,7 @@ class SingleThreadedTaskCursor : public TaskCursorBase {
  public:
   explicit SingleThreadedTaskCursor(const CursorParameters& params)
       : TaskCursorBase(params, nullptr) {
-    VELOX_CHECK(params.serialExecutionMode)
+    VELOX_CHECK(params.serialExecution)
     VELOX_CHECK(
         !queryCtx_->isExecutorSupplied(),
         "Executor should not be set in serial task cursor")
@@ -402,7 +402,7 @@ class SingleThreadedTaskCursor : public TaskCursorBase {
 };
 
 std::unique_ptr<TaskCursor> TaskCursor::create(const CursorParameters& params) {
-  if (params.serialExecutionMode) {
+  if (params.serialExecution) {
     return std::make_unique<SingleThreadedTaskCursor>(params);
   }
   return std::make_unique<MultiThreadedTaskCursor>(params);

--- a/velox/exec/tests/utils/Cursor.h
+++ b/velox/exec/tests/utils/Cursor.h
@@ -64,7 +64,7 @@ struct CursorParameters {
   bool copyResult = true;
 
   /// If true, use serial execution mode. Use parallel execution mode otherwise.
-  bool serialExecutionMode = false;
+  bool serialExecution = false;
 
   /// If both 'queryConfigs' and 'queryCtx' are specified, the configurations in
   /// 'queryCtx' will be overridden by 'queryConfig'.

--- a/velox/exec/tests/utils/Cursor.h
+++ b/velox/exec/tests/utils/Cursor.h
@@ -63,8 +63,8 @@ struct CursorParameters {
 
   bool copyResult = true;
 
-  /// If true, use single threaded execution.
-  bool singleThreaded = false;
+  /// If true, use serial execution. Use parallel execution otherwise.
+  bool serial = false;
 
   /// If both 'queryConfigs' and 'queryCtx' are specified, the configurations in
   /// 'queryCtx' will be overridden by 'queryConfig'.

--- a/velox/exec/tests/utils/Cursor.h
+++ b/velox/exec/tests/utils/Cursor.h
@@ -63,8 +63,8 @@ struct CursorParameters {
 
   bool copyResult = true;
 
-  /// If true, use serial execution. Use parallel execution otherwise.
-  bool serial = false;
+  /// If true, use serial execution mode. Use parallel execution mode otherwise.
+  bool serialExecutionMode = false;
 
   /// If both 'queryConfigs' and 'queryCtx' are specified, the configurations in
   /// 'queryCtx' will be overridden by 'queryConfig'.


### PR DESCRIPTION
A code cleanup for task execution mode concepts, to uniformly use `serial` / `parallel`. Remove usages of `single-threaded` / `multi-threaded`.

Fixes https://github.com/facebookincubator/velox/issues/10745