### PR TITLE
Refactor TimestampConversion to return velox::Expected

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -1423,24 +1423,24 @@ Expected<DateTimeResult> DateTimeFormatter::parse(
   }
 
   // Convert the parsed date/time into a timestamp.
-  Expected<int64_t> expected;
+  Expected<int64_t> daysSinceEpoch;
   if (date.weekDateFormat) {
-    expected =
+    daysSinceEpoch =
         util::daysSinceEpochFromWeekDate(date.year, date.week, date.dayOfWeek);
   } else if (date.dayOfYearFormat) {
-    expected = util::daysSinceEpochFromDayOfYear(date.year, date.dayOfYear);
+    daysSinceEpoch = util::daysSinceEpochFromDayOfYear(date.year, date.dayOfYear);
   } else {
-    expected = util::daysSinceEpochFromDate(date.year, date.month, date.day);
+    daysSinceEpoch = util::daysSinceEpochFromDate(date.year, date.month, date.day);
   }
-  if (expected.hasError()) {
-    VELOX_DCHECK(expected.error().isUserError());
-    return folly::makeUnexpected(expected.error());
+  if (daysSinceEpoch.hasError()) {
+    VELOX_DCHECK(daysSinceEpoch.error().isUserError());
+    return folly::makeUnexpected(daysSinceEpoch.error());
   }
 
   int64_t microsSinceMidnight =
       util::fromTime(date.hour, date.minute, date.second, date.microsecond);
   return DateTimeResult{
-      util::fromDatetime(expected.value(), microsSinceMidnight),
+      util::fromDatetime(daysSinceEpoch.value(), microsSinceMidnight),
       date.timezoneId};
 }
 

--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -1428,9 +1428,11 @@ Expected<DateTimeResult> DateTimeFormatter::parse(
     daysSinceEpoch =
         util::daysSinceEpochFromWeekDate(date.year, date.week, date.dayOfWeek);
   } else if (date.dayOfYearFormat) {
-    daysSinceEpoch = util::daysSinceEpochFromDayOfYear(date.year, date.dayOfYear);
+    daysSinceEpoch =
+        util::daysSinceEpochFromDayOfYear(date.year, date.dayOfYear);
   } else {
-    daysSinceEpoch = util::daysSinceEpochFromDate(date.year, date.month, date.day);
+    daysSinceEpoch =
+        util::daysSinceEpochFromDate(date.year, date.month, date.day);
   }
   if (daysSinceEpoch.hasError()) {
     VELOX_DCHECK(daysSinceEpoch.error().isUserError());

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -402,27 +402,24 @@ struct LastDayOfMonthFunction : public InitSessionTimezone<T>,
       const arg_type<Timestamp>& timestamp) {
     auto dt = getDateTime(timestamp, this->timeZone_);
     int64_t daysSinceEpochFromDate;
-    auto status =
-        util::lastDayOfMonthSinceEpochFromDate(dt, daysSinceEpochFromDate);
-    if (!status.ok()) {
-      VELOX_DCHECK(status.isUserError());
-      VELOX_USER_FAIL(status.message());
+    Expected<int64_t> expected = util::lastDayOfMonthSinceEpochFromDate(dt);
+    if (expected.hasError()) {
+      VELOX_DCHECK(expected.error().isUserError());
+      VELOX_USER_FAIL(expected.error().message());
     }
-    result = daysSinceEpochFromDate;
+    result = expected.value();
   }
 
   FOLLY_ALWAYS_INLINE void call(
       out_type<Date>& result,
       const arg_type<Date>& date) {
     auto dt = getDateTime(date);
-    int64_t daysSinceEpochFromDate;
-    auto status =
-        util::lastDayOfMonthSinceEpochFromDate(dt, daysSinceEpochFromDate);
-    if (!status.ok()) {
-      VELOX_DCHECK(status.isUserError());
-      VELOX_USER_FAIL(status.message());
+    Expected<int64_t> expected = util::lastDayOfMonthSinceEpochFromDate(dt);
+    if (expected.hasError()) {
+      VELOX_DCHECK(expected.error().isUserError());
+      VELOX_USER_FAIL(expected.error().message());
     }
-    result = daysSinceEpochFromDate;
+    result = expected.value();
   }
 
   FOLLY_ALWAYS_INLINE void call(
@@ -430,14 +427,12 @@ struct LastDayOfMonthFunction : public InitSessionTimezone<T>,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
     auto timestamp = this->toTimestamp(timestampWithTimezone);
     auto dt = getDateTime(timestamp, nullptr);
-    int64_t daysSinceEpochFromDate;
-    auto status =
-        util::lastDayOfMonthSinceEpochFromDate(dt, daysSinceEpochFromDate);
-    if (!status.ok()) {
-      VELOX_DCHECK(status.isUserError());
-      VELOX_USER_FAIL(status.message());
+    Expected<int64_t> expected = util::lastDayOfMonthSinceEpochFromDate(dt);
+    if (expected.hasError()) {
+      VELOX_DCHECK(expected.error().isUserError());
+      VELOX_USER_FAIL(expected.error().message());
     }
-    result = daysSinceEpochFromDate;
+    result = expected.value();
   }
 };
 

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -401,25 +401,24 @@ struct LastDayOfMonthFunction : public InitSessionTimezone<T>,
       out_type<Date>& result,
       const arg_type<Timestamp>& timestamp) {
     auto dt = getDateTime(timestamp, this->timeZone_);
-    int64_t daysSinceEpochFromDate;
-    Expected<int64_t> expected = util::lastDayOfMonthSinceEpochFromDate(dt);
-    if (expected.hasError()) {
-      VELOX_DCHECK(expected.error().isUserError());
-      VELOX_USER_FAIL(expected.error().message());
+    Expected<int64_t> daysSinceEpochFromDate = util::lastDayOfMonthSinceEpochFromDate(dt);
+    if (daysSinceEpochFromDate.hasError()) {
+      VELOX_DCHECK(daysSinceEpochFromDate.error().isUserError());
+      VELOX_USER_FAIL(daysSinceEpochFromDate.error().message());
     }
-    result = expected.value();
+    result = daysSinceEpochFromDate.value();
   }
 
   FOLLY_ALWAYS_INLINE void call(
       out_type<Date>& result,
       const arg_type<Date>& date) {
     auto dt = getDateTime(date);
-    Expected<int64_t> expected = util::lastDayOfMonthSinceEpochFromDate(dt);
-    if (expected.hasError()) {
-      VELOX_DCHECK(expected.error().isUserError());
-      VELOX_USER_FAIL(expected.error().message());
+    Expected<int64_t> lastDayOfMonthSinceEpoch = util::lastDayOfMonthSinceEpochFromDate(dt);
+    if (lastDayOfMonthSinceEpoch.hasError()) {
+      VELOX_DCHECK(lastDayOfMonthSinceEpoch.error().isUserError());
+      VELOX_USER_FAIL(lastDayOfMonthSinceEpoch.error().message());
     }
-    result = expected.value();
+    result = lastDayOfMonthSinceEpoch.value();
   }
 
   FOLLY_ALWAYS_INLINE void call(
@@ -427,12 +426,12 @@ struct LastDayOfMonthFunction : public InitSessionTimezone<T>,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
     auto timestamp = this->toTimestamp(timestampWithTimezone);
     auto dt = getDateTime(timestamp, nullptr);
-    Expected<int64_t> expected = util::lastDayOfMonthSinceEpochFromDate(dt);
-    if (expected.hasError()) {
-      VELOX_DCHECK(expected.error().isUserError());
-      VELOX_USER_FAIL(expected.error().message());
+    Expected<int64_t> lastDayOfMonthSinceEpoch = util::lastDayOfMonthSinceEpochFromDate(dt);
+    if (lastDayOfMonthSinceEpoch.hasError()) {
+      VELOX_DCHECK(lastDayOfMonthSinceEpoch.error().isUserError());
+      VELOX_USER_FAIL(lastDayOfMonthSinceEpoch.error().message());
     }
-    result = expected.value();
+    result = lastDayOfMonthSinceEpoch.value();
   }
 };
 

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -401,7 +401,8 @@ struct LastDayOfMonthFunction : public InitSessionTimezone<T>,
       out_type<Date>& result,
       const arg_type<Timestamp>& timestamp) {
     auto dt = getDateTime(timestamp, this->timeZone_);
-    Expected<int64_t> daysSinceEpochFromDate = util::lastDayOfMonthSinceEpochFromDate(dt);
+    Expected<int64_t> daysSinceEpochFromDate =
+        util::lastDayOfMonthSinceEpochFromDate(dt);
     if (daysSinceEpochFromDate.hasError()) {
       VELOX_DCHECK(daysSinceEpochFromDate.error().isUserError());
       VELOX_USER_FAIL(daysSinceEpochFromDate.error().message());
@@ -413,7 +414,8 @@ struct LastDayOfMonthFunction : public InitSessionTimezone<T>,
       out_type<Date>& result,
       const arg_type<Date>& date) {
     auto dt = getDateTime(date);
-    Expected<int64_t> lastDayOfMonthSinceEpoch = util::lastDayOfMonthSinceEpochFromDate(dt);
+    Expected<int64_t> lastDayOfMonthSinceEpoch =
+        util::lastDayOfMonthSinceEpochFromDate(dt);
     if (lastDayOfMonthSinceEpoch.hasError()) {
       VELOX_DCHECK(lastDayOfMonthSinceEpoch.error().isUserError());
       VELOX_USER_FAIL(lastDayOfMonthSinceEpoch.error().message());
@@ -426,7 +428,8 @@ struct LastDayOfMonthFunction : public InitSessionTimezone<T>,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
     auto timestamp = this->toTimestamp(timestampWithTimezone);
     auto dt = getDateTime(timestamp, nullptr);
-    Expected<int64_t> lastDayOfMonthSinceEpoch = util::lastDayOfMonthSinceEpochFromDate(dt);
+    Expected<int64_t> lastDayOfMonthSinceEpoch =
+        util::lastDayOfMonthSinceEpochFromDate(dt);
     if (lastDayOfMonthSinceEpoch.hasError()) {
       VELOX_DCHECK(lastDayOfMonthSinceEpoch.error().isUserError());
       VELOX_USER_FAIL(lastDayOfMonthSinceEpoch.error().message());

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -415,13 +415,12 @@ struct MakeDateFunction {
       const int32_t year,
       const int32_t month,
       const int32_t day) {
-    int64_t daysSinceEpoch;
-    auto status =
-        util::daysSinceEpochFromDate(year, month, day, daysSinceEpoch);
-    if (!status.ok()) {
-      VELOX_DCHECK(status.isUserError());
-      VELOX_USER_FAIL(status.message());
+    Expected<int64_t> expected = util::daysSinceEpochFromDate(year, month, day);
+    if (expected.hasError()) {
+      VELOX_DCHECK(expected.error().isUserError());
+      VELOX_USER_FAIL(expected.error().message());
     }
+    int64_t daysSinceEpoch = expected.value();
     VELOX_USER_CHECK_EQ(
         daysSinceEpoch,
         (int32_t)daysSinceEpoch,
@@ -457,13 +456,13 @@ struct LastDayFunction {
     int32_t month = getMonth(dateTime);
     int32_t day = getMonth(dateTime);
     auto lastDay = util::getMaxDayOfMonth(year, month);
-    int64_t daysSinceEpoch;
-    auto status =
-        util::daysSinceEpochFromDate(year, month, lastDay, daysSinceEpoch);
-    if (!status.ok()) {
-      VELOX_DCHECK(status.isUserError());
-      VELOX_USER_FAIL(status.message());
+    Expected<int64_t> expected =
+        util::daysSinceEpochFromDate(year, month, lastDay);
+    if (expected.hasError()) {
+      VELOX_DCHECK(expected.error().isUserError());
+      VELOX_USER_FAIL(expected.error().message());
     }
+    int64_t daysSinceEpoch = expected.value();
     VELOX_USER_CHECK_EQ(
         daysSinceEpoch,
         (int32_t)daysSinceEpoch,
@@ -567,13 +566,13 @@ struct AddMonthsFunction {
     // Adjusts day to valid one.
     auto dayResult = lastDayOfMonth < day ? lastDayOfMonth : day;
 
-    int64_t daysSinceEpoch;
-    auto status = util::daysSinceEpochFromDate(
-        yearResult, monthResult, dayResult, daysSinceEpoch);
-    if (!status.ok()) {
-      VELOX_DCHECK(status.isUserError());
-      VELOX_USER_FAIL(status.message());
+    Expected<int64_t> expected =
+        util::daysSinceEpochFromDate(yearResult, monthResult, dayResult);
+    if (expected.hasError()) {
+      VELOX_DCHECK(expected.error().isUserError());
+      VELOX_USER_FAIL(expected.error().message());
     }
+    int64_t daysSinceEpoch = expected.value();
     VELOX_USER_CHECK_EQ(
         daysSinceEpoch,
         (int32_t)daysSinceEpoch,

--- a/velox/functions/sparksql/MakeTimestamp.cpp
+++ b/velox/functions/sparksql/MakeTimestamp.cpp
@@ -50,19 +50,19 @@ std::optional<Timestamp> makeTimeStampFromDecodedArgs(
   }
 
   // Year, month, day will be checked in utils::daysSinceEpochFromDate.
-  Expected<int64_t> expected = util::daysSinceEpochFromDate(
+  Expected<int64_t> daysSinceEpoch = util::daysSinceEpochFromDate(
       yearVector->valueAt<int32_t>(row),
       monthVector->valueAt<int32_t>(row),
       dayVector->valueAt<int32_t>(row));
-  if (expected.hasError()) {
-    VELOX_DCHECK(expected.error().isUserError());
+  if (daysSinceEpoch.hasError()) {
+    VELOX_DCHECK(daysSinceEpoch.error().isUserError());
     return std::nullopt;
   }
 
   // Micros has at most 8 digits (2 for seconds + 6 for microseconds),
   // thus it's safe to cast micros from int64_t to int32_t.
   auto localMicros = util::fromTime(hour, minute, 0, (int32_t)micros);
-  return util::fromDatetime(expected.value(), localMicros);
+  return util::fromDatetime(daysSinceEpoch.value(), localMicros);
 }
 
 void setTimestampOrNull(

--- a/velox/functions/sparksql/MakeTimestamp.cpp
+++ b/velox/functions/sparksql/MakeTimestamp.cpp
@@ -50,21 +50,19 @@ std::optional<Timestamp> makeTimeStampFromDecodedArgs(
   }
 
   // Year, month, day will be checked in utils::daysSinceEpochFromDate.
-  int64_t daysSinceEpoch;
-  auto status = util::daysSinceEpochFromDate(
+  Expected<int64_t> expected = util::daysSinceEpochFromDate(
       yearVector->valueAt<int32_t>(row),
       monthVector->valueAt<int32_t>(row),
-      dayVector->valueAt<int32_t>(row),
-      daysSinceEpoch);
-  if (!status.ok()) {
-    VELOX_DCHECK(status.isUserError());
+      dayVector->valueAt<int32_t>(row));
+  if (expected.hasError()) {
+    VELOX_DCHECK(expected.error().isUserError());
     return std::nullopt;
   }
 
   // Micros has at most 8 digits (2 for seconds + 6 for microseconds),
   // thus it's safe to cast micros from int64_t to int32_t.
   auto localMicros = util::fromTime(hour, minute, 0, (int32_t)micros);
-  return util::fromDatetime(daysSinceEpoch, localMicros);
+  return util::fromDatetime(expected.value(), localMicros);
 }
 
 void setTimestampOrNull(

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -616,10 +616,9 @@ daysSinceEpochFromDate(int32_t year, int32_t month, int32_t day) {
   if (!isValidDate(year, month, day)) {
     if (threadSkipErrorDetails()) {
       return folly::makeUnexpected(Status::UserError());
-    } else {
-      return folly::makeUnexpected(
-          Status::UserError("Date out of range: {}-{}-{}", year, month, day));
     }
+    return folly::makeUnexpected(
+        Status::UserError("Date out of range: {}-{}-{}", year, month, day));
   }
   while (year < 1970) {
     year += kYearInterval;
@@ -643,10 +642,9 @@ Expected<int64_t> daysSinceEpochFromWeekDate(
   if (!isValidWeekDate(weekYear, weekOfYear, dayOfWeek)) {
     if (threadSkipErrorDetails()) {
       return folly::makeUnexpected(Status::UserError());
-    } else {
-      return folly::makeUnexpected(Status::UserError(
-          "Date out of range: {}-{}-{}", weekYear, weekOfYear, dayOfWeek));
     }
+    return folly::makeUnexpected(Status::UserError(
+        "Date out of range: {}-{}-{}", weekYear, weekOfYear, dayOfWeek));
   }
 
   return daysSinceEpochFromDate(weekYear, 1, 4)
@@ -669,14 +667,9 @@ Expected<int64_t> daysSinceEpochFromWeekOfMonthDate(
       !isValidWeekOfMonthDate(year, month, weekOfMonth, dayOfWeek)) {
     if (threadSkipErrorDetails()) {
       return folly::makeUnexpected(Status::UserError());
-    } else {
-      return folly::makeUnexpected(Status::UserError(
-          "Date out of range: {}-{}-{}-{}",
-          year,
-          month,
-          weekOfMonth,
-          dayOfWeek));
     }
+    return folly::makeUnexpected(Status::UserError(
+        "Date out of range: {}-{}-{}-{}", year, month, weekOfMonth, dayOfWeek));
   }
 
   // Adjusts the year and month to ensure month is within the range 1-12,
@@ -713,10 +706,9 @@ Expected<int64_t> daysSinceEpochFromDayOfYear(int32_t year, int32_t dayOfYear) {
   if (!isValidDayOfYear(year, dayOfYear)) {
     if (threadSkipErrorDetails()) {
       return folly::makeUnexpected(Status::UserError());
-    } else {
-      return folly::makeUnexpected(
-          Status::UserError("Day of year out of range: {}", dayOfYear));
     }
+    return folly::makeUnexpected(
+        Status::UserError("Day of year out of range: {}", dayOfYear));
   }
   return daysSinceEpochFromDate(year, 1, 1)
       .then([&dayOfYear](int64_t startOfYear) {

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -295,11 +295,12 @@ bool tryParseDateString(
   // No day.
   if ((mode == ParseMode::kSparkCast || mode == ParseMode::kIso8601) &&
       pos == len) {
-    Expected<int64_t> daysSinceEpoch = daysSinceEpochFromDate(year, month, 1);
-    if (daysSinceEpoch.hasError()) {
+    Expected<int64_t> expected = daysSinceEpochFromDate(year, month, 1);
+    if (expected.hasError()) {
       return false;
     }
-    return validDate(daysSinceEpoch.value());
+    daysSinceEpoch = expected.value();
+    return validDate(daysSinceEpoch);
   }
 
   if (pos >= len) {

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -161,9 +161,8 @@ bool isValidWeekOfMonthDate(
   Expected<int64_t> expected = daysSinceEpochFromDate(year, month, 1);
   if (expected.hasError()) {
     return false;
-  } else {
-    daysSinceEpochOfFirstDayOfMonth = expected.value();
   }
+  daysSinceEpochOfFirstDayOfMonth = expected.value();
 
   // Calculates the actual number of week of month and validates if it is in the
   // valid range.
@@ -264,9 +263,8 @@ bool tryParseDateString(
     Expected<int64_t> expected = daysSinceEpochFromDate(year, 1, 1);
     if (expected.hasError()) {
       return false;
-    } else {
-      daysSinceEpoch = expected.value();
     }
+    daysSinceEpoch = expected.value();
     return validDate(daysSinceEpoch);
   }
 
@@ -300,9 +298,8 @@ bool tryParseDateString(
     Expected<int64_t> expected = daysSinceEpochFromDate(year, month, 1);
     if (expected.hasError()) {
       return false;
-    } else {
-      daysSinceEpoch = expected.value();
     }
+    daysSinceEpoch = expected.value();
     return validDate(daysSinceEpoch);
   }
 
@@ -327,9 +324,8 @@ bool tryParseDateString(
     Expected<int64_t> expected = daysSinceEpochFromDate(year, month, day);
     if (expected.hasError()) {
       return false;
-    } else {
-      daysSinceEpoch = expected.value();
     }
+    daysSinceEpoch = expected.value();
 
     if (mode == ParseMode::kPrestoCast) {
       skipSpaces(buf, len, pos);
@@ -347,9 +343,8 @@ bool tryParseDateString(
     Expected<int64_t> expected = daysSinceEpochFromDate(year, month, day);
     if (expected.hasError()) {
       return false;
-    } else {
-      daysSinceEpoch = expected.value();
     }
+    daysSinceEpoch = expected.value();
 
     if (!validDate(daysSinceEpoch)) {
       return false;
@@ -396,10 +391,9 @@ bool tryParseDateString(
   Expected<int64_t> expected = daysSinceEpochFromDate(year, month, day);
   if (expected.hasError()) {
     return false;
-  } else {
-    daysSinceEpoch = expected.value();
-    return true;
   }
+  daysSinceEpoch = expected.value();
+  return true;
 }
 
 void parseTimeSeparator(

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -157,17 +157,16 @@ bool isValidWeekOfMonthDate(
     return false;
   }
 
-  int64_t daysSinceEpochOfFirstDayOfMonth;
-  Expected<int64_t> expected = daysSinceEpochFromDate(year, month, 1);
-  if (expected.hasError()) {
+  Expected<int64_t> daysSinceEpochOfFirstDayOfMonth = daysSinceEpochFromDate(year, month, 1);
+  if (daysSinceEpochOfFirstDayOfMonth.hasError()) {
     return false;
   }
-  daysSinceEpochOfFirstDayOfMonth = expected.value();
+  daysSinceEpochOfFirstDayOfMonth = daysSinceEpochOfFirstDayOfMonth.value();
 
   // Calculates the actual number of week of month and validates if it is in the
   // valid range.
   const int32_t firstDayOfWeek =
-      extractISODayOfTheWeek(daysSinceEpochOfFirstDayOfMonth);
+      extractISODayOfTheWeek(daysSinceEpochOfFirstDayOfMonth.value());
   const int32_t firstWeekLength = 7 - firstDayOfWeek + 1;
   const int32_t monthLength =
       isLeapYear(year) ? kLeapDays[month] : kNormalDays[month];
@@ -295,12 +294,11 @@ bool tryParseDateString(
   // No day.
   if ((mode == ParseMode::kSparkCast || mode == ParseMode::kIso8601) &&
       pos == len) {
-    Expected<int64_t> expected = daysSinceEpochFromDate(year, month, 1);
-    if (expected.hasError()) {
+    Expected<int64_t> daysSinceEpoch = daysSinceEpochFromDate(year, month, 1);
+    if (daysSinceEpoch.hasError()) {
       return false;
     }
-    daysSinceEpoch = expected.value();
-    return validDate(daysSinceEpoch);
+    return validDate(daysSinceEpoch.value());
   }
 
   if (pos >= len) {

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -157,7 +157,8 @@ bool isValidWeekOfMonthDate(
     return false;
   }
 
-  Expected<int64_t> daysSinceEpochOfFirstDayOfMonth = daysSinceEpochFromDate(year, month, 1);
+  Expected<int64_t> daysSinceEpochOfFirstDayOfMonth =
+      daysSinceEpochFromDate(year, month, 1);
   if (daysSinceEpochOfFirstDayOfMonth.hasError()) {
     return false;
   }

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -158,10 +158,11 @@ bool isValidWeekOfMonthDate(
   }
 
   int64_t daysSinceEpochOfFirstDayOfMonth;
-  const Status status =
-      daysSinceEpochFromDate(year, month, 1, daysSinceEpochOfFirstDayOfMonth);
-  if (!status.ok()) {
+  Expected<int64_t> expected = daysSinceEpochFromDate(year, month, 1);
+  if (expected.hasError()) {
     return false;
+  } else {
+    daysSinceEpochOfFirstDayOfMonth = expected.value();
   }
 
   // Calculates the actual number of week of month and validates if it is in the
@@ -260,8 +261,11 @@ bool tryParseDateString(
   // No month or day.
   if ((mode == ParseMode::kSparkCast || mode == ParseMode::kIso8601) &&
       pos == len) {
-    if (!daysSinceEpochFromDate(year, 1, 1, daysSinceEpoch).ok()) {
+    Expected<int64_t> expected = daysSinceEpochFromDate(year, 1, 1);
+    if (expected.hasError()) {
       return false;
+    } else {
+      daysSinceEpoch = expected.value();
     }
     return validDate(daysSinceEpoch);
   }
@@ -293,8 +297,11 @@ bool tryParseDateString(
   // No day.
   if ((mode == ParseMode::kSparkCast || mode == ParseMode::kIso8601) &&
       pos == len) {
-    if (!daysSinceEpochFromDate(year, month, 1, daysSinceEpoch).ok()) {
+    Expected<int64_t> expected = daysSinceEpochFromDate(year, month, 1);
+    if (expected.hasError()) {
       return false;
+    } else {
+      daysSinceEpoch = expected.value();
     }
     return validDate(daysSinceEpoch);
   }
@@ -317,8 +324,11 @@ bool tryParseDateString(
   }
 
   if (mode == ParseMode::kPrestoCast || mode == ParseMode::kIso8601) {
-    if (!daysSinceEpochFromDate(year, month, day, daysSinceEpoch).ok()) {
+    Expected<int64_t> expected = daysSinceEpochFromDate(year, month, day);
+    if (expected.hasError()) {
       return false;
+    } else {
+      daysSinceEpoch = expected.value();
     }
 
     if (mode == ParseMode::kPrestoCast) {
@@ -334,8 +344,11 @@ bool tryParseDateString(
   // In non-standard cast mode, an optional trailing 'T' or space followed
   // by any optional characters are valid patterns.
   if (mode == ParseMode::kSparkCast) {
-    if (!daysSinceEpochFromDate(year, month, day, daysSinceEpoch).ok()) {
+    Expected<int64_t> expected = daysSinceEpochFromDate(year, month, day);
+    if (expected.hasError()) {
       return false;
+    } else {
+      daysSinceEpoch = expected.value();
     }
 
     if (!validDate(daysSinceEpoch)) {
@@ -380,8 +393,13 @@ bool tryParseDateString(
       return false;
     }
   }
-
-  return daysSinceEpochFromDate(year, month, day, daysSinceEpoch).ok();
+  Expected<int64_t> expected = daysSinceEpochFromDate(year, month, day);
+  if (expected.hasError()) {
+    return false;
+  } else {
+    daysSinceEpoch = expected.value();
+    return true;
+  }
 }
 
 void parseTimeSeparator(
@@ -586,26 +604,27 @@ bool isValidDayOfYear(int32_t year, int32_t dayOfYear) {
   return true;
 }
 
-Status lastDayOfMonthSinceEpochFromDate(const std::tm& dateTime, int64_t& out) {
+Expected<int64_t> lastDayOfMonthSinceEpochFromDate(const std::tm& dateTime) {
   auto year = dateTime.tm_year + 1900;
   auto month = dateTime.tm_mon + 1;
   auto day = util::getMaxDayOfMonth(year, month);
-  return util::daysSinceEpochFromDate(year, month, day, out);
+  return util::daysSinceEpochFromDate(year, month, day);
 }
 
 int32_t getMaxDayOfMonth(int32_t year, int32_t month) {
   return isLeapYear(year) ? kLeapDays[month] : kNormalDays[month];
 }
 
-Status
-daysSinceEpochFromDate(int32_t year, int32_t month, int32_t day, int64_t& out) {
+Expected<int64_t>
+daysSinceEpochFromDate(int32_t year, int32_t month, int32_t day) {
   int64_t daysSinceEpoch = 0;
 
   if (!isValidDate(year, month, day)) {
     if (threadSkipErrorDetails()) {
-      return Status::UserError();
+      return folly::makeUnexpected(Status::UserError());
     } else {
-      return Status::UserError("Date out of range: {}-{}-{}", year, month, day);
+      return folly::makeUnexpected(
+          Status::UserError("Date out of range: {}-{}-{}", year, month, day));
     }
   }
   while (year < 1970) {
@@ -620,29 +639,30 @@ daysSinceEpochFromDate(int32_t year, int32_t month, int32_t day, int64_t& out) {
   daysSinceEpoch += isLeapYear(year) ? kCumulativeLeapDays[month - 1]
                                      : kCumulativeDays[month - 1];
   daysSinceEpoch += day - 1;
-  out = daysSinceEpoch;
-  return Status::OK();
+  return daysSinceEpoch;
 }
 
-Status daysSinceEpochFromWeekDate(
+Expected<int64_t> daysSinceEpochFromWeekDate(
     int32_t weekYear,
     int32_t weekOfYear,
-    int32_t dayOfWeek,
-    int64_t& out) {
+    int32_t dayOfWeek) {
   if (!isValidWeekDate(weekYear, weekOfYear, dayOfWeek)) {
-    return Status::UserError(
-        "Date out of range: {}-{}-{}", weekYear, weekOfYear, dayOfWeek);
+    if (threadSkipErrorDetails()) {
+      return folly::makeUnexpected(Status::UserError());
+    } else {
+      return folly::makeUnexpected(Status::UserError(
+          "Date out of range: {}-{}-{}", weekYear, weekOfYear, dayOfWeek));
+    }
   }
 
-  int64_t daysSinceEpochOfJanFourth;
-  VELOX_RETURN_NOT_OK(
-      daysSinceEpochFromDate(weekYear, 1, 4, daysSinceEpochOfJanFourth));
-  int32_t firstDayOfWeekYear =
-      extractISODayOfTheWeek(daysSinceEpochOfJanFourth);
+  return daysSinceEpochFromDate(weekYear, 1, 4)
+      .then([&weekOfYear, &dayOfWeek](int64_t daysSinceEpochOfJanFourth) {
+        int32_t firstDayOfWeekYear =
+            extractISODayOfTheWeek(daysSinceEpochOfJanFourth);
 
-  out = daysSinceEpochOfJanFourth - (firstDayOfWeekYear - 1) +
-      7 * (weekOfYear - 1) + dayOfWeek - 1;
-  return Status::OK();
+        return daysSinceEpochOfJanFourth - (firstDayOfWeekYear - 1) +
+            7 * (weekOfYear - 1) + dayOfWeek - 1;
+      });
 }
 
 Expected<int64_t> daysSinceEpochFromWeekOfMonthDate(
@@ -677,35 +697,37 @@ Expected<int64_t> daysSinceEpochFromWeekOfMonthDate(
   }
   year += additionYears;
 
-  int64_t daysSinceEpochOfFirstDayOfMonth;
-  const Status status =
-      daysSinceEpochFromDate(year, month, 1, daysSinceEpochOfFirstDayOfMonth);
-  if (!status.ok()) {
-    return folly::makeUnexpected(status);
-  }
-  const int32_t firstDayOfWeek =
-      extractISODayOfTheWeek(daysSinceEpochOfFirstDayOfMonth);
-  int32_t days;
-  if (dayOfWeek < 1) {
-    days = 7 - abs(dayOfWeek - 1) % 7;
-  } else if (dayOfWeek > 7) {
-    days = (dayOfWeek - 1) % 7;
-  } else {
-    days = dayOfWeek % 7;
-  }
-  return daysSinceEpochOfFirstDayOfMonth - (firstDayOfWeek - 1) +
-      7 * (weekOfMonth - 1) + days - 1;
+  return daysSinceEpochFromDate(year, month, 1)
+      .then(
+          [&dayOfWeek, &weekOfMonth](int64_t daysSinceEpochOfFirstDayOfMonth) {
+            const int32_t firstDayOfWeek =
+                extractISODayOfTheWeek(daysSinceEpochOfFirstDayOfMonth);
+            int32_t days;
+            if (dayOfWeek < 1) {
+              days = 7 - abs(dayOfWeek - 1) % 7;
+            } else if (dayOfWeek > 7) {
+              days = (dayOfWeek - 1) % 7;
+            } else {
+              days = dayOfWeek % 7;
+            }
+            return daysSinceEpochOfFirstDayOfMonth - (firstDayOfWeek - 1) +
+                7 * (weekOfMonth - 1) + days - 1;
+          });
 }
 
-Status
-daysSinceEpochFromDayOfYear(int32_t year, int32_t dayOfYear, int64_t& out) {
+Expected<int64_t> daysSinceEpochFromDayOfYear(int32_t year, int32_t dayOfYear) {
   if (!isValidDayOfYear(year, dayOfYear)) {
-    return Status::UserError("Day of year out of range: {}", dayOfYear);
+    if (threadSkipErrorDetails()) {
+      return folly::makeUnexpected(Status::UserError());
+    } else {
+      return folly::makeUnexpected(
+          Status::UserError("Day of year out of range: {}", dayOfYear));
+    }
   }
-  int64_t startOfYear;
-  VELOX_RETURN_NOT_OK(daysSinceEpochFromDate(year, 1, 1, startOfYear));
-  out = startOfYear + (dayOfYear - 1);
-  return Status::OK();
+  return daysSinceEpochFromDate(year, 1, 1)
+      .then([&dayOfYear](int64_t startOfYear) {
+        return startOfYear + (dayOfYear - 1);
+      });
 }
 
 Expected<int32_t> fromDateString(const char* str, size_t len, ParseMode mode) {

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -94,22 +94,21 @@ int32_t getMaxDayOfMonth(int32_t year, int32_t month);
 
 /// Computes the last day of month since unix epoch (1970-01-01).
 /// Returns UserError status if the date is invalid.
-Status lastDayOfMonthSinceEpochFromDate(const std::tm& dateTime, int64_t& out);
+Expected<int64_t> lastDayOfMonthSinceEpochFromDate(const std::tm& dateTime);
 
 /// Date conversions.
 
 /// Computes the (signed) number of days since unix epoch (1970-01-01).
 /// Returns UserError status if the date is invalid.
-Status
-daysSinceEpochFromDate(int32_t year, int32_t month, int32_t day, int64_t& out);
+Expected<int64_t>
+daysSinceEpochFromDate(int32_t year, int32_t month, int32_t day);
 
 /// Computes the (signed) number of days since unix epoch (1970-01-01).
 /// Returns UserError status if the date is invalid.
-Status daysSinceEpochFromWeekDate(
+Expected<int64_t> daysSinceEpochFromWeekDate(
     int32_t weekYear,
     int32_t weekOfYear,
-    int32_t dayOfWeek,
-    int64_t& out);
+    int32_t dayOfWeek);
 
 /// Computes the signed number of days since the Unix epoch (1970-01-01). To
 /// align with Spark's SimpleDateFormat behavior, this function offers two
@@ -145,8 +144,7 @@ Expected<int64_t> daysSinceEpochFromWeekOfMonthDate(
 
 /// Computes the (signed) number of days since unix epoch (1970-01-01).
 /// Returns UserError status if the date is invalid.
-Status
-daysSinceEpochFromDayOfYear(int32_t year, int32_t dayOfYear, int64_t& out);
+Expected<int64_t> daysSinceEpochFromDayOfYear(int32_t year, int32_t dayOfYear);
 
 /// Cast string to date. Supported date formats vary, depending on input
 /// ParseMode. Refer to ParseMode enum for further info.

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -50,13 +50,13 @@ std::pair<Timestamp, const tz::TimeZone*> parseTimestampWithTimezone(
 }
 
 TEST(DateTimeUtilTest, fromDate) {
-  auto testDaysSinceEpochFromDate = [](int32_t year,
-                                       int32_t month,
-                                       int32_t day) {
-    Expected<int64_t> daysSinceEpoch = util::daysSinceEpochFromDate(year, month, day);
-    EXPECT_FALSE(daysSinceEpoch.hasError());
-    return daysSinceEpoch.value();
-  };
+  auto testDaysSinceEpochFromDate =
+      [](int32_t year, int32_t month, int32_t day) {
+        Expected<int64_t> daysSinceEpoch =
+            util::daysSinceEpochFromDate(year, month, day);
+        EXPECT_FALSE(daysSinceEpoch.hasError());
+        return daysSinceEpoch.value();
+      };
   EXPECT_EQ(0, testDaysSinceEpochFromDate(1970, 1, 1));
   EXPECT_EQ(1, testDaysSinceEpochFromDate(1970, 1, 2));
   EXPECT_EQ(365, testDaysSinceEpochFromDate(1971, 1, 1));

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -53,9 +53,9 @@ TEST(DateTimeUtilTest, fromDate) {
   auto testDaysSinceEpochFromDate = [](int32_t year,
                                        int32_t month,
                                        int32_t day) {
-    Expected<int64_t> expected = util::daysSinceEpochFromDate(year, month, day);
-    EXPECT_FALSE(expected.hasError());
-    return expected.value();
+    Expected<int64_t> daysSinceEpoch = util::daysSinceEpochFromDate(year, month, day);
+    EXPECT_FALSE(daysSinceEpoch.hasError());
+    return daysSinceEpoch.value();
   };
   EXPECT_EQ(0, testDaysSinceEpochFromDate(1970, 1, 1));
   EXPECT_EQ(1, testDaysSinceEpochFromDate(1970, 1, 2));

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -50,14 +50,13 @@ std::pair<Timestamp, const tz::TimeZone*> parseTimestampWithTimezone(
 }
 
 TEST(DateTimeUtilTest, fromDate) {
-  auto testDaysSinceEpochFromDate =
-      [](int32_t year, int32_t month, int32_t day) {
-        int64_t daysSinceEpoch;
-        auto status =
-            util::daysSinceEpochFromDate(year, month, day, daysSinceEpoch);
-        EXPECT_TRUE(status.ok());
-        return daysSinceEpoch;
-      };
+  auto testDaysSinceEpochFromDate = [](int32_t year,
+                                       int32_t month,
+                                       int32_t day) {
+    Expected<int64_t> expected = util::daysSinceEpochFromDate(year, month, day);
+    EXPECT_FALSE(expected.hasError());
+    return expected.value();
+  };
   EXPECT_EQ(0, testDaysSinceEpochFromDate(1970, 1, 1));
   EXPECT_EQ(1, testDaysSinceEpochFromDate(1970, 1, 2));
   EXPECT_EQ(365, testDaysSinceEpochFromDate(1971, 1, 1));
@@ -81,11 +80,11 @@ TEST(DateTimeUtilTest, fromDate) {
 TEST(DateTimeUtilTest, fromDateInvalid) {
   auto testDaysSinceEpochFromDateInvalid =
       [](int32_t year, int32_t month, int32_t day, const std::string& error) {
-        int64_t daysSinceEpoch;
-        auto status =
-            util::daysSinceEpochFromDate(year, month, day, daysSinceEpoch);
-        EXPECT_TRUE(status.isUserError());
-        EXPECT_EQ(status.message(), error);
+        Expected<int64_t> expected =
+            util::daysSinceEpochFromDate(year, month, day);
+        EXPECT_TRUE(expected.hasError());
+        EXPECT_TRUE(expected.error().isUserError());
+        EXPECT_EQ(expected.error().message(), error);
       };
   EXPECT_NO_THROW(testDaysSinceEpochFromDateInvalid(
       1970, 1, -1, "Date out of range: 1970-1--1"));


### PR DESCRIPTION
We have recently introduced velox::Expected (https://github.com/facebookincubator/velox/pull/9858) to use in non-void no-throw APIs. It's more proper to return that.