### PR TITLE
Fix array_join(Timestamp).

### DIFF
--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -52,25 +52,6 @@ class CastExprTest : public functions::test::CastBaseTest {
         {"error_on_odd_else_unknown"});
   }
 
-  void setLegacyCast(bool value) {
-    queryCtx_->testingOverrideConfigUnsafe({
-        {core::QueryConfig::kLegacyCast, std::to_string(value)},
-    });
-  }
-
-  void setCastMatchStructByName(bool value) {
-    queryCtx_->testingOverrideConfigUnsafe({
-        {core::QueryConfig::kCastMatchStructByName, std::to_string(value)},
-    });
-  }
-
-  void setTimezone(const std::string& value) {
-    queryCtx_->testingOverrideConfigUnsafe({
-        {core::QueryConfig::kSessionTimezone, value},
-        {core::QueryConfig::kAdjustTimestampToTimezone, "true"},
-    });
-  }
-
   std::shared_ptr<core::ConstantTypedExpr> makeConstantNullExpr(TypeKind kind) {
     return std::make_shared<core::ConstantTypedExpr>(
         createType(kind, {}), variant(kind));

--- a/velox/functions/prestosql/tests/ArrayJoinTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayJoinTest.cpp
@@ -101,4 +101,40 @@ TEST_F(ArrayJoinTest, boolTest) {
       {true, std::nullopt, false}, ","_sv, "apple"_sv, "true,apple,false"_sv);
 }
 
+TEST_F(ArrayJoinTest, timestampTest) {
+  setLegacyCast(false);
+  testArrayJoinNoReplacement<Timestamp>(
+      {Timestamp{333183, 0}, std::nullopt, Timestamp{2925183, 0}},
+      "~"_sv,
+      "1970-01-04 20:33:03.000~1970-02-03 20:33:03.000"_sv);
+  testArrayJoinReplacement<Timestamp>(
+      {Timestamp{333183, 0}, std::nullopt, Timestamp{2925183, 0}},
+      "~"_sv,
+      "<n/a>"_sv,
+      "1970-01-04 20:33:03.000~<n/a>~1970-02-03 20:33:03.000"_sv);
+
+  setLegacyCast(true);
+  testArrayJoinNoReplacement<Timestamp>(
+      {Timestamp{333183, 0}, std::nullopt, Timestamp{2925183, 0}},
+      "~"_sv,
+      "1970-01-04T20:33:03.000~1970-02-03T20:33:03.000"_sv);
+  testArrayJoinReplacement<Timestamp>(
+      {Timestamp{333183, 0}, std::nullopt, Timestamp{2925183, 0}},
+      "~"_sv,
+      "<missing>"_sv,
+      "1970-01-04T20:33:03.000~<missing>~1970-02-03T20:33:03.000"_sv);
+
+  setLegacyCast(false);
+  setTimezone("America/Los_Angeles");
+  testArrayJoinNoReplacement<Timestamp>(
+      {Timestamp{333183, 0}, std::nullopt, Timestamp{2925183, 0}},
+      "~"_sv,
+      "1970-01-04 12:33:03.000~1970-02-03 12:33:03.000"_sv);
+  testArrayJoinReplacement<Timestamp>(
+      {Timestamp{333183, 0}, std::nullopt, Timestamp{2925183, 0}},
+      "~"_sv,
+      "<absent>"_sv,
+      "1970-01-04 12:33:03.000~<absent>~1970-02-03 12:33:03.000"_sv);
+}
+
 } // namespace

--- a/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
@@ -42,6 +42,25 @@ class FunctionBaseTest : public testing::Test,
       DoubleType,
       RealType>;
 
+  void setLegacyCast(bool value) {
+    queryCtx_->testingOverrideConfigUnsafe({
+        {core::QueryConfig::kLegacyCast, std::to_string(value)},
+    });
+  }
+
+  void setCastMatchStructByName(bool value) {
+    queryCtx_->testingOverrideConfigUnsafe({
+        {core::QueryConfig::kCastMatchStructByName, std::to_string(value)},
+    });
+  }
+
+  void setTimezone(const std::string& value) {
+    queryCtx_->testingOverrideConfigUnsafe({
+        {core::QueryConfig::kSessionTimezone, value},
+        {core::QueryConfig::kAdjustTimestampToTimezone, "true"},
+    });
+  }
+
  protected:
   static void SetUpTestCase();
 


### PR DESCRIPTION
Summary:
array_join(Timestamp) was returning results different from Presto
Java.
This was because it was not using session timezone, like CAST() does.
The change is to make array_join(Timestamp) behave like CAST(Timestamp AS
Varchar).

Differential Revision: D61940944
