### PR TITLE
fix: Fix register simple function SignatureMap overwrite

### DIFF
--- a/velox/core/SimpleFunctionMetadata.h
+++ b/velox/core/SimpleFunctionMetadata.h
@@ -498,6 +498,11 @@ class SimpleFunctionMetadata : public ISimpleFunctionMetadata {
 
   bool physicalSignatureEquals(
       const ISimpleFunctionMetadata& other) const override {
+    // Decimal function registered as (short, short) -> short and
+    // (short, short) -> long.
+    if (!resultPhysicalType_->kindEquals(other.resultPhysicalType())) {
+      return false;
+    }
     if (argPhysicalTypes_.size() != other.argPhysicalTypes().size()) {
       return false;
     }
@@ -514,7 +519,7 @@ class SimpleFunctionMetadata : public ISimpleFunctionMetadata {
   std::string helpMessage(const std::string& name) const final {
     // return fmt::format("{}({})", name, signature_->toString());
     std::string s{name};
-    s.append("(");
+    s.append("\nSignature argument types:\n");
     bool first = true;
     for (auto& arg : signature_->argumentTypes()) {
       if (!first) {
@@ -528,7 +533,22 @@ class SimpleFunctionMetadata : public ISimpleFunctionMetadata {
       s.append("...");
     }
 
-    s.append(")");
+    first = true;
+    s.append("\nArgument physical types:\n");
+    for (const auto& arg : argPhysicalTypes_) {
+      if (!first) {
+        s.append(", ");
+      }
+      first = false;
+      s.append(arg->toString());
+    }
+    if (isVariadic()) {
+      s.append("...");
+    }
+
+    s.append("\nResult physical types:\n" + resultPhysicalType_->toString());
+    s.append("\nPriority: " + std::to_string(priority_));
+    s.append("\nDefaultNullBehavior_: " + std::to_string(defaultNullBehavior_));
     return s;
   }
 

--- a/velox/core/SimpleFunctionMetadata.h
+++ b/velox/core/SimpleFunctionMetadata.h
@@ -498,10 +498,6 @@ class SimpleFunctionMetadata : public ISimpleFunctionMetadata {
 
   bool physicalSignatureEquals(
       const ISimpleFunctionMetadata& other) const override {
-    if (!resultPhysicalType_->kindEquals(other.resultPhysicalType())) {
-      return false;
-    }
-
     if (argPhysicalTypes_.size() != other.argPhysicalTypes().size()) {
       return false;
     }

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -515,12 +515,9 @@ template <>
 struct hash<std::vector<facebook::velox::exec::TypeSignature>> {
   using argument_type = std::vector<facebook::velox::exec::TypeSignature>;
   std::size_t operator()(const argument_type& key) const noexcept {
-    auto typeSignatureHasher =
-        std::hash<facebook::velox::exec::TypeSignature>{};
-
     size_t val = 0;
     for (const auto& arg : key) {
-      val = val * 31 + typeSignatureHasher(arg);
+      val = val * 31 + std::hash<std::string>{}(arg.baseName());
     }
     return val;
   }

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -511,4 +511,19 @@ struct hash<facebook::velox::exec::FunctionSignature> {
   }
 };
 
+template <>
+struct hash<std::vector<facebook::velox::exec::TypeSignature>> {
+  using argument_type = std::vector<facebook::velox::exec::TypeSignature>;
+  std::size_t operator()(const argument_type& key) const noexcept {
+    auto typeSignatureHasher =
+        std::hash<facebook::velox::exec::TypeSignature>{};
+
+    size_t val = 0;
+    for (const auto& arg : key) {
+      val = val * 31 + typeSignatureHasher(arg);
+    }
+    return val;
+  }
+};
+
 } // namespace std

--- a/velox/expression/SimpleFunctionRegistry.cpp
+++ b/velox/expression/SimpleFunctionRegistry.cpp
@@ -60,6 +60,9 @@ bool SimpleFunctionRegistry::registerFunctionInternal(
           metadata->defaultNullBehavior(), otherMetadata.defaultNullBehavior());
       VELOX_USER_CHECK_EQ(
           metadata->isDeterministic(), otherMetadata.isDeterministic());
+      VELOX_USER_CHECK_EQ(
+          metadata->signature()->variableArity(),
+          otherMetadata.signature()->variableArity());
     }
 
     functions.emplace_back(

--- a/velox/expression/SimpleFunctionRegistry.h
+++ b/velox/expression/SimpleFunctionRegistry.h
@@ -66,6 +66,8 @@ struct SignatureHash {
 /// try to register map<long, long>, we will get it from SignatureMap, but its
 /// physical type is not equal, so not overwrite map<int, long>, both map<int,
 /// long> and map<long, long> exist in FunctionEntry.
+/// Function with Variadic<int64_t> or int64_t should not exist at the same
+/// time, we cannot distinguish which to call for single input.
 struct SignatureCmp {
   bool operator()(const FunctionSignature& l, const FunctionSignature& r)
       const {

--- a/velox/expression/tests/ArrayWriterTest.cpp
+++ b/velox/expression/tests/ArrayWriterTest.cpp
@@ -1084,10 +1084,10 @@ struct ThrowsErrorsFunc {
 
 TEST_F(ArrayWriterTest, errorHandlingE2E) {
   registerFunction<ThrowsErrorsFunc, Array<Array<int64_t>>, int64_t>(
-      {"throws_errors"});
+      {"throws_errors_array"});
 
   auto result = evaluate(
-      "try(throws_errors(c0))",
+      "try(throws_errors_array(c0))",
       makeRowVector({makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6})}));
 
   assertEqualVectors(

--- a/velox/expression/tests/MapWriterTest.cpp
+++ b/velox/expression/tests/MapWriterTest.cpp
@@ -781,10 +781,10 @@ TEST_F(MapWriterTest, errorHandlingE2E) {
   registerFunction<
       ThrowsErrorsFunc,
       Map<int64_t, Map<Varchar, float>>,
-      int64_t>({"throws_errors"});
+      int64_t>({"throws_errors_map"});
 
   auto result = evaluate(
-      "try(throws_errors(c0))",
+      "try(throws_errors_map(c0))",
       makeRowVector({makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6})}));
 
   auto innerKeys = makeFlatVector<StringView>(

--- a/velox/expression/tests/RowWriterTest.cpp
+++ b/velox/expression/tests/RowWriterTest.cpp
@@ -563,10 +563,10 @@ TEST_F(RowWriterTest, errorHandlingE2E) {
   registerFunction<
       ThrowsErrorsFunc,
       Row<int64_t, Varchar, Array<float>, Map<int32_t, double>>,
-      int64_t>({"throws_errors"});
+      int64_t>({"throws_errors_row"});
 
   auto result = evaluate(
-      "try(throws_errors(c0))",
+      "try(throws_errors_row(c0))",
       makeRowVector({makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6})}));
 
   auto field1 = makeFlatVector<int64_t>({1, 0, 3, 0, 5, 0});

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -1071,7 +1071,10 @@ TEST_F(SimpleFunctionTest, variadicReuseNoArgs) {
 }
 
 TEST_F(SimpleFunctionTest, variadicReuseNoArgsDifferentType) {
-  std::string functionName = "function_with_variadic";
+  // Change the function name because we register same name function only diffs
+  // with result type in other tests before, 2 function entry will exist.
+  // Randomly get the entry, if get result type is not int32_t, will core dump.
+  std::string functionName = "function_with_variadic_different_type";
   registerFunction<FunctionWithVariadic, int32_t, Variadic<int64_t>>(
       {functionName});
 


### PR DESCRIPTION
Before this PR, the `SignatureMap` key is `FunctionSignature` and will compare all the fields of it. But fields `std::unordered_map<std::string, SignatureVariable> variables`  and `TypeSignature returnType`  is different, causing registering functions only differs with result type.  It should only consider name and input types and not allow registering functions that differ only in result type. But for decimal registration, (short, short) -> short, (short, short) -> long exists, so I only relax the result type computation logic, allow the result type diffs. 

This PR introduces `SignatureHash` and `SignatureCmp` to `SignatureMap`, which only consider the argument type base name, and check metadata's physical argument type and physical result type by `kindEquals` which will check the child data type to determine whether to overwrite.

Resolves: https://github.com/facebookincubator/velox/issues/10602