### PR TITLE
Handle Multi-Char delims in split_to_map function

### DIFF
--- a/velox/functions/prestosql/SplitToMap.h
+++ b/velox/functions/prestosql/SplitToMap.h
@@ -105,7 +105,7 @@ struct SplitToMapFunction {
           onDuplicateKey,
           keyValuePairs));
 
-      pos = nextEntryPos + 1;
+      pos = nextEntryPos + entryDelimiter.size();
       nextEntryPos = input.find(entryDelimiter, pos);
     }
 
@@ -143,14 +143,17 @@ struct SplitToMapFunction {
             "No delimiter found. Key-value delimiter must appear exactly once in each entry. Bad input: '{}'",
             entry));
     VELOX_RETURN_IF(
-        entry.find(keyValueDelimiter, delimiterPos + 1) != std::string::npos,
+        entry.find(
+            keyValueDelimiter, delimiterPos + keyValueDelimiter.size()) !=
+            std::string::npos,
         Status::UserError(
             "More than one delimiter found. Key-value delimiter must appear exactly once in each entry. Bad input: '{}'",
             entry));
 
     const auto key = std::string_view(entry.data(), delimiterPos);
     const auto value = std::string_view(
-        entry.data() + delimiterPos + 1, entry.size() - delimiterPos - 1);
+        entry.data() + delimiterPos + keyValueDelimiter.size(),
+        entry.size() - delimiterPos - keyValueDelimiter.size());
 
     switch (onDuplicateKey) {
       case OnDuplicateKey::kFail: {


### PR DESCRIPTION
Summary:
Presto split_to_map implementation in velox currently doesnt handle multi-char delims. This creates behavior difference with java presto. This diff fixes the bug. Example:
split_to_map("4;=40,", ',', ';=')" now correctly produce {4, 40}. Without this fix it will produce {4, =40}
Similarly this diff also address the case when EntryDelim contains multiple chars.
Finally, this diff address the cases where KeyValueDelim is substring of EntryDelim.
split_to_map("0;4;;;40;;", ';;', ';')" now correctly produce {{'0', 4}, {'', 40}}

Differential Revision: D61843419
