### PR TITLE
Add Query Trace Deleter

### DIFF
--- a/velox/exec/trace/CMakeLists.txt
+++ b/velox/exec/trace/CMakeLists.txt
@@ -17,7 +17,8 @@ velox_add_library(
   QueryMetadataWriter.cpp
   QueryTraceConfig.cpp
   QueryDataWriter.cpp
-  QueryTraceUtil.cpp)
+  QueryTraceUtil.cpp
+  QueryDataDeleter.cpp)
 
 velox_link_libraries(
   velox_query_trace_exec

--- a/velox/exec/trace/QueryDataDeleter.cpp
+++ b/velox/exec/trace/QueryDataDeleter.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/trace/QueryDataDeleter.h"
+
+#include <folly/FileUtil.h>
+#include <filesystem>
+
+namespace facebook::velox::exec::trace {
+QueryDataDeleter::QueryDataDeleter() {
+  deleteFileExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(
+      1, std::make_shared<folly::NamedThreadFactory>("QueryDataDeleter"));
+}
+
+void QueryDataDeleter::asyncDeleteDir(const std::string& dirPath) {
+  if (std::filesystem::exists(dirPath)) {
+    deleteFileExecutor_->add([dirPath] {
+      if (std::filesystem::exists(dirPath)) {
+        LOG(INFO) << "QueryDataDeleter removing all files from " << dirPath;
+        try {
+          auto n = std::filesystem::remove_all(dirPath);
+          LOG(INFO) << "QueryDataDeleter has removed " << n << " files.";
+        } catch (...) {
+          // Since the deletion of the directory is performed asynchronously,
+          // the exception thrown will not be received by the outside, and this
+          // exception has no other bad impact, so it can be ignored directly.
+          LOG(WARNING) << "QueryDataDeleter failed to remove all trace files.";
+        }
+      }
+    });
+  }
+}
+
+QueryDataDeleter* QueryDataDeleter::instance() {
+  static std::unique_ptr<QueryDataDeleter> instance =
+      std::make_unique<QueryDataDeleter>();
+  return instance.get();
+}
+} // namespace facebook::velox::exec::trace

--- a/velox/exec/trace/QueryDataDeleter.h
+++ b/velox/exec/trace/QueryDataDeleter.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/executors/IOThreadPoolExecutor.h>
+
+namespace facebook::velox::exec::trace {
+class QueryDataDeleter {
+ public:
+  QueryDataDeleter();
+  static QueryDataDeleter* instance();
+
+  // On the same node, multiple tasks of one single query may delete old files
+  // concurrently, which further leads to deleting failure. To solve this
+  // problem, we submit the deletion task to a thread pool with only a single
+  // thread, so that all concurrent tasks will be executed sequentially.
+  void asyncDeleteDir(const std::string& dirPath);
+
+ private:
+  std::unique_ptr<folly::IOThreadPoolExecutor> deleteFileExecutor_;
+};
+} // namespace facebook::velox::exec::trace

--- a/velox/exec/trace/test/QueryTraceTest.cpp
+++ b/velox/exec/trace/test/QueryTraceTest.cpp
@@ -24,6 +24,7 @@
 #include "velox/exec/tests/utils/ArbitratorTestUtil.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/exec/trace/QueryDataDeleter.h"
 #include "velox/exec/trace/QueryDataReader.h"
 #include "velox/exec/trace/QueryDataWriter.h"
 #include "velox/exec/trace/QueryMetadataReader.h"
@@ -129,6 +130,24 @@ TEST_F(QueryTracerTest, traceData) {
     ++numOutputVectors;
   }
   ASSERT_EQ(numOutputVectors, inputVectors.size());
+}
+
+TEST_F(QueryTracerTest, deleteData) {
+  const auto rowType = generateTypes(5);
+  RowVectorPtr inputVector = vectorFuzzer_.fuzzInputRow(rowType);
+
+  const auto dirPath = "/tmp/velox_test_delete_trace_data";
+  bool createRes = std::filesystem::create_directory(dirPath);
+  ASSERT_TRUE(createRes);
+
+  auto writer = trace::QueryDataWriter(dirPath, pool());
+  writer.write(inputVector);
+  writer.finish();
+
+  const auto deleter = trace::QueryDataDeleter::instance();
+  deleter->asyncDeleteDir(dirPath);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  ASSERT_FALSE(std::filesystem::exists(dirPath));
 }
 
 TEST_F(QueryTracerTest, traceMetadata) {


### PR DESCRIPTION
Add a query trace deleter to delete all generated trace data in
`query_trace_dir` and avoid manually deleting them on each node of 
clusters. Note that for the same `query_trace_dir`, the generation and
deletion of trace files should not occur concurrently to avoid potential
conflicts or issues.

Part of https://github.com/facebookincubator/velox/issues/9668