### PR TITLE
Combine low selectivity vectors generated by the hash join filter

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1116,7 +1116,7 @@ RowVectorPtr HashProbe::getOutputInternal(bool toSpillOutput) {
           accumulatedNumOutput < operatorCtx_->driverCtx()
                                      ->queryConfig()
                                      .preferredOutputBatchBytes() &&
-          outputBatchSize - numOut > 0) {
+          outputBatchSize > numOut) {
         mapping = folly::Range(
             outputRowMapping_->asMutable<vector_size_t>() +
                 accumulatedNumOutput,
@@ -1160,13 +1160,9 @@ RowVectorPtr HashProbe::createFilterInput(
     vector_size_t size,
     vector_size_t offset) {
   BufferPtr outputRowMapping = outputRowMapping_;
-  if (offset > 0) {
-    outputRowMapping = BaseVector::sliceBuffer(
-        *INTEGER(),
-        outputRowMapping_,
-        offset,
-        outputTableRowsCapacity_ - offset,
-        pool());
+  if (offset > 0 && outputRowMapping_) {
+    outputRowMapping = Buffer::slice<vector_size_t>(
+        outputRowMapping_, offset, outputTableRowsCapacity_ - offset, pool());
   }
   std::vector<VectorPtr> filterColumns(filterInputType_->size());
   for (auto projection : filterInputProjections_) {

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -136,9 +136,8 @@ class HashProbe : public Operator {
   // for right join and full join.
   RowVectorPtr getBuildSideOutput();
 
-  // Applies 'filter_' to 'outputTableRows_' starting at 'offset' with 'size'
-  // length and updates 'outputRowMapping_'.
-  // Returns the number of passing rows.
+  // Apply 'filter_' to 'outputTableRows_' from 'offset' for 'size' entries,
+  // updating 'outputRowMapping_'. Returns the number of passing rows.
   vector_size_t evalFilter(vector_size_t numRows, vector_size_t offset);
 
   inline bool filterPassed(vector_size_t row) {

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -138,7 +138,7 @@ class HashProbe : public Operator {
 
   // Applies 'filter_' to 'outputTableRows_' and updates 'outputRowMapping_'.
   // Returns the number of passing rows.
-  vector_size_t evalFilter(vector_size_t numRows);
+  vector_size_t evalFilter(vector_size_t numRows, vector_size_t offset);
 
   inline bool filterPassed(vector_size_t row) {
     return filterInputRows_.isValid(row) &&
@@ -149,7 +149,7 @@ class HashProbe : public Operator {
   // Create a temporary input vector to be passed to the filter. This ensures it
   // gets destroyed in case its wrapping an unloaded vector which eventually
   // needs to be wrapped in fillOutput().
-  RowVectorPtr createFilterInput(vector_size_t size);
+  RowVectorPtr createFilterInput(vector_size_t size, vector_size_t offset);
 
   // Prepare filter row selectivity for null-aware join. 'numRows'
   // specifies the number of rows in 'filterInputRows_' to process. If
@@ -158,12 +158,14 @@ class HashProbe : public Operator {
   void prepareFilterRowsForNullAwareJoin(
       RowVectorPtr& filterInput,
       vector_size_t numRows,
-      bool filterPropagateNulls);
+      bool filterPropagateNulls,
+      vector_size_t* rawMapping);
 
   // Evaluate the filter for null-aware anti or left semi project join.
   SelectivityVector evalFilterForNullAwareJoin(
       vector_size_t numRows,
-      bool filterPropagateNulls);
+      bool filterPropagateNulls,
+      vector_size_t* rawMapping);
 
   // Combine the selected probe-side rows with all or null-join-key (depending
   // on the iterator) build side rows and evaluate the filter.  Mark probe rows

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -136,7 +136,8 @@ class HashProbe : public Operator {
   // for right join and full join.
   RowVectorPtr getBuildSideOutput();
 
-  // Applies 'filter_' to 'outputTableRows_' and updates 'outputRowMapping_'.
+  // Applies 'filter_' to 'outputTableRows_' starting at 'offset' with 'size'
+  // length and updates 'outputRowMapping_'.
   // Returns the number of passing rows.
   vector_size_t evalFilter(vector_size_t numRows, vector_size_t offset);
 

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -8386,4 +8386,169 @@ DEBUG_ONLY_TEST_F(HashJoinTest, spillOnBlockedProbe) {
   arbitrationThread.join();
   waitForAllTasksToBeDeleted(30'000'000);
 }
+
+TEST_F(HashJoinTest, combineSmallVectorsAfterFilter) {
+  // Verify low selectivity / small vectors are combined.
+  // Three build vectors and one probe vector are created. The duplication rate
+  // of keys in the build vector is 5. Half of the rows in the build vector can
+  // find a matching key row in the probe vector.
+  // The filter condition '(t1 + u1) % 3 = 0' can filter out most of the
+  // matching rows.
+  auto probeVectors = makeBatches(1, [&](auto /*unused*/) {
+    return makeRowVector(
+        {"t0", "t1"},
+        {
+            makeFlatVector<int32_t>(
+                1'000, [](auto row) { return row; }, nullEvery(400)),
+            makeFlatVector<int64_t>(1'000, [](auto row) { return row * 10; }),
+        });
+  });
+
+  auto buildVectors = makeBatches(3, [&](auto /*unused*/) {
+    return makeRowVector(
+        {"u0", "u1"},
+        {
+            makeFlatVector<int32_t>(
+                1'000,
+                [](auto row) { return -100 + (row / 5); },
+                nullEvery(300)),
+            makeFlatVector<int64_t>(
+                1'000, [](auto row) { return -1000 + (row / 5) * 10; }),
+        });
+  });
+
+  std::shared_ptr<TempFilePath> probeFile = TempFilePath::create();
+  writeToFile(probeFile->getPath(), probeVectors);
+
+  std::shared_ptr<TempFilePath> buildFile = TempFilePath::create();
+  writeToFile(buildFile->getPath(), buildVectors);
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+  core::PlanNodeId probeScanId;
+  core::PlanNodeId buildScanId;
+  core::PlanNodeId joinNodeId;
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+
+  auto verifyJoinOutputVectorCount = [&](int expectedVectorCount,
+                                         core::JoinType joinType,
+                                         const std::string& refQuery,
+                                         bool nullAware = false,
+                                         bool flipJoinSide = false) {
+    std::vector<std::string> output = {"t0", "t1"};
+    if (joinType == core::JoinType::kLeftSemiProject) {
+      output.emplace_back("match");
+    }
+    auto plan = PlanBuilder(planNodeIdGenerator)
+                    .tableScan(asRowType(probeVectors[0]->type()))
+                    .capturePlanNodeId(probeScanId)
+                    .hashJoin(
+                        {"t0"},
+                        {"u0"},
+                        PlanBuilder(planNodeIdGenerator)
+                            .tableScan(asRowType(buildVectors[0]->type()))
+                            .capturePlanNodeId(buildScanId)
+                            .planNode(),
+                        "(t1 + u1) % 3 = 0",
+                        output,
+                        joinType,
+                        nullAware)
+                    .capturePlanNodeId(joinNodeId)
+                    .planNode();
+
+    SplitInput splitInput = {
+        {probeScanId,
+         {exec::Split(makeHiveConnectorSplit(probeFile->getPath()))}},
+        {buildScanId,
+         {exec::Split(makeHiveConnectorSplit(buildFile->getPath()))}},
+    };
+    if (flipJoinSide) {
+      plan = flipJoinSides(plan);
+    }
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+        .planNode(plan)
+        .inputSplits(splitInput)
+        .checkSpillStats(false)
+        .referenceQuery(refQuery)
+        .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
+          ASSERT_EQ(
+              toPlanStats(task->taskStats()).at(joinNodeId).outputVectors,
+              expectedVectorCount);
+        })
+        .run();
+  };
+  {
+    SCOPED_TRACE("inner join");
+    verifyJoinOutputVectorCount(
+        1, // 2 output vectors are merged to 1 vector.
+        core::JoinType::kInner,
+        "SELECT t0, t1, FROM t, u WHERE t0 = u0 AND (t1 + u1) % 3 = 0");
+  }
+  {
+    SCOPED_TRACE("full join");
+    verifyJoinOutputVectorCount(
+        5, // 6 output vectors are merged to 5 vector.
+        core::JoinType::kFull,
+        "SELECT t0, t1, FROM t FULL OUTER JOIN u ON t0 = u0 AND (t1 + u1) % 3 = 0");
+  }
+  {
+    SCOPED_TRACE("left join");
+    verifyJoinOutputVectorCount(
+        2, // 3 output vectors are merged to 2 vectors.
+        core::JoinType::kLeft,
+        "SELECT t0, t1 FROM t LEFT JOIN u ON t0 = u0 AND (t1 + u1) % 3 = 0");
+  }
+  {
+    SCOPED_TRACE("right join");
+    verifyJoinOutputVectorCount(
+        2, // 3 output vectors are merged to 2 vectors.
+        core::JoinType::kLeft, // Flip join side.
+        "SELECT t0, t1 FROM t LEFT JOIN u ON t0 = u0 AND (t1 + u1) % 3 = 0",
+        false,
+        true);
+  }
+  {
+    SCOPED_TRACE("semi project join");
+    verifyJoinOutputVectorCount(
+        1, // 3 output vectors are merged to 1 vector.
+        core::JoinType::kLeftSemiProject,
+        "SELECT t0, t1, EXISTS (SELECT u0 FROM u WHERE t0 = u0 AND (t1 + u1) % 3 = 0) FROM t");
+    verifyJoinOutputVectorCount(
+        1, // 3 output vectors are merged to 1 vector.
+        core::JoinType::kLeftSemiProject,
+        "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE (t1 + u1) % 3 = 0) FROM t",
+        true);
+    verifyJoinOutputVectorCount(
+        1, // 3 output vectors are merged to 1 vector.
+        core::JoinType::kLeftSemiProject, // Flip join side.
+        "SELECT t0, t1, EXISTS (SELECT u0 FROM u WHERE t0 = u0 AND (t1 + u1) % 3 = 0) FROM t",
+        false,
+        true);
+  }
+  {
+    SCOPED_TRACE("semi filter join");
+    verifyJoinOutputVectorCount(
+        1, // 2 output vectors are merged to 1 vector.
+        core::JoinType::kLeftSemiFilter,
+        "SELECT t0, t1, FROM t WHERE EXISTS (SELECT u0 FROM u WHERE t0 = u0 AND (t1 + u1) % 3 = 0)");
+    verifyJoinOutputVectorCount(
+        1, // 2 output vectors are merged to 1 vector.
+        core::JoinType::kLeftSemiFilter, // Flip join side.
+        "SELECT t0, t1, FROM t WHERE EXISTS (SELECT u0 FROM u WHERE t0 = u0 AND (t1 + u1) % 3 = 0)",
+        false,
+        true);
+  }
+  {
+    SCOPED_TRACE("anti join");
+    verifyJoinOutputVectorCount(
+        1, // 3 output vectors are merged to 1 vector.
+        core::JoinType::kAnti,
+        "SELECT t0, t1 FROM t WHERE NOT EXISTS (SELECT * FROM u WHERE t0 = u0 AND (t1 + u1) % 3 = 0)");
+    verifyJoinOutputVectorCount(
+        1, // 2 output vectors are merged to 1 vector.
+        core::JoinType::kAnti,
+        "SELECT t0, t1 FROM t WHERE t0 NOT IN (SELECT u0 FROM u WHERE (t1 + u1) % 3 = 0)",
+        true);
+  }
+}
 } // namespace

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -8388,11 +8388,10 @@ DEBUG_ONLY_TEST_F(HashJoinTest, spillOnBlockedProbe) {
 }
 
 TEST_F(HashJoinTest, combineSmallVectorsAfterFilter) {
-  // Verify low selectivity / small vectors are combined.
-  // Three build vectors and one probe vector are created. The duplication rate
-  // of keys in the build vector is 5. Half of the rows in the build vector can
-  // find a matching key row in the probe vector.
-  // The filter condition '(t1 + u1) % 3 = 0' can filter out most of the
+  // Verify that low-selectivity or small vectors are combined.
+  // Three build vectors and one probe vector are created with a 5x key
+  // duplication rate in the build vectors. Half of the build rows have matching
+  // keys in the probe vector. The filter '(t1 + u1) % 3 == 0' filters out most
   // matching rows.
   auto probeVectors = makeBatches(1, [&](auto /*unused*/) {
     return makeRowVector(

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -888,6 +888,18 @@ class BaseVector {
     storageByteCount_ = std::nullopt;
   }
 
+  // Slice a buffer with specific type.
+  //
+  // For boolean type and if the offset is not multiple of 8, return a shifted
+  // copy; otherwise return a BufferView into the original buffer (with shared
+  // ownership of original buffer).
+  static BufferPtr sliceBuffer(
+      const Type&,
+      const BufferPtr&,
+      vector_size_t offset,
+      vector_size_t length,
+      memory::MemoryPool*);
+
  protected:
   // Returns a brief summary of the vector. The default implementation includes
   // encoding, type, number of rows and number of nulls.

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -888,18 +888,6 @@ class BaseVector {
     storageByteCount_ = std::nullopt;
   }
 
-  // Slice a buffer with specific type.
-  //
-  // For boolean type and if the offset is not multiple of 8, return a shifted
-  // copy; otherwise return a BufferView into the original buffer (with shared
-  // ownership of original buffer).
-  static BufferPtr sliceBuffer(
-      const Type&,
-      const BufferPtr&,
-      vector_size_t offset,
-      vector_size_t length,
-      memory::MemoryPool*);
-
  protected:
   // Returns a brief summary of the vector. The default implementation includes
   // encoding, type, number of rows and number of nulls.


### PR DESCRIPTION
Combine low selectivity vectors generated by join filter
**Problem**
We found in TPCDS query72 that the join filter leads to a large number of 
low-selectivity result vectors, which affects the performance of subsequent 
operations.

Details:
The number of input vectors on the probe side of the corresponding join is 
84,087, with a total of 743,851,486 rows (our batch size is set to 10,240). Due 
to a large number of duplicate rows on the build side, the final result 
inflates. The number of output vectors from the join is 2,806,054. The 
corresponding join filter filters out a large portion of the results, so the
 number of output rows is 1,430,253,235. This leads to the output of many 
 sparse vectors (the average batch row count is 504).

 **Solution**
The original logic continues the [loop](https://github.com/facebookincubator/velox/blob/main/velox/exec/HashProbe.cpp#L1065) to fill more rows if no rows pass the
filters. To resolve this issue, we can extend it to handle cases where only 
partial rows pass the filters. We need to ensure that the indices 
'outputRowMapping_' and 'outputTableRows_' are filled as much as possible until 
we either reach the preferred batch size or have processed all rows in the 
current input vector.

This approach will not only address the issue mentioned above but also avoid 
unnecessary data copying.