### PR TITLE
Support hook process for orc decimal reader

### DIFF
--- a/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.h
@@ -42,7 +42,13 @@ class SelectiveDecimalColumnReader : public SelectiveColumnReader {
 
  private:
   template <bool kDense>
-  void readHelper(RowSet rows);
+  void readScales(RowSet rows);
+
+  template <bool kDense, typename ExtractValues>
+  void readHelper(RowSet rows, ExtractValues extractValues);
+
+  template <bool kDense>
+  void processValueHook(RowSet rows, ValueHook* hook);
 
   std::unique_ptr<IntDecoder<true>> valueDecoder_;
   std::unique_ptr<IntDecoder<true>> scaleDecoder_;

--- a/velox/exec/AggregationHook.h
+++ b/velox/exec/AggregationHook.h
@@ -19,7 +19,6 @@
 
 #include "velox/common/base/CheckedArithmetic.h"
 #include "velox/common/base/Range.h"
-#include "velox/type/FloatingPointUtil.h"
 #include "velox/vector/LazyVector.h"
 
 namespace facebook::velox::aggregate {
@@ -85,6 +84,8 @@ class SumHook final : public AggregationHook {
       return kDoubleSum;
     } else if (std::is_same_v<TAggregate, int64_t>) {
       return Overflow ? kBigintSumOverflow : kBigintSum;
+    } else if (std::is_same_v<TAggregate, int128_t>) {
+      return Overflow ? kHugeintSumOverflow : kHugeintSum;
     }
     return kGeneric;
   }
@@ -201,6 +202,9 @@ class MinMaxHook final : public AggregationHook {
     if (std::is_same_v<TAggregate, float> ||
         std::is_same_v<TAggregate, double>) {
       return isMin ? kFloatingPointMin : kFloatingPointMax;
+    }
+    if (std::is_same_v<TAggregate, int128_t>) {
+      return isMin ? kHugeintMin : kHugeintMax;
     }
     return kGeneric;
   }

--- a/velox/vector/LazyVector.h
+++ b/velox/vector/LazyVector.h
@@ -46,6 +46,10 @@ class ValueHook {
     kBigintMin,
     kFloatingPointMax,
     kFloatingPointMin,
+    kHugeintSum,
+    kHugeintSumOverflow,
+    kHugeintMax,
+    kHugeintMin,
   };
 
   static constexpr bool kSkipNulls = true;


### PR DESCRIPTION
Currently, orc decimal reader doesn't process the hook passed in, which causes the result of aggregate functions to be NULL. This PR add related logic to orc decimal reader.