### PR TITLE
Fix skip custom escape

### DIFF
--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -2202,13 +2202,16 @@ std::shared_ptr<exec::VectorFunction> makeLike(
   PatternMetadata patternMetadata = PatternMetadata::generic();
   try {
     // Fast path for substrings search.
-    auto substrings =
-        PatternMetadata::parseSubstrings(std::string_view(pattern));
-    if (substrings.size() > 0) {
-      patternMetadata = PatternMetadata::substrings(std::move(substrings));
-      return std::make_shared<OptimizedLike<PatternKind::kSubstrings>>(
-          patternMetadata);
+    if (escapeChar.has_value()) {
+      auto substrings =
+          PatternMetadata::parseSubstrings(std::string_view(pattern));
+      if (substrings.size() > 0) {
+        patternMetadata = PatternMetadata::substrings(std::move(substrings));
+        return std::make_shared<OptimizedLike<PatternKind::kSubstrings>>(
+            patternMetadata);
+      }
     }
+
     patternMetadata =
         determinePatternKind(std::string_view(pattern), escapeChar);
   } catch (...) {

--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -2202,7 +2202,7 @@ std::shared_ptr<exec::VectorFunction> makeLike(
   PatternMetadata patternMetadata = PatternMetadata::generic();
   try {
     // Fast path for substrings search.
-    if (escapeChar.has_value()) {
+    if (!escapeChar.has_value()) {
       auto substrings =
           PatternMetadata::parseSubstrings(std::string_view(pattern));
       if (substrings.size() > 0) {

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -939,6 +939,7 @@ TEST_F(Re2FunctionsTest, likePatternAndEscape) {
   testLike("a%c", "%#%%", '#', true);
   testLike("%cd", "%#%%", '#', true);
   testLike("cde", "%#%%", '#', false);
+  testLike("///__", "%//%/%", '/', false);
 
   testLike(
       "abcd",


### PR DESCRIPTION
Fix csutom escape char for substrings-search in constant like pattern.

The exsit ut has covered the custom-escape case but escape char '#' is  just not supported by substrings-search
```
  testLike("%cd", "%#%%", '#', true);
  testLike("cde", "%#%%", '#', false);
```

Add ut to cover the case:
```
  testLike("///__", "%//%/%", '/', false);
```