### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,5 +27,5 @@ CMake/ @assignUser
 *.cmake @assignUser
 **/CMakeLists.txt @assignUser
 scripts/ @assignUser
-.github @assignUser
+.github/ @assignUser
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,31 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The CODEOWNERS file allows us to setup file based rules that will automatically
+# request a review from owners on PRs with changes to matching files.
+# We currently do not enforce these reviews as required so it's only a tool
+# for more granular notifications at the moment. For example component maintainers
+# can set a rule so that they are pinged on changes to the sections of the 
+# codebase that are relevant for their component.
+
+# Only users that have write access to the repo can be added as owners.
+# See the official docs for more details on syntax and precedence of rules: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
+
+# Build & CI
+CMake/ @assignUser
+*.cmake @assignUser
+**/CMakeLists.txt @assignUser
+scripts/ @assignUser
+.github @assignUser
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,9 +23,20 @@
 # See the official docs for more details on syntax and precedence of rules: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
 
 # Build & CI
-CMake/ @assignUser
-*.cmake @assignUser
-**/CMakeLists.txt @assignUser
-scripts/ @assignUser
-.github/ @assignUser
+CMake/ @assignUser @majetideepak
+*.cmake @assignUser @majetideepak
+**/CMakeLists.txt @assignUser @majetideepak
+scripts/ @assignUser @majetideepak
+.github/ @assignUser @majetideepak
 
+# Parquet
+velox/dwio/parquet/ @majetideepak
+
+# Storage Adapters
+velox/connectors/hive/storage_adapters/ @majetideepak
+
+# Connectors
+velox/connectors/ @majetideepak
+
+# Caching
+velox/common/caching/ @majetideepak 


### PR DESCRIPTION
The CODEOWNERS file allows us to setup file based rules that will automatically request a review from owners on PRs with changes to matching files.

We currently do not enforce these reviews as required so it's only a tool for more granular notifications at the moment. For example component maintainers can set a rule so that they are pinged on changes to the sections of the codebase that are relevant for their component.

