### PR TITLE
Fix fast_float installation problems

### DIFF
--- a/CMake/resolve_dependency_modules/fast_float.cmake
+++ b/CMake/resolve_dependency_modules/fast_float.cmake
@@ -17,7 +17,7 @@ set(VELOX_FAST_FLOAT_VERSION 6.1.6)
 set(VELOX_FAST_FLOAT_BUILD_SHA256_CHECKSUM
     4458aae4b0eb55717968edda42987cabf5f7fc737aee8fede87a70035dba9ab0)
 set(VELOX_FAST_FLOAT_SOURCE_URL
-    "https://github.com/fastfloat/fast_float/archive/v${VELOX_FAST_FLOAT_VERSION}.tar.gz"
+    "https://github.com/fastfloat/fast_float/archive/refs/tags/v${VELOX_FAST_FLOAT_VERSION}.tar.gz"
 )
 
 resolve_dependency_url(FAST_FLOAT)

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -43,6 +43,7 @@ MACOS_VELOX_DEPS="bison flex gflags glog googletest icu4c libevent libsodium lz4
 MACOS_BUILD_DEPS="ninja cmake"
 FB_OS_VERSION="v2024.09.16.00"
 FMT_VERSION="10.1.1"
+FAST_FLOAT_VERSION="v6.1.6"
 
 function update_brew {
   DEFAULT_BREW_PATH=/usr/local/bin/brew


### PR DESCRIPTION
https://github.com/facebookincubator/velox/pull/11018 added install_fast_float, but didn't specify the version by default. The setup failed to download the package with the "tar: Error opening archive: Unrecognized archive format" error. Also the fast_float.cmake introduced by this PR had the wrong VELOX_FAST_FLOAT_SOURCE_URL. It is missing "refs/tags/".

This PR fixes these two problems.

Fixes https://github.com/facebookincubator/velox/issues/11055