### PR TITLE
add query config to control eager flushing for partial limit

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -131,6 +131,16 @@ class QueryConfig {
   static constexpr const char* kAbandonPartialTopNRowNumberMinPct =
       "abandon_partial_topn_row_number_min_pct";
 
+  /// the threshold for eager flushing of partial limit nodes.
+  ///
+  /// When the sum of the offset and the count of a partial limit node
+  /// is below this threshold, results are flushed eagerly to improve
+  /// performance by reducing unnecessary data processing.
+  ///
+  /// Default value is 10,000.
+  static constexpr const char* kPartialLimitEagerFlushThreshold =
+      "partial_limit_eager_flush_threshold";
+
   static constexpr const char* kMaxPartitionedOutputBufferSize =
       "max_page_partitioning_buffer_size";
 
@@ -424,6 +434,10 @@ class QueryConfig {
 
   int32_t abandonPartialTopNRowNumberMinPct() const {
     return get<int32_t>(kAbandonPartialTopNRowNumberMinPct, 80);
+  }
+
+  int64_t partialLimitEagerFlushThreshold() const {
+    return get<int64_t>(kPartialLimitEagerFlushThreshold, 10'000);
   }
 
   uint64_t maxSpillRunRows() const {

--- a/velox/core/tests/QueryConfigTest.cpp
+++ b/velox/core/tests/QueryConfigTest.cpp
@@ -202,4 +202,13 @@ TEST_F(QueryConfigTest, expressionEvaluationRelatedConfigs) {
   testConfig(createConfig(false, false, false, true));
 }
 
+TEST_F(QueryConfigTest, partialLimitEagerFlushThresholdConfig) {
+  std::unordered_map<std::string, std::string> configData(
+      {{QueryConfig::kPartialLimitEagerFlushThreshold, "1000"}});
+  auto queryCtx = QueryCtx::create(nullptr, QueryConfig{std::move(configData)});
+  const QueryConfig& config = queryCtx->queryConfig();
+
+  ASSERT_EQ(config.partialLimitEagerFlushThreshold(), 1000);
+}
+
 } // namespace facebook::velox::core::test

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -47,6 +47,10 @@ Generic Configuration
      - integer
      - 80
      - Abandons partial TopNRowNumber if number of output rows equals or exceeds this percentage of the number of input rows.
+   * - partial_limit_eager_flush_threshold
+     - integer
+     - 10,000
+     - used to flush eagerly the results when the sum of offset and count for the partial limit node is below the threshold.
    * - session_timezone
      - string
      -

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -393,7 +393,7 @@ namespace {
 
 // If the upstream is partial limit, downstream is final limit and we want to
 // flush as soon as we can to reach the limit and do as little work as possible.
-bool eagerFlush(const core::PlanNode& node, const int64_t& threshold) {
+bool eagerFlush(const core::PlanNode& node, int64_t threshold) {
   if (auto* limit = dynamic_cast<const core::LimitNode*>(&node)) {
     return limit->isPartial() && limit->offset() + limit->count() < threshold;
   }


### PR DESCRIPTION
summary:

This PR introduces a new configuration option, partial_limit_eager_flush_threshold, to provide greater control over the eager flushing behavior of partial limit nodes.
