### PR TITLE
Add support for smallint to PrefixSort

### DIFF
--- a/velox/exec/PrefixSort.cpp
+++ b/velox/exec/PrefixSort.cpp
@@ -51,6 +51,10 @@ FOLLY_ALWAYS_INLINE void extractRowColumnToPrefix(
     char* const row,
     char* const prefix) {
   switch (typeKind) {
+    case TypeKind::SMALLINT: {
+      encodeRowColumn<int16_t>(prefixSortLayout, index, rowColumn, row, prefix);
+      return;
+    }
     case TypeKind::INTEGER: {
       encodeRowColumn<int32_t>(prefixSortLayout, index, rowColumn, row, prefix);
       return;

--- a/velox/exec/prefixsort/tests/PrefixEncoderTest.cpp
+++ b/velox/exec/prefixsort/tests/PrefixEncoderTest.cpp
@@ -304,6 +304,17 @@ TEST_F(PrefixEncoderTest, encode) {
   }
 
   {
+    uint16_t ascExpected = 0x2211;
+    uint16_t descExpected = 0xddee;
+    testEncode<uint16_t>(0x1122, (char*)&ascExpected, (char*)&descExpected);
+  }
+  {
+    int16_t ascExpected = 0x2291;
+    int16_t descExpected = 0xdd6e;
+    testEncode<int16_t>(0x1122, (char*)&ascExpected, (char*)&descExpected);
+  }
+
+  {
     uint32_t ascExpected = 0x0050c3c7;
     uint32_t descExpected = 0xffaf3c38;
     testEncode<float>(100000.00, (char*)&ascExpected, (char*)&descExpected);
@@ -330,11 +341,17 @@ TEST_F(PrefixEncoderTest, encode) {
 TEST_F(PrefixEncoderTest, compare) {
   testCompare<uint64_t>();
   testCompare<uint32_t>();
+  testCompare<uint16_t>();
   testCompare<int64_t>();
   testCompare<int32_t>();
+  testCompare<int16_t>();
   testCompare<float>();
   testCompare<double>();
   testCompare<Timestamp>();
+}
+
+TEST_F(PrefixEncoderTest, fuzzySmallInt) {
+  testFuzz<TypeKind::SMALLINT>();
 }
 
 TEST_F(PrefixEncoderTest, fuzzyInteger) {


### PR DESCRIPTION
According to the benchmark, for data sets larger than 0.5k, PrefixSort outperforms std::sort with performance improvements ranging from approximately 250% to over 500%.  Here's a summary of the benchmark results:

| Dataset Size | PrefixSort Improvement (No Payload) |PrefixSort Improvement(With Payload) |
|--------------|-------------------------------------|-------------------------------------|
| 0.5k         | 248.97% - 287.43%                   | 249.71% - 289.74%                   |
| 1k           | 214.44% - 310.92%                   | 215.03% - 315.14%                   |
| 10k          | 216.21% - 255.38%                   | 217.88% - 256.88%                   |
| 100k         | 279.81% - 318.26%                   | 284.89% - 295.21%                   |
| 1000k        | 304.36% - 351.31%                   | 454.04% - 514.28%                   |

follow-up #8350 
Part of #6766 