### PR TITLE
Use the apache hive logic to fetch escape delimiter in Hive SerDeOptions

### DIFF
--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -159,6 +159,38 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
   performConfigure();
   EXPECT_TRUE(compareSerDeOptions(readerOptions.serDeOptions(), expectedSerDe));
 
+  // Empty escape delim means default escape char.
+  clearDynamicParameters(FileFormat::TEXT);
+  serdeParameters[SerDeOptions::kEscapeChar] = "";
+  expectedSerDe.escapeChar = '\\';
+  expectedSerDe.isEscaped = true;
+  performConfigure();
+  EXPECT_TRUE(compareSerDeOptions(readerOptions.serDeOptions(), expectedSerDe));
+
+  // Convertible to byte escape char - use it.
+  clearDynamicParameters(FileFormat::TEXT);
+  serdeParameters[SerDeOptions::kEscapeChar] = "38";
+  expectedSerDe.escapeChar = '&';
+  expectedSerDe.isEscaped = true;
+  performConfigure();
+  EXPECT_TRUE(compareSerDeOptions(readerOptions.serDeOptions(), expectedSerDe));
+
+  // Overflow byte escape char - fall back to the 1st character of the string.
+  clearDynamicParameters(FileFormat::TEXT);
+  serdeParameters[SerDeOptions::kEscapeChar] = "381";
+  expectedSerDe.escapeChar = '3';
+  expectedSerDe.isEscaped = true;
+  performConfigure();
+  EXPECT_TRUE(compareSerDeOptions(readerOptions.serDeOptions(), expectedSerDe));
+
+  // Not convertible string - fall back to the 1st character of the string.
+  clearDynamicParameters(FileFormat::TEXT);
+  serdeParameters[SerDeOptions::kEscapeChar] = "7!";
+  expectedSerDe.escapeChar = '7';
+  expectedSerDe.isEscaped = true;
+  performConfigure();
+  EXPECT_TRUE(compareSerDeOptions(readerOptions.serDeOptions(), expectedSerDe));
+
   // Modify all previous together.
   clearDynamicParameters(FileFormat::TEXT);
   serdeParameters[SerDeOptions::kFieldDelim] = '~';
@@ -167,12 +199,12 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
   expectedSerDe.separators[size_t(SerDeSeparator::COLLECTION_DELIM)] = '$';
   serdeParameters[SerDeOptions::kMapKeyDelim] = '*';
   expectedSerDe.separators[size_t(SerDeSeparator::MAP_KEY_DELIM)] = '*';
+  serdeParameters[SerDeOptions::kEscapeChar] = '*';
+  expectedSerDe.escapeChar = '*';
+  expectedSerDe.isEscaped = true;
   tableParameters[TableParameter::kSerializationNullFormat] = "";
   expectedSerDe.nullString = "";
   performConfigure();
-  EXPECT_TRUE(compareSerDeOptions(readerOptions.serDeOptions(), expectedSerDe));
-  EXPECT_TRUE(compareSerDeOptions(readerOptions.serDeOptions(), expectedSerDe));
-  EXPECT_TRUE(compareSerDeOptions(readerOptions.serDeOptions(), expectedSerDe));
   EXPECT_TRUE(compareSerDeOptions(readerOptions.serDeOptions(), expectedSerDe));
 
   // Tests other custom reader options.


### PR DESCRIPTION
Summary:
Use the apache hive logic to fetch escape delimiter in Hive SerDeOptions.
https://github.com/apache/hive/blob/3f6f940af3f60cc28834268e5d7f5612e3b13c30/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazySerDeParameters.java#L105-L108

Differential Revision: D62139559
