### PR TITLE
Fix tsan failure in duplicate row hash join test

### DIFF
--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -1349,7 +1349,7 @@ class RowContainer {
   int32_t nextOffset_ = 0;
   // Indicates if this row container has rows with duplicate keys. This only
   // applies if 'nextOffset_' is set.
-  bool hasDuplicateRows_{false};
+  tsan_atomic<bool> hasDuplicateRows_{false};
   // Bit position of null bit  in the row. 0 if no null flag. Order is keys,
   // accumulators, dependent.
   std::vector<int32_t> nullOffsets_;


### PR DESCRIPTION
Summary:
For the parallel hash join build, there are multiple thread build different partitions
from the same table, and they might try to set the duplicate row flags concurrently but all
from false to true so it is not real data race. Change the flag type from bool to tsan_atomic to avoid
tsan test flakiness

Differential Revision: D62678580
