### PR TITLE
Clean up timezoneId from TimestampWithTimezone helper

### DIFF
--- a/velox/type/tz/TimeZoneMap.h
+++ b/velox/type/tz/TimeZoneMap.h
@@ -108,6 +108,10 @@ class TimeZone {
   TimeZone(const TimeZone&) = delete;
   TimeZone& operator=(const TimeZone&) = delete;
 
+  friend std::ostream& operator<<(std::ostream& os, const TimeZone& timezone) {
+    return os << timezone.name();
+  }
+
   using seconds = std::chrono::seconds;
 
   /// Converts a local time (the time as perceived in the user time zone


### PR DESCRIPTION
Summary: We want to capture a tz::TimeZone* instead of relying on timezoneID inside TimestampWithTimezone helper. The former is more flexible and provides conversion capabilities.

Reviewed By: pedroerp

Differential Revision: D63139790
