### PR TITLE
Add Spark CAST(integral as timestamp)

### DIFF
--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -239,3 +239,23 @@ Valid example
   SELECT cast(cast(180 as smallint) as binary); -- [00 B4]
   SELECT cast(cast(180000 as integer) as binary); -- [00 02 BF 20]
   SELECT cast(cast(180000 as bigint) as binary); -- [00 00 00 00 00 02 BF 20]
+
+Cast to Timestamp
+-----------------
+
+From integral types
+^^^^^^^^^^^^^^^^^^^
+
+Casting integral value to timestamp type is allowed.
+The input value is treated as the number of seconds since the epoch (1970-01-01 00:00:00 UTC).
+Supported types are tinyint, smallint, integer and bigint.
+
+Valid example
+
+::
+
+  SELECT cast(0 as timestamp); -- 1970-01-01 00:00:00
+  SELECT cast(1727181032 as timestamp); -- 2024-09-24 12:30:32
+  SELECT cast(9223372036855 as timestamp); -- 294247-01-10 04:00:54.775807
+  SELECT cast(-9223372036855 as timestamp); -- 290308-12-21 19:59:05.224192
+  

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -276,6 +276,16 @@ void CastExpr::applyCastKernel(
   try {
     auto inputRowValue = input->valueAt(row);
 
+    if constexpr (
+        (FromKind == TypeKind::TINYINT || FromKind == TypeKind::SMALLINT ||
+         FromKind == TypeKind::INTEGER || FromKind == TypeKind::BIGINT) &&
+        ToKind == TypeKind::TIMESTAMP) {
+      const auto castResult =
+          hooks_->castIntToTimestamp((int64_t)inputRowValue);
+      setResultOrError(castResult, row);
+      return;
+    }
+
     // Optimize empty input strings casting by avoiding throwing exceptions.
     if constexpr (
         FromKind == TypeKind::VARCHAR || FromKind == TypeKind::VARBINARY) {

--- a/velox/expression/CastHooks.h
+++ b/velox/expression/CastHooks.h
@@ -35,7 +35,7 @@ class CastHooks {
   virtual Expected<Timestamp> castStringToTimestamp(
       const StringView& view) const = 0;
 
-  virtual Expected<Timestamp> castIntToTimestamp(int64_t value) const = 0;
+  virtual Expected<Timestamp> castIntToTimestamp(int64_t seconds) const = 0;
 
   virtual Expected<int32_t> castStringToDate(
       const StringView& dateString) const = 0;

--- a/velox/expression/CastHooks.h
+++ b/velox/expression/CastHooks.h
@@ -35,6 +35,8 @@ class CastHooks {
   virtual Expected<Timestamp> castStringToTimestamp(
       const StringView& view) const = 0;
 
+  virtual Expected<Timestamp> castIntToTimestamp(int64_t value) const = 0;
+
   virtual Expected<int32_t> castStringToDate(
       const StringView& dateString) const = 0;
 

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -67,7 +67,7 @@ Expected<Timestamp> PrestoCastHooks::castStringToTimestamp(
   return result.first;
 }
 
-Expected<Timestamp> PrestoCastHooks::castIntToTimestamp(int64_t value) const {
+Expected<Timestamp> PrestoCastHooks::castIntToTimestamp(int64_t seconds) const {
   return folly::makeUnexpected(
       Status::UserError("Conversion to Timestamp is not supported"));
 }

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -67,6 +67,11 @@ Expected<Timestamp> PrestoCastHooks::castStringToTimestamp(
   return result.first;
 }
 
+Expected<Timestamp> PrestoCastHooks::castIntToTimestamp(int64_t value) const {
+  return folly::makeUnexpected(
+      Status::UserError("Conversion to Timestamp is not supported"));
+}
+
 Expected<int32_t> PrestoCastHooks::castStringToDate(
     const StringView& dateString) const {
   // Cast from string to date allows only complete ISO 8601 formatted strings:

--- a/velox/expression/PrestoCastHooks.h
+++ b/velox/expression/PrestoCastHooks.h
@@ -30,6 +30,8 @@ class PrestoCastHooks : public CastHooks {
   Expected<Timestamp> castStringToTimestamp(
       const StringView& view) const override;
 
+  Expected<Timestamp> castIntToTimestamp(int64_t value) const override;
+
   // Uses standard cast mode to cast from string to date.
   Expected<int32_t> castStringToDate(
       const StringView& dateString) const override;

--- a/velox/expression/PrestoCastHooks.h
+++ b/velox/expression/PrestoCastHooks.h
@@ -30,7 +30,7 @@ class PrestoCastHooks : public CastHooks {
   Expected<Timestamp> castStringToTimestamp(
       const StringView& view) const override;
 
-  Expected<Timestamp> castIntToTimestamp(int64_t value) const override;
+  Expected<Timestamp> castIntToTimestamp(int64_t seconds) const override;
 
   // Uses standard cast mode to cast from string to date.
   Expected<int32_t> castStringToDate(

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -34,7 +34,7 @@ Expected<Timestamp> SparkCastHooks::castIntToTimestamp(int64_t seconds) const {
   } else if (seconds < -maxSeconds) {
     return Timestamp::fromMicros(std::numeric_limits<int64_t>::min());
   }
-  return Timestamp::fromMillis(seconds * kMillisInSecond);
+  return Timestamp(seconds, 0);
 }
 
 Expected<int32_t> SparkCastHooks::castStringToDate(

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -26,6 +26,17 @@ Expected<Timestamp> SparkCastHooks::castStringToTimestamp(
       view.data(), view.size(), util::TimestampParseMode::kSparkCast);
 }
 
+Expected<Timestamp> SparkCastHooks::castIntToTimestamp(int64_t seconds) const {
+  // Spark internally use microsecond precision for timestamp.
+  static constexpr int64_t maxSeconds = 9223372036854L;
+  if (seconds > maxSeconds) {
+    return Timestamp::fromMicros(std::numeric_limits<int64_t>::max());
+  } else if (seconds < -maxSeconds) {
+    return Timestamp::fromMicros(std::numeric_limits<int64_t>::min());
+  }
+  return Timestamp::fromMillis(seconds * kMillisInSecond);
+}
+
 Expected<int32_t> SparkCastHooks::castStringToDate(
     const StringView& dateString) const {
   // Allows all patterns supported by Spark:

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -33,10 +33,10 @@ Expected<Timestamp> SparkCastHooks::castIntToTimestamp(int64_t seconds) const {
       (Timestamp::kMicrosecondsInMillisecond *
        Timestamp::kMillisecondsInSecond);
   if (seconds > maxSeconds) {
-    return Timestamp::fromMicros(std::numeric_limits<int64_t>::max());
+    return Timestamp::fromMicrosNoError(std::numeric_limits<int64_t>::max());
   }
   if (seconds < -maxSeconds) {
-    return Timestamp::fromMicros(std::numeric_limits<int64_t>::min());
+    return Timestamp::fromMicrosNoError(std::numeric_limits<int64_t>::min());
   }
   return Timestamp(seconds, 0);
 }

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -27,8 +27,8 @@ class SparkCastHooks : public exec::CastHooks {
   Expected<Timestamp> castStringToTimestamp(
       const StringView& view) const override;
 
-  // When casting integral value as timestamp, the input is treated as the
-  // number of seconds since the epoch (1970-01-01 00:00:00 UTC).
+  /// When casting integral value as timestamp, the input is treated as the
+  /// number of seconds since the epoch (1970-01-01 00:00:00 UTC).
   Expected<Timestamp> castIntToTimestamp(int64_t seconds) const override;
 
   /// 1) Removes all leading and trailing UTF8 white-spaces before cast. 2) Uses

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -27,6 +27,8 @@ class SparkCastHooks : public exec::CastHooks {
   Expected<Timestamp> castStringToTimestamp(
       const StringView& view) const override;
 
+  Expected<Timestamp> castIntToTimestamp(int64_t value) const override;
+
   /// 1) Removes all leading and trailing UTF8 white-spaces before cast. 2) Uses
   /// non-standard cast mode to cast from string to date.
   Expected<int32_t> castStringToDate(

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -27,7 +27,9 @@ class SparkCastHooks : public exec::CastHooks {
   Expected<Timestamp> castStringToTimestamp(
       const StringView& view) const override;
 
-  Expected<Timestamp> castIntToTimestamp(int64_t value) const override;
+  // When casting integral value as timestamp, the input is treated as the
+  // number of seconds since the epoch (1970-01-01 00:00:00 UTC).
+  Expected<Timestamp> castIntToTimestamp(int64_t seconds) const override;
 
   /// 1) Removes all leading and trailing UTF8 white-spaces before cast. 2) Uses
   /// non-standard cast mode to cast from string to date.

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -105,12 +105,8 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
         makeNullableFlatVector<Timestamp>(
             {Timestamp(0, 0),
              Timestamp(1, 0),
-             Timestamp::fromMillis(
-                 std::numeric_limits<T>::max() *
-                 Timestamp::kMillisecondsInSecond),
-             Timestamp::fromMillis(
-                 std::numeric_limits<T>::min() *
-                 Timestamp::kMillisecondsInSecond),
+             Timestamp(std::numeric_limits<T>::max(), 0),
+             Timestamp(std::numeric_limits<T>::min(), 0),
              std::nullopt}));
   }
 };

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -264,7 +264,7 @@ TEST_F(SparkCastExprTest, stringToTimestamp) {
 }
 
 TEST_F(SparkCastExprTest, intToTimestamp) {
-  // int64_t
+  // Cast bigint as timestamp.
   testCast(
       makeNullableFlatVector<int64_t>({
           0,
@@ -285,7 +285,7 @@ TEST_F(SparkCastExprTest, intToTimestamp) {
           Timestamp(-9223372036855, 224'192'000),
       }));
 
-  // Ensure that other integral types cast to int64 work as well.
+  // Cast tinyint/smallint/integer as timestamp.
   testIntegralToTimestampCast<int8_t>();
   testIntegralToTimestampCast<int16_t>();
   testIntegralToTimestampCast<int32_t>();


### PR DESCRIPTION
Add Spark CAST (integral as timestamp). The input value is treated as the 
number of seconds since the epoch (1970-01-01 00:00:00 UTC). Supported types 
are tinyint, smallint, integer and bigint.

Spark's implementation: https://github.com/apache/spark/blob/v3.5.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala#L680