### PR TITLE
Fix hash build not able to reclaim in finishHashBuild

### DIFF
--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -143,10 +143,7 @@ class HashBuild final : public Operator {
 
   // Invoked to ensure there is sufficient memory to build the join table. The
   // function throws to fail the query if the memory reservation fails.
-  void ensureTableFits(
-      const std::vector<HashBuild*>& otherBuilds,
-      const std::vector<std::unique_ptr<BaseHashTable>>& otherTables,
-      bool isParallelJoin);
+  void ensureTableFits(uint64_t numRows);
 
   // Invoked to compute spill partitions numbers for each row 'input' and spill
   // rows to spiller directly if the associated partition(s) is spilling. The


### PR DESCRIPTION
This is a regression caused by previous change. When hash build is in finishHashBuild() function, it ought to be reclaimable while calling ensureTableFits(). But ensureTableFits was called after spiller_ and table_ ownerships have been transferred, which caused the whole operator to be in a not able to reclaim state. This PR fixed the issue and added tests to avoid similar issues from happening again.