### PR TITLE
Fix DuckDB bundling and add support for DuckDB install on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,9 +48,6 @@ endif()
 if(DEFINED ENV{INSTALL_PREFIX})
   message(STATUS "Dependency install directory set to: $ENV{INSTALL_PREFIX}")
   list(APPEND CMAKE_PREFIX_PATH "$ENV{INSTALL_PREFIX}")
-  # Allow installed package headers to be picked up before brew/system package
-  # headers
-  include_directories(BEFORE "$ENV{INSTALL_PREFIX}/include")
 endif()
 
 list(PREPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMake"
@@ -190,6 +187,18 @@ if(${VELOX_BUILD_PYTHON_PACKAGE})
   set(VELOX_ENABLE_EXEC ON)
   set(VELOX_ENABLE_AGGREGATES ON)
   set(VELOX_ENABLE_SPARK_FUNCTIONS ON)
+endif()
+
+if(${VELOX_ENABLE_DUCKDB})
+  set_source(DuckDB)
+  resolve_dependency(DuckDB)
+endif()
+
+if(DEFINED ENV{INSTALL_PREFIX})
+  # Allow installed package headers to be picked up before brew/system package
+  # headers. We set this after DuckDB bundling since DuckDB uses its own
+  # dependencies.
+  include_directories(BEFORE "$ENV{INSTALL_PREFIX}/include")
 endif()
 
 # We look for OpenSSL here to cache the result enforce the version across our
@@ -412,11 +421,6 @@ else()
   set(glog_SOURCE SYSTEM)
 endif()
 resolve_dependency(glog)
-
-if(${VELOX_ENABLE_DUCKDB})
-  set_source(DuckDB)
-  resolve_dependency(DuckDB)
-endif()
 
 set_source(fmt)
 resolve_dependency(fmt 9.0.0)

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -38,6 +38,7 @@ PYTHON_VENV=${PYHTON_VENV:-"${SCRIPTDIR}/../.venv"}
 export OS_CXXFLAGS=" -isystem $(brew --prefix)/include "
 NPROC=$(getconf _NPROCESSORS_ONLN)
 
+BUILD_DUCKDB="${BUILD_DUCKDB:-true}"
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
 MACOS_VELOX_DEPS="bison flex gflags glog googletest icu4c libevent libsodium lz4 lzo openssl protobuf@21 snappy xz zstd"
 MACOS_BUILD_DEPS="ninja cmake"
@@ -147,6 +148,14 @@ function install_fast_float {
   cmake_install_dir fast_float
 }
 
+function install_duckdb {
+  if $BUILD_DUCKDB ; then
+    echo 'Building DuckDB'
+    wget_and_untar https://github.com/duckdb/duckdb/archive/refs/tags/v0.8.1.tar.gz duckdb
+    cmake_install_dir duckdb -DBUILD_UNITTESTS=OFF -DENABLE_SANITIZER=OFF -DENABLE_UBSAN=OFF -DBUILD_SHELL=OFF -DEXPORT_DLL_SYMBOLS=OFF -DCMAKE_BUILD_TYPE=Release
+  fi
+}
+
 function install_velox_deps {
   run_and_time install_velox_deps_from_brew
   run_and_time install_ranges_v3
@@ -159,6 +168,7 @@ function install_velox_deps {
   run_and_time install_wangle
   run_and_time install_mvfst
   run_and_time install_fbthrift
+  run_and_time install_duckdb
 }
 
 (return 2> /dev/null) && return # If script was sourced, don't run commands.


### PR DESCRIPTION
DuckDB fails to build after the recent support for INSTALL_PREFIX

Resolves https://github.com/facebookincubator/velox/issues/11058