### PR TITLE
Simplify and optimize duplicate row memory allocations

### DIFF
--- a/velox/common/memory/AllocationPool.h
+++ b/velox/common/memory/AllocationPool.h
@@ -18,13 +18,12 @@
 #include "velox/common/memory/Memory.h"
 
 namespace facebook::velox::memory {
-// A set of Allocations holding the fixed width payload
-// rows. The Runs are filled to the end except for the last one. This
-// is used for iterating over the payload for rehashing, returning
-// results etc. This is used via HashStringAllocator for variable length
-// allocation for backing ByteStreams for complex objects. In that case, there
-// is a current run that is appended to and when this is exhausted a new run is
-// started.
+/// A set of Allocations holding the fixed width payload ows. The Runs are
+/// filled to the end except for the last one. This is used for iterating over
+/// the payload for rehashing, returning results etc. This is used via
+/// HashStringAllocator for variable length allocation for backing ByteStreams
+/// for complex objects. In that case, there is a current run that is appended
+/// to and when this is exhausted a new run is started.
 class AllocationPool {
  public:
   static constexpr int32_t kMinPages = 16;

--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -793,10 +793,4 @@ int64_t HashStringAllocator::checkConsistency() const {
 bool HashStringAllocator::isEmpty() const {
   return state_.sizeFromPool() == 0 && checkConsistency() == 0;
 }
-
-void HashStringAllocator::checkEmpty() const {
-  VELOX_CHECK_EQ(0, state_.sizeFromPool());
-  VELOX_CHECK_EQ(0, checkConsistency());
-}
-
 } // namespace facebook::velox

--- a/velox/common/memory/HashStringAllocator.h
+++ b/velox/common/memory/HashStringAllocator.h
@@ -341,12 +341,6 @@ class HashStringAllocator : public StreamArena {
   /// checkConsistency() which makes it slow. Do not use in hot paths.
   bool isEmpty() const;
 
-  /// Throws if 'this' is not empty. Checks consistency of
-  /// 'this'. This is a fast check for RowContainer users freeing the
-  /// variable length data they store. Can be used in non-debug
-  /// builds.
-  void checkEmpty() const;
-
   std::string toString() const;
 
   /// Effectively makes this immutable while executing f, any attempt to access

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1371,9 +1371,6 @@ void GroupingSet::toIntermediate(
   if (intermediateRows_) {
     intermediateRows_->eraseRows(folly::Range<char**>(
         intermediateGroups_.data(), intermediateGroups_.size()));
-    if (intermediateRows_->checkFree()) {
-      intermediateRows_->stringAllocator().checkEmpty();
-    }
   }
 
   // It's unnecessary to call function->clear() to reset the internal states of

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -636,11 +636,8 @@ uint64_t Operator::MemoryReclaimer::reclaim(
       "facebook::velox::exec::Operator::MemoryReclaimer::reclaim", pool);
 
   // NOTE: we can't reclaim memory from an operator which is under
-  // non-reclaimable section, except for HashBuild operator. If it is HashBuild
-  // operator, we allow it to enter HashBuild::reclaim because there is a good
-  // chance we can release some unused reserved memory even if it's in
   // non-reclaimable section.
-  if (op_->nonReclaimableSection_ && op_->operatorType() != "HashBuild") {
+  if (op_->nonReclaimableSection_) {
     // TODO: reduce the log frequency if it is too verbose.
     ++stats.numNonReclaimableAttempts;
     RECORD_METRIC_VALUE(kMetricMemoryNonReclaimableCount);
@@ -659,12 +656,6 @@ uint64_t Operator::MemoryReclaimer::reclaim(
         {
           memory::ScopedReclaimedBytesRecorder recoder(pool, &reclaimedBytes);
           op_->reclaim(targetBytes, stats);
-        }
-        // NOTE: the parallel hash build is running at the background thread
-        // pool which won't stop during memory reclamation so the operator's
-        // memory usage might increase in such case. memory usage.
-        if (op_->operatorType() == "HashBuild") {
-          reclaimedBytes = std::max<int64_t>(0, reclaimedBytes);
         }
         VELOX_CHECK_GE(
             reclaimedBytes,

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -144,12 +144,12 @@ RowContainer::RowContainer(
     : keyTypes_(keyTypes),
       nullableKeys_(nullableKeys),
       isJoinBuild_(isJoinBuild),
-      accumulators_(accumulators),
       hasNormalizedKeys_(hasNormalizedKeys),
-      rows_(pool),
       stringAllocator_(
           stringAllocator ? stringAllocator
-                          : std::make_shared<HashStringAllocator>(pool)) {
+                          : std::make_shared<HashStringAllocator>(pool)),
+      accumulators_(accumulators),
+      rows_(pool) {
   // Compute the layout of the payload row.  The row has keys, null flags,
   // accumulators, dependent fields. All fields are fixed width. If variable
   // width data is referenced, this is done with StringView(for VARCHAR) and
@@ -392,13 +392,15 @@ int32_t RowContainer::findRows(folly::Range<char**> rows, char** result) {
   return numRows;
 }
 
-void RowContainer::appendNextRow(char* current, char* nextRow) {
+void RowContainer::appendNextRow(
+    char* current,
+    char* nextRow,
+    HashStringAllocator* allocator) {
   VELOX_CHECK(getNextRowVector(nextRow) == nullptr);
   NextRowVector*& nextRowArrayPtr = getNextRowVector(current);
   if (nextRowArrayPtr == nullptr) {
-    nextRowArrayPtr =
-        new (stringAllocator_->allocate(kNextRowVectorSize)->begin())
-            NextRowVector(StlAllocator<char*>(stringAllocator_.get()));
+    nextRowArrayPtr = new (allocator->allocate(kNextRowVectorSize)->begin())
+        NextRowVector(StlAllocator<char*>(allocator));
     hasDuplicateRows_ = true;
     nextRowArrayPtr->emplace_back(current);
   }
@@ -935,8 +937,7 @@ void RowContainer::hash(
 
 void RowContainer::clear() {
   const bool sharedStringAllocator = !stringAllocator_.unique();
-  if (checkFree_ || sharedStringAllocator || usesExternalMemory_ ||
-      hasDuplicateRows_) {
+  if (sharedStringAllocator || usesExternalMemory_) {
     constexpr int32_t kBatch = 1000;
     std::vector<char*> rows(kBatch);
     RowContainerIterator iter;
@@ -944,11 +945,10 @@ void RowContainer::clear() {
       freeRowsExtraMemory(folly::Range<char**>(rows.data(), numRows), true);
     }
   }
+  hasDuplicateRows_ = false;
+
   rows_.clear();
   if (!sharedStringAllocator) {
-    if (checkFree_) {
-      stringAllocator_->checkEmpty();
-    }
     stringAllocator_->clear();
   }
   numRows_ = 0;
@@ -956,18 +956,6 @@ void RowContainer::clear() {
   normalizedKeySize_ = originalNormalizedKeySize_;
   numFreeRows_ = 0;
   firstFreeRow_ = nullptr;
-}
-
-void RowContainer::clearNextRowVectors() {
-  if (hasDuplicateRows_) {
-    constexpr int32_t kBatch = 1000;
-    std::vector<char*> rows(kBatch);
-    RowContainerIterator iter;
-    while (auto numRows = listRows(&iter, kBatch, rows.data())) {
-      freeNextRowVectors(folly::Range<char**>(rows.data(), numRows), true);
-    }
-    hasDuplicateRows_ = false;
-  }
 }
 
 void RowContainer::setProbedFlag(char** rows, int32_t numRows) {

--- a/velox/exec/benchmarks/HashJoinListResultBenchmark.cpp
+++ b/velox/exec/benchmarks/HashJoinListResultBenchmark.cpp
@@ -166,15 +166,18 @@ struct HashTableBenchmarkResult {
 
   double eraseClock{0};
 
+  uint64_t peakMemoryBytes{0};
+
   // The mode of the table.
   BaseHashTable::HashMode hashMode;
 
-  void merge(HashTableBenchmarkResult other) {
-    numIter++;
+  void merge(const HashTableBenchmarkResult& other) {
+    ++numIter;
     buildClocks += other.buildClocks;
     listJoinResultClocks += other.listJoinResultClocks;
     totalClock += other.totalClock;
     eraseClock += other.eraseClock;
+    peakMemoryBytes += other.peakMemoryBytes;
   }
 
   std::string toString() const {
@@ -186,7 +189,8 @@ struct HashTableBenchmarkResult {
         << " listJoinResultClocks=" << listJoinResultClocks << "("
         << (listJoinResultClocks / totalClock * 100)
         << "%) buildClocks=" << buildClocks << "("
-        << (buildClocks / totalClock * 100) << "%)";
+        << (buildClocks / totalClock * 100) << "%)"
+        << " peakMemoryBytes=" << succinctBytes(peakMemoryBytes);
     if (params.runErase) {
       out << " eraseClock=" << eraseClock << "("
           << (eraseClock / totalClock * 100) << "%)";
@@ -201,13 +205,21 @@ class HashTableListJoinResultBenchmark : public VectorTestBase {
       : randomEngine_((std::random_device{}())) {}
 
   HashTableBenchmarkResult run(HashTableBenchmarkParams params) {
+    std::shared_ptr<memory::MemoryPool> tableAggregatePool =
+        rootPool_->addAggregateChild("tableAggregate");
+    std::vector<std::shared_ptr<memory::MemoryPool>> tablePools;
+    tablePools.reserve(params.numTables);
+    for (int i = 0; i < params_.numTables; ++i) {
+      tablePools.push_back(
+          tableAggregatePool->addLeafChild(fmt::format("table{}", i)));
+    }
     params_ = params;
     HashTableBenchmarkResult result;
     result.params = params_;
-    SelectivityInfo totalClock;
+    uint64_t totalClocks{0};
     {
-      SelectivityTimer timer(totalClock, 0);
-      buildTable();
+      ClockTimer timer(totalClocks);
+      buildTable(tablePools);
       result.numOutput = probeTableAndListResult();
       result.hashMode = topTable_->hashMode();
       VELOX_CHECK_EQ(result.hashMode, params_.mode);
@@ -219,8 +231,8 @@ class HashTableListJoinResultBenchmark : public VectorTestBase {
     }
     result.buildClocks += buildTime_;
     result.listJoinResultClocks += listJoinResultTime_;
-    result.totalClock += totalClock.timeToDropValue();
-
+    result.totalClock = totalClocks;
+    result.peakMemoryBytes = tableAggregatePool->peakBytes();
     return result;
   }
 
@@ -348,7 +360,8 @@ class HashTableListJoinResultBenchmark : public VectorTestBase {
   }
 
   // Prepare join table.
-  void buildTable() {
+  void buildTable(
+      const std::vector<std::shared_ptr<memory::MemoryPool>>& tablePools) {
     std::vector<TypePtr> dependentTypes;
     std::vector<std::unique_ptr<BaseHashTable>> otherTables;
     std::vector<RowVectorPtr> batches;
@@ -363,7 +376,7 @@ class HashTableListJoinResultBenchmark : public VectorTestBase {
           true,
           false,
           1'000,
-          pool_.get());
+          tablePools[i].get());
 
       copyVectorsToTable(batches[i], table.get());
       if (i == 0) {
@@ -372,15 +385,15 @@ class HashTableListJoinResultBenchmark : public VectorTestBase {
         otherTables.push_back(std::move(table));
       }
     }
-    SelectivityInfo buildClocks;
+    uint64_t buildClocks{0};
     {
-      SelectivityTimer timer(buildClocks, 0);
+      ClockTimer timer(buildClocks);
       topTable_->prepareJoinTable(
           std::move(otherTables),
           BaseHashTable::kNoSpillInputStartPartitionBit,
           executor_.get());
     }
-    buildTime_ = buildClocks.timeToDropValue();
+    buildTime_ = buildClocks;
   }
 
   void probeTable(
@@ -428,9 +441,8 @@ class HashTableListJoinResultBenchmark : public VectorTestBase {
   // Hash probe and list join result.
   int64_t probeTableAndListResult() {
     auto lookup = std::make_unique<HashLookup>(topTable_->hashers());
-    auto numBatch = params_.probeSize / params_.hashTableSize;
-    auto batchSize = params_.hashTableSize;
-    SelectivityInfo listJoinResultClocks;
+    const auto numBatch = params_.probeSize / params_.hashTableSize;
+    const auto batchSize = params_.hashTableSize;
     BufferPtr outputRowMapping;
     auto outputBatchSize = batchSize;
     std::vector<char*> outputTableRows;
@@ -444,8 +456,9 @@ class HashTableListJoinResultBenchmark : public VectorTestBase {
       auto mapping = initializeRowNumberMapping(
           outputRowMapping, outputBatchSize, pool_.get());
       outputTableRows.resize(outputBatchSize);
+      uint64_t listJoinResultClocks{0};
       {
-        SelectivityTimer timer(listJoinResultClocks, 0);
+        ClockTimer timer(listJoinResultClocks);
         while (!resultsIter.atEnd()) {
           numJoinListResult += topTable_->listJoinResults(
               resultsIter,
@@ -455,8 +468,8 @@ class HashTableListJoinResultBenchmark : public VectorTestBase {
               std::numeric_limits<uint64_t>::max());
         }
       }
+      listJoinResultTime_ += listJoinResultClocks;
     }
-    listJoinResultTime_ = listJoinResultClocks.timeToDropValue();
     return numJoinListResult;
   }
 
@@ -464,7 +477,6 @@ class HashTableListJoinResultBenchmark : public VectorTestBase {
     auto lookup = std::make_unique<HashLookup>(topTable_->hashers());
     auto batchSize = 10000;
     auto mode = topTable_->hashMode();
-    SelectivityInfo eraseClock;
     BufferPtr outputRowMapping;
     auto outputBatchSize = topTable_->rows()->numRows() + 2;
     std::vector<char*> outputTableRows;
@@ -482,12 +494,13 @@ class HashTableListJoinResultBenchmark : public VectorTestBase {
         mapping,
         folly::Range(outputTableRows.data(), outputTableRows.size()),
         std::numeric_limits<uint64_t>::max());
+    uint64_t eraseClocks{0};
     {
-      SelectivityTimer timer(eraseClock, 0);
+      ClockTimer timer(eraseClocks);
       topTable_->rows()->eraseRows(
           folly::Range<char**>(outputTableRows.data(), num));
     }
-    eraseTime_ += eraseClock.timeToDropValue();
+    eraseTime_ = eraseClocks;
   }
 
   std::default_random_engine randomEngine_;

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -5925,29 +5925,22 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringAllocation) {
     ASSERT_EQ(reclaimable, enableSpilling);
     if (enableSpilling) {
       ASSERT_GE(reclaimableBytes, 0);
-      op->reclaim(
-          folly::Random::oneIn(2) ? 0 : folly::Random::rand32(),
-          reclaimerStats_);
     } else {
       ASSERT_EQ(reclaimableBytes, 0);
-      VELOX_ASSERT_THROW(
-          op->reclaim(
-              folly::Random::oneIn(2) ? 0 : folly::Random::rand32(),
-              reclaimerStats_),
-          "");
     }
+    VELOX_ASSERT_THROW(
+        op->reclaim(
+            folly::Random::oneIn(2) ? 0 : folly::Random::rand32(),
+            reclaimerStats_),
+        "");
 
     driverWait.notify();
     Task::resume(task);
     task.reset();
 
     taskThread.join();
-    if (enableSpilling) {
-      ASSERT_GT(reclaimerStats_.reclaimedBytes, 0);
-    } else {
-      ASSERT_EQ(reclaimerStats_, memory::MemoryReclaimer::Stats{0});
-    }
   }
+  ASSERT_EQ(reclaimerStats_, memory::MemoryReclaimer::Stats{0});
 }
 
 DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringOutputProcessing) {

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -1951,15 +1951,15 @@ TEST_F(RowContainerTest, nextRowVector) {
   };
 
   auto validateNextRowVector = [&]() {
-    for (int i = 0; i < rows.size(); i++) {
+    for (int i = 0; i < rows.size(); ++i) {
       auto vector = data->getNextRowVector(rows[i]);
       if (vector) {
         auto iter = std::find(vector->begin(), vector->end(), rows[i]);
-        EXPECT_NE(iter, vector->end());
-        EXPECT_TRUE(vector->size() <= 2 && vector->size() > 0);
+        ASSERT_NE(iter, vector->end());
+        ASSERT_TRUE(vector->size() <= 2 && vector->size() > 0);
         for (auto next : *vector) {
-          EXPECT_EQ(data->getNextRowVector(next), vector);
-          EXPECT_TRUE(std::find(rows.begin(), rows.end(), next) != rows.end());
+          ASSERT_EQ(data->getNextRowVector(next), vector);
+          ASSERT_TRUE(std::find(rows.begin(), rows.end(), next) != rows.end());
         }
       }
     }
@@ -1969,18 +1969,18 @@ TEST_F(RowContainerTest, nextRowVector) {
     for (int i = 0; i < numRows; ++i) {
       rows.push_back(data->newRow());
       rowSet.insert(rows.back());
-      EXPECT_EQ(data->getNextRowVector(rows.back()), nullptr);
+      ASSERT_EQ(data->getNextRowVector(rows.back()), nullptr);
     }
-    EXPECT_EQ(numRows, data->numRows());
+    ASSERT_EQ(numRows, data->numRows());
     std::vector<char*> rowsFromContainer(numRows);
     RowContainerIterator iter;
-    EXPECT_EQ(
+    ASSERT_EQ(
         data->listRows(&iter, numRows, rowsFromContainer.data()), numRows);
-    EXPECT_EQ(0, data->listRows(&iter, numRows, rows.data()));
-    EXPECT_EQ(rows, rowsFromContainer);
+    ASSERT_EQ(0, data->listRows(&iter, numRows, rows.data()));
+    ASSERT_EQ(rows, rowsFromContainer);
 
     for (int i = 0; i + 2 <= numRows; i += 2) {
-      data->appendNextRow(rows[i], rows[i + 1]);
+      data->appendNextRow(rows[i], rows[i + 1], &data->stringAllocator());
     }
     validateNextRowVector();
   };
@@ -2008,7 +2008,6 @@ TEST_F(RowContainerTest, nextRowVector) {
   std::vector<int> eraseRows(numRows);
   std::iota(eraseRows.begin(), eraseRows.end(), 0);
   nextRowVectorEraseValidation(eraseRows);
-
   VELOX_ASSERT_THROW(
       nextRowVectorEraseValidation({1}),
       "All rows with the same keys must be present in 'rows'");


### PR DESCRIPTION
This PR simplifies the duplicate row memory allocations by using dedicated
hash string allocator with one per each partition. All the dedicated hash
string allocators are all backup by the memory pool of the top level hash
table. Then we can simplify the memory reservation in hash build operator
and avoid the unnecessary memory fragements. Now we have to reserve memory
from each of the hash build operator for the worst case of duplicate row
memory allocations.

This PR also make free next row vectors optional which can helps save >10%
cpu cycles in hash join list microbenchmark. The free next row vectors are
not necessary and most for sanity check. Also current implementation does
not guaratee the next row vectors free always get executed as the duplicate
row flag is not set correctly. This PR also fixes this by always passing the
associated row container when do parallel row insertion.