### PR TITLE
Fix internal build of velox_expression_fuzzer_test

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -15,7 +15,6 @@
  */
 
 #include <folly/init/Init.h>
-#include <gtest/gtest.h>
 #include <unordered_set>
 
 #include "velox/expression/fuzzer/ArgGenerator.h"
@@ -40,8 +39,6 @@ using facebook::velox::fuzzer::FuzzerRunner;
 
 int main(int argc, char** argv) {
   facebook::velox::functions::prestosql::registerAllScalarFunctions();
-
-  ::testing::InitGoogleTest(&argc, argv);
 
   // Calls common init functions in the necessary order, initializing
   // singletons, installing proper signal handlers for better debugging
@@ -96,5 +93,5 @@ int main(int argc, char** argv) {
        {"mod", std::make_shared<ModulusArgGenerator>()},
        {"truncate", std::make_shared<TruncateArgGenerator>()}};
 
-  return FuzzerRunner::run(initialSeed, skipFunctions, {{}}, argGenerators);
+  FuzzerRunner::runFromGtest(initialSeed, skipFunctions, {{}}, argGenerators);
 }


### PR DESCRIPTION
Summary:
A previous change happened to break the internal build of expression_fuzzer_test, but the
broken build was not caught at diff-time internally because the expression_fuzzer_test
target was disabled. This target is useful for debugging. This diff fixes the broken build.
Plus, since we only want expression_fuzzer_test to be built but not run at diff time, this diff
changes the target type to cpp_binary and removes the GTest logic that was required to run
it as cpp_unittest before.

Reviewed By: kgpai

Differential Revision: D63042420
