### PR TITLE
Remove SeekableInputStream.h include from FormatData.h

### DIFF
--- a/velox/dwio/common/FormatData.h
+++ b/velox/dwio/common/FormatData.h
@@ -18,7 +18,6 @@
 
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/ScanSpec.h"
-#include "velox/dwio/common/SeekableInputStream.h"
 #include "velox/dwio/common/Statistics.h"
 #include "velox/dwio/common/TypeWithId.h"
 #include "velox/type/Filter.h"

--- a/velox/dwio/common/FormatData.h
+++ b/velox/dwio/common/FormatData.h
@@ -23,6 +23,8 @@
 #include "velox/type/Filter.h"
 
 namespace facebook::velox::dwio::common {
+/// Defined in SeekableInputStream.h
+class PositionProvider;
 
 /// Interface base class for format-specific state in common between different
 /// file format readers.
@@ -39,7 +41,7 @@ class FormatData {
   /// data. If there are no nulls, 'nulls' is set to nullptr, else to
   /// a suitable sized and padded Buffer. 'incomingNulls' may be given
   /// if there are enclosing level nulls that should be merged into
-  /// the read reasult. If provided, this has 'numValues' bits and
+  /// the read result. If provided, this has 'numValues' bits and
   /// each zero marks an incoming null for which no bit is read from
   /// the nulls stream of 'this'. For Parquet, 'nulls' is always set
   /// to nullptr because nulls are represented by the data pages

--- a/velox/dwio/common/FormatData.h
+++ b/velox/dwio/common/FormatData.h
@@ -17,14 +17,13 @@
 #pragma once
 
 #include "velox/common/memory/Memory.h"
+#include "velox/dwio/common/PositionProvider.h"
 #include "velox/dwio/common/ScanSpec.h"
 #include "velox/dwio/common/Statistics.h"
 #include "velox/dwio/common/TypeWithId.h"
 #include "velox/type/Filter.h"
 
 namespace facebook::velox::dwio::common {
-/// Defined in SeekableInputStream.h
-class PositionProvider;
 
 /// Interface base class for format-specific state in common between different
 /// file format readers.

--- a/velox/dwio/common/PositionProvider.h
+++ b/velox/dwio/common/PositionProvider.h
@@ -16,52 +16,22 @@
 
 #pragma once
 
-#include "velox/dwio/common/exception/Exception.h"
+#include <vector>
 
 namespace facebook::velox::dwio::common {
 
-// Base class for closeable object which need to be explicitly closed before
-// being destructed
-class Closeable {
+class PositionProvider {
  public:
-  Closeable() : closed_{false} {}
+  explicit PositionProvider(const std::vector<uint64_t>& positions)
+      : position_{positions.begin()}, end_{positions.end()} {}
 
-  virtual ~Closeable() {
-    destroy();
-  }
+  uint64_t next();
 
-  bool isClosed() const {
-    return closed_;
-  }
-
-  void close() {
-    if (!closed_) {
-      closed_ = true;
-      doClose();
-    }
-  }
-
- protected:
-  void markClosed() {
-    closed_ = true;
-  }
-
-  virtual void doClose() {}
-
-  void destroy() {
-    if (!closed_) {
-      DWIO_WARN_EVERY_N(1000, "close() not called");
-      try {
-        close();
-      } catch (...) {
-        DWIO_WARN("failed to call close()");
-      }
-    }
-    DWIO_ENSURE(closed_);
-  }
+  bool hasNext() const;
 
  private:
-  bool closed_;
+  std::vector<uint64_t>::const_iterator position_;
+  std::vector<uint64_t>::const_iterator end_;
 };
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/SeekableInputStream.h
+++ b/velox/dwio/common/SeekableInputStream.h
@@ -16,29 +16,14 @@
 
 #pragma once
 
-#include <vector>
-
 #include "velox/dwio/common/DataBuffer.h"
 #include "velox/dwio/common/InputStream.h"
+#include "velox/dwio/common/PositionProvider.h"
 #include "velox/dwio/common/wrap/zero-copy-stream-wrapper.h"
 
 namespace facebook::velox::dwio::common {
 
 void printBuffer(std::ostream& out, const char* buffer, uint64_t length);
-
-class PositionProvider {
- public:
-  explicit PositionProvider(const std::vector<uint64_t>& positions)
-      : position_{positions.begin()}, end_{positions.end()} {}
-
-  uint64_t next();
-
-  bool hasNext() const;
-
- private:
-  std::vector<uint64_t>::const_iterator position_;
-  std::vector<uint64_t>::const_iterator end_;
-};
 
 /**
  * A subclass of Google's ZeroCopyInputStream that supports seek.


### PR DESCRIPTION
SeekableInputStream.h is causing the protobuf dependency to leak into Velox clients. 
Move the PositionProvider class to its own file.

```
In file included from /Users/reetikaagrawal/Documents/Projects/Oss/prestodb-hivepoc/prestodb/presto-native-execution/velox/velox/connectors/hive/iceberg/IcebergSplitReader.cpp:17:
In file included from /Users/reetikaagrawal/Documents/Projects/Oss/prestodb-hivepoc/prestodb/presto-native-execution/velox/velox/connectors/hive/iceberg/IcebergSplitReader.h:21:
In file included from /Users/reetikaagrawal/Documents/Projects/Oss/prestodb-hivepoc/prestodb/presto-native-execution/velox/velox/connectors/hive/iceberg/PositionalDeleteFileReader.h:26:
In file included from /Users/reetikaagrawal/Documents/Projects/Oss/prestodb-hivepoc/prestodb/presto-native-execution/velox/velox/dwio/common/Reader.h:27:
In file included from /Users/reetikaagrawal/Documents/Projects/Oss/prestodb-hivepoc/prestodb/presto-native-execution/velox/velox/dwio/common/SelectiveColumnReader.h:22:
In file included from /Users/reetikaagrawal/Documents/Projects/Oss/prestodb-hivepoc/prestodb/presto-native-execution/velox/velox/dwio/common/FormatData.h:21:
In file included from /Users/reetikaagrawal/Documents/Projects/Oss/prestodb-hivepoc/prestodb/presto-native-execution/velox/velox/dwio/common/SeekableInputStream.h:23:
/Users/reetikaagrawal/Documents/Projects/Oss/prestodb-hivepoc/prestodb/presto-native-execution/velox/velox/dwio/common/wrap/zero-copy-stream-wrapper.h:31:10: fatal error: 'google/protobuf/io/zero_copy_stream.h' file not found
#include <google/protobuf/io/zero_copy_stream.h>
```
See https://github.com/prestodb/presto/issues/23528