### PR TITLE
Cast timestamp to json

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -718,7 +718,7 @@ void CastExpr::applyPeeled(
 
     auto applyCustomCast = [&]() {
       if (castToOperator) {
-        castToOperator->castTo(input, context, rows, toType, result);
+        castToOperator->castTo(input, context, rows, toType, result, hooks_);
       } else {
         castFromOperator->castFrom(input, context, rows, toType, result);
       }

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -52,6 +52,16 @@ class CastOperator {
       const TypePtr& resultType,
       VectorPtr& result) const = 0;
 
+  virtual void castTo(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      VectorPtr& result,
+      const std::shared_ptr<CastHooks>& /* hooks */) const {
+    castTo(input, context, rows, resultType, result);
+  }
+
   /// Casts a vector of the custom type to another type. This function should
   /// not throw when processing input rows, but report errors via
   /// context.setError().


### PR DESCRIPTION
Cast timestamp as json had a few differences as compared to Presto. (e.g. cast(timestamp '1970-01-01 00:00:00.123' as json) would give 1970-01-01T08:00:00.123000000 vs "1970-01-01 00:00:00.123").

Fixed:
- precision/formatting
- difference in hour (08 vs 00)
- missing quotation marks (in also cast date to json)
