### PR TITLE
Refactor Confusing Dwrf Reader RowNumber Method

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -588,6 +588,17 @@ int64_t DwrfRowReader::nextRowNumber() {
   return kAtEnd;
 }
 
+uint64_t DwrfRowReader::rowNumber() {
+  const auto nextRow = nextRowNumber();
+  if (nextRow != kAtEnd) {
+    return nextRow;
+  }
+  if (isEmptyFile()) {
+    return 0;
+  }
+  return getReader().footer().numberOfRows();
+}
+
 int64_t DwrfRowReader::nextReadSize(uint64_t size) {
   VELOX_DCHECK_GT(size, 0);
   if (nextRowNumber() == kAtEnd) {

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -79,9 +79,7 @@ class DwrfRowReader : public StrideIndexProvider,
     return selectedSchema_;
   }
 
-  uint64_t rowNumber() const {
-    return previousRow_;
-  }
+  uint64_t rowNumber();
 
   uint64_t seekToRow(uint64_t rowNumber);
 


### PR DESCRIPTION
Summary: We noticed that the `RowNumber` method in Dwrf reader produces two different outputs based on when it is called. It returns the current position of the reader after a seek operation and then the previous position of the reader before a `next` read operation was called. This makes it almost unusable without an understanding of its underlying implementation. In this diff, we modify it's design to return the current position of the reader for all calls.

Differential Revision: D62412793
