### PR TITLE
Add back memory reclaim async callback to remove async dependency on …

### DIFF
--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -480,15 +480,6 @@ ScopedMemoryArbitrationContext::ScopedMemoryArbitrationContext(
   arbitrationCtx = &currentArbitrationCtx_;
 }
 
-ScopedMemoryArbitrationContext::ScopedMemoryArbitrationContext(
-    const MemoryArbitrationContext* contextToRestore)
-    : savedArbitrationCtx_(arbitrationCtx) {
-  if (contextToRestore != nullptr) {
-    currentArbitrationCtx_ = *contextToRestore;
-    arbitrationCtx = &currentArbitrationCtx_;
-  }
-}
-
 ScopedMemoryArbitrationContext::~ScopedMemoryArbitrationContext() {
   arbitrationCtx = savedArbitrationCtx_;
 }

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -18,6 +18,7 @@
 
 #include <vector>
 
+#include "velox/common/base/AsyncSource.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/Portability.h"
 #include "velox/common/base/SuccinctPrinter.h"
@@ -419,13 +420,6 @@ class ScopedMemoryArbitrationContext {
  public:
   explicit ScopedMemoryArbitrationContext(const MemoryPool* requestor);
 
-  /// Can be used to restore a previously captured MemoryArbitrationContext.
-  /// contextToRestore can be nullptr if there was no context at the time it was
-  /// captured, in which case arbitrationCtx is unchanged upon
-  /// contruction/destruction of this object.
-  explicit ScopedMemoryArbitrationContext(
-      const MemoryArbitrationContext* contextToRestore);
-
   ~ScopedMemoryArbitrationContext();
 
  private:
@@ -450,6 +444,23 @@ const MemoryArbitrationContext* memoryArbitrationContext();
 
 /// Returns true if the running thread is under memory arbitration or not.
 bool underMemoryArbitration();
+
+/// Creates an async memory reclaim task with memory arbitration context set.
+/// This is to avoid recursive memory arbitration during memory reclaim.
+///
+/// NOTE: this must be called under memory arbitration.
+template <typename Item>
+std::shared_ptr<AsyncSource<Item>> createAsyncMemoryReclaimTask(
+    std::function<std::unique_ptr<Item>()> task) {
+  auto* arbitrationCtx = memory::memoryArbitrationContext();
+  VELOX_CHECK_NOT_NULL(arbitrationCtx);
+  return std::make_shared<AsyncSource<Item>>(
+      [asyncTask = std::move(task), arbitrationCtx]() -> std::unique_ptr<Item> {
+        VELOX_CHECK_NOT_NULL(arbitrationCtx);
+        memory::ScopedMemoryArbitrationContext ctx(arbitrationCtx->requestor);
+        return asyncTask();
+      });
+}
 
 /// The function triggers memory arbitration by shrinking memory pools from
 /// 'manager' by invoking shrinkPools API. If 'manager' is not set, then it

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -706,7 +706,7 @@ TEST_F(MockSharedArbitrationTest, asyncArbitrationWork) {
 
           explicit Result(bool _succeeded) : succeeded(_succeeded) {}
         };
-        auto asyncReclaimTask = std::make_shared<AsyncSource<Result>>([&]() {
+        auto asyncReclaimTask = createAsyncMemoryReclaimTask<Result>([&]() {
           memoryOp->allocate(poolCapacity);
           return std::make_unique<Result>(true);
         });

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -1163,7 +1163,7 @@ void HashBuild::reclaim(
   for (auto* op : operators) {
     HashBuild* buildOp = static_cast<HashBuild*>(op);
     spillTasks.push_back(
-        std::make_shared<AsyncSource<SpillResult>>([buildOp]() {
+        memory::createAsyncMemoryReclaimTask<SpillResult>([buildOp]() {
           try {
             buildOp->spiller_->spill();
             buildOp->table_->clear();

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1766,7 +1766,7 @@ void HashProbe::spillOutput(const std::vector<HashProbe*>& operators) {
   for (auto* op : operators) {
     HashProbe* probeOp = static_cast<HashProbe*>(op);
     spillTasks.push_back(
-        std::make_shared<AsyncSource<SpillResult>>([probeOp]() {
+        memory::createAsyncMemoryReclaimTask<SpillResult>([probeOp]() {
           try {
             probeOp->spillOutput();
             return std::make_unique<SpillResult>(nullptr);
@@ -1868,8 +1868,8 @@ SpillPartitionSet HashProbe::spillTable() {
     if (rowContainer->numRows() == 0) {
       continue;
     }
-    spillTasks.push_back(
-        std::make_shared<AsyncSource<SpillResult>>([this, rowContainer]() {
+    spillTasks.push_back(memory::createAsyncMemoryReclaimTask<SpillResult>(
+        [this, rowContainer]() {
           try {
             return std::make_unique<SpillResult>(spillTable(rowContainer));
           } catch (const std::exception& e) {


### PR DESCRIPTION
The async source depends on memory module to setup memory arbitration context.
The global memory arbitration optimization might also need the async source to parallelize
the query spill so it can cause circular dependency. The memory arbitration context will
only be used by memory reclamation so it is not necessary be part of base lib. This PR keeps
previous async memory reclaim callback to handle the memory arbitration context setup to
remove this dependency.