### PR TITLE
Provide custom comparison functions in TimestampWithTimezone

### DIFF
--- a/velox/exec/VectorHasher.h
+++ b/velox/exec/VectorHasher.h
@@ -540,7 +540,7 @@ class VectorHasher {
     return *reinterpret_cast<const T*>(group + offset);
   }
 
-  template <TypeKind Kind>
+  template <bool typeProvidesCustomComparison, TypeKind Kind>
   void hashValues(const SelectivityVector& rows, bool mix, uint64_t* result);
 
   const column_index_t channel_;


### PR DESCRIPTION
Summary:
https://github.com/facebookincubator/velox/pull/11021 introduced the ability for custom types to
provide their own compare and hash semantics.

This change updates TimestampWithTimezone to take advantage of this new feature. It is
represented as a 64-bit integer, but only the top 42 bits of the value, which represent the millis since
epoch in UTC, should be used for the purposes of comparison and hashing.  The bottom 12 bits
which represent the timezone should be ignored.

Differential Revision: D62906383
