### PR TITLE
Fix showing repo name in cmake_install

### DIFF
--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -170,7 +170,7 @@ function cmake_install {
   else
     DIR=$(pwd)
   fi
-  local NAME=$(basename "$(pwd)")
+  local NAME=$(basename "${DIR}")
   local BINARY_DIR=_build
   SUDO="${SUDO:-""}"
   pushd "${DIR}"


### PR DESCRIPTION
A follow-up fix for #9198.

When calling velox dependency setup script, the name of the dependency repos being re-installed / updated, however, shows incorrectly.

```sh
velox_dependency_install $ ../velox/scripts/setup-macos.sh

+ Finished running install_velox_deps_from_brew
+ run_and_time install_ranges_v3

...

+ cmake_install ranges_v3 -DRANGES_ENABLE_WERROR=OFF -DRANGE_V3_TESTS=OFF -DRANGE_V3_EXAMPLES=OFF
+ '[' -d ranges_v3 ']'
+ DIR=ranges_v3
+ shift
+++ pwd
++ basename /velox_dependency_install
+ local NAME=velox_dependency_install

...

+ '[' -d _build ']'
+ prompt 'Do you want to rebuild velox_dependency_install?'
Do you want to rebuild velox_dependency_install? [Y, n]
```

W/ this PR,
```sh
+ cmake_install ranges_v3 -DRANGES_ENABLE_WERROR=OFF -DRANGE_V3_TESTS=OFF -DRANGE_V3_EXAMPLES=OFF
+ '[' -d ranges_v3 ']'
+ DIR=ranges_v3
+ shift
++ basename ranges_v3
+ local NAME=ranges_v3

...

+ '[' -d _build ']'
+ prompt 'Do you want to rebuild ranges_v3?'
Do you want to rebuild ranges_v3? [Y, n]
```