### PR TITLE
Fix shortDecimal test cases for Parquet.

### DIFF
--- a/velox/dwio/common/tests/utils/BatchMaker.cpp
+++ b/velox/dwio/common/tests/utils/BatchMaker.cpp
@@ -136,13 +136,18 @@ VectorPtr BatchMaker::createVector<TypeKind::INTEGER>(
 
 template <>
 VectorPtr BatchMaker::createVector<TypeKind::BIGINT>(
-    const TypePtr& /*type*/,
+    const TypePtr& type,
     size_t size,
     MemoryPool& pool,
     std::mt19937& gen,
     std::function<bool(vector_size_t /*index*/)> isNullAt) {
   return createScalar<int64_t>(
-      size, gen, [&gen]() { return Random::rand64(gen); }, pool, isNullAt);
+      size,
+      gen,
+      [&gen]() { return Random::rand64(gen); },
+      pool,
+      isNullAt,
+      type);
 }
 
 template <>

--- a/velox/dwio/parquet/reader/IntegerColumnReader.h
+++ b/velox/dwio/parquet/reader/IntegerColumnReader.h
@@ -68,6 +68,8 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
       vector_size_t offset,
       const RowSet& rows,
       const uint64_t* /*incomingNulls*/) override {
+    VELOX_CHECK(!scanSpec_->filter());
+    VELOX_CHECK(!scanSpec_->valueHook());
     auto& data = formatData_->as<ParquetData>();
     VELOX_WIDTH_DISPATCH(
         parquetSizeOfIntKind(fileType_->type()->kind()),

--- a/velox/dwio/parquet/reader/IntegerColumnReader.h
+++ b/velox/dwio/parquet/reader/IntegerColumnReader.h
@@ -68,8 +68,10 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
       vector_size_t offset,
       const RowSet& rows,
       const uint64_t* /*incomingNulls*/) override {
-    VELOX_CHECK(!scanSpec_->filter());
-    VELOX_CHECK(!scanSpec_->valueHook());
+    if (fileType_->type()->isDecimal()) {
+      VELOX_CHECK(!scanSpec_->filter());
+      VELOX_CHECK(!scanSpec_->valueHook());
+    }
     auto& data = formatData_->as<ParquetData>();
     VELOX_WIDTH_DISPATCH(
         parquetSizeOfIntKind(fileType_->type()->kind()),

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -336,7 +336,7 @@ TEST_F(E2EFilterTest, shortDecimalDictionary) {
               true);
         },
         false,
-        {"shortdecimal_val"},
+        {},
         20);
   }
 }
@@ -365,7 +365,7 @@ TEST_F(E2EFilterTest, shortDecimalDirect) {
               true);
         },
         false,
-        {"shortdecimal_val"},
+        {},
         20);
   }
 
@@ -375,7 +375,7 @@ TEST_F(E2EFilterTest, shortDecimalDirect) {
         useSuppliedValues<int64_t>("shortdecimal_val", 0, {-479, 40000000});
       },
       false,
-      {"shortdecimal_val"},
+      {},
       20);
 }
 


### PR DESCRIPTION
Currently, `E2EFilterTest#shortDecimalDirect` and `E2EFilterTest#shortDecimalDictionary` test cases of Parquet actually test bigint instead of short decimal. The reason is that `BatchMaker::createVector<TypeKind::BIGINT>` does not pass the type when creating FlatVector. Therefore, the type parameter of `BatchMaker#createScalar` is actually the BIGINT type (`const TypePtr type = CppToType<T>::create()`). which ultimately results in a test of BIGINT.

CC: @Yuhta @majetideepak 