### PR TITLE
Add spill metric spillExtractVectorTimeNanos

### DIFF
--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -123,6 +123,9 @@ constexpr folly::StringPiece kMetricSpillFillTimeMs{"velox.spill_fill_time_ms"};
 
 constexpr folly::StringPiece kMetricSpillSortTimeMs{"velox.spill_sort_time_ms"};
 
+constexpr folly::StringPiece kMetricSpillExtractVectorTimeMs{
+    "velox.spill_extract_vector_time_ms"};
+
 constexpr folly::StringPiece kMetricSpillSerializationTimeMs{
     "velox.spill_serialization_time_ms"};
 

--- a/velox/common/base/SpillStats.cpp
+++ b/velox/common/base/SpillStats.cpp
@@ -44,6 +44,7 @@ SpillStats::SpillStats(
     uint64_t _spilledFiles,
     uint64_t _spillFillTimeNanos,
     uint64_t _spillSortTimeNanos,
+    uint64_t _spillExtractVectorTimeNanos,
     uint64_t _spillSerializationTimeNanos,
     uint64_t _spillWrites,
     uint64_t _spillFlushTimeNanos,
@@ -61,6 +62,7 @@ SpillStats::SpillStats(
       spilledFiles(_spilledFiles),
       spillFillTimeNanos(_spillFillTimeNanos),
       spillSortTimeNanos(_spillSortTimeNanos),
+      spillExtractVectorTimeNanos(_spillExtractVectorTimeNanos),
       spillSerializationTimeNanos(_spillSerializationTimeNanos),
       spillWrites(_spillWrites),
       spillFlushTimeNanos(_spillFlushTimeNanos),
@@ -80,6 +82,7 @@ SpillStats& SpillStats::operator+=(const SpillStats& other) {
   spilledFiles += other.spilledFiles;
   spillFillTimeNanos += other.spillFillTimeNanos;
   spillSortTimeNanos += other.spillSortTimeNanos;
+  spillExtractVectorTimeNanos += other.spillExtractVectorTimeNanos;
   spillSerializationTimeNanos += other.spillSerializationTimeNanos;
   spillWrites += other.spillWrites;
   spillFlushTimeNanos += other.spillFlushTimeNanos;
@@ -102,6 +105,8 @@ SpillStats SpillStats::operator-(const SpillStats& other) const {
   result.spilledFiles = spilledFiles - other.spilledFiles;
   result.spillFillTimeNanos = spillFillTimeNanos - other.spillFillTimeNanos;
   result.spillSortTimeNanos = spillSortTimeNanos - other.spillSortTimeNanos;
+  result.spillExtractVectorTimeNanos = spillExtractVectorTimeNanos - other.spillExtractVectorTimeNanos;
+  result.spillDeserializationTimeNanos = spillExtractVectorTimeNanos - other.spillExtractVectorTimeNanos;
   result.spillSerializationTimeNanos =
       spillSerializationTimeNanos - other.spillSerializationTimeNanos;
   result.spillWrites = spillWrites - other.spillWrites;
@@ -137,6 +142,7 @@ bool SpillStats::operator<(const SpillStats& other) const {
   UPDATE_COUNTER(spilledFiles);
   UPDATE_COUNTER(spillFillTimeNanos);
   UPDATE_COUNTER(spillSortTimeNanos);
+  UPDATE_COUNTER(spillExtractVectorTimeNanos);
   UPDATE_COUNTER(spillSerializationTimeNanos);
   UPDATE_COUNTER(spillWrites);
   UPDATE_COUNTER(spillFlushTimeNanos);
@@ -177,6 +183,7 @@ bool SpillStats::operator==(const SpillStats& other) const {
              spilledFiles,
              spillFillTimeNanos,
              spillSortTimeNanos,
+             spillExtractVectorTimeNanos,
              spillSerializationTimeNanos,
              spillWrites,
              spillFlushTimeNanos,
@@ -195,6 +202,7 @@ bool SpillStats::operator==(const SpillStats& other) const {
              other.spilledFiles,
              other.spillFillTimeNanos,
              other.spillSortTimeNanos,
+             other.spillExtractVectorTimeNanos,
              other.spillSerializationTimeNanos,
              other.spillWrites,
              other.spillFlushTimeNanos,
@@ -215,6 +223,7 @@ void SpillStats::reset() {
   spilledFiles = 0;
   spillFillTimeNanos = 0;
   spillSortTimeNanos = 0;
+  spillExtractVectorTimeNanos = 0;
   spillSerializationTimeNanos = 0;
   spillWrites = 0;
   spillFlushTimeNanos = 0;
@@ -230,7 +239,7 @@ std::string SpillStats::toString() const {
   return fmt::format(
       "spillRuns[{}] spilledInputBytes[{}] spilledBytes[{}] spilledRows[{}] "
       "spilledPartitions[{}] spilledFiles[{}] spillFillTimeNanos[{}] "
-      "spillSortTimeNanos[{}] spillSerializationTimeNanos[{}] spillWrites[{}] "
+      "spillSortTimeNanos[{}] spillExtractVectorTime[{}] spillSerializationTimeNanos[{}] spillWrites[{}] "
       "spillFlushTimeNanos[{}] spillWriteTimeNanos[{}] maxSpillExceededLimitCount[{}] "
       "spillReadBytes[{}] spillReads[{}] spillReadTimeNanos[{}] "
       "spillReadDeserializationTimeNanos[{}]",
@@ -242,6 +251,7 @@ std::string SpillStats::toString() const {
       spilledFiles,
       succinctNanos(spillFillTimeNanos),
       succinctNanos(spillSortTimeNanos),
+      succinctNanos(spillExtractVectorTimeNanos),
       succinctNanos(spillSerializationTimeNanos),
       spillWrites,
       succinctNanos(spillFlushTimeNanos),
@@ -281,6 +291,12 @@ void updateGlobalSpillFillTime(uint64_t timeNs) {
 void updateGlobalSpillSortTime(uint64_t timeNs) {
   RECORD_HISTOGRAM_METRIC_VALUE(kMetricSpillSortTimeMs, timeNs / 1'000'000);
   localSpillStats().wlock()->spillSortTimeNanos += timeNs;
+}
+
+void updateGlobalSpillExtractVectorTime(uint64_t timeNs) {
+  RECORD_HISTOGRAM_METRIC_VALUE(
+      kMetricSpillExtractVectorTimeMs, timeNs / 1'000'000);
+  localSpillStats().wlock()->spillExtractVectorTimeNanos += timeNs;
 }
 
 void updateGlobalSpillWriteStats(

--- a/velox/common/base/SpillStats.h
+++ b/velox/common/base/SpillStats.h
@@ -42,6 +42,8 @@ struct SpillStats {
   uint64_t spillFillTimeNanos{0};
   /// The time spent on sorting rows for spilling.
   uint64_t spillSortTimeNanos{0};
+  /// The time spent on extracting vector from RowContainer for spilling.
+  uint64_t spillExtractVectorTimeNanos{0};
   /// The time spent on serializing rows for spilling.
   uint64_t spillSerializationTimeNanos{0};
   /// The number of spill writer flushes, equivalent to number of write calls to
@@ -74,6 +76,7 @@ struct SpillStats {
       uint64_t _spilledFiles,
       uint64_t _spillFillTimeNanos,
       uint64_t _spillSortTimeNanos,
+      uint64_t _spillExtractVectorTimeNanos,
       uint64_t _spillSerializationTimeNanos,
       uint64_t _spillWrites,
       uint64_t _spillFlushTimeNanos,
@@ -120,31 +123,34 @@ void updateGlobalSpillRunStats(uint64_t numRuns);
 /// rows and the serializaion time.
 void updateGlobalSpillAppendStats(
     uint64_t numRows,
-    uint64_t serializaionTimeUs);
+    uint64_t serializaionTimeNs);
 
 /// Increments the number of spilled partitions.
 void incrementGlobalSpilledPartitionStats();
 
 /// Updates the time spent on filling rows to spill.
-void updateGlobalSpillFillTime(uint64_t timeUs);
+void updateGlobalSpillFillTime(uint64_t timeNs);
 
 /// Updates the time spent on sorting rows to spill.
-void updateGlobalSpillSortTime(uint64_t timeUs);
+void updateGlobalSpillSortTime(uint64_t timeNs);
+
+/// Updates the time spent on extracting vector from RowContainer to spill.
+void updateGlobalSpillExtractVectorTime(uint64_t timeNs);
 
 /// Updates the stats for disk write including the number of disk writes,
 /// the written bytes, the time spent on copying out (compression) for disk
 /// writes, the time spent on disk writes.
 void updateGlobalSpillWriteStats(
     uint64_t spilledBytes,
-    uint64_t flushTimeUs,
-    uint64_t writeTimeUs);
+    uint64_t flushTimeNs,
+    uint64_t writeTimeNs);
 
 /// Updates the stats for disk read including the number of disk reads, the
 /// amount of data read in bytes, and the time it takes to read from the disk.
 void updateGlobalSpillReadStats(
     uint64_t spillReads,
     uint64_t spillReadBytes,
-    uint64_t spillRadTimeUs);
+    uint64_t spillRadTimeNs);
 
 /// Increments the spill memory bytes.
 void updateGlobalSpillMemoryBytes(uint64_t spilledInputBytes);
@@ -157,7 +163,7 @@ void updateGlobalMaxSpillLevelExceededCount(
     uint64_t maxSpillLevelExceededCount);
 
 /// Increments the spill read deserialization time.
-void updateGlobalSpillDeserializationTimeNs(uint64_t timeUs);
+void updateGlobalSpillDeserializationTimeNs(uint64_t timeNs);
 
 /// Gets the cumulative global spill stats.
 SpillStats globalSpillStats();

--- a/velox/common/base/tests/SpillStatsTest.cpp
+++ b/velox/common/base/tests/SpillStatsTest.cpp
@@ -33,6 +33,7 @@ TEST(SpillStatsTest, spillStats) {
   stats1.spillFlushTimeNanos = 1023;
   stats1.spillWrites = 1023;
   stats1.spillSortTimeNanos = 1023;
+  stats1.spillExtractVectorTimeNanos = 1023;
   stats1.spillFillTimeNanos = 1023;
   stats1.spilledRows = 1023;
   stats1.spillSerializationTimeNanos = 1023;
@@ -52,6 +53,7 @@ TEST(SpillStatsTest, spillStats) {
   stats2.spillFlushTimeNanos = 1027;
   stats2.spillWrites = 1028;
   stats2.spillSortTimeNanos = 1029;
+  stats2.spillExtractVectorTimeNanos = 1033;
   stats2.spillFillTimeNanos = 1030;
   stats2.spilledRows = 1031;
   stats2.spillSerializationTimeNanos = 1032;
@@ -83,6 +85,7 @@ TEST(SpillStatsTest, spillStats) {
   ASSERT_EQ(delta.spillFlushTimeNanos, 4);
   ASSERT_EQ(delta.spillWrites, 5);
   ASSERT_EQ(delta.spillSortTimeNanos, 6);
+  ASSERT_EQ(delta.spillExtractVectorTimeNanos, 10);
   ASSERT_EQ(delta.spillFillTimeNanos, 7);
   ASSERT_EQ(delta.spilledRows, 8);
   ASSERT_EQ(delta.spillSerializationTimeNanos, 9);
@@ -99,6 +102,7 @@ TEST(SpillStatsTest, spillStats) {
   ASSERT_EQ(delta.spillFlushTimeNanos, -4);
   ASSERT_EQ(delta.spillWrites, -5);
   ASSERT_EQ(delta.spillSortTimeNanos, -6);
+  ASSERT_EQ(delta.spillExtractVectorTimeNanos, -10);
   ASSERT_EQ(delta.spillFillTimeNanos, -7);
   ASSERT_EQ(delta.spilledRows, -8);
   ASSERT_EQ(delta.spillSerializationTimeNanos, -9);
@@ -123,7 +127,7 @@ TEST(SpillStatsTest, spillStats) {
       stats2.toString(),
       "spillRuns[100] spilledInputBytes[2.00KB] spilledBytes[1.00KB] "
       "spilledRows[1031] spilledPartitions[1025] spilledFiles[1026] "
-      "spillFillTimeNanos[1.03us] spillSortTimeNanos[1.03us] "
+      "spillFillTimeNanos[1.03us] spillSortTimeNanos[1.03us] spillExtractVectorTime[1.03us] "
       "spillSerializationTimeNanos[1.03us] spillWrites[1028] spillFlushTimeNanos[1.03us] "
       "spillWriteTimeNanos[1.03us] maxSpillExceededLimitCount[4] "
       "spillReadBytes[2.00KB] spillReads[10] spillReadTimeNanos[100ns] "
@@ -132,7 +136,7 @@ TEST(SpillStatsTest, spillStats) {
       fmt::format("{}", stats2),
       "spillRuns[100] spilledInputBytes[2.00KB] spilledBytes[1.00KB] "
       "spilledRows[1031] spilledPartitions[1025] spilledFiles[1026] "
-      "spillFillTimeNanos[1.03us] spillSortTimeNanos[1.03us] "
+      "spillFillTimeNanos[1.03us] spillSortTimeNanos[1.03us] spillExtractVectorTime[1.03us] "
       "spillSerializationTimeNanos[1.03us] spillWrites[1028] "
       "spillFlushTimeNanos[1.03us] spillWriteTimeNanos[1.03us] "
       "maxSpillExceededLimitCount[4] "

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -507,7 +507,7 @@ TEST_F(HiveDataSinkTest, basic) {
       stats.toString(),
       "numWrittenBytes 0B numWrittenFiles 0 spillRuns[0] spilledInputBytes[0B] "
       "spilledBytes[0B] spilledRows[0] spilledPartitions[0] spilledFiles[0] "
-      "spillFillTimeNanos[0ns] spillSortTimeNanos[0ns] spillSerializationTimeNanos[0ns] "
+      "spillFillTimeNanos[0ns] spillSortTimeNanos[0ns] spillExtractVectorTime[0ns] spillSerializationTimeNanos[0ns] "
       "spillWrites[0] spillFlushTimeNanos[0ns] spillWriteTimeNanos[0ns] "
       "maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] "
       "spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns]");
@@ -555,7 +555,7 @@ TEST_F(HiveDataSinkTest, basicBucket) {
       stats.toString(),
       "numWrittenBytes 0B numWrittenFiles 0 spillRuns[0] spilledInputBytes[0B] "
       "spilledBytes[0B] spilledRows[0] spilledPartitions[0] spilledFiles[0] "
-      "spillFillTimeNanos[0ns] spillSortTimeNanos[0ns] spillSerializationTimeNanos[0ns] "
+      "spillFillTimeNanos[0ns] spillSortTimeNanos[0ns] spillExtractVectorTime[0ns] spillSerializationTimeNanos[0ns] "
       "spillWrites[0] spillFlushTimeNanos[0ns] spillWriteTimeNanos[0ns] "
       "maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] "
       "spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns]");

--- a/velox/docs/monitoring/stats.rst
+++ b/velox/docs/monitoring/stats.rst
@@ -122,6 +122,9 @@ These stats are reported by operators that support spilling.
    * - spillSortWallNanos
      - nanos
      - The time spent on sorting rows for spilling.
+   * - spillExtractVectorWallNanos
+     - nanos
+     - The time spent on extracting Vector from RowContainer for spilling.
    * - spillSerializationWallNanos
      - nanos
      - The time spent on serializing rows for spilling.

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -318,6 +318,13 @@ void Operator::recordSpillStats() {
             static_cast<int64_t>(lockedSpillStats->spillSortTimeNanos),
             RuntimeCounter::Unit::kNanos});
   }
+  if (lockedSpillStats->spillExtractVectorTimeNanos != 0) {
+    lockedStats->addRuntimeStat(
+        kSpillExtractVectorTime,
+        RuntimeCounter{
+            static_cast<int64_t>(lockedSpillStats->spillExtractVectorTimeNanos),
+            RuntimeCounter::Unit::kNanos});
+  }
   if (lockedSpillStats->spillSerializationTimeNanos != 0) {
     lockedStats->addRuntimeStat(
         kSpillSerializationTime,

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -333,6 +333,7 @@ class Operator : public BaseRuntimeStatWriter {
   /// The spill write stats.
   static inline const std::string kSpillFillTime{"spillFillWallNanos"};
   static inline const std::string kSpillSortTime{"spillSortWallNanos"};
+  static inline const std::string kSpillExtractVectorTime{"spillExtractVectorWallNanos"};
   static inline const std::string kSpillSerializationTime{
       "spillSerializationWallNanos"};
   static inline const std::string kSpillFlushTime{"spillFlushWallNanos"};

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -306,13 +306,13 @@ int64_t Spiller::extractSpillVector(
     RowVectorPtr& spillVector,
     size_t& nextBatchIndex) {
   VELOX_CHECK_NE(type_, Type::kHashJoinProbe);
-  uint64_t extractNanos{0};
+  uint64_t extractNs{0};
   auto limit = std::min<size_t>(rows.size() - nextBatchIndex, maxRows);
   VELOX_CHECK(!rows.empty());
   int32_t numRows = 0;
   int64_t bytes = 0;
   {
-    NanosecondTimer timer(&extractNanos);
+    NanosecondTimer timer(&extractNs);
     for (; numRows < limit; ++numRows) {
       bytes += container_->rowSize(rows[nextBatchIndex + numRows]);
       if (bytes > maxBytes) {
@@ -325,7 +325,7 @@ int64_t Spiller::extractSpillVector(
     extractSpill(folly::Range(&rows[nextBatchIndex], numRows), spillVector);
     nextBatchIndex += numRows;
   }
-  updateSpillExtractVectorTime(extractNanos);
+  updateSpillExtractVectorTime(extractNs);
   return bytes;
 }
 

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -447,20 +447,20 @@ std::unique_ptr<Spiller::SpillStatus> Spiller::writeSpill(int32_t partition) {
     int64_t totalBytes = 0;
     size_t written = 0;
     uint64_t extractNanos{0};
-    {
-      NanosecondTimer timer(&extractNanos);
-      while (written < run.rows.size()) {
+    while (written < run.rows.size()) {
+      {
+        NanosecondTimer timer(&extractNanos);
         extractSpillVector(
             run.rows,
             kTargetBatchRows,
             kTargetBatchBytes,
             spillVector,
             written);
-        totalBytes += state_.appendToPartition(partition, spillVector);
-        if (totalBytes > state_.targetFileSize()) {
-          VELOX_CHECK(!needSort());
-          state_.finishFile(partition);
-        }
+      }
+      totalBytes += state_.appendToPartition(partition, spillVector);
+      if (totalBytes > state_.targetFileSize()) {
+        VELOX_CHECK(!needSort());
+        state_.finishFile(partition);
       }
     }
     updateSpillExtractVectorTime(extractNanos);

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -319,6 +319,8 @@ class Spiller {
   void updateSpillFillTime(uint64_t timeUs);
 
   void updateSpillSortTime(uint64_t timeUs);
+  
+  void updateSpillExtractVectorTime(uint64_t timeUs);
 
   const Type type_;
   // NOTE: for hash join probe type, there is no associated row container for

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -110,6 +110,7 @@ void checkSpillStats(PlanNodeStats& stats, bool expectedSpill) {
     ASSERT_GT(stats.customStats[Operator::kSpillRuns].sum, 0);
     ASSERT_GT(stats.customStats[Operator::kSpillFillTime].sum, 0);
     ASSERT_GT(stats.customStats[Operator::kSpillSortTime].sum, 0);
+    ASSERT_GT(stats.customStats[Operator::kSpillExtractVectorTime].sum, 0);
     ASSERT_GT(stats.customStats[Operator::kSpillSerializationTime].sum, 0);
     ASSERT_GT(stats.customStats[Operator::kSpillFlushTime].sum, 0);
     ASSERT_GT(stats.customStats[Operator::kSpillWrites].sum, 0);
@@ -123,6 +124,7 @@ void checkSpillStats(PlanNodeStats& stats, bool expectedSpill) {
     ASSERT_EQ(stats.customStats[Operator::kSpillRuns].sum, 0);
     ASSERT_EQ(stats.customStats[Operator::kSpillFillTime].sum, 0);
     ASSERT_EQ(stats.customStats[Operator::kSpillSortTime].sum, 0);
+    ASSERT_EQ(stats.customStats[Operator::kSpillExtractVectorTime].sum, 0);
     ASSERT_EQ(stats.customStats[Operator::kSpillSerializationTime].sum, 0);
     ASSERT_EQ(stats.customStats[Operator::kSpillFlushTime].sum, 0);
     ASSERT_EQ(stats.customStats[Operator::kSpillWrites].sum, 0);

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -128,6 +128,7 @@ void verifyTaskSpilledRuntimeStats(const exec::Task& task, bool expectedSpill) {
             ASSERT_GE(op.runtimeStats[Operator::kSpillFillTime].sum, 0);
           }
           ASSERT_EQ(op.runtimeStats[Operator::kSpillSortTime].sum, 0);
+          // NOTE: spill extract vector might take less than one nanosecond.
           ASSERT_GT(op.runtimeStats[Operator::kSpillExtractVectorTime].sum, 0);
           ASSERT_GT(op.runtimeStats[Operator::kSpillSerializationTime].sum, 0);
           ASSERT_GE(op.runtimeStats[Operator::kSpillFlushTime].sum, 0);

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -122,14 +122,16 @@ void verifyTaskSpilledRuntimeStats(const exec::Task& task, bool expectedSpill) {
           if (op.operatorType == "HashBuild") {
             ASSERT_GT(op.runtimeStats[Operator::kSpillRuns].count, 0);
             ASSERT_GT(op.runtimeStats[Operator::kSpillFillTime].sum, 0);
+            ASSERT_GT(
+                op.runtimeStats[Operator::kSpillExtractVectorTime].sum, 0);
           } else {
             // The table spilling might also be triggered from hash probe side.
             ASSERT_GE(op.runtimeStats[Operator::kSpillRuns].count, 0);
             ASSERT_GE(op.runtimeStats[Operator::kSpillFillTime].sum, 0);
+            ASSERT_GE(
+                op.runtimeStats[Operator::kSpillExtractVectorTime].sum, 0);
           }
           ASSERT_EQ(op.runtimeStats[Operator::kSpillSortTime].sum, 0);
-          // NOTE: spill extract vector might take less than one nanosecond.
-          ASSERT_GT(op.runtimeStats[Operator::kSpillExtractVectorTime].sum, 0);
           ASSERT_GT(op.runtimeStats[Operator::kSpillSerializationTime].sum, 0);
           ASSERT_GE(op.runtimeStats[Operator::kSpillFlushTime].sum, 0);
           // NOTE: spill flush might take less than one microsecond.

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -107,6 +107,8 @@ void verifyTaskSpilledRuntimeStats(const exec::Task& task, bool expectedSpill) {
           ASSERT_EQ(op.runtimeStats[Operator::kSpillFillTime].count, 0);
           ASSERT_EQ(op.runtimeStats[Operator::kSpillSortTime].count, 0);
           ASSERT_EQ(
+              op.runtimeStats[Operator::kSpillExtractVectorTime].count, 0);
+          ASSERT_EQ(
               op.runtimeStats[Operator::kSpillSerializationTime].count, 0);
           ASSERT_EQ(op.runtimeStats[Operator::kSpillFlushTime].count, 0);
           ASSERT_EQ(op.runtimeStats[Operator::kSpillWrites].count, 0);
@@ -126,6 +128,7 @@ void verifyTaskSpilledRuntimeStats(const exec::Task& task, bool expectedSpill) {
             ASSERT_GE(op.runtimeStats[Operator::kSpillFillTime].sum, 0);
           }
           ASSERT_EQ(op.runtimeStats[Operator::kSpillSortTime].sum, 0);
+          ASSERT_GT(op.runtimeStats[Operator::kSpillExtractVectorTime].sum, 0);
           ASSERT_GT(op.runtimeStats[Operator::kSpillSerializationTime].sum, 0);
           ASSERT_GE(op.runtimeStats[Operator::kSpillFlushTime].sum, 0);
           // NOTE: spill flush might take less than one microsecond.

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -512,6 +512,7 @@ TEST_F(OrderByTest, spill) {
   ASSERT_GT(planStats.customStats[Operator::kSpillRuns].count, 0);
   ASSERT_GT(planStats.customStats[Operator::kSpillFillTime].sum, 0);
   ASSERT_GT(planStats.customStats[Operator::kSpillSortTime].sum, 0);
+  ASSERT_GT(planStats.customStats[Operator::kSpillExtractVectorTime].sum, 0);
   ASSERT_GT(planStats.customStats[Operator::kSpillSerializationTime].sum, 0);
   ASSERT_GT(planStats.customStats[Operator::kSpillFlushTime].sum, 0);
   ASSERT_EQ(

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -402,7 +402,7 @@ class SpillTest : public ::testing::TestWithParam<common::CompressionKind>,
         fmt::format(
             "spillRuns[{}] spilledInputBytes[{}] spilledBytes[{}] spilledRows[{}] "
             "spilledPartitions[{}] spilledFiles[{}] spillFillTimeNanos[{}] "
-            "spillSortTimeNanos[{}] spillSerializationTimeNanos[{}] spillWrites[{}] "
+            "spillSortTimeNanos[{}] spillExtractVectorTime[{}] spillSerializationTimeNanos[{}] spillWrites[{}] "
             "spillFlushTimeNanos[{}] spillWriteTimeNanos[{}] maxSpillExceededLimitCount[0] "
             "spillReadBytes[{}] spillReads[{}] spillReadTimeNanos[{}] "
             "spillReadDeserializationTimeNanos[{}]",
@@ -414,6 +414,7 @@ class SpillTest : public ::testing::TestWithParam<common::CompressionKind>,
             finalStats.spilledFiles,
             succinctNanos(finalStats.spillFillTimeNanos),
             succinctNanos(finalStats.spillSortTimeNanos),
+            succinctNanos(finalStats.spillExtractVectorTimeNanos),
             succinctNanos(finalStats.spillSerializationTimeNanos),
             finalStats.spillWrites,
             succinctNanos(finalStats.spillFlushTimeNanos),

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -864,9 +864,12 @@ class SpillerTest : public exec::test::RowContainerTestBase {
           ASSERT_GT(stats.spillSerializationTimeNanos, 0);
           ASSERT_GT(stats.spillWrites, 0);
         }
+        // kHashJoinProbe throws before extract vector.
+        ASSERT_EQ(stats.spillExtractVectorTimeNanos, 0);
       } else {
         ASSERT_GT(stats.spilledRows, 0);
         ASSERT_GT(stats.spilledBytes, 0);
+        ASSERT_GT(stats.spillExtractVectorTimeNanos, 0);
         ASSERT_GT(stats.spillWriteTimeNanos, 0);
         ASSERT_GT(stats.spillFlushTimeNanos, 0);
         ASSERT_GT(stats.spillSerializationTimeNanos, 0);
@@ -874,7 +877,6 @@ class SpillerTest : public exec::test::RowContainerTestBase {
       }
       ASSERT_GT(stats.spilledPartitions, 0);
       ASSERT_EQ(stats.spillSortTimeNanos, 0);
-      ASSERT_GT(stats.spillExtractVectorTimeNanos, 0);
       if (type_ == Spiller::Type::kHashJoinBuild ||
           type_ == Spiller::Type::kRowNumber) {
         ASSERT_GT(stats.spillFillTimeNanos, 0);

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -296,6 +296,7 @@ class SpillerTest : public exec::test::RowContainerTestBase {
     } else {
       ASSERT_GT(stats.spillSortTimeNanos, 0);
     }
+    ASSERT_GT(stats.spillExtractVectorTimeNanos, 0);
     ASSERT_GT(stats.spillFlushTimeNanos, 0);
     ASSERT_GT(stats.spillFillTimeNanos, 0);
     ASSERT_GT(stats.spillSerializationTimeNanos, 0);
@@ -328,6 +329,10 @@ class SpillerTest : public exec::test::RowContainerTestBase {
     ASSERT_EQ(
         prevGStats.spillSortTimeNanos + stats.spillSortTimeNanos,
         newGStats.spillSortTimeNanos);
+    ASSERT_EQ(
+        prevGStats.spillExtractVectorTimeNanos +
+            stats.spillExtractVectorTimeNanos,
+        newGStats.spillExtractVectorTimeNanos);
     ASSERT_EQ(
         prevGStats.spillFlushTimeNanos + stats.spillFlushTimeNanos,
         newGStats.spillFlushTimeNanos)
@@ -869,6 +874,7 @@ class SpillerTest : public exec::test::RowContainerTestBase {
       }
       ASSERT_GT(stats.spilledPartitions, 0);
       ASSERT_EQ(stats.spillSortTimeNanos, 0);
+      ASSERT_GT(stats.spillExtractVectorTimeNanos, 0);
       if (type_ == Spiller::Type::kHashJoinBuild ||
           type_ == Spiller::Type::kRowNumber) {
         ASSERT_GT(stats.spillFillTimeNanos, 0);
@@ -892,6 +898,10 @@ class SpillerTest : public exec::test::RowContainerTestBase {
       ASSERT_EQ(
           prevGStats.spillSortTimeNanos + stats.spillSortTimeNanos,
           newGStats.spillSortTimeNanos);
+      ASSERT_EQ(
+          prevGStats.spillExtractVectorTimeNanos +
+              stats.spillExtractVectorTimeNanos,
+          newGStats.spillExtractVectorTimeNanos);
       ASSERT_EQ(
           prevGStats.spillFlushTimeNanos + stats.spillFlushTimeNanos,
           newGStats.spillFlushTimeNanos)
@@ -1462,9 +1472,11 @@ TEST_P(AggregationOutputOnly, basic) {
     if (expectedNumSpilledRows == 0) {
       ASSERT_EQ(stats.spilledFiles, 0) << stats.toString();
       ASSERT_EQ(stats.spilledRows, 0) << stats.toString();
+      ASSERT_EQ(stats.spillExtractVectorTimeNanos, 0);
     } else {
       ASSERT_EQ(stats.spilledFiles, 1) << stats.toString();
       ASSERT_EQ(stats.spilledRows, expectedNumSpilledRows) << stats.toString();
+      ASSERT_GT(stats.spillExtractVectorTimeNanos, 0);
     }
     ASSERT_EQ(stats.spillSortTimeNanos, 0);
   }
@@ -1569,9 +1581,11 @@ TEST_P(OrderByOutputOnly, basic) {
     if (expectedNumSpilledRows == 0) {
       ASSERT_EQ(stats.spilledFiles, 0) << stats.toString();
       ASSERT_EQ(stats.spilledRows, 0) << stats.toString();
+      ASSERT_EQ(stats.spillExtractVectorTimeNanos, 0);
     } else {
       ASSERT_EQ(stats.spilledFiles, 1) << stats.toString();
       ASSERT_EQ(stats.spilledRows, expectedNumSpilledRows) << stats.toString();
+      ASSERT_GT(stats.spillExtractVectorTimeNanos, 0);
     }
     ASSERT_EQ(stats.spillSortTimeNanos, 0);
   }

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -3313,6 +3313,7 @@ TEST_P(BucketSortOnlyTableWriterTest, sortWriterSpill) {
   ASSERT_GT(stats.customStats[Operator::kSpillRuns].sum, 0);
   ASSERT_GT(stats.customStats[Operator::kSpillFillTime].sum, 0);
   ASSERT_GT(stats.customStats[Operator::kSpillSortTime].sum, 0);
+  ASSERT_GT(stats.customStats[Operator::kSpillExtractVectorTime].sum, 0);
   ASSERT_GT(stats.customStats[Operator::kSpillSerializationTime].sum, 0);
   ASSERT_GT(stats.customStats[Operator::kSpillFlushTime].sum, 0);
   ASSERT_GT(stats.customStats[Operator::kSpillWrites].sum, 0);


### PR DESCRIPTION
The extract vector time is 315.24ms while sort time is 475.01ms with default row type `INTEGER(), BIGINT(), VARCHAR(), VARBINARY(), DOUBLE()` and key type `INTEGER(), BIGINT()` 
