### PR TITLE
More semicolon enforcement on velox macros calls

### DIFF
--- a/velox/common/base/Exceptions.h
+++ b/velox/common/base/Exceptions.h
@@ -206,16 +206,18 @@ DECLARE_CHECK_FAIL_TEMPLATES(::facebook::velox::VeloxRuntimeError);
 /// Throws VeloxRuntimeError when functions receive input values out of the
 /// supported range. This should only be used when we want to force TRY() to not
 /// suppress the error.
-#define VELOX_CHECK_UNSUPPORTED_INPUT_UNCATCHABLE(expr, ...)                 \
-  if (UNLIKELY(!(expr))) {                                                   \
-    _VELOX_THROW_IMPL(                                                       \
-        ::facebook::velox::VeloxRuntimeError,                                \
-        #expr,                                                               \
-        ::facebook::velox::error_source::kErrorSourceRuntime.c_str(),        \
-        ::facebook::velox::error_code::kUnsupportedInputUncatchable.c_str(), \
-        /* isRetriable */ false,                                             \
-        __VA_ARGS__);                                                        \
-  }
+#define VELOX_CHECK_UNSUPPORTED_INPUT_UNCATCHABLE(expr, ...)                   \
+  do {                                                                         \
+    if (UNLIKELY(!(expr))) {                                                   \
+      _VELOX_THROW_IMPL(                                                       \
+          ::facebook::velox::VeloxRuntimeError,                                \
+          #expr,                                                               \
+          ::facebook::velox::error_source::kErrorSourceRuntime.c_str(),        \
+          ::facebook::velox::error_code::kUnsupportedInputUncatchable.c_str(), \
+          /* isRetriable */ false,                                             \
+          __VA_ARGS__);                                                        \
+    }                                                                          \
+  } while (0)
 
 // If the caller passes a custom message (4 *or more* arguments), we
 // have to construct a format string from ours ("({} vs. {})") plus
@@ -234,17 +236,19 @@ DECLARE_CHECK_FAIL_TEMPLATES(::facebook::velox::VeloxRuntimeError);
       ##__VA_ARGS__)
 
 #define _VELOX_CHECK_OP_HELPER(implmacro, expr1, expr2, op, ...) \
-  if constexpr (FOLLY_PP_DETAIL_NARGS(__VA_ARGS__) > 0) {        \
-    _VELOX_CHECK_OP_WITH_USER_FMT_HELPER(                        \
-        implmacro, expr1, expr2, op, __VA_ARGS__);               \
-  } else {                                                       \
-    implmacro(                                                   \
-        (expr1)op(expr2),                                        \
-        #expr1 " " #op " " #expr2,                               \
-        "({} vs. {})",                                           \
-        expr1,                                                   \
-        expr2);                                                  \
-  }
+  do {                                                           \
+    if constexpr (FOLLY_PP_DETAIL_NARGS(__VA_ARGS__) > 0) {      \
+      _VELOX_CHECK_OP_WITH_USER_FMT_HELPER(                      \
+          implmacro, expr1, expr2, op, __VA_ARGS__);             \
+    } else {                                                     \
+      implmacro(                                                 \
+          (expr1)op(expr2),                                      \
+          #expr1 " " #op " " #expr2,                             \
+          "({} vs. {})",                                         \
+          expr1,                                                 \
+          expr2);                                                \
+    }                                                            \
+  } while (0)
 
 #define _VELOX_CHECK_OP(expr1, expr2, op, ...) \
   _VELOX_CHECK_OP_HELPER(_VELOX_CHECK_IMPL, expr1, expr2, op, ##__VA_ARGS__)

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1607,7 +1607,7 @@ MarkDistinctNode::MarkDistinctNode(
       sources_{std::move(source)},
       outputType_(
           getMarkDistinctOutputType(sources_[0]->outputType(), markerName_)) {
-  VELOX_USER_CHECK_GT(markerName_.size(), 0)
+  VELOX_USER_CHECK_GT(markerName_.size(), 0);
   VELOX_USER_CHECK_GT(distinctKeys_.size(), 0);
 }
 

--- a/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
@@ -147,7 +147,7 @@ int ParquetReaderBenchmark::read(
     VELOX_CHECK_EQ(
         rowVector->childrenSize(),
         1,
-        "The benchmark is performed on single columns. So the result should only contain one column.")
+        "The benchmark is performed on single columns. So the result should only contain one column.");
 
     for (int i = 0; i < rowVector->size(); i++) {
       resultSize += !rowVector->childAt(0)->isNullAt(i);

--- a/velox/exec/AssignUniqueId.cpp
+++ b/velox/exec/AssignUniqueId.cpp
@@ -36,7 +36,7 @@ AssignUniqueId::AssignUniqueId(
   VELOX_USER_CHECK_LT(
       uniqueTaskId,
       kTaskUniqueIdLimit,
-      "Unique 24-bit ID specified for AssignUniqueId exceeds the limit")
+      "Unique 24-bit ID specified for AssignUniqueId exceeds the limit");
   uniqueValueMask_ = ((int64_t)uniqueTaskId) << 40;
 
   const auto numColumns = planNode->outputType()->size();
@@ -55,7 +55,7 @@ AssignUniqueId::AssignUniqueId(
 void AssignUniqueId::addInput(RowVectorPtr input) {
   auto numInput = input->size();
   VELOX_CHECK_NE(
-      numInput, 0, "AssignUniqueId::addInput received empty set of rows")
+      numInput, 0, "AssignUniqueId::addInput received empty set of rows");
   input_ = std::move(input);
 }
 

--- a/velox/exec/EnforceSingleRow.cpp
+++ b/velox/exec/EnforceSingleRow.cpp
@@ -33,7 +33,7 @@ EnforceSingleRow::EnforceSingleRow(
 void EnforceSingleRow::addInput(RowVectorPtr input) {
   auto numInput = input->size();
   VELOX_CHECK_NE(
-      numInput, 0, "EnforceSingleRow::addInput received empty set of rows")
+      numInput, 0, "EnforceSingleRow::addInput received empty set of rows");
   if (input_ == nullptr) {
     VELOX_USER_CHECK_EQ(
         numInput,

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -66,10 +66,10 @@ void extractColumns(
     memory::MemoryPool* pool,
     const std::vector<TypePtr>& resultTypes,
     std::vector<VectorPtr>& resultVectors) {
-  VELOX_CHECK_EQ(resultTypes.size(), resultVectors.size())
+  VELOX_CHECK_EQ(resultTypes.size(), resultVectors.size());
   for (auto projection : projections) {
     const auto resultChannel = projection.outputChannel;
-    VELOX_CHECK_LT(resultChannel, resultVectors.size())
+    VELOX_CHECK_LT(resultChannel, resultVectors.size());
 
     auto& child = resultVectors[resultChannel];
     // TODO: Consider reuse of complex types.

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -251,7 +251,7 @@ uint32_t maxDrivers(
             *result,
             0,
             "maxDrivers must be greater than 0. Plan node: {}",
-            node->toString())
+            node->toString());
         if (*result == 1) {
           return 1;
         }

--- a/velox/exec/PartitionStreamingWindowBuild.cpp
+++ b/velox/exec/PartitionStreamingWindowBuild.cpp
@@ -63,7 +63,7 @@ void PartitionStreamingWindowBuild::noMoreInput() {
 std::shared_ptr<WindowPartition>
 PartitionStreamingWindowBuild::nextPartition() {
   VELOX_CHECK_GT(
-      partitionStartRows_.size(), 0, "No window partitions available")
+      partitionStartRows_.size(), 0, "No window partitions available");
 
   ++currentPartition_;
   VELOX_CHECK_LE(

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -735,7 +735,7 @@ void Task::start(uint32_t maxDrivers, uint32_t concurrentSplitGroups) {
 }
 
 void Task::checkExecutionMode(ExecutionMode mode) {
-  VELOX_CHECK_EQ(mode, mode_, "Inconsistent task execution mode.")
+  VELOX_CHECK_EQ(mode, mode_, "Inconsistent task execution mode.");
 }
 
 void Task::createDriverFactoriesLocked(uint32_t maxDrivers) {

--- a/velox/exec/Unnest.cpp
+++ b/velox/exec/Unnest.cpp
@@ -45,7 +45,7 @@ Unnest::Unnest(
     VELOX_CHECK_EQ(
         outputType_->children().back(),
         BIGINT(),
-        "Ordinality column should be BIGINT type.")
+        "Ordinality column should be BIGINT type.");
   }
 
   column_index_t outputChannel = 0;

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -968,7 +968,7 @@ PlanBuilder& PlanBuilder::expand(
 
   for (auto i = 0; i < numRows; i++) {
     std::vector<core::TypedExprPtr> projectExpr;
-    VELOX_CHECK_EQ(numColumns, projections[i].size())
+    VELOX_CHECK_EQ(numColumns, projections[i].size());
     for (auto j = 0; j < numColumns; j++) {
       auto untypedExpression = parse::parseExpr(projections[i][j], options_);
       auto typedExpression = inferTypes(untypedExpression);

--- a/velox/expression/LambdaExpr.cpp
+++ b/velox/expression/LambdaExpr.cpp
@@ -115,7 +115,7 @@ class ExprCallable : public Callable {
       const BufferPtr& wrapCapture,
       const std::vector<VectorPtr>& args,
       vector_size_t size) {
-    VELOX_CHECK_EQ(signature_->size(), args.size())
+    VELOX_CHECK_EQ(signature_->size(), args.size());
     std::vector<VectorPtr> allVectors = args;
     for (auto index = args.size(); index < capture_->childrenSize(); ++index) {
       auto values = capture_->childAt(index);

--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -1783,7 +1783,7 @@ class PatternStringIterator {
           pattern_.size(),
           "Escape character must be followed by '%', '_' or the escape character itself: {}, escape {}",
           pattern_,
-          escapeChar_.value())
+          escapeChar_.value());
 
       currentChar = charAt(currentStart_ + 1);
       // The char follows escapeChar can only be one of (%, _, escapeChar).

--- a/velox/functions/prestosql/Bitwise.h
+++ b/velox/functions/prestosql/Bitwise.h
@@ -82,7 +82,7 @@ struct BitwiseArithmeticShiftRightFunction {
   // Only support bigint inputs.
   FOLLY_ALWAYS_INLINE void
   call(int64_t& result, int64_t number, int64_t shift) {
-    VELOX_USER_CHECK_GE(shift, 0, "Shift must be non-negative")
+    VELOX_USER_CHECK_GE(shift, 0, "Shift must be non-negative");
     if (shift >= 63) {
       if (number >= 0) {
         result = 0;

--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -318,7 +318,7 @@ FOLLY_ALWAYS_INLINE int64_t diffTimestamp(
       fromTimestamp.toString(),
       toTimestamp.toString(),
       toTimePointMillis,
-      toDaysTimepointMillis)
+      toDaysTimepointMillis);
   const uint8_t fromDay = static_cast<unsigned>(fromCalDate.day()),
                 fromMonth = static_cast<unsigned>(fromCalDate.month());
   const uint8_t toDay = static_cast<unsigned>(toCalDate.day()),

--- a/velox/functions/prestosql/FromUtf8.cpp
+++ b/velox/functions/prestosql/FromUtf8.cpp
@@ -172,7 +172,7 @@ class FromUtf8Function : public exec::VectorFunction {
       VELOX_USER_CHECK_EQ(
           charLength,
           replacement.size(),
-          "Replacement string must be empty or a single character")
+          "Replacement string must be empty or a single character");
     }
     return replacement;
   }

--- a/velox/functions/prestosql/MapTopN.h
+++ b/velox/functions/prestosql/MapTopN.h
@@ -54,7 +54,7 @@ struct MapTopNFunction {
       out_type<Map<Orderable<T1>, Orderable<T2>>>& out,
       const arg_type<Map<Orderable<T1>, Orderable<T2>>>& inputMap,
       int64_t n) {
-    VELOX_USER_CHECK_GE(n, 0, "n must be greater than or equal to 0")
+    VELOX_USER_CHECK_GE(n, 0, "n must be greater than or equal to 0");
 
     if (n == 0) {
       return;

--- a/velox/functions/prestosql/MapTopNImpl.h
+++ b/velox/functions/prestosql/MapTopNImpl.h
@@ -30,7 +30,7 @@ struct MapTopNImpl {
       out_type<Array<Orderable<T1>>>& out,
       const arg_type<Map<Orderable<T1>, Orderable<T2>>>& inputMap,
       int64_t n) {
-    VELOX_USER_CHECK_GE(n, 0, "n must be greater than or equal to 0")
+    VELOX_USER_CHECK_GE(n, 0, "n must be greater than or equal to 0");
 
     if (n == 0 || inputMap.size() == 0) {
       return;

--- a/velox/functions/prestosql/WidthBucketArray.cpp
+++ b/velox/functions/prestosql/WidthBucketArray.cpp
@@ -169,7 +169,7 @@ std::vector<double> toBinValues(
       VELOX_USER_CHECK_GT(
           value,
           simpleVector->valueAt(offset + i - 1),
-          "Bin values are not sorted in ascending order")
+          "Bin values are not sorted in ascending order");
     }
     binValues.push_back(value);
   }

--- a/velox/functions/prestosql/aggregates/PrestoHasher.cpp
+++ b/velox/functions/prestosql/aggregates/PrestoHasher.cpp
@@ -44,7 +44,7 @@ FOLLY_ALWAYS_INLINE void applyHashFunction(
     const DecodedVector& vector,
     BufferPtr& hashes,
     Callable func) {
-  VELOX_CHECK_GE(hashes->size(), rows.end())
+  VELOX_CHECK_GE(hashes->size(), rows.end());
   auto rawHashes = hashes->asMutable<int64_t>();
 
   rows.applyToSelected([&](auto row) {
@@ -273,7 +273,7 @@ void PrestoHasher::hash<TypeKind::MAP>(
     BufferPtr& hashes) {
   auto baseMap = vector_->base()->as<MapVector>();
   auto indices = vector_->indices();
-  VELOX_CHECK_EQ(children_.size(), 2)
+  VELOX_CHECK_EQ(children_.size(), 2);
 
   auto nonNullRows = SelectivityVector(rows);
   if (vector_->nulls(&nonNullRows)) {

--- a/velox/functions/sparksql/Bitwise.cpp
+++ b/velox/functions/sparksql/Bitwise.cpp
@@ -115,11 +115,11 @@ struct BitGetFunction {
     VELOX_USER_CHECK_GE(
         pos,
         0,
-        "The value of 'pos' argument must be greater than or equal to zero.")
+        "The value of 'pos' argument must be greater than or equal to zero.");
     VELOX_USER_CHECK_LT(
         pos,
         kMaxBits,
-        "The value of 'pos' argument must not exceed the number of bits in 'x' - 1.")
+        "The value of 'pos' argument must not exceed the number of bits in 'x' - 1.");
     result = (num >> pos) & 1;
   }
 };

--- a/velox/parse/QueryPlanner.cpp
+++ b/velox/parse/QueryPlanner.cpp
@@ -262,7 +262,7 @@ PlanNodePtr toVeloxPlan(
     memory::MemoryPool* pool,
     std::vector<PlanNodePtr> sources,
     QueryContext& queryContext) {
-  VELOX_CHECK_EQ(1, logicalFilter.expressions.size())
+  VELOX_CHECK_EQ(1, logicalFilter.expressions.size());
   auto filter = toVeloxExpression(
       *logicalFilter.expressions.front(), sources[0]->outputType());
   return std::make_shared<FilterNode>(

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -907,7 +907,7 @@ void ArrayVectorBase::validateArrayVectorBase(
         rawOffsets_[i],
         0,
         "ArrayVectorBase offset must be greater than zero. Index: {}.",
-        i)
+        i);
     VELOX_CHECK_LT(
         rawOffsets_[i] + rawSizes_[i] - 1,
         minChildVectorSize,

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -92,7 +92,7 @@ class FlatVector final : public SimpleVector<T> {
       VELOX_CHECK_EQ(
           0,
           cnt,
-          "FlatVector with null values buffer must have all rows set to null")
+          "FlatVector with null values buffer must have all rows set to null");
       return;
     }
     auto byteSize = BaseVector::byteSize<T>(BaseVector::length_);

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -269,7 +269,7 @@ class SimpleVector : public BaseVector {
   template <typename U = T>
   typename std::enable_if_t<std::is_same_v<U, StringView>, std::optional<bool>>
   isAscii(vector_size_t index) const {
-    VELOX_CHECK_GE(index, 0)
+    VELOX_CHECK_GE(index, 0);
     auto rlockedAsciiComputedRows{asciiInfo.readLockedAsciiComputedRows()};
     if (index < rlockedAsciiComputedRows->size() &&
         rlockedAsciiComputedRows->isValid(index)) {

--- a/velox/vector/tests/utils/VectorMaker.cpp
+++ b/velox/vector/tests/utils/VectorMaker.cpp
@@ -225,7 +225,7 @@ ArrayVectorPtr VectorMaker::arrayVector(
     auto rawNulls = nullsBuffer->asMutable<uint64_t>();
 
     for (int i = 0; i < nulls.size(); i++) {
-      VELOX_CHECK_EQ(rawSizes[nulls[i]], 0)
+      VELOX_CHECK_EQ(rawSizes[nulls[i]], 0);
       bits::setNull(rawNulls, nulls[i]);
     }
   }
@@ -266,7 +266,7 @@ MapVectorPtr VectorMaker::mapVector(
     auto rawNulls = nullsBuffer->asMutable<uint64_t>();
 
     for (int i = 0; i < nulls.size(); i++) {
-      VELOX_CHECK_EQ(rawSizes[nulls[i]], 0)
+      VELOX_CHECK_EQ(rawSizes[nulls[i]], 0);
       bits::setNull(rawNulls, nulls[i]);
     }
   }


### PR DESCRIPTION
This unblocks enabling `-Wextra-semi` and `-Wextra-semi-stmt` in Velox.

Differential Revision: D63036057