### PR TITLE
Handle missing fields when read flatmap as struct

### DIFF
--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -271,11 +271,9 @@ void SelectiveStructColumnReaderBase::recordParentNullsInChildren(
   }
 }
 
-bool SelectiveStructColumnReaderBase::isChildConstant(
+bool SelectiveStructColumnReaderBase::isChildMissing(
     const velox::common::ScanSpec& childSpec) const {
-  // Returns true if the child has a constant set in the ScanSpec, or if the
-  // file doesn't have this child (in which case it will be treated as null).
-  return childSpec.isConstant() ||
+  return
       // The below check is trying to determine if this is a missing field in a
       // struct that should be constant null.
       (!isRoot_ && // If we're in the root struct channel is meaningless in this

--- a/velox/dwio/common/SelectiveStructColumnReader.h
+++ b/velox/dwio/common/SelectiveStructColumnReader.h
@@ -133,9 +133,15 @@ class SelectiveStructColumnReaderBase : public SelectiveColumnReader {
     return hasDeletion_;
   }
 
-  // Returns true if we'll return a constant for that childSpec (i.e. we don't
-  // need to read it).
-  bool isChildConstant(const velox::common::ScanSpec& childSpec) const;
+  // Returns true if the file doesn't have this child (in which case it will be
+  // treated as null).
+  bool isChildMissing(const velox::common::ScanSpec& childSpec) const;
+
+  bool isChildConstant(const velox::common::ScanSpec& childSpec) const {
+    return childSpec.isConstant() ||
+        childSpec.subscript() == kConstantChildSpecSubscript ||
+        isChildMissing(childSpec);
+  }
 
   void fillOutputRowsFromMutation(vector_size_t size);
 

--- a/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
@@ -183,6 +183,9 @@ class SelectiveFlatMapAsStructReader : public SelectiveStructColumnReaderBase {
         !keyNodes_.empty(),
         "For struct encoding, keys to project must be configured");
     children_.resize(keyNodes_.size());
+    for (auto& childSpec : scanSpec.children()) {
+      childSpec->setSubscript(kConstantChildSpecSubscript);
+    }
     for (int i = 0; i < keyNodes_.size(); ++i) {
       keyNodes_[i].reader->scanSpec()->setSubscript(i);
       children_[i] = keyNodes_[i].reader.get();

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
@@ -53,7 +53,7 @@ SelectiveStructColumnReader::SelectiveStructColumnReader(
     if (childSpec->isExplicitRowNumber()) {
       continue;
     }
-    if (isChildConstant(*childSpec)) {
+    if (childSpec->isConstant() || isChildMissing(*childSpec)) {
       childSpec->setSubscript(kConstantChildSpecSubscript);
       continue;
     }

--- a/velox/dwio/parquet/reader/StructColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StructColumnReader.cpp
@@ -35,7 +35,8 @@ StructColumnReader::StructColumnReader(
   auto& childSpecs = scanSpec_->stableChildren();
   for (auto i = 0; i < childSpecs.size(); ++i) {
     auto childSpec = childSpecs[i];
-    if (childSpecs[i]->isConstant()) {
+    if (childSpec->isConstant() || isChildMissing(*childSpec)) {
+      childSpec->setSubscript(kConstantChildSpecSubscript);
       continue;
     }
     if (childSpecs[i]->isExplicitRowNumber()) {


### PR DESCRIPTION
Summary:
When we read flatmap as struct, the presence of a field is not decided
the same way as a normal struct field.  We need to handle this separately and
set `ScanSpec::subscript` according to the flatmap specific logic, and also
leverage this subscript in the subsequent reading to treat it as constant.

Differential Revision: D63469632
