### PR TITLE
Update replace function to work with empty input and search strings

### DIFF
--- a/velox/functions/lib/string/StringCore.h
+++ b/velox/functions/lib/string/StringCore.h
@@ -377,8 +377,12 @@ inline int64_t findNthInstanceByteIndexFromEnd(
 /// be the same. When replaced is empty and ignoreEmptyReplaced is false,
 /// replacement is added before and after each charecter. When replaced is
 /// empty and ignoreEmptyReplaced is true, the result is the inputString value.
-/// When inputString is empty results is empty.
-/// replace("", "", "x") = ""
+/// When inputString and replaced strings are empty, result is the
+/// replacement string if ignoreEmptyReplaced is false, otherwise the result is
+/// empty.
+///
+/// replace("", "", "x") = "" -- when ignoreEmptyReplaced is true
+/// replace("", "", "x") = "x" -- when ignoreEmptyReplaced is false
 /// replace("aa", "", "x") = "xaxax" -- when ignoreEmptyReplaced is false
 /// replace("aa", "", "x") = "aa" -- when ignoreEmptyReplaced is true
 template <bool ignoreEmptyReplaced = false>
@@ -388,12 +392,16 @@ inline static size_t replace(
     const std::string_view& replaced,
     const std::string_view& replacement,
     bool inPlace = false) {
-  if (inputString.size() == 0) {
+  if (inputString.empty()) {
+    if (!ignoreEmptyReplaced && replaced.empty() && !replacement.empty()) {
+      std::memcpy(outputString, replacement.data(), replacement.size());
+      return replacement.size();
+    }
     return 0;
   }
 
   if constexpr (ignoreEmptyReplaced) {
-    if (replaced.size() == 0) {
+    if (replaced.empty()) {
       if (!inPlace) {
         std::memcpy(outputString, inputString.data(), inputString.size());
       }
@@ -446,8 +454,8 @@ inline static size_t replace(
   };
 
   // Special case when size of replaced is 0
-  if (replaced.size() == 0) {
-    if (replacement.size() == 0) {
+  if (replaced.empty()) {
+    if (replacement.empty()) {
       if (!inPlace) {
         std::memcpy(outputString, inputString.data(), inputString.size());
       }

--- a/velox/functions/lib/string/tests/StringImplTest.cpp
+++ b/velox/functions/lib/string/tests/StringImplTest.cpp
@@ -542,7 +542,7 @@ TEST_F(StringImplTest, replace) {
   runTest("foo", "", "", "foo");
   runTest("foo", "foo", "", "");
   runTest("abc", "", "xx", "xxaxxbxxcxx");
-  runTest("", "", "xx", "");
+  runTest("", "", "xx", "xx");
   runTest("", "", "", "");
 
   runTest(

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -1463,11 +1463,14 @@ TEST_F(StringFunctionsTest, replace) {
       {{"123tech123", "123", "tech"}, {"techtechtech"}},
       {{"123tech123", "123", ""}, {"tech"}},
       {{"222tech", "2", "3"}, {"333tech"}},
+      {{"", "", "K"}, {"K"}},
+      {{"", "", ""}, {""}},
   };
 
   replace_input_test_t testsTwoArgs = {
       {{"abcdefabcdef", "cd", ""}, {"abefabef"}},
       {{"123tech123", "123", ""}, {"tech"}},
+      {{"", "K", ""}, {""}},
       {{"", "", ""}, {""}},
   };
 


### PR DESCRIPTION
Summary:
Presto and Velox currently return different results for the following:

select replace(c0, c0, c1) from (values ('', 'K')) t(c0, c1);

Presto-0.289: Returns "K".
Velox: Returns "".

This change updates the velox function to work like the Presto function.

Differential Revision: D63268907
