### PR TITLE
Remove wall time from BM report

### DIFF
--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -18,6 +18,7 @@ on:
   pull_request:
       paths:
         - ".github/workflows/build-metrics.yml"
+        - "script/bm-report/**"
 
   workflow_dispatch:
     inputs:

--- a/scripts/bm-report/report.qmd
+++ b/scripts/bm-report/report.qmd
@@ -87,7 +87,7 @@ format_tags <- function(x) {
 ```{r total-graphs}
 # Filter the data and layout the overview plots
 times_plot <- results |>
-  filter(tags.suite == "total", endsWith(tags.source, "time")) |>
+  filter(tags.suite == "total", endsWith(tags.source, "time"), tags.name != "wall_time") |>
   mutate(
     stats.data = lubridate::dseconds(stats.data),
     tags.name = format_tags(tags.name)

--- a/scripts/build-metrics.py
+++ b/scripts/build-metrics.py
@@ -95,7 +95,7 @@ class BinarySizeAdapter(BenchmarkAdapter):
 class NinjaLogAdapter(BenchmarkAdapter):
     """
     Adapter to extract compile and link times from a .ninja_log.
-    Will calculate aggregates for total, compile, link and wall time.
+    Will calculate aggregates for total, compile and link time.
     Suite metadata will be set based on binary ending to object, library or executable.
 
     Only files in paths beginning with velox/ will be tracked to avoid dependencies.
@@ -135,7 +135,6 @@ class NinjaLogAdapter(BenchmarkAdapter):
             "link_time": 0,
             "compile_time": 0,
             "total_time": 0,
-            "wall_time": get_epoch(log_lines[-1]) - get_epoch(log_lines[0]),
         }
 
         for line in log_lines:


### PR DESCRIPTION
The method I used to get the wall time is brittle against changes in the ninja log layout (e.g. through cmake or ninja updates) and currently making the plots useless due to an underflow. 

- remove wall time from plots
- no longer track wall time