### PR TITLE
feat: Support WEEK_YEAR for date time formatter

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -324,6 +324,22 @@ class QueryConfig {
   static constexpr const char* kSparkLegacyDateFormatter =
       "spark.legacy_date_formatter";
 
+  /// The first day-of-week varies by culture.
+  /// firstDayOfWeek is a 1-based weekday number starting with Sunday. It
+  /// determines how week-based calendar works. For example, the ISO-8601 use
+  /// Monday (2) and the US uses Sunday (1). It should be set to match the
+  /// 'Calender.getFirstDayOfWeek()' in Java. Sunday (1) is used by default.
+  static constexpr const char* kSparkFirstDayOfWeek =
+      "spark.legacy_date_formatter.first_day_of_week";
+
+  /// The minimal number of days in the first week by culture.
+  /// The week that includes January 1st and has 'minimalDaysInFirstWeek' or
+  /// more days is referred to as week 1. It determines how week-based calendar
+  /// works. It should be set to match the
+  /// 'Calender.getMinimalDaysInFirstWeek()' in Java. 1 days is used by default.
+  static constexpr const char* kSparkMinimalDaysInFirstWeek =
+      "spark.legacy_date_formatter.minimal_days_in_first_week";
+
   /// The number of local parallel table writer operators per task.
   static constexpr const char* kTaskWriterCount = "task_writer_count";
 
@@ -815,6 +831,22 @@ class QueryConfig {
 
   bool sparkLegacyDateFormatter() const {
     return get<bool>(kSparkLegacyDateFormatter, false);
+  }
+
+  uint8_t sparkFirstDayOfWeek() const {
+    auto value = get<uint32_t>(kSparkFirstDayOfWeek, 1);
+    VELOX_USER_CHECK(
+        1 <= value && value <= 7,
+        "firstDayOfWeek must be a number between 1 and 7");
+    return static_cast<uint8_t>(value);
+  }
+
+  uint8_t sparkMinimalDaysInFirstWeek() const {
+    auto value = get<uint32_t>(kSparkMinimalDaysInFirstWeek, 1);
+    VELOX_USER_CHECK(
+        1 <= value && value <= 7,
+        "minimalDaysInFirstWeek must be a number between 1 and 7");
+    return static_cast<uint8_t>(value);
   }
 
   bool exprTrackCpuUsage() const {

--- a/velox/functions/lib/DateTimeFormatter.h
+++ b/velox/functions/lib/DateTimeFormatter.h
@@ -215,11 +215,31 @@ class DateTimeFormatter {
       bool allowOverflow = false,
       const std::optional<std::string>& zeroOffsetText = std::nullopt) const;
 
+  void setFirstDayOfWeek(uint8_t firstDayOfWeek) {
+    firstDayOfWeek_ = firstDayOfWeek;
+  }
+
+  void setMinimalDaysInFirstWeek(uint8_t minimalDaysInFirstWeek) {
+    minimalDaysInFirstWeek_ = minimalDaysInFirstWeek;
+  }
+
  private:
   std::unique_ptr<char[]> literalBuf_;
   size_t bufSize_;
   std::vector<DateTimeToken> tokens_;
   DateTimeFormatterType type_;
+
+  /// The first day-of-week varies by culture.
+  /// firstDayOfWeek is a 1-based weekday number starting with Sunday. It
+  /// determines how week-based calendar works. For example, the ISO-8601 use
+  /// Monday (2) and the US uses Sunday (1).
+  uint8_t firstDayOfWeek_ = 2;
+
+  /// The minimal number of days in the first week by culture.
+  /// The week that includes January 1st and has 'minimalDaysInFirstWeek' or
+  /// more days is referred to as week 1. It determines how week-based calendar
+  /// works. For example, the ISO-8601 use 4 days.
+  uint8_t minimalDaysInFirstWeek_ = 4;
 };
 
 Expected<std::shared_ptr<DateTimeFormatter>> buildMysqlDateTimeFormatter(

--- a/velox/functions/lib/TimeUtils.h
+++ b/velox/functions/lib/TimeUtils.h
@@ -20,6 +20,7 @@
 #include "velox/external/date/date.h"
 #include "velox/external/date/iso_week.h"
 #include "velox/functions/Macros.h"
+#include "velox/type/TimestampConversion.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox::functions {
@@ -123,4 +124,97 @@ struct InitSessionTimezone {
     timeZone_ = getTimeZoneFromConfig(config);
   }
 };
+
+/// Return day-of-year (DOY) of the first `dayOfWeek` in the year.
+///
+/// `dayOfWeek` is a 1-based weekday number starting with Sunday.
+///   (1 = Sunday, 2 = Monday, ..., 7 = Saturday).
+///
+/// If the `dayOfWeek` is Monday, it returns DOY of first Monday in
+/// the year. The returned DOY is a number from 1 to 7.
+FOLLY_ALWAYS_INLINE
+uint32_t getDayOfFirstDayOfWeek(int32_t y, uint32_t dayOfWeek) {
+  auto firstDay =
+      date::year_month_day(date::year(y), date::month(1), date::day(1));
+  auto weekday = date::weekday(firstDay).c_encoding() + 1;
+
+  int32_t delta = dayOfWeek - weekday;
+  if (delta < 0) {
+    delta += 7;
+  }
+
+  return delta + 1;
+}
+
+/// Return the week year represented by Gregorian calendar for the given year,
+/// month and day.
+///
+/// getWeekYear only works with Gregorian calendar due to limitations in the
+/// date library. As a result, dates before the Gregorian calendar
+/// (1582-10-15) yields mismatched results.
+///
+/// The week that includes January 1st and has 'minimalDaysInFirstWeek' or more
+/// days is referred to as week 1. The starting day of the week is decided by
+/// the `firstDayOfWeek`, which is a 1-based weekday number starting with
+/// Sunday.
+///
+/// For ISO 8601, `firstDayOfWeek` is 2 (Monday) and `minimalDaysInFirstWeek`
+/// is 4. For legacy Spark, `firstDayOfWeek` is 1 (Sunday) and
+/// `minimalDaysInFirstWeek` is 1.
+///
+/// The algorithm refers to the getWeekYear algorithm in openjdk:
+/// https://github.com/openjdk/jdk/blob/d9c67443f7d7f03efb2837b63ee2acc6113f737f/src/java.base/share/classes/java/util/GregorianCalendar.java#L2058
+FOLLY_ALWAYS_INLINE
+int32_t getWeekYear(
+    int32_t y,
+    uint32_t m,
+    uint32_t d,
+    uint32_t firstDayOfWeek,
+    uint32_t minimalDaysInFirstWeek) {
+  const auto ymd =
+      date::year_month_day(date::year(y), date::month(m), date::day(d));
+  const auto firstDayOfTheYear =
+      date::year_month_day(ymd.year(), date::month(1), date::day(1));
+  const auto dayOfYear =
+      (date::sys_days{ymd} - date::sys_days{firstDayOfTheYear}).count() + 1;
+  const auto maxDayOfYear = util::isLeapYear(y) ? 366 : 365;
+
+  // If this week does not cross the years (`7 < dayOfYear && dayOfYear <
+  // (maxDayOfYear - 6)`), the weekyear must be equal to the year.
+  //
+  // If some days of this week fall in the last year and `minimalDaysInFirstWeek
+  // < dayOfYear`, the number of days in this week in this year must be greater
+  // than minimalDaysInFirstWeek, so the weekyear must be equal to the year.
+  //
+  // Since minimalDaysInFirstWeek always no more than 7, these two conditions
+  // can be reduced to the following code.
+  if (dayOfYear > minimalDaysInFirstWeek && dayOfYear < (maxDayOfYear - 6)) {
+    return y;
+  }
+
+  auto year = y;
+  // Day of beginning of first complete week of this year.
+  auto minDayOfYear = getDayOfFirstDayOfWeek(y, firstDayOfWeek);
+  if (dayOfYear >= minDayOfYear) {
+    // Day of ending of first week of the last year.
+    auto minDayOfYear = getDayOfFirstDayOfWeek(y + 1, firstDayOfWeek) - 1;
+    if (minDayOfYear == 0) {
+      minDayOfYear = 7;
+    }
+
+    // If that week belongs to the next weekyear.
+    if (minDayOfYear >= minimalDaysInFirstWeek) {
+      // If dayOfYear is in that week.
+      int days = maxDayOfYear - dayOfYear + 1;
+      if (days <= (7 - minDayOfYear)) {
+        ++year;
+      }
+    }
+  } else if (minDayOfYear <= minimalDaysInFirstWeek) {
+    // Days of the first week in this year less then minimalDaysInFirstWeek
+    --year;
+  }
+
+  return year;
+}
 } // namespace facebook::velox::functions

--- a/velox/functions/lib/tests/CMakeLists.txt
+++ b/velox/functions/lib/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(
   RepeatTest.cpp
   TDigestTest.cpp
   Utf8Test.cpp
+  TimeUtilsTest.cpp
   ZetaDistributionTest.cpp)
 
 add_test(

--- a/velox/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/velox/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -1357,6 +1357,26 @@ TEST_F(JodaDateTimeFormatterTest, betterErrorMessaging) {
       "Value 429 for dayOfMonth must be in the range [1,365] for year 2057 and month 2.");
 }
 
+TEST_F(JodaDateTimeFormatterTest, formatWeekYear) {
+  DateTimeFormatterBuilder builder(10);
+  auto formatter =
+      builder.appendWeekYear(4).setType(DateTimeFormatterType::JODA).build();
+  auto* timezone = tz::locateZone("GMT");
+  const auto maxSize = formatter->maxResultSize(timezone);
+
+  auto weekYear = [&](StringView time) {
+    std::string result(maxSize, '\0');
+    auto resultSize = formatter->format(
+        fromTimestampString(time), timezone, maxSize, result.data());
+    result.resize(resultSize);
+    return result;
+  };
+
+  EXPECT_EQ(weekYear("2019-12-31 00:00:00"), "2020");
+  EXPECT_EQ(weekYear("2020-12-26 00:00:00"), "2020");
+  EXPECT_EQ(weekYear("2021-01-01 00:00:00"), "2020");
+}
+
 class MysqlDateTimeTest : public DateTimeFormatterTest {};
 
 TEST_F(MysqlDateTimeTest, validBuild) {

--- a/velox/functions/lib/tests/TimeUtilsTest.cpp
+++ b/velox/functions/lib/tests/TimeUtilsTest.cpp
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/lib/TimeUtils.h"
+#include <gtest/gtest.h>
+
+namespace facebook::velox::functions::test {
+
+class TimeUtilsTest : public testing::Test {};
+
+TEST_F(TimeUtilsTest, getFirstDayOfWeek) {
+  EXPECT_EQ(getDayOfFirstDayOfWeek(2024, 1), 7);
+  EXPECT_EQ(getDayOfFirstDayOfWeek(2024, 2), 1);
+  EXPECT_EQ(getDayOfFirstDayOfWeek(2024, 3), 2);
+  EXPECT_EQ(getDayOfFirstDayOfWeek(2024, 4), 3);
+  EXPECT_EQ(getDayOfFirstDayOfWeek(2024, 5), 4);
+  EXPECT_EQ(getDayOfFirstDayOfWeek(2024, 6), 5);
+  EXPECT_EQ(getDayOfFirstDayOfWeek(2024, 7), 6);
+}
+
+TEST_F(TimeUtilsTest, getWeakYear) {
+  EXPECT_EQ(getWeekYear(2017, 01, 01, 1, 1), 2017); // 2017W1
+  EXPECT_EQ(getWeekYear(2017, 01, 01, 2, 4), 2016); // 2016W52
+  EXPECT_EQ(getWeekYear(2017, 01, 02, 1, 1), 2017); // 2017W1
+  EXPECT_EQ(getWeekYear(2017, 01, 02, 2, 4), 2017); // 2017W1
+  EXPECT_EQ(getWeekYear(2017, 01, 03, 1, 1), 2017); // 2017W1
+  EXPECT_EQ(getWeekYear(2017, 01, 03, 2, 4), 2017); // 2017W1
+  EXPECT_EQ(getWeekYear(2017, 01, 04, 1, 1), 2017); // 2017W1
+  EXPECT_EQ(getWeekYear(2017, 01, 04, 2, 4), 2017); // 2017W1
+  EXPECT_EQ(getWeekYear(2017, 01, 05, 1, 1), 2017); // 2017W1
+  EXPECT_EQ(getWeekYear(2017, 01, 05, 2, 4), 2017); // 2017W1
+  EXPECT_EQ(getWeekYear(2017, 01, 06, 1, 1), 2017); // 2017W1
+  EXPECT_EQ(getWeekYear(2017, 01, 06, 2, 4), 2017); // 2017W1
+  EXPECT_EQ(getWeekYear(2017, 01, 07, 1, 1), 2017); // 2017W1
+  EXPECT_EQ(getWeekYear(2017, 01, 07, 2, 4), 2017); // 2017W1
+  EXPECT_EQ(getWeekYear(2017, 12, 25, 1, 1), 2017); // 2017W52
+  EXPECT_EQ(getWeekYear(2017, 12, 25, 2, 4), 2017); // 2017W52
+  EXPECT_EQ(getWeekYear(2017, 12, 26, 1, 1), 2017); // 2017W52
+  EXPECT_EQ(getWeekYear(2017, 12, 26, 2, 4), 2017); // 2017W52
+  EXPECT_EQ(getWeekYear(2017, 12, 27, 1, 1), 2017); // 2017W52
+  EXPECT_EQ(getWeekYear(2017, 12, 27, 2, 4), 2017); // 2017W52
+  EXPECT_EQ(getWeekYear(2017, 12, 28, 1, 1), 2017); // 2017W52
+  EXPECT_EQ(getWeekYear(2017, 12, 28, 2, 4), 2017); // 2017W52
+  EXPECT_EQ(getWeekYear(2017, 12, 29, 1, 1), 2017); // 2017W52
+  EXPECT_EQ(getWeekYear(2017, 12, 29, 2, 4), 2017); // 2017W52
+  EXPECT_EQ(getWeekYear(2017, 12, 30, 1, 1), 2017); // 2017W52
+  EXPECT_EQ(getWeekYear(2017, 12, 30, 2, 4), 2017); // 2017W52
+  EXPECT_EQ(getWeekYear(2017, 12, 31, 1, 1), 2018); // 2018W1
+  EXPECT_EQ(getWeekYear(2017, 12, 31, 2, 4), 2017); // 2017W52
+  EXPECT_EQ(getWeekYear(2018, 01, 01, 1, 1), 2018); // 2018W1
+  EXPECT_EQ(getWeekYear(2018, 01, 01, 2, 4), 2018); // 2018W1
+  EXPECT_EQ(getWeekYear(2018, 01, 02, 1, 1), 2018); // 2018W1
+  EXPECT_EQ(getWeekYear(2018, 01, 02, 2, 4), 2018); // 2018W1
+  EXPECT_EQ(getWeekYear(2018, 01, 03, 1, 1), 2018); // 2018W1
+  EXPECT_EQ(getWeekYear(2018, 01, 03, 2, 4), 2018); // 2018W1
+  EXPECT_EQ(getWeekYear(2018, 01, 04, 1, 1), 2018); // 2018W1
+  EXPECT_EQ(getWeekYear(2018, 01, 04, 2, 4), 2018); // 2018W1
+  EXPECT_EQ(getWeekYear(2018, 01, 05, 1, 1), 2018); // 2018W1
+  EXPECT_EQ(getWeekYear(2018, 01, 05, 2, 4), 2018); // 2018W1
+  EXPECT_EQ(getWeekYear(2018, 01, 06, 1, 1), 2018); // 2018W1
+  EXPECT_EQ(getWeekYear(2018, 01, 06, 2, 4), 2018); // 2018W1
+  EXPECT_EQ(getWeekYear(2018, 01, 07, 1, 1), 2018); // 2018W2
+  EXPECT_EQ(getWeekYear(2018, 01, 07, 2, 4), 2018); // 2018W1
+  EXPECT_EQ(getWeekYear(2018, 12, 25, 1, 1), 2018); // 2018W52
+  EXPECT_EQ(getWeekYear(2018, 12, 25, 2, 4), 2018); // 2018W52
+  EXPECT_EQ(getWeekYear(2018, 12, 26, 1, 1), 2018); // 2018W52
+  EXPECT_EQ(getWeekYear(2018, 12, 26, 2, 4), 2018); // 2018W52
+  EXPECT_EQ(getWeekYear(2018, 12, 27, 1, 1), 2018); // 2018W52
+  EXPECT_EQ(getWeekYear(2018, 12, 27, 2, 4), 2018); // 2018W52
+  EXPECT_EQ(getWeekYear(2018, 12, 28, 1, 1), 2018); // 2018W52
+  EXPECT_EQ(getWeekYear(2018, 12, 28, 2, 4), 2018); // 2018W52
+  EXPECT_EQ(getWeekYear(2018, 12, 29, 1, 1), 2018); // 2018W52
+  EXPECT_EQ(getWeekYear(2018, 12, 29, 2, 4), 2018); // 2018W52
+  EXPECT_EQ(getWeekYear(2018, 12, 30, 1, 1), 2019); // 2019W1
+  EXPECT_EQ(getWeekYear(2018, 12, 30, 2, 4), 2018); // 2018W52
+  EXPECT_EQ(getWeekYear(2018, 12, 31, 1, 1), 2019); // 2019W1
+  EXPECT_EQ(getWeekYear(2018, 12, 31, 2, 4), 2019); // 2019W1
+  EXPECT_EQ(getWeekYear(2019, 01, 01, 1, 1), 2019); // 2019W1
+  EXPECT_EQ(getWeekYear(2019, 01, 01, 2, 4), 2019); // 2019W1
+  EXPECT_EQ(getWeekYear(2019, 01, 02, 1, 1), 2019); // 2019W1
+  EXPECT_EQ(getWeekYear(2019, 01, 02, 2, 4), 2019); // 2019W1
+  EXPECT_EQ(getWeekYear(2019, 01, 03, 1, 1), 2019); // 2019W1
+  EXPECT_EQ(getWeekYear(2019, 01, 03, 2, 4), 2019); // 2019W1
+  EXPECT_EQ(getWeekYear(2019, 01, 04, 1, 1), 2019); // 2019W1
+  EXPECT_EQ(getWeekYear(2019, 01, 04, 2, 4), 2019); // 2019W1
+  EXPECT_EQ(getWeekYear(2019, 01, 05, 1, 1), 2019); // 2019W1
+  EXPECT_EQ(getWeekYear(2019, 01, 05, 2, 4), 2019); // 2019W1
+  EXPECT_EQ(getWeekYear(2019, 01, 06, 1, 1), 2019); // 2019W2
+  EXPECT_EQ(getWeekYear(2019, 01, 06, 2, 4), 2019); // 2019W1
+  EXPECT_EQ(getWeekYear(2019, 01, 07, 1, 1), 2019); // 2019W2
+  EXPECT_EQ(getWeekYear(2019, 01, 07, 2, 4), 2019); // 2019W2
+  EXPECT_EQ(getWeekYear(2019, 12, 25, 1, 1), 2019); // 2019W52
+  EXPECT_EQ(getWeekYear(2019, 12, 25, 2, 4), 2019); // 2019W52
+  EXPECT_EQ(getWeekYear(2019, 12, 26, 1, 1), 2019); // 2019W52
+  EXPECT_EQ(getWeekYear(2019, 12, 26, 2, 4), 2019); // 2019W52
+  EXPECT_EQ(getWeekYear(2019, 12, 27, 1, 1), 2019); // 2019W52
+  EXPECT_EQ(getWeekYear(2019, 12, 27, 2, 4), 2019); // 2019W52
+  EXPECT_EQ(getWeekYear(2019, 12, 28, 1, 1), 2019); // 2019W52
+  EXPECT_EQ(getWeekYear(2019, 12, 28, 2, 4), 2019); // 2019W52
+  EXPECT_EQ(getWeekYear(2019, 12, 29, 1, 1), 2020); // 2020W1
+  EXPECT_EQ(getWeekYear(2019, 12, 29, 2, 4), 2019); // 2019W52
+  EXPECT_EQ(getWeekYear(2019, 12, 30, 1, 1), 2020); // 2020W1
+  EXPECT_EQ(getWeekYear(2019, 12, 30, 2, 4), 2020); // 2020W1
+  EXPECT_EQ(getWeekYear(2019, 12, 31, 1, 1), 2020); // 2020W1
+  EXPECT_EQ(getWeekYear(2019, 12, 31, 2, 4), 2020); // 2020W1
+  EXPECT_EQ(getWeekYear(2020, 01, 01, 1, 1), 2020); // 2020W1
+  EXPECT_EQ(getWeekYear(2020, 01, 01, 2, 4), 2020); // 2020W1
+  EXPECT_EQ(getWeekYear(2020, 01, 02, 1, 1), 2020); // 2020W1
+  EXPECT_EQ(getWeekYear(2020, 01, 02, 2, 4), 2020); // 2020W1
+  EXPECT_EQ(getWeekYear(2020, 01, 03, 1, 1), 2020); // 2020W1
+  EXPECT_EQ(getWeekYear(2020, 01, 03, 2, 4), 2020); // 2020W1
+  EXPECT_EQ(getWeekYear(2020, 01, 04, 1, 1), 2020); // 2020W1
+  EXPECT_EQ(getWeekYear(2020, 01, 04, 2, 4), 2020); // 2020W1
+  EXPECT_EQ(getWeekYear(2020, 01, 05, 1, 1), 2020); // 2020W2
+  EXPECT_EQ(getWeekYear(2020, 01, 05, 2, 4), 2020); // 2020W1
+  EXPECT_EQ(getWeekYear(2020, 01, 06, 1, 1), 2020); // 2020W2
+  EXPECT_EQ(getWeekYear(2020, 01, 06, 2, 4), 2020); // 2020W2
+  EXPECT_EQ(getWeekYear(2020, 01, 07, 1, 1), 2020); // 2020W2
+  EXPECT_EQ(getWeekYear(2020, 01, 07, 2, 4), 2020); // 2020W2
+  EXPECT_EQ(getWeekYear(2020, 12, 25, 1, 1), 2020); // 2020W52
+  EXPECT_EQ(getWeekYear(2020, 12, 25, 2, 4), 2020); // 2020W52
+  EXPECT_EQ(getWeekYear(2020, 12, 26, 1, 1), 2020); // 2020W52
+  EXPECT_EQ(getWeekYear(2020, 12, 26, 2, 4), 2020); // 2020W52
+  EXPECT_EQ(getWeekYear(2020, 12, 27, 1, 1), 2021); // 2021W1
+  EXPECT_EQ(getWeekYear(2020, 12, 27, 2, 4), 2020); // 2020W52
+  EXPECT_EQ(getWeekYear(2020, 12, 28, 1, 1), 2021); // 2021W1
+  EXPECT_EQ(getWeekYear(2020, 12, 28, 2, 4), 2020); // 2020W53
+  EXPECT_EQ(getWeekYear(2020, 12, 29, 1, 1), 2021); // 2021W1
+  EXPECT_EQ(getWeekYear(2020, 12, 29, 2, 4), 2020); // 2020W53
+  EXPECT_EQ(getWeekYear(2020, 12, 30, 1, 1), 2021); // 2021W1
+  EXPECT_EQ(getWeekYear(2020, 12, 30, 2, 4), 2020); // 2020W53
+  EXPECT_EQ(getWeekYear(2020, 12, 31, 1, 1), 2021); // 2021W1
+  EXPECT_EQ(getWeekYear(2020, 12, 31, 2, 4), 2020); // 2020W53
+  EXPECT_EQ(getWeekYear(2021, 01, 01, 1, 1), 2021); // 2021W1
+  EXPECT_EQ(getWeekYear(2021, 01, 01, 2, 4), 2020); // 2020W53
+  EXPECT_EQ(getWeekYear(2021, 01, 02, 1, 1), 2021); // 2021W1
+  EXPECT_EQ(getWeekYear(2021, 01, 02, 2, 4), 2020); // 2020W53
+  EXPECT_EQ(getWeekYear(2021, 01, 03, 1, 1), 2021); // 2021W2
+  EXPECT_EQ(getWeekYear(2021, 01, 03, 2, 4), 2020); // 2020W53
+  EXPECT_EQ(getWeekYear(2021, 01, 04, 1, 1), 2021); // 2021W2
+  EXPECT_EQ(getWeekYear(2021, 01, 04, 2, 4), 2021); // 2021W1
+  EXPECT_EQ(getWeekYear(2021, 01, 05, 1, 1), 2021); // 2021W2
+  EXPECT_EQ(getWeekYear(2021, 01, 05, 2, 4), 2021); // 2021W1
+  EXPECT_EQ(getWeekYear(2021, 01, 06, 1, 1), 2021); // 2021W2
+  EXPECT_EQ(getWeekYear(2021, 01, 06, 2, 4), 2021); // 2021W1
+  EXPECT_EQ(getWeekYear(2021, 01, 07, 1, 1), 2021); // 2021W2
+  EXPECT_EQ(getWeekYear(2021, 01, 07, 2, 4), 2021); // 2021W1
+  EXPECT_EQ(getWeekYear(2021, 12, 25, 1, 1), 2021); // 2021W52
+  EXPECT_EQ(getWeekYear(2021, 12, 25, 2, 4), 2021); // 2021W51
+  EXPECT_EQ(getWeekYear(2021, 12, 26, 1, 1), 2022); // 2022W1
+  EXPECT_EQ(getWeekYear(2021, 12, 26, 2, 4), 2021); // 2021W51
+  EXPECT_EQ(getWeekYear(2021, 12, 27, 1, 1), 2022); // 2022W1
+  EXPECT_EQ(getWeekYear(2021, 12, 27, 2, 4), 2021); // 2021W52
+  EXPECT_EQ(getWeekYear(2021, 12, 28, 1, 1), 2022); // 2022W1
+  EXPECT_EQ(getWeekYear(2021, 12, 28, 2, 4), 2021); // 2021W52
+  EXPECT_EQ(getWeekYear(2021, 12, 29, 1, 1), 2022); // 2022W1
+  EXPECT_EQ(getWeekYear(2021, 12, 29, 2, 4), 2021); // 2021W52
+  EXPECT_EQ(getWeekYear(2021, 12, 30, 1, 1), 2022); // 2022W1
+  EXPECT_EQ(getWeekYear(2021, 12, 30, 2, 4), 2021); // 2021W52
+  EXPECT_EQ(getWeekYear(2021, 12, 31, 1, 1), 2022); // 2022W1
+  EXPECT_EQ(getWeekYear(2021, 12, 31, 2, 4), 2021); // 2021W52
+  EXPECT_EQ(getWeekYear(2022, 01, 01, 1, 1), 2022); // 2022W1
+  EXPECT_EQ(getWeekYear(2022, 01, 01, 2, 4), 2021); // 2021W52
+  EXPECT_EQ(getWeekYear(2022, 01, 02, 1, 1), 2022); // 2022W2
+  EXPECT_EQ(getWeekYear(2022, 01, 02, 2, 4), 2021); // 2021W52
+  EXPECT_EQ(getWeekYear(2022, 01, 03, 1, 1), 2022); // 2022W2
+  EXPECT_EQ(getWeekYear(2022, 01, 03, 2, 4), 2022); // 2022W1
+  EXPECT_EQ(getWeekYear(2022, 01, 04, 1, 1), 2022); // 2022W2
+  EXPECT_EQ(getWeekYear(2022, 01, 04, 2, 4), 2022); // 2022W1
+  EXPECT_EQ(getWeekYear(2022, 01, 05, 1, 1), 2022); // 2022W2
+  EXPECT_EQ(getWeekYear(2022, 01, 05, 2, 4), 2022); // 2022W1
+  EXPECT_EQ(getWeekYear(2022, 01, 06, 1, 1), 2022); // 2022W2
+  EXPECT_EQ(getWeekYear(2022, 01, 06, 2, 4), 2022); // 2022W1
+  EXPECT_EQ(getWeekYear(2022, 01, 07, 1, 1), 2022); // 2022W2
+  EXPECT_EQ(getWeekYear(2022, 01, 07, 2, 4), 2022); // 2022W1
+  EXPECT_EQ(getWeekYear(2022, 12, 25, 1, 1), 2022); // 2022W53
+  EXPECT_EQ(getWeekYear(2022, 12, 25, 2, 4), 2022); // 2022W51
+  EXPECT_EQ(getWeekYear(2022, 12, 26, 1, 1), 2022); // 2022W53
+  EXPECT_EQ(getWeekYear(2022, 12, 26, 2, 4), 2022); // 2022W52
+  EXPECT_EQ(getWeekYear(2022, 12, 27, 1, 1), 2022); // 2022W53
+  EXPECT_EQ(getWeekYear(2022, 12, 27, 2, 4), 2022); // 2022W52
+  EXPECT_EQ(getWeekYear(2022, 12, 28, 1, 1), 2022); // 2022W53
+  EXPECT_EQ(getWeekYear(2022, 12, 28, 2, 4), 2022); // 2022W52
+  EXPECT_EQ(getWeekYear(2022, 12, 29, 1, 1), 2022); // 2022W53
+  EXPECT_EQ(getWeekYear(2022, 12, 29, 2, 4), 2022); // 2022W52
+  EXPECT_EQ(getWeekYear(2022, 12, 30, 1, 1), 2022); // 2022W53
+  EXPECT_EQ(getWeekYear(2022, 12, 30, 2, 4), 2022); // 2022W52
+  EXPECT_EQ(getWeekYear(2022, 12, 31, 1, 1), 2022); // 2022W53
+  EXPECT_EQ(getWeekYear(2022, 12, 31, 2, 4), 2022); // 2022W52
+}
+
+} // namespace facebook::velox::functions::test

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -3797,8 +3797,6 @@ TEST_F(DateTimeFunctionsTest, formatDateTime) {
 
   // User format errors or unsupported errors.
   EXPECT_THROW(
-      formatDatetime(parseTimestamp("1970-01-01"), "x"), VeloxUserError);
-  EXPECT_THROW(
       formatDatetime(parseTimestamp("1970-01-01"), "q"), VeloxUserError);
   EXPECT_THROW(
       formatDatetime(parseTimestamp("1970-01-01"), "'abcd"), VeloxUserError);
@@ -3880,6 +3878,24 @@ TEST_F(DateTimeFunctionsTest, dateFormat) {
       "-2000-02-29 00:00:00.987000",
       dateFormat(
           parseTimestamp("-2000-02-29 00:00:00.987"), "%Y-%m-%d %H:%i:%s.%f"));
+
+  // Week year cases.
+  EXPECT_EQ("2016", dateFormat(parseTimestamp("2017-01-01"), "%x"));
+  EXPECT_EQ("2017", dateFormat(parseTimestamp("2017-12-31"), "%x"));
+  EXPECT_EQ("2018", dateFormat(parseTimestamp("2018-01-01"), "%x"));
+  EXPECT_EQ("2019", dateFormat(parseTimestamp("2018-12-31"), "%x"));
+  EXPECT_EQ("2019", dateFormat(parseTimestamp("2019-01-01"), "%x"));
+  EXPECT_EQ("2020", dateFormat(parseTimestamp("2019-12-30"), "%x"));
+  EXPECT_EQ("2020", dateFormat(parseTimestamp("2019-12-31"), "%x"));
+  EXPECT_EQ("2020", dateFormat(parseTimestamp("2020-01-01"), "%x"));
+  EXPECT_EQ("2020", dateFormat(parseTimestamp("2020-12-31"), "%x"));
+  EXPECT_EQ("2020", dateFormat(parseTimestamp("2021-01-01"), "%x"));
+  EXPECT_EQ("2020", dateFormat(parseTimestamp("2021-01-02"), "%x"));
+  EXPECT_EQ("2020", dateFormat(parseTimestamp("2021-01-03"), "%x"));
+  EXPECT_EQ("2021", dateFormat(parseTimestamp("2021-12-31"), "%x"));
+  EXPECT_EQ("2021", dateFormat(parseTimestamp("2022-01-01"), "%x"));
+  EXPECT_EQ("2021", dateFormat(parseTimestamp("2022-01-02"), "%x"));
+  EXPECT_EQ("2022", dateFormat(parseTimestamp("2022-12-31"), "%x"));
 
   // Varying digit year cases.
   EXPECT_EQ("06", dateFormat(parseTimestamp("-6-06-20"), "%y"));
@@ -4122,9 +4138,6 @@ TEST_F(DateTimeFunctionsTest, dateFormat) {
   VELOX_ASSERT_THROW(
       dateFormat(timestamp, "%X"),
       "Date format specifier is not supported: %X");
-  VELOX_ASSERT_THROW(
-      dateFormat(timestamp, "%x"),
-      "Date format specifier is not supported: WEEK_YEAR");
 }
 
 TEST_F(DateTimeFunctionsTest, dateFormatTimestampWithTimezone) {

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -936,6 +936,71 @@ TEST_F(DateTimeFunctionsTest, fromUnixtime) {
       fromUnixTime(getUnixTime("2020-06-30 23:59:59"), "yyyy-MM-dd HH:mm:ss"),
       "2020-07-01 07:59:59");
 
+  // Weekyear cases of ISO-8601 standard.
+  queryCtx_->testingOverrideConfigUnsafe({
+      {core::QueryConfig::kSparkLegacyDateFormatter, "true"},
+      {core::QueryConfig::kSparkFirstDayOfWeek, std::to_string(2)},
+      {core::QueryConfig::kSparkMinimalDaysInFirstWeek, std::to_string(4)},
+  });
+  EXPECT_EQ(fromUnixTime(getUnixTime("2017-01-01 00:00:00"), "YYYY"), "2016");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2017-12-31 00:00:00"), "YYYY"), "2017");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2018-01-01 00:00:00"), "YYYY"), "2018");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2018-12-31 00:00:00"), "YYYY"), "2019");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2019-01-01 00:00:00"), "YYYY"), "2019");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2019-12-30 00:00:00"), "YYYY"), "2020");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2019-12-31 00:00:00"), "YYYY"), "2020");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2020-01-01 00:00:00"), "YYYY"), "2020");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2020-12-31 00:00:00"), "YYYY"), "2020");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2021-01-01 00:00:00"), "YYYY"), "2020");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2021-01-02 00:00:00"), "YYYY"), "2020");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2021-01-03 00:00:00"), "YYYY"), "2020");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2021-12-31 00:00:00"), "YYYY"), "2021");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2022-01-01 00:00:00"), "YYYY"), "2021");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2022-01-02 00:00:00"), "YYYY"), "2021");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2022-12-31 00:00:00"), "YYYY"), "2022");
+
+  // Weekyear cases of spark legacy date formatter with default config.
+  queryCtx_->testingOverrideConfigUnsafe({
+      {core::QueryConfig::kSparkLegacyDateFormatter, "true"},
+      {core::QueryConfig::kSparkFirstDayOfWeek, std::to_string(1)},
+      {core::QueryConfig::kSparkMinimalDaysInFirstWeek, std::to_string(1)},
+  });
+  EXPECT_EQ(fromUnixTime(getUnixTime("2017-01-01 00:00:00"), "YYYY"), "2017");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2017-12-31 00:00:00"), "YYYY"), "2018");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2018-01-01 00:00:00"), "YYYY"), "2018");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2018-12-30 00:00:00"), "YYYY"), "2019");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2018-12-31 00:00:00"), "YYYY"), "2019");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2019-01-01 00:00:00"), "YYYY"), "2019");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2019-12-29 00:00:00"), "YYYY"), "2020");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2019-12-30 00:00:00"), "YYYY"), "2020");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2019-12-31 00:00:00"), "YYYY"), "2020");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2020-01-01 00:00:00"), "YYYY"), "2020");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2020-12-27 00:00:00"), "YYYY"), "2021");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2020-12-28 00:00:00"), "YYYY"), "2021");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2020-12-29 00:00:00"), "YYYY"), "2021");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2020-12-30 00:00:00"), "YYYY"), "2021");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2020-12-31 00:00:00"), "YYYY"), "2021");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2021-01-01 00:00:00"), "YYYY"), "2021");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2021-12-26 00:00:00"), "YYYY"), "2022");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2021-12-27 00:00:00"), "YYYY"), "2022");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2021-12-28 00:00:00"), "YYYY"), "2022");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2021-12-29 00:00:00"), "YYYY"), "2022");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2021-12-30 00:00:00"), "YYYY"), "2022");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2021-12-31 00:00:00"), "YYYY"), "2022");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2022-01-01 00:00:00"), "YYYY"), "2022");
+  EXPECT_EQ(fromUnixTime(getUnixTime("2022-12-31 00:00:00"), "YYYY"), "2022");
+
+  // Week config should only apply to spark legacy date formatter.
+  queryCtx_->testingOverrideConfigUnsafe({
+      {core::QueryConfig::kSparkLegacyDateFormatter, "false"},
+      {core::QueryConfig::kSparkFirstDayOfWeek, std::to_string(1)},
+      {core::QueryConfig::kSparkMinimalDaysInFirstWeek, std::to_string(1)},
+  });
+  EXPECT_EQ(fromUnixTime(getUnixTime("2017-12-31 00:00:00"), "x"), "2017");
+
+  // Reset config.
+  queryCtx_->testingOverrideConfigUnsafe({});
+
   // Invalid format.
   VELOX_ASSERT_THROW(
       fromUnixTime(0, "yyyy-AA"), "Specifier A is not supported.");


### PR DESCRIPTION
Support WEEK_YEAR for date time formatter. `getWeekYear()` is cloned from [jdk 8](https://github.com/openjdk/jdk8/blob/6a383433a9f4661a96a90b2a4c7b5b9a85720031/jdk/src/share/classes/java/util/GregorianCalendar.java#L2077) supporting both ISO8601 and Java SimpleDateFormat standards.

Test case is generated by the scala script below.

``` scala
def gen_week_years_more() = {
  import java.util.Calendar
  import java.util.GregorianCalendar

  for {
    y <- (2017 to 2022);
    (m, d) <- Seq(
      (Calendar.JANUARY, 1),
      (Calendar.JANUARY, 2),
      (Calendar.JANUARY, 3),
      (Calendar.JANUARY, 4),
      (Calendar.JANUARY, 5),
      (Calendar.JANUARY, 6),
      (Calendar.JANUARY, 7),
      (Calendar.DECEMBER, 25),
      (Calendar.DECEMBER, 26),
      (Calendar.DECEMBER, 27),
      (Calendar.DECEMBER, 28),
      (Calendar.DECEMBER, 29),
      (Calendar.DECEMBER, 30),
      (Calendar.DECEMBER, 31),
    );
    (fd, md) <- Seq(
      (Calendar.SUNDAY, 1), // SimpleDateFormat
      (Calendar.MONDAY, 4)  // ISO
    )
  } yield {
    val cal = Calendar.getInstance();
    cal.setFirstDayOfWeek(fd)
    cal.setMinimalDaysInFirstWeek(md)

    cal.set(Calendar.YEAR, y)
    cal.set(Calendar.MONTH, m)
    cal.set(Calendar.DAY_OF_MONTH, d)
    cal.getTime

    val wy = cal.getWeekYear
    val woy = cal.get(Calendar.WEEK_OF_YEAR)

    f"  std::make_tuple(${y}%4d, ${m+1}%02d, $d%02d, ${fd-1}, ${md}, ${wy}%4d)," ++
    f" // ${wy}W${woy}"
  }
}

```

Presto test case is generated by the following query on presto 0.289:

``` sql
with
  dates as (select
    date_parse(cast(year as varchar) || '-' || cast(month as varchar) || '-' || cast(day as varchar), '%Y-%m-%d') as d
  from
    (select * from unnest(sequence(2017, 2022)) as years(year)),
    (select * from (values
      (1, 1),
      (1, 2),
      (1, 3),
      (1, 4),
      (1, 5),
      (1, 6),
      (1, 7),
      (12, 25),
      (12, 26),
      (12, 27),
      (12, 28),
      (12, 29),
      (12, 30),
      (12, 31)
    ) as monthdays(month, day))
  )
select date_format(d, '%Y-%m-%d'), date_format(d, '%x') from dates
where day(d) in (1, 31) or year(d) != year_of_week(d);
```

SparkSQL test case is generated by the following query on spark 3.5.2:

``` sql
SET spark.sql.legacy.timeParserPolicy=LEGACY;
with
  dates as (select
    cast(year as string) || '-' || cast(month as string) || '-' || cast(day as string) as d
  from
    (select * from (values
      (2017),
      (2018),
      (2019),
      (2020),
      (2021),
      (2022)
    ) as years(year)),
    (select * from (values
      (1, 1),
      (1, 2),
      (1, 3),
      (1, 4),
      (1, 5),
      (1, 6),
      (1, 7),
      (12, 25),
      (12, 26),
      (12, 27),
      (12, 28),
      (12, 29),
      (12, 30),
      (12, 31)
    ) as monthdays(month, day))
  )
select date_format(d, 'yyyy-MM-dd') as date, date_format(d, 'Y') as weekyear from dates
where day(d) in (1, 31) or date_format(d, 'yyyy') != date_format(d, 'YYYY')
order by d;
```