### PR TITLE
CMake: Make the env variable precedence by default in set_with_default

### DIFF
--- a/CMake/ResolveDependency.cmake
+++ b/CMake/ResolveDependency.cmake
@@ -139,7 +139,7 @@ macro(resolve_dependency_url dependency_name)
   set_with_default(
     VELOX_${dependency_name}_SOURCE_URL VELOX_${dependency_name}_URL
     ${VELOX_${dependency_name}_SOURCE_URL})
-  message(STATUS "Set VELOX_${dependency_name}_SOURCE_URL to "
+  message(VERBOSE "Set VELOX_${dependency_name}_SOURCE_URL to "
                  "${VELOX_${dependency_name}_SOURCE_URL}")
   if(DEFINED ENV{VELOX_${dependency_name}_URL})
     set_with_default(VELOX_${dependency_name}_BUILD_SHA256_CHECKSUM

--- a/CMake/ResolveDependency.cmake
+++ b/CMake/ResolveDependency.cmake
@@ -103,12 +103,10 @@ function(set_with_default var_name envvar_name default)
     set(${var_name}
         $ENV{${envvar_name}}
         PARENT_SCOPE)
-  else()
-    if(NOT DEFINED ${var_name})
-      set(${var_name}
-          ${default}
-          PARENT_SCOPE)
-    endif()
+  elseif(NOT DEFINED ${var_name})
+    set(${var_name}
+        ${default}
+        PARENT_SCOPE)
   endif()
 endfunction()
 

--- a/CMake/ResolveDependency.cmake
+++ b/CMake/ResolveDependency.cmake
@@ -141,6 +141,8 @@ macro(resolve_dependency_url dependency_name)
   set_with_default(
     VELOX_${dependency_name}_SOURCE_URL VELOX_${dependency_name}_URL
     ${VELOX_${dependency_name}_SOURCE_URL})
+  message(STATUS "Set VELOX_${dependency_name}_SOURCE_URL to "
+                 "${VELOX_${dependency_name}_SOURCE_URL}")
   if(DEFINED ENV{VELOX_${dependency_name}_URL})
     set_with_default(VELOX_${dependency_name}_BUILD_SHA256_CHECKSUM
                      VELOX_${dependency_name}_SHA256 "")

--- a/CMake/ResolveDependency.cmake
+++ b/CMake/ResolveDependency.cmake
@@ -140,7 +140,7 @@ macro(resolve_dependency_url dependency_name)
     VELOX_${dependency_name}_SOURCE_URL VELOX_${dependency_name}_URL
     ${VELOX_${dependency_name}_SOURCE_URL})
   message(VERBOSE "Set VELOX_${dependency_name}_SOURCE_URL to "
-                 "${VELOX_${dependency_name}_SOURCE_URL}")
+          "${VELOX_${dependency_name}_SOURCE_URL}")
   if(DEFINED ENV{VELOX_${dependency_name}_URL})
     set_with_default(VELOX_${dependency_name}_BUILD_SHA256_CHECKSUM
                      VELOX_${dependency_name}_SHA256 "")

--- a/CMake/ResolveDependency.cmake
+++ b/CMake/ResolveDependency.cmake
@@ -94,22 +94,21 @@ macro(set_source dependency_name)
     STATUS "Setting ${dependency_name} source to ${${dependency_name}_SOURCE}")
 endmacro()
 
-# If the var_name is not defined then set var_name to the value of
-# $ENV{envvar_name} if it is defined. If neither is defined then set var_name to
-# ${DEFAULT}. If called from within a nested scope the variable will not
-# propagate into outer scopes automatically! Use PARENT_SCOPE.
+# Set var_name to the value of $ENV{envvar_name} if ENV is defined. If neither
+# ENV or var_name is defined then set var_name to ${DEFAULT}. If called from
+# within a nested scope the variable will not propagate into outer scopes
+# automatically! Use PARENT_SCOPE.
 function(set_with_default var_name envvar_name default)
-  if(DEFINED ${var_name})
-    return()
-  endif()
   if(DEFINED ENV{${envvar_name}})
     set(${var_name}
         $ENV{${envvar_name}}
         PARENT_SCOPE)
   else()
-    set(${var_name}
-        ${default}
-        PARENT_SCOPE)
+    if(NOT DEFINED ${var_name})
+      set(${var_name}
+          ${default}
+          PARENT_SCOPE)
+    endif()
   endif()
 endfunction()
 


### PR DESCRIPTION
After the modification in #11040, if the `var_name` is already defined, the `set_with_default` method will not override it with the env variable. However, before that, the value from the env will be prioritized for defining `var_name`. The design goal of the `resolve_dependency_url` method is to allow the overriding of values defined in `VELOX_xxx_SOURCE_URL` with env variables, which enables specifying `VELOX_xxx_SOURCE_URL` to a local file to reduce dependency download time and achieve offline dependency compilation.