### PR TITLE
Fix fmt V11 build errors 

### DIFF
--- a/velox/benchmarks/basic/LikeTpchBenchmark.cpp
+++ b/velox/benchmarks/basic/LikeTpchBenchmark.cpp
@@ -48,7 +48,7 @@ enum class TpchBenchmarkCase {
 
 template <>
 struct fmt::formatter<TpchBenchmarkCase> : fmt::formatter<int> {
-  auto format(const TpchBenchmarkCase& s, format_context& ctx) {
+  auto format(const TpchBenchmarkCase& s, format_context& ctx) const {
     return formatter<int>::format(static_cast<int>(s), ctx);
   }
 };

--- a/velox/common/base/Exceptions.h
+++ b/velox/common/base/Exceptions.h
@@ -20,9 +20,8 @@
 #include <sstream>
 
 #include <fmt/format.h>
-#include <folly/Preprocessor.h>
-
 #include <fmt/ostream.h>
+#include <folly/Preprocessor.h>
 
 #include "velox/common/base/FmtStdFormatters.h"
 #include "velox/common/base/VeloxException.h"

--- a/velox/common/base/Fs.cpp
+++ b/velox/common/base/Fs.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/common/base/Fs.h"
+
 #include <fmt/format.h>
 #include <glog/logging.h>
 

--- a/velox/common/base/RuntimeMetrics.h
+++ b/velox/common/base/RuntimeMetrics.h
@@ -113,7 +113,8 @@ class RuntimeStatWriterScopeGuard {
 } // namespace facebook::velox
 template <>
 struct fmt::formatter<facebook::velox::RuntimeCounter::Unit> : formatter<int> {
-  auto format(facebook::velox::RuntimeCounter::Unit s, format_context& ctx) {
+  auto format(facebook::velox::RuntimeCounter::Unit s, format_context& ctx)
+      const {
     return formatter<int>::format(static_cast<int>(s), ctx);
   }
 };

--- a/velox/common/base/RuntimeMetrics.h
+++ b/velox/common/base/RuntimeMetrics.h
@@ -16,10 +16,11 @@
 
 #pragma once
 
-#include <fmt/format.h>
-#include <folly/CppAttributes.h>
 #include <limits>
 #include <sstream>
+
+#include <fmt/format.h>
+#include <folly/CppAttributes.h>
 
 namespace facebook::velox {
 

--- a/velox/common/base/SpillStats.h
+++ b/velox/common/base/SpillStats.h
@@ -166,9 +166,8 @@ SpillStats globalSpillStats();
 template <>
 struct fmt::formatter<facebook::velox::common::SpillStats>
     : fmt::formatter<std::string> {
-  auto format(
-      const facebook::velox::common::SpillStats& s,
-      format_context& ctx) {
+  auto format(const facebook::velox::common::SpillStats& s, format_context& ctx)
+      const {
     return formatter<std::string>::format(s.toString(), ctx);
   }
 };

--- a/velox/common/base/SpillStats.h
+++ b/velox/common/base/SpillStats.h
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 #pragma once
+
 #include <stdint.h>
 #include <string.h>
 
 #include <folly/executors/CPUThreadPoolExecutor.h>
+
 #include "velox/common/compression/Compression.h"
 
 namespace facebook::velox::common {

--- a/velox/common/base/Status.h
+++ b/velox/common/base/Status.h
@@ -519,7 +519,7 @@ using Expected = folly::Expected<T, Status>;
 
 template <>
 struct fmt::formatter<facebook::velox::Status> : fmt::formatter<std::string> {
-  auto format(const facebook::velox::Status& s, format_context& ctx) {
+  auto format(const facebook::velox::Status& s, format_context& ctx) const {
     return formatter<std::string>::format(s.toString(), ctx);
   }
 };
@@ -527,7 +527,7 @@ struct fmt::formatter<facebook::velox::Status> : fmt::formatter<std::string> {
 template <>
 struct fmt::formatter<facebook::velox::StatusCode>
     : fmt::formatter<std::string_view> {
-  auto format(facebook::velox::StatusCode code, format_context& ctx) {
+  auto format(facebook::velox::StatusCode code, format_context& ctx) const {
     return formatter<std::string_view>::format(
         facebook::velox::toString(code), ctx);
   }

--- a/velox/common/base/Status.h
+++ b/velox/common/base/Status.h
@@ -18,12 +18,13 @@
 
 #pragma once
 
+#include <string>
+#include <utility>
+
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 #include <folly/Expected.h>
 #include <folly/Likely.h>
-#include <string>
-#include <utility>
 
 namespace facebook::velox {
 

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -978,7 +978,7 @@ struct fmt::formatter<facebook::velox::cache::CoalescedLoad::State>
     : formatter<int> {
   auto format(
       facebook::velox::cache::CoalescedLoad::State s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<int>::format(static_cast<int>(s), ctx);
   }
 };

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -19,10 +19,11 @@
 #include <deque>
 
 #include <fmt/format.h>
+#include <folly/GLog.h>
 #include <folly/chrono/Hardware.h>
 #include <folly/container/F14Set.h>
 #include <folly/futures/SharedPromise.h>
-#include "folly/GLog.h"
+
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/CoalesceIo.h"
 #include "velox/common/base/Portability.h"

--- a/velox/common/compression/Compression.h
+++ b/velox/common/compression/Compression.h
@@ -53,7 +53,7 @@ struct fmt::formatter<facebook::velox::common::CompressionKind>
     : fmt::formatter<std::string> {
   auto format(
       const facebook::velox::common::CompressionKind& s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<std::string>::format(
         facebook::velox::common::compressionKindToString(s), ctx);
   }

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -518,7 +518,7 @@ struct fmt::formatter<facebook::velox::memory::MemoryAllocator::InjectedFailure>
     : fmt::formatter<int> {
   auto format(
       facebook::velox::memory::MemoryAllocator::InjectedFailure s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<int>::format(static_cast<int>(s), ctx);
   }
 };

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -492,7 +492,7 @@ struct fmt::formatter<facebook::velox::memory::MemoryArbitrator::Stats>
     : formatter<std::string> {
   auto format(
       facebook::velox::memory::MemoryArbitrator::Stats s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<std::string>::format(s.toString(), ctx);
   }
 };

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -1109,9 +1109,8 @@ class StlAllocator {
 template <>
 struct fmt::formatter<facebook::velox::memory::MemoryPool::Kind>
     : formatter<std::string> {
-  auto format(
-      facebook::velox::memory::MemoryPool::Kind s,
-      format_context& ctx) {
+  auto format(facebook::velox::memory::MemoryPool::Kind s, format_context& ctx)
+      const {
     return formatter<std::string>::format(
         facebook::velox::memory::MemoryPool::kindString(s), ctx);
   }

--- a/velox/connectors/fuzzer/FuzzerConnectorSplit.h
+++ b/velox/connectors/fuzzer/FuzzerConnectorSplit.h
@@ -34,7 +34,7 @@ struct fmt::formatter<facebook::velox::connector::fuzzer::FuzzerConnectorSplit>
     : formatter<std::string> {
   auto format(
       facebook::velox::connector::fuzzer::FuzzerConnectorSplit s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<std::string>::format(s.toString(), ctx);
   }
 };
@@ -46,7 +46,7 @@ struct fmt::formatter<
   auto format(
       std::shared_ptr<facebook::velox::connector::fuzzer::FuzzerConnectorSplit>
           s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<std::string>::format(s->toString(), ctx);
   }
 };

--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -626,7 +626,7 @@ struct fmt::formatter<facebook::velox::connector::hive::HiveDataSink::State>
     : formatter<int> {
   auto format(
       facebook::velox::connector::hive::HiveDataSink::State s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<int>::format(static_cast<int>(s), ctx);
   }
 };
@@ -637,7 +637,7 @@ struct fmt::formatter<
     : formatter<int> {
   auto format(
       facebook::velox::connector::hive::LocationHandle::TableType s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<int>::format(static_cast<int>(s), ctx);
   }
 };

--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/connectors/hive/HiveDataSource.h"
 
+#include <fmt/ranges.h>
 #include <string>
 #include <unordered_map>
 

--- a/velox/connectors/tpch/TpchConnectorSplit.h
+++ b/velox/connectors/tpch/TpchConnectorSplit.h
@@ -58,7 +58,7 @@ struct fmt::formatter<
     : formatter<std::string> {
   auto format(
       std::shared_ptr<facebook::velox::connector::tpch::TpchConnectorSplit> s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<std::string>::format(s->toString(), ctx);
   }
 };

--- a/velox/core/PlanFragment.h
+++ b/velox/core/PlanFragment.h
@@ -89,7 +89,7 @@ struct fmt::formatter<facebook::velox::core::ExecutionStrategy>
     : formatter<int> {
   auto format(
       const facebook::velox::core::ExecutionStrategy& s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<int>::format(static_cast<int>(s), ctx);
   }
 };

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -2402,7 +2402,7 @@ struct fmt::formatter<facebook::velox::core::PartitionedOutputNode::Kind>
     : formatter<std::string> {
   auto format(
       facebook::velox::core::PartitionedOutputNode::Kind s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<std::string>::format(
         facebook::velox::core::PartitionedOutputNode::kindString(s), ctx);
   }
@@ -2410,7 +2410,7 @@ struct fmt::formatter<facebook::velox::core::PartitionedOutputNode::Kind>
 
 template <>
 struct fmt::formatter<facebook::velox::core::JoinType> : formatter<int> {
-  auto format(facebook::velox::core::JoinType s, format_context& ctx) {
+  auto format(facebook::velox::core::JoinType s, format_context& ctx) const {
     return formatter<int>::format(static_cast<int>(s), ctx);
   }
 };

--- a/velox/dwio/catalog/fbhive/FileUtils.cpp
+++ b/velox/dwio/catalog/fbhive/FileUtils.cpp
@@ -15,9 +15,12 @@
  */
 
 #include "FileUtils.h"
-#include <fmt/core.h>
+
 #include <bitset>
-#include "folly/container/Array.h"
+
+#include <fmt/core.h>
+#include <folly/container/Array.h>
+
 #include "velox/dwio/common/exception/Exception.h"
 
 namespace facebook {

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -644,9 +644,8 @@ template <>
 struct fmt::formatter<facebook::velox::dwio::common::FileFormat>
     : fmt::formatter<std::string_view> {
   template <typename FormatContext>
-  auto format(
-      facebook::velox::dwio::common::FileFormat fmt,
-      FormatContext& ctx) {
+  auto format(facebook::velox::dwio::common::FileFormat fmt, FormatContext& ctx)
+      const {
     return formatter<std::string_view>::format(
         facebook::velox::dwio::common::toString(fmt), ctx);
   }

--- a/velox/dwio/dwrf/common/FileMetadata.h
+++ b/velox/dwio/dwrf/common/FileMetadata.h
@@ -832,7 +832,7 @@ class FooterWrapper : public ProtoWrapperBase {
 
 template <>
 struct fmt::formatter<facebook::velox::dwrf::DwrfFormat> : formatter<int> {
-  auto format(facebook::velox::dwrf::DwrfFormat s, format_context& ctx) {
+  auto format(facebook::velox::dwrf::DwrfFormat s, format_context& ctx) const {
     return formatter<int>::format(static_cast<int>(s), ctx);
   }
 };

--- a/velox/dwio/parquet/thrift/ParquetThriftTypes.h
+++ b/velox/dwio/parquet/thrift/ParquetThriftTypes.h
@@ -3749,7 +3749,7 @@ struct fmt::formatter<facebook::velox::parquet::thrift::Type::type>
     : fmt::formatter<std::string_view> {
   auto format(
       const facebook::velox::parquet::thrift::Type::type& s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<std::string_view>::format(
         facebook::velox::parquet::thrift::to_string(s), ctx);
   }
@@ -3760,7 +3760,7 @@ struct fmt::formatter<facebook::velox::parquet::thrift::CompressionCodec::type>
     : fmt::formatter<std::string_view> {
   auto format(
       const facebook::velox::parquet::thrift::CompressionCodec::type& s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<std::string_view>::format(
         facebook::velox::parquet::thrift::to_string(s), ctx);
   }
@@ -3771,7 +3771,7 @@ struct fmt::formatter<facebook::velox::parquet::thrift::ConvertedType::type>
     : fmt::formatter<std::string_view> {
   auto format(
       const facebook::velox::parquet::thrift::ConvertedType::type& s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<std::string_view>::format(
         facebook::velox::parquet::thrift::to_string(s), ctx);
   }
@@ -3783,7 +3783,7 @@ struct fmt::formatter<
     : fmt::formatter<std::string_view> {
   auto format(
       const facebook::velox::parquet::thrift::FieldRepetitionType::type& s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<std::string_view>::format(
         facebook::velox::parquet::thrift::to_string(s), ctx);
   }
@@ -3794,7 +3794,7 @@ struct fmt::formatter<facebook::velox::parquet::thrift::Encoding::type>
     : fmt::formatter<std::string_view> {
   auto format(
       const facebook::velox::parquet::thrift::Encoding::type& s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<std::string_view>::format(
         facebook::velox::parquet::thrift::to_string(s), ctx);
   }
@@ -3805,7 +3805,7 @@ struct fmt::formatter<facebook::velox::parquet::thrift::PageType::type>
     : fmt::formatter<std::string_view> {
   auto format(
       const facebook::velox::parquet::thrift::PageType::type& s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<std::string_view>::format(
         facebook::velox::parquet::thrift::to_string(s), ctx);
   }
@@ -3816,7 +3816,7 @@ struct fmt::formatter<facebook::velox::parquet::thrift::BoundaryOrder::type>
     : fmt::formatter<std::string_view> {
   auto format(
       const facebook::velox::parquet::thrift::BoundaryOrder::type& s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<std::string_view>::format(
         facebook::velox::parquet::thrift::to_string(s), ctx);
   }

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -753,7 +753,7 @@ DriverThreadContext* driverThreadContext();
 template <>
 struct fmt::formatter<facebook::velox::exec::StopReason>
     : formatter<std::string> {
-  auto format(facebook::velox::exec::StopReason s, format_context& ctx) {
+  auto format(facebook::velox::exec::StopReason s, format_context& ctx) const {
     return formatter<std::string>::format(
         facebook::velox::exec::stopReasonString(s), ctx);
   }

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -314,7 +314,8 @@ inline std::ostream& operator<<(std::ostream& os, HashBuild::State state) {
 template <>
 struct fmt::formatter<facebook::velox::exec::HashBuild::State>
     : formatter<std::string> {
-  auto format(facebook::velox::exec::HashBuild::State s, format_context& ctx) {
+  auto format(facebook::velox::exec::HashBuild::State s, format_context& ctx)
+      const {
     return formatter<std::string>::format(
         facebook::velox::exec::HashBuild::stateName(s), ctx);
   }

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -1098,7 +1098,7 @@ struct fmt::formatter<facebook::velox::exec::BaseHashTable::HashMode>
     : formatter<std::string> {
   auto format(
       facebook::velox::exec::BaseHashTable::HashMode s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<std::string>::format(
         facebook::velox::exec::BaseHashTable::modeString(s), ctx);
   }

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -829,7 +829,7 @@ class SourceOperator : public Operator {
 
 template <>
 struct fmt::formatter<std::thread::id> : formatter<std::string> {
-  auto format(std::thread::id s, format_context& ctx) {
+  auto format(std::thread::id s, format_context& ctx) const {
     std::ostringstream oss;
     oss << s;
     return formatter<std::string>::format(oss.str(), ctx);

--- a/velox/exec/ProbeOperatorState.h
+++ b/velox/exec/ProbeOperatorState.h
@@ -59,9 +59,8 @@ std::string probeOperatorStateName(ProbeOperatorState state);
 template <>
 struct fmt::formatter<facebook::velox::exec::ProbeOperatorState>
     : formatter<int> {
-  auto format(
-      facebook::velox::exec::ProbeOperatorState s,
-      format_context& ctx) {
+  auto format(facebook::velox::exec::ProbeOperatorState s, format_context& ctx)
+      const {
     return formatter<int>::format(static_cast<int>(s), ctx);
   }
 };

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -500,7 +500,8 @@ struct hash<::facebook::velox::exec::SpillPartitionId> {
 template <>
 struct fmt::formatter<facebook::velox::exec::SpillPartitionId>
     : formatter<std::string> {
-  auto format(facebook::velox::exec::SpillPartitionId s, format_context& ctx) {
+  auto format(facebook::velox::exec::SpillPartitionId s, format_context& ctx)
+      const {
     return formatter<std::string>::format(s.toString(), ctx);
   }
 };

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -347,7 +347,8 @@ class Spiller {
 
 template <>
 struct fmt::formatter<facebook::velox::exec::Spiller::Type> : formatter<int> {
-  auto format(facebook::velox::exec::Spiller::Type s, format_context& ctx) {
+  auto format(facebook::velox::exec::Spiller::Type s, format_context& ctx)
+      const {
     return formatter<int>::format(static_cast<int>(s), ctx);
   }
 };

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -1221,9 +1221,8 @@ std::ostream& operator<<(std::ostream& out, Task::ExecutionMode mode);
 template <>
 struct fmt::formatter<facebook::velox::exec::Task::ExecutionMode>
     : formatter<std::string> {
-  auto format(
-      facebook::velox::exec::Task::ExecutionMode m,
-      format_context& ctx) {
+  auto format(facebook::velox::exec::Task::ExecutionMode m, format_context& ctx)
+      const {
     return formatter<std::string>::format(
         facebook::velox::exec::executionModeString(m), ctx);
   }

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #pragma once
+
 #include "velox/core/PlanFragment.h"
 #include "velox/core/QueryCtx.h"
 #include "velox/exec/Driver.h"

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/exec/TableScan.h"
+#include <fmt/ranges.h>
 #include <folly/synchronization/Baton.h>
 #include <folly/synchronization/Latch.h>
 #include <atomic>
 #include <shared_mutex>
+
 #include "folly/experimental/EventCount.h"
 #include "velox/common/base/Fs.h"
 #include "velox/common/base/tests/GTestUtils.h"
@@ -34,6 +35,7 @@
 #include "velox/exec/Exchange.h"
 #include "velox/exec/OutputBufferManager.h"
 #include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/TableScan.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/Cursor.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <fmt/ranges.h>
-#include <folly/synchronization/Baton.h>
-#include <folly/synchronization/Latch.h>
 #include <atomic>
 #include <shared_mutex>
 
-#include "folly/experimental/EventCount.h"
+#include <fmt/ranges.h>
+#include <folly/experimental/EventCount.h>
+#include <folly/synchronization/Baton.h>
+#include <folly/synchronization/Latch.h>
+
 #include "velox/common/base/Fs.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/tests/FaultyFile.h"

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -1618,7 +1618,7 @@ std::unordered_map<std::string, OperatorStats> toOperatorStats(
 
 template <>
 struct fmt::formatter<::duckdb::LogicalTypeId> : formatter<int> {
-  auto format(::duckdb::LogicalTypeId s, format_context& ctx) {
+  auto format(::duckdb::LogicalTypeId s, format_context& ctx) const {
     return formatter<int>::format(static_cast<int>(s), ctx);
   }
 };

--- a/velox/functions/lib/DateTimeFormatter.h
+++ b/velox/functions/lib/DateTimeFormatter.h
@@ -216,7 +216,7 @@ struct fmt::formatter<facebook::velox::functions::DateTimeFormatterType>
     : formatter<int> {
   auto format(
       facebook::velox::functions::DateTimeFormatterType s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<int>::format(static_cast<int>(s), ctx);
   }
 };
@@ -226,7 +226,7 @@ struct fmt::formatter<facebook::velox::functions::DateTimeFormatSpecifier>
     : formatter<int> {
   auto format(
       facebook::velox::functions::DateTimeFormatSpecifier s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<int>::format(static_cast<int>(s), ctx);
   }
 };

--- a/velox/functions/lib/Re2Functions.h
+++ b/velox/functions/lib/Re2Functions.h
@@ -418,7 +418,8 @@ regexpReplaceWithLambdaSignatures();
 template <>
 struct fmt::formatter<facebook::velox::functions::PatternKind>
     : formatter<int> {
-  auto format(facebook::velox::functions::PatternKind s, format_context& ctx) {
+  auto format(facebook::velox::functions::PatternKind s, format_context& ctx)
+      const {
     return formatter<int>::format(static_cast<int>(s), ctx);
   }
 };

--- a/velox/substrait/SubstraitToVeloxExpr.h
+++ b/velox/substrait/SubstraitToVeloxExpr.h
@@ -85,9 +85,8 @@ class SubstraitVeloxExprConverter {
 
 template <>
 struct fmt::formatter<substrait::Expression::RexTypeCase> : formatter<int> {
-  auto format(
-      const substrait::Expression::RexTypeCase& s,
-      format_context& ctx) {
+  auto format(const substrait::Expression::RexTypeCase& s, format_context& ctx)
+      const {
     return formatter<int>::format(static_cast<int>(s), ctx);
   }
 };
@@ -97,7 +96,7 @@ struct fmt::formatter<substrait::Expression::Cast::FailureBehavior>
     : formatter<int> {
   auto format(
       const substrait::Expression::Cast::FailureBehavior& s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<int>::format(static_cast<int>(s), ctx);
   }
 };
@@ -106,7 +105,7 @@ struct fmt::formatter<substrait::Expression_FieldReference::ReferenceTypeCase>
     : formatter<int> {
   auto format(
       const substrait::Expression_FieldReference::ReferenceTypeCase& s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<int>::format(static_cast<int>(s), ctx);
   }
 };
@@ -116,7 +115,7 @@ struct fmt::formatter<substrait::Expression_Literal::LiteralTypeCase>
     : formatter<int> {
   auto format(
       const substrait::Expression_Literal::LiteralTypeCase& s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<int>::format(static_cast<int>(s), ctx);
   }
 };

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -505,7 +505,7 @@ struct formatter<facebook::velox::TimestampToStringOptions::Precision>
     : formatter<int> {
   auto format(
       facebook::velox::TimestampToStringOptions::Precision s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<int>::format(static_cast<int>(s), ctx);
   }
 };
@@ -514,7 +514,7 @@ struct formatter<facebook::velox::TimestampToStringOptions::Mode>
     : formatter<int> {
   auto format(
       facebook::velox::TimestampToStringOptions::Mode s,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<int>::format(static_cast<int>(s), ctx);
   }
 };

--- a/velox/type/fbhive/HiveTypeParser.cpp
+++ b/velox/type/fbhive/HiveTypeParser.cpp
@@ -80,7 +80,7 @@ std::shared_ptr<const Type> HiveTypeParser::parse(const std::string& ser) {
       "Input remaining after parsing the Hive type \"{}\"\n"
       "Remaining: \"{}\"",
       ser,
-      remaining_);
+      remaining_.toString());
   return result.type;
 }
 
@@ -142,7 +142,9 @@ Result HiveTypeParser::parseType() {
     }
   } else {
     VELOX_FAIL(fmt::format(
-        "Unexpected token {} at {}", nt.value, remaining_.toString()));
+        "Unexpected token {} at {}",
+        nt.value.toString(),
+        remaining_.toString()));
   }
 }
 

--- a/velox/type/fbhive/HiveTypeParser.h
+++ b/velox/type/fbhive/HiveTypeParser.h
@@ -22,7 +22,8 @@
 #include <string>
 #include <vector>
 
-#include "folly/Range.h"
+#include <folly/Range.h>
+
 #include "velox/type/TypeParser.h"
 
 namespace facebook::velox::type::fbhive {

--- a/velox/vector/VectorSaver.cpp
+++ b/velox/vector/VectorSaver.cpp
@@ -778,7 +778,7 @@ SelectivityVector restoreSelectivityVector(std::istream& in) {
 
 template <>
 struct fmt::formatter<facebook::velox::Encoding> : formatter<int> {
-  auto format(facebook::velox::Encoding s, format_context& ctx) {
+  auto format(facebook::velox::Encoding s, format_context& ctx) const {
     return formatter<int>::format(static_cast<int>(s), ctx);
   }
 };


### PR DESCRIPTION
Recently brew updated fmt version from 10.1 to 11.0. In order to prevent build errors from happening after we upgrade Folly, the following changes are made:

1. Error "'this' argument to member function 'format' has type 'const fmt::formatter<facebook::velox::exec::Spiller::Type>', but function is not marked const".
The new fmt v11 forces the const check. To fix this error, the "const" keyword was added to the `format()` function declarations.

2. Error "error: static assertion failed due to requirement 'formattable_char': Mixing character types is disallowed." The new fmt v11 added a check if the arguments of fmt::make_format_args() have mixing different character types (e.g., char vs wchar_t or std::string vs folly::Range<const char*>). To fix this, we need to convert the folly::StringPiece to string.

These changes will be needed after we upgrade Folly, which is also dependent on fmt v11. The changes are backward compatible for fmt v10.

Fixes https://github.com/facebookincubator/velox/issues/10886