### PR TITLE
[Presto][Fuzzer] Catch Cast System error in Expression Fuzzer

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzer.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzer.cpp
@@ -313,8 +313,9 @@ static void filterSignatures(
     for (auto it = input.begin(); it != input.end();) {
       if (!nameSet.count(it->first)) {
         it = input.erase(it);
-      } else
+      } else {
         it++;
+      }
     }
   }
 

--- a/velox/expression/fuzzer/ExpressionFuzzerVerifier.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerVerifier.cpp
@@ -342,7 +342,16 @@ void ExpressionFuzzerVerifier::go() {
           resultVectors ? BaseVector::copy(*resultVectors) : nullptr,
           true, // canThrow
           columnsToWrapInLazy);
-    } catch (const std::exception&) {
+    } catch (const std::exception& exp) {
+      auto veloxError = dynamic_cast<const VeloxRuntimeError*>(&exp);
+      if (veloxError &&
+          veloxError->message() ==
+              "Unicode characters are not supported for conversion to integer types") {
+        LOG(WARNING)
+            << "Ignoring conversion of unicode characters to integer types error";
+        continue;
+      }
+
       if (options_.findMinimalSubexpression) {
         test::computeMinimumSubExpression(
             {&execCtx_, {false, ""}},


### PR DESCRIPTION
PR https://github.com/facebookincubator/velox/pull/10804 made changes to cast behavior to throw a system error instead of a user error when unicode is encountered . This was done for correctness reasons as unicode digits arent supported yet. 
This unfortunately causes expression fuzzer to fail when it creates unicode characters for an expression that uses cast. This particular PR supresses the failure by catching this runtime error and carrying on. Another option is to use a custom generator for cast of varchar to integral types  that then always uses a constant ascii , but it feels to me that option is more akin to unit test. 