### PR TITLE
Add disable pool management option to memory manager

### DIFF
--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -81,6 +81,9 @@ struct MemoryManagerOptions {
   /// Terminates the process and generates a core file on an allocation failure
   bool coreOnAllocationFailureEnabled{false};
 
+  /// Disables the memory manager's tracking on memory pools.
+  bool disableMemoryPoolTracking{false};
+
   /// ================== 'MemoryAllocator' settings ==================
 
   /// Specifies the max memory allocation capacity in bytes enforced by
@@ -344,21 +347,26 @@ class MemoryManager {
   }
 
  private:
+  std::shared_ptr<MemoryPool> createRootPool(
+      std::string poolName,
+      std::unique_ptr<MemoryReclaimer>& reclaimer,
+      MemoryPool::Options& options);
+
   void dropPool(MemoryPool* pool);
 
   //  Returns the shared references to all the alive memory pools in 'pools_'.
   std::vector<std::shared_ptr<MemoryPool>> getAlivePools() const;
 
   const std::shared_ptr<MemoryAllocator> allocator_;
-  // Specifies the capacity to allocate from 'arbitrator_' for a newly created
-  // root memory pool.
-  const uint64_t poolInitCapacity_;
+
   // If not null, used to arbitrate the memory capacity among 'pools_'.
   const std::unique_ptr<MemoryArbitrator> arbitrator_;
   const uint16_t alignment_;
   const bool checkUsageLeak_;
   const bool debugEnabled_;
   const bool coreOnAllocationFailureEnabled_;
+  const bool disableMemoryPoolTracking_;
+
   // The destruction callback set for the allocated root memory pools which are
   // tracked by 'pools_'. It is invoked on the root pool destruction and removes
   // the pool from 'pools_'.

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -64,7 +64,7 @@ class MemoryArbitrator {
     MemoryArbitrationStateCheckCB arbitrationStateCheckCb{nullptr};
 
     /// Additional configs that are arbitrator implementation specific.
-    std::unordered_map<std::string, std::string> extraConfigs;
+    std::unordered_map<std::string, std::string> extraConfigs{};
   };
 
   using Factory = std::function<std::unique_ptr<MemoryArbitrator>(

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -620,4 +620,57 @@ TEST_F(MemoryManagerTest, quotaEnforcement) {
     }
   }
 }
+
+TEST_F(MemoryManagerTest, disableMemoryPoolTracking) {
+  const std::string kSharedKind{"SHARED"};
+  const std::string kNoopKind{""};
+  MemoryManagerOptions options;
+  options.disableMemoryPoolTracking = true;
+  options.allocatorCapacity = 64LL << 20;
+  options.arbitratorCapacity = 64LL << 20;
+  std::vector<std::string> arbitratorKinds{kNoopKind, kSharedKind};
+  for (auto arbitratorKind : arbitratorKinds) {
+    options.arbitratorKind = arbitratorKind;
+    MemoryManager manager{options};
+    auto root0 = manager.addRootPool("root_0", 35LL << 20);
+    auto leaf0 = root0->addLeafChild("leaf_0");
+
+    // Not throwing since there is no duplicate check.
+    auto root0Dup = manager.addRootPool("root_0", 35LL << 20);
+
+    // 1TB capacity is allowed since there is no capacity check.
+    auto root1 = manager.addRootPool("root_1", 1LL << 40);
+    auto leaf1 = root1->addLeafChild("leaf_1");
+
+    ASSERT_EQ(root0->capacity(), 35LL << 20);
+    if (arbitratorKind == kSharedKind) {
+      ASSERT_EQ(root0Dup->capacity(), 29LL << 20);
+      ASSERT_EQ(root1->capacity(), 0);
+    } else {
+      ASSERT_EQ(root0Dup->capacity(), 35LL << 20);
+      ASSERT_EQ(root1->capacity(), 1LL << 40);
+    }
+
+    ASSERT_EQ(manager.capacity(), 64LL << 20);
+    ASSERT_EQ(manager.shrinkPools(), 0);
+    // Default 1 system pool with 1 leaf child
+    ASSERT_EQ(manager.numPools(), 1);
+
+    VELOX_ASSERT_THROW(
+        leaf0->allocate(38LL << 20), "Exceeded memory pool capacity");
+    if (arbitratorKind == kSharedKind) {
+      VELOX_ASSERT_THROW(
+          leaf1->allocate(256LL << 20), "Exceeded memory pool capacity");
+    } else {
+      VELOX_ASSERT_THROW(
+          leaf1->allocate(256LL << 20), "Exceeded memory allocator limit");
+    }
+
+    ASSERT_NO_THROW(leaf0.reset());
+    ASSERT_NO_THROW(leaf1.reset());
+    ASSERT_NO_THROW(root0.reset());
+    ASSERT_NO_THROW(root0Dup.reset());
+    ASSERT_NO_THROW(root1.reset());
+  }
+}
 } // namespace facebook::velox::memory


### PR DESCRIPTION
Add this disable pool management option to give users an option to have better memory pool performance (creation), especially for high QPS use cases.