### PR TITLE
Fix recursive memory arbitration caused by parallel spill

### DIFF
--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -180,6 +180,7 @@ std::unique_ptr<MemoryReclaimer> MemoryReclaimer::create() {
 uint64_t MemoryReclaimer::run(
     const std::function<int64_t()>& func,
     Stats& stats) {
+  VELOX_CHECK(underMemoryArbitration());
   uint64_t execTimeUs{0};
   int64_t reclaimedBytes{0};
   {

--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -556,6 +556,10 @@ uint64_t SharedArbitrator::getCapacityGrowthTarget(
 }
 
 bool SharedArbitrator::growCapacity(MemoryPool* pool, uint64_t requestBytes) {
+  // NOTE: we shouldn't trigger the recursive memory capacity growth under
+  // memory arbitration context.
+  VELOX_CHECK(!underMemoryArbitration());
+
   ArbitrationOperation op(
       pool, requestBytes, getCapacityGrowthTarget(*pool, requestBytes));
   ScopedArbitration scopedArbitration(this, &op);

--- a/velox/exec/MemoryReclaimer.cpp
+++ b/velox/exec/MemoryReclaimer.cpp
@@ -122,7 +122,7 @@ uint64_t ParallelMemoryReclaimer::reclaim(
     if (candidate.reclaimableBytes == 0) {
       continue;
     }
-    reclaimTasks.push_back(std::make_shared<AsyncSource<ReclaimResult>>(
+    reclaimTasks.push_back(memory::createAsyncMemoryReclaimTask<ReclaimResult>(
         [&, reclaimPool = candidate.pool]() {
           try {
             Stats reclaimStats;

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -17,6 +17,7 @@
 #include "velox/exec/Spiller.h"
 #include <folly/ScopeGuard.h>
 #include "velox/common/base/AsyncSource.h"
+#include "velox/common/memory/MemoryArbitrator.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/HashJoinBridge.h"
@@ -476,7 +477,7 @@ void Spiller::runSpill(bool lastRun) {
     if (spillRuns_[partition].rows.empty()) {
       continue;
     }
-    writes.push_back(std::make_shared<AsyncSource<SpillStatus>>(
+    writes.push_back(memory::createAsyncMemoryReclaimTask<SpillStatus>(
         [partition, this]() { return writeSpill(partition); }));
     if ((writes.size() > 1) && executor_ != nullptr) {
       executor_->add([source = writes.back()]() { source->prepare(); });


### PR DESCRIPTION
Summary:
We do parallel spill at plan node level which reclaim memory from background threads which
might trigger memory allocation like file writer stripe flush. The memory allocation might
trigger memory arbitration again if the background thread doesn't carry the memory arbitration
context. The recursive memory arbitration might deadlock the new memory arbitration requests, and
eventually all the driver threads on a worker. We currently have createAsyncMemoryReclaimTask
which carries on the memory arbitration context but it doesn't cover all the cases (this is due to a recent
regression which breaks the dependency from memory module on velox common base as async source
is defined in common base).

The fix is to use createAsyncMemoryReclaimTask to trigger parallel spill. The follow is to have a generic
execution context framework and the async source automatically pickups the current set execution
context. Also with global arbitration optimization, we won't block driver thread execution from different threads.
It also has e2e memory arbitration request timeout mechanism to prevent this.

Reviewed By: kevinwilfong, oerling

Differential Revision: D62512713
