### PR TITLE
Fix duckdb build failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,9 +48,6 @@ endif()
 if(DEFINED ENV{INSTALL_PREFIX})
   message(STATUS "Dependency install directory set to: $ENV{INSTALL_PREFIX}")
   list(APPEND CMAKE_PREFIX_PATH "$ENV{INSTALL_PREFIX}")
-  # Allow installed package headers to be picked up before brew/system package
-  # headers
-  include_directories(BEFORE "$ENV{INSTALL_PREFIX}/include")
 endif()
 
 list(PREPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMake"


### PR DESCRIPTION
Improve dependency install and build (#10920) installs all dependencies in
    deps-install subfolder, and set the include directory to it in front of
    other include directories. This caused duckdb build failed with "error:
    use of undeclared identifier 'FMT_SNPRINTF'". This commit removes the
    BEFORE keyword to fix the problem.

Fixes https://github.com/facebookincubator/velox/issues/11058