### PR TITLE
Add separate writer threads config for bucketed table write to avoid max open file exceeded error

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1853,6 +1853,7 @@ folly::dynamic TableWriteNode::serialize() const {
   obj["connectorInsertTableHandle"] =
       insertTableHandle_->connectorInsertTableHandle()->serialize();
   obj["hasPartitioningScheme"] = hasPartitioningScheme_;
+  obj["hasBucketProperty"] = hasBucketProperty_;
   obj["outputType"] = outputType_->serialize();
   obj["commitStrategy"] = connector::commitStrategyToString(commitStrategy_);
   return obj;
@@ -1875,6 +1876,7 @@ PlanNodePtr TableWriteNode::create(const folly::dynamic& obj, void* context) {
           ISerializable::deserialize<connector::ConnectorInsertTableHandle>(
               obj["connectorInsertTableHandle"]));
   const bool hasPartitioningScheme = obj["hasPartitioningScheme"].asBool();
+  const bool hasBucketProperty = obj["hasBucketProperty"].asBool();
   auto outputType = deserializeRowType(obj["outputType"]);
   auto commitStrategy =
       connector::stringToCommitStrategy(obj["commitStrategy"].asString());
@@ -1887,6 +1889,7 @@ PlanNodePtr TableWriteNode::create(const folly::dynamic& obj, void* context) {
       std::make_shared<InsertTableHandle>(
           connectorId, connectorInsertTableHandle),
       hasPartitioningScheme,
+      hasBucketProperty,
       outputType,
       commitStrategy,
       source);

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -300,6 +300,11 @@ class QueryConfig {
   static constexpr const char* kTaskPartitionedWriterCount =
       "task_partitioned_writer_count";
 
+  /// The number of local parallel table writer operators per task for
+  /// bucketed writes. If not set, use "task_writer_count".
+  static constexpr const char* kTaskBucketedWriterCount =
+      "task_bucketed_writer_count";
+
   /// If true, finish the hash probe on an empty build table for a specific set
   /// of hash joins.
   static constexpr const char* kHashProbeFinishEarlyOnEmptyBuild =
@@ -765,6 +770,10 @@ class QueryConfig {
   uint32_t taskPartitionedWriterCount() const {
     return get<uint32_t>(kTaskPartitionedWriterCount)
         .value_or(taskWriterCount());
+  }
+
+  uint32_t taskBucketedWriterCount() const {
+    return get<uint32_t>(kTaskBucketedWriterCount).value_or(taskWriterCount());
   }
 
   bool hashProbeFinishEarlyOnEmptyBuild() const {

--- a/velox/core/tests/QueryConfigTest.cpp
+++ b/velox/core/tests/QueryConfigTest.cpp
@@ -57,27 +57,42 @@ TEST_F(QueryConfigTest, taskWriterCountConfig) {
   struct {
     std::optional<int> numWriterCounter;
     std::optional<int> numPartitionedWriterCounter;
+    std::optional<int> numBucketedWriterCounter;
     int expectedWriterCounter;
     int expectedPartitionedWriterCounter;
+    int expectedBucketedWriterCounter;
 
     std::string debugString() const {
       return fmt::format(
-          "numWriterCounter[{}] numPartitionedWriterCounter[{}] expectedWriterCounter[{}] expectedPartitionedWriterCounter[{}]",
+          "numWriterCounter[{}] numPartitionedWriterCounter[{}] numBucketedWriterCounter[{}] expectedPartitionedWriterCounter[{}] expectedBucketedWriterCounter[{}]",
           numWriterCounter.value_or(0),
           numPartitionedWriterCounter.value_or(0),
+          numBucketedWriterCounter.value_or(0),
           expectedWriterCounter,
-          expectedPartitionedWriterCounter);
+          expectedPartitionedWriterCounter,
+          expectedBucketedWriterCounter);
     }
   } testSettings[] = {
-      {std::nullopt, std::nullopt, 4, 4},
-      {std::nullopt, 1, 4, 1},
-      {std::nullopt, 6, 4, 6},
-      {2, 4, 2, 4},
-      {4, 2, 4, 2},
-      {4, 6, 4, 6},
-      {6, 5, 6, 5},
-      {6, 4, 6, 4},
-      {6, std::nullopt, 6, 6}};
+      {std::nullopt, std::nullopt, std::nullopt, 4, 4, 4},
+      {std::nullopt, 1, std::nullopt, 4, 1, 4},
+      {std::nullopt, 6, std::nullopt, 4, 6, 4},
+      {2, 4, std::nullopt, 2, 4, 2},
+      {4, 2, std::nullopt, 4, 2, 4},
+      {4, 6, std::nullopt, 4, 6, 4},
+      {6, 5, std::nullopt, 6, 5, 6},
+      {6, 4, std::nullopt, 6, 4, 6},
+      {6, std::nullopt, 6, 6, 6, 6},
+      {6, std::nullopt, 1, 6, 6, 1},
+      {std::nullopt, std::nullopt, 4, 4, 4, 4},
+      {std::nullopt, std::nullopt, 1, 4, 4, 1},
+      {std::nullopt, 1, 1, 4, 1, 1},
+      {std::nullopt, 1, 2, 4, 1, 2},
+      {std::nullopt, 6, 6, 4, 6, 6},
+      {std::nullopt, 6, 3, 4, 6, 3},
+      {2, 4, 3, 2, 4, 3},
+      {4, 2, 1, 4, 2, 1},
+      {4, 6, 7, 4, 6, 7},
+      {6, std::nullopt, 4, 6, 6, 4}};
   for (const auto& testConfig : testSettings) {
     SCOPED_TRACE(testConfig.debugString());
     std::unordered_map<std::string, std::string> configData;
@@ -91,6 +106,11 @@ TEST_F(QueryConfigTest, taskWriterCountConfig) {
           QueryConfig::kTaskPartitionedWriterCount,
           std::to_string(testConfig.numPartitionedWriterCounter.value()));
     }
+    if (testConfig.numBucketedWriterCounter.has_value()) {
+      configData.emplace(
+          QueryConfig::kTaskBucketedWriterCount,
+          std::to_string(testConfig.numBucketedWriterCounter.value()));
+    }
     auto queryCtx =
         QueryCtx::create(nullptr, QueryConfig{std::move(configData)});
     const QueryConfig& config = queryCtx->queryConfig();
@@ -98,6 +118,9 @@ TEST_F(QueryConfigTest, taskWriterCountConfig) {
     ASSERT_EQ(
         config.taskPartitionedWriterCount(),
         testConfig.expectedPartitionedWriterCounter);
+    ASSERT_EQ(
+        config.taskBucketedWriterCount(),
+        testConfig.expectedBucketedWriterCounter);
   }
 }
 

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -384,6 +384,10 @@ Table Writer
    * - task_partitioned_writer_count
      - integer
      - task_writer_count
+     - The number of parallel table writer threads per task for partitioned table writes. If not set, use 'task_writer_count' as default.
+   * - task_bucketed_writer_count
+     - integer
+     - task_writer_count
      - The number of parallel table writer threads per task for bucketed table writes. If not set, use 'task_writer_count' as default.
 
 Hive Connector

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -238,7 +238,9 @@ uint32_t maxDrivers(
       if (!connectorInsertHandle->supportsMultiThreading()) {
         return 1;
       } else {
-        if (tableWrite->hasPartitioningScheme()) {
+        if (tableWrite->hasBucketProperty()) {
+          return queryConfig.taskBucketedWriterCount();
+        } else if (tableWrite->hasPartitioningScheme()) {
           return queryConfig.taskPartitionedWriterCount();
         } else {
           return queryConfig.taskWriterCount();

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -434,7 +434,7 @@ PlanBuilder& PlanBuilder::tableWrite(
       connector::hive::LocationHandle::TableType::kNew,
       outputFileName);
   std::shared_ptr<HiveBucketProperty> bucketProperty;
-  if (!partitionBy.empty() && bucketCount != 0) {
+  if (bucketCount != 0) {
     bucketProperty =
         buildHiveBucketProperty(rowType, bucketCount, bucketedBy, sortBy);
   }
@@ -471,7 +471,8 @@ PlanBuilder& PlanBuilder::tableWrite(
       rowType->names(),
       aggregationNode,
       insertHandle,
-      false,
+      !partitionBy.empty(),
+      bucketProperty != nullptr,
       TableWriteTraits::outputType(aggregationNode),
       connector::CommitStrategy::kNoCommit,
       planNode_);


### PR DESCRIPTION
Summary:
The bucket table write could run into max open file exceeding errors. There are problems here:
(1) on GBM cluster which only has 300 nodes, so the query will run on 300 nodes and the bucket table writer has 4 driver threads
per node. And the remote exchange and local exchange both uses the same hive partition function but the remote exchange has 300
partitions while the local has 4 partitions and 300 is a multiple of 4 which could cause the data skew which cause one driver thread has
received all the data which exceeds the open file limit. Confirmed with both 9 and 7 writer threads work
(2) native cluster is generally 1/2 of the java cluster size so it is more easily run into the max open file limit so we need to bump up the
write driver threads for native cluster.

This PR adds a separate config at the native side to bump up the bucket table write driver threads to solve the problem. We don't want to
bump up the partition writer threads as non-bucketed partition table won't have any open files (partitions) and we don't want to
create too many small files unnecessarily. This PR only adds support at Velox side: extends the plan node to include a bucket table
property flag to indicate if this is bucketed table as well as configure that table writer threads based on in local query planner.
The followups will add support at Prestissimo side.

Differential Revision: D63325016
