### PR TITLE
Allow Custom Types to provide custom implementations of compare and hash functions.

### DIFF
--- a/velox/docs/develop/types.rst
+++ b/velox/docs/develop/types.rst
@@ -137,6 +137,14 @@ the existing physical types. For example, Presto Types described below are imple
 by extending the physical types.
 An OPAQUE type must be used when there is no physical type available to back the logical type.
 
+When extending an existing physical type, if different compare and/or hash semantics are
+needed instead of those provided by the underlying native C++ type, this can be achieved by
+doing the following:
+* Pass `true` for the `providesCustomComparison` argument in the custom type's base class's constructor.
+* Override the `compare` and `hash` functions inherited from the `TypeBase` class (you must implement both).
+Note that this is currently only supported for custom types that extend physical types that
+are primitive and fixed width.
+
 Complex Types
 ~~~~~~~~~~~~~
 Velox supports the ARRAY, MAP, and ROW complex types.
@@ -184,12 +192,12 @@ IPPREFIX networks.
 
 Spark Types
 ~~~~~~~~~~~~
-The `data types <https://spark.apache.org/docs/latest/sql-ref-datatypes.html>`_ in Spark have some semantic differences compared to those in 
-Presto. These differences require us to implement the same functions 
-separately for each system in Velox, such as min, max and collect_set. The 
+The `data types <https://spark.apache.org/docs/latest/sql-ref-datatypes.html>`_ in Spark have some semantic differences compared to those in
+Presto. These differences require us to implement the same functions
+separately for each system in Velox, such as min, max and collect_set. The
 key differences are listed below.
 
-* Spark operates on timestamps with "microsecond" precision while Presto with 
+* Spark operates on timestamps with "microsecond" precision while Presto with
   "millisecond" precision.
   Example::
 
@@ -210,7 +218,7 @@ key differences are listed below.
       FROM (
           VALUES
               (ARRAY[1, 2]),
-              (ARRAY[1, null])  
+              (ARRAY[1, null])
       ) AS t(a);
       -- ARRAY[1, null]
 

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -1106,7 +1106,9 @@ class RowContainer {
 
     using T = typename KindToFlatVector<Kind>::HashRowType;
     return SimpleVector<T>::comparePrimitiveAsc(
-               decoded.valueAt<T>(index), valueAt<T>(row, offset)) == 0;
+               decoded.base()->type().get(),
+               decoded.valueAt<T>(index),
+               valueAt<T>(row, offset)) == 0;
   }
 
   template <TypeKind Kind>
@@ -1137,7 +1139,8 @@ class RowContainer {
     }
     auto left = valueAt<T>(row, column.offset());
     auto right = decoded.valueAt<T>(index);
-    auto result = SimpleVector<T>::comparePrimitiveAsc(left, right);
+    auto result = SimpleVector<T>::comparePrimitiveAsc(
+        decoded.base()->type().get(), left, right);
     return flags.ascending ? result : result * -1;
   }
 
@@ -1178,7 +1181,8 @@ class RowContainer {
 
     auto leftValue = valueAt<T>(left, leftOffset);
     auto rightValue = valueAt<T>(right, rightOffset);
-    auto result = SimpleVector<T>::comparePrimitiveAsc(leftValue, rightValue);
+    auto result =
+        SimpleVector<T>::comparePrimitiveAsc(type, leftValue, rightValue);
     return flags.ascending ? result : result * -1;
   }
 

--- a/velox/exec/VectorHasher.cpp
+++ b/velox/exec/VectorHasher.cpp
@@ -62,10 +62,17 @@ uint64_t hashOne(DecodedVector& decoded, vector_size_t index) {
   }
   // Inlined for scalars.
   using T = typename KindToFlatVector<Kind>::HashRowType;
+  T value = decoded.valueAt<T>(index);
+
+  if (decoded.base()->type()->providesCustomComparison()) {
+    return static_cast<const TypeBase<Kind>*>(decoded.base()->type().get())
+        ->hash(&value);
+  }
+
   if constexpr (std::is_floating_point_v<T>) {
-    return util::floating_point::NaNAwareHash<T>()(decoded.valueAt<T>(index));
+    return util::floating_point::NaNAwareHash<T>()(value);
   } else {
-    return folly::hasher<T>()(decoded.valueAt<T>(index));
+    return folly::hasher<T>()(value);
   }
 }
 } // namespace

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -136,6 +136,7 @@ target_link_libraries(
   velox_serialization
   velox_test_util
   velox_type
+  velox_type_test_lib
   velox_vector
   velox_vector_fuzzer
   velox_writer_fuzzer

--- a/velox/functions/prestosql/tests/ArrayMaxTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayMaxTest.cpp
@@ -165,7 +165,7 @@ TEST_F(ArrayMaxTest, docs) {
 template <typename Type>
 class ArrayMaxIntegralTest : public FunctionBaseTest {
  public:
-  using T = typename Type::NativeType::NativeType;
+  using T = typename Type::NativeType;
 
   void testArrayMax(const VectorPtr& input, const VectorPtr& expected) {
     auto result =
@@ -230,7 +230,7 @@ class ArrayMaxIntegralTest : public FunctionBaseTest {
 template <typename Type>
 class ArrayMaxFloatingPointTest : public FunctionBaseTest {
  public:
-  using T = typename Type::NativeType::NativeType;
+  using T = typename Type::NativeType;
 
   void testArrayMax(VectorPtr input, VectorPtr expected) {
     auto result =

--- a/velox/functions/prestosql/tests/ComparisonsTest.cpp
+++ b/velox/functions/prestosql/tests/ComparisonsTest.cpp
@@ -778,7 +778,7 @@ typedef ::testing::Types<
 template <typename ComparisonTypeOp>
 class SimdComparisonsTest : public functions::test::FunctionBaseTest {
  public:
-  using T = typename ComparisonTypeOp::type::NativeType::NativeType;
+  using T = typename ComparisonTypeOp::type::NativeType;
   using ComparisonOp = typename ComparisonTypeOp::fn;
   const std::string sqlFn = ComparisonTypeOp().sqlFunction;
 

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
@@ -22,6 +22,31 @@
 
 namespace facebook::velox {
 
+using TimeZoneKey = int16_t;
+
+constexpr int32_t kTimezoneMask = 0xFFF;
+constexpr int32_t kMillisShift = 12;
+
+inline int64_t unpackMillisUtc(int64_t dateTimeWithTimeZone) {
+  return dateTimeWithTimeZone >> kMillisShift;
+}
+
+inline TimeZoneKey unpackZoneKeyId(int64_t dateTimeWithTimeZone) {
+  return dateTimeWithTimeZone & kTimezoneMask;
+}
+
+inline int64_t pack(int64_t millisUtc, int16_t timeZoneKey) {
+  return (millisUtc << kMillisShift) | (timeZoneKey & kTimezoneMask);
+}
+
+inline int64_t pack(const Timestamp& timestamp, int16_t timeZoneKey) {
+  return pack(timestamp.toMillis(), timeZoneKey);
+}
+
+inline Timestamp unpackTimestampUtc(int64_t dateTimeWithTimeZone) {
+  return Timestamp::fromMillis(unpackMillisUtc(dateTimeWithTimeZone));
+}
+
 class TimestampWithTimeZoneCastOperator : public exec::CastOperator {
  public:
   static const std::shared_ptr<const CastOperator>& get() {
@@ -56,7 +81,7 @@ class TimestampWithTimeZoneCastOperator : public exec::CastOperator {
 /// Represents timestamp with time zone as a number of milliseconds since epoch
 /// and time zone ID.
 class TimestampWithTimeZoneType : public BigintType {
-  TimestampWithTimeZoneType() = default;
+  TimestampWithTimeZoneType() : BigintType(true) {}
 
  public:
   static const std::shared_ptr<const TimestampWithTimeZoneType>& get() {
@@ -70,6 +95,19 @@ class TimestampWithTimeZoneType : public BigintType {
   bool equivalent(const Type& other) const override {
     // Pointer comparison works since this type is a singleton.
     return this == &other;
+  }
+
+  int32_t compare(const int64_t* left, const int64_t* right) const override {
+    int64_t leftUnpacked = unpackMillisUtc(*left);
+    int64_t rightUnpacked = unpackMillisUtc(*right);
+
+    return leftUnpacked < rightUnpacked ? -1
+        : leftUnpacked == rightUnpacked ? 0
+                                        : 1;
+  }
+
+  uint64_t hash(const int64_t* value) const override {
+    return folly::hasher<int64_t>()(unpackMillisUtc(*value));
   }
 
   const char* name() const override {
@@ -124,30 +162,5 @@ class TimestampWithTimeZoneTypeFactories : public CustomTypeFactories {
 };
 
 void registerTimestampWithTimeZoneType();
-
-using TimeZoneKey = int16_t;
-
-constexpr int32_t kTimezoneMask = 0xFFF;
-constexpr int32_t kMillisShift = 12;
-
-inline int64_t unpackMillisUtc(int64_t dateTimeWithTimeZone) {
-  return dateTimeWithTimeZone >> kMillisShift;
-}
-
-inline TimeZoneKey unpackZoneKeyId(int64_t dateTimeWithTimeZone) {
-  return dateTimeWithTimeZone & kTimezoneMask;
-}
-
-inline int64_t pack(int64_t millisUtc, int16_t timeZoneKey) {
-  return (millisUtc << kMillisShift) | (timeZoneKey & kTimezoneMask);
-}
-
-inline int64_t pack(const Timestamp& timestamp, int16_t timeZoneKey) {
-  return pack(timestamp.toMillis(), timeZoneKey);
-}
-
-inline Timestamp unpackTimestampUtc(int64_t dateTimeWithTimeZone) {
-  return Timestamp::fromMillis(unpackMillisUtc(dateTimeWithTimeZone));
-}
 
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/tests/TimestampWithTimeZoneTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/TimestampWithTimeZoneTypeTest.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/functions/prestosql/types/tests/TypeTestBase.h"
+#include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox::test {
 
@@ -63,6 +64,65 @@ TEST_F(TimestampWithTimeZoneTypeTest, pack) {
     ASSERT_EQ(unpackMillisUtc(packedTimeMillis), millisUtc);
     ASSERT_EQ(unpackZoneKeyId(packedTimeMillis), timeZoneKey);
   }
+}
+
+TEST_F(TimestampWithTimeZoneTypeTest, compare) {
+  auto compare = [](int32_t expected,
+                    int64_t millis1,
+                    const std::string& tz1,
+                    int64_t millis2,
+                    const std::string& tz2) {
+    int64_t left = pack(millis1, tz::getTimeZoneID(tz1));
+    int64_t right = pack(millis2, tz::getTimeZoneID(tz2));
+
+    ASSERT_EQ(expected, TIMESTAMP_WITH_TIME_ZONE()->compare(&left, &right));
+  };
+
+  compare(0, 1639426440000, "+01:00", 1639426440000, "+03:00");
+  compare(0, 1639426440000, "+01:00", 1639426440000, "-14:00");
+  compare(0, 1639426440000, "+03:00", 1639426440000, "-14:00");
+
+  compare(-1, 1549770072000, "+01:00", 1639426440000, "+03:00");
+  compare(-1, 1549770072000, "+01:00", 1639426440000, "-14:00");
+  compare(-1, 1549770072000, "+03:00", 1639426440000, "-14:00");
+
+  compare(1, 1639426440000, "+01:00", 1549770072000, "+03:00");
+  compare(1, 1639426440000, "+01:00", 1549770072000, "-14:00");
+  compare(1, 1639426440000, "+03:00", 1549770072000, "-14:00");
+}
+
+TEST_F(TimestampWithTimeZoneTypeTest, hash) {
+  auto expectHashesEq = [](int64_t millis1,
+                           const std::string& tz1,
+                           int64_t millis2,
+                           const std::string& tz2) {
+    int64_t left = pack(millis1, tz::getTimeZoneID(tz1));
+    int64_t right = pack(millis2, tz::getTimeZoneID(tz2));
+
+    ASSERT_EQ(
+        TIMESTAMP_WITH_TIME_ZONE()->hash(&left),
+        TIMESTAMP_WITH_TIME_ZONE()->hash(&right));
+  };
+
+  auto expectHashesNeq = [](int64_t millis1,
+                            const std::string& tz1,
+                            int64_t millis2,
+                            const std::string& tz2) {
+    int64_t left = pack(millis1, tz::getTimeZoneID(tz1));
+    int64_t right = pack(millis2, tz::getTimeZoneID(tz2));
+
+    ASSERT_NE(
+        TIMESTAMP_WITH_TIME_ZONE()->hash(&left),
+        TIMESTAMP_WITH_TIME_ZONE()->hash(&right));
+  };
+
+  expectHashesEq(1639426440000, "+01:00", 1639426440000, "+03:00");
+  expectHashesEq(1639426440000, "+01:00", 1639426440000, "-14:00");
+  expectHashesEq(1639426440000, "+03:00", 1639426440000, "-14:00");
+
+  expectHashesNeq(1549770072000, "+01:00", 1639426440000, "+03:00");
+  expectHashesNeq(1549770072000, "+01:00", 1639426440000, "-14:00");
+  expectHashesNeq(1549770072000, "+03:00", 1639426440000, "-14:00");
 }
 
 } // namespace facebook::velox::test

--- a/velox/functions/sparksql/tests/ArrayMaxTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayMaxTest.cpp
@@ -90,7 +90,7 @@ TEST_F(ArrayMaxTest, timestamp) {
 template <typename Type>
 class ArrayMaxIntegralTest : public ArrayMaxTest {
  public:
-  using NATIVE_TYPE = typename Type::NativeType::NativeType;
+  using NATIVE_TYPE = typename Type::NativeType;
 };
 
 TYPED_TEST_SUITE(ArrayMaxIntegralTest, FunctionBaseTest::IntegralTypes);
@@ -131,7 +131,7 @@ TYPED_TEST(ArrayMaxIntegralTest, basic) {
 template <typename Type>
 class ArrayMaxFloatingPointTest : public ArrayMaxTest {
  public:
-  using NATIVE_TYPE = typename Type::NativeType::NativeType;
+  using NATIVE_TYPE = typename Type::NativeType;
 };
 
 TYPED_TEST_SUITE(

--- a/velox/functions/sparksql/tests/ArrayMinTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayMinTest.cpp
@@ -91,7 +91,7 @@ TEST_F(ArrayMinTest, timestamp) {
 template <typename Type>
 class ArrayMinIntegralTest : public ArrayMinTest {
  public:
-  using NATIVE_TYPE = typename Type::NativeType::NativeType;
+  using NATIVE_TYPE = typename Type::NativeType;
 };
 
 TYPED_TEST_SUITE(ArrayMinIntegralTest, FunctionBaseTest::IntegralTypes);
@@ -132,7 +132,7 @@ TYPED_TEST(ArrayMinIntegralTest, basic) {
 template <typename Type>
 class ArrayMinFloatingPointTest : public ArrayMinTest {
  public:
-  using NATIVE_TYPE = typename Type::NativeType::NativeType;
+  using NATIVE_TYPE = typename Type::NativeType;
 };
 
 TYPED_TEST_SUITE(

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -231,7 +231,9 @@ const TypePtr& ArrayType::childAt(uint32_t idx) const {
 }
 
 ArrayType::ArrayType(TypePtr child)
-    : child_{std::move(child)}, parameters_{{TypeParameter(child_)}} {}
+    : TypeBase<TypeKind::ARRAY>(false),
+      child_{std::move(child)},
+      parameters_{{TypeParameter(child_)}} {}
 
 bool ArrayType::equivalent(const Type& other) const {
   if (&other == this) {
@@ -279,7 +281,8 @@ const char* MapType::nameOf(uint32_t idx) const {
 }
 
 MapType::MapType(TypePtr keyType, TypePtr valueType)
-    : keyType_{std::move(keyType)},
+    : TypeBase<TypeKind::MAP>(false),
+      keyType_{std::move(keyType)},
       valueType_{std::move(valueType)},
       parameters_{{TypeParameter(keyType_), TypeParameter(valueType_)}} {}
 
@@ -340,7 +343,9 @@ std::string namesAndTypesToString(
 } // namespace
 
 RowType::RowType(std::vector<std::string>&& names, std::vector<TypePtr>&& types)
-    : names_{std::move(names)}, children_{std::move(types)} {
+    : TypeBase<TypeKind::ROW>(false),
+      names_{std::move(names)},
+      children_{std::move(types)} {
   VELOX_CHECK_EQ(
       names_.size(),
       children_.size(),
@@ -572,7 +577,8 @@ bool MapType::equivalent(const Type& other) const {
 FunctionType::FunctionType(
     std::vector<std::shared_ptr<const Type>>&& argumentTypes,
     std::shared_ptr<const Type> returnType)
-    : children_(allChildren(std::move(argumentTypes), returnType)),
+    : TypeBase<TypeKind::FUNCTION>(false),
+      children_(allChildren(std::move(argumentTypes), returnType)),
       parameters_{createTypeParameters(children_)} {}
 
 bool FunctionType::equivalent(const Type& other) const {
@@ -616,8 +622,11 @@ folly::dynamic FunctionType::serialize() const {
   return obj;
 }
 
-OpaqueType::OpaqueType(const std::type_index& typeIndex)
-    : typeIndex_(typeIndex) {}
+OpaqueType::OpaqueType(
+    const std::type_index& typeIndex,
+    bool providesCustomComparison)
+    : TypeBase<TypeKind::OPAQUE>(providesCustomComparison),
+      typeIndex_(typeIndex) {}
 
 bool OpaqueType::equivalent(const Type& other) const {
   if (&other == this) {

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -33,6 +33,7 @@
 
 #include "velox/common/base/ClassName.h"
 #include "velox/common/serialization/Serializable.h"
+#include "velox/type/FloatingPointUtil.h"
 #include "velox/type/HugeInt.h"
 #include "velox/type/StringView.h"
 #include "velox/type/Timestamp.h"
@@ -434,7 +435,8 @@ struct TypeParameter {
 ///                   BigintType
 class Type : public Tree<const TypePtr>, public velox::ISerializable {
  public:
-  explicit Type(TypeKind kind) : kind_{kind} {}
+  explicit Type(TypeKind kind, bool providesCustomComparison = false)
+      : kind_{kind}, providesCustomComparison_(providesCustomComparison) {}
 
   TypeKind kind() const {
     return kind_;
@@ -463,6 +465,13 @@ class Type : public Tree<const TypePtr>, public velox::ISerializable {
   /// usually orderable, arrays and structs are orderable if their nested types
   /// are, while map types are not orderable.
   virtual bool isOrderable() const = 0;
+
+  /// Returns true if values of this type implements custom comparison and hash
+  /// functions. If this returns true the compare and hash functions in TypeBase
+  /// should be used instead of native implementations, e.g. ==, <, >, etc.
+  bool providesCustomComparison() const {
+    return providesCustomComparison_;
+  }
 
   /// Returns unique logical type name. It can be
   /// different from the physical type name returned by 'kindName()'.
@@ -560,6 +569,7 @@ class Type : public Tree<const TypePtr>, public velox::ISerializable {
 
  private:
   const TypeKind kind_;
+  const bool providesCustomComparison_;
 
   VELOX_DEFINE_CLASS_NAME(Type)
 };
@@ -569,9 +579,16 @@ class Type : public Tree<const TypePtr>, public velox::ISerializable {
 template <TypeKind KIND>
 class TypeBase : public Type {
  public:
-  using NativeType = TypeTraits<KIND>;
+  using NativeType = typename TypeTraits<KIND>::NativeType;
 
-  TypeBase() : Type{KIND} {}
+  explicit TypeBase(bool providesCustomComparison = false)
+      : Type{KIND, providesCustomComparison} {
+    if (providesCustomComparison) {
+      VELOX_CHECK(
+          TypeTraits<KIND>::isPrimitiveType && TypeTraits<KIND>::isFixedWidth,
+          "Custom comparisons are only supported for primite types that are fixed width.");
+    }
+  }
 
   bool isPrimitiveType() const override {
     return TypeTraits<KIND>::isPrimitiveType;
@@ -601,11 +618,30 @@ class TypeBase : public Type {
     static const std::vector<TypeParameter> kEmpty = {};
     return kEmpty;
   }
+
+  virtual int32_t compare(
+      const NativeType* /*left*/,
+      const NativeType* /*right*/) const {
+    VELOX_CHECK(
+        !providesCustomComparison(),
+        "Type {} is marked as providesCustomComparison but did not implement compare.");
+    VELOX_FAIL("Type {} does not provide custom comparison", name());
+  }
+
+  virtual uint64_t hash(const NativeType* /*value*/) const {
+    VELOX_CHECK(
+        !providesCustomComparison(),
+        "Type {} is marked as providesCustomComparison but did not implement hash.");
+    VELOX_FAIL("Type {} does not provide custom hash", name());
+  }
 };
 
 template <TypeKind KIND>
 class ScalarType : public TypeBase<KIND> {
  public:
+  explicit ScalarType(bool providesCustomComparison = false)
+      : TypeBase<KIND>{providesCustomComparison} {}
+
   uint32_t size() const override {
     return 0;
   }
@@ -657,8 +693,8 @@ const std::shared_ptr<const ScalarType<KIND>> ScalarType<KIND>::create() {
 
 /// This class represents the fixed-point numbers.
 /// The parameter "precision" represents the number of digits the
-/// Decimal Type can support and "scale" represents the number of digits to the
-/// right of the decimal point.
+/// Decimal Type can support and "scale" represents the number of digits to
+/// the right of the decimal point.
 template <TypeKind KIND>
 class DecimalType : public ScalarType<KIND> {
  public:
@@ -769,7 +805,8 @@ std::pair<uint8_t, uint8_t> getDecimalPrecisionScale(const Type& type);
 
 class UnknownType : public TypeBase<TypeKind::UNKNOWN> {
  public:
-  UnknownType() = default;
+  explicit UnknownType(bool proivdesCustomComparison = false)
+      : TypeBase<TypeKind::UNKNOWN>(proivdesCustomComparison) {}
 
   uint32_t size() const override {
     return 0;
@@ -1054,7 +1091,9 @@ class OpaqueType : public TypeBase<TypeKind::OPAQUE> {
   template <typename T>
   using DeserializeFunc = std::function<std::shared_ptr<T>(const std::string&)>;
 
-  explicit OpaqueType(const std::type_index& typeIndex);
+  explicit OpaqueType(
+      const std::type_index& typeInde,
+      bool providesCustomComparison = false);
 
   uint32_t size() const override {
     return 0;
@@ -1077,11 +1116,12 @@ class OpaqueType : public TypeBase<TypeKind::OPAQUE> {
   folly::dynamic serialize() const override;
   /// In special cases specific OpaqueTypes might want to serialize additional
   /// metadata. In those cases we need to deserialize it back. Since
-  /// OpaqueType::create<T>() returns canonical type for T without metadata, we
-  /// allow to create new instance here or return nullptr if the same one can be
-  /// used. Note that it's about deserialization of type itself, DeserializeFunc
-  /// above is about deserializing instances of the type. It's implemented as a
-  /// virtual member instead of a standalone registry just for convenience.
+  /// OpaqueType::create<T>() returns canonical type for T without metadata,
+  /// we allow to create new instance here or return nullptr if the same one
+  /// can be used. Note that it's about deserialization of type itself,
+  /// DeserializeFunc above is about deserializing instances of the type. It's
+  /// implemented as a virtual member instead of a standalone registry just
+  /// for convenience.
   virtual std::shared_ptr<const OpaqueType> deserializeExtra(
       const folly::dynamic& json) const;
 
@@ -1236,8 +1276,8 @@ class IntervalYearMonthType : public IntegerType {
   }
 
   /// Returns the interval 'value' (months) formatted as YEARS MONTHS.
-  /// For example, 14 months (INTERVAL '1-2' YEAR TO MONTH) would be represented
-  /// as 1-2; -14 months would be represents as -1-2.
+  /// For example, 14 months (INTERVAL '1-2' YEAR TO MONTH) would be
+  /// represented as 1-2; -14 months would be represents as -1-2.
   std::string valueToString(int32_t value) const;
 
   folly::dynamic serialize() const override {
@@ -1896,8 +1936,8 @@ using CastOperatorPtr = std::shared_ptr<const CastOperator>;
 
 } // namespace exec
 
-/// Associates custom types with their custom operators to be the payload in the
-/// custom type registry.
+/// Associates custom types with their custom operators to be the payload in
+/// the custom type registry.
 class CustomTypeFactories {
  public:
   virtual ~CustomTypeFactories() = default;
@@ -1912,9 +1952,9 @@ class CustomTypeFactories {
   virtual exec::CastOperatorPtr getCastOperator() const = 0;
 };
 
-/// Adds custom type to the registry if it doesn't exist already. No-op if type
-/// with specified name already exists. Returns true if type was added, false if
-/// type with the specified name already exists.
+/// Adds custom type to the registry if it doesn't exist already. No-op if
+/// type with specified name already exists. Returns true if type was added,
+/// false if type with the specified name already exists.
 bool registerCustomType(
     const std::string& name,
     std::unique_ptr<const CustomTypeFactories> factories);

--- a/velox/type/tests/CMakeLists.txt
+++ b/velox/type/tests/CMakeLists.txt
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+add_subdirectory(utils)
+
 add_executable(
   velox_type_test
   ConversionsTest.cpp
@@ -31,6 +33,7 @@ add_test(velox_type_test velox_type_test)
 target_link_libraries(
   velox_type_test
   velox_type
+  velox_type_test_lib
   velox_common_base
   Folly::folly
   GTest::gtest

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/type/CppToType.h"
 #include "velox/type/SimpleFunctionApi.h"
+#include "velox/type/tests/utils/CustomTypesForTesting.h"
 
 using namespace facebook;
 using namespace facebook::velox;
@@ -989,4 +990,59 @@ TEST(TypeTest, functionTypeEquivalent) {
       std::vector<TypePtr>{MAP(BIGINT(), VARCHAR())}, BOOLEAN());
 
   EXPECT_TRUE(functionType->equivalent(*otherFunctionType));
+}
+
+TEST(TypeTest, providesCustomComparison) {
+  // None of the builtin types provide custom comparison.
+  EXPECT_FALSE(BOOLEAN()->providesCustomComparison());
+  EXPECT_FALSE(TINYINT()->providesCustomComparison());
+  EXPECT_FALSE(SMALLINT()->providesCustomComparison());
+  EXPECT_FALSE(INTEGER()->providesCustomComparison());
+  EXPECT_FALSE(BIGINT()->providesCustomComparison());
+  EXPECT_FALSE(HUGEINT()->providesCustomComparison());
+  EXPECT_FALSE(REAL()->providesCustomComparison());
+  EXPECT_FALSE(DOUBLE()->providesCustomComparison());
+  EXPECT_FALSE(VARCHAR()->providesCustomComparison());
+  EXPECT_FALSE(VARBINARY()->providesCustomComparison());
+  EXPECT_FALSE(TIMESTAMP()->providesCustomComparison());
+  EXPECT_FALSE(DATE()->providesCustomComparison());
+  EXPECT_FALSE(ARRAY(INTEGER())->providesCustomComparison());
+  EXPECT_FALSE(MAP(INTEGER(), INTEGER())->providesCustomComparison());
+  EXPECT_FALSE(ROW({INTEGER()})->providesCustomComparison());
+  EXPECT_FALSE(DECIMAL(10, 5)->providesCustomComparison());
+  EXPECT_FALSE(UNKNOWN()->providesCustomComparison());
+  EXPECT_FALSE(INTERVAL_YEAR_MONTH()->providesCustomComparison());
+  EXPECT_FALSE(INTERVAL_DAY_TIME()->providesCustomComparison());
+  EXPECT_FALSE(FUNCTION({INTEGER()}, INTEGER())->providesCustomComparison());
+
+  int64_t value = 0;
+  // This custom type does provide custom comparison.
+  EXPECT_TRUE(
+      test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON()->providesCustomComparison());
+  EXPECT_EQ(
+      0, test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON()->compare(&value, &value));
+  EXPECT_EQ(
+      8633297058295171728,
+      test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON()->hash(&value));
+
+  // BIGINT does not provide custom comparison so calling compare or hash on it
+  // should fail.
+  EXPECT_THROW(BIGINT()->compare(&value, &value), VeloxRuntimeError);
+  EXPECT_THROW(BIGINT()->hash(&value), VeloxRuntimeError);
+
+  // This type claims it providesCustomComparison but does not implement the
+  // compare and hash functions so invoking them should still fail.
+  EXPECT_TRUE(test::BIGINT_TYPE_WITH_INVALID_CUSTOM_COMPARISON()
+                  ->providesCustomComparison());
+  EXPECT_THROW(
+      test::BIGINT_TYPE_WITH_INVALID_CUSTOM_COMPARISON()->compare(
+          &value, &value),
+      VeloxRuntimeError);
+  EXPECT_THROW(
+      test::BIGINT_TYPE_WITH_INVALID_CUSTOM_COMPARISON()->hash(&value),
+      VeloxRuntimeError);
+
+  // We do not support variable width custom comparison for variable width
+  // types, so attempting to instantiate one should fail.
+  EXPECT_THROW(test::VARCHAR_TYPE_WITH_CUSTOM_COMPARISON(), VeloxRuntimeError);
 }

--- a/velox/type/tests/utils/CMakeLists.txt
+++ b/velox/type/tests/utils/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+add_library(velox_type_test_lib INTERFACE)
+
+target_link_libraries(
+  velox_type_test_lib
+  INTERFACE velox_type)

--- a/velox/type/tests/utils/CustomTypesForTesting.h
+++ b/velox/type/tests/utils/CustomTypesForTesting.h
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/type/Type.h"
+
+namespace facebook::velox::test {
+// A custom type that provides custom comparison and hash functions.
+class BigintTypeWithCustomComparison : public BigintType {
+  BigintTypeWithCustomComparison() : BigintType(true) {}
+
+ public:
+  static const std::shared_ptr<const BigintTypeWithCustomComparison>& get() {
+    static const std::shared_ptr<const BigintTypeWithCustomComparison>
+        instance = std::shared_ptr<BigintTypeWithCustomComparison>(
+            new BigintTypeWithCustomComparison());
+
+    return instance;
+  }
+
+  bool equivalent(const Type& other) const override {
+    // Pointer comparison works since this type is a singleton.
+    return this == &other;
+  }
+
+  // For the purposes of testing, this type only compares the bottom 8 bits of
+  // values.
+  int32_t compare(const int64_t* left, const int64_t* right) const override {
+    int64_t leftTruncated = *left & 0xff;
+    int64_t rightTruncated = *right & 0xff;
+
+    return leftTruncated < rightTruncated ? -1
+        : leftTruncated == rightTruncated ? 0
+                                          : 1;
+  }
+
+  uint64_t hash(const int64_t* value) const override {
+    return folly::hasher<int64_t>()(*value & 0xff);
+  }
+
+  const char* name() const override {
+    return "BIGINT TYPE WITH CUSTOM COMPARISON";
+  }
+
+  const std::vector<TypeParameter>& parameters() const override {
+    static const std::vector<TypeParameter> kEmpty = {};
+    return kEmpty;
+  }
+
+  std::string toString() const override {
+    return name();
+  }
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = "Type";
+    obj["type"] = name();
+    return obj;
+  }
+};
+
+inline std::shared_ptr<const BigintTypeWithCustomComparison>
+BIGINT_TYPE_WITH_CUSTOM_COMPARISON() {
+  return BigintTypeWithCustomComparison::get();
+}
+
+// A custom type that declares it providesCustomComparison but does not
+// implement the compare or hash functions. This is not supported.
+class BigintTypeWithInvalidCustomComparison : public BigintType {
+  BigintTypeWithInvalidCustomComparison() : BigintType(true) {}
+
+ public:
+  static const std::shared_ptr<const BigintTypeWithInvalidCustomComparison>&
+  get() {
+    static const std::shared_ptr<const BigintTypeWithInvalidCustomComparison>
+        instance = std::shared_ptr<BigintTypeWithInvalidCustomComparison>(
+            new BigintTypeWithInvalidCustomComparison());
+
+    return instance;
+  }
+
+  bool equivalent(const Type& other) const override {
+    // Pointer comparison works since this type is a singleton.
+    return this == &other;
+  }
+
+  const char* name() const override {
+    return "BIGINT TYPE WITH INVALID CUSTOM COMPARISON";
+  }
+
+  const std::vector<TypeParameter>& parameters() const override {
+    static const std::vector<TypeParameter> kEmpty = {};
+    return kEmpty;
+  }
+
+  std::string toString() const override {
+    return name();
+  }
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = "Type";
+    obj["type"] = name();
+    return obj;
+  }
+};
+
+inline std::shared_ptr<const BigintTypeWithInvalidCustomComparison>
+BIGINT_TYPE_WITH_INVALID_CUSTOM_COMPARISON() {
+  return BigintTypeWithInvalidCustomComparison::get();
+}
+
+// A custom type that is not fixed width that provides custom comparison and
+// hash functions. This is not currently supported.
+class VarcharTypeWithCustomComparison : public VarcharType {
+  VarcharTypeWithCustomComparison() : VarcharType(true) {}
+
+ public:
+  static const std::shared_ptr<const VarcharTypeWithCustomComparison>& get() {
+    static const std::shared_ptr<const VarcharTypeWithCustomComparison>
+        instance = std::shared_ptr<VarcharTypeWithCustomComparison>(
+            new VarcharTypeWithCustomComparison());
+
+    return instance;
+  }
+
+  bool equivalent(const Type& other) const override {
+    // Pointer comparison works since this type is a singleton.
+    return this == &other;
+  }
+
+  // For the purposes of testing, this type only compares the bottom 8 bits of
+  // values.
+  int32_t compare(const StringView* left, const StringView* right)
+      const override {
+    return *left < *right ? -1 : *left == *right ? 0 : 1;
+  }
+
+  uint64_t hash(const StringView* value) const override {
+    return folly::hasher<StringView>()(*value);
+  }
+
+  const char* name() const override {
+    return "VARCHAR TYPE WITH CUSTOM COMPARISON";
+  }
+
+  const std::vector<TypeParameter>& parameters() const override {
+    static const std::vector<TypeParameter> kEmpty = {};
+    return kEmpty;
+  }
+
+  std::string toString() const override {
+    return name();
+  }
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = "Type";
+    obj["type"] = name();
+    return obj;
+  }
+};
+
+inline std::shared_ptr<const VarcharTypeWithCustomComparison>
+VARCHAR_TYPE_WITH_CUSTOM_COMPARISON() {
+  return VarcharTypeWithCustomComparison::get();
+}
+} // namespace facebook::velox::test

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -313,8 +313,8 @@ class ConstantVector final : public SimpleVector<T> {
               isNull_, otherConstant->isNull_, flags);
         }
 
-        auto result =
-            SimpleVector<T>::comparePrimitiveAsc(value_, otherConstant->value_);
+        auto result = SimpleVector<T>::comparePrimitiveAsc(
+            this->type_.get(), value_, otherConstant->value_);
         return flags.ascending ? result : result * -1;
       }
     }

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -326,7 +326,8 @@ class FlatVector final : public SimpleVector<T> {
 
     auto thisValue = valueAtFast(index);
     auto otherValue = other->valueAtFast(otherIndex);
-    auto result = SimpleVector<T>::comparePrimitiveAsc(thisValue, otherValue);
+    auto result = SimpleVector<T>::comparePrimitiveAsc(
+        this->type_.get(), thisValue, otherValue);
     return flags.ascending ? result : result * -1;
   }
 
@@ -335,7 +336,8 @@ class FlatVector final : public SimpleVector<T> {
     auto compareNonNull = [&](vector_size_t left, vector_size_t right) {
       auto leftValue = valueAtFast(left);
       auto rightValue = valueAtFast(right);
-      auto result = SimpleVector<T>::comparePrimitiveAsc(leftValue, rightValue);
+      auto result = SimpleVector<T>::comparePrimitiveAsc(
+          this->type_.get(), leftValue, rightValue);
       return (flags.ascending ? result : result * -1) < 0;
     };
 
@@ -365,7 +367,8 @@ class FlatVector final : public SimpleVector<T> {
     auto compareNonNull = [&](vector_size_t left, vector_size_t right) {
       auto leftValue = valueAtFast(mapping[left]);
       auto rightValue = valueAtFast(mapping[right]);
-      auto result = SimpleVector<T>::comparePrimitiveAsc(leftValue, rightValue);
+      auto result = SimpleVector<T>::comparePrimitiveAsc(
+          this->type_.get(), leftValue, rightValue);
       return (flags.ascending ? result : result * -1) < 0;
     };
 

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ target_link_libraries(
   velox_presto_serializer
   velox_presto_types
   velox_temp_path
+  velox_type_test_lib
   velox_vector_fuzzer
   Boost::atomic
   Boost::context


### PR DESCRIPTION
Summary:
**Problem**:
Today, when a Custom Type extends an existing physical type, it inherits the comparison and hashing
semantics of the native type. This can lead to undesired semantics. For example, we've seen for
TimestampWithTimeZone, it inherits its equality and hashing from int64_t, but in order to match
Presto semantics we need times at different time zones that are equivalent when converted to UTC
to be considered equal generally.

**Solution**:
This change attempts to address this in three parts:
1) I added a boolean parameter `providesCustomComparison` to Type which is set in the
constructor. Custom types that want to provide their own implementation of compare & hash set this
to true in their constructor.
2) I added virtual functions `compare` and `hash` to TypeBase. Custom types that want to provide
their own implementation of compare & hash implement them by overriding these functions. These
will be invoked instead of the native type's compare and hash functions if
`providesCustomComparison` is set. By default these throw, as they should not be invoked if
`providesCustomComparison` is not set, and if `providesCustomComparison` is set they must be
overridden.
3) I modified a few core places in Velox where comparison and hash operators are invoked to call
the provided compare & hash functions if available. Specifically: SimpleVector, VectorHasher,
RowContainer, and ContainerRowSerde. There are functions (scalar and aggregate) that need to be
updated and testing to ensure we haven't missed anything.  I will address these in follow ups.

As an example and the motivating use case, I've updated TimestampWithTimeZone to provide
custom compare & hash functions.

**Limitations**:
For now I've limited this to primitive, fixed width types.  Primitive most non-primitive types do not
have a well defined NativeType, so how to implement custom compare & hash functions is not
immediately clear (at least to me). Fixed width because in some places, e.g. ContainerRowSerde,
they take advantage of the fact that compare does not need the data to be contiguous in memory to
avoid copying the data, and without a motivating use case I didn't want to complicate this logic.

**Alternatives Considered**:
* Add a new TypeKind for new custom types that need custom comparisons. This requires changes
to Velox core code for custom types form customers, which removes a lot of the value of custom
types.
* Just have virtual `compare` and `hash` functions (no `providesCustomComparison`). The
conditional already adds some overhead, a dynamic call in the general case would be prohibitively
expensive.
* Add a `TypeWithCustomComparison` base class (or something like that) so that we don't need
to make the `compare` and `hash` functions only available in custom types that don't need it. This
would mean casting to `TypeWithCustomComparison<TypeKind>` in places where we need to call
the custom functions. This would be less safe than casting to `TypeBase<TypeKind>` (since all types
inherit from some `TypeBase<TypeKind>`) and require a dynamic_cast which would be more
expensive.
* Somehow work this into `CustomTypeFactories`. This would require a map lookup which would be
even more expensive than a dynamic call.

Differential Revision: D62766364
