### PR TITLE
Fix build errors in Presto due to misconfigured generated proto file paths

### DIFF
--- a/velox/functions/sparksql/fuzzer/CMakeLists.txt
+++ b/velox/functions/sparksql/fuzzer/CMakeLists.txt
@@ -68,7 +68,7 @@ endforeach()
 # Generate Spark connect hearders and sources.
 add_custom_command(
   OUTPUT ${PROTO_OUTPUT_FILES}
-  COMMAND protobuf::protoc ${PROTO_PATH_ARGS} --cpp_out ${CMAKE_BINARY_DIR}
+  COMMAND protobuf::protoc ${PROTO_PATH_ARGS} --cpp_out ${PROJECT_BINARY_DIR}
           ${PROTO_FILES_FULL}
   DEPENDS protobuf::protoc
   COMMENT "Running PROTO compiler"
@@ -78,7 +78,7 @@ add_custom_command(
 add_custom_command(
   OUTPUT ${GRPC_OUTPUT_FILES}
   COMMAND
-    protobuf::protoc ${PROTO_PATH_ARGS} --grpc_out=${CMAKE_BINARY_DIR}
+    protobuf::protoc ${PROTO_PATH_ARGS} --grpc_out=${PROJECT_BINARY_DIR}
     --plugin=protoc-gen-grpc=$<TARGET_FILE:gRPC::grpc_cpp_plugin>
     ${PROTO_FILES_FULL}
   DEPENDS protobuf::protoc


### PR DESCRIPTION
A follow-up fix for #10357

In Presto build, the following two CMake arguments for `velox` are different, although both are the same in the `velox` standalone build:
* `CMAKE_BINARY_DIR`: presto/presto-native-execution/cmake-build-debug
* `PROJECT_BINARY_DIR`: presto/presto-native-execution/cmake-build-debug/velox

```sh
Building CXX object velox/velox/functions/sparksql/fuzzer/CMakeFiles/velox_spark_query_runner.dir/__/__/__/__/spark/connect/catalog.pb.cc.o
FAILED: 
clang++: error: no such file or directory: 'presto/presto-native-execution/cmake-build-debug/velox/spark/connect/catalog.pb.cc'
clang++: error: no input files

$ ls presto/presto-native-execution/cmake-build-debug/spark/connect/catalog.*
catalog.grpc.pb.cc  catalog.grpc.pb.h  catalog.pb.cc  catalog.pb.h 
```

