### PR TITLE
Fix blockedOperatorId_ when the driver is blocked for arbitration case

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -591,7 +591,7 @@ StopReason Driver::runInternal(
           // for the current running arbitration, it is more efficient
           // system-wide to let driver go off thread for the other queries which
           // have free memory capacity to run during the time.
-          blockedOperatorId_ = curOperatorId_ + 1;
+          blockedOperatorId_ = curOperatorId_;
           VELOX_CHECK(future.valid());
           blockingReason_ = BlockingReason::kWaitForArbitration;
           blockingState = std::make_shared<BlockingState>(


### PR DESCRIPTION
When the driver is blocked becuase it is under arbitration, the blockedOperatorId_ was set to be the next operator's id. However the blocked operator is the current operator and the blockedOperatorId_ should be set as the current operator's id. This commit fixes this issue.