### PR TITLE
Disable macos 13 github workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -46,9 +46,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-13 = x86_64 Mac
+        # macos-13 = x86_64 Mac, disabled temporarily till it's fixed
         # macos-14 = arm64 Mac
-        os: [macos-13, macos-14]
+        os: [macos-14]
     runs-on: ${{ matrix.os }}
     env:
       CCACHE_DIR: '${{ github.workspace }}/.ccache'


### PR DESCRIPTION
MacOS 13 image recently updated and broke the build and hence the
workflow. Disabling it till we find a fix.