### PR TITLE
Add basic group by  and status returning without unified page faults

### DIFF
--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -91,7 +91,6 @@ struct WriterOptions : public dwio::common::WriterOptions {
   bool enableDictionary = true;
   int64_t dataPageSize = 1'024 * 1'024;
   int64_t dictionaryPageSizeLimit = 1'024 * 1'024;
-
   // Growth ratio passed to ArrowDataBufferSink. The default value is a
   // heuristic borrowed from
   // folly/FBVector(https://github.com/facebook/folly/blob/main/folly/docs/FBVector.md#memory-handling).

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -165,7 +165,7 @@ HiveConnectorTestBase::makeHiveConnectorSplits(
       filesystems::getFileSystem(filePath, nullptr)->openFileForRead(filePath);
   const int64_t fileSize = file->size();
   // Take the upper bound.
-  const int splitSize = std::ceil((fileSize) / splitCount);
+  const int64_t splitSize = std::ceil((fileSize) / splitCount);
   std::vector<std::shared_ptr<connector::hive::HiveConnectorSplit>> splits;
   // Add all the splits.
   for (int i = 0; i < splitCount; i++) {

--- a/velox/experimental/wave/common/ArenaWithFree.cuh
+++ b/velox/experimental/wave/common/ArenaWithFree.cuh
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <assert.h>
+#include <cub/thread/thread_load.cuh>
+#include <cub/util_ptx.cuh>
+#include "velox/experimental/wave/common/ArenaWithFreeBase.h"
+#include "velox/experimental/wave/common/FreeSet.cuh"
+
+namespace facebook::velox::wave {
+
+/// Allocator subclass that defines device member functions.
+struct ArenaWithFree : public ArenaWithFreeBase {
+  template <typename T>
+  T* __device__ allocateRow() {
+    auto fromFree = getFromFree();
+    if (fromFree != kEmpty) {
+      ++numFromFree;
+      return reinterpret_cast<T*>(base + fromFree);
+    }
+    auto offset = atomicAdd(&rowOffset, rowSize);
+
+    if (offset + rowSize < cub::ThreadLoad<cub::LOAD_CG>(&stringOffset)) {
+      if (!inRange(base + offset)) {
+        assert(false);
+      }
+      return reinterpret_cast<T*>(base + offset);
+    }
+    return nullptr;
+  }
+
+  uint32_t __device__ getFromFree() {
+    uint32_t item = reinterpret_cast<FreeSet<uint32_t, 1024>*>(freeSet)->get();
+    if (item != kEmpty) {
+      ++numFromFree;
+    }
+    return item;
+  }
+
+  void __device__ freeRow(void* row) {
+    if (!inRange(row)) {
+      assert(false);
+    }
+    uint32_t offset = reinterpret_cast<uint64_t>(row) - base;
+    numFull += reinterpret_cast<FreeSet<uint32_t, 1024>*>(freeSet)->put(
+                   offset) == false;
+  }
+
+  template <typename T>
+  T* __device__ allocate(int32_t cnt) {
+    uint32_t size = sizeof(T) * cnt;
+    auto offset = atomicSub(&stringOffset, size);
+    if (offset - size > cub::ThreadLoad<cub::LOAD_CG>(&rowOffset)) {
+      if (!inRange(base + offset - size)) {
+        assert(false);
+      }
+      return reinterpret_cast<T*>(base + offset - size);
+    }
+    return nullptr;
+  }
+
+  template <typename T>
+  bool __device__ inRange(T ptr) {
+    return reinterpret_cast<uint64_t>(ptr) >= base &&
+        reinterpret_cast<uint64_t>(ptr) < base + capacity;
+  }
+};
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/ArenaWithFreeBase.h
+++ b/velox/experimental/wave/common/ArenaWithFreeBase.h
@@ -14,23 +14,32 @@
  * limitations under the License.
  */
 
-#include "velox/experimental/wave/exec/ExprKernel.h"
+#pragma once
 
-#include <gflags/gflags.h>
-#include "velox/experimental/wave/common/Block.cuh"
-#include "velox/experimental/wave/common/CudaUtil.cuh"
-#include "velox/experimental/wave/exec/Aggregate.cuh"
-#include "velox/experimental/wave/exec/WaveCore.cuh"
-
-DECLARE_bool(kernel_gdb);
+#include <cstdint>
 
 namespace facebook::velox::wave {
 
-__global__ void
-oneReadAggregate(KernelParams params, int32_t pc, int32_t base) {
-  PROGRAM_PREAMBLE(base);
-  readAggregateKernel(&instruction[pc]._.aggregate, shared);
-  PROGRAM_EPILOGUE();
-}
+/// A device arena for device side allocation.
+struct ArenaWithFreeBase {
+  static constexpr uint32_t kEmpty = ~0;
 
+  ArenaWithFreeBase(char* data, uint32_t size, uint32_t rowSize, void* freeSet)
+      : rowSize(rowSize),
+        base(reinterpret_cast<uint64_t>(data)),
+        capacity(size),
+        stringOffset(capacity),
+        freeSet(freeSet) {}
+
+  const int32_t rowSize{0};
+  const uint64_t base{0};
+  uint32_t rowOffset{0};
+  const uint32_t capacity{0};
+  uint32_t stringOffset{0};
+  void* freeSet{nullptr};
+  int32_t numFromFree{0};
+  int32_t numFull{0};
+};
+
+struct ArenaWithFree;
 } // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/HashTable.h
+++ b/velox/experimental/wave/common/HashTable.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <string.h>
 #include <cstdint>
 
 /// Structs for tagged GPU hash table. Can be inclued in both Velox .cpp and
@@ -25,6 +26,8 @@ namespace facebook::velox::wave {
 /// A 32 byte tagged bucket with 4 tags, 4 flag bytes and 4 6-byte
 /// pointers. Fits in one 32 byte GPU cache sector.
 struct GpuBucketMembers {
+  static constexpr int32_t kNumSlots = 4;
+
   uint32_t tags;
   uint32_t flags;
   uint16_t data[12];
@@ -45,29 +48,142 @@ class FreeSetBase {
   T items_[kSize] = {};
 };
 
+static inline int32_t roundUp64(int32_t value) {
+  return (value + 64 - 1) / 64 * 64;
+}
+
+/// Range of addresses. fixed length from bottom and variable length from top.
+/// if 'rowOffset' goes above 'rowLimit' then rows are full. If 'stringOffset'
+/// goes below 'rowLimit' then strings are full.
+struct AllocationRange {
+  AllocationRange() = default;
+  AllocationRange(
+      uintptr_t base,
+      uint32_t capacity,
+      uint32_t rowLimit,
+      int32_t rowSize)
+      : fixedFull(false),
+        variableFull(false),
+        base(base),
+        capacity(capacity),
+        rowLimit(rowLimit),
+        // We leave n words of 64 bits, one bit for each possible row within
+        // 'capacity' below first row.
+        firstRowOffset(roundUp64(capacity / rowSize) / 8),
+        rowOffset(firstRowOffset),
+        stringOffset(capacity) {
+    ::memset(reinterpret_cast<char*>(base), 0, firstRowOffset);
+  }
+
+  AllocationRange(AllocationRange&& other) {
+    *this = std::move(other);
+  }
+
+  AllocationRange& operator=(const AllocationRange& other) = default;
+
+  void operator=(AllocationRange&& other) {
+    *this = other;
+    new (&other) AllocationRange();
+  }
+
+  int64_t availableFixed() {
+    return rowOffset > rowLimit ? 0 : rowLimit - rowOffset;
+  }
+
+  /// Raises rowLimit by up to 'size'. Returns the amount raised.
+  int32_t raiseRowLimit(int32_t size) {
+    auto space = stringOffset - rowLimit;
+    auto delta = std::min<int32_t>(space, size);
+    rowLimit += delta;
+    if (delta > 0) {
+      fixedFull = false;
+    }
+    return delta;
+  }
+
+  void clearOverflows(int32_t rowSize) {
+    if (rowOffset > rowLimit) {
+      // Set 'rowOffset' to the greatest multipl of rowSize from 'base' that is
+      // below the limit.
+      int32_t numRows = (rowLimit - firstRowOffset) / rowSize;
+      rowOffset = firstRowOffset + numRows * rowSize;
+    }
+    if (stringOffset < rowLimit) {
+      stringOffset = rowLimit;
+    }
+  }
+
+  /// Sets row limit so that there are at most 'target' allocatable
+  /// bytes. If available space is less than the target, the available
+  /// space is not changed. Returns 'target' minus the available space
+  // in 'this'.
+  int32_t trimFixed(int32_t target) {
+    auto available = rowLimit - rowOffset;
+    if (available > target) {
+      rowLimit = rowOffset + target;
+    }
+    return target - (rowLimit - rowOffset);
+  }
+
+  /// True if in post-default constructed state.
+  bool empty() {
+    return capacity == 0;
+  }
+
+  bool fixedFull{true};
+  bool variableFull{true};
+  /// Number of the partition. Used when filing away ranges on the control
+  /// plane.
+  uint8_t partition{0};
+  uint64_t base{0};
+  uint32_t capacity{0};
+  uint32_t rowLimit{0};
+  int32_t firstRowOffset{0};
+  uint32_t rowOffset{0};
+  uint32_t stringOffset{0};
+};
+
 /// A device arena for device side allocation.
 struct HashPartitionAllocator {
   static constexpr uint32_t kEmpty = ~0;
 
   HashPartitionAllocator(
       char* data,
-      uint32_t size,
-      uint32_t rowSize,
-      void* freeSet)
-      : rowSize(rowSize),
-        base(reinterpret_cast<uint64_t>(data)),
-        capacity(size),
-        stringOffset(capacity),
-        freeSet(freeSet) {}
+      uint32_t capacity,
+      uint32_t rowLimit,
+      uint32_t rowSize)
+      : rowSize(rowSize) {
+    ranges[0] = AllocationRange(
+        reinterpret_cast<uintptr_t>(data), capacity, rowLimit, rowSize);
+  }
+  /// Returns the available bytes  in fixed size pools.
+  int64_t availableFixed() {
+    return ranges[0].availableFixed() + ranges[1].availableFixed();
+  }
+
+  /// Sets allocated offsets to limit if these are over the
+  /// limit. They are over limit and available is negative after many
+  /// concurrent failed allocations.
+  void clearOverflows() {
+    ranges[0].clearOverflows(rowSize);
+    ranges[1].clearOverflows(rowSize);
+  }
+
+  /// Raises the row limit by up to size bytes. Returns th amount raised.
+  int32_t raiseRowLimits(int32_t size) {
+    auto raised = ranges[0].raiseRowLimit(size);
+    return raised + ranges[1].raiseRowLimit(size - raised);
+  }
+
+  /// sets rowLimit so that there will be at most 'maxSize' bytes of fixed
+  /// length.
+  void trimRows(int32_t target) {
+    target = ranges[0].trimFixed(target);
+    ranges[1].trimFixed(target);
+  }
 
   const int32_t rowSize{0};
-  const uint64_t base{0};
-  uint32_t rowOffset{0};
-  const uint32_t capacity{0};
-  uint32_t stringOffset{0};
-  void* freeSet{nullptr};
-  int32_t numFromFree{0};
-  int32_t numFull{0};
+  AllocationRange ranges[2];
 };
 
 /// Implementation of HashPartitionAllocator, defined in .cuh.
@@ -120,6 +236,17 @@ struct HashProbe {
 struct GpuBucket;
 
 struct GpuHashTableBase {
+  GpuHashTableBase(
+      GpuBucket* buckets,
+      int32_t sizeMask,
+      int32_t partitionMask,
+      RowAllocator* allocators)
+      : buckets(buckets),
+        sizeMask(sizeMask),
+        partitionMask(partitionMask),
+        allocators(allocators),
+        maxEntries(((sizeMask + 1) * GpuBucketMembers::kNumSlots) / 6 * 5) {}
+
   /// Bucket array. Size is 'sizeMask + 1'.
   GpuBucket* buckets{nullptr};
 
@@ -127,14 +254,22 @@ struct GpuHashTableBase {
   // sizemask of 63 means 64 buckets, which is up to 256 entries.
   uint32_t sizeMask;
 
-  // Translates a hash number to a partition number '(hash &
-  // partitionMask) >> partitionShift' is a partition number used as
-  // a physical partition of the table. Used as index into 'allocators'.
+  // Translates a hash number to a partition number '(hash >> 41) &
+  // partitionMask gives a physical partition of the table. Used as
+  // index into 'allocators'.
   uint32_t partitionMask{0};
-  uint8_t partitionShift{0};
 
   /// A RowAllocator for each partition.
   RowAllocator* allocators;
+
+  /// Count of entries in buckets.
+  int64_t numDistinct{0};
+
+  /// Maximum number of entries. Incremented by atomic add at warp
+  /// level. Must be at least 32 belo count of slots. If numDistinct
+  /// after add exceeds max, the inserts in the warp fail and will be
+  /// retried after rehash.
+  int64_t maxEntries{0};
 };
 
 } // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/tests/BlockTest.h
+++ b/velox/experimental/wave/common/tests/BlockTest.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "velox/experimental/wave/common/ArenaWithFreeBase.h"
 #include "velox/experimental/wave/common/Cuda.h"
 #include "velox/experimental/wave/common/HashTable.h"
 #include "velox/experimental/wave/common/tests/HashTestUtil.h"
@@ -60,7 +61,7 @@ struct TestingRow {
 
 /// Result of allocator test kernel.
 struct AllocatorTestResult {
-  RowAllocator* allocator;
+  ArenaWithFree* allocator;
   int32_t numRows;
   int32_t numStrings;
   int64_t* rows[200000];
@@ -133,9 +134,12 @@ class BlockTestStream : public Stream {
   /// 'numBlocks' gives how many TBs are run, the rows per TB are in 'probe'.
   void hashTest(GpuHashTableBase* table, HashRun& probe, HashCase mode);
 
+  void
+  rehash(GpuHashTableBase* table, GpuBucket* oldBuckets, int32_t numOldBuckets);
+
   static int32_t freeSetSize();
 
-  void initAllocator(HashPartitionAllocator* allocator);
+  void initAllocator(ArenaWithFree* allocator);
 
   /// tests RowAllocator.
   void rowAllocatorTest(

--- a/velox/experimental/wave/exec/Aggregate.cuh
+++ b/velox/experimental/wave/exec/Aggregate.cuh
@@ -19,15 +19,183 @@
 #include <gflags/gflags.h>
 #include "velox/experimental/wave/common/Block.cuh"
 #include "velox/experimental/wave/common/CudaUtil.cuh"
+#include "velox/experimental/wave/common/HashTable.cuh"
 #include "velox/experimental/wave/exec/WaveCore.cuh"
 
 namespace facebook::velox::wave {
 
-inline __device__ void clearReturnState(
-    const IAggregate& agg,
-    WaveShared* shared) {
-  auto* lanes = laneStatus<uint8_t>(shared, agg.status, 0);
-  lanes[threadIdx.x] = 0;
+struct SumGroupRow {
+  uint32_t lock;
+  uint32_t nulls;
+  int64_t key;
+  int32_t accNulls;
+  int64_t sums[20];
+};
+
+inline void __device__ increment(int64_t& a, int64_t i) {
+  atomicAdd((unsigned long long*)&a, (unsigned long long)i);
+}
+
+class SumGroupByOps {
+ public:
+  __device__ SumGroupByOps(WaveShared* shared, const IAggregate* inst)
+      : shared_(shared), inst_(inst) {}
+
+  uint64_t __device__ hash(int32_t i) {
+    int64_t key;
+    if (operandOrNull(
+            shared_->operands,
+            *reinterpret_cast<int16_t*>(
+                &inst_->aggregates[inst_->numAggregates]),
+            shared_->blockBase,
+            &shared_->data,
+            key)) {
+      constexpr uint64_t kMul = 0x9ddfea08eb382d69ULL;
+      return kMul * key;
+    }
+    return 1;
+  }
+
+  uint64_t __device__ hashRow(SumGroupRow* row) {
+    constexpr uint64_t kMul = 0x9ddfea08eb382d69ULL;
+    return kMul * row->key;
+  }
+
+  bool __device__ compare(GpuHashTable* table, SumGroupRow* row, int32_t i) {
+    int64_t key;
+    auto k =
+        asDeviceAtomic<int64_t>(&row->key)->load(cuda::memory_order_consume);
+    if (operandOrNull(
+            shared_->operands,
+            *reinterpret_cast<int16_t*>(
+                &inst_->aggregates[inst_->numAggregates]),
+            shared_->blockBase,
+            &shared_->data,
+            key)) {
+      return k == key;
+    }
+    return false;
+  }
+
+  SumGroupRow* __device__
+  newRow(GpuHashTable* table, int32_t partition, int32_t i) {
+    auto* allocator = &table->allocators[partition];
+    auto row = allocator->allocateRow<SumGroupRow>();
+    if (row) {
+      for (auto i = 0; i < inst_->numAggregates; ++i) {
+        row->sums[i] = 0;
+      }
+      int64_t k;
+      operandOrNull(
+          shared_->operands,
+          *reinterpret_cast<int16_t*>(&inst_->aggregates[inst_->numAggregates]),
+          shared_->blockBase,
+          &shared_->data,
+          k);
+      asDeviceAtomic<int64_t>(&row->key)->store(k, cuda::memory_order_release);
+    }
+    return row;
+  }
+
+  ProbeState __device__ insert(
+      GpuHashTable* table,
+      int32_t partition,
+      GpuBucket* bucket,
+      uint32_t misses,
+      uint32_t oldTags,
+      uint32_t tagWord,
+      int32_t i,
+      SumGroupRow*& row) {
+    if (!row) {
+      row = newRow(table, partition, i);
+      if (!row) {
+        return ProbeState::kNeedSpace;
+      }
+    }
+    auto missShift = __ffs(misses) - 1;
+    if (!bucket->addNewTag(tagWord, oldTags, missShift)) {
+      return ProbeState::kRetry;
+    }
+    bucket->store(missShift / 8, row);
+    increment(table->numDistinct, 1);
+    return ProbeState::kDone;
+  }
+
+  void __device__ addHostRetry(int32_t i) {
+    shared_->hasContinue = true;
+    shared_->status[i / kBlockSize].errors[i & (kBlockSize - 1)] =
+        ErrorCode::kInsufficientMemory;
+  }
+
+  void __device__
+  freeInsertable(GpuHashTable* table, SumGroupRow* row, uint64_t h) {
+    int32_t partition = table->partitionIdx(h);
+    auto* allocator = &table->allocators[partition];
+    allocator->markRowFree(row);
+  }
+
+  SumGroupRow* __device__ getExclusive(
+      GpuHashTable* table,
+      GpuBucket* bucket,
+      SumGroupRow* row,
+      int32_t hitIdx) {
+    return row;
+  }
+
+  void __device__ writeDone(SumGroupRow* row) {}
+
+  ProbeState __device__
+  update(GpuHashTable* table, GpuBucket* bucket, SumGroupRow* row, int32_t i) {
+    int32_t numAggs = inst_->numAggregates;
+    for (auto acc = 0; acc < numAggs; ++acc) {
+      int64_t x;
+      operandOrNull(
+          shared_->operands,
+          inst_->aggregates[acc].arg1,
+          shared_->blockBase,
+          &shared_->data,
+          x);
+      increment(row->sums[acc], x);
+    }
+    return ProbeState::kDone;
+  }
+
+  WaveShared* shared_;
+  const IAggregate* inst_;
+};
+
+void __device__ __forceinline__ interpretedGroupBy(
+    WaveShared* shared,
+    DeviceAggregation* deviceAggregation,
+    const IAggregate* agg,
+    ErrorCode& laneStatus) {
+  SumGroupByOps ops(shared, agg);
+  auto* table = reinterpret_cast<GpuHashTable*>(deviceAggregation->table);
+  if (shared->isContinue) {
+    laneStatus = laneStatus == ErrorCode::kInsufficientMemory
+        ? ErrorCode::kOk
+        : ErrorCode::kInactive;
+    shared->status->errors[threadIdx.x] = laneStatus;
+  }
+  // Reset the return status for this stream.
+  if (threadIdx.x == 0) {
+    auto status = gridStatus<AggregateReturn>(shared, agg->status);
+    status->numDistinct = 0;
+  }
+
+  table->updatingProbe<SumGroupRow>(
+      threadIdx.x, cub::LaneId(), laneActive(laneStatus), ops);
+  __syncthreads();
+  laneStatus = shared->status->errors[threadIdx.x];
+  if (threadIdx.x == 0 && shared->hasContinue) {
+    auto ret = gridStatus<AggregateReturn>(shared, agg->status);
+    ret->numDistinct = table->numDistinct;
+  }
+  __syncthreads();
+  if (threadIdx.x == 0 && shared->isContinue) {
+    shared->isContinue = false;
+  }
+  __syncthreads();
 }
 
 __device__ __forceinline__ void aggregateKernel(
@@ -36,44 +204,87 @@ __device__ __forceinline__ void aggregateKernel(
     ErrorCode& laneStatus) {
   auto state =
       reinterpret_cast<DeviceAggregation*>(shared->states[agg.stateIndex]);
-  char* row = state->singleRow;
-  for (auto i = 0; i < agg.numAggregates; ++i) {
-    auto& acc = agg.aggregates[i];
-    int64_t value = 0;
-    if (laneStatus == ErrorCode::kOk) {
-      operandOrNull(
-          shared->operands, acc.arg1, shared->blockBase, &shared->data, value);
-    }
-    using Reduce = cub::WarpReduce<int64_t>;
-    auto sum =
-        Reduce(*reinterpret_cast<Reduce::TempStorage*>(shared)).Sum(value);
-    if ((threadIdx.x & (kWarpThreads - 1)) == 0) {
-      auto* data = addCast<unsigned long long>(row, acc.accumulatorOffset);
-      atomicAdd(data, static_cast<unsigned long long>(sum));
+  if (agg.numKeys) {
+    interpretedGroupBy(shared, state, &agg, laneStatus);
+  } else {
+    char* row = state->singleRow;
+    for (auto i = 0; i < agg.numAggregates; ++i) {
+      auto& acc = agg.aggregates[i];
+      int64_t value = 0;
+      if (laneStatus == ErrorCode::kOk) {
+        operandOrNull(
+            shared->operands,
+            acc.arg1,
+            shared->blockBase,
+            &shared->data,
+            value);
+      }
+      using Reduce = cub::WarpReduce<int64_t>;
+      auto sum =
+          Reduce(*reinterpret_cast<Reduce::TempStorage*>(shared)).Sum(value);
+      if ((threadIdx.x & (kWarpThreads - 1)) == 0) {
+        auto* data = addCast<unsigned long long>(row, acc.accumulatorOffset);
+        atomicAdd(data, static_cast<unsigned long long>(sum));
+      }
     }
   }
 }
 
 __device__ __forceinline__ void readAggregateKernel(
-    const IAggregate& agg,
+    const IAggregate* agg,
     WaveShared* shared) {
-  if (shared->blockBase > 0) {
-    if (threadIdx.x == 0) {
-      shared->status->numRows = 0;
+  auto state =
+      reinterpret_cast<DeviceAggregation*>(shared->states[agg->stateIndex]);
+  if (state->resultRowPointers) {
+    if (shared->streamIdx >= state->numReadStreams) {
+      if (threadIdx.x == 0) {
+        shared->status[blockIdx.x].numRows = 0;
+      }
+    } else {
+      auto rowIdx = blockIdx.x * kBlockSize + threadIdx.x + 1;
+      auto numRows = state->resultRowPointers[shared->streamIdx][0];
+      if (rowIdx <= numRows) {
+        int64_t* row = reinterpret_cast<int64_t*>(
+            state->resultRowPointers[shared->streamIdx][rowIdx]);
+        // Copy keys and accumulators to output.
+        auto* keys = reinterpret_cast<OperandIndex*>(
+            &agg->aggregates[agg->numAggregates]);
+        for (auto i = 0; i < agg->numKeys; ++i) {
+          auto opIdx = keys[i];
+          auto k = *addCast<int64_t>(row, (i + 1) * sizeof(int64_t));
+          flatResult<int64_t>(
+              shared->operands, opIdx, shared->blockBase, &shared->data) = k;
+        }
+        for (auto i = 0; i < agg->numAggregates; ++i) {
+          auto& acc = agg->aggregates[i];
+          flatResult<int64_t>(
+              shared->operands, acc.result, shared->blockBase, &shared->data) =
+              *addCast<int64_t>(row, acc.accumulatorOffset);
+        }
+      }
+      if (threadIdx.x == 0) {
+        shared->numRows = rowIdx + kBlockSize <= numRows
+            ? kBlockSize
+            : numRows - blockIdx.x * kBlockSize;
+      }
     }
-    __syncthreads();
-    return;
-  }
-  if (threadIdx.x == 0) {
-    auto state =
-        reinterpret_cast<DeviceAggregation*>(shared->states[agg.stateIndex]);
-    char* row = state->singleRow;
-    shared->status->numRows = 1;
-    for (auto i = 0; i < agg.numAggregates; ++i) {
-      auto& acc = agg.aggregates[i];
-      flatResult<int64_t>(
-          shared->operands, acc.result, shared->blockBase, &shared->data) =
-          *addCast<int64_t>(row, acc.accumulatorOffset);
+  } else {
+    if (shared->blockBase > 0) {
+      if (threadIdx.x == 0) {
+        shared->numRows = 0;
+      }
+      __syncthreads();
+      return;
+    }
+    if (threadIdx.x == 0) {
+      char* row = state->singleRow;
+      shared->status->numRows = 1;
+      for (auto i = 0; i < agg->numAggregates; ++i) {
+        auto& acc = agg->aggregates[i];
+        flatResult<int64_t>(
+            shared->operands, acc.result, shared->blockBase, &shared->data) =
+            *addCast<int64_t>(row, acc.accumulatorOffset);
+      }
     }
   }
   __syncthreads();

--- a/velox/experimental/wave/exec/Aggregation.cpp
+++ b/velox/experimental/wave/exec/Aggregation.cpp
@@ -279,7 +279,7 @@ void Aggregation::flush(bool noMoreInput) {
   flushDone_.record(*flushStream_);
 }
 
-AdvanceResult Aggregation::canAdvance(WaveStream& stream) {
+std::vector<AdvanceResult> Aggregation::canAdvance(WaveStream& stream) {
   if (!noMoreInput_ || finished_) {
     return {};
   }
@@ -287,7 +287,7 @@ AdvanceResult Aggregation::canAdvance(WaveStream& stream) {
     waitFlushDone();
     flush(true);
   }
-  return {.numRows = container_->actualNumGroups};
+  return {{.numRows = container_->actualNumGroups}};
 }
 
 void Aggregation::schedule(WaveStream& waveStream, int32_t maxRows) {

--- a/velox/experimental/wave/exec/Aggregation.h
+++ b/velox/experimental/wave/exec/Aggregation.h
@@ -43,7 +43,7 @@ class Aggregation : public WaveOperator {
 
   void flush(bool noMoreInput) override;
 
-  AdvanceResult canAdvance(WaveStream& stream) override;
+  std::vector<AdvanceResult> canAdvance(WaveStream& stream) override;
 
   void schedule(WaveStream& stream, int32_t maxRows) override;
 

--- a/velox/experimental/wave/exec/Instruction.cpp
+++ b/velox/experimental/wave/exec/Instruction.cpp
@@ -22,27 +22,289 @@ std::string rowTypeString(const Type& type) {
   return "";
 }
 
+std::string AdvanceResult::toString() const {
+  if (empty()) {
+    return "AdvanceResult::empty";
+  }
+  return fmt::format(
+      "AdvanceResult(.numRows={}, .isRetry={}, .sync={})",
+      numRows,
+      isRetry,
+      syncDrivers       ? "drivers"
+          : syncStreams ? "streams"
+                        : "none");
+}
+
 void AbstractAggregation::reserveState(InstructionStatus& reservedState) {
   instructionStatus = reservedState;
   // A group by produces 8 bytes of grid level state and uses the main main
   // BlockStatus for lane status.
-  reservedState.gridState += 8;
+  reservedState.gridState += sizeof(AggregateReturn);
+}
+
+int32_t countErrors(BlockStatus* status, int32_t numBlocks, ErrorCode error) {
+  int32_t count = 0;
+  for (auto i = 0; i < numBlocks; ++i) {
+    for (auto j = 0; j < status[i].numRows; ++j) {
+      count += status[i].errors[j] == error;
+    }
+  }
+  return count;
+}
+
+void restockAllocator(
+    AggregateOperatorState& state,
+    GpuArena& arena,
+    int32_t size,
+    HashPartitionAllocator* allocator) {
+  // If we can get rows by raising the row limit we do this first.
+  int32_t adjustedSize = size - allocator->raiseRowLimits(size);
+  if (adjustedSize <= 0) {
+    return;
+  }
+  if (allocator->ranges[0].fixedFull) {
+    state.ranges.push_back(std::move(allocator->ranges[0]));
+    allocator->ranges[0] = std::move(allocator->ranges[1]);
+  }
+  auto buffer = arena.allocate<char>(size);
+  state.buffers.push_back(buffer);
+  AllocationRange newRange(
+      reinterpret_cast<uintptr_t>(buffer->as<char>()),
+      size,
+      size,
+      allocator->rowSize);
+  if (allocator->ranges[0].empty()) {
+    allocator->ranges[0] = std::move(newRange);
+  } else {
+    allocator->ranges[1] = std::move(newRange);
+  }
+}
+
+void AggregateOperatorState::setSizesToSafe() {
+  GpuHashTableBase* hashTable =
+      reinterpret_cast<GpuHashTableBase*>(alignedHead + 1);
+  auto* allocators = reinterpret_cast<HashPartitionAllocator*>(hashTable + 1);
+  int32_t numPartitions = hashTable->partitionMask + 1;
+  int32_t rowSize = allocators[0].rowSize;
+  int32_t spaceInTable = hashTable->maxEntries - hashTable->numDistinct;
+  auto allowedPerPartition = spaceInTable / numPartitions;
+  for (auto i = 0; i < numPartitions; ++i) {
+    auto availableInAllocator = allocators[i].availableFixed() / rowSize;
+    if (availableInAllocator > allowedPerPartition) {
+      allocators[i].trimRows(allowedPerPartition * rowSize);
+    }
+  }
+}
+
+void resupplyHashTable(WaveStream& stream, AbstractInstruction& inst) {
+  auto* agg = &inst.as<AbstractAggregation>();
+  auto deviceStream = WaveStream::streamFromReserve();
+  auto stateId = agg->state->id;
+  auto* state = stream.operatorState(stateId)->as<AggregateOperatorState>();
+  auto* head = state->alignedHead;
+  auto* hashTable = reinterpret_cast<GpuHashTableBase*>(head + 1);
+  auto* gridState = stream.gridStatus<AggregateReturn>(agg->instructionStatus);
+  auto* blockStatus = stream.hostBlockStatus();
+  int32_t numBlocks = bits::roundUp(stream.numRows(), kBlockSize) / kBlockSize;
+  int32_t numFailed =
+      countErrors(blockStatus, numBlocks, ErrorCode::kInsufficientMemory);
+  int32_t rowSize = agg->rowSize();
+  int32_t numPartitions = hashTable->partitionMask + 1;
+  int64_t newSize =
+      bits::nextPowerOfTwo(numFailed + hashTable->numDistinct * 2);
+  int64_t increment =
+      rowSize * (newSize - hashTable->numDistinct) / numPartitions;
+  for (auto i = 0; i < numPartitions; ++i) {
+    auto* allocator =
+        &reinterpret_cast<HashPartitionAllocator*>(hashTable + 1)[i];
+    // Many concurrent failed allocation attempts can leave the fill way past
+    // limit. Reset fills to limits if over limit.
+    allocator->clearOverflows();
+    if (allocator->availableFixed() < increment) {
+      restockAllocator(*state, stream.arena(), increment, allocator);
+    }
+  }
+  bool rehash = false;
+  WaveBufferPtr oldBuckets;
+  int32_t numOldBuckets;
+  // Rehash if close to max. We can have growth from variable length
+  // accumulators so rehash is not always right.
+  if (gridState->numDistinct >= hashTable->maxEntries / 10 * 9) {
+    oldBuckets = state->buffers[1];
+    numOldBuckets = hashTable->sizeMask + 1;
+    state->buffers[1] = stream.arena().allocate<GpuBucketMembers>(
+        newSize / GpuBucketMembers::kNumSlots);
+    hashTable->sizeMask = (newSize / GpuBucketMembers::kNumSlots) - 1;
+    hashTable->buckets = state->buffers[1]->as<GpuBucket>();
+    hashTable->maxEntries = newSize / 6 * 5;
+    rehash = true;
+  }
+  state->setSizesToSafe();
+  deviceStream->prefetch(
+      getDevice(), state->alignedHead, state->alignedHeadSize);
+  if (rehash) {
+    AggregationControl control;
+    control.head = head;
+    control.oldBuckets = oldBuckets->as<char>();
+    control.numOldBuckets = numOldBuckets;
+    reinterpret_cast<WaveKernelStream*>(deviceStream.get())
+        ->setupAggregation(control);
+  }
+  deviceStream->wait();
+  WaveStream::releaseStream(std::move(deviceStream));
 }
 
 AdvanceResult AbstractAggregation::canAdvance(
     WaveStream& stream,
     LaunchControl* control,
     OperatorState* state,
-    int32_t programIdx) const {
+    int32_t instructionIdx) const {
+  if (keys.empty()) {
+    return {};
+  }
+  auto gridState = stream.gridStatus<AggregateReturn>(instructionStatus);
+  if (gridState->numDistinct) {
+    // The hash table needs memory or rehash. Request a Task-wide break to
+    // resupply the device side hash table.
+    return {
+        .numRows = stream.numRows(),
+        .instructionIdx = instructionIdx,
+        .isRetry = true,
+        .syncDrivers = true,
+        .updateStatus = resupplyHashTable,
+        .reason = state};
+  }
   return {};
+}
+
+std::pair<int64_t, int64_t> countResultRows(
+    std::vector<AllocationRange>& ranges,
+    int32_t rowSize) {
+  int64_t count = 0;
+  int64_t bytes = 0;
+  for (auto& range : ranges) {
+    auto bits = reinterpret_cast<uint64_t*>(range.base);
+    int32_t numFree = bits::countBits(bits, 0, range.firstRowOffset * 8);
+    auto n = ((range.rowOffset - range.firstRowOffset) / rowSize) - numFree;
+    count += n;
+    bytes += n * rowSize + (range.capacity - range.stringOffset);
+  }
+  return {count, bytes};
+}
+
+int32_t makeResultRows(
+    AllocationRange* ranges,
+    int32_t numRanges,
+    int32_t rowSize,
+    int32_t maxRows,
+    int32_t& startRange,
+    int32_t& startRow,
+    uintptr_t* result) {
+  int32_t fill = 0;
+  for (; startRange < numRanges; ++startRange) {
+    auto& range = ranges[startRange];
+    uint64_t* bits = reinterpret_cast<uint64_t*>(range.base);
+    auto firstRowOffset = range.firstRowOffset;
+    uint32_t offset = startRow * rowSize + firstRowOffset;
+    uint32_t limit = range.rowOffset - rowSize;
+    for (; offset <= limit; offset += rowSize, ++startRow) {
+      if (bits::isBitSet(bits, startRow)) {
+        continue;
+      }
+      result[fill++] = range.base + offset;
+      if (fill >= maxRows) {
+        return fill;
+      }
+    }
+    startRow = 0;
+  }
+  return fill;
 }
 
 AdvanceResult AbstractReadAggregation::canAdvance(
     WaveStream& stream,
     LaunchControl* control,
     OperatorState* state,
-    int32_t programIdx) const {
+    int32_t instructionIdx) const {
   auto* aggState = reinterpret_cast<AggregateOperatorState*>(state);
+  int32_t batchSize = 100'000;
+  int32_t rowSize = aggState->instruction->rowSize();
+  std::lock_guard<std::mutex> l(aggState->mutex);
+  if (!aggState->instruction->keys.empty()) {
+    auto deviceStream = WaveStream::streamFromReserve();
+    auto deviceAgg = aggState->alignedHead;
+    // On first continue set up the device side row ranges.
+    if (aggState->isNew) {
+      aggState->isNew = false;
+      auto* hashTable =
+          reinterpret_cast<GpuHashTableBase*>(aggState->alignedHead + 1);
+      auto* allocators =
+          reinterpret_cast<HashPartitionAllocator*>(hashTable + 1);
+      int32_t numPartitions = hashTable->partitionMask + 1;
+      for (auto i = 0; i < numPartitions; ++i) {
+        for (auto j = 0; j < 2; j++) {
+          if (!allocators[i].ranges[j].empty()) {
+            aggState->ranges.push_back(std::move(allocators[i].ranges[j]));
+          }
+        }
+      }
+      aggState->rangeIdx = 0;
+      aggState->rowIdx = 0;
+      auto [r, b] = countResultRows(aggState->ranges, rowSize);
+      aggState->numRows = r;
+      aggState->bytes = b;
+      auto maxReadStreams = aggState->instruction->maxReadStreams;
+      aggState->resultRowPointers =
+          stream.arena().allocate<int64_t*>(maxReadStreams);
+      deviceAgg->numReadStreams = maxReadStreams;
+      deviceAgg->resultRowPointers =
+          aggState->resultRowPointers->as<uintptr_t*>();
+      aggState->resultRows.resize(maxReadStreams);
+      deviceStream->memset(
+          aggState->resultRowPointers->as<char>(),
+          0,
+          maxReadStreams * sizeof(void*));
+      aggState->alignedHead->resultRowPointers =
+          aggState->resultRowPointers->as<uintptr_t*>();
+      deviceStream->prefetch(
+          getDevice(), aggState->alignedHead, aggState->alignedHeadSize);
+      aggState->temp =
+          getSmallTransferArena().allocate<int64_t*>(batchSize + 1);
+    }
+    int64_t* tempPtr;
+    auto streamIdx = stream.streamIdx();
+    if (!aggState->resultRows[streamIdx]) {
+      aggState->resultRows[streamIdx] =
+          stream.arena().allocate<int64_t*>(batchSize + 1);
+
+      // Put the new array in the per-stream array in device side state.
+      tempPtr = aggState->resultRows[streamIdx]->as<int64_t>();
+      deviceStream->hostToDeviceAsync(
+          aggState->resultRowPointers->as<int64_t*>() + streamIdx,
+          &tempPtr,
+          sizeof(tempPtr));
+    }
+    auto numRows = makeResultRows(
+        aggState->ranges.data(),
+        aggState->ranges.size(),
+        rowSize,
+        batchSize,
+        aggState->rangeIdx,
+        aggState->rowIdx,
+        aggState->temp->as<uintptr_t>() + 1);
+    aggState->temp->as<uintptr_t>()[0] = numRows;
+    if (numRows == 0) {
+      return {};
+    }
+    deviceStream->hostToDeviceAsync(
+        aggState->resultRows[streamIdx]->as<char>(),
+        aggState->temp->as<char>(),
+        (numRows + 1) * sizeof(int64_t*));
+    deviceStream->wait();
+    return {.numRows = numRows};
+  }
+
+  // Single row case.
   if (aggState->isNew) {
     aggState->isNew = false;
     return {.numRows = 1};

--- a/velox/experimental/wave/exec/Project.h
+++ b/velox/experimental/wave/exec/Project.h
@@ -56,7 +56,7 @@ class Project : public WaveOperator {
     return last.size() == 1 && last[0]->isSink();
   }
 
-  AdvanceResult canAdvance(WaveStream& Stream) override;
+  std::vector<AdvanceResult> canAdvance(WaveStream& Stream) override;
 
   void schedule(WaveStream& stream, int32_t maxRows = 0) override;
 
@@ -69,6 +69,8 @@ class Project : public WaveOperator {
   const OperandSet& syncSet() const override {
     return computedSet_;
   }
+
+  void callUpdateStatus(WaveStream& stream, AdvanceResult& advance) override;
 
  private:
   struct ContinueLocation {

--- a/velox/experimental/wave/exec/TableScan.cpp
+++ b/velox/experimental/wave/exec/TableScan.cpp
@@ -39,15 +39,15 @@ BlockingReason TableScan::isBlocked(ContinueFuture* future) {
   return BlockingReason::kNotBlocked;
 }
 
-AdvanceResult TableScan::canAdvance(WaveStream& stream) {
+std::vector<AdvanceResult> TableScan::canAdvance(WaveStream& stream) {
   if (!dataSource_ || needNewSplit_) {
     return {};
   }
   if (isNewSplit_) {
     isNewSplit_ = false;
-    return {.numRows = waveDataSource_->canAdvance(stream)};
+    return {{.numRows = waveDataSource_->canAdvance(stream)}};
   }
-  return {.numRows = nextAvailableRows_};
+  return {{.numRows = nextAvailableRows_}};
 }
 
 void TableScan::schedule(WaveStream& stream, int32_t maxRows) {

--- a/velox/experimental/wave/exec/TableScan.h
+++ b/velox/experimental/wave/exec/TableScan.h
@@ -50,7 +50,7 @@ class TableScan : public WaveSourceOperator {
     connector_ = connector::getConnector(tableHandle_->connectorId());
   }
 
-  AdvanceResult canAdvance(WaveStream& stream) override;
+  std::vector<AdvanceResult> canAdvance(WaveStream& stream) override;
 
   void schedule(WaveStream& stream, int32_t maxRows = 0) override;
 

--- a/velox/experimental/wave/exec/Values.cpp
+++ b/velox/experimental/wave/exec/Values.cpp
@@ -25,12 +25,12 @@ Values::Values(CompileState& state, const core::ValuesNode& values)
       values_(values.values()),
       roundsLeft_(values.repeatTimes()) {}
 
-AdvanceResult Values::canAdvance(WaveStream& stream) {
+std::vector<AdvanceResult> Values::canAdvance(WaveStream& stream) {
   if (current_ < values_.size()) {
-    return {.numRows = values_[current_]->size()};
+    return {{.numRows = values_[current_]->size()}};
   }
   if (roundsLeft_ > 1) {
-    return {.numRows = values_[0]->size()};
+    return {{.numRows = values_[0]->size()}};
   }
   return {};
 }

--- a/velox/experimental/wave/exec/Values.h
+++ b/velox/experimental/wave/exec/Values.h
@@ -24,7 +24,7 @@ class Values : public WaveSourceOperator {
  public:
   Values(CompileState& state, const core::ValuesNode& values);
 
-  AdvanceResult canAdvance(WaveStream& stream) override;
+  std::vector<AdvanceResult> canAdvance(WaveStream& stream) override;
 
   bool isStreaming() const override {
     return true;

--- a/velox/experimental/wave/exec/WaveDriver.cpp
+++ b/velox/experimental/wave/exec/WaveDriver.cpp
@@ -29,6 +29,137 @@ DEFINE_int32(
 
 namespace facebook::velox::wave {
 
+std::mutex WaveBarrier::barriersMutex_;
+std::unordered_map<std::string, std::weak_ptr<WaveBarrier>>
+    WaveBarrier::barriers_;
+
+WaveBarrier::WaveBarrier(std::string idString)
+    : idString_(std::move(idString)) {}
+
+std::shared_ptr<WaveBarrier> WaveBarrier::get(
+    const std::string& taskId,
+    int32_t driverId,
+    int32_t operatorId) {
+  auto id = fmt::format("{}:{}:{}", taskId, driverId, operatorId);
+  std::lock_guard<std::mutex> l(barriersMutex_);
+  auto it = barriers_.find(id);
+  if (it != barriers_.end()) {
+    auto ptr = it->second.lock();
+    if (ptr) {
+      return ptr;
+    }
+  }
+  auto barrier = std::make_shared<WaveBarrier>(id);
+  barriers_[id] = barrier;
+  return barrier;
+}
+
+WaveBarrier::~WaveBarrier() {
+  std::lock_guard<std::mutex> l(barriersMutex_);
+  barriers_.erase(idString_);
+}
+
+void waitFor(ContinueFuture future) {
+  std::move(future).via(&folly::QueuedImmediateExecutor::instance()).wait();
+}
+
+bool waitForBool(folly::SemiFuture<bool> future) {
+  return std::move(future)
+      .via(&folly::QueuedImmediateExecutor::instance())
+      .value();
+}
+
+void WaveBarrier::enter() {
+  for (;;) {
+    ContinueFuture waitFuture;
+    {
+      std::lock_guard<std::mutex> l(mutex_);
+      if (!exclusiveToken_) {
+        ++numJoined_;
+        return;
+      }
+      auto [promise, waitFuture] =
+          makeVeloxContinuePromiseContract("WaveDriver");
+
+      promises_.push_back(std::move(promise));
+    }
+    waitFor(std::move(waitFuture));
+  }
+}
+
+void WaveBarrier::maybeReleaseAcquireLocked() {
+  if (numJoined_ - numInArrive_ == exclusivePromises_.size()) {
+    exclusiveToken_ = exclusiveTokens_.back();
+    exclusivePromises_.back().setValue(true);
+    exclusivePromises_.pop_back();
+    exclusiveTokens_.pop_back();
+  }
+}
+
+void WaveBarrier::leave() {
+  VELOX_CHECK_NULL(exclusiveToken_);
+  std::lock_guard<std::mutex> l(mutex_);
+  --numJoined_;
+  maybeReleaseAcquireLocked();
+}
+
+bool WaveBarrier::acquire(void* reason) {
+  folly::SemiFuture<bool> future(false);
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    if (numJoined_ == 1) {
+      exclusiveToken_ = reason;
+      return true;
+    }
+    auto promise = folly::Promise<bool>();
+    auto future = promise.getSemiFuture();
+    exclusivePromises_.push_back(std::move(promise));
+    exclusiveTokens_.push_back(reason);
+    maybeReleaseAcquireLocked();
+  }
+  return waitForBool(std::move(future));
+}
+
+void WaveBarrier::release() {
+  VELOX_CHECK_NOT_NULL(exclusiveToken_);
+  ContinueFuture waitFuture;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    if (numJoined_ == 1) {
+      exclusiveToken_ = nullptr;
+      return;
+    }
+    if (exclusivePromises_.empty()) {
+      for (auto& promise : promises_) {
+        promise.setValue();
+      }
+      numInArrive_ = 0;
+      return;
+    }
+    auto [promise, future] = makeVeloxContinuePromiseContract("WaveDriver");
+    promises_.push_back(std::move(promise));
+    waitFuture = std::move(future);
+    maybeReleaseAcquireLocked();
+  }
+  waitFor(std::move(waitFuture));
+}
+
+void WaveBarrier::arrive() {
+  ContinueFuture waitFuture;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    if (exclusiveTokens_.empty()) {
+      return;
+    }
+    ++numInArrive_;
+    auto [promise, future] = makeVeloxContinuePromiseContract("WaveDriver");
+    promises_.push_back(std::move(promise));
+    waitFuture = std::move(future);
+    maybeReleaseAcquireLocked();
+  }
+  waitFor(std::move(waitFuture));
+}
+
 WaveDriver::WaveDriver(
     exec::DriverCtx* driverCtx,
     RowTypePtr outputType,
@@ -47,6 +178,10 @@ WaveDriver::WaveDriver(
           operatorId,
           planNodeId,
           "Wave"),
+      barrier_(WaveBarrier::get(
+          driverCtx->task->taskId(),
+          driverCtx->driverId,
+          operatorId)),
       arena_(std::move(arena)),
       resultOrder_(std::move(resultOrder)),
       subfields_(std::move(subfields)),
@@ -86,6 +221,8 @@ RowVectorPtr WaveDriver::getOutput() {
   if (finished_) {
     return nullptr;
   }
+  barrier_->enter();
+  auto guard = [&]() { barrier_->leave(); };
   startTimeMs_ = getCurrentTimeMs();
   int32_t last = pipelines_.size() - 1;
   try {
@@ -168,9 +305,11 @@ exec::BlockingReason WaveDriver::processArrived(Pipeline& pipeline) {
       auto advance =
           pipeline.operators[i]->canAdvance(*pipeline.arrived[streamIdx]);
       if (!advance.empty()) {
+        prepareAdvance(pipeline, *pipeline.arrived[streamIdx], i, advance);
+
         runOperators(
-            pipeline, *pipeline.arrived[streamIdx], i, advance.numRows);
-        moveTo(pipeline.arrived, i, pipeline.running, true);
+            pipeline, *pipeline.arrived[streamIdx], i, advance[0].numRows);
+        moveTo(pipeline.arrived, streamIdx, pipeline.running, true);
         continued = true;
         break;
       }
@@ -180,6 +319,7 @@ exec::BlockingReason WaveDriver::processArrived(Pipeline& pipeline) {
       --streamIdx;
     } else {
       /// Not blocked and not continuable, so must be at end.
+      pipeline.arrived[streamIdx]->releaseStreamsAndEvents();
       moveTo(pipeline.arrived, streamIdx, pipeline.finished);
       --streamIdx;
     }
@@ -187,11 +327,45 @@ exec::BlockingReason WaveDriver::processArrived(Pipeline& pipeline) {
   return exec::BlockingReason::kNotBlocked;
 }
 
+void WaveDriver::prepareAdvance(
+    Pipeline& pipeline,
+    WaveStream& stream,
+    int32_t from,
+    std::vector<AdvanceResult>& advanceVector) {
+  void* driversToken = nullptr;
+  int32_t exclusiveIndex = 0;
+  for (auto i = 0; i < advanceVector.size(); ++i) {
+    auto& advance = advanceVector[i];
+    if (!advance.updateStatus) {
+      continue;
+    }
+    if (advance.syncDrivers) {
+      VELOX_CHECK_NULL(driversToken);
+      driversToken = advance.reason;
+      VELOX_CHECK_NOT_NULL(driversToken);
+      exclusiveIndex = i;
+    } else if (advance.syncStreams) {
+    } else {
+      // No sync, like adding memory to string pool for func.
+      pipeline.operators[from]->callUpdateStatus(stream, advance);
+    }
+  }
+  if (driversToken) {
+    barrier_->acquire(driversToken);
+    waitForArrival(pipeline);
+    pipeline.operators[from]->callUpdateStatus(
+        stream, advanceVector[exclusiveIndex]);
+    barrier_->release();
+  }
+}
+
 void WaveDriver::runOperators(
     Pipeline& pipeline,
     WaveStream& stream,
     int32_t from,
     int32_t numRows) {
+  // Pause here if other WaveDrivers need exclusive access.
+  barrier_->arrive();
   // The stream is in 'host' state for any host to device data
   // transfer, then in parallel state after first kernel launch.
   ++stream.stats().numWaves;
@@ -313,8 +487,19 @@ Advance WaveDriver::advance(int pipelineIdx) {
     if (pipeline.finished.empty() &&
         pipeline.running.size() + pipeline.arrived.size() <
             FLAGS_max_streams_per_driver) {
+      // Ordinal of WaveStream across this pipeline across all parallel
+      // WaveDrivers.
+      int16_t streamId = pipeline.arrived.size() +
+          pipeline.running.size() *
+              (FLAGS_max_streams_per_driver *
+               operatorCtx_->driverCtx()->driverId);
       auto stream = std::make_unique<WaveStream>(
-          *arena_, *deviceArena_, &operands(), &stateMap_, instructionStatus_);
+          *arena_,
+          *deviceArena_,
+          &operands(),
+          &stateMap_,
+          instructionStatus_,
+          streamId);
       stream->setState(WaveStream::State::kHost);
       pipeline.arrived.push_back(std::move(stream));
     }

--- a/velox/experimental/wave/exec/WaveOperator.h
+++ b/velox/experimental/wave/exec/WaveOperator.h
@@ -78,8 +78,8 @@ class WaveOperator {
   /// Returns how many rows of output are available from 'this'. Source
   /// operators and cardinality increasing operators must return a correct
   /// answer if they are ready to produce data. Others should return 0.
-  virtual AdvanceResult canAdvance(WaveStream& stream) {
-    return {.numRows = 0};
+  virtual std::vector<AdvanceResult> canAdvance(WaveStream& stream) {
+    return {};
   }
 
   /// Adds processing for 'this' to 'stream'. If 'maxRows' is given,
@@ -99,6 +99,10 @@ class WaveOperator {
 
   virtual bool isSink() const {
     return false;
+  }
+
+  virtual void callUpdateStatus(WaveStream& stream, AdvanceResult& advance) {
+    VELOX_FAIL("Only Project supports callUpdateStatus()");
   }
 
   virtual std::string toString() const;

--- a/velox/experimental/wave/exec/tests/TableScanTest.cpp
+++ b/velox/experimental/wave/exec/tests/TableScanTest.cpp
@@ -349,13 +349,12 @@ TEST_P(TableScanTest, scanAgg) {
 }
 
 TEST_P(TableScanTest, scanGroupBy) {
-  GTEST_SKIP();
   auto type =
       ROW({"c0", "c1", "c2", "c3", "rn"},
           {BIGINT(), BIGINT(), BIGINT(), BIGINT(), BIGINT()});
   auto splits =
       makeData(type, numBatches_, batchSize_, true, [&](RowVectorPtr row) {
-        makeRange(row, 1000000000, true, 1, -1);
+        makeRange(row, 1000000000, true);
       });
 
   auto plan = PlanBuilder(pool_.get())
@@ -372,7 +371,7 @@ TEST_P(TableScanTest, scanGroupBy) {
   auto task = assertQuery(
       plan,
       splits,
-      "SELECT c0, sum(c1 + 1), sum(c2 + 2), sum(c3 + c2), sum(rn + 1) FROM tmp where c0 < 950000000 group by c0");
+      "SELECT c0, sum(c1 + 1), sum(c2 + 2), sum(c3 + c2), sum(rn + 1) FROM tmp where c1 < 950000000 group by c0");
 }
 
 VELOX_INSTANTIATE_TEST_SUITE_P(

--- a/velox/experimental/wave/vector/Operand.h
+++ b/velox/experimental/wave/vector/Operand.h
@@ -153,6 +153,23 @@ struct BlockStatus {
   ErrorCode errors[kBlockSize];
 };
 
+/// User error status returned from kernels. Represents one error from
+/// an arbitrary kernel thread with an error.
+struct KernelError {
+  static constexpr uintptr_t kNoParam = 0;
+  static constexpr uintptr_t kStringParam = 1UL << 60;
+  static constexpr uintptr_t kInt64Param = 2UL << 60;
+
+  /// Host addressable constant string with error message. nullptr if
+  /// no error message. The 4 high bits of the pointer indicate if the
+  /// message is compleemented by 'number' (kInt64Param) or
+  /// 'ptr'kStringParam) (k. If kNoParam the string is the only error
+  /// info.
+  const char* messageAndTag{nullptr};
+  int64_t number;
+  char* ptr;
+};
+
 /// Describes the location of an instruction's return state in the
 /// BlockStatus area. The return states are allocated right above
 /// the BlockStatus array. First are grid level statuses for instructions that


### PR DESCRIPTION
Add basic group by

Adds an interpreted group by with only bigint summs and single bigint
key.  Adds a continue mechanism used when the table runs out of space
in mid kernel. Failed lanes are restarted after filling up the device
side allocator and possibly rehashing the hash table.

Adds a rehash function and logic for allocating group by rows as
needed. The sizes are set up so that the rows to allocate run out
before the slots in the table, so that only the availability of new
rows needs to be checked.

- Sets the memory order for keys to be release on write and consume on
  read. Write the first key last and read the first key first to order
  other stores with the first key acting as the atomic for memory
  order.

- Adds a Task-wide barrier for Wave for cases of updating resources
  (hash tables) shared between Driver pipelines.

- Next step is to use the code as a a codegen template for different
  key/aggregate combinations.

