### PR TITLE
Fix arm64 macOS failure

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -74,7 +74,7 @@ jobs:
         uses: assignUser/stash/restore@v1
         with:
           path: '${{ env.CCACHE_DIR }}'
-          key: ccache-macos-${{ matrix.os }}
+          key: ccache-macos-1-${{ matrix.os }}
 
       - name: Configure Build
         env:
@@ -98,7 +98,7 @@ jobs:
       - uses: assignUser/stash/save@v1
         with:
           path: '${{ env.CCACHE_DIR }}'
-          key: ccache-macos-${{ matrix.os }}
+          key: ccache-macos-1-${{ matrix.os }}
 
       - name: Run Tests
         if: false

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -52,6 +52,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       CCACHE_DIR: '${{ github.workspace }}/.ccache'
+      # The arm runners have only 7GB RAM
+      BUILD_TYPE: "${{ matrix.os ==  'macos-14' && 'Release' || 'Debug' }}"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -76,20 +78,21 @@ jobs:
 
       - name: Configure Build
         env:
-          folly_SOURCE: BUNDLED
+          folly_SOURCE: BUNDLED #brew folly does not have int128
         run: |
             ccache -sz -M 5Gi
             cmake \
-                -B _build/debug \
+                -B _build/$BUILD_TYPE \
                 -GNinja \
                 -DTREAT_WARNINGS_AS_ERRORS=1 \
                 -DENABLE_ALL_WARNINGS=1 \
                 -DVELOX_ENABLE_PARQUET=ON \
-                -DCMAKE_BUILD_TYPE=Debug
+                -DVELOX_MONO_LIBRARY=ON \
+                -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
       - name: Build
         run: |
-            cmake --build _build/debug -j $NJOBS
+            cmake --build _build/$BUILD_TYPE -j $NJOBS
             ccache -s
 
       - uses: assignUser/stash/save@v1

--- a/velox/type/parser/CMakeLists.txt
+++ b/velox/type/parser/CMakeLists.txt
@@ -35,6 +35,6 @@ if(VELOX_MONO_LIBRARY)
 endif()
 velox_add_library(velox_type_parser ${BISON_TypeParser_OUTPUTS}
                   ${FLEX_TypeParserScanner_OUTPUTS} ParserUtil.cpp)
-velox_include_directories(velox_type_parser ${PROJECT_BINARY_DIR}
-                          ${FLEX_INCLUDE_DIRS})
+velox_include_directories(velox_type_parser PRIVATE ${PROJECT_BINARY_DIR}
+                                                    ${FLEX_INCLUDE_DIRS})
 velox_link_libraries(velox_type_parser velox_common_base)

--- a/velox/type/parser/CMakeLists.txt
+++ b/velox/type/parser/CMakeLists.txt
@@ -33,9 +33,8 @@ if(VELOX_MONO_LIBRARY)
                                       ${FLEX_TypeParserScanner_OUTPUTS})
   add_dependencies(velox velox_type_parser_gen_src)
 endif()
-
-include_directories(${PROJECT_BINARY_DIR})
-include_directories(${FLEX_INCLUDE_DIRS})
 velox_add_library(velox_type_parser ${BISON_TypeParser_OUTPUTS}
                   ${FLEX_TypeParserScanner_OUTPUTS} ParserUtil.cpp)
+velox_include_directories(velox_type_parser ${PROJECT_BINARY_DIR}
+                          ${FLEX_INCLUDE_DIRS})
 velox_link_libraries(velox_type_parser velox_common_base)


### PR DESCRIPTION
The build on arm64 macos is stopped due to running out of disk space:
> You are running out of disk space. The runner will stop working when the machine runs out of disk space. Free space left: 76 MB

This is likely due to swap as it only has 7GB of RAM compared to 14GB on the  amd64 runner. 

- Switch both macos jobs to build the monolithic library to save diskspace.
- Switch the arm64 build to release to further decrease memory footprint.

Fixes #10901