### PR TITLE
Add status return and fixes for nulls

### DIFF
--- a/velox/experimental/wave/common/Cuda.cu
+++ b/velox/experimental/wave/common/Cuda.cu
@@ -148,6 +148,7 @@ void Stream::hostToDeviceAsync(
       size,
       cudaMemcpyHostToDevice,
       stream_->stream));
+  isTransfer_ = true;
 }
 
 void Stream::deviceToHostAsync(

--- a/velox/experimental/wave/common/Cuda.h
+++ b/velox/experimental/wave/common/Cuda.h
@@ -75,10 +75,16 @@ class Stream {
   void*& userData() {
     return userData_;
   }
+  bool getAndClearIsTransfer() {
+    auto flag = isTransfer_;
+    isTransfer_ = false;
+    return flag;
+  }
 
  protected:
   std::unique_ptr<StreamImpl> stream_;
   void* userData_{nullptr};
+  bool isTransfer_{false};
 
   friend class Event;
 };

--- a/velox/experimental/wave/dwio/ColumnReader.h
+++ b/velox/experimental/wave/dwio/ColumnReader.h
@@ -225,6 +225,7 @@ class ReadStream : public Executable {
   // Leading bytes in control_->deviceData used for BlockStatus. Cleared on
   // device. The bytes after that are set on host and then prefetched to device.
   int32_t statusBytes_{0};
+  int32_t gridStatusBytes_{0};
   LaunchControl* control_{nullptr};
 
   // Set to true when after first griddize() and akeOps().

--- a/velox/experimental/wave/dwio/FormatData.h
+++ b/velox/experimental/wave/dwio/FormatData.h
@@ -316,12 +316,16 @@ class FormatData {
       ColumnOp& op,
       const ColumnOp* previousFilter,
       ResultStaging& deviceStaging,
+      SplitStaging& splitStaging,
       ReadStream& stream,
       WaveTypeKind columnKind,
       int32_t blockIdx);
 
   // Staging id for nulls.
   int32_t nullsStagingId_{SplitStaging::kNoStaging};
+  // Id for nulls buffer. The nulls buffer has no address at time of scheduling
+  // if nulls decode is in the same kernel as decoding.
+  BufferId nullsBufferId_{kNoBufferId};
   // id of last splitStaging 'this' depends on.
   int32_t lastStagingId_{SplitStaging::kNoStaging};
 

--- a/velox/experimental/wave/dwio/decode/DecodeStep.h
+++ b/velox/experimental/wave/dwio/decode/DecodeStep.h
@@ -130,8 +130,13 @@ struct alignas(16) GpuDecode {
   // launched in the same grid but are independent. The ordinal for non-first
   // TBs gets the base index for values.
   uint16_t nthBlock{0};
-
+  /// Number of rows to process per thread of this block. This is equal across
+  /// the grid, except for last block.
   uint16_t numRowsPerThread{1};
+
+  /// Number of rows per thread in the grid, same for all blocks including the
+  /// last one.
+  uint16_t gridNumRowsPerThread{1};
 
   /// Number of rows to decode. if kFilterHits, the previous GpuDecode gives
   /// this number in BlockStatus. If 'rows' is set, this is the number of valid
@@ -325,6 +330,8 @@ struct alignas(16) GpuDecode {
   struct RowCountNoFilter {
     int32_t numRows;
     BlockStatus* status;
+    int32_t gridStatusSize;
+    bool gridOnly;
   };
 
   struct CountBits {

--- a/velox/experimental/wave/exec/Aggregate.cuh
+++ b/velox/experimental/wave/exec/Aggregate.cuh
@@ -23,6 +23,13 @@
 
 namespace facebook::velox::wave {
 
+inline __device__ void clearReturnState(
+    const IAggregate& agg,
+    WaveShared* shared) {
+  auto* lanes = laneStatus<uint8_t>(shared, agg.status, 0);
+  lanes[threadIdx.x] = 0;
+}
+
 __device__ __forceinline__ void aggregateKernel(
     const IAggregate& agg,
     WaveShared* shared,

--- a/velox/experimental/wave/exec/ExprKernel.h
+++ b/velox/experimental/wave/exec/ExprKernel.h
@@ -140,7 +140,12 @@ struct IUpdateAgg {
 struct IAggregate {
   uint16_t numKeys;
   uint16_t numAggregates;
+  // Serial is used in BlockStatus to identify 'this' for continue.
+  uint8_t serial;
+  /// Index of the state in operator states.
   uint8_t stateIndex;
+  /// Position of status return block in operator status returned to host.
+  InstructionStatus status;
   //  'numAggre gates' Updates followed by key 'numKeys' key operand indices.
   IUpdateAgg* aggregates;
 };

--- a/velox/experimental/wave/exec/Instruction.cpp
+++ b/velox/experimental/wave/exec/Instruction.cpp
@@ -22,6 +22,21 @@ std::string rowTypeString(const Type& type) {
   return "";
 }
 
+void AbstractAggregation::reserveState(InstructionStatus& reservedState) {
+  instructionStatus = reservedState;
+  // A group by produces 8 bytes of grid level state and uses the main main
+  // BlockStatus for lane status.
+  reservedState.gridState += 8;
+}
+
+AdvanceResult AbstractAggregation::canAdvance(
+    WaveStream& stream,
+    LaunchControl* control,
+    OperatorState* state,
+    int32_t programIdx) const {
+  return {};
+}
+
 AdvanceResult AbstractReadAggregation::canAdvance(
     WaveStream& stream,
     LaunchControl* control,

--- a/velox/experimental/wave/exec/Instruction.h
+++ b/velox/experimental/wave/exec/Instruction.h
@@ -167,8 +167,13 @@ struct AbstractInstruction {
     return false;
   }
 
-  /// Sets up status return.
-  virtual void setupReturn(WaveStream& stream, LaunchControl& control) const {}
+  virtual void reserveState(InstructionStatus& state) {}
+
+  /// Returns the InstructionStatus if any. Used for patching the grid
+  /// size after all statuses in the operator pipeline are known.
+  virtual InstructionStatus* mutableInstructionStatus() {
+    return nullptr;
+  }
 
   OpCode opCode;
 
@@ -364,6 +369,20 @@ struct AbstractAggregation : public AbstractOperator {
   bool isSink() const override {
     return true;
   }
+
+  void reserveState(InstructionStatus& state) override;
+
+  InstructionStatus* mutableInstructionStatus() override {
+    return &instructionStatus;
+  }
+
+  AdvanceResult canAdvance(
+      WaveStream& stream,
+      LaunchControl* control,
+      OperatorState* state,
+      int32_t programIdx) const override;
+
+  InstructionStatus instructionStatus;
 
   bool intermediateInput{false};
   bool intermediateOutput{false};

--- a/velox/experimental/wave/exec/Project.cpp
+++ b/velox/experimental/wave/exec/Project.cpp
@@ -131,11 +131,6 @@ void Project::schedule(WaveStream& stream, int32_t maxRows) {
                 control->sharedMemorySize,
                 control->params);
           }
-          // A sink at the end has no output params but need to wait for host
-          // return event before reusing the stream.
-          if (exes.size() == 1 && exes[0]->programShared->isSink()) {
-            stream.resultToHost();
-          }
         });
     isContinue = false;
   }

--- a/velox/experimental/wave/exec/ToWave.cpp
+++ b/velox/experimental/wave/exec/ToWave.cpp
@@ -521,6 +521,8 @@ void CompileState::makeAggregateAccumulate(const core::AggregationNode* node) {
       sourceList.push_back(s);
     }
   }
+  instruction->reserveState(instructionStatus_);
+  allStatuses_.push_back(instruction->mutableInstructionStatus());
   auto aggInstruction = instruction.get();
   addInstruction(std::move(instruction), nullptr, sourceList);
   if (allPrograms_.size() > numPrograms) {
@@ -534,7 +536,10 @@ void CompileState::makeAggregateAccumulate(const core::AggregationNode* node) {
   makeProject(numPrograms, node->outputType());
   auto project = reinterpret_cast<Project*>(operators_.back().get());
   for (auto i = 0; i < node->groupingKeys().size(); ++i) {
-    VELOX_NYI();
+    std::string name = aggInstruction->keys[i]->label;
+    operators_.back()->defined(
+        Value(toSubfield(name)), aggInstruction->keys[i]);
+    definedIn_[aggInstruction->keys[i]] = reader;
   }
   for (auto i = 0; i < aggInstruction->aggregates.size(); ++i) {
     std::string name = aggInstruction->aggregates[i].result->label;
@@ -694,6 +699,10 @@ bool CompileState::compile() {
   for (auto& op : operators_) {
     op->finalize(*this);
   }
+  instructionStatus_.gridStateSize = instructionStatus_.gridState;
+  for (auto* status : allStatuses_) {
+    status->gridStateSize = instructionStatus_.gridState;
+  }
   auto waveOpUnique = std::make_unique<WaveDriver>(
       driver_.driverCtx(),
       outputType,
@@ -704,7 +713,8 @@ bool CompileState::compile() {
       std::move(resultOrder),
       std::move(subfields_),
       std::move(operands_),
-      std::move(operatorStates_));
+      std::move(operatorStates_),
+      instructionStatus_);
   auto waveOp = waveOpUnique.get();
   waveOp->initialize();
   std::vector<std::unique_ptr<exec::Operator>> added;

--- a/velox/experimental/wave/exec/ToWave.h
+++ b/velox/experimental/wave/exec/ToWave.h
@@ -178,6 +178,11 @@ class CompileState {
   int32_t operandCounter_{0};
   int32_t wrapCounter_{0};
   int32_t stateCounter_{0};
+  InstructionStatus instructionStatus_;
+
+  // All InstructionStatus records in instructions that have them. Used for
+  // patching the final grid size when this is known.
+  std::vector<InstructionStatus*> allStatuses_;
 
   int32_t nthContinuable_{0};
   std::shared_ptr<aggregation::AggregateFunctionRegistry>

--- a/velox/experimental/wave/exec/WaveCore.cuh
+++ b/velox/experimental/wave/exec/WaveCore.cuh
@@ -25,6 +25,32 @@
 
 namespace facebook::velox::wave {
 
+template <typename T>
+inline T* __device__
+gridStatus(const WaveShared* shared, const InstructionStatus& status) {
+  int32_t numBlocks = roundUp(shared->numRows, kBlockSize) / kBlockSize;
+  return reinterpret_cast<T*>(
+      roundUp(
+          reinterpret_cast<uintptr_t>(shared->status) +
+              numBlocks * sizeof(BlockStatus),
+          8) +
+      status.gridState);
+}
+
+template <typename T>
+inline T* __device__ laneStatus(
+    const WaveShared* shared,
+    const InstructionStatus& status,
+    int32_t nthBlock) {
+  int32_t numBlocks = roundUp(shared->numRows, kBlockSize) / kBlockSize;
+  return reinterpret_cast<T*>(
+      roundUp(
+          reinterpret_cast<uintptr_t>(shared->status) +
+              numBlocks * sizeof(BlockStatus),
+          8) +
+      status.gridStateSize + status.blockState * numBlocks);
+}
+
 inline bool __device__ laneActive(ErrorCode code) {
   return static_cast<uint8_t>(code) <=
       static_cast<uint8_t>(ErrorCode::kContinue);

--- a/velox/experimental/wave/exec/WaveDriver.h
+++ b/velox/experimental/wave/exec/WaveDriver.h
@@ -35,7 +35,8 @@ class WaveDriver : public exec::SourceOperator {
       std::vector<OperandId> resultOrder_,
       SubfieldMap subfields,
       std::vector<std::unique_ptr<AbstractOperand>> operands,
-      std::vector<std::unique_ptr<AbstractState>> states);
+      std::vector<std::unique_ptr<AbstractState>> states,
+      InstructionStatus instructionStatus);
 
   RowVectorPtr getOutput() override;
 
@@ -189,6 +190,9 @@ class WaveDriver : public exec::SourceOperator {
   // States shared between WaveStreams and WaveDrivers, for example join/group
   // by tables.
   OperatorStateMap stateMap_;
+
+  // Space reserved in BlockStatus array for instruction level return state.
+  InstructionStatus instructionStatus_;
 
   RowVectorPtr result_;
 };

--- a/velox/experimental/wave/exec/tests/TableScanTest.cpp
+++ b/velox/experimental/wave/exec/tests/TableScanTest.cpp
@@ -30,6 +30,7 @@
 
 DECLARE_int32(wave_max_reader_batch_rows);
 DECLARE_int32(max_streams_per_driver);
+DECLARE_int32(wave_reader_rows_per_tb);
 
 using namespace facebook::velox;
 using namespace facebook::velox::core;
@@ -39,14 +40,17 @@ using namespace facebook::velox::exec::test;
 struct WaveScanTestParam {
   int32_t numStreams{1};
   int32_t batchSize{20000};
+  int32_t rowsPerTB{1024};
 };
 
 std::vector<WaveScanTestParam> waveScanTestParams() {
   return {
       WaveScanTestParam{},
-      WaveScanTestParam{.numStreams = 4},
+      WaveScanTestParam{.numStreams = 4, .rowsPerTB = 4096},
       WaveScanTestParam{.numStreams = 4, .batchSize = 1111},
-      WaveScanTestParam{.numStreams = 9, .batchSize = 16500}};
+      WaveScanTestParam{.numStreams = 9, .batchSize = 16500},
+      WaveScanTestParam{
+          .numStreams = 2, .batchSize = 20000, .rowsPerTB = 20480}};
 }
 
 class TableScanTest : public virtual HiveConnectorTestBase,
@@ -66,6 +70,7 @@ class TableScanTest : public virtual HiveConnectorTestBase,
     auto param = GetParam();
     FLAGS_max_streams_per_driver = param.numStreams;
     FLAGS_wave_max_reader_batch_rows = param.batchSize;
+    FLAGS_wave_reader_rows_per_tb = param.rowsPerTB;
   }
 
   static void SetUpTestCase() {
@@ -82,11 +87,16 @@ class TableScanTest : public virtual HiveConnectorTestBase,
       const RowTypePtr& type,
       int32_t numVectors,
       int32_t vectorSize,
-      bool notNull = true) {
-    vectors_ = makeVectors(type, numVectors, vectorSize);
+      bool notNull = true,
+      std::function<void(RowVectorPtr)> custom = nullptr) {
+    vectors_ = makeVectors(type, numVectors, vectorSize, notNull ? 0 : 0.1);
     int32_t cnt = 0;
     for (auto& vector : vectors_) {
-      makeRange(vector, 1000000000, notNull);
+      if (custom) {
+        custom(vector);
+      } else {
+        makeRange(vector, 1000000000, notNull);
+      }
       auto rn = vector->childAt(type->size() - 1)->as<FlatVector<int64_t>>();
       for (auto i = 0; i < rn->size(); ++i) {
         rn->set(i, cnt++);
@@ -120,8 +130,16 @@ class TableScanTest : public virtual HiveConnectorTestBase,
   void makeRange(
       RowVectorPtr row,
       int64_t mod = std::numeric_limits<int64_t>::max(),
-      bool notNull = true) {
-    for (auto i = 0; i < row->type()->size(); ++i) {
+      bool notNull = true,
+      int32_t begin = -1,
+      int32_t end = -1) {
+    if (begin == -1) {
+      begin = 0;
+    }
+    if (end == -1) {
+      end = row->type()->size();
+    }
+    for (auto i = begin; i < end; ++i) {
       auto child = row->childAt(i);
       if (auto ints = child->as<FlatVector<int64_t>>()) {
         for (auto i = 0; i < child->size(); ++i) {
@@ -328,6 +346,33 @@ TEST_P(TableScanTest, scanAgg) {
       plan,
       splits,
       "SELECT sum(c0), sum(c1 + 1), sum(c2 + 2), sum(c3 + c2), sum(rn + 1) FROM tmp where c0 < 950000000");
+}
+
+TEST_P(TableScanTest, scanGroupBy) {
+  GTEST_SKIP();
+  auto type =
+      ROW({"c0", "c1", "c2", "c3", "rn"},
+          {BIGINT(), BIGINT(), BIGINT(), BIGINT(), BIGINT()});
+  auto splits =
+      makeData(type, numBatches_, batchSize_, true, [&](RowVectorPtr row) {
+        makeRange(row, 1000000000, true, 1, -1);
+      });
+
+  auto plan = PlanBuilder(pool_.get())
+                  .tableScan(type, {"c1 < 950000000"})
+                  .project(
+                      {"c0",
+                       "c1 + 1 as c1",
+                       "c2 + 2 as c2",
+                       "c3 + c2 as c3",
+                       "rn + 1 as rn"})
+                  .singleAggregation(
+                      {"c0"}, {"sum(c1)", "sum(c2)", "sum(c3)", "sum(rn)"})
+                  .planNode();
+  auto task = assertQuery(
+      plan,
+      splits,
+      "SELECT c0, sum(c1 + 1), sum(c2 + 2), sum(c3 + c2), sum(rn + 1) FROM tmp where c0 < 950000000 group by c0");
 }
 
 VELOX_INSTANTIATE_TEST_SUITE_P(

--- a/velox/experimental/wave/exec/tests/WaveBenchmark.cpp
+++ b/velox/experimental/wave/exec/tests/WaveBenchmark.cpp
@@ -111,7 +111,7 @@ class WaveBenchmark : public QueryBenchmarkBase {
         table->toFile(FLAGS_data_path + "/test.wave");
       }
     } else {
-      std::string temp = FLAGS_data_path + "/data.dwrf";
+      std::string temp = FLAGS_data_path + "/data." + FLAGS_data_format;
       auto config = std::make_shared<dwrf::Config>();
       config->set(dwrf::Config::COMPRESSION, common::CompressionKind_NONE);
       config->set(
@@ -198,6 +198,7 @@ class WaveBenchmark : public QueryBenchmarkBase {
           plan.dataFiles["0"] = {FLAGS_data_path + "/test.wave"};
         } else {
           plan.dataFiles["0"] = {FLAGS_data_path + "/data.dwrf"};
+          plan.dataFileFormat = toFileFormat(FLAGS_data_format);
         }
         int64_t bound = (1'000'000'000LL * FLAGS_filter_pass_pct) / 100;
         std::vector<std::string> scanFilters;

--- a/velox/experimental/wave/vector/Operand.h
+++ b/velox/experimental/wave/vector/Operand.h
@@ -153,6 +153,24 @@ struct BlockStatus {
   ErrorCode errors[kBlockSize];
 };
 
+/// Describes the location of an instruction's return state in the
+/// BlockStatus area. The return states are allocated right above
+/// the BlockStatus array. First are grid level statuses for instructions that
+/// return a status. After this are block level statuses.
+
+struct InstructionStatus {
+  // Offset of containing instruction's grid state from the end of BlockStatus
+  // array.
+  uint16_t gridState{0};
+  // Total size of gridStates. Block level states start after the last grid
+  // state.
+  uint16_t gridStateSize{0};
+  // Start of per-block status. gridStateSize + gridDim.x * blocksPerThread *
+  // blockState' is the  offset of the first per block status from the end of
+  // BlockStatus array.
+  uint16_t blockState{0};
+};
+
 /// Returns the number of active rows in 'status' for 'numBlocks'.
 int32_t statusNumRows(const BlockStatus* status, int32_t numBlocks);
 


### PR DESCRIPTION
- Add per instruction status return block above the BlockStatus array. Copy the Blockstatus array to host and do not use unified memory for this. The instruction return has a grid-scope status where all grid scope statuses are directly after the the BlockStatuses. Additionally there can be a block level status with n bytes per TB. These are after all the grid level statuses.

- Zero out the grid level statuses in reader, so that subsequent ops are guaranteed a zero grid level status. Block level statuses are uninitialized. If an instruction is continuable, it will first set its grid status and optionally its block level statuses.

- Add one status copy at the end of each pipeline. This serves for all error and continuability information.
- test coverage for cases with nulls with different numbers of rows per tb, including a case of TB doing more rows than the stripe has, in which case griddize can be skipped.

- Add an optional counter for tracking host to device transfer latency separately from compute latency.