### PR TITLE
Fix TRY_CAST(VARCHAR as TIMESTAMP) incorrectly suppress errors of input outside supported ranges

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -76,6 +76,13 @@ int main(int argc, char** argv) {
       "regexp_like",
       "regexp_replace",
       "regexp_split",
+      // date_format and format_datetime throw VeloxRuntimeError when input
+      // timestamp is out of the supported range.
+      "date_format",
+      "format_datetime",
+      // from_unixtime can generate timestamps out of the supported range that
+      // make other functions throw VeloxRuntimeErrors.
+      "from_unixtime",
   };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
 

--- a/velox/expression/fuzzer/SparkExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/SparkExpressionFuzzerTest.cpp
@@ -62,7 +62,14 @@ int main(int argc, char** argv) {
       "chr",
       "replace",
       "might_contain",
-      "unix_timestamp"};
+      "unix_timestamp",
+      // from_unixtime throws VeloxRuntimeError when the timestamp is out of the
+      // supported range.
+      "from_unixtime",
+      // timestamp_millis(bigint) can generate timestamps out of the supported
+      // range that make other functions throw VeloxRuntimeErrors.
+      "timestamp_millis(bigint) -> timestamp",
+  };
 
   // Required by spark_partition_id function.
   std::unordered_map<std::string, std::string> queryConfigs = {

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -581,10 +581,27 @@ TEST_F(CastExprTest, stringToTimestamp) {
   };
   testCast<std::string, Timestamp>("timestamp", input, expected);
 
+  // Test invalid inputs.
   VELOX_ASSERT_THROW(
       (evaluateOnce<Timestamp, std::string>(
           "cast(c0 as timestamp)", "1970-01-01T00:00")),
       "Cannot cast VARCHAR '1970-01-01T00:00' to TIMESTAMP. Unable to parse timestamp value");
+  VELOX_ASSERT_THROW(
+      (evaluateOnce<Timestamp, std::string>(
+          "cast(c0 as timestamp)", "201915-04-23 11:46:00.000")),
+      "Timepoint is outside of supported year range");
+  VELOX_ASSERT_THROW(
+      (evaluateOnce<Timestamp, std::string>(
+          "try_cast(c0 as timestamp)", "201915-04-23 11:46:00.000")),
+      "Timepoint is outside of supported year range");
+  VELOX_ASSERT_THROW(
+      (evaluateOnce<Timestamp, std::string>(
+          "cast(c0 as timestamp)", "2045-12-31 18:00:00")),
+      "Unable to convert timezone 'America/Los_Angeles' past 2037-11-01 09:00:00");
+  VELOX_ASSERT_THROW(
+      (evaluateOnce<Timestamp, std::string>(
+          "try_cast(c0 as timestamp)", "2045-12-31 18:00:00")),
+      "Unable to convert timezone 'America/Los_Angeles' past 2037-11-01 09:00:00");
 
   setLegacyCast(true);
   input = {

--- a/velox/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/velox/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -1447,10 +1447,10 @@ TEST_F(MysqlDateTimeTest, formatYear) {
       "-0001");
   EXPECT_THROW(
       formatMysqlDateTime("%Y", fromTimestampString("-99999-01-01"), timezone),
-      VeloxUserError);
+      VeloxRuntimeError);
   EXPECT_THROW(
       formatMysqlDateTime("%Y", fromTimestampString("99999-01-01"), timezone),
-      VeloxUserError);
+      VeloxRuntimeError);
 }
 
 TEST_F(MysqlDateTimeTest, formatMonthDay) {

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -56,6 +56,11 @@ void Timestamp::toGMT(const tz::TimeZone& zone) {
   } catch (const date::nonexistent_local_time& error) {
     // If the time does not exist, fail the conversion.
     VELOX_USER_FAIL(error.what());
+  } catch (const std::invalid_argument& e) {
+    // Invalid argument means we hit a conversion not supported by
+    // external/date. Need to throw a RuntimeError so that try() statements do
+    // not suppress it.
+    VELOX_FAIL(e.what());
   }
   seconds_ = sysSeconds.count();
 }

--- a/velox/type/tz/TimeZoneMap.cpp
+++ b/velox/type/tz/TimeZoneMap.cpp
@@ -209,7 +209,7 @@ void validateRangeImpl(time_point<TDuration> timePoint) {
   auto year = year_month_day(floor<days>(timePoint)).year();
 
   if (year < kMinYear || year > kMaxYear) {
-    VELOX_USER_FAIL(
+    VELOX_FAIL(
         "Timepoint is outside of supported year range: [{}, {}], got {}",
         (int)kMinYear,
         (int)kMaxYear,


### PR DESCRIPTION
Summary: Similar to https://github.com/facebookincubator/velox/pull/10097, force CAST(VARCHAR as TIMESTAMP) to throw VeloxRuntimeErrors on inputs outside the supported ranges, so that TRY_CAST doesn't suppress them.

Reviewed By: amitkdutta

Differential Revision: D62196915
