### PR TITLE
Trace metadata during task creation

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -157,6 +157,7 @@ MemoryManager::MemoryManager(const MemoryManagerOptions& options)
               .coreOnAllocationFailureEnabled =
                   options.coreOnAllocationFailureEnabled})},
       spillPool_{addLeafPool("__sys_spilling__")},
+      tracePool_{addLeafPool("__sys_tracing__")},
       sharedLeafPools_(createSharedLeafMemoryPools(*sysRoot_)) {
   VELOX_CHECK_NOT_NULL(allocator_);
   VELOX_CHECK_NOT_NULL(arbitrator_);
@@ -426,5 +427,9 @@ memory::MemoryPool* spillMemoryPool() {
 
 bool isSpillMemoryPool(memory::MemoryPool* pool) {
   return pool == spillMemoryPool();
+}
+
+memory::MemoryPool* traceMemoryPool() {
+  return memory::MemoryManager::getInstance()->tracePool();
 }
 } // namespace facebook::velox::memory

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -342,6 +342,11 @@ class MemoryManager {
     return spillPool_.get();
   }
 
+  /// Returns the process wide leaf memory pool used for query tracing.
+  MemoryPool* tracePool() const {
+    return tracePool_.get();
+  }
+
   const std::vector<std::shared_ptr<MemoryPool>>& testingSharedLeafPools() {
     return sharedLeafPools_;
   }
@@ -374,6 +379,7 @@ class MemoryManager {
 
   const std::shared_ptr<MemoryPool> sysRoot_;
   const std::shared_ptr<MemoryPool> spillPool_;
+  const std::shared_ptr<MemoryPool> tracePool_;
   const std::vector<std::shared_ptr<MemoryPool>> sharedLeafPools_;
 
   mutable folly::SharedMutex mutex_;
@@ -419,6 +425,9 @@ memory::MemoryPool* spillMemoryPool();
 
 /// Returns true if the provided 'pool' is the spilling memory pool.
 bool isSpillMemoryPool(memory::MemoryPool* pool);
+
+/// Returns the system-wide memory pool for tracing memory usage.
+memory::MemoryPool* traceMemoryPool();
 
 FOLLY_ALWAYS_INLINE int32_t alignmentPadding(void* address, int32_t alignment) {
   auto extra = reinterpret_cast<uintptr_t>(address) % alignment;

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -346,6 +346,16 @@ class QueryConfig {
   /// derived using micro-benchmarking.
   static constexpr const char* kPrefixSortMinRows = "prefixsort_min_rows";
 
+  /// Enable query tracing flag.
+  static constexpr const char* kQueryTraceEnabled = "query_trace_enabled";
+
+  /// Base dir of a query to store tracing data.
+  static constexpr const char* kQueryTraceDir = "query_trace_dir";
+
+  /// A comma-separated list of plan node ids whose input data will be traced.
+  /// Empty string if only want to trace the query metadata.
+  static constexpr const char* kQueryTraceNodeIds = "query_trace_node_ids";
+
   uint64_t queryMaxMemoryPerNode() const {
     return config::toCapacity(
         get<std::string>(kQueryMaxMemoryPerNode, "0B"),
@@ -609,6 +619,21 @@ class QueryConfig {
   int32_t spillableReservationGrowthPct() const {
     constexpr int32_t kDefaultPct = 10;
     return get<int32_t>(kSpillableReservationGrowthPct, kDefaultPct);
+  }
+
+  /// Returns true if query tracing is enabled.
+  bool queryTraceEnabled() const {
+    return get<bool>(kQueryTraceEnabled, false);
+  }
+
+  std::string queryTraceDir() const {
+    // The default query trace dir, empty by default.
+    return get<std::string>(kQueryTraceDir, "");
+  }
+
+  std::string queryTraceNodeIds() const {
+    // The default query trace nodes, empty by default.
+    return get<std::string>(kQueryTraceNodeIds, "");
   }
 
   bool prestoArrayAggIgnoreNulls() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -686,4 +686,29 @@ Spark-specific Configuration
        the value of this config can not exceed the default value.
    * - spark.partition_id
      - integer
+     -
      - The current task's Spark partition ID. It's set by the query engine (Spark) prior to task execution.
+
+Tracing
+--------
+.. list-table::
+   :widths: 30 10 10 70
+   :header-rows: 1
+
+   * - Property Name
+     - Type
+     - Default Value
+     - Description
+   * - query_trace_enabled
+     - bool
+     - true
+     - If true, enable query tracing.
+   * - query_trace_dir
+     - string
+     -
+     - The root directory to store the tracing data and metadata for a query.
+   * - query_trace_node_ids
+     - string
+     -
+     - A comma-separated list of plan node ids whose input data will be trace. If it is empty, then we only trace the
+       query metadata which includes the query plan and configs etc.

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -23,6 +23,8 @@
 #include "velox/exec/Split.h"
 #include "velox/exec/TaskStats.h"
 #include "velox/exec/TaskStructs.h"
+#include "velox/exec/trace/QueryMetadataWriter.h"
+#include "velox/exec/trace/QueryTraceConfig.h"
 #include "velox/vector/ComplexVector.h"
 
 namespace facebook::velox::exec {
@@ -969,6 +971,13 @@ class Task : public std::enable_shared_from_this<Task> {
   std::shared_ptr<ExchangeClient> getExchangeClientLocked(
       int32_t pipelineId) const;
 
+  // Builds the query trace config.
+  std::optional<trace::QueryTraceConfig> maybeMakeTraceConfig() const;
+
+  // Create a 'QueryMetadtaWriter' to trace the query metadata if the query
+  // trace enabled.
+  void maybeInitQueryTrace();
+
   // The helper class used to maintain 'numCreatedTasks_' and 'numDeletedTasks_'
   // on task construction and destruction.
   class TaskCounter {
@@ -999,6 +1008,7 @@ class Task : public std::enable_shared_from_this<Task> {
   core::PlanFragment planFragment_;
   const int destination_;
   const std::shared_ptr<core::QueryCtx> queryCtx_;
+  const std::optional<trace::QueryTraceConfig> traceConfig_;
 
   // The execution mode of the task. It is enforced that a task can only be
   // executed in a single mode throughout its lifetime

--- a/velox/exec/trace/CMakeLists.txt
+++ b/velox/exec/trace/CMakeLists.txt
@@ -12,10 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_query_trace_exec QueryMetadataWriter.cpp QueryTraceConfig.cpp
-                                   QueryDataWriter.cpp)
+velox_add_library(
+  velox_query_trace_exec
+  QueryMetadataWriter.cpp
+  QueryTraceConfig.cpp
+  QueryDataWriter.cpp
+  QueryTraceUtil.cpp)
 
-target_link_libraries(
+velox_link_libraries(
   velox_query_trace_exec
   PRIVATE
     velox_common_io
@@ -26,10 +30,10 @@ target_link_libraries(
     velox_common_base
     velox_presto_serializer)
 
-add_library(velox_query_trace_retrieve QueryDataReader.cpp
-                                       QueryMetadataReader.cpp)
+velox_add_library(velox_query_trace_retrieve QueryDataReader.cpp
+                  QueryMetadataReader.cpp)
 
-target_link_libraries(
+velox_link_libraries(
   velox_query_trace_retrieve
   velox_common_io
   velox_file

--- a/velox/exec/trace/QueryTraceConfig.cpp
+++ b/velox/exec/trace/QueryTraceConfig.cpp
@@ -24,4 +24,9 @@ QueryTraceConfig::QueryTraceConfig(
     : queryNodes(std::move(_queryNodeIds)),
       queryTraceDir(std::move(_queryTraceDir)) {}
 
+QueryTraceConfig::QueryTraceConfig(std::string _queryTraceDir)
+    : QueryTraceConfig(
+          std::unordered_set<std::string>{},
+          std::move(_queryTraceDir)) {}
+
 } // namespace facebook::velox::exec::trace

--- a/velox/exec/trace/QueryTraceUtil.cpp
+++ b/velox/exec/trace/QueryTraceUtil.cpp
@@ -14,24 +14,25 @@
  * limitations under the License.
  */
 
-#pragma once
-
-#include <string>
-#include <unordered_set>
+#include "velox/exec/trace/QueryTraceUtil.h"
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/file/FileSystems.h"
 
 namespace facebook::velox::exec::trace {
-struct QueryTraceConfig {
-  /// Target query trace nodes.
-  std::unordered_set<std::string> queryNodes;
-  /// Base dir of query trace.
-  std::string queryTraceDir;
 
-  QueryTraceConfig(
-      std::unordered_set<std::string> _queryNodeIds,
-      std::string _queryTraceDir);
+void createTraceDirectory(const std::string& traceDir) {
+  try {
+    const auto fs = filesystems::getFileSystem(traceDir, nullptr);
+    if (fs->exists(traceDir)) {
+      fs->rmdir(traceDir);
+    }
+    fs->mkdir(traceDir);
+  } catch (const std::exception& e) {
+    VELOX_FAIL(
+        "Failed to create trace directory '{}' with error: {}",
+        traceDir,
+        e.what());
+  }
+}
 
-  QueryTraceConfig(std::string _queryTraceDir);
-
-  QueryTraceConfig() = default;
-};
 } // namespace facebook::velox::exec::trace

--- a/velox/exec/trace/QueryTraceUtil.h
+++ b/velox/exec/trace/QueryTraceUtil.h
@@ -17,21 +17,10 @@
 #pragma once
 
 #include <string>
-#include <unordered_set>
 
 namespace facebook::velox::exec::trace {
-struct QueryTraceConfig {
-  /// Target query trace nodes.
-  std::unordered_set<std::string> queryNodes;
-  /// Base dir of query trace.
-  std::string queryTraceDir;
 
-  QueryTraceConfig(
-      std::unordered_set<std::string> _queryNodeIds,
-      std::string _queryTraceDir);
+/// Creates a directory to store the query trace metdata and data.
+void createTraceDirectory(const std::string& traceDir);
 
-  QueryTraceConfig(std::string _queryTraceDir);
-
-  QueryTraceConfig() = default;
-};
 } // namespace facebook::velox::exec::trace

--- a/velox/exec/trace/test/CMakeLists.txt
+++ b/velox/exec/trace/test/CMakeLists.txt
@@ -28,4 +28,6 @@ target_link_libraries(
   velox_memory
   velox_query_trace_exec
   velox_query_trace_retrieve
-  velox_vector_fuzzer)
+  velox_vector_fuzzer
+  GTest::gtest_main
+  GTest::gmock)

--- a/velox/exec/trace/test/QueryTraceTest.cpp
+++ b/velox/exec/trace/test/QueryTraceTest.cpp
@@ -28,6 +28,7 @@
 #include "velox/exec/trace/QueryDataWriter.h"
 #include "velox/exec/trace/QueryMetadataReader.h"
 #include "velox/exec/trace/QueryMetadataWriter.h"
+#include "velox/exec/trace/QueryTraceUtil.h"
 #include "velox/serializers/PrestoSerializer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -202,4 +203,169 @@ TEST_F(QueryTracerTest, traceMetadata) {
     ASSERT_EQ(actualConnectorConfigs.at(key), expectedConnectorConfigs.at(key));
   }
 }
+
+TEST_F(QueryTracerTest, task) {
+  const auto rowType =
+      ROW({"c0", "c1", "c2", "c3", "c4", "c5"},
+          {BIGINT(), SMALLINT(), TINYINT(), VARCHAR(), VARCHAR(), VARCHAR()});
+  std::vector<RowVectorPtr> rows;
+  constexpr auto numBatch = 1;
+  rows.reserve(numBatch);
+  for (auto i = 0; i < numBatch; ++i) {
+    rows.push_back(vectorFuzzer_.fuzzRow(rowType, 2));
+  }
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  const auto planNode =
+      PlanBuilder(planNodeIdGenerator)
+          .values(rows, false)
+          .project({"c0", "c1", "c2"})
+          .hashJoin(
+              {"c0"},
+              {"u0"},
+              PlanBuilder(planNodeIdGenerator)
+                  .values(rows, true)
+                  .singleAggregation({"c0", "c1"}, {"min(c2)"})
+                  .project({"c0 AS u0", "c1 AS u1", "a0 AS u2"})
+                  .planNode(),
+              "c0 < 135",
+              {"c0", "c1", "c2"},
+              core::JoinType::kInner)
+          .planNode();
+  const auto expectedResult =
+      AssertQueryBuilder(planNode).maxDrivers(1).copyResults(pool());
+
+  for (const auto& queryTraceNodeIds : {"1,2", ""}) {
+    const auto outputDir = TempDirectoryPath::create();
+    const auto expectedQueryConfigs =
+        std::unordered_map<std::string, std::string>{
+            {core::QueryConfig::kSpillEnabled, "true"},
+            {core::QueryConfig::kSpillNumPartitionBits, "17"},
+            {core::QueryConfig::kQueryTraceEnabled, "true"},
+            {core::QueryConfig::kQueryTraceDir, outputDir->getPath()},
+            {core::QueryConfig::kQueryTraceEnabled, queryTraceNodeIds},
+            {"key1", "value1"},
+        };
+    const auto expectedConnectorProperties =
+        std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>{
+            {"test_trace",
+             std::make_shared<config::ConfigBase>(
+                 std::unordered_map<std::string, std::string>{
+                     {"cKey1", "cVal1"}})}};
+    const auto queryCtx = core::QueryCtx::create(
+        executor_.get(),
+        core::QueryConfig(expectedQueryConfigs),
+        expectedConnectorProperties);
+
+    std::shared_ptr<Task> task;
+    const auto result = AssertQueryBuilder(planNode)
+                            .queryCtx(queryCtx)
+                            .maxDrivers(1)
+                            .copyResults(pool(), task);
+    assertEqualResults({result}, {expectedResult});
+
+    const auto expectedDir =
+        fmt::format("{}/{}", outputDir->getPath(), task->taskId());
+    const auto fs = filesystems::getFileSystem(expectedDir, nullptr);
+    const auto actaulDirs = fs->list(outputDir->getPath());
+    ASSERT_EQ(actaulDirs.size(), 1);
+    ASSERT_EQ(actaulDirs.at(0), expectedDir);
+
+    std::unordered_map<std::string, std::string> acutalQueryConfigs;
+    std::
+        unordered_map<std::string, std::unordered_map<std::string, std::string>>
+            actualConnectorProperties;
+    core::PlanNodePtr actualQueryPlan;
+    auto reader = trace::QueryMetadataReader(expectedDir, pool());
+    reader.read(acutalQueryConfigs, actualConnectorProperties, actualQueryPlan);
+
+    ASSERT_TRUE(isSamePlan(actualQueryPlan, planNode));
+    ASSERT_EQ(acutalQueryConfigs.size(), expectedQueryConfigs.size());
+    for (const auto& [key, value] : acutalQueryConfigs) {
+      ASSERT_EQ(acutalQueryConfigs.at(key), expectedQueryConfigs.at(key));
+    }
+
+    ASSERT_EQ(
+        actualConnectorProperties.size(), expectedConnectorProperties.size());
+    ASSERT_EQ(actualConnectorProperties.count("test_trace"), 1);
+    const auto expectedConnectorConfigs =
+        expectedConnectorProperties.at("test_trace")->rawConfigsCopy();
+    const auto actualConnectorConfigs =
+        actualConnectorProperties.at("test_trace");
+    for (const auto& [key, value] : actualConnectorConfigs) {
+      ASSERT_EQ(
+          actualConnectorConfigs.at(key), expectedConnectorConfigs.at(key));
+    }
+  }
+}
+
+TEST_F(QueryTracerTest, error) {
+  const auto planNode = PlanBuilder().values({}).planNode();
+  const auto expectedQueryConfigs =
+      std::unordered_map<std::string, std::string>{
+          {core::QueryConfig::kSpillEnabled, "true"},
+          {core::QueryConfig::kSpillNumPartitionBits, "17"},
+          {core::QueryConfig::kQueryTraceEnabled, "true"},
+      };
+  const auto queryCtx = core::QueryCtx::create(
+      executor_.get(), core::QueryConfig(expectedQueryConfigs));
+  VELOX_ASSERT_USER_THROW(
+      AssertQueryBuilder(planNode).queryCtx(queryCtx).maxDrivers(1).copyResults(
+          pool()),
+      "Query trace enabled but the trace dir is not set");
+}
+
+TEST_F(QueryTracerTest, traceDir) {
+  const auto outputDir = TempDirectoryPath::create();
+  const auto rootDir = outputDir->getPath();
+  const auto fs = filesystems::getFileSystem(rootDir, nullptr);
+  auto dir1 = fmt::format("{}/{}", outputDir->getPath(), "t1");
+  trace::createTraceDirectory(dir1);
+  ASSERT_TRUE(fs->exists(dir1));
+
+  auto dir2 = fmt::format("{}/{}", dir1, "t1_1");
+  trace::createTraceDirectory(dir2);
+  ASSERT_TRUE(fs->exists(dir2));
+
+  // It will remove the old dir1 along with its subdir when created the dir1
+  // again.
+  trace::createTraceDirectory(dir1);
+  ASSERT_TRUE(fs->exists(dir1));
+  ASSERT_FALSE(fs->exists(dir2));
+
+  const auto parentDir = fmt::format("{}/{}", outputDir->getPath(), "p");
+  fs->mkdir(parentDir);
+
+  constexpr auto numThreads = 5;
+  std::vector<std::thread> queryThreads;
+  queryThreads.reserve(numThreads);
+  std::set<std::string> expectedDirs;
+  for (int i = 0; i < numThreads; ++i) {
+    queryThreads.emplace_back([&, i]() {
+      const auto dir = fmt::format("{}/s{}", parentDir, i);
+      trace::createTraceDirectory(dir);
+      expectedDirs.insert(dir);
+    });
+  }
+
+  for (auto& queryThread : queryThreads) {
+    queryThread.join();
+  }
+
+  const auto actualDirs = fs->list(parentDir);
+  ASSERT_EQ(actualDirs.size(), numThreads);
+  ASSERT_EQ(actualDirs.size(), expectedDirs.size());
+  for (const auto& dir : actualDirs) {
+    ASSERT_EQ(expectedDirs.count(dir), 1);
+  }
+}
 } // namespace facebook::velox::exec::test
+
+// This main is needed for some tests on linux.
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  // Signal handler required for ThreadDebugInfoTest
+  facebook::velox::process::addDefaultFatalSignalHandler();
+  folly::Init init(&argc, &argv, false);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Create a directory named `$QueryTraceBaseDir/$taskId` when a task is initiated,
if query tracing is enabled. This directory will store metadata related to the task,
including the query plan node tree, query configurations, and connector properties.

Part of #9668 