### PR TITLE
Support UNSUPPORTED_INPUT VeloxRuntimeError in expression fuzzer

### DIFF
--- a/velox/common/base/Exceptions.h
+++ b/velox/common/base/Exceptions.h
@@ -196,6 +196,20 @@ DECLARE_CHECK_FAIL_TEMPLATES(::facebook::velox::VeloxRuntimeError);
       /* isRetriable */ false,                                      \
       ##__VA_ARGS__)
 
+/// Throws VeloxRuntimeError when functions receive input values out of the
+/// supported range. This should only be used when we want to force TRY() to not
+/// suppress the error.
+#define VELOX_CHECK_UNSUPPORTED_INPUT_UNCATCHABLE(expr, ...)                 \
+  if (UNLIKELY(!(expr))) {                                                   \
+    _VELOX_THROW_IMPL(                                                       \
+        ::facebook::velox::VeloxRuntimeError,                                \
+        #expr,                                                               \
+        ::facebook::velox::error_source::kErrorSourceRuntime.c_str(),        \
+        ::facebook::velox::error_code::kUnsupportedInputUncatchable.c_str(), \
+        /* isRetriable */ false,                                             \
+        __VA_ARGS__);                                                        \
+  }
+
 // If the caller passes a custom message (4 *or more* arguments), we
 // have to construct a format string from ours ("({} vs. {})") plus
 // theirs by adding a space and shuffling arguments. If they don't (exactly 3
@@ -328,6 +342,17 @@ DECLARE_CHECK_FAIL_TEMPLATES(::facebook::velox::VeloxRuntimeError);
       ::facebook::velox::error_source::kErrorSourceRuntime.c_str(), \
       ::facebook::velox::error_code::kInvalidState.c_str(),         \
       /* isRetriable */ false,                                      \
+      ##__VA_ARGS__)
+
+/// Throws VeloxRuntimeError when functions receive input values out of the
+/// supported range. This should only be used when we want to force TRY() to not
+/// suppress the error.
+#define VELOX_FAIL_UNSUPPORTED_INPUT_UNCATCHABLE(...)                      \
+  _VELOX_THROW(                                                            \
+      ::facebook::velox::VeloxRuntimeError,                                \
+      ::facebook::velox::error_source::kErrorSourceRuntime.c_str(),        \
+      ::facebook::velox::error_code::kUnsupportedInputUncatchable.c_str(), \
+      /* isRetriable */ false,                                             \
       ##__VA_ARGS__)
 
 DECLARE_CHECK_FAIL_TEMPLATES(::facebook::velox::VeloxUserError);

--- a/velox/common/base/VeloxException.h
+++ b/velox/common/base/VeloxException.h
@@ -110,6 +110,12 @@ inline constexpr auto kFileNotFound = "FILE_NOT_FOUND"_fs;
 
 // We do not know how to classify it yet.
 inline constexpr auto kUnknown = "UNKNOWN"_fs;
+
+// VeloxRuntimeErrors due to unsupported input values such as unicode input to
+// cast-varchar-to-integer and timestamps beyond the year 2037 to datetime
+// functions. This kind of errors is allowed in expression fuzzer.
+inline constexpr auto kUnsupportedInputUncatchable =
+    "UNSUPPORTED_INPUT_UNCATCHABLE"_fs;
 } // namespace error_code
 
 class VeloxException : public std::exception {

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -309,7 +309,9 @@ void CastExpr::applyCastKernel(
           ToKind == TypeKind::INTEGER || ToKind == TypeKind::BIGINT ||
           ToKind == TypeKind::HUGEINT) {
         if constexpr (TPolicy::throwOnUnicode) {
-          VELOX_CHECK(
+          // This is a special case where we intentionally throw
+          // VeloxRuntimeError to avoid it being suppressed by TRY().
+          VELOX_CHECK_UNSUPPORTED_INPUT_UNCATCHABLE(
               functions::stringCore::isAscii(
                   inputRowValue.data(), inputRowValue.size()),
               "Unicode characters are not supported for conversion to integer types");

--- a/velox/expression/fuzzer/FuzzerToolkit.h
+++ b/velox/expression/fuzzer/FuzzerToolkit.h
@@ -46,6 +46,9 @@ struct SignatureTemplate {
 struct ResultOrError {
   RowVectorPtr result;
   std::exception_ptr exceptionPtr;
+  /// Whether the exception is UNSUPPORTED_INPUT_UNCATCHABLE error. This flag
+  /// should only be set to true when exceptionPtr is not a nullptr.
+  bool unsupportedInputUncatchableError{false};
 };
 
 /// Sort callable function signatures.

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -79,9 +79,9 @@ void Timestamp::toTimezone(const tz::TimeZone& zone) {
     seconds_ = zone.to_local(std::chrono::seconds(seconds_)).count();
   } catch (const std::invalid_argument& e) {
     // Invalid argument means we hit a conversion not supported by
-    // external/date. Need to throw a RuntimeError so that try() statements do
-    // not suppress it.
-    VELOX_FAIL(e.what());
+    // external/date. This is a special case where we intentionally throw
+    // VeloxRuntimeError to avoid it being suppressed by TRY().
+    VELOX_FAIL_UNSUPPORTED_INPUT_UNCATCHABLE(e.what());
   }
 }
 

--- a/velox/type/tz/TimeZoneMap.cpp
+++ b/velox/type/tz/TimeZoneMap.cpp
@@ -209,7 +209,9 @@ void validateRangeImpl(time_point<TDuration> timePoint) {
   auto year = year_month_day(floor<days>(timePoint)).year();
 
   if (year < kMinYear || year > kMaxYear) {
-    VELOX_FAIL(
+    // This is a special case where we intentionally throw
+    // VeloxRuntimeError to avoid it being suppressed by TRY().
+    VELOX_FAIL_UNSUPPORTED_INPUT_UNCATCHABLE(
         "Timepoint is outside of supported year range: [{}, {}], got {}",
         (int)kMinYear,
         (int)kMaxYear,


### PR DESCRIPTION
Summary:
We recently made cast-varchar-to-integral throw VeloxRuntimeError on unicode
inputs and made date-time functions throw VeloxRuntimeError when timestamps
are out of supported range. The expression fuzzer tests have been failing due to
these changes because VeloxRuntimeError is not allowed in fuzzer. This diff
introduces a new ErrorCode `UNSUPPORTED_INPUT ` to VeloxRuntimeError that is
ignored in fuzzers, and makes the cast and date-time functions throw errors with
this error code.

Differential Revision: D62612232
