### PR TITLE
Check task pause first when driver leave suspended state

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2703,18 +2703,19 @@ StopReason Task::leaveSuspended(ThreadState& state) {
           ++numThreads_;
         }
       });
-      if (state.isTerminated) {
-        return StopReason::kAlreadyTerminated;
-      }
-      if (terminateRequested_) {
-        state.isTerminated = true;
-        return StopReason::kTerminate;
-      }
       if (state.numSuspensions > 1 || !pauseRequested_) {
+        if (state.isTerminated) {
+          return StopReason::kAlreadyTerminated;
+        }
+        if (terminateRequested_) {
+          state.isTerminated = true;
+          return StopReason::kTerminate;
+        }
         // If we have more than one suspension requests on this driver thread or
         // the task has been resumed, then we return here.
         return StopReason::kNone;
       }
+
       VELOX_CHECK_GT(state.numSuspensions, 0);
       VELOX_CHECK_GE(numThreads_, 0);
       leaveGuard.dismiss();

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -1120,7 +1120,7 @@ class Task : public std::enable_shared_from_this<Task> {
   // queued split groups.
   std::queue<uint32_t> queuedSplitGroups_;
 
-  TaskState state_ = TaskState::kRunning;
+  TaskState state_{TaskState::kRunning};
 
   // Stores splits state structure for each plan node. At construction populated
   // with all leaf plan nodes that require splits. Afterwards accessed with


### PR DESCRIPTION
Summary:
When driver thread leave suspension state, it first check if the task has been terminated or not.
If it is terminated, then it returns without waiting for the task has been resumed or not. This assumes
that the driver thread will only leave suspend state if there is no spilling on the associated query
task. This assumption might always be true with global arbitration optimization which decouple the
memory arbitration request and memory arbitration operation. So we need to let driver thread wait until
the task has been resumed. Otherwise, the driver thread might continue execution after leave
suspended state until it checks the task state. This might cause concurrent updates to the operator
state.

The sequence to trigger this with global arbitration optimization:
T1. driver call try reserve memory (put the driver thread in reclaimable state) which trigger memory arbitration
T2. driver memory arbitration succeeds and about to leave
T3. the background global memory arbitration kicks off and try to reclaim from the driver as it is in reclaimable
state. The memory arbitration will pause the task execution.
T4. the task is terminated by coordinator for some reason
T5. driver thread tries to leave suspended state and realize that the task has been terminated so it just leaves the
suspended state.
T6. driver thread continue execution after memory reservation as it doesn't notice the task has been terminated.
Given that, both the driver execution and spill could operate on the same thread in parallel.

This PR changes driver thread to wait for the task resume signal first when leave from suspended state in T5.
Unit test is added and verified with global arbitration optimization shadow

Differential Revision: D62727855
