### PR TITLE
Support custom comparison in ContainerRowSerde

### DIFF
--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -136,6 +136,7 @@ target_link_libraries(
   velox_serialization
   velox_test_util
   velox_type
+  velox_type_test_lib
   velox_vector
   velox_vector_fuzzer
   velox_writer_fuzzer


### PR DESCRIPTION
Summary:
Building on https://github.com/facebookincubator/velox/pull/11021 this adds support for custom
comparison functions provided by custom types in ContainerRowSerde.

Compare was already handled by updating SimpleVector, so this just updates the hash function and
adds tests.

Differential Revision: D62902814
