### PR TITLE
Fix the race between query abort and suspension state leave

### DIFF
--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -516,9 +516,12 @@ void testingRunArbitration(
     MemoryPool* pool,
     uint64_t targetBytes,
     bool allowSpill) {
-  ScopedMemoryPoolArbitrationCtx arbitrationCtx{pool};
-  static_cast<MemoryPoolImpl*>(pool)->testingManager()->shrinkPools(
-      targetBytes, allowSpill);
+  {
+    ScopedMemoryPoolArbitrationCtx arbitrationCtx{pool};
+    static_cast<MemoryPoolImpl*>(pool)->testingManager()->shrinkPools(
+        targetBytes, allowSpill);
+  }
+  static_cast<MemoryPoolImpl*>(pool)->testingCheckIfAborted();
 }
 
 ScopedReclaimedBytesRecorder::ScopedReclaimedBytesRecorder(

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -679,13 +679,12 @@ void Operator::MemoryReclaimer::abort(
       !driver->state().isOnThread() || driver->state().suspended() ||
       driver->state().isTerminated);
   VELOX_CHECK(driver->task()->isCancelled());
-  if (driver->state().isOnThread() && driver->state().suspended()) {
-    // We can't abort an operator if it is running on a driver thread and
-    // suspended for memory arbitration. Otherwise, it might cause random crash
-    // when the driver thread throws after detects the aborted query.
+  if (driver->state().isOnThread()) {
+    // We can't abort an operator if it is running on a driver thread for memory
+    // arbitration. Otherwise, it might cause random crash when the driver
+    // thread throws after detects the aborted query.
     return;
   }
-
   // Calls operator close to free up major memory usage.
   op_->close();
 }

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2690,6 +2690,7 @@ StopReason Task::leaveSuspended(ThreadState& state) {
   VELOX_CHECK(!state.hasBlockingFuture);
   VELOX_CHECK(state.isOnThread());
 
+  TestValue::adjust("facebook::velox::exec::Task::leaveSuspended", this);
   for (;;) {
     {
       std::lock_guard<std::timed_mutex> l(mutex_);
@@ -2984,6 +2985,7 @@ void Task::MemoryReclaimer::abort(
   VELOX_CHECK_EQ(task->pool()->name(), pool->name());
 
   task->setError(error);
+  // TODO: respect the memory arbitration request timeout later.
   const static uint32_t maxTaskAbortWaitUs = 6'000'000; // 60s
   if (task->taskCompletionFuture().wait(
           std::chrono::microseconds(maxTaskAbortWaitUs))) {

--- a/velox/exec/tests/utils/Cursor.cpp
+++ b/velox/exec/tests/utils/Cursor.cpp
@@ -280,7 +280,7 @@ class MultiThreadedTaskCursor : public TaskCursorBase {
       // Wait for the task to finish (there's' a small period of time between
       // when the error is set on the Task and terminate is called).
       task_->taskCompletionFuture()
-          .within(std::chrono::microseconds(1'000'000))
+          .within(std::chrono::microseconds(5'000'000))
           .wait();
 
       // Wait for all task drivers to finish to avoid destroying the executor_


### PR DESCRIPTION
There is a time race in existing query memory abort processing. Here is the event sequence
that can lead to the race condition:
T1: driver thread is in suspended state and about to leave from memory arbitration on success;
T2: query pool has been aborted by memory arbitrator;
T3: memory pool abort to wait for all the driver threads to complete. The driver thread mentioned
       in T1 is still under suspension state so the memory pool abort thinks all the driver threads are
       not running and start operator abort (task has already been terminated at this point)
T4: driver thread leave suspension state and the memory arbitration succeeds so the driver thread
       can proceed with the rest of operation processing
T5: memory pool abort tries to abort the operator from the previously suspended driver by close
       those operators which might free major data structures.
T6: driver thread resume operator processing can cause memory segment fault.

To prevent this, we should add a step check if the pool has been aborted. If aborted, release the
committed memory reservation by arbitration and throw the aborted error. The other option is to
check task error after memory arbitration which can cover both memory pool abort and task terminate
events. Since task terminate race condition has been handled well, then we just handle the async
memory pool abort error event inside memory pool.

With this protection, we can remove the suspended driver thread check inside the operator abort
function so we can always close an operator no matter it is associated driver thread is running or
not. This is an enhancement as we can release the memory resource from an operator earlier.  Also
note the removed check in this PR can not prevent the race condition above.