### PR TITLE
Parquet LazyVector support

### DIFF
--- a/velox/common/base/RawVector.cpp
+++ b/velox/common/base/RawVector.cpp
@@ -30,13 +30,14 @@ bool initializeIota() {
 }
 } // namespace
 
-const int32_t* iota(int32_t size, raw_vector<int32_t>& storage) {
-  if (iotaData.size() < size) {
+const int32_t*
+iota(int32_t size, raw_vector<int32_t>& storage, int32_t offset) {
+  if (iotaData.size() < offset + size) {
     storage.resize(size);
-    std::iota(&storage[0], &storage[storage.size()], 0);
+    std::iota(storage.begin(), storage.end(), offset);
     return storage.data();
   }
-  return iotaData.data();
+  return iotaData.data() + offset;
 }
 
 static bool FB_ANONYMOUS_VARIABLE(g_iotaConstants) = initializeIota();

--- a/velox/common/base/RawVector.h
+++ b/velox/common/base/RawVector.h
@@ -201,6 +201,7 @@ class raw_vector {
 // SIMD width. Typically returns preallocated memory but if this is
 // not large enough,resizes and initializes 'storage' to the requested
 // size and returns storage.data().
-const int32_t* iota(int32_t size, raw_vector<int32_t>& storage);
+const int32_t*
+iota(int32_t size, raw_vector<int32_t>& storage, int32_t offset = 0);
 
 } // namespace facebook::velox

--- a/velox/dwio/common/DecoderUtil.h
+++ b/velox/dwio/common/DecoderUtil.h
@@ -322,10 +322,9 @@ void fixedWidthScan(
                 }
                 if (!hasFilter) {
                   if (hasHook) {
-                    hook.addValues(
-                        scatterRows + rowIndex,
-                        reinterpret_cast<T*>(&values),
-                        width);
+                    T values2[values.size];
+                    values.store_unaligned(values2);
+                    hook.addValues(scatterRows + rowIndex, values2, width);
                   } else {
                     if (scatter) {
                       scatterDense<T>(

--- a/velox/dwio/common/DirectDecoder.h
+++ b/velox/dwio/common/DirectDecoder.h
@@ -194,6 +194,11 @@ class DirectDecoder : public IntDecoder<isSigned> {
           return;
         }
       }
+      if (hasHook && visitor.numValuesBias() > 0) {
+        for (auto& row : *outerVector) {
+          row += visitor.numValuesBias();
+        }
+      }
       if (super::useVInts_) {
         if (Visitor::dense) {
           super::bulkRead(numNonNull, data);
@@ -244,7 +249,10 @@ class DirectDecoder : public IntDecoder<isSigned> {
                 rowsAsRange,
                 0,
                 rowsAsRange.size(),
-                hasHook ? velox::iota(numRows, visitor.innerNonNullRows())
+                hasHook ? velox::iota(
+                              numRows,
+                              visitor.innerNonNullRows(),
+                              visitor.numValuesBias())
                         : nullptr,
                 visitor.rawValues(numRows),
                 hasFilter ? visitor.outputRows(numRows) : nullptr,
@@ -254,7 +262,10 @@ class DirectDecoder : public IntDecoder<isSigned> {
       } else {
         dwio::common::fixedWidthScan<T, filterOnly, false>(
             rowsAsRange,
-            hasHook ? velox::iota(numRows, visitor.innerNonNullRows())
+            hasHook ? velox::iota(
+                          numRows,
+                          visitor.innerNonNullRows(),
+                          visitor.numValuesBias())
                     : nullptr,
             visitor.rawValues(numRows),
             hasFilter ? visitor.outputRows(numRows) : nullptr,

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.h
@@ -120,7 +120,8 @@ class E2EFilterTestBase : public testing::Test {
 
   static bool typeKindSupportsValueHook(TypeKind kind) {
     return kind != TypeKind::TIMESTAMP && kind != TypeKind::ARRAY &&
-        kind != TypeKind::ROW && kind != TypeKind::MAP;
+        kind != TypeKind::ROW && kind != TypeKind::MAP &&
+        kind != TypeKind::HUGEINT;
   }
 
   std::vector<RowVectorPtr> makeDataset(
@@ -257,7 +258,7 @@ class E2EFilterTestBase : public testing::Test {
     for (int32_t i = 0; i < 5 && i < batch->size(); ++i) {
       rows.push_back(i);
     }
-    for (int32_t i = 5; i < 5 && i < batch->size(); i += 2) {
+    for (int32_t i = 5; i < batch->size(); i += 2) {
       rows.push_back(i);
     }
     auto result = std::static_pointer_cast<FlatVector<T>>(

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
@@ -478,7 +478,7 @@ void SelectiveStringDirectColumnReader::read(
       lengths_->asMutable<int32_t>(), numRows - numNulls);
   rawLengths_ = lengths_->as<uint32_t>();
   lengthIndex_ = 0;
-  dwio::common::StringColumnReadWithVisitorHelper<true>(
+  dwio::common::StringColumnReadWithVisitorHelper<true, false>(
       *this, rows)([&](auto visitor) { readWithVisitor(rows, visitor); });
   readOffset_ += numRows;
 }

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -856,6 +856,7 @@ class ParquetRowReader::Impl {
         *options_.scanSpec());
     columnReader_->setFillMutatedOutputRows(
         options_.rowNumberColumnInfo().has_value());
+    columnReader_->setIsTopLevel();
 
     filterRowGroups();
     if (!rowGroupIds_.empty()) {

--- a/velox/dwio/parquet/reader/RleBpDataDecoder.h
+++ b/velox/dwio/parquet/reader/RleBpDataDecoder.h
@@ -114,6 +114,11 @@ class RleBpDataDecoder : public facebook::velox::parquet::RleBpDecoder {
           visitor.setAllNull(hasFilter ? 0 : numRows);
           return;
         }
+        if (hasHook && visitor.numValuesBias() > 0) {
+          for (auto& row : *outerVector) {
+            row += visitor.numValuesBias();
+          }
+        }
         bulkScan<hasFilter, hasHook, true>(
             folly::Range<const int32_t*>(rows, outerVector->size()),
             outerVector->data(),
@@ -137,6 +142,11 @@ class RleBpDataDecoder : public facebook::velox::parquet::RleBpDecoder {
           skip<false>(tailSkip, 0, nullptr);
           visitor.setAllNull(hasFilter ? 0 : numRows);
           return;
+        }
+        if (hasHook && visitor.numValuesBias() > 0) {
+          for (auto& row : *outerVector) {
+            row += visitor.numValuesBias();
+          }
         }
         bulkScan<hasFilter, hasHook, true>(
             *innerVector, outerVector->data(), visitor);

--- a/velox/dwio/parquet/reader/StringColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StringColumnReader.cpp
@@ -36,7 +36,7 @@ void StringColumnReader::read(
     const RowSet& rows,
     const uint64_t* incomingNulls) {
   prepareRead<folly::StringPiece>(offset, rows, incomingNulls);
-  dwio::common::StringColumnReadWithVisitorHelper<true>(
+  dwio::common::StringColumnReadWithVisitorHelper<true, false>(
       *this, rows)([&](auto visitor) {
     formatData_->as<ParquetData>().readWithVisitor(visitor);
   });

--- a/velox/vector/LazyVector.cpp
+++ b/velox/vector/LazyVector.cpp
@@ -69,7 +69,7 @@ void VectorLoader::load(
       return;
     }
   }
-  std::vector<vector_size_t> positions(rows.countSelected());
+  raw_vector<vector_size_t> positions(rows.countSelected());
   simd::indicesOfSetBits(
       rows.allBits(), rows.begin(), rows.end(), positions.data());
   load(positions, hook, resultSize, result);


### PR DESCRIPTION
Summary:
Parquet reader was not generating `LazyVector` at all.  Fix this and
address the bugs along the way:

1. Fix the `rowIndex` passed to hook by considering `numValuesBias_`.
2. Add the missing `setNumValues` call in Parquet `StringDecoder`.
3. Fix the Parquet string dictionary column visitor call and reuse the same code
   in DWRF string dictionary column reader.
4. Fix write over boundary in `VectorLoader::load`.

Fix https://github.com/facebookincubator/velox/issues/9563

Differential Revision: D62724551
