### PR TITLE
Enable more test cases for serial execution mode in SharedArbitratorTest

### DIFF
--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -316,13 +316,13 @@ class SharedArbitrationTest : public testing::WithParamInterface<TestParam>,
   AssertQueryBuilder newQueryBuilder() {
     AssertQueryBuilder builder = AssertQueryBuilder(duckDbQueryRunner_);
     builder.serialExecution(isSerialExecutionMode_);
-    return std::move(builder);
+    return builder;
   }
 
   AssertQueryBuilder newQueryBuilder(const core::PlanNodePtr& plan) {
     AssertQueryBuilder builder = AssertQueryBuilder(plan);
     builder.serialExecution(isSerialExecutionMode_);
-    return std::move(builder);
+    return builder;
   }
 
   static inline FakeMemoryOperatorFactory* fakeOperatorFactory_;

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -1238,7 +1238,9 @@ DEBUG_ONLY_TEST_P(
   }
 }
 
-TEST_P(SharedArbitrationTestWithParallelExecutionModeOnly, concurrentArbitration) {
+TEST_P(
+    SharedArbitrationTestWithParallelExecutionModeOnly,
+    concurrentArbitration) {
   // Tries to replicate an actual workload by concurrently running multiple
   // query shapes that support spilling (and hence can be forced to abort or
   // spill by the arbitrator). Also adds an element of randomness by randomly
@@ -1256,18 +1258,31 @@ TEST_P(SharedArbitrationTestWithParallelExecutionModeOnly, concurrentArbitration
     vectors.push_back(makeRowVector(rowType_, fuzzerOpts_));
   }
   const int numDrivers = 4;
-  const auto expectedWriteResult =
-      runWriteTask(
-          vectors, nullptr, isSerialExecutionMode_, numDrivers, pool(), kHiveConnectorId, false)
-          .data;
+  const auto expectedWriteResult = runWriteTask(
+                                       vectors,
+                                       nullptr,
+                                       isSerialExecutionMode_,
+                                       numDrivers,
+                                       pool(),
+                                       kHiveConnectorId,
+                                       false)
+                                       .data;
   const auto expectedJoinResult =
-      runHashJoinTask(vectors, nullptr, isSerialExecutionMode_, numDrivers, pool(), false).data;
+      runHashJoinTask(
+          vectors, nullptr, isSerialExecutionMode_, numDrivers, pool(), false)
+          .data;
   const auto expectedOrderResult =
-      runOrderByTask(vectors, nullptr, isSerialExecutionMode_, numDrivers, pool(), false).data;
+      runOrderByTask(
+          vectors, nullptr, isSerialExecutionMode_, numDrivers, pool(), false)
+          .data;
   const auto expectedRowNumberResult =
-      runRowNumberTask(vectors, nullptr, isSerialExecutionMode_,numDrivers, pool(), false).data;
+      runRowNumberTask(
+          vectors, nullptr, isSerialExecutionMode_, numDrivers, pool(), false)
+          .data;
   const auto expectedTopNResult =
-      runTopNTask(vectors, nullptr, isSerialExecutionMode_,numDrivers, pool(), false).data;
+      runTopNTask(
+          vectors, nullptr, isSerialExecutionMode_, numDrivers, pool(), false)
+          .data;
 
   struct {
     uint64_t totalCapacity;

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -335,8 +335,11 @@ class SharedArbitrationTest : public testing::WithParamInterface<TestParam>,
   bool isSerialExecutionMode_{false};
 };
 
+/// A test fixture that runs cases within parallel execution mode.
 class SharedArbitrationTestWithParallelExecutionModeOnly
     : public SharedArbitrationTest {};
+/// A test fixture that runs cases within both serial and
+/// parallel execution modes.
 class SharedArbitrationTestWithThreadingModes : public SharedArbitrationTest {};
 
 DEBUG_ONLY_TEST_P(

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -226,7 +226,19 @@ class FakeMemoryOperatorFactory : public Operator::PlanNodeTranslator {
   uint32_t maxDrivers_{1};
 };
 
-class SharedArbitrationTestBase : public exec::test::HiveConnectorTestBase {
+namespace {
+std::unique_ptr<folly::Executor> newParallelExecutor() {
+  return std::make_unique<folly::CPUThreadPoolExecutor>(32);
+}
+
+struct TestParam {
+  bool isSerialExecutionMode{false};
+};
+} // namespace
+
+class SharedArbitrationTest : public testing::WithParamInterface<TestParam>,
+                              public exec::test::HiveConnectorTestBase {
+ public:
  protected:
   static void SetUpTestCase() {
     exec::test::HiveConnectorTestBase::SetUpTestCase();
@@ -253,6 +265,12 @@ class SharedArbitrationTestBase : public exec::test::HiveConnectorTestBase {
     fuzzerOpts_.allowLazyVector = false;
     vector_ = makeRowVector(rowType_, fuzzerOpts_);
     numAddedPools_ = 0;
+    isSerialExecutionMode_ = GetParam().isSerialExecutionMode;
+    if (isSerialExecutionMode_) {
+      executor_ = nullptr;
+    } else {
+      executor_ = newParallelExecutor();
+    }
   }
 
   void TearDown() override {
@@ -295,6 +313,18 @@ class SharedArbitrationTestBase : public exec::test::HiveConnectorTestBase {
     }
   }
 
+  AssertQueryBuilder newQueryBuilder() {
+    AssertQueryBuilder builder = AssertQueryBuilder(duckDbQueryRunner_);
+    builder.serialExecution(isSerialExecutionMode_);
+    return std::move(builder);
+  }
+
+  AssertQueryBuilder newQueryBuilder(const core::PlanNodePtr& plan) {
+    AssertQueryBuilder builder = AssertQueryBuilder(plan);
+    builder.serialExecution(isSerialExecutionMode_);
+    return std::move(builder);
+  }
+
   static inline FakeMemoryOperatorFactory* fakeOperatorFactory_;
   std::unique_ptr<memory::MemoryManager> memoryManager_;
   SharedArbitrator* arbitrator_{nullptr};
@@ -302,51 +332,16 @@ class SharedArbitrationTestBase : public exec::test::HiveConnectorTestBase {
   VectorFuzzer::Options fuzzerOpts_;
   RowVectorPtr vector_;
   std::atomic_uint64_t numAddedPools_{0};
-};
-
-namespace {
-std::unique_ptr<folly::Executor> newParallelExecutor() {
-  return std::make_unique<folly::CPUThreadPoolExecutor>(32);
-}
-
-struct TestParam {
-  bool isSerialExecutionMode{false};
-};
-} // namespace
-
-/// A test fixture that runs cases within parallel execution mode.
-class SharedArbitrationTest : public SharedArbitrationTestBase {
- protected:
-  void SetUp() override {
-    SharedArbitrationTestBase::SetUp();
-    executor_ = newParallelExecutor();
-  }
-};
-/// A test fixture that runs cases within both serial and
-/// parallel execution modes.
-class SharedArbitrationTestWithExecutionModes
-    : public testing::WithParamInterface<TestParam>,
-      public SharedArbitrationTestBase {
- public:
-  static std::vector<TestParam> getTestParams() {
-    return std::vector<TestParam>({{false}, {true}});
-  }
-
- protected:
-  void SetUp() override {
-    SharedArbitrationTestBase::SetUp();
-    isSerialExecutionMode_ = GetParam().isSerialExecutionMode;
-    if (isSerialExecutionMode_) {
-      executor_ = nullptr;
-    } else {
-      executor_ = newParallelExecutor();
-    }
-  }
-
   bool isSerialExecutionMode_{false};
 };
 
-DEBUG_ONLY_TEST_F(SharedArbitrationTest, queryArbitrationStateCheck) {
+class SharedArbitrationTestWithParallelExecutionModeOnly
+    : public SharedArbitrationTest {};
+class SharedArbitrationTestWithThreadingModes : public SharedArbitrationTest {};
+
+DEBUG_ONLY_TEST_P(
+    SharedArbitrationTestWithThreadingModes,
+    queryArbitrationStateCheck) {
   const std::vector<RowVectorPtr> vectors =
       createVectors(rowType_, 32, 32 << 20);
   createDuckDbTable(vectors);
@@ -364,7 +359,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, queryArbitrationStateCheck) {
   const auto spillDirectory = exec::test::TempDirectoryPath::create();
   TestScopedSpillInjection scopedSpillInjection(100);
   core::PlanNodeId aggregationNodeId;
-  AssertQueryBuilder(duckDbQueryRunner_)
+  newQueryBuilder()
       .queryCtx(queryCtx)
       .spillDirectory(spillDirectory->getPath())
       .config(core::QueryConfig::kSpillEnabled, "true")
@@ -380,7 +375,9 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, queryArbitrationStateCheck) {
   ASSERT_FALSE(queryCtx->testingUnderArbitration());
 }
 
-DEBUG_ONLY_TEST_F(SharedArbitrationTest, raceBetweenAbortAndArbitrationLeave) {
+DEBUG_ONLY_TEST_P(
+    SharedArbitrationTestWithThreadingModes,
+    raceBetweenAbortAndArbitrationLeave) {
   const std::vector<RowVectorPtr> vectors =
       createVectors(rowType_, 32, 32 << 20);
   setupMemory(kMemoryCapacity, /*memoryPoolInitCapacity=*/0);
@@ -415,7 +412,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, raceBetweenAbortAndArbitrationLeave) {
                     .capturePlanNodeId(aggregationNodeId)
                     .planNode();
     VELOX_ASSERT_THROW(
-        AssertQueryBuilder(plan)
+        newQueryBuilder(plan)
             .queryCtx(queryCtx)
             .spillDirectory(spillDirectory->getPath())
             .config(core::QueryConfig::kSpillEnabled, "true")
@@ -434,7 +431,9 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, raceBetweenAbortAndArbitrationLeave) {
   waitForAllTasksToBeDeleted();
 }
 
-DEBUG_ONLY_TEST_F(SharedArbitrationTest, skipNonReclaimableTaskTest) {
+DEBUG_ONLY_TEST_P(
+    SharedArbitrationTestWithThreadingModes,
+    skipNonReclaimableTaskTest) {
   const std::vector<RowVectorPtr> vectors =
       createVectors(rowType_, 32, 32 << 20);
   std::shared_ptr<core::QueryCtx> queryCtx =
@@ -485,7 +484,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, skipNonReclaimableTaskTest) {
                              .planNode();
   std::thread spillableThread([&]() {
     const auto spillDirectory = exec::test::TempDirectoryPath::create();
-    AssertQueryBuilder(spillPlan)
+    newQueryBuilder(spillPlan)
         .queryCtx(queryCtx)
         .spillDirectory(spillDirectory->getPath())
         .copyResults(pool());
@@ -501,7 +500,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, skipNonReclaimableTaskTest) {
                                     false)
                                 .planNode();
   std::thread nonSpillableThread([&]() {
-    AssertQueryBuilder(nonSpillPlan).queryCtx(queryCtx).copyResults(pool());
+    newQueryBuilder(nonSpillPlan).queryCtx(queryCtx).copyResults(pool());
   });
 
   while (!blockedPartialAggregation || !blockedAggregation) {
@@ -525,7 +524,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, skipNonReclaimableTaskTest) {
   ASSERT_EQ(taskPausedCount, 1);
 }
 
-DEBUG_ONLY_TEST_P(SharedArbitrationTestWithExecutionModes, reclaimToOrderBy) {
+DEBUG_ONLY_TEST_P(SharedArbitrationTestWithThreadingModes, reclaimToOrderBy) {
   const int numVectors = 32;
   std::vector<RowVectorPtr> vectors;
   for (int i = 0; i < numVectors; ++i) {
@@ -588,7 +587,7 @@ DEBUG_ONLY_TEST_P(SharedArbitrationTestWithExecutionModes, reclaimToOrderBy) {
     std::thread orderByThread([&]() {
       core::PlanNodeId orderByNodeId;
       auto task =
-          AssertQueryBuilder(duckDbQueryRunner_)
+          newQueryBuilder()
               .queryCtx(orderByQueryCtx)
               .serialExecution(isSerialExecutionMode_)
               .plan(PlanBuilder()
@@ -605,7 +604,7 @@ DEBUG_ONLY_TEST_P(SharedArbitrationTestWithExecutionModes, reclaimToOrderBy) {
 
     std::thread memThread([&]() {
       auto task =
-          AssertQueryBuilder(duckDbQueryRunner_)
+          newQueryBuilder()
               .queryCtx(fakeMemoryQueryCtx)
               .serialExecution(isSerialExecutionMode_)
               .plan(PlanBuilder()
@@ -628,7 +627,7 @@ DEBUG_ONLY_TEST_P(SharedArbitrationTestWithExecutionModes, reclaimToOrderBy) {
 }
 
 DEBUG_ONLY_TEST_P(
-    SharedArbitrationTestWithExecutionModes,
+    SharedArbitrationTestWithThreadingModes,
     reclaimToAggregation) {
   const int numVectors = 32;
   std::vector<RowVectorPtr> vectors;
@@ -692,7 +691,7 @@ DEBUG_ONLY_TEST_P(
     std::thread aggregationThread([&]() {
       core::PlanNodeId aggregationNodeId;
       auto task =
-          AssertQueryBuilder(duckDbQueryRunner_)
+          newQueryBuilder()
               .queryCtx(aggregationQueryCtx)
               .serialExecution(isSerialExecutionMode_)
               .plan(PlanBuilder()
@@ -710,7 +709,7 @@ DEBUG_ONLY_TEST_P(
 
     std::thread memThread([&]() {
       auto task =
-          AssertQueryBuilder(duckDbQueryRunner_)
+          newQueryBuilder()
               .queryCtx(fakeMemoryQueryCtx)
               .serialExecution(isSerialExecutionMode_)
               .plan(PlanBuilder()
@@ -733,7 +732,7 @@ DEBUG_ONLY_TEST_P(
 }
 
 DEBUG_ONLY_TEST_P(
-    SharedArbitrationTestWithExecutionModes,
+    SharedArbitrationTestWithThreadingModes,
     reclaimToJoinBuilder) {
   const int numVectors = 32;
   std::vector<RowVectorPtr> vectors;
@@ -798,7 +797,7 @@ DEBUG_ONLY_TEST_P(
       auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
       core::PlanNodeId joinNodeId;
       auto task =
-          AssertQueryBuilder(duckDbQueryRunner_)
+          newQueryBuilder()
               .queryCtx(joinQueryCtx)
               .serialExecution(isSerialExecutionMode_)
               .plan(PlanBuilder(planNodeIdGenerator)
@@ -826,7 +825,7 @@ DEBUG_ONLY_TEST_P(
 
     std::thread memThread([&]() {
       auto task =
-          AssertQueryBuilder(duckDbQueryRunner_)
+          newQueryBuilder()
               .queryCtx(fakeMemoryQueryCtx)
               .serialExecution(isSerialExecutionMode_)
               .plan(PlanBuilder()
@@ -848,7 +847,9 @@ DEBUG_ONLY_TEST_P(
   }
 }
 
-DEBUG_ONLY_TEST_F(SharedArbitrationTest, driverInitTriggeredArbitration) {
+DEBUG_ONLY_TEST_P(
+    SharedArbitrationTestWithThreadingModes,
+    driverInitTriggeredArbitration) {
   const int numVectors = 2;
   std::vector<RowVectorPtr> vectors;
   const int vectorSize = 100;
@@ -872,7 +873,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, driverInitTriggeredArbitration) {
   ASSERT_EQ(queryCtx->pool()->maxCapacity(), kMemoryCapacity);
 
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
-  AssertQueryBuilder(duckDbQueryRunner_)
+  newQueryBuilder()
       .config(core::QueryConfig::kSpillEnabled, "false")
       .queryCtx(queryCtx)
       .plan(PlanBuilder(planNodeIdGenerator, pool())
@@ -885,8 +886,8 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, driverInitTriggeredArbitration) {
   waitForAllTasksToBeDeleted();
 }
 
-DEBUG_ONLY_TEST_F(
-    SharedArbitrationTest,
+DEBUG_ONLY_TEST_P(
+    SharedArbitrationTestWithThreadingModes,
     DISABLED_raceBetweenTaskTerminateAndReclaim) {
   setupMemory(kMemoryCapacity, 0);
   const int numVectors = 10;
@@ -949,7 +950,7 @@ DEBUG_ONLY_TEST_F(
   const auto spillDirectory = exec::test::TempDirectoryPath::create();
   std::thread queryThread([&]() {
     VELOX_ASSERT_THROW(
-        AssertQueryBuilder(duckDbQueryRunner_)
+        newQueryBuilder()
             .queryCtx(queryCtx)
             .spillDirectory(spillDirectory->getPath())
             .config(core::QueryConfig::kSpillEnabled, "true")
@@ -982,7 +983,9 @@ DEBUG_ONLY_TEST_F(
   waitForAllTasksToBeDeleted();
 }
 
-DEBUG_ONLY_TEST_F(SharedArbitrationTest, asyncArbitratonFromNonDriverContext) {
+DEBUG_ONLY_TEST_P(
+    SharedArbitrationTestWithParallelExecutionModeOnly,
+    asyncArbitratonFromNonDriverContext) {
   setupMemory(kMemoryCapacity, 0);
   const int numVectors = 10;
   std::vector<RowVectorPtr> vectors;
@@ -1020,7 +1023,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, asyncArbitratonFromNonDriverContext) {
   const auto spillDirectory = exec::test::TempDirectoryPath::create();
   std::shared_ptr<Task> task;
   std::thread queryThread([&]() {
-    task = AssertQueryBuilder(duckDbQueryRunner_)
+    task = newQueryBuilder()
                .queryCtx(queryCtx)
                .spillDirectory(spillDirectory->getPath())
                .config(core::QueryConfig::kSpillEnabled, "true")
@@ -1058,7 +1061,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, asyncArbitratonFromNonDriverContext) {
   waitForAllTasksToBeDeleted();
 }
 
-DEBUG_ONLY_TEST_F(SharedArbitrationTest, runtimeStats) {
+DEBUG_ONLY_TEST_P(SharedArbitrationTestWithThreadingModes, runtimeStats) {
   const uint64_t memoryCapacity = 128 * MB;
   setupMemory(memoryCapacity);
   fuzzerOpts_.vectorSize = 1000;
@@ -1101,7 +1104,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, runtimeStats) {
           .planNode();
   {
     const std::shared_ptr<Task> task =
-        AssertQueryBuilder(duckDbQueryRunner_)
+        newQueryBuilder()
             .queryCtx(queryCtx)
             .maxDrivers(1)
             .spillDirectory(spillDirectory->getPath())
@@ -1136,7 +1139,9 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, runtimeStats) {
   waitForAllTasksToBeDeleted();
 }
 
-DEBUG_ONLY_TEST_F(SharedArbitrationTest, arbitrateMemoryFromOtherOperator) {
+DEBUG_ONLY_TEST_P(
+    SharedArbitrationTestWithParallelExecutionModeOnly,
+    arbitrateMemoryFromOtherOperator) {
   setupMemory(kMemoryCapacity, 0);
   const int numVectors = 10;
   std::vector<RowVectorPtr> vectors;
@@ -1195,7 +1200,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, arbitrateMemoryFromOtherOperator) {
     core::PlanNodeId aggregationNodeId;
     std::thread queryThread([&]() {
       if (sameDriver) {
-        task = AssertQueryBuilder(duckDbQueryRunner_)
+        task = newQueryBuilder()
                    .queryCtx(queryCtx)
                    .plan(PlanBuilder()
                              .values(vectors)
@@ -1206,7 +1211,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, arbitrateMemoryFromOtherOperator) {
                    .assertResults(
                        "SELECT c0, c1, array_agg(c2) FROM tmp GROUP BY c0, c1");
       } else {
-        task = AssertQueryBuilder(duckDbQueryRunner_)
+        task = newQueryBuilder()
                    .queryCtx(queryCtx)
                    .plan(PlanBuilder()
                              .values(vectors)
@@ -1233,7 +1238,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, arbitrateMemoryFromOtherOperator) {
   }
 }
 
-TEST_F(SharedArbitrationTest, concurrentArbitration) {
+TEST_P(SharedArbitrationTestWithParallelExecutionModeOnly, concurrentArbitration) {
   // Tries to replicate an actual workload by concurrently running multiple
   // query shapes that support spilling (and hence can be forced to abort or
   // spill by the arbitrator). Also adds an element of randomness by randomly
@@ -1253,16 +1258,16 @@ TEST_F(SharedArbitrationTest, concurrentArbitration) {
   const int numDrivers = 4;
   const auto expectedWriteResult =
       runWriteTask(
-          vectors, nullptr, numDrivers, pool(), kHiveConnectorId, false)
+          vectors, nullptr, isSerialExecutionMode_, numDrivers, pool(), kHiveConnectorId, false)
           .data;
   const auto expectedJoinResult =
-      runHashJoinTask(vectors, nullptr, numDrivers, pool(), false).data;
+      runHashJoinTask(vectors, nullptr, isSerialExecutionMode_, numDrivers, pool(), false).data;
   const auto expectedOrderResult =
-      runOrderByTask(vectors, nullptr, numDrivers, pool(), false).data;
+      runOrderByTask(vectors, nullptr, isSerialExecutionMode_, numDrivers, pool(), false).data;
   const auto expectedRowNumberResult =
-      runRowNumberTask(vectors, nullptr, numDrivers, pool(), false).data;
+      runRowNumberTask(vectors, nullptr, isSerialExecutionMode_,numDrivers, pool(), false).data;
   const auto expectedTopNResult =
-      runTopNTask(vectors, nullptr, numDrivers, pool(), false).data;
+      runTopNTask(vectors, nullptr, isSerialExecutionMode_,numDrivers, pool(), false).data;
 
   struct {
     uint64_t totalCapacity;
@@ -1305,6 +1310,7 @@ TEST_F(SharedArbitrationTest, concurrentArbitration) {
             task = runWriteTask(
                        vectors,
                        queryCtx,
+                       isSerialExecutionMode_,
                        numDrivers,
                        pool(),
                        kHiveConnectorId,
@@ -1315,6 +1321,7 @@ TEST_F(SharedArbitrationTest, concurrentArbitration) {
             task = runHashJoinTask(
                        vectors,
                        queryCtx,
+                       isSerialExecutionMode_,
                        numDrivers,
                        pool(),
                        true,
@@ -1324,6 +1331,7 @@ TEST_F(SharedArbitrationTest, concurrentArbitration) {
             task = runOrderByTask(
                        vectors,
                        queryCtx,
+                       isSerialExecutionMode_,
                        numDrivers,
                        pool(),
                        true,
@@ -1333,6 +1341,7 @@ TEST_F(SharedArbitrationTest, concurrentArbitration) {
             task = runRowNumberTask(
                        vectors,
                        queryCtx,
+                       isSerialExecutionMode_,
                        numDrivers,
                        pool(),
                        true,
@@ -1342,6 +1351,7 @@ TEST_F(SharedArbitrationTest, concurrentArbitration) {
             task = runTopNTask(
                        vectors,
                        queryCtx,
+                       isSerialExecutionMode_,
                        numDrivers,
                        pool(),
                        true,
@@ -1376,7 +1386,7 @@ TEST_F(SharedArbitrationTest, concurrentArbitration) {
   }
 }
 
-TEST_F(SharedArbitrationTest, reserveReleaseCounters) {
+TEST_P(SharedArbitrationTestWithThreadingModes, reserveReleaseCounters) {
   for (int i = 0; i < 37; ++i) {
     folly::Random::DefaultGenerator rng(i);
     auto numRootPools = folly::Random::rand32(rng) % 11 + 3;
@@ -1407,10 +1417,14 @@ TEST_F(SharedArbitrationTest, reserveReleaseCounters) {
 }
 
 VELOX_INSTANTIATE_TEST_SUITE_P(
-    SharedArbitrationTestWithExecutionModes,
-    SharedArbitrationTestWithExecutionModes,
-    testing::ValuesIn(
-        SharedArbitrationTestWithExecutionModes::getTestParams()));
+    SharedArbitrationTest,
+    SharedArbitrationTestWithParallelExecutionModeOnly,
+    testing::ValuesIn(std::vector<TestParam>{{false}}));
+
+VELOX_INSTANTIATE_TEST_SUITE_P(
+    SharedArbitrationTest,
+    SharedArbitrationTestWithThreadingModes,
+    testing::ValuesIn(std::vector<TestParam>{{false}, {true}}));
 } // namespace facebook::velox::memory
 
 int main(int argc, char** argv) {

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -4282,7 +4282,8 @@ DEBUG_ONLY_TEST_F(
   std::vector<RowVectorPtr> vectors =
       createVectors(rowType_, memoryCapacity / 8, fuzzerOpts_);
   const auto expectedResult =
-      runWriteTask(vectors, nullptr, 1, pool(), kHiveConnectorId, false).data;
+      runWriteTask(vectors, nullptr, 1, false, pool(), kHiveConnectorId, false)
+          .data;
   auto queryCtx =
       newQueryCtx(memory::memoryManager(), executor_.get(), memoryCapacity);
 
@@ -4307,7 +4308,14 @@ DEBUG_ONLY_TEST_F(
 
   std::thread queryThread([&]() {
     const auto result = runWriteTask(
-        vectors, queryCtx, 1, pool(), kHiveConnectorId, true, expectedResult);
+        vectors,
+        queryCtx,
+        1,
+        false,
+        pool(),
+        kHiveConnectorId,
+        true,
+        expectedResult);
   });
 
   writerCloseWait.await([&]() { return !writerCloseWaitFlag.load(); });

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -4282,7 +4282,7 @@ DEBUG_ONLY_TEST_F(
   std::vector<RowVectorPtr> vectors =
       createVectors(rowType_, memoryCapacity / 8, fuzzerOpts_);
   const auto expectedResult =
-      runWriteTask(vectors, nullptr, 1, false, pool(), kHiveConnectorId, false)
+      runWriteTask(vectors, nullptr, false, 1, pool(), kHiveConnectorId, false)
           .data;
   auto queryCtx =
       newQueryCtx(memory::memoryManager(), executor_.get(), memoryCapacity);

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -4310,8 +4310,8 @@ DEBUG_ONLY_TEST_F(
     const auto result = runWriteTask(
         vectors,
         queryCtx,
-        1,
         false,
+        1,
         pool(),
         kHiveConnectorId,
         true,

--- a/velox/exec/tests/utils/ArbitratorTestUtil.cpp
+++ b/velox/exec/tests/utils/ArbitratorTestUtil.cpp
@@ -91,6 +91,7 @@ core::PlanNodePtr hashJoinPlan(
 QueryTestResult runHashJoinTask(
     const std::vector<RowVectorPtr>& vectors,
     const std::shared_ptr<core::QueryCtx>& queryCtx,
+    bool serialExecution,
     uint32_t numDrivers,
     memory::MemoryPool* pool,
     bool enableSpilling,
@@ -100,6 +101,7 @@ QueryTestResult runHashJoinTask(
   if (enableSpilling) {
     const auto spillDirectory = exec::test::TempDirectoryPath::create();
     result.data = AssertQueryBuilder(plan)
+                      .serialExecution(serialExecution)
                       .spillDirectory(spillDirectory->getPath())
                       .config(core::QueryConfig::kSpillEnabled, true)
                       .config(core::QueryConfig::kJoinSpillEnabled, true)
@@ -109,6 +111,7 @@ QueryTestResult runHashJoinTask(
                       .copyResults(pool, result.task);
   } else {
     result.data = AssertQueryBuilder(plan)
+                      .serialExecution(serialExecution)
                       .queryCtx(queryCtx)
                       .maxDrivers(numDrivers)
                       .copyResults(pool, result.task);
@@ -133,6 +136,7 @@ core::PlanNodePtr aggregationPlan(
 QueryTestResult runAggregateTask(
     const std::vector<RowVectorPtr>& vectors,
     const std::shared_ptr<core::QueryCtx>& queryCtx,
+    bool serialExecution,
     bool enableSpilling,
     uint32_t numDrivers,
     memory::MemoryPool* pool,
@@ -143,6 +147,7 @@ QueryTestResult runAggregateTask(
     const auto spillDirectory = exec::test::TempDirectoryPath::create();
     result.data =
         AssertQueryBuilder(plan)
+            .serialExecution(serialExecution)
             .spillDirectory(spillDirectory->getPath())
             .config(core::QueryConfig::kSpillEnabled, "true")
             .config(core::QueryConfig::kAggregationSpillEnabled, "true")
@@ -151,6 +156,7 @@ QueryTestResult runAggregateTask(
             .copyResults(pool, result.task);
   } else {
     result.data = AssertQueryBuilder(plan)
+                      .serialExecution(serialExecution)
                       .queryCtx(queryCtx)
                       .maxDrivers(numDrivers)
                       .copyResults(pool, result.task);
@@ -176,6 +182,7 @@ core::PlanNodePtr orderByPlan(
 QueryTestResult runOrderByTask(
     const std::vector<RowVectorPtr>& vectors,
     const std::shared_ptr<core::QueryCtx>& queryCtx,
+    bool serialExecution,
     uint32_t numDrivers,
     memory::MemoryPool* pool,
     bool enableSpilling,
@@ -185,6 +192,7 @@ QueryTestResult runOrderByTask(
   if (enableSpilling) {
     const auto spillDirectory = exec::test::TempDirectoryPath::create();
     result.data = AssertQueryBuilder(plan)
+                      .serialExecution(serialExecution)
                       .spillDirectory(spillDirectory->getPath())
                       .config(core::QueryConfig::kSpillEnabled, "true")
                       .config(core::QueryConfig::kOrderBySpillEnabled, "true")
@@ -193,6 +201,7 @@ QueryTestResult runOrderByTask(
                       .copyResults(pool, result.task);
   } else {
     result.data = AssertQueryBuilder(plan)
+                      .serialExecution(serialExecution)
                       .queryCtx(queryCtx)
                       .maxDrivers(numDrivers)
                       .copyResults(pool, result.task);
@@ -218,6 +227,7 @@ core::PlanNodePtr rowNumberPlan(
 QueryTestResult runRowNumberTask(
     const std::vector<RowVectorPtr>& vectors,
     const std::shared_ptr<core::QueryCtx>& queryCtx,
+    bool serialExecution,
     uint32_t numDrivers,
     memory::MemoryPool* pool,
     bool enableSpilling,
@@ -227,6 +237,7 @@ QueryTestResult runRowNumberTask(
   if (enableSpilling) {
     const auto spillDirectory = exec::test::TempDirectoryPath::create();
     result.data = AssertQueryBuilder(plan)
+                      .serialExecution(serialExecution)
                       .spillDirectory(spillDirectory->getPath())
                       .config(core::QueryConfig::kSpillEnabled, "true")
                       .config(core::QueryConfig::kRowNumberSpillEnabled, "true")
@@ -235,6 +246,7 @@ QueryTestResult runRowNumberTask(
                       .copyResults(pool, result.task);
   } else {
     result.data = AssertQueryBuilder(plan)
+                      .serialExecution(serialExecution)
                       .queryCtx(queryCtx)
                       .maxDrivers(numDrivers)
                       .copyResults(pool, result.task);
@@ -260,6 +272,7 @@ core::PlanNodePtr topNPlan(
 QueryTestResult runTopNTask(
     const std::vector<RowVectorPtr>& vectors,
     const std::shared_ptr<core::QueryCtx>& queryCtx,
+    bool serialExecution,
     uint32_t numDrivers,
     memory::MemoryPool* pool,
     bool enableSpilling,
@@ -270,6 +283,7 @@ QueryTestResult runTopNTask(
     const auto spillDirectory = exec::test::TempDirectoryPath::create();
     result.data =
         AssertQueryBuilder(plan)
+            .serialExecution(serialExecution)
             .spillDirectory(spillDirectory->getPath())
             .config(core::QueryConfig::kSpillEnabled, "true")
             .config(core::QueryConfig::kTopNRowNumberSpillEnabled, "true")
@@ -278,6 +292,7 @@ QueryTestResult runTopNTask(
             .copyResults(pool, result.task);
   } else {
     result.data = AssertQueryBuilder(plan)
+                      .serialExecution(serialExecution)
                       .queryCtx(queryCtx)
                       .maxDrivers(numDrivers)
                       .copyResults(pool, result.task);
@@ -305,6 +320,7 @@ core::PlanNodePtr writePlan(
 QueryTestResult runWriteTask(
     const std::vector<RowVectorPtr>& vectors,
     const std::shared_ptr<core::QueryCtx>& queryCtx,
+    bool serialExecution,
     uint32_t numDrivers,
     memory::MemoryPool* pool,
     const std::string& kHiveConnectorId,
@@ -317,6 +333,7 @@ QueryTestResult runWriteTask(
     const auto spillDirectory = exec::test::TempDirectoryPath::create();
     result.data =
         AssertQueryBuilder(plan)
+            .serialExecution(serialExecution)
             .spillDirectory(spillDirectory->getPath())
             .config(core::QueryConfig::kSpillEnabled, "true")
             .config(core::QueryConfig::kAggregationSpillEnabled, "false")
@@ -345,6 +362,7 @@ QueryTestResult runWriteTask(
             .copyResults(pool, result.task);
   } else {
     result.data = AssertQueryBuilder(plan)
+                      .serialExecution(serialExecution)
                       .queryCtx(queryCtx)
                       .maxDrivers(numDrivers)
                       .copyResults(pool, result.task);

--- a/velox/exec/tests/utils/ArbitratorTestUtil.h
+++ b/velox/exec/tests/utils/ArbitratorTestUtil.h
@@ -114,6 +114,7 @@ core::PlanNodePtr hashJoinPlan(
 QueryTestResult runHashJoinTask(
     const std::vector<RowVectorPtr>& vectors,
     const std::shared_ptr<core::QueryCtx>& queryCtx,
+    bool serialExecution,
     uint32_t numDrivers,
     memory::MemoryPool* pool,
     bool enableSpilling,
@@ -126,6 +127,7 @@ core::PlanNodePtr aggregationPlan(
 QueryTestResult runAggregateTask(
     const std::vector<RowVectorPtr>& vectors,
     const std::shared_ptr<core::QueryCtx>& queryCtx,
+    bool serialExecution,
     bool enableSpilling,
     uint32_t numDrivers,
     memory::MemoryPool* pool,
@@ -138,6 +140,7 @@ core::PlanNodePtr orderByPlan(
 QueryTestResult runOrderByTask(
     const std::vector<RowVectorPtr>& vectors,
     const std::shared_ptr<core::QueryCtx>& queryCtx,
+    bool serialExecution,
     uint32_t numDrivers,
     memory::MemoryPool* pool,
     bool enableSpilling,
@@ -150,6 +153,7 @@ core::PlanNodePtr rowNumberPlan(
 QueryTestResult runRowNumberTask(
     const std::vector<RowVectorPtr>& vectors,
     const std::shared_ptr<core::QueryCtx>& queryCtx,
+    bool serialExecution,
     uint32_t numDrivers,
     memory::MemoryPool* pool,
     bool enableSpilling,
@@ -162,6 +166,7 @@ core::PlanNodePtr topNPlan(
 QueryTestResult runTopNTask(
     const std::vector<RowVectorPtr>& vectors,
     const std::shared_ptr<core::QueryCtx>& queryCtx,
+    bool serialExecution,
     uint32_t numDrivers,
     memory::MemoryPool* pool,
     bool enableSpilling,
@@ -175,6 +180,7 @@ core::PlanNodePtr writePlan(
 QueryTestResult runWriteTask(
     const std::vector<RowVectorPtr>& vectors,
     const std::shared_ptr<core::QueryCtx>& queryCtx,
+    bool serialExecution,
     uint32_t numDrivers,
     memory::MemoryPool* pool,
     const std::string& kHiveConnectorId,


### PR DESCRIPTION
As title, and with minor refactors.

The following 3 cases will still be executed with parallel mode only because:

1. `asyncArbitratonFromNonDriverContext`: Plan doesn't support serial execution
2. `arbitrateMemoryFromOtherOperator`: Plan doesn't support serial execution
3. `concurrentArbitration`: Test run hangs

`3` should be fixed in subsequent PR.