### PR TITLE
Fix S3FileSystem CRC32 checksum on AWS S3

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -397,7 +397,7 @@ class S3WriteFile::Impl {
       // Don't add the checksum to the part if the checksum is empty.
       // Some filesystems such as IBM COS require this to be not set.
       if (!result.GetChecksumCRC32().empty()) {
-          part.SetChecksumCRC32(result.GetChecksumCRC32());
+        part.SetChecksumCRC32(result.GetChecksumCRC32());
       }
       uploadState_.completedParts.push_back(std::move(part));
     }

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -263,6 +263,10 @@ class S3WriteFile::Impl {
       /// (https://github.com/apache/arrow/issues/11934). So we instead default
       /// to application/octet-stream which is less misleading.
       request.SetContentType(kApplicationOctetStream);
+      // The default algorithm used is MD5. However, MD5 is not supported with
+      // fips and can cause a SIGSEGV. Set CRC32 instead which is a standard for
+      // checksum computation and is not restricted by fips.
+      request.SetChecksumAlgorithm(Aws::S3::Model::ChecksumAlgorithm::CRC32);
 
       auto outcome = client_->CreateMultipartUpload(request);
       VELOX_CHECK_AWS_OUTCOME(
@@ -390,6 +394,11 @@ class S3WriteFile::Impl {
 
       part.SetPartNumber(uploadState_.partNumber);
       part.SetETag(result.GetETag());
+      // Don't add the checksum to the part if the checksum is empty.
+      // Some filesystems such as IBM COS require this to be not set.
+      if (!result.GetChecksumCRC32().empty()) {
+          part.SetChecksumCRC32(result.GetChecksumCRC32());
+      }
       uploadState_.completedParts.push_back(std::move(part));
     }
   }


### PR DESCRIPTION
The recent change was tested against Minio and not on AWS S3.
AWS S3 needs some more API calls.