### PR TITLE
Fix the result mismatch in RowsStreamingWindowBuild

### DIFF
--- a/velox/exec/RowsStreamingWindowBuild.h
+++ b/velox/exec/RowsStreamingWindowBuild.h
@@ -63,6 +63,9 @@ class RowsStreamingWindowBuild : public WindowBuild {
   // does not exist.
   void addPartitionInputs(bool finished);
 
+  // Sets to true if this window node has range frames.
+  const bool hasRangeFrame_;
+
   // Points to the input rows in the current partition.
   std::vector<char*> inputRows_;
 


### PR DESCRIPTION
For a Range frame, it is necessary to ensure that the peer is ready before commencing the window function computation