### PR TITLE
Relax the reclaimed bytes check for hash build

### DIFF
--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -1052,7 +1052,7 @@ void HashTable<ignoreNullKeys>::buildJoinPartition(
       buildPartitionBounds_[partition],
       buildPartitionBounds_[partition + 1],
       overflow};
-  auto rowContainer =
+  auto* rowContainer =
       (partition == 0 ? this : otherTables_[partition - 1].get())->rows();
   for (auto i = 0; i < numPartitions; ++i) {
     auto* table = i == 0 ? this : otherTables_[i - 1].get();
@@ -1138,16 +1138,16 @@ void HashTable<ignoreNullKeys>::insertForGroupBy(
 
 template <bool ignoreNullKeys>
 bool HashTable<ignoreNullKeys>::arrayPushRow(char* row, int32_t index) {
-  auto existing = table_[index];
-  if (existing) {
-    if (nextOffset_) {
+  auto* existingRow = table_[index];
+  if (existingRow != nullptr) {
+    if (nextOffset_ > 0) {
       hasDuplicates_ = true;
-      rows_->appendNextRow(existing, row);
+      rows_->appendNextRow(existingRow, row);
     }
     return false;
   }
   table_[index] = row;
-  return !existing;
+  return existingRow == nullptr;
 }
 
 template <bool ignoreNullKeys>
@@ -1155,10 +1155,9 @@ void HashTable<ignoreNullKeys>::pushNext(
     RowContainer* rows,
     char* row,
     char* next) {
-  if (nextOffset_ > 0) {
-    hasDuplicates_ = true;
-    rows->appendNextRow(row, next);
-  }
+  VELOX_CHECK_GT(nextOffset_, 0);
+  hasDuplicates_ = true;
+  rows->appendNextRow(row, next);
 }
 
 template <bool ignoreNullKeys>
@@ -1187,7 +1186,7 @@ FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::buildFullProbe(
         [&](char* group, int32_t /*row*/) {
           if (RowContainer::normalizedKey(group) ==
               RowContainer::normalizedKey(inserted)) {
-            if (nextOffset_) {
+            if (nextOffset_ > 0) {
               pushNext(rows, group, inserted);
             }
             return true;
@@ -1809,7 +1808,7 @@ int32_t HashTable<ignoreNullKeys>::listJoinResults(
           (joinProjectedVarColumnsSize(iter.varSizeListColumns, hit) +
            iter.fixedSizeListColumnsSizeSum);
     } else {
-      auto numRows = rows->size();
+      const auto numRows = rows->size();
       auto num =
           std::min(numRows - iter.lastDuplicateRowIndex, maxOut - numOut);
       std::fill_n(inputRows.begin() + numOut, num, row);

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -1002,7 +1002,7 @@ class HashTable : public BaseHashTable {
   std::atomic<bool> hasDuplicates_{false};
 
   // Offset of next row link for join build side set from 'rows_'.
-  int32_t nextOffset_;
+  int32_t nextOffset_{0};
   char** table_ = nullptr;
   memory::ContiguousAllocation tableAllocation_;
 

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -391,8 +391,9 @@ int32_t RowContainer::findRows(folly::Range<char**> rows, char** result) {
 }
 
 void RowContainer::appendNextRow(char* current, char* nextRow) {
+  VELOX_CHECK(getNextRowVector(nextRow) == nullptr);
   NextRowVector*& nextRowArrayPtr = getNextRowVector(current);
-  if (!nextRowArrayPtr) {
+  if (nextRowArrayPtr == nullptr) {
     nextRowArrayPtr =
         new (stringAllocator_->allocate(kNextRowVectorSize)->begin())
             NextRowVector(StlAllocator<char*>(stringAllocator_.get()));


### PR DESCRIPTION
Join fuzzer detects check failure on hash build operator reclaim as the operator memory usage gets increased after reclamation. This happens when the parallel join build is running at a background and the memory reclamation is
skipped. The parallel join build can cause additional memory usage such as data structure used to store parallel join
data partitioning as well as duplicate row vector. This PR fixes this by skipping the reclaimed bytes check for hash
build which only use the spill memory pool for memory reclamation.