### PR TITLE
Install FMT and download ccache on MacOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -64,7 +64,8 @@ jobs:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "TRUE"
         run: |
           source scripts/setup-macos.sh
-          brew install $MACOS_BUILD_DEPS $MACOS_VELOX_DEPS
+          install_build_prerequisites
+          install_velox_deps_from_brew
 
           echo "NJOBS=`sysctl -n hw.ncpu`" >> $GITHUB_ENV
           brew unlink protobuf || echo "protobuf not installed"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -79,6 +79,7 @@ jobs:
       - name: Configure Build
         env:
           folly_SOURCE: BUNDLED #brew folly does not have int128
+          fmt_SOURCE: BUNDLED #brew fmt11 is not supported
         run: |
             ccache -sz -M 5Gi
             cmake \

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -77,7 +77,7 @@ function install_build_prerequisites {
     python3 -m venv ${PYTHON_VENV}
   fi
   source ${PYTHON_VENV}/bin/activate; pip3 install cmake-format regex pyyaml
-  wget -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-darwin.tar.gz
+  wget -O ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-darwin.tar.gz
   tar -xf ccache.tar.gz
   mv ccache-4.10.2-darwin/ccache /usr/local/bin/
 }

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -35,8 +35,8 @@ PYTHON_VENV=${PYHTON_VENV:-"${SCRIPTDIR}/../.venv"}
 NPROC=$(getconf _NPROCESSORS_ONLN)
 
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
-MACOS_VELOX_DEPS="bison boost double-conversion flex fmt gflags glog googletest icu4c libevent libsodium lz4 lzo openssl protobuf@21 simdjson snappy thrift xz xsimd zstd"
-MACOS_BUILD_DEPS="ninja cmake ccache"
+MACOS_VELOX_DEPS="bison boost double-conversion flex gflags glog googletest icu4c libevent libsodium lz4 lzo openssl protobuf@21 simdjson snappy thrift xz xsimd zstd"
+MACOS_BUILD_DEPS="ninja cmake"
 FB_OS_VERSION="v2024.05.20.00"
 FMT_VERSION="10.1.1"
 
@@ -77,6 +77,9 @@ function install_build_prerequisites {
     python3 -m venv ${PYTHON_VENV}
   fi
   source ${PYTHON_VENV}/bin/activate; pip3 install cmake-format regex pyyaml
+  wget -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-darwin.tar.gz
+  tar -xf ccache.tar.gz
+  mv ccache-4.10.2-darwin/ccache /usr/local/bin/
 }
 
 function install_velox_deps_from_brew {


### PR DESCRIPTION
Brew fmt11 is not supported.
ccache brings in fmt11 from brew. 
The brew fmt11 headers are taking precedence over bundled headers.
Bundle fmt and download prebuilt ccache that is statically linked.
We will fix the header include issue in https://github.com/facebookincubator/velox/pull/10920.
Resolves https://github.com/facebookincubator/velox/issues/10936