### PR TITLE
feat(build): Switch to use C++20 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,6 +325,24 @@ endif()
 # Required so velox code can be used in a dynamic library
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
+# For C++20 support we need GNU GCC11 (or later versions) or Clang/AppleClang 15
+# (or later versions) to get support for the used features.
+if(NOT
+   (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND ${CMAKE_CXX_COMPILER_VERSION}
+                                                   VERSION_GREATER_EQUAL 11)
+    OR (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"
+         OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+        AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 15)))
+  message(
+    FATAL_ERROR
+      "Unsupported compiler ${CMAKE_CXX_COMPILER_ID} with version ${CMAKE_CXX_COMPILER_VERSION} found."
+  )
+endif()
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+set(CMAKE_CXX_EXTENSIONS ON) # Big Int is an extension
+
 execute_process(
   COMMAND
     bash -c
@@ -385,6 +403,11 @@ if(ENABLE_ALL_WARNINGS)
          -Wno-unused-result \
          -Wno-format-overflow \
          -Wno-strict-aliasing")
+    # Avoid compiler bug for GCC 12.2.1
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "12.2.1")
+      string(APPEND KNOWN_COMPILER_SPECIFIC_WARNINGS " -Wno-restrict")
+    endif()
   endif()
 
   set(KNOWN_WARNINGS
@@ -576,13 +599,6 @@ endif()
 
 # GCC needs to link a library to enable std::filesystem.
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
-
-  # Ensure we have gcc at least 9+.
-  if(CMAKE_CXX_COMPILER_VERSION LESS 9.0)
-    message(
-      FATAL_ERROR "VELOX requires gcc > 9. Found ${CMAKE_CXX_COMPILER_VERSION}")
-  endif()
-
   # Find Threads library
   find_package(Threads REQUIRED)
 endif()

--- a/README.md
+++ b/README.md
@@ -112,6 +112,32 @@ Details on the dependencies and how Velox manages some of them for you
 Velox also provides the following scripts to help developers setup and install Velox
 dependencies for a given platform.
 
+### Supported OS and compiler matrix
+
+The minimum versions of supported compilers:
+
+| OS | Compiler | Version |
+|----|----------|---------|
+| Linux | gcc | 11 |
+| Linux | clang | 15 |
+| macOS | clang | 15 |
+
+The recommended OS versions and compilers:
+
+| OS | Compiler | Version |
+|----|----------|---------|
+| CentOS 9/RHEL 9 | gcc | 12 |
+| Ubuntu 22.04 | gcc | 11 |
+| macOS | clang | 16 |
+
+Alternative combinations:
+
+| OS | Compiler | Version |
+|----|----------|---------|
+| CentOS 9/RHEL 9 | gcc | 11 |
+| Ubuntu 20.04 | gcc | 11 |
+| Ubuntu 24.04 | clang | 15 |
+
 ### Setting up dependencies
 
 The following setup scripts use the `DEPENDENCY_DIR` environment variable to set the

--- a/velox/common/base/CMakeLists.txt
+++ b/velox/common/base/CMakeLists.txt
@@ -43,7 +43,12 @@ velox_add_library(
 velox_link_libraries(
   velox_common_base
   PUBLIC velox_exception Folly::folly fmt::fmt xsimd
-  PRIVATE velox_common_compression velox_process velox_test_util glog::glog)
+  PRIVATE
+    velox_caching
+    velox_common_compression
+    velox_process
+    velox_test_util
+    glog::glog)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/common/base/Semaphore.h
+++ b/velox/common/base/Semaphore.h
@@ -63,8 +63,8 @@ class Semaphore {
  private:
   std::mutex mutex_;
   std::condition_variable cv_;
-  volatile int32_t count_;
-  volatile int32_t numWaiting_{0};
+  int32_t count_;
+  int32_t numWaiting_{0};
 };
 
 } // namespace facebook::velox

--- a/velox/common/base/tests/ExceptionTest.cpp
+++ b/velox/common/base/tests/ExceptionTest.cpp
@@ -41,7 +41,7 @@ struct fmt::formatter<Counter> {
   template <typename FormatContext>
   auto format(const Counter& c, FormatContext& ctx) const {
     auto x = c.counter++;
-    return format_to(ctx.out(), "{}", x);
+    return fmt::format_to(ctx.out(), "{}", x);
   }
 };
 

--- a/velox/common/base/tests/Memcpy.cpp
+++ b/velox/common/base/tests/Memcpy.cpp
@@ -74,7 +74,7 @@ int main(int argc, char** argv) {
   Semaphore sem(0);
   std::vector<CopyCallable> ops;
   ops.resize(FLAGS_threads);
-  volatile uint64_t totalSum = 0;
+  uint64_t totalSum = 0;
   uint64_t totalUsec = 0;
   for (auto repeat = 0; repeat < FLAGS_repeats; ++repeat) {
     // Read once through 'other' to clear cache effects.

--- a/velox/common/caching/tests/CMakeLists.txt
+++ b/velox/common/caching/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_test(simple_lru_cache_test simple_lru_cache_test)
 target_link_libraries(
   simple_lru_cache_test
   PRIVATE
+    velox_common_base
     Folly::folly
     velox_time
     glog::glog
@@ -50,7 +51,7 @@ add_test(cached_factory_test cached_factory_test)
 target_link_libraries(
   cached_factory_test
   PRIVATE
-    velox_process
+    velox_common_base
     Folly::folly
     velox_time
     glog::glog

--- a/velox/common/encode/tests/CMakeLists.txt
+++ b/velox/common/encode/tests/CMakeLists.txt
@@ -21,5 +21,6 @@ target_link_libraries(
     velox_encode
     velox_exception
     velox_status
+    velox_common_base
     GTest::gtest
     GTest::gtest_main)

--- a/velox/common/fuzzer/ConstrainedGenerators.h
+++ b/velox/common/fuzzer/ConstrainedGenerators.h
@@ -82,7 +82,7 @@ template <typename T>
 class RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, StringView>>>
     : public AbstractInputGenerator {
  public:
-  RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, StringView>>>(
+  RandomInputGenerator(
       size_t seed,
       const TypePtr& type,
       double nullRatio,
@@ -98,8 +98,7 @@ class RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, StringView>>>
         encodings_{encodings},
         randomStrVariationOptions_{randomStrVariationOptions} {}
 
-  ~RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, StringView>>>()
-      override = default;
+  ~RandomInputGenerator() override = default;
 
   variant generate() override {
     if (coinToss(rng_, nullRatio_)) {
@@ -126,7 +125,7 @@ template <typename T>
 class RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, ArrayType>>>
     : public AbstractInputGenerator {
  public:
-  RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, ArrayType>>>(
+  RandomInputGenerator(
       size_t seed,
       const TypePtr& type,
       double nullRatio,
@@ -143,8 +142,7 @@ class RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, ArrayType>>>
         containAtIndex_{containAtIndex},
         containGenerator_{std::move(containGenerator)} {}
 
-  ~RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, ArrayType>>>()
-      override = default;
+  ~RandomInputGenerator() override = default;
 
   variant generate() override {
     if (coinToss(rng_, nullRatio_)) {
@@ -180,7 +178,7 @@ template <typename T>
 class RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, MapType>>>
     : public AbstractInputGenerator {
  public:
-  RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, MapType>>>(
+  RandomInputGenerator(
       size_t seed,
       const TypePtr& type,
       double nullRatio,
@@ -207,8 +205,7 @@ class RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, MapType>>>
     }
   }
 
-  ~RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, MapType>>>()
-      override = default;
+  ~RandomInputGenerator() override = default;
 
   variant generate() override {
     if (coinToss(rng_, nullRatio_)) {
@@ -248,7 +245,7 @@ template <typename T>
 class RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, RowType>>>
     : public AbstractInputGenerator {
  public:
-  RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, RowType>>>(
+  RandomInputGenerator(
       size_t seed,
       const TypePtr& type,
       std::vector<std::unique_ptr<AbstractInputGenerator>> fieldGenerators,
@@ -267,8 +264,7 @@ class RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, RowType>>>
     }
   }
 
-  ~RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, RowType>>>()
-      override = default;
+  ~RandomInputGenerator() override = default;
 
   variant generate() override {
     if (coinToss(rng_, nullRatio_)) {

--- a/velox/connectors/hive/HiveConnectorSplit.h
+++ b/velox/connectors/hive/HiveConnectorSplit.h
@@ -106,6 +106,8 @@ struct HiveConnectorSplit : public connector::ConnectorSplit {
         rowIdProperties(_rowIdProperties),
         bucketConversion(_bucketConversion) {}
 
+  ~HiveConnectorSplit() = default;
+
   std::string toString() const override;
 
   std::string getFileName() const;

--- a/velox/duckdb/conversion/tests/CMakeLists.txt
+++ b/velox/duckdb/conversion/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_test(velox_duckdb_conversion_test velox_duckdb_conversion_test)
 target_link_libraries(
   velox_duckdb_conversion_test
   velox_duckdb_parser
+  velox_common_base
   velox_parse_expression
   velox_functions_prestosql
   velox_functions_lib

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -334,7 +334,7 @@ class SelectiveColumnReader {
   template <typename T>
   inline void addValue(T value) {
     static_assert(
-        std::is_pod_v<T>,
+        std::is_standard_layout_v<T>,
         "General case of addValue is only for primitive types");
     VELOX_DCHECK_NOT_NULL(rawValues_);
     VELOX_DCHECK_LE((numValues_ + 1) * sizeof(T), values_->capacity());

--- a/velox/dwio/parquet/tests/writer/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/writer/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(
   velox_dwio_parquet_writer
   velox_dwio_common_test_utils
   velox_vector_fuzzer
+  velox_caching
   Boost::regex
   velox_link_libs
   Folly::folly
@@ -43,6 +44,7 @@ target_link_libraries(
   velox_dwio_parquet_writer
   velox_dwio_parquet_reader
   velox_dwio_common_test_utils
+  velox_caching
   velox_link_libs
   Boost::regex
   Folly::folly

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -117,7 +117,7 @@ class MergeJoinTest : public HiveConnectorTestBase {
             child->type(),
             child->size(),
             std::make_unique<MySimpleVectorLoader>(
-                batchId, counter, [=](RowSet) { return child; })));
+                batchId, counter, [=, this](RowSet) { return child; })));
       }
 
       data.push_back(makeRowVector(children));

--- a/velox/expression/tests/ExprEncodingsTest.cpp
+++ b/velox/expression/tests/ExprEncodingsTest.cpp
@@ -490,7 +490,7 @@ class ExprEncodingsTest
         execCtx_->pool(),
         vector->type(),
         vector->size(),
-        std::make_unique<SimpleVectorLoader>([=](RowSet /*rows*/) {
+        std::make_unique<SimpleVectorLoader>([=, this](RowSet /*rows*/) {
           auto indices =
               makeIndices(vector->size(), [](auto row) { return row; });
           return wrapInDictionary(indices, vector->size(), vector);

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -4059,7 +4059,7 @@ TEST_P(ParameterizedExprTest, cseOverLazyDictionary) {
           pool(),
           BIGINT(),
           5,
-          std::make_unique<SimpleVectorLoader>([=](RowSet /*rows*/) {
+          std::make_unique<SimpleVectorLoader>([=, this](RowSet /*rows*/) {
             return wrapInDictionary(
                 makeIndicesInReverse(5),
                 makeFlatVector<int64_t>({8, 9, 10, 11, 12}));

--- a/velox/functions/lib/CMakeLists.txt
+++ b/velox/functions/lib/CMakeLists.txt
@@ -43,6 +43,7 @@ velox_add_library(
 
 velox_link_libraries(
   velox_functions_lib
+  velox_expression
   velox_functions_util
   velox_vector
   velox_type_tz

--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -63,6 +63,7 @@ velox_link_libraries(
   velox_exec
   velox_expression
   velox_presto_serializer
+  velox_presto_types
   velox_functions_aggregates
   velox_functions_lib
   velox_functions_util

--- a/velox/row/tests/CMakeLists.txt
+++ b/velox/row/tests/CMakeLists.txt
@@ -20,8 +20,6 @@ target_link_libraries(
   velox_row_test
   PRIVATE
     velox_exception
-    velox_row_fast
-    velox_vector
     velox_vector_fuzzer
     velox_vector_test_lib
     Folly::folly

--- a/velox/tool/trace/OperatorReplayerBase.cpp
+++ b/velox/tool/trace/OperatorReplayerBase.cpp
@@ -138,7 +138,8 @@ std::shared_ptr<core::QueryCtx> OperatorReplayerBase::createQueryCtx() {
 
 std::function<core::PlanNodePtr(std::string, core::PlanNodePtr)>
 OperatorReplayerBase::replayNodeFactory(const core::PlanNode* node) const {
-  return [=](const core::PlanNodeId& nodeId,
+  return [=, this](
+             const core::PlanNodeId& nodeId,
              const core::PlanNodePtr& source) -> core::PlanNodePtr {
     return createPlanNode(node, nodeId, source);
   };

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -43,18 +43,15 @@ add_test(velox_vector_test velox_vector_test)
 
 target_link_libraries(
   velox_vector_test
+  velox_time
+  velox_vector_fuzzer
   velox_vector_test_lib
   velox_buffer
-  velox_vector
-  velox_vector_fuzzer
   velox_serialization
-  velox_memory
   velox_presto_serializer
   velox_presto_types
   velox_temp_path
-  velox_test_util
   velox_type_test_lib
-  velox_vector_fuzzer
   Boost::atomic
   Boost::context
   Boost::date_time

--- a/velox/vector/tests/utils/VectorMaker.h
+++ b/velox/vector/tests/utils/VectorMaker.h
@@ -146,7 +146,7 @@ class VectorMaker {
         pool_,
         CppToType<T>::create(),
         size,
-        std::make_unique<SimpleVectorLoader>([=](RowSet rowSet) {
+        std::make_unique<SimpleVectorLoader>([=, this](RowSet rowSet) {
           // Populate requested rows with correct data and fill in gaps with
           // "garbage".
           SelectivityVector rows(rowSet.back() + 1, false);

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -810,7 +810,7 @@ class VectorTestBase {
         pool(),
         CppToType<T>::create(),
         size,
-        std::make_unique<SimpleVectorLoader>([=](RowSet rows) {
+        std::make_unique<SimpleVectorLoader>([=, this](RowSet rows) {
           if (expectedSize.has_value()) {
             VELOX_CHECK_EQ(rows.size(), *expectedSize);
           }
@@ -828,7 +828,7 @@ class VectorTestBase {
         pool(),
         vector->type(),
         vector->size(),
-        std::make_unique<SimpleVectorLoader>([=](RowSet /*rows*/) {
+        std::make_unique<SimpleVectorLoader>([=, this](RowSet /*rows*/) {
           auto indices =
               makeIndices(vector->size(), [](auto row) { return row; });
           return wrapInDictionary(indices, vector->size(), vector);


### PR DESCRIPTION
Fixes as a result:
- remove usage of volatile variables where not needed
- replace usage of deprecated std::is_pod_v
- fix deprecated usage of implicit capture of ‘this’ via ‘[=]’
- fix ambiguity when calling == operator for LambdaTypedExpr
- rearrange some link libraries order to prevent undefined symbols
- handle AppleClang versions overloading operator<< for sys_seconds input
- handle AppleClang format_to function ambiguity between fmt and system headers
- disable folly coroutine headers because the library is not built to support it

Resolves: https://github.com/facebookincubator/velox/issues/10814