### PR TITLE
Fix the row container for duplicate row processing

### DIFF
--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -786,6 +786,7 @@ class HashTable : public BaseHashTable {
   // stores these in 'hashes' and inserts the groups using
   // insertForJoin or insertForGroupBy.
   bool insertBatch(
+      RowContainer* rows,
       char** groups,
       int32_t numGroups,
       raw_vector<uint64_t>& hashes,
@@ -886,7 +887,7 @@ class HashTable : public BaseHashTable {
   // Adds a row to a hash join table in kArray hash mode. Returns true
   // if a new entry was made and false if the row was added to an
   // existing set of rows with the same key.
-  bool arrayPushRow(char* row, int32_t index);
+  bool arrayPushRow(RowContainer* rows, char* row, int32_t index);
 
   // Adds a row to a hash join build side entry with multiple rows
   // with the same key.

--- a/velox/exec/benchmarks/HashJoinListResultBenchmark.cpp
+++ b/velox/exec/benchmarks/HashJoinListResultBenchmark.cpp
@@ -225,7 +225,7 @@ class HashTableListJoinResultBenchmark : public VectorTestBase {
   }
 
  private:
-  // Generate buiild key based on current key and key repetition distribution.
+  // Generate build key based on current key and key repetition distribution.
   int64_t getBuildKey(int64_t& buildKey, int32_t& iterTimes, int32_t& repeat) {
     if (iterTimes >= repeat) {
       iterTimes = 0;


### PR DESCRIPTION
When we handle duplicate row, we mark a row container has duplicate row and the corresponding
cleanup code does cleanup the duplicate row vectors. However, in array mode, we always mark the
the top row container has duplicate row but not the other subtables, and the duplicate row vector
cleanup code is not executed. Run into this in other PR which needs explicit memory allocation free.