### PR TITLE
Fix full outer result mismatch issue when output contains multiple matching rows

### DIFF
--- a/velox/exec/MergeJoin.h
+++ b/velox/exec/MergeJoin.h
@@ -190,7 +190,12 @@ class MergeJoin : public Operator {
   bool addToOutput();
 
   // Appends the current set of matching rows, leftMatch_ x rightMatch_ for
-  // left.
+  // left. Full outer join is matched according to left join, so when there are
+  // multiple matched rows, it is easy to lose rows from the right table that do
+  // not have matches. Therefore, after all matches on the left side are
+  // completed, we call the filter function to check if there are any rows on
+  // the right side that do not have matches. If there are, a new row needs to
+  // be added, with the left side of this new row set to null.
   bool addToOutputForLeftJoin();
 
   // Appends the current set of matching rows, rightMatch_ x leftMatch_ for

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -508,6 +508,45 @@ TEST_F(MergeJoinTest, leftAndRightJoinFilter) {
   }
 }
 
+TEST_F(MergeJoinTest, fullOuterJoinWithDuplicateMatch) {
+  // Each row on the left side has at most one match on the right side.
+  auto left = makeRowVector(
+      {"a", "b"},
+      {
+          makeNullableFlatVector<int32_t>({1, 2, 2, 2, 3, 5, 6, std::nullopt}),
+          makeNullableFlatVector<double>(
+              {2.0, 100.0, 1.0, 1.0, 3.0, 1.0, 6.0, std::nullopt}),
+      });
+
+  auto right = makeRowVector(
+      {"c", "d"},
+      {
+          makeNullableFlatVector<int32_t>(
+              {0, 2, 2, 2, 2, 3, 4, 5, 7, std::nullopt}),
+          makeNullableFlatVector<double>(
+              {0.0, 3.0, -1.0, -1.0, 3.0, 2.0, 1.0, 3.0, 7.0, std::nullopt}),
+      });
+
+  createDuckDbTable("t", {left});
+  createDuckDbTable("u", {right});
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+
+  auto rightPlan =
+      PlanBuilder(planNodeIdGenerator)
+          .values({left})
+          .mergeJoin(
+              {"a"},
+              {"c"},
+              PlanBuilder(planNodeIdGenerator).values({right}).planNode(),
+              "b < d",
+              {"a", "b", "c", "d"},
+              core::JoinType::kFull)
+          .planNode();
+  AssertQueryBuilder(rightPlan, duckDbQueryRunner_)
+      .assertResults("SELECT * from t FULL OUTER JOIN u ON a = c AND b < d");
+}
+
 TEST_F(MergeJoinTest, rightJoinWithDuplicateMatch) {
   // Each row on the left side has at most one match on the right side.
   auto left = makeRowVector(


### PR DESCRIPTION
Assume the left table has columns a and b:
```
a       b
2	100
2	1
2	1
```
The right table has columns c and d:
```
c       d
2	3
2	-1
2	-1
2	3
```

The two tables are joined using a full outer join on the condition a == c and b < d. During the doGetOutput phase, the result is matched using a left join, resulting in 3 * 4 = 12 records:

```
No      a        b       c      d
0	2	100	 2	3
1	2	100	 2	-1
2	2	100	 2	-1
3	2	100	 2	3
4	2	1	 2	3
5	2	1	 2	-1
6	2	1	 2	-1
7	2	1	 2	3
8	2	1	 2	3
9	2	1	 2	-1
10	2	1	 2	-1
11	2	1	 2	3
```

Then, in the filter method, the records are filtered based on the condition b < d, resulting in the following:

```
No	a	b	c	d	matched
0	2	100	2	3	FALSE
1	2	100	2	-1	FALSE
2	2	100	2	-1	FALSE
3	2	100	2	3	FALSE
4	2	1	2	3	TRUE
5	2	1	2	-1	FALSE
6	2	1	2	-1	FALSE
7	2	1	2	3	TRUE
8	2	1	2	3	TRUE
9	2	1	2	-1	FALSE
10	2	1	2	-1	FALSE
11	2	1	2	3	TRUE
```

Finally, records from the left table that do not have a match are filled with nulls, resulting in the following final output:
```
No	a	b	c	 d
0	2	100	null null
1	2	1	2	 3
2	2	1	2	 3
3	2	1	2	 3
4	2	1	2	 3
```
The above result is incorrect because it is missing rows from the right table that do not have a match. Among the 12 rows above, rows 0, 4, and 8 correspond to the first record (2, 3) from the right table, rows 1, 5, and 9 correspond to the second record (2, -1) from the right table, rows 2, 6, and 10 correspond to the third record (2, -1) from the right table, and rows 3, 7, and 11 correspond to the fourth record (2, 3) from the right table. From the matching results above, rows 1, 5, and 9, as well as rows 2, 6, and 10, are all false, meaning that the third and fourth records from the right table do not have matching rows. Therefore, the final result is missing rows from the right table that do not have matches. The correct final result should be:
```
No	a	b	c	 d
0	2	100	null   null
1	2	1	2	 3
2	2	1	2	 3
3	2	1	2	 3
4	2	1	2	 3
5       null    null    2       -1
6       null    null    2       -1
```

This PR calls the filter function when the keys are the same to filter out rows from the right table that do not have matches. If a row from the right table does not have a match, a new record is inserted with the corresponding columns from the left table set to null.