### PR TITLE
Enable reading explicit row number column from Prism connector

### DIFF
--- a/velox/dwio/common/ColumnSelector.cpp
+++ b/velox/dwio/common/ColumnSelector.cpp
@@ -344,7 +344,7 @@ std::shared_ptr<ColumnSelector> ColumnSelector::fromScanSpec(
     const RowTypePtr& rowType) {
   std::vector<std::string> columnNames;
   for (auto& child : spec.children()) {
-    if (child->isConstant()) {
+    if (child->isConstant() || child->isExplicitRowNumber()) {
       continue;
     }
     std::string name = child->fieldName();

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -5090,6 +5090,10 @@ TEST_F(TableScanTest, rowNumberInRemainingFilter) {
   auto file = TempFilePath::create();
   writeToFile(file->getPath(), {vector});
   auto outputType = ROW({"c1"}, {BIGINT()});
+  // FIXME: We should not need r1 in table schema for production code; this is
+  // just to infer type of r1 in remaining filter expression parser.  We
+  // probably need to find a way to specify the type of r1 without adding it to
+  // table schema to test this case.  For now it's essentially untested.
   auto schema = ROW({"c1", "r1"}, {BIGINT(), BIGINT()});
   auto plan = PlanBuilder()
                   .startTableScan()


### PR DESCRIPTION
Summary:
Also add the missing implementation for
`FlatMapAsStructColumnReader::estimateMaterializedSize`.

Differential Revision: D63151114
