### PR TITLE
Split MinMaxByAggregates.cpp for faster compilation times

### DIFF
--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -36,7 +36,8 @@ velox_add_library(
   MapUnionSumAggregate.cpp
   MaxSizeForStatsAggregate.cpp
   MinMaxAggregates.cpp
-  MinMaxByAggregates.cpp
+  MaxByAggregate.cpp
+  MinByAggregate.cpp
   MultiMapAggAggregate.cpp
   PrestoHasher.cpp
   ReduceAgg.cpp

--- a/velox/functions/prestosql/aggregates/MaxByAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MaxByAggregate.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/aggregates/AggregateNames.h"
+#include "velox/functions/prestosql/aggregates/MinMaxByAggregateBase.h"
+
+namespace facebook::velox::aggregate::prestosql {
+
+template <typename V, typename C>
+class MaxByNAggregate : public MinMaxByNAggregate<V, C, Greater<V, C>> {
+ public:
+  explicit MaxByNAggregate(TypePtr resultType)
+      : MinMaxByNAggregate<V, C, Greater<V, C>>(resultType) {}
+};
+
+template <typename C>
+class MaxByNAggregate<ComplexType, C>
+    : public MinMaxByNAggregate<
+          ComplexType,
+          C,
+          Greater<HashStringAllocator::Position, C>> {
+ public:
+  explicit MaxByNAggregate(TypePtr resultType)
+      : MinMaxByNAggregate<
+            ComplexType,
+            C,
+            Greater<HashStringAllocator::Position, C>>(resultType) {}
+};
+
+void registerMaxByAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite) {
+  registerMinMaxBy<
+      functions::aggregate::MinMaxByAggregateBase,
+      true,
+      MaxByNAggregate>(prefix + kMaxBy, withCompanionFunctions, overwrite);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MinByAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MinByAggregate.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/aggregates/AggregateNames.h"
+#include "velox/functions/prestosql/aggregates/MinMaxByAggregateBase.h"
+
+namespace facebook::velox::aggregate::prestosql {
+
+template <typename V, typename C>
+class MinByNAggregate : public MinMaxByNAggregate<V, C, Less<V, C>> {
+ public:
+  explicit MinByNAggregate(TypePtr resultType)
+      : MinMaxByNAggregate<V, C, Less<V, C>>(resultType) {}
+};
+
+template <typename C>
+class MinByNAggregate<ComplexType, C>
+    : public MinMaxByNAggregate<
+          ComplexType,
+          C,
+          Less<HashStringAllocator::Position, C>> {
+ public:
+  explicit MinByNAggregate(TypePtr resultType)
+      : MinMaxByNAggregate<
+            ComplexType,
+            C,
+            Less<HashStringAllocator::Position, C>>(resultType) {}
+};
+
+void registerMinByAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite) {
+  registerMinMaxBy<
+      functions::aggregate::MinMaxByAggregateBase,
+      false,
+      MinByNAggregate>(prefix + kMinBy, withCompanionFunctions, overwrite);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -129,7 +129,11 @@ extern void registerMinMaxAggregates(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-extern void registerMinMaxByAggregates(
+extern void registerMaxByAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite);
+extern void registerMinByAggregates(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
@@ -176,7 +180,8 @@ void registerAllAggregateFunctions(
   registerSumDataSizeForStatsAggregate(
       prefix, withCompanionFunctions, overwrite);
   registerMinMaxAggregates(prefix, withCompanionFunctions, overwrite);
-  registerMinMaxByAggregates(prefix, withCompanionFunctions, overwrite);
+  registerMaxByAggregates(prefix, withCompanionFunctions, overwrite);
+  registerMinByAggregates(prefix, withCompanionFunctions, overwrite);
   registerReduceAgg(prefix, withCompanionFunctions, overwrite);
   registerSetAggAggregate(prefix, withCompanionFunctions, overwrite);
   registerSetUnionAggregate(prefix, withCompanionFunctions, overwrite);


### PR DESCRIPTION
Summary:
Splitting the .cpp into two compilation unitst (one for min one for
max) so that compilation can be parallelized. In my development environment,
recompilations of this unit went from 1m50s to about 40s.

Differential Revision: D63433609
