### PR TITLE
Fix write to Nimble table in HiveConnector

### DIFF
--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -993,12 +993,20 @@ void updateWriterOptionsFromHiveConfig(
     const std::shared_ptr<const HiveConfig>& hiveConfig,
     const config::ConfigBase* sessionProperties,
     std::shared_ptr<dwio::common::WriterOptions>& writerOptions) {
-  if (fileFormat == dwio::common::FileFormat::PARQUET) {
+  switch (fileFormat) {
+    case dwio::common::FileFormat::DWRF:
+      updateDWRFWriterOptions(hiveConfig, sessionProperties, writerOptions);
+      break;
+    case dwio::common::FileFormat::PARQUET:
 #ifdef VELOX_ENABLE_PARQUET
-    updateParquetWriterOptions(hiveConfig, sessionProperties, writerOptions);
+      updateParquetWriterOptions(hiveConfig, sessionProperties, writerOptions);
 #endif
-  } else {
-    updateDWRFWriterOptions(hiveConfig, sessionProperties, writerOptions);
+      break;
+    case dwio::common::FileFormat::NIMBLE:
+      // No-op for now.
+      break;
+    default:
+      VELOX_UNSUPPORTED("{}", fileFormat);
   }
 }
 


### PR DESCRIPTION
Summary:
Recent refactor https://github.com/facebookincubator/velox/pull/10915
breaks the capability to write to Nimble table in Hive connector, fix it.

Differential Revision: D62302602
