### PR TITLE
Add unique pointer conversion utility to avoid memory leak

### DIFF
--- a/velox/common/base/Pointers.h
+++ b/velox/common/base/Pointers.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox {
+
+/// Used to dynamically cast a unique pointer from 'SourceType' to
+/// 'DestinationType'. The raw object is moved from 'srcPtr' to 'dstPtr' on
+/// success. The function throws if the cast fails, and the raw object is also
+/// freed.
+template <typename SourceType, typename DestinationType>
+inline void castUniquePointer(
+    std::unique_ptr<SourceType>&& srcPtr,
+    std::unique_ptr<DestinationType>& dstPtr) {
+  auto* rawSrcPtr = srcPtr.release();
+  VELOX_CHECK_NOT_NULL(rawSrcPtr);
+  try {
+    auto* rawDstPtr = dynamic_cast<DestinationType*>(rawSrcPtr);
+    VELOX_CHECK_NOT_NULL(rawDstPtr);
+    dstPtr.reset(rawDstPtr);
+  } catch (const std::exception& e) {
+    srcPtr.reset(rawSrcPtr);
+    throw;
+  }
+}
+} // namespace facebook::velox

--- a/velox/common/base/tests/PointersTest.cpp
+++ b/velox/common/base/tests/PointersTest.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/Pointers.h"
+
+#include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
+
+using namespace facebook::velox;
+namespace {
+TEST(PointersTest, uniquePtrConvert) {
+  class Foo1 {
+   public:
+    explicit Foo1(int32_t a) : a_(a) {}
+    virtual ~Foo1() = default;
+
+    int32_t a() const {
+      return a_;
+    }
+
+   protected:
+    int32_t a_;
+  };
+
+  class Foo2 : public Foo1 {
+   public:
+    Foo2(int32_t a, int32_t b) : Foo1(a), b_(b) {}
+
+    int32_t b() const {
+      return b_;
+    }
+
+   private:
+    int32_t b_;
+  };
+
+  Foo2* rawFoo2 = new Foo2(10, 20);
+  ASSERT_EQ(rawFoo2->a(), 10);
+  ASSERT_EQ(rawFoo2->b(), 20);
+  std::unique_ptr<Foo1> foo1(rawFoo2);
+  std::unique_ptr<Foo2> foo2;
+  castUniquePointer(std::move(foo1), foo2);
+  ASSERT_TRUE(foo2 != nullptr);
+  ASSERT_EQ(foo2->a(), 10);
+  ASSERT_EQ(foo2->b(), 20);
+
+  class Foo3 {
+   public:
+    explicit Foo3(int32_t c) : c_(c) {}
+
+   private:
+    int32_t c_;
+  };
+  std::unique_ptr<Foo3> foo3;
+
+  ASSERT_ANY_THROW(castUniquePointer(std::move(foo2), foo3));
+  ASSERT_TRUE(foo3 == nullptr);
+}
+} // namespace

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -19,6 +19,7 @@
 #include <folly/ScopeGuard.h>
 
 #include "velox/common/base/Counters.h"
+#include "velox/common/base/Pointers.h"
 #include "velox/common/base/StatsReporter.h"
 #include "velox/common/memory/MemoryArbitrator.h"
 #include "velox/common/testutil/TestValue.h"
@@ -90,18 +91,7 @@ Writer::Writer(
         context.stripeSizeFlushThreshold(),
         context.dictionarySizeFlushThreshold());
   } else {
-    auto* flushPolicy = options.flushPolicyFactory().release();
-    VELOX_CHECK_NOT_NULL(flushPolicy);
-    // TODO: consider to add a utility to handle similar smart pointer
-    // conversion use cases.
-    try {
-      auto* dwrfFlushPolicy = dynamic_cast<DWRFFlushPolicy*>(flushPolicy);
-      VELOX_CHECK_NOT_NULL(dwrfFlushPolicy);
-      flushPolicy_.reset(dwrfFlushPolicy);
-    } catch (const std::exception& e) {
-      delete flushPolicy;
-      throw;
-    }
+    castUniquePointer(options.flushPolicyFactory(), flushPolicy_);
   }
 
   if (options.layoutPlannerFactory != nullptr) {

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -18,6 +18,7 @@
 #include <arrow/c/bridge.h>
 #include <arrow/io/interfaces.h>
 #include <arrow/table.h>
+#include "velox/common/base/Pointers.h"
 #include "velox/common/config/Config.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/core/QueryConfig.h"
@@ -233,18 +234,7 @@ Writer::Writer(
   validateSchemaRecursive(schema_);
 
   if (options.flushPolicyFactory) {
-    auto* flushPolicy = options.flushPolicyFactory().release();
-    VELOX_CHECK_NOT_NULL(flushPolicy);
-    // TODO: consider to add a utility to handle similar smart pointer
-    // conversion use cases.
-    try {
-      auto* parquetFlushPolicy = dynamic_cast<DefaultFlushPolicy*>(flushPolicy);
-      VELOX_CHECK_NOT_NULL(parquetFlushPolicy);
-      flushPolicy_.reset(parquetFlushPolicy);
-    } catch (const std::exception& e) {
-      delete flushPolicy;
-      throw;
-    }
+    castUniquePointer(options.flushPolicyFactory(), flushPolicy_);
   } else {
     flushPolicy_ = std::make_unique<DefaultFlushPolicy>();
   }


### PR DESCRIPTION
Summary: Add utility to cast utility without memory leaks

Differential Revision: D62729896
