### PR TITLE
Add write IO metrics and print physical written bytes in PlanNodeStats#toString

### DIFF
--- a/velox/common/io/IoStatistics.cpp
+++ b/velox/common/io/IoStatistics.cpp
@@ -46,8 +46,8 @@ uint64_t IoStatistics::totalScanTime() const {
   return totalScanTime_.load(std::memory_order_relaxed);
 }
 
-uint64_t IoStatistics::writeIOTime() const {
-  return writeIOTime_.load(std::memory_order_relaxed);
+uint64_t IoStatistics::writeIOTimeUs() const {
+  return writeIOTimeUs_.load(std::memory_order_relaxed);
 }
 
 uint64_t IoStatistics::incRawBytesRead(int64_t v) {
@@ -74,8 +74,8 @@ uint64_t IoStatistics::incTotalScanTime(int64_t v) {
   return totalScanTime_.fetch_add(v, std::memory_order_relaxed);
 }
 
-uint64_t IoStatistics::incWriteIOTime(int64_t v) {
-  return writeIOTime_.fetch_add(v, std::memory_order_relaxed);
+uint64_t IoStatistics::incWriteIOTimeUs(int64_t v) {
+  return writeIOTimeUs_.fetch_add(v, std::memory_order_relaxed);
 }
 
 void IoStatistics::incOperationCounters(

--- a/velox/common/io/IoStatistics.cpp
+++ b/velox/common/io/IoStatistics.cpp
@@ -46,6 +46,10 @@ uint64_t IoStatistics::totalScanTime() const {
   return totalScanTime_.load(std::memory_order_relaxed);
 }
 
+uint64_t IoStatistics::writeIOTime() const {
+  return writeIOTime_.load(std::memory_order_relaxed);
+}
+
 uint64_t IoStatistics::incRawBytesRead(int64_t v) {
   return rawBytesRead_.fetch_add(v, std::memory_order_relaxed);
 }
@@ -68,6 +72,10 @@ uint64_t IoStatistics::incRawOverreadBytes(int64_t v) {
 
 uint64_t IoStatistics::incTotalScanTime(int64_t v) {
   return totalScanTime_.fetch_add(v, std::memory_order_relaxed);
+}
+
+uint64_t IoStatistics::incWriteIOTime(int64_t v) {
+  return writeIOTime_.fetch_add(v, std::memory_order_relaxed);
 }
 
 void IoStatistics::incOperationCounters(

--- a/velox/common/io/IoStatistics.h
+++ b/velox/common/io/IoStatistics.h
@@ -97,7 +97,7 @@ class IoStatistics {
   uint64_t inputBatchSize() const;
   uint64_t outputBatchSize() const;
   uint64_t totalScanTime() const;
-  uint64_t writeIOTime() const;
+  uint64_t writeIOTimeUs() const;
 
   uint64_t incRawBytesRead(int64_t);
   uint64_t incRawOverreadBytes(int64_t);
@@ -105,7 +105,7 @@ class IoStatistics {
   uint64_t incInputBatchSize(int64_t);
   uint64_t incOutputBatchSize(int64_t);
   uint64_t incTotalScanTime(int64_t);
-  uint64_t incWriteIOTime(int64_t);
+  uint64_t incWriteIOTimeUs(int64_t);
 
   IoCounter& prefetch() {
     return prefetch_;
@@ -152,7 +152,7 @@ class IoStatistics {
   std::atomic<uint64_t> outputBatchSize_{0};
   std::atomic<uint64_t> rawOverreadBytes_{0};
   std::atomic<uint64_t> totalScanTime_{0};
-  std::atomic<uint64_t> writeIOTime_{0};
+  std::atomic<uint64_t> writeIOTimeUs_{0};
 
   // Planned read from storage or SSD.
   IoCounter prefetch_;

--- a/velox/common/io/IoStatistics.h
+++ b/velox/common/io/IoStatistics.h
@@ -97,6 +97,7 @@ class IoStatistics {
   uint64_t inputBatchSize() const;
   uint64_t outputBatchSize() const;
   uint64_t totalScanTime() const;
+  uint64_t writeIOTime() const;
 
   uint64_t incRawBytesRead(int64_t);
   uint64_t incRawOverreadBytes(int64_t);
@@ -104,6 +105,7 @@ class IoStatistics {
   uint64_t incInputBatchSize(int64_t);
   uint64_t incOutputBatchSize(int64_t);
   uint64_t incTotalScanTime(int64_t);
+  uint64_t incWriteIOTime(int64_t);
 
   IoCounter& prefetch() {
     return prefetch_;
@@ -150,6 +152,7 @@ class IoStatistics {
   std::atomic<uint64_t> outputBatchSize_{0};
   std::atomic<uint64_t> rawOverreadBytes_{0};
   std::atomic<uint64_t> totalScanTime_{0};
+  std::atomic<uint64_t> writeIOTime_{0};
 
   // Planned read from storage or SSD.
   IoCounter prefetch_;

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -151,6 +151,7 @@ class DataSink {
   struct Stats {
     uint64_t numWrittenBytes{0};
     uint32_t numWrittenFiles{0};
+    uint64_t writeIOTimeMicro{0};
     common::SpillStats spillStats;
 
     bool empty() const;

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -151,7 +151,7 @@ class DataSink {
   struct Stats {
     uint64_t numWrittenBytes{0};
     uint32_t numWrittenFiles{0};
-    uint64_t writeIOTimeMicro{0};
+    uint64_t writeIOTimeUs{0};
     common::SpillStats spillStats;
 
     bool empty() const;

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -511,10 +511,13 @@ DataSink::Stats HiveDataSink::stats() const {
   }
 
   int64_t numWrittenBytes{0};
+  int64_t writeIOTimeMicro{0};
   for (const auto& ioStats : ioStats_) {
     numWrittenBytes += ioStats->rawBytesWritten();
+    writeIOTimeMicro += ioStats->writeIOTime();
   }
   stats.numWrittenBytes = numWrittenBytes;
+  stats.writeIOTimeMicro = writeIOTimeMicro;
 
   if (state_ != State::kClosed) {
     return stats;

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -511,13 +511,13 @@ DataSink::Stats HiveDataSink::stats() const {
   }
 
   int64_t numWrittenBytes{0};
-  int64_t writeIOTimeMicro{0};
+  int64_t writeIOTimeUs{0};
   for (const auto& ioStats : ioStats_) {
     numWrittenBytes += ioStats->rawBytesWritten();
-    writeIOTimeMicro += ioStats->writeIOTime();
+    writeIOTimeUs += ioStats->writeIOTimeUs();
   }
   stats.numWrittenBytes = numWrittenBytes;
-  stats.writeIOTimeMicro = writeIOTimeMicro;
+  stats.writeIOTimeUs = writeIOTimeUs;
 
   if (state_ != State::kClosed) {
     return stats;

--- a/velox/dwio/common/FileSink.cpp
+++ b/velox/dwio/common/FileSink.cpp
@@ -67,14 +67,19 @@ void FileSink::writeImpl(
     const std::function<uint64_t(const DataBuffer<char>&)>& callback) {
   DWIO_ENSURE(!isClosed(), "Cannot write to closed sink.");
   const uint64_t oldSize = size_;
-  for (auto& buf : buffers) {
-    // NOTE: we need to update 'size_' after each 'callback' invocation as some
-    // file sink implementation like MemorySink depends on the updated 'size_'
-    // for new write.
-    size_ += callback(buf);
+  uint64_t usec{0};
+  {
+    MicrosecondTimer timer(&usec);
+    for (auto& buf : buffers) {
+      // NOTE: we need to update 'size_' after each 'callback' invocation as
+      // some file sink implementation like MemorySink depends on the updated
+      // 'size_' for new write.
+      size_ += callback(buf);
+    }
   }
   if (stats_ != nullptr) {
     stats_->incRawBytesWritten(size_ - oldSize);
+    stats_->incWriteIOTime(usec);
   }
   // Writing buffer is treated as transferring ownership. So clearing the
   // buffers after all buffers are written.

--- a/velox/dwio/common/FileSink.cpp
+++ b/velox/dwio/common/FileSink.cpp
@@ -67,9 +67,9 @@ void FileSink::writeImpl(
     const std::function<uint64_t(const DataBuffer<char>&)>& callback) {
   DWIO_ENSURE(!isClosed(), "Cannot write to closed sink.");
   const uint64_t oldSize = size_;
-  uint64_t usec{0};
+  uint64_t writeTimeUs{0};
   {
-    MicrosecondTimer timer(&usec);
+    MicrosecondTimer timer(&writeTimeUs);
     for (auto& buf : buffers) {
       // NOTE: we need to update 'size_' after each 'callback' invocation as
       // some file sink implementation like MemorySink depends on the updated
@@ -79,7 +79,7 @@ void FileSink::writeImpl(
   }
   if (stats_ != nullptr) {
     stats_->incRawBytesWritten(size_ - oldSize);
-    stats_->incWriteIOTime(usec);
+    stats_->incWriteIOTimeUs(writeTimeUs);
   }
   // Writing buffer is treated as transferring ownership. So clearing the
   // buffers after all buffers are written.

--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -97,7 +97,7 @@ std::string PlanNodeStats::toString(bool includeInputStats) const {
   out << "Output: " << outputRows << " rows (" << succinctBytes(outputBytes)
       << ", " << outputVectors << " batches)";
   if (physicalWrittenBytes > 0) {
-    out << ", Physical Written output: " << succinctBytes(physicalWrittenBytes);
+    out << ", Physical written output: " << succinctBytes(physicalWrittenBytes);
   }
   out << ", Cpu time: " << succinctNanos(cpuWallTiming.cpuNanos)
       << ", Blocked wall time: " << succinctNanos(blockedWallNanos)

--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -95,8 +95,11 @@ std::string PlanNodeStats::toString(bool includeInputStats) const {
     }
   }
   out << "Output: " << outputRows << " rows (" << succinctBytes(outputBytes)
-      << ", " << outputVectors << " batches)"
-      << ", Cpu time: " << succinctNanos(cpuWallTiming.cpuNanos)
+      << ", " << outputVectors << " batches)";
+  if (physicalWrittenBytes > 0) {
+    out << ", Physical Written output: " << succinctBytes(physicalWrittenBytes);
+  }
+  out << ", Cpu time: " << succinctNanos(cpuWallTiming.cpuNanos)
       << ", Blocked wall time: " << succinctNanos(blockedWallNanos)
       << ", Peak memory: " << succinctBytes(peakMemoryBytes)
       << ", Memory allocations: " << numMemoryAllocations;

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -253,6 +253,10 @@ void TableWriter::updateStats(const connector::DataSink::Stats& stats) {
     }
     lockedStats->addRuntimeStat(
         "numWrittenFiles", RuntimeCounter(stats.numWrittenFiles));
+    lockedStats->addRuntimeStat(
+        "writeIOTime",
+        RuntimeCounter(
+            stats.writeIOTimeMicro * 1000, RuntimeCounter::Unit::kNanos));
   }
   if (!stats.spillStats.empty()) {
     *spillStats_.wlock() += stats.spillStats;

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -256,7 +256,7 @@ void TableWriter::updateStats(const connector::DataSink::Stats& stats) {
     lockedStats->addRuntimeStat(
         "writeIOTime",
         RuntimeCounter(
-            stats.writeIOTimeMicro * 1000, RuntimeCounter::Unit::kNanos));
+            stats.writeIOTimeUs * 1000, RuntimeCounter::Unit::kNanos));
   }
   if (!stats.spillStats.empty()) {
     *spillStats_.wlock() += stats.spillStats;

--- a/velox/exec/tests/PrintPlanWithStatsTest.cpp
+++ b/velox/exec/tests/PrintPlanWithStatsTest.cpp
@@ -51,8 +51,7 @@ void compareOutputs(
     while (!RE2::FullMatch(line, expectedLine.line)) {
       potentialLines.push_back(expectedLine.line);
       if (!expectedLine.optional) {
-        ASSERT_FALSE(true) << "Output did not match "
-                           << "Source:" << testName
+        ASSERT_FALSE(true) << "Output did not match " << "Source:" << testName
                            << ", Line number:" << lineCount
                            << ", Line: " << line << ", Expected Line one of: "
                            << folly::join(",", potentialLines);

--- a/velox/exec/tests/PrintPlanWithStatsTest.cpp
+++ b/velox/exec/tests/PrintPlanWithStatsTest.cpp
@@ -51,7 +51,8 @@ void compareOutputs(
     while (!RE2::FullMatch(line, expectedLine.line)) {
       potentialLines.push_back(expectedLine.line);
       if (!expectedLine.optional) {
-        ASSERT_FALSE(true) << "Output did not match " << "Source:" << testName
+        ASSERT_FALSE(true) << "Output did not match "
+                           << "Source:" << testName
                            << ", Line number:" << lineCount
                            << ", Line: " << line << ", Expected Line one of: "
                            << folly::join(",", potentialLines);
@@ -321,16 +322,15 @@ TEST_F(PrintPlanWithStatsTest, tableWriterWithTableScan) {
   writeToFile(filePath->getPath(), vectors);
   const auto writeDir = TempDirectoryPath::create();
 
-  auto writePlan =
-      PlanBuilder()
-          .tableScan(rowType)
-          .tableWrite(writeDir->getPath())
-          .planNode();
+  auto writePlan = PlanBuilder()
+                       .tableScan(rowType)
+                       .tableWrite(writeDir->getPath())
+                       .planNode();
 
   std::shared_ptr<exec::Task> task;
-      AssertQueryBuilder(writePlan)
-          .splits(makeHiveConnectorSplits({filePath}))
-          .copyResults(pool(), task);
+  AssertQueryBuilder(writePlan)
+      .splits(makeHiveConnectorSplits({filePath}))
+      .copyResults(pool(), task);
   ensureTaskCompletion(task.get());
   compareOutputs(
       ::testing::UnitTest::GetInstance()->current_test_info()->name(),

--- a/velox/exec/tests/PrintPlanWithStatsTest.cpp
+++ b/velox/exec/tests/PrintPlanWithStatsTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
 
 #include <gtest/gtest.h>
 #include <re2/re2.h>
@@ -308,4 +309,77 @@ TEST_F(PrintPlanWithStatsTest, partialAggregateWithTableScan) {
          {"        totalRemainingFilterTime\\s+sum: .+, count: .+, min: .+, max: .+"},
          {"        totalScanTime    [ ]* sum: .+, count: .+, min: .+, max: .+"}});
   }
+}
+
+TEST_F(PrintPlanWithStatsTest, tableWriterWithTableScan) {
+  RowTypePtr rowType{
+      ROW({"c0", "c1", "c2", "c3", "c4", "c5"},
+          {BIGINT(), INTEGER(), SMALLINT(), REAL(), DOUBLE(), VARCHAR()})};
+  auto vectors = makeVectors(rowType, 10, 10);
+
+  const auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), vectors);
+  const auto writeDir = TempDirectoryPath::create();
+
+  auto writePlan =
+      PlanBuilder()
+          .tableScan(rowType)
+          .tableWrite(writeDir->getPath())
+          .planNode();
+
+  std::shared_ptr<exec::Task> task;
+      AssertQueryBuilder(writePlan)
+          .splits(makeHiveConnectorSplits({filePath}))
+          .copyResults(pool(), task);
+  ensureTaskCompletion(task.get());
+  compareOutputs(
+      ::testing::UnitTest::GetInstance()->current_test_info()->name(),
+      printPlanWithStats(*writePlan, task->taskStats()),
+      {{R"(-- TableWrite\[1\]\[.+InsertTableHandle .+)"},
+       {"   Output: .+, Physical written output: .+, Cpu time: .+, Blocked wall time: .+, Peak memory: .+, Memory allocations: .+, Threads: 1"},
+       {R"(  -- TableScan\[0\]\[table: hive_table\] -> c0:BIGINT, c1:INTEGER, c2:SMALLINT, c3:REAL, c4:DOUBLE, c5:VARCHAR)"},
+       {R"(     Input: 100 rows \(.+\), Output: 100 rows \(.+\), Cpu time: .+, Blocked wall time: .+, Peak memory: .+, Memory allocations: .+, Threads: 1, Splits: 1)"}});
+
+  compareOutputs(
+      ::testing::UnitTest::GetInstance()->current_test_info()->name(),
+      printPlanWithStats(*writePlan, task->taskStats(), true),
+      {{R"(-- TableWrite\[1\]\[.+InsertTableHandle .+)"},
+       {"   Output: .+, Physical written output: .+, Cpu time: .+, Blocked wall time: .+, Peak memory: .+, Memory allocations: .+, Threads: 1"},
+       {"      dataSourceLazyCpuNanos\\s+sum: .+, count: .+, min: .+, max: .+"},
+       {"      dataSourceLazyWallNanos\\s+sum: .+, count: .+, min: .+, max: .+"},
+       {"      numWrittenFiles\\s+sum: .+, count: 1, min: .+, max: .+"},
+       {"      runningAddInputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
+       {"      runningFinishWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
+       {"      runningGetOutputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
+       {"      stripeSize\\s+sum: .+, count: 1, min: .+, max: .+"},
+       {"      writeIOTime\\s+sum: .+, count: 1, min: .+, max: .+"},
+       {R"(  -- TableScan\[0\]\[table: hive_table\] -> c0:BIGINT, c1:INTEGER, c2:SMALLINT, c3:REAL, c4:DOUBLE, c5:VARCHAR)"},
+       {R"(     Input: 100 rows \(.+\), Output: 100 rows \(.+\), Cpu time: .+, Blocked wall time: .+, Peak memory: .+, Memory allocations: .+, Threads: 1, Splits: 1)"},
+       {"        dataSourceAddSplitWallNanos[ ]* sum: .+, count: 1, min: .+, max: .+"},
+       {"        dataSourceReadWallNanos[ ]* sum: .+, count: 1, min: .+, max: .+"},
+       {"        flattenStringDictionaryValues [ ]* sum: 0, count: 1, min: 0, max: 0"},
+       {"        ioWaitWallNanos      [ ]* sum: .+, count: .+ min: .+, max: .+"},
+       {"        localReadBytes   [ ]* sum: 0B, count: 1, min: 0B, max: 0B"},
+       {"        maxSingleIoWaitWallNanos[ ]*sum: .+, count: 1, min: .+, max: .+"},
+       {"        numLocalRead     [ ]* sum: 0, count: 1, min: 0, max: 0"},
+       {"        numPrefetch      [ ]* sum: .+, count: .+, min: .+, max: .+"},
+       {"        numRamRead       [ ]* sum: 7, count: 1, min: 7, max: 7"},
+       {"        numStorageRead   [ ]* sum: .+, count: 1, min: .+, max: .+"},
+       {"        overreadBytes[ ]* sum: 0B, count: 1, min: 0B, max: 0B"},
+
+       {"        prefetchBytes    [ ]* sum: .+, count: 1, min: .+, max: .+"},
+       {"        preloadedSplits[ ]+sum: .+, count: .+, min: .+, max: .+",
+        true},
+       {"        ramReadBytes     [ ]* sum: .+, count: 1, min: .+, max: .+"},
+       {"        readyPreloadedSplits[ ]+sum: .+, count: .+, min: .+, max: .+",
+        true},
+       {"        runningAddInputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
+       {"        runningFinishWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
+       {"        runningGetOutputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
+       {"        skippedSplitBytes[ ]* sum: 0B, count: 1, min: 0B, max: 0B"},
+       {"        skippedSplits    [ ]* sum: 0, count: 1, min: 0, max: 0"},
+       {"        skippedStrides   [ ]* sum: 0, count: 1, min: 0, max: 0"},
+       {"        storageReadBytes [ ]* sum: .+, count: 1, min: .+, max: .+"},
+       {"        totalRemainingFilterTime\\s+sum: .+, count: .+, min: .+, max: .+"},
+       {"        totalScanTime    [ ]* sum: .+, count: .+, min: .+, max: .+"}});
 }

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -2360,6 +2360,8 @@ TEST_P(UnpartitionedTableWriterTest, runtimeStatsCheck) {
         stats[1].runtimeStats["stripeSize"].count, testData.expectedNumStripes);
     ASSERT_EQ(stats[1].runtimeStats["numWrittenFiles"].sum, 1);
     ASSERT_EQ(stats[1].runtimeStats["numWrittenFiles"].count, 1);
+    ASSERT_EQ(stats[1].runtimeStats["writeIOTime"].sum, 1);
+    ASSERT_EQ(stats[1].runtimeStats["writeIOTime"].count, 1);
   }
 }
 
@@ -3132,6 +3134,9 @@ TEST_P(AllTableWriterTest, tableWriterStats) {
           ->customStats.at("numWrittenFiles")
           .sum,
       numWrittenFiles);
+  ASSERT_GE(
+      stats.operatorStats.at("TableWrite")->customStats.at("writeIOTime").sum,
+      0);
 }
 
 DEBUG_ONLY_TEST_P(

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -2360,7 +2360,7 @@ TEST_P(UnpartitionedTableWriterTest, runtimeStatsCheck) {
         stats[1].runtimeStats["stripeSize"].count, testData.expectedNumStripes);
     ASSERT_EQ(stats[1].runtimeStats["numWrittenFiles"].sum, 1);
     ASSERT_EQ(stats[1].runtimeStats["numWrittenFiles"].count, 1);
-    ASSERT_EQ(stats[1].runtimeStats["writeIOTime"].sum, 1);
+    ASSERT_GE(stats[1].runtimeStats["writeIOTime"].sum, 0);
     ASSERT_EQ(stats[1].runtimeStats["writeIOTime"].count, 1);
   }
 }


### PR DESCRIPTION
Summary:
Count write IO metrics when invoke WriteFile#append, and print physical written bytes when invoke printPlanWithStats.


Fixes: #10794