### PR TITLE
Add support for "week of month" in SimpleDateTimeFormatter

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -53,9 +53,8 @@ struct Date {
   bool centuryFormat = false;
 
   bool isYearOfEra = false; // Year of era cannot be zero or negative.
-  bool hasYear = false;
-  // Whether dayOfWeek was explicitly specified.
-  bool hasDayOfWeek = false;
+  bool hasYear = false; // Whether year was explicitly specified.
+  bool hasDayOfWeek = false; // Whether dayOfWeek was explicitly specified.
 
   int32_t hour = 0;
   int32_t minute = 0;
@@ -999,10 +998,10 @@ int32_t parseFromPattern(
           }
         }
         date.dayOfWeek = number;
+        date.hasDayOfWeek = true;
         if (!date.weekOfMonthDateFormat) {
           date.weekDateFormat = true;
         }
-        date.hasDayOfWeek = true;
         date.dayOfYearFormat = false;
         if (!date.hasYear) {
           date.hasYear = true;

--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -744,7 +744,9 @@ int32_t parseFromPattern(
       return -1;
     }
     cur += size;
-    date.weekDateFormat = true;
+    if (!date.weekOfMonthDateFormat) {
+      date.weekDateFormat = true;
+    }
     date.dayOfYearFormat = false;
     if (!date.hasYear) {
       date.hasYear = true;
@@ -997,7 +999,9 @@ int32_t parseFromPattern(
           }
         }
         date.dayOfWeek = number;
-        date.weekDateFormat = true;
+        if (!date.weekOfMonthDateFormat) {
+          date.weekDateFormat = true;
+        }
         date.hasDayOfWeek = true;
         date.dayOfYearFormat = false;
         if (!date.hasYear) {

--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -744,6 +744,7 @@ int32_t parseFromPattern(
       return -1;
     }
     cur += size;
+    date.weekDateFormat = true;
     date.dayOfYearFormat = false;
     if (!date.hasYear) {
       date.hasYear = true;
@@ -996,6 +997,7 @@ int32_t parseFromPattern(
           }
         }
         date.dayOfWeek = number;
+        date.weekDateFormat = true;
         date.hasDayOfWeek = true;
         date.dayOfYearFormat = false;
         if (!date.hasYear) {

--- a/velox/functions/lib/DateTimeFormatter.h
+++ b/velox/functions/lib/DateTimeFormatter.h
@@ -112,7 +112,10 @@ enum class DateTimeFormatSpecifier : uint8_t {
   TIMEZONE_OFFSET_ID = 22,
 
   // A literal % character
-  LITERAL_PERCENT = 23
+  LITERAL_PERCENT = 23,
+
+  // Week of month based on java.text.SimpleDateFormat, e.g: 2
+  WEEK_OF_MONTH = 24
 };
 
 struct FormatPattern {

--- a/velox/functions/lib/DateTimeFormatterBuilder.cpp
+++ b/velox/functions/lib/DateTimeFormatterBuilder.cpp
@@ -56,6 +56,13 @@ DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendWeekOfWeekYear(
   return *this;
 }
 
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendWeekOfMonth(
+    size_t minDigits) {
+  tokens_.emplace_back(
+      FormatPattern{DateTimeFormatSpecifier::WEEK_OF_MONTH, minDigits});
+  return *this;
+}
+
 DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendDayOfWeek0Based(
     size_t minDigits) {
   tokens_.emplace_back(

--- a/velox/functions/lib/DateTimeFormatterBuilder.h
+++ b/velox/functions/lib/DateTimeFormatterBuilder.h
@@ -88,6 +88,16 @@ class DateTimeFormatterBuilder {
   /// will be 001
   DateTimeFormatterBuilder& appendWeekOfWeekYear(size_t minDigits);
 
+  /// Appends week of month to formatter builder, e.g: 2
+  ///
+  /// \param minDigits describes the minimum number of digits this format is
+  /// required to represent week of month. The format by default is going
+  /// use as few digits as possible greater than or equal to minDigits to
+  /// represent week of month. e.g. 1999-01-01, with min digit being 1 the
+  /// formatted result will be 1, with min digit being 4 the formatted result
+  /// will be 0001
+  DateTimeFormatterBuilder& appendWeekOfMonth(size_t minDigits);
+
   /// Appends day of week to formatter builder. The number is 0 based with 0 ~ 6
   /// representing Sunday to Saturday respectively
   ///

--- a/velox/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/velox/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -2303,4 +2303,128 @@ TEST_F(MysqlDateTimeTest, parseConsecutiveSpecifiers) {
   EXPECT_THROW(parseMysql("1212", "%Y%H"), VeloxUserError);
 }
 
+class SimpleDateTimeFormatterTest : public DateTimeFormatterTest {
+ protected:
+  DateTimeResult parseSimple(
+      const std::string_view& input,
+      const std::string_view& format,
+      bool lenient) {
+    auto dateTimeResultExpected =
+        buildSimpleDateTimeFormatter(format, lenient)->parse(input);
+    return dateTimeResult(dateTimeResultExpected);
+  }
+
+  std::string formatSimpleDateTime(
+      const std::string& format,
+      const Timestamp& timestamp,
+      const tz::TimeZone* timezone,
+      bool lenient) const {
+    auto formatter = buildSimpleDateTimeFormatter(format, lenient);
+    const auto maxSize = formatter->maxResultSize(timezone);
+    std::string result(maxSize, '\0');
+    auto resultSize =
+        formatter->format(timestamp, timezone, maxSize, result.data());
+    result.resize(resultSize);
+    return result;
+  }
+};
+
+TEST_F(SimpleDateTimeFormatterTest, validSimpleBuild) {
+  // W specifier case.
+  std::vector<DateTimeToken> expected = {
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::WEEK_OF_MONTH, 1})};
+  EXPECT_EQ(expected, buildSimpleDateTimeFormatter("W", true)->tokens());
+  EXPECT_EQ(expected, buildSimpleDateTimeFormatter("W", false)->tokens());
+}
+
+TEST_F(SimpleDateTimeFormatterTest, parseSimpleWeekOfMonth) {
+  // Common cases for lenient and strict mode.
+  for (bool lenient : {true, false}) {
+    // Format contains year, month, weekOfMonth and dayOfWeek.
+    EXPECT_EQ(
+        fromTimestampString("2024-08-02"),
+        parseSimple("2024 08 01 5", "yyyy MM WW e", lenient).timestamp);
+    EXPECT_EQ(
+        fromTimestampString("2024-08-03"),
+        parseSimple("2024 08 01 6", "yyyy MM WW e", lenient).timestamp);
+    EXPECT_EQ(
+        fromTimestampString("2024-08-09"),
+        parseSimple("2024 08 02 5", "yyyy MM WW e", lenient).timestamp);
+    EXPECT_EQ(
+        fromTimestampString("2024-08-12"),
+        parseSimple("2024 08 03 1", "yyyy MM WW e", lenient).timestamp);
+
+    // Format contains year, month and weekOfMonth.
+    EXPECT_EQ(
+        fromTimestampString("2024-07-28"),
+        parseSimple("2024 08 01", "yyyy MM WW", lenient).timestamp);
+
+    // Format contains year and weekOfMonth.
+    EXPECT_EQ(
+        fromTimestampString("2023-12-31"),
+        parseSimple("2024 01", "yyyy WW", lenient).timestamp);
+
+    // Format contains weekOfMonth.
+    EXPECT_EQ(
+        fromTimestampString("1969-12-28"),
+        parseSimple("1", "W", lenient).timestamp);
+  }
+
+  // Field out of range for lenient mode.
+  EXPECT_EQ(
+      fromTimestampString("2024-09-30"),
+      parseSimple("2024 08 10 1", "yyyy MM WW e", true).timestamp);
+  EXPECT_EQ(
+      fromTimestampString("2024-07-28"),
+      parseSimple("2024 08 01", "yyyy MM WW", true).timestamp);
+  EXPECT_EQ(
+      fromTimestampString("2025-02-24"),
+      parseSimple("2024 15 01 1", "yyyy MM WW e", true).timestamp);
+  EXPECT_EQ(
+      fromTimestampString("2024-07-29"),
+      parseSimple("2024 08 01 9", "yyyy MM WW e", true).timestamp);
+
+  // Field out of range for strict mode.
+  EXPECT_THROW(
+      parseSimple("2024 08 10 1", "yyyy MM WW e", false), VeloxUserError);
+  EXPECT_THROW(parseSimple("2024 08 10", "yyyy MM WW", false), VeloxUserError);
+  EXPECT_THROW(
+      parseSimple("2024 15 01 1", "yyyy MM WW e", false), VeloxUserError);
+  EXPECT_THROW(
+      parseSimple("2024 08 01 9", "yyyy MM WW e", false), VeloxUserError);
+}
+
+TEST_F(SimpleDateTimeFormatterTest, formatResultSize) {
+  EXPECT_EQ(
+      buildSimpleDateTimeFormatter("WW", false)->maxResultSize(nullptr), 2);
+  EXPECT_EQ(
+      buildSimpleDateTimeFormatter("WW", true)->maxResultSize(nullptr), 2);
+}
+
+TEST_F(SimpleDateTimeFormatterTest, formatWeekOfMonth) {
+  auto* timezone = tz::locateZone("GMT");
+  for (bool lenient : {true, false}) {
+    EXPECT_EQ(
+        formatSimpleDateTime(
+            "W", fromTimestampString("2024-08-01"), timezone, lenient),
+        "1");
+    EXPECT_EQ(
+        formatSimpleDateTime(
+            "W", fromTimestampString("2024-08-10"), timezone, lenient),
+        "2");
+    EXPECT_EQ(
+        formatSimpleDateTime(
+            "W", fromTimestampString("2024-08-11"), timezone, lenient),
+        "3");
+    EXPECT_EQ(
+        formatSimpleDateTime(
+            "W", fromTimestampString("2024-08-15"), timezone, lenient),
+        "3");
+    EXPECT_EQ(
+        formatSimpleDateTime(
+            "W", fromTimestampString("2024-08-30"), timezone, lenient),
+        "5");
+  }
+}
+
 } // namespace facebook::velox::functions


### PR DESCRIPTION
`java.text.SimpleDateFormat` supports using 'week of month' to parse/format 
date. The specifier of 'week of month' is 'W'. Now DateTimeFormatter supports 3 
group of fields specifying the day within the year. They are following 
combinations:

```
year + week + dayOfWeek
year + dayOfYear
year + month + day
```
This PR introduces a new combination that is
`year + month + weekOfMonth + dayOfWeek` and adds support for "week of month"
in SimpleDateTimeFormatter.

Relates issue : #10354