### PR TITLE
Fix arrow install with custom INSTALL_PREFIX

### DIFF
--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -206,7 +206,8 @@ function install_arrow {
     -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
     -DCMAKE_BUILD_TYPE=Release \
     -DARROW_BUILD_STATIC=ON \
-    -DThrift_SOURCE=BUNDLED
+    -DThrift_SOURCE=BUNDLED \
+    -DBOOST_ROOT=${INSTALL_PREFIX}
 
   (
     # Install thrift.

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -214,7 +214,8 @@ function install_arrow {
     -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
     -DCMAKE_BUILD_TYPE=Release \
     -DARROW_BUILD_STATIC=ON \
-    -DThrift_SOURCE=BUNDLED
+    -DThrift_SOURCE=BUNDLED \
+    -DBOOST_ROOT=${INSTALL_PREFIX}
 
   (
     # Install thrift.


### PR DESCRIPTION
If the recently added INSTALL_PREFIX does not point to /usr/local in Linux then the bundled Thrift installation from the Arrow dependency fails because it cannot locate Boost.

Boost was previously installed into the INSTALL_PREFIX but the Thrift CMake in Arrow does not pass on any PREFIX_PATH settings to Thrift. The PREFIX_PATH is set to the INSTALL_PREFIX and works with Arrow itself just fine.

The error would be

Could NOT find Boost (missing: Boost_INCLUDE_DIR) (Required is at least
  version "1.56")