### PR TITLE
Release memory when reservation triggers spilling

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -928,6 +928,14 @@ void GroupingSet::ensureOutputFits() {
   {
     memory::ReclaimableSectionGuard guard(nonReclaimableSection_);
     if (pool_.maybeReserve(outputBufferSizeToReserve)) {
+      if (hasSpilled()) {
+        // If reservation triggers spilling on the 'GroupingSet' itself, we will
+        // no longer need the reserved memory for output processing as the
+        // output processing will be conducted from unspilled data through
+        // 'getOutputWithSpill()', and it does not require this amount of memory
+        // to process.
+        pool_.release();
+      }
       return;
     }
   }


### PR DESCRIPTION
Spillable operator might trigger spill when it reserve memory from the arbitrator. If that happens, we shall release the reserved memory if the reserved memory is no longer needed after spilling.