### PR TITLE
Refactor time zone

### DIFF
--- a/velox/benchmarks/basic/SimpleCastExpr.cpp
+++ b/velox/benchmarks/basic/SimpleCastExpr.cpp
@@ -102,35 +102,35 @@ TypePtr buildStructType(
 std::unique_ptr<SimpleCastBenchmark> benchmark;
 
 BENCHMARK(castTimestampDateSmall) {
-  benchmark->setAdjustTimestampToTimezone("false");
+  benchmark->setAdjustTimestampToTimeZone("false");
   benchmark->runSmall(TIMESTAMP(), DATE());
 }
 
 BENCHMARK(castTimestampDateMedium) {
-  benchmark->setAdjustTimestampToTimezone("false");
+  benchmark->setAdjustTimestampToTimeZone("false");
   benchmark->runMedium(TIMESTAMP(), DATE());
 }
 
 BENCHMARK(castTimestampDateLarge) {
-  benchmark->setAdjustTimestampToTimezone("false");
+  benchmark->setAdjustTimestampToTimeZone("false");
   benchmark->runLarge(TIMESTAMP(), DATE());
 }
 
 BENCHMARK(castTimestampDateAdjustTimeZoneSmall) {
-  benchmark->setTimezone("America/Los_Angeles");
-  benchmark->setAdjustTimestampToTimezone("true");
+  benchmark->setTimeZone("America/Los_Angeles");
+  benchmark->setAdjustTimestampToTimeZone("true");
   benchmark->runSmall(TIMESTAMP(), DATE());
 }
 
 BENCHMARK(castTimestampDateAdjustTimeZoneMedium) {
-  benchmark->setTimezone("America/Los_Angeles");
-  benchmark->setAdjustTimestampToTimezone("true");
+  benchmark->setTimeZone("America/Los_Angeles");
+  benchmark->setAdjustTimestampToTimeZone("true");
   benchmark->runMedium(TIMESTAMP(), DATE());
 }
 
 BENCHMARK(castTimestampDateAdjustTimeZoneLarge) {
-  benchmark->setTimezone("America/Los_Angeles");
-  benchmark->setAdjustTimestampToTimezone("true");
+  benchmark->setTimeZone("America/Los_Angeles");
+  benchmark->setAdjustTimestampToTimeZone("true");
   benchmark->runLarge(TIMESTAMP(), DATE());
 }
 

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -282,7 +282,7 @@ class ConnectorQueryCtx {
         taskId_(taskId),
         driverId_(driverId),
         planNodeId_(planNodeId),
-        sessionTimezone_(sessionTimezone),
+        sessionTimeZone_(sessionTimezone),
         cancellationToken_(std::move(cancellationToken)) {
     VELOX_CHECK_NOT_NULL(sessionProperties);
   }
@@ -344,11 +344,11 @@ class ConnectorQueryCtx {
     return planNodeId_;
   }
 
-  /// Session timezone used for reading Timestamp. Stores a string with the
-  /// actual timezone name. If the session timezone is not set in the
+  /// Session time zone used for reading Timestamp. Stores a string with the
+  /// actual time zone name. If the session time zone is not set in the
   /// QueryConfig, it will return an empty string.
-  const std::string& sessionTimezone() const {
-    return sessionTimezone_;
+  const std::string& sessionTimeZone() const {
+    return sessionTimeZone_;
   }
 
   /// Returns the cancellation token associated with this task.
@@ -377,7 +377,7 @@ class ConnectorQueryCtx {
   const std::string taskId_;
   const int driverId_;
   const std::string planNodeId_;
-  const std::string sessionTimezone_;
+  const std::string sessionTimeZone_;
   const folly::CancellationToken cancellationToken_;
   bool selectiveNimbleReaderEnabled_{false};
 };

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -558,10 +558,10 @@ void configureReaderOptions(
   readerOptions.setPrefetchRowGroups(hiveConfig->prefetchRowGroups());
   readerOptions.setNoCacheRetention(
       hiveConfig->cacheNoRetention(sessionProperties));
-  const auto& sessionTzName = connectorQueryCtx->sessionTimezone();
+  const auto& sessionTzName = connectorQueryCtx->sessionTimeZone();
   if (!sessionTzName.empty()) {
-    const auto timezone = tz::locateZone(sessionTzName);
-    readerOptions.setSessionTimezone(timezone);
+    const auto timeZone = tz::locateZone(sessionTzName);
+    readerOptions.setSessionTimezone(timeZone);
   }
   readerOptions.setSelectiveNimbleReaderEnabled(
       connectorQueryCtx->selectiveNimbleReaderEnabled());
@@ -884,8 +884,8 @@ std::optional<TimestampUnit> getTimestampUnit(
 std::optional<std::string> getTimestampTimeZone(
     const config::ConfigBase& config,
     const char* configKey) {
-  if (const auto timezone = config.get<std::string>(configKey)) {
-    return timezone.value();
+  if (const auto timeZone = config.get<std::string>(configKey)) {
+    return timeZone.value();
   }
   return std::nullopt;
 }

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -55,7 +55,7 @@ VectorPtr newConstantFromString(
                       VELOX_USER_FAIL("{}", status.message());
                     });
     if constexpr (kind == TypeKind::TIMESTAMP) {
-      copy.toGMT(Timestamp::defaultTimezone());
+      copy.toGMT(Timestamp::defaultTimeZone());
     }
     return std::make_shared<ConstantVector<T>>(
         pool, size, false, type, std::move(copy));

--- a/velox/core/QueryConfig.cpp
+++ b/velox/core/QueryConfig.cpp
@@ -35,7 +35,7 @@ QueryConfig::QueryConfig(std::unordered_map<std::string, std::string>&& values)
 }
 
 void QueryConfig::validateConfig() {
-  // Validate if timezone name can be recognized.
+  // Validate if time zone name can be recognized.
   if (config_->valueExists(QueryConfig::kSessionTimezone)) {
     VELOX_USER_CHECK(
         tz::getTimeZoneID(

--- a/velox/docs/develop/scalar-functions.rst
+++ b/velox/docs/develop/scalar-functions.rst
@@ -310,7 +310,7 @@ Here is an example of a zero-copy function:
 Access to Session Properties and Constant Inputs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Some functions require access to session properties such as session’s timezone.
+Some functions require access to session properties such as session’s time zone.
 Some examples are the :func:`day`, :func:`hour`, and :func:`minute` Presto
 functions. Other functions could benefit from pre-processing some of the
 constant inputs, e.g. compile regular expression patterns or parse date and

--- a/velox/docs/develop/types.rst
+++ b/velox/docs/develop/types.rst
@@ -175,12 +175,12 @@ IPADDRESS                 HUGEINT
 ========================  =====================
 
 TIMESTAMP WITH TIME ZONE represents a time point in milliseconds precision
-from UNIX epoch with timezone information. Its physical type is BIGINT.
+from UNIX epoch with time zone information. Its physical type is BIGINT.
 The high 52 bits of bigint store signed integer for milliseconds in UTC.
 Supported range of milliseconds is [0xFFF8000000000000L, 0x7FFFFFFFFFFFF]
 (or [-69387-04-22T03:45:14.752, 73326-09-11T20:14:45.247]). The low 12 bits
-store timezone ID. Supported range of timezone ID is [1, 1680].
-The definition of timezone IDs can be found in ``TimeZoneDatabase.cpp``.
+store time zone ID. Supported range of time zone ID is [1, 1680].
+The definition of time zone IDs can be found in ``TimeZoneDatabase.cpp``.
 
 IPADDRESS represents an IPV6 or IPV4 formatted IPV6 address. Its physical
 type is HUGEINT. The format that the address is stored in is defined as part of `(RFC 4291#section-2.5.5.2) <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.5.5.2>`_

--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -58,13 +58,13 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
-     - 
+     -
      -
      -
      -
      -
      - Y
-     - 
+     -
    * - smallint
      - Y
      - Y
@@ -74,13 +74,13 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
-     - 
+     -
      -
      -
      -
      -
      - Y
-     - 
+     -
    * - integer
      - Y
      - Y
@@ -90,13 +90,13 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
-     - 
+     -
      -
      -
      -
      -
      - Y
-     - 
+     -
    * - bigint
      - Y
      - Y
@@ -106,13 +106,13 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
-     - 
+     -
      -
      -
      -
      -
      - Y
-     - 
+     -
    * - boolean
      - Y
      - Y
@@ -122,13 +122,13 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
-     - 
+     -
      -
      -
      -
      -
      - Y
-     - 
+     -
    * - real
      - Y
      - Y
@@ -138,13 +138,13 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
-     - 
+     -
      -
      -
      -
      -
      - Y
-     - 
+     -
    * - double
      - Y
      - Y
@@ -154,13 +154,13 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
-     - 
+     -
      -
      -
      -
      -
      - Y
-     - 
+     -
    * - varchar
      - Y
      - Y
@@ -170,7 +170,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
-     - 
+     -
      - Y
      - Y
      - Y
@@ -178,20 +178,20 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
    * - varbinary
-     - 
-     - 
-     - 
-     - 
-     - 
-     - 
-     - 
-     - 
-     - 
-     - 
-     - 
-     - 
      -
-     - 
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+     -
      - Y
    * - timestamp
      -
@@ -202,13 +202,13 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      - Y
-     - 
+     -
      - Y
      - Y
      - Y
      -
      -
-     - 
+     -
    * - timestamp with time zone
      -
      -
@@ -218,7 +218,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      - Y
-     - 
+     -
      - Y
      -
      - Y
@@ -234,7 +234,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      - Y
-     - 
+     -
      - Y
      - Y
      -
@@ -250,7 +250,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      - Y
-     - 
+     -
      -
      -
      -
@@ -266,7 +266,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
-     - 
+     -
      -
      -
      -
@@ -274,21 +274,21 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      -
    * - ipaddress
-     - 
-     - 
-     - 
-     - 
-     - 
-     - 
-     - 
+     -
+     -
+     -
+     -
+     -
+     -
+     -
      - Y
      - Y
      -
      -
      -
      -
-     - 
-     - 
+     -
+     -
 
 Cast to Integral Types
 ----------------------
@@ -743,12 +743,12 @@ Invalid example:
 
   SELECT cast('2012-Oct-23' as timestamp); -- Invalid argument
 
-Optionally, strings may also contain timezone information at the end. Timezone
+Optionally, strings may also contain time zone information at the end. Time zone
 information may be offsets in the format `+01:00` or `-02:00`, for example, or
-timezone names, like `UTC`, `Z`, `America/Los_Angeles` and others,
+time zone names, like `UTC`, `Z`, `America/Los_Angeles` and others,
 `as defined here <https://github.com/facebookincubator/velox/blob/main/velox/type/tz/TimeZoneDatabase.cpp>`_.
 
-For example, these strings contain valid timezone information:
+For example, these strings contain valid time zone information:
 
 ::
 
@@ -756,12 +756,12 @@ For example, these strings contain valid timezone information:
   SELECT cast('1970-01-01 00:00:00 UTC' as timestamp);
   SELECT cast('1970-01-01 00:00:00 America/Sao_Paulo' as timestamp);
 
-If timezone information is specified in the string, the returned timestamp
-is adjusted to the corresponding timezone. Otherwise, the timestamp is
-assumed to be in the client session timezone, and adjusted accordingly
+If time zone information is specified in the string, the returned timestamp
+is adjusted to the corresponding time zone. Otherwise, the timestamp is
+assumed to be in the client session time zone, and adjusted accordingly
 based on the value of `adjust_timestamp_to_session_timezone`, as described below.
 
-The space between the hour and timezone definition is optional.
+The space between the hour and time zone definition is optional.
 
 ::
 
@@ -787,10 +787,10 @@ From TIMESTAMP WITH TIME ZONE
 
 The results depend on whether configuration property `adjust_timestamp_to_session_timezone` is set or not.
 
-If set to true, input timezone is ignored and timestamp is returned as is. For example,
+If set to true, input time zone is ignored and timestamp is returned as is. For example,
 "1970-01-01 00:00:00.000 America/Los_Angeles" becomes "1970-01-01 08:00:00.000".
 
-Otherwise, timestamp is shifted by the offset of the timezone. For example,
+Otherwise, timestamp is shifted by the offset of the time zone. For example,
 "1970-01-01 00:00:00.000 America/Los_Angeles" becomes "1970-01-01 00:00:00.000".
 
 Valid examples

--- a/velox/docs/functions/presto/datetime.rst
+++ b/velox/docs/functions/presto/datetime.rst
@@ -297,7 +297,7 @@ a format string compatible with JodaTime’s `DateTimeFormat
 pattern format. The symbols currently supported are ``y``, ``Y``, ``M`` , ``d``,
 ``H``, ``m``, ``s``, ``S``, ``z`` and ``Z``.
 
-``z`` represents a timezone name (3-letter format), and ``Z`` a timezone offset
+``z`` represents a time zone name (3-letter format), and ``Z`` a time zone offset
 specified using the format ``+00``, ``+00:00`` or ``+0000`` (or ``-``). ``Z``
 also accepts ``UTC``,  ``UCT``, ``GMT``, and ``GMT0`` as valid representations
 of GMT.
@@ -458,11 +458,11 @@ It can be interpreted as `2014-11-02 01:30:00 PDT`, or `2014-11-02 01:30:00 PST`
 `2014-11-02 08:30:00 UTC` or `2014-11-02 09:30:00 UTC` respectively. The former one is
 picked to be consistent with Presto.
 
-**Timezone Name Parsing**: When parsing strings that contain timezone names, the
-list of supported timezones follow the definition `here
+**Time Zone Name Parsing**: When parsing strings that contain time zone names, the
+list of supported time zones follow the definition `here
 <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>`_.
 
-**Timezone Conversion**: The ``AT TIME ZONE`` operator sets the time zone of a timestamp: ::
+**Time Zone Conversion**: The ``AT TIME ZONE`` operator sets the time zone of a timestamp: ::
 
         SELECT timestamp '2012-10-31 01:00 UTC';
         -- 2012-10-31 01:00:00.000 UTC

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -80,7 +80,7 @@ These functions support TIMESTAMP and DATE input types.
 
 .. spark:function:: from_unixtime(unixTime, format) -> string
 
-    Adjusts ``unixTime`` (elapsed seconds since UNIX epoch) to configured session timezone, then
+    Adjusts ``unixTime`` (elapsed seconds since UNIX epoch) to configured session time zone, then
     converts it to a formatted time string according to ``format``. Only supports BIGINT type for
     ``unixTime``.
     `Valid patterns for date format
@@ -101,7 +101,7 @@ These functions support TIMESTAMP and DATE input types.
 
 .. spark:function:: from_utc_timestamp(timestamp, string) -> timestamp
 
-    Returns the timestamp value from UTC timezone to the given timezone. ::
+    Returns the timestamp value from UTC time zone to the given time zone. ::
 
         SELECT from_utc_timestamp('2015-07-24 07:00:00', 'America/Los_Angeles'); -- '2015-07-24 00:00:00'
 
@@ -252,7 +252,7 @@ These functions support TIMESTAMP and DATE input types.
 
 .. spark:function:: to_utc_timestamp(timestamp, string) -> timestamp
 
-    Returns the timestamp value from the given timezone to UTC timezone. ::
+    Returns the timestamp value from the given time zone to UTC time zone. ::
 
         SELECT to_utc_timestamp('2015-07-24 00:00:00', 'America/Los_Angeles'); -- '2015-07-24 07:00:00'
 
@@ -278,7 +278,7 @@ These functions support TIMESTAMP and DATE input types.
         SELECT unix_millis('1970-01-01 00:00:01'); -- 1000
 
 .. spark:function:: unix_seconds(timestamp) -> bigint
-    
+
     Returns the number of seconds since 1970-01-01 00:00:00 UTC. ::
 
         SELECT unix_seconds('1970-01-01 00:00:01'); -- 1
@@ -290,7 +290,7 @@ These functions support TIMESTAMP and DATE input types.
 .. spark:function:: unix_timestamp(string) -> integer
    :noindex:
 
-    Returns the UNIX timestamp of time specified by ``string``. Assumes the 
+    Returns the UNIX timestamp of time specified by ``string``. Assumes the
     format ``yyyy-MM-dd HH:mm:ss``. Returns null if ``string`` does not match
     ``format``.
 

--- a/velox/dwio/common/IntCodecCommon.h
+++ b/velox/dwio/common/IntCodecCommon.h
@@ -28,9 +28,9 @@ constexpr uint64_t BASE_128_MASK = 0x7f;
 constexpr uint64_t BASE_256_MASK = 0xff;
 constexpr __int128_t INT128_BASE_256_MASK = 0xff;
 
-// Timezone constants
+// Time zone constants
 constexpr int64_t SECONDS_PER_HOUR = 60 * 60;
-// Timezone offset of PST from UTC.
+// Time zone offset of PST from UTC.
 constexpr int64_t TIMEZONE_OFFSET = (8 * SECONDS_PER_HOUR);
 // ORC base epoch: 2015-01-01 00:00:00 in UTC, as seconds from UNIX epoch.
 constexpr int64_t UTC_EPOCH_OFFSET = 1420070400;

--- a/velox/examples/SimpleFunctions.cpp
+++ b/velox/examples/SimpleFunctions.cpp
@@ -344,7 +344,7 @@ struct MyRegexpMatchFunction {
     }
 
     // Optionally, one could also inspect the session configs in `QueryConfig`.
-    // One common use case is to initialize user supplied session timezone for
+    // One common use case is to initialize user supplied session time zone for
     // date/time manipulation functions.
   }
 

--- a/velox/exec/fuzzer/AggregationFuzzerOptions.h
+++ b/velox/exec/fuzzer/AggregationFuzzerOptions.h
@@ -55,7 +55,7 @@ struct AggregationFuzzerOptions {
       VectorFuzzer::Options::TimestampPrecision::kMilliSeconds};
 
   /// A set of configuration properties to use when running query plans.
-  /// Could be used to specify timezone or enable/disable settings that
+  /// Could be used to specify time zone or enable/disable settings that
   /// affect semantics of individual aggregate functions.
   std::unordered_map<std::string, std::string> queryConfigs;
 

--- a/velox/exec/tests/FunctionResolutionTest.cpp
+++ b/velox/exec/tests/FunctionResolutionTest.cpp
@@ -306,13 +306,13 @@ TEST_F(FunctionResolutionTest, resolveCustomTypeJson) {
 template <typename T>
 struct FuncTimestampWithTimeZone {
   VELOX_DEFINE_FUNCTION_TYPES(T);
-  bool call(out_type<TimestampWithTimezone>&) {
+  bool call(out_type<TimestampWithTimeZone>&) {
     return false;
   }
 };
 
 TEST_F(FunctionResolutionTest, resolveCustomTypeTimestampWithTimeZone) {
-  registerFunction<FuncTimestampWithTimeZone, TimestampWithTimezone>(
+  registerFunction<FuncTimestampWithTimeZone, TimestampWithTimeZone>(
       {"f_timestampzone"});
 
   auto type =

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -4684,7 +4684,7 @@ TEST_F(TableScanTest, timestampPartitionKey) {
                                  folly::identity, [&](const Status& status) {
                                    VELOX_USER_FAIL("{}", status.message());
                                  });
-                t.toGMT(Timestamp::defaultTimezone());
+                t.toGMT(Timestamp::defaultTimeZone());
                 return t;
               }),
       });

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -871,10 +871,10 @@ VectorPtr CastExpr::applyTimestampToVarcharCast(
   char* rawBuffer = buffer->asMutable<char>() + buffer->size();
 
   applyToSelectedNoThrowLocal(context, rows, result, [&](vector_size_t row) {
-    // Adjust input timestamp according the session timezone.
+    // Adjust input timestamp according the session time zone.
     Timestamp inputValue(simpleInput->valueAt(row));
     if (options.timeZone) {
-      inputValue.toTimezone(*(options.timeZone));
+      inputValue.toTimeZone(*(options.timeZone));
     }
     const auto stringView =
         Timestamp::tsToStringView(inputValue, options, rawBuffer);

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -40,7 +40,7 @@ PrestoCastHooks::PrestoCastHooks(const core::QueryConfig& config)
 
 Expected<Timestamp> PrestoCastHooks::castStringToTimestamp(
     const StringView& view) const {
-  const auto conversionResult = util::fromTimestampWithTimezoneString(
+  const auto conversionResult = util::fromTimestampWithTimeZoneString(
       view.data(),
       view.size(),
       legacyCast_ ? util::TimestampParseMode::kLegacyCast
@@ -51,15 +51,15 @@ Expected<Timestamp> PrestoCastHooks::castStringToTimestamp(
 
   auto result = conversionResult.value();
 
-  // If the parsed string has timezone information, convert the timestamp at
+  // If the parsed string has time zone information, convert the timestamp at
   // GMT at that time. For example, "1970-01-01 00:00:00 -00:01" is 60 seconds
   // at GMT.
   if (result.second != nullptr) {
     result.first.toGMT(*result.second);
 
   }
-  // If no timezone information is available in the input string, check if we
-  // should understand it as being at the session timezone, and if so, convert
+  // If no time zone information is available in the input string, check if we
+  // should understand it as being at the session time zone, and if so, convert
   // to GMT.
   else if (options_.timeZone != nullptr) {
     result.first.toGMT(*options_.timeZone);

--- a/velox/expression/PrestoCastHooks.h
+++ b/velox/expression/PrestoCastHooks.h
@@ -45,7 +45,7 @@ class PrestoCastHooks : public CastHooks {
   // Returns the input as is.
   StringView removeWhiteSpaces(const StringView& view) const override;
 
-  // Returns cast options following 'isLegacyCast' and session timezone.
+  // Returns cast options following 'isLegacyCast' and session time zone.
   const TimestampToStringOptions& timestampToStringOptions() const override;
 
   bool truncate() const override {

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -563,8 +563,8 @@ TEST_F(CastExprTest, stringToTimestamp) {
   };
   testCast<std::string, Timestamp>("timestamp", input, expected);
 
-  // Try with a different session timezone.
-  setTimezone("America/Los_Angeles");
+  // Try with a different session time zone.
+  setTimeZone("America/Los_Angeles");
   input = {
       "1970-01-01 00:00",
       "1970-01-01 00:00 +00:00",
@@ -683,7 +683,7 @@ TEST_F(CastExprTest, timestampToString) {
       });
 
   setLegacyCast(false);
-  setTimezone("America/Los_Angeles");
+  setTimeZone("America/Los_Angeles");
   testCast<Timestamp, std::string>(
       "string",
       {
@@ -759,7 +759,7 @@ TEST_F(CastExprTest, timestampToDate) {
       TIMESTAMP(),
       DATE());
 
-  setTimezone("America/Los_Angeles");
+  setTimeZone("America/Los_Angeles");
   testCast<Timestamp, int32_t>(
       "date",
       inputTimestamps,
@@ -813,11 +813,11 @@ TEST_F(CastExprTest, timestampInvalid) {
 }
 
 TEST_F(CastExprTest, timestampAdjustToTimezone) {
-  // Empty timezone is assumed to be GMT.
+  // Empty time zone is assumed to be GMT.
   testCast<std::string, Timestamp>(
       "timestamp", {"1970-01-01"}, {Timestamp(0, 0)});
 
-  setTimezone("America/Los_Angeles");
+  setTimeZone("America/Los_Angeles");
 
   // Expect unix epochs to be converted to LA timezone (8h offset).
   testCast<std::string, Timestamp>(

--- a/velox/functions/lib/DateTimeFormatter.h
+++ b/velox/functions/lib/DateTimeFormatter.h
@@ -93,10 +93,10 @@ enum class DateTimeFormatSpecifier : uint8_t {
   // Decimal fraction of a second, e.g: The fraction of 00:00:01.987 is 987
   FRACTION_OF_SECOND = 20,
 
-  // Timezone, e.g: "Pacific Standard Time" or "PST"
+  // Time zone, e.g: "Pacific Standard Time" or "PST"
   TIMEZONE = 21,
 
-  // Timezone offset/id, e.g: "-0800", "-08:00" or "America/Los_Angeles"
+  // Time zone offset/id, e.g: "-0800", "-08:00" or "America/Los_Angeles"
   TIMEZONE_OFFSET_ID = 22,
 
   // A literal % character
@@ -142,7 +142,7 @@ struct DateTimeToken {
 
 struct DateTimeResult {
   Timestamp timestamp;
-  int64_t timezoneId{-1};
+  int64_t timeZoneId{-1};
 };
 
 /// A user defined formatter that formats/parses time to/from user provided
@@ -175,13 +175,13 @@ class DateTimeFormatter {
   }
 
   // Returns an Expected<DateTimeResult> object containing the parsed
-  // Timestamp and timezone information if parsing succeeded. Otherwise,
+  // Timestamp and time zone information if parsing succeeded. Otherwise,
   // Returns Unexpected with UserError status if parsing failed.
   Expected<DateTimeResult> parse(const std::string_view& input) const;
 
   /// Returns max size of the formatted string. Can be used to preallocate
   /// memory before calling format() to avoid extra copy.
-  uint32_t maxResultSize(const tz::TimeZone* timezone) const;
+  uint32_t maxResultSize(const tz::TimeZone* timeZone) const;
 
   /// Result buffer is pre-allocated according to maxResultSize.
   /// Returns actual size.
@@ -191,7 +191,7 @@ class DateTimeFormatter {
   /// allowed in converting to milliseconds.
   int32_t format(
       const Timestamp& timestamp,
-      const tz::TimeZone* timezone,
+      const tz::TimeZone* timeZone,
       const uint32_t maxResultSize,
       char* result,
       bool allowOverflow = false) const;

--- a/velox/functions/lib/TimeUtils.h
+++ b/velox/functions/lib/TimeUtils.h
@@ -40,7 +40,7 @@ FOLLY_ALWAYS_INLINE const tz::TimeZone* getTimeZoneFromConfig(
 FOLLY_ALWAYS_INLINE int64_t
 getSeconds(Timestamp timestamp, const tz::TimeZone* timeZone) {
   if (timeZone != nullptr) {
-    timestamp.toTimezone(*timeZone);
+    timestamp.toTimeZone(*timeZone);
     return timestamp.getSeconds();
   } else {
     return timestamp.getSeconds();
@@ -93,7 +93,7 @@ FOLLY_ALWAYS_INLINE int32_t getDayOfYear(const std::tm& time) {
 }
 
 template <typename T>
-struct InitSessionTimezone {
+struct InitSessionTimeZone {
   VELOX_DEFINE_FUNCTION_TYPES(T);
   const tz::TimeZone* timeZone_{nullptr};
 

--- a/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
+++ b/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
@@ -31,13 +31,13 @@ class FunctionBenchmarkBase {
     exec::registerFunctionCallToSpecialForms();
   }
 
-  void setTimezone(const std::string& value) {
+  void setTimeZone(const std::string& value) {
     queryCtx_->testingOverrideConfigUnsafe({
         {core::QueryConfig::kSessionTimezone, value},
     });
   }
 
-  void setAdjustTimestampToTimezone(const std::string& value) {
+  void setAdjustTimestampToTimeZone(const std::string& value) {
     queryCtx_->testingOverrideConfigUnsafe(
         {{core::QueryConfig::kAdjustTimestampToTimezone, value}});
   }

--- a/velox/functions/prestosql/ArrayFunctions.h
+++ b/velox/functions/prestosql/ArrayFunctions.h
@@ -202,7 +202,7 @@ struct ArrayJoinFunction {
   void writeValue(out_type<velox::Varchar>& result, const Timestamp& value) {
     Timestamp inputValue{value};
     if (options_.timeZone) {
-      inputValue.toTimezone(*(options_.timeZone));
+      inputValue.toTimeZone(*(options_.timeZone));
     }
     result += inputValue.toString(options_);
   }

--- a/velox/functions/prestosql/Comparisons.h
+++ b/velox/functions/prestosql/Comparisons.h
@@ -39,12 +39,12 @@ namespace facebook::velox::functions {
 
 #define VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(Name, tsExpr, TResult) \
   template <typename T>                                                       \
-  struct Name##TimestampWithTimezone {                                        \
+  struct Name##TimestampWithTimeZone {                                        \
     VELOX_DEFINE_FUNCTION_TYPES(T);                                           \
     FOLLY_ALWAYS_INLINE void call(                                            \
         bool& result,                                                         \
-        const arg_type<TimestampWithTimezone>& lhs,                           \
-        const arg_type<TimestampWithTimezone>& rhs) {                         \
+        const arg_type<TimestampWithTimeZone>& lhs,                           \
+        const arg_type<TimestampWithTimeZone>& rhs) {                         \
       result = (tsExpr);                                                      \
     }                                                                         \
   };
@@ -68,19 +68,23 @@ VELOX_GEN_BINARY_EXPR(
 
 VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(
     LtFunction,
-    unpackMillisUtc(lhs) < unpackMillisUtc(rhs),
+    TimestampWithTimeZoneType::unpackMillisUtc(lhs) <
+        TimestampWithTimeZoneType::unpackMillisUtc(rhs),
     bool);
 VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(
     GtFunction,
-    unpackMillisUtc(lhs) > unpackMillisUtc(rhs),
+    TimestampWithTimeZoneType::unpackMillisUtc(lhs) >
+        TimestampWithTimeZoneType::unpackMillisUtc(rhs),
     bool);
 VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(
     LteFunction,
-    unpackMillisUtc(lhs) <= unpackMillisUtc(rhs),
+    TimestampWithTimeZoneType::unpackMillisUtc(lhs) <=
+        TimestampWithTimeZoneType::unpackMillisUtc(rhs),
     bool);
 VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(
     GteFunction,
-    unpackMillisUtc(lhs) >= unpackMillisUtc(rhs),
+    TimestampWithTimeZoneType::unpackMillisUtc(lhs) >=
+        TimestampWithTimeZoneType::unpackMillisUtc(rhs),
     bool);
 
 #undef VELOX_GEN_BINARY_EXPR
@@ -141,14 +145,15 @@ struct EqFunction {
 };
 
 template <typename T>
-struct EqFunctionTimestampWithTimezone {
+struct EqFunctionTimestampWithTimeZone {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   void call(
       bool& result,
-      const arg_type<TimestampWithTimezone>& lhs,
-      const arg_type<TimestampWithTimezone>& rhs) {
-    result = unpackMillisUtc(lhs) == unpackMillisUtc(rhs);
+      const arg_type<TimestampWithTimeZone>& lhs,
+      const arg_type<TimestampWithTimeZone>& rhs) {
+    result = TimestampWithTimeZoneType::unpackMillisUtc(lhs) ==
+        TimestampWithTimeZoneType::unpackMillisUtc(rhs);
   }
 };
 
@@ -181,14 +186,15 @@ struct NeqFunction {
 };
 
 template <typename T>
-struct NeqFunctionTimestampWithTimezone {
+struct NeqFunctionTimestampWithTimeZone {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   void call(
       bool& result,
-      const arg_type<TimestampWithTimezone>& lhs,
-      const arg_type<TimestampWithTimezone>& rhs) {
-    result = unpackMillisUtc(lhs) != unpackMillisUtc(rhs);
+      const arg_type<TimestampWithTimeZone>& lhs,
+      const arg_type<TimestampWithTimeZone>& rhs) {
+    result = TimestampWithTimeZoneType::unpackMillisUtc(lhs) !=
+        TimestampWithTimeZoneType::unpackMillisUtc(rhs);
   }
 };
 
@@ -208,17 +214,17 @@ struct BetweenFunction {
 };
 
 template <typename TExec>
-struct BetweenFunctionTimestampWithTimezone {
+struct BetweenFunctionTimestampWithTimeZone {
   VELOX_DEFINE_FUNCTION_TYPES(TExec);
 
   void call(
       bool& result,
-      const arg_type<TimestampWithTimezone>& value,
-      const arg_type<TimestampWithTimezone>& low,
-      const arg_type<TimestampWithTimezone>& high) {
-    const auto millis = unpackMillisUtc(value);
-    result =
-        (millis >= unpackMillisUtc(low)) && (millis <= unpackMillisUtc(high));
+      const arg_type<TimestampWithTimeZone>& value,
+      const arg_type<TimestampWithTimeZone>& low,
+      const arg_type<TimestampWithTimeZone>& high) {
+    const auto millis = TimestampWithTimeZoneType::unpackMillisUtc(value);
+    result = (millis >= TimestampWithTimeZoneType::unpackMillisUtc(low)) &&
+        (millis <= TimestampWithTimeZoneType::unpackMillisUtc(high));
   }
 };
 

--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -210,20 +210,23 @@ FOLLY_ALWAYS_INLINE Timestamp addToTimestamp(
     return addToTimestamp(timestamp, unit, value);
   } else {
     Timestamp zonedTimestamp = timestamp;
-    zonedTimestamp.toTimezone(*timeZone);
+    zonedTimestamp.toTimeZone(*timeZone);
     auto resultTimestamp = addToTimestamp(zonedTimestamp, unit, value);
     resultTimestamp.toGMT(*timeZone);
     return resultTimestamp;
   }
 }
 
-FOLLY_ALWAYS_INLINE int64_t addToTimestampWithTimezone(
-    int64_t timestampWithTimezone,
+FOLLY_ALWAYS_INLINE int64_t addToTimestampWithTimeZone(
+    int64_t timestampWithTimeZone,
     const DateTimeUnit unit,
     const int32_t value) {
-  auto timestamp = unpackTimestampUtc(timestampWithTimezone);
+  auto timestamp =
+      TimestampWithTimeZoneType::unpackTimestampUtc(timestampWithTimeZone);
   auto finalTimeStamp = addToTimestamp(timestamp, unit, (int32_t)value);
-  return pack(finalTimeStamp, unpackZoneKeyId(timestampWithTimezone));
+  return TimestampWithTimeZoneType::pack(
+      finalTimeStamp,
+      TimestampWithTimeZoneType::unpackTimeZoneId(timestampWithTimeZone));
 }
 
 FOLLY_ALWAYS_INLINE int64_t diffTimestamp(

--- a/velox/functions/prestosql/GreatestLeast.h
+++ b/velox/functions/prestosql/GreatestLeast.h
@@ -93,24 +93,26 @@ struct ExtremeValueFunction {
 };
 
 template <typename TExec, bool isLeast>
-struct ExtremeValueFunctionTimestampWithTimezone {
+struct ExtremeValueFunctionTimestampWithTimeZone {
   VELOX_DEFINE_FUNCTION_TYPES(TExec);
 
   FOLLY_ALWAYS_INLINE void call(
-      out_type<TimestampWithTimezone>& result,
-      const arg_type<TimestampWithTimezone>& firstElement,
-      const arg_type<Variadic<TimestampWithTimezone>>& remainingElement) {
+      out_type<TimestampWithTimeZone>& result,
+      const arg_type<TimestampWithTimeZone>& firstElement,
+      const arg_type<Variadic<TimestampWithTimeZone>>& remainingElement) {
     auto currentValue = firstElement;
 
     for (auto element : remainingElement) {
       auto candidateValue = element.value();
 
       if constexpr (isLeast) {
-        if (unpackMillisUtc(candidateValue) < unpackMillisUtc(currentValue)) {
+        if (TimestampWithTimeZoneType::unpackMillisUtc(candidateValue) <
+            TimestampWithTimeZoneType::unpackMillisUtc(currentValue)) {
           currentValue = candidateValue;
         }
       } else {
-        if (unpackMillisUtc(candidateValue) > unpackMillisUtc(currentValue)) {
+        if (TimestampWithTimeZoneType::unpackMillisUtc(candidateValue) >
+            TimestampWithTimeZoneType::unpackMillisUtc(currentValue)) {
           currentValue = candidateValue;
         }
       }
@@ -125,14 +127,14 @@ template <typename TExec, typename T>
 using LeastFunction = details::ExtremeValueFunction<TExec, T, true>;
 
 template <typename TExec>
-using LeastFunctionTimestampWithTimezone =
-    details::ExtremeValueFunctionTimestampWithTimezone<TExec, true>;
+using LeastFunctionTimestampWithTimeZone =
+    details::ExtremeValueFunctionTimestampWithTimeZone<TExec, true>;
 
 template <typename TExec, typename T>
 using GreatestFunction = details::ExtremeValueFunction<TExec, T, false>;
 
 template <typename TExec>
-using GreatestFunctionTimestampWithTimezone =
-    details::ExtremeValueFunctionTimestampWithTimezone<TExec, false>;
+using GreatestFunctionTimestampWithTimeZone =
+    details::ExtremeValueFunctionTimestampWithTimeZone<TExec, false>;
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/aggregates/PrestoHasher.cpp
+++ b/velox/functions/prestosql/aggregates/PrestoHasher.cpp
@@ -142,7 +142,8 @@ FOLLY_ALWAYS_INLINE void PrestoHasher::hash<TypeKind::BIGINT>(
   } else if (isTimestampWithTimeZoneType(vector_->base()->type())) {
     // Hash only timestamp value.
     applyHashFunction(rows, *vector_.get(), hashes, [&](auto row) {
-      return hashInteger(unpackMillisUtc(vector_->valueAt<int64_t>(row)));
+      return hashInteger(TimestampWithTimeZoneType::unpackMillisUtc(
+          vector_->valueAt<int64_t>(row)));
     });
   } else {
     applyHashFunction(rows, *vector_.get(), hashes, [&](auto row) {

--- a/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
@@ -369,14 +369,16 @@ TEST_F(ChecksumAggregateTest, globalAggregationNoData) {
   assertQuery(agg, "VALUES (CAST(NULL AS VARCHAR))");
 }
 
-TEST_F(ChecksumAggregateTest, timestampWithTimezone) {
-  auto timestampWithTimezone = makeFlatVector<int64_t>(
+TEST_F(ChecksumAggregateTest, timestampWithTimeZone) {
+  auto timestampWithTimeZone = makeFlatVector<int64_t>(
       5,
-      [](auto /* row */) { return pack(1639426440000, 0); },
+      [](auto /* row */) {
+        return TimestampWithTimeZoneType::pack(1639426440000, 0);
+      },
       /* isNullAt */ nullptr,
       TIMESTAMP_WITH_TIME_ZONE());
 
-  assertChecksum(timestampWithTimezone, "jwqENA0VLZY=");
+  assertChecksum(timestampWithTimeZone, "jwqENA0VLZY=");
 }
 
 TEST_F(ChecksumAggregateTest, unknown) {

--- a/velox/functions/prestosql/aggregates/tests/PrestoHasherTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/PrestoHasherTest.cpp
@@ -390,7 +390,7 @@ TEST_F(PrestoHasherTest, wrongVectorType) {
   ASSERT_ANY_THROW(hasher.hash(vector, rows, hashes));
 }
 
-TEST_F(PrestoHasherTest, timestampWithTimezone) {
+TEST_F(PrestoHasherTest, timestampWithTimeZone) {
   const auto toUnixtimeWithTimeZone =
       [&](const std::vector<std::optional<std::pair<int64_t, std::string>>>&
               timestampWithTimeZones) {
@@ -407,8 +407,9 @@ TEST_F(PrestoHasherTest, timestampWithTimezone) {
             auto timestamp = timestampWithTimeZone.value().first;
             auto tz = timestampWithTimeZone.value().second;
             const int16_t tzid = tz::getTimeZoneID(tz);
-            auto timestampWithTimezone = pack(timestamp, tzid);
-            timestampWithTimeZoneVector.push_back(timestampWithTimezone);
+            auto timestampWithTimeZone =
+                TimestampWithTimeZoneType::pack(timestamp, tzid);
+            timestampWithTimeZoneVector.push_back(timestampWithTimeZone);
             bits::clearNull(rawNulls, i);
           } else {
             timestampWithTimeZoneVector.push_back(std::nullopt);

--- a/velox/functions/prestosql/benchmarks/DateTimeBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/DateTimeBenchmark.cpp
@@ -55,13 +55,13 @@ class HourFunction : public exec::VectorFunction {
     auto rawResults = result->as<FlatVector<int64_t>>()->mutableRawValues();
 
     // Check if we need to adjust the current UTC timestamps to
-    // the user provided session timezone.
+    // the user provided session time zone.
     const auto* timeZone =
         getTimeZoneIfNeeded(context.execCtx()->queryCtx()->queryConfig());
     if (timeZone != nullptr) {
       rows.applyToSelected([&](int row) {
         auto timestamp = timestamps[row];
-        timestamp.toTimezone(*timeZone);
+        timestamp.toTimeZone(*timeZone);
         int64_t seconds = timestamp.getSeconds();
         std::tm dateTime;
         gmtime_r((const time_t*)&seconds, &dateTime);

--- a/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
@@ -31,7 +31,7 @@ void registerNonSimdizableScalar(const std::vector<std::string>& aliases) {
 } // namespace
 
 void registerComparisonFunctions(const std::string& prefix) {
-  // Comparison functions also need TimestampWithTimezoneType,
+  // Comparison functions also need TimestampWithTimeZoneType,
   // independent of DateTimeFunctions
   registerTimestampWithTimeZoneType();
 
@@ -39,51 +39,51 @@ void registerComparisonFunctions(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_eq, prefix + "eq");
   registerFunction<EqFunction, bool, Generic<T1>, Generic<T1>>({prefix + "eq"});
   registerFunction<
-      EqFunctionTimestampWithTimezone,
+      EqFunctionTimestampWithTimeZone,
       bool,
-      TimestampWithTimezone,
-      TimestampWithTimezone>({prefix + "eq"});
+      TimestampWithTimeZone,
+      TimestampWithTimeZone>({prefix + "eq"});
 
   registerNonSimdizableScalar<NeqFunction, bool>({prefix + "neq"});
   VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_neq, prefix + "neq");
   registerFunction<NeqFunction, bool, Generic<T1>, Generic<T1>>(
       {prefix + "neq"});
   registerFunction<
-      NeqFunctionTimestampWithTimezone,
+      NeqFunctionTimestampWithTimeZone,
       bool,
-      TimestampWithTimezone,
-      TimestampWithTimezone>({prefix + "neq"});
+      TimestampWithTimeZone,
+      TimestampWithTimeZone>({prefix + "neq"});
 
   registerNonSimdizableScalar<LtFunction, bool>({prefix + "lt"});
   registerFunction<
-      LtFunctionTimestampWithTimezone,
+      LtFunctionTimestampWithTimeZone,
       bool,
-      TimestampWithTimezone,
-      TimestampWithTimezone>({prefix + "lt"});
+      TimestampWithTimeZone,
+      TimestampWithTimeZone>({prefix + "lt"});
   VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_lt, prefix + "lt");
 
   registerNonSimdizableScalar<GtFunction, bool>({prefix + "gt"});
   registerFunction<
-      GtFunctionTimestampWithTimezone,
+      GtFunctionTimestampWithTimeZone,
       bool,
-      TimestampWithTimezone,
-      TimestampWithTimezone>({prefix + "gt"});
+      TimestampWithTimeZone,
+      TimestampWithTimeZone>({prefix + "gt"});
   VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_gt, prefix + "gt");
 
   registerNonSimdizableScalar<LteFunction, bool>({prefix + "lte"});
   registerFunction<
-      LteFunctionTimestampWithTimezone,
+      LteFunctionTimestampWithTimeZone,
       bool,
-      TimestampWithTimezone,
-      TimestampWithTimezone>({prefix + "lte"});
+      TimestampWithTimeZone,
+      TimestampWithTimeZone>({prefix + "lte"});
   VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_lte, prefix + "lte");
 
   registerNonSimdizableScalar<GteFunction, bool>({prefix + "gte"});
   registerFunction<
-      GteFunctionTimestampWithTimezone,
+      GteFunctionTimestampWithTimeZone,
       bool,
-      TimestampWithTimezone,
-      TimestampWithTimezone>({prefix + "gte"});
+      TimestampWithTimeZone,
+      TimestampWithTimeZone>({prefix + "gte"});
   VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_gte, prefix + "gte");
 
   registerFunction<DistinctFromFunction, bool, Generic<T1>, Generic<T1>>(
@@ -132,11 +132,11 @@ void registerComparisonFunctions(const std::string& prefix) {
       IntervalYearMonth,
       IntervalYearMonth>({prefix + "between"});
   registerFunction<
-      BetweenFunctionTimestampWithTimezone,
+      BetweenFunctionTimestampWithTimeZone,
       bool,
-      TimestampWithTimezone,
-      TimestampWithTimezone,
-      TimestampWithTimezone>({prefix + "between"});
+      TimestampWithTimeZone,
+      TimestampWithTimeZone,
+      TimestampWithTimeZone>({prefix + "between"});
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -24,7 +24,7 @@ namespace {
 // Register timestamp + interval and interval + timestamp
 // functions for specified TTimestamp type and 2 supported interval types
 // (IntervalDayTime and IntervalYearMonth).
-// @tparam TTimestamp Timestamp or TimestampWithTimezone.
+// @tparam TTimestamp Timestamp or TimestampWithTimeZone.
 template <typename TTimestamp>
 void registerTimestampPlusInterval(const std::string& name) {
   registerFunction<
@@ -51,7 +51,7 @@ void registerTimestampPlusInterval(const std::string& name) {
 
 // Register timestamp - IntervalYearMonth and timestamp - IntervalDayTime
 // functions for specified TTimestamp type.
-// @tparam TTimestamp Timestamp or TimestampWithTimezone.
+// @tparam TTimestamp Timestamp or TimestampWithTimeZone.
 template <typename TTimestamp>
 void registerTimestampMinusInterval(const std::string& name) {
   registerFunction<
@@ -70,12 +70,12 @@ void registerFromUnixtime(const std::string& name) {
   registerFunction<FromUnixtimeFunction, Timestamp, double>({name});
   registerFunction<
       FromUnixtimeFunction,
-      TimestampWithTimezone,
+      TimestampWithTimeZone,
       double,
       Varchar>({name});
   registerFunction<
       FromUnixtimeFunction,
-      TimestampWithTimezone,
+      TimestampWithTimeZone,
       double,
       int64_t,
       int64_t>({name});
@@ -85,24 +85,24 @@ void registerSimpleFunctions(const std::string& prefix) {
   // Date time functions.
   registerFunction<ToUnixtimeFunction, double, Timestamp>(
       {prefix + "to_unixtime"});
-  registerFunction<ToUnixtimeFunction, double, TimestampWithTimezone>(
+  registerFunction<ToUnixtimeFunction, double, TimestampWithTimeZone>(
       {prefix + "to_unixtime"});
 
   registerFromUnixtime(prefix + "from_unixtime");
 
   registerFunction<DateFunction, Date, Varchar>({prefix + "date"});
   registerFunction<DateFunction, Date, Timestamp>({prefix + "date"});
-  registerFunction<DateFunction, Date, TimestampWithTimezone>(
+  registerFunction<DateFunction, Date, TimestampWithTimeZone>(
       {prefix + "date"});
-  registerFunction<TimeZoneHourFunction, int64_t, TimestampWithTimezone>(
+  registerFunction<TimeZoneHourFunction, int64_t, TimestampWithTimeZone>(
       {prefix + "timezone_hour"});
 
-  registerFunction<TimeZoneMinuteFunction, int64_t, TimestampWithTimezone>(
+  registerFunction<TimeZoneMinuteFunction, int64_t, TimestampWithTimeZone>(
       {prefix + "timezone_minute"});
 
   registerFunction<YearFunction, int64_t, Timestamp>({prefix + "year"});
   registerFunction<YearFunction, int64_t, Date>({prefix + "year"});
-  registerFunction<YearFunction, int64_t, TimestampWithTimezone>(
+  registerFunction<YearFunction, int64_t, TimestampWithTimeZone>(
       {prefix + "year"});
   registerFunction<YearFromIntervalFunction, int64_t, IntervalYearMonth>(
       {prefix + "year"});
@@ -111,16 +111,16 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "week", prefix + "week_of_year"});
   registerFunction<WeekFunction, int64_t, Date>(
       {prefix + "week", prefix + "week_of_year"});
-  registerFunction<WeekFunction, int64_t, TimestampWithTimezone>(
+  registerFunction<WeekFunction, int64_t, TimestampWithTimeZone>(
       {prefix + "week", prefix + "week_of_year"});
   registerFunction<QuarterFunction, int64_t, Timestamp>({prefix + "quarter"});
   registerFunction<QuarterFunction, int64_t, Date>({prefix + "quarter"});
-  registerFunction<QuarterFunction, int64_t, TimestampWithTimezone>(
+  registerFunction<QuarterFunction, int64_t, TimestampWithTimeZone>(
       {prefix + "quarter"});
 
   registerFunction<MonthFunction, int64_t, Timestamp>({prefix + "month"});
   registerFunction<MonthFunction, int64_t, Date>({prefix + "month"});
-  registerFunction<MonthFunction, int64_t, TimestampWithTimezone>(
+  registerFunction<MonthFunction, int64_t, TimestampWithTimeZone>(
       {prefix + "month"});
   registerFunction<MonthFromIntervalFunction, int64_t, IntervalYearMonth>(
       {prefix + "month"});
@@ -143,8 +143,8 @@ void registerSimpleFunctions(const std::string& prefix) {
 
   registerTimestampPlusInterval<Timestamp>({prefix + "plus"});
   registerTimestampMinusInterval<Timestamp>({prefix + "minus"});
-  registerTimestampPlusInterval<TimestampWithTimezone>({prefix + "plus"});
-  registerTimestampMinusInterval<TimestampWithTimezone>({prefix + "minus"});
+  registerTimestampPlusInterval<TimestampWithTimeZone>({prefix + "plus"});
+  registerTimestampMinusInterval<TimestampWithTimeZone>({prefix + "minus"});
 
   registerFunction<
       TimestampMinusFunction,
@@ -155,33 +155,33 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerFunction<
       TimestampMinusFunction,
       IntervalDayTime,
-      TimestampWithTimezone,
-      TimestampWithTimezone>({prefix + "minus"});
+      TimestampWithTimeZone,
+      TimestampWithTimeZone>({prefix + "minus"});
 
-  registerFunction<DayFunction, int64_t, TimestampWithTimezone>(
+  registerFunction<DayFunction, int64_t, TimestampWithTimeZone>(
       {prefix + "day", prefix + "day_of_month"});
   registerFunction<DayOfWeekFunction, int64_t, Timestamp>(
       {prefix + "dow", prefix + "day_of_week"});
   registerFunction<DayOfWeekFunction, int64_t, Date>(
       {prefix + "dow", prefix + "day_of_week"});
-  registerFunction<DayOfWeekFunction, int64_t, TimestampWithTimezone>(
+  registerFunction<DayOfWeekFunction, int64_t, TimestampWithTimeZone>(
       {prefix + "dow", prefix + "day_of_week"});
   registerFunction<DayOfYearFunction, int64_t, Timestamp>(
       {prefix + "doy", prefix + "day_of_year"});
   registerFunction<DayOfYearFunction, int64_t, Date>(
       {prefix + "doy", prefix + "day_of_year"});
-  registerFunction<DayOfYearFunction, int64_t, TimestampWithTimezone>(
+  registerFunction<DayOfYearFunction, int64_t, TimestampWithTimeZone>(
       {prefix + "doy", prefix + "day_of_year"});
   registerFunction<YearOfWeekFunction, int64_t, Timestamp>(
       {prefix + "yow", prefix + "year_of_week"});
   registerFunction<YearOfWeekFunction, int64_t, Date>(
       {prefix + "yow", prefix + "year_of_week"});
-  registerFunction<YearOfWeekFunction, int64_t, TimestampWithTimezone>(
+  registerFunction<YearOfWeekFunction, int64_t, TimestampWithTimeZone>(
       {prefix + "yow", prefix + "year_of_week"});
 
   registerFunction<HourFunction, int64_t, Timestamp>({prefix + "hour"});
   registerFunction<HourFunction, int64_t, Date>({prefix + "hour"});
-  registerFunction<HourFunction, int64_t, TimestampWithTimezone>(
+  registerFunction<HourFunction, int64_t, TimestampWithTimeZone>(
       {prefix + "hour"});
   registerFunction<HourFromIntervalFunction, int64_t, IntervalDayTime>(
       {prefix + "hour"});
@@ -190,19 +190,19 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "last_day_of_month"});
   registerFunction<LastDayOfMonthFunction, Date, Date>(
       {prefix + "last_day_of_month"});
-  registerFunction<LastDayOfMonthFunction, Date, TimestampWithTimezone>(
+  registerFunction<LastDayOfMonthFunction, Date, TimestampWithTimeZone>(
       {prefix + "last_day_of_month"});
 
   registerFunction<MinuteFunction, int64_t, Timestamp>({prefix + "minute"});
   registerFunction<MinuteFunction, int64_t, Date>({prefix + "minute"});
-  registerFunction<MinuteFunction, int64_t, TimestampWithTimezone>(
+  registerFunction<MinuteFunction, int64_t, TimestampWithTimeZone>(
       {prefix + "minute"});
   registerFunction<MinuteFromIntervalFunction, int64_t, IntervalDayTime>(
       {prefix + "minute"});
 
   registerFunction<SecondFunction, int64_t, Timestamp>({prefix + "second"});
   registerFunction<SecondFunction, int64_t, Date>({prefix + "second"});
-  registerFunction<SecondFunction, int64_t, TimestampWithTimezone>(
+  registerFunction<SecondFunction, int64_t, TimestampWithTimeZone>(
       {prefix + "second"});
   registerFunction<SecondFromIntervalFunction, int64_t, IntervalDayTime>(
       {prefix + "second"});
@@ -211,7 +211,7 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "millisecond"});
   registerFunction<MillisecondFunction, int64_t, Date>(
       {prefix + "millisecond"});
-  registerFunction<MillisecondFunction, int64_t, TimestampWithTimezone>(
+  registerFunction<MillisecondFunction, int64_t, TimestampWithTimeZone>(
       {prefix + "millisecond"});
   registerFunction<MillisecondFromIntervalFunction, int64_t, IntervalDayTime>(
       {prefix + "millisecond"});
@@ -222,19 +222,19 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "date_trunc"});
   registerFunction<
       DateTruncFunction,
-      TimestampWithTimezone,
+      TimestampWithTimeZone,
       Varchar,
-      TimestampWithTimezone>({prefix + "date_trunc"});
+      TimestampWithTimeZone>({prefix + "date_trunc"});
   registerFunction<DateAddFunction, Date, Varchar, int64_t, Date>(
       {prefix + "date_add"});
   registerFunction<DateAddFunction, Timestamp, Varchar, int64_t, Timestamp>(
       {prefix + "date_add"});
   registerFunction<
       DateAddFunction,
-      TimestampWithTimezone,
+      TimestampWithTimeZone,
       Varchar,
       int64_t,
-      TimestampWithTimezone>({prefix + "date_add"});
+      TimestampWithTimeZone>({prefix + "date_add"});
   registerFunction<DateDiffFunction, int64_t, Varchar, Date, Date>(
       {prefix + "date_diff"});
   registerFunction<DateDiffFunction, int64_t, Varchar, Timestamp, Timestamp>(
@@ -243,42 +243,42 @@ void registerSimpleFunctions(const std::string& prefix) {
       DateDiffFunction,
       int64_t,
       Varchar,
-      TimestampWithTimezone,
-      TimestampWithTimezone>({prefix + "date_diff"});
+      TimestampWithTimeZone,
+      TimestampWithTimeZone>({prefix + "date_diff"});
   registerFunction<DateFormatFunction, Varchar, Timestamp, Varchar>(
       {prefix + "date_format"});
-  registerFunction<DateFormatFunction, Varchar, TimestampWithTimezone, Varchar>(
+  registerFunction<DateFormatFunction, Varchar, TimestampWithTimeZone, Varchar>(
       {prefix + "date_format"});
   registerFunction<FormatDateTimeFunction, Varchar, Timestamp, Varchar>(
       {prefix + "format_datetime"});
   registerFunction<
       FormatDateTimeFunction,
       Varchar,
-      TimestampWithTimezone,
+      TimestampWithTimeZone,
       Varchar>({prefix + "format_datetime"});
   registerFunction<
       ParseDateTimeFunction,
-      TimestampWithTimezone,
+      TimestampWithTimeZone,
       Varchar,
       Varchar>({prefix + "parse_datetime"});
   registerFunction<DateParseFunction, Timestamp, Varchar, Varchar>(
       {prefix + "date_parse"});
   registerFunction<FromIso8601Date, Date, Varchar>(
       {prefix + "from_iso8601_date"});
-  registerFunction<FromIso8601Timestamp, TimestampWithTimezone, Varchar>(
+  registerFunction<FromIso8601Timestamp, TimestampWithTimeZone, Varchar>(
       {prefix + "from_iso8601_timestamp"});
   registerFunction<CurrentDateFunction, Date>({prefix + "current_date"});
 
   registerFunction<ToISO8601Function, Varchar, Date>({prefix + "to_iso8601"});
   registerFunction<ToISO8601Function, Varchar, Timestamp>(
       {prefix + "to_iso8601"});
-  registerFunction<ToISO8601Function, Varchar, TimestampWithTimezone>(
+  registerFunction<ToISO8601Function, Varchar, TimestampWithTimeZone>(
       {prefix + "to_iso8601"});
 
   registerFunction<
-      AtTimezoneFunction,
-      TimestampWithTimezone,
-      TimestampWithTimezone,
+      AtTimeZoneFunction,
+      TimestampWithTimeZone,
+      TimestampWithTimeZone,
       Varchar>({prefix + "at_timezone"});
 
   registerFunction<ToMillisecondFunction, int64_t, IntervalDayTime>(

--- a/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
@@ -57,16 +57,16 @@ void registerAllGreatestLeastFunctions(const std::string& prefix) {
   registerGreatestLeastFunction<Timestamp>(prefix);
 
   registerFunction<
-      GreatestFunctionTimestampWithTimezone,
-      TimestampWithTimezone,
-      TimestampWithTimezone,
-      Variadic<TimestampWithTimezone>>({prefix + "greatest"});
+      GreatestFunctionTimestampWithTimeZone,
+      TimestampWithTimeZone,
+      TimestampWithTimeZone,
+      Variadic<TimestampWithTimeZone>>({prefix + "greatest"});
 
   registerFunction<
-      LeastFunctionTimestampWithTimezone,
-      TimestampWithTimezone,
-      TimestampWithTimezone,
-      Variadic<TimestampWithTimezone>>({prefix + "least"});
+      LeastFunctionTimestampWithTimeZone,
+      TimestampWithTimeZone,
+      TimestampWithTimeZone,
+      Variadic<TimestampWithTimeZone>>({prefix + "least"});
 }
 } // namespace
 

--- a/velox/functions/prestosql/tests/ArrayJoinTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayJoinTest.cpp
@@ -135,7 +135,7 @@ TEST_F(ArrayJoinTest, timestampTest) {
       "1970-01-04T20:33:03.000~<missing>~1970-02-03T20:33:03.000"_sv);
 
   setLegacyCast(false);
-  setTimezone("America/Los_Angeles");
+  setTimeZone("America/Los_Angeles");
   testArrayJoinNoReplacement<Timestamp>(
       {Timestamp{333183, 0}, std::nullopt, Timestamp{2925183, 0}},
       "~"_sv,

--- a/velox/functions/prestosql/tests/GreatestLeastTest.cpp
+++ b/velox/functions/prestosql/tests/GreatestLeastTest.cpp
@@ -225,7 +225,7 @@ TEST_F(GreatestLeastTest, leastTimeStamp) {
       {Timestamp(0, 0), Timestamp(10, 1), Timestamp(1, 10)});
 }
 
-TEST_F(GreatestLeastTest, greatestTimestampWithTimezone) {
+TEST_F(GreatestLeastTest, greatestTimestampWithTimeZone) {
   auto greatest = [&](const std::string& a,
                       const std::string& b,
                       const std::string& c) {

--- a/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
@@ -54,7 +54,7 @@ class FunctionBaseTest : public testing::Test,
     });
   }
 
-  void setTimezone(const std::string& value) {
+  void setTimeZone(const std::string& value) {
     queryCtx_->testingOverrideConfigUnsafe({
         {core::QueryConfig::kSessionTimezone, value},
         {core::QueryConfig::kAdjustTimestampToTimezone, "true"},

--- a/velox/functions/prestosql/types/JsonType.cpp
+++ b/velox/functions/prestosql/types/JsonType.cpp
@@ -86,7 +86,7 @@ void generateJsonTyped(
         Timestamp inputValue = value;
         const auto& options = hooks->timestampToStringOptions();
         if (options.timeZone) {
-          inputValue.toTimezone(*(options.timeZone));
+          inputValue.toTimeZone(*(options.timeZone));
         }
         buffer.resize(getMaxStringLength(options));
         const auto stringView =

--- a/velox/functions/prestosql/types/tests/TimestampWithTimeZoneTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/TimestampWithTimeZoneTypeTest.cpp
@@ -59,9 +59,14 @@ TEST_F(TimestampWithTimeZoneTypeTest, pack) {
     SCOPED_TRACE(
         fmt::format("millisUtc={}, timeZoneKey={}", millisUtc, timeZoneKey));
 
-    auto packedTimeMillis = pack(millisUtc, timeZoneKey);
-    ASSERT_EQ(unpackMillisUtc(packedTimeMillis), millisUtc);
-    ASSERT_EQ(unpackZoneKeyId(packedTimeMillis), timeZoneKey);
+    auto packedTimeMillis =
+        TimestampWithTimeZoneType::pack(millisUtc, timeZoneKey);
+    ASSERT_EQ(
+        TimestampWithTimeZoneType::unpackMillisUtc(packedTimeMillis),
+        millisUtc);
+    ASSERT_EQ(
+        TimestampWithTimeZoneType::unpackTimeZoneId(packedTimeMillis),
+        timeZoneKey);
   }
 }
 

--- a/velox/functions/sparksql/MakeTimestamp.cpp
+++ b/velox/functions/sparksql/MakeTimestamp.cpp
@@ -118,8 +118,8 @@ class MakeTimestampFunction : public exec::VectorFunction {
     auto* micros = decodedArgs.at(5);
 
     if (args.size() == 7) {
-      // If the timezone argument is specified, treat the input timestamp as the
-      // time in that timezone.
+      // If the time zone argument is specified, treat the input timestamp as
+      // the time in that time zone.
       if (args[6]->isConstantEncoding()) {
         auto tz =
             args[6]->asUnchecked<ConstantVector<StringView>>()->valueAt(0);
@@ -145,7 +145,7 @@ class MakeTimestampFunction : public exec::VectorFunction {
         });
       }
     } else {
-      // Otherwise use session timezone.
+      // Otherwise use session time zone.
       rows.applyToSelected([&](vector_size_t row) {
         auto timestamp = makeTimeStampFromDecodedArgs(
             row, year, month, day, hour, minute, micros);

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -45,7 +45,7 @@ class SparkCastHooks : public exec::CastHooks {
   /// whitespaces before cast.
   StringView removeWhiteSpaces(const StringView& view) const override;
 
-  /// 1) Does not follow 'isLegacyCast' and session timezone. 2) The conversion
+  /// 1) Does not follow 'isLegacyCast' and session time zone. 2) The conversion
   /// precision is microsecond. 3) Does not append trailing zeros. 4) Adds a
   /// positive sign at first if the year exceeds 9999.
   const TimestampToStringOptions& timestampToStringOptions() const override;

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -258,7 +258,7 @@ TEST_F(DateTimeFunctionsTest, unixTimestampCurrent) {
   EXPECT_GE(epoch, 500'000'000);
   EXPECT_LT(epoch, 5'000'000'000);
 
-  // Spark doesn't seem to adjust based on timezones.
+  // Spark doesn't seem to adjust based on time zones.
   auto gmtEpoch = evaluateOnce<int64_t>("unix_timestamp()", mockRowVector);
   setQueryTimeZone("America/Los_Angeles");
   auto laEpoch = evaluateOnce<int64_t>("unix_timestamp()", mockRowVector);

--- a/velox/functions/sparksql/tests/MakeTimestampTest.cpp
+++ b/velox/functions/sparksql/tests/MakeTimestampTest.cpp
@@ -41,11 +41,11 @@ TEST_F(MakeTimestampTest, basic) {
         : evaluate("make_timestamp(c0, c1, c2, c3, c4, c5)", data);
     facebook::velox::test::assertEqualVectors(expected, result);
   };
-  const auto testConstantTimezone = [&](const RowVectorPtr& data,
-                                        const std::string& timezone,
+  const auto testConstantTimeZone = [&](const RowVectorPtr& data,
+                                        const std::string& timeZone,
                                         const VectorPtr& expected) {
     auto result = evaluate(
-        fmt::format("make_timestamp(c0, c1, c2, c3, c4, c5, '{}')", timezone),
+        fmt::format("make_timestamp(c0, c1, c2, c3, c4, c5, '{}')", timeZone),
         data);
     facebook::velox::test::assertEqualVectors(expected, result);
   };
@@ -69,18 +69,18 @@ TEST_F(MakeTimestampTest, basic) {
          parseTimestamp("2021-07-11 06:30:59.999999"),
          std::nullopt});
     testMakeTimestamp(data, expectedGMT, false);
-    testConstantTimezone(data, "GMT", expectedGMT);
+    testConstantTimeZone(data, "GMT", expectedGMT);
 
     setQueryTimeZone("Asia/Shanghai");
-    auto expectedSessionTimezone = makeNullableFlatVector<Timestamp>(
+    auto expectedSessionTimeZone = makeNullableFlatVector<Timestamp>(
         {parseTimestamp("2021-07-10 22:30:45.678"),
          parseTimestamp("2021-07-10 22:30:01"),
          parseTimestamp("2021-07-10 22:31:00"),
          parseTimestamp("2021-07-10 22:30:59.999999"),
          std::nullopt});
-    testMakeTimestamp(data, expectedSessionTimezone, false);
+    testMakeTimestamp(data, expectedSessionTimeZone, false);
     // Session time zone will be ignored if time zone is specified in argument.
-    testConstantTimezone(data, "GMT", expectedGMT);
+    testConstantTimeZone(data, "GMT", expectedGMT);
   }
 
   // Valid cases w/ time zone argument.
@@ -184,7 +184,7 @@ TEST_F(MakeTimestampTest, errors) {
       "DECIMAL(16, 8)).");
 }
 
-TEST_F(MakeTimestampTest, invalidTimezone) {
+TEST_F(MakeTimestampTest, invalidTimeZone) {
   const auto microsType = DECIMAL(16, 6);
   const auto year = makeFlatVector<int32_t>({2021, 2021, 2021, 2021, 2021});
   const auto month = makeFlatVector<int32_t>({7, 7, 7, 7, 7});
@@ -203,7 +203,7 @@ TEST_F(MakeTimestampTest, invalidTimezone) {
   // Invalid constant time zone.
   setQueryTimeZone("GMT");
   for (auto timeZone : {"Invalid", ""}) {
-    SCOPED_TRACE(fmt::format("timezone: {}", timeZone));
+    SCOPED_TRACE(fmt::format("timeZone: {}", timeZone));
     VELOX_ASSERT_USER_THROW(
         evaluate(
             fmt::format(
@@ -212,7 +212,7 @@ TEST_F(MakeTimestampTest, invalidTimezone) {
         fmt::format("Unknown time zone: '{}'", timeZone));
   }
 
-  // Invalid timezone from vector.
+  // Invalid time zone from vector.
   auto timeZones = makeFlatVector<StringView>(
       {"GMT", "CET", "Asia/Shanghai", "Invalid", "GMT"});
   data = makeRowVector({year, month, day, hour, minute, micros, timeZones});

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -877,7 +877,9 @@ TEST_P(PrestoSerializerTest, emptyMap) {
 TEST_P(PrestoSerializerTest, timestampWithTimeZone) {
   auto timestamp = makeFlatVector<int64_t>(
       100,
-      [](auto row) { return pack(10'000 + row, row % 37); },
+      [](auto row) {
+        return TimestampWithTimeZoneType::pack(10'000 + row, row % 37);
+      },
       /* isNullAt */ nullptr,
       TIMESTAMP_WITH_TIME_ZONE());
 

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -74,7 +74,7 @@ Timestamp::toTimePointMs(bool allowOverflow) const {
   return tp;
 }
 
-void Timestamp::toTimezone(const tz::TimeZone& zone) {
+void Timestamp::toTimeZone(const tz::TimeZone& zone) {
   try {
     seconds_ = zone.to_local(std::chrono::seconds(seconds_)).count();
   } catch (const std::invalid_argument& e) {
@@ -85,7 +85,7 @@ void Timestamp::toTimezone(const tz::TimeZone& zone) {
   }
 }
 
-const tz::TimeZone& Timestamp::defaultTimezone() {
+const tz::TimeZone& Timestamp::defaultTimeZone() {
   static const tz::TimeZone* kDefault = ({
     // TODO: We are hard-coding PST/PDT here to be aligned with the current
     // behavior in DWRF reader/writer.  Once they are fixed, we can use

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -341,7 +341,7 @@ struct Timestamp {
   // time at the same moment. For example:
   //
   //  Timestamp ts{0, 0};
-  //  ts.Timezone("America/Los_Angeles");
+  //  ts.toGMT("America/Los_Angeles");
   //  ts.toString(); // returns January 1, 1970 08:00:00
   void toGMT(const tz::TimeZone& zone);
 
@@ -349,12 +349,12 @@ struct Timestamp {
   /// the same moment at zone. For example:
   ///
   ///  Timestamp ts{0, 0};
-  ///  ts.Timezone("America/Los_Angeles");
+  ///  ts.toTimeZone("America/Los_Angeles");
   ///  ts.toString(); // returns December 31, 1969 16:00:00
-  void toTimezone(const tz::TimeZone& zone);
+  void toTimeZone(const tz::TimeZone& zone);
 
   /// A default time zone that is same across the process.
-  static const tz::TimeZone& defaultTimezone();
+  static const tz::TimeZone& defaultTimeZone();
 
   bool operator==(const Timestamp& b) const {
     return seconds_ == b.seconds_ && nanos_ == b.nanos_;

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -825,7 +825,7 @@ fromTimestampString(const char* str, size_t len, TimestampParseMode parseMode) {
 }
 
 Expected<std::pair<Timestamp, const tz::TimeZone*>>
-fromTimestampWithTimezoneString(
+fromTimestampWithTimeZoneString(
     const char* str,
     size_t len,
     TimestampParseMode parseMode) {
@@ -842,7 +842,7 @@ fromTimestampWithTimezoneString(
     pos++;
   }
 
-  // If there is anything left to parse, it must be a timezone definition.
+  // If there is anything left to parse, it must be a timeZone definition.
   if (pos < len) {
     if (parseMode == TimestampParseMode::kIso8601) {
       // Only +HH:MM and -HH:MM are supported. Minutes, seconds, etc. in the
@@ -852,20 +852,20 @@ fromTimestampWithTimezoneString(
       }
     }
 
-    size_t timezonePos = pos;
-    while (timezonePos < len && !characterIsSpace(str[timezonePos])) {
-      timezonePos++;
+    size_t timeZonePos = pos;
+    while (timeZonePos < len && !characterIsSpace(str[timeZonePos])) {
+      timeZonePos++;
     }
 
-    std::string_view timeZoneName(str + pos, timezonePos - pos);
+    std::string_view timeZoneName(str + pos, timeZonePos - pos);
 
     if ((timeZone = tz::locateZone(timeZoneName, false)) == nullptr) {
       return folly::makeUnexpected(
-          Status::UserError("Unknown timezone value: \"{}\"", timeZoneName));
+          Status::UserError("Unknown time zone value: \"{}\"", timeZoneName));
     }
 
     // Skip any spaces at the end.
-    pos = timezonePos;
+    pos = timeZonePos;
     if (parseMode != TimestampParseMode::kIso8601) {
       skipSpaces(str, len, pos);
     }
@@ -892,7 +892,7 @@ int32_t toDate(const Timestamp& timestamp, const tz::TimeZone* timeZone_) {
 
   if (timeZone_ != nullptr) {
     Timestamp copy = timestamp;
-    copy.toTimezone(*timeZone_);
+    copy.toTimeZone(*timeZone_);
     return convertToDate(copy);
   }
 

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -209,15 +209,15 @@ enum class TimestampParseMode {
 
 /// Parses a timestamp string using specified TimestampParseMode.
 ///
-/// This function does not accept any timezone information in the string (e.g.
-/// UTC, Z, or a timezone offsets). This is because the returned timestamp does
-/// not contain timezone information; therefore, it would either be required for
-/// this function to convert the parsed timestamp (but we don't know the
-/// original timezone), or ignore the timezone information, which would be
+/// This function does not accept any time zone information in the string (e.g.
+/// UTC, Z, or a time zone offsets). This is because the returned timestamp does
+/// not contain time zone information; therefore, it would either be required
+/// for this function to convert the parsed timestamp (but we don't know the
+/// original time zone), or ignore the time zone information, which would be
 /// incorecct.
 ///
-/// For a timezone-aware version of this function, check
-/// `fromTimestampWithTimezoneString()` below.
+/// For a time-zone-aware version of this function, check
+/// `fromTimestampWithTimeZoneString()` below.
 Expected<Timestamp>
 fromTimestampString(const char* buf, size_t len, TimestampParseMode parseMode);
 
@@ -229,29 +229,29 @@ inline Expected<Timestamp> fromTimestampString(
 
 /// Parses a timestamp string using specified TimestampParseMode.
 ///
-/// This is a timezone-aware version of the function above
+/// This is a time-zone-aware version of the function above
 /// `fromTimestampString()` which returns both the parsed timestamp and the
 /// TimeZone pointer. It is up to the client to do the expected conversion based
 /// on these two values.
 ///
-/// The timezone information at the end of the string may contain a timezone
+/// The time zone information at the end of the string may contain a time zone
 /// name (as defined in velox/type/tz/*), such as "UTC" or
-/// "America/Los_Angeles", or a timezone offset, like "+06:00" or "-09:30". The
+/// "America/Los_Angeles", or a time zone offset, like "+06:00" or "-09:30". The
 /// white space between the hour definition and timestamp is optional.
 ///
-/// `nullptr` means no timezone information was found. Returns Unexpected with
+/// `nullptr` means no time zone information was found. Returns Unexpected with
 /// UserError status in case of parsing errors.
 Expected<std::pair<Timestamp, const tz::TimeZone*>>
-fromTimestampWithTimezoneString(
+fromTimestampWithTimeZoneString(
     const char* buf,
     size_t len,
     TimestampParseMode parseMode);
 
 inline Expected<std::pair<Timestamp, const tz::TimeZone*>>
-fromTimestampWithTimezoneString(
+fromTimestampWithTimeZoneString(
     const StringView& str,
     TimestampParseMode parseMode) {
-  return fromTimestampWithTimezoneString(str.data(), str.size(), parseMode);
+  return fromTimestampWithTimeZoneString(str.data(), str.size(), parseMode);
 }
 
 Timestamp fromDatetime(int64_t daysSinceEpoch, int64_t microsSinceMidnight);

--- a/velox/type/tests/TimestampTest.cpp
+++ b/velox/type/tests/TimestampTest.cpp
@@ -390,28 +390,28 @@ TEST(TimestampTest, decreaseOperator) {
 }
 
 TEST(TimestampTest, outOfRange) {
-  // There are two ranges for timezone conversion.
+  // There are two ranges for time zone conversion.
   //
   // #1. external/date cannot handle years larger than 32k (date::year::max()).
   // Any conversions exceeding that threshold will fail right away.
-  auto* timezone = tz::locateZone("GMT");
+  auto* timeZone = tz::locateZone("GMT");
   Timestamp t1(-3217830796800, 0);
 
   std::string expected = "Timepoint is outside of supported year range";
   VELOX_ASSERT_THROW(t1.toTimePointMs(), expected);
-  VELOX_ASSERT_THROW(t1.toTimezone(*timezone), expected);
+  VELOX_ASSERT_THROW(t1.toTimeZone(*timeZone), expected);
 
-  timezone = tz::locateZone("America/Los_Angeles");
-  VELOX_ASSERT_THROW(t1.toGMT(*timezone), expected);
+  timeZone = tz::locateZone("America/Los_Angeles");
+  VELOX_ASSERT_THROW(t1.toGMT(*timeZone), expected);
 
   // #2. external/date doesn't understand OS_TZDB repetition rules. Therefore,
-  // for timezones with pre-defined repetition rules for daylight savings, for
+  // for time zones with pre-defined repetition rules for daylight savings, for
   // example, it will throw for anything larger than 2037 (which is what is
   // currently materialized in OS_TZDBs). America/Los_Angeles is an example of
-  // such timezone.
+  // such time zone.
   Timestamp t2(32517359891, 0);
   VELOX_ASSERT_THROW(
-      t2.toTimezone(*timezone),
+      t2.toTimeZone(*timeZone),
       "Unable to convert timezone 'America/Los_Angeles' past");
 }
 

--- a/velox/type/tz/TimeZoneMap.cpp
+++ b/velox/type/tz/TimeZoneMap.cpp
@@ -49,7 +49,7 @@ const date::time_zone* locateZoneImpl(std::string_view tz_name) {
 }
 
 // Flattens the input vector of pairs into a vector, assuming that the
-// timezoneIDs are (mostly) sequential. Note that since they are "mostly"
+// time zone IDs are (mostly) sequential. Note that since they are "mostly"
 // senquential, the vector can have holes. But it is still more efficient than
 // looking up on a map.
 TTimeZoneDatabase buildTimeZoneDatabase(
@@ -99,7 +99,7 @@ const TTimeZoneDatabase& getTimeZoneDatabase() {
   return timeZoneDatabase;
 }
 
-// Reverses the vector of pairs into a map key'ed by the timezone name for
+// Reverses the vector of pairs into a map key'ed by the time zone name for
 // reverse look ups.
 TTimeZoneIndex buildTimeZoneIndex(const TTimeZoneDatabase& tzDatabase) {
   TTimeZoneIndex reversed;
@@ -137,7 +137,7 @@ inline bool isTimeZoneOffset(std::string_view str) {
   return str.size() >= 3 && (str[0] == '+' || str[0] == '-');
 }
 
-// The timezone parsing logic follows what is defined here:
+// The time zone parsing logic follows what is defined here:
 //   https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 inline bool isUtcEquivalentName(std::string_view zone) {
   static folly::F14FastSet<std::string> utcSet = {
@@ -283,7 +283,7 @@ const TimeZone* locateZone(std::string_view timeZone, bool failOnError) {
     return it->second;
   }
 
-  // If an exact match wasn't found, try to normalize the timezone name.
+  // If an exact match wasn't found, try to normalize the time zone name.
   it = timeZoneIndex.find(normalizeTimeZone(timeZoneLowered));
   if (it != timeZoneIndex.end()) {
     return it->second;
@@ -311,12 +311,12 @@ int16_t getTimeZoneID(int32_t offsetMinutes) {
   VELOX_USER_CHECK_LE(
       kMinOffset,
       offsetMinutes,
-      "Invalid timezone offset minutes: {}",
+      "Invalid time zone offset minutes: {}",
       offsetMinutes);
   VELOX_USER_CHECK_LE(
       offsetMinutes,
       kMaxOffset,
-      "Invalid timezone offset minutes: {}",
+      "Invalid time zone offset minutes: {}",
       offsetMinutes);
 
   if (offsetMinutes < 0) {

--- a/velox/type/tz/TimeZoneMap.h
+++ b/velox/type/tz/TimeZoneMap.h
@@ -51,11 +51,11 @@ const TimeZone* locateZone(std::string_view timeZone, bool failOnError = true);
 /// zone ID was not valid.
 const TimeZone* locateZone(int16_t timeZoneID, bool failOnError = true);
 
-/// Returns the timezone name associated with timeZoneID.
+/// Returns the time zone name associated with timeZoneID.
 std::string getTimeZoneName(int64_t timeZoneID);
 
-/// Returns the timeZoneID for the timezone name.
-/// If failOnError = true, throws an exception for unrecognized timezone.
+/// Returns the timeZoneID for the time zone name.
+/// If failOnError = true, throws an exception for unrecognized time zone.
 /// Otherwise, returns -1.
 int16_t getTimeZoneID(std::string_view timeZone, bool failOnError = true);
 
@@ -74,7 +74,7 @@ void validateRange(time_point<std::chrono::milliseconds> timePoint);
 /// TimeZone is the proxy object for time zone management. It provides access to
 /// time zone names, their IDs (as defined in TimeZoneDatabase.cpp and
 /// consistent with Presto), and utilities for timestamp conversion across
-/// timezones by leveraging the .to_sys() and .to_local() methods as documented
+/// time zones by leveraging the .to_sys() and .to_local() methods as documented
 /// in:
 ///
 ///   https://howardhinnant.github.io/date/tz.html

--- a/velox/type/tz/tests/TimeZoneMapTest.cpp
+++ b/velox/type/tz/tests/TimeZoneMapTest.cpp
@@ -218,8 +218,8 @@ TEST(TimeZoneMapTest, getTimeZoneIDFromOffset) {
   EXPECT_EQ("-08:00", nameFromOffset(-8 * 60));
   EXPECT_EQ("+02:17", nameFromOffset(2 * 60 + 17));
 
-  VELOX_ASSERT_THROW(getTimeZoneID(15'000), "Invalid timezone offset");
-  VELOX_ASSERT_THROW(getTimeZoneID(-15'000), "Invalid timezone offset");
+  VELOX_ASSERT_THROW(getTimeZoneID(15'000), "Invalid time zone offset");
+  VELOX_ASSERT_THROW(getTimeZoneID(-15'000), "Invalid time zone offset");
 }
 
 TEST(TimeZoneMapTest, invalid) {

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -137,7 +137,7 @@ struct VeloxToArrowSchemaBridgeHolder {
 
   std::unique_ptr<ArrowSchema> dictionary;
 
-  // Buffer required to generate a decimal format or timestamp with timezone
+  // Buffer required to generate a decimal format or timestamp with time zone
   // format.
   std::string formatBuffer;
 

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -200,7 +200,7 @@ TEST_F(ArrowBridgeSchemaExportTest, scalar) {
   testScalarType(VARCHAR(), "u");
   testScalarType(VARBINARY(), "z");
 
-  // Test default timezone
+  // Test default time zone
   testScalarType(
       TIMESTAMP(), "tss:", {.timestampUnit = TimestampUnit::kSecond});
   testScalarType(TIMESTAMP(), "tsm:", {.timestampUnit = TimestampUnit::kMilli});
@@ -210,7 +210,7 @@ TEST_F(ArrowBridgeSchemaExportTest, scalar) {
   testScalarType(VARCHAR(), "vu", {.exportToStringView = true});
   testScalarType(VARBINARY(), "vz", {.exportToStringView = true});
 
-  // Test specific timezone
+  // Test specific time zone
   testScalarType(
       TIMESTAMP(),
       "tss:+01:0",


### PR DESCRIPTION
Summary:
Working with the TimestampWithTimezoneType recently I've noticed a few issues that have made it
a little difficult to work with:
1) The word time zone is treated as 1 or 2 words inconsistently throughout the code base.
2) The integer indicating a time zone is sometimes called time zone ID, time zone key, or zone key ID.
3) The pack and unpack functions and a few other static values in the TimestampWithTimeZone.h
file are polluting the global facebook::velox namespace.

This diff is a refactor, no new implementations are introduced, which does the following:
1) Treats "time zone" as two words where possible (I did not touch SessionConfig or ReaderOptions
to keep from breaking projects that depend on Velox).
2) Calls the integer indicating a time zone "time zone ID" consistently.
3) Moves the values/functions from the global namespace in TimestampWithTimeZone.h to be
statics under TimestampWithTimeZoneType.

Differential Revision: D62976731
