### PR TITLE
Free up memory resource after hash probe spill

### DIFF
--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -221,6 +221,9 @@ class HashProbe : public Operator {
   // operator is set to reclaimable at this stage.
   void ensureOutputFits();
 
+  // Setups spilled output reader if 'spillOutputPartitionSet_' is not empty.
+  void maybeSetupSpillOutputReader();
+
   // Reads from the spilled output if the spilling has been triggered during the
   // middle of an input processing. The latter produces all the outputs and
   // spill them on to disk in case the output is too large to fit in memory in
@@ -303,7 +306,9 @@ class HashProbe : public Operator {
   // Wake up the peer hash probe operators when last probe operator finishes.
   void wakeupPeerOperators();
 
-  //  std::vector<Operator*> findPeerOperators();
+  // Invoked to release internal buffers to free up memory resources after
+  // memory reclamation or operator close.
+  void clearBuffers();
 
   // TODO: Define batch size as bytes based on RowContainer row sizes.
   const uint32_t outputBatchSize_;
@@ -617,6 +622,10 @@ class HashProbe : public Operator {
   HashBitRange tableSpillHashBits_;
   // The row type used to spill hash table on disk.
   RowTypePtr tableSpillType_;
+
+  // The spilled output partition set which is cleared after setup
+  // 'spillOutputReader_'.
+  SpillPartitionSet spillOutputPartitionSet_;
 
   // The reader used to read the spilled output produced by pending input during
   // the spill processing.

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -656,12 +656,6 @@ uint64_t Operator::MemoryReclaimer::reclaim(
           memory::ScopedReclaimedBytesRecorder recoder(pool, &reclaimedBytes);
           op_->reclaim(targetBytes, stats);
         }
-        // NOTE: the parallel hash build is running at the background thread
-        // pool which won't stop during memory reclamation so the operator's
-        // memory usage might increase in such case. memory usage.
-        if (op_->operatorType() == "HashBuild") {
-          reclaimedBytes = std::max<int64_t>(0, reclaimedBytes);
-        }
         return reclaimedBytes;
       },
       stats);


### PR DESCRIPTION
The join fuzzer detects the memory usage of hash probe operator increased after spill and 
this mostly happen on the first hash probe input spill which creates buffers and spilled output
reader which consumes memory from the hash probe operator pool. This PR fixes this by
clear the buffers at the end of spill as well as defer the spilled output reader creation.