### PR TITLE
Support custom comparison in Vectors

### DIFF
--- a/velox/type/tests/utils/CustomTypesForTesting.h
+++ b/velox/type/tests/utils/CustomTypesForTesting.h
@@ -142,8 +142,6 @@ class VarcharTypeWithCustomComparison : public VarcharType {
     return this == &other;
   }
 
-  // For the purposes of testing, this type only compares the bottom 8 bits of
-  // values.
   int32_t compare(const StringView& left, const StringView& right)
       const override {
     return left.compare(right);

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -43,6 +43,8 @@ BaseVector::BaseVector(
     std::optional<ByteCount> storageByteCount)
     : type_(std::move(type)),
       typeKind_(type_ ? type_->kind() : TypeKind::INVALID),
+      typeUsesCustomComparison_(
+          type_ ? type_->providesCustomComparison() : false),
       encoding_(encoding),
       nulls_(std::move(nulls)),
       rawNulls_(nulls_.get() ? nulls_->as<uint64_t>() : nullptr),

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -186,6 +186,10 @@ class BaseVector {
     return type_;
   }
 
+  bool typeUsesCustomComparison() const {
+    return typeUsesCustomComparison_;
+  }
+
   /// Changes vector type. The new type can have a different
   /// logical representation while maintaining the same physical type.
   /// Additionally, note that the caller must ensure that this vector is not
@@ -900,6 +904,12 @@ class BaseVector {
 
   TypePtr type_;
   const TypeKind typeKind_;
+  // Whether `type_` is a type that provides custom comparison operations.
+  // We use this instead of calling type_->providesCustomCompare() because
+  // having a constant field helps the compiler to pull this condition up in
+  // loops, and `type_` itself is non-constant (though it can only be modified
+  // logically, so this property is safe to store).
+  const bool typeUsesCustomComparison_;
   const VectorEncoding::Simple encoding_;
   BufferPtr nulls_;
   // Caches raw pointer to 'nulls->as<uint64_t>().

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -313,8 +313,12 @@ class ConstantVector final : public SimpleVector<T> {
               isNull_, otherConstant->isNull_, flags);
         }
 
-        auto result =
-            SimpleVector<T>::comparePrimitiveAsc(value_, otherConstant->value_);
+        auto result = this->typeUsesCustomComparison_
+            ? SimpleVector<T>::comparePrimitiveAscWithCustomComparison(
+                  this->type_.get(), value_, otherConstant->value_)
+            : SimpleVector<T>::comparePrimitiveAsc(
+                  value_, otherConstant->value_);
+
         return flags.ascending ? result : result * -1;
       }
     }

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ target_link_libraries(
   velox_presto_serializer
   velox_presto_types
   velox_temp_path
+  velox_type_test_lib
   velox_vector_fuzzer
   Boost::atomic
   Boost::context


### PR DESCRIPTION
Summary:
Building on https://github.com/facebookincubator/velox/pull/11021 this adds support for custom
comparison functions provided by custom types in the compare and hash functions in the
BaseVector implementations.

Since this is only supported for primitive types the changes are largely contained in just the
SimpleVector class.

Note that this will introduce a regression in the general performance of compare and hash since we
need to check another condition on type->providesCustomComparison(). Unfortunately, I think
some sort of runtime check there is unavoidable.

Differential Revision: D62901338
