### PR TITLE
Add a faster string-search method with simd instructions than std::find

### DIFF
--- a/velox/common/base/SimdUtil.cpp
+++ b/velox/common/base/SimdUtil.cpp
@@ -62,6 +62,7 @@ const LeadingMask<int64_t, xsimd::default_arch> leadingMask64;
 const FromBitMask<int32_t, xsimd::default_arch> fromBitMask32;
 const FromBitMask<int64_t, xsimd::default_arch> fromBitMask64;
 
+const int kPageSize = sysconf(_SC_PAGESIZE);
 } // namespace detail
 
 namespace {

--- a/velox/common/base/SimdUtil.h
+++ b/velox/common/base/SimdUtil.h
@@ -497,6 +497,9 @@ xsimd::batch<T, A> reinterpretBatch(xsimd::batch<U, A>, const A& = {});
 template <typename A = xsimd::default_arch>
 inline bool memEqualUnsafe(const void* x, const void* y, int32_t size);
 
+FOLLY_ALWAYS_INLINE size_t
+simdStrstr(const char* s, size_t n, const char* needle, size_t k);
+
 } // namespace facebook::velox::simd
 
 #include "velox/common/base/SimdUtil-inl.h"

--- a/velox/common/base/benchmarks/CMakeLists.txt
+++ b/velox/common/base/benchmarks/CMakeLists.txt
@@ -17,3 +17,9 @@ target_link_libraries(
   velox_common_base_benchmarks
   PUBLIC ${FOLLY_BENCHMARK}
   PRIVATE velox_common_base Folly::folly)
+
+add_executable(velox_common_stringsearch_benchmarks StringSearchBenchmark.cpp)
+target_link_libraries(
+  velox_common_stringsearch_benchmarks
+  PUBLIC ${FOLLY_BENCHMARK}
+  PRIVATE velox_common_base Folly::folly)

--- a/velox/common/base/benchmarks/StringSearchBenchmark.cpp
+++ b/velox/common/base/benchmarks/StringSearchBenchmark.cpp
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/FBString.h>
+
+#include <cstdlib>
+#include <fstream>
+#include <list>
+#include <random>
+#include <sstream>
+
+#include <folly/Benchmark.h>
+#include <folly/Random.h>
+#include <folly/container/Foreach.h>
+#include <folly/portability/GFlags.h>
+
+#include <iostream>
+
+#include "velox/common/base/SimdUtil.h"
+
+/// Copy Part code from
+/// https://github.com/facebook/folly/blob/ce5edfb9b08ead9e78cb46879e7b9499861f7cd2/folly/test/FBStringTestBenchmarks.cpp.h
+using namespace std;
+using namespace folly;
+/// Fixed seed for stable benchmark result, simdStrStr is always faster than
+/// std::find with different seeds.
+static const int seed = 123456;
+static std::mt19937 rng(seed);
+
+namespace facebook::velox {
+template <class Integral1, class Integral2>
+Integral2 random(Integral1 low, Integral2 up) {
+  std::uniform_int_distribution<> range(low, up);
+  return range(rng);
+}
+
+enum ALG { SIMD, STD, KMP, BOYER_MOORE };
+
+class KmpSearcher {
+ public:
+  KmpSearcher(const std::string& needle) : needle_(std::move(needle)) {
+    next_ = new int[1 + needle.size()];
+    initNextArr(needle);
+  }
+
+  ~KmpSearcher() {
+    delete[] next_;
+  }
+
+  size_t search(const char* heyStack, size_t heyStackSize) const {
+    int i = 0, j = 0;
+    while ((i < (int32_t)heyStackSize) && (j < (int32_t)needle_.size())) {
+      if (j == -1 || heyStack[i] == needle_[j]) {
+        i++;
+        j++;
+      } else {
+        j = next_[j];
+      }
+    }
+    if (j >= needle_.size()) {
+      return (i - needle_.size());
+    };
+    return (std::string::npos);
+  }
+
+ private:
+  void initNextArr(const string& needle) {
+    int j = 0, k = -1;
+    next_[0] = -1;
+    for (; j < needle.length();) {
+      if (k == -1 || needle[j] == needle[k]) {
+        j++;
+        k++;
+        next_[j] = k;
+      } else
+        k = next_[k];
+    }
+  }
+  std::string needle_;
+  int* next_;
+};
+
+class TestStringSearch {
+ public:
+  TestStringSearch(const std::string& heyStack, const std::string& needle)
+      : heyStack_(std::move(heyStack)),
+        needle_(std::move(needle)),
+        searher_(needle_.begin(), needle_.end()),
+        kmpSearcher_(needle_) {}
+
+  template <ALG alg>
+  void runSearching(size_t iters) const {
+    if constexpr (alg == SIMD) {
+      FOR_EACH_RANGE (i, 0, iters)
+        doNotOptimizeAway(simd::simdStrstr(
+            heyStack_.data(),
+            heyStack_.size(),
+            needle_.data(),
+            needle_.size()));
+    } else if constexpr (alg == STD) {
+      FOR_EACH_RANGE (i, 0, iters)
+        doNotOptimizeAway(
+            std::string_view(heyStack_.data(), heyStack_.size())
+                .find(std::string_view(needle_.data(), needle_.size())));
+    } else if constexpr (alg == BOYER_MOORE) {
+      FOR_EACH_RANGE (i, 0, iters)
+        doNotOptimizeAway(
+            std::search(heyStack_.begin(), heyStack_.end(), searher_));
+    } else if constexpr (alg == KMP) {
+      FOR_EACH_RANGE (i, 0, iters)
+        doNotOptimizeAway(
+            kmpSearcher_.search(heyStack_.data(), heyStack_.size()));
+    }
+  }
+
+ private:
+  std::string heyStack_;
+  std::string needle_;
+  std::boyer_moore_searcher<std::string::iterator> searher_;
+  KmpSearcher kmpSearcher_;
+};
+
+TestStringSearch generateTest(int hayStackSize, int needleSize) {
+  // Text courtesy (ahem) of
+  // http://www.psychologytoday.com/blog/career-transitions/200906/
+  // the-dreaded-writing-sample
+  // 1028chars
+  static const std::string s =
+      "\
+Even if you've mastered the art of the cover letter and the resume, \
+another part of the job search process can trip up an otherwise \
+qualified candidate: the writing sample.\n\
+\n\
+Strong writing and communication skills are highly sought after by \
+most employers. Whether crafting short emails or lengthy annual \
+reports, many workers use their writing skills every day. And for an \
+employer seeking proof behind that ubiquitous candidate \
+phrase,\"excellent communication skills\", a required writing sample \
+is invaluable.\n\
+\n\
+Writing samples need the same care and attention given to cover \
+letters and resumes. Candidates with otherwise impeccable credentials \
+are routinely eliminated by a poorly chosen writing sample. Notice I \
+said \"poorly chosen\" not \"poorly written.\" Because that's the rub: \
+a writing sample not only reveals the individual's writing skills, it \
+also offers a peek into what they consider important or relevant for \
+the position. If you miss that mark with your writing sample, don't \
+expect to get a call for an interview.";
+  auto pos = random(0, s.size() - hayStackSize);
+  auto needlePos = random(2, hayStackSize - needleSize);
+  std::string haystack = s.substr(pos, hayStackSize);
+  std::string needle = haystack.substr(needlePos, needleSize);
+  return TestStringSearch(std::move(haystack), std::move(needle));
+}
+
+void findSuccessful(
+    unsigned /*arg*/,
+    ALG alg,
+    size_t iters,
+    const TestStringSearch& testdata) {
+  switch (alg) {
+    case KMP:
+      testdata.runSearching<KMP>(iters);
+      break;
+    case STD:
+      testdata.runSearching<STD>(iters);
+      break;
+    case SIMD:
+      testdata.runSearching<SIMD>(iters);
+      break;
+    case BOYER_MOORE:
+      testdata.runSearching<BOYER_MOORE>(iters);
+      break;
+  }
+}
+
+/// Folly uses random test data for each iteration, but this cannot guarantee
+/// that the data for each test of different algorithms is the same, so we use
+/// the same random data for each comparison benchmark here.
+#define STRING_SEARCH_BENCHMARK(name, start, end, iters)             \
+  TestStringSearch test##start##end = generateTest(start, end);      \
+  BENCHMARK_NAMED_PARAM(                                             \
+      name, simd_##start##_to_##end, SIMD, iters, test##start##end); \
+  BENCHMARK_NAMED_PARAM(                                             \
+      name, std_##start##_to_##end, STD, iters, test##start##end);   \
+  BENCHMARK_NAMED_PARAM(                                             \
+      name,                                                          \
+      std_boyer_moore_##start##_to_##end,                            \
+      BOYER_MOORE,                                                   \
+      iters,                                                         \
+      test##start##end);                                             \
+                                                                     \
+  BENCHMARK_NAMED_PARAM(                                             \
+      name, kmp_##start##_to_##end, KMP, iters, test##start##end);
+
+STRING_SEARCH_BENCHMARK(findSuccessful, 50, 5, 52428800)
+STRING_SEARCH_BENCHMARK(findSuccessful, 100, 10, 52428800)
+STRING_SEARCH_BENCHMARK(findSuccessful, 100, 20, 52428800)
+STRING_SEARCH_BENCHMARK(findSuccessful, 1000, 10, 52428800)
+STRING_SEARCH_BENCHMARK(findSuccessful, 1000, 100, 5242880)
+STRING_SEARCH_BENCHMARK(findSuccessful, 1000, 200, 5242880)
+
+/// std::find only handle fast-path for prefix-unmatch-char, if there is a
+/// prefix-match-char(in practice, it is a high probability event that a
+/// first char match is successful.), the performance of std::find drops
+/// significantly in such a scenario.
+TestStringSearch prefixMatch = {
+    "luffily close dugouts wake about the pinto beans. pending, ironic dependencies",
+    "b???"};
+
+TestStringSearch prefixUnMatch = {
+    "luffily close dugouts wake about the pinto beans. pending, ironic dependencies",
+    "????"};
+void findUnsuccessful(
+    size_t /*arg*/,
+    bool useStd,
+    size_t iters,
+    const TestStringSearch& test) {
+  if (useStd) {
+    test.runSearching<STD>(iters);
+  } else {
+    test.runSearching<SIMD>(iters);
+  }
+}
+
+BENCHMARK_NAMED_PARAM(
+    findUnsuccessful,
+    std_first_char_match,
+    true,
+    52428800,
+    prefixMatch)
+BENCHMARK_NAMED_PARAM(
+    findUnsuccessful,
+    opt_first_char_match,
+    false,
+    52428800,
+    prefixMatch)
+BENCHMARK_NAMED_PARAM(
+    findUnsuccessful,
+    std_first_char_unmatch,
+    true,
+    52428800,
+    prefixUnMatch)
+BENCHMARK_NAMED_PARAM(
+    findUnsuccessful,
+    opt_first_char_unmatch,
+    false,
+    52428800,
+    prefixUnMatch)
+} // namespace facebook::velox
+
+int main(int argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  folly::runBenchmarks();
+  return 0;
+}


### PR DESCRIPTION
### Description
In practice, c_strstr is always faster than std::find in most cases, refer to [1]. However, the c_strstr interface will truncate '\0', which makes it unable to handle unicode characters. In addition, glibc uses two-way- search, see[2], but it does not seem to be exposed as a common interface. It requires some additional code to determine the best path. In some scenarios, the decision-making code may cause performance degradation.

### Solution
There are many optimization algorithms for string-search, refer to [7], but they cannot change the essence of the problem, which is a search process of O(n*m) complexity. I think the most common way to improve performance is to optimize the search instructions. For example, doris (the same is true for clickhouse, this part of the code of doris was copied from clickhouse, and the Volnitsky[11] part was removed), see [5].
This PR refers to the implementation of [5], [6], [8] ：
[5] doris : first-two comapre first, and  the issue of page-safe was also mentioned
[6] stringzilla: first-mid-lst compare first
[8] simd-strstr implement by WojciechMula, first-lst comapre first.

They all look few chars first, the more chars you choose to look the higher probability of hitting the optimized path, and the more cost  of 'optimized path' itself.

In the end, the solution I chose is to first compare first-last-chars and then compare the remaining bytes. This is because in practice, our users seem to be able to get the matching results through first-last-chars.

**ut & benchmark**
This part of the code refers to folly’s test code, see [9] [10], of course, some adjustments have been made based on the code implementation.

### Benchmark : std::find vs simdStrStr:

findSuccessful(opt_50_5)                                   31.66ms     31.59
findSuccessful(opt_100_10)                                 36.81ms     27.16
findSuccessful(opt_100_20)                                 96.47ms     10.37
findSuccessful(opt_1k_10)                                  63.27ms     15.81
findSuccessful(opt_1k_100)                                156.95ms      6.37
findSuccessful(std_50_5)                                   45.24ms     22.11
findSuccessful(std_100_10)                                191.23ms      5.23
findSuccessful(std_100_20)                                322.11ms      3.10
findSuccessful(std_1k_10)                                 122.69ms      8.15
findSuccessful(std_1k_100)                                168.10ms      5.95
findUnsuccessful(std_first_char_match)                    819.13ms      1.22
findUnsuccessful(opt_first_char_match)                    261.46ms      3.82
findUnsuccessful(std_first_char_unmatch)                  249.12ms      4.01
findUnsuccessful(opt_first_char_unmatch)                  199.02ms      5.02

### References

[1] gcc std::search issue:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66414
[2] glibc strstr implements:
https://github.com/lattera/glibc/blob/master/string/strstr.c
[3] two way search:
http://www-igm.univ-mlv.fr/~lecroq/string/node26.html#SECTION00260
[4] std::boyer_moore_searcher
https://en.cppreference.com/w/cpp/utility/functional/boyer_moore_searcher
https://github.com/mclow/search-library?tab=readme-ov-file
[5] doris string-search
https://github.com/apache/doris/blob/4e326e5f496109edb253d094869d057573ab7a59/be/src/vec/common/string_searcher.h#L44
[6] stringzilla
https://github.com/ashvardanian/StringZilla/blob/main/include/stringzilla/stringzilla.h#L2187
[7] string-search algorithms
https://www-igm.univ-mlv.fr/~lecroq/string/
[8] sse4 strst
https://github.com/WojciechMula/sse4-strstr
[9] folly benchmark
https://github.com/facebook/folly/blob/ce5edfb9b08ead9e78cb46879e7b9499861f7cd2/folly/test/FBStringTestBenchmarks.cpp.h
[10] folly ut
https://github.com/facebook/folly/blob/ce5edfb9b08ead9e78cb46879e7b9499861f7cd2/folly/test/FBStringTest.cpp#L1277
[11] clickhouse Volnitsky
https://github.com/ClickHouse/ClickHouse/blob/a51f867ce014a4cb8f97c46e004b90f5feafd80f/src/Common/Volnitsky.h#L482