### PR TITLE
Optimized the 'tobitmask' for Arm64.

### DIFF
--- a/velox/common/base/BitUtil.h
+++ b/velox/common/base/BitUtil.h
@@ -118,6 +118,18 @@ inline int32_t getAndClearLastSetBit(uint16_t& bits) {
   return trailingZeros;
 }
 
+#if __ARM_ARCH
+inline int32_t arm64_getAndClearLastSetBit(uint64_t& bits) {
+  int32_t trailingZeros = __builtin_ctzll(bits) >> 2;
+  // erase last 4 non-zero bit
+  bits &= bits - 1;
+  bits &= bits - 1;
+  bits &= bits - 1;
+  bits &= bits - 1;
+  return trailingZeros;
+}
+#endif
+
 /**
  * Invokes a function for each batch of bits (partial or full words)
  * in a given range.

--- a/velox/common/base/SimdUtil-inl.h
+++ b/velox/common/base/SimdUtil-inl.h
@@ -90,6 +90,10 @@ struct BitMask<T, A, 1> {
     uint8x16_t vmask = vshlq_u8(vandq_u8(mask, vdupq_n_u8(0x80)), vshift);
     return (vaddv_u8(vget_high_u8(vmask)) << 8) | vaddv_u8(vget_low_u8(vmask));
   }
+
+  static uint64_t arm64ToBitMask(xsimd::batch_bool<T, A> mask, const xsimd::neon&) {
+    return vget_lane_u64(vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(mask), 4)), 0);
+  }
 #endif
 };
 
@@ -114,6 +118,12 @@ struct BitMask<T, A, 2> {
   }
 #endif
 
+#if XSIMD_WITH_NEON
+  static uint64_t arm64ToBitMask(xsimd::batch_bool<T, A> mask, const xsimd::neon&) {
+    return vget_lane_u64(vreinterpret_u64_u8(vshrn_n_u16(mask, 4)), 0);
+  }
+#endif
+
   static int toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::generic&) {
     return genericToBitMask(mask);
   }
@@ -132,6 +142,12 @@ struct BitMask<T, A, 4> {
 #if XSIMD_WITH_SSE2
   static int toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::sse2&) {
     return _mm_movemask_ps(reinterpret_cast<__m128>(mask.data));
+  }
+#endif
+
+#if XSIMD_WITH_NEON
+  static uint64_t arm64ToBitMask(xsimd::batch_bool<T, A> mask, const xsimd::neon&) {
+    return vget_lane_u64(vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u32(mask), 4)), 0);
   }
 #endif
 
@@ -159,6 +175,12 @@ struct BitMask<T, A, 8> {
 #if XSIMD_WITH_SSE2
   static int toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::sse2&) {
     return _mm_movemask_pd(reinterpret_cast<__m128d>(mask.data));
+  }
+#endif
+
+#if XSIMD_WITH_NEON
+  static uint64_t arm64ToBitMask(xsimd::batch_bool<T, A> mask, const xsimd::neon&) {
+    return vget_lane_u64(vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u64(mask), 4)), 0);
   }
 #endif
 

--- a/velox/common/base/SimdUtil.h
+++ b/velox/common/base/SimdUtil.h
@@ -294,6 +294,13 @@ auto toBitMask(xsimd::batch_bool<T, A> mask, const A& arch = {}) {
   return detail::BitMask<T, A>::toBitMask(mask, arch);
 }
 
+#if __ARM_ARCH
+template <typename T, typename A = xsimd::default_arch>
+auto arm64ToBitMask(xsimd::batch_bool<T, A> mask, const A& arch = {}) {
+  return detail::BitMask<T, A>::arm64ToBitMask(mask, arch);
+}
+#endif
+
 // Get a vector mask from bit mask.
 template <typename T, typename BitMaskType, typename A = xsimd::default_arch>
 xsimd::batch_bool<T, A> fromBitMask(BitMaskType bitMask, const A& arch = {}) {

--- a/velox/type/tests/FilterBenchmark.cpp
+++ b/velox/type/tests/FilterBenchmark.cpp
@@ -46,7 +46,12 @@ int32_t run4x64(const std::vector<int64_t>& data) {
   assert(data.size() % kStep == 0);
   for (auto i = 0; i < data.size(); i += kStep) {
     auto result = filter->testValues(xsimd::load_unaligned(data.data() + i));
+
+#if __ARM_ARCH
+    count += __builtin_popcountll(simd::arm64ToBitMask(result) & 0x8000000080000000);
+#else
     count += __builtin_popcount(simd::toBitMask(result));
+#endif
   }
   return count;
 }


### PR DESCRIPTION
1. Added Arm64 implementation of `tobitmask`.
It's Arm64 equivalent implementation for x86 `movemasks`.
The implementation idea is from:
https://community.arm.com/arm-community-blogs/b/infrastructure-solutions-blog/posts/porting-x86-vector-bitmask-optimizations-to-arm-neon

3. The all cases in `velox_exec_test` were passed.
4. `velox_filter_benchmark`: 

Original:
```
[root@c542207d9649 tests]# ./velox_filter_benchmark
WARNING: Benchmark running in DEBUG mode
============================================================================
[...]/velox/type/tests/FilterBenchmark.cpp     relative  time/iter   iters/s
============================================================================
scalarDense                                                 5.58ms    179.33
simdDense                                       51.841%    10.76ms     92.97
scalarSparse                                                1.94ms    514.79
simdSparse                                      80.786%     2.40ms    415.88
```

Optimized:
```
[root@c542207d9649 tests]# ./velox_filter_benchmark
WARNING: Benchmark running in DEBUG mode
============================================================================
[...]/velox/type/tests/FilterBenchmark.cpp     relative  time/iter   iters/s
============================================================================
scalarDense                                                 5.59ms    178.95
simdDense                                       55.537%    10.06ms     99.38
scalarSparse                                                1.94ms    515.24
simdSparse                                      98.249%     1.98ms    506.22

```

5.  This PR firstly provided the Arm64 `tobitmask` API.  And the next step (will be in the other separated PR): 
Adjust `arm64bitmask` caller API in `Hashtable.cpp` to accelerate `HashJoin` performace on Arm64.
