### PR TITLE
Allow Custom Types to provide custom implementations of compare and hash functions.

### DIFF
--- a/velox/docs/develop/types.rst
+++ b/velox/docs/develop/types.rst
@@ -137,6 +137,14 @@ the existing physical types. For example, Presto Types described below are imple
 by extending the physical types.
 An OPAQUE type must be used when there is no physical type available to back the logical type.
 
+When extending an existing physical type, if different compare and/or hash semantics are
+needed instead of those provided by the underlying native C++ type, this can be achieved by
+doing the following:
+* Pass `true` for the `providesCustomComparison` argument in the custom type's base class's constructor.
+* Override the `compare` and `hash` functions inherited from the `TypeBase` class (you must implement both).
+Note that this is currently only supported for custom types that extend physical types that
+are primitive and fixed width.
+
 Complex Types
 ~~~~~~~~~~~~~
 Velox supports the ARRAY, MAP, and ROW complex types.
@@ -184,12 +192,12 @@ IPPREFIX networks.
 
 Spark Types
 ~~~~~~~~~~~~
-The `data types <https://spark.apache.org/docs/latest/sql-ref-datatypes.html>`_ in Spark have some semantic differences compared to those in 
-Presto. These differences require us to implement the same functions 
-separately for each system in Velox, such as min, max and collect_set. The 
+The `data types <https://spark.apache.org/docs/latest/sql-ref-datatypes.html>`_ in Spark have some semantic differences compared to those in
+Presto. These differences require us to implement the same functions
+separately for each system in Velox, such as min, max and collect_set. The
 key differences are listed below.
 
-* Spark operates on timestamps with "microsecond" precision while Presto with 
+* Spark operates on timestamps with "microsecond" precision while Presto with
   "millisecond" precision.
   Example::
 
@@ -210,7 +218,7 @@ key differences are listed below.
       FROM (
           VALUES
               (ARRAY[1, 2]),
-              (ARRAY[1, null])  
+              (ARRAY[1, null])
       ) AS t(a);
       -- ARRAY[1, null]
 

--- a/velox/functions/prestosql/tests/ArrayMaxTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayMaxTest.cpp
@@ -165,7 +165,7 @@ TEST_F(ArrayMaxTest, docs) {
 template <typename Type>
 class ArrayMaxIntegralTest : public FunctionBaseTest {
  public:
-  using T = typename Type::NativeType::NativeType;
+  using T = typename Type::NativeType;
 
   void testArrayMax(const VectorPtr& input, const VectorPtr& expected) {
     auto result =
@@ -230,7 +230,7 @@ class ArrayMaxIntegralTest : public FunctionBaseTest {
 template <typename Type>
 class ArrayMaxFloatingPointTest : public FunctionBaseTest {
  public:
-  using T = typename Type::NativeType::NativeType;
+  using T = typename Type::NativeType;
 
   void testArrayMax(VectorPtr input, VectorPtr expected) {
     auto result =

--- a/velox/functions/prestosql/tests/ComparisonsTest.cpp
+++ b/velox/functions/prestosql/tests/ComparisonsTest.cpp
@@ -778,7 +778,7 @@ typedef ::testing::Types<
 template <typename ComparisonTypeOp>
 class SimdComparisonsTest : public functions::test::FunctionBaseTest {
  public:
-  using T = typename ComparisonTypeOp::type::NativeType::NativeType;
+  using T = typename ComparisonTypeOp::type::NativeType;
   using ComparisonOp = typename ComparisonTypeOp::fn;
   const std::string sqlFn = ComparisonTypeOp().sqlFunction;
 

--- a/velox/functions/sparksql/tests/ArrayMaxTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayMaxTest.cpp
@@ -90,7 +90,7 @@ TEST_F(ArrayMaxTest, timestamp) {
 template <typename Type>
 class ArrayMaxIntegralTest : public ArrayMaxTest {
  public:
-  using NATIVE_TYPE = typename Type::NativeType::NativeType;
+  using NATIVE_TYPE = typename Type::NativeType;
 };
 
 TYPED_TEST_SUITE(ArrayMaxIntegralTest, FunctionBaseTest::IntegralTypes);
@@ -131,7 +131,7 @@ TYPED_TEST(ArrayMaxIntegralTest, basic) {
 template <typename Type>
 class ArrayMaxFloatingPointTest : public ArrayMaxTest {
  public:
-  using NATIVE_TYPE = typename Type::NativeType::NativeType;
+  using NATIVE_TYPE = typename Type::NativeType;
 };
 
 TYPED_TEST_SUITE(

--- a/velox/functions/sparksql/tests/ArrayMinTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayMinTest.cpp
@@ -91,7 +91,7 @@ TEST_F(ArrayMinTest, timestamp) {
 template <typename Type>
 class ArrayMinIntegralTest : public ArrayMinTest {
  public:
-  using NATIVE_TYPE = typename Type::NativeType::NativeType;
+  using NATIVE_TYPE = typename Type::NativeType;
 };
 
 TYPED_TEST_SUITE(ArrayMinIntegralTest, FunctionBaseTest::IntegralTypes);
@@ -132,7 +132,7 @@ TYPED_TEST(ArrayMinIntegralTest, basic) {
 template <typename Type>
 class ArrayMinFloatingPointTest : public ArrayMinTest {
  public:
-  using NATIVE_TYPE = typename Type::NativeType::NativeType;
+  using NATIVE_TYPE = typename Type::NativeType;
 };
 
 TYPED_TEST_SUITE(

--- a/velox/type/tests/CMakeLists.txt
+++ b/velox/type/tests/CMakeLists.txt
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+add_subdirectory(utils)
+
 add_executable(
   velox_type_test
   ConversionsTest.cpp
@@ -31,6 +33,7 @@ add_test(velox_type_test velox_type_test)
 target_link_libraries(
   velox_type_test
   velox_type
+  velox_type_test_lib
   velox_common_base
   Folly::folly
   GTest::gtest

--- a/velox/type/tests/utils/CMakeLists.txt
+++ b/velox/type/tests/utils/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+add_library(velox_type_test_lib INTERFACE)
+
+target_link_libraries(
+  velox_type_test_lib
+  INTERFACE velox_type)

--- a/velox/type/tests/utils/CustomTypesForTesting.h
+++ b/velox/type/tests/utils/CustomTypesForTesting.h
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/type/Type.h"
+
+namespace facebook::velox::test {
+// A custom type that provides custom comparison and hash functions.
+class BigintTypeWithCustomComparison : public BigintType {
+  BigintTypeWithCustomComparison() : BigintType(true) {}
+
+ public:
+  static const std::shared_ptr<const BigintTypeWithCustomComparison>& get() {
+    static const std::shared_ptr<const BigintTypeWithCustomComparison>
+        instance = std::shared_ptr<BigintTypeWithCustomComparison>(
+            new BigintTypeWithCustomComparison());
+
+    return instance;
+  }
+
+  bool equivalent(const Type& other) const override {
+    // Pointer comparison works since this type is a singleton.
+    return this == &other;
+  }
+
+  // For the purposes of testing, this type only compares the bottom 8 bits of
+  // values.
+  int32_t compare(const int64_t& left, const int64_t& right) const override {
+    int64_t leftTruncated = left & 0xff;
+    int64_t rightTruncated = right & 0xff;
+
+    return leftTruncated < rightTruncated ? -1
+        : leftTruncated == rightTruncated ? 0
+                                          : 1;
+  }
+
+  uint64_t hash(const int64_t& value) const override {
+    return folly::hasher<int64_t>()(value & 0xff);
+  }
+
+  const char* name() const override {
+    return "BIGINT TYPE WITH CUSTOM COMPARISON";
+  }
+
+  const std::vector<TypeParameter>& parameters() const override {
+    static const std::vector<TypeParameter> kEmpty = {};
+    return kEmpty;
+  }
+
+  std::string toString() const override {
+    return name();
+  }
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = "Type";
+    obj["type"] = name();
+    return obj;
+  }
+};
+
+inline std::shared_ptr<const BigintTypeWithCustomComparison>
+BIGINT_TYPE_WITH_CUSTOM_COMPARISON() {
+  return BigintTypeWithCustomComparison::get();
+}
+
+// A custom type that declares it providesCustomComparison but does not
+// implement the compare or hash functions. This is not supported.
+class BigintTypeWithInvalidCustomComparison : public BigintType {
+  BigintTypeWithInvalidCustomComparison() : BigintType(true) {}
+
+ public:
+  static const std::shared_ptr<const BigintTypeWithInvalidCustomComparison>&
+  get() {
+    static const std::shared_ptr<const BigintTypeWithInvalidCustomComparison>
+        instance = std::shared_ptr<BigintTypeWithInvalidCustomComparison>(
+            new BigintTypeWithInvalidCustomComparison());
+
+    return instance;
+  }
+
+  bool equivalent(const Type& other) const override {
+    // Pointer comparison works since this type is a singleton.
+    return this == &other;
+  }
+
+  const char* name() const override {
+    return "BIGINT TYPE WITH INVALID CUSTOM COMPARISON";
+  }
+
+  const std::vector<TypeParameter>& parameters() const override {
+    static const std::vector<TypeParameter> kEmpty = {};
+    return kEmpty;
+  }
+
+  std::string toString() const override {
+    return name();
+  }
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = "Type";
+    obj["type"] = name();
+    return obj;
+  }
+};
+
+inline std::shared_ptr<const BigintTypeWithInvalidCustomComparison>
+BIGINT_TYPE_WITH_INVALID_CUSTOM_COMPARISON() {
+  return BigintTypeWithInvalidCustomComparison::get();
+}
+
+// A custom type that is not fixed width that provides custom comparison and
+// hash functions. This is not currently supported.
+class VarcharTypeWithCustomComparison : public VarcharType {
+  VarcharTypeWithCustomComparison() : VarcharType(true) {}
+
+ public:
+  static const std::shared_ptr<const VarcharTypeWithCustomComparison>& get() {
+    static const std::shared_ptr<const VarcharTypeWithCustomComparison>
+        instance = std::shared_ptr<VarcharTypeWithCustomComparison>(
+            new VarcharTypeWithCustomComparison());
+
+    return instance;
+  }
+
+  bool equivalent(const Type& other) const override {
+    // Pointer comparison works since this type is a singleton.
+    return this == &other;
+  }
+
+  // For the purposes of testing, this type only compares the bottom 8 bits of
+  // values.
+  int32_t compare(const StringView& left, const StringView& right)
+      const override {
+    return left.compare(right);
+  }
+
+  uint64_t hash(const StringView& value) const override {
+    return folly::hasher<StringView>()(value);
+  }
+
+  const char* name() const override {
+    return "VARCHAR TYPE WITH CUSTOM COMPARISON";
+  }
+
+  const std::vector<TypeParameter>& parameters() const override {
+    static const std::vector<TypeParameter> kEmpty = {};
+    return kEmpty;
+  }
+
+  std::string toString() const override {
+    return name();
+  }
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = "Type";
+    obj["type"] = name();
+    return obj;
+  }
+};
+
+inline std::shared_ptr<const VarcharTypeWithCustomComparison>
+VARCHAR_TYPE_WITH_CUSTOM_COMPARISON() {
+  return VarcharTypeWithCustomComparison::get();
+}
+} // namespace facebook::velox::test


### PR DESCRIPTION
Summary:
**Problem**:
Today, when a Custom Type extends an existing physical type, it inherits the comparison and hashing
semantics of the native type. This can lead to undesired semantics. For example, we've seen for
TimestampWithTimeZone, it inherits its equality and hashing from int64_t, but in order to match
Presto semantics we need times at different time zones that are equivalent when converted to UTC
to be considered equal generally.

**Solution**:
This change attempts to address this:
1) I added a boolean parameter `providesCustomComparison` to Type which is set in the
constructor. Custom types that want to provide their own implementation of compare & hash set this
to true in their constructor.
2) I added virtual functions `compare` and `hash` to TypeBase. Custom types that want to provide
their own implementation of compare & hash implement them by overriding these functions. These
will be invoked instead of the native type's compare and hash functions if
`providesCustomComparison` is set. By default these throw, as they should not be invoked if
`providesCustomComparison` is not set, and if `providesCustomComparison` is set they must be
overridden.

I will update the places where we do comparisons/hash to make use of this in diffs later in the stack.

**Limitations**:
For now I've limited this to primitive, fixed width types.  Primitive most non-primitive types do not
have a well defined NativeType, so how to implement custom compare & hash functions is not
immediately clear (at least to me). Fixed width because in some places, e.g. ContainerRowSerde,
they take advantage of the fact that compare does not need the data to be contiguous in memory to
avoid copying the data, and without a motivating use case I didn't want to complicate this logic.

**Alternatives Considered**:
* Add a new TypeKind for new custom types that need custom comparisons. This requires changes
to Velox core code for custom types form customers, which removes a lot of the value of custom
types.
* Just have virtual `compare` and `hash` functions (no `providesCustomComparison`). The
conditional already adds some overhead, a dynamic call in the general case would be prohibitively
expensive.
* Add a `TypeWithCustomComparison` base class (or something like that) so that we don't need
to make the `compare` and `hash` functions only available in custom types that don't need it. This
would mean casting to `TypeWithCustomComparison<TypeKind>` in places where we need to call
the custom functions. This would be less safe than casting to `TypeBase<TypeKind>` (since all types
inherit from some `TypeBase<TypeKind>`) and require a dynamic_cast which would be more
expensive.
* Somehow work this into `CustomTypeFactories`. This would require a map lookup which would be
even more expensive than a dynamic call.

Differential Revision: D62900789
