### PR TITLE
Remove re2::StringPiece.as_string usage in RegexpReplace

### DIFF
--- a/velox/functions/prestosql/RegexpReplace.h
+++ b/velox/functions/prestosql/RegexpReplace.h
@@ -74,16 +74,17 @@ FOLLY_ALWAYS_INLINE std::string preparePrestoRegexpReplaceReplacement(
       RE2::UNANCHORED,
       groupName,
       2)) {
-    auto groupIter = re.NamedCapturingGroups().find(groupName[1].as_string());
+    std::string groupNameStr(groupName[1]);
+    auto groupIter = re.NamedCapturingGroups().find(groupNameStr);
     if (groupIter == re.NamedCapturingGroups().end()) {
       VELOX_USER_FAIL(
           "Invalid replacement sequence: unknown group {{ {} }}.",
-          groupName[1].as_string());
+          groupNameStr);
     }
 
     RE2::GlobalReplace(
         &newReplacement,
-        fmt::format(R"(\${{{}}})", groupName[1].as_string()),
+        fmt::format(R"(\${{{}}})", groupNameStr),
         fmt::format("${}", groupIter->second));
   }
 


### PR DESCRIPTION
Fix #7717.

Per https://github.com/google/re2/issues/388, `re2::StringPiece` in `C++17` essentially `std::string_view`[^1], and the `as_string` method has removed since Jun 2023.

[^1]: https://github.com/abseil/abseil-cpp/blob/fd7713cb9a97c49096211ff40de280b6cebbb21c/absl/strings/string_view.h#L53
