### PR TITLE
Fix LEFT and ANTI joins to preserve probe order

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1526,6 +1526,10 @@ class AbstractJoinNode : public PlanNode {
     return joinType_ == JoinType::kAnti;
   }
 
+  bool isPreservingProbeOrder() const {
+    return isInnerJoin() || isLeftJoin() || isAntiJoin();
+  }
+
   const std::vector<FieldAccessTypedExprPtr>& leftKeys() const {
     return leftKeys_;
   }


### PR DESCRIPTION
Summary:
Currently for LEFT and ANTI joins, when there is a carryover missing
row from previous batch, we keep it and add it at end of current batch if there
is capacity, which breaks the order of probe side rows.

To fix this we simplify the logic of `NoMatchDetector` to emit rows in order.
As a result of that, the carryover row will be added as soon as we can decide it
needs to be added to output; this means we need to make one row extra space on
output buffers for the carryover case.  In the same case we also need to use
temporary buffers to avoid data being overwritten before we read them.

Differential Revision: D61795406
