### PR TITLE
fix: Use dequeue to track WindowPartitions in RowStreamingWindowBuild

### DIFF
--- a/velox/exec/RowsStreamingWindowBuild.cpp
+++ b/velox/exec/RowsStreamingWindowBuild.cpp
@@ -122,7 +122,6 @@ void RowsStreamingWindowBuild::noMoreInput() {
 }
 
 std::shared_ptr<WindowPartition> RowsStreamingWindowBuild::nextPartition() {
-  VELOX_CHECK(!windowPartitions_.empty());
   return outputPartition();
 }
 

--- a/velox/exec/RowsStreamingWindowBuild.cpp
+++ b/velox/exec/RowsStreamingWindowBuild.cpp
@@ -118,13 +118,14 @@ std::shared_ptr<WindowPartition> RowsStreamingWindowBuild::nextPartition() {
     windowPartitions_.pop_front();
   }
 
+  VELOX_CHECK(hasNextPartition());
   return windowPartitions_.front();
 }
 
 bool RowsStreamingWindowBuild::hasNextPartition() {
   // Checks if there is a window partition that is either incomplete or
   // completed but has unconsumed rows.
-  for (auto windowPartition : windowPartitions_) {
+  for (const auto& windowPartition : windowPartitions_) {
     if (!windowPartition->complete() || windowPartition->numRows() > 0) {
       return true;
     }

--- a/velox/exec/RowsStreamingWindowBuild.cpp
+++ b/velox/exec/RowsStreamingWindowBuild.cpp
@@ -125,7 +125,9 @@ std::shared_ptr<WindowPartition> RowsStreamingWindowBuild::nextPartition() {
 bool RowsStreamingWindowBuild::hasNextPartition() {
   // Checks if there is a window partition that is either incomplete or
   // completed but has unconsumed rows.
-  for (const auto& windowPartition : windowPartitions_) {
+  for (auto it = windowPartitions_.rbegin(); it != windowPartitions_.rend();
+       ++it) {
+    const auto& windowPartition = *it;
     if (!windowPartition->complete() || windowPartition->numRows() > 0) {
       return true;
     }

--- a/velox/exec/RowsStreamingWindowBuild.cpp
+++ b/velox/exec/RowsStreamingWindowBuild.cpp
@@ -126,9 +126,13 @@ std::shared_ptr<WindowPartition> RowsStreamingWindowBuild::nextPartition() {
 }
 
 bool RowsStreamingWindowBuild::hasNextPartition() {
-  // Remove the processed output partition from the queue.
+  // Note: an exception may be thrown if remove the windowPartition_ in
+  // nextPartition method. This is because hasNextPartition might return true,
+  // but when we actually retrieve the window partition in nextPartition, it
+  // could be empty after the removal.
   while (!windowPartitions_.empty() && outputPartition()->complete() &&
          outputPartition()->numRows() == 0) {
+    // Remove the processed output partition from the queue.
     windowPartitions_.pop_front();
   }
 

--- a/velox/exec/RowsStreamingWindowBuild.h
+++ b/velox/exec/RowsStreamingWindowBuild.h
@@ -76,6 +76,12 @@ class RowsStreamingWindowBuild : public WindowBuild {
   // Used to compare rows based on partitionKeys.
   char* previousRow_ = nullptr;
 
+  // Point to the current output partition if not -1.
+  vector_size_t outputPartition_ = 0;
+
+  // Current input partition that receives inputs.
+  vector_size_t inputPartition_ = 0;
+
   // The head of the deque (front) will always point to the current WP being
   // processed. Once the current WP is processed, it will be discarded (removed
   // from the front of the deque). The next WP to be processed will then become

--- a/velox/exec/RowsStreamingWindowBuild.h
+++ b/velox/exec/RowsStreamingWindowBuild.h
@@ -58,13 +58,10 @@ class RowsStreamingWindowBuild : public WindowBuild {
   // does not exist.
   void addPartitionInputs(bool finished);
 
-  // Returns the current input partition.
-  std::shared_ptr<WindowPartition> inputPartition() const;
-
-  // Returns the current output partition.
-  std::shared_ptr<WindowPartition> outputPartition() const;
-
-  // Ensure an incomplete Window Partition exists; otherwise, create a new one.
+  // Invoked before add input to ensure there is an open (in-complete) partition
+  // to accept new input. The function creates a new one at the tail of
+  // 'windowPartitions_' if it is empty or the last partition is already
+  // completed.
   void ensureInputPartition();
 
   // Sets to true if this window node has range frames.
@@ -76,10 +73,8 @@ class RowsStreamingWindowBuild : public WindowBuild {
   // Used to compare rows based on partitionKeys.
   char* previousRow_ = nullptr;
 
-  // The head of the deque (front) will always point to the current WP being
-  // processed. Once the current WP is processed, it will be discarded (removed
-  // from the front of the deque). The next WP to be processed will then become
-  // the new head of the deque.
+  /// The output gets next partition from the head of 'windowPartitions_' and
+  /// input adds to the next partition from the tail of 'windowPartitions_'.
   std::deque<std::shared_ptr<WindowPartition>> windowPartitions_;
 };
 

--- a/velox/exec/RowsStreamingWindowBuild.h
+++ b/velox/exec/RowsStreamingWindowBuild.h
@@ -51,7 +51,7 @@ class RowsStreamingWindowBuild : public WindowBuild {
 
   std::shared_ptr<WindowPartition> nextPartition() override;
 
-  inline bool needsInput() override;
+  bool needsInput() override;
 
  private:
   // Adds input rows to the current partition, or creates a new partition if it
@@ -59,10 +59,13 @@ class RowsStreamingWindowBuild : public WindowBuild {
   void addPartitionInputs(bool finished);
 
   // Returns the current input partition.
-  std::shared_ptr<WindowPartition> inputPartition();
+  std::shared_ptr<WindowPartition> inputPartition() const;
 
   // Returns the current output partition.
-  std::shared_ptr<WindowPartition> outputPartition();
+  std::shared_ptr<WindowPartition> outputPartition() const;
+
+  // Ensure an incomplete Window Partition exists; otherwise, create a new one.
+  void ensureInputPartition();
 
   // Sets to true if this window node has range frames.
   const bool hasRangeFrame_;

--- a/velox/exec/RowsStreamingWindowBuild.h
+++ b/velox/exec/RowsStreamingWindowBuild.h
@@ -76,12 +76,6 @@ class RowsStreamingWindowBuild : public WindowBuild {
   // Used to compare rows based on partitionKeys.
   char* previousRow_ = nullptr;
 
-  // Point to the current output partition if not -1.
-  vector_size_t outputPartition_ = 0;
-
-  // Current input partition that receives inputs.
-  vector_size_t inputPartition_ = 0;
-
   // The head of the deque (front) will always point to the current WP being
   // processed. Once the current WP is processed, it will be discarded (removed
   // from the front of the deque). The next WP to be processed will then become


### PR DESCRIPTION
In the core case, if each row corresponds to a separate WindowPartition, this could result in an excessive number of WindowPartition instances being held in memory, potentially leading to OOM . To fix this issue, this PR  proposes replacing the std::vector with a deque data structure, which will allow for more efficient release of WindowPartition resources.