### PR TITLE
Fix "wget: command not found" error when installing ccache

### DIFF
--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -77,7 +77,7 @@ function install_build_prerequisites {
     python3 -m venv ${PYTHON_VENV}
   fi
   source ${PYTHON_VENV}/bin/activate; pip3 install cmake-format regex pyyaml
-  wget -O ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-darwin.tar.gz
+  curl -L https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-darwin.tar.gz > ccache.tar.gz
   tar -xf ccache.tar.gz
   mv ccache-4.10.2-darwin/ccache /usr/local/bin/
 }


### PR DESCRIPTION
In "Install FMT and download ccache on MacOS (#10933)", wget was used to download ccache in setup-macos.sh. However, wget is not pre-installed on MacOs by default, and the following error was thrown:

```
+ wget -O ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-darwin.tar.gz ../scripts/setup-macos.sh: line 80: wget: command not found
+ tar -xf ccache.tar.gz tar: Error opening archive: Failed to open 'ccache.tar.gz'
```

This commit changes wget to curl, which is guaranteed to be pre-installed on MacOS.