### PR TITLE
Add RowVector::pushDictionaryToRowVectorLeaves utility

### DIFF
--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -245,6 +245,17 @@ class RowVector : public BaseVector {
   /// Note : If the child is null, then it will stay null after the resize.
   void resize(vector_size_t newSize, bool setNotNull = true) override;
 
+  /// Push all dictionary encoding to the leave vectors of a RowVector tree
+  /// (i.e. we traverse the tree consists of RowVectors, possibly wrapped in
+  /// DictionaryVector, and no traverse into other complex types like array or
+  /// map children).  If the wrapper introduce nulls on RowVector, we don't push
+  /// the dictionary into that RowVector.  The input vector should not contain
+  /// any unloaded lazy.
+  ///
+  /// This is used for example in writing Nimble ArrayWithOffsets and
+  /// SlidingWindowMap.
+  static VectorPtr pushDictionaryToRowVectorLeaves(const VectorPtr& input);
+
   VectorPtr& rawVectorForBatchReader() {
     return rawVectorForBatchReader_;
   }

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -3797,6 +3797,86 @@ TEST_F(VectorTest, mapUpdateMultipleUpdates) {
   }
 }
 
+TEST_F(VectorTest, pushDictionaryToRowVectorLeaves) {
+  auto iota = makeFlatVector<int64_t>(10, folly::identity);
+  auto output = RowVector::pushDictionaryToRowVectorLeaves(iota);
+  ASSERT_EQ(output, iota);
+
+  auto input = wrapInDictionary(makeIndicesInReverse(10), iota);
+  output = RowVector::pushDictionaryToRowVectorLeaves(input);
+  ASSERT_EQ(output, input);
+
+  {
+    SCOPED_TRACE("General");
+    input = wrapInDictionary(
+        makeIndicesInReverse(10),
+        makeRowVector({
+            // c0
+            iota,
+            // c1
+            makeRowVector({iota}),
+            // c2
+            BaseVector::wrapInDictionary(
+                makeNulls(10, nullEvery(3)),
+                makeIndicesInReverse(10),
+                10,
+                iota),
+            // c3
+            iota,
+            // c4
+            wrapInDictionary(
+                makeIndicesInReverse(10),
+                makeRowVector({
+                    iota,
+                    wrapInDictionary(makeIndicesInReverse(10), iota),
+                    iota,
+                })),
+            // c5
+            BaseVector::wrapInDictionary(
+                makeNulls(10, nullEvery(7)),
+                makeIndicesInReverse(10),
+                10,
+                makeRowVector({iota, iota})),
+        }));
+    output = RowVector::pushDictionaryToRowVectorLeaves(input);
+    test::assertEqualVectors(input, output);
+    ASSERT_EQ(output->encoding(), VectorEncoding::Simple::ROW);
+    auto* outputRow = output->asUnchecked<RowVector>();
+    auto& c0 = outputRow->childAt(0);
+    ASSERT_EQ(c0->encoding(), VectorEncoding::Simple::DICTIONARY);
+    ASSERT_EQ(c0->wrapInfo().get(), input->wrapInfo().get());
+    auto& c1 = outputRow->childAt(1);
+    ASSERT_EQ(c1->encoding(), VectorEncoding::Simple::ROW);
+    auto* c1Row = c1->asUnchecked<RowVector>();
+    auto& c1c0 = c1Row->childAt(0);
+    ASSERT_EQ(c1c0->encoding(), VectorEncoding::Simple::DICTIONARY);
+    ASSERT_EQ(c1c0->wrapInfo().get(), c0->wrapInfo().get());
+    auto& c2 = outputRow->childAt(2);
+    ASSERT_EQ(c2->encoding(), VectorEncoding::Simple::DICTIONARY);
+    auto& c3 = outputRow->childAt(3);
+    ASSERT_EQ(c3->encoding(), VectorEncoding::Simple::DICTIONARY);
+    ASSERT_EQ(c3->wrapInfo().get(), c0->wrapInfo().get());
+    auto& c4 = outputRow->childAt(4);
+    ASSERT_EQ(c4->encoding(), VectorEncoding::Simple::ROW);
+    auto* c4Row = c4->asUnchecked<RowVector>();
+    auto& c4c0 = c4Row->childAt(0);
+    ASSERT_EQ(c4c0->encoding(), VectorEncoding::Simple::DICTIONARY);
+    auto& c4c1 = c4Row->childAt(1);
+    ASSERT_EQ(c4c1->encoding(), VectorEncoding::Simple::DICTIONARY);
+    auto& c4c2 = c4Row->childAt(2);
+    ASSERT_EQ(c4c2->encoding(), VectorEncoding::Simple::DICTIONARY);
+    ASSERT_EQ(c4c0->wrapInfo().get(), c4c2->wrapInfo().get());
+    auto& c5 = outputRow->childAt(5);
+    ASSERT_EQ(c5->encoding(), VectorEncoding::Simple::DICTIONARY);
+    ASSERT_EQ(c5->valueVector()->encoding(), VectorEncoding::Simple::ROW);
+    auto* c5Row = c5->valueVector()->asUnchecked<RowVector>();
+    auto& c5c0 = c5Row->childAt(0);
+    ASSERT_EQ(c5c0->encoding(), VectorEncoding::Simple::FLAT);
+    auto& c5c1 = c5Row->childAt(1);
+    ASSERT_EQ(c5c1->encoding(), VectorEncoding::Simple::FLAT);
+  }
+}
+
 TEST_F(VectorTest, arrayCopyTargetNullOffsets) {
   auto target = BaseVector::create(ARRAY(BIGINT()), 11, pool());
   auto offsetsRef = target->asUnchecked<ArrayVector>()->offsets();


### PR DESCRIPTION
Summary:
In Nimble writer we need to merge multiple dictionary layers in
different levels of a `RowVector` into one dictionary layer at the lowest
possible vectors, so that `ArrayWithOffsets` can be encoded efficiently.  Add a
utility to achieve this.

Differential Revision: D61988576
