### PR TITLE
refactor: Update Base64 to match coding standard

### DIFF
--- a/velox/common/encode/Base64.cpp
+++ b/velox/common/encode/Base64.cpp
@@ -184,13 +184,17 @@ size_t Base64::calculateEncodedSize(size_t inputSize, bool withPadding) {
 }
 
 // static
-void Base64::encode(std::string_view input, std::string& output) {
-  encodeImpl(input, kBase64Charset, true, output);
+std::string Base64::encode(std::string_view input, bool includePadding) {
+  std::string output;
+  encodeImpl(input, kBase64Charset, includePadding, output);
+  return output;
 }
 
 // static
-void Base64::encodeUrl(std::string_view input, std::string& output) {
-  encodeImpl(input, kBase64UrlCharset, true, output);
+std::string Base64::encodeUrl(std::string_view input, bool includePadding) {
+  std::string output;
+  encodeImpl(input, kBase64UrlCharset, includePadding, output);
+  return output;
 }
 
 // static

--- a/velox/common/encode/Base64.cpp
+++ b/velox/common/encode/Base64.cpp
@@ -309,12 +309,15 @@ std::string Base64::encode(const folly::IOBuf* inputBuffer) {
 
 // static
 std::string Base64::decode(std::string_view input) {
-  std::string output;
+  Expected<std::string> output;
   auto status = decodeImpl(input, output, kBase64ReverseIndexTable);
   if (!status.ok()) {
     VELOX_USER_FAIL(status.message());
   }
-  return output;
+  if (output.hasError()) {
+    VELOX_USER_FAIL(output.error().message());
+  }
+  return output.value();
 }
 
 // static
@@ -331,7 +334,7 @@ Expected<uint8_t> Base64::base64ReverseLookup(
 }
 
 // static
-Status Base64::decode(std::string_view input, std::string& output) {
+Status Base64::decode(std::string_view input, Expected<std::string>& output) {
   return decodeImpl(input, output, kBase64ReverseIndexTable);
 }
 
@@ -384,9 +387,9 @@ Expected<size_t> Base64::calculateDecodedSize(
 // static
 Status Base64::decodeImpl(
     std::string_view input,
-    std::string& output,
+    Expected<std::string>& output,
     const ReverseIndex& reverseIndex) {
-  output.clear();
+  std::string outputString;
   if (input.empty()) {
     return Status::OK();
   }
@@ -396,7 +399,7 @@ Status Base64::decodeImpl(
   if (decodedSize.hasError()) {
     return decodedSize.error();
   }
-  output.reserve(decodedSize.value());
+  outputString.reserve(decodedSize.value());
   const char* inputPointer = input.data();
   // Handle full groups of 4 characters
   for (; inputSize > 4; inputSize -= 4, inputPointer += 4) {
@@ -412,9 +415,9 @@ Status Base64::decodeImpl(
       }
       decodedBlock |= reverseLookupValue.value() << (18 - 6 * i);
     }
-    output.push_back(static_cast<char>((decodedBlock >> 16) & 0xFF));
-    output.push_back(static_cast<char>((decodedBlock >> 8) & 0xFF));
-    output.push_back(static_cast<char>(decodedBlock & 0xFF));
+    outputString.push_back(static_cast<char>((decodedBlock >> 16) & 0xFF));
+    outputString.push_back(static_cast<char>((decodedBlock >> 8) & 0xFF));
+    outputString.push_back(static_cast<char>(decodedBlock & 0xFF));
   }
 
   // Handle the last 2-4 characters. This is similar to the above, but the
@@ -431,7 +434,7 @@ Status Base64::decodeImpl(
       }
       decodedBlock |= reverseLookupValue.value() << (18 - 6 * i);
     }
-    output.push_back(static_cast<char>((decodedBlock >> 16) & 0xFF));
+    outputString.push_back(static_cast<char>((decodedBlock >> 16) & 0xFF));
 
     if (inputSize > 2) {
       auto reverseLookupValue =
@@ -440,7 +443,7 @@ Status Base64::decodeImpl(
         return reverseLookupValue.error();
       }
       decodedBlock |= reverseLookupValue.value() << 6;
-      output.push_back(static_cast<char>((decodedBlock >> 8) & 0xFF));
+      outputString.push_back(static_cast<char>((decodedBlock >> 8) & 0xFF));
 
       if (inputSize > 3) {
         reverseLookupValue = base64ReverseLookup(inputPointer[3], reverseIndex);
@@ -448,11 +451,11 @@ Status Base64::decodeImpl(
           return reverseLookupValue.error();
         }
         decodedBlock |= reverseLookupValue.value();
-        output.push_back(static_cast<char>(decodedBlock & 0xFF));
+        outputString.push_back(static_cast<char>(decodedBlock & 0xFF));
       }
     }
   }
-
+  output = outputString;
   return Status::OK();
 }
 
@@ -467,18 +470,23 @@ std::string Base64::encodeUrl(std::string_view input) {
 }
 
 // static
-Status Base64::decodeUrl(std::string_view input, std::string& output) {
+Status Base64::decodeUrl(
+    std::string_view input,
+    Expected<std::string>& output) {
   return decodeImpl(input, output, kBase64UrlReverseIndexTable);
 }
 
 // static
 std::string Base64::decodeUrl(std::string_view input) {
-  std::string output;
+  Expected<std::string> output;
   auto status = decodeImpl(input, output, kBase64UrlReverseIndexTable);
   if (!status.ok()) {
     VELOX_USER_FAIL(status.message());
   }
-  return output;
+  if (output.hasError()) {
+    VELOX_USER_FAIL(output.error().message());
+  }
+  return output.value();
 }
 
 } // namespace facebook::velox::encoding

--- a/velox/common/encode/Base64.cpp
+++ b/velox/common/encode/Base64.cpp
@@ -15,10 +15,11 @@
  */
 #include "velox/common/encode/Base64.h"
 
+#include <cstdint>
+
 #include <folly/Portability.h>
 #include <folly/container/Foreach.h>
 #include <folly/io/Cursor.h>
-#include <cstdint>
 
 #include "velox/common/base/Exceptions.h"
 
@@ -156,18 +157,15 @@ static_assert(
 //         kBase64UrlReverseIndexTable),
 //     "kBase64UrlReverseIndexTable has incorrect entries.");
 
-// Implementation of Base64 encoding and decoding functions.
 // static
 template <class T>
 std::string Base64::encodeImpl(
     const T& input,
     const Charset& charset,
     bool includePadding) {
-  size_t encodedSize = calculateEncodedSize(input.size(), includePadding);
-  std::string encodedResult;
-  encodedResult.resize(encodedSize);
-  encodeImpl(input, charset, includePadding, encodedResult.data());
-  return encodedResult;
+  std::string output;
+  encodeImpl(input, charset, includePadding, output);
+  return output;
 }
 
 // static
@@ -186,15 +184,13 @@ size_t Base64::calculateEncodedSize(size_t inputSize, bool withPadding) {
 }
 
 // static
-void Base64::encode(const char* input, size_t inputSize, char* output) {
-  encodeImpl(
-      folly::StringPiece(input, inputSize), kBase64Charset, true, output);
+void Base64::encode(std::string_view input, std::string& output) {
+  encodeImpl(input, kBase64Charset, true, output);
 }
 
 // static
-void Base64::encodeUrl(const char* input, size_t inputSize, char* output) {
-  encodeImpl(
-      folly::StringPiece(input, inputSize), kBase64UrlCharset, true, output);
+void Base64::encodeUrl(std::string_view input, std::string& output) {
+  encodeImpl(input, kBase64UrlCharset, true, output);
 }
 
 // static
@@ -203,13 +199,16 @@ void Base64::encodeImpl(
     const T& input,
     const Charset& charset,
     bool includePadding,
-    char* outputBuffer) {
+    std::string& output) {
   auto inputSize = input.size();
+  output.clear();
   if (inputSize == 0) {
     return;
   }
 
-  auto outputPointer = outputBuffer;
+  size_t encodedSize = calculateEncodedSize(inputSize, includePadding);
+  output.reserve(encodedSize);
+
   auto inputIterator = input.begin();
 
   // For each group of 3 bytes (24 bits) in the input, split that into
@@ -219,10 +218,10 @@ void Base64::encodeImpl(
     inputBlock |= static_cast<uint8_t>(*inputIterator++) << 8;
     inputBlock |= static_cast<uint8_t>(*inputIterator++);
 
-    *outputPointer++ = charset[(inputBlock >> 18) & 0x3f];
-    *outputPointer++ = charset[(inputBlock >> 12) & 0x3f];
-    *outputPointer++ = charset[(inputBlock >> 6) & 0x3f];
-    *outputPointer++ = charset[inputBlock & 0x3f];
+    output.push_back(charset[(inputBlock >> 18) & 0x3F]);
+    output.push_back(charset[(inputBlock >> 12) & 0x3F]);
+    output.push_back(charset[(inputBlock >> 6) & 0x3F]);
+    output.push_back(charset[inputBlock & 0x3F]);
   }
 
   if (inputSize > 0) {
@@ -230,32 +229,33 @@ void Base64::encodeImpl(
     // above (assuming 0 for all other bytes).  Optionally append the '='
     // character if it is requested.
     uint32_t inputBlock = static_cast<uint8_t>(*inputIterator++) << 16;
-    *outputPointer++ = charset[(inputBlock >> 18) & 0x3f];
+    output.push_back(charset[(inputBlock >> 18) & 0x3F]);
+
     if (inputSize > 1) {
       inputBlock |= static_cast<uint8_t>(*inputIterator) << 8;
-      *outputPointer++ = charset[(inputBlock >> 12) & 0x3f];
-      *outputPointer++ = charset[(inputBlock >> 6) & 0x3f];
+      output.push_back(charset[(inputBlock >> 12) & 0x3F]);
+      output.push_back(charset[(inputBlock >> 6) & 0x3F]);
       if (includePadding) {
-        *outputPointer = kPadding;
+        output.push_back(kPadding);
       }
     } else {
-      *outputPointer++ = charset[(inputBlock >> 12) & 0x3f];
+      output.push_back(charset[(inputBlock >> 12) & 0x3F]);
       if (includePadding) {
-        *outputPointer++ = kPadding;
-        *outputPointer = kPadding;
+        output.push_back(kPadding);
+        output.push_back(kPadding);
       }
     }
   }
 }
 
 // static
-std::string Base64::encode(folly::StringPiece text) {
-  return encodeImpl(text, kBase64Charset, true);
+std::string Base64::encode(std::string_view input) {
+  return encodeImpl(input, kBase64Charset, true);
 }
 
 // static
 std::string Base64::encode(const char* input, size_t inputSize) {
-  return encode(folly::StringPiece(input, inputSize));
+  return encodeImpl(std::string_view(input, inputSize), kBase64Charset, true);
 }
 
 namespace {
@@ -308,36 +308,13 @@ std::string Base64::encode(const folly::IOBuf* inputBuffer) {
 }
 
 // static
-std::string Base64::decode(folly::StringPiece encodedText) {
-  std::string decodedResult;
-  decode(std::make_pair(encodedText.data(), encodedText.size()), decodedResult);
-  return decodedResult;
-}
-
-// static
-void Base64::decode(
-    const std::pair<const char*, int32_t>& payload,
-    std::string& decodedOutput) {
-  size_t inputSize = payload.second;
-  auto decodedSize = calculateDecodedSize(payload.first, inputSize);
-  if (decodedSize.hasError()) {
-    VELOX_USER_FAIL(decodedSize.error().message());
-  }
-  decodedOutput.resize(decodedSize.value());
-  auto status = decode(
-      payload.first, inputSize, decodedOutput.data(), decodedOutput.size());
+std::string Base64::decode(std::string_view input) {
+  std::string output;
+  auto status = decodeImpl(input, output, kBase64ReverseIndexTable);
   if (!status.ok()) {
     VELOX_USER_FAIL(status.message());
   }
-}
-
-// static
-void Base64::decode(const char* input, size_t inputSize, char* outputBuffer) {
-  size_t outputSize = inputSize / 4 * 3;
-  auto status = decode(input, inputSize, outputBuffer, outputSize);
-  if (!status.ok()) {
-    VELOX_USER_FAIL(status.message());
-  }
+  return output;
 }
 
 // static
@@ -354,29 +331,20 @@ Expected<uint8_t> Base64::base64ReverseLookup(
 }
 
 // static
-Status Base64::decode(
-    const char* input,
-    size_t inputSize,
-    char* output,
-    size_t outputSize) {
-  auto decodedSize = decodeImpl(
-      input, inputSize, output, outputSize, kBase64ReverseIndexTable);
-  if (decodedSize.hasError()) {
-    return decodedSize.error();
-  }
-  return Status::OK();
+Status Base64::decode(std::string_view input, std::string& output) {
+  return decodeImpl(input, output, kBase64ReverseIndexTable);
 }
 
 // static
 Expected<size_t> Base64::calculateDecodedSize(
-    const char* input,
+    std::string_view input,
     size_t& inputSize) {
   if (inputSize == 0) {
     return 0;
   }
 
   // Check if the input string is padded
-  if (isPadded(input, inputSize)) {
+  if (isPadded(input)) {
     // If padded, ensure that the string length is a multiple of the encoded
     // block size
     if (inputSize % kEncodedBlockByteSize != 0) {
@@ -387,7 +355,7 @@ Expected<size_t> Base64::calculateDecodedSize(
 
     auto decodedSize =
         (inputSize * kBinaryBlockByteSize) / kEncodedBlockByteSize;
-    auto paddingCount = numPadding(input, inputSize);
+    auto paddingCount = numPadding(input);
     inputSize -= paddingCount;
 
     // Adjust the needed size by deducting the bytes corresponding to the
@@ -414,44 +382,39 @@ Expected<size_t> Base64::calculateDecodedSize(
 }
 
 // static
-Expected<size_t> Base64::decodeImpl(
-    const char* input,
-    size_t inputSize,
-    char* outputBuffer,
-    size_t outputSize,
+Status Base64::decodeImpl(
+    std::string_view input,
+    std::string& output,
     const ReverseIndex& reverseIndex) {
-  if (inputSize == 0) {
-    return 0;
+  output.clear();
+  if (input.empty()) {
+    return Status::OK();
   }
 
+  size_t inputSize = input.size();
   auto decodedSize = calculateDecodedSize(input, inputSize);
   if (decodedSize.hasError()) {
-    return folly::makeUnexpected(decodedSize.error());
+    return decodedSize.error();
   }
-
-  if (outputSize < decodedSize.value()) {
-    return folly::makeUnexpected(
-        Status::UserError("Base64::decode() - invalid output string: "
-                          "output string is too small."));
-  }
-  outputSize = decodedSize.value();
-
+  output.reserve(decodedSize.value());
+  const char* inputPointer = input.data();
   // Handle full groups of 4 characters
-  for (; inputSize > 4; inputSize -= 4, input += 4, outputBuffer += 3) {
+  for (; inputSize > 4; inputSize -= 4, inputPointer += 4) {
     // Each character of the 4 encodes 6 bits of the original, grab each with
     // the appropriate shifts to rebuild the original and then split that back
     // into the original 8-bit bytes.
     uint32_t decodedBlock = 0;
     for (int i = 0; i < 4; ++i) {
-      auto reverseLookupValue = base64ReverseLookup(input[i], reverseIndex);
+      auto reverseLookupValue =
+          base64ReverseLookup(inputPointer[i], reverseIndex);
       if (reverseLookupValue.hasError()) {
-        return folly::makeUnexpected(reverseLookupValue.error());
+        return reverseLookupValue.error();
       }
       decodedBlock |= reverseLookupValue.value() << (18 - 6 * i);
     }
-    outputBuffer[0] = static_cast<char>((decodedBlock >> 16) & 0xff);
-    outputBuffer[1] = static_cast<char>((decodedBlock >> 8) & 0xff);
-    outputBuffer[2] = static_cast<char>(decodedBlock & 0xff);
+    output.push_back(static_cast<char>((decodedBlock >> 16) & 0xFF));
+    output.push_back(static_cast<char>((decodedBlock >> 8) & 0xFF));
+    output.push_back(static_cast<char>(decodedBlock & 0xFF));
   }
 
   // Handle the last 2-4 characters. This is similar to the above, but the
@@ -461,44 +424,36 @@ Expected<size_t> Base64::decodeImpl(
 
     // Process the first two characters
     for (int i = 0; i < 2; ++i) {
-      auto reverseLookupValue = base64ReverseLookup(input[i], reverseIndex);
+      auto reverseLookupValue =
+          base64ReverseLookup(inputPointer[i], reverseIndex);
       if (reverseLookupValue.hasError()) {
-        return folly::makeUnexpected(reverseLookupValue.error());
+        return reverseLookupValue.error();
       }
       decodedBlock |= reverseLookupValue.value() << (18 - 6 * i);
     }
-    outputBuffer[0] = static_cast<char>((decodedBlock >> 16) & 0xff);
+    output.push_back(static_cast<char>((decodedBlock >> 16) & 0xFF));
 
     if (inputSize > 2) {
-      auto reverseLookupValue = base64ReverseLookup(input[2], reverseIndex);
+      auto reverseLookupValue =
+          base64ReverseLookup(inputPointer[2], reverseIndex);
       if (reverseLookupValue.hasError()) {
-        return folly::makeUnexpected(reverseLookupValue.error());
+        return reverseLookupValue.error();
       }
       decodedBlock |= reverseLookupValue.value() << 6;
-      outputBuffer[1] = static_cast<char>((decodedBlock >> 8) & 0xff);
+      output.push_back(static_cast<char>((decodedBlock >> 8) & 0xFF));
 
       if (inputSize > 3) {
-        auto reverseLookupValue = base64ReverseLookup(input[3], reverseIndex);
+        reverseLookupValue = base64ReverseLookup(inputPointer[3], reverseIndex);
         if (reverseLookupValue.hasError()) {
-          return folly::makeUnexpected(reverseLookupValue.error());
+          return reverseLookupValue.error();
         }
         decodedBlock |= reverseLookupValue.value();
-        outputBuffer[2] = static_cast<char>(decodedBlock & 0xff);
+        output.push_back(static_cast<char>(decodedBlock & 0xFF));
       }
     }
   }
 
-  return decodedSize.value();
-}
-
-// static
-std::string Base64::encodeUrl(folly::StringPiece text) {
-  return encodeImpl(text, kBase64UrlCharset, false);
-}
-
-// static
-std::string Base64::encodeUrl(const char* input, size_t inputSize) {
-  return encodeUrl(folly::StringPiece(input, inputSize));
+  return Status::OK();
 }
 
 // static
@@ -507,43 +462,23 @@ std::string Base64::encodeUrl(const folly::IOBuf* inputBuffer) {
 }
 
 // static
-Status Base64::decodeUrl(
-    const char* input,
-    size_t inputSize,
-    char* outputBuffer,
-    size_t outputSize) {
-  auto decodedSize = decodeImpl(
-      input, inputSize, outputBuffer, outputSize, kBase64UrlReverseIndexTable);
-  if (decodedSize.hasError()) {
-    return decodedSize.error();
-  }
-  return Status::OK();
+std::string Base64::encodeUrl(std::string_view input) {
+  return encodeImpl(input, kBase64UrlCharset, false);
 }
 
 // static
-std::string Base64::decodeUrl(folly::StringPiece encodedText) {
-  std::string decodedOutput;
-  decodeUrl(
-      std::make_pair(encodedText.data(), encodedText.size()), decodedOutput);
-  return decodedOutput;
+Status Base64::decodeUrl(std::string_view input, std::string& output) {
+  return decodeImpl(input, output, kBase64UrlReverseIndexTable);
 }
 
 // static
-void Base64::decodeUrl(
-    const std::pair<const char*, int32_t>& payload,
-    std::string& decodedOutput) {
-  size_t expectedDecodedSize = (payload.second + 3) / 4 * 3;
-  decodedOutput.resize(expectedDecodedSize, '\0');
-  auto decodedSize = decodeImpl(
-      payload.first,
-      payload.second,
-      decodedOutput.data(),
-      expectedDecodedSize,
-      kBase64UrlReverseIndexTable);
-  if (decodedSize.hasError()) {
-    VELOX_USER_FAIL(decodedSize.error().message());
+std::string Base64::decodeUrl(std::string_view input) {
+  std::string output;
+  auto status = decodeImpl(input, output, kBase64UrlReverseIndexTable);
+  if (!status.ok()) {
+    VELOX_USER_FAIL(status.message());
   }
-  decodedOutput.resize(decodedSize.value());
+  return output;
 }
 
 } // namespace facebook::velox::encoding

--- a/velox/common/encode/Base64.h
+++ b/velox/common/encode/Base64.h
@@ -44,96 +44,62 @@ class Base64 {
   /// Encodes the specified number of characters from the 'input'.
   static std::string encode(const char* input, size_t inputSize);
 
-  /// Encodes the specified text.
-  static std::string encode(folly::StringPiece text);
+  /// Encodes the specified input.
+  static std::string encode(std::string_view input);
 
   /// Encodes the specified IOBuf data.
   static std::string encode(const folly::IOBuf* inputBuffer);
 
-  /// Encodes the specified number of characters from the 'input' and writes the
-  /// result to the 'outputBuffer'. The output must have enough space as
-  /// returned by the calculateEncodedSize().
-  static void encode(const char* input, size_t inputSize, char* outputBuffer);
+  /// Encodes the 'input' string and writes Base64-encoded string in 'output'.
+  static void encode(std::string_view input, std::string& output);
 
-  /// Encodes the specified number of characters from the 'input' using URL
-  /// encoding.
-  static std::string encodeUrl(const char* input, size_t inputSize);
-
-  /// Encodes the specified text using URL encoding.
-  static std::string encodeUrl(folly::StringPiece text);
+  /// Encodes the 'input' string using URL encoding.
+  static std::string encodeUrl(std::string_view input);
 
   /// Encodes the specified IOBuf data using URL encoding.
   static std::string encodeUrl(const folly::IOBuf* inputBuffer);
 
-  /// Encodes the specified number of characters from the 'input' and writes the
-  /// result to the 'outputBuffer' using URL encoding. The output must have
-  /// enough space as returned by the calculateEncodedSize().
-  static void
-  encodeUrl(const char* input, size_t inputSize, char* outputBuffer);
+  /// Encodes the 'input' string and writes the result to the 'output' using URL
+  /// encoding.
+  static void encodeUrl(std::string_view input, std::string& output);
 
   /// Decodes the input Base64 encoded string.
-  static std::string decode(folly::StringPiece encodedText);
+  static std::string decode(std::string_view input);
 
-  /// Decodes the specified encoded payload and writes the result to the
-  /// 'output'.
-  static void decode(
-      const std::pair<const char*, int32_t>& payload,
-      std::string& output);
-
-  /// Decodes the specified number of characters from the 'input' and writes the
-  /// result to the 'outputBuffer'. The output must have enough space as
-  /// returned by the calculateDecodedSize().
-  static void decode(const char* input, size_t inputSize, char* outputBuffer);
-
-  /// Decodes the specified number of characters from the 'input' and writes the
-  /// result to the 'outputBuffer'.
-  static Status decode(
-      const char* input,
-      size_t inputSize,
-      char* outputBuffer,
-      size_t outputSize);
+  /// Decodes the base64-encoded string and writes the result to the 'output'.
+  static Status decode(std::string_view input, std::string& output);
 
   /// Decodes the input Base64 URL encoded string.
-  static std::string decodeUrl(folly::StringPiece encodedText);
+  static std::string decodeUrl(std::string_view input);
 
-  /// Decodes the specified URL encoded payload and writes the result to the
-  /// 'output'.
-  static void decodeUrl(
-      const std::pair<const char*, int32_t>& payload,
-      std::string& output);
-
-  /// Decodes the specified number of characters from the 'input' using URL
-  /// encoding and writes the result to the 'outputBuffer'
-  static Status decodeUrl(
-      const char* input,
-      size_t inputSize,
-      char* outputBuffer,
-      size_t outputSize);
-
-  /// Calculates the encoded size based on input 'inputSize'.
-  static size_t calculateEncodedSize(size_t inputSize, bool withPadding = true);
-
-  /// Calculates the decoded size based on encoded input and adjusts the input
-  /// size for padding.
-  static Expected<size_t> calculateDecodedSize(
-      const char* input,
-      size_t& inputSize);
+  /// Decodes the 'input' string using URL encoding and writes the result to the
+  /// 'output'
+  static Status decodeUrl(std::string_view input, std::string& output);
 
  private:
   // Padding character used in encoding.
   static const char kPadding = '=';
 
+  // Calculates the encoded size based on input 'inputSize'.
+  static size_t calculateEncodedSize(size_t inputSize, bool withPadding = true);
+
+  // Calculates the decoded size based on encoded input and adjusts the input
+  // size for padding.
+  static Expected<size_t> calculateDecodedSize(
+      std::string_view input,
+      size_t& inputSize);
+
   // Checks if the input Base64 string is padded.
-  static inline bool isPadded(const char* input, size_t inputSize) {
-    return (inputSize > 0 && input[inputSize - 1] == kPadding);
+  static inline bool isPadded(std::string_view input) {
+    return (!input.empty() && input.back() == kPadding);
   }
 
   // Counts the number of padding characters in encoded input.
-  static inline size_t numPadding(const char* input, size_t inputSize) {
+  static inline size_t numPadding(std::string_view input) {
     size_t numPadding{0};
-    while (inputSize > 0 && input[inputSize - 1] == kPadding) {
+    while (!input.empty() && input.back() == kPadding) {
       numPadding++;
-      inputSize--;
+      input.remove_suffix(1);
     }
     return numPadding;
   }
@@ -155,18 +121,17 @@ class Base64 {
       const T& input,
       const Charset& charset,
       bool includePadding,
-      char* outputBuffer);
+      std::string& output);
 
   // Decodes the specified data using the provided reverse lookup table.
-  static Expected<size_t> decodeImpl(
-      const char* input,
-      size_t inputSize,
-      char* outputBuffer,
-      size_t outputSize,
+  static Status decodeImpl(
+      std::string_view input,
+      std::string& output,
       const ReverseIndex& reverseIndex);
 
   VELOX_FRIEND_TEST(Base64Test, checksPadding);
   VELOX_FRIEND_TEST(Base64Test, countsPaddingCorrectly);
+  VELOX_FRIEND_TEST(Base64Test, calculateDecodedSizeProperSize);
 };
 
 } // namespace facebook::velox::encoding

--- a/velox/common/encode/Base64.h
+++ b/velox/common/encode/Base64.h
@@ -51,7 +51,7 @@ class Base64 {
   static std::string encode(const folly::IOBuf* inputBuffer);
 
   /// Encodes the 'input' string and writes Base64-encoded string in 'output'.
-  static void encode(std::string_view input, std::string& output);
+  static std::string encode(std::string_view input, bool includePadding);
 
   /// Encodes the 'input' string using URL encoding.
   static std::string encodeUrl(std::string_view input);
@@ -61,7 +61,7 @@ class Base64 {
 
   /// Encodes the 'input' string and writes the result to the 'output' using URL
   /// encoding.
-  static void encodeUrl(std::string_view input, std::string& output);
+  static std::string encodeUrl(std::string_view input, bool includePadding);
 
   /// Decodes the input Base64 encoded string.
   static std::string decode(std::string_view input);

--- a/velox/common/encode/Base64.h
+++ b/velox/common/encode/Base64.h
@@ -67,14 +67,16 @@ class Base64 {
   static std::string decode(std::string_view input);
 
   /// Decodes the base64-encoded string and writes the result to the 'output'.
-  static Status decode(std::string_view input, std::string& output);
+  static Status decode(std::string_view input, Expected<std::string>& output);
 
   /// Decodes the input Base64 URL encoded string.
   static std::string decodeUrl(std::string_view input);
 
   /// Decodes the 'input' string using URL encoding and writes the result to the
   /// 'output'
-  static Status decodeUrl(std::string_view input, std::string& output);
+  static Status decodeUrl(
+      std::string_view input,
+      Expected<std::string>& output);
 
  private:
   // Padding character used in encoding.
@@ -126,7 +128,7 @@ class Base64 {
   // Decodes the specified data using the provided reverse lookup table.
   static Status decodeImpl(
       std::string_view input,
-      std::string& output,
+      Expected<std::string>& output,
       const ReverseIndex& reverseIndex);
 
   VELOX_FRIEND_TEST(Base64Test, checksPadding);

--- a/velox/common/encode/tests/Base64Test.cpp
+++ b/velox/common/encode/tests/Base64Test.cpp
@@ -98,13 +98,13 @@ TEST_F(Base64Test, calculateDecodedSizeProperSize) {
 }
 
 TEST_F(Base64Test, checksPadding) {
-  EXPECT_TRUE(Base64::isPadded("ABC=", 4));
-  EXPECT_FALSE(Base64::isPadded("ABC", 3));
+  EXPECT_TRUE(Base64::isPadded("ABC="));
+  EXPECT_FALSE(Base64::isPadded("ABC"));
 }
 
 TEST_F(Base64Test, countsPaddingCorrectly) {
-  EXPECT_EQ(0, Base64::numPadding("ABC", 3));
-  EXPECT_EQ(1, Base64::numPadding("ABC=", 4));
-  EXPECT_EQ(2, Base64::numPadding("AB==", 4));
+  EXPECT_EQ(0, Base64::numPadding("ABC"));
+  EXPECT_EQ(1, Base64::numPadding("ABC="));
+  EXPECT_EQ(2, Base64::numPadding("AB=="));
 }
 } // namespace facebook::velox::encoding

--- a/velox/functions/prestosql/BinaryFunctions.h
+++ b/velox/functions/prestosql/BinaryFunctions.h
@@ -298,17 +298,26 @@ struct FromBase64Function {
   // same, but hard-coding one of them might be confusing.
   template <typename T>
   FOLLY_ALWAYS_INLINE Status call(out_type<Varbinary>& result, const T& input) {
+    if (!input.data() || input.size() == 0) {
+      result.resize(0);
+      return Status::OK();
+    }
+
     std::string_view inputString(
         reinterpret_cast<const char*>(input.data()), input.size());
-    std::string output;
+    Expected<std::string> output;
 
     auto status = encoding::Base64::decode(inputString, output);
     if (!status.ok()) {
       return status;
     }
 
-    result.resize(output.size());
-    std::memcpy(result.data(), output.data(), output.size());
+    if (output.hasError()) {
+      return Status::UserError("Base64 decoding failed: {}", output.error());
+    }
+
+    result.resize(output->size());
+    std::memcpy(result.data(), output->data(), output->size());
     return Status::OK();
   }
 };
@@ -318,16 +327,25 @@ struct FromBase64UrlFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
   FOLLY_ALWAYS_INLINE Status
   call(out_type<Varbinary>& result, const arg_type<Varchar>& input) {
+    if (!input.data() || input.size() == 0) {
+      result.resize(0);
+      return Status::OK();
+    }
     std::string_view inputString(
         reinterpret_cast<const char*>(input.data()), input.size());
-    std::string output;
+    Expected<std::string> output;
 
     auto status = encoding::Base64::decodeUrl(inputString, output);
     if (!status.ok()) {
       return status;
     }
-    result.resize(output.size());
-    std::memcpy(result.data(), output.data(), output.size());
+
+    if (output.hasError()) {
+      return Status::UserError("Base64 decoding failed: {}", output.error());
+    }
+
+    result.resize(output->size());
+    std::memcpy(result.data(), output->data(), output->size());
     return Status::OK();
   }
 };

--- a/velox/functions/prestosql/BinaryFunctions.h
+++ b/velox/functions/prestosql/BinaryFunctions.h
@@ -282,11 +282,9 @@ struct ToBase64Function {
   FOLLY_ALWAYS_INLINE void call(
       out_type<Varchar>& result,
       const arg_type<Varbinary>& input) {
-    std::string output;
     std::string_view inputString{
         reinterpret_cast<const char*>(input.data()), input.size()};
-    encoding::Base64::encode(inputString, output);
-    result = output;
+    result = encoding::Base64::encode(inputString, true);
   }
 };
 
@@ -357,11 +355,9 @@ struct ToBase64UrlFunction {
   FOLLY_ALWAYS_INLINE void call(
       out_type<Varchar>& result,
       const arg_type<Varbinary>& input) {
-    std::string output;
     std::string_view inputString{
         reinterpret_cast<const char*>(input.data()), input.size()};
-    encoding::Base64::encodeUrl(inputString, output);
-    result = output;
+    result = encoding::Base64::encodeUrl(inputString, true);
   }
 };
 

--- a/velox/functions/prestosql/BinaryFunctions.h
+++ b/velox/functions/prestosql/BinaryFunctions.h
@@ -282,8 +282,11 @@ struct ToBase64Function {
   FOLLY_ALWAYS_INLINE void call(
       out_type<Varchar>& result,
       const arg_type<Varbinary>& input) {
-    result.resize(encoding::Base64::calculateEncodedSize(input.size()));
-    encoding::Base64::encode(input.data(), input.size(), result.data());
+    std::string output;
+    std::string_view inputString{
+        reinterpret_cast<const char*>(input.data()), input.size()};
+    encoding::Base64::encode(inputString, output);
+    result = output;
   }
 };
 
@@ -295,15 +298,18 @@ struct FromBase64Function {
   // same, but hard-coding one of them might be confusing.
   template <typename T>
   FOLLY_ALWAYS_INLINE Status call(out_type<Varbinary>& result, const T& input) {
-    auto inputSize = input.size();
-    auto decodedSize =
-        encoding::Base64::calculateDecodedSize(input.data(), inputSize);
-    if (decodedSize.hasError()) {
-      return decodedSize.error();
+    std::string_view inputString(
+        reinterpret_cast<const char*>(input.data()), input.size());
+    std::string output;
+
+    auto status = encoding::Base64::decode(inputString, output);
+    if (!status.ok()) {
+      return status;
     }
-    result.resize(decodedSize.value());
-    return encoding::Base64::decode(
-        input.data(), inputSize, result.data(), result.size());
+
+    result.resize(output.size());
+    std::memcpy(result.data(), output.data(), output.size());
+    return Status::OK();
   }
 };
 
@@ -312,15 +318,17 @@ struct FromBase64UrlFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
   FOLLY_ALWAYS_INLINE Status
   call(out_type<Varbinary>& result, const arg_type<Varchar>& input) {
-    auto inputSize = input.size();
-    auto decodedSize =
-        encoding::Base64::calculateDecodedSize(input.data(), inputSize);
-    if (decodedSize.hasError()) {
-      return decodedSize.error();
+    std::string_view inputString(
+        reinterpret_cast<const char*>(input.data()), input.size());
+    std::string output;
+
+    auto status = encoding::Base64::decodeUrl(inputString, output);
+    if (!status.ok()) {
+      return status;
     }
-    result.resize(decodedSize.value());
-    return encoding::Base64::decodeUrl(
-        input.data(), inputSize, result.data(), result.size());
+    result.resize(output.size());
+    std::memcpy(result.data(), output.data(), output.size());
+    return Status::OK();
   }
 };
 
@@ -331,8 +339,11 @@ struct ToBase64UrlFunction {
   FOLLY_ALWAYS_INLINE void call(
       out_type<Varchar>& result,
       const arg_type<Varbinary>& input) {
-    result.resize(encoding::Base64::calculateEncodedSize(input.size()));
-    encoding::Base64::encodeUrl(input.data(), input.size(), result.data());
+    std::string output;
+    std::string_view inputString{
+        reinterpret_cast<const char*>(input.data()), input.size()};
+    encoding::Base64::encodeUrl(inputString, output);
+    result = output;
   }
 };
 


### PR DESCRIPTION
Follow-up PR: https://github.com/facebookincubator/velox/pull/10371

Changes  

- `const char*` is changed to `std::string_view`(https://github.com/facebookincubator/velox/pull/10371#discussion_r1711236730).
- `char*` is changed to `std::string`(https://github.com/facebookincubator/velox/pull/10371#discussion_r1711233864).
- `folly::StringPiece` is changed to `std::string_view`.(https://github.com/facebookincubator/velox/pull/10371#discussion_r1711236265).
- Identical duplicate API after the above changes is removed.